### PR TITLE
[+0-all-arguments] Use SILGenBuilder APIs to ensure we put cleanups o…

### DIFF
--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -389,16 +389,8 @@ static ManagedValue emitCastFromReferenceType(SILGenFunction &SGF,
     SILValue result = SILUndef::get(destType, SGF.SGM.M);
     return ManagedValue::forUnmanaged(result);
   }
-  
-  // Save the cleanup on the argument so we can forward it onto the cast
-  // result.
-  auto cleanup = args[0].getCleanup();
 
-  // Take the reference type argument and cast it.
-  SILValue result = SGF.B.createUncheckedRefCast(loc, args[0].getValue(),
-                                                 destType);
-  // Return the cast result with the original cleanup.
-  return ManagedValue(result, cleanup);
+  return SGF.B.createUncheckedRefCast(loc, args[0], destType);
 }
 
 /// Specialized emitter for Builtin.castFromNativeObject.


### PR DESCRIPTION
…n the case result instead of on the cast argument.

Otherwise, we break SILGen tests when they are updated for +0. This breakage
occurs since we use the original cleanup from args[0] instead of forwarding that
cleanup and creating a new cleanup on the result.

rdar://34222540
