### PR TITLE
[4.1] [SubstitutionMap] Handle conformance lookup via superclass requirements.

### DIFF
--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -192,9 +192,19 @@ SubstitutionMap::lookupConformance(CanType type, ProtocolDecl *proto) const {
 
   auto genericSig = getGenericSignature();
 
-  // If the type doesn't conform to this protocol, fail.
-  if (!genericSig->conformsToProtocol(type, proto))
+  // If the type doesn't conform to this protocol, the result isn't formed
+  // from these requirements.
+  if (!genericSig->conformsToProtocol(type, proto)) {
+    // Check whether the superclass conforms.
+    if (auto superclass = genericSig->getSuperclassBound(type)) {
+      return LookUpConformanceInSignature(*getGenericSignature())(
+                                                 type->getCanonicalType(),
+                                                 superclass,
+                                                 proto->getDeclaredType());
+    }
+
     return None;
+  }
 
   auto accessPath =
     genericSig->getConformanceAccessPath(type, proto);

--- a/validation-test/compiler_crashers_2_fixed/0144-sr7072.swift
+++ b/validation-test/compiler_crashers_2_fixed/0144-sr7072.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend %s -emit-sil -o - | %FileCheck %s
+
+public final class GenClass<Element: Cl> {
+    public subscript(index: Int) -> Element {
+        get { return unsafeBitCast(0, to: Element.self) }
+    }
+}
+
+public protocol Proto { }
+
+public struct Iter<Element: Proto>: IteratorProtocol {
+    public mutating func next() -> Element? { return nil }
+}
+
+extension GenClass: RandomAccessCollection {
+    public func makeIterator() -> Iter<Element> { return Iter() }
+    public var startIndex: Int { return 0 }
+    public var endIndex: Int { return 0 }
+}
+
+open class Cl: Proto { }
+
+class Bar: Cl {
+    var x: Int?
+}
+
+// CHECK-LABEL: sil hidden @$S4main5crash4barsSbAA8GenClassCyAA3BarCG_tF
+func crash(bars: GenClass<Bar>) -> Bool {
+    // CHECK: apply [[FN:%.*]]<Bar, [Bar]>
+    return Array(bars.filter { $0.x == nil }).isEmpty
+}

--- a/validation-test/compiler_crashers_2_fixed/0144-sr7072.swift
+++ b/validation-test/compiler_crashers_2_fixed/0144-sr7072.swift
@@ -24,7 +24,7 @@ class Bar: Cl {
     var x: Int?
 }
 
-// CHECK-LABEL: sil hidden @_T04main5crash4barsSbAA8GenClassCyAA3BarCG_tF
+// CHECK-LABEL: sil hidden @_T04main5crashSbAA8GenClassCyAA3BarCG4bars_tF
 func crash(bars: GenClass<Bar>) -> Bool {
     // CHECK: apply [[FN:%.*]]<Bar, [Bar]>
     return Array(bars.filter { $0.x == nil }).isEmpty

--- a/validation-test/compiler_crashers_2_fixed/0144-sr7072.swift
+++ b/validation-test/compiler_crashers_2_fixed/0144-sr7072.swift
@@ -24,7 +24,7 @@ class Bar: Cl {
     var x: Int?
 }
 
-// CHECK-LABEL: sil hidden @$S4main5crash4barsSbAA8GenClassCyAA3BarCG_tF
+// CHECK-LABEL: sil hidden @_T04main5crash4barsSbAA8GenClassCyAA3BarCG_tF
 func crash(bars: GenClass<Bar>) -> Bool {
     // CHECK: apply [[FN:%.*]]<Bar, [Bar]>
     return Array(bars.filter { $0.x == nil }).isEmpty


### PR DESCRIPTION
**Explanation:** Teach SubstitutionMap's conformance lookup to
detect the case where a conformance can only be determined by lookup for a
concrete conformance on the superclass bound of a type variable, which otherwise
would fail (causing a crash).
**Scope:** Affects projects that make use of superclass bounds in certain specific cases, potentially triggered by the optimizer.
**Risk:** Very low; we're only changing behavior along a path that would otherwise fail (and crash).
**Testing:** Regression tests, including a new test reduced by @eeckstein 
**Reviewer:** @eeckstein, who developed this with me
**SR / Radar:** SR-7072 / rdar://problem/37904576.