### PR TITLE
[5.0] DefiniteInitialization: Storing back to the 'self' box in a class init is OK.

### DIFF
--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -1636,7 +1636,14 @@ void LifetimeChecker::handleLoadUseFailure(const DIMemoryUse &Use,
                                            bool SuperInitDone,
                                            bool FailedSelfUse) {
   SILInstruction *Inst = Use.Inst;
-  
+
+  // Stores back to the 'self' box are OK.
+  if (auto store = dyn_cast<StoreInst>(Inst)) {
+    if (store->getDest() == TheMemory.MemoryInst
+        && TheMemory.isClassInitSelf())
+      return;
+  }
+
   if (FailedSelfUse) {
     emitSelfConsumedDiagnostic(Inst);
     return;

--- a/test/SILOptimizer/definite-init-try-in-self-init-argument.swift
+++ b/test/SILOptimizer/definite-init-try-in-self-init-argument.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+class Y: X {
+  required init(_: Z) throws {
+    try super.init(Z())
+  }
+}
+class Z { init() throws {} }
+
+class X {
+  required init(_: Z) throws {}
+}


### PR DESCRIPTION
Explanation: Fixes a regression where spurious "self used before super.init" errors would occur when an argument to a `self.init` or `super.init` delegation threw.

Scope: Regression from 4.0

Issue: rdar://problem/37007554

Risk: Low, small bug fix

Testing: Swift CI, test case from Radar