### PR TITLE
[Batch mode] When emitting dependencies, only emit supplementary outputs for the current input.

### DIFF
--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -116,19 +116,15 @@ void FrontendOptions::forAllOutputPaths(
     else
       fn(input.outputFilename());
   }
-  (void)InputsAndOutputs.forEachInputProducingSupplementaryOutput(
-      [&](const InputFile &inp) -> bool {
-        const SupplementaryOutputPaths &outs =
-            inp.getPrimarySpecificPaths().SupplementaryOutputs;
-        const std::string *outputs[] = {&outs.ModuleOutputPath,
-                                        &outs.ModuleDocOutputPath,
-                                        &outs.ObjCHeaderOutputPath};
-        for (const std::string *next : outputs) {
-          if (!next->empty())
-            fn(*next);
-        }
-        return false;
-      });
+  const SupplementaryOutputPaths &outs =
+      input.getPrimarySpecificPaths().SupplementaryOutputs;
+  const std::string *outputs[] = {&outs.ModuleOutputPath,
+                                  &outs.ModuleDocOutputPath,
+                                  &outs.ObjCHeaderOutputPath};
+  for (const std::string *next : outputs) {
+    if (!next->empty())
+      fn(*next);
+  }
 }
 
 const char *

--- a/test/Frontend/dependencies-selective-supplementaries.swift
+++ b/test/Frontend/dependencies-selective-supplementaries.swift
@@ -1,0 +1,23 @@
+// This test verifies that, in batch-mode (i.e. >1 primary input),
+// we have fixed a bug that caused every primary input to be a dependent
+// of every ModuleOutputPath, etc.
+
+// RUN: %empty-directory(%t)
+// RUN: echo 'public func a() { }' >%t/a.swift
+// RUN: echo 'public func main() {a()}' >%t/main.swift
+// RUN: %target-swift-frontend -c -enable-batch-mode -bypass-batch-mode-checks -module-name foo -primary-file %t/a.swift -primary-file %t/main.swift -emit-dependencies-path %t/a.d -emit-dependencies-path %t/main.d  -o %t/a.o -o %t/main.o -emit-module-path %t/a.swiftmodule -emit-module-path %t/main.swiftmodule
+// RUN: %FileCheck -check-prefix=CHECK-MAIN %s <%t/main.d
+// RUN: %FileCheck -check-prefix=NEGATIVE-MAIN %s <%t/main.d
+//
+// CHECK-MAIN-DAG: main.swiftmodule :
+// CHECK-MAIN-DAG: main.o :
+// NEGATIVE-MAIN-NOT: a.swiftmodule
+// NEGATIVE-MAIN-NOT: a.o
+//
+// RUN: %FileCheck -check-prefix=CHECK-A %s <%t/a.d
+// RUN: %FileCheck -check-prefix=NEGATIVE-A %s <%t/a.d
+//
+// CHECK-A-DAG: a.swiftmodule :
+// CHECK-A-DAG: a.o :
+// NEGATIVE-A-NOT: main.swiftmodule
+// NEGATIVE-A-NOT: main.o


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fix performance bug for >1 primary by not visiting every supplementary output for every primary input.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
