### PR TITLE
[4.1] [Type checker] Suppress near-miss warnings within the type definition.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4021,6 +4021,11 @@ static bool shouldWarnAboutPotentialWitness(
       isUnlabeledInitializerOrSubscript(witness))
     return false;
 
+  // For non-@objc requirements, only warn if the witness comes from an
+  // extension.
+  if (!req->isObjC() && !isa<ExtensionDecl>(witness->getDeclContext()))
+    return false;
+
   // If the score is relatively high, don't warn: this is probably
   // unrelated.  Allow about one typo for every four properly-typed
   // characters, which prevents completely-wacky suggestions in many

--- a/test/decl/ext/protocol.swift
+++ b/test/decl/ext/protocol.swift
@@ -526,7 +526,7 @@ struct SConforms7a : PConforms7 { }
 protocol PConforms8 {
   associatedtype Assoc
 
-  func method() -> Assoc // expected-note{{requirement 'method()' declared here}}
+  func method() -> Assoc
   var property: Assoc { get }
   subscript (i: Assoc) -> Assoc { get }
 }
@@ -551,10 +551,7 @@ func testSConforms8b() {
 }
 
 struct SConforms8c : PConforms8 { 
-  func method() -> String { return "" } // expected-warning{{instance method 'method()' nearly matches defaulted requirement 'method()' of protocol 'PConforms8'}}
-  // expected-note@-1{{candidate has non-matching type '() -> String' [with Assoc = Int]}}
-  // expected-note@-2{{move 'method()' to an extension to silence this warning}}
-  // expected-note@-3{{make 'method()' private to silence this warning}}
+  func method() -> String { return "" } // no warning in type definition
 }
 
 func testSConforms8c() {


### PR DESCRIPTION
**Explanation:** Back off slightly on the protocol conformance "near-miss" warnings introduced in Swift 4.1, suppressing them in the main type definition, which we hope will reduce the incidence of false positives that are annoying annoying users.
**Scope:** The code to check for these warnings is used all the time, but they don't fire that often. Scope is sorta uninteresting for this one.
**Risk:** Very low; we're disabling a warning in certain cases.
**Testing:** Regression tests
**Reviewer:** @huonw 
**SR / Radar:** rdar://problem/37283860