### PR TITLE
[IRGen] Always get the CanType of a conformance's contextual type

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1210,7 +1210,8 @@ public:
           ConcreteType(SILWT->getConformance()->getDeclContext()
                          ->mapTypeIntoContext(
                            SILWT->getConformance()->getType()
-                             ->getCanonicalType())),
+                             ->getCanonicalType())
+                         ->getCanonicalType()),
           Conformance(*SILWT->getConformance()),
           SILEntries(SILWT->getEntries()),
           SILConditionalConformances(SILWT->getConditionalConformances()),

--- a/test/Inputs/conditional_conformance_basic_conformances.swift
+++ b/test/Inputs/conditional_conformance_basic_conformances.swift
@@ -323,3 +323,11 @@ public func double_concrete_concrete() {
 func dynamicCastToP1(_ value: Any) -> P1? {
   return value as? P1
 }
+
+protocol P4 {}
+typealias P4Typealias = P4
+protocol P5 {}
+
+struct SR7101<T> {}
+extension SR7101 : P5 where T == P4Typealias {}
+


### PR DESCRIPTION
The conformance type's contextual type might not be canonical, such as in the case of substituting a `typealias` type for a generic placeholder, so ensure we get the canonical type for the conformance.

Resolves [SR-7101](https://bugs.swift.org/browse/SR-7101).

