### PR TITLE
[sourcekit] Use the driver to parse command line arguments

### DIFF
--- a/test/SourceKit/CodeComplete/complete_crash1.swift
+++ b/test/SourceKit/CodeComplete/complete_crash1.swift
@@ -1,5 +1,5 @@
 // XFAIL: broken_std_regex
-// RUN: %complete-test -tok=TOK1 -hide-none %s -- %s
+// RUN: %complete-test -tok=TOK1 -hide-none %s
 
 import QuartzCore
 

--- a/test/SourceKit/CodeComplete/complete_import_module_flag.swift
+++ b/test/SourceKit/CodeComplete/complete_import_module_flag.swift
@@ -1,8 +1,8 @@
 // XFAIL: broken_std_regex
 // RUN: %empty-directory(%t)
 // RUN: %swift -Xcc -I%S/Inputs -emit-module -o %t/auxiliary_file.swiftmodule %S/Inputs/auxiliary_file.swift
-// RUN: %complete-test -group=none -hide-none -raw -tok=TOP_LEVEL_0 %s -- -import-module auxiliary_file  -I %t -I %S/Inputs | %FileCheck %s
-// RUN: %complete-test -group=none -tok=TOP_LEVEL_0 %s -- -import-module auxiliary_file  -I %t -I %S/Inputs | %FileCheck %s -check-prefix=WITH_HIDING
+// RUN: %complete-test -group=none -hide-none -raw -tok=TOP_LEVEL_0 %s -- -Xfrontend -import-module -Xfrontend auxiliary_file  -I %t -I %S/Inputs | %FileCheck %s
+// RUN: %complete-test -group=none -tok=TOP_LEVEL_0 %s -- -Xfrontend -import-module -Xfrontend auxiliary_file  -I %t -I %S/Inputs | %FileCheck %s -check-prefix=WITH_HIDING
 
 func fromMainModule() {}
 func test() {

--- a/test/SourceKit/CursorInfo/cursor_info_async.swift
+++ b/test/SourceKit/CursorInfo/cursor_info_async.swift
@@ -2,11 +2,15 @@ import Foo
 
 // REQUIRES: objc_interop
 
+// RUN: %empty-directory(%t)
+// RUN: %build-clang-importer-objc-overlays
+
 // Perform 8 concurrent cursor infos, which is often enough to cause
 // contention.  We disable printing the requests to minimize delay.
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- \
-// RUN:                  -F %S/../Inputs/libIDE-mock-sdk %mcp_opt %clang-importer-sdk \
+// RUN:                  -F %S/../Inputs/libIDE-mock-sdk %mcp_opt \
+// RUN:                   -target %target-triple %clang-importer-sdk-nosource -I %t \
 // RUN:   == -async -dont-print-request -req=cursor -pos=60:15 \
 // RUN:   == -async -dont-print-request -req=cursor -pos=60:15 \
 // RUN:   == -async -dont-print-request -req=cursor -pos=60:15 \

--- a/test/SourceKit/CursorInfo/cursor_stdlib.swift
+++ b/test/SourceKit/CursorInfo/cursor_stdlib.swift
@@ -22,47 +22,53 @@ import Swift
 func foo3(a: Float, b: Bool) {}
 
 // REQUIRES: objc_interop
-// RUN: %sourcekitd-test -req=cursor -pos=3:18 %s -- %s %mcp_opt %clang-importer-sdk | %FileCheck -check-prefix=CHECK-OVERLAY %s
+
+// RUN: %empty-directory(%t)
+// RUN: %build-clang-importer-objc-overlays
+
+// RUN: %sourcekitd-test -req=cursor -pos=3:18 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-OVERLAY %s
 // CHECK-OVERLAY:      source.lang.swift.ref.var.global
 // CHECK-OVERLAY-NEXT: NSUTF8StringEncoding
 // CHECK-OVERLAY-NEXT: s:10Foundation20NSUTF8StringEncodingSuv
 // CHECK-OVERLAY-NEXT: UInt
 // CHECK-OVERLAY-NEXT: $SSuD
-// CHECK-OVERLAY-NEXT: <Declaration>public let NSUTF8StringEncoding: <Type usr="s:Su">UInt</Type></Declaration>
+// CHECK-OVERLAY-NEXT: Foundation
+// CHECK-OVERLAY-NEXT: SYSTEM
+// CHECK-OVERLAY-NEXT: <Declaration>let NSUTF8StringEncoding: <Type usr="s:Su">UInt</Type></Declaration>
 
-// RUN: %sourcekitd-test -req=cursor -pos=5:13 %s -- %s %mcp_opt %clang-importer-sdk | %FileCheck -check-prefix=CHECK-ITERATOR %s
+// RUN: %sourcekitd-test -req=cursor -pos=5:13 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-ITERATOR %s
 // CHECK-ITERATOR-NOT: _AnyIteratorBase
 // CHECK-ITERATOR: <Group>Collection/Type-erased</Group>
 
-// RUN: %sourcekitd-test -req=cursor -pos=8:10 %s -- %s %mcp_opt %clang-importer-sdk | %FileCheck -check-prefix=CHECK-REPLACEMENT1 %s
+// RUN: %sourcekitd-test -req=cursor -pos=8:10 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-REPLACEMENT1 %s
 // CHECK-REPLACEMENT1: <Group>Collection/Array</Group>
 // CHECK-REPLACEMENT1: <Declaration>{{.*}}func sorted() -&gt; [<Type usr="s:Si">Int</Type>]</Declaration>
 // CHECK-REPLACEMENT1: RELATED BEGIN
 // CHECK-REPLACEMENT1: sorted(by:)</RelatedName>
 // CHECK-REPLACEMENT1: RELATED END
 
-// RUN: %sourcekitd-test -req=cursor -pos=9:8 %s -- %s %mcp_opt %clang-importer-sdk | %FileCheck -check-prefix=CHECK-REPLACEMENT2 %s
+// RUN: %sourcekitd-test -req=cursor -pos=9:8 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-REPLACEMENT2 %s
 // CHECK-REPLACEMENT2: <Group>Collection/Array</Group>
 // CHECK-REPLACEMENT2: <Declaration>{{.*}}mutating func append(_ newElement: <Type usr="s:Si">Int</Type>)</Declaration>
 
-// RUN: %sourcekitd-test -req=cursor -pos=15:10 %s -- %s %mcp_opt %clang-importer-sdk | %FileCheck -check-prefix=CHECK-REPLACEMENT3 %s
+// RUN: %sourcekitd-test -req=cursor -pos=15:10 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-REPLACEMENT3 %s
 // CHECK-REPLACEMENT3: <Group>Collection/Array</Group>
 // CHECK-REPLACEMENT3: func sorted(by areInIncreasingOrder: (<Type usr="s:13cursor_stdlib2S1V">S1</Type>
 // CHECK-REPLACEMENT3: sorted()</RelatedName>
 
-// RUN: %sourcekitd-test -req=cursor -pos=18:8 %s -- %s %mcp_opt %clang-importer-sdk | %FileCheck -check-prefix=CHECK-REPLACEMENT4 %s
+// RUN: %sourcekitd-test -req=cursor -pos=18:8 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-REPLACEMENT4 %s
 // CHECK-REPLACEMENT4: <Group>Collection/Array</Group>
 // CHECK-REPLACEMENT4: <Declaration>{{.*}}mutating func append(_ newElement: <Type usr="s:13cursor_stdlib2S1V">S1</Type>)</Declaration>
 
-// RUN: %sourcekitd-test -req=cursor -pos=21:10 %s -- %s %mcp_opt %clang-importer-sdk | %FileCheck -check-prefix=CHECK-MODULE-GROUP1 %s
+// RUN: %sourcekitd-test -req=cursor -pos=21:10 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-MODULE-GROUP1 %s
 // CHECK-MODULE-GROUP1: MODULE GROUPS BEGIN
 // CHECK-MODULE-GROUP1-DAG: Math
 // CHECK-MODULE-GROUP1-DAG: Collection
 // CHECK-MODULE-GROUP1-DAG: Collection/Array
 // CHECK-MODULE-GROUP1: MODULE GROUPS END
 
-// RUN: %sourcekitd-test -req=cursor -pos=22:17 %s -- %s %mcp_opt %clang-importer-sdk | %FileCheck -check-prefix=CHECK-FLOAT1 %s
+// RUN: %sourcekitd-test -req=cursor -pos=22:17 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-FLOAT1 %s
 // CHECK-FLOAT1: s:Sf
 
-// RUN: %sourcekitd-test -req=cursor -pos=22:25 %s -- %s %mcp_opt %clang-importer-sdk | %FileCheck -check-prefix=CHECK-BOOL1 %s
+// RUN: %sourcekitd-test -req=cursor -pos=22:25 %s -- %s %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-BOOL1 %s
 // CHECK-BOOL1: s:Sb

--- a/test/SourceKit/CursorInfo/rdar_18677108-2.swift
+++ b/test/SourceKit/CursorInfo/rdar_18677108-2.swift
@@ -1,7 +1,6 @@
 // RUN: %sourcekitd-test -req=open %S/Inputs/rdar_18677108-2-a.swift \
 // RUN:                               --  %S/Inputs/rdar_18677108-2-b.swift \
 // RUN:                                   %S/Inputs/rdar_18677108-2-a.swift \
-// RUN:                                   -primary-file %S/Inputs/rdar_18677108-2-a.swift \
 // RUN:               == -req=print-diags %S/Inputs/rdar_18677108-2-a.swift | %sed_clean > %t.response
 // RUN: diff -u %s.response %t.response
 

--- a/test/SourceKit/DocSupport/doc_clang_module.swift
+++ b/test/SourceKit/DocSupport/doc_clang_module.swift
@@ -1,4 +1,11 @@
 // REQUIRES: objc_interop
+
+// FIXME: the test output we're comparing to is specific to macOS.
+// REQUIRES-ANY: OS=macosx
+
+// RUN: %empty-directory(%t)
+// RUN: %build-clang-importer-objc-overlays
+
 // RUN: %sourcekitd-test -req=doc-info -module Foo -- -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt %clang-importer-sdk | %sed_clean > %t.response
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %sed_clean > %t.response
 // RUN: diff -u %s.response %t.response

--- a/test/SourceKit/DocSupport/doc_source_file.swift
+++ b/test/SourceKit/DocSupport/doc_source_file.swift
@@ -1,2 +1,7 @@
 // RUN: %sourcekitd-test -req=doc-info %S/Inputs/main.swift > %t.response
 // RUN: diff -u %s.response %t.response
+
+// RUN: not %sourcekitd-test -req=doc-info %S/Inputs/main.swift -- %S/Inputs/cake.swift 2> %t.error
+// RUN: %FileCheck %s -check-prefix=MULTI_FILE < %t.error
+
+// MULTI_FILE: unexpected input in compiler arguments

--- a/test/SourceKit/DocSupport/doc_source_file.swift.response
+++ b/test/SourceKit/DocSupport/doc_source_file.swift.response
@@ -71,7 +71,7 @@
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "CC0",
-    key.usr: "s:8__main__3CC0C",
+    key.usr: "s:4main3CC0C",
     key.offset: 71,
     key.length: 3
   },
@@ -225,14 +225,14 @@
   {
     key.kind: source.lang.swift.ref.var.instance,
     key.name: "instV",
-    key.usr: "s:8__main__2CCC5instVAA3CC0Cvp",
+    key.usr: "s:4main2CCC5instVAA3CC0Cvp",
     key.offset: 267,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.function.constructor,
     key.name: "init()",
-    key.usr: "s:8__main__3CC0CACycfc",
+    key.usr: "s:4main3CC0CACycfc",
     key.offset: 275,
     key.length: 3
   },
@@ -249,7 +249,7 @@
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "CC",
-    key.usr: "s:8__main__2CCC",
+    key.usr: "s:4main2CCC",
     key.offset: 299,
     key.length: 2
   },
