### PR TITLE
Introduce and use a _StringGuts visitor

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -124,6 +124,7 @@ set(SWIFTLIB_ESSENTIAL
   StringBridge.swift
   StringComparable.swift
   StringGuts.swift
+  StringGutsVisitor.swift
   StringObject.swift
   StringIndex.swift
   StringInterpolation.swift

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -286,8 +286,7 @@ extension Character
         return Character(_codeUnitPair: UInt16(_CR), UInt16(_LF))
       },
       utf16: { utf16 in return Character(_unverified: utf16) },
-      opaque: { opaque in return Character(_unverified: opaque) }
-    )
+      opaque: { opaque in return Character(_unverified: opaque) })
   }
 
   /// Construct a Character from a slice of a _StringGuts, assuming
@@ -308,8 +307,7 @@ extension Character
         return Character(_codeUnitPair: UInt16(_CR), UInt16(_LF))
       },
       utf16: { utf16 in return Character(_unverified: utf16) },
-      opaque: { opaque in return Character(_unverified: opaque) }
-    )
+      opaque: { opaque in return Character(_unverified: opaque) })
   }
 
   @_inlineable

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -225,7 +225,9 @@ extension Character
         | UInt64(utf16[3]) &<< 48
       _representation = .smallUTF16(Builtin.trunc_Int64_Int63(bits._value))
     default:
-      _representation = .large(_StringGuts(utf16)._extractNativeStorage())
+      // TODO(SSO): small check
+      _representation = .large(
+        _StringGuts(_large: utf16)._extractNativeStorage())
     }
   }
 
@@ -450,7 +452,8 @@ extension String {
       self = String(decoding: utf16, as: Unicode.UTF16.self)
     }
     else {
-      self = String(_StringGuts(c._largeUTF16!))
+      // TODO(SSO): small check
+      self = String(_StringGuts(_large: c._largeUTF16!))
     }
   }
 }

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -274,38 +274,20 @@ extension Character
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal init(_unverified guts: _StringGuts) {
-    defer { _fixLifetime(guts) }
-    if _slowPath(guts._isOpaque) {
-      self.init(_opaqueUnverified: guts)
-      return
-    }
-
-    if guts.isASCII {
-      let ascii = guts._unmanagedASCIIView
-      if _fastPath(ascii.count == 1) {
-        self.init(_singleCodeUnit: ascii[0])
-      } else {
+    self = _visitGuts(guts,
+      ascii: { ascii in
+        if _fastPath(ascii.count == 1) {
+          return Character(_singleCodeUnit: ascii[0])
+        }
         // The only multi-scalar ASCII grapheme cluster is CR/LF.
         _sanityCheck(ascii.count == 2)
         _sanityCheck(ascii.start[0] == _CR)
         _sanityCheck(ascii.start[1] == _LF)
-        self.init(_codeUnitPair: UInt16(_CR), UInt16(_LF))
-      }
-      return
-    }
-
-    if guts._isNative {
-      self.init(_unverified:
-        guts._object.nativeStorage(of: UTF16.CodeUnit.self))
-    } else {
-      self.init(_unverified: guts._unmanagedUTF16View)
-    }
-  }
-
-  @_versioned // @opaque
-  internal init(_opaqueUnverified guts: _StringGuts) {
-    _sanityCheck(guts._isOpaque)
-    self.init(_unverified: guts._asOpaque())
+        return Character(_codeUnitPair: UInt16(_CR), UInt16(_LF))
+      },
+      utf16: { utf16 in return Character(_unverified: utf16) },
+      opaque: { opaque in return Character(_unverified: opaque) }
+    )
   }
 
   /// Construct a Character from a slice of a _StringGuts, assuming
@@ -313,46 +295,21 @@ extension Character
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal init(_unverified guts: _StringGuts, range: Range<Int>) {
-    defer { _fixLifetime(guts) }
-    if _fastPath(range.count == 1) {
-      let cu = guts.codeUnit(atCheckedOffset: range.lowerBound)
-      // Check for half a surrogate pair. (We may encounter these at boundaries
-      // of String slices or when the data itself has an invalid encoding.)
-      if _fastPath(UTF16._isScalar(cu)) {
-        self.init(_singleCodeUnit: cu)
-      } else {
-        self.init(_singleCodeUnit: UTF16._replacementCodeUnit)
-      }
-      return
-    }
-    if _slowPath(guts._isOpaque) {
-      self.init(_opaqueUnverifiedFixedLifetime: guts, range: range)
-      return
-    }
-
-    if guts.isASCII {
-      let ascii = guts._unmanagedASCIIView
-      // The only multi-scalar ASCII grapheme cluster is CR/LF.
-      ascii._boundsCheck(offsetRange: range)
-      _sanityCheck(range.count == 2)
-      _sanityCheck(ascii.start[range.lowerBound] == _CR)
-      _sanityCheck(ascii.start[range.lowerBound + 1] == _LF)
-      self.init(_codeUnitPair: UInt16(_CR), UInt16(_LF))
-      return
-    }
-
-    _sanityCheck(guts._object.isContiguousUTF16)
-    let utf16 = guts._unmanagedUTF16View.checkedSlice(range)
-    self.init(_unverified: utf16)
-  }
-
-  @_versioned // @opaque
-  internal init(
-    _opaqueUnverifiedFixedLifetime guts: _StringGuts, range: Range<Int>
-  ) {
-    _sanityCheck(guts._isOpaque)
-    let opaque = guts._asOpaque().checkedSlice(range)
-    self.init(_unverified: opaque._copyToNativeStorage())
+    self = _visitGuts(
+      guts, range: (range, performBoundsCheck: true),
+      ascii: { ascii in
+        if _fastPath(ascii.count == 1) {
+          return Character(_singleCodeUnit: ascii[0])
+        }
+        // The only multi-scalar ASCII grapheme cluster is CR/LF.
+        _sanityCheck(ascii.count == 2)
+        _sanityCheck(ascii.start[0] == _CR)
+        _sanityCheck(ascii.start[1] == _LF)
+        return Character(_codeUnitPair: UInt16(_CR), UInt16(_LF))
+      },
+      utf16: { utf16 in return Character(_unverified: utf16) },
+      opaque: { opaque in return Character(_unverified: opaque) }
+    )
   }
 
   @_inlineable

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -16,6 +16,7 @@
     "StringComparable.swift",
     "StringObject.swift",
     "StringGuts.swift",
+    "StringGutsVisitor.swift",
     "StringGraphemeBreaking.swift",  
     "StringHashable.swift",
     "StringIndex.swift",

--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -47,7 +47,7 @@ where Rest.Element : UnsignedInteger {
     guard _fastPath(!overflow0) else { return nil }
     result = result0
   }
