### PR TITLE
[dev-scripts] Add a tool called emacs-compile that runs $@ in an emac…

### DIFF
--- a/utils/dev-scripts/emacs-compile
+++ b/utils/dev-scripts/emacs-compile
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+tmpfile=$(mktemp "/tmp/emacs-compile.XXXXXX")
+
+cat <<EOF > $tmpfile
+;; Turn off y-or-no-p
+(defalias 'yes-or-no-p 'y-or-n-p)
+;; Set the skip threshold to 2 so that we jump only to errors, not warnings.
+(setq compilation-skip-threshold 2)
+
+;; Now that we are configured, call compile and set the main window.
+(compile "$@")
+(switch-to-buffer "*compilation*")
+(delete-other-windows)
+EOF
+
+emacs -Q -l $tmpfile


### PR DESCRIPTION
…s compile session.

Something useful that I use all the time that I would like to give to others. It
enables emacs compile-mode to be used like a standalone-ish application instead
of one application with many modes, one of which is compile-mode.
