### PR TITLE
[stdlib] Use Swift-native Character iteration for hasPrefix/Suffix

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -36,10 +36,8 @@ public protocol StringProtocol
   var utf16: UTF16View { get }
   var unicodeScalars: UnicodeScalarView { get }
 
-#if _runtime(_ObjC)
   func hasPrefix(_ prefix: String) -> Bool
   func hasSuffix(_ prefix: String) -> Bool
-#endif
 
   func lowercased() -> String
   func uppercased() -> String

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -84,35 +84,36 @@ extension String {
   }
 }
 
-#if _runtime(_ObjC)
-/// Determines if `theString` starts with `prefix` comparing the strings under
-/// canonical equivalence.
-@_inlineable // FIXME(sil-serialize-all)
-@_versioned // FIXME(sil-serialize-all)
-@_silgen_name("swift_stdlib_NSStringHasPrefixNFD")
-internal func _stdlib_NSStringHasPrefixNFD(
-  _ theString: AnyObject, _ prefix: AnyObject) -> Bool
 
-@_inlineable // FIXME(sil-serialize-all)
-@_versioned // FIXME(sil-serialize-all)
-@_silgen_name("swift_stdlib_NSStringHasPrefixNFDPointer")
-internal func _stdlib_NSStringHasPrefixNFDPointer(
-  _ theString: OpaquePointer, _ prefix: OpaquePointer) -> Bool
+// TODO: since this is generally useful, make public via evolution proposal.
+extension BidirectionalCollection {
+  @_inlineable
+  @_versioned
+  internal func _ends<Suffix: BidirectionalCollection>(
+    with suffix: Suffix, by areEquivalent: (Element,Element) -> Bool
+  ) -> Bool where Suffix.Element == Element {
+    var (i,j) = (self.endIndex,suffix.endIndex)
+    while i != self.startIndex, j != suffix.startIndex {
+      self.formIndex(before: &i)
+      suffix.formIndex(before: &j)
+      if !areEquivalent(self[i],suffix[j]) { return false }
+    } 
+    return j == suffix.startIndex
+  }
+}
 
-/// Determines if `theString` ends with `suffix` comparing the strings under
-/// canonical equivalence.
-@_inlineable // FIXME(sil-serialize-all)
-@_versioned // FIXME(sil-serialize-all)
-@_silgen_name("swift_stdlib_NSStringHasSuffixNFD")
-internal func _stdlib_NSStringHasSuffixNFD(
-  _ theString: AnyObject, _ suffix: AnyObject) -> Bool
-@_inlineable // FIXME(sil-serialize-all)
-@_versioned // FIXME(sil-serialize-all)
-@_silgen_name("swift_stdlib_NSStringHasSuffixNFDPointer")
-internal func _stdlib_NSStringHasSuffixNFDPointer(
-  _ theString: OpaquePointer, _ suffix: OpaquePointer) -> Bool
+extension BidirectionalCollection where Element: Equatable {
+  @_inlineable
+  @_versioned
+  internal func _ends<Suffix: BidirectionalCollection>(
+    with suffix: Suffix
+  ) -> Bool where Suffix.Element == Element {
+      return _ends(with: suffix, by: ==)
+  }
+}
 
