### PR TITLE
swift-api-digester: serialize and de-serialize whether a parameter has a default argument.

### DIFF
--- a/include/swift/IDE/DigesterEnums.def
+++ b/include/swift/IDE/DigesterEnums.def
@@ -90,6 +90,7 @@ KEY(declKind)
 KEY(ownership)
 KEY(superclassUsr)
 KEY(parentExtensionReqs)
+KEY(hasDefaultArg)
 
 KNOWN_TYPE(Optional)
 KNOWN_TYPE(ImplicitlyUnwrappedOptional)

--- a/test/api-digester/Inputs/cake.swift
+++ b/test/api-digester/Inputs/cake.swift
@@ -22,3 +22,6 @@ public extension C0 where T1 == S1, T2 == S1, T3 == S1 {
 public extension C0 {
   func unconditionalFooExt() {}
 }
+
+public func foo1(_ a: Int = 1, b: S1) {}
+public func foo2(_ a: Int = #line, b: S1) {}

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -335,6 +335,60 @@
           ]
         }
       ]
+    },
+    {
+      "kind": "Function",
+      "name": "foo1",
+      "printedName": "foo1(_:b:)",
+      "declKind": "Func",
+      "usr": "s:4cake4foo1_1bySi_AA2S1VtF",
+      "location": "",
+      "moduleName": "cake",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Void",
+          "printedName": "()"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "Int",
+          "printedName": "Int",
+          "hasDefaultArg": true
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "S1",
+          "printedName": "S1"
+        }
+      ]
+    },
+    {
+      "kind": "Function",
+      "name": "foo2",
+      "printedName": "foo2(_:b:)",
+      "declKind": "Func",
+      "usr": "s:4cake4foo2_1bySi_AA2S1VtF",
+      "location": "",
+      "moduleName": "cake",
+      "children": [
+        {
+          "kind": "TypeNominal",
+          "name": "Void",
+          "printedName": "()"
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "Int",
+          "printedName": "Int",
+          "hasDefaultArg": true
+        },
+        {
+          "kind": "TypeNominal",
+          "name": "S1",
+          "printedName": "S1"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Removing default arguments can be source-breaking.