### PR TITLE
[Demangler] Add convenience functions to ask about types.

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -246,6 +246,31 @@ bool isSwiftSymbol(const char *mangledName);
 /// This does not include the old (<= swift 3.x) mangling prefix "_T".
 llvm::StringRef dropSwiftManglingPrefix(llvm::StringRef mangledName);
 
+/// Returns true if the mangled name is an alias type name.
+///
+/// \param mangledName A null-terminated string containing a mangled name.
+bool isAlias(llvm::StringRef mangledName);
+
+/// Returns true if the mangled name is a class type name.
+///
+/// \param mangledName A null-terminated string containing a mangled name.
+bool isClass(llvm::StringRef mangledName);
+
+/// Returns true if the mangled name is an enum type name.
+///
+/// \param mangledName A null-terminated string containing a mangled name.
+bool isEnum(llvm::StringRef mangledName);
+
+/// Returns true if the mangled name is a protocol type name.
+///
+/// \param mangledName A null-terminated string containing a mangled name.
+bool isProtocol(llvm::StringRef mangledName);
+
+/// Returns true if the mangled name is a structure type name.
+///
+/// \param mangledName A null-terminated string containing a mangled name.
+bool isStruct(llvm::StringRef mangledName);
+
 /// Returns true if the mangled name has the old scheme of function type
 /// mangling where labels are part of the type.
 ///

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -168,6 +168,94 @@ llvm::StringRef swift::Demangle::dropSwiftManglingPrefix(StringRef mangledName){
   return mangledName.drop_front(getManglingPrefixLength(mangledName));
 }
 
