### PR TITLE
[SourceKit] Add syntaxtype for #error/#warning syntax coloring

### DIFF
--- a/include/swift/IDE/SyntaxModel.h
+++ b/include/swift/IDE/SyntaxModel.h
@@ -48,6 +48,8 @@ enum class SyntaxNodeKind : uint8_t {
   BuildConfigKeyword,
   /// An identifier in a #if condition.
   BuildConfigId,
+  /// #-keywords like #warning, #sourceLocation
+  PoundDirectiveKeyword,
   /// Any occurrence of '@<attribute-name>' anywhere.
   AttributeId,
   /// A "resolved/active" attribute. Mis-applied attributes will be AttributeId.

--- a/include/swift/Syntax/TokenKinds.def
+++ b/include/swift/Syntax/TokenKinds.def
@@ -24,6 +24,8 @@
 ///     POUND_OBJECT_LITERAL(kw, desc, proto)
 ///     POUND_OLD_OBJECT_LITERAL(kw, new_kw, old_arg, new_arg)
 ///     POUND_CONFIG(kw)
+///     POUND_DIRECTIVE_KEYWORD(kw)
+///       POUND_COND_DIRECTIVE_KEYWORD(kw)
 ///   PUNCTUATOR(name, str)
 ///   LITERAL(name)
 ///   MISC(name)
@@ -105,6 +107,19 @@
 ///   Every keyword prefixed with a '#' representing a configuration.
 #ifndef POUND_CONFIG
 #define POUND_CONFIG(kw) POUND_KEYWORD(kw)
+#endif
+
+/// POUND_DIRECTIVE_KEYWORD(kw)
+///   Every keyword prefixed with a '#' that is a compiler control directive.
+#ifndef POUND_DIRECTIVE_KEYWORD
+#define POUND_DIRECTIVE_KEYWORD(kw) POUND_KEYWORD(kw)
+#endif
+
+/// POUND_COND_DIRECTIVE_KEYWORD(kw)
+///   Every keyword prefixed with a '#' that is part of conditional compilation
+///   control.
+#ifndef POUND_COND_DIRECTIVE_KEYWORD
+#define POUND_COND_DIRECTIVE_KEYWORD(kw) POUND_DIRECTIVE_KEYWORD(kw)
 #endif
 
 /// PUNCTUATOR(name, str)
@@ -250,21 +265,28 @@ PUNCTUATOR(multiline_string_quote, "\"\"\"")
 PUNCTUATOR(l_square_lit,  "[#")
 PUNCTUATOR(r_square_lit,  "#]")
 
-// Keywords prefixed with a '#'.  "if" becomes "tok::pound_if".
-POUND_KEYWORD(if)
-POUND_KEYWORD(else)
-POUND_KEYWORD(elseif)
-POUND_KEYWORD(endif)
+// Keywords prefixed with a '#'.  "keyPath" becomes "tok::pound_keyPath".
 POUND_KEYWORD(keyPath)
 POUND_KEYWORD(line)
-POUND_KEYWORD(sourceLocation)
 POUND_KEYWORD(selector)
-POUND_KEYWORD(warning)
-POUND_KEYWORD(error)
+POUND_KEYWORD(file)
+POUND_KEYWORD(column)
+POUND_KEYWORD(function)
+POUND_KEYWORD(dsohandle)
+
+// Directive '#' keywords.
+POUND_DIRECTIVE_KEYWORD(sourceLocation)
+POUND_DIRECTIVE_KEYWORD(warning)
+POUND_DIRECTIVE_KEYWORD(error)
+
+// Conditional compilation '#' keywords.
+POUND_COND_DIRECTIVE_KEYWORD(if)
+POUND_COND_DIRECTIVE_KEYWORD(else)
+POUND_COND_DIRECTIVE_KEYWORD(elseif)
+POUND_COND_DIRECTIVE_KEYWORD(endif)
 
 // Keywords prefixed with a '#' that are build configurations.
 POUND_CONFIG(available)
-
 
 // Object literals and their corresponding protocols.
 POUND_OBJECT_LITERAL(fileLiteral, "file reference", ExpressibleByFileReferenceLiteral)
@@ -274,11 +296,6 @@ POUND_OBJECT_LITERAL(colorLiteral, "color", ExpressibleByColorLiteral)
 POUND_OLD_OBJECT_LITERAL(FileReference, fileLiteral, fileReferenceLiteral, resourceName)
 POUND_OLD_OBJECT_LITERAL(Image, imageLiteral, imageLiteral, resourceName)
 POUND_OLD_OBJECT_LITERAL(Color, colorLiteral, colorLiteralRed, red)
-
-POUND_KEYWORD(file)
-POUND_KEYWORD(column)
-POUND_KEYWORD(function)
-POUND_KEYWORD(dsohandle)
 
 // Single-token literals
 LITERAL(integer_literal)
@@ -314,6 +331,8 @@ MISC(string_interpolation_anchor)
 #undef POUND_OBJECT_LITERAL
 #undef POUND_OLD_OBJECT_LITERAL
 #undef POUND_CONFIG
+#undef POUND_DIRECTIVE_KEYWORD
+#undef POUND_COND_DIRECTIVE_KEYWORD
 #undef PUNCTUATOR
 #undef LITERAL
 #undef MISC

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -107,8 +107,20 @@ SyntaxModelContext::SyntaxModelContext(SourceFile &SrcFile)
         LiteralStartLoc = Loc;
         continue;
 
+#define POUND_COND_DIRECTIVE_KEYWORD(Name) case tok::pound_##Name:
+#include "swift/Syntax/TokenKinds.def"
+        Kind = SyntaxNodeKind::BuildConfigKeyword;
+        break;
+
+#define POUND_DIRECTIVE_KEYWORD(Name) case tok::pound_##Name:
+#define POUND_COND_DIRECTIVE_KEYWORD(Name)
+#include "swift/Syntax/TokenKinds.def"
+        Kind = SyntaxNodeKind::PoundDirectiveKeyword;
+        break;
+
 #define POUND_OBJECT_LITERAL(Name, Desc, Proto)
 #define POUND_OLD_OBJECT_LITERAL(Name, NewName, OldArg, NewArg)
+#define POUND_DIRECTIVE_KEYWORD(Name)
 #define POUND_KEYWORD(Name) case tok::pound_##Name:
 #include "swift/Syntax/TokenKinds.def"
         Kind = SyntaxNodeKind::Keyword;
@@ -816,17 +828,6 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
 
   } else if (auto *ConfigD = dyn_cast<IfConfigDecl>(D)) {
     for (auto &Clause : ConfigD->getClauses()) {
-      unsigned TokLen;
-      if (&Clause == &*ConfigD->getClauses().begin())
-        TokLen = 3; // '#if'
-      else if (Clause.Cond == nullptr)
-        TokLen = 5; // '#else'
-      else
-        TokLen = 7; // '#elseif'
-      if (!passNonTokenNode({SyntaxNodeKind::BuildConfigKeyword,
-                            CharSourceRange(Clause.Loc, TokLen) }))
-        return false;
-      
       if (Clause.Cond && !annotateIfConfigConditionIdentifiers(Clause.Cond))
         return false;
 
@@ -841,11 +842,6 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
         VisitedNodesInsideIfConfig.insert(Element);
       }
     }
