### PR TITLE
Allow shared_external functions to be considered by interprocedural analysis

### DIFF
--- a/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/BasicCalleeAnalysis.cpp
@@ -34,7 +34,11 @@ bool CalleeList::allCalleesVisible() {
     // Do not consider functions in other modules (libraries) because of library
     // evolution: such function may behave differently in future/past versions
     // of the library.
-    if (Callee->isAvailableExternally())
+    // TODO: exclude functions which are deserialized from modules in the same
+    // resilience domain.
+    if (Callee->isAvailableExternally() &&
+        // shared_external functions are always emitted in the client.
+        Callee->getLinkage() != SILLinkage::SharedExternal)
       return false;
   }
   return true;

--- a/test/SILOptimizer/side-effect.sil
+++ b/test/SILOptimizer/side-effect.sil
@@ -506,3 +506,19 @@ bb0:
   return %r : $()
 }
 
+sil shared_external @shared_external_func : $@convention(thin) () -> () {
+bb0:
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @call_shared_external_func
+// CHECK-NEXT: <func=>
+sil @call_shared_external_func : $@convention(thin) () -> () {
+bb0:
+  %u = function_ref @shared_external_func : $@convention(thin) () -> ()
+  %a = apply %u() : $@convention(thin) () -> ()
+  %r = tuple ()
+  return %r : $()
+}
+


### PR DESCRIPTION

This is a follow-up to https://github.com/apple/swift/pull/14516
