### PR TITLE
[build-script] Presets Module

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -988,9 +988,8 @@ def main_preset():
 
     try:
         preset_parser.read(args.preset_file_names)
-    except presets.UnparsedFilesError as e:
-        diagnostics.fatal('unable to parse preset files {}'
-                          .format(e.message))
+    except presets.Error as e:
+        diagnostics.fatal(e.message)
 
     if args.show_presets:
         for name in sorted(preset_parser.preset_names(),
@@ -1009,14 +1008,8 @@ def main_preset():
     try:
         preset = preset_parser.get_preset(args.preset,
                                           vars=args.preset_substitutions)
-    except presets.InterpolationError as e:
-        diagnostics.fatal('missing value for substitution "{}" in preset "{}"'
-                          .format(e.message, args.preset))
-    except presets.MissingOptionError as e:
-        diagnostics.fatal('missing option(s) for preset "{}": {}'
-                          .format(args.preset, e.message))
-    except presets.PresetNotFoundError:
-        diagnostics.fatal('preset "{}" not found'.format(args.preset))
+    except presets.Error as e:
+        diagnostics.fatal(e.message)
 
     preset_args = migrate_swift_sdks(preset.format_args())
 

--- a/utils/build-script
+++ b/utils/build-script
@@ -20,6 +20,8 @@ import time
 
 from build_swift import defaults
 from build_swift import driver_arguments
+from build_swift import presets
+from build_swift.migration import migrate_swift_sdks
 
 from swift_build_support.swift_build_support import (
     arguments,
@@ -32,16 +34,12 @@ from swift_build_support.swift_build_support import (
     targets,
     workspace
 )
-
 from swift_build_support.swift_build_support.SwiftBuildSupport import (
     HOME,
     SWIFT_BUILD_ROOT,
     SWIFT_REPO_NAME,
     SWIFT_SOURCE_ROOT,
-    get_all_preset_names,
-    get_preset_options,
 )
-
 from swift_build_support.swift_build_support.cmake import CMake
 from swift_build_support.swift_build_support.targets import \
     StdlibDeploymentTarget
@@ -977,15 +975,26 @@ def main_preset():
 
     if len(args.preset_file_names) == 0:
         args.preset_file_names = [
-            os.path.join(HOME, ".swift-build-presets"),
             os.path.join(
                 SWIFT_SOURCE_ROOT, SWIFT_REPO_NAME, "utils",
                 "build-presets.ini")
         ]
 
+        user_presets_file = os.path.join(HOME, '.swift-build-presets')
+        if os.path.isfile(user_presets_file):
+            args.preset_file_names.append(user_presets_file)
+
+    preset_parser = presets.PresetParser()
+
+    try:
+        preset_parser.read(args.preset_file_names)
+    except presets.UnparsedFilesError as e:
+        diagnostics.fatal('unable to parse preset files {}'
+                          .format(e.message))
+
     if args.show_presets:
-        for name in sorted(get_all_preset_names(args.preset_file_names),
-                           key=str.lower):
+        for name in sorted(preset_parser.preset_names(),
+                           key=lambda name: name.lower()):
             print(name)
         return 0
 
@@ -993,26 +1002,36 @@ def main_preset():
         diagnostics.fatal("missing --preset option")
 
     args.preset_substitutions = {}
-
     for arg in args.preset_substitutions_raw:
         name, value = arg.split("=", 1)
         args.preset_substitutions[name] = value
 
-    preset_args = get_preset_options(
-        args.preset_substitutions, args.preset_file_names, args.preset)
+    try:
+        preset = preset_parser.get_preset(args.preset,
+                                          vars=args.preset_substitutions)
+    except presets.InterpolationError as e:
+        diagnostics.fatal('missing value for substitution "{}" in preset "{}"'
+                          .format(e.message, args.preset))
+    except presets.MissingOptionError as e:
+        diagnostics.fatal('missing option(s) for preset "{}": {}'
+                          .format(args.preset, e.message))
+    except presets.PresetNotFoundError:
+        diagnostics.fatal('preset "{}" not found'.format(args.preset))
+
+    preset_args = migrate_swift_sdks(preset.format_args())
 
     build_script_args = [sys.argv[0]]
     if args.dry_run:
         build_script_args += ["--dry-run"]
+
     build_script_args += preset_args
     if args.distcc:
         build_script_args += ["--distcc"]
     if args.build_jobs:
         build_script_args += ["--jobs", str(args.build_jobs)]
 
-    diagnostics.note(
-        "using preset '" + args.preset + "', which expands to \n\n" +
-        shell.quote_command(build_script_args) + "\n")
+    diagnostics.note('using preset "{}", which expands to \n\n{}\n'.format(
+        args.preset, shell.quote_command(build_script_args)))
 
     if args.expand_build_script_invocation:
         return 0

--- a/utils/build_swift/migration.py
+++ b/utils/build_swift/migration.py
@@ -1,0 +1,83 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+"""
+Temporary module with functionaly used to migrate away from build-script-impl.
+"""
+
+
+from swift_build_support.swift_build_support.targets import \
+    StdlibDeploymentTarget
+
+
+__all__ = [
+    'UnknownSDKError',
+    'migrate_swift_sdks',
+]
+
+
+_SDK_TARGETS = {
+    'OSX': StdlibDeploymentTarget.OSX.targets,
+    'IOS': StdlibDeploymentTarget.iOS.targets,
+    'IOS_SIMULATOR': StdlibDeploymentTarget.iOSSimulator.targets,
+    'TVOS': StdlibDeploymentTarget.AppleTV.targets,
+    'TVOS_SIMULATOR': StdlibDeploymentTarget.AppleTVSimulator.targets,
+    'WATCHOS': StdlibDeploymentTarget.AppleWatch.targets,
+    'WATCHOS_SIMULATOR': StdlibDeploymentTarget.AppleWatchSimulator.targets,
+}
+
+
+# -----------------------------------------------------------------------------
+
+class UnknownSDKError(Exception):
+    """Error indicating an unknown SDK was encountered when migrating to target
+    triples.
+    """
+
+    pass
+
+
+def _swift_sdks_to_stdlib_targets(swift_sdks):
+    stdlib_targets = []
+    for sdk in swift_sdks:
+        sdk_targets = _SDK_TARGETS.get(sdk, None)
+        if sdk_targets is None:
+            raise UnknownSDKError(sdk)
+        stdlib_targets += sdk_targets
+
+    return stdlib_targets
+
+
+def migrate_swift_sdks(args):
+    """Migrate usages of the now deprecated `--swift-sdks` option to the new
+    `--stdlib-deployment-targets` option, converting Swift SDKs to the
+    corresponding targets. Since argument parsing is a last-wins scenario, only
+    the last `--swift-sdks` option is migrated, all others are removed.
+
+    This function is a stop-gap to replacing all instances of `--swift-sdks`.
+    """
+
+    swift_sdks_args = [arg for arg in args if arg.startswith('--swift-sdks')]
+
+    if len(swift_sdks_args) < 1:
+        return args
+
+    # Only get the last --swift-sdks arg since last-wins
+    swift_sdks_arg = swift_sdks_args[-1]
+
+    sdk_list = swift_sdks_arg.split('=')[1].split(';')
+    stdlib_targets = _swift_sdks_to_stdlib_targets(sdk_list)
+
+    target_names = ' '.join([target.name for target in stdlib_targets])
+    stdlib_targets_arg = '--stdlib-deployment-targets=' + target_names
+
+    args = [arg for arg in args if not arg.startswith('--swift-sdks')]
+    args.append(stdlib_targets_arg)
+
+    return args

--- a/utils/build_swift/migration.py
+++ b/utils/build_swift/migration.py
@@ -11,6 +11,7 @@
 Temporary module with functionaly used to migrate away from build-script-impl.
 """
 
+from __future__ import absolute_import, unicode_literals
 
 from swift_build_support.swift_build_support.targets import \
     StdlibDeploymentTarget

--- a/utils/build_swift/presets.py
+++ b/utils/build_swift/presets.py
@@ -1,0 +1,247 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+"""
+Swift preset parsing and handling functionality.
+"""
+
+
+from collections import namedtuple
+from copy import copy
+
+try:
+    # Python 3
+    import configparser
+    from io import StringIO
+except ImportError:
+    import ConfigParser as configparser
+    from StringIO import StringIO
+
+
+__all__ = [
+    'Preset',
+    'PresetParser',
+
+    'InterpolationError',
+    'MissingOptionError',
+    'PresetNotFoundError',
+    'UnparsedFilesError',
+]
+
+
+# -----------------------------------------------------------------------------
+
+_RawPreset = namedtuple('_RawPreset', ['name', 'mixins', 'args'])
+
+
+def _interpolate_string(string, values):
+    if string is None:
+        return string
+
+    try:
+        return string % values
+    except KeyError as e:
+        raise InterpolationError(e.message)
+
+
+def _remove_prefix(string, prefix):
+    if string.startswith(prefix):
+        return string[len(prefix):]
+    return string
+
+
+# -----------------------------------------------------------------------------
+
+class InterpolationError(Exception):
+    """Error indicating a filaure while interpolating variables in preset
+    argument values.
+    """
+
+    pass
+
+
+class MissingOptionError(Exception):
+    """Error indicating a missing option while parsing presets.
+    """
+
+    pass
+
+
+class PresetNotFoundError(Exception):
+    """Error indicating failure when attempting to get a preset.
+    """
+
+    pass
+
+
+class UnparsedFilesError(Exception):
+    """Error indicating failure when parsing preset files.
+    """
+
+    pass
+
+
+class Preset(namedtuple('Preset', ['name', 'args'])):
+    """Container class used to wrap preset names and expanded argument lists.
+    """
+
+    # Keeps memory costs low according to the docs
+    __slots__ = ()
+
+    def format_args(self):
+        """Format argument pairs for use in the command line.
+        """
+
+        args = []
+        for (name, value) in self.args:
+            if value is None:
+                args.append(name)
+            else:
+                args.append('{}={}'.format(name, value))
+
+        return args
+
+
+# -----------------------------------------------------------------------------
+
+class PresetParser(object):
+    """Parser class used to read and manipulate Swift preset files.
+    """
+
+    _PRESET_PREFIX = 'preset: '
+
+    def __init__(self):
+        self._parser = configparser.RawConfigParser(allow_no_value=True)
+        self._presets = {}
+
+    def _parse_raw_preset(self, section):
+        preset_name = _remove_prefix(section, PresetParser._PRESET_PREFIX)
+
+        try:
+            section_items = self._parser.items(section)
+        except configparser.InterpolationMissingOptionError as e:
+            raise MissingOptionError(e)
+
+        args, mixins = [], []
+        for (name, value) in section_items:
+            # Ignore the '--' separator, it's no longer necessary
+            if name == 'dash-dash':
+                continue
+
+            # Parse out mixin names
+            if name == 'mixin-preset':
+                mixins = list(map(lambda name: name.strip(),
+                                  value.strip().splitlines()))
+                continue
+
+            name = '--' + name  # Format as an option name
+            args.append((name, value))
+
+        return _RawPreset(preset_name, mixins, args)
+
+    def _parse_raw_presets(self):
+        for section in self._parser.sections():
+            raw_preset = self._parse_raw_preset(section)
+            self._presets[raw_preset.name] = raw_preset
+
+    def read(self, filenames):
+        """Reads and parses preset files. Throws an UnparsedFilesError if any
+        of the files couldn't be read.
+        """
+
+        parsed_files = self._parser.read(filenames)
+
+        unparsed_files = set(filenames) - set(parsed_files)
+        if len(unparsed_files) > 0:
+            raise UnparsedFilesError(list(unparsed_files))
+
+        self._parse_raw_presets()
+
+    def read_file(self, file):
+        """Reads and parses a single file.
+        """
+
+        self.read([file])
+
+    def read_string(self, string):
+        """Reads and parses a string containing preset definintions.
+        """
+
+        fp = StringIO(unicode(string))
+
+        # ConfigParser changes drastically from Python 2 to 3
+        if hasattr(self._parser, 'read_file'):
+            self._parser.read_file(fp)
+        else:
+            self._parser.readfp(fp)
+
+        self._parse_raw_presets()
+
+    def _get_preset(self, name):
+        preset = self._presets.get(name)
+        if preset is None:
+            raise PresetNotFoundError(name)
+
+        if isinstance(preset, _RawPreset):
+            preset = self._resolve_preset_mixins(preset)
+
+            # Cache resolved preset
+            self._presets[name] = preset
+
+        return preset
+
+    def _resolve_preset_mixins(self, raw_preset):
+        """Resolve all mixins in a preset, fully expanding the arguments list.
+        """
+
+        assert isinstance(raw_preset, _RawPreset)
+
+        # Expand mixin arguments
+        args = copy(raw_preset.args)
+        for mixin_name in raw_preset.mixins:
+            mixin = self._get_preset(mixin_name)
+
+            args += mixin.args
+
+        return Preset(raw_preset.name, args)
+
+    def _interpolate_preset_vars(self, preset, vars):
+        interpolated_args = []
+        for (name, value) in preset.args:
+            value = _interpolate_string(value, vars)
+            interpolated_args.append((name, value))
+
+        return Preset(preset.name, interpolated_args)
+
+    def get_preset(self, name, raw=False, vars=None):
+        """Returns the preset with the requested name or throws a
+        PresetNotFoundError.
+
+        If raw is False vars will be interpolated into the preset arguments.
+        Otherwise presets will be returned without interpolation.
+
+        Presets are retrieved using a dynamic caching algorithm that expands
+        only the requested preset and it's mixins recursively. Every expanded
+        preset is then cached. All subsequent expansions or calls to
+        `get_preset` for any pre-expanded presets will use the cached results.
+        """
+
+        vars = vars or {}
+
+        preset = self._get_preset(name)
+        if not raw:
+            preset = self._interpolate_preset_vars(preset, vars)
+
+        return preset
+
+    def preset_names(self):
+        """Returns a list of all parsed preset names.
+        """
+
+        return self._presets.keys()

--- a/utils/build_swift/tests/test_migration.py
+++ b/utils/build_swift/tests/test_migration.py
@@ -1,0 +1,70 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+from .utils import TestCase
+from .. import migration
+
+
+def _get_sdk_targets(sdk_names):
+    targets = []
+    for sdk_name in sdk_names:
+        targets += migration._SDK_TARGETS[sdk_name]
+
+    return targets
+
+
+def _get_sdk_target_names(sdk_names):
+    return [target.name for target in _get_sdk_targets(sdk_names)]
+
+
+# -----------------------------------------------------------------------------
+
+class TestMigrateSwiftSDKsMeta(type):
+    """Metaclass used to dynamically generate test methods.
+    """
+
+    def __new__(cls, name, bases, attrs):
+        # Generate tests for migrating each Swift SDK
+        for sdk_name in migration._SDK_TARGETS.keys():
+            test_name = 'test_migrate_swift_sdk_' + sdk_name
+            attrs[test_name] = cls.generate_migrate_swift_sdks_test(sdk_name)
+
+        return super(TestMigrateSwiftSDKsMeta, cls).__new__(
+            cls, name, bases, attrs)
+
+    @classmethod
+    def generate_migrate_swift_sdks_test(cls, sdk_name):
+        def test(self):
+            args = ['--swift-sdks={}'.format(sdk_name)]
+            args = migration.migrate_swift_sdks(args)
+
+            target_names = _get_sdk_target_names([sdk_name])
+            self.assertListEqual(args, [
+                '--stdlib-deployment-targets={}'.format(' '.join(target_names))
+            ])
+
+        return test
+
+
+class TestMigrateSwiftSDKs(TestCase):
+
+    __metaclass__ = TestMigrateSwiftSDKsMeta
+
+    def test_multiple_swift_sdk_flags(self):
+        args = [
+            '--swift-sdks=OSX',
+            '--swift-sdks=OSX;IOS;IOS_SIMULATOR'
+        ]
+
+        args = migration.migrate_swift_sdks(args)
+        target_names = _get_sdk_target_names(['OSX', 'IOS', 'IOS_SIMULATOR'])
+
+        self.assertListEqual(args, [
+            '--stdlib-deployment-targets={}'.format(' '.join(target_names))
+        ])

--- a/utils/build_swift/tests/test_migration.py
+++ b/utils/build_swift/tests/test_migration.py
@@ -7,7 +7,9 @@
 # See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
-from .utils import TestCase
+from __future__ import absolute_import, unicode_literals
+
+from .utils import TestCase, add_metaclass
 from .. import migration
 
 
@@ -52,9 +54,8 @@ class TestMigrateSwiftSDKsMeta(type):
         return test
 
 
+@add_metaclass(TestMigrateSwiftSDKsMeta)
 class TestMigrateSwiftSDKs(TestCase):
-
-    __metaclass__ = TestMigrateSwiftSDKsMeta
 
     def test_multiple_swift_sdk_flags(self):
         args = [

--- a/utils/build_swift/tests/test_presets.py
+++ b/utils/build_swift/tests/test_presets.py
@@ -70,6 +70,24 @@ ios
 ios
 """
 
+IGNORED_SECTION = """
+[section_name]
+
+random-options=1
+"""
+
+MIXIN_ORDER_PRESETS = """
+[preset: test_mixin]
+first-opt=0
+second-opt=1
+
+
+[preset: test]
+first-opt=1
+mixin-preset=test_mixin
+second-opt=2
+"""
+
 
 # -----------------------------------------------------------------------------
 
@@ -152,6 +170,31 @@ class TestPresetParser(TestCase):
             (u'--verbose-build', None),
             (u'--build-ninja', None),
             (u'--install-symroot', u'/tmp')
+        ])
+
+    def test_parser_ignores_non_preset_sections(self):
+        parser = PresetParser()
+
+        parser.read_string(IGNORED_SECTION)
+        self.assertEqual(len(parser._presets), 0)
+
+    def test_mixin_expansion_preserves_argument_order(self):
+        """Mixins should be expanded in-place.
+        """
+
+        parser = PresetParser()
+
+        parser.read_string(MIXIN_ORDER_PRESETS)
+
+        preset = parser.get_preset('test')
+        self.assertListEqual(preset.format_args(), [
+            '--first-opt=1',
+
+            # Mixin arguments
+            '--first-opt=0',
+            '--second-opt=1',
+
+            '--second-opt=2',
         ])
 
     def test_duplicate_option_error(self):

