### PR TITLE
[WIP] [Parse] Add _pointer_bit_width platform condition

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -43,7 +43,7 @@ namespace swift {
     Arch,
     /// The active arch target endianness (big or little)
     Endianness,
-    /// The active arch target pointer bit width (32 or 64)
+    /// The active arch target pointer bit width (_32 or _64)
     PointerBitWidth,
     /// Runtime support (_ObjC or _Native)
     Runtime,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -41,10 +41,10 @@ namespace swift {
     OS,
     /// The active arch target (x86_64, i386, arm, arm64, etc.)
     Arch,
-    /// The active endianness target (big or little)
+    /// The active arch target endianness (big or little)
     Endianness,
-    /// The active native word size target (32 or 64)
-    NativeWordSize,
+    /// The active arch target pointer bit width (32 or 64)
+    PointerBitWidth,
     /// Runtime support (_ObjC or _Native)
     Runtime,
     /// Conditional import of module

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -43,11 +43,13 @@ namespace swift {
     Arch,
     /// The active endianness target (big or little)
     Endianness,
+    /// The active native word size target (32 or 64)
+    NativeWordSize,
     /// Runtime support (_ObjC or _Native)
     Runtime,
     /// Conditional import of module
     CanImport,
-    /// Target Environment (currently just 'simulator' or absent)
+    /// Target environment (currently just 'simulator' or absent)
     TargetEnvironment,
   };
 
@@ -360,7 +362,7 @@ namespace swift {
     }
 
   private:
-    llvm::SmallVector<std::pair<PlatformConditionKind, std::string>, 5>
+    llvm::SmallVector<std::pair<PlatformConditionKind, std::string>, 6>
         PlatformConditionValues;
     llvm::SmallVector<std::string, 2> CustomConditionalCompilationFlags;
   };

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -57,8 +57,8 @@ static const StringRef SupportedConditionalCompilationEndianness[] = {
 };
 
 static const StringRef SupportedConditionalCompilationPointerBitWidths[] = {
-  "32",
-  "64"
+  "_32",
+  "_64"
 };
 
 static const StringRef SupportedConditionalCompilationRuntimes[] = {
@@ -268,25 +268,25 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   switch (Target.getArch()) {
   case llvm::Triple::ArchType::arm:
   case llvm::Triple::ArchType::thumb:
-    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "32");
+    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "_32");
     break;
   case llvm::Triple::ArchType::aarch64:
-    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "64");
+    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "_64");
     break;
   case llvm::Triple::ArchType::ppc64:
-    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "64");
+    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "_64");
     break;
   case llvm::Triple::ArchType::ppc64le:
-    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "64");
+    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "_64");
     break;
   case llvm::Triple::ArchType::x86:
-    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "32");
+    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "_32");
     break;
   case llvm::Triple::ArchType::x86_64:
-    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "64");
+    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "_64");
     break;
   case llvm::Triple::ArchType::systemz:
-    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "64");
+    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "_64");
     break;
   default:
     llvm_unreachable("undefined architecture pointer bit width");

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -56,6 +56,11 @@ static const StringRef SupportedConditionalCompilationEndianness[] = {
   "big"
 };
 
