### PR TITLE
SwiftSyntax: Teach SwiftSyntax to use SourceKit to serialize syntax trees.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -255,7 +255,7 @@ function(_add_variant_c_compile_flags)
   else()
     list(APPEND result "-DNDEBUG")
   endif()
-  
+
   if(SWIFT_ENABLE_RUNTIME_FUNCTION_COUNTERS)
     list(APPEND result "-DSWIFT_ENABLE_RUNTIME_FUNCTION_COUNTERS")
   endif()
@@ -320,7 +320,7 @@ function(_add_variant_swift_compile_flags
   if (SWIFT_ENABLE_GUARANTEED_NORMAL_ARGUMENTS)
     list(APPEND result "-Xfrontend" "-enable-guaranteed-normal-arguments")
   endif()
-  
+
   if(SWIFT_ENABLE_RUNTIME_FUNCTION_COUNTERS)
     list(APPEND result "-D" "SWIFT_ENABLE_RUNTIME_FUNCTION_COUNTERS")
   endif()
@@ -1605,7 +1605,7 @@ function(add_swift_library name)
         if(SWIFTLIB_IS_SDK_OVERLAY)
           list(APPEND swiftlib_swift_compile_flags_all "-Fsystem" "${SWIFT_SDK_${sdk}_PATH}/System/Library/PrivateFrameworks/")
         endif()
-       
+
        if("${sdk}" STREQUAL "IOS_SIMULATOR")
          if("${name}" STREQUAL "swiftMediaPlayer")
            message("DISABLING AUTOLINK FOR swiftMediaPlayer")
@@ -1854,7 +1854,7 @@ function(add_swift_library name)
           LIBRARY DESTINATION lib${LLVM_LIBDIR_SUFFIX}
           RUNTIME DESTINATION bin)
       swift_is_installing_component(dev is_installing)
-      
+
       if(NOT is_installing)
         set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${name})
       else()
@@ -2177,7 +2177,7 @@ function(add_swift_host_tool executable)
 
     swift_is_installing_component(${ADDSWIFTHOSTTOOL_SWIFT_COMPONENT}
       is_installing)
-  
+
     if(NOT is_installing)
       set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${executable})
     else()

--- a/test/SwiftSyntax/ParseFile.swift
+++ b/test/SwiftSyntax/ParseFile.swift
@@ -2,7 +2,6 @@
 // REQUIRES: executable_test
 // REQUIRES: OS=macosx
 // REQUIRES: objc_interop
-// REQUIRES: rdar36740859
 
 import Foundation
 import StdlibUnittest

--- a/test/SwiftSyntax/VisitorTest.swift
+++ b/test/SwiftSyntax/VisitorTest.swift
@@ -3,9 +3,6 @@
 // REQUIRES: OS=macosx
 // REQUIRES: objc_interop
 
-// FIXME: This test fails occassionally in CI with invalid json.
-// REQUIRES: disabled
-
 import StdlibUnittest
 import Foundation
 import SwiftSyntax

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -286,6 +286,7 @@ else:
     test_resource_dir = os.path.join(config.swift_lib_dir, 'swift')
     resource_dir_opt = ""
 stdlib_resource_dir_opt = resource_dir_opt
+sourcekitd_framework_dir = ("%s/.." % test_resource_dir)
 lit_config.note('Using resource dir: ' + test_resource_dir)
 
 # Parse the variant triple.
@@ -670,12 +671,13 @@ if run_vendor == 'apple':
             (run_cpu, run_os, run_vers, clang_mcp_opt))
 
         config.target_build_swift = (
-            "%s %s %s -F %s -Xlinker -rpath -Xlinker %s %s %s %s %s"
+            "%s %s %s -F %s -Xlinker -rpath -Xlinker %s %s %s %s %s -F %s -Xlinker -rpath -Xlinker %s"
             % (xcrun_prefix, config.swiftc, target_options,
                extra_frameworks_dir, extra_frameworks_dir,
                sdk_overlay_linker_opt, config.swift_test_options,
                config.swift_driver_test_options,
-               swift_execution_tests_extra_flags))
+               swift_execution_tests_extra_flags, sourcekitd_framework_dir,
+               sourcekitd_framework_dir))
         config.target_run = ""
 
         if 'interpret' in lit_config.params:

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -286,7 +286,7 @@ else:
     test_resource_dir = os.path.join(config.swift_lib_dir, 'swift')
     resource_dir_opt = ""
 stdlib_resource_dir_opt = resource_dir_opt
