### PR TITLE
[string] Simplify String creation.

### DIFF
--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift.gyb
@@ -588,10 +588,10 @@ func _stdlib_getline() -> String? {
       if result.isEmpty {
         return nil
       }
-      return String._fromWellFormedCodeUnitSequence(UTF8.self, input: result)
+      return String(decoding: result, as: UTF8.self)
     }
     if c == CInt(Unicode.Scalar("\n").value) {
-      return String._fromWellFormedCodeUnitSequence(UTF8.self, input: result)
+      return String(decoding: result, as: UTF8.self)
     }
     result.append(UInt8(c))
   }

--- a/stdlib/private/SwiftPrivate/IO.swift
+++ b/stdlib/private/SwiftPrivate/IO.swift
@@ -26,15 +26,15 @@ public struct _FDInputStream {
   public mutating func getline() -> String? {
     if let newlineIndex =
       _buffer[0..<_bufferUsed].index(of: UInt8(Unicode.Scalar("\n").value)) {
-      let result = String._fromWellFormedCodeUnitSequence(
-        UTF8.self, input: _buffer[0..<newlineIndex])
+      let result = String._fromWellFormedUTF8CodeUnitSequence(
+        input: _buffer[0..<newlineIndex])
       _buffer.removeSubrange(0...newlineIndex)
       _bufferUsed -= newlineIndex + 1
       return result
     }
     if isEOF && _bufferUsed > 0 {
-      let result = String._fromWellFormedCodeUnitSequence(
-        UTF8.self, input: _buffer[0..<_bufferUsed])
+      let result = String._fromWellFormedUTF8CodeUnitSequence(
+        input: _buffer[0..<_bufferUsed])
       _buffer.removeAll()
       _bufferUsed = 0
       return result

--- a/stdlib/public/core/InputStream.swift
+++ b/stdlib/public/core/InputStream.swift
@@ -65,7 +65,7 @@ public func readLine(strippingNewline: Bool = true) -> String? {
       }
     }
   }
-  let result = String._fromCodeUnitSequenceWithRepair(UTF8.self,
+  let result = String._fromUTF8CodeUnitSequenceWithRepair(
     input: UnsafeMutableBufferPointer(
       start: linePtr,
       count: readBytes)).0

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -1742,8 +1742,7 @@ extension BinaryInteger {
     if isNegative {
       result.append(UInt8(("-" as Unicode.Scalar).value))
     }
-    return String._fromWellFormedCodeUnitSequence(
-      UTF8.self, input: result.reversed())
+    return String._fromASCII(result.reversed())
   }
 
   /// A textual representation of this value.

--- a/stdlib/public/core/Misc.swift
+++ b/stdlib/public/core/Misc.swift
@@ -81,8 +81,7 @@ public func _getTypeName(_ type: Any.Type, qualified: Bool)
 public // @testable
 func _typeName(_ type: Any.Type, qualified: Bool = true) -> String {
   let (stringPtr, count) = _getTypeName(type, qualified: qualified)
-  return ._fromWellFormedCodeUnitSequence(UTF8.self,
-    input: UnsafeBufferPointer(start: stringPtr, count: count))
+  return ._fromASCII(UnsafeBufferPointer(start: stringPtr, count: count))
 }
 
 /// Lookup a class given a name. Until the demangled encoding of type

--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -436,9 +436,8 @@ internal func _float${bits}ToString(
   var buffer = _Buffer32()
   return buffer.withBytes { (bufferPtr) in
     let actualLength = _float${bits}ToStringImpl(bufferPtr, 32, value, debug)
-    return String._fromWellFormedCodeUnitSequence(
-      UTF8.self,
-      input: UnsafeBufferPointer(start: bufferPtr, count: Int(actualLength)))
+    return String._fromASCII(
+      UnsafeBufferPointer(start: bufferPtr, count: Int(actualLength)))
   }
 }
 
@@ -467,18 +466,16 @@ internal func _int64ToString(
     return buffer.withBytes { (bufferPtr) in
       let actualLength
       = _int64ToStringImpl(bufferPtr, 32, value, radix, uppercase)
-      return String._fromWellFormedCodeUnitSequence(
-        UTF8.self,
-        input: UnsafeBufferPointer(start: bufferPtr, count: Int(actualLength)))
+      return String._fromASCII(
+        UnsafeBufferPointer(start: bufferPtr, count: Int(actualLength)))
     }
   } else {
     var buffer = _Buffer72()
     return buffer.withBytes { (bufferPtr) in
       let actualLength
       = _int64ToStringImpl(bufferPtr, 72, value, radix, uppercase)
-      return String._fromWellFormedCodeUnitSequence(
-        UTF8.self,
-        input: UnsafeBufferPointer(start: bufferPtr, count: Int(actualLength)))
+      return String._fromASCII(
+        UnsafeBufferPointer(start: bufferPtr, count: Int(actualLength)))
     }
   }
 }
@@ -501,18 +498,16 @@ func _uint64ToString(
     return buffer.withBytes { (bufferPtr) in
       let actualLength
       = _uint64ToStringImpl(bufferPtr, 32, value, radix, uppercase)
-      return String._fromWellFormedCodeUnitSequence(
-        UTF8.self,
-        input: UnsafeBufferPointer(start: bufferPtr, count: Int(actualLength)))
+      return String._fromASCII(
+        UnsafeBufferPointer(start: bufferPtr, count: Int(actualLength)))
     }
   } else {
     var buffer = _Buffer72()
     return buffer.withBytes { (bufferPtr) in
       let actualLength
       = _uint64ToStringImpl(bufferPtr, 72, value, radix, uppercase)
-      return String._fromWellFormedCodeUnitSequence(
-        UTF8.self,
-        input: UnsafeBufferPointer(start: bufferPtr, count: Int(actualLength)))
+      return String._fromASCII(
+        UnsafeBufferPointer(start: bufferPtr, count: Int(actualLength)))
     }
   }
 }

