### PR TITLE
Experiment: Disable constraint optimizer.

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3365,7 +3365,7 @@ Type ConstraintSystem::generateConstraints(Pattern *pattern,
 }
 
 void ConstraintSystem::optimizeConstraints(Expr *e) {
-  
+  return;
   SmallVector<Expr *, 16> linkedExprs;
   
   // Collect any linked expressions.


### PR DESCRIPTION
Not to be merged. Just an experiment to see what breaks and how when the constraint optimization pass is disabled.