### PR TITLE
[stdlib] Explicitly conform to Encodable & Decodable (NFC)

### DIFF
--- a/stdlib/public/core/Codable.swift.gyb
+++ b/stdlib/public/core/Codable.swift.gyb
@@ -1797,7 +1797,7 @@ internal final class _KeyedDecodingContainerBox<
 //===----------------------------------------------------------------------===//
 
 % for type in codable_types:
-extension ${type} : Codable {
+extension ${type} : Encodable, Decodable {
   /// Creates a new instance by decoding from the given decoder.
   ///
   /// This initializer throws an error if reading from the decoder fails, or


### PR DESCRIPTION
The stdlib codable types currently declare conformance to the type alias `Codable`, which is tricking some downstream systems. This switches the extensions to instead declare conformance to `Encodable` and `Decodable`, which has the same result on the types' conformance.