@@ -261,14 +261,14 @@
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "CC0",
-    key.usr: "s:8__main__3CC0C",
+    key.usr: "s:4main3CC0C",
     key.offset: 306,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "CC",
-    key.usr: "s:8__main__2CCC",
+    key.usr: "s:4main2CCC",
     key.offset: 314,
     key.length: 2
   },
@@ -371,7 +371,7 @@
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot",
-    key.usr: "s:8__main__4ProtP",
+    key.usr: "s:4main4ProtP",
     key.offset: 451,
     key.length: 4
   },
@@ -398,7 +398,7 @@
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "CC",
-    key.usr: "s:8__main__2CCC",
+    key.usr: "s:4main2CCC",
     key.offset: 474,
     key.length: 2
   },
@@ -410,7 +410,7 @@
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "E",
-    key.usr: "s:8__main__1EO",
+    key.usr: "s:4main1EO",
     key.offset: 481,
     key.length: 1
   },
@@ -444,7 +444,7 @@
   {
     key.kind: source.lang.swift.ref.var.global,
     key.name: "globV",
-    key.usr: "s:8__main__5globVSivp",
+    key.usr: "s:4main5globVSivp",
     key.offset: 508,
     key.length: 5
   },
@@ -467,7 +467,7 @@
   {
     key.kind: source.lang.swift.ref.function.operator.infix,
     key.name: "+(_:_:)",
-    key.usr: "s:8__main__1poiyAA2CCCAD_AA3CC0CtF",
+    key.usr: "s:4main1poiyAA2CCCAD_AA3CC0CtF",
     key.offset: 526,
     key.length: 1
   },
@@ -480,7 +480,7 @@
   {
     key.kind: source.lang.swift.ref.var.instance,
     key.name: "instV",
-    key.usr: "s:8__main__2CCC5instVAA3CC0Cvp",
+    key.usr: "s:4main2CCC5instVAA3CC0Cvp",
     key.offset: 530,
     key.length: 5
   },
@@ -493,21 +493,21 @@
   {
     key.kind: source.lang.swift.ref.function.method.instance,
     key.name: "meth()",
-    key.usr: "s:8__main__2CCC4methyyF",
+    key.usr: "s:4main2CCC4methyyF",
     key.offset: 540,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "CC",
-    key.usr: "s:8__main__2CCC",
+    key.usr: "s:4main2CCC",
     key.offset: 549,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.function.method.class,
     key.name: "smeth()",
-    key.usr: "s:8__main__2CCC5smethyyFZ",
+    key.usr: "s:4main2CCC5smethyyFZ",
     key.offset: 552,
     key.length: 5
   },
@@ -520,14 +520,14 @@
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "E",
-    key.usr: "s:8__main__1EO",
+    key.usr: "s:4main1EO",
     key.offset: 566,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.enumelement,
     key.name: "EElem",
-    key.usr: "s:8__main__1EO5EElemyA2CmF",
+    key.usr: "s:4main1EO5EElemyA2CmF",
     key.offset: 568,
     key.length: 5
   },
@@ -544,7 +544,7 @@
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "CC",
-    key.usr: "s:8__main__2CCC",
+    key.usr: "s:4main2CCC",
     key.offset: 583,
     key.length: 2
   },
@@ -571,7 +571,7 @@
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "LocalCC",
-    key.usr: "s:8__main__3foo_1byAA2CCC_AA1EOtF05LocalC0L_C",
+    key.usr: "s:4main3foo_1byAA2CCC_AA1EOtF05LocalC0L_C",
     key.offset: 614,
     key.length: 7
   },
@@ -588,7 +588,7 @@
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "CC",
-    key.usr: "s:8__main__2CCC",
+    key.usr: "s:4main2CCC",
     key.offset: 645,
     key.length: 2
   },
@@ -600,14 +600,14 @@
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "CC",
-    key.usr: "s:8__main__2CCC",
+    key.usr: "s:4main2CCC",
     key.offset: 659,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot",
-    key.usr: "s:8__main__4ProtP",
+    key.usr: "s:4main4ProtP",
     key.offset: 664,
     key.length: 4
   },
@@ -634,7 +634,7 @@
   {
     key.kind: source.lang.swift.ref.typealias,
     key.name: "CCAlias",
-    key.usr: "s:8__main__7CCAliasa",
+    key.usr: "s:4main7CCAliasa",
     key.offset: 689,
     key.length: 7
   },
@@ -661,7 +661,7 @@
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot",
-    key.usr: "s:8__main__4ProtP",
+    key.usr: "s:4main4ProtP",
     key.offset: 722,
     key.length: 4
   },
@@ -705,7 +705,7 @@
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "CC",
-    key.usr: "s:8__main__2CCC",
+    key.usr: "s:4main2CCC",
     key.offset: 778,
     key.length: 2
   },
@@ -722,7 +722,7 @@
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "SubCC",
-    key.usr: "s:8__main__5SubCCC",
+    key.usr: "s:4main5SubCCC",
     key.offset: 797,
     key.length: 5
   },
@@ -859,7 +859,7 @@
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot",
-    key.usr: "s:8__main__4ProtP",
+    key.usr: "s:4main4ProtP",
     key.offset: 1036,
     key.length: 4
   },
@@ -876,14 +876,14 @@
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "BC2",
-    key.usr: "s:8__main__3BC2C",
+    key.usr: "s:4main3BC2C",
     key.offset: 1061,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot",
-    key.usr: "s:8__main__4ProtP",
+    key.usr: "s:4main4ProtP",
     key.offset: 1066,
     key.length: 4
   },
@@ -915,7 +915,7 @@
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot",
-    key.usr: "s:8__main__4ProtP",
+    key.usr: "s:4main4ProtP",
     key.offset: 1103,
     key.length: 4
   },
@@ -1025,7 +1025,7 @@
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "ComputedProperty",
-    key.usr: "s:8__main__16ComputedPropertyC",
+    key.usr: "s:4main16ComputedPropertyC",
     key.offset: 1250,
     key.length: 16
   },
@@ -1037,7 +1037,7 @@
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "CC2",
-    key.usr: "s:8__main__3CC2C",
+    key.usr: "s:4main3CC2C",
     key.offset: 1273,
     key.length: 3
   },
@@ -1060,7 +1060,7 @@
   {
     key.kind: source.lang.swift.ref.var.instance,
     key.name: "value",
-    key.usr: "s:8__main__16ComputedPropertyC5valueSivp",
+    key.usr: "s:4main16ComputedPropertyC5valueSivp",
     key.offset: 1293,
     key.length: 5
   },
@@ -1079,7 +1079,7 @@
   {
     key.kind: source.lang.swift.ref.var.instance,
     key.name: "readOnly",
-    key.usr: "s:8__main__16ComputedPropertyC8readOnlySivp",
+    key.usr: "s:4main16ComputedPropertyC8readOnlySivp",
     key.offset: 1308,
     key.length: 8
   },
@@ -1092,7 +1092,7 @@
   {
     key.kind: source.lang.swift.ref.var.instance,
     key.name: "value",
-    key.usr: "s:8__main__16ComputedPropertyC5valueSivp",
+    key.usr: "s:4main16ComputedPropertyC5valueSivp",
     key.offset: 1322,
     key.length: 5
   },
@@ -1111,7 +1111,7 @@
   {
     key.kind: source.lang.swift.ref.var.instance,
     key.name: "value",
-    key.usr: "s:8__main__16ComputedPropertyC5valueSivp",
+    key.usr: "s:4main16ComputedPropertyC5valueSivp",
     key.offset: 1337,
     key.length: 5
   },
@@ -1142,7 +1142,7 @@
   {
     key.kind: source.lang.swift.ref.function.subscript,
     key.name: "subscript(_:)",
-    key.usr: "s:8__main__3CC2CyS2icip",
+    key.usr: "s:4main3CC2CyS2icip",
     key.offset: 1357,
     key.length: 1
   },
@@ -1154,7 +1154,7 @@
   {
     key.kind: source.lang.swift.ref.function.subscript,
     key.name: "subscript(_:)",
-    key.usr: "s:8__main__3CC2CyS2icip",
+    key.usr: "s:4main3CC2CyS2icip",
     key.offset: 1359,
     key.length: 1
   },
@@ -1167,7 +1167,7 @@
   {
     key.kind: source.lang.swift.ref.function.subscript,
     key.name: "subscript(_:)",
-    key.usr: "s:8__main__3CC2CyS2icip",
+    key.usr: "s:4main3CC2CyS2icip",
     key.offset: 1366,
     key.length: 1
   },
@@ -1179,7 +1179,7 @@
   {
     key.kind: source.lang.swift.ref.function.subscript,
     key.name: "subscript(_:)",
-    key.usr: "s:8__main__3CC2CyS2icip",
+    key.usr: "s:4main3CC2CyS2icip",
     key.offset: 1368,
     key.length: 1
   },
@@ -1198,7 +1198,7 @@
   {
     key.kind: source.lang.swift.ref.function.subscript,
     key.name: "subscript(_:)",
-    key.usr: "s:8__main__3CC2CyS2icip",
+    key.usr: "s:4main3CC2CyS2icip",
     key.offset: 1379,
     key.length: 1
   },
@@ -1210,7 +1210,7 @@
   {
     key.kind: source.lang.swift.ref.function.subscript,
     key.name: "subscript(_:)",
-    key.usr: "s:8__main__3CC2CyS2icip",
+    key.usr: "s:4main3CC2CyS2icip",
     key.offset: 1381,
     key.length: 1
   },
@@ -1259,7 +1259,7 @@
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "S2",
-    key.usr: "s:8__main__2S2V",
+    key.usr: "s:4main2S2V",
     key.offset: 1442,
     key.length: 2
   },
@@ -1276,7 +1276,7 @@
   {
     key.kind: source.lang.swift.ref.function.constructor,
     key.name: "init()",
-    key.usr: "s:8__main__2S2VACycfc",
+    key.usr: "s:4main2S2VACycfc",
     key.offset: 1466,
     key.length: 2
   },
@@ -1293,14 +1293,14 @@
   {
     key.kind: source.lang.swift.ref.var.global,
     key.name: "globReadOnly",
-    key.usr: "s:8__main__12globReadOnlyAA2S2Vvp",
+    key.usr: "s:4main12globReadOnlyAA2S2Vvp",
     key.offset: 1496,
     key.length: 12
   },
   {
     key.kind: source.lang.swift.ref.function.method.instance,
     key.name: "sfoo()",
-    key.usr: "s:8__main__2S2V4sfooyyF",
+    key.usr: "s:4main2S2V4sfooyyF",
     key.offset: 1509,
     key.length: 4
   },
@@ -1337,7 +1337,7 @@
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "B1",
-    key.usr: "s:8__main__2B1C",
+    key.usr: "s:4main2B1C",
     key.offset: 1561,
     key.length: 2
   },
@@ -1359,7 +1359,7 @@
   {
     key.kind: source.lang.swift.ref.function.method.instance,
     key.name: "foo()",
-    key.usr: "s:8__main__3SB1C3fooyyF",
+    key.usr: "s:4main3SB1C3fooyyF",
     key.offset: 1594,
     key.length: 3
   },
@@ -1372,7 +1372,7 @@
   {
     key.kind: source.lang.swift.ref.function.method.instance,
     key.name: "foo()",
-    key.usr: "s:8__main__3SB1C3fooyyF",
+    key.usr: "s:4main3SB1C3fooyyF",
     key.offset: 1609,
     key.length: 3
   },
@@ -1384,7 +1384,7 @@
   {
     key.kind: source.lang.swift.ref.function.method.instance,
     key.name: "foo()",
-    key.usr: "s:8__main__2B1C3fooyyF",
+    key.usr: "s:4main2B1C3fooyyF",
     key.offset: 1625,
     key.length: 3
   },
@@ -1411,7 +1411,7 @@
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "SB1",
-    key.usr: "s:8__main__3SB1C",
+    key.usr: "s:4main3SB1C",
     key.offset: 1654,
     key.length: 3
   },
