### PR TITLE
SIL: Add an 'external' KeyPathPatternComponent kind.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4392,6 +4392,13 @@ public:
   /// property from the given module?
   bool isResilient(ModuleDecl *M, ResilienceExpansion expansion) const;
 
+  /// Returns the interface type of elements of storage represented by this
+  /// declaration.
+  ///
+  /// For variables, this is the type of the variable itself.
+  /// For subscripts, this is the type of the subscript element.
+  Type getStorageInterfaceType() const;
+
   /// Does the storage use a behavior?
   bool hasBehavior() const {
     return BehaviorInfo.getPointer() != nullptr;

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -162,6 +162,10 @@ public:
                           unsigned origDepthOrIndex,
                           GenericSignature *genericSig);
 
+  /// Swap archetypes in the substitution map's replacement types with their
+  /// interface types.
+  SubstitutionMap mapReplacementTypesOutOfContext() const;
+
   /// Verify that this substitution map is valid.
   void verify() const;
 

--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -66,6 +66,12 @@ using TypeSubstitutionFn
   = llvm::function_ref<Type(SubstitutableType *dependentType)>;
 
 /// A function object suitable for use as a \c TypeSubstitutionFn that
+/// replaces archetypes with their interface types.
+struct MapTypeOutOfContext {
+  Type operator()(SubstitutableType *type) const;
+};
+
+/// A function object suitable for use as a \c TypeSubstitutionFn that
 /// queries an underlying \c TypeSubstitutionMap.
 struct QueryTypeSubstitutionMap {
   const TypeSubstitutionMap &substitutions;

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -121,11 +121,13 @@ Type GenericEnvironment::mapTypeIntoContext(GenericEnvironment *env,
   return env->mapTypeIntoContext(type);
 }
 
+Type MapTypeOutOfContext::operator()(SubstitutableType *type) const {
+  return cast<ArchetypeType>(type)->getInterfaceType();
+}
+
 Type TypeBase::mapTypeOutOfContext() {
   assert(!hasTypeParameter() && "already have an interface type");
-  return Type(this).subst([&](SubstitutableType *t) -> Type {
-      return cast<ArchetypeType>(t)->getInterfaceType();
-    },
+  return Type(this).subst(MapTypeOutOfContext(),
     MakeAbstractConformanceForGenericType(),
     SubstFlags::AllowLoweredTypes);
 }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1558,6 +1558,18 @@ bool AbstractStorageDecl::isSetterAccessibleFrom(const DeclContext *DC) const {
   return checkAccess(DC, getDeclContext(), getSetterFormalAccess());
 }
 
+Type AbstractStorageDecl::getStorageInterfaceType() const {
+  if (auto var = dyn_cast<VarDecl>(this)) {
+    return var->getInterfaceType();
+  }
+  
+  if (auto sub = dyn_cast<SubscriptDecl>(this)) {
+    return sub->getElementInterfaceType();
+  }
+  
+  llvm_unreachable("unhandled storage decl kind");
+}
+
 bool DeclContext::lookupQualified(Type type,
                                   DeclName member,
                                   NLOptions options,

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -269,6 +269,10 @@ addConformance(CanType type, ProtocolConformanceRef conformance) {
   conformanceMap[type].push_back(conformance);
 }
 
+SubstitutionMap SubstitutionMap::mapReplacementTypesOutOfContext() const {
+  return subst(MapTypeOutOfContext(), MakeAbstractConformanceForGenericType());
+}
+
 SubstitutionMap SubstitutionMap::subst(const SubstitutionMap &subMap) const {
   return subst(QuerySubstitutionMap{subMap},
                LookUpConformanceInSubstitutionMap(subMap));

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -2501,6 +2501,81 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
       if (P.parseToken(tok::l_paren, diag::expected_tok_in_sil_instr, "("))
         return true;
       
+      auto parseComponentIndices =
+        [&](SmallVectorImpl<KeyPathPatternComponent::Index> &indexes) -> bool {
+          while (true) {
+            unsigned index;
+            CanType formalTy;
+            SILType loweredTy;
+            if (P.parseToken(tok::oper_prefix,
+                             diag::expected_tok_in_sil_instr, "%")
+                || P.parseToken(tok::sil_dollar,
+                                diag::expected_tok_in_sil_instr, "$"))
+              return true;
+            
+            if (!P.Tok.is(tok::integer_literal)
+                || P.Tok.getText().getAsInteger(0, index))
+              return true;
+            
+            P.consumeToken(tok::integer_literal);
+            
+            SourceLoc formalTyLoc;
+            SourceLoc loweredTyLoc;
+            GenericEnvironment *ignoredParsedEnv;
+            if (P.parseToken(tok::colon,
+                             diag::expected_tok_in_sil_instr, ":")
+                || P.parseToken(tok::sil_dollar,
+                                diag::expected_tok_in_sil_instr, "$")
+                || parseASTType(formalTy, formalTyLoc, patternEnv)
+                || P.parseToken(tok::colon,
+                                diag::expected_tok_in_sil_instr, ":")
+                || parseSILType(loweredTy, loweredTyLoc,
+                                ignoredParsedEnv, patternEnv))
+              return true;
+            
+            if (patternEnv)
+              loweredTy = SILType::getPrimitiveType(
+                loweredTy.getSwiftRValueType()->mapTypeOutOfContext()
+                  ->getCanonicalType(),
+                loweredTy.getCategory());
+
+            // Formal type must be hashable.
+            auto proto = P.Context.getProtocol(KnownProtocolKind::Hashable);
+            Type contextFormalTy = formalTy;
+            if (patternEnv)
+              contextFormalTy = patternEnv->mapTypeIntoContext(formalTy);
+            auto lookup = P.SF.getParentModule()->lookupConformance(
+                                                    contextFormalTy, proto);
+            if (!lookup) {
+              P.diagnose(formalTyLoc,
+                         diag::sil_keypath_index_not_hashable,
+                         formalTy);
+              return true;
+            }
+            auto conformance = ProtocolConformanceRef(*lookup);
+            
+            indexes.push_back({index, formalTy, loweredTy, conformance});
+            
+            operandTypes.resize(index+1);
+            if (operandTypes[index] && operandTypes[index] != loweredTy) {
+              P.diagnose(loweredTyLoc,
+                         diag::sil_keypath_index_operand_type_conflict,
+                         index,
+                         operandTypes[index].getSwiftRValueType(),
+                         loweredTy.getSwiftRValueType());
+              return true;
+            }
+            operandTypes[index] = loweredTy;
+            
+            if (P.consumeIf(tok::comma))
+              continue;
+            if (P.consumeIf(tok::r_square))
+              break;
+            return true;
+          }
+          return false;
+        };
+      
       while (true) {
         Identifier componentKind;
         SourceLoc componentLoc;
@@ -2528,17 +2603,71 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
           CanType ty;
           if (parseSILDottedPath(prop)
               || P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":")
-              || P.parseToken(tok::sil_dollar, diag::expected_tok_in_sil_instr, "$")
+              || P.parseToken(tok::sil_dollar,
+                              diag::expected_tok_in_sil_instr, "$")
               || parseASTType(ty, patternEnv))
             return true;
           components.push_back(
             KeyPathPatternComponent::forStoredProperty(cast<VarDecl>(prop), ty));
+        } else if (componentKind.str() == "external") {
+          ValueDecl *externalDecl;
+          SmallVector<ParsedSubstitution, 4> parsedSubs;
+          SmallVector<Substitution, 4> subs;
+          SmallVector<KeyPathPatternComponent::Index, 4> indexes;
+          CanType ty;
+
+          if (parseSILDottedPath(externalDecl)
+              || parseSubstitutions(parsedSubs, patternEnv))
+            return true;
+
+          if (P.consumeIf(tok::l_square)) {
+            if (parseComponentIndices(indexes))
+              return true;
+          }
+          
+          if (P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":")
+              || P.parseToken(tok::sil_dollar,
+                              diag::expected_tok_in_sil_instr, "$")
+              || parseASTType(ty, patternEnv))
+            return true;
+          
+          if (!parsedSubs.empty()) {
+            auto genericEnv = externalDecl->getInnermostDeclContext()
+                                          ->getGenericEnvironmentOfContext();
+            if (!genericEnv) {
+              P.diagnose(P.Tok,
+                         diag::sil_substitutions_on_non_polymorphic_type);
+              return true;
+            }
+            if (getApplySubstitutionsFromParsed(*this, genericEnv,
+                                                parsedSubs, subs))
+              return true;
+            
+            // Map the substitutions out of the pattern context so that they
+            // use interface types.
+            auto subsMap = genericEnv->getGenericSignature()
+              ->getSubstitutionMap(subs);
+            subsMap = subsMap.mapReplacementTypesOutOfContext();
+            subs.clear();
+            genericEnv->getGenericSignature()->getSubstitutions(subsMap, subs);
+            
+            for (auto &sub : subs)
+              sub = sub.getCanonicalSubstitution();
+          }
+          
+          auto indexesCopy = P.Context.AllocateCopy(indexes);
+          auto subsCopy = P.Context.AllocateCopy(subs);
+          
+          components.push_back(
+            KeyPathPatternComponent::forExternal(
+              cast<AbstractStorageDecl>(externalDecl),
+              subsCopy, indexesCopy, ty));
         } else if (componentKind.str() == "gettable_property"
                    || componentKind.str() == "settable_property") {
           bool isSettable = componentKind.str()[0] == 's';
           
           CanType componentTy;
-          if (P.parseToken(tok::sil_dollar, diag::expected_tok_in_sil_instr, "$")
+          if (P.parseToken(tok::sil_dollar,diag::expected_tok_in_sil_instr,"$")
               || parseASTType(componentTy, patternEnv)
               || P.parseToken(tok::comma, diag::expected_tok_in_sil_instr, ","))
             return true;
@@ -2586,79 +2715,9 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
                 return true;
             } else if (subKind.str() == "indices") {
               if (P.parseToken(tok::l_square,
-                               diag::expected_tok_in_sil_instr, "["))
+                               diag::expected_tok_in_sil_instr, "[")
+                  || parseComponentIndices(indexes))
                 return true;
-              
-              while (true) {
-                unsigned index;
-                CanType formalTy;
-                SILType loweredTy;
-                if (P.parseToken(tok::oper_prefix,
-                                 diag::expected_tok_in_sil_instr, "%")
-                    || P.parseToken(tok::sil_dollar,
-                                    diag::expected_tok_in_sil_instr, "$"))
-                  return true;
-                
-                if (!P.Tok.is(tok::integer_literal)
-                    || P.Tok.getText().getAsInteger(0, index))
-                  return true;
-                
-                P.consumeToken(tok::integer_literal);
-                
-                SourceLoc formalTyLoc;
-                SourceLoc loweredTyLoc;
-                GenericEnvironment *ignoredParsedEnv;
-                if (P.parseToken(tok::colon,
-                                 diag::expected_tok_in_sil_instr, ":")
-                    || P.parseToken(tok::sil_dollar,
-                                    diag::expected_tok_in_sil_instr, "$")
-                    || parseASTType(formalTy, formalTyLoc, patternEnv)
-                    || P.parseToken(tok::colon,
-                                    diag::expected_tok_in_sil_instr, ":")
-                    || parseSILType(loweredTy, loweredTyLoc,
-                                    ignoredParsedEnv, patternEnv))
-                  return true;
-                
-                if (patternEnv)
-                  loweredTy = SILType::getPrimitiveType(
-                    loweredTy.getSwiftRValueType()->mapTypeOutOfContext()
-                      ->getCanonicalType(),
-                    loweredTy.getCategory());
-
-                // Formal type must be hashable.
-                auto proto = P.Context.getProtocol(KnownProtocolKind::Hashable);
-                Type contextFormalTy = formalTy;
-                if (patternEnv)
-                  contextFormalTy = patternEnv->mapTypeIntoContext(formalTy);
-                auto lookup = P.SF.getParentModule()->lookupConformance(
-                                                        contextFormalTy, proto);
-                if (!lookup) {
-                  P.diagnose(formalTyLoc,
-                             diag::sil_keypath_index_not_hashable,
-                             formalTy);
-                  return true;
-                }
-                auto conformance = ProtocolConformanceRef(*lookup);
-                
-                indexes.push_back({index, formalTy, loweredTy, conformance});
-                
-                operandTypes.resize(index+1);
-                if (operandTypes[index] && operandTypes[index] != loweredTy) {
-                  P.diagnose(loweredTyLoc,
-                             diag::sil_keypath_index_operand_type_conflict,
-                             index,
-                             operandTypes[index].getSwiftRValueType(),
-                             loweredTy.getSwiftRValueType());
-                  return true;
-                }
-                operandTypes[index] = loweredTy;
-                
-                if (P.consumeIf(tok::comma))
-                  continue;
-                if (P.consumeIf(tok::r_square))
-                  break;
-                return true;
-              }
             } else if (subKind.str() == "indices_equals") {
               if (parseSILFunctionRef(InstLoc, equals))
                 return true;

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -228,9 +228,9 @@ protected:
           break;
         }
 
-        if (auto equals = component.getComputedPropertyIndexEquals())
+        if (auto equals = component.getSubscriptIndexEquals())
           ensureAlive(equals);
-        if (auto hash = component.getComputedPropertyIndexHash())
+        if (auto hash = component.getSubscriptIndexHash())
           ensureAlive(hash);
 
         continue;
@@ -239,6 +239,7 @@ protected:
       case KeyPathPatternComponent::Kind::OptionalChain:
       case KeyPathPatternComponent::Kind::OptionalForce:
       case KeyPathPatternComponent::Kind::OptionalWrap:
+      case KeyPathPatternComponent::Kind::External:
         continue;
       }
     }

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -1943,7 +1943,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       };
       auto handleComputedIndices
         = [&](const KeyPathPatternComponent &component) {
-          auto indices = component.getComputedPropertyIndices();
+          auto indices = component.getSubscriptIndices();
           ListOfValues.push_back(indices.size());
           for (auto &index : indices) {
             ListOfValues.push_back(index.Operand);
@@ -1955,9 +1955,9 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
           }
           if (!indices.empty()) {
             ListOfValues.push_back(
-              addSILFunctionRef(component.getComputedPropertyIndexEquals()));
+              addSILFunctionRef(component.getSubscriptIndexEquals()));
             ListOfValues.push_back(
-              addSILFunctionRef(component.getComputedPropertyIndexHash()));
+              addSILFunctionRef(component.getSubscriptIndexHash()));
           }
         };
     
