### PR TITLE
[sourcekitd] Rename module SwiftSourceKit to SwiftLang.

### DIFF
--- a/test/SwiftSyntax/DeserializeFile.swift
+++ b/test/SwiftSyntax/DeserializeFile.swift
@@ -6,7 +6,7 @@
 import StdlibUnittest
 import Foundation
 import SwiftSyntax
-import SwiftSourceKit
+import SwiftLang
 
 func getInput(_ file: String) -> URL {
   var result = URL(fileURLWithPath: #file)
@@ -20,7 +20,7 @@ var DecodeTests = TestSuite("DecodeSyntax")
 
 DecodeTests.test("Basic") {
   expectDoesNotThrow({
-    let content = try SourceFileSyntax.encodeSourceFileSyntax(getInput("visitor.swift"))
+    let content = try SwiftLang.parse(getInput("visitor.swift"))
     let source = try String(contentsOf: getInput("visitor.swift"))
     let parsed = try SourceFileSyntax.decodeSourceFileSyntax(content)
     expectEqual("\(parsed)", source)

--- a/test/SwiftSyntax/ParseFile.swift
+++ b/test/SwiftSyntax/ParseFile.swift
@@ -6,7 +6,7 @@
 import Foundation
 import StdlibUnittest
 import SwiftSyntax
-import SwiftSourceKit
+import SwiftLang
 
 var ParseFile = TestSuite("ParseFile")
 
@@ -32,7 +32,7 @@ ParseFile.test("ParseSingleFile") {
   expectDoesNotThrow({
     let currentFileContents = try String(contentsOf: currentFile)
     let parsed = try SourceFileSyntax.decodeSourceFileSyntax(try
-      SourceKitdService.encodeSourceFileSyntax(currentFile))
+      SwiftLang.parse(currentFile))
     expectEqual("\(parsed)", currentFileContents)
   })
 }

--- a/test/SwiftSyntax/VisitorTest.swift
+++ b/test/SwiftSyntax/VisitorTest.swift
@@ -6,7 +6,7 @@
 import StdlibUnittest
 import Foundation
 import SwiftSyntax
-import SwiftSourceKit
+import SwiftLang
 
 func getInput(_ file: String) -> URL {
   var result = URL(fileURLWithPath: #file)
@@ -28,7 +28,7 @@ VisitorTests.test("Basic") {
   }
   expectDoesNotThrow({
     let parsed = try SourceFileSyntax.decodeSourceFileSyntax(try
-      SourceKitdService.encodeSourceFileSyntax(getInput("visitor.swift")))
+      SwiftLang.parse(getInput("visitor.swift")))
     let counter = FuncCounter()
     let hashBefore = parsed.hashValue
     counter.visit(parsed)

--- a/tools/SwiftSourceKitClient/CMakeLists.txt
+++ b/tools/SwiftSourceKitClient/CMakeLists.txt
@@ -2,7 +2,8 @@ set(EXTRA_COMPILE_FLAGS "-F" "${SWIFT_LIBRARY_OUTPUT_INTDIR}")
 set(EXTRA_LINKER_FLAGS "-Xlinker" "-rpath" "-Xlinker" "${SWIFT_LIBRARY_OUTPUT_INTDIR}"
     "-Xlinker" "-F" "-Xlinker" "${SWIFT_LIBRARY_OUTPUT_INTDIR}")
 
-add_swift_library(swiftSwiftSourceKit SHARED
+add_swift_library(swiftSwiftLang SHARED
+  SwiftLang.swift
   SourceKitdClient.swift
   SourceKitdRequest.swift
   SourceKitdResponse.swift

--- a/tools/SwiftSourceKitClient/SourceKitdClient.swift
+++ b/tools/SwiftSourceKitClient/SourceKitdClient.swift
@@ -27,22 +27,3 @@ public class SourceKitdService {
     return SourceKitdResponse(resp: sourcekitd_send_request_sync(request.rawRequest))
   }
 }
-
-extension SourceKitdService {
-  /// Parses the Swift file at the provided URL into a `Syntax` tree in Json
-  /// serialization format by querying SourceKitd service.
-  /// - Parameter url: The URL you wish to parse.
-  /// - Returns: The syntax tree in Json format string.
-  public static func encodeSourceFileSyntax(_ url: URL) throws -> String {
-    let Service = SourceKitdService()
-    let Request = SourceKitdRequest(uid: .source_request_editor_open)
-    let Path = url.path
-    Request.addParameter(.key_sourcefile, value: Path)
-    Request.addParameter(.key_name, value: Path)
-    Request.addParameter(.key_enable_syntax_tree, value: 1)
-
-    // FIXME: SourceKitd error handling.
-    let Resp = Service.sendSyn(request: Request)
-    return Resp.value.getString(.key_serialized_syntax_tree)
-  }
-}

--- a/tools/SwiftSourceKitClient/SwiftLang.swift
+++ b/tools/SwiftSourceKitClient/SwiftLang.swift
@@ -1,0 +1,35 @@
+//===--------------------- SwiftLang.swift -------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+// This file provides Swift language support by invoking SourceKit internally.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+public class SwiftLang {
+
+  /// Parses the Swift file at the provided URL into a `Syntax` tree in Json
+  /// serialization format by querying SourceKitd service.
+  /// - Parameter url: The URL you wish to parse.
+  /// - Returns: The syntax tree in Json format string.
+  public static func parse(_ url: URL) throws -> String {
+    let Service = SourceKitdService()
+    let Request = SourceKitdRequest(uid: .source_request_editor_open)
+    let Path = url.path
+    Request.addParameter(.key_sourcefile, value: Path)
+    Request.addParameter(.key_name, value: Path)
+    Request.addParameter(.key_enable_syntax_tree, value: 1)
+
+    // FIXME: SourceKitd error handling.
+    let Resp = Service.sendSyn(request: Request)
+    return Resp.value.getString(.key_serialized_syntax_tree)
+  }
+}


### PR DESCRIPTION
The sourcekitd client library provides parsing APIs for SwiftSyntax users.
The internal use of sourcekit service is an implementation detail that end users
shouldn't worry about.
