### PR TITLE
Add a -verify-exclusivity option.

### DIFF
--- a/include/swift/AST/SILOptions.h
+++ b/include/swift/AST/SILOptions.h
@@ -140,6 +140,9 @@ public:
   /// Emit checks to trap at run time when the law of exclusivity is violated.
   bool EnforceExclusivityDynamic = true;
 
+  /// Emit extra exclusvity markers for memory access and verify coverage.
+  bool VerifyExclusivity = false;
+
   /// Enable the mandatory semantic arc optimizer.
   bool EnableMandatorySemanticARCOpts = false;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -457,4 +457,10 @@ def fix_string_substring_conversion: Flag<["-"], "fix-string-substring-conversio
 def bypass_batch_mode_checks: Flag<["-"], "bypass-batch-mode-checks">,
     HelpText<"Bypass checks for batch-mode errors.">;
 
+def enable_verify_exclusivity : Flag<["-"], "enable-verify-exclusivity">,
+  HelpText<"Enable verification of access markers used to enforce exclusivity.">;
+
+def disable_verify_exclusivity : Flag<["-"], "disable-verify-exclusivity">,
+  HelpText<"Diable verification of access markers used to enforce exclusivity.">;
+
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -139,6 +139,13 @@ struct LLVM_LIBRARY_VISIBILITY FindClosureResult {
 /// by a reabstraction thunk.
 FindClosureResult findClosureForAppliedArg(SILValue V);
 
+/// Visit each address accessed by the given memory operation.
+///
+/// This only visits instructions that modify memory in some user-visible way,
+/// which could be considered part of a formal access.
+void visitAccessedAddress(SILInstruction *I,
+                          std::function<void(Operand *)> visitor);
+
 /// A utility class for evaluating whether a newly parsed or deserialized
 /// function has qualified or unqualified ownership.
 ///

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -3345,17 +3345,17 @@ class AssignInst
                              NonValueInstruction> {
   friend SILBuilder;
 
+  FixedOperandList<2> Operands;
+
+  AssignInst(SILDebugLocation DebugLoc, SILValue Src, SILValue Dest);
+
+public:
   enum {
     /// the value being stored
     Src,
     /// the lvalue being stored to
     Dest
   };
-  FixedOperandList<2> Operands;
-
-  AssignInst(SILDebugLocation DebugLoc, SILValue Src, SILValue Dest);
-
-public:
 
   SILValue getSrc() const { return Operands[Src].get(); }
   SILValue getDest() const { return Operands[Dest].get(); }
@@ -3767,8 +3767,6 @@ class BindMemoryInst final :
                                           BindMemoryInst, NonValueInstruction> {
   friend SILBuilder;
 
-  enum { BaseOperIdx, IndexOperIdx, NumFixedOpers };
-
   SILType BoundType;
 
   static BindMemoryInst *create(
@@ -3782,6 +3780,8 @@ class BindMemoryInst final :
                                           Loc), BoundType(BoundType) {}
 
 public:
+  enum { BaseOperIdx, IndexOperIdx, NumFixedOpers };
+
   SILValue getBase() const { return getAllOperands()[BaseOperIdx].get(); }
 
   SILValue getIndex() const { return getAllOperands()[IndexOperIdx].get(); }
@@ -7240,12 +7240,6 @@ class CheckedCastAddrBranchInst
 
   CastConsumptionKind ConsumptionKind;
 
-  enum {
-    /// the value being stored
-    Src,
-    /// the lvalue being stored to
-    Dest
-  };
   FixedOperandList<2> Operands;
   SILSuccessor DestBBs[2];
 
@@ -7264,6 +7258,13 @@ class CheckedCastAddrBranchInst
         SourceType(srcType), TargetType(targetType) {}
 
 public:
+  enum {
+    /// the value being stored
+    Src,
+    /// the lvalue being stored to
+    Dest
+  };
+
   CastConsumptionKind getConsumptionKind() const { return ConsumptionKind; }
 
   SILValue getSrc() const { return Operands[Src].get(); }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -698,7 +698,12 @@ static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,
     IRGenOpts.Sanitizers = Opts.Sanitizers;
   }
 
-  if (Opts.shouldOptimize())
+  if (auto A = Args.getLastArg(OPT_enable_verify_exclusivity,
+                               OPT_disable_verify_exclusivity)) {
+    Opts.VerifyExclusivity
+      = A->getOption().matches(OPT_enable_verify_exclusivity);
+  }
+  if (Opts.shouldOptimize() && !Opts.VerifyExclusivity)
     Opts.EnforceExclusivityDynamic = false;
   if (const Arg *A = Args.getLastArg(options::OPT_enforce_exclusivity_EQ)) {
     parseExclusivityEnforcementOptions(A, Opts, Diags);

--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -303,18 +303,34 @@ static bool isLetAccess(SILValue address) {
     return false;
 
   case ValueKind::AllocStackInst: {
-    auto *decl = cast<AllocStackInst>(address)->getDecl();
+    VarDecl *decl = cast<AllocStackInst>(address)->getDecl();
     return decl && decl->isLet();
   }
   case ValueKind::AllocBoxInst: {
-    auto *decl = cast<AllocBoxInst>(address)->getDecl();
+    VarDecl *decl = cast<AllocBoxInst>(address)->getDecl();
+    return decl && decl->isLet();
+  }
+  case ValueKind::RefElementAddrInst: {
+    VarDecl *decl = cast<RefElementAddrInst>(address)->getField();
     return decl && decl->isLet();
   }
   case ValueKind::GlobalAddrInst: {
-    auto *global = cast<GlobalAddrInst>(address)->getReferencedGlobal();
+    SILGlobalVariable *global =
+        cast<GlobalAddrInst>(address)->getReferencedGlobal();
     return global && global->isLet();
   }
   };
+}
+
+// An address base is a block argument. Verify that it is actually a box
+// projected from a switch_enum.
+static void checkSwitchEnumBlockArg(SILPHIArgument *arg) {
+  assert(!arg->getType().isAddress());
+  SILBasicBlock *Pred = arg->getParent()->getSinglePredecessorBlock();
+  if (!Pred || !isa<SwitchEnumInst>(Pred->getTerminator())) {
+    arg->dump();
+    llvm_unreachable("unexpected box source.");
+  }
 }
 
 SILValue swift::findAccessedAddressBase(SILValue sourceAddr) {
@@ -346,15 +362,23 @@ SILValue swift::findAccessedAddressBase(SILValue sourceAddr) {
 
     // A block argument may be a box value projected out of
     // switch_enum. Address-type block arguments are not allowed.
-    case ValueKind::SILPHIArgument: {
-      assert(!address->getType().isAddress());
-      SILBasicBlock *Pred =
-        cast<SILPHIArgument>(address)->getParent()->getSinglePredecessorBlock();
-      if (!Pred || !isa<SwitchEnumInst>(Pred->getTerminator())) {
-        address->dump();
-        llvm_unreachable("unexpected box source.");
-      }
+    case ValueKind::SILPHIArgument:
+      checkSwitchEnumBlockArg(cast<SILPHIArgument>(address));
       return address;
+
+    // Load a box from an indirect payload of an opaque enum.
+    // We must have peeked past the project_box earlier in this loop.
+    // (the indirectness makes it a box, the load is for address-only).
+    // 
+    // %payload_adr = unchecked_take_enum_data_addr %enum : $*Enum, #Enum.case
+    // %box = load [take] %payload_adr : $*{ var Enum }
+    //
+    // FIXME: this case should go away with opaque values.
+    case ValueKind::LoadInst: {
+      assert(address->getType().is<SILBoxType>());
+      address = cast<LoadInst>(address)->getOperand();
+      assert(isa<UncheckedTakeEnumDataAddrInst>(address));
+      continue;
     }
     // Inductive cases:
     // Look through address casts to find the source address.
@@ -365,8 +389,9 @@ SILValue swift::findAccessedAddressBase(SILValue sourceAddr) {
     case ValueKind::CopyValueInst:
     case ValueKind::MarkDependenceInst:
     // Look through a project_box to identify the underlying alloc_box as the
-    // accesed object. It must be possible to reach the alloc_box in this loop,
-    // only looking through simple value propagation such as copy_value.
+    // accesed object. It must be possible to reach either the alloc_box or the
+    // containing enum in this loop, only looking through simple value
+    // propagation such as copy_value.
     case ValueKind::ProjectBoxInst:
     // Handle project_block_storage just like project_box.
     case ValueKind::ProjectBlockStorageInst:
@@ -405,9 +430,20 @@ SILValue swift::findAccessedAddressBase(SILValue sourceAddr) {
 }
 
 bool swift::isPossibleFormalAccessBase(SILValue baseAddress) {
+  // A begin_access is considered a separate base for the purpose of conflict
+  // checking. However, for the purpose of inserting unenforced markers and
+  // performaing verification, it needs to be ignored.
+  while (auto *beginAccess = dyn_cast<BeginAccessInst>(baseAddress))
+    baseAddress = beginAccess->getOperand();
+
   // Function arguments are accessed by the caller.
   if (isa<SILFunctionArgument>(baseAddress))
     return false;
+
+  if (isa<SILPHIArgument>(baseAddress)) {
+    checkSwitchEnumBlockArg(cast<SILPHIArgument>(baseAddress));
+    return false;
+  }
 
   // Pointer-to-address exclusivity cannot be enforced. `baseAddress` may be
   // pointing anywhere within an object.
@@ -523,6 +559,221 @@ FindClosureResult swift::findClosureForAppliedArg(SILValue V) {
   }
   return FindClosureResult(PAI, false);
 }
+
+/// Helper for visitApplyAccesses that visits address-type call arguments,
+/// including arguments to @noescape functions that are passed as closures to
+/// the current call.
+static void visitApplyAccesses(ApplySite apply,
+                               std::function<void(Operand *)> visitor) {
+  for (Operand &oper : apply.getArgumentOperands()) {
+    // Consider any address-type operand an access. Whether it is read or modify
+    // depends on the argument convention.
+    if (oper.get()->getType().isAddress()) {
+      visitor(&oper);
+      continue;
+    }
+    auto fnType = oper.get()->getType().getAs<SILFunctionType>();
+    if (!fnType || !fnType->isNoEscape())
+      continue;
+
+    // When @noescape function closures are passed as arguments, their
+    // arguments are considered accessed at the call site.
+    FindClosureResult result = findClosureForAppliedArg(oper.get());
+    if (!result.PAI)
+      continue;
+
+    // Recursively visit @noescape function closure arguments.
+    visitApplyAccesses(result.PAI, visitor);
+  }
+}
+
+void swift::visitAccessedAddress(SILInstruction *I,
+                                 std::function<void(Operand *)> visitor) {
+  assert(I->mayReadOrWriteMemory());
+
+  // Reference counting instructions do not access user visible memory.
+  if (isa<RefCountingInst>(I))
+    return;
+
+  if (isa<DeallocationInst>(I))
+    return;
+
+  if (auto apply = FullApplySite::isa(I)) {
+    visitApplyAccesses(apply, visitor);
+    return;
+  }
+
+  if (auto builtin = dyn_cast<BuiltinInst>(I)) {
+    if (auto Kind = builtin->getBuiltinKind()) {
+      switch (Kind.getValue()) {
+      default:
+        I->dump();
+        llvm_unreachable("unexpected bulitin memory access.");
+
+      // Buitins that affect memory but can't be formal accesses.
+      case BuiltinValueKind::UnexpectedError:
+      case BuiltinValueKind::ErrorInMain:
+      case BuiltinValueKind::IsOptionalType:
+      case BuiltinValueKind::AllocRaw:
+      case BuiltinValueKind::DeallocRaw:
+      case BuiltinValueKind::Fence:
+      case BuiltinValueKind::StaticReport:
+      case BuiltinValueKind::Once:
+      case BuiltinValueKind::OnceWithContext:
+      case BuiltinValueKind::Unreachable:
+      case BuiltinValueKind::CondUnreachable:
+      case BuiltinValueKind::DestroyArray:
+      case BuiltinValueKind::UnsafeGuaranteed:
+      case BuiltinValueKind::UnsafeGuaranteedEnd:
+      case BuiltinValueKind::Swift3ImplicitObjCEntrypoint:
+      case BuiltinValueKind::TSanInoutAccess:
+        return;
+
+      // General memory access to a pointer in first operand position.
+      case BuiltinValueKind::CmpXChg:
+      case BuiltinValueKind::AtomicLoad:
+      case BuiltinValueKind::AtomicStore:
+      case BuiltinValueKind::AtomicRMW:
+        // Currently ignored because the access is on a RawPointer, not a
+        // SIL address.
+        // visitor(&builtin->getAllOperands()[0]);
+        return;
+
+      // Arrays: (T.Type, Builtin.RawPointer, Builtin.RawPointer,
+      // Builtin.Word)
+      case BuiltinValueKind::CopyArray:
+      case BuiltinValueKind::TakeArrayNoAlias:
+      case BuiltinValueKind::TakeArrayFrontToBack:
+      case BuiltinValueKind::TakeArrayBackToFront:
+      case BuiltinValueKind::AssignCopyArrayNoAlias:
+      case BuiltinValueKind::AssignCopyArrayFrontToBack:
+      case BuiltinValueKind::AssignCopyArrayBackToFront:
+      case BuiltinValueKind::AssignTakeArray:
+        // Currently ignored because the access is on a RawPointer.
+        // visitor(&builtin->getAllOperands()[1]);
+        // visitor(&builtin->getAllOperands()[2]);
+        return;
+      }
+    }
+    if (auto ID = builtin->getIntrinsicID()) {
+      switch (ID.getValue()) {
+      // Exhaustively verifying all LLVM instrinsics that access memory is
+      // impractical. Instead, we call out the few common cases and return in
+      // the default case.
+      default:
+        return;
+      case llvm::Intrinsic::memcpy:
+      case llvm::Intrinsic::memmove:
+        // Currently ignored because the access is on a RawPointer.
+        // visitor(&builtin->getAllOperands()[0]);
+        // visitor(&builtin->getAllOperands()[1]);
+        return;
+      case llvm::Intrinsic::memset:
+        // Currently ignored because the access is on a RawPointer.
+        // visitor(&builtin->getAllOperands()[0]);
+        return;
+      }
+    }
+    llvm_unreachable("Must be either a builtin or intrinsic.");
+  }
+
+  switch (I->getKind()) {
+  default:
+    I->dump();
+    llvm_unreachable("unexpected memory access.");
+
+  case SILInstructionKind::AssignInst:
+    visitor(&I->getAllOperands()[AssignInst::Dest]);
+    return;
+
+  case SILInstructionKind::CheckedCastAddrBranchInst:
+    visitor(&I->getAllOperands()[CheckedCastAddrBranchInst::Src]);
+    visitor(&I->getAllOperands()[CheckedCastAddrBranchInst::Dest]);
+    return;
+
+  case SILInstructionKind::CopyAddrInst:
+    visitor(&I->getAllOperands()[CopyAddrInst::Src]);
+    visitor(&I->getAllOperands()[CopyAddrInst::Dest]);
+    return;
+
+  case SILInstructionKind::StoreInst:
+  case SILInstructionKind::StoreBorrowInst:
+  case SILInstructionKind::StoreUnownedInst:
+  case SILInstructionKind::StoreWeakInst:
+    visitor(&I->getAllOperands()[StoreInst::Dest]);
+    return;
+
+  case SILInstructionKind::SelectEnumAddrInst:
+    visitor(&I->getAllOperands()[0]);
+    return;
+
+  case SILInstructionKind::InitExistentialAddrInst:
+  case SILInstructionKind::InjectEnumAddrInst:
+  case SILInstructionKind::LoadInst:
+  case SILInstructionKind::LoadBorrowInst:
+  case SILInstructionKind::LoadWeakInst:
+  case SILInstructionKind::LoadUnownedInst:
+  case SILInstructionKind::OpenExistentialAddrInst:
+  case SILInstructionKind::SwitchEnumAddrInst:
+  case SILInstructionKind::UncheckedTakeEnumDataAddrInst:
+  case SILInstructionKind::UnconditionalCheckedCastInst: {
+    assert(I->getNumOperands() - I->getNumTypeDependentOperands() == 1);
+    Operand *singleOperand = &I->getAllOperands()[0];
+    if (singleOperand->get()->getType().isAddress())
+      visitor(singleOperand);
+    return;
+  }
+  // Non-access cases: these are marked with memory side effects, but, by
+  // themselves, do not access formal memory.
+  case SILInstructionKind::AbortApplyInst:
+  case SILInstructionKind::AllocBoxInst:
+  case SILInstructionKind::AllocExistentialBoxInst:
+  case SILInstructionKind::AllocGlobalInst:
+  case SILInstructionKind::BeginAccessInst:
+  case SILInstructionKind::BeginApplyInst:
+  case SILInstructionKind::BeginBorrowInst:
+  case SILInstructionKind::BeginUnpairedAccessInst:
+  case SILInstructionKind::BindMemoryInst:
+  case SILInstructionKind::CheckedCastValueBranchInst:
+  case SILInstructionKind::CondFailInst:
+  case SILInstructionKind::CopyBlockInst:
+  case SILInstructionKind::CopyValueInst:
+  case SILInstructionKind::CopyUnownedValueInst:
+  case SILInstructionKind::DeinitExistentialAddrInst:
+  case SILInstructionKind::DeinitExistentialValueInst:
+  case SILInstructionKind::DestroyAddrInst:
+  case SILInstructionKind::DestroyValueInst:
+  case SILInstructionKind::EndAccessInst:
+  case SILInstructionKind::EndApplyInst:
+  case SILInstructionKind::EndBorrowArgumentInst:
+  case SILInstructionKind::EndBorrowInst:
+  case SILInstructionKind::EndUnpairedAccessInst:
+  case SILInstructionKind::EndLifetimeInst:
+  case SILInstructionKind::ExistentialMetatypeInst:
+  case SILInstructionKind::FixLifetimeInst:
+  case SILInstructionKind::InitExistentialValueInst:
+  case SILInstructionKind::IsUniqueInst:
+  case SILInstructionKind::IsUniqueOrPinnedInst:
+  case SILInstructionKind::KeyPathInst:
+  case SILInstructionKind::OpenExistentialBoxInst:
+  case SILInstructionKind::OpenExistentialBoxValueInst:
+  case SILInstructionKind::OpenExistentialValueInst:
+  case SILInstructionKind::PartialApplyInst:
+  case SILInstructionKind::ProjectValueBufferInst:
+  case SILInstructionKind::StrongPinInst:
+  case SILInstructionKind::YieldInst:
+  case SILInstructionKind::UnwindInst:
+  case SILInstructionKind::UncheckedOwnershipConversionInst:
+  case SILInstructionKind::UncheckedRefCastAddrInst:
+  case SILInstructionKind::UnconditionalCheckedCastAddrInst:
+  case SILInstructionKind::UnconditionalCheckedCastValueInst:
+  case SILInstructionKind::UnownedReleaseInst:
+  case SILInstructionKind::UnownedRetainInst:
+  case SILInstructionKind::ValueMetatypeInst:
+    return;
+  }
+}
+
 namespace {
 
 enum class OwnershipQualifiedKind {

--- a/lib/SILGen/FormalEvaluation.h
+++ b/lib/SILGen/FormalEvaluation.h
@@ -71,6 +71,10 @@ protected:
   virtual void finishImpl(SILGenFunction &SGF) = 0;
 };
 
+// FIXME: Misnomer. This is not used for borrowing a formal memory location
+// (ExclusiveBorrowFormalAccess is always used for that). This is only used for
+// formal access from a +0 value, which requires producing a "borrowed"
+// SILValue.
 class SharedBorrowFormalAccess : public FormalAccess {
   SILValue originalValue;
   SILValue borrowedValue;

--- a/lib/SILGen/FormalEvaluation.h
+++ b/lib/SILGen/FormalEvaluation.h
@@ -26,7 +26,7 @@ class LogicalPathComponent;
 
 class FormalAccess {
 public:
-  enum Kind { Shared, Exclusive, Owned };
+  enum Kind { Shared, Exclusive, Owned, Unenforced };
 
 private:
   unsigned allocatedSize;

--- a/lib/SILGen/Initialization.h
+++ b/lib/SILGen/Initialization.h
@@ -235,7 +235,6 @@ public:
   void finishUninitialized(SILGenFunction &SGF) override {}
 };
 
-/// Abstract base class for single-buffer initializations.
 class TemporaryInitialization : public SingleBufferInitialization {
   SILValue Addr;
   CleanupHandle Cleanup;

--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -500,6 +500,8 @@ public:
   ~InOutConversionScope();
 };
 
+// FIXME: Misnomer. This class is used for both shared (read) and exclusive
+// (modify) formal borrows.
 struct LLVM_LIBRARY_VISIBILITY ExclusiveBorrowFormalAccess : FormalAccess {
   std::unique_ptr<LogicalPathComponent> component;
   ManagedValue base;

--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -535,6 +535,62 @@ struct LLVM_LIBRARY_VISIBILITY ExclusiveBorrowFormalAccess : FormalAccess {
   }
 };
 
+struct LLVM_LIBRARY_VISIBILITY UnenforcedAccess {
+  // Make sure someone called `endAccess` before destroying this.
+  struct DeleterCheck {
+    void operator()(BeginAccessInst *) {
+      llvm_unreachable("access scope must be ended");
+    }
+  };
+  typedef std::unique_ptr<BeginAccessInst, DeleterCheck> BeginAccessPtr;
+  BeginAccessPtr beginAccessPtr;
+
+  UnenforcedAccess() = default;
+  UnenforcedAccess(const UnenforcedAccess &other) = delete;
+  UnenforcedAccess(UnenforcedAccess &&other) = default;
+
+  UnenforcedAccess &operator=(const UnenforcedAccess &) = delete;
+  UnenforcedAccess &operator=(UnenforcedAccess &&other) = default;
+
+  // Return the a new begin_access if it was required, otherwise return the
+  // given `address`.
+  SILValue beginAccess(SILGenFunction &SGF, SILLocation loc, SILValue address,
+                       SILAccessKind kind);
+
+  // End the access and release beginAccessPtr.
+  void endAccess(SILGenFunction &SGF);
+
+  // Emit the end_access (on a branch) without marking this access as ended.
+  void emitEndAccess(SILGenFunction &SGF);
+};
+
+/// Pseudo-formal access that emits access markers but does not actually
+/// require enforcement. It may be used for access to formal memory that is
+/// exempt from exclusivity checking, such as initialization, or it may be used
+/// for accesses to local memory that are indistinguishable from formal access
+/// at the SIL level. Adding the access markers in these cases gives SIL address
+/// users a structural property that allows for exhaustive verification.
+struct LLVM_LIBRARY_VISIBILITY UnenforcedFormalAccess : FormalAccess {
+
+  static SILValue enter(SILGenFunction &SGF, SILLocation loc, SILValue address,
+                        SILAccessKind kind);
+
+  // access.beginAccessPtr is either the begin_access or null if no access was
+  // required.
+  UnenforcedAccess access;
+
+  UnenforcedFormalAccess(SILLocation loc, UnenforcedAccess &&access,
+                         CleanupHandle cleanup)
+      : FormalAccess(sizeof(*this), FormalAccess::Unenforced, loc, cleanup),
+        access(std::move(access)) {}
+
+  // Emit the end_access (on a branch) without marking this access as ended.
+  void emitEndAccess(SILGenFunction &SGF);
+
+  // Only called at the end formal evaluation scope. End this access.
+  void finishImpl(SILGenFunction &SGF) override;
+};
+
 } // namespace Lowering
 } // namespace swift
 

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -24,6 +24,7 @@
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/DiagnosticsCommon.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILUndef.h"
@@ -52,7 +53,7 @@ struct LValueWritebackCleanup : Cleanup {
   void dump(SILGenFunction &) const override {
 #ifndef NDEBUG
     llvm::errs() << "LValueWritebackCleanup\n"
-                 << "State: " << getState() << "Depth: " << Depth.getDepth()
+                 << "State: " << getState() << " Depth: " << Depth.getDepth()
                  << "\n";
 #endif
   }
@@ -266,6 +267,13 @@ ManagedValue LogicalPathComponent::getMaterialized(SILGenFunction &SGF,
 
   ManagedValue temp = std::move(*this).materializeIntoTemporary(SGF, loc, base);
 
+  if (SGF.getOptions().VerifyExclusivity) {
+    // Begin an access of the temporary. It is unenforced because enforcement
+    // isn't required for RValues.
+    SILValue accessAddress = UnenforcedFormalAccess::enter(
+        SGF, loc, temp.getValue(), SILAccessKind::Modify);
+    temp = std::move(temp).transform(accessAddress);
+  }
   // Push a writeback for the temporary.
   pushWriteback(SGF, loc, std::move(clonedComponent), base,
                 MaterializedLValue(temp));
@@ -473,6 +481,93 @@ static SILValue enterAccessScope(SILGenFunction &SGF, SILLocation loc,
                 MaterializedLValue());
 
   return addr;
+}
+
+// Find the base of the formal access at `address`. If the base requires an
+// access marker, then create a begin_access on `address`. Return the
+// address to be used for the access.
+//
+// FIXME: In order to generate more consistent and verifiable SIL patterns, or
+// subobject projections, create the access on the base address and recreate the
+// projection.
+SILValue UnenforcedAccess::beginAccess(SILGenFunction &SGF, SILLocation loc,
+                                       SILValue address, SILAccessKind kind) {
+  if (!SGF.getOptions().VerifyExclusivity)
+    return address;
+
+  SILValue base = findAccessedAddressBase(address);
+  if (!base || !isPossibleFormalAccessBase(base))
+    return address;
+
+  auto BAI =
+      SGF.B.createBeginAccess(loc, address, kind, SILAccessEnforcement::Unsafe);
+  beginAccessPtr = BeginAccessPtr(BAI, DeleterCheck());
+
+  return BAI;
+}
+
+void UnenforcedAccess::endAccess(SILGenFunction &SGF) {
+  emitEndAccess(SGF);
+  beginAccessPtr.release();
+}
+
+void UnenforcedAccess::emitEndAccess(SILGenFunction &SGF) {
+  if (!beginAccessPtr)
+    return;
+
+  SGF.B.createEndAccess(beginAccessPtr->getLoc(), beginAccessPtr.get(),
+                        /*abort*/ false);
+}
+
+// Emit an end_access marker when executing a cleanup (on a side branch).
+void UnenforcedFormalAccess::emitEndAccess(SILGenFunction &SGF) {
+  access.emitEndAccess(SGF);
+}
+
+// End the access when existing the FormalEvaluationScope.
+void UnenforcedFormalAccess::finishImpl(SILGenFunction &SGF) {
+  access.endAccess(SGF);
+}
+
+namespace {
+struct UnenforcedAccessCleanup : Cleanup {
+  FormalEvaluationContext::stable_iterator Depth;
+
+  UnenforcedAccessCleanup() : Depth() {}
+
+  void emit(SILGenFunction &SGF, CleanupLocation loc) override {
+    auto &evaluation = *SGF.FormalEvalContext.find(Depth);
+    assert(evaluation.getKind() == FormalAccess::Unenforced);
+    auto &formalAccess = static_cast<UnenforcedFormalAccess &>(evaluation);
+    formalAccess.emitEndAccess(SGF);
+  }
+
+  void dump(SILGenFunction &) const override {
+#ifndef NDEBUG
+    llvm::errs() << "UnenforcedAccessCleanup\n"
+                 << "State: " << getState() << " Depth: " << Depth.getDepth()
+                 << "\n";
+#endif
+  }
+};
+} // end anonymous namespace
+
+SILValue UnenforcedFormalAccess::enter(SILGenFunction &SGF, SILLocation loc,
+                                       SILValue address, SILAccessKind kind) {
+  assert(SGF.InFormalEvaluationScope);
+
+  UnenforcedAccess access;
+  SILValue accessAddress = access.beginAccess(SGF, loc, address, kind);
+  if (!access.beginAccessPtr)
+    return address;
+
+  auto &cleanup = SGF.Cleanups.pushCleanup<UnenforcedAccessCleanup>();
+  CleanupHandle handle = SGF.Cleanups.getTopCleanup();
+  auto &context = SGF.FormalEvalContext;
+  context.push<UnenforcedFormalAccess>(loc, std::move(access), handle);
+  cleanup.Depth = context.stable_begin();
+
+  return accessAddress;
 }
 
 namespace {
@@ -1259,6 +1354,7 @@ namespace {
         // indirectly.
         SILValue baseAddress;
         SILValue baseMetatype;
+        UnenforcedAccess baseAccess;
         if (base) {
           if (base.getType().isAddress()) {
             baseAddress = base.getValue();
@@ -1269,6 +1365,10 @@ namespace {
                                             baseFormalType);
 
             baseAddress = SGF.emitTemporaryAllocation(loc, base.getType());
+            // Create an unenforced formal access for the temporary base, which
+            // is passed @inout to the callback.
+            baseAddress = baseAccess.beginAccess(SGF, loc, baseAddress,
+                                                 SILAccessKind::Modify);
             if (base.getOwnershipKind() == ValueOwnershipKind::Guaranteed) {
               SGF.B.createStoreBorrow(loc, base.getValue(), baseAddress);
             } else {
@@ -1298,6 +1398,9 @@ namespace {
                             baseAddress,
                             baseMetatype
                           }, false);
+
+        if (baseAccess.beginAccessPtr)
+          baseAccess.endAccess(SGF);
       }
 
       // Continue.

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.cpp
@@ -1112,7 +1112,9 @@ void ElementUseCollector::collectClassSelfUses() {
   //   4) Potential escapes after super.init, if self is closed over.
   //
   // Handle each of these in turn.
-  for (auto *Op : MUI->getUses()) {
+  SmallVector<Operand *, 8> Uses(MUI->getUses());
+  while (!Uses.empty()) {
+    Operand *Op = Uses.pop_back_val();
     SILInstruction *User = Op->getUser();
 
     // Stores to self.
@@ -1148,6 +1150,14 @@ void ElementUseCollector::collectClassSelfUses() {
     // Ignore end_borrows. These can only come from us being the source of a
     // load_borrow.
     if (isa<EndBorrowInst>(User))
+      continue;
+
+    // Recurse through begin_access.
+    if (auto *beginAccess = dyn_cast<BeginAccessInst>(User)) {
+      Uses.append(beginAccess->getUses().begin(), beginAccess->getUses().end());
+      continue;
+    }
+    if (isa<EndAccessInst>(User))
       continue;
 
     // Loads of the box produce self, so collect uses from them.
@@ -1379,8 +1389,8 @@ void ElementUseCollector::collectClassSelfUses(
       continue;
     }
 
-    // Skip end_borrow.
-    if (isa<EndBorrowInst>(User))
+    // Skip end_borrow and end_access.
+    if (isa<EndBorrowInst>(User) || isa<EndAccessInst>(User))
       continue;
 
     // ref_element_addr P, #field lookups up a field.
@@ -1417,10 +1427,9 @@ void ElementUseCollector::collectClassSelfUses(
 
     // Look through begin_borrow, upcast, unchecked_ref_cast
     // and copy_value.
-    if (isa<BeginBorrowInst>(User) ||
-        isa<UpcastInst>(User) ||
-        isa<UncheckedRefCastInst>(User) ||
-        isa<CopyValueInst>(User)) {
+    if (isa<BeginBorrowInst>(User) || isa<BeginAccessInst>(User)
+        || isa<UpcastInst>(User) || isa<UncheckedRefCastInst>(User)
+        || isa<CopyValueInst>(User)) {
       auto value = cast<SingleValueInstruction>(User);
       std::copy(value->use_begin(), value->use_end(),
                 std::back_inserter(Worklist));
@@ -1498,12 +1507,22 @@ void DelegatingInitElementUseCollector::collectClassInitSelfUses() {
   //   4) Potential escapes after super.init, if self is closed over.
   // Handle each of these in turn.
   //
-  for (auto *Op : MUI->getUses()) {
+  SmallVector<Operand *, 8> Uses(MUI->getUses());
+  while (!Uses.empty()) {
+    Operand *Op = Uses.pop_back_val();
     SILInstruction *User = Op->getUser();
 
     // Ignore end_borrow. If we see an end_borrow it can only come from a
     // load_borrow from ourselves.
     if (isa<EndBorrowInst>(User))
+      continue;
+
+    // Recurse through begin_access.
+    if (auto *beginAccess = dyn_cast<BeginAccessInst>(User)) {
+      Uses.append(beginAccess->getUses().begin(), beginAccess->getUses().end());
+      continue;
+    }
+    if (isa<EndAccessInst>(User))
       continue;
 
     // Stores to self.

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -1076,6 +1076,96 @@ static void checkNoEscapePartialApply(PartialApplyInst *PAI) {
 }
 #endif
 
+// Check if the given memory instruction obviously initializes the memory
+// object at `root`. Initialization does not require exclusivity enforcement
+// because uninitialized variables can't be captured.
+static bool isSafeInitialization(SILInstruction *memInst, SILValue root) {
+  // Local variable initialization is already filtered out by the check for
+  // temporary buffer access. Handle globals.
+  if (auto *globalAddr = dyn_cast<GlobalAddrInst>(root)) {
+    // There doesn't seem to be a better way to check for initialization than
+    // scanning for the preceding alloc_global.
+    SILGlobalVariable *var = globalAddr->getReferencedGlobal();
+    auto I = globalAddr->getIterator();
+    auto beginI = globalAddr->getParent()->begin();
+    while (I != beginI) {
+      --I;
+      if (auto *allocGlobal = dyn_cast<AllocGlobalInst>(I)) {
+        if (allocGlobal->getReferencedGlobal() == var)
+          return true;
+      }
+      if (I->mayReadOrWriteMemory())
+        break;
+    }
+  }
+  return false;
+}
+
+// Check that the given address-type operand is guarded by begin/end access
+// markers.
+static void checkAccessedAddress(Operand *memOper, StorageMap &Accesses) {
+  SILValue address = memOper->get();
+  SILInstruction *memInst = memOper->getUser();
+
+  auto error = [address, memInst]() {
+    llvm::dbgs() << "Memory access not protected by begin_access:\n";
+    memInst->printInContext(llvm::dbgs());
+    llvm::dbgs() << "Accessing: " << address;
+    llvm::dbgs() << "In function:\n";
+    memInst->getFunction()->print(llvm::dbgs());
+    abort();
+  };
+
+  if (auto apply = ApplySite::isa(memInst)) {
+    SILArgumentConvention conv =
+        apply.getArgumentConvention(apply.getCalleeArgIndex(*memOper));
+    // Captured addresses currently use the @inout_aliasable convention. They
+    // are considered an access at any call site that uses the closure. However,
+    // those accesses are never explictly protected by access markers. Instead,
+    // exclusivity uses AccessSummaryAnalysis to check for conflicts. Here, we
+    // can simply ignore any @inout_aliasable arguments.
+    if (conv == SILArgumentConvention::Indirect_InoutAliasable)
+      return;
+
+    assert(!isa<PartialApplyInst>(memInst)
+           && "partial apply can only capture an address as inout_aliasable");
+    // TODO: We currently assume @in/@in_guaranteed are only used for
+    // pass-by-value arguments. i.e. the address points a local copy of the
+    // argument, which is only passed by address for abstraction
+    // reasons. However, in the future, @in_guaranteed may be used for
+    // borrowed values, which should be recognized as a formal read.
+    if (conv != SILArgumentConvention::Indirect_Inout)
+      return;
+  }
+
+  // Strip off address projections, but not ref_element_addr.
+  SILValue base = findAccessedAddressBase(address);
+  // `base` is null for address producers that are only used for local
+  // initialization.
+  if (!base || !isPossibleFormalAccessBase(base))
+    return;
+
+  // Skip local non-lvalue accesses. There are many local initialization
+  // patterns that don't require access markers.
+  if (!isa<ApplySite>(memInst)
+      && (isa<AllocStackInst>(base) || isa<AllocBoxInst>(base))) {
+    return;
+  }
+
+  if (isSafeInitialization(memInst, base))
+    return;
+
+  // Otherwise, the address base should be an in-scope begin_access.
+  if (auto *BAI = dyn_cast<BeginAccessInst>(base)) {
+    const AccessedStorage &Storage = findAccessedStorage(BAI->getSource());
+    AccessInfo &Info = Accesses[Storage];
+    if (!Info.hasAccessesInProgress())
+      error();
+    return;
+  }
+  error();
+}
+
 static void checkStaticExclusivity(SILFunction &Fn, PostOrderFunctionInfo *PO,
                                    AccessSummaryAnalysis *ASA) {
   // The implementation relies on the following SIL invariants:
@@ -1095,6 +1185,8 @@ static void checkStaticExclusivity(SILFunction &Fn, PostOrderFunctionInfo *PO,
 
   if (Fn.empty())
     return;
+
+  bool VerifyMemOps = Fn.getModule().getOptions().VerifyExclusivity;
 
   // Collects calls the Standard Library swap() for Fix-Its.
   llvm::SmallVector<ApplyInst *, 8> CallsToSwap;
@@ -1166,6 +1258,12 @@ static void checkStaticExclusivity(SILFunction &Fn, PostOrderFunctionInfo *PO,
         if (!Info.hasAccessesInProgress())
           Accesses.erase(It);
         continue;
+      }
+
+      if (VerifyMemOps && I.mayReadOrWriteMemory()) {
+        visitAccessedAddress(&I, [&Accesses](Operand *memOper) {
+          checkAccessedAddress(memOper, Accesses);
+        });
       }
 
       if (auto *AI = dyn_cast<ApplyInst>(&I)) {

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -1219,6 +1219,10 @@ public:
 
 private:
   void run() override {
+    // Don't rerun diagnostics on deserialized functions.
+    if (getFunction()->wasDeserializedCanonical())
+      return;
+
     SILFunction *Fn = getFunction();
     // This is a staging flag. Eventually the ability to turn off static
     // enforcement will be removed.

--- a/lib/SILOptimizer/Mandatory/GuaranteedARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/GuaranteedARCOpts.cpp
@@ -206,8 +206,8 @@ bool GuaranteedARCOptsVisitor::visitReleaseValueInst(ReleaseValueInst *RVI) {
 namespace {
 
 // Even though this is a mandatory pass, it is rerun after deserialization in
-// cast DiagnosticConstantPropagation exposed anything new in this assert
-// configutation.
+// case DiagnosticConstantPropagation exposed anything new in this assert
+// configuration.
 struct GuaranteedARCOpts : SILFunctionTransform {
   void run() override {
     GuaranteedARCOptsVisitor Visitor;

--- a/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
@@ -141,6 +141,9 @@ static bool optimizeGuaranteedArgument(SILArgument *Arg,
 
 namespace {
 
+// Even though this is a mandatory pass, it is rerun after deserialization in
+// case DiagnosticConstantPropagation exposed anything new in this assert
+// configuration.
 struct SemanticARCOpts : SILFunctionTransform {
   void run() override {
     bool MadeChange = false;

--- a/test/SILOptimizer/Inputs/access_marker_verify_objc.h
+++ b/test/SILOptimizer/Inputs/access_marker_verify_objc.h
@@ -1,0 +1,3 @@
+#include <CoreFoundation/CFString.h>
+
+extern const CFStringRef constCGlobal;

--- a/test/SILOptimizer/access_marker_verify.swift
+++ b/test/SILOptimizer/access_marker_verify.swift
@@ -1,0 +1,1009 @@
+// RUN: %target-swift-frontend -enable-verify-exclusivity -enforce-exclusivity=checked -enable-sil-ownership -Onone -emit-silgen -swift-version 4 -parse-as-library %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-verify-exclusivity -enforce-exclusivity=checked -enable-sil-ownership -Onone -emit-sil -swift-version 4 -parse-as-library %s
+// REQUIRES: asserts
+
+// Test the combination of SILGen + DiagnoseStaticExclusivity with verification.
+//
+// This is a collection of tests that cover SILGen cases that require special
+// handling for exclusivity verification. SILGen must generate access markers,
+// possibly unenforced, to satisfy the verification run during the
+// DiagnoseStaticExclusivity pass.
+//
+// These cases are mostly covered by existing SILGen tests, but need to be
+// repeated here to ensure they are run with exclusivity verification enabled.
+import SwiftShims
+
+protocol P {}
+struct StructP : P {}
+
+protocol PBar {
+  func bar()
+}
+
+class BaseClass  {
+  init() {}
+}
+class SubClass : BaseClass {
+  override required init() {}
+}
+
+enum E {
+case V(Int)
+}
+
+func takesClosure(_ f: () -> ()) {
+  f()
+}
+
+// --- struct initialization.
+struct StructOfInt {
+  var i: Int
+
+  init() {
+    i = 1
+  }
+
+  mutating func changeMe() {
+    i = 3
+  }
+}
+// The verifier ignores the load of the self box.
+// CHECK-LABEL: sil hidden @$S20access_marker_verify11StructOfIntVACycfC : $@convention(method) (@thin StructOfInt.Type) -> StructOfInt {
+// CHECK: bb0(%0 : @trivial $@thin StructOfInt.Type):
+// CHECK:   [[BOX:%.*]] = alloc_box ${ var StructOfInt }, var, name "self"
+// CHECK:   [[UNINIT:%.*]] = mark_uninitialized [rootself] [[BOX]] : ${ var StructOfInt }
+// CHECK:   [[PROJ:%.*]] = project_box [[UNINIT]] : ${ var StructOfInt }, 0
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJ]] : $*StructOfInt
+// CHECK:   [[ADR:%.*]] = struct_element_addr [[ACCESS]] : $*StructOfInt, #StructOfInt.i
+// CHECK:   assign %{{.*}} to [[ADR]] : $*Int
+// CHECK:   end_access [[ACCESS]] : $*StructOfInt
+// CHECK-NOT: begin_access
+// CHECK:   [[VAL:%.*]] = load [trivial] [[PROJ]] : $*StructOfInt
+// CHECK:   destroy_value [[UNINIT]] : ${ var StructOfInt }
+// CHECK:   return [[VAL]] : $StructOfInt
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify11StructOfIntVACycfC'
+
+// --- class initialization.
+class SuperHasInt {
+  var i: Int
+
+  init() {
+    i = 3
+  }
+}
+
+class SubHasInt : SuperHasInt {
+  var j: Int
+  
+  override init() {
+    j = 4
+    super.init()
+  }
+
+  init(x: Int) {
+    j = x
+    super.init()
+  }
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify11SuperHasIntCACycfc : $@convention(method) (@owned SuperHasInt) -> @owned SuperHasInt {
+// CHECK:   bb0(%0 : @owned $SuperHasInt):
+// CHECK:   [[UNINIT:%.*]] = mark_uninitialized [rootself] %0 : $SuperHasInt
+// CHECK:   [[BORROW:%.*]] = begin_borrow [[UNINIT]] : $SuperHasInt
+// CHECK:   [[ADR:%.*]] = ref_element_addr [[BORROW]] : $SuperHasInt, #SuperHasInt.i
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[ADR]] : $*Int
+// CHECK:   assign %{{.*}} to [[ACCESS]] : $*Int
+// CHECK:   end_access [[ACCESS]] : $*Int
+// CHECK:   end_borrow [[BORROW]] from [[UNINIT]] : $SuperHasInt, $SuperHasInt
+// CHECK-NOT: begin_access
+// CHECK:   [[VAL:%.*]] = copy_value [[UNINIT]] : $SuperHasInt
+// CHECK:   destroy_value [[UNINIT]] : $SuperHasInt
+// CHECK:   return [[VAL]] : $SuperHasInt
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify11SuperHasIntCACycfc'
+
+// CHECK-LABEL: sil hidden @$S20access_marker_verify9SubHasIntCACycfc : $@convention(method) (@owned SubHasInt) -> @owned SubHasInt {
+// CHECK: bb0(%0 : @owned $SubHasInt):
+// CHECK:   [[BOX:%.*]] = alloc_box ${ var SubHasInt }, let, name "self"
+// CHECK:   [[UNINIT:%.*]] = mark_uninitialized [derivedself] [[BOX]] : ${ var SubHasInt }
+// CHECK:   [[PROJ:%.*]] = project_box [[UNINIT]] : ${ var SubHasInt }, 0
+// CHECK-NOT: begin_access
+// CHECK:   store %0 to [init] [[PROJ]] : $*SubHasInt
+// CHECK-NOT: begin_access
+// CHECK:   [[BORROW:%.*]] = load_borrow [[PROJ]] : $*SubHasInt
+// CHECK:   [[ADR:%.*]] = ref_element_addr [[BORROW]] : $SubHasInt, #SubHasInt.j
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[ADR]] : $*Int
+// CHECK:   assign %{{.*}} to [[ACCESS]] : $*Int
+// CHECK:   end_access [[ACCESS]] : $*Int
+// CHECK:   end_borrow [[BORROW]] from [[PROJ]] : $SubHasInt, $*SubHasInt
+// CHECK-NOT: begin_access
+// CHECK:   load [take] [[PROJ]] : $*SubHasInt
+// CHECK:   upcast %{{.*}} : $SubHasInt to $SuperHasInt
+// CHECK:   function_ref @$S20access_marker_verify11SuperHasIntCACycfc : $@convention(method) (@owned SuperHasInt) -> @owned SuperHasInt
+// CHECK:   apply
+// CHECK:   unchecked_ref_cast %{{.*}} : $SuperHasInt to $SubHasInt
+// CHECK-NOT: begin_access
+// CHECK:   store %{{.*}} to [init] [[PROJ]] : $*SubHasInt
+// CHECK:   [[VAL:%.*]] = load [copy] [[PROJ]] : $*SubHasInt
+// CHECK:   destroy_value [[UNINIT]] : ${ var SubHasInt }
+// CHECK:   return [[VAL]] : $SubHasInt
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify9SubHasIntCACycfc'
+
+// CHECK-LABEL: sil hidden @$S20access_marker_verify9SubHasIntC1xACSi_tcfc : $@convention(method) (Int, @owned SubHasInt) -> @owned SubHasInt {
+// CHECK: bb0(%0 : @trivial $Int, %1 : @owned $SubHasInt):
+// CHECK:   [[BOX:%.*]] = alloc_box ${ var SubHasInt }, let, name "self"
+// CHECK:   [[UNINIT:%.*]] = mark_uninitialized [derivedself] [[BOX]] : ${ var SubHasInt }
+// CHECK:   [[PROJ:%.*]] = project_box [[UNINIT]] : ${ var SubHasInt }, 0
+// CHECK-NOT: begin_access
+// CHECK:   store %{{.*}} to [init] [[PROJ]] : $*SubHasInt
+// CHECK-NOT: begin_access
+// CHECK:   [[BORROW:%.*]] = load_borrow [[PROJ]] : $*SubHasInt
+// CHECK:   [[ADR:%.*]] = ref_element_addr [[BORROW]] : $SubHasInt, #SubHasInt.j
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [dynamic] [[ADR]] : $*Int
+// CHECK:   assign %0 to [[ACCESS]] : $*Int
+// CHECK:   end_access [[ACCESS]] : $*Int
+// CHECK:   end_borrow [[BORROW]] from [[PROJ]] : $SubHasInt, $*SubHasInt
+// CHECK-NOT: begin_access
+// CHECK:   load [take] [[PROJ]] : $*SubHasInt
+// CHECK:   upcast %{{.*}} : $SubHasInt to $SuperHasInt
+// CHECK:   function_ref @$S20access_marker_verify11SuperHasIntCACycfc : $@convention(method) (@owned SuperHasInt) -> @owned SuperHasInt
+// CHECK:   apply
+// CHECK:   unchecked_ref_cast %{{.*}} : $SuperHasInt to $SubHasInt
+// CHECK-NOT: begin_access
+// CHECK:   store %{{.*}} to [init] [[PROJ]] : $*SubHasInt
+// CHECK:   [[VAL:%.*]] = load [copy] [[PROJ]] : $*SubHasInt
+// CHECK:   destroy_value [[UNINIT]] : ${ var SubHasInt }
+// CHECK:   return [[VAL]] : $SubHasInt
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify9SubHasIntC1xACSi_tcfc'
+
+// --- access `let` property.
+class LetClass {
+  let x = 3
+}
+
+// FIXME: should be a [unknown] access.
+//
+// CHECK-LABEL: sil hidden @$S20access_marker_verify10testGetLet1cSiAA0F5ClassC_tF : $@convention(thin) (@owned LetClass) -> Int {
+// CHECK: bb0(%0 : @owned $LetClass):
+// CHECK:   begin_borrow %0 : $LetClass
+// CHECK:   ref_element_addr
+// CHECK:   begin_access [read] [dynamic]
+// CHECK:   load [trivial]
+// CHECK:   end_access
+// CHECK:   end_borrow
+// CHECK:   destroy_value %0 : $LetClass
+// CHECK:   return
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify10testGetLet1cSiAA0F5ClassC_tF'
+func testGetLet(c: LetClass) -> Int {
+  return c.x
+}
+
+// --- initialize let property and superclass.
+struct IntWrapper {
+  var x: Int
+}
+
+final class SubWrapper : BaseClass {
+  let val: IntWrapper
+
+  init(_ val: IntWrapper) {
+    self.val = val
+    super.init()
+  }
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify10SubWrapperCyAcA03IntE0Vcfc : $@convention(method) (IntWrapper, @owned SubWrapper) -> @owned SubWrapper {
+// CHECK: bb0(%0 : @trivial $IntWrapper, %1 : @owned $SubWrapper):
+// CHECK:   alloc_box ${ var SubWrapper }, let, name "self"
+// CHECK:   mark_uninitialized [derivedself]
+// CHECK:   project_box
+// CHECK-NOT: begin_access
+// CHECK:   store %1 to [init]
+// CHECK-NOT: begin_access
+// CHECK:   load_borrow
+// CHECK:   ref_element_addr
+// CHECK:   begin_access [modify] [dynamic]
+// CHECK:   assign %0 to
+// CHECK:   end_access
+// CHECK:   end_borrow
+// CHECK-NOT: begin_access
+// CHECK:   load [take]
+// CHECK-NOT: begin_access
+// CHECK:   store %{{.*}} to [init]
+// CHECK:   [[VAL:%.*]] = load [copy]
+// CHECK:   destroy_value %{{.*}} : ${ var SubWrapper }
+// CHECK:   return [[VAL]] : $SubWrapper
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify10SubWrapperCyAcA03IntE0Vcfc'
+
+// --- captured local.
+func testCaptureLocal() -> ()->() {
+  var x = 1
+  let f = { x = 3 }
+  _ = x
+  return f
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify16testCaptureLocalyycyF : $@convention(thin) () -> @owned @callee_guaranteed () -> () {
+// CHECK: bb0:
+// CHECK:   alloc_box ${ var Int }, var, name "x"
+// CHECK:   [[PROJ:%.*]] = project_box
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unsafe] [[PROJ]] : $*Int
+// CHECK:   store %{{.*}} to [trivial] [[ACCESS]]
+// CHECK:   end_access
+// CHECK:   [[CAPTURE:%.*]] = copy_value %0 : ${ var Int }
+// CHECK:   partial_apply [callee_guaranteed] %{{.*}}([[CAPTURE]]) : $@convention(thin) (@guaranteed { var Int }) -> ()
+// CHECK:   alloc_stack $Int
+// CHECK:   [[UNINIT:%.*]] = mark_uninitialized [var]
+// CHECK:   begin_access [read] [unknown] [[PROJ]]
+// CHECK:   [[VAL:%.*]] = load [trivial]
+// CHECK:   end_access
+// CHECK-NOT: begin_access
+// CHECK:   assign [[VAL]] to [[UNINIT]] : $*Int
+// CHECK:   return {{.*}} : $@callee_guaranteed () -> ()
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify16testCaptureLocalyycyF'
+
+// --- mutating struct.
+func testModifyS(_ arg: StructOfInt) -> StructOfInt {
+  var lhs: StructOfInt
+  lhs = arg
+  lhs.changeMe()
+  return lhs
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify11testModifySyAA11StructOfIntVADF : $@convention(thin) (StructOfInt) -> StructOfInt {
+// CHECK: bb0(%0 : @trivial $StructOfInt):
+// CHECK:   alloc_box ${ var StructOfInt }, var, name "lhs"
+// CHECK:   mark_uninitialized [var]
+// CHECK:   project_box
+// CHECK:   begin_access [modify] [unknown]
+// CHECK:   assign
+// CHECK:   end_access
+// CHECK:   begin_access [modify] [unknown]
+// CHECK:   function_ref @$S20access_marker_verify11StructOfIntV8changeMeyyF : $@convention(method) (@inout StructOfInt) -> ()
+// CHECK:   apply
+// CHECK:   end_access
+// CHECK:   begin_access [read] [unknown]
+// CHECK:   load [trivial]
+// CHECK:   end_access
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify11testModifySyAA11StructOfIntVADF'
+
+// --- initialize LValue.
+protocol HasIntGetter {
+  var x: Int { get }
+}
+func testInitLValue(p: HasIntGetter) -> Int {
+  var x = p.x
+  return x
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify14testInitLValue1pSiAA12HasIntGetter_p_tF : $@convention(thin) (@in HasIntGetter) -> Int {
+// CHECK: bb0(%0 : @trivial $*HasIntGetter):
+// CHECK:   alloc_box ${ var Int }, var, name "x"
+// CHECK:   [[PROJ:%.*]] = project_box
+// CHECK:   [[OPENED:%.*]] = open_existential_addr immutable_access %0
+// CHECK:   [[X:%.*]] = alloc_stack $@opened
+// CHECK-NOT: begin_access
+// CHECK:   copy_addr %{{.*}} to [initialization] [[X]] : $*@opened
+// CHECK:   witness_method $@opened
+// CHECK:   apply %{{.*}}<@opened("{{.*}}") HasIntGetter>([[X]]) : $@convention(witness_method: HasIntGetter) <τ_0_0 where τ_0_0 : HasIntGetter> (@in_guaranteed τ_0_0) -> Int
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unsafe] [[PROJ]] : $*Int
+// CHECK:   store %{{.*}} to [trivial] [[ACCESS]] : $*Int
+// CHECK:   end_access
+// CHECK:   destroy_addr
+// CHECK:   dealloc_stack
+// CHECK:   begin_access [read] [unknown] [[PROJ]]
+// CHECK:   load [trivial]
+// CHECK:   end_access
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify14testInitLValue1pSiAA12HasIntGetter_p_tF'
+
+// --- initialize let.
+func testCopyS(_ arg: StructOfInt) -> StructOfInt {
+  let lhs: StructOfInt
+  lhs = arg
+  return lhs
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify9testCopySyAA11StructOfIntVADF : $@convention(thin) (StructOfInt) -> StructOfInt {
+// CHECK: bb0(%0 : @trivial $StructOfInt):
+// CHECK:   alloc_stack $StructOfInt, let, name "lhs"
+// CHECK:   [[UNINIT:%.*]] = mark_uninitialized [var]
+// CHECK-NOT: begin_access
+// CHECK:   assign %0 to [[UNINIT]] : $*StructOfInt
+// CHECK-NOT: begin_access
+// CHECK:   %5 = load [trivial] [[UNINIT]] : $*StructOfInt
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify9testCopySyAA11StructOfIntVADF'
+
+// --- local var init (single buffer).
+func testLocalVarInit(_ arg: StructOfInt) -> Int {
+  var lhs = arg
+  return lhs.i
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify16testLocalVarInitySiAA11StructOfIntVF : $@convention(thin) (StructOfInt) -> Int {
+// CHECK: bb0(%0 : @trivial $StructOfInt):
+// CHECK:   alloc_box ${ var StructOfInt }, var, name "lhs"
+// CHECK:   [[BOX:%.*]] = project_box
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unsafe] [[BOX]]
+// CHECK:   store %0 to [trivial] [[ACCESS]]
+// CHECK:   end_access
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify16testLocalVarInitySiAA11StructOfIntVF'
+
+// --- init generic enum
+enum GenericEnum<T> {
+case V(T)
+
+  init?(t: T) {
+    self = .V(t)
+  }
+}
+
+func testInitGenericEnum<T>(t: T) -> GenericEnum<T>? {
+  return GenericEnum(t: t)
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify11GenericEnumO1tACyxGSgx_tcfC : $@convention(method) <T> (@in T, @thin GenericEnum<T>.Type) -> @out Optional<GenericEnum<T>> {
+// CHECK: bb0(%0 : @trivial $*Optional<GenericEnum<T>>, %1 : @trivial $*T, %2 : @trivial $@thin GenericEnum<T>.Type):
+// CHECK:   alloc_box $<τ_0_0> { var GenericEnum<τ_0_0> } <T>, var, name "self"
+// CHECK:   mark_uninitialized [delegatingself] %3 : $<τ_0_0> { var GenericEnum<τ_0_0> } <T>
+// CHECK:   [[PROJ:%.*]] = project_box
+// CHECK:   [[STK:%.*]] = alloc_stack $GenericEnum<T>
+// CHECK:   [[ADR1:%.*]] = init_enum_data_addr [[STK]]
+// CHECK-NOT: begin_access
+// CHECK:   copy_addr %1 to [initialization] [[ADR1]] : $*T
+// CHECK:   inject_enum_addr
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unknown] [[PROJ]]
+// CHECK:   copy_addr [take] %{{.*}} to [[ACCESS]] : $*GenericEnum<T>
+// CHECK:   end_access [[ACCESS]] : $*GenericEnum<T>
+// CHECK:   [[ADR2:%.*]] = init_enum_data_addr %0
+// CHECK-NOT: begin_access
+// CHECK:   copy_addr %{{.*}} to [initialization] [[ADR2]] : $*GenericEnum<T>
+// CHECK:   inject_enum_addr %0 : $*Optional<GenericEnum<T>>, #Optional.some!enumelt.1
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify11GenericEnumO1tACyxGSgx_tcfC'
+
+// -- initialize indirect enum.
+enum IndirectEnum {
+  indirect case V(Int)
+}
+
+func testIndirectEnum() -> IndirectEnum {
+  return IndirectEnum.V(3)
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify16testIndirectEnumAA0eF0OyF : $@convention(thin) () -> @owned IndirectEnum {
+// CHECK: bb0:
+// CHECK:   alloc_box ${ var Int }
+// CHECK:   [[PROJ:%.*]] = project_box
+// CHECK:   apply
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unsafe] [[PROJ]]
+// CHECK:   store %{{.*}} to [trivial] [[ACCESS]] : $*Int
+// CHECK:   end_access
+// CHECK:   enum $IndirectEnum, #IndirectEnum.V!enumelt.1
+// CHECK:   return
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify16testIndirectEnumAA0eF0OyF'
+
+// -- indirect enum with getter.
+enum IntEnum {
+  indirect case int(Int)
+
+  var getValue: Int {
+    switch self {
+    case .int(let x): return x
+    }
+  }
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify7IntEnumO8getValueSivg : $@convention(method) (@guaranteed IntEnum) -> Int {
+// CHECK: bb0(%0 : @guaranteed $IntEnum):
+// CHECK:   switch_enum %{{.*}} : $IntEnum, case #IntEnum.int!enumelt.1: bb1
+// CHECK: bb1(%{{.*}} : @owned ${ var Int }):
+// CHECK:   [[PROJ:%.*]] = project_box
+// CHECK-NOT: begin_access
+// CHECK:   load [trivial] [[PROJ]] : $*Int
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify7IntEnumO8getValueSivg'
+
+// -- indirect enum reference.
+enum RefEnum {
+  indirect case ref(BaseClass)
+
+  var getValue: BaseClass {
+    switch self {
+    case .ref(let c): return c
+    }
+  }
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify7RefEnumO8getValueAA9BaseClassCvg : $@convention(method) (@guaranteed RefEnum) -> @owned BaseClass {
+// CHECK: bb0(%0 : @guaranteed $RefEnum):
+// CHECK:   switch_enum %{{.*}} : $RefEnum, case #RefEnum.ref!enumelt.1: bb1
+// CHECK: bb1(%{{.*}} : @owned ${ var BaseClass }):
+// CHECK:   [[PROJ:%.*]] = project_box %{{.*}} : ${ var BaseClass }, 0
+// CHECK-NOT: begin_access
+// CHECK:   load_borrow [[PROJ]] : $*BaseClass
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify7RefEnumO8getValueAA9BaseClassCvg'
+
+// --- indirect enum pattern.
+func testEnumPattern(ie: IndirectEnum) -> Bool {
+  guard case .V(let kind) = ie else {
+    return false
+  }
+  _ = kind
+  return true
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify15testEnumPattern2ieSbAA08IndirectE0O_tF : $@convention(thin) (@owned IndirectEnum) -> Bool {
+// CHECK: bb0(%0 : @owned $IndirectEnum):
+// CHECK:   switch_enum %{{.*}} : $IndirectEnum, case #IndirectEnum.V!enumelt.1: [[BBV:bb.*]], default bb
+// CHECK: [[BBV]](%{{.*}} : @owned ${ var Int }):
+// CHECK:   [[PROJ:%.*]] = project_box
+// CHECK-NOT: begin_access
+// CHECK:   load [trivial] [[PROJ]] : $*Int
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify15testEnumPattern2ieSbAA08IndirectE0O_tF'
+
+// --- enum LValue.
+struct StructOfEnum {
+  var e: E
+  var f: E
+}
+func enumLValueHelper(_: inout E, _: inout E) {}
+
+// CHECK-LABEL: sil hidden @$S20access_marker_verify14testEnumLValue1syAA08StructOfE0Vz_tF : $@convention(thin) (@inout StructOfEnum) -> () {
+// CHECK: bb0(%0 : @trivial $*StructOfEnum):
+// CHECK:   begin_access [modify] [unknown] %0 : $*StructOfEnum
+// CHECK:   struct_element_addr %2 : $*StructOfEnum, #StructOfEnum.e
+// CHECK:   begin_access [modify] [unknown] %0 : $*StructOfEnum
+// CHECK:   struct_element_addr %4 : $*StructOfEnum, #StructOfEnum.f
+// CHECK:   function_ref @$S20access_marker_verify16enumLValueHelperyyAA1EOz_ADztF : $@convention(thin) (@inout E, @inout E) -> ()
+// CHECK:   apply %6(%3, %5) : $@convention(thin) (@inout E, @inout E) -> ()
+// CHECK:   end_access %4 : $*StructOfEnum
+// CHECK:   end_access %2 : $*StructOfEnum
+// CHECK:   %10 = tuple ()
+// CHECK:   return %10 : $()
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify14testEnumLValue1syAA08StructOfE0Vz_tF'
+func testEnumLValue(s: inout StructOfEnum) {
+  enumLValueHelper(&s.e, &s.f)
+}
+
+// --- Optional access.
+func accessOptionalArray(_ dict : [Int : [Int]] = [:]) {
+  var dict = dict
+  dict[1]?.append(2)
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify0A13OptionalArrayyys10DictionaryVySiSaySiGGF : $@convention(thin) (@owned Dictionary<Int, Array<Int>>) -> () {
+// CHECK: bb0(%0 : @owned $Dictionary<Int, Array<Int>>):
+// CHECK:   alloc_box ${ var Dictionary<Int, Array<Int>> }, var, name "dict"
+// CHECK:   [[PROJ:%.*]] = project_box
+// ----- initialize the box.
+// CHECK:   [[INITACCESS:%.*]] = begin_access [modify] [unsafe] [[PROJ]]
+// CHECK:   store %{{.*}} to [init] [[INITACCESS]]
+// CHECK:   end_access [[INITACCESS]]
+// ----- begin formal access for Dictionary.subscript.setter
+// CHECK:   [[BOXACCESS:%.*]] = begin_access [modify] [unknown] [[PROJ]]
+// CHECK:   [[TEMP:%.*]] = alloc_stack $Optional<Array<Int>>
+// CHECK:   load_borrow [[BOXACCESS]] : $*Dictionary<Int, Array<Int>>
+// ----- Initialize some trivial temporaries.
+// CHECK:   alloc_stack $Int
+// CHECK-NOT: begin_access
+// CHECK:   store %{{.*}} to [trivial]
+// ----- Call Dictionary.subscript.getter.
+// CHECK-NOT: begin_access
+// CHECK:   apply %{{.*}}<Int, [Int]>
+// ----- access the temporary array result of the getter
+// CHECK:   [[TEMPACCESS:%.*]] = begin_access [modify] [unsafe] [[TEMP]]
+// CHECK:   select_enum_addr [[TEMPACCESS]] : $*Optional<Array<Int>>, case #Optional.some!enumelt.1
+// CHECK:   cond_br %{{.*}}, bb2, bb1
+//
+// CHECK: bb1:
+// CHECK:   [[TEMPARRAY:%.*]] = load [copy] [[TEMPACCESS]]
+// CHECK:   [[WRITEBACK:%.*]] = alloc_stack $Optional<Array<Int>>
+// CHECK-NOT: begin_access
+// CHECK:   store [[TEMPARRAY]] to [init] [[WRITEBACK]]
+// CHECK:   alloc_stack $Int
+// CHECK-NOT: begin_access
+// CHECK:   store %{{.*}} to [trivial] %31 : $*Int
+// Call Dictionary.subscript.setter
+// CHECK:   apply %{{.*}}<Int, [Int]>([[WRITEBACK]], %{{.*}}, [[BOXACCESS]]) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@in Optional<τ_0_1>, @in τ_0_0, @inout Dictionary<τ_0_0, τ_0_1>) -> ()
+// CHECK:   end_access [[TEMPACCESS]] : $*Optional<Array<Int>>
+// CHECK:   end_access [[BOXACCESS]] : $*Dictionary<Int, Array<Int>>
+// CHECK:   br
+//
+// CHECK: bb2:
+// CHECK-NOT: begin_access
+// CHECK:   [[TEMPARRAYADR:%.*]] = unchecked_take_enum_data_addr [[TEMPACCESS]] : $*Optional<Array<Int>>, #Optional.some!enumelt.1
+// ----- call Array.append
+// CHECK:   alloc_stack $Int
+// CHECK:   store %{{.*}} to [trivial]
+// CHECK:   function_ref @$SSa6appendyyxF : $@convention(method) <τ_0_0> (@in τ_0_0, @inout Array<τ_0_0>) -> ()
+// CHECK:   apply %{{.*}}<Int>(%{{.*}}, [[TEMPARRAYADR]]) : $@convention(method) <τ_0_0> (@in τ_0_0, @inout Array<τ_0_0>) -> ()
+// CHECK:   [[TEMPARRAYVAL:%.*]] = load [take] [[TEMPACCESS]] : $*Optional<Array<Int>>
+// CHECK:   [[ARRAYCOPY:%.*]] = alloc_stack $Optional<Array<Int>>
+// CHECK:   store [[TEMPARRAYVAL]] to [init] [[ARRAYCOPY]] : $*Optional<Array<Int>>
+// CHECK:   alloc_stack $Int
+// CHECK:   store %{{.*}} to [trivial]
+// ----- call Dictionary.subscript.setter
+// CHECK: apply %{{.*}}<Int, [Int]>([[ARRAYCOPY]], %{{.*}}, [[BOXACCESS]]) : $@convention(method) <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (@in Optional<τ_0_1>, @in τ_0_0, @inout Dictionary<τ_0_0, τ_0_1>) -> ()
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify0A13OptionalArrayyys10DictionaryVySiSaySiGGF'
+
+// --- Optional map.
+enum OptionalWithMap<Wrapped> {
+  case none
+
+  case some(Wrapped)
+
+  init(_ some: Wrapped) { self = .some(some) }
+
+  func map<U>(
+    _ transform: (Wrapped) throws -> U
+  ) rethrows -> U? {
+    switch self {
+    case .some(let y):
+      return .some(try transform(y))
+    case .none:
+      return .none
+    }
+  }
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify15OptionalWithMapO3mapyqd__Sgqd__xKXEKlF : $@convention(method) <Wrapped><U> (@noescape @callee_guaranteed (@in Wrapped) -> (@out U, @error Error), @in_guaranteed OptionalWithMap<Wrapped>) -> (@out Optional<U>, @error Error) {
+// CHECK: bb0(%0 : @trivial $*Optional<U>, %1 : @trivial $@noescape @callee_guaranteed (@in Wrapped) -> (@out U, @error Error), %2 : @trivial $*OptionalWithMap<Wrapped>):
+// CHECK: [[STK:%.]] = alloc_stack $OptionalWithMap<Wrapped>
+// CHECK-NOT: begin_access
+// CHECK: copy_addr %2 to [initialization] [[STK]] : $*OptionalWithMap<Wrapped>
+// CHECK: switch_enum_addr [[STK]] : $*OptionalWithMap<Wrapped>, case #OptionalWithMap.some!enumelt.1: [[BBSOME:bb.*]], case #OptionalWithMap.none!enumelt: bb
+//
+// CHECK: [[BBSOME]]:
+// CHECK-NOT: begin_access
+// CHECK: [[ADR:%.*]] = unchecked_take_enum_data_addr [[STK]]
+// CHECK: alloc_stack $Wrapped, let, name "y"
+// CHECK-NOT: begin_access
+// CHECK: copy_addr [take] [[ADR]] to [initialization]
+// CHECK: alloc_stack $Wrapped
+// CHECK-NOT: begin_access
+// CHECK: copy_addr %{{.*}} to [initialization]
+// ----- call transform.
+// CHECK: try_apply
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify15OptionalWithMapO3mapyqd__Sgqd__xKXEKlF'
+
+// --- delegating initializer.
+struct DelegatingInit {
+  var i: Int
+  init(i: Int) {
+    self.i = i
+  }
+  init() {
+    self.init(i: 4)
+  }
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify14DelegatingInitV1iACSi_tcfC : $@convention(method) (Int, @thin DelegatingInit.Type) -> DelegatingInit {
+// CHECK: bb0(%0 : @trivial $Int, %1 : @trivial $@thin DelegatingInit.Type):
+// CHECK:   alloc_box ${ var DelegatingInit }, var, name "self"
+// CHECK:   mark_uninitialized [rootself] %2 : ${ var DelegatingInit }
+// CHECK:   [[BOX:%.*]] = project_box
+// CHECK:   begin_access [modify] [unknown]
+// CHECK:   struct_element_addr
+// CHECK:   assign
+// CHECK:   end_access
+// CHECK-NOT: begin_access
+// CHECK:   load [trivial] [[BOX]] : $*DelegatingInit
+// CHECK:   destroy_value
+// CHECK:   return %10 : $DelegatingInit
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify14DelegatingInitV1iACSi_tcfC'
+
+// --- addressor.
+func testAddressor(p: UnsafePointer<Int>) -> Int {
+  return p.pointee
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify13testAddressor1pSiSPySiG_tF : $@convention(thin) (UnsafePointer<Int>) -> Int {
+// CHECK: bb0(%0 : @trivial $UnsafePointer<Int>):
+// CHECK:   apply
+// CHECK:   struct_extract
+// CHECK:   [[ADR:%.*]] = pointer_to_address
+// CHECK-NOT: begin_access
+// CHECK:   load [trivial] [[ADR]] : $*Int
+// CHECK:   return
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify13testAddressor1pSiSPySiG_tF'
+
+// --- shims.
+func testShims() -> UInt32 {
+  return _SwiftKeyPathBufferHeader_SizeMask
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify9testShimss6UInt32VyF : $@convention(thin) () -> UInt32 {
+// CHECK: bb0:
+// CHECK:   [[GA:%.*]] = global_addr @_SwiftKeyPathBufferHeader_SizeMask : $*UInt32
+// CHECK-NOT: begin_access
+// CHECK:   load [trivial] [[GA]] : $*UInt32
+// CHECK:   return
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify9testShimss6UInt32VyF'
+
+// --- global variable initialization.
+var globalString1 = "⓪" // start non-empty
+// CHECK-LABEL: sil private @globalinit_33_{{.*}}_func0 : $@convention(c) () -> () {
+// CHECK: alloc_global @$S20access_marker_verify13globalString1SSvp
+// CHECK: [[GA:%.*]] = global_addr @$S20access_marker_verify13globalString1SSvp : $*String
+// CHECK: apply
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unsafe] [[GA]] : $*String
+// CHECK: store %{{.*}} to [init] [[ACCESS]] : $*String
+// CHECK: end_access
+// CHECK-LABEL: } // end sil function 'globalinit_33_180BF7B9126DB0C8C6C26F15ACD01908_func0'
+
+var globalString2 = globalString1
+// CHECK-LABEL: sil private @globalinit_33_180BF7B9126DB0C8C6C26F15ACD01908_func1 : $@convention(c) () -> () {
+// CHECK: alloc_global @$S20access_marker_verify13globalString2SSvp
+// CHECK: [[GA:%.*]] = global_addr @$S20access_marker_verify13globalString2SSvp : $*String
+// CHECK: apply
+// CHECK: [[PTR:%.*]] = pointer_to_address
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [[PTR]] : $*String
+// CHECK-NOT: begin_access
+// CHECK: copy_addr [[ACCESS]] to [initialization] [[GA]] : $*String
+// CHECK: end_access [[ACCESS]] : $*String
+// CHECK-NOT: end_access
+// CHECK-LABEL: } // end sil function 'globalinit_33_180BF7B9126DB0C8C6C26F15ACD01908_func1'
+
+
+// --- getter.
+struct GenericStructWithGetter<T> {
+  var t: T
+  var val: Int
+
+  struct Value {
+    internal var val: Int
+    
+    internal init(_ val: Int) { self.val = val }
+  }
+  var value : Value {
+    get { return Value(val) }
+  }
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify23GenericStructWithGetterV5valueAC5ValueVyx_Gvg : $@convention(method) <T> (@in_guaranteed GenericStructWithGetter<T>) -> GenericStructWithGetter<T>.Value {
+// CHECK: bb0(%0 : @trivial $*GenericStructWithGetter<T>):
+// CHECK:   [[ADR:%.*]] = struct_element_addr %0 : $*GenericStructWithGetter<T>, #GenericStructWithGetter.val
+// CHECK-NOT: begin_access
+// CHECK:   load [trivial] [[ADR]] : $*Int
+// CHECK:   apply
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify23GenericStructWithGetterV5valueAC5ValueVyx_Gvg'
+
+// --- setter.
+struct StructWithSetter {
+  var _val: Int
+
+  internal var val: Int {
+    get {
+      return _val
+    }
+    set {
+      _val = newValue
+    }
+  }
+
+  mutating func inc(incVal: Int) {
+    val += incVal
+  }
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify16StructWithSetterV3inc0G3ValySi_tF : $@convention(method) (Int, @inout StructWithSetter) -> () {
+// CHECK: bb0(%0 : @trivial $Int, %1 : @trivial $*StructWithSetter):
+// CHECK: [[FORMALACCESS:%.*]] = begin_access [modify] [unknown] %1
+// CHECK: alloc_stack $Int
+// CHECK: load [trivial] [[FORMALACCESS]] : $*StructWithSetter
+// CHECK: [[GETTER:%.*]] = function_ref @$S20access_marker_verify16StructWithSetterV3valSivg
+// CHECK: apply [[GETTER]]
+// CHECK: begin_access [modify] [unsafe]
+// CHECK: store %{{.*}} to [trivial]
+// CHECK: end_access
+// CHECK: begin_access [modify] [unsafe]
+// CHECK: [[INC:%.*]] = function_ref @$SSi2peoiyySiz_SitFZ
+// CHECK: apply [[INC]]
+// CHECK: load [trivial] %13 : $*Int
+// CHECK: [[SETTER:%.*]] = function_ref @$S20access_marker_verify16StructWithSetterV3valSivs
+// CHECK: apply [[SETTER]]
+// CHECK: end_access
+// CHECK: end_access [[FORMALACCESS]]
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify16StructWithSetterV3inc0G3ValySi_tF'
+
+// --- lazy inout.
+func increment(_ x: inout Int) { x += 1 }
+
+final class LazyFinalClassProperty {
+  lazy var cat: Int = 5
+}
+
+func inoutWriteOfLazyFinalClassProperty(l: inout LazyFinalClassProperty) {
+  increment(&l.cat)
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify34inoutWriteOfLazyFinalClassProperty1lyAA0ghiJ0Cz_tF : $@convention(thin) (@inout LazyFinalClassProperty) -> () {
+// CHECK: bb0(%0 : @trivial $*LazyFinalClassProperty):
+// CHECK:   [[FORMALACCESS:%.*]] = begin_access [read] [unknown] %0 : $*LazyFinalClassProperty
+// CHECK:   load [copy] [[FORMALACCESS]] : $*LazyFinalClassProperty
+// CHECK:   end_access [[FORMALACCESS]] : $*LazyFinalClassProperty
+// CHECK:   // function_ref LazyFinalClassProperty.cat.getter
+// CHECK:   [[GETTER:%.*]] = function_ref @$S20access_marker_verify22LazyFinalClassPropertyC3catSivg
+// CHECK:   apply [[GETTER]]
+// CHECK:   begin_access [modify] [unsafe]
+// CHECK:   store %{{.*}} to [trivial]
+// CHECK:   end_access
+// CHECK:   [[TEMPACCESS:%.*]] = begin_access [modify] [unsafe] %5 : $*Int
+// CHECK:   [[INC:%.*]] = function_ref @$S20access_marker_verify9incrementyySizF : $@convention(thin) (@inout Int) -> ()
+// CHECK:   apply [[INC]]([[TEMPACCESS]]) : $@convention(thin) (@inout Int) -> ()
+// CHECK:   load [trivial] [[TEMPACCESS]] : $*Int
+// CHECK:   [[SETTER:%.*]] = function_ref @$S20access_marker_verify22LazyFinalClassPropertyC3catSivs
+// CHECK:   apply [[SETTER]]
+// CHECK:   end_access [[TEMPACCESS]] : $*Int
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify34inoutWriteOfLazyFinalClassProperty1lyAA0ghiJ0Cz_tF'
+
+// --- lazy getter.
+func inoutAccessOfLazyFinalClassProperty(
+  l: inout LazyFinalClassProperty
+) -> Int {
+  return l.cat
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify35inoutAccessOfLazyFinalClassProperty1lSiAA0ghiJ0Cz_tF : $@convention(thin) (@inout LazyFinalClassProperty) -> Int {
+// CHECK: bb0(%0 : @trivial $*LazyFinalClassProperty):
+// CHECK:   begin_access [read] [unknown] %0
+// CHECK:   load [copy]
+// CHECK:   end_access
+// CHECK:   [[GETTER:%.*]] = function_ref @$S20access_marker_verify22LazyFinalClassPropertyC3catSivg : $@convention(method) (@guaranteed LazyFinalClassProperty) -> Int
+// CHECK:   apply [[GETTER]]
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify35inoutAccessOfLazyFinalClassProperty1lSiAA0ghiJ0Cz_tF'
+
+// --- polymorphic getter
+protocol Abstractable {
+  associatedtype Result
+  var storedFunction: () -> Result { get set }
+}
+
+class C : Abstractable {
+  var storedFunction: () -> Int = { 0 }
+}
+// CHECK-LABEL: sil private [transparent] [thunk] @$S20access_marker_verify1CCAA12AbstractableA2aDP14storedFunction6ResultQzycvmTW : $@convention(witness_method: Abstractable) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout C) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
+// CHECK: bb0(%0 : @trivial $Builtin.RawPointer, %1 : @trivial $*Builtin.UnsafeValueBuffer, %2 : @trivial $*C):
+// CHECK:   [[ADR:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*@callee_guaranteed () -> @out Int
+// CHECK:   [[TEMP:%.*]] = alloc_stack $@callee_guaranteed () -> Int
+// CHECK:   [[GETTER:%.*]] = apply
+// CHECK:   [[ACCESS:%.*]] = begin_access [modify] [unsafe] [[TEMP]] : $*@callee_guaranteed () -> Int
+// CHECK:   store %{{.*}} to [init] [[ACCESS]] : $*@callee_guaranteed () -> Int
+// CHECK:   end_access [[ACCESS]] : $*@callee_guaranteed () -> Int
+// CHECK-NOT: begin_access
+// CHECK:   load [copy] [[TEMP]] : $*@callee_guaranteed () -> Int
+// CHECK:   [[PA:%.*]] = partial_apply
+// CHECK:   destroy_addr [[TEMP]] : $*@callee_guaranteed () -> Int
+// CHECK-NOT: begin_access
+// CHECK:   store [[PA]] to [init] [[ADR]] : $*@callee_guaranteed () -> @out Int
+// CHECK:   [[PTR:%.*]] = address_to_pointer [[ADR]] : $*@callee_guaranteed () -> @out Int to $Builtin.RawPointer
+// CHECK:   [[FPTR:%.*]] = thin_function_to_pointer %{{.*}} : $@convention(witness_method: Abstractable) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout C, @thick C.Type) -> () to $Builtin.RawPointer
+// CHECK:   [[ENUM:%.*]] = enum $Optional<Builtin.RawPointer>, #Optional.some!enumelt.1, [[FPTR]] : $Builtin.RawPointer
+// CHECK:   [[R:%.*]] = tuple ([[PTR]] : $Builtin.RawPointer, [[ENUM]] : $Optional<Builtin.RawPointer>)
+// CHECK:   return [[R]] : $(Builtin.RawPointer, Optional<Builtin.RawPointer>)
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify1CCAA12AbstractableA2aDP14storedFunction6ResultQzycvmTW'
+
+// --- writeback address-only.
+var addressOnly: P {
+  get {
+    return StructP()
+  }
+  set {}
+}
+
+func takesInoutP(x: inout P) {}
+
+func testWriteback() {
+  takesInoutP(x: &addressOnly)
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify13testWritebackyyF : $@convention(thin) () -> () {
+// CHECK: bb0:
+// CHECK:   %0 = alloc_stack $P
+// CHECK: [[GETTER:%.*]] = apply
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unsafe] %0 : $*P
+// Call takesInoutP
+// CHECK: apply %{{.*}}([[ACCESS]]) : $@convention(thin) (@inout P) -> ()
+// Call addressOnly.setter
+// CHECK: apply %{{.*}}([[ACCESS]]) : $@convention(thin) (@in P) -> ()
+// CHECK: end_access [[ACCESS]] : $*P
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify13testWritebackyyF'
+
+// --- writeback temp.
+struct MutableStorage {
+  mutating func push() {}
+}
+
+class Container {
+  var storage: MutableStorage
+
+  init() {
+    storage = MutableStorage()
+  }
+
+  func testWritebackTemp() {
+    self.storage.push()
+  }
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify9ContainerC17testWritebackTempyyF : $@convention(method) (@guaranteed Container) -> () {
+// CHECK: bb0(%0 : @guaranteed $Container):
+// call storage.materializeForSet
+// CHECK: [[MATSET:%.*]] = class_method %0 : $Container, #Container.storage!materializeForSet.1
+// CHECK: apply [[MATSET]]
+// call MutableStorage.push()
+// CHECK: apply %{{.*}}(%{{.*}}) : $@convention(method) (@inout MutableStorage) -> ()
+// CHECK: switch_enum %{{.*}} : $Optional<Builtin.RawPointer>, case #Optional.some!enumelt.1: [[BBSOME:bb.*]], case #Optional.none!enumelt: bb
+// CHECK: [[BBSOME]]([[WB:%.*]] : @trivial $Builtin.RawPointer):
+// CHECK: [[WBF:%.*]] = pointer_to_thin_function [[WB]]
+// CHECK: [[TEMP:%.*]] = alloc_stack $Container
+// CHECK: [[ACCESS:%.*]] = begin_access [modify] [unsafe] [[TEMP]] : $*Container
+// CHECK: store_borrow %0 to [[ACCESS]] : $*Container
+// writeback
+// CHECK: apply [[WBF]]
+// CHECK: end_access [[ACCESS]] : $*Container
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify9ContainerC17testWritebackTempyyF'
+
+// --- return mixed tuple
+protocol HasClassGetter {
+  var c: BaseClass { get }
+}
+func testMixedTuple(p: HasClassGetter) -> (BaseClass, Any) {
+  return (p.c, p.c)
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify14testMixedTuple1pAA9BaseClassC_yptAA03HasH6Getter_p_tF : $@convention(thin) (@in HasClassGetter) -> (@owned BaseClass, @out Any) {
+// CHECK: bb0(%0 : @trivial $*Any, %1 : @trivial $*HasClassGetter):
+// CHECK: [[P1:%.*]] = open_existential_addr immutable_access %1 : $*HasClassGetter to $*@opened
+// CHECK: [[TEMP1:%.*]] = alloc_stack $@opened
+// CHECK-NOT: begin_access
+// CHECK: copy_addr [[P1]] to [initialization] [[TEMP1]] : $*@opened
+// CHECK-NOT: begin_access
+// CHECK: [[OUTC:%.*]] = apply {{.*}} $@convention(witness_method: HasClassGetter) <τ_0_0 where τ_0_0 : HasClassGetter> (@in_guaranteed τ_0_0) -> @owned BaseClass
+// CHECK: [[OUTANY:%.*]] = init_existential_addr %0 : $*Any, $BaseClass
+// CHECK: [[P2:%.*]] = open_existential_addr immutable_access %1 : $*HasClassGetter to $*@opened
+// CHECK: [[TEMP2:%.*]] = alloc_stack $@opened
+// CHECK-NOT: begin_access
+// CHECK: copy_addr [[P2]] to [initialization] [[TEMP2]] : $*@opened
+// CHECK-NOT: begin_access
+// CHECK: apply {{.*}} $@convention(witness_method: HasClassGetter) <τ_0_0 where τ_0_0 : HasClassGetter> (@in_guaranteed τ_0_0) -> @owned BaseClass
+// CHECK: store %{{.*}} to [init] [[OUTANY]] : $*BaseClass
+// CHECK: return [[OUTC]] : $BaseClass
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify14testMixedTuple1pAA9BaseClassC_yptAA03HasH6Getter_p_tF'
+
+// --- existential cast.
+internal protocol CanCast {
+  func unbox<T : Hashable>() -> T?
+}
+
+internal struct CanCastStruct<Base : Hashable> : CanCast {
+  internal var base: Base
+
+  internal func unbox<T : Hashable>() -> T? {
+    return (self as CanCast as? CanCastStruct<T>)?.base
+  }
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify13CanCastStructV5unboxqd__Sgys8HashableRd__lF : $@convention(method) <Base where Base : Hashable><T where T : Hashable> (@in_guaranteed CanCastStruct<Base>) -> @out Optional<T> {
+// CHECK: bb0(%0 : @trivial $*Optional<T>, %1 : @trivial $*CanCastStruct<Base>):
+// CHECK: [[OUT_ENUM:%.*3]] = init_enum_data_addr %0 : $*Optional<T>, #Optional.some!enumelt.1
+// CHECK: [[TEMP_SUB:%.*]] = alloc_stack $Optional<CanCastStruct<T>>
+// CHECK: [[TEMP_BASE:%.*]] = alloc_stack $CanCast
+// CHECK: [[TEMP_BASE_ADR:%.*]] = init_existential_addr [[TEMP_BASE]] : $*CanCast, $CanCastStruct<Base>
+// CHECK-NOT: begin_access
+// CHECK: copy_addr %1 to [initialization] [[TEMP_BASE_ADR]] : $*CanCastStruct<Base>
+// CHECK-NOT: begin_access
+// CHECK: [[TEMP_SUB_ADR:%.*]] = init_enum_data_addr [[TEMP_SUB]] : $*Optional<CanCastStruct<T>>, #Optional.some!enumelt.1
+// CHECK-NOT: begin_access
+// CHECK: checked_cast_addr_br take_always CanCast in [[TEMP_BASE]] : $*CanCast to CanCastStruct<T> in [[TEMP_SUB_ADR]] : $*CanCastStruct<T>
+// CHECK-NOT: begin_access
+// CHECK: [[TEMP_DATA:%.*]] = unchecked_take_enum_data_addr [[TEMP_SUB]] : $*Optional<CanCastStruct<T>>, #Optional.some!enumelt.1
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unsafe] [[TEMP_DATA]] : $*CanCastStruct<T>
+// CHECK: [[BASE_ADR:%.*]] = struct_element_addr [[ACCESS]] : $*CanCastStruct<T>, #CanCastStruct.base
+// CHECK-NOT: begin_access
+// CHECK: copy_addr [[BASE_ADR]] to [initialization] [[OUT_ENUM]] : $*T
+// CHECK: end_access [[ACCESS]] : $*CanCastStruct<T>
+// CHECK-NOT: begin_access
+// CHECK: inject_enum_addr %0 : $*Optional<T>, #Optional.some!enumelt.1
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify13CanCastStructV5unboxqd__Sgys8HashableRd__lF'
+
+// --- open existential
+protocol Q : PBar {}
+
+func testOpenExistential(p: PBar) {
+  let q0 = p as? Q
+  if q0 != nil, let q = q0 {
+    q.bar()
+  }
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify19testOpenExistential1pyAA4PBar_p_tF : $@convention(thin) (@in PBar) -> () {
+// CHECK: bb0(%0 : @trivial $*PBar):
+// CHECK: [[Q0:%.*]] = alloc_stack $Optional<Q>, let, name "q0"
+// CHECK: [[PBAR:%.*]] = alloc_stack $PBar
+// CHECK-NOT: begin_access
+// CHECK: copy_addr %0 to [initialization] [[PBAR]] : $*PBar
+// CHECK-NOT: begin_access
+// CHECK: [[Q0_DATA:%.*]] = init_enum_data_addr [[Q0]] : $*Optional<Q>, #Optional.some!enumelt.1
+// CHECK-NOT: begin_access
+// CHECK: checked_cast_addr_br take_always PBar in [[PBAR]] : $*PBar to Q in [[Q0_DATA]] : $*Q, bb1, bb2
+// CHECK-NOT: begin_access
+// CHECK: inject_enum_addr [[Q0]] : $*Optional<Q>, #Optional.some!enumelt.1
+// CHECK: [[TMP_Q:%.*]] = alloc_stack $Optional<Q>
+// CHECK-NOT: begin_access
+// CHECK: copy_addr [[Q0]] to [initialization] [[TMP_Q]] : $*Optional<Q>
+// CHECK-NOT: begin_access
+// CHECK: apply %{{.*}}<Q>([[TMP_Q]], {{.*}}) : $@convention(method) <τ_0_0> (@in Optional<τ_0_0>, _OptionalNilComparisonType, @thin Optional<τ_0_0>.Type) -> Bool
+// CHECK: [[Q:%.*]] = alloc_stack $Q, let, name "q"
+// CHECK: [[OPT_Q:%.*]] = alloc_stack $Optional<Q>
+// CHECK-NOT: begin_access
+// CHECK: copy_addr [[Q0]] to [initialization] [[OPT_Q]] : $*Optional<Q>
+// CHECK-NOT: begin_access
+// CHECK: switch_enum_addr [[OPT_Q]] : $*Optional<Q>, case #Optional.some!enumelt.1: bb
+// CHECK-NOT: begin_access
+// CHECK: [[OPT_Q_ADR:%.*]] = unchecked_take_enum_data_addr [[OPT_Q]] : $*Optional<Q>, #Optional.some!enumelt.1
+// CHECK-NOT: begin_access
+// CHECK: copy_addr [take] [[OPT_Q_ADR]] to [initialization] [[Q]] : $*Q
+// CHECK-NOT: begin_access
+// CHECK: [[Q_ADR:%.*]] = open_existential_addr immutable_access [[Q]] : $*Q to $*@opened("{{.*}}") Q
+// CHECK: witness_method $@opened("{{.*}}") Q, #PBar.bar!1
+// CHECK: apply %{{.*}}<@opened("{{.*}}") Q>([[Q_ADR]])
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify19testOpenExistential1pyAA4PBar_p_tF'
+
+// --- local existential
+func getP() -> P {
+  struct S : P {}
+  return S()
+}
+
+func testLocalExistential() {
+  var p = getP()
+  takesClosure { p = getP() }
+  _ = p
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify20testLocalExistentialyyF : $@convention(thin) () -> () {
+// CHECK: alloc_box ${ var P }, var, name "p"
+// CHECK: [[PROJ:%.*]] = project_box %{{.*}} : ${ var P }, 0
+// CHECK-NOT: begin_access
+// CHECK: apply %{{.*}}([[PROJ]]) : $@convention(thin) () -> @out P
+// CHECK-NOT: begin_access
+// CHECK: partial_apply [callee_guaranteed] %{{.*}}([[PROJ]]) : $@convention(thin) (@inout_aliasable P) -> ()
+// CHECK-NOT: begin_access
+// CHECK: apply
+// CHECK: [[TMP:%.*]] = alloc_stack $P
+// CHECK: [[UNINIT:%.*]] = mark_uninitialized [var] [[TMP]] : $*P
+// CHECK: [[ACCESS:%.*]] = begin_access [read] [unknown] [[PROJ]] : $*P
+// CHECK: [[COPY:%.*]] = alloc_stack $P
+// CHECK-NOT: begin_access
+// CHECK: copy_addr [[ACCESS]] to [initialization] [[COPY]] : $*P
+// CHECK: end_access
+// CHECK-NOT: begin_access
+// CHECK: copy_addr [take] [[COPY]] to [[UNINIT]] : $*P
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify20testLocalExistentialyyF'
+
+// --- address-only argument.
+protocol UsesSelf {
+  func bar(_: Self)
+}
+
+extension UsesSelf {
+  static func testSelf(a: Self, b: Self) {
+    a.bar(b)
+  }
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify8UsesSelfPAAE04testE01a1byx_xtFZ : $@convention(method) <Self where Self : UsesSelf> (@in Self, @in Self, @thick Self.Type) -> () {
+// CHECK: bb0(%0 : @trivial $*Self, %1 : @trivial $*Self, %2 : @trivial $@thick Self.Type):
+// CHECK: [[COPY:%.*]] = alloc_stack $Self
+// CHECK: copy_addr %1 to [initialization] [[COPY]] : $*Self
+// CHECK: apply %{{.*}}<Self>([[COPY]], %0) : $@convention(witness_method: UsesSelf) <τ_0_0 where τ_0_0 : UsesSelf> (@in τ_0_0, @in_guaranteed τ_0_0) -> ()
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify8UsesSelfPAAE04testE01a1byx_xtFZ'
+
+// --- autoclosure
+struct StructWithLayout {
+  internal init() {
+    _sanityCheck(MemoryLayout.size(ofValue: self) >= 0)
+  }
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify16StructWithLayoutVACycfC : $@convention(method) (@thin StructWithLayout.Type) -> StructWithLayout {
+// CHECK: bb0(%0 : @trivial $@thin StructWithLayout.Type):
+// CHECK: alloc_box ${ var StructWithLayout }, var, name "self"
+// CHECK: mark_uninitialized [rootself] %{{.*}} : ${ var StructWithLayout }
+// CHECK: [[PROJ:%.*]] = project_box %{{.*}} : ${ var StructWithLayout }, 0
+// CHECK: [[PA:%.*]] = partial_apply [callee_guaranteed] %{{.*}}([[PROJ]]) : $@convention(thin) (@inout_aliasable StructWithLayout) -> Bool
+// CHECK: [[CLOSURE:%.*]] = convert_escape_to_noescape [[PA]] : $@callee_guaranteed () -> Bool to $@noescape @callee_guaranteed () -> Bool
+// call default argument
+// CHECK: apply %{{.*}}() : $@convention(thin) () -> StaticString
+// call StaticString.init
+// CHECK: apply
+// call UInt.init(_builtinIntegerLiteral:)
+// CHECK: apply
+// call _sanityCheck(_:_:file:line:)
+// CHECK: apply %{{.*}}([[CLOSURE]], {{.*}})
+// CHECK: load [trivial] [[PROJ]] : $*StructWithLayout
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify16StructWithLayoutVACycfC'
+
+// --- pointer_to_address
+// Verification should ignore this case.
+func testPointerInit(x: Int, y: UnsafeMutablePointer<Int>) {
+  y.pointee = x
+}
+// CHECK-LABEL: sil hidden @$S20access_marker_verify15testPointerInit1x1yySi_SpySiGtF : $@convention(thin) (Int, UnsafeMutablePointer<Int>) -> () {
+// CHECK: bb0(%0 : @trivial $Int, %1 : @trivial $UnsafeMutablePointer<Int>):
+// call addressor
+// CHECK: [[POINTEE:%.*]] = apply %{{.*}}<Int>(%1) : $@convention(method) <τ_0_0> (UnsafeMutablePointer<τ_0_0>) -> UnsafeMutablePointer<τ_0_0>
+// CHECK: [[RAWPTR:%.*]] = struct_extract [[POINTEE]] : $UnsafeMutablePointer<Int>, #UnsafeMutablePointer._rawValue
+// CHECK: [[ADR:%.*]] = pointer_to_address [[RAWPTR]] : $Builtin.RawPointer to [strict] $*Int
+// CHECK-NOT: begin_access
+// CHECK: assign %0 to [[ADR]] : $*Int
+// CHECK-LABEL: } // end sil function '$S20access_marker_verify15testPointerInit1x1yySi_SpySiGtF'

--- a/test/SILOptimizer/access_marker_verify_objc.swift
+++ b/test/SILOptimizer/access_marker_verify_objc.swift
@@ -1,0 +1,68 @@
+// RUN: %target-swift-frontend -enforce-exclusivity=checked -enable-sil-ownership -import-objc-header %S/Inputs/access_marker_verify_objc.h -Onone -emit-silgen -swift-version 4 -parse-as-library %s | %FileCheck %s
+// RUN: %target-swift-frontend -enable-verify-exclusivity -enforce-exclusivity=checked -enable-sil-ownership -import-objc-header %S/Inputs/access_marker_verify_objc.h -Onone -emit-sil -swift-version 4 -parse-as-library %s
+// REQUIRES: asserts
+// REQUIRES: OS=macosx
+
+// Test the combination of SILGen + DiagnoseStaticExclusivity with verification.
+//
+// This augments access_marker_verify with tests that require ObjC or
+// CoreFoundation.
+import Foundation
+
+// --- initializer `let` of CFString.
+// The verifier should ignore this.
+
+// CHECK_LABEL: sil private @globalinit{{.*}} : $@convention(c) () -> () {
+// CHECK: bb0:
+// CHECK:   alloc_global @$S25access_marker_verify_objc12testCFStringC8cfStringSo0F3RefavpZ
+// CHECK:   [[GA:%.*]] = global_addr @$S25access_marker_verify_objc12testCFStringC8cfStringSo0F3RefavpZ : $*CFString
+// CHECK-NOT: begin_access
+// CHECK:   store %{{.*}} to [init] [[GA]] : $*CFString
+// CHECK:   return %{{.*}} : $()                               
+// CHECK-LABEL: } // end sil function 'globalinit{{.*}}'
+class testCFString {
+  public static let cfString: CFString = "" as CFString
+}
+
+// --- objC method.
+// The verifier should be able to handle a thunk of a block and ignore
+// an incoming block argument.
+@objc protocol HasBlock {
+  func block(_: (Int) -> Int)
+}
+
+class HasBlockImpl: HasBlock {
+  @objc func block(_: (Int) -> Int) {}
+}
+// CHECK-LABEL: sil hidden [thunk] @$S25access_marker_verify_objc12HasBlockImplC5blockyyS2iXEFTo : $@convention(objc_method) (@convention(block) @noescape (Int) -> Int, HasBlockImpl) -> () {
+// CHECK: bb0(%0 : @unowned $@convention(block) @noescape (Int) -> Int, %1 : @unowned $HasBlockImpl):
+// CHECK:   [[CP:%.*]] = copy_block %0 : $@convention(block) @noescape (Int) -> Int
+            // function_ref thunk for @callee_unowned @convention(block) (@unowned Int) -> (@unowned Int)
+// CHECK:   [[THUNK:%.*]] = function_ref @$SS2iIyByd_S2iIegyd_TR : $@convention(thin) (Int, @guaranteed @convention(block) @noescape (Int) -> Int) -> Int
+// CHECK:   [[PA:%.*]] = partial_apply [callee_guaranteed] [[THUNK]]([[CP]]) : $@convention(thin) (Int, @guaranteed @convention(block) @noescape (Int) -> Int) -> Int
+// CHECK:   [[CVT:%.*]] = convert_escape_to_noescape [[PA]] : $@callee_guaranteed (Int) -> Int to $@noescape @callee_guaranteed (Int) -> Int
+// CHECK:   [[F:%.*]] = function_ref @$S25access_marker_verify_objc12HasBlockImplC5blockyyS2iXEF : $@convention(method) (@noescape @callee_guaranteed (Int) -> Int, @guaranteed HasBlockImpl) -> ()
+// CHECK:   %{{.*}} = apply [[F]]([[CVT]], %{{.*}}) : $@convention(method) (@noescape @callee_guaranteed (Int) -> Int, @guaranteed HasBlockImpl) -> ()
+// CHECK:   return %{{.*}} : $()                                
+// CHECK-LABEL: } // end sil function '$S25access_marker_verify_objc12HasBlockImplC5blockyyS2iXEFTo'
+
+// thunk for @callee_unowned @convention(block) (@unowned Int) -> (@unowned Int)
+// CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @$SS2iIyByd_S2iIegyd_TR : $@convention(thin) (Int, @guaranteed @convention(block) @noescape (Int) -> Int) -> Int {
+// CHECK: bb0(%0 : @trivial $Int, %1 : @guaranteed $@convention(block) @noescape (Int) -> Int):
+// CHECK:   %{{.*}} = apply %1(%0) : $@convention(block) @noescape (Int) -> Int
+// CHECK:  return %{{.*}} : $Int                               
+// CHECK-LABEL: } // end sil function '$SS2iIyByd_S2iIegyd_TR'
+
+// --- C global.
+// The verifier should ignore this access.
+// CHECK-LABEL: sil hidden @$S25access_marker_verify_objc14GlobalPropertyC14globalCFStringSo0H3RefavgZ : $@convention(method) (@thick GlobalProperty.Type) -> @owned CFString {
+// CHECK: bb0(%0 : @trivial $@thick GlobalProperty.Type):
+// CHECK:   [[GA:%.*]] = global_addr @constCGlobal : $*Optional<CFString>
+// CHECK:   [[STR:%.*]] = load [copy] [[GA]] : $*Optional<CFString>            
+// CHECK: switch_enum [[STR]] : $Optional<CFString>, case #Optional.some!enumelt.1: [[SOMEBB:bb.*]], case #Optional.none!enumelt: bb{{.*}}
+// CHECK:   [[SOMEBB]]([[R:%.*]] : @owned $CFString):
+// CHECK:   return [[R]] : $CFString
+// CHECK_LABEL: } // end sil function '$S25access_marker_verify_objc14GlobalPropertyC14globalCFStringSo0H3RefavgZ'
+class GlobalProperty {
+  public class var globalCFString: CFString { return constCGlobal }
+}

--- a/test/SILOptimizer/access_marker_verify_repl.swift
+++ b/test/SILOptimizer/access_marker_verify_repl.swift
@@ -1,0 +1,12 @@
+// RUN: %target-repl-run-simple-swift -enable-verify-exclusivity -enforce-exclusivity=checked | %FileCheck %s
+// REQUIRES: asserts
+// REQUIRES: OS=macosx
+// REQUIRES: swift_repl
+
+// Test the combination of SILGen + DiagnoseStaticExclusivity with verification.
+//
+// This augments access_marker_verify with tests that require the repl.
+
+// Global variable initialization is different in the repl.
+// CHECK: glob_i8 : Int8 = 8
+var glob_i8:   Int8 = 8

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -84,6 +84,10 @@ static llvm::cl::opt<bool>
 EnableSILOpaqueValues("enable-sil-opaque-values",
                       llvm::cl::desc("Compile the module with sil-opaque-values enabled."));
 
+static llvm::cl::opt<bool>
+VerifyExclusivity("enable-verify-exclusivity",
+                  llvm::cl::desc("Verify the access markers used to enforce exclusivity."));
+
 namespace {
 enum EnforceExclusivityMode {
   Unchecked, // static only
@@ -324,6 +328,7 @@ int main(int argc, char **argv) {
   SILOpts.EnableGuaranteedNormalArguments =
     EnableGuaranteedNormalArguments;
 
+  SILOpts.VerifyExclusivity = VerifyExclusivity;
   if (EnforceExclusivity.getNumOccurrences() != 0) {
     switch (EnforceExclusivity) {
     case EnforceExclusivityMode::Unchecked:


### PR DESCRIPTION
This option runs exhaustive verification of SIL access markers during
the DiagnoseStaticExclusivity pass. It's a good validation of the
exclusivity model implementation.

We can't enable the option by default yet because it generates a
substantial number of useless begin_access [unsafe] markers. This
bloats the SIL, potentially interferes with optimization, and is
prohibitively disruptive to SIL test cases.

The long-term goal is to always emit enough markers for exhaustive
verification, but to simplify SIL/SILGen enough that it isn't as
messy. This can be revisited after generalized accessors and
opaque values are enabled by default.

For now, this option will be tested on the side by "verification" bots
and motivated developers.