### PR TITLE
[test] disable AutolinkExtract/import_archive.swift while investigating. rdar://37605557

### DIFF
--- a/test/AutolinkExtract/import_archive.swift
+++ b/test/AutolinkExtract/import_archive.swift
@@ -1,3 +1,4 @@
+// REQUIRES: rdar37605557
 // RUN: %empty-directory(%t)
 // RUN: %target-swiftc_driver -emit-library -emit-module -emit-module-path %t/empty.swiftmodule -module-name empty -module-link-name empty %S/empty.swift
 // RUN: %target-swiftc_driver -c %s -I %t -o %t/import_experimental.o


### PR DESCRIPTION
We've seen this test failing on bot:
https://ci.swift.org/job/oss-swift-incremental-RA-linux-ubuntu-16_04/2836/