### PR TITLE
[CSSolver/TypeJoin] Look through optional types before trying to join

### DIFF
--- a/test/Sema/type_join.swift
+++ b/test/Sema/type_join.swift
@@ -9,3 +9,7 @@ public func expectEqualType<T>(_: T.Type, _: T.Type) {}
 
 expectEqualType(Builtin.type_join(Int.self, Int.self), Int.self)
 expectEqualType(Builtin.type_join_meta(D.self, C.self), C.self)
+
+func rdar37241221(_ a: C?, _ b: D?) {
+  let _ = [a!, b] // Should be inferred as `[C?]`
+}


### PR DESCRIPTION
Bring back old code which deals with optionality of the types
before trying to compute join, this is temporary before all of the
type visitor cases are implemented and we can switch to better
implementation.

rdar://problem/37241221

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
