### PR TITLE
[driver] Add -working-directory option

### DIFF
--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -205,9 +205,11 @@ public:
   std::unique_ptr<llvm::opt::InputArgList>
   parseArgStrings(ArrayRef<const char *> Args);
 
-  /// Translate the input arguments into a DerivedArgList.
-  llvm::opt::DerivedArgList *translateInputArgs(
-      const llvm::opt::InputArgList &ArgList) const;
+  /// Resolve path arguments if \p workingDirectory is non-empty, and translate
+  /// inputs from -- arguments into a DerivedArgList.
+  llvm::opt::DerivedArgList *
+  translateInputAndPathArgs(const llvm::opt::InputArgList &ArgList,
+                            StringRef workingDirectory) const;
 
   /// Construct the list of inputs and their types from the given arguments.
   ///
@@ -247,7 +249,8 @@ public:
 
   /// Construct the OutputFileMap for the driver from the given arguments.
   std::unique_ptr<OutputFileMap>
-  buildOutputFileMap(const llvm::opt::DerivedArgList &Args) const;
+  buildOutputFileMap(const llvm::opt::DerivedArgList &Args,
+                     StringRef workingDirectory) const;
 
   /// Add top-level Jobs to Compilation \p C for the given \p Actions and
   /// OutputInfo.
@@ -255,12 +258,13 @@ public:
   /// \param TopLevelActions The main Actions to build Jobs for.
   /// \param OI The OutputInfo for which Jobs should be generated.
   /// \param OFM The OutputFileMap for which Jobs should be generated.
+  /// \param workingDirectory If non-empty, used to resolve any generated paths.
   /// \param TC The ToolChain to build Jobs with.
   /// \param C The Compilation containing the Actions for which Jobs should be
   /// created.
   void buildJobs(ArrayRef<const Action *> TopLevelActions, const OutputInfo &OI,
-                 const OutputFileMap *OFM, const ToolChain &TC,
-                 Compilation &C) const;
+                 const OutputFileMap *OFM, StringRef workingDirectory,
+                 const ToolChain &TC, Compilation &C) const;
 
   /// A map for caching Jobs for a given Action/ToolChain pair
   using JobCacheMap =
@@ -280,8 +284,8 @@ public:
   /// \returns a Job for the given Action/ToolChain pair
   Job *buildJobsForAction(Compilation &C, const JobAction *JA,
                           const OutputInfo &OI, const OutputFileMap *OFM,
-                          const ToolChain &TC, bool AtTopLevel,
-                          JobCacheMap &JobCache) const;
+                          StringRef workingDirectory, const ToolChain &TC,
+                          bool AtTopLevel, JobCacheMap &JobCache) const;
 
 private:
   void computeMainOutput(Compilation &C, const JobAction *JA,
@@ -290,6 +294,7 @@ private:
                          SmallVectorImpl<const Action *> &InputActions,
                          SmallVectorImpl<const Job *> &InputJobs,
                          const TypeToPathMap *OutputMap,
+                         StringRef workingDirectory,
                          StringRef BaseInput,
                          StringRef PrimaryInput,
                          llvm::SmallString<128> &Buf,
@@ -298,10 +303,12 @@ private:
   void chooseSwiftModuleOutputPath(Compilation &C, const OutputInfo &OI,
                                    const OutputFileMap *OFM,
                                    const TypeToPathMap *OutputMap,
+                                   StringRef workingDirectory,
                                    CommandOutput *Output) const;
 
   void chooseSwiftModuleDocOutputPath(Compilation &C,
                                       const TypeToPathMap *OutputMap,
+                                      StringRef workingDirectory,
                                       CommandOutput *Output) const;
   void chooseRemappingOutputPath(Compilation &C, const TypeToPathMap *OutputMap,
                                  CommandOutput *Output) const;
@@ -309,27 +316,33 @@ private:
   void chooseSerializedDiagnosticsPath(Compilation &C, const JobAction *JA,
                                        const OutputInfo &OI,
                                        const TypeToPathMap *OutputMap,
+                                       StringRef workingDirectory,
                                        CommandOutput *Output) const;
 
   void chooseDependenciesOutputPaths(Compilation &C, const OutputInfo &OI,
                                      const TypeToPathMap *OutputMap,
+                                     StringRef workingDirectory,
                                      llvm::SmallString<128> &Buf,
                                      CommandOutput *Output) const;
 
   void chooseOptimizationRecordPath(Compilation &C, const OutputInfo &OI,
+                                    StringRef workingDirectory,
                                     llvm::SmallString<128> &Buf,
                                     CommandOutput *Output) const;
 
   void chooseObjectiveCHeaderOutputPath(Compilation &C, const OutputInfo &OI,
                                         const TypeToPathMap *OutputMap,
+                                        StringRef workingDirectory,
                                         CommandOutput *Output) const;
 
   void chooseLoadedModuleTracePath(Compilation &C, const OutputInfo &OI,
+                                   StringRef workingDirectory,
                                    llvm::SmallString<128> &Buf,
                                    CommandOutput *Output) const;
 
   void chooseTBDPath(Compilation &C, const OutputInfo &OI,
-                     llvm::SmallString<128> &Buf, CommandOutput *Output) const;
+                     StringRef workingDirectory, llvm::SmallString<128> &Buf,
+                     CommandOutput *Output) const;
 
 public:
   /// Handle any arguments which should be treated before building actions or