-    
-    if (!ConfigD->hadMissingEnd())
-      if (!passNonTokenNode({ SyntaxNodeKind::BuildConfigKeyword,
-            CharSourceRange(ConfigD->getEndLoc(), 6/*'#endif'*/) }))
-        return false;
 
   } else if (auto *EnumCaseD = dyn_cast<EnumCaseDecl>(D)) {
     SyntaxStructureNode SN;

--- a/test/IDE/coloring_configs.swift
+++ b/test/IDE/coloring_configs.swift
@@ -316,3 +316,10 @@ class NestedPoundIf {
     func foo3() {}
 // CHECK: <kw>func</kw> foo3() {}
 }
+
+// CHECK: <#kw>#error</#kw>(<str>"Error"</str>)
+#error("Error")
+// CHECK: <#kw>#warning</#kw>(<str>"Warning"</str>)
+#warning("Warning")
+// CHECK: <#kw>#sourceLocation</#kw>(file: <str>"x"</str>, line: <int>1</int>)
+#sourceLocation(file: "x", line: 1)

--- a/test/SourceKit/SyntaxMapData/syntaxmap-pound-keyword.swift
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-pound-keyword.swift
@@ -8,3 +8,11 @@ let c = #column
 
 if #available(iOS 9.0, *) {}
 
+#if false
+#error("Error")
+#elseif true
+#warning("Warning")
+#else
+#sourceLocation(file: "here.swift", line:100)
+#sourceLocation()
+#endif

--- a/test/SourceKit/SyntaxMapData/syntaxmap-pound-keyword.swift.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap-pound-keyword.swift.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 206,
+  key.length: 342,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.syntaxmap: [
     {
@@ -92,6 +92,86 @@
       key.kind: source.lang.swift.syntaxtype.number,
       key.offset: 194,
       key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.buildconfig.keyword,
+      key.offset: 206,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 210,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.pounddirective.keyword,
+      key.offset: 216,
+      key.length: 6
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.string,
+      key.offset: 223,
+      key.length: 7
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.buildconfig.keyword,
+      key.offset: 232,
+      key.length: 7
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 240,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.pounddirective.keyword,
+      key.offset: 245,
+      key.length: 8
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.string,
+      key.offset: 254,
+      key.length: 9
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.buildconfig.keyword,
+      key.offset: 265,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.pounddirective.keyword,
+      key.offset: 271,
+      key.length: 15
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 287,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.string,
+      key.offset: 293,
+      key.length: 12
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 307,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.number,
+      key.offset: 312,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.pounddirective.keyword,
+      key.offset: 317,
+      key.length: 15
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.buildconfig.keyword,
+      key.offset: 335,
+      key.length: 6
     }
   ]
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -704,6 +704,7 @@ public:
     case SyntaxNodeKind::TypeId:
     case SyntaxNodeKind::BuildConfigKeyword:
     case SyntaxNodeKind::BuildConfigId:
+    case SyntaxNodeKind::PoundDirectiveKeyword:
     case SyntaxNodeKind::AttributeId:
     case SyntaxNodeKind::AttributeBuiltin:
     case SyntaxNodeKind::ObjectLiteral:

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -339,6 +339,8 @@ UIdent SwiftLangSupport::getUIDForSyntaxNodeKind(SyntaxNodeKind SC) {
     return KindBuildConfigKeyword;
   case SyntaxNodeKind::BuildConfigId:
     return KindBuildConfigId;
+  case SyntaxNodeKind::PoundDirectiveKeyword:
+    return KindPoundDirectiveKeyword;
   case SyntaxNodeKind::AttributeId:
     return KindAttributeId;
   case SyntaxNodeKind::AttributeBuiltin:

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -897,6 +897,7 @@ public:
     case SyntaxNodeKind::TypeId: Id = "type"; break;
     case SyntaxNodeKind::BuildConfigKeyword: Id = "#kw"; break;
     case SyntaxNodeKind::BuildConfigId: Id = "#id"; break;
+    case SyntaxNodeKind::PoundDirectiveKeyword: Id = "#kw"; break;
     case SyntaxNodeKind::AttributeId: Id = "attr-id"; break;
     case SyntaxNodeKind::AttributeBuiltin: Id = "attr-builtin"; break;
     case SyntaxNodeKind::EditorPlaceholder: Id = "placeholder"; break;
@@ -927,6 +928,7 @@ public:
     case SyntaxNodeKind::TypeId: Col = llvm::raw_ostream::CYAN; break;
     case SyntaxNodeKind::BuildConfigKeyword: Col = llvm::raw_ostream::YELLOW; break;
     case SyntaxNodeKind::BuildConfigId: Col = llvm::raw_ostream::YELLOW; break;
+    case SyntaxNodeKind::PoundDirectiveKeyword: Col = llvm::raw_ostream::YELLOW; break;
     case SyntaxNodeKind::AttributeId: Col = llvm::raw_ostream::CYAN; break;
     case SyntaxNodeKind::AttributeBuiltin: Col = llvm::raw_ostream::MAGENTA; break;
     case SyntaxNodeKind::EditorPlaceholder: Col = llvm::raw_ostream::YELLOW; break;

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -337,6 +337,8 @@ UID_KINDS = [
     KIND('BuildConfigKeyword',
          'source.lang.swift.syntaxtype.buildconfig.keyword'),
     KIND('BuildConfigId', 'source.lang.swift.syntaxtype.buildconfig.id'),
+    KIND('PoundDirectiveKeyword',
+         'source.lang.swift.syntaxtype.pounddirective.keyword'),
     KIND('AttributeId', 'source.lang.swift.syntaxtype.attribute.id'),
     KIND('AttributeBuiltin', 'source.lang.swift.syntaxtype.attribute.builtin'),
     KIND('Number', 'source.lang.swift.syntaxtype.number'),


### PR DESCRIPTION
This PR allows Xcode etc. to syntax-highlight `#error`/`#warning` like `#if`, & like `#error` in C, instead of like regular language keywords. 

Before (now):
![current](https://user-images.githubusercontent.com/26768470/36439454-e6244fdc-1664-11e8-9435-cf15a4f67412.png)

After (with Xcode change...):
![proposed](https://user-images.githubusercontent.com/26768470/36439459-e9a5d446-1664-11e8-89b6-ab649e1404ee.png)

From [SR-6964](https://bugs.swift.org/browse/SR-6964).  Per discussion there this introduces a new syntax type for these types of compiler control statement that includes `#sourceLocation`.

If this still sounds like a good idea at all then it's probably only worth taking if the Xcode change will happen - otherwise `#error` etc. will get no coloring at all which looks worse.