### PR TITLE
[Benchmarks] Update benchmarks to Swift 4

### DIFF
--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -219,7 +219,6 @@ function (swift_benchmark_compile_archopts)
     endif()
   endif()
 
-  set(common_swift3_options ${common_options} "-swift-version" "3")
   set(common_swift4_options ${common_options} "-swift-version" "4")
 
   # Always optimize the driver modules.
@@ -247,7 +246,7 @@ function (swift_benchmark_compile_archopts)
       SOURCE_DIR "${srcdir}"
       OBJECT_DIR "${objdir}"
       SOURCES ${sources}
-      LIBRARY_FLAGS ${common_swift3_options})
+      LIBRARY_FLAGS ${common_swift4_options})
     precondition(objfile_out)
     list(APPEND bench_library_objects "${objfile_out}")
     if (SWIFT_BENCHMARK_EMIT_SIB)
@@ -316,7 +315,7 @@ function (swift_benchmark_compile_archopts)
             ${stdlib_dependencies} ${bench_library_objects}
             "${srcdir}/${module_name_path}.swift"
           COMMAND "${SWIFT_EXEC}"
-          ${common_swift3_options}
+          ${common_swift4_options}
           ${extra_options}
           "-parse-as-library"
           ${bench_flags}
@@ -334,7 +333,7 @@ function (swift_benchmark_compile_archopts)
               ${stdlib_dependencies} ${bench_library_sibfiles}
               "${srcdir}/${module_name_path}.swift"
             COMMAND "${SWIFT_EXEC}"
-            ${common_swift3_options}
+            ${common_swift4_options}
             "-parse-as-library"
             ${bench_flags}
             "-module-name" "${module_name}"
@@ -364,7 +363,7 @@ function (swift_benchmark_compile_archopts)
         SOURCE_DIR "${srcdir}"
         OBJECT_DIR "${objdir}"
         SOURCES ${${module_name}_sources}
-        LIBRARY_FLAGS ${common_swift3_options} ${bench_flags}
+        LIBRARY_FLAGS ${common_swift4_options} ${bench_flags}
         DEPENDS ${bench_library_objects} ${stdlib_dependencies})
       precondition(objfile_out)
       list(APPEND SWIFT_BENCH_OBJFILES "${objfile_out}")
@@ -382,7 +381,7 @@ function (swift_benchmark_compile_archopts)
         SOURCE_DIR "${srcdir}"
         OBJECT_DIR "${objdir}"
         SOURCES ${${module_name}_sources}
-        LIBRARY_FLAGS ${common_swift3_options} ${bench_flags}
+        LIBRARY_FLAGS ${common_swift4_options} ${bench_flags}
         DEPENDS ${bench_library_objects} ${stdlib_dependencies})
       precondition(objfiles_out)
       list(APPEND SWIFT_BENCH_OBJFILES ${objfiles_out})
@@ -435,7 +434,7 @@ function (swift_benchmark_compile_archopts)
         ${bench_library_sibfiles} ${bench_driver_sibfiles}
         ${SWIFT_BENCH_SIBFILES} "${source}"
       COMMAND "${SWIFT_EXEC}"
-      ${common_swift3_options}
+      ${common_swift4_options}
       "-force-single-frontend-invocation"
       "-emit-module" "-module-name" "${module_name}"
       "-I" "${objdir}"

