### PR TITLE
Render TypeContextDescriptor into a proper hierarchy; NFC

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -739,7 +739,10 @@ template <typename Runtime> struct TargetStructMetadata;
 template <typename Runtime> struct TargetOpaqueMetadata;
 template <typename Runtime> struct TargetValueMetadata;
 template <typename Runtime> struct TargetForeignClassMetadata;
-template <typename Runtime> struct TargetTypeContextDescriptor;
+template <typename Runtime> class TargetTypeContextDescriptor;
+template <typename Runtime> class TargetClassDescriptor;
+template <typename Runtime> class TargetEnumDescriptor;
+template <typename Runtime> class TargetStructDescriptor;
 
 // FIXME: https://bugs.swift.org/browse/SR-1155
 #pragma clang diagnostic push
@@ -1171,7 +1174,7 @@ private:
   /// if this is an artificial subclass.  We currently provide no
   /// supported mechanism for making a non-artificial subclass
   /// dynamically.
-  ConstTargetMetadataPointer<Runtime, TargetTypeContextDescriptor> Description;
+  ConstTargetMetadataPointer<Runtime, TargetClassDescriptor> Description;
 
   /// A function for destroying instance variables, used to clean up
   /// after an early return from a constructor.
@@ -1185,14 +1188,13 @@ private:
   //   - "tabulated" virtual methods
 
 public:
-  ConstTargetMetadataPointer<Runtime, TargetTypeContextDescriptor>
+  ConstTargetMetadataPointer<Runtime, TargetClassDescriptor>
   getDescription() const {
     assert(isTypeMetadata());
     return Description;
   }
 
