### PR TITLE
[+0-normal-args] Turn on ensurePlusOne for RValues.

### DIFF
--- a/lib/SILGen/RValue.cpp
+++ b/lib/SILGen/RValue.cpp
@@ -706,7 +706,7 @@ RValue RValue::copy(SILGenFunction &SGF, SILLocation loc) const & {
 }
 
 RValue RValue::ensurePlusOne(SILGenFunction &SGF, SILLocation loc) && {
-  if (SGF.getOptions().EnableGuaranteedNormalArguments && isPlusZero(SGF))
+  if (!isPlusOne(SGF))
     return copy(SGF, loc);
   return std::move(*this);
 }


### PR DESCRIPTION
ManagedValue::ensurePlusOne is already enabled.

I also tightened up the implementation a little bit by:

1. Fixed a typo in ManagedValue::isPlueZero(). I forgot to negate a boolean
=/. Luckily, I have been using isPlusOne() instead of isPlusZero for all queries
I have needed so far.

2. I added code to ManagedValue/RValue so that if we have SILUndef, we do not
emit copies on SILUndef when we perform ensurePlusOne().

3. I changed isPlusOne() and isPlusZero() to return true for SILUndef. SILUndef
has "any" ownership so it is compatible with all forms of ownership.

rdar://34222540
