### PR TITLE
Allow 'public' classes to have 'internal' required initializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ CHANGELOG
 Swift 5.0
 ---------
 
+* Public classes may now have internal `required` initializers. The rule for
+  `required` initializers is that they must be available everywhere the class
+  can be subclassed, but previously we said that `required` initializers on
+  public classes needed to be public themselves. (This limitation is a holdover
+  from before the introduction of the open/public distinction in Swift 3.)
+
 * C macros containing casts are no longer imported to Swift if the type in the
   cast is unavailable or deprecated, or produces some other diagnostic when
   referenced. (These macros were already only imported under very limited

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3176,7 +3176,9 @@ NOTE(required_initializer_here,none,
       "'required' initializer is declared in superclass here", ())
 
 ERROR(required_initializer_not_accessible,none,
-      "'required' initializer must be as accessible as its enclosing type", ())
+      "'required' initializer must be accessible wherever class %0 can be "
+      "subclassed",
+      (DeclName))
 ERROR(required_initializer_missing_keyword,none,
       "'required' modifier must be present on all overrides of a required "
       "initializer", ())

--- a/test/Compatibility/accessibility.swift
+++ b/test/Compatibility/accessibility.swift
@@ -165,7 +165,7 @@ internal extension Base {
 }
 
 public class PublicSub: Base {
-  required init() {} // expected-error {{'required' initializer must be as accessible as its enclosing type}} {{12-12=public }}
+  private required init() {} // expected-error {{'required' initializer must be accessible wherever class 'PublicSub' can be subclassed}} {{3-10=internal}}
   override func foo() {} // expected-error {{overriding instance method must be as accessible as the declaration it overrides}} {{12-12=public }}
   override var bar: Int { // expected-error {{overriding var must be as accessible as the declaration it overrides}} {{12-12=public }}
     get { return 0 }
@@ -174,8 +174,12 @@ public class PublicSub: Base {
   override subscript () -> () { return () } // expected-error {{overriding subscript must be as accessible as the declaration it overrides}} {{12-12=public }}
 }
 
+public class PublicSubGood: Base {
+  required init() {} // okay
+}
+
 internal class InternalSub: Base {
-  required private init() {} // expected-error {{'required' initializer must be as accessible as its enclosing type}} {{12-19=internal}}
+  required private init() {} // expected-error {{'required' initializer must be accessible wherever class 'InternalSub' can be subclassed}} {{12-19=internal}}
   private override func foo() {} // expected-error {{overriding instance method must be as accessible as its enclosing type}} {{3-10=internal}}
   private override var bar: Int { // expected-error {{overriding var must be as accessible as its enclosing type}} {{3-10=internal}}
     get { return 0 }
@@ -207,7 +211,7 @@ internal class InternalSubPrivateSet: Base {
 }
 
 fileprivate class FilePrivateSub: Base {
-  required private init() {} // expected-error {{'required' initializer must be as accessible as its enclosing type}} {{12-19=fileprivate}}
+  required private init() {} // expected-error {{'required' initializer must be accessible wherever class 'FilePrivateSub' can be subclassed}} {{12-19=fileprivate}}
   private override func foo() {} // expected-error {{overriding instance method must be as accessible as its enclosing type}} {{3-10=fileprivate}}
   private override var bar: Int { // expected-error {{overriding var must be as accessible as its enclosing type}} {{3-10=fileprivate}}
     get { return 0 }
@@ -249,7 +253,7 @@ fileprivate class FilePrivateSubPrivateSet: Base {
 }
 
 private class PrivateSub: Base {
-  required private init() {} // expected-error {{'required' initializer must be as accessible as its enclosing type}} {{12-19=fileprivate}}
+  required private init() {} // expected-error {{'required' initializer must be accessible wherever class 'PrivateSub' can be subclassed}} {{12-19=fileprivate}}
   private override func foo() {} // expected-error {{overriding instance method must be as accessible as its enclosing type}} {{3-10=fileprivate}}
   private override var bar: Int { // expected-error {{overriding var must be as accessible as its enclosing type}} {{3-10=fileprivate}}
     get { return 0 }

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -165,7 +165,7 @@ internal extension Base {
 }
 
 public class PublicSub: Base {
-  required init() {} // expected-error {{'required' initializer must be as accessible as its enclosing type}} {{12-12=public }}
+  private required init() {} // expected-error {{'required' initializer must be accessible wherever class 'PublicSub' can be subclassed}} {{3-10=internal}}
   override func foo() {} // expected-error {{overriding instance method must be as accessible as the declaration it overrides}} {{12-12=public }}
   override var bar: Int { // expected-error {{overriding var must be as accessible as the declaration it overrides}} {{12-12=public }}
     get { return 0 }
@@ -174,8 +174,12 @@ public class PublicSub: Base {
   override subscript () -> () { return () } // expected-error {{overriding subscript must be as accessible as the declaration it overrides}} {{12-12=public }}
 }
 
+public class PublicSubGood: Base {
+  required init() {} // okay
+}
+
 internal class InternalSub: Base {
-  required private init() {} // expected-error {{'required' initializer must be as accessible as its enclosing type}} {{12-19=internal}}
+  required private init() {} // expected-error {{'required' initializer must be accessible wherever class 'InternalSub' can be subclassed}} {{12-19=internal}}
   private override func foo() {} // expected-error {{overriding instance method must be as accessible as its enclosing type}} {{3-10=internal}}
   private override var bar: Int { // expected-error {{overriding var must be as accessible as its enclosing type}} {{3-10=internal}}
     get { return 0 }
@@ -207,7 +211,7 @@ internal class InternalSubPrivateSet: Base {
 }
 
 fileprivate class FilePrivateSub: Base {
-  required private init() {} // expected-error {{'required' initializer must be as accessible as its enclosing type}} {{12-19=fileprivate}}
+  required private init() {} // expected-error {{'required' initializer must be accessible wherever class 'FilePrivateSub' can be subclassed}} {{12-19=fileprivate}}
   private override func foo() {} // expected-error {{overriding instance method must be as accessible as its enclosing type}} {{3-10=fileprivate}}
   private override var bar: Int { // expected-error {{overriding var must be as accessible as its enclosing type}} {{3-10=fileprivate}}
     get { return 0 }
@@ -249,7 +253,7 @@ fileprivate class FilePrivateSubPrivateSet: Base {
 }
 
 private class PrivateSub: Base {
-  required private init() {} // expected-error {{'required' initializer must be as accessible as its enclosing type}} {{12-19=fileprivate}}
+  required private init() {} // expected-error {{'required' initializer must be accessible wherever class 'PrivateSub' can be subclassed}} {{12-19=fileprivate}}
   private override func foo() {} // expected-error {{overriding instance method must be as accessible as its enclosing type}} {{3-10=fileprivate}}
   private override var bar: Int { // expected-error {{overriding var must be as accessible as its enclosing type}} {{3-10=fileprivate}}
     get { return 0 }


### PR DESCRIPTION
They're already not subclassable publicly, so it's okay for the initializer to not be available to cross-module clients, just like if it were non-'required'. This allows constructing a class instance chosen at runtime *within* the module without having to expose the existence of the constructor to everybody.

rdar://problem/22845087