### PR TITLE
Allow options: -O with -enforce-exclusivity.

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -528,11 +528,6 @@ void parseExclusivityEnforcementOptions(const llvm::opt::Arg *A,
     Diags.diagnose(SourceLoc(), diag::error_unsupported_option_argument,
         A->getOption().getPrefixedName(), A->getValue());
   }
-  if (Opts.shouldOptimize() && Opts.EnforceExclusivityDynamic) {
-    Diags.diagnose(SourceLoc(),
-                   diag::warning_argument_not_supported_with_optimization,
-                   A->getOption().getPrefixedName() + A->getValue());
-  }
 }
 
 static bool ParseSILArgs(SILOptions &Opts, ArgList &Args,

--- a/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
@@ -36,7 +36,7 @@ using namespace swift;
 // This is currently unsupported because tail duplication results in
 // address-type block arguments.
 llvm::cl::opt<bool> EnableOptimizedAccessMarkers(
-    "sil-optimized-access-markers", llvm::cl::init(false),
+    "sil-optimized-access-markers", llvm::cl::init(true),
     llvm::cl::desc("Enable memory access markers during optimization passes."));
 
 namespace {

--- a/test/SILOptimizer/access_marker_elim.sil
+++ b/test/SILOptimizer/access_marker_elim.sil
@@ -1,4 +1,5 @@
-// RUN: %target-sil-opt -enforce-exclusivity=checked -emit-sorted-sil -access-marker-elim %s | %FileCheck %s
+// RUN: %target-sil-opt -enforce-exclusivity=unchecked -emit-sorted-sil -access-marker-elim %s | %FileCheck %s --check-prefix=UNCHECKED
+// RUN: %target-sil-opt -enforce-exclusivity=checked -emit-sorted-sil -access-marker-elim %s | %FileCheck %s --check-prefix=CHECKED
 
 sil_stage raw
 
@@ -11,21 +12,40 @@ public struct S {
   init(i: Int)
 }
 
-// CHECK-LABEL: sil hidden [noinline] @f010_initS : $@convention(thin) () -> @owned S {
-// CHECK: bb0:
-// CHECK:  %[[BOX:.*]] = alloc_box ${ var S }, var, name "s"
-// CHECK:  %[[ADDRS:.*]] = project_box %[[BOX]] : ${ var S }, 0
-// CHECK:  %[[NUM:.*]] = integer_literal $Builtin.Int64, 1
-// CHECK-NOT: begin_access
-// CHECK:  %[[ADDRI:.*]] = struct_element_addr %[[ADDRS]] : $*S, #S.i
-// CHECK:  assign %[[NUM]] to %[[ADDRI]] : $*Builtin.Int64
-// CHECK-NOT: end_access
-// CHECK-NOT: begin_access
-// CHECK:  %[[VALS:.*]] = load [trivial] %[[ADDRS]] : $*S
-// CHECK-NOT: end_access
-// CHECK:  destroy_value %[[BOX]] : ${ var S }
-// CHECK:  return %[[VALS]] : $S
-// CHECK-LABEL: } // end sil function 'f010_initS'
+// [unknown] markers are treated like [dynamic] markers by AccessMarkerElimination.
+// We don't remove them for -enforce-exclusivity=checked
+
+// UNCHECKED-LABEL: sil hidden [noinline] @f010_initS : $@convention(thin) () -> @owned S {
+// UNCHECKED: bb0:
+// UNCHECKED:  [[BOX:%.*]] = alloc_box ${ var S }, var, name "s"
+// UNCHECKED:  [[ADDRS:%.*]] = project_box [[BOX]] : ${ var S }, 0
+// UNCHECKED:  [[NUM:%.*]] = integer_literal $Builtin.Int64, 1
+// UNCHECKED-NOT: begin_access
+// UNCHECKED:  [[ADDRI:%.*]] = struct_element_addr [[ADDRS]] : $*S, #S.i
+// UNCHECKED:  assign [[NUM]] to [[ADDRI]] : $*Builtin.Int64
+// UNCHECKED-NOT: end_access
+// UNCHECKED-NOT: begin_access
+// UNCHECKED:  [[VALS:%.*]] = load [trivial] [[ADDRS]] : $*S
+// UNCHECKED-NOT: end_access
+// UNCHECKED:  destroy_value [[BOX]] : ${ var S }
+// UNCHECKED:  return [[VALS]] : $S
+// UNCHECKED-LABEL: } // end sil function 'f010_initS'
+//
+// CHECKED-LABEL: sil hidden [noinline] @f010_initS : $@convention(thin) () -> @owned S {
+// CHECKED: bb0:
+// CHECKED:  [[BOX:%.*]] = alloc_box ${ var S }, var, name "s"
+// CHECKED:  [[ADDRS:%.*]] = project_box [[BOX]] : ${ var S }, 0
+// CHECKED:  [[NUM:%.*]] = integer_literal $Builtin.Int64, 1
+// CHECKED:  [[ACCESS:%.*]] = begin_access [modify] [unknown] [[ADDRS]]
+// CHECKED:  [[ADDRI:%.*]] = struct_element_addr [[ACCESS]] : $*S, #S.i
+// CHECKED:  assign [[NUM]] to [[ADDRI]] : $*Builtin.Int64
+// CHECKED:  end_access [[ACCESS]]
+// CHECKED:  [[ACCESS:%.*]] = begin_access [read] [unknown] [[ADDRS]]
+// CHECKED:  [[VALS:%.*]] = load [trivial] [[ACCESS]] : $*S
+// CHECKED:  end_access [[ACCESS]]
+// CHECKED:  destroy_value [[BOX]] : ${ var S }
+// CHECKED:  return [[VALS]] : $S
+// CHECKED-LABEL: } // end sil function 'f010_initS'
 sil hidden [noinline] @f010_initS : $@convention(thin) () -> @owned S {
 bb0:
   %0 = alloc_box ${ var S }, var, name "s"
@@ -46,14 +66,27 @@ bb0:
 // And since inactive elimination currently eliminates all dynamic markers,
 // they are gone from the output.
 //
-// CHECK-LABEL: sil hidden @f020_boxArg : $@convention(thin) (@owned { var Builtin.Int64 }) -> () {
-// CHECK: bb0(%0 : ${ var Builtin.Int64 }):
-// CHECK:  [[ADR:%.*]] = project_box %0 : ${ var Builtin.Int64 }, 0
-// CHECK:  [[VAL:%.*]] = integer_literal $Builtin.Int64, 42
-// CHECK:  store [[VAL]] to [trivial] [[ADR]] : $*Builtin.Int64
-// CHECK:  destroy_value %0 : ${ var Builtin.Int64 }
-// CHECK:  return %{{.*}} : $()
-// CHECK-LABEL: } // end sil function 'f020_boxArg'
+// UNCHECKED-LABEL: sil hidden @f020_boxArg : $@convention(thin) (@owned { var Builtin.Int64 }) -> () {
+// UNCHECKED: bb0(%0 : ${ var Builtin.Int64 }):
+// UNCHECKED:  [[ADR:%.*]] = project_box %0 : ${ var Builtin.Int64 }, 0
+// UNCHECKED:  [[VAL:%.*]] = integer_literal $Builtin.Int64, 42
+// UNCHECKED-NOT: begin_access
+// UNCHECKED:  store [[VAL]] to [trivial] [[ADR]] : $*Builtin.Int64
+// UNCHECKED-NOT: end_access
+// UNCHECKED:  destroy_value %0 : ${ var Builtin.Int64 }
+// UNCHECKED:  return %{{.*}} : $()
+// UNCHECKED-LABEL: } // end sil function 'f020_boxArg'
+//
+// CHECKED-LABEL: sil hidden @f020_boxArg : $@convention(thin) (@owned { var Builtin.Int64 }) -> () {
+// CHECKED: bb0(%0 : ${ var Builtin.Int64 }):
+// CHECKED:  [[ADR:%.*]] = project_box %0 : ${ var Builtin.Int64 }, 0
+// CHECKED:  [[VAL:%.*]] = integer_literal $Builtin.Int64, 42
+// CHECKED:  [[ACCESS:%.*]] = begin_access [modify] [unknown] [[ADR]]
+// CHECKED:  store [[VAL]] to [trivial] [[ACCESS]] : $*Builtin.Int64
+// CHECKED:  end_access [[ACCESS]]
+// CHECKED:  destroy_value %0 : ${ var Builtin.Int64 }
+// CHECKED:  return %{{.*}} : $()
+// CHECKED-LABEL: } // end sil function 'f020_boxArg'
 sil hidden @f020_boxArg : $@convention(thin) (@owned { var Builtin.Int64 }) -> () {
 bb0(%0 : ${ var Builtin.Int64 }):
   %1 = project_box %0 : ${ var Builtin.Int64 }, 0


### PR DESCRIPTION
Allow -enforce-exclusivity=checked at -O so we can begin fixing bugs and improving performance.