### PR TITLE
[Runtime] Enable -Wall for the builds.

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -13,6 +13,10 @@ if(SWIFT_RUNTIME_USE_SANITIZERS)
   endif()
 endif()
 
+# Build the runtime with -Wall to catch, e.g., uninitialized variables
+# warnings.
+list(APPEND SWIFT_RUNTIME_CXX_FLAGS "-Wall")
+
 set(SWIFT_RUNTIME_CORE_CXX_FLAGS "${SWIFT_RUNTIME_CXX_FLAGS}")
 set(SWIFT_RUNTIME_CORE_LINK_FLAGS "${SWIFT_RUNTIME_LINK_FLAGS}")
 


### PR DESCRIPTION
This helps catching trivial mistakes & UB, e.g. uninitialized
booleans, see, e.g. https://github.com/apple/swift/pull/14400

Verified this now triggers on, e.g. SwiftRemoteAST.

```
[1/2] /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang++   -DCMARK_STATIC_DEFINE -DGTEST_HAS_RTTI=0 -D_DEBUG -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -Ilib/RemoteAST -I/Users/dcci/work/swift/swift/lib/RemoteAST -Iinclude -I/Users/dcci/work/swift/swift/include -I/Users/dcci/work/swift/llvm/include -I/Users/dcci/work/swift/build/Ninja-RelWithDebInfoAssert/llvm-macosx-x86_64/include -I/Users/dcci/work/swift/build/Ninja-RelWithDebInfoAssert/llvm-macosx-x86_64/tools/clang/include -I/Users/dcci/work/swift/llvm/tools/clang/include -I/Users/dcci/work/swift/cmark/src -I/Users/dcci/work/swift/build/Ninja-RelWithDebInfoAssert/cmark-macosx-x86_64/src -Wno-unknown-warning-option -Werror=unguarded-availability-new -fno-stack-protector -stdlib=libc++ -fPIC -fvisibility-inlines-hidden -Werror=date-time -Werror=unguarded-availability-new -std=c++11 -Wall -W -Wno-unused-parameter -Wwrite-strings -Wcast-qual -Wmissing-field-initializers -Wcovered-switch-default -Wnon-virtual-dtor -Wdelete-non-virtual-dtor -Wstring-conversion -fcolor-diagnostics -Werror=switch -Wdocumentation -Wimplicit-fallthrough -Wunreachable-code -Woverloaded-virtual -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -O2  -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk   -UNDEBUG  -fno-exceptions -fno-rtti -target x86_64-apple-macosx10.9 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk -arch x86_64 -F /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.13.sdk/../../../Developer/Library/Frameworks -mmacosx-version-min=10.9 -O2 -g -UNDEBUG -DSWIFT_ENABLE_RUNTIME_FUNCTION_COUNTERS -MD -MT lib/RemoteAST/CMakeFiles/swiftRemoteAST.dir/RemoteAST.cpp.o -MF lib/RemoteAST/CMakeFiles/swiftRemoteAST.dir/RemoteAST.cpp.o.d -o lib/RemoteAST/CMakeFiles/swiftRemoteAST.dir/RemoteAST.cpp.o -c /Users/dcci/work/swift/swift/lib/RemoteAST/RemoteAST.cpp
```

I'm not a build system expert, so, if this needs to be implemented in a different way (or extended), please let me know.