### PR TITLE
[WIP][Sema] Permit implicit casting from an archetype to an enum case in pattern matching

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1398,8 +1398,8 @@ recur:
         }
       }
       // Otherwise, see if we can introduce a cast pattern to get from an
-      // existential pattern type to the enum type.
-      else if (type->isAnyExistentialType()) {
+      // existential or archetype pattern type to the enum type.
+      else if (type->isAnyExistentialType() || type->is<ArchetypeType>()) {
         auto foundCastKind =
           typeCheckCheckedCast(type, parentTy,
                                CheckedCastContextKind::EnumElementPattern,

--- a/test/Constraints/patterns.swift
+++ b/test/Constraints/patterns.swift
@@ -129,6 +129,67 @@ default:
   break
 }
 
+func testSwitchEnumOnHairTypeArchetype<T : HairType>(_ x: T) {
+  switch x {
+  case MacbookHair.HairSupply(let s):
+    s.s()
+  case iPadHair<S>.HairForceOne:
+    ()
+  case iPadHair<E>.HairForceOne:
+    ()
+  case iPadHair.HairForceOne: // expected-error{{generic enum type 'iPadHair' is ambiguous without explicit generic parameters when matching value of type 'T'}}
+    ()
+  case Watch.Edition: // TODO: should warn that cast can't succeed with currently known conformances
+    ()
+  // TODO: Bad error message
+  case .HairForceOne: // expected-error{{cannot convert}}
+    ()
+  default:
+    break
+  }
+}
+
+func testSwitchEnumOnUnconstrainedArchetype<T>(_ x: T) {
+  switch x {
+  case MacbookHair.HairSupply(let s):
+    s.s()
+  case iPadHair<S>.HairForceOne:
+    ()
+  case iPadHair<E>.HairForceOne:
+    ()
+  case iPadHair.HairForceOne: // expected-error{{generic enum type 'iPadHair' is ambiguous without explicit generic parameters when matching value of type 'T'}}
+    ()
+  case Watch.Edition:
+    ()
+  // TODO: Bad error message
+  case .HairForceOne: // expected-error{{cannot convert}}
+    ()
+  default:
+    break
+  }
+}
+
+extension HairType {
+  func testSwitchEnumOnImplicitSelfArchetype() {
+    switch self {
+    case MacbookHair.HairSupply(let s):
+      s.s()
+    case iPadHair<S>.HairForceOne:
+      ()
+    case iPadHair<E>.HairForceOne:
+      ()
+    case iPadHair.HairForceOne: // expected-error{{generic enum type 'iPadHair' is ambiguous without explicit generic parameters when matching value of type 'Self'}}
+      ()
+    case Watch.Edition: // TODO: should warn that cast can't succeed with currently known conformances
+      ()
+    // TODO: Bad error message
+    case .HairForceOne: // expected-error{{cannot convert}}
+      ()
+    default:
+      break
+    }
+  }
+}
 
 // <rdar://problem/19382878> Introduce new x? pattern
 switch Optional(42) {

--- a/test/SILGen/switch_isa.swift
+++ b/test/SILGen/switch_isa.swift
@@ -43,6 +43,24 @@ func testSwitchEnumOnExistential(_ value: Any) {
 // CHECK:   checked_cast_addr_br copy_on_success Any in {{%.*}} : $*Any to Bar<Int>
 // CHECK:   checked_cast_addr_br copy_on_success Any in {{%.*}} : $*Any to Bar<Foo>
 
+func testSwitchEnumOnArchetype<T>(_ value: T) {
+  switch value {
+  case Foo.A:
+    ()
+  case Bar<Int>.B(let i):
+    ()
+  case Bar<Foo>.B(let f):
+    ()
+  default:
+    ()
+  }
+}
+
+// CHECK-LABEL: sil hidden @$S10switch_isa25testSwitchEnumOnArchetypeyyxlF : $@convention(thin) <T> (@in T) -> ()
+// CHECK:   checked_cast_addr_br copy_on_success T in {{%.*}} : $*T to Foo
+// CHECK:   checked_cast_addr_br copy_on_success T in {{%.*}} : $*T to Bar<Int>
+// CHECK:   checked_cast_addr_br copy_on_success T in {{%.*}} : $*T to Bar<Foo>
+
 class B {}
 class D: B {}
 


### PR DESCRIPTION
When pattern matching on a value of archetype type, allow implicit casts to enum cases. Previously we allowed this only for existential patterns, but it's reasonable to allow it for archetypes too.

Resolves [SR-6955](https://bugs.swift.org/browse/SR-6955).

