### PR TITLE
SwiftDemangle: correct linkage for COFF targets

### DIFF
--- a/include/swift/SwiftDemangle/Platform.h
+++ b/include/swift/SwiftDemangle/Platform.h
@@ -1,0 +1,44 @@
+//===-- SwiftDemangle/Platform.h - SwiftDemangle Platform Decls -*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_DEMANGLE_PLATFORM_H
+#define SWIFT_DEMANGLE_PLATFORM_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#if defined(SwiftDemangle_EXPORTS)
+# if defined(__ELF__)
+#   define SWIFT_DEMANGLE_LINKAGE __attribute__((__visibility__("protected")))
+# elif defined(__MACH__)
+#   define SWIFT_DEMANGLE_LINKAGE __attribute__((__visibility__("default")))
+# else
+#   define SWIFT_DEMANGLE_LINKAGE __declspec(dllexport)
+# endif
+#else
+# if defined(__ELF__)
+#   define SWIFT_DEMANGLE_LINKAGE __attribute__((__visibility__("default")))
+# elif defined(__MACH__)
+#   define SWIFT_DEMANGLE_LINKAGE __attribute__((__visibility__("default")))
+# else
+#   define SWIFT_DEMANGLE_LINKAGE __declspec(dllimport)
+# endif
+#endif
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif
+
+

--- a/include/swift/SwiftDemangle/SwiftDemangle.h
+++ b/include/swift/SwiftDemangle/SwiftDemangle.h
@@ -19,6 +19,8 @@
 #ifndef SWIFT_DEMANGLE_SWIFT_DEMANGLE_H
 #define SWIFT_DEMANGLE_SWIFT_DEMANGLE_H
 
+#include <swift/SwiftDemangle/Platform.h>
+
 /// @{
 /// Version constants for libswiftDemangle library.
 
@@ -40,8 +42,9 @@ extern "C" {
 /// \returns the length of the demangled function name (even if greater than the
 /// size of the output buffer) or 0 if the input is not a Swift-mangled function
 /// name (in which cases \p OutputBuffer is left untouched).
-size_t swift_demangle_getDemangledName(const char *MangledName, char *OutputBuffer,
-                                       size_t Length);
+SWIFT_DEMANGLE_LINKAGE
+size_t swift_demangle_getDemangledName(const char *MangledName,
+                                       char *OutputBuffer, size_t Length);
 
 /// \brief Demangle Swift function names with module names and implicit self
 /// and metatype type names in function signatures stripped.
@@ -49,6 +52,7 @@ size_t swift_demangle_getDemangledName(const char *MangledName, char *OutputBuff
 /// \returns the length of the demangled function name (even if greater than the
 /// size of the output buffer) or 0 if the input is not a Swift-mangled function
 /// name (in which cases \p OutputBuffer is left untouched).
+SWIFT_DEMANGLE_LINKAGE
 size_t swift_demangle_getSimplifiedDemangledName(const char *MangledName,
                                                  char *OutputBuffer,
                                                  size_t Length);
@@ -59,6 +63,7 @@ size_t swift_demangle_getSimplifiedDemangledName(const char *MangledName,
 /// \returns true if the function conforms to the Swift calling convention.
 /// The return value is unspecified if the \p MangledName does not refer to a
 /// function symbol.
+SWIFT_DEMANGLE_LINKAGE
 int swift_demangle_hasSwiftCallingConvention(const char *MangledName);
 
 #ifdef __cplusplus
@@ -91,6 +96,7 @@ extern "C" {
 /// \returns the length of the demangled function name (even if greater than the
 /// size of the output buffer) or 0 if the input is not a Swift-mangled function
 /// name (in which cases \p OutputBuffer is left untouched).
+SWIFT_DEMANGLE_LINKAGE
 size_t fnd_get_demangled_name(const char *MangledName, char *OutputBuffer,
                               size_t Length);
 


### PR DESCRIPTION
This adds the DLL storage attribute on COFF, and switches to protected
visibility on ELF for the interfaces as a small optimization.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