--- a/include/swift/Driver/OutputFileMap.h
+++ b/include/swift/Driver/OutputFileMap.h
@@ -39,14 +39,23 @@ public:
   ~OutputFileMap() = default;
 
   /// Loads an OutputFileMap from the given \p Path, if possible.
-  static std::unique_ptr<OutputFileMap> loadFromPath(StringRef Path);
+  ///
+  /// When non-empty, \p workingDirectory is used to resolve relative paths in
+  /// the output file map.
+  static std::unique_ptr<OutputFileMap>
+  loadFromPath(StringRef Path, StringRef workingDirectory);
 
-  static std::unique_ptr<OutputFileMap> loadFromBuffer(StringRef Data);
+  static std::unique_ptr<OutputFileMap>
+  loadFromBuffer(StringRef Data, StringRef workingDirectory);
 
   /// Loads an OutputFileMap from the given \p Buffer, taking ownership
   /// of the buffer in the process.
+  ///
+  /// When non-empty, \p workingDirectory is used to resolve relative paths in
+  /// the output file map.
   static std::unique_ptr<OutputFileMap>
-  loadFromBuffer(std::unique_ptr<llvm::MemoryBuffer> Buffer);
+  loadFromBuffer(std::unique_ptr<llvm::MemoryBuffer> Buffer,
+                 StringRef workingDirectory);
 
   /// Get the map of outputs for the given \p Input, if present in the
   /// OutputFileMap. (If not present, returns nullptr.)
@@ -69,8 +78,12 @@ private:
   /// \brief Parses the given \p Buffer into the OutputFileMap, taking ownership
   /// of \p Buffer in the process.
   ///
+  /// When non-empty, \p workingDirectory is used to resolve relative paths in
+  /// the output file map.
+  ///
   /// \returns true on error, false on success
-  bool parse(std::unique_ptr<llvm::MemoryBuffer> Buffer);
+  bool parse(std::unique_ptr<llvm::MemoryBuffer> Buffer,
+             StringRef workingDirectory);
 };
 
 } // end namespace driver

--- a/include/swift/Option/Options.h
+++ b/include/swift/Option/Options.h
@@ -34,6 +34,7 @@ namespace options {
     AutolinkExtractOption = (1 << 9),
     ModuleWrapOption = (1 << 10),
     SwiftFormatOption = (1 << 11),
+    ArgumentIsPath = (1 << 12),
   };
 
   enum ID {

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -43,6 +43,10 @@ def NoBatchOption : OptionFlag;
 // The option should not force a full rebuild if added, changed, or removed.
 def DoesNotAffectIncrementalBuild : OptionFlag;
 
+// The option's argument is a file-system path that may be affected by the
+// current working directory.
+def ArgumentIsPath : OptionFlag;
+
 /////////
 // Options
 
@@ -129,13 +133,13 @@ def _DASH_DASH : Option<["--"], "", KIND_REMAINING_ARGS>,
 
 def o : JoinedOrSeparate<["-"], "o">,
   Flags<[FrontendOption, AutolinkExtractOption, ModuleWrapOption,
-         NoInteractiveOption, SwiftFormatOption]>,
+         NoInteractiveOption, SwiftFormatOption, ArgumentIsPath]>,
   HelpText<"Write output to <file>">, MetaVarName<"<file>">;
 
 def j : JoinedOrSeparate<["-"], "j">, Flags<[DoesNotAffectIncrementalBuild]>,
   HelpText<"Number of commands to execute in parallel">, MetaVarName<"<n>">;
 
