### PR TITLE
build: repair the -SourceKit build

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -11,7 +11,9 @@ endif()
 
 # Add generated libSyntax headers to global dependencies.
 list(APPEND LLVM_COMMON_DEPENDS swift-syntax-generated-headers)
-list(APPEND LLVM_COMMON_DEPENDS generated_sourcekit_uids)
+if(SWIFT_BUILD_SOURCEKIT)
+  list(APPEND LLVM_COMMON_DEPENDS generated_sourcekit_uids)
+endif()
 
 add_swift_tool_subdirectory(driver)
 add_swift_tool_subdirectory(sil-opt)


### PR DESCRIPTION
It is possible to disable the SourceKit build.  However, we would
unconditionally add dependencies on targets which would only be
generated when SourceKit was being built, resulting in CMake failing to
configure.  Restore the ability to disable the SourceKit build.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
