### PR TITLE
[SR-7030] Forward getLoc() to getLoc()

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1959,7 +1959,7 @@ bool AbstractClosureExpr::hasSingleExpressionBody() const {
     return (NODE)->getEndLoc();                   \
   }                                               \
   SourceLoc CLASS::getLoc() const {               \
-    return (NODE)->getStartLoc();                 \
+    return (NODE)->getLoc();                      \
   }
 
 FORWARD_SOURCE_LOCS_TO(ClosureExpr, Body.getPointer())


### PR DESCRIPTION
The `FORWARD_SOURCE_LOCS_TO` in `Expr.cpp` incorrectly forwards the `getLoc()` to `getStartLoc()`. Change this so it forwards to `getLoc()` instead, similar to include/swift/AST/Expr.h

Resolves [SR-7030](https://bugs.swift.org/browse/SR-7030).

Discovered by https://lists.swift.org/pipermail/swift-dev/Week-of-Mon-20161107/003440.html and details at https://gist.github.com/modocache/00eb437ca3cac84960992cdc23fa0f52