### PR TITLE
[4.1] [GSB] Make conformance access paths robust against non-canonical signatures

### DIFF
--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -958,20 +958,32 @@ static bool hasNonCanonicalSelfProtocolRequirement(
 
 /// Retrieve the best requirement source from the list
 static const RequirementSource *
-getBestCanonicalRequirementSource(
-                      ArrayRef<GSBConstraint<ProtocolDecl *>> constraints) {
+getBestRequirementSource(ArrayRef<GSBConstraint<ProtocolDecl *>> constraints) {
   const RequirementSource *bestSource = nullptr;
+  bool bestIsNonCanonical = false;
+
+  auto isBetter = [&](const RequirementSource *source, bool isNonCanonical) {
+    if (!bestSource) return true;
+
+    if (bestIsNonCanonical != isNonCanonical)
+      return bestIsNonCanonical;
+
+    return bestSource->compare(source) > 0;
+  };
+
   for (const auto &constraint : constraints) {
     auto source = constraint.source;
 
     // If there is a non-canonical protocol requirement next to the root,
     // skip this requirement source.
-    if (hasNonCanonicalSelfProtocolRequirement(source, constraint.value))
-      continue;
+    bool isNonCanonical =
+      hasNonCanonicalSelfProtocolRequirement(source, constraint.value);
 
-    // Check whether this is better than our best source.
-    if (!bestSource || source->compare(bestSource) < 0)
+    if (isBetter(source, isNonCanonical)) {
       bestSource = source;
+      bestIsNonCanonical = isNonCanonical;
+      continue;
+    }
   }
 
   return bestSource;
@@ -1007,13 +1019,32 @@ ConformanceAccessPath GenericSignature::getConformanceAccessPath(
                   ProtocolDecl *requirementSignatureProto) {
     // Each protocol requirement is a step along the path.
     if (source->isProtocolRequirement()) {
-      // If we're expanding for a protocol that has no requirement signature
-      // (yet) and have hit the penultimate step, this is the last step
+      // If we're expanding for a protocol that had no requirement signature
+      // and have hit the penultimate step, this is the last step
       // that would occur in the requirement signature.
+      Optional<GenericSignatureBuilder> replacementBuilder;
       if (!source->parent->parent && requirementSignatureProto) {
-        Type subjectType = source->getStoredType()->getCanonicalType();
-        path.path.push_back({subjectType, conformingProto});
-        return;
+        // If we have a requirement signature now, we're done.
+        if (source->usesRequirementSignature || true) {
+          Type subjectType = source->getStoredType()->getCanonicalType();
+          path.path.push_back({subjectType, conformingProto});
+          return;
+        }
+
+        // The generic signature builder we're using for this protocol
+        // wasn't built from its own requirement signature, so we can't
+        // trust it. Make sure we have a requirement signature, then build
+        // a new generic signature builder.
+        // FIXME: It would be better if we could replace the canonical generic
+        // signature builder with the rebuilt one.
+        if (!requirementSignatureProto->isRequirementSignatureComputed())
+          requirementSignatureProto->computeRequirementSignature();
+        assert(requirementSignatureProto->isRequirementSignatureComputed());
+
+        replacementBuilder.emplace(getASTContext());
+        replacementBuilder->addGenericSignature(
+                            requirementSignatureProto->getGenericSignature());
+        replacementBuilder->processDelayedRequirements();
       }
 
       // Follow the rest of the path to derive the conformance into which
@@ -1046,9 +1077,12 @@ ConformanceAccessPath GenericSignature::getConformanceAccessPath(
         return;
       }
 
+      // Get the generic signature builder for the protocol.
       // Get a generic signature for the protocol's signature.
       auto inProtoSig = inProtocol->getGenericSignature();
-      auto &inProtoSigBuilder = *inProtoSig->getGenericSignatureBuilder();
+      auto &inProtoSigBuilder =
+          replacementBuilder ? *replacementBuilder
+                             : *inProtoSig->getGenericSignatureBuilder();
 
       // Retrieve the stored type, but erase all of the specific associated
       // type declarations; we don't want any details of the enclosing context
@@ -1067,7 +1101,7 @@ ConformanceAccessPath GenericSignature::getConformanceAccessPath(
       assert(conforms != equivClass->conformsTo.end());
 
       // Compute the root type, canonicalizing it w.r.t. the protocol context.
-      auto conformsSource = getBestCanonicalRequirementSource(conforms->second);
+      auto conformsSource = getBestRequirementSource(conforms->second);
       assert(conformsSource != source || !requirementSignatureProto);
       Type localRootType = conformsSource->getRootType();
       localRootType = inProtoSig->getCanonicalTypeInContext(localRootType);
@@ -1115,7 +1149,7 @@ ConformanceAccessPath GenericSignature::getConformanceAccessPath(
   };
 
   // Canonicalize the root type.
-  auto source = getBestCanonicalRequirementSource(conforms->second);
+  auto source = getBestRequirementSource(conforms->second);
   Type rootType = source->getRootType()->getCanonicalType(this);
 
   // Build the path.

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -1025,7 +1025,7 @@ ConformanceAccessPath GenericSignature::getConformanceAccessPath(
       Optional<GenericSignatureBuilder> replacementBuilder;
       if (!source->parent->parent && requirementSignatureProto) {
         // If we have a requirement signature now, we're done.
-        if (source->usesRequirementSignature || true) {
+        if (source->usesRequirementSignature) {
           Type subjectType = source->getStoredType()->getCanonicalType();
           path.path.push_back({subjectType, conformingProto});
           return;


### PR DESCRIPTION
**Explanation:** With specific type-checking interleavings in large projects, the generic
signature builder for the generic signature of a protocol might not have
been built from the requirement signature of the protocol, which would
lead to malformed conformance access paths. Make this code path more
robust by building a new generic signature builder when this happens.
**Scope:** Affects projects that make heavy use of generics, across multiple files, and which also have a number of unaddressed "redundant constraint" warnings.
**Risk:** Very low; we're only changing behavior along a path in the type checker that would otherwise fail.
**Testing:** Regression tests, building the affected project to ensure it no longer crashes
**Reviewer:** @huonw 
**SR / Radar:** rdar://problem/37335173
