### PR TITLE
SwiftRemoteMirror: annotate public interfaces

### DIFF
--- a/include/swift/SwiftRemoteMirror/CMakeLists.txt
+++ b/include/swift/SwiftRemoteMirror/CMakeLists.txt
@@ -1,9 +1,12 @@
 set(swift_remote_mirror_headers)
 list(APPEND swift_remote_mirror_headers
-  "MemoryReaderInterface.h"
-  "SwiftRemoteMirror.h"
-  "SwiftRemoteMirrorTypes.h")
+       MemoryReaderInterface.h
+       Platform.h
+       SwiftRemoteMirror.h
+       SwiftRemoteMirrorTypes.h)
 swift_install_in_component("swift-remote-mirror-headers"
-  FILES ${swift_remote_mirror_headers}
-  DESTINATION "include/swift/SwiftRemoteMirror")
+                           FILES
+                             ${swift_remote_mirror_headers}
+                           DESTINATION
+                             "include/swift/SwiftRemoteMirror")
 

--- a/include/swift/SwiftRemoteMirror/Platform.h
+++ b/include/swift/SwiftRemoteMirror/Platform.h
@@ -1,0 +1,45 @@
+//===-- SwiftRemoteMirror/Platform.h - Remote Mirror Platform --*-- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_REMOTE_MIRROR_PLATFORM_H
+#define SWIFT_REMOTE_MIRROR_PLATFORM_H
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+#if defined(swiftRemoteMirror_EXPORTS)
+# if defined(__ELF__)
+#   define SWIFT_REMOTE_MIRROR_LINKAGE __attribute__((__visibility__("protected")))
+# elif defined(__MACH__)
+#   define SWIFT_REMOTE_MIRROR_LINKAGE __attribute__((__visibility__("default")))
+# else
+#   define SWIFT_REMOTE_MIRROR_LINKAGE __declspec(dllexport)
+# endif
+#else
+# if defined(__ELF__)
+#   define SWIFT_REMOTE_MIRROR_LINKAGE __attribute__((__visibility__("default")))
+# elif defined(__MACH__)
+#   define SWIFT_REMOTE_MIRROR_LINKAGE __attribute__((__visibility__("default")))
+# else
+#   define SWIFT_REMOTE_MIRROR_LINKAGE __declspec(dllimport)
+# endif
+#endif
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif
+
+
+

--- a/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
+++ b/include/swift/SwiftRemoteMirror/SwiftRemoteMirror.h
@@ -20,6 +20,7 @@
 #ifndef SWIFT_REFLECTION_SWIFT_REFLECTION_H
 #define SWIFT_REFLECTION_SWIFT_REFLECTION_H
 
+#include "Platform.h"
 #include "MemoryReaderInterface.h"
 #include "SwiftRemoteMirrorTypes.h"
 
