### PR TITLE
[Deserialization] Weakened DeclContext asssertion in maybeReadGenericParams.

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -738,7 +738,8 @@ GenericParamList *ModuleFile::maybeReadGenericParams(DeclContext *DC,
       // precede SIL linkage, we should be ok.
       assert((genericParam->getDeclContext()->isModuleScopeContext() ||
               DC->isModuleScopeContext() ||
-              genericParam->getDeclContext() == DC) &&
+              genericParam->getDeclContext() == DC ||
+              genericParam->getDeclContext()->isChildContextOf(DC)) &&
              "Mismatched decl context for generic types.");
       params.push_back(genericParam);
       break;

--- a/test/SIL/Serialization/Inputs/def_generic.swift
+++ b/test/SIL/Serialization/Inputs/def_generic.swift
@@ -10,4 +10,8 @@ public class A<T> {
   @_versioned
   @_inlineable
   init() {}
+
+  @_inlineable public subscript<U>(value: T) -> U? {
+    return nil
+  }
 }


### PR DESCRIPTION
An over-eager assertion in ModuleFile::maybeReadGenericParams() rejected
deserialization into the context of a generic subscript for a generic
parameter within one of its accessors. Weaken the assertion; the
DeclContext of the generic parameter will be overwritten with the
correct context later.

Fixes rdar://problem/37408205.
