### PR TITLE
[4.1][AST] Retrive EndLine after StartLineAndColumn for SingleRawComment

### DIFF
--- a/include/swift/AST/RawComment.h
+++ b/include/swift/AST/RawComment.h
@@ -32,7 +32,7 @@ struct SingleRawComment {
   unsigned Kind : 8;
   unsigned StartColumn : 16;
   unsigned StartLine;
-  const unsigned EndLine;
+  unsigned EndLine;
 
   SingleRawComment(CharSourceRange Range, const SourceManager &SourceMgr);
   SingleRawComment(StringRef RawText, unsigned StartColumn);

--- a/lib/AST/RawComment.cpp
+++ b/lib/AST/RawComment.cpp
@@ -57,11 +57,11 @@ static SingleRawComment::CommentKind getCommentKind(StringRef Comment) {
 SingleRawComment::SingleRawComment(CharSourceRange Range,
                                    const SourceManager &SourceMgr)
     : Range(Range), RawText(SourceMgr.extractText(Range)),
-      Kind(static_cast<unsigned>(getCommentKind(RawText))),
-      EndLine(SourceMgr.getLineNumber(Range.getEnd())) {
+      Kind(static_cast<unsigned>(getCommentKind(RawText))) {
   auto StartLineAndColumn = SourceMgr.getLineAndColumn(Range.getStart());
   StartLine = StartLineAndColumn.first;
   StartColumn = StartLineAndColumn.second;
+  EndLine = SourceMgr.getLineNumber(Range.getEnd());
 }
 
 SingleRawComment::SingleRawComment(StringRef RawText, unsigned StartColumn)


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/14733 to swift-4.1-branch

**Explanation:** `llvm::SourceMgr` caches the position and the line number of the last query. For subsequent queries, It usually scans from that position. However, if the query is for a position ahead of the last query, it re-scan from the top of the whole buffer. This significantly slows down the performance.
This change reorder the queries to `llvm::SourceMgr` so that they aligns the order of appearance in the source file. This change effectively mitigate performance regression introduced in https://github.com/apple/swift/pull/11264 without functional changes.
**Scope:** SourceKit and ASTSerialization. Changes are localized in `SingleRawComment` class, no interface change.
**Radar/SR:** rdar://problem/37570893
**Risk:** Low. No API change. This change is just for utilizing cache functionality of `llvm::SourceMgr`
**Testing:** Passes all tests.
**Reviewer:** @akyrtzi @benlangmuir 
