### PR TITLE
Don't force inlinable constructors to delegate in non-resilient code

### DIFF
--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -5471,7 +5471,11 @@ ConstructorDecl::getDelegatingOrChainedInitKind(DiagnosticEngine *diags,
   // always delegating. This occurs if the struct type is not fixed layout,
   // and the constructor is either inlinable or defined in another module.
   if (Kind == BodyInitKind::None && isa<StructDecl>(NTD)) {
-    if (NTD->isFormallyResilient() &&
+    // Note: This is specifically not using isFormallyResilient. We relax this
+    // rule for structs in non-resilient modules so that they can have inlinable
+    // constructors, as long as those constructors don't reference private
+    // declarations.
+    if (NTD->isResilient() &&
         getResilienceExpansion() == ResilienceExpansion::Minimal) {
       Kind = BodyInitKind::Delegating;
 

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1620,9 +1620,12 @@ bool TypeChecker::typeCheckConstructorBodyUntil(ConstructorDecl *ctor,
     }
 
     // An inlinable constructor in a class must always be delegating,
-    // unless the class is formally '@_fixed_layout'.
-    if (!isDelegating &&
-        ClassD->isFormallyResilient() &&
+    // unless the class is '@_fixed_layout'.
+    // Note: This is specifically not using isFormallyResilient. We relax this
+    // rule for classes in non-resilient modules so that they can have inlinable
+    // constructors, as long as those constructors don't reference private
+    // declarations.
+    if (!isDelegating && ClassD->isResilient() &&
         ctor->getResilienceExpansion() == ResilienceExpansion::Minimal) {
       diagnose(ctor, diag::class_designated_init_inlineable_resilient,
                ClassD->getDeclaredInterfaceType(),

--- a/test/decl/init/resilience-cross-module.swift
+++ b/test/decl/init/resilience-cross-module.swift
@@ -1,0 +1,38 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_protocol.swiftmodule -module-name=resilient_protocol %S/../../Inputs/resilient_protocol.swift
+
+// RUN: %target-swift-frontend -typecheck -swift-version 4 -verify -I %t %s
+// RUN: %target-swift-frontend -typecheck -swift-version 4 -verify -enable-resilience -I %t %s
+
+// RUN: %target-swift-frontend -typecheck -swift-version 5 -verify -I %t %s
+// RUN: %target-swift-frontend -typecheck -swift-version 5 -verify -enable-resilience -I %t %s
+
+import resilient_struct
+import resilient_protocol
+
+// Size is not @_fixed_layout, so we cannot define a new designated initializer
+extension Size {
+  init(ww: Int, hh: Int) {
+    self.w = ww
+    self.h = hh // expected-error {{'let' property 'h' may not be initialized directly; use "self.init(...)" or "self = ..." instead}}
+  }
+
+  // This is OK
+  init(www: Int, hhh: Int) {
+    self.init(w: www, h: hhh)
+  }
+
+  // This is OK
+  init(other: Size) {
+    self = other
+  }
+}
+
+// Protocol extension initializers are OK too
+extension OtherResilientProtocol {
+  public init(other: Self) {
+    self = other
+  }
+}

--- a/test/decl/init/resilience.swift
+++ b/test/decl/init/resilience.swift
@@ -1,34 +1,9 @@
-// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -swift-version 4 -verify -enable-resilience %s -DRESILIENT
+// RUN: %target-swift-frontend -typecheck -swift-version 5 -verify -enable-resilience %s -DRESILIENT
 
-// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../../Inputs/resilient_struct.swift
-// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_protocol.swiftmodule -module-name=resilient_protocol %S/../../Inputs/resilient_protocol.swift
-
-// RUN: %target-swift-frontend -typecheck -swift-version 4 -verify -I %t %s
-// RUN: %target-swift-frontend -typecheck -swift-version 4 -verify -enable-resilience -I %t %s
-
-// RUN: %target-swift-frontend -typecheck -swift-version 5 -verify -I %t %s
-// RUN: %target-swift-frontend -typecheck -swift-version 5 -verify -enable-resilience -I %t %s
-
-import resilient_struct
-import resilient_protocol
-
-// Size is not @_fixed_layout, so we cannot define a new designated initializer
-extension Size {
-  init(ww: Int, hh: Int) {
-    self.w = ww
-    self.h = hh // expected-error {{'let' property 'h' may not be initialized directly; use "self.init(...)" or "self = ..." instead}}
-  }
-
-  // This is OK
-  init(www: Int, hhh: Int) {
-    self.init(w: www, h: hhh)
-  }
-
-  // This is OK
-  init(other: Size) {
-    self = other
-  }
-}
+// There should be no errors when run without resilience enabled.
+// RUN: %target-swift-frontend -typecheck -swift-version 4 %s
+// RUN: %target-swift-frontend -typecheck -swift-version 5 %s
 
 // Animal is not @_fixed_layout, so we cannot define an @_inlineable
 // designated initializer
@@ -84,12 +59,5 @@ extension Gadget {
   @_inlineable public init(unused: Int) {
     // This is OK
     self.init()
-  }
-}
-
-// Protocol extension initializers are OK too
-extension OtherResilientProtocol {
-  public init(other: Self) {
-    self = other
   }
 }


### PR DESCRIPTION
This restriction came from wanting to make resilient and non-resilient code follow the same rules whenever possible, but after thinking about it a bit more we realized there was no reason why you *wouldn't* just mark your structs `@_fixed_layout` in non-resilient libraries anyway. Since that (currently?) doesn't affect what you can do with the struct across module boundaries, and since the layout of the struct is available anyway in a non-resilient library, there's no real downside, which means it's a meaningless restriction.

The same logic doesn't *quite* apply to classes, since classes are normally much more flexible than structs. (For example, you could add a stored property to a class without recompiling clients, as long as no initializers are inlined.) But it's close enough that we don't want to put in the restriction at this time.

All of this is about attributes that haven't been finalized yet anyway (hence the leading underscore), but it's still useful information.

rdar://problem/37408668