### PR TITLE
[Type checker] Suggest @objc for ill-formed extensions of ObjC generic classes.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1371,6 +1371,8 @@ ERROR(objc_generic_extension_using_type_parameter,none,
       "generic parameters at runtime", ())
 NOTE(objc_generic_extension_using_type_parameter_here,none,
      "generic parameter used here", ())
+NOTE(objc_generic_extension_using_type_parameter_try_objc,none,
+     "add '@objc' to allow uses of 'self' within the function body", ())
 
 // Protocols
 ERROR(type_does_not_conform,none,

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -19,6 +19,7 @@
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ASTWalker.h"
 #include "swift/AST/Decl.h"
+#include "swift/AST/ForeignErrorConvention.h"
 #include "swift/AST/ParameterList.h"
 #include "swift/AST/TypeWalker.h"
 #include "swift/Basic/Defer.h"
@@ -743,9 +744,20 @@ void TypeChecker::computeCaptures(AnyFunctionRef AFR) {
   // their context.
   if (AFD && GenericParamCaptureLoc.isValid()) {
     if (auto Clas = AFD->getParent()->getAsClassOrClassExtensionContext()) {
-      if (Clas->isGenericContext() && Clas->hasClangNode()) {
+      if (Clas->usesObjCGenericsModel()) {
         diagnose(AFD->getLoc(),
                  diag::objc_generic_extension_using_type_parameter);
+
+        // If it's possible, suggest adding @objc.
+        Optional<ForeignErrorConvention> errorConvention;
+        if (!AFD->isObjC() &&
+            isRepresentableInObjC(AFD, ObjCReason::MemberOfObjCMembersClass,
+                                  errorConvention)) {
+          diagnose(AFD->getLoc(),
+                   diag::objc_generic_extension_using_type_parameter_try_objc)
+            .fixItInsert(AFD->getAttributeInsertionLoc(false), "@objc ");
+        }
+
         diagnose(GenericParamCaptureLoc,
                  diag::objc_generic_extension_using_type_parameter_here);
       }

--- a/test/ClangImporter/objc_bridging_generics.swift
+++ b/test/ClangImporter/objc_bridging_generics.swift
@@ -123,7 +123,7 @@ extension GenericClass {
     _ = T.self // expected-note{{used here}}
   }
   // expected-error@+1{{extension of a generic Objective-C class cannot access the class's generic parameters}}
-@objc   func usesGenericParamE(_ x: Int) {
+  @objc func usesGenericParamE(_ x: Int) {
     _ = x as? T // expected-note{{used here}}
   }
   // expected-error@+1{{extension of a generic Objective-C class cannot access the class's generic parameters}}
@@ -249,18 +249,22 @@ extension AnimalContainer {
   }
 
 
+  // expected-note@+2{{add '@objc' to allow uses of 'self' within the function body}}{{3-3=@objc }}
   // expected-error@+1{{extension of a generic Objective-C class cannot access the class's generic parameters}}
   func usesGenericParamA(_ x: T) {
     _ = T(noise: x) // expected-note{{used here}}
   }
+  // expected-note@+2{{add '@objc' to allow uses of 'self' within the function body}}{{3-3=@objc }}
   // expected-error@+1{{extension of a generic Objective-C class cannot access the class's generic parameters}}
   func usesGenericParamB() {
     _ = T.create() // expected-note{{used here}}
   }
+  // expected-note@+2{{add '@objc' to allow uses of 'self' within the function body}}{{3-3=@objc }}
   // expected-error@+1{{extension of a generic Objective-C class cannot access the class's generic parameters}}
   func usesGenericParamC() {
     _ = T.apexPredator // expected-note{{used here}}
   }
+  // expected-note@+2{{add '@objc' to allow uses of 'self' within the function body}}{{3-3=@objc }}
   // expected-error@+1{{extension of a generic Objective-C class cannot access the class's generic parameters}}
   func usesGenericParamD(_ x: T) {
     T.apexPredator = x // expected-note{{used here}}
@@ -269,6 +273,7 @@ extension AnimalContainer {
   // rdar://problem/27796375 -- allocating init entry points for ObjC
   // initializers are generated as true Swift generics, so reify type
   // parameters.
+  // expected-note@+2{{add '@objc' to allow uses of 'self' within the function body}}{{3-3=@objc }}
   // expected-error@+1{{extension of a generic Objective-C class cannot access the class's generic parameters}}
   func usesGenericParamE(_ x: T) {
     _ = GenericClass(thing: x) // expected-note{{used here}}


### PR DESCRIPTION
`@objc` is used as a proxy to allow 'self' to access type parameters within
an extension of an Objective-C generic class. Suggest it in cases where it
might make sense.

Clarifies the fix for cases like rdar://problem/27796182.
