### PR TITLE
Revert "[Runtime] Reference ObjC class objects indirectly in conformance records

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -756,9 +756,6 @@ public:
   bool isForeignTypeMetadataCandidate() const {
     return getKind() == Kind::ForeignTypeMetadataCandidate;
   }
-  bool isObjCClassRef() const {
-    return getKind() == Kind::ObjCClassRef;
-  }
 
   /// Determine whether this entity will be weak-imported.
   bool isWeakImported(ModuleDecl *module) const {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2442,15 +2442,6 @@ IRGenModule::getAddrOfLLVMVariableOrGOTEquivalent(LinkEntity entity,
                               Alignment alignment,
                               llvm::Type *defaultType,
                               ConstantReference::Directness forceIndirectness) {
-  // ObjC class references can always be directly referenced, even in
-  // the weird cases where we don't see a definition.
-  if (entity.isObjCClassRef()) {
-    auto value = getAddrOfObjCClassRef(
-      const_cast<ClassDecl *>(cast<ClassDecl>(entity.getDecl())));
-    return { cast<llvm::Constant>(value.getAddress()),
-             ConstantReference::Direct };
-  }
-
   // Ensure the variable is at least forward-declared.
   if (entity.isForeignTypeMetadataCandidate()) {
     auto foreignCandidate
@@ -2528,7 +2519,7 @@ IRGenModule::getTypeEntityReference(NominalTypeDecl *decl) {
 
     kind = TypeMetadataRecordKind::IndirectObjCClass;
     defaultTy = TypeMetadataPtrTy;
-    entity = LinkEntity::forObjCClassRef(clas);
+    entity = LinkEntity::forObjCClass(clas);
   } else {
     // A reference to a concrete type.
     // TODO: consider using a symbolic reference (i.e. a symbol string
@@ -2543,8 +2534,8 @@ IRGenModule::getTypeEntityReference(NominalTypeDecl *decl) {
 
   // Adjust the flags now that we know whether the reference to this
   // entity will be indirect.
-  if (ref.isIndirect()) {
-    assert(kind == TypeMetadataRecordKind::DirectNominalTypeDescriptor);
+  if (ref.isIndirect() &&
+      kind == TypeMetadataRecordKind::DirectNominalTypeDescriptor) {
     kind = TypeMetadataRecordKind::IndirectNominalTypeDescriptor;
   }
 

--- a/test/IRGen/objc_bridged_generic_conformance.swift
+++ b/test/IRGen/objc_bridged_generic_conformance.swift
@@ -3,7 +3,7 @@
 
 // CHECK-NOT: _TMnCSo
 
-// CHECK: @"$SSo6ThingyCyxG32objc_bridged_generic_conformance1PADMc" = hidden constant %swift.protocol_conformance_descriptor {{.*}} @"OBJC_CLASS_REF_$_Thingy"
+// CHECK: @"$SSo6ThingyCyxG32objc_bridged_generic_conformance1PADMc" = hidden constant %swift.protocol_conformance_descriptor {{.*}} @"got.OBJC_CLASS_$_Thingy"
 
 // CHECK-NOT: _TMnCSo
 

--- a/test/IRGen/protocol_conformance_records_objc.swift
+++ b/test/IRGen/protocol_conformance_records_objc.swift
@@ -30,7 +30,7 @@ extension NSRect: Runcible {
 // -- protocol descriptor
 // CHECK-SAME:           [[RUNCIBLE]]
 // -- class object reference
-// CHECK-SAME:           @"OBJC_CLASS_REF_$_Gizmo"
+// CHECK-SAME:           @"got.OBJC_CLASS_$_Gizmo"
 // -- witness table
 // CHECK-SAME:           @"$SSo5GizmoC33protocol_conformance_records_objc8RuncibleACWP"
 // -- flags


### PR DESCRIPTION
This reverts commit 65b4c9a. It broke
the stdlib/ErrorBridged.swift test at -Onone. Fixes rdar://problem/37925234.