--- a/benchmark/single-source/ArraySubscript.swift
+++ b/benchmark/single-source/ArraySubscript.swift
@@ -30,7 +30,7 @@ public func run_ArraySubscript(_ N: Int) {
   var arrays = [[Int]](repeating: [], count: numArrays)
   for i in 0..<numArrays {
     for _ in 0..<numArrayElements {
-      arrays[i].append(Int(truncatingBitPattern: Random()))
+      arrays[i].append(Int(truncatingIfNeeded: Random()))
     }
   }
 

--- a/benchmark/single-source/CString.swift
+++ b/benchmark/single-source/CString.swift
@@ -37,7 +37,7 @@ public func run_StringWithCString(_ N: Int) {
 
 @inline(never)
 public func run_CStringLongAscii(_ N: Int) {
-  var res: UInt = 0
+  var res = 0
   for _ in 1...N*500 {
     // static string to c -> from c to String -> implicit conversion
     res &= strlen(ascii.withCString(String.init(cString:)))
@@ -47,7 +47,7 @@ public func run_CStringLongAscii(_ N: Int) {
 
 @inline(never)
 public func run_CStringLongNonAscii(_ N: Int) {
-  var res: UInt = 0
+  var res = 0
   for _ in 1...N*500 {
     res &= strlen(japanese.withCString(String.init(cString:)))
   }

--- a/benchmark/single-source/Hash.swift
+++ b/benchmark/single-source/Hash.swift
@@ -114,8 +114,8 @@ class Hash {
   final
   func rol(_ x: UInt32, _ c: UInt32) -> UInt32 {
     // TODO: use the &>> operator.
-    let a = UInt32(truncatingBitPattern: Int64(x) << Int64(c))
-    let b = UInt32(truncatingBitPattern: Int64(x) >> (32 - Int64(c)))
+    let a = UInt32(truncatingIfNeeded: Int64(x) << Int64(c))
+    let b = UInt32(truncatingIfNeeded: Int64(x) >> (32 - Int64(c)))
     return a|b
   }
 
@@ -123,8 +123,8 @@ class Hash {
   final
   func ror(_ x: UInt32, _ c: UInt32) -> UInt32 {
     // TODO: use the &>> operator.
-    let a = UInt32(truncatingBitPattern: Int64(x) >> Int64(c))
-    let b = UInt32(truncatingBitPattern: Int64(x) << (32 - Int64(c)))
+    let a = UInt32(truncatingIfNeeded: Int64(x) >> Int64(c))
+    let b = UInt32(truncatingIfNeeded: Int64(x) << (32 - Int64(c)))
     return a|b
   }
 }
@@ -177,10 +177,10 @@ class MD5 : Hash {
   }
 
   func appendBytes(_ Val: Int, _ Message: inout Array<UInt8>, _ Offset : Int) {
-    Message[Offset] = UInt8(truncatingBitPattern: Val)
-    Message[Offset + 1] = UInt8(truncatingBitPattern: Val >> 8)
-    Message[Offset + 2] = UInt8(truncatingBitPattern: Val >> 16)
-    Message[Offset + 3] = UInt8(truncatingBitPattern: Val >> 24)
+    Message[Offset] = UInt8(truncatingIfNeeded: Val)
+    Message[Offset + 1] = UInt8(truncatingIfNeeded: Val >> 8)
+    Message[Offset + 2] = UInt8(truncatingIfNeeded: Val >> 16)
+    Message[Offset + 3] = UInt8(truncatingIfNeeded: Val >> 24)
   }
 
   override

--- a/benchmark/single-source/IterateData.swift
+++ b/benchmark/single-source/IterateData.swift
@@ -21,8 +21,9 @@ public let IterateData = BenchmarkInfo(
 @inline(never)
 func generateData() -> Data {
   var data = Data(count: 16 * 1024)
+  let n = data.count
   data.withUnsafeMutableBytes { (ptr: UnsafeMutablePointer<UInt8>) -> () in
-    for i in 0..<data.count {
+    for i in 0..<n {
       ptr[i] = UInt8(i % 23)
     }
   }

--- a/benchmark/single-source/LuhnAlgoEager.swift
+++ b/benchmark/single-source/LuhnAlgoEager.swift
@@ -144,7 +144,7 @@ let charToString = { (c: Character) -> String in String(c) }
 let charToInt = stringToInt • charToString
 
 func sum<S: Sequence>(_ nums: S)->S.Iterator.Element where S.Iterator.Element: FixedWidthInteger {
-    return nums.reduce(0) { $0.0 + $0.1 }
+    return nums.reduce(0, +)
 }
 
 func reverse<C: LazyCollectionProtocol>(

--- a/benchmark/single-source/LuhnAlgoLazy.swift
+++ b/benchmark/single-source/LuhnAlgoLazy.swift
@@ -143,8 +143,8 @@ let stringToInt = freeMemberFunc(String.toInt)
 let charToString = { (c: Character) -> String in String(c) }
 let charToInt = stringToInt • charToString
 
-func sum<S: Sequence>(_ nums: S)->S.Iterator.Element where S.Iterator.Element: FixedWidthInteger {
-    return nums.reduce(0) { $0.0 + $0.1 }
+func sum<S: Sequence>(_ nums: S)->S.Element where S.Element: FixedWidthInteger {
+    return nums.reduce(0,+)
 }
 
 func reverse<C: LazyCollectionProtocol>(
@@ -154,14 +154,14 @@ func reverse<C: LazyCollectionProtocol>(
 }
 
 func map<S: LazySequenceProtocol, U>(
-  _ source: S, _ transform: @escaping (S.Elements.Iterator.Element)->U
+  _ source: S, _ transform: @escaping (S.Elements.Element)->U
 ) -> LazyMapSequence<S.Elements,U> {
   return source.map(transform)
 }
 
 func mapSome<C: LazyCollectionProtocol, U>(
     _ source: C,
-    _ transform: @escaping (C.Elements.Iterator.Element)->U?
+    _ transform: @escaping (C.Elements.Element)->U?
 ) -> LazySequence<MapSomeSequenceView<C.Elements, U>> {
     return source.mapSome(transform)
 }

--- a/benchmark/single-source/MonteCarloE.swift
+++ b/benchmark/single-source/MonteCarloE.swift
@@ -28,7 +28,7 @@ public func run_MonteCarloE(scale: Int) {
   let N = 200000*scale
   var intervals = [Bool](repeating: false, count: N)
   for _ in 1...N {
-    let pos = Int(UInt(truncatingBitPattern: Random())%UInt(N))
+    let pos = Int(UInt(truncatingIfNeeded: Random())%UInt(N))
     intervals[pos] = true
   }
   let numEmptyIntervals = intervals.filter{!$0}.count

--- a/benchmark/single-source/MonteCarloPi.swift
+++ b/benchmark/single-source/MonteCarloPi.swift
@@ -22,8 +22,8 @@ public func run_MonteCarloPi(scale: Int) {
   let r = 10000
   let N = 500000*scale
   for _ in 1...N {
-    let x = Int(truncatingBitPattern: Random())%r
-    let y = Int(truncatingBitPattern: Random())%r
+    let x = Int(truncatingIfNeeded: Random())%r
+    let y = Int(truncatingIfNeeded: Random())%r
     if x*x + y*y < r*r {
       pointsInside += 1
     }

--- a/benchmark/single-source/NibbleSort.swift
+++ b/benchmark/single-source/NibbleSort.swift
@@ -29,8 +29,6 @@ public func run_NibbleSort(_ N: Int) {
 }
 
 struct NibbleCollection: RandomAccessCollection, MutableCollection {
-  typealias Indices = CountableRange<UInt64>
-
   var val: UInt64
   init(_ val: UInt64) { self.val = val }
 

--- a/benchmark/single-source/PopFront.swift
+++ b/benchmark/single-source/PopFront.swift
@@ -56,6 +56,6 @@ public func run_PopFrontUnsafePointer(_ N: Int) {
       CheckResults(result == arrayCount)
     }
   }
-  a.deallocate(capacity: arrayCount)
+  a.deallocate()
 }
 

--- a/benchmark/single-source/RangeIteration.swift
+++ b/benchmark/single-source/RangeIteration.swift
@@ -52,7 +52,7 @@ public func run_RangeIterationSigned(_ N: Int) {
 
 @inline(never)
 public func run_RangeIterationSigned64(_ N: Int) {
-  let range: CountableRange<Int64> = 0..<100000
+  let range: Range<Int64> = 0..<100000
   check = 0
   for _ in 1...N {
     for e in range {
@@ -65,7 +65,7 @@ public func run_RangeIterationSigned64(_ N: Int) {
 
 @inline(never)
 public func run_RangeIterationUnsigned(_ N: Int) {
-  let range: CountableRange<UInt> = 0..<100000
+  let range: Range<UInt> = 0..<100000
   check = 0
   for _ in 1...N {
     for e in range {

--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -33,8 +33,8 @@ public func run_SetIsSubsetOf(_ N: Int) {
   var otherSet = Set<Int>(minimumCapacity: size)
 
   for _ in 0 ..< size {
-    set.insert(Int(truncatingBitPattern: Random()))
-    otherSet.insert(Int(truncatingBitPattern: Random()))
+    set.insert(Int(truncatingIfNeeded: Random()))
+    otherSet.insert(Int(truncatingIfNeeded: Random()))
   }
 
   var isSubset = false
@@ -62,8 +62,8 @@ public func run_SetExclusiveOr(_ N: Int) {
   var otherSet = Set<Int>(minimumCapacity: size)
 
   for _ in 0 ..< size {
-    set.insert(Int(truncatingBitPattern: Random()))
-    otherSet.insert(Int(truncatingBitPattern: Random()))
+    set.insert(Int(truncatingIfNeeded: Random()))
+    otherSet.insert(Int(truncatingIfNeeded: Random()))
   }
 
   var xor = Set<Int>()
@@ -83,8 +83,8 @@ public func run_SetUnion(_ N: Int) {
   var otherSet = Set<Int>(minimumCapacity: size)
 
   for _ in 0 ..< size {
-    set.insert(Int(truncatingBitPattern: Random()))
-    otherSet.insert(Int(truncatingBitPattern: Random()))
+    set.insert(Int(truncatingIfNeeded: Random()))
+    otherSet.insert(Int(truncatingIfNeeded: Random()))
   }
 
   var or = Set<Int>()
@@ -104,8 +104,8 @@ public func run_SetIntersect(_ N: Int) {
   var otherSet = Set<Int>(minimumCapacity: size)
 
   for _ in 0 ..< size {
-    set.insert(Int(truncatingBitPattern: Random()))
-    otherSet.insert(Int(truncatingBitPattern: Random()))
+    set.insert(Int(truncatingIfNeeded: Random()))
+    otherSet.insert(Int(truncatingIfNeeded: Random()))
   }
 
   var and = Set<Int>()
@@ -141,8 +141,8 @@ public func run_SetIsSubsetOf_OfObjects(_ N: Int) {
   var otherSet = Set<Box<Int>>(minimumCapacity: size)
 
   for _ in 0 ..< size {
-    set.insert(Box(Int(truncatingBitPattern: Random())))
-    otherSet.insert(Box(Int(truncatingBitPattern: Random())))
+    set.insert(Box(Int(truncatingIfNeeded: Random())))
+    otherSet.insert(Box(Int(truncatingIfNeeded: Random())))
   }
 
   var isSubset = false
@@ -170,8 +170,8 @@ public func run_SetExclusiveOr_OfObjects(_ N: Int) {
   var otherSet = Set<Box<Int>>(minimumCapacity: size)
 
   for _ in 0 ..< size {
-    set.insert(Box(Int(truncatingBitPattern: Random())))
-    otherSet.insert(Box(Int(truncatingBitPattern: Random())))
+    set.insert(Box(Int(truncatingIfNeeded: Random())))
+    otherSet.insert(Box(Int(truncatingIfNeeded: Random())))
   }
 
   var xor = Set<Box<Int>>()
@@ -191,8 +191,8 @@ public func run_SetUnion_OfObjects(_ N: Int) {
   var otherSet = Set<Box<Int>>(minimumCapacity: size)
 
   for _ in 0 ..< size {
-    set.insert(Box(Int(truncatingBitPattern: Random())))
-    otherSet.insert(Box(Int(truncatingBitPattern: Random())))
+    set.insert(Box(Int(truncatingIfNeeded: Random())))
+    otherSet.insert(Box(Int(truncatingIfNeeded: Random())))
   }
 
   var or = Set<Box<Int>>()
@@ -212,8 +212,8 @@ public func run_SetIntersect_OfObjects(_ N: Int) {
   var otherSet = Set<Box<Int>>(minimumCapacity: size)
 
   for _ in 0 ..< size {
-    set.insert(Box(Int(truncatingBitPattern: Random())))
-    otherSet.insert(Box(Int(truncatingBitPattern: Random())))
+    set.insert(Box(Int(truncatingIfNeeded: Random())))
+    otherSet.insert(Box(Int(truncatingIfNeeded: Random())))
   }
 
   var and = Set<Box<Int>>()

--- a/benchmark/single-source/StaticArray.swift
+++ b/benchmark/single-source/StaticArray.swift
@@ -48,9 +48,7 @@ struct A2X<T : StaticArrayProtocol> : StaticArrayProtocol {
 
 struct StaticArray<
   T : StaticArrayProtocol
-> : StaticArrayProtocol, RandomAccessCollection, MutableCollection {
-  typealias Indices = CountableRange<Int>
-  
+> : StaticArrayProtocol, RandomAccessCollection, MutableCollection {  
   init(_ defaultValue : T.ElemTy) { values = T(defaultValue) }
   var values : T
   func get(_ idx: Int) -> T.ElemTy { return values.get(idx) }

--- a/benchmark/single-source/StringMatch.swift
+++ b/benchmark/single-source/StringMatch.swift
@@ -22,23 +22,15 @@ public let StringMatch = BenchmarkInfo(
   runFunction: run_StringMatch,
   tags: [.validation, .api, .String])
 
-extension String {
-  @inline(__always)
-  func dropFirst(_ n: Int = 1) -> String {
-    let startIndex = self.index(self.startIndex, offsetBy: n)
-    return self[startIndex ..< self.endIndex]
-  }
-}
-
 /* match: search for regexp anywhere in text */
 func match(regexp: String, text: String) -> Bool {
   if regexp.first == "^" {
-    return matchHere(regexp.dropFirst(), text)
+    return matchHere(regexp.dropFirst(), text[...])
   }
   
   var idx = text.startIndex
   while true {  // must look even if string is empty
-    if matchHere(regexp, text[idx..<text.endIndex]) {
+    if matchHere(regexp[...], text[idx..<text.endIndex]) {
       return true
     }
     guard idx != text.endIndex else { break }
@@ -50,7 +42,7 @@ func match(regexp: String, text: String) -> Bool {
 }
 
 /* matchhere: search for regexp at beginning of text */
-func matchHere(_ regexp: String, _ text: String) -> Bool {
+func matchHere(_ regexp: Substring, _ text: Substring) -> Bool {
   if regexp.isEmpty {
     return true
   }
@@ -71,7 +63,7 @@ func matchHere(_ regexp: String, _ text: String) -> Bool {
 }
 
 /* matchstar: search for c*regexp at beginning of text */
-func matchStar(_ c: Character, _ regexp: String, _ text: String) -> Bool {
+func matchStar(_ c: Character, _ regexp: Substring, _ text: Substring) -> Bool {
   var idx = text.startIndex
   while true {   /* a * matches zero or more instances */
     if matchHere(regexp, text[idx..<text.endIndex]) {


### PR DESCRIPTION
Update benchmarks to Swift 4. Just seeing if doing this makes any of them change, first, then we'll see if we want to make this change at this particular time.

Also I'm immensely suspicious of all that `truncatingBitPattern:`

Edit: Looks like all OK except maybe some regressions in debug. We should probably do this.