### PR TITLE
Skip diagnostic passes for deserialized functions.

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -215,6 +215,11 @@ private:
   /// after the pass runs, we only see a semantic-arc world.
   bool HasQualifiedOwnership = true;
 
+  /// Set if the function body was deserialized from canonical SIL. This implies
+  /// that the function's home module performed SIL diagnostics prior to
+  /// serialization.
+  bool WasDeserializedCanonical = false;
+
   SILFunction(SILModule &module, SILLinkage linkage, StringRef mangledName,
               CanSILFunctionType loweredType, GenericEnvironment *genericEnv,
               Optional<SILLocation> loc, IsBare_t isBareSILFunction,
@@ -335,6 +340,13 @@ public:
   void setUnqualifiedOwnership() {
     HasQualifiedOwnership = false;
   }
+
+  /// Returns true if this function was deserialized from canonical
+  /// SIL. (.swiftmodule files contain canonical SIL; .sib files may be 'raw'
+  /// SIL). If so, diagnostics should not be reapplied.
+  bool wasDeserializedCanonical() const { return WasDeserializedCanonical; }
+
+  void setWasDeserializedCanonical() { WasDeserializedCanonical = true; }
 
   /// Returns the calling convention used by this entry point.
   SILFunctionTypeRepresentation getRepresentation() const {

--- a/include/swift/SILOptimizer/PassManager/Passes.h
+++ b/include/swift/SILOptimizer/PassManager/Passes.h
@@ -50,7 +50,7 @@ namespace swift {
 
   /// \brief Detect and remove unreachable code. Diagnose provably unreachable
   /// user code.
-  void performSILDiagnoseUnreachable(SILModule *M, SILModuleTransform *T);
+  void performSILDiagnoseUnreachable(SILModule *M);
 
   /// \brief Remove dead functions from \p M.
   void performSILDeadFunctionElimination(SILModule *M);

--- a/include/swift/SILOptimizer/PassManager/Transforms.h
+++ b/include/swift/SILOptimizer/PassManager/Transforms.h
@@ -122,7 +122,6 @@ namespace swift {
     /// pipeline on it.
     void restartPassPipeline() { PM->restartWithCurrentFunction(this); }
 
-  protected:
     SILFunction *getFunction() { return F; }
 
     void invalidateAnalysis(SILAnalysis::InvalidationKind K) {

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -87,6 +87,11 @@ class ModuleFile
   /// The number of entities that are currently being deserialized.
   unsigned NumCurrentDeserializingEntities = 0;
 
+  /// Is this module file actually a .sib file? .sib files are serialized SIL at
+  /// arbitrary granularity and arbitrary stage; unlike serialized Swift
+  /// modules, which are assumed to contain canonical SIL for an entire module.
+  bool IsSIB = false;
+
   /// RAII class to be used when deserializing an entity.
   class DeserializingEntityRAII {
     ModuleFile &MF;

--- a/lib/SILOptimizer/Analysis/ClosureScope.cpp
+++ b/lib/SILOptimizer/Analysis/ClosureScope.cpp
@@ -91,6 +91,15 @@ public:
     auto scopeFunc = PAI->getFunction();
     int scopeIdx = lookupScopeIndex(scopeFunc);
 
+    // Passes may assume that a deserialized function can only refer to
+    // deserialized closures. For example, AccessEnforcementSelection skips
+    // deserialized functions but assumes all a closure's parent scope have been
+    // processed.
+    assert(scopeFunc->wasDeserializedCanonical()
+           == closureFunc->wasDeserializedCanonical() &&
+           "A closure cannot be serialized in a different module than its "
+           "parent context");
+
     auto &indices = closureToScopesMap[closureFunc];
     if (std::find(indices.begin(), indices.end(), scopeIdx) != indices.end())
       return;

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -1306,6 +1306,9 @@ class CapturePromotionPass : public SILModuleTransform {
   void run() override {
     SmallVector<SILFunction*, 128> Worklist;
     for (auto &F : *getModule()) {
+      if (F.wasDeserializedCanonical())
+        continue;
+
       processFunction(&F, Worklist);
     }
 

--- a/lib/SILOptimizer/Mandatory/ConstantPropagation.cpp
+++ b/lib/SILOptimizer/Mandatory/ConstantPropagation.cpp
@@ -46,6 +46,8 @@ private:
 } // end anonymous namespace
 
 SILTransform *swift::createDiagnosticConstantPropagation() {
+  // Diagostic propagation is rerun on deserialized SIL because it is sensitive
+  // to assert configuration.
   return new ConstantPropagation(true /*enable diagnostics*/);
 }
 

--- a/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
@@ -120,6 +120,10 @@ class EmitDFDiagnostics : public SILFunctionTransform {
 
   /// The entry point to the transformation.
   void run() override {
+    // Don't rerun diagnostics on deserialized functions.
+    if (getFunction()->wasDeserializedCanonical())
+      return;
+
     SILModule &M = getFunction()->getModule();
     for (auto &BB : *getFunction())
       for (auto &I : BB) {

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -2963,6 +2963,10 @@ class DefiniteInitialization : public SILFunctionTransform {
 
   /// The entry point to the transformation.
   void run() override {
+    // Don't rerun diagnostics on deserialized functions.
+    if (getFunction()->wasDeserializedCanonical())
+      return;
+
     // Walk through and promote all of the alloc_box's that we can.
     if (checkDefiniteInitialization(*getFunction())) {
       invalidateAnalysis(SILAnalysis::InvalidationKind::FunctionBody);

--- a/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseUnreachable.cpp
@@ -793,6 +793,10 @@ void swift::performSILDiagnoseUnreachable(SILModule *M) {
 namespace {
 class NoReturnFolding : public SILFunctionTransform {
   void run() override {
+    // Don't rerun diagnostics on deserialized functions.
+    if (getFunction()->wasDeserializedCanonical())
+      return;
+
     performNoReturnFunctionProcessing(*getFunction(), this);
   }
   };
@@ -804,6 +808,8 @@ SILTransform *swift::createNoReturnFolding() {
 
 
 namespace {
+// This pass reruns on deserialized SIL because diagnostic constant propagation
+// can expose unreachable blocks which are then removed by this pass.
 class DiagnoseUnreachable : public SILFunctionTransform {
   void run() override {
     diagnoseUnreachable(*getFunction());

--- a/lib/SILOptimizer/Mandatory/GuaranteedARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/GuaranteedARCOpts.cpp
@@ -205,6 +205,9 @@ bool GuaranteedARCOptsVisitor::visitReleaseValueInst(ReleaseValueInst *RVI) {
 
 namespace {
 
+// Even though this is a mandatory pass, it is rerun after deserialization in
+// cast DiagnosticConstantPropagation exposed anything new in this assert
+// configutation.
 struct GuaranteedARCOpts : SILFunctionTransform {
   void run() override {
     GuaranteedARCOptsVisitor Visitor;

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -1394,6 +1394,12 @@ namespace {
 
 class PredictableMemoryOptimizations : public SILFunctionTransform {
   /// The entry point to the transformation.
+  ///
+  /// FIXME: This pass should not need to rerun on deserialized
+  /// functions. Nothing should have changed in the upstream pipeline after
+  /// deserialization. However, rerunning does improve some benchmarks. This
+  /// either indicates that this pass missing some opportunities the first time,
+  /// or has a pass order dependency on other early passes.
   void run() override {
     if (optimizeMemoryAllocations(*getFunction()))
       invalidateAnalysis(SILAnalysis::InvalidationKind::FunctionBody);

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -91,6 +91,10 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P,
   P.addOwnershipModelEliminator();
   P.addMandatoryInlining();
   P.addPredictableMemoryOptimizations();
+
+  // Diagnostic ConstantPropagation must be rerun on deserialized functions
+  // because it is sensitive to the assert configuration.
+  // Consequently, certain optimization passes beyond this point will also rerun.
   P.addDiagnosticConstantPropagation();
   P.addGuaranteedARCOpts();
   P.addDiagnoseUnreachable();

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -944,6 +944,10 @@ namespace {
 class AllocBoxToStack : public SILFunctionTransform {
   /// The entry point to the transformation.
   void run() override {
+    // Don't rerun on deserialized functions. Nothing should have changed.
+    if (getFunction()->wasDeserializedCanonical())
+      return;
+
     AllocBoxToStackState pass(this);
     for (auto &BB : *getFunction()) {
       for (auto &I : BB)

--- a/lib/SILOptimizer/Transforms/MarkUninitializedFixup.cpp
+++ b/lib/SILOptimizer/Transforms/MarkUninitializedFixup.cpp
@@ -74,6 +74,10 @@ namespace {
 
 struct MarkUninitializedFixup : SILFunctionTransform {
   void run() override {
+    // Don't rerun on deserialized functions. Nothing should have changed.
+    if (getFunction()->wasDeserializedCanonical())
+      return;
+
     bool MadeChange = false;
     for (auto &BB : *getFunction()) {
       for (auto II = BB.begin(), IE = BB.end(); II != IE;) {

--- a/lib/SILOptimizer/Transforms/MarkUninitializedFixup.cpp
+++ b/lib/SILOptimizer/Transforms/MarkUninitializedFixup.cpp
@@ -72,70 +72,65 @@ getInitialProjectBox(MarkUninitializedInst *MUI,
 
 namespace {
 
-struct MarkUninitializedFixup : SILModuleTransform {
+struct MarkUninitializedFixup : SILFunctionTransform {
   void run() override {
     bool MadeChange = false;
+    for (auto &BB : *getFunction()) {
+      for (auto II = BB.begin(), IE = BB.end(); II != IE;) {
+        // Grab our given instruction and advance the iterator. This is
+        // important since we may be destroying the given instruction.
+        auto *MUI = dyn_cast<MarkUninitializedInst>(&*II);
+        ++II;
 
-    for (auto &F : *getModule()) {
-      for (auto &BB : F) {
-        for (auto II = BB.begin(), IE = BB.end(); II != IE;) {
-          // Grab our given instruction and advance the iterator. This is
-          // important since we may be destroying the given instruction.
-          auto *MUI = dyn_cast<MarkUninitializedInst>(&*II);
-          ++II;
+        // If we do not have a mark_uninitialized or we have a
+        // mark_uninitialized of an alloc_box, continue. These are not
+        // interesting to us.
+        if (!MUI)
+          continue;
 
-          // If we do not have a mark_uninitialized or we have a
-          // mark_uninitialized of an alloc_box, continue. These are not
-          // interesting to us.
-          if (!MUI)
-            continue;
+        auto *Box = dyn_cast<AllocBoxInst>(MUI->getOperand());
+        if (!Box)
+          continue;
 
-          auto *Box = dyn_cast<AllocBoxInst>(MUI->getOperand());
-          if (!Box)
-            continue;
-
-          // We expect there to be in most cases exactly one project_box. That
-          // being said, it is not impossible for there to be multiple. In such
-          // a case, we assume that the correct project_box is the one that is
-          // nearest to the mark_uninitialized in the same block. This preserves
-          // the existing behavior.
-          llvm::TinyPtrVector<ProjectBoxInst *> Projections;
-          for (auto *Op : MUI->getUses()) {
-            if (auto *PBI = dyn_cast<ProjectBoxInst>(Op->getUser())) {
-              Projections.push_back(PBI);
-            }
+        // We expect there to be in most cases exactly one project_box. That
+        // being said, it is not impossible for there to be multiple. In such
+        // a case, we assume that the correct project_box is the one that is
+        // nearest to the mark_uninitialized in the same block. This preserves
+        // the existing behavior.
+        llvm::TinyPtrVector<ProjectBoxInst *> Projections;
+        for (auto *Op : MUI->getUses()) {
+          if (auto *PBI = dyn_cast<ProjectBoxInst>(Op->getUser())) {
+            Projections.push_back(PBI);
           }
-          assert(!Projections.empty() && "SILGen should never emit a "
-                                         "mark_uninitialized by itself");
-
-          // First replace all uses of the mark_uninitialized with the box.
-          MUI->replaceAllUsesWith(Box);
-
-          // That means now our project box now has the alloc_box as its
-          // operand. Grab that project_box.
-          auto *PBI = getInitialProjectBox(MUI, Projections);
-
-          // Then create the new mark_uninitialized and force all uses of the
-          // project_box to go through the new mark_uninitialized.
-          SILBuilder B(std::next(PBI->getIterator()));
-          SILValue Undef = SILUndef::get(PBI->getType(), PBI->getModule());
-          auto *NewMUI = B.createMarkUninitialized(PBI->getLoc(), Undef,
-                                                   MUI->getKind());
-          PBI->replaceAllUsesWith(NewMUI);
-          NewMUI->setOperand(PBI);
-
-          // Finally, remove the old mark_uninitialized.
-          MUI->eraseFromParent();
-          MadeChange = true;
         }
-      }
+        assert(!Projections.empty()
+               && "SILGen should never emit a "
+                  "mark_uninitialized by itself");
 
-      if (MadeChange) {
-        auto InvalidKind =
-            SILAnalysis::InvalidationKind::BranchesAndInstructions;
-        invalidateAnalysis(&F, InvalidKind);
+        // First replace all uses of the mark_uninitialized with the box.
+        MUI->replaceAllUsesWith(Box);
+
+        // That means now our project box now has the alloc_box as its
+        // operand. Grab that project_box.
+        auto *PBI = getInitialProjectBox(MUI, Projections);
+
+        // Then create the new mark_uninitialized and force all uses of the
+        // project_box to go through the new mark_uninitialized.
+        SILBuilder B(std::next(PBI->getIterator()));
+        SILValue Undef = SILUndef::get(PBI->getType(), PBI->getModule());
+        auto *NewMUI =
+            B.createMarkUninitialized(PBI->getLoc(), Undef, MUI->getKind());
+        PBI->replaceAllUsesWith(NewMUI);
+        NewMUI->setOperand(PBI);
+
+        // Finally, remove the old mark_uninitialized.
+        MUI->eraseFromParent();
+        MadeChange = true;
       }
     }
+    if (MadeChange)
+      invalidateAnalysis(
+          SILAnalysis::InvalidationKind::BranchesAndInstructions);
   }
 };
 

--- a/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
+++ b/lib/SILOptimizer/Transforms/OwnershipModelEliminator.cpp
@@ -297,6 +297,10 @@ namespace {
 struct OwnershipModelEliminator : SILModuleTransform {
   void run() override {
     for (auto &F : *getModule()) {
+      // Don't rerun early lowering on deserialized functions.
+      if (F.wasDeserializedCanonical())
+        continue;
+
       // Set F to have unqualified ownership.
       F.setUnqualifiedOwnership();
 

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -506,6 +506,10 @@ SILFunction *SILDeserializer::readSILFunction(DeclID FID,
 
     if (Callback) Callback->didDeserialize(MF->getAssociatedModule(), fn);
   }
+  // Mark this function as deserialized. This avoids rerunning diagnostic
+  // passes. Certain passes in the madatory pipeline may expect not to rerun
+  // after arbitrary optimization and lowering.
+  fn->setWasDeserializedCanonical();
 
   assert(fn->empty() &&
          "SILFunction to be deserialized starts being empty.");

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -507,9 +507,10 @@ SILFunction *SILDeserializer::readSILFunction(DeclID FID,
     if (Callback) Callback->didDeserialize(MF->getAssociatedModule(), fn);
   }
   // Mark this function as deserialized. This avoids rerunning diagnostic
-  // passes. Certain passes in the madatory pipeline may expect not to rerun
+  // passes. Certain passes in the madatory pipeline may not work as expected
   // after arbitrary optimization and lowering.
-  fn->setWasDeserializedCanonical();
+  if (!MF->IsSIB)
+    fn->setWasDeserializedCanonical();
 
   assert(fn->empty() &&
          "SILFunction to be deserialized starts being empty.");

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1115,6 +1115,7 @@ ModuleFile::ModuleFile(
       Name = info.name;
       TargetTriple = info.targetTriple;
       CompatibilityVersion = info.compatibilityVersion;
+      IsSIB = extInfo->isSIB();
 
       hasValidControlBlock = true;
       break;

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -212,7 +212,7 @@ void removeUnwantedFunctions(SILModule *M, ArrayRef<std::string> MangledNames,
   // After running this pass all of the functions we will remove
   // should consist only of one basic block terminated by
   // UnreachableInst.
-  performSILDiagnoseUnreachable(M, nullptr);
+  performSILDiagnoseUnreachable(M);
 
   // Now mark all of these functions as public and remove their bodies.
   for (auto &F : DeadFunctions) {


### PR DESCRIPTION
Establish control over the pass pipeline that runs on serialized functions. Certain passes should definitely not be rerun. Most optimization passes should not need to be rerun. The assert configuration makes this tricky though. And PredictableMemOps either has some pass order problems or misses some things the first time, so we rerun it for the best performance--this is really unfortunate for compile time though.