### PR TITLE
[stdlib] Replace #elseif with #else for 64-bit platforms

### DIFF
--- a/stdlib/private/SwiftPrivate/PRNG.swift
+++ b/stdlib/private/SwiftPrivate/PRNG.swift
@@ -29,10 +29,8 @@ public func rand64() -> UInt64 {
 public func randInt() -> Int {
 #if arch(i386) || arch(arm)
   return Int(Int32(bitPattern: rand32()))
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
-  return Int(Int64(bitPattern: rand64()))
 #else
-  fatalError("unimplemented")
+  return Int(Int64(bitPattern: rand64()))
 #endif
 }
 

--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -143,7 +143,7 @@ public // @testable
 func _mixUInt(_ value: UInt) -> UInt {
 #if arch(i386) || arch(arm)
   return UInt(_mixUInt32(UInt32(value)))
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
+#else
   return UInt(_mixUInt64(UInt64(value)))
 #endif
 }
@@ -154,7 +154,7 @@ public // @testable
 func _mixInt(_ value: Int) -> Int {
 #if arch(i386) || arch(arm)
   return Int(_mixInt32(Int32(value)))
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
+#else
   return Int(_mixInt64(Int64(value)))
 #endif
 }
@@ -207,7 +207,7 @@ func _combineHashValues(_ firstValue: Int, _ secondValue: Int) -> Int {
   // (0x1.9e3779b97f4a7c15f39cc0605cedc8341082276bf3a27251f86c6a11d0c18e95p0).
 #if arch(i386) || arch(arm)
   let magic = 0x9e3779b9 as UInt
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
+#else
   let magic = 0x9e3779b97f4a7c15 as UInt
 #endif
   var x = UInt(bitPattern: firstValue)

--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -212,7 +212,7 @@ internal func _stdlib_atomicCompareExchangeStrongInt(
 #if arch(i386) || arch(arm)
   let (oldValue, won) = Builtin.cmpxchg_seqcst_seqcst_Int32(
     target._rawValue, expected.pointee._value, desired._value)
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
+#else
   let (oldValue, won) = Builtin.cmpxchg_seqcst_seqcst_Int64(
     target._rawValue, expected.pointee._value, desired._value)
 #endif
@@ -227,7 +227,7 @@ internal func _swift_stdlib_atomicStoreInt(
   desired: Int) {
 #if arch(i386) || arch(arm)
   Builtin.atomicstore_seqcst_Int32(target._rawValue, desired._value)
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
+#else
   Builtin.atomicstore_seqcst_Int64(target._rawValue, desired._value)
 #endif
 }
@@ -239,7 +239,7 @@ public func _swift_stdlib_atomicLoadInt(
 #if arch(i386) || arch(arm)
   let value = Builtin.atomicload_seqcst_Int32(target._rawValue)
   return Int(value)
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
+#else
   let value = Builtin.atomicload_seqcst_Int64(target._rawValue)
   return Int(value)
 #endif
@@ -269,7 +269,7 @@ public func _swift_stdlib_atomicFetch${operation}Int(
   let value = _swift_stdlib_atomicFetch${operation}Int32(
     object: rawTarget.assumingMemoryBound(to: Int32.self),
     operand: Int32(operand))
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
+#else
   let value = _swift_stdlib_atomicFetch${operation}Int64(
     object: rawTarget.assumingMemoryBound(to: Int64.self),
     operand: Int64(operand))

--- a/stdlib/public/core/SipHash.swift.gyb
+++ b/stdlib/public/core/SipHash.swift.gyb
@@ -264,7 +264,7 @@ struct ${Self} {
     let hash: UInt64 = finalizeAndReturnHash()
 #if arch(i386) || arch(arm)
     return Int(truncatingIfNeeded: hash)
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
+#else
     return Int(Int64(bitPattern: hash))
 #endif
   }


### PR DESCRIPTION
As discussed in #14386:

> It seems unnecessarily fragile/verbose to list all supported 64-bit architectures[...]. We did go with #else in the new String implementation[...]

This PR removes the list of supported 64-bit architectures from non-test code in the standard library. (It'll be fine to continue testing only specifically enumerated architectures.)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->