### PR TITLE
[ClangImporter] If a submodule named 'Private' is missing, ask Clang

### DIFF
--- a/lib/Sema/NameBinding.cpp
+++ b/lib/Sema/NameBinding.cpp
@@ -198,7 +198,13 @@ void NameBinder::addImport(
     // If we imported a submodule, import the top-level module as well.
     Identifier topLevelName = ID->getModulePath().front().first;
     topLevelModule = Context.getLoadedModule(topLevelName);
-    assert(topLevelModule && "top-level module missing");
+    if (!topLevelModule) {
+      // Clang can sometimes import top-level modules as if they were
+      // submodules.
+      assert(!M->getFiles().empty() &&
+             isa<ClangModuleUnit>(M->getFiles().front()));
+      topLevelModule = M;
+    }
   }
 
   auto *testableAttr = ID->getAttrs().getAttribute<TestableAttr>();

--- a/test/ClangImporter/Inputs/frameworks/PrivateAsParallel.framework/Headers/PrivateAsParallel.h
+++ b/test/ClangImporter/Inputs/frameworks/PrivateAsParallel.framework/Headers/PrivateAsParallel.h
@@ -1,0 +1,1 @@
+extern int PPGlobal;

--- a/test/ClangImporter/Inputs/frameworks/PrivateAsParallel.framework/Modules/module.modulemap
+++ b/test/ClangImporter/Inputs/frameworks/PrivateAsParallel.framework/Modules/module.modulemap
@@ -1,0 +1,7 @@
+framework module PrivateAsParallel {
+  umbrella header "PrivateAsParallel.h"
+  export *
+  module * {
+    export *
+  }
+}

--- a/test/ClangImporter/Inputs/frameworks/PrivateAsParallel.framework/Modules/module.private.modulemap
+++ b/test/ClangImporter/Inputs/frameworks/PrivateAsParallel.framework/Modules/module.private.modulemap
@@ -1,0 +1,7 @@
+framework module PrivateAsParallel_Private {
+  umbrella header "PrivateAsParallel_Priv.h"
+  export *
+  module * {
+    export *
+  }
+}

--- a/test/ClangImporter/Inputs/frameworks/PrivateAsParallel.framework/PrivateHeaders/PrivateAsParallel_Priv.h
+++ b/test/ClangImporter/Inputs/frameworks/PrivateAsParallel.framework/PrivateHeaders/PrivateAsParallel_Priv.h
@@ -1,0 +1,2 @@
+#include <PrivateAsParallel/PrivateAsParallel.h>
+extern int PPPrivateGlobal;

--- a/test/ClangImporter/Inputs/frameworks/PrivateAsSubmodule.framework/Headers/PrivateAsSubmodule.h
+++ b/test/ClangImporter/Inputs/frameworks/PrivateAsSubmodule.framework/Headers/PrivateAsSubmodule.h
@@ -1,0 +1,1 @@
+extern int PSGlobal;

--- a/test/ClangImporter/Inputs/frameworks/PrivateAsSubmodule.framework/Modules/module.modulemap
+++ b/test/ClangImporter/Inputs/frameworks/PrivateAsSubmodule.framework/Modules/module.modulemap
@@ -1,0 +1,7 @@
+framework module PrivateAsSubmodule {
+  umbrella header "PrivateAsSubmodule.h"
+  export *
+  module * {
+    export *
+  }
+}

--- a/test/ClangImporter/Inputs/frameworks/PrivateAsSubmodule.framework/Modules/module.private.modulemap
+++ b/test/ClangImporter/Inputs/frameworks/PrivateAsSubmodule.framework/Modules/module.private.modulemap
@@ -1,0 +1,7 @@
+explicit module PrivateAsSubmodule.Private {
+  umbrella header "PrivateAsSubmodule_Priv.h"
+  export *
+  module * {
+    export *
+  }
+}

--- a/test/ClangImporter/Inputs/frameworks/PrivateAsSubmodule.framework/PrivateHeaders/PrivateAsSubmodule_Priv.h
+++ b/test/ClangImporter/Inputs/frameworks/PrivateAsSubmodule.framework/PrivateHeaders/PrivateAsSubmodule_Priv.h
@@ -1,0 +1,2 @@
+#include <PrivateAsSubmodule/PrivateAsSubmodule.h>
+extern int PSPrivateGlobal;

--- a/test/ClangImporter/private_frameworks_modules.swift
+++ b/test/ClangImporter/private_frameworks_modules.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -typecheck -F %S/Inputs/frameworks -DOLD -verify %s
+// RUN: %target-swift-frontend -typecheck -F %S/Inputs/frameworks -DNEW -verify %s
+
+import PrivateAsSubmodule.Private
+
+#if OLD
+import PrivateAsParallel.Private
+#elseif NEW
+import PrivateAsParallel_Private
+#else
+#error("OLD or NEW must be defined")
+#endif
+
+let _: Bool = PSGlobal // expected-error {{cannot convert value of type 'Int32'}}
+let _: Bool = PSPrivateGlobal // expected-error {{cannot convert value of type 'Int32'}}
+let _: Bool = PPGlobal // expected-error {{cannot convert value of type 'Int32'}}
+let _: Bool = PPPrivateGlobal // expected-error {{cannot convert value of type 'Int32'}}


### PR DESCRIPTION
Previously the recommended pattern for having a "private" interface for a public framework that was easy to strip out was to define an explicit submodule named 'Private'. However, that makes it all too easy to have dependencies from the public parts of the module on the private parts, and other such problems. We're now recommending that the private module map instead define a parallel module named with "_Private" as a suffix. Clang already implemented this, but Swift didn't get the same treatment.

This fix tries to avoid hardcoding too much; it notes that this kind of remapping is limited to the name 'Private' as the second component of a module hierarchy, but doesn't actually encode the mapping with the "_Private" suffix.

rdar://problem/37553763