### PR TITLE
[4.1][stdlib] Only deprecate flatMap starting with Swift 4.1

### DIFF
--- a/stdlib/public/core/FlatMap.swift
+++ b/stdlib/public/core/FlatMap.swift
@@ -60,7 +60,7 @@ extension LazySequenceProtocol {
   ///
   /// - Complexity: O(1)
   @inline(__always)
-  @available(*, deprecated, renamed: "compactMap(_:)",
+  @available(swift, deprecated: 4.1, renamed: "compactMap(_:)",
     message: "Please use compactMap(_:) for the case where closure returns an optional value")
   public func flatMap<ElementOfResult>(
     _ transform: @escaping (Elements.Element) -> ElementOfResult?
@@ -124,7 +124,7 @@ extension LazyCollectionProtocol {
   ///   collection as its argument and returns an optional value.
   ///
   /// - Complexity: O(1)
-  @available(*, deprecated, renamed: "compactMap(_:)",
+  @available(swift, deprecated: 4.1, renamed: "compactMap(_:)",
     message: "Please use compactMap(_:) for the case where closure returns an optional value")
   @_inlineable // FIXME(sil-serialize-all)
   public func flatMap<ElementOfResult>(

--- a/stdlib/public/core/SequenceAlgorithms.swift.gyb
+++ b/stdlib/public/core/SequenceAlgorithms.swift.gyb
@@ -783,7 +783,7 @@ extension Sequence {
   /// - Complexity: O(*m* + *n*), where *m* is the length of this sequence
   ///   and *n* is the length of the result.
   @inline(__always)
-  @available(*, deprecated, renamed: "compactMap(_:)",
+  @available(swift, deprecated: 4.1, renamed: "compactMap(_:)",
     message: "Please use compactMap(_:) for the case where closure returns an optional value")
   public func flatMap<ElementOfResult>(
     _ transform: (Element) throws -> ElementOfResult?

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -448,7 +448,7 @@ extension Collection {
     return try _compactMap(transform)
   }
 
-  @available(*, deprecated, renamed: "compactMap(_:)",
+  @available(swift, deprecated: 4.1, renamed: "compactMap(_:)",
     message: "Please use compactMap(_:) for the case where closure returns an optional value")
   @inline(__always)
   public func flatMap(

--- a/test/stdlib/FlatMapDeprecation.swift
+++ b/test/stdlib/FlatMapDeprecation.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift %s
+// RUN: %swift -swift-version 4 -typecheck -verify  %s
 
 func flatMapOnSequence<
   S : Sequence


### PR DESCRIPTION
* Explanation: The suggested replacement for this variant of flatMap (i.e. compactMap) was first introduced in Swift 4.1, so the deprecation should only be enabled from that version onward.
* Risk: Minimal
* Reviewed By: Ben Cohen
* Testing: Automated test suite with a specific test case
* Directions for QA: N/A
* Radar: rdar://problem/37393816