### PR TITLE
Visibility fixes for ELF.

### DIFF
--- a/stdlib/public/SwiftShims/Visibility.h
+++ b/stdlib/public/SwiftShims/Visibility.h
@@ -72,19 +72,37 @@
 // SWIFT_RUNTIME_EXPORT on the library it's exported from.
 
 /// Attribute used to export symbols from the runtime.
-#if defined(__MACH__) || defined(__ELF__)
+#if defined(__MACH__)
+
 # define SWIFT_EXPORT_ATTRIBUTE __attribute__((__visibility__("default")))
 
-#else  // FIXME: this #else should be some sort of #elif Windows
+#elif defined(__ELF__)
+
+// We make assumptions that the runtime and standard library can refer to each
+// other's symbols as DSO-local, which means we can't allow the dynamic linker
+// to relocate these symbols. We must give them protected visibility while
+// building the standard library and runtime.
+# if defined(swiftCore_EXPORTS)
+#  define SWIFT_EXPORT_ATTRIBUTE __attribute__((__visibility__("protected")))
+# else
+#  define SWIFT_EXPORT_ATTRIBUTE __attribute__((__visibility__("default")))
+# endif
+
+// FIXME: this #else should be some sort of #elif Windows
+#else // !__MACH__ && !__ELF__
+
 # if defined(__CYGWIN__)
 #  define SWIFT_EXPORT_ATTRIBUTE
 # else
+
 #  if defined(swiftCore_EXPORTS)
 #   define SWIFT_EXPORT_ATTRIBUTE __declspec(dllexport)
 #  else
 #   define SWIFT_EXPORT_ATTRIBUTE __declspec(dllimport)
 #  endif
+
 # endif
+
 #endif
 
 #if defined(__cplusplus)

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -37,6 +37,7 @@ SWIFT_RUNTIME_STDLIB_INTERFACE
 ClassMetadata CLASS_METADATA_SYM(s20_RawNativeSetStorage);
 } // namespace swift
 
+SWIFT_RUNTIME_STDLIB_INTERFACE
 swift::_SwiftEmptyArrayStorage swift::_swiftEmptyArrayStorage = {
   // HeapObject header;
   {
@@ -50,8 +51,7 @@ swift::_SwiftEmptyArrayStorage swift::_swiftEmptyArrayStorage = {
   }
 };
 
-
-
+SWIFT_RUNTIME_STDLIB_INTERFACE
 swift::_SwiftEmptyDictionaryStorage swift::_swiftEmptyDictionaryStorage = {
   // HeapObject header;
   {
@@ -79,7 +79,7 @@ swift::_SwiftEmptyDictionaryStorage swift::_swiftEmptyDictionaryStorage = {
   0 // int entries; (zero'd bits)
 };
 
-
+SWIFT_RUNTIME_STDLIB_INTERFACE
 swift::_SwiftEmptySetStorage swift::_swiftEmptySetStorage = {
   // HeapObject header;
   {


### PR DESCRIPTION
- `_swiftEmpty{Array,Dictionary,Set}Storage` should be marked with `SWIFT_RUNTIME_STDLIB_INTERFACE` so that they can be linked from the standard library implementation.
- Runtime export symbols ought to have protected visibility.