### PR TITLE
runtime: fix build of the runtime tests for Windows

### DIFF
--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -47,6 +47,13 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     $<TARGET_OBJECTS:swiftRuntime${SWIFT_PRIMARY_VARIANT_SUFFIX}>
     )
 
+  # The local stdlib implementation provides definitions of the swiftCore
+  # interfaes to avoid pulling in swiftCore itself.  Build the SwiftRuntimeTests
+  # with swiftCore_EXPORTS to permit exporting the stdlib interfaces.
+  target_compile_definitions(SwiftRuntimeTests
+                             PRIVATE
+                               swiftCore_EXPORTS)
+
   # FIXME: cross-compile for all variants.
   target_link_libraries(SwiftRuntimeTests
     swiftCore${SWIFT_PRIMARY_VARIANT_SUFFIX}


### PR DESCRIPTION
Ensure that the local definition of the stdlib functions are marked for
export.  We would previously mark the runtime functions as dllimport on
Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
