### PR TITLE
[Diagnostics] Fix crash in `diagnoseSubscriptErrors`

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4640,10 +4640,12 @@ bool FailureDiagnosis::diagnoseSubscriptErrors(SubscriptExpr *SE,
           UncurriedCandidate cand = calleeInfo.candidates[0];
           auto candType = baseType->getTypeOfMember(CS.DC->getParentModule(),
                                                     cand.getDecl(), nullptr);
-          auto paramsType = candType->getAs<FunctionType>()->getInput();
-          if (!typeCheckChildIndependently(indexExpr, paramsType,
-                                           CTP_CallArgument, TCC_ForceRecheck))
-            return true;
+          if (auto *candFunc = candType->getAs<FunctionType>()) {
+            auto paramsType = candFunc->getInput();
+            if (!typeCheckChildIndependently(
+                    indexExpr, paramsType, CTP_CallArgument, TCC_ForceRecheck))
+              return true;
+          }
         }
       }
 


### PR DESCRIPTION
If there is a single candidate with a valid index type, don't assume
that such candidate always has a valid function type. There are
multiple examples of this crash we've seen but there is no reproducer
test-case unfortunately.

Resolves: rdar://problem/37565861

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
