### PR TITLE
[+0-all-args] Use SILGenBuilder APIs when converting bridged to nativ…

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1094,10 +1094,8 @@ ManagedValue SILGenFunction::emitBridgedToNativeError(SILLocation loc,
     };
     auto conformances = getASTContext().AllocateCopy(conformanceArray);
 
-    SILValue nativeError =
-      B.createInitExistentialRef(loc, nativeErrorTy, bridgedErrorTy,
-                                 bridgedError.forward(*this), conformances);
-    return emitManagedRValueWithCleanup(nativeError);
+    return B.createInitExistentialRef(loc, nativeErrorTy, bridgedErrorTy,
+                                      bridgedError, conformances);
   }
 
   // Otherwise, we need to call a runtime function to potential substitute


### PR DESCRIPTION
…e errors.

By using this API, we properly forward ownership when we perform this
conversion. Previously if we had a guaranteed bridged error argument, we would
wrap the bridged error argument in an class existential box and then destroy
that box, violating the +0 contract. Instead now we forward the ownership
correctly through the init_existential_ref.

Found while updating SILGen tests for +0 arguments.

rdar://34222540
