### PR TITLE
 [Type checker] Suppress near-miss warnings within the type definition.

### DIFF
--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -959,20 +959,32 @@ static bool hasNonCanonicalSelfProtocolRequirement(
 
 /// Retrieve the best requirement source from the list
 static const RequirementSource *
-getBestCanonicalRequirementSource(
-                      ArrayRef<GSBConstraint<ProtocolDecl *>> constraints) {
+getBestRequirementSource(ArrayRef<GSBConstraint<ProtocolDecl *>> constraints) {
   const RequirementSource *bestSource = nullptr;
+  bool bestIsNonCanonical = false;
+
+  auto isBetter = [&](const RequirementSource *source, bool isNonCanonical) {
+    if (!bestSource) return true;
+
+    if (bestIsNonCanonical != isNonCanonical)
+      return bestIsNonCanonical;
+
+    return bestSource->compare(source) > 0;
+  };
+
   for (const auto &constraint : constraints) {
     auto source = constraint.source;
 
     // If there is a non-canonical protocol requirement next to the root,
     // skip this requirement source.
-    if (hasNonCanonicalSelfProtocolRequirement(source, constraint.value))
-      continue;
+    bool isNonCanonical =
+      hasNonCanonicalSelfProtocolRequirement(source, constraint.value);
 
-    // Check whether this is better than our best source.
-    if (!bestSource || source->compare(bestSource) < 0)
+    if (isBetter(source, isNonCanonical)) {
       bestSource = source;
+      bestIsNonCanonical = isNonCanonical;
+      continue;
+    }
   }
 
   return bestSource;
@@ -1008,13 +1020,32 @@ ConformanceAccessPath GenericSignature::getConformanceAccessPath(
                   ProtocolDecl *requirementSignatureProto) {
     // Each protocol requirement is a step along the path.
     if (source->isProtocolRequirement()) {
-      // If we're expanding for a protocol that has no requirement signature
-      // (yet) and have hit the penultimate step, this is the last step
+      // If we're expanding for a protocol that had no requirement signature
+      // and have hit the penultimate step, this is the last step
       // that would occur in the requirement signature.
+      Optional<GenericSignatureBuilder> replacementBuilder;
       if (!source->parent->parent && requirementSignatureProto) {
-        Type subjectType = source->getStoredType()->getCanonicalType();
-        path.path.push_back({subjectType, conformingProto});
-        return;
+        // If we have a requirement signature now, we're done.
+        if (source->usesRequirementSignature || true) {
+          Type subjectType = source->getStoredType()->getCanonicalType();
+          path.path.push_back({subjectType, conformingProto});
+          return;
+        }
+
+        // The generic signature builder we're using for this protocol
+        // wasn't built from its own requirement signature, so we can't
+        // trust it. Make sure we have a requirement signature, then build
+        // a new generic signature builder.
+        // FIXME: It would be better if we could replace the canonical generic
+        // signature builder with the rebuilt one.
+        if (!requirementSignatureProto->isRequirementSignatureComputed())
+          requirementSignatureProto->computeRequirementSignature();
+        assert(requirementSignatureProto->isRequirementSignatureComputed());
+
+        replacementBuilder.emplace(getASTContext());
+        replacementBuilder->addGenericSignature(
+                            requirementSignatureProto->getGenericSignature());
+        replacementBuilder->processDelayedRequirements();
       }
 
       // Follow the rest of the path to derive the conformance into which
@@ -1047,9 +1078,12 @@ ConformanceAccessPath GenericSignature::getConformanceAccessPath(
         return;
       }
 
+      // Get the generic signature builder for the protocol.
       // Get a generic signature for the protocol's signature.
       auto inProtoSig = inProtocol->getGenericSignature();
-      auto &inProtoSigBuilder = *inProtoSig->getGenericSignatureBuilder();
+      auto &inProtoSigBuilder =
+          replacementBuilder ? *replacementBuilder
+                             : *inProtoSig->getGenericSignatureBuilder();
 
       // Retrieve the stored type, but erase all of the specific associated
       // type declarations; we don't want any details of the enclosing context
@@ -1068,7 +1102,7 @@ ConformanceAccessPath GenericSignature::getConformanceAccessPath(
       assert(conforms != equivClass->conformsTo.end());
 
       // Compute the root type, canonicalizing it w.r.t. the protocol context.
-      auto conformsSource = getBestCanonicalRequirementSource(conforms->second);
+      auto conformsSource = getBestRequirementSource(conforms->second);
       assert(conformsSource != source || !requirementSignatureProto);
       Type localRootType = conformsSource->getRootType();
       localRootType = inProtoSig->getCanonicalTypeInContext(localRootType);
@@ -1116,7 +1150,7 @@ ConformanceAccessPath GenericSignature::getConformanceAccessPath(
   };
 
   // Canonicalize the root type.
-  auto source = getBestCanonicalRequirementSource(conforms->second);
+  auto source = getBestRequirementSource(conforms->second);
   Type rootType = source->getRootType()->getCanonicalType(this);
 
   // Build the path.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4071,6 +4071,11 @@ static bool shouldWarnAboutPotentialWitness(
       isUnlabeledInitializerOrSubscript(witness))
     return false;
 
+  // For non-@objc requirements, only warn if the witness comes from an
+  // extension.
+  if (!req->isObjC() && !isa<ExtensionDecl>(witness->getDeclContext()))
+    return false;
+
   // If the score is relatively high, don't warn: this is probably
   // unrelated.  Allow about one typo for every four properly-typed
   // characters, which prevents completely-wacky suggestions in many

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -526,7 +526,7 @@ struct SConforms7a : PConforms7 { }
 protocol PConforms8 {
   associatedtype Assoc
 
-  func method() -> Assoc // expected-note{{requirement 'method()' declared here}}
+  func method() -> Assoc
   var property: Assoc { get }
   subscript (i: Assoc) -> Assoc { get }
 }
@@ -551,10 +551,7 @@ func testSConforms8b() {
 }
 
 struct SConforms8c : PConforms8 { 
-  func method() -> String { return "" } // expected-warning{{instance method 'method()' nearly matches defaulted requirement 'method()' of protocol 'PConforms8'}}
-  // expected-note@-1{{candidate has non-matching type '() -> String' [with Assoc = Int]}}
-  // expected-note@-2{{move 'method()' to an extension to silence this warning}}
-  // expected-note@-3{{make 'method()' private to silence this warning}}
+  func method() -> String { return "" } // no warning in type definition
 }
 
 func testSConforms8c() {


### PR DESCRIPTION
There are a number of things that can only be written within the main
type definition (e.g., required initializers, stored properties),
making it far more likely that we'll get false positives from the
newly-introduced "near-miss" warnings for protocol
conformances. Moreover, sometimes a number of protocol conformances
are placed on the main type definition, increasing the potential for
false positives.

Suppress near-miss warnings for potential candidates when the protocol
conformance is stated on the main type definition itself. Therefore,
we only perform near-miss checking of non-@objc requirements when the
conformance itself was declared on an extension, which is roughly the
development style that near-miss warnings favor.

Fixes rdar://problem/37283860.