### PR TITLE
[4.1] [Sema] Disallow conditional conformances on objective-c generics.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1420,6 +1420,10 @@ ERROR(objc_runtime_visible_cannot_conform_to_objc_protocol,none,
       "class %0 cannot conform to @objc protocol %1 because "
       "the class is only visible via the Objective-C runtime",
       (Type, Type))
+ERROR(objc_generics_cannot_conditionally_conform,none,
+      "type %0 cannot conditionally conform to protocol %1 because "
+      "the type uses the Objective-C generics model",
+      (Type, Type))
 ERROR(protocol_has_missing_requirements,none,
       "type %0 cannot conform to protocol %1 because it has requirements that "
       "cannot be satisfied", (Type, Type))

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1313,6 +1313,27 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
     }
   }
 
+  // Not every protocol/type is compatible with conditional conformances.
+  if (!conformance->getConditionalRequirements().empty()) {
+    auto nestedType = canT;
+    // Obj-C generics cannot be looked up at runtime, so we don't support
+    // conditional conformances involving them. Check the full stack of nested
+    // types for any obj-c ones.
+    while (nestedType) {
+      if (auto clas = nestedType->getClassOrBoundGenericClass()) {
+        if (clas->usesObjCGenericsModel()) {
+          TC.diagnose(ComplainLoc,
+                      diag::objc_generics_cannot_conditionally_conform, T,
+                      Proto->getDeclaredType());
+          conformance->setInvalid();
+          return conformance;
+        }
+      }
+
+      nestedType = nestedType.getNominalParent();
+    }
+  }
+
   // If the protocol contains missing requirements, it can't be conformed to
   // at all.
   if (Proto->hasMissingRequirements()) {

--- a/test/Generics/Inputs/conditional_conformances_objc.h
+++ b/test/Generics/Inputs/conditional_conformances_objc.h
@@ -1,0 +1,7 @@
+@import Foundation;
+
+@interface ObjC <ObjectType>: NSObject
+@end
+
+@interface ObjC2: NSObject
+@end

--- a/test/Generics/conditional_conformances_objc.swift
+++ b/test/Generics/conditional_conformances_objc.swift
@@ -1,0 +1,34 @@
+// RUN: %target-typecheck-verify-swift -import-objc-header %S/Inputs/conditional_conformances_objc.h
+
+// REQUIRES: objc_interop
+
+protocol Foo {}
+extension ObjC: Foo where ObjectType == ObjC2 {}
+// expected-error@-1{{type 'ObjC<ObjectType>' cannot conditionally conform to protocol 'Foo' because the type uses the Objective-C generics model}}
+
+protocol Bar {}
+extension ObjC: Bar where ObjectType: Bar {}
+// expected-error@-1{{type 'ObjC<ObjectType>' cannot conditionally conform to protocol 'Bar' because the type uses the Objective-C generics model}}
+
+extension ObjC {
+    struct Struct {
+        enum Enum {}
+    }
+    class Class<T> {}
+}
+
+extension ObjC.Struct: Foo where ObjectType == ObjC2 {}
+// expected-error@-1{{type 'ObjC<ObjectType>.Struct' cannot conditionally conform to protocol 'Foo' because the type uses the Objective-C generics model}}
+extension ObjC.Struct: Bar where ObjectType: Bar {}
+// expected-error@-1{{type 'ObjC<ObjectType>.Struct' cannot conditionally conform to protocol 'Bar' because the type uses the Objective-C generics model}}
+
+extension ObjC.Struct.Enum: Foo where ObjectType == ObjC2 {}
+// expected-error@-1{{type 'ObjC<ObjectType>.Struct.Enum' cannot conditionally conform to protocol 'Foo' because the type uses the Objective-C generics model}}
+extension ObjC.Struct.Enum: Bar where ObjectType: Bar {}
+// expected-error@-1{{type 'ObjC<ObjectType>.Struct.Enum' cannot conditionally conform to protocol 'Bar' because the type uses the Objective-C generics model}}
+
+extension ObjC.Class: Foo where T == ObjC2 {}
+// expected-error@-1{{type 'ObjC<ObjectType>.Class<T>' cannot conditionally conform to protocol 'Foo' because the type uses the Objective-C generics model}}
+extension ObjC.Class: Bar where T: Bar {}
+// expected-error@-1{{type 'ObjC<ObjectType>.Class<T>' cannot conditionally conform to protocol 'Bar' because the type uses the Objective-C generics model}}
+


### PR DESCRIPTION
• Explanation: Dynamic casts to existentials (i.e. given `x: Any`, `x as SomeProtocol`) requires looking up type information for conditional conformances to validate the requirements(i.e. if `x` is a `Foo<Bar>` where `extension Foo: SomeProtocol where T == Int`, then the cast above requires checking (and failing, in this case) that `T == Bar == Int`), and these look-ups can only happen dynamically. Metadata about the types used in objective-C generics doesn't exist at runtime and so the look-ups are impossible. We want to keep the static and dynamic type systems the same, so we have to outlaw such conditional conformances.
• Scope of Issue: Only code trying to conditionally conform a protocol to an objective-c generic type is affected, and 4.1 is the first release including conditional conformances.  
• Origination: Only recently realised that this is a consequence of conditional conformances.
• Risk: Low: small change to unreleased feature.
• Reviewed By: @DougGregor
• Testing: Compiler regression tests
• Radar / SR: rdar://problem/37524969

https://github.com/apple/swift/pull/14628