### PR TITLE
runtime: add `initializeTypeFieldLookup` on COFF

### DIFF
--- a/stdlib/public/runtime/ImageInspectionCOFF.cpp
+++ b/stdlib/public/runtime/ImageInspectionCOFF.cpp
@@ -82,6 +82,20 @@ void swift::initializeTypeMetadataRecordLookup() {
   }
 }
 
+void swift::initializeTypeFieldLookup() {
+  const swift::MetadataSections *sections = registered;
+  while (true) {
+    const swift::MetadataSections::Range &fields = sections->swift5_fieldmd;
+    if (fields.length)
+      addImageTypeFieldDescriptorBlockCallback(
+          reinterpret_cast<void *>(fields.start), fields.length);
+
+    if (sections->next == registered)
+      break;
+    sections = sections->next;
+  }
+}
+
 SWIFT_RUNTIME_EXPORT
 void swift_addNewDSOImage(const void *addr) {
   const swift::MetadataSections *sections =


### PR DESCRIPTION
The runtime needs this method to initialize the type fields when loading
the images.  This was added to the ELF side of the initialization path
but not the COFF side.  It repairs the swiftCore.dll build for Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