-  
+
   while let u = rest.next() {
     let d0 = _asciiDigit(codeUnit: u, radix: radix)
     guard _fastPath(d0 != nil), let d = d0 else { return nil }

--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -145,30 +145,26 @@ extension FixedWidthInteger {
     let r = Self(radix)
     let range = text._encodedOffsetRange
     let guts = text._wholeString._guts
-    defer { _fixLifetime(guts) }
     let result: Self?
-    if _slowPath(guts._isOpaque) {
-      result = Self._opaqueParseFixedLifetime(guts, range, radix: r)
-    } else if guts.isASCII {
-      var i = guts._unmanagedASCIIView[range].makeIterator()
-      result = _parseASCII(codeUnits: &i, radix: r)
-    } else {
-      var i = guts._unmanagedUTF16View[range].makeIterator()
-      result = Self._parseASCIISlowPath(codeUnits: &i, radix: r)
-    }
+    result = _visitGuts(guts,
+      range: (range, false), args: r,
+      ascii: { view, radix in
+        var i = view.makeIterator()
+        return _parseASCII(codeUnits: &i, radix: radix)
+      },
+      utf16: { view, radix in
+        var i = view.makeIterator()
+        return Self._parseASCIISlowPath(codeUnits: &i, radix: radix)
+      },
+      opaque: { view, radix in
+        var i = view.makeIterator()
+        return Self._parseASCIISlowPath(codeUnits: &i, radix: radix)
+      }
+    )
+
     guard _fastPath(result != nil) else { return nil }
     self = result._unsafelyUnwrappedUnchecked
   }
-
-  @_versioned // @opaque
-  static func _opaqueParseFixedLifetime(
-    _ guts: _StringGuts, _ range: Range<Int>, radix r: Self
-  ) -> Self? {
-    _sanityCheck(guts._isOpaque)
-    var i = guts._asOpaque()[range].makeIterator()
-    return Self._parseASCIISlowPath(codeUnits: &i, radix: r)
-  }
-
 
   /// Creates a new integer value from the given string.
   ///

--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -148,8 +148,7 @@ extension FixedWidthInteger {
     defer { _fixLifetime(guts) }
     let result: Self?
     if _slowPath(guts._isOpaque) {
-      var i = guts._asOpaque()[range].makeIterator()
-      result = Self._parseASCIISlowPath(codeUnits: &i, radix: r)
+      result = Self._opaqueParseFixedLifetime(guts, range, radix: r)
     } else if guts.isASCII {
       var i = guts._unmanagedASCIIView[range].makeIterator()
       result = _parseASCII(codeUnits: &i, radix: r)
@@ -160,6 +159,16 @@ extension FixedWidthInteger {
     guard _fastPath(result != nil) else { return nil }
     self = result._unsafelyUnwrappedUnchecked
   }
+
+  @_versioned // @opaque
+  static func _opaqueParseFixedLifetime(
+    _ guts: _StringGuts, _ range: Range<Int>, radix r: Self
+  ) -> Self? {
+    _sanityCheck(guts._isOpaque)
+    var i = guts._asOpaque()[range].makeIterator()
+    return Self._parseASCIISlowPath(codeUnits: &i, radix: r)
+  }
+
 
   /// Creates a new integer value from the given string.
   ///

--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -155,16 +155,13 @@ extension FixedWidthInteger {
       range: (range, false), args: r,
       ascii: { view, radix in
         var i = view.makeIterator()
-        return _parseASCII(codeUnits: &i, radix: radix)
-      },
+        return _parseASCII(codeUnits: &i, radix: radix) },
       utf16: { view, radix in
         var i = view.makeIterator()
-        return Self._parseASCIISlowPath(codeUnits: &i, radix: radix)
-      },
+        return Self._parseASCIISlowPath(codeUnits: &i, radix: radix) },
       opaque: { view, radix in
         var i = view.makeIterator()
-        return Self._parseASCIISlowPath(codeUnits: &i, radix: radix)
-      }
+        return Self._parseASCIISlowPath(codeUnits: &i, radix: radix) }
     )
 
     guard _fastPath(result != nil) else { return nil }

--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -62,6 +62,11 @@ where Rest.Element : UnsignedInteger {
   return result
 }
 
