### PR TITLE
[Runtime] Existential types marked as @objc should satisfy class requirement

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -949,6 +949,8 @@ public:
     return asWords + description->getGenericArgumentOffset(this);
   }
 
+  bool satisfiesClassConstraint() const;
+
 #if SWIFT_OBJC_INTEROP
   /// Get the ObjC class object for this type if it has one, or return null if
   /// the type is not a class (or not a class with a class object).

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3015,3 +3015,13 @@ void MetadataAllocator::Deallocate(const void *allocation, size_t size) {
 void *swift::allocateMetadata(size_t size, size_t alignment) {
   return MetadataAllocator().Allocate(size, alignment);
 }
+
+template<>
+bool Metadata::satisfiesClassConstraint() const {
+  // existential types marked with @objc satisfy class requirement.
+  if (auto *existential = dyn_cast<ExistentialTypeMetadata>(this))
+    return existential->isObjC();
+
+  // or it's a class.
+  return isAnyClass();
+}

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -777,8 +777,8 @@ bool swift::_checkGenericRequirements(
     case GenericRequirementKind::Layout: {
       switch (req.getLayout()) {
       case GenericRequirementLayoutKind::Class:
-        // Check whether the subject type is a class.
-        if (!subjectType->isAnyClass()) return true;
+        if (!subjectType->satisfiesClassConstraint())
+          return true;
         continue;
       }
 

--- a/test/stdlib/RuntimeObjC.swift
+++ b/test/stdlib/RuntimeObjC.swift
@@ -386,12 +386,16 @@ Runtime.test("Generic class ObjC runtime names") {
                                                   GenericEnum<GenericEnum<Int>>>.self))
 }
 
+@objc protocol P {}
+struct AnyObjStruct<T: AnyObject> {}
+
 Runtime.test("typeByName") {
   // Make sure we don't crash if we have foreign classes in the
   // table -- those don't have NominalTypeDescriptors
   print(CFArray.self)
   expectTrue(_typeByName("a.SomeClass") == SomeClass.self)
   expectTrue(_typeByName("DoesNotExist") == nil)
+  expectTrue(_typeByName("1a12AnyObjStructVyAA1P_pG") == AnyObjStruct<P>.self)
 }
 
 Runtime.test("casting AnyObject to class metatypes") {


### PR DESCRIPTION
Make sure that `checkGenericRequirements` properly enforces
"class requirement" constraint on the generic parameters.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
