### PR TITLE
[GSB] Term rewriting for same-type constraints

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -819,6 +819,12 @@ public:
   bool simplifyType(GenericParamKey base,
                     SmallVectorImpl<AssociatedTypeDecl *> &path);
 
+  /// Simplify the given type down to its anchor.
+  ///
+  /// \returns null if the type involved dependent member types that
+  /// don't have associated types.
+  Type simplifyType(Type type);
+
   /// Verify the correctness of the given generic signature.
   ///
   /// This routine will test that the given generic signature is both minimal

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -273,9 +273,8 @@ public:
       /// The cached anchor itself.
       Type anchor;
 
-      /// The number of members of the equivalence class when the archetype
-      /// anchor was cached.
-      unsigned numMembers;
+      /// The generation at which the anchor was last computed.
+      unsigned lastGeneration;
     } archetypeAnchorCache;
 
     /// Describes a cached nested type.

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -258,11 +258,13 @@ public:
     Type getTypeInContext(GenericSignatureBuilder &builder,
                           GenericEnvironment *genericEnv);
 
-    /// Dump a debugging representation of this equivalence class.
-    void dump(llvm::raw_ostream &out) const;
+    /// Dump a debugging representation of this equivalence class,
+    void dump(llvm::raw_ostream &out,
+              GenericSignatureBuilder *builder = nullptr) const;
 
-    LLVM_ATTRIBUTE_DEPRECATED(void dump() const,
-                              "only for use in the debugger");
+    LLVM_ATTRIBUTE_DEPRECATED(
+                  void dump(GenericSignatureBuilder *builder = nullptr) const,
+                  "only for use in the debugger");
 
     /// Caches.
 
@@ -443,6 +445,11 @@ private:
 
   /// Note that we have added the nested type nestedPA
   void addedNestedType(PotentialArchetype *nestedPA);
+
+  /// Add a rewrite rule for a same-type constraint between the given
+  /// types.
+  void addSameTypeRewriteRule(PotentialArchetype *type1,
+                              PotentialArchetype *type2);
 
   /// \brief Add a new conformance requirement specifying that the given
   /// potential archetypes are equivalent.
@@ -801,6 +808,16 @@ public:
 
   /// Determine whether the two given types are in the same equivalence class.
   bool areInSameEquivalenceClass(Type type1, Type type2);
+
+  /// Simplify the given type, which is described by a base parameter
+  /// followed by a sequence of associated types.
+  ///
+  /// \param path is updated to describe the best path from the given base
+  /// to the same equivalence class.
+  ///
+  /// \returns true if the path was simplified at all.
+  bool simplifyType(GenericParamKey base,
+                    SmallVectorImpl<AssociatedTypeDecl *> &path);
 
   /// Verify the correctness of the given generic signature.
   ///

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -809,21 +809,11 @@ public:
   /// Determine whether the two given types are in the same equivalence class.
   bool areInSameEquivalenceClass(Type type1, Type type2);
 
-  /// Simplify the given type, which is described by a base parameter
-  /// followed by a sequence of associated types.
-  ///
-  /// \param path is updated to describe the best path from the given base
-  /// to the same equivalence class.
-  ///
-  /// \returns true if the path was simplified at all.
-  bool simplifyType(GenericParamKey base,
-                    SmallVectorImpl<AssociatedTypeDecl *> &path);
-
-  /// Simplify the given type down to its anchor.
+  /// Simplify the given dependent type down to its canonical representation.
   ///
   /// \returns null if the type involved dependent member types that
   /// don't have associated types.
-  Type simplifyType(Type type);
+  Type getCanonicalTypeParameter(Type type);
 
   /// Verify the correctness of the given generic signature.
   ///


### PR DESCRIPTION
Introduce a new representation of same-type constraints as rewrite
rules in a term-rewriting system, where each same-type constraint maps
to a rewrite rule that produces a "more canonical"
term. Fully-simplifying a type according to these rewrite rules will
produce the canonical representation of that type, i.e., the "anchor"
of its equivalence class. Use this term-rewriting system to replace the
existing, weird "anchor" computation.

The rewrite rules are stored as a prefix tree, such that a "match"
operation walks the tree matching the prefix of a path of associated
type references, e.g., SubSequence -> SubSequence -> Element, and any
node within the tree can provide a replacement path (e.g.,
"Element"). The "dump" operation provides a visualization of the tree,
e.g.,

    `--(cont'd)
        `--Sequence.Iterator
        |   `--IteratorProtocol.Element --> [Sequence.Element]
        `--Sequence.SubSequence --> []
        |   `--Sequence.Element --> [Sequence.Iterator -> IteratorProtocol.Element]
        |   |   `--(cont'd) --> [Sequence.Element]
        |   `--Sequence.Iterator --> [Sequence.Iterator]
        |   |   `--IteratorProtocol.Element --> [Sequence.Iterator -> IteratorProtocol.Element]
        |   `--Sequence.SubSequence --> []
        |   |   `--Sequence.Element --> [Sequence.Element]
        |   |   `--Sequence.Iterator --> [Sequence.Iterator]
        |   `--C.Index --> [C.Index]
        |   `--C.Indices --> [C.Indices]
        |       `--Sequence.Element --> [C.Indices -> Sequence.Element]
        |       `--Sequence.SubSequence --> [C.Indices -> Sequence.SubSequence]
        |       `--C.Index --> [C.Indices -> C.Index]
        |       `--C.Indices --> [C.Indices -> C.Indices]
        `--C.Index --> [Sequence.Element]
        `--C.Indices
            `--Sequence.Element --> [C.Index]

