### PR TITLE
[build-script-impl] Process substitution avoiding "/bin/sh: Argument list too long"

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -3000,9 +3000,9 @@ for host in "${ALL_HOSTS[@]}"; do
                     echo "Test command: ${dry_run_command_output}"
 
                     if [[ ! "${test_paths}" ]]; then
-                        sh -e -x -c "${dry_run_command_output}"
+                        env bash -ex <(echo -e "${dry_run_command_output}")
                     else
-                        sh -e -x -c "${dry_run_command_output} $(echo ${test_paths[@]})"
+                        env bash -ex <(echo -e "${dry_run_command_output}" "${test_paths[@]}")
                     fi
                 else
                     call "${build_cmd[@]}" ${BUILD_TARGET_FLAG} ${test_target}


### PR DESCRIPTION
# Purpose

This PR adds a fix to `build-script-impl` that should avoid the `/bin/sh: Argument list too long` error that's been seen on the [ASAN CI bot](https://ci.swift.org/view/Dashboard/job/oss-swift-incremental-ASAN-RA-osx/).

rdar://33714951