### PR TITLE
[IRGen] Add a placeholder field to the beginning of class vtables to reserve space for a potential vtable canary in the future.

### DIFF
--- a/include/swift/SIL/SILVTableVisitor.h
+++ b/include/swift/SIL/SILVTableVisitor.h
@@ -81,6 +81,8 @@ protected:
     // Imported classes do not have a vtable.
     if (!theClass->hasKnownSwiftImplementation())
       return;
+    
+    asDerived().addCanaryPlaceholder();
 
     for (auto member : theClass->getMembers()) {
       if (auto *fd = dyn_cast<FuncDecl>(member))

--- a/lib/IRGen/ClassMetadataVisitor.h
+++ b/lib/IRGen/ClassMetadataVisitor.h
@@ -181,6 +181,7 @@ public:
   void addClassAddressPoint() { addInt32(); }
   void addClassCacheData() { addPointer(); addPointer(); }
   void addClassDataPointer() { addPointer(); }
+  void addCanaryPlaceholder() { addPointer(); }
   void addMethod(SILDeclRef declRef) {
     addPointer();
   }

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1031,6 +1031,8 @@ void IRGenModule::emitClassDecl(ClassDecl *D) {
         : IGM(IGM), D(D) {
         addVTableEntries(D);
       }
+      
+      void addCanaryPlaceholder() {}
 
       void addMethodOverride(SILDeclRef baseRef, SILDeclRef declRef) {}
 

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -67,6 +67,8 @@
 using namespace swift;
 using namespace irgen;
 
+#define CANARY_PLACEHOLDER_VALUE 0x1234567890abcdef
+
 static Address emitAddressOfMetadataSlotAtIndex(IRGenFunction &IGF,
                                                 llvm::Value *metadata,
                                                 int index,
@@ -2882,6 +2884,10 @@ namespace {
       addVTableEntries(getType());
     }
     
+    void addCanaryPlaceholder() {
+      B.addInt(IGM.SizeTy, CANARY_PLACEHOLDER_VALUE);
+    }
+    
     void addMethod(SILDeclRef fn) {
       assert(VTable && "no vtable?!");
 
@@ -3840,6 +3846,10 @@ namespace {
     
     void addFieldOffsetPlaceholders(MissingMemberDecl *placeholder) {
       Members.addFieldOffsetPlaceholders(placeholder);
+    }
+    
+    void addCanaryPlaceholder() {
+      B.addInt(IGM.SizeTy, CANARY_PLACEHOLDER_VALUE);
     }
 
     void addMethod(SILDeclRef fn) {

--- a/lib/IRGen/MetadataLayout.cpp
+++ b/lib/IRGen/MetadataLayout.cpp
@@ -321,6 +321,10 @@ ClassMetadataLayout::ClassMetadataLayout(IRGenModule &IGM, ClassDecl *decl)
       }
       super::addGenericArgument(argType, forClass);
     }
+    
+    void addCanaryPlaceholder() {
+      super::addCanaryPlaceholder();
+    }
 
     void addMethod(SILDeclRef fn) {
       if (fn.getDecl()->getDeclContext() == Target) {

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -248,6 +248,8 @@ public:
 
     addVTableEntries(ancestor);
   }
+  
+  void addCanaryPlaceholder() {}
 
   // Try to find an overridden entry.
   void addMethodOverride(SILDeclRef baseRef, SILDeclRef declRef) {

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -216,6 +216,8 @@ void TBDGenVisitor::visitClassDecl(ClassDecl *CD) {
   public:
     VTableVisitor(TBDGenVisitor &TBD, ClassDecl *CD)
         : TBD(TBD), CD(CD) {}
+    
+    void addCanaryPlaceholder() {}
 
     void addMethod(SILDeclRef method) {
       if (method.getDecl()->getDeclContext() == CD)


### PR DESCRIPTION
I'm not entirely sure if this is necessary or useful, but I wanted to try it, and put it out there in case someone with stronger opinions could convince me one way or the other.

I'm also not sure if I adjusted everything that needs adjusting for the new field. The tests appear to pass and I manually verified that vtable dispatch still works and the placeholder value shows up in the right spot, but there could certainly be more.

rdar://problem/17386249