### PR TITLE
[MetadataReader] Work around a possible miscompile (or UB).

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -919,6 +919,10 @@ private:
 
   /// Given the address of a nominal type descriptor, attempt to read it.
   ContextDescriptorRef
+  // FIXME: There's a miscompile/UB going on that causes many tests to
+  // fail in lldb if this function is built with optimization, so, for now,
+  // as workaround we slapt optnone on it.
+  __attribute__((optnone))
   readContextDescriptor(StoredPointer address) {
     if (address == 0)
       return nullptr;


### PR DESCRIPTION
On some lldb tests, the semantic of this function changes
if it's built with optimization or without. I'm tracking the
problem down, but in the meanwhile, given this breaks many
tests in lldb, try to work around the problem to make the
bots green.
