### PR TITLE
MandatoryInlining: Add a peephole for inlining thorough a thin to noe…

### DIFF
--- a/test/SILOptimizer/mandatory_inlining.sil
+++ b/test/SILOptimizer/mandatory_inlining.sil
@@ -1184,3 +1184,23 @@ bb0(%0: $C):
   apply %closure() : $@callee_guaranteed () -> ()
   return %closure : $@callee_guaranteed () -> ()
 }
+
+
+sil [transparent] @return_one : $@convention(thin) () -> Builtin.Int32 {
+bb0:
+  %0 = integer_literal $Builtin.Int32, 1
+  return %0 : $Builtin.Int32
+}
+
+// CHECK-LABEL: sil @test_thin_convert_function_inline
+// CHECK-NEXT: bb0
+// CHECK-NEXT: [[RES:%.*]] = integer_literal $Builtin.Int32, 1
+// CHECK-NEXT  return [[RES]]
+sil @test_thin_convert_function_inline : $@convention(thin) () -> Builtin.Int32 {
+bb0:
+  %0 = function_ref @return_one : $@convention(thin) () -> Builtin.Int32
+  %1 = convert_function %0 : $@convention(thin) () -> Builtin.Int32 to $@convention(thin) @noescape () -> Builtin.Int32
+  %2 = thin_to_thick_function %1 : $@convention(thin) @noescape () -> Builtin.Int32 to $@noescape () -> Builtin.Int32
+  %3 = apply %2() : $@noescape () -> Builtin.Int32
+  return %3 : $Builtin.Int32
+}


### PR DESCRIPTION
…scape conversion

  %0 = function_ref @return_one : $@convention(thin) () -> Builtin.Int32
  %1 = convert_function %0 : $@convention(thin) () -> Builtin.Int32 to $@convention(thin) @noescape () -> Builtin.Int32
  %2 = thin_to_thick_function %1 : $@convention(thin) @noescape () -> Builtin.Int32 to $@noescape () -> Builtin.Int32
  %3 = apply %2() : $@noescape () -> Builtin.Int32

rdar://37945226