### PR TITLE
[SDK] Remove Foundation's last use of _silgen_name

### DIFF
--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -38,9 +38,6 @@ internal func __NSDataIsCompact(_ data: NSData) -> Bool {
 import _SwiftFoundationOverlayShims
 import _SwiftCoreFoundationOverlayShims
     
-@_silgen_name("__NSDataWriteToURL")
-internal func __NSDataWriteToURL(_ data: NSData, _ url: NSURL, _ options: UInt, _ error: NSErrorPointer) -> Bool
-    
 #endif
 
 public final class _DataStorage {
@@ -1407,9 +1404,9 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
 #else
             if _shouldUseNonAtomicWriteReimplementation(options: options) {
                 var error: NSError? = nil
-                guard __NSDataWriteToURL($0, url as NSURL, options.rawValue, &error) else { throw error! }
+                guard __NSDataWriteToURL($0, url, options, &error) else { throw error! }
             } else {
-                try $0.write(to: url, options: WritingOptions(rawValue: options.rawValue))
+                try $0.write(to: url, options: options)
             }
 #endif
         }

--- a/stdlib/public/SDK/Foundation/DataThunks.m
+++ b/stdlib/public/SDK/Foundation/DataThunks.m
@@ -111,8 +111,8 @@ static NSError *_NSErrorWithFilePathAndErrno(NSInteger posixErrno, id pathOrURL,
     return error;
 }
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
-BOOL __NSDataWriteToURL(NSData *SWIFT_NS_RELEASES_ARGUMENT data, NSURL *SWIFT_NS_RELEASES_ARGUMENT url, NSDataWritingOptions writingOptions, NSError **_Nullable errorPtr) {
+SWIFT_RUNTIME_STDLIB_INTERNAL
+BOOL __NSDataWriteToURL(NSData * _Nonnull data NS_RELEASES_ARGUMENT, NSURL * _Nonnull url NS_RELEASES_ARGUMENT, NSDataWritingOptions writingOptions, NSError **errorPtr) {
     assert((writingOptions & NSDataWritingAtomic) == 0);
 
     NSString *path = url.path;

--- a/stdlib/public/SwiftShims/NSDataShims.h
+++ b/stdlib/public/SwiftShims/NSDataShims.h
@@ -14,7 +14,7 @@
 
 NS_BEGIN_DECLS
 
-typedef void (^NSDataDeallocator)(void *, NSUInteger);
+typedef void (^NSDataDeallocator)(void * _Null_unspecified, NSUInteger);
 FOUNDATION_EXPORT const NSDataDeallocator NSDataDeallocatorVM;
 FOUNDATION_EXPORT const NSDataDeallocator NSDataDeallocatorUnmap;
 FOUNDATION_EXPORT const NSDataDeallocator NSDataDeallocatorFree;
@@ -23,5 +23,7 @@ FOUNDATION_EXPORT const NSDataDeallocator NSDataDeallocatorNone;
 @interface NSData (FoundationSPI)
 - (BOOL)_isCompact;
 @end
+
+BOOL __NSDataWriteToURL(NS_NON_BRIDGED(NSData *) _Nonnull data NS_RELEASES_ARGUMENT, NSURL * _Nonnull url NS_RELEASES_ARGUMENT, NSDataWritingOptions writingOptions, NSError **errorPtr);
 
 NS_END_DECLS


### PR DESCRIPTION
No intended functionality change.

This only affects the Apple Foundation, but I'll copy over to corelibs-foundation afterwards to keep them in sync.