### PR TITLE
[ownership-verifier] Allow owned enum arguments to be passed as guara…

### DIFF
--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -1035,9 +1035,16 @@ OwnershipUseCheckerResult OwnershipCompatibilityUseChecker::visitEnumArgument(
   // The operand has a non-trivial ownership kind. It must match the argument
   // convention.
   auto ownership = getOwnershipKind();
-  auto lifetimeConstraint = (ownership == ValueOwnershipKind::Owned)
-                                ? UseLifetimeConstraint::MustBeInvalidated
-                                : UseLifetimeConstraint::MustBeLive;
+  UseLifetimeConstraint lifetimeConstraint;
+  if (ownership == ValueOwnershipKind::Owned) {
+    if (RequiredKind != ValueOwnershipKind::Owned) {
+      lifetimeConstraint = UseLifetimeConstraint::MustBeLive;
+    } else {
+      lifetimeConstraint = UseLifetimeConstraint::MustBeInvalidated;
+    }
+  } else {
+    lifetimeConstraint = UseLifetimeConstraint::MustBeLive;
+  }
   return {compatibleOwnershipKinds(ownership, RequiredKind),
           lifetimeConstraint};
 }

--- a/test/SIL/ownership-verifier/over_consume_positive.sil
+++ b/test/SIL/ownership-verifier/over_consume_positive.sil
@@ -1,0 +1,31 @@
+// RUN: %target-sil-opt -enable-sil-ownership -enable-sil-verify-all=0 -module-name Swift -o /dev/null 2>&1  %s
+// REQUIRES: asserts
+
+// This file is meant to contain tests that previously the verifier treated
+// incorrectly. This is important to ensure that the verifier does not
+// regress. It should only deal with dataflow over consuming failures.
+
+sil_stage canonical
+
+import Builtin
+
+enum FakeOptional<T> {
+case some(T)
+case none
+}
+
+class Klass {
+}
+
+sil @klass_user : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> ()
+
+sil @guaranteed_is_not_owned_use : $@convention(thin) (@guaranteed Klass) -> () {
+bb0(%0 : @guaranteed $Klass):
+  %1 = copy_value %0 : $Klass
+  %2 = function_ref @klass_user : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> ()
+  %3 = enum $FakeOptional<Klass>, #FakeOptional.some!enumelt.1, %1 : $Klass
+  %4 = apply %2(%3) : $@convention(thin) (@guaranteed FakeOptional<Klass>) -> ()
+  destroy_value %3 : $FakeOptional<Klass>
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
…nteed function arguments.

Enums require special handling in the ownership verifier since an enum is a sum
type whose triviality or non-triviality is erased at function arguments. When
the ownership verifier was changed to allow for owned values to be passed as
guaranteed objects via instantaneous borrowing, this code was not updated.

rdar://34222540