### PR TITLE
[CSSolver] Prioritize bindings with fewer default types

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2758,6 +2758,9 @@ private:
       if (!x.hasNonDefaultableBindings())
         return false;
 
+      if (x.FullyBound || x.SubtypeOfExistentialType)
+        return false;
+
       llvm::SmallPtrSet<Constraint *, 8> intersection(x.Sources);
       llvm::set_intersect(intersection, y.Sources);
 
@@ -2774,7 +2777,9 @@ private:
           return x.TypeVar == typeVar;
       }
 
-      return false;
+      // If the only difference is default types,
+      // prioritize bindings with fewer of them.
+      return x.NumDefaultableBindings < y.NumDefaultableBindings;
     }
 
     void foundLiteralBinding(ProtocolDecl *proto) {

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -194,3 +194,10 @@ struct S_35740653 {
 func rdar35740653(val: S_35740653) {
   let _ = 0...Int(val / .value(1.0 / 42.0)) // Ok
 }
+
+protocol P_37290898 {}
+struct S_37290898: P_37290898 {}
+
+func rdar37290898(_ arr: inout [P_37290898], _ element: S_37290898?) {
+  arr += [element].compactMap { $0 } // Ok
+}


### PR DESCRIPTION
With all else equal prioritize bindings with fewer defaultable types,
which always gets us closer to solution since defaultable bindings
mostly come from the collections and could be checked at the end.
This also makes sure that solver not as aggresive at assigning bindings
to trailing closures and allows solver to consider types which come
from inside the closure.

Resolves: rdar://problem/37290898

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
