### PR TITLE
[CSSolver] Increment score when performing certain function conversions

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1067,6 +1067,8 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
       return getTypeMatchFailure(locator);
     if (kind < ConstraintKind::Subtype)
       return getTypeMatchFailure(locator);
+
+    increaseScore(SK_FunctionConversion);
   }
   
   // A non-throwing function can be a subtype of a throwing function.
@@ -1814,8 +1816,10 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       // If the 2nd type is an autoclosure, then we don't actually want to
       // treat these as parallel. The first type needs wrapping in a closure
       // despite already being a function type.
-      if (!func1->isAutoClosure() && func2->isAutoClosure())
+      if (!func1->isAutoClosure() && func2->isAutoClosure()) {
+        increaseScore(SK_FunctionConversion);
         break;
+      }
       return matchFunctionTypes(func1, func2, kind, flags, locator);
     }
 

--- a/test/Constraints/rdar37160679.swift
+++ b/test/Constraints/rdar37160679.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
+
+func foo(_ f: @autoclosure () -> Int) {}
+func foo(_ f: () -> Int) {}
+
+func bar(_ f: () throws -> Int) {}
+func bar(_ f: () -> Int) {}
+
+func baz(a1: @autoclosure () -> Int,
+         a2: () -> Int,
+         b1: () throws -> Int,
+         b2: () -> Int) {
+  // CHECK: function_ref @$S12rdar371606793fooyySiyXKF
+  foo(a1)
+  // CHECK: function_ref @$S12rdar371606793fooyySiyXEF
+  foo(a2)
+  // CHECK: function_ref @$S12rdar371606793baryySiyKXEF
+  bar(b1)
+  // CHECK: function_ref @$S12rdar371606793baryySiyXEF
+  bar(b2)
+}


### PR DESCRIPTION
Increase solution score when performing function conversions where only
one side has `@autoclosure` or `throws`. That is going to help pick the
best overload when only difference lays in presence of such attributes.

e.g.

```swift
func foo(_: @autoclosure () -> Int) {}
func foo(_: () -> Int) {}
```

If the argument is itself `@autoclosure` it's preferable to use overload
with `@autoclosure` attribute, otherwise `() -> Int` should be used.

Resolves: rdar://problem/36560486

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
