### PR TITLE
[4.1] Fix allocation for types which have alignment > 16 bytes

### DIFF
--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -777,9 +777,10 @@ static llvm::Value *stackPromote(IRGenFunction &IGF,
   return Alloca.getAddress();
 }
 
-llvm::Value *irgen::appendSizeForTailAllocatedArrays(IRGenFunction &IGF,
-                                                     llvm::Value *size,
-                                                     TailArraysRef TailArrays) {
+std::pair<llvm::Value *, llvm::Value *>
+irgen::appendSizeForTailAllocatedArrays(IRGenFunction &IGF,
+                                    llvm::Value *size, llvm::Value *alignMask,
+                                    TailArraysRef TailArrays) {
   for (const auto &TailArray : TailArrays) {
     SILType ElemTy = TailArray.first;
     llvm::Value *Count = TailArray.second;
@@ -788,16 +789,17 @@ llvm::Value *irgen::appendSizeForTailAllocatedArrays(IRGenFunction &IGF,
 
     // Align up to the tail-allocated array.
     llvm::Value *ElemStride = ElemTI.getStride(IGF, ElemTy);
-    llvm::Value *AlignMask = ElemTI.getAlignmentMask(IGF, ElemTy);
-    size = IGF.Builder.CreateAdd(size, AlignMask);
-    llvm::Value *InvertedMask = IGF.Builder.CreateNot(AlignMask);
+    llvm::Value *ElemAlignMask = ElemTI.getAlignmentMask(IGF, ElemTy);
+    size = IGF.Builder.CreateAdd(size, ElemAlignMask);
+    llvm::Value *InvertedMask = IGF.Builder.CreateNot(ElemAlignMask);
     size = IGF.Builder.CreateAnd(size, InvertedMask);
 
     // Add the size of the tail allocated array.
     llvm::Value *AllocSize = IGF.Builder.CreateMul(ElemStride, Count);
     size = IGF.Builder.CreateAdd(size, AllocSize);
+    alignMask = IGF.Builder.CreateOr(alignMask, ElemAlignMask);
   }
-  return size;
+  return {size, alignMask};
 }
 
 
@@ -838,7 +840,8 @@ llvm::Value *irgen::emitClassAllocation(IRGenFunction &IGF, SILType selfType,
     val = IGF.emitInitStackObjectCall(metadata, val, "reference.new");
   } else {
     // Allocate the object on the heap.
-    size = appendSizeForTailAllocatedArrays(IGF, size, TailArrays);
+    std::tie(size, alignMask)
+      = appendSizeForTailAllocatedArrays(IGF, size, alignMask, TailArrays);
     val = IGF.emitAllocObjectCall(metadata, size, alignMask, "reference.new");
     StackAllocSize = -1;
   }
@@ -861,7 +864,8 @@ llvm::Value *irgen::emitClassAllocationDynamic(IRGenFunction &IGF,
     = emitClassResilientInstanceSizeAndAlignMask(IGF,
                                    selfType.getClassOrBoundGenericClass(),
                                    metadata);
-  size = appendSizeForTailAllocatedArrays(IGF, size, TailArrays);
+  std::tie(size, alignMask)
+    = appendSizeForTailAllocatedArrays(IGF, size, alignMask, TailArrays);
 
   llvm::Value *val = IGF.emitAllocObjectCall(metadata, size, alignMask,
                                              "reference.new");

--- a/lib/IRGen/GenClass.h
+++ b/lib/IRGen/GenClass.h
@@ -95,10 +95,12 @@ namespace irgen {
   typedef llvm::ArrayRef<std::pair<SILType, llvm::Value *>> TailArraysRef;
 
   /// Adds the size for tail allocated arrays to \p size and returns the new
-  /// size value.
-  llvm::Value *appendSizeForTailAllocatedArrays(IRGenFunction &IGF,
-                                                llvm::Value *size,
-                                                TailArraysRef TailArrays);
+  /// size value. Also updades the alignment mask to represent the alignment of
+  /// the largest element.
+  std::pair<llvm::Value *, llvm::Value *>
+  appendSizeForTailAllocatedArrays(IRGenFunction &IGF,
+                                   llvm::Value *size, llvm::Value *alignMask,
+                                   TailArraysRef TailArrays);
 
   /// Emit an allocation of a class.
   /// The \p StackAllocSize is an in- and out-parameter. The passed value

--- a/stdlib/public/runtime/Heap.cpp
+++ b/stdlib/public/runtime/Heap.cpp
@@ -24,13 +24,12 @@ using namespace swift;
 
 void *swift::swift_slowAlloc(size_t size, size_t alignMask)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
-  // FIXME: use posix_memalign if alignMask is larger than the system guarantee.
-  void *p = malloc(size);
+  void *p = AlignedAlloc(size, alignMask + 1);
   if (!p) swift::crash("Could not allocate memory.");
   return p;
 }
 
 void swift::swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
-  free(ptr);
+  AlignedFree(ptr);
 }

--- a/stdlib/public/runtime/Heap.cpp
+++ b/stdlib/public/runtime/Heap.cpp
@@ -18,18 +18,55 @@
 #include "swift/Runtime/Heap.h"
 #include "Private.h"
 #include "swift/Runtime/Debug.h"
+#include <algorithm>
 #include <stdlib.h>
 
 using namespace swift;
 
+#if defined(__APPLE__)
+// Apple malloc is always 16-byte aligned.
+#  define MALLOC_ALIGN_MASK 15
+
+#elif defined(__linux__)
+// Linux malloc is 16-byte aligned on 64-bit, and 8-byte aligned on 32-bit.
+#  if defined(__LP64)
+#    define MALLOC_ALIGN_MASK 15
+#  else
+#    define MALLOC_ALIGN_MASK 7
+#  endif
+
+#elif defined(_WIN64)
+// Windows malloc is 16-byte aligned on 64-bit and 8-byte aligned on 32-bit.
+#  define MALLOC_ALIGN_MASK 15
+#elif defined(_WIN32)
+#  define MALLOC_ALIGN_MASK 7
+
+#else
+// Unknown alignment, but the standard requires alignment suitable for the largest
+// standard types.
+#  define MALLOC_ALIGN_MASK std::max(alignof(void *), alignof(double))
+
+#endif
+
+
+
 void *swift::swift_slowAlloc(size_t size, size_t alignMask)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
-  void *p = AlignedAlloc(size, alignMask + 1);
+  void *p;
+  if (alignMask <= MALLOC_ALIGN_MASK) {
+    p = malloc(size);
+  } else {
+    p = AlignedAlloc(size, alignMask + 1);
+  }
   if (!p) swift::crash("Could not allocate memory.");
   return p;
 }
 
 void swift::swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask)
     SWIFT_CC(RegisterPreservingCC_IMPL) {
-  AlignedFree(ptr);
+  if (alignMask <= MALLOC_ALIGN_MASK) {
+    free(ptr);
+  } else {
+    AlignedFree(ptr);
+  }
 }

