### PR TITLE
Fix em dash and apostrophe presentation in the Swift man page.

### DIFF
--- a/docs/tools/swift.pod
+++ b/docs/tools/swift.pod
@@ -72,7 +72,7 @@ B<Fast.> Swift is intended as a replacement for C-based languages (C, C++, and
 Objective-C). As such, Swift must be comparable to those languages in
 performance for most tasks. Performance must also be predictable and consistent,
 not just fast in short bursts that require clean-up later. There are lots of
-languages with novel features — being fast is rare.
+languages with novel features - being fast is rare.
 
 B<Expressive.> Swift benefits from decades of advancement in computer science to
 offer syntax that is a joy to use, with modern features developers expect. But
@@ -81,12 +81,11 @@ works, continually evolving to make Swift even better.
 
 =head1 BUGS
 
-Reporting bugs is a great way for anyone to help improve Swift.
-The bug tracker for Swift, an open-source project, is located at
-L<https://bugs.swift.org>.
+Reporting bugs is a great way for anyone to help improve Swift. The bug tracker
+for Swift, an open-source project, is located at L<https://bugs.swift.org>.
 
 If a bug can be reproduced only within an Xcode project or a playground, or if
-the bug is associated with an Apple NDA, please file a report to Apple’s
+the bug is associated with an Apple NDA, please file a report to Apple's
 bug reporter at L<https://bugreport.apple.com> instead.
 
 =head1 SEE ALSO


### PR DESCRIPTION
Terminal (`man swift`) currently renders em dashes and apostrophes incorrectly (as the letter X rather than the proper symbol):

> `please file a report to AppleXs bug reporter`
> `features X being fast is rare`

This PR replaces those characters with their ASCII-safe representations. If there's a nice way to use the semantically-correct characters in the POD format, I'd be happy to use that way, too, but this fix is better than the current situation. 

---

This PR makes a small change nearby in the same document:  it reformats some whitespace to remove a double space after a sentence:

> `a great way for anyone to help improve Swift.  The bug tracker`


