### PR TITLE
Add CanType::getOptionalObjectType for staging a rename.

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -391,6 +391,7 @@ class CanType : public Type {
   static bool isObjCExistentialTypeImpl(CanType type);
   static CanType getAnyOptionalObjectTypeImpl(CanType type,
                                               OptionalTypeKind &kind);
+  static CanType getOptionalObjectTypeImpl(CanType type);
   static CanType getReferenceStorageReferentImpl(CanType type);
   static CanType getWithoutSpecifierTypeImpl(CanType type);
 
@@ -456,6 +457,10 @@ public:
   CanType getNominalParent() const; // in Types.h
   NominalTypeDecl *getAnyNominal() const;
   GenericTypeDecl *getAnyGeneric() const;
+
+  CanType getOptionalObjectType() const {
+    return getOptionalObjectTypeImpl(*this);
+  }
 
   CanType getAnyOptionalObjectType() const {
     OptionalTypeKind kind;

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -526,6 +526,13 @@ CanType CanType::getAnyOptionalObjectTypeImpl(CanType type,
   return CanType();
 }
 
+CanType CanType::getOptionalObjectTypeImpl(CanType type) {
+  if (auto boundTy = dyn_cast<BoundGenericEnumType>(type))
+    if (boundTy->getDecl()->classifyAsOptionalType() == OTK_Optional)
+      return boundTy.getGenericArgs()[0];
+  return CanType();
+}
+
 Type TypeBase::getAnyPointerElementType(PointerTypeKind &PTK) {
   auto &C = getASTContext();
   if (auto nominalTy = getAs<NominalType>()) {


### PR DESCRIPTION
In order to replace uses of getAnyOptionalObjectType() with
getOptionalObjectType(), we need to update LLDB. But in order
to do that, we need to have the version of this function for
CanType available.

So this adds this, as a temporary measure, to facilitate the LLDB
update that will unblock the compiler rename.
