### PR TITLE
[Experiment] [Objective-C interoperability] Eliminate import of NSObjectProtocol.

### DIFF
--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -221,6 +221,7 @@ OmissionTypeName importer::getClangTypeNameForOmission(clang::ASTContext &ctx,
 
     // For id<Proto> or NSObject<Proto>, retrieve the name of "Proto".
     if (objcObjectPtr->getNumProtocols() == 1 &&
+        !isNSObjectProtocol(*objcObjectPtr->qual_begin()) &&
         (!objcClass || objcClass->getName() == "NSObject"))
       return (*objcObjectPtr->qual_begin())->getName();
 

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -612,6 +612,9 @@ findSwiftNameAttr(const clang::Decl *decl, ImportNameVersion version) {
   if (version == ImportNameVersion::raw())
     return nullptr;
 
+  // HACK: Don't rename the NSObject protocol.
+  if (isNSObjectProtocol(decl)) return nullptr;
+
   // Handle versioned API notes for Swift 3 and later. This is the common case.
   if (version > ImportNameVersion::swift2()) {
     const auto *activeAttr = decl->getAttr<clang::SwiftNameAttr>();
@@ -1020,6 +1023,10 @@ static bool shouldBeSwiftPrivate(NameImporter &nameImporter,
       break;
     }
   }
+
+  // The NSObject protocol is SwiftPrivate.
+  // FIXME: Move this into the API notes for the ObjectiveC module.
+  if (isNSObjectProtocol(decl)) return true;
 
   return false;
 }

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1409,6 +1409,8 @@ static T *castIgnoringCompatibilityAlias(Decl *D) {
   return cast_or_null<T>(D);
 }
 
+bool isNSObjectProtocol(const clang::Decl *decl);
+
 class SwiftNameLookupExtension : public clang::ModuleFileExtension {
   std::unique_ptr<SwiftLookupTable> &pchLookupTable;
   LookupTableMap &lookupTables;

--- a/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
@@ -196,7 +196,10 @@ public var NO: ObjCBool {
 
 // NSObject implements Equatable's == as -[NSObject isEqual:]
 // NSObject implements Hashable's hashValue() as -[NSObject hash]
-// FIXME: what about NSObjectProtocol?
+
+@available(*, deprecated, renamed: "AnyObject",
+           message: "all classes implicitly conform to the 'NSObject' protocol")
+public typealias NSObjectProtocol = AnyObject
 
 extension NSObject : Equatable, Hashable {
   /// The hash value.

--- a/test/ClangImporter/Dispatch_test.swift
+++ b/test/ClangImporter/Dispatch_test.swift
@@ -7,14 +7,14 @@ import Foundation
 
 func test1(_ queue: dispatch_queue_t) {} // expected-error {{'dispatch_queue_t' is unavailable}}
 func test2(_ queue: DispatchQueue) {
-  let base: NSObjectProtocol = queue
+  let base: AnyObject = queue
   let _: DispatchObject = queue
 
   let _ = base as? DispatchQueue
 
   // Make sure the dispatch types are actually distinct types!
   let _ = queue as DispatchSource // expected-error {{cannot convert value of type 'DispatchQueue' to type 'DispatchSource' in coercion}}
-  let _ = base as DispatchSource // expected-error {{'NSObjectProtocol' is not convertible to 'DispatchSource'; did you mean to use 'as!' to force downcast?}}
+  let _ = base as DispatchSource // expected-error {{'AnyObject' is not convertible to 'DispatchSource'; did you mean to use 'as!' to force downcast?}}
 }
 
 extension dispatch_queue_t {} // expected-error {{'dispatch_queue_t' is unavailable}}

--- a/test/ClangImporter/MixedSource/mixed-target-using-header.swift
+++ b/test/ClangImporter/MixedSource/mixed-target-using-header.swift
@@ -12,7 +12,7 @@ func test(_ foo : FooProto) {
 @objc class ForwardClass : NSObject {
 }
 
-@objc protocol ForwardProto : NSObjectProtocol {
+@objc protocol ForwardProto : AnyObject {
 }
 @objc class ForwardProtoAdopter : NSObject, ForwardProto {
 }

--- a/test/ClangImporter/MixedSource/mixed-target-using-module.swift
+++ b/test/ClangImporter/MixedSource/mixed-target-using-module.swift
@@ -12,7 +12,7 @@
 @objc class ForwardClass : NSObject {
 }
 
-@objc protocol ForwardProto : NSObjectProtocol {
+@objc protocol ForwardProto : AnyObject {
 }
 @objc class ForwardProtoAdopter : NSObject, ForwardProto {
 }

--- a/test/ClangImporter/availability.swift
+++ b/test/ClangImporter/availability.swift
@@ -13,10 +13,6 @@ func test_unavailable_instance_method(_ x : NSObject) -> Bool {
   return x.allowsWeakReference() // expected-error {{'allowsWeakReference()' is unavailable}}
 }
 
-func test_unavailable_method_in_protocol(_ x : NSObjectProtocol) {
-  // expected-warning @+1 {{expression of type 'NSObjectProtocol' is unused}}
-  x.retain() // expected-error {{'retain()' is unavailable}}
-}
 func test_unavailable_method_in_protocol_use_class_instance(_ x : NSObject) {
   x.retain() // expected-error {{'retain()' is unavailable}} expected-warning {{result of call to 'retain()' is unused}}
 }

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -57,7 +57,7 @@ func instanceMethods(_ b: B) {
 
   // Instance methods with keyword components
   var obj = NSObject()
-  var prot = NSObjectProtocol.self
+  var prot = NSCoding.self
   b.`protocol`(prot, hasThing:obj)
   b.doThing(obj, protocol: prot)
 }
@@ -311,10 +311,10 @@ func ivars(_ hive: Hive) {
   hive.queen.description() // expected-error{{value of type 'Hive' has no member 'queen'}}
 }
 
-class NSObjectable : NSObjectProtocol {
-  @objc var description : String { return "" }
-  @objc(conformsToProtocol:) func conforms(to _: Protocol) -> Bool { return false }
-  @objc(isKindOfClass:) func isKind(of aClass: AnyClass) -> Bool { return false }
+class NSObjectable : NSObject {
+  @objc override var description : String { return "" }
+  @objc(conformsToProtocol:) override func conforms(to _: Protocol) -> Bool { return false }
+  @objc(isKindOfClass:) override func isKind(of aClass: AnyClass) -> Bool { return false }
 }
 
 
@@ -553,17 +553,15 @@ func testStrangeSelectors(obj: StrangeSelectors) {
 
 func testProtocolQualified(_ obj: CopyableNSObject, cell: CopyableSomeCell,
                            plainObj: NSObject, plainCell: SomeCell) {
-  _ = obj as NSObject // expected-error {{'CopyableNSObject' (aka 'NSCopying & NSObjectProtocol') is not convertible to 'NSObject'; did you mean to use 'as!' to force downcast?}} {{11-13=as!}}
-  _ = obj as NSObjectProtocol
+  _ = obj as NSObject // expected-error {{'CopyableNSObject' (aka 'NSCopying') is not convertible to 'NSObject'; did you mean to use 'as!' to force downcast?}} {{11-13=as!}}
   _ = obj as NSCopying
-  _ = obj as SomeCell // expected-error {{'CopyableNSObject' (aka 'NSCopying & NSObjectProtocol') is not convertible to 'SomeCell'; did you mean to use 'as!' to force downcast?}} {{11-13=as!}}
+  _ = obj as SomeCell // expected-error {{'CopyableNSObject' (aka 'NSCopying') is not convertible to 'SomeCell'; did you mean to use 'as!' to force downcast?}} {{11-13=as!}}
 
   _ = cell as NSObject
-  _ = cell as NSObjectProtocol
   _ = cell as NSCopying // expected-error {{'CopyableSomeCell' (aka 'SomeCell') is not convertible to 'NSCopying'; did you mean to use 'as!' to force downcast?}} {{12-14=as!}}
   _ = cell as SomeCell
   
-  _ = plainObj as CopyableNSObject // expected-error {{'NSObject' is not convertible to 'CopyableNSObject' (aka 'NSCopying & NSObjectProtocol'); did you mean to use 'as!' to force downcast?}} {{16-18=as!}}
+  _ = plainObj as CopyableNSObject // expected-error {{'NSObject' is not convertible to 'CopyableNSObject' (aka 'NSCopying'); did you mean to use 'as!' to force downcast?}} {{16-18=as!}}
   _ = plainCell as CopyableSomeCell // FIXME: This is not really typesafe.
 }
 

--- a/test/Compatibility/nsobjectprotocol.swift
+++ b/test/Compatibility/nsobjectprotocol.swift
@@ -1,0 +1,16 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: objc_interop
+
+import ObjectiveC
+import Foundation
+
+class X: NSObjectProtocol { } // expected-warning{{'NSObjectProtocol' is deprecated: all classes implicitly conform to the 'NSObject' protocol}}
+// expected-note@-1{{use 'AnyObject' instead}}
+// expected-warning@-2{{conformance of class 'X' to 'AnyObject' is redundant}}
+
+protocol P: NSObjectProtocol { } // expected-warning{{'NSObjectProtocol' is deprecated: all classes implicitly conform to the 'NSObject' protocol}}
+// expected-note@-1{{use 'AnyObject' instead}}
+
+func composition(_: NSCoding & NSObjectProtocol) { } // expected-warning{{'NSObjectProtocol' is deprecated: all classes implicitly conform to the 'NSObject' protocol}}
+// expected-note@-1{{use 'AnyObject' instead}}
+

--- a/test/Compatibility/nsobjectprotocol.swift
+++ b/test/Compatibility/nsobjectprotocol.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -swift-version 3
+// RUN: %target-typecheck-verify-swift -swift-version 4
 // REQUIRES: objc_interop
 
 import ObjectiveC

--- a/test/IDE/dump_swift_lookup_tables_objc.swift
+++ b/test/IDE/dump_swift_lookup_tables_objc.swift
@@ -14,10 +14,11 @@
 // CHECK-NOT: lookup table
 // CHECK:   NSObject:
 // CHECK-NEXT:     TU: NSObject
-// CHECK-NEXT:   NSObjectProtocol:
+// CHECK:   __NSObjectProtocol:
 // CHECK-NEXT:     TU: NSObject
 // CHECK:   responds:
 // CHECK-NEXT:     -[NSObject respondsToSelector:]
+
 
 // CHECK-LABEL: <<Bridging header lookup table>>
 // CHECK-NEXT:      Base name -> entry mappings:

--- a/test/IDE/importProtocols.swift
+++ b/test/IDE/importProtocols.swift
@@ -3,7 +3,7 @@
 
 // REQUIRES: objc_interop
 
-// CHECK: protocol ImportedProtocolBase : NSObjectProtocol {
+// CHECK: protocol ImportedProtocolBase {
 // CHECK: }
 // CHECK: typealias ImportedProtocolBase_t = ImportedProtocolBase
 // CHECK: protocol IPSub : ImportedProtocolBase {

--- a/test/IDE/print_clang_ObjectiveC.swift
+++ b/test/IDE/print_clang_ObjectiveC.swift
@@ -13,13 +13,13 @@
 // NEGATIVE-WITHOUT-FORWARD-DECLS-NOT: var description
 // NEGATIVE-NOT: NSCoder
 
-// CHECK-LABEL: protocol NSObjectProtocol {
+// CHECK-LABEL: protocol __NSObjectProtocol {
 // CHECK-DAG: var superclass: AnyClass? { get }
 // CHECK-DAG: func zone() -> NSZone
 // CHECK-WITH-FORWARD-DECLS-DAG: var description: String { get }
 // CHECK: {{^[}]$}}
 
-// CHECK-LABEL: class NSObject : NSObjectProtocol {
+// CHECK-LABEL: class NSObject {
 // CHECK-DAG: func copy() -> Any
 // CHECK-DAG: class func hash() -> Int
 // CHECK-WITH-FORWARD-DECLS-DAG: class func description() -> String

--- a/test/IDE/print_omit_needless_words.swift
+++ b/test/IDE/print_omit_needless_words.swift
@@ -140,7 +140,7 @@
 // CHECK-FOUNDATION: func doSomething(with: NSCopying)
 
 // Note: NSObject<Proto> treated as "Proto".
-// CHECK-FOUNDATION: func doSomethingElse(with: NSCopying & NSObjectProtocol)
+// CHECK-FOUNDATION: func doSomethingElse(with: NSCopying)
 
 // Note: Function type -> "Function".
 // CHECK-FOUNDATION: func sort(_: @escaping @convention(c) (Any, Any) -> Int)

--- a/test/Inputs/clang-importer-sdk/swift-modules-without-ns/ObjectiveC.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules-without-ns/ObjectiveC.swift
@@ -82,3 +82,7 @@ extension NSObject : Equatable, Hashable {
 public func == (lhs: NSObject, rhs: NSObject) -> Bool {
   return lhs.isEqual(rhs)
 }
+
+@available(*, deprecated, renamed: "AnyObject",
+           message: "all classes implicitly conform to the 'NSObject' protocol")
+public typealias NSObjectProtocol = AnyObject

--- a/test/Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/ObjectiveC.swift
@@ -96,3 +96,7 @@ extension NSObject : Equatable, Hashable {
 public func == (lhs: NSObject, rhs: NSObject) -> Bool {
   return lhs.isEqual(rhs)
 }
+
+@available(*, deprecated, renamed: "AnyObject",
+           message: "all classes implicitly conform to the 'NSObject' protocol")
+public typealias NSObjectProtocol = AnyObject

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -89,13 +89,13 @@ class ClassWithCustomName2 {}
 class ClassWithCustomNameSub : ClassWithCustomName {}
 
 
-// CHECK-LABEL: @interface ClassWithNSObjectProtocol <NSObject>
+// CHECK-LABEL: @interface ClassWithNSObjectProtocol
 // CHECK-NEXT: @property (nonatomic, readonly, copy) NSString * _Nonnull description;
 // CHECK-NEXT: - (BOOL)conformsToProtocol:(Protocol * _Nonnull)_ SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (BOOL)isKindOfClass:(Class _Nonnull)aClass SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: - (nonnull instancetype)init OBJC_DESIGNATED_INITIALIZER;
 // CHECK-NEXT: @end
-@objc class ClassWithNSObjectProtocol : NSObjectProtocol {
+@objc class ClassWithNSObjectProtocol {
   @objc var description: String { return "me" }
   @objc(conformsToProtocol:)
   func conforms(to _: Protocol) -> Bool { return false }
@@ -355,9 +355,9 @@ typealias AliasForNSRect = NSRect
 // NEGATIVE-NOT: @interface NSObject
 class MyObject : NSObject {}
 
-// CHECK-LABEL: @protocol MyProtocol <NSObject>
+// CHECK-LABEL: @protocol MyProtocol
 // CHECK-NEXT: @end
-@objc protocol MyProtocol : NSObjectProtocol {}
+@objc protocol MyProtocol {}
 
 // CHECK-LABEL: @protocol MyProtocolMetaOnly;
 // CHECK-LABEL: @interface MyProtocolMetaCheck
@@ -521,7 +521,6 @@ public class NonObjCClass { }
 // CHECK-NEXT: @property (nonatomic, copy) IBOutletCollection(Properties) NSArray<Properties *> * _Null_unspecified outletCollection;
 // CHECK-NEXT: @property (nonatomic, copy) IBOutletCollection(CustomName) NSArray<CustomName *> *  _Nullable outletCollectionOptional;
 // CHECK-NEXT: @property (nonatomic, copy) IBOutletCollection(id) NSArray * _Nullable outletCollectionAnyObject;
-// CHECK-NEXT: @property (nonatomic, copy) IBOutletCollection(id) NSArray<id <NSObject>> * _Nullable outletCollectionProto;
 // CHECK-NEXT: SWIFT_CLASS_PROPERTY(@property (nonatomic, class, readonly) NSInteger staticInt;)
 // CHECK-NEXT: + (NSInteger)staticInt SWIFT_WARN_UNUSED_RESULT;
 // CHECK-NEXT: SWIFT_CLASS_PROPERTY(@property (nonatomic, class, copy) NSString * _Nonnull staticString;)
@@ -614,7 +613,6 @@ public class NonObjCClass { }
   @IBOutlet var outletCollection: [Properties]!
   @IBOutlet var outletCollectionOptional: [ClassWithCustomName]? = []
   @IBOutlet var outletCollectionAnyObject: [AnyObject]?
-  @IBOutlet var outletCollectionProto: [NSObjectProtocol]?
 
   @objc static let staticInt = 2
   @objc static var staticString = "Hello"

--- a/test/stdlib/RuntimeObjC.swift
+++ b/test/stdlib/RuntimeObjC.swift
@@ -695,8 +695,8 @@ Reflection.test("MetatypeMirror") {
     dump(compositionConcreteMetatype, to: &output)
     expectEqual(expectedComposition, output)
     
-    let objcDefinedProtoType = NSObjectProtocol.self
-    expectEqual(String(describing: objcDefinedProtoType), "NSObject")
+    let objcDefinedProtoType = NSCoding.self
+    expectEqual(String(describing: objcDefinedProtoType), "NSCoding")
   }
 }
 


### PR DESCRIPTION
Stop importing the Objective-C protocol `NSObject` into Swift
programs, because it causes more harm than good. Specifically, with
this change:

* The `NSObjectProtocol` protocol itself is not visible to Swift
  programs.
* `NSObjectProtocol` is dropped from the inheritance list of any
  imported Objective-C protocol, e.g., `UITableViewDelegate` will not
  mention `NSObjectProtocol` in its inherited protocols.
* `NSObjectProtocol` is removed from the list of protocols to which an
  imported Objective-C class conforms (e.g., the imported class
  `NSObject` will no longer state its conformance to
  `NSObjectProtocol`).
* Qualified types in Objective-C will drop the `NSObject` protocol on
  import, e.g., an Objective-C type `id<NSCopying, NSObject>` will be
  imported as `NSCopying` rather than `NSCopying &
  NSObjectProtocol`. The type `id<NSObject>` will simply be imported
  as `AnyObject`.
* Introduce a deprecated type alias into the ObjectiveC module overlay
  to ease transition:
   ```swift
  public typealias NSObjectProtocol = AnyObject
  ```