@@ -1423,14 +1423,14 @@
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "S2",
-    key.usr: "s:8__main__2S2V",
+    key.usr: "s:4main2S2V",
     key.offset: 1662,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.function.free,
     key.name: "test2()",
-    key.usr: "s:8__main__5test2yyF",
+    key.usr: "s:4main5test2yyF",
     key.offset: 1670,
     key.length: 5
   },
@@ -1443,7 +1443,7 @@
   {
     key.kind: source.lang.swift.ref.function.method.instance,
     key.name: "foo()",
-    key.usr: "s:8__main__3SB1C3fooyyF",
+    key.usr: "s:4main3SB1C3fooyyF",
     key.offset: 1682,
     key.length: 3
   },
@@ -1456,7 +1456,7 @@
   {
     key.kind: source.lang.swift.ref.function.method.instance,
     key.name: "sfoo()",
-    key.usr: "s:8__main__2S2V4sfooyyF",
+    key.usr: "s:4main2S2V4sfooyyF",
     key.offset: 1692,
     key.length: 4
   },
@@ -1557,7 +1557,7 @@
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot2",
-    key.usr: "s:8__main__5Prot2P",
+    key.usr: "s:4main5Prot2P",
     key.offset: 1825,
     key.length: 5
   },
@@ -1628,7 +1628,7 @@
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot2",
-    key.usr: "s:8__main__5Prot2P",
+    key.usr: "s:4main5Prot2P",
     key.offset: 1912,
     key.length: 5
   },
@@ -1645,7 +1645,7 @@
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "T",
-    key.usr: "s:8__main__6genfooyyxAA5Prot2RzSi7ElementRtzlF1TL_xmfp",
+    key.usr: "s:4main6genfooyyxAA5Prot2RzSi7ElementRtzlF1TL_xmfp",
     key.offset: 1924,
     key.length: 1
   },
@@ -1657,14 +1657,14 @@
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "T",
-    key.usr: "s:8__main__6genfooyyxAA5Prot2RzSi7ElementRtzlF1TL_xmfp",
+    key.usr: "s:4main6genfooyyxAA5Prot2RzSi7ElementRtzlF1TL_xmfp",
     key.offset: 1933,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.associatedtype,
     key.name: "Element",
-    key.usr: "s:8__main__5Prot2P7Element",
+    key.usr: "s:4main5Prot2P7Element",
     key.offset: 1935,
     key.length: 7
   },
@@ -1703,7 +1703,7 @@
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Self",
-    key.usr: "s:8__main__5Prot3P4Selfxmfp",
+    key.usr: "s:4main5Prot3P4Selfxmfp",
     key.offset: 1990,
     key.length: 4
   },
@@ -1715,7 +1715,7 @@
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Self",
-    key.usr: "s:8__main__5Prot3P4Selfxmfp",
+    key.usr: "s:4main5Prot3P4Selfxmfp",
     key.offset: 1999,
     key.length: 4
   }
@@ -1724,13 +1724,13 @@
   {
     key.kind: source.lang.swift.decl.var.global,
     key.name: "globV",
-    key.usr: "s:8__main__5globVSivp",
+    key.usr: "s:4main5globVSivp",
     key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>globV</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type></decl.var.global>"
   },
   {
     key.kind: source.lang.swift.decl.class,
     key.name: "CC0",
-    key.usr: "s:8__main__3CC0C",
+    key.usr: "s:4main3CC0C",
     key.offset: 16,
     key.length: 29,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>CC0</decl.name></decl.class>",
@@ -1738,7 +1738,7 @@
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "x",
-        key.usr: "s:8__main__3CC0C1xSivp",
+        key.usr: "s:4main3CC0C1xSivp",
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>x</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type></decl.var.instance>"
       }
     ]
