### PR TITLE
[AST] Retrive EndLine after StartLineAndColumn for SingleRawComment

### DIFF
--- a/include/swift/AST/RawComment.h
+++ b/include/swift/AST/RawComment.h
@@ -32,7 +32,7 @@ struct SingleRawComment {
   unsigned Kind : 8;
   unsigned StartColumn : 16;
   unsigned StartLine;
-  const unsigned EndLine;
+  unsigned EndLine;
 
   SingleRawComment(CharSourceRange Range, const SourceManager &SourceMgr);
   SingleRawComment(StringRef RawText, unsigned StartColumn);

--- a/lib/AST/RawComment.cpp
+++ b/lib/AST/RawComment.cpp
@@ -57,11 +57,11 @@ static SingleRawComment::CommentKind getCommentKind(StringRef Comment) {
 SingleRawComment::SingleRawComment(CharSourceRange Range,
                                    const SourceManager &SourceMgr)
     : Range(Range), RawText(SourceMgr.extractText(Range)),
-      Kind(static_cast<unsigned>(getCommentKind(RawText))),
-      EndLine(SourceMgr.getLineNumber(Range.getEnd())) {
+      Kind(static_cast<unsigned>(getCommentKind(RawText))) {
   auto StartLineAndColumn = SourceMgr.getLineAndColumn(Range.getStart());
   StartLine = StartLineAndColumn.first;
   StartColumn = StartLineAndColumn.second;
+  EndLine = SourceMgr.getLineNumber(Range.getEnd());
 }
 
 SingleRawComment::SingleRawComment(StringRef RawText, unsigned StartColumn)


### PR DESCRIPTION
[`llvm::SourceMgr` caches the position and the line number  of the *last* query](https://github.com/apple/swift-llvm/blob/c4ec2ab808fe4f1c01156095afea3f8e14ec15b8/lib/Support/SourceMgr.cpp#L103-L111). For subsequent queries, it usually scans from that position. However, if the query is for a position ahead of the last query, it re-scan from the top of the whole buffer. This significally slows down the performance.

This change effectively mitigate SourceKit performance regressions introduced in https://github.com/apple/swift/pull/11264 without functional changes.

rdar://problem/37570893