### PR TITLE
Revert "Mark the runtime's reimplementation of fixed_seed_override weak"

### DIFF
--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -129,13 +129,8 @@ void swift::_swift_instantiateInertHeapObject(void *address,
 
 namespace llvm { namespace hashing { namespace detail {
   // An extern variable expected by LLVM's hashing templates. We don't link any
-  // LLVM libs into the runtime, so define it as a weak symbol.
-  //
-  // Systems that compile this code into a dynamic library will do so with
-  // hidden visibility, making this all internal to the dynamic library.
-  // Systems that statically link the Swift runtime into applications (e.g. on
-  // Linux) need this to handle the case when the app already uses LLVM.
-  size_t LLVM_ATTRIBUTE_WEAK fixed_seed_override = 0;
+  // LLVM libs into the runtime, so define this here.
+  size_t fixed_seed_override = 0;
 } // namespace detail
 } // namespace hashing
 } // namespace llvm


### PR DESCRIPTION
Reverts apple/swift#14791. Apple policy doesn't allow libraries with weak definitions, so we can't use this solution, at least not unconditionally.