### PR TITLE
Devirtualizer: disable the “effectively final” optimization if a function is inlinable

### DIFF
--- a/include/swift/SILOptimizer/Utils/Devirtualize.h
+++ b/include/swift/SILOptimizer/Utils/Devirtualize.h
@@ -70,15 +70,17 @@ DevirtualizationResult tryDevirtualizeApply(ApplySite AI,
 bool canDevirtualizeApply(FullApplySite AI, ClassHierarchyAnalysis *CHA);
 bool isNominalTypeWithUnboundGenericParameters(SILType Ty, SILModule &M);
 bool canDevirtualizeClassMethod(FullApplySite AI, SILType ClassInstanceType,
-                                OptRemark::Emitter *ORE = nullptr);
+                                OptRemark::Emitter *ORE = nullptr,
+                                bool isEffectivelyFinalMethod = false);
 SILFunction *getTargetClassMethod(SILModule &M, SILType ClassOrMetatypeType,
                                   MethodInst *MI);
 DevirtualizationResult devirtualizeClassMethod(FullApplySite AI,
                                                SILValue ClassInstance,
                                                OptRemark::Emitter *ORE);
-DevirtualizationResult tryDevirtualizeClassMethod(FullApplySite AI,
-                                                  SILValue ClassInstance,
-                                                  OptRemark::Emitter *ORE);
+DevirtualizationResult
+tryDevirtualizeClassMethod(FullApplySite AI, SILValue ClassInstance,
+                           OptRemark::Emitter *ORE,
+                           bool isEffectivelyFinalMethod = false);
 DevirtualizationResult
 tryDevirtualizeWitnessMethod(ApplySite AI, OptRemark::Emitter *ORE);
 }

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -95,8 +95,6 @@ public class BigClass {
 }
 
 // CHECK-LABEL: define{{( protected)?}} hidden swiftcc void @"$S22big_types_corner_cases8BigClassC03useE6Struct0aH0yAA0eH0V_tF"(%T22big_types_corner_cases9BigStructV* noalias nocapture dereferenceable({{.*}}), %T22big_types_corner_cases8BigClassC* swiftself)
-// CHECK: getelementptr inbounds %T22big_types_corner_cases8BigClassC, %T22big_types_corner_cases8BigClassC*
-// CHECK: call void @"$SSqWy
 // CHECK: [[BITCAST:%.*]] = bitcast i8* {{.*}} to void (%T22big_types_corner_cases9BigStructV*, %swift.refcounted*)*
 // CHECK: call swiftcc void [[BITCAST]](%T22big_types_corner_cases9BigStructV* noalias nocapture dereferenceable({{.*}}) %0, %swift.refcounted* swiftself 
 // CHECK: ret void

--- a/test/SILOptimizer/devirt_access_serialized.sil
+++ b/test/SILOptimizer/devirt_access_serialized.sil
@@ -1,0 +1,57 @@
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -devirtualizer | %FileCheck %s
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+class X
+{
+  private func ping() -> Int
+  @objc deinit
+  init()
+}
+
+class Y : X
+{
+  @objc deinit
+  override init()
+}
+
+sil [serialized] @_TFC14devirt_access21X4pingfS0_FT_Si : $@convention(method) (@guaranteed X) -> Int
+sil public_external [transparent] @_TFSi33_convertFromBuiltinIntegerLiteralfMSiFBi2048_Si : $@convention(thin) (Builtin.Int2048, @thin Int.Type) -> Int
+sil @_TFC14devirt_access21Xd : $@convention(method) (@guaranteed X) -> @owned Builtin.NativeObject
+sil @_TFC14devirt_access21XD : $@convention(method) (@guaranteed X) -> ()
+sil @_TFC14devirt_access21XcfMS0_FT_S0_ : $@convention(method) (@owned X) -> @owned X
+sil @_TFC14devirt_access21XCfMS0_FT_S0_ : $@convention(thin) (@thick X.Type) -> @owned X
+sil @_TFC14devirt_access21Yd : $@convention(method) (@guaranteed Y) -> @owned Builtin.NativeObject
+sil @_TFC14devirt_access21YD : $@convention(method) (@guaranteed Y) -> ()
+sil @_TFC14devirt_access21YcfMS0_FT_S0_ : $@convention(method) (@owned Y) -> @owned Y
+sil @_TFC14devirt_access21YCfMS0_FT_S0_ : $@convention(thin) (@thick Y.Type) -> @owned Y
+
+//CHECK-LABEL: sil @Case
+//CHECK-NOT: function_ref @_TFC14devirt_access21X4pingfS0_FT_Si
+//CHECK: class_method
+//CHECK: apply
+//CHECK: return
+sil @Case : $@convention(thin) (@owned Y) -> Int {
+bb0(%0 : $Y):
+  debug_value %0 : $Y, let, name "a" // id: %1
+  strong_retain %0 : $Y                           // id: %2
+  %3 = upcast %0 : $Y to $X                       // users: %4, %5
+  %4 = class_method %3 : $X, #X.ping!1 : (X) -> () -> Int, $@convention(method) (@guaranteed X) -> Int // user: %5
+  %5 = apply %4(%3) : $@convention(method) (@guaranteed X) -> Int // user: %7
+  strong_release %0 : $Y                          // id: %6
+  return %5 : $Int                                // id: %7
+}
+
+sil_vtable X {
+  #X.ping!1: @_TFC14devirt_access21X4pingfS0_FT_Si	// devirt_access2.X.ping (devirt_access2.X)() -> Swift.Int
+  #X.init!initializer.1: @_TFC14devirt_access21XcfMS0_FT_S0_	// devirt_access2.X.init (devirt_access2.X.Type)() -> devirt_access2.X
+}
+
+sil_vtable Y {
+  #X.ping!1: @_TFC14devirt_access21X4pingfS0_FT_Si	// devirt_access2.X.ping (devirt_access2.X)() -> Swift.Int
+  #X.init!initializer.1: @_TFC14devirt_access21YcfMS0_FT_S0_	// devirt_access2.Y.init (devirt_access2.Y.Type)() -> devirt_access2.Y
+}

--- a/test/sil-func-extractor/basic.swift
+++ b/test/sil-func-extractor/basic.swift
@@ -56,10 +56,8 @@
 
 // EXTRACT-NOW-LABEL:   sil [serialized] @$S5basic7VehicleC3nowSiyF : $@convention(method) (@guaranteed Vehicle) -> Int {
 // EXTRACT-NOW:         bb0
-// EXTRACT-NOW:           ref_element_addr
-// EXTRACT-NOW-NEXT:      begin_access [read] [dynamic]
-// EXTRACT-NOW-NEXT:      load
-// EXTRACT-NOW-NEXT:      end_access
+// EXTRACT-NOW:           class_method
+// EXTRACT-NOW-NEXT:      apply
 // EXTRACT-NOW-NEXT:      return
 
 public struct X {


### PR DESCRIPTION
radar rdar://problem/36703886

The devirtualizer performs two optimizations:

- If a value is known to have an exact class type, ie it is the result of an alloc_ref, we can devirtualize calls of *non-final* methods, because we know we’re calling that specific method and not an override.

- If a method is known to be “effectively final” (it is not open, and there are no overrides inside the module) we can devirtualize it.

However the second optimization needs to be disabled if a function is inlinable `(F->getResilienceExpansion() == ResilienceExpansion::Minimal)`.