### PR TITLE
[WIP] Avoid rerunning diagnostic passes on deserialized SIL.

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -215,6 +215,10 @@ private:
   /// after the pass runs, we only see a semantic-arc world.
   bool HasQualifiedOwnership = true;
 
+  /// Set if the function body was deserialized. This implies that the
+  /// function's home module performed SIL diagnostics prior to serialization.
+  bool WasDeserialized = false;
+
   SILFunction(SILModule &module, SILLinkage linkage, StringRef mangledName,
               CanSILFunctionType loweredType, GenericEnvironment *genericEnv,
               Optional<SILLocation> loc, IsBare_t isBareSILFunction,
@@ -335,6 +339,14 @@ public:
   void setUnqualifiedOwnership() {
     HasQualifiedOwnership = false;
   }
+
+  /// Returns true if this function was deserialized from another .swiftmodule
+  /// (not a .sib file). If so, it must have been serialized in the canonical
+  /// stage, so should not have diagnostics reapplied. (.sib is serialized IR
+  /// from any SIL stage).
+  bool wasDeserialized() const { return WasDeserialized; }
+
+  void setWasDeserialized() { WasDeserialized = true; }
 
   /// Returns the calling convention used by this entry point.
   SILFunctionTypeRepresentation getRepresentation() const {

--- a/include/swift/SILOptimizer/PassManager/Passes.h
+++ b/include/swift/SILOptimizer/PassManager/Passes.h
@@ -50,7 +50,7 @@ namespace swift {
 
   /// \brief Detect and remove unreachable code. Diagnose provably unreachable
   /// user code.
-  void performSILDiagnoseUnreachable(SILModule *M, SILModuleTransform *T);
+  void performSILDiagnoseUnreachable(SILModule *M);
 
   /// \brief Remove dead functions from \p M.
   void performSILDeadFunctionElimination(SILModule *M);

--- a/include/swift/SILOptimizer/PassManager/Transforms.h
+++ b/include/swift/SILOptimizer/PassManager/Transforms.h
@@ -122,7 +122,6 @@ namespace swift {
     /// pipeline on it.
     void restartPassPipeline() { PM->restartWithCurrentFunction(this); }
 
-  protected:
     SILFunction *getFunction() { return F; }
 
     void invalidateAnalysis(SILAnalysis::InvalidationKind K) {

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -87,6 +87,11 @@ class ModuleFile
   /// The number of entities that are currently being deserialized.
   unsigned NumCurrentDeserializingEntities = 0;
 
+  /// Is this module file actually a .sib file? .sib files are serialized SIL at
+  /// arbitrary granularity and arbitrary stage; unlike serialized Swift
+  /// modules, which are assumed to contain canonical SIL for an entire module.
+  bool IsSIB = false;
+
   /// RAII class to be used when deserializing an entity.
   class DeserializingEntityRAII {
     ModuleFile &MF;

--- a/lib/SILOptimizer/Analysis/ClosureScope.cpp
+++ b/lib/SILOptimizer/Analysis/ClosureScope.cpp
@@ -91,6 +91,14 @@ public:
     auto scopeFunc = PAI->getFunction();
     int scopeIdx = lookupScopeIndex(scopeFunc);
 
+    // Passes may assume that a deserialized function can only refer to
+    // deserialized closures. For example, AccessEnforcementSelection skips
+    // deserialized functions but assumes all a closure's parent scope have been
+    // processed.
+    assert(scopeFunc->wasDeserialized() == closureFunc->wasDeserialized() &&
+           "A closure cannot be serialized in a different module than its "
+           "parent context");
+
     auto &indices = closureToScopesMap[closureFunc];
     if (std::find(indices.begin(), indices.end(), scopeIdx) != indices.end())
       return;

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -1306,6 +1306,9 @@ class CapturePromotionPass : public SILModuleTransform {
   void run() override {
     SmallVector<SILFunction*, 128> Worklist;
     for (auto &F : *getModule()) {
+      if (F.wasDeserialized())
+        continue;
+
       processFunction(&F, Worklist);
     }
 

--- a/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessEnforcementSelection.cpp
@@ -13,19 +13,19 @@
 /// This pass eliminates 'unknown' access enforcement by selecting either
 /// static or dynamic enforcement.
 ///
-/// TODO: This is currently a module transform so that closures can be
-/// transformed after their parent scope is analyzed. This isn't a big problem
-/// now because AccessMarkerElimination is also a module pass that follows this
-/// pass. However, we would like to mostly eliminate module transforms. This
-/// could be done by changing the PassManager to follow CloseScopeAnalysis. A
-/// new ClosureTransform type would be pipelined just like FunctionTransform,
-/// but would have an entry point that handled a parent closure scope and all
-/// its children in one invocation. For function pipelining to be upheld, we
-/// would need to verify that BasicCalleeAnalysis never conflicts with
-/// ClosureScopeAnalysis. i.e. we could never create a caller->callee edge when
-/// the callee is passed as a function argument. Normal FunctionTransforms would
-/// then be called on each closure function and its parent scope before calling
-/// the ClosureTransform.
+/// TODO: This is currently a module transform so that it can process closures
+/// after analyzing their parent scope. This isn't a big problem now because
+/// AccessMarkerElimination is also a module pass that follows this pass, so all
+/// markers will still be present when this pass runs. However, we would like to
+/// mostly eliminate module transforms. This could be done by changing the
+/// PassManager to follow ClosureScopeAnalysis. A new ClosureTransform type
+/// would be pipelined just like FunctionTransform, but would have an entry
+/// point that handled a parent closure scope and all its children in one
+/// invocation. For function pipelining to be upheld, we would need to verify
+/// that BasicCalleeAnalysis never conflicts with ClosureScopeAnalysis. i.e. we
+/// could never create a caller->callee edge when the callee is passed as a
+/// function argument. Normal FunctionTransforms would then be called on each
+/// closure function and its parent scope before calling the ClosureTransform.
 ///
 /// FIXME: handle boxes used by copy_value when neither copy is captured.
 ///
@@ -521,6 +521,12 @@ struct SourceAccess {
 };
 
 /// The pass.
+///
+/// This can't be a SILFunctionTransform because DynamicCaptures need to be
+/// recorded while analyzing a closure's parent scopes before processing the
+/// closures.
+///
+/// TODO: Make this a "ClosureTransform". See the file-level comments above.
 class AccessEnforcementSelection : public SILModuleTransform {
   // Reference back to the known dynamically enforced non-escaping closure
   // arguments in this module. Parent scopes are processed before the closures
@@ -554,6 +560,12 @@ void AccessEnforcementSelection::run() {
 }
 
 void AccessEnforcementSelection::processFunction(SILFunction *F) {
+  if (F->wasDeserialized()) {
+    DEBUG(llvm::dbgs() << "Skipping Access Enforcement Selection of "
+                          "deserialized "
+                       << F->getName() << "\n");
+    return;
+  }
   DEBUG(llvm::dbgs() << "Access Enforcement Selection in " << F->getName()
                      << "\n");
 #ifndef NDEBUG

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -614,7 +614,11 @@ class MandatoryInlining : public SILModuleTransform {
     ImmutableFunctionSet::Factory SetFactory;
 
     for (auto &F : *M) {
-      
+      // Don't inline into deserialized functions. They have already inlined all
+      // mandatory callees.
+      if (F.wasDeserialized())
+        continue;
+
       // Don't inline into thunks, even transparent callees.
       if (F.isThunk())
         continue;

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -298,6 +298,10 @@ void SILPassManager::runPassOnFunction(unsigned TransIdx, SILFunction *F) {
 
   assert(analysesUnlocked() && "Expected all analyses to be unlocked!");
 
+  // Serialization requires all diagnostic passes. Don't rerun them.
+  if (isMandatoryPipeline && F->wasDeserialized())
+    return;
+
   auto *SFT = cast<SILFunctionTransform>(Transformations[TransIdx]);
   SFT->injectPassManager(this);
   SFT->injectFunction(F);

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -823,6 +823,7 @@ specializePartialApply(PartialApplyInst *PartialApply,
     PromotedParamCloner Cloner(F, Serialized, PromotedArgIndices, ClonedName);
     Cloner.populateCloned();
     ClonedFn = Cloner.getCloned();
+    pass.T->notifyAddFunction(ClonedFn, F);
   }
 
   // Now create the new partial_apply using the cloned function.

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -31,20 +31,114 @@ using namespace swift;
 STATISTIC(NumStackPromoted, "Number of alloc_box's promoted to the stack");
 
 //===----------------------------------------------------------------------===//
-//                           alloc_box Promotion
+//                 SIL Utilities for alloc_box Promotion
 //===----------------------------------------------------------------------===//
 
-/// This is a list we use to store a set of indices. We create the set by
-/// sorting, uniquing at the appropriate time. The reason why it makes sense to
-/// just use a sorted vector with std::count is because generally functions do
-/// not have that many arguments and even fewer promoted arguments.
-using ArgIndexList = llvm::SmallVector<unsigned, 8>;
+static SILValue stripOffCopyValue(SILValue V) {
+  while (auto *CVI = dyn_cast<CopyValueInst>(V)) {
+    V = CVI->getOperand();
+  }
+  return V;
+}
 
-static SILInstruction* findUnexpectedBoxUse(SILValue Box,
-                                            bool examinePartialApply,
-                                            bool inAppliedFunction,
-                                            llvm::SmallVectorImpl<Operand*> &);
-static bool partialApplyArgumentEscapes(Operand *O);
+/// \brief Returns True if the operand or one of its users is captured.
+static bool useCaptured(Operand *UI) {
+  auto *User = UI->getUser();
+
+  // These instructions do not cause the address to escape.
+  if (isa<DebugValueInst>(User) || isa<DebugValueAddrInst>(User)
+      || isa<StrongReleaseInst>(User) || isa<StrongRetainInst>(User)
+      || isa<DestroyValueInst>(User))
+    return false;
+
+  if (auto *Store = dyn_cast<StoreInst>(User)) {
+    if (Store->getDest() == UI->get())
+      return false;
+  } else if (auto *Assign = dyn_cast<AssignInst>(User)) {
+    if (Assign->getDest() == UI->get())
+      return false;
+  }
+
+  return true;
+}
+
+/// Given an apply or partial_apply, return the direct callee or
+/// nullptr if this is not a direct call.
+static FunctionRefInst *getDirectCallee(SILInstruction *Call) {
+  if (auto *Apply = dyn_cast<ApplyInst>(Call))
+    return dyn_cast<FunctionRefInst>(Apply->getCallee());
+  else
+    return dyn_cast<FunctionRefInst>(cast<PartialApplyInst>(Call)->getCallee());
+}
+
+/// Given an operand of a direct apply or partial_apply of a function,
+/// return the argument index of the parameter used in the body of the function
+/// to represent this operand.
+static size_t getArgIndexForOperand(Operand *O) {
+  assert(isa<ApplyInst>(O->getUser())
+         || isa<PartialApplyInst>(O->getUser())
+                && "Expected apply or partial_apply!");
+
+  auto OperandIndex = O->getOperandNumber();
+  assert(OperandIndex != 0 && "Operand cannot be the applied function!");
+
+  // The applied function is the first operand.
+  auto ArgIndex = OperandIndex - ApplyInst::getArgumentOperandNumber();
+
+  if (auto *Apply = dyn_cast<ApplyInst>(O->getUser())) {
+    assert(Apply->getSubstCalleeConv().getNumSILArguments()
+               == Apply->getArguments().size()
+           && "Expected all arguments to be supplied!");
+    (void)Apply;
+  } else {
+    auto *PartialApply = cast<PartialApplyInst>(O->getUser());
+    auto fnConv = PartialApply->getSubstCalleeConv();
+    auto ArgCount = PartialApply->getArguments().size();
+    assert(ArgCount <= fnConv.getNumParameters());
+    ArgIndex += (fnConv.getNumSILArguments() - ArgCount);
+  }
+
+  return ArgIndex;
+}
+
+/// Given an operand of a direct apply or partial_apply of a function,
+/// return the parameter used in the body of the function to represent
+/// this operand.
+static SILArgument *getParameterForOperand(SILFunction *F, Operand *O) {
+  assert(F && !F->empty() && "Expected a function with a body!");
+
+  auto &Entry = F->front();
+  size_t ArgIndex = getArgIndexForOperand(O);
+  assert(ArgIndex >= F->getConventions().getSILArgIndexOfFirstParam());
+
+  return Entry.getArgument(ArgIndex);
+}
+
+/// Return a pointer to the SILFunction called by Call if we can
+/// determine which function that is, and we have a body for that
+/// function. Otherwise return nullptr.
+static SILFunction *getFunctionBody(SILInstruction *Call) {
+  if (auto *FRI = getDirectCallee(Call))
+    if (auto *F = FRI->getReferencedFunction())
+      if (!F->empty())
+        return F;
+
+  return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
+//                 Liveness for alloc_box Promotion
+//===----------------------------------------------------------------------===//
+
+// Is any successor of BB in the LiveIn set?
+static bool successorHasLiveIn(SILBasicBlock *BB,
+                               llvm::SmallPtrSetImpl<SILBasicBlock *> &LiveIn) {
+  for (auto &Succ : BB->getSuccessors())
+    if (LiveIn.count(Succ))
+      return true;
+
+  return false;
+}
 
 // Propagate liveness backwards from an initial set of blocks in our
 // LiveIn set.
@@ -69,23 +163,6 @@ static void propagateLiveness(llvm::SmallPtrSetImpl<SILBasicBlock*> &LiveIn,
     for (auto Pred : BB->getPredecessorBlocks())
       Worklist.push_back(Pred);
   }
-}
-
-// Is any successor of BB in the LiveIn set?
-static bool successorHasLiveIn(SILBasicBlock *BB,
-                               llvm::SmallPtrSetImpl<SILBasicBlock*> &LiveIn) {
-  for (auto &Succ : BB->getSuccessors())
-    if (LiveIn.count(Succ))
-      return true;
-
-  return false;
-}
-
-static SILValue stripOffCopyValue(SILValue V) {
-  while (auto *CVI = dyn_cast<CopyValueInst>(V)) {
-    V = CVI->getOperand();
-  }
-  return V;
 }
 
 // Walk backwards in BB looking for strong_release, destroy_value, or
@@ -177,25 +254,30 @@ getFinalReleases(SILValue Box,
   return true;
 }
 
-/// \brief Returns True if the operand or one of its users is captured.
-static bool useCaptured(Operand *UI) {
-  auto *User = UI->getUser();
+//===----------------------------------------------------------------------===//
+//                      alloc_box Escape Analysis
+//===----------------------------------------------------------------------===//
 
-  // These instructions do not cause the address to escape.
-  if (isa<DebugValueInst>(User) || isa<DebugValueAddrInst>(User) ||
-      isa<StrongReleaseInst>(User) || isa<StrongRetainInst>(User) ||
-      isa<DestroyValueInst>(User))
-    return false;
+/// This is a list we use to store a set of indices. We create the set by
+/// sorting, uniquing at the appropriate time. The reason why it makes sense to
+/// just use a sorted vector with std::count is because generally functions do
+/// not have that many arguments and even fewer promoted arguments.
+using ArgIndexList = llvm::SmallVector<unsigned, 8>;
 
-  if (auto *Store = dyn_cast<StoreInst>(User)) {
-    if (Store->getDest() == UI->get())
-      return false;
-  } else if (auto *Assign = dyn_cast<AssignInst>(User)) {
-    if (Assign->getDest() == UI->get())
-      return false;
-  }
+static bool partialApplyEscapes(SILValue V, bool examineApply);
 
-  return true;
+/// Could this operand to an apply escape that function by being
+/// stored or returned?
+static bool partialApplyArgumentEscapes(Operand *O) {
+  SILFunction *F = getFunctionBody(O->getUser());
+  // If we cannot examine the function body, assume the worst.
+  if (!F)
+    return true;
+
+  // Check the uses of the operand, but do not recurse down into other
+  // apply instructions.
+  auto Param = SILValue(getParameterForOperand(F, O));
+  return partialApplyEscapes(Param, /* examineApply = */ false);
 }
 
 static bool partialApplyEscapes(SILValue V, bool examineApply) {
@@ -255,83 +337,10 @@ static bool partialApplyEscapes(SILValue V, bool examineApply) {
   return false;
 }
 
-
-/// Given an apply or partial_apply, return the direct callee or
-/// nullptr if this is not a direct call.
-static FunctionRefInst *getDirectCallee(SILInstruction *Call) {
-  if (auto *Apply = dyn_cast<ApplyInst>(Call))
-    return dyn_cast<FunctionRefInst>(Apply->getCallee());
-  else
-    return dyn_cast<FunctionRefInst>(cast<PartialApplyInst>(Call)->getCallee());
-}
-
-/// Given an operand of a direct apply or partial_apply of a function,
-/// return the argument index of the parameter used in the body of the function
-/// to represent this operand.
-static size_t getArgIndexForOperand(Operand *O) {
-  assert(isa<ApplyInst>(O->getUser()) || isa<PartialApplyInst>(O->getUser()) &&
-         "Expected apply or partial_apply!");
-
-  auto OperandIndex = O->getOperandNumber();
-  assert(OperandIndex != 0 && "Operand cannot be the applied function!");
-
-  // The applied function is the first operand.
-  auto ArgIndex = OperandIndex - ApplyInst::getArgumentOperandNumber();
-
-  if (auto *Apply = dyn_cast<ApplyInst>(O->getUser())) {
-    assert(Apply->getSubstCalleeConv().getNumSILArguments()
-               == Apply->getArguments().size()
-           && "Expected all arguments to be supplied!");
-    (void) Apply;
-  } else {
-    auto *PartialApply = cast<PartialApplyInst>(O->getUser());
-    auto fnConv = PartialApply->getSubstCalleeConv();
-    auto ArgCount = PartialApply->getArguments().size();
-    assert(ArgCount <= fnConv.getNumParameters());
-    ArgIndex += (fnConv.getNumSILArguments() - ArgCount);
-  }
-
-  return ArgIndex;
-}
-
-/// Given an operand of a direct apply or partial_apply of a function,
-/// return the parameter used in the body of the function to represent
-/// this operand.
-static SILArgument *getParameterForOperand(SILFunction *F, Operand *O) {
-  assert(F && !F->empty() && "Expected a function with a body!");
-
-  auto &Entry = F->front();
-  size_t ArgIndex = getArgIndexForOperand(O);
-  assert(ArgIndex >= F->getConventions().getSILArgIndexOfFirstParam());
-
-  return Entry.getArgument(ArgIndex);
-}
-
-/// Return a pointer to the SILFunction called by Call if we can
-/// determine which function that is, and we have a body for that
-/// function. Otherwise return nullptr.
-static SILFunction *getFunctionBody(SILInstruction *Call) {
-  if (auto *FRI = getDirectCallee(Call))
-    if (auto *F = FRI->getReferencedFunction())
-      if (!F->empty())
-        return F;
-
-  return nullptr;
-}
-
-/// Could this operand to an apply escape that function by being
-/// stored or returned?
-static bool partialApplyArgumentEscapes(Operand *O) {
-  SILFunction *F = getFunctionBody(O->getUser());
-  // If we cannot examine the function body, assume the worst.
-  if (!F)
-    return true;
-
-  // Check the uses of the operand, but do not recurse down into other
-  // apply instructions.
-  auto Param = SILValue(getParameterForOperand(F, O));
-  return partialApplyEscapes(Param, /* examineApply = */ false);
-}
+static SILInstruction *findUnexpectedBoxUse(SILValue Box,
+                                            bool examinePartialApply,
+                                            bool inAppliedFunction,
+                                            llvm::SmallVectorImpl<Operand *> &);
 
 /// checkPartialApplyBody - Check the body of a partial apply to see
 /// if the box pointer argument passed to it has uses that would
@@ -356,10 +365,10 @@ static bool checkPartialApplyBody(Operand *O) {
 /// consideration for promotion to a stack element. Optionally examine the body
 /// of partial_apply to see if there is an unexpected use inside.  Return the
 /// instruction with the unexpected use if we find one.
-static SILInstruction* findUnexpectedBoxUse(SILValue Box,
-                                            bool examinePartialApply,
-                                            bool inAppliedFunction,
-                            llvm::SmallVectorImpl<Operand *> &PromotedOperands) {
+static SILInstruction *
+findUnexpectedBoxUse(SILValue Box, bool examinePartialApply,
+                     bool inAppliedFunction,
+                     llvm::SmallVectorImpl<Operand *> &PromotedOperands) {
   assert((Box->getType().is<SILBoxType>()
           || Box->getType()
                  == SILType::getNativeObjectType(Box->getType().getASTContext()))
@@ -430,6 +439,23 @@ static bool canPromoteAllocBox(AllocBoxInst *ABI,
   // Okay, it looks like this value doesn't escape.
   return true;
 }
+
+//===----------------------------------------------------------------------===//
+//                           alloc_box Promotion
+//===----------------------------------------------------------------------===//
+
+namespace {
+// Pass context and per-function analysis results.
+struct AllocBoxToStackState {
+  SILFunctionTransform *T;
+  bool CFGChanged = false;
+
+  llvm::SmallVector<AllocBoxInst *, 8> Promotable;
+  llvm::SmallVector<Operand *, 8> PromotedOperands;
+
+  AllocBoxToStackState(SILFunctionTransform *T) : T(T) {}
+};
+} // anonymous namespace
 
 static void replaceProjectBoxUsers(SILValue HeapBox, SILValue StackBox) {
   llvm::SmallVector<Operand *, 8> Worklist(HeapBox->use_begin(),
@@ -570,7 +596,8 @@ private:
 };
 } // end anonymous namespace
 
-PromotedParamCloner::PromotedParamCloner(SILFunction *Orig, IsSerialized_t Serialized,
+PromotedParamCloner::PromotedParamCloner(SILFunction *Orig,
+                                         IsSerialized_t Serialized,
                                          ArgIndexList &PromotedArgIndices,
                                          llvm::StringRef ClonedName)
     : SILClonerWithScopes<PromotedParamCloner>(
@@ -772,7 +799,8 @@ void PromotedParamCloner::visitProjectBoxInst(ProjectBoxInst *Inst) {
 /// references.
 static PartialApplyInst *
 specializePartialApply(PartialApplyInst *PartialApply,
-                       ArgIndexList &PromotedArgIndices, bool &CFGChanged) {
+                       ArgIndexList &PromotedArgIndices,
+                       AllocBoxToStackState &pass) {
   auto *FRI = cast<FunctionRefInst>(PartialApply->getCallee());
   assert(FRI && "Expected a direct partial_apply!");
   auto *F = FRI->getReferencedFunction();
@@ -822,8 +850,8 @@ specializePartialApply(PartialApplyInst *PartialApply,
 
     if (PAFrontier.empty()) {
       ValueLifetimeAnalysis VLA(PartialApply);
-      CFGChanged |= !VLA.computeFrontier(PAFrontier,
-                                      ValueLifetimeAnalysis::AllowToModifyCFG);
+      pass.CFGChanged |= !VLA.computeFrontier(
+          PAFrontier, ValueLifetimeAnalysis::AllowToModifyCFG);
       assert(!PAFrontier.empty() && "partial_apply must have at least one use "
                                     "to release the returned function");
     }
@@ -847,15 +875,13 @@ specializePartialApply(PartialApplyInst *PartialApply,
       PartialApply->getType().getAs<SILFunctionType>()->getCalleeConvention());
 }
 
-static void
-rewritePartialApplies(llvm::SmallVectorImpl<Operand *> &PromotedOperands,
-                      bool &CFGChanged) {
+static void rewritePartialApplies(AllocBoxToStackState &pass) {
   llvm::DenseMap<PartialApplyInst *, ArgIndexList> IndexMap;
   ArgIndexList Indices;
 
   // Build a map from partial_apply to the indices of the operands
   // that will be promoted in our rewritten version.
-  for (auto *O : PromotedOperands) {
+  for (auto *O : pass.PromotedOperands) {
     auto ArgIndexNumber = getArgIndexForOperand(O);
 
     Indices.clear();
@@ -881,8 +907,8 @@ rewritePartialApplies(llvm::SmallVectorImpl<Operand *> &PromotedOperands,
     std::sort(Indices.begin(), Indices.end());
     Indices.erase(std::unique(Indices.begin(), Indices.end()), Indices.end());
 
-    auto *Replacement = specializePartialApply(PartialApply, Indices,
-                                               CFGChanged);
+    PartialApplyInst *Replacement =
+        specializePartialApply(PartialApply, Indices, pass);
     PartialApply->replaceAllUsesWith(Replacement);
 
     auto *FRI = cast<FunctionRefInst>(PartialApply->getCallee());
@@ -894,17 +920,16 @@ rewritePartialApplies(llvm::SmallVectorImpl<Operand *> &PromotedOperands,
   }
 }
 
-static unsigned
-rewritePromotedBoxes(llvm::SmallVectorImpl<AllocBoxInst *> &Promoted,
-                     llvm::SmallVectorImpl<Operand *> &PromotedOperands,
-                     bool &CFGChanged) {
+/// Clone closure bodies and rewrite partial applies. Returns the number of
+/// alloc_box allocations promoted.
+static unsigned rewritePromotedBoxes(AllocBoxToStackState &pass) {
   // First we'll rewrite any partial applies that we can to remove the
   // box container pointer from the operands.
-  rewritePartialApplies(PromotedOperands, CFGChanged);
+  rewritePartialApplies(pass);
 
   unsigned Count = 0;
-  auto rend = Promoted.rend();
-  for (auto I = Promoted.rbegin(); I != rend; ++I) {
+  auto rend = pass.Promotable.rend();
+  for (auto I = pass.Promotable.rbegin(); I != rend; ++I) {
     auto *ABI = *I;
     if (rewriteAllocBoxAsAllocStack(ABI)) {
       ++Count;
@@ -918,33 +943,29 @@ namespace {
 class AllocBoxToStack : public SILFunctionTransform {
   /// The entry point to the transformation.
   void run() override {
-    llvm::SmallVector<AllocBoxInst *, 8> Promotable;
-    llvm::SmallVector<Operand *, 8> PromotedOperands;
-
+    AllocBoxToStackState pass(this);
     for (auto &BB : *getFunction()) {
       for (auto &I : BB)
         if (auto *ABI = dyn_cast<AllocBoxInst>(&I))
-          if (canPromoteAllocBox(ABI, PromotedOperands))
-            Promotable.push_back(ABI);
+          if (canPromoteAllocBox(ABI, pass.PromotedOperands))
+            pass.Promotable.push_back(ABI);
     }
 
-    if (!Promotable.empty()) {
-      bool CFGChanged = false;
-      auto Count = rewritePromotedBoxes(Promotable, PromotedOperands,
-                                        CFGChanged);
+    if (!pass.Promotable.empty()) {
+      auto Count = rewritePromotedBoxes(pass);
       NumStackPromoted += Count;
       if (Count) {
         StackNesting SN;
         if (SN.correctStackNesting(getFunction()) == StackNesting::Changes::CFG)
-          CFGChanged = true;
+          pass.CFGChanged = true;
       }
-      
-      invalidateAnalysis(CFGChanged ?
-                         SILAnalysis::InvalidationKind::FunctionBody :
-                         SILAnalysis::InvalidationKind::CallsAndInstructions);
+
+      invalidateAnalysis(
+          pass.CFGChanged
+              ? SILAnalysis::InvalidationKind::FunctionBody
+              : SILAnalysis::InvalidationKind::CallsAndInstructions);
     }
   }
-
 };
 } // end anonymous namespace
 

--- a/lib/SILOptimizer/Transforms/MarkUninitializedFixup.cpp
+++ b/lib/SILOptimizer/Transforms/MarkUninitializedFixup.cpp
@@ -72,70 +72,65 @@ getInitialProjectBox(MarkUninitializedInst *MUI,
 
 namespace {
 
-struct MarkUninitializedFixup : SILModuleTransform {
+struct MarkUninitializedFixup : SILFunctionTransform {
   void run() override {
     bool MadeChange = false;
+    for (auto &BB : *getFunction()) {
+      for (auto II = BB.begin(), IE = BB.end(); II != IE;) {
+        // Grab our given instruction and advance the iterator. This is
+        // important since we may be destroying the given instruction.
+        auto *MUI = dyn_cast<MarkUninitializedInst>(&*II);
+        ++II;
 
-    for (auto &F : *getModule()) {
-      for (auto &BB : F) {
-        for (auto II = BB.begin(), IE = BB.end(); II != IE;) {
-          // Grab our given instruction and advance the iterator. This is
-          // important since we may be destroying the given instruction.
-          auto *MUI = dyn_cast<MarkUninitializedInst>(&*II);
-          ++II;
+        // If we do not have a mark_uninitialized or we have a
+        // mark_uninitialized of an alloc_box, continue. These are not
+        // interesting to us.
+        if (!MUI)
+          continue;
 
-          // If we do not have a mark_uninitialized or we have a
-          // mark_uninitialized of an alloc_box, continue. These are not
-          // interesting to us.
-          if (!MUI)
-            continue;
+        auto *Box = dyn_cast<AllocBoxInst>(MUI->getOperand());
+        if (!Box)
+          continue;
 
-          auto *Box = dyn_cast<AllocBoxInst>(MUI->getOperand());
-          if (!Box)
-            continue;
-
-          // We expect there to be in most cases exactly one project_box. That
-          // being said, it is not impossible for there to be multiple. In such
-          // a case, we assume that the correct project_box is the one that is
-          // nearest to the mark_uninitialized in the same block. This preserves
-          // the existing behavior.
-          llvm::TinyPtrVector<ProjectBoxInst *> Projections;
-          for (auto *Op : MUI->getUses()) {
-            if (auto *PBI = dyn_cast<ProjectBoxInst>(Op->getUser())) {
-              Projections.push_back(PBI);
-            }
+        // We expect there to be in most cases exactly one project_box. That
+        // being said, it is not impossible for there to be multiple. In such
+        // a case, we assume that the correct project_box is the one that is
+        // nearest to the mark_uninitialized in the same block. This preserves
+        // the existing behavior.
+        llvm::TinyPtrVector<ProjectBoxInst *> Projections;
+        for (auto *Op : MUI->getUses()) {
+          if (auto *PBI = dyn_cast<ProjectBoxInst>(Op->getUser())) {
+            Projections.push_back(PBI);
           }
-          assert(!Projections.empty() && "SILGen should never emit a "
-                                         "mark_uninitialized by itself");
-
-          // First replace all uses of the mark_uninitialized with the box.
-          MUI->replaceAllUsesWith(Box);
-
-          // That means now our project box now has the alloc_box as its
-          // operand. Grab that project_box.
-          auto *PBI = getInitialProjectBox(MUI, Projections);
-
-          // Then create the new mark_uninitialized and force all uses of the
-          // project_box to go through the new mark_uninitialized.
-          SILBuilder B(std::next(PBI->getIterator()));
-          SILValue Undef = SILUndef::get(PBI->getType(), PBI->getModule());
-          auto *NewMUI = B.createMarkUninitialized(PBI->getLoc(), Undef,
-                                                   MUI->getKind());
-          PBI->replaceAllUsesWith(NewMUI);
-          NewMUI->setOperand(PBI);
-
-          // Finally, remove the old mark_uninitialized.
-          MUI->eraseFromParent();
-          MadeChange = true;
         }
-      }
+        assert(!Projections.empty()
+               && "SILGen should never emit a "
+                  "mark_uninitialized by itself");
 
-      if (MadeChange) {
-        auto InvalidKind =
-            SILAnalysis::InvalidationKind::BranchesAndInstructions;
-        invalidateAnalysis(&F, InvalidKind);
+        // First replace all uses of the mark_uninitialized with the box.
+        MUI->replaceAllUsesWith(Box);
+
+        // That means now our project box now has the alloc_box as its
+        // operand. Grab that project_box.
+        auto *PBI = getInitialProjectBox(MUI, Projections);
+
+        // Then create the new mark_uninitialized and force all uses of the
+        // project_box to go through the new mark_uninitialized.
+        SILBuilder B(std::next(PBI->getIterator()));
+        SILValue Undef = SILUndef::get(PBI->getType(), PBI->getModule());
+        auto *NewMUI =
+            B.createMarkUninitialized(PBI->getLoc(), Undef, MUI->getKind());
+        PBI->replaceAllUsesWith(NewMUI);
+        NewMUI->setOperand(PBI);
+
+        // Finally, remove the old mark_uninitialized.
+        MUI->eraseFromParent();
+        MadeChange = true;
       }
     }
+    if (MadeChange)
+      invalidateAnalysis(
+          SILAnalysis::InvalidationKind::BranchesAndInstructions);
   }
 };
 

--- a/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
@@ -297,6 +297,9 @@ namespace {
 struct OwnershipModelEliminator : SILModuleTransform {
   void run() override {
     for (auto &F : *getModule()) {
+      if (F.wasDeserialized())
+        continue;
+
       // Set F to have unqualified ownership.
       F.setUnqualifiedOwnership();
 

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -507,9 +507,10 @@ SILFunction *SILDeserializer::readSILFunction(DeclID FID,
     if (Callback) Callback->didDeserialize(MF->getAssociatedModule(), fn);
   }
   // Mark this function as deserialized. This avoids rerunning diagnostic
-  // passes. Certain passes in the madatory pipeline may expect not to rerun
+  // passes. Certain passes in the madatory pipeline may not work as expected
   // after arbitrary optimization and lowering.
-  fn->setWasDeserialized();
+  if (!MF->IsSIB)
+    fn->setWasDeserialized();
 
   assert(fn->empty() &&
          "SILFunction to be deserialized starts being empty.");

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -506,6 +506,10 @@ SILFunction *SILDeserializer::readSILFunction(DeclID FID,
 
     if (Callback) Callback->didDeserialize(MF->getAssociatedModule(), fn);
   }
+  // Mark this function as deserialized. This avoids rerunning diagnostic
+  // passes. Certain passes in the madatory pipeline may expect not to rerun
+  // after arbitrary optimization and lowering.
+  fn->setWasDeserialized();
 
   assert(fn->empty() &&
          "SILFunction to be deserialized starts being empty.");

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1115,6 +1115,7 @@ ModuleFile::ModuleFile(
       Name = info.name;
       TargetTriple = info.targetTriple;
       CompatibilityVersion = info.compatibilityVersion;
+      IsSIB = extInfo->isSIB();
 
       hasValidControlBlock = true;
       break;

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -212,7 +212,7 @@ void removeUnwantedFunctions(SILModule *M, ArrayRef<std::string> MangledNames,
   // After running this pass all of the functions we will remove
   // should consist only of one basic block terminated by
   // UnreachableInst.
-  performSILDiagnoseUnreachable(M, nullptr);
+  performSILDiagnoseUnreachable(M);
 
   // Now mark all of these functions as public and remove their bodies.
   for (auto &F : DeadFunctions) {


### PR DESCRIPTION
This provides basic control over the compilation pipeline that we
typically expect when reasoning about the pass order. It obviously
saves app compile time. It's not uncommon for early mandatory passes
to assume that they won't be rerun after arbitrary optimization and
lowering. Ideally, this shouldn't be required for correctness, but for
the time being it is required at least for exclusivity
diagnostics. It's also impossible to verify access markers without
this feature.
