### PR TITLE
[benchmark] Add benchmark exercising the hash compression function

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -59,6 +59,7 @@ set(SWIFT_BENCH_MODULES
     single-source/DictTest
     single-source/DictTest2
     single-source/DictTest3
+    single-source/DictTest4
     single-source/DictionaryBridge
     single-source/DictionaryGroup
     single-source/DictionaryLiteral

--- a/benchmark/single-source/DictTest4.swift
+++ b/benchmark/single-source/DictTest4.swift
@@ -1,0 +1,129 @@
+//===--- DictTest4.swift --------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+
+// This benchmark mostly measures lookups in dictionaries with complex keys,
+// exercising the default hash compression function.
+
+public let Dictionary4 = [
+  BenchmarkInfo(name: "Dictionary4", runFunction: run_Dictionary4, tags: [.validation, .api, .Dictionary]),
+  BenchmarkInfo(name: "Dictionary4OfObjects", runFunction: run_Dictionary4OfObjects, tags: [.validation, .api, .Dictionary]),
+]
+
+struct LargeKey: Hashable {
+  let i: Int
+  let j: Int
+  let k: Double
+  let l: UInt32
+  let m: Bool
+  let n: Bool
+  let o: Bool
+  let p: Bool
+  let q: Bool
+
+  init(_ value: Int) {
+    self.i = value
+    self.j = 2 * value
+    self.k = Double(value) / 7
+    self.l = UInt32(truncatingIfNeeded: value)
+    self.m = value & 1 == 0
+    self.n = value & 2 == 0
+    self.o = value & 4 == 0
+    self.p = value & 8 == 0
+    self.q = value & 16 == 0
+  }
+}
+
+@inline(never)
+public func run_Dictionary4(_ N: Int) {
+  let size1 = 100
+  let reps = 20
+  let ref_result = "1 99 \(reps) \(reps * 99)"
+  var hash1 = [LargeKey: Int]()
+  var hash2 = [LargeKey: Int]()
+  var res = ""
+
+  for _ in 1...N {
+    // Test insertions
+    hash1 = [:]
+    for i in 0..<size1 {
+      hash1[LargeKey(i)] = i
+    }
+
+    hash2 = hash1
+
+    // Test lookups & value replacement
+    for _ in 1..<reps {
+      for (k, v) in hash1 {
+        hash2[k] = hash2[k]! + v
+      }
+    }
+
+    res = "\(hash1[LargeKey(1)]!) \(hash1[LargeKey(99)]!)" +
+      " \(hash2[LargeKey(1)]!) \(hash2[LargeKey(99)]!)"
+    if res != ref_result {
+      break
+    }
+  }
+  CheckResults(res == ref_result)
+}
+
+class Box<T : Hashable> : Hashable {
+  var value: T
+
+  init(_ v: T) {
+    value = v
+  }
+
+  var hashValue: Int {
+    return value.hashValue
+  }
+  
+  static func ==(lhs: Box, rhs: Box) -> Bool {
+    return lhs.value == rhs.value
+  }
+}
+
+@inline(never)
+public func run_Dictionary4OfObjects(_ N: Int) {
+  let size1 = 100
+  let reps = 20
+  let ref_result = "1 99 \(reps) \(reps * 99)"
+  var hash1 = [Box<LargeKey>: Int]()
+  var hash2 = [Box<LargeKey>: Int]()
+  var res = ""
+
+  for _ in 1...N {
+    // Test insertions
+    hash1 = [:]
+    for i in 0..<size1 {
+      hash1[Box(LargeKey(i))] = i
+    }
+
+    hash2 = hash1
+
+    // Test lookups & value replacement
+    for _ in 1..<reps {
+      for (k, v) in hash1 {
+        hash2[k] = hash2[k]! + v
+      }
+    }
+
+    res = "\(hash1[Box(LargeKey(1))]!) \(hash1[Box(LargeKey(99))]!)" +
+      " \(hash2[Box(LargeKey(1))]!) \(hash2[Box(LargeKey(99))]!)"
+    if res != ref_result {
+      break
+    }
+  }
+  CheckResults(res == ref_result)
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -46,6 +46,7 @@ import DictOfArraysToArrayOfDicts
 import DictTest
 import DictTest2
 import DictTest3
+import DictTest4
 import DictionaryBridge
 import DictionaryGroup
 import DictionaryLiteral
@@ -189,6 +190,7 @@ registerBenchmark(DictOfArraysToArrayOfDicts)
 registerBenchmark(Dictionary)
 registerBenchmark(Dictionary2)
 registerBenchmark(Dictionary3)
+registerBenchmark(Dictionary4)
 registerBenchmark(DictionaryBridge)
 registerBenchmark(DictionaryGroup)
 registerBenchmark(DictionaryLiteral)


### PR DESCRIPTION
This adds a benchmark that runs `Dictionary` lookups with keys consisting of 9 fields, using the synthesized `Hashable` implementation.

We currently only have `Set`/`Dictionary` benchmark for `String` and `Int` keys, so `_combineHashValues` wasn't exercised much, if at all.