### PR TITLE
Add ConstraintSystem::dump(Expr *).

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -566,8 +566,22 @@ public:
   LLVM_ATTRIBUTE_DEPRECATED(
       void dump() const LLVM_ATTRIBUTE_USED,
       "only for use within the debugger");
+  LLVM_ATTRIBUTE_DEPRECATED(
+      void dump(llvm::function_ref<Type(const Expr *)> getType,
+                llvm::function_ref<Type(const TypeLoc &)> getTypeOfTypeLoc)
+          const LLVM_ATTRIBUTE_USED,
+      "only for use within the debugger");
+  LLVM_ATTRIBUTE_DEPRECATED(
+      void dump(raw_ostream &OS, llvm::function_ref<Type(const Expr *)> getType,
+                llvm::function_ref<Type(const TypeLoc &)> getTypeOfTypeLoc)
+          const LLVM_ATTRIBUTE_USED,
+      "only for use within the debugger");
+
   void dump(raw_ostream &OS) const;
   void print(raw_ostream &OS, unsigned Indent = 0) const;
+  void print(raw_ostream &OS, llvm::function_ref<Type(const Expr *)> getType,
+             llvm::function_ref<Type(const TypeLoc &)> getTypeOfTypeLoc,
+             unsigned Indent = 0) const;
   void print(ASTPrinter &Printer, const PrintOptions &Opts) const;
 
   // Only allow allocation of Exprs using the allocator in ASTContext

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1380,9 +1380,15 @@ ConstraintSystem::solve(Expr *&expr,
   }
 
   if (TC.getLangOpts().DebugConstraintSolver) {
+    auto getTypeOfExpr = [&](const Expr *E) -> Type { return getType(E); };
+    auto getTypeOfTypeLoc = [&](const TypeLoc &TL) -> Type {
+      return getType(TL);
+    };
+
     auto &log = getASTContext().TypeCheckerDebug->getStream();
     log << "---Initial constraints for the given expression---\n";
-    expr->print(log);
+
+    expr->print(log, getTypeOfExpr, getTypeOfTypeLoc);
     log << "\n";
     print(log);
   }

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3101,6 +3101,9 @@ public:
   LLVM_ATTRIBUTE_DEPRECATED(
       void dump() LLVM_ATTRIBUTE_USED,
       "only for use within the debugger");
+  LLVM_ATTRIBUTE_DEPRECATED(void dump(Expr *) LLVM_ATTRIBUTE_USED,
+                            "only for use within the debugger");
+
   void print(raw_ostream &out);
 };
 

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3118,6 +3118,15 @@ void ConstraintSystem::dump() {
   print(llvm::errs());
 }
 
+void ConstraintSystem::dump(Expr *E) {
+  auto getTypeOfExpr = [&](const Expr *E) -> Type { return getType(E); };
+  auto getTypeOfTypeLoc = [&](const TypeLoc &TL) -> Type {
+    return getType(TL);
+  };
+
+  E->dump(getTypeOfExpr, getTypeOfTypeLoc);
+}
+
 void ConstraintSystem::print(raw_ostream &out) {
   // Print all type variables as $T0 instead of _ here.
   llvm::SaveAndRestore<bool> X(getASTContext().LangOpts.DebugConstraintSolver,


### PR DESCRIPTION
Add dumpers to dump from the constraint system type cache.

There isn't a TypeLoc dumper per-se, but the places where we dump
TypeLocs in expression dumping will read the type from the cache.
