### PR TITLE
master-next: DLLImport values should not be hidden

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1648,7 +1648,7 @@ getIRLinkage(const UniversalLinkageInfo &info, SILLinkage linkage,
     if (isDefinition) {
       return std::make_tuple(llvm::GlobalValue::AvailableExternallyLinkage,
                              llvm::GlobalValue::DefaultVisibility,
-                             ExportedStorage);
+                             llvm::GlobalValue::DefaultStorageClass);
     }
 
     auto linkage = isWeakImported ? llvm::GlobalValue::ExternalWeakLinkage
@@ -1659,10 +1659,14 @@ getIRLinkage(const UniversalLinkageInfo &info, SILLinkage linkage,
 
   case SILLinkage::HiddenExternal:
   case SILLinkage::PrivateExternal:
-    return std::make_tuple(isDefinition
-                               ? llvm::GlobalValue::AvailableExternallyLinkage
-                               : llvm::GlobalValue::ExternalLinkage,
-                           llvm::GlobalValue::HiddenVisibility,
+    if (isDefinition) {
+      return std::make_tuple(llvm::GlobalValue::AvailableExternallyLinkage,
+                             llvm::GlobalValue::HiddenVisibility,
+                             llvm::GlobalValue::DefaultStorageClass);
+    }
+
+    return std::make_tuple(llvm::GlobalValue::ExternalLinkage,
+                           llvm::GlobalValue::DefaultVisibility,
                            ImportedStorage);
 
   }


### PR DESCRIPTION
LLVM r322806 defaults to make symbols with non-default visibility be marked
as dso_local. However, there is also an assertion that DLLImport symbols
are not dso_local, since that combination makes no sense. These changes
revealed some problems in Swift's IR linkage for PublicExternal,
HiddenExternal and PrivateExternal SIL linkage. Those mean different things
for definitions vs. declarations.

PublicExternal definitions were marked with DLLExport but with
AvailableExternally linkage. That seems inconsistent. AvailableExternally
symbols are not supposed to be emitted at all.

HiddenExternal and PrivateExternal symbols were using the same visibility
and storage class regardless of whether they were declarations or
definitions. This change fixes that so that those symbols are either hidden
or DLLImport but not both at the same time.

rdar://problem/36683229