### PR TITLE
[4.1][CSSolver] Prioritize bindings with fewer default types

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2639,6 +2639,9 @@ private:
       if (!x.hasNonDefaultableBindings())
         return false;
 
+      if (x.FullyBound || x.SubtypeOfExistentialType)
+        return false;
+
       llvm::SmallPtrSet<Constraint *, 8> intersection(x.Sources);
       llvm::set_intersect(intersection, y.Sources);
 
@@ -2655,7 +2658,9 @@ private:
           return x.TypeVar == typeVar;
       }
 
-      return false;
+      // If the only difference is default types,
+      // prioritize bindings with fewer of them.
+      return x.NumDefaultableBindings < y.NumDefaultableBindings;
     }
 
     void foundLiteralBinding(ProtocolDecl *proto) {

--- a/test/Constraints/operator.swift
+++ b/test/Constraints/operator.swift
@@ -194,3 +194,10 @@ struct S_35740653 {
 func rdar35740653(val: S_35740653) {
   let _ = 0...Int(val / .value(1.0 / 42.0)) // Ok
 }
+
+protocol P_37290898 {}
+struct S_37290898: P_37290898 {}
+
+func rdar37290898(_ arr: inout [P_37290898], _ element: S_37290898?) {
+  arr += [element].compactMap { $0 } // Ok
+}


### PR DESCRIPTION
• **Explanation**: With all else equal prioritize bindings with fewer defaultable types,
which always gets us closer to solution since defaultable bindings
mostly come from the collections and could be checked at the end.
This also makes sure that solver not as aggresive at assigning bindings
to trailing closures and allows solver to consider types which come
from inside the closure.
• **Scope of Issue**: Affects logic related to picking bindings for type variables in constraint solver.
• **Origination**: Caused by the performance work related to attempting literal bindings earlier than before which fixes performances related to multiple chained literal array declarations.
• **Risk**: Low risk; Fixes a bug in constraint solver.
• **Reviewed By**: @rudkx 
• **Testing**: Compiler regression tests
• **Radar / SR**: rdar://problem/37290898

Resolves: rdar://problem/37290898
(cherry picked from commit aff49744337ab8d18c0eb68a9720970cbcdfcf72)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
