### PR TITLE
[CSBindings] Look through optional types when trying to validate l-va…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -447,7 +447,8 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
 
     // Make sure we aren't trying to equate type variables with different
     // lvalue-binding rules.
-    if (auto otherTypeVar = type->getAs<TypeVariableType>()) {
+    if (auto otherTypeVar =
+            type->lookThroughAllOptionalTypes()->getAs<TypeVariableType>()) {
       if (typeVar->getImpl().canBindToLValue() !=
           otherTypeVar->getImpl().canBindToLValue())
         continue;

--- a/test/Constraints/rdar37291371.swift
+++ b/test/Constraints/rdar37291371.swift
@@ -1,0 +1,21 @@
+// RUN: %target-typecheck-verify-swift
+
+extension Collection where Element: Numeric {
+  var v: Element {
+    return self.reduce(0, +)
+  }
+}
+
+struct R<T> {}
+func ==<T: Equatable>(lhs: R<T>, rhs: T?) {}
+
+func foo<T>(_ e: @autoclosure @escaping () throws -> T?) -> R<T> {
+  return R<T>()
+}
+
+func bar<T>(_ e: T?) -> R<T> {
+  return R<T>()
+}
+
+foo([Double(1.0)].v) == Double(1.0)
+bar([Double(1.0)].v) == Double(1.0)

--- a/validation-test/compiler_crashers_fixed/28625-destoptionals-size-destextraoptionals-srcoptionals-size.swift
+++ b/validation-test/compiler_crashers_fixed/28625-destoptionals-size-destextraoptionals-srcoptionals-size.swift
@@ -5,7 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-[.a
-[Int?as?Int
-nil?
+// RUN: not %target-swift-frontend %s -emit-ir
+
+nil?as?Int??

--- a/validation-test/compiler_crashers_fixed/28866-unreachable-executed-at-swift-include-swift-ast-cantypevisitor-h-41.swift
+++ b/validation-test/compiler_crashers_fixed/28866-unreachable-executed-at-swift-include-swift-ast-cantypevisitor-h-41.swift
@@ -5,6 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
-nil?as?Int??
+// RUN: not %target-swift-frontend %s -emit-ir
+[.a
+[Int?as?Int
+nil?


### PR DESCRIPTION
…lueness of the new bindings

When bindings are picked for particular type variable, right-hand
side of the binding might be another type variable wrapped into optional
type, when trying to determine if both sides of the binding have the
same l-valueness it's imperative to look throught optional type of the
right-hand side. Otherwise new binding might be effectively unsolvable.

Resolves: rdar://problem/37291371

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
