### PR TITLE
[test] Remove old stubs no longer needed by the compiler.

### DIFF
--- a/test/IDE/complete_from_foundation_overlay.swift
+++ b/test/IDE/complete_from_foundation_overlay.swift
@@ -11,7 +11,7 @@ import Foundation
 // REQUIRES: objc_interop
 
 // NO_STDLIB_PRIVATE: Begin completions
-// NO_STDLIB_PRIVATE-NOT: _convertStringToNSString
+// NO_STDLIB_PRIVATE-NOT: _convertErrorToNSError
 // NO_STDLIB_PRIVATE: End completions
 
 #^PLAIN_TOP_LEVEL_1^#

--- a/test/IRGen/Inputs/Foundation.swift
+++ b/test/IRGen/Inputs/Foundation.swift
@@ -3,34 +3,6 @@
 
 @_exported import ObjectiveC
 
-// String/NSString bridging functions.
-@_silgen_name("swift_StringToNSString") internal
-func _convertStringToNSString(_ string: String) -> NSString
-
-@_silgen_name("swift_NSStringToString") internal
-func _convertNSStringToString(_ nsstring: NSString?) -> String
-
-@_silgen_name("swift_ArrayToNSArray") internal
-func _convertArrayToNSArray<T>(array: Array<T>) -> NSArray
-
-@_silgen_name("swift_NSArrayToArray") internal
-func _convertNSArrayToArray<T>(nsstring: NSArray?) -> Array<T>
-
-@_silgen_name("swift_DictionaryToNSDictionary") internal
-func _convertDictionaryToNSDictionary<K: Hashable, V>(array: Dictionary<K, V>) -> NSDictionary
-
-@_silgen_name("swift_NSDictionaryToDictionary") internal
-func _convertNSDictionaryToDictionary<K: Hashable, V>(nsstring: NSDictionary?) -> Dictionary<K, V>
-
-// NSSet bridging entry points
-func _convertSetToNSSet<T: Hashable>(s: Set<T>) -> NSSet {
-  return NSSet()
-}
-
-func _convertNSSetToSet<T: NSObject>(s: NSSet?) -> Set<T> {
-  return Set<T>()
-}
-
 extension String : _ObjectiveCBridgeable {
   public func _bridgeToObjectiveC() -> NSString {
     return NSString()

--- a/test/Inputs/clang-importer-sdk/swift-modules-without-ns/Foundation.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules-without-ns/Foundation.swift
@@ -2,48 +2,11 @@
 @_exported import CoreGraphics
 @_exported import Foundation
 
-@_silgen_name("swift_StringToNSString")
-public func _convertStringToNSString(_ string: String) -> NSString
-
-@_silgen_name("swift_NSStringToString")
-public func _convertNSStringToString(_ nsstring: NSString?) -> String
-
 public func == (lhs: NSObject, rhs: NSObject) -> Bool {
   return lhs.isEqual(rhs)
 }
 
 public let NSUTF8StringEncoding: UInt = 8
-
-// NSArray bridging entry points
-public func _convertNSArrayToArray<T>(_ nsarr: NSArray?) -> [T] {
-  return [T]()
-}
-
-public func _convertArrayToNSArray<T>(_ arr: [T]) -> NSArray {
-  return NSArray()
-}
-
-// NSDictionary bridging entry points
-public func _convertDictionaryToNSDictionary<Key, Value>(
-    _ d: Dictionary<Key, Value>
-) -> NSDictionary {
-  return NSDictionary()
-}
-
-public func _convertNSDictionaryToDictionary<K: NSObject, V: AnyObject>(
-       _ d: NSDictionary?
-     ) -> Dictionary<K, V> {
-  return Dictionary<K, V>()
-}
-
-// NSSet bridging entry points
-public func _convertSetToNSSet<T>(_ s: Set<T>) -> NSSet {
-  return NSSet()
-}
-
-public func _convertNSSetToSet<T>(_ s: NSSet?) -> Set<T> {
-  return Set<T>()
-}
 
 extension String : _ObjectiveCBridgeable {
   public func _bridgeToObjectiveC() -> NSString {

--- a/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
@@ -2,48 +2,11 @@
 @_exported import CoreGraphics
 @_exported import Foundation
 
-@_silgen_name("swift_StringToNSString")
-public func _convertStringToNSString(_ string: String) -> NSString
-
-@_silgen_name("swift_NSStringToString")
-public func _convertNSStringToString(_ nsstring: NSString?) -> String
-
 public func == (lhs: NSObject, rhs: NSObject) -> Bool {
   return lhs.isEqual(rhs)
 }
 
 public let NSUTF8StringEncoding: UInt = 8
-
-// NSArray bridging entry points
-public func _convertNSArrayToArray<T>(_ nsarr: NSArray?) -> [T] {
-  return [T]()
-}
-
-public func _convertArrayToNSArray<T>(_ arr: [T]) -> NSArray {
-  return NSArray()
-}
-
-// NSDictionary bridging entry points
-public func _convertDictionaryToNSDictionary<Key, Value>(
-    _ d: Dictionary<Key, Value>
-) -> NSDictionary {
-  return NSDictionary()
-}
-
-public func _convertNSDictionaryToDictionary<K: NSObject, V: AnyObject>(
-       _ d: NSDictionary?
-     ) -> Dictionary<K, V> {
-  return Dictionary<K, V>()
-}
-
-// NSSet bridging entry points
-public func _convertSetToNSSet<T>(_ s: Set<T>) -> NSSet {
-  return NSSet()
-}
-
-public func _convertNSSetToSet<T>(_ s: NSSet?) -> Set<T> {
-  return Set<T>()
-}
 
 extension AnyHashable : _ObjectiveCBridgeable {
   public func _bridgeToObjectiveC() -> NSObject {
@@ -281,6 +244,7 @@ public func _convertNSErrorToError(_ error: NSError?) -> Error {
 public func _convertErrorToNSError(_ x: Error) -> NSError {
   return x as NSError
 }
+
 
 extension NSArray {
   @objc(methodIntroducedInOverlay) public func introducedInOverlay() { }

--- a/test/SILGen/Inputs/Foundation.swift
+++ b/test/SILGen/Inputs/Foundation.swift
@@ -3,43 +3,6 @@
 @_exported import ObjectiveC
 @_exported import Foundation // clang module
 
-@_silgen_name("swift_StringToNSString")
-func _convertStringToNSString(string: String) -> NSString
-
-@_silgen_name("swift_NSStringToString")
-func _convertNSStringToString(nsstring: NSString?) -> String
-
-// NSArray bridging entry points
-func _convertNSArrayToArray<T>(nsarr: NSArray?) -> [T] {
-  return [T]()
-}
-
-func _convertArrayToNSArray<T>(arr: [T]) -> NSArray {
-  return NSArray()
-}
-
-// NSDictionary bridging entry points
-func _convertDictionaryToNSDictionary<Key, Value>(
-    d: Dictionary<Key, Value>
-) -> NSDictionary {
-  return NSDictionary()
-}
-
-func _convertNSDictionaryToDictionary<K: NSObject, V: AnyObject>(
-       d: NSDictionary?
-     ) -> Dictionary<K, V> {
-  return Dictionary<K, V>()
-}
-
-// NSSet bridging entry points
-func _convertSetToNSSet<T>(s: Set<T>) -> NSSet {
-  return NSSet()
-}
-
-func _convertNSSetToSet<T>(s: NSSet?) -> Set<T> {
-  return Set<T>()
-}
-
 extension String : _ObjectiveCBridgeable {
   public func _bridgeToObjectiveC() -> NSString {
     return NSString()


### PR DESCRIPTION
Karoly removed the last use of `_convertStringToNSString` in #14046; the replacement is referenced by the runtime but not by the compiler. Doug had removed all the others from the stdlib in d92ae7707.

rdar://problem/35230338