### PR TITLE
[stdlib] Add an ambiguity breaker for RRC.popLast

### DIFF
--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -832,6 +832,7 @@ extension RangeReplaceableCollection where Self : BidirectionalCollection {
   public mutating func removeLast() -> Element {
     _precondition(!isEmpty, "Can't remove last element from an empty collection")
     // NOTE if you change this implementation, change popLast above as well
+    // AND change the tie-breaker implementations in the next extension
     if let result = _customRemoveLast() { return result }
     return remove(at: index(before: endIndex))
   }
@@ -865,10 +866,27 @@ extension RangeReplaceableCollection where Self : BidirectionalCollection {
   }
 }
 
-// FIXME: swift-3-indexing-model: file a bug for the compiler?
 /// Ambiguity breakers.
 extension RangeReplaceableCollection
-  where Self : BidirectionalCollection, SubSequence == Self {
+where Self : BidirectionalCollection, SubSequence == Self {
+  /// Removes and returns the last element of the collection.
+  ///
+  /// Calling this method may invalidate all saved indices of this
+  /// collection. Do not rely on a previously stored index value after
+  /// altering a collection with any operation that can change its length.
+  ///
+  /// - Returns: The last element of the collection if the collection is not
+  /// empty; otherwise, `nil`.
+  ///
+  /// - Complexity: O(1)
+  @_inlineable
+  public mutating func popLast() -> Element? {
+    if isEmpty { return nil }
+    // duplicate of removeLast logic below, to avoid redundant precondition
+    if let result = _customRemoveLast() { return result }
+    return remove(at: index(before: endIndex))
+  }
+
   /// Removes and returns the last element of the collection.
   ///
   /// The collection must not be empty.
@@ -884,9 +902,8 @@ extension RangeReplaceableCollection
   @discardableResult
   public mutating func removeLast() -> Element {
     _precondition(!isEmpty, "Can't remove last element from an empty collection")
-    if let result = _customRemoveLast() {
-      return result
-    }
+    // NOTE if you change this implementation, change popLast above as well
+    if let result = _customRemoveLast() { return result }
     return remove(at: index(before: endIndex))
   }
 

--- a/validation-test/stdlib/Arrays.swift.gyb
+++ b/validation-test/stdlib/Arrays.swift.gyb
@@ -1513,7 +1513,7 @@ ArrayTestSuite.test("Native/isEmpty") {
   expectFalse(a.isEmpty)
 }
 
-% for Kind in ['Array', 'ContiguousArray']:
+% for Kind in ['Array', 'ContiguousArray', 'ArraySlice']:
 ArrayTestSuite.test("${Kind}/popLast") {
   // Empty
   do {


### PR DESCRIPTION
Source compatibility regression from adding a default implementation of popLast to RRC.

~~Needs tests to avoid future regression but will do in separate PR to unblock things quicker~~