### PR TITLE
[4.1] [ClangImporter] Fix handling of bitfields in unions

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -3091,11 +3091,13 @@ namespace {
 
         // Bitfields are imported as computed properties with Clang-generated
         // accessors.
+        bool isBitField = false;
         if (auto field = dyn_cast<clang::FieldDecl>(nd)) {
           if (field->isBitField()) {
             // We can't represent this struct completely in SIL anymore,
             // but we're still able to define a memberwise initializer.
             hasUnreferenceableStorage = true;
+            isBitField = true;
 
             makeBitFieldAccessors(Impl,
                                   const_cast<clang::RecordDecl *>(decl),
@@ -3109,7 +3111,7 @@ namespace {
           // Indirect fields are created as computed property accessible the
           // fields on the anonymous field from which they are injected.
           makeIndirectFieldAccessors(Impl, ind, members, result, VD);
-        } else if (decl->isUnion()) {
+        } else if (decl->isUnion() && !isBitField) {
           // Union fields should only be available indirectly via a computed
           // property. Since the union is made of all of the fields at once,
           // this is a trivial accessor that casts self to the correct

--- a/test/Interpreter/Inputs/unions-and-bitfields.h
+++ b/test/Interpreter/Inputs/unions-and-bitfields.h
@@ -1,0 +1,62 @@
+#include <stdint.h>
+#include <string.h>
+
+union PlainUnion {
+  uint32_t whole;
+  unsigned char first;
+};
+
+struct PlainBitfield {
+  uint32_t offset;
+  uint32_t first: 8;
+  uint32_t : 0;
+};
+_Static_assert(sizeof(struct PlainBitfield) == sizeof(uint64_t),
+               "must fit in 64 bits");
+
+struct PlainIndirect {
+  uint32_t offset;
+  struct {
+    uint32_t whole;
+  };
+};
+
+union BitfieldUnion {
+  uint32_t whole;
+  uint32_t first: 8;
+};
+
+struct BitfieldIndirect {
+  uint32_t offset;
+  struct {
+    uint32_t first: 8;
+    uint32_t : 0;
+  };
+};
+
+struct UnionIndirect {
+  uint32_t offset;
+  union {
+    uint32_t whole;
+    unsigned char first;
+  };
+};
+
+struct BitfieldUnionIndirect {
+  uint32_t offset;
+  union {
+    uint32_t whole;
+    uint32_t first: 8;
+  };
+};
+
+void populate(void *memory) {
+  const uint32_t value = 0x11223344;
+  memcpy(memory, &value, sizeof(value));
+}
+
+void populateAtOffset(void *memory) {
+  const uint32_t value = 0x11223344;
+  memcpy((char *)memory + sizeof(uint32_t), &value, sizeof(value));
+}
+

--- a/test/Interpreter/unions-and-bitfields.swift
+++ b/test/Interpreter/unions-and-bitfields.swift
@@ -1,0 +1,60 @@
+// RUN: %target-build-swift %s -import-objc-header %S/Inputs/unions-and-bitfields.h -disable-bridging-pch -o %t
+// RUN: %target-run %t
+// REQUIRES: executable_test
+
+// The -disable-bridging-pch above isn't actually relevant to the test; however,
+// precompiled headers don't play nice with the way we include the platform
+// module map on non-Apple platforms. See 
+// https://bugs.llvm.org/show_bug.cgi?id=36245.
+
+import StdlibUnittest
+
+var suite = TestSuite("UnionsAndBitfields")
+
+suite.test("PlainUnion") {
+  var x = PlainUnion()
+  populate(&x)
+  expectEqual(0x11223344, x.whole)
+  expectTrue(x.first == 0x11 || x.first == 0x44)
+}
+
+suite.test("PlainBitfield") {
+  var x = PlainBitfield()
+  populateAtOffset(&x)
+  expectTrue(x.first == 0x11 || x.first == 0x44)
+}
+
+suite.test("PlainIndirect") {
+  var x = PlainIndirect()
+  populateAtOffset(&x)
+  expectEqual(0x11223344, x.whole)
+}
+
+suite.test("BitfieldUnion") {
+  var x = BitfieldUnion()
+  populate(&x)
+  expectEqual(0x11223344, x.whole)
+  expectTrue(x.first == 0x11 || x.first == 0x44)
+}
+
+suite.test("BitfieldIndirect") {
+  var x = BitfieldIndirect()
+  populateAtOffset(&x)
+  expectTrue(x.first == 0x11 || x.first == 0x44)
+}
+
+suite.test("UnionIndirect") {
+  var x = UnionIndirect()
+  populateAtOffset(&x)
+  expectEqual(0x11223344, x.whole)
+  expectTrue(x.first == 0x11 || x.first == 0x44)
+}
+
+suite.test("BitfieldUnionIndirect") {
+  var x = BitfieldUnionIndirect()
+  populateAtOffset(&x)
+  expectEqual(0x11223344, x.whole)
+  expectTrue(x.first == 0x11 || x.first == 0x44)
+}
+
+runAllTests()


### PR DESCRIPTION
- **Explanation**: Both unions and bitfields need to be handled specially when importing C types into Swift, but we were trying to apply *both* special handlings for bitfields *in* unions. In +Asserts builds this led to an assertion failure; in -Asserts builds it had the wrong behavior.
- **Scope**: Only affects bitfields in unions.
- **Issue**: rdar://problem/37242238
- **Reviewed by**: @jckarter
- **Risk**: Low. Everything that previously worked will continue doing what it did before.
- **Testing**: Added compiler regression tests