### PR TITLE
[TypeChecker] Fix crash related to chained optionals in case statements

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/0143-rdar35870863.swift
+++ b/validation-test/compiler_crashers_2_fixed/0143-rdar35870863.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend %s -typecheck
+
+struct S {
+  let foo = "bar"
+}
+let s: S? = S()
+let str: String? = "hello world"
+
+switch str {
+  case s?.foo?: ()
+  default: ()
+}


### PR DESCRIPTION
Type checker didn't handle the safe of disjoint optional chaining when trying
to convert such chaining into `.Some` cases, which leads to dangling
`BindOptionalExpr` in the AST.

Resolves: rdar://problem/35870863

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
