### PR TITLE
Revert "IRGen: fix alignment for tail allocated arrays with elements which have a large alignment"

### DIFF
--- a/lib/IRGen/GenClass.h
+++ b/lib/IRGen/GenClass.h
@@ -95,12 +95,10 @@ namespace irgen {
   typedef llvm::ArrayRef<std::pair<SILType, llvm::Value *>> TailArraysRef;
 
   /// Adds the size for tail allocated arrays to \p size and returns the new
-  /// size value. Also updades the alignment mask to represent the alignment of
-  /// the largest element.
-  std::pair<llvm::Value *, llvm::Value *>
-  appendSizeForTailAllocatedArrays(IRGenFunction &IGF,
-                                   llvm::Value *size, llvm::Value *alignMask,
-                                   TailArraysRef TailArrays);
+  /// size value.
+  llvm::Value *appendSizeForTailAllocatedArrays(IRGenFunction &IGF,
+                                                llvm::Value *size,
+                                                TailArraysRef TailArrays);
 
   /// Emit an allocation of a class.
   /// The \p StackAllocSize is an in- and out-parameter. The passed value

--- a/test/IRGen/tail_alloc.sil
+++ b/test/IRGen/tail_alloc.sil
@@ -95,8 +95,7 @@ bb0(%c1 : $Builtin.Word, %c2 : $Builtin.Word):
 // CHECK-NEXT: [[S3:%[0-9]+]] = and i64 [[S1]], [[S2]]
 // CHECK-NEXT: [[S4:%[0-9]+]] = mul i64 %stride, %0
 // CHECK-NEXT: [[S5:%[0-9]+]] = add i64 [[S3]], [[S4]]
-// CHECK-NEXT: [[A:%[0-9]+]] = or i64 7, %flags.alignmentMask
-// CHECK:      call noalias %swift.refcounted* @swift_allocObject(%swift.type* %{{[0-9]+}}, i64 [[S5]], i64 [[A]])
+// CHECK:      call noalias %swift.refcounted* @swift_allocObject(%swift.type* %{{[0-9]+}}, i64 [[S5]], i64 7)
 // CHECK:      ret
 sil @alloc_generic : $@convention(thin) <T> (Builtin.Word, @thick T.Type) -> @owned TestClass {
 bb0(%0 : $Builtin.Word, %1 : $@thick T.Type):
@@ -111,15 +110,10 @@ bb0(%0 : $Builtin.Word, %1 : $@thick T.Type):
 // CHECK-NEXT: [[INT_PTR:%[0-9]+]] = bitcast i8* [[SIZE_ADDR]] to i32*
 // CHECK-NEXT: [[SIZE:%[0-9]+]] = load i32, i32* [[INT_PTR]]
 // CHECK-NEXT: [[SIZE64:%[0-9]+]] = zext i32 [[SIZE]] to i64
-// CHECK-NEXT: [[ALIGN_ADDR:%[0-9]+]] = getelementptr inbounds i8, i8* [[BYTE_PTR]], i32 52
-// CHECK-NEXT: [[SHORT_PTR:%[0-9]+]] = bitcast i8* [[ALIGN_ADDR]] to i16*
-// CHECK-NEXT: [[ALIGN:%[0-9]+]] = load i16, i16* [[SHORT_PTR]]
-// CHECK-NEXT: [[ALIGN64:%[0-9]+]] = zext i16 [[ALIGN]] to i64
-// CHECK-NEXT: [[ALIGN_TMP:%[0-9]+]] = add i64 [[SIZE64]], 3
+// CHECK:      [[ALIGN_TMP:%[0-9]+]] = add i64 [[SIZE64]], 3
 // CHECK-NEXT: [[ALIGNED:%[0-9]+]] = and i64 [[ALIGN_TMP]], -4
 // CHECK-NEXT: [[TOTAL_SIZE:%[0-9]+]] = add i64 [[ALIGNED]], 12
-// CHECK-NEXT: [[TOTAL_ALIGN:%[0-9]+]] = or i64 [[ALIGN64]], 3
-// CHECK-NEXT: [[O:%[0-9]+]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* %0, i64 [[TOTAL_SIZE]], i64 [[TOTAL_ALIGN]])
+// CHECK-NEXT: [[O:%[0-9]+]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* %0, i64 [[TOTAL_SIZE]], i64 {{.*}})
 // CHECK-NEXT: [[O2:%[0-9]+]] = bitcast %swift.refcounted* [[O]] to %{{.*TestClassC}}*
 // CHECK-NEXT:  ret %{{.*TestClassC}}* [[O2]]
 sil @alloc_dynamic : $@convention(thin) (@thick TestClass.Type) -> @owned TestClass {


### PR DESCRIPTION
Reverts apple/swift#14652

Based on https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-16_10/2703/, it seems like this might broken the stdlib/String.swift test on Linux.

What's curious is it passed PR testing, but two of my subsequent PR test attempts have failed in the same way. Perhaps this was a case of two commits landing at the same time, each passing individually but failing when combined?