### PR TITLE
Change the linking of icu in libswiftCore to use icu-config instead of simply adding via an -l flag in order to capture the correct path

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -203,8 +203,8 @@ else()
   #set(LINK_FLAGS
   #  -Wl,--whole-archive swiftRuntime -Wl,--no-whole-archive)
   if("${SWIFT_PATH_TO_LIBICU_BUILD}" STREQUAL "")
-    list(APPEND swift_core_private_link_libraries
-      ICU_UC ICU_I18N)
+    list(APPEND swift_core_link_flags
+      `icu-config --ldflags`)
   else()
     list(APPEND swift_core_private_link_libraries -licui18n -licuuc -licudata)
   endif()


### PR DESCRIPTION
Using `-licuXYZ` on the command line selects whatever version shows up first in the search path. In the case of CentOS we have `/usr/lib/libicuXYZ.so.50` being chosen which is not compatible with Swift. Using `icu-config` allows the user installed icu variants to take priority.

Requires 
https://github.com/apple/swift/pull/14734
https://github.com/apple/swift/pull/14728