### PR TITLE
[5.0] Tweak _SwiftDispatchOverlayShims for use by swift-corelibs-libdispatch

### DIFF
--- a/stdlib/public/SDK/Dispatch/Queue.swift
+++ b/stdlib/public/SDK/Dispatch/Queue.swift
@@ -112,7 +112,7 @@ public extension DispatchQueue {
 	}
 
 	public class func concurrentPerform(iterations: Int, execute work: (Int) -> Void) {
-		_swift_dispatch_apply_current(UInt32(iterations), work)
+		_swift_dispatch_apply_current(iterations, work)
 	}
 
 	public class var main: DispatchQueue {

--- a/stdlib/public/SwiftShims/DispatchOverlayShims.h
+++ b/stdlib/public/SwiftShims/DispatchOverlayShims.h
@@ -2,20 +2,31 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
+//
+// Note that this file is used by both swift-corelibs-libdispatch and the
+// Dispatch overlay for Darwin in swift/stdlib/public/SDK/Dispatch/.
+//
+//===----------------------------------------------------------------------===//
+
 
 #ifndef SWIFT_STDLIB_SHIMS_DISPATCHSHIMS_H
 #define SWIFT_STDLIB_SHIMS_DISPATCHSHIMS_H
 
-@import Dispatch;
+#include <dispatch/dispatch.h>
 
+#ifdef __OBJC__
 #define SWIFT_DISPATCH_RETURNS_RETAINED __attribute__((__ns_returns_retained__))
+#else
+#define SWIFT_DISPATCH_RETURNS_RETAINED
+#endif
+
 #define SWIFT_DISPATCH_NOESCAPE __attribute__((__noescape__))
 
 #pragma clang assume_nonnull begin
@@ -25,7 +36,12 @@ namespace swift { extern "C" {
 #endif
 
 typedef void (^__swift_shims_dispatch_block_t)(void);
+
+#ifdef __OBJC__
 typedef id __swift_shims_dispatch_data_t;
+#else
+typedef void *__swift_shims_dispatch_data_t;
+#endif
 
 
 static inline dispatch_queue_attr_t
@@ -66,21 +82,24 @@ _swift_dispatch_data_destructor_munmap(void) {
 SWIFT_DISPATCH_SOURCE_TYPE(DATA_ADD)
 SWIFT_DISPATCH_SOURCE_TYPE(DATA_OR)
 SWIFT_DISPATCH_SOURCE_TYPE(DATA_REPLACE)
+SWIFT_DISPATCH_SOURCE_TYPE(READ)
+SWIFT_DISPATCH_SOURCE_TYPE(SIGNAL)
+SWIFT_DISPATCH_SOURCE_TYPE(TIMER)
+SWIFT_DISPATCH_SOURCE_TYPE(WRITE)
+
+#if __APPLE__
 SWIFT_DISPATCH_SOURCE_TYPE(MACH_SEND)
 SWIFT_DISPATCH_SOURCE_TYPE(MACH_RECV)
 SWIFT_DISPATCH_SOURCE_TYPE(MEMORYPRESSURE)
 SWIFT_DISPATCH_SOURCE_TYPE(PROC)
-SWIFT_DISPATCH_SOURCE_TYPE(READ)
-SWIFT_DISPATCH_SOURCE_TYPE(SIGNAL)
-SWIFT_DISPATCH_SOURCE_TYPE(TIMER)
 SWIFT_DISPATCH_SOURCE_TYPE(VNODE)
-SWIFT_DISPATCH_SOURCE_TYPE(WRITE)
+#endif
 
 
 static inline __swift_shims_dispatch_block_t
 _swift_dispatch_block_create_with_qos_class(
     dispatch_block_flags_t flags,
-    qos_class_t qos,
+    dispatch_qos_class_t qos,
     int relative_priority,
     __swift_shims_dispatch_block_t _Nonnull block) {
   return dispatch_block_create_with_qos_class(
@@ -158,7 +177,7 @@ static inline void _swift_dispatch_after(
 
 
 static inline void _swift_dispatch_apply_current(
-    unsigned int iterations,
+    size_t iterations,
     void SWIFT_DISPATCH_NOESCAPE (^block)(long)) {
   dispatch_apply(iterations, (dispatch_queue_t _Nonnull)0, ^(size_t i){
     block((long)i);
@@ -202,6 +221,18 @@ static inline void _swift_dispatch_source_set_registration_handler(
     dispatch_source_t source,
     __swift_shims_dispatch_block_t _Nullable block) {
   dispatch_source_set_registration_handler(source, block);
+}
+
+#if defined(__ANDROID__)
+extern void _dispatch_install_thread_detach_callback(dispatch_function_t cb);
+#endif
+
+static inline void _swift_dispatch_retain(dispatch_object_t object) {
+  dispatch_retain(object);
+}
+
+static inline void _swift_dispatch_release(dispatch_object_t object) {
+  dispatch_release(object);
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Cherry-pick of #6033 to the 5.0 branch because we don't have a separate 5.0 branch of swift-corelibs-libdispatch at the moment. Should not have any effect on the Apple platform builds.