### PR TITLE
Shims: match the declared type for CF interfaces

### DIFF
--- a/stdlib/public/SwiftShims/CFHashingShims.h
+++ b/stdlib/public/SwiftShims/CFHashingShims.h
@@ -29,10 +29,10 @@ CF_INLINE CFHashCode __CFHashDouble(double d) {
     return (CFHashCode)(integralHash + (CFHashCode)((d - dInt) * ULONG_MAX));
 }
 
-CF_EXPORT CFHashCode CFHashBytes(uint8_t *_Nullable bytes, long len);
+CF_EXPORT CFHashCode CFHashBytes(uint8_t *_Nullable bytes, CFIndex len);
 
 
-CF_INLINE CFHashCode __CFHashBytes(uint8_t *_Nullable bytes, long len) {
+CF_INLINE CFHashCode __CFHashBytes(uint8_t *_Nullable bytes, CFIndex len) {
     return CFHashBytes(bytes, len);
 }
 


### PR DESCRIPTION
`CFHashBytes` takes a `CFIndex`, not a `long`.  Because this type is
declared differently on different platforms, desugaring the type can
cause mismatches.  Make the shims match the real declarations in
swift-corelibs-foundation.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
