### PR TITLE
cmpcodesize: fix the sign of the percentage change.

### DIFF
--- a/utils/cmpcodesize/cmpcodesize/compare.py
+++ b/utils/cmpcodesize/cmpcodesize/compare.py
@@ -163,7 +163,7 @@ def compare_sizes(old_sizes, new_sizes, name_key, title, total_size_key="",
     if old_size is not None and new_size is not None:
         if old_size != 0:
             perc = "%.1f%%" % (
-                (1.0 - float(new_size) / float(old_size)) * 100.0)
+                (float(new_size) / float(old_size) - 1.0) * 100.0)
         else:
             perc = "- "
 


### PR DESCRIPTION
The formula for percentage change in _any_ metric, without exception, is:

(new_value - old_value) / old_value

Some people flip the sign of their result, presumably because they
associate "positive" with "good" or want to render a graph where
"upward" bars are "good". Making this mistake consistently leads to
tremendous confusion.

This is particularly horrible when people confuse time and speed,
which are inverse metrics. Flipping the sign in order to present the
inverse metric is commonly done, but is mathematically incorrect and
is often extremely misleading. That's why it's so important to use a
standard (mathematically correct) convention for reporting a change in
percentage of any metric.

So, if I triple the size of the code, I'll now see +200%, not -200% which is
mathematically impossible and shear nonsense.
