### PR TITLE
[5.0] %swift-target-frontend => %target-swift-frontend.

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/0128-rdar35088384.swift
+++ b/validation-test/compiler_crashers_2_fixed/0128-rdar35088384.swift
@@ -1,4 +1,4 @@
-// RUN: %swift-target-frontend -typecheck -verify %s
+// RUN: %target-swift-frontend -typecheck -verify %s
 
 protocol Command {}
 


### PR DESCRIPTION
Looks like it was a typo.
