### PR TITLE
[Batch mode]: More robust ownership for PrimarySpecificPath getters. (4a)

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -302,8 +302,11 @@ public:
     return FrontendOpts.InputKind == InputFileKind::IFK_Swift_Library;
   }
 
-  PrimarySpecificPaths getPrimarySpecificPathsForAtMostOnePrimary();
-  PrimarySpecificPaths getPrimarySpecificPathsForPrimary(StringRef filename);
+  PrimarySpecificPaths getPrimarySpecificPathsForAtMostOnePrimary() const;
+  PrimarySpecificPaths
+  getPrimarySpecificPathsForPrimary(StringRef filename) const;
+  PrimarySpecificPaths
+  getPrimarySpecificPathsForSourceFile(const SourceFile &SF) const;
 };
 
 /// A class which manages the state and execution of the compiler.
@@ -583,9 +586,13 @@ private:
   void finishTypeChecking(OptionSet<TypeCheckingFlags> TypeCheckOptions);
 
 public:
-  PrimarySpecificPaths getPrimarySpecificPathsForWholeModuleOptimizationMode();
-  PrimarySpecificPaths getPrimarySpecificPathsForPrimary(StringRef filename);
-  PrimarySpecificPaths getPrimarySpecificPathsForAtMostOnePrimary();
+  PrimarySpecificPaths
+  getPrimarySpecificPathsForWholeModuleOptimizationMode() const;
+  PrimarySpecificPaths
+  getPrimarySpecificPathsForPrimary(StringRef filename) const;
+  PrimarySpecificPaths getPrimarySpecificPathsForAtMostOnePrimary() const;
+  PrimarySpecificPaths
+  getPrimarySpecificPathsForSourceFile(const SourceFile &SF) const;
 };
 
 } // namespace swift

--- a/include/swift/Frontend/FrontendInputsAndOutputs.h
+++ b/include/swift/Frontend/FrontendInputsAndOutputs.h
@@ -224,13 +224,11 @@ public:
   /// Assumes there is not more than one primary input file, if any.
   /// Otherwise, you would need to call getPrimarySpecificPathsForPrimary
   /// to tell it which primary input you wanted the outputs for.
-  ///
-  /// Must not be constructed on-the-fly because some parts of the compiler
-  /// receive StringRefs to its components, so it must live as long as the
-  /// compiler.
-  PrimarySpecificPaths &getPrimarySpecificPathsForAtMostOnePrimary();
 
-  PrimarySpecificPaths &getPrimarySpecificPathsForPrimary(StringRef filename);
+  PrimarySpecificPaths getPrimarySpecificPathsForAtMostOnePrimary() const;
+
+  PrimarySpecificPaths
+  getPrimarySpecificPathsForPrimary(StringRef filename) const;
 
   bool hasDependenciesPath() const;
   bool hasReferenceDependenciesPath() const;

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -275,8 +275,8 @@ public:
            InputsAndOutputs.hasSingleInput();
   }
 
-  PrimarySpecificPaths getPrimarySpecificPathsForAtMostOnePrimary();
-  PrimarySpecificPaths getPrimarySpecificPathsForPrimary(StringRef);
+  PrimarySpecificPaths getPrimarySpecificPathsForAtMostOnePrimary() const;
+  PrimarySpecificPaths getPrimarySpecificPathsForPrimary(StringRef) const;
 
 private:
   static bool canActionEmitDependencies(ActionType);

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -54,13 +54,18 @@ std::string CompilerInvocation::getPCHHash() const {
 }
 
 PrimarySpecificPaths
