### PR TITLE
master-next: Update DebugInfo/Imports.swift test to match LLVM r324270

### DIFF
--- a/test/DebugInfo/Imports.swift
+++ b/test/DebugInfo/Imports.swift
@@ -31,4 +31,4 @@ markUsed(basic.foo(1, 2))
 
 // DWARF-NOT: "Swift.Optional"
 
-// DWARF-DAG: file_names{{.*}} Imports.swift
+// DWARF-DAG: file_names{{.*}} "Imports.swift"


### PR DESCRIPTION
The change in LLVM r324270 wraps the file name in double quotes. Update
the expected output to match.