### PR TITLE
[4.1][CSSolver] Increment score when performing certain function conversions

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1089,6 +1089,8 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
       return SolutionKind::Error;
     if (kind < ConstraintKind::Subtype)
       return SolutionKind::Error;
+
+    increaseScore(SK_FunctionConversion);
   }
   
   // A non-throwing function can be a subtype of a throwing function.
@@ -1880,8 +1882,10 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
       // If the 2nd type is an autoclosure, then we don't actually want to
       // treat these as parallel. The first type needs wrapping in a closure
       // despite already being a function type.
-      if (!func1->isAutoClosure() && func2->isAutoClosure())
+      if (!func1->isAutoClosure() && func2->isAutoClosure()) {
+        increaseScore(SK_FunctionConversion);
         break;
+      }
       return matchFunctionTypes(func1, func2, kind, flags, locator);
     }
 

--- a/test/Constraints/rdar37160679.swift
+++ b/test/Constraints/rdar37160679.swift
@@ -1,0 +1,21 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
+
+func foo(_ f: @autoclosure () -> Int) {}
+func foo(_ f: () -> Int) {}
+
+func bar(_ f: () throws -> Int) {}
+func bar(_ f: () -> Int) {}
+
+func baz(a1: @autoclosure () -> Int,
+         a2: () -> Int,
+         b1: () throws -> Int,
+         b2: () -> Int) {
+  // CHECK: function_ref @_T012rdar371606793fooySiyXKF
+  foo(a1)
+  // CHECK: function_ref @_T012rdar371606793fooySiycF
+  foo(a2)
+  // CHECK: function_ref @_T012rdar371606793barySiyKcF
+  bar(b1)
+  // CHECK: function_ref @_T012rdar371606793barySiycF
+  bar(b2)
+}


### PR DESCRIPTION
• **Explanation**: Increase solution score when performing function conversions where only
one side has `@autoclosure`. That is going to help pick the best overload
when only difference lays in presence of such attribute.

e.g.

```swift
func foo(_: @autoclosure () -> Int) {}
func foo(_: () -> Int) {}
```

If the argument is itself `@autoclosure` it's preferable to use overload
with `@autoclosure` attribute, otherwise `() -> Int` should be used.
• **Scope of Issue**: Affects matching of the arguments to parameters marked with `@autoclosure` attributes.
• **Origination**: Caused by the attempt to fix nil coalescing operator to support optional closures.
• **Risk**: Low risk; Fixes a bug in constraint solver.
• **Reviewed By**: @rudkx 
• **Testing**: Compiler regression tests
• **Radar / SR**: rdar://problem/37160679

Resolves: rdar://problem/37160679
(cherry picked from commit 8316353e073352f484e57b9663c613acf5ccdfc9)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
