### PR TITLE
[5.0] Fix SR-6837 - allow function conversion for -swift-version 4 *only*

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1173,6 +1173,16 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
         if (auto *paren2 = dyn_cast<ParenType>(func2Input.getPointer())) {
           if (!func1Input->hasParenSugar())
             func2Input = paren2->getUnderlyingType();
+        } else if (getASTContext().isSwiftVersionAtLeast(4)
+                   && !getASTContext().isSwiftVersionAtLeast(5)
+                   && !func2Input->hasParenSugar()) {
+          auto *simplified = locator.trySimplifyToExpr();
+          // We somehow let tuple unsplatting function conversions
+          // through in some cases in Swift 4, so let's let that
+          // continue to work, but only for Swift 4.
+          if (simplified && isa<DeclRefExpr>(simplified))
+            if (auto *paren1 = dyn_cast<ParenType>(func1Input.getPointer()))
+              func1Input = paren1->getUnderlyingType();
         }
       }
     }

--- a/test/Compatibility/tuple_arguments.swift
+++ b/test/Compatibility/tuple_arguments.swift
@@ -1507,3 +1507,12 @@ public extension Optional {
     return value.apply(self)
   }
 } 
+
+// https://bugs.swift.org/browse/SR-6837
+do {
+  func takeFn(fn: (_ i: Int, _ j: Int?) -> ()) {}
+  func takePair(_ pair: (Int, Int?)) {}
+  takeFn(fn: takePair)
+  takeFn(fn: { (pair: (Int, Int?)) in } )
+  takeFn { (pair: (Int, Int?)) in }
+}

--- a/test/Constraints/tuple_arguments.swift
+++ b/test/Constraints/tuple_arguments.swift
@@ -1642,3 +1642,15 @@ public extension Optional {
     return value.apply(self)
   }
 }
+
+
+// https://bugs.swift.org/browse/SR-6837
+do {
+  func takeFn(fn: (_ i: Int, _ j: Int?) -> ()) {}
+  func takePair(_ pair: (Int, Int?)) {}
+  takeFn(fn: takePair) // Allow for -swift-version 4, but not later
+  takeFn(fn: { (pair: (Int, Int?)) in } ) // Disallow for -swift-version 4 and later
+  // expected-error@-1 {{contextual closure type '(Int, Int?) -> ()' expects 2 arguments, but 1 was used in closure body}}
+  takeFn { (pair: (Int, Int?)) in } // Disallow for -swift-version 4 and later
+  // expected-error@-1 {{contextual closure type '(Int, Int?) -> ()' expects 2 arguments, but 1 was used in closure body}}
+}


### PR DESCRIPTION
We inadvertantly allowed a function conversion for Swift 4 that we did
not intend to allow.

This commit adds an extremely narrow fix to continue to allow this for
-swift-verson 4 only.

Fixes rdar://problem/36875195 / https://bugs.swift.org/browse/SR-6837

(cherry picked from commit 1de989764499ce163b353e30fffca986ebcae41a)
