### PR TITLE
[SR-7036] Use || instead of && for kind comparison

### DIFF
--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -668,8 +668,8 @@ public:
 
   static bool classof(const TypeRef *TR) {
     auto Kind = TR->getKind();
-    return (Kind == TypeRefKind::UnownedStorage &&
-            Kind == TypeRefKind::WeakStorage &&
+    return (Kind == TypeRefKind::UnownedStorage ||
+            Kind == TypeRefKind::WeakStorage ||
             Kind == TypeRefKind::UnmanagedStorage);
   }
 };


### PR DESCRIPTION
<!-- What's in this pull request? -->
This fix changes the existing comparison, which was using `&&` for several incompatible kinds (and therefore always returning `false` to use `||` instead.

Reported via https://gist.github.com/modocache/00eb437ca3cac84960992cdc23fa0f52#file-swift-6edb5132-tasks-txt-L1476
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7036](https://bugs.swift.org/browse/SR-7036).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->