### PR TITLE
[build-script] Factor out and reuse the lldb smoketest logic

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -280,6 +280,20 @@ build-subdir=Ninja-ReleaseAssert+stdlib-RelWithDebInfo+sil-ownership
 enable-sil-ownership
 dash-dash
 
+# This is a mixin preset which builds and smoke-tests lldb.
+[preset: lldb-smoketest,tools=RA]
+# Build LLDB
+lldb
+
+dash-dash
+
+# Use the system debugserver to run the lldb swift tests
+lldb-no-debugserver
+lldb-use-system-debugserver
+lldb-build-type=Release
+lldb-test-swift-only
+lldb-assertions
+
 #===------------------------------------------------------------------------===#
 # Incremental buildbots for Darwin OSes
 #===------------------------------------------------------------------------===#
@@ -500,7 +514,9 @@ swift-stdlib-build-type=RelWithDebInfo
 
 
 [preset: buildbot_incremental,tools=RA,stdlib=RD,smoketest=macosx]
-mixin-preset=buildbot_incremental_base
+mixin-preset=
+    buildbot_incremental_base
+    lldb-smoketest,tools=RA
 build-subdir=buildbot_incremental
 
 # We build release+asserts.
@@ -515,9 +531,6 @@ llvm-targets-to-build=X86
 
 # Set the vendor to apple
 compiler-vendor=apple
-
-# Build LLDB
-lldb
 
 dash-dash
 
@@ -547,13 +560,6 @@ skip-test-watchos
 stdlib-deployment-targets=macosx-x86_64
 swift-primary-variant-sdk=OSX
 swift-primary-variant-arch=x86_64
-
-# Use the system debugserver to run the lldb swift tests
-lldb-no-debugserver
-lldb-use-system-debugserver
-lldb-build-type=Release
-lldb-test-swift-only
-lldb-assertions
 
 # Don't build the benchmarks
 skip-build-benchmarks
@@ -1127,7 +1133,9 @@ build-swift-static-sdk-overlay
 #===------------------------------------------------------------------------===#
 
 [preset: buildbot_all_platforms,tools=RA,stdlib=RA]
-mixin-preset=buildbot_incremental_base_all_platforms
+mixin-preset=
+    buildbot_incremental_base_all_platforms
+    lldb-smoketest,tools=RA
 
 build-subdir=buildbot_incremental
 


### PR DESCRIPTION
This defines the lldb-smoketest,tools=RA preset which runs lldb smoke tests. It also mixes in the preset for regular/smoky PR testing.