### PR TITLE
[build-script] Shell Module

### DIFF
--- a/utils/build_swift/class_utils.py
+++ b/utils/build_swift/class_utils.py
@@ -1,0 +1,38 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+"""
+Class utility functions and decorators.
+"""
+
+from __future__ import absolute_import, unicode_literals
+
+
+__all__ = []
+
+
+def add_metaclass(metacls):
+    def wrapper(cls):
+        body = vars(cls).copy()
+
+        body.pop('__dict__', None)
+        body.pop('__weakref__', None)
+
+        return metacls(cls.__name__, cls.__bases__, body)
+
+    return wrapper
+
+
+def enum():
+    pass
+
+
+def infer_repr():
+    def wrapper(cls):
+        pass

--- a/utils/build_swift/shell.py
+++ b/utils/build_swift/shell.py
@@ -1,0 +1,294 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+"""
+Shell utilities wrapper module.
+"""
+
+
+import os
+import shutil
+import subprocess
+import sys
+from contextlib import contextmanager
+from copy import copy
+from subprocess import CalledProcessError
+
+try:
+    # Python 3
+    from shutil import quote
+except ImportError:
+    from pipes import quote
+
+
+__all__ = [
+    'CommandExecutor',
+    'NullExecutor',
+
+    'PIPE',
+    'STDOUT',
+]
+
+
+# Re-export subprocess constants
+PIPE = subprocess.PIPE
+STDOUT = subprocess.STDOUT
+
+
+class _EchoAction(object):
+
+    DEFAULT_PREFIX = '>>> '
+
+    def __init__(self, output_stream, prefix=None):
+        self.output_stream = output_stream
+        self.prefix = prefix or _EchoAction.DEFAULT_PREFIX
+
+    def __call__(self, command):
+        line = unicode(self.prefix + ' '.join(command) + '\n')
+        self.output_stream.write(line)
+
+
+class _FakePopen():
+    """Fake class which implements the same interface as subprocess.Popen.
+    """
+
+    def __init__(self, pid=0, returncode=0):
+        self.stdin = None
+        self.stdout = None
+        self.stderr = None
+        self.pid = pid
+        self.returncode = returncode
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self):
+        return self.returncode
+
+    def communicate(**kwargs):
+        return (None, None)
+
+    def send_signal(self, signal):
+        return
+
+    def terminate(self):
+        return
+
+    def kill(self):
+        return
+
+
+def _quote_command(command):
+    return list(map(quote, command))
+
+
+# -----------------------------------------------------------------------------
+# Executors
+
+class CommandExecutor(object):
+    """Wrapper class for executing shell commands while maintaining a command
+    history.
+    """
+
+    def __init__(self, env=None,
+                 stdin=None, stdout=None, stderr=None):
+        self._env = env
+        self._stdin = stdin or sys.stdin
+        self._stdout = stdout or sys.stderr
+        self._stderr = stderr or sys.stdout
+
+        # Actions performed before executing each command
+        self._actions = []
+
+        # Executed command history
+        self._command_history = []
+
+        def store_history_action(command):
+            self._command_history.append(command)
+
+        self.add_action(store_history_action)
+
+    def _exec_actions(self, command):
+        command = _quote_command(command)
+
+        for action in self._actions:
+            action(command)
+
+    def add_action(self, action):
+        """Add an action to the executor which will be called prior to excuting
+        commands. Actions must be callable and accept a single argument, the
+        command being executed.
+        """
+
+        self._actions.append(action)
+
+    def add_echo_action(self, output_stream=None, prefix=None):
+        """Adds an echo action to the executor which will output the command
+        to an output stream or stdout. An optional prefix can be used to format
+        the final command.
+        """
+
+        self.add_action(_EchoAction(output_stream or self._stdout, prefix))
+
+    def _kwargs_set_defaults(self, kwargs):
+        defaults = {
+            'env': self._env,
+            'stdin': self._stdin,
+            'stdout': self._stdout,
+            'stderr': self._stderr,
+        }
+
+        for key, value in defaults.items():
+            kwargs.setdefault(key, value)
+
+        return kwargs
+
+    def _fake_popen(self, command):
+        self._exec_actions(command)
+        return _FakePopen()
+
+    def _popen(self, command, **kwargs):
+        self._exec_actions(command)
+
+        kwargs = self._kwargs_set_defaults(kwargs)
+        p = subprocess.Popen(command, **kwargs)
+
+        try:
+            p.wait()
+        except Exception as e:
+            p.kill()
+            p.wait()
+            raise e
+
+        return p
+
+    def popen(self, command, **kwargs):
+        """Create and return an instance of subprocess.Popen with the
+        given command and kwargs.
+        """
+
+        return self._popen(command, **kwargs)
+
+    def call(self, command):
+        """Run command. Wait for the command to exit and then return the
+        returncode.
+        """
+
+        return self.popen(command).returncode
+
+    def check_call(self, command):
+        """Run command. Wait for the command to exit. If the returncode was 0
+        then return, otherwise raises CalledProcessError.
+        """
+
+        p = self.popen(command)
+        if p.returncode:
+            raise CalledProcessError(p.returncode, command)
+
+        return 0
+
+    def check_output(self, command):
+        """Run command. Wait for the command to exit. If the returncode was 0
+        then return the output, otherwise raises CalledProcessError.
+        """
+
+        p = self.popen(command, stdout=subprocess.PIPE)
+        output, _ = p.communicate()
+
+        returncode = p.poll()
+        if returncode:
+            raise CalledProcessError(returncode, command, output=output)
+
+        return output
+
+    def history(self):
+        """Return the executor's command history.
+        """
+
+        return copy(self._command_history)
+
+    # -------------------------------------------------------------------------
+    # Common shell utility wrappers
+
+    def cd(self, path):
+        self._fake_popen(['cd', path])
+        os.chdir(path)
+
+    def cp(self, source, destination):
+        self._fake_popen(['cp', '-r', source, destination])
+        if os.path.isfile(source):
+            shutil.copyfile(source, destination)
+        elif os.path.isdir(source):
+            shutil.copytree(source, destination)
+        else:
+            raise OSError('{} does not exist'.format(source))
+
+    def ls(self, path=None):
+        path = path or os.getcwd()
+        self._fake_popen(['ls', path])
+        return os.listdir(path)
+
+    def mkdir(self, path):
+        self._fake_popen(['mkdir', '-p', path])
+        if not os.path.isdir(path):
+            os.makedirs(path)
+
+    def mv(self, source, destination):
+        self._fake_popen(['mv', source, destination])
+        shutil.move(source, destination)
+
+    @contextmanager
+    def pushd(self, path):
+        cwd = os.getcwd()
+        self._fake_popen(['pushd', path])
+        os.chdir(path)
+
+        yield
+
+        self._fake_popen(['popd'])
+        os.chdir(cwd)
+
+    def rm(self, path):
+        self._fake_popen(['rm', '-rf', path])
+        if os.path.isfile(path):
+            os.remove(path)
+        elif os.path.isdir(path):
+            shutil.rmtree(path)
+        else:
+            raise OSError('{} does not exist'.format(path))
+
+    def which(self, name):
+        try:
+            return self.check_output(['which', name]).strip()
+        except CalledProcessError:
+            return None
+
+
+class NullExecutor(CommandExecutor):
+    """Variant of the CommandExecutor that does not execute any subprocess
+    commands. This class should be useful for testing and iterating on scripts
+    while still retaining output logging and history functionality.
+    """
+
+    def popen(self, command, **kwargs):
+        return self._fake_popen(command, **kwargs)
+
+    # Overriding commands that mutate the system
+
+    def cp(self, source, destination):
+        self._fake_popen(['cp', '-r', source, destination])
+
+    def mkdir(self, path):
+        self._fake_popen(['mkdir', '-p', path])
+
+    def mv(self, source, destination):
+        self._fake_popen(['mv', source, destination])
+
+    def rm(self, path):
+        self._fake_popen(['rm', '-rf', path])

