### PR TITLE
[testsuite] Run only the swift tests for lldb.

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -56,7 +56,7 @@ KNOWN_SETTINGS=(
     lldb-extra-xcodebuild-args  ""               "extra command line args to pass to lldb xcodebuild"
     lldb-test-cc                ""               "CC to use for building LLDB testsuite test inferiors.  Defaults to just-built, in-tree clang.  If set to 'host-toolchain', sets it to same as host-cc."
     lldb-test-with-curses       ""               "run test lldb test runner using curses terminal control"
-    lldb-test-swift-only        ""               "when running lldb tests, only include Swift-specific tests"
+    lldb-test-swift-only        "1"               "when running lldb tests, only include Swift-specific tests"
     lldb-no-debugserver         ""               "delete debugserver after building it, and don't try to codesign it"
     lldb-use-system-debugserver ""               "don't try to codesign debugserver, and use the system's debugserver instead"
     llvm-build-type             "Debug"          "the CMake build variant for LLVM and Clang (Debug, RelWithDebInfo, Release, MinSizeRel).  Defaults to Debug."


### PR DESCRIPTION
Matches what we have on the bot.
Jonas, I'm afraid you'll have to roll back this  locally while working on your "let's clean all the unexpected successes" project.