### PR TITLE
Don't spend time initializing LLVM when running the driver

### DIFF
--- a/include/swift/Basic/LLVMInitialize.h
+++ b/include/swift/Basic/LLVMInitialize.h
@@ -10,34 +10,33 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// A file that declares a macro for initializing all parts of LLVM that various
-// binaries in swift use. Please call the macro in the main routine of all
-// binaries.
+// A file that declares macros for initializing all parts of LLVM that various
+// binaries in swift use. Please call PROGRAM_START in the main routine of all
+// binaries, and INITIALIZE_LLVM in anything that uses Clang or LLVM IR.
 //
 //===----------------------------------------------------------------------===//
 
 #ifndef SWIFT_BASIC_LLVMINITIALIZE_H
 #define SWIFT_BASIC_LLVMINITIALIZE_H
 
-#include "llvm/Support/FileSystem.h"
-#include "llvm/Support/Host.h"
 #include "llvm/Support/ManagedStatic.h"
-#include "llvm/Support/Path.h"
 #include "llvm/Support/PrettyStackTrace.h"
-#include "llvm/Support/Process.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/TargetSelect.h"
-#include "llvm/Support/raw_ostream.h"
 
-#define INITIALIZE_LLVM(argc, argv) \
+#define PROGRAM_START(argc, argv) \
   llvm::sys::PrintStackTraceOnErrorSignal(argv[0]); \
   llvm::PrettyStackTraceProgram _INITIALIZE_LLVM_STACKTRACE(argc, argv); \
-  llvm::llvm_shutdown_obj _INITIALIZE_LLVM_SHUTDOWN_OBJ; \
-  llvm::InitializeAllTargets(); \
-  llvm::InitializeAllTargetMCs(); \
-  llvm::InitializeAllAsmPrinters(); \
-  llvm::InitializeAllAsmParsers(); \
-  llvm::InitializeAllDisassemblers(); \
-  llvm::InitializeAllTargetInfos();
+  llvm::llvm_shutdown_obj _INITIALIZE_LLVM_SHUTDOWN_OBJ
+
+#define INITIALIZE_LLVM() \
+  do { \
+    llvm::InitializeAllTargets(); \
+    llvm::InitializeAllTargetMCs(); \
+    llvm::InitializeAllAsmPrinters(); \
+    llvm::InitializeAllAsmParsers(); \
+    llvm::InitializeAllDisassemblers(); \
+    llvm::InitializeAllTargetInfos(); \
+  } while (0)
 
 #endif // SWIFT_BASIC_LLVMINITIALIZE_H

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -40,6 +40,7 @@
 #include "swift/Basic/FileSystem.h"
 #include "swift/Basic/JSONSerialization.h"
 #include "swift/Basic/LLVMContext.h"
+#include "swift/Basic/LLVMInitialize.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Basic/Statistic.h"
 #include "swift/Basic/Timer.h"
