### PR TITLE
Don't consider external functions in inter-procedural analysis, like …

### DIFF
--- a/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
@@ -31,6 +31,11 @@ bool CalleeList::allCalleesVisible() {
   for (SILFunction *Callee : *this) {
     if (Callee->isExternalDeclaration())
       return false;
+    // Do not consider functions in other modules (libraries) because of library
+    // evolution: such function may behave differently in future/past versions
+    // of the library.
+    if (Callee->isAvailableExternally())
+      return false;
   }
   return true;
 }

--- a/test/SILOptimizer/escape_analysis.sil
+++ b/test/SILOptimizer/escape_analysis.sil
@@ -1477,3 +1477,25 @@ sil_vtable X {
 sil_vtable Z {
   #Z.deinit!deallocator: @$S4main1ZCfD
 }
+
+
+sil public_external @public_external_func : $@convention(thin) (@owned X) -> () {
+bb0(%0 : $X):
+  strong_release %0 : $X
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: CG of call_public_external_func
+// CHECK:        Val %0 Esc: G, Succ: (%0.1)
+// CHECK:        Con %0.1 Esc: G, Succ: 
+// CHECKL:      End
+sil @call_public_external_func : $@convention(thin) () -> () {
+bb0:
+  %0 = alloc_ref $X
+  %1 = function_ref @public_external_func : $@convention(thin) (@owned X) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (@owned X) -> ()
+  %7 = tuple ()
+  return %7 : $()
+}
+

--- a/test/SILOptimizer/side-effect.sil
+++ b/test/SILOptimizer/side-effect.sil
@@ -489,3 +489,20 @@ bb0(%0 : $*Int32):
 }
 
 sil @closure : $@convention(thin) (Bool, @in Int32) -> Int32
+
+sil public_external @public_external_func : $@convention(thin) () -> () {
+bb0:
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @call_public_external_func
+// CHECK-NEXT: <func=rw+-;alloc;trap;readrc>
+sil @call_public_external_func : $@convention(thin) () -> () {
+bb0:
+  %u = function_ref @public_external_func : $@convention(thin) () -> ()
+  %a = apply %u() : $@convention(thin) () -> ()
+  %r = tuple ()
+  return %r : $()
+}
+


### PR DESCRIPTION
…side-effect or escape analysis.

The behavior of functions in other libraries may change in past/future versions of the library. So the compiler should not make any assumptions about them.

rdar://problem/32275048
