### PR TITLE
linux: remove swiftImageInspectionShared

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -265,10 +265,6 @@ elseif(SWIFT_PRIMARY_VARIANT_SDK STREQUAL FREEBSD)
   # workaround for libatomic needing to be after object files for swiftCore.so
   list(APPEND swift_core_private_link_libraries
     ${SWIFTLIB_DIR}/clang/lib/freebsd/libclang_rt.builtins-${SWIFT_PRIMARY_VARIANT_ARCH}.a)
-elseif(SWIFT_PRIMARY_VARIANT_SDK STREQUAL LINUX)
-  if(SWIFT_BUILD_STATIC_STDLIB)
-    list(APPEND swift_core_private_link_libraries swiftImageInspectionShared)
-  endif()
 elseif(SWIFT_PRIMARY_VARIANT_SDK STREQUAL WINDOWS)
   list(APPEND swift_core_private_link_libraries shell32;DbgHelp)
 endif()

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -90,47 +90,8 @@ list(APPEND swift_runtime_library_compile_flags -I${SWIFT_SOURCE_DIR}/include)
 
 set(sdk "${SWIFT_HOST_VARIANT_SDK}")
 if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
-  list(REMOVE_ITEM swift_runtime_sources ImageInspectionELF.cpp)
   set(static_binary_lnk_file_list)
   string(TOLOWER "${sdk}" lowercase_sdk)
-
-  # These two libraries are only used with the static swiftcore
-  add_swift_target_library(swiftImageInspectionShared STATIC
-    ImageInspectionELF.cpp
-    C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
-    LINK_FLAGS ${swift_runtime_linker_flags}
-    SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
-    INSTALL_IN_COMPONENT stdlib)
-
-  foreach(arch IN LISTS SWIFT_SDK_${sdk}_ARCHITECTURES)
-    set(FragileSupportLibrary swiftImageInspectionShared-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch})
-    set(LibraryLocation ${SWIFTSTATICLIB_DIR}/${lowercase_sdk}/${arch})
-    add_custom_command_target(swift_image_inspection_${arch}_static
-      COMMAND
-        "${CMAKE_COMMAND}" -E copy $<TARGET_FILE:${FragileSupportLibrary}> ${LibraryLocation}
-      OUTPUT
-        "${LibraryLocation}/${CMAKE_STATIC_LIBRARY_PREFIX}swiftImageInspectionShared${CMAKE_STATIC_LIBRARY_SUFFIX}"
-      DEPENDS
-         ${FragileSupportLibrary})
-    add_dependencies(stdlib ${FragileSupportLibrary})
-    swift_install_in_component(FILES $<TARGET_FILE:${FragileSupportLibrary}>
-                               DESTINATION "lib/swift_static/${lowercase_sdk}/${arch}"
-                               COMPONENT stdlib)
-  endforeach()
-
-  set(FragileSupportLibraryPrimary swiftImageInspectionShared-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${SWIFT_PRIMARY_VARIANT_ARCH})
-  set(LibraryLocationPrimary ${SWIFTSTATICLIB_DIR}/${lowercase_sdk})
-  add_custom_command_target(swift_image_inspection_static_primary_arch
-      COMMAND
-         "${CMAKE_COMMAND}" -E copy $<TARGET_FILE:${FragileSupportLibraryPrimary}> ${LibraryLocationPrimary}
-      OUTPUT
-      "${LibraryLocationPrimary}/${CMAKE_STATIC_LIBRARY_PREFIX}swiftImageInspectionShared${CMAKE_STATIC_LIBRARY_SUFFIX}"
-      DEPENDS
-         ${FragileSupportLibraryPrimary})
-    add_dependencies(stdlib ${FragileSupportLibraryPrimary})
-    swift_install_in_component(FILES $<TARGET_FILE:${FragileSupportLibraryPrimary}>
-                               DESTINATION "lib/swift_static/${lowercase_sdk}"
-                               COMPONENT stdlib)
 
   # Generate the static-executable-args.lnk file used for ELF systems (eg linux)
   set(linkfile "${lowercase_sdk}/static-executable-args.lnk")
@@ -149,18 +110,7 @@ if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
                              DESTINATION "lib/swift_static/${lowercase_sdk}"
                              COMPONENT stdlib)
   add_custom_target(static_binary_magic ALL DEPENDS ${static_binary_lnk_file_list})
-  foreach(arch IN LISTS SWIFT_SDK_LINUX_ARCHITECTURES)
-    add_dependencies(static_binary_magic ${swift_image_inspection_${arch}_static})
-  endforeach()
-  add_dependencies(static_binary_magic ${swift_image_inspection_static_primary_arch})
   add_dependencies(stdlib static_binary_magic)
-
-  add_swift_target_library(swiftImageInspectionSharedObject OBJECT_LIBRARY
-    ImageInspectionELF.cpp
-    C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
-    LINK_FLAGS ${swift_runtime_linker_flags}
-    SWIFT_COMPILE_FLAGS ${SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS}
-    INSTALL_IN_COMPONENT never_install)
 endif()
 
 add_swift_target_library(swiftRuntime OBJECT_LIBRARY

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -28,12 +28,6 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     endif()
   endif()
 
-  set(swift_runtime_test_extra_libraries)
-  if(SWIFT_BUILD_STATIC_STDLIB AND "${SWIFT_HOST_VARIANT_SDK}" STREQUAL "LINUX")
-    list(APPEND swift_runtime_test_extra_libraries 
-      $<TARGET_FILE:swiftImageInspectionShared-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}>)
-  endif()
-
   add_subdirectory(LongTests)
 
   set(PLATFORM_SOURCES)
@@ -90,7 +84,6 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     PRIVATE
     swiftCore${SWIFT_PRIMARY_VARIANT_SUFFIX}
     ${PLATFORM_TARGET_LINK_LIBRARIES}
-    ${swift_runtime_test_extra_libraries}
     )
 endif()
 

--- a/utils/gen-static-stdlib-link-args
+++ b/utils/gen-static-stdlib-link-args
@@ -64,7 +64,6 @@ function write_linkfile {
 -latomic
 -lswiftCore
 -latomic
--lswiftImageInspectionShared
 $ICU_LIBS
 -lstdc++
 -lm

--- a/utils/static-executable-args.lnk
+++ b/utils/static-executable-args.lnk
@@ -1,6 +1,5 @@
 -static
 -lswiftCore
--lswiftImageInspectionShared
 -Xlinker
 --defsym=__import_pthread_self=pthread_self
 -Xlinker


### PR DESCRIPTION
Merge this into the runtime as expected rather than having a separate
component.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
