### PR TITLE
[docs] Update man page links

### DIFF
--- a/docs/tools/swift.pod
+++ b/docs/tools/swift.pod
@@ -81,26 +81,15 @@ works, continually evolving to make Swift even better.
 
 =head1 BUGS
 
-Reporting bugs is a great way for anyone to help improve Swift.
-The bug tracker for Swift, an open-source project, is located at
-L<https://bugs.swift.org>.
+Reporting bugs is a great way for anyone to help improve Swift. The bug tracker
+for Swift, an open-source project, is located at L<https://bugs.swift.org>.
 
 If a bug can be reproduced only within an Xcode project or a playground, or if
-the bug is associated with an Apple NDA, please file a report to Apple’s
-bug reporter at L<https://bugreport.apple.com> instead.
+the bug is associated with an Apple NDA, please file a report to Apple's bug
+reporter at L<https://bugreport.apple.com> instead.
 
 =head1 SEE ALSO
 
-=head2 HOME PAGE
-
-L<https://swift.org>
-
-=head2 APPLE DEVELOPER RESOURCES
-
-L<https://developer.apple.com/swift/resources>
-
-=head2 CODE REPOSITORIES
-
-Swift Programming Language at L<https://github.com/apple/swift>
-
-Swift Package Manager at L<https://github.com/apple/swift-package-manager>
+L<https://swift.org/documentation/>    Documentation
+L<https://swift.org/source-code/>      Source Code
+L<https://forums.swift.org>            Forums


### PR DESCRIPTION
This PR makes the following changes to the man page:

* Adds a link to Swift Forums.
* Replaces links to Apple Developer Swift Resources with a link to https://swift.org/documentation/, which both describes that resource _and_ provides a direct link to the latest edition of _The Swift Programming Language_.
* Replaces links to two GitHub repositories with a link to https://swift.org/source-code/, which lists both of those repositories _and_ all other relevant projects (for example, core libraries).

For gardening purposes, some text is also re-wrapped to 80 columns.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
