### PR TITLE
Master next test fixes

### DIFF
--- a/test/DebugInfo/Imports.swift
+++ b/test/DebugInfo/Imports.swift
@@ -31,4 +31,5 @@ markUsed(basic.foo(1, 2))
 
 // DWARF-NOT: "Swift.Optional"
 
-// DWARF-DAG: file_names{{.*}} "Imports.swift"
+// DWARF-DAG: file_names{{.*}}
+// DWARF-NEXT: "Imports.swift"

--- a/test/IRGen/ordering_x86.sil
+++ b/test/IRGen/ordering_x86.sil
@@ -41,4 +41,4 @@ bb0:
 // the order of features differs.
 
 // X86_64: define{{( protected)?}} swiftcc void @baz{{.*}}#0
-// X86_64: #0 = {{.*}}"target-features"="+cx16,+fxsr,+mmx,+sse,+sse2,+sse3,+ssse3,+x87"
+// X86_64: #0 = {{.*}}"target-features"="+cx16,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+ssse3,+x87"


### PR DESCRIPTION
The master-next branch has been broken for a while and in the meantime, some changes have
come in that require adjusting the expected output of the tests.