-CompilerInvocation::getPrimarySpecificPathsForAtMostOnePrimary() {
+CompilerInvocation::getPrimarySpecificPathsForAtMostOnePrimary() const {
   return getFrontendOptions().getPrimarySpecificPathsForAtMostOnePrimary();
 }
 
-PrimarySpecificPaths
-CompilerInvocation::getPrimarySpecificPathsForPrimary(StringRef filename) {
+PrimarySpecificPaths CompilerInvocation::getPrimarySpecificPathsForPrimary(
+    StringRef filename) const {
   return getFrontendOptions().getPrimarySpecificPathsForPrimary(filename);
+}
+
+PrimarySpecificPaths CompilerInvocation::getPrimarySpecificPathsForSourceFile(
+    const SourceFile &SF) const {
+  return getPrimarySpecificPathsForPrimary(SF.getFilename());
 }
 
 void CompilerInstance::createSILModule() {
@@ -837,14 +842,19 @@ void CompilerInstance::freeASTContext() {
 void CompilerInstance::freeSILModule() { TheSILModule.reset(); }
 
 PrimarySpecificPaths
-CompilerInstance::getPrimarySpecificPathsForWholeModuleOptimizationMode() {
+CompilerInstance::getPrimarySpecificPathsForWholeModuleOptimizationMode()
+    const {
   return getPrimarySpecificPathsForAtMostOnePrimary();
 }
 PrimarySpecificPaths
-CompilerInstance::getPrimarySpecificPathsForAtMostOnePrimary() {
+CompilerInstance::getPrimarySpecificPathsForAtMostOnePrimary() const {
   return Invocation.getPrimarySpecificPathsForAtMostOnePrimary();
 }
 PrimarySpecificPaths
-CompilerInstance::getPrimarySpecificPathsForPrimary(StringRef filename) {
+CompilerInstance::getPrimarySpecificPathsForPrimary(StringRef filename) const {
   return Invocation.getPrimarySpecificPathsForPrimary(filename);
+}
+PrimarySpecificPaths CompilerInstance::getPrimarySpecificPathsForSourceFile(
+    const SourceFile &SF) const {
+  return Invocation.getPrimarySpecificPathsForSourceFile(SF);
 }

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -397,13 +397,13 @@ bool FrontendInputsAndOutputs::hasDependencyTrackerPath() const {
          hasLoadedModuleTracePath();
 }
 
-PrimarySpecificPaths &
-FrontendInputsAndOutputs::getPrimarySpecificPathsForAtMostOnePrimary() {
+PrimarySpecificPaths
+FrontendInputsAndOutputs::getPrimarySpecificPathsForAtMostOnePrimary() const {
   return PrimarySpecificPathsForAtMostOnePrimary;
 }
 
-PrimarySpecificPaths &
+PrimarySpecificPaths
 FrontendInputsAndOutputs::getPrimarySpecificPathsForPrimary(
-    StringRef filename) {
+    StringRef filename) const {
   return getPrimarySpecificPathsForAtMostOnePrimary(); // just a stub for now
 }

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -388,11 +388,11 @@ bool FrontendOptions::doesActionProduceTextualOutput(ActionType action) {
 }
 
 PrimarySpecificPaths
-FrontendOptions::getPrimarySpecificPathsForAtMostOnePrimary() {
+FrontendOptions::getPrimarySpecificPathsForAtMostOnePrimary() const {
   return InputsAndOutputs.getPrimarySpecificPathsForAtMostOnePrimary();
 }
 
 PrimarySpecificPaths
-FrontendOptions::getPrimarySpecificPathsForPrimary(StringRef filename) {
+FrontendOptions::getPrimarySpecificPathsForPrimary(StringRef filename) const {
   return InputsAndOutputs.getPrimarySpecificPathsForPrimary(filename);
 }

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -298,7 +298,7 @@ static bool writeSIL(SILModule &SM, ModuleDecl *M, bool EmitVerboseSIL,
   return false;
 }
 
-static bool writeSIL(SILModule &SM, const PrimarySpecificPaths PSPs,
+static bool writeSIL(SILModule &SM, const PrimarySpecificPaths &PSPs,
                      CompilerInstance &Instance,
                      CompilerInvocation &Invocation) {
   const FrontendOptions &opts = Invocation.getFrontendOptions();
@@ -804,7 +804,7 @@ generateSILModules(CompilerInvocation &Invocation, CompilerInstance &Instance) {
     auto SM = performSILGeneration(*PrimaryFile, SILOpts, None);
     std::deque<PostSILGenInputs> PSGIs;
     const PrimarySpecificPaths PSPs =
-        Instance.getPrimarySpecificPathsForPrimary(PrimaryFile->getFilename());
+        Instance.getPrimarySpecificPathsForSourceFile(*PrimaryFile);
     PSGIs.push_back(PostSILGenInputs{std::move(SM), true, PrimaryFile, PSPs});
     return PSGIs;
   }
@@ -831,7 +831,7 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
                                           std::unique_ptr<SILModule> SM,
                                           bool astGuaranteedToCorrespondToSIL,
                                           ModuleOrSourceFile MSF,
-                                          PrimarySpecificPaths PSPs,
+                                          const PrimarySpecificPaths &PSPs,
                                           bool moduleIsPublic,
                                           int &ReturnValue,
                                           FrontendObserver *observer,
@@ -1182,7 +1182,7 @@ static bool performCompileStepsPostSILGen(CompilerInstance &Instance,
                                           std::unique_ptr<SILModule> SM,
                                           bool astGuaranteedToCorrespondToSIL,
                                           ModuleOrSourceFile MSF,
-                                          const PrimarySpecificPaths PSPs,
+                                          const PrimarySpecificPaths &PSPs,
                                           bool moduleIsPublic,
                                           int &ReturnValue,
                                           FrontendObserver *observer,

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -260,12 +260,12 @@ bool swift::immediate::IRGenImportedModules(
     }
     runSILLoweringPasses(*SILMod);
 
+    const auto PSPs = CI.getPrimarySpecificPathsForAtMostOnePrimary();
     // FIXME: We shouldn't need to use the global context here, but
     // something is persisting across calls to performIRGeneration.
     auto SubModule = performIRGeneration(
-        IRGenOpts, import, std::move(SILMod), import->getName().str(),
-        CI.getPrimarySpecificPathsForAtMostOnePrimary(), getGlobalLLVMContext(),
-        ArrayRef<std::string>());
+        IRGenOpts, import, std::move(SILMod), import->getName().str(), PSPs,
+        getGlobalLLVMContext(), ArrayRef<std::string>());
 
     if (CI.getASTContext().hadError()) {
       hadError = true;
@@ -299,12 +299,12 @@ int swift::RunImmediately(CompilerInstance &CI, const ProcessCmdLine &CmdLine,
   
   // IRGen the main module.
   auto *swiftModule = CI.getMainModule();
+  const auto PSPs = CI.getPrimarySpecificPathsForAtMostOnePrimary();
   // FIXME: We shouldn't need to use the global context here, but
   // something is persisting across calls to performIRGeneration.
   auto ModuleOwner = performIRGeneration(
       IRGenOpts, swiftModule, CI.takeSILModule(), swiftModule->getName().str(),
-      CI.getPrimarySpecificPathsForAtMostOnePrimary(), getGlobalLLVMContext(),
-      ArrayRef<std::string>());
+      PSPs, getGlobalLLVMContext(), ArrayRef<std::string>());
   auto *Module = ModuleOwner.get();
 
   if (Context.hadError())

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -900,10 +900,10 @@ private:
     // IRGen the current line(s).
     // FIXME: We shouldn't need to use the global context here, but
     // something is persisting across calls to performIRGeneration.
+    const auto PSPs = CI.getPrimarySpecificPathsForAtMostOnePrimary();
     auto LineModule = performIRGeneration(
-        IRGenOpts, REPLInputFile, std::move(sil), "REPLLine",
-        CI.getPrimarySpecificPathsForAtMostOnePrimary(), getGlobalLLVMContext(),
-        RC.CurIRGenElem);
+        IRGenOpts, REPLInputFile, std::move(sil), "REPLLine", PSPs,
+        getGlobalLLVMContext(), RC.CurIRGenElem);
     RC.CurIRGenElem = RC.CurElem;
     
     if (CI.getASTContext().hadError())

--- a/tools/sil-llvm-gen/SILLLVMGen.cpp
+++ b/tools/sil-llvm-gen/SILLLVMGen.cpp
@@ -204,7 +204,7 @@ int main(int argc, char **argv) {
       SL->getAll();
   }
 
-  PrimarySpecificPaths PSPs(OutputFilename, InputFilename);
+  const PrimarySpecificPaths PSPs(OutputFilename, InputFilename);
   std::unique_ptr<llvm::Module> Mod =
       performIRGeneration(Opts, CI.getMainModule(), CI.takeSILModule(),
                           CI.getMainModule()->getName().str(),


### PR DESCRIPTION
Also added getPrimarySpecificPathsForSourceFile.

<!-- What's in this pull request? -->
The existing code was not robust w.r.t. ownership of PrimarySpecificPath objects.
Make it more robust at a small copying expense.

Have the getPrimarySpecificPathsFor... functions return an object instead of a ref, which allows them to be const w.r.t. the receiver. Allocate a PrimarySpecificPaths object at the highest stack level that receives one of these, and then pass const refs down the stack.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
