### PR TITLE
Partial apply arguments pluszero

### DIFF
--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -92,6 +92,13 @@ public:
                                   SILType substFnTy, SubstitutionList subs,
                                   ArrayRef<ManagedValue> args,
                                   SILType closureTy);
+  ManagedValue createPartialApply(SILLocation loc, ManagedValue fn,
+                                  SILType substFnTy, SubstitutionList subs,
+                                  ArrayRef<ManagedValue> args,
+                                  SILType closureTy) {
+    return createPartialApply(loc, fn.getValue(), substFnTy, subs, args,
+                              closureTy);
+  }
 
   BuiltinInst *createBuiltin(SILLocation loc, Identifier name, SILType resultTy,
                              SubstitutionList subs, ArrayRef<SILValue> args);

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -168,9 +168,9 @@ void SILGenFunction::emitCurryThunk(SILDeclRef thunk) {
   resultTy = F.mapTypeIntoContext(resultTy);
   auto substTy = toFn.getType().substGenericArgs(SGM.M, subs);
 
-  auto calleeConvention = ParameterConvention::Direct_Guaranteed;
-
   // Partially apply the next uncurry level and return the result closure.
+  selfArg = selfArg.ensurePlusOne(*this, vd);
+  auto calleeConvention = ParameterConvention::Direct_Guaranteed;
   auto closureTy = SILGenBuilder::getPartialApplyResultType(
       toFn.getType(), /*appliedParams=*/1, SGM.M, subs, calleeConvention);
   ManagedValue toClosure =

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -82,11 +82,10 @@ SILValue SILGenFunction::emitDynamicMethodRef(SILLocation loc,
   return B.createFunctionRef(loc, F);
 }
 
-static SILValue getNextUncurryLevelRef(SILGenFunction &SGF,
-                                       SILLocation loc,
-                                       SILDeclRef thunk,
-                                       SILValue selfArg,
-                                       SubstitutionList curriedSubs) {
+static ManagedValue getNextUncurryLevelRef(SILGenFunction &SGF, SILLocation loc,
+                                           SILDeclRef thunk,
+                                           ManagedValue selfArg,
+                                           SubstitutionList curriedSubs) {
   auto *vd = thunk.getDecl();
 
   // Reference the next uncurrying level of the function.
@@ -95,12 +94,12 @@ static SILValue getNextUncurryLevelRef(SILGenFunction &SGF,
 
   // If the function is natively foreign, reference its foreign entry point.
   if (requiresForeignToNativeThunk(vd))
-    return SGF.emitGlobalFunctionRef(loc, next);
+    return ManagedValue::forUnmanaged(SGF.emitGlobalFunctionRef(loc, next));
 
   // If the thunk is a curry thunk for a direct method reference, we are
   // doing a direct dispatch (eg, a fragile 'super.foo()' call).
   if (thunk.isDirectReference)
-    return SGF.emitGlobalFunctionRef(loc, next);
+    return ManagedValue::forUnmanaged(SGF.emitGlobalFunctionRef(loc, next));
 
   auto constantInfo = SGF.SGM.Types.getConstantInfo(next);
 
@@ -108,10 +107,13 @@ static SILValue getNextUncurryLevelRef(SILGenFunction &SGF,
     if (getMethodDispatch(func) == MethodDispatch::Class) {
       // Use the dynamic thunk if dynamic.
       if (vd->isDynamic())
-        return SGF.emitDynamicMethodRef(loc, next, constantInfo.SILFnType);
+        return ManagedValue::forUnmanaged(
+                 SGF.emitDynamicMethodRef(loc, next, constantInfo.SILFnType));
 
       auto methodTy = SGF.SGM.Types.getConstantOverrideType(next);
-      return SGF.emitClassMethodRef(loc, selfArg, next, methodTy);
+      SILValue result =
+          SGF.emitClassMethodRef(loc, selfArg.getValue(), next, methodTy);
+      return ManagedValue::forUnmanaged(result);
     }
 
     // If the fully-uncurried reference is to a generic method, look up the
@@ -125,13 +127,14 @@ static SILValue getNextUncurryLevelRef(SILGenFunction &SGF,
       auto origSelfType = protocol->getSelfInterfaceType()->getCanonicalType();
       auto substSelfType = origSelfType.subst(subMap)->getCanonicalType();
       auto conformance = subMap.lookupConformance(origSelfType, protocol);
-      return SGF.B.createWitnessMethod(loc, substSelfType, *conformance, next,
-                                      constantInfo.getSILType());
+      auto result = SGF.B.createWitnessMethod(loc, substSelfType, *conformance,
+                                              next, constantInfo.getSILType());
+      return ManagedValue::forUnmanaged(result);
     }
   }
 
   // Otherwise, emit a direct call.
-  return SGF.emitGlobalFunctionRef(loc, next);
+  return ManagedValue::forUnmanaged(SGF.emitGlobalFunctionRef(loc, next));
 }
 
 void SILGenFunction::emitCurryThunk(SILDeclRef thunk) {
@@ -148,13 +151,13 @@ void SILGenFunction::emitCurryThunk(SILDeclRef thunk) {
   auto selfTy = vd->getInterfaceType()->castTo<AnyFunctionType>()
     ->getInput();
   selfTy = vd->getInnermostDeclContext()->mapTypeIntoContext(selfTy);
-  auto selfArg = F.begin()->createFunctionArgument(getLoweredType(selfTy));
+  ManagedValue selfArg =
+      B.createFunctionArgument(getLoweredType(selfTy), nullptr);
 
   // Forward substitutions.
   auto subs = F.getForwardingSubstitutions();
 
-  SILValue toFn = getNextUncurryLevelRef(*this, vd, thunk,
-                                         selfArg, subs);
+  ManagedValue toFn = getNextUncurryLevelRef(*this, vd, thunk, selfArg, subs);
 
   // FIXME: Using the type from the ConstantInfo instead of looking at
   // getConstantOverrideInfo() for methods looks suspect in the presence
@@ -163,15 +166,15 @@ void SILGenFunction::emitCurryThunk(SILDeclRef thunk) {
       SGM.Types.getConstantInfo(thunk).SILFnType, SGM.M);
   SILType resultTy = fromConv.getSingleSILResultType();
   resultTy = F.mapTypeIntoContext(resultTy);
-  auto substTy = toFn->getType().substGenericArgs(SGM.M,  subs);
+  auto substTy = toFn.getType().substGenericArgs(SGM.M, subs);
 
   auto calleeConvention = ParameterConvention::Direct_Guaranteed;
 
   // Partially apply the next uncurry level and return the result closure.
   auto closureTy = SILGenBuilder::getPartialApplyResultType(
-      toFn->getType(), /*appliedParams=*/1, SGM.M, subs, calleeConvention);
-  SILValue toClosure =
-    B.createPartialApply(vd, toFn, substTy, subs, {selfArg}, closureTy);
+      toFn.getType(), /*appliedParams=*/1, SGM.M, subs, calleeConvention);
+  ManagedValue toClosure =
+      B.createPartialApply(vd, toFn, substTy, subs, {selfArg}, closureTy);
   if (resultTy != closureTy) {
     CanSILFunctionType resultFnTy = resultTy.castTo<SILFunctionType>();
     CanSILFunctionType closureFnTy = closureTy.castTo<SILFunctionType>();
@@ -179,9 +182,7 @@ void SILGenFunction::emitCurryThunk(SILDeclRef thunk) {
       toClosure = B.createConvertFunction(vd, toClosure, resultTy);
     } else {
       toClosure =
-          emitCanonicalFunctionThunk(vd, ManagedValue::forUnmanaged(toClosure),
-                                     closureFnTy, resultFnTy)
-              .forward(*this);
+          emitCanonicalFunctionThunk(vd, toClosure, closureFnTy, resultFnTy);
     }
   }
   B.createReturn(ImplicitReturnLocation::getImplicitReturnLoc(vd), toClosure);


### PR DESCRIPTION
This PR does two two different things in two commits:

1. getNextUncurryLevelRef and emitCurryThunk are converted to traffic in ManagedValues.
2. Now that we are working with ManagedValues, I can fix an issue that comes up a few times when I run the normal test suite with ownership enabled. Basically, we weren't copying a guaranteed value before we passed it off at +1 to a partial apply. So the fix is a simple convention independent ManagedValue::ensurePlusOne(...).

rdar://34222540