### PR TITLE
Adding the correct value for __swift_mode_t in Android.

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -50,7 +50,11 @@ typedef      long int __swift_ssize_t;
 // This declaration might not be universally correct.
 // We verify its correctness for the current platform in the runtime code.
 #if defined(__linux__)
+# if defined(__ANDROID__)
+typedef __swift_uint16_t __swift_mode_t;
+# else
 typedef __swift_uint32_t __swift_mode_t;
+# endif
 #elif defined(__APPLE__)
 typedef __swift_uint16_t __swift_mode_t;
 #elif defined(_WIN32)
@@ -179,10 +183,12 @@ long double _stdlib_lgammal_r(long double x, int *psigngam);
 
 // TLS - thread local storage
 
-#if defined(__ANDROID__)
+#if defined(__linux__)
+# if defined(__ANDROID__)
 typedef int __swift_thread_key_t;
-#elif defined(__linux__)
+# else
 typedef unsigned int __swift_thread_key_t;
+# endif
 #elif defined(__FreeBSD__)
 typedef int __swift_thread_key_t;
 #elif defined(_WIN32)


### PR DESCRIPTION
As `defined(__linux__)` also matches, this never gets to the final `else` case. The lack of this line is causing the [following static assert](https://github.com/apple/swift/blob/master/stdlib/public/stubs/LibcShims.cpp#L48-L49) to fail.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->