-sourcekitd_framework_dir = ("%s/.." % test_resource_dir)
+sourcekitd_framework_dir = config.swift_lib_dir
 lit_config.note('Using resource dir: ' + test_resource_dir)
 
 # Parse the variant triple.

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -16,10 +16,18 @@ add_swift_tool_subdirectory(swift-api-digester)
 add_swift_tool_subdirectory(swift-syntax-test)
 add_swift_tool_subdirectory(swift-refactor)
 
-if(SWIFT_BUILD_SOURCEKIT)
-  add_swift_tool_subdirectory(SourceKit)
+if (SWIFT_BUILD_SOURCEKIT AND SWIFT_BUILD_STDLIB AND SWIFT_BUILD_SDK_OVERLAY)
+  set(BUILD_SOURCEKIT_SWIFT_CLIENT TRUE)
+else()
+  set(BUILD_SOURCEKIT_SWIFT_CLIENT FALSE)
 endif()
 
+if(SWIFT_BUILD_SOURCEKIT)
+  add_swift_tool_subdirectory(SourceKit)
+  if(BUILD_SOURCEKIT_SWIFT_CLIENT)
+    add_subdirectory(SwiftSourceKitClient)
+  endif()
+endif()
 
 if(SWIFT_HOST_VARIANT STREQUAL "macosx")
   # Only build Darwin-specific tools when deploying to OS X.
@@ -28,7 +36,7 @@ if(SWIFT_HOST_VARIANT STREQUAL "macosx")
   # SwiftSyntax depends on both the standard library (because it's a
   # Swift module), and the SDK overlays (because it depends on Foundation).
   # Ensure we only build SwiftSyntax when we're building both.
-  if(SWIFT_BUILD_STDLIB AND SWIFT_BUILD_SDK_OVERLAY)
+  if(BUILD_SOURCEKIT_SWIFT_CLIENT)
     add_subdirectory(SwiftSyntax)
   endif()
 endif()

--- a/tools/SwiftSourceKitClient/CMakeLists.txt
+++ b/tools/SwiftSourceKitClient/CMakeLists.txt
@@ -1,0 +1,18 @@
+set(EXTRA_COMPILE_FLAGS "-F" "${SWIFT_LIBRARY_OUTPUT_INTDIR}")
+set(EXTRA_LINKER_FLAGS "-Xlinker" "-rpath" "-Xlinker" "${SWIFT_LIBRARY_OUTPUT_INTDIR}"
+    "-Xlinker" "-F" "-Xlinker" "${SWIFT_LIBRARY_OUTPUT_INTDIR}")
+
+add_swift_library(swiftSwiftSourceKit SHARED
+  # This file should be listed the first.  Module name is inferred from the
+  # filename.
+  SourceKitdClient.swift
+  SourceKitdRequest.swift
+  SourceKitdResponse.swift
+  SourceKitdUID.swift
+
+  SWIFT_COMPILE_FLAGS ${EXTRA_COMPILE_FLAGS}
+  LINK_FLAGS ${EXTRA_LINKER_FLAGS}
+  SWIFT_MODULE_DEPENDS Foundation
+  INSTALL_IN_COMPONENT swift-syntax
+  TARGET_SDKS OSX
+  IS_STDLIB)

--- a/tools/SwiftSourceKitClient/SourceKitdClient.swift
+++ b/tools/SwiftSourceKitClient/SourceKitdClient.swift
@@ -1,0 +1,28 @@
+//===--------------------- SourceKitdClient.swift -------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// This file provides a wrapper of SourceKitd service.
+//===----------------------------------------------------------------------===//
+
+import sourcekitd
+
+public class SourceKitdService {
+
+  public init() {
+    sourcekitd_initialize()
+  }
+  deinit {
+    sourcekitd_shutdown()
+  }
+  public func sendSyn(request: SourceKitdRequest) -> SourceKitdResponse {
+    return SourceKitdResponse(resp: sourcekitd_send_request_sync(request.rawRequest))
+  }
+}

