### PR TITLE
[stdlib/Sema] Minor improvements to synthesized hashValue

### DIFF
--- a/stdlib/public/core/DoubleWidth.swift.gyb
+++ b/stdlib/public/core/DoubleWidth.swift.gyb
@@ -154,7 +154,6 @@ extension DoubleWidth : Hashable {
     var result = 0
     result = _combineHashValues(result, _storage.high.hashValue)
     result = _combineHashValues(result, _storage.low.hashValue)
-    result = _mixInt(result)
     return result
   }
 }

--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -203,7 +203,13 @@ func _squeezeHashValue(_ hashValue: Int, _ upperBound: Int) -> Int {
 @_transparent
 public // @testable
 func _combineHashValues(_ firstValue: Int, _ secondValue: Int) -> Int {
-  let magic = 0x9e3779b9 as UInt // Based on the golden ratio.
+  // Use a magic number based on the golden ratio
+  // (0x1.9e3779b97f4a7c15f39cc0605cedc8341082276bf3a27251f86c6a11d0c18e95p0).
+#if arch(i386) || arch(arm)
+  let magic = 0x9e3779b9 as UInt
+#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
+  let magic = 0x9e3779b97f4a7c15 as UInt
+#endif
   var x = UInt(bitPattern: firstValue)
   x ^= UInt(bitPattern: secondValue) &+ magic &+ (x &<< 6) &+ (x &>> 2)
   return Int(bitPattern: x)


### PR DESCRIPTION
This PR makes two minor improvements to the synthesized implementation of `hashValue`.

* As mentioned in #13056 and explained in #14247, the extraneous final `_mixInt` call is removed.
* In `_combineHashValues`, a 64-bit magic number is used instead of a 32-bit magic number on 64-bit architectures.

The manual implementation of `DoubleWidth.hashValue` is adjusted to match its synthesized counterparts.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->