### PR TITLE
[stdlib] Correctly import C Int types on Windows x64

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4400,6 +4400,13 @@ ASTContext::getForeignRepresentationInfo(NominalTypeDecl *nominal,
 #define MAP_BUILTIN_TYPE(CLANG_BUILTIN_KIND, SWIFT_TYPE_NAME) \
       addTrivial(getIdentifier(#SWIFT_TYPE_NAME), stdlib);
 #include "swift/ClangImporter/BuiltinMappedTypes.def"
+
+      // Even though we may never import types directly as Int or UInt
+      // (e.g. on 64-bit Windows, where CLong maps to Int32 and
+      // CLongLong to Int64), it's always possible to convert an Int
+      // or UInt to a C type.
+      addTrivial(getIdentifier("Int"), stdlib);
+      addTrivial(getIdentifier("UInt"), stdlib);
     }
 
     if (auto darwin = getLoadedModule(Id_Darwin)) {

--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -315,6 +315,21 @@ ClangTypeConverter::reverseBuiltinTypeMapping(IRGenModule &IGM,
   cacheStdlibType(#SWIFT_TYPE_NAME, clang::BuiltinType::CLANG_BUILTIN_KIND);
 #include "swift/ClangImporter/BuiltinMappedTypes.def"
 
+  // On 64-bit Windows, no C type is imported as an Int or UInt; CLong is
+  // imported as an Int32 and CLongLong as an Int64. Therefore, manually
+  // add mappings to C for Int and UInt.
+  if (IGM.Triple.isOSWindows() && IGM.Triple.isArch64Bit()) {
+    // Map UInt to uintptr_t
+    auto swiftUIntType = getNamedSwiftType(stdlib, "UInt");
+    auto clangUIntPtrType = ctx.getCanonicalType(ctx.getUIntPtrType());
+    Cache.insert({swiftUIntType, clangUIntPtrType});
+    
+    // Map Int to intptr_t
+    auto swiftIntType = getNamedSwiftType(stdlib, "Int");
+    auto clangIntPtrType = ctx.getCanonicalType(ctx.getIntPtrType());
+    Cache.insert({swiftIntType, clangIntPtrType});
+  }
+
   // The above code sets up a bunch of mappings in the cache; just
   // assume that we hit one of them.
   auto it = Cache.find(type);

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -28,7 +28,11 @@ public typealias CUnsignedShort = UInt16
 public typealias CUnsignedInt = UInt32
 
 /// The C 'unsigned long' type.
+#if os(Windows) && arch(x86_64)
+public typealias CUnsignedLong = UInt32
+#else
 public typealias CUnsignedLong = UInt
+#endif
 
 /// The C 'unsigned long long' type.
 public typealias CUnsignedLongLong = UInt64
@@ -42,21 +46,15 @@ public typealias CShort = Int16
 /// The C 'int' type.
 public typealias CInt = Int32
 
-#if os(Windows) && arch(x86_64)
 /// The C 'long' type.
+#if os(Windows) && arch(x86_64)
 public typealias CLong = Int32
 #else
-/// The C 'long' type.
 public typealias CLong = Int
 #endif
 
-#if os(Windows) && arch(x86_64)
-/// The C 'long long' type.
-public typealias CLongLong = Int
-#else
 /// The C 'long long' type.
 public typealias CLongLong = Int64
-#endif
 
 /// The C 'float' type.
 public typealias CFloat = Float


### PR DESCRIPTION
64-bit Windows is an LLP64 architecture; unlike on other 64-bit platforms, `long` is a 32-bit type. This means we don't have a one-to-one mapping between `CInt`/`Int32`, `CLong`/`Int`, `CLongLong`/`Int64` like we do on other platforms.

Instead, import `long` as `Int32` and `long long` as `Int64`. An alternative would be to import `long long` as `Int`; however, that would mean that code would require changes in many cases between 32-bit and 64-bit Windows.

Since there's no direct mapping from a C type to `Int`, manually create mappings back from `Int` to `long long`.

Do the same for unsigned data types.