### PR TITLE
SwiftSyntax: Add ParenthesizedSyntax trait and mark various syntax nodes for conformances. NFC

### DIFF
--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -56,6 +56,7 @@ DECL_NODES = [
          element='FunctionParameter'),
 
     Node('ParameterClause', kind='Syntax',
+         traits=['Parenthesized'],
          children=[
              Child('LeftParen', kind='LeftParenToken'),
              Child('ParameterList', kind='FunctionParameterList'),
@@ -106,19 +107,21 @@ DECL_NODES = [
          ]),
 
     Node('PoundErrorDecl', kind='Decl',
+         traits=['Parenthesized'],
          children=[
              Child('PoundError', kind='PoundErrorToken'),
-             Child('LeftParenToken', kind='LeftParenToken'),
+             Child('LeftParen', kind='LeftParenToken'),
              Child('Message', kind='StringLiteralExpr'),
-             Child('RightParenToken', kind='RightParenToken')
+             Child('RightParen', kind='RightParenToken')
          ]),
 
     Node('PoundWarningDecl', kind='Decl',
+         traits=['Parenthesized'],
          children=[
              Child('PoundWarning', kind='PoundWarningToken'),
-             Child('LeftParenToken', kind='LeftParenToken'),
+             Child('LeftParen', kind='LeftParenToken'),
              Child('Message', kind='StringLiteralExpr'),
-             Child('RightParenToken', kind='RightParenToken')
+             Child('RightParen', kind='RightParenToken')
          ]),
 
     Node('DeclModifier', kind='Syntax',
@@ -416,11 +419,11 @@ DECL_NODES = [
     Node('AccessLevelModifier', kind='Syntax',
          children=[
              Child('Name', kind='IdentifierToken'),
-             Child('OpenParen', kind='LeftParenToken',
+             Child('LeftParen', kind='LeftParenToken',
                    is_optional=True),
              Child('Modifier', kind='IdentifierToken',
                    is_optional=True),
-             Child('CloseParen', kind='RightParenToken',
+             Child('RightParen', kind='RightParenToken',
                    is_optional=True),
          ]),
 
@@ -447,6 +450,7 @@ DECL_NODES = [
 
     # (value)
     Node('AccessorParameter', kind='Syntax',
+         traits=['Parenthesized'],
          children=[
              Child('LeftParen', kind='LeftParenToken'),
              Child('Name', kind='IdentifierToken'),

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -59,6 +59,7 @@ EXPR_NODES = [
     Node('DeclNameArgumentList', kind='SyntaxCollection',
          element='DeclNameArgument'),
     Node('DeclNameArguments', kind='Syntax',
+         traits=['Parenthesized'],
          children=[
              Child('LeftParen', kind='LeftParenToken'),
              Child('Arguments', kind='DeclNameArgumentList'),
@@ -181,6 +182,7 @@ EXPR_NODES = [
          ]),
 
     Node('TupleExpr', kind='Expr',
+         traits=['Parenthesized'],
          children=[
              Child('LeftParen', kind='LeftParenToken'),
              Child('ElementList', kind='TupleElementList'),
@@ -459,6 +461,7 @@ EXPR_NODES = [
 
     # expression segment in a string interpolation expression.
     Node('ExpressionSegment', kind='Syntax',
+         traits=['Parenthesized'],
          children=[
              Child('Backslash', kind='BackslashToken'),
              Child('LeftParen', kind='LeftParenToken'),
@@ -501,6 +504,7 @@ EXPR_NODES = [
 
     # e.g. "#keyPath(a.b.c)"
     Node('ObjcKeyPathExpr', kind='Expr',
+         traits=['Parenthesized'],
          children=[
              Child('KeyPath', kind='PoundKeyPathToken'),
              Child('LeftParen', kind='LeftParenToken'),
@@ -515,6 +519,7 @@ EXPR_NODES = [
          ]),
     # #fileLiteral(a, b, c)
     Node('ObjectLiteralExpr', kind='Expr',
+         traits=['Parenthesized'],
          children=[
              Child('Identifier', kind='Token',
                    token_choices=[

--- a/utils/gyb_syntax_support/PatternNodes.py
+++ b/utils/gyb_syntax_support/PatternNodes.py
@@ -51,10 +51,11 @@ PATTERN_NODES = [
 
     # tuple-pattern -> '(' tuple-pattern-element-list ')'
     Node('TuplePattern', kind='Pattern',
+         traits=['Parenthesized'],
          children=[
-             Child('OpenParen', kind='LeftParenToken'),
+             Child('LeftParen', kind='LeftParenToken'),
              Child('Elements', kind='TuplePatternElementList'),
-             Child('CloseParen', kind='RightParenToken'),
+             Child('RightParen', kind='RightParenToken'),
          ]),
 
     # wildcard-pattern -> '_' type-annotation?

--- a/utils/gyb_syntax_support/Traits.py
+++ b/utils/gyb_syntax_support/Traits.py
@@ -31,4 +31,10 @@ TRAITS = [
           children=[
               Child('Body', kind='CodeBlock'),
           ]),
+
+    Trait('Parenthesized',
+          children=[
+              Child('LeftParen', kind='LeftParenToken'),
+              Child('RightParen', kind='RightParenToken'),
+          ]),
 ]

--- a/utils/gyb_syntax_support/TypeNodes.py
+++ b/utils/gyb_syntax_support/TypeNodes.py
@@ -133,6 +133,7 @@ TYPE_NODES = [
 
     # tuple-type -> '(' tuple-type-element-list ')'
     Node('TupleType', kind='Type',
+         traits=['Parenthesized'],
          children=[
              Child('LeftParen', kind='LeftParenToken'),
              Child('Elements', kind='TupleTypeElementList'),
@@ -143,6 +144,7 @@ TYPE_NODES = [
     # function-type -> attribute-list '(' function-type-argument-list ')'
     #   throwing-specifier? '->'? type?
     Node('FunctionType', kind='Type',
+         traits=['Parenthesized'],
          children=[
              Child('LeftParen', kind='LeftParenToken'),
              Child('Arguments', kind='TupleTypeElementList'),


### PR DESCRIPTION
This also helps us to fix several cases of inconsistent naming.