### PR TITLE
[build-script-impl] Enable llbuild's Swift bindings

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2355,9 +2355,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DFILECHECK_EXECUTABLE:PATH="$(build_directory_bin ${LOCAL_HOST} llvm)/FileCheck"
                     -DCMAKE_BUILD_TYPE:STRING="${LLBUILD_BUILD_TYPE}"
                     -DLLVM_ENABLE_ASSERTIONS:BOOL=$(true_false "${LLBUILD_ENABLE_ASSERTIONS}")
-                    # We disable all bindings, since llbuild builds before Swift
-                    # and can't use the unbuilt `swiftc`.
-                    -DLLBUILD_SUPPORT_BINDINGS:=
+                    -DLLBUILD_SUPPORT_BINDINGS:=Swift
                 )
                 ;;
             swiftpm)


### PR DESCRIPTION
This is no longer a dependency problem because llbuild now builds after
Swift.