### PR TITLE
[SubstitutionMap] Handle conformance lookup via superclass requirements.

### DIFF
--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -192,9 +192,19 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
 
   auto genericSig = getGenericSignature();
 
-  // If the type doesn't conform to this protocol, fail.
-  if (!genericSig->conformsToProtocol(type, proto))
+  // If the type doesn't conform to this protocol, the result isn't formed
+  // from these requirements.
+  if (!genericSig->conformsToProtocol(type, proto)) {
+    // Check whether the superclass conforms.
+    if (auto superclass = genericSig->getSuperclassBound(type)) {
+      return LookUpConformanceInSignature(*getGenericSignature())(
+                                                 type->getCanonicalType(),
+                                                 superclass,
+                                                 proto->getDeclaredType());
+    }
+
     return None;
+  }
 
   auto accessPath =
     genericSig->getConformanceAccessPath(type, proto);

--- a/validation-test/compiler_crashers_2_fixed/0144-sr7072.swift
+++ b/validation-test/compiler_crashers_2_fixed/0144-sr7072.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend %s -emit-sil -o - | %FileCheck %s
+
+public final class GenClass<Element: Cl> {
+    public subscript(index: Int) -> Element {
+        get { return unsafeBitCast(0, to: Element.self) }
+    }
+}
+
+public protocol Proto { }
+
+public struct Iter<Element: Proto>: IteratorProtocol {
+    public mutating func next() -> Element? { return nil }
+}
+
+extension GenClass: RandomAccessCollection {
+    public func makeIterator() -> Iter<Element> { return Iter() }
+    public var startIndex: Int { return 0 }
+    public var endIndex: Int { return 0 }
+}
+
+open class Cl: Proto { }
+
+class Bar: Cl {
+    var x: Int?
+}
+
+// CHECK-LABEL: sil hidden @$S4main5crash4barsSbAA8GenClassCyAA3BarCG_tF
+func crash(bars: GenClass<Bar>) -> Bool {
+    // CHECK: apply [[FN:%.*]]<Bar, [Bar]>
+    return Array(bars.filter { $0.x == nil }).isEmpty
+}


### PR DESCRIPTION
Conformances that discoverably for a type parameter via a superclass
requirement occupy a bit of a gray area in the type checker and
generic signature handling right now: we have a type parameter (so the
paths that handle concrete conformances don't kick in), but the
conformance itself isn't modeled as a requirement because it is
available via lookup. Teach SubstitutionMap's conformance lookup to
detect this case and perform conformance lookup in the generic
signature (i.e., falling back to global lookup) in this case,
replicating the hack that IRGen uses to address the same issue when
accessing the conformance (see GenArchetype.cpp's TODO where we lookup
a conformance on the superclass). The removal of that hack (as well as
this one) are tracked by rdar://problem/34609744.

For now, fixes SR-7072 / rdar://problem/37904576.
