### PR TITLE
utils: remove reference to swiftImageInspectionStatic

### DIFF
--- a/utils/static-executable-args.lnk
+++ b/utils/static-executable-args.lnk
@@ -1,6 +1,5 @@
 -static
 -lswiftCore
--lswiftImageInspectionStatic
 -Xlinker
 --defsym=__import_pthread_self=pthread_self
 -Xlinker


### PR DESCRIPTION
This was removed with the metadata registration restructuring for ELF.
There is no equivalent for this.  The metadata registration occurs via
the swiftrt.o object now in the same manner across all build types.

This is a cherry-pick from #14772
rdar://problem/37710244