### PR TITLE
[Sema] Crash fix for nested type named identically to coding key 

### DIFF
--- a/test/decl/protocol/special/coding/struct_codable_member_type_lookup.swift
+++ b/test/decl/protocol/special/coding/struct_codable_member_type_lookup.swift
@@ -649,3 +649,8 @@ extension C.Inner {
 struct GenericCodableStruct<T : Codable> : Codable {}
 
 func foo(_: GenericCodableStruct<Int>.CodingKeys) // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}
+
+struct sr6886 {
+  struct Nested : Codable {}
+  let Nested: Nested // Don't crash with a coding key that is the same as a nested type name
+}


### PR DESCRIPTION
Code to derive Codable was assuming any decl lookup of a coding key would be a VarDecl, now does the right thing in the presence of identically named other declarations (like nested types).

Resolves [SR-6886](https://bugs.swift.org/browse/SR-6886).