@@ -37,34 +38,34 @@ extern "C" {
 #endif
 
 /// Get the metadata version supported by the Remote Mirror library.
-uint16_t
-swift_reflection_getSupportedMetadataVersion();
+SWIFT_REMOTE_MIRROR_LINKAGE
+uint16_t swift_reflection_getSupportedMetadataVersion();
 
 /// \returns An opaque reflection context.
+SWIFT_REMOTE_MIRROR_LINKAGE
 SwiftReflectionContextRef
-swift_reflection_createReflectionContext(
-    void *ReaderContext,
-    PointerSizeFunction getPointerSize,
-    SizeSizeFunction getSizeSize,
-    ReadBytesFunction readBytes,
-    GetStringLengthFunction getStringLength,
-    GetSymbolAddressFunction getSymbolAddress);
+swift_reflection_createReflectionContext(void *ReaderContext,
+                                         PointerSizeFunction getPointerSize,
+                                         SizeSizeFunction getSizeSize,
+                                         ReadBytesFunction readBytes,
+                                         GetStringLengthFunction getStringLength,
+                                         GetSymbolAddressFunction getSymbolAddress);
 
 /// Destroys an opaque reflection context.
+SWIFT_REMOTE_MIRROR_LINKAGE
 void
 swift_reflection_destroyReflectionContext(SwiftReflectionContextRef Context);
 
 /// Add reflection sections for a loaded Swift image.
-void
-swift_reflection_addReflectionInfo(SwiftReflectionContextRef ContextRef,
-                                   swift_reflection_info_t Info);
-
+SWIFT_REMOTE_MIRROR_LINKAGE
+void swift_reflection_addReflectionInfo(SwiftReflectionContextRef ContextRef,
+                                        swift_reflection_info_t Info);
 
 /// Returns a boolean indicating if the isa mask was successfully
 /// read, in which case it is stored in the isaMask out parameter.
-int
-swift_reflection_readIsaMask(SwiftReflectionContextRef ContextRef,
-                             uintptr_t *outIsaMask);
+SWIFT_REMOTE_MIRROR_LINKAGE
+int swift_reflection_readIsaMask(SwiftReflectionContextRef ContextRef,
+                                 uintptr_t *outIsaMask);
 
 /// Returns an opaque type reference for a metadata pointer, or
 /// NULL if one can't be constructed.
@@ -72,6 +73,7 @@ swift_reflection_readIsaMask(SwiftReflectionContextRef ContextRef,
 /// This function loses information; in particular, passing the
 /// result to swift_reflection_infoForTypeRef() will not give
 /// the same result as calling swift_reflection_infoForMetadata().
+SWIFT_REMOTE_MIRROR_LINKAGE
 swift_typeref_t
 swift_reflection_typeRefForMetadata(SwiftReflectionContextRef ContextRef,
                                     uintptr_t Metadata);
@@ -82,11 +84,13 @@ swift_reflection_typeRefForMetadata(SwiftReflectionContextRef ContextRef,
 /// This function loses information; in particular, passing the
 /// result to swift_reflection_infoForTypeRef() will not give
 /// the same result as calling swift_reflection_infoForInstance().
+SWIFT_REMOTE_MIRROR_LINKAGE
 swift_typeref_t
 swift_reflection_typeRefForInstance(SwiftReflectionContextRef ContextRef,
                                     uintptr_t Object);
 
 /// Returns a typeref from a mangled type name string.
+SWIFT_REMOTE_MIRROR_LINKAGE
 swift_typeref_t
 swift_reflection_typeRefForMangledTypeName(SwiftReflectionContextRef ContextRef,
                                            const char *MangledName,
@@ -94,47 +98,52 @@ swift_reflection_typeRefForMangledTypeName(SwiftReflectionContextRef ContextRef,
 
 /// Returns a structure describing the layout of a value of a typeref.
 /// For classes, this returns the reference value itself.
+SWIFT_REMOTE_MIRROR_LINKAGE
 swift_typeinfo_t
 swift_reflection_infoForTypeRef(SwiftReflectionContextRef ContextRef,
                                 swift_typeref_t OpaqueTypeRef);
 
 /// Returns the information about a child field of a value by index.
+SWIFT_REMOTE_MIRROR_LINKAGE
 swift_childinfo_t
 swift_reflection_childOfTypeRef(SwiftReflectionContextRef ContextRef,
-                                swift_typeref_t OpaqueTypeRef,
-                                unsigned Index);
+                                swift_typeref_t OpaqueTypeRef, unsigned Index);
 
 /// Returns a structure describing the layout of a class instance
 /// from the isa pointer of a class.
+SWIFT_REMOTE_MIRROR_LINKAGE
 swift_typeinfo_t
 swift_reflection_infoForMetadata(SwiftReflectionContextRef ContextRef,
                                  uintptr_t Metadata);
 
 /// Returns the information about a child field of a class instance
 /// by index.
+SWIFT_REMOTE_MIRROR_LINKAGE
 swift_childinfo_t
 swift_reflection_childOfMetadata(SwiftReflectionContextRef ContextRef,
-                                 uintptr_t Metadata,
-                                 unsigned Index);
+                                 uintptr_t Metadata, unsigned Index);
 
 /// Returns a structure describing the layout of a class or closure
 /// context instance, from a pointer to the object itself.
+SWIFT_REMOTE_MIRROR_LINKAGE
 swift_typeinfo_t
 swift_reflection_infoForInstance(SwiftReflectionContextRef ContextRef,
                                  uintptr_t Object);
 
 /// Returns the information about a child field of a class or closure
 /// context instance.
+SWIFT_REMOTE_MIRROR_LINKAGE
 swift_childinfo_t
 swift_reflection_childOfInstance(SwiftReflectionContextRef ContextRef,
-                                 uintptr_t Object,
-                                 unsigned Index);
+                                 uintptr_t Object, unsigned Index);
 
 /// Returns the number of generic arguments of a typeref.
+SWIFT_REMOTE_MIRROR_LINKAGE
 unsigned
 swift_reflection_genericArgumentCountOfTypeRef(swift_typeref_t OpaqueTypeRef);
 
 /// Returns a fully instantiated typeref for a generic argument by index.
+SWIFT_REMOTE_MIRROR_LINKAGE
 swift_typeref_t
 swift_reflection_genericArgumentOfTypeRef(swift_typeref_t OpaqueTypeRef,
                                           unsigned Index);
@@ -158,6 +167,7 @@ swift_reflection_genericArgumentOfTypeRef(swift_typeref_t OpaqueTypeRef,
 ///
 /// Returns true if InstanceTypeRef and StartOfInstanceData contain valid
 /// valid values.
+SWIFT_REMOTE_MIRROR_LINKAGE
 int swift_reflection_projectExistential(SwiftReflectionContextRef ContextRef,
                                         swift_addr_t ExistentialAddress,
                                         swift_typeref_t ExistentialTypeRef,
@@ -165,17 +175,21 @@ int swift_reflection_projectExistential(SwiftReflectionContextRef ContextRef,
                                         swift_addr_t *OutStartOfInstanceData);
 
 /// Dump a brief description of the typeref as a tree to stderr.
+SWIFT_REMOTE_MIRROR_LINKAGE
 void swift_reflection_dumpTypeRef(swift_typeref_t OpaqueTypeRef);
 
 /// Dump information about the layout for a typeref.
+SWIFT_REMOTE_MIRROR_LINKAGE
 void swift_reflection_dumpInfoForTypeRef(SwiftReflectionContextRef ContextRef,
                                          swift_typeref_t OpaqueTypeRef);
 
 /// Dump information about the layout of a class instance from its isa pointer.
+SWIFT_REMOTE_MIRROR_LINKAGE
 void swift_reflection_dumpInfoForMetadata(SwiftReflectionContextRef ContextRef,
                                           uintptr_t Metadata);
 
 /// Dump information about the layout of a class or closure context instance.
+SWIFT_REMOTE_MIRROR_LINKAGE
 void swift_reflection_dumpInfoForInstance(SwiftReflectionContextRef ContextRef,
                                           uintptr_t Object);
 
@@ -186,10 +200,9 @@ void swift_reflection_dumpInfoForInstance(SwiftReflectionContextRef ContextRef,
 ///
 /// Returns the length of the demangled string this function tried to copy
 /// into `OutDemangledName`.
-size_t swift_reflection_demangle(const char *MangledName,
-                                 size_t Length,
-                                 char *OutDemangledName,
-                                 size_t MaxLength);
+SWIFT_REMOTE_MIRROR_LINKAGE
+size_t swift_reflection_demangle(const char *MangledName, size_t Length,
+                                 char *OutDemangledName, size_t MaxLength);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
+++ b/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
@@ -4,10 +4,15 @@ string(REGEX REPLACE "-Wl,-z,defs" "" CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_
 # libswiftRemoteMirror.dylib should not have runtime dependencies; it's
 # always built as a shared library.
 if(SWIFT_BUILD_DYNAMIC_STDLIB OR SWIFT_BUILD_REMOTE_MIRROR)
-  add_swift_library(swiftRemoteMirror SHARED TARGET_LIBRARY DONT_EMBED_BITCODE NOSWIFTRT
-      SwiftRemoteMirror.cpp
-      LINK_LIBRARIES swiftReflection
-      C_COMPILE_FLAGS ${SWIFT_RUNTIME_CXX_FLAGS}
-      LINK_FLAGS ${SWIFT_RUNTIME_LINK_FLAGS}
-      INSTALL_IN_COMPONENT swift-remote-mirror)
+  add_swift_library(swiftRemoteMirror
+                    SHARED TARGET_LIBRARY DONT_EMBED_BITCODE NOSWIFTRT
+                    SwiftRemoteMirror.cpp
+                    LINK_LIBRARIES
+                      swiftReflection
+                    C_COMPILE_FLAGS
+                      ${SWIFT_RUNTIME_CXX_FLAGS} -DswiftRemoteMirror_EXPORTS
+                    LINK_FLAGS
+                      ${SWIFT_RUNTIME_LINK_FLAGS}
+                    INSTALL_IN_COMPONENT
+                      swift-remote-mirror)
 endif()


### PR DESCRIPTION
Mark the public interfaces with the appropriate visibility/dll storage.
This fixes an issue with the Windows build which keeps the
SwiftRemoteMirror.dll out of date constantly as no import library is
created.  That occurs due to the fact that the library does not export
any interfaces.

Take the opportunity to move the public interfaces to protected
visibility on ELF.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
