### PR TITLE
[4.1][stdlib] Remove the unnecessary compactMap overload

### DIFF
--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -441,13 +441,6 @@ extension Sequence {
 }
 
 extension Collection {
-  @_inlineable // FIXME(sil-serialize-all)
-  public func compactMap(
-    _ transform: (Element) throws -> String?
-  ) rethrows -> [String] {
-    return try _compactMap(transform)
-  }
-
   @available(swift, deprecated: 4.1, renamed: "compactMap(_:)",
     message: "Please use compactMap(_:) for the case where closure returns an optional value")
   @inline(__always)


### PR DESCRIPTION
* Explanation: Remove an unnecessary overlad that was introduced by mistake.
* Risk: Minimal, as compactMap were introduced only recently
* Reviewed By: Ben Cohen
* Testing: Automated test suite + compatibility test suite
* Directions for QA: N/A
* Radar: <rdar://problem/37764446>