### PR TITLE
[Runtime] Reference ObjC class objects indirectly in conformance records

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -723,6 +723,9 @@ public:
   bool isForeignTypeMetadataCandidate() const {
     return getKind() == Kind::ForeignTypeMetadataCandidate;
   }
+  bool isObjCClassRef() const {
+    return getKind() == Kind::ObjCClassRef;
+  }
 
   /// Determine whether this entity will be weak-imported.
   bool isWeakImported(ModuleDecl *module) const {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2352,6 +2352,9 @@ IRGenModule::getAddrOfLLVMVariableOrGOTEquivalent(LinkEntity entity,
     auto foreignCandidate
       = getAddrOfForeignTypeMetadataCandidate(entity.getType());
     (void)foreignCandidate;
+  } else if (entity.isObjCClassRef()) {
+    (void)getAddrOfObjCClassRef(
+                  const_cast<ClassDecl *>(cast<ClassDecl>(entity.getDecl())));
   } else {
     getAddrOfLLVMVariable(entity, alignment, ConstantInit(),
                           defaultType, DebugTypeInfo());
@@ -2442,7 +2445,7 @@ getTypeEntityInfo(IRGenModule &IGM, CanType conformingType) {
     typeKind = TypeMetadataRecordKind::IndirectObjCClass;
     defaultTy = IGM.TypeMetadataPtrTy;
     defaultPtrTy = IGM.TypeMetadataPtrTy;
-    entity = LinkEntity::forObjCClass(clas);
+    entity = LinkEntity::forObjCClassRef(clas);
   } else {
     // Conformances for generics and concrete subclasses of generics
     // are represented by referencing the nominal type descriptor.

--- a/test/IRGen/objc_bridged_generic_conformance.swift
+++ b/test/IRGen/objc_bridged_generic_conformance.swift
@@ -3,7 +3,7 @@
 
 // CHECK-NOT: _TMnCSo
 
-// CHECK: @"$SSo6ThingyCyxG32objc_bridged_generic_conformance1PADMc" = hidden constant %swift.protocol_conformance_descriptor {{.*}} @"got.OBJC_CLASS_$_Thingy"
+// CHECK: @"$SSo6ThingyCyxG32objc_bridged_generic_conformance1PADMc" = hidden constant %swift.protocol_conformance_descriptor {{.*}} @"OBJC_CLASS_REF_$_Thingy"
 
 // CHECK-NOT: _TMnCSo
 

--- a/test/IRGen/protocol_conformance_records_objc.swift
+++ b/test/IRGen/protocol_conformance_records_objc.swift
@@ -30,7 +30,7 @@ extension NSRect: Runcible {
 // -- protocol descriptor
 // CHECK-SAME:           [[RUNCIBLE]]
 // -- class object reference
-// CHECK-SAME:           @"got.OBJC_CLASS_$_Gizmo"
+// CHECK-SAME:           @"OBJC_CLASS_REF_$_Gizmo"
 // -- witness table
 // CHECK-SAME:           @"$SSo5GizmoC33protocol_conformance_records_objc8RuncibleACWP"
 // -- flags


### PR DESCRIPTION
Within conformance records, reference Objective-C class objects
indirectly so the runtime can update those references appropriately.
We don't need to do this for classes with Swift metadata.

Fixes the ABI-affecting part of rdar://problem/36310179.
