### PR TITLE
[MetadataReader] Initialize fields to prevent UB.

### DIFF
--- a/include/swift/Remote/MetadataReader.h
+++ b/include/swift/Remote/MetadataReader.h
@@ -933,9 +933,9 @@ private:
                            sizeof(flags)))
       return nullptr;
     
-    unsigned baseSize;
+    unsigned baseSize = 0;
     unsigned genericHeaderSize = sizeof(GenericContextDescriptorHeader);
-    bool hasVTable;
+    bool hasVTable = false;
     switch (auto kind = flags.getKind()) {
     case ContextDescriptorKind::Module:
       baseSize = sizeof(TargetModuleContextDescriptor<Runtime>);


### PR DESCRIPTION
hasVtable is not initialized on all paths, so when we read it,
we end up reading a random value. On debug builds, this value
almost always happen to be zero, so we do the right thing. This
isn't necessarily true when the optimizations kick in.

lldb uses metadata reder to resolve types and as result of this
undefined behaviour sometimes gets wrong results back, causing
a bunch of tests to fail in release builds.