### PR TITLE
[4.1] Fix SR-6837 - allow function conversion for -swift-version 4 *only*

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1173,6 +1173,16 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
         if (auto *paren2 = dyn_cast<ParenType>(func2Input.getPointer())) {
           if (!isa<ParenType>(func1Input.getPointer()))
             func2Input = paren2->getUnderlyingType();
+        } else if (getASTContext().isSwiftVersionAtLeast(4)
+                   && !getASTContext().isSwiftVersionAtLeast(5)
+                   && !isa<ParenType>(func2Input.getPointer())) {
+          auto *simplified = locator.trySimplifyToExpr();
+          // We somehow let tuple unsplatting function conversions
+          // through in some cases in Swift 4, so let's let that
+          // continue to work, but only for Swift 4.
+          if (simplified && isa<DeclRefExpr>(simplified))
+            if (auto *paren1 = dyn_cast<ParenType>(func1Input.getPointer()))
+              func1Input = paren1->getUnderlyingType();
         }
       }
     }

--- a/test/Compatibility/tuple_arguments.swift
+++ b/test/Compatibility/tuple_arguments.swift
@@ -1493,3 +1493,12 @@ do {
   func bar() -> ((()) -> Void)? { return nil }
   foo(bar()) // OK in Swift 3 mode
 }
+
+// https://bugs.swift.org/browse/SR-6837
+do {
+  func takeFn(fn: (_ i: Int, _ j: Int?) -> ()) {}
+  func takePair(_ pair: (Int, Int?)) {}
+  takeFn(fn: takePair)
+  takeFn(fn: { (pair: (Int, Int?)) in } )
+  takeFn { (pair: (Int, Int?)) in }
+}

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1628,3 +1628,14 @@ do {
   func bar() -> ((()) -> Void)? { return nil }
   foo(bar()) // expected-error {{cannot convert value of type '((()) -> Void)?' to expected argument type '(() -> Void)?'}}
 }
+
+// https://bugs.swift.org/browse/SR-6837
+do {
+  func takeFn(fn: (_ i: Int, _ j: Int?) -> ()) {}
+  func takePair(_ pair: (Int, Int?)) {}
+  takeFn(fn: takePair) // Allow for -swift-version 4, but not later
+  takeFn(fn: { (pair: (Int, Int?)) in } ) // Disallow for -swift-version 4 and later
+  // expected-error@-1 {{contextual closure type '(Int, Int?) -> ()' expects 2 arguments, but 1 was used in closure body}}
+  takeFn { (pair: (Int, Int?)) in } // Disallow for -swift-version 4 and later
+  // expected-error@-1 {{contextual closure type '(Int, Int?) -> ()' expects 2 arguments, but 1 was used in closure body}}
+}


### PR DESCRIPTION
- **Explanation**: We broke compatibility with something we did not intend to support, but accidentally did, in Swift 4 (and had previously in Swift 3).

- **Scope of Issue**: In some cases we allowed functions taking an N-tuple to be passed where functions taking N individual arguments were expected.

- **Origination**: A change was made to make function types more consistent, to avoid exactly this kind of "emergent behavior".

- **Risk**: The fix here is very targeted, so the risk seems low.

- **Bug**: rdar://problem/36875195 / https://bugs.swift.org/browse/SR-6837

- **Reviewed By**: Doug Gregor

- **Testing**: Regression tests and source compatibility testing.