### PR TITLE
Profile stats

### DIFF
--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -66,14 +66,14 @@ class UnifiedStatsReporter {
 public:
   struct AlwaysOnDriverCounters
   {
-#define DRIVER_STATISTIC(ID) size_t ID;
+#define DRIVER_STATISTIC(ID) int64_t ID;
 #include "Statistics.def"
 #undef DRIVER_STATISTIC
   };
 
   struct AlwaysOnFrontendCounters
   {
-#define FRONTEND_STATISTIC(NAME, ID) size_t ID;
+#define FRONTEND_STATISTIC(NAME, ID) int64_t ID;
 #include "Statistics.def"
 #undef FRONTEND_STATISTIC
   };
@@ -98,8 +98,8 @@ public:
     bool IsEntry;
     StringRef EventName;
     StringRef CounterName;
-    size_t CounterDelta;
-    size_t CounterValue;
+    int64_t CounterDelta;
+    int64_t CounterValue;
     const void *Entity;
     const TraceFormatter *Formatter;
   };

--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -78,15 +78,6 @@ public:
 #undef FRONTEND_STATISTIC
   };
 
-  struct AlwaysOnFrontendRecursiveSharedTimers {
-    AlwaysOnFrontendRecursiveSharedTimers();
-#define FRONTEND_RECURSIVE_SHARED_TIMER(ID) RecursiveSharedTimer ID;
-#include "Statistics.def"
-#undef FRONTEND_RECURSIVE_SHARED_TIMER
-
-    int dummyInstanceVariableToGetConstructorToParse;
-  };
-
   // To trace an entity, you have to provide a TraceFormatter for it. This is a
   // separate type since we do not have retroactive conformances in C++, and it
   // is a type that takes void* arguments since we do not have existentials
@@ -133,8 +124,6 @@ private:
   std::unique_ptr<AlwaysOnFrontendCounters> LastTracedFrontendCounters;
   std::vector<FrontendStatsEvent> FrontendStatsEvents;
   std::unique_ptr<RecursionSafeTimers> RecursiveTimers;
-  std::unique_ptr<AlwaysOnFrontendRecursiveSharedTimers>
-      FrontendRecursiveSharedTimers;
 
   void publishAlwaysOnStatsToLLVM();
   void printAlwaysOnStatsAndTimers(llvm::raw_ostream &OS);
@@ -160,7 +149,6 @@ public:
 
   AlwaysOnDriverCounters &getDriverCounters();
   AlwaysOnFrontendCounters &getFrontendCounters();
-  AlwaysOnFrontendRecursiveSharedTimers &getFrontendRecursiveSharedTimers();
   void noteCurrentProcessExitStatus(int);
   void saveAnyFrontendStatsEvents(FrontendStatsTracer const &T, bool IsEntry);
 };

--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -113,6 +113,12 @@ public:
     const TraceFormatter *Formatter;
   };
 
+  // We only write fine-grained trace entries when the user passed
+  // -trace-stats-events, but we recycle the same FrontendStatsTracers to give
+  // us some free recursion-save phase timings whenever -trace-stats-dir is
+  // active at all. Reduces redundant machinery.
+  class RecursionSafeTimers;
+
 private:
   bool currentProcessExitStatusSet;
   int currentProcessExitStatus;
@@ -126,6 +132,7 @@ private:
   std::unique_ptr<AlwaysOnFrontendCounters> FrontendCounters;
   std::unique_ptr<AlwaysOnFrontendCounters> LastTracedFrontendCounters;
   std::vector<FrontendStatsEvent> FrontendStatsEvents;
+  std::unique_ptr<RecursionSafeTimers> RecursiveTimers;
   std::unique_ptr<AlwaysOnFrontendRecursiveSharedTimers>
       FrontendRecursiveSharedTimers;
 

--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -185,6 +185,7 @@ public:
   /// entity type, and produce a tracer that's either active or inert depending
   /// on whether the provided \p Reporter is null (nullptr means "tracing is
   /// disabled").
