### PR TITLE
[stdlib] Fix an issue in Windows FloatingPoint parsing

### DIFF
--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -467,6 +467,8 @@ static const char *_swift_stdlib_strtoX_clocale_impl(
   *outResult = ParsedValue;
 
   int pos = ValueStream.tellg();
+  if (ValueStream.eof())
+    pos = strlen(nptr);
   if (pos <= 0)
     return nullptr;
 


### PR DESCRIPTION
On `istringstream`, `tellg()` returns -1 if the stream is at the end of the file. This indicates success in this circumstance (the entire string was read into the float), so we should update `pos` accordingly.

Without this, simple examples such as Float("1") return nil on Windows.

NFC on platforms other than Windows, Cygwin, and Haiku.