### PR TITLE
[5.0][SourceKit] Add defensive guard for invalid offset

### DIFF
--- a/test/SourceKit/CursorInfo/invalid_offset.swift
+++ b/test/SourceKit/CursorInfo/invalid_offset.swift
@@ -1,0 +1,12 @@
+let a = 12
+
+// rdar://problem/30346106
+// Invalid offset should trigger a crash.
+
+// RUN: %sourcekitd-test \
+// RUN:   -req=open %s -- %s == \
+// RUN:   -req=edit -async -offset=0 -length=200 -replace='' %s -- %s == \
+// RUN:   -req=cursor -offset=250 %s -- %s \
+// RUN: | %FileCheck %s
+
+// CHECK: <empty cursor info>

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -496,6 +496,11 @@ void walkRelatedDecls(const ValueDecl *VD, const FnTy &Fn) {
 static StringRef getSourceToken(unsigned Offset,
                                 ImmutableTextSnapshotRef Snap) {
   auto MemBuf = Snap->getBuffer()->getInternalBuffer();
+
+  // FIXME: Invalid offset shouldn't reach here.
+  if (Offset >= MemBuf->getBufferSize())
+    return StringRef();
+
   SourceManager SM;
   auto MemBufRef = llvm::MemoryBuffer::getMemBuffer(MemBuf->getBuffer(),
                                                  MemBuf->getBufferIdentifier());


### PR DESCRIPTION
Cherry-pick of #14803 for swift-5.0-branch

Invalid offset used to cause a inifinite loop in Lexer in some race
condition.

This is a quick fix until we fix underlying problem in SourceKit.

