### PR TITLE
[5.0] [IDE] Teach type checker about conditional conformance extensions.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -170,10 +170,6 @@ public:
 };
 
 class SILLayout; // From SIL
-/// \brief Describes either a nominal type declaration or an extension
-/// declaration.
-typedef llvm::PointerUnion<NominalTypeDecl *, ExtensionDecl *>
-  TypeOrExtensionDecl;
 
 /// ASTContext - This object creates and owns the AST objects.
 /// However, this class does more than just maintain context within an AST.

--- a/include/swift/AST/ASTPrinter.h
+++ b/include/swift/AST/ASTPrinter.h
@@ -84,7 +84,7 @@ enum class PrintStructureKind {
 class ASTPrinter {
   unsigned CurrentIndentation = 0;
   unsigned PendingNewlines = 0;
-  const NominalTypeDecl *SynthesizeTarget = nullptr;
+  TypeOrExtensionDecl SynthesizeTarget;
 
   void printTextImpl(StringRef Text);
 
@@ -136,13 +136,14 @@ public:
 
   /// Called before printing a synthesized extension.
   virtual void printSynthesizedExtensionPre(const ExtensionDecl *ED,
-                                            const NominalTypeDecl *NTD,
+                                            TypeOrExtensionDecl NTD,
                                             Optional<BracketOptions> Bracket) {}
 
   /// Called after printing a synthesized extension.
   virtual void printSynthesizedExtensionPost(const ExtensionDecl *ED,
-                                             const NominalTypeDecl *NTD,
-                                             Optional<BracketOptions> Bracket) {}
+                                             TypeOrExtensionDecl TargetDecl,
+                                             Optional<BracketOptions> Bracket) {
+  }
 
   /// Called before printing a structured entity.
   ///
@@ -213,7 +214,7 @@ public:
     CurrentIndentation = NumSpaces;
   }
 
