### PR TITLE
[4.1] [GSB] Avoid unresolved dependent member types in generic signatures.

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -5233,11 +5233,28 @@ void GenericSignatureBuilder::checkConformanceConstraints(
   }
 }
 
+/// Compare dependent types for use in anchors.
+///
+/// FIXME: This is a hack that will go away once we eliminate potential
+/// archetypes that refer to concrete type declarations.
+static int compareAnchorDependentTypes(Type type1, Type type2) {
+  // We don't want any unresolved dependent member types to be anchors, so
+  // prefer that they don't get through.
+  bool hasUnresolvedDependentMember1 =
+    type1->findUnresolvedDependentMemberType() != nullptr;
+  bool hasUnresolvedDependentMember2 =
+    type2->findUnresolvedDependentMemberType() != nullptr;
+  if (hasUnresolvedDependentMember1 != hasUnresolvedDependentMember2)
+    return hasUnresolvedDependentMember2 ? -1 : +1;
+
+  return compareDependentTypes(type1, type2);
+}
+
 namespace swift {
   bool operator<(const DerivedSameTypeComponent &lhs,
                  const DerivedSameTypeComponent &rhs) {
-    return compareDependentTypes(getUnresolvedType(lhs.anchor, { }),
-                                 getUnresolvedType(rhs.anchor, { })) < 0;
+    return compareAnchorDependentTypes(getUnresolvedType(lhs.anchor, { }),
+                                       getUnresolvedType(rhs.anchor, { })) < 0;
   }
 } // namespace swift
 
@@ -5373,7 +5390,7 @@ static void computeDerivedSameTypeComponents(
     componentOf[depType] = componentIndex;
 
     // If this is a better anchor, record it.
-    if (compareDependentTypes(
+    if (compareAnchorDependentTypes(
                 depType,
                 getUnresolvedType(components[componentIndex].anchor, { })) < 0)
       components[componentIndex].anchor = pa;
@@ -5692,7 +5709,7 @@ static void collapseSameTypeComponents(
       auto &newComponent = newComponents[newRepresentativeIndex];
 
       // If the old component has a better anchor, keep it.
-      if (compareDependentTypes(
+      if (compareAnchorDependentTypes(
                             getUnresolvedType(oldComponent.anchor, { }),
                             getUnresolvedType(newComponent.anchor, { })) < 0)
         newComponent.anchor = oldComponent.anchor;
@@ -6092,7 +6109,7 @@ static int compareSameTypeComponents(const SameTypeComponentRef *lhsPtr,
       rhsPtr->first->derivedSameTypeComponents[rhsPtr->second].anchor,
       { });
 
-  return compareDependentTypes(lhsType, rhsType);
+  return compareAnchorDependentTypes(lhsType, rhsType);
 }
 
 void GenericSignatureBuilder::enumerateRequirements(
@@ -6320,6 +6337,9 @@ static void collectRequirements(GenericSignatureBuilder &builder,
 
     if (depTy->hasError())
       return;
+
+    assert(!depTy->findUnresolvedDependentMemberType() &&
+           "Unresolved dependent member type in requirements");
 
     Type repTy;
     if (auto concreteTy = type.dyn_cast<Type>()) {

--- a/validation-test/compiler_crashers_2_fixed/0142-rdar36549499.swift
+++ b/validation-test/compiler_crashers_2_fixed/0142-rdar36549499.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend %s -emit-ir -o /dev/null
+protocol S {
+  associatedtype I: IteratorProtocol
+  typealias E = I.Element
+}
+
+func foo<T: S>(_ s: T) -> Int where T.E == Int {
+  return 42
+}


### PR DESCRIPTION
**Explanation:** The GenericSignatureBuilder is allowing unresolved dependent member
types to creep into generic signatures, which eventually blows up in
name mangling. Prefer to pick dependent member types that are
fully-resolved when choosing anchors.
**Scope:** Affects projects that make use of nontrivial typealiases within protocols and protocol extensions. We've seen a number of compiler crashes due to this issue.
**Risk:** Very low; we're only changing behavior along a path in the type checker that would otherwise fail.
**Testing:** Regression tests, including a new test provided by @xedin 
**Reviewer:** @rudkx
**SR / Radar:** rdar://problem/36549499.
