### PR TITLE
sourcekitd: duplicate sourcekitd UIDs should lead to build failure.

### DIFF
--- a/tools/SourceKit/include/SourceKit/Core/ProtocolUIDs.def.gyb
+++ b/tools/SourceKit/include/SourceKit/Core/ProtocolUIDs.def.gyb
@@ -1,8 +1,7 @@
 %{
   # -*- mode: Python -*-
-  from gyb_sourcekit_support.UIDs import UID_KEYS
-  from gyb_sourcekit_support.UIDs import UID_REQUESTS
-  from gyb_sourcekit_support.UIDs import UID_KINDS
+  from gyb_sourcekit_support import *
+  assert check_uid_duplication(), "Found UID duplication"
   # Ignore the following admonition; it applies to the resulting .def file only
 }%
 //// Automatically Generated From ProtocolUIDs.def.gyb.

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -45,7 +45,6 @@ UID_KEYS = [
     KEY('Severity', 'key.severity'),
     KEY('Offset', 'key.offset'),
     KEY('Length', 'key.length'),
-    KEY('Lengthddd', 'key.length'),
     KEY('SourceFile', 'key.sourcefile'),
     KEY('SerializedSyntaxTree', 'key.serialized_syntax_tree'),
     KEY('SourceText', 'key.sourcetext'),

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -45,6 +45,7 @@ UID_KEYS = [
     KEY('Severity', 'key.severity'),
     KEY('Offset', 'key.offset'),
     KEY('Length', 'key.length'),
+    KEY('Lengthddd', 'key.length'),
     KEY('SourceFile', 'key.sourcefile'),
     KEY('SerializedSyntaxTree', 'key.serialized_syntax_tree'),
     KEY('SourceText', 'key.sourcetext'),

--- a/utils/gyb_sourcekit_support/__init__.py
+++ b/utils/gyb_sourcekit_support/__init__.py
@@ -18,6 +18,7 @@ from UIDs import UID_KEYS
 from UIDs import UID_KINDS
 from UIDs import UID_REQUESTS
 
+
 def check_uid_duplication():
     all_external_names = [K.externalName for K in UID_KEYS] + \
         [R.externalName for R in UID_REQUESTS] +              \

--- a/utils/gyb_sourcekit_support/__init__.py
+++ b/utils/gyb_sourcekit_support/__init__.py
@@ -14,3 +14,12 @@
 # utils/gyb_sourcekit_support/ directory as a module.
 #
 # ----------------------------------------------------------------------------
+from UIDs import UID_KEYS
+from UIDs import UID_KINDS
+from UIDs import UID_REQUESTS
+
+def check_uid_duplication():
+    all_external_names = [K.externalName for K in UID_KEYS] + \
+        [R.externalName for R in UID_REQUESTS] +              \
+        [K.externalName for K in UID_KINDS]
+    return len(all_external_names) == len(set(all_external_names))


### PR DESCRIPTION
This ensures we can safely add new UIDs.