--- a/utils/build_swift/shell.py
+++ b/utils/build_swift/shell.py
@@ -12,6 +12,8 @@ Shell utilities wrapper module.
 """
 
 
+from __future__ import absolute_import, unicode_literals
+
 import os
 import shutil
 import subprocess

--- a/utils/build_swift/shell.py
+++ b/utils/build_swift/shell.py
@@ -281,6 +281,9 @@ class NullExecutor(CommandExecutor):
 
     # Overriding commands that mutate the system
 
+    def cd(self, path):
+        self._fake_popen(['cd', path])
+
     def cp(self, source, destination):
         self._fake_popen(['cp', '-r', source, destination])
 
@@ -289,6 +292,12 @@ class NullExecutor(CommandExecutor):
 
     def mv(self, source, destination):
         self._fake_popen(['mv', source, destination])
+
+    @contextmanager
+    def pushd(self, path):
+        self._fake_popen(['pushd', path])
+        yield
+        self._fake_popen(['popd'])
 
     def rm(self, path):
         self._fake_popen(['rm', '-rf', path])

--- a/utils/build_swift/shell.py
+++ b/utils/build_swift/shell.py
@@ -71,7 +71,7 @@ class _FakePopen():
     def wait(self):
         return self.returncode
 
-    def communicate(**kwargs):
+    def communicate(self, **kwargs):
         return (None, None)
 
     def send_signal(self, signal):
@@ -149,7 +149,7 @@ class CommandExecutor(object):
 
         return kwargs
 
-    def _fake_popen(self, command):
+    def _fake_popen(self, command, **kwargs):
         self._exec_actions(command)
         return _FakePopen()
 

--- a/utils/build_swift/tests/test_shell.py
+++ b/utils/build_swift/tests/test_shell.py
@@ -7,6 +7,8 @@
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
+from __future__ import absolute_import, unicode_literals
+
 import os
 import sys
 

--- a/utils/build_swift/tests/test_shell.py
+++ b/utils/build_swift/tests/test_shell.py
@@ -1,0 +1,134 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+import os
+import sys
+
+from .utils import TestCase
+from .. import shell
+
+try:
+    # Python 3
+    from io import StringIO
+except ImportError:
+    from StringIO import StringIO
+
+
+class TestCommandExecutor(TestCase):
+
+    def test_settings_passthrough(self):
+        sh = shell.CommandExecutor(env={'EDITOR': 'subl'})
+
+        sh._fake_popen(['ls', '-al'])
+
+    def test_add_action(self):
+        sh = shell.CommandExecutor()
+        self.assertEqual(len(sh._actions), 1)
+
+        def callable(command):
+            pass
+
+        sh.add_action(callable)
+        self.assertEqual(sh._actions[1], callable)
+
+    def test_add_echo_action(self):
+        sh = shell.CommandExecutor()
+
+        sh.add_echo_action()
+        action = sh._actions[1]
+        self.assertIsInstance(action, shell._EchoAction)
+        self.assertEqual(action.output_stream, sh._stdout)
+        self.assertEqual(action.prefix, shell._EchoAction.DEFAULT_PREFIX)
+
+        sh._actions.pop()
+
+        stream = StringIO()
+
+        sh.add_echo_action(output_stream=stream, prefix='$ ')
+        action = sh._actions[1]
+        self.assertIsInstance(action, shell._EchoAction)
+        self.assertEqual(action.output_stream, stream)
+        self.assertEqual(action.prefix, '$ ')
+
+        sh._fake_popen(['true'])
+        self.assertEqual(stream.getvalue(), '$ true\n')
+
+    def test_popen(self):
+        devnull = open(os.devnull, 'w')
+        sh = shell.CommandExecutor(stdout=devnull, stderr=devnull)
+
+        p = sh.popen([sys.executable, '--version'])
+        self.assertEqual(p.returncode, 0)
+
+        p = sh.popen([sys.executable, '-c', 'raise SysExit(1)'])
+        self.assertEqual(p.returncode, 1)
+
+    def test_call(self):
+        devnull = open(os.devnull, 'w')
+        sh = shell.CommandExecutor(stdout=devnull, stderr=devnull)
+
+        returncode = sh.call([sys.executable, '--version'])
+        self.assertEqual(returncode, 0)
+
+        returncode = sh.call([sys.executable, '-c', 'raise SysExit(1)'])
+        self.assertEqual(returncode, 1)
+
+    def test_check_call(self):
+        devnull = open(os.devnull, 'w')
+        sh = shell.CommandExecutor(stdout=devnull, stderr=devnull)
+
+        with self.assertNotRaises(shell.CalledProcessError):
+            sh.check_call([sys.executable, '--version'])
+
+        with self.assertRaises(shell.CalledProcessError):
+            sh.check_call([sys.executable, '-c', 'raise SysExit(1)'])
+
+    def test_check_output(self):
+        devnull = open(os.devnull, 'w')
+        sh = shell.CommandExecutor(stdout=devnull, stderr=devnull)
+
+        output = sh.check_output([sys.executable, '--version'])
+        self.assertRegexpMatches(r'^Python [0-9.]+$', output)
+
+        with self.assertRaises(shell.CalledProcessError):
+            sh.check_output([sys.executable, '-c', 'raise SysExit(1)'])
+
+    def test_history(self):
+        sh = shell.CommandExecutor()
+
+        sh._fake_popen(['ls', '-al'])
+        sh._fake_popen(['touch', 'text.txt'])
+        sh._fake_popen(['python', '-m', 'unittest', 'discover'])
+
+        history = sh.history()
+        self.assertListEqual(history, [
+            ['ls', '-al'],
+            ['touch', 'text.txt'],
+            ['python', '-m', 'unittest', 'discover'],
+        ])
+
+    def test_command_quoting(self):
+        sh = shell.CommandExecutor()
+
+        sh._fake_popen(['cd', '/Applications/Sample Program.app'])
+        self.assertListEqual(sh.history(), [
+            ['cd', "'/Applications/Sample Program.app'"],
+        ])
+
+    # TODO: Devise testing for shell command wrappers
+
+
+class TestNullExecutor(TestCase):
+
+    def test_commands_return_fake_popen(self):
+        sh = shell.NullExecutor()
+
+        p = sh.popen(['true'])
+
+        self.assertIsInstance(p, shell._FakePopen)

--- a/utils/build_swift/tests/test_xcrun.py
+++ b/utils/build_swift/tests/test_xcrun.py
@@ -1,0 +1,26 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+from .utils import TestCase
+from ..xcrun import Xcrun
+
+
+class TestXcrun(TestCase):
+
+    def test_build_command(self):
+        xcrun = Xcrun()
+        self.assertEqual(xcrun._build_command([]), ['xcrun'])
+
+        xcrun = Xcrun(sdk='default', toolchain='default')
+        self.assertEqual(xcrun._build_command(['--find', 'clang']), [
+            'xcrun',
+            '--sdk', 'default',
+            '--toolchain', 'default',
+            '--find', 'clang',
+        ])

--- a/utils/build_swift/tests/test_xcrun.py
+++ b/utils/build_swift/tests/test_xcrun.py
@@ -7,7 +7,10 @@
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 
+from __future__ import absolute_import, unicode_literals
+
 from .utils import TestCase
+from .. import shell
 from ..xcrun import Xcrun
 
 
@@ -24,3 +27,19 @@ class TestXcrun(TestCase):
             '--toolchain', 'default',
             '--find', 'clang',
         ])
+
+    def test_override_sdk(self):
+        sh = shell.NullExecutor()
+        xcrun = Xcrun(sh, sdk='iphoneos')
+        self.assertEqual(xcrun._sdk, 'iphoneos')
+
+        xcrun.popen([], sdk='tvos')
+        self.assertEqual(sh.history()[0], ['xcrun', '--sdk', 'tvos'])
+
+    def test_override_toolchain(self):
+        sh = shell.NullExecutor()
+        xcrun = Xcrun(sh, toolchain='default')
+        self.assertEqual(xcrun._toolchain, 'default')
+
+        xcrun.popen([], toolchain='test')
+        self.assertEqual(sh.history()[0], ['xcrun', '--toolchain', 'test'])

--- a/utils/build_swift/xcrun.py
+++ b/utils/build_swift/xcrun.py
@@ -12,6 +12,8 @@ Xcrun wrapper module.
 """
 
 
