### PR TITLE
unittests/runtime: Add more stubs related to protocol conformance

### DIFF
--- a/unittests/runtime/Stdlib.cpp
+++ b/unittests/runtime/Stdlib.cpp
@@ -29,6 +29,9 @@ void _swift_makeAnyHashableUsingDefaultRepresentation(
   abort();
 }
 
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $Ss11AnyHashableVMn[1] = {0};
+
 // SwiftHashableSupport
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
@@ -56,7 +59,6 @@ bool _swift_anyHashableDownCastConditionalIndirect(
   OpaqueValue *source, OpaqueValue *destination, const Metadata *targetType) {
   abort();
 }
-
 
 // Casting
 
@@ -155,3 +157,81 @@ SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
 void *$Ss32_getErrorEmbeddedNSErrorIndirectyyXlSgSPyxGs0B0RzlF(void *) {
   abort();
 }
+
+// Hashable
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $Ss8HashableMp[1] = {0};
+
+// Array
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $SSaMn[1] = {0};
+
+// Dictionary
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $Ss10DictionaryVMn[1] = {0};
+
+// Set
+
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $Ss3SetVMn[1] = {0};
+
+// Mirror
+
+// protocol witness table for Swift._ClassSuperMirror : Swift._Mirror in Swift
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $Ss17_ClassSuperMirrorVs01_C0sWP[1] = {0};
+
+// type metadata accessor for Swift._ClassSuperMirror
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $Ss17_ClassSuperMirrorVMa[1] = {0};
+
+// protocol witness table for Swift._MetatypeMirror : Swift._Mirror in Swift
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $Ss15_MetatypeMirrorVs01_B0sWP[1] = {0};
+
+// type metadata accessor for Swift._MetatypeMirror
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $Ss15_MetatypeMirrorVMa[1] = {0};
+
+// protocol witness table for Swift._EnumMirror : Swift._Mirror in Swift
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $Ss11_EnumMirrorVs01_B0sWP[1] = {0};
+
+// type metadata accessor for Swift._EnumMirror
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $Ss11_EnumMirrorVMa[1] = {0};
+
+// protocol witness table for Swift._OpaqueMirror : Swift._Mirror in Swift
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $Ss13_OpaqueMirrorVs01_B0sWP[1] = {0};
+
+// type metadata accessor for Swift._OpaqueMirror
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $Ss13_OpaqueMirrorVMa[1] = {0};
+
+// protocol witness table for Swift._StructMirror : Swift._Mirror in Swift
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $Ss13_StructMirrorVs01_B0sWP[1] = {0};
+
+// type metadata accessor for Swift._StructMirror
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $Ss13_StructMirrorVMa[1] = {0};
+
+// protocol witness table for Swift._TupleMirror : Swift._Mirror in Swift
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $Ss12_TupleMirrorVs01_B0sWP[1] = {0};
+
+// type metadata accessor for Swift._TupleMirror
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $Ss12_TupleMirrorVMa[1] = {0};
+
+// protocol witness table for Swift._ClassMirror : Swift._Mirror in Swift
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $Ss12_ClassMirrorVs01_B0sWP[1] = {0};
+
+// type metadata accessor for Swift._ClassMirror
+SWIFT_RUNTIME_STDLIB_INTERNAL
+const long long $Ss12_ClassMirrorVMa[1] = {0};


### PR DESCRIPTION
Found whilst attempting to build the runtime tests on Windows