### PR TITLE
[GSB] Avoid unresolved dependent member types in generic signatures.

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/0142-rdar36549499.swift
+++ b/validation-test/compiler_crashers_2_fixed/0142-rdar36549499.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend %s -emit-ir -o /dev/null
+protocol S {
+  associatedtype I: IteratorProtocol
+  typealias E = I.Element
+}
+
+func foo<T: S>(_ s: T) -> Int where T.E == Int {
+  return 42
+}


### PR DESCRIPTION
The GenericSignatureBuilder is allowing unresolved dependent member
types to creep into generic signatures, which eventually blows up in
name mangling. Prefer to pick dependent member types that are
fully-resolved when choosing anchors.

This is a spot fix; a better approach would eliminate the notion of
unresolved dependent member types entirely from
PotentialArchetype. 

Fixes rdar://problem/36549499.