+from __future__ import absolute_import, unicode_literals
+
 from . import shell
 
 
@@ -30,26 +32,34 @@ class Xcrun(object):
         self._sdk = sdk
         self._toolchain = toolchain
 
-    def _build_command(self, args):
+    def _build_command(self, args, sdk=None, toolchain=None):
         command = ['xcrun']
-        if self._sdk is not None:
-            command += ['--sdk', self._sdk]
-        if self._toolchain is not None:
-            command += ['--toolchain', self._toolchain]
+
+        sdk = sdk or self._sdk
+        if sdk is not None:
+            command += ['--sdk', sdk]
+
+        toolchain = toolchain or self._toolchain
+        if toolchain is not None:
+            command += ['--toolchain', toolchain]
 
         return command + args
 
-    def popen(self, args, **kwargs):
-        return self._sh.popen(self._build_command(args), **kwargs)
+    def popen(self, args, sdk=None, toolchain=None, **kwargs):
+        command = self._build_command(args, sdk=sdk, toolchain=toolchain)
+        return self._sh.popen(command, **kwargs)
 
-    def call(self, args):
-        return self._sh.call(self._build_command(args))
+    def call(self, args, sdk=None, toolchain=None, **kwargs):
+        command = self._build_command(args, sdk=sdk, toolchain=toolchain)
+        return self._sh.call(command, **kwargs)
 
