### PR TITLE
Restore build and install of the swiftImageInspectionShared library

### DIFF
--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -102,6 +102,10 @@ if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
   set_target_properties(swiftImageInspectionShared PROPERTIES
     ARCHIVE_OUTPUT_DIRECTORY "${SWIFTSTATICLIB_DIR}/${lowercase_sdk}")
 
+  swift_install_in_component(stdlib
+    TARGETS swiftImageInspectionShared
+    DESTINATION "lib/swift_static/${lowercase_sdk}")
+
   # Generate the static-executable-args.lnk file used for ELF systems (eg linux)
   set(linkfile "${lowercase_sdk}/static-executable-args.lnk")
   add_custom_command_target(swift_static_binary_${sdk}_args


### PR DESCRIPTION
Commit 0c42b57962 ("ELF: restructure image metadata registration")
removed the swift_install_in_component lines for both
swiftImageInspectionStatic and swiftImageInspectionShared libraries,
even though only the former library was removed in that change. As a
result, the swiftImageInspectionShared was not being built or
installed. This should fix SR-7038.
rdar://problem/37710244