### PR TITLE
master-next: Update Statistic initializers for LLVM r323999.

### DIFF
--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -22,7 +22,7 @@
 #define SWIFT_FUNC_STAT                                                 \
   do {                                                                  \
     static llvm::Statistic FStat =                                      \
-      {DEBUG_TYPE, __func__, __func__, {0}, false};                     \
+      {DEBUG_TYPE, __func__, __func__, {0}, {false}};                   \
     ++FStat;                                                            \
   } while (0)
 

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -209,7 +209,7 @@ UnifiedStatsReporter::publishAlwaysOnStatsToLLVM() {
     auto &C = getFrontendCounters();
 #define FRONTEND_STATISTIC(TY, NAME)                            \
     do {                                                        \
-      static Statistic Stat = {#TY, #NAME, #NAME, {0}, false};  \
+      static Statistic Stat = {#TY, #NAME, #NAME, {0}, {false}};  \
       Stat += (C).NAME;                                         \
     } while (0);
 #include "swift/Basic/Statistics.def"
@@ -219,7 +219,7 @@ UnifiedStatsReporter::publishAlwaysOnStatsToLLVM() {
     auto &C = getDriverCounters();
 #define DRIVER_STATISTIC(NAME)                                       \
     do {                                                             \
-      static Statistic Stat = {"Driver", #NAME, #NAME, {0}, false};  \
+      static Statistic Stat = {"Driver", #NAME, #NAME, {0}, {false}};  \
       Stat += (C).NAME;                                              \
     } while (0);
 #include "swift/Basic/Statistics.def"


### PR DESCRIPTION
LLVM r323999 changed the Initialized field of llvm::Statistic from a
bool to std::atomic<bool>.