--- a/utils/build_swift/tests/test_presets.py
+++ b/utils/build_swift/tests/test_presets.py
@@ -1,0 +1,186 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+import os
+
+from .utils import TestCase, UTILS_PATH
+from ..presets import (InterpolationError, Preset, PresetNotFoundError,
+                       PresetParser, UnparsedFilesError)
+
+try:
+    # Python 3
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
+
+
+PRESET_FILES = [
+    os.path.join(UTILS_PATH, 'build-presets.ini'),
+]
+
+PRESET_DEFAULTS = {
+    'darwin_toolchain_alias': 'Alias',
+    'darwin_toolchain_bundle_identifier': 'BundleIdentifier',
+    'darwin_toolchain_display_name': 'DisplayName',
+    'darwin_toolchain_display_name_short': 'DispalyNameShort',
+    'darwin_toolchain_version': '1.0',
+    'darwin_toolchain_xctoolchain_name': 'default',
+    'extra_swift_args': '',
+    'install_destdir': '/tmp/install',
+    'install_symroot': '/tmp/install/symroot',
+    'install_toolchain_dir': '/tmp/install/toolchain',
+    'installable_package': '/tmp/install/pkg',
+    'swift_install_destdir': '/tmp/install/swift',
+    'symbols_package': '/path/to/symbols/package',
+}
+
+SAMPLE_PRESET = """
+[preset: sample]
+
+# This is a comment
+
+ios
+tvos
+watchos
+test
+validation-test
+lit-args=-v
+compiler-vendor=apple
+
+# The '--' argument is now unnecessary
+dash-dash
+
+verbose-build
+build-ninja
+
+# Default interpolation
+install-symroot=%(install_symroot)s
+"""
+
+INVALID_PRESET = """
+[preset: invalid]
+
+ios
+ios
+"""
+
+
+# -----------------------------------------------------------------------------
+
+class TestPreset(TestCase):
+
+    def test_format_args(self):
+        preset = Preset('sample', [('--ios', None), ('--test', '1')])
+
+        self.assertEqual(preset.format_args(), ['--ios', '--test=1'])
+
+
+# -----------------------------------------------------------------------------
+
+class TestPresetParserMeta(type):
+    """Metaclass used to dynamically generate test methods to validate all of
+    the available presets.
+    """
+
+    def __new__(cls, name, bases, attrs):
+        preset_parser = PresetParser()
+        preset_parser.read(PRESET_FILES)
+
+        # Generate tests for each preset
+        for preset_name in preset_parser.preset_names():
+            test_name = 'test_get_preset_' + preset_name
+            attrs[test_name] = cls.generate_get_preset_test(
+                preset_parser, preset_name)
+
+        return super(TestPresetParserMeta, cls).__new__(
+            cls, name, bases, attrs)
+
+    @classmethod
+    def generate_get_preset_test(cls, preset_parser, preset_name):
+        def test(self):
+            with self.assertNotRaises():
+                preset_parser.get_preset(preset_name, vars=PRESET_DEFAULTS)
+
+        return test
+
+
+class TestPresetParser(TestCase):
+
+    __metaclass__ = TestPresetParserMeta
+
+    def test_read(self):
+        parser = PresetParser()
+
+        with self.assertNotRaises():
+            parser.read(PRESET_FILES)
+
+    def test_read_invalid_files(self):
+        parser = PresetParser()
+
+        with self.assertRaises(UnparsedFilesError):
+            parser.read(['nonsense-presets.ini'])
+
+    def test_read_file(self):
+        parser = PresetParser()
+
+        with self.assertNotRaises():
+            parser.read_file(PRESET_FILES[0])
+
+    def test_read_string(self):
+        parser = PresetParser()
+
+        with self.assertNotRaises():
+            parser.read_string(SAMPLE_PRESET)
+
+        preset = parser.get_preset('sample', vars={'install_symroot': '/tmp'})
+        self.assertIsNotNone(preset)
+        self.assertEqual(preset.name, 'sample')
+        self.assertListEqual(preset.args, [
+            (u'--ios', None),
+            (u'--tvos', None),
+            (u'--watchos', None),
+            (u'--test', None),
+            (u'--validation-test', None),
+            (u'--lit-args', u'-v'),
+            (u'--compiler-vendor', u'apple'),
+            (u'--verbose-build', None),
+            (u'--build-ninja', None),
+            (u'--install-symroot', u'/tmp')
+        ])
+
+    def test_duplicate_option_error(self):
+        parser = PresetParser()
+
+        # Skip this test if using the Python 2 ConfigParser module
+        if not hasattr(configparser, 'DuplicateOptionError'):
+            return
+
+        with self.assertRaises(configparser.DuplicateOptionError):
+            parser.read_string(INVALID_PRESET)
+
+    def test_interpolation_error(self):
+        parser = PresetParser()
+        parser.read_string(SAMPLE_PRESET)
+
+        with self.assertRaises(InterpolationError):
+            parser.get_preset('sample')
+
+    def test_get_missing_preset(self):
+        parser = PresetParser()
+
+        with self.assertRaises(PresetNotFoundError):
+            parser.get_preset('preset')
+
+    def test_preset_names(self):
+        parser = PresetParser()
+
+        parser.read_string(SAMPLE_PRESET)
+        parser.read_string('[preset: test]\nios\n')
+
+        self.assertListEqual(parser.preset_names(), ['sample', 'test'])

