### PR TITLE
Modify tabstop and shiftwidth for vim

### DIFF
--- a/utils/vim/ftplugin/swift.vim
+++ b/utils/vim/ftplugin/swift.vim
@@ -1,5 +1,5 @@
 setlocal comments=s1:/*,mb:*,ex:*/,:///,://
 setlocal expandtab
-setlocal ts=2
-setlocal sw=2
+setlocal ts=4
+setlocal sw=4
 setlocal smartindent


### PR DESCRIPTION
I'm using vim syntax in this repo.
However, I think tabstop/shiftwidth should be 4.

Many Swift codes on Apple official documentation or this repo are indented 4 tab width.