@@ -1511,10 +1512,7 @@ computeStatsReporter(const CompilerInvocation &Invocation, CompilerInstance *Ins
 int swift::performFrontend(ArrayRef<const char *> Args,
                            const char *Argv0, void *MainAddr,
                            FrontendObserver *observer) {
-  llvm::InitializeAllTargets();
-  llvm::InitializeAllTargetMCs();
-  llvm::InitializeAllAsmPrinters();
-  llvm::InitializeAllAsmParsers();
+  INITIALIZE_LLVM();
 
   PrintingDiagnosticConsumer PDC;
 

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -110,7 +110,7 @@ static bool shouldRunAsSubcommand(StringRef ExecName,
 extern int apinotes_main(ArrayRef<const char *> Args);
 
 int main(int argc_, const char **argv_) {
-  INITIALIZE_LLVM(argc_, argv_);
+  PROGRAM_START(argc_, argv_);
 
   SmallVector<const char *, 256> argv;
   llvm::SpecificBumpPtrAllocator<char> ArgAllocator;

--- a/tools/driver/modulewrap_main.cpp
+++ b/tools/driver/modulewrap_main.cpp
@@ -18,6 +18,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "swift/AST/DiagnosticsFrontend.h"
+#include "swift/Basic/LLVMInitialize.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/Option/Options.h"
@@ -113,10 +114,7 @@ public:
 
 int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
                     void *MainAddr) {
-  llvm::InitializeAllTargets();
-  llvm::InitializeAllTargetMCs();
-  llvm::InitializeAllAsmPrinters();
-  llvm::InitializeAllAsmParsers();
+  INITIALIZE_LLVM();
 
   CompilerInstance Instance;
   PrintingDiagnosticConsumer PDC;

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -62,7 +62,8 @@ static void printValidationInfo(llvm::StringRef data) {
 }
 
 int main(int argc, char **argv) {
-  INITIALIZE_LLVM(argc, argv);
+  PROGRAM_START(argc, argv);
+  INITIALIZE_LLVM();
 
   // Command line handling.
   llvm::cl::list<std::string> InputNames(

--- a/tools/sil-func-extractor/SILFunctionExtractor.cpp
+++ b/tools/sil-func-extractor/SILFunctionExtractor.cpp
@@ -225,7 +225,8 @@ void removeUnwantedFunctions(SILModule *M, ArrayRef<std::string> MangledNames,
 }
 
 int main(int argc, char **argv) {
-  INITIALIZE_LLVM(argc, argv);
+  PROGRAM_START(argc, argv);
+  INITIALIZE_LLVM();
 
   llvm::cl::ParseCommandLineOptions(argc, argv, "Swift SIL Extractor\n");
 

--- a/tools/sil-llvm-gen/SILLLVMGen.cpp
+++ b/tools/sil-llvm-gen/SILLLVMGen.cpp
@@ -113,7 +113,8 @@ static llvm::cl::opt<IRGenOutputKind>
 void anchorForGetMainExecutable() {}
 
 int main(int argc, char **argv) {
-  INITIALIZE_LLVM(argc, argv);
+  PROGRAM_START(argc, argv);
+  INITIALIZE_LLVM();
 
   llvm::cl::ParseCommandLineOptions(argc, argv, "Swift LLVM IR Generator\n");
 

--- a/tools/sil-nm/SILNM.cpp
+++ b/tools/sil-nm/SILNM.cpp
@@ -139,7 +139,8 @@ static void nmModule(SILModule *M) {
 }
 
 int main(int argc, char **argv) {
-  INITIALIZE_LLVM(argc, argv);
+  PROGRAM_START(argc, argv);
+  INITIALIZE_LLVM();
 
   llvm::cl::ParseCommandLineOptions(argc, argv, "SIL NM\n");
 

--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -264,7 +264,8 @@ static void runCommandLineSelectedPasses(SILModule *Module,
 void anchorForGetMainExecutable() {}
 
 int main(int argc, char **argv) {
-  INITIALIZE_LLVM(argc, argv);
+  PROGRAM_START(argc, argv);
+  INITIALIZE_LLVM();
 
   llvm::cl::ParseCommandLineOptions(argc, argv, "Swift SIL optimizer\n");
 

--- a/tools/sil-passpipeline-dumper/SILPassPipelineDumper.cpp
+++ b/tools/sil-passpipeline-dumper/SILPassPipelineDumper.cpp
@@ -44,7 +44,8 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &os, PassPipelineKind Kind) {
 } // namespace llvm
 
 int main(int argc, char **argv) {
-  INITIALIZE_LLVM(argc, argv);
+  PROGRAM_START(argc, argv);
+  INITIALIZE_LLVM();
 
   llvm::cl::ParseCommandLineOptions(argc, argv,
                                     "Swift SIL Pass Pipeline Dumper\n");

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -3610,7 +3610,8 @@ static int deserializeSDKDump(StringRef dumpPath, StringRef OutputPath) {
 }
 
 int main(int argc, char *argv[]) {
-  INITIALIZE_LLVM(argc, argv);
+  PROGRAM_START(argc, argv);
+  INITIALIZE_LLVM();
 
   llvm::cl::ParseCommandLineOptions(argc, argv, "Swift SDK Digester\n");
   CompilerInvocation InitInvok;

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2928,7 +2928,8 @@ static int doTestCompilerInvocationFromModule(StringRef ModuleFilePath) {
 void anchorForGetMainExecutable() {}
 
 int main(int argc, char *argv[]) {
-  INITIALIZE_LLVM(argc, argv);
+  PROGRAM_START(argc, argv);
+  INITIALIZE_LLVM();
 
   if (argc > 1) {
     // Handle integrated test tools which do not use

--- a/tools/swift-llvm-opt/LLVMOpt.cpp
+++ b/tools/swift-llvm-opt/LLVMOpt.cpp
@@ -212,7 +212,8 @@ static void runSpecificPasses(StringRef Binary, llvm::Module *M,
 //===----------------------------------------------------------------------===//
 
 int main(int argc, char **argv) {
-  INITIALIZE_LLVM(argc, argv);
+  PROGRAM_START(argc, argv);
+  INITIALIZE_LLVM();
 
   // Initialize passes
   PassRegistry &Registry = *PassRegistry::getPassRegistry();

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -10,12 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "llvm/Support/CommandLine.h"
 #include "swift/Basic/LLVMInitialize.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
 #include "swift/IDE/Refactoring.h"
 #include "swift/IDE/Utils.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/FileSystem.h"
 
 #include <regex>
 
@@ -218,7 +219,8 @@ RangeConfig getRange(unsigned BufferID, SourceManager &SM,
 void anchorForGetMainExecutable() {}
 
 int main(int argc, char *argv[]) {
-  INITIALIZE_LLVM(argc, argv);
+  PROGRAM_START(argc, argv);
+  INITIALIZE_LLVM();
   llvm::cl::ParseCommandLineOptions(argc, argv, "Swift refactor\n");
   if (options::SourceFilename.empty()) {
     llvm::errs() << "cannot find source filename\n";

--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -293,6 +293,7 @@ static int doDumpReflectionSections(ArrayRef<std::string> binaryFilenames,
 }
 
 int main(int argc, char *argv[]) {
+  PROGRAM_START(argc, argv);
   llvm::cl::ParseCommandLineOptions(argc, argv, "Swift Reflection Dump\n");
   return doDumpReflectionSections(options::BinaryFilename,
                                   options::Architecture,

--- a/tools/swift-remoteast-test/swift-remoteast-test.cpp
+++ b/tools/swift-remoteast-test/swift-remoteast-test.cpp
@@ -19,6 +19,7 @@
 #include "swift/Frontend/Frontend.h"
 #include "swift/FrontendTool/FrontendTool.h"
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/LLVMInitialize.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
@@ -143,6 +144,8 @@ struct Observer : public FrontendObserver {
 } // end anonymous namespace
 
 int main(int argc, const char *argv[]) {
+  PROGRAM_START(argc, argv);
+
   unsigned numForwardedArgs = argc
       - 1  // we drop argv[0]
       + 1; // -interpret

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -21,6 +21,7 @@
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsFrontend.h"
 #include "swift/Basic/LangOptions.h"
+#include "swift/Basic/LLVMInitialize.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Frontend/Frontend.h"
 #include "swift/Frontend/PrintingDiagnosticConsumer.h"
@@ -281,6 +282,7 @@ int dumpEOFSourceLoc(const char *MainExecutablePath,
 }// end of anonymous namespace
 
 int main(int argc, char *argv[]) {
+  PROGRAM_START(argc, argv);
   llvm::cl::ParseCommandLineOptions(argc, argv, "Swift Syntax Test\n");
 
   int ExitCode = EXIT_SUCCESS;


### PR DESCRIPTION
Tiny start-up time optimization noticed while looking at how we do PrettyStackTraceProgram. Also add PrettyStackTraceProgram to a few more of our testing tools, via the new `PROGRAM_START` macro.

Split out from #14814, since it's not really related. Already reviewed by @gottesmm.