### PR TITLE
Add a SWIFT_BUILD_DIR variable to pass as an arugment to xctest/build…

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2369,6 +2369,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
                 XCTEST_BUILD_DIR=$(build_directory ${host} xctest)
                 FOUNDATION_BUILD_DIR=$(build_directory ${host} foundation)
+                SWIFT_BUILD_DIR=$(build_directory ${host} swift)
 
                 # Staging: require opt-in for building with dispatch
                 if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
@@ -2387,6 +2388,7 @@ for host in "${ALL_HOSTS[@]}"; do
                     --swiftc="${SWIFTC_BIN}" \
                     --build-dir="${XCTEST_BUILD_DIR}" \
                     --foundation-build-dir="${FOUNDATION_BUILD_DIR}/Foundation" \
+                    --swift-build-dir="${SWIFT_BUILD_DIR}" \
                     $LIBDISPATCH_BUILD_ARGS \
                     $XCTEST_BUILD_ARGS
 


### PR DESCRIPTION
…_scripy.py

(cherry picked from commit 4b8d4d9640aa414ff453b6fd786a51e847cef11f)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