--- a/tools/SwiftSourceKitClient/SourceKitdRequest.swift
+++ b/tools/SwiftSourceKitClient/SourceKitdRequest.swift
@@ -1,0 +1,154 @@
+//===--------------- SourceKitdRequest.swift ------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// This file provides a convenient way to build a sourcekitd request.
+//===----------------------------------------------------------------------===//
+
+import sourcekitd
+
+public struct SourceKitdRequest: CustomStringConvertible {
+
+  public class Dictionary: CustomStringConvertible {
+    let dict: sourcekitd_object_t
+
+    public init() {
+      dict = sourcekitd_request_dictionary_create(nil, nil, 0)
+    }
+
+    deinit {
+      sourcekitd_request_release(UnsafeMutableRawPointer(dict))
+    }
+
+    public func add(_ key: SourceKitdUID, value: String) {
+      sourcekitd_request_dictionary_set_string(dict, key.uid, value)
+    }
+
+    public func add(_ key: SourceKitdUID, value: Int) {
+      sourcekitd_request_dictionary_set_int64(dict, key.uid, Int64(value))
+    }
+
+    public func add(_ key: SourceKitdUID, value: SourceKitdUID) {
+      sourcekitd_request_dictionary_set_uid(dict, key.uid, value.uid)
+    }
+
+    public func add(_ key: SourceKitdUID, value: Array) {
+      sourcekitd_request_dictionary_set_value(dict, key.uid, value.arr)
+    }
+
+    public func add(_ key: SourceKitdUID, value: Dictionary) {
+      sourcekitd_request_dictionary_set_value(dict, key.uid, value.dict)
+    }
+
+    public func add(_ key: SourceKitdUID, value: Bool) {
+      sourcekitd_request_dictionary_set_int64(dict, key.uid, value ? 1 : 0)
+    }
+
+    public var description: String {
+      let utf8Str = sourcekitd_request_description_copy(dict)!
+      let result = String(cString: utf8Str)
+      free(utf8Str)
+      return result
+    }
+
+  }
+
+  public class Array: CustomStringConvertible {
+    let arr: sourcekitd_object_t
+    private let Append: Int = -1
+
+    public init() {
+      arr = sourcekitd_request_array_create(nil, 0)
+    }
+
+    deinit {
+      sourcekitd_request_release(arr)
+    }
+
+    public func add(_ value: String) {
+      sourcekitd_request_array_set_string(arr, Append, value)
+    }
+
+    public func add(_ value: Int) {
+      sourcekitd_request_array_set_int64(arr, Append, Int64(value))
+    }
+
+    public func add(_ value: SourceKitdUID) {
+      sourcekitd_request_array_set_uid(arr, Append, value.uid)
+    }
+
+    public func add(_ value: Dictionary) {
+      sourcekitd_request_array_set_value(arr, Append, value.dict)
+    }
+
+    public var description: String {
+      let utf8Str = sourcekitd_request_description_copy(arr)!
+      let result = String(cString: utf8Str)
+      free(utf8Str)
+      return result
+    }
+
+  }
+
+  private let req = Dictionary()
+
+  public init(uid: SourceKitdUID) {
+    req.add(SourceKitdUID.key_request, value: uid)
+  }
+
+  public func addParameter(_ key: SourceKitdUID, value: String) {
+    req.add(key, value: value)
+  }
+
+  public func addParameter(_ key: SourceKitdUID, value: Int) {
+    req.add(key, value: value)
+  }
+
+  public func addParameter(_ key: SourceKitdUID, value: SourceKitdUID) {
+    req.add(key, value: value)
+  }
+
+  public func addArrayParameter(_ key: SourceKitdUID) -> Array {
+    let arr = Array()
+    req.add(key, value: arr)
+    return arr
+  }
+
+  public func addDictionaryParameter(_ key: SourceKitdUID) -> Dictionary {
+    let dict = Dictionary()
+    req.add(key, value: dict)
+    return dict
+  }
+
+  public var description: String {
+    return req.description
+  }
+
+  public var rawRequest: sourcekitd_object_t {
+    return req.dict
+  }
+
+  public func addCompilerArgsToRequest(_ compilerArguments: [String]?,
+                                       _ bufferName: String? = nil) {
+    let args = self.addArrayParameter(SourceKitdUID.key_compilerargs)
+
+    if let compilerArguments = compilerArguments {
+      for argument in compilerArguments {
+        switch argument {
+        // Exclude some arguments which SourceKit doesn't want or need.
+        case "-Xfrontend":
+          break
+        default:
+          args.add(argument)
+        }
+      }
+    }
+  }
+}

