### PR TITLE
[runtime] Add a dumping method to HeapObject when asserts are enabled.

### DIFF
--- a/stdlib/public/SwiftShims/HeapObject.h
+++ b/stdlib/public/SwiftShims/HeapObject.h
@@ -53,6 +53,11 @@ struct HeapObject {
     : metadata(newMetadata)
     , refCounts(InlineRefCounts::Initialized)
   { }
+
+#ifndef NDEBUG
+  void dump() const LLVM_ATTRIBUTE_USED;
+#endif
+
 #endif // __cplusplus
 };
 

--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -975,6 +975,18 @@ class RefCounts {
       return bits.getIsDeiniting();
   }
 
+  bool hasSideTable() const {
+    auto bits = refCounts.load(SWIFT_MEMORY_ORDER_CONSUME);
+    return bits.hasSideTable();
+  }
+
+  void *getSideTable() const {
+    auto bits = refCounts.load(SWIFT_MEMORY_ORDER_CONSUME);
+    if (!bits.hasSideTable())
+      return nullptr;
+    return bits.getSideTable();
+  }
+
   /// Return true if the object can be freed directly right now.
   /// (transition DEINITING -> DEAD)
   /// This is used in swift_deallocObject().

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -859,3 +859,24 @@ WeakReference *swift::swift_weakTakeAssign(WeakReference *dest,
   return dest;
 }
 
+#ifndef NDEBUG
+
+void HeapObject::dump() const {
+  auto *Self = const_cast<HeapObject *>(this);
+  printf("HeapObject: %p\n", Self);
+  printf("HeapMetadata Pointer: %p.\n", Self->metadata);
+  printf("Strong Ref Count: %d.\n", Self->refCounts.getCount());
+  printf("Unowned Ref Count: %d.\n", Self->refCounts.getUnownedCount());
+  printf("Weak Ref Count: %d.\n", Self->refCounts.getWeakCount());
+  if (Self->metadata->getKind() == MetadataKind::Class) {
+    printf("Uses Native Retain: %s.\n",
+           (objectUsesNativeSwiftReferenceCounting(Self) ? "true" : "false"));
+  } else {
+    printf("Uses Native Retain: Not a class. N/A.\n");
+  }
+  printf("RefCount Side Table: %p.\n", Self->refCounts.getSideTable());
+  printf("Is Deiniting: %s.\n",
+         (Self->refCounts.isDeiniting() ? "true" : "false"));
+}
+
+#endif


### PR DESCRIPTION
Given any heap object, this method dumps:

1. The pointer address of the heap object.
2. The pointer address of the heap metadata of the object.
3. The strong reference count.
4. The unowned reference count.
5. Whether or not the value is pinned.
6. Whether or not the heap object uses swift_retain or objc_retain.
7. The address of the object's side table if one exists.

This makes it really easy when debugging quickly to get all of the information
that you could possibly need from a HeapObject.
