### PR TITLE
[ClangImporter] Handle submodule imports in bridging headers

### DIFF
--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -336,7 +336,6 @@ public:
 
   bool IsReadingBridgingPCH;
   llvm::SmallVector<clang::serialization::SubmoduleID, 2> PCHImportedSubmodules;
-  llvm::SmallVector<const clang::Module*, 2> DeferredHeaderImports;
 
   const Version CurrentVersion;
 
@@ -529,7 +528,7 @@ public:
   ClangModuleUnit *ImportedHeaderUnit = nullptr;
 
   /// The modules re-exported by imported headers.
-  llvm::SmallVector<ModuleDecl::ImportedModule, 8> ImportedHeaderExports;
+  llvm::SmallVector<clang::Module *, 8> ImportedHeaderExports;
 
   /// The modules that requested imported headers.
   ///

--- a/test/ClangImporter/Inputs/submodules-bridging-header.h
+++ b/test/ClangImporter/Inputs/submodules-bridging-header.h
@@ -1,0 +1,1 @@
+#include <ctypes/bits.h>

--- a/test/ClangImporter/pch-bridging-header.swift
+++ b/test/ClangImporter/pch-bridging-header.swift
@@ -4,30 +4,30 @@
 
 // First test the explicit frontend-based bridging PCH generation and use works
 // RUN: %target-swift-frontend -emit-pch -o %t/sdk-bridging-header.pch %S/Inputs/sdk-bridging-header.h
-// RUN: %target-swift-frontend -parse -verify %s -import-objc-header %t/sdk-bridging-header.pch
+// RUN: %target-swift-frontend -typecheck -verify %s -import-objc-header %t/sdk-bridging-header.pch
 
 // Now test the driver-automated version is inert when disabled
-// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse -disable-bridging-pch -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header.h
+// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -typecheck -disable-bridging-pch -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header.h
 // RUN: not ls %t/tmp/*.pch >/dev/null 2>&1
 
 // Test the driver-automated version works by default
-// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header.h
+// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -typecheck -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header.h
 // RUN: ls %t/tmp/*.pch >/dev/null 2>&1
 // RUN: llvm-objdump -raw-clang-ast %t/tmp/*.pch | llvm-bcanalyzer -dump | %FileCheck %s
 // CHECK: ORIGINAL_FILE{{.*}}Inputs/sdk-bridging-header.h
 
 // Test the driver-automated version deletes its PCH file when done
 // RUN: rm %t/tmp/*.pch
-// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -parse %s -import-objc-header %S/Inputs/sdk-bridging-header.h
+// RUN: env TMPDIR=%t/tmp/ %target-swiftc_driver -typecheck %s -import-objc-header %S/Inputs/sdk-bridging-header.h
 // RUN: not ls %t/tmp/*.pch >/dev/null 2>&1
 
 // Test -emit-pch invocation but with a persistent PCH
 // RUN: %target-swift-frontend -emit-pch -pch-output-dir %t/pch %S/Inputs/sdk-bridging-header.h
-// RUN: %target-swift-frontend -parse -verify %s -import-objc-header %S/Inputs/sdk-bridging-header.h -pch-output-dir %t/pch -pch-disable-validation
+// RUN: %target-swift-frontend -typecheck -verify %s -import-objc-header %S/Inputs/sdk-bridging-header.h -pch-output-dir %t/pch -pch-disable-validation
 // RUN: ls %t/pch/*.pch >/dev/null 2>&1
 
 // Test implicit use of persistent PCH
-// RUN: %target-swift-frontend -parse -verify %s -import-objc-header %S/Inputs/sdk-bridging-header.h -pch-output-dir %t/pch2
+// RUN: %target-swift-frontend -typecheck -verify %s -import-objc-header %S/Inputs/sdk-bridging-header.h -pch-output-dir %t/pch2
 // RUN: ls %t/pch2/*.pch >/dev/null 2>&1
 
 // RUN: touch %t/header.with.dot.h
@@ -37,7 +37,7 @@
 // RUN: ls %t/pch_with_dot/*swift*clang*.pch | count 2
 
 // Test the driver-automated version using persistent PCH
-// RUN: %target-swiftc_driver -parse -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header.h -pch-output-dir %t/pch3
+// RUN: %target-swiftc_driver -typecheck -save-temps %s -import-objc-header %S/Inputs/sdk-bridging-header.h -pch-output-dir %t/pch3
 // RUN: ls %t/pch3/*.pch >/dev/null 2>&1
 // RUN: llvm-objdump -raw-clang-ast %t/pch3/*.pch | llvm-bcanalyzer -dump | %FileCheck %s -check-prefix=PERSISTENT
 // PERSISTENT: ORIGINAL_FILE{{.*}}Inputs/sdk-bridging-header.h

--- a/test/ClangImporter/submodules-bridging-header.swift
+++ b/test/ClangImporter/submodules-bridging-header.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules/ -import-objc-header %S/Inputs/submodules-bridging-header.h %s
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-pch -o %t/submodules-bridging-header.pch %S/Inputs/submodules-bridging-header.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules/ -import-objc-header %t/submodules-bridging-header.pch %s
+
+// From ctypes.bits submodule
+public var x : DWORD = MY_INT
+public var y : CInt = x
+public var z : DWORD = "" // expected-error {{cannot convert value}}
+


### PR DESCRIPTION
If a bridging header imported a submodule but *not* the top-level module, the top-level module would never be made visible. This is a problem since the Clang importer makes all top-level decls available through their enclosing top-level modules, not the individual submodules.

To fix this, stop special-casing the way we handle bridging header imports; we can translate them from Clang Modules to Swift ModuleDecls the same way we do for regular imports.

rdar://problem/37355259