@@ -1746,7 +1746,7 @@
   {
     key.kind: source.lang.swift.decl.class,
     key.name: "CC",
-    key.usr: "s:8__main__2CCC",
+    key.usr: "s:4main2CCC",
     key.offset: 47,
     key.length: 238,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>CC</decl.name></decl.class>",
@@ -1754,13 +1754,13 @@
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "instV",
-        key.usr: "s:8__main__2CCC5instVAA3CC0Cvp",
-        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>instV</decl.name>: <decl.var.type><ref.class usr=\"s:8__main__3CC0C\">CC0</ref.class></decl.var.type></decl.var.instance>"
+        key.usr: "s:4main2CCC5instVAA3CC0Cvp",
+        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>instV</decl.name>: <decl.var.type><ref.class usr=\"s:4main3CC0C\">CC0</ref.class></decl.var.type></decl.var.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "meth()",
-        key.usr: "s:8__main__2CCC4methyyF",
+        key.usr: "s:4main2CCC4methyyF",
         key.offset: 77,
         key.length: 13,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>meth</decl.name>()</decl.function.method.instance>"
@@ -1768,7 +1768,7 @@
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "instanceFunc0(_:b:)",
-        key.usr: "s:8__main__2CCC13instanceFunc0_1bS2i_SftF",
+        key.usr: "s:4main2CCC13instanceFunc0_1bS2i_SftF",
         key.offset: 94,
         key.length: 63,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>instanceFunc0</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>b</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:Sf\">Float</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int</ref.struct></decl.function.returntype></decl.function.method.instance>",
@@ -1792,7 +1792,7 @@
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "instanceFunc1(a:b:)",
-        key.usr: "s:8__main__2CCC13instanceFunc11a1bS2i_SftF",
+        key.usr: "s:4main2CCC13instanceFunc11a1bS2i_SftF",
         key.offset: 161,
         key.length: 65,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>instanceFunc1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>a</decl.var.parameter.argument_label> <decl.var.parameter.name>x</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>b</decl.var.parameter.argument_label> <decl.var.parameter.name>y</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sf\">Float</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int</ref.struct></decl.function.returntype></decl.function.method.instance>",
@@ -1816,7 +1816,7 @@
       {
         key.kind: source.lang.swift.decl.function.method.class,
         key.name: "smeth()",
-        key.usr: "s:8__main__2CCC5smethyyFZ",
+        key.usr: "s:4main2CCC5smethyyFZ",
         key.offset: 230,
         key.length: 20,
         key.fully_annotated_decl: "<decl.function.method.class><syntaxtype.keyword>class</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>smeth</decl.name>()</decl.function.method.class>"
@@ -1824,7 +1824,7 @@
       {
         key.kind: source.lang.swift.decl.function.constructor,
         key.name: "init()",
-        key.usr: "s:8__main__2CCCACycfc",
+        key.usr: "s:4main2CCCACycfc",
         key.offset: 254,
         key.length: 29,
         key.fully_annotated_decl: "<decl.function.constructor><syntaxtype.keyword>init</syntaxtype.keyword>()</decl.function.constructor>"
@@ -1834,10 +1834,10 @@
   {
     key.kind: source.lang.swift.decl.function.operator.infix,
     key.name: "+(_:_:)",
-    key.usr: "s:8__main__1poiyAA2CCCAD_AA3CC0CtF",
+    key.usr: "s:4main1poiyAA2CCCAD_AA3CC0CtF",
     key.offset: 288,
     key.length: 42,
-    key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>+ </decl.name>(<decl.var.parameter><decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr=\"s:8__main__2CCC\">CC</ref.class></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>b</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr=\"s:8__main__3CC0C\">CC0</ref.class></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.class usr=\"s:8__main__2CCC\">CC</ref.class></decl.function.returntype></decl.function.operator.infix>",
+    key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>+ </decl.name>(<decl.var.parameter><decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr=\"s:4main2CCC\">CC</ref.class></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>b</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr=\"s:4main3CC0C\">CC0</ref.class></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.class usr=\"s:4main2CCC\">CC</ref.class></decl.function.returntype></decl.function.operator.infix>",
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,
@@ -1858,7 +1858,7 @@
   {
     key.kind: source.lang.swift.decl.struct,
     key.name: "S",
-    key.usr: "s:8__main__1SV",
+    key.usr: "s:4main1SV",
     key.offset: 333,
     key.length: 53,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S</decl.name></decl.struct>",
@@ -1866,7 +1866,7 @@
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "meth()",
-        key.usr: "s:8__main__1SV4methyyF",
+        key.usr: "s:4main1SV4methyyF",
         key.offset: 346,
         key.length: 13,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>meth</decl.name>()</decl.function.method.instance>"
@@ -1874,7 +1874,7 @@
       {
         key.kind: source.lang.swift.decl.function.method.static,
         key.name: "smeth()",
-        key.usr: "s:8__main__1SV5smethyyFZ",
+        key.usr: "s:4main1SV5smethyyFZ",
         key.offset: 363,
         key.length: 21,
         key.fully_annotated_decl: "<decl.function.method.static><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>smeth</decl.name>()</decl.function.method.static>"
@@ -1884,7 +1884,7 @@
   {
     key.kind: source.lang.swift.decl.enum,
     key.name: "E",
-    key.usr: "s:8__main__1EO",
+    key.usr: "s:4main1EO",
     key.offset: 389,
     key.length: 22,
     key.fully_annotated_decl: "<decl.enum><syntaxtype.keyword>enum</syntaxtype.keyword> <decl.name>E</decl.name></decl.enum>",
@@ -1892,7 +1892,7 @@
       {
         key.kind: source.lang.swift.decl.enumelement,
         key.name: "EElem",
-        key.usr: "s:8__main__1EO5EElemyA2CmF",
+        key.usr: "s:4main1EO5EElemyA2CmF",
         key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>EElem</decl.name></decl.enumelement>"
       }
     ]
@@ -1900,7 +1900,7 @@
   {
     key.kind: source.lang.swift.decl.protocol,
     key.name: "Prot",
-    key.usr: "s:8__main__4ProtP",
+    key.usr: "s:4main4ProtP",
     key.offset: 414,
     key.length: 43,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>Prot</decl.name></decl.protocol>",
@@ -1908,10 +1908,10 @@
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "protMeth(_:)",
-        key.usr: "s:8__main__4ProtP8protMethyyAaB_pF",
+        key.usr: "s:4main4ProtP8protMethyyAaB_pF",
         key.offset: 432,
         key.length: 23,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>protMeth</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.protocol usr=\"s:8__main__4ProtP\">Prot</ref.protocol></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>protMeth</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.protocol usr=\"s:4main4ProtP\">Prot</ref.protocol></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
           {
             key.kind: source.lang.swift.decl.var.local,
@@ -1927,10 +1927,10 @@
   {
     key.kind: source.lang.swift.decl.function.free,
     key.name: "foo(_:b:)",
-    key.usr: "s:8__main__3foo_1byAA2CCC_AA1EOtF",
+    key.usr: "s:4main3foo_1byAA2CCC_AA1EOtF",
     key.offset: 460,
     key.length: 162,
-    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr=\"s:8__main__2CCC\">CC</ref.class></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>b</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.enum usr=\"s:8__main__1EO\">E</ref.enum></decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr=\"s:4main2CCC\">CC</ref.class></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>b</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.enum usr=\"s:4main1EO\">E</ref.enum></decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,
@@ -1951,10 +1951,10 @@
   {
     key.kind: source.lang.swift.decl.typealias,
     key.name: "CCAlias",
-    key.usr: "s:8__main__7CCAliasa",
+    key.usr: "s:4main7CCAliasa",
     key.offset: 625,
     key.length: 20,
-    key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>CCAlias</decl.name> = <ref.class usr=\"s:8__main__2CCC\">CC</ref.class></decl.typealias>"
+    key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>CCAlias</decl.name> = <ref.class usr=\"s:4main2CCC\">CC</ref.class></decl.typealias>"
   },
   {
     key.kind: source.lang.swift.decl.extension.class,
@@ -1964,22 +1964,22 @@
       {
         key.kind: source.lang.swift.ref.protocol,
         key.name: "Prot",
-        key.usr: "s:8__main__4ProtP"
+        key.usr: "s:4main4ProtP"
       }
     ],
     key.extends: {
       key.kind: source.lang.swift.ref.class,
       key.name: "CC",
-      key.usr: "s:8__main__2CCC"
+      key.usr: "s:4main2CCC"
     },
     key.entities: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "meth2(_:)",
-        key.usr: "s:8__main__2CCC5meth2yyACF",
+        key.usr: "s:4main2CCC5meth2yyACF",
         key.offset: 673,
         key.length: 26,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>meth2</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>x</decl.var.parameter.name>: <decl.var.parameter.type><ref.typealias usr=\"s:8__main__7CCAliasa\">CCAlias</ref.typealias></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>meth2</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>x</decl.var.parameter.name>: <decl.var.parameter.type><ref.typealias usr=\"s:4main7CCAliasa\">CCAlias</ref.typealias></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
           {
             key.kind: source.lang.swift.decl.var.local,
@@ -1993,15 +1993,15 @@
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "protMeth(_:)",
-        key.usr: "s:8__main__2CCC8protMethyyAA4Prot_pF",
+        key.usr: "s:4main2CCC8protMethyyAA4Prot_pF",
         key.offset: 703,
         key.length: 26,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>protMeth</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.protocol usr=\"s:8__main__4ProtP\">Prot</ref.protocol></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>protMeth</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.protocol usr=\"s:4main4ProtP\">Prot</ref.protocol></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.conforms: [
           {
             key.kind: source.lang.swift.ref.function.method.instance,
             key.name: "protMeth(_:)",
-            key.usr: "s:8__main__4ProtP8protMethyyAaB_pF"
+            key.usr: "s:4main4ProtP8protMethyyAaB_pF"
           }
         ],
         key.entities: [
@@ -2017,12 +2017,12 @@
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "extV",
-        key.usr: "s:8__main__2CCC4extVSivp",
+        key.usr: "s:4main2CCC4extVSivp",
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>extV</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.accessor.getter,
-        key.usr: "s:8__main__2CCC4extVSivg",
+        key.usr: "s:4main2CCC4extVSivg",
         key.offset: 748,
         key.length: 11,
         key.fully_annotated_decl: "<decl.function.accessor.getter><decl.name>get</decl.name> {}</decl.function.accessor.getter>"
@@ -2032,28 +2032,28 @@
   {
     key.kind: source.lang.swift.decl.class,
     key.name: "SubCC",
-    key.usr: "s:8__main__5SubCCC",
+    key.usr: "s:4main5SubCCC",
     key.offset: 764,
     key.length: 18,
-    key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>SubCC</decl.name> : <ref.class usr=\"s:8__main__2CCC\">CC</ref.class></decl.class>",
+    key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>SubCC</decl.name> : <ref.class usr=\"s:4main2CCC\">CC</ref.class></decl.class>",
     key.inherits: [
       {
         key.kind: source.lang.swift.ref.class,
         key.name: "CC",
-        key.usr: "s:8__main__2CCC"
+        key.usr: "s:4main2CCC"
       }
     ]
   },
   {
     key.kind: source.lang.swift.decl.var.global,
     key.name: "globV2",
-    key.usr: "s:8__main__6globV2AA5SubCCCvp",
-    key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>globV2</decl.name>: <decl.var.type><ref.class usr=\"s:8__main__5SubCCC\">SubCC</ref.class></decl.var.type></decl.var.global>"
+    key.usr: "s:4main6globV2AA5SubCCCvp",
+    key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>globV2</decl.name>: <decl.var.type><ref.class usr=\"s:4main5SubCCC\">SubCC</ref.class></decl.var.type></decl.var.global>"
   },
   {
     key.kind: source.lang.swift.decl.class,
     key.name: "ComputedProperty",
-    key.usr: "s:8__main__16ComputedPropertyC",
+    key.usr: "s:4main16ComputedPropertyC",
     key.offset: 804,
     key.length: 196,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>ComputedProperty</decl.name></decl.class>",
@@ -2061,19 +2061,19 @@
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "value",
-        key.usr: "s:8__main__16ComputedPropertyC5valueSivp",
+        key.usr: "s:4main16ComputedPropertyC5valueSivp",
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>value</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.var.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.accessor.getter,
-        key.usr: "s:8__main__16ComputedPropertyC5valueSivg",
+        key.usr: "s:4main16ComputedPropertyC5valueSivg",
         key.offset: 853,
         key.length: 51,
         key.fully_annotated_decl: "<decl.function.accessor.getter><decl.name>get</decl.name> {}</decl.function.accessor.getter>"
       },
       {
         key.kind: source.lang.swift.decl.function.accessor.setter,
-        key.usr: "s:8__main__16ComputedPropertyC5valueSivs",
+        key.usr: "s:4main16ComputedPropertyC5valueSivs",
         key.offset: 910,
         key.length: 49,
         key.fully_annotated_decl: "<decl.function.accessor.setter><decl.name>set(newVal)</decl.name> {}</decl.function.accessor.setter>"
@@ -2081,12 +2081,12 @@
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "readOnly",
-        key.usr: "s:8__main__16ComputedPropertyC8readOnlySivp",
+        key.usr: "s:4main16ComputedPropertyC8readOnlySivp",
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>readOnly</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.accessor.getter,
-        key.usr: "s:8__main__16ComputedPropertyC8readOnlySivg",
+        key.usr: "s:4main16ComputedPropertyC8readOnlySivg",
         key.offset: 987,
         key.length: 11,
         key.fully_annotated_decl: "<decl.function.accessor.getter><decl.name>get</decl.name> {}</decl.function.accessor.getter>"
@@ -2096,7 +2096,7 @@
   {
     key.kind: source.lang.swift.decl.class,
     key.name: "BC2",
-    key.usr: "s:8__main__3BC2C",
+    key.usr: "s:4main3BC2C",
     key.offset: 1003,
     key.length: 42,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>BC2</decl.name></decl.class>",
@@ -2104,10 +2104,10 @@
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "protMeth(_:)",
-        key.usr: "s:8__main__3BC2C8protMethyyAA4Prot_pF",
+        key.usr: "s:4main3BC2C8protMethyyAA4Prot_pF",
         key.offset: 1017,
         key.length: 26,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>protMeth</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.protocol usr=\"s:8__main__4ProtP\">Prot</ref.protocol></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>protMeth</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.protocol usr=\"s:4main4ProtP\">Prot</ref.protocol></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.entities: [
           {
             key.kind: source.lang.swift.decl.var.local,
@@ -2123,44 +2123,44 @@
   {
     key.kind: source.lang.swift.decl.class,
     key.name: "SubC2",
-    key.usr: "s:8__main__5SubC2C",
+    key.usr: "s:4main5SubC2C",
     key.offset: 1047,
     key.length: 65,
-    key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>SubC2</decl.name> : <ref.class usr=\"s:8__main__3BC2C\">BC2</ref.class>, <ref.protocol usr=\"s:8__main__4ProtP\">Prot</ref.protocol></decl.class>",
+    key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>SubC2</decl.name> : <ref.class usr=\"s:4main3BC2C\">BC2</ref.class>, <ref.protocol usr=\"s:4main4ProtP\">Prot</ref.protocol></decl.class>",
     key.inherits: [
       {
         key.kind: source.lang.swift.ref.class,
         key.name: "BC2",
-        key.usr: "s:8__main__3BC2C"
+        key.usr: "s:4main3BC2C"
       }
     ],
     key.conforms: [
       {
         key.kind: source.lang.swift.ref.protocol,
         key.name: "Prot",
-        key.usr: "s:8__main__4ProtP"
+        key.usr: "s:4main4ProtP"
       }
     ],
     key.entities: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "protMeth(_:)",
-        key.usr: "s:8__main__5SubC2C8protMethyyAA4Prot_pF",
+        key.usr: "s:4main5SubC2C8protMethyyAA4Prot_pF",
         key.offset: 1084,
         key.length: 26,
-        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>override</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>protMeth</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.protocol usr=\"s:8__main__4ProtP\">Prot</ref.protocol></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
+        key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>override</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>protMeth</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><ref.protocol usr=\"s:4main4ProtP\">Prot</ref.protocol></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
         key.inherits: [
           {
             key.kind: source.lang.swift.ref.function.method.instance,
             key.name: "protMeth(_:)",
-            key.usr: "s:8__main__3BC2C8protMethyyAA4Prot_pF"
+            key.usr: "s:4main3BC2C8protMethyyAA4Prot_pF"
           }
         ],
         key.conforms: [
           {
             key.kind: source.lang.swift.ref.function.method.instance,
             key.name: "protMeth(_:)",
-            key.usr: "s:8__main__4ProtP8protMethyyAaB_pF"
+            key.usr: "s:4main4ProtP8protMethyyAaB_pF"
           }
         ],
         key.entities: [
@@ -2178,7 +2178,7 @@
   {
     key.kind: source.lang.swift.decl.class,
     key.name: "CC2",
-    key.usr: "s:8__main__3CC2C",
+    key.usr: "s:4main3CC2C",
     key.offset: 1115,
     key.length: 115,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>CC2</decl.name></decl.class>",
@@ -2186,7 +2186,7 @@
       {
         key.kind: source.lang.swift.decl.function.subscript,
         key.name: "subscript(_:)",
-        key.usr: "s:8__main__3CC2CyS2icip",
+        key.usr: "s:4main3CC2CyS2icip",
         key.offset: 1129,
         key.length: 99,
         key.fully_annotated_decl: "<decl.function.subscript><syntaxtype.keyword>subscript</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.name>i</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int</ref.struct></decl.function.returntype> { <syntaxtype.keyword>get</syntaxtype.keyword> <syntaxtype.keyword>set</syntaxtype.keyword> }</decl.function.subscript>",
@@ -2202,14 +2202,14 @@
       },
       {
         key.kind: source.lang.swift.decl.function.accessor.getter,
-        key.usr: "s:8__main__3CC2CyS2icig",
+        key.usr: "s:4main3CC2CyS2icig",
         key.offset: 1162,
         key.length: 25,
         key.fully_annotated_decl: "<decl.function.accessor.getter><decl.name>get</decl.name> {}</decl.function.accessor.getter>"
       },
       {
         key.kind: source.lang.swift.decl.function.accessor.setter,
-        key.usr: "s:8__main__3CC2CyS2icis",
+        key.usr: "s:4main3CC2CyS2icis",
         key.offset: 1193,
         key.length: 31,
         key.fully_annotated_decl: "<decl.function.accessor.setter><decl.name>set(vvv)</decl.name> {}</decl.function.accessor.setter>"
@@ -2219,10 +2219,10 @@
   {
     key.kind: source.lang.swift.decl.function.free,
     key.name: "test1(_:sub:)",
-    key.usr: "s:8__main__5test1_3subyAA16ComputedPropertyC_AA3CC2CtF",
+    key.usr: "s:4main5test1_3subyAA16ComputedPropertyC_AA3CC2CtF",
     key.offset: 1233,
     key.length: 155,
-    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>test1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>cp</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr=\"s:8__main__16ComputedPropertyC\">ComputedProperty</ref.class></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>sub</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.class usr=\"s:8__main__3CC2C\">CC2</ref.class></decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>test1</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>cp</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr=\"s:4main16ComputedPropertyC\">ComputedProperty</ref.class></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>sub</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.class usr=\"s:4main3CC2C\">CC2</ref.class></decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,
@@ -2243,7 +2243,7 @@
   {
     key.kind: source.lang.swift.decl.struct,
     key.name: "S2",
-    key.usr: "s:8__main__2S2V",
+    key.usr: "s:4main2S2V",
     key.offset: 1391,
     key.length: 29,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S2</decl.name></decl.struct>",
@@ -2251,7 +2251,7 @@
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "sfoo()",
-        key.usr: "s:8__main__2S2V4sfooyyF",
+        key.usr: "s:4main2S2V4sfooyyF",
         key.offset: 1405,
         key.length: 13,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>sfoo</decl.name>()</decl.function.method.instance>"
@@ -2261,12 +2261,12 @@
   {
     key.kind: source.lang.swift.decl.var.global,
     key.name: "globReadOnly",
-    key.usr: "s:8__main__12globReadOnlyAA2S2Vvp",
-    key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>globReadOnly</decl.name>: <decl.var.type><ref.struct usr=\"s:8__main__2S2V\">S2</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
+    key.usr: "s:4main12globReadOnlyAA2S2Vvp",
+    key.fully_annotated_decl: "<decl.var.global><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>globReadOnly</decl.name>: <decl.var.type><ref.struct usr=\"s:4main2S2V\">S2</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.global>"
   },
   {
     key.kind: source.lang.swift.decl.function.accessor.getter,
-    key.usr: "s:8__main__12globReadOnlyAA2S2Vvg",
+    key.usr: "s:4main12globReadOnlyAA2S2Vvg",
     key.offset: 1449,
     key.length: 25,
     key.fully_annotated_decl: "<decl.function.accessor.getter><decl.name>get</decl.name> {}</decl.function.accessor.getter>"
@@ -2274,7 +2274,7 @@
   {
     key.kind: source.lang.swift.decl.function.free,
     key.name: "test2()",
-    key.usr: "s:8__main__5test2yyF",
+    key.usr: "s:4main5test2yyF",
     key.offset: 1479,
     key.length: 37,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>test2</decl.name>()</decl.function.free>"
@@ -2282,7 +2282,7 @@
   {
     key.kind: source.lang.swift.decl.class,
     key.name: "B1",
-    key.usr: "s:8__main__2B1C",
+    key.usr: "s:4main2B1C",
     key.offset: 1519,
     key.length: 27,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>B1</decl.name></decl.class>",
@@ -2290,7 +2290,7 @@
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo()",
-        key.usr: "s:8__main__2B1C3fooyyF",
+        key.usr: "s:4main2B1C3fooyyF",
         key.offset: 1532,
         key.length: 12,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>()</decl.function.method.instance>"
@@ -2300,22 +2300,22 @@
   {
     key.kind: source.lang.swift.decl.class,
     key.name: "SB1",
-    key.usr: "s:8__main__3SB1C",
+    key.usr: "s:4main3SB1C",
     key.offset: 1549,
     key.length: 86,
-    key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>SB1</decl.name> : <ref.class usr=\"s:8__main__2B1C\">B1</ref.class></decl.class>",
+    key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>SB1</decl.name> : <ref.class usr=\"s:4main2B1C\">B1</ref.class></decl.class>",
     key.inherits: [
       {
         key.kind: source.lang.swift.ref.class,
         key.name: "B1",
-        key.usr: "s:8__main__2B1C"
+        key.usr: "s:4main2B1C"
       }
     ],
     key.entities: [
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo()",
-        key.usr: "s:8__main__3SB1C3fooyyF",
+        key.usr: "s:4main3SB1C3fooyyF",
         key.offset: 1577,
         key.length: 56,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>override</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>()</decl.function.method.instance>",
@@ -2323,7 +2323,7 @@
           {
             key.kind: source.lang.swift.ref.function.method.instance,
             key.name: "foo()",
-            key.usr: "s:8__main__2B1C3fooyyF"
+            key.usr: "s:4main2B1C3fooyyF"
           }
         ]
       }
@@ -2332,10 +2332,10 @@
   {
     key.kind: source.lang.swift.decl.function.free,
     key.name: "test3(_:s:)",
-    key.usr: "s:8__main__5test3_1syAA3SB1C_AA2S2VtF",
+    key.usr: "s:4main5test3_1syAA3SB1C_AA2S2VtF",
     key.offset: 1638,
     key.length: 61,
-    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>test3</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>c</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr=\"s:8__main__3SB1C\">SB1</ref.class></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>s</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:8__main__2S2V\">S2</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>test3</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>c</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr=\"s:4main3SB1C\">SB1</ref.class></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>s</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.struct usr=\"s:4main2S2V\">S2</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,
@@ -2356,7 +2356,7 @@
   {
     key.kind: source.lang.swift.decl.function.free,
     key.name: "test4(_:)",
-    key.usr: "s:8__main__5test4yySizF",
+    key.usr: "s:4main5test4yySizF",
     key.offset: 1702,
     key.length: 28,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>test4</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>a</decl.var.parameter.name>: <decl.var.parameter.type><syntaxtype.keyword>inout</syntaxtype.keyword> <ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>)</decl.function.free>",
@@ -2373,7 +2373,7 @@
   {
     key.kind: source.lang.swift.decl.protocol,
     key.name: "Prot2",
-    key.usr: "s:8__main__5Prot2P",
+    key.usr: "s:4main5Prot2P",
     key.offset: 1733,
     key.length: 77,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>Prot2</decl.name></decl.protocol>",
@@ -2381,7 +2381,7 @@
       {
         key.kind: source.lang.swift.decl.associatedtype,
         key.name: "Element",
-        key.usr: "s:8__main__5Prot2P7Element",
+        key.usr: "s:4main5Prot2P7Element",
         key.offset: 1752,
         key.length: 15,
         key.fully_annotated_decl: "<decl.associatedtype><syntaxtype.keyword>associatedtype</syntaxtype.keyword> <decl.name>Element</decl.name></decl.associatedtype>"
@@ -2389,18 +2389,18 @@
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "p",
-        key.usr: "s:8__main__5Prot2P1pSivp",
+        key.usr: "s:4main5Prot2P1pSivp",
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>p</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.accessor.getter,
-        key.usr: "s:8__main__5Prot2P1pSivg",
+        key.usr: "s:4main5Prot2P1pSivg",
         key.fully_annotated_decl: "<decl.function.accessor.getter><decl.name>get</decl.name> {}</decl.function.accessor.getter>"
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo()",
-        key.usr: "s:8__main__5Prot2P3fooyyF",
+        key.usr: "s:4main5Prot2P3fooyyF",
         key.offset: 1799,
         key.length: 9,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>()</decl.function.method.instance>"
@@ -2410,25 +2410,25 @@
   {
     key.kind: source.lang.swift.decl.struct,
     key.name: "S1",
-    key.usr: "s:8__main__2S1V",
+    key.usr: "s:4main2S1V",
     key.offset: 1813,
     key.length: 80,
-    key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S1</decl.name> : <ref.protocol usr=\"s:8__main__5Prot2P\">Prot2</ref.protocol></decl.struct>",
+    key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S1</decl.name> : <ref.protocol usr=\"s:4main5Prot2P\">Prot2</ref.protocol></decl.struct>",
     key.conforms: [
       {
         key.kind: source.lang.swift.ref.protocol,
         key.name: "Prot2",
-        key.usr: "s:8__main__5Prot2P"
+        key.usr: "s:4main5Prot2P"
       }
     ],
     key.entities: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.name: "Element",
-        key.usr: "s:8__main__2S1V7Elementa",
+        key.usr: "s:4main2S1V7Elementa",
         key.offset: 1835,
         key.length: 20,
-        key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <ref.struct usr=\"s:8__main__2S1V\">S1</ref.struct>.<decl.name>Element</decl.name> = <ref.struct usr=\"s:Si\">Int</ref.struct></decl.typealias>",
+        key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <ref.struct usr=\"s:4main2S1V\">S1</ref.struct>.<decl.name>Element</decl.name> = <ref.struct usr=\"s:Si\">Int</ref.struct></decl.typealias>",
         key.conforms: [
           {
             key.kind: source.lang.swift.ref.protocol,
@@ -2450,20 +2450,20 @@
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "p",
-        key.usr: "s:8__main__2S1V1pSivp",
+        key.usr: "s:4main2S1V1pSivp",
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>p</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type></decl.var.instance>",
         key.conforms: [
           {
             key.kind: source.lang.swift.ref.var.instance,
             key.name: "p",
-            key.usr: "s:8__main__5Prot2P1pSivp"
+            key.usr: "s:4main5Prot2P1pSivp"
           }
         ]
       },
       {
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo()",
-        key.usr: "s:8__main__2S1V3fooyyF",
+        key.usr: "s:4main2S1V3fooyyF",
         key.offset: 1879,
         key.length: 12,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>()</decl.function.method.instance>",
@@ -2471,7 +2471,7 @@
           {
             key.kind: source.lang.swift.ref.function.method.instance,
             key.name: "foo()",
-            key.usr: "s:8__main__5Prot2P3fooyyF"
+            key.usr: "s:4main5Prot2P3fooyyF"
           }
         ]
       }
@@ -2480,7 +2480,7 @@
   {
     key.kind: source.lang.swift.decl.function.free,
     key.name: "genfoo(_:)",
-    key.usr: "s:8__main__6genfooyyxAA5Prot2RzSi7ElementRtzlF",
+    key.usr: "s:4main6genfooyyxAA5Prot2RzSi7ElementRtzlF",
     key.generic_params: [
       {
         key.name: "T"
@@ -2496,7 +2496,7 @@
     ],
     key.offset: 1896,
     key.length: 55,
-    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>genfoo</decl.name>&lt;<decl.generic_type_param usr=\"s:8__main__6genfooyyxAA5Prot2RzSi7ElementRtzlF1TL_xmfp\"><decl.generic_type_param.name>T</decl.generic_type_param.name></decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>x</decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:8__main__6genfooyyxAA5Prot2RzSi7ElementRtzlF1TL_xmfp\">T</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>) <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement>T : <ref.protocol usr=\"s:8__main__5Prot2P\">Prot2</ref.protocol></decl.generic_type_requirement>, <decl.generic_type_requirement>T.Element == <ref.struct usr=\"s:Si\">Int</ref.struct></decl.generic_type_requirement></decl.function.free>",
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>genfoo</decl.name>&lt;<decl.generic_type_param usr=\"s:4main6genfooyyxAA5Prot2RzSi7ElementRtzlF1TL_xmfp\"><decl.generic_type_param.name>T</decl.generic_type_param.name></decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>_</decl.var.parameter.argument_label> <decl.var.parameter.name>x</decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:4main6genfooyyxAA5Prot2RzSi7ElementRtzlF1TL_xmfp\">T</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>) <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement>T : <ref.protocol usr=\"s:4main5Prot2P\">Prot2</ref.protocol></decl.generic_type_requirement>, <decl.generic_type_requirement>T.Element == <ref.struct usr=\"s:Si\">Int</ref.struct></decl.generic_type_requirement></decl.function.free>",
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,
@@ -2510,7 +2510,7 @@
   {
     key.kind: source.lang.swift.decl.protocol,
     key.name: "Prot3",
-    key.usr: "s:8__main__5Prot3P",
+    key.usr: "s:4main5Prot3P",
     key.offset: 1954,
     key.length: 51,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>Prot3</decl.name></decl.protocol>",
@@ -2518,10 +2518,10 @@
       {
         key.kind: source.lang.swift.decl.function.operator.infix,
         key.name: "+(_:_:)",
-        key.usr: "s:8__main__5Prot3P1poiyyx_xtFZ",
+        key.usr: "s:4main5Prot3P1poiyyx_xtFZ",
         key.offset: 1973,
         key.length: 30,
-        key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>+ </decl.name>(<decl.var.parameter><decl.var.parameter.name>x</decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:8__main__5Prot3P4Selfxmfp\">Self</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>y</decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:8__main__5Prot3P4Selfxmfp\">Self</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>)</decl.function.operator.infix>",
+        key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>+ </decl.name>(<decl.var.parameter><decl.var.parameter.name>x</decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:4main5Prot3P4Selfxmfp\">Self</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>y</decl.var.parameter.name>: <decl.var.parameter.type><ref.generic_type_param usr=\"s:4main5Prot3P4Selfxmfp\">Self</ref.generic_type_param></decl.var.parameter.type></decl.var.parameter>)</decl.function.operator.infix>",
         key.entities: [
           {
             key.kind: source.lang.swift.decl.var.local,

--- a/test/SourceKit/DocumentStructure/structure.swift.placeholders.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.placeholders.response
@@ -9,7 +9,7 @@
       key.name: "<#MyCls#>",
       key.offset: 0,
       key.length: 35,
-      key.runtime_name: "_TtC8__main__9<#MyCls#>",
+      key.runtime_name: "_TtC4main9<#MyCls#>",
       key.nameoffset: 6,
       key.namelength: 9,
       key.bodyoffset: 34,

--- a/test/SourceKit/DocumentStructure/structure.swift.placeholders.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.placeholders.response
@@ -9,7 +9,7 @@
       key.name: "<#MyCls#>",
       key.offset: 0,
       key.length: 35,
-      key.runtime_name: "_TtC4main9<#MyCls#>",
+      key.runtime_name: "_TtC12placeholders9<#MyCls#>",
       key.nameoffset: 6,
       key.namelength: 9,
       key.bodyoffset: 34,

--- a/test/SourceKit/Indexing/index.swift
+++ b/test/SourceKit/Indexing/index.swift
@@ -2,7 +2,7 @@
 // integer protocols
 // XFAIL: *
 
-// RUN: %sourcekitd-test -req=index %s -- -serialize-diagnostics-path %t.dia %s | %sed_clean > %t.response
+// RUN: %sourcekitd-test -req=index %s -- -Xfrontend -serialize-diagnostics-path -Xfrontend %t.dia %s | %sed_clean > %t.response
 // RUN: diff -u %s.response %t.response
 
 var globV: Int

--- a/test/SourceKit/Indexing/index_bad_modulename.swift
+++ b/test/SourceKit/Indexing/index_bad_modulename.swift
@@ -1,6 +1,8 @@
-// RUN: %sourcekitd-test -req=index %s -- %s -module-name Swift %mcp_opt %clang-importer-sdk | %sed_clean > %t.response1
+// RUN: %empty-directory(%t)
+// RUN: %build-clang-importer-objc-overlays
+// RUN: %sourcekitd-test -req=index %s -- %s -module-name Swift %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %sed_clean > %t.response1
 // RUN: diff -u %s.response %t.response1
-// RUN: %sourcekitd-test -req=index %s -- %s -module-name 12345 %mcp_opt %clang-importer-sdk | %sed_clean > %t.response2
+// RUN: %sourcekitd-test -req=index %s -- %s -module-name 12345 %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %sed_clean > %t.response2
 // RUN: diff -u %s.response %t.response2
 
 import ObjectiveC

--- a/test/SourceKit/Indexing/index_bad_modulename.swift.response
+++ b/test/SourceKit/Indexing/index_bad_modulename.swift.response
@@ -7,6 +7,43 @@
       key.filepath: Swift.swiftmodule,
       key.hash: <hash>,
       key.is_system: 1
+    },
+    {
+      key.kind: source.lang.swift.import.module.swift,
+      key.name: "ObjectiveC",
+      key.filepath: ObjectiveC.swiftmodule,
+      key.hash: <hash>,
+      key.is_system: 1,
+      key.dependencies: [
+        {
+          key.kind: source.lang.swift.import.module.clang,
+          key.name: "ObjectiveC",
+          key.filepath: ObjectiveC.pcm,
+          key.is_system: 1
+        },
+        {
+          key.kind: source.lang.swift.import.module.swift,
+          key.name: "Swift",
+          key.filepath: Swift.swiftmodule,
+          key.hash: <hash>,
+          key.is_system: 1
+        },
+        {
+          key.kind: source.lang.swift.import.module.swift,
+          key.name: "SwiftOnoneSupport",
+          key.filepath: SwiftOnoneSupport.swiftmodule,
+          key.hash: <hash>,
+          key.dependencies: [
+            {
+              key.kind: source.lang.swift.import.module.swift,
+              key.name: "Swift",
+              key.filepath: Swift.swiftmodule,
+              key.hash: <hash>,
+              key.is_system: 1
+            }
+          ]
+        }
+      ]
     }
   ],
   key.entities: [
@@ -14,19 +51,19 @@
       key.kind: source.lang.swift.decl.var.global,
       key.name: "v",
       key.usr: "s:4main1vSo8NSObjectCSgvp",
-      key.line: 7,
+      key.line: 9,
       key.column: 5,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.function.accessor.getter,
           key.usr: "s:4main1vSo8NSObjectCSgvg",
-          key.line: 7,
+          key.line: 9,
           key.column: 5
         },
         {
           key.kind: source.lang.swift.decl.function.accessor.setter,
           key.usr: "s:4main1vSo8NSObjectCSgvs",
-          key.line: 7,
+          key.line: 9,
           key.column: 5
         }
       ]
@@ -35,7 +72,7 @@
       key.kind: source.lang.swift.ref.class,
       key.name: "NSObject",
       key.usr: "c:objc(cs)NSObject",
-      key.line: 7,
+      key.line: 9,
       key.column: 8
     }
   ]

--- a/test/SourceKit/Indexing/index_constructors.swift
+++ b/test/SourceKit/Indexing/index_constructors.swift
@@ -1,4 +1,4 @@
-// RUN: %sourcekitd-test -req=index %s -- %s %S/Inputs/index_constructors_other.swift | %sed_clean > %t.response
+// RUN: %sourcekitd-test -req=index %s -- %s %S/Inputs/index_constructors_other.swift -module-name index_constructors | %sed_clean > %t.response
 // RUN: diff -u %s.response %t.response
 
 import Foundation

--- a/test/SourceKit/Indexing/index_enum_case.swift
+++ b/test/SourceKit/Indexing/index_enum_case.swift
@@ -1,4 +1,4 @@
-// RUN: %sourcekitd-test -req=index %s -- -serialize-diagnostics-path %t.dia %s | %sed_clean > %t.response
+// RUN: %sourcekitd-test -req=index %s -- -Xfrontend -serialize-diagnostics-path -Xfrontend %t.dia %s | %sed_clean > %t.response
 // RUN: diff -u %s.response %t.response
 
 public enum E {

--- a/test/SourceKit/Indexing/index_forbid_typecheck.swift
+++ b/test/SourceKit/Indexing/index_forbid_typecheck.swift
@@ -1,2 +1,2 @@
-// RUN: %sourcekitd-test -req=index %S/../Inputs/forbid_typecheck_primary.swift -- -Xfrontend -debug-forbid-typecheck-prefix -Xfrontend NOTYPECHECK %S/../Inputs/forbid_typecheck_2.swift %S/../Inputs/forbid_typecheck_primary.swift | %sed_clean > %t.response
+// RUN: %sourcekitd-test -req=index %S/../Inputs/forbid_typecheck_primary.swift -- -Xfrontend -debug-forbid-typecheck-prefix -Xfrontend NOTYPECHECK %S/../Inputs/forbid_typecheck_2.swift %S/../Inputs/forbid_typecheck_primary.swift -module-name forbid_typecheck | %sed_clean > %t.response
 // RUN: diff -u %s.response %t.response

--- a/test/SourceKit/Indexing/index_forbid_typecheck.swift.response
+++ b/test/SourceKit/Indexing/index_forbid_typecheck.swift.response
@@ -13,19 +13,19 @@
     {
       key.kind: source.lang.swift.decl.var.global,
       key.name: "globalPrim",
-      key.usr: "s:18forbid_typecheck_210globalPrimSivp",
+      key.usr: "s:16forbid_typecheck10globalPrimSivp",
       key.line: 1,
       key.column: 5,
       key.entities: [
         {
           key.kind: source.lang.swift.decl.function.accessor.getter,
-          key.usr: "s:18forbid_typecheck_210globalPrimSivg",
+          key.usr: "s:16forbid_typecheck10globalPrimSivg",
           key.line: 1,
           key.column: 5
         },
         {
           key.kind: source.lang.swift.decl.function.accessor.setter,
-          key.usr: "s:18forbid_typecheck_210globalPrimSivs",
+          key.usr: "s:16forbid_typecheck10globalPrimSivs",
           key.line: 1,
           key.column: 5
         }
@@ -34,13 +34,13 @@
     {
       key.kind: source.lang.swift.ref.var.global,
       key.name: "globalSec",
-      key.usr: "s:18forbid_typecheck_29globalSecSivp",
+      key.usr: "s:16forbid_typecheck9globalSecSivp",
       key.line: 1,
       key.column: 18,
       key.entities: [
         {
           key.kind: source.lang.swift.ref.function.accessor.getter,
-          key.usr: "s:18forbid_typecheck_29globalSecSivg",
+          key.usr: "s:16forbid_typecheck9globalSecSivg",
           key.line: 1,
           key.column: 18
         }
@@ -49,44 +49,44 @@
     {
       key.kind: source.lang.swift.decl.function.free,
       key.name: "primFn()",
-      key.usr: "s:18forbid_typecheck_26primFnyyF",
+      key.usr: "s:16forbid_typecheck6primFnyyF",
       key.line: 3,
       key.column: 6,
       key.entities: [
         {
           key.kind: source.lang.swift.ref.function.free,
           key.name: "secFn()",
-          key.usr: "s:18forbid_typecheck_25secFnyyF",
+          key.usr: "s:16forbid_typecheck5secFnyyF",
           key.line: 4,
           key.column: 3
         },
         {
           key.kind: source.lang.swift.ref.class,
           key.name: "ClsSec",
-          key.usr: "s:18forbid_typecheck_26ClsSecC",
+          key.usr: "s:16forbid_typecheck6ClsSecC",
           key.line: 5,
           key.column: 11
         },
         {
           key.kind: source.lang.swift.ref.function.constructor,
           key.name: "init()",
-          key.usr: "s:18forbid_typecheck_26ClsSecCACycfc",
+          key.usr: "s:16forbid_typecheck6ClsSecCACycfc",
           key.line: 5,
           key.column: 11
         },
         {
           key.kind: source.lang.swift.ref.var.instance,
           key.name: "member",
-          key.usr: "s:18forbid_typecheck_26ClsSecC6memberSivp",
+          key.usr: "s:16forbid_typecheck6ClsSecC6memberSivp",
           key.line: 5,
           key.column: 20,
           key.entities: [
             {
               key.kind: source.lang.swift.ref.function.accessor.getter,
-              key.usr: "s:18forbid_typecheck_26ClsSecC6memberSivg",
+              key.usr: "s:16forbid_typecheck6ClsSecC6memberSivg",
               key.line: 5,
               key.column: 20,
-              key.receiver_usr: "s:18forbid_typecheck_26ClsSecC",
+              key.receiver_usr: "s:16forbid_typecheck6ClsSecC",
               key.is_dynamic: 1
             }
           ]

--- a/test/SourceKit/Indexing/index_is_test_candidate.swift
+++ b/test/SourceKit/Indexing/index_is_test_candidate.swift
@@ -1,4 +1,4 @@
-// RUN: %sourcekitd-test -req=index %s -- -serialize-diagnostics-path %t.dia %s | %sed_clean > %t.response
+// RUN: %sourcekitd-test -req=index %s -- -Xfrontend -serialize-diagnostics-path -Xfrontend %t.dia %s | %sed_clean > %t.response
 // RUN: diff -u %s.response %t.response
 
 // This test verifies that, when Objective-C interop is disabled, private

--- a/test/SourceKit/Indexing/index_is_test_candidate_objc.swift
+++ b/test/SourceKit/Indexing/index_is_test_candidate_objc.swift
@@ -1,4 +1,4 @@
-// RUN: %sourcekitd-test -req=index %s -- -serialize-diagnostics-path %t.dia %s | %sed_clean > %t.response
+// RUN: %sourcekitd-test -req=index %s -- -Xfrontend -serialize-diagnostics-path -Xfrontend %t.dia %s | %sed_clean > %t.response
 // RUN: diff -u %s.response %t.response
 
 // This test verifies that, when Objective-C interop is enabled, all "test

--- a/test/SourceKit/Indexing/index_with_clang_module.swift
+++ b/test/SourceKit/Indexing/index_with_clang_module.swift
@@ -1,6 +1,10 @@
 // REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: %build-clang-importer-objc-overlays
+
 // RUN: %sourcekitd-test -req=index %s -- %s -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt %clang-importer-sdk | %FileCheck %s
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck %s
 
 import Foo
 

--- a/test/SourceKit/Indexing/rdar_21602898.swift
+++ b/test/SourceKit/Indexing/rdar_21602898.swift
@@ -1,4 +1,4 @@
-// RUN: %sourcekitd-test -req=index %s -- -serialize-diagnostics-path %t.dia %s | %sed_clean > %t.response
+// RUN: %sourcekitd-test -req=index %s -- -Xfrontend -serialize-diagnostics-path -Xfrontend %t.dia %s | %sed_clean > %t.response
 // RUN: diff -u %s.response %t.response
 
 protocol P {}

--- a/test/SourceKit/Indexing/sr_3815.swift
+++ b/test/SourceKit/Indexing/sr_3815.swift
@@ -1,4 +1,4 @@
-// RUN: %sourcekitd-test -req=index %s -- -serialize-diagnostics-path %t.dia %s | %sed_clean > %t.response
+// RUN: %sourcekitd-test -req=index %s -- -Xfrontend -serialize-diagnostics-path -Xfrontend %t.dia %s | %sed_clean > %t.response
 // RUN: diff -u %s.response %t.response
 
 protocol P {

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift
@@ -4,35 +4,40 @@ var x: FooClassBase
 
 // REQUIRES: objc_interop
 
+// FIXME: the test output we're comparing to is specific to macOS.
+// REQUIRES-ANY: OS=macosx
+
 // RUN: %empty-directory(%t.overlays)
+// RUN: %empty-directory(%t)
+// RUN: %build-clang-importer-objc-overlays
 //
-// RUN: %swift -emit-module -o %t.overlays -F %S/../Inputs/libIDE-mock-sdk %S/Inputs/Foo.swift
+// RUN: %target-swift-frontend -emit-module -o %t.overlays -F %S/../Inputs/libIDE-mock-sdk %S/Inputs/Foo.swift
 //
 // RUN: %sourcekitd-test -req=interface-gen -module Foo -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt %clang-importer-sdk > %t.response
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t > %t.response
 // RUN: diff -u %s.response %t.response
 
 // RUN: %sourcekitd-test -req=interface-gen -module Foo.FooSub -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt %clang-importer-sdk > %t.sub.response
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t > %t.sub.response
 // RUN: diff -u %s.sub.response %t.sub.response
 
 // RUN: %sourcekitd-test -req=interface-gen -module FooHelper -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt %clang-importer-sdk > %t.helper.response
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t > %t.helper.response
 // RUN: diff -u %s.helper.response %t.helper.response
 
 // RUN: %sourcekitd-test -req=interface-gen -module FooHelper.FooHelperExplicit -- -I %t.overlays \
-// RUN:         -F %S/../Inputs/libIDE-mock-sdk  %mcp_opt %clang-importer-sdk > %t.helper.explicit.response
+// RUN:         -F %S/../Inputs/libIDE-mock-sdk  %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t > %t.helper.explicit.response
 // RUN: diff -u %s.helper.explicit.response %t.helper.explicit.response
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt %clang-importer-sdk \
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t \
 // RUN:      == -req=cursor -pos=205:67 | %FileCheck -check-prefix=CHECK1 %s
 // The cursor points to 'FooClassBase' inside the list of base classes, see 'gen_clang_module.swift.response'
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt %clang-importer-sdk \
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t \
 // RUN:   == -req=cursor -pos=3:11 %s -- %s -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt %clang-importer-sdk | %FileCheck -check-prefix=CHECK1 %s
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK1 %s
 
 // CHECK1: source.lang.swift.ref.class ({{.*}}Foo.framework/Headers/Foo.h:147:12-147:24)
 // CHECK1: FooClassBase
@@ -41,7 +46,7 @@ var x: FooClassBase
 // CHECK1-NEXT: /<interface-gen>
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt %clang-importer-sdk \
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t \
 // RUN:      == -req=cursor -pos=232:20 | %FileCheck -check-prefix=CHECK2 %s
 // The cursor points inside the interface, see 'gen_clang_module.swift.response'
 
@@ -52,22 +57,22 @@ var x: FooClassBase
 // CHECK2-NEXT: /<interface-gen>
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt %clang-importer-sdk \
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t \
 // RUN:      == -req=find-usr -usr "c:objc(cs)FooClassDerived(im)fooInstanceFunc0" | %FileCheck -check-prefix=CHECK-USR %s
 // The returned line:col points inside the interface, see 'gen_clang_module.swift.response'
 
 // CHECK-USR: (232:15-232:33)
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt %clang-importer-sdk \
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t \
 // RUN:   == -req=find-interface -module Foo -- %s -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt %clang-importer-sdk | %FileCheck -check-prefix=CHECK-IFACE %s
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK-IFACE %s
 
 // CHECK-IFACE: DOC: (/<interface-gen>)
 // CHECK-IFACE: ARGS: [-target x86_64-{{.*}} -sdk {{.*}} -F {{.*}}/libIDE-mock-sdk -I {{.*}}.overlays {{.*}} -module-cache-path {{.*}} ]
 
 // RUN: %sourcekitd-test -req=interface-gen-open -module Foo -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk \
-// RUN:         %mcp_opt %clang-importer-sdk \
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t \
 // RUN:      == -req=cursor -pos=1:8 == -req=cursor -pos=1:12 \
 // RUN:      == -req=cursor -pos=2:10 \
 // RUN:      == -req=cursor -pos=3:10 | %FileCheck -check-prefix=CHECK-IMPORT %s

--- a/test/SourceKit/InterfaceGen/gen_header_swift_args.swift
+++ b/test/SourceKit/InterfaceGen/gen_header_swift_args.swift
@@ -1,5 +1,5 @@
 // REQUIRES: objc_interop
-// RUN: %sourcekitd-test -req=interface-gen -using-swift-args -header %S/Inputs/header.h -- %s -enable-objc-interop -import-objc-header %S/Inputs/header.h > %t.response
+// RUN: %sourcekitd-test -req=interface-gen -using-swift-args -header %S/Inputs/header.h -- %s -Xfrontend -enable-objc-interop -import-objc-header %S/Inputs/header.h > %t.response
 // RUN: diff -u %S/gen_header.swift.response %t.response
 
 doSomethingInHead(1)

--- a/test/SourceKit/InterfaceGen/gen_mixed_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_mixed_module.swift
@@ -1,9 +1,15 @@
 var x = 10
 
 // REQUIRES: objc_interop
-// RUN: %empty-directory(%t.overlays)
 
-// RUN: %swift -emit-module -o %t.overlays -F %S/../Inputs/libIDE-mock-sdk %S/../Inputs/libIDE-mock-sdk/Mixed.swift -import-underlying-module -module-name Mixed -disable-objc-attr-requires-foundation-module
-// RUN: %sourcekitd-test -req=interface-gen -module Mixed -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk %mcp_opt %clang-importer-sdk | %FileCheck -check-prefix=CHECK1 %s
+// FIXME: the test output we're comparing to is specific to macOS.
+// REQUIRES-ANY: OS=macosx
+
+// RUN: %empty-directory(%t.overlays)
+// RUN: %empty-directory(%t)
+// RUN: %build-clang-importer-objc-overlays
+
+// RUN: %target-swift-frontend -emit-module -o %t.overlays -F %S/../Inputs/libIDE-mock-sdk %S/../Inputs/libIDE-mock-sdk/Mixed.swift -import-underlying-module -module-name Mixed -disable-objc-attr-requires-foundation-module
+// RUN: %sourcekitd-test -req=interface-gen -module Mixed -- -I %t.overlays -F %S/../Inputs/libIDE-mock-sdk %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t | %FileCheck -check-prefix=CHECK1 %s
 
 // CHECK1: PureSwiftClass

--- a/test/SourceKit/InterfaceGen/gen_swift_source.swift
+++ b/test/SourceKit/InterfaceGen/gen_swift_source.swift
@@ -1,7 +1,12 @@
-// RUN: %sourcekitd-test -req=interface-gen %S/Inputs/Foo2.swift -- %S/Inputs/Foo2.swift %mcp_opt %clang-importer-sdk > %t.response
+// REQUIRES: objc_interop
+
+// RUN: %empty-directory(%t)
+// RUN: %build-clang-importer-objc-overlays
+
+// RUN: %sourcekitd-test -req=interface-gen %S/Inputs/Foo2.swift -- %S/Inputs/Foo2.swift %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t > %t.response
 // RUN: diff -u %s.response %t.response
 
-// RUN: %sourcekitd-test -req=interface-gen-open %S/Inputs/Foo2.swift -- %S/Inputs/Foo2.swift %mcp_opt %clang-importer-sdk \
+// RUN: %sourcekitd-test -req=interface-gen-open %S/Inputs/Foo2.swift -- %S/Inputs/Foo2.swift %mcp_opt -target %target-triple %clang-importer-sdk-nosource -I %t \
 // RUN: == -req=cursor -pos=18:49 | %FileCheck -check-prefix=CHECK1 %s
 // The cursor points to 'FooOverlayClassBase' inside the list of base classes, see 'gen_swift_source.swift.response'
 

--- a/test/SourceKit/InterfaceGen/gen_swift_source.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_swift_source.swift.response
@@ -329,12 +329,14 @@ internal enum Colors {
   {
     key.kind: source.lang.swift.ref.module,
     key.offset: 76,
-    key.length: 10
+    key.length: 10,
+    key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.module,
     key.offset: 94,
-    key.length: 6
+    key.length: 6,
+    key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,

--- a/test/SourceKit/Misc/ignored-flags.swift
+++ b/test/SourceKit/Misc/ignored-flags.swift
@@ -4,8 +4,26 @@ s.
 // CHECK: littleEndian
 
 // RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -j4 %s | %FileCheck %s
-// RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -c %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -j 4 %s | %FileCheck %s
 // RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -v %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -c %s | %FileCheck %s
 // RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -embed-bitcode %s | %FileCheck %s
 // RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -enable-bridging-pch %s | %FileCheck %s
 // RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -disable-bridging-pch %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -verify-debug-info %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -Xlinker blah %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -use-ld=blah %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -incremental %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -driver-time-compilation %s | %FileCheck %s
+
+
+// Mode flags
+// RUN: %empty-directory(%t)
+// RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -emit-object %s -o %t/test.o | %FileCheck %s
+// RUN: not find %t/test.o
+// RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -emit-executable %s -o %t/test | %FileCheck %s
+// RUN: not find %t/test
+// RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -emit-library -module-name test %s -o %t/test | %FileCheck %s
+// RUN: not find %t/test
+// RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -emit-module -module-name test %s  -o %t/test.swiftmodule | %FileCheck %s
+// RUN: not find %t/test.swiftmodule

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -377,7 +377,7 @@ static void setModuleName(CompilerInvocation &Invocation) {
   StringRef Filename = Invocation.getOutputFilename();
   if (Filename.empty()) {
     if (!Invocation.getFrontendOptions().InputsAndOutputs.hasInputs()) {
-      Invocation.setModuleName("__main__");
+      Invocation.setModuleName("main");
       return;
     }
     Filename = Invocation.getFrontendOptions()
@@ -386,7 +386,7 @@ static void setModuleName(CompilerInvocation &Invocation) {
   Filename = llvm::sys::path::filename(Filename);
   StringRef ModuleName = llvm::sys::path::stem(Filename);
   if (ModuleName.empty() || !Lexer::isIdentifier(ModuleName)) {
-    Invocation.setModuleName("__main__");
+    Invocation.setModuleName("main");
     return;
   }
   Invocation.setModuleName(ModuleName);

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -21,6 +21,7 @@
 #include "SourceKit/Support/Tracing.h"
 
 #include "swift/Basic/Cache.h"
+#include "swift/Driver/FrontendUtil.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/Strings.h"
@@ -370,49 +371,6 @@ SwiftASTManager::getMemoryBuffer(StringRef Filename, std::string &Error) {
   return Impl.getMemoryBuffer(Filename, Error);
 }
 
-static void setModuleName(CompilerInvocation &Invocation) {
-  if (!Invocation.getModuleName().empty())
-    return;
-
-  StringRef Filename = Invocation.getOutputFilename();
-  if (Filename.empty()) {
-    if (!Invocation.getFrontendOptions().InputsAndOutputs.hasInputs()) {
-      Invocation.setModuleName("main");
-      return;
-    }
-    Filename = Invocation.getFrontendOptions()
-                   .InputsAndOutputs.getFilenameOfFirstInput();
-  }
-  Filename = llvm::sys::path::filename(Filename);
-  StringRef ModuleName = llvm::sys::path::stem(Filename);
-  if (ModuleName.empty() || !Lexer::isIdentifier(ModuleName)) {
-    Invocation.setModuleName("main");
-    return;
-  }
-  Invocation.setModuleName(ModuleName);
-}
-
-static void sanitizeCompilerArgs(ArrayRef<const char *> Args,
-                                 SmallVectorImpl<const char *> &NewArgs) {
-  for (const char *CArg : Args) {
-    StringRef Arg = CArg;
-    if (Arg.startswith("-j"))
-      continue;
-    if (Arg == "-c")
-      continue;
-    if (Arg == "-v")
-      continue;
-    if (Arg == "-Xfrontend")
-      continue;
-    if (Arg == "-embed-bitcode")
-      continue;
-    if (Arg == "-enable-bridging-pch" ||
-        Arg == "-disable-bridging-pch")
-      continue;
-    NewArgs.push_back(CArg);
-  }
-}
-
 static FrontendInputsAndOutputs
 convertFileContentsToInputs(const SmallVectorImpl<FileContent> &contents) {
   FrontendInputsAndOutputs inputsAndOutputs;
@@ -456,19 +414,20 @@ resolveSymbolicLinksInInputs(FrontendInputsAndOutputs &inputsAndOutputs,
 }
 
 bool SwiftASTManager::initCompilerInvocation(CompilerInvocation &Invocation,
-                                             ArrayRef<const char *> OrigArgs,
+                                             ArrayRef<const char *> Args,
                                              DiagnosticEngine &Diags,
                                              StringRef UnresolvedPrimaryFile,
                                              std::string &Error) {
-  SmallVector<const char *, 16> Args;
-  sanitizeCompilerArgs(OrigArgs, Args);
-
-  Invocation.setRuntimeResourcePath(Impl.RuntimeResourcePath);
-  if (Invocation.parseArgs(Args, Diags)) {
+  if (auto driverInvocation = driver::createCompilerInvocation(Args, Diags)) {
+    Invocation = *driverInvocation;
+  } else {
     // FIXME: Get the actual diagnostic.
     Error = "error when parsing the compiler arguments";
     return true;
   }
+
+  Invocation.setRuntimeResourcePath(Impl.RuntimeResourcePath);
+
   Invocation.getFrontendOptions().InputsAndOutputs =
       resolveSymbolicLinksInInputs(
           Invocation.getFrontendOptions().InputsAndOutputs,
@@ -479,7 +438,7 @@ bool SwiftASTManager::initCompilerInvocation(CompilerInvocation &Invocation,
   ClangImporterOptions &ImporterOpts = Invocation.getClangImporterOptions();
   ImporterOpts.DetailedPreprocessingRecord = true;
 
-  setModuleName(Invocation);
+  assert(!Invocation.getModuleName().empty());
   Invocation.setSerializedDiagnosticsPath(StringRef());
   Invocation.getLangOptions().AttachCommentsToDecls = true;
   Invocation.getLangOptions().DiagnosticsEditorMode = true;
@@ -496,6 +455,10 @@ bool SwiftASTManager::initCompilerInvocation(CompilerInvocation &Invocation,
   // Disable the index-store functionality for the sourcekitd requests.
   FrontendOpts.IndexStorePath.clear();
   ImporterOpts.IndexStorePath.clear();
+
+  // Force the action type to be -typecheck. This affects importing the
+  // SwiftONoneSupport module.
+  FrontendOpts.RequestedAction = FrontendOptions::ActionType::Typecheck;
 
   return false;
 }
@@ -517,6 +480,27 @@ bool SwiftASTManager::initCompilerInvocation(CompilerInvocation &CompInvok,
       Error = ErrOS.str();
     return true;
   }
+  return false;
+}
+
+bool SwiftASTManager::initCompilerInvocationNoInputs(
+    swift::CompilerInvocation &Invocation, ArrayRef<const char *> OrigArgs,
+    swift::DiagnosticEngine &Diags, std::string &Error, bool AllowInputs) {
+
+  SmallVector<const char *, 16> Args(OrigArgs.begin(), OrigArgs.end());
+  // Use stdin as a .swift input to satisfy the driver.
+  Args.push_back("-");
+  if (initCompilerInvocation(Invocation, Args, Diags, "", Error))
+    return true;
+
+  if (!AllowInputs &&
+      Invocation.getFrontendOptions().InputsAndOutputs.inputCount() > 1) {
+    Error = "unexpected input in compiler arguments";
+    return true;
+  }
+
+  // Clear the inputs.
+  Invocation.getFrontendOptions().InputsAndOutputs.clearInputs();
   return false;
 }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.h
@@ -118,6 +118,16 @@ public:
                               StringRef PrimaryFile,
                               std::string &Error);
 
+  /// Initializes \p Invocation as if for typechecking, but with no inputs.
+  ///
+  /// If \p AllowInputs is false, it is an error for \p OrigArgs to contain any
+  /// input files.
+  bool initCompilerInvocationNoInputs(swift::CompilerInvocation &Invocation,
+                                      ArrayRef<const char *> OrigArgs,
+                                      swift::DiagnosticEngine &Diags,
+                                      std::string &Error,
+                                      bool AllowInputs = true);
+
   void removeCachedAST(SwiftInvocationRef Invok);
 
   struct Implementation;

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -1194,10 +1194,14 @@ void SwiftLangSupport::codeCompleteOpen(
 
   // Add any codecomplete.open specific flags.
   std::vector<const char *> extendedArgs(args.begin(), args.end());
-  if (CCOpts.addInitsToTopLevel)
+  if (CCOpts.addInitsToTopLevel) {
+    extendedArgs.push_back("-Xfrontend");
     extendedArgs.push_back("-code-complete-inits-in-postfix-expr");
-  if (CCOpts.callPatternHeuristics)
+  }
+  if (CCOpts.callPatternHeuristics) {
+    extendedArgs.push_back("-Xfrontend");
     extendedArgs.push_back("-code-complete-call-pattern-heuristics");
+  }
 
   // Invoke completion.
   std::string error;

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -1359,9 +1359,8 @@ SourceFile *SwiftLangSupport::getSyntacticSourceFile(
     CompilerInstance &ParseCI, std::string &Error) {
   CompilerInvocation Invocation;
 
-  bool Failed = getASTManager().initCompilerInvocation(Invocation, Args,
-                                                       ParseCI.getDiags(),
-                                                       StringRef(), Error);
+  bool Failed = getASTManager().initCompilerInvocationNoInputs(
+      Invocation, Args, ParseCI.getDiags(), Error);
   if (Failed) {
     Error = "Compiler invocation init failed";
     return nullptr;
@@ -1415,14 +1414,14 @@ void SwiftLangSupport::getDocInfo(llvm::MemoryBuffer *InputBuf,
 
   CompilerInvocation Invocation;
   std::string Error;
-  bool Failed = getASTManager().initCompilerInvocation(Invocation, Args,
-                                                       CI.getDiags(),
-                                                       StringRef(),
-                                                       Error);
+  bool Failed = getASTManager().initCompilerInvocationNoInputs(
+      Invocation, Args, CI.getDiags(), Error, /*AllowInputs=*/false);
+
   if (Failed) {
     Consumer.failed(Error);
     return;
   }
+
   Invocation.getClangImporterOptions().ImportForwardDeclarations = true;
 
   if (!ModuleName.empty()) {
@@ -1451,8 +1450,8 @@ findModuleGroups(StringRef ModuleName, ArrayRef<const char *> Args,
   CI.addDiagnosticConsumer(&PrintDiags);
   std::vector<StringRef> Groups;
   std::string Error;
-  if (getASTManager().initCompilerInvocation(Invocation, Args, CI.getDiags(),
-                                             StringRef(), Error)) {
+  if (getASTManager().initCompilerInvocationNoInputs(Invocation, Args,
+                                                     CI.getDiags(), Error)) {
     Receiver(Groups, Error);
     return;
   }

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1766,7 +1766,8 @@ void SwiftEditorDocument::parse(ImmutableTextSnapshotRef Snapshot,
     Impl.SemanticInfo->getInvocation()->applyTo(CompInv);
     Impl.SemanticInfo->getInvocation()->raw(Args, PrimaryFile);
   } else {
-    ArrayRef<const char *> Args;
+    SmallVector<const char *, 1> Args;
+    Args.push_back(Impl.FilePath.c_str()); // Input
     std::string Error;
     // Ignore possible error(s)
     Lang.getASTManager().

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -700,8 +700,8 @@ void SwiftLangSupport::editorOpenInterface(EditorConsumer &Consumer,
 
   CompilerInvocation Invocation;
   std::string Error;
-  if (getASTManager().initCompilerInvocation(Invocation, Args, CI.getDiags(),
-                                             StringRef(), Error)) {
+  if (getASTManager().initCompilerInvocationNoInputs(Invocation, Args,
+                                                     CI.getDiags(), Error)) {
     Consumer.handleRequestError(Error.c_str());
     return;
   }
@@ -814,8 +814,8 @@ void SwiftLangSupport::editorOpenHeaderInterface(EditorConsumer &Consumer,
   std::string Error;
 
   ArrayRef<const char *> SwiftArgs = UsingSwiftArgs ? Args : llvm::None;
-  if (getASTManager().initCompilerInvocation(Invocation, SwiftArgs, CI.getDiags(),
-                                             StringRef(), Error)) {
+  if (getASTManager().initCompilerInvocationNoInputs(Invocation, SwiftArgs,
+                                                     CI.getDiags(), Error)) {
     Consumer.handleRequestError(Error.c_str());
     return;
   }

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -253,13 +253,18 @@ void SwiftLangSupport::indexSource(StringRef InputFile,
   // response, and it can be expensive to do typo-correction when there are many
   // errors, which is common in indexing.
   SmallVector<const char *, 16> Args(OrigArgs.begin(), OrigArgs.end());
+  Args.push_back("-Xfrontend");
   Args.push_back("-disable-typo-correction");
 
   CompilerInvocation Invocation;
-  bool Failed = getASTManager().initCompilerInvocation(Invocation, Args,
-                                                       CI.getDiags(),
-                    /*PrimaryFile=*/IsModuleIndexing ? StringRef() : InputFile,
-                                                       Error);
+  bool Failed = true;
+  if (IsModuleIndexing) {
+    Failed = getASTManager().initCompilerInvocationNoInputs(
+        Invocation, Args, CI.getDiags(), Error);
+  } else {
+    Failed = getASTManager().initCompilerInvocation(
+        Invocation, Args, CI.getDiags(), InputFile, Error);
+  }
   if (Failed) {
     IdxConsumer.failed(Error);
     return;


### PR DESCRIPTION
Stop parsing frontend arguments directly and use the driver instead. The most intersting part of this change is that it forces us to consider whether our compiler invocation will have inputs or not.  We have several kinds of requests that need to create a compiler instance, but not parse any inputs (interface-generation, doc-info, and indexing when operating on a module instead of source files).

rdar://17897287