### PR TITLE
[Batch Mode] Move supplementary output paths into a dedicated structure in FrontendInputsAndOutputs (3)

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -190,6 +190,9 @@ ERROR(error_index_failed_status_check,none,
 ERROR(error_index_inputs_more_than_outputs,none,
   "index output filenames do not match input source files", ())
 
+ERROR(error_wrong_number_of_arguments,none,
+"wrong number of '%0' arguments (expected %1, got %2)", (StringRef, int, int))
+
 ERROR(error_formatting_multiple_file_ranges,none,
   "file ranges don't support multiple input files", ())
 

--- a/include/swift/Frontend/ArgsToFrontendOptionsConverter.h
+++ b/include/swift/Frontend/ArgsToFrontendOptionsConverter.h
@@ -37,7 +37,7 @@ private:
   void computeDebugTimeOptions();
   bool computeFallbackModuleName();
   bool computeModuleName();
-  bool computeOutputFilenames();
+  bool computeMainAndSupplementaryOutputFilenames();
   void computeDumpScopeMapLocations();
   void computeHelpOptions();
   void computeImplicitImportModuleNames();
@@ -52,7 +52,7 @@ private:
 
   bool setUpForSILOrLLVM();
 
-  void determineSupplementaryOutputFilenames();
+  bool checkUnusedSupplementaryOutputPaths() const;
 
   /// \returns the output filenames on the command line or in the output
   /// filelist, or an empty vector if there were neither -o's nor an output

--- a/include/swift/Frontend/ArgsToFrontendOutputsConverter.h
+++ b/include/swift/Frontend/ArgsToFrontendOutputsConverter.h
@@ -124,10 +124,24 @@ public:
       const llvm::opt::ArgList &args, DiagnosticEngine &diags,
       const FrontendInputsAndOutputs &inputsAndOutputs,
       ArrayRef<std::string> outputFiles, StringRef moduleName);
-  Optional<SupplementaryOutputPaths> computeOutputPaths() const;
+  Optional<std::vector<SupplementaryOutputPaths>> computeOutputPaths() const;
 
 private:
-  /// \return None if error.
+  /// \Return a set of supplementary output paths for each input that might
+  /// produce supplementary outputs, or None to signal an error.
+  /// \note
+  /// At present, only one input can produce supplementary outputs, but
+  /// in the future, batch-mode will support multiple primary inputs and thus,
+  /// multiple sets of supplementary outputs. This function is written with that
+  /// future in mind.
+  /// \par
+  /// The paths are derived from arguments
+  /// such as -emit-module-path. These are not the final computed paths,
+  /// merely the ones passed in via the command line.
+  /// \note
+  /// In the future, these will also include those passed in via whatever
+  /// filelist scheme gets implemented to handle cases where the command line
+  /// arguments become burdensome.
   Optional<std::vector<SupplementaryOutputPaths>>
   getSupplementaryOutputPathsFromArguments() const;
 

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -175,10 +175,12 @@ public:
   }
 
   void setSerializedDiagnosticsPath(StringRef Path) {
-    FrontendOpts.SerializedDiagnosticsPath = Path;
+    FrontendOpts.InputsAndOutputs.supplementaryOutputs()
+        .SerializedDiagnosticsPath = Path;
   }
   StringRef getSerializedDiagnosticsPath() const {
-    return FrontendOpts.SerializedDiagnosticsPath;
+    return FrontendOpts.InputsAndOutputs.supplementaryOutputs()
+        .SerializedDiagnosticsPath;
   }
 
   LangOptions &getLangOptions() {

--- a/include/swift/Frontend/FrontendInputsAndOutputs.h
+++ b/include/swift/Frontend/FrontendInputsAndOutputs.h
@@ -15,6 +15,7 @@
 
 #include "swift/AST/Module.h"
 #include "swift/Frontend/InputFile.h"
+#include "swift/Frontend/SupplementaryOutputPaths.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/MapVector.h"
 
@@ -43,9 +44,18 @@ class FrontendInputsAndOutputs {
   /// Punt where needed to enable batch mode experiments.
   bool AreBatchModeChecksBypassed = false;
 
+  SupplementaryOutputPaths SupplementaryOutputs;
+
 public:
   bool areBatchModeChecksBypassed() const { return AreBatchModeChecksBypassed; }
   void setBypassBatchModeChecks(bool bbc) { AreBatchModeChecksBypassed = bbc; }
+
+  const SupplementaryOutputPaths &supplementaryOutputs() const {
+    return SupplementaryOutputs;
+  }
+  SupplementaryOutputPaths &supplementaryOutputs() {
+    return SupplementaryOutputs;
+  }
 
   FrontendInputsAndOutputs() = default;
   FrontendInputsAndOutputs(const FrontendInputsAndOutputs &other);
@@ -164,7 +174,9 @@ public:
 private:
   friend class ArgsToFrontendOptionsConverter;
 
-  void setMainOutputs(ArrayRef<std::string> outputFiles);
+  void
+  setMainAndSupplementaryOutputs(ArrayRef<std::string> outputFiles,
+                                 SupplementaryOutputPaths supplementaryOutputs);
 
 public:
   unsigned countOfInputsProducingMainOutputs() const;
@@ -193,8 +205,20 @@ public:
 
   // Supplementary outputs
 
+  unsigned countOfFilesProducingSupplementaryOutput() const;
+
   void forEachInputProducingSupplementaryOutput(
       llvm::function_ref<void(const InputFile &)> fn) const;
+
+  bool hasDependenciesPath() const;
+  bool hasReferenceDependenciesPath() const;
+  bool hasObjCHeaderOutputPath() const;
+  bool hasLoadedModuleTracePath() const;
+  bool hasModuleOutputPath() const;
+  bool hasModuleDocOutputPath() const;
+  bool hasTBDPath() const;
+
+  bool hasDependencyTrackerPath() const;
 };
 
 } // namespace swift

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -52,36 +52,11 @@ public:
   /// The name of the module which the frontend is building.
   std::string ModuleName;
 