-  void setSynthesizedTarget(NominalTypeDecl *Target) {
+  void setSynthesizedTarget(TypeOrExtensionDecl Target) {
     assert((!SynthesizeTarget || !Target || Target == SynthesizeTarget) &&
            "unexpected change of setSynthesizedTarget");
     // FIXME: this can overwrite the original target with nullptr.

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -16,6 +16,7 @@
 #include "swift/Basic/STLExtras.h"
 #include "swift/AST/AttrKind.h"
 #include "swift/AST/Identifier.h"
+#include "swift/AST/TypeOrExtensionDecl.h"
 #include "llvm/ADT/Optional.h"
 #include <limits.h>
 #include <vector>
@@ -36,32 +37,6 @@ enum DeclAttrKind : unsigned;
 class SynthesizedExtensionAnalyzer;
 struct PrintOptions;
 
-/// \brief Describes either a nominal type declaration or an extension
-/// declaration.
-struct TypeOrExtensionDecl {
-  llvm::PointerUnion<NominalTypeDecl *, ExtensionDecl *> Decl;
-
-  TypeOrExtensionDecl() = default;
-
-  TypeOrExtensionDecl(NominalTypeDecl *D);
-  TypeOrExtensionDecl(ExtensionDecl *D);
-
-  /// \brief Return the contained *Decl as the Decl superclass.
-  class Decl *getAsDecl() const;
-  /// \brief Return the contained *Decl as the DeclContext superclass.
-  DeclContext *getAsDeclContext() const;
-  /// \brief Return the contained NominalTypeDecl or that of the extended type
-  /// in the ExtensionDecl.
-  NominalTypeDecl *getBaseNominal() const;
-
-  /// \brief Is the contained pointer null?
-  bool isNull() const;
-  explicit operator bool() const { return !isNull(); }
-
-  bool operator==(TypeOrExtensionDecl rhs) { return Decl == rhs.Decl; }
-  bool operator!=(TypeOrExtensionDecl rhs) { return Decl != rhs.Decl; }
-  bool operator<(TypeOrExtensionDecl rhs) { return Decl < rhs.Decl; }
-};
 
 /// Necessary information for archetype transformation during printing.
 struct TypeTransformContext {

--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -36,16 +36,45 @@ enum DeclAttrKind : unsigned;
 class SynthesizedExtensionAnalyzer;
 struct PrintOptions;
 
+/// \brief Describes either a nominal type declaration or an extension
+/// declaration.
+struct TypeOrExtensionDecl {
+  llvm::PointerUnion<NominalTypeDecl *, ExtensionDecl *> Decl;
+
+  TypeOrExtensionDecl() = default;
+
+  TypeOrExtensionDecl(NominalTypeDecl *D);
+  TypeOrExtensionDecl(ExtensionDecl *D);
+
+  /// \brief Return the contained *Decl as the Decl superclass.
+  class Decl *getAsDecl() const;
+  /// \brief Return the contained *Decl as the DeclContext superclass.
+  DeclContext *getAsDeclContext() const;
+  /// \brief Return the contained NominalTypeDecl or that of the extended type
+  /// in the ExtensionDecl.
+  NominalTypeDecl *getBaseNominal() const;
+
+  /// \brief Is the contained pointer null?
+  bool isNull() const;
+  explicit operator bool() const { return !isNull(); }
+
+  bool operator==(TypeOrExtensionDecl rhs) { return Decl == rhs.Decl; }
+  bool operator!=(TypeOrExtensionDecl rhs) { return Decl != rhs.Decl; }
+  bool operator<(TypeOrExtensionDecl rhs) { return Decl < rhs.Decl; }
+};
+
 /// Necessary information for archetype transformation during printing.
 struct TypeTransformContext {
   TypeBase *BaseType;
-  NominalTypeDecl *Nominal = nullptr;
+  TypeOrExtensionDecl Decl;
 
   explicit TypeTransformContext(Type T);
-  explicit TypeTransformContext(NominalTypeDecl* NTD);
+  explicit TypeTransformContext(TypeOrExtensionDecl D);
 
   Type getBaseType() const;
-  NominalTypeDecl *getNominal() const;
+  TypeOrExtensionDecl getDecl() const;
+
+  DeclContext *getDeclContext() const;
 
   bool isPrintingSynthesizedExtension() const;
 };
@@ -417,7 +446,7 @@ struct PrintOptions {
 
   void setBaseType(Type T);
 
-  void initForSynthesizedExtension(NominalTypeDecl *D);
+  void initForSynthesizedExtension(TypeOrExtensionDecl D);
 
   void clearSynthesizedExtension();
 

--- a/include/swift/AST/TypeOrExtensionDecl.h
+++ b/include/swift/AST/TypeOrExtensionDecl.h
@@ -1,0 +1,59 @@
+//===- TypeOrExtensionDecl.h - Swift Language Declaration ASTs -*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the TypeOrExtensionDecl struct, separately to Decl.h so
+// that this can be included in files that Decl.h includes.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_TYPE_OR_EXTENSION_DECL_H
+#define SWIFT_TYPE_OR_EXTENSION_DECL_H
+
+#include "llvm/ADT/PointerUnion.h"
+
+namespace swift {
+class Decl;
+class NominalTypeDecl;
+class ExtensionDecl;
+class DeclContext;
+
+/// \brief Describes either a nominal type declaration or an extension
+/// declaration.
+struct TypeOrExtensionDecl {
+  // (The definitions are in Decl.cpp.)
+  llvm::PointerUnion<NominalTypeDecl *, ExtensionDecl *> Decl;
+
+  TypeOrExtensionDecl() = default;
+
+  TypeOrExtensionDecl(NominalTypeDecl *D);
+  TypeOrExtensionDecl(ExtensionDecl *D);
+
+  /// \brief Return the contained *Decl as the Decl superclass.
+  class Decl *getAsDecl() const;
+  /// \brief Return the contained *Decl as the DeclContext superclass.
+  DeclContext *getAsDeclContext() const;
+  /// \brief Return the contained NominalTypeDecl or that of the extended type
+  /// in the ExtensionDecl.
+  NominalTypeDecl *getBaseNominal() const;
+
+  /// \brief Is the contained pointer null?
+  bool isNull() const;
+  explicit operator bool() const { return !isNull(); }
+
+  bool operator==(TypeOrExtensionDecl rhs) { return Decl == rhs.Decl; }
+  bool operator!=(TypeOrExtensionDecl rhs) { return Decl != rhs.Decl; }
+  bool operator<(TypeOrExtensionDecl rhs) { return Decl < rhs.Decl; }
+};
+
+} // end namespace swift
+
+#endif

--- a/include/swift/Sema/IDETypeChecking.h
+++ b/include/swift/Sema/IDETypeChecking.h
@@ -137,10 +137,18 @@ namespace swift {
   /// Creates a lazy type resolver for use in lookups.
   OwnedResolver createLazyResolver(ASTContext &Ctx);
 
-  typedef std::pair<ExtensionDecl*, bool> ExtensionAndIsSynthesized;
+  struct ExtensionInfo {
+    // The extension with the declarations to apply.
+    ExtensionDecl *Ext;
+    // The extension that enables the former to apply, if any (i.e. a
+    // conditional
+    // conformance to Foo enables 'extension Foo').
+    ExtensionDecl *EnablingExt;
+    bool IsSynthesized;
+  };
 
-  typedef llvm::function_ref<void(ArrayRef<ExtensionAndIsSynthesized>)>
-    ExtensionGroupOperation;
+  typedef llvm::function_ref<void(ArrayRef<ExtensionInfo>)>
+      ExtensionGroupOperation;
 
   class SynthesizedExtensionAnalyzer {
     struct Implementation;

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -63,23 +63,6 @@ void PrintOptions::clearSynthesizedExtension() {
   TransformContext.reset();
 }
 
-TypeOrExtensionDecl::TypeOrExtensionDecl(NominalTypeDecl *D) : Decl(D) {}
-TypeOrExtensionDecl::TypeOrExtensionDecl(ExtensionDecl *D) : Decl(D) {}
-
-Decl *TypeOrExtensionDecl::getAsDecl() const {
-  if (auto NTD = Decl.dyn_cast<NominalTypeDecl *>())
-    return NTD;
-
-  return Decl.get<ExtensionDecl *>();
-}
-DeclContext *TypeOrExtensionDecl::getAsDeclContext() const {
-  return getAsDecl()->getInnermostDeclContext();
-}
-NominalTypeDecl *TypeOrExtensionDecl::getBaseNominal() const {
-  return getAsDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
-}
-bool TypeOrExtensionDecl::isNull() const { return Decl.isNull(); }
-
 TypeTransformContext::TypeTransformContext(Type T)
     : BaseType(T.getPointer()) {
   assert(T->mayHaveMembers());

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -55,7 +55,7 @@ void PrintOptions::setBaseType(Type T) {
   TransformContext = TypeTransformContext(T);
 }
 
-void PrintOptions::initForSynthesizedExtension(NominalTypeDecl *D) {
+void PrintOptions::initForSynthesizedExtension(TypeOrExtensionDecl D) {
   TransformContext = TypeTransformContext(D);
 }
 
@@ -63,16 +63,40 @@ void PrintOptions::clearSynthesizedExtension() {
   TransformContext.reset();
 }
 
+TypeOrExtensionDecl::TypeOrExtensionDecl(NominalTypeDecl *D) : Decl(D) {}
+TypeOrExtensionDecl::TypeOrExtensionDecl(ExtensionDecl *D) : Decl(D) {}
+
+Decl *TypeOrExtensionDecl::getAsDecl() const {
+  if (auto NTD = Decl.dyn_cast<NominalTypeDecl *>())
+    return NTD;
+
+  return Decl.get<ExtensionDecl *>();
+}
+DeclContext *TypeOrExtensionDecl::getAsDeclContext() const {
+  return getAsDecl()->getInnermostDeclContext();
+}
+NominalTypeDecl *TypeOrExtensionDecl::getBaseNominal() const {
+  return getAsDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+}
+bool TypeOrExtensionDecl::isNull() const { return Decl.isNull(); }
+
 TypeTransformContext::TypeTransformContext(Type T)
     : BaseType(T.getPointer()) {
   assert(T->mayHaveMembers());
 }
 
-TypeTransformContext::TypeTransformContext(NominalTypeDecl *NTD)
-    : BaseType(NTD->getDeclaredTypeInContext().getPointer()), Nominal(NTD) {}
+TypeTransformContext::TypeTransformContext(TypeOrExtensionDecl D)
+    : BaseType(nullptr), Decl(D) {
+  if (auto NTD = Decl.Decl.dyn_cast<NominalTypeDecl *>())
+    BaseType = NTD->getDeclaredTypeInContext().getPointer();
+  else
+    BaseType = Decl.Decl.get<ExtensionDecl *>()->getExtendedType().getPointer();
+}
 
-NominalTypeDecl *TypeTransformContext::getNominal() const {
-  return Nominal;
+TypeOrExtensionDecl TypeTransformContext::getDecl() const { return Decl; }
+
+DeclContext *TypeTransformContext::getDeclContext() const {
+  return Decl.getAsDecl()->getDeclContext();
 }
 
 Type TypeTransformContext::getBaseType() const {
@@ -80,7 +104,7 @@ Type TypeTransformContext::getBaseType() const {
 }
 
 bool TypeTransformContext::isPrintingSynthesizedExtension() const {
-  return Nominal != nullptr;
+  return !Decl.isNull();
 }
 
 std::string ASTPrinter::sanitizeUtf8(StringRef Text) {
@@ -619,8 +643,7 @@ private:
 #define STMT(Name, Parent) void visit##Name##Stmt(Name##Stmt *stmt);
 #include "swift/AST/StmtNodes.def"
 
-  void printSynthesizedExtension(NominalTypeDecl* Decl,
-                                 ExtensionDecl* ExtDecl);
+  void printSynthesizedExtension(Type ExtendedType, ExtensionDecl *ExtDecl);
 
   void printExtension(ExtensionDecl* ExtDecl);
 
@@ -656,8 +679,9 @@ public:
         Options.TransformContext &&
         Options.TransformContext->isPrintingSynthesizedExtension() &&
         isa<ExtensionDecl>(D);
-    if (Synthesize)
-      Printer.setSynthesizedTarget(Options.TransformContext->getNominal());
+    if (Synthesize) {
+      Printer.setSynthesizedTarget(Options.TransformContext->getDecl());
+    }
 
     // We want to print a newline before doc comments.  Swift code already
     // handles this, but we need to insert it for clang doc comments when not
@@ -680,10 +704,10 @@ public:
     ASTVisitor::visit(D);
 
     if (Synthesize) {
-      Printer.setSynthesizedTarget(nullptr);
-      Printer.printSynthesizedExtensionPost(
-          cast<ExtensionDecl>(D), Options.TransformContext->getNominal(),
-          Options.BracketOptions);
+      Printer.setSynthesizedTarget({});
+      Printer.printSynthesizedExtensionPost(cast<ExtensionDecl>(D),
+                                            Options.TransformContext->getDecl(),
+                                            Options.BracketOptions);
     } else {
       Printer.callPrintDeclPost(D, Options.BracketOptions);
     }
@@ -1766,14 +1790,14 @@ static void printExtendedTypeName(Type ExtendedType, ASTPrinter &Printer,
   Printer.printTypeRef(ExtendedType, Nominal, Nominal->getName());
 }
 
-void PrintAST::
-printSynthesizedExtension(NominalTypeDecl* Decl, ExtensionDecl *ExtDecl) {
+void PrintAST::printSynthesizedExtension(Type ExtendedType,
+                                         ExtensionDecl *ExtDecl) {
   if (Options.BracketOptions.shouldOpenExtension(ExtDecl)) {
     printDocumentationComment(ExtDecl);
     printAttributes(ExtDecl);
     Printer << tok::kw_extension << " ";
 
-    printExtendedTypeName(Decl->getDeclaredType(), Printer, Options);
+    printExtendedTypeName(ExtendedType, Printer, Options);
     printInherited(ExtDecl);
 
     if (ExtDecl->getGenericParams())
@@ -1823,9 +1847,11 @@ void PrintAST::printExtension(ExtensionDecl *decl) {
 
 void PrintAST::visitExtensionDecl(ExtensionDecl *decl) {
   if (Options.TransformContext &&
-      Options.TransformContext->isPrintingSynthesizedExtension())
-    printSynthesizedExtension(Options.TransformContext->getNominal(), decl);
-  else
+      Options.TransformContext->isPrintingSynthesizedExtension()) {
+    auto extendedType =
+        Options.TransformContext->getBaseType()->mapTypeOutOfContext();
+    printSynthesizedExtension(extendedType, decl);
+  } else
     printExtension(decl);
 }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5548,3 +5548,21 @@ void ClassDecl::setSuperclass(Type superclass) {
          && "superclass must be interface type");
   LazySemanticInfo.Superclass.setPointerAndInt(superclass, true);
 }
+
+TypeOrExtensionDecl::TypeOrExtensionDecl(NominalTypeDecl *D) : Decl(D) {}
+TypeOrExtensionDecl::TypeOrExtensionDecl(ExtensionDecl *D) : Decl(D) {}
+
+Decl *TypeOrExtensionDecl::getAsDecl() const {
+  if (auto NTD = Decl.dyn_cast<NominalTypeDecl *>())
+    return NTD;
+
+  return Decl.get<ExtensionDecl *>();
+}
+DeclContext *TypeOrExtensionDecl::getAsDeclContext() const {
+  return getAsDecl()->getInnermostDeclContext();
+}
+NominalTypeDecl *TypeOrExtensionDecl::getBaseNominal() const {
+  return getAsDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+}
+bool TypeOrExtensionDecl::isNull() const { return Decl.isNull(); }
+

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -382,7 +382,7 @@ void NormalProtocolConformance::differenceAndStoreConditionalRequirements() {
   // Find the requirements in the extension that aren't proved by the original
   // type, these are the ones that make the conformance conditional.
   ConditionalRequirements =
-    ctxt.AllocateCopy(canExtensionSig->requirementsNotSatisfiedBy(canTypeSig));
+      ctxt.AllocateCopy(extensionSig->requirementsNotSatisfiedBy(typeSig));
 }
 
 void NormalProtocolConformance::setSignatureConformances(

--- a/lib/IDE/IDETypeChecking.cpp
+++ b/lib/IDE/IDETypeChecking.cpp
@@ -31,14 +31,13 @@ static bool shouldPrintAsFavorable(const Decl *D, PrintOptions &Options) {
       !D->getDeclContext()->isExtensionContext() ||
       !Options.TransformContext->isPrintingSynthesizedExtension())
     return true;
-  NominalTypeDecl *Target = Options.TransformContext->getNominal();
-  Type BaseTy = Target->getDeclaredTypeInContext();
+  auto DC = Options.TransformContext->getDeclContext();
+  auto BaseTy = Options.TransformContext->getBaseType();
   const auto *FD = dyn_cast<FuncDecl>(D);
   if (!FD)
     return true;
   ResolvedMemberResult Result =
-  resolveValueMember(*Target->getDeclContext(), BaseTy,
-                     FD->getEffectiveFullName());
+      resolveValueMember(*DC, BaseTy, FD->getEffectiveFullName());
   return !(Result.hasBestOverload() && Result.getBestOverload() != D);
 }
 
@@ -122,9 +121,11 @@ struct SynthesizedExtensionAnalyzer::Implementation {
   struct SynthesizedExtensionInfo {
     ExtensionDecl *Ext = nullptr;
     bool IsSynthesized;
+    ExtensionDecl *EnablingExt = nullptr;
     operator bool() const { return Ext; }
-    SynthesizedExtensionInfo(bool IsSynthesized = true) :
-    IsSynthesized(IsSynthesized) {}
+    SynthesizedExtensionInfo(bool IsSynthesized = false,
+                             ExtensionDecl *EnablingExt = nullptr)
+        : IsSynthesized(IsSynthesized), EnablingExt(EnablingExt) {}
     bool operator< (const SynthesizedExtensionInfo& Rhs) const {
 
       // Synthesized are always after actual ones.
@@ -146,6 +147,7 @@ struct SynthesizedExtensionAnalyzer::Implementation {
           return LeftOrder.getValue() < RightOrder.getValue();
         }
       }
+
       return false;
     }
   };
@@ -269,62 +271,65 @@ struct SynthesizedExtensionAnalyzer::Implementation {
   }
 
   std::pair<SynthesizedExtensionInfo, ExtensionMergeInfo>
-  isApplicable(ExtensionDecl *Ext, bool IsSynthesized) {
-    SynthesizedExtensionInfo Result(IsSynthesized);
+  isApplicable(ExtensionDecl *Ext, bool IsSynthesized,
+               ExtensionDecl *EnablingExt, NormalProtocolConformance *Conf) {
+    SynthesizedExtensionInfo Result(IsSynthesized, EnablingExt);
     ExtensionMergeInfo MergeInfo;
     MergeInfo.HasDocComment = !Ext->getRawComment().isEmpty();
     MergeInfo.InheritsCount = countInherits(Ext);
-    if (!Ext->isConstrainedExtension()) {
+
+    // There's (up to) two extensions here: the extension with the items that we
+    // might be merging, plus the "enabling extension", which is the route
+    // through which \c Ext itself applies, e.g. extension SomeProtocol {}
+    // extension SomeType: SomeProtocol where T: SomeProtocol {}. The former is
+    // Ext and the latter is EnablingExt/Conf. Either of these can be
+    // conditional in ways that need to be considered when merging.
+    auto conformanceIsConditional =
+        Conf && !Conf->getConditionalRequirements().empty();
+    if (!Ext->isConstrainedExtension() && !conformanceIsConditional) {
       if (IncludeUnconditional)
         Result.Ext = Ext;
       return {Result, MergeInfo};
     }
 
-    // Get the substitutions from the generic signature of
-    // the extension to the interface types of the base type's
-    // declaration.
-    auto *M = DC->getParentModule();
-    SubstitutionMap subMap;
-    if (!BaseType->isExistentialType())
-      subMap = BaseType->getContextSubstitutionMap(M, Ext);
+    auto handleRequirements = [&](SubstitutionMap subMap,
+                                  GenericSignature *GenericSig,
+                                  ArrayRef<Requirement> Reqs) {
+      for (auto Req : Reqs) {
+        auto Kind = Req.getKind();
 
-    assert(Ext->getGenericSignature() && "No generic signature.");
-    auto GenericSig = Ext->getGenericSignature();
-    for (auto Req : GenericSig->getRequirements()) {
-      auto Kind = Req.getKind();
+        // FIXME: Could do something here
+        if (Kind == RequirementKind::Layout)
+          continue;
 
-      // FIXME: Could do something here
-      if (Kind == RequirementKind::Layout)
-        continue;
+        auto First = Req.getFirstType();
+        auto Second = Req.getSecondType();
+        if (!BaseType->isExistentialType()) {
+          First = First.subst(subMap);
+          Second = Second.subst(subMap);
 
-      auto First = Req.getFirstType();
-      auto Second = Req.getSecondType();
-      if (!BaseType->isExistentialType()) {
-        First = First.subst(subMap);
-        Second = Second.subst(subMap);
-
-        if (!First || !Second) {
-          // Substitution with interface type bases can only fail
-          // if a concrete type fails to conform to a protocol.
-          // In this case, just give up on the extension altogether.
-          return {Result, MergeInfo};
+          if (!First || !Second) {
+            // Substitution with interface type bases can only fail
+            // if a concrete type fails to conform to a protocol.
+            // In this case, just give up on the extension altogether.
+            return true;
+          }
         }
-      }
 
-      switch (Kind) {
+        switch (Kind) {
         case RequirementKind::Conformance:
         case RequirementKind::Superclass:
           // FIXME: This could be more accurate; check
           // conformance instead of subtyping
           if (!canPossiblyConvertTo(First, Second, *DC))
-            return {Result, MergeInfo};
+            return true;
           else if (!isConvertibleTo(First, Second, *DC))
             MergeInfo.addRequirement(GenericSig, First, Second, Kind);
           break;
 
         case RequirementKind::SameType:
           if (!canPossiblyEqual(First, Second, *DC)) {
-            return {Result, MergeInfo};
+            return true;
           } else if (!First->isEqual(Second)) {
             MergeInfo.addRequirement(GenericSig, First, Second, Kind);
           }
@@ -332,8 +337,31 @@ struct SynthesizedExtensionAnalyzer::Implementation {
 
         case RequirementKind::Layout:
           llvm_unreachable("Handled above");
+        }
       }
+      return false;
+    };
+
+    auto *M = DC->getParentModule();
+    if (Ext->isConstrainedExtension()) {
+      // Get the substitutions from the generic signature of
+      // the extension to the interface types of the base type's
+      // declaration.
+      SubstitutionMap subMap;
+      if (!BaseType->isExistentialType())
+        subMap = BaseType->getContextSubstitutionMap(M, Ext);
+
+      assert(Ext->getGenericSignature() && "No generic signature.");
+      auto GenericSig = Ext->getGenericSignature();
+      if (handleRequirements(subMap, GenericSig, GenericSig->getRequirements()))
+        return {Result, MergeInfo};
     }
+
+    if (Conf && handleRequirements(Conf->getSubstitutions(M),
+                                   Conf->getGenericSignature(),
+                                   Conf->getConditionalRequirements()))
+      return {Result, MergeInfo};
+
     Result.Ext = Ext;
     return {Result, MergeInfo};
   }
@@ -368,7 +396,9 @@ struct SynthesizedExtensionAnalyzer::Implementation {
     for (auto *E : Target->getExtensions()) {
       if (!Options.shouldPrint(E))
         continue;
-      auto Pair = isApplicable(E, /*Synthesized*/false);
+      auto Pair = isApplicable(E, /*Synthesized*/ false,
+                               /*EnablingExt*/ nullptr,
+                               /*Conf*/ nullptr);
       if (Pair.first) {
         InfoMap->insert({E, Pair.first});
         MergeInfoMap.insert({E, Pair.second});
@@ -400,9 +430,11 @@ struct SynthesizedExtensionAnalyzer::Implementation {
     ExtensionMergeInfoMap MergeInfoMap;
     std::vector<NominalTypeDecl*> Unhandled;
 
-    auto handleExtension = [&](ExtensionDecl *E, bool Synthesized) {
+    auto handleExtension = [&](ExtensionDecl *E, bool Synthesized,
+                               ExtensionDecl *EnablingE,
+                               NormalProtocolConformance *Conf) {
       if (Options.shouldPrint(E)) {
-        auto Pair = isApplicable(E, Synthesized);
+        auto Pair = isApplicable(E, Synthesized, EnablingE, Conf);
         if (Pair.first) {
           InfoMap->insert({E, Pair.first});
           MergeInfoMap.insert({E, Pair.second});
@@ -421,7 +453,7 @@ struct SynthesizedExtensionAnalyzer::Implementation {
       NominalTypeDecl* Back = Unhandled.back();
       Unhandled.pop_back();
       for (ExtensionDecl *E : Back->getExtensions()) {
-        handleExtension(E, true);
+        handleExtension(E, true, nullptr, nullptr);
       }
       for (auto *Conf : Back->getLocalConformances()) {
         Unhandled.push_back(Conf->getProtocol());
@@ -433,11 +465,11 @@ struct SynthesizedExtensionAnalyzer::Implementation {
     }
 
     // Merge with actual extensions.
-    for (auto *E : Target->getExtensions()) {
-      handleExtension(E, false);
-      for (auto *Conf : E->getLocalConformances()) {
+    for (auto *EnablingE : Target->getExtensions()) {
+      handleExtension(EnablingE, false, nullptr, nullptr);
+      for (auto *Conf : EnablingE->getLocalConformances()) {
         for (auto E : Conf->getProtocol()->getExtensions())
-          handleExtension(E, true);
+          handleExtension(E, true, EnablingE, Conf->getRootNormalConformance());
       }
     }
 
@@ -482,9 +514,10 @@ forEachExtensionMergeGroup(MergeGroupKind Kind, ExtensionGroupOperation Fn) {
       if (Kind != Group.Kind)
         continue;
     }
-    std::vector<ExtensionAndIsSynthesized> GroupContent;
+    std::vector<ExtensionInfo> GroupContent;
     for (auto &Member : Group.Members) {
-      GroupContent.push_back({Member->Ext, Member->IsSynthesized});
+      GroupContent.push_back(
+          {Member->Ext, Member->EnablingExt, Member->IsSynthesized});
     }
     Fn(llvm::makeArrayRef(GroupContent));
   }

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -39,7 +39,7 @@ func takes_P5<X: P5>(_: X) {}
 struct Free<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Free<T>
 // CHECK-NEXT: (normal_conformance type=Free<T> protocol=P2
-// CHECK-NEXT:   conforms_to: τ_0_0 P1)
+// CHECK-NEXT:   conforms_to: T P1)
 extension Free: P2 where T: P1 {}
 func free_good<U: P1>(_: U) {
     takes_P2(Free<U>())
@@ -54,7 +54,7 @@ func free_bad<U>(_: U) {
 struct Constrained<T: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Constrained<T>
 // CHECK-NEXT: (normal_conformance type=Constrained<T> protocol=P2
-// CHECK-NEXT:   conforms_to: τ_0_0 P3)
+// CHECK-NEXT:   conforms_to: T P3)
 extension Constrained: P2 where T: P3 {}
 func constrained_good<U: P1 & P3>(_: U) {
     takes_P2(Constrained<U>())
@@ -79,7 +79,7 @@ extension RedundantSuper: P2 where T: P1 {}
 struct OverlappingSub<T: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=OverlappingSub<T>
 // CHECK-NEXT: (normal_conformance type=OverlappingSub<T> protocol=P2
-// CHECK-NEXT:   conforms_to: τ_0_0 P4)
+// CHECK-NEXT:   conforms_to: T P4)
 extension OverlappingSub: P2 where T: P4 {}
 func overlapping_sub_good<U: P4>(_: U) {
     takes_P2(OverlappingSub<U>())
@@ -95,7 +95,7 @@ func overlapping_sub_bad<U: P1>(_: U) {
 struct SameType<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=SameType<Int>
 // CHECK-NEXT: (normal_conformance type=SameType<T> protocol=P2
-// CHECK-NEXT:   same_type: τ_0_0 Int)
+// CHECK-NEXT:   same_type: T Int)
 extension SameType: P2 where T == Int {}
 func same_type_good() {
     takes_P2(SameType<Int>())
@@ -109,7 +109,7 @@ func same_type_bad<U>(_: U) {
 struct SameTypeGeneric<T, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=SameTypeGeneric<T, T>
 // CHECK-NEXT: (normal_conformance type=SameTypeGeneric<T, U> protocol=P2
-// CHECK-NEXT:   same_type: τ_0_0 τ_0_1)
+// CHECK-NEXT:   same_type: T U)
 extension SameTypeGeneric: P2 where T == U {}
 func same_type_generic_good<U, V>(_: U, _: V)
   where U: Assoc, V: Assoc, U.AT == V.AT
@@ -131,8 +131,8 @@ func same_type_bad<U, V>(_: U, _: V) {
 struct Infer<T, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Infer<Constrained<U>, U>
 // CHECK-NEXT: (normal_conformance type=Infer<T, U> protocol=P2
-// CHECK-NEXT:   same_type: τ_0_0 Constrained<τ_0_1>
-// CHECK-NEXT:   conforms_to:  τ_0_1 P1)
+// CHECK-NEXT:   same_type: T Constrained<U>
+// CHECK-NEXT:   conforms_to:  U P1)
 extension Infer: P2 where T == Constrained<U> {}
 func infer_good<U: P1>(_: U) {
     takes_P2(Infer<Constrained<U>, U>())
@@ -147,7 +147,7 @@ func infer_bad<U: P1, V>(_: U, _: V) {
 struct InferRedundant<T, U: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InferRedundant<Constrained<U>, U>
 // CHECK-NEXT: (normal_conformance type=InferRedundant<T, U> protocol=P2
-// CHECK-NEXT:   same_type: τ_0_0 Constrained<τ_0_1>)
+// CHECK-NEXT:   same_type: T Constrained<U>)
 extension InferRedundant: P2 where T == Constrained<U> {}
 func infer_redundant_good<U: P1>(_: U) {
     takes_P2(InferRedundant<Constrained<U>, U>())
@@ -167,7 +167,7 @@ class C3: C2 {}
 struct ClassFree<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassFree<T>
 // CHECK-NEXT: (normal_conformance type=ClassFree<T> protocol=P2
-// CHECK-NEXT:   superclass: τ_0_0 C1)
+// CHECK-NEXT:   superclass: T C1)
 extension ClassFree: P2 where T: C1 {}
 func class_free_good<U: C1>(_: U) {
     takes_P2(ClassFree<U>())
@@ -180,7 +180,7 @@ func class_free_bad<U>(_: U) {
 struct ClassMoreSpecific<T: C1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=ClassMoreSpecific<T>
 // CHECK-NEXT: (normal_conformance type=ClassMoreSpecific<T> protocol=P2
-// CHECK-NEXT:   superclass: τ_0_0 C3)
+// CHECK-NEXT:   superclass: T C3)
 extension ClassMoreSpecific: P2 where T: C3 {}
 func class_more_specific_good<U: C3>(_: U) {
     takes_P2(ClassMoreSpecific<U>())
@@ -216,11 +216,11 @@ func subclass_bad() {
 struct InheritEqual<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual<T>
 // CHECK-NEXT:  (normal_conformance type=InheritEqual<T> protocol=P2
-// CHECK-NEXT:    conforms_to: τ_0_0 P1)
+// CHECK-NEXT:    conforms_to: T P1)
 extension InheritEqual: P2 where T: P1 {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual<T>
 // CHECK-NEXT:  (normal_conformance type=InheritEqual<T> protocol=P5
-// CHECK-NEXT:    conforms_to: τ_0_0 P1)
+// CHECK-NEXT:    conforms_to: T P1)
 extension InheritEqual: P5 where T: P1 {}
 func inheritequal_good<U: P1>(_: U) {
   takes_P2(InheritEqual<U>())
@@ -248,11 +248,11 @@ extension InheritLess: P5 {} // expected-error{{type 'T' does not conform to pro
 struct InheritMore<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore<T>
 // CHECK-NEXT:  (normal_conformance type=InheritMore<T> protocol=P2
-// CHECK-NEXT:    conforms_to: τ_0_0 P1)
+// CHECK-NEXT:    conforms_to: T P1)
 extension InheritMore: P2 where T: P1 {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore<T>
 // CHECK-NEXT:  (normal_conformance type=InheritMore<T> protocol=P5
-// CHECK-NEXT:    conforms_to: τ_0_0 P4)
+// CHECK-NEXT:    conforms_to: T P4)
 extension InheritMore: P5 where T: P4 {}
 func inheritequal_good_good<U: P4>(_: U) {
   takes_P2(InheritMore<U>())
@@ -315,13 +315,13 @@ extension TwoDisjointConformances: P2 where T == String {}
 struct RedundancyOrderDependenceGood<T: P1, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceGood<T, T>
 // CHECK-NEXT: (normal_conformance type=RedundancyOrderDependenceGood<T, U> protocol=P2
-// CHECK-NEXT:   same_type: τ_0_0 τ_0_1)
+// CHECK-NEXT:   same_type: T U)
 extension RedundancyOrderDependenceGood: P2 where U: P1, T == U {}
 struct RedundancyOrderDependenceBad<T, U: P1> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=RedundancyOrderDependenceBad<T, T>
 // CHECK-NEXT: (normal_conformance type=RedundancyOrderDependenceBad<T, U> protocol=P2
-// CHECK-NEXT:   conforms_to: τ_0_0 P1
-// CHECK-NEXT:   same_type: τ_0_0 τ_0_1)
+// CHECK-NEXT:   conforms_to: T P1
+// CHECK-NEXT:   same_type: T U)
 extension RedundancyOrderDependenceBad: P2 where T: P1, T == U {}
 
 // Checking of conditional requirements for existential conversions.

--- a/test/SourceKit/DocSupport/Inputs/cake.swift
+++ b/test/SourceKit/DocSupport/Inputs/cake.swift
@@ -83,3 +83,17 @@ extension C1 : P4 {
     public func C1S1foo(a : P4) {}
   }
 }
+
+// rdar://problem/36553066
+
+public protocol P5 {
+    associatedtype Element
+}
+public protocol P6: P5 {}
+extension P6 {
+    public var null: Element? { return nil }
+}
+public struct S3<Wrapped: P5>: P5 {
+    public typealias Element = Wrapped.Element
+}
+extension S3: P6 where Wrapped: P6 {}

--- a/test/SourceKit/DocSupport/doc_swift_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_swift_module.swift.response
@@ -85,6 +85,19 @@ protocol P3 {
 protocol P4 {
 }
 
+protocol P5 {
+
+    associatedtype Element
+}
+
+protocol P6 : P5 {
+}
+
+extension P6 {
+
+    var null: Self.Element? { get }
+}
+
 protocol Prot {
 
     associatedtype Element
@@ -135,6 +148,16 @@ extension SE {
 struct S2 : P3 {
 
     typealias T = cake.S2
+}
+
+struct S3<Wrapped> : P5 where Wrapped : P5 {
+
+    typealias Element = Wrapped.Element
+}
+
+extension S3 {
+
+    var null: Wrapped.Element? { get }
 }
 
 func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Element == cake.C1.Element
@@ -834,76 +857,78 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 1005,
-    key.length: 4
+    key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1017,
+    key.offset: 1015,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1032,
+    key.offset: 1030,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1045,
-    key.length: 3
+    key.offset: 1041,
+    key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1049,
-    key.length: 1
+    key.offset: 1050,
+    key.length: 2
   },
   {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Int",
-    key.usr: "s:Si",
-    key.offset: 1052,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1058,
-    key.length: 3
+    key.kind: source.lang.swift.ref.protocol,
+    key.name: "P5",
+    key.usr: "s:4cake2P5P",
+    key.offset: 1055,
+    key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1069,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1074,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1085,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1090,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1100,
+    key.offset: 1063,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
-    key.name: "Prot",
-    key.usr: "s:4cake4ProtP",
-    key.offset: 1110,
-    key.length: 4
+    key.name: "P6",
+    key.usr: "s:4cake2P6P",
+    key.offset: 1073,
+    key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1122,
+    key.offset: 1083,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1087,
     key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.ref.generic_type_param,
+    key.name: "Self",
+    key.usr: "s:4cake2P6P4Selfxmfp",
+    key.offset: 1093,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1098,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1109,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1118,
+    key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
@@ -913,397 +938,567 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 1139,
-    key.length: 9
+    key.length: 14
   },
   {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1149,
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1154,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1167,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1171,
     key.length: 1
   },
   {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1151,
-    key.length: 5
-  },
-  {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 1158,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "Int",
-    key.usr: "s:Si",
-    key.offset: 1166,
+    key.offset: 1174,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1172,
+    key.offset: 1180,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1181,
+    key.offset: 1191,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1196,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1207,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1212,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1222,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot",
     key.usr: "s:4cake4ProtP",
-    key.offset: 1191,
+    key.offset: 1232,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1196,
+    key.offset: 1244,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1249,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1261,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 1271,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 1273,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int",
+    key.usr: "s:Si",
+    key.offset: 1280,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "Int",
+    key.usr: "s:Si",
+    key.offset: 1288,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1294,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1303,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.ref.protocol,
+    key.name: "Prot",
+    key.usr: "s:4cake4ProtP",
+    key.offset: 1313,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1318,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Self",
     key.usr: "s:4cake4ProtPAASi7ElementRtzrlE4Selfxmfp",
-    key.offset: 1202,
+    key.offset: 1324,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1207,
+    key.offset: 1329,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 1218,
+    key.offset: 1340,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1229,
+    key.offset: 1351,
     key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1234,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1246,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1253,
-    key.length: 2
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1263,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1268,
-    key.length: 2
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1282,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1287,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1298,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1303,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1314,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1319,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1332,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1337,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1349,
-    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 1356,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1368,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1375,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1370,
+    key.offset: 1385,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1390,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1404,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1409,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1420,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1425,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1436,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1441,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1454,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1459,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1471,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1478,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1492,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1374,
+    key.offset: 1496,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 1377,
+    key.offset: 1499,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1390,
+    key.offset: 1512,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "SE",
     key.usr: "s:4cake2S1V2SEO",
-    key.offset: 1400,
+    key.offset: 1522,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1410,
+    key.offset: 1532,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1417,
+    key.offset: 1539,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1426,
+    key.offset: 1548,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1428,
+    key.offset: 1550,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "S1",
     key.usr: "s:4cake2S1V",
-    key.offset: 1433,
+    key.offset: 1555,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "SE",
     key.usr: "s:4cake2S1V2SEO",
-    key.offset: 1436,
+    key.offset: 1558,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1440,
+    key.offset: 1562,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1442,
+    key.offset: 1564,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "S1",
     key.usr: "s:4cake2S1V",
-    key.offset: 1447,
+    key.offset: 1569,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "SE",
     key.usr: "s:4cake2S1V2SEO",
-    key.offset: 1450,
+    key.offset: 1572,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 1457,
+    key.offset: 1579,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1465,
+    key.offset: 1587,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1472,
+    key.offset: 1594,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P3",
     key.usr: "s:4cake2P3P",
-    key.offset: 1477,
+    key.offset: 1599,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1487,
+    key.offset: 1609,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1497,
+    key.offset: 1619,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1501,
+    key.offset: 1623,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "S2",
     key.usr: "s:4cake2S2V",
-    key.offset: 1506,
+    key.offset: 1628,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1512,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1517,
+    key.offset: 1634,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1524,
+    key.offset: 1641,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1528,
-    key.length: 2
+    key.offset: 1644,
+    key.length: 7
   },
   {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1532,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1534,
-    key.length: 2
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1538,
-    key.length: 2
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1542,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1544,
-    key.length: 2
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1548,
+    key.kind: source.lang.swift.ref.protocol,
+    key.name: "P5",
+    key.usr: "s:4cake2P5P",
+    key.offset: 1655,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1552,
+    key.offset: 1658,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1558,
+    key.offset: 1664,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.ref.protocol,
+    key.name: "P5",
+    key.usr: "s:4cake2P5P",
+    key.offset: 1674,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1684,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1694,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1704,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1712,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1723,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "S3",
+    key.usr: "s:4cake2S3V",
+    key.offset: 1733,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1743,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1747,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1753,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1761,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1772,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1781,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1786,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1793,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1797,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 1801,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 1803,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1807,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 1811,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 1813,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1817,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1821,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1827,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot",
     key.usr: "s:4cake4ProtP",
-    key.offset: 1563,
+    key.offset: 1832,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1569,
+    key.offset: 1838,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1574,
+    key.offset: 1843,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "C1",
     key.usr: "s:4cake2C1C",
-    key.offset: 1579,
+    key.offset: 1848,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1583,
+    key.offset: 1852,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1586,
+    key.offset: 1855,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1597,
+    key.offset: 1866,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "C1",
     key.usr: "s:4cake2C1C",
-    key.offset: 1602,
+    key.offset: 1871,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.typealias,
     key.name: "Element",
     key.usr: "s:4cake2C1C7Elementa",
-    key.offset: 1605,
+    key.offset: 1874,
     key.length: 7
   }
 ]
@@ -1381,7 +1576,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
       {
         key.kind: source.lang.swift.decl.function.subscript,
         key.name: "subscript(_:)",
-        key.usr: "s:4cake2C1CyS2icip",
+        key.usr: "s:4cake2C1CS2icip",
         key.offset: 110,
         key.length: 38,
         key.fully_annotated_decl: "<decl.function.subscript><syntaxtype.keyword>subscript</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.name>index</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int</ref.struct></decl.function.returntype> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.function.subscript>",
@@ -1398,7 +1593,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
       {
         key.kind: source.lang.swift.decl.function.subscript,
         key.name: "subscript(index:)",
-        key.usr: "s:4cake2C1C5indexSiSf_tcip",
+        key.usr: "s:4cake2C1CSiSf5index_tcip",
         key.offset: 154,
         key.length: 40,
         key.fully_annotated_decl: "<decl.function.subscript><syntaxtype.keyword>subscript</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.argument_label>index</decl.var.parameter.argument_label> <decl.var.parameter.name>i</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Sf\">Float</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int</ref.struct></decl.function.returntype> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.function.subscript>",
@@ -1430,7 +1625,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.name: "case1",
-            key.usr: "s:4cake2C1C0B5CasesO5case1yA2EmF",
+            key.usr: "s:4cake2C1C0B5CasesO5case1A2EmF",
             key.offset: 230,
             key.length: 10,
             key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>case1</decl.name></decl.enumelement>"
@@ -1458,8 +1653,8 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
       {
         key.kind: source.lang.swift.decl.function.subscript,
         key.name: "subscript(_:)",
-        key.usr: "s:4cake4ProtPAAEyS2icip::SYNTHESIZED::s:4cake2C1C",
-        key.original_usr: "s:4cake4ProtPAAEyS2icip",
+        key.usr: "s:4cake4ProtPAAES2icip::SYNTHESIZED::s:4cake2C1C",
+        key.original_usr: "s:4cake4ProtPAAES2icip",
         key.offset: 288,
         key.length: 38,
         key.fully_annotated_decl: "<decl.function.subscript><syntaxtype.keyword>subscript</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.name>index</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int</ref.struct></decl.function.returntype> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.function.subscript>",
@@ -1511,7 +1706,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
           {
             key.kind: source.lang.swift.decl.function.method.instance,
             key.name: "C1S1foo(a:)",
-            key.usr: "s:4cake2C1C0B2S1V0B5S1foo1ayAA2P4_p_tF",
+            key.usr: "s:4cake2C1C0B2S1V0B5S1fooyAA2P4_p1a_tF",
             key.offset: 396,
             key.length: 21,
             key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>C1S1foo</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>a</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.protocol usr=\"s:4cake2P4P\">P4</ref.protocol></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
@@ -1542,9 +1737,8 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
       {
         key.kind: source.lang.swift.decl.function.operator.infix,
         key.name: "!=(_:_:)",
-        key.usr: "s:s9EquatablePsE2neoiySbx_xtFZ::SYNTHESIZED::s:4cake2C1C0B5CasesO",
-        key.original_usr: "s:s9EquatablePsE2neoiySbx_xtFZ",
-        key.doc.full_as_xml: "<Function><Name>!=(_:_:)</Name><USR>s:s9EquatablePsE2neoiySbx_xtFZ</USR><Declaration>static func != (lhs: Self, rhs: Self) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are not equal.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A value to compare.</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Another value to compare.</Para></Discussion></Parameter></Parameters><Discussion><Para>Inequality is the inverse of equality. For any values <codeVoice>a</codeVoice> and <codeVoice>b</codeVoice>, <codeVoice>a != b</codeVoice> implies that <codeVoice>a == b</codeVoice> is <codeVoice>false</codeVoice>.</Para><Para>This is the default implementation of the not-equal-to operator (<codeVoice>!=</codeVoice>) for any type that conforms to <codeVoice>Equatable</codeVoice>.</Para></Discussion></CommentParts></Function>",
+        key.usr: "s:s9EquatablePsE2neoiSbx_xtFZ::SYNTHESIZED::s:4cake2C1C0B5CasesO",
+        key.original_usr: "s:s9EquatablePsE2neoiSbx_xtFZ",
         key.offset: 452,
         key.length: 61,
         key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@_inlineable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr=\"s:4cake2C1C\">C1</ref.class>.<ref.enum usr=\"s:4cake2C1C0B5CasesO\">C1Cases</ref.enum></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr=\"s:4cake2C1C\">C1</ref.class>.<ref.enum usr=\"s:4cake2C1C0B5CasesO\">C1Cases</ref.enum></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
@@ -1609,7 +1803,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.name: "case1",
-            key.usr: "s:4cake2C1C0B5CasesO5case1yA2EmF",
+            key.usr: "s:4cake2C1C0B5CasesO5case1A2EmF",
             key.offset: 591,
             key.length: 10,
             key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>case1</decl.name></decl.enumelement>"
@@ -1637,8 +1831,8 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
       {
         key.kind: source.lang.swift.decl.function.subscript,
         key.name: "subscript(_:)",
-        key.usr: "s:4cake4ProtPAAEyS2icip::SYNTHESIZED::s:4cake2C2C",
-        key.original_usr: "s:4cake4ProtPAAEyS2icip",
+        key.usr: "s:4cake4ProtPAAES2icip::SYNTHESIZED::s:4cake2C2C",
+        key.original_usr: "s:4cake4ProtPAAES2icip",
         key.offset: 649,
         key.length: 38,
         key.fully_annotated_decl: "<decl.function.subscript><syntaxtype.keyword>subscript</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.name>index</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int</ref.struct></decl.function.returntype> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.function.subscript>",
@@ -1692,7 +1886,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
           {
             key.kind: source.lang.swift.decl.function.method.instance,
             key.name: "C1S1foo(a:)",
-            key.usr: "s:4cake2C1C0B2S1V0B5S1foo1ayAA2P4_p_tF",
+            key.usr: "s:4cake2C1C0B2S1V0B5S1fooyAA2P4_p1a_tF",
             key.offset: 757,
             key.length: 21,
             key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>C1S1foo</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>a</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.protocol usr=\"s:4cake2P4P\">P4</ref.protocol></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
@@ -1728,7 +1922,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
       {
         key.kind: source.lang.swift.decl.enumelement,
         key.name: "Blah",
-        key.usr: "s:4cake6MyEnumO4BlahyA2CmF",
+        key.usr: "s:4cake6MyEnumO4BlahA2CmF",
         key.offset: 813,
         key.length: 9,
         key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>Blah</decl.name></decl.enumelement>"
@@ -1736,9 +1930,8 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
       {
         key.kind: source.lang.swift.decl.function.operator.infix,
         key.name: "!=(_:_:)",
-        key.usr: "s:s9EquatablePsE2neoiySbx_xtFZ::SYNTHESIZED::s:4cake6MyEnumO",
-        key.original_usr: "s:s9EquatablePsE2neoiySbx_xtFZ",
-        key.doc.full_as_xml: "<Function><Name>!=(_:_:)</Name><USR>s:s9EquatablePsE2neoiySbx_xtFZ</USR><Declaration>static func != (lhs: Self, rhs: Self) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are not equal.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A value to compare.</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Another value to compare.</Para></Discussion></Parameter></Parameters><Discussion><Para>Inequality is the inverse of equality. For any values <codeVoice>a</codeVoice> and <codeVoice>b</codeVoice>, <codeVoice>a != b</codeVoice> implies that <codeVoice>a == b</codeVoice> is <codeVoice>false</codeVoice>.</Para><Para>This is the default implementation of the not-equal-to operator (<codeVoice>!=</codeVoice>) for any type that conforms to <codeVoice>Equatable</codeVoice>.</Para></Discussion></CommentParts></Function>",
+        key.usr: "s:s9EquatablePsE2neoiSbx_xtFZ::SYNTHESIZED::s:4cake6MyEnumO",
+        key.original_usr: "s:s9EquatablePsE2neoiSbx_xtFZ",
         key.offset: 828,
         key.length: 53,
         key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@_inlineable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:4cake6MyEnumO\">MyEnum</ref.enum></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:4cake6MyEnumO\">MyEnum</ref.enum></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
@@ -1808,9 +2001,62 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
   },
   {
     key.kind: source.lang.swift.decl.protocol,
+    key.name: "P5",
+    key.usr: "s:4cake2P5P",
+    key.offset: 996,
+    key.length: 43,
+    key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P5</decl.name></decl.protocol>",
+    key.entities: [
+      {
+        key.kind: source.lang.swift.decl.associatedtype,
+        key.name: "Element",
+        key.usr: "s:4cake2P5P7Element",
+        key.offset: 1015,
+        key.length: 22,
+        key.fully_annotated_decl: "<decl.associatedtype><syntaxtype.keyword>associatedtype</syntaxtype.keyword> <decl.name>Element</decl.name></decl.associatedtype>"
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.protocol,
+    key.name: "P6",
+    key.usr: "s:4cake2P6P",
+    key.offset: 1041,
+    key.length: 20,
+    key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P6</decl.name> : <ref.protocol usr=\"s:4cake2P5P\">P5</ref.protocol></decl.protocol>",
+    key.conforms: [
+      {
+        key.kind: source.lang.swift.ref.protocol,
+        key.name: "P5",
+        key.usr: "s:4cake2P5P"
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension.protocol,
+    key.offset: 1063,
+    key.length: 53,
+    key.extends: {
+      key.kind: source.lang.swift.ref.protocol,
+      key.name: "P6",
+      key.usr: "s:4cake2P6P"
+    },
+    key.entities: [
+      {
+        key.kind: source.lang.swift.decl.var.instance,
+        key.name: "null",
+        key.usr: "s:4cake2P6PAAE4null7ElementQzSgvp",
+        key.offset: 1083,
+        key.length: 31,
+        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>null</decl.name>: <decl.var.type><ref.generic_type_param usr=\"s:4cake2P6P4Selfxmfp\">Self</ref.generic_type_param>.Element?</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.protocol,
     key.name: "Prot",
     key.usr: "s:4cake4ProtP",
-    key.offset: 996,
+    key.offset: 1118,
     key.length: 102,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>Prot</decl.name></decl.protocol>",
     key.entities: [
@@ -1818,7 +2064,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.associatedtype,
         key.name: "Element",
         key.usr: "s:4cake4ProtP7Element",
-        key.offset: 1017,
+        key.offset: 1139,
         key.length: 22,
         key.fully_annotated_decl: "<decl.associatedtype><syntaxtype.keyword>associatedtype</syntaxtype.keyword> <decl.name>Element</decl.name></decl.associatedtype>"
       },
@@ -1826,7 +2072,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "p",
         key.usr: "s:4cake4ProtP1pSivp",
-        key.offset: 1045,
+        key.offset: 1167,
         key.length: 18,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>p</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -1834,7 +2080,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo()",
         key.usr: "s:4cake4ProtP3fooyyF",
-        key.offset: 1069,
+        key.offset: 1191,
         key.length: 10,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>()</decl.function.method.instance>"
       },
@@ -1842,7 +2088,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo1()",
         key.usr: "s:4cake4ProtP4foo1yyF",
-        key.offset: 1085,
+        key.offset: 1207,
         key.length: 11,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo1</decl.name>()</decl.function.method.instance>"
       }
@@ -1850,7 +2096,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
   },
   {
     key.kind: source.lang.swift.decl.extension.protocol,
-    key.offset: 1100,
+    key.offset: 1222,
     key.length: 79,
     key.extends: {
       key.kind: source.lang.swift.ref.protocol,
@@ -1863,15 +2109,15 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.name: "foo1()",
         key.usr: "s:4cake4ProtPAAE4foo1yyF",
         key.default_implementation_of: "s:4cake4ProtP4foo1yyF",
-        key.offset: 1122,
+        key.offset: 1244,
         key.length: 11,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo1</decl.name>()</decl.function.method.instance>"
       },
       {
         key.kind: source.lang.swift.decl.function.subscript,
         key.name: "subscript(_:)",
-        key.usr: "s:4cake4ProtPAAEyS2icip",
-        key.offset: 1139,
+        key.usr: "s:4cake4ProtPAAES2icip",
+        key.offset: 1261,
         key.length: 38,
         key.fully_annotated_decl: "<decl.function.subscript><syntaxtype.keyword>subscript</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.name>index</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int</ref.struct></decl.function.returntype> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.function.subscript>",
         key.entities: [
@@ -1879,7 +2125,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "index",
-            key.offset: 1158,
+            key.offset: 1280,
             key.length: 3
           }
         ]
@@ -1893,7 +2139,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.description: "Self.Element == Int"
       }
     ],
-    key.offset: 1181,
+    key.offset: 1303,
     key.length: 63,
     key.extends: {
       key.kind: source.lang.swift.ref.protocol,
@@ -1905,7 +2151,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "extfoo()",
         key.usr: "s:4cake4ProtPAASi7ElementRtzrlE6extfooyyF",
-        key.offset: 1229,
+        key.offset: 1351,
         key.length: 13,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>extfoo</decl.name>()</decl.function.method.instance>"
       }
@@ -1915,7 +2161,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
     key.kind: source.lang.swift.decl.struct,
     key.name: "S1",
     key.usr: "s:4cake2S1V",
-    key.offset: 1246,
+    key.offset: 1368,
     key.length: 142,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S1</decl.name></decl.struct>",
     key.entities: [
@@ -1923,31 +2169,31 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.enum,
         key.name: "SE",
         key.usr: "s:4cake2S1V2SEO",
-        key.offset: 1263,
+        key.offset: 1385,
         key.length: 63,
         key.fully_annotated_decl: "<decl.enum><syntaxtype.keyword>enum</syntaxtype.keyword> <ref.struct usr=\"s:4cake2S1V\">S1</ref.struct>.<decl.name>SE</decl.name></decl.enum>",
         key.entities: [
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.name: "a",
-            key.usr: "s:4cake2S1V2SEO1ayA2EmF",
-            key.offset: 1282,
+            key.usr: "s:4cake2S1V2SEO1aA2EmF",
+            key.offset: 1404,
             key.length: 6,
             key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>a</decl.name></decl.enumelement>"
           },
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.name: "b",
-            key.usr: "s:4cake2S1V2SEO1byA2EmF",
-            key.offset: 1298,
+            key.usr: "s:4cake2S1V2SEO1bA2EmF",
+            key.offset: 1420,
             key.length: 6,
             key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>b</decl.name></decl.enumelement>"
           },
           {
             key.kind: source.lang.swift.decl.enumelement,
             key.name: "c",
-            key.usr: "s:4cake2S1V2SEO1cyA2EmF",
-            key.offset: 1314,
+            key.usr: "s:4cake2S1V2SEO1cA2EmF",
+            key.offset: 1436,
             key.length: 6,
             key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>c</decl.name></decl.enumelement>"
           }
@@ -1957,7 +2203,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo1()",
         key.usr: "s:4cake2S1V4foo1yyF",
-        key.offset: 1332,
+        key.offset: 1454,
         key.length: 11,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo1</decl.name>()</decl.function.method.instance>"
       },
@@ -1965,7 +2211,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.struct,
         key.name: "S2",
         key.usr: "s:4cake2S1V2S2V",
-        key.offset: 1349,
+        key.offset: 1471,
         key.length: 37,
         key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S2</decl.name></decl.struct>",
         key.entities: [
@@ -1973,7 +2219,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
             key.kind: source.lang.swift.decl.var.instance,
             key.name: "b",
             key.usr: "s:4cake2S1V2S2V1bSivp",
-            key.offset: 1370,
+            key.offset: 1492,
             key.length: 10,
             key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>let</syntaxtype.keyword> <decl.name>b</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type></decl.var.instance>"
           }
@@ -1983,7 +2229,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
   },
   {
     key.kind: source.lang.swift.decl.extension.enum,
-    key.offset: 1390,
+    key.offset: 1512,
     key.length: 73,
     key.extends: {
       key.kind: source.lang.swift.ref.enum,
@@ -1994,10 +2240,9 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
       {
         key.kind: source.lang.swift.decl.function.operator.infix,
         key.name: "!=(_:_:)",
-        key.usr: "s:s9EquatablePsE2neoiySbx_xtFZ::SYNTHESIZED::s:4cake2S1V2SEO",
-        key.original_usr: "s:s9EquatablePsE2neoiySbx_xtFZ",
-        key.doc.full_as_xml: "<Function><Name>!=(_:_:)</Name><USR>s:s9EquatablePsE2neoiySbx_xtFZ</USR><Declaration>static func != (lhs: Self, rhs: Self) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are not equal.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A value to compare.</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Another value to compare.</Para></Discussion></Parameter></Parameters><Discussion><Para>Inequality is the inverse of equality. For any values <codeVoice>a</codeVoice> and <codeVoice>b</codeVoice>, <codeVoice>a != b</codeVoice> implies that <codeVoice>a == b</codeVoice> is <codeVoice>false</codeVoice>.</Para><Para>This is the default implementation of the not-equal-to operator (<codeVoice>!=</codeVoice>) for any type that conforms to <codeVoice>Equatable</codeVoice>.</Para></Discussion></CommentParts></Function>",
-        key.offset: 1410,
+        key.usr: "s:s9EquatablePsE2neoiSbx_xtFZ::SYNTHESIZED::s:4cake2S1V2SEO",
+        key.original_usr: "s:s9EquatablePsE2neoiSbx_xtFZ",
+        key.offset: 1532,
         key.length: 51,
         key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@_inlineable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:4cake2S1V\">S1</ref.struct>.<ref.enum usr=\"s:4cake2S1V2SEO\">SE</ref.enum></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:4cake2S1V\">S1</ref.struct>.<ref.enum usr=\"s:4cake2S1V2SEO\">SE</ref.enum></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
         key.entities: [
@@ -2005,14 +2250,14 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "lhs",
-            key.offset: 1433,
+            key.offset: 1555,
             key.length: 5
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rhs",
-            key.offset: 1447,
+            key.offset: 1569,
             key.length: 5
           }
         ]
@@ -2023,7 +2268,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
     key.kind: source.lang.swift.decl.struct,
     key.name: "S2",
     key.usr: "s:4cake2S2V",
-    key.offset: 1465,
+    key.offset: 1587,
     key.length: 45,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S2</decl.name> : <ref.protocol usr=\"s:4cake2P3P\">P3</ref.protocol></decl.struct>",
     key.conforms: [
@@ -2038,7 +2283,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.typealias,
         key.name: "T",
         key.usr: "s:4cake2S2V1Ta",
-        key.offset: 1487,
+        key.offset: 1609,
         key.length: 21,
         key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <ref.struct usr=\"s:4cake2S2V\">S2</ref.struct>.<decl.name>T</decl.name> = <ref.struct usr=\"s:4cake2S2V\">S2</ref.struct></decl.typealias>",
         key.conforms: [
@@ -2052,9 +2297,72 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
     ]
   },
   {
+    key.kind: source.lang.swift.decl.struct,
+    key.name: "S3",
+    key.usr: "s:4cake2S3V",
+    key.generic_params: [
+      {
+        key.name: "Wrapped"
+      }
+    ],
+    key.generic_requirements: [
+      {
+        key.description: "Wrapped : P5"
+      }
+    ],
+    key.offset: 1634,
+    key.length: 87,
+    key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S3</decl.name>&lt;<decl.generic_type_param usr=\"s:4cake2S3V7Wrappedxmfp\"><decl.generic_type_param.name>Wrapped</decl.generic_type_param.name></decl.generic_type_param>&gt; : <ref.protocol usr=\"s:4cake2P5P\">P5</ref.protocol> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement>Wrapped : <ref.protocol usr=\"s:4cake2P5P\">P5</ref.protocol></decl.generic_type_requirement></decl.struct>",
+    key.conforms: [
+      {
+        key.kind: source.lang.swift.ref.protocol,
+        key.name: "P5",
+        key.usr: "s:4cake2P5P"
+      }
+    ],
+    key.entities: [
+      {
+        key.kind: source.lang.swift.decl.typealias,
+        key.name: "Element",
+        key.usr: "s:4cake2S3V7Elementa",
+        key.offset: 1684,
+        key.length: 35,
+        key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <ref.struct usr=\"s:4cake2S3V\">S3</ref.struct>&lt;Wrapped&gt;.<decl.name>Element</decl.name> = Wrapped.Element</decl.typealias>",
+        key.conforms: [
+          {
+            key.kind: source.lang.swift.ref.associatedtype,
+            key.name: "Element",
+            key.usr: "s:4cake2P5P7Element"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension.struct,
+    key.offset: 1723,
+    key.length: 56,
+    key.extends: {
+      key.kind: source.lang.swift.ref.struct,
+      key.name: "S3",
+      key.usr: "s:4cake2S3V"
+    },
+    key.entities: [
+      {
+        key.kind: source.lang.swift.decl.var.instance,
+        key.name: "null",
+        key.usr: "s:4cake2P6PAAE4null7ElementQzSgvp::SYNTHESIZED::s:4cake2S3V",
+        key.original_usr: "s:4cake2P6PAAE4null7ElementQzSgvp",
+        key.offset: 1743,
+        key.length: 34,
+        key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>null</decl.name>: <decl.var.type>Wrapped.Element?</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
+      }
+    ]
+  },
+  {
     key.kind: source.lang.swift.decl.function.free,
     key.name: "genfoo(x:y:)",
-    key.usr: "s:4cake6genfoo1x1yyx_q_tAA4ProtRzAA2C1CRb_Si7ElementRtzr0_lF",
+    key.usr: "s:4cake6genfooyx1x_q_1ytAA4ProtRzAA2C1CRb_Si7ElementRtzr0_lF",
     key.generic_params: [
       {
         key.name: "T1"
@@ -2074,22 +2382,22 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.description: "T1.Element == C1.Element"
       }
     ],
-    key.offset: 1512,
+    key.offset: 1781,
     key.length: 100,
-    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>genfoo</decl.name>&lt;<decl.generic_type_param usr=\"s:4cake6genfoo1x1yyx_q_tAA4ProtRzAA2C1CRb_Si7ElementRtzr0_lF2T1L_xmfp\"><decl.generic_type_param.name>T1</decl.generic_type_param.name></decl.generic_type_param>, <decl.generic_type_param usr=\"s:4cake6genfoo1x1yyx_q_tAA4ProtRzAA2C1CRb_Si7ElementRtzr0_lF2T2L_q_mfp\"><decl.generic_type_param.name>T2</decl.generic_type_param.name></decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label> <decl.var.parameter.name>ix</decl.var.parameter.name>: <decl.var.parameter.type>T1</decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label> <decl.var.parameter.name>iy</decl.var.parameter.name>: <decl.var.parameter.type>T2</decl.var.parameter.type></decl.var.parameter>) <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement>T1 : <ref.protocol usr=\"s:4cake4ProtP\">Prot</ref.protocol></decl.generic_type_requirement>, <decl.generic_type_requirement>T2 : <ref.class usr=\"s:4cake2C1C\">C1</ref.class></decl.generic_type_requirement>, <decl.generic_type_requirement>T1.Element == <ref.class usr=\"s:4cake2C1C\">C1</ref.class>.<ref.typealias usr=\"s:4cake2C1C7Elementa\">Element</ref.typealias></decl.generic_type_requirement></decl.function.free>",
+    key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>genfoo</decl.name>&lt;<decl.generic_type_param usr=\"s:4cake6genfooyx1x_q_1ytAA4ProtRzAA2C1CRb_Si7ElementRtzr0_lF2T1L_xmfp\"><decl.generic_type_param.name>T1</decl.generic_type_param.name></decl.generic_type_param>, <decl.generic_type_param usr=\"s:4cake6genfooyx1x_q_1ytAA4ProtRzAA2C1CRb_Si7ElementRtzr0_lF2T2L_q_mfp\"><decl.generic_type_param.name>T2</decl.generic_type_param.name></decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label> <decl.var.parameter.name>ix</decl.var.parameter.name>: <decl.var.parameter.type>T1</decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label> <decl.var.parameter.name>iy</decl.var.parameter.name>: <decl.var.parameter.type>T2</decl.var.parameter.type></decl.var.parameter>) <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement>T1 : <ref.protocol usr=\"s:4cake4ProtP\">Prot</ref.protocol></decl.generic_type_requirement>, <decl.generic_type_requirement>T2 : <ref.class usr=\"s:4cake2C1C\">C1</ref.class></decl.generic_type_requirement>, <decl.generic_type_requirement>T1.Element == <ref.class usr=\"s:4cake2C1C\">C1</ref.class>.<ref.typealias usr=\"s:4cake2C1C7Elementa\">Element</ref.typealias></decl.generic_type_requirement></decl.function.free>",
     key.entities: [
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "x",
         key.name: "ix",
-        key.offset: 1538,
+        key.offset: 1807,
         key.length: 2
       },
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "y",
         key.name: "iy",
-        key.offset: 1548,
+        key.offset: 1817,
         key.length: 2
       }
     ]

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -62,7 +62,7 @@ struct TextRange {
 
 struct TextEntity {
   const Decl *Dcl = nullptr;
-  const Decl *SynthesizeTarget = nullptr;
+  TypeOrExtensionDecl SynthesizeTarget;
   const Decl *DefaultImplementationOf = nullptr;
   StringRef Argument;
   TextRange Range;
@@ -70,26 +70,26 @@ struct TextEntity {
   std::vector<TextEntity> SubEntities;
   const bool IsSynthesizedExtension;
 
-  TextEntity(const Decl *D, const Decl *SynthesizeTarget,
-             const Decl* DefaultImplementationOf,
-             unsigned StartOffset, bool IsSynthesizedExtension)
-    : Dcl(D), SynthesizeTarget(SynthesizeTarget),
-      DefaultImplementationOf(DefaultImplementationOf), Range{StartOffset, 0},
-      IsSynthesizedExtension(IsSynthesizedExtension) {}
+  TextEntity(const Decl *D, TypeOrExtensionDecl SynthesizeTarget,
+             const Decl *DefaultImplementationOf, unsigned StartOffset,
+             bool IsSynthesizedExtension)
+      : Dcl(D), SynthesizeTarget(SynthesizeTarget),
+        DefaultImplementationOf(DefaultImplementationOf), Range{StartOffset, 0},
+        IsSynthesizedExtension(IsSynthesizedExtension) {}
 
-  TextEntity(const Decl *D, const Decl *SynthesizeTarget,
-             const Decl* DefaultImplementationOf, TextRange TR,
-             unsigned LocOffset, bool IsSynthesizedExtension) : Dcl(D),
-             DefaultImplementationOf(DefaultImplementationOf), Range(TR),
-              LocOffset(LocOffset),
-              IsSynthesizedExtension(IsSynthesizedExtension) {}
+  TextEntity(const Decl *D, TypeOrExtensionDecl SynthesizeTarget,
+             const Decl *DefaultImplementationOf, TextRange TR,
+             unsigned LocOffset, bool IsSynthesizedExtension)
+      : Dcl(D), DefaultImplementationOf(DefaultImplementationOf), Range(TR),
+        LocOffset(LocOffset), IsSynthesizedExtension(IsSynthesizedExtension) {}
 
-  TextEntity(const Decl *D, const Decl *SynthesizeTarget,
-             const Decl* DefaultImplementationOf, StringRef Arg,
-             TextRange TR, unsigned LocOffset, bool IsSynthesizedExtension)
-    : Dcl(D), SynthesizeTarget(SynthesizeTarget),
-      DefaultImplementationOf(DefaultImplementationOf), Argument(Arg), Range(TR),
-      LocOffset(LocOffset), IsSynthesizedExtension(IsSynthesizedExtension) {}
+  TextEntity(const Decl *D, TypeOrExtensionDecl SynthesizeTarget,
+             const Decl *DefaultImplementationOf, StringRef Arg, TextRange TR,
+             unsigned LocOffset, bool IsSynthesizedExtension)
+      : Dcl(D), SynthesizeTarget(SynthesizeTarget),
+        DefaultImplementationOf(DefaultImplementationOf), Argument(Arg),
+        Range(TR), LocOffset(LocOffset),
+        IsSynthesizedExtension(IsSynthesizedExtension) {}
 };
 
 struct TextReference {
@@ -103,8 +103,8 @@ struct TextReference {
 
 class AnnotatingPrinter : public StreamPrinter {
 
-  std::pair<const ExtensionDecl *, const NominalTypeDecl *>
-    SynthesizedExtensionInfo = {nullptr, nullptr};
+  std::pair<const ExtensionDecl *, TypeOrExtensionDecl>
+      SynthesizedExtensionInfo = {nullptr, {}};
 
   typedef llvm::SmallDenseMap<ValueDecl*, ValueDecl*> DefaultImplementMap;
   llvm::SmallDenseMap<ProtocolDecl*, DefaultImplementMap> AllDefaultMaps;
@@ -175,22 +175,22 @@ public:
   }
 
   void printSynthesizedExtensionPre(const ExtensionDecl *ED,
-                                    const NominalTypeDecl *NTD,
+                                    TypeOrExtensionDecl Target,
                                     Optional<BracketOptions> Bracket) override {
     assert(!SynthesizedExtensionInfo.first);
-    SynthesizedExtensionInfo = {ED, NTD};
+    SynthesizedExtensionInfo = {ED, Target};
     if (!shouldContinuePre(ED, Bracket))
       return;
     unsigned StartOffset = OS.tell();
-    EntitiesStack.emplace_back(ED, SynthesizedExtensionInfo.second, nullptr,
-                               StartOffset, true);
+    EntitiesStack.emplace_back(ED, Target, nullptr, StartOffset, true);
   }
 
-  void printSynthesizedExtensionPost(const ExtensionDecl *ED,
-                                     const NominalTypeDecl *NTD,
-                                     Optional<BracketOptions> Bracket) override {
+  void
+  printSynthesizedExtensionPost(const ExtensionDecl *ED,
+                                TypeOrExtensionDecl Target,
+                                Optional<BracketOptions> Bracket) override {
     assert(SynthesizedExtensionInfo.first);
-    SynthesizedExtensionInfo = {nullptr, nullptr};
+    SynthesizedExtensionInfo = {nullptr, {}};
     if (!shouldContinuePost(ED, Bracket))
       return;
     TextEntity Entity = std::move(EntitiesStack.back());
@@ -207,8 +207,8 @@ public:
       return;
     unsigned StartOffset = OS.tell();
     initDefaultMapToUse(D);
-    const NominalTypeDecl *SynthesizedTarget = nullptr;
     // If D is declared in the extension, then the synthesized target is valid.
+    TypeOrExtensionDecl SynthesizedTarget;
     if (D->getDeclContext() == SynthesizedExtensionInfo.first)
       SynthesizedTarget = SynthesizedExtensionInfo.second;
     EntitiesStack.emplace_back(D, SynthesizedTarget,
@@ -297,10 +297,10 @@ static void initDocGenericParams(const Decl *D, DocEntityInfo &Info) {
   }
 }
 
-static bool initDocEntityInfo(const Decl *D, const Decl *SynthesizedTarget,
-                              const Decl *DefaultImplementationOf,
-                              bool IsRef, bool IsSynthesizedExtension,
-                              DocEntityInfo &Info,
+static bool initDocEntityInfo(const Decl *D,
+                              TypeOrExtensionDecl SynthesizedTarget,
+                              const Decl *DefaultImplementationOf, bool IsRef,
+                              bool IsSynthesizedExtension, DocEntityInfo &Info,
                               StringRef Arg = StringRef()) {
   if (!IsRef && D->isImplicit())
     return true;
@@ -320,9 +320,13 @@ static bool initDocEntityInfo(const Decl *D, const Decl *SynthesizedTarget,
     return false;
   }
 
-  if (IsSynthesizedExtension)
-    Info.Kind = SwiftLangSupport::getUIDForExtensionOfDecl(SynthesizedTarget);
-  else
+  auto SynthesizedTargetNTD =
+      SynthesizedTarget ? SynthesizedTarget.getBaseNominal() : nullptr;
+
+  if (IsSynthesizedExtension) {
+    Info.Kind =
+        SwiftLangSupport::getUIDForExtensionOfDecl(SynthesizedTargetNTD);
+  } else
     Info.Kind = SwiftLangSupport::getUIDForDecl(D, IsRef);
 
   if (Info.Kind.isInvalid())
@@ -335,7 +339,7 @@ static bool initDocEntityInfo(const Decl *D, const Decl *SynthesizedTarget,
       SwiftLangSupport::printUSR(VD, OS);
       if (SynthesizedTarget) {
         OS << SwiftLangSupport::SynthesizedUSRSeparator;
-        SwiftLangSupport::printUSR(dyn_cast<ValueDecl>(SynthesizedTarget), OS);
+        SwiftLangSupport::printUSR(SynthesizedTargetNTD, OS);
         {
           llvm::raw_svector_ostream OS(Info.OriginalUSR);
           SwiftLangSupport::printUSR(VD, OS);
@@ -375,8 +379,7 @@ static bool initDocEntityInfo(const Decl *D, const Decl *SynthesizedTarget,
         SecondPart = SecondPart.substr(ExtendedName.size());
         llvm::SmallString<128> UpdatedDocBuffer;
         UpdatedDocBuffer.append(FirstPart);
-        UpdatedDocBuffer.append(((const NominalTypeDecl*)SynthesizedTarget)->getName().
-                                str());
+        UpdatedDocBuffer.append(SynthesizedTargetNTD->getName().str());
         UpdatedDocBuffer.append(SecondPart);
         OS << UpdatedDocBuffer;
       } else
@@ -392,9 +395,7 @@ static bool initDocEntityInfo(const Decl *D, const Decl *SynthesizedTarget,
       llvm::raw_svector_ostream OS(Info.FullyAnnotatedDecl);
       if (SynthesizedTarget)
         SwiftLangSupport::printFullyAnnotatedSynthesizedDeclaration(
-            VD, const_cast<NominalTypeDecl *>(
-                    static_cast<const NominalTypeDecl *>(SynthesizedTarget)),
-            OS);
+            VD, SynthesizedTarget, OS);
       else
         SwiftLangSupport::printFullyAnnotatedDeclaration(VD, Type(), OS);
     }
@@ -461,13 +462,13 @@ static const TypeDecl *getTypeDeclFromType(Type Ty) {
 
 static void passInherits(const ValueDecl *D, DocInfoConsumer &Consumer) {
   DocEntityInfo EntInfo;
-  if (initDocEntityInfo(D, nullptr, nullptr, /*IsRef=*/true, false, EntInfo))
+  if (initDocEntityInfo(D, {}, nullptr, /*IsRef=*/true, false, EntInfo))
     return;
   Consumer.handleInheritsEntity(EntInfo);
 }
 static void passConforms(const ValueDecl *D, DocInfoConsumer &Consumer) {
   DocEntityInfo EntInfo;
-  if (initDocEntityInfo(D, nullptr, nullptr, /*IsRef=*/true, false, EntInfo))
+  if (initDocEntityInfo(D, {}, nullptr, /*IsRef=*/true, false, EntInfo))
     return;
   Consumer.handleConformsToEntity(EntInfo);
 }
@@ -503,7 +504,7 @@ static void passConforms(ArrayRef<ValueDecl *> Dcls,
 }
 static void passExtends(const ValueDecl *D, DocInfoConsumer &Consumer) {
   DocEntityInfo EntInfo;
-  if (initDocEntityInfo(D, nullptr, nullptr, /*IsRef=*/true, false, EntInfo))
+  if (initDocEntityInfo(D, {}, nullptr, /*IsRef=*/true, false, EntInfo))
     return;
   Consumer.handleExtendsEntity(EntInfo);
 }
@@ -516,15 +517,15 @@ static void passInheritsAndConformancesForValueDecl(const ValueDecl *VD,
                Consumer);
 }
 
-static void reportRelated(ASTContext &Ctx,
-                          const Decl *D,
-                          const Decl* SynthesizedTarget,
+static void reportRelated(ASTContext &Ctx, const Decl *D,
+                          TypeOrExtensionDecl SynthesizedTarget,
                           DocInfoConsumer &Consumer) {
   if (!D || isa<ParamDecl>(D))
     return;
   if (const auto *ED = dyn_cast<ExtensionDecl>(D)) {
     if (SynthesizedTarget) {
-      passExtends((const ValueDecl*)SynthesizedTarget, Consumer);
+      auto Extends = SynthesizedTarget.getBaseNominal();
+      passExtends(Extends, Consumer);
     } else if (Type T = ED->getExtendedType()) {
       if (auto TD = getTypeDeclFromType(T))
         passExtends(TD, Consumer);
@@ -645,7 +646,8 @@ static void reportDocEntities(ASTContext &Ctx,
       continue;
     Consumer.startSourceEntity(EntInfo);
     reportRelated(Ctx, Entity.Dcl,
-          Entity.IsSynthesizedExtension ? Entity.SynthesizeTarget : nullptr,
+                  Entity.IsSynthesizedExtension ? Entity.SynthesizeTarget
+                                                : TypeOrExtensionDecl(),
                   Consumer);
     reportDocEntities(Ctx, Entity.SubEntities, Consumer);
     reportAttributes(Ctx, Entity.Dcl, Consumer);
@@ -759,8 +761,7 @@ private:
       const TextReference &Ref = References.front();
       References = References.slice(1);
       DocEntityInfo Info;
-      if (initDocEntityInfo(Ref.Dcl, nullptr, nullptr, /*IsRef=*/true, false,
-                            Info))
+      if (initDocEntityInfo(Ref.Dcl, {}, nullptr, /*IsRef=*/true, false, Info))
         continue;
       Info.Offset = Ref.Range.Offset;
       Info.Length = Ref.Range.Length;
@@ -826,7 +827,7 @@ static void addParameters(ArrayRef<Identifier> &ArgNames,
         SM.getLocOffsetInBuffer(Lexer::getLocForEndOfToken(SM, TypeRange.End),
                                 BufferID);
       TextRange TR{ StartOffs, EndOffs-StartOffs };
-      TextEntity Param(param, nullptr, nullptr, Arg, TR, StartOffs, false);
+      TextEntity Param(param, {}, nullptr, Arg, TR, StartOffs, false);
       Ent.SubEntities.push_back(std::move(Param));
     }
   }
@@ -1020,7 +1021,8 @@ public:
       return true;
     TextRange TR = getTextRange(D->getSourceRange());
     unsigned LocOffset = getOffset(Range.getStart());
-    EntitiesStack.emplace_back(D, nullptr, nullptr, TR, LocOffset, false);
+    EntitiesStack.emplace_back(D, TypeOrExtensionDecl(), nullptr, TR, LocOffset,
+                               false);
     return true;
   }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -129,21 +129,22 @@ public:
     assert(DeclUSRs.empty() && "unmatched printDeclLoc call ?");
   }
 
-
   void printSynthesizedExtensionPre(const ExtensionDecl *ED,
-                                    const NominalTypeDecl *Target,
+                                    TypeOrExtensionDecl Target,
                                     Optional<BracketOptions> Bracket) override {
     // When we start print a synthesized extension, record the target's USR.
     llvm::SmallString<64> Buf;
     llvm::raw_svector_ostream OS(Buf);
-    if (!SwiftLangSupport::printUSR(Target, OS)) {
+    auto TargetNTD = Target.getBaseNominal();
+    if (!SwiftLangSupport::printUSR(TargetNTD, OS)) {
       TargetUSR = OS.str();
     }
   }
 
-  void printSynthesizedExtensionPost(const ExtensionDecl *ED,
-                                     const NominalTypeDecl *Target,
-                                     Optional<BracketOptions> Bracket) override {
+  void
+  printSynthesizedExtensionPost(const ExtensionDecl *ED,
+                                TypeOrExtensionDecl Target,
+                                Optional<BracketOptions> Bracket) override {
     // When we leave a synthesized extension, clear target's USR.
     TargetUSR = "";
   }

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -354,9 +354,9 @@ public:
                                              swift::Type BaseTy,
                                              llvm::raw_ostream &OS);
 
-  static void printFullyAnnotatedSynthesizedDeclaration(
-                                            const swift::ValueDecl *VD,
-                                            swift::NominalTypeDecl *Target,
+  static void
+  printFullyAnnotatedSynthesizedDeclaration(const swift::ValueDecl *VD,
+                                            swift::TypeOrExtensionDecl Target,
                                             llvm::raw_ostream &OS);
 
   /// Tries to resolve the path to the real file-system path. If it fails it

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -433,19 +433,20 @@ void SwiftLangSupport::printFullyAnnotatedDeclaration(const ValueDecl *VD,
   VD->print(Printer, PO);
 }
 
-void SwiftLangSupport::
-printFullyAnnotatedSynthesizedDeclaration(const swift::ValueDecl *VD,
-                                          swift::NominalTypeDecl *Target,
-                                          llvm::raw_ostream &OS) {
+void SwiftLangSupport::printFullyAnnotatedSynthesizedDeclaration(
+    const swift::ValueDecl *VD, TypeOrExtensionDecl Target,
+    llvm::raw_ostream &OS) {
   // FIXME: Mutable global variable - gross!
   static llvm::SmallDenseMap<swift::ValueDecl*,
     std::unique_ptr<swift::SynthesizedExtensionAnalyzer>> TargetToAnalyzerMap;
   FullyAnnotatedDeclarationPrinter Printer(OS);
   PrintOptions PO = PrintOptions::printQuickHelpDeclaration();
-  if (TargetToAnalyzerMap.count(Target) == 0) {
+  NominalTypeDecl *TargetNTD = Target.getBaseNominal();
+
+  if (TargetToAnalyzerMap.count(TargetNTD) == 0) {
     std::unique_ptr<SynthesizedExtensionAnalyzer> Analyzer(
-      new SynthesizedExtensionAnalyzer(Target, PO));
-    TargetToAnalyzerMap.insert({Target, std::move(Analyzer)});
+        new SynthesizedExtensionAnalyzer(TargetNTD, PO));
+    TargetToAnalyzerMap.insert({TargetNTD, std::move(Analyzer)});
   }
   PO.initForSynthesizedExtension(Target);
   PO.PrintAsMember = true;

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1698,18 +1698,18 @@ public:
       printDeclPost(D, None);
   }
 
-
   void printSynthesizedExtensionPre(const ExtensionDecl *ED,
-                                    const NominalTypeDecl *NTD,
+                                    TypeOrExtensionDecl Target,
                                     Optional<BracketOptions> Bracket) override {
     if (Bracket.hasValue() && !Bracket.getValue().shouldOpenExtension(ED))
       return;
     OS << "<synthesized>";
   }
 
-  void printSynthesizedExtensionPost(const ExtensionDecl *ED,
-                                     const NominalTypeDecl *NTD,
-                                     Optional<BracketOptions> Bracket) override {
+  void
+  printSynthesizedExtensionPost(const ExtensionDecl *ED,
+                                TypeOrExtensionDecl Target,
+                                Optional<BracketOptions> Bracket) override {
     if (Bracket.hasValue() && !Bracket.getValue().shouldCloseExtension(ED))
       return;
     OS << "</synthesized>";


### PR DESCRIPTION
Before conditional conformances, the archetypes in conformance
extensions (i.e. extension Foo: SomeProtocol) were equivalent to those
in the type decl, with the same protocol bounds and so on. The code for
printing "synthesized" members relied on this fact. This commit teaches
that code to deal with archetypes in the conditional conformance
extension when required.

Fixes rdar://problem/36553066 and SR-6930.
