### PR TITLE
[Syntax] Introduce CodeBlockItem

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3905,7 +3905,8 @@ bool Parser::parseGetSetImpl(ParseDeclOptions Flags,
   if (Flags.contains(PD_InProtocol) || isInSILMode()) {
     if (Tok.is(tok::r_brace)) {
       // Give syntax node an empty statement list.
-      SyntaxParsingContext StmtListContext(SyntaxContext, SyntaxKind::StmtList);
+      SyntaxParsingContext StmtListContext(SyntaxContext,
+                                           SyntaxKind::CodeBlockItemList);
     }
     while (Tok.isNot(tok::r_brace)) {
       if (Tok.is(tok::eof))
@@ -3988,7 +3989,8 @@ bool Parser::parseGetSetImpl(ParseDeclOptions Flags,
   // an implicit fallthrough off the end.
   if (Tok.is(tok::r_brace)) {
     // Give syntax node an empty statement list.
-    SyntaxParsingContext StmtListContext(SyntaxContext, SyntaxKind::StmtList);
+    SyntaxParsingContext StmtListContext(SyntaxContext,
+                                         SyntaxKind::CodeBlockItemList);
     diagnose(Tok, diag::computed_property_no_accessors);
     return true;
   }

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -68,17 +68,10 @@ RC<RawSyntax> SyntaxParsingContext::bridgeAs(SyntaxContextKind Kind,
   if (Parts.size() == 1) {
     auto RawNode = Parts.front();
     switch (Kind) {
-    case SyntaxContextKind::Stmt: {
-      if (RawNode->isStmt())
-        return RawNode;
-      else if (RawNode->isDecl())
-        return createSyntaxAs(SyntaxKind::DeclarationStmt, Parts);
-      else if (RawNode->isExpr())
-        return createSyntaxAs(SyntaxKind::ExpressionStmt, Parts);
-      else
+    case SyntaxContextKind::Stmt:
+      if (!RawNode->isStmt())
         return makeUnknownSyntax(SyntaxKind::UnknownStmt, Parts);
       break;
-    }
     case SyntaxContextKind::Decl:
       if (!RawNode->isDecl())
         return makeUnknownSyntax(SyntaxKind::UnknownDecl, Parts);
@@ -186,6 +179,7 @@ void SyntaxParsingContext::createNodeInPlace(SyntaxKind Kind) {
     createNodeInPlace(Kind, Pair.first);
     break;
   }
+  case SyntaxKind::CodeBlockItem:
   case SyntaxKind::IdentifierExpr:
   case SyntaxKind::SpecializeExpr:
   case SyntaxKind::MemberAccessExpr:
@@ -255,8 +249,8 @@ void finalizeSourceFile(RootContextData &RootData,
 
   if (SF.hasSyntaxRoot()) {
     auto SourceRaw = SF.getSyntaxRoot().getRaw();
-    auto Decls = SourceRaw->getChild(SourceFileSyntax::Cursor::TopLevelDecls)
-                     ->getLayout();
+    auto Decls =
+        SourceRaw->getChild(SourceFileSyntax::Cursor::Items)->getLayout();
     std::copy(Decls.begin(), Decls.end(), std::back_inserter(AllTopLevel));
     EOFToken = SourceRaw->getChild(SourceFileSyntax::Cursor::EOFToken);
   }
@@ -267,12 +261,13 @@ void finalizeSourceFile(RootContextData &RootData,
   }
 
   for (auto RawNode : Parts) {
-    if (RawNode->getKind() != SyntaxKind::StmtList)
+    if (RawNode->getKind() != SyntaxKind::CodeBlockItemList)
       // FIXME: Skip toplevel garbage nodes for now. we shouldn't emit them in
       // the first place.
       continue;
-    AllTopLevel.push_back(
-        SyntaxFactory::createRaw(SyntaxKind::TopLevelCodeDecl, {RawNode}));
+
+    auto Items = RawNode->getLayout();
+    std::copy(Items.begin(), Items.end(), std::back_inserter(AllTopLevel));
   }
 
   if (!EOFToken)
@@ -281,8 +276,10 @@ void finalizeSourceFile(RootContextData &RootData,
   auto newRaw = SyntaxFactory::createRaw(
       SyntaxKind::SourceFile,
       {
-          SyntaxFactory::createRaw(SyntaxKind::DeclList, AllTopLevel), EOFToken,
+          SyntaxFactory::createRaw(SyntaxKind::CodeBlockItemList, AllTopLevel),
+          EOFToken,
       });
+  assert(newRaw);
   SF.setSyntaxRoot(make<SourceFileSyntax>(newRaw));
 
   if (SF.getASTContext().LangOpts.VerifySyntaxTree) {

--- a/lib/Syntax/RawSyntax.cpp
+++ b/lib/Syntax/RawSyntax.cpp
@@ -30,7 +30,7 @@ static bool isTrivialSyntaxKind(SyntaxKind Kind) {
     return true;
   switch(Kind) {
   case SyntaxKind::SourceFile:
-  case SyntaxKind::TopLevelCodeDecl:
+  case SyntaxKind::CodeBlockItem:
   case SyntaxKind::ExpressionStmt:
   case SyntaxKind::DeclarationStmt:
     return true;
@@ -179,6 +179,8 @@ RawSyntax::accumulateAbsolutePosition(AbsolutePosition &Pos) const {
       Trailer.accumulateAbsolutePosition(Pos);
   } else {
     for (auto &Child : getLayout()) {
+      if (!Child)
+        continue;
       auto Result = Child->accumulateAbsolutePosition(Pos);
       if (!Ret && Result)
         Ret = Result;
@@ -254,6 +256,8 @@ void RawSyntax::dump(llvm::raw_ostream &OS, unsigned Indent) const {
     }
   } else {
     for (auto &Child : getLayout()) {
+      if (!Child)
+        continue;
       OS << "\n";
       Child->dump(OS, Indent + 1);
     }

--- a/test/SwiftSyntax/SyntaxChildren.swift
+++ b/test/SwiftSyntax/SyntaxChildren.swift
@@ -28,25 +28,21 @@ var SyntaxChildrenAPI = TestSuite("SyntaxChildrenAPI")
 SyntaxChildrenAPI.test("IterateWithAllPresent") {
   let returnStmt = SyntaxFactory.makeReturnStmt(
     returnKeyword: SyntaxFactory.makeReturnKeyword(),
-    expression: SyntaxFactory.makeBlankUnknownExpr(),
-    semicolon: SyntaxFactory.makeSemicolonToken())
+    expression: SyntaxFactory.makeBlankUnknownExpr())
 
   var iterator = returnStmt.children.makeIterator()
   expectNext(&iterator) { ($0 as? TokenSyntax)?.tokenKind == .returnKeyword }
   expectNext(&iterator) { $0 is ExprSyntax }
-  expectNext(&iterator) { ($0 as? TokenSyntax)?.tokenKind == .semicolon }
   expectNextIsNil(&iterator)
 }
 
 SyntaxChildrenAPI.test("IterateWithSomeMissing") {
   let returnStmt = SyntaxFactory.makeReturnStmt(
     returnKeyword: SyntaxFactory.makeReturnKeyword(),
-    expression: nil,
-    semicolon: SyntaxFactory.makeSemicolonToken())
+    expression: nil)
 
   var iterator = returnStmt.children.makeIterator()
   expectNext(&iterator) { ($0 as? TokenSyntax)?.tokenKind == .returnKeyword }
-  expectNext(&iterator) { ($0 as? TokenSyntax)?.tokenKind == .semicolon }
   expectNextIsNil(&iterator)
 }
 

--- a/test/Syntax/Inputs/serialize_multiple_decls.json
+++ b/test/Syntax/Inputs/serialize_multiple_decls.json
@@ -2,193 +2,181 @@
   "kind": "SourceFile",
   "layout": [
     {
-      "kind": "DeclList",
+      "kind": "CodeBlockItemList",
       "layout": [
         {
-          "kind": "TopLevelCodeDecl",
+          "kind": "CodeBlockItem",
           "layout": [
             {
-              "kind": "StmtList",
+              "kind": "StructDecl",
               "layout": [
+                null,
+                null,
                 {
-                  "kind": "DeclarationStmt",
-                  "layout": [
+                  "tokenKind": {
+                    "kind": "kw_struct"
+                  },
+                  "leadingTrivia": [
                     {
-                      "kind": "StructDecl",
-                      "layout": [
-                        null,
-                        null,
-                        {
-                          "tokenKind": {
-                            "kind": "kw_struct"
-                          },
-                          "leadingTrivia": [
-                            {
-                              "kind": "LineComment",
-                              "value": "\/\/ RUN: %swift-syntax-test -input-source-filename %s -serialize-raw-tree > %t"
-                            },
-                            {
-                              "kind": "Newline",
-                              "value": 1
-                            },
-                            {
-                              "kind": "LineComment",
-                              "value": "\/\/ RUN: diff %t %S\/Inputs\/serialize_multiple_decls.json"
-                            },
-                            {
-                              "kind": "Newline",
-                              "value": 2
-                            }
-                          ],
-                          "trailingTrivia": [
-                            {
-                              "kind": "Space",
-                              "value": 1
-                            }
-                          ],
-                          "presence": "Present"
-                        },
-                        {
-                          "tokenKind": {
-                            "kind": "identifier",
-                            "text": "A"
-                          },
-                          "leadingTrivia": [],
-                          "trailingTrivia": [
-                            {
-                              "kind": "Space",
-                              "value": 1
-                            }
-                          ],
-                          "presence": "Present"
-                        },
-                        null,
-                        null,
-                        null,
-                        {
-                          "kind": "MemberDeclBlock",
-                          "layout": [
-                            {
-                              "tokenKind": {
-                                "kind": "l_brace"
-                              },
-                              "leadingTrivia": [],
-                              "trailingTrivia": [],
-                              "presence": "Present"
-                            },
-                            {
-                              "kind": "DeclList",
-                              "layout": [],
-                              "presence": "Present"
-                            },
-                            {
-                              "tokenKind": {
-                                "kind": "r_brace"
-                              },
-                              "leadingTrivia": [
-                                {
-                                  "kind": "Newline",
-                                  "value": 1
-                                }
-                              ],
-                              "trailingTrivia": [],
-                              "presence": "Present"
-                            }
-                          ],
-                          "presence": "Present"
-                        }
-                      ],
-                      "presence": "Present"
+                      "kind": "LineComment",
+                      "value": "\/\/ RUN: %swift-syntax-test -input-source-filename %s -serialize-raw-tree > %t"
                     },
-                    null
+                    {
+                      "kind": "Newline",
+                      "value": 1
+                    },
+                    {
+                      "kind": "LineComment",
+                      "value": "\/\/ RUN: diff %t %S\/Inputs\/serialize_multiple_decls.json"
+                    },
+                    {
+                      "kind": "Newline",
+                      "value": 2
+                    }
+                  ],
+                  "trailingTrivia": [
+                    {
+                      "kind": "Space",
+                      "value": 1
+                    }
                   ],
                   "presence": "Present"
                 },
                 {
-                  "kind": "DeclarationStmt",
+                  "tokenKind": {
+                    "kind": "identifier",
+                    "text": "A"
+                  },
+                  "leadingTrivia": [],
+                  "trailingTrivia": [
+                    {
+                      "kind": "Space",
+                      "value": 1
+                    }
+                  ],
+                  "presence": "Present"
+                },
+                null,
+                null,
+                null,
+                {
+                  "kind": "MemberDeclBlock",
                   "layout": [
                     {
-                      "kind": "StructDecl",
-                      "layout": [
-                        null,
-                        null,
-                        {
-                          "tokenKind": {
-                            "kind": "kw_struct"
-                          },
-                          "leadingTrivia": [
-                            {
-                              "kind": "Newline",
-                              "value": 2
-                            }
-                          ],
-                          "trailingTrivia": [
-                            {
-                              "kind": "Space",
-                              "value": 1
-                            }
-                          ],
-                          "presence": "Present"
-                        },
-                        {
-                          "tokenKind": {
-                            "kind": "identifier",
-                            "text": "B"
-                          },
-                          "leadingTrivia": [],
-                          "trailingTrivia": [
-                            {
-                              "kind": "Space",
-                              "value": 1
-                            }
-                          ],
-                          "presence": "Present"
-                        },
-                        null,
-                        null,
-                        null,
-                        {
-                          "kind": "MemberDeclBlock",
-                          "layout": [
-                            {
-                              "tokenKind": {
-                                "kind": "l_brace"
-                              },
-                              "leadingTrivia": [],
-                              "trailingTrivia": [],
-                              "presence": "Present"
-                            },
-                            {
-                              "kind": "DeclList",
-                              "layout": [],
-                              "presence": "Present"
-                            },
-                            {
-                              "tokenKind": {
-                                "kind": "r_brace"
-                              },
-                              "leadingTrivia": [
-                                {
-                                  "kind": "Newline",
-                                  "value": 1
-                                }
-                              ],
-                              "trailingTrivia": [],
-                              "presence": "Present"
-                            }
-                          ],
-                          "presence": "Present"
-                        }
-                      ],
+                      "tokenKind": {
+                        "kind": "l_brace"
+                      },
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
                       "presence": "Present"
                     },
-                    null
+                    {
+                      "kind": "DeclList",
+                      "layout": [],
+                      "presence": "Present"
+                    },
+                    {
+                      "tokenKind": {
+                        "kind": "r_brace"
+                      },
+                      "leadingTrivia": [
+                        {
+                          "kind": "Newline",
+                          "value": 1
+                        }
+                      ],
+                      "trailingTrivia": [],
+                      "presence": "Present"
+                    }
                   ],
                   "presence": "Present"
                 }
               ],
               "presence": "Present"
-            }
+            },
+            null
+          ],
+          "presence": "Present"
+        },
+        {
+          "kind": "CodeBlockItem",
+          "layout": [
+            {
+              "kind": "StructDecl",
+              "layout": [
+                null,
+                null,
+                {
+                  "tokenKind": {
+                    "kind": "kw_struct"
+                  },
+                  "leadingTrivia": [
+                    {
+                      "kind": "Newline",
+                      "value": 2
+                    }
+                  ],
+                  "trailingTrivia": [
+                    {
+                      "kind": "Space",
+                      "value": 1
+                    }
+                  ],
+                  "presence": "Present"
+                },
+                {
+                  "tokenKind": {
+                    "kind": "identifier",
+                    "text": "B"
+                  },
+                  "leadingTrivia": [],
+                  "trailingTrivia": [
+                    {
+                      "kind": "Space",
+                      "value": 1
+                    }
+                  ],
+                  "presence": "Present"
+                },
+                null,
+                null,
+                null,
+                {
+                  "kind": "MemberDeclBlock",
+                  "layout": [
+                    {
+                      "tokenKind": {
+                        "kind": "l_brace"
+                      },
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "presence": "Present"
+                    },
+                    {
+                      "kind": "DeclList",
+                      "layout": [],
+                      "presence": "Present"
+                    },
+                    {
+                      "tokenKind": {
+                        "kind": "r_brace"
+                      },
+                      "leadingTrivia": [
+                        {
+                          "kind": "Newline",
+                          "value": 1
+                        }
+                      ],
+                      "trailingTrivia": [],
+                      "presence": "Present"
+                    }
+                  ],
+                  "presence": "Present"
+                }
+              ],
+              "presence": "Present"
+            },
+            null
           ],
           "presence": "Present"
         }

--- a/test/Syntax/Inputs/serialize_struct_decl.json
+++ b/test/Syntax/Inputs/serialize_struct_decl.json
@@ -2,354 +2,85 @@
   "kind": "SourceFile",
   "layout": [
     {
-      "kind": "DeclList",
+      "kind": "CodeBlockItemList",
       "layout": [
         {
-          "kind": "TopLevelCodeDecl",
+          "kind": "CodeBlockItem",
           "layout": [
             {
-              "kind": "StmtList",
+              "kind": "StructDecl",
               "layout": [
+                null,
+                null,
                 {
-                  "kind": "DeclarationStmt",
+                  "tokenKind": {
+                    "kind": "kw_struct"
+                  },
+                  "leadingTrivia": [
+                    {
+                      "kind": "LineComment",
+                      "value": "\/\/ RUN: %swift-syntax-test -input-source-filename %s -serialize-raw-tree > %t"
+                    },
+                    {
+                      "kind": "Newline",
+                      "value": 1
+                    },
+                    {
+                      "kind": "LineComment",
+                      "value": "\/\/ RUN: diff %t %S\/Inputs\/serialize_struct_decl.json"
+                    },
+                    {
+                      "kind": "Newline",
+                      "value": 2
+                    }
+                  ],
+                  "trailingTrivia": [
+                    {
+                      "kind": "Space",
+                      "value": 1
+                    }
+                  ],
+                  "presence": "Present"
+                },
+                {
+                  "tokenKind": {
+                    "kind": "identifier",
+                    "text": "Foo"
+                  },
+                  "leadingTrivia": [],
+                  "trailingTrivia": [
+                    {
+                      "kind": "Space",
+                      "value": 1
+                    }
+                  ],
+                  "presence": "Present"
+                },
+                null,
+                null,
+                null,
+                {
+                  "kind": "MemberDeclBlock",
                   "layout": [
                     {
-                      "kind": "StructDecl",
+                      "tokenKind": {
+                        "kind": "l_brace"
+                      },
+                      "leadingTrivia": [],
+                      "trailingTrivia": [],
+                      "presence": "Present"
+                    },
+                    {
+                      "kind": "DeclList",
                       "layout": [
-                        null,
-                        null,
                         {
-                          "tokenKind": {
-                            "kind": "kw_struct"
-                          },
-                          "leadingTrivia": [
-                            {
-                              "kind": "LineComment",
-                              "value": "\/\/ RUN: %swift-syntax-test -input-source-filename %s -serialize-raw-tree > %t"
-                            },
-                            {
-                              "kind": "Newline",
-                              "value": 1
-                            },
-                            {
-                              "kind": "LineComment",
-                              "value": "\/\/ RUN: diff %t %S\/Inputs\/serialize_struct_decl.json"
-                            },
-                            {
-                              "kind": "Newline",
-                              "value": 2
-                            }
-                          ],
-                          "trailingTrivia": [
-                            {
-                              "kind": "Space",
-                              "value": 1
-                            }
-                          ],
-                          "presence": "Present"
-                        },
-                        {
-                          "tokenKind": {
-                            "kind": "identifier",
-                            "text": "Foo"
-                          },
-                          "leadingTrivia": [],
-                          "trailingTrivia": [
-                            {
-                              "kind": "Space",
-                              "value": 1
-                            }
-                          ],
-                          "presence": "Present"
-                        },
-                        null,
-                        null,
-                        null,
-                        {
-                          "kind": "MemberDeclBlock",
+                          "kind": "VariableDecl",
                           "layout": [
+                            null,
+                            null,
                             {
                               "tokenKind": {
-                                "kind": "l_brace"
-                              },
-                              "leadingTrivia": [],
-                              "trailingTrivia": [],
-                              "presence": "Present"
-                            },
-                            {
-                              "kind": "DeclList",
-                              "layout": [
-                                {
-                                  "kind": "VariableDecl",
-                                  "layout": [
-                                    null,
-                                    null,
-                                    {
-                                      "tokenKind": {
-                                        "kind": "kw_let"
-                                      },
-                                      "leadingTrivia": [
-                                        {
-                                          "kind": "Newline",
-                                          "value": 1
-                                        },
-                                        {
-                                          "kind": "Space",
-                                          "value": 2
-                                        }
-                                      ],
-                                      "trailingTrivia": [
-                                        {
-                                          "kind": "Space",
-                                          "value": 3
-                                        }
-                                      ],
-                                      "presence": "Present"
-                                    },
-                                    {
-                                      "kind": "PatternBindingList",
-                                      "layout": [
-                                        {
-                                          "kind": "PatternBinding",
-                                          "layout": [
-                                            {
-                                              "kind": "IdentifierPattern",
-                                              "layout": [
-                                                {
-                                                  "tokenKind": {
-                                                    "kind": "identifier",
-                                                    "text": "bar"
-                                                  },
-                                                  "leadingTrivia": [],
-                                                  "trailingTrivia": [
-                                                    {
-                                                      "kind": "Space",
-                                                      "value": 1
-                                                    }
-                                                  ],
-                                                  "presence": "Present"
-                                                }
-                                              ],
-                                              "presence": "Present"
-                                            },
-                                            {
-                                              "kind": "TypeAnnotation",
-                                              "layout": [
-                                                {
-                                                  "tokenKind": {
-                                                    "kind": "colon"
-                                                  },
-                                                  "leadingTrivia": [],
-                                                  "trailingTrivia": [
-                                                    {
-                                                      "kind": "Space",
-                                                      "value": 1
-                                                    }
-                                                  ],
-                                                  "presence": "Present"
-                                                },
-                                                {
-                                                  "kind": "SimpleTypeIdentifier",
-                                                  "layout": [
-                                                    {
-                                                      "tokenKind": {
-                                                        "kind": "identifier",
-                                                        "text": "Int"
-                                                      },
-                                                      "leadingTrivia": [],
-                                                      "trailingTrivia": [],
-                                                      "presence": "Present"
-                                                    },
-                                                    null
-                                                  ],
-                                                  "presence": "Present"
-                                                }
-                                              ],
-                                              "presence": "Present"
-                                            },
-                                            null,
-                                            null,
-                                            null
-                                          ],
-                                          "presence": "Present"
-                                        }
-                                      ],
-                                      "presence": "Present"
-                                    }
-                                  ],
-                                  "presence": "Present"
-                                },
-                                {
-                                  "kind": "VariableDecl",
-                                  "layout": [
-                                    null,
-                                    null,
-                                    {
-                                      "tokenKind": {
-                                        "kind": "kw_let"
-                                      },
-                                      "leadingTrivia": [
-                                        {
-                                          "kind": "Newline",
-                                          "value": 2
-                                        },
-                                        {
-                                          "kind": "Space",
-                                          "value": 2
-                                        }
-                                      ],
-                                      "trailingTrivia": [
-                                        {
-                                          "kind": "Space",
-                                          "value": 1
-                                        }
-                                      ],
-                                      "presence": "Present"
-                                    },
-                                    {
-                                      "kind": "PatternBindingList",
-                                      "layout": [
-                                        {
-                                          "kind": "PatternBinding",
-                                          "layout": [
-                                            {
-                                              "kind": "IdentifierPattern",
-                                              "layout": [
-                                                {
-                                                  "tokenKind": {
-                                                    "kind": "identifier",
-                                                    "text": "baz"
-                                                  },
-                                                  "leadingTrivia": [],
-                                                  "trailingTrivia": [
-                                                    {
-                                                      "kind": "Space",
-                                                      "value": 1
-                                                    }
-                                                  ],
-                                                  "presence": "Present"
-                                                }
-                                              ],
-                                              "presence": "Present"
-                                            },
-                                            {
-                                              "kind": "TypeAnnotation",
-                                              "layout": [
-                                                {
-                                                  "tokenKind": {
-                                                    "kind": "colon"
-                                                  },
-                                                  "leadingTrivia": [],
-                                                  "trailingTrivia": [
-                                                    {
-                                                      "kind": "Space",
-                                                      "value": 1
-                                                    }
-                                                  ],
-                                                  "presence": "Present"
-                                                },
-                                                {
-                                                  "kind": "SimpleTypeIdentifier",
-                                                  "layout": [
-                                                    {
-                                                      "tokenKind": {
-                                                        "kind": "identifier",
-                                                        "text": "Array"
-                                                      },
-                                                      "leadingTrivia": [],
-                                                      "trailingTrivia": [
-                                                        {
-                                                          "kind": "Space",
-                                                          "value": 1
-                                                        }
-                                                      ],
-                                                      "presence": "Present"
-                                                    },
-                                                    {
-                                                      "kind": "GenericArgumentClause",
-                                                      "layout": [
-                                                        {
-                                                          "tokenKind": {
-                                                            "kind": "l_angle"
-                                                          },
-                                                          "leadingTrivia": [],
-                                                          "trailingTrivia": [
-                                                            {
-                                                              "kind": "Space",
-                                                              "value": 1
-                                                            }
-                                                          ],
-                                                          "presence": "Present"
-                                                        },
-                                                        {
-                                                          "kind": "GenericArgumentList",
-                                                          "layout": [
-                                                            {
-                                                              "kind": "GenericArgument",
-                                                              "layout": [
-                                                                {
-                                                                  "kind": "SimpleTypeIdentifier",
-                                                                  "layout": [
-                                                                    {
-                                                                      "tokenKind": {
-                                                                        "kind": "identifier",
-                                                                        "text": "Int"
-                                                                      },
-                                                                      "leadingTrivia": [],
-                                                                      "trailingTrivia": [
-                                                                        {
-                                                                          "kind": "Space",
-                                                                          "value": 1
-                                                                        }
-                                                                      ],
-                                                                      "presence": "Present"
-                                                                    },
-                                                                    null
-                                                                  ],
-                                                                  "presence": "Present"
-                                                                },
-                                                                null
-                                                              ],
-                                                              "presence": "Present"
-                                                            }
-                                                          ],
-                                                          "presence": "Present"
-                                                        },
-                                                        {
-                                                          "tokenKind": {
-                                                            "kind": "r_angle"
-                                                          },
-                                                          "leadingTrivia": [],
-                                                          "trailingTrivia": [],
-                                                          "presence": "Present"
-                                                        }
-                                                      ],
-                                                      "presence": "Present"
-                                                    }
-                                                  ],
-                                                  "presence": "Present"
-                                                }
-                                              ],
-                                              "presence": "Present"
-                                            },
-                                            null,
-                                            null,
-                                            null
-                                          ],
-                                          "presence": "Present"
-                                        }
-                                      ],
-                                      "presence": "Present"
-                                    }
-                                  ],
-                                  "presence": "Present"
-                                }
-                              ],
-                              "presence": "Present"
-                            },
-                            {
-                              "tokenKind": {
-                                "kind": "r_brace"
+                                "kind": "kw_let"
                               },
                               "leadingTrivia": [
                                 {
@@ -358,10 +89,250 @@
                                 },
                                 {
                                   "kind": "Space",
-                                  "value": 6
+                                  "value": 2
                                 }
                               ],
-                              "trailingTrivia": [],
+                              "trailingTrivia": [
+                                {
+                                  "kind": "Space",
+                                  "value": 3
+                                }
+                              ],
+                              "presence": "Present"
+                            },
+                            {
+                              "kind": "PatternBindingList",
+                              "layout": [
+                                {
+                                  "kind": "PatternBinding",
+                                  "layout": [
+                                    {
+                                      "kind": "IdentifierPattern",
+                                      "layout": [
+                                        {
+                                          "tokenKind": {
+                                            "kind": "identifier",
+                                            "text": "bar"
+                                          },
+                                          "leadingTrivia": [],
+                                          "trailingTrivia": [
+                                            {
+                                              "kind": "Space",
+                                              "value": 1
+                                            }
+                                          ],
+                                          "presence": "Present"
+                                        }
+                                      ],
+                                      "presence": "Present"
+                                    },
+                                    {
+                                      "kind": "TypeAnnotation",
+                                      "layout": [
+                                        {
+                                          "tokenKind": {
+                                            "kind": "colon"
+                                          },
+                                          "leadingTrivia": [],
+                                          "trailingTrivia": [
+                                            {
+                                              "kind": "Space",
+                                              "value": 1
+                                            }
+                                          ],
+                                          "presence": "Present"
+                                        },
+                                        {
+                                          "kind": "SimpleTypeIdentifier",
+                                          "layout": [
+                                            {
+                                              "tokenKind": {
+                                                "kind": "identifier",
+                                                "text": "Int"
+                                              },
+                                              "leadingTrivia": [],
+                                              "trailingTrivia": [],
+                                              "presence": "Present"
+                                            },
+                                            null
+                                          ],
+                                          "presence": "Present"
+                                        }
+                                      ],
+                                      "presence": "Present"
+                                    },
+                                    null,
+                                    null,
+                                    null
+                                  ],
+                                  "presence": "Present"
+                                }
+                              ],
+                              "presence": "Present"
+                            }
+                          ],
+                          "presence": "Present"
+                        },
+                        {
+                          "kind": "VariableDecl",
+                          "layout": [
+                            null,
+                            null,
+                            {
+                              "tokenKind": {
+                                "kind": "kw_let"
+                              },
+                              "leadingTrivia": [
+                                {
+                                  "kind": "Newline",
+                                  "value": 2
+                                },
+                                {
+                                  "kind": "Space",
+                                  "value": 2
+                                }
+                              ],
+                              "trailingTrivia": [
+                                {
+                                  "kind": "Space",
+                                  "value": 1
+                                }
+                              ],
+                              "presence": "Present"
+                            },
+                            {
+                              "kind": "PatternBindingList",
+                              "layout": [
+                                {
+                                  "kind": "PatternBinding",
+                                  "layout": [
+                                    {
+                                      "kind": "IdentifierPattern",
+                                      "layout": [
+                                        {
+                                          "tokenKind": {
+                                            "kind": "identifier",
+                                            "text": "baz"
+                                          },
+                                          "leadingTrivia": [],
+                                          "trailingTrivia": [
+                                            {
+                                              "kind": "Space",
+                                              "value": 1
+                                            }
+                                          ],
+                                          "presence": "Present"
+                                        }
+                                      ],
+                                      "presence": "Present"
+                                    },
+                                    {
+                                      "kind": "TypeAnnotation",
+                                      "layout": [
+                                        {
+                                          "tokenKind": {
+                                            "kind": "colon"
+                                          },
+                                          "leadingTrivia": [],
+                                          "trailingTrivia": [
+                                            {
+                                              "kind": "Space",
+                                              "value": 1
+                                            }
+                                          ],
+                                          "presence": "Present"
+                                        },
+                                        {
+                                          "kind": "SimpleTypeIdentifier",
+                                          "layout": [
+                                            {
+                                              "tokenKind": {
+                                                "kind": "identifier",
+                                                "text": "Array"
+                                              },
+                                              "leadingTrivia": [],
+                                              "trailingTrivia": [
+                                                {
+                                                  "kind": "Space",
+                                                  "value": 1
+                                                }
+                                              ],
+                                              "presence": "Present"
+                                            },
+                                            {
+                                              "kind": "GenericArgumentClause",
+                                              "layout": [
+                                                {
+                                                  "tokenKind": {
+                                                    "kind": "l_angle"
+                                                  },
+                                                  "leadingTrivia": [],
+                                                  "trailingTrivia": [
+                                                    {
+                                                      "kind": "Space",
+                                                      "value": 1
+                                                    }
+                                                  ],
+                                                  "presence": "Present"
+                                                },
+                                                {
+                                                  "kind": "GenericArgumentList",
+                                                  "layout": [
+                                                    {
+                                                      "kind": "GenericArgument",
+                                                      "layout": [
+                                                        {
+                                                          "kind": "SimpleTypeIdentifier",
+                                                          "layout": [
+                                                            {
+                                                              "tokenKind": {
+                                                                "kind": "identifier",
+                                                                "text": "Int"
+                                                              },
+                                                              "leadingTrivia": [],
+                                                              "trailingTrivia": [
+                                                                {
+                                                                  "kind": "Space",
+                                                                  "value": 1
+                                                                }
+                                                              ],
+                                                              "presence": "Present"
+                                                            },
+                                                            null
+                                                          ],
+                                                          "presence": "Present"
+                                                        },
+                                                        null
+                                                      ],
+                                                      "presence": "Present"
+                                                    }
+                                                  ],
+                                                  "presence": "Present"
+                                                },
+                                                {
+                                                  "tokenKind": {
+                                                    "kind": "r_angle"
+                                                  },
+                                                  "leadingTrivia": [],
+                                                  "trailingTrivia": [],
+                                                  "presence": "Present"
+                                                }
+                                              ],
+                                              "presence": "Present"
+                                            }
+                                          ],
+                                          "presence": "Present"
+                                        }
+                                      ],
+                                      "presence": "Present"
+                                    },
+                                    null,
+                                    null,
+                                    null
+                                  ],
+                                  "presence": "Present"
+                                }
+                              ],
                               "presence": "Present"
                             }
                           ],
@@ -370,13 +341,30 @@
                       ],
                       "presence": "Present"
                     },
-                    null
+                    {
+                      "tokenKind": {
+                        "kind": "r_brace"
+                      },
+                      "leadingTrivia": [
+                        {
+                          "kind": "Newline",
+                          "value": 1
+                        },
+                        {
+                          "kind": "Space",
+                          "value": 6
+                        }
+                      ],
+                      "trailingTrivia": [],
+                      "presence": "Present"
+                    }
                   ],
                   "presence": "Present"
                 }
               ],
               "presence": "Present"
-            }
+            },
+            null
           ],
           "presence": "Present"
         }

--- a/unittests/Syntax/DeclSyntaxTests.cpp
+++ b/unittests/Syntax/DeclSyntaxTests.cpp
@@ -506,10 +506,10 @@ CodeBlockSyntax getCannedBody() {
   auto ReturnKW =
     SyntaxFactory::makeReturnKeyword(Trivia::newlines(1) + Trivia::spaces(2),
                                      {});
-  auto Return = SyntaxFactory::makeReturnStmt(ReturnKW, One, None);
+  auto Return = SyntaxFactory::makeReturnStmt(ReturnKW, One);
+  auto ReturnItem = SyntaxFactory::makeCodeBlockItem(Return, None);
 
-  auto Stmts = SyntaxFactory::makeBlankStmtList()
-    .appending(Return);
+  auto Stmts = SyntaxFactory::makeCodeBlockItemList({ReturnItem});
 
   auto LBrace = SyntaxFactory::makeLeftBraceToken({}, {});
   auto RBrace = SyntaxFactory::makeRightBraceToken(Trivia::newlines(1), {});

--- a/unittests/Syntax/StmtSyntaxTests.cpp
+++ b/unittests/Syntax/StmtSyntaxTests.cpp
@@ -41,7 +41,7 @@ TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
 
-    SyntaxFactory::makeFallthroughStmt(FallthroughKW, llvm::None).print(OS);
+    SyntaxFactory::makeFallthroughStmt(FallthroughKW).print(OS);
     ASSERT_EQ(OS.str().str(), "fallthrough");
   }
 
@@ -51,7 +51,7 @@ TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
 
     auto NewFallthroughKW = FallthroughKW.withLeadingTrivia(Trivia::spaces(2));
 
-    SyntaxFactory::makeFallthroughStmt(NewFallthroughKW, llvm::None).print(OS);
+    SyntaxFactory::makeFallthroughStmt(NewFallthroughKW).print(OS);
     ASSERT_EQ(OS.str().str(), "  fallthrough");
   }
 
@@ -62,7 +62,7 @@ TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
     auto NewFallthroughKW = FallthroughKW.withLeadingTrivia(Trivia::spaces(2))
                                          .withTrailingTrivia(Trivia::spaces(2));
 
-    SyntaxFactory::makeFallthroughStmt(NewFallthroughKW, llvm::None).print(OS);
+    SyntaxFactory::makeFallthroughStmt(NewFallthroughKW).print(OS);
     ASSERT_EQ(OS.str().str(), "  fallthrough  ");
   }
 
@@ -80,7 +80,7 @@ TEST(StmtSyntaxTests, FallthroughStmtMakeAPIs) {
 TEST(StmtSyntaxTests, BreakStmtGetAPIs) {
   auto BreakKW = SyntaxFactory::makeBreakKeyword({}, Trivia::spaces(1));
   auto Label = SyntaxFactory::makeIdentifier("sometimesYouNeedTo", {}, {});
-  auto Break = SyntaxFactory::makeBreakStmt(BreakKW, Label, llvm::None);
+  auto Break = SyntaxFactory::makeBreakStmt(BreakKW, Label);
 
   /// These should be directly shared through reference-counting.
   ASSERT_EQ(BreakKW.getRaw(), Break.getBreakKeyword().getRaw());
@@ -128,7 +128,7 @@ TEST(StmtSyntaxTests, BreakStmtMakeAPIs) {
     llvm::raw_svector_ostream OS(Scratch);
     auto BreakKW = SyntaxFactory::makeBreakKeyword({}, Trivia::spaces(1));
     auto Label = SyntaxFactory::makeIdentifier("theBuild", {}, {});
-    auto Break = SyntaxFactory::makeBreakStmt(BreakKW, Label, llvm::None);
+    auto Break = SyntaxFactory::makeBreakStmt(BreakKW, Label);
     Break.print(OS);
     ASSERT_EQ(OS.str().str(), "break theBuild"); // don't you dare
   }
@@ -145,8 +145,7 @@ TEST(StmtSyntaxTests, BreakStmtMakeAPIs) {
 TEST(StmtSyntaxTests, ContinueStmtGetAPIs) {
   auto ContinueKW = SyntaxFactory::makeContinueKeyword({}, Trivia::spaces(1));
   auto Label = SyntaxFactory::makeIdentifier("always", {}, {});
-  auto Continue = SyntaxFactory::makeContinueStmt(ContinueKW, Label,
-                                                  llvm::None);
+  auto Continue = SyntaxFactory::makeContinueStmt(ContinueKW, Label);
 
   /// These should be directly shared through reference-counting.
   ASSERT_EQ(ContinueKW.getRaw(), Continue.getContinueKeyword().getRaw());
@@ -194,8 +193,7 @@ TEST(StmtSyntaxTests, ContinueStmtMakeAPIs) {
     llvm::raw_svector_ostream OS(Scratch);
     auto ContinueKW = SyntaxFactory::makeContinueKeyword({}, Trivia::spaces(1));
     auto Label = SyntaxFactory::makeIdentifier("toLead", {}, {});
-    auto Continue = SyntaxFactory::makeContinueStmt(ContinueKW, Label,
-                                                    llvm::None);
+    auto Continue = SyntaxFactory::makeContinueStmt(ContinueKW, Label);
     Continue.print(OS);
     ASSERT_EQ(OS.str().str(), "continue toLead"); // by example
   }
@@ -226,7 +224,7 @@ TEST(StmtSyntaxTests, ReturnStmtMakeAPIs) {
   {
     llvm::SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
-    SyntaxFactory::makeReturnStmt(ReturnKW, MinusOne, None).print(OS);
+    SyntaxFactory::makeReturnStmt(ReturnKW, MinusOne).print(OS);
     ASSERT_EQ(OS.str().str(), "return -1");
   }
 }
@@ -237,7 +235,7 @@ TEST(StmtSyntaxTests, ReturnStmtGetAPIs) {
   auto OneDigits = SyntaxFactory::makeIntegerLiteral("1", {}, {});
   auto MinusOne = SyntaxFactory::makePrefixOperatorExpr(Minus,
     SyntaxFactory::makeIntegerLiteralExpr(OneDigits));
-  auto Return = SyntaxFactory::makeReturnStmt(ReturnKW, MinusOne, None);
+  auto Return = SyntaxFactory::makeReturnStmt(ReturnKW, MinusOne);
 
   ASSERT_EQ(ReturnKW.getRaw(), Return.getReturnKeyword().getRaw());
   auto GottenExpression = Return.getExpression().getValue();

--- a/unittests/Syntax/ThreadSafeCachingTests.cpp
+++ b/unittests/Syntax/ThreadSafeCachingTests.cpp
@@ -88,7 +88,7 @@ TEST(ThreadSafeCachingTests, ReturnGetExpression) {
   Pool P;
 
   for (unsigned i = 0; i < 10000; ++i) {
-    auto Return = SyntaxFactory::makeReturnStmt(ReturnKW, MinusOne, None);
+    auto Return = SyntaxFactory::makeReturnStmt(ReturnKW, MinusOne);
 
     auto Future1 = P.run(getExpressionFrom, Return);
     auto Future2 = P.run(getExpressionFrom, Return);

--- a/utils/gyb_syntax_support/CommonNodes.py
+++ b/utils/gyb_syntax_support/CommonNodes.py
@@ -1,4 +1,5 @@
-from Node import Node
+from Child import Child
+from Node import Node  # noqa: I201
 
 COMMON_NODES = [
     Node('Decl', kind='Syntax'),
@@ -11,4 +12,29 @@ COMMON_NODES = [
     Node('UnknownStmt', kind='Stmt'),
     Node('UnknownType', kind='Type'),
     Node('UnknownPattern', kind='Pattern'),
+
+    # code-block-item = (decl | stmt | expr) ';'?
+    Node('CodeBlockItem', kind='Syntax',
+         children=[
+             Child('Item', kind='Syntax',
+                   node_choices=[
+                       Child('Decl', kind='Decl'),
+                       Child('Stmt', kind='Stmt'),
+                       Child('Expr', kind='Expr'),
+                   ]),
+             Child('Semicolon', kind='SemicolonToken',
+                   is_optional=True),
+         ]),
+
+    # code-block-item-list -> code-block-item code-block-item-list?
+    Node('CodeBlockItemList', kind='SyntaxCollection',
+         element='CodeBlockItem'),
+
+    # code-block -> '{' stmt-list '}'
+    Node('CodeBlock', kind='Syntax',
+         children=[
+             Child('OpenBrace', kind='LeftBraceToken'),
+             Child('Statements', kind='CodeBlockItemList'),
+             Child('CloseBrace', kind='RightBraceToken'),
+         ]),
 ]

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -88,7 +88,7 @@ DECL_NODES = [
          children=[
              Child('PoundElseif', kind='PoundElseifToken'),
              Child('Condition', kind='Expr'),
-             Child('Body', kind='StmtList'),
+             Child('Body', kind='CodeBlockItemList'),
          ]),
 
     # if-config-decl -> '#if' expr stmt-list else-if-directive-clause-list
@@ -97,7 +97,7 @@ DECL_NODES = [
          children=[
              Child('PoundIf', kind='PoundIfToken'),
              Child('Condition', kind='Expr'),
-             Child('Body', kind='StmtList'),
+             Child('Body', kind='CodeBlockItemList'),
              Child('ElseifDirectiveClauses', kind='ElseifDirectiveClauseList',
                    is_optional=True),
              Child('ElseClause', kind='ElseDirectiveClause',
@@ -245,17 +245,11 @@ DECL_NODES = [
     Node('DeclList', kind='SyntaxCollection',
          element='Decl'),
 
-    # source-file = decl-list eof
+    # source-file = code-block-item-list eof
     Node('SourceFile', kind='Syntax',
          children=[
-             Child('TopLevelDecls', kind='DeclList'),
+             Child('Items', kind='CodeBlockItemList'),
              Child('EOFToken', kind='EOFToken')
-         ]),
-
-    # top-level-code-decl = stmt-list
-    Node('TopLevelCodeDecl', kind='Decl',
-         children=[
-             Child('Body', kind='StmtList')
          ]),
 
     # initializer -> '=' expr
@@ -408,7 +402,7 @@ DECL_NODES = [
     Node('ElseDirectiveClause', kind='Syntax',
          children=[
              Child('PoundElse', kind='PoundElseToken'),
-             Child('Body', kind='StmtList'),
+             Child('Body', kind='CodeBlockItemList'),
          ]),
 
     # access-level-modifier -> 'private' | 'private' '(' 'set' ')'
@@ -476,7 +470,7 @@ DECL_NODES = [
              Child('AccessorListOrStmtList', kind='Syntax',
                    node_choices=[
                       Child('Accessors', kind='AccessorList'),
-                      Child('Statements', kind='StmtList')]),
+                      Child('Statements', kind='CodeBlockItemList')]),
              Child('RightBrace', kind='RightBraceToken'),
          ]),
 

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -387,7 +387,7 @@ EXPR_NODES = [
          children=[
              Child('LeftBrace', kind='LeftBraceToken'),
              Child('Signature', kind='ClosureSignature', is_optional=True),
-             Child('Statements', kind='StmtList'),
+             Child('Statements', kind='CodeBlockItemList'),
              Child('RightBrace', kind='RightBraceToken'),
          ]),
 

--- a/utils/gyb_syntax_support/StmtNodes.py
+++ b/utils/gyb_syntax_support/StmtNodes.py
@@ -8,8 +8,6 @@ STMT_NODES = [
              Child('ContinueKeyword', kind='ContinueToken'),
              Child('Label', kind='IdentifierToken',
                    is_optional=True),
-             Child('Semicolon', kind='SemicolonToken',
-                   is_optional=True),
          ]),
 
     # while-stmt -> label? ':'? 'while' condition-list code-block ';'?
@@ -22,8 +20,6 @@ STMT_NODES = [
              Child('WhileKeyword', kind='WhileToken'),
              Child('Conditions', kind='ConditionElementList'),
              Child('Body', kind='CodeBlock'),
-             Child('Semicolon', kind='SemicolonToken',
-                   is_optional=True),
          ]),
 
     # defer-stmt -> 'defer' code-block ';'?
@@ -31,16 +27,12 @@ STMT_NODES = [
          children=[
              Child('DeferKeyword', kind='DeferToken'),
              Child('Body', kind='CodeBlock'),
-             Child('Semicolon', kind='SemicolonToken',
-                   is_optional=True),
          ]),
 
     # expr-stmt -> expression ';'?
     Node('ExpressionStmt', kind='Stmt',
          children=[
              Child('Expression', kind='Expr'),
-             Child('Semicolon', kind='SemicolonToken',
-                   is_optional=True),
          ]),
 
     # switch-case-list -> switch-case switch-case-list?
@@ -58,8 +50,6 @@ STMT_NODES = [
              Child('Body', kind='CodeBlock'),
              Child('WhileKeyword', kind='WhileToken'),
              Child('Condition', kind='Expr'),
-             Child('Semicolon', kind='SemicolonToken',
-                   is_optional=True),
          ]),
 
     # guard-stmt -> 'guard' condition-list 'else' code-block ';'?
@@ -69,8 +59,6 @@ STMT_NODES = [
              Child('Conditions', kind='ConditionElementList'),
              Child('ElseKeyword', kind='ElseToken'),
              Child('Body', kind='CodeBlock'),
-             Child('Semicolon', kind='SemicolonToken',
-                   is_optional=True),
          ]),
 
     Node('WhereClause', kind='Syntax',
@@ -98,8 +86,6 @@ STMT_NODES = [
              Child('WhereClause', kind='WhereClause',
                    is_optional=True),
              Child('Body', kind='CodeBlock'),
-             Child('Semicolon', kind='SemicolonToken',
-                   is_optional=True),
          ]),
 
     # switch-stmt -> identifier? ':'? 'switch' expr '{'
@@ -115,8 +101,6 @@ STMT_NODES = [
              Child('OpenBrace', kind='LeftBraceToken'),
              Child('Cases', kind='SwitchCaseList'),
              Child('CloseBrace', kind='RightBraceToken'),
-             Child('Semicolon', kind='SemicolonToken',
-                   is_optional=True),
          ]),
 
     # catch-clause-list -> catch-clause catch-clause-list?
@@ -134,8 +118,6 @@ STMT_NODES = [
              Child('Body', kind='CodeBlock'),
              Child('CatchClauses', kind='CatchClauseList',
                    is_optional=True),
-             Child('Semicolon', kind='SemicolonToken',
-                   is_optional=True),
          ]),
 
     # return-stmt -> 'return' expr? ';'?
@@ -144,16 +126,12 @@ STMT_NODES = [
              Child('ReturnKeyword', kind='ReturnToken'),
              Child('Expression', kind='Expr',
                    is_optional=True),
-             Child('Semicolon', kind='SemicolonToken',
-                   is_optional=True),
          ]),
 
     # fallthrough-stmt -> 'fallthrough' ';'?
     Node('FallthroughStmt', kind='Stmt',
          children=[
              Child('FallthroughKeyword', kind='FallthroughToken'),
-             Child('Semicolon', kind='SemicolonToken',
-                   is_optional=True),
          ]),
 
     # break-stmt -> 'break' identifier? ';'?
@@ -162,16 +140,6 @@ STMT_NODES = [
              Child('BreakKeyword', kind='BreakToken'),
              Child('Label', kind='IdentifierToken',
                    is_optional=True),
-             Child('Semicolon', kind='SemicolonToken',
-                   is_optional=True),
-         ]),
-
-    # code-block -> '{' stmt-list '}'
-    Node('CodeBlock', kind='Syntax',
-         children=[
-             Child('OpenBrace', kind='LeftBraceToken'),
-             Child('Statements', kind='StmtList'),
-             Child('CloseBrace', kind='RightBraceToken'),
          ]),
 
     # case-item-list -> case-item case-item-list?
@@ -231,8 +199,6 @@ STMT_NODES = [
     Node('DeclarationStmt', kind='Stmt',
          children=[
              Child('Declaration', kind='Decl'),
-             Child('Semicolon', kind='SemicolonToken',
-                   is_optional=True),
          ]),
 
     # throw-stmt -> 'throw' expr ';'?
@@ -240,8 +206,6 @@ STMT_NODES = [
          children=[
              Child('ThrowKeyword', kind='ThrowToken'),
              Child('Expression', kind='Expr'),
-             Child('Semicolon', kind='SemicolonToken',
-                   is_optional=True),
          ]),
 
     # if-stmt -> identifier? ':'? 'if' condition-list code-block
@@ -263,8 +227,6 @@ STMT_NODES = [
                        Child('CodeBlock', kind='CodeBlock'),
                    ],
                    is_optional=True),
-             Child('Semicolon', kind='SemicolonToken',
-                   is_optional=True),
          ]),
 
     # else-if-continuation -> label? ':'? 'while' condition-list code-block ';'
@@ -278,20 +240,14 @@ STMT_NODES = [
          children=[
              Child('ElseKeyword', kind='ElseToken'),
              Child('Body', kind='CodeBlock'),
-             Child('Semicolon', kind='SemicolonToken',
-                   is_optional=True),
          ]),
-
-    # stmt-list -> stmt stmt-list?
-    Node('StmtList', kind='SyntaxCollection',
-         element='Stmt'),
 
     # switch-case -> switch-case-label stmt-list
     #              | default-label stmt-list
     Node('SwitchCase', kind='Syntax',
          children=[
              Child('Label', kind='Syntax'),
-             Child('Body', kind='StmtList'),
+             Child('Body', kind='CodeBlockItemList'),
          ]),
 
     # switch-default-label -> 'default' ':'


### PR DESCRIPTION
`CodeBlockItem` represents `Decl`, `Stmt` or `Expr` that optionally followed by
semi-colon. It typically appears in function body or top level.
`SourceFile` syntax holds a list of `CodeBlockItem`.

Removed `TopLevelCodeDecl` and `StmtList`.

#49479