### PR TITLE
[build-script] Use ${NINJA_BIN} instead of ninja

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2746,7 +2746,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     fi
                 else
                     with_pushd ${lldb_build_dir} \
-                        ninja check-lldb-unit
+                        ${NINJA_BIN} check-lldb-unit
                 fi
 
                 swift_build_dir=$(build_directory ${host} swift)


### PR DESCRIPTION
build-script shouldn't assume ninja is in the system path.