--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -270,9 +270,12 @@ public struct StaticString
   /// A string representation of the static string.
   @_inlineable // FIXME(sil-serialize-all)
   public var description: String {
-    return withUTF8Buffer {
-      (buffer) in
-      return String._fromWellFormedCodeUnitSequence(UTF8.self, input: buffer)
+    return withUTF8Buffer { (buffer) in
+      if isASCII {
+        return String._fromASCII(buffer)
+      } else {
+        return String._fromWellFormedUTF8CodeUnitSequence(input: buffer)
+      }
     }
   }
 

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -75,15 +75,6 @@ extension String {
   }
 }
 
-extension String {
-  @_inlineable // FIXME(sil-serialize-all)
-  public init(_ _c: Unicode.Scalar) {
-    self = String._fromWellFormedCodeUnitSequence(
-      UTF32.self,
-      input: repeatElement(_c.value, count: 1))
-  }
-}
-
 #if _runtime(_ObjC)
 /// Determines if `theString` starts with `prefix` comparing the strings under
 /// canonical equivalence.

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -290,9 +290,7 @@ extension Unicode.Scalar : CustomStringConvertible, CustomDebugStringConvertible
   /// A textual representation of the Unicode scalar.
   @_inlineable // FIXME(sil-serialize-all)
   public var description: String {
-    return String._fromWellFormedCodeUnitSequence(
-      UTF32.self,
-      input: repeatElement(self.value, count: 1))
+    return String(self)
   }
 
   /// An escaped textual representation of the Unicode scalar, suitable for

--- a/stdlib/public/core/UnmanagedString.swift
+++ b/stdlib/public/core/UnmanagedString.swift
@@ -74,6 +74,13 @@ struct _UnmanagedString<CodeUnit>
     self.start = start
     self.count = count
   }
+
+  @_inlineable
+  @_versioned
+  init(_ buf: UnsafeBufferPointer<CodeUnit>) {
+    self.init(
+      start: buf.baseAddress._unsafelyUnwrappedUnchecked, count: buf.count)
+  }
 }
 
 extension _UnmanagedString {
@@ -173,33 +180,33 @@ extension _UnmanagedString : _StringVariant {
       start: start + offsetRange.lowerBound,
       count: offsetRange.count)
   }
-  
+
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal subscript(offsetRange: PartialRangeFrom<Int>) -> SubSequence {
     _sanityCheck(offsetRange.lowerBound >= 0)
     return _UnmanagedString(
-      start: start + offsetRange.lowerBound, 
+      start: start + offsetRange.lowerBound,
       count: self.count - offsetRange.lowerBound
     )
   }
-  
+
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal subscript(offsetRange: PartialRangeUpTo<Int>) -> SubSequence {
     _sanityCheck(offsetRange.upperBound <= count)
     return _UnmanagedString(
-      start: start, 
+      start: start,
       count: offsetRange.upperBound
     )
   }
-  
+
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal subscript(offsetRange: PartialRangeThrough<Int>) -> SubSequence {
     _sanityCheck(offsetRange.upperBound < count)
     return _UnmanagedString(
-      start: start, 
+      start: start,
       count: offsetRange.upperBound + 1
     )
   }

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -1089,7 +1089,7 @@ StringTests.test("toInt") {
   ) {
     var chars = Array(String(initialValue).utf8)
     modification(&chars)
-    let str = String._fromWellFormedCodeUnitSequence(UTF8.self, input: chars)
+    let str = String._fromWellFormedUTF8CodeUnitSequence(input: chars)
     expectNil(Int(str))
   }
 


### PR DESCRIPTION
Most Strings are created by funneling through _fromCodeUnits (often
through another intermediary). However, most callers of this have more
specific information, such as whether they are ASCII, than the generic
_fromCodeUnits. Simplify the intermediaries and expose the opportunity
for more direct String construction given more contextual information.

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