--- a/test/IRGen/tail_alloc.sil
+++ b/test/IRGen/tail_alloc.sil
@@ -95,7 +95,8 @@ bb0(%c1 : $Builtin.Word, %c2 : $Builtin.Word):
 // CHECK-NEXT: [[S3:%[0-9]+]] = and i64 [[S1]], [[S2]]
 // CHECK-NEXT: [[S4:%[0-9]+]] = mul i64 %stride, %0
 // CHECK-NEXT: [[S5:%[0-9]+]] = add i64 [[S3]], [[S4]]
-// CHECK:      call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* %{{[0-9]+}}, i64 [[S5]], i64 7)
+// CHECK-NEXT: [[A:%[0-9]+]] = or i64 7, %flags.alignmentMask
+// CHECK:      call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* %{{[0-9]+}}, i64 [[S5]], i64 [[A]])
 // CHECK:      ret
 sil @alloc_generic : $@convention(thin) <T> (Builtin.Word, @thick T.Type) -> @owned TestClass {
 bb0(%0 : $Builtin.Word, %1 : $@thick T.Type):
@@ -110,10 +111,15 @@ bb0(%0 : $Builtin.Word, %1 : $@thick T.Type):
 // CHECK-NEXT: [[INT_PTR:%[0-9]+]] = bitcast i8* [[SIZE_ADDR]] to i32*
 // CHECK-NEXT: [[SIZE:%[0-9]+]] = load i32, i32* [[INT_PTR]]
 // CHECK-NEXT: [[SIZE64:%[0-9]+]] = zext i32 [[SIZE]] to i64
-// CHECK:      [[ALIGN_TMP:%[0-9]+]] = add i64 [[SIZE64]], 3
+// CHECK-NEXT: [[ALIGN_ADDR:%[0-9]+]] = getelementptr inbounds i8, i8* [[BYTE_PTR]], i32 52
+// CHECK-NEXT: [[SHORT_PTR:%[0-9]+]] = bitcast i8* [[ALIGN_ADDR]] to i16*
+// CHECK-NEXT: [[ALIGN:%[0-9]+]] = load i16, i16* [[SHORT_PTR]]
+// CHECK-NEXT: [[ALIGN64:%[0-9]+]] = zext i16 [[ALIGN]] to i64
+// CHECK-NEXT: [[ALIGN_TMP:%[0-9]+]] = add i64 [[SIZE64]], 3
 // CHECK-NEXT: [[ALIGNED:%[0-9]+]] = and i64 [[ALIGN_TMP]], -4
 // CHECK-NEXT: [[TOTAL_SIZE:%[0-9]+]] = add i64 [[ALIGNED]], 12
-// CHECK-NEXT: [[O:%[0-9]+]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* %0, i64 [[TOTAL_SIZE]], i64 {{.*}})
+// CHECK-NEXT: [[TOTAL_ALIGN:%[0-9]+]] = or i64 [[ALIGN64]], 3
+// CHECK-NEXT: [[O:%[0-9]+]] = call noalias %swift.refcounted* @swift_rt_swift_allocObject(%swift.type* %0, i64 [[TOTAL_SIZE]], i64 [[TOTAL_ALIGN]])
 // CHECK-NEXT: [[O2:%[0-9]+]] = bitcast %swift.refcounted* [[O]] to %{{.*TestClassC}}*
 // CHECK-NEXT:  ret %{{.*TestClassC}}* [[O2]]
 sil @alloc_dynamic : $@convention(thin) (@thick TestClass.Type) -> @owned TestClass {


### PR DESCRIPTION
The fix consists of 2 parts:
* [Runtime] Fix swift_slowAlloc to respect its alignMask parameter.
    rdar://problem/22975669
* IRGen: fix alignment for tail allocated arrays with elements which have a large alignment
    rdar://problem/37470003

