### PR TITLE
[NFC] Fix typo in assert: `Excted` to `Expected`

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -691,7 +691,7 @@ static bool isValueToBridgeObjectremovable(ValueToBridgeObjectInst *VTBOI) {
   // If operand is a struct $UInt (% : $Builtin.), fetch the real source
   if (auto *SI = dyn_cast<StructInst>(operand)) {
     assert(SI->SILInstruction::getAllOperands().size() == 1 &&
-           "Excted a single operand");
+           "Expected a single operand");
     operand = SI->getOperand(0);
   }
   if (auto *BI = dyn_cast<BuiltinInst>(operand)) {


### PR DESCRIPTION
<!-- What's in this pull request? -->
I was looking through commits and noticed this typo in a (new) assert.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: 
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).
-->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->