+//
+// TODO (TODO: JIRA): This needs to be completely rewritten. It's about 20KB of
+// always-inline code, most of which are MOV instructions.
+//
+
 @_inlineable // FIXME(sil-serialize-all)
 @_versioned // FIXME(sil-serialize-all)
 @inline(__always)

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -280,14 +280,11 @@ extension _StringGuts {
     _ body: (UnsafePointer<TargetEncoding.CodeUnit>, Int) throws -> Result
   ) rethrows -> Result {
     if _slowPath(_isOpaque) {
-      let opaque = _asOpaque()[bounds]
-      return try Swift._withCStringAndLength(
-        encodedAs: targetEncoding,
-        from: opaque,
-        encodedAs: Unicode.UTF16.self,
-        execute: body
-      )
+      return try _opaqueWithCStringAndLength(
+        in: bounds, encoding: targetEncoding, body)
     }
+
+    defer { _fixLifetime(self) }
     if isASCII {
       let ascii = _unmanagedASCIIView[bounds]
       return try Swift._withCStringAndLength(
@@ -304,6 +301,24 @@ extension _StringGuts {
       encodedAs: Unicode.UTF16.self,
       execute: body
     )
+  }
+
+  @_versioned // @opaque
+  func _opaqueWithCStringAndLength<
+    Result, TargetEncoding: Unicode.Encoding
+  >(
+    in bounds: Range<Int>,
+    encoding targetEncoding: TargetEncoding.Type,
+    _ body: (UnsafePointer<TargetEncoding.CodeUnit>, Int) throws -> Result
+  ) rethrows -> Result {
+    _sanityCheck(_isOpaque)
+    defer { _fixLifetime(self) }
+    let opaque = _asOpaque()[bounds]
+    return try Swift._withCStringAndLength(
+      encodedAs: targetEncoding,
+      from: opaque,
+      encodedAs: Unicode.UTF16.self,
+      execute: body)
   }
 }
 
@@ -967,13 +982,11 @@ extension String {
     into processCodeUnit: (Encoding.CodeUnit) -> Void
   ) {
     if _slowPath(_guts._isOpaque) {
-      let opaque = _guts._asOpaque()
-      var i = opaque.makeIterator()
-      Unicode.UTF16.ForwardParser._parse(&i) {
-        Encoding._transcode($0, from: UTF16.self).forEach(processCodeUnit)
-      }
+      _opaqueEncode(encoding, into: processCodeUnit)
       return
     }
+
+    defer { _fixLifetime(self) }
     if _guts.isASCII {
       let ascii = _guts._unmanagedASCIIView
       if encoding == Unicode.ASCII.self
@@ -994,6 +1007,20 @@ extension String {
     }
     let utf16 = _guts._unmanagedUTF16View
     var i = utf16.makeIterator()
+    Unicode.UTF16.ForwardParser._parse(&i) {
+      Encoding._transcode($0, from: UTF16.self).forEach(processCodeUnit)
+    }
+  }
+
+  @_versioned // @opaque
+  internal func _opaqueEncode<Encoding: Unicode.Encoding>(
+    _ encoding: Encoding.Type,
+    into processCodeUnit: (Encoding.CodeUnit) -> Void
+  ) {
+    _sanityCheck(_guts._isOpaque)
+    defer { _fixLifetime(self) }
+    let opaque = _guts._asOpaque()
+    var i = opaque.makeIterator()
     Unicode.UTF16.ForwardParser._parse(&i) {
       Encoding._transcode($0, from: UTF16.self).forEach(processCodeUnit)
     }

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -291,16 +291,14 @@ extension _StringGuts {
         encodedAs: targetEncoding,
         from: ascii.buffer,
         encodedAs: Unicode.ASCII.self,
-        execute: body
-      )
+        execute: body)
     }
     let utf16 = _unmanagedUTF16View[bounds]
     return try Swift._withCStringAndLength(
       encodedAs: targetEncoding,
       from: utf16.buffer,
       encodedAs: Unicode.UTF16.self,
-      execute: body
-    )
+      execute: body)
   }
 
   @_versioned // @opaque

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -255,6 +255,12 @@ where Source.Iterator.Element == SourceEncoding.CodeUnit {
 }
 
 extension _StringGuts {
+  //
+  // TODO:(TODO: JIRA) This is all very bloated code, needs a rewrite given
+  // StringGuts' new design and the potential to run direclty on internal
+  // storage. For now, follow a hand-coded opaque pattern.
+  //
+
   /// Invokes `body` on a null-terminated sequence of code units in the given
   /// encoding corresponding to the substring in `bounds`.
   @_inlineable // FIXME(sil-serialize-all)
@@ -965,6 +971,12 @@ extension String {
     self._encode(encoding, into: { _ in codeUnitCount += 1 })
     return codeUnitCount
   }
+
+  //
+  // TODO (TODO: JIRA): This needs to be completely rewritten. It's about 12KB
+  // of code, most of which are MOV instructions. Keeping the by-hand opaque
+  // visitation pattern for now.
+  //
 
   // FIXME: this function may not handle the case when a wrapped NSString
   // contains unpaired surrogates.  Fix this before exposing this function as a

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -144,12 +144,13 @@ internal func _getCocoaStringPointer(
 internal
 func _makeCocoaStringGuts(_ cocoaString: _CocoaString) -> _StringGuts {
   if let ascii = cocoaString as? _ASCIIStringStorage {
-    return _StringGuts(ascii)
+    return _StringGuts(_large: ascii)
   } else if let utf16 = cocoaString as? _UTF16StringStorage {
-    return _StringGuts(utf16)
+    return _StringGuts(_large: utf16)
   } else if let wrapped = cocoaString as? _NSContiguousString {
     return wrapped._guts
   } else if _isObjCTaggedPointer(cocoaString) {
+    // TODO(SSO): small check
     return _StringGuts(_taggedCocoaObject: cocoaString)
   }
   // "copy" it into a value to be sure nobody will modify behind
@@ -159,15 +160,18 @@ func _makeCocoaStringGuts(_ cocoaString: _CocoaString) -> _StringGuts {
     = _stdlib_binary_CFStringCreateCopy(cocoaString) as AnyObject
 
   if _isObjCTaggedPointer(immutableCopy) {
+    // TODO(SSO): small check
     return _StringGuts(_taggedCocoaObject: immutableCopy)
   }
 
   let (start, isUTF16) = _getCocoaStringPointer(immutableCopy)
 
+  // TODO(SSO): small check
+
   let length = _StringGuts.getCocoaLength(
     _unsafeBitPattern: Builtin.reinterpretCast(immutableCopy))
   return _StringGuts(
-    _nonTaggedCocoaObject: immutableCopy,
+    _largeNonTaggedCocoaObject: immutableCopy,
     count: length,
     isSingleByte: !isUTF16,
     start: start)
@@ -240,9 +244,9 @@ public final class _NSContiguousString : _SwiftNativeNSString, _NSStringCore {
     _sanityCheck(!guts._isOpaque,
       "_NSContiguousString requires contiguous storage")
     if guts.isASCII {
-      self._guts = _StringGuts(guts._unmanagedASCIIView)
+      self._guts = _StringGuts(_large: guts._unmanagedASCIIView)
     } else {
-      self._guts = _StringGuts(guts._unmanagedUTF16View)
+      self._guts = _StringGuts(_large: guts._unmanagedUTF16View)
     }
     super.init()
   }
@@ -252,9 +256,9 @@ public final class _NSContiguousString : _SwiftNativeNSString, _NSStringCore {
     _sanityCheck(!guts._isOpaque,
       "_NSContiguousString requires contiguous storage")
     if guts.isASCII {
-      self._guts = _StringGuts(guts._unmanagedASCIIView[range])
+      self._guts = _StringGuts(_large: guts._unmanagedASCIIView[range])
     } else {
-      self._guts = _StringGuts(guts._unmanagedUTF16View[range])
+      self._guts = _StringGuts(_large: guts._unmanagedUTF16View[range])
     }
     super.init()
   }

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -30,6 +30,7 @@ func _stdlib_binary_CFStringCreateCopy(
 }
 
 @_inlineable // FIXME(sil-serialize-all)
+@effects(readonly)
 public // @testable
 func _stdlib_binary_CFStringGetLength(
   _ source: _CocoaString

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -572,8 +572,7 @@ extension _StringGuts {
 }
 
 extension _StringGuts {
-  @inline(never)
-  @_versioned
+  // @opaque
   internal func _asOpaque() -> _UnmanagedOpaqueString {
 #if _runtime(_ObjC)
     if _object.isSmall {

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -500,12 +500,7 @@ extension _StringGuts {
       return _taggedCocoaObject
     }
     _sanityCheck(_object.isUnmanaged)
-    if _object.isSingleByte {
-      return _NSContiguousString(_StringGuts(_asUnmanaged(of: UInt8.self)))
-    }
-
-    return _NSContiguousString(
-      _StringGuts(_asUnmanaged(of: UTF16.CodeUnit.self)))
+    return _NSContiguousString(_unmanaged: self)
   }
 
   /// Return an NSString instance containing a slice of this string.

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -519,6 +519,8 @@ extension _StringGuts {
   @_inlineable
   internal
   func _ephemeralCocoaString(_ range: Range<Int>) -> _CocoaString {
+    // Keeping by-hand visit pattern, as this will be removed shortly once
+    // comparison lands.
     if _slowPath(_isOpaque) {
       return _opaqueEphemeralString(range)
     }
@@ -904,6 +906,12 @@ extension _StringGuts {
     }
     return 0
   }
+
+  //
+  // TODO (TODO: JIRA): Remove all of this. StringGuts users need to deal with
+  // the fact that it has multiple representations, otherwise they'll never be
+  // efficient.
+  //
 
   /// Get the UTF-16 code unit stored at the specified position in this string.
   @_inlineable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -298,16 +298,6 @@ extension _StringGuts {
 }
 #else // !_runtime(_ObjC)
 extension _StringGuts {
-  @_versioned
-  @_inlineable
-  internal
-  var _opaqueCount: Int {
-    @inline(__always) get {
-      _sanityCheck(_object.isOpaque)
-      return Int(bitPattern: _otherBits)
-    }
-  }
-
   // TODO(SSO): consider a small-checking variant
   @inline(never)
   @_versioned
@@ -894,7 +884,11 @@ extension _StringGuts {
   internal var _opaqueCount: Int {
     _sanityCheck(_isOpaque)
     defer { _fixLifetime(self) }
+#if _runtime(_ObjC)
     return _asOpaque().count
+#else
+    return Int(bitPattern: _otherBits)
+#endif
   }
 
   @_inlineable

--- a/stdlib/public/core/StringGutsVisitor.swift
+++ b/stdlib/public/core/StringGutsVisitor.swift
@@ -1,0 +1,175 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// TODO: describe
+
+//
+// HACK HACK HACK: For whatever reason, having this directly on String instead
+// of _StringGuts avoids a cascade of ARC. Also note, we can have a global
+// function that forwards, but that function **must not be on _StringGuts**,
+// else ARC.
+//
+extension String {
+  @_versioned
+  @_inlineable
+  @inline(__always)
+  func _visit<Result>(
+    range: (Range<Int>, performBoundsCheck: Bool)? = nil,
+    ascii: /*@convention(thin)*/ (_UnmanagedString<UInt8>) -> Result,
+    utf16: /*@convention(thin)*/ (_UnmanagedString<UInt16>) -> Result,
+    opaque: /*@convention(thin)*/ (_UnmanagedOpaqueString) -> Result
+  ) -> Result {
+    if _slowPath(_guts._isOpaque) {
+      return self._visitOpaque(
+        range: range, ascii: ascii, utf16: utf16, opaque: opaque)
+    }
+
+    defer { _fixLifetime(self) }
+    if _guts.isASCII {
+      var view = _guts._unmanagedASCIIView
+      if let (range, boundsCheck) = range {
+        if boundsCheck {
+          view._boundsCheck(offsetRange: range)
+        }
+        view = view[range]
+      }
+      return ascii(view)
+    } else {
+      var view = _guts._unmanagedUTF16View
+      if let (range, boundsCheck) = range {
+        if boundsCheck {
+          view._boundsCheck(offsetRange: range)
+        }
+        view = view[range]
+      }
+      return utf16(view)
+    }
+  }
+
+  @_versioned
+  @effects(readonly)
+  @inline(never)
+  func _visitOpaque<Result>(
+    range: (Range<Int>, performBoundsCheck: Bool)? = nil,
+    ascii: /*@convention(thin)*/ (_UnmanagedString<UInt8>) -> Result,
+    utf16: /*@convention(thin)*/ (_UnmanagedString<UInt16>) -> Result,
+    opaque: /*@convention(thin)*/ (_UnmanagedOpaqueString) -> Result
+  ) -> Result {
+    _sanityCheck(_guts._isOpaque)
+
+    // TODO: But can it provide a pointer+length representation?
+    defer { _fixLifetime(self) }
+    var view = _guts._asOpaque()
+    if let (range, boundsCheck) = range {
+      if boundsCheck {
+        view._boundsCheck(offsetRange: range)
+      }
+      view = view[range]
+    }
+
+    return opaque(view)
+  }
+
+  @_versioned
+  @_inlineable
+  @inline(__always)
+  func _visit<T, Result>(
+    range: (Range<Int>, performBoundsCheck: Bool)?,
+    args x: T,
+    ascii: /*@convention(thin)*/ (_UnmanagedString<UInt8>, T) -> Result,
+    utf16: /*@convention(thin)*/ (_UnmanagedString<UInt16>, T) -> Result,
+    opaque: /*@convention(thin)*/ (_UnmanagedOpaqueString, T) -> Result
+  ) -> Result {
+    if _slowPath(_guts._isOpaque) {
+      return self._visitOpaque(
+        range: range, args: x, ascii: ascii, utf16: utf16, opaque: opaque)
+    }
+
+    defer { _fixLifetime(self) }
+    if _guts.isASCII {
+      var view = _guts._unmanagedASCIIView
+      if let (range, boundsCheck) = range {
+        if boundsCheck {
+          view._boundsCheck(offsetRange: range)
+        }
+        view = view[range]
+      }
+      return ascii(view, x)
+    } else  {
+      var view = _guts._unmanagedUTF16View
+      if let (range, boundsCheck) = range {
+        if boundsCheck {
+          view._boundsCheck(offsetRange: range)
+        }
+        view = view[range]
+      }
+      return utf16(view, x)
+    }
+  }
+
+  @_versioned
+  @effects(readonly)
+  @inline(never)
+  func _visitOpaque<T, Result>(
+    range: (Range<Int>, performBoundsCheck: Bool)?,
+    args x: T,
+    ascii: /*@convention(thin)*/ (_UnmanagedString<UInt8>, T) -> Result,
+    utf16: /*@convention(thin)*/ (_UnmanagedString<UInt16>, T) -> Result,
+    opaque: /*@convention(thin)*/ (_UnmanagedOpaqueString, T) -> Result
+  ) -> Result {
+    _sanityCheck(_guts._isOpaque)
+
+    // TODO: But can it provide a pointer+length representation?
+    defer { _fixLifetime(self) }
+    var view = _guts._asOpaque()
+    if let (range, boundsCheck) = range {
+      if boundsCheck {
+        view._boundsCheck(offsetRange: range)
+      }
+      view = view[range]
+    }
+
+    return opaque(view, x)
+  }
+}
+
+@_versioned
+@_inlineable
+@inline(__always)
+internal
+func _visitGuts<Result>(
+  _ guts: _StringGuts,
+  range: (Range<Int>, performBoundsCheck: Bool)? = nil,
+  ascii: /*@convention(thin)*/ (_UnmanagedString<UInt8>) -> Result,
+  utf16: /*@convention(thin)*/ (_UnmanagedString<UInt16>) -> Result,
+  opaque: /*@convention(thin)*/ (_UnmanagedOpaqueString) -> Result
+) -> Result {
+  return String(guts)._visit(
+    range: range, ascii: ascii, utf16: utf16, opaque: opaque)
+}
+
+@_versioned
+@_inlineable
+@inline(__always)
+internal
+func _visitGuts<T, Result>(
+  _ guts: _StringGuts,
+  range: (Range<Int>, performBoundsCheck: Bool)? = nil,
+  args x: T,
+  ascii: /*@convention(thin)*/ (_UnmanagedString<UInt8>, T) -> Result,
+  utf16: /*@convention(thin)*/ (_UnmanagedString<UInt16>, T) -> Result,
+  opaque: /*@convention(thin)*/ (_UnmanagedOpaqueString, T) -> Result
+) -> Result {
+  return String(guts)._visit(
+    range: range, args: x, ascii: ascii, utf16: utf16, opaque: opaque)
+}
+

--- a/stdlib/public/core/StringHashable.swift
+++ b/stdlib/public/core/StringHashable.swift
@@ -110,7 +110,7 @@ extension _UnmanagedString where CodeUnit == UTF16.CodeUnit {
   @inline(never) // Hide the CF dependency
   internal func computeHashValue() -> Int {
 #if _runtime(_ObjC)
-    let temp = _NSContiguousString(_StringGuts(self))
+    let temp = _NSContiguousString(_StringGuts(_large: self))
     let hash = temp._unsafeWithNotEscapedSelfPointer {
       return _stdlib_NSStringHashValuePointer($0, isASCII: false)
     }

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -57,9 +57,11 @@ extension String {
     defer { _fixLifetime(repeatedValue) }
     // TODO (TODO: JIRA): Small string detection, micro-benchmarking, etc.
     if _slowPath(repeatedValue._guts._isOpaque) {
-      let opaque = repeatedValue._guts._asOpaque()
-      self.init(_StringGuts(_large: opaque._repeated(count)))
-    } else if repeatedValue._guts.isASCII {
+      self.init(_opaqueRepeating: repeatedValue, count: count)
+      return
+    }
+
+    if repeatedValue._guts.isASCII {
       let ascii = repeatedValue._guts._unmanagedASCIIView
       self.init(_StringGuts(_large: ascii._repeated(count)))
     } else {
@@ -67,6 +69,15 @@ extension String {
       self.init(_StringGuts(_large: utf16._repeated(count)))
     }
   }
+
+  @_versioned // @opaque
+  init(_opaqueRepeating repeatedValue: String, count: Int) {
+    _sanityCheck(repeatedValue._guts._isOpaque)
+    defer { _fixLifetime(repeatedValue) }
+    let opaque = repeatedValue._guts._asOpaque()
+    self.init(_StringGuts(_large: opaque._repeated(count)))
+  }
+
 
   /// A Boolean value indicating whether a string has no characters.
   @_inlineable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -55,15 +55,16 @@ extension String {
 
     precondition(count > 0, "Negative count not allowed")
     defer { _fixLifetime(repeatedValue) }
+    // TODO (TODO: JIRA): Small string detection, micro-benchmarking, etc.
     if _slowPath(repeatedValue._guts._isOpaque) {
       let opaque = repeatedValue._guts._asOpaque()
-      self.init(_StringGuts(opaque._repeated(count)))
+      self.init(_StringGuts(_large: opaque._repeated(count)))
     } else if repeatedValue._guts.isASCII {
       let ascii = repeatedValue._guts._unmanagedASCIIView
-      self.init(_StringGuts(ascii._repeated(count)))
+      self.init(_StringGuts(_large: ascii._repeated(count)))
     } else {
       let utf16 = repeatedValue._guts._unmanagedUTF16View
-      self.init(_StringGuts(utf16._repeated(count)))
+      self.init(_StringGuts(_large: utf16._repeated(count)))
     }
   }
 

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -56,15 +56,11 @@ extension String {
     precondition(count > 0, "Negative count not allowed")
     self = _visitGuts(repeatedValue._guts, range: nil, args: count,
       ascii: { ascii, count in
-        return String(_StringGuts(_large: ascii._repeated(count)))
-      },
+        return String(_StringGuts(_large: ascii._repeated(count))) },
       utf16: { utf16, count in
-        return String(_StringGuts(_large: utf16._repeated(count)))
-      },
+        return String(_StringGuts(_large: utf16._repeated(count))) },
       opaque: { opaque, count in
-        return String(_StringGuts(_large: opaque._repeated(count)))
-      }
-    )
+        return String(_StringGuts(_large: opaque._repeated(count))) })
   }
 
   /// A Boolean value indicating whether a string has no characters.

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -733,7 +733,7 @@ extension _StringObject {
     } else {
       fatalError("Unimplemented string form")
     }
-#endif
+#endif // INTERNAL_CHECKS_ENABLED
   }
 }
 
@@ -752,34 +752,39 @@ extension _StringObject {
     isOpaque: Bool,
     isTwoByte: Bool
   ) {
+#if INTERNAL_CHECKS_ENABLED
+    defer {
+      _sanityCheck(isSmall == (isValue && isSmallOrObjC))
+      _sanityCheck(isUnmanaged == (isValue && !isSmallOrObjC))
+      _sanityCheck(isCocoa == (!isValue && isSmallOrObjC))
+      _sanityCheck(isNative == (!isValue && !isSmallOrObjC))
+    }
+#endif
+
 #if arch(i386) || arch(arm)
-    var variant: _Variant
-    var bits: UInt
     if isValue {
       if isSmallOrObjC {
         _sanityCheck(isOpaque)
-        self.init(
-          isTwoByte ? .smallDoubleByte : .smallSingleByte,
-          _payloadBits)
+        self.init(isTwoByte ? .smallDoubleByte : .smallSingleByte, _payloadBits)
       } else {
         _sanityCheck(!isOpaque)
         self.init(
-          isTwoByte ? .unmanagedDoubleByte : .unmanagedSingleByte,
-          _payloadBits)
+          isTwoByte ? .unmanagedDoubleByte : .unmanagedSingleByte, _payloadBits)
       }
-    } else {
-      var bits: UInt = 0
-      if isSmallOrObjC {
-        bits |= _StringObject._isCocoaBit
-      }
-      if isOpaque {
-        bits |= _StringObject._isOpaqueBit
-      }
-      if isTwoByte {
-        bits |= _StringObject._twoByteBit
-      }
-      self.init(.strong(Builtin.reinterpretCast(_payloadBits)), bits)
+      return
     }
+
+    var bits: UInt = 0
+    if isSmallOrObjC {
+      bits |= _StringObject._isCocoaBit
+    }
+    if isOpaque {
+      bits |= _StringObject._isOpaqueBit
+    }
+    if isTwoByte {
+      bits |= _StringObject._twoByteBit
+    }
+    self.init(.strong(Builtin.reinterpretCast(_payloadBits)), bits)
 #else
     _sanityCheck(_payloadBits & ~_StringObject._payloadMask == 0)
     var rawBits = _payloadBits & _StringObject._payloadMask
@@ -801,10 +806,6 @@ extension _StringObject {
       self.init(nonTaggedRawBits: rawBits)
     }
 #endif
-    _sanityCheck(isSmall == (isValue && isSmallOrObjC))
-    _sanityCheck(isUnmanaged == (isValue && !isSmallOrObjC))
-    _sanityCheck(isCocoa == (!isValue && isSmallOrObjC))
-    _sanityCheck(isNative == (!isValue && !isSmallOrObjC))
   }
 
   @_versioned

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-extension String : StringProtocol, RangeReplaceableCollection {  
+extension String : StringProtocol, RangeReplaceableCollection {
   /// A type that represents the number of steps between two `String.Index`
   /// values, where one value is reachable from the other.
   ///
@@ -32,7 +32,7 @@ extension String : StringProtocol, RangeReplaceableCollection {
   ///
   /// - Parameters:
   ///   - repeatedValue: The character to repeat.
-  ///   - count: The number of times to repeat `repeatedValue` in the 
+  ///   - count: The number of times to repeat `repeatedValue` in the
   ///     resulting string.
   @_inlineable // FIXME(sil-serialize-all)
   public init(repeating repeatedValue: Character, count: Int) {
@@ -43,7 +43,7 @@ extension String : StringProtocol, RangeReplaceableCollection {
   // that String conforms to Collection:
   // - init<T>(_ value: T) where T : LosslessStringConvertible
   // - init<S>(_ characters: S) where S : Sequence, S.Element == Character
-  
+
   /// Creates a new string containing the characters in the given sequence.
   ///
   /// You can use this initializer to create a new string from the result of
@@ -57,16 +57,16 @@ extension String : StringProtocol, RangeReplaceableCollection {
   ///     print(disemvoweled)
   ///     // Prints "Th rn n Spn stys mnly n th pln."
   ///
-  /// - Parameter other: A string instance or another sequence of 
+  /// - Parameter other: A string instance or another sequence of
   ///   characters.
   @_inlineable // FIXME(sil-serialize-all)
   public init<S : Sequence & LosslessStringConvertible>(_ other: S)
   where S.Element == Character {
     self = other.description
   }
-  
+
   // The defaulted argument prevents this initializer from satisfies the
-  // LosslessStringConvertible conformance.  You can satisfy a protocol 
+  // LosslessStringConvertible conformance.  You can satisfy a protocol
   // requirement with something that's not yet available, but not with
   // something that has become unavailable. Without this, the code won't
   // compile as Swift 4.
@@ -311,7 +311,7 @@ extension String {
   ///     print(disemvoweled)
   ///     // Prints "Th rn n Spn stys mnly n th pln."
   ///
-  /// - Parameter characters: A string instance or another sequence of 
+  /// - Parameter characters: A string instance or another sequence of
   ///   characters.
   @_inlineable // FIXME(sil-serialize-all)
   public init<S : Sequence>(_ characters: S)

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -121,12 +121,22 @@ extension String : StringProtocol, RangeReplaceableCollection {
   @_versioned // FIXME(sil-serialize-all)
   internal func _index(atEncodedOffset offset: Int) -> Index {
     if _slowPath(_guts._isOpaque) {
-      return _guts._asOpaque().characterIndex(atOffset: offset)
-    } else if _guts.isASCII {
+      return _opaqueIndex(atEncodedOffset: offset)
+    }
+
+    defer { _fixLifetime(self) }
+    if _guts.isASCII {
       return _guts._unmanagedASCIIView.characterIndex(atOffset: offset)
     } else {
       return _guts._unmanagedUTF16View.characterIndex(atOffset: offset)
     }
+  }
+
+  @_versioned // @opaque
+  func _opaqueIndex(atEncodedOffset offset: Int) -> Index {
+    _sanityCheck(_guts._isOpaque)
+    defer { _fixLifetime(self) }
+    return _guts._asOpaque().characterIndex(atOffset: offset)
   }
 
   /// Returns the position immediately after the given index.
@@ -137,12 +147,22 @@ extension String : StringProtocol, RangeReplaceableCollection {
   @_inlineable // FIXME(sil-serialize-all)
   public func index(after i: Index) -> Index {
     if _slowPath(_guts._isOpaque) {
-      return _guts._asOpaque().characterIndex(after: i)
-    } else if _guts.isASCII {
+      return _opaqueIndex(after: i)
+    }
+
+    defer { _fixLifetime(self) }
+    if _guts.isASCII {
       return _guts._unmanagedASCIIView.characterIndex(after: i)
     } else {
       return _guts._unmanagedUTF16View.characterIndex(after: i)
     }
+  }
+
+  @_versioned // @opaque
+  func _opaqueIndex(after i: Index) -> Index {
+    _sanityCheck(_guts._isOpaque)
+    defer { _fixLifetime(self) }
+    return _guts._asOpaque().characterIndex(after: i)
   }
 
   /// Returns the position immediately before the given index.
@@ -153,12 +173,22 @@ extension String : StringProtocol, RangeReplaceableCollection {
   @_inlineable // FIXME(sil-serialize-all)
   public func index(before i: Index) -> Index {
     if _slowPath(_guts._isOpaque) {
-      return _guts._asOpaque().characterIndex(before: i)
-    } else if _guts.isASCII {
+      return _opaqueIndex(before: i)
+    }
+
+    defer { _fixLifetime(self) }
+    if _guts.isASCII {
       return _guts._unmanagedASCIIView.characterIndex(before: i)
     } else {
       return _guts._unmanagedUTF16View.characterIndex(before: i)
     }
+  }
+
+  @_versioned // @opaque
+  func _opaqueIndex(before i: Index) -> Index {
+    _sanityCheck(_guts._isOpaque)
+    defer { _fixLifetime(self) }
+    return _guts._asOpaque().characterIndex(before: i)
   }
 
   /// Returns an index that is the specified distance from the given index.
@@ -186,12 +216,22 @@ extension String : StringProtocol, RangeReplaceableCollection {
   @_inlineable // FIXME(sil-serialize-all)
   public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
     if _slowPath(_guts._isOpaque) {
-      return _guts._asOpaque().characterIndex(i, offsetBy: n)
-    } else if _guts.isASCII {
+      return _opaqueIndex(i, offsetBy: n)
+    }
+
+    defer { _fixLifetime(self) }
+    if _guts.isASCII {
       return _guts._unmanagedASCIIView.characterIndex(i, offsetBy: n)
     } else {
       return _guts._unmanagedUTF16View.characterIndex(i, offsetBy: n)
     }
+  }
+
+  @_versioned // @opaque
+  func _opaqueIndex(_ i: Index, offsetBy n: IndexDistance) -> Index {
+    _sanityCheck(_guts._isOpaque)
+    defer { _fixLifetime(self) }
+    return _guts._asOpaque().characterIndex(i, offsetBy: n)
   }
 
   /// Returns an index that is the specified distance from the given index,
@@ -236,18 +276,26 @@ extension String : StringProtocol, RangeReplaceableCollection {
     _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
   ) -> Index? {
     if _slowPath(_guts._isOpaque) {
-      return _guts._asOpaque().characterIndex(i, offsetBy: n, limitedBy: limit)
-    } else if _guts.isASCII {
+      return _opaqueIndex(i, offsetBy: n, limitedBy: limit)
+    }
+
+    defer { _fixLifetime(self) }
+    if _guts.isASCII {
       return _guts._unmanagedASCIIView.characterIndex(
-        i,
-        offsetBy: n,
-        limitedBy: limit)
+        i, offsetBy: n, limitedBy: limit)
     } else {
       return _guts._unmanagedUTF16View.characterIndex(
-        i,
-        offsetBy: n,
-        limitedBy: limit)
+        i, offsetBy: n, limitedBy: limit)
     }
+  }
+
+  @_versioned // @opaque
+  func _opaqueIndex(
+    _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
+  ) -> Index? {
+    _sanityCheck(_guts._isOpaque)
+    defer { _fixLifetime(self) }
+    return _guts._asOpaque().characterIndex(i, offsetBy: n, limitedBy: limit)
   }
 
   /// Returns the distance between two indices.
@@ -262,12 +310,22 @@ extension String : StringProtocol, RangeReplaceableCollection {
   @_inlineable // FIXME(sil-serialize-all)
   public func distance(from start: Index, to end: Index) -> IndexDistance {
     if _slowPath(_guts._isOpaque) {
-      return _guts._asOpaque().characterDistance(from: start, to: end)
-    } else if _guts.isASCII {
+      return _opaqueDistance(from: start, to: end)
+    }
+
+    defer { _fixLifetime(self) }
+    if _guts.isASCII {
       return _guts._unmanagedASCIIView.characterDistance(from: start, to: end)
     } else {
       return _guts._unmanagedUTF16View.characterDistance(from: start, to: end)
     }
+  }
+
+  @_versioned // @opaque
+  func _opaqueDistance(from start: Index, to end: Index) -> IndexDistance {
+    _sanityCheck(_guts._isOpaque)
+    defer { _fixLifetime(self) }
+    return _guts._asOpaque().characterDistance(from: start, to: end)
   }
 
   /// Accesses the character at the given position.
@@ -288,12 +346,22 @@ extension String : StringProtocol, RangeReplaceableCollection {
   @_inlineable // FIXME(sil-serialize-all)
   public subscript(i: Index) -> Character {
     if _slowPath(_guts._isOpaque) {
-      return _guts._asOpaque().character(at: i)
-    } else if _guts.isASCII {
+      return _opaqueSubscript(i)
+    }
+
+    defer { _fixLifetime(self) }
+    if _guts.isASCII {
       return _guts._unmanagedASCIIView.character(at: i)
     } else {
       return _guts._unmanagedUTF16View.character(at: i)
     }
+  }
+
+  @_versioned // @opaque
+  func _opaqueSubscript(_ i: Index) -> Character {
+    _sanityCheck(_guts._isOpaque)
+    defer { _fixLifetime(self) }
+    return _guts._asOpaque().character(at: i)
   }
 }
 
@@ -488,14 +556,25 @@ extension String {
       _sanityCheck(stride > 0)
       return Int(stride)
     }
-    let offset = i.encodedOffset
     if _slowPath(_guts._isOpaque) {
-      return _guts._asOpaque().characterStride(atOffset: offset)
-    } else if _guts.isASCII {
+      return _opaqueStride(of: i)
+    }
+
+    let offset = i.encodedOffset
+    defer { _fixLifetime(self) }
+    if _guts.isASCII {
       return _guts._unmanagedASCIIView.characterStride(atOffset: offset)
     } else {
       return _guts._unmanagedUTF16View.characterStride(atOffset: offset)
     }
+  }
+
+  @_versioned // @opaque
+  func _opaqueStride(of i: Index) -> Int {
+    _sanityCheck(_guts._isOpaque)
+    defer { _fixLifetime(self) }
+    let offset = i.encodedOffset
+    return _guts._asOpaque().characterStride(atOffset: offset)
   }
 
   /// Removes the characters in the given range.

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -120,23 +120,11 @@ extension String : StringProtocol, RangeReplaceableCollection {
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal func _index(atEncodedOffset offset: Int) -> Index {
-    if _slowPath(_guts._isOpaque) {
-      return _opaqueIndex(atEncodedOffset: offset)
-    }
-
-    defer { _fixLifetime(self) }
-    if _guts.isASCII {
-      return _guts._unmanagedASCIIView.characterIndex(atOffset: offset)
-    } else {
-      return _guts._unmanagedUTF16View.characterIndex(atOffset: offset)
-    }
-  }
-
-  @_versioned // @opaque
-  func _opaqueIndex(atEncodedOffset offset: Int) -> Index {
-    _sanityCheck(_guts._isOpaque)
-    defer { _fixLifetime(self) }
-    return _guts._asOpaque().characterIndex(atOffset: offset)
+    return _visitGuts(_guts, args: offset,
+      ascii: { ascii, offset in return ascii.characterIndex(atOffset: offset) },
+      utf16: { utf16, offset in return utf16.characterIndex(atOffset: offset) },
+      opaque: { opaque, offset in
+        return opaque.characterIndex(atOffset: offset) })
   }
 
   /// Returns the position immediately after the given index.
@@ -146,23 +134,10 @@ extension String : StringProtocol, RangeReplaceableCollection {
   /// - Returns: The index value immediately after `i`.
   @_inlineable // FIXME(sil-serialize-all)
   public func index(after i: Index) -> Index {
-    if _slowPath(_guts._isOpaque) {
-      return _opaqueIndex(after: i)
-    }
-
-    defer { _fixLifetime(self) }
-    if _guts.isASCII {
-      return _guts._unmanagedASCIIView.characterIndex(after: i)
-    } else {
-      return _guts._unmanagedUTF16View.characterIndex(after: i)
-    }
-  }
-
-  @_versioned // @opaque
-  func _opaqueIndex(after i: Index) -> Index {
-    _sanityCheck(_guts._isOpaque)
-    defer { _fixLifetime(self) }
-    return _guts._asOpaque().characterIndex(after: i)
+    return _visitGuts(_guts, args: i,
+      ascii: { ascii, i in ascii.characterIndex(after: i) },
+      utf16: { utf16, i in utf16.characterIndex(after: i) },
+      opaque: { opaque, i in opaque.characterIndex(after: i) })
   }
 
   /// Returns the position immediately before the given index.
@@ -172,23 +147,10 @@ extension String : StringProtocol, RangeReplaceableCollection {
   /// - Returns: The index value immediately before `i`.
   @_inlineable // FIXME(sil-serialize-all)
   public func index(before i: Index) -> Index {
-    if _slowPath(_guts._isOpaque) {
-      return _opaqueIndex(before: i)
-    }
-
-    defer { _fixLifetime(self) }
-    if _guts.isASCII {
-      return _guts._unmanagedASCIIView.characterIndex(before: i)
-    } else {
-      return _guts._unmanagedUTF16View.characterIndex(before: i)
-    }
-  }
-
-  @_versioned // @opaque
-  func _opaqueIndex(before i: Index) -> Index {
-    _sanityCheck(_guts._isOpaque)
-    defer { _fixLifetime(self) }
-    return _guts._asOpaque().characterIndex(before: i)
+    return _visitGuts(_guts, args: i,
+      ascii: { ascii, i in ascii.characterIndex(before: i) },
+      utf16: { utf16, i in utf16.characterIndex(before: i) },
+      opaque: { opaque, i in opaque.characterIndex(before: i) })
   }
 
   /// Returns an index that is the specified distance from the given index.
@@ -215,23 +177,13 @@ extension String : StringProtocol, RangeReplaceableCollection {
   /// - Complexity: O(*n*), where *n* is the absolute value of `n`.
   @_inlineable // FIXME(sil-serialize-all)
   public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
-    if _slowPath(_guts._isOpaque) {
-      return _opaqueIndex(i, offsetBy: n)
-    }
-
-    defer { _fixLifetime(self) }
-    if _guts.isASCII {
-      return _guts._unmanagedASCIIView.characterIndex(i, offsetBy: n)
-    } else {
-      return _guts._unmanagedUTF16View.characterIndex(i, offsetBy: n)
-    }
-  }
-
-  @_versioned // @opaque
-  func _opaqueIndex(_ i: Index, offsetBy n: IndexDistance) -> Index {
-    _sanityCheck(_guts._isOpaque)
-    defer { _fixLifetime(self) }
-    return _guts._asOpaque().characterIndex(i, offsetBy: n)
+    return _visitGuts(_guts, args: (i, n),
+      ascii: { ascii, args in let (i, n) = args
+        return ascii.characterIndex(i, offsetBy: n) },
+      utf16: { utf16, args in let (i, n) = args
+        return utf16.characterIndex(i, offsetBy: n) },
+      opaque: { opaque, args in let (i, n) = args
+        return opaque.characterIndex(i, offsetBy: n) })
   }
 
   /// Returns an index that is the specified distance from the given index,
@@ -275,27 +227,13 @@ extension String : StringProtocol, RangeReplaceableCollection {
   public func index(
     _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
   ) -> Index? {
-    if _slowPath(_guts._isOpaque) {
-      return _opaqueIndex(i, offsetBy: n, limitedBy: limit)
-    }
-
-    defer { _fixLifetime(self) }
-    if _guts.isASCII {
-      return _guts._unmanagedASCIIView.characterIndex(
-        i, offsetBy: n, limitedBy: limit)
-    } else {
-      return _guts._unmanagedUTF16View.characterIndex(
-        i, offsetBy: n, limitedBy: limit)
-    }
-  }
-
-  @_versioned // @opaque
-  func _opaqueIndex(
-    _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
-  ) -> Index? {
-    _sanityCheck(_guts._isOpaque)
-    defer { _fixLifetime(self) }
-    return _guts._asOpaque().characterIndex(i, offsetBy: n, limitedBy: limit)
+    return _visitGuts(_guts, args: (i, n, limit),
+      ascii: { ascii, args in let (i, n, limit) = args
+        return ascii.characterIndex(i, offsetBy: n, limitedBy: limit) },
+      utf16: { utf16, args in let (i, n, limit) = args
+        return utf16.characterIndex(i, offsetBy: n, limitedBy: limit) },
+      opaque: { opaque, args in let (i, n, limit) = args
+        return opaque.characterIndex(i, offsetBy: n, limitedBy: limit) })
   }
 
   /// Returns the distance between two indices.
@@ -309,23 +247,13 @@ extension String : StringProtocol, RangeReplaceableCollection {
   /// - Complexity: O(*n*), where *n* is the resulting distance.
   @_inlineable // FIXME(sil-serialize-all)
   public func distance(from start: Index, to end: Index) -> IndexDistance {
-    if _slowPath(_guts._isOpaque) {
-      return _opaqueDistance(from: start, to: end)
-    }
-
-    defer { _fixLifetime(self) }
-    if _guts.isASCII {
-      return _guts._unmanagedASCIIView.characterDistance(from: start, to: end)
-    } else {
-      return _guts._unmanagedUTF16View.characterDistance(from: start, to: end)
-    }
-  }
-
-  @_versioned // @opaque
-  func _opaqueDistance(from start: Index, to end: Index) -> IndexDistance {
-    _sanityCheck(_guts._isOpaque)
-    defer { _fixLifetime(self) }
-    return _guts._asOpaque().characterDistance(from: start, to: end)
+    return _visitGuts(_guts, args: (start, end),
+      ascii: { ascii, args in let (start, end) = args
+        return ascii.characterDistance(from: start, to: end) },
+      utf16: { utf16, args in let (start, end) = args
+        return utf16.characterDistance(from: start, to: end) },
+      opaque: { opaque, args in let (start, end) = args
+        return opaque.characterDistance(from: start, to: end) })
   }
 
   /// Accesses the character at the given position.
@@ -345,23 +273,10 @@ extension String : StringProtocol, RangeReplaceableCollection {
   ///   string's end index.
   @_inlineable // FIXME(sil-serialize-all)
   public subscript(i: Index) -> Character {
-    if _slowPath(_guts._isOpaque) {
-      return _opaqueSubscript(i)
-    }
-
-    defer { _fixLifetime(self) }
-    if _guts.isASCII {
-      return _guts._unmanagedASCIIView.character(at: i)
-    } else {
-      return _guts._unmanagedUTF16View.character(at: i)
-    }
-  }
-
-  @_versioned // @opaque
-  func _opaqueSubscript(_ i: Index) -> Character {
-    _sanityCheck(_guts._isOpaque)
-    defer { _fixLifetime(self) }
-    return _guts._asOpaque().character(at: i)
+    return _visitGuts(_guts, args: i,
+      ascii: { ascii, i in return ascii.character(at: i) },
+      utf16: { utf16, i in return utf16.character(at: i) },
+      opaque: { opaque, i in return opaque.character(at: i) })
   }
 }
 
@@ -556,25 +471,14 @@ extension String {
       _sanityCheck(stride > 0)
       return Int(stride)
     }
-    if _slowPath(_guts._isOpaque) {
-      return _opaqueStride(of: i)
-    }
-
     let offset = i.encodedOffset
-    defer { _fixLifetime(self) }
-    if _guts.isASCII {
-      return _guts._unmanagedASCIIView.characterStride(atOffset: offset)
-    } else {
-      return _guts._unmanagedUTF16View.characterStride(atOffset: offset)
-    }
-  }
-
-  @_versioned // @opaque
-  func _opaqueStride(of i: Index) -> Int {
-    _sanityCheck(_guts._isOpaque)
-    defer { _fixLifetime(self) }
-    let offset = i.encodedOffset
-    return _guts._asOpaque().characterStride(atOffset: offset)
+    return _visitGuts(_guts, args: offset,
+      ascii: { ascii, offset in
+        return ascii.characterStride(atOffset: offset) },
+      utf16: { utf16, offset in
+        return utf16.characterStride(atOffset: offset) },
+      opaque: { opaque, offset in
+        return opaque.characterStride(atOffset: offset) })
   }
 
   /// Removes the characters in the given range.

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -247,50 +247,20 @@ extension _SwiftStringStorage {
   @_versioned
   @nonobjc
   internal final func _appendInPlace(_ other: _StringGuts, range: Range<Int>) {
-    if _slowPath(other._isOpaque) {
-      _opaqueAppendInPlace(opaqueOther: other, range: range)
-      return
-    }
-
-    defer { _fixLifetime(other) }
-    if other.isASCII {
-      _appendInPlace(other._unmanagedASCIIView[range])
-    } else {
-      _appendInPlace(other._unmanagedUTF16View[range])
-    }
-  }
-
-  @_versioned // @opaque
-  internal final func _opaqueAppendInPlace(
-    opaqueOther other: _StringGuts, range: Range<Int>
-  ) {
-    _sanityCheck(other._isOpaque)
-    defer { _fixLifetime(other) }
-    _appendInPlace(other._asOpaque()[range])
+    _visitGuts(other, range: (range, performBoundsCheck: false),
+      ascii: { ascii in _appendInPlace(ascii) },
+      utf16: { utf16 in _appendInPlace(utf16) },
+      opaque: { opaque in _appendInPlace(opaque) })
   }
 
   @_inlineable
   @_versioned
   @nonobjc
   internal final func _appendInPlace(_ other: _StringGuts) {
-    if _slowPath(other._isOpaque) {
-      _opaqueAppendInPlace(opaqueOther: other)
-      return
-    }
-
-    defer { _fixLifetime(other) }
-    if other.isASCII {
-      _appendInPlace(other._unmanagedASCIIView)
-    } else {
-      _appendInPlace(other._unmanagedUTF16View)
-    }
-  }
-
-  @_versioned // @opaque
-  internal final func _opaqueAppendInPlace(opaqueOther other: _StringGuts) {
-    _sanityCheck(other._isOpaque)
-    defer { _fixLifetime(other) }
-    _appendInPlace(other._asOpaque())
+    _visitGuts(other,
+      ascii: { ascii in _appendInPlace(ascii) },
+      utf16: { utf16 in _appendInPlace(utf16) },
+      opaque: { opaque in _appendInPlace(opaque) })
   }
 
   @_inlineable

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -247,20 +247,50 @@ extension _SwiftStringStorage {
   @_versioned
   @nonobjc
   internal final func _appendInPlace(_ other: _StringGuts, range: Range<Int>) {
-    _visitGuts(other, range: (range, performBoundsCheck: false),
-      ascii: { ascii in _appendInPlace(ascii) },
-      utf16: { utf16 in _appendInPlace(utf16) },
-      opaque: { opaque in _appendInPlace(opaque) })
+    if _slowPath(other._isOpaque) {
+      _opaqueAppendInPlace(opaqueOther: other, range: range)
+      return
+    }
+
+    defer { _fixLifetime(other) }
+    if other.isASCII {
+      _appendInPlace(other._unmanagedASCIIView[range])
+    } else {
+      _appendInPlace(other._unmanagedUTF16View[range])
+    }
+  }
+
+  @_versioned // @opaque
+  internal final func _opaqueAppendInPlace(
+    opaqueOther other: _StringGuts, range: Range<Int>
+  ) {
+    _sanityCheck(other._isOpaque)
+    defer { _fixLifetime(other) }
+    _appendInPlace(other._asOpaque()[range])
   }
 
   @_inlineable
   @_versioned
   @nonobjc
   internal final func _appendInPlace(_ other: _StringGuts) {
-    _visitGuts(other,
-      ascii: { ascii in _appendInPlace(ascii) },
-      utf16: { utf16 in _appendInPlace(utf16) },
-      opaque: { opaque in _appendInPlace(opaque) })
+    if _slowPath(other._isOpaque) {
+      _opaqueAppendInPlace(opaqueOther: other)
+      return
+    }
+
+    defer { _fixLifetime(other) }
+    if other.isASCII {
+      _appendInPlace(other._unmanagedASCIIView)
+    } else {
+      _appendInPlace(other._unmanagedUTF16View)
+    }
+  }
+
+  @_versioned // @opaque
+  internal final func _opaqueAppendInPlace(opaqueOther other: _StringGuts) {
+    _sanityCheck(other._isOpaque)
+    defer { _fixLifetime(other) }
+    _appendInPlace(other._asOpaque())
   }
 
   @_inlineable

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -247,28 +247,50 @@ extension _SwiftStringStorage {
   @_versioned
   @nonobjc
   internal final func _appendInPlace(_ other: _StringGuts, range: Range<Int>) {
-    defer { _fixLifetime(other) }
     if _slowPath(other._isOpaque) {
-      _appendInPlace(other._asOpaque()[range])
-    } else if other.isASCII {
+      _opaqueAppendInPlace(opaqueOther: other, range: range)
+      return
+    }
+
+    defer { _fixLifetime(other) }
+    if other.isASCII {
       _appendInPlace(other._unmanagedASCIIView[range])
     } else {
       _appendInPlace(other._unmanagedUTF16View[range])
     }
   }
 
+  @_versioned // @opaque
+  internal final func _opaqueAppendInPlace(
+    opaqueOther other: _StringGuts, range: Range<Int>
+  ) {
+    _sanityCheck(other._isOpaque)
+    defer { _fixLifetime(other) }
+    _appendInPlace(other._asOpaque()[range])
+  }
+
   @_inlineable
   @_versioned
   @nonobjc
   internal final func _appendInPlace(_ other: _StringGuts) {
-    defer { _fixLifetime(other) }
     if _slowPath(other._isOpaque) {
-      _appendInPlace(other._asOpaque())
-    } else if other.isASCII {
+      _opaqueAppendInPlace(opaqueOther: other)
+      return
+    }
+
+    defer { _fixLifetime(other) }
+    if other.isASCII {
       _appendInPlace(other._unmanagedASCIIView)
     } else {
       _appendInPlace(other._unmanagedUTF16View)
     }
+  }
+
+  @_versioned // @opaque
+  internal final func _opaqueAppendInPlace(opaqueOther other: _StringGuts) {
+    _sanityCheck(other._isOpaque)
+    defer { _fixLifetime(other) }
+    _appendInPlace(other._asOpaque())
   }
 
   @_inlineable

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -545,7 +545,7 @@ extension String.UTF16View.Indices : BidirectionalCollection {
   }
 }
 
-// backward compatibility for index interchange.  
+// backward compatibility for index interchange.
 extension String.UTF16View {
   @_inlineable // FIXME(sil-serialize-all)
   @available(

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -88,10 +88,10 @@ extension String {
   @_fixed_layout // FIXME(sil-serialize-all)
   public struct UTF8View
     : BidirectionalCollection,
-      CustomStringConvertible, 
+      CustomStringConvertible,
       CustomDebugStringConvertible {
 
-    /// Underlying UTF-16-compatible representation 
+    /// Underlying UTF-16-compatible representation
     @_versioned
     internal var _guts: _StringGuts
 
@@ -189,7 +189,7 @@ extension String {
       }
       return Index(encodedOffset: n, .utf8(buffer: buffer))
     }
-  
+
     /// Returns the next consecutive position after `i`.
     ///
     /// - Precondition: The next position is representable.
@@ -202,15 +202,15 @@ extension String {
       }
 
       var j = i
-      
+
       // Ensure j's cache is utf8
       if _slowPath(j._cache.utf8 == nil) {
         j = _index(atEncodedOffset: j.encodedOffset)
         precondition(j != endIndex, "Index out of bounds")
       }
-      
+
       let buffer = j._cache.utf8._unsafelyUnwrappedUnchecked
-      
+
       var scalarLength16 = 1
       let b0 = buffer.first._unsafelyUnwrappedUnchecked
       var nextBuffer = buffer
@@ -235,7 +235,7 @@ extension String {
         nextBuffer.removeFirst(n8)
       }
 
-      if _fastPath(!nextBuffer.isEmpty) {        
+      if _fastPath(!nextBuffer.isEmpty) {
         return Index(
           encodedOffset: j.encodedOffset + scalarLength16,
           .utf8(buffer: nextBuffer))
@@ -250,14 +250,14 @@ extension String {
         precondition(i.encodedOffset > 0)
         return Index(encodedOffset: i.encodedOffset - 1)
       }
-      
+
       if i._transcodedOffset != 0 {
         _sanityCheck(i._cache.utf8 != nil)
         var r = i
         r._compoundOffset = r._compoundOffset &- 1
         return r
       }
-      
+
       // Handle the scalar boundary the same way as the not-a-utf8-index case.
       _precondition(i.encodedOffset > 0, "Can't move before startIndex")
 
@@ -270,7 +270,7 @@ extension String {
         .utf8(buffer: String.Index._UTF8Buffer(u8))
       )
     }
-    
+
     @_inlineable // FIXME(sil-serialize-all)
     public func distance(from i: Index, to j: Index) -> Int {
       if _fastPath(_guts.isASCII) {
@@ -288,7 +288,7 @@ extension String {
         _count(fromUTF16: IteratorSequence(_guts.makeIterator(
           in: i.encodedOffset..<j.encodedOffset)))
     }
-    
+
     /// Accesses the code unit at the given position.
     ///
     /// The following example uses the subscript to print the value of a
@@ -639,7 +639,7 @@ extension String.UTF8View : CustomPlaygroundQuickLookable {
   }
 }
 
-// backward compatibility for index interchange.  
+// backward compatibility for index interchange.
 extension String.UTF8View {
   @_inlineable // FIXME(sil-serialize-all)
   @available(

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -85,7 +85,7 @@ extension String {
     }
 
     public typealias Index = String.Index
-    
+
     /// Translates a `_guts` index into a `UnicodeScalarIndex` using this
     /// view's `_coreOffset`.
     @_inlineable // FIXME(sil-serialize-all)
@@ -93,7 +93,7 @@ extension String {
     internal func _fromCoreIndex(_ i: Int) -> Index {
       return Index(encodedOffset: i + _coreOffset)
     }
-    
+
     /// Translates a `UnicodeScalarIndex` into a `_guts` index using this
     /// view's `_coreOffset`.
     @_inlineable // FIXME(sil-serialize-all)
@@ -101,7 +101,7 @@ extension String {
     internal func _toCoreIndex(_ i: Index) -> Int {
       return i.encodedOffset - _coreOffset
     }
-    
+
     /// The position of the first Unicode scalar value if the string is
     /// nonempty.
     ///
@@ -336,7 +336,7 @@ extension String.UnicodeScalarView : RangeReplaceableCollection {
   public init() {
     self = String.UnicodeScalarView(_StringGuts())
   }
-  
+
   /// Reserves enough space in the view's underlying storage to store the
   /// specified number of ASCII characters.
   ///
@@ -353,7 +353,7 @@ extension String.UnicodeScalarView : RangeReplaceableCollection {
   public mutating func reserveCapacity(_ n: Int) {
     _guts.reserveCapacity(n)
   }
-  
+
   /// Appends the given Unicode scalar to the view.
   ///
   /// - Parameter c: The character to append to the string.
@@ -518,7 +518,7 @@ extension String.UnicodeScalarView {
     if _fastPath(!UTF16.isTrailSurrogate(_guts[i2])) { return true }
     return i2 == 0 || !UTF16.isLeadSurrogate(_guts[i2 &- 1])
   }
-  
+
   // NOTE: Don't make this function inlineable.  Grapheme cluster
   // segmentation uses a completely different algorithm in Unicode 9.0.
   @_inlineable // FIXME(sil-serialize-all)
@@ -549,7 +549,7 @@ extension String.UnicodeScalarView : CustomPlaygroundQuickLookable {
   }
 }
 
-// backward compatibility for index interchange.  
+// backward compatibility for index interchange.
 extension String.UnicodeScalarView {
   @_inlineable // FIXME(sil-serialize-all)
   @available(


### PR DESCRIPTION
Continuation of https://github.com/apple/swift/pull/14470. Starting to get a clean and consistent introspection pattern that allows us to make much of _StringGuts's bit pattern resilient.

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->