### PR TITLE
[Perf] Improve dirty AST rebuild speed 2.56x on many-core machines

### DIFF
--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1604,11 +1604,11 @@ ValueDecl *swift::getBuiltinValueDecl(ASTContext &Context, Identifier Id) {
     return getAllocWithTailElemsOperation(Context, Id, NumTailTypes);
   }
 
-  BuiltinValueKind BV = llvm::StringSwitch<BuiltinValueKind>(OperationName)
+  auto BV = BuiltinValueKind::None;
 #define BUILTIN(id, name, Attrs) \
-       .Case(name, BuiltinValueKind::id)
+  if (name == OperationName) { BV = BuiltinValueKind::id; } else
 #include "swift/AST/Builtins.def"
-       .Default(BuiltinValueKind::None);
+  /* final "else" */ {}
 
   // Filter out inappropriate overloads.
   OverloadedBuiltinKind OBK = OverloadedBuiltinKinds[unsigned(BV)];

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -455,11 +455,10 @@ const BuiltinInfo &SILModule::getBuiltinInfo(Identifier ID) {
     Info.ID = BuiltinValueKind::AllocWithTailElems;
   else {
     // Switch through the rest of builtins.
-    Info.ID = llvm::StringSwitch<BuiltinValueKind>(OperationName)
-#define BUILTIN(ID, Name, Attrs) \
-      .Case(Name, BuiltinValueKind::ID)
+#define BUILTIN(Id, Name, Attrs) \
+    if (OperationName == Name) { Info.ID = BuiltinValueKind::Id; } else
 #include "swift/AST/Builtins.def"
-      .Default(BuiltinValueKind::None);
+    /* final "else" */ { Info.ID = BuiltinValueKind::None; }
   }
 
   return Info;


### PR DESCRIPTION
On many-core machines, the files that take the longest to compile are build bottlenecks. With this change, we workaround clang scaling problems compiling large llvm::StringSwitch expressions and bring the `touch tools/swift/include/swift/AST/* ; time ninja swift` time down from 1m43.24s down to 40.26s.

I've also benchmarked rebuilding Swift.o after this change. The before and after seems to be deep in the noise.