### PR TITLE
 Extend test/DebugInfo/local-vars.swift.gyb to include more scenarios.

### DIFF
--- a/test/DebugInfo/local-vars.swift.gyb
+++ b/test/DebugInfo/local-vars.swift.gyb
@@ -23,26 +23,98 @@ public struct S {
   let j : Int32 = 2
 }
 
+public struct SLarge {
+  var tuple : (Int64, Int64, Int64, Int64, Int64, Int64, Int64, Int64)
+}
+
+public enum ENoPayload {
+  case one
+  case two
+}
+
+public enum ESinglePayload : Int {
+  case one = 1
+  case two = 2
+}
+
+public enum EMultiPayload {
+  case int(Int)
+  indirect case recursive(EMultiPayload)
+  case string(String)
+}
+
+public protocol Proto {
+  func f()
+}
+
 func use<T>(_ x: T) {}
 func variable_use<T>(_ x: inout T) {}
 
-% def derive_name((type, val)):
-%   return (type.replace('<', '_').replace(' ', '_').replace(',', '_')
-%               .replace('?', '_').replace('>', '_')
-%               .replace('[', '_').replace(']', '_'), type, val)
-% for name, type, val in map(derive_name,
-%   [("UInt64", "64"), ("UInt32", "32"), ("Int64", "64"), ("Int32", "32"),
-%    ("Int", "42"), ("UInt", "42"), ("C", "C(42)"), ("String", '"string"'),
-%    ("Dictionary<UInt64, String>", '[1:"entry"]'),
-%    ("Float", "2.71"), ("Double", "3.14"), ("[UInt64]", "[1, 2, 3]"),
-%    ("S", "S()")]):
+%{
+type_initializer_map = [
+  #// Basic types.
+   ("UInt64", "64"), ("UInt32", "32"), ("Int64", "64"), ("Int32", "32"),
+   ("Int", "42"), ("UInt", "42"),
+   ("Float", "2.71"), ("Double", "3.14"),
+  #// Sugared types and strings.
+   ("String", '"string"'),
+   ("[UInt64]", "[1, 2, 3]"),
+   ("Dictionary<UInt64, String>", '[1:"entry"]'),
+  #// Classes, structs, tuples.
+   ("(Int, C)", "(42, C(42))"),
+   ("C", "C(42)"),
+   ("S", "S()"),
+   ("SLarge", "SLarge(tuple: (1,2,3,4,5,6,7,8))"),  
+  #// Enums.
+   ("ENoPayload", ".two"),
+   ("ESinglePayload", ".two"),
+   ("EMultiPayload", ".recursive(.string(\"string\"))"),
+  #// Existentials.
+   ("T", "self.t"),
+   ("U", "self.u"),
+  ]
 
+def derive_name((type, val)):
+  return (type.replace('<', '_').replace(' ', '_')
+              .replace(',', '_').replace('.', '_')
+              .replace('?', '_').replace('>', '_')
+              .replace('(', '_').replace(')', '_')
+              .replace('[', '_').replace(']', '_'), type, val)
+
+for name, type, val in map(derive_name, type_initializer_map):
+  generic = (type in ['T', 'U'])
+}%                                  
+%  if generic:
+public class ContextA_${name}<T, U : Proto> {
+  let t : T
+  let u : U
+  init(_ t: T, _ u: U) { self.t = t; self.u = u; }
+%  end
+  
 public func constant_${name}() -> ${type} {
   let v : ${type} = ${val}
   // CHECK: !DILocalVariable(name: "v",{{.*}} line: [[@LINE-1]]
   // DWARF: DW_TAG_subprogram
-  // DWARF: DW_AT_name {{.*}}constant_${name}
+  // DWARF-LABEL: DW_AT_name {{.*}}constant_${name}
   // DWARF-NOT: DW_TAG_subprogram
+%  if generic:
+  // DWARF: DW_TAG_formal_parameter
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("self")
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_artificial
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("$swift.type.{{T|U}}")
+  // DWARF: DW_AT_artificial
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("$swift.type.{{T|U}}")
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_artificial
+%  end
   // DWARF: DW_TAG_variable
   // DWARF-NOT: DW_TAG
   // DWARF: {{(DW_AT_location)|(DW_AT_const_value)}}
@@ -55,8 +127,26 @@ public func constvar_${name}() {
   var v : ${type} = ${val}
   // CHECK: !DILocalVariable(name: "v",{{.*}} line: [[@LINE-1]]
   // DWARF: DW_TAG_subprogram
-  // DWARF: DW_AT_name {{.*}}constvar_${name}
+  // DWARF-LABEL: DW_AT_name {{.*}}constvar_${name}
   // DWARF-NOT: DW_TAG_subprogram
+%  if generic:
+  // DWARF: DW_TAG_formal_parameter
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("self")
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_artificial
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("$swift.type.{{T|U}}")
+  // DWARF: DW_AT_artificial
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("$swift.type.{{T|U}}")
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_artificial
+%  end
   // DWARF: DW_TAG_variable
   // DWARF-NOT: DW_TAG
   // DWARF: {{(DW_AT_location)|(DW_AT_const_value)}}
@@ -69,8 +159,26 @@ public func let_${name}() {
   let v : ${type} = constant_${name}()
   // CHECK: !DILocalVariable(name: "v",{{.*}} line: [[@LINE-1]]
   // DWARF: DW_TAG_subprogram
-  // DWARF: DW_AT_name {{.*}}let_${name}
+  // DWARF-LABEL: DW_AT_name {{.*}}let_${name}
   // DWARF-NOT: DW_TAG_subprogram
+%  if generic:
+  // DWARF: DW_TAG_formal_parameter
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("self")
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_artificial
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("$swift.type.{{T|U}}")
+  // DWARF: DW_AT_artificial
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("$swift.type.{{T|U}}")
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_artificial
+%  end
   // DWARF: DW_TAG_variable
   // DWARF-NOT: DW_TAG
   // DWARF: {{(DW_AT_location)|(DW_AT_const_value)}}
@@ -79,6 +187,40 @@ public func let_${name}() {
   use(v)
 }
 
+public func case_let_${name}() {
+  switch constant_${name}() {
+    case let v:
+  // CHECK: !DILocalVariable(name: "v",{{.*}} line: [[@LINE-1]]
+      use(v)
+  }
+  // DWARF: DW_TAG_subprogram
+  // DWARF-LABEL: DW_AT_name {{.*}}let_${name}
+  // DWARF-NOT: DW_TAG_subprogram
+%  if generic:
+  // DWARF: DW_TAG_formal_parameter
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("self")
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_artificial
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("$swift.type.{{T|U}}")
+  // DWARF: DW_AT_artificial
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("$swift.type.{{T|U}}")
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_artificial
+%  end
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: {{(DW_AT_location)|(DW_AT_const_value)}}
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("v")
+}
+  
 public func optional_${name}() -> ${type}? {
   return constant_${name}();
 }
@@ -87,8 +229,26 @@ public func guard_let_${name}() {
   let opt : ${type}? = optional_${name}()
   // CHECK: !DILocalVariable(name: "opt",{{.*}} line: [[@LINE-1]]
   // DWARF: DW_TAG_subprogram
-  // DWARF: DW_AT_name {{.*}}guard_let_${name}
+  // DWARF-LABEL: DW_AT_name {{.*}}guard_let_${name}
   // DWARF-NOT: DW_TAG_subprogram
+%  if generic:
+  // DWARF: DW_TAG_formal_parameter
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("self")
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_artificial
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("$swift.type.{{T|U}}")
+  // DWARF: DW_AT_artificial
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("$swift.type.{{T|U}}")
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_artificial
+%  end
   // DWARF: DW_TAG_variable
   // DWARF-NOT: DW_TAG
   // DWARF: DW_AT_location
@@ -113,8 +273,26 @@ public func var_${name}() {
   var v : ${type} = constant_${name}()
   // CHECK: !DILocalVariable(name: "v",{{.*}} line: [[@LINE-1]]
   // DWARF: DW_TAG_subprogram
-  // DWARF: DW_AT_name {{.*}}var_${name}
+  // DWARF-LABEL: DW_AT_name {{.*}}var_${name}
   // DWARF-NOT: DW_TAG_subprogram
+%  if generic:
+  // DWARF: DW_TAG_formal_parameter
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("self")
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_artificial
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("$swift.type.{{T|U}}")
+  // DWARF: DW_AT_artificial
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("$swift.type.{{T|U}}")
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_artificial
+%  end
   // DWARF: DW_TAG_variable
   // DWARF-NOT: DW_TAG
   // DWARF: DW_AT_location
@@ -126,25 +304,163 @@ public func var_${name}() {
 public func arg_${name}(_ v: ${type}) {
   // CHECK: !DILocalVariable(name: "v",{{.*}} line: [[@LINE-1]]
   // DWARF: DW_TAG_subprogram
-  // DWARF: DW_AT_name {{.*}}arg_${name}
+  // DWARF-LABEL: DW_AT_name {{.*}}arg_${name}
   // DWARF-NOT: DW_TAG_subprogram
   // DWARF: DW_TAG_formal_parameter
   // DWARF-NOT: DW_TAG
   // DWARF: DW_AT_location
   // DWARF-NOT: DW_TAG
   // DWARF: DW_AT_name {{.*}}"v"
+%  if generic:
+  // DWARF: DW_TAG_formal_parameter
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("self")
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_artificial
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("$swift.type.{{T|U}}")
+  // DWARF: DW_AT_artificial
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("$swift.type.{{T|U}}")
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_artificial
+%  end
   use(v)
 }
 
 public func arg_inout_${name}(_ v: inout ${type}) {
   // CHECK: !DILocalVariable(name: "v",{{.*}} line: [[@LINE-1]]
   // DWARF: DW_TAG_subprogram
-  // DWARF: DW_AT_name {{.*}}arg_inout_${name}
+  // DWARF-LABEL: DW_AT_name {{.*}}arg_inout_${name}
   // DWARF-NOT: DW_TAG_subprogram
   // DWARF: DW_TAG_formal_parameter
   // DWARF-NOT: DW_TAG
   // DWARF: DW_AT_location
   // DWARF-NOT: DW_TAG
   // DWARF: DW_AT_name {{.*}}"v"
+%  if generic:
+  // DWARF: DW_TAG_formal_parameter
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("self")
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_artificial
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("$swift.type.{{T|U}}")
+  // DWARF: DW_AT_artificial
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("$swift.type.{{T|U}}")
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_artificial
+%  end
   variable_use(&v)
 }
+
+public func arg_tuple_${name}(_ v: (${type}, ${type})) {
+  let (_, y) = v
+  // CHECK: !DILocalVariable(name: "y",{{.*}} line: [[@LINE-1]]
+  // DWARF: DW_TAG_subprogram
+  // DWARF-LABEL: DW_AT_name {{.*}}arg_tuple_${name}
+  // DWARF-NOT: DW_TAG_subprogram
+  // DWARF:  DW_TAG_formal_parameter
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_location
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name {{.*}}"v"
+%  if generic:
+  // FIXME-DWARF: DW_TAG_formal_parameter
+  // FIXME-DWARF-NOT: DW_TAG
+  // FIXME-DWARF: DW_AT_name ("self")
+  // FIXME-DWARF-NOT: DW_TAG
+  // FIXME-DWARF: DW_AT_artificial
+  // FIMXE-DWARF-NOT: DW_TAG
+  // FIXME-DWARF: DW_TAG_variable
+  // FIXME-DWARF-NOT: DW_TAG
+  // FIXME-DWARF: DW_AT_name ("$swift.type.{{T|U}}")
+  // FIXME-DWARF: DW_AT_artificial
+  // FIXME-DWARF: DW_TAG_variable
+  // FIXME-DWARF-NOT: DW_TAG
+  // FIXME-DWARF: DW_AT_name ("$swift.type.{{T|U}}")
+  // FIXME-DWARF-NOT: DW_TAG
+  // FIXME-DWARF: DW_AT_artificial
+%  end
+  // FIXME-DWARF: DW_TAG_variable
+  // FIXME-DWARF-NOT: DW_TAG
+  // FIXME-DWARF: DW_AT_location
+  // FIXME-DWARF-NOT: DW_TAG
+  // FIXME-DWARF: DW_AT_name {{.*}}"y"
+  use(y)
+}
+  
+public func closure_capture_${name}() {
+  let v : ${type} = constant_${name}();
+  // CHECK: !DILocalVariable(name: "v",{{.*}} line: [[@LINE-1]]
+  use({ () -> ${type} in v }())
+  // DWARF: DW_TAG_subprogram
+  // DWARF-LABEL: DW_AT_name {{.*}}closure_capture_${name}
+  // DWARF: DW_TAG_subprogram
+  // DWARF: DW_AT_linkage_name {{.*}}closure_capture_${name}
+  // DWARF-NOT: DW_AT_name {{.*}}closure_capture_${name}
+  // DWARF: DW_TAG_formal_parameter
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_location
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name {{.*}}"v"
+%  if generic:
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("$swift.type.{{T|U}}")
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_artificial
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("$swift.type.{{T|U}}")
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_artificial
+%  end
+}
+
+public func closure_capture_byref_${name}() {
+  var v : ${type} = constant_${name}();
+  // CHECK: !DILocalVariable(name: "v",{{.*}} line: [[@LINE-1]]
+  { () -> () in v = ${val} }()
+  use(v)
+  // DWARF: DW_TAG_subprogram
+  // DWARF-LABEL: DW_AT_name {{.*}}closure_capture_byref_${name}
+  // DWARF: DW_TAG_subprogram
+  // DWARF: DW_AT_linkage_name {{.*}}closure_capture_byref_${name}
+  // DWARF-NOT: DW_AT_name {{.*}}closure_capture_byref_${name}
+  // DWARF: DW_TAG_formal_parameter
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_location
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name {{.*}}"v"
+%  if generic:
+  // DWARF: DW_TAG_formal_parameter
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("self")
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_artificial
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("$swift.type.{{T|U}}")
+  // DWARF: DW_AT_artificial
+  // DWARF: DW_TAG_variable
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_name ("$swift.type.{{T|U}}")
+  // DWARF-NOT: DW_TAG
+  // DWARF: DW_AT_artificial
+%  end
+}
+  
+%  if generic:
+} // End of Context_${name}.
+%  end


### PR DESCRIPTION
New data types include various forms of enums, tuples, large structs,
generics, and existentials. New contexts include switch statements
closure captures and (also) tuples.

This uncovered at least one bug so some of the CHECKs are commented out.

<rdar://problem/36031959>
