### PR TITLE
[5.0] Revert "[test] Disable ClangImporter/private_frameworks_modules.swift"

### DIFF
--- a/test/ClangImporter/private_frameworks_modules.swift
+++ b/test/ClangImporter/private_frameworks_modules.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -typecheck -F %S/Inputs/frameworks -DOLD -verify %s -Xcc -Wno-private-module
-// RUN: %target-swift-frontend -typecheck -F %S/Inputs/frameworks -DNEW -verify %s -Xcc -Wno-private-module
+// RUN: %target-swift-frontend -typecheck -F %S/Inputs/frameworks -DOLD -verify %s -Xcc -w
+// RUN: %target-swift-frontend -typecheck -F %S/Inputs/frameworks -DNEW -verify %s -Xcc -w
 
 import PrivateAsSubmodule.Private
 


### PR DESCRIPTION
Cherry-pick of #14711 to swift-5.0-branch, although the disabling never actually happened here. Now it won't need to. rdar://37618912