### PR TITLE
[+0-normal-args] Use SILGenBuilder in SILGenConvert when injecting an…

### DIFF
--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -691,6 +691,14 @@ ManagedValue SILGenBuilder::createOpenExistentialBoxValue(SILLocation loc,
   return ManagedValue::forUnmanaged(openedExistential);
 }
 
+ManagedValue SILGenBuilder::createOpenExistentialMetatype(SILLocation loc,
+                                                          ManagedValue value,
+                                                          SILType openedType) {
+  SILValue result = SILGenBuilder::createOpenExistentialMetatype(
+      loc, value.getValue(), openedType);
+  return ManagedValue::forTrivialRValue(result);
+}
+
 ManagedValue SILGenBuilder::createStore(SILLocation loc, ManagedValue value,
                                         SILValue address,
                                         StoreOwnershipQualifier qualifier) {

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -313,6 +313,11 @@ public:
   ManagedValue createOpenExistentialBoxValue(SILLocation loc,
                                           ManagedValue original, SILType type);
 
+  using SILBuilder::createOpenExistentialMetatype;
+  ManagedValue createOpenExistentialMetatype(SILLocation loc,
+                                             ManagedValue value,
+                                             SILType openedType);
+
   /// Convert a @convention(block) value to AnyObject.
   ManagedValue createBlockToAnyObject(SILLocation loc, ManagedValue block,
                                       SILType type);


### PR DESCRIPTION
… optional so we propagate through +0 vs +1.

This commit does two different things:

1. Changes some code paths in SILGenConvert to use SILGenBuilder APIs.
2. It eliminates a few bugs in this path exposed by running the SILGen tests
with +0 enabled.

The bug specifically is that we are assuming in this code that the input value
is always at +1, so we unconditionally forward the input value and then create
destroys on the output. This is not correct in general (since we have guaranteed
values) and occurs all the time with +0 arguments enabled.

This is tested by running the SILGen tests with +0 arguments enabled.

rdar://34222540