### PR TITLE
Teach the generic specializer how to convert @in_guaranteed parameters to @guaranteed parameters.

### DIFF
--- a/test/SILOptimizer/specialize.sil
+++ b/test/SILOptimizer/specialize.sil
@@ -637,14 +637,14 @@ bb0:
 
 // Test a specialization of a self-recursive generic closure.
 
-// CHECK-LABEL: sil shared @$S27selfReferringGenericClosurexBi64_Bi64_Bi64_Rs_r0_lIetnny_Tp5 : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_1 == Builtin.Int64> (@in_guaranteed τ_0_0, @in_guaranteed Builtin.Int64, Builtin.Int64) -> ()
-// CHECK: [[SPECIALIZED_FN:%[0-9]+]] = function_ref @$S27selfReferringGenericClosurexBi64_Bi64_Bi64_Rs_r0_lIetnny_Tp5
-// CHECK: partial_apply [[SPECIALIZED_FN]]{{.*}}({{.*}}) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_1 == Builtin.Int64> (@in_guaranteed τ_0_0, @in_guaranteed Builtin.Int64, Builtin.Int64) -> ()
+// CHECK-LABEL: sil shared @$S27selfReferringGenericClosurexBi64_Bi64_Bi64_Rs_r0_lIetnyy_Tp5 : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_1 == Builtin.Int64> (@in_guaranteed τ_0_0, Builtin.Int64, Builtin.Int64) -> () {
+// CHECK: [[SPECIALIZED_FN:%[0-9]+]] = function_ref @$S27selfReferringGenericClosurexBi64_Bi64_Bi64_Rs_r0_lIetnyy_Tp5
+// CHECK: partial_apply [[SPECIALIZED_FN]]{{.*}}({{.*}}) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_1 == Builtin.Int64> (@in_guaranteed τ_0_0, Builtin.Int64, Builtin.Int64) -> ()
 
 // CHECK-LABEL: sil @selfReferringGenericClosure : $@convention(thin) <R, S> (@in_guaranteed R, @in_guaranteed S, Builtin.Int64) -> ()
 // Refer to the specialized version of the function
-// CHECK: [[SPECIALIZED_FN:%[0-9]+]] = function_ref @$S27selfReferringGenericClosurexBi64_Bi64_Bi64_Rs_r0_lIetnny_Tp5
-// CHECK: partial_apply [[SPECIALIZED_FN]]<R>({{.*}}) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_1 == Builtin.Int64> (@in_guaranteed τ_0_0, @in_guaranteed Builtin.Int64, Builtin.Int64) -> ()
+// CHECK: [[SPECIALIZED_FN:%[0-9]+]] = function_ref @$S27selfReferringGenericClosurexBi64_Bi64_Bi64_Rs_r0_lIetnyy_Tp5
+// CHECK: partial_apply [[SPECIALIZED_FN]]<R>({{.*}}) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_1 == Builtin.Int64> (@in_guaranteed τ_0_0, Builtin.Int64, Builtin.Int64) -> ()
 sil @selfReferringGenericClosure : $@convention(thin) <R, S> (@in_guaranteed R, @in_guaranteed S, Builtin.Int64) -> () {
 bb0(%0 : $*R, %1 : $*S, %2 : $Builtin.Int64):
   %4 = integer_literal $Builtin.Int64, 100

--- a/test/SILOptimizer/specialize_default_witness_resilience.sil
+++ b/test/SILOptimizer/specialize_default_witness_resilience.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -generic-specializer %s | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-resilience -enable-sil-verify-all -generic-specializer %s | %FileCheck %s
 
 sil_stage canonical
 
@@ -10,16 +10,16 @@ public protocol ResilientProtocol {
   func defaultB()
 }
 
-struct ConformingStruct : ResilientProtocol {
-  func defaultA()
-  func defaultB()
+public struct ConformingStruct : ResilientProtocol {
+  public func defaultA()
+  public func defaultB()
 }
 
 // CHECK-LABEL: sil shared @$S8defaultA4main16ConformingStructV_Tg5
-// CHECK:       bb0(%0 : $ConformingStruct):
+// CHECK:       bb0(%0 : $*ConformingStruct):
 // CHECK:         [[FN:%.*]] = function_ref @$S8defaultB4main16ConformingStructV_Tg5
-// CHECK:    [[RESULT:%.*]] = apply [[FN]]
-// CHECK:    return [[RESULT]]
+// CHECK-NEXT:    [[RESULT:%.*]] = apply [[FN]](%0)
+// CHECK-NEXT:    return [[RESULT]]
 
 sil @defaultA : $@convention(witness_method: ResilientProtocol) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> () {
 bb0(%0 : $*Self):
@@ -29,9 +29,9 @@ bb0(%0 : $*Self):
 }
 
 // CHECK-LABEL: sil shared @$S8defaultB4main16ConformingStructV_Tg5
-// CHECK:       bb0(%0 : $ConformingStruct):
-// CHECK:    [[RESULT:%.*]] = tuple ()
-// CHECK:    return [[RESULT]]
+// CHECK:       bb0(%0 : $*ConformingStruct):
+// CHECK-NEXT:    [[RESULT:%.*]] = tuple ()
+// CHECK-NEXT:    return [[RESULT]]
 
 sil @defaultB : $@convention(witness_method: ResilientProtocol) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> () {
 bb0(%0 : $*Self):
@@ -42,8 +42,8 @@ bb0(%0 : $*Self):
 // CHECK-LABEL: sil hidden @test_specialize_default_witness_method
 // CHECK:       bb0(%0 : $*ConformingStruct):
 // CHECK:         [[FN:%.*]] = function_ref @$S8defaultA4main16ConformingStructV_Tg5
-// CHECK:    [[RESULT:%.*]] = apply [[FN]]
-// CHECK:    return [[RESULT]]
+// CHECK-NEXT:    [[RESULT:%.*]] = apply [[FN]](%0)
+// CHECK-NEXT:    return [[RESULT]]
 
 sil hidden @test_specialize_default_witness_method : $@convention(thin) (@in_guaranteed ConformingStruct) -> () {
 bb0(%0 : $*ConformingStruct):


### PR DESCRIPTION
radars rdar://problem/37947612 and rdar://problem/33767770

We already do this for @in parameters. I think it was just never implemented for
@in_guaranteed. The reason I am doing this now is that a bunch of test cases
that tested @in -> trivial. By doing this I get the @in_guaranteed -> trivial
implying those test cases do not need to be updated.

Important Note: We have bad test cases for resilience when dealing with generic specializer. Also add correct test cases + change existing ones