### PR TITLE
[stdlib] Fix a data race with _swiftEmptyArrayStorage's count

### DIFF
--- a/stdlib/public/core/ContiguousArrayBuffer.swift
+++ b/stdlib/public/core/ContiguousArrayBuffer.swift
@@ -750,9 +750,13 @@ internal struct _UnsafePartiallyInitializedContiguousArrayBuffer<Element> {
         _uninitializedCount: newCapacity, minimumCapacity: 0)
       p = newResult.firstElementAddress + result.capacity
       remainingCapacity = newResult.capacity - result.capacity
-      newResult.firstElementAddress.moveInitialize(
-        from: result.firstElementAddress, count: result.capacity)
-      result.count = 0
+      if !result.isEmpty {
+        // This check prevents a data race writting to _swiftEmptyArrayStorage
+        // Since count is always 0 there, this code does nothing anyway
+        newResult.firstElementAddress.moveInitialize(
+          from: result.firstElementAddress, count: result.capacity)
+        result.count = 0
+      }
       (result, newResult) = (newResult, result)
     }
     addWithExistingCapacity(element)


### PR DESCRIPTION
Dave's analysis in the bug below:

This new zero is getting written over the existing zero after we’ve moved all zero of the zero elements in the empty array buffer into the new buffer, so they won’t be destroyed twice (* zero == zero) .  We should just skip this whole part if the source buffer is empty.

rdar://problem/31378400