### PR TITLE
build: canonicalise the windows paths prior to use

### DIFF
--- a/cmake/modules/SwiftWindowsSupport.cmake
+++ b/cmake/modules/SwiftWindowsSupport.cmake
@@ -61,8 +61,8 @@ endfunction()
 function(swift_windows_generate_sdk_vfs_overlay flags)
   swift_verify_windows_environment_variables()
 
-  set(VCToolsInstallDir $ENV{VCToolsInstallDir})
-  set(UniversalCRTSdkDir $ENV{UniversalCRTSdkDir})
+  get_filename_component(VCToolsInstallDir $ENV{VCToolsInstallDir} ABSOLUTE)
+  get_filename_component(UniversalCRTSdkDir $ENV{UniversalCRTSdkDir} ABSOLUTE)
   set(UCRTVersion $ENV{UCRTVersion})
 
   # TODO(compnerd) use a target to avoid re-creating this file all the time


### PR DESCRIPTION
In order to substitute the path into the VFS overlay, we need to escape
the paths.  Instead, opt on the CMake behaviour of
`get_filename_component` providing the canonicalised path with forward
slashes rather than backslashes.  This allows the overlay to be used on
Windows as well as Linux.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