-    def check_call(self, args):
-        return self._sh.check_call(self._build_command(args))
+    def check_call(self, args, sdk=None, toolchain=None, **kwargs):
+        command = self._build_command(args, sdk=sdk, toolchain=toolchain)
+        return self._sh.check_call(command, **kwargs)
 
-    def check_output(self, args):
-        return self._sh.check_output(self._build_command(args))
+    def check_output(self, args, sdk=None, toolchain=None, **kwargs):
+        command = self._build_command(args, sdk=sdk, toolchain=toolchain)
+        return self._sh.check_output(command, **kwargs)
 
     # -------------------------------------------------------------------------
 

--- a/utils/build_swift/xcrun.py
+++ b/utils/build_swift/xcrun.py
@@ -1,0 +1,75 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+"""
+Xcrun wrapper module.
+"""
+
+
+from . import shell
+
+
+__all__ = [
+    'Xcrun',
+]
+
+
+class Xcrun(object):
+    """Wrapper class around the Xcrun utility. Provides methods for each
+    subcommand available.
+    """
+
+    def __init__(self, command_executor=None, sdk=None, toolchain=None):
+        self._sh = command_executor or shell.CommandExecutor()
+        self._sdk = sdk
+        self._toolchain = toolchain
+
+    def _build_command(self, args):
+        command = ['xcrun']
+        if self._sdk is not None:
+            command += ['--sdk', self._sdk]
+        if self._toolchain is not None:
+            command += ['--toolchain', self._toolchain]
+
+        return command + args
+
+    def popen(self, args, **kwargs):
+        return self._sh.popen(self._build_command(args), **kwargs)
+
+    def call(self, args):
+        return self._sh.call(self._build_command(args))
+
+    def check_call(self, args):
+        return self._sh.check_call(self._build_command(args))
+
+    def check_output(self, args):
+        return self._sh.check_output(self._build_command(args))
+
+    # -------------------------------------------------------------------------
+
+    def find(self, tool):
+        return self.check_output(['-find', tool]).rstrip()
+
+    def sdk_path(self):
+        return self.check_output(['--show-sdk-path']).rstrip()
+
+    def sdk_version(self):
+        return self.check_output(['--show-sdk-version']).rstrip()
+
+    def sdk_build_version(self):
+        return self.check_output(['--show-sdk-build-version']).rstrip()
+
+    def sdk_platform_path(self):
+        return self.check_output(['--show-sdk-platform-path']).rstrip()
+
+    def sdk_platform_version(self):
+        return self.check_output(['--show-sdk-platform-version']).rstrip()
+
+    def version(self):
+        return self.check_output(['--version']).rstrip()


### PR DESCRIPTION
# Purpose

This PR introduces two new modules. First is the `shell` module which implements a `CommandExecutor` that wraps portions of the standard `subprocess` module in a context object that tracks common state and command history. The executor is extensible with a trivial action system that allows for users to add any callable to the queue of actions performed prior to executing a command. The intended use-case here is to have a centralized shell-object that is passed around through the program to build up a history and maintain state.

For example:

```python
import os

from build_swift import shell

ENV = {
    'PATH': '/usr/bin',
}

sh = shell.CommandExecutor(env=ENV, stdout=open(os.devnull, 'w'))
sh.cp('/Applications/Xcode.app')
sh.mkdir('test')

sh.check_call(['./utils/build-script', '--reconfigure', '-t'])

sh.history()
```

It's possible to hook-in custom actions like so:

```python
def callable(command):
    # Do something with the command
    log_command(command)

sh.add_action(callable)
```

Every action is performed before executing the command.

The second module is pretty small, wrapping the `xcrun` utility using the `shell` module. Both have testing, albeit not much in the way of `xcrun`.

This furthers the efforts for completing [SR-237](https://bugs.swift.org/browse/SR-237)
rdar://25281853