### PR TITLE
[WIP] [ClangImporter] Don't bridge typedefs marked swift_nonbridged

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -705,6 +705,9 @@ namespace {
         }
 #endif
         hint = underlyingResult.Hint;
+        if (hint.Kind == ImportHint::ObjCBridged)
+          if (type->getDecl()->hasAttr<clang::SwiftNonbridgedAttr>())
+            hint = ImportHint::ObjCPointer;
 
         // If the imported typealias is unavailable, return the
         // underlying type.

--- a/test/ClangImporter/objc_bridging.swift
+++ b/test/ClangImporter/objc_bridging.swift
@@ -63,3 +63,24 @@ func objcStructs(_ s: StructOfNSStrings, sb: StructOfBlocks) {
   _ = sb.block as Bool // expected-error {{cannot convert value of type '@convention(block) () -> Void' to type 'Bool' in coercion}}
   sb.block() // okay
 }
+
+func deliberatelyUnbridgedTypedefs(_ s: String, _ ns: NSString) {
+  takesBridgedNSString(s)
+  takesBridgedNSString(ns) // expected-error {{'NSString' is not implicitly convertible to 'String'}}
+  takesUnbridgedNSString(s) // expected-error {{cannot convert value of type 'String' to expected argument type 'UnbridgedNSString' (aka 'NSString')}}
+  takesUnbridgedNSString(ns)
+
+  // This doesn't affect non-bridgeable positions, of course.
+  var mutS = s
+  var mutNS = ns
+  takesBridgedNSStringPointer(&mutS) // expected-error {{cannot convert value of type 'String' to expected argument type 'BridgedNSString' (aka 'NSString')}}
+  takesBridgedNSStringPointer(&mutNS)
+  takesUnbridgedNSStringPointer(&mutS) // expected-error {{cannot convert value of type 'String' to expected argument type 'UnbridgedNSString' (aka 'NSString')}}
+  takesUnbridgedNSStringPointer(&mutNS)
+
+  // Typedefs for classes never get bridged, with or without the attribute.
+  let _: BridgedNSString = s // expected-error {{cannot convert value of type 'String' to specified type 'BridgedNSString' (aka 'NSString')}}
+  let _: BridgedNSString = ns
+  let _: UnbridgedNSString = s // expected-error {{cannot convert value of type 'String' to specified type 'UnbridgedNSString' (aka 'NSString')}}
+  let _: UnbridgedNSString = ns
+}

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -1157,3 +1157,12 @@ void takeNullableId(__nullable id);
 @interface IUOProperty
 @property (readonly) id<OptionalMethods> iuo;
 @end
+
+typedef NSString *BridgedNSString;
+typedef NSString *UnbridgedNSString __attribute__((swift_nonbridged));
+
+void takesBridgedNSString(BridgedNSString _Nonnull);
+void takesUnbridgedNSString(UnbridgedNSString _Nonnull);
+
+void takesBridgedNSStringPointer(BridgedNSString _Nonnull const * _Nonnull);
+void takesUnbridgedNSStringPointer(UnbridgedNSString _Nonnull const * _Nonnull);


### PR DESCRIPTION
Some APIs really need reference semantics even for a type that's normally bridged to a Swift value type, such as the NSString view onto NSTextStorage's backing in AppKit. Up until now people have had to work around this with hacks, usually wrapper functions that return an "NSObject" that then can be downcast back to NSString. This new Clang attribute avoids that.

rdar://problem/28480421


* * *

This PR depends on a Clang-side change, and should not be merged until that change is available in `swift-clang/stable`.