### PR TITLE
[4.1] [DeclChecker] Don't try to derive conformances for invalid enums

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4509,6 +4509,7 @@ public:
       {
         // Check for duplicate enum members.
         llvm::DenseMap<Identifier, EnumElementDecl *> Elements;
+        bool hasErrors = false;
         for (auto *EED : ED->getAllElements()) {
           auto Res = Elements.insert({ EED->getName(), EED });
           if (!Res.second) {
@@ -4521,7 +4522,13 @@ public:
             TC.diagnose(EED->getLoc(), diag::duplicate_enum_element);
             TC.diagnose(PreviousEED->getLoc(),
                         diag::previous_decldef, true, EED->getName());
+            hasErrors = true;
           }
+        }
+
+        if (hasErrors) {
+          ED->setInterfaceType(ErrorType::get(TC.Context));
+          ED->setInvalid();
         }
       }
     }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4513,10 +4513,7 @@ public:
         for (auto *EED : ED->getAllElements()) {
           auto Res = Elements.insert({ EED->getName(), EED });
           if (!Res.second) {
-            EED->setInterfaceType(ErrorType::get(TC.Context));
             EED->setInvalid();
-            if (auto *RawValueExpr = EED->getRawValueExpr())
-              RawValueExpr->setType(ErrorType::get(TC.Context));
 
             auto PreviousEED = Res.first->second;
             TC.diagnose(EED->getLoc(), diag::duplicate_enum_element);
@@ -4526,10 +4523,10 @@ public:
           }
         }
 
-        if (hasErrors) {
-          ED->setInterfaceType(ErrorType::get(TC.Context));
+        // If one of the cases is invalid, let's mark
+        // whole enum as invalid as well.
+        if (hasErrors)
           ED->setInvalid();
-        }
       }
     }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4655,6 +4655,8 @@ ValueDecl *TypeChecker::deriveProtocolRequirement(DeclContext *DC,
     return nullptr;
 
   auto Decl = DC->getInnermostDeclarationDeclContext();
+  if (Decl->isInvalid())
+    return nullptr;
 
   switch (*knownKind) {
   case KnownProtocolKind::RawRepresentable:

--- a/validation-test/compiler_crashers_2_fixed/0141-rdar36989792.swift
+++ b/validation-test/compiler_crashers_2_fixed/0141-rdar36989792.swift
@@ -1,0 +1,6 @@
+// RUN: not %target-swift-frontend %s -typecheck
+
+enum E : Equatable {
+    case c(Int)
+    case c(String)
+}


### PR DESCRIPTION
• **Explanation**: If one of the cases is invalid, let's mark parent enum as invalid
as well, and avoid trying to derive any conformances related to it.
• **Scope of Issue**: Affects derivation of the equatable/hashable and other conformances for enums with invalid cases.
• **Origination**: Before attempting to derive conformances synthesizer needs to check if the enum is valid.
• **Risk**: Low risk; Fixes a bug in declaration checker.
• **Reviewed By**: @DougGregor 
• **Testing**: Compiler regression tests
• **Radar / SR**: rdar://problem/36989792

Resolves: rdar://problem/36989792
Resolves #49402
