### PR TITLE
[stdlib][NFC] Warning cleanup

### DIFF
--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -126,7 +126,7 @@ internal protocol _ArrayBufferProtocol
   var endIndex: Int { get }
 }
 
-extension _ArrayBufferProtocol where Indices == CountableRange<Int>{
+extension _ArrayBufferProtocol where Indices == Range<Int>{
 
   @_inlineable
   @_versioned
@@ -142,7 +142,7 @@ extension _ArrayBufferProtocol where Indices == CountableRange<Int>{
     let newBuffer = _ContiguousArrayBuffer<Element>(
       _uninitializedCount: buffer.count, minimumCapacity: buffer.count)
     buffer._copyContents(
-      subRange: Range(buffer.indices),
+      subRange: buffer.indices,
       initializing: newBuffer.firstElementAddress)
     self = Self( _buffer: newBuffer, shiftedToStartIndex: buffer.startIndex)
   }

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -292,7 +292,13 @@ where Bound : Strideable, Bound.Stride : SignedInteger
 
   @_inlineable
   public func _customContainsEquatableElement(_ element: Bound) -> Bool? {
-    return element >= self.lowerBound && element <= self.upperBound
+    return lowerBound <= element && element <= upperBound
+  }
+
+  @_inlineable
+  public func _customIndexOfEquatableElement(_ element: Bound) -> Index?? {
+    return lowerBound <= element && element <= upperBound
+              ? .inRange(element) : nil
   }
 }
 

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -250,6 +250,11 @@ where Bound : Strideable, Bound.Stride : SignedInteger
     return lowerBound <= element && element < upperBound
   }
 
+  @_inlineable
+  public func _customIndexOfEquatableElement(_ element: Bound) -> Index?? {
+    return lowerBound <= element && element < upperBound ? element : nil
+  }
+
   /// Accesses the element at specified position.
   ///
   /// You can subscript a collection with any valid index other than the

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -472,10 +472,6 @@ extension Substring {
   ///
   /// - Complexity: O(1)
   @_inlineable // FIXME(sil-serialize-all)
-  % if property == 'characters':
-  @available(swift, deprecated: 3.2, message:
-    "Please use String or Substring directly")
-  % end
   public init(_ content: ${View}) {
     self = content._wholeString[content.startIndex..<content.endIndex]
   }

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -48,7 +48,7 @@ internal class _SwiftNativeNSArrayWithContiguousStorage
 
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
-  internal override init() {}
+  @nonobjc internal override init() {}
 
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)


### PR DESCRIPTION
Couple of uses of `CountableRange`, a near-miss, remove a deprecation warning that won't be missed, and mark `_SwiftNativeNSArrayWithContiguousStorage.init` `@nonobjc`