### PR TITLE
[stdlib] Source compatibility fix for lazy filter-filter and map-map cases

### DIFF
--- a/stdlib/public/core/Filter.swift
+++ b/stdlib/public/core/Filter.swift
@@ -385,6 +385,7 @@ extension LazyCollectionProtocol {
 }
 
 extension LazyFilterSequence {
+  @available(swift, introduced: 5)
   public func filter(
     _ isIncluded: @escaping (Element) -> Bool
   ) -> LazyFilterSequence<Base> {
@@ -395,6 +396,7 @@ extension LazyFilterSequence {
 }
 
 extension LazyFilterCollection {
+  @available(swift, introduced: 5)
   public func filter(
     _ isIncluded: @escaping (Element) -> Bool
   ) -> LazyFilterCollection<Base> {

--- a/stdlib/public/core/Map.swift
+++ b/stdlib/public/core/Map.swift
@@ -278,6 +278,7 @@ extension LazyMapCollection {
 
 extension LazyMapSequence {
   @_inlineable
+  @available(swift, introduced: 5)
   public func map<ElementOfResult>(
     _ transform: @escaping (Element) -> ElementOfResult
   ) -> LazyMapSequence<Base, ElementOfResult> {
@@ -289,6 +290,7 @@ extension LazyMapSequence {
 
 extension LazyMapCollection {
   @_inlineable
+  @available(swift, introduced: 5)
   public func map<ElementOfResult>(
     _ transform: @escaping (Element) -> ElementOfResult
   ) -> LazyMapCollection<Base, ElementOfResult> {

--- a/test/stdlib/Filter.swift
+++ b/test/stdlib/Filter.swift
@@ -73,36 +73,4 @@ FilterTests.test("single-count") {
   expectEqual(30, count)
 }
 
-FilterTests.test("Double filter type/Sequence") {
-  func foldingLevels<S : Sequence>(_ xs: S) {
-    var result = xs.lazy.filter { _ in true }.filter { _ in true }
-    expectType(LazyFilterSequence<S>.self, &result)
-  }
-  foldingLevels(Array(0..<10))
-
-  func backwardCompatible<S : Sequence>(_ xs: S) {
-    typealias ExpectedType = LazyFilterSequence<LazyFilterSequence<S>>
-    var result: ExpectedType = xs.lazy
-      .filter { _ in true }.filter { _ in true }
-    expectType(ExpectedType.self, &result)
-  }
-  backwardCompatible(Array(0..<10))
-}
-
-FilterTests.test("Double filter type/Collection") {
-  func foldingLevels<C : Collection>(_ xs: C) {
-    var result = xs.lazy.filter { _ in true }.filter { _ in true }
-    expectType(LazyFilterCollection<C>.self, &result)
-  }
-  foldingLevels(Array(0..<10))
-
-  func backwardCompatible<C : Collection>(_ xs: C) {
-    typealias ExpectedType = LazyFilterCollection<LazyFilterCollection<C>>
-    var result: ExpectedType = xs.lazy
-      .filter { _ in true }.filter { _ in true }
-    expectType(ExpectedType.self, &result)
-  }
-  backwardCompatible(Array(0..<10))
-}
-
 runAllTests()

--- a/test/stdlib/Map.swift
+++ b/test/stdlib/Map.swift
@@ -100,40 +100,5 @@ print(Array(m1))
 // CHECK-NEXT: [2, 4, 6, 8]
 print(Array(m1))
 
-// lazy.map.map chain should fold two layers of LazyMapSequence
-func foldingLevelsSequence<S : Sequence>(_ xs: S) {
-  let result = xs.lazy.map { $0 }.map { $0 }
-  print(type(of: result))
-}
-// CHECK-NEXT: LazyMapSequence<Array<Int>, Int>
-foldingLevelsSequence(Array(0..<10))
-
-// ... but the old way should also be available given explicit type context
-func backwardCompatibleSequence<S : Sequence>(_ xs: S) {
-  typealias ExpectedType = LazyMapSequence<LazyMapSequence<S, S.Element>, S.Element>
-  let result: ExpectedType = xs.lazy.map { $0 }.map { $0 }
-  print(type(of: result))
-}
-// CHECK-NEXT: LazyMapSequence<LazyMapSequence<Array<Int>, Int>, Int>
-backwardCompatibleSequence(Array(0..<10))
-
-// lazy.map.map chain should fold two layers of LazyMapCollection
-func foldingLevelsCollection<C : Collection>(_ xs: C) {
-  let result = xs.lazy.map { $0 }.map { $0 }
-  print(type(of: result))
-}
-// CHECK-NEXT: LazyMapCollection<Array<Int>, Int>
-foldingLevelsCollection(Array(0..<10))
-
-// ... but the old way should also be available given explicit type context
-func backwardCompatibleCollection<C : Collection>(_ xs: C) {
-  typealias ExpectedType =
-    LazyMapCollection<LazyMapCollection<C, C.Element>, C.Element>
-  let result: ExpectedType = xs.lazy.map { $0 }.map { $0 }
-  print(type(of: result))
-}
-// CHECK-NEXT: LazyMapCollection<LazyMapCollection<Array<Int>, Int>, Int>
-backwardCompatibleCollection(Array(0..<10))
-
 // CHECK-NEXT: all done.
 print("all done.")

--- a/test/stdlib/MapFilterLayerFoldingCompatibilty.swift
+++ b/test/stdlib/MapFilterLayerFoldingCompatibilty.swift
@@ -1,0 +1,101 @@
+// RUN: rm -rf %t ; mkdir -p %t
+// RUN: %target-build-swift %s -o %t/a.out3 -swift-version 3 && %target-run %t/a.out3
+// RUN: %target-build-swift %s -o %t/a.out4 -swift-version 4 && %target-run %t/a.out4
+// RUN: %target-build-swift %s -o %t/a.out5 -swift-version 5 && %target-run %t/a.out5
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+#if swift(>=5)
+let swiftVersion = ">=5"
+#else
+let swiftVersion = "<5"
+#endif
+
+let tests = TestSuite("MapFilterLayerFoldingCompatibility")
+
+tests.test("Double filter type/Sequence/\(swiftVersion)") {
+  func foldingLevels<S : Sequence>(_ xs: S) {
+    var result = xs.lazy.filter { _ in true }.filter { _ in true }
+#if swift(>=5)
+    expectType(LazyFilterSequence<S>.self, &result)
+#else
+    expectType(LazyFilterSequence<LazyFilterSequence<S>>.self, &result)
+#endif
+  }
+  foldingLevels(Array(0..<10))
+
+  func backwardCompatible<S : Sequence>(_ xs: S) {
+    typealias ExpectedType = LazyFilterSequence<LazyFilterSequence<S>>
+    var result: ExpectedType = xs.lazy
+      .filter { _ in true }.filter { _ in true }
+    expectType(ExpectedType.self, &result)
+  }
+  backwardCompatible(Array(0..<10))
+}
+
+tests.test("Double filter type/Collection/\(swiftVersion)") {
+  func foldingLevels<C : Collection>(_ xs: C) {
+    var result = xs.lazy.filter { _ in true }.filter { _ in true }
+#if swift(>=5)
+    expectType(LazyFilterCollection<C>.self, &result)
+#else
+    expectType(LazyFilterCollection<LazyFilterCollection<C>>.self, &result)
+#endif
+  }
+  foldingLevels(Array(0..<10))
+
+  func backwardCompatible<C : Collection>(_ xs: C) {
+    typealias ExpectedType = LazyFilterCollection<LazyFilterCollection<C>>
+    var result: ExpectedType = xs.lazy
+      .filter { _ in true }.filter { _ in true }
+    expectType(ExpectedType.self, &result)
+  }
+  backwardCompatible(Array(0..<10))
+}
+
+tests.test("Double map type/Sequence/\(swiftVersion)") {
+  func foldingLevels<S : Sequence>(_ xs: S) {
+    var result = xs.lazy.map { $0 }.map { $0 }
+#if swift(>=5)
+    expectType(LazyMapSequence<S, S.Element>.self, &result)
+#else
+    expectType(
+      LazyMapSequence<LazyMapSequence<S, S.Element>, S.Element>.self,
+      &result)
+#endif
+  }
+  foldingLevels(Array(0..<10))
+
+  func backwardCompatible<S : Sequence>(_ xs: S) {
+    typealias ExpectedType =
+      LazyMapSequence<LazyMapSequence<S, S.Element>, S.Element>
+    var result: ExpectedType = xs.lazy.map { $0 }.map { $0 }
+    expectType(ExpectedType.self, &result)
+  }
+  backwardCompatible(Array(0..<10))
+}
+
+tests.test("Double map type/Collection/\(swiftVersion)") {
+  func foldingLevels<C : Collection>(_ xs: C) {
+    var result = xs.lazy.map { $0 }.map { $0 }
+#if swift(>=5)
+    expectType(LazyMapCollection<C, C.Element>.self, &result)
+#else
+    expectType(
+      LazyMapCollection<LazyMapCollection<C, C.Element>, C.Element>.self,
+      &result)
+#endif
+  }
+  foldingLevels(Array(0..<10))
+
+  func backwardCompatible<C : Collection>(_ xs: C) {
+    typealias ExpectedType =
+      LazyMapCollection<LazyMapCollection<C, C.Element>, C.Element>
+    var result: ExpectedType = xs.lazy.map { $0 }.map { $0 }
+    expectType(ExpectedType.self, &result)
+  }
+  backwardCompatible(Array(0..<10))
+}
+
+runAllTests()


### PR DESCRIPTION
In order to maintain source compatibility the type-folding behavior
should not be the default in Swift 3 and Swift 4 modes.