-  /// The path to which we should emit a serialized module.
-  std::string ModuleOutputPath;
-
-  /// The path to which we should emit a module documentation file.
-  std::string ModuleDocOutputPath;
-
   /// The name of the library to link against when using this module.
   std::string ModuleLinkName;
 
-  /// The path to which we should emit an Objective-C header for the module.
-  std::string ObjCHeaderOutputPath;
-
-  /// Path to a file which should contain serialized diagnostics for this
-  /// frontend invocation.
-  std::string SerializedDiagnosticsPath;
-
-  /// The path to which we should output a Make-style dependencies file.
-  std::string DependenciesFilePath;
-
-  /// The path to which we should output a Swift reference dependencies file.
-  std::string ReferenceDependenciesFilePath;
-
   /// The path to which we should output fixits as source edits.
   std::string FixitsOutputPath;
-
-  /// The path to which we should output a loaded module trace file.
-  std::string LoadedModuleTracePath;
-
-  /// The path to which we should output a TBD file.
-  std::string TBDPath;
 
   /// Arguments which should be passed in immediate mode.
   std::vector<std::string> ImmediateArgv;
@@ -301,15 +276,10 @@ public:
   }
 
 private:
-  bool hasUnusedDependenciesFilePath() const;
   static bool canActionEmitDependencies(ActionType);
-  bool hasUnusedObjCHeaderOutputPath() const;
-  static bool canActionEmitHeader(ActionType);
-  bool hasUnusedLoadedModuleTracePath() const;
+  static bool canActionEmitObjCHeader(ActionType);
   static bool canActionEmitLoadedModuleTrace(ActionType);
-  bool hasUnusedModuleOutputPath() const;
   static bool canActionEmitModule(ActionType);
-  bool hasUnusedModuleDocOutputPath() const;
   static bool canActionEmitModuleDoc(ActionType);
 
 public:

