### PR TITLE
Fix the "tail" command to be compatible with coreutils. NFC.

### DIFF
--- a/test/IDE/print_clang_bool_bridging.swift
+++ b/test/IDE/print_clang_bool_bridging.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-ide-test -print-module -source-filename %s -module-to-print=BoolBridgingTests -function-definitions=false -print-regular-comments -skip-unavailable -F %S/Inputs/mock-sdk > %t.txt
-// RUN: diff -u <(tail +9 %s) %t.txt
+// RUN: diff -u <(tail -n +9 %s) %t.txt
 
 // REQUIRES: objc_interop
 

--- a/test/IDE/print_clang_swift_name.swift
+++ b/test/IDE/print_clang_swift_name.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -source-filename %s -module-to-print=SwiftNameTests -function-definitions=false -print-regular-comments -F %S/Inputs/mock-sdk > %t.txt
-// RUN: diff -u <(tail +9 %s) %t.txt
+// RUN: diff -u <(tail -n +9 %s) %t.txt
 
 // REQUIRES: objc_interop
 


### PR DESCRIPTION
I had builds failing during testing because the tail command inside:

test/IDE/print_clang_bool_bridging.swift,
test/IDE/print_clang_swift_name.swift

did not use the -n option. This should make the invocation of the
default tail command compatible with the one provided by coreutils.

<!-- What's in this pull request? -->
Pass the -n option to "tail" in order to be compatible with the version provided by coreutils.