### PR TITLE
[4.1] [Deserialization] Weakened DeclContext asssertion in maybeReadGenericParams.

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -738,7 +738,8 @@ GenericParamList *ModuleFile::maybeReadGenericParams(DeclContext *DC,
       // precede SIL linkage, we should be ok.
       assert((genericParam->getDeclContext()->isModuleScopeContext() ||
               DC->isModuleScopeContext() ||
-              genericParam->getDeclContext() == DC) &&
+              genericParam->getDeclContext() == DC ||
+              genericParam->getDeclContext()->isChildContextOf(DC)) &&
              "Mismatched decl context for generic types.");
       params.push_back(genericParam);
       break;

--- a/test/SIL/Serialization/Inputs/def_generic.swift
+++ b/test/SIL/Serialization/Inputs/def_generic.swift
@@ -9,4 +9,8 @@ public class A<T> {
   @_versioned
   @_inlineable
   init() {}
+
+  @_inlineable public subscript<U>(value: T) -> U? {
+    return nil
+  }
 }


### PR DESCRIPTION
**Explanation:** An over-eager assertion in `ModuleFile::maybeReadGenericParams()` rejected
deserialization into the context of a generic subscript for a generic
parameter within one of its accessors. Weaken the assertion; the
`DeclContext` of the generic parameter will be overwritten with the
correct context later.
**Scope:** Rare crash-on-valid involving deserialization of `@_inlineable` subscripts.
**Risk:** Very low; we're fixing an over-eager assertions.
**Testing:** Regression tests; built the project triggering the assertion.
**Reviewer:** @jrose-apple 
**SR / Radar:** rdar://problem/37408205