+static const StringRef SupportedConditionalCompilationNativeWordSizes[] = {
+  "32",
+  "64"
+};
+
 static const StringRef SupportedConditionalCompilationRuntimes[] = {
   "_ObjC",
   "_Native",
@@ -100,6 +105,9 @@ checkPlatformConditionSupported(PlatformConditionKind Kind, StringRef Value,
                     suggestions);
   case PlatformConditionKind::Endianness:
     return contains(SupportedConditionalCompilationEndianness, Value,
+                    suggestions);
+  case PlatformConditionKind::NativeWordSize:
+    return contains(SupportedConditionalCompilationNativeWordSizes, Value,
                     suggestions);
   case PlatformConditionKind::Runtime:
     return contains(SupportedConditionalCompilationRuntimes, Value,
@@ -254,6 +262,34 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
     break;
   default:
     llvm_unreachable("undefined architecture endianness");
+  }
+
+  // Set the "_native_word_size" platform condition.
+  switch (Target.getArch()) {
+  case llvm::Triple::ArchType::arm:
+  case llvm::Triple::ArchType::thumb:
+    addPlatformConditionValue(PlatformConditionKind::NativeWordSize, "32");
+    break;
+  case llvm::Triple::ArchType::aarch64:
+    addPlatformConditionValue(PlatformConditionKind::NativeWordSize, "64");
+    break;
+  case llvm::Triple::ArchType::ppc64:
+    addPlatformConditionValue(PlatformConditionKind::NativeWordSize, "64");
+    break;
+  case llvm::Triple::ArchType::ppc64le:
+    addPlatformConditionValue(PlatformConditionKind::NativeWordSize, "64");
+    break;
+  case llvm::Triple::ArchType::x86:
+    addPlatformConditionValue(PlatformConditionKind::NativeWordSize, "32");
+    break;
+  case llvm::Triple::ArchType::x86_64:
+    addPlatformConditionValue(PlatformConditionKind::NativeWordSize, "64");
+    break;
+  case llvm::Triple::ArchType::systemz:
+    addPlatformConditionValue(PlatformConditionKind::NativeWordSize, "64");
+    break;
+  default:
+    llvm_unreachable("undefined architecture native word size");
   }
 
   // Set the "runtime" platform condition.

--- a/lib/Basic/LangOptions.cpp
+++ b/lib/Basic/LangOptions.cpp
@@ -56,7 +56,7 @@ static const StringRef SupportedConditionalCompilationEndianness[] = {
   "big"
 };
 
-static const StringRef SupportedConditionalCompilationNativeWordSizes[] = {
+static const StringRef SupportedConditionalCompilationPointerBitWidths[] = {
   "32",
   "64"
 };
@@ -106,8 +106,8 @@ checkPlatformConditionSupported(PlatformConditionKind Kind, StringRef Value,
   case PlatformConditionKind::Endianness:
     return contains(SupportedConditionalCompilationEndianness, Value,
                     suggestions);
-  case PlatformConditionKind::NativeWordSize:
-    return contains(SupportedConditionalCompilationNativeWordSizes, Value,
+  case PlatformConditionKind::PointerBitWidth:
+    return contains(SupportedConditionalCompilationPointerBitWidths, Value,
                     suggestions);
   case PlatformConditionKind::Runtime:
     return contains(SupportedConditionalCompilationRuntimes, Value,
@@ -268,28 +268,28 @@ std::pair<bool, bool> LangOptions::setTarget(llvm::Triple triple) {
   switch (Target.getArch()) {
   case llvm::Triple::ArchType::arm:
   case llvm::Triple::ArchType::thumb:
-    addPlatformConditionValue(PlatformConditionKind::NativeWordSize, "32");
+    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "32");
     break;
   case llvm::Triple::ArchType::aarch64:
-    addPlatformConditionValue(PlatformConditionKind::NativeWordSize, "64");
+    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "64");
     break;
   case llvm::Triple::ArchType::ppc64:
-    addPlatformConditionValue(PlatformConditionKind::NativeWordSize, "64");
+    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "64");
     break;
   case llvm::Triple::ArchType::ppc64le:
-    addPlatformConditionValue(PlatformConditionKind::NativeWordSize, "64");
+    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "64");
     break;
   case llvm::Triple::ArchType::x86:
-    addPlatformConditionValue(PlatformConditionKind::NativeWordSize, "32");
+    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "32");
     break;
   case llvm::Triple::ArchType::x86_64:
-    addPlatformConditionValue(PlatformConditionKind::NativeWordSize, "64");
+    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "64");
     break;
   case llvm::Triple::ArchType::systemz:
-    addPlatformConditionValue(PlatformConditionKind::NativeWordSize, "64");
+    addPlatformConditionValue(PlatformConditionKind::PointerBitWidth, "64");
     break;
   default:
-    llvm_unreachable("undefined architecture native word size");
+    llvm_unreachable("undefined architecture pointer bit width");
   }
 
   // Set the "runtime" platform condition.

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -40,6 +40,7 @@ Optional<PlatformConditionKind> getPlatformConditionKind(StringRef Name) {
     .Case("os", PlatformConditionKind::OS)
     .Case("arch", PlatformConditionKind::Arch)
     .Case("_endian", PlatformConditionKind::Endianness)
+    .Case("_native_word_size", PlatformConditionKind::NativeWordSize)
     .Case("_runtime", PlatformConditionKind::Runtime)
     .Case("canImport", PlatformConditionKind::CanImport)
     .Case("targetEnvironment", PlatformConditionKind::TargetEnvironment)
@@ -296,7 +297,7 @@ public:
       return E;
     }
 
