### PR TITLE
Fixes two compile time problems which came up with the DoubleWidth benchmark

### DIFF
--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -170,7 +170,11 @@ public:
 
 protected:
   SILType remapType(SILType Ty) {
-    return Ty.subst(Original.getModule(), SubsMap);
+    SILType &Sty = TypeCache[Ty];
+    if (!Sty) {
+      Sty = Ty.subst(Original.getModule(), SubsMap);
+    }
+    return Sty;
   }
 
   CanType remapASTType(CanType ty) {
@@ -286,6 +290,8 @@ protected:
   ModuleDecl *SwiftMod;
   /// The substitutions list for the specialization.
   SubstitutionMap SubsMap;
+  /// Cache for substituted types.
+  llvm::DenseMap<SILType, SILType> TypeCache;
   /// The original function to specialize.
   SILFunction &Original;
   /// The substitutions used at the call site.

--- a/lib/SIL/Projection.cpp
+++ b/lib/SIL/Projection.cpp
@@ -73,8 +73,6 @@ Projection::Projection(SingleValueInstruction *I) : Value() {
     Value = ValueTy(ProjectionKind::Struct, SEAI->getFieldNo());
     assert(getKind() == ProjectionKind::Struct);
     assert(getIndex() == SEAI->getFieldNo());
-    assert(getType(SEAI->getOperand()->getType(), SEAI->getModule()) ==
-           SEAI->getType());
     break;
   }
   case SILInstructionKind::StructExtractInst: {
@@ -82,8 +80,6 @@ Projection::Projection(SingleValueInstruction *I) : Value() {
     Value = ValueTy(ProjectionKind::Struct, SEI->getFieldNo());
     assert(getKind() == ProjectionKind::Struct);
     assert(getIndex() == SEI->getFieldNo());
-    assert(getType(SEI->getOperand()->getType(), SEI->getModule()) ==
-           SEI->getType());
     break;
   }
   case SILInstructionKind::RefElementAddrInst: {
@@ -91,8 +87,6 @@ Projection::Projection(SingleValueInstruction *I) : Value() {
     Value = ValueTy(ProjectionKind::Class, REAI->getFieldNo());
     assert(getKind() == ProjectionKind::Class);
     assert(getIndex() == REAI->getFieldNo());
-    assert(getType(REAI->getOperand()->getType(), REAI->getModule()) ==
-           REAI->getType());
     break;
   }
   case SILInstructionKind::RefTailAddrInst: {
@@ -107,8 +101,6 @@ Projection::Projection(SingleValueInstruction *I) : Value() {
     Value = ValueTy(ProjectionKind::Box, static_cast<uintptr_t>(0));
     assert(getKind() == ProjectionKind::Box);
     assert(getIndex() == 0);
-    assert(getType(PBI->getOperand()->getType(), PBI->getModule()) ==
-           PBI->getType());
     (void) PBI;
     break;
   }
@@ -117,8 +109,6 @@ Projection::Projection(SingleValueInstruction *I) : Value() {
     Value = ValueTy(ProjectionKind::Tuple, TEI->getFieldNo());
     assert(getKind() == ProjectionKind::Tuple);
     assert(getIndex() == TEI->getFieldNo());
-    assert(getType(TEI->getOperand()->getType(), TEI->getModule()) ==
-           TEI->getType());
     break;
   }
   case SILInstructionKind::TupleElementAddrInst: {
@@ -126,8 +116,6 @@ Projection::Projection(SingleValueInstruction *I) : Value() {
     Value = ValueTy(ProjectionKind::Tuple, TEAI->getFieldNo());
     assert(getKind() == ProjectionKind::Tuple);
     assert(getIndex() == TEAI->getFieldNo());
-    assert(getType(TEAI->getOperand()->getType(), TEAI->getModule()) ==
-           TEAI->getType());
     break;
   }
   case SILInstructionKind::UncheckedEnumDataInst: {
@@ -135,8 +123,6 @@ Projection::Projection(SingleValueInstruction *I) : Value() {
     Value = ValueTy(ProjectionKind::Enum, UEDI->getElementNo());
     assert(getKind() == ProjectionKind::Enum);
     assert(getIndex() == UEDI->getElementNo());
-    assert(getType(UEDI->getOperand()->getType(), UEDI->getModule()) ==
-           UEDI->getType());
     break;
   }
   case SILInstructionKind::UncheckedTakeEnumDataAddrInst: {
@@ -144,8 +130,6 @@ Projection::Projection(SingleValueInstruction *I) : Value() {
     Value = ValueTy(ProjectionKind::Enum, UTEDAI->getElementNo());
     assert(getKind() == ProjectionKind::Enum);
     assert(getIndex() == UTEDAI->getElementNo());
-    assert(getType(UTEDAI->getOperand()->getType(), UTEDAI->getModule()) ==
-           UTEDAI->getType());
     break;
   }
   case SILInstructionKind::IndexAddrInst: {
@@ -168,8 +152,6 @@ Projection::Projection(SingleValueInstruction *I) : Value() {
     assert(Ty->isCanonical());
     Value = ValueTy(ProjectionKind::Upcast, Ty);
     assert(getKind() == ProjectionKind::Upcast);
-    assert(getType(I->getOperand(0)->getType(), I->getModule()) ==
-           I->getType());
     break;
   }
   case SILInstructionKind::UncheckedRefCastInst: {
@@ -177,8 +159,6 @@ Projection::Projection(SingleValueInstruction *I) : Value() {
     assert(Ty->isCanonical());
     Value = ValueTy(ProjectionKind::RefCast, Ty);
     assert(getKind() == ProjectionKind::RefCast);
-    assert(getType(I->getOperand(0)->getType(), I->getModule()) ==
-           I->getType());
     break;
   }
   case SILInstructionKind::UncheckedBitwiseCastInst:
@@ -187,8 +167,6 @@ Projection::Projection(SingleValueInstruction *I) : Value() {
     assert(Ty->isCanonical());
     Value = ValueTy(ProjectionKind::BitwiseCast, Ty);
     assert(getKind() == ProjectionKind::BitwiseCast);
-    assert(getType(I->getOperand(0)->getType(), I->getModule()) ==
-           I->getType());
     break;
   }
   }


### PR DESCRIPTION
* Remove an assertion from the Projection constructor to avoid bad corner-case compile times.

* Cache the substituted types in the TypeSubstCloner.

Both changes give a 5x compile time improvement (for an assert compiler). But the compile time is still bad: ~3.5 min

rdar://problem/36887449