### PR TITLE
stubs: match ICU signature for unorm2_normalize (NFC)

### DIFF
--- a/stdlib/public/SwiftShims/UnicodeShims.h
+++ b/stdlib/public/SwiftShims/UnicodeShims.h
@@ -440,8 +440,8 @@ __swift_stdlib_unorm2_getNFCInstance(__swift_stdlib_UErrorCode *);
 SWIFT_RUNTIME_STDLIB_INTERFACE
 __swift_int32_t
 __swift_stdlib_unorm2_normalize(const __swift_stdlib_UNormalizer2 *,
-                                const __swift_uint16_t *, __swift_int32_t,
-                                __swift_uint16_t *, __swift_int32_t,
+                                const __swift_stdlib_UChar *, __swift_int32_t,
+                                __swift_stdlib_UChar *, __swift_int32_t,
                                 __swift_stdlib_UErrorCode *);
 
 SWIFT_RUNTIME_STDLIB_INTERFACE

--- a/stdlib/public/stubs/UnicodeNormalization.cpp
+++ b/stdlib/public/stubs/UnicodeNormalization.cpp
@@ -63,6 +63,7 @@ UBool u_isdefined(UChar32);
 #include <unicode/uiter.h>
 #include <unicode/ubrk.h>
 #include <unicode/uchar.h>
+#include <unicode/uvernum.h>
 
 #pragma clang diagnostic pop
 
@@ -288,11 +289,19 @@ swift::__swift_stdlib_unorm2_getNFCInstance(__swift_stdlib_UErrorCode *err) {
 }
 
 int32_t swift::__swift_stdlib_unorm2_normalize(
-    const __swift_stdlib_UNormalizer2 *norm, const __swift_uint16_t *src,
-    __swift_int32_t len, __swift_uint16_t *dst, __swift_int32_t capacity,
+    const __swift_stdlib_UNormalizer2 *norm, const __swift_stdlib_UChar *src,
+    __swift_int32_t len, __swift_stdlib_UChar *dst, __swift_int32_t capacity,
     __swift_stdlib_UErrorCode *err) {
+  // TODO remove this compatibility when we require ICU >= 60 on Linux
+#if defined(__APPLE__) || U_ICU_VERSION_MAJOR_NUM >= 60
   return unorm2_normalize(ptr_cast<UNormalizer2>(norm), src, len, dst, capacity,
                           ptr_cast<UErrorCode>(err));
+#else
+  return unorm2_normalize(ptr_cast<UNormalizer2>(norm),
+                          reinterpret_cast<const UChar *>(src), len,
+                          reinterpret_cast<UChar *>(dst), capacity,
+                          ptr_cast<UErrorCode>(err));
+#endif
 }
 
 __swift_int32_t swift::__swift_stdlib_unorm2_spanQuickCheckYes(


### PR DESCRIPTION
Adjust the signature to match the ICU declaration for
`unorm2_normalize`.  This was adjusted to allow building against ICU
59.1.  The shim type definition for the UChar ensures that the signature
is correct on all the targets.  NFC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
