### PR TITLE
build: avoid incremental links with link.exe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,6 +376,10 @@ if(SWIFT_BUILT_STANDALONE)
   project(Swift C CXX ASM)
 endif()
 
+if(MSVC OR "${CMAKE_SIMULATE_ID}" STREQUAL MSVC)
+  include(ClangClCompileRules)
+endif()
+
 precondition(CMAKE_SYSTEM_NAME)
 if("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
   set(SWIFT_BUILD_SOURCEKIT_default TRUE)

--- a/cmake/modules/ClangClCompileRules.cmake
+++ b/cmake/modules/ClangClCompileRules.cmake
@@ -1,0 +1,17 @@
+
+# clang-cl interprets paths starting with /U as macro undefines, so we need to
+# put a -- before the input file path to force it to be treated as a path.
+string(REPLACE "-c <SOURCE>" "-c -- <SOURCE>" CMAKE_C_COMPILE_OBJECT "${CMAKE_C_COMPILE_OBJECT}")
+string(REPLACE "-c <SOURCE>" "-c -- <SOURCE>" CMAKE_CXX_COMPILE_OBJECT "${CMAKE_CXX_COMPILE_OBJECT}")
+
+# NOTE(compnerd) incremental linking is known to cause corruption in the
+# protocol conformance tables.  Avoid using incremental links with Visual
+# Studio.
+foreach(TYPE EXE SHARED MODULE)
+  foreach(BUILD DEBUG RELWITHDEBINFO)
+    string(REPLACE "/INCREMENTAL:YES" "" CMAKE_${TYPE}_LINKER_FLAGS_${BUILD} "${CMAKE_${TYPE}_LINKER_FLAGS_${BUILD}}")
+    string(REPLACE "/INCREMENTAL" "" CMAKE_${TYPE}_LINKER_FLAGS_${BUILD} "${CMAKE_${TYPE}_LINKER_FLAGS_${BUILD}}")
+    set(CMAKE_${TYPE}_LINKER_FLAGS_${BUILD} ${CMAKE_${TYPE}_LINKER_FLAGS_${BUILD}} CACHE STRING "Flags used by the linker during builds." FORCE)
+  endforeach()
+endforeach()
+


### PR DESCRIPTION
This is a workaround for Visual Studio's link causing corruption with
incremental linking.  The markers for the metadata are padded out
incorrectly, resulting in load time failures.  With this, it is possible
to link with link and use the generated binaries on Windows x86_64.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
