### PR TITLE
mangling: remove the round-trip check for mangled runtime names

### DIFF
--- a/include/swift/Basic/Mangler.h
+++ b/include/swift/Basic/Mangler.h
@@ -109,7 +109,6 @@ protected:
 
   /// Verify that demangling and remangling works.
   static void verify(StringRef mangledName);
-  static void verifyOld(StringRef mangledName);
 
   void dump();
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -476,7 +476,6 @@ std::string ASTMangler::mangleObjCRuntimeName(const NominalTypeDecl *Nominal) {
   Node *NewGlobal = Dem.createNode(Node::Kind::Global);
   NewGlobal->addChild(TyMangling, Dem);
   std::string OldName = mangleNodeOld(NewGlobal);
-  verifyOld(OldName);
   return OldName;
 #endif
 }

--- a/lib/Basic/Mangler.cpp
+++ b/lib/Basic/Mangler.cpp
@@ -197,35 +197,6 @@ void Mangler::verify(StringRef nameStr) {
 #endif
 }
 
-void Mangler::verifyOld(StringRef nameStr) {
-#ifndef NDEBUG
-  Demangler Dem;
-  NodePointer Root = demangleOldSymbolAsNode(nameStr, Dem);
-  if (!Root || treeContains(Root, Node::Kind::Suffix)) {
-    llvm::errs() << "Can't demangle: " << nameStr << '\n';
-    abort();
-  }
-  std::string Remangled = mangleNodeOld(Root);
-  if (Remangled == nameStr)
-    return;
-
-  // There are cases (e.g. with dependent associated types) which results in
-  // different remangled names. See ASTMangler::appendAssociatedTypeName.
-  // This is no problem for the compiler, but we have to be more tolerant for
-  // those cases. Instead we try to re-de-mangle the remangled name.
-  NodePointer RootOfRemangled = Dem.demangleSymbol(Remangled);
-  std::string ReDemangled = mangleNode(RootOfRemangled);
-  if (Remangled == ReDemangled)
-    return;
-
-  llvm::errs() << "Remangling failed:\n"
-  "original     = " << nameStr << "\n"
-  "remangled    = " << Remangled << "\n"
-  "re-demangled = " << ReDemangled << '\n';
-  abort();
-#endif
-}
-
 void Mangler::appendIdentifier(StringRef ident) {
   auto Iter = StringSubstitutions.find(ident);
   if (Iter != StringSubstitutions.end())


### PR DESCRIPTION
 ... in the old mangling scheme

This check doesn't make sense anymore because we are still making changes to the old remangler, but not to the old demangler.
Also, this check didn't work in most cases anyway.

rdar://problem/37241935