--- a/tools/SwiftSourceKitClient/SourceKitdResponse.swift
+++ b/tools/SwiftSourceKitClient/SourceKitdResponse.swift
@@ -175,63 +175,15 @@ public class SourceKitdResponse: CustomStringConvertible {
       return Dictionary(dict: val)
     }
 
-    public func asAnyObject() -> AnyObject? {
-      switch sourcekitd_variant_get_type(val) {
-      case SOURCEKITD_VARIANT_TYPE_NULL:
-        return NSNull()
-      case SOURCEKITD_VARIANT_TYPE_DICTIONARY:
-        let dict = NSMutableDictionary()
-        _ = sourcekitd_variant_dictionary_apply(val) { (k, v) in
-          if let val = Variant(val: v).asAnyObject() {
-            dict.setValue(val, forKey: SourceKitdUID(uid: k!).asString)
-          }
-          return true
-        }
-        return dict
-      case SOURCEKITD_VARIANT_TYPE_ARRAY:
-        let arr = NSMutableArray()
-        _ = sourcekitd_variant_array_apply(val) { (_, v) in
-          arr.add(Variant(val: v).asAnyObject()!)
-          return true
-        }
-        return arr
-      case SOURCEKITD_VARIANT_TYPE_INT64:
-        return getInt() as NSNumber
-      case SOURCEKITD_VARIANT_TYPE_STRING:
-        return getString() as NSString
-      case SOURCEKITD_VARIANT_TYPE_UID:
-        return getUID().asString as NSString
-      case SOURCEKITD_VARIANT_TYPE_BOOL:
-        return getBool() as NSNumber
-      default:
-        assert(false, "unknown sourcekitd variant")
-        return nil
-      }
-    }
-
     public var description: String {
       return val.description
     }
-
   }
 
   private let resp: sourcekitd_response_t
 
   public var value: Dictionary {
     return Dictionary(dict: sourcekitd_response_get_value(resp))
-  }
-
-  /// An NSDictionary representing the response
-  public var nsdictionary: NSDictionary {
-    let dict = NSMutableDictionary()
-    _ = sourcekitd_variant_dictionary_apply(sourcekitd_response_get_value(resp))
-    { (k, v) in
-      if let val = Variant(val: v).asAnyObject() {
-        dict.setValue(val, forKey: SourceKitdUID(uid: k!).asString)
-      }
-      return true
-    }
-    return dict
   }
 
   /// Copies the raw bytes of the JSON description of this documentation item.

