### PR TITLE
[SILVerifier] Disallow address-type block arguments in raw SIL.

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -349,7 +349,9 @@ public:
   /// SIL). If so, diagnostics should not be reapplied.
   bool wasDeserializedCanonical() const { return WasDeserializedCanonical; }
 
-  void setWasDeserializedCanonical() { WasDeserializedCanonical = true; }
+  void setWasDeserializedCanonical(bool val = true) {
+    WasDeserializedCanonical = val;
+  }
 
   /// Returns the calling convention used by this entry point.
   SILFunctionTypeRepresentation getRepresentation() const {

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -885,6 +885,7 @@ void SILParser::convertRequirements(SILFunction *F,
 
 static bool parseDeclSILOptional(bool *isTransparent,
                                  IsSerialized_t *isSerialized,
+                                 bool *isCanonical,
                                  IsThunk_t *isThunk, bool *isGlobalInit,
                                  Inline_t *inlineStrategy,
                                  OptimizationMode *optimizationMode,
@@ -909,6 +910,8 @@ static bool parseDeclSILOptional(bool *isTransparent,
       *isSerialized = IsSerialized;
     else if (isSerialized && SP.P.Tok.getText() == "serializable")
       *isSerialized = IsSerializable;
+    else if (isCanonical && SP.P.Tok.getText() == "canonical")
+      *isCanonical = true;
     else if (isThunk && SP.P.Tok.getText() == "thunk")
       *isThunk = IsThunk;
     else if (isThunk && SP.P.Tok.getText() == "reabstraction_thunk")
@@ -5118,6 +5121,7 @@ bool SILParserTUState::parseDeclSIL(Parser &P) {
   Scope S(&P, ScopeKind::TopLevel);
   bool isTransparent = false;
   IsSerialized_t isSerialized = IsNotSerialized;
+  bool isCanonical = false;
   IsThunk_t isThunk = IsNotThunk;
   bool isGlobalInit = false, isWeakLinked = false;
   Inline_t inlineStrategy = InlineDefault;
@@ -5127,7 +5131,8 @@ bool SILParserTUState::parseDeclSIL(Parser &P) {
   ValueDecl *ClangDecl = nullptr;
   EffectsKind MRK = EffectsKind::Unspecified;
   if (parseSILLinkage(FnLinkage, P) ||
-      parseDeclSILOptional(&isTransparent, &isSerialized, &isThunk, &isGlobalInit,
+      parseDeclSILOptional(&isTransparent, &isSerialized, &isCanonical,
+                           &isThunk, &isGlobalInit,
                            &inlineStrategy, &optimizationMode, nullptr,
                            &isWeakLinked, &Semantics, &SpecAttrs,
                            &ClangDecl, &MRK, FunctionState) ||
@@ -5153,6 +5158,7 @@ bool SILParserTUState::parseDeclSIL(Parser &P) {
     FunctionState.F->setBare(IsBare);
     FunctionState.F->setTransparent(IsTransparent_t(isTransparent));
     FunctionState.F->setSerialized(IsSerialized_t(isSerialized));
+    FunctionState.F->setWasDeserializedCanonical(isCanonical);
     FunctionState.F->setThunk(IsThunk_t(isThunk));
     FunctionState.F->setGlobalInit(isGlobalInit);
     FunctionState.F->setWeakLinked(isWeakLinked);
@@ -5286,7 +5292,7 @@ bool SILParserTUState::parseSILGlobal(Parser &P) {
   Scope S(&P, ScopeKind::TopLevel);
   SILParser State(P);
   if (parseSILLinkage(GlobalLinkage, P) ||
-      parseDeclSILOptional(nullptr, &isSerialized, nullptr, nullptr,
+      parseDeclSILOptional(nullptr, &isSerialized, nullptr, nullptr, nullptr,
                            nullptr, nullptr, &isLet, nullptr, nullptr, nullptr,
                            nullptr, nullptr, State) ||
       P.parseToken(tok::at_sign, diag::expected_sil_value_name) ||
@@ -5329,7 +5335,7 @@ bool SILParserTUState::parseSILProperty(Parser &P) {
   SILParser SP(P);
   
   IsSerialized_t Serialized = IsNotSerialized;
-  if (parseDeclSILOptional(nullptr, &Serialized, nullptr, nullptr,
+  if (parseDeclSILOptional(nullptr, &Serialized, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, SP))
     return true;
@@ -5383,7 +5389,7 @@ bool SILParserTUState::parseSILVTable(Parser &P) {
   SILParser VTableState(P);
 
   IsSerialized_t Serialized = IsNotSerialized;
-  if (parseDeclSILOptional(nullptr, &Serialized, nullptr, nullptr,
+  if (parseDeclSILOptional(nullptr, &Serialized, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, VTableState))
     return true;
@@ -5733,7 +5739,7 @@ bool SILParserTUState::parseSILWitnessTable(Parser &P) {
   parseSILLinkage(Linkage, P);
   
   IsSerialized_t isSerialized = IsNotSerialized;
-  if (parseDeclSILOptional(nullptr, &isSerialized, nullptr, nullptr,
+  if (parseDeclSILOptional(nullptr, &isSerialized, nullptr, nullptr, nullptr,
                            nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
                            nullptr, nullptr, WitnessState))
     return true;

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2324,6 +2324,15 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
     OS << "] ";
   }
 
+  // Handle functions that are deserialized from canonical SIL. Normally, we
+  // should emit SIL with the correct SIL stage, so preserving this attribute
+  // won't be necessary. But consider serializing raw SIL (either textual SIL or
+  // SIB) after importing canonical SIL from another module. If the imported
+  // functions are reserialized (e.g. shared linkage), then we must preserve
+  // this attribute.
+  if (WasDeserializedCanonical && getModule().getStage() == SILStage::Raw)
+    OS << "[canonical] ";
+
   printName(OS);
   OS << " : $";
   

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -329,9 +329,58 @@ public:
       delete Dominance;
   }
 
+  // Address-type block args must be prohibited whenever access markers are
+  // present. Access markers are always present in raw SIL to diagnose exclusive
+  // memory access. In canonical SIL, access markers are only present with
+  // EnforceExclusivityDynamic.
+  //
+  // FIXME: For sanity, address-type block args should be prohibited at all SIL
+  // stages. However, the optimizer currently breaks the invariant in three
+  // places:
+  // 1. Normal Simplify CFG during conditional branch simplification
+  //    (sneaky jump threading).
+  // 2. Simplify CFG via Jump Threading.
+  // 3. Loop Rotation.
+  // Once EnforceExclusivityDynamic is performant enough to be enabled by
+  // default at -O, address-type blocks args can be prohibited unconditionally.
+  bool prohibitAddressBlockArgs() {
+    // If this function was deserialized from canonical SIL, this invariant may
+    // already have been violated regardless of this module's SIL stage or
+    // exclusivity enforcement level. Presumably, access markers were already
+    // removed prior to serialization.
+    if (F.wasDeserializedCanonical())
+      return false;
+
+    SILModule &M = F.getModule();
+    if (M.getStage() == SILStage::Raw)
+      return true;
+
+    // If dynamic enforcement is enabled, markers are present at -O so we
+    // prohibit address block args.
+    return M.getOptions().EnforceExclusivityDynamic;
+  }
+
   void visitSILArgument(SILArgument *arg) {
     checkLegalType(arg->getFunction(), arg, nullptr);
     checkValueBaseOwnership(arg);
+
+    if (isa<SILPHIArgument>(arg) && prohibitAddressBlockArgs()) {
+      // As a structural SIL property, we disallow address-type block
+      // arguments. Supporting them would prevent reliably reasoning about the
+      // underlying storage of memory access. This reasoning is important for
+      // diagnosing violations of memory access rules and supporting future
+      // optimizations such as bitfield packing. Address-type block arguments
+      // also create unnecessary complexity for SIL optimization passes that
+      // need to reason about memory aliasing.
+      //
+      // Note: We could allow non-phi block arguments to be addresses, because
+      // the address source would still be uniquely recoverable. But then
+      // we would need to separately ensure that something like begin_access is
+      // never passed as a block argument before being used by end_access. For
+      // now, it simpler to have a strict prohibition.
+      require(!arg->getType().isAddress(),
+              "Block arguments cannot be addresses");
+    }
   }
 
   void visitSILInstruction(SILInstruction *I) {

--- a/test/Frontend/sil-merge-partial-modules.swift
+++ b/test/Frontend/sil-merge-partial-modules.swift
@@ -43,25 +43,25 @@ public class CircleManager : ShapeManager {
 
 // FIXME: Why is the definition order totally random?
 
-// CHECK-LABEL: sil @$S4test17versionedFunctionyyF : $@convention(thin) () -> ()
+// CHECK-LABEL: sil [canonical] @$S4test17versionedFunctionyyF : $@convention(thin) () -> ()
 
-// CHECK-LABEL: sil @$S4test9RectangleV4areaSfvg : $@convention(method) (Rectangle) -> Float
+// CHECK-LABEL: sil [canonical] @$S4test9RectangleV4areaSfvg : $@convention(method) (Rectangle) -> Float
 
-// CHECK-LABEL: sil shared [serialized] @$S4test18inlineableFunctionyyFyycfU_ : $@convention(thin) () -> () {
+// CHECK-LABEL: sil shared [serialized] [canonical] @$S4test18inlineableFunctionyyFyycfU_ : $@convention(thin) () -> () {
 // CHECK: function_ref @$S4test17versionedFunctionyyF
 // CHECK: }
 
-// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] @$S4test9RectangleVAA5ShapeA2aDP4drawyyFTW : $@convention(witness_method: Shape) (@in_guaranteed Rectangle) -> () {
+// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] [canonical] @$S4test9RectangleVAA5ShapeA2aDP4drawyyFTW : $@convention(witness_method: Shape) (@in_guaranteed Rectangle) -> () {
 // CHECK: function_ref @$S4test14publicFunctionyyF
 // CHECK: }
 
-// CHECK-LABEL: sil [serialized] @$S4test18inlineableFunctionyyF : $@convention(thin) () -> () {
+// CHECK-LABEL: sil [serialized] [canonical] @$S4test18inlineableFunctionyyF : $@convention(thin) () -> () {
 // CHECK: function_ref @$S4test18inlineableFunctionyyFyycfU_
 // CHECK: }
 
-// CHECK-LABEL: sil @$S4test14publicFunctionyyF : $@convention(thin) () -> ()
+// CHECK-LABEL: sil [canonical] @$S4test14publicFunctionyyF : $@convention(thin) () -> ()
 
-// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] @$S4test9RectangleVAA5ShapeA2aDP4areaSfvgTW : $@convention(witness_method: Shape) (@in_guaranteed Rectangle) -> Float {
+// CHECK-LABEL: sil shared [transparent] [serialized] [thunk] [canonical] @$S4test9RectangleVAA5ShapeA2aDP4areaSfvgTW : $@convention(witness_method: Shape) (@in_guaranteed Rectangle) -> Float {
 // CHECK: function_ref @$S4test9RectangleV4areaSfvg
 // CHECK: }
 

--- a/test/SIL/Parser/stage.swift
+++ b/test/SIL/Parser/stage.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module %s -O -parse-stdlib -parse-as-library -emit-module -o %t/stage.swiftmodule
+// RUN: %target-sil-opt %t/stage.swiftmodule -disable-sil-linking -sil-disable-ast-dump -o %t/stage.sil
+// RUN: %target-sil-opt %t/stage.sil -o - | %FileCheck %s
+
+// FIXME: We create all SIL modules in the 'raw' stage regardless of the input
+// kind. If the primary input is a serialized module, we should assume the
+// canonical stage. Also .sib files should have their stage
+// serialized/deserialized.
+//
+// CHECK: sil_stage raw
+//
+// Verify that the '[canonical]' attribute was set.
+// CHECK: sil [serialized] [canonical] @$S5stage21functionToReserializeyyF : $@convention(thin) () -> () {
+@_inlineable
+public func functionToReserialize() {}

--- a/test/SIL/Serialization/deserialize_generic.sil
+++ b/test/SIL/Serialization/deserialize_generic.sil
@@ -21,5 +21,5 @@ bb0:
 }
 
 // Make sure the function body is deserialized.
-// CHECK-LABEL: sil public_external [serialized] @$S11def_generic1AC23convertFromArrayLiteralyACyxGxd_tF : $@convention(method) <T> (@owned Array<T>, @guaranteed A<T>) -> @owned A<T> {
+// CHECK-LABEL: sil public_external [serialized] [canonical] @$S11def_generic1AC23convertFromArrayLiteralyACyxGxd_tF : $@convention(method) <T> (@owned Array<T>, @guaranteed A<T>) -> @owned A<T> {
 sil @$S11def_generic1AC23convertFromArrayLiteralyACyxGxd_tF : $@convention(method) <T> (@owned Array<T>, @guaranteed A<T>) -> @owned A<T>

--- a/test/SIL/Serialization/function_param_convention.sil
+++ b/test/SIL/Serialization/function_param_convention.sil
@@ -6,7 +6,7 @@ import Swift
 import FunctionInput
 
 // Make sure we can deserialize a SIL function with these various attributes.
-// CHECK: sil public_external [serialized] @foo : $@convention(thin) (@in X, @inout X, @in_guaranteed X, @owned X, X, @guaranteed X) -> @out X {
+// CHECK: sil public_external [serialized] [canonical] @foo : $@convention(thin) (@in X, @inout X, @in_guaranteed X, @owned X, X, @guaranteed X) -> @out X {
 
 sil @foo : $@convention(thin) (@in X, @inout X, @in_guaranteed X, @owned X, X, @guaranteed X) -> @out X
 

--- a/test/SIL/Serialization/public_non_abi.sil
+++ b/test/SIL/Serialization/public_non_abi.sil
@@ -20,6 +20,6 @@ bb0:
 }
 
 // Make sure the function body is deserialized.
-// CHECK-LABEL: sil shared_external [serialized] @public_non_abi_function : $@convention(thin) () -> ()
+// CHECK-LABEL: sil shared_external [serialized] [canonical] @public_non_abi_function : $@convention(thin) () -> ()
 // CHECK: return
 sil hidden_external [serialized] @public_non_abi_function : $@convention(thin) () -> ()

--- a/test/SIL/Serialization/visibility.sil
+++ b/test/SIL/Serialization/visibility.sil
@@ -20,21 +20,21 @@ import Builtin
 
 // Check that all functions are defined/declared appropriately.
 // NEG-CHECK-NOT: sil [serialized] @public_external_function_test : $@convention(thin) () -> () {
-// CHECK-DAG: sil [serialized] @public_external_function_test : $@convention(thin) () -> ()
-// CHECK-DAG: sil hidden [serialized] @hidden_function_test : $@convention(thin) () -> () {
-// CHECK-DAG: sil [serialized] @references_public_function : $@convention(thin) () -> () {
-// CHECK-DAG: sil [serialized] @references_shared_function : $@convention(thin) () -> () {
-// CHECK-DAG: sil [serialized] @references_hidden_function : $@convention(thin) () -> () {
-// CHECK-DAG: sil [serialized] @references_private_function : $@convention(thin) () -> ()
-// CHECK-DAG: sil [serialized] @references_public_global : $@convention(thin) () -> () {
-// CHECK-DAG: sil [serialized] @references_shared_global : $@convention(thin) () -> () {
-// CHECK-DAG: sil [serialized] @references_hidden_global : $@convention(thin) () -> () {
-// CHECK-DAG: sil [serialized] @references_private_global : $@convention(thin) () -> ()
-// CHECK-DAG: sil hidden_external [serialized] @hidden_external_function_test : $@convention(thin) () -> ()
-// CHECK-DAG: sil [serialized] @public_function_test : $@convention(thin) () -> () {
-// CHECK-DAG: sil [serialized] @public_function : $@convention(thin) () -> () {
-// CHECK-DAG: sil hidden [serialized] @hidden_function : $@convention(thin) () -> () {
-// CHECK-DAG: sil shared_external [serialized] @shared_external_function_test : $@convention(thin) () -> ()
+// CHECK-DAG: sil [serialized] [canonical] @public_external_function_test : $@convention(thin) () -> ()
+// CHECK-DAG: sil hidden [serialized] [canonical] @hidden_function_test : $@convention(thin) () -> () {
+// CHECK-DAG: sil [serialized] [canonical] @references_public_function : $@convention(thin) () -> () {
+// CHECK-DAG: sil [serialized] [canonical] @references_shared_function : $@convention(thin) () -> () {
+// CHECK-DAG: sil [serialized] [canonical] @references_hidden_function : $@convention(thin) () -> () {
+// CHECK-DAG: sil [serialized] [canonical] @references_private_function : $@convention(thin) () -> ()
+// CHECK-DAG: sil [serialized] [canonical] @references_public_global : $@convention(thin) () -> () {
+// CHECK-DAG: sil [serialized] [canonical] @references_shared_global : $@convention(thin) () -> () {
+// CHECK-DAG: sil [serialized] [canonical] @references_hidden_global : $@convention(thin) () -> () {
+// CHECK-DAG: sil [serialized] [canonical] @references_private_global : $@convention(thin) () -> ()
+// CHECK-DAG: sil hidden_external [serialized] [canonical] @hidden_external_function_test : $@convention(thin) () -> ()
+// CHECK-DAG: sil [serialized] [canonical] @public_function_test : $@convention(thin) () -> () {
+// CHECK-DAG: sil [serialized] [canonical] @public_function : $@convention(thin) () -> () {
+// CHECK-DAG: sil hidden [serialized] [canonical] @hidden_function : $@convention(thin) () -> () {
+// CHECK-DAG: sil shared_external [serialized] [canonical] @shared_external_function_test : $@convention(thin) () -> ()
 
 sil_global private [serialized] @private_global : $Builtin.Word
 sil_global [serialized] @public_global : $Builtin.Word

--- a/test/SILOptimizer/basic-aa.sil
+++ b/test/SILOptimizer/basic-aa.sil
@@ -1,6 +1,11 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -module-name Swift %s -aa-kind=basic-aa -aa-dump -o /dev/null | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enforce-exclusivity=none -module-name Swift %s -aa-kind=basic-aa -aa-dump -o /dev/null | %FileCheck %s
 
 // REQUIRES: asserts
+
+// Declare this SIL to be canonical because some tests break raw SIL
+// conventions. e.g. address-type block args. -enforce-exclusivity=none is also
+// required to allow address-type block args in canonical SIL.
+sil_stage canonical
 
 import Builtin
 

--- a/test/SILOptimizer/copyforward.sil
+++ b/test/SILOptimizer/copyforward.sil
@@ -1,5 +1,8 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -copy-forwarding -enable-copyforwarding -enable-destroyhoisting | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enforce-exclusivity=none -enable-sil-verify-all %s -copy-forwarding -enable-copyforwarding -enable-destroyhoisting | %FileCheck %s
 
+// Declare this SIL to be canonical because some tests break raw SIL
+// conventions. e.g. address-type block args. -enforce-exclusivity=none is also
+// required to allow address-type block args in canonical SIL.
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/cowarray_opt.sil
+++ b/test/SILOptimizer/cowarray_opt.sil
@@ -1,5 +1,8 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -cowarray-opt %s | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enforce-exclusivity=none -enable-sil-verify-all -cowarray-opt %s | %FileCheck %s
 
+// Declare this SIL to be canonical because some tests break raw SIL
+// conventions. e.g. address-type block args. -enforce-exclusivity=none is also
+// required to allow address-type block args in canonical SIL.
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/licm.sil
+++ b/test/SILOptimizer/licm.sil
@@ -1,5 +1,8 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -licm | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enforce-exclusivity=none -enable-sil-verify-all %s -licm | %FileCheck %s
 
+// Declare this SIL to be canonical because some tests break raw SIL
+// conventions. e.g. address-type block args. -enforce-exclusivity=none is also
+// required to allow address-type block args in canonical SIL.
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/linker.swift
+++ b/test/SILOptimizer/linker.swift
@@ -2,20 +2,20 @@
 // RUN: %target-swift-frontend -emit-module %S/Inputs/linker_pass_input.swift -o %t/Swift.swiftmodule -parse-stdlib -parse-as-library -module-name Swift -module-link-name swiftCore
 // RUN: %target-swift-frontend %s -O -I %t -sil-debug-serialization -o - -emit-sil | %FileCheck %s
 
-// CHECK: sil public_external [serialized] @$Ss11doSomethingyyF : $@convention(thin) () -> () {
+// CHECK: sil public_external [serialized] [canonical] @$Ss11doSomethingyyF : $@convention(thin) () -> () {
 doSomething()
 
 // CHECK: sil @$Ss12doSomething2yyF : $@convention(thin) () -> ()
 // CHECK-NOT: return
 doSomething2()
 
-// CHECK: sil public_external [serialized] [noinline] @$Ss16callDoSomething3yyF
+// CHECK: sil public_external [serialized] [noinline] [canonical] @$Ss16callDoSomething3yyF
 
-// CHECK: sil @unknown
+// CHECK: sil [canonical] @unknown
 
-// CHECK: sil @$Ss1AVABycfC
+// CHECK: sil [canonical] @$Ss1AVABycfC
 
-// CHECK: sil [noinline] @$Ss12doSomething3yyxlF
+// CHECK: sil [noinline] [canonical] @$Ss12doSomething3yyxlF
 // CHECK-NOT: return
 
 callDoSomething3()

--- a/test/SILOptimizer/looprotate.sil
+++ b/test/SILOptimizer/looprotate.sil
@@ -1,5 +1,8 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -loop-rotate %s | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enforce-exclusivity=none -enable-sil-verify-all -loop-rotate %s | %FileCheck %s
 
+// Declare this SIL to be canonical because some tests break raw SIL
+// conventions. e.g. address-type block args. -enforce-exclusivity=none is also
+// required to allow address-type block args in canonical SIL.
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/redundant_load_elim.sil
+++ b/test/SILOptimizer/redundant_load_elim.sil
@@ -1,4 +1,9 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -redundant-load-elim | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enforce-exclusivity=none -enable-sil-verify-all %s -redundant-load-elim | %FileCheck %s
+
+// Declare this SIL to be canonical because some tests break raw SIL
+// conventions. e.g. address-type block args. -enforce-exclusivity=none is also
+// required to allow address-type block args in canonical SIL.
+sil_stage canonical
 
 import Builtin
 import Swift

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -1,5 +1,8 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -sil-combine -verify-skip-unreachable-must-be-last | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enforce-exclusivity=none -enable-sil-verify-all %s -sil-combine -verify-skip-unreachable-must-be-last | %FileCheck %s
 
+// Declare this SIL to be canonical because some tests break raw SIL
+// conventions. e.g. address-type block args. -enforce-exclusivity=none is also
+// required to allow address-type block args in canonical SIL.
 sil_stage canonical
 
 import Builtin

--- a/test/SILOptimizer/simplify_cfg.sil
+++ b/test/SILOptimizer/simplify_cfg.sil
@@ -1,10 +1,13 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enforce-exclusivity=none -enable-sil-verify-all %s -jumpthread-simplify-cfg | %FileCheck %s
 // FIXME: Update for select_enum change.
+
+// Declare this SIL to be canonical because some tests break raw SIL
+// conventions. e.g. address-type block args. -enforce-exclusivity=none is also
+// required to allow address-type block args in canonical SIL.
+sil_stage canonical
 
 import Builtin
 import Swift
-
-sil_stage canonical
 
 ///////////////////////
 // Type Declarations //

--- a/test/SILOptimizer/sroa_bbargs.sil
+++ b/test/SILOptimizer/sroa_bbargs.sil
@@ -1,5 +1,8 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -sroa-bb-args %s | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enforce-exclusivity=none -enable-sil-verify-all -sroa-bb-args %s | %FileCheck %s
 
+// Declare this SIL to be canonical because some tests break raw SIL
+// conventions. e.g. address-type block args. -enforce-exclusivity=none is also
+// required to allow address-type block args in canonical SIL.
 sil_stage canonical
 
 import Builtin

--- a/test/Serialization/Inputs/def_basic.sil
+++ b/test/Serialization/Inputs/def_basic.sil
@@ -30,7 +30,7 @@ bb0:
 }
 
 // This references a public global so we *SHOULD* deserialize this.
-// CHECK-LABEL: sil public_external [serialized] @_TV18lazy_global_access4Type10staticPropySia_public : $@convention(thin) () -> Builtin.RawPointer {
+// CHECK-LABEL: sil public_external [serialized] [canonical] @_TV18lazy_global_access4Type10staticPropySia_public : $@convention(thin) () -> Builtin.RawPointer {
 sil [serialized] @_TV18lazy_global_access4Type10staticPropySia_public : $@convention(thin) () -> Builtin.RawPointer {
 bb0:
   // CHECK: alloc_global @public_global
@@ -62,7 +62,7 @@ class Class2 {
 
 // Instructions
 
-// CHECK-LABEL: sil public_external [serialized] @test1 : $@convention(thin) () -> ()
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test1 : $@convention(thin) () -> ()
 sil [serialized] @test1 : $@convention(thin) () -> () {
 bb0:                                  // CHECK: bb0:
   %0 = tuple ()                       // CHECK:   %0 = tuple ()
@@ -74,7 +74,7 @@ bb1:
 }
 
 // Forward referenced values.
-// CHECK-LABEL: sil public_external [serialized] @test2 : $@convention(thin) (Int) -> ()
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test2 : $@convention(thin) (Int) -> ()
 sil [serialized] @test2 : $@convention(thin) (Int) -> () {
   // CHECK: bb1:
   // CHECK: %[[VAL:[0-9]+]] = tuple ()
@@ -575,7 +575,7 @@ bb0(%0 : $*SomeProtocol):
   return %6 : $@thick SomeProtocol.Type
 }
 
-// CHECK-LABEL: sil public_external [serialized] @test_unreachable
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_unreachable
 sil [serialized] @test_unreachable : $@convention(thin) () -> () {
 bb0:
   unreachable
@@ -597,7 +597,7 @@ bb0(%0 : $SomeClass):
   return %5 : $()
 }
 
-// CHECK-LABEL: sil public_external [serialized] @test_basic_block_arguments
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_basic_block_arguments
 sil [serialized] @test_basic_block_arguments : $@convention(thin) (Builtin.Int1) -> Builtin.Word {
 bb0(%0 : $Builtin.Int1):
   // CHECK: cond_br
@@ -615,7 +615,7 @@ bb3(%6 : $Builtin.Word):
   return %6 : $Builtin.Word
 }
 
-// CHECK-LABEL: sil public_external [serialized] @test_cond_branch_basic_block_args
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_cond_branch_basic_block_args
 sil [serialized] @test_cond_branch_basic_block_args : $@convention(thin) (Int, Builtin.Int1) -> Int {
 bb0(%0 : $Int, %1 : $Builtin.Int1):
   cond_br %1, bb1(%0 : $Int), bb2(%0 : $Int)
@@ -628,7 +628,7 @@ bb3(%4 : $Int):
   return %4 : $Int
 }
 
-// CHECK-LABEL: sil public_external [serialized] @test_builtin_func_ref
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_builtin_func_ref
 sil [serialized] @test_builtin_func_ref : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> Builtin.Int1 {
 bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1):
   %2 = alloc_box $<τ_0_0> { var τ_0_0 } <Builtin.Int1>
@@ -646,7 +646,7 @@ bb0(%0 : $Builtin.Int1, %1 : $Builtin.Int1):
   return %10 : $Builtin.Int1
 }
 
-// CHECK-LABEL: sil public_external [serialized] @test_dealloc_ref
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_dealloc_ref
 sil [serialized] @test_dealloc_ref : $@convention(thin) () -> () {
 bb0:
   %0 = alloc_ref $Class1
@@ -655,7 +655,7 @@ bb0:
   return %2 : $()
 }
 
-// CHECK-LABEL: sil public_external [serialized] @test_dealloc_partial_ref
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_dealloc_partial_ref
 sil [serialized] @test_dealloc_partial_ref : $@convention(thin) () -> () {
 bb0:
   %0 = alloc_ref $Class1
@@ -665,7 +665,7 @@ bb0:
   return %2 : $()
 }
 
-// CHECK-LABEL: sil public_external [serialized] @test_dealloc_box
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_dealloc_box
 sil [serialized] @test_dealloc_box : $@convention(thin) () -> () {
 bb0:
   %0 = alloc_box $<τ_0_0> { var τ_0_0 } <Class1>
@@ -674,7 +674,7 @@ bb0:
   return %2 : $()
 }
 
-// CHECK-LABEL: sil public_external [serialized] @test_stack_flag
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_stack_flag
 sil [serialized] @test_stack_flag : $@convention(thin) () -> () {
 bb0:
   // CHECK: alloc_ref [stack] $Class1
@@ -685,7 +685,7 @@ bb0:
   return %2 : $()
 }
 
-// CHECK-LABEL: sil public_external [serialized] @test_tail_elems
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_tail_elems
 sil [serialized] @test_tail_elems : $@convention(thin) (Builtin.Word, Builtin.Word) -> () {
 bb0(%0 : $Builtin.Word, %1 : $Builtin.Word):
   // CHECK: alloc_ref  [tail_elems $Val * %0 : $Builtin.Word] [tail_elems $Aleph * %1 : $Builtin.Word] $Class1
@@ -696,7 +696,7 @@ bb0(%0 : $Builtin.Word, %1 : $Builtin.Word):
   return %3 : $()
 }
 
-// CHECK-LABEL: sil public_external [serialized] @test_tail_elems_dynamic
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_tail_elems_dynamic
 sil [serialized] @test_tail_elems_dynamic : $@convention(thin) (Builtin.Word, Builtin.Word, @thick Class1.Type) -> () {
 bb0(%0 : $Builtin.Word, %1 : $Builtin.Word, %2 : $@thick Class1.Type):
   // CHECK: alloc_ref_dynamic  [tail_elems $Val * %0 : $Builtin.Word] [tail_elems $Aleph * %1 : $Builtin.Word] %2 : $@thick Class1
@@ -707,7 +707,7 @@ bb0(%0 : $Builtin.Word, %1 : $Builtin.Word, %2 : $@thick Class1.Type):
   return %4 : $()
 }
 
-// CHECK-LABEL: sil public_external [serialized] @test_tail_addr
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_tail_addr
 sil [serialized] @test_tail_addr : $@convention(thin) (@owned Class1, Builtin.Word) -> @owned Class1 {
 bb0(%0 : $Class1, %1 : $Builtin.Word):
   // CHECK: [[T:%[0-9]+]] = ref_tail_addr %0 : $Class1, $Val
@@ -748,7 +748,7 @@ sil [serialized] @$S6switch1ayyF : $@convention(thin) () -> ()
 sil [serialized] @$S6switch1byyF : $@convention(thin) () -> ()
 sil [serialized] @$S6switch1cyyF : $@convention(thin) () -> ()
 
-// CHECK-LABEL: sil public_external [serialized] @test_switch_union : $@convention(thin) (MaybePair) -> ()
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_switch_union : $@convention(thin) (MaybePair) -> ()
 sil [serialized] @test_switch_union : $@convention(thin) (MaybePair) -> () {
 bb0(%0 : $MaybePair):
   %1 = alloc_box $<τ_0_0> { var τ_0_0 } <MaybePair>
@@ -791,7 +791,7 @@ enum MaybeAddressOnlyPair {
   case Left(Q)
 }
 
-// CHECK-LABEL: sil public_external [serialized] @test_switch_union_addr : $@convention(thin) (@in MaybeAddressOnlyPair) -> ()
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_switch_union_addr : $@convention(thin) (@in MaybeAddressOnlyPair) -> ()
 sil [serialized] @test_switch_union_addr : $@convention(thin) (@in MaybeAddressOnlyPair) -> () {
 bb0(%0 : $*MaybeAddressOnlyPair):
   // CHECK: switch_enum_addr [[ENUM:%.*]] : $*MaybeAddressOnlyPair, case #MaybeAddressOnlyPair.Neither!enumelt: bb{{.*}}, case #MaybeAddressOnlyPair.Left!enumelt.1: bb
@@ -810,7 +810,7 @@ bb3:
   return %t : $()
 }
 
-// CHECK-LABEL: sil public_external [serialized] @test_switch_value : $@convention(thin) (Builtin.Word) -> ()
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_switch_value : $@convention(thin) (Builtin.Word) -> ()
 sil [serialized] @test_switch_value : $@convention(thin) (Builtin.Word) -> () {
 bb0(%0 : $Builtin.Word):
   // CHECK: switch_value %{{.*}} : $Builtin.Word, case %1: bb2, case %2: bb1
@@ -838,7 +838,7 @@ class ConcreteClass : ClassP {
 struct Spoon : Bendable {
 }
 
-// CHECK-LABEL: sil public_external [serialized] @test_init_existential : $@convention(thin) (Spoon) -> @out Bendable
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_init_existential : $@convention(thin) (Spoon) -> @out Bendable
 sil [serialized] @test_init_existential : $@convention(thin) (Spoon) -> @out Bendable {
 bb0(%0 : $*Bendable, %1 : $Spoon):
   %2 = alloc_box $<τ_0_0> { var τ_0_0 } <Spoon>
@@ -855,7 +855,7 @@ bb0(%0 : $*Bendable, %1 : $Spoon):
   return %8 : $()
 }
 
-// CHECK-LABEL: sil public_external [serialized] @test_existential_ref : $@convention(thin) (ConcreteClass) -> ClassP
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_existential_ref : $@convention(thin) (ConcreteClass) -> ClassP
 sil [serialized] @test_existential_ref : $@convention(thin) (ConcreteClass) -> ClassP {
 bb0(%0 : $ConcreteClass):
   %1 = alloc_box $<τ_0_0> { var τ_0_0 } <ConcreteClass>
@@ -869,13 +869,13 @@ bb0(%0 : $ConcreteClass):
   return %5 : $ClassP
 }
 
-sil [serialized] @test_assign : $@convention(thin) (Int, @inout Int) -> () {    // CHECK-LABEL: sil public_external [serialized] @test_assign
+sil [serialized] @test_assign : $@convention(thin) (Int, @inout Int) -> () {    // CHECK-LABEL: sil public_external [serialized] [canonical] @test_assign
 bb0(%0 : $Int, %1 : $*Int):
   assign %0 to %1 : $*Int                   // CHECK: assign
   unreachable
 }
 
-// CHECK-LABEL: sil public_external [serialized] @test_transparent : $@convention(thin) () -> () {
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_transparent : $@convention(thin) () -> () {
 sil [serialized] @test_transparent : $@convention(thin) () -> () {
 bb0:
   // CHECK: function_ref
@@ -886,14 +886,14 @@ bb0:
   return %2 : $()
 }
 
-// CHECK-LABEL: sil public_external [serialized] [thunk] @test_thunk : $@convention(thin) () -> () {
+// CHECK-LABEL: sil public_external [serialized] [thunk] [canonical] @test_thunk : $@convention(thin) () -> () {
 sil [serialized] [thunk] @test_thunk : $@convention(thin) () -> () {
 bb0:
   %0 = tuple ()
   return %0 : $()
 }
 
-// CHECK-LABEL: [noinline] @noinline_callee
+// CHECK-LABEL: [noinline] [canonical] @noinline_callee
 sil [serialized] [noinline] @noinline_callee : $@convention(thin) () -> Int {
 bb0:
   %0 = function_ref @$SSi33_convertFromBuiltinIntegerLiteralySiBi2048_cSimF : $@convention(thin) (Builtin.Int2048, @thin Int.Type) -> Int
@@ -902,7 +902,7 @@ bb0:
   %3 = apply %0(%2, %1) : $@convention(thin) (Builtin.Int2048, @thin Int.Type) -> Int
   return %3 : $Int
 }
-// CHECK-LABEL: [always_inline] @always_inline_callee
+// CHECK-LABEL: [always_inline] [canonical] @always_inline_callee
 sil [serialized] [always_inline] @always_inline_callee : $@convention(thin) () -> Int {
 bb0:
   %0 = function_ref @$SSi33_convertFromBuiltinIntegerLiteralySiBi2048_cSimF : $@convention(thin) (Builtin.Int2048, @thin Int.Type) -> Int
@@ -913,28 +913,28 @@ bb0:
 }
 sil [serialized] [transparent] @$SSi33_convertFromBuiltinIntegerLiteralySiBi2048_cSimF : $@convention(thin) (Builtin.Int2048, @thin Int.Type) -> Int
 
-// CHECK-LABEL: [_semantics "foo"] @test_semantics : $@convention(thin) () -> ()
+// CHECK-LABEL: [_semantics "foo"] [canonical] @test_semantics : $@convention(thin) () -> ()
 sil [serialized] [_semantics "foo"] @test_semantics : $@convention(thin) () -> () {
 bb0:
   %2 = tuple ()
   return %2 : $()
 }
 
-// CHECK-LABEL: [Onone] @test_onone : $@convention(thin) () -> ()
+// CHECK-LABEL: [Onone] [canonical] @test_onone : $@convention(thin) () -> ()
 sil [serialized] [Onone] @test_onone : $@convention(thin) () -> () {
 bb0:
   %2 = tuple ()
   return %2 : $()
 }
 
-// CHECK-LABEL: [Ospeed] @test_ospeed : $@convention(thin) () -> ()
+// CHECK-LABEL: [Ospeed] [canonical] @test_ospeed : $@convention(thin) () -> ()
 sil [serialized] [Ospeed] @test_ospeed : $@convention(thin) () -> () {
 bb0:
   %2 = tuple ()
   return %2 : $()
 }
 
-// CHECK-LABEL: [Osize] @test_osize : $@convention(thin) () -> ()
+// CHECK-LABEL: [Osize] [canonical] @test_osize : $@convention(thin) () -> ()
 sil [serialized] [Osize] @test_osize : $@convention(thin) () -> () {
 bb0:
   %2 = tuple ()
@@ -945,7 +945,7 @@ sil [serialized] @takes_unnamed_closure : $@convention(thin) (@callee_owned () -
 
 sil [serialized] @takes_int64_float32 : $@convention(thin) (Int, Float32) -> ()
 
-// CHECK-LABEL: sil public_external [serialized] @test_partial_apply : $@convention(thin) (Float) -> @callee_owned (Int) -> () {
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_partial_apply : $@convention(thin) (Float) -> @callee_owned (Int) -> () {
 sil [serialized] @test_partial_apply : $@convention(thin) Float32 -> @callee_owned Int -> () {
 bb0(%0 : $Float32):
   %1 = function_ref @takes_int64_float32 : $@convention(thin) (Int, Float) -> ()
@@ -958,7 +958,7 @@ class X {
   @objc func f() { }
 }
 
-// CHECK-LABEL: sil public_external [serialized] @test_dynamic_lookup_br : $@convention(thin) (AnyObject) -> ()
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_dynamic_lookup_br : $@convention(thin) (AnyObject) -> ()
 sil [serialized] @test_dynamic_lookup_br : $@convention(thin) (AnyObject) -> () {
 bb0(%0 : $AnyObject):
   %1 = alloc_box $<τ_0_0> { var τ_0_0 } <AnyObject>
@@ -983,7 +983,7 @@ bb3:
   return %28 : $()
 }
 
-// CHECK-LABEL: sil public_external [serialized] @test_mark_fn_escape
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_mark_fn_escape
 sil [serialized] @test_mark_fn_escape : $@convention(thin) () -> () {
   %b = alloc_box $<τ_0_0> { var τ_0_0 } <Int>
   %ba = project_box %b : $<τ_0_0> { var τ_0_0 } <Int>, 0
@@ -997,7 +997,7 @@ sil [serialized] @test_mark_fn_escape : $@convention(thin) () -> () {
   return %28 : $()
 }
 
-// CHECK-LABEL: sil public_external [serialized] @test_copy_release_value
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_copy_release_value
 sil [serialized] @test_copy_release_value : $@convention(thin) (X) -> (X) {
 bb0(%0 : $X):
   retain_value %0 : $X
@@ -1010,7 +1010,7 @@ bb0(%0 : $X):
   // CHECK-NEXT: return [[T0]] : $X
 }
 
-// CHECK-LABEL: sil public_external [serialized] @test_set_deallocating
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_set_deallocating
 sil [serialized] @test_set_deallocating : $@convention(thin) (X) -> (X) {
 bb0(%0 : $X):
   set_deallocating %0 : $X
@@ -1019,7 +1019,7 @@ bb0(%0 : $X):
   // CHECK-NEXT: return [[T0]] : $X
 }
 
-// CHECK-LABEL: sil public_external [serialized] @test_pointer_to_address
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_pointer_to_address
 sil [serialized] @test_pointer_to_address : $@convention(thin) (Builtin.RawPointer, X) -> () {
 bb0(%0 : $Builtin.RawPointer, %1 : $X):
   %2 = pointer_to_address %0 : $Builtin.RawPointer to $*X
@@ -1034,7 +1034,7 @@ bb0(%0 : $Builtin.RawPointer, %1 : $X):
   return %28 : $()
 }
 
-// CHECK-LABEL: sil public_external [serialized] @test_bind_memory
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_bind_memory
 sil [serialized] @test_bind_memory : $@convention(thin) (Builtin.RawPointer, Builtin.Word) -> () {
 bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
   bind_memory %0 : $Builtin.RawPointer, %1 : $Builtin.Word to $*X
@@ -1046,7 +1046,7 @@ bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
 public func serialize_all() {
 }
 
-// CHECK: sil public_external [serialized] @cond_fail_test : $@convention(thin) (Builtin.Int1) -> () {
+// CHECK: sil public_external [serialized] [canonical] @cond_fail_test : $@convention(thin) (Builtin.Int1) -> () {
 sil [serialized] @cond_fail_test : $@convention(thin) Builtin.Int1 -> () {
 entry(%0 : $Builtin.Int1):
   // CHECK: cond_fail %0 : $Builtin.Int1
@@ -1055,7 +1055,7 @@ entry(%0 : $Builtin.Int1):
   return %1 : $()
 }
 
-// CHECK-LABEL: sil public_external [serialized] @block_storage_type
+// CHECK-LABEL: sil public_external [serialized] [canonical] @block_storage_type
 sil [serialized] @block_storage_type : $@convention(thin) Int -> @convention(block) () -> () {
 entry(%0 : $Int):
   // CHECK: [[STORAGE:%.*]] = alloc_stack $@block_storage Int
@@ -1074,7 +1074,7 @@ entry(%0 : $Int):
   return %b : $@convention(block) () -> ()
 }
 
-// CHECK-LABEL: sil public_external [serialized] @bitcasts : $@convention(thin) (@owned Class1) -> @owned (Class2, Int) {
+// CHECK-LABEL: sil public_external [serialized] [canonical] @bitcasts : $@convention(thin) (@owned Class1) -> @owned (Class2, Int) {
 // CHECK:  bb0(%0 : $Class1):
 // CHECK-NEXT:    %1 = unchecked_ref_cast %0 : $Class1 to $Class2
 // CHECK-NEXT:    %2 = unchecked_trivial_bit_cast %0 : $Class1 to $Int
@@ -1093,7 +1093,7 @@ sil [serialized] @block_invoke : $@convention(c) (@inout_aliasable @block_storag
 
 // Test try_apply and throws
 // rdar://20925014
-// CHECK-LABEL: sil public_external [serialized] @test_try_apply : $@convention(thin) (@convention(thin) () -> @error Error) -> @error Error {
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_try_apply : $@convention(thin) (@convention(thin) () -> @error Error) -> @error Error {
 sil [serialized]  @test_try_apply : $@convention(thin) (@convention(thin) () -> @error Error) -> @error Error {
 bb0(%0 : $@convention(thin) () -> @error Error):
   // CHECK: try_apply %0() : $@convention(thin) () -> @error Error, normal bb2, error bb1
@@ -1108,7 +1108,7 @@ bb2(%3 : $Error):
 }
 
 // Test apply with the nothrow attribute
-// CHECK-LABEL: sil public_external [serialized] @test_try_nothrow : $@convention(thin) (@convention(thin) () -> @error Error) -> () {
+// CHECK-LABEL: sil public_external [serialized] [canonical] @test_try_nothrow : $@convention(thin) (@convention(thin) () -> @error Error) -> () {
 sil [serialized]  @test_try_nothrow : $@convention(thin) (@convention(thin) () -> @error Error) -> () {
 bb0(%0 : $@convention(thin) () -> @error Error):
   // CHECK: apply [nothrow] %0() : $@convention(thin) () -> @error Error
@@ -1117,7 +1117,7 @@ bb0(%0 : $@convention(thin) () -> @error Error):
   return %2 : $()
 }
 
-// CHECK-LABEL: sil public_external [serialized] @box_type : $@convention(thin) (<τ_0_0> { var τ_0_0 } <Int>, Int) -> () {
+// CHECK-LABEL: sil public_external [serialized] [canonical] @box_type : $@convention(thin) (<τ_0_0> { var τ_0_0 } <Int>, Int) -> () {
 sil [serialized] @box_type : $@convention(thin) (<τ_0_0> { var τ_0_0 } <Int>, Int) -> () {
 // CHECK: bb0(%0 : $<τ_0_0> { var τ_0_0 } <Int>, %1 : $Int):
 bb0(%0 : $<τ_0_0> { var τ_0_0 } <Int>, %1 : $Int):
@@ -1136,7 +1136,7 @@ bb0(%0 : $<τ_0_0> { var τ_0_0 } <Int>, %1 : $Int):
 // CHECK-LABEL: @test_forward_ref
 sil [serialized]  @test_forward_ref : $@convention(thin) (UInt8, UInt8) -> UInt8
 
-// CHECK-LABEL: sil public_external [serialized] @partial_apply : $@convention(thin) (@convention(thin) (Int) -> @out Int, Int) -> Int {
+// CHECK-LABEL: sil public_external [serialized] [canonical] @partial_apply : $@convention(thin) (@convention(thin) (Int) -> @out Int, Int) -> Int {
 // CHECK: [[PA:%.*]] = partial_apply {{%.*}}({{%.*}}) : $@convention(thin) (Int) -> @out Int
 // CHECK: apply [[PA]]({{%.*}}) : $@callee_owned () -> @out Int
 sil [serialized] @partial_apply : $@convention(thin) (@convention(thin) (Int) -> @out Int, Int) -> Int {
@@ -1188,7 +1188,7 @@ entry(%0 : $GenericStruct<Int64>):
   return %1 : $Int64
 }
 
-// CHECK-LABEL: sil public_external [serialized] @select_enum : $@convention(thin) (@in Beth) -> () {
+// CHECK-LABEL: sil public_external [serialized] [canonical] @select_enum : $@convention(thin) (@in Beth) -> () {
 sil [serialized] @select_enum : $@convention(thin) (@in Beth) -> () {
 bb0(%0 : $*Beth):
   %1 = load %0 : $*Beth
@@ -1210,7 +1210,7 @@ struct SomeError: Error {
   var _code: Int { get }
 }
 
-// CHECK-LABEL: sil public_external [serialized] @existential_box : $@convention(thin) (SomeError) -> () {
+// CHECK-LABEL: sil public_external [serialized] [canonical] @existential_box : $@convention(thin) (SomeError) -> () {
 sil [serialized] @existential_box : $@convention(thin) (SomeError) -> () {
 bb0(%0 : $SomeError):
   // CHECK: %1 = alloc_existential_box $Error, $SomeError
@@ -1228,7 +1228,7 @@ bb0(%0 : $SomeError):
   return undef : $()
 }
 
-// CHECK-LABEL: sil public_external [serialized] @bridge_object : $@convention(thin) (@owned Class1, Builtin.Word) -> () {
+// CHECK-LABEL: sil public_external [serialized] [canonical] @bridge_object : $@convention(thin) (@owned Class1, Builtin.Word) -> () {
 // CHECK:  bb0([[X:%.*]] : $Class1, [[W:%.*]] : $Builtin.Word):
 // CHECK-NEXT:    [[A:%.*]] = ref_to_bridge_object [[X]] : $Class1, [[W]] : $Builtin.Word
 // CHECK-NEXT:    [[B:%.*]] = bridge_object_to_ref [[A]] : $Builtin.BridgeObject to $Class1
@@ -1242,12 +1242,12 @@ entry(%x : $Class1, %w : $Builtin.Word):
   return undef : $()
 }
 
-// CHECK-LABEL: sil {{.*}}[reabstraction_thunk] @a_reabstraction_thunk : $@convention(thin) () -> ()
+// CHECK-LABEL: sil {{.*}}[reabstraction_thunk] [canonical] @a_reabstraction_thunk : $@convention(thin) () -> ()
 sil [reabstraction_thunk] @a_reabstraction_thunk : $@convention(thin) () -> () {
   %1 = tuple()
   return %1 : $()
 }
-// CHECK-LABEL: sil {{.*}}[thunk] @a_regular_thunk : $@convention(thin) () -> () {
+// CHECK-LABEL: sil {{.*}}[thunk] [canonical] @a_regular_thunk : $@convention(thin) () -> () {
 sil [serialized] [thunk] @a_regular_thunk : $@convention(thin) () -> () {
   %1 = tuple()
   return %1 : $()
@@ -1260,7 +1260,7 @@ public class WeakUnownedTest {
   deinit
 }
 
-// CHECK-LABEL: sil public_external [serialized] @weak_unowned : $@convention(thin) (@owned WeakUnownedTest, @owned AnyObject) -> ()
+// CHECK-LABEL: sil public_external [serialized] [canonical] @weak_unowned : $@convention(thin) (@owned WeakUnownedTest, @owned AnyObject) -> ()
 sil [serialized] @weak_unowned : $@convention(thin) (@owned WeakUnownedTest, @owned AnyObject) -> () {
 bb0(%0 : $WeakUnownedTest, %1 : $AnyObject):
   %2 = ref_element_addr %0 : $WeakUnownedTest, #WeakUnownedTest.unownedVal
@@ -1285,8 +1285,8 @@ public class Foo {
   init()
 }
 
-// CHECK-LABEL: sil [serialized] @$S3tmp3FooC9subscriptSiSi1x_Si1ytcfg : $@convention(method) (Int, Int, @guaranteed Foo) -> Int32
-// CHECK_DECL-LABEL: sil [serialized] @$S3tmp3FooC9subscriptSiSi1x_Si1ytcfg : $@convention(method) (Int, Int, @guaranteed Foo) -> Int32{{$}}
+// CHECK-LABEL: sil [serialized] [canonical] @$S3tmp3FooC9subscriptSiSi1x_Si1ytcfg : $@convention(method) (Int, Int, @guaranteed Foo) -> Int32
+// CHECK_DECL-LABEL: sil [serialized] [canonical] @$S3tmp3FooC9subscriptSiSi1x_Si1ytcfg : $@convention(method) (Int, Int, @guaranteed Foo) -> Int32{{$}}
 sil [serialized] @$S3tmp3FooC9subscriptSiSi1x_Si1ytcfg : $@convention(method) (Int, Int, @guaranteed Foo) -> Int32 {
 bb0(%0 : $Int, %1 : $Int, %2 : $Foo):
   %3 = tuple ()
@@ -1306,8 +1306,8 @@ bb0(%0 : $Int, %1 : $Int, %2 : $Foo):
   return %13 : $Int32
 }
 
-// CHECK-LABEL: sil [serialized] @$S3tmp3FooC9subscriptSiSi1x_Si1ytcfs : $@convention(method) (Int32, Int, Int, @guaranteed Foo) -> ()
-// CHECK_DECL-LABEL: sil [serialized] @$S3tmp3FooC9subscriptSiSi1x_Si1ytcfs : $@convention(method) (Int32, Int, Int, @guaranteed Foo) -> (){{$}}
+// CHECK-LABEL: sil [serialized] [canonical] @$S3tmp3FooC9subscriptSiSi1x_Si1ytcfs : $@convention(method) (Int32, Int, Int, @guaranteed Foo) -> ()
+// CHECK_DECL-LABEL: sil [serialized] [canonical] @$S3tmp3FooC9subscriptSiSi1x_Si1ytcfs : $@convention(method) (Int32, Int, Int, @guaranteed Foo) -> (){{$}}
 sil [serialized] @$S3tmp3FooC9subscriptSiSi1x_Si1ytcfs : $@convention(method) (Int32, Int, Int, @guaranteed Foo) -> () {
 bb0(%0 : $Int32, %1 : $Int, %2 : $Int, %3 : $Foo):
   %4 = alloc_stack $Int32  // var value         // users: %16, %5

--- a/test/Serialization/Inputs/def_basic_objc.sil
+++ b/test/Serialization/Inputs/def_basic_objc.sil
@@ -31,7 +31,7 @@ sil [serialized] @$SSSSSycSSmcfC : $@convention(thin) (@thin String.Type) -> @ow
 
 protocol SomeClassProtocol : class {}
 
-// CHECK-LABEL: sil public_external [serialized] @metatype_to_object
+// CHECK-LABEL: sil public_external [serialized] [canonical] @metatype_to_object
 // CHECK:         {{%.*}} = objc_metatype_to_object {{%.*}} : $@objc_metatype SomeClass.Type to $AnyObject
 // CHECK:         {{%.*}} = objc_existential_metatype_to_object {{%.*}} : $@objc_metatype SomeClassProtocol.Type to $AnyObject
 sil [serialized] @metatype_to_object : $@convention(thin) (@objc_metatype SomeClass.Type, @objc_metatype SomeClassProtocol.Type) -> @owned (AnyObject, AnyObject) {
@@ -44,7 +44,7 @@ entry(%a : $@objc_metatype SomeClass.Type, %b : $@objc_metatype SomeClassProtoco
 
 @objc protocol ObjCProto {}
 
-// CHECK-LABEL: sil public_external [serialized] @protocol_conversion
+// CHECK-LABEL: sil public_external [serialized] [canonical] @protocol_conversion
 sil [serialized] @protocol_conversion : $@convention(thin) () -> @owned Protocol {
 entry:
   // CHECK: {{%.*}} = objc_protocol #ObjCProto : $Protocol

--- a/test/Serialization/always_inline.swift
+++ b/test/Serialization/always_inline.swift
@@ -19,7 +19,7 @@ var raw = testAlwaysInline(x: false)
 
 var a = AlwaysInlineInitStruct(x: false)
 
-// SIL-LABEL: [always_inline] @$S17def_always_inline16testAlwaysInline1xS2b_tF : $@convention(thin) (Bool) -> Bool
+// SIL-LABEL: [always_inline] [canonical] @$S17def_always_inline16testAlwaysInline1xS2b_tF : $@convention(thin) (Bool) -> Bool
 
-// SIL-LABEL: sil public_external [serialized] [always_inline] @$S17def_always_inline22AlwaysInlineInitStructV1xACSb_tcfC : $@convention(method) (Bool, @thin AlwaysInlineInitStruct.Type) -> AlwaysInlineInitStruct {
+// SIL-LABEL: sil public_external [serialized] [always_inline] [canonical] @$S17def_always_inline22AlwaysInlineInitStructV1xACSb_tcfC : $@convention(method) (Bool, @thin AlwaysInlineInitStruct.Type) -> AlwaysInlineInitStruct {
 

--- a/test/Serialization/class-roundtrip-module.swift
+++ b/test/Serialization/class-roundtrip-module.swift
@@ -3,4 +3,4 @@
 // RUN: %target-swift-frontend -emit-module -parse-as-library -o %t/def_class.swiftmodule %t/stage1.swiftmodule
 // RUN: %target-swift-frontend -emit-sil -sil-debug-serialization -I %t %S/class.swift | %FileCheck %s -check-prefix=SIL
 
-// SIL-LABEL: sil public_external [transparent] [serialized] @$SSi1poiyS2i_SitFZ : $@convention(method) (Int, Int, @thin Int.Type) -> Int
+// SIL-LABEL: sil public_external [transparent] [serialized] [canonical] @$SSi1poiyS2i_SitFZ : $@convention(method) (Int, Int, @thin Int.Type) -> Int

--- a/test/Serialization/class.swift
+++ b/test/Serialization/class.swift
@@ -76,7 +76,7 @@ var rsrc = Resource()
 
 getReqPairLike()
 
-// SIL-LABEL: sil public_external [transparent] [serialized] @$SSi1poiyS2i_SitFZ : $@convention(method) (Int, Int, @thin Int.Type) -> Int
+// SIL-LABEL: sil public_external [transparent] [serialized] [canonical] @$SSi1poiyS2i_SitFZ : $@convention(method) (Int, Int, @thin Int.Type) -> Int
 
 func test(_ sharer: ResourceSharer) {}
 

--- a/test/Serialization/early-serialization.swift
+++ b/test/Serialization/early-serialization.swift
@@ -13,10 +13,10 @@ public struct Int {
 }
 
 // Check that a specialized version of a function is produced
-// CHECK: sil shared [serializable] [_semantics "array.get_capacity"] @$SSa12_getCapacitySiyFSi_Tgq5 : $@convention(method) (Array<Int>) -> Int
+// CHECK: sil shared [serializable] [_semantics "array.get_capacity"] [canonical] @$SSa12_getCapacitySiyFSi_Tgq5 : $@convention(method) (Array<Int>) -> Int
 
 // Check that a call of a @_semantics function was not inlined if early-serialization is enabled.
-// CHECK: sil [serialized] @$Ss28userOfSemanticsAnnotatedFuncySiSaySiGF
+// CHECK: sil [serialized] [canonical] @$Ss28userOfSemanticsAnnotatedFuncySiSaySiGF
 // CHECK: function_ref
 // CHECK: apply
 @_inlineable
@@ -30,7 +30,7 @@ public struct Array<T> {
   public init() {}
 
   // Check that the generic version of a @_semantics function is preserved.
-  // CHECK: sil [serialized] [_semantics "array.get_capacity"] @$SSa12_getCapacitySiyF : $@convention(method) <T> (Array<T>) -> Int
+  // CHECK: sil [serialized] [_semantics "array.get_capacity"] [canonical] @$SSa12_getCapacitySiyF : $@convention(method) <T> (Array<T>) -> Int
   @_inlineable
   @_versioned
   @_semantics("array.get_capacity")

--- a/test/Serialization/global_init.swift
+++ b/test/Serialization/global_init.swift
@@ -20,8 +20,8 @@ var MyVar = 3
 // CHECK: let MyConst: Int
 // CHECK: var MyVar: Int
 
-// CHECK-DAG: sil [global_init] @$S11global_init7MyConstSivau : $@convention(thin) () -> Builtin.RawPointer
-// CHECK-DAG: sil [global_init] @$S11global_init5MyVarSivau : $@convention(thin) () -> Builtin.RawPointer
+// CHECK-DAG: sil [global_init] [canonical] @$S11global_init7MyConstSivau : $@convention(thin) () -> Builtin.RawPointer
+// CHECK-DAG: sil [global_init] [canonical] @$S11global_init5MyVarSivau : $@convention(thin) () -> Builtin.RawPointer
 
 @_inlineable
 @_versioned

--- a/test/Serialization/noinline.swift
+++ b/test/Serialization/noinline.swift
@@ -19,6 +19,6 @@ var raw = testNoinline(x: false)
 
 var a = NoInlineInitStruct(x: false)
 
-// SIL-LABEL: [serialized] [noinline] @$S12def_noinline12testNoinline1xS2b_tF : $@convention(thin) (Bool) -> Bool
+// SIL-LABEL: [serialized] [noinline] [canonical] @$S12def_noinline12testNoinline1xS2b_tF : $@convention(thin) (Bool) -> Bool
 
-// SIL-LABEL: sil public_external [serialized] [noinline] @$S12def_noinline18NoInlineInitStructV1xACSb_tcfC : $@convention(method) (Bool, @thin NoInlineInitStruct.Type) -> NoInlineInitStruct {
+// SIL-LABEL: sil public_external [serialized] [noinline] [canonical] @$S12def_noinline18NoInlineInitStructV1xACSb_tcfC : $@convention(method) (Bool, @thin NoInlineInitStruct.Type) -> NoInlineInitStruct {

--- a/test/Serialization/serialize_attr.swift
+++ b/test/Serialization/serialize_attr.swift
@@ -78,6 +78,6 @@ public class CC<T : PP> {
   }
 }
 
-// CHECK-DAG: sil [serialized] [_specialize exported: false, kind: full, where T == Int, U == Float] @$S14serialize_attr14specializeThis_1uyx_q_tr0_lF : $@convention(thin) <T, U> (@in T, @in U) -> () {
+// CHECK-DAG: sil [serialized] [_specialize exported: false, kind: full, where T == Int, U == Float] [canonical] @$S14serialize_attr14specializeThis_1uyx_q_tr0_lF : $@convention(thin) <T, U> (@in T, @in U) -> () {
 
-// CHECK-DAG: sil [serialized] [noinline] [_specialize exported: false, kind: full, where T == RR, U == SS] @$S14serialize_attr2CCC3foo_1gqd___AA2GGVyxGtqd___AHtAA2QQRd__lF : $@convention(method) <T where T : PP><U where U : QQ> (@in U, GG<T>, @guaranteed CC<T>) -> (@out U, GG<T>) {
+// CHECK-DAG: sil [serialized] [noinline] [_specialize exported: false, kind: full, where T == RR, U == SS] [canonical] @$S14serialize_attr2CCC3foo_1gqd___AA2GGVyxGtqd___AHtAA2QQRd__lF : $@convention(method) <T where T : PP><U where U : QQ> (@in U, GG<T>, @guaranteed CC<T>) -> (@out U, GG<T>) {

--- a/test/Serialization/transparent-std.swift
+++ b/test/Serialization/transparent-std.swift
@@ -7,14 +7,14 @@
 
 import def_transparent_std
 
-// SIL-LABEL: sil public_external [transparent] [serialized] @$S19def_transparent_std3foo1x1yBi1_Bi1__Bi1_tF : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> Builtin.Int1 {
+// SIL-LABEL: sil public_external [transparent] [serialized] [canonical] @$S19def_transparent_std3foo1x1yBi1_Bi1__Bi1_tF : $@convention(thin) (Builtin.Int1, Builtin.Int1) -> Builtin.Int1 {
 // SIL: = builtin "cmp_eq_Int1"(%0 : $Builtin.Int1, %1 : $Builtin.Int1) : $Builtin.Int1
 func test_foo(x: Builtin.Int1, y: Builtin.Int1) -> Builtin.Int1 {
   var a = foo(x: x, y: y)
   return a
 }
 
-// SIL-LABEL: sil public_external [transparent] [serialized] @$S19def_transparent_std12assign_tuple1x1yyBi64__Bot_BptF : $@convention(thin) (Builtin.Int64, @owned Builtin.NativeObject, Builtin.RawPointer) -> () {
+// SIL-LABEL: sil public_external [transparent] [serialized] [canonical] @$S19def_transparent_std12assign_tuple1x1yyBi64__Bot_BptF : $@convention(thin) (Builtin.Int64, @owned Builtin.NativeObject, Builtin.RawPointer) -> () {
 // SIL: = tuple (%0 : $Builtin.Int64, %1 : $Builtin.NativeObject)
 // SIL: retain_value
 // SIL: = tuple_extract
@@ -28,29 +28,29 @@ func test_tuple(x: (Builtin.Int64, Builtin.NativeObject),
 }
 
 func test_conversion(c: C, t32: Builtin.Int32) {
-// SIL-LABEL: sil public_external [transparent] [serialized] @$S19def_transparent_std22class_to_native_object1cBoAA1CC_tF : $@convention(thin) (@owned C) -> @owned Builtin.NativeObject {
+// SIL-LABEL: sil public_external [transparent] [serialized] [canonical] @$S19def_transparent_std22class_to_native_object1cBoAA1CC_tF : $@convention(thin) (@owned C) -> @owned Builtin.NativeObject {
 // SIL: bb0(%0 : $C):
 // SIL: unchecked_ref_cast %0 : $C to $Builtin.NativeObject
 // SIL-NEXT: return
   var b = class_to_native_object(c: c)
 
-// SIL-LABEL: sil public_external [transparent] [serialized] @$S19def_transparent_std24class_from_native_object1pAA1CCBo_tF : $@convention(thin) (@owned Builtin.NativeObject) -> @owned C {
+// SIL-LABEL: sil public_external [transparent] [serialized] [canonical] @$S19def_transparent_std24class_from_native_object1pAA1CCBo_tF : $@convention(thin) (@owned Builtin.NativeObject) -> @owned C {
 // SIL: unchecked_ref_cast %0 : $Builtin.NativeObject to $C
   var c = class_from_native_object(p: b)
 
-// SIL-LABEL: sil public_external [transparent] [serialized] @$S19def_transparent_std20class_to_raw_pointer1cBpAA1CC_tF : $@convention(thin) (@owned C) -> Builtin.RawPointer {
+// SIL-LABEL: sil public_external [transparent] [serialized] [canonical] @$S19def_transparent_std20class_to_raw_pointer1cBpAA1CC_tF : $@convention(thin) (@owned C) -> Builtin.RawPointer {
 // SIL: ref_to_raw_pointer %0 : $C to $Builtin.RawPointer
   var d = class_to_raw_pointer(c: c)
 
-// SIL-LABEL: sil public_external [transparent] [serialized] @$S19def_transparent_std22class_from_raw_pointer1pAA1CCBp_tF : $@convention(thin) (Builtin.RawPointer) -> @owned C {
+// SIL-LABEL: sil public_external [transparent] [serialized] [canonical] @$S19def_transparent_std22class_from_raw_pointer1pAA1CCBp_tF : $@convention(thin) (Builtin.RawPointer) -> @owned C {
 // SIL: raw_pointer_to_ref %0 : $Builtin.RawPointer to $C
   var e = class_from_raw_pointer(p: d)
 
-// SIL-LABEL: sil public_external [transparent] [serialized] @$S19def_transparent_std5gep321p1iBpBp_Bi32_tF : $@convention(thin) (Builtin.RawPointer, Builtin.Int32) -> Builtin.RawPointer {
+// SIL-LABEL: sil public_external [transparent] [serialized] [canonical] @$S19def_transparent_std5gep321p1iBpBp_Bi32_tF : $@convention(thin) (Builtin.RawPointer, Builtin.Int32) -> Builtin.RawPointer {
 // SIL: index_raw_pointer %0 : $Builtin.RawPointer, %1 : $Builtin.Int32
   var f = gep32(p: d, i: t32)
 
-// SIL-LABEL: sil public_external [transparent] [serialized] @$S19def_transparent_std11destroy_obj1xyBp_tF : $@convention(thin) (Builtin.RawPointer) -> () {
+// SIL-LABEL: sil public_external [transparent] [serialized] [canonical] @$S19def_transparent_std11destroy_obj1xyBp_tF : $@convention(thin) (Builtin.RawPointer) -> () {
 // SIL: pointer_to_address %0 : $Builtin.RawPointer to [strict] $*Builtin.NativeObject
   destroy_obj(x: d)
 }

--- a/test/Serialization/transparent.swift
+++ b/test/Serialization/transparent.swift
@@ -20,17 +20,17 @@ var raw = testTransparent(x: false)
 // SIL: store [[RESULT2]] to [trivial] [[TMP]] : $*Int32
 var tmp = testBuiltin()
 
-// SIL-LABEL: sil public_external [transparent] [serialized] @$S15def_transparent15testTransparent1xS2b_tF : $@convention(thin) (Bool) -> Bool {
+// SIL-LABEL: sil public_external [transparent] [serialized] [canonical] @$S15def_transparent15testTransparent1xS2b_tF : $@convention(thin) (Bool) -> Bool {
 // SIL: bb0(%0 : $Bool):
 // SIL: return %0 : $Bool
 
-// SIL-LABEL: sil public_external [transparent] [serialized] @$S15def_transparent11testBuiltins5Int32VyF : $@convention(thin) () -> Int32 {
+// SIL-LABEL: sil public_external [transparent] [serialized] [canonical] @$S15def_transparent11testBuiltins5Int32VyF : $@convention(thin) () -> Int32 {
 // SIL: bb0:
 // SIL: integer_literal $Builtin.Int32, 300
 // SIL: string_literal utf8 "foo"
 // SIL: return %{{.*}} : $Int32
 
-// SIL-LABEL: sil public_external [transparent] [serialized] @$S15def_transparent7test_bryyF : $@convention(thin) () -> () {
+// SIL-LABEL: sil public_external [transparent] [serialized] [canonical] @$S15def_transparent7test_bryyF : $@convention(thin) () -> () {
 // SIL: bb{{.*}}:
 // SIL: cond_br %{{.*}}, bb{{.*}}, bb{{.*}}
 // SIL: bb{{.*}}:
@@ -39,7 +39,7 @@ func wrap_br() {
   test_br()
 }
 
-// SIL-LABEL: sil public_external [serialized] @$S15def_transparent9do_switch1uyAA9MaybePairO_tF : $@convention(thin) (@owned MaybePair) -> () {
+// SIL-LABEL: sil public_external [serialized] [canonical] @$S15def_transparent9do_switch1uyAA9MaybePairO_tF : $@convention(thin) (@owned MaybePair) -> () {
 // SIL: bb0(%0 : $MaybePair):
 // SIL: retain_value %0 : $MaybePair
 // SIL: switch_enum %0 : $MaybePair, case #MaybePair.Neither!enumelt: bb[[CASE1:[0-9]+]], case #MaybePair.Left!enumelt.1: bb[[CASE2:[0-9]+]], case #MaybePair.Right!enumelt.1: bb[[CASE3:[0-9]+]], case #MaybePair.Both!enumelt.1: bb[[CASE4:[0-9]+]]
@@ -51,10 +51,10 @@ func test_switch(u: MaybePair) {
   do_switch(u: u)
 }
 
-// SIL-LABEL: sil public_external [transparent] [serialized] @$S15def_transparent7WrapperV3ValACs5Int32V_tcfC : $@convention(method) (Int32, @thin Wrapper.Type) -> Wrapper {
-// SIL-LABEL: sil public_external [transparent] [serialized] @$S15def_transparent7WrapperV8getValue{{[_0-9a-zA-Z]*}}F : $@convention(method) (Wrapper) -> Int32 {
-// SIL-LABEL: sil public_external [transparent] [serialized] @$S15def_transparent7WrapperV10valueAgains5Int32Vvg : $@convention(method) (Wrapper) -> Int32 {
-// SIL-LABEL: sil public_external [transparent] [serialized] @$S15def_transparent7WrapperV13getValueAgain{{[_0-9a-zA-Z]*}}F : $@convention(method) (Wrapper) -> Int32 {
+// SIL-LABEL: sil public_external [transparent] [serialized] [canonical] @$S15def_transparent7WrapperV3ValACs5Int32V_tcfC : $@convention(method) (Int32, @thin Wrapper.Type) -> Wrapper {
+// SIL-LABEL: sil public_external [transparent] [serialized] [canonical] @$S15def_transparent7WrapperV8getValue{{[_0-9a-zA-Z]*}}F : $@convention(method) (Wrapper) -> Int32 {
+// SIL-LABEL: sil public_external [transparent] [serialized] [canonical] @$S15def_transparent7WrapperV10valueAgains5Int32Vvg : $@convention(method) (Wrapper) -> Int32 {
+// SIL-LABEL: sil public_external [transparent] [serialized] [canonical] @$S15def_transparent7WrapperV13getValueAgain{{[_0-9a-zA-Z]*}}F : $@convention(method) (Wrapper) -> Int32 {
 func test_wrapper() {
   var w = Wrapper(Val: 42)
   
@@ -64,7 +64,7 @@ func test_wrapper() {
   print(w.getValueAgain(), terminator: "")
 }
 
-// SIL-LABEL: sil public_external [transparent] [serialized] @$S15def_transparent17open_existentials1p2cpyAA1P_p_AA2CP_ptF
+// SIL-LABEL: sil public_external [transparent] [serialized] [canonical] @$S15def_transparent17open_existentials1p2cpyAA1P_p_AA2CP_ptF
 func test_open_existentials(p: P, cp: CP) {
   // SIL: open_existential_addr immutable_access [[EXIST:%[0-9]+]] : $*P to $*@opened([[N:".*"]]) P
   // SIL: open_existential_ref [[EXIST:%[0-9]+]] : $CP to $@opened([[M:".*"]]) CP

--- a/test/sil-func-extractor/load-serialized-sil.swift
+++ b/test/sil-func-extractor/load-serialized-sil.swift
@@ -12,9 +12,9 @@
 // CHECK-NEXT:  init
 // CHECK-NEXT: }
 
-// CHECK: sil @unknown : $@convention(thin) () -> ()
+// CHECK: sil [canonical] @unknown : $@convention(thin) () -> ()
 
-// CHECK-LABEL: sil [serialized] @$Ss1XV4testyyF : $@convention(method) (X) -> ()
+// CHECK-LABEL: sil [serialized] [canonical] @$Ss1XV4testyyF : $@convention(method) (X) -> ()
 // CHECK: bb0
 // CHECK-NEXT: function_ref
 // CHECK-NEXT: function_ref @unknown : $@convention(thin) () -> ()
@@ -36,9 +36,9 @@
 // SIB-CHECK-NEXT:  init
 // SIB-CHECK-NEXT: }
 
-// SIB-CHECK: sil @unknown : $@convention(thin) () -> ()
+// SIB-CHECK: sil [canonical] @unknown : $@convention(thin) () -> ()
 
-// SIB-CHECK-LABEL: sil [serialized] @$Ss1XV4testyyF : $@convention(method) (X) -> ()
+// SIB-CHECK-LABEL: sil [serialized] [canonical] @$Ss1XV4testyyF : $@convention(method) (X) -> ()
 // SIB-CHECK: bb0
 // SIB-CHECK-NEXT: function_ref
 // SIB-CHECK-NEXT: function_ref @unknown : $@convention(thin) () -> ()

--- a/test/sil-opt/sil-opt.swift
+++ b/test/sil-opt/sil-opt.swift
@@ -13,12 +13,12 @@
 
 // CHECK: sil{{.*}} @unknown : $@convention(thin) () -> ()
 
-// CHECK-LABEL: sil [serialized] @$Ss1XVABycfC : $@convention(method) (@thin X.Type) -> X
+// CHECK-LABEL: sil [serialized] [canonical] @$Ss1XVABycfC : $@convention(method) (@thin X.Type) -> X
 // CHECK: bb0
 // CHECK-NEXT: struct $X ()
 // CHECK-NEXT: return
 
-// CHECK-LABEL: sil [serialized] @$Ss1XV4testyyF : $@convention(method) (X) -> ()
+// CHECK-LABEL: sil [serialized] [canonical] @$Ss1XV4testyyF : $@convention(method) (X) -> ()
 // CHECK: bb0
 // CHECK-NEXT: function_ref
 // CHECK-NEXT: function_ref @unknown : $@convention(thin) () -> ()
@@ -37,14 +37,14 @@
 // SIB-CHECK-NEXT:  init
 // SIB-CHECK-NEXT: }
 
-// SIB-CHECK: sil @unknown : $@convention(thin) () -> ()
+// SIB-CHECK: sil [canonical] @unknown : $@convention(thin) () -> ()
 
-// SIB-CHECK-LABEL: sil [serialized] @$Ss1XVABycfC : $@convention(method) (@thin X.Type) -> X
+// SIB-CHECK-LABEL: sil [serialized] [canonical] @$Ss1XVABycfC : $@convention(method) (@thin X.Type) -> X
 // SIB-CHECK: bb0
 // SIB-CHECK-NEXT: struct $X ()
 // SIB-CHECK-NEXT: return
 
-// SIB-CHECK-LABEL: sil [serialized] @$Ss1XV4testyyF : $@convention(method) (X) -> ()
+// SIB-CHECK-LABEL: sil [serialized] [canonical] @$Ss1XV4testyyF : $@convention(method) (X) -> ()
 // SIB-CHECK: bb0
 // SIB-CHECK-NEXT: function_ref
 // SIB-CHECK-NEXT: function_ref @unknown : $@convention(thin) () -> ()


### PR DESCRIPTION
As a structural SIL property, we disallow address-type block
arguments. Supporting them would prevent reliably reasoning about the
underlying storage of memory access. This reasoning is important for
diagnosing violations of memory access rules and supporting future
optimizations such as bitfield packing. Address-type block arguments
also create unnecessary complexity for SIL optimization passes that
need to reason about memory aliasing.

This must be enforced in raw SIL for diagnosing exclusive memory
access. The optimizer currently breaks the invariant in three places:
1. Normal Simplify CFG during conditional branch simplification
   (sneaky jump threading).
2. Simplify CFG via Jump Threading.
3. Loop Rotation.

Note: With -enforce-exclusivity=checked, the above optimizations
will be partially disabled. When this mode nears performance parity,
it will be enabled by default and, at that time, address-type block args
will be prohibited at all stages.