### PR TITLE
-sil-print-all (et al.) should print specialized functions when they …

### DIFF
--- a/include/swift/SILOptimizer/PassManager/PassManager.h
+++ b/include/swift/SILOptimizer/PassManager/PassManager.h
@@ -155,6 +155,9 @@ public:
     CompletedPassesMap.clear();
   }
 
+  /// \brief Notify the pass manager of a newly create function for tracing.
+  void notifyOfNewFunction(SILFunction *F, SILTransform *T);
+
   /// \brief Add the function \p F to the function pass worklist.
   /// If not null, the function \p DerivedFrom is the function from which \p F
   /// is derived. This is used to avoid an infinite amount of functions pushed
@@ -290,6 +293,9 @@ private:
 
   /// Return true if all analyses are unlocked.
   bool analysesUnlocked();
+
+  /// Dumps information about the pass with index \p TransIdx to llvm::dbgs().
+  void dumpPassInfo(const char *Title, SILTransform *Tr, SILFunction *F);
 
   /// Dumps information about the pass with index \p TransIdx to llvm::dbgs().
   void dumpPassInfo(const char *Title, unsigned TransIdx,

--- a/include/swift/SILOptimizer/PassManager/Transforms.h
+++ b/include/swift/SILOptimizer/PassManager/Transforms.h
@@ -114,6 +114,7 @@ namespace swift {
     /// The number should be small anyway, but bugs in optimizations could cause
     /// an infinite loop in the passmanager.
     void notifyAddFunction(SILFunction *F, SILFunction *DerivedFrom) {
+      PM->notifyOfNewFunction(F, this);
       PM->addFunctionToWorklist(F, DerivedFrom);
       PM->notifyAnalysisOfFunction(F);
     }
@@ -171,6 +172,7 @@ namespace swift {
 
     /// Inform the pass manager of an added function.
     void notifyAddFunction(SILFunction *F) {
+      PM->notifyOfNewFunction(F, this);
       PM->notifyAnalysisOfFunction(F);
     }
   };

--- a/lib/SILOptimizer/PassManager/PassManager.cpp
+++ b/lib/SILOptimizer/PassManager/PassManager.cpp
@@ -283,6 +283,16 @@ static bool breakBeforeRunning(StringRef fnName, SILFunctionTransform *SFT) {
     && (SFT->getID() == SILBreakOnPass || SFT->getTag() == SILBreakOnPass);
 }
 
+void SILPassManager::dumpPassInfo(const char *Title, SILTransform *Tr,
+                                  SILFunction *F) {
+  llvm::dbgs() << "  " << Title << " #" << NumPassesRun << ", stage "
+               << StageName << ", pass : " << Tr->getID()
+               << " (" << Tr->getTag() << ")";
+  if (F)
+    llvm::dbgs() << ", Function: " << F->getName();
+  llvm::dbgs() << '\n';
+}
+
 void SILPassManager::dumpPassInfo(const char *Title, unsigned TransIdx,
                                   SILFunction *F) {
   SILTransform *Tr = Transformations[TransIdx];
@@ -538,6 +548,13 @@ SILPassManager::~SILPassManager() {
     assert(!A->isLocked() &&
            "Deleting a locked analysis. Did we forget to unlock ?");
     delete A;
+  }
+}
+
+void SILPassManager::notifyOfNewFunction(SILFunction *F, SILTransform *T) {
+  if (doPrintAfter(T, F, SILPrintAll)) {
+    dumpPassInfo("*** New SIL function in ", T, F);
+    F->dump(getOptions().EmitVerboseSIL);
   }
 }
 


### PR DESCRIPTION
…are created.

