### PR TITLE
utils: add -lswiftImageInspectionShared to static-executable-args.lnk

### DIFF
--- a/utils/static-executable-args.lnk
+++ b/utils/static-executable-args.lnk
@@ -1,5 +1,6 @@
 -static
 -lswiftCore
+-lswiftImageInspectionShared
 -Xlinker
 --defsym=__import_pthread_self=pthread_self
 -Xlinker


### PR DESCRIPTION
This fixes the -static-executable part of the problem reported in
SR-7038 (rdar://problem/37710244).