### PR TITLE
[+0-all-args] Verify thunks right after we generate their bodies.

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -857,6 +857,9 @@ static void buildBlockToFuncThunkBody(SILGenFunction &SGF,
   scope.pop();
 
   SGF.B.createReturn(loc, r);
+
+  // Finally, verify the thunk for SIL invariants.
+  SGF.F.verify();
 }
 
 /// Bridge a native function to a block with a thunk.


### PR DESCRIPTION
Previously, we were not verifying these thunks later in the pipeline. This makes
it harder to track down verifier errors in such thunks. Instead, this PR just
moves the thunk verification to right after we generate the thunk body,
i.e. right after the bad code would have been emitted.

Found while debugging test/SILGen/objc_bridging_any.swift for +0-all-args.

rdar://34222540
