### PR TITLE
[SR-7043] Remove duplicate if statement

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -2367,9 +2367,7 @@ class SwiftArrayOptPass : public SILFunctionTransform {
                             DT, nullptr);
 
       DEBUG(getFunction()->viewCFG());
-    }
 
-    if (HasChanged) {
       // We preserve the dominator tree. Let's invalidate everything
       // else.
       DA->lockInvalidation();


### PR DESCRIPTION
<!-- What's in this pull request? -->
There are two `if` blocks next to each other, with a condition `if (HasChanged)`. They can be merged into one, since the `HasChanged` is local and does not appear to be updated.

This was identified from https://gist.github.com/modocache/00eb437ca3cac84960992cdc23fa0f52#file-swift-6edb5132-tasks-txt-L1415

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7043](https://bugs.swift.org/browse/SR-7043).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->