### PR TITLE
[SIL] Always print types in SIL

### DIFF
--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2571,9 +2571,9 @@ void SILModule::print(SILPrintContext &PrintCtx, ModuleDecl *M,
   OS << "\n\nimport Builtin\nimport " << STDLIB_NAME
      << "\nimport SwiftShims" << "\n\n";
 
-  // Print the declarations and types from the origin module, unless we're not
-  // in whole-module mode.
-  if (M && AssociatedDeclContext == M && PrintASTDecls) {
+  // Print the declarations and types from the associated context (origin module or
+  // current file).
+  if (M && PrintASTDecls) {
     PrintOptions Options = PrintOptions::printSIL();
     Options.TypeDefinitions = true;
     Options.VarInitializers = true;
@@ -2583,10 +2583,13 @@ void SILModule::print(SILPrintContext &PrintCtx, ModuleDecl *M,
     Options.PrintGetSetOnRWProperties = true;
     Options.PrintInSILBody = false;
     Options.PrintDefaultParameterPlaceholder = false;
+    bool WholeModuleMode = (M == AssociatedDeclContext);
 
     SmallVector<Decl *, 32> topLevelDecls;
     M->getTopLevelDecls(topLevelDecls);
     for (const Decl *D : topLevelDecls) {
+      if (!WholeModuleMode && !(D->getDeclContext() == AssociatedDeclContext))
+          continue;
       if ((isa<ValueDecl>(D) || isa<OperatorDecl>(D) ||
            isa<ExtensionDecl>(D)) &&
           !D->isImplicit()) {

--- a/test/SIL/Inputs/printer_include_decls_module_helper.swift
+++ b/test/SIL/Inputs/printer_include_decls_module_helper.swift
@@ -1,0 +1,4 @@
+class Bar {
+// CHECK: class Bar
+// CHECK-NEGATIVE-NOT: class Bar
+}

--- a/test/SIL/printer_include_decls_module.swift
+++ b/test/SIL/printer_include_decls_module.swift
@@ -1,0 +1,14 @@
+// RUN: rm -f %t.*
+// RUN: %target-swift-frontend -emit-sil %s %S/Inputs/printer_include_decls_module_helper.swift -o %t.sil -module-name main
+// RUN: %FileCheck --input-file=%t.sil %s
+// RUN: %FileCheck --input-file=%t.sil %S/Inputs/printer_include_decls_module_helper.swift
+
+// RUN: %target-swift-frontend -emit-sil -primary-file %s %S/Inputs/printer_include_decls_module_helper.swift -o %t.sil -module-name main
+// RUN: %FileCheck --input-file=%t.sil %s
+// RUN: %FileCheck --input-file=%t.sil %S/Inputs/printer_include_decls_module_helper.swift -check-prefix=CHECK-NEGATIVE
+
+class Foo {
+// CHECK: class Foo
+// CHECK-NEGATIVE-NOT: class Foo
+}
+


### PR DESCRIPTION
SIL prints types and declarations defined in a current file
(-primary-file flag) or a module (whole module mode).

Previously, SIL generated types for whole-module mode but didn't for
-primary-file. Therefore, -emit-sil output was not parseable for 
"single file" mode (missing types and declarations). 

Resolves [SR-3773](https://bugs.swift.org/browse/SR-3773).