### PR TITLE
Remove undefined behavior warning for null reference passed to emitLoadedModuleTraceIfNeeded.

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -188,7 +188,7 @@ template <> struct ObjectTraits<LoadedModuleTraceFormat> {
 }
 
 static bool emitLoadedModuleTraceIfNeeded(ASTContext &ctxt,
-                                          DependencyTracker &depTracker,
+                                          DependencyTracker *depTracker,
                                           const FrontendOptions &opts) {
   if (opts.InputsAndOutputs.supplementaryOutputs()
           .LoadedModuleTracePath.empty())
@@ -210,7 +210,7 @@ static bool emitLoadedModuleTraceIfNeeded(ASTContext &ctxt,
   llvm::SmallVector<std::string, 16> swiftModules;
 
   // Canonicalise all the paths by opening them.
-  for (auto &dep : depTracker.getDependencies()) {
+  for (auto &dep : depTracker->getDependencies()) {
     llvm::SmallString<256> buffer;
     StringRef realPath;
     int FD;
@@ -903,7 +903,7 @@ static bool performCompile(CompilerInstance &Instance,
 
   emitReferenceDependenciesIfNeeded(Invocation, Instance);
 
-  (void)emitLoadedModuleTraceIfNeeded(Context, *Instance.getDependencyTracker(),
+  (void)emitLoadedModuleTraceIfNeeded(Context, Instance.getDependencyTracker(),
                                       opts);
 
   if (Context.hadError()) {


### PR DESCRIPTION
<!-- What's in this pull request? -->
My recent refactoring created the possibility of passing a null reference into emitLoadedModuleTraceIfNeeded. I do not believe this would actually ever happen, based on an inspection of prior code. Fix by passing a pointer instead of a reference.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
