### PR TITLE
[stdlib] String comparison prefix segment bug

### DIFF
--- a/stdlib/public/core/NormalizedCodeUnitIterator.swift
+++ b/stdlib/public/core/NormalizedCodeUnitIterator.swift
@@ -128,8 +128,7 @@ struct _NormalizedCodeUnitIterator: IteratorProtocol {
         index += 1
         bufferIndex += 1
       } while unmanagedString.hasNormalizationBoundary(
-          after: index - 1, 
-          count: unmanagedString.count) == false
+          after: index - 1) == false
       
       return bufferIndex
     }

--- a/stdlib/public/core/StringComparison.swift
+++ b/stdlib/public/core/StringComparison.swift
@@ -1115,8 +1115,8 @@ extension _UnmanagedString where CodeUnit == UInt16 {
       &selfOutputBuffer, selfLength,
       &otherOutputBuffer, otherLength) 
     {
-      let selfSlice = self[selfSegmentEndIdx...]
-      let otherSlice = other[otherSegmentEndIdx...]
+      let selfSlice = self[selfSegmentStartIdx...]
+      let otherSlice = other[otherSegmentStartIdx...]
       return selfSlice._compareStringsPathological(other: otherSlice)
     }
 

--- a/stdlib/public/core/StringComparison.swift
+++ b/stdlib/public/core/StringComparison.swift
@@ -803,7 +803,7 @@ extension _UnmanagedString where CodeUnit == UInt8 {
       if idx+1 == other.count {
         return _lexicographicalCompare(selfASCIIChar, otherCU)
       }
-      if _fastPath(other.hasNormalizationBoundary(after: idx, count: other.count)) {
+      if _fastPath(other.hasNormalizationBoundary(after: idx)) {
         return _lexicographicalCompare(selfASCIIChar, otherCU)
       }
     }
@@ -843,9 +843,9 @@ extension _UnmanagedOpaqueString {
 }
 
 extension _UnmanagedString where CodeUnit == UInt16 {
-  func hasNormalizationBoundary(after index: Int, count: Int) -> Bool {
+  func hasNormalizationBoundary(after index: Int) -> Bool {
     let nextIndex = index + 1
-    if nextIndex >= count {
+    if nextIndex >= self.count {
       return true
     }
     

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -2011,6 +2011,7 @@ let comparisonTestCases = [
     "a\u{fa1}\u{fb7}\u{fa1}\u{fb7}a\u{fa1}\u{fb7}\u{fa1}\u{fb7}\u{fa1}\u{fb7}\u{fa1}\u{fb7}\u{fa1}\u{fb7}\u{fa1}\u{fb7}"
     ], .equal),
 
+  ComparisonTestCase(["a\u{301}\u{0301}", "\u{e1}"], .greater),
   ComparisonTestCase(["😀", "😀"], .equal),
   ComparisonTestCase(["\u{2f9df}", "\u{8f38}"], .equal),
   ComparisonTestCase([


### PR DESCRIPTION
shorterPrefixesOther doesn't consume the longer segment, it only invalidates the shorter one. The pathological case needs to compare the entire segment, not skip the end of the longer one.