### PR TITLE
[4.1] Restore a very narrow function argument conversion for -swift-version 4.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6127,9 +6127,12 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       // func bar() -> ((()) -> Void)? { return nil }
       // foo(bar) // This expression should compile in Swift 3 mode
       // ```
-      if (tc.getLangOpts().isSwiftVersion3()) {
-        auto obj1 = fromType->getAnyOptionalObjectType();
-        auto obj2 = toType->getAnyOptionalObjectType();
+      //
+      // See also: https://bugs.swift.org/browse/SR-6796
+      if (cs.getASTContext().isSwiftVersionAtLeast(3) &&
+          !cs.getASTContext().isSwiftVersionAtLeast(5)) {
+        auto obj1 = fromType->getOptionalObjectType();
+        auto obj2 = toType->getOptionalObjectType();
 
         if (obj1 && obj2) {
           auto *fn1 = obj1->getAs<AnyFunctionType>();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1190,6 +1190,35 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
     }
   }
 
+  // https://bugs.swift.org/browse/SR-6796
+  // Add a super-narrow hack to allow:
+  //   (()) -> T to be passed in place of () -> T
+  if (getASTContext().isSwiftVersionAtLeast(4) &&
+      !getASTContext().isSwiftVersionAtLeast(5)) {
+    SmallVector<LocatorPathElt, 4> path;
+    locator.getLocatorParts(path);
+
+    // Find the last path element, skipping GenericArgument elements
+    // so that we allow this exception in cases of optional types, and
+    // skipping OptionalPayload elements so that we allow this
+    // exception in cases of optional injection.
+    auto last = std::find_if(
+        path.rbegin(), path.rend(), [](LocatorPathElt &elt) -> bool {
+          return elt.getKind() != ConstraintLocator::GenericArgument &&
+                 elt.getKind() != ConstraintLocator::OptionalPayload;
+        });
+
+    if (last != path.rend()) {
+      if (last->getKind() == ConstraintLocator::ApplyArgToParam) {
+        if (auto *paren1 = dyn_cast<ParenType>(func1Input.getPointer())) {
+          auto innerTy = paren1->getUnderlyingType();
+          if (func2Input->isVoid() && innerTy->isVoid())
+            func1Input = innerTy;
+        }
+      }
+    }
+  }
+
   // Input types can be contravariant (or equal).
   SmallVector<AnyFunctionType::Param, 4> func1Params;
   SmallVector<AnyFunctionType::Param, 4> func2Params;

--- a/test/Compatibility/tuple_arguments.swift
+++ b/test/Compatibility/tuple_arguments.swift
@@ -1502,3 +1502,14 @@ do {
   takeFn(fn: { (pair: (Int, Int?)) in } )
   takeFn { (pair: (Int, Int?)) in }
 }
+
+// https://bugs.swift.org/browse/SR-6796
+do {
+  func f(a: (() -> Void)? = nil) {}
+  func log<T>() -> ((T) -> Void)? { return nil }
+
+  f(a: log() as ((()) -> Void)?) // Allow ((()) -> Void)? to be passed in place of (() -> Void)?
+
+  func logNoOptional<T>() -> (T) -> Void { }
+  f(a: logNoOptional() as ((()) -> Void)) // Also allow the optional-injected form.
+}

--- a/test/Compatibility/tuple_arguments_3.swift
+++ b/test/Compatibility/tuple_arguments_3.swift
@@ -1,11 +1,27 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5
+// RUN: %target-typecheck-verify-swift -swift-version 3
 
-// See test/Compatibility/tuple_arguments_3.swift for the Swift 3 behavior.
-// See test/Compatibility/tuple_arguments_4.swift for the Swift 4 behavior.
+// Tests for tuple argument behavior in Swift 3, which was broken.
+// The Swift 4 test is in test/Compatibility/tuple_arguments_4.swift.
+// The test for the most recent version is in test/Constraints/tuple_arguments.swift.
+
+// Key:
+// - "Crashes in actual Swift 3" -- snippets which crashed in Swift 3.0.1.
+//   These don't have well-defined semantics in Swift 3 mode and don't
+//   matter for source compatibility purposes.
+//
+// - "Does not diagnose in Swift 3 mode" -- snippets which failed to typecheck
+//   in Swift 3.0.1, but now typecheck. This is fine.
+//
+// - "Diagnoses in Swift 3 mode" -- snippets which typechecked in Swift 3.0.1,
+//   but now fail to typecheck. These are bugs in Swift 3 mode that should be
+//   fixed.
+//
+// - "Crashes in Swift 3 mode" -- snippets which did not crash Swift 3.0.1,
+//   but now crash. These are bugs in Swift 3 mode that should be fixed.
 
 func concrete(_ x: Int) {}
 func concreteLabeled(x: Int) {}
-func concreteTwo(_ x: Int, _ y: Int) {} // expected-note 5 {{'concreteTwo' declared here}}
+func concreteTwo(_ x: Int, _ y: Int) {} // expected-note 3 {{'concreteTwo' declared here}}
 func concreteTuple(_ x: (Int, Int)) {}
 
 do {
@@ -34,10 +50,10 @@ do {
   concrete(c)
 
   concreteTwo(a, b)
-  concreteTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  concreteTwo(d) // expected-error {{missing argument for parameter #2 in call}}
+  concreteTwo((a, b))
+  concreteTwo(d) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
 
-  concreteTuple(a, b) // expected-error {{global function 'concreteTuple' expects a single parameter of type '(Int, Int)'}} {{17-17=(}} {{21-21=)}}
+  concreteTuple(a, b)
   concreteTuple((a, b))
   concreteTuple(d)
 }
@@ -68,7 +84,7 @@ func genericTuple<T, U>(_ x: (T, U)) {}
 
 do {
   generic(3)
-  generic(3, 4) // expected-error {{extra argument in call}}
+  generic(3, 4)
   generic((3))
   generic((3, 4))
 
@@ -91,7 +107,7 @@ do {
   let d = (a, b)
 
   generic(a)
-  generic(a, b) // expected-error {{extra argument in call}}
+  generic(a, b)
   generic((a))
   generic(c)
   generic((a, b))
@@ -113,7 +129,7 @@ do {
   var d = (a, b)
 
   generic(a)
-  generic(a, b) // expected-error {{extra argument in call}}
+  // generic(a, b) // Crashes in actual Swift 3
   generic((a))
   generic(c)
   generic((a, b))
@@ -129,7 +145,7 @@ do {
 }
 
 var function: (Int) -> ()
-var functionTwo: (Int, Int) -> () // expected-note 5 {{'functionTwo' declared here}}
+var functionTwo: (Int, Int) -> () // expected-note 3 {{'functionTwo' declared here}}
 var functionTuple: ((Int, Int)) -> ()
 
 do {
@@ -154,10 +170,10 @@ do {
   function(c)
 
   functionTwo(a, b)
-  functionTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  functionTwo(d) // expected-error {{missing argument for parameter #2 in call}}
+  functionTwo((a, b))
+  functionTwo(d) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
 
-  functionTuple(a, b) // expected-error {{var 'functionTuple' expects a single parameter of type '(Int, Int)'}} {{17-17=(}} {{21-21=)}}
+  functionTuple(a, b)
   functionTuple((a, b))
   functionTuple(d)
 }
@@ -185,7 +201,7 @@ struct Concrete {}
 
 extension Concrete {
   func concrete(_ x: Int) {}
-  func concreteTwo(_ x: Int, _ y: Int) {} // expected-note 5 {{'concreteTwo' declared here}}
+  func concreteTwo(_ x: Int, _ y: Int) {} // expected-note 3 {{'concreteTwo' declared here}}
   func concreteTuple(_ x: (Int, Int)) {}
 }
 
@@ -215,10 +231,10 @@ do {
   s.concrete(c)
 
   s.concreteTwo(a, b)
-  s.concreteTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  s.concreteTwo(d) // expected-error {{missing argument for parameter #2 in call}}
+  s.concreteTwo((a, b))
+  s.concreteTwo(d) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
 
-  s.concreteTuple(a, b) // expected-error {{instance method 'concreteTuple' expects a single parameter of type '(Int, Int)'}} {{19-19=(}} {{23-23=)}}
+  s.concreteTuple(a, b)
   s.concreteTuple((a, b))
   s.concreteTuple(d)
 }
@@ -255,7 +271,7 @@ do {
   let s = Concrete()
 
   s.generic(3)
-  s.generic(3, 4) // expected-error {{extra argument in call}}
+  s.generic(3, 4)
   s.generic((3))
   s.generic((3, 4))
 
@@ -280,7 +296,7 @@ do {
   let d = (a, b)
 
   s.generic(a)
-  s.generic(a, b) // expected-error {{extra argument in call}}
+  s.generic(a, b)
   s.generic((a))
   s.generic((a, b))
   s.generic(d)
@@ -303,7 +319,7 @@ do {
   var d = (a, b)
 
   s.generic(a)
-  s.generic(a, b) // expected-error {{extra argument in call}}
+  // s.generic(a, b) // Crashes in actual Swift 3
   s.generic((a))
   s.generic((a, b))
   s.generic(d)
@@ -319,7 +335,7 @@ do {
 
 extension Concrete {
   mutating func mutatingConcrete(_ x: Int) {}
-  mutating func mutatingConcreteTwo(_ x: Int, _ y: Int) {} // expected-note 5 {{'mutatingConcreteTwo' declared here}}
+  mutating func mutatingConcreteTwo(_ x: Int, _ y: Int) {} // expected-note 3 {{'mutatingConcreteTwo' declared here}}
   mutating func mutatingConcreteTuple(_ x: (Int, Int)) {}
 }
 
@@ -349,10 +365,10 @@ do {
   s.mutatingConcrete(c)
 
   s.mutatingConcreteTwo(a, b)
-  s.mutatingConcreteTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  s.mutatingConcreteTwo(d) // expected-error {{missing argument for parameter #2 in call}}
+  s.mutatingConcreteTwo((a, b))
+  s.mutatingConcreteTwo(d) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
 
-  s.mutatingConcreteTuple(a, b) // expected-error {{instance method 'mutatingConcreteTuple' expects a single parameter of type '(Int, Int)'}} {{27-27=(}} {{31-31=)}}
+  s.mutatingConcreteTuple(a, b)
   s.mutatingConcreteTuple((a, b))
   s.mutatingConcreteTuple(d)
 }
@@ -389,7 +405,7 @@ do {
   var s = Concrete()
 
   s.mutatingGeneric(3)
-  s.mutatingGeneric(3, 4) // expected-error {{extra argument in call}}
+  s.mutatingGeneric(3, 4)
   s.mutatingGeneric((3))
   s.mutatingGeneric((3, 4))
 
@@ -414,7 +430,7 @@ do {
   let d = (a, b)
 
   s.mutatingGeneric(a)
-  s.mutatingGeneric(a, b) // expected-error {{extra argument in call}}
+  s.mutatingGeneric(a, b)
   s.mutatingGeneric((a))
   s.mutatingGeneric((a, b))
   s.mutatingGeneric(d)
@@ -437,7 +453,7 @@ do {
   var d = (a, b)
 
   s.mutatingGeneric(a)
-  s.mutatingGeneric(a, b) // expected-error {{extra argument in call}}
+  // s.mutatingGeneric(a, b) // Crashes in actual Swift 3
   s.mutatingGeneric((a))
   s.mutatingGeneric((a, b))
   s.mutatingGeneric(d)
@@ -483,11 +499,10 @@ do {
   s.function(c)
 
   s.functionTwo(a, b)
-  s.functionTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  s.functionTwo(d) // expected-error {{missing argument for parameter #2 in call}}
+  s.functionTwo((a, b))
+  s.functionTwo(d) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
 
-
-  s.functionTuple(a, b) // expected-error {{single parameter of type '(Int, Int)' is expected in call}} {{19-19=(}} {{23-23=)}}
+  s.functionTuple(a, b)
   s.functionTuple((a, b))
   s.functionTuple(d)
 }
@@ -514,7 +529,7 @@ do {
 }
 
 struct InitTwo {
-  init(_ x: Int, _ y: Int) {} // expected-note 5 {{'init' declared here}}
+  init(_ x: Int, _ y: Int) {} // expected-note 3 {{'init' declared here}}
 }
 
 struct InitTuple {
@@ -542,10 +557,10 @@ do {
   let c = (a, b)
 
   _ = InitTwo(a, b)
-  _ = InitTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  _ = InitTwo(c) // expected-error {{missing argument for parameter #2 in call}}
+  _ = InitTwo((a, b))
+  _ = InitTwo(c) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
 
-  _ = InitTuple(a, b) // expected-error {{initializer expects a single parameter of type '(Int, Int)'}} {{17-17=(}} {{21-21=)}}
+  _ = InitTuple(a, b)
   _ = InitTuple((a, b))
   _ = InitTuple(c)
 }
@@ -565,7 +580,7 @@ do {
 }
 
 struct SubscriptTwo {
-  subscript(_ x: Int, _ y: Int) -> Int { get { return 0 } set { } } // expected-note 5 {{'subscript' declared here}}
+  subscript(_ x: Int, _ y: Int) -> Int { get { return 0 } set { } } // expected-note 3 {{'subscript' declared here}}
 }
 
 struct SubscriptTuple {
@@ -584,6 +599,10 @@ do {
   let s2 = SubscriptTuple()
   _ = s2[3, 4] // expected-error {{subscript expects a single parameter of type '(Int, Int)'}} {{10-10=(}} {{14-14=)}}
   _ = s2[(3, 4)]
+
+  let s3 = SubscriptLabeledTuple()
+  _ = s3[x: 3, 4] // expected-error {{extra argument in call}}
+  _ = s3[x: (3, 4)]
 }
 
 do {
@@ -593,17 +612,13 @@ do {
 
   let s1 = SubscriptTwo()
   _ = s1[a, b]
-  _ = s1[(a, b)] // expected-error {{missing argument for parameter #2 in call}}
-  _ = s1[d] // expected-error {{missing argument for parameter #2 in call}}
+  _ = s1[(a, b)]
+  _ = s1[d]
 
   let s2 = SubscriptTuple()
-  _ = s2[a, b] // expected-error {{subscript expects a single parameter of type '(Int, Int)'}} {{10-10=(}} {{14-14=)}}
+  _ = s2[a, b]
   _ = s2[(a, b)]
   _ = s2[d]
-
-  let s3 = SubscriptLabeledTuple()
-  _ = s3[x: 3, 4] // expected-error {{extra argument in call}}
-  _ = s3[x: (3, 4)]
 }
 
 do {
@@ -624,7 +639,7 @@ do {
 }
 
 enum Enum {
-  case two(Int, Int) // expected-note 6 {{'two' declared here}}
+  case two(Int, Int) // expected-note 3 {{'two' declared here}}
   case tuple((Int, Int))
   case labeledTuple(x: (Int, Int))
 }
@@ -632,7 +647,6 @@ enum Enum {
 do {
   _ = Enum.two(3, 4)
   _ = Enum.two((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
-  _ = Enum.two(3 > 4 ? 3 : 4) // expected-error {{missing argument for parameter #2 in call}}
 
   _ = Enum.tuple(3, 4) // expected-error {{enum element 'tuple' expects a single parameter of type '(Int, Int)'}} {{18-18=(}} {{22-22=)}}
   _ = Enum.tuple((3, 4))
@@ -647,10 +661,10 @@ do {
   let c = (a, b)
 
   _ = Enum.two(a, b)
-  _ = Enum.two((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  _ = Enum.two(c) // expected-error {{missing argument for parameter #2 in call}}
+  _ = Enum.two((a, b))
+  _ = Enum.two(c) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
 
-  _ = Enum.tuple(a, b) // expected-error {{enum element 'tuple' expects a single parameter of type '(Int, Int)'}} {{18-18=(}} {{22-22=)}}
+  _ = Enum.tuple(a, b)
   _ = Enum.tuple((a, b))
   _ = Enum.tuple(c)
 }
@@ -674,7 +688,7 @@ struct Generic<T> {}
 extension Generic {
   func generic(_ x: T) {}
   func genericLabeled(x: T) {}
-  func genericTwo(_ x: T, _ y: T) {} // expected-note 3 {{'genericTwo' declared here}}
+  func genericTwo(_ x: T, _ y: T) {} // expected-note 2 {{'genericTwo' declared here}}
   func genericTuple(_ x: (T, T)) {}
 }
 
@@ -715,14 +729,14 @@ do {
   s.generic(c)
 
   s.genericTwo(a, b)
-  s.genericTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
+  s.genericTwo((a, b))
 
-  s.genericTuple(a, b) // expected-error {{instance method 'genericTuple' expects a single parameter of type '(Double, Double)'}} {{18-18=(}} {{22-22=)}}
+  s.genericTuple(a, b)
   s.genericTuple((a, b))
 
   let sTwo = Generic<(Double, Double)>()
 
-  sTwo.generic(a, b) // expected-error {{instance method 'generic' expects a single parameter of type '(Double, Double)'}} {{16-16=(}} {{20-20=)}}
+  sTwo.generic(a, b)
   sTwo.generic((a, b))
   sTwo.generic(d)
 }
@@ -755,7 +769,7 @@ do {
 extension Generic {
   mutating func mutatingGeneric(_ x: T) {}
   mutating func mutatingGenericLabeled(x: T) {}
-  mutating func mutatingGenericTwo(_ x: T, _ y: T) {} // expected-note 3 {{'mutatingGenericTwo' declared here}}
+  mutating func mutatingGenericTwo(_ x: T, _ y: T) {} // expected-note 2 {{'mutatingGenericTwo' declared here}}
   mutating func mutatingGenericTuple(_ x: (T, T)) {}
 }
 
@@ -796,14 +810,14 @@ do {
   s.mutatingGeneric(c)
 
   s.mutatingGenericTwo(a, b)
-  s.mutatingGenericTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
+  s.mutatingGenericTwo((a, b))
 
-  s.mutatingGenericTuple(a, b) // expected-error {{instance method 'mutatingGenericTuple' expects a single parameter of type '(Double, Double)'}} {{26-26=(}} {{30-30=)}}
+  s.mutatingGenericTuple(a, b)
   s.mutatingGenericTuple((a, b))
 
   var sTwo = Generic<(Double, Double)>()
 
-  sTwo.mutatingGeneric(a, b) // expected-error {{instance method 'mutatingGeneric' expects a single parameter of type '(Double, Double)'}} {{24-24=(}} {{28-28=)}}
+  sTwo.mutatingGeneric(a, b)
   sTwo.mutatingGeneric((a, b))
   sTwo.mutatingGeneric(d)
 }
@@ -853,8 +867,8 @@ do {
 
   let sTwo = Generic<(Double, Double)>()
 
-  sTwo.genericFunction(3.0, 4.0) // expected-error {{single parameter of type '(Double, Double)' is expected in call}} {{24-24=(}} {{32-32=)}}
-  sTwo.genericFunction((3.0, 4.0))
+  sTwo.genericFunction(3.0, 4.0)
+  sTwo.genericFunction((3.0, 4.0)) // Does not diagnose in Swift 3 mode
 }
 
 do {
@@ -870,16 +884,16 @@ do {
   s.genericFunction(c)
 
   s.genericFunctionTwo(a, b)
-  s.genericFunctionTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
+  s.genericFunctionTwo((a, b))
 
-  s.genericFunctionTuple(a, b) // expected-error {{single parameter of type '(Double, Double)' is expected in call}} {{26-26=(}} {{30-30=)}}
+  s.genericFunctionTuple(a, b)
   s.genericFunctionTuple((a, b))
 
   let sTwo = Generic<(Double, Double)>()
 
-  sTwo.genericFunction(a, b) // expected-error {{single parameter of type '(Double, Double)' is expected in call}} {{24-24=(}} {{28-28=)}}
+  sTwo.genericFunction(a, b)
   sTwo.genericFunction((a, b))
-  sTwo.genericFunction(d)
+  sTwo.genericFunction(d) // Does not diagnose in Swift 3 mode
 }
 
 do {
@@ -902,12 +916,12 @@ do {
 
   var sTwo = Generic<(Double, Double)>()
 
-  sTwo.genericFunction(a, b) // expected-error {{single parameter of type '(Double, Double)' is expected in call}} {{24-24=(}} {{28-28=)}}
-  sTwo.genericFunction((a, b))
-  sTwo.genericFunction(d)
+  sTwo.genericFunction(a, b)
+  sTwo.genericFunction((a, b)) // Does not diagnose in Swift 3 mode
+  sTwo.genericFunction(d) // Does not diagnose in Swift 3 mode
 }
 
-struct GenericInit<T> {
+struct GenericInit<T> { // expected-note 2 {{'T' declared as parameter to type 'GenericInit'}}
   init(_ x: T) {}
 }
 
@@ -916,7 +930,7 @@ struct GenericInitLabeled<T> {
 }
 
 struct GenericInitTwo<T> {
-  init(_ x: T, _ y: T) {} // expected-note 10 {{'init' declared here}}
+  init(_ x: T, _ y: T) {} // expected-note 8 {{'init' declared here}}
 }
 
 struct GenericInitTuple<T> {
@@ -928,7 +942,7 @@ struct GenericInitLabeledTuple<T> {
 }
 
 do {
-  _ = GenericInit(3, 4) // expected-error {{extra argument in call}}
+  _ = GenericInit(3, 4)
   _ = GenericInit((3, 4))
 
   _ = GenericInitLabeled(x: 3, 4) // expected-error {{extra argument in call}}
@@ -945,8 +959,8 @@ do {
 }
 
 do {
-  _ = GenericInit<(Int, Int)>(3, 4) // expected-error {{extra argument in call}}
-  _ = GenericInit<(Int, Int)>((3, 4))
+  _ = GenericInit<(Int, Int)>(3, 4)
+  _ = GenericInit<(Int, Int)>((3, 4)) // expected-error {{expression type 'GenericInit<(Int, Int)>' is ambiguous without more context}}
 
   _ = GenericInitLabeled<(Int, Int)>(x: 3, 4) // expected-error {{extra argument in call}}
   _ = GenericInitLabeled<(Int, Int)>(x: (3, 4))
@@ -966,7 +980,7 @@ do {
   let b = 4
   let c = (a, b)
 
-  _ = GenericInit(a, b) // expected-error {{extra argument in call}}
+  _ = GenericInit(a, b)
   _ = GenericInit((a, b))
   _ = GenericInit(c)
 
@@ -984,15 +998,15 @@ do {
   let b = 4
   let c = (a, b)
 
-  _ = GenericInit<(Int, Int)>(a, b) // expected-error {{extra argument in call}}
+  _ = GenericInit<(Int, Int)>(a, b)
   _ = GenericInit<(Int, Int)>((a, b))
   _ = GenericInit<(Int, Int)>(c)
 
   _ = GenericInitTwo<Int>(a, b)
-  _ = GenericInitTwo<Int>((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  _ = GenericInitTwo<Int>(c) // expected-error {{missing argument for parameter #2 in call}}
+  _ = GenericInitTwo<Int>((a, b)) // Does not diagnose in Swift 3 mode
+  _ = GenericInitTwo<Int>(c) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
 
-  _ = GenericInitTuple<Int>(a, b) // expected-error {{initializer expects a single parameter of type '(T, T)'}} {{29-29=(}} {{33-33=)}}
+  _ = GenericInitTuple<Int>(a, b) // Does not diagnose in Swift 3 mode
   _ = GenericInitTuple<Int>((a, b))
   _ = GenericInitTuple<Int>(c)
 }
@@ -1003,8 +1017,8 @@ do {
   var c = (a, b)
 
   _ = GenericInit(a, b) // expected-error {{extra argument in call}}
-  _ = GenericInit((a, b))
-  _ = GenericInit(c)
+  _ = GenericInit((a, b)) // expected-error {{generic parameter 'T' could not be inferred}} // expected-note {{explicitly specify the generic arguments to fix this issue}}
+  _ = GenericInit(c) // expected-error {{generic parameter 'T' could not be inferred}} // expected-note {{explicitly specify the generic arguments to fix this issue}}
 
   _ = GenericInitTwo(a, b)
   _ = GenericInitTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
@@ -1020,9 +1034,9 @@ do {
   var b = 4 // expected-warning {{variable 'b' was never mutated; consider changing to 'let' constant}}
   var c = (a, b) // expected-warning {{variable 'c' was never mutated; consider changing to 'let' constant}}
 
-  _ = GenericInit<(Int, Int)>(a, b) // expected-error {{extra argument in call}}
-  _ = GenericInit<(Int, Int)>((a, b))
-   _ = GenericInit<(Int, Int)>(c)
+  // _ = GenericInit<(Int, Int)>(a, b) // Crashes in Swift 3
+  _ = GenericInit<(Int, Int)>((a, b)) // expected-error {{expression type 'GenericInit<(Int, Int)>' is ambiguous without more context}}
+   _ = GenericInit<(Int, Int)>(c) // expected-error {{expression type 'GenericInit<(Int, Int)>' is ambiguous without more context}}
 
   _ = GenericInitTwo<Int>(a, b)
   _ = GenericInitTwo<Int>((a, b)) // expected-error {{missing argument for parameter #2 in call}}
@@ -1034,7 +1048,8 @@ do {
 }
 
 struct GenericSubscript<T> {
-  subscript(_ x: T) -> Int { get { return 0 } set { } }
+  // TODO: Restore regressed diagnostics rdar://problem/31724211
+  subscript(_ x: T) -> Int { get { return 0 } set { } } // expected-note* {{}}
 }
 
 struct GenericSubscriptLabeled<T> {
@@ -1042,21 +1057,22 @@ struct GenericSubscriptLabeled<T> {
 }
 
 struct GenericSubscriptTwo<T> {
-  subscript(_ x: T, _ y: T) -> Int { get { return 0 } set { } } // expected-note 5 {{'subscript' declared here}}
-}
-
-struct GenericSubscriptLabeledTuple<T> {
-  subscript(x x: (T, T)) -> Int { get { return 0 } set { } }
+  subscript(_ x: T, _ y: T) -> Int { get { return 0 } set { } } // expected-note 3 {{'subscript' declared here}}
 }
 
 struct GenericSubscriptTuple<T> {
   subscript(_ x: (T, T)) -> Int { get { return 0 } set { } }
 }
 
+struct GenericSubscriptLabeledTuple<T> {
+  subscript(x x: (T, T)) -> Int { get { return 0 } set { } }
+}
+
 do {
   let s1 = GenericSubscript<(Double, Double)>()
-  _ = s1[3.0, 4.0] // expected-error {{extra argument in call}}
-  _ = s1[(3.0, 4.0)]
+  _ = s1[3.0, 4.0]
+  // TODO: Restore regressed diagnostics rdar://problem/31724211
+  _ = s1[(3.0, 4.0)] // expected-error {{}}
 
   let s1a  = GenericSubscriptLabeled<(Double, Double)>()
   _ = s1a [x: 3.0, 4.0] // expected-error {{extra argument in call}}
@@ -1081,17 +1097,17 @@ do {
   let d = (a, b)
 
   let s1 = GenericSubscript<(Double, Double)>()
-  _ = s1[a, b] // expected-error {{extra argument in call}}
+  _ = s1[a, b]
   _ = s1[(a, b)]
   _ = s1[d]
 
   let s2 = GenericSubscriptTwo<Double>()
   _ = s2[a, b]
-  _ = s2[(a, b)] // expected-error {{missing argument for parameter #2 in call}}
-  _ = s2[d] // expected-error {{missing argument for parameter #2 in call}}
+  _ = s2[(a, b)] // Does not diagnose in Swift 3 mode
+  _ = s2[d] // Does not diagnose in Swift 3 mode
 
   let s3 = GenericSubscriptTuple<Double>()
-  _ = s3[a, b] // expected-error {{subscript expects a single parameter of type '(T, T)'}} {{10-10=(}} {{14-14=)}}
+  _ = s3[a, b] // Does not diagnose in Swift 3 mode
   _ = s3[(a, b)]
   _ = s3[d]
 }
@@ -1103,9 +1119,11 @@ do {
   var d = (a, b) // e/xpected-warning {{variable 'd' was never mutated; consider changing to 'let' constant}}
 
   var s1 = GenericSubscript<(Double, Double)>()
-  _ = s1[a, b] // expected-error {{extra argument in call}}
-  _ = s1[(a, b)]
-  _ = s1[d]
+  _ = s1[a, b]
+  // TODO: Restore regressed diagnostics rdar://problem/31724211
+  // These two lines give different regressed behavior in S3 and S4 mode
+  // _ = s1[(a, b)] // e/xpected-error {{expression type '@lvalue Int' is ambiguous without more context}}
+  // _ = s1[d] // e/xpected-error {{expression type '@lvalue Int' is ambiguous without more context}}
 
   var s2 = GenericSubscriptTwo<Double>()
   _ = s2[a, b]
@@ -1121,12 +1139,12 @@ do {
 enum GenericEnum<T> {
   case one(T)
   case labeled(x: T)
-  case two(T, T) // expected-note 10 {{'two' declared here}}
+  case two(T, T) // expected-note 8 {{'two' declared here}}
   case tuple((T, T))
 }
 
 do {
-  _ = GenericEnum.one(3, 4) // expected-error {{extra argument in call}}
+  _ = GenericEnum.one(3, 4)
   _ = GenericEnum.one((3, 4))
 
   _ = GenericEnum.labeled(x: 3, 4) // expected-error {{extra argument in call}}
@@ -1142,8 +1160,8 @@ do {
 }
 
 do {
-  _ = GenericEnum<(Int, Int)>.one(3, 4) // expected-error {{enum element 'one' expects a single parameter of type '(Int, Int)'}} {{35-35=(}} {{39-39=)}}
-  _ = GenericEnum<(Int, Int)>.one((3, 4))
+  _ = GenericEnum<(Int, Int)>.one(3, 4)
+  _ = GenericEnum<(Int, Int)>.one((3, 4)) // Does not diagnose in Swift 3 mode
 
   _ = GenericEnum<(Int, Int)>.labeled(x: 3, 4) // expected-error {{extra argument in call}}
   _ = GenericEnum<(Int, Int)>.labeled(x: (3, 4))
@@ -1162,7 +1180,7 @@ do {
   let b = 4
   let c = (a, b)
 
-  _ = GenericEnum.one(a, b) // expected-error {{extra argument in call}}
+  _ = GenericEnum.one(a, b)
   _ = GenericEnum.one((a, b))
   _ = GenericEnum.one(c)
 
@@ -1180,15 +1198,15 @@ do {
   let b = 4
   let c = (a, b)
 
-  _ = GenericEnum<(Int, Int)>.one(a, b) // expected-error {{enum element 'one' expects a single parameter of type '(Int, Int)'}} {{35-35=(}} {{39-39=)}}
+  _ = GenericEnum<(Int, Int)>.one(a, b)
   _ = GenericEnum<(Int, Int)>.one((a, b))
   _ = GenericEnum<(Int, Int)>.one(c)
 
   _ = GenericEnum<Int>.two(a, b)
-  _ = GenericEnum<Int>.two((a, b)) // expected-error {{missing argument for parameter #2 in call}}
-  _ = GenericEnum<Int>.two(c) // expected-error {{missing argument for parameter #2 in call}}
+  _ = GenericEnum<Int>.two((a, b))
+  _ = GenericEnum<Int>.two(c) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
 
-  _ = GenericEnum<Int>.tuple(a, b) // expected-error {{enum element 'tuple' expects a single parameter of type '(Int, Int)'}} {{30-30=(}} {{34-34=)}}
+  _ = GenericEnum<Int>.tuple(a, b)
   _ = GenericEnum<Int>.tuple((a, b))
   _ = GenericEnum<Int>.tuple(c)
 }
@@ -1198,9 +1216,9 @@ do {
   var b = 4
   var c = (a, b)
 
-  _ = GenericEnum.one(a, b) // expected-error {{extra argument in call}}
-  _ = GenericEnum.one((a, b))
-  _ = GenericEnum.one(c)
+  // _ = GenericEnum.one(a, b) // Crashes in actual Swift 3
+  _ = GenericEnum.one((a, b)) // Does not diagnose in Swift 3 mode
+  _ = GenericEnum.one(c) // Does not diagnose in Swift 3 mode
 
   _ = GenericEnum.two(a, b)
   _ = GenericEnum.two((a, b)) // expected-error {{missing argument for parameter #2 in call}}
@@ -1216,9 +1234,9 @@ do {
   var b = 4
   var c = (a, b)
 
-  _ = GenericEnum<(Int, Int)>.one(a, b) // expected-error {{enum element 'one' expects a single parameter of type '(Int, Int)'}} {{35-35=(}} {{39-39=)}}
-  _ = GenericEnum<(Int, Int)>.one((a, b))
-  _ = GenericEnum<(Int, Int)>.one(c)
+  // _ = GenericEnum<(Int, Int)>.one(a, b) // Crashes in actual Swift 3
+  _ = GenericEnum<(Int, Int)>.one((a, b)) // Does not diagnose in Swift 3 mode
+  _ = GenericEnum<(Int, Int)>.one(c) // Does not diagnose in Swift 3 mode
 
   _ = GenericEnum<Int>.two(a, b)
   _ = GenericEnum<Int>.two((a, b)) // expected-error {{missing argument for parameter #2 in call}}
@@ -1236,7 +1254,7 @@ protocol Protocol {
 extension Protocol {
   func requirement(_ x: Element) {}
   func requirementLabeled(x: Element) {}
-  func requirementTwo(_ x: Element, _ y: Element) {} // expected-note 3 {{'requirementTwo' declared here}}
+  func requirementTwo(_ x: Element, _ y: Element) {} // expected-note 2 {{'requirementTwo' declared here}}
   func requirementTuple(_ x: (Element, Element)) {}
 }
 
@@ -1249,7 +1267,7 @@ do {
 
   s.requirement(3.0)
   s.requirement((3.0))
- 
+
   s.requirementLabeled(x: 3.0)
   s.requirementLabeled(x: (3.0))
 
@@ -1281,14 +1299,14 @@ do {
   s.requirement(c)
 
   s.requirementTwo(a, b)
-  s.requirementTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
+  s.requirementTwo((a, b)) // Does not diagnose in Swift 3 mode
 
-  s.requirementTuple(a, b) // expected-error {{instance method 'requirementTuple' expects a single parameter of type '(Double, Double)'}} {{22-22=(}} {{26-26=)}}
+  s.requirementTuple(a, b) // Does not diagnose in Swift 3 mode
   s.requirementTuple((a, b))
 
   let sTwo = GenericConforms<(Double, Double)>()
 
-  sTwo.requirement(a, b) // expected-error {{instance method 'requirement' expects a single parameter of type '(Double, Double)'}} {{20-20=(}} {{24-24=)}}
+  sTwo.requirement(a, b)
   sTwo.requirement((a, b))
   sTwo.requirement(d)
 }
@@ -1330,9 +1348,9 @@ do {
   s.takesClosure({ x in })
   s.takesClosure({ (x: Double) in })
 
-  s.takesClosureTwo({ _ = $0 }) // expected-error {{contextual closure type '(Double, Double) -> ()' expects 2 arguments, but 1 was used in closure body}}
-  s.takesClosureTwo({ x in }) // expected-error {{contextual closure type '(Double, Double) -> ()' expects 2 arguments, but 1 was used in closure body}}
-  s.takesClosureTwo({ (x: (Double, Double)) in }) // expected-error {{contextual closure type '(Double, Double) -> ()' expects 2 arguments, but 1 was used in closure body}}
+  s.takesClosureTwo({ _ = $0 })
+  s.takesClosureTwo({ x in })
+  s.takesClosureTwo({ (x: (Double, Double)) in })
   s.takesClosureTwo({ _ = $0; _ = $1 })
   s.takesClosureTwo({ (x, y) in })
   s.takesClosureTwo({ (x: Double, y:Double) in })
@@ -1358,12 +1376,12 @@ do {
   let _: ((Int, Int)) -> () = { _ = ($0.0, $0.1) }
   let _: ((Int, Int)) -> () = { t in _ = (t.0, t.1) }
 
-  let _: ((Int, Int)) -> () = { _ = ($0, $1) } // expected-error {{closure tuple parameter '(Int, Int)' does not support destructuring}}
-  let _: ((Int, Int)) -> () = { t, u in _ = (t, u) } // expected-error {{closure tuple parameter '(Int, Int)' does not support destructuring}} {{33-37=(arg)}} {{41-41=let (t, u) = arg; }}
+  let _: ((Int, Int)) -> () = { _ = ($0, $1) }
+  let _: ((Int, Int)) -> () = { t, u in _ = (t, u) }
 
-  let _: (Int, Int) -> () = { _ = $0 } // expected-error {{contextual closure type '(Int, Int) -> ()' expects 2 arguments, but 1 was used in closure body}}
-  let _: (Int, Int) -> () = { _ = ($0.0, $0.1) } // expected-error {{contextual closure type '(Int, Int) -> ()' expects 2 arguments, but 1 was used in closure body}}
-  let _: (Int, Int) -> () = { t in _ = (t.0, t.1) } // expected-error {{contextual closure type '(Int, Int) -> ()' expects 2 arguments, but 1 was used in closure body}}
+  let _: (Int, Int) -> () = { _ = $0 }
+  let _: (Int, Int) -> () = { _ = ($0.0, $0.1) }
+  let _: (Int, Int) -> () = { t in _ = (t.0, t.1) }
 
   let _: (Int, Int) -> () = { _ = ($0, $1) }
   let _: (Int, Int) -> () = { t, u in _ = (t, u) }
@@ -1381,17 +1399,19 @@ do {
   let fn: (Any) -> () = { _ in }
 
   fn(123)
-  fn(data: 123) // expected-error {{extraneous argument label 'data:' in call}}
+  fn(data: 123)
 
   takesAny(123)
-  takesAny(data: 123) // expected-error {{extraneous argument label 'data:' in call}}
+  takesAny(data: 123)
 
   _ = HasAnyCase.any(123)
-  _ = HasAnyCase.any(data: 123) // expected-error {{extraneous argument label 'data:' in call}}
+  _ = HasAnyCase.any(data: 123)
 }
 
 // rdar://problem/29739905 - protocol extension methods on Array had
 // ParenType sugar stripped off the element type
+typealias BoolPair = (Bool, Bool)
+
 func processArrayOfFunctions(f1: [((Bool, Bool)) -> ()],
                              f2: [(Bool, Bool) -> ()],
                              c: Bool) {
@@ -1400,27 +1420,24 @@ func processArrayOfFunctions(f1: [((Bool, Bool)) -> ()],
   f1.forEach { block in
     block(p)
     block((c, c))
-    block(c, c) // expected-error {{parameter 'block' expects a single parameter of type '(Bool, Bool)'}} {{11-11=(}} {{15-15=)}}
+    block(c, c)
   }
 
   f2.forEach { block in
-  // expected-note@-1 2{{'block' declared here}}
-    block(p) // expected-error {{missing argument for parameter #2 in call}}
-    block((c, c)) // expected-error {{missing argument for parameter #2 in call}}
+    block(p) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
+    block((c, c))
     block(c, c)
   }
 
   f2.forEach { (block: ((Bool, Bool)) -> ()) in
-  // expected-error@-1 {{cannot convert value of type '(((Bool, Bool)) -> ()) -> ()' to expected argument type '((Bool, Bool) -> ()) -> Void}}
     block(p)
     block((c, c))
     block(c, c)
   }
 
   f2.forEach { (block: (Bool, Bool) -> ()) in
-  // expected-note@-1 2{{'block' declared here}}
-    block(p) // expected-error {{missing argument for parameter #2 in call}}
-    block((c, c)) // expected-error {{missing argument for parameter #2 in call}}
+    block(p) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
+    block((c, c))
     block(c, c)
   }
 }
@@ -1433,7 +1450,7 @@ func singleElementTupleArgument(completion: ((didAdjust: Bool)) -> Void) {
 }
 
 
-// SR-4378
+// SR-4378 -- FIXME -- this should type check, it used to work in Swift 3.0
 
 final public class MutableProperty<Value> {
     public init(_ initialValue: Value) {}
@@ -1444,215 +1461,47 @@ enum DataSourcePage<T> {
 }
 
 let pages1: MutableProperty<(data: DataSourcePage<Int>, totalCount: Int)> = MutableProperty((
+    // expected-error@-1 {{expression type 'MutableProperty<(data: DataSourcePage<Int>, totalCount: Int)>' is ambiguous without more context}}
     data: .notLoaded,
     totalCount: 0
 ))
 
 
 let pages2: MutableProperty<(data: DataSourcePage<Int>, totalCount: Int)> = MutableProperty((
+    // expected-error@-1 {{cannot convert value of type 'MutableProperty<(data: DataSourcePage<_>, totalCount: Int)>' to specified type 'MutableProperty<(data: DataSourcePage<Int>, totalCount: Int)>'}}
     data: DataSourcePage.notLoaded,
     totalCount: 0
 ))
 
 
 let pages3: MutableProperty<(data: DataSourcePage<Int>, totalCount: Int)> = MutableProperty((
+    // expected-error@-1 {{expression type 'MutableProperty<(data: DataSourcePage<Int>, totalCount: Int)>' is ambiguous without more context}}
     data: DataSourcePage<Int>.notLoaded,
     totalCount: 0
 ))
 
-// SR-4745
-let sr4745 = [1, 2]
-let _ = sr4745.enumerated().map { (count, element) in "\(count): \(element)" }
-
-// SR-4738
-
-let sr4738 = (1, (2, 3))
-[sr4738].map { (x, (y, z)) -> Int in x + y + z } // expected-error {{use of undeclared type 'y'}}
-// expected-error@-1 {{closure tuple parameter does not support destructuring}} {{20-26=arg1}} {{38-38=let (y, z) = arg1; }}
-
-// rdar://problem/31892961
-let r31892961_1 = [1: 1, 2: 2]
-r31892961_1.forEach { (k, v) in print(k + v) }
-
-let r31892961_2 = [1, 2, 3]
-let _: [Int] = r31892961_2.enumerated().map { ((index, val)) in
-  // expected-error@-1 {{closure tuple parameter does not support destructuring}} {{48-60=arg0}} {{3-3=\n  let (index, val) = arg0\n  }}
-  // expected-error@-2 {{use of undeclared type 'index'}}
-  val + 1
-}
-
-let r31892961_3 = (x: 1, y: 42)
-_ = [r31892961_3].map { (x: Int, y: Int) in x + y }
-
-_ = [r31892961_3].map { (x, y: Int) in x + y }
-
-let r31892961_4 = (1, 2)
-_ = [r31892961_4].map { x, y in x + y }
-
-let r31892961_5 = (x: 1, (y: 2, (w: 3, z: 4)))
-[r31892961_5].map { (x: Int, (y: Int, (w: Int, z: Int))) in x + y }
-// expected-error@-1 {{closure tuple parameter does not support destructuring}} {{30-56=arg1}} {{61-61=let (y, (w, z)) = arg1; }}
-
-let r31892961_6 = (x: 1, (y: 2, z: 4))
-[r31892961_6].map { (x: Int, (y: Int, z: Int)) in x + y }
-// expected-error@-1 {{closure tuple parameter does not support destructuring}} {{30-46=arg1}} {{51-51=let (y, z) = arg1; }}
-
-// rdar://problem/32214649 -- these regressed in Swift 4 mode
-// with SE-0110 because of a problem in associated type inference
-
-func r32214649_1<X,Y>(_ a: [X], _ f: (X)->Y) -> [Y] {
-  return a.map(f)
-}
-
-func r32214649_2<X>(_ a: [X], _ f: (X) -> Bool) -> [X] {
-  return a.filter(f)
-}
-
-func r32214649_3<X>(_ a: [X]) -> [X] {
-  return a.filter { _ in return true }
-}
-
-// rdar://problem/32301091 - [SE-0110] causes errors when passing a closure with a single underscore to a block accepting multiple parameters
+// rdar://problem/32301091 - Make sure that in Swift 3 mode following expressions still compile just fine
 
 func rdar32301091_1(_ :((Int, Int) -> ())!) {}
-rdar32301091_1 { _ in }
-// expected-error@-1 {{contextual closure type '(Int, Int) -> ()' expects 2 arguments, but 1 was used in closure body}} {{19-19=,_ }}
+rdar32301091_1 { _ in } // Ok in Swift 3
 
 func rdar32301091_2(_ :(Int, Int) -> ()) {}
-rdar32301091_2 { _ in }
-// expected-error@-1 {{contextual closure type '(Int, Int) -> ()' expects 2 arguments, but 1 was used in closure body}} {{19-19=,_ }}
-rdar32301091_2 { x in }
-// expected-error@-1 {{contextual closure type '(Int, Int) -> ()' expects 2 arguments, but 1 was used in closure body}} {{19-19=,<#arg#> }}
+rdar32301091_2 { _ in } // Ok in Swift 3
 
-func rdar32875953() {
-  let myDictionary = ["hi":1]
-
-  myDictionary.forEach {
-    print("\($0) -> \($1)")
-  }
-
-  myDictionary.forEach { key, value in
-    print("\(key) -> \(value)")
-  }
-
-  myDictionary.forEach { (key, value) in
-    print("\(key) -> \(value)")
-  }
-
-  let array1 = [1]
-  let array2 = [2]
-
-  _ = zip(array1, array2).map(+)
-}
-
-struct SR_5199 {}
-extension Sequence where Iterator.Element == (key: String, value: String?) {
-  func f() -> [SR_5199] {
-    return self.map { (key, value) in
-        SR_5199() // Ok
-    }
-  }
-}
-
-func rdar33043106(_ records: [(Int)], _ other: [((Int))]) -> [Int] {
-  let x: [Int] = records.map { _ in
-    let i = 1
-    return i
-  }
-  let y: [Int] = other.map { _ in
-    let i = 1
-    return i
-  }
-
-  return x + y
-}
-
-func itsFalse(_: Int) -> Bool? {
-  return false
-}
-
-func rdar33159366(s: AnySequence<Int>) {
-  _ = s.compactMap(itsFalse)
-  let a = Array(s)
-  _ = a.compactMap(itsFalse)
-}
-
-func sr5429<T>(t: T) {
-  _ = AnySequence([t]).first(where: { (t: T) in true })
-}
-
-extension Concrete {
-  typealias T = (Int, Int)
-  typealias F = (T) -> ()
-  func opt1(_ fn: (((Int, Int)) -> ())?) {}
-  func opt2(_ fn: (((Int, Int)) -> ())??) {}
-  func opt3(_ fn: (((Int, Int)) -> ())???) {}
-  func optAliasT(_ fn: ((T) -> ())?) {}
-  func optAliasF(_ fn: F?) {}
-}
-
-extension Generic {
-  typealias F = (T) -> ()
-  func opt1(_ fn: (((Int, Int)) -> ())?) {}
-  func opt2(_ fn: (((Int, Int)) -> ())??) {}
-  func opt3(_ fn: (((Int, Int)) -> ())???) {}
-  func optAliasT(_ fn: ((T) -> ())?) {}
-  func optAliasF(_ fn: F?) {}
-}
-
-func rdar33239714() {
-  Concrete().opt1 { x, y in }
-  Concrete().opt1 { (x, y) in }
-  Concrete().opt2 { x, y in }
-  Concrete().opt2 { (x, y) in }
-  Concrete().opt3 { x, y in }
-  Concrete().opt3 { (x, y) in }
-  Concrete().optAliasT { x, y in }
-  Concrete().optAliasT { (x, y) in }
-  Concrete().optAliasF { x, y in }
-  Concrete().optAliasF { (x, y) in }
-  Generic<(Int, Int)>().opt1 { x, y in }
-  Generic<(Int, Int)>().opt1 { (x, y) in }
-  Generic<(Int, Int)>().opt2 { x, y in }
-  Generic<(Int, Int)>().opt2 { (x, y) in }
-  Generic<(Int, Int)>().opt3 { x, y in }
-  Generic<(Int, Int)>().opt3 { (x, y) in }
-  Generic<(Int, Int)>().optAliasT { x, y in }
-  Generic<(Int, Int)>().optAliasT { (x, y) in }
-  Generic<(Int, Int)>().optAliasF { x, y in }
-  Generic<(Int, Int)>().optAliasF { (x, y) in }
-}
-
-// rdar://problem/35198459 - source-compat-suite failure: Moya (toType->hasUnresolvedType() && "Should have handled this above"
+// rdar://problem/35198459 - source-compat-suite failure: Moya (toType->hasUnresolvedType() && "Should have handled this above")
 do {
   func foo(_: (() -> Void)?) {}
   func bar() -> ((()) -> Void)? { return nil }
-  foo(bar()) // expected-error {{cannot convert value of type '((()) -> Void)?' to expected argument type '(() -> Void)?'}}
-}
-
-// https://bugs.swift.org/browse/SR-6509
-public extension Optional {
-  public func apply<Result>(_ transform: ((Wrapped) -> Result)?) -> Result? {
-    return self.flatMap { value in
-      transform.map { $0(value) }
-    }
-  }
-
-  public func apply<Value, Result>(_ value: Value?) -> Result?
-    where Wrapped == (Value) -> Result {
-    return value.apply(self)
-  }
+  foo(bar()) // OK in Swift 3 mode
 }
 
 // https://bugs.swift.org/browse/SR-6837
 do {
   func takeFn(fn: (_ i: Int, _ j: Int?) -> ()) {}
   func takePair(_ pair: (Int, Int?)) {}
-  takeFn(fn: takePair) // expected-error {{cannot convert value of type '((Int, Int?)) -> ()' to expected argument type '(Int, Int?) -> ()'}}
-  takeFn(fn: { (pair: (Int, Int?)) in } ) // Disallow for -swift-version 4 and later
-  // expected-error@-1 {{contextual closure type '(Int, Int?) -> ()' expects 2 arguments, but 1 was used in closure body}}
-  takeFn { (pair: (Int, Int?)) in } // Disallow for -swift-version 4 and later
-  // expected-error@-1 {{contextual closure type '(Int, Int?) -> ()' expects 2 arguments, but 1 was used in closure body}}
+  takeFn(fn: takePair)
+  takeFn(fn: { (pair: (Int, Int?)) in } )
+  takeFn { (pair: (Int, Int?)) in }
 }
 
 // https://bugs.swift.org/browse/SR-6796
@@ -1660,14 +1509,14 @@ do {
   func f(a: (() -> Void)? = nil) {}
   func log<T>() -> ((T) -> Void)? { return nil }
 
-  f(a: log() as ((()) -> Void)?) // expected-error {{cannot convert value of type '((()) -> Void)?' to expected argument type '(() -> Void)?'}}
+  f(a: log() as ((()) -> Void)?) // Allow ((()) -> Void)? to be passed in place of (() -> Void)?
 
   func logNoOptional<T>() -> (T) -> Void { }
-  f(a: logNoOptional() as ((()) -> Void)) // expected-error {{cannot convert value of type '(()) -> Void' to expected argument type '(() -> Void)?'}}
+  f(a: logNoOptional() as ((()) -> Void)) // Also allow the optional-injected form.
 
   func g() {}
-  g(()) // expected-error {{argument passed to call that takes no arguments}}
+  g(())
 
-  func h(_: ()) {} // expected-note {{'h' declared here}}
-  h() // expected-error {{missing argument for parameter #1 in call}}
+  func h(_: ()) {}
+  h()
 }

--- a/test/Compatibility/tuple_arguments_4.swift
+++ b/test/Compatibility/tuple_arguments_4.swift
@@ -1,26 +1,10 @@
-// RUN: %target-typecheck-verify-swift -swift-version 3
+// RUN: %target-typecheck-verify-swift -swift-version 4
 
-// Tests for tuple argument behavior in Swift 3, which was broken.
-// The Swift 4 test is in test/Constraints/tuple_arguments.swift.
-
-// Key:
-// - "Crashes in actual Swift 3" -- snippets which crashed in Swift 3.0.1.
-//   These don't have well-defined semantics in Swift 3 mode and don't
-//   matter for source compatibility purposes.
-//
-// - "Does not diagnose in Swift 3 mode" -- snippets which failed to typecheck
-//   in Swift 3.0.1, but now typecheck. This is fine.
-//
-// - "Diagnoses in Swift 3 mode" -- snippets which typechecked in Swift 3.0.1,
-//   but now fail to typecheck. These are bugs in Swift 3 mode that should be
-//   fixed.
-//
-// - "Crashes in Swift 3 mode" -- snippets which did not crash Swift 3.0.1,
-//   but now crash. These are bugs in Swift 3 mode that should be fixed.
+// See test/Compatibility/tuple_arguments_3.swift for the Swift 3 behavior.
 
 func concrete(_ x: Int) {}
 func concreteLabeled(x: Int) {}
-func concreteTwo(_ x: Int, _ y: Int) {} // expected-note 3 {{'concreteTwo' declared here}}
+func concreteTwo(_ x: Int, _ y: Int) {} // expected-note 5 {{'concreteTwo' declared here}}
 func concreteTuple(_ x: (Int, Int)) {}
 
 do {
@@ -49,10 +33,10 @@ do {
   concrete(c)
 
   concreteTwo(a, b)
-  concreteTwo((a, b))
-  concreteTwo(d) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
+  concreteTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
+  concreteTwo(d) // expected-error {{missing argument for parameter #2 in call}}
 
-  concreteTuple(a, b)
+  concreteTuple(a, b) // expected-error {{global function 'concreteTuple' expects a single parameter of type '(Int, Int)'}} {{17-17=(}} {{21-21=)}}
   concreteTuple((a, b))
   concreteTuple(d)
 }
@@ -83,7 +67,7 @@ func genericTuple<T, U>(_ x: (T, U)) {}
 
 do {
   generic(3)
-  generic(3, 4)
+  generic(3, 4) // expected-error {{extra argument in call}}
   generic((3))
   generic((3, 4))
 
@@ -106,7 +90,7 @@ do {
   let d = (a, b)
 
   generic(a)
-  generic(a, b)
+  generic(a, b) // expected-error {{extra argument in call}}
   generic((a))
   generic(c)
   generic((a, b))
@@ -128,7 +112,7 @@ do {
   var d = (a, b)
 
   generic(a)
-  // generic(a, b) // Crashes in actual Swift 3
+  generic(a, b) // expected-error {{extra argument in call}}
   generic((a))
   generic(c)
   generic((a, b))
@@ -144,7 +128,7 @@ do {
 }
 
 var function: (Int) -> ()
-var functionTwo: (Int, Int) -> () // expected-note 3 {{'functionTwo' declared here}}
+var functionTwo: (Int, Int) -> () // expected-note 5 {{'functionTwo' declared here}}
 var functionTuple: ((Int, Int)) -> ()
 
 do {
@@ -169,10 +153,10 @@ do {
   function(c)
 
   functionTwo(a, b)
-  functionTwo((a, b))
-  functionTwo(d) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
+  functionTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
+  functionTwo(d) // expected-error {{missing argument for parameter #2 in call}}
 
-  functionTuple(a, b)
+  functionTuple(a, b) // expected-error {{var 'functionTuple' expects a single parameter of type '(Int, Int)'}} {{17-17=(}} {{21-21=)}}
   functionTuple((a, b))
   functionTuple(d)
 }
@@ -200,7 +184,7 @@ struct Concrete {}
 
 extension Concrete {
   func concrete(_ x: Int) {}
-  func concreteTwo(_ x: Int, _ y: Int) {} // expected-note 3 {{'concreteTwo' declared here}}
+  func concreteTwo(_ x: Int, _ y: Int) {} // expected-note 5 {{'concreteTwo' declared here}}
   func concreteTuple(_ x: (Int, Int)) {}
 }
 
@@ -230,10 +214,10 @@ do {
   s.concrete(c)
 
   s.concreteTwo(a, b)
-  s.concreteTwo((a, b))
-  s.concreteTwo(d) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
+  s.concreteTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
+  s.concreteTwo(d) // expected-error {{missing argument for parameter #2 in call}}
 
-  s.concreteTuple(a, b)
+  s.concreteTuple(a, b) // expected-error {{instance method 'concreteTuple' expects a single parameter of type '(Int, Int)'}} {{19-19=(}} {{23-23=)}}
   s.concreteTuple((a, b))
   s.concreteTuple(d)
 }
@@ -270,7 +254,7 @@ do {
   let s = Concrete()
 
   s.generic(3)
-  s.generic(3, 4)
+  s.generic(3, 4) // expected-error {{extra argument in call}}
   s.generic((3))
   s.generic((3, 4))
 
@@ -295,7 +279,7 @@ do {
   let d = (a, b)
 
   s.generic(a)
-  s.generic(a, b)
+  s.generic(a, b) // expected-error {{extra argument in call}}
   s.generic((a))
   s.generic((a, b))
   s.generic(d)
@@ -318,7 +302,7 @@ do {
   var d = (a, b)
 
   s.generic(a)
-  // s.generic(a, b) // Crashes in actual Swift 3
+  s.generic(a, b) // expected-error {{extra argument in call}}
   s.generic((a))
   s.generic((a, b))
   s.generic(d)
@@ -334,7 +318,7 @@ do {
 
 extension Concrete {
   mutating func mutatingConcrete(_ x: Int) {}
-  mutating func mutatingConcreteTwo(_ x: Int, _ y: Int) {} // expected-note 3 {{'mutatingConcreteTwo' declared here}}
+  mutating func mutatingConcreteTwo(_ x: Int, _ y: Int) {} // expected-note 5 {{'mutatingConcreteTwo' declared here}}
   mutating func mutatingConcreteTuple(_ x: (Int, Int)) {}
 }
 
@@ -364,10 +348,10 @@ do {
   s.mutatingConcrete(c)
 
   s.mutatingConcreteTwo(a, b)
-  s.mutatingConcreteTwo((a, b))
-  s.mutatingConcreteTwo(d) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
+  s.mutatingConcreteTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
+  s.mutatingConcreteTwo(d) // expected-error {{missing argument for parameter #2 in call}}
 
-  s.mutatingConcreteTuple(a, b)
+  s.mutatingConcreteTuple(a, b) // expected-error {{instance method 'mutatingConcreteTuple' expects a single parameter of type '(Int, Int)'}} {{27-27=(}} {{31-31=)}}
   s.mutatingConcreteTuple((a, b))
   s.mutatingConcreteTuple(d)
 }
@@ -404,7 +388,7 @@ do {
   var s = Concrete()
 
   s.mutatingGeneric(3)
-  s.mutatingGeneric(3, 4)
+  s.mutatingGeneric(3, 4) // expected-error {{extra argument in call}}
   s.mutatingGeneric((3))
   s.mutatingGeneric((3, 4))
 
@@ -429,7 +413,7 @@ do {
   let d = (a, b)
 
   s.mutatingGeneric(a)
-  s.mutatingGeneric(a, b)
+  s.mutatingGeneric(a, b) // expected-error {{extra argument in call}}
   s.mutatingGeneric((a))
   s.mutatingGeneric((a, b))
   s.mutatingGeneric(d)
@@ -452,7 +436,7 @@ do {
   var d = (a, b)
 
   s.mutatingGeneric(a)
-  // s.mutatingGeneric(a, b) // Crashes in actual Swift 3
+  s.mutatingGeneric(a, b) // expected-error {{extra argument in call}}
   s.mutatingGeneric((a))
   s.mutatingGeneric((a, b))
   s.mutatingGeneric(d)
@@ -498,10 +482,11 @@ do {
   s.function(c)
 
   s.functionTwo(a, b)
-  s.functionTwo((a, b))
-  s.functionTwo(d) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
+  s.functionTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
+  s.functionTwo(d) // expected-error {{missing argument for parameter #2 in call}}
 
-  s.functionTuple(a, b)
+
+  s.functionTuple(a, b) // expected-error {{single parameter of type '(Int, Int)' is expected in call}} {{19-19=(}} {{23-23=)}}
   s.functionTuple((a, b))
   s.functionTuple(d)
 }
@@ -528,7 +513,7 @@ do {
 }
 
 struct InitTwo {
-  init(_ x: Int, _ y: Int) {} // expected-note 3 {{'init' declared here}}
+  init(_ x: Int, _ y: Int) {} // expected-note 5 {{'init' declared here}}
 }
 
 struct InitTuple {
@@ -556,10 +541,10 @@ do {
   let c = (a, b)
 
   _ = InitTwo(a, b)
-  _ = InitTwo((a, b))
-  _ = InitTwo(c) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
+  _ = InitTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
+  _ = InitTwo(c) // expected-error {{missing argument for parameter #2 in call}}
 
-  _ = InitTuple(a, b)
+  _ = InitTuple(a, b) // expected-error {{initializer expects a single parameter of type '(Int, Int)'}} {{17-17=(}} {{21-21=)}}
   _ = InitTuple((a, b))
   _ = InitTuple(c)
 }
@@ -579,7 +564,7 @@ do {
 }
 
 struct SubscriptTwo {
-  subscript(_ x: Int, _ y: Int) -> Int { get { return 0 } set { } } // expected-note 3 {{'subscript' declared here}}
+  subscript(_ x: Int, _ y: Int) -> Int { get { return 0 } set { } } // expected-note 5 {{'subscript' declared here}}
 }
 
 struct SubscriptTuple {
@@ -598,10 +583,6 @@ do {
   let s2 = SubscriptTuple()
   _ = s2[3, 4] // expected-error {{subscript expects a single parameter of type '(Int, Int)'}} {{10-10=(}} {{14-14=)}}
   _ = s2[(3, 4)]
-
-  let s3 = SubscriptLabeledTuple()
-  _ = s3[x: 3, 4] // expected-error {{extra argument in call}}
-  _ = s3[x: (3, 4)]
 }
 
 do {
@@ -611,13 +592,17 @@ do {
 
   let s1 = SubscriptTwo()
   _ = s1[a, b]
-  _ = s1[(a, b)]
-  _ = s1[d]
+  _ = s1[(a, b)] // expected-error {{missing argument for parameter #2 in call}}
+  _ = s1[d] // expected-error {{missing argument for parameter #2 in call}}
 
   let s2 = SubscriptTuple()
-  _ = s2[a, b]
+  _ = s2[a, b] // expected-error {{subscript expects a single parameter of type '(Int, Int)'}} {{10-10=(}} {{14-14=)}}
   _ = s2[(a, b)]
   _ = s2[d]
+
+  let s3 = SubscriptLabeledTuple()
+  _ = s3[x: 3, 4] // expected-error {{extra argument in call}}
+  _ = s3[x: (3, 4)]
 }
 
 do {
@@ -638,7 +623,7 @@ do {
 }
 
 enum Enum {
-  case two(Int, Int) // expected-note 3 {{'two' declared here}}
+  case two(Int, Int) // expected-note 6 {{'two' declared here}}
   case tuple((Int, Int))
   case labeledTuple(x: (Int, Int))
 }
@@ -646,6 +631,7 @@ enum Enum {
 do {
   _ = Enum.two(3, 4)
   _ = Enum.two((3, 4)) // expected-error {{missing argument for parameter #2 in call}}
+  _ = Enum.two(3 > 4 ? 3 : 4) // expected-error {{missing argument for parameter #2 in call}}
 
   _ = Enum.tuple(3, 4) // expected-error {{enum element 'tuple' expects a single parameter of type '(Int, Int)'}} {{18-18=(}} {{22-22=)}}
   _ = Enum.tuple((3, 4))
@@ -660,10 +646,10 @@ do {
   let c = (a, b)
 
   _ = Enum.two(a, b)
-  _ = Enum.two((a, b))
-  _ = Enum.two(c) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
+  _ = Enum.two((a, b)) // expected-error {{missing argument for parameter #2 in call}}
+  _ = Enum.two(c) // expected-error {{missing argument for parameter #2 in call}}
 
-  _ = Enum.tuple(a, b)
+  _ = Enum.tuple(a, b) // expected-error {{enum element 'tuple' expects a single parameter of type '(Int, Int)'}} {{18-18=(}} {{22-22=)}}
   _ = Enum.tuple((a, b))
   _ = Enum.tuple(c)
 }
@@ -687,7 +673,7 @@ struct Generic<T> {}
 extension Generic {
   func generic(_ x: T) {}
   func genericLabeled(x: T) {}
-  func genericTwo(_ x: T, _ y: T) {} // expected-note 2 {{'genericTwo' declared here}}
+  func genericTwo(_ x: T, _ y: T) {} // expected-note 3 {{'genericTwo' declared here}}
   func genericTuple(_ x: (T, T)) {}
 }
 
@@ -728,14 +714,14 @@ do {
   s.generic(c)
 
   s.genericTwo(a, b)
-  s.genericTwo((a, b))
+  s.genericTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
 
-  s.genericTuple(a, b)
+  s.genericTuple(a, b) // expected-error {{instance method 'genericTuple' expects a single parameter of type '(Double, Double)'}} {{18-18=(}} {{22-22=)}}
   s.genericTuple((a, b))
 
   let sTwo = Generic<(Double, Double)>()
 
-  sTwo.generic(a, b)
+  sTwo.generic(a, b) // expected-error {{instance method 'generic' expects a single parameter of type '(Double, Double)'}} {{16-16=(}} {{20-20=)}}
   sTwo.generic((a, b))
   sTwo.generic(d)
 }
@@ -768,7 +754,7 @@ do {
 extension Generic {
   mutating func mutatingGeneric(_ x: T) {}
   mutating func mutatingGenericLabeled(x: T) {}
-  mutating func mutatingGenericTwo(_ x: T, _ y: T) {} // expected-note 2 {{'mutatingGenericTwo' declared here}}
+  mutating func mutatingGenericTwo(_ x: T, _ y: T) {} // expected-note 3 {{'mutatingGenericTwo' declared here}}
   mutating func mutatingGenericTuple(_ x: (T, T)) {}
 }
 
@@ -809,14 +795,14 @@ do {
   s.mutatingGeneric(c)
 
   s.mutatingGenericTwo(a, b)
-  s.mutatingGenericTwo((a, b))
+  s.mutatingGenericTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
 
-  s.mutatingGenericTuple(a, b)
+  s.mutatingGenericTuple(a, b) // expected-error {{instance method 'mutatingGenericTuple' expects a single parameter of type '(Double, Double)'}} {{26-26=(}} {{30-30=)}}
   s.mutatingGenericTuple((a, b))
 
   var sTwo = Generic<(Double, Double)>()
 
-  sTwo.mutatingGeneric(a, b)
+  sTwo.mutatingGeneric(a, b) // expected-error {{instance method 'mutatingGeneric' expects a single parameter of type '(Double, Double)'}} {{24-24=(}} {{28-28=)}}
   sTwo.mutatingGeneric((a, b))
   sTwo.mutatingGeneric(d)
 }
@@ -866,8 +852,8 @@ do {
 
   let sTwo = Generic<(Double, Double)>()
 
-  sTwo.genericFunction(3.0, 4.0)
-  sTwo.genericFunction((3.0, 4.0)) // Does not diagnose in Swift 3 mode
+  sTwo.genericFunction(3.0, 4.0) // expected-error {{single parameter of type '(Double, Double)' is expected in call}} {{24-24=(}} {{32-32=)}}
+  sTwo.genericFunction((3.0, 4.0))
 }
 
 do {
@@ -883,16 +869,16 @@ do {
   s.genericFunction(c)
 
   s.genericFunctionTwo(a, b)
-  s.genericFunctionTwo((a, b))
+  s.genericFunctionTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
 
-  s.genericFunctionTuple(a, b)
+  s.genericFunctionTuple(a, b) // expected-error {{single parameter of type '(Double, Double)' is expected in call}} {{26-26=(}} {{30-30=)}}
   s.genericFunctionTuple((a, b))
 
   let sTwo = Generic<(Double, Double)>()
 
-  sTwo.genericFunction(a, b)
+  sTwo.genericFunction(a, b) // expected-error {{single parameter of type '(Double, Double)' is expected in call}} {{24-24=(}} {{28-28=)}}
   sTwo.genericFunction((a, b))
-  sTwo.genericFunction(d) // Does not diagnose in Swift 3 mode
+  sTwo.genericFunction(d)
 }
 
 do {
@@ -915,12 +901,12 @@ do {
 
   var sTwo = Generic<(Double, Double)>()
 
-  sTwo.genericFunction(a, b)
-  sTwo.genericFunction((a, b)) // Does not diagnose in Swift 3 mode
-  sTwo.genericFunction(d) // Does not diagnose in Swift 3 mode
+  sTwo.genericFunction(a, b) // expected-error {{single parameter of type '(Double, Double)' is expected in call}} {{24-24=(}} {{28-28=)}}
+  sTwo.genericFunction((a, b))
+  sTwo.genericFunction(d)
 }
 
-struct GenericInit<T> { // expected-note 2 {{'T' declared as parameter to type 'GenericInit'}}
+struct GenericInit<T> {
   init(_ x: T) {}
 }
 
@@ -929,7 +915,7 @@ struct GenericInitLabeled<T> {
 }
 
 struct GenericInitTwo<T> {
-  init(_ x: T, _ y: T) {} // expected-note 8 {{'init' declared here}}
+  init(_ x: T, _ y: T) {} // expected-note 10 {{'init' declared here}}
 }
 
 struct GenericInitTuple<T> {
@@ -941,7 +927,7 @@ struct GenericInitLabeledTuple<T> {
 }
 
 do {
-  _ = GenericInit(3, 4)
+  _ = GenericInit(3, 4) // expected-error {{extra argument in call}}
   _ = GenericInit((3, 4))
 
   _ = GenericInitLabeled(x: 3, 4) // expected-error {{extra argument in call}}
@@ -958,8 +944,8 @@ do {
 }
 
 do {
-  _ = GenericInit<(Int, Int)>(3, 4)
-  _ = GenericInit<(Int, Int)>((3, 4)) // expected-error {{expression type 'GenericInit<(Int, Int)>' is ambiguous without more context}}
+  _ = GenericInit<(Int, Int)>(3, 4) // expected-error {{extra argument in call}}
+  _ = GenericInit<(Int, Int)>((3, 4))
 
   _ = GenericInitLabeled<(Int, Int)>(x: 3, 4) // expected-error {{extra argument in call}}
   _ = GenericInitLabeled<(Int, Int)>(x: (3, 4))
@@ -979,7 +965,7 @@ do {
   let b = 4
   let c = (a, b)
 
-  _ = GenericInit(a, b)
+  _ = GenericInit(a, b) // expected-error {{extra argument in call}}
   _ = GenericInit((a, b))
   _ = GenericInit(c)
 
@@ -997,15 +983,15 @@ do {
   let b = 4
   let c = (a, b)
 
-  _ = GenericInit<(Int, Int)>(a, b)
+  _ = GenericInit<(Int, Int)>(a, b) // expected-error {{extra argument in call}}
   _ = GenericInit<(Int, Int)>((a, b))
   _ = GenericInit<(Int, Int)>(c)
 
   _ = GenericInitTwo<Int>(a, b)
-  _ = GenericInitTwo<Int>((a, b)) // Does not diagnose in Swift 3 mode
-  _ = GenericInitTwo<Int>(c) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
+  _ = GenericInitTwo<Int>((a, b)) // expected-error {{missing argument for parameter #2 in call}}
+  _ = GenericInitTwo<Int>(c) // expected-error {{missing argument for parameter #2 in call}}
 
-  _ = GenericInitTuple<Int>(a, b) // Does not diagnose in Swift 3 mode
+  _ = GenericInitTuple<Int>(a, b) // expected-error {{initializer expects a single parameter of type '(T, T)'}} {{29-29=(}} {{33-33=)}}
   _ = GenericInitTuple<Int>((a, b))
   _ = GenericInitTuple<Int>(c)
 }
@@ -1016,8 +1002,8 @@ do {
   var c = (a, b)
 
   _ = GenericInit(a, b) // expected-error {{extra argument in call}}
-  _ = GenericInit((a, b)) // expected-error {{generic parameter 'T' could not be inferred}} // expected-note {{explicitly specify the generic arguments to fix this issue}}
-  _ = GenericInit(c) // expected-error {{generic parameter 'T' could not be inferred}} // expected-note {{explicitly specify the generic arguments to fix this issue}}
+  _ = GenericInit((a, b))
+  _ = GenericInit(c)
 
   _ = GenericInitTwo(a, b)
   _ = GenericInitTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
@@ -1033,9 +1019,9 @@ do {
   var b = 4 // expected-warning {{variable 'b' was never mutated; consider changing to 'let' constant}}
   var c = (a, b) // expected-warning {{variable 'c' was never mutated; consider changing to 'let' constant}}
 
-  // _ = GenericInit<(Int, Int)>(a, b) // Crashes in Swift 3
-  _ = GenericInit<(Int, Int)>((a, b)) // expected-error {{expression type 'GenericInit<(Int, Int)>' is ambiguous without more context}}
-   _ = GenericInit<(Int, Int)>(c) // expected-error {{expression type 'GenericInit<(Int, Int)>' is ambiguous without more context}}
+  _ = GenericInit<(Int, Int)>(a, b) // expected-error {{extra argument in call}}
+  _ = GenericInit<(Int, Int)>((a, b))
+   _ = GenericInit<(Int, Int)>(c)
 
   _ = GenericInitTwo<Int>(a, b)
   _ = GenericInitTwo<Int>((a, b)) // expected-error {{missing argument for parameter #2 in call}}
@@ -1047,8 +1033,7 @@ do {
 }
 
 struct GenericSubscript<T> {
-  // TODO: Restore regressed diagnostics rdar://problem/31724211
-  subscript(_ x: T) -> Int { get { return 0 } set { } } // expected-note* {{}}
+  subscript(_ x: T) -> Int { get { return 0 } set { } }
 }
 
 struct GenericSubscriptLabeled<T> {
@@ -1056,22 +1041,21 @@ struct GenericSubscriptLabeled<T> {
 }
 
 struct GenericSubscriptTwo<T> {
-  subscript(_ x: T, _ y: T) -> Int { get { return 0 } set { } } // expected-note 3 {{'subscript' declared here}}
-}
-
-struct GenericSubscriptTuple<T> {
-  subscript(_ x: (T, T)) -> Int { get { return 0 } set { } }
+  subscript(_ x: T, _ y: T) -> Int { get { return 0 } set { } } // expected-note 5 {{'subscript' declared here}}
 }
 
 struct GenericSubscriptLabeledTuple<T> {
   subscript(x x: (T, T)) -> Int { get { return 0 } set { } }
 }
 
+struct GenericSubscriptTuple<T> {
+  subscript(_ x: (T, T)) -> Int { get { return 0 } set { } }
+}
+
 do {
   let s1 = GenericSubscript<(Double, Double)>()
-  _ = s1[3.0, 4.0]
-  // TODO: Restore regressed diagnostics rdar://problem/31724211
-  _ = s1[(3.0, 4.0)] // expected-error {{}}
+  _ = s1[3.0, 4.0] // expected-error {{extra argument in call}}
+  _ = s1[(3.0, 4.0)]
 
   let s1a  = GenericSubscriptLabeled<(Double, Double)>()
   _ = s1a [x: 3.0, 4.0] // expected-error {{extra argument in call}}
@@ -1096,17 +1080,17 @@ do {
   let d = (a, b)
 
   let s1 = GenericSubscript<(Double, Double)>()
-  _ = s1[a, b]
+  _ = s1[a, b] // expected-error {{extra argument in call}}
   _ = s1[(a, b)]
   _ = s1[d]
 
   let s2 = GenericSubscriptTwo<Double>()
   _ = s2[a, b]
-  _ = s2[(a, b)] // Does not diagnose in Swift 3 mode
-  _ = s2[d] // Does not diagnose in Swift 3 mode
+  _ = s2[(a, b)] // expected-error {{missing argument for parameter #2 in call}}
+  _ = s2[d] // expected-error {{missing argument for parameter #2 in call}}
 
   let s3 = GenericSubscriptTuple<Double>()
-  _ = s3[a, b] // Does not diagnose in Swift 3 mode
+  _ = s3[a, b] // expected-error {{subscript expects a single parameter of type '(T, T)'}} {{10-10=(}} {{14-14=)}}
   _ = s3[(a, b)]
   _ = s3[d]
 }
@@ -1118,11 +1102,9 @@ do {
   var d = (a, b) // e/xpected-warning {{variable 'd' was never mutated; consider changing to 'let' constant}}
 
   var s1 = GenericSubscript<(Double, Double)>()
-  _ = s1[a, b]
-  // TODO: Restore regressed diagnostics rdar://problem/31724211
-  // These two lines give different regressed behavior in S3 and S4 mode
-  // _ = s1[(a, b)] // e/xpected-error {{expression type '@lvalue Int' is ambiguous without more context}}
-  // _ = s1[d] // e/xpected-error {{expression type '@lvalue Int' is ambiguous without more context}}
+  _ = s1[a, b] // expected-error {{extra argument in call}}
+  _ = s1[(a, b)]
+  _ = s1[d]
 
   var s2 = GenericSubscriptTwo<Double>()
   _ = s2[a, b]
@@ -1138,12 +1120,12 @@ do {
 enum GenericEnum<T> {
   case one(T)
   case labeled(x: T)
-  case two(T, T) // expected-note 8 {{'two' declared here}}
+  case two(T, T) // expected-note 10 {{'two' declared here}}
   case tuple((T, T))
 }
 
 do {
-  _ = GenericEnum.one(3, 4)
+  _ = GenericEnum.one(3, 4) // expected-error {{extra argument in call}}
   _ = GenericEnum.one((3, 4))
 
   _ = GenericEnum.labeled(x: 3, 4) // expected-error {{extra argument in call}}
@@ -1159,8 +1141,8 @@ do {
 }
 
 do {
-  _ = GenericEnum<(Int, Int)>.one(3, 4)
-  _ = GenericEnum<(Int, Int)>.one((3, 4)) // Does not diagnose in Swift 3 mode
+  _ = GenericEnum<(Int, Int)>.one(3, 4) // expected-error {{enum element 'one' expects a single parameter of type '(Int, Int)'}} {{35-35=(}} {{39-39=)}}
+  _ = GenericEnum<(Int, Int)>.one((3, 4))
 
   _ = GenericEnum<(Int, Int)>.labeled(x: 3, 4) // expected-error {{extra argument in call}}
   _ = GenericEnum<(Int, Int)>.labeled(x: (3, 4))
@@ -1179,7 +1161,7 @@ do {
   let b = 4
   let c = (a, b)
 
-  _ = GenericEnum.one(a, b)
+  _ = GenericEnum.one(a, b) // expected-error {{extra argument in call}}
   _ = GenericEnum.one((a, b))
   _ = GenericEnum.one(c)
 
@@ -1197,15 +1179,15 @@ do {
   let b = 4
   let c = (a, b)
 
-  _ = GenericEnum<(Int, Int)>.one(a, b)
+  _ = GenericEnum<(Int, Int)>.one(a, b) // expected-error {{enum element 'one' expects a single parameter of type '(Int, Int)'}} {{35-35=(}} {{39-39=)}}
   _ = GenericEnum<(Int, Int)>.one((a, b))
   _ = GenericEnum<(Int, Int)>.one(c)
 
   _ = GenericEnum<Int>.two(a, b)
-  _ = GenericEnum<Int>.two((a, b))
-  _ = GenericEnum<Int>.two(c) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
+  _ = GenericEnum<Int>.two((a, b)) // expected-error {{missing argument for parameter #2 in call}}
+  _ = GenericEnum<Int>.two(c) // expected-error {{missing argument for parameter #2 in call}}
 
-  _ = GenericEnum<Int>.tuple(a, b)
+  _ = GenericEnum<Int>.tuple(a, b) // expected-error {{enum element 'tuple' expects a single parameter of type '(Int, Int)'}} {{30-30=(}} {{34-34=)}}
   _ = GenericEnum<Int>.tuple((a, b))
   _ = GenericEnum<Int>.tuple(c)
 }
@@ -1215,9 +1197,9 @@ do {
   var b = 4
   var c = (a, b)
 
-  // _ = GenericEnum.one(a, b) // Crashes in actual Swift 3
-  _ = GenericEnum.one((a, b)) // Does not diagnose in Swift 3 mode
-  _ = GenericEnum.one(c) // Does not diagnose in Swift 3 mode
+  _ = GenericEnum.one(a, b) // expected-error {{extra argument in call}}
+  _ = GenericEnum.one((a, b))
+  _ = GenericEnum.one(c)
 
   _ = GenericEnum.two(a, b)
   _ = GenericEnum.two((a, b)) // expected-error {{missing argument for parameter #2 in call}}
@@ -1233,9 +1215,9 @@ do {
   var b = 4
   var c = (a, b)
 
-  // _ = GenericEnum<(Int, Int)>.one(a, b) // Crashes in actual Swift 3
-  _ = GenericEnum<(Int, Int)>.one((a, b)) // Does not diagnose in Swift 3 mode
-  _ = GenericEnum<(Int, Int)>.one(c) // Does not diagnose in Swift 3 mode
+  _ = GenericEnum<(Int, Int)>.one(a, b) // expected-error {{enum element 'one' expects a single parameter of type '(Int, Int)'}} {{35-35=(}} {{39-39=)}}
+  _ = GenericEnum<(Int, Int)>.one((a, b))
+  _ = GenericEnum<(Int, Int)>.one(c)
 
   _ = GenericEnum<Int>.two(a, b)
   _ = GenericEnum<Int>.two((a, b)) // expected-error {{missing argument for parameter #2 in call}}
@@ -1253,7 +1235,7 @@ protocol Protocol {
 extension Protocol {
   func requirement(_ x: Element) {}
   func requirementLabeled(x: Element) {}
-  func requirementTwo(_ x: Element, _ y: Element) {} // expected-note 2 {{'requirementTwo' declared here}}
+  func requirementTwo(_ x: Element, _ y: Element) {} // expected-note 3 {{'requirementTwo' declared here}}
   func requirementTuple(_ x: (Element, Element)) {}
 }
 
@@ -1266,7 +1248,7 @@ do {
 
   s.requirement(3.0)
   s.requirement((3.0))
-
+ 
   s.requirementLabeled(x: 3.0)
   s.requirementLabeled(x: (3.0))
 
@@ -1298,14 +1280,14 @@ do {
   s.requirement(c)
 
   s.requirementTwo(a, b)
-  s.requirementTwo((a, b)) // Does not diagnose in Swift 3 mode
+  s.requirementTwo((a, b)) // expected-error {{missing argument for parameter #2 in call}}
 
-  s.requirementTuple(a, b) // Does not diagnose in Swift 3 mode
+  s.requirementTuple(a, b) // expected-error {{instance method 'requirementTuple' expects a single parameter of type '(Double, Double)'}} {{22-22=(}} {{26-26=)}}
   s.requirementTuple((a, b))
 
   let sTwo = GenericConforms<(Double, Double)>()
 
-  sTwo.requirement(a, b)
+  sTwo.requirement(a, b) // expected-error {{instance method 'requirement' expects a single parameter of type '(Double, Double)'}} {{20-20=(}} {{24-24=)}}
   sTwo.requirement((a, b))
   sTwo.requirement(d)
 }
@@ -1347,9 +1329,9 @@ do {
   s.takesClosure({ x in })
   s.takesClosure({ (x: Double) in })
 
-  s.takesClosureTwo({ _ = $0 })
-  s.takesClosureTwo({ x in })
-  s.takesClosureTwo({ (x: (Double, Double)) in })
+  s.takesClosureTwo({ _ = $0 }) // expected-error {{contextual closure type '(Double, Double) -> ()' expects 2 arguments, but 1 was used in closure body}}
+  s.takesClosureTwo({ x in }) // expected-error {{contextual closure type '(Double, Double) -> ()' expects 2 arguments, but 1 was used in closure body}}
+  s.takesClosureTwo({ (x: (Double, Double)) in }) // expected-error {{contextual closure type '(Double, Double) -> ()' expects 2 arguments, but 1 was used in closure body}}
   s.takesClosureTwo({ _ = $0; _ = $1 })
   s.takesClosureTwo({ (x, y) in })
   s.takesClosureTwo({ (x: Double, y:Double) in })
@@ -1375,12 +1357,12 @@ do {
   let _: ((Int, Int)) -> () = { _ = ($0.0, $0.1) }
   let _: ((Int, Int)) -> () = { t in _ = (t.0, t.1) }
 
-  let _: ((Int, Int)) -> () = { _ = ($0, $1) }
-  let _: ((Int, Int)) -> () = { t, u in _ = (t, u) }
+  let _: ((Int, Int)) -> () = { _ = ($0, $1) } // expected-error {{closure tuple parameter '(Int, Int)' does not support destructuring}}
+  let _: ((Int, Int)) -> () = { t, u in _ = (t, u) } // expected-error {{closure tuple parameter '(Int, Int)' does not support destructuring}} {{33-37=(arg)}} {{41-41=let (t, u) = arg; }}
 
-  let _: (Int, Int) -> () = { _ = $0 }
-  let _: (Int, Int) -> () = { _ = ($0.0, $0.1) }
-  let _: (Int, Int) -> () = { t in _ = (t.0, t.1) }
+  let _: (Int, Int) -> () = { _ = $0 } // expected-error {{contextual closure type '(Int, Int) -> ()' expects 2 arguments, but 1 was used in closure body}}
+  let _: (Int, Int) -> () = { _ = ($0.0, $0.1) } // expected-error {{contextual closure type '(Int, Int) -> ()' expects 2 arguments, but 1 was used in closure body}}
+  let _: (Int, Int) -> () = { t in _ = (t.0, t.1) } // expected-error {{contextual closure type '(Int, Int) -> ()' expects 2 arguments, but 1 was used in closure body}}
 
   let _: (Int, Int) -> () = { _ = ($0, $1) }
   let _: (Int, Int) -> () = { t, u in _ = (t, u) }
@@ -1398,19 +1380,17 @@ do {
   let fn: (Any) -> () = { _ in }
 
   fn(123)
-  fn(data: 123)
+  fn(data: 123) // expected-error {{extraneous argument label 'data:' in call}}
 
   takesAny(123)
-  takesAny(data: 123)
+  takesAny(data: 123) // expected-error {{extraneous argument label 'data:' in call}}
 
   _ = HasAnyCase.any(123)
-  _ = HasAnyCase.any(data: 123)
+  _ = HasAnyCase.any(data: 123) // expected-error {{extraneous argument label 'data:' in call}}
 }
 
 // rdar://problem/29739905 - protocol extension methods on Array had
 // ParenType sugar stripped off the element type
-typealias BoolPair = (Bool, Bool)
-
 func processArrayOfFunctions(f1: [((Bool, Bool)) -> ()],
                              f2: [(Bool, Bool) -> ()],
                              c: Bool) {
@@ -1419,24 +1399,27 @@ func processArrayOfFunctions(f1: [((Bool, Bool)) -> ()],
   f1.forEach { block in
     block(p)
     block((c, c))
-    block(c, c)
+    block(c, c) // expected-error {{parameter 'block' expects a single parameter of type '(Bool, Bool)'}} {{11-11=(}} {{15-15=)}}
   }
 
   f2.forEach { block in
-    block(p) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
-    block((c, c))
+  // expected-note@-1 2{{'block' declared here}}
+    block(p) // expected-error {{missing argument for parameter #2 in call}}
+    block((c, c)) // expected-error {{missing argument for parameter #2 in call}}
     block(c, c)
   }
 
   f2.forEach { (block: ((Bool, Bool)) -> ()) in
+  // expected-error@-1 {{cannot convert value of type '(((Bool, Bool)) -> ()) -> ()' to expected argument type '((Bool, Bool) -> ()) -> Void}}
     block(p)
     block((c, c))
     block(c, c)
   }
 
   f2.forEach { (block: (Bool, Bool) -> ()) in
-    block(p) // expected-error {{passing 2 arguments to a callee as a single tuple value has been removed in Swift 3}}
-    block((c, c))
+  // expected-note@-1 2{{'block' declared here}}
+    block(p) // expected-error {{missing argument for parameter #2 in call}}
+    block((c, c)) // expected-error {{missing argument for parameter #2 in call}}
     block(c, c)
   }
 }
@@ -1449,7 +1432,7 @@ func singleElementTupleArgument(completion: ((didAdjust: Bool)) -> Void) {
 }
 
 
-// SR-4378 -- FIXME -- this should type check, it used to work in Swift 3.0
+// SR-4378
 
 final public class MutableProperty<Value> {
     public init(_ initialValue: Value) {}
@@ -1460,47 +1443,215 @@ enum DataSourcePage<T> {
 }
 
 let pages1: MutableProperty<(data: DataSourcePage<Int>, totalCount: Int)> = MutableProperty((
-    // expected-error@-1 {{expression type 'MutableProperty<(data: DataSourcePage<Int>, totalCount: Int)>' is ambiguous without more context}}
     data: .notLoaded,
     totalCount: 0
 ))
 
 
 let pages2: MutableProperty<(data: DataSourcePage<Int>, totalCount: Int)> = MutableProperty((
-    // expected-error@-1 {{cannot convert value of type 'MutableProperty<(data: DataSourcePage<_>, totalCount: Int)>' to specified type 'MutableProperty<(data: DataSourcePage<Int>, totalCount: Int)>'}}
     data: DataSourcePage.notLoaded,
     totalCount: 0
 ))
 
 
 let pages3: MutableProperty<(data: DataSourcePage<Int>, totalCount: Int)> = MutableProperty((
-    // expected-error@-1 {{expression type 'MutableProperty<(data: DataSourcePage<Int>, totalCount: Int)>' is ambiguous without more context}}
     data: DataSourcePage<Int>.notLoaded,
     totalCount: 0
 ))
 
-// rdar://problem/32301091 - Make sure that in Swift 3 mode following expressions still compile just fine
+// SR-4745
+let sr4745 = [1, 2]
+let _ = sr4745.enumerated().map { (count, element) in "\(count): \(element)" }
+
+// SR-4738
+
+let sr4738 = (1, (2, 3))
+[sr4738].map { (x, (y, z)) -> Int in x + y + z } // expected-error {{use of undeclared type 'y'}}
+// expected-error@-1 {{closure tuple parameter does not support destructuring}} {{20-26=arg1}} {{38-38=let (y, z) = arg1; }}
+
+// rdar://problem/31892961
+let r31892961_1 = [1: 1, 2: 2]
+r31892961_1.forEach { (k, v) in print(k + v) }
+
+let r31892961_2 = [1, 2, 3]
+let _: [Int] = r31892961_2.enumerated().map { ((index, val)) in
+  // expected-error@-1 {{closure tuple parameter does not support destructuring}} {{48-60=arg0}} {{3-3=\n  let (index, val) = arg0\n  }}
+  // expected-error@-2 {{use of undeclared type 'index'}}
+  val + 1
+}
+
+let r31892961_3 = (x: 1, y: 42)
+_ = [r31892961_3].map { (x: Int, y: Int) in x + y }
+
+_ = [r31892961_3].map { (x, y: Int) in x + y }
+
+let r31892961_4 = (1, 2)
+_ = [r31892961_4].map { x, y in x + y }
+
+let r31892961_5 = (x: 1, (y: 2, (w: 3, z: 4)))
+[r31892961_5].map { (x: Int, (y: Int, (w: Int, z: Int))) in x + y }
+// expected-error@-1 {{closure tuple parameter does not support destructuring}} {{30-56=arg1}} {{61-61=let (y, (w, z)) = arg1; }}
+
+let r31892961_6 = (x: 1, (y: 2, z: 4))
+[r31892961_6].map { (x: Int, (y: Int, z: Int)) in x + y }
+// expected-error@-1 {{closure tuple parameter does not support destructuring}} {{30-46=arg1}} {{51-51=let (y, z) = arg1; }}
+
+// rdar://problem/32214649 -- these regressed in Swift 4 mode
+// with SE-0110 because of a problem in associated type inference
+
+func r32214649_1<X,Y>(_ a: [X], _ f: (X)->Y) -> [Y] {
+  return a.map(f)
+}
+
+func r32214649_2<X>(_ a: [X], _ f: (X) -> Bool) -> [X] {
+  return a.filter(f)
+}
+
+func r32214649_3<X>(_ a: [X]) -> [X] {
+  return a.filter { _ in return true }
+}
+
+// rdar://problem/32301091 - [SE-0110] causes errors when passing a closure with a single underscore to a block accepting multiple parameters
 
 func rdar32301091_1(_ :((Int, Int) -> ())!) {}
-rdar32301091_1 { _ in } // Ok in Swift 3
+rdar32301091_1 { _ in }
+// expected-error@-1 {{contextual closure type '(Int, Int) -> ()' expects 2 arguments, but 1 was used in closure body}} {{19-19=,_ }}
 
 func rdar32301091_2(_ :(Int, Int) -> ()) {}
-rdar32301091_2 { _ in } // Ok in Swift 3
+rdar32301091_2 { _ in }
+// expected-error@-1 {{contextual closure type '(Int, Int) -> ()' expects 2 arguments, but 1 was used in closure body}} {{19-19=,_ }}
+rdar32301091_2 { x in }
+// expected-error@-1 {{contextual closure type '(Int, Int) -> ()' expects 2 arguments, but 1 was used in closure body}} {{19-19=,<#arg#> }}
 
-// rdar://problem/35198459 - source-compat-suite failure: Moya (toType->hasUnresolvedType() && "Should have handled this above")
+func rdar32875953() {
+  let myDictionary = ["hi":1]
+
+  myDictionary.forEach {
+    print("\($0) -> \($1)")
+  }
+
+  myDictionary.forEach { key, value in
+    print("\(key) -> \(value)")
+  }
+
+  myDictionary.forEach { (key, value) in
+    print("\(key) -> \(value)")
+  }
+
+  let array1 = [1]
+  let array2 = [2]
+
+  _ = zip(array1, array2).map(+)
+}
+
+struct SR_5199 {}
+extension Sequence where Iterator.Element == (key: String, value: String?) {
+  func f() -> [SR_5199] {
+    return self.map { (key, value) in
+        SR_5199() // Ok
+    }
+  }
+}
+
+func rdar33043106(_ records: [(Int)], _ other: [((Int))]) -> [Int] {
+  let x: [Int] = records.map { _ in
+    let i = 1
+    return i
+  }
+  let y: [Int] = other.map { _ in
+    let i = 1
+    return i
+  }
+
+  return x + y
+}
+
+func itsFalse(_: Int) -> Bool? {
+  return false
+}
+
+func rdar33159366(s: AnySequence<Int>) {
+  _ = s.compactMap(itsFalse)
+  let a = Array(s)
+  _ = a.compactMap(itsFalse)
+}
+
+func sr5429<T>(t: T) {
+  _ = AnySequence([t]).first(where: { (t: T) in true })
+}
+
+extension Concrete {
+  typealias T = (Int, Int)
+  typealias F = (T) -> ()
+  func opt1(_ fn: (((Int, Int)) -> ())?) {}
+  func opt2(_ fn: (((Int, Int)) -> ())??) {}
+  func opt3(_ fn: (((Int, Int)) -> ())???) {}
+  func optAliasT(_ fn: ((T) -> ())?) {}
+  func optAliasF(_ fn: F?) {}
+}
+
+extension Generic {
+  typealias F = (T) -> ()
+  func opt1(_ fn: (((Int, Int)) -> ())?) {}
+  func opt2(_ fn: (((Int, Int)) -> ())??) {}
+  func opt3(_ fn: (((Int, Int)) -> ())???) {}
+  func optAliasT(_ fn: ((T) -> ())?) {}
+  func optAliasF(_ fn: F?) {}
+}
+
+func rdar33239714() {
+  Concrete().opt1 { x, y in }
+  Concrete().opt1 { (x, y) in }
+  Concrete().opt2 { x, y in }
+  Concrete().opt2 { (x, y) in }
+  Concrete().opt3 { x, y in }
+  Concrete().opt3 { (x, y) in }
+  Concrete().optAliasT { x, y in }
+  Concrete().optAliasT { (x, y) in }
+  Concrete().optAliasF { x, y in }
+  Concrete().optAliasF { (x, y) in }
+  Generic<(Int, Int)>().opt1 { x, y in }
+  Generic<(Int, Int)>().opt1 { (x, y) in }
+  Generic<(Int, Int)>().opt2 { x, y in }
+  Generic<(Int, Int)>().opt2 { (x, y) in }
+  Generic<(Int, Int)>().opt3 { x, y in }
+  Generic<(Int, Int)>().opt3 { (x, y) in }
+  Generic<(Int, Int)>().optAliasT { x, y in }
+  Generic<(Int, Int)>().optAliasT { (x, y) in }
+  Generic<(Int, Int)>().optAliasF { x, y in }
+  Generic<(Int, Int)>().optAliasF { (x, y) in }
+}
+
+// rdar://problem/35198459 - source-compat-suite failure: Moya (toType->hasUnresolvedType() && "Should have handled this above"
 do {
   func foo(_: (() -> Void)?) {}
   func bar() -> ((()) -> Void)? { return nil }
-  foo(bar()) // OK in Swift 3 mode
+  foo(bar()) // Allow ((()) -> Void)? to be passed in place of (() -> Void)? for -swift-version 4 but not later.
+}
+
+// https://bugs.swift.org/browse/SR-6509
+public extension Optional {
+  public func apply<Result>(_ transform: ((Wrapped) -> Result)?) -> Result? {
+    return self.flatMap { value in
+      transform.map { $0(value) }
+    }
+  }
+
+  public func apply<Value, Result>(_ value: Value?) -> Result?
+    where Wrapped == (Value) -> Result {
+    return value.apply(self)
+  }
 }
 
 // https://bugs.swift.org/browse/SR-6837
 do {
   func takeFn(fn: (_ i: Int, _ j: Int?) -> ()) {}
   func takePair(_ pair: (Int, Int?)) {}
-  takeFn(fn: takePair)
-  takeFn(fn: { (pair: (Int, Int?)) in } )
-  takeFn { (pair: (Int, Int?)) in }
+  takeFn(fn: takePair) // Allow for -swift-version 4, but not later
+  takeFn(fn: { (pair: (Int, Int?)) in } ) // Disallow for -swift-version 4 and later
+  // expected-error@-1 {{contextual closure type '(Int, Int?) -> ()' expects 2 arguments, but 1 was used in closure body}}
+  takeFn { (pair: (Int, Int?)) in } // Disallow for -swift-version 4 and later
+  // expected-error@-1 {{contextual closure type '(Int, Int?) -> ()' expects 2 arguments, but 1 was used in closure body}}
 }
 
 // https://bugs.swift.org/browse/SR-6796
@@ -1508,8 +1659,14 @@ do {
   func f(a: (() -> Void)? = nil) {}
   func log<T>() -> ((T) -> Void)? { return nil }
 
-  f(a: log() as ((()) -> Void)?) // Allow ((()) -> Void)? to be passed in place of (() -> Void)?
+  f(a: log() as ((()) -> Void)?) // Allow ((()) -> Void)? to be passed in place of (() -> Void)? for -swift-version 4 but not later.
 
   func logNoOptional<T>() -> (T) -> Void { }
   f(a: logNoOptional() as ((()) -> Void)) // Also allow the optional-injected form.
+
+  func g() {}
+  g(()) // expected-error {{argument passed to call that takes no arguments}}
+
+  func h(_: ()) {} // expected-note {{'h' declared here}}
+  h() // expected-error {{missing argument for parameter #1 in call}}
 }


### PR DESCRIPTION
- **Explanation**: We broke compatibility with treating function types that take `Void` as an argument as being allowed as arguments to functions expecting function types that take no arguments. We do not want to support this long term, but did up through Swift 4, so we shouldn't break it in Swift 4.1.

- **Scope of Issue**: This particular case probably will not effect a large number of users directly, but this affects at least one popular project and could effect the users of that project.

- **Origination**: A change was made to make function types more consistent, to avoid exactly this kind of "emergent behavior".

- **Risk**: The fix here is very targeted, so the risk seems low.

- **Fixes**: rdar://problem/36670720 / https://bugs.swift.org/browse/SR-6796

- **Reviewed By**: @xedin