### PR TITLE
[ClangImporter] Use unique import locations for bridging headers too

### DIFF
--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -357,13 +357,19 @@ private:
 
   /// \brief The fake buffer used to import modules.
   ///
-  /// FIXME: Horrible hack for loadModule().
-  clang::FileID DummyImportBuffer;
+  /// \see getNextIncludeLoc
+  clang::FileID DummyIncludeBuffer;
 
   /// \brief A count of the number of load module operations.
   ///
-  /// FIXME: Horrible, horrible hack for \c loadModule().
-  unsigned ImportCounter = 0;
+  /// \see getNextIncludeLoc
+  unsigned IncludeCounter = 0;
+
+  /// Generate a dummy Clang source location for header includes and module
+  /// imports.
+  ///
+  /// These have to be unique and valid or Clang gets very confused.
+  clang::SourceLocation getNextIncludeLoc();
 
   /// \brief Used to avoid running the AST verifier over the same declarations.
   size_t VerifiedDeclsCounter = 0;


### PR DESCRIPTION
Like #8303, but for bridging headers. We can have multiple bridging headers if someone is sneaking them into a library target, even though we've tried to lock down on that. Up until now we've been pretending they're all included at offset 0 in the dummy main source file, but that causes problems in rare occasions involving precompiled headers.

(I'm being vague about what those circumstances are because I haven't actually nailed them down yet, nor have I reduced the reproducing project to something that can be checked in as a regression test. But it's something like "we encountered this header through a particular include path, but we thought that include path led to a different header".)

Instead, reuse the fix we had for module imports: a monotonically increasing include location in a fake (but allocated) buffer. This will still put the bridging header first under normal circumstances, but will also handle a mix of module imports and extra bridging headers being loaded.

rdar://problem/34349832