### PR TITLE
Dump (some) filelists in the PrettyStackTrace

### DIFF
--- a/include/swift/Basic/PrettyStackTrace.h
+++ b/include/swift/Basic/PrettyStackTrace.h
@@ -16,6 +16,10 @@
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/ADT/StringRef.h"
 
+namespace llvm {
+  class MemoryBuffer;
+}
+
 namespace swift {
 
 /// A PrettyStackTraceEntry for performing an action involving a StringRef.
@@ -28,6 +32,15 @@ class PrettyStackTraceStringAction : public llvm::PrettyStackTraceEntry {
 public:
   PrettyStackTraceStringAction(const char *action, llvm::StringRef string)
     : Action(action), TheString(string) {}
+  void print(llvm::raw_ostream &OS) const override;
+};
+
+/// A PrettyStackTraceEntry to dump the contents of a file.
+class PrettyStackTraceFileContents : public llvm::PrettyStackTraceEntry {
+  const llvm::MemoryBuffer &Buffer;
+public:
+  explicit PrettyStackTraceFileContents(const llvm::MemoryBuffer &buffer)
+    : Buffer(buffer) {}
   void print(llvm::raw_ostream &OS) const override;
 };
 

--- a/include/swift/Frontend/ArgsToFrontendInputsConverter.h
+++ b/include/swift/Frontend/ArgsToFrontendInputsConverter.h
@@ -42,7 +42,6 @@ namespace swift {
 class ArgsToFrontendInputsConverter {
   DiagnosticEngine &Diags;
   const llvm::opt::ArgList &Args;
-  FrontendInputsAndOutputs &InputsAndOutputs;
 
   llvm::opt::Arg const *const FilelistPathArg;
   llvm::opt::Arg const *const PrimaryFilelistPathArg;
@@ -53,10 +52,9 @@ class ArgsToFrontendInputsConverter {
 
 public:
   ArgsToFrontendInputsConverter(DiagnosticEngine &diags,
-                                const llvm::opt::ArgList &args,
-                                FrontendInputsAndOutputs &inputsAndOutputs);
+                                const llvm::opt::ArgList &args);
 
-  bool convert();
+  Optional<FrontendInputsAndOutputs> convert();
 
 private:
   bool enforceFilelistExclusion();
@@ -66,11 +64,19 @@ private:
                              llvm::function_ref<void(StringRef)> fn);
   bool addFile(StringRef file);
   Optional<std::set<StringRef>> readPrimaryFiles();
-  std::set<StringRef>
-  createInputFilesConsumingPrimaries(std::set<StringRef> primaryFiles);
-  bool checkForMissingPrimaryFiles(std::set<StringRef> primaryFiles);
 
-  bool isSingleThreadedWMO() const;
+  /// Returns the newly set-up FrontendInputsAndOutputs, as well as a set of
+  /// any unused primary files (those that do not correspond to an input).
+  std::pair<FrontendInputsAndOutputs, std::set<StringRef>>
+  createInputFilesConsumingPrimaries(std::set<StringRef> primaryFiles);
+
+  /// Emits an error for each file in \p unusedPrimaryFiles.
+  ///
+  /// \returns true if \p unusedPrimaryFiles is non-empty.
+  bool diagnoseUnusedPrimaryFiles(std::set<StringRef> unusedPrimaryFiles);
+
+  bool
+  isSingleThreadedWMO(const FrontendInputsAndOutputs &inputsAndOutputs) const;
 };
 
 } // namespace swift

--- a/include/swift/Frontend/ArgsToFrontendInputsConverter.h
+++ b/include/swift/Frontend/ArgsToFrontendInputsConverter.h
@@ -46,7 +46,9 @@ class ArgsToFrontendInputsConverter {
   llvm::opt::Arg const *const FilelistPathArg;
   llvm::opt::Arg const *const PrimaryFilelistPathArg;
 
-  SmallVector<std::unique_ptr<llvm::MemoryBuffer>, 4> BuffersToKeepAlive;
+  /// A place to keep alive any buffers that are loaded as part of setting up
+  /// the frontend inputs.
+  SmallVector<std::unique_ptr<llvm::MemoryBuffer>, 4> ConfigurationFileBuffers;
 
   llvm::SetVector<StringRef> Files;
 
@@ -54,7 +56,14 @@ public:
   ArgsToFrontendInputsConverter(DiagnosticEngine &diags,
                                 const llvm::opt::ArgList &args);
 
-  Optional<FrontendInputsAndOutputs> convert();
+  /// Produces a FrontendInputsAndOutputs object with the inputs populated from
+  /// the arguments the converter was initialized with.
+  ///
+  /// \param buffers If present, buffers read in the processing of the frontend
+  /// inputs will be saved here. These should only be used for debugging
+  /// purposes.
+  Optional<FrontendInputsAndOutputs> convert(
+      SmallVectorImpl<std::unique_ptr<llvm::MemoryBuffer>> *buffers);
 
 private:
   bool enforceFilelistExclusion();

--- a/include/swift/Frontend/ArgsToFrontendOptionsConverter.h
+++ b/include/swift/Frontend/ArgsToFrontendOptionsConverter.h
@@ -69,7 +69,13 @@ public:
                                  FrontendOptions &Opts)
       : Diags(Diags), Args(Args), Opts(Opts) {}
 
