### PR TITLE
[+0-normal-args] Change SILGenFunction::emitDynamicMethodRef to retur…

### DIFF
--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -136,8 +136,10 @@ SILGenFunction::emitSiblingMethodRef(SILLocation loc,
   // dispatch (viz. objc_msgSend for now).
   if (methodConstant.hasDecl()
       && methodConstant.getDecl()->isDynamic()) {
-    methodValue = emitDynamicMethodRef(loc, methodConstant,
-                           SGM.Types.getConstantInfo(methodConstant).SILFnType);
+    methodValue = emitDynamicMethodRef(
+                      loc, methodConstant,
+                      SGM.Types.getConstantInfo(methodConstant).SILFnType)
+                      .getValue();
   } else {
     methodValue = emitGlobalFunctionRef(loc, methodConstant);
   }

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1046,8 +1046,8 @@ public:
   
   /// Returns a reference to a function value that dynamically dispatches
   /// the function in a runtime-modifiable way.
-  SILValue emitDynamicMethodRef(SILLocation loc, SILDeclRef constant,
-                                CanSILFunctionType constantTy);
+  ManagedValue emitDynamicMethodRef(SILLocation loc, SILDeclRef constant,
+                                    CanSILFunctionType constantTy);
 
   /// Returns a reference to a vtable-dispatched method.
   SILValue emitClassMethodRef(SILLocation loc, SILValue selfPtr,

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3282,7 +3282,7 @@ getWitnessFunctionRef(SILGenFunction &SGF,
   case WitnessDispatchKind::Static:
     return SGF.emitGlobalFunctionRef(loc, witness);
   case WitnessDispatchKind::Dynamic:
-    return SGF.emitDynamicMethodRef(loc, witness, witnessFTy);
+    return SGF.emitDynamicMethodRef(loc, witness, witnessFTy).getValue();
   case WitnessDispatchKind::Class: {
     SILValue selfPtr = witnessParams.back().getValue();
     return SGF.emitClassMethodRef(loc, selfPtr, witness, witnessFTy);


### PR DESCRIPTION
…n a ManagedValue.

There are a bunch of methods in this area that do not use ManagedValues, but
that should. This is another step towards unwinding the hairball.

rdar://34222540

----

This is NFC.