### PR TITLE
[4.1] [Type checker] Tolerate missing generic environments better.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2271,9 +2271,7 @@ public:
   /// Set the interface type for the given value.
   void setInterfaceType(Type type);
 
-  bool hasValidSignature() const {
-    return hasInterfaceType() && !isBeingValidated();
-  }
+  bool hasValidSignature() const;
 
   /// isSettable - Determine whether references to this decl may appear
   /// on the left-hand side of an assignment or as the operand of a

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1972,6 +1972,10 @@ void ValueDecl::setInterfaceType(Type type) {
   TypeAndAccess.setPointer(type);
 }
 
+bool ValueDecl::hasValidSignature() const {
+  return hasInterfaceType() && !isBeingValidated();
+}
+
 Optional<ObjCSelector> ValueDecl::getObjCRuntimeName() const {
   if (auto func = dyn_cast<AbstractFunctionDecl>(this))
     return func->getObjCSelector();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1074,7 +1074,7 @@ void ConstraintSystem::openGeneric(
 
   // Create the type variables for the generic parameters.
   for (auto gp : sig->getGenericParams()) {
-    auto contextTy = genericEnv->mapTypeIntoContext(gp);
+    auto contextTy = GenericEnvironment::mapTypeIntoContext(genericEnv, gp);
     if (auto *archetype = contextTy->getAs<ArchetypeType>())
       locatorPtr = getConstraintLocator(
           locator.withPathElement(LocatorPathElt(archetype)));

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -941,8 +941,14 @@ bool WitnessChecker::findBestWitness(
         continue;
       }
 
-      if (!witness->hasInterfaceType())
+      if (!witness->hasValidSignature()) {
         TC.validateDecl(witness);
+
+        if (!witness->hasValidSignature()) {
+          doNotDiagnoseMatches = true;
+          continue;
+        }
+      }
 
       auto match = matchWitness(TC, Proto, conformance, DC,
                                 requirement, witness);


### PR DESCRIPTION
**Explanation:** Before matching witnesses, ensure that we have a valid signature, and be
more tolerant of null generic environments by using the `mapTypeIntoContext` entry point meant to handle null.
**Scope:** Crash-on-invalid that's showing up in SourceKit
**Risk:** Very low; we're handling NULL in a place where we would otherwise crashed.
**Testing:** Regression tests.
**Reviewer:** @xedin  
**SR / Radar:** rdar://problem/37255982
