### PR TITLE
DefiniteInitialization: Storing back to the 'self' box in a class init is OK.

### DIFF
--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1636,7 +1636,14 @@ void LifetimeChecker::handleLoadUseFailure(const DIMemoryUse &Use,
                                            bool SuperInitDone,
                                            bool FailedSelfUse) {
   SILInstruction *Inst = Use.Inst;
-  
+
+  // Stores back to the 'self' box are OK.
+  if (auto store = dyn_cast<StoreInst>(Inst)) {
+    if (store->getDest() == TheMemory.MemoryInst
+        && TheMemory.isClassInitSelf())
+      return;
+  }
+
   if (FailedSelfUse) {
     emitSelfConsumedDiagnostic(Inst);
     return;

--- a/test/SILOptimizer/definite-init-try-in-self-init-argument.swift
+++ b/test/SILOptimizer/definite-init-try-in-self-init-argument.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+class Y: X {
+  required init(_: Z) throws {
+    try super.init(Z())
+  }
+}
+class Z { init() throws {} }
+
+class X {
+  required init(_: Z) throws {}
+}


### PR DESCRIPTION
SILGen does this now to maintain ownership balance when a class initializer delegation gets interrupted, such as by an error propagation through one of the arguments to the delegatee. Fixes rdar://problem/37007554 .