--- a/tools/SwiftSourceKitClient/SourceKitdResponse.swift
+++ b/tools/SwiftSourceKitClient/SourceKitdResponse.swift
@@ -1,0 +1,306 @@
+//===--------------------- SourceKitdResponse.swift -----------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// This file provides convenient APIs to interpret a SourceKitd response.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import sourcekitd
+
+public class SourceKitdResponse: CustomStringConvertible {
+
+  public struct Dictionary: CustomStringConvertible, CustomReflectable {
+    private let dict: sourcekitd_variant_t
+
+    public init(dict: sourcekitd_variant_t) {
+      assert(sourcekitd_variant_get_type(dict).rawValue ==
+        SOURCEKITD_VARIANT_TYPE_DICTIONARY.rawValue)
+      self.dict = dict
+    }
+
+    public func getString(_ key: SourceKitdUID) -> String {
+      let value = sourcekitd_variant_dictionary_get_string(dict, key.uid)!
+      return String(cString: value)
+    }
+
+    public func getInt(_ key: SourceKitdUID) -> Int {
+      let value = sourcekitd_variant_dictionary_get_int64(dict, key.uid)
+      return Int(value)
+    }
+
+    public func getBool(_ key: SourceKitdUID) -> Bool {
+      let value = sourcekitd_variant_dictionary_get_bool(dict, key.uid)
+      return value
+    }
+
+    public func getUID(_ key: SourceKitdUID) -> SourceKitdUID {
+      let value = sourcekitd_variant_dictionary_get_uid(dict, key.uid)!
+      return SourceKitdUID(uid: value)
+    }
+
+    public func getArray(_ key: SourceKitdUID) -> Array {
+      let value = sourcekitd_variant_dictionary_get_value(dict, key.uid)
+      return Array(arr: value)
+    }
+
+    public func getDictionary(_ key: SourceKitdUID) -> Dictionary {
+      let value = sourcekitd_variant_dictionary_get_value(dict, key.uid)
+      return Dictionary(dict: value)
+    }
+
+    public func getOptional(_ key: SourceKitdUID) -> Variant? {
+      let value = sourcekitd_variant_dictionary_get_value(dict, key.uid)
+      if sourcekitd_variant_get_type(value).rawValue ==
+          SOURCEKITD_VARIANT_TYPE_NULL.rawValue {
+        return nil
+      }
+      return Variant(val: value)
+    }
+
+    public var description: String {
+      return dict.description
+    }
+
+    public var customMirror: Mirror {
+      return Mirror(self, children: [:])
+    }
+  }
+
+  public struct Array: CustomStringConvertible {
+    private let arr: sourcekitd_variant_t
+
+    public var count: Int {
+      let count = sourcekitd_variant_array_get_count(arr)
+      return Int(count)
+    }
+
+    public init(arr: sourcekitd_variant_t) {
+      assert(sourcekitd_variant_get_type(arr).rawValue ==
+          SOURCEKITD_VARIANT_TYPE_ARRAY.rawValue)
+      self.arr = arr
+    }
+
+    public func getString(_ index: Int) -> String {
+      let value = sourcekitd_variant_array_get_string(arr, index)!
+      return String(cString: value)
+    }
+
+    public func getInt(_ index: Int) -> Int {
+      let value = sourcekitd_variant_array_get_int64(arr, index)
+      return Int(value)
+    }
+
+    public func getBool(_ index: Int) -> Bool {
+      let value = sourcekitd_variant_array_get_bool(arr, index)
+      return value
+    }
+
+    public func getUID(_ index: Int) -> SourceKitdUID {
+      let value = sourcekitd_variant_array_get_uid(arr, index)!
+      return SourceKitdUID(uid: value)
+    }
+
+    public func getArray(_ index: Int) -> Array {
+      let value = sourcekitd_variant_array_get_value(arr, index)
+      return Array(arr: value)
+    }
+
+    public func getDictionary(_ index: Int) -> Dictionary {
+      let value = sourcekitd_variant_array_get_value(arr, index)
+      return Dictionary(dict: value)
+    }
+
+    public func enumerate(_ applier: (_ index: Int, _ value: Variant) -> Bool) {
+      // The block passed to sourcekit_variant_array_apply() does not actually
+      // escape, it's synchronous and not called after returning.
+      withoutActuallyEscaping(applier) { escapingApplier in
+        _ = sourcekitd_variant_array_apply(arr) { (index, elem) -> Bool in
+          return escapingApplier(Int(index), Variant(val: elem))
+        }
+      }
+    }
+
+    public var description: String {
+      return arr.description
+    }
+
+  }
+
+  public struct Variant: CustomStringConvertible {
+    private let val: sourcekitd_variant_t
+
+    fileprivate init(val: sourcekitd_variant_t) {
+      self.val = val
+    }
+
+    public func getString() -> String {
+      let value = sourcekitd_variant_string_get_ptr(val)!
+      let length = sourcekitd_variant_string_get_length(val)
+      return fromCStringLen(value, length: length)!
+    }
+
+    public func getStringBuffer() -> UnsafeBufferPointer<Int8> {
+      return UnsafeBufferPointer(start: sourcekitd_variant_string_get_ptr(val),
+                                 count: sourcekitd_variant_string_get_length(val))
+    }
+
+    public func getInt() -> Int {
+      let value = sourcekitd_variant_int64_get_value(val)
+      return Int(value)
+    }
+
+    public func getBool() -> Bool {
+      let value = sourcekitd_variant_bool_get_value(val)
+      return value
+    }
+
+    public func getUID() -> SourceKitdUID {
+      let value = sourcekitd_variant_uid_get_value(val)!
+      return SourceKitdUID(uid:value)
+    }
+
+    public func getArray() -> Array {
+      return Array(arr: val)
+    }
+
+    public func getDictionary() -> Dictionary {
+      return Dictionary(dict: val)
+    }
+
+    public func asAnyObject() -> AnyObject? {
+      switch sourcekitd_variant_get_type(val) {
+      case SOURCEKITD_VARIANT_TYPE_NULL:
+        return NSNull()
+      case SOURCEKITD_VARIANT_TYPE_DICTIONARY:
+        let dict = NSMutableDictionary()
+        _ = sourcekitd_variant_dictionary_apply(val) { (k, v) in
+          if let val = Variant(val: v).asAnyObject() {
+            dict.setValue(val, forKey: SourceKitdUID(uid: k!).asString)
+          }
+          return true
+        }
+        return dict
+      case SOURCEKITD_VARIANT_TYPE_ARRAY:
+        let arr = NSMutableArray()
+        _ = sourcekitd_variant_array_apply(val) { (_, v) in
+          arr.add(Variant(val: v).asAnyObject()!)
+          return true
+        }
+        return arr
+      case SOURCEKITD_VARIANT_TYPE_INT64:
+        return getInt() as NSNumber
+      case SOURCEKITD_VARIANT_TYPE_STRING:
+        return getString() as NSString
+      case SOURCEKITD_VARIANT_TYPE_UID:
+        return getUID().asString as NSString
+      case SOURCEKITD_VARIANT_TYPE_BOOL:
+        return getBool() as NSNumber
+      default:
+        assert(false, "unknown sourcekitd variant")
+        return nil
+      }
+    }
+
+    public var description: String {
+      return val.description
+    }
+
+  }
+
+  private let resp: sourcekitd_response_t
+
+  public var value: Dictionary {
+    return Dictionary(dict: sourcekitd_response_get_value(resp))
+  }
+
+  /// An NSDictionary representing the response
+  public var nsdictionary: NSDictionary {
+    let dict = NSMutableDictionary()
+    _ = sourcekitd_variant_dictionary_apply(sourcekitd_response_get_value(resp))
+    { (k, v) in
+      if let val = Variant(val: v).asAnyObject() {
+        dict.setValue(val, forKey: SourceKitdUID(uid: k!).asString)
+      }
+      return true
+    }
+    return dict
+  }
+
+  /// Copies the raw bytes of the JSON description of this documentation item.
+  /// The caller is responsible for freeing the associated memory.
+  public func copyRawJSONDocumentation() -> UnsafeMutablePointer<Int8>? {
+    return sourcekitd_variant_json_description_copy(
+      sourcekitd_response_get_value(resp))
+  }
+
+  /// Whether or not this response represents an error.
+  public var isError: Bool {
+    return sourcekitd_response_is_error(resp)
+  }
+
+  /// Whether or not this response represents a notification.
+  public var isNotification: Bool {
+    return value.getOptional(.key_notification) != nil
+  }
+
+  /// Whether or not this response represents a connection interruption error.
+  public var isConnectionInterruptionError: Bool {
+    return sourcekitd_response_is_error(resp) &&
+      sourcekitd_response_error_get_kind(resp) ==
+        SOURCEKITD_ERROR_CONNECTION_INTERRUPTED
+  }
+
+  /// Whether or not this response represents a compiler crash.
+  public var isCompilerCrash: Bool {
+    guard let notification = value.getOptional(.key_notification)?.getUID()
+    else { return false }
+    return notification == .compilerCrashedNotification
+  }
+
+  /// If this is a document update notification, returns the name of the
+  /// document to which this update applies. Otherwise, returns `nil`.
+  public var documentUpdateNotificationDocumentName: String? {
+    let response = value
+    guard let notification = response.getOptional(.key_notification)?.getUID(),
+      notification == .source_notification_editor_documentupdate
+    else { return nil }
+    return response.getOptional(.key_name)?.getString()
+  }
+
+  public init(resp: sourcekitd_response_t) {
+    self.resp = resp
+  }
+
+  deinit {
+    sourcekitd_response_dispose(resp)
+  }
+
+  public var description: String {
+    let utf8Str = sourcekitd_response_description_copy(resp)!
+    let result = String(cString: utf8Str)
+    free(utf8Str)
+    return result
+  }
+}
+
+extension sourcekitd_variant_t: CustomStringConvertible {
+  public var description: String {
+    let utf8Str = sourcekitd_variant_description_copy(self)!
+    let result = String(cString: utf8Str)
+    free(utf8Str)
+    return result
+  }
+}
+
+private func fromCStringLen(_ ptr: UnsafePointer<Int8>, length: Int) -> String? {
+  return NSString(bytes: ptr, length: length,
+                  encoding: String.Encoding.utf8.rawValue) as String?
+}

