### PR TITLE
Smol String

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -588,10 +588,10 @@ func _stdlib_getline() -> String? {
       if result.isEmpty {
         return nil
       }
-      return String._fromWellFormedCodeUnitSequence(UTF8.self, input: result)
+      return String(decoding: result, as: UTF8.self)
     }
     if c == CInt(Unicode.Scalar("\n").value) {
-      return String._fromWellFormedCodeUnitSequence(UTF8.self, input: result)
+      return String(decoding: result, as: UTF8.self)
     }
     result.append(UInt8(c))
   }

--- a/stdlib/private/SwiftPrivate/IO.swift
+++ b/stdlib/private/SwiftPrivate/IO.swift
@@ -26,15 +26,15 @@ public struct _FDInputStream {
   public mutating func getline() -> String? {
     if let newlineIndex =
       _buffer[0..<_bufferUsed].index(of: UInt8(Unicode.Scalar("\n").value)) {
-      let result = String._fromWellFormedCodeUnitSequence(
-        UTF8.self, input: _buffer[0..<newlineIndex])
+      let result = String._fromWellFormedUTF8CodeUnitSequence(
+        _buffer[0..<newlineIndex])
       _buffer.removeSubrange(0...newlineIndex)
       _bufferUsed -= newlineIndex + 1
       return result
     }
     if isEOF && _bufferUsed > 0 {
-      let result = String._fromWellFormedCodeUnitSequence(
-        UTF8.self, input: _buffer[0..<_bufferUsed])
+      let result = String._fromWellFormedUTF8CodeUnitSequence(
+        _buffer[0..<_bufferUsed])
       _buffer.removeAll()
       _bufferUsed = 0
       return result

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -115,6 +115,7 @@ set(SWIFTLIB_ESSENTIAL
   ShadowProtocols.swift
   Shims.swift
   Slice.swift
+  SmallString.swift
   Sort.swift.gyb
   StaticString.swift
   Stride.swift.gyb

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -423,10 +423,15 @@ extension String {
   @_inlineable // FIXME(sil-serialize-all)
   public init(_ c: Character) {
     if let utf16 = c._smallUTF16 {
-      self = String(decoding: utf16, as: Unicode.UTF16.self)
+      if let small = _SmallUTF8String(utf16) {
+        self = String(_StringGuts(small))
+      } else {
+        // FIXME: Remove when we support UTF-8 in small string
+        self = String(decoding: utf16, as: Unicode.UTF16.self)
+      }
     }
     else {
-      // TODO(SSO): small check
+      // TODO(SSO): small check. For now, since we only do ASCII, this won't hit
       self = String(_StringGuts(_large: c._largeUTF16!))
     }
   }

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -10,6 +10,7 @@
     "CharacterUnicodeScalars.swift",
     "ICU.swift",
     "NormalizedCodeUnitIterator.swift",
+    "SmallString.swift",
     "StaticString.swift",
     "String.swift",
     "StringBridge.swift",

--- a/stdlib/public/core/InputStream.swift
+++ b/stdlib/public/core/InputStream.swift
@@ -65,10 +65,9 @@ public func readLine(strippingNewline: Bool = true) -> String? {
       }
     }
   }
-  let result = String._fromCodeUnitSequenceWithRepair(UTF8.self,
-    input: UnsafeMutableBufferPointer(
-      start: linePtr,
-      count: readBytes)).0
+  let result = String._fromUTF8CodeUnitSequence(
+    UnsafeMutableBufferPointer(start: linePtr, count: readBytes),
+    repair: true)!
   _stdlib_free(linePtr)
   return result
 }

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1802,8 +1802,7 @@ extension BinaryInteger {
     if isNegative {
       result.append(UInt8(("-" as Unicode.Scalar).value))
     }
-    return String._fromWellFormedCodeUnitSequence(
-      UTF8.self, input: result.reversed())
+    return String._fromASCII(result.reversed())
   }
 
   /// A textual representation of this value.

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -81,8 +81,7 @@ public func _getTypeName(_ type: Any.Type, qualified: Bool)
 public // @testable
 func _typeName(_ type: Any.Type, qualified: Bool = true) -> String {
   let (stringPtr, count) = _getTypeName(type, qualified: qualified)
-  return ._fromWellFormedCodeUnitSequence(UTF8.self,
-    input: UnsafeBufferPointer(start: stringPtr, count: count))
+  return ._fromASCII(UnsafeBufferPointer(start: stringPtr, count: count))
 }
 
 /// Lookup a class given a name. Until the demangled encoding of type

--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -436,9 +436,8 @@ internal func _float${bits}ToString(
   var buffer = _Buffer32()
   return buffer.withBytes { (bufferPtr) in
     let actualLength = _float${bits}ToStringImpl(bufferPtr, 32, value, debug)
-    return String._fromWellFormedCodeUnitSequence(
-      UTF8.self,
-      input: UnsafeBufferPointer(start: bufferPtr, count: Int(actualLength)))
+    return String._fromASCII(
+      UnsafeBufferPointer(start: bufferPtr, count: Int(actualLength)))
   }
 }
 
@@ -467,18 +466,16 @@ internal func _int64ToString(
     return buffer.withBytes { (bufferPtr) in
       let actualLength
       = _int64ToStringImpl(bufferPtr, 32, value, radix, uppercase)
-      return String._fromWellFormedCodeUnitSequence(
-        UTF8.self,
-        input: UnsafeBufferPointer(start: bufferPtr, count: Int(actualLength)))
+      return String._fromASCII(
+        UnsafeBufferPointer(start: bufferPtr, count: Int(actualLength)))
     }
   } else {
     var buffer = _Buffer72()
     return buffer.withBytes { (bufferPtr) in
       let actualLength
       = _int64ToStringImpl(bufferPtr, 72, value, radix, uppercase)
-      return String._fromWellFormedCodeUnitSequence(
-        UTF8.self,
-        input: UnsafeBufferPointer(start: bufferPtr, count: Int(actualLength)))
+      return String._fromASCII(
+        UnsafeBufferPointer(start: bufferPtr, count: Int(actualLength)))
     }
   }
 }
@@ -501,18 +498,16 @@ func _uint64ToString(
     return buffer.withBytes { (bufferPtr) in
       let actualLength
       = _uint64ToStringImpl(bufferPtr, 32, value, radix, uppercase)
-      return String._fromWellFormedCodeUnitSequence(
-        UTF8.self,
-        input: UnsafeBufferPointer(start: bufferPtr, count: Int(actualLength)))
+      return String._fromASCII(
+        UnsafeBufferPointer(start: bufferPtr, count: Int(actualLength)))
     }
   } else {
     var buffer = _Buffer72()
     return buffer.withBytes { (bufferPtr) in
       let actualLength
       = _uint64ToStringImpl(bufferPtr, 72, value, radix, uppercase)
-      return String._fromWellFormedCodeUnitSequence(
-        UTF8.self,
-        input: UnsafeBufferPointer(start: bufferPtr, count: Int(actualLength)))
+      return String._fromASCII(
+        UnsafeBufferPointer(start: bufferPtr, count: Int(actualLength)))
     }
   }
 }

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -1,0 +1,845 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+internal
+typealias _SmallUTF16StringBuffer = _FixedArray16<UInt16>
+
+//
+// NOTE: Small string is not available on 32-bit platforms (not enough bits!),
+// but we don't want to #if-def all use sites (at least for now). So, provide a
+// minimal unavailable interface.
+//
+#if arch(i386) || arch(arm)
+// Helper method for declaring something as not supported in 32-bit. Use inside
+// a function body inside a #if block so that callers don't have to be
+// conditional.
+@_transparent @_versioned
+func unsupportedOn32bit() -> Never { _conditionallyUnreachable() }
+
+// Trivial type declaration for type checking. Never present at runtime.
+@_fixed_layout public struct _SmallUTF8String {}
+
+#else
+@_fixed_layout
+public // @testable
+struct _SmallUTF8String {
+  typealias _RawBitPattern = (low: UInt, high: UInt)
+
+  //
+  // TODO: pretty ASCII art.
+  //
+  // TODO: endianess awareness day
+  //
+  // The low byte of the first word stores the first code unit. There is up to
+  // 15 such code units encodable, with the second-highest byte of the second
+  // word being the final code unit. The high byte of the final word stores the
+  // count.
+  //
+  @_versioned
+  var _storage: _RawBitPattern = (0,0)
+  @_versioned
+  @_inlineable
+  @inline(__always)
+  init() {
+    self._storage = (0,0)
+  }
+}
+#endif // 64-bit
+
+//
+// Small string creation interface
+//
+extension _SmallUTF8String {
+  @_inlineable
+  public // @testable
+  static var capacity: Int { return 15 }
+
+#if _runtime(_ObjC)
+  public // @testable
+  init?(_cocoaString cocoa: _CocoaString) {
+#if arch(i386) || arch(arm)
+    return nil // Never form small strings on 32-bit
+#else
+    self.init()
+    let len = self._withAllUnsafeMutableBytes { bufPtr -> Int? in
+      guard let len = _bridgeASCIICocoaString(cocoa, intoUTF8: bufPtr),
+            len <= _SmallUTF8String.capacity
+      else {
+        return nil
+      }
+      return len
+    }
+    guard let count = len else { return nil }
+    _sanityCheck(self.count == 0, "overwrote count early?")
+
+    self.count = count
+    _invariantCheck()
+#endif
+  }
+#endif // _runtime(_ObjC)
+
+  @_inlineable
+  public // @testable
+  init?<C: RandomAccessCollection>(_ codeUnits: C) where C.Element == UInt16 {
+#if arch(i386) || arch(arm)
+    return nil // Never form small strings on 32-bit
+#else
+    guard codeUnits.count <= _SmallUTF8String.capacity else { return nil }
+    // TODO(TODO: JIRA): Just implement this directly
+
+    self.init()
+    var bufferIdx = 0
+    for encodedScalar in Unicode._ParsingIterator(
+      codeUnits: codeUnits.makeIterator(),
+      parser: Unicode.UTF16.ForwardParser()
+    ) {
+      guard let transcoded = Unicode.UTF8.transcode(
+        encodedScalar, from: Unicode.UTF16.self
+      ) else {
+        // FIXME: can this fail with unpaired surrogates?
+        _sanityCheckFailure("UTF-16 should be transcodable to UTF-8")
+        return nil
+      }
+      _sanityCheck(transcoded.count <= 4, "how?")
+      guard bufferIdx + transcoded.count <= _SmallUTF8String.capacity else {
+        return nil
+      }
+      for i in transcoded.indices {
+        self._uncheckedSetCodeUnit(at: bufferIdx, to: transcoded[i])
+        bufferIdx += 1
+      }
+    }
+    _sanityCheck(self.count == 0, "overwrote count early?")
+    self.count = bufferIdx
+
+    // FIXME: support transcoding
+    if !self.isASCII { return nil }
+
+    _invariantCheck()
+#endif
+  }
+
+  @_inlineable
+  public // @testable
+  init?<C: RandomAccessCollection>(_ codeUnits: C) where C.Element == UInt8 {
+#if arch(i386) || arch(arm)
+    return nil // Never form small strings on 32-bit
+#else
+    let count = codeUnits.count
+    guard count <= _SmallUTF8String.capacity else { return nil }
+    self.init()
+    self._withAllUnsafeMutableBytes { rawBufPtr in
+      let bufPtr = UnsafeMutableBufferPointer(
+        start: rawBufPtr.baseAddress.unsafelyUnwrapped.assumingMemoryBound(
+          to: UInt8.self),
+        count: rawBufPtr.count)
+      var (itr, written) = codeUnits._copyContents(initializing: bufPtr)
+      _sanityCheck(itr.next() == nil)
+      _sanityCheck(count == written)
+    }
+    _sanityCheck(self.count == 0, "overwrote count early?")
+    self.count = count
+
+    // FIXME: support transcoding
+    if !self.isASCII { return nil }
+
+    _invariantCheck()
+#endif
+  }
+}
+
+//
+// Small string read interface
+//
+extension _SmallUTF8String {
+  @_versioned
+  @_inlineable
+  @inline(__always)
+  func withUTF8CodeUnits<Result>(
+    _ body: (UnsafeBufferPointer<UInt8>) throws -> Result
+  ) rethrows -> Result {
+#if arch(i386) || arch(arm)
+    unsupportedOn32bit()
+#else
+    return try _withAllUnsafeBytes { bufPtr in
+      let ptr = bufPtr.baseAddress._unsafelyUnwrappedUnchecked
+        .assumingMemoryBound(to: UInt8.self)
+      return try body(UnsafeBufferPointer(start: ptr, count: self.count))
+    }
+#endif
+  }
+
+  @_inlineable
+  @inline(__always)
+  public // @testable
+  func withTranscodedUTF16CodeUnits<Result>(
+    _ body: (UnsafeBufferPointer<UInt16>) throws -> Result
+  ) rethrows -> Result {
+#if arch(i386) || arch(arm)
+    unsupportedOn32bit()
+#else
+    var (transcoded, transcodedCount) = self.transcoded
+    return try Swift.withUnsafeBytes(of: &transcoded.storage) {
+      bufPtr -> Result in
+      let ptr = bufPtr.baseAddress._unsafelyUnwrappedUnchecked
+        .assumingMemoryBound(to: UInt16.self)
+      return try body(UnsafeBufferPointer(start: ptr, count: transcodedCount))
+    }
+#endif
+  }
+
+  @_versioned
+  @_inlineable
+  @inline(__always)
+  func withUnmanagedUTF16<Result>(
+    _ body: (_UnmanagedString<UInt16>) throws -> Result
+  ) rethrows -> Result {
+#if arch(i386) || arch(arm)
+    unsupportedOn32bit()
+#else
+    return try withTranscodedUTF16CodeUnits {
+      return try body(_UnmanagedString($0))
+    }
+#endif
+  }
+
+  @_versioned
+  @_inlineable
+  @inline(__always)
+  func withUnmanagedASCII<Result>(
+    _ body: (_UnmanagedString<UInt8>) throws -> Result
+  ) rethrows -> Result {
+#if arch(i386) || arch(arm)
+    unsupportedOn32bit()
+#else
+    _sanityCheck(self.isASCII)
+    return try withUTF8CodeUnits {
+      return try body(_UnmanagedString($0))
+    }
+#endif
+  }
+}
+extension _SmallUTF8String {
+  @_inlineable
+  public // @testable
+  // FIXME:  internal(set)
+  var count: Int {
+    @inline(__always) get {
+#if arch(i386) || arch(arm)
+    unsupportedOn32bit()
+#else
+      return Int(bitPattern: UInt(self._uncheckedCodeUnit(at: 15)))
+#endif
+    }
+    @inline(__always) set {
+#if arch(i386) || arch(arm)
+    unsupportedOn32bit()
+#else
+      _sanityCheck(newValue <= _SmallUTF8String.capacity, "out of bounds")
+      self._uncheckedSetCodeUnit(
+        at: 15, to: UInt8(truncatingIfNeeded: UInt(bitPattern: newValue)))
+#endif
+    }
+  }
+
+  @_inlineable
+  public // @testable
+  var capacity: Int { @inline(__always) get { return 15 } }
+
+  @_inlineable
+  public // @testable
+  var unusedCapacity: Int { @inline(__always) get { return capacity - count } }
+
+  @_inlineable
+  public // @testable
+  var isASCII: Bool {
+    @inline(__always) get {
+#if arch(i386) || arch(arm)
+      unsupportedOn32bit()
+#else
+      // TODO (TODO: JIRA): Consider using our last bit for this
+      _sanityCheck(_uncheckedCodeUnit(at: 15) & 0xF0 == 0)
+
+      let topBitMask: UInt = 0x8080_8080_8080_8080
+      return (_storage.low | _storage.high) & topBitMask == 0
+#endif
+    }
+  }
+
+  @_versioned
+  @_inlineable
+  func _invariantCheck() {
+#if arch(i386) || arch(arm)
+    unsupportedOn32bit()
+#else
+    #if INTERNAL_CHECKS_ENABLED
+    _sanityCheck(count <= _SmallUTF8String.capacity)
+    _sanityCheck(self.isASCII, "UTF-8 currently unsupported")
+    #endif // INTERNAL_CHECKS_ENABLED
+#endif
+  }
+
+  internal
+  func _dump() {
+#if arch(i386) || arch(arm)
+    unsupportedOn32bit()
+#else
+    #if INTERNAL_CHECKS_ENABLED
+    print("""
+      smallUTF8: count: \(self.count), codeUnits: \(
+        self.map { String($0, radix: 16) }.dropLast()
+      )
+      """)
+    #endif // INTERNAL_CHECKS_ENABLED
+#endif
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  @_versioned // FIXME(sil-serialize-all)
+  internal func _copy<TargetCodeUnit>(
+    into target: UnsafeMutableBufferPointer<TargetCodeUnit>
+  ) where TargetCodeUnit : FixedWidthInteger & UnsignedInteger {
+#if arch(i386) || arch(arm)
+    unsupportedOn32bit()
+#else
+    _sanityCheck(target.count >= self.count)
+    guard count > 0 else { return }
+
+    if _fastPath(TargetCodeUnit.bitWidth == 8) {
+      _sanityCheck(TargetCodeUnit.self == UInt8.self)
+      let target = _castBufPtr(target, to: UInt8.self)
+
+      // TODO: Inspect generated code. Consider checking count for alignment so
+      // we can just copy our UInts directly when possible.
+      var ptr = target.baseAddress._unsafelyUnwrappedUnchecked
+      for cu in self {
+        ptr[0] = cu
+        ptr += 1
+      }
+      return
+    }
+
+    _sanityCheck(TargetCodeUnit.self == UInt16.self)
+    self.transcode(_uncheckedInto: _castBufPtr(target, to: UInt16.self))
+#endif
+  }
+}
+extension _SmallUTF8String: RandomAccessCollection {
+  public // @testable
+  typealias Index = Int
+  public // @testable
+  typealias Element = UInt8
+  public // @testable
+  typealias SubSequence = _SmallUTF8String
+
+  @_inlineable
+  public // @testable
+  var startIndex: Int { @inline(__always) get { return 0 } }
+
+  @_inlineable
+  public // @testable
+  var endIndex: Int { @inline(__always) get { return count } }
+
+  @_inlineable
+  public // @testable
+  subscript(_ idx: Int) -> UInt8 {
+    @inline(__always) get {
+#if arch(i386) || arch(arm)
+      unsupportedOn32bit()
+#else
+      _sanityCheck(idx >= 0 && idx <= count)
+      return _uncheckedCodeUnit(at: idx)
+#endif
+    }
+    @inline(__always) set {
+#if arch(i386) || arch(arm)
+      unsupportedOn32bit()
+#else
+      _sanityCheck(idx >= 0 && idx <= count)
+      _uncheckedSetCodeUnit(at: idx, to: newValue)
+#endif
+    }
+  }
+
+  @_inlineable
+  public // @testable
+  subscript(_ bounds: Range<Index>) -> SubSequence {
+    @inline(__always) get {
+#if arch(i386) || arch(arm)
+    unsupportedOn32bit()
+#else
+      _sanityCheck(bounds.lowerBound >= 0 && bounds.upperBound <= count)
+      return self._uncheckedClamp(
+        lowerBound: bounds.lowerBound, upperBound: bounds.upperBound)
+#endif
+    }
+  }
+}
+
+extension _SmallUTF8String {
+  @_inlineable
+  public // @testable
+  func _repeated(_ n: Int) -> _SmallUTF8String? {
+#if arch(i386) || arch(arm)
+      unsupportedOn32bit()
+#else
+    _sanityCheck(n > 1)
+    let finalCount = self.count * n
+    guard finalCount <= 15 else { return nil }
+    var ret = self
+    for _ in 0..<(n &- 1) {
+      ret = ret._appending(self)._unsafelyUnwrappedUnchecked
+    }
+    return ret
+#endif
+  }
+
+  @_inlineable
+  public // @testable
+  func _appending<C: RandomAccessCollection>(_ other: C) -> _SmallUTF8String?
+  where C.Element == UInt8 {
+#if arch(i386) || arch(arm)
+      unsupportedOn32bit()
+#else
+    guard other.count <= self.unusedCapacity else { return nil }
+
+    // TODO: as _copyContents
+    var result = self
+    result._withMutableExcessCapacityBytes { rawBufPtr in
+      var i = 0
+      for cu in other {
+        rawBufPtr[i] = cu
+        i += 1
+      }
+    }
+    result.count = self.count &+ other.count
+    return result
+#endif
+  }
+
+  @_versioned
+  @_inlineable
+  func _appending<C: RandomAccessCollection>(_ other: C) -> _SmallUTF8String?
+  where C.Element == UInt16 {
+#if arch(i386) || arch(arm)
+      unsupportedOn32bit()
+#else
+    guard other.count <= self.unusedCapacity else { return nil }
+
+    // TODO: as _copyContents
+    var result = self
+    let success = result._withMutableExcessCapacityBytes { rawBufPtr -> Bool in
+      var i = 0
+      for cu in other {
+        guard cu <= 0x7F else {
+          // TODO: transcode and communicate count back
+          return false
+        }
+        rawBufPtr[i] = UInt8(truncatingIfNeeded: cu)
+        i += 1
+      }
+      return true
+    }
+    guard success else { return nil }
+
+    result.count = self.count &+ other.count
+    return result
+#endif
+  }
+
+  // NOTE: This exists to facilitate _fromCodeUnits, which is awful for this use
+  // case. Please don't call this from anywhere else.
+  @_versioned
+  @inline(never) // @outlined
+  // @_specialize(where Encoding == UTF16)
+  // @_specialize(where Encoding == UTF8)
+  init?<S: Sequence, Encoding: Unicode.Encoding>(
+    _fromCodeUnits codeUnits: S,
+    utf16Length: Int,
+    isASCII: Bool,
+    _: Encoding.Type = Encoding.self
+  ) where S.Element == Encoding.CodeUnit {
+#if arch(i386) || arch(arm)
+    return nil // Never form small strings on 32-bit
+#else
+    guard utf16Length <= 15 else { return nil }
+
+    // TODO: transcode
+    guard isASCII else { return nil }
+
+    self.init()
+    var bufferIdx = 0
+    for encodedScalar in Unicode._ParsingIterator(
+      codeUnits: codeUnits.makeIterator(),
+      parser: Encoding.ForwardParser()
+    ) {
+      guard let transcoded = Unicode.UTF8.transcode(
+        encodedScalar, from: Encoding.self
+      ) else {
+        fatalError("Somehow un-transcodable?")
+      }
+      _sanityCheck(transcoded.count <= 4, "how?")
+      guard bufferIdx + transcoded.count <= 15 else { return nil }
+      for i in transcoded.indices {
+        self._uncheckedSetCodeUnit(at: bufferIdx, to: transcoded[i])
+        bufferIdx += 1
+      }
+    }
+    _sanityCheck(self.count == 0, "overwrote count early?")
+    self.count = bufferIdx
+
+    // FIXME: support transcoding
+    if !self.isASCII { return nil }
+
+    _invariantCheck()
+#endif
+  }
+}
+
+extension _SmallUTF8String {
+#if arch(i386) || arch(arm)
+  @_fixed_layout @_versioned struct UnicodeScalarIterator {
+    @_versioned @_inlineable @inline(__always)
+    func next() -> Unicode.Scalar? { unsupportedOn32bit() }
+  }
+  @_versioned @_inlineable @inline(__always)
+  func makeUnicodeScalarIterator() -> UnicodeScalarIterator {
+    unsupportedOn32bit()
+  }
+#else
+  // FIXME (TODO: JIRA): Just make a real decoding iterator
+  @_fixed_layout
+  @_versioned // FIXME(sil-serialize-all)
+  struct UnicodeScalarIterator {
+    @_versioned // FIXME(sil-serialize-all)
+    var buffer: _SmallUTF16StringBuffer
+    @_versioned // FIXME(sil-serialize-all)
+    var count: Int
+    @_versioned // FIXME(sil-serialize-all)
+    var _offset: Int
+
+    @_inlineable // FIXME(sil-serialize-all)
+    @_versioned // FIXME(sil-serialize-all)
+    init(_ base: _SmallUTF8String) {
+      (self.buffer, self.count) = base.transcoded
+      self._offset = 0
+    }
+
+    @_inlineable // FIXME(sil-serialize-all)
+    @_versioned // FIXME(sil-serialize-all)
+    mutating func next() -> Unicode.Scalar? {
+      if _slowPath(_offset == count) { return nil }
+      let u0 = buffer[_offset]
+      if _fastPath(UTF16._isScalar(u0)) {
+        _offset += 1
+        return Unicode.Scalar(u0)
+      }
+      if UTF16.isLeadSurrogate(u0) && _offset + 1 < count {
+        let u1 = buffer[_offset + 1]
+        if UTF16.isTrailSurrogate(u1) {
+          _offset += 2
+          return UTF16._decodeSurrogates(u0, u1)
+        }
+      }
+      _offset += 1
+      return Unicode.Scalar._replacementCharacter
+    }
+  }
+
+  @_versioned // FIXME(sil-serialize-all)
+  @_inlineable
+  func makeUnicodeScalarIterator() -> UnicodeScalarIterator {
+    return UnicodeScalarIterator(self)
+  }
+#endif // 64-bit
+}
+
+#if arch(i386) || arch(arm)
+#else
+extension _SmallUTF8String {
+  @_inlineable
+  @_versioned
+  @inline(__always)
+  init(_rawBits: _RawBitPattern) {
+    self._storage.low = _rawBits.low
+    self._storage.high = _rawBits.high
+    _invariantCheck()
+  }
+
+  @_inlineable
+  @_versioned
+  @inline(__always)
+  init(low: UInt, high: UInt, count: Int) {
+    self.init()
+    self._storage.low = low
+    self._storage.high = high
+    self.count = count
+    _invariantCheck()
+  }
+
+  @_inlineable
+  @_versioned
+  internal var _rawBits: _RawBitPattern {
+    @inline(__always) get { return _storage }
+  }
+
+  @_inlineable
+  @_versioned
+  internal var lowUnpackedBits: UInt {
+    @inline(__always) get { return _storage.low }
+  }
+  @_inlineable
+  @_versioned
+  internal var highUnpackedBits: UInt {
+    @inline(__always) get { return _storage.high & 0x00FF_FFFF_FFFF_FFFF }
+  }
+
+  @_inlineable
+  @_versioned
+  internal var unpackedBits: (low: UInt, high: UInt, count: Int) {
+    @inline(__always)
+    get { return (lowUnpackedBits, highUnpackedBits, count) }
+  }
+}
+extension _SmallUTF8String {
+  // Operate with a pointer to the entire struct, including unused capacity
+  // and inline count. You should almost never call this directly.
+  @_versioned
+  @_inlineable
+  @inline(__always)
+  mutating func _withAllUnsafeMutableBytes<Result>(
+    _ body: (UnsafeMutableRawBufferPointer) throws -> Result
+  ) rethrows -> Result {
+    var copy = self
+    defer { self = copy }
+    return try Swift.withUnsafeMutableBytes(of: &copy._storage) { try body($0) }
+  }
+  @_versioned
+  @_inlineable
+  @inline(__always)
+  func _withAllUnsafeBytes<Result>(
+    _ body: (UnsafeRawBufferPointer) throws -> Result
+  ) rethrows -> Result {
+    var copy = self
+    return try Swift.withUnsafeBytes(of: &copy._storage) { try body($0) }
+  }
+  @_versioned
+  @_inlineable
+  @inline(__always)
+  mutating func _withMutableExcessCapacityBytes<Result>(
+    _ body: (UnsafeMutableRawBufferPointer) throws -> Result
+  ) rethrows -> Result {
+    let unusedCapacity = self.unusedCapacity
+    let count = self.count
+    return try self._withAllUnsafeMutableBytes { allBufPtr in
+      let ptr = allBufPtr.baseAddress._unsafelyUnwrappedUnchecked + count
+      return try body(
+        UnsafeMutableRawBufferPointer(start: ptr, count: unusedCapacity))
+    }
+  }
+
+}
+extension _SmallUTF8String {
+  @_versioned
+  @_inlineable
+  @inline(__always)
+  func _uncheckedCodeUnit(at i: Int) -> UInt8 {
+    _sanityCheck(i >= 0 && i <= 15)
+    if i < 8 {
+      return _storage.low._uncheckedGetByte(at: i)
+    } else {
+      return _storage.high._uncheckedGetByte(at: i &- 8)
+    }
+  }
+  @_versioned
+  @_inlineable
+  @inline(__always)
+  mutating func _uncheckedSetCodeUnit(at i: Int, to: UInt8) {
+    // TODO(TODO: JIRA): in-register operation instead
+    self._withAllUnsafeMutableBytes { $0[i] = to }
+  }
+}
+
+extension _SmallUTF8String {
+  @_inlineable
+  @_versioned
+  @inline(__always)
+  internal func _uncheckedClamp(upperBound: Int) -> _SmallUTF8String {
+    _sanityCheck(upperBound <= self.count)
+    guard upperBound >= 8 else {
+      var low = self.lowUnpackedBits
+      let shift = upperBound &* 8
+      let mask: UInt = (1 &<< shift) &- 1
+      low &= mask
+      return _SmallUTF8String(low: low, high: 0, count: upperBound)
+    }
+    let shift = (upperBound &- 8) &* 8
+    _sanityCheck(shift % 8 == 0)
+
+    var high = self.highUnpackedBits
+    high &= (1 &<< shift) &- 1
+    return _SmallUTF8String(
+      low: self.lowUnpackedBits, high: high, count: upperBound)
+  }
+
+  @_inlineable
+  @_versioned
+  @inline(__always)
+  internal func _uncheckedClamp(lowerBound: Int) -> _SmallUTF8String {
+    _sanityCheck(lowerBound < self.count)
+    let low: UInt
+    let high: UInt
+    if lowerBound < 8 {
+      let shift: UInt = UInt(bitPattern: lowerBound) &* 8
+      let newLowHigh: UInt = self.highUnpackedBits & ((1 &<< shift) &- 1)
+      low = (self.lowUnpackedBits &>> shift) | (newLowHigh &<< (64 &- shift))
+      high = self.highUnpackedBits &>> shift
+    } else {
+      high = 0
+      low = self.highUnpackedBits &>> ((lowerBound &- 8) &* 8)
+    }
+
+    return _SmallUTF8String(
+      low: low, high: high, count: self.count &- lowerBound)
+  }
+
+  @_inlineable
+  @_versioned
+  @inline(__always)
+  internal func _uncheckedClamp(
+    lowerBound: Int, upperBound: Int
+  ) -> _SmallUTF8String {
+    // TODO: More efficient to skip the intermediary shifts and just mask up
+    // front.
+    _sanityCheck(upperBound >= lowerBound)
+    if lowerBound == upperBound { return _SmallUTF8String() }
+    let dropTop = self._uncheckedClamp(upperBound: upperBound)
+    return dropTop._uncheckedClamp(lowerBound: lowerBound)
+  }
+}
+
+extension _SmallUTF8String {//}: _StringVariant {
+  typealias TranscodedBuffer = _SmallUTF16StringBuffer
+
+  @_inlineable
+  @_versioned
+  @discardableResult
+  func transcode(
+    _uncheckedInto buffer: UnsafeMutableBufferPointer<UInt16>
+  ) -> Int {
+      if _fastPath(isASCII) {
+        _sanityCheck(buffer.count >= self.count)
+        var bufferIdx = 0
+        for cu in self {
+            buffer[bufferIdx] = UInt16(cu)
+            bufferIdx += 1
+        }
+        return bufferIdx
+    }
+
+    let length = _transcodeNonASCII(_uncheckedInto: buffer)
+    _sanityCheck(length <= buffer.count) // TODO: assert ahead-of-time
+
+    return length
+  }
+
+  @_inlineable
+  @_versioned
+  @inline(__always)
+  func transcode(into buffer: UnsafeMutablePointer<TranscodedBuffer>) -> Int {
+    let ptr = UnsafeMutableRawPointer(buffer).assumingMemoryBound(
+      to: UInt16.self)
+
+    return transcode(
+      _uncheckedInto: UnsafeMutableBufferPointer(start: ptr, count: count))
+  }
+
+  @_inlineable
+  @_versioned
+  var transcoded: (TranscodedBuffer, count: Int) {
+    @inline(__always) get {
+      // TODO: in-register zero-extension for ascii
+      var buffer = TranscodedBuffer(allZeros:())
+      let count = transcode(into: &buffer)
+      return (buffer, count: count)
+    }
+  }
+
+  @_versioned
+  @inline(never) // @outlined
+  func _transcodeNonASCII(
+    _uncheckedInto buffer: UnsafeMutableBufferPointer<UInt16>
+  ) -> Int {
+    _sanityCheck(!isASCII)
+
+    // TODO(TODO: JIRA): Just implement this directly
+
+    var bufferIdx = 0
+    for encodedScalar in Unicode._ParsingIterator(
+      codeUnits: self.makeIterator(),
+      parser: Unicode.UTF8.ForwardParser()
+    ) {
+      guard let transcoded = Unicode.UTF16.transcode(
+        encodedScalar, from: Unicode.UTF8.self
+      ) else {
+        fatalError("Somehow un-transcodable?")
+      }
+      switch transcoded.count {
+      case 1:
+        buffer[bufferIdx] = transcoded.first!
+        bufferIdx += 1
+      case 2:
+        buffer[bufferIdx] = transcoded.first!
+        buffer[bufferIdx+1] = transcoded.dropFirst().first!
+        bufferIdx += 2
+      case _: fatalError("Somehow, not transcoded or more than 2?")
+      }
+    }
+
+    _sanityCheck(bufferIdx <= buffer.count) // TODO: assert earlier
+    return bufferIdx
+  }
+}
+
+@_versioned
+@_inlineable
+@inline(__always)
+internal
+func _castBufPtr<A, B>(
+  _ bufPtr: UnsafeMutableBufferPointer<A>, to: B.Type = B.self
+) -> UnsafeMutableBufferPointer<B> {
+  let numBytes = bufPtr.count &* MemoryLayout<A>.stride
+  _sanityCheck(numBytes % MemoryLayout<B>.stride == 0)
+
+  let ptr = UnsafeMutableRawPointer(
+    bufPtr.baseAddress._unsafelyUnwrappedUnchecked
+  ).assumingMemoryBound(to: B.self)
+  let count = numBytes / MemoryLayout<B>.stride
+  return UnsafeMutableBufferPointer(start: ptr, count: count)
+}
+
+#endif // 64-bit
+
+extension UInt {
+  // Fetches the `i`th byte, from least-significant to most-significant
+  //
+  // TODO: endianess awareness day
+  @_inlineable
+  @_versioned
+  @inline(__always)
+  func _uncheckedGetByte(at i: Int) -> UInt8 {
+    _sanityCheck(i >= 0 && i < MemoryLayout<UInt>.stride)
+    let shift = UInt(bitPattern: i) &* 8
+    return UInt8(truncatingIfNeeded: (self &>> shift))
+  }
+}
+

--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -270,9 +270,12 @@ public struct StaticString
   /// A string representation of the static string.
   @_inlineable // FIXME(sil-serialize-all)
   public var description: String {
-    return withUTF8Buffer {
-      (buffer) in
-      return String._fromWellFormedCodeUnitSequence(UTF8.self, input: buffer)
+    return withUTF8Buffer { (buffer) in
+      if isASCII {
+        return String._fromASCII(buffer)
+      } else {
+        return String._fromWellFormedUTF8CodeUnitSequence(buffer)
+      }
     }
   }
 

--- a/stdlib/public/core/StringComparison.swift
+++ b/stdlib/public/core/StringComparison.swift
@@ -12,8 +12,27 @@
 
 import SwiftShims
 
-//HACK: This gets rid of some retains/releases that was slowing down the
-//memcmp fast path for comparing ascii strings. rdar://problem/37473470
+// TODO: pick values that give us the best branching pattern
+internal
+enum _GutsClassification: UInt {
+  case smallUTF8 = 0
+  case irregular = 1
+  case regularASCII = 2
+  case regularUTF16 = 4
+}
+
+extension _StringGuts {
+  @_versioned
+  @_inlineable
+  var classification: _GutsClassification {
+    if _isSmall { return .smallUTF8 }
+    if _isContiguous { return isASCII ? .regularASCII : .regularUTF16 }
+    return .irregular
+  }
+}
+
+// HACK: This gets rid of some retains/releases that was slowing down the
+// memcmp fast path for comparing ascii strings. rdar://problem/37473470
 @inline(never) // @outlined
 @effects(readonly)
 @_versioned // @opaque
@@ -24,15 +43,31 @@ func _compareUnicode(
   let left = _StringGuts(rawBits: lhs)
   let right = _StringGuts(rawBits: rhs)
 
-  if _slowPath(!left._isContiguous || !right._isContiguous) {
-    if !left._isContiguous {
-      return left._asOpaque()._compareOpaque(right).rawValue
-    } else {
-      return right._asOpaque()._compareOpaque(left).flipped.rawValue
-    }
-  }
+  switch (left.classification, right.classification) {
+    // Both small: fast in-register comparison
+    case (.smallUTF8, .smallUTF8):
+      return left._smallUTF8String._compare(right._smallUTF8String).rawValue
 
-  return left._compareContiguous(right)
+    // Either irregular: branch to opaque code
+    case (.irregular, _):
+      return left._asOpaque()._compare(right).rawValue
+    case (_, .irregular):
+      return right._asOpaque()._compare(left).flipped.rawValue
+
+    // One small, other contiguous in memory
+    case (.smallUTF8, _):
+      return left._smallUTF8String._compare(_contiguous: right).rawValue
+    case (_, .smallUTF8):
+      return right._smallUTF8String._compare(
+        _contiguous: left
+      ).flipped.rawValue
+
+    // Both contiguous
+    case (.regularASCII, _):
+      return left._unmanagedASCIIView._compare(_contiguous: right).rawValue
+    case (.regularUTF16, _):
+      return left._unmanagedUTF16View._compare(_contiguous: right).rawValue
+  }
 }
 
 @inline(never) // @outlined
@@ -46,19 +81,179 @@ func _compareUnicode(
   let left = _StringGuts(rawBits: lhs)
   let right = _StringGuts(rawBits: rhs)
 
-   if _slowPath(!left._isContiguous || !right._isContiguous) {
-     if !left._isContiguous {
-       return left._asOpaque()[leftRange]._compareOpaque(
-         right, rightRange
-       ).rawValue
-     } else {
-       return right._asOpaque()[rightRange]._compareOpaque(
-         left, leftRange
-       ).flipped.rawValue
-     }
-   }
+  switch (left.classification, right.classification) {
+    // Both small: fast in-register comparison
+    case (.smallUTF8, .smallUTF8):
+      return left._smallUTF8String[leftRange]._compare(
+        right._smallUTF8String[rightRange]
+      ).rawValue
 
-  return left._compareContiguous(leftRange, right, rightRange)
+    // Either irregular: branch to opaque code
+    case (.irregular, _):
+      return left._asOpaque()[leftRange]._compare(right, rightRange).rawValue
+    case (_, .irregular):
+      return right._asOpaque()[rightRange]._compare(
+        left, leftRange
+      ).flipped.rawValue
+
+    // One small, other contiguous in memory
+    case (.smallUTF8, _):
+      return left._smallUTF8String[leftRange]._compare(
+        _contiguous: right, rightRange
+      ).rawValue
+    case (_, .smallUTF8):
+      return right._smallUTF8String[rightRange]._compare(
+        _contiguous: left, leftRange
+      ).flipped.rawValue
+
+    // Both contiguous
+    case (.regularASCII, _):
+      return left._unmanagedASCIIView[leftRange]._compare(
+        _contiguous: right, rightRange
+      ).rawValue
+    case (.regularUTF16, _):
+      return left._unmanagedUTF16View[leftRange]._compare(
+        _contiguous: right, rightRange
+      ).rawValue
+  }
+}
+
+// TODO: coalesce many of these into a protocol to simplify the code
+
+extension _SmallUTF8String {
+  func _compare(_ other: _SmallUTF8String) -> _Ordering {
+#if arch(i386) || arch(arm)
+    _conditionallyUnreachable()
+#else
+    if _fastPath(self.isASCII && other.isASCII) {
+      // TODO: fast in-register comparison
+      return self.withUnmanagedASCII { selfView in
+        return other.withUnmanagedASCII { otherView in
+          return _Ordering(signedNotation: selfView.compareASCII(to: otherView))
+        }
+      }
+    }
+
+    // TODO: fast in-register comparison
+    return self.withUnmanagedUTF16 { selfView in
+      return other.withUnmanagedUTF16 { otherView in
+        return selfView._compare(otherView)
+      }
+    }
+#endif // 64-bit
+  }
+  func _compare(_contiguous other: _StringGuts) -> _Ordering {
+#if arch(i386) || arch(arm)
+    unsupportedOn32bit()
+#else
+    _sanityCheck(other._isContiguous)
+    if other.isASCII {
+      // TODO: fast in-register comparison
+      return self._compare(other._unmanagedASCIIView)
+    }
+    return self._compare(other._unmanagedUTF16View)
+#endif // 64-bit
+  }
+
+  func _compare(
+    _contiguous other: _StringGuts, _ otherRange: Range<Int>
+  ) -> _Ordering {
+#if arch(i386) || arch(arm)
+    unsupportedOn32bit()
+#else
+    _sanityCheck(other._isContiguous)
+    if other.isASCII {
+      return self._compare(other._unmanagedASCIIView[otherRange])
+    }
+    return self._compare(other._unmanagedUTF16View[otherRange])
+#endif // 64-bit
+  }
+
+  func _compare(_ other: _UnmanagedString<UInt8>) -> _Ordering {
+#if arch(i386) || arch(arm)
+    unsupportedOn32bit()
+#else
+    if _fastPath(self.isASCII) {
+      return self.withUnmanagedASCII { selfView in
+        return _Ordering(
+          signedNotation: selfView.compareASCII(to: other))
+      }
+    }
+    return self.withUnmanagedUTF16 { $0._compare(other) }
+#endif // 64-bit
+  }
+
+  func _compare(_ other: _UnmanagedString<UInt16>) -> _Ordering {
+#if arch(i386) || arch(arm)
+    unsupportedOn32bit()
+#else
+    if _fastPath(self.isASCII) {
+      return self.withUnmanagedASCII { $0._compare(other) }
+    }
+    return self.withUnmanagedUTF16 { $0._compare(other) }
+#endif // 64-bit    
+  }
+}
+
+extension _UnmanagedString where CodeUnit == UInt8 {
+  func _compare(_contiguous other: _StringGuts) -> _Ordering {
+    _sanityCheck(other._isContiguous)
+    if other.isASCII {
+      return self._compare(other._unmanagedASCIIView)
+    }
+    return self._compare(other._unmanagedUTF16View)
+  }
+  func _compare(
+    _contiguous other: _StringGuts, _ otherRange: Range<Int>
+  ) -> _Ordering {
+    _sanityCheck(other._isContiguous)
+    if other.isASCII {
+      return self._compare(other._unmanagedASCIIView[otherRange])
+    }
+    return self._compare(other._unmanagedUTF16View[otherRange])
+  }
+
+  func _compare(_ other: _UnmanagedString<UInt8>) -> _Ordering {
+    fatalError("Should have hit the ascii comp in StringComparable.compare")
+  }
+  func _compare(_ other: _UnmanagedString<UInt16>) -> _Ordering {
+    return self._compareStringsPreLoop(other)
+  }
+}
+
+extension _UnmanagedString where CodeUnit == UInt16 {
+  func _compare(_contiguous other: _StringGuts) -> _Ordering {
+    _sanityCheck(other._isContiguous)
+    if other.isASCII {
+      return self._compare(other._unmanagedASCIIView)
+    }
+    return self._compare(other._unmanagedUTF16View)
+  }
+  func _compare(
+    _contiguous other: _StringGuts, _ otherRange: Range<Int>
+  ) -> _Ordering {
+    _sanityCheck(other._isContiguous)
+    if other.isASCII {
+      return self._compare(other._unmanagedASCIIView[otherRange])
+    }
+    return self._compare(other._unmanagedUTF16View[otherRange])
+  }
+
+  func _compare(_ other: _UnmanagedString<UInt8>) -> _Ordering {
+    return other._compare(self).flipped
+  }
+  func _compare(_ other: _UnmanagedString<UInt16>) -> _Ordering {
+    return self._compareStringsPreLoop(other)
+  }
+}
+
+extension _UnmanagedOpaqueString {
+  func _compare(_ other: _StringGuts) -> _Ordering {
+    return self._compareOpaque(other)
+  }
+  func _compare(_ other: _StringGuts, _ otherRange: Range<Int>) -> _Ordering {
+    return self._compareOpaque(other, otherRange)
+  }
 }
 
 //
@@ -506,58 +701,6 @@ extension _UnmanagedString where CodeUnit == UInt8 {
   }
 }
 
-public extension _StringGuts {
-  @inline(__always)
-  public
-  func _compareContiguous(_ other: _StringGuts) -> Int {
-    _sanityCheck(self._isContiguous && other._isContiguous)
-    switch (self.isASCII, other.isASCII) {
-    case (true, true):
-      fatalError("Should have hit the ascii comp in StringComparable.compare()")
-    case (true, false):
-      return self._unmanagedASCIIView._compareStringsPreLoop(
-        other: other._unmanagedUTF16View
-      ).rawValue
-    case (false, true):
-      // Same compare, just invert result
-      return other._unmanagedASCIIView._compareStringsPreLoop(
-        other: self._unmanagedUTF16View
-      ).flipped.rawValue
-    case (false, false):
-      return self._unmanagedUTF16View._compareStringsPreLoop(
-        other: other._unmanagedUTF16View
-      ).rawValue
-    }
-  }
-
-  @inline(__always)
-  public
-  func _compareContiguous(
-    _ selfRange: Range<Int>,
-    _ other: _StringGuts,
-    _ otherRange: Range<Int>
-  ) -> Int {
-    _sanityCheck(self._isContiguous && other._isContiguous)
-    switch (self.isASCII, other.isASCII) {
-    case (true, true):
-      fatalError("Should have hit the ascii comp in StringComparable.compare()")
-    case (true, false):
-      return self._unmanagedASCIIView[selfRange]._compareStringsPreLoop(
-        other: other._unmanagedUTF16View[otherRange]
-      ).rawValue
-    case (false, true):
-      // Same compare, just invert result
-      return other._unmanagedASCIIView[otherRange]._compareStringsPreLoop(
-        other: self._unmanagedUTF16View[selfRange]
-      ).flipped.rawValue
-    case (false, false):
-      return self._unmanagedUTF16View[selfRange]._compareStringsPreLoop(
-        other: other._unmanagedUTF16View[otherRange]
-      ).rawValue
-    }
-  }
-}
-
 extension _UnmanagedOpaqueString {
   @inline(never) // @outlined
   @_versioned
@@ -775,7 +918,7 @@ extension UnicodeScalar {
 extension _UnmanagedString where CodeUnit == UInt8 {
   @_versioned
   internal func _compareStringsPreLoop(
-    other: _UnmanagedString<UInt16>
+    _ other: _UnmanagedString<UInt16>
   ) -> _Ordering {
     let count = Swift.min(self.count, other.count)
 
@@ -990,7 +1133,7 @@ extension _UnmanagedString where CodeUnit == UInt16 {
   @_versioned
   internal
   func _compareStringsPreLoop(
-    other: _UnmanagedString<UInt16>
+    _ other: _UnmanagedString<UInt16>
   ) -> _Ordering {
     let count = Swift.min(self.count, other.count)
 

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -688,6 +688,9 @@ extension _StringGuts {
     if self.isASCII {
       defer { _fixLifetime(self) }
       let ascii = self._unmanagedASCIIView[range]
+      if let small = _SmallUTF8String(ascii.buffer) {
+        return _StringGuts(small)
+      }
       if _object.isUnmanaged {
         return _StringGuts(_large: ascii)
       }
@@ -1348,6 +1351,15 @@ extension _StringGuts {
       return (nil, true)
     }
     if isASCII {
+      if let small = _SmallUTF8String(
+        _fromCodeUnits: input,
+        utf16Length: utf16Count,
+        isASCII: true,
+        Encoding.self
+      ) {
+        return (_StringGuts(small), false)
+      }
+
       let storage = _SwiftStringStorage<UTF8.CodeUnit>.create(
         capacity: Swift.max(minimumCapacity, utf16Count),
         count: utf16Count)

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -1323,6 +1323,8 @@ extension _StringGuts : Sequence {
 }
 
 extension _StringGuts {
+  // TODO: Drop or unify with String._fromCodeUnits
+  //
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal
@@ -1358,6 +1360,20 @@ extension _StringGuts {
       fromCodeUnits: input,
       encoding: Encoding.self)
     return (_StringGuts(_large: storage), hadError)
+  }
+}
+
+extension _StringGuts {
+  // For testing purposes only. Might be both inefficient and too low-level.
+  // There should be an eventual API on String to accomplish something similar.
+  public // @_testable
+  static
+  func _createStringFromUTF16<C: RandomAccessCollection>(_ cus: C) -> String
+  where C.Element == UInt16 {
+    let storage = _SwiftStringStorage<UTF16.CodeUnit>.create(
+      capacity: cus.count, count: cus.count)
+    _ = storage._initialize(fromCodeUnits: cus, encoding: UTF16.self)
+    return String(_StringGuts(_large: storage))
   }
 }
 

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -70,16 +70,6 @@ extension String {
   }
 }
 
-extension String {
-  @_inlineable // FIXME(sil-serialize-all)
-  public init(_ _c: Unicode.Scalar) {
-    self = String._fromWellFormedCodeUnitSequence(
-      UTF32.self,
-      input: repeatElement(_c.value, count: 1))
-  }
-}
-
-
 // TODO: since this is generally useful, make public via evolution proposal.
 extension BidirectionalCollection {
   @_inlineable

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -167,6 +167,23 @@ extension String {
     let prefixCount = prefix._guts.count
     if prefixCount == 0 { return true }
 
+    // TODO: replace with 2-way vistor
+    if self._guts._isSmall && prefix._guts._isSmall {
+      let selfSmall = self._guts._smallUTF8String
+      let prefixSmall = prefix._guts._smallUTF8String
+      if selfSmall.isASCII && prefixSmall.isASCII {
+        return selfSmall.withUnmanagedASCII { selfASCII in
+          return prefixSmall.withUnmanagedASCII { prefixASCII in
+            if prefixASCII.count > selfASCII.count { return false }
+            return (0 as CInt) == _stdlib_memcmp(
+                selfASCII.rawStart,
+                prefixASCII.rawStart,
+                prefixASCII.count)
+          }
+        }
+      }
+    }
+
     if _fastPath(!self._guts._isOpaque && !prefix._guts._isOpaque) {
       if self._guts.isASCII && prefix._guts.isASCII {
         let result: Bool
@@ -198,12 +215,29 @@ extension String {
     let suffixCount = suffix._guts.count
     if suffixCount == 0 { return true }
 
+    // TODO: replace with 2-way vistor
+    if self._guts._isSmall && suffix._guts._isSmall {
+      let selfSmall = self._guts._smallUTF8String
+      let suffixSmall = suffix._guts._smallUTF8String
+      if selfSmall.isASCII && suffixSmall.isASCII {
+        return selfSmall.withUnmanagedASCII { selfASCII in
+          return suffixSmall.withUnmanagedASCII { suffixASCII in
+            if suffixASCII.count > selfASCII.count { return false }
+            return (0 as CInt) == _stdlib_memcmp(
+                selfASCII.rawStart + (selfASCII.count - suffixASCII.count),
+                suffixASCII.rawStart,
+                suffixASCII.count)
+          }
+        }
+      }
+    }
+
     if _fastPath(!self._guts._isOpaque && !suffix._guts._isOpaque) {
       if self._guts.isASCII && suffix._guts.isASCII {
         let result: Bool
         let selfASCII = self._guts._unmanagedASCIIView
         let suffixASCII = suffix._guts._unmanagedASCIIView
-        if suffixASCII.count > self._guts.count {
+        if suffixASCII.count > selfASCII.count {
           // Suffix is longer than self.
           result = false
         } else {

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -61,6 +61,13 @@ where CodeUnit : UnsignedInteger & FixedWidthInteger {
     count: Int = 0
   ) -> _SwiftStringStorage<CodeUnit> {
     _sanityCheck(count >= 0 && count <= capacity)
+
+#if arch(i386) || arch(arm)
+#else
+    _sanityCheck((CodeUnit.self != UInt8.self || capacity > 15),
+      "Should prefer a small representation")
+#endif // 64-bit
+
     let storage = Builtin.allocWithTailElems_1(
       _SwiftStringStorage<CodeUnit>.self,
       capacity._builtinWordValue, CodeUnit.self)

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -265,6 +265,12 @@ extension _SwiftStringStorage {
     opaqueOther other: _StringGuts, range: Range<Int>
   ) {
     _sanityCheck(other._isOpaque)
+    if other._isSmall {
+      other._smallUTF8String[range].withUnmanagedUTF16 {
+        self._appendInPlace($0)
+      }
+      return
+    }
     defer { _fixLifetime(other) }
     _appendInPlace(other._asOpaque()[range])
   }
@@ -289,6 +295,12 @@ extension _SwiftStringStorage {
   @_versioned // @opaque
   internal final func _opaqueAppendInPlace(opaqueOther other: _StringGuts) {
     _sanityCheck(other._isOpaque)
+    if other._isSmall {
+      other._smallUTF8String.withUnmanagedUTF16 {
+        self._appendInPlace($0)
+      }
+      return
+    }
     defer { _fixLifetime(other) }
     _appendInPlace(other._asOpaque())
   }

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -493,6 +493,10 @@ extension String.UTF8View.Iterator : IteratorProtocol {
       defer { _nextOffset += 1 }
       return _guts._unmanagedASCIIView.buffer[_nextOffset]
     }
+    if _guts._isSmall {
+      defer { _nextOffset += 1 }
+      return _guts._smallUTF8String[_nextOffset]
+    }
 
     if _fastPath(!_buffer.isEmpty) {
       return _buffer.removeFirst()

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -290,9 +290,7 @@ extension Unicode.Scalar : CustomStringConvertible, CustomDebugStringConvertible
   /// A textual representation of the Unicode scalar.
   @_inlineable // FIXME(sil-serialize-all)
   public var description: String {
-    return String._fromWellFormedCodeUnitSequence(
-      UTF32.self,
-      input: repeatElement(self.value, count: 1))
+    return String(self)
   }
 
   /// An escaped textual representation of the Unicode scalar, suitable for

--- a/stdlib/public/core/UnmanagedString.swift
+++ b/stdlib/public/core/UnmanagedString.swift
@@ -74,6 +74,14 @@ struct _UnmanagedString<CodeUnit>
     self.start = start
     self.count = count
   }
+
+  @_inlineable
+  @_versioned
+  init(_ bufPtr: UnsafeBufferPointer<CodeUnit>) {
+    self.init(
+      start: bufPtr.baseAddress._unsafelyUnwrappedUnchecked,
+      count: bufPtr.count)
+  }
 }
 
 extension _UnmanagedString {

--- a/test/SILOptimizer/unused_containers.swift
+++ b/test/SILOptimizer/unused_containers.swift
@@ -2,6 +2,12 @@
 
 // REQUIRES: swift_stdlib_no_asserts
 
+// The below temporary disables this XFAIL-ed test on Linux for
+// https://github.com/apple/swift/pull/14755, where it unexpectedly passes.
+// @gottesmm is working on a fix.
+//
+// REQUIRES: OS=macosx
+
 // XFAIL: plus_zero_runtime
 
 //CHECK-LABEL: @$S17unused_containers16empty_array_testyyF

--- a/test/stdlib/NewString.swift
+++ b/test/stdlib/NewString.swift
@@ -20,21 +20,26 @@ func repr(_ x: NSString) -> String {
 
 func repr(_ x: _StringGuts) -> String {
   if x._isNative {
-    return "Native("
-      + "owner: \(hexAddrVal(x._owner)), "
-      + "count: \(x.count), "
-      + "capacity: \(x.capacity))"
+    return """
+      Native(\
+      owner: \(hexAddrVal(x._owner)), \
+      count: \(x.count), \
+      capacity: \(x.capacity))
+      """
   } else if x._isCocoa {
-    return "Cocoa("
-      + "owner: \(hexAddrVal(x._owner)), "
-      + "count: \(x.count))"
+    return """
+      Cocoa(\
+      owner: \(hexAddrVal(x._owner)), \
+      count: \(x.count))
+      """
   } else if x._isSmall {
-    return "Cocoa("
-      + "owner: <tagged>, "
-      + "count: \(x.count))"
+    return """
+      Small(count: \(x.count))
+      """
   } else if x._isUnmanaged {
-    return "Unmanaged("
-      + "count: \(x.count))"
+    return """
+      Unmanaged(count: \(x.count))
+      """
   }
   return "?????"
 }
@@ -58,7 +63,7 @@ print("  \(repr(nsb))")
 var empty = String()
 // CHECK-NEXT: These are empty: <>
 print("These are empty: <\(empty)>")
-// CHECK-NEXT: String(Unmanaged(count: 0))
+// CHECK-NEXT: String({{Unmanaged|Small}}(count: 0))
 print("  \(repr(empty))")
 
 
@@ -161,17 +166,17 @@ ascii()
 // CHECK: --- Literals ---
 print("--- Literals ---")
 
-// CHECK-NEXT: String(Unmanaged(count: 6)) = "foobar"
-// CHECK-NEXT: true
+// CHECK-NEXT: String({{Unmanaged|Small}}(count: 6)) = "foobar"
+// X_CHECK-NEXT: true // FIXME: _StringGuts's isASCII should be renamed
 let asciiLiteral: String = "foobar"
 print("  \(repr(asciiLiteral))")
-print("  \(asciiLiteral._guts.isASCII)")
+//print("  \(asciiLiteral._guts.isASCII)")
 
 // CHECK-NEXT: String(Unmanaged(count: 11)) = "🏂☃❅❆❄︎⛄️❄️"
 // CHECK-NEXT: false
 let nonASCIILiteral: String = "🏂☃❅❆❄︎⛄️❄️"
 print("  \(repr(nonASCIILiteral))")
-print("  \(!asciiLiteral._guts.isASCII)")
+print("  \(nonASCIILiteral._guts.isASCII)")
 
 // ===------- Appending -------===
 

--- a/test/stdlib/SmallString.swift
+++ b/test/stdlib/SmallString.swift
@@ -1,0 +1,155 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+// REQUIRES: CPU=arm64 || CPU=x86_64
+
+//
+// Tests for small strings
+//
+
+import StdlibUnittest
+import Foundation
+var SmallStringTests = TestSuite("SmallStringTests")
+
+extension String: Error {}
+
+func verifySmallString(_ small: _SmallUTF8String, _ input: String) {
+  expectEqual(_SmallUTF8String.capacity, small.count + small.unusedCapacity)
+  let tiny = Array(input.utf8)
+  expectEqual(tiny.count, small.count)
+  for (lhs, rhs) in zip(tiny, small) {
+    expectEqual(lhs, rhs)
+  }
+  small.withTranscodedUTF16CodeUnits {
+    let codeUnits = Array(input.utf16)
+    expectEqualSequence(codeUnits, $0)
+  }
+
+  let smallFromUTF16 = _SmallUTF8String(Array(input.utf16))
+  expectNotNil(smallFromUTF16)
+  expectEqualSequence(small, smallFromUTF16!)
+
+  // Test slicing
+  //
+  for i in 0..<small.count {
+    for j in i...small.count {
+      expectEqualSequence(tiny[i..<j], small[i..<j])
+      if j < small.count {
+        expectEqualSequence(tiny[i...j], small[i...j])
+      }
+    }
+  }
+}
+
+SmallStringTests.test("FitsInSmall") {
+  func runTest(_ input: String) throws {
+    let tiny = Array(input.utf8)
+    // Constructed from UTF-8 code units
+    guard let small = _SmallUTF8String(tiny) else {
+      throw "Didn't fit"
+    }
+    verifySmallString(small, input)
+
+    // Constructed from UTF-16 code units
+    guard let fromUTF16Small = _SmallUTF8String(Array(input.utf16)) else {
+        throw "Failed from utf-16"
+    }
+    verifySmallString(fromUTF16Small, input)
+  }
+
+  // Pass tests
+  //
+  // TODO(UTF-8 SSO): expectDoesNotThrow({ try runTest("ab😇c") })
+  expectDoesNotThrow({ try runTest("0123456789abcde") })
+  // TODO(UTF-8 SSO): expectDoesNotThrow({ try runTest("👨‍👦") })
+  expectDoesNotThrow({ try runTest("") })
+
+  // Fail tests
+  //
+  expectThrows("Didn't fit", { try runTest("0123456789abcdef") })
+  expectThrows("Didn't fit", { try runTest("👩‍👦‍👦") })
+}
+
+SmallStringTests.test("Bridging") {
+  // Test bridging retains small string form
+  func bridge(_ small: _SmallUTF8String) -> String {
+    return _bridgeToCocoa(small) as! String
+  }
+  func runTestSmall(_ input: String) throws {
+    // Constructed through CF
+    guard let fromCocoaSmall = _SmallUTF8String(
+      _cocoaString: input as NSString
+    ) else {
+        throw "Didn't fit"
+    }
+    verifySmallString(fromCocoaSmall, input)
+    verifySmallString(fromCocoaSmall, bridge(fromCocoaSmall))
+  }
+
+  // Pass tests
+  //
+  expectDoesNotThrow({ try runTestSmall("abc") })
+  expectDoesNotThrow({ try runTestSmall("0123456789abcde") })
+  expectDoesNotThrow({ try runTestSmall("\u{0}") })
+  // TODO(UTF-8 SSO): expectDoesNotThrow({ try runTestSmall("👨‍👦") })
+  expectDoesNotThrow({ try runTestSmall("") })
+  // TODO(UTF-8 SSO): expectDoesNotThrow({ try runTestSmall("👨‍👦abcd") })
+
+  // Fail tests
+  //
+  expectThrows("Didn't fit", { try runTestSmall("👨‍👩‍👦") })
+  expectThrows("Didn't fit", { try runTestSmall("👨‍👦abcde") })
+}
+
+SmallStringTests.test("Append, repeating") {
+  let strings = [
+    "",
+    "a",
+    "bc",
+    "def",
+    "hijk",
+    "lmnop",
+    "qrstuv",
+    "xyzzzzz",
+    "01234567",
+    "890123456",
+    "7890123456",
+    "78901234567",
+    "890123456789",
+    "0123456789012",
+    "34567890123456",
+    "789012345678901",
+    ]
+  let smallstrings = strings.compactMap {
+    _SmallUTF8String(Array($0.utf8))
+  }
+  expectEqual(strings.count, smallstrings.count)
+  for (small, str) in zip(smallstrings, strings) {
+    verifySmallString(small, str)
+  }
+
+  for i in 0..<smallstrings.count {
+    for j in i..<smallstrings.count {
+      let lhs = smallstrings[i]
+      let rhs = smallstrings[j]
+      if lhs.count + rhs.count > _SmallUTF8String.capacity {
+        continue
+      }
+      verifySmallString(lhs._appending(rhs)!, (strings[i] + strings[j]))
+      verifySmallString(rhs._appending(lhs)!, (strings[j] + strings[i]))
+    }
+  }
+
+  for i in 0..<smallstrings.count {
+    for c in 2...15 {
+      let str = String(repeating: strings[i], count: c)
+      if let small = smallstrings[i]._repeated(c) {
+        verifySmallString(small, str)
+      } else {
+        expectTrue(str.utf8.count > 15)
+      }
+    }
+  }
+}
+
+runAllTests()

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -912,22 +912,34 @@ StringTests.test("stringGutsReserve")
   .skip(.nativeRuntime("Foundation dependency"))
   .code {
 #if _runtime(_ObjC)
-  for k in 0...5 {
+  for k in 0...7 {
     var base: String
     var startedNative: Bool
     let shared: String = "X"
+
+    // Managed native, unmanaged native, or small
+    func isSwiftNative(_ s: String) -> Bool {
+      return s._guts._isNative || s._guts._isSmall || s._guts._isUnmanaged
+    }
 
     switch k {
     case 0: (base, startedNative) = (String(), true)
     case 1: (base, startedNative) = (asciiString("x"), true)
     case 2: (base, startedNative) = ("Ξ", true)
+#if arch(i386) || arch(arm)
     case 3: (base, startedNative) = ("x" as NSString as String, false)
     case 4: (base, startedNative) = ("x" as NSMutableString as String, false)
+#else
+    case 3: (base, startedNative) = ("x" as NSString as String, true)
+    case 4: (base, startedNative) = ("x" as NSMutableString as String, true)
+#endif
     case 5: (base, startedNative) = (shared, true)
+    case 6: (base, startedNative) = ("xá" as NSString as String, false)
+    case 7: (base, startedNative) = ("xá" as NSMutableString as String, false)
     default:
       fatalError("case unhandled!")
     }
-    expectEqual(base._guts._isNative || base._guts._isUnmanaged, startedNative)
+    expectEqual(isSwiftNative(base), startedNative)
     
     let originalBuffer = base.bufferID
     let isUnique = base._guts.isUniqueNative()
@@ -964,6 +976,7 @@ StringTests.test("stringGutsReserve")
     case 1,3,4: expected = "x"
     case 2: expected = "Ξ"
     case 5: expected = shared
+    case 6,7: expected = "xá"
     default:
       fatalError("case unhandled!")
     }
@@ -1155,10 +1168,15 @@ StringTests.test("Construction") {
 }
 
 StringTests.test("Conversions") {
+  // Whether we are natively ASCII or small ASCII
+  func isKnownASCII(_ s: String) -> Bool {
+    return s._guts.isASCII ||
+      (s._guts._isSmall && s._guts._smallUTF8String.isASCII)
+  }
   do {
     let c: Character = "a"
     let x = String(c)
-    expectTrue(x._guts.isASCII)
+    expectTrue(isKnownASCII(x))
 
     let s: String = "a"
     expectEqual(s, x)
@@ -1167,7 +1185,7 @@ StringTests.test("Conversions") {
   do {
     let c: Character = "\u{B977}"
     let x = String(c)
-    expectFalse(x._guts.isASCII)
+    expectFalse(isKnownASCII(x))
 
     let s: String = "\u{B977}"
     expectEqual(s, x)
@@ -1728,7 +1746,7 @@ StringTests.test("String.removeSubrange()/closedRange") {
 
 public let testSuffix = "z"
 StringTests.test("COW.Smoke") {
-  var s1 = "Cypseloides" + testSuffix
+  var s1 = "COW Smoke Cypseloides" + testSuffix
   let identity1 = s1._rawIdentifier()
   
   var s2 = s1
@@ -1750,7 +1768,7 @@ struct COWStringTest {
 }
 
 var testCases: [COWStringTest] {
-  return [ COWStringTest(test: "abcdefg", name: "ASCII"),
+  return [ COWStringTest(test: "abcdefghijklmnopqrxtuvwxyz", name: "ASCII"),
            COWStringTest(test: "🐮🐄🤠", name: "Unicode") 
          ]
 }

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -1089,7 +1089,7 @@ StringTests.test("toInt") {
   ) {
     var chars = Array(String(initialValue).utf8)
     modification(&chars)
-    let str = String._fromWellFormedCodeUnitSequence(UTF8.self, input: chars)
+    let str = String._fromWellFormedUTF8CodeUnitSequence(chars)
     expectNil(Int(str))
   }
 

--- a/validation-test/stdlib/StringViews.swift
+++ b/validation-test/stdlib/StringViews.swift
@@ -37,8 +37,7 @@ let replacementCharacter = Character(replacementScalar)
 // UTF16, grapheme clusters composed of multiple Unicode scalars, and
 // invalid UTF16 that should be replaced with replacement characters.
 let winterUTF16 = Array("🏂☃❅❆❄︎⛄️❄️".utf16) + [0xD83C, 0x0020, 0xDF67, 0xD83C]
-var winter = ""
-winter._guts.append(contentsOf: winterUTF16)
+var winter = _StringGuts._createStringFromUTF16(winterUTF16)
 let winterInvalidUTF8: [UTF8.CodeUnit] = replacementUTF8 + ([0x20] as [UTF8.CodeUnit]) + replacementUTF8 + replacementUTF8
 let winterUTF8: [UTF8.CodeUnit] = [
   0xf0, 0x9f, 0x8f, 0x82, 0xe2, 0x98, 0x83, 0xe2, 0x9d, 0x85, 0xe2,


### PR DESCRIPTION
<!-- What's in this pull request? -->

Add in small strings, plumb all APIs through, etc. There's some current performance issues, namely that small string support introduces branching and our default implementation technique involves spilling to the stack and calling `_UnmanagedString` methods. The first is unavoidable (although we're planning a better overall branching strategy to reduce this impact), the second is TODO.


