### PR TITLE
NSArchive support: don't eagerly create class metadata for nested classes.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4173,8 +4173,7 @@ static void inferStaticInitializeObjCMetadata(TypeChecker &tc,
 
   // If we know that the Objective-C metadata will be statically registered,
   // there's nothing to do.
-  if (!hasGenericAncestry(classDecl) &&
-      classDecl->getDeclContext()->isModuleScopeContext()) {
+  if (!hasGenericAncestry(classDecl)) {
     return;
   }
 

--- a/test/Interpreter/SDK/archive_attributes.swift
+++ b/test/Interpreter/SDK/archive_attributes.swift
@@ -1,6 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift %s -module-name=test -DENCODE -o %t/encode
 // RUN: %target-build-swift %s -module-name=test -o %t/decode
+// RUN: %target-build-swift %s -module-name=test -Xfrontend -disable-llvm-optzns -emit-ir | %FileCheck -check-prefix=CHECK-IR %s
 // RUN: %target-run %t/encode %t/test.arc
 // RUN: plutil -p %t/test.arc | %FileCheck -check-prefix=CHECK-ARCHIVE %s
 // RUN: %target-run %t/decode %t/test.arc | %FileCheck %s
@@ -175,4 +176,14 @@ func main() {
 }
 
 main()
+
+// Check that we eagerly create metadata of generic classes, but not for nested classes.
+
+// CHECK-IR-LABEL: define {{.*}} @_swift_eager_class_initialization
+// CHECK-IR-NEXT:  entry:
+// CHECK-IR-NEXT:    call {{.*}}IntClassCMa
+// CHECK-IR-NEXT:    call void asm
+// CHECK-IR-NEXT:    call {{.*}}DoubleClassCMa
+// CHECK-IR-NEXT:    call void asm
+// CHECK-IR-NEXT:    ret
 

--- a/test/decl/protocol/conforms/nscoding.swift
+++ b/test/decl/protocol/conforms/nscoding.swift
@@ -21,7 +21,7 @@ class CodingA : NSObject, NSCoding {
 
 // Nested classes
 extension CodingA {
-  // CHECK: class_decl "NestedA"{{.*}}@_staticInitializeObjCMetadata
+  // CHECK-NOT: class_decl "NestedA"{{.*}}@_staticInitializeObjCMetadata
   class NestedA : NSObject, NSCoding { // expected-error{{nested class 'CodingA.NestedA' has an unstable name when archiving via 'NSCoding'}}
     // expected-note@-1{{for compatibility with existing archives, use '@objc' to record the Swift 3 runtime name}}{{3-3=@objc(_TtCC8nscoding7CodingA7NestedA)}}
     // expected-note@-2{{for new classes, use '@objc' to specify a unique, prefixed Objective-C runtime name}}{{3-3=@objc(<#prefixed Objective-C class name#>)}}
@@ -36,14 +36,14 @@ extension CodingA {
     func encode(coder: NSCoder) { }
   }
 
-  // CHECK: class_decl "NestedC"{{.*}}@_staticInitializeObjCMetadata
+  // CHECK-NOT: class_decl "NestedC"{{.*}}@_staticInitializeObjCMetadata
   @objc(CodingA_NestedC)
   class NestedC : NSObject, NSCoding {
     required init(coder: NSCoder) { }
     func encode(coder: NSCoder) { }
   }
 
-  // CHECK: class_decl "NestedD"{{.*}}@_staticInitializeObjCMetadata
+  // CHECK-NOT: class_decl "NestedD"{{.*}}@_staticInitializeObjCMetadata
   @objc(CodingA_NestedD)
   class NestedD : NSObject {
     required init(coder: NSCoder) { }


### PR DESCRIPTION
This is not required anymore to be able to unarchive such classes (before the first object of the class is instantiated).

rdar://problem/37568342
