### PR TITLE
[stdlib] Constrain MutableCollection's subscript default implementation

### DIFF
--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -193,7 +193,9 @@ extension MutableCollection {
   ) rethrows -> R? {
     return nil
   }
+}
 
+extension MutableCollection where SubSequence == Slice<Self> {
   /// Accesses a contiguous subrange of the collection's elements.
   ///
   /// The accessed slice uses the same indices for the same elements as the
@@ -228,7 +230,13 @@ extension MutableCollection {
       _writeBackMutableSlice(&self, bounds: bounds, slice: newValue)
     }
   }
+}
 
+//===----------------------------------------------------------------------===//
+// swapAt(_:_:), swap(_:_:)
+//===----------------------------------------------------------------------===//
+
+extension MutableCollection {
   /// Exchanges the values at the specified indices of the collection.
   ///
   /// Both parameters must be valid indices of the collection that are not


### PR DESCRIPTION
This only provides the subscript(Range<Index>) -> Slice<Self> implementation when the collection's subsequence is actually a Slice.

(The diff is funny—I moved the subscript down, but it shows the change as moving the `swapAt` method up.)