### PR TITLE
[Sema] Ignore non-useful cast patterns during switch exhaustiveness checking.

### DIFF
--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -786,3 +786,19 @@ func checkLiteralTuples() {
   default: break
   }
 }
+
+func sr6975() {
+  enum E {
+    case a, b
+  }
+
+  let e = E.b
+  switch e {
+  case .a as E: // expected-warning {{'as' test is always true}}
+    print("a")
+  case .b: // Valid!
+    print("b")
+  case .a: // expected-warning {{case is already handled by previous patterns; consider removing it}}
+    print("second a")
+  }
+}


### PR DESCRIPTION
Resolves [SR-6975](https://bugs.swift.org/browse/SR-6975).
