### PR TITLE
[5.0] [AST] Keep generic type params generic in RequirementEnvironments.

### DIFF
--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -360,3 +360,11 @@ func passesConditionallyNotF7(x21: X2<X1>) {
   // expected-note@-2{{requirement specified as 'X1.A' (aka 'X0') : 'P7'}}
   // expected-note@-3{{requirement from conditional conformance of 'X2<X1>' to 'P7'}}
 }
+
+
+public struct SR6990<T, U> {}
+extension SR6990: Sequence where T == Int {
+    public typealias Element = Float
+    public typealias Iterator = IndexingIterator<[Float]>
+    public func makeIterator() -> Iterator { fatalError() }
+}


### PR DESCRIPTION
Before this patch, the use of GenericSignature::getSubstitutionMap to
create a substitution map would result in some generic parameters being
completely elided (well, being mapped to concrete types causing a
->castTo<GenericTypeParamType>() to crash). This patch changes that to
just do the reindexing of the type parameters directly, without trying
to be smart with more contextual information (i.e. τ_0_0 -> τ_1_0, even
if there's a τ_0_0 == Int requirement).

Fixes rdar://problem/37291254 and SR-6990.
