### PR TITLE
[build-script] Use a single-threaded runner for the lldb tests

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2810,6 +2810,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     LLDB_TEST_DEBUG_SERVER=""
                 fi
 
+		# rdar://37173570: dotest's multiprocess runner is not reliable, use --no-multiprocess for now.
                 call mkdir -p "${results_dir}"
                 with_pushd "${results_dir}" \
                            call env SWIFTCC="$(build_directory $LOCAL_HOST swift)/bin/swiftc" \
@@ -2820,6 +2821,7 @@ for host in "${ALL_HOSTS[@]}"; do
                            ${LLDB_TEST_SUBDIR_CLAUSE} \
                            ${LLDB_TEST_CATEGORIES} \
                            ${LLDB_DOTEST_CC_OPTS} \
+                           --no-multiprocess \
                            ${LLDB_FORMATTER_OPTS}
                 continue
                 ;;


### PR DESCRIPTION
The multithreaded runner has been reported to issue "Connection refused"
failures for unclear reasons.

rdar://37173570