### PR TITLE
[5.0] [Sema] Disallow conditional conformances on objective-c generics.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1423,6 +1423,10 @@ ERROR(objc_runtime_visible_cannot_conform_to_objc_protocol,none,
       "class %0 cannot conform to @objc protocol %1 because "
       "the class is only visible via the Objective-C runtime",
       (Type, Type))
+ERROR(objc_generics_cannot_conditionally_conform,none,
+      "type %0 cannot conditionally conform to protocol %1 because "
+      "the type uses the Objective-C generics model",
+      (Type, Type))
 ERROR(protocol_has_missing_requirements,none,
       "type %0 cannot conform to protocol %1 because it has requirements that "
       "cannot be satisfied", (Type, Type))

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1313,6 +1313,27 @@ checkIndividualConformance(NormalProtocolConformance *conformance,
     }
   }
 
+  // Not every protocol/type is compatible with conditional conformances.
+  if (!conformance->getConditionalRequirements().empty()) {
+    auto nestedType = canT;
+    // Obj-C generics cannot be looked up at runtime, so we don't support
+    // conditional conformances involving them. Check the full stack of nested
+    // types for any obj-c ones.
+    while (nestedType) {
+      if (auto clas = nestedType->getClassOrBoundGenericClass()) {
+        if (clas->usesObjCGenericsModel()) {
+          TC.diagnose(ComplainLoc,
+                      diag::objc_generics_cannot_conditionally_conform, T,
+                      Proto->getDeclaredType());
+          conformance->setInvalid();
+          return conformance;
+        }
+      }
+
+      nestedType = nestedType.getNominalParent();
+    }
+  }
+
   // If the protocol contains missing requirements, it can't be conformed to
   // at all.
   if (Proto->hasMissingRequirements()) {

--- a/test/Generics/Inputs/conditional_conformances_objc.h
+++ b/test/Generics/Inputs/conditional_conformances_objc.h
@@ -1,0 +1,7 @@
+@import Foundation;
+
+@interface ObjC <ObjectType>: NSObject
+@end
+
+@interface ObjC2: NSObject
+@end

--- a/test/Generics/conditional_conformances_objc.swift
+++ b/test/Generics/conditional_conformances_objc.swift
@@ -1,0 +1,34 @@
+// RUN: %target-typecheck-verify-swift -import-objc-header %S/Inputs/conditional_conformances_objc.h
+
+// REQUIRES: objc_interop
+
+protocol Foo {}
+extension ObjC: Foo where ObjectType == ObjC2 {}
+// expected-error@-1{{type 'ObjC<ObjectType>' cannot conditionally conform to protocol 'Foo' because the type uses the Objective-C generics model}}
+
+protocol Bar {}
+extension ObjC: Bar where ObjectType: Bar {}
+// expected-error@-1{{type 'ObjC<ObjectType>' cannot conditionally conform to protocol 'Bar' because the type uses the Objective-C generics model}}
+
+extension ObjC {
+    struct Struct {
+        enum Enum {}
+    }
+    class Class<T> {}
+}
+
+extension ObjC.Struct: Foo where ObjectType == ObjC2 {}
+// expected-error@-1{{type 'ObjC<ObjectType>.Struct' cannot conditionally conform to protocol 'Foo' because the type uses the Objective-C generics model}}
+extension ObjC.Struct: Bar where ObjectType: Bar {}
+// expected-error@-1{{type 'ObjC<ObjectType>.Struct' cannot conditionally conform to protocol 'Bar' because the type uses the Objective-C generics model}}
+
+extension ObjC.Struct.Enum: Foo where ObjectType == ObjC2 {}
+// expected-error@-1{{type 'ObjC<ObjectType>.Struct.Enum' cannot conditionally conform to protocol 'Foo' because the type uses the Objective-C generics model}}
+extension ObjC.Struct.Enum: Bar where ObjectType: Bar {}
+// expected-error@-1{{type 'ObjC<ObjectType>.Struct.Enum' cannot conditionally conform to protocol 'Bar' because the type uses the Objective-C generics model}}
+
+extension ObjC.Class: Foo where T == ObjC2 {}
+// expected-error@-1{{type 'ObjC<ObjectType>.Class<T>' cannot conditionally conform to protocol 'Foo' because the type uses the Objective-C generics model}}
+extension ObjC.Class: Bar where T: Bar {}
+// expected-error@-1{{type 'ObjC<ObjectType>.Class<T>' cannot conditionally conform to protocol 'Bar' because the type uses the Objective-C generics model}}
+


### PR DESCRIPTION
There's no way to look up information about objective-c generic
parameters, meaning the runtime cannot check same-type constraints or
conformance requirements, so dynamic casts cannot work. We want to keep
the static and dynamic systems the same, so we have to disable this
functionality from the start (i.e. no conditional conformances on
objective-c types :( ).

Fixes rdar://problem/37524969.

5.0 of https://github.com/apple/swift/pull/14628