+  FrontendStatsTracer(UnifiedStatsReporter *Reporter,  StringRef EventName);
   FrontendStatsTracer(UnifiedStatsReporter *Reporter,  StringRef EventName,
                       const Decl *D);
   FrontendStatsTracer(UnifiedStatsReporter *Reporter,  StringRef EventName,

--- a/include/swift/Basic/Statistic.h
+++ b/include/swift/Basic/Statistic.h
@@ -56,6 +56,7 @@ namespace clang {
 namespace swift {
 
 class Decl;
+class ProtocolConformance;
 class Expr;
 class SILFunction;
 class FrontendStatsTracer;
@@ -192,6 +193,8 @@ public:
   FrontendStatsTracer(UnifiedStatsReporter *Reporter,  StringRef EventName,
                       const Decl *D);
   FrontendStatsTracer(UnifiedStatsReporter *Reporter,  StringRef EventName,
+                      const ProtocolConformance *P);
+  FrontendStatsTracer(UnifiedStatsReporter *Reporter,  StringRef EventName,
                       const clang::Decl *D);
   FrontendStatsTracer(UnifiedStatsReporter *Reporter,  StringRef EventName,
                       const Expr *E);
@@ -208,6 +211,9 @@ public:
 
 template<> const UnifiedStatsReporter::TraceFormatter*
 FrontendStatsTracer::getTraceFormatter<const Decl *>();
+
+template<> const UnifiedStatsReporter::TraceFormatter*
+FrontendStatsTracer::getTraceFormatter<const ProtocolConformance *>();
 
 template<> const UnifiedStatsReporter::TraceFormatter*
 FrontendStatsTracer::getTraceFormatter<const clang::Decl *>();

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -19,9 +19,6 @@
 //   - Subsystem is a token to be stringified as a name prefix
 //   - Id is an identifier suitable for use in C++
 //
-// FRONTEND_RECURSIVE_SHARED_TIMER(Id)
-//   - Id is an identifier suitable for use in C++
-//
 //===----------------------------------------------------------------------===//
 
 /// Driver statistics are collected for driver processes
@@ -218,14 +215,4 @@ FRONTEND_STATISTIC(IRModule, NumIRInsts)
 /// of the frontend job, which should be the same as the size of
 /// the .o file you find on disk after the frontend exits.
 FRONTEND_STATISTIC(LLVM, NumLLVMBytesOutput)
-#endif
-
-/// Frontend timers for recursive routines
-#ifdef FRONTEND_RECURSIVE_SHARED_TIMER
-
-/// Time spent in  NominalTypeDecl::lookupDirect.
-FRONTEND_RECURSIVE_SHARED_TIMER(NominalTypeDecl__lookupDirect)
-
-/// Time spent in ClangImporter::Implementation::loadAllMembers.
-FRONTEND_RECURSIVE_SHARED_TIMER(ClangImporter__Implementation__loadAllMembers)
 #endif

--- a/include/swift/Basic/Timer.h
+++ b/include/swift/Basic/Timer.h
@@ -45,66 +45,6 @@ namespace swift {
       CompilationTimersEnabled = State::Enabled;
     }
   };
-
-  /// A SharedTimer for recursive routines.
-  /// void example() {
-  ///  RecursiveSharedTimer::Guard guard; // MUST BE AT TOP SCOPE of function to
-  ///  work right! if (auto s = getASTContext().Stats) {
-  ///    guard =
-  ///    ctx.Stats->getFrontendRecursiveSharedTimers().NominalTypeDecl__lookupDirect.getGuard();
-  //  }
-  ///   ...
-  /// }
-
-  class RecursiveSharedTimer {
-  private:
-    int recursionCount = 0;
-    const StringRef name;
-    llvm::Optional<SharedTimer> timer;
-
-    void enterRecursiveFunction() {
-      assert(recursionCount >= 0  &&  "too many exits");
-      if (recursionCount++ == 0)
-        timer.emplace(name);
-    }
-    void exitRecursiveFunction() {
-      assert(recursionCount > 0  &&  "too many exits");
-      if (--recursionCount == 0)
-        timer.reset();
-    }
-
-  public:
-    RecursiveSharedTimer(StringRef name) : name(name) {}
-
-    struct Guard {
-      RecursiveSharedTimer *recursiveTimerOrNull;
-
-      Guard(RecursiveSharedTimer *rst) : recursiveTimerOrNull(rst) {
-        if (recursiveTimerOrNull)
-          recursiveTimerOrNull->enterRecursiveFunction();
-      }
-      ~Guard() {
-        if (recursiveTimerOrNull)
-          recursiveTimerOrNull->exitRecursiveFunction();
-      }
-
-      // All this stuff is to do an RAII object that be moved.
-      Guard() : recursiveTimerOrNull(nullptr) {}
-      Guard(Guard &&other) {
-        recursiveTimerOrNull = other.recursiveTimerOrNull;
-        other.recursiveTimerOrNull = nullptr;
-      }
-      Guard &operator=(Guard &&other) {
-        recursiveTimerOrNull = other.recursiveTimerOrNull;
-        other.recursiveTimerOrNull = nullptr;
-        return *this;
-      }
-      Guard(const Guard &) = delete;
-      Guard &operator=(const Guard &) = delete;
-    };
-
-    Guard getGuard() { return Guard(this); }
-  };
 } // end namespace swift
 
 #endif // SWIFT_BASIC_TIMER_H

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -164,6 +164,13 @@ public:
   /// Trace changes to stats to files in StatsOutputDir.
   bool TraceStats = false;
 
+  /// Profile changes to stats to files in StatsOutputDir.
+  bool ProfileEvents = false;
+
+  /// Profile changes to stats to files in StatsOutputDir, grouped by source
+  /// entity.
+  bool ProfileEntities = false;
+
   /// If true, serialization encodes an extra lookup table for use in module-
   /// merging when emitting partial modules (the per-file modules in a non-WMO
   /// build).

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -202,6 +202,12 @@ def stats_output_dir: Separate<["-"], "stats-output-dir">,
 def trace_stats_events: Flag<["-"], "trace-stats-events">,
   Flags<[FrontendOption, HelpHidden]>,
   HelpText<"Trace changes to stats in -stats-output-dir">;
+def profile_stats_events: Flag<["-"], "profile-stats-events">,
+  Flags<[FrontendOption, HelpHidden]>,
+  HelpText<"Profile changes to stats in -stats-output-dir">;
+def profile_stats_entities: Flag<["-"], "profile-stats-entities">,
+  Flags<[FrontendOption, HelpHidden]>,
+  HelpText<"Profile changes to stats in -stats-output-dir, subdivided by source entity">;
 
 def emit_dependencies : Flag<["-"], "emit-dependencies">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1402,7 +1402,7 @@ void ASTContext::loadObjCMethods(
 
 void ASTContext::verifyAllLoadedModules() const {
 #ifndef NDEBUG
-  SharedTimer("verifyAllLoadedModules");
+  FrontendStatsTracer tracer(Stats, "verify-all-loaded-modules");
   for (auto &loader : Impl.ModuleLoaders)
     loader->verifyAllModules();
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5677,6 +5677,10 @@ struct DeclTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
     const Decl *D = static_cast<const Decl *>(Entity);
     if (auto const *VD = dyn_cast<const ValueDecl>(D)) {
       VD->getFullName().print(OS, false);
+    } else {
+      OS << "<"
+         << Decl::getDescriptiveKindName(D->getDescriptiveKind())
+         << ">";
     }
   }
   void traceLoc(const void *Entity, SourceManager *SM,

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5694,14 +5694,10 @@ struct DeclTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
 
 static DeclTraceFormatter TF;
 
-UnifiedStatsReporter::FrontendStatsTracer
-UnifiedStatsReporter::getStatsTracer(StringRef EventName, const Decl *D) {
-  if (LastTracedFrontendCounters)
-    // Return live tracer object.
-    return FrontendStatsTracer(EventName, D, &TF, this);
-  else
-    // Return inert tracer object.
-    return FrontendStatsTracer();
+template<>
+const UnifiedStatsReporter::TraceFormatter*
+FrontendStatsTracer::getTraceFormatter<const Decl *>() {
+  return &TF;
 }
 
 TypeOrExtensionDecl::TypeOrExtensionDecl(NominalTypeDecl *D) : Decl(D) {}

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2297,12 +2297,8 @@ struct ExprTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
 
 static ExprTraceFormatter TF;
 
-UnifiedStatsReporter::FrontendStatsTracer
-UnifiedStatsReporter::getStatsTracer(StringRef EventName, const Expr *E) {
-  if (LastTracedFrontendCounters)
-    // Return live tracer object.
-    return FrontendStatsTracer(EventName, E, &TF, this);
-  else
-    // Return inert tracer object.
-    return FrontendStatsTracer();
+template<>
+const UnifiedStatsReporter::TraceFormatter*
+FrontendStatsTracer::getTraceFormatter<const Expr *>() {
+  return &TF;
 }

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1352,12 +1352,10 @@ void NominalTypeDecl::makeMemberVisible(ValueDecl *member) {
 TinyPtrVector<ValueDecl *> NominalTypeDecl::lookupDirect(
                                                   DeclName name,
                                                   bool ignoreNewExtensions) {
-  RecursiveSharedTimer::Guard guard;
   ASTContext &ctx = getASTContext();
+  FrontendStatsTracer tracer(ctx.Stats, "lookup-direct", this);
   if (auto s = ctx.Stats) {
     ++s->getFrontendCounters().NominalTypeLookupDirectCount;
-    guard = s->getFrontendRecursiveSharedTimers()
-                .NominalTypeDecl__lookupDirect.getGuard();
   }
 
   // We only use NamedLazyMemberLoading when a user opts-in and we have

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -24,6 +24,7 @@
 #include "swift/AST/Substitution.h"
 #include "swift/AST/Types.h"
 #include "swift/AST/TypeWalker.h"
+#include "swift/Basic/Statistic.h"
 #include "swift/ClangImporter/ClangModule.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/Statistic.h"
@@ -1366,4 +1367,40 @@ ProtocolConformanceRef::getCanonicalConformanceRef() const {
   if (isAbstract())
     return *this;
   return ProtocolConformanceRef(getConcrete()->getCanonicalConformance());
+}
+
+// See swift/Basic/Statistic.h for declaration: this enables tracing
+// ProtocolConformances, is defined here to avoid too much layering violation /
+// circular linkage dependency.
+
+struct ProtocolConformanceTraceFormatter
+    : public UnifiedStatsReporter::TraceFormatter {
+  void traceName(const void *Entity, raw_ostream &OS) const {
+    if (!Entity)
+      return;
+    const ProtocolConformance *C =
+        static_cast<const ProtocolConformance *>(Entity);
+    C->printName(OS);
+  }
+  void traceLoc(const void *Entity, SourceManager *SM,
+                clang::SourceManager *CSM, raw_ostream &OS) const {
+    if (!Entity)
+      return;
+    const ProtocolConformance *C =
+        static_cast<const ProtocolConformance *>(Entity);
+    if (auto const *NPC = dyn_cast<NormalProtocolConformance>(C)) {
+      NPC->getLoc().print(OS, *SM);
+    } else if (auto const *DC = C->getDeclContext()) {
+      if (auto const *D = DC->getAsDeclOrDeclExtensionContext())
+        D->getLoc().print(OS, *SM);
+    }
+  }
+};
+
+static ProtocolConformanceTraceFormatter TF;
+
+template<>
+const UnifiedStatsReporter::TraceFormatter*
+FrontendStatsTracer::getTraceFormatter<const ProtocolConformance *>() {
+  return &TF;
 }

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -296,6 +296,10 @@ FrontendStatsTracer::FrontendStatsTracer(
 
 FrontendStatsTracer::FrontendStatsTracer() = default;
 
+FrontendStatsTracer::FrontendStatsTracer(UnifiedStatsReporter *R, StringRef S)
+    : FrontendStatsTracer(R, S, nullptr, nullptr)
+{}
+
 FrontendStatsTracer::FrontendStatsTracer(UnifiedStatsReporter *R, StringRef S,
                                          const Decl *D)
     : FrontendStatsTracer(R, S, D, getTraceFormatter<const Decl *>())

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -277,6 +277,11 @@ FrontendStatsTracer::FrontendStatsTracer(UnifiedStatsReporter *R, StringRef S,
 {}
 
 FrontendStatsTracer::FrontendStatsTracer(UnifiedStatsReporter *R, StringRef S,
+                                         const ProtocolConformance *P)
+    : FrontendStatsTracer(R, S, P,
+                          getTraceFormatter<const ProtocolConformance *>()) {}
+
+FrontendStatsTracer::FrontendStatsTracer(UnifiedStatsReporter *R, StringRef S,
                                          const Expr *E)
     : FrontendStatsTracer(R, S, E, getTraceFormatter<const Expr *>())
 {}

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -14,6 +14,7 @@
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
+#include "swift/Basic/Timer.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
 #include "swift/SIL/SILFunction.h"
@@ -126,6 +127,37 @@ auxName(StringRef ModuleName,
           + "-" + cleanName(OptType));
 }
 
+class UnifiedStatsReporter::RecursionSafeTimers {
+
+  struct RecursionSafeTimer {
+    llvm::Optional<SharedTimer> Timer;
+    size_t RecursionDepth;
+  };
+
+  StringMap<RecursionSafeTimer> Timers;
+
+public:
+
+  void beginTimer(StringRef Name) {
+    RecursionSafeTimer &T = Timers[Name];
+    if (T.RecursionDepth == 0) {
+      T.Timer.emplace(Name);
+    }
+    T.RecursionDepth++;
+  }
+
+  void endTimer(StringRef Name) {
+    auto I = Timers.find(Name);
+    assert(I != Timers.end());
+    RecursionSafeTimer &T = I->getValue();
+    assert(T.RecursionDepth != 0);
+    T.RecursionDepth--;
+    if (T.RecursionDepth == 0) {
+      T.Timer.reset();
+    }
+  }
+};
+
 UnifiedStatsReporter::UnifiedStatsReporter(StringRef ProgramName,
                                            StringRef ModuleName,
                                            StringRef InputName,
@@ -162,7 +194,8 @@ UnifiedStatsReporter::UnifiedStatsReporter(StringRef ProgramName,
                                         "Building Target",
                                         ProgramName, "Running Program")),
     SourceMgr(SM),
-    ClangSourceMgr(CSM)
+    ClangSourceMgr(CSM),
+    RecursiveTimers(llvm::make_unique<RecursionSafeTimers>())
 {
   path::append(StatsFilename, makeStatsFileName(ProgramName, AuxName));
   path::append(TraceFilename, makeTraceFileName(ProgramName, AuxName));
@@ -329,6 +362,16 @@ UnifiedStatsReporter::saveAnyFrontendStatsEvents(
     FrontendStatsTracer const& T,
     bool IsEntry)
 {
+  // First make a note in the recursion-safe timers; these
+  // are active anytime UnifiedStatsReporter is active.
+  if (IsEntry) {
+    RecursiveTimers->beginTimer(T.EventName);
+  } else {
+    RecursiveTimers->endTimer(T.EventName);
+  }
+
+  // If we don't have a saved entry to form deltas against in
+  // the trace buffer, we're not tracing: return early.
   if (!LastTracedFrontendCounters)
     return;
   auto Now = llvm::TimeRecord::getCurrentTime();

--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -221,14 +221,6 @@ UnifiedStatsReporter::getFrontendCounters()
   return *FrontendCounters;
 }
 
-UnifiedStatsReporter::AlwaysOnFrontendRecursiveSharedTimers &
-UnifiedStatsReporter::getFrontendRecursiveSharedTimers() {
-  if (!FrontendRecursiveSharedTimers)
-    FrontendRecursiveSharedTimers =
-        make_unique<AlwaysOnFrontendRecursiveSharedTimers>();
-  return *FrontendRecursiveSharedTimers;
-}
-
 void
 UnifiedStatsReporter::noteCurrentProcessExitStatus(int status) {
   assert(!currentProcessExitStatusSet);
@@ -393,15 +385,6 @@ UnifiedStatsReporter::saveAnyFrontendStatsEvents(
   } while (0);
 #include "swift/Basic/Statistics.def"
 #undef FRONTEND_STATISTIC
-}
-
-UnifiedStatsReporter::AlwaysOnFrontendRecursiveSharedTimers::
-    AlwaysOnFrontendRecursiveSharedTimers()
-    :
-#define FRONTEND_RECURSIVE_SHARED_TIMER(ID) ID(#ID),
-#include "swift/Basic/Statistics.def"
-#undef FRONTEND_RECURSIVE_SHARED_TIMER
-      dummyInstanceVariableToGetConstructorToParse(0) {
 }
 
 UnifiedStatsReporter::TraceFormatter::~TraceFormatter() {}

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8346,12 +8346,8 @@ createUnavailableDecl(Identifier name, DeclContext *dc, Type type,
 
 void
 ClangImporter::Implementation::loadAllMembers(Decl *D, uint64_t extra) {
-  RecursiveSharedTimer::Guard guard;
-  if (auto s = D->getASTContext().Stats) {
-    guard = s->getFrontendRecursiveSharedTimers()
-                .ClangImporter__Implementation__loadAllMembers.getGuard();
-  }
 
+  FrontendStatsTracer tracer(D->getASTContext().Stats, "load-all-members", D);
   assert(D);
 
   // Check whether we're importing an Objective-C container of some sort.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -8604,17 +8604,20 @@ struct ClangDeclTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
     const clang::Decl *CD = static_cast<const clang::Decl *>(Entity);
     if (auto const *ND = dyn_cast<const clang::NamedDecl>(CD)) {
       ND->printName(OS);
+    } else {
+      OS << "<unnamed-clang-decl>";
     }
   }
 
-  static inline void printClangShortLoc(raw_ostream &OS,
+  static inline bool printClangShortLoc(raw_ostream &OS,
                                         clang::SourceManager *CSM,
                                         clang::SourceLocation L) {
     if (!L.isValid() || !L.isFileID())
-      return;
+      return false;
     auto PLoc = CSM->getPresumedLoc(L);
     OS << llvm::sys::path::filename(PLoc.getFilename()) << ':' << PLoc.getLine()
        << ':' << PLoc.getColumn();
+    return true;
   }
 
   void traceLoc(const void *Entity, SourceManager *SM,
@@ -8624,8 +8627,8 @@ struct ClangDeclTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
     if (CSM) {
       const clang::Decl *CD = static_cast<const clang::Decl *>(Entity);
       auto Range = CD->getSourceRange();
-      printClangShortLoc(OS, CSM, Range.getBegin());
-      OS << '-';
+      if (printClangShortLoc(OS, CSM, Range.getBegin()))
+        OS << '-';
       printClangShortLoc(OS, CSM, Range.getEnd());
     }
   }

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7878,11 +7878,8 @@ Decl *ClangImporter::Implementation::importDeclAndCacheImpl(
   if (!ClangDecl)
     return nullptr;
 
-  UnifiedStatsReporter::FrontendStatsTracer Tracer;
-  if (SwiftContext.Stats)
-    Tracer = SwiftContext.Stats->getStatsTracer("import-clang-decl",
-                                                ClangDecl);
-
+  FrontendStatsTracer StatsTracer(SwiftContext.Stats,
+                                  "import-clang-decl", ClangDecl);
   clang::PrettyStackTraceDecl trace(ClangDecl, clang::SourceLocation(),
                                     Instance->getSourceManager(), "importing");
 
@@ -8636,13 +8633,8 @@ struct ClangDeclTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
 
 static ClangDeclTraceFormatter TF;
 
-UnifiedStatsReporter::FrontendStatsTracer
-UnifiedStatsReporter::getStatsTracer(StringRef EventName,
-                                     const clang::Decl *D) {
-  if (LastTracedFrontendCounters)
-    // Return live tracer object.
-    return FrontendStatsTracer(EventName, D, &TF, this);
-  else
-    // Return inert tracer object.
-    return FrontendStatsTracer();
+template<>
+const UnifiedStatsReporter::TraceFormatter*
+FrontendStatsTracer::getTraceFormatter<const clang::Decl *>() {
+  return &TF;
 }

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -167,6 +167,8 @@ static void addCommonFrontendArgs(const ToolChain &TC,
   inputArgs.AddLastArg(arguments, options::OPT_enforce_exclusivity_EQ);
   inputArgs.AddLastArg(arguments, options::OPT_stats_output_dir);
   inputArgs.AddLastArg(arguments, options::OPT_trace_stats_events);
+  inputArgs.AddLastArg(arguments, options::OPT_profile_stats_events);
+  inputArgs.AddLastArg(arguments, options::OPT_profile_stats_entities);
   inputArgs.AddLastArg(arguments,
                        options::OPT_solver_shrink_unsolved_threshold);
   inputArgs.AddLastArg(arguments, options::OPT_O_Group);

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -179,6 +179,12 @@ void ArgsToFrontendOptionsConverter::computeDebugTimeOptions() {
     if (Args.getLastArg(OPT_trace_stats_events)) {
       Opts.TraceStats = true;
     }
+    if (Args.getLastArg(OPT_profile_stats_events)) {
+      Opts.ProfileEvents = true;
+    }
+    if (Args.getLastArg(OPT_profile_stats_entities)) {
+      Opts.ProfileEntities = true;
+    }
   }
 }
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -391,7 +391,7 @@ shouldImplicityImportSwiftOnoneSupportModule(CompilerInvocation &Invocation) {
 }
 
 void CompilerInstance::performSema() {
-  SharedTimer timer("performSema");
+  FrontendStatsTracer tracer(Context->Stats, "perform-sema");
   Context->LoadedModules[MainModule->getName()] = getMainModule();
 
   if (Invocation.getInputKind() == InputFileKind::IFK_SIL) {
@@ -439,7 +439,7 @@ CompilerInstance::ImplicitImports::ImplicitImports(CompilerInstance &compiler) {
 }
 
 bool CompilerInstance::loadStdlib() {
-  SharedTimer timer("performSema-loadStdlib");
+  FrontendStatsTracer tracer(Context->Stats, "load-stdlib");
   ModuleDecl *M = Context->getStdlibModule(true);
 
   if (!M) {
@@ -458,7 +458,7 @@ bool CompilerInstance::loadStdlib() {
 }
 
 ModuleDecl *CompilerInstance::importUnderlyingModule() {
-  SharedTimer timer("performSema-importUnderlyingModule");
+  FrontendStatsTracer tracer(Context->Stats, "import-underlying-module");
   ModuleDecl *objCModuleUnderlyingMixedFramework =
       static_cast<ClangImporter *>(Context->getClangModuleLoader())
           ->loadModule(SourceLoc(),
@@ -471,7 +471,7 @@ ModuleDecl *CompilerInstance::importUnderlyingModule() {
 }
 
 ModuleDecl *CompilerInstance::importBridgingHeader() {
-  SharedTimer timer("performSema-importBridgingHeader");
+  FrontendStatsTracer tracer(Context->Stats, "import-bridging-header");
   const StringRef implicitHeaderPath =
       Invocation.getFrontendOptions().ImplicitObjCHeaderPath;
   auto clangImporter =
@@ -486,7 +486,7 @@ ModuleDecl *CompilerInstance::importBridgingHeader() {
 
 void CompilerInstance::getImplicitlyImportedModules(
     SmallVectorImpl<ModuleDecl *> &importModules) {
-  SharedTimer timer("performSema-getImplicitlyImportedModules");
+  FrontendStatsTracer tracer(Context->Stats, "get-implicitly-imported-modules");
   for (auto &ImplicitImportModuleName :
        Invocation.getFrontendOptions().ImplicitImportModuleNames) {
     if (Lexer::isIdentifier(ImplicitImportModuleName)) {
@@ -542,7 +542,7 @@ void CompilerInstance::addMainFileToModule(
 
 void CompilerInstance::parseAndCheckTypes(
     const ImplicitImports &implicitImports) {
-  SharedTimer timer("performSema-parseAndCheckTypes");
+  FrontendStatsTracer tracer(Context->Stats, "parse-and-check-types");
   // Delayed parsing callback for the primary file, or all files
   // in non-WMO mode.
   std::unique_ptr<DelayedParsingCallbacks> PrimaryDelayedCB{
@@ -606,7 +606,7 @@ void CompilerInstance::parseLibraryFile(
     PersistentParserState &PersistentState,
     DelayedParsingCallbacks *PrimaryDelayedCB,
     DelayedParsingCallbacks *SecondaryDelayedCB) {
-  SharedTimer timer("performSema-parseLibraryFile");
+  FrontendStatsTracer tracer(Context->Stats, "parse-library-file");
 
   auto *NextInput = createSourceFileForMainModule(
       SourceFileKind::Library, implicitImports.kind, BufferID);
@@ -660,7 +660,8 @@ bool CompilerInstance::parsePartialModulesAndLibraryFiles(
     PersistentParserState &PersistentState,
     DelayedParsingCallbacks *PrimaryDelayedCB,
     DelayedParsingCallbacks *SecondaryDelayedCB) {
-  SharedTimer timer("performSema-parsePartialModulesAndLibraryFiles");
+  FrontendStatsTracer tracer(Context->Stats,
+                             "parse-partial-modules-and-library-files");
   bool hadLoadError = false;
   // Parse all the partial modules first.
   for (auto &PM : PartialModules) {
@@ -684,8 +685,8 @@ void CompilerInstance::parseAndTypeCheckMainFile(
     PersistentParserState &PersistentState,
     DelayedParsingCallbacks *DelayedParseCB,
     OptionSet<TypeCheckingFlags> TypeCheckOptions) {
-  SharedTimer timer(
-      "performSema-checkTypesWhileParsingMain-parseAndTypeCheckMainFile");
+  FrontendStatsTracer tracer(Context->Stats,
+                             "parse-and-typecheck-main-file");
   bool mainIsPrimary =
       (isWholeModuleCompilation() || isPrimaryInput(MainBufferID));
 

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1477,6 +1477,8 @@ computeStatsReporter(const CompilerInvocation &Invocation, CompilerInstance *Ins
   StringRef OutputType = llvm::sys::path::extension(OutFile);
   std::string TripleName = LangOpts.Target.normalize();
   auto Trace = Invocation.getFrontendOptions().TraceStats;
+  auto ProfileEvents = Invocation.getFrontendOptions().ProfileEvents;
+  auto ProfileEntities = Invocation.getFrontendOptions().ProfileEntities;
   SourceManager *SM = &Instance->getSourceMgr();
   clang::SourceManager *CSM = nullptr;
   if (auto *clangImporter = static_cast<ClangImporter *>(
@@ -1485,7 +1487,8 @@ computeStatsReporter(const CompilerInvocation &Invocation, CompilerInstance *Ins
   }
   return llvm::make_unique<UnifiedStatsReporter>(
       "swift-frontend", FEOpts.ModuleName, InputName, TripleName, OutputType,
-      OptType, StatsOutputDir, SM, CSM, Trace);
+      OptType, StatsOutputDir, SM, CSM, Trace,
+      ProfileEvents, ProfileEntities);
 }
 
 int swift::performFrontend(ArrayRef<const char *> Args,

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -515,13 +515,8 @@ struct SILFunctionTraceFormatter : public UnifiedStatsReporter::TraceFormatter {
 
 static SILFunctionTraceFormatter TF;
 
-UnifiedStatsReporter::FrontendStatsTracer
-UnifiedStatsReporter::getStatsTracer(StringRef EventName,
-                                     const SILFunction *F) {
-  if (LastTracedFrontendCounters)
-    // Return live tracer object.
-    return FrontendStatsTracer(EventName, F, &TF, this);
-  else
-    // Return inert tracer object.
-    return FrontendStatsTracer();
+template<>
+const UnifiedStatsReporter::TraceFormatter*
+FrontendStatsTracer::getTraceFormatter<const SILFunction *>() {
+  return &TF;
 }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -707,9 +707,7 @@ void SILGenModule::emitFunction(FuncDecl *fd) {
   emitAbstractFuncDecl(fd);
 
   if (hasSILBody(fd)) {
-    UnifiedStatsReporter::FrontendStatsTracer Tracer;
-    if (getASTContext().Stats)
-      Tracer = getASTContext().Stats->getStatsTracer("emit-SIL", fd);
+    FrontendStatsTracer Tracer(getASTContext().Stats, "emit-SIL", fd);
     PrettyStackTraceDecl stackTrace("emitting SIL for", fd);
 
     SILDeclRef constant(decl);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3949,9 +3949,7 @@ public:
       : TC(TC), IsFirstPass(IsFirstPass), IsSecondPass(IsSecondPass) {}
 
   void visit(Decl *decl) {
-    UnifiedStatsReporter::FrontendStatsTracer Tracer;
-    if (TC.Context.Stats)
-      Tracer = TC.Context.Stats->getStatsTracer("typecheck-decl", decl);
+    FrontendStatsTracer StatsTracer(TC.Context.Stats, "typecheck-decl", decl);
     PrettyStackTraceDecl StackTrace("type-checking", decl);
     
     DeclVisitor<DeclChecker>::visit(decl);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -21,6 +21,7 @@
 #include "TypeChecker.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/StringExtras.h"
+#include "swift/Basic/Statistic.h"
 #include "swift/AST/AccessScope.h"
 #include "swift/AST/GenericSignatureBuilder.h"
 #include "swift/AST/ASTContext.h"
@@ -3046,6 +3047,9 @@ void ConformanceChecker::ensureRequirementsAreSatisfied(
 #pragma mark Protocol conformance checking
 void ConformanceChecker::checkConformance(MissingWitnessDiagnosisKind Kind) {
   assert(!Conformance->isComplete() && "Conformance is already complete");
+
+  FrontendStatsTracer statsTracer(TC.Context.Stats, "check-conformance",
+                                  Conformance);
 
   llvm::SaveAndRestore<bool> restoreSuppressDiagnostics(SuppressDiagnostics);
   SuppressDiagnostics = false;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -694,8 +694,8 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
 }
 
 void swift::performWholeModuleTypeChecking(SourceFile &SF) {
-  SharedTimer("performWholeModuleTypeChecking");
   auto &Ctx = SF.getASTContext();
+  FrontendStatsTracer tracer(Ctx.Stats, "perform-whole-module-type-checking");
   Ctx.diagnoseAttrsRequiringFoundation(SF);
   Ctx.diagnoseObjCMethodConflicts(SF);
   Ctx.diagnoseObjCUnsatisfiedOptReqConflicts(SF);

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -420,9 +420,7 @@ static void typeCheckFunctionsAndExternalDecls(TypeChecker &TC) {
       // but that gets tricky with synthesized function bodies.
       if (AFD->isBodyTypeChecked()) continue;
 
-      UnifiedStatsReporter::FrontendStatsTracer Tracer;
-      if (TC.Context.Stats)
-        Tracer = TC.Context.Stats->getStatsTracer("typecheck-fn", AFD);
+      FrontendStatsTracer StatsTracer(TC.Context.Stats, "typecheck-fn", AFD);
       PrettyStackTraceDecl StackEntry("type-checking", AFD);
       TC.typeCheckAbstractFunctionBody(AFD);
 

--- a/test/Misc/stats_dir_profiler.swift
+++ b/test/Misc/stats_dir_profiler.swift
@@ -1,0 +1,30 @@
+// RUN: %empty-directory(%t)
+// RUN: %empty-directory(%t/stats-events)
+// RUN: %empty-directory(%t/stats-entities)
+// RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t/stats-events %s -profile-stats-events
+// RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t/stats-entities %s -profile-stats-entities
+// RUN: %FileCheck -check-prefix=EVENTS -input-file %t/stats-events/*.dir/Time.User.events %s
+// RUN: %FileCheck -check-prefix=ENTITIES -input-file %t/stats-entities/*.dir/Time.User.entities %s
+
+// EVENTS: {{perform-sema;.*;typecheck-decl [0-9]+}}
+// ENTITIES: {{perform-sema;.*;typecheck-fn bar\(\);typecheck-decl <pattern binding> [0-9]+}}
+
+public func foo() {
+    print("hello")
+}
+
+protocol Proto {
+  func bar() -> Int;
+}
+
+class Bar {
+  typealias T = Int
+}
+
+extension Bar : Proto {
+  func bar() -> T {
+    let x = 1
+    let y = Int(1.0)
+    return x + y
+  }
+}

--- a/test/Misc/stats_dir_tracer.swift
+++ b/test/Misc/stats_dir_tracer.swift
@@ -2,8 +2,26 @@
 // RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t %s -trace-stats-events
 // RUN: %FileCheck -input-file %t/*.csv %s
 
-// CHECK: {{"Sema.NumTypesDeserialized"}}
+// CHECK: {{[0-9]+,[0-9]+,"exit","check-conformance","Sema.NominalTypeLookupDirectCount",[0-9]+,[0-9]+,"<conformance Bar : Proto>","\[.*stats_dir_tracer.swift:21:1 - line:27:1\]"}}
+// CHECK: {{[0-9]+,[0-9]+,"exit","typecheck-fn","Sema.NumTypesDeserialized",[0-9]+,[0-9]+,"foo\(\)","\[.*stats_dir_tracer.swift:9:8 - line:11:1\]"}}
+// CHECK: {{[0-9]+,[0-9]+,"exit","typecheck-decl","Sema.NumConstraintScopes",[0-9]+,[0-9]+,"<pattern binding>","\[.*stats_dir_tracer.swift:23:5 - line:23:13\]"}}
 
 public func foo() {
     print("hello")
+}
+
+protocol Proto {
+  func bar() -> Int;
+}
+
+class Bar {
+  typealias T = Int
+}
+
+extension Bar : Proto {
+  func bar() -> T {
+    let x = 1
+    let y = Int(1.0)
+    return x + y
+  }
 }

--- a/test/Misc/stats_dir_tracer.swift
+++ b/test/Misc/stats_dir_tracer.swift
@@ -2,7 +2,7 @@
 // RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t %s -trace-stats-events
 // RUN: %FileCheck -input-file %t/*.csv %s
 
-// CHECK: {{[0-9]+,[0-9]+,"exit","check-conformance","Sema.NominalTypeLookupDirectCount",[0-9]+,[0-9]+,"<conformance Bar : Proto>","\[.*stats_dir_tracer.swift:21:1 - line:27:1\]"}}
+// CHECK: {{[0-9]+,[0-9]+,"exit","lookup-direct","Sema.NominalTypeLookupDirectCount",[0-9]+,[0-9]+,"Proto","\[.*stats_dir_tracer.swift:13:1 - line:15:1\]"}}
 // CHECK: {{[0-9]+,[0-9]+,"exit","typecheck-fn","Sema.NumTypesDeserialized",[0-9]+,[0-9]+,"foo\(\)","\[.*stats_dir_tracer.swift:9:8 - line:11:1\]"}}
 // CHECK: {{[0-9]+,[0-9]+,"exit","typecheck-decl","Sema.NumConstraintScopes",[0-9]+,[0-9]+,"<pattern binding>","\[.*stats_dir_tracer.swift:23:5 - line:23:13\]"}}
 


### PR DESCRIPTION
Followup to #14695 with a single additional feature, commit ea2e87f, that adds a couple banks of hierarchical profilers to the -stats-output-dir / -trace-stats-events machinery. The user need only pass -profile-stats-events or -profile-stats-entities (along with -stats-output-dir) to get the full feature, so it's still quite easy to explain, capture, transport, etc.

The additional output is a subdirectory full of plain-text hierarchical profiles in the input format to flamegraph.pl, each of which shows time or event-counts arranged into pseudo-stacks formed by the entry/exit events of the FrontendStatsTracer objects, optionally subdivided by source entity (though that makes the profile quite a bit more fine-grained -- it also removes the mystery of which call to "typecheck-decl" is which!).

Here's a (github-sanitized, script-disabled so only half-useful, but you can still get tooltips) version showing the Sema.NumGenericSignatureBuilders counter broken down by source entity in a single file from the Plank project, as an example:
<img src="https://gist.githubusercontent.com/graydon/71352764ba4a8f41a8e2ff68325ac19e/raw/92119c4709bf518db0c51269b11fbdc93e049832/gistfile1.svg?sanitize=true">

I'll push a few more tests next week, just wanted to get this posted for any early feedback.