### PR TITLE
[build-script] Disable lldb unit tests in PR testing

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2733,20 +2733,22 @@ for host in "${ALL_HOSTS[@]}"; do
                 fi
                 lldb_build_dir=$(build_directory ${host} lldb)
 
-                # Run the gtests.
-                if [[ "$(uname -s)" == "Darwin" && "$(true_false ${LLDB_BUILD_WITH_XCODE})" == "TRUE" ]] ; then
-                    set_lldb_xcodebuild_options
-                    # Run the LLDB unittests (gtests).
-                    with_pushd ${LLDB_SOURCE_DIR} \
-                               call xcodebuild -scheme lldb-gtest -configuration ${LLDB_BUILD_MODE} ${lldb_xcodebuild_options[@]}
-                    rc=$?
-                    if [[ "$rc" -ne 0 ]] ; then
-                        >&2 echo "error: LLDB gtests failed"
-                        exit 1
+                if [[ ! "${LLDB_TEST_SWIFT_ONLY}" ]]; then
+                    # Run the gtests.
+                    if [[ "$(uname -s)" == "Darwin" && "$(true_false ${LLDB_BUILD_WITH_XCODE})" == "TRUE" ]] ; then
+                        set_lldb_xcodebuild_options
+                        # Run the LLDB unittests (gtests).
+                        with_pushd ${LLDB_SOURCE_DIR} \
+                                   call xcodebuild -scheme lldb-gtest -configuration ${LLDB_BUILD_MODE} ${lldb_xcodebuild_options[@]}
+                        rc=$?
+                        if [[ "$rc" -ne 0 ]] ; then
+                            >&2 echo "error: LLDB gtests failed"
+                            exit 1
+                        fi
+                    else
+                        with_pushd ${lldb_build_dir} \
+                            ${NINJA_BIN} check-lldb-unit
                     fi
-                else
-                    with_pushd ${lldb_build_dir} \
-                        ${NINJA_BIN} check-lldb-unit
                 fi
 
                 swift_build_dir=$(build_directory ${host} swift)


### PR DESCRIPTION
There is some unresolved flakiness with the unit tests on Linux, which
we don't want interfering with PR testing. See:
https://github.com/apple/swift-lldb/pull/306