-def sdk : Separate<["-"], "sdk">, Flags<[FrontendOption]>,
+def sdk : Separate<["-"], "sdk">, Flags<[FrontendOption, ArgumentIsPath]>,
   HelpText<"Compile against <sdk>">, MetaVarName<"<sdk>">;
 
 def swift_version : Separate<["-"], "swift-version">, Flags<[FrontendOption]>,
@@ -143,33 +147,37 @@ def swift_version : Separate<["-"], "swift-version">, Flags<[FrontendOption]>,
   MetaVarName<"<vers>">;
 
 def tools_directory : Separate<["-"], "tools-directory">,
-  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
+         ArgumentIsPath]>,
   HelpText<"Look for external executables (ld, clang, binutils) in <directory>">, MetaVarName<"<directory>">;
 
 def D : JoinedOrSeparate<["-"], "D">, Flags<[FrontendOption]>,
   HelpText<"Marks a conditional compilation flag as true">;
 
-def F : JoinedOrSeparate<["-"], "F">, Flags<[FrontendOption]>,
+def F : JoinedOrSeparate<["-"], "F">, Flags<[FrontendOption, ArgumentIsPath]>,
   HelpText<"Add directory to framework search path">;
-def F_EQ : Joined<["-"], "F=">, Flags<[FrontendOption]>, Alias<F>;
+def F_EQ : Joined<["-"], "F=">, Flags<[FrontendOption, ArgumentIsPath]>,
+  Alias<F>;
 
-def Fsystem : Separate<["-"], "Fsystem">, Flags<[FrontendOption]>,
+def Fsystem : Separate<["-"], "Fsystem">,
+  Flags<[FrontendOption, ArgumentIsPath]>,
   HelpText<"Add directory to system framework search path">;
 
-def I : JoinedOrSeparate<["-"], "I">, Flags<[FrontendOption]>,
+def I : JoinedOrSeparate<["-"], "I">, Flags<[FrontendOption, ArgumentIsPath]>,
   HelpText<"Add directory to the import search path">;
-def I_EQ : Joined<["-"], "I=">, Flags<[FrontendOption]>, Alias<I>;
+def I_EQ : Joined<["-"], "I=">, Flags<[FrontendOption, ArgumentIsPath]>,
+  Alias<I>;
 
 def import_underlying_module : Flag<["-"], "import-underlying-module">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Implicitly imports the Objective-C half of a module">;
 
 def import_objc_header : Separate<["-"], "import-objc-header">,
-  Flags<[FrontendOption, HelpHidden]>,
+  Flags<[FrontendOption, HelpHidden, ArgumentIsPath]>,
   HelpText<"Implicitly imports an Objective-C header file">;
 
 def pch_output_dir: Separate<["-"], "pch-output-dir">,
-  Flags<[FrontendOption, HelpHidden]>,
+  Flags<[FrontendOption, HelpHidden, ArgumentIsPath]>,
   HelpText<"Directory to persist automatically created precompiled bridging headers">;
 
 // FIXME: Unhide this once it doesn't depend on an output file map.
@@ -181,10 +189,11 @@ def nostdimport : Flag<["-"], "nostdimport">, Flags<[FrontendOption]>,
   HelpText<"Don't search the standard library import path for modules">;
 
 def output_file_map : Separate<["-"], "output-file-map">,
-  Flags<[NoInteractiveOption]>,
+  Flags<[NoInteractiveOption, ArgumentIsPath]>,
   HelpText<"A file which specifies the location of outputs">,
   MetaVarName<"<path>">;
 def output_file_map_EQ : Joined<["-"], "output-file-map=">,
+  Flags<[NoInteractiveOption, ArgumentIsPath]>,
   Alias<output_file_map>;
 
 def save_temps : Flag<["-"], "save-temps">,
@@ -194,7 +203,7 @@ def driver_time_compilation : Flag<["-"], "driver-time-compilation">,
   Flags<[NoInteractiveOption,DoesNotAffectIncrementalBuild]>,
   HelpText<"Prints the total time it took to execute all compilation tasks">;
 def stats_output_dir: Separate<["-"], "stats-output-dir">,
-  Flags<[FrontendOption, HelpHidden]>,
+  Flags<[FrontendOption, HelpHidden, ArgumentIsPath]>,
   HelpText<"Directory to write unified compilation-statistics files to">;
 def trace_stats_events: Flag<["-"], "trace-stats-events">,
   Flags<[FrontendOption, HelpHidden]>,
