### PR TITLE
[+0-normal-args] When partially applying a super method, be sure that…

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4095,6 +4095,10 @@ CallEmission::applyPartiallyAppliedSuperMethod(SGFContext C) {
   auto subs = callee.getSubstitutions();
   auto upcastedSelf = uncurriedArgs.back();
 
+  // Make sure that upcasted self is at +1 since we are going to place it into a
+  // partial_apply.
+  upcastedSelf = upcastedSelf.ensurePlusOne(SGF, loc);
+
   auto constantInfo = SGF.getConstantInfo(callee.getMethodName());
   auto functionTy = constantInfo.getSILType();
   ManagedValue superMethod;
@@ -4120,11 +4124,9 @@ CallEmission::applyPartiallyAppliedSuperMethod(SGFContext C) {
   if (constantInfo.SILFnType->isPolymorphic() && !subs.empty())
     partialApplyTy = partialApplyTy.substGenericArgs(module, subs);
 
-  SILValue partialApply =
-      SGF.B.createPartialApply(loc, superMethod.getValue(), partialApplyTy,
-                               subs, {upcastedSelf.forward(SGF)}, closureTy);
+  ManagedValue pa = SGF.B.createPartialApply(loc, superMethod, partialApplyTy,
+                                             subs, {upcastedSelf}, closureTy);
   assert(!closureTy.castTo<SILFunctionType>()->isNoEscape());
-  ManagedValue pa = SGF.emitManagedRValueWithCleanup(partialApply);
   firstLevelResult.value = RValue(SGF, loc, formalApplyType.getResult(), pa);
   return firstLevelResult;
 }


### PR DESCRIPTION
… upcasted self is at +1.

Since I used ensurePlusOne, this should not have any effect on the compiler
today. This happens quite often once "normal arguments" are at +0 though.

I also changed this code to use SILGenBuilder APIs to ensure that ownership is
forwarded correctly.

Found when updating SILGen tests for +0.

rdar://34222540