### PR TITLE
[silgen] Make ensurePlusOne emit copies even when guaranteed normal a…

### DIFF
--- a/lib/SILGen/ManagedValue.cpp
+++ b/lib/SILGen/ManagedValue.cpp
@@ -203,9 +203,7 @@ void ManagedValue::dump(raw_ostream &os, unsigned indent) const {
 
 ManagedValue ManagedValue::ensurePlusOne(SILGenFunction &SGF,
                                          SILLocation loc) const {
-  // guaranteed-normal-args-todo: We only copy here when guaranteed normal args
-  // are explicitly enabled. Otherwise, this always just returns self.
-  if (SGF.getOptions().EnableGuaranteedNormalArguments && !hasCleanup()) {
+  if (!hasCleanup()) {
     return copy(SGF, loc);
   }
   return *this;


### PR DESCRIPTION
…rguments is not enabled.

I want to use this to fix issues around us forwarding +0 values into memory.
These fixes are good even from the perspective of normal compilation.

rdar://34222540

----

This fixes some of the issues in #14566 since I used ensurePlusOne to fix the exposed issues there
 in emitForceInto.