### PR TITLE
[DO NOT MERGE] remove reference to swiftImageInspectionShared static library

### DIFF
--- a/utils/gen-static-stdlib-link-args
+++ b/utils/gen-static-stdlib-link-args
@@ -64,7 +64,6 @@ function write_linkfile {
 -latomic
 -lswiftCore
 -latomic
--lswiftImageInspectionShared
 $ICU_LIBS
 -Xlinker
 -export-dynamic


### PR DESCRIPTION
Even the name of this library shows that it is not a static library....
The static-stdlib-args.lnk file is generated by the
gen-static-stdlib-link-args script. The previous change for SR-7038
(PR 14772) only fixed the reference in the static-executable-args.lnk file.
rdar://problem/37710244