### PR TITLE
swift-api-digester: print header file names along with source-breaking changes.

### DIFF
--- a/test/api-digester/Inputs/APINotesLeft/APINotesTest.h
+++ b/test/api-digester/Inputs/APINotesLeft/APINotesTest.h
@@ -10,3 +10,9 @@ extern int ANTGlobalValue;
   +(void) plusPrint;
   -(int) getPropertyA;
 @end
+
+@protocol ObjcProt
+  -(void) ProtMemberFunc;
+  -(void) ProtMemberFunc2;
+  -(void) ProtMemberFunc3;
+@end

--- a/test/api-digester/Inputs/APINotesRight/APINotesTest.h
+++ b/test/api-digester/Inputs/APINotesRight/APINotesTest.h
@@ -10,3 +10,7 @@ extern int ANTGlobalValue;
   +(void) plusPrint;
   @property int PropertyA;
 @end
+
+@protocol ObjcProt
+  -(void) ProtMemberFunc;
+@end

--- a/test/api-digester/Outputs/apinotes-diags.txt
+++ b/test/api-digester/Outputs/apinotes-diags.txt
@@ -1,0 +1,15 @@
+
+/* Removed Decls */
+APINotesTest(APINotesTest.h): Var OldType.oldMember has been removed
+APINotesTest(APINotesTest.h): Func ObjcProt.protMemberFunc2() has been removed
+APINotesTest(APINotesTest.h): Func ObjcProt.protMemberFunc3() has been removed
+APINotesTest(APINotesTest.h): Func SwiftTypeWithMethodLeft.getPropertyA() has been removed
+
+/* Moved Decls */
+
+/* Renamed Decls */
+APINotesTest(APINotesTest.h): Protocol SwiftTypeWithMethodLeft has been renamed to Protocol SwiftTypeWithMethodRight
+
+/* Type Changes */
+
+/* Decl Attribute changes */

--- a/test/api-digester/apinotes-diags.swift
+++ b/test/api-digester/apinotes-diags.swift
@@ -1,0 +1,8 @@
+// REQUIRES: OS=macosx
+// RUN: %empty-directory(%t.mod)
+// RUN: %empty-directory(%t.sdk)
+// RUN: %empty-directory(%t.module-cache)
+// RUN: %api-digester -dump-sdk -module APINotesTest -o %t.dump1.json -module-cache-path %t.module-cache -sdk %t.sdk -swift-version 3 -I %S/Inputs/APINotesLeft
+// RUN: %api-digester -dump-sdk -module APINotesTest -o %t.dump2.json -module-cache-path %t.module-cache -sdk %t.sdk -swift-version 3 -I %S/Inputs/APINotesRight
+// RUN: %api-digester -diagnose-sdk -print-module -input-paths %t.dump1.json -input-paths %t.dump2.json > %t.result
+// RUN: diff -u %S/Outputs/apinotes-diags.txt %t.result


### PR DESCRIPTION
When diagnosing API source-breaking changes, we
should also output the header file name from where the effected Clang
declaration is defined.

This may expedite screening process.
