### PR TITLE
IRGen: adjust protocol conformance references in PE/COFF

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2252,6 +2252,17 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(SILFunction *f,
 static llvm::GlobalVariable *createGOTEquivalent(IRGenModule &IGM,
                                                  llvm::Constant *global,
                                                  StringRef globalName) {
+  if (IGM.Triple.getObjectFormat() == llvm::Triple::COFF) {
+    if (cast<llvm::GlobalValue>(global)->hasDLLImportStorageClass()) {
+      llvm::GlobalVariable *GV =
+          new llvm::GlobalVariable(IGM.Module, global->getType(),
+                                   /*Constant=*/true,
+                                   llvm::GlobalValue::ExternalLinkage,
+                                   nullptr, llvm::Twine("__imp_") + globalName);
+      GV->setExternallyInitialized(true);
+      return GV;
+    }
+  }
 
   auto gotEquivalent = new llvm::GlobalVariable(IGM.Module,
                                       global->getType(),

--- a/test/IRGen/dllimport.swift
+++ b/test/IRGen/dllimport.swift
@@ -52,7 +52,7 @@ public func g() {
 // CHECK-OPT-DAG: declare dllimport %swift.refcounted* @swift_retain(%swift.refcounted* returned) local_unnamed_addr
 // CHECK-OPT-DAG: @"$SBoWV" = external dllimport global i8*
 // CHECK-OPT-DAG: @"$S9dllexport1cCN" = external dllimport global %swift.type
-// CHECK-OPT-DAG: @"$S9dllexport1pMp" = external dllimport global %swift.protocol
+// CHECK-OPT-DAG: @"__imp_$S9dllexport1pMp" = external externally_initialized constant %swift.protocol*
 // CHECK-OPT-DAG: declare dllimport swiftcc i8* @"$S9dllexport2ciAA1cCvau"()
 // CHECK-OPT-DAG: declare dllimport %swift.type* @"$S9dllexport1cCMa"()
 // CHECK-OPT-DAG: declare dllimport void @swift_deallocClassInstance(%swift.refcounted*, i32, i32)


### PR DESCRIPTION
There is no GOT on PE/COFF.  However, the IAT entries serve the same
purpose.  Use the synthetic symbol which will be initialized externally
by the loader to compute the address.  This allows for cross-module
protocol references on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
