### PR TITLE
[4.1] [AST] Keep generic type params generic in RequirementEnvironments.

### DIFF
--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -360,3 +360,11 @@ func passesConditionallyNotF7(x21: X2<X1>) {
   // expected-note@-2{{requirement specified as 'X1.A' (aka 'X0') : 'P7'}}
   // expected-note@-3{{requirement from conditional conformance of 'X2<X1>' to 'P7'}}
 }
+
+
+public struct SR6990<T, U> {}
+extension SR6990: Sequence where T == Int {
+    public typealias Element = Float
+    public typealias Iterator = IndexingIterator<[Float]>
+    public func makeIterator() -> Iterator { fatalError() }
+}


### PR DESCRIPTION
• **Explanation**: Conditional conformances with a same-type constraint would crash in the type checker because code that was trying to remap generic type parameters got a concrete type instead of a parameter. This makes the code "dumber" and only do the remapping, not using any of the contextual information that says a given parameter is equal to a concrete type.
• **Scope of Issue**: Crashes with some conditional conformances using same-type constraints.
• **Origination**: Long-term latent bug that was revealed by conditional conformances.
• **Risk**: Low risk; Fixes a bug in the type checker.
• **Reviewed By**: @DougGregor  
• **Testing**: Compiler regression tests
• **Radar / SR**: rdar://problem/37291254