### PR TITLE
Reenable test/AutolinkExtract/import_archive.swift

### DIFF
--- a/test/AutolinkExtract/import_archive.swift
+++ b/test/AutolinkExtract/import_archive.swift
@@ -1,4 +1,3 @@
-// REQUIRES: rdar37605557
 // RUN: %empty-directory(%t)
 // RUN: %target-swiftc_driver -emit-library -emit-module -emit-module-path %t/empty.swiftmodule -module-name empty -module-link-name empty %S/empty.swift
 // RUN: %target-swiftc_driver -c %s -I %t -o %t/import_experimental.o


### PR DESCRIPTION
<!-- What's in this pull request? -->
Verify that the failure is reproducible here. (It seems to have passed for me.)
This test was disabled: https://github.com/apple/swift/pull/14677
See rdar://problem/37605557.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->