### PR TITLE
[Sema] Disallow conditional conformances on objective-c generics.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1426,6 +1426,10 @@ ERROR(objc_runtime_visible_cannot_conform_to_objc_protocol,none,
       "class %0 cannot conform to @objc protocol %1 because "
       "the class is only visible via the Objective-C runtime",
       (Type, Type))
+ERROR(objc_generics_cannot_conditionally_conform,none,
+      "type %0 cannot conditionally conform to protocol %1 because "
+      "the type uses the Objective-C generics model",
+      (Type, Type))
 ERROR(protocol_has_missing_requirements,none,
       "type %0 cannot conform to protocol %1 because it has requirements that "
       "cannot be satisfied", (Type, Type))

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -16,6 +16,7 @@
 #include "swift/Basic/STLExtras.h"
 #include "swift/AST/AttrKind.h"
 #include "swift/AST/Identifier.h"
+#include "swift/AST/TypeOrExtensionDecl.h"
 #include "llvm/ADT/Optional.h"
 #include <limits.h>
 #include <vector>
@@ -36,32 +37,6 @@ enum DeclAttrKind : unsigned;
 class SynthesizedExtensionAnalyzer;
 struct PrintOptions;
 
-/// \brief Describes either a nominal type declaration or an extension
-/// declaration.
-struct TypeOrExtensionDecl {
-  llvm::PointerUnion<NominalTypeDecl *, ExtensionDecl *> Decl;
-
-  TypeOrExtensionDecl() = default;
-
-  TypeOrExtensionDecl(NominalTypeDecl *D);
-  TypeOrExtensionDecl(ExtensionDecl *D);
-
-  /// \brief Return the contained *Decl as the Decl superclass.
-  class Decl *getAsDecl() const;
-  /// \brief Return the contained *Decl as the DeclContext superclass.
-  DeclContext *getAsDeclContext() const;
-  /// \brief Return the contained NominalTypeDecl or that of the extended type
-  /// in the ExtensionDecl.
-  NominalTypeDecl *getBaseNominal() const;
-
-  /// \brief Is the contained pointer null?
-  bool isNull() const;
-  explicit operator bool() const { return !isNull(); }
-
-  bool operator==(TypeOrExtensionDecl rhs) { return Decl == rhs.Decl; }
-  bool operator!=(TypeOrExtensionDecl rhs) { return Decl != rhs.Decl; }
-  bool operator<(TypeOrExtensionDecl rhs) { return Decl < rhs.Decl; }
-};
 
 /// Necessary information for archetype transformation during printing.
 struct TypeTransformContext {

--- a/include/swift/AST/TypeAlignments.h
+++ b/include/swift/AST/TypeAlignments.h
@@ -37,6 +37,7 @@ namespace swift {
   class ExtensionDecl;
   class GenericEnvironment;
   class GenericTypeParamDecl;
+  class NominalTypeDecl;
   class NormalProtocolConformance;
   class OperatorDecl;
   class Pattern;
@@ -90,6 +91,7 @@ LLVM_DECLARE_TYPE_ALIGNMENT(swift::OperatorDecl, swift::DeclAlignInBits)
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::ProtocolDecl, swift::DeclAlignInBits)
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::TypeDecl, swift::DeclAlignInBits)
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::ValueDecl, swift::DeclAlignInBits)
+LLVM_DECLARE_TYPE_ALIGNMENT(swift::NominalTypeDecl, swift::DeclAlignInBits)
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::ExtensionDecl, swift::DeclAlignInBits)
 
 LLVM_DECLARE_TYPE_ALIGNMENT(swift::TypeBase, swift::TypeAlignInBits)

--- a/include/swift/AST/TypeOrExtensionDecl.h
+++ b/include/swift/AST/TypeOrExtensionDecl.h
@@ -1,0 +1,56 @@
+//===- TypeOrExtensionDecl.h - Swift Language Declaration ASTs -*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the TypeOrExtensionDecl struct, separately to Decl.h so
+// that this can be included in files that Decl.h includes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_TYPE_OR_EXTENSION_DECL_H
+#define SWIFT_TYPE_OR_EXTENSION_DECL_H
+
+#include "swift/AST/TypeAlignments.h"
+#include "llvm/ADT/PointerUnion.h"
+
+namespace swift {
+
+/// \brief Describes either a nominal type declaration or an extension
+/// declaration.
+struct TypeOrExtensionDecl {
+  // (The definitions are in Decl.cpp.)
+  llvm::PointerUnion<NominalTypeDecl *, ExtensionDecl *> Decl;
+
+  TypeOrExtensionDecl() = default;
+
+  TypeOrExtensionDecl(NominalTypeDecl *D);
+  TypeOrExtensionDecl(ExtensionDecl *D);
+
+  /// \brief Return the contained *Decl as the Decl superclass.
+  class Decl *getAsDecl() const;
+  /// \brief Return the contained *Decl as the DeclContext superclass.
+  DeclContext *getAsDeclContext() const;
+  /// \brief Return the contained NominalTypeDecl or that of the extended type
+  /// in the ExtensionDecl.
+  NominalTypeDecl *getBaseNominal() const;
+
+  /// \brief Is the contained pointer null?
+  bool isNull() const;
+  explicit operator bool() const { return !isNull(); }
+
+  bool operator==(TypeOrExtensionDecl rhs) { return Decl == rhs.Decl; }
+  bool operator!=(TypeOrExtensionDecl rhs) { return Decl != rhs.Decl; }
+  bool operator<(TypeOrExtensionDecl rhs) { return Decl < rhs.Decl; }
+};
+
+} // end namespace swift
+
+#endif

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -63,23 +63,6 @@ void PrintOptions::clearSynthesizedExtension() {
   TransformContext.reset();
 }
 
