### PR TITLE
[typo] s/plaform/platform/ everywhere.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1519,7 +1519,7 @@ WARNING(unknown_platform_condition_argument,none,
       "unknown %0 for build configuration '%1'",
       (StringRef, StringRef))
 WARNING(likely_simulator_platform_condition,none,
-      "plaform condition appears to be testing for simulator environment; "
+      "platform condition appears to be testing for simulator environment; "
       "use 'targetEnvironment(simulator)' instead",
       ())
 

--- a/test/Parse/ConditionalCompilation/simulatorTargetEnv.swift
+++ b/test/Parse/ConditionalCompilation/simulatorTargetEnv.swift
@@ -14,26 +14,26 @@ var x = C()
 var y = x
 
 #if os(iOS) && arch(i386)
-// expected-warning @-1 {{plaform condition appears to be testing for simulator environment}} {{5-26=targetEnvironment(simulator)}}
+// expected-warning @-1 {{platform condition appears to be testing for simulator environment}} {{5-26=targetEnvironment(simulator)}}
 class C1 {}
 #endif
 
 #if arch(i386) && os(iOS)
-// expected-warning @-1 {{plaform condition appears to be testing for simulator environment}} {{5-26=targetEnvironment(simulator)}}
+// expected-warning @-1 {{platform condition appears to be testing for simulator environment}} {{5-26=targetEnvironment(simulator)}}
 class C2 {}
 #endif
 
 #if arch(i386) && (os(iOS) || os(watchOS))
-// expected-warning @-1 {{plaform condition appears to be testing for simulator environment}} {{5-43=targetEnvironment(simulator)}}
+// expected-warning @-1 {{platform condition appears to be testing for simulator environment}} {{5-43=targetEnvironment(simulator)}}
 class C3 {}
 #endif
 
 #if (arch(x86_64) || arch(i386)) && (os(iOS) || os(watchOS) || os(tvOS))
-// expected-warning @-1 {{plaform condition appears to be testing for simulator environment}} {{5-73=targetEnvironment(simulator)}}
+// expected-warning @-1 {{platform condition appears to be testing for simulator environment}} {{5-73=targetEnvironment(simulator)}}
 class C4 {}
 #endif
 
 #if !(arch(x86_64) && os(tvOS))
-// expected-warning @-1 {{plaform condition appears to be testing for simulator environment}} {{7-31=targetEnvironment(simulator)}}
+// expected-warning @-1 {{platform condition appears to be testing for simulator environment}} {{7-31=targetEnvironment(simulator)}}
 class C5 {}
 #endif

--- a/utils/gen-static-stdlib-link-args
+++ b/utils/gen-static-stdlib-link-args
@@ -2,7 +2,7 @@
 
 #
 # Generate the static-stdlib-args.lnk used by the -static-stdlib option for
-# 'GenericUnix' (eg linux) plaforms. Tries to find static .a files for libs
+# 'GenericUnix' (eg linux) platforms. Tries to find static .a files for libs
 # not normally installed by default (currently libicu)
 # If libicu is built locally then include libicudata
 #


### PR DESCRIPTION
Spelling fix for typo noticed by @billThePill in https://github.com/apple/swift/commit/94988a253ec30542110abc1caec3d72a0e469173#commitcomment-27764164

