### PR TITLE
[Name lookup] Fix an issue with lazy named member lookup.

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1273,7 +1273,7 @@ static void populateLookupTableEntryFromCurrentMembersWithoutLoading(
     IterableDeclContext *IDC) {
   for (auto m : IDC->getCurrentMembersWithoutLoading()) {
     if (auto v = dyn_cast<ValueDecl>(m)) {
-      if (v->getFullName().matchesRef(name)) {
+      if (v->getFullName().matchesRef(name.getBaseName())) {
         LookupTable.addMember(m);
       }
     }

--- a/test/NameBinding/Inputs/NamedLazyMembers/NamedLazyMembers.h
+++ b/test/NameBinding/Inputs/NamedLazyMembers/NamedLazyMembers.h
@@ -103,3 +103,8 @@
 - (void)doSomething:(double)x celsius:(double)y;
 - (void)doSomething:(double)x fahrenheit:(double)y using:(void (^)(void))block;
 @end
+
+@interface SimpleDoerSubclass : SimpleDoer
+- (void)simplyDoSomeWorkWithSpeed:(int)s thoroughness:(int)t
+  NS_SWIFT_NAME(simplyDoVeryImportantWork(speed:thoroughness:));
+@end

--- a/test/NameBinding/Inputs/NamedLazyMembers/NamedLazyMembersExt.swift
+++ b/test/NameBinding/Inputs/NamedLazyMembers/NamedLazyMembersExt.swift
@@ -1,0 +1,5 @@
+import NamedLazyMembers
+
+extension SimpleDoer {
+  func simplyDoVeryImportantWork(speed: Int, motivation: Int) { }
+}

--- a/test/NameBinding/named_lazy_member_loading_objc_interface.swift
+++ b/test/NameBinding/named_lazy_member_loading_objc_interface.swift
@@ -3,14 +3,18 @@
 // RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Prime module cache
-// RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -typecheck %s
+// RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -typecheck -primary-file %s %S/Inputs/NamedLazyMembers/NamedLazyMembersExt.swift
 //
 // Check that named-lazy-member-loading reduces the number of Decls deserialized
-// RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -disable-named-lazy-member-loading -stats-output-dir %t/stats-pre %s
-// RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -stats-output-dir %t/stats-post %s
+// RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -disable-named-lazy-member-loading -stats-output-dir %t/stats-pre -primary-file %s %S/Inputs/NamedLazyMembers/NamedLazyMembersExt.swift
+// RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -stats-output-dir %t/stats-post -primary-file %s %S/Inputs/NamedLazyMembers/NamedLazyMembersExt.swift
 // RUN: %utils/process-stats-dir.py --evaluate-delta 'NumTotalClangImportedEntities < -10' %t/stats-pre %t/stats-post
 
 import NamedLazyMembers
+
+public func bar(d: SimpleDoerSubclass) {
+    let _ = d.simplyDoVeryImportantWork(speed: 10, motivation: 42)
+}
 
 public func foo(d: SimpleDoer) {
   let _ = d.simplyDoSomeWork()


### PR DESCRIPTION
Fix an issue with lazy named member lookup where a sequence of lookups
into a class based on full names (e.g., constraint(equalTo:constant:))
could prevent us from adding candidates with the same based name but
different argument labels.

Fixes SR-6834 / rdar://problem/36851018
