### PR TITLE
[stdlib] Remove the unnecessary compactMap overload

### DIFF
--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -574,41 +574,6 @@ extension Sequence {
 }
 
 extension Collection {
-  /// Returns an array containing the non-`nil` strings resulting from the given
-  /// transformation on each element of this sequence.
-  ///
-  /// Use this method to receive an array of non-optional strings when your
-  /// transformation produces a `String?`.
-  ///
-  /// In this example, note the difference in the result of using `map` and
-  /// `compactMap` with a transformation that returns a `String?` value.
-  ///
-  ///     let errorLookup = [400: "Bad request",
-  ///                        403: "Forbidden",
-  ///                        404: "Not found"]
-  ///
-  ///     let errorCodes = [400, 407, 404]
-  ///
-  ///     let mapped: [String?] = errorCodes.map { code in errorLookup[code] }
-  ///     // ["Bad request", nil, "Not found"]
-  ///
-  ///     let compactMapped: [String] = errorCodes.compactMap { code in errorLookup[code] }
-  ///     // ["Bad request", "Not found"]
-  ///
-  /// - Parameter transform: A closure that accepts an element of this
-  ///   sequence as its argument and returns a `String?`.
-  /// - Returns: An array of the non-`nil` results of calling `transform`
-  ///   with each element of the sequence.
-  ///
-  /// - Complexity: O(*m* + *n*), where *m* is the length of this sequence
-  ///   and *n* is the length of the result.
-  @_inlineable // FIXME(sil-serialize-all)
-  public func compactMap(
-    _ transform: (Element) throws -> String?
-  ) rethrows -> [String] {
-    return try _compactMap(transform)
-  }
-
   @available(swift, deprecated: 4.1, renamed: "compactMap(_:)",
     message: "Please use compactMap(_:) for the case where closure returns an optional value")
   @inline(__always)


### PR DESCRIPTION
This particular overload of compactMap was mechanically copied from the `flatMap` while implementing SE-0187, but as community members correctly noticed on the forum thread [here](https://forums.swift.org/t/why-is-there-a-collection-flatmap-that-takes-a-closure-returning-string/10141), there is no code that we should be backward compatible with, since`compactMap` has only been introduced recently.

After applying this change, the following code is correctly ambiguous again:

```swift
[].compactMap { _ in nil } // error: 'nil' requires a contextual type
```

as opposed to:

```swift
[].flatMap { _ in nil } // r0 : [String] = []
```

Fixes: https://bugs.swift.org/browse/SR-7052