+static bool isAliasNode(Demangle::NodePointer Node) {
+  switch (Node->getKind()) {
+  case Demangle::Node::Kind::Type:
+    return isAliasNode(Node->getChild(0));
+  case Demangle::Node::Kind::TypeAlias:
+    return true;
+  default:
+    return false;
+  }
+  llvm_unreachable("Unhandled node kind!");
+}
+
+bool swift::Demangle::isAlias(llvm::StringRef mangledName) {
+  Demangle::Demangler Dem;
+  return isAliasNode(Dem.demangleType(mangledName));
+}
+
+static bool isClassNode(Demangle::NodePointer Node) {
+  switch (Node->getKind()) {
+  case Demangle::Node::Kind::Type:
+    return isClassNode(Node->getChild(0));
+  case Demangle::Node::Kind::Class:
+  case Demangle::Node::Kind::BoundGenericClass:
+    return true;
+  default:
+    return false;
+  }
+  llvm_unreachable("Unhandled node kind!");
+}
+
+bool swift::Demangle::isClass(llvm::StringRef mangledName) {
+  Demangle::Demangler Dem;
+  return isClassNode(Dem.demangleType(mangledName));
+}
+
+static bool isEnumNode(Demangle::NodePointer Node) {
+  switch (Node->getKind()) {
+  case Demangle::Node::Kind::Type:
+    return isEnumNode(Node->getChild(0));
+  case Demangle::Node::Kind::Enum:
+  case Demangle::Node::Kind::BoundGenericEnum:
+    return true;
+  default:
+    return false;
+  }
+  llvm_unreachable("Unhandled node kind!");
+}
+
+bool swift::Demangle::isEnum(llvm::StringRef mangledName) {
+  Demangle::Demangler Dem;
+  return isEnumNode(Dem.demangleType(mangledName));
+}
+
+static bool isProtocolNode(Demangle::NodePointer Node) {
+  switch (Node->getKind()) {
+  case Demangle::Node::Kind::Type:
+    return isProtocolNode(Node->getChild(0));
+  case Demangle::Node::Kind::Protocol:
+    return true;
+  default:
+    return false;
+  }
+  llvm_unreachable("Unhandled node kind!");
+}
+
+bool swift::Demangle::isProtocol(llvm::StringRef mangledName) {
+  Demangle::Demangler Dem;
+  return isProtocolNode(Dem.demangleType(dropSwiftManglingPrefix(mangledName)));
+}
+
+static bool isStructNode(Demangle::NodePointer Node) {
+  switch (Node->getKind()) {
+  case Demangle::Node::Kind::Type:
+    return isStructNode(Node->getChild(0));
+  case Demangle::Node::Kind::Structure:
+  case Demangle::Node::Kind::BoundGenericStructure:
+    return true;
+  default:
+    return false;
+  }
+  llvm_unreachable("Unhandled node kind!");
+}
+
+bool swift::Demangle::isStruct(llvm::StringRef mangledName) {
+  Demangle::Demangler Dem;
+  return isStructNode(Dem.demangleType(mangledName));
+}
+
 namespace swift {
 namespace Demangle {
 

--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -420,92 +420,22 @@ GenericArgumentMap TypeRef::getSubstMap() const {
   return Substitutions;
 }
 
-namespace {
-bool isStruct(Demangle::NodePointer Node) {
-  switch (Node->getKind()) {
-    case Demangle::Node::Kind::Type:
-      return isStruct(Node->getChild(0));
-    case Demangle::Node::Kind::Structure:
-    case Demangle::Node::Kind::BoundGenericStructure:
-      return true;
-    default:
-      return false;
-  }
-}
-bool isEnum(Demangle::NodePointer Node) {
-  switch (Node->getKind()) {
-    case Demangle::Node::Kind::Type:
-      return isEnum(Node->getChild(0));
-    case Demangle::Node::Kind::Enum:
-    case Demangle::Node::Kind::BoundGenericEnum:
-      return true;
-    default:
-      return false;
-  }
-}
-bool isClass(Demangle::NodePointer Node) {
-  switch (Node->getKind()) {
-    case Demangle::Node::Kind::Type:
-      return isClass(Node->getChild(0));
-    case Demangle::Node::Kind::Class:
-    case Demangle::Node::Kind::BoundGenericClass:
-      return true;
-    default:
-      return false;
-  }
-}
-bool isProtocol(Demangle::NodePointer Node) {
-  switch (Node->getKind()) {
-    case Demangle::Node::Kind::Type:
-      return isProtocol(Node->getChild(0));
-    case Demangle::Node::Kind::Protocol:
-      return true;
-    default:
-      return false;
-  }
-}
-
-bool isAlias(Demangle::NodePointer Node) {
-  switch (Node->getKind()) {
-    case Demangle::Node::Kind::Type:
-      return isAlias(Node->getChild(0));
-    case Demangle::Node::Kind::TypeAlias:
-      return true;
-    default:
-      return false;
-  }
-}
-} // end anonymous namespace
-
 bool NominalTypeTrait::isStruct() const {
-  Demangle::Demangler Dem;
-  Demangle::NodePointer Demangled = Dem.demangleType(MangledName);
-  return ::isStruct(Demangled);
+  return Demangle::isStruct(MangledName);
 }
 
-bool NominalTypeTrait::isEnum() const {
-  Demangle::Demangler Dem;
-  Demangle::NodePointer Demangled = Dem.demangleType(MangledName);
-  return ::isEnum(Demangled);
-}
+bool NominalTypeTrait::isEnum() const { return Demangle::isEnum(MangledName); }
 
 bool NominalTypeTrait::isClass() const {
-  Demangle::Demangler Dem;
-  Demangle::NodePointer Demangled = Dem.demangleType(MangledName);
-  return ::isClass(Demangled);
+  return Demangle::isClass(MangledName);
 }
 
 bool NominalTypeTrait::isProtocol() const {
-  Demangle::Demangler Dem;
-  StringRef adjustedMangledName = Demangle::dropSwiftManglingPrefix(MangledName);
-  Demangle::NodePointer Demangled = Dem.demangleType(adjustedMangledName);
-  return ::isProtocol(Demangled);
+  return Demangle::isProtocol(MangledName);
 }
 
 bool NominalTypeTrait::isAlias() const {
-  Demangle::Demangler Dem;
-  Demangle::NodePointer Demangled = Dem.demangleType(MangledName);
-  return ::isAlias(Demangled);
+  return Demangle::isAlias(MangledName);
 }
 
 /// Visitor class to set the WasAbstract flag of any MetatypeTypeRefs


### PR DESCRIPTION
And use them in the reflection library (TypeRef). These were
private to `TypeRef.cpp` but can be moved to the demangler as
they can be of general use, and we can use them from lldb (which
has homemade versions of the functions as well). Bonus point,
it probably makes sense for these helpers to live in the demangler
anyway.

<rdar://problem/37710513>