### PR TITLE
Handle 'import struct Foo' where Foo is a non-nominal typealias

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -688,9 +688,13 @@ ERROR(decl_does_not_exist_in_module,none,
       "%1 does not exist in module %2",
       (/*ImportKind*/ unsigned, Identifier, Identifier))
 ERROR(imported_decl_is_wrong_kind,none,
-      "%0 was imported as '%1', but is a "
-      "%select{%error|type|struct|class|enum|protocol|variable|function}2",
+      "%0 was imported as '%1', but is "
+      "%select{%error|a type|a struct|a class|an enum|a protocol|a variable|"
+      "a function}2",
       (Identifier, StringRef, /*ImportKind*/ unsigned))
+ERROR(imported_decl_is_wrong_kind_typealias,none,
+      "%0 %1 cannot be imported as '%2'",
+      (DescriptiveDeclKind, Type, StringRef))
 ERROR(ambiguous_decl_in_module,none,
       "ambiguous name %0 in module %1", (Identifier, Identifier))
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -804,7 +804,10 @@ ImportKind ImportDecl::getBestImportKind(const ValueDecl *VD) {
 
   case DeclKind::TypeAlias: {
     Type type = cast<TypeAliasDecl>(VD)->getDeclaredInterfaceType();
-    return getBestImportKind(type->getAnyNominal());
+    auto *nominal = type->getAnyNominal();
+    if (!nominal)
+      return ImportKind::Type;
+    return getBestImportKind(nominal);
   }
 
   case DeclKind::Accessor:

--- a/test/NameBinding/Inputs/DeclsUsedWrongly.swift
+++ b/test/NameBinding/Inputs/DeclsUsedWrongly.swift
@@ -1,0 +1,9 @@
+public var x: Int = 0
+
+public enum Choice {
+  case yes, no, maybeSo
+}
+
+public typealias Callback = () -> Void
+
+public typealias Pair<T> = (T, T)

--- a/test/NameBinding/import-specific-fixits.swift
+++ b/test/NameBinding/import-specific-fixits.swift
@@ -3,8 +3,8 @@
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/ambiguous_left.swift
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/ambiguous_right.swift
 // RUN: %target-swift-frontend -emit-module -o %t -I %t %S/Inputs/ambiguous.swift
+// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/DeclsUsedWrongly.swift
 
-// RUN: echo "public var x = Int()" | %target-swift-frontend -module-name FooBar -emit-module -o %t -
 // RUN: %target-swift-frontend -typecheck -I %t -serialize-diagnostics-path %t.dia %s -verify
 // RUN: c-index-test -read-diagnostics %t.dia > %t.deserialized_diagnostics.txt 2>&1
 // RUN: %FileCheck --input-file=%t.deserialized_diagnostics.txt %s
@@ -29,7 +29,15 @@ import class Swift.Int64 // expected-error {{'Int64' was imported as 'class', bu
 
 import class Swift.Bool // expected-error {{'Bool' was imported as 'class', but is a struct}} {{8-13=struct}}
 
-import struct FooBar.x // expected-error {{'x' was imported as 'struct', but is a variable}} {{8-14=var}}
+import struct DeclsUsedWrongly.x // expected-error {{'x' was imported as 'struct', but is a variable}} {{8-14=var}}
+
+import struct DeclsUsedWrongly.Choice // expected-error {{'Choice' was imported as 'struct', but is an enum}} {{8-14=enum}}
+
+import struct DeclsUsedWrongly.Callback // expected-error {{type alias 'Callback' (aka '() -> ()') cannot be imported as 'struct'}} {{8-14=typealias}}
+import var DeclsUsedWrongly.Callback // expected-error {{'Callback' was imported as 'var', but is a type}} {{8-11=typealias}}
+
+import struct DeclsUsedWrongly.Pair // expected-error {{type alias 'Pair' cannot be imported as 'struct'}} {{8-14=typealias}}
+import var DeclsUsedWrongly.Pair // expected-error {{'Pair' was imported as 'var', but is a type}} {{8-11=typealias}}
 
 import struct Swift.print // expected-error {{'print' was imported as 'struct', but is a function}} {{8-14=func}}
 


### PR DESCRIPTION
Previously this just crashed. Now it suggests `import typealias Foo`, a syntax that works back to Swift 1.

rdar://problem/36756349