### PR TITLE
Add a SWIFT_BUILD_DIR variable to pass as an arugment to xctest/build_script.py

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2369,6 +2369,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
                 XCTEST_BUILD_DIR=$(build_directory ${host} xctest)
                 FOUNDATION_BUILD_DIR=$(build_directory ${host} foundation)
+                SWIFT_BUILD_DIR=$(build_directory ${host} swift)
 
                 # Staging: require opt-in for building with dispatch
                 if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
@@ -2387,6 +2388,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     --swiftc="${SWIFTC_BIN}" \
                     --build-dir="${XCTEST_BUILD_DIR}" \
                     --foundation-build-dir="${FOUNDATION_BUILD_DIR}/Foundation" \
+                    --swift-build-dir="${SWIFT_BUILD_DIR}" \
                     $LIBDISPATCH_BUILD_ARGS \
                     $XCTEST_BUILD_ARGS
 


### PR DESCRIPTION
Pass a `SWIFT_BUILD_DIR` variable to the invocation of `build_script.py` on xctest in order to account for the changes in https://github.com/apple/swift/pull/14243.
@compnerd 

Requires
https://github.com/apple/swift/pull/14243
https://github.com/apple/swift-corelibs-xctest/pull/211