### PR TITLE
Shims: adjust the ICU interface

### DIFF
--- a/stdlib/public/SwiftShims/UnicodeShims.h
+++ b/stdlib/public/SwiftShims/UnicodeShims.h
@@ -294,7 +294,15 @@ typedef enum __swift_stdlib_UBreakIteratorType {
 } __swift_stdlib_UBreakIteratorType;
 
 typedef struct __swift_stdlib_UBreakIterator __swift_stdlib_UBreakIterator;
+#if defined(__APPLE__)
 typedef __swift_uint16_t __swift_stdlib_UChar;
+#else
+#if defined(__cplusplus)
+typedef char16_t __swift_stdlib_UChar;
+#else
+typedef __swift_uint16_t __swift_stdlib_UChar;
+#endif
+#endif
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
 void __swift_stdlib_ubrk_close(__swift_stdlib_UBreakIterator *bi);

--- a/stdlib/public/stubs/UnicodeNormalization.cpp
+++ b/stdlib/public/stubs/UnicodeNormalization.cpp
@@ -301,7 +301,8 @@ void swift::__swift_stdlib_ubrk_close(
 
 swift::__swift_stdlib_UBreakIterator *swift::__swift_stdlib_ubrk_open(
     swift::__swift_stdlib_UBreakIteratorType type, const char *locale,
-    const uint16_t *text, int32_t textLength, __swift_stdlib_UErrorCode *status) {
+    const __swift_stdlib_UChar *text, int32_t textLength,
+    __swift_stdlib_UErrorCode *status) {
   return ptr_cast<swift::__swift_stdlib_UBreakIterator>(
       ubrk_open(static_cast<UBreakIteratorType>(type), locale,
                 reinterpret_cast<const UChar *>(text), textLength,


### PR DESCRIPTION
The default ICU build will change the underlying type of the UChar type,
with C++ using the builtin `char16_t` rather than `unsigned short`.
This adjusts the interface to account for that.  I've verified across
Apple's implementation that they always use the `unsigned short` as the
type for `UChar`.  Since we cannot guarantee that the ICU interfaces are
built the same way on all targets, especially when using the underlying
system's ICU.

Adjust the stubs implementation declaration to match the ICU header's
declaration.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