-  bool convert();
+  /// Populates the FrontendOptions the converter was initialized with.
+  ///
+  /// \param buffers If present, buffers read in the processing of the frontend
+  /// options will be saved here. These should only be used for debugging
+  /// purposes.
+  bool convert(
+      SmallVectorImpl<std::unique_ptr<llvm::MemoryBuffer>> *buffers);
 
   static FrontendOptions::ActionType
   determineRequestedAction(const llvm::opt::ArgList &);

--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -86,11 +86,19 @@ public:
   /// default values given the /absence/ of a flag. This is because \c parseArgs
   /// may be used to modify an already partially configured invocation.
   ///
+  /// Any configuration files loaded as a result of parsing arguments will be
+  /// stored in \p ConfigurationFileBuffers, if non-null. The contents of these
+  /// buffers should \e not be interpreted by the caller; they are only present
+  /// in order to make it possible to reproduce how these arguments were parsed
+  /// if the compiler ends up crashing or exhibiting other bad behavior.
+  ///
   /// If non-empty, relative search paths are resolved relative to
   /// \p workingDirectory.
   ///
   /// \returns true if there was an error, false on success.
   bool parseArgs(ArrayRef<const char *> Args, DiagnosticEngine &Diags,
+                 SmallVectorImpl<std::unique_ptr<llvm::MemoryBuffer>>
+                     *ConfigurationFileBuffers = nullptr,
                  StringRef workingDirectory = {});
 
   /// Sets specific options based on the given serialized Swift binary data.

--- a/lib/Basic/PrettyStackTrace.cpp
+++ b/lib/Basic/PrettyStackTrace.cpp
@@ -17,10 +17,19 @@
 
 #include "swift/Basic/PrettyStackTrace.h"
 #include "swift/Basic/QuotedString.h"
+#include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/raw_ostream.h"
 
 using namespace swift;
 
 void PrettyStackTraceStringAction::print(llvm::raw_ostream &out) const {
   out << "While " << Action << ' ' << QuotedString(TheString) << '\n';
+}
+
+void PrettyStackTraceFileContents::print(llvm::raw_ostream &out) const {
+  out << "Contents of " << Buffer.getBufferIdentifier() << ":\n---\n"
+      << Buffer.getBuffer();
+  if (!Buffer.getBuffer().endswith("\n"))
+    out << '\n';
+  out << "---\n";
 }

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -93,9 +93,11 @@ bool ArgsToFrontendOptionsConverter::convert() {
 
   computeDumpScopeMapLocations();
 
-  if (ArgsToFrontendInputsConverter(Diags, Args, Opts.InputsAndOutputs)
-          .convert())
+  Optional<FrontendInputsAndOutputs> inputsAndOutputs =
+      ArgsToFrontendInputsConverter(Diags, Args).convert();
+  if (!inputsAndOutputs)
     return true;
+  Opts.InputsAndOutputs = std::move(inputsAndOutputs).getValue();
 
   Opts.RequestedAction = determineRequestedAction(Args);
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -45,7 +45,8 @@ static void debugFailWithAssertion() {
 LLVM_ATTRIBUTE_NOINLINE
 static void debugFailWithCrash() { LLVM_BUILTIN_TRAP; }
 
-bool ArgsToFrontendOptionsConverter::convert() {
+bool ArgsToFrontendOptionsConverter::convert(
+    SmallVectorImpl<std::unique_ptr<llvm::MemoryBuffer>> *buffers) {
   using namespace options;
 
   handleDebugCrashGroupArguments();
@@ -94,7 +95,7 @@ bool ArgsToFrontendOptionsConverter::convert() {
   computeDumpScopeMapLocations();
 
   Optional<FrontendInputsAndOutputs> inputsAndOutputs =
-      ArgsToFrontendInputsConverter(Diags, Args).convert();
+      ArgsToFrontendInputsConverter(Diags, Args).convert(buffers);
   if (!inputsAndOutputs)
     return true;
   Opts.InputsAndOutputs = std::move(inputsAndOutputs).getValue();

--- a/test/Frontend/crash.swift
+++ b/test/Frontend/crash.swift
@@ -1,0 +1,14 @@
+// RUN: echo %s > %t.filelist.txt
+// RUN: not --crash %target-swift-frontend -typecheck -debug-crash-after-parse -filelist %t.filelist.txt 2>&1 | %FileCheck %s
+
+// Check that we see the contents of the input file list in the crash log.
+// CHECK-LABEL: Stack dump
+// CHECK-NEXT: Program arguments: {{.*swift(c?)}} -frontend
+// CHECK-NEXT: Contents of {{.*}}.filelist.txt:
+// CHECK-NEXT: ---
+// CHECK-NEXT: test/Frontend/crash.swift{{$}}
+// CHECK-NEXT: ---
+
+func anchor() {}
+anchor()
+


### PR DESCRIPTION
(and later, the derived output file map)

This may help us reproduce a failing build when all we have is a build log, and will become much more important in batch mode when we *really* need to know what ended up in what batch.

Also make a micro-optimization to driver startup time.