-extension String {
+
+extension StringProtocol {
   /// Returns a Boolean value indicating whether the string begins with the
   /// specified prefix.
   ///
@@ -142,40 +143,9 @@ extension String {
   ///
   /// - Parameter prefix: A possible prefix to test against this string.
   /// - Returns: `true` if the string begins with `prefix`; otherwise, `false`.
-  @_inlineable // FIXME(sil-serialize-all)
-  public func hasPrefix(_ prefix: String) -> Bool {
-    let prefixCount = prefix._guts.count
-    if prefixCount == 0 {
-      return true
-    }
-    if _fastPath(!self._guts._isOpaque && !prefix._guts._isOpaque) {
-      let result: Bool
-      if self._guts.isASCII && prefix._guts.isASCII {
-        let selfASCII = self._guts._unmanagedASCIIView
-        let prefixASCII = prefix._guts._unmanagedASCIIView
-        if prefixASCII.count > selfASCII.count {
-          // Prefix is longer than self.
-          result = false
-        } else {
-          result = (0 as CInt) == _stdlib_memcmp(
-            selfASCII.rawStart,
-            prefixASCII.rawStart,
-            prefixASCII.count)
-        }
-      } else {
-        let lhsStr = _NSContiguousString(_unmanaged: self._guts)
-        let rhsStr = _NSContiguousString(_unmanaged: prefix._guts)
-        result = lhsStr._unsafeWithNotEscapedSelfPointerPair(rhsStr) {
-          return _stdlib_NSStringHasPrefixNFDPointer($0, $1)
-        }
-      }
-      _fixLifetime(self)
-      _fixLifetime(prefix)
-      return result
-    }
-    return _stdlib_NSStringHasPrefixNFD(
-      self._bridgeToObjectiveCImpl(),
-      prefix._bridgeToObjectiveCImpl())
+  @_inlineable
+  public func hasPrefix<Prefix: StringProtocol>(_ prefix: Prefix) -> Bool {
+    return self.starts(with: prefix)
   }
 
   /// Returns a Boolean value indicating whether the string ends with the
@@ -207,15 +177,52 @@ extension String {
   ///
   /// - Parameter suffix: A possible suffix to test against this string.
   /// - Returns: `true` if the string ends with `suffix`; otherwise, `false`.
+  @_inlineable
+  public func hasSuffix<Suffix: StringProtocol>(_ suffix: Suffix) -> Bool {
+    return self._ends(with: suffix)
+  }
+}
+
+extension String {
+  @_inlineable // FIXME(sil-serialize-all)
+  public func hasPrefix(_ prefix: String) -> Bool {
+    let prefixCount = prefix._guts.count
+    if prefixCount == 0 { return true }
+
+    if _fastPath(!self._guts._isOpaque && !prefix._guts._isOpaque) {
+      if self._guts.isASCII && prefix._guts.isASCII {
+        let result: Bool
+        let selfASCII = self._guts._unmanagedASCIIView
+        let prefixASCII = prefix._guts._unmanagedASCIIView
+        if prefixASCII.count > selfASCII.count {
+          // Prefix is longer than self.
+          result = false
+        } else {
+          result = (0 as CInt) == _stdlib_memcmp(
+            selfASCII.rawStart,
+            prefixASCII.rawStart,
+            prefixASCII.count)
+        }
+        _fixLifetime(self)
+        _fixLifetime(prefix)
+        return result
+      }
+      else {
+        
+      }
+    }
+
+    return self.starts(with: prefix)
+  }
+
   @_inlineable // FIXME(sil-serialize-all)
   public func hasSuffix(_ suffix: String) -> Bool {
     let suffixCount = suffix._guts.count
-    if suffixCount == 0 {
-      return true
-    }
+    if suffixCount == 0 { return true }
+
     if _fastPath(!self._guts._isOpaque && !suffix._guts._isOpaque) {
-      let result: Bool
       if self._guts.isASCII && suffix._guts.isASCII {
+        let result: Bool
         let selfASCII = self._guts._unmanagedASCIIView
         let suffixASCII = suffix._guts._unmanagedASCIIView
         if suffixASCII.count > self._guts.count {
@@ -227,26 +234,15 @@ extension String {
             suffixASCII.rawStart,
             suffixASCII.count)
         }
-      } else {
-        let lhsStr = _NSContiguousString(_unmanaged: self._guts)
-        let rhsStr = _NSContiguousString(_unmanaged: suffix._guts)
-        result = lhsStr._unsafeWithNotEscapedSelfPointerPair(rhsStr) {
-          return _stdlib_NSStringHasSuffixNFDPointer($0, $1)
-        }
+        _fixLifetime(self)
+        _fixLifetime(suffix)
+        return result
       }
-      _fixLifetime(self)
-      _fixLifetime(suffix)
-      return result
     }
-    return _stdlib_NSStringHasSuffixNFD(
-      self._bridgeToObjectiveCImpl(),
-      suffix._bridgeToObjectiveCImpl())
+
+    return self._ends(with: suffix)
   }
 }
-#else
-// FIXME: Implement hasPrefix and hasSuffix without objc
-// rdar://problem/18878343
-#endif
 
 // Conversions to string from other types.
 extension String {

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -525,22 +525,6 @@ extension Substring.UnicodeScalarView : RangeReplaceableCollection {
   }
 }
 
-#if _runtime(_ObjC)
-
-extension Substring {
-  @_inlineable // FIXME(sil-serialize-all)
-  public func hasPrefix(_ prefix: String) -> Bool {
-    return String(self).hasPrefix(prefix)
-  }
-
-  @_inlineable // FIXME(sil-serialize-all)
-  public func hasSuffix(_ suffix: String) -> Bool {
-    return String(self).hasSuffix(suffix)
-  }
-}
-
-#endif
-
 extension Substring : RangeReplaceableCollection {
   @_inlineable // FIXME(sil-serialize-all)
   public init<S : Sequence>(_ elements: S)

--- a/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
+++ b/stdlib/public/stubs/SwiftNativeNSXXXBase.mm.gyb
@@ -144,55 +144,6 @@ swift_stdlib_CFStringHashCString(const uint8_t *bytes, CFIndex len) {
   return Result;
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-bool swift_stdlib_NSStringHasPrefixNFD(NSString *theString,
-                                       NSString *prefix) {
-  auto Length = CFStringGetLength((__bridge CFStringRef)theString);
-  int Result = CFStringFindWithOptions(
-      (__bridge CFStringRef)theString, (__bridge CFStringRef)prefix,
-      CFRangeMake(0, Length), kCFCompareAnchored | kCFCompareNonliteral,
-      nullptr);
-  SWIFT_CC_PLUSONE_GUARD(swift_unknownRelease(theString));
-  SWIFT_CC_PLUSONE_GUARD(swift_unknownRelease(prefix));
-  return Result;
-}
-
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-bool swift_stdlib_NSStringHasPrefixNFDPointer(void *theString,
-                                              void *prefix) {
-  auto Length = CFStringGetLength((__bridge CFStringRef)theString);
-  int Result = CFStringFindWithOptions(
-      (__bridge CFStringRef)theString, (__bridge CFStringRef)prefix,
-      CFRangeMake(0, Length), kCFCompareAnchored | kCFCompareNonliteral,
-      nullptr);
-  return Result;
-}
-
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-bool
-swift_stdlib_NSStringHasSuffixNFD(NSString *SWIFT_NS_RELEASES_ARGUMENT theString,
-                                  NSString *SWIFT_NS_RELEASES_ARGUMENT suffix) {
-  auto Length = CFStringGetLength((__bridge CFStringRef)theString);
-  int Result = CFStringFindWithOptions(
-      (__bridge CFStringRef)theString, (__bridge CFStringRef)suffix,
-      CFRangeMake(0, Length),
-      kCFCompareAnchored | kCFCompareBackwards | kCFCompareNonliteral, nullptr);
-  SWIFT_CC_PLUSONE_GUARD(swift_unknownRelease(theString));
-  SWIFT_CC_PLUSONE_GUARD(swift_unknownRelease(suffix));
-  return Result;
-}
-
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
-bool swift_stdlib_NSStringHasSuffixNFDPointer(void *theString,
-                                              void *suffix) {
-  auto Length = CFStringGetLength((__bridge CFStringRef)theString);
-  int Result = CFStringFindWithOptions(
-      (__bridge CFStringRef)theString, (__bridge CFStringRef)suffix,
-      CFRangeMake(0, Length),
-      kCFCompareAnchored | kCFCompareBackwards | kCFCompareNonliteral, nullptr);
-  return Result;
-}
-
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
 void swift_stdlib_CFSetGetValues(NSSet *SWIFT_NS_RELEASES_ARGUMENT set,
                                  const void **values) {

--- a/test/stdlib/RuntimeObjC.swift
+++ b/test/stdlib/RuntimeObjC.swift
@@ -512,54 +512,6 @@ RuntimeFoundationWrappers.test("_stdlib_NSStringHashValuePointerNonASCII/NoLeak"
   expectEqual(0, nsStringCanaryCount)
 }
 
-RuntimeFoundationWrappers.test("_stdlib_NSStringHasPrefixNFDPointer/NoLeak") {
-  nsStringCanaryCount = 0
-  autoreleasepool {
-    let a = NSStringCanary()
-    let b = NSStringCanary()
-    expectEqual(2, nsStringCanaryCount)
-    let ptrA = unsafeBitCast(a, to: OpaquePointer.self)
-    let ptrB = unsafeBitCast(b, to: OpaquePointer.self)
-    _stdlib_NSStringHasPrefixNFDPointer(ptrA, ptrB)
-  }
-  expectEqual(0, nsStringCanaryCount)
-}
-
-RuntimeFoundationWrappers.test("_stdlib_NSStringHasSuffixNFDPointer/NoLeak") {
-  nsStringCanaryCount = 0
-  autoreleasepool {
-    let a = NSStringCanary()
-    let b = NSStringCanary()
-    expectEqual(2, nsStringCanaryCount)
-    let ptrA = unsafeBitCast(a, to: OpaquePointer.self)
-    let ptrB = unsafeBitCast(b, to: OpaquePointer.self)
-    _stdlib_NSStringHasSuffixNFDPointer(ptrA, ptrB)
-  }
-  expectEqual(0, nsStringCanaryCount)
-}
-
-RuntimeFoundationWrappers.test("_stdlib_NSStringHasPrefixNFD/NoLeak") {
-  nsStringCanaryCount = 0
-  autoreleasepool {
-    let a = NSStringCanary()
-    let b = NSStringCanary()
-    expectEqual(2, nsStringCanaryCount)
-    _stdlib_NSStringHasPrefixNFD(a, b)
-  }
-  expectEqual(0, nsStringCanaryCount)
-}
-
-RuntimeFoundationWrappers.test("_stdlib_NSStringHasSuffixNFD/NoLeak") {
-  nsStringCanaryCount = 0
-  autoreleasepool {
-    let a = NSStringCanary()
-    let b = NSStringCanary()
-    expectEqual(2, nsStringCanaryCount)
-    _stdlib_NSStringHasSuffixNFD(a, b)
-  }
-  expectEqual(0, nsStringCanaryCount)
-}
-
 RuntimeFoundationWrappers.test("_stdlib_NSStringLowercaseString/NoLeak") {
   nsStringCanaryCount = 0
   autoreleasepool {

--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -272,21 +272,10 @@ StringTests.test("LosslessStringConvertible") {
 let substringTests = tests.map {
   (test: ComparisonTest) -> ComparisonTest in
   switch (test.expectedUnicodeCollation, test.lhs, test.rhs) {
-  case (.eq, "\u{0}", "\u{0}"):
-    return test.replacingPredicate(.objCRuntime(
-      "https://bugs.swift.org/browse/SR-332"))
 
   case (.gt, "\r\n", "\n"):
     return test.replacingPredicate(.objCRuntime(
       "blocked on rdar://problem/19036555"))
-
-  case (.eq, "\u{0301}", "\u{0341}"):
-    return test.replacingPredicate(.objCRuntime(
-      "https://bugs.swift.org/browse/SR-243"))
-
-  case (.lt, "\u{1F1E7}", "\u{1F1E7}\u{1F1E7}"):
-    return test.replacingPredicate(.objCRuntime(
-      "https://bugs.swift.org/browse/SR-367"))
 
   default:
     return test

--- a/test/stdlib/StringCompatibility.swift
+++ b/test/stdlib/StringCompatibility.swift
@@ -116,8 +116,6 @@ extension MyString : Hashable {
   }
 }
 
-#if _runtime(_ObjC)
-
 extension MyString {
   public func hasPrefix(_ prefix: String) -> Bool {
     return self.base.hasPrefix(prefix)
@@ -127,8 +125,6 @@ extension MyString {
     return self.base.hasSuffix(suffix)
   }
 }
-
-#endif
 
 extension MyString : StringProtocol {
   typealias UTF8Index = String.UTF8Index


### PR DESCRIPTION
Should help avoid regressions with small string, plus gets rid of a CF dependency and give us these methods on Linux too. Also eliminates copy for Substring combination variants.

These are a regression specifically for two non-ASCII contiguous strings. Still further performance wins available after this lands – it could assume same-normalization and still try memcmp, falling back to the slow path for a false negative from the point of divergence.

Needs coordination with apple/swift-corelibs-foundation#1459 which removes the now-ambiguous versions for Linux.