### PR TITLE
Update ConstraintSystem::dump to check hasType before calling getType.

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -3125,9 +3125,15 @@ void ConstraintSystem::dump() {
 }
 
 void ConstraintSystem::dump(Expr *E) {
-  auto getTypeOfExpr = [&](const Expr *E) -> Type { return getType(E); };
+  auto getTypeOfExpr = [&](const Expr *E) -> Type {
+    if (hasType(E))
+      return getType(E);
+    return Type();
+  };
   auto getTypeOfTypeLoc = [&](const TypeLoc &TL) -> Type {
-    return getType(TL);
+    if (hasType(TL))
+      return getType(TL);
+    return Type();
   };
 
   E->dump(getTypeOfExpr, getTypeOfTypeLoc);


### PR DESCRIPTION
We assert if the type isn't in the cache, so we need to check that
before attempting to fetch the type, and return Type() if we
do not have it in the cache.
