### PR TITLE
Add test case for rdar://problem/37840927.

### DIFF
--- a/test/Interpreter/class_in_constrained_extension.swift
+++ b/test/Interpreter/class_in_constrained_extension.swift
@@ -1,0 +1,16 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+
+class Foo {}
+
+extension Array where Element == Foo {
+  class Bar { var foo = Foo() }
+  
+  init(withAThing: String) {
+    self = [Bar(), Bar(), Bar()].map { $0.foo }
+  }
+}
+
+// CHECK: [main.Foo, main.Foo, main.Foo]
+let foos = [Foo](withAThing: "Hi")
+print(foos)


### PR DESCRIPTION
This example broke in Swift 4.1, but is fixed on master. Make sure we don't regress.