### PR TITLE
[5.0][CSBindings] Form bindings correctly when they come from 'OptionalObj…

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -402,6 +402,15 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
     if (type->hasError())
       continue;
 
+    // If the source of the binding is 'OptionalObject' constraint
+    // and type variable is on the left-hand side, that means
+    // that it _has_ to be of optional type, since the right-hand
+    // side of the constraint is object type of the optional.
+    if (constraint->getKind() == ConstraintKind::OptionalObject &&
+        kind == AllowedBindingKind::Subtypes) {
+      type = OptionalType::get(type);
+    }
+
     // If the type we'd be binding to is a dependent member, don't try to
     // resolve this type variable yet.
     if (type->is<DependentMemberType>()) {

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -1097,7 +1097,7 @@ func rdar17170728() {
 
   let _ = [i, j, k].reduce(0 as Int?) {
     $0 && $1 ? $0! + $1! : ($0 ? $0! : ($1 ? $1! : nil))
-    // expected-error@-1 {{type of expression is ambiguous without more context}}
+    // expected-error@-1 {{ambiguous use of operator '+'}}
   }
 }
 

--- a/test/Constraints/optional.swift
+++ b/test/Constraints/optional.swift
@@ -267,3 +267,8 @@ class Bar {
     let _: Int = result // expected-error{{cannot convert value of type 'X?' to specified type 'Int'}}
   }
 }
+
+// rdar://problem/37508855
+func rdar37508855(_ e1: X?, _ e2: X?) -> [X] {
+  return [e1, e2].filter { $0 == nil }.map { $0! }
+}


### PR DESCRIPTION
…ect' constraint

Fixes a bug in `getPotentialBindings` when the source of the bindings
is 'OptionalObject' constraint and type variable is on the left-hand
side of that constraint, that makes such type variable always have an
optional type since right-hand side of 'OptionalObject' is its 'object'
type.

Resolves: rdar://problem/37508855
(cherry picked from commit 5208049ff8174e72409b937ff81a92e790003e84)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