--- a/include/swift/Frontend/SupplementaryOutputPaths.h
+++ b/include/swift/Frontend/SupplementaryOutputPaths.h
@@ -1,0 +1,53 @@
+//===--- SupplementaryOutputPaths.h ----------------------------*- C++ -*-===*//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_FRONTEND_SUPPLEMENTARYOUTPUTPATHS_H
+#define SWIFT_FRONTEND_SUPPLEMENTARYOUTPUTPATHS_H
+
+#include "swift/Basic/LLVM.h"
+#include "llvm/ADT/Optional.h"
+
+#include <string>
+
+namespace swift {
+struct SupplementaryOutputPaths {
+  /// The path to which we should emit an Objective-C header for the module.
+  std::string ObjCHeaderOutputPath;
+
+  /// The path to which we should emit a serialized module.
+  std::string ModuleOutputPath;
+
+  /// The path to which we should emit a module documentation file.
+  std::string ModuleDocOutputPath;
+
+  /// The path to which we should output a Make-style dependencies file.
+  std::string DependenciesFilePath;
+
+  /// The path to which we should output a Swift reference dependencies file.
+  std::string ReferenceDependenciesFilePath;
+
+  /// Path to a file which should contain serialized diagnostics for this
+  /// frontend invocation.
+  std::string SerializedDiagnosticsPath;
+
+  /// The path to which we should output a loaded module trace file.
+  std::string LoadedModuleTracePath;
+
+  /// The path to which we should output a TBD file.
+  std::string TBDPath;
+
+  SupplementaryOutputPaths() = default;
+  SupplementaryOutputPaths(const SupplementaryOutputPaths &) = default;
+};
+} // namespace swift
+
+#endif /* SWIFT_FRONTEND_SUPPLEMENTARYOUTPUTPATHS_H */

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -111,16 +111,17 @@ bool ArgsToFrontendOptionsConverter::convert() {
   if (computeModuleName())
     return true;
 
-  if (computeOutputFilenames())
-    return true;
-  determineSupplementaryOutputFilenames();
-
-  if (checkForUnusedOutputPaths())
+  if (computeMainAndSupplementaryOutputFilenames())
     return true;
 
-  if (const Arg *A = Args.getLastArg(OPT_module_link_name)) {
+  if (checkUnusedSupplementaryOutputPaths())
+    return true;
+
+  if (const Arg *A = Args.getLastArg(OPT_emit_fixits_path))
+    Opts.FixitsOutputPath = A->getValue();
+
+  if (const Arg *A = Args.getLastArg(OPT_module_link_name))
     Opts.ModuleLinkName = A->getValue();
-  }
 
   Opts.AlwaysSerializeDebuggingOptions |=
       Args.hasArg(OPT_serialize_debugging_options);
@@ -431,108 +432,48 @@ bool ArgsToFrontendOptionsConverter::computeFallbackModuleName() {
   return false;
 }
 
-bool ArgsToFrontendOptionsConverter::computeOutputFilenames() {
-  Optional<std::vector<std::string>> outs =
-      ArgsToFrontendOutputsConverter(Args, Opts.ModuleName,
-                                     Opts.InputsAndOutputs, Diags)
-          .convert();
-  if (!outs)
+bool ArgsToFrontendOptionsConverter::
+    computeMainAndSupplementaryOutputFilenames() {
+  std::vector<std::string> mainOutputs;
+  SupplementaryOutputPaths supplementaryOutputs;
+  const bool hadError = ArgsToFrontendOutputsConverter(
+                            Args, Opts.ModuleName, Opts.InputsAndOutputs, Diags)
+                            .convert(mainOutputs, supplementaryOutputs);
+  if (hadError)
     return true;
-  if (FrontendOptions::doesActionProduceOutput(Opts.RequestedAction))
-    Opts.InputsAndOutputs.setMainOutputs(*outs);
-  else
-    assert(outs->empty() &&
-           "cannot have main outputs for actions that don't produce outputs");
+  assert(FrontendOptions::doesActionProduceOutput(Opts.RequestedAction) ||
+         mainOutputs.empty() &&
+             "Should be no main outputs if action does not produce them");
+  Opts.InputsAndOutputs.setMainAndSupplementaryOutputs(mainOutputs,
+                                                       supplementaryOutputs);
   return false;
 }
 
-void ArgsToFrontendOptionsConverter::determineSupplementaryOutputFilenames() {
-  using namespace options;
-  auto determineOutputFilename =
-      [&](std::string &output, OptSpecifier optWithoutPath,
-          OptSpecifier optWithPath, const char *extension, bool useMainOutput) {
-        if (const Arg *A = Args.getLastArg(optWithPath)) {
-          Args.ClaimAllArgs(optWithoutPath);
-          output = A->getValue();
-          return;
-        }
-
-        if (!Args.hasArg(optWithoutPath))
-          return;
-
-        if (useMainOutput &&
-            !Opts.InputsAndOutputs.getSingleOutputFilename().empty()) {
-          output = Opts.InputsAndOutputs.getSingleOutputFilename();
-          return;
-        }
-
-        if (!output.empty())
-          return;
-
-        llvm::SmallString<128> path(Opts.originalPath());
-        llvm::sys::path::replace_extension(path, extension);
-        output = path.str();
-      };
-
-  determineOutputFilename(Opts.DependenciesFilePath, OPT_emit_dependencies,
-                          OPT_emit_dependencies_path, "d", false);
-  determineOutputFilename(
-      Opts.ReferenceDependenciesFilePath, OPT_emit_reference_dependencies,
-      OPT_emit_reference_dependencies_path, "swiftdeps", false);
-  determineOutputFilename(Opts.SerializedDiagnosticsPath,
-                          OPT_serialize_diagnostics,
-                          OPT_serialize_diagnostics_path, "dia", false);
-  determineOutputFilename(Opts.ObjCHeaderOutputPath, OPT_emit_objc_header,
-                          OPT_emit_objc_header_path, "h", false);
-  determineOutputFilename(
-      Opts.LoadedModuleTracePath, OPT_emit_loaded_module_trace,
-      OPT_emit_loaded_module_trace_path, "trace.json", false);
-
-  determineOutputFilename(Opts.TBDPath, OPT_emit_tbd, OPT_emit_tbd_path, "tbd",
-                          false);
-
-  if (const Arg *A = Args.getLastArg(OPT_emit_fixits_path)) {
-    Opts.FixitsOutputPath = A->getValue();
-  }
-
-  bool isSIB = Opts.RequestedAction == FrontendOptions::ActionType::EmitSIB ||
-               Opts.RequestedAction == FrontendOptions::ActionType::EmitSIBGen;
-  bool canUseMainOutputForModule =
-      Opts.RequestedAction == FrontendOptions::ActionType::MergeModules ||
-      Opts.RequestedAction == FrontendOptions::ActionType::EmitModuleOnly ||
-      isSIB;
-  auto ext = isSIB ? SIB_EXTENSION : SERIALIZED_MODULE_EXTENSION;
-  auto sibOpt = Opts.RequestedAction == FrontendOptions::ActionType::EmitSIB
-                    ? OPT_emit_sib
-                    : OPT_emit_sibgen;
-  determineOutputFilename(Opts.ModuleOutputPath,
-                          isSIB ? sibOpt : OPT_emit_module,
-                          OPT_emit_module_path, ext, canUseMainOutputForModule);
-
-  determineOutputFilename(Opts.ModuleDocOutputPath, OPT_emit_module_doc,
-                          OPT_emit_module_doc_path,
-                          SERIALIZED_MODULE_DOC_EXTENSION, false);
-}
-
-bool ArgsToFrontendOptionsConverter::checkForUnusedOutputPaths() const {
-  if (Opts.hasUnusedDependenciesFilePath()) {
+bool ArgsToFrontendOptionsConverter::checkUnusedSupplementaryOutputPaths()
+    const {
+  if (!FrontendOptions::canActionEmitDependencies(Opts.RequestedAction) &&
+      Opts.InputsAndOutputs.hasDependenciesPath()) {
     Diags.diagnose(SourceLoc(), diag::error_mode_cannot_emit_dependencies);
     return true;
   }
-  if (Opts.hasUnusedObjCHeaderOutputPath()) {
+  if (!FrontendOptions::canActionEmitObjCHeader(Opts.RequestedAction) &&
+      Opts.InputsAndOutputs.hasObjCHeaderOutputPath()) {
     Diags.diagnose(SourceLoc(), diag::error_mode_cannot_emit_header);
     return true;
   }
-  if (Opts.hasUnusedLoadedModuleTracePath()) {
+  if (!FrontendOptions::canActionEmitLoadedModuleTrace(Opts.RequestedAction) &&
+      Opts.InputsAndOutputs.hasLoadedModuleTracePath()) {
     Diags.diagnose(SourceLoc(),
                    diag::error_mode_cannot_emit_loaded_module_trace);
     return true;
   }
-  if (Opts.hasUnusedModuleOutputPath()) {
+  if (!FrontendOptions::canActionEmitModule(Opts.RequestedAction) &&
+      Opts.InputsAndOutputs.hasModuleOutputPath()) {
     Diags.diagnose(SourceLoc(), diag::error_mode_cannot_emit_module);
     return true;
   }
-  if (Opts.hasUnusedModuleDocOutputPath()) {
+  if (!FrontendOptions::canActionEmitModuleDoc(Opts.RequestedAction) &&
+      Opts.InputsAndOutputs.hasModuleDocOutputPath()) {
     Diags.diagnose(SourceLoc(), diag::error_mode_cannot_emit_module_doc);
     return true;
   }
@@ -543,8 +484,9 @@ void ArgsToFrontendOptionsConverter::computeImportObjCHeaderOptions() {
   using namespace options;
   if (const Arg *A = Args.getLastArgNoClaim(OPT_import_objc_header)) {
     Opts.ImplicitObjCHeaderPath = A->getValue();
-    Opts.SerializeBridgingHeader |= !Opts.InputsAndOutputs.hasPrimaryInputs() &&
-                                    !Opts.ModuleOutputPath.empty();
+    Opts.SerializeBridgingHeader |=
+        !Opts.InputsAndOutputs.hasPrimaryInputs() &&
+        !Opts.InputsAndOutputs.supplementaryOutputs().ModuleOutputPath.empty();
   }
 }
 void ArgsToFrontendOptionsConverter::computeImplicitImportModuleNames() {

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -441,9 +441,6 @@ bool ArgsToFrontendOptionsConverter::
                             .convert(mainOutputs, supplementaryOutputs);
   if (hadError)
     return true;
-  assert(FrontendOptions::doesActionProduceOutput(Opts.RequestedAction) ||
-         mainOutputs.empty() &&
-             "Should be no main outputs if action does not produce them");
   Opts.InputsAndOutputs.setMainAndSupplementaryOutputs(mainOutputs,
                                                        supplementaryOutputs);
   return false;

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -31,16 +31,32 @@
 using namespace swift;
 using namespace llvm::opt;
 
-Optional<std::vector<std::string>> ArgsToFrontendOutputsConverter::convert() {
+bool ArgsToFrontendOutputsConverter::convert(
+    std::vector<std::string> &mainOutputs,
+    SupplementaryOutputPaths &supplementaryOutputs) {
   const auto requestedAction =
       ArgsToFrontendOptionsConverter::determineRequestedAction(Args);
-
   if (!FrontendOptions::doesActionProduceOutput(requestedAction))
-    return std::vector<std::string>();
+    return false;
 
-  if (auto ofc = OutputFilesComputer::create(Args, Diags, InputsAndOutputs))
-    return ofc->computeOutputFiles();
-  return None;
+  Optional<OutputFilesComputer> ofc =
+      OutputFilesComputer::create(Args, Diags, InputsAndOutputs);
+  if (!ofc)
+    return true;
+  Optional<std::vector<std::string>> mains = ofc->computeOutputFiles();
+  if (!mains)
+    return true;
+
+  Optional<SupplementaryOutputPaths> supplementaries =
+      SupplementaryOutputPathsComputer(Args, Diags, InputsAndOutputs, *mains,
+                                       ModuleName)
+          .computeOutputPaths();
+  if (!supplementaries)
+    return true;
+
+  mainOutputs = std::move(*mains);
+  supplementaryOutputs = std::move(*supplementaries);
+  return false;
 }
 
 Optional<std::vector<std::string>>
@@ -201,4 +217,211 @@ OutputFilesComputer::deriveOutputFileFromParts(StringRef dir,
   llvm::sys::path::append(path, base);
   llvm::sys::path::replace_extension(path, Suffix);
   return path.str();
+}
+
+SupplementaryOutputPathsComputer::SupplementaryOutputPathsComputer(
+    const ArgList &args, DiagnosticEngine &diags,
+    const FrontendInputsAndOutputs &inputsAndOutputs,
+    ArrayRef<std::string> outputFiles, StringRef moduleName)
+    : Args(args), Diags(diags), InputsAndOutputs(inputsAndOutputs),
+      OutputFiles(outputFiles), ModuleName(moduleName),
+      RequestedAction(
+          ArgsToFrontendOptionsConverter::determineRequestedAction(Args)) {}
+
+Optional<SupplementaryOutputPaths>
+SupplementaryOutputPathsComputer::computeOutputPaths() const {
+  Optional<std::vector<SupplementaryOutputPaths>> pathsFromUser =
+      getSupplementaryOutputPathsFromArguments();
+  if (!pathsFromUser)
+    return None;
+
+  return computeOutputPathsForOneInput(
+      OutputFiles[0], (*pathsFromUser)[0],
+      InputsAndOutputs.firstInputProducingOutput());
+}
+
+Optional<std::vector<SupplementaryOutputPaths>>
+SupplementaryOutputPathsComputer::getSupplementaryOutputPathsFromArguments()
+    const {
+
+  auto objCHeaderOutput = getSupplementaryFilenamesFromArguments(
+      options::OPT_emit_objc_header_path);
+  auto moduleOutput =
+      getSupplementaryFilenamesFromArguments(options::OPT_emit_module_path);
+  auto moduleDocOutput =
+      getSupplementaryFilenamesFromArguments(options::OPT_emit_module_doc_path);
+  auto dependenciesFile = getSupplementaryFilenamesFromArguments(
+      options::OPT_emit_dependencies_path);
+  auto referenceDependenciesFile = getSupplementaryFilenamesFromArguments(
+      options::OPT_emit_reference_dependencies_path);
+  auto serializedDiagnostics = getSupplementaryFilenamesFromArguments(
+      options::OPT_serialize_diagnostics_path);
+  auto loadedModuleTrace = getSupplementaryFilenamesFromArguments(
+      options::OPT_emit_loaded_module_trace_path);
+  auto TBD = getSupplementaryFilenamesFromArguments(options::OPT_emit_tbd_path);
+
+  if (!objCHeaderOutput || !moduleOutput || !moduleDocOutput ||
+      !dependenciesFile || !referenceDependenciesFile ||
+      !serializedDiagnostics || !loadedModuleTrace || !TBD) {
+    return None;
+  }
+  std::vector<SupplementaryOutputPaths> result;
+
+  const unsigned N =
+      InputsAndOutputs.countOfFilesProducingSupplementaryOutput();
+  for (unsigned i = 0; i < N; ++i) {
+    SupplementaryOutputPaths sop;
+    sop.ObjCHeaderOutputPath = (*objCHeaderOutput)[i];
+    sop.ModuleOutputPath = (*moduleOutput)[i];
+    sop.ModuleDocOutputPath = (*moduleDocOutput)[i];
+    sop.DependenciesFilePath = (*dependenciesFile)[i];
+    sop.ReferenceDependenciesFilePath = (*referenceDependenciesFile)[i];
+    sop.SerializedDiagnosticsPath = (*serializedDiagnostics)[i];
+    sop.LoadedModuleTracePath = (*loadedModuleTrace)[i];
+    sop.TBDPath = (*TBD)[i];
+
+    result.push_back(sop);
+  }
+  return result;
+}
+
+// Extend this routine for filelists if/when we have them.
+
+Optional<std::vector<std::string>>
+SupplementaryOutputPathsComputer::getSupplementaryFilenamesFromArguments(
+    options::ID pathID) const {
+  std::vector<std::string> paths = Args.getAllArgValues(pathID);
+
+  const unsigned N =
+      InputsAndOutputs.countOfFilesProducingSupplementaryOutput();
+
+  if (paths.size() == N)
+    return paths;
+
+  if (paths.size() == 0)
+    return std::vector<std::string>(N, std::string());
+
+  Diags.diagnose(SourceLoc(), diag::error_wrong_number_of_arguments,
+                 Args.getLastArg(pathID)->getOption().getName(), N,
+                 paths.size());
+  return None;
+}
+
+Optional<SupplementaryOutputPaths>
+SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
+    StringRef outputFile, const SupplementaryOutputPaths &pathsFromArguments,
+    const InputFile &input) const {
+  StringRef defaultSupplementaryOutputPathExcludingExtension =
+      deriveDefaultSupplementaryOutputPathExcludingExtension(outputFile, input);
+
+  using namespace options;
+
+  auto dependenciesFilePath = determineSupplementaryOutputFilename(
+      OPT_emit_dependencies, pathsFromArguments.DependenciesFilePath, "d", "",
+      defaultSupplementaryOutputPathExcludingExtension);
+
+  auto referenceDependenciesFilePath = determineSupplementaryOutputFilename(
+      OPT_emit_reference_dependencies,
+      pathsFromArguments.ReferenceDependenciesFilePath, "swiftdeps", "",
+      defaultSupplementaryOutputPathExcludingExtension);
+
+  auto serializedDiagnosticsPath = determineSupplementaryOutputFilename(
+      OPT_serialize_diagnostics, pathsFromArguments.SerializedDiagnosticsPath,
+      "dia", "", defaultSupplementaryOutputPathExcludingExtension);
+
+  auto objcHeaderOutputPath = determineSupplementaryOutputFilename(
+      OPT_emit_objc_header, pathsFromArguments.ObjCHeaderOutputPath, "h", "",
+      defaultSupplementaryOutputPathExcludingExtension);
+
+  auto loadedModuleTracePath = determineSupplementaryOutputFilename(
+      OPT_emit_loaded_module_trace, pathsFromArguments.LoadedModuleTracePath,
+      "trace.json", "", defaultSupplementaryOutputPathExcludingExtension);
+
+  auto tbdPath = determineSupplementaryOutputFilename(
+      OPT_emit_tbd, pathsFromArguments.TBDPath, "tbd", "",
+      defaultSupplementaryOutputPathExcludingExtension);
+
+  auto moduleDocOutputPath = determineSupplementaryOutputFilename(
+      OPT_emit_module_doc, pathsFromArguments.ModuleDocOutputPath,
+      SERIALIZED_MODULE_DOC_EXTENSION, "",
+      defaultSupplementaryOutputPathExcludingExtension);
+
+  ID emitModuleOption;
+  std::string moduleExtension;
+  std::string mainOutputIfUsableForModule;
+  deriveModulePathParameters(emitModuleOption, moduleExtension,
+                             mainOutputIfUsableForModule);
+
+  auto moduleOutputPath = determineSupplementaryOutputFilename(
+      emitModuleOption, pathsFromArguments.ModuleOutputPath, moduleExtension,
+      mainOutputIfUsableForModule,
+      defaultSupplementaryOutputPathExcludingExtension);
+
+  SupplementaryOutputPaths sop;
+  sop.ObjCHeaderOutputPath = objcHeaderOutputPath;
+  sop.ModuleOutputPath = moduleOutputPath;
+  sop.ModuleDocOutputPath = moduleDocOutputPath;
+  sop.DependenciesFilePath = dependenciesFilePath;
+  sop.ReferenceDependenciesFilePath = referenceDependenciesFilePath;
+  sop.SerializedDiagnosticsPath = serializedDiagnosticsPath;
+  sop.LoadedModuleTracePath = loadedModuleTracePath;
+  sop.TBDPath = tbdPath;
+  return sop;
+}
+
+StringRef SupplementaryOutputPathsComputer::
+    deriveDefaultSupplementaryOutputPathExcludingExtension(
+        StringRef outputFilename, const InputFile &input) const {
+  // Put the supplementary output file next to the output file if possible.
+  if (!outputFilename.empty() && outputFilename != "-")
+    return outputFilename;
+
+  if (input.isPrimary() && input.file() != "-")
+    return llvm::sys::path::filename(input.file());
+
+  return ModuleName;
+}
+
+std::string
+SupplementaryOutputPathsComputer::determineSupplementaryOutputFilename(
+    options::ID emitOpt, std::string pathFromArguments, StringRef extension,
+    StringRef mainOutputIfUsable,
+    StringRef defaultSupplementaryOutputPathExcludingExtension) const {
+  using namespace options;
+
+  if (!pathFromArguments.empty())
+    return pathFromArguments;
+
+  if (!Args.hasArg(emitOpt))
+    return std::string();
+
+  if (!mainOutputIfUsable.empty()) {
+    return mainOutputIfUsable.str();
+  }
+
+  llvm::SmallString<128> path(defaultSupplementaryOutputPathExcludingExtension);
+  llvm::sys::path::replace_extension(path, extension);
+  return path.str().str();
+};
+
+void SupplementaryOutputPathsComputer::deriveModulePathParameters(
+    options::ID &emitOption, std::string &extension,
+    std::string &mainOutputIfUsable) const {
+
+  bool isSIB = RequestedAction == FrontendOptions::ActionType::EmitSIB ||
+               RequestedAction == FrontendOptions::ActionType::EmitSIBGen;
+
+  emitOption = !isSIB ? options::OPT_emit_module
+                      : RequestedAction == FrontendOptions::ActionType::EmitSIB
+                            ? options::OPT_emit_sib
+                            : options::OPT_emit_sibgen;
+
+  bool canUseMainOutputForModule =
+      RequestedAction == FrontendOptions::ActionType::MergeModules ||
+      RequestedAction == FrontendOptions::ActionType::EmitModuleOnly || isSIB;
+
+  extension = isSIB ? SIB_EXTENSION : SERIALIZED_MODULE_EXTENSION;
+
+  mainOutputIfUsable =
+      canUseMainOutputForModule && !OutputFiles.empty() ? OutputFiles[0] : "";
 }

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -81,7 +81,9 @@ bool CompilerInstance::setup(const CompilerInvocation &Invok) {
 
   // If we are asked to emit a module documentation file, configure lexing and
   // parsing to remember comments.
-  if (!Invocation.getFrontendOptions().ModuleDocOutputPath.empty())
+  if (!Invocation.getFrontendOptions()
+           .InputsAndOutputs.supplementaryOutputs()
+           .ModuleDocOutputPath.empty())
     Invocation.getLangOptions().AttachCommentsToDecls = true;
 
   // If we are doing index-while-building, configure lexing and parsing to

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -289,9 +289,7 @@ void FrontendInputsAndOutputs::forEachInputProducingAMainOutputFile(
 void FrontendInputsAndOutputs::setMainAndSupplementaryOutputs(
     ArrayRef<std::string> outputFiles,
     SupplementaryOutputPaths supplementaryOutputs) {
-  if (outputFiles.empty())
-    ;
-  else if (hasPrimaryInputs()) {
+  if (hasPrimaryInputs()) {
     unsigned i = 0;
     for (auto index : indices(AllInputs)) {
       InputFile &f = AllInputs[index];
@@ -344,15 +342,14 @@ bool FrontendInputsAndOutputs::hasNamedOutputFile() const {
 
 unsigned
 FrontendInputsAndOutputs::countOfFilesProducingSupplementaryOutput() const {
-  assertMustNotBeMoreThanOnePrimaryInput();
-  return 1; // will be extended when batch mode is implemented
+  return hasPrimaryInputs() ? primaryInputCount() : hasInputs() ? 1 : 0;
 }
 
 void FrontendInputsAndOutputs::forEachInputProducingSupplementaryOutput(
     llvm::function_ref<void(const InputFile &)> fn) const {
   if (hasPrimaryInputs())
     forEachPrimaryInput(fn);
-  else
+  else if (hasInputs())
     fn(firstInput());
 }
 

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -117,10 +117,9 @@ void FrontendOptions::forAllOutputPaths(
       fn(input.outputFilename());
   }
   const std::string *outputs[] = {
-    &ModuleOutputPath,
-    &ModuleDocOutputPath,
-    &ObjCHeaderOutputPath
-  };
+      &InputsAndOutputs.supplementaryOutputs().ModuleOutputPath,
+      &InputsAndOutputs.supplementaryOutputs().ModuleDocOutputPath,
+      &InputsAndOutputs.supplementaryOutputs().ObjCHeaderOutputPath};
   for (const std::string *next : outputs) {
     if (!next->empty())
       fn(*next);
@@ -195,11 +194,6 @@ FrontendOptions::suffixForPrincipalOutputFileForAction(ActionType action) {
   }
 }
 
-bool FrontendOptions::hasUnusedDependenciesFilePath() const {
-  return !DependenciesFilePath.empty() &&
-         !canActionEmitDependencies(RequestedAction);
-}
-
 bool FrontendOptions::canActionEmitDependencies(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
@@ -231,11 +225,7 @@ bool FrontendOptions::canActionEmitDependencies(ActionType action) {
   }
 }
 
-bool FrontendOptions::hasUnusedObjCHeaderOutputPath() const {
-  return !ObjCHeaderOutputPath.empty() && !canActionEmitHeader(RequestedAction);
-}
-
-bool FrontendOptions::canActionEmitHeader(ActionType action) {
+bool FrontendOptions::canActionEmitObjCHeader(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
   case ActionType::DumpParse:
@@ -264,11 +254,6 @@ bool FrontendOptions::canActionEmitHeader(ActionType action) {
   case ActionType::EmitImportedModules:
     return true;
   }
-}
-
-bool FrontendOptions::hasUnusedLoadedModuleTracePath() const {
-  return !LoadedModuleTracePath.empty() &&
-         !canActionEmitLoadedModuleTrace(RequestedAction);
 }
 
 bool FrontendOptions::canActionEmitLoadedModuleTrace(ActionType action) {
@@ -300,14 +285,6 @@ bool FrontendOptions::canActionEmitLoadedModuleTrace(ActionType action) {
   case ActionType::EmitImportedModules:
     return true;
   }
-}
-
-bool FrontendOptions::hasUnusedModuleOutputPath() const {
-  return !ModuleOutputPath.empty() && !canActionEmitModule(RequestedAction);
-}
-
-bool FrontendOptions::hasUnusedModuleDocOutputPath() const {
-  return !ModuleDocOutputPath.empty() && !canActionEmitModule(RequestedAction);
 }
 
 bool FrontendOptions::canActionEmitModule(ActionType action) {

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1037,8 +1037,8 @@ static void setPrivateDiscriminatorIfNeeded(IRGenOptions &IRGenOpts,
     IRGenOpts.DWARFDebugFlags += (" -private-discriminator " + PD.str()).str();
 }
 
-static bool serializeSIB(FrontendOptions &opts, SILModule *SM,
-                         ASTContext &Context, ModuleOrSourceFile MSF) {
+static bool serializeSIBIfNeeded(FrontendOptions &opts, SILModule *SM,
+                                 ASTContext &Context, ModuleOrSourceFile MSF) {
   const std::string &moduleOutputPath = opts.ModuleOutputPath;
   assert(!moduleOutputPath.empty() && "must have an output path");
 
@@ -1175,8 +1175,8 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
 
   if (Action == FrontendOptions::ActionType::EmitSIBGen) {
     linkAllIfNeeded(Invocation, SM.get());
-    serializeSIB(Invocation.getFrontendOptions(), SM.get(),
-                 Instance.getASTContext(), MSF);
+    serializeSIBIfNeeded(Invocation.getFrontendOptions(), SM.get(),
+                         Instance.getASTContext(), MSF);
     return Context.hadError();
   }
 
@@ -1235,8 +1235,8 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
                             opts.ImplicitObjCHeaderPath, moduleIsPublic);
 
   if (Action == FrontendOptions::ActionType::EmitSIB)
-    return serializeSIB(Invocation.getFrontendOptions(), SM.get(),
-                        Instance.getASTContext(), MSF);
+    return serializeSIBIfNeeded(Invocation.getFrontendOptions(), SM.get(),
+                                Instance.getASTContext(), MSF);
 
   const bool haveModulePath =
       !opts.ModuleOutputPath.empty() || !opts.ModuleDocOutputPath.empty();

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -132,16 +132,22 @@ bool swift::emitReferenceDependencies(DiagnosticEngine &diags,
   // Before writing to the dependencies file path, preserve any previous file
   // that may have been there. No error handling -- this is just a nicety, it
   // doesn't matter if it fails.
-  llvm::sys::fs::rename(opts.ReferenceDependenciesFilePath,
-                        opts.ReferenceDependenciesFilePath + "~");
+  llvm::sys::fs::rename(opts.InputsAndOutputs.supplementaryOutputs()
+                            .ReferenceDependenciesFilePath,
+                        opts.InputsAndOutputs.supplementaryOutputs()
+                                .ReferenceDependenciesFilePath +
+                            "~");
 
   std::error_code EC;
-  llvm::raw_fd_ostream out(opts.ReferenceDependenciesFilePath, EC,
-                           llvm::sys::fs::F_None);
+  llvm::raw_fd_ostream out(opts.InputsAndOutputs.supplementaryOutputs()
+                               .ReferenceDependenciesFilePath,
+                           EC, llvm::sys::fs::F_None);
 
   if (out.has_error() || EC) {
     diags.diagnose(SourceLoc(), diag::error_opening_output,
-                   opts.ReferenceDependenciesFilePath, EC.message());
+                   opts.InputsAndOutputs.supplementaryOutputs()
+                       .ReferenceDependenciesFilePath,
+                   EC.message());
     out.clear_error();
     return true;
   }

--- a/test/Frontend/wrong-number-of-arguments.swift
+++ b/test/Frontend/wrong-number-of-arguments.swift
@@ -1,0 +1,2 @@
+// RUN: not %swift  -c -primary-file a.swift b.swift -emit-module-path one -emit-module-path two 2>&1 | %FileCheck %s -check-prefix=CHECK1
+// CHECK1: <unknown>:0: error: wrong number of 'emit-module-path' arguments (expected 1, got 2)

--- a/test/Frontend/wrong-number-of-arguments.swift
+++ b/test/Frontend/wrong-number-of-arguments.swift
@@ -1,2 +1,2 @@
 // RUN: not %swift  -c -primary-file a.swift b.swift -emit-module-path one -emit-module-path two 2>&1 | %FileCheck %s -check-prefix=CHECK1
-// CHECK1: <unknown>:0: error: wrong number of 'emit-module-path' arguments (expected 1, got 2)
+// CHECK1: <unknown>:0: error: wrong number of '-emit-module-path' arguments (expected 1, got 2)


### PR DESCRIPTION
<!-- What's in this pull request? -->
In preparation for many sets of supplementary outputs, reify the set, and move it into FrontendInputsAndOutputs. Also move the computation of those.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->