### PR TITLE
[build-script] Cleanup arg-parsing tests

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -20,6 +20,8 @@ import time
 
 from build_swift import defaults
 from build_swift import driver_arguments
+from build_swift import presets
+from build_swift.migration import migrate_swift_sdks
 
 from swift_build_support.swift_build_support import (
     arguments,
@@ -32,16 +34,12 @@ from swift_build_support.swift_build_support import (
     targets,
     workspace
 )
-
 from swift_build_support.swift_build_support.SwiftBuildSupport import (
     HOME,
     SWIFT_BUILD_ROOT,
     SWIFT_REPO_NAME,
     SWIFT_SOURCE_ROOT,
-    get_all_preset_names,
-    get_preset_options,
 )
-
 from swift_build_support.swift_build_support.cmake import CMake
 from swift_build_support.swift_build_support.targets import \
     StdlibDeploymentTarget
@@ -977,15 +975,26 @@ def main_preset():
 
     if len(args.preset_file_names) == 0:
         args.preset_file_names = [
-            os.path.join(HOME, ".swift-build-presets"),
             os.path.join(
                 SWIFT_SOURCE_ROOT, SWIFT_REPO_NAME, "utils",
                 "build-presets.ini")
         ]
 
+        user_presets_file = os.path.join(HOME, '.swift-build-presets')
+        if os.path.isfile(user_presets_file):
+            args.preset_file_names.append(user_presets_file)
+
+    preset_parser = presets.PresetParser()
+
+    try:
+        preset_parser.read(args.preset_file_names)
+    except presets.UnparsedFilesError as e:
+        diagnostics.fatal('unable to parse preset files {}'
+                          .format(e.message))
+
     if args.show_presets:
-        for name in sorted(get_all_preset_names(args.preset_file_names),
-                           key=str.lower):
+        for name in sorted(preset_parser.preset_names(),
+                           key=lambda name: name.lower()):
             print(name)
         return 0
 
@@ -993,26 +1002,36 @@ def main_preset():
         diagnostics.fatal("missing --preset option")
 
     args.preset_substitutions = {}
-
     for arg in args.preset_substitutions_raw:
         name, value = arg.split("=", 1)
         args.preset_substitutions[name] = value
 
-    preset_args = get_preset_options(
-        args.preset_substitutions, args.preset_file_names, args.preset)
+    try:
+        preset = preset_parser.get_preset(args.preset,
+                                          vars=args.preset_substitutions)
+    except presets.InterpolationError as e:
+        diagnostics.fatal('missing value for substitution "{}" in preset "{}"'
+                          .format(e.message, args.preset))
+    except presets.MissingOptionError as e:
+        diagnostics.fatal('missing option(s) for preset "{}": {}'
+                          .format(args.preset, e.message))
+    except presets.PresetNotFoundError:
+        diagnostics.fatal('preset "{}" not found'.format(args.preset))
+
+    preset_args = migrate_swift_sdks(preset.format_args())
 
     build_script_args = [sys.argv[0]]
     if args.dry_run:
         build_script_args += ["--dry-run"]
+
     build_script_args += preset_args
     if args.distcc:
         build_script_args += ["--distcc"]
     if args.build_jobs:
         build_script_args += ["--jobs", str(args.build_jobs)]
 
-    diagnostics.note(
-        "using preset '" + args.preset + "', which expands to \n\n" +
-        shell.quote_command(build_script_args) + "\n")
+    diagnostics.note('using preset "{}", which expands to \n\n{}\n'.format(
+        args.preset, shell.quote_command(build_script_args)))
 
     if args.expand_build_script_invocation:
         return 0

--- a/utils/build_swift/argparse/types.py
+++ b/utils/build_swift/argparse/types.py
@@ -18,6 +18,7 @@ import re
 import shlex
 
 from . import ArgumentTypeError
+from .. import utils
 
 
 __all__ = [
@@ -56,19 +57,13 @@ class CompilerVersion(object):
     def __str__(self):
         return '.'.join([str(part) for part in self.components])
 
+    def __repr__(self):
+        return utils.repr_class(self, {
+            'components': self.components
+        })
+
 
 # -----------------------------------------------------------------------------
-
-def _repr(cls, args):
-    """Helper function for implementing __repr__ methods on *Type classes.
-    """
-
-    _args = []
-    for key, value in args.viewitems():
-        _args.append('{}={}'.format(key, repr(value)))
-
-    return '{}({})'.format(type(cls).__name__, ', '.join(_args))
-
 
 class BoolType(object):
     """Argument type used to validate an input string as a bool-like type.
@@ -94,7 +89,7 @@ class BoolType(object):
             raise ArgumentTypeError('{} is not a boolean value'.format(value))
 
     def __repr__(self):
-        return _repr(self, {
+        return utils.repr_class(self, {
             'true_values': self._true_values,
             'false_values': self._false_values,
         })
@@ -123,7 +118,7 @@ class PathType(object):
         return path
 
     def __repr__(self):
-        return _repr(self, {
+        return utils.repr_class(self, {
             'assert_exists': self._assert_exists,
             'assert_executable': self._assert_executable,
         })
@@ -150,7 +145,7 @@ class RegexType(object):
         return matches
 
     def __repr__(self):
-        return _repr(self, {
+        return utils.repr_class(self, {
             'regex': self._regex,
             'error_message': self._error_message,
         })
@@ -217,4 +212,4 @@ class ShellSplitType(object):
         return list(lex)
 
     def __repr__(self):
-        return _repr(self, {})
+        return utils.repr_class(self, {})

--- a/utils/build_swift/migration.py
+++ b/utils/build_swift/migration.py
@@ -1,0 +1,83 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+"""
+Temporary module with functionaly used to migrate away from build-script-impl.
+"""
+
+
+from swift_build_support.swift_build_support.targets import \
+    StdlibDeploymentTarget
+
+
+__all__ = [
+    'UnknownSDKError',
+    'migrate_swift_sdks',
+]
+
+
+_SDK_TARGETS = {
+    'OSX': StdlibDeploymentTarget.OSX.targets,
+    'IOS': StdlibDeploymentTarget.iOS.targets,
+    'IOS_SIMULATOR': StdlibDeploymentTarget.iOSSimulator.targets,
+    'TVOS': StdlibDeploymentTarget.AppleTV.targets,
+    'TVOS_SIMULATOR': StdlibDeploymentTarget.AppleTVSimulator.targets,
+    'WATCHOS': StdlibDeploymentTarget.AppleWatch.targets,
+    'WATCHOS_SIMULATOR': StdlibDeploymentTarget.AppleWatchSimulator.targets,
+}
+
+
+# -----------------------------------------------------------------------------
+
+class UnknownSDKError(Exception):
+    """Error indicating an unknown SDK was encountered when migrating to target
+    triples.
+    """
+
+    pass
+
+
+def _swift_sdks_to_stdlib_targets(swift_sdks):
+    stdlib_targets = []
+    for sdk in swift_sdks:
+        sdk_targets = _SDK_TARGETS.get(sdk, None)
+        if sdk_targets is None:
+            raise UnknownSDKError(sdk)
+        stdlib_targets += sdk_targets
+
+    return stdlib_targets
+
+
+def migrate_swift_sdks(args):
+    """Migrate usages of the now deprecated `--swift-sdks` option to the new
+    `--stdlib-deployment-targets` option, converting Swift SDKs to the
+    corresponding targets. Since argument parsing is a last-wins scenario, only
+    the last `--swift-sdks` option is migrated, all others are removed.
+
+    This function is a stop-gap to replacing all instances of `--swift-sdks`.
+    """
+
+    swift_sdks_args = [arg for arg in args if arg.startswith('--swift-sdks')]
+
+    if len(swift_sdks_args) < 1:
+        return args
+
+    # Only get the last --swift-sdks arg since last-wins
+    swift_sdks_arg = swift_sdks_args[-1]
+
+    sdk_list = swift_sdks_arg.split('=')[1].split(';')
+    stdlib_targets = _swift_sdks_to_stdlib_targets(sdk_list)
+
+    target_names = ' '.join([target.name for target in stdlib_targets])
+    stdlib_targets_arg = '--stdlib-deployment-targets=' + target_names
+
+    args = [arg for arg in args if not arg.startswith('--swift-sdks')]
+    args.append(stdlib_targets_arg)
+
+    return args

--- a/utils/build_swift/presets.py
+++ b/utils/build_swift/presets.py
@@ -1,0 +1,247 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+"""
+Swift preset parsing and handling functionality.
+"""
+
+
+from collections import namedtuple
+from copy import copy
+
+try:
+    # Python 3
+    import configparser
+    from io import StringIO
+except ImportError:
+    import ConfigParser as configparser
+    from StringIO import StringIO
+
+
+__all__ = [
+    'Preset',
+    'PresetParser',
+
+    'InterpolationError',
+    'MissingOptionError',
+    'PresetNotFoundError',
+    'UnparsedFilesError',
+]
+
+
+# -----------------------------------------------------------------------------
+
+_RawPreset = namedtuple('_RawPreset', ['name', 'mixins', 'args'])
+
+
+def _interpolate_string(string, values):
+    if string is None:
+        return string
+
+    try:
+        return string % values
+    except KeyError as e:
+        raise InterpolationError(e.message)
+
+
+def _remove_prefix(string, prefix):
+    if string.startswith(prefix):
+        return string[len(prefix):]
+    return string
+
+
+# -----------------------------------------------------------------------------
+
+class InterpolationError(Exception):
+    """Error indicating a filaure while interpolating variables in preset
+    argument values.
+    """
+
+    pass
+
+
+class MissingOptionError(Exception):
+    """Error indicating a missing option while parsing presets.
+    """
+
+    pass
+
+
+class PresetNotFoundError(Exception):
+    """Error indicating failure when attempting to get a preset.
+    """
+
+    pass
+
+
+class UnparsedFilesError(Exception):
+    """Error indicating failure when parsing preset files.
+    """
+
+    pass
+
+
+class Preset(namedtuple('Preset', ['name', 'args'])):
+    """Container class used to wrap preset names and expanded argument lists.
+    """
+
+    # Keeps memory costs low according to the docs
+    __slots__ = ()
+
+    def format_args(self):
+        """Format argument pairs for use in the command line.
+        """
+
+        args = []
+        for (name, value) in self.args:
+            if value is None:
+                args.append(name)
+            else:
+                args.append('{}={}'.format(name, value))
+
+        return args
+
+
+# -----------------------------------------------------------------------------
+
+class PresetParser(object):
+    """Parser class used to read and manipulate Swift preset files.
+    """
+
+    _PRESET_PREFIX = 'preset: '
+
+    def __init__(self):
+        self._parser = configparser.RawConfigParser(allow_no_value=True)
+        self._presets = {}
+
+    def _parse_raw_preset(self, section):
+        preset_name = _remove_prefix(section, PresetParser._PRESET_PREFIX)
+
+        try:
+            section_items = self._parser.items(section)
+        except configparser.InterpolationMissingOptionError as e:
+            raise MissingOptionError(e)
+
+        args, mixins = [], []
+        for (name, value) in section_items:
+            # Ignore the '--' separator, it's no longer necessary
+            if name == 'dash-dash':
+                continue
+
+            # Parse out mixin names
+            if name == 'mixin-preset':
+                mixins = list(map(lambda name: name.strip(),
+                                  value.strip().splitlines()))
+                continue
+
+            name = '--' + name  # Format as an option name
+            args.append((name, value))
+
+        return _RawPreset(preset_name, mixins, args)
+
+    def _parse_raw_presets(self):
+        for section in self._parser.sections():
+            raw_preset = self._parse_raw_preset(section)
+            self._presets[raw_preset.name] = raw_preset
+
+    def read(self, filenames):
+        """Reads and parses preset files. Throws an UnparsedFilesError if any
+        of the files couldn't be read.
+        """
+
+        parsed_files = self._parser.read(filenames)
+
+        unparsed_files = set(filenames) - set(parsed_files)
+        if len(unparsed_files) > 0:
+            raise UnparsedFilesError(list(unparsed_files))
+
+        self._parse_raw_presets()
+
+    def read_file(self, file):
+        """Reads and parses a single file.
+        """
+
+        self.read([file])
+
+    def read_string(self, string):
+        """Reads and parses a string containing preset definintions.
+        """
+
+        fp = StringIO(unicode(string))
+
+        # ConfigParser changes drastically from Python 2 to 3
+        if hasattr(self._parser, 'read_file'):
+            self._parser.read_file(fp)
+        else:
+            self._parser.readfp(fp)
+
+        self._parse_raw_presets()
+
+    def _get_preset(self, name):
+        preset = self._presets.get(name)
+        if preset is None:
+            raise PresetNotFoundError(name)
+
+        if isinstance(preset, _RawPreset):
+            preset = self._resolve_preset_mixins(preset)
+
+            # Cache resolved preset
+            self._presets[name] = preset
+
+        return preset
+
+    def _resolve_preset_mixins(self, raw_preset):
+        """Resolve all mixins in a preset, fully expanding the arguments list.
+        """
+
+        assert isinstance(raw_preset, _RawPreset)
+
+        # Expand mixin arguments
+        args = copy(raw_preset.args)
+        for mixin_name in raw_preset.mixins:
+            mixin = self._get_preset(mixin_name)
+
+            args += mixin.args
+
+        return Preset(raw_preset.name, args)
+
+    def _interpolate_preset_vars(self, preset, vars):
+        interpolated_args = []
+        for (name, value) in preset.args:
+            value = _interpolate_string(value, vars)
+            interpolated_args.append((name, value))
+
+        return Preset(preset.name, interpolated_args)
+
+    def get_preset(self, name, raw=False, vars=None):
+        """Returns the preset with the requested name or throws a
+        PresetNotFoundError.
+
+        If raw is False vars will be interpolated into the preset arguments.
+        Otherwise presets will be returned without interpolation.
+
+        Presets are retrieved using a dynamic caching algorithm that expands
+        only the requested preset and it's mixins recursively. Every expanded
+        preset is then cached. All subsequent expansions or calls to
+        `get_preset` for any pre-expanded presets will use the cached results.
+        """
+
+        vars = vars or {}
+
+        preset = self._get_preset(name)
+        if not raw:
+            preset = self._interpolate_preset_vars(preset, vars)
+
+        return preset
+
+    def preset_names(self):
+        """Returns a list of all parsed preset names.
+        """
+
+        return self._presets.keys()

--- a/utils/build_swift/shell.py
+++ b/utils/build_swift/shell.py
@@ -1,0 +1,294 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+"""
+Shell utilities wrapper module.
+"""
+
+
+import os
+import shutil
+import subprocess
+import sys
+from contextlib import contextmanager
+from copy import copy
+from subprocess import CalledProcessError
+
+try:
+    # Python 3
+    from shutil import quote
+except ImportError:
+    from pipes import quote
+
+
+__all__ = [
+    'CommandExecutor',
+    'NullExecutor',
+
+    'PIPE',
+    'STDOUT',
+]
+
+
+# Re-export subprocess constants
+PIPE = subprocess.PIPE
+STDOUT = subprocess.STDOUT
+
+
+class _EchoAction(object):
+
+    DEFAULT_PREFIX = '>>> '
+
+    def __init__(self, output_stream, prefix=None):
+        self.output_stream = output_stream
+        self.prefix = prefix or _EchoAction.DEFAULT_PREFIX
+
+    def __call__(self, command):
+        line = unicode(self.prefix + ' '.join(command) + '\n')
+        self.output_stream.write(line)
+
+
+class _FakePopen():
+    """Fake class which implements the same interface as subprocess.Popen.
+    """
+
+    def __init__(self, pid=0, returncode=0):
+        self.stdin = None
+        self.stdout = None
+        self.stderr = None
+        self.pid = pid
+        self.returncode = returncode
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self):
+        return self.returncode
+
+    def communicate(**kwargs):
+        return (None, None)
+
+    def send_signal(self, signal):
+        return
+
+    def terminate(self):
+        return
+
+    def kill(self):
+        return
+
+
+def _quote_command(command):
+    return list(map(quote, command))
+
+
+# -----------------------------------------------------------------------------
+# Executors
+
+class CommandExecutor(object):
+    """Wrapper class for executing shell commands while maintaining a command
+    history.
+    """
+
+    def __init__(self, env=None,
+                 stdin=None, stdout=None, stderr=None):
+        self._env = env
+        self._stdin = stdin or sys.stdin
+        self._stdout = stdout or sys.stderr
+        self._stderr = stderr or sys.stdout
+
+        # Actions performed before executing each command
+        self._actions = []
+
+        # Executed command history
+        self._command_history = []
+
+        def store_history_action(command):
+            self._command_history.append(command)
+
+        self.add_action(store_history_action)
+
+    def _exec_actions(self, command):
+        command = _quote_command(command)
+
+        for action in self._actions:
+            action(command)
+
+    def add_action(self, action):
+        """Add an action to the executor which will be called prior to excuting
+        commands. Actions must be callable and accept a single argument, the
+        command being executed.
+        """
+
+        self._actions.append(action)
+
+    def add_echo_action(self, output_stream=None, prefix=None):
+        """Adds an echo action to the executor which will output the command
+        to an output stream or stdout. An optional prefix can be used to format
+        the final command.
+        """
+
+        self.add_action(_EchoAction(output_stream or self._stdout, prefix))
+
+    def _kwargs_set_defaults(self, kwargs):
+        defaults = {
+            'env': self._env,
+            'stdin': self._stdin,
+            'stdout': self._stdout,
+            'stderr': self._stderr,
+        }
+
+        for key, value in defaults.items():
+            kwargs.setdefault(key, value)
+
+        return kwargs
+
+    def _fake_popen(self, command):
+        self._exec_actions(command)
+        return _FakePopen()
+
+    def _popen(self, command, **kwargs):
+        self._exec_actions(command)
+
+        kwargs = self._kwargs_set_defaults(kwargs)
+        p = subprocess.Popen(command, **kwargs)
+
+        try:
+            p.wait()
+        except Exception as e:
+            p.kill()
+            p.wait()
+            raise e
+
+        return p
+
+    def popen(self, command, **kwargs):
+        """Create and return an instance of subprocess.Popen with the
+        given command and kwargs.
+        """
+
+        return self._popen(command, **kwargs)
+
+    def call(self, command):
+        """Run command. Wait for the command to exit and then return the
+        returncode.
+        """
+
+        return self.popen(command).returncode
+
+    def check_call(self, command):
+        """Run command. Wait for the command to exit. If the returncode was 0
+        then return, otherwise raises CalledProcessError.
+        """
+
+        p = self.popen(command)
+        if p.returncode:
+            raise CalledProcessError(p.returncode, command)
+
+        return 0
+
+    def check_output(self, command):
+        """Run command. Wait for the command to exit. If the returncode was 0
+        then return the output, otherwise raises CalledProcessError.
+        """
+
+        p = self.popen(command, stdout=subprocess.PIPE)
+        output, _ = p.communicate()
+
+        returncode = p.poll()
+        if returncode:
+            raise CalledProcessError(returncode, command, output=output)
+
+        return output
+
+    def history(self):
+        """Return the executor's command history.
+        """
+
+        return copy(self._command_history)
+
+    # -------------------------------------------------------------------------
+    # Common shell utility wrappers
+
+    def cd(self, path):
+        self._fake_popen(['cd', path])
+        os.chdir(path)
+
+    def cp(self, source, destination):
+        self._fake_popen(['cp', '-r', source, destination])
+        if os.path.isfile(source):
+            shutil.copyfile(source, destination)
+        elif os.path.isdir(source):
+            shutil.copytree(source, destination)
+        else:
+            raise OSError('{} does not exist'.format(source))
+
+    def ls(self, path=None):
+        path = path or os.getcwd()
+        self._fake_popen(['ls', path])
+        return os.listdir(path)
+
+    def mkdir(self, path):
+        self._fake_popen(['mkdir', '-p', path])
+        if not os.path.isdir(path):
+            os.makedirs(path)
+
+    def mv(self, source, destination):
+        self._fake_popen(['mv', source, destination])
+        shutil.move(source, destination)
+
+    @contextmanager
+    def pushd(self, path):
+        cwd = os.getcwd()
+        self._fake_popen(['pushd', path])
+        os.chdir(path)
+
+        yield
+
+        self._fake_popen(['popd'])
+        os.chdir(cwd)
+
+    def rm(self, path):
+        self._fake_popen(['rm', '-rf', path])
+        if os.path.isfile(path):
+            os.remove(path)
+        elif os.path.isdir(path):
+            shutil.rmtree(path)
+        else:
+            raise OSError('{} does not exist'.format(path))
+
+    def which(self, name):
+        try:
+            return self.check_output(['which', name]).strip()
+        except CalledProcessError:
+            return None
+
+
+class NullExecutor(CommandExecutor):
+    """Variant of the CommandExecutor that does not execute any subprocess
+    commands. This class should be useful for testing and iterating on scripts
+    while still retaining output logging and history functionality.
+    """
+
+    def popen(self, command, **kwargs):
+        return self._fake_popen(command, **kwargs)
+
+    # Overriding commands that mutate the system
+
+    def cp(self, source, destination):
+        self._fake_popen(['cp', '-r', source, destination])
+
+    def mkdir(self, path):
+        self._fake_popen(['mkdir', '-p', path])
+
+    def mv(self, source, destination):
+        self._fake_popen(['mv', source, destination])
+
+    def rm(self, path):
+        self._fake_popen(['rm', '-rf', path])

--- a/utils/build_swift/shell.py
+++ b/utils/build_swift/shell.py
@@ -281,6 +281,9 @@ class NullExecutor(CommandExecutor):
 
     # Overriding commands that mutate the system
 
+    def cd(self, path):
+        self._fake_popen(['cd', path])
+
     def cp(self, source, destination):
         self._fake_popen(['cp', '-r', source, destination])
 
@@ -289,6 +292,12 @@ class NullExecutor(CommandExecutor):
 
     def mv(self, source, destination):
         self._fake_popen(['mv', source, destination])
+
+    @contextmanager
+    def pushd(self, path):
+        self._fake_popen(['pushd', path])
+        yield
+        self._fake_popen(['popd'])
 
     def rm(self, path):
         self._fake_popen(['rm', '-rf', path])

--- a/utils/build_swift/shell.py
+++ b/utils/build_swift/shell.py
@@ -71,7 +71,7 @@ class _FakePopen():
     def wait(self):
         return self.returncode
 
-    def communicate(**kwargs):
+    def communicate(self, **kwargs):
         return (None, None)
 
     def send_signal(self, signal):
@@ -149,7 +149,7 @@ class CommandExecutor(object):
 
         return kwargs
 
-    def _fake_popen(self, command):
+    def _fake_popen(self, command, **kwargs):
         self._exec_actions(command)
         return _FakePopen()
 

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -14,15 +14,16 @@ from swift_build_support.swift_build_support import targets
 
 from .. import argparse
 from .. import defaults
+from .. import utils
 
 
 __all__ = [
     'HelpOption',
-    'SetOption',
-    'SetTrueOption',
-    'SetFalseOption',
-    'DisableOption',
-    'EnableOption',
+    'ConstOption',
+    'TrueOption',
+    'FalseOption',
+    'ToggleTrueOption',
+    'ToggleFalseOption',
     'ChoicesOption',
     'IntOption',
     'StrOption',
@@ -30,6 +31,7 @@ __all__ = [
     'AppendOption',
     'UnsupportedOption',
     'IgnoreOption',
+
     'EXPECTED_OPTIONS',
     'EXPECTED_DEFAULTS',
 ]
@@ -211,27 +213,39 @@ class _BaseOption(object):
         self.dest = dest
         self.default = default
 
+        self._repr_args = {
+            'option_string': self.option_string,
+            'dest': self.dest,
+            'default': self.default,
+        }
+
     def sanitized_string(self):
         return _sanitize_option_string(self.option_string)
 
+    def __repr__(self):
+        return utils.repr_class(self, self._repr_args)
+
 
 class HelpOption(_BaseOption):
-    """Option that prints the help message and exits."""
+    """Option that prints the help message and exits.
+    """
 
     pass
 
 
-class SetOption(_BaseOption):
+class ConstOption(_BaseOption):
     """Option that accepts no arguments, setting the destination to a
     hard-coded value or None.
     """
 
     def __init__(self, *args, **kwargs):
-        self.value = kwargs.pop('value', None)
-        super(SetOption, self).__init__(*args, **kwargs)
+        self.const = kwargs.pop('const', None)
+        super(ConstOption, self).__init__(*args, **kwargs)
+
+        self._repr_args['const'] = self.const
 
 
-class SetTrueOption(_BaseOption):
+class TrueOption(_BaseOption):
     """Option that accepts no arguments, setting the destination value to True
     if parsed and defaulting to False otherwise.
     """
@@ -239,7 +253,7 @@ class SetTrueOption(_BaseOption):
     pass
 
 
-class SetFalseOption(_BaseOption):
+class FalseOption(_BaseOption):
     """Option that accepts no arguments, setting the destination value to False
     if parsed and defaulting to True otherwise.
     """
@@ -247,7 +261,7 @@ class SetFalseOption(_BaseOption):
     pass
 
 
-class EnableOption(_BaseOption):
+class ToggleTrueOption(_BaseOption):
     """Option that sets the destination to True when parsed and False by default.
     Can be toggled True or False with an optional bool argument.
     """
@@ -255,7 +269,7 @@ class EnableOption(_BaseOption):
     pass
 
 
-class DisableOption(_BaseOption):
+class ToggleFalseOption(_BaseOption):
     """Option that sets the destination to False when parsed and True by default.
     Can be toggled True or False with an optional bool argument, which is then
     negated. Thus if an option is passed the value 'True' it will set the
@@ -266,27 +280,33 @@ class DisableOption(_BaseOption):
 
 
 class ChoicesOption(_BaseOption):
-    """Option that accepts an argument from a predifined list of choices."""
+    """Option that accepts an argument from a predifined list of choices.
+    """
 
     def __init__(self, *args, **kwargs):
         self.choices = kwargs.pop('choices', None)
         super(ChoicesOption, self).__init__(*args, **kwargs)
 
+        self._repr_args['choices'] = self.choices
+
 
 class IntOption(_BaseOption):
-    """Option that accepts an int argument."""
+    """Option that accepts an int argument.
+    """
 
     pass
 
 
 class StrOption(_BaseOption):
-    """Option that accepts a str argument."""
+    """Option that accepts a str argument.
+    """
 
     pass
 
 
 class PathOption(_BaseOption):
-    """Option that accepts a path argument."""
+    """Option that accepts a path argument.
+    """
 
     pass
 
@@ -300,7 +320,8 @@ class AppendOption(_BaseOption):
 
 
 class UnsupportedOption(_BaseOption):
-    """Option that is not supported."""
+    """Option that is not supported.
+    """
 
     pass
 
@@ -321,150 +342,150 @@ EXPECTED_OPTIONS = [
     HelpOption('-h', dest='help', default=argparse.SUPPRESS),
     HelpOption('--help', dest='help', default=argparse.SUPPRESS),
 
-    SetOption('--debug', dest='build_variant', value='Debug'),
-    SetOption('--debug-cmark', dest='cmark_build_variant', value='Debug'),
-    SetOption('--debug-foundation',
-              dest='foundation_build_variant', value='Debug'),
-    SetOption('--debug-libdispatch',
-              dest='libdispatch_build_variant', value='Debug'),
-    SetOption('--debug-libicu', dest='libicu_build_variant', value='Debug'),
-    SetOption('--debug-lldb', dest='lldb_build_variant', value='Debug'),
-    SetOption('--lldb-build-with-xcode', dest='lldb_build_with_xcode',
-              value='1'),
-    SetOption('--lldb-build-with-cmake', dest='lldb_build_with_xcode',
-              value='0'),
-    SetOption('--debug-llvm', dest='llvm_build_variant', value='Debug'),
-    SetOption('--debug-swift', dest='swift_build_variant', value='Debug'),
-    SetOption('--debug-swift-stdlib',
-              dest='swift_stdlib_build_variant', value='Debug'),
-    SetOption('--eclipse',
-              dest='cmake_generator', value='Eclipse CDT4 - Ninja'),
-    SetOption('--make', dest='cmake_generator', value='Unix Makefiles'),
-    SetOption('--release', dest='build_variant', value='Release'),
-    SetOption('--release-debuginfo',
-              dest='build_variant', value='RelWithDebInfo'),
-    SetOption('--xcode', dest='cmake_generator', value='Xcode'),
-    SetOption('-R', dest='build_variant', value='Release'),
-    SetOption('-d', dest='build_variant', value='Debug'),
-    SetOption('-e', dest='cmake_generator', value='Eclipse CDT4 - Ninja'),
-    SetOption('-m', dest='cmake_generator', value='Unix Makefiles'),
-    SetOption('-r', dest='build_variant', value='RelWithDebInfo'),
-    SetOption('-x', dest='cmake_generator', value='Xcode'),
+    ConstOption('--debug', dest='build_variant', const='Debug'),
+    ConstOption('--debug-cmark', dest='cmark_build_variant', const='Debug'),
+    ConstOption('--debug-foundation',
+                dest='foundation_build_variant', const='Debug'),
+    ConstOption('--debug-libdispatch',
+                dest='libdispatch_build_variant', const='Debug'),
+    ConstOption('--debug-libicu', dest='libicu_build_variant', const='Debug'),
+    ConstOption('--debug-lldb', dest='lldb_build_variant', const='Debug'),
+    ConstOption('--lldb-build-with-xcode', dest='lldb_build_with_xcode',
+                const='1'),
+    ConstOption('--lldb-build-with-cmake', dest='lldb_build_with_xcode',
+                const='0'),
+    ConstOption('--debug-llvm', dest='llvm_build_variant', const='Debug'),
+    ConstOption('--debug-swift', dest='swift_build_variant', const='Debug'),
+    ConstOption('--debug-swift-stdlib',
+                dest='swift_stdlib_build_variant', const='Debug'),
+    ConstOption('--eclipse',
+                dest='cmake_generator', const='Eclipse CDT4 - Ninja'),
+    ConstOption('--make', dest='cmake_generator', const='Unix Makefiles'),
+    ConstOption('--release', dest='build_variant', const='Release'),
+    ConstOption('--release-debuginfo',
+                dest='build_variant', const='RelWithDebInfo'),
+    ConstOption('--xcode', dest='cmake_generator', const='Xcode'),
+    ConstOption('-R', dest='build_variant', const='Release'),
+    ConstOption('-d', dest='build_variant', const='Debug'),
+    ConstOption('-e', dest='cmake_generator', const='Eclipse CDT4 - Ninja'),
+    ConstOption('-m', dest='cmake_generator', const='Unix Makefiles'),
+    ConstOption('-r', dest='build_variant', const='RelWithDebInfo'),
+    ConstOption('-x', dest='cmake_generator', const='Xcode'),
 
     # FIXME: Convert these options to set_true actions
-    SetOption('--assertions', value=True),
-    SetOption('--cmark-assertions', value=True),
-    SetOption('--lldb-assertions', value=True),
-    SetOption('--llvm-assertions', value=True),
-    SetOption('--swift-assertions', value=True),
-    SetOption('--swift-stdlib-assertions', value=True),
-    SetOption('-T', dest='validation_test', value=True),
-    SetOption('-o', dest='test_optimized', value=True),
-    SetOption('-s', dest='test_optimize_for_size', value=True),
-    SetOption('-t', dest='test', value=True),
+    ConstOption('--assertions', const=True),
+    ConstOption('--cmark-assertions', const=True),
+    ConstOption('--lldb-assertions', const=True),
+    ConstOption('--llvm-assertions', const=True),
+    ConstOption('--swift-assertions', const=True),
+    ConstOption('--swift-stdlib-assertions', const=True),
+    ConstOption('-T', dest='validation_test', const=True),
+    ConstOption('-o', dest='test_optimized', const=True),
+    ConstOption('-s', dest='test_optimize_for_size', const=True),
+    ConstOption('-t', dest='test', const=True),
 
     # FIXME: Convert these options to set_false actions
-    SetOption('--no-assertions', dest='assertions', value=False),
-    SetOption('--no-lldb-assertions', dest='lldb_assertions', value=False),
-    SetOption('--no-llvm-assertions', dest='llvm_assertions', value=False),
-    SetOption('--no-swift-assertions', dest='swift_assertions', value=False),
-    SetOption('--no-swift-stdlib-assertions',
-              dest='swift_stdlib_assertions', value=False),
-    SetOption('--skip-ios', dest='ios', value=False),
-    SetOption('--skip-tvos', dest='tvos', value=False),
-    SetOption('--skip-watchos', dest='watchos', value=False),
+    ConstOption('--no-assertions', dest='assertions', const=False),
+    ConstOption('--no-lldb-assertions', dest='lldb_assertions', const=False),
+    ConstOption('--no-llvm-assertions', dest='llvm_assertions', const=False),
+    ConstOption('--no-swift-assertions', dest='swift_assertions', const=False),
+    ConstOption('--no-swift-stdlib-assertions',
+                dest='swift_stdlib_assertions', const=False),
+    ConstOption('--skip-ios', dest='ios', const=False),
+    ConstOption('--skip-tvos', dest='tvos', const=False),
+    ConstOption('--skip-watchos', dest='watchos', const=False),
 
-    SetTrueOption('--benchmark'),
-    SetTrueOption('--clean'),
-    SetTrueOption('--dry-run'),
-    SetTrueOption('--enable-sil-ownership'),
-    SetTrueOption('--enable-guaranteed-normal-arguments'),
-    SetTrueOption('--force-optimized-typechecker'),
-    SetTrueOption('--ios'),
-    SetTrueOption('--llbuild', dest='build_llbuild'),
-    SetTrueOption('--lldb', dest='build_lldb'),
-    SetTrueOption('--playgroundsupport', dest='build_playgroundsupport'),
-    SetTrueOption('--skip-build'),
-    SetTrueOption('--swiftpm', dest='build_swiftpm'),
-    SetTrueOption('-B', dest='benchmark'),
-    SetTrueOption('-S', dest='skip_build'),
-    SetTrueOption('-b', dest='build_llbuild'),
-    SetTrueOption('-c', dest='clean'),
-    SetTrueOption('-i', dest='ios'),
-    SetTrueOption('-l', dest='build_lldb'),
-    SetTrueOption('-n', dest='dry_run'),
-    SetTrueOption('-p', dest='build_swiftpm'),
+    TrueOption('--benchmark'),
+    TrueOption('--clean'),
+    TrueOption('--dry-run'),
+    TrueOption('--enable-sil-ownership'),
+    TrueOption('--enable-guaranteed-normal-arguments'),
+    TrueOption('--force-optimized-typechecker'),
+    TrueOption('--ios'),
+    TrueOption('--llbuild', dest='build_llbuild'),
+    TrueOption('--lldb', dest='build_lldb'),
+    TrueOption('--playgroundsupport', dest='build_playgroundsupport'),
+    TrueOption('--skip-build'),
+    TrueOption('--swiftpm', dest='build_swiftpm'),
+    TrueOption('-B', dest='benchmark'),
+    TrueOption('-S', dest='skip_build'),
+    TrueOption('-b', dest='build_llbuild'),
+    TrueOption('-c', dest='clean'),
+    TrueOption('-i', dest='ios'),
+    TrueOption('-l', dest='build_lldb'),
+    TrueOption('-n', dest='dry_run'),
+    TrueOption('-p', dest='build_swiftpm'),
 
-    SetFalseOption('--no-legacy-impl', dest='legacy_impl'),
+    FalseOption('--no-legacy-impl', dest='legacy_impl'),
 
-    EnableOption('--android'),
-    EnableOption('--build-external-benchmarks'),
-    EnableOption('--build-ninja'),
-    EnableOption('--build-runtime-with-host-compiler'),
-    EnableOption('--build-swift-dynamic-sdk-overlay'),
-    EnableOption('--build-swift-dynamic-stdlib'),
-    EnableOption('--build-swift-static-sdk-overlay'),
-    EnableOption('--build-swift-static-stdlib'),
-    EnableOption('--build-swift-stdlib-unittest-extra'),
-    EnableOption('--distcc'),
-    EnableOption('--enable-asan'),
-    EnableOption('--enable-lsan'),
-    EnableOption('--enable-tsan'),
-    EnableOption('--enable-tsan-runtime'),
-    EnableOption('--enable-ubsan'),
-    EnableOption('--export-compile-commands'),
-    EnableOption('--foundation', dest='build_foundation'),
-    EnableOption('--host-test'),
-    EnableOption('--libdispatch', dest='build_libdispatch'),
-    EnableOption('--libicu', dest='build_libicu'),
-    EnableOption('--long-test'),
-    EnableOption('--show-sdks'),
-    EnableOption('--test'),
-    EnableOption('--test-optimize-for-size'),
-    EnableOption('--test-optimized'),
-    EnableOption('--tvos'),
-    EnableOption('--validation-test'),
-    EnableOption('--verbose-build'),
-    EnableOption('--watchos'),
-    EnableOption('--xctest', dest='build_xctest'),
+    ToggleTrueOption('--android'),
+    ToggleTrueOption('--build-external-benchmarks'),
+    ToggleTrueOption('--build-ninja'),
+    ToggleTrueOption('--build-runtime-with-host-compiler'),
+    ToggleTrueOption('--build-swift-dynamic-sdk-overlay'),
+    ToggleTrueOption('--build-swift-dynamic-stdlib'),
+    ToggleTrueOption('--build-swift-static-sdk-overlay'),
+    ToggleTrueOption('--build-swift-static-stdlib'),
+    ToggleTrueOption('--build-swift-stdlib-unittest-extra'),
+    ToggleTrueOption('--distcc'),
+    ToggleTrueOption('--enable-asan'),
+    ToggleTrueOption('--enable-lsan'),
+    ToggleTrueOption('--enable-tsan'),
+    ToggleTrueOption('--enable-tsan-runtime'),
+    ToggleTrueOption('--enable-ubsan'),
+    ToggleTrueOption('--export-compile-commands'),
+    ToggleTrueOption('--foundation', dest='build_foundation'),
+    ToggleTrueOption('--host-test'),
+    ToggleTrueOption('--libdispatch', dest='build_libdispatch'),
+    ToggleTrueOption('--libicu', dest='build_libicu'),
+    ToggleTrueOption('--long-test'),
+    ToggleTrueOption('--show-sdks'),
+    ToggleTrueOption('--test'),
+    ToggleTrueOption('--test-optimize-for-size'),
+    ToggleTrueOption('--test-optimized'),
+    ToggleTrueOption('--tvos'),
+    ToggleTrueOption('--validation-test'),
+    ToggleTrueOption('--verbose-build'),
+    ToggleTrueOption('--watchos'),
+    ToggleTrueOption('--xctest', dest='build_xctest'),
 
-    DisableOption('--skip-build-android', dest='build_android'),
-    DisableOption('--skip-build-benchmarks', dest='build_benchmarks'),
-    DisableOption('--skip-build-cygwin', dest='build_cygwin'),
-    DisableOption('--skip-build-freebsd', dest='build_freebsd'),
-    DisableOption('--skip-build-ios', dest='build_ios'),
-    DisableOption('--skip-build-ios-device', dest='build_ios_device'),
-    DisableOption('--skip-build-ios-simulator',
-                  dest='build_ios_simulator'),
-    DisableOption('--skip-build-linux', dest='build_linux'),
-    DisableOption('--skip-build-osx', dest='build_osx'),
-    DisableOption('--skip-build-tvos', dest='build_tvos'),
-    DisableOption('--skip-build-tvos-device', dest='build_tvos_device'),
-    DisableOption('--skip-build-tvos-simulator',
-                  dest='build_tvos_simulator'),
-    DisableOption('--skip-build-watchos', dest='build_watchos'),
-    DisableOption('--skip-build-watchos-device',
-                  dest='build_watchos_device'),
-    DisableOption('--skip-build-watchos-simulator',
-                  dest='build_watchos_simulator'),
-    DisableOption('--skip-test-android-host', dest='test_android_host'),
-    DisableOption('--skip-test-cygwin', dest='test_cygwin'),
-    DisableOption('--skip-test-freebsd', dest='test_freebsd'),
-    DisableOption('--skip-test-ios', dest='test_ios'),
-    DisableOption('--skip-test-ios-32bit-simulator',
-                  dest='test_ios_32bit_simulator'),
-    DisableOption('--skip-test-ios-host', dest='test_ios_host'),
-    DisableOption('--skip-test-ios-simulator', dest='test_ios_simulator'),
-    DisableOption('--skip-test-linux', dest='test_linux'),
-    DisableOption('--skip-test-osx', dest='test_osx'),
-    DisableOption('--skip-test-tvos', dest='test_tvos'),
-    DisableOption('--skip-test-tvos-host', dest='test_tvos_host'),
-    DisableOption('--skip-test-tvos-simulator',
-                  dest='test_tvos_simulator'),
-    DisableOption('--skip-test-watchos', dest='test_watchos'),
-    DisableOption('--skip-test-watchos-host', dest='test_watchos_host'),
-    DisableOption('--skip-test-watchos-simulator',
-                  dest='test_watchos_simulator'),
+    ToggleFalseOption('--skip-build-android', dest='build_android'),
+    ToggleFalseOption('--skip-build-benchmarks', dest='build_benchmarks'),
+    ToggleFalseOption('--skip-build-cygwin', dest='build_cygwin'),
+    ToggleFalseOption('--skip-build-freebsd', dest='build_freebsd'),
+    ToggleFalseOption('--skip-build-ios', dest='build_ios'),
+    ToggleFalseOption('--skip-build-ios-device', dest='build_ios_device'),
+    ToggleFalseOption('--skip-build-ios-simulator',
+                      dest='build_ios_simulator'),
+    ToggleFalseOption('--skip-build-linux', dest='build_linux'),
+    ToggleFalseOption('--skip-build-osx', dest='build_osx'),
+    ToggleFalseOption('--skip-build-tvos', dest='build_tvos'),
+    ToggleFalseOption('--skip-build-tvos-device', dest='build_tvos_device'),
+    ToggleFalseOption('--skip-build-tvos-simulator',
+                      dest='build_tvos_simulator'),
+    ToggleFalseOption('--skip-build-watchos', dest='build_watchos'),
+    ToggleFalseOption('--skip-build-watchos-device',
+                      dest='build_watchos_device'),
+    ToggleFalseOption('--skip-build-watchos-simulator',
+                      dest='build_watchos_simulator'),
+    ToggleFalseOption('--skip-test-android-host', dest='test_android_host'),
+    ToggleFalseOption('--skip-test-cygwin', dest='test_cygwin'),
+    ToggleFalseOption('--skip-test-freebsd', dest='test_freebsd'),
+    ToggleFalseOption('--skip-test-ios', dest='test_ios'),
+    ToggleFalseOption('--skip-test-ios-32bit-simulator',
+                      dest='test_ios_32bit_simulator'),
+    ToggleFalseOption('--skip-test-ios-host', dest='test_ios_host'),
+    ToggleFalseOption('--skip-test-ios-simulator', dest='test_ios_simulator'),
+    ToggleFalseOption('--skip-test-linux', dest='test_linux'),
+    ToggleFalseOption('--skip-test-osx', dest='test_osx'),
+    ToggleFalseOption('--skip-test-tvos', dest='test_tvos'),
+    ToggleFalseOption('--skip-test-tvos-host', dest='test_tvos_host'),
+    ToggleFalseOption('--skip-test-tvos-simulator',
+                      dest='test_tvos_simulator'),
+    ToggleFalseOption('--skip-test-watchos', dest='test_watchos'),
+    ToggleFalseOption('--skip-test-watchos-host', dest='test_watchos_host'),
+    ToggleFalseOption('--skip-test-watchos-simulator',
+                      dest='test_watchos_simulator'),
 
     ChoicesOption('--android-ndk-gcc-version',
                   choices=['4.8', '4.9']),
@@ -524,7 +545,7 @@ EXPECTED_OPTIONS = [
 
     # NOTE: LTO flag is a special case that acts both as an option and has
     # valid choices
-    SetOption('--lto', dest='lto_type'),
+    ConstOption('--lto', dest='lto_type'),
     ChoicesOption('--lto', dest='lto_type', choices=['thin', 'full']),
 
     # NOTE: We'll need to manually test the behavior of these since they

--- a/utils/build_swift/tests/test_migration.py
+++ b/utils/build_swift/tests/test_migration.py
@@ -1,0 +1,70 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+from .utils import TestCase
+from .. import migration
+
+
+def _get_sdk_targets(sdk_names):
+    targets = []
+    for sdk_name in sdk_names:
+        targets += migration._SDK_TARGETS[sdk_name]
+
+    return targets
+
+
+def _get_sdk_target_names(sdk_names):
+    return [target.name for target in _get_sdk_targets(sdk_names)]
+
+
+# -----------------------------------------------------------------------------
+
+class TestMigrateSwiftSDKsMeta(type):
+    """Metaclass used to dynamically generate test methods.
+    """
+
+    def __new__(cls, name, bases, attrs):
+        # Generate tests for migrating each Swift SDK
+        for sdk_name in migration._SDK_TARGETS.keys():
+            test_name = 'test_migrate_swift_sdk_' + sdk_name
+            attrs[test_name] = cls.generate_migrate_swift_sdks_test(sdk_name)
+
+        return super(TestMigrateSwiftSDKsMeta, cls).__new__(
+            cls, name, bases, attrs)
+
+    @classmethod
+    def generate_migrate_swift_sdks_test(cls, sdk_name):
+        def test(self):
+            args = ['--swift-sdks={}'.format(sdk_name)]
+            args = migration.migrate_swift_sdks(args)
+
+            target_names = _get_sdk_target_names([sdk_name])
+            self.assertListEqual(args, [
+                '--stdlib-deployment-targets={}'.format(' '.join(target_names))
+            ])
+
+        return test
+
+
+class TestMigrateSwiftSDKs(TestCase):
+
+    __metaclass__ = TestMigrateSwiftSDKsMeta
+
+    def test_multiple_swift_sdk_flags(self):
+        args = [
+            '--swift-sdks=OSX',
+            '--swift-sdks=OSX;IOS;IOS_SIMULATOR'
+        ]
+
+        args = migration.migrate_swift_sdks(args)
+        target_names = _get_sdk_target_names(['OSX', 'IOS', 'IOS_SIMULATOR'])
+
+        self.assertListEqual(args, [
+            '--stdlib-deployment-targets={}'.format(' '.join(target_names))
+        ])

--- a/utils/build_swift/tests/test_presets.py
+++ b/utils/build_swift/tests/test_presets.py
@@ -70,6 +70,24 @@ ios
 ios
 """
 
+IGNORED_SECTION = """
+[section_name]
+
+random-options=1
+"""
+
+MIXIN_ORDER_PRESETS = """
+[preset: test_mixin]
+first-opt=0
+second-opt=1
+
+
+[preset: test]
+first-opt=1
+mixin-preset=test_mixin
+second-opt=2
+"""
+
 
 # -----------------------------------------------------------------------------
 
@@ -152,6 +170,31 @@ class TestPresetParser(TestCase):
             (u'--verbose-build', None),
             (u'--build-ninja', None),
             (u'--install-symroot', u'/tmp')
+        ])
+
+    def test_parser_ignores_non_preset_sections(self):
+        parser = PresetParser()
+
+        parser.read_string(IGNORED_SECTION)
+        self.assertEqual(len(parser._presets), 0)
+
+    def test_mixin_expansion_preserves_argument_order(self):
+        """Mixins should be expanded in-place.
+        """
+
+        parser = PresetParser()
+
+        parser.read_string(MIXIN_ORDER_PRESETS)
+
+        preset = parser.get_preset('test')
+        self.assertListEqual(preset.format_args(), [
+            '--first-opt=1',
+
+            # Mixin arguments
+            '--first-opt=0',
+            '--second-opt=1',
+
+            '--second-opt=2',
         ])
 
     def test_duplicate_option_error(self):

--- a/utils/build_swift/tests/test_presets.py
+++ b/utils/build_swift/tests/test_presets.py
@@ -1,0 +1,186 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+import os
+
+from .utils import TestCase, UTILS_PATH
+from ..presets import (InterpolationError, Preset, PresetNotFoundError,
+                       PresetParser, UnparsedFilesError)
+
+try:
+    # Python 3
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
+
+
+PRESET_FILES = [
+    os.path.join(UTILS_PATH, 'build-presets.ini'),
+]
+
+PRESET_DEFAULTS = {
+    'darwin_toolchain_alias': 'Alias',
+    'darwin_toolchain_bundle_identifier': 'BundleIdentifier',
+    'darwin_toolchain_display_name': 'DisplayName',
+    'darwin_toolchain_display_name_short': 'DispalyNameShort',
+    'darwin_toolchain_version': '1.0',
+    'darwin_toolchain_xctoolchain_name': 'default',
+    'extra_swift_args': '',
+    'install_destdir': '/tmp/install',
+    'install_symroot': '/tmp/install/symroot',
+    'install_toolchain_dir': '/tmp/install/toolchain',
+    'installable_package': '/tmp/install/pkg',
+    'swift_install_destdir': '/tmp/install/swift',
+    'symbols_package': '/path/to/symbols/package',
+}
+
+SAMPLE_PRESET = """
+[preset: sample]
+
+# This is a comment
+
+ios
+tvos
+watchos
+test
+validation-test
+lit-args=-v
+compiler-vendor=apple
+
+# The '--' argument is now unnecessary
+dash-dash
+
+verbose-build
+build-ninja
+
+# Default interpolation
+install-symroot=%(install_symroot)s
+"""
+
+INVALID_PRESET = """
+[preset: invalid]
+
+ios
+ios
+"""
+
+
+# -----------------------------------------------------------------------------
+
+class TestPreset(TestCase):
+
+    def test_format_args(self):
+        preset = Preset('sample', [('--ios', None), ('--test', '1')])
+
+        self.assertEqual(preset.format_args(), ['--ios', '--test=1'])
+
+
+# -----------------------------------------------------------------------------
+
+class TestPresetParserMeta(type):
+    """Metaclass used to dynamically generate test methods to validate all of
+    the available presets.
+    """
+
+    def __new__(cls, name, bases, attrs):
+        preset_parser = PresetParser()
+        preset_parser.read(PRESET_FILES)
+
+        # Generate tests for each preset
+        for preset_name in preset_parser.preset_names():
+            test_name = 'test_get_preset_' + preset_name
+            attrs[test_name] = cls.generate_get_preset_test(
+                preset_parser, preset_name)
+
+        return super(TestPresetParserMeta, cls).__new__(
+            cls, name, bases, attrs)
+
+    @classmethod
+    def generate_get_preset_test(cls, preset_parser, preset_name):
+        def test(self):
+            with self.assertNotRaises():
+                preset_parser.get_preset(preset_name, vars=PRESET_DEFAULTS)
+
+        return test
+
+
+class TestPresetParser(TestCase):
+
+    __metaclass__ = TestPresetParserMeta
+
+    def test_read(self):
+        parser = PresetParser()
+
+        with self.assertNotRaises():
+            parser.read(PRESET_FILES)
+
+    def test_read_invalid_files(self):
+        parser = PresetParser()
+
+        with self.assertRaises(UnparsedFilesError):
+            parser.read(['nonsense-presets.ini'])
+
+    def test_read_file(self):
+        parser = PresetParser()
+
+        with self.assertNotRaises():
+            parser.read_file(PRESET_FILES[0])
+
+    def test_read_string(self):
+        parser = PresetParser()
+
+        with self.assertNotRaises():
+            parser.read_string(SAMPLE_PRESET)
+
+        preset = parser.get_preset('sample', vars={'install_symroot': '/tmp'})
+        self.assertIsNotNone(preset)
+        self.assertEqual(preset.name, 'sample')
+        self.assertListEqual(preset.args, [
+            (u'--ios', None),
+            (u'--tvos', None),
+            (u'--watchos', None),
+            (u'--test', None),
+            (u'--validation-test', None),
+            (u'--lit-args', u'-v'),
+            (u'--compiler-vendor', u'apple'),
+            (u'--verbose-build', None),
+            (u'--build-ninja', None),
+            (u'--install-symroot', u'/tmp')
+        ])
+
+    def test_duplicate_option_error(self):
+        parser = PresetParser()
+
+        # Skip this test if using the Python 2 ConfigParser module
+        if not hasattr(configparser, 'DuplicateOptionError'):
+            return
+
+        with self.assertRaises(configparser.DuplicateOptionError):
+            parser.read_string(INVALID_PRESET)
+
+    def test_interpolation_error(self):
+        parser = PresetParser()
+        parser.read_string(SAMPLE_PRESET)
+
+        with self.assertRaises(InterpolationError):
+            parser.get_preset('sample')
+
+    def test_get_missing_preset(self):
+        parser = PresetParser()
+
+        with self.assertRaises(PresetNotFoundError):
+            parser.get_preset('preset')
+
+    def test_preset_names(self):
+        parser = PresetParser()
+
+        parser.read_string(SAMPLE_PRESET)
+        parser.read_string('[preset: test]\nios\n')
+
+        self.assertListEqual(parser.preset_names(), ['sample', 'test'])

--- a/utils/build_swift/tests/test_shell.py
+++ b/utils/build_swift/tests/test_shell.py
@@ -1,0 +1,134 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+import os
+import sys
+
+from .utils import TestCase
+from .. import shell
+
+try:
+    # Python 3
+    from io import StringIO
+except ImportError:
+    from StringIO import StringIO
+
+
+class TestCommandExecutor(TestCase):
+
+    def test_settings_passthrough(self):
+        sh = shell.CommandExecutor(env={'EDITOR': 'subl'})
+
+        sh._fake_popen(['ls', '-al'])
+
+    def test_add_action(self):
+        sh = shell.CommandExecutor()
+        self.assertEqual(len(sh._actions), 1)
+
+        def callable(command):
+            pass
+
+        sh.add_action(callable)
+        self.assertEqual(sh._actions[1], callable)
+
+    def test_add_echo_action(self):
+        sh = shell.CommandExecutor()
+
+        sh.add_echo_action()
+        action = sh._actions[1]
+        self.assertIsInstance(action, shell._EchoAction)
+        self.assertEqual(action.output_stream, sh._stdout)
+        self.assertEqual(action.prefix, shell._EchoAction.DEFAULT_PREFIX)
+
+        sh._actions.pop()
+
+        stream = StringIO()
+
+        sh.add_echo_action(output_stream=stream, prefix='$ ')
+        action = sh._actions[1]
+        self.assertIsInstance(action, shell._EchoAction)
+        self.assertEqual(action.output_stream, stream)
+        self.assertEqual(action.prefix, '$ ')
+
+        sh._fake_popen(['true'])
+        self.assertEqual(stream.getvalue(), '$ true\n')
+
+    def test_popen(self):
+        devnull = open(os.devnull, 'w')
+        sh = shell.CommandExecutor(stdout=devnull, stderr=devnull)
+
+        p = sh.popen([sys.executable, '--version'])
+        self.assertEqual(p.returncode, 0)
+
+        p = sh.popen([sys.executable, '-c', 'raise SysExit(1)'])
+        self.assertEqual(p.returncode, 1)
+
+    def test_call(self):
+        devnull = open(os.devnull, 'w')
+        sh = shell.CommandExecutor(stdout=devnull, stderr=devnull)
+
+        returncode = sh.call([sys.executable, '--version'])
+        self.assertEqual(returncode, 0)
+
+        returncode = sh.call([sys.executable, '-c', 'raise SysExit(1)'])
+        self.assertEqual(returncode, 1)
+
+    def test_check_call(self):
+        devnull = open(os.devnull, 'w')
+        sh = shell.CommandExecutor(stdout=devnull, stderr=devnull)
+
+        with self.assertNotRaises(shell.CalledProcessError):
+            sh.check_call([sys.executable, '--version'])
+
+        with self.assertRaises(shell.CalledProcessError):
+            sh.check_call([sys.executable, '-c', 'raise SysExit(1)'])
+
+    def test_check_output(self):
+        devnull = open(os.devnull, 'w')
+        sh = shell.CommandExecutor(stdout=devnull, stderr=devnull)
+
+        output = sh.check_output([sys.executable, '--version'])
+        self.assertRegexpMatches(r'^Python [0-9.]+$', output)
+
+        with self.assertRaises(shell.CalledProcessError):
+            sh.check_output([sys.executable, '-c', 'raise SysExit(1)'])
+
+    def test_history(self):
+        sh = shell.CommandExecutor()
+
+        sh._fake_popen(['ls', '-al'])
+        sh._fake_popen(['touch', 'text.txt'])
+        sh._fake_popen(['python', '-m', 'unittest', 'discover'])
+
+        history = sh.history()
+        self.assertListEqual(history, [
+            ['ls', '-al'],
+            ['touch', 'text.txt'],
+            ['python', '-m', 'unittest', 'discover'],
+        ])
+
+    def test_command_quoting(self):
+        sh = shell.CommandExecutor()
+
+        sh._fake_popen(['cd', '/Applications/Sample Program.app'])
+        self.assertListEqual(sh.history(), [
+            ['cd', "'/Applications/Sample Program.app'"],
+        ])
+
+    # TODO: Devise testing for shell command wrappers
+
+
+class TestNullExecutor(TestCase):
+
+    def test_commands_return_fake_popen(self):
+        sh = shell.NullExecutor()
+
+        p = sh.popen(['true'])
+
+        self.assertIsInstance(p, shell._FakePopen)

--- a/utils/build_swift/tests/test_xcrun.py
+++ b/utils/build_swift/tests/test_xcrun.py
@@ -1,0 +1,26 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+from .utils import TestCase
+from ..xcrun import Xcrun
+
+
+class TestXcrun(TestCase):
+
+    def test_build_command(self):
+        xcrun = Xcrun()
+        self.assertEqual(xcrun._build_command([]), ['xcrun'])
+
+        xcrun = Xcrun(sdk='default', toolchain='default')
+        self.assertEqual(xcrun._build_command(['--find', 'clang']), [
+            'xcrun',
+            '--sdk', 'default',
+            '--toolchain', 'default',
+            '--find', 'clang',
+        ])

--- a/utils/build_swift/tests/utils.py
+++ b/utils/build_swift/tests/utils.py
@@ -22,7 +22,16 @@ __all__ = [
     'redirect_stderr',
     'redirect_stdout',
     'TestCase',
+
+    'UTILS_PATH',
 ]
+
+
+UTILS_PATH = os.path.abspath(os.path.join(
+    os.path.dirname(__file__),
+    os.pardir,
+    os.pardir,
+))
 
 
 # -----------------------------------------------------------------------------

--- a/utils/build_swift/utils.py
+++ b/utils/build_swift/utils.py
@@ -1,0 +1,23 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https://swift.org/LICENSE.txt for license information
+# See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+__all__ = [
+    'repr_class',
+]
+
+
+def repr_class(cls, args):
+    """Helper function for implementing __repr__ methods on classes.
+    """
+
+    _args = []
+    for key, value in args.items():
+        _args.append('{}={}'.format(key, repr(value)))
+
+    return '{}({})'.format(type(cls).__name__, ', '.join(_args))

--- a/utils/build_swift/xcrun.py
+++ b/utils/build_swift/xcrun.py
@@ -1,0 +1,75 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+
+"""
+Xcrun wrapper module.
+"""
+
+
+from . import shell
+
+
+__all__ = [
+    'Xcrun',
+]
+
+
+class Xcrun(object):
+    """Wrapper class around the Xcrun utility. Provides methods for each
+    subcommand available.
+    """
+
+    def __init__(self, command_executor=None, sdk=None, toolchain=None):
+        self._sh = command_executor or shell.CommandExecutor()
+        self._sdk = sdk
+        self._toolchain = toolchain
+
+    def _build_command(self, args):
+        command = ['xcrun']
+        if self._sdk is not None:
+            command += ['--sdk', self._sdk]
+        if self._toolchain is not None:
+            command += ['--toolchain', self._toolchain]
+
+        return command + args
+
+    def popen(self, args, **kwargs):
+        return self._sh.popen(self._build_command(args), **kwargs)
+
+    def call(self, args):
+        return self._sh.call(self._build_command(args))
+
+    def check_call(self, args):
+        return self._sh.check_call(self._build_command(args))
+
+    def check_output(self, args):
+        return self._sh.check_output(self._build_command(args))
+
+    # -------------------------------------------------------------------------
+
+    def find(self, tool):
+        return self.check_output(['-find', tool]).rstrip()
+
+    def sdk_path(self):
+        return self.check_output(['--show-sdk-path']).rstrip()
+
+    def sdk_version(self):
+        return self.check_output(['--show-sdk-version']).rstrip()
+
+    def sdk_build_version(self):
+        return self.check_output(['--show-sdk-build-version']).rstrip()
+
+    def sdk_platform_path(self):
+        return self.check_output(['--show-sdk-platform-path']).rstrip()
+
+    def sdk_platform_version(self):
+        return self.check_output(['--show-sdk-platform-version']).rstrip()
+
+    def version(self):
+        return self.check_output(['--version']).rstrip()


### PR DESCRIPTION
# Purpose

This PR mainly cleans up some of the argument parsing tests. It removes some duplicate code and uses the new presets module from #14422 and the shell module from #14430.

This furthers the efforts for completing [SR-237](https://bugs.swift.org/browse/SR-237)
rdar://25281853