### PR TITLE
[ownership-verifier] Improve error message for owned values leaked du…

### DIFF
--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -1921,11 +1921,16 @@ bool SILValueOwnershipChecker::checkValueWithoutLifetimeEndingUses() {
 
   if (!isValueAddressOrTrivial(Value, Mod)) {
     return !handleError([&] {
-      llvm::errs() << "Function: '" << Value->getFunction()->getName() << "'\n"
-                   << "Non trivial values, non address values, and non "
-                      "guaranteed function args must have at least one "
-                      "lifetime ending use?!\n"
-                   << "Value: " << *Value << '\n';
+      llvm::errs() << "Function: '" << Value->getFunction()->getName() << "'\n";
+      if (Value.getOwnershipKind() == ValueOwnershipKind::Owned) {
+        llvm::errs() << "Error! Found a leaked owned value that was never "
+                        "consumed.\n";
+      } else {
+        llvm::errs() << "Non trivial values, non address values, and non "
+                        "guaranteed function args must have at least one "
+                        "lifetime ending use?!\n";
+      }
+      llvm::errs() << "Value: " << *Value << '\n';
     });
   }
 

--- a/test/SIL/ownership-verifier/leaks.sil
+++ b/test/SIL/ownership-verifier/leaks.sil
@@ -1,0 +1,71 @@
+// RUN: %target-sil-opt -module-name Swift -sil-ownership-verifier-enable-testing -enable-sil-ownership -enable-sil-verify-all=0 %s -o /dev/null 2>&1 | %FileCheck %s
+// REQUIRES: asserts
+
+// This file is meant to contain dataflow tests that are true leaks. It is
+// intended to test both that we are failing and that we are emitting
+// appropriate error messages.
+
+//////////////////
+// Declarations //
+//////////////////
+
+sil_stage canonical
+
+import Builtin
+
+///////////
+// Tests //
+///////////
+
+// CHECK-LABEL: Function: 'owned_never_consumed'
+// CHECK: Error! Found a leaked owned value that was never consumed.
+// CHECK: Value:   %1 = copy_value %0 : $Builtin.NativeObject
+sil @owned_never_consumed : $@convention(thin) (@guaranteed Builtin.NativeObject) -> () {
+bb0(%0 : @guaranteed $Builtin.NativeObject):
+  %1 = copy_value %0 : $Builtin.NativeObject
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: Function: 'owned_leaks_along_one_path'
+// CHECK: Error! Found a leak due to a consuming post-dominance failure!
+// CHECK:     Value: %0 = argument of bb0 : $Builtin.NativeObject
+// CHECK:     Post Dominating Failure Blocks:
+// CHECK:         bb1
+sil @owned_leaks_along_one_path : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  cond_br undef, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  destroy_value %0 : $Builtin.NativeObject
+  br bb3
+
+bb3:
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// Make sure that we report the leak at the phi.
+// CHECK-LABEL: Function: 'owned_leaks_with_phi'
+// CHECK: Error! Found a leaked owned value that was never consumed.
+// CHECK: Value: %6 = argument of bb4 : $Builtin.NativeObject
+sil @owned_leaks_with_phi : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+bb0(%0 : @owned $Builtin.NativeObject):
+  br bb1(%0 : $Builtin.NativeObject)
+
+bb1(%1 : @owned $Builtin.NativeObject):
+  cond_br undef, bb3, bb2
+
+bb2:
+  br bb4(%1 : $Builtin.NativeObject)
+
+bb3:
+  br bb1(%1 : $Builtin.NativeObject)
+
+bb4(%2 : @owned $Builtin.NativeObject):
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
…e to lack of "lifetime ending uses".

The ownership verifier diagnoses leaks of owned objects in two different
places/ways:

1. If the owned value does not have any "consuming" uses, we bail early without
performing dataflow verification.
2. If the owned value has at least 1 "consuming" uses, we perform dataflow to
determine the blocks where the leaked value escapes without being destroyed.

In the latter case, we give a nice error message saying that a leak occured. In
contrast in the former, we go down a "generic error" path that just says that a
"lifetime ending use" is required. This commit changes that generic error
message for owned parameters to say that the value was leaked, resulting in a
clearer message. The other cases are still left along though.

I also added a test file to specifically test leaks/leak error messages. I added
a few tests to make sure this error message is correct and a few more tests just
for fun.
