### PR TITLE
[SIL] Remove unused ResilienceExpansion from SILDeclRef

### DIFF
--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -54,7 +54,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// in source control, you should also update the comment to briefly
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
-const uint16_t VERSION_MINOR = 396; // Last change: add convert_escape_to_noescape
+const uint16_t VERSION_MINOR = 397; // No resilience expansion in SILDeclRef
 
 using DeclIDField = BCFixed<31>;
 

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -1381,7 +1381,6 @@ void irgen::emitObjCIVarInitDestroyDescriptor(IRGenModule &IGM,
   SILDeclRef declRef = SILDeclRef(cd, 
                                   isDestroyer? SILDeclRef::Kind::IVarDestroyer
                                              : SILDeclRef::Kind::IVarInitializer,
-                                  ResilienceExpansion::Minimal,
                                   1, 
                                   /*foreign*/ true);
   Selector selector(declRef);

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1247,11 +1247,10 @@ bool SILParser::parseSILDeclRef(SILDeclRef &Result,
   SILDeclRef::Kind Kind = SILDeclRef::Kind::Func;
   unsigned uncurryLevel = 0;
   bool IsObjC = false;
-  ResilienceExpansion expansion = ResilienceExpansion::Minimal;
 
   if (!P.consumeIf(tok::sil_exclamation)) {
     // Construct SILDeclRef.
-    Result = SILDeclRef(VD, Kind, expansion, /*isCurried=*/false, IsObjC);
+    Result = SILDeclRef(VD, Kind, /*isCurried=*/false, IsObjC);
     if (uncurryLevel < Result.getParameterListCount() - 1)
       Result = Result.asCurried();
     return false;
@@ -1333,13 +1332,12 @@ bool SILParser::parseSILDeclRef(SILDeclRef &Result,
       P.consumeToken(tok::integer_literal);
       ParseState = 2;
     } else
-      // TODO: resilience expansion?
       break;
 
   } while (P.consumeIf(tok::period));
 
   // Construct SILDeclRef.
-  Result = SILDeclRef(VD, Kind, expansion, /*isCurried=*/false, IsObjC);
+  Result = SILDeclRef(VD, Kind, /*isCurried=*/false, IsObjC);
   if (uncurryLevel < Result.getParameterListCount() - 1)
     Result = Result.asCurried();
   return false;

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -104,15 +104,13 @@ bool swift::requiresForeignEntryPoint(ValueDecl *vd) {
 }
 
 SILDeclRef::SILDeclRef(ValueDecl *vd, SILDeclRef::Kind kind,
-                       ResilienceExpansion expansion,
                        bool isCurried, bool isForeign)
-  : loc(vd), kind(kind), Expansion(unsigned(expansion)),
+  : loc(vd), kind(kind),
     isCurried(isCurried), isForeign(isForeign),
     isDirectReference(0), defaultArgIndex(0)
 {}
 
 SILDeclRef::SILDeclRef(SILDeclRef::Loc baseLoc,
-                       ResilienceExpansion expansion,
                        bool isCurried, bool asForeign) 
   : isCurried(isCurried), isDirectReference(0), defaultArgIndex(0)
 {
@@ -153,7 +151,6 @@ SILDeclRef::SILDeclRef(SILDeclRef::Loc baseLoc,
     llvm_unreachable("impossible SILDeclRef loc");
   }
 
-  Expansion = (unsigned) expansion;
   isForeign = asForeign;
 }
 
@@ -689,7 +686,7 @@ SILDeclRef SILDeclRef::getOverridden() const {
   if (!overridden)
     return SILDeclRef();
 
-  return SILDeclRef(overridden, kind, getResilienceExpansion(), isCurried);
+  return SILDeclRef(overridden, kind, isCurried);
 }
 
 SILDeclRef SILDeclRef::getNextOverriddenVTableEntry() const {

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -2184,7 +2184,6 @@ void KeyPathPattern::Profile(llvm::FoldingSetNodeID &ID,
         ID.AddPointer(declRef.loc.getOpaqueValue());
         ID.AddInteger((unsigned)declRef.kind);
         ID.AddInteger(declRef.isCurried);
-        ID.AddBoolean(declRef.Expansion);
         ID.AddBoolean(declRef.isCurried);
         ID.AddBoolean(declRef.isForeign);
         ID.AddBoolean(declRef.isDirectReference);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1872,9 +1872,7 @@ ManagedValue emitCFunctionPointer(SILGenFunction &SGF,
   }
 
   // Produce a reference to the C-compatible entry point for the function.
-  SILDeclRef constant(loc, ResilienceExpansion::Minimal,
-                      /*uncurryLevel*/ 0,
-                      /*foreign*/ true);
+  SILDeclRef constant(loc, /*uncurryLevel*/ 0, /*foreign*/ true);
   SILConstantInfo constantInfo = SGF.getConstantInfo(constant);
 
   return convertCFunctionSignature(

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -727,15 +727,14 @@ static CastConsumptionKind getCastConsumptionKind(unsigned attr) {
 static SILDeclRef getSILDeclRef(ModuleFile *MF,
                                 ArrayRef<uint64_t> ListOfValues,
                                 unsigned &NextIdx) {
-  assert(ListOfValues.size() >= NextIdx+5 &&
-         "Expect 5 numbers for SILDeclRef");
+  assert(ListOfValues.size() >= NextIdx+4 &&
+         "Expect 4 numbers for SILDeclRef");
   SILDeclRef DRef(cast<ValueDecl>(MF->getDecl(ListOfValues[NextIdx])),
                   (SILDeclRef::Kind)ListOfValues[NextIdx+1],
-                  (swift::ResilienceExpansion)ListOfValues[NextIdx+2],
-                  /*isCurried=*/false, ListOfValues[NextIdx+4] > 0);
-  if (ListOfValues[NextIdx+3] < DRef.getParameterListCount() - 1)
+                  /*isCurried=*/false, ListOfValues[NextIdx+3] > 0);
+  if (ListOfValues[NextIdx+2] < DRef.getParameterListCount() - 1)
     DRef = DRef.asCurried();
-  NextIdx += 5;
+  NextIdx += 4;
   return DRef;
 }
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -470,7 +470,6 @@ static void handleSILDeclRef(Serializer &S, const SILDeclRef &Ref,
                              SmallVectorImpl<ValueID> &ListOfValues) {
   ListOfValues.push_back(S.addDeclRef(Ref.getDecl()));
   ListOfValues.push_back((unsigned)Ref.kind);
-  ListOfValues.push_back((unsigned)Ref.getResilienceExpansion());
   ListOfValues.push_back(Ref.getParameterListCount() - 1);
   ListOfValues.push_back(Ref.isForeign);
 }


### PR DESCRIPTION
We ended up not using this, so let's not leave it in as cruft. No functionality change.