-    // ( 'os' | 'arch' | '_endian' | '_runtime' | 'canImport') '(' identifier ')''
+    // ( 'os' | 'arch' | '_endian' | '_native_word_size' | '_runtime' | 'canImport') '(' identifier ')''
     auto Kind = getPlatformConditionKind(*KindName);
     if (!Kind.hasValue()) {
       D.diagnose(E->getLoc(), diag::unsupported_platform_condition_expression);
@@ -329,6 +330,8 @@ public:
         DiagName = "architecture"; break;
       case PlatformConditionKind::Endianness:
         DiagName = "endianness"; break;
+      case PlatformConditionKind::NativeWordSize:
+        DiagName = "native word size"; break;
       case PlatformConditionKind::CanImport:
         DiagName = "import conditional"; break;
       case PlatformConditionKind::TargetEnvironment:

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -40,7 +40,7 @@ Optional<PlatformConditionKind> getPlatformConditionKind(StringRef Name) {
     .Case("os", PlatformConditionKind::OS)
     .Case("arch", PlatformConditionKind::Arch)
     .Case("_endian", PlatformConditionKind::Endianness)
-    .Case("_native_word_size", PlatformConditionKind::NativeWordSize)
+    .Case("_pointer_bit_width", PlatformConditionKind::PointerBitWidth)
     .Case("_runtime", PlatformConditionKind::Runtime)
     .Case("canImport", PlatformConditionKind::CanImport)
     .Case("targetEnvironment", PlatformConditionKind::TargetEnvironment)
@@ -297,7 +297,7 @@ public:
       return E;
     }
 
-    // ( 'os' | 'arch' | '_endian' | '_native_word_size' | '_runtime' | 'canImport') '(' identifier ')''
+    // ( 'os' | 'arch' | '_endian' | '_pointer_bit_width' | '_runtime' | 'canImport') '(' identifier ')''
     auto Kind = getPlatformConditionKind(*KindName);
     if (!Kind.hasValue()) {
       D.diagnose(E->getLoc(), diag::unsupported_platform_condition_expression);
@@ -330,8 +330,8 @@ public:
         DiagName = "architecture"; break;
       case PlatformConditionKind::Endianness:
         DiagName = "endianness"; break;
-      case PlatformConditionKind::NativeWordSize:
-        DiagName = "native word size"; break;
+      case PlatformConditionKind::PointerBitWidth:
+        DiagName = "pointer bit width"; break;
       case PlatformConditionKind::CanImport:
         DiagName = "import conditional"; break;
       case PlatformConditionKind::TargetEnvironment:

--- a/test/Parse/ConditionalCompilation/arm64AppleTVOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/arm64AppleTVOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(arm64) && os(tvOS) && _runtime(_ObjC) && _endian(little)
+#if arch(arm64) && os(tvOS) && _runtime(_ObjC) && _endian(little) && _native_word_size(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/arm64AppleTVOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/arm64AppleTVOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(arm64) && os(tvOS) && _runtime(_ObjC) && _endian(little) && _native_word_size(64)
+#if arch(arm64) && os(tvOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/arm64AppleTVOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/arm64AppleTVOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(arm64) && os(tvOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(64)
+#if arch(arm64) && os(tvOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(_64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/arm64IOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/arm64IOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(arm64) && os(iOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(64)
+#if arch(arm64) && os(iOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(_64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/arm64IOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/arm64IOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(arm64) && os(iOS) && _runtime(_ObjC) && _endian(little)
+#if arch(arm64) && os(iOS) && _runtime(_ObjC) && _endian(little) && _native_word_size(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/arm64IOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/arm64IOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(arm64) && os(iOS) && _runtime(_ObjC) && _endian(little) && _native_word_size(64)
+#if arch(arm64) && os(iOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/armAndroidTarget.swift
+++ b/test/Parse/ConditionalCompilation/armAndroidTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(arm) && os(Android) && _runtime(_Native) && _endian(little) && _native_word_size(32)
+#if arch(arm) && os(Android) && _runtime(_Native) && _endian(little) && _pointer_bit_width(32)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/armAndroidTarget.swift
+++ b/test/Parse/ConditionalCompilation/armAndroidTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(arm) && os(Android) && _runtime(_Native) && _endian(little) && _pointer_bit_width(32)
+#if arch(arm) && os(Android) && _runtime(_Native) && _endian(little) && _pointer_bit_width(_32)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/armAndroidTarget.swift
+++ b/test/Parse/ConditionalCompilation/armAndroidTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(arm) && os(Android) && _runtime(_Native) && _endian(little)
+#if arch(arm) && os(Android) && _runtime(_Native) && _endian(little) && _native_word_size(32)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/armIOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/armIOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(arm) && os(iOS) && _runtime(_ObjC) && _endian(little)
+#if arch(arm) && os(iOS) && _runtime(_ObjC) && _endian(little) && _native_word_size(32)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/armIOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/armIOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(arm) && os(iOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(32)
+#if arch(arm) && os(iOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(_32)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/armIOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/armIOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(arm) && os(iOS) && _runtime(_ObjC) && _endian(little) && _native_word_size(32)
+#if arch(arm) && os(iOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(32)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/armWatchOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/armWatchOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(arm) && os(watchOS) && _runtime(_ObjC) && _endian(little)
+#if arch(arm) && os(watchOS) && _runtime(_ObjC) && _endian(little) && _native_word_size(32)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/armWatchOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/armWatchOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(arm) && os(watchOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(32)
+#if arch(arm) && os(watchOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(_32)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/armWatchOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/armWatchOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(arm) && os(watchOS) && _runtime(_ObjC) && _endian(little) && _native_word_size(32)
+#if arch(arm) && os(watchOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(32)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/i386AppleTVOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/i386AppleTVOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(i386) && os(tvOS) && _runtime(_ObjC) && _endian(little) && _native_word_size(32)
+#if arch(i386) && os(tvOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(32)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/i386AppleTVOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/i386AppleTVOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(i386) && os(tvOS) && _runtime(_ObjC) && _endian(little)
+#if arch(i386) && os(tvOS) && _runtime(_ObjC) && _endian(little) && _native_word_size(32)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/i386AppleTVOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/i386AppleTVOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(i386) && os(tvOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(32)
+#if arch(i386) && os(tvOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(_32)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/i386IOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/i386IOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(i386) && os(iOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(32)
+#if arch(i386) && os(iOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(_32)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/i386IOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/i386IOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(i386) && os(iOS) && _runtime(_ObjC) && _endian(little)
+#if arch(i386) && os(iOS) && _runtime(_ObjC) && _endian(little) && _native_word_size(32)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/i386IOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/i386IOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(i386) && os(iOS) && _runtime(_ObjC) && _endian(little) && _native_word_size(32)
+#if arch(i386) && os(iOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(32)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/i386WatchOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/i386WatchOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(i386) && os(watchOS) && _runtime(_ObjC) && _endian(little) && _native_word_size(32)
+#if arch(i386) && os(watchOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(32)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/i386WatchOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/i386WatchOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(i386) && os(watchOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(32)
+#if arch(i386) && os(watchOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(_32)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/i386WatchOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/i386WatchOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(i386) && os(watchOS) && _runtime(_ObjC) && _endian(little)
+#if arch(i386) && os(watchOS) && _runtime(_ObjC) && _endian(little) && _native_word_size(32)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/identifierName.swift
+++ b/test/Parse/ConditionalCompilation/identifierName.swift
@@ -5,7 +5,7 @@
 func f2(
   FOO: Int,
   swift: Int, _compiler_version: Int,
-  os: Int, arch: Int, _endian: Int, _native_word_size: Int, _runtime: Int,
+  os: Int, arch: Int, _endian: Int, _pointer_bit_width: Int, _runtime: Int,
   targetEnvironment: Int,
   arm: Int, i386: Int, macOS: Int, OSX: Int, Linux: Int,
   big: Int, little: Int,
@@ -21,8 +21,8 @@ func f2(
   _ = arch + i386 + arm
 #elseif _endian(big) && _endian(little)
   _ = _endian + big + little
-#elseif _native_word_size(32) && _native_word_size(64)
-  _ = _native_word_size
+#elseif _pointer_bit_width(32) && _pointer_bit_width(64)
+  _ = _pointer_bit_width
 #elseif _runtime(_ObjC) && _runtime(_Native)
   _ = _runtime + _ObjC + _Native
 #elseif swift(>=1.0) && _compiler_version("3.*.0")
@@ -36,7 +36,7 @@ func f2(
 func f2() {
   let
     FOO = 1, swift = 1, _compiler_version = 1,
-    os = 1, arch = 1, _endian = 1, _native_word_size = 1, _runtime = 1,
+    os = 1, arch = 1, _endian = 1, _pointer_bit_width = 1, _runtime = 1,
     targetEnvironment = 1,
     arm = 1, i386 = 1, macOS = 1, OSX = 1, Linux = 1,
     big = 1, little = 1,
@@ -51,8 +51,8 @@ func f2() {
   _ = arch + i386 + arm
 #elseif _endian(big) && _endian(little)
   _ = _endian + big + little
-#elseif _native_word_size(32) && _native_word_size(64)
-  _ = _native_word_size
+#elseif _pointer_bit_width(32) && _pointer_bit_width(64)
+  _ = _pointer_bit_width
 #elseif _runtime(_ObjC) && _runtime(_Native)
   _ = _runtime + _ObjC + _Native
 #elseif swift(>=1.0) && _compiler_version("3.*.0")
@@ -66,7 +66,7 @@ func f2() {
 struct S {
   let
     FOO = 1, swift = 1, _compiler_version = 1,
-    os = 1, arch = 1, _endian = 1, _native_word_size = 1, _runtime = 1,
+    os = 1, arch = 1, _endian = 1, _pointer_bit_width = 1, _runtime = 1,
     targetEnvironment = 1,
     arm = 1, i386 = 1, macOS = 1, OSX = 1, Linux = 1,
     big = 1, little = 1,
@@ -77,7 +77,7 @@ struct S {
 #elseif os(macOS) && os(OSX) && os(Linux)
 #elseif arch(i386) && arch(arm)
 #elseif _endian(big) && _endian(little)
-#elseif _native_word_size(32) && _native_word_size(64)
+#elseif _pointer_bit_width(32) && _pointer_bit_width(64)
 #elseif _runtime(_ObjC) && _runtime(_Native)
 #elseif swift(>=1.0) && _compiler_version("3.*.0")
 #elseif targetEnvironment(simulator)

--- a/test/Parse/ConditionalCompilation/identifierName.swift
+++ b/test/Parse/ConditionalCompilation/identifierName.swift
@@ -5,7 +5,7 @@
 func f2(
   FOO: Int,
   swift: Int, _compiler_version: Int,
-  os: Int, arch: Int, _endian: Int, _runtime: Int,
+  os: Int, arch: Int, _endian: Int, _native_word_size: Int, _runtime: Int,
   targetEnvironment: Int,
   arm: Int, i386: Int, macOS: Int, OSX: Int, Linux: Int,
   big: Int, little: Int,
@@ -21,6 +21,8 @@ func f2(
   _ = arch + i386 + arm
 #elseif _endian(big) && _endian(little)
   _ = _endian + big + little
+#elseif _native_word_size(32) && _native_word_size(64)
+  _ = _native_word_size
 #elseif _runtime(_ObjC) && _runtime(_Native)
   _ = _runtime + _ObjC + _Native
 #elseif swift(>=1.0) && _compiler_version("3.*.0")
@@ -34,7 +36,7 @@ func f2(
 func f2() {
   let
     FOO = 1, swift = 1, _compiler_version = 1,
-    os = 1, arch = 1, _endian = 1, _runtime = 1,
+    os = 1, arch = 1, _endian = 1, _native_word_size = 1, _runtime = 1,
     targetEnvironment = 1,
     arm = 1, i386 = 1, macOS = 1, OSX = 1, Linux = 1,
     big = 1, little = 1,
@@ -49,6 +51,8 @@ func f2() {
   _ = arch + i386 + arm
 #elseif _endian(big) && _endian(little)
   _ = _endian + big + little
+#elseif _native_word_size(32) && _native_word_size(64)
+  _ = _native_word_size
 #elseif _runtime(_ObjC) && _runtime(_Native)
   _ = _runtime + _ObjC + _Native
 #elseif swift(>=1.0) && _compiler_version("3.*.0")
@@ -62,7 +66,7 @@ func f2() {
 struct S {
   let
     FOO = 1, swift = 1, _compiler_version = 1,
-    os = 1, arch = 1, _endian = 1, _runtime = 1,
+    os = 1, arch = 1, _endian = 1, _native_word_size = 1, _runtime = 1,
     targetEnvironment = 1,
     arm = 1, i386 = 1, macOS = 1, OSX = 1, Linux = 1,
     big = 1, little = 1,
@@ -73,6 +77,7 @@ struct S {
 #elseif os(macOS) && os(OSX) && os(Linux)
 #elseif arch(i386) && arch(arm)
 #elseif _endian(big) && _endian(little)
+#elseif _native_word_size(32) && _native_word_size(64)
 #elseif _runtime(_ObjC) && _runtime(_Native)
 #elseif swift(>=1.0) && _compiler_version("3.*.0")
 #elseif targetEnvironment(simulator)

--- a/test/Parse/ConditionalCompilation/identifierName.swift
+++ b/test/Parse/ConditionalCompilation/identifierName.swift
@@ -9,6 +9,7 @@ func f2(
   targetEnvironment: Int,
   arm: Int, i386: Int, macOS: Int, OSX: Int, Linux: Int,
   big: Int, little: Int,
+  _32: Int, _64: Int,
   _ObjC: Int, _Native: Int,
   simulator: Int
 ) {
@@ -21,8 +22,8 @@ func f2(
   _ = arch + i386 + arm
 #elseif _endian(big) && _endian(little)
   _ = _endian + big + little
-#elseif _pointer_bit_width(32) && _pointer_bit_width(64)
-  _ = _pointer_bit_width
+#elseif _pointer_bit_width(_32) && _pointer_bit_width(_64)
+  _ = _pointer_bit_width + _32 + _64
 #elseif _runtime(_ObjC) && _runtime(_Native)
   _ = _runtime + _ObjC + _Native
 #elseif swift(>=1.0) && _compiler_version("3.*.0")
@@ -40,6 +41,7 @@ func f2() {
     targetEnvironment = 1,
     arm = 1, i386 = 1, macOS = 1, OSX = 1, Linux = 1,
     big = 1, little = 1,
+    _32 = 1, _64 = 1,
     _ObjC = 1, _Native = 1,
     simulator = 1
 
@@ -51,8 +53,8 @@ func f2() {
   _ = arch + i386 + arm
 #elseif _endian(big) && _endian(little)
   _ = _endian + big + little
-#elseif _pointer_bit_width(32) && _pointer_bit_width(64)
-  _ = _pointer_bit_width
+#elseif _pointer_bit_width(_32) && _pointer_bit_width(_64)
+  _ = _pointer_bit_width + _32 + _64
 #elseif _runtime(_ObjC) && _runtime(_Native)
   _ = _runtime + _ObjC + _Native
 #elseif swift(>=1.0) && _compiler_version("3.*.0")
@@ -70,6 +72,7 @@ struct S {
     targetEnvironment = 1,
     arm = 1, i386 = 1, macOS = 1, OSX = 1, Linux = 1,
     big = 1, little = 1,
+    _32 = 1, _64 = 1,
     _ObjC = 1, _Native = 1,
     simulator = 1
 
@@ -77,7 +80,7 @@ struct S {
 #elseif os(macOS) && os(OSX) && os(Linux)
 #elseif arch(i386) && arch(arm)
 #elseif _endian(big) && _endian(little)
-#elseif _pointer_bit_width(32) && _pointer_bit_width(64)
+#elseif _pointer_bit_width(_32) && _pointer_bit_width(_64)
 #elseif _runtime(_ObjC) && _runtime(_Native)
 #elseif swift(>=1.0) && _compiler_version("3.*.0")
 #elseif targetEnvironment(simulator)

--- a/test/Parse/ConditionalCompilation/powerpc64LinuxTarget.swift
+++ b/test/Parse/ConditionalCompilation/powerpc64LinuxTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -D FOO -D BAR -target powerpc64-unknown-linux-gnu -disable-objc-interop -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target powerpc64-unknown-linux-gnu
 
-#if arch(powerpc64) && os(Linux) && _runtime(_Native) && _endian(big)
+#if arch(powerpc64) && os(Linux) && _runtime(_Native) && _endian(big) && _native_word_size(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/powerpc64LinuxTarget.swift
+++ b/test/Parse/ConditionalCompilation/powerpc64LinuxTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -D FOO -D BAR -target powerpc64-unknown-linux-gnu -disable-objc-interop -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target powerpc64-unknown-linux-gnu
 
-#if arch(powerpc64) && os(Linux) && _runtime(_Native) && _endian(big) && _pointer_bit_width(64)
+#if arch(powerpc64) && os(Linux) && _runtime(_Native) && _endian(big) && _pointer_bit_width(_64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/powerpc64LinuxTarget.swift
+++ b/test/Parse/ConditionalCompilation/powerpc64LinuxTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -D FOO -D BAR -target powerpc64-unknown-linux-gnu -disable-objc-interop -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target powerpc64-unknown-linux-gnu
 
-#if arch(powerpc64) && os(Linux) && _runtime(_Native) && _endian(big) && _native_word_size(64)
+#if arch(powerpc64) && os(Linux) && _runtime(_Native) && _endian(big) && _pointer_bit_width(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/powerpc64leLinuxTarget.swift
+++ b/test/Parse/ConditionalCompilation/powerpc64leLinuxTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -D FOO -D BAR -target powerpc64le-unknown-linux-gnu -disable-objc-interop -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target powerpc64le-unknown-linux-gnu
 
-#if arch(powerpc64le) && os(Linux) && _runtime(_Native) && _endian(little) && _pointer_bit_width(64)
+#if arch(powerpc64le) && os(Linux) && _runtime(_Native) && _endian(little) && _pointer_bit_width(_64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/powerpc64leLinuxTarget.swift
+++ b/test/Parse/ConditionalCompilation/powerpc64leLinuxTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -D FOO -D BAR -target powerpc64le-unknown-linux-gnu -disable-objc-interop -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target powerpc64le-unknown-linux-gnu
 
-#if arch(powerpc64le) && os(Linux) && _runtime(_Native) && _endian(little)
+#if arch(powerpc64le) && os(Linux) && _runtime(_Native) && _endian(little) && _native_word_size(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/powerpc64leLinuxTarget.swift
+++ b/test/Parse/ConditionalCompilation/powerpc64leLinuxTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -D FOO -D BAR -target powerpc64le-unknown-linux-gnu -disable-objc-interop -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target powerpc64le-unknown-linux-gnu
 
-#if arch(powerpc64le) && os(Linux) && _runtime(_Native) && _endian(little) && _native_word_size(64)
+#if arch(powerpc64le) && os(Linux) && _runtime(_Native) && _endian(little) && _pointer_bit_width(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/s390xLinuxTarget.swift
+++ b/test/Parse/ConditionalCompilation/s390xLinuxTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -D FOO -D BAR -target s390x-unknown-linux-gnu -disable-objc-interop -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target s390x-unknown-linux-gnu
 
-#if arch(s390x) && os(Linux) && _runtime(_Native) && _endian(big) && _pointer_bit_width(64)
+#if arch(s390x) && os(Linux) && _runtime(_Native) && _endian(big) && _pointer_bit_width(_64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/s390xLinuxTarget.swift
+++ b/test/Parse/ConditionalCompilation/s390xLinuxTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -D FOO -D BAR -target s390x-unknown-linux-gnu -disable-objc-interop -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target s390x-unknown-linux-gnu
 
-#if arch(s390x) && os(Linux) && _runtime(_Native) && _endian(big) && _native_word_size(64)
+#if arch(s390x) && os(Linux) && _runtime(_Native) && _endian(big) && _pointer_bit_width(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/s390xLinuxTarget.swift
+++ b/test/Parse/ConditionalCompilation/s390xLinuxTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -D FOO -D BAR -target s390x-unknown-linux-gnu -disable-objc-interop -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target s390x-unknown-linux-gnu
 
-#if arch(s390x) && os(Linux) && _runtime(_Native) && _endian(big)
+#if arch(s390x) && os(Linux) && _runtime(_Native) && _endian(big) && _native_word_size(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64AppleTVOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64AppleTVOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(x86_64) && os(tvOS) && _runtime(_ObjC) && _endian(little) && _native_word_size(64)
+#if arch(x86_64) && os(tvOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64AppleTVOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64AppleTVOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(x86_64) && os(tvOS) && _runtime(_ObjC) && _endian(little)
+#if arch(x86_64) && os(tvOS) && _runtime(_ObjC) && _endian(little) && _native_word_size(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64AppleTVOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64AppleTVOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(x86_64) && os(tvOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(64)
+#if arch(x86_64) && os(tvOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(_64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64CygwinTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64CygwinTarget.swift
@@ -1,6 +1,6 @@
 // RUN: %swift -parse %s -verify -D FOO -D BAR -target x86_64-unknown-windows-cygnus -disable-objc-interop -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-unknown-windows-cygnus
-#if arch(x86_64) && os(Cygwin) && _runtime(_Native) && _pointer_bit_width(64)
+#if arch(x86_64) && os(Cygwin) && _runtime(_Native) && _pointer_bit_width(_64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64CygwinTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64CygwinTarget.swift
@@ -1,6 +1,6 @@
 // RUN: %swift -parse %s -verify -D FOO -D BAR -target x86_64-unknown-windows-cygnus -disable-objc-interop -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-unknown-windows-cygnus
-#if arch(x86_64) && os(Cygwin) && _runtime(_Native)
+#if arch(x86_64) && os(Cygwin) && _runtime(_Native) && _native_word_size(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64CygwinTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64CygwinTarget.swift
@@ -1,6 +1,6 @@
 // RUN: %swift -parse %s -verify -D FOO -D BAR -target x86_64-unknown-windows-cygnus -disable-objc-interop -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-unknown-windows-cygnus
-#if arch(x86_64) && os(Cygwin) && _runtime(_Native) && _native_word_size(64)
+#if arch(x86_64) && os(Cygwin) && _runtime(_Native) && _pointer_bit_width(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64FreeBSDTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64FreeBSDTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -D FOO -D BAR -target x86_64-unknown-freebsd10 -disable-objc-interop -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-unknown-freebsd10
 
-#if arch(x86_64) && os(FreeBSD) && _runtime(_Native) && _endian(little) && _native_word_size(64)
+#if arch(x86_64) && os(FreeBSD) && _runtime(_Native) && _endian(little) && _pointer_bit_width(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64FreeBSDTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64FreeBSDTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -D FOO -D BAR -target x86_64-unknown-freebsd10 -disable-objc-interop -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-unknown-freebsd10
 
-#if arch(x86_64) && os(FreeBSD) && _runtime(_Native) && _endian(little) && _pointer_bit_width(64)
+#if arch(x86_64) && os(FreeBSD) && _runtime(_Native) && _endian(little) && _pointer_bit_width(_64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64FreeBSDTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64FreeBSDTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -D FOO -D BAR -target x86_64-unknown-freebsd10 -disable-objc-interop -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-unknown-freebsd10
 
-#if arch(x86_64) && os(FreeBSD) && _runtime(_Native) && _endian(little)
+#if arch(x86_64) && os(FreeBSD) && _runtime(_Native) && _endian(little) && _native_word_size(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64IOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64IOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(x86_64) && os(iOS) && _runtime(_ObjC) && _endian(little)
+#if arch(x86_64) && os(iOS) && _runtime(_ObjC) && _endian(little) && _native_word_size(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64IOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64IOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(x86_64) && os(iOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(64)
+#if arch(x86_64) && os(iOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(_64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64IOSTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64IOSTarget.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(x86_64) && os(iOS) && _runtime(_ObjC) && _endian(little) && _native_word_size(64)
+#if arch(x86_64) && os(iOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64LinuxTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64LinuxTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -D FOO -D BAR -target x86_64-unknown-linux-gnu -disable-objc-interop -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-unknown-linux-gnu
 
-#if arch(x86_64) && os(Linux) && _runtime(_Native) && _endian(little) && _pointer_bit_width(64)
+#if arch(x86_64) && os(Linux) && _runtime(_Native) && _endian(little) && _pointer_bit_width(_64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64LinuxTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64LinuxTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -D FOO -D BAR -target x86_64-unknown-linux-gnu -disable-objc-interop -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-unknown-linux-gnu
 
-#if arch(x86_64) && os(Linux) && _runtime(_Native) && _endian(little)
+#if arch(x86_64) && os(Linux) && _runtime(_Native) && _endian(little) && _native_word_size(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64LinuxTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64LinuxTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -D FOO -D BAR -target x86_64-unknown-linux-gnu -disable-objc-interop -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-unknown-linux-gnu
 
-#if arch(x86_64) && os(Linux) && _runtime(_Native) && _endian(little) && _native_word_size(64)
+#if arch(x86_64) && os(Linux) && _runtime(_Native) && _endian(little) && _pointer_bit_width(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64OSXTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64OSXTarget.swift
@@ -1,14 +1,14 @@
 // RUN: %swift -typecheck %s -verify -D FOO -D BAR -target x86_64-apple-macosx10.9 -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-apple-macosx10.9
 
-#if arch(x86_64) && os(OSX) && _runtime(_ObjC) && _endian(little)
+#if arch(x86_64) && os(OSX) && _runtime(_ObjC) && _endian(little) && _native_word_size(64)
 class C {}
 var x = C()
 #endif
 var y = x
 
 
-#if arch(x86_64) && os(macOS) && _runtime(_ObjC) && _endian(little)
+#if arch(x86_64) && os(macOS) && _runtime(_ObjC) && _endian(little) && _native_word_size(64)
 class CC {}
 var xx = CC()
 #endif

--- a/test/Parse/ConditionalCompilation/x64OSXTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64OSXTarget.swift
@@ -1,14 +1,14 @@
 // RUN: %swift -typecheck %s -verify -D FOO -D BAR -target x86_64-apple-macosx10.9 -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-apple-macosx10.9
 
-#if arch(x86_64) && os(OSX) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(64)
+#if arch(x86_64) && os(OSX) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(_64)
 class C {}
 var x = C()
 #endif
 var y = x
 
 
-#if arch(x86_64) && os(macOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(64)
+#if arch(x86_64) && os(macOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(_64)
 class CC {}
 var xx = CC()
 #endif

--- a/test/Parse/ConditionalCompilation/x64OSXTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64OSXTarget.swift
@@ -1,14 +1,14 @@
 // RUN: %swift -typecheck %s -verify -D FOO -D BAR -target x86_64-apple-macosx10.9 -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-apple-macosx10.9
 
-#if arch(x86_64) && os(OSX) && _runtime(_ObjC) && _endian(little) && _native_word_size(64)
+#if arch(x86_64) && os(OSX) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(64)
 class C {}
 var x = C()
 #endif
 var y = x
 
 
-#if arch(x86_64) && os(macOS) && _runtime(_ObjC) && _endian(little) && _native_word_size(64)
+#if arch(x86_64) && os(macOS) && _runtime(_ObjC) && _endian(little) && _pointer_bit_width(64)
 class CC {}
 var xx = CC()
 #endif

--- a/test/Parse/ConditionalCompilation/x64WindowsTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64WindowsTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -D FOO -D BAR -target x86_64-unknown-windows-msvc -disable-objc-interop -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-unknown-windows-msvc
 
-#if arch(x86_64) && os(Windows) && _runtime(_Native) && _endian(little) && _pointer_bit_width(64)
+#if arch(x86_64) && os(Windows) && _runtime(_Native) && _endian(little) && _pointer_bit_width(_64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64WindowsTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64WindowsTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -D FOO -D BAR -target x86_64-unknown-windows-msvc -disable-objc-interop -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-unknown-windows-msvc
 
-#if arch(x86_64) && os(Windows) && _runtime(_Native) && _endian(little) && _native_word_size(64)
+#if arch(x86_64) && os(Windows) && _runtime(_Native) && _endian(little) && _pointer_bit_width(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x64WindowsTarget.swift
+++ b/test/Parse/ConditionalCompilation/x64WindowsTarget.swift
@@ -1,7 +1,7 @@
 // RUN: %swift -typecheck %s -verify -D FOO -D BAR -target x86_64-unknown-windows-msvc -disable-objc-interop -D FOO -parse-stdlib
 // RUN: %swift-ide-test -test-input-complete -source-filename=%s -target x86_64-unknown-windows-msvc
 
-#if arch(x86_64) && os(Windows) && _runtime(_Native) && _endian(little)
+#if arch(x86_64) && os(Windows) && _runtime(_Native) && _endian(little) && _native_word_size(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x86_64PS4Target.swift
+++ b/test/Parse/ConditionalCompilation/x86_64PS4Target.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(x86_64) && os(PS4) && _runtime(_Native) && _endian(little) && _native_word_size(64)
+#if arch(x86_64) && os(PS4) && _runtime(_Native) && _endian(little) && _pointer_bit_width(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x86_64PS4Target.swift
+++ b/test/Parse/ConditionalCompilation/x86_64PS4Target.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(x86_64) && os(PS4) && _runtime(_Native) && _endian(little)
+#if arch(x86_64) && os(PS4) && _runtime(_Native) && _endian(little) && _native_word_size(64)
 class C {}
 var x = C()
 #endif

--- a/test/Parse/ConditionalCompilation/x86_64PS4Target.swift
+++ b/test/Parse/ConditionalCompilation/x86_64PS4Target.swift
@@ -7,7 +7,7 @@
 let i: Int = "Hello"
 #endif
 
-#if arch(x86_64) && os(PS4) && _runtime(_Native) && _endian(little) && _pointer_bit_width(64)
+#if arch(x86_64) && os(PS4) && _runtime(_Native) && _endian(little) && _pointer_bit_width(_64)
 class C {}
 var x = C()
 #endif


### PR DESCRIPTION
Instead of explicitly listing each platform when testing for the native word size (which, per documentation, is the bit width of `Int`), add an explicit (underscored) platform conditional.

This supersedes the solution discussed in #14386 and #14409.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
