### PR TITLE
[4.1] Fix two issues which prevents incremental llvm compilation

### DIFF
--- a/test/DebugInfo/compiler-flags.swift
+++ b/test/DebugInfo/compiler-flags.swift
@@ -21,3 +21,8 @@
 // CHECK-LLDB-NOT: debug_pubnames
 // CHECK-LLDB:     apple_names
 // CHECK-LLDB-NOT: debug_pubnames
+
+// Check that we don't write temporary file names in the debug info
+// RUN: TMPDIR=abc/def %target-swift-frontend %s -I abc/def/xyz -g -emit-ir -o - | %FileCheck --check-prefix CHECK-TEMP %s
+// CHECK-TEMP: !DICompileUnit({{.*}} flags: "{{.*}} -I <temporary-file>
+


### PR DESCRIPTION
## CCC Info
* **Radar**: rdar://problem/37253518
* **Explanation**:
There are two problems with non-determinism:
  * Temporary file pathes written into debug info
  * A peephole optimization in SILCombine

These problems almost always prevent incremental llvm compilation: that means in whole-module mode, all llvm modules are recompiled even if they don't change.
* **Risk**: Low. The changes are small and only affect the command line we store in the debug info +  a fix in SILCombine. The generated code should be the same (module non-determinism)
* **Scope of issue**: Can affect build time for whole-module release builds.
* **Origination**: The issues are there since a long time
* **Reviewed by**: Adrian and Jordan
* **Testing**: Recompile a large project in release mode and check if the output object file is not rewritten if there are no source changes. Currently we don't have an automated test for this. I'm doing that locally with the stdlib build.