### PR TITLE
Fix incorrect indentation in docs.

### DIFF
--- a/docs/ABI/TypeMetadata.rst
+++ b/docs/ABI/TypeMetadata.rst
@@ -424,9 +424,11 @@ contains:
   describing the conformance itself; the form of this field is determined by the
   **protocol conformance flags** described below.
 - The **protocol conformance flags** is a 32-bit field comprised of:
+
   * **Bits 0-3** contain the type metadata record kind, which indicates how
     the **conforming type** field is encoded.
   * **Bits 4-5** contain the kind of witness table. The value can be one of:
+
     0) The **witness table field** is a reference to a witness table.
     1) The **witness table field** is a reference to a **witness table
        accessor** function for an unconditional conformance.


### PR DESCRIPTION
Explanation: A small fix to .rst formatting that prevents docs from building under sphinx.
Scope of issue: Build breakage when sphinx is present.
Origination: Typo when written, as near as I can tell.
Risk: Minimal, unless sphinx changes its mind about valid docs.
Reviewed by: Jordan Rose
Testing: Normal regression tests.
Radar: rdar://37282724