### PR TITLE
swift-api-digester: teach the tool to serialize and de-serialize generic requirements.

### DIFF
--- a/include/swift/IDE/DigesterEnums.def
+++ b/include/swift/IDE/DigesterEnums.def
@@ -89,6 +89,7 @@ KEY(declAttributes)
 KEY(declKind)
 KEY(ownership)
 KEY(superclassUsr)
+KEY(parentExtensionReqs)
 
 KNOWN_TYPE(Optional)
 KNOWN_TYPE(ImplicitlyUnwrappedOptional)

--- a/test/api-digester/Inputs/cake.swift
+++ b/test/api-digester/Inputs/cake.swift
@@ -7,10 +7,18 @@ public struct S1 {
   public func foo6() -> Void {}
 }
 
-public class C0 {}
+public class C0<T1, T2, T3> {}
 
-public class C1: C0 {
+public class C1: C0<S1, S1, S1> {
 	open class func foo1() {}
 	public weak var Ins : C1?
 	public unowned var Ins2 : C1 = C1()
+}
+
+public extension C0 where T1 == S1, T2 == S1, T3 == S1 {
+  func conditionalFooExt() {}
+}
+
+public extension C0 {
+  func unconditionalFooExt() {}
 }

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -17,14 +17,69 @@
           "name": "init",
           "printedName": "init()",
           "declKind": "Constructor",
-          "usr": "s:4cake2C0CACycfc",
+          "usr": "s:4cake2C0CACyxq_q0_Gycfc",
           "location": "",
           "moduleName": "cake",
           "children": [
             {
               "kind": "TypeNominal",
               "name": "C0",
-              "printedName": "C0"
+              "printedName": "C0<T1, T2, T3>",
+              "children": [
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "T1"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "T2"
+                },
+                {
+                  "kind": "TypeNominal",
+                  "name": "GenericTypeParam",
+                  "printedName": "T3"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "conditionalFooExt",
+          "printedName": "conditionalFooExt()",
+          "declKind": "Func",
+          "usr": "s:4cake2C0CA2A2S1VRszAERs_AERs0_rlE17conditionalFooExtyyF",
+          "location": "",
+          "moduleName": "cake",
+          "parentExtensionReqs": [
+            "T1 == cake.S1",
+            "T2 == cake.S1",
+            "T3 == cake.S1"
+          ],
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
+            }
+          ]
+        },
+        {
+          "kind": "Function",
+          "name": "unconditionalFooExt",
+          "printedName": "unconditionalFooExt()",
+          "declKind": "Func",
+          "usr": "s:4cake2C0C19unconditionalFooExtyyF",
+          "location": "",
+          "moduleName": "cake",
+          "parentExtensionReqs": [],
+          "children": [
+            {
+              "kind": "TypeNominal",
+              "name": "Void",
+              "printedName": "()"
             }
           ]
         }

--- a/test/api-digester/dump-module.swift
+++ b/test/api-digester/dump-module.swift
@@ -5,3 +5,7 @@
 // RUN: %api-digester -dump-sdk -module cake -o %t.dump.json -module-cache-path %t.module-cache -sdk %t.sdk -swift-version 3 -I %t.mod
 // RUN: diff -u %S/Outputs/cake.json %t.dump.json
 // RUN: %api-digester -diagnose-sdk --input-paths %t.dump.json -input-paths %S/Outputs/cake.json
+
+// Round-trip testing:
+// RUN: %api-digester -deserialize-sdk --input-paths %S/Outputs/cake.json -o %t.dump.json
+// RUN: diff -u %S/Outputs/cake.json %t.dump.json


### PR DESCRIPTION
The tool should diagnose the change of extension's applicability since
such change can be source-breaking. We need first to support the
requirements in the module dump. Currently, we decorate each
member defined in extension with a field called extension info. The
field will keep track of the generic requirements that need to be satisfied
for this decorated member to be applicable. This patch doesn't implement the checking
of requirements change.