@@ -208,28 +217,30 @@ def emit_loaded_module_trace : Flag<["-"], "emit-loaded-module-trace">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Emit a JSON file containing information about what modules were loaded">;
 def emit_loaded_module_trace_path : Separate<["-"], "emit-loaded-module-trace-path">,
-  Flags<[FrontendOption, NoInteractiveOption]>,
+  Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath]>,
   HelpText<"Emit the loaded module trace JSON to <path>">,
   MetaVarName<"<path>">;
 def emit_loaded_module_trace_path_EQ : Joined<["-"], "emit-loaded-module-trace-path=">,
-  Flags<[FrontendOption, NoInteractiveOption]>, Alias<emit_loaded_module_trace_path>;
+  Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath]>,
+  Alias<emit_loaded_module_trace_path>;
 
 def emit_tbd : Flag<["-"], "emit-tbd">,
   HelpText<"Emit a TBD file">,
   Flags<[FrontendOption, NoInteractiveOption]>;
 def emit_tbd_path : Separate<["-"], "emit-tbd-path">,
-  Flags<[FrontendOption, NoInteractiveOption]>,
+  Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath]>,
   HelpText<"Emit the TBD file to <path>">,
   MetaVarName<"<path>">;
 def emit_tbd_path_EQ : Joined<["-"], "emit-tbd-path=">,
-  Flags<[FrontendOption, NoInteractiveOption]>, Alias<emit_tbd_path>;
+  Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath]>,
+  Alias<emit_tbd_path>;
 
 def serialize_diagnostics : Flag<["-"], "serialize-diagnostics">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Serialize diagnostics in a binary format">;
 
 def module_cache_path : Separate<["-"], "module-cache-path">,
-  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
   HelpText<"Specifies the Clang module cache path">;
 
 def module_name : Separate<["-"], "module-name">, Flags<[FrontendOption]>,
@@ -250,17 +261,21 @@ def emit_module : Flag<["-"], "emit-module">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Emit an importable module">;
 def emit_module_path : Separate<["-"], "emit-module-path">,
-  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
+         ArgumentIsPath]>,
   HelpText<"Emit an importable module to <path>">,
   MetaVarName<"<path>">;
 def emit_module_path_EQ : Joined<["-"], "emit-module-path=">,
-  Flags<[FrontendOption, NoInteractiveOption]>, Alias<emit_module_path>;
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
+         ArgumentIsPath]>,
+  Alias<emit_module_path>;
 
 def emit_objc_header : Flag<["-"], "emit-objc-header">,
   Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Emit an Objective-C header file">;
 def emit_objc_header_path : Separate<["-"], "emit-objc-header-path">,
-  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
+         ArgumentIsPath]>,
   MetaVarName<"<path>">, HelpText<"Emit an Objective-C header file to <path>">;
 
 def import_cf_types : Flag<["-"], "import-cf-types">,
@@ -337,7 +352,7 @@ def save_optimization_record : Flag<["-"], "save-optimization-record">,
   Flags<[FrontendOption]>, HelpText<"Generate a YAML optimization record file">;
 def save_optimization_record_path :
   Separate<["-"], "save-optimization-record-path">,
-  Flags<[FrontendOption]>,
+  Flags<[FrontendOption, ArgumentIsPath]>,
   HelpText<"Specify the file name of any generated YAML optimization record">;
 
 // Platform options.
@@ -357,9 +372,11 @@ def framework : Separate<["-"], "framework">, Group<linker_option_Group>,
   HelpText<"Specifies a framework which should be linked against">;
 
 def L : JoinedOrSeparate<["-"], "L">, Group<linker_option_Group>,
-  Flags<[FrontendOption, DoesNotAffectIncrementalBuild]>,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
   HelpText<"Add directory to library link search path">;
-def L_EQ : Joined<["-"], "L=">, Alias<L>;
+def L_EQ : Joined<["-"], "L=">,
+  Flags<[FrontendOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
+  Alias<L>;
 
 def link_objc_runtime : Flag<["-"], "link-objc-runtime">,
   Flags<[DoesNotAffectIncrementalBuild]>;
@@ -495,12 +512,14 @@ def emit_migrated_file_path: Separate<["-"], "emit-migrated-file-path">,
   MetaVarName<"<path>">;
 
 def dump_migration_states_dir: Separate<["-"], "dump-migration-states-dir">,
-  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
+         ArgumentIsPath]>,
   HelpText<"Dump the input text, output text, and states for migration to <path>">,
   MetaVarName<"<path>">;
 
 def api_diff_data_file: Separate<["-"], "api-diff-data-file">,
