### PR TITLE
Add a RangeSpecificDiagnosticConsumer

### DIFF
--- a/lib/AST/DiagnosticConsumer.cpp
+++ b/lib/AST/DiagnosticConsumer.cpp
@@ -22,7 +22,104 @@
 #include "llvm/Support/raw_ostream.h"
 using namespace swift;
 
-DiagnosticConsumer::~DiagnosticConsumer() { }
+DiagnosticConsumer::~DiagnosticConsumer() = default;
+
+llvm::SMLoc DiagnosticConsumer::getRawLoc(SourceLoc loc) {
+  return loc.Value;
+}
+
+RangeSpecificDiagnosticConsumer::RangeSpecificDiagnosticConsumer(
+    MutableArrayRef<ConsumerPair> consumers) {
+  using MapEntry = std::pair<CharSourceRange, unsigned>;
+
+  // Split up the ConsumerPairs into the "map" (to be sorted) and the actual
+  // owning vector (preserving order).
+  for (ConsumerPair &pair : consumers) {
+    LocationToConsumerMap.emplace_back(pair.first, SubConsumers.size());
+    SubConsumers.emplace_back(std::move(pair).second);
+  }
+
+  // Sort the "map" by buffer /end/ location, for use with std::lower_bound
+  // later. (Sorting by start location would produce the same sort, since the
+  // ranges must not be overlapping, but since we need to check end locations
+  // later it's consistent to sort by that here.)
+  std::sort(LocationToConsumerMap.begin(), LocationToConsumerMap.end(),
+            [](const MapEntry &left, const MapEntry &right) -> bool {
+    auto compare = std::less<const char *>();
+    return compare(getRawLoc(left.first.getEnd()).getPointer(),
+                   getRawLoc(right.first.getEnd()).getPointer());
+  });
+
+  // Check that the ranges are non-overlapping.
+  assert(LocationToConsumerMap.end() ==
+           std::adjacent_find(LocationToConsumerMap.begin(),
+                              LocationToConsumerMap.end(),
+                              [](const MapEntry &left, const MapEntry &right) {
+                                return left.first.overlaps(right.first);
+                              }) &&
+         "overlapping ranges given to RangeSpecificDiagnosticConsumer");
+}
+
+DiagnosticConsumer *
+RangeSpecificDiagnosticConsumer::consumerForLocation(SourceLoc loc) const {
+  // "Find the first range whose end location is greater than or equal to
+  // 'loc'."
+  auto possiblyContainingRangeIter =
+      std::lower_bound(LocationToConsumerMap.begin(),
+                       LocationToConsumerMap.end(),
+                       loc,
+                       [](const std::pair<CharSourceRange, unsigned> &entry,
+                          SourceLoc loc) -> bool {
+    auto compare = std::less<const char *>();
+    return compare(getRawLoc(entry.first.getEnd()).getPointer(),
+                   getRawLoc(loc).getPointer());
+  });
+
+  if (possiblyContainingRangeIter != LocationToConsumerMap.end() &&
+      possiblyContainingRangeIter->first.contains(loc)) {
+    return SubConsumers[possiblyContainingRangeIter->second].get();
+  }
+
+  return nullptr;
+}
+
+void RangeSpecificDiagnosticConsumer::handleDiagnostic(
+    SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
+    StringRef FormatString, ArrayRef<DiagnosticArgument> FormatArgs,
+    const DiagnosticInfo &Info) {
+
+  DiagnosticConsumer *specificConsumer;
+  switch (Kind) {
+  case DiagnosticKind::Error:
+  case DiagnosticKind::Warning:
+  case DiagnosticKind::Remark:
+    specificConsumer = consumerForLocation(Loc);
+    ConsumerForSubsequentNotes = specificConsumer;
+    break;
+  case DiagnosticKind::Note:
+    specificConsumer = ConsumerForSubsequentNotes;
+    break;
+  }
+
+  if (specificConsumer) {
+    specificConsumer->handleDiagnostic(SM, Loc, Kind, FormatString, FormatArgs,
+                                       Info);
+  } else {
+    for (auto &subConsumer : SubConsumers) {
+      subConsumer->handleDiagnostic(SM, Loc, Kind, FormatString, FormatArgs,
+                                    Info);
+    }
+  }
+}
+
+bool RangeSpecificDiagnosticConsumer::finishProcessing() {
+  // Deliberately don't use std::any_of here because we don't want early-exit
+  // behavior.
+  bool hadError = false;
+  for (auto &subConsumer : SubConsumers)
+    hadError |= subConsumer->finishProcessing();
+  return hadError;
+}
 
 void NullDiagnosticConsumer::handleDiagnostic(
     SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,

--- a/lib/Frontend/PrintingDiagnosticConsumer.cpp
+++ b/lib/Frontend/PrintingDiagnosticConsumer.cpp
@@ -63,10 +63,6 @@ namespace {
   };
 } // end anonymous namespace
 
