### PR TITLE
Formatting: sanitize formatting option of 0 tab-width. rdar://37835956

### DIFF
--- a/lib/IDE/Formatting.cpp
+++ b/lib/IDE/Formatting.cpp
@@ -982,6 +982,15 @@ std::pair<LineRange, std::string> swift::ide::reformat(LineRange Range,
                                                        CodeFormatOptions Options,
                                                        SourceManager &SM,
                                                        SourceFile &SF) {
+  // Sanitize 0-width tab
+  if (Options.UseTabs && !Options.TabWidth) {
+    // If IndentWidth is specified, use it as the tab width.
+    if (Options.IndentWidth)
+      Options.TabWidth = Options.IndentWidth;
+    // Otherwise, use the default value,
+    else
+      Options.TabWidth = 4;
+  }
   FormatWalker walker(SF, SM);
   auto SourceBufferID = SF.getBufferID().getValue();
   StringRef Text = SM.getLLVMSourceMgr()

--- a/test/SourceKit/CodeFormat/indent-with-tab.swift
+++ b/test/SourceKit/CodeFormat/indent-with-tab.swift
@@ -21,6 +21,7 @@ b: Int) {}
 // RUN: %sourcekitd-test -req=format -line=8 -length=1 -req-opts=usetabs=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=9 -length=1 -req-opts=usetabs=1 %s >>%t.response
 // RUN: %sourcekitd-test -req=format -line=12 -length=1 -req-opts=usetabs=1 %s >>%t.response
+// RUN: %sourcekitd-test -req=format -line=12 -length=1 -req-opts=usetabs=1 -req-opts=tabwidth=0 %s >> %t.response
 // RUN: %FileCheck --strict-whitespace %s <%t.response
 
 // CHECK: key.sourcetext: "class Foo {"
@@ -32,4 +33,5 @@ b: Int) {}
 // CHECK: key.sourcetext: "\t}"
 // CHECK: key.sourcetext: "\t"
 // CHECK: key.sourcetext: "}"
+// CHECK: key.sourcetext: "\t\t b: Int) {}"
 // CHECK: key.sourcetext: "\t\t b: Int) {}"


### PR DESCRIPTION
If the format option specifies using tab of zero width, we reset the
tab width to a non-zero value.