### PR TITLE
[5.0][stdlib] Remove the unnecessary compactMap overload

### DIFF
--- a/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift.gyb
@@ -441,13 +441,6 @@ extension Sequence {
 }
 
 extension Collection {
-  @_inlineable // FIXME(sil-serialize-all)
-  public func compactMap(
-    _ transform: (Element) throws -> String?
-  ) rethrows -> [String] {
-    return try _compactMap(transform)
-  }
-
   @available(swift, deprecated: 4.1, renamed: "compactMap(_:)",
     message: "Please use compactMap(_:) for the case where closure returns an optional value")
   @inline(__always)


### PR DESCRIPTION
This particular overload of compactMap was mechanically copied from the
`flatMap` while implementing SE-0187, but as community members correctly
noticed on the forum thread
[here](https://forums.swift.org/t/why-is-there-a-collection-flatmap-that-takes-a-closure-returning-string/10141),
there is no code that we should be backward compatible with, since
`compactMap` has only been introduced recently.

After applying this change, the following code is correctly ambiguous
again:

```swift
[].compactMap { _ in nil } // error: 'nil' requires a contextual type
```

as opposed to:

```swift
[].flatMap { _ in nil } // r0 : [String] = []
```

Fixes: https://bugs.swift.org/browse/SR-7052 (<rdar://problem/37764446>)
(cherry picked from commit 9d705748bbc9fd0b9dc8810767cb7dc7629e4589)
(cherry picked from commit b9ed4751935953324ef61ef3f4273de1e0f57429)