### PR TITLE
SwiftDemangle: fix exports macro

### DIFF
--- a/include/swift/SwiftDemangle/Platform.h
+++ b/include/swift/SwiftDemangle/Platform.h
@@ -17,7 +17,7 @@
 extern "C" {
 #endif
 
-#if defined(SwiftDemangle_EXPORTS)
+#if defined(swiftDemangle_EXPORTS)
 # if defined(__ELF__)
 #   define SWIFT_DEMANGLE_LINKAGE __attribute__((__visibility__("protected")))
 # elif defined(__MACH__)


### PR DESCRIPTION
Correct the case on the macro.  The warning for the mismatch was lost in
the copious warnings during the Windows build.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
