### PR TITLE
Revert "[test] Disable ClangImporter/private_frameworks_modules.swift"

### DIFF
--- a/test/ClangImporter/private_frameworks_modules.swift
+++ b/test/ClangImporter/private_frameworks_modules.swift
@@ -1,8 +1,7 @@
-// REQUIRES: rdar37618912
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck -F %S/Inputs/frameworks -DOLD -verify %s -Xcc -Wno-private-module
-// RUN: %target-swift-frontend -typecheck -F %S/Inputs/frameworks -DNEW -verify %s -Xcc -Wno-private-module
+// RUN: %target-swift-frontend -typecheck -F %S/Inputs/frameworks -DOLD -verify %s -Xcc -w
+// RUN: %target-swift-frontend -typecheck -F %S/Inputs/frameworks -DNEW -verify %s -Xcc -w
 
 import PrivateAsSubmodule.Private
 


### PR DESCRIPTION
This reverts #14693. -Wno- options currently aren't respected with -Xcc, so just use a blanket -w instead.

rdar://37618912