### PR TITLE
[Reflection] Add support for imported structs with recorded fields (attempt #2)

### DIFF
--- a/include/swift/Reflection/Records.h
+++ b/include/swift/Reflection/Records.h
@@ -186,6 +186,10 @@ public:
             Kind == FieldDescriptorKind::ObjCProtocol);
   }
 
+  bool isStruct() const {
+    return Kind == FieldDescriptorKind::Struct;
+  }
+
   const_iterator begin() const {
     auto Begin = getFieldRecordBuffer();
     auto End = Begin + NumFields;

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -5618,7 +5618,9 @@ IRGenModule::getAddrOfForeignTypeMetadataCandidate(CanType type) {
   } else if (auto structType = dyn_cast<StructType>(type)) {
     auto structDecl = structType->getDecl();
     assert(isa<ClangModuleUnit>(structDecl->getModuleScopeContext()));
-    
+
+    ImportedStructs.insert(structDecl);
+
     ForeignStructMetadataBuilder builder(*this, structDecl, init);
     builder.layout();
     addressPoint = builder.getOffsetOfAddressPoint();

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -920,6 +920,9 @@ public:
   /// Imported protocols referenced by types in this module when emitting
   /// reflection metadata.
   llvm::SetVector<const ProtocolDecl *> ImportedProtocols;
+  /// Imported structs referenced by types in this module when emitting
+  /// reflection metadata.
+  llvm::SetVector<const StructDecl *> ImportedStructs;
 
   llvm::Constant *getAddrOfStringForTypeRef(StringRef Str);
   llvm::Constant *getAddrOfFieldName(StringRef Name);

--- a/stdlib/public/Reflection/TypeLowering.cpp
+++ b/stdlib/public/Reflection/TypeLowering.cpp
@@ -1057,7 +1057,7 @@ public:
 
   const TypeInfo *visitAnyNominalTypeRef(const TypeRef *TR) {
     const auto &FD = TC.getBuilder().getFieldTypeInfo(TR);
-    if (FD.first == nullptr) {
+    if (FD.first == nullptr || FD.first->isStruct()) {
       // Maybe this type is opaque -- look for a builtin
       // descriptor to see if we at least know its size
       // and alignment.
@@ -1065,8 +1065,10 @@ public:
         return TC.makeTypeInfo<BuiltinTypeInfo>(ImportedTypeDescriptor);
 
       // Otherwise, we're out of luck.
-      DEBUG(std::cerr << "No TypeInfo for nominal type: "; TR->dump());
-      return nullptr;
+      if (FD.first == nullptr) {
+        DEBUG(std::cerr << "No TypeInfo for nominal type: "; TR->dump());
+        return nullptr;
+      }
     }
 
     switch (FD.first->Kind) {

--- a/test/Reflection/typeref_decoding_imported.swift
+++ b/test/Reflection/typeref_decoding_imported.swift
@@ -20,6 +20,19 @@
 // CHECK-32: mce: __C.MyCEnum
 // CHECK-32: (struct __C.MyCEnum)
 
+// CHECK-32: __C.MyCStruct
+// CHECK-32: -------------
+// CHECK-32: i: Swift.Int32
+// CHECK-32: (struct Swift.Int32)
+
+// CHECK-32: ip: Swift.Optional<Swift.UnsafeMutablePointer<Swift.Int32>>
+// CHECK-32: (bound_generic_enum Swift.Optional
+// CHECK-32:   (bound_generic_struct Swift.UnsafeMutablePointer
+// CHECK-32:     (struct Swift.Int32)))
+
+// CHECK-32: c: Swift.Int8
+// CHECK-32: (struct Swift.Int8)
+
 // CHECK-32: TypesToReflect.AlsoHasCTypes
 // CHECK-32: ----------------------------
 
@@ -81,6 +94,19 @@
 
 // CHECK-64: mcu: __C.MyCUnion
 // CHECK-64: (struct __C.MyCUnion)
+
+// CHECK-64: __C.MyCStruct
+// CHECK-64: -------------
+// CHECK-64: i: Swift.Int32
+// CHECK-64: (struct Swift.Int32)
+
+// CHECK-64: ip: Swift.Optional<Swift.UnsafeMutablePointer<Swift.Int32>>
+// CHECK-64: (bound_generic_enum Swift.Optional
+// CHECK-64:   (bound_generic_struct Swift.UnsafeMutablePointer
+// CHECK-64:     (struct Swift.Int32)))
+
+// CHECK-64: c: Swift.Int8
+// CHECK-64: (struct Swift.Int8)
 
 // CHECK-64: TypesToReflect.AlsoHasCTypes
 // CHECK-64: ----------------------------


### PR DESCRIPTION
Update IRGen to trigger generation of type metadata for foreign
struct types found in fields. And fix TypeRefBuilder to handle
the case where struct has fields but at the same time has opaque
metadata.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