-  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
+         ArgumentIsPath]>,
   HelpText<"API migration data is from <path>">,
   MetaVarName<"<path>">;
 
@@ -654,7 +673,7 @@ def Xllvm : Separate<["-"], "Xllvm">,
   MetaVarName<"<arg>">, HelpText<"Pass <arg> to LLVM.">;
 
 def resource_dir : Separate<["-"], "resource-dir">,
-  Flags<[FrontendOption, HelpHidden]>,
+  Flags<[FrontendOption, HelpHidden, ArgumentIsPath]>,
   MetaVarName<"</usr/lib/swift>">,
   HelpText<"The directory that holds the compiler resource files">;
 
@@ -672,7 +691,8 @@ def profile_generate : Flag<["-"], "profile-generate">,
   HelpText<"Generate instrumented code to collect execution counts">;
 
 def profile_use : CommaJoined<["-"], "profile-use=">,
-  Flags<[FrontendOption, NoInteractiveOption]>, MetaVarName<"<profdata>">,
+  Flags<[FrontendOption, NoInteractiveOption, ArgumentIsPath]>,
+  MetaVarName<"<profdata>">,
   HelpText<"Supply a profdata file to enable profile-guided optimization">;
 
 def profile_coverage_mapping : Flag<["-"], "profile-coverage-mapping">,
@@ -705,16 +725,22 @@ def index_file : Flag<["-"], "index-file">,
   HelpText<"Produce index data for a source file">, ModeOpt,
   Flags<[NoInteractiveOption, DoesNotAffectIncrementalBuild]>;
 def index_file_path : Separate<["-"], "index-file-path">,