--- a/tools/SwiftSourceKitClient/SourceKitdUID.swift
+++ b/tools/SwiftSourceKitClient/SourceKitdUID.swift
@@ -1,0 +1,51 @@
+//===------------------------ SourceKitdUID.swift -------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// This file provides SourceKitd UIDs.
+//===----------------------------------------------------------------------===//
+
+import sourcekitd
+
+public struct SourceKitdUID: Equatable, Hashable, CustomStringConvertible {
+  public let uid: sourcekitd_uid_t
+
+  init(uid: sourcekitd_uid_t) {
+    self.uid = uid
+  }
+
+  public init(string: String) {
+    self.uid = sourcekitd_uid_get_from_cstr(string)
+  }
+
+  public var description: String {
+    return String(cString: sourcekitd_uid_get_string_ptr(uid))
+  }
+
+  public var asString: String {
+    return String(cString: sourcekitd_uid_get_string_ptr(uid))
+  }
+
+  public var hashValue: Int {
+    return uid.hashValue
+  }
+}
+
+extension SourceKitdUID {
+  public static let key_request = SourceKitdUID(string: "key.request")
+  public static let key_compilerargs = SourceKitdUID(string: "key.compilerargs")
+  public static let key_notification = SourceKitdUID(string: "key.notification")
+  public static let key_name = SourceKitdUID(string: "key.name")
+  public static let key_enable_syntax_tree = SourceKitdUID(string: "key.enablesyntaxtree")
+  public static let key_serialized_syntax_tree = SourceKitdUID(string: "key.serialized_syntax_tree")
+  public static let compilerCrashedNotification = SourceKitdUID(string: "notification.toolchain-compiler-crashed")
+  public static let source_request_editor_open = SourceKitdUID(string: "source.request.editor.open")
+  public static let source_notification_editor_documentupdate = SourceKitdUID(string: "source.notification.editor.documentupdate")
+}

