### PR TITLE
In -debug-constraints, only attempt to print types that we've cached.

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1380,9 +1380,15 @@ ConstraintSystem::solve(Expr *&expr,
   }
 
   if (TC.getLangOpts().DebugConstraintSolver) {
-    auto getTypeOfExpr = [&](const Expr *E) -> Type { return getType(E); };
+    auto getTypeOfExpr = [&](const Expr *E) -> Type {
+      if (hasType(E))
+        return getType(E);
+      return Type();
+    };
     auto getTypeOfTypeLoc = [&](const TypeLoc &TL) -> Type {
-      return getType(TL);
+      if (hasType(TL))
+        return getType(TL);
+      return Type();
     };
 
     auto &log = getASTContext().TypeCheckerDebug->getStream();


### PR DESCRIPTION
Calling getType() when the type is not in the cache results in an
assert.
