### PR TITLE
[4.1] [ClangImporter] Use unique import locations for bridging headers too

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1095,6 +1095,27 @@ bool ClangImporter::addSearchPath(StringRef newSearchPath, bool isFramework,
   return false;
 }
 
+clang::SourceLocation
+ClangImporter::Implementation::getNextIncludeLoc() {
+  clang::SourceManager &srcMgr = getClangInstance()->getSourceManager();
+
+  if (!DummyIncludeBuffer.isValid()) {
+    clang::SourceLocation includeLoc =
+        srcMgr.getLocForStartOfFile(srcMgr.getMainFileID());
+    DummyIncludeBuffer = srcMgr.createFileID(
+        llvm::make_unique<ZeroFilledMemoryBuffer>(
+          256*1024, StringRef(moduleImportBufferName)),
+        clang::SrcMgr::C_User, /*LoadedID*/0, /*LoadedOffset*/0, includeLoc);
+  }
+
+  clang::SourceLocation clangImportLoc =
+      srcMgr.getLocForStartOfFile(DummyIncludeBuffer)
+            .getLocWithOffset(IncludeCounter++);
+  assert(srcMgr.isInFileID(clangImportLoc, DummyIncludeBuffer) &&
+         "confused Clang's source manager with our fake locations");
+  return clangImportLoc;
+}
+
 bool ClangImporter::Implementation::importHeader(
     ModuleDecl *adapter, StringRef headerName, SourceLoc diagLoc,
     bool trackParsedSymbols,
@@ -1112,22 +1133,17 @@ bool ClangImporter::Implementation::importHeader(
 
   bool hadError = clangDiags.hasErrorOccurred();
 
-  clang::ASTContext &ClangCtx = getClangASTContext();
-  clang::Preprocessor &pp = getClangPreprocessor();
-
-  clang::SourceManager &sourceMgr = ClangCtx.getSourceManager();
-
-  clang::SourceLocation includeLoc =
-    sourceMgr.getLocForStartOfFile(sourceMgr.getMainFileID());
+  clang::SourceManager &sourceMgr = getClangInstance()->getSourceManager();
   clang::FileID bufferID = sourceMgr.createFileID(std::move(sourceBuffer),
                                                   clang::SrcMgr::C_User,
                                                   /*LoadedID=*/0,
                                                   /*LoadedOffset=*/0,
-                                                  includeLoc);
+                                                  getNextIncludeLoc());
   auto &consumer =
       static_cast<HeaderParsingASTConsumer &>(Instance->getASTConsumer());
   consumer.reset();
 
+  clang::Preprocessor &pp = getClangPreprocessor();
   pp.EnterSourceFile(bufferID, /*Dir=*/nullptr, /*Loc=*/{});
   // Force the import to occur.
   pp.LookAhead(0);
@@ -1440,7 +1456,6 @@ ModuleDecl *ClangImporter::loadModule(
                           Impl.exportSourceLoc(component.second) } );
   }
 
-  auto &srcMgr = clangContext.getSourceManager();
   auto &rawDiagClient = Impl.Instance->getDiagnosticClient();
   auto &diagClient = static_cast<ClangDiagnosticConsumer &>(rawDiagClient);
 
@@ -1463,27 +1478,7 @@ ModuleDecl *ClangImporter::loadModule(
       }
     }
 
-    // FIXME: The source location here is completely bogus. It can't be
-    // invalid, it can't be the same thing twice in a row, and it has to come
-    // from an actual buffer, so we make a fake buffer and just use a counter.
-    if (!Impl.DummyImportBuffer.isValid()) {
-      clang::SourceLocation includeLoc =
-          srcMgr.getLocForStartOfFile(srcMgr.getMainFileID());
-      // Zero offset is reserved for the bridging header. Increase the offset
-      // so that headers from the bridging header are considered as coming
-      // before headers that are imported from swift code.
-      includeLoc = includeLoc.getLocWithOffset(1);
-      Impl.DummyImportBuffer = srcMgr.createFileID(
-          llvm::make_unique<ZeroFilledMemoryBuffer>(
-              256*1024, StringRef(Implementation::moduleImportBufferName)),
-          clang::SrcMgr::C_User,
-          /*LoadedID*/0, /*LoadedOffset*/0, includeLoc);
-    }
-    clang::SourceLocation clangImportLoc
-      = srcMgr.getLocForStartOfFile(Impl.DummyImportBuffer)
-              .getLocWithOffset(Impl.ImportCounter++);
-    assert(srcMgr.isInFileID(clangImportLoc, Impl.DummyImportBuffer) &&
-           "confused Clang's source manager with our fake locations");
+    clang::SourceLocation clangImportLoc = Impl.getNextIncludeLoc();
 
     clang::ModuleLoadResult result =
         Impl.Instance->loadModule(clangImportLoc, path, visibility,

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -319,13 +319,19 @@ private:
 
   /// \brief The fake buffer used to import modules.
   ///
-  /// FIXME: Horrible hack for loadModule().
-  clang::FileID DummyImportBuffer;
+  /// \see getNextIncludeLoc
+  clang::FileID DummyIncludeBuffer;
 
   /// \brief A count of the number of load module operations.
   ///
-  /// FIXME: Horrible, horrible hack for \c loadModule().
-  unsigned ImportCounter = 0;
+  /// \see getNextIncludeLoc
+  unsigned IncludeCounter = 0;
+
+  /// Generate a dummy Clang source location for header includes and module
+  /// imports.
+  ///
+  /// These have to be unique and valid or Clang gets very confused.
+  clang::SourceLocation getNextIncludeLoc();
 
   /// \brief Used to avoid running the AST verifier over the same declarations.
   size_t VerifiedDeclsCounter = 0;


### PR DESCRIPTION
- **Explanation**: Swift allows importing non-modular C code through the use of a "bridging header". You're supposed to only use bridging headers for an app *or* a unit test target, meaning only one is relevant for any given compilation, but we can have multiple bridging headers if someone is sneaking them into a library target, even though we've tried to lock down on that. Up until now we've been pretending any bridging header is included at offset 0 in a dummy buffer, but reusing offset 0 for multiple headers seems to be causing problems that lead to both compiler and SourceKit crashes in rare cases. This change reuses the fix we had for a similar issue with module imports: a monotonically increasing include location in a fake (but allocated) buffer.
- **Scope**: Affects imports of bridging headers, but likely not in any observable way.
- **Issue**: rdar://problem/34349832
- **Reviewed by**: @akyrtzi   
- **Risk**: Medium-low. This ought to just be changing Clang source location bookkeeping, not actual behavior users depend on.
- **Testing**: Verified that the project running into the issue no longer crashes, but I was unable to isolate a standalone test case.