--- a/utils/build_swift/tests/utils.py
+++ b/utils/build_swift/tests/utils.py
@@ -19,6 +19,7 @@ from contextlib import contextmanager
 
 
 __all__ = [
+    'add_metaclass',
     'redirect_stderr',
     'redirect_stdout',
     'TestCase',
@@ -35,6 +36,18 @@ UTILS_PATH = os.path.abspath(os.path.join(
 
 
 # -----------------------------------------------------------------------------
+
+def add_metaclass(metacls):
+    def wrapper(cls):
+        body = vars(cls).copy()
+
+        body.pop('__dict__', None)
+        body.pop('__weakref__', None)
+
+        return metacls(cls.__name__, cls.__bases__, body)
+
+    return wrapper
+
 
 @contextmanager
 def redirect_stderr(stream=None):

--- a/utils/build_swift/tests/utils.py
+++ b/utils/build_swift/tests/utils.py
@@ -22,7 +22,16 @@ __all__ = [
     'redirect_stderr',
     'redirect_stdout',
     'TestCase',
+
+    'UTILS_PATH',
 ]
+
+
+UTILS_PATH = os.path.abspath(os.path.join(
+    os.path.dirname(__file__),
+    os.pardir,
+    os.pardir,
+))
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
# Purpose

This PR implements a new `presets` module with a more robust and easy to understand presets parser compared to the `swift_build_support` implementation in `SwiftBuildSupport.py`. The `--swift-sdks` migration code has also been moved to a new `migration` module that will house functionality for eventually migrating away from `build-script-impl`.

There's testing for all the new functionality, both the `presets` and `migration` modules have associated test suites.

This furthers the efforts for completing [SR-237](https://bugs.swift.org/browse/SR-237)
rdar://25281853