### PR TITLE
Fix for SR-6986; Swift does not build with Clang 6

### DIFF
--- a/include/swift/Basic/ArrayRefView.h
+++ b/include/swift/Basic/ArrayRefView.h
@@ -47,6 +47,8 @@ public:
     Projected operator->() const { return operator*(); }
     iterator &operator++() { Ptr++; return *this; }
     iterator operator++(int) { return iterator(Ptr++); }
+    iterator &operator--() { Ptr--; return *this; }
+    iterator operator--(int) { return iterator(Ptr--); }
     bool operator==(iterator rhs) const { return Ptr == rhs.Ptr; }
     bool operator!=(iterator rhs) const { return Ptr != rhs.Ptr; }
 


### PR DESCRIPTION
Added decrement operators for the ArrayRefView class

Resolves [SR-6986](https://bugs.swift.org/browse/SR-6986).