-  Flags<[NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
+  Flags<[NoInteractiveOption, DoesNotAffectIncrementalBuild, ArgumentIsPath]>,
   HelpText<"Produce index data for file <path>">,
   MetaVarName<"<path>">;
 
 def index_store_path : Separate<["-"], "index-store-path">,
-  Flags<[FrontendOption]>, MetaVarName<"<path>">,
+  Flags<[FrontendOption, ArgumentIsPath]>, MetaVarName<"<path>">,
   HelpText<"Store indexing data to <path>">;
 
 def enforce_exclusivity_EQ : Joined<["-"], "enforce-exclusivity=">,
   Flags<[FrontendOption]>, MetaVarName<"<enforcement>">,
   HelpText<"Enforce law of exclusivity">;
+
+def working_directory : Separate<["-"], "working-directory">,
+  HelpText<"Resolve file paths relative to the specified directory">,
+  MetaVarName<"<path>">;
+def working_directory_EQ : Joined<["-"], "working-directory=">,
+  Alias<working_directory>;
 
 include "FrontendOptions.td"

--- a/lib/Driver/OutputFileMap.cpp
+++ b/lib/Driver/OutputFileMap.cpp
@@ -13,32 +13,36 @@
 #include "swift/Driver/OutputFileMap.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringRef.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 #include <system_error>
 
 using namespace swift;
 using namespace swift::driver;
 
-std::unique_ptr<OutputFileMap> OutputFileMap::loadFromPath(StringRef Path) {
+std::unique_ptr<OutputFileMap>
+OutputFileMap::loadFromPath(StringRef Path, StringRef workingDirectory) {
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> FileBufOrErr =
     llvm::MemoryBuffer::getFile(Path);
   if (!FileBufOrErr)
     return nullptr;
-  return loadFromBuffer(std::move(FileBufOrErr.get()));
-}
-
-std::unique_ptr<OutputFileMap> OutputFileMap::loadFromBuffer(StringRef Data) {
-  std::unique_ptr<llvm::MemoryBuffer> Buffer{
-    llvm::MemoryBuffer::getMemBuffer(Data)
-  };
-  return loadFromBuffer(std::move(Buffer));
+  return loadFromBuffer(std::move(FileBufOrErr.get()), workingDirectory);
 }
 
 std::unique_ptr<OutputFileMap>
-OutputFileMap::loadFromBuffer(std::unique_ptr<llvm::MemoryBuffer> Buffer) {
+OutputFileMap::loadFromBuffer(StringRef Data, StringRef workingDirectory) {
+  std::unique_ptr<llvm::MemoryBuffer> Buffer{
+    llvm::MemoryBuffer::getMemBuffer(Data)
+  };
+  return loadFromBuffer(std::move(Buffer), workingDirectory);
+}
+
+std::unique_ptr<OutputFileMap>
+OutputFileMap::loadFromBuffer(std::unique_ptr<llvm::MemoryBuffer> Buffer,
+                              StringRef workingDirectory) {
   std::unique_ptr<OutputFileMap> OFM(new OutputFileMap());
 
-  if (OFM->parse(std::move(Buffer)))
+  if (OFM->parse(std::move(Buffer), workingDirectory))
     return nullptr;
 
   return OFM;
@@ -104,7 +108,8 @@ void OutputFileMap::dump(llvm::raw_ostream &os, bool Sort) const {
   }
 }
 
-bool OutputFileMap::parse(std::unique_ptr<llvm::MemoryBuffer> Buffer) {
+bool OutputFileMap::parse(std::unique_ptr<llvm::MemoryBuffer> Buffer,
+                          StringRef workingDirectory) {
   llvm::SourceMgr SM;
   llvm::yaml::Stream YAMLStream(Buffer->getMemBufferRef(), SM);
   auto I = YAMLStream.begin();
@@ -118,6 +123,26 @@ bool OutputFileMap::parse(std::unique_ptr<llvm::MemoryBuffer> Buffer) {
   auto *Map = dyn_cast<llvm::yaml::MappingNode>(Root);
   if (!Map)
     return true;
+
+  auto resolvePath =
+      [workingDirectory](
+          llvm::yaml::ScalarNode *Path,
+          llvm::SmallVectorImpl<char> &PathStorage) -> StringRef {
+    StringRef PathStr = Path->getValue(PathStorage);
+    if (workingDirectory.empty() || PathStr.empty() || PathStr == "-" ||
+        llvm::sys::path::is_absolute(PathStr)) {
+      return PathStr;
+    }
+    // Copy the path to avoid making assumptions about how getValue deals with
+    // Storage.
+    SmallString<128> PathStrCopy(PathStr);
+    PathStorage.clear();
+    PathStorage.reserve(PathStrCopy.size() + workingDirectory.size() + 1);
+    PathStorage.insert(PathStorage.begin(), workingDirectory.begin(),
+                       workingDirectory.end());
+    llvm::sys::path::append(PathStorage, PathStrCopy);
+    return StringRef(PathStorage.data(), PathStorage.size());
+  };
 
   for (auto Pair : *Map) {
     llvm::yaml::Node *Key = Pair.getKey();
@@ -162,12 +187,13 @@ bool OutputFileMap::parse(std::unique_ptr<llvm::MemoryBuffer> Buffer) {
         continue;
 
       llvm::SmallString<128> PathStorage;
-      OutputMap.insert(
-        std::pair<types::ID, std::string>(Kind, Path->getValue(PathStorage)));
+      OutputMap.insert(std::pair<types::ID, std::string>(
+          Kind, resolvePath(Path, PathStorage)));
     }
 
     llvm::SmallString<128> InputStorage;
-    InputToOutputsMap[InputPath->getValue(InputStorage)] = std::move(OutputMap);
+    InputToOutputsMap[resolvePath(InputPath, InputStorage)] =
+        std::move(OutputMap);
   }
 
   return false;

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -179,6 +179,18 @@ static void addCommonFrontendArgs(const ToolChain &TC,
   // Pass through the values passed to -Xfrontend.
   inputArgs.AddAllArgValues(arguments, options::OPT_Xfrontend);
 
+  if (auto *A = inputArgs.getLastArg(options::OPT_working_directory)) {
+    // Add -Xcc -working-directory before any other -Xcc options to ensure it is
+    // overridden by an explicit -Xcc -working-directory, although having a
+    // different working directory is probably incorrect.
+    SmallString<128> workingDirectory(A->getValue());
+    llvm::sys::fs::make_absolute(workingDirectory);
+    arguments.push_back("-Xcc");
+    arguments.push_back("-working-directory");
+    arguments.push_back("-Xcc");
+    arguments.push_back(inputArgs.MakeArgString(workingDirectory));
+  }
+
   // Pass through any subsystem flags.
   inputArgs.AddAllArgs(arguments, options::OPT_Xllvm);
   inputArgs.AddAllArgs(arguments, options::OPT_Xcc);

--- a/test/Driver/working-directory.swift
+++ b/test/Driver/working-directory.swift
@@ -1,0 +1,96 @@
+// RUN: %empty-directory(%t)
+
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -c main.swift | %FileCheck %s -check-prefix=INPUT
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -c %S/Inputs/main.swift | %FileCheck %s -check-prefix=INPUT
+// INPUT: SOURCE_DIR/test/Driver/Inputs/main.swift
+
+// Relative -working-directory...
+// RUN: cd %S && %swiftc_driver -driver-print-jobs -working-directory Inputs -c %S/Inputs/main.swift | %FileCheck %s -check-prefix=INPUT
+
+// -working-directory=
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory=%S/Inputs -c %S/Inputs/main.swift | %FileCheck %s -check-prefix=INPUT
+
+// In another driver mode.
+// RUN: cd %t && %swift_driver -driver-print-jobs -working-directory %S/Inputs -F. | %FileCheck %s -check-prefix=REPL
+// RUN: cd %t && %swift_driver -driver-print-jobs -deprecated-integrated-repl -working-directory %S/Inputs -F. | %FileCheck %s -check-prefix=REPL
+// REPL: -F SOURCE_DIR/test/Driver/Inputs/.
+
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory=%S/Inputs -c -module-name m main.swift lib.swift | %FileCheck %s -check-prefix=MULTI_INPUT
+// MULTI_INPUT: SOURCE_DIR/test/Driver/Inputs/main.swift
+// MULTI_INPUT-SAME: SOURCE_DIR/test/Driver/Inputs/lib.swift
+
+// Using --
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory=%S/Inputs -c -module-name m -- main.swift lib.swift | %FileCheck %s -check-prefix=MULTI_INPUT
+
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -c %s -F . | %FileCheck %s -check-prefix=SEARCH_PATH
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -c %s -F. | %FileCheck %s -check-prefix=SEARCH_PATH
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -c %s -F=. | %FileCheck %s -check-prefix=SEARCH_PATH
+// SEARCH_PATH: -F SOURCE_DIR/test/Driver/Inputs/.
+
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -emit-executable %s -L . | %FileCheck %s -check-prefix=L_PATH
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -emit-executable %s -L. | %FileCheck %s -check-prefix=L_PATH
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -emit-executable %s -L=. | %FileCheck %s -check-prefix=L_PATH
+// L_PATH: -L SOURCE_DIR/test/Driver/Inputs/.
+
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -c %s -disable-bridging-pch -import-objc-header bridging-header.h | %FileCheck %s -check-prefix=OBJC_HEADER1
+// OBJC_HEADER1: -import-objc-header SOURCE_DIR/test/Driver/Inputs/bridging-header.h
+
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -c %s -enable-bridging-pch -import-objc-header bridging-header.h | %FileCheck %s -check-prefix=OBJC_HEADER2
+// OBJC_HEADER2: SOURCE_DIR/test/Driver/Inputs/bridging-header.h {{.*}}-emit-pch
+
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -c %s -o main.o | %FileCheck %s -check-prefix=OUTPUT_OBJ
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -c %s -o %S/Inputs/main.o | %FileCheck %s -check-prefix=OUTPUT_OBJ
+// OUTPUT_OBJ: -o SOURCE_DIR/test/Driver/Inputs/main.o
+
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -c %s -module-cache-path mcp | %FileCheck %s -check-prefix=ARG_IS_PATH
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -c %s -module-cache-path %S/Inputs/mcp | %FileCheck %s -check-prefix=ARG_IS_PATH
+// ARG_IS_PATH: -module-cache-path SOURCE_DIR/test/Driver/Inputs/mcp
+
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -emit-executable %s -o main | %FileCheck %s -check-prefix=OUTPUT_EXE
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -emit-executable %s -o %S/Inputs/main | %FileCheck %s -check-prefix=OUTPUT_EXE
+// OUTPUT_EXE: -o SOURCE_DIR/test/Driver/Inputs/main
+
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -emit-ir %s -o - | %FileCheck %s -check-prefix=OUTPUT_STDOUT
+// OUTPUT_STDOUT: -o -
+
+// RUN: echo "{\"main.swift\": {\"object\": \"main-modified.o\"}}" > %t/ofmo.json
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -c main.swift -output-file-map %t/ofmo.json | %FileCheck %s -check-prefix=OUTPUT_FILE_MAP_1
+// OUTPUT_FILE_MAP_1: -o SOURCE_DIR/test/Driver/Inputs/main-modified.o
+
+// -output-file-map itself
+// RUN: echo "{\"main.swift\": {\"object\": \"main-modified.o\"}}" > %t/ofmo2.json
+// RUN: touch %t/main.swift
+// RUN: cd %S && %swiftc_driver -driver-print-jobs -working-directory %t -c main.swift -output-file-map ofmo2.json | %FileCheck %s -check-prefix=OUTPUT_FILE_MAP_2
+// -output-file-map= is an alias for -output-file-map
+// RUN: cd %S && %swiftc_driver -driver-print-jobs -working-directory %t -c main.swift -output-file-map=ofmo2.json | %FileCheck %s -check-prefix=OUTPUT_FILE_MAP_2
+// OUTPUT_FILE_MAP_2: BUILD_DIR{{.*}}main-modified.o
+
+// RUN: %empty-directory(%t/sub)
+// RUN: echo "{\"\": {\"swift-dependencies\": \"br.swiftdeps\"}}" > %t/sub/ofmo.json
+// RUN: touch %t/sub/a.swift %t/sub/b.swift
+// RUN: cd %t && %swiftc_driver -incremental -working-directory %t/sub -emit-dependencies -c -module-name ab a.swift b.swift -output-file-map=%t/sub/ofmo.json
+// RUN: ls %t/sub/br.swiftdeps
+
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -Xcc -working-directory -Xcc %t -c %s | %FileCheck %s -check-prefix=CLANG
+// CLANG: -Xcc -working-directory -Xcc SOURCE_DIR
+// CLANG-SAME: -Xcc -working-directory -Xcc BUILD_DIR
+
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -c main.swift | %FileCheck %s -check-prefix=OUTPUT_IMPLICIT_OBJ
+// OUTPUT_IMPLICIT_OBJ: -o SOURCE_DIR/test/Driver/Inputs/main.o
+
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -emit-module main.swift | %FileCheck %s -check-prefix=OUTPUT_IMPLICIT_MODULE
+// OUTPUT_IMPLICIT_MODULE: -emit-module-doc-path SOURCE_DIR/test/Driver/Inputs/main.swiftdoc
+// OUTPUT_IMPLICIT_MODULE-SAME: -o SOURCE_DIR/test/Driver/Inputs/main.swiftmodule
+
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -emit-executable main.swift | %FileCheck %s -check-prefix=OUTPUT_IMPLICIT_EXE
+// OUTPUT_IMPLICIT_EXE: -o SOURCE_DIR/test/Driver/Inputs/main
+
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -emit-module -emit-executable main.swift | %FileCheck %s -check-prefix=OUTPUT_IMPLICIT_EXE_AND_MODULE
+// OUTPUT_IMPLICIT_EXE_AND_MODULE: -emit-module-doc-path SOURCE_DIR/test/Driver/Inputs/main.swiftdoc
+// OUTPUT_IMPLICIT_EXE_AND_MODULE-SAME: -o SOURCE_DIR/test/Driver/Inputs/main.swiftmodule
+// OUTPUT_IMPLICIT_EXE_AND_MODULE: -o SOURCE_DIR/test/Driver/Inputs/main
+
+// RUN: cd %t && %swiftc_driver -driver-print-jobs -working-directory %S/Inputs -emit-module -emit-executable main.swift -o not_main | %FileCheck %s -check-prefix=OUTPUT_IMPLICIT_EXPLICIT
+// OUTPUT_IMPLICIT_EXPLICIT: -emit-module-doc-path SOURCE_DIR/test/Driver/Inputs/not_main.swiftdoc
+// OUTPUT_IMPLICIT_EXPLICIT-SAME: -o SOURCE_DIR/test/Driver/Inputs/not_main.swiftmodule
+// OUTPUT_IMPLICIT_EXPLICIT: -o SOURCE_DIR/test/Driver/Inputs/not_main

--- a/test/SourceKit/CodeComplete/complete_working_directory.swift
+++ b/test/SourceKit/CodeComplete/complete_working_directory.swift
@@ -1,0 +1,8 @@
+import Foo
+
+// REQUIRES: objc_interop
+
+// RUN: %sourcekitd-test -req=complete.open -pos=2:1 -req-opts=hidelowpriority=0 %s -- %s -F libIDE-mock-sdk -working-directory %S/../Inputs | %FileCheck %s
+// RUN: %sourcekitd-test -req=complete.open -pos=2:1 -req-opts=hidelowpriority=0 %s -- %s -Xcc -F -Xcc libIDE-mock-sdk -working-directory %S/../Inputs | %FileCheck %s
+
+// CHECK: fooFunc


### PR DESCRIPTION
Adds a -working-directory option which can be used to modify how
relative paths are resolved. It affects all other paths used in driver
options (controlled by a new ArgumentIsPath flag on options) as well as
the contents of output file maps and auxilliary file paths generated
implicitly by the compiler itself.

rdar://37713856