### PR TITLE
Remove most uses of OptionalTypeKind.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -90,7 +90,6 @@ namespace swift {
   class PrecedenceGroupDecl;
   class TupleTypeElt;
   class EnumElementDecl;
-  enum OptionalTypeKind : unsigned;
   class ProtocolDecl;
   class SubstitutableType;
   class SourceManager;
@@ -410,17 +409,11 @@ public:
   DECL_CLASS *get##NAME##Decl() const;
 #include "swift/AST/KnownStdlibTypes.def"
 
-  /// Retrieve the declaration of Swift.Optional.
-  EnumDecl *getOptionalDecl(OptionalTypeKind kind) const;
-
   /// Retrieve the declaration of Swift.Optional<T>.Some.
   EnumElementDecl *getOptionalSomeDecl() const;
   
   /// Retrieve the declaration of Swift.Optional<T>.None.
   EnumElementDecl *getOptionalNoneDecl() const;
-
-  EnumElementDecl *getOptionalSomeDecl(OptionalTypeKind kind) const;
-  EnumElementDecl *getOptionalNoneDecl(OptionalTypeKind kind) const;
 
   /// Retrieve the declaration of the "pointee" property of a pointer type.
   VarDecl *getPointerPointeePropertyDecl(PointerTypeKind ptrKind) const;

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -613,12 +613,6 @@ ERROR(invalid_redecl,none,"invalid redeclaration of %0", (DeclName))
 NOTE(invalid_redecl_prev,none,
      "%0 previously declared here", (DeclName))
 
-WARNING(deprecated_redecl_by_optionality, none,
-        "invalid redeclaration of %0 which differs only by the kind of optional passed as an inout argument (%1 vs. %2)",
-        (DeclName, Type, Type))
-NOTE(deprecated_redecl_by_optionality_note, none,
-     "overloading by kind of optional is deprecated and will be removed in a future release", ())
-
 ERROR(ambiguous_type_base,none,
       "%0 is ambiguous for type lookup in this context", (Identifier))
 ERROR(invalid_member_type,none,

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -43,7 +43,6 @@ class ModuleDecl;
 class NominalTypeDecl;
 class GenericTypeDecl;
 class NormalProtocolConformance;
-enum OptionalTypeKind : unsigned;
 class ProtocolConformanceRef;
 class ProtocolDecl;
 class ProtocolType;
@@ -389,8 +388,7 @@ class CanType : public Type {
   static bool isExistentialTypeImpl(CanType type);
   static bool isAnyExistentialTypeImpl(CanType type);
   static bool isObjCExistentialTypeImpl(CanType type);
-  static CanType getOptionalObjectTypeImpl(CanType type,
-                                           OptionalTypeKind &kind);
+  static CanType getOptionalObjectTypeImpl(CanType type, bool &isOptional);
   static CanType getReferenceStorageReferentImpl(CanType type);
   static CanType getWithoutSpecifierTypeImpl(CanType type);
 
@@ -458,12 +456,12 @@ public:
   GenericTypeDecl *getAnyGeneric() const;
 
   CanType getOptionalObjectType() const {
-    OptionalTypeKind kind;
-    return getOptionalObjectTypeImpl(*this, kind);
+    bool isOptional;
+    return getOptionalObjectTypeImpl(*this, isOptional);
   }
 
-  CanType getOptionalObjectType(OptionalTypeKind &kind) const {
-    return getOptionalObjectTypeImpl(*this, kind);
+  CanType getOptionalObjectType(bool &isOptional) const {
+    return getOptionalObjectTypeImpl(*this, isOptional);
   }
 
   CanType getReferenceStorageReferent() const {

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -69,7 +69,6 @@ namespace swift {
   class ModuleDecl;
   class ModuleType;
   class ProtocolConformance;
-  enum OptionalTypeKind : unsigned;
   enum PointerTypeKind : unsigned;
   struct ValueOwnershipKind;
 
@@ -1002,7 +1001,7 @@ public:
   /// Return T if this type is Optional<T>; otherwise, return the null
   /// type. Set \p kind to OTK_Optional if it is an optional, OTK_None
   /// otherwise.
-  Type getOptionalObjectType(OptionalTypeKind &kind);
+  Type getOptionalObjectType(bool &isOptional);
 
   // Return type underlying type of a swift_newtype annotated imported struct;
   // otherwise, return the null type.
@@ -4091,16 +4090,6 @@ class OptionalType : public UnarySyntaxSugarType {
 public:
   /// Return a uniqued optional type with the specified base type.
   static OptionalType *get(Type baseTy);
-
-  /// Build one of the optional type sugar kinds.
-  ///
-  /// It's a bit unnatural to have this on OptionalType, but we don't
-  /// have an abstract common class, and polluting TypeBase with it
-  /// would be unfortunate.  If we ever make an AnyOptionalType,
-  /// we can move it there.
-  ///
-  /// \param kind - can't be OTK_None
-  static Type get(OptionalTypeKind kind, Type baseTy);
 
   // Implement isa/cast/dyncast/etc.
   static bool classof(const TypeBase *T) {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -152,12 +152,6 @@ struct ASTContext::Implementation {
   /// The declaration of Swift.Optional<T>.None.
   EnumElementDecl *OptionalNoneDecl = nullptr;
 
-  /// The declaration of Swift.ImplicitlyUnwrappedOptional<T>.Some.
-  EnumElementDecl *ImplicitlyUnwrappedOptionalSomeDecl = nullptr;
-
-  /// The declaration of Swift.ImplicitlyUnwrappedOptional<T>.None.
-  EnumElementDecl *ImplicitlyUnwrappedOptionalNoneDecl = nullptr;
-  
   /// The declaration of Swift.UnsafeMutableRawPointer.memory.
   VarDecl *UnsafeMutableRawPointerMemoryDecl = nullptr;
 
@@ -642,43 +636,6 @@ CanType ASTContext::getExceptionType() const {
 
 ProtocolDecl *ASTContext::getErrorDecl() const {
   return getProtocol(KnownProtocolKind::Error);
-}
-
-EnumDecl *ASTContext::getOptionalDecl(OptionalTypeKind kind) const {
-  switch (kind) {
-  case OTK_None:
-    llvm_unreachable("not optional");
-  case OTK_ImplicitlyUnwrappedOptional:
-    llvm_unreachable("Should no longer have IUOs");
-  case OTK_Optional:
-    return getOptionalDecl();
-  }
-
-  llvm_unreachable("Unhandled OptionalTypeKind in switch.");
-}
-
-EnumElementDecl *ASTContext::getOptionalSomeDecl(OptionalTypeKind kind) const {
-  switch (kind) {
-  case OTK_Optional:
-    return getOptionalSomeDecl();
-  case OTK_ImplicitlyUnwrappedOptional:
-    llvm_unreachable("Should not have IUOs.");
-  case OTK_None:
-    llvm_unreachable("getting Some decl for non-optional type?");
-  }
-  llvm_unreachable("bad OTK");
-}
-
-EnumElementDecl *ASTContext::getOptionalNoneDecl(OptionalTypeKind kind) const {
-  switch (kind) {
-  case OTK_Optional:
-    return getOptionalNoneDecl();
-  case OTK_ImplicitlyUnwrappedOptional:
-    llvm_unreachable("Should not have IUOs.");
-  case OTK_None:
-    llvm_unreachable("getting None decl for non-optional type?");
-  }
-  llvm_unreachable("bad OTK");
 }
 
 EnumElementDecl *ASTContext::getOptionalSomeDecl() const {
@@ -4023,18 +3980,6 @@ DictionaryType *DictionaryType::get(Type keyType, Type valueType) {
 
   return entry = new (C, arena) DictionaryType(C, keyType, valueType, 
                                                properties);
-}
-
-Type OptionalType::get(OptionalTypeKind which, Type valueType) {
-  switch (which) {
-  // It wouldn't be unreasonable for this method to just ignore
-  // OTK_None if we made code more convenient to write.
-  case OTK_None: llvm_unreachable("building a non-optional type!");
-  case OTK_Optional: return OptionalType::get(valueType);
-  case OTK_ImplicitlyUnwrappedOptional:
-    llvm_unreachable("Should no longer have IUOs");
-  }
-  llvm_unreachable("bad optional type kind");
 }
 
 OptionalType *OptionalType::get(Type base) {

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2687,12 +2687,11 @@ public:
       if (!CD->isInvalid() &&
           CD->getDeclContext()->getDeclaredInterfaceType()->getAnyNominal() !=
               Ctx.getOptionalDecl()) {
-        OptionalTypeKind resultOptionality = OTK_None;
-        CD->getResultInterfaceType()->getOptionalObjectType(resultOptionality);
-        auto declOptionality = CD->getFailability();
+        bool resultIsOptional;
+        CD->getResultInterfaceType()->getOptionalObjectType(resultIsOptional);
+        auto declIsOptional = CD->getFailability() != OTK_None;
 
-        if ((resultOptionality != OTK_None || declOptionality != OTK_None) &&
-            (resultOptionality == OTK_None || declOptionality == OTK_None)) {
+        if (resultIsOptional != declIsOptional) {
           Out << "Initializer has result optionality/failability mismatch\n";
           CD->dump(llvm::errs());
           abort();
@@ -2701,13 +2700,11 @@ public:
         // Also check the interface type.
         if (auto genericFn 
               = CD->getInterfaceType()->getAs<GenericFunctionType>()) {
-          resultOptionality = OTK_None;
           genericFn->getResult()
               ->castTo<AnyFunctionType>()
               ->getResult()
-              ->getOptionalObjectType(resultOptionality);
-          if ((resultOptionality != OTK_None || declOptionality != OTK_None) &&
-              (resultOptionality == OTK_None || declOptionality == OTK_None)) {
+              ->getOptionalObjectType(resultIsOptional);
+          if (resultIsOptional != declIsOptional) {
             Out << "Initializer has result optionality/failability mismatch\n";
             CD->dump(llvm::errs());
             abort();

--- a/lib/AST/TypeJoinMeet.cpp
+++ b/lib/AST/TypeJoinMeet.cpp
@@ -67,8 +67,7 @@ public:
 
     // Until we handle all the combinations of joins, we need to make
     // sure we visit the optional side.
-    OptionalTypeKind otk;
-    if (second->getOptionalObjectType(otk))
+    if (second->getOptionalObjectType())
       return TypeJoin(first).visit(second);
 
     return TypeJoin(second).visit(first);
@@ -160,12 +159,17 @@ CanType TypeJoin::visitBoundGenericEnumType(CanType second) {
   if (First->getKind() != second->getKind())
     return First->getASTContext().TheAnyType;
 
-  OptionalTypeKind otk1, otk2;
-  auto firstObject = First->getOptionalObjectType(otk1);
-  auto secondObject = second->getOptionalObjectType(otk2);
-  if (otk1 == OTK_Optional || otk2 == OTK_Optional) {
-    auto canFirst = firstObject->getCanonicalType();
-    auto canSecond = secondObject->getCanonicalType();
+  bool firstIsOptional, secondIsOptional;
+  auto firstObject = First->getOptionalObjectType(firstIsOptional);
+  auto secondObject = second->getOptionalObjectType(secondIsOptional);
+  if (firstIsOptional || secondIsOptional) {
+    CanType canFirst;
+    CanType canSecond;
+
+    if (firstObject)
+      canFirst = firstObject->getCanonicalType();
+    if (secondObject)
+      canSecond = secondObject->getCanonicalType();
 
     // Compute the join of the unwrapped type. If there is none, we're done.
     auto unwrappedJoin =

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1238,8 +1238,8 @@ static ImportedType adjustTypeForConcreteImport(
     if (!elementType || PTK != PTK_UnsafeMutablePointer)
       return Type();
 
-    OptionalTypeKind OTK;
-    auto insideOptionalType = elementType->getOptionalObjectType(OTK);
+    bool isOptional;
+    auto insideOptionalType = elementType->getOptionalObjectType(isOptional);
     if (!insideOptionalType)
       insideOptionalType = elementType;
 
@@ -1255,10 +1255,8 @@ static ImportedType adjustTypeForConcreteImport(
            "signature of Unmanaged has changed");
 
     auto resultTy = boundGenericTy->getGenericArgs().front();
-    if (OTK != OTK_None) {
-      assert(OTK != OTK_ImplicitlyUnwrappedOptional);
+    if (isOptional)
       resultTy = OptionalType::get(resultTy);
-    }
 
     StringRef pointerName;
     if (importKind == ImportTypeKind::CFRetainedOutParameter)
@@ -1509,8 +1507,7 @@ ImportedType ClangImporter::Implementation::importPropertyType(
 /// Apply the @noescape attribute
 static Type applyNoEscape(Type type) {
   // Recurse into optional types.
-  OptionalTypeKind optKind;
-  if (Type objectType = type->getOptionalObjectType(optKind)) {
+  if (Type objectType = type->getOptionalObjectType()) {
     return OptionalType::get(applyNoEscape(objectType));
   }
 
@@ -1951,8 +1948,8 @@ ImportedType ClangImporter::Implementation::importMethodType(
       clangDecl->getMethodFamily() == clang::OMF_performSelector) {
     // performSelector methods that return 'id' should be imported into Swift
     // as returning Unmanaged<AnyObject>.
-    Type nonOptionalTy =
-        swiftResultTy->getOptionalObjectType(OptionalityOfReturn);
+    bool resultIsOptional;
+    Type nonOptionalTy = swiftResultTy->getOptionalObjectType(resultIsOptional);
     if (!nonOptionalTy)
       nonOptionalTy = swiftResultTy;
 
@@ -1962,7 +1959,7 @@ ImportedType ClangImporter::Implementation::importMethodType(
 
     if (nonOptionalTy->isAnyClassReferenceType()) {
       swiftResultTy = getUnmanagedType(*this, nonOptionalTy);
-      if (OptionalityOfReturn != OTK_None)
+      if (resultIsOptional)
         swiftResultTy = OptionalType::get(swiftResultTy);
     }
   }

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -309,7 +309,8 @@ private:
   getObjectTypeAndOptionality(const Decl *D, Type ty) {
     OptionalTypeKind kind;
     if (auto objTy =
-            ty->getReferenceStorageReferent()->getOptionalObjectType(kind)) {
+            ty->getReferenceStorageReferent()->getOptionalObjectType()) {
+      kind = OTK_Optional;
       if (D->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>())
         kind = OTK_ImplicitlyUnwrappedOptional;
 
@@ -1035,8 +1036,8 @@ private:
       os << ", unsafe_unretained";
     } else {
       Type copyTy = ty;
-      OptionalTypeKind optionalType;
-      if (auto unwrappedTy = copyTy->getOptionalObjectType(optionalType))
+      bool isOptional;
+      if (auto unwrappedTy = copyTy->getOptionalObjectType(isOptional))
         copyTy = unwrappedTy;
 
       auto nominal = copyTy->getNominalOrBoundGenericNominal();
@@ -1053,8 +1054,8 @@ private:
           // Don't print unsafe_unretained twice.
           if (auto boundTy = copyTy->getAs<BoundGenericType>()) {
             ty = boundTy->getGenericArgs().front();
-            if (optionalType != OTK_None)
-              ty = OptionalType::get(optionalType, ty);
+            if (isOptional)
+              ty = OptionalType::get(ty);
           }
         }
       } else if (auto fnTy = copyTy->getAs<FunctionType>()) {
@@ -1670,9 +1671,8 @@ private:
                               optionalKind))
       return;
 
-    OptionalTypeKind innerOptionalKind;
-    if (auto underlying = BGT->getOptionalObjectType(innerOptionalKind)) {
-      visitPart(underlying, innerOptionalKind);
+    if (auto underlying = BGT->getOptionalObjectType()) {
+      visitPart(underlying, OTK_Optional);
     } else
       visitType(BGT, optionalKind);
   }

--- a/lib/SIL/Bridging.cpp
+++ b/lib/SIL/Bridging.cpp
@@ -121,13 +121,12 @@ Type TypeConverter::getLoweredBridgedType(AbstractionPattern pattern,
     bool canBridgeBool = (rep == SILFunctionTypeRepresentation::ObjCMethod);
 
     // Look through optional types.
-    OptionalTypeKind optKind;
-    if (auto valueTy = t->getOptionalObjectType(optKind)) {
+    if (auto valueTy = t->getOptionalObjectType()) {
       pattern = pattern.transformType([](CanType patternTy) {
         return CanType(patternTy->getOptionalObjectType());
       });
       auto ty = getLoweredCBridgedType(pattern, valueTy, canBridgeBool, false);
-      return ty ? OptionalType::get(optKind, ty) : ty;
+      return ty ? OptionalType::get(ty) : ty;
     }
     return getLoweredCBridgedType(pattern, t, canBridgeBool,
                                   purpose == ForResult);

--- a/lib/SIL/DynamicCasts.cpp
+++ b/lib/SIL/DynamicCasts.cpp
@@ -858,9 +858,7 @@ namespace {
         return emitSameType(source, target);
 
       // Handle subtype conversions involving optionals.
-      OptionalTypeKind sourceOptKind;
-      if (auto sourceObjectType =
-              source.FormalType.getOptionalObjectType(sourceOptKind)) {
+      if (auto sourceObjectType = source.FormalType.getOptionalObjectType()) {
         return emitOptionalToOptional(source, sourceObjectType, target);
       }
       assert(!target.FormalType.getOptionalObjectType());

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -637,7 +637,7 @@ bool SILFunctionType::isNoReturnFunction() {
 
 SILType SILType::wrapAnyOptionalType(SILFunction &F) const {
   SILModule &M = F.getModule();
-  EnumDecl *OptionalDecl = M.getASTContext().getOptionalDecl(OTK_Optional);
+  EnumDecl *OptionalDecl = M.getASTContext().getOptionalDecl();
   BoundGenericType *BoundEnumDecl =
       BoundGenericType::get(OptionalDecl, Type(), {getSwiftRValueType()});
   AbstractionPattern Pattern(F.getLoweredFunctionType()->getGenericSignature(),

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -572,10 +572,7 @@ public:
     }
 
     // Optionals should have had their objects lowered.
-    OptionalTypeKind optKind;
-    if (auto objectType = rvalueType.getOptionalObjectType(optKind)) {
-      require(optKind == OTK_Optional,
-              "ImplicitlyUnwrappedOptional is not legal in SIL values");
+    if (auto objectType = rvalueType.getOptionalObjectType()) {
       return checkLegalSILType(F, objectType, I);
     }
 

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1467,8 +1467,7 @@ static CanTupleType getLoweredTupleType(TypeConverter &tc,
 static CanType getLoweredOptionalType(TypeConverter &tc,
                                       AbstractionPattern origType,
                                       CanType substType,
-                                      CanType substObjectType,
-                                      OptionalTypeKind optKind) {
+                                      CanType substObjectType) {
   assert(substType.getOptionalObjectType() == substObjectType);
 
   CanType loweredObjectType =
@@ -1476,7 +1475,7 @@ static CanType getLoweredOptionalType(TypeConverter &tc,
           .getSwiftRValueType();
 
   // If the object type didn't change, we don't have to rebuild anything.
-  if (loweredObjectType == substObjectType && optKind == OTK_Optional) {
+  if (loweredObjectType == substObjectType) {
     return substType;
   }
 
@@ -1651,10 +1650,8 @@ CanType TypeConverter::getLoweredRValueType(AbstractionPattern origType,
   }
 
   // Lower the object type of optional types.
-  OptionalTypeKind optKind;
-  if (auto substObjectType = substType.getOptionalObjectType(optKind)) {
-    return getLoweredOptionalType(*this, origType, substType,
-                                  substObjectType, optKind);
+  if (auto substObjectType = substType.getOptionalObjectType()) {
+    return getLoweredOptionalType(*this, origType, substType, substObjectType);
   }
 
   // The Swift type directly corresponds to the lowered type.

--- a/lib/SILGen/ResultPlan.cpp
+++ b/lib/SILGen/ResultPlan.cpp
@@ -312,7 +312,7 @@ class ForeignErrorInitializationPlan : public ResultPlan {
   ManagedValue managedErrorTemp;
   CanType unwrappedPtrType;
   PointerTypeKind ptrKind;
-  OptionalTypeKind optKind;
+  bool isOptional;
   CanType errorPtrType;
 
 public:
@@ -328,7 +328,7 @@ public:
     // of optional.
     errorPtrType = errorParameter.getType();
     unwrappedPtrType = errorPtrType;
-    if (Type unwrapped = errorPtrType->getOptionalObjectType(optKind))
+    if (Type unwrapped = errorPtrType->getOptionalObjectType(isOptional))
       unwrappedPtrType = unwrapped->getCanonicalType();
 
     auto errorType =
@@ -371,7 +371,7 @@ public:
         SGF.emitLValueToPointer(loc, std::move(lvalue), pointerInfo);
 
     // Wrap up in an Optional if called for.
-    if (optKind != OTK_None) {
+    if (isOptional) {
       auto &optTL = SGF.getTypeLowering(errorPtrType);
       pointerValue = SGF.getOptionalSomeValue(loc, pointerValue, optTL);
     }

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -203,14 +203,12 @@ SILInstruction *CastOptimizer::optimizeBridgedObjCToSwiftCast(
   // Temporary to hold the intermediate result.
   AllocStackInst *Tmp = nullptr;
   CanType OptionalTy;
-  OptionalTypeKind OTK;
   SILValue InOutOptionalParam;
   if (isConditional) {
     // Create a temporary
     OptionalTy = OptionalType::get(Dest->getType().getSwiftRValueType())
                      ->getImplementationType()
                      ->getCanonicalType();
-    OptionalTy.getOptionalObjectType(OTK);
     Tmp = Builder.createAllocStack(Loc,
                                    SILType::getPrimitiveObjectType(OptionalTy));
     InOutOptionalParam = Tmp;
@@ -255,7 +253,7 @@ SILInstruction *CastOptimizer::optimizeBridgedObjCToSwiftCast(
   if (isConditional) {
     // Copy the temporary into Dest.
     // Load from the optional.
-    auto *SomeDecl = Builder.getASTContext().getOptionalSomeDecl(OTK);
+    auto *SomeDecl = Builder.getASTContext().getOptionalSomeDecl();
 
     SILBasicBlock *ConvSuccessBB = Inst->getFunction()->createBasicBlock();
     SmallVector<std::pair<EnumElementDecl *, SILBasicBlock *>, 1> CaseBBs;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1259,9 +1259,8 @@ namespace {
           CS.getConstraintLocator(expr, ConstraintLocator::ApplyArgument));
 
       Type result = tv;
-      if (constr->getFailability() != OTK_None) {
-        result = OptionalType::get(constr->getFailability(), result);
-      }
+      if (constr->getFailability() != OTK_None)
+        result = OptionalType::get(result);
 
       return result;
     }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2047,11 +2047,10 @@ bool swift::fixItOverrideDeclarationTypes(InFlightDiagnostic &diag,
     Type newOverrideTy = baseTy;
 
     // Preserve optionality if we're dealing with a simple type.
-    OptionalTypeKind OTK;
     if (Type unwrappedTy = newOverrideTy->getOptionalObjectType())
       newOverrideTy = unwrappedTy;
-    if (overrideTy->getOptionalObjectType(OTK))
-      newOverrideTy = OptionalType::get(OTK, newOverrideTy);
+    if (overrideTy->getOptionalObjectType())
+      newOverrideTy = OptionalType::get(newOverrideTy);
 
     SmallString<32> baseTypeBuf;
     llvm::raw_svector_ostream baseTypeStr(baseTypeBuf);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -982,63 +982,6 @@ static void checkRedeclaration(TypeChecker &tc, ValueDecl *current) {
           continue;
       }
 
-      // Signatures are the same, but interface types are not. We must
-      // have a type that we've massaged as part of signature
-      // interface type generation. If it's a result of remapping a
-      // function parameter from 'inout T!' to 'inout T?', emit a
-      // warning that these overloads are deprecated and will no
-      // longer be supported in the future.
-      if (!current->getInterfaceType()->isEqual(other->getInterfaceType())) {
-        if (currentDC->isTypeContext() == other->getDeclContext()->isTypeContext()) {
-          auto currFnTy = current->getInterfaceType()->getAs<AnyFunctionType>();
-          auto otherFnTy = other->getInterfaceType()->getAs<AnyFunctionType>();
-          if (currFnTy && otherFnTy && currentDC->isTypeContext()) {
-            currFnTy = currFnTy->getResult()->getAs<AnyFunctionType>();
-            otherFnTy = otherFnTy->getResult()->getAs<AnyFunctionType>();
-          }
-
-          if (currFnTy && otherFnTy) {
-            ArrayRef<AnyFunctionType::Param> currParams = currFnTy->getParams();
-            ArrayRef<AnyFunctionType::Param> otherParams = otherFnTy->getParams();
-
-            if (currParams.size() == otherParams.size()) {
-              auto diagnosed = false;
-              for (unsigned i : indices(currParams)) {
-                if (currParams[i].isInOut() && otherParams[i].isInOut()) {
-                  auto currParamTy = currParams[i]
-                    .getType()
-                    ->getAs<InOutType>()
-                    ->getObjectType();
-                  auto otherParamTy = otherParams[i]
-                    .getType()
-                    ->getAs<InOutType>()
-                    ->getObjectType();
-                  OptionalTypeKind currOTK;
-                  OptionalTypeKind otherOTK;
-                  (void)currParamTy->getOptionalObjectType(currOTK);
-                  (void)otherParamTy->getOptionalObjectType(otherOTK);
-                  if (currOTK != OTK_None && otherOTK != OTK_None &&
-                      currOTK != otherOTK) {
-                    tc.diagnose(current, diag::deprecated_redecl_by_optionality,
-                                current->getFullName(), currParamTy,
-                                otherParamTy);
-                    tc.diagnose(other, diag::invalid_redecl_prev,
-                                other->getFullName());
-                    tc.diagnose(current,
-                                diag::deprecated_redecl_by_optionality_note);
-                    diagnosed = true;
-                    break;
-                  }
-                }
-              }
-
-              if (diagnosed)
-                break;
-            }
-          }
-        }
-      }
-
       // If the conflicting declarations have non-overlapping availability and,
       // we allow the redeclaration to proceed if...
       //
@@ -5662,34 +5605,24 @@ public:
       if (!paramTy || !parentParamTy)
         return;
 
-      OptionalTypeKind paramOTK;
-      (void)paramTy->getOptionalObjectType(paramOTK);
-      if (paramOTK == OTK_Optional)
-        if (!decl->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>())
-          return;
-
-      OptionalTypeKind parentOTK;
-      (void)parentParamTy->getOptionalObjectType(parentOTK);
-
       TypeLoc TL = decl->getTypeLoc();
       if (!TL.getTypeRepr())
         return;
 
-      if (paramOTK == OTK_None) {
-        switch (parentOTK) {
-        case OTK_None:
-          return;
-        case OTK_ImplicitlyUnwrappedOptional:
+      bool paramIsOptional;
+      (void)paramTy->getOptionalObjectType(paramIsOptional);
+
+      bool parentIsOptional;
+      (void)parentParamTy->getOptionalObjectType(parentIsOptional);
+
+      if (paramIsOptional == parentIsOptional)
+        return;
+
+      if (!paramIsOptional) {
+        if (parentDecl->getAttrs()
+                .hasAttribute<ImplicitlyUnwrappedOptionalAttr>())
           if (!treatIUOResultAsError)
             return;
-          break;
-        case OTK_Optional:
-          if (parentDecl->getAttrs()
-                  .hasAttribute<ImplicitlyUnwrappedOptionalAttr>())
-            if (!treatIUOResultAsError)
-              return;
-          break;
-        }
 
         emittedError = true;
         auto diag = TC.diagnose(decl->getStartLoc(),
@@ -5706,7 +5639,7 @@ public:
         return;
       }
 
-      if (parentOTK != OTK_None)
+      if (!decl->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>())
         return;
 
       // Allow silencing this warning using parens.
@@ -5745,13 +5678,12 @@ public:
       if (!resultTy || !parentResultTy)
         return;
 
-      OptionalTypeKind resultOTK;
-      if (!resultTy->getOptionalObjectType(resultOTK))
+      if (!resultTy->getOptionalObjectType())
         return;
 
       TypeRepr *TR = resultTL.getTypeRepr();
 
-      bool resultIsPlainOptional = resultOTK == OTK_Optional;
+      bool resultIsPlainOptional = true;
       if (member->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>())
         resultIsPlainOptional = false;
 

--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -1209,11 +1209,10 @@ recur:
     }
 
     // case nil is equivalent to .none when switching on Optionals.
-    OptionalTypeKind Kind;
-    if (type->getOptionalObjectType(Kind)) {
+    if (type->getOptionalObjectType()) {
       auto EP = cast<ExprPattern>(P);
       if (auto *NLE = dyn_cast<NilLiteralExpr>(EP->getSubExpr())) {
-        auto *NoneEnumElement = Context.getOptionalNoneDecl(Kind);
+        auto *NoneEnumElement = Context.getOptionalNoneDecl();
         P = new (Context) EnumElementPattern(TypeLoc::withoutLoc(type),
                                              NLE->getLoc(), NLE->getLoc(),
                                              NoneEnumElement->getName(),
@@ -1501,8 +1500,7 @@ recur:
 
   case PatternKind::OptionalSome: {
     auto *OP = cast<OptionalSomePattern>(P);
-    OptionalTypeKind optionalKind;
-    Type elementType = type->getOptionalObjectType(optionalKind);
+    Type elementType = type->getOptionalObjectType();
 
     if (elementType.isNull()) {
       auto diagID = diag::optional_element_pattern_not_valid_type;
@@ -1517,7 +1515,7 @@ recur:
       return true;
     }
 
-    EnumElementDecl *elementDecl = Context.getOptionalSomeDecl(optionalKind);
+    EnumElementDecl *elementDecl = Context.getOptionalSomeDecl();
     if (!elementDecl)
       return true;
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1736,14 +1736,12 @@ Type TypeResolver::resolveType(TypeRepr *repr, TypeResolutionOptions options) {
 }
 
 static Type rebuildWithDynamicSelf(ASTContext &Context, Type ty) {
-  OptionalTypeKind OTK;
   if (auto metatypeTy = ty->getAs<MetatypeType>()) {
     return MetatypeType::get(
         rebuildWithDynamicSelf(Context, metatypeTy->getInstanceType()),
         metatypeTy->getRepresentation());
-  } else if (auto optionalTy = ty->getOptionalObjectType(OTK)) {
-    return OptionalType::get(
-        OTK, rebuildWithDynamicSelf(Context, optionalTy));
+  } else if (auto optionalTy = ty->getOptionalObjectType()) {
+    return OptionalType::get(rebuildWithDynamicSelf(Context, optionalTy));
   } else {
     return DynamicSelfType::get(ty, Context);
   }


### PR DESCRIPTION
What remains are places where we are conflating optionality with
either nullability or failability.
