### PR TITLE
SwiftSyntax: Add a trait for those statement nodes with code block as body.

### DIFF
--- a/tools/SwiftSyntax/SyntaxNodes.swift.gyb
+++ b/tools/SwiftSyntax/SyntaxNodes.swift.gyb
@@ -54,19 +54,6 @@ public struct UnknownSyntax: _SyntaxBase {
   }
 }
 
-% for trait in TRAITS:
-public protocol ${trait.trait_name} {
-% for child in trait.children:
-%   ret_type = child.type_name
-%   if child.is_optional:
-%       ret_type += '?'
-%    end
-  var ${child.swift_name}: ${ret_type} { get }
-  func with${child.name}(_ newChild: ${child.type_name}?) -> Self
-% end
-}
-% end
-
 % for node in SYNTAX_NODES:
 %   base_type = node.base_type
 %   if node.is_base():
@@ -75,12 +62,7 @@ public protocol ${node.name}: Syntax {}
 %   elif node.collection_element:
 %     pass
 %   else:
-%     traits_list = ""
-%     if node.traits:
-%       traits_list = ", ".join(node.traits)
-%       traits_list = traits_list + ", "
-%     end
-public struct ${node.name}: ${traits_list} ${base_type}, _SyntaxBase, Hashable {
+public struct ${node.name}: ${base_type}, _SyntaxBase, Hashable {
 %     if node.children:
   enum Cursor: Int {
 %       for child in node.children:
@@ -189,6 +171,31 @@ public struct ${node.name}: ${traits_list} ${base_type}, _SyntaxBase, Hashable {
   }
 }
 
+%   end
+% end
+
+% for trait in TRAITS:
+public protocol ${trait.trait_name}Syntax {
+% for child in trait.children:
+%   ret_type = child.type_name
+%   if child.is_optional:
+%       ret_type += '?'
+%   end
+  var ${child.swift_name}: ${ret_type} { get }
+  func with${child.name}(_ newChild: ${child.type_name}?) -> Self
+% end
+}
+% end
+
+% for node in SYNTAX_NODES:
+%   base_type = node.base_type
+%   if node.is_base():
+%     pass
+%   elif node.collection_element:
+%     pass
+%   elif node.traits:
+%     traits_list = ", ".join(trait + 'Syntax' for trait in node.traits)
+extension ${node.name}: ${traits_list} {}
 %   end
 % end
 

--- a/utils/gyb_syntax_support/CommonNodes.py
+++ b/utils/gyb_syntax_support/CommonNodes.py
@@ -32,7 +32,7 @@ COMMON_NODES = [
 
     # code-block -> '{' stmt-list '}'
     Node('CodeBlock', kind='Syntax',
-         traits=['BracedSyntax'],
+         traits=['Braced'],
          children=[
              Child('LeftBrace', kind='LeftBraceToken'),
              Child('Statements', kind='CodeBlockItemList'),

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -15,7 +15,7 @@ DECL_NODES = [
     #                            typealias-name generic-parameter-clause?
     #                            type-assignment
     # typealias-name -> identifier
-    Node('TypealiasDecl', kind='Decl', traits=['IdentifiedDeclSyntax'],
+    Node('TypealiasDecl', kind='Decl', traits=['IdentifiedDecl'],
          children=[
              Child('Attributes', kind='AttributeList',
                    is_optional=True),
@@ -36,7 +36,7 @@ DECL_NODES = [
     #                                 inheritance-clause? type-assignment?
     #                                 generic-where-clause?
     # associatedtype-name -> identifier
-    Node('AssociatedtypeDecl', kind='Decl', traits=['IdentifiedDeclSyntax'],
+    Node('AssociatedtypeDecl', kind='Decl', traits=['IdentifiedDecl'],
          children=[
              Child('Attributes', kind='AttributeList',
                    is_optional=True),
@@ -158,7 +158,7 @@ DECL_NODES = [
     #                     '{' class-members '}'
     # class-name -> identifier
     Node('ClassDecl', kind='Decl',
-         traits=['DeclGroupSyntax', 'IdentifiedDeclSyntax'],
+         traits=['DeclGroup', 'IdentifiedDecl'],
          children=[
              Child('Attributes', kind='AttributeList',
                    is_optional=True),
@@ -183,7 +183,7 @@ DECL_NODES = [
     #                         '{' struct-members '}'
     # struct-name -> identifier
     Node('StructDecl', kind='Decl',
-         traits=['DeclGroupSyntax', 'IdentifiedDeclSyntax'],
+         traits=['DeclGroup', 'IdentifiedDecl'],
          children=[
              Child('Attributes', kind='AttributeList',
                    is_optional=True),
@@ -201,7 +201,7 @@ DECL_NODES = [
          ]),
 
     Node('ProtocolDecl', kind='Decl',
-         traits=['DeclGroupSyntax', 'IdentifiedDeclSyntax'],
+         traits=['DeclGroup', 'IdentifiedDecl'],
          children=[
              Child('Attributes', kind='AttributeList',
                    is_optional=True),
@@ -222,7 +222,7 @@ DECL_NODES = [
     #                            generic-where-clause?
     #                            '{' extension-members '}'
     # extension-name -> identifier
-    Node('ExtensionDecl', kind='Decl', traits=['DeclGroupSyntax'],
+    Node('ExtensionDecl', kind='Decl', traits=['DeclGroup'],
          children=[
              Child('Attributes', kind='AttributeList',
                    is_optional=True),
@@ -237,7 +237,7 @@ DECL_NODES = [
              Child('Members', kind='MemberDeclBlock'),
          ]),
 
-    Node('MemberDeclBlock', kind='Syntax', traits=['BracedSyntax'],
+    Node('MemberDeclBlock', kind='Syntax', traits=['Braced'],
          children=[
              Child('LeftBrace', kind='LeftBraceToken'),
              Child('Members', kind='DeclList'),
@@ -315,7 +315,7 @@ DECL_NODES = [
          element='Syntax',
          element_name='Modifier'),
 
-    Node('FunctionDecl', kind='Decl', traits=['IdentifiedDeclSyntax'],
+    Node('FunctionDecl', kind='Decl', traits=['IdentifiedDecl'],
          children=[
              Child('Attributes', kind='AttributeList',
                    is_optional=True),
@@ -467,7 +467,7 @@ DECL_NODES = [
 
     Node('AccessorList', kind="SyntaxCollection", element='AccessorDecl'),
 
-    Node('AccessorBlock', kind="Syntax", traits=['BracedSyntax'],
+    Node('AccessorBlock', kind="Syntax", traits=['Braced'],
          children=[
              Child('LeftBrace', kind='LeftBraceToken'),
              Child('AccessorListOrStmtList', kind='Syntax',

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -384,7 +384,7 @@ EXPR_NODES = [
          ]),
 
     Node('ClosureExpr', kind='Expr',
-         traits=['BracedSyntax'],
+         traits=['Braced'],
          children=[
              Child('LeftBrace', kind='LeftBraceToken'),
              Child('Signature', kind='ClosureSignature', is_optional=True),

--- a/utils/gyb_syntax_support/StmtNodes.py
+++ b/utils/gyb_syntax_support/StmtNodes.py
@@ -12,6 +12,7 @@ STMT_NODES = [
 
     # while-stmt -> label? ':'? 'while' condition-list code-block ';'?
     Node('WhileStmt', kind='Stmt',
+         traits=['WithCodeBlock'],
          children=[
              Child('LabelName', kind='IdentifierToken',
                    is_optional=True),
@@ -24,6 +25,7 @@ STMT_NODES = [
 
     # defer-stmt -> 'defer' code-block ';'?
     Node('DeferStmt', kind='Stmt',
+         traits=['WithCodeBlock'],
          children=[
              Child('DeferKeyword', kind='DeferToken'),
              Child('Body', kind='CodeBlock'),
@@ -41,6 +43,7 @@ STMT_NODES = [
 
     # repeat-while-stmt -> label? ':'? 'repeat' code-block 'while' expr ';'?
     Node('RepeatWhileStmt', kind='Stmt',
+         traits=['WithCodeBlock'],
          children=[
              Child('LabelName', kind='IdentifierToken',
                    is_optional=True),
@@ -54,6 +57,7 @@ STMT_NODES = [
 
     # guard-stmt -> 'guard' condition-list 'else' code-block ';'?
     Node('GuardStmt', kind='Stmt',
+         traits=['WithCodeBlock'],
          children=[
              Child('GuardKeyword', kind='GuardToken'),
              Child('Conditions', kind='ConditionElementList'),
@@ -70,6 +74,7 @@ STMT_NODES = [
     # for-in-stmt -> label? ':'? 'for' 'case'? pattern 'in' expr 'where'?
     #   expr code-block ';'?
     Node('ForInStmt', kind='Stmt',
+         traits=['WithCodeBlock'],
          children=[
              Child('LabelName', kind='IdentifierToken',
                    is_optional=True),
@@ -91,7 +96,7 @@ STMT_NODES = [
     # switch-stmt -> identifier? ':'? 'switch' expr '{'
     #   switch-case-list '}' ';'?
     Node('SwitchStmt', kind='Stmt',
-         traits=['BracedSyntax'],
+         traits=['Braced'],
          children=[
              Child('LabelName', kind='IdentifierToken',
                    is_optional=True),
@@ -110,6 +115,7 @@ STMT_NODES = [
 
     # do-stmt -> identifier? ':'? 'do' code-block catch-clause-list ';'?
     Node('DoStmt', kind='Stmt',
+         traits=['WithCodeBlock'],
          children=[
              Child('LabelName', kind='IdentifierToken',
                    is_optional=True),
@@ -212,6 +218,7 @@ STMT_NODES = [
     # if-stmt -> identifier? ':'? 'if' condition-list code-block
     #   else-clause ';'?
     Node('IfStmt', kind='Stmt',
+         traits=['WithCodeBlock'],
          children=[
              Child('LabelName', kind='IdentifierToken',
                    is_optional=True),
@@ -238,6 +245,7 @@ STMT_NODES = [
 
     # else-clause -> 'else' code-block
     Node('ElseBlock', kind='Syntax',
+         traits=['WithCodeBlock'],
          children=[
              Child('ElseKeyword', kind='ElseToken'),
              Child('Body', kind='CodeBlock'),

--- a/utils/gyb_syntax_support/Traits.py
+++ b/utils/gyb_syntax_support/Traits.py
@@ -8,7 +8,7 @@ class Trait(object):
 
 
 TRAITS = [
-    Trait('DeclGroupSyntax',
+    Trait('DeclGroup',
           children=[
               Child('Attributes', kind='AttributeList', is_optional=True),
               Child('AccessLevelModifier', kind='DeclModifier',
@@ -16,14 +16,19 @@ TRAITS = [
               Child('Members', kind='MemberDeclBlock'),
           ]),
 
-    Trait('BracedSyntax',
+    Trait('Braced',
           children=[
               Child('LeftBrace', kind='LeftBraceToken'),
               Child('RightBrace', kind='RightBraceToken'),
           ]),
 
-    Trait('IdentifiedDeclSyntax',
+    Trait('IdentifiedDecl',
           children=[
               Child('Identifier', kind='IdentifierToken'),
+          ]),
+
+    Trait('WithCodeBlock',
+          children=[
+              Child('Body', kind='CodeBlock'),
           ]),
 ]


### PR DESCRIPTION
This patch also refactors SyntaxNodes code so that protocol conformances
are declared as extensions.