### PR TITLE
[ClangImporter] Import objc_subclassing_restricted classes as 'public'

### DIFF
--- a/test/ClangImporter/Inputs/attr-objc_subclassing_restricted.h
+++ b/test/ClangImporter/Inputs/attr-objc_subclassing_restricted.h
@@ -1,0 +1,6 @@
+// This file is meant to be used with the mock SDK.
+#import <Foundation.h>
+
+__attribute__((objc_subclassing_restricted))
+@interface Restricted: NSObject
+@end

--- a/test/ClangImporter/attr-objc_subclassing_restricted.swift
+++ b/test/ClangImporter/attr-objc_subclassing_restricted.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -import-objc-header %S/Inputs/attr-objc_subclassing_restricted.h %s -swift-version 5 -verify
+
+// No errors in Swift 3 and 4 modes.
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -import-objc-header %S/Inputs/attr-objc_subclassing_restricted.h %s -swift-version 4
+
+// REQUIRES: objc_interop
+
+class Sub: Restricted { // expected-error {{cannot inherit from non-open class 'Restricted' outside of its defining module}}
+}


### PR DESCRIPTION
(rather than 'open')

This attribute was originally introduced for Swift classes exposed to Objective-C, but if it *is* used on a pure Objective-C class Swift should respect it. There might be an actual reason, such as a hot code path in ContrivedExampleKit checking against the class object's address instead of using `-isKindOfClass:`.

For source compatibility, only enforce this in Swift 5 mode.

rdar://problem/33971529