### PR TITLE
[Parse] Support `#if swift(<4.1)`

### DIFF
--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -152,6 +152,7 @@ public:
 };
 
 bool operator>=(const Version &lhs, const Version &rhs);
+bool operator<(const Version &lhs, const Version &rhs);
 bool operator==(const Version &lhs, const Version &rhs);
 inline bool operator!=(const Version &lhs, const Version &rhs) {
   return !(lhs == rhs);

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -384,6 +384,11 @@ bool operator>=(const class Version &lhs,
   return true;
 }
 
+bool operator<(const class Version &lhs,
+               const class Version &rhs) {
+    return !(lhs >= rhs);
+}
+
 bool operator==(const class Version &lhs,
                 const class Version &rhs) {
   auto n = std::max(lhs.size(), rhs.size());

--- a/test/Parse/ConditionalCompilation/language_version_explicit.swift
+++ b/test/Parse/ConditionalCompilation/language_version_explicit.swift
@@ -37,3 +37,46 @@
   let c = 1
 #endif
 // NOTE: ...the next time the version goes up.
+
+#if swift(<4)
+  // This shouldn't emit any diagnostics.
+  asdf asdf asdf asdf
+#else
+  let a = 1
+#endif
+
+#if !swift(<4)
+  let b = 1
+#else
+  // This shouldn't emit any diagnostics.
+  asdf asdf asdf asdf
+#endif
+
+#if swift(<4.0)
+  // This shouldn't emit any diagnostics.
+  asdf asdf asdf asdf
+#else
+  let c = 1
+#endif
+
+#if swift(<4.0.0)
+  // This shouldn't emit any diagnostics.
+  asdf asdf asdf asdf
+#else
+  let d = 1
+#endif
+
+#if swift(<4.0.1)
+  // This shouldn't emit any diagnostics.
+  asdf asdf asdf asdf
+#else
+  let e = 1
+#endif
+
+#if swift(<99)
+  let f = 1
+#else
+  // This shouldn't emit any diagnostics.
+  asdf asdf asdf asdf
+#endif
+


### PR DESCRIPTION
Add the ability to specify conditional compilation using `<` in addition to the currently supported `>=` unary prefix. `#if swift(<4.1)` is equivalent to `#if !swift(>=4.1)`.

Resolves #49401.