### PR TITLE
[+0-normal-args] When performing optional-to-optional conversions, be…

### DIFF
--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -369,6 +369,9 @@ SILGenFunction::emitOptionalToOptional(SILLocation loc,
   auto isNotPresentBB = createBasicBlock();
   auto isPresentBB = createBasicBlock();
 
+  // All conversions happen at +1.
+  input = input.ensurePlusOne(*this, loc);
+
   SwitchEnumBuilder SEBuilder(B, loc, input);
   SILType noOptResultTy = resultTy.getOptionalObjectType();
   assert(noOptResultTy);


### PR DESCRIPTION
… sure the passed in conversion is at +1 since all conversions happen at +1.

This assumption is already in the code here. My change just makes it so that
when we perform optional-to-optional on a +0 argument, we copy before the
transform.

Caught via the ownership verifier when updating test/SILGen/objc_blocks_bridging.swift for +0 arguments.

rdar://34222540