### PR TITLE
Fix an issue with the constraint favoring code in the constraint opti…

### DIFF
--- a/test/stdlib/ImplicitlyUnwrappedOptional.swift
+++ b/test/stdlib/ImplicitlyUnwrappedOptional.swift
@@ -57,5 +57,18 @@ ImplicitlyUnwrappedOptionalTests.test("flatMap") {
   // expectNil((3 as Int!).flatMap(half))
 }
 
-runAllTests()
+infix operator *^* : ComparisonPrecedence
 
+func *^*(lhs: Int?, rhs: Int?) -> Bool { return true }
+func *^*(lhs: Int, rhs: Int) -> Bool { return true }
+
+ImplicitlyUnwrappedOptionalTests.test("preferOptional") {
+  let i: Int! = nil
+  let j: Int = 1
+  if i != j {} // we should choose != for Optionals rather than forcing i
+  if i == j {} // we should choose == for Optionals rather than forcing i
+  // FIXME: https://bugs.swift.org/browse/SR-6988
+  //  if i *^* j {} // we should choose *^* for Optionals rather than forcing i
+}
+
+runAllTests()


### PR DESCRIPTION
…mizer.

The code was favoring overloads where *either* argument matched its
parameter type and where both parameter types were the same. This
is really overly broad and can result in bugs like the one here, where
we only attempt the
```
  (Int, Int) -> Bool
```

overload of '!=' despite the fact that it means forcing an
optional. We should select the
```
  <T>(T?, T?) -> Bool
```
overload instead, and inject the non-optional operand into an optional.

Fixes rdar://problem/37073401.