@@ -1991,6 +1991,8 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       case KeyPathPatternComponent::Kind::OptionalWrap:
         handleComponentCommon(KeyPathComponentKindEncoding::OptionalWrap);
         break;
+      case KeyPathPatternComponent::Kind::External:
+        llvm_unreachable("todo");
       }
     }
     

--- a/test/SIL/Parser/keypath.sil
+++ b/test/SIL/Parser/keypath.sil
@@ -36,6 +36,12 @@ struct Gen<A: P, B: Q, C: R> {
   var z: C
 }
 
+public struct External<T> {
+  var ro: T { get }
+
+  subscript<U: Hashable>(ro _: U) -> T { get }
+}
+
 // CHECK-LABEL: sil shared @stored_properties
 sil shared @stored_properties : $@convention(thin) () -> () {
 entry:
@@ -136,3 +142,20 @@ entry(%s : $S, %c : $C):
   return undef : $()
 }
 
+// CHECK-LABEL: sil @external
+sil @external : $@convention(thin) <A, B: Hashable> (@in B) -> () {
+entry(%z : $*B):
+  // CHECK: %1 = keypath $KeyPath<External<Int>, Int>, (root $External<Int>; external #External.ro<Int> : $Int)
+  %a = keypath $KeyPath<External<Int>, Int>, (root $External<Int>; external #External.ro<Int> : $Int)
+
+  // CHECK: %2 = keypath $KeyPath<External<A>, A>, <τ_0_0, τ_0_1, τ_0_2> (root $External<τ_0_2>; external #External.ro<τ_0_2> : $τ_0_2) <A, A, A>
+  %b = keypath $KeyPath<External<A>, A>, <C, D, E> (root $External<E>; external #External.ro <E> : $E) <A, A, A>
+
+  // CHECK: %3 = keypath $KeyPath<External<Int>, Int>, <τ_0_0> (root $External<τ_0_0>; external #External.ro<τ_0_0> : $τ_0_0) <Int>
+  %c = keypath $KeyPath<External<Int>, Int>, <F> (root $External<F>; external #External.ro <F> : $F) <Int>
+
+  // CHECK: %4 = keypath $KeyPath<External<A>, A>, <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (root $External<τ_0_1>; external #External.subscript<τ_0_1, τ_0_0>[%$0 : $τ_0_0 : $*τ_0_0] : $τ_0_1) <B, A> (%0)
+  %d = keypath $KeyPath<External<A>, A>, <G: Hashable, H> (root $External<H>; external #External.subscript <H, G> [%$0 : $G : $*G] : $H) <B, A> (%z)
+
+  return undef : $()
+}


### PR DESCRIPTION
This will allow key paths to resiliently reference public properties from other binaries by referencing a descriptor vended by the originating binary. NFC yet, this just provides printing/parsing/verification of the new component.