### PR TITLE
[AST] Prefer 'synthesized' conformances to 'implied' ones consistently.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Swift 5.0
 
 	Runtime query of conditional conformances is now implemented. Therefore,
 	a dynamic cast such as `value as? P`, where the dynamic type of `value`
-	conditional conforms to `P`, will succeed when the conditional
+	conditionally conforms to `P`, will succeed when the conditional
 	requirements are met.
 
 Swift 4.1

--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -120,8 +120,8 @@ enum class LocalDeclContextKind : uint8_t {
 ///
 /// The enumerators are ordered in terms of decreasing preference:
 /// an inherited conformance is best, followed by explicit
-/// conformances, then implied conformances. Earlier conformance
-/// kinds supersede later conformance kinds, possibly with a
+/// conformances, then synthesized and implied conformances. Earlier
+/// conformance kinds supersede later conformance kinds, possibly with a
 /// diagnostic (e.g., if an inherited conformance supersedes an
 /// explicit conformance).
 enum class ConformanceEntryKind : unsigned {
@@ -131,11 +131,11 @@ enum class ConformanceEntryKind : unsigned {
   /// Explicitly specified.
   Explicit,
 
-  /// Implied by an explicitly-specified conformance.
-  Implied,
-
   /// Implicitly synthesized.
   Synthesized,
+
+  /// Implied by an explicitly-specified conformance.
+  Implied,
 };
 
 /// Describes the kind of conformance lookup desired.

--- a/test/multifile/Inputs/protocol-conformance-sr6839-other.swift
+++ b/test/multifile/Inputs/protocol-conformance-sr6839-other.swift
@@ -1,0 +1,4 @@
+class EnumValueConstructor<EnumType : EnumValueType> where EnumType.RawValue : Hashable {}
+class _PositionRelation_GeneratedWrapperConstructor : EnumValueConstructor<_PositionRelation> {}
+extension _PositionRelation : EnumValueType {}
+protocol EnumValueType : RawRepresentable {}

--- a/test/multifile/protocol-conformance-sr6839.swift
+++ b/test/multifile/protocol-conformance-sr6839.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -emit-sil -module-name main -primary-file %s %S/Inputs/protocol-conformance-sr6839-other.swift | %FileCheck -check-prefix CHECK-FIRST %s
+// RUN: %target-swift-frontend -emit-sil -module-name main %s -primary-file %S/Inputs/protocol-conformance-sr6839-other.swift | %FileCheck -check-prefix CHECK-SECOND %s
+
+// We need to consistently pick where the witness table for _PositionRelation :
+// RawRepresentable goes.
+// CHECK-FIRST: sil_witness_table hidden _PositionRelation: RawRepresentable
+// CHECK-SECOND-NOT: sil_witness_table hidden _PositionRelation: RawRepresentable
+enum _PositionRelation: Int {
+  case before = 0
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
When determining which declaration context should own a particular
protocol conformance that was not explicitly spelled out, prefer
"synthesized" contexts (i.e., which is always the nominal type itself)
for automatically-generated conformances (such as a raw-valued enum's
conformance to RawRepresentable) to conformances that are "implied" by
conformance to a more-refined protocol. Previously, we biased the
other way---but because conformances due to more-refined protocols can
be discovered later, we could get into a problem where two files
disagreed on which context would own the conformance---and neither
would emit the corresponding witness table.

Biasing toward "synthesized" contexts, which are always trivially
discoverable from the nominal type declaration itself, eliminates the
issue.

Fixes SR-6839 / rdar://problem/36911943.