### PR TITLE
Add a (tiny) test that adding "final" to a file rebuilds dependents

### DIFF
--- a/validation-test/Driver/Dependencies/Inputs/rdar23148987/helper-1.swift
+++ b/validation-test/Driver/Dependencies/Inputs/rdar23148987/helper-1.swift
@@ -1,0 +1,3 @@
+public class Test {
+  func foo() {}
+}

--- a/validation-test/Driver/Dependencies/Inputs/rdar23148987/helper-2.swift
+++ b/validation-test/Driver/Dependencies/Inputs/rdar23148987/helper-2.swift
@@ -1,0 +1,3 @@
+public final class Test {
+  func foo() {}
+}

--- a/validation-test/Driver/Dependencies/Inputs/rdar23148987/output.json
+++ b/validation-test/Driver/Dependencies/Inputs/rdar23148987/output.json
@@ -1,0 +1,13 @@
+{
+  "./helper.swift": {
+    "object": "./helper.o",
+    "swift-dependencies": "./helper.swiftdeps",
+  },
+  "./main.swift": {
+    "object": "./main.o",
+    "swift-dependencies": "./main.swiftdeps",
+  },
+  "": {
+    "swift-dependencies": "./main~buildrecord.swiftdeps"
+  }
+}

--- a/validation-test/Driver/Dependencies/rdar23148987.swift
+++ b/validation-test/Driver/Dependencies/rdar23148987.swift
@@ -1,0 +1,61 @@
+// RUN: %empty-directory(%t)
+
+// RUN: cp %s %t/main.swift
+// RUN: cp %S/Inputs/rdar23148987/helper-1.swift %t/helper.swift
+// RUN: touch -t 201401240005 %t/*.swift
+
+// RUN: cd %t && %target-build-swift -c -incremental -output-file-map %S/Inputs/rdar23148987/output.json -parse-as-library ./main.swift ./helper.swift -parseable-output -j1 -module-name main 2>&1 | %FileCheck -check-prefix=CHECK-1 %s
+
+// CHECK-1-NOT: warning
+// CHECK-1: {{^{$}}
+// CHECK-1: "kind": "began"
+// CHECK-1: "name": "compile"
+// CHECK-1: ".\/main.swift"
+// CHECK-1: {{^}$}}
+
+// CHECK-1: {{^{$}}
+// CHECK-1: "kind": "began"
+// CHECK-1: "name": "compile"
+// CHECK-1: ".\/helper.swift"
+// CHECK-1: {{^}$}}
+
+// RUN: ls %t/ | %FileCheck -check-prefix=CHECK-LS %s
+
+// CHECK-LS-DAG: main.o
+// CHECK-LS-DAG: helper.o
+
+// RUN: cd %t && %target-build-swift -c -incremental -output-file-map %S/Inputs/rdar23148987/output.json -parse-as-library ./main.swift ./helper.swift -parseable-output -j1 -module-name main 2>&1 | %FileCheck -check-prefix=CHECK-1-SKIPPED %s
+
+// CHECK-1-SKIPPED-NOT: warning
+// CHECK-1-SKIPPED: {{^{$}}
+// CHECK-1-SKIPPED: "kind": "skipped"
+// CHECK-1-SKIPPED: "name": "compile"
+// CHECK-1-SKIPPED: ".\/main.swift"
+// CHECK-1-SKIPPED: {{^}$}}
+
+// CHECK-1-SKIPPED: {{^{$}}
+// CHECK-1-SKIPPED: "kind": "skipped"
+// CHECK-1-SKIPPED: "name": "compile"
+// CHECK-1-SKIPPED: ".\/helper.swift"
+// CHECK-1-SKIPPED: {{^}$}}
+
+// RUN: cp %S/Inputs/rdar23148987/helper-2.swift %t/helper.swift
+// RUN: touch -t 201401240006 %t/helper.swift
+// RUN: cd %t && %target-build-swift -c -incremental -output-file-map %S/Inputs/rdar23148987/output.json -parse-as-library ./main.swift ./helper.swift -parseable-output -j1 -module-name main 2>&1 | %FileCheck -check-prefix=CHECK-2 %s
+
+// CHECK-2-NOT: warning
+// CHECK-2: {{^{$}}
+// CHECK-2: "kind": "began"
+// CHECK-2: "name": "compile"
+// CHECK-2: ".\/helper.swift"
+// CHECK-2: {{^}$}}
+
+// CHECK-2: {{^{$}}
+// CHECK-2: "kind": "began"
+// CHECK-2: "name": "compile"
+// CHECK-2: ".\/main.swift"
+// CHECK-2: {{^}$}}
+
+func test(obj: Test) {
+  obj.foo()
+}


### PR DESCRIPTION
I can't see how we'd ever get this wrong at this point, but way back in the early days of incremental builds we apparently managed to. Adding a test just to close this out.

rdar://problem/23148987