### PR TITLE
[+0-all-args] Add SILGenBuilder APIs for createRefToBridgeObject and …

### DIFF
--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -762,6 +762,14 @@ ManagedValue SILGenBuilder::createBridgeObjectToRef(SILLocation loc,
   return cloner.clone(result);
 }
 
+ManagedValue SILGenBuilder::createRefToBridgeObject(SILLocation loc,
+                                                    ManagedValue mv,
+                                                    SILValue bits) {
+  CleanupCloner cloner(*this, mv);
+  SILValue result = createRefToBridgeObject(loc, mv.forward(SGF), bits);
+  return cloner.clone(result);
+}
+
 ManagedValue SILGenBuilder::createBlockToAnyObject(SILLocation loc,
                                                    ManagedValue v,
                                                    SILType destType) {

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -360,6 +360,10 @@ public:
   ManagedValue createBridgeObjectToRef(SILLocation loc, ManagedValue mv,
                                        SILType destType);
 
+  using SILBuilder::createRefToBridgeObject;
+  ManagedValue createRefToBridgeObject(SILLocation loc, ManagedValue mv,
+                                       SILValue bits);
+
   using SILBuilder::createBranch;
   BranchInst *createBranch(SILLocation Loc, SILBasicBlock *TargetBlock,
                            ArrayRef<ManagedValue> Args);

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -677,11 +677,8 @@ static ManagedValue emitBuiltinCastToBridgeObject(SILGenFunction &SGF,
     SILValue undef = SILUndef::get(objPointerType, SGF.SGM.M);
     return ManagedValue::forUnmanaged(undef);
   }
-  
-  // Save the cleanup on the argument so we can forward it onto the cast
-  // result.
-  auto refCleanup = args[0].getCleanup();
-  SILValue ref = args[0].getValue();
+
+  ManagedValue ref = args[0];
   SILValue bits = args[1].getUnmanagedValue();
   
   // If the argument is existential, open it.
@@ -691,9 +688,8 @@ static ManagedValue emitBuiltinCastToBridgeObject(SILGenFunction &SGF,
     SILType loweredOpenedTy = SGF.getLoweredLoadableType(openedTy);
     ref = SGF.B.createOpenExistentialRef(loc, ref, loweredOpenedTy);
   }
-  
-  SILValue result = SGF.B.createRefToBridgeObject(loc, ref, bits);
-  return ManagedValue(result, refCleanup);
+
+  return SGF.B.createRefToBridgeObject(loc, ref, bits);
 }
 
 /// Specialized emitter for Builtin.castReferenceFromBridgeObject.


### PR DESCRIPTION
…use it in emitBuiltinCastToBridgeObject to ensure cleanups are on the actual bridge object.

This eliminates a case where we were not moving a cleanup onto a forwarding case
and instead just jammed the original cleanup and the new value into 1 managed
value.

NFC, but helps the ownership verifier.

rdar://34222540