### PR TITLE
Factor out the test for the .apple_names section and disable it on Li…

### DIFF
--- a/test/DebugInfo/apple-names-accel.swift
+++ b/test/DebugInfo/apple-names-accel.swift
@@ -1,0 +1,10 @@
+// Check that the apple-names section is emitted on Darwin.
+// Adapted from llvm/test/DebugInfo/X86/debugger-tune.ll
+// RUN: %target-swiftc_driver -emit-object -g %s -o %t
+// RUN: llvm-readobj -sections %t | %FileCheck --check-prefix=CHECK-LLDB %s
+
+// CHECK-LLDB-NOT: debug_pubnames
+// CHECK-LLDB:     apple_names
+// CHECK-LLDB-NOT: debug_pubnames
+
+// REQUIRES: OS=macosx

--- a/test/DebugInfo/compiler-flags.swift
+++ b/test/DebugInfo/compiler-flags.swift
@@ -12,16 +12,6 @@
 // CHECK-EXPLICIT-NOT:            "
 // CHECK-EXPLICIT-SAME:           -resource-dir 
 
-
-// Check that we tune the debug output for LLDB.
-// Adapted from llvm/test/DebugInfo/X86/debugger-tune.ll
-// RUN: %target-swiftc_driver -emit-object -g %s -o %t
-// RUN: llvm-readobj -sections %t | %FileCheck --check-prefix=CHECK-LLDB %s
-
-// CHECK-LLDB-NOT: debug_pubnames
-// CHECK-LLDB:     apple_names
-// CHECK-LLDB-NOT: debug_pubnames
-
 // Check that we don't write temporary file names in the debug info
 // RUN: TMPDIR=abc/def %target-swift-frontend %s -I abc/def/xyz -g -emit-ir -o - | %FileCheck --check-prefix CHECK-TEMP %s
 // CHECK-TEMP: !DICompileUnit({{.*}} flags: "{{.*}} -I <temporary-file>


### PR DESCRIPTION
…nux.

This is in reaction to LLVM r322633.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
