### PR TITLE
[5.0][AST] Retrive EndLine after StartLineAndColumn for SingleRawComment

### DIFF
--- a/include/swift/AST/RawComment.h
+++ b/include/swift/AST/RawComment.h
@@ -32,7 +32,7 @@ struct SingleRawComment {
   unsigned Kind : 8;
   unsigned StartColumn : 16;
   unsigned StartLine;
-  const unsigned EndLine;
+  unsigned EndLine;
 
   SingleRawComment(CharSourceRange Range, const SourceManager &SourceMgr);
   SingleRawComment(StringRef RawText, unsigned StartColumn);

--- a/lib/AST/RawComment.cpp
+++ b/lib/AST/RawComment.cpp
@@ -57,11 +57,11 @@ static SingleRawComment::CommentKind getCommentKind(StringRef Comment) {
 SingleRawComment::SingleRawComment(CharSourceRange Range,
                                    const SourceManager &SourceMgr)
     : Range(Range), RawText(SourceMgr.extractText(Range)),
-      Kind(static_cast<unsigned>(getCommentKind(RawText))),
-      EndLine(SourceMgr.getLineNumber(Range.getEnd())) {
+      Kind(static_cast<unsigned>(getCommentKind(RawText))) {
   auto StartLineAndColumn = SourceMgr.getLineAndColumn(Range.getStart());
   StartLine = StartLineAndColumn.first;
   StartColumn = StartLineAndColumn.second;
+  EndLine = SourceMgr.getLineNumber(Range.getEnd());
 }
 
 SingleRawComment::SingleRawComment(StringRef RawText, unsigned StartColumn)


### PR DESCRIPTION
Cherry-pick of #14733 to swift-5.0-branch.

rdar://problem/37570893