### PR TITLE
[Metadata/TypeByName] NFC: Don't try to check for dot syntax in presence o…

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -851,7 +851,7 @@ swift::_getTypeByMangledName(StringRef typeName,
       return llvm::StringRef::npos;
     if (typeName.find('.', dotPos + 1) != llvm::StringRef::npos)
       return llvm::StringRef::npos;
-    if (typeName.find('$') != llvm::StringRef::npos)
+    if (typeName.find('\1') != llvm::StringRef::npos)
       return llvm::StringRef::npos;
     return dotPos;
   };


### PR DESCRIPTION
…f symbolic references

If symbolic references are present in the mangled name don't try
to check for convenience dot syntax as well since they can't appear
together.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