-TypeOrExtensionDecl::TypeOrExtensionDecl(NominalTypeDecl *D) : Decl(D) {}
-TypeOrExtensionDecl::TypeOrExtensionDecl(ExtensionDecl *D) : Decl(D) {}
-
-Decl *TypeOrExtensionDecl::getAsDecl() const {
-  if (auto NTD = Decl.dyn_cast<NominalTypeDecl *>())
-    return NTD;
-
-  return Decl.get<ExtensionDecl *>();
-}
-DeclContext *TypeOrExtensionDecl::getAsDeclContext() const {
-  return getAsDecl()->getInnermostDeclContext();
-}
-NominalTypeDecl *TypeOrExtensionDecl::getBaseNominal() const {
-  return getAsDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
-}
-bool TypeOrExtensionDecl::isNull() const { return Decl.isNull(); }
-
 TypeTransformContext::TypeTransformContext(Type T)
     : BaseType(T.getPointer()) {
   assert(T->mayHaveMembers());

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5689,3 +5689,20 @@ UnifiedStatsReporter::getStatsTracer(StringRef EventName, const Decl *D) {
     // Return inert tracer object.
     return FrontendStatsTracer();
 }
+
+TypeOrExtensionDecl::TypeOrExtensionDecl(NominalTypeDecl *D) : Decl(D) {}
+TypeOrExtensionDecl::TypeOrExtensionDecl(ExtensionDecl *D) : Decl(D) {}
+
+Decl *TypeOrExtensionDecl::getAsDecl() const {
+  if (auto NTD = Decl.dyn_cast<NominalTypeDecl *>())
+    return NTD;
+
+  return Decl.get<ExtensionDecl *>();
+}
+DeclContext *TypeOrExtensionDecl::getAsDeclContext() const {
+  return getAsDecl()->getInnermostDeclContext();
+}
+NominalTypeDecl *TypeOrExtensionDecl::getBaseNominal() const {
+  return getAsDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+}
+bool TypeOrExtensionDecl::isNull() const { return Decl.isNull(); }

--- a/test/Generics/Inputs/conditional_conformances_objc.h
+++ b/test/Generics/Inputs/conditional_conformances_objc.h
@@ -1,0 +1,7 @@
+@import Foundation;
+
+@interface ObjC <ObjectType>: NSObject
+@end
+
+@interface ObjC2: NSObject
+@end

--- a/test/Generics/conditional_conformances_objc.swift
+++ b/test/Generics/conditional_conformances_objc.swift
@@ -1,0 +1,34 @@
+// RUN: %target-typecheck-verify-swift -import-objc-header %S/Inputs/conditional_conformances_objc.h
+
+// REQUIRES: objc_interop
+
+protocol Foo {}
+extension ObjC: Foo where ObjectType == ObjC2 {}
+// expected-error@-1{{type 'ObjC<ObjectType>' cannot conditionally conform to protocol 'Foo' because the type uses the Objective-C generics model}}
+
+protocol Bar {}
+extension ObjC: Bar where ObjectType: Bar {}
+// expected-error@-1{{type 'ObjC<ObjectType>' cannot conditionally conform to protocol 'Bar' because the type uses the Objective-C generics model}}
+
+extension ObjC {
+    struct Struct {
+        enum Enum {}
+    }
+    class Class<T> {}
+}
+
+extension ObjC.Struct: Foo where ObjectType == ObjC2 {}
+// expected-error@-1{{type 'ObjC<ObjectType>.Struct' cannot conditionally conform to protocol 'Foo' because the type uses the Objective-C generics model}}
+extension ObjC.Struct: Bar where ObjectType: Bar {}
+// expected-error@-1{{type 'ObjC<ObjectType>.Struct' cannot conditionally conform to protocol 'Bar' because the type uses the Objective-C generics model}}
+
+extension ObjC.Struct.Enum: Foo where ObjectType == ObjC2 {}
+// expected-error@-1{{type 'ObjC<ObjectType>.Struct.Enum' cannot conditionally conform to protocol 'Foo' because the type uses the Objective-C generics model}}
+extension ObjC.Struct.Enum: Bar where ObjectType: Bar {}
+// expected-error@-1{{type 'ObjC<ObjectType>.Struct.Enum' cannot conditionally conform to protocol 'Bar' because the type uses the Objective-C generics model}}
+
+extension ObjC.Class: Foo where T == ObjC2 {}
+// expected-error@-1{{type 'ObjC<ObjectType>.Class<T>' cannot conditionally conform to protocol 'Foo' because the type uses the Objective-C generics model}}
+extension ObjC.Class: Bar where T: Bar {}
+// expected-error@-1{{type 'ObjC<ObjectType>.Class<T>' cannot conditionally conform to protocol 'Bar' because the type uses the Objective-C generics model}}
+


### PR DESCRIPTION
There's no way to look up information about objective-c generic
parameters, meaning the runtime cannot check same-type constraints or
conformance requirements, so dynamic casts cannot work. We want to keep
the static and dynamic systems the same, so we have to disable this
functionality from the start (i.e. no conditional conformances on
objective-c types :( ).

Fixes rdar://problem/37524969.

(Plus moving `TypeOrExtensionDecl`.)
