### PR TITLE
Adds solver "expression too complex" bail reasons on predictive fail outs

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -142,8 +142,20 @@ ERROR(cannot_pass_rvalue_mutating_getter,none,
       "cannot use mutating getter on immutable value of type %0",
       (Type))
 
-ERROR(expression_too_complex,none,
-      "the compiler is unable to type-check this expression in reasonable time; "
+ERROR(expression_too_complex_hard_memory,none,
+      "the compiler is unable to type-check this expression in reasonable time. Solver memory limit reached; "
+      "try breaking up the expression into distinct sub-expressions", ())
+ERROR(expression_too_complex_hard_time,none,
+      "the compiler is unable to type-check this expression in reasonable time. Solver time limit reached; "
+      "try breaking up the expression into distinct sub-expressions", ())
+ERROR(expression_too_complex_predicted_exponential_ratio,none,
+      "the compiler is unable to type-check this expression in reasonable time. Predicting solver memory exhaustion. Heuristic: type assignments/disjunctions; "
+      "try breaking up the expression into distinct sub-expressions", ())
+ERROR(expression_too_complex_predicted_exponential_disjunction_count,none,
+      "the compiler is unable to type-check this expression in reasonable time. Predicting solver memory exhaustion. Heuristic: high disjunction count; "
+      "try breaking up the expression into distinct sub-expressions", ())
+ERROR(expression_too_complex_default,none,
+      "the compiler is unable to type-check this expression in reasonable time. Reason unspecified.; "
       "try breaking up the expression into distinct sub-expressions", ())
 
 ERROR(value_type_comparison_with_nil_illegal_did_you_mean,none,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -179,6 +179,11 @@ namespace swift {
     /// allocated by the constraint solver.
     unsigned SolverMemoryThreshold = 512 * 1024 * 1024;
 
+    /// \brief After this many disjunctions, start evaluating heuristics to
+    /// predict exponential memory complexity for solving expression types.
+    unsigned SolverComplexityEvaluationThreshold = 16 * 1024;
+
+    /// \brief Hard upper bound quantity of disjuntions to try.
     unsigned SolverBindingThreshold = 1024 * 1024;
 
     /// \brief The upper bound to number of sub-expressions unsolved

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -8516,9 +8516,32 @@ bool ConstraintSystem::salvage(SmallVectorImpl<Solution> &viable, Expr *expr) {
     // Fall through to produce diagnostics.
   }
 
-  if (getExpressionTooComplex(viable)) {
-    TC.diagnose(expr->getLoc(), diag::expression_too_complex).
-      highlight(expr->getSourceRange());
+
+  if (getShouldFailDueToExpressionComplexity(viable)) {
+    auto complexityEvaluation = getExpressionComplexity(viable);
+    switch(complexityEvaluation){
+      case ComplexityEvaluation::StrategicFailureTypeAssignmentDisjunctionRatio:
+        TC.diagnose(expr->getLoc(),
+                    diag::expression_too_complex_predicted_exponential_ratio).highlight(expr->getSourceRange());
+        break;
+      case ComplexityEvaluation::StrategicFailureHighDisjunctionCount:
+        TC.diagnose(expr->getLoc(),
+                    diag::expression_too_complex_predicted_exponential_disjunction_count).highlight(expr->getSourceRange());
+        break;
+      case ComplexityEvaluation::HardFailureMemoryThresholdExceeded:
+        TC.diagnose(expr->getLoc(),
+                    diag::expression_too_complex_hard_memory).highlight(expr->getSourceRange());
+        break;
+      case ComplexityEvaluation::HardFailureTimeThresholdExceeded:
+        TC.diagnose(expr->getLoc(),
+                    diag::expression_too_complex_hard_time).highlight(expr->getSourceRange());
+        break;
+      default: //StillSolvable and future cases without special descriptions
+        TC.diagnose(expr->getLoc(),
+                    diag::expression_too_complex_default).highlight(expr->getSourceRange());
+        break;
+    }
+
     return true;
   }
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -568,7 +568,7 @@ bool ConstraintSystem::tryTypeVariableBindings(
   ++solverState->NumTypeVariablesBound;
 
   // If we've already explored a lot of potential solutions, bail.
-  if (getExpressionTooComplex(solutions))
+  if (getShouldFailDueToExpressionComplexity(solutions))
     return true;
 
   for (unsigned tryCount = 0; !anySolved && !bindings.empty(); ++tryCount) {
@@ -1403,7 +1403,7 @@ ConstraintSystem::solve(Expr *&expr,
   // had found at least one solution before deciding an expression was
   // "too complex". Maintain that behavior, but for Swift > 3 return
   // Unsolved in these cases.
-  auto tooComplex = getExpressionTooComplex(solutions);
+  auto tooComplex = getShouldFailDueToExpressionComplexity(solutions);
   auto unsolved = tooComplex || solutions.empty();
 
   return unsolved ? SolutionKind::Unsolved : SolutionKind::Solved;
@@ -1957,7 +1957,7 @@ bool ConstraintSystem::solveSimplified(
     }
 
     // If the expression was deemed "too complex", stop now and salvage.
-    if (getExpressionTooComplex(solutions))
+    if (getShouldFailDueToExpressionComplexity(solutions))
       break;
 
     // Try to solve the system with this option in the disjunction.
@@ -2016,7 +2016,7 @@ bool ConstraintSystem::solveSimplified(
 
   // If we are exiting due to an expression that is too complex, do
   // not allow our caller to continue as if we have been successful.
-  auto tooComplex = getExpressionTooComplex(solutions);
+  auto tooComplex = getShouldFailDueToExpressionComplexity(solutions);
   return tooComplex || !lastSolvedChoice;
 }
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3041,36 +3041,66 @@ public:
   /// increase the likelihood that a favored constraint will be successfully
   /// resolved before any others.
   void optimizeConstraints(Expr *e);
-  
+
+  /// \brief Why (and if) an expression has been deemed too complex
+  enum class ComplexityEvaluation: unsigned char {
+    /// The expresssion has not yet been found to be too complex.
+    StillSolvable = 0,
+    /// Expression is predicted to have exponential time complexity. We have
+    ///    not found enough types given the quantity of disjunctions
+    ///    we have examined. We predict we will eventually exceed the
+    ///    memory threshold, so bail out early to save everybody time.
+    StrategicFailureTypeAssignmentDisjunctionRatio,
+    /// Expression is predicted to have exponential time complexity.
+    ///    We have looked through too many alternatives. We predict we
+    ///    will eventually exceed the memory threshold, so bail out
+    ///    early to save everybody time.
+    StrategicFailureHighDisjunctionCount,
+    /// We have run for too long.
+    HardFailureTimeThresholdExceeded,
+    /// We have exhausted the memory available for the solver's use.
+    HardFailureMemoryThresholdExceeded
+  };
+
   /// \brief Determine if we've already explored too many paths in an
   /// attempt to solve this expression.
-  bool getExpressionTooComplex(SmallVectorImpl<Solution> const &solutions) {
+  bool getShouldFailDueToExpressionComplexity(SmallVectorImpl<Solution> const &solutions) {
+    return getExpressionComplexity(solutions) != ComplexityEvaluation::StillSolvable;
+  }
+
+
+  /// \brief Determine why we've already explored too many paths in an
+  /// attempt to solve this expression.
+  ComplexityEvaluation getExpressionComplexity(SmallVectorImpl<Solution> const &solutions) {
     auto timeoutThresholdInMillis = TC.getExpressionTimeoutThresholdInSeconds();
     if (Timer && Timer->isExpired(timeoutThresholdInMillis)) {
       // Disable warnings about expressions that go over the warning
       // threshold since we're arbitrarily ending evaluation and
       // emitting an error.
       Timer->disableWarning();
-      return true;
+      return ComplexityEvaluation::HardFailureTimeThresholdExceeded;
     }
 
     if (!getASTContext().isSwiftVersion3()) {
+      //making good progress, continue in spite of possible memory issues
       if (CountScopes < TypeCounter)
-        return false;
+        return ComplexityEvaluation::StillSolvable;
 
       // If we haven't explored a relatively large number of possibilities
       // yet, continue.
-      if (CountScopes <= 16 * 1024)
-        return false;
+      if (CountScopes <= TC.Context.LangOpts.SolverComplexityEvaluationThreshold)
+        return ComplexityEvaluation::StillSolvable;
 
-      // Clearly exponential
+      // Rather than waiting until we've used a huge amount of memory, attempt to
+      //   make the choice to bail out based on the number of type bindings /
+      //   disjunction choices we visit. Bail on clearly exponential situations.
       if (TypeCounter < 32 && CountScopes > (1U << TypeCounter))
-        return true;
+        return ComplexityEvaluation::StrategicFailureTypeAssignmentDisjunctionRatio;
 
       // Bail out once we've looked at a really large number of
       // choices, even if we haven't used a huge amount of memory.
       if (CountScopes > TC.Context.LangOpts.SolverBindingThreshold)
-        return true;
+        return ComplexityEvaluation::StrategicFailureHighDisjunctionCount;
     }
 
     auto used = TC.Context.getSolverMemory();
@@ -3079,7 +3109,11 @@ public:
     }
     MaxMemory = std::max(used, MaxMemory);
     auto threshold = TC.Context.LangOpts.SolverMemoryThreshold;
-    return MaxMemory > threshold;
+    if (MaxMemory > threshold)
+      return ComplexityEvaluation::HardFailureMemoryThresholdExceeded;
+    
+
+    return ComplexityEvaluation::StillSolvable;
   }
   
   LLVM_ATTRIBUTE_DEPRECATED(


### PR DESCRIPTION
As suggested in #14391, this is broken out into it's own PR:

Instead of just returning a bool, the reason the solver ends early is encoded into an enum, which is then bubbled up to separate error messages. To decrease review cost of this PR, a wrapper call maintains the original bool semantics for client code of the replaced call.

Multiple error messages have been added. They each contain the same core explanation of "the compiler is unable to type-check this expression in reasonable time" (formerly: "the expression is too complex"). However, they now are broken out per termination reason.  

While this itself is not an enormous improvement for end-users it does allow people googling specific problems to have slightly more to go on for which reason bumped them out of the solver run.

Even imperfect information here can be a huge help to those who are used to looser conversion semantics of other languages. This can also "prove" if regressions (listed below) are from the early exits.

Creating scaffolding for future work is the final motivation for this change.  In theory, we can  bubble up useful info to the user such as the type assignments  which have been made for all disjunctions, and which have not. This could lead to showning which sub-expressions currently have many disjunctions (and which only have a few), thereby allowing the user the smallest number of annotations required. If nothing else, any hints in this area gives users a start on *a* simplification that would get their code typechecking. 


<!-- What's in this pull request? -->
In #14391, the "expression too complex" error was reworded to be less likely to blame the user. 

In that vein, users lacking a background in parsers are likely to "thrash" about when trying to 
figure out what types they need to add into and around expressions to make the type checker 
able to figure it all out.

Some degree of user assistance can be provided by providing details on what is understood, and what is not, by the compiler. Then they can write code which will type check. Users *can* learn some things 
from the exit reason.

This PR does not implement the error messages shown in #14391 (duplicated here), but does enable them to be added in easier. I did not wish to write one of those and find they are conceptually unwelcome. 

Eventually, this code supports easier introduction of messages like:

- Line 56: The expression is inferring 12 types. Please rewrite the expression
in more lines with more explicit types. \<click to expand for example\>.

- Line 56:  The number of inferred types in this {closure/declaration/generic function} results in (1,329,223 combinations). The current limit of swiftc is roughly 64,000 combinations.  Annotating all of the following expressions with explicit types would cut down the number of combinations to a level likely less than the current limit:
     -Line 56:84: (180 * another_number) + a_number * a_possible_float 
     -Line 53:6: let a_number = a_generic_function()

- Line 56: This line requires more combinations of possible types than the compiler currently will perform. Use swiftc --annotate-holes to add placeholders to the file for user-specified types to make the line understandable to the compiler. 

- Line 56: The expression is inferring 12 types. Please specify 3 or more of them. Use swiftc --breakup-complex-expressions to breakup the expression into subexpressions which you can manually type to get past this error. 

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
This will clear up the cause of these regressions once and for all. Are they being caused by predictive early exits or by normal time/memory bounds?

[SR-5253](https://bugs.swift.org/browse/SR-5253)

[SR-6031](https://bugs.swift.org/browse/SR-6031)

[SR-6928](https://bugs.swift.org/browse/SR-6928)

[SR-5950](https://bugs.swift.org/browse/SR-5950)

[SR-5583](https://bugs.swift.org/browse/SR-5583)

[SR-5563](https://bugs.swift.org/browse/SR-5563)

[SR-5151](https://bugs.swift.org/browse/SR-5151)

[SR-5140](https://bugs.swift.org/browse/SR-5140)

[SR-5109](https://bugs.swift.org/browse/SR-5109)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
Testing to ensure there are no regressions on general solver speed from the small changes to structure done in this PR.
@swift-ci Please smoke benchmark
@swift-ci Please test compiler performance

A small regression on the error message "print" statement should be acceptable, as this is typically a terminal case. 