### PR TITLE
[+0-all-args] Ensure that we always return an enum at +1 from enum co…

### DIFF
--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -428,7 +428,7 @@ void SILGenFunction::emitEnumConstructor(EnumElementDecl *element) {
     B.createReturn(ReturnLoc, emitEmptyTuple(Loc));
   } else {
     assert(enumTI.isLoadable() || !silConv.useLoweredAddresses());
-    SILValue result = mv.forward(*this);
+    SILValue result = mv.ensurePlusOne(*this, ReturnLoc).forward(*this);
     scope.pop();
     B.createReturn(ReturnLoc, result);
   }


### PR DESCRIPTION
…nstructors.

This was exposed by a test in the SILGen filecheck tests that I am updating out
of tree.

What is basically happening here is that we construct an enum from a guaranteed
argument and then return that enum. We need to ensure in such a case that the
return value is still at +1. This commit fixes the issue by using an
ensurePlusOne, ensuring that in normal cases we do not emit an extra copy, but
in a world where we have +0 arguments, ensures we insert a copy before we
return.

rdar://34222540
