### PR TITLE
[+0-normal-args] When forcing an argument into memory when performing…

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -843,7 +843,7 @@ void SILGenFunction::collectThunkParams(SILLocation loc,
 static void emitForceInto(SILGenFunction &SGF, SILLocation loc,
                           ManagedValue result, TemporaryInitialization &temp) {
   if (result.isInContext()) return;
-  result.forwardInto(SGF, loc, temp.getAddress());
+  result.ensurePlusOne(SGF, loc).forwardInto(SGF, loc, temp.getAddress());
   temp.finishInitialization(SGF);
 }
 


### PR DESCRIPTION
… a translating transform thunk, make sure it is at +1.

Fixes an issue where it was possible for a +0 pointer from an argument to get to
this thunk transform code. This is significantly more likely to happen when all
arguments are at +0.

This is tested by a SILGen test that I updated out of tree. It shouldn't effect
normal +1 code.

rdar://34222540
