### PR TITLE
[PrintAsObjC] Prints availability information for properties

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -1119,6 +1119,8 @@ private:
 
     printSwift3ObjCDeprecatedInference(VD);
 
+    printAvailability(VD);
+
     os << ";";
     if (VD->isStatic()) {
       os << ")\n";

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -48,11 +48,17 @@
 // CHECK-DAG: SWIFT_AVAILABILITY(watchos_app_extension,unavailable)
 // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: - (nonnull instancetype)initWithX:(NSInteger)_ OBJC_DESIGNATED_INITIALIZER SWIFT_AVAILABILITY(macos,introduced=10.10);
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger simpleProperty;
+// CHECK-NEXT: @property (nonatomic) NSInteger alwaysUnavailableProperty SWIFT_UNAVAILABLE_MSG("'alwaysUnavailableProperty' has been renamed to 'baz': whatever");
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger alwaysDeprecatedProperty SWIFT_DEPRECATED_MSG("use something else", "quux");
+// CHECK-NEXT: @property (nonatomic, readonly, strong) Availability * _Null_unspecified singlePlatCombinedPropertyClass SWIFT_AVAILABILITY(macos,introduced=10.7,deprecated=10.9,obsoleted=10.10);
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger platformUnavailableRenameWithMessageProperty SWIFT_AVAILABILITY(macos,unavailable,message="'platformUnavailableRenameWithMessageProperty' has been renamed to 'anotherPlea': still trapped");
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: {{^}}SWIFT_AVAILABILITY(macos,introduced=999){{$}}
 // CHECK-NEXT: @interface Availability (SWIFT_EXTENSION(availability))
 // CHECK-NEXT: - (void)extensionAvailability:(WholeClassAvailability * _Nonnull)_;
+// CHECK-NEXT: @property (nonatomic, readonly) NSInteger propertyDeprecatedInsideExtension SWIFT_AVAILABILITY(macos,deprecated=10.10);
 // CHECK-NEXT: @end
 
 // CHECK-LABEL: @interface AvailabilitySub
@@ -147,12 +153,52 @@
     @objc init() {}
     @available(macOS 10.10, *)
     @objc init(x _: Int) {}
+
+    var simpleProperty: Int {
+	get {
+		return 100
+	    }
+    }
+    @available(*, unavailable, message: "whatever", renamed: "baz")
+    @objc var alwaysUnavailableProperty: Int {
+	get {
+		return 100
+	    }
+	set {
+	    }
+    }
+    @available(*, deprecated, message: "use something else", renamed: "quux")
+    @objc var alwaysDeprecatedProperty: Int {
+	get {
+		return -1
+	    }
+    }
+    @available(macOS, introduced: 10.7, deprecated: 10.9, obsoleted: 10.10)
+    @objc var singlePlatCombinedPropertyClass: Availability! {
+	get {
+		return nil
+	    }
+    }
+    @available(macOS, unavailable, renamed: "anotherPlea", message: "still trapped")
+    @objc var platformUnavailableRenameWithMessageProperty: Int {
+	get {
+		return -1
+	    }
+    }
 }
 
 // Deliberately a high number that the default deployment target will not reach.
 @available(macOS 999, *)
 extension Availability {
   @objc func extensionAvailability(_: WholeClassAvailability) {}
+
+
+  @available(macOS, deprecated: 10.10)
+  var propertyDeprecatedInsideExtension: Int {
+	  get {
+		  return 0
+	  }
+  }
 }
 
 @objc class AvailabilitySub: Availability {


### PR DESCRIPTION


<!-- What's in this pull request? -->
Fixes the bug where availability information for properties in Objective-C generated headers were not present.

PS: I haven't written tests considering all the different possibilities for properties because most of the possibilities are covered as a part of availability tests for methods.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-6884](https://bugs.swift.org/browse/SR-6884)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
