### PR TITLE
stdlib: remove vestigial bits of PreserveMostCC

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -119,17 +119,6 @@
 #define SWIFT_INDIRECT_RESULT
 #endif
 
-// SWIFT_CC(PreserveMost) is used in the runtime implementation to prevent
-// register spills on the hot path.
-// It is not safe to use for external calls; the loader's lazy function
-// binding may not save all of the registers required for this convention.
-#if __has_attribute(preserve_most) &&                                          \
-    (defined(__aarch64__) || defined(__x86_64__))
-#define SWIFT_CC_PreserveMost __attribute__((preserve_most))
-#else
-#define SWIFT_CC_PreserveMost
-#endif
-
 // This is the DefaultCC value used by the compiler.
 // FIXME: the runtime's code does not honor DefaultCC
 // so changing this value is not sufficient.

--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -724,7 +724,7 @@ class RefCounts {
   // Out-of-line slow paths.
 
   LLVM_ATTRIBUTE_NOINLINE
-  void incrementSlow(RefCountBits oldbits, uint32_t inc) SWIFT_CC(PreserveMost);
+  void incrementSlow(RefCountBits oldbits, uint32_t inc);
 
   LLVM_ATTRIBUTE_NOINLINE
   void incrementNonAtomicSlow(RefCountBits oldbits, uint32_t inc);


### PR DESCRIPTION
This calling convention never materialized into an implementation as it
was not as beneficial as intended.  Remove the last references to it
from the tree.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
