### PR TITLE
[BatchMode] Switch CommandOutput objects to use an OutputFileMap

### DIFF
--- a/include/swift/Driver/Action.h
+++ b/include/swift/Driver/Action.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -117,7 +117,7 @@ public:
   // Returns the index of the Input action's output file which is used as
   // (single) input to this action. Most actions produce only a single output
   // file, so we return 0 by default.
-  virtual int getInputIndex() const { return 0; }
+  virtual size_t getInputIndex() const { return 0; }
 
   static bool classof(const Action *A) {
     return (A->getKind() >= ActionClass::JobFirst &&
@@ -188,16 +188,16 @@ private:
   // In case of multi-threaded compilation, the compile-action produces multiple
   // output bitcode-files. For each bitcode-file a BackendJobAction is created.
   // This index specifies which of the files to select for the input.
-  int InputIndex;
+  size_t InputIndex;
 public:
-  BackendJobAction(const Action *Input, types::ID OutputType, int InputIndex)
+  BackendJobAction(const Action *Input, types::ID OutputType, size_t InputIndex)
       : JobAction(Action::BackendJob, Input, OutputType),
         InputIndex(InputIndex) {}
   static bool classof(const Action *A) {
     return A->getKind() == Action::BackendJob;
   }
   
-  virtual int getInputIndex() const { return InputIndex; }
+  virtual size_t getInputIndex() const { return InputIndex; }
 };
 
 class REPLJobAction : public JobAction {

--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -76,6 +76,11 @@ private:
 
   /// The OutputLevel at which this Compilation should generate output.
   OutputLevel Level;
+
+  /// The OutputFileMap describing the Compilation's outputs, populated both by
+  /// the user-provided output file map (if it exists) and inference rules that
+  /// derive otherwise-unspecified output filenames from context.
+  OutputFileMap DerivedOutputFileMap;
 
   /// The Actions which were used to build the Jobs.
   ///
@@ -217,6 +222,11 @@ public:
 
   const llvm::opt::DerivedArgList &getArgs() const { return *TranslatedArgs; }
   ArrayRef<InputPair> getInputFiles() const { return InputFilesWithTypes; }
+
+  OutputFileMap &getDerivedOutputFileMap() { return DerivedOutputFileMap; }
+  const OutputFileMap &getDerivedOutputFileMap() const {
+    return DerivedOutputFileMap;
+  }
 
   unsigned getNumberOfParallelCommands() const {
     return NumberOfParallelCommands;

--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -72,7 +72,7 @@ private:
 
   /// The ToolChain this Compilation was built with, that it may reuse to build
   /// subsequent BatchJobs.
-  const ToolChain &TheToolChain;
+  LLVM_ATTRIBUTE_UNUSED const ToolChain &TheToolChain;
 
   /// The OutputLevel at which this Compilation should generate output.
   OutputLevel Level;

--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -289,7 +289,9 @@ private:
                          const ToolChain &TC, bool AtTopLevel,
                          SmallVectorImpl<const Action *> &InputActions,
                          SmallVectorImpl<const Job *> &InputJobs,
-                         const TypeToPathMap *OutputMap, StringRef BaseInput,
+                         const TypeToPathMap *OutputMap,
+                         StringRef BaseInput,
+                         StringRef PrimaryInput,
                          llvm::SmallString<128> &Buf,
                          CommandOutput *Output) const;
 

--- a/include/swift/Driver/Job.h
+++ b/include/swift/Driver/Job.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -15,12 +15,14 @@
 
 #include "swift/Basic/LLVM.h"
 #include "swift/Driver/Action.h"
+#include "swift/Driver/OutputFileMap.h"
 #include "swift/Driver/Types.h"
 #include "swift/Driver/Util.h"
 #include "llvm/Option/Option.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/PointerIntPair.h"
+#include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/Chrono.h"
@@ -34,48 +36,145 @@ namespace driver {
 class Job;
 class JobAction;
 
+/// \file Job.h
+///
+///Some terminology for the following sections (and especially Driver.cpp):
+///
+/// BaseInput: a filename provided by the user, upstream of the entire Job
+///            graph, usually denoted by an InputAction. Every Job has access,
+///            during construction, to a set of BaseInputs that are upstream of
+///            its inputs and input jobs in the job graph, and from which it can
+///            derive PrimaryInput names for itself.
+///
+/// BaseOutput: a filename that is a non-temporary, output at the bottom of a
+///             Job graph, and often (though not always) directly specified by
+///             the user in the form of a -o or -emit-foo-path name, or an entry
+///             in a user-provided OutputFileMap. May also be an auxiliary,
+///             derived from a BaseInput and a type.
+///
+/// PrimaryInput: one of the distinguished inputs-to-act-on (as opposed to
+///               merely informative additional inputs) to a Job. May be a
+///               BaseInput but may also be a temporary that doesn't live beyond
+///               the execution of the Job graph.
+///
+/// PrimaryOutput: an output file matched 1:1 with a specific
+///                PrimaryInput. Auxiliary outputs may also be produced. A
+///                PrimaryOutput may be a BaseOutput, but may also be a
+///                temporary that doesn't live beyond the execution of the Job
+///                graph (that is: it exists in order to be the PrimaryInput
+///                for a subsequent Job).
+///
+/// The user-provided OutputFileMap lists BaseInputs and BaseOutputs, but doesn't
+/// describe the temporaries inside the Job graph.
+///
+/// The Compilation's DerivedOutputFileMap (shared by all CommandOutputs) lists
+/// PrimaryInputs and maps them to PrimaryOutputs, including all the
+/// temporaries. This means that in a multi-stage Job graph, the BaseInput =>
+/// BaseOutput entries provided by the user are split in two (or more) steps,
+/// one BaseInput => SomeTemporary and one SomeTemporary => BaseOutput.
+///
+/// To try to keep this as simple as possible (it's already awful) we associate
+/// every PrimaryInput 1:1 with a specific BaseInput from which it was derived;
+/// this way a CommandOutput will have a vector of _pairs_ of
+/// {Base,Primary}Inputs rather than a pair of separate vectors. This arrangement
+/// appears to cover all the graph topologies we encounter in practice.
+
+
+struct CommandInputPair {
+  /// A filename provided from the user, either on the command line or in an
+  /// input file map. Feeds into a Job graph, from InputActions, and is
+  /// _associated_ with a PrimaryInput for a given Job, but may be upstream of
+  /// the Job (and its PrimaryInput) and thus not necessarily passed as a
+  /// filename to the job. Used as a key into the user-provided OutputFileMap
+  /// (of BaseInputs and BaseOutputs), and used to derive downstream names --
+  /// both temporaries and auxiliaries -- but _not_ used as a key into the
+  /// DerivedOutputFileMap.
+  StringRef Base;
+
+  /// A filename that _will be passed_ to the command as a designated primary
+  /// input. Typically either equal to BaseInput or a temporary with a name
+  /// derived from the BaseInput it is related to. Also used as a key into
+  /// the DerivedOutputFileMap.
+  StringRef Primary;
+};
+
 class CommandOutput {
+
+  /// A CommandOutput designates one type of output as primary, though there
+  /// may be multiple outputs of that type.
   types::ID PrimaryOutputType;
-  
-  /// The primary output files of the command.
-  /// Usually a command has only a single output file. Only the compiler in
-  /// multi-threaded compilation produces multiple output files.
-  SmallVector<std::string, 1> PrimaryOutputFilenames;
 
-  /// For each primary output file there is a base input. This is the input file
-  /// from which the output file is derived.
-  SmallVector<StringRef, 1> BaseInputs;
+  /// A CommandOutput also restricts its attention regarding additional-outputs
+  /// to a subset of the PrimaryOutputs associated with its PrimaryInputs;
+  /// sometimes multiple commands operate on the same PrimaryInput, in different
+  /// phases (eg. autolink-extract and link both operate on the same .o file),
+  /// so Jobs cannot _just_ rely on the presence of a primary output in the
+  /// DerivedOutputFileMap.
+  llvm::SmallSet<types::ID, 4> AdditionalOutputTypes;
 
-  llvm::SmallDenseMap<types::ID, std::string, 4> AdditionalOutputsMap;
+  /// The set of input filenames for this \c CommandOutput; combined with \c
+  /// DerivedOutputMap, specifies a set of output filenames (of which one -- the
+  /// one of type \c PrimaryOutputType) is the primary output filename.
+  SmallVector<CommandInputPair, 1> Inputs;
+
+  /// All CommandOutputs in a Compilation share the same \c
+  /// DerivedOutputMap. This is computed both from any user-provided input file
+  /// map, and any inference steps.
+  OutputFileMap &DerivedOutputMap;
+
+  // If there is an entry in the DerivedOutputMap for a given (\p
+  // PrimaryInputFile, \p Type) pair, return a nonempty StringRef, otherwise
+  // return an empty StringRef.
+  StringRef
+  getOutputForInputAndType(StringRef PrimaryInputFile, types::ID Type) const;
+
+  /// Add an entry to the \c DerivedOutputMap if it doesn't exist. If an entry
+  /// already exists for \p PrimaryInputFile of type \p type, then either
+  /// overwrite the entry (if \p overwrite is \c true) or assert that it has
+  /// the same value as \p OutputFile.
+  void ensureEntry(StringRef PrimaryInputFile,
+                   types::ID Type,
+                   StringRef OutputFile,
+                   bool Overwrite);
 
 public:
-  CommandOutput(types::ID PrimaryOutputType)
-      : PrimaryOutputType(PrimaryOutputType) { }
+  CommandOutput(types::ID PrimaryOutputType, OutputFileMap &Derived);
 
-  types::ID getPrimaryOutputType() const { return PrimaryOutputType; }
+  /// Return the primary output type for this CommandOutput.
+  types::ID getPrimaryOutputType() const;
 
-  void addPrimaryOutput(StringRef FileName, StringRef BaseInput) {
-    PrimaryOutputFilenames.push_back(FileName);
-    BaseInputs.push_back(BaseInput);
-  }
-  
-  // This returns a std::string instead of a StringRef so that users can rely
-  // on the data buffer being null-terminated.
-  const std::string &getPrimaryOutputFilename() const {
-    assert(PrimaryOutputFilenames.size() == 1);
-    return PrimaryOutputFilenames[0];
-  }
+  /// Associate a new \p PrimaryOutputFile (of type \c getPrimaryOutputType())
+  /// with the provided \p Input pair of Base and Primary inputs.
+  void addPrimaryOutput(CommandInputPair Input, StringRef PrimaryOutputFile);
 
-  ArrayRef<std::string> getPrimaryOutputFilenames() const {
-    return PrimaryOutputFilenames;
-  }
-  
+  /// Assuming (and asserting) that there is only one input pair, return the
+  /// primary output file associated with it. Note that the returned StringRef
+  /// may be invalidated by subsequent mutations to the \c CommandOutput.
+  StringRef getPrimaryOutputFilename() const;
+
+  /// Return a all of the outputs of type \c getPrimaryOutputType() associated
+  /// with a primary input. Note that the returned \c StringRef vector may be
+  /// invalidated by subsequent mutations to the \c CommandOutput.
+  SmallVector<StringRef, 16> getPrimaryOutputFilenames() const;
+
+  /// Assuming (and asserting) that there are one or more input pairs, associate
+  /// an additional output named \p OutputFilename of type \p type with the
+  /// first primary input. If the provided \p type is the primary output type,
+  /// overwrite the existing entry assocaited with the first primary input.
   void setAdditionalOutputForType(types::ID type, StringRef OutputFilename);
-  const std::string &getAdditionalOutputForType(types::ID type) const;
 
-  const std::string &getAnyOutputForType(types::ID type) const;
+  /// Assuming (and asserting) that there are one or more input pairs, return
+  /// the _additional_ (not primary) output of type \p type associated with the
+  /// first primary input.
+  StringRef getAdditionalOutputForType(types::ID type) const;
 
-  StringRef getBaseInput(int Index) const { return BaseInputs[Index]; }
+  /// Assuming (and asserting) that there is only one input pair, return any
+  /// output -- primary or additional -- of type \p type associated with that
+  /// the sole primary input.
+  StringRef getAnyOutputForType(types::ID type) const;
+
+  /// Return the BaseInput numbered by \p Index.
+  StringRef getBaseInput(size_t Index) const;
 };
 
 class Job {

--- a/include/swift/Driver/Job.h
+++ b/include/swift/Driver/Job.h
@@ -175,6 +175,9 @@ public:
 
   /// Return the BaseInput numbered by \p Index.
   StringRef getBaseInput(size_t Index) const;
+
+  void print(raw_ostream &Stream) const;
+  void dump() const LLVM_ATTRIBUTE_USED;
 };
 
 class Job {

--- a/include/swift/Driver/OutputFileMap.h
+++ b/include/swift/Driver/OutputFileMap.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -33,9 +33,9 @@ class OutputFileMap {
 private:
   llvm::StringMap<TypeToPathMap> InputToOutputsMap;
 
+public:
   OutputFileMap() {}
 
-public:
   ~OutputFileMap() = default;
 
   /// Loads an OutputFileMap from the given \p Path, if possible.
@@ -52,8 +52,15 @@ public:
   /// OutputFileMap. (If not present, returns nullptr.)
   const TypeToPathMap *getOutputMapForInput(StringRef Input) const;
 
+  /// Get a map of outputs for the given \p Input, creating it in
+  /// the OutputFileMap if not already present.
+  TypeToPathMap &getOrCreateOutputMapForInput(StringRef Input);
+
   /// Get the map of outputs for a single compile product.
   const TypeToPathMap *getOutputMapForSingleOutput() const;
+
+  /// Get or create the map of outputs for a single compile product.
+  TypeToPathMap &getOrCreateOutputMapForSingleOutput();
 
   /// Dump the OutputFileMap to the given \p os.
   void dump(llvm::raw_ostream &os, bool Sort = false) const;

--- a/include/swift/Driver/PrettyStackTrace.h
+++ b/include/swift/Driver/PrettyStackTrace.h
@@ -1,0 +1,76 @@
+//===--- PrettyStackTrace.h - PrettyStackTrace for the Driver ---*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_DRIVER_PRETTYSTACKTRACE_H
+#define SWIFT_DRIVER_PRETTYSTACKTRACE_H
+
+#include "llvm/Support/PrettyStackTrace.h"
+#include "swift/Driver/Types.h"
+
+namespace swift {
+namespace driver {
+
+class Action;
+class Job;
+class CommandOutput;
+
+class PrettyStackTraceDriverAction : public llvm::PrettyStackTraceEntry {
+  const Action *TheAction;
+  const char *Description;
+
+public:
+  PrettyStackTraceDriverAction(const char *desc, const Action *A)
+      : TheAction(A), Description(desc) {}
+  void print(llvm::raw_ostream &OS) const override;
+};
+
+class PrettyStackTraceDriverJob : public llvm::PrettyStackTraceEntry {
+  const Job *TheJob;
+  const char *Description;
+
+public:
+  PrettyStackTraceDriverJob(const char *desc, const Job *A)
+      : TheJob(A), Description(desc) {}
+  void print(llvm::raw_ostream &OS) const override;
+};
+
+class PrettyStackTraceDriverCommandOutput : public llvm::PrettyStackTraceEntry {
+  const CommandOutput *TheCommandOutput;
+  const char *Description;
+
+public:
+  PrettyStackTraceDriverCommandOutput(const char *desc, const CommandOutput *A)
+      : TheCommandOutput(A), Description(desc) {}
+  void print(llvm::raw_ostream &OS) const override;
+};
+
+class PrettyStackTraceDriverCommandOutputAddition
+    : public llvm::PrettyStackTraceEntry {
+  const CommandOutput *TheCommandOutput;
+  StringRef PrimaryInput;
+  types::ID NewOutputType;
+  StringRef NewOutputName;
+  const char *Description;
+
+public:
+  PrettyStackTraceDriverCommandOutputAddition(const char *desc,
+                                              const CommandOutput *A,
+                                              StringRef Primary, types::ID type,
+                                              StringRef New)
+      : TheCommandOutput(A), PrimaryInput(Primary), NewOutputType(type),
+        NewOutputName(New), Description(desc) {}
+  void print(llvm::raw_ostream &OS) const override;
+};
+}
+}
+
+#endif

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -77,6 +77,8 @@ def driver_print_actions : Flag<["-"], "driver-print-actions">,
   InternalDebugOpt, HelpText<"Dump list of actions to perform">;
 def driver_print_output_file_map : Flag<["-"], "driver-print-output-file-map">,
   InternalDebugOpt, HelpText<"Dump the contents of the output file map">;
+def driver_print_derived_output_file_map : Flag<["-"], "driver-print-derived-output-file-map">,
+  InternalDebugOpt, HelpText<"Dump the contents of the derived output file map">;
 def driver_print_bindings : Flag<["-"], "driver-print-bindings">,
   InternalDebugOpt, HelpText<"Dump list of job inputs and outputs">;
 def driver_print_jobs : Flag<["-"], "driver-print-jobs">, InternalDebugOpt,

--- a/lib/Driver/CMakeLists.txt
+++ b/lib/Driver/CMakeLists.txt
@@ -7,6 +7,7 @@ set(swiftDriver_sources
   Job.cpp
   OutputFileMap.cpp
   ParseableOutput.cpp
+  PrettyStackTrace.cpp
   ToolChain.cpp
   ToolChains.cpp
   Types.cpp

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -813,7 +813,7 @@ static bool writeFilelistIfNecessary(const Job *job, DiagnosticEngine &diags) {
           for (auto &output : outputInfo.getPrimaryOutputFilenames())
             out << output << "\n";
         } else {
-          auto &output = outputInfo.getAnyOutputForType(filelistInfo.type);
+          auto output = outputInfo.getAnyOutputForType(filelistInfo.type);
           if (!output.empty())
             out << output << "\n";
         }

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -30,6 +30,7 @@
 #include "swift/Driver/Compilation.h"
 #include "swift/Driver/Job.h"
 #include "swift/Driver/OutputFileMap.h"
+#include "swift/Driver/PrettyStackTrace.h"
 #include "swift/Driver/ToolChain.h"
 #include "swift/Option/Options.h"
 #include "swift/Option/SanitizerOptions.h"
@@ -2013,6 +2014,9 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
                                 const OutputFileMap *OFM,
                                 const ToolChain &TC, bool AtTopLevel,
                                 JobCacheMap &JobCache) const {
+
+  PrettyStackTraceDriverAction CrashInfo("building jobs", JA);
+
   // 1. See if we've already got this cached.
   std::pair<const Action *, const ToolChain *> Key(JA, &TC);
   {
@@ -2066,6 +2070,9 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
 
   std::unique_ptr<CommandOutput> Output(
       new CommandOutput(JA->getType(), C.getDerivedOutputFileMap()));
+
+  PrettyStackTraceDriverCommandOutput CrashInfo2("determining output",
+                                                 Output.get());
   llvm::SmallString<128> Buf;
   computeMainOutput(C, JA, OI, OFM, TC, AtTopLevel, InputActions, InputJobs,
                     OutputMap, BaseInput, PrimaryInput, Buf, Output.get());

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -511,6 +511,8 @@ Driver::buildCompilation(const ToolChain &TC,
   bool DriverPrintActions = ArgList->hasArg(options::OPT_driver_print_actions);
   bool DriverPrintOutputFileMap =
     ArgList->hasArg(options::OPT_driver_print_output_file_map);
+  bool DriverPrintDerivedOutputFileMap =
+    ArgList->hasArg(options::OPT_driver_print_derived_output_file_map);
   DriverPrintBindings = ArgList->hasArg(options::OPT_driver_print_bindings);
   bool DriverPrintJobs = ArgList->hasArg(options::OPT_driver_print_jobs);
   bool DriverSkipExecution =
@@ -694,6 +696,11 @@ Driver::buildCompilation(const ToolChain &TC,
   }
 
   buildJobs(TopLevelActions, OI, OFM.get(), TC, *C);
+
+  if (DriverPrintDerivedOutputFileMap) {
+    C->getDerivedOutputFileMap().dump(llvm::outs(), true);
+    return nullptr;
+  }
 
   // For getting bulk fixits, or for when users explicitly request to continue
   // building despite errors.

--- a/lib/Driver/Job.cpp
+++ b/lib/Driver/Job.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -22,26 +22,93 @@
 using namespace swift;
 using namespace swift::driver;
 
-void CommandOutput::setAdditionalOutputForType(types::ID type,
+StringRef CommandOutput::getOutputForInputAndType(StringRef PrimaryInputFile,
+                                                  types::ID Type) const {
+  auto const *M = DerivedOutputMap.getOutputMapForInput(PrimaryInputFile);
+  if (!M)
+    return StringRef();
+  auto const Out = M->find(Type);
+  if (Out == M->end())
+    return StringRef();
+  return StringRef(Out->second);
+}
+
+void CommandOutput::ensureEntry(StringRef PrimaryInputFile,
+                                types::ID Type,
+                                StringRef OutputFile,
+                                bool Overwrite) {
+  auto &M = DerivedOutputMap.getOrCreateOutputMapForInput(PrimaryInputFile);
+  if (Overwrite) {
+    M[Type] = OutputFile;
+  } else {
+    auto res = M.insert(std::make_pair(Type, OutputFile));
+    if (res.second) {
+      // New entry, no need to compare.
+    } else {
+      // Existing entry, check equality with request.
+      assert(res.first->getSecond() == OutputFile);
+    }
+  }
+}
+
+CommandOutput::CommandOutput(types::ID PrimaryOutputType,
+                             OutputFileMap &Derived)
+    : PrimaryOutputType(PrimaryOutputType), DerivedOutputMap(Derived) {}
+
+types::ID CommandOutput::getPrimaryOutputType() const {
+  return PrimaryOutputType;
+}
+
+void CommandOutput::addPrimaryOutput(CommandInputPair Input,
+                                     StringRef PrimaryOutputFile) {
+  Inputs.push_back(Input);
+  ensureEntry(Input.Primary, PrimaryOutputType, PrimaryOutputFile, false);
+}
+
+StringRef CommandOutput::getPrimaryOutputFilename() const {
+  assert(Inputs.size() >= 1);
+  return getOutputForInputAndType(Inputs[0].Primary, PrimaryOutputType);
+}
+
+SmallVector<StringRef, 16> CommandOutput::getPrimaryOutputFilenames() const {
+  SmallVector<StringRef, 16> V;
+  for (auto const &I : Inputs) {
+    auto Out = getOutputForInputAndType(I.Primary, PrimaryOutputType);
+    V.push_back(Out);
+  }
+  return V;
+}
+
+void CommandOutput::setAdditionalOutputForType(types::ID Type,
                                                StringRef OutputFilename) {
-  AdditionalOutputsMap[type] = OutputFilename;
+  assert(Inputs.size() >= 1);
+
+  // If we're given an "additional" output with the same type as the primary,
+  // and we've not yet had such an additional type added, we treat it as a
+  // request to overwrite the primary choice (which happens early and is
+  // sometimes just inferred) with a refined value (eg. -emit-module-path).
+  bool Overwrite = (Type == PrimaryOutputType &&
+                    AdditionalOutputTypes.count(Type) == 0);
+  ensureEntry(Inputs[0].Primary, Type, OutputFilename, Overwrite);
+  AdditionalOutputTypes.insert(Type);
 }
 
-const std::string &
-CommandOutput::getAdditionalOutputForType(types::ID type) const {
-  auto iter = AdditionalOutputsMap.find(type);
-  if (iter != AdditionalOutputsMap.end())
-    return iter->second;
-
-  static const std::string empty;
-  return empty;
+StringRef CommandOutput::getAdditionalOutputForType(types::ID Type) const {
+  if (AdditionalOutputTypes.count(Type) == 0)
+    return StringRef();
+  assert(Inputs.size() >= 1);
+  return getOutputForInputAndType(Inputs[0].Primary, Type);
 }
 
-const std::string &
-CommandOutput::getAnyOutputForType(types::ID type) const {
-  if (PrimaryOutputType == type)
-    return PrimaryOutputFilenames[0];
-  return getAdditionalOutputForType(type);
+StringRef CommandOutput::getAnyOutputForType(types::ID Type) const {
+  if (PrimaryOutputType == Type)
+    return getPrimaryOutputFilename();
+  return getAdditionalOutputForType(Type);
+}
+
+StringRef CommandOutput::getBaseInput(size_t Index) const {
+  assert(Index < Inputs.size());
+  return Inputs[Index].Base;
 }
 
 static void escapeAndPrintString(llvm::raw_ostream &os, StringRef Str) {

--- a/lib/Driver/OutputFileMap.cpp
+++ b/lib/Driver/OutputFileMap.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -52,8 +52,18 @@ const TypeToPathMap *OutputFileMap::getOutputMapForInput(StringRef Input) const{
     return &iter->second;
 }
 
+TypeToPathMap &
+OutputFileMap::getOrCreateOutputMapForInput(StringRef Input) {
+  return InputToOutputsMap[Input];
+}
+
 const TypeToPathMap *OutputFileMap::getOutputMapForSingleOutput() const {
   return getOutputMapForInput(StringRef());
+}
+
+TypeToPathMap &
+OutputFileMap::getOrCreateOutputMapForSingleOutput() {
+  return InputToOutputsMap[StringRef()];
 }
 
 void OutputFileMap::dump(llvm::raw_ostream &os, bool Sort) const {

--- a/lib/Driver/ParseableOutput.cpp
+++ b/lib/Driver/ParseableOutput.cpp
@@ -114,7 +114,7 @@ public:
     }
 
     for (const Job *J : Cmd.getInputs()) {
-      ArrayRef<std::string> OutFiles = J->getOutput().getPrimaryOutputFilenames();
+      auto OutFiles = J->getOutput().getPrimaryOutputFilenames();
       if (const auto *BJAction = dyn_cast<BackendJobAction>(&Cmd.getSource())) {
         Inputs.push_back(CommandInput(OutFiles[BJAction->getInputIndex()]));
       } else {
@@ -133,8 +133,7 @@ public:
       }
     }
     types::forAllTypes([&](types::ID Ty) {
-      const std::string &Output =
-          Cmd.getOutput().getAdditionalOutputForType(Ty);
+      auto Output = Cmd.getOutput().getAdditionalOutputForType(Ty);
       if (!Output.empty())
         Outputs.push_back(OutputPair(Ty, Output));
     });

--- a/lib/Driver/PrettyStackTrace.cpp
+++ b/lib/Driver/PrettyStackTrace.cpp
@@ -1,0 +1,54 @@
+//===--- PrettyStackTrace.cpp - Defines Driver crash prettifiers -------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Driver/PrettyStackTrace.h"
+#include "swift/Driver/Action.h"
+#include "swift/Driver/Job.h"
+#include "swift/Driver/Types.h"
+#include "llvm/Option/Arg.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace swift::driver;
+
+void PrettyStackTraceDriverAction::print(llvm::raw_ostream &out) const {
+  out << "While " << Description << " for driver Action "
+      << TheAction->getClassName()
+      << " of type "
+      << types::getTypeName(TheAction->getType());
+  if (auto *IA = dyn_cast<InputAction>(TheAction)) {
+    out << " = ";
+    IA->getInputArg().print(out);
+  }
+  out << '\n';
+}
+
+void PrettyStackTraceDriverJob::print(llvm::raw_ostream &out) const {
+  out << "While " << Description << " for driver Job ";
+  TheJob->printSummary(out);
+  out << '\n';
+}
+
+void PrettyStackTraceDriverCommandOutput::print(llvm::raw_ostream &out) const {
+  out << "While " << Description << " for driver CommandOutput\n";
+  TheCommandOutput->print(out);
+  out << '\n';
+}
+
+void PrettyStackTraceDriverCommandOutputAddition::print(
+    llvm::raw_ostream &out) const {
+  out << "While adding " << Description
+      << " output named " << NewOutputName
+      << " of type " << types::getTypeName(NewOutputType)
+      << " to driver CommandOutput\n";
+  TheCommandOutput->print(out);
+  out << '\n';
+}


### PR DESCRIPTION
This principally switches the driver's CommandOutput objects to have a single shared OutputFileMap (called the DerivedOutputFileMap, owned by the Compilation) rather than a bunch of object-local lists of primary outputs.

The long-term plan here is to write the Derived OFM out to reuse in batch-mode frontend jobs, to avoid passing them a zillion little file lists. In the short term this change shouldn't really do anything observable though, it just changes how the information is stored.

There's more churn than you might expect here for a few reasons:

  1. I was just really really confused about the differences between primary inputs and base inputs, and it took me a long time to tease apart what the different code assumptions and then figure out mechanisms to preserve them. So there's a bunch of docs and debug machinery which I figured I might as well leave in place.
  2. The lifetimes of argument strings changed, since the shared OFM is being updated in steps that are interleaved with the extraction of argument strings and construction of argument lists. So there's a bunch of copying strings up to the correct argument list lifetime.

I suspect this isn't quite the final state we should leave things in, there's still some logic factoring and cleanup to do (and notably there are still a few weird assumptions baked in -- that were there before -- about dealing only with the first primary output and ignoring secondary ones) but I think it's a step in the right direction, and ought to be enough to facilitate the subsequent driver changes for batch mode.