### PR TITLE
Reword the "expression too complex" error not to blame the user.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -143,8 +143,8 @@ ERROR(cannot_pass_rvalue_mutating_getter,none,
       (Type))
 
 ERROR(expression_too_complex,none,
-      "expression was too complex to be solved in reasonable time; "
-      "consider breaking up the expression into distinct sub-expressions", ())
+      "the compiler is unable to type-check this expression in reasonable time; "
+      "try breaking up the expression into distinct sub-expressions", ())
 
 ERROR(value_type_comparison_with_nil_illegal_did_you_mean,none,
       "value of type %0 cannot be compared by reference; "

--- a/test/Misc/expression_too_complex.swift
+++ b/test/Misc/expression_too_complex.swift
@@ -1,6 +1,6 @@
 // RUN: %target-typecheck-verify-swift -solver-memory-threshold 16000 -propagate-constraints
 
-var z = 10 + 10 // expected-error{{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
+var z = 10 + 10 // expected-error{{reasonable time}}
 
 // No errors should appear below as a result of the error above.
 var x = [1, 2, 3, 4.5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18 ,19]

--- a/test/Misc/expression_too_complex_2.swift
+++ b/test/Misc/expression_too_complex_2.swift
@@ -9,7 +9,7 @@ class MyViewCell: UITableViewCell {
   required init?(coder aDecoder: NSCoder) { fatalError("no") }
   override init(style: UITableViewCellStyle, reuseIdentifier: String?) {
     super.init(style: .default, reuseIdentifier: reuseIdentifier)
-    NSLayoutConstraint.activate([ // expected-error{{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
+    NSLayoutConstraint.activate([ // expected-error{{reasonable time}}
         NSLayoutConstraint(item: View1, attribute: .top, relatedBy: .equal, toItem: label1, attribute: .top, multiplier: 1, constant: 1),
         NSLayoutConstraint(item: View1, attribute: .top, relatedBy: .equal, toItem: label2, attribute: .top, multiplier: 1, constant: 1),
         NSLayoutConstraint(item: View1, attribute: .top, relatedBy: .equal, toItem: label3, attribute: .top, multiplier: 1, constant: 1),

--- a/test/Misc/expression_too_complex_4.swift
+++ b/test/Misc/expression_too_complex_4.swift
@@ -2,5 +2,5 @@
 
 func test(_ i: Int, _ j: Int) -> Int {
   return 1 + (((i >> 1) + (i >> 2) + (i >> 3) + (i >> 4) << 1) << 1) & 0x40
-  // expected-error@-1 {{expression was too complex to be solved in reasonable time; consider breaking up the expression into distinct sub-expressions}}
+  // expected-error@-1 {{reasonable time}}
 }


### PR DESCRIPTION
It's not you, it's us. We shouldn't tell the user their code is too complex, and "solve" doesn't mean anything to them in this context. Make it clearer this is an implementation limitation.