-llvm::SMLoc DiagnosticConsumer::getRawLoc(SourceLoc loc) {
-  return loc.Value;
-}
-
 void PrintingDiagnosticConsumer::handleDiagnostic(
     SourceManager &SM, SourceLoc Loc, DiagnosticKind Kind,
     StringRef FormatString, ArrayRef<DiagnosticArgument> FormatArgs,

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_swift_unittest(SwiftASTTests
+  DiagnosticConsumerTests.cpp
   SourceLocTests.cpp
   TestContext.cpp
   TypeMatchTests.cpp

--- a/unittests/AST/DiagnosticConsumerTests.cpp
+++ b/unittests/AST/DiagnosticConsumerTests.cpp
@@ -1,0 +1,424 @@
+//===--- DiagnosticConsumerTests.cpp --------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/AST/DiagnosticConsumer.h"
+#include "swift/Basic/SourceManager.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+
+namespace {
+  using ExpectedDiagnostic = std::pair<SourceLoc, StringRef>;
+
+  class ExpectationDiagnosticConsumer: public DiagnosticConsumer {
+    ExpectationDiagnosticConsumer *previous;
+    SmallVector<ExpectedDiagnostic, 4> expected;
+    bool hasFinished = false;
+
+  public:
+    ExpectationDiagnosticConsumer(ExpectationDiagnosticConsumer *previous,
+                                  ArrayRef<ExpectedDiagnostic> expected)
+      : previous(previous), expected(expected.begin(), expected.end()) {}
+
+    ~ExpectationDiagnosticConsumer() override {
+      EXPECT_TRUE(hasFinished);
+      EXPECT_TRUE(expected.empty());
+    }
+
+    void handleDiagnostic(SourceManager &SM, SourceLoc loc, DiagnosticKind kind,
+                          StringRef formatString,
+                          ArrayRef<DiagnosticArgument> formatArgs,
+                          const DiagnosticInfo &info) override {
+      ASSERT_FALSE(expected.empty());
+      EXPECT_EQ(std::make_pair(loc, formatString), expected.front());
+      expected.erase(expected.begin());
+    }
+
+    bool finishProcessing() override {
+      EXPECT_FALSE(hasFinished);
+      if (previous)
+        EXPECT_TRUE(previous->hasFinished);
+      hasFinished = true;
+      return false;
+    }
+  };
+} // end anonymous namespace
+
+TEST(RangeSpecificDiagnosticConsumer, SubConsumersFinishInOrder) {
+  SourceManager sourceMgr;
+  unsigned bufferA = sourceMgr.addMemBufferCopy("abcde", "A");
+  unsigned bufferB = sourceMgr.addMemBufferCopy("vwxyz", "B");
+  (void)bufferB;
+
+  auto consumerA = llvm::make_unique<ExpectationDiagnosticConsumer>(
+      nullptr, None);
+  auto consumerB = llvm::make_unique<ExpectationDiagnosticConsumer>(
+      consumerA.get(), None);
+
+  RangeSpecificDiagnosticConsumer::ConsumerPair consumers[] = {
+    {sourceMgr.getRangeForBuffer(bufferA), std::move(consumerA)},
+    {CharSourceRange(), std::move(consumerB)}};
+
+  RangeSpecificDiagnosticConsumer topConsumer(consumers);
+  topConsumer.finishProcessing();
+}
+
+TEST(RangeSpecificDiagnosticConsumer, InvalidLocDiagsGoToEveryConsumer) {
+  SourceManager sourceMgr;
+  unsigned bufferA = sourceMgr.addMemBufferCopy("abcde", "A");
+  unsigned bufferB = sourceMgr.addMemBufferCopy("vwxyz", "B");
+  (void)bufferB;
+
+  ExpectedDiagnostic expected[] = { {SourceLoc(), "dummy"} };
+  auto consumerA = llvm::make_unique<ExpectationDiagnosticConsumer>(nullptr,
+      expected);
+  auto consumerB = llvm::make_unique<ExpectationDiagnosticConsumer>(
+      consumerA.get(), expected);
+
+  RangeSpecificDiagnosticConsumer::ConsumerPair consumers[] = {
+    {sourceMgr.getRangeForBuffer(bufferA), std::move(consumerA)},
+    {CharSourceRange(), std::move(consumerB)}};
+
+  RangeSpecificDiagnosticConsumer topConsumer(consumers);
+  topConsumer.handleDiagnostic(sourceMgr, SourceLoc(), DiagnosticKind::Error,
+                               "dummy", {}, DiagnosticInfo());
+  topConsumer.finishProcessing();
+}
+
+TEST(RangeSpecificDiagnosticConsumer, ErrorsWithLocationsGoToExpectedConsumers){
+  SourceManager sourceMgr;
+  //                                             01234
+  unsigned bufferA = sourceMgr.addMemBufferCopy("abcde", "A");
+  unsigned bufferB = sourceMgr.addMemBufferCopy("vwxyz", "B");
+
+  SourceLoc frontOfA = sourceMgr.getLocForOffset(bufferA, 0);
+  SourceLoc middleOfA = sourceMgr.getLocForOffset(bufferA, 2);
+  SourceLoc backOfA = sourceMgr.getLocForOffset(bufferA, 4);
+
+  SourceLoc frontOfB = sourceMgr.getLocForOffset(bufferB, 0);
+  SourceLoc middleOfB = sourceMgr.getLocForOffset(bufferB, 2);
+  SourceLoc backOfB = sourceMgr.getLocForOffset(bufferB, 4);
+
+  ExpectedDiagnostic expectedA[] = {
+    {frontOfA, "front"},
+    {frontOfB, "front"},
+    {middleOfA, "middle"},
+    {middleOfB, "middle"},
+    {backOfA, "back"},
+    {backOfB, "back"}
+  };
+  ExpectedDiagnostic expectedB[] = {
+    {frontOfB, "front"},
+    {middleOfB, "middle"},
+    {backOfB, "back"}
+  };
+
+  auto consumerA = llvm::make_unique<ExpectationDiagnosticConsumer>(
+      nullptr, expectedA);
+  auto consumerB = llvm::make_unique<ExpectationDiagnosticConsumer>(
+      consumerA.get(), expectedB);
+
+  RangeSpecificDiagnosticConsumer::ConsumerPair consumers[] = {
+    {sourceMgr.getRangeForBuffer(bufferA), std::move(consumerA)},
+    {CharSourceRange(), std::move(consumerB)}};
+
+  RangeSpecificDiagnosticConsumer topConsumer(consumers);
+  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
+                               "front", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Error,
+                               "front", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Error,
+                               "middle", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Error,
+                               "middle", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Error,
+                               "back", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Error,
+                               "back", {}, DiagnosticInfo());
+  topConsumer.finishProcessing();
+}
+
+TEST(RangeSpecificDiagnosticConsumer, WarningsAndRemarksAreTreatedLikeErrors) {
+  SourceManager sourceMgr;
+  //                                             01234
+  unsigned bufferA = sourceMgr.addMemBufferCopy("abcde", "A");
+  unsigned bufferB = sourceMgr.addMemBufferCopy("vwxyz", "B");
+
+  SourceLoc frontOfA = sourceMgr.getLocForBufferStart(bufferA);
+  SourceLoc frontOfB = sourceMgr.getLocForBufferStart(bufferB);
+
+  ExpectedDiagnostic expectedA[] = {
+    {frontOfA, "warning"},
+    {frontOfB, "warning"},
+    {frontOfA, "remark"},
+    {frontOfB, "remark"},
+  };
+  ExpectedDiagnostic expectedB[] = {
+    {frontOfB, "warning"},
+    {frontOfB, "remark"},
+  };
+
+  auto consumerA = llvm::make_unique<ExpectationDiagnosticConsumer>(
+      nullptr, expectedA);
+  auto consumerB = llvm::make_unique<ExpectationDiagnosticConsumer>(
+      consumerA.get(), expectedB);
+
+  RangeSpecificDiagnosticConsumer::ConsumerPair consumers[] = {
+    {sourceMgr.getRangeForBuffer(bufferA), std::move(consumerA)},
+    {CharSourceRange(), std::move(consumerB)}};
+
+  RangeSpecificDiagnosticConsumer topConsumer(consumers);
+  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Warning,
+                               "warning", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Warning,
+                               "warning", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Remark,
+                               "remark", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Remark,
+                               "remark", {}, DiagnosticInfo());
+  topConsumer.finishProcessing();
+}
+
+TEST(RangeSpecificDiagnosticConsumer, NotesAreAttachedToErrors) {
+  SourceManager sourceMgr;
+  //                                             01234
+  unsigned bufferA = sourceMgr.addMemBufferCopy("abcde", "A");
+  unsigned bufferB = sourceMgr.addMemBufferCopy("vwxyz", "B");
+
+  SourceLoc frontOfA = sourceMgr.getLocForOffset(bufferA, 0);
+  SourceLoc middleOfA = sourceMgr.getLocForOffset(bufferA, 2);
+  SourceLoc backOfA = sourceMgr.getLocForOffset(bufferA, 4);
+
+  SourceLoc frontOfB = sourceMgr.getLocForOffset(bufferB, 0);
+  SourceLoc middleOfB = sourceMgr.getLocForOffset(bufferB, 2);
+  SourceLoc backOfB = sourceMgr.getLocForOffset(bufferB, 4);
+
+  ExpectedDiagnostic expectedA[] = {
+    {frontOfA, "error"},
+    {middleOfA, "note"},
+    {backOfA, "note"},
+    {frontOfB, "error"},
+    {middleOfB, "note"},
+    {backOfB, "note"},
+    {frontOfA, "error"},
+    {middleOfA, "note"},
+    {backOfA, "note"},
+  };
+  ExpectedDiagnostic expectedB[] = {
+    {frontOfB, "error"},
+    {middleOfB, "note"},
+    {backOfB, "note"},
+  };
+
+  auto consumerA = llvm::make_unique<ExpectationDiagnosticConsumer>(
+      nullptr, expectedA);
+  auto consumerB = llvm::make_unique<ExpectationDiagnosticConsumer>(
+      consumerA.get(), expectedB);
+
+  RangeSpecificDiagnosticConsumer::ConsumerPair consumers[] = {
+    {sourceMgr.getRangeForBuffer(bufferA), std::move(consumerA)},
+    {CharSourceRange(), std::move(consumerB)}};
+
+  RangeSpecificDiagnosticConsumer topConsumer(consumers);
+  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
+                               "error", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
+                               "note", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
+                               "note", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Error,
+                               "error", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Note,
+                               "note", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Note,
+                               "note", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
+                               "error", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
+                               "note", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
+                               "note", {}, DiagnosticInfo());
+  topConsumer.finishProcessing();
+}
+
+TEST(RangeSpecificDiagnosticConsumer, NotesAreAttachedToWarningsAndRemarks) {
+  SourceManager sourceMgr;
+  //                                             01234
+  unsigned bufferA = sourceMgr.addMemBufferCopy("abcde", "A");
+  unsigned bufferB = sourceMgr.addMemBufferCopy("vwxyz", "B");
+
+  SourceLoc frontOfA = sourceMgr.getLocForOffset(bufferA, 0);
+  SourceLoc middleOfA = sourceMgr.getLocForOffset(bufferA, 2);
+  SourceLoc backOfA = sourceMgr.getLocForOffset(bufferA, 4);
+
+  SourceLoc frontOfB = sourceMgr.getLocForOffset(bufferB, 0);
+  SourceLoc middleOfB = sourceMgr.getLocForOffset(bufferB, 2);
+  SourceLoc backOfB = sourceMgr.getLocForOffset(bufferB, 4);
+
+  ExpectedDiagnostic expectedA[] = {
+    {frontOfA, "warning"},
+    {middleOfA, "note"},
+    {backOfA, "note"},
+    {frontOfB, "warning"},
+    {middleOfB, "note"},
+    {backOfB, "note"},
+    {frontOfA, "remark"},
+    {middleOfA, "note"},
+    {backOfA, "note"},
+  };
+  ExpectedDiagnostic expectedB[] = {
+    {frontOfB, "warning"},
+    {middleOfB, "note"},
+    {backOfB, "note"},
+  };
+
+  auto consumerA = llvm::make_unique<ExpectationDiagnosticConsumer>(
+      nullptr, expectedA);
+  auto consumerB = llvm::make_unique<ExpectationDiagnosticConsumer>(
+      consumerA.get(), expectedB);
+
+  RangeSpecificDiagnosticConsumer::ConsumerPair consumers[] = {
+    {sourceMgr.getRangeForBuffer(bufferA), std::move(consumerA)},
+    {CharSourceRange(), std::move(consumerB)}};
+
+  RangeSpecificDiagnosticConsumer topConsumer(consumers);
+  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Warning,
+                               "warning", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
+                               "note", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
+                               "note", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Warning,
+                               "warning", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Note,
+                               "note", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Note,
+                               "note", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Remark,
+                               "remark", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
+                               "note", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
+                               "note", {}, DiagnosticInfo());
+  topConsumer.finishProcessing();
+}
+
+TEST(RangeSpecificDiagnosticConsumer, NotesAreAttachedToErrorsEvenAcrossFiles) {
+  SourceManager sourceMgr;
+  //                                             01234
+  unsigned bufferA = sourceMgr.addMemBufferCopy("abcde", "A");
+  unsigned bufferB = sourceMgr.addMemBufferCopy("vwxyz", "B");
+
+  SourceLoc frontOfA = sourceMgr.getLocForOffset(bufferA, 0);
+  SourceLoc middleOfA = sourceMgr.getLocForOffset(bufferA, 2);
+  SourceLoc backOfA = sourceMgr.getLocForOffset(bufferA, 4);
+
+  SourceLoc frontOfB = sourceMgr.getLocForOffset(bufferB, 0);
+  SourceLoc middleOfB = sourceMgr.getLocForOffset(bufferB, 2);
+  SourceLoc backOfB = sourceMgr.getLocForOffset(bufferB, 4);
+
+  ExpectedDiagnostic expectedA[] = {
+    {frontOfA, "error"},
+    {middleOfB, "note"},
+    {backOfA, "note"},
+    {frontOfB, "error"},
+    {middleOfA, "note"},
+    {backOfB, "note"},
+    {frontOfA, "error"},
+    {middleOfB, "note"},
+    {backOfA, "note"},
+  };
+  ExpectedDiagnostic expectedB[] = {
+    {frontOfB, "error"},
+    {middleOfA, "note"},
+    {backOfB, "note"},
+  };
+
+  auto consumerA = llvm::make_unique<ExpectationDiagnosticConsumer>(
+      nullptr, expectedA);
+  auto consumerB = llvm::make_unique<ExpectationDiagnosticConsumer>(
+      consumerA.get(), expectedB);
+
+  RangeSpecificDiagnosticConsumer::ConsumerPair consumers[] = {
+    {sourceMgr.getRangeForBuffer(bufferA), std::move(consumerA)},
+    {CharSourceRange(), std::move(consumerB)}};
+
+  RangeSpecificDiagnosticConsumer topConsumer(consumers);
+  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
+                               "error", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Note,
+                               "note", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
+                               "note", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Error,
+                               "error", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, middleOfA, DiagnosticKind::Note,
+                               "note", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Note,
+                               "note", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
+                               "error", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, middleOfB, DiagnosticKind::Note,
+                               "note", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
+                               "note", {}, DiagnosticInfo());
+  topConsumer.finishProcessing();
+}
+
+
+TEST(RangeSpecificDiagnosticConsumer,
+     NotesWithInvalidLocsAreStillAttachedToErrors) {
+  SourceManager sourceMgr;
+  //                                             01234
+  unsigned bufferA = sourceMgr.addMemBufferCopy("abcde", "A");
+  unsigned bufferB = sourceMgr.addMemBufferCopy("vwxyz", "B");
+
+  SourceLoc frontOfA = sourceMgr.getLocForBufferStart(bufferA);
+  SourceLoc frontOfB = sourceMgr.getLocForBufferStart(bufferB);
+
+  ExpectedDiagnostic expectedA[] = {
+    {frontOfA, "error"},
+    {SourceLoc(), "note"},
+    {frontOfB, "error"},
+    {SourceLoc(), "note"},
+    {frontOfA, "error"},
+    {SourceLoc(), "note"},
+  };
+  ExpectedDiagnostic expectedB[] = {
+    {frontOfB, "error"},
+    {SourceLoc(), "note"},
+  };
+
+  auto consumerA = llvm::make_unique<ExpectationDiagnosticConsumer>(
+      nullptr, expectedA);
+  auto consumerB = llvm::make_unique<ExpectationDiagnosticConsumer>(
+      consumerA.get(), expectedB);
+
+  RangeSpecificDiagnosticConsumer::ConsumerPair consumers[] = {
+    {sourceMgr.getRangeForBuffer(bufferA), std::move(consumerA)},
+    {CharSourceRange(), std::move(consumerB)}};
+
+  RangeSpecificDiagnosticConsumer topConsumer(consumers);
+  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
+                               "error", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, SourceLoc(), DiagnosticKind::Note,
+                               "note", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Error,
+                               "error", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, SourceLoc(), DiagnosticKind::Note,
+                               "note", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, frontOfA, DiagnosticKind::Error,
+                               "error", {}, DiagnosticInfo());
+  topConsumer.handleDiagnostic(sourceMgr, SourceLoc(), DiagnosticKind::Note,
+                               "note", {}, DiagnosticInfo());
+  topConsumer.finishProcessing();
+}


### PR DESCRIPTION
If a top-level diagnostic is in a particular source range, the RangeSpecificDiagnosticConsumer will funnel it and any attached notes to a particular "sub-consumer" designated for that range (intended to be used with whole files). If it's not in a range designated for any sub-consumer, the diagnostic is passed to all registered sub-consumers.

This is intended to be used for batch mode, so that diagnostics that are definitely associated with a particular file can be emitted in that file's .dia output, while diagnostics that may be associated with other files (such as those that come from Clang) will still get presented to the user.