### PR TITLE
Don't print AST if-clauses when emitting SIL.

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -465,6 +465,7 @@ struct PrintOptions {
     result.PrintForSIL = true;
     result.PrintInSILBody = true;
     result.PreferTypeRepr = false;
+    result.PrintIfConfig = false;
     return result;
   }
 

--- a/test/SIL/if_clause_printing.swift
+++ b/test/SIL/if_clause_printing.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -emit-sil %s | %FileCheck %s
+
+// Check that we don't crash when trying to print an inactive if-clause.
+
+// CHECK:      struct TestStruct
+// CHECK-NEXT:   internal enum TheRealOne
+// CHECK-NEXT:     case B
+
+struct TestStruct {
+#if abc
+  internal enum Unused {
+    case A(AnyObject)
+  }
+#else
+  internal enum TheRealOne {
+    case B(AnyObject)
+  }
+#endif
+}
+


### PR DESCRIPTION
This crashed while emitting the SIL of the stdlib build.
