### PR TITLE
 Expose substring-based initializers in StringProtocol.

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -44,6 +44,12 @@ public protocol StringProtocol
   func lowercased() -> String
   func uppercased() -> String
 
+  /// Creates a string having the given substring's unicode scalars as its content.
+  ///
+  /// - Parameters:
+  ///   - content: The `unicodeScalars` of a subsequence of this string.
+  init(_ content: SubSequence.UnicodeScalarView)
+    
   /// Creates a string from the given Unicode code units in the specified
   /// encoding.
   ///


### PR DESCRIPTION
Herein I propose a very small (one line) non-intrusive addition to StringProtocol which unifies existing initializers on String and Substring, allowing for writing generic extensions across both which are currently possible, but require unwieldy and unnecessary encoding/decoding. 

The short version of the motivation is that there is no generic way to instantiate an arbitrary StringProtocol from its own SubSequence, despite all conforming types providing the corresponding initializer.

For a motivating example, see the following discussion: https://forums.swift.org/t/unify-string-substring-unicodescalarview-initializers-in-stringprotocol/10181/7

This added requirement requires no implementation. Both `String` and `Substring` (the only two public `StringProtocol` instances) both already provide this initializer.