-  void setDescription(const TargetTypeContextDescriptor<Runtime> *
-                      description) {
+  void setDescription(const TargetClassDescriptor<Runtime> *description) {
     Description = description;
   }
 
@@ -1279,7 +1281,7 @@ public:
   /// Get a pointer to the field offset vector, if present, or null.
   const StoredPointer *getFieldOffsets() const {
     assert(isTypeMetadata());
-    auto offset = getDescription()->Class.getFieldOffsetVectorOffset(this);
+    auto offset = getDescription()->getFieldOffsetVectorOffset(this);
     if (offset == 0)
       return nullptr;
     auto asWords = reinterpret_cast<const void * const*>(this);
@@ -1289,7 +1291,7 @@ public:
   /// Get a pointer to the field type vector, if present, or null.
   const FieldType *getFieldTypes() const {
     assert(isTypeMetadata());
-    auto *getter = getDescription()->Class.GetFieldTypes.get();
+    auto *getter = getDescription()->GetFieldTypes.get();
     if (!getter)
       return nullptr;
     
@@ -1511,7 +1513,7 @@ struct TargetForeignClassMetadata
   using StoredPointer = typename Runtime::StoredPointer;
 
   /// An out-of-line description of the type.
-  const TargetTypeContextDescriptor<Runtime> *Description;
+  const TargetClassDescriptor<Runtime> *Description;
 
   /// The superclass of the foreign class, if any.
   ConstTargetMetadataPointer<Runtime, swift::TargetForeignClassMetadata>
@@ -1555,9 +1557,13 @@ struct TargetStructMetadata : public TargetValueMetadata<Runtime> {
   using StoredPointer = typename Runtime::StoredPointer;
   using TargetValueMetadata<Runtime>::TargetValueMetadata;
   
+  const TargetStructDescriptor<Runtime> *getDescription() const {
+    return llvm::cast<TargetStructDescriptor<Runtime>>(this->Description);
+  }
+
   /// Get a pointer to the field offset vector, if present, or null.
   const StoredPointer *getFieldOffsets() const {
-    auto offset = this->Description->Struct.FieldOffsetVectorOffset;
+    auto offset = getDescription()->FieldOffsetVectorOffset;
     if (offset == 0)
       return nullptr;
     auto asWords = reinterpret_cast<const void * const*>(this);
@@ -1566,7 +1572,7 @@ struct TargetStructMetadata : public TargetValueMetadata<Runtime> {
   
   /// Get a pointer to the field type vector, if present, or null.
   const FieldType *getFieldTypes() const {
-    auto *getter = this->Description->Struct.GetFieldTypes.get();
+    auto *getter = getDescription()->GetFieldTypes.get();
     if (!getter)
       return nullptr;
     
@@ -1586,9 +1592,13 @@ struct TargetEnumMetadata : public TargetValueMetadata<Runtime> {
   using StoredSize = typename Runtime::StoredSize;
   using TargetValueMetadata<Runtime>::TargetValueMetadata;
 
+  const TargetEnumDescriptor<Runtime> *getDescription() const {
+    return llvm::cast<TargetEnumDescriptor<Runtime>>(this->Description);
+  }
+
   /// True if the metadata records the size of the payload area.
   bool hasPayloadSize() const {
-    return this->Description->Enum.hasPayloadSizeOffset();
+    return getDescription()->hasPayloadSizeOffset();
   }
 
   /// Retrieve the size of the payload area.
@@ -1596,7 +1606,7 @@ struct TargetEnumMetadata : public TargetValueMetadata<Runtime> {
   /// `hasPayloadSize` must be true for this to be valid.
   StoredSize getPayloadSize() const {
     assert(hasPayloadSize());
-    auto offset = this->Description->Enum.getPayloadSizeOffset();
+    auto offset = getDescription()->getPayloadSizeOffset();
     const StoredSize *asWords = reinterpret_cast<const StoredSize *>(this);
     asWords += offset;
     return *asWords;
@@ -1604,7 +1614,7 @@ struct TargetEnumMetadata : public TargetValueMetadata<Runtime> {
 
   StoredSize &getPayloadSize() {
     assert(hasPayloadSize());
-    auto offset = this->Description->Enum.getPayloadSizeOffset();
+    auto offset = getDescription()->getPayloadSizeOffset();
     StoredSize *asWords = reinterpret_cast<StoredSize *>(this);
     asWords += offset;
     return *asWords;
@@ -3042,30 +3052,75 @@ public:
   }
 };
 
-template<typename Runtime>
-struct TargetTypeContextDescriptor final
-    : TargetContextDescriptor<Runtime>,
-      TrailingGenericContextObjects<TargetTypeContextDescriptor<Runtime>,
-                                    TypeGenericContextDescriptorHeader,
-                                    /*additional trailing objects:*/
-                                    TargetVTableDescriptorHeader<Runtime>,
-                                    TargetMethodDescriptor<Runtime>>
-{
+template <typename Runtime>
+class TargetTypeContextDescriptor
+    : public TargetContextDescriptor<Runtime> {
+public:
+  /// The name of the type.
+  TargetRelativeDirectPointer<Runtime, const char, /*nullable*/ false> Name;
+
+  /// A pointer to the metadata access function for this type.
+  ///
+  /// The function type here is a stand-in. You should use getAccessFunction()
+  /// to wrap the function pointer in an accessor that uses the proper calling
+  /// convention for a given number of arguments.
+  TargetRelativeDirectPointer<Runtime, const Metadata *(...),
+                              /*Nullable*/ true> AccessFunctionPtr;
+
+  MetadataAccessFunction getAccessFunction() const {
+    return MetadataAccessFunction(AccessFunctionPtr.get());
+  }
+
+  const GenericContextDescriptorHeader &getGenericContextHeader() const;
+
+  /// Return the offset of the start of generic arguments in the nominal
+  /// type's metadata. The returned value is measured in sizeof(void*).
+  uint32_t getGenericArgumentOffset(
+                               const TargetMetadata<Runtime> *metadata) const;
+
+  /// Return the start of the generic arguments array in the nominal
+  /// type's metadata. The returned value is measured in sizeof(void*).
+  const TargetMetadata<Runtime> * const *getGenericArguments(
+                               const TargetMetadata<Runtime> *metadata) const {
+    auto offset = getGenericArgumentOffset(metadata);
+    auto words =
+      reinterpret_cast<const TargetMetadata<Runtime> * const *>(metadata);
+    return words + offset;
+  }
+
+  static bool classof(const TargetContextDescriptor<Runtime> *cd) {
+    return cd->getKind() >= ContextDescriptorKind::Type_First
+        && cd->getKind() <= ContextDescriptorKind::Type_Last;
+  }
+};
+
+using TypeContextDescriptor = TargetTypeContextDescriptor<InProcess>;
+
+template <typename Runtime>
+class TargetClassDescriptor final
+    : public TargetTypeContextDescriptor<Runtime>,
+      public TrailingGenericContextObjects<TargetClassDescriptor<Runtime>,
+                                           TypeGenericContextDescriptorHeader,
+                                           /*additional trailing objects:*/
+                                          TargetVTableDescriptorHeader<Runtime>,
+                                           TargetMethodDescriptor<Runtime>> {
 private:
   using TrailingGenericContextObjects =
-    TrailingGenericContextObjects<TargetTypeContextDescriptor<Runtime>,
+    TrailingGenericContextObjects<TargetClassDescriptor<Runtime>,
                                   TypeGenericContextDescriptorHeader,
                                   TargetVTableDescriptorHeader<Runtime>,
                                   TargetMethodDescriptor<Runtime>>;
-  
+
   using TrailingObjects =
     typename TrailingGenericContextObjects::TrailingObjects;
-  
+  friend TrailingObjects;
+
 public:
   using MethodDescriptor = TargetMethodDescriptor<Runtime>;
   using VTableDescriptorHeader = TargetVTableDescriptorHeader<Runtime>;
 
   using TrailingGenericContextObjects::getGenericContext;
+  using TrailingGenericContextObjects::getGenericContextHeader;
   using TrailingGenericContextObjects::getFullGenericContextHeader;
 
   /// This bit is set in the context descriptor header's kind-specific flags
@@ -3078,127 +3133,60 @@ public:
   static constexpr const uint16_t HasResilientSuperclassFlag =
     uint16_t(TypeContextDescriptorFlags::HasResilientSuperclass);
   
-  /// The name of the type.
-  TargetRelativeDirectPointer<Runtime, const char, /*nullable*/ false> Name;
-  
-  /// A pointer to the metadata access function for this type.
+  /// The number of stored properties in the class, not including its
+  /// superclasses. If there is a field offset vector, this is its length.
+  uint32_t NumFields;
+
+private:
+  /// The offset of the field offset vector for this class's stored
+  /// properties in its metadata, in words. 0 means there is no field offset
+  /// vector.
   ///
-  /// The function type here is a stand-in. You should use getAccessFunction()
-  /// to wrap the function pointer in an accessor that uses the proper calling
-  /// convention for a given number of arguments.
-  TargetRelativeDirectPointer<Runtime, const Metadata *(...),
-                              /*Nullable*/ true> AccessFunctionPtr;
+  /// If this class has a resilient superclass, this offset is relative to
+  /// the size of the resilient superclass metadata. Otherwise, it is
+  /// absolute.
+  uint32_t FieldOffsetVectorOffset;
+
+  template<typename T>
+  using OverloadToken =
+    typename TrailingGenericContextObjects::template OverloadToken<T>;
   
-  MetadataAccessFunction getAccessFunction() const {
-    return MetadataAccessFunction(AccessFunctionPtr.get());
+  using TrailingGenericContextObjects::numTrailingObjects;
+
+  size_t numTrailingObjects(OverloadToken<VTableDescriptorHeader>) const {
+    return hasVTable() ? 1 : 0;
   }
 
-  // ABI TODO: These fields ought to be superseded by remote mirror metadata for
-  // the type.
-  union {
-    /// Information about class types.
-    struct {
-      /// The number of stored properties in the class, not including its
-      /// superclasses. If there is a field offset vector, this is its length.
-      uint32_t NumFields;
+  size_t numTrailingObjects(OverloadToken<MethodDescriptor>) const {
+    if (!hasVTable())
+      return 0;
 
-    private:
-      /// The offset of the field offset vector for this class's stored
-      /// properties in its metadata, in words. 0 means there is no field offset
-      /// vector.
-      ///
-      /// If this class has a resilient superclass, this offset is relative to
-      /// the size of the resilient superclass metadata. Otherwise, it is
-      /// absolute.
-      uint32_t FieldOffsetVectorOffset;
+    return getVTableDescriptor()->VTableSize;
+  }
 
-    public:
-      /// The field names. A doubly-null-terminated list of strings, whose
-      /// length and order is consistent with that of the field offset vector.
-      RelativeDirectPointer<const char, /*nullable*/ true> FieldNames;
+public:
+  /// The field names. A doubly-null-terminated list of strings, whose
+  /// length and order is consistent with that of the field offset vector.
+  RelativeDirectPointer<const char, /*nullable*/ true> FieldNames;
 
-      /// The field type vector accessor. Returns a pointer to an array of
-      /// type metadata references whose order is consistent with that of the
-      /// field offset vector.
-      RelativeDirectPointer<const FieldType *
-        (const TargetMetadata<Runtime> *)> GetFieldTypes;
+  /// The field type vector accessor. Returns a pointer to an array of
+  /// type metadata references whose order is consistent with that of the
+  /// field offset vector.
+  RelativeDirectPointer<const FieldType *
+    (const TargetMetadata<Runtime> *)> GetFieldTypes;
 
-      /// True if metadata records for this type have a field offset vector for
-      /// its stored properties.
-      bool hasFieldOffsetVector() const { return FieldOffsetVectorOffset != 0; }
+  /// True if metadata records for this type have a field offset vector for
+  /// its stored properties.
+  bool hasFieldOffsetVector() const { return FieldOffsetVectorOffset != 0; }
 
-      unsigned getFieldOffsetVectorOffset(const ClassMetadata *metadata) const {
-        const auto *description = metadata->getDescription();
+  unsigned getFieldOffsetVectorOffset(const ClassMetadata *metadata) const {
+    const auto *description = metadata->getDescription();
 
-        if (description->hasResilientSuperclass())
-          return metadata->SuperClass->getSizeInWords() + FieldOffsetVectorOffset;
+    if (description->hasResilientSuperclass())
+      return metadata->SuperClass->getSizeInWords() + FieldOffsetVectorOffset;
 
-        return FieldOffsetVectorOffset;
-      }
-    } Class;
-    
-    /// Information about struct types.
-    struct {
-      /// The number of stored properties in the class, not including its
-      /// superclasses. If there is a field offset vector, this is its length.
-      uint32_t NumFields;
-      /// The offset of the field offset vector for this class's stored
-      /// properties in its metadata, if any. 0 means there is no field offset
-      /// vector.
-      uint32_t FieldOffsetVectorOffset;
-      
-      /// The field names. A doubly-null-terminated list of strings, whose
-      /// length and order is consistent with that of the field offset vector.
-      RelativeDirectPointer<const char, /*nullable*/ true> FieldNames;
-      
-      /// The field type vector accessor. Returns a pointer to an array of
-      /// type metadata references whose order is consistent with that of the
-      /// field offset vector.
-      RelativeDirectPointer<const FieldType *
-        (const TargetMetadata<Runtime> *)> GetFieldTypes;
-
-      /// True if metadata records for this type have a field offset vector for
-      /// its stored properties.
-      bool hasFieldOffsetVector() const { return FieldOffsetVectorOffset != 0; }
-    } Struct;
-    
-    /// Information about enum types.
-    struct {
-      /// The number of non-empty cases in the enum are in the low 24 bits;
-      /// the offset of the payload size in the metadata record in words,
-      /// if any, is stored in the high 8 bits.
-      uint32_t NumPayloadCasesAndPayloadSizeOffset;
-      /// The number of empty cases in the enum.
-      uint32_t NumEmptyCases;
-      /// The names of the cases. A doubly-null-terminated list of strings,
-      /// whose length is NumNonEmptyCases + NumEmptyCases. Cases are named in
-      /// tag order, non-empty cases first, followed by empty cases.
-      RelativeDirectPointer<const char, /*nullable*/ true> CaseNames;
-      /// The field type vector accessor. Returns a pointer to an array of
-      /// type metadata references whose order is consistent with that of the
-      /// CaseNames. Only types for payload cases are provided.
-      RelativeDirectPointer<
-        const FieldType * (const TargetMetadata<Runtime> *)>
-        GetCaseTypes;
-
-      uint32_t getNumPayloadCases() const {
-        return NumPayloadCasesAndPayloadSizeOffset & 0x00FFFFFFU;
-      }
-      uint32_t getNumEmptyCases() const {
-        return NumEmptyCases;
-      }
-      uint32_t getNumCases() const {
-        return getNumPayloadCases() + NumEmptyCases;
-      }
-      size_t getPayloadSizeOffset() const {
-        return ((NumPayloadCasesAndPayloadSizeOffset & 0xFF000000U) >> 24);
-      }
-      
-      bool hasPayloadSizeOffset() const {
-        return getPayloadSizeOffset() != 0;
-      }
-    } Enum;
-  };
+    return FieldOffsetVectorOffset;
+  }
 
   bool hasVTable() const {
     return (this->Flags.getKindSpecificFlags() & HasVTableFlag) != 0;
@@ -3222,17 +3210,6 @@ public:
             numTrailingObjects(OverloadToken<MethodDescriptor>{})};
   }
 
-  void *getMethod(unsigned i) const {
-    assert(hasVTable()
-           && i < numTrailingObjects(OverloadToken<MethodDescriptor>{}));
-    return getMethodDescriptors()[i].Impl.get();
-  }
-
-  static bool classof(const TargetContextDescriptor<Runtime> *cd) {
-    return cd->getKind() >= ContextDescriptorKind::Type_First
-        && cd->getKind() <= ContextDescriptorKind::Type_Last;
-  }
-  
   /// This is factored in a silly way because remote mirrors cannot directly
   /// dereference the SuperClass field of class metadata.
   uint32_t getGenericArgumentOffset(
@@ -3246,14 +3223,6 @@ public:
   }
 
   /// Return the offset of the start of generic arguments in the nominal
-  /// type's metadata. This method should only be used with value type
-  /// metadata and class metadata with a non-resilient superclass.
-  uint32_t getGenericArgumentOffset() const {
-    assert(!hasResilientSuperclass());
-    return getFullGenericContextHeader().ArgumentOffset;
-  }
-
-  /// Return the offset of the start of generic arguments in the nominal
   /// type's metadata. The returned value is measured in sizeof(void*).
   uint32_t
   getGenericArgumentOffset(const TargetMetadata<Runtime> *metadata) const {
@@ -3263,39 +3232,141 @@ public:
       return getGenericArgumentOffset(classMetadata, superMetadata);
     }
 
-    return getGenericArgumentOffset();
+    return getFullGenericContextHeader().ArgumentOffset;
   }
-  
-  const TargetMetadata<Runtime> * const *getGenericArguments(
-                               const TargetMetadata<Runtime> *metadata) const {
-    auto offset = getGenericArgumentOffset(metadata);
-    auto words =
-      reinterpret_cast<const TargetMetadata<Runtime> * const *>(metadata);
-    return words + offset;
-  }
-  
-private:
-  template<typename T>
-  using OverloadToken =
-    typename TrailingGenericContextObjects::template OverloadToken<T>;
-  
-  friend TrailingObjects;
-  
-  using TrailingGenericContextObjects::numTrailingObjects;
-  
-  size_t numTrailingObjects(OverloadToken<VTableDescriptorHeader>) const {
-    return hasVTable() ? 1 : 0;
-  }
-  
-  size_t numTrailingObjects(OverloadToken<MethodDescriptor>) const {
-    if (!hasVTable())
-      return 0;
 
-    return getVTableDescriptor()->VTableSize;
+  void *getMethod(unsigned i) const {
+    assert(hasVTable()
+           && i < numTrailingObjects(OverloadToken<MethodDescriptor>{}));
+    return getMethodDescriptors()[i].Impl.get();
+  }
+  
+  static bool classof(const TargetContextDescriptor<Runtime> *cd) {
+    return cd->getKind() == ContextDescriptorKind::Class;
   }
 };
 
-using TypeContextDescriptor = TargetTypeContextDescriptor<InProcess>;
+using ClassDescriptor = TargetClassDescriptor<InProcess>;
+
+template <typename Runtime>
+class TargetStructDescriptor final
+    : public TargetTypeContextDescriptor<Runtime>,
+      public TrailingGenericContextObjects<TargetStructDescriptor<Runtime>,
+                                           TypeGenericContextDescriptorHeader> {
+private:
+  using TrailingGenericContextObjects =
+    TrailingGenericContextObjects<TargetStructDescriptor<Runtime>,
+                                  TypeGenericContextDescriptorHeader>;
+
+  using TrailingObjects =
+    typename TrailingGenericContextObjects::TrailingObjects;
+  friend TrailingObjects;
+
+public:
+  using TrailingGenericContextObjects::getGenericContext;
+  using TrailingGenericContextObjects::getGenericContextHeader;
+  using TrailingGenericContextObjects::getFullGenericContextHeader;
+
+  /// The number of stored properties in the struct.
+  /// If there is a field offset vector, this is its length.
+  uint32_t NumFields;
+  /// The offset of the field offset vector for this struct's stored
+  /// properties in its metadata, if any. 0 means there is no field offset
+  /// vector.
+  uint32_t FieldOffsetVectorOffset;
+  
+  /// The field names. A doubly-null-terminated list of strings, whose
+  /// length and order is consistent with that of the field offset vector.
+  RelativeDirectPointer<const char, /*nullable*/ true> FieldNames;
+  
+  /// The field type vector accessor. Returns a pointer to an array of
+  /// type metadata references whose order is consistent with that of the
+  /// field offset vector.
+  RelativeDirectPointer<const FieldType *
+    (const TargetMetadata<Runtime> *)> GetFieldTypes;
+
+  /// True if metadata records for this type have a field offset vector for
+  /// its stored properties.
+  bool hasFieldOffsetVector() const { return FieldOffsetVectorOffset != 0; }
+
+  uint32_t getGenericArgumentOffset() const {
+    return getFullGenericContextHeader().ArgumentOffset;
+  }
+
+  static bool classof(const TargetContextDescriptor<Runtime> *cd) {
+    return cd->getKind() == ContextDescriptorKind::Struct;
+  }
+};
+
+using StructDescriptor = TargetStructDescriptor<InProcess>;
+
+template <typename Runtime>
+class TargetEnumDescriptor final
+    : public TargetTypeContextDescriptor<Runtime>,
+      public TrailingGenericContextObjects<TargetEnumDescriptor<Runtime>,
+                                           TypeGenericContextDescriptorHeader> {
+private:
+  using TrailingGenericContextObjects =
+    TrailingGenericContextObjects<TargetEnumDescriptor<Runtime>,
+                                  TypeGenericContextDescriptorHeader>;
+
+  using TrailingObjects =
+    typename TrailingGenericContextObjects::TrailingObjects;
+  friend TrailingObjects;
+
+public:
+  using TrailingGenericContextObjects::getGenericContext;
+  using TrailingGenericContextObjects::getGenericContextHeader;
+  using TrailingGenericContextObjects::getFullGenericContextHeader;
+
+  /// The number of non-empty cases in the enum are in the low 24 bits;
+  /// the offset of the payload size in the metadata record in words,
+  /// if any, is stored in the high 8 bits.
+  uint32_t NumPayloadCasesAndPayloadSizeOffset;
+
+  /// The number of empty cases in the enum.
+  uint32_t NumEmptyCases;
+
+  /// The names of the cases. A doubly-null-terminated list of strings,
+  /// whose length is NumNonEmptyCases + NumEmptyCases. Cases are named in
+  /// tag order, non-empty cases first, followed by empty cases.
+  RelativeDirectPointer<const char, /*nullable*/ true> CaseNames;
+
+  /// The field type vector accessor. Returns a pointer to an array of
+  /// type metadata references whose order is consistent with that of the
+  /// CaseNames. Only types for payload cases are provided.
+  RelativeDirectPointer<
+    const FieldType * (const TargetMetadata<Runtime> *)>
+    GetCaseTypes;
+
+  uint32_t getNumPayloadCases() const {
+    return NumPayloadCasesAndPayloadSizeOffset & 0x00FFFFFFU;
+  }
+
+  uint32_t getNumEmptyCases() const {
+    return NumEmptyCases;
+  }
+  uint32_t getNumCases() const {
+    return getNumPayloadCases() + NumEmptyCases;
+  }
+  size_t getPayloadSizeOffset() const {
+    return ((NumPayloadCasesAndPayloadSizeOffset & 0xFF000000U) >> 24);
+  }
+  
+  bool hasPayloadSizeOffset() const {
+    return getPayloadSizeOffset() != 0;
+  }
+
+  uint32_t getGenericArgumentOffset() const {
+    return getFullGenericContextHeader().ArgumentOffset;
+  }
+
+  static bool classof(const TargetContextDescriptor<Runtime> *cd) {
+    return cd->getKind() == ContextDescriptorKind::Enum;
+  }
+};
+
+using EnumDescriptor = TargetEnumDescriptor<InProcess>;
 
 template<typename Runtime>
 inline const TargetGenericContext<Runtime> *
@@ -3313,18 +3384,57 @@ TargetContextDescriptor<Runtime>::getGenericContext() const {
   case ContextDescriptorKind::Anonymous:
     return llvm::cast<TargetAnonymousContextDescriptor<Runtime>>(this)
       ->getGenericContext();
-  default:
-    if (getKind() >= ContextDescriptorKind::Type_First
-        && getKind() <= ContextDescriptorKind::Type_Last) {
-      return llvm::cast<TargetTypeContextDescriptor<Runtime>>(this)
+  case ContextDescriptorKind::Class:
+    return llvm::cast<TargetClassDescriptor<Runtime>>(this)
         ->getGenericContext();
-    }
-    
+  case ContextDescriptorKind::Enum:
+    return llvm::cast<TargetEnumDescriptor<Runtime>>(this)
+        ->getGenericContext();
+  case ContextDescriptorKind::Struct:
+    return llvm::cast<TargetStructDescriptor<Runtime>>(this)
+        ->getGenericContext();
+  default:    
     // We don't know about this kind of descriptor.
     return nullptr;
   }
 }
-  
+
+template <typename Runtime>
+uint32_t TargetTypeContextDescriptor<Runtime>::getGenericArgumentOffset(
+                                const TargetMetadata<Runtime> *metadata) const {
+  switch (this->getKind()) {
+  case ContextDescriptorKind::Class:
+    return llvm::cast<TargetClassDescriptor<Runtime>>(this)
+        ->getGenericArgumentOffset(metadata);
+  case ContextDescriptorKind::Enum:
+    return llvm::cast<TargetEnumDescriptor<Runtime>>(this)
+        ->getGenericArgumentOffset();
+  case ContextDescriptorKind::Struct:
+    return llvm::cast<TargetStructDescriptor<Runtime>>(this)
+        ->getGenericArgumentOffset();
+  default:
+    swift_runtime_unreachable("Not a type context descriptor.");
+  }
+}
+
+template <typename Runtime>
+const GenericContextDescriptorHeader &
+TargetTypeContextDescriptor<Runtime>::getGenericContextHeader() const {
+  switch (this->getKind()) {
+  case ContextDescriptorKind::Class:
+    return llvm::cast<TargetClassDescriptor<Runtime>>(this)
+        ->getGenericContextHeader();
+  case ContextDescriptorKind::Enum:
+    return llvm::cast<TargetEnumDescriptor<Runtime>>(this)
+        ->getGenericContextHeader();
+  case ContextDescriptorKind::Struct:
+    return llvm::cast<TargetStructDescriptor<Runtime>>(this)
+        ->getGenericContextHeader();
+  default:
+    swift_runtime_unreachable("Not a type context descriptor.");
+  }
+}
+
 /// \brief Fetch a uniqued metadata object for a generic nominal type.
 ///
 /// The basic algorithm for fetching a metadata object is:

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -638,7 +638,7 @@ id getErrorEmbeddedNSErrorIndirect(const OpaqueValue *error,
 /******************************************************************************/
 
 /// Nominal type descriptor for Swift.AnyHashable.
-extern "C" const TypeContextDescriptor STRUCT_TYPE_DESCR_SYM(s11AnyHashable);
+extern "C" const StructDescriptor STRUCT_TYPE_DESCR_SYM(s11AnyHashable);
 
 static bool isAnyHashableType(const StructMetadata *type) {
   return type->getDescription() == &STRUCT_TYPE_DESCR_SYM(s11AnyHashable);
@@ -2117,13 +2117,13 @@ static bool tryDynamicCastBoxedSwiftValue(OpaqueValue *dest,
 /******************************************************************************/
 
 /// Nominal type descriptor for Swift.Array.
-extern "C" const TypeContextDescriptor NOMINAL_TYPE_DESCR_SYM(Sa);
+extern "C" const StructDescriptor NOMINAL_TYPE_DESCR_SYM(Sa);
 
 /// Nominal type descriptor for Swift.Dictionary.
-extern "C" const TypeContextDescriptor STRUCT_TYPE_DESCR_SYM(s10Dictionary);
+extern "C" const StructDescriptor STRUCT_TYPE_DESCR_SYM(s10Dictionary);
 
 /// Nominal type descriptor for Swift.Set.
-extern "C" const TypeContextDescriptor STRUCT_TYPE_DESCR_SYM(s3Set);
+extern "C" const StructDescriptor STRUCT_TYPE_DESCR_SYM(s3Set);
 
 // internal func _arrayDownCastIndirect<SourceValue, TargetValue>(
 //   _ source: UnsafePointer<Array<SourceValue>>,

--- a/stdlib/public/runtime/Enum.cpp
+++ b/stdlib/public/runtime/Enum.cpp
@@ -184,7 +184,7 @@ swift::swift_initEnumMetadataMultiPayload(EnumMetadata *enumType,
   
   // The total size includes space for the tag.
   unsigned totalSize = payloadSize + getNumTagBytes(payloadSize,
-                                enumType->Description->Enum.getNumEmptyCases(),
+                                enumType->getDescription()->getNumEmptyCases(),
                                 numPayloads);
 
   auto vwtable = getMutableVWTableForInit(enumType, layoutFlags);
@@ -296,7 +296,7 @@ swift::swift_storeEnumTagMultiPayload(OpaqueValue *value,
                                       const EnumMetadata *enumType,
                                       unsigned whichCase) {
   auto layout = getMultiPayloadLayout(enumType);
-  unsigned numPayloads = enumType->Description->Enum.getNumPayloadCases();
+  unsigned numPayloads = enumType->getDescription()->getNumPayloadCases();
   if (whichCase < numPayloads) {
     // For a payload case, store the tag after the payload area.
     storeMultiPayloadTag(value, layout, whichCase);
@@ -322,7 +322,7 @@ unsigned
 swift::swift_getEnumCaseMultiPayload(const OpaqueValue *value,
                                      const EnumMetadata *enumType) {
   auto layout = getMultiPayloadLayout(enumType);
-  unsigned numPayloads = enumType->Description->Enum.getNumPayloadCases();
+  unsigned numPayloads = enumType->getDescription()->getNumPayloadCases();
 
   unsigned tag = loadMultiPayloadTag(value, layout);
   if (tag < numPayloads) {

--- a/stdlib/public/runtime/ErrorDefaultImpls.cpp
+++ b/stdlib/public/runtime/ErrorDefaultImpls.cpp
@@ -32,7 +32,7 @@ intptr_t _swift_stdlib_getDefaultErrorCode(OpaqueValue *error,
       // Enum tags use negative values for payload cases, so adjust code to be
       // in the range [0, num-cases).
       result = T->vw_getEnumTag(error) +
-        T->getTypeContextDescriptor()->Enum.getNumPayloadCases();
+        cast<EnumMetadata>(T)->getDescription()->getNumPayloadCases();
       break;
 
     case MetadataKind::Class:

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -1516,12 +1516,12 @@ static void _swift_initializeSuperclass(ClassMetadata *theClass) {
     }
 
     // Copy the field offsets.
-    if (description->Class.hasFieldOffsetVector()) {
+    if (description->hasFieldOffsetVector()) {
       unsigned fieldOffsetVector =
-        description->Class.getFieldOffsetVectorOffset(ancestor);
+        description->getFieldOffsetVectorOffset(ancestor);
       memcpy(classWords + fieldOffsetVector,
              superWords + fieldOffsetVector,
-             description->Class.NumFields * sizeof(uintptr_t));
+             description->NumFields * sizeof(uintptr_t));
     }
     ancestor = ancestor->SuperClass;
   }

--- a/stdlib/public/runtime/Reflection.mm
+++ b/stdlib/public/runtime/Reflection.mm
@@ -534,7 +534,7 @@ intptr_t swift_StructMirror_count(HeapObject *owner,
                                   const Metadata *type) {
   auto Struct = static_cast<const StructMetadata *>(type);
   SWIFT_CC_PLUSONE_GUARD(swift_release(owner));
-  return Struct->Description->Struct.NumFields;
+  return Struct->getDescription()->NumFields;
 }
 
 // internal func _getStructChild<T>(_: Int, _: _MagicMirrorData) -> (T, _Mirror)
@@ -549,7 +549,7 @@ void swift_StructMirror_subscript(String *outString,
                                   const Metadata *type) {
   auto Struct = static_cast<const StructMetadata *>(type);
 
-  if (i < 0 || (size_t)i > Struct->Description->Struct.NumFields)
+  if (i < 0 || (size_t)i > Struct->getDescription()->NumFields)
     swift::crash("Swift mirror subscript bounds check failure");
 
   // Load the type and offset from their respective vectors.
@@ -559,7 +559,7 @@ void swift_StructMirror_subscript(String *outString,
   auto bytes = reinterpret_cast<char*>(value);
   auto fieldData = reinterpret_cast<OpaqueValue *>(bytes + fieldOffset);
 
-  new (outString) String(getFieldName(Struct->Description->Struct.FieldNames, i));
+  new (outString) String(getFieldName(Struct->getDescription()->FieldNames, i));
 
   // 'owner' is consumed by this call.
   SWIFT_CC_PLUSZERO_GUARD(swift_unknownRetain(owner));
@@ -577,7 +577,7 @@ void swift_StructMirror_subscript(String *outString,
 
 static bool isEnumReflectable(const Metadata *type) {
   const auto Enum = static_cast<const EnumMetadata *>(type);
-  const auto &Description = Enum->Description->Enum;
+  const auto &Description = *Enum->getDescription();
 
   // No metadata for C and @objc enums yet
   if (Description.CaseNames == nullptr)
@@ -592,7 +592,7 @@ static void getEnumMirrorInfo(const OpaqueValue *value,
                               const Metadata **payloadTypePtr,
                               bool *indirectPtr) {
   const auto Enum = static_cast<const EnumMetadata *>(type);
-  const auto &Description = Enum->Description->Enum;
+  const auto &Description = *Enum->getDescription();
 
   unsigned payloadCases = Description.getNumPayloadCases();
 
@@ -633,7 +633,7 @@ const char *swift_EnumMirror_caseName(HeapObject *owner,
   }
 
   const auto Enum = static_cast<const EnumMetadata *>(type);
-  const auto &Description = Enum->Description->Enum;
+  const auto &Description = *Enum->getDescription();
 
   unsigned tag;
   getEnumMirrorInfo(value, type, &tag, nullptr, nullptr);
@@ -701,7 +701,7 @@ void swift_EnumMirror_subscript(String *outString,
                                 const OpaqueValue *value,
                                 const Metadata *type) {
   const auto Enum = static_cast<const EnumMetadata *>(type);
-  const auto &Description = Enum->Description->Enum;
+  const auto &Description = *Enum->getDescription();
 
   unsigned tag;
   const Metadata *payloadType;
@@ -750,7 +750,7 @@ intptr_t swift_ClassMirror_count(HeapObject *owner,
                                  const Metadata *type) {
   auto Clas = static_cast<const ClassMetadata*>(type);
   SWIFT_CC_PLUSONE_GUARD(swift_release(owner));
-  auto count = Clas->getDescription()->Class.NumFields;
+  auto count = Clas->getDescription()->NumFields;
 
   // If the class has a superclass, the superclass instance is treated as the
   // first child.
@@ -788,7 +788,7 @@ void swift_ClassMirror_subscript(String *outString,
     --i;
   }
 
-  if (i < 0 || (size_t)i > Clas->getDescription()->Class.NumFields)
+  if (i < 0 || (size_t)i > Clas->getDescription()->NumFields)
     swift::crash("Swift mirror subscript bounds check failure");
 
   // Load the type and offset from their respective vectors.
@@ -815,8 +815,7 @@ void swift_ClassMirror_subscript(String *outString,
   auto bytes = *reinterpret_cast<char * const *>(value);
   auto fieldData = reinterpret_cast<OpaqueValue *>(bytes + fieldOffset);
 
-  new (outString) String(getFieldName(Clas->getDescription()->Class.FieldNames,
-                                      i));
+  new (outString) String(getFieldName(Clas->getDescription()->FieldNames, i));
 
  if (loadSpecialReferenceStorage(owner, fieldData, fieldType, outMirror))
    return;


### PR DESCRIPTION
The purpose here is to make it easier to add type-specific fields to the descriptor.