--- a/tools/SwiftSourceKitClient/SourceKitdUID.swift
+++ b/tools/SwiftSourceKitClient/SourceKitdUID.swift
@@ -45,6 +45,7 @@ extension SourceKitdUID {
   public static let key_name = SourceKitdUID(string: "key.name")
   public static let key_enable_syntax_tree = SourceKitdUID(string: "key.enablesyntaxtree")
   public static let key_serialized_syntax_tree = SourceKitdUID(string: "key.serialized_syntax_tree")
+  public static let key_sourcefile = SourceKitdUID(string: "key.sourcefile")
   public static let compilerCrashedNotification = SourceKitdUID(string: "notification.toolchain-compiler-crashed")
   public static let source_request_editor_open = SourceKitdUID(string: "source.request.editor.open")
   public static let source_notification_editor_documentupdate = SourceKitdUID(string: "source.notification.editor.documentupdate")

--- a/tools/SwiftSyntax/CMakeLists.txt
+++ b/tools/SwiftSyntax/CMakeLists.txt
@@ -1,3 +1,7 @@
+set(EXTRA_COMPILE_FLAGS "-F" "${SWIFT_LIBRARY_OUTPUT_INTDIR}")
+set(EXTRA_LINKER_FLAGS "-Xlinker" "-rpath" "-Xlinker" "${SWIFT_LIBRARY_OUTPUT_INTDIR}"
+    "-Xlinker" "-F" "-Xlinker" "${SWIFT_LIBRARY_OUTPUT_INTDIR}")
+
 add_swift_library(swiftSwiftSyntax SHARED
   # This file should be listed the first.  Module name is inferred from the
   # filename.
@@ -23,7 +27,9 @@ add_swift_library(swiftSwiftSyntax SHARED
   TokenKind.swift.gyb
   Trivia.swift
 
-  SWIFT_MODULE_DEPENDS Foundation
+  SWIFT_COMPILE_FLAGS ${EXTRA_COMPILE_FLAGS}
+  LINK_FLAGS ${EXTRA_LINKER_FLAGS}
+  SWIFT_MODULE_DEPENDS SwiftSourceKit
   INSTALL_IN_COMPONENT swift-syntax
   TARGET_SDKS OSX
   IS_STDLIB)

--- a/tools/SwiftSyntax/SwiftSyntax.swift
+++ b/tools/SwiftSyntax/SwiftSyntax.swift
@@ -33,6 +33,7 @@ extension Syntax {
 #if os(macOS)
     let Service = SourceKitdService()
     let Request = SourceKitdRequest(uid: .source_request_editor_open)
+    Request.addParameter(.key_sourcefile, value: url.absoluteString)
     Request.addParameter(.key_name, value: url.absoluteString)
     Request.addParameter(.key_enable_syntax_tree, value: 1)
     let Resp = Service.sendSyn(request: Request)

--- a/tools/SwiftSyntax/SwiftSyntax.swift
+++ b/tools/SwiftSyntax/SwiftSyntax.swift
@@ -33,8 +33,8 @@ extension Syntax {
 #if os(macOS)
     let Service = SourceKitdService()
     let Request = SourceKitdRequest(uid: .source_request_editor_open)
-    Request.addParameter(.key_sourcefile, value: url.absoluteString)
-    Request.addParameter(.key_name, value: url.absoluteString)
+    Request.addParameter(.key_sourcefile, value: url.path)
+    Request.addParameter(.key_name, value: url.path)
     Request.addParameter(.key_enable_syntax_tree, value: 1)
     let Resp = Service.sendSyn(request: Request)
     return Resp.value.getString(.key_serialized_syntax_tree).data(using: .utf8)!

--- a/tools/SwiftSyntax/SwiftSyntax.swift
+++ b/tools/SwiftSyntax/SwiftSyntax.swift
@@ -33,9 +33,12 @@ extension Syntax {
 #if os(macOS)
     let Service = SourceKitdService()
     let Request = SourceKitdRequest(uid: .source_request_editor_open)
-    Request.addParameter(.key_sourcefile, value: url.path)
-    Request.addParameter(.key_name, value: url.path)
+    let Path = url.path
+    Request.addParameter(.key_sourcefile, value: Path)
+    Request.addParameter(.key_name, value: Path)
     Request.addParameter(.key_enable_syntax_tree, value: 1)
+
+    // FIXME: SourceKitd error handling.
     let Resp = Service.sendSyn(request: Request)
     return Resp.value.getString(.key_serialized_syntax_tree).data(using: .utf8)!
 #else


### PR DESCRIPTION
When using SwiftSyntax as a standalone tool, we invoke Swiftc
internally to get the serialized syntax tree. This is not ideal for
several reasons: (1) we have to hard-code the relative path of swiftc
to invoke it; (2) we have to rely on standard input/output to pass the
tree across the process boundaries; and (3) we have to maintain two
different ways to get syntax tree (swiftc and sourcekitd).

This patch attempts to teach SwiftSyntax to use SourceKit to get the
tree just like other clients. We first add a SourceKit client library
written in Swift; and next teach SwiftSyntax to use this SourceKit
client-side library. For platforms other than MacOS, we still use Swiftc
to get syntax trees.

This patch also re-enables several flaky tests.