### PR TITLE
Implementation for /most/ of SE-0192 (frozen and non-frozen enums)

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -164,7 +164,7 @@ SIMPLE_DECL_ATTR(nonobjc, NonObjC,
                  OnExtension | OnFunc | OnVar | OnSubscript | OnConstructor, 30)
 
 SIMPLE_DECL_ATTR(_fixed_layout, FixedLayout,
-                 OnVar | OnClass | OnStruct | OnEnum | UserInaccessible, 31)
+                 OnVar | OnClass | OnStruct | UserInaccessible, 31)
 
 SIMPLE_DECL_ATTR(_inlineable, Inlineable,
                  OnVar | OnSubscript | OnFunc | OnConstructor | OnDestructor |

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -314,6 +314,8 @@ SIMPLE_DECL_ATTR(_weakLinked, WeakLinked,
                  UserInaccessible,
                  75)
 
+SIMPLE_DECL_ATTR(_frozen, Frozen, OnEnum | UserInaccessible, 76)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef SIMPLE_DECL_ATTR

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3238,6 +3238,13 @@ public:
   bool isIndirect() const {
     return getAttrs().hasAttribute<IndirectAttr>();
   }
+
+  /// True if the enum can be exhaustively switched within \p useDC.
+  ///
+  /// Note that this property is \e not necessarily true for all children of
+  /// \p useDC. In particular, an inlinable function does not get to switch
+  /// exhaustively over a non-exhaustive enum declared in the same module.
+  bool isExhaustive(const DeclContext *useDC) const;
 };
 
 /// StructDecl - This is the declaration of a struct, for example:

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1204,11 +1204,15 @@ WARNING(expr_dynamic_lookup_swift3_objc_inference,none,
 ERROR(alignment_not_power_of_two,none,
       "alignment value must be a power of two", ())
 
-// Indirect enums
+// Enum annotations
 ERROR(indirect_case_without_payload,none,
       "enum case %0 without associated value cannot be 'indirect'", (Identifier))
 ERROR(indirect_case_in_indirect_enum,none,
       "enum case in 'indirect' enum cannot also be 'indirect'", ())
+WARNING(enum_frozen_nonresilient,none,
+        "%0 has no effect without -enable-resilience", (DeclAttribute))
+WARNING(enum_frozen_nonpublic,none,
+        "%0 has no effect on non-public enums", (DeclAttribute))
 
 // Variables (var and let).
 ERROR(unimplemented_static_var,none,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -239,6 +239,10 @@ namespace swift {
     /// Diagnose uses of NSCoding with classes that have unstable mangled names.
     bool EnableNSKeyedArchiverDiagnostics = true;
 
+    /// Diagnose switches over non-frozen enums that do not have catch-all
+    /// cases.
+    bool EnableNonFrozenEnumExhaustivityDiagnostics = false;
+
     /// Regex for the passes that should report passed and missed optimizations.
     ///
     /// These are shared_ptrs so that this class remains copyable.

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -321,6 +321,13 @@ def disable_nskeyedarchiver_diagnostics :
   Flag<["-"], "disable-nskeyedarchiver-diagnostics">,
   HelpText<"Allow classes with unstable mangled names to adopt NSCoding">;
 
+def enable_nonfrozen_enum_exhaustivity_diagnostics :
+  Flag<["-"], "enable-nonfrozen-enum-exhaustivity-diagnostics">,
+  HelpText<"Diagnose switches over non-frozen enums without catch-all cases">;
+def disable_nonfrozen_enum_exhaustivity_diagnostics :
+  Flag<["-"], "disable-nonfrozen-enum-exhaustivity-diagnostics">,
+  HelpText<"Allow switches over non-frozen enums without catch-all cases">;
+
 def warn_long_function_bodies : Separate<["-"], "warn-long-function-bodies">,
   MetaVarName<"<n>">,
   HelpText<"Warns when type-checking a function takes longer than <n> ms">;

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -757,9 +757,9 @@ namespace {
 
       if (NTD->hasInterfaceType()) {
         if (NTD->isResilient())
-          OS << " @_resilient_layout";
+          OS << " resilient";
         else
-          OS << " @_fixed_layout";
+          OS << " non-resilient";
       }
     }
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3116,6 +3116,11 @@ bool EnumDecl::isExhaustive(const DeclContext *useDC) const {
   if (!accessScope.isPublic())
     return true;
 
+  // All other checks are use-site specific; with no further information, the
+  // enum must be treated non-exhaustively.
+  if (!useDC)
+    return false;
+
   // Enums in the same module as the use site are exhaustive /unless/ the use
   // site is inlinable.
   if (useDC->getParentModule() == containingModule)

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2286,9 +2286,11 @@ bool NominalTypeDecl::isFormallyResilient() const {
                             /*respectVersionedAttr=*/true).isPublic())
     return false;
 
-  // Check for an explicit @_fixed_layout attribute.
-  if (getAttrs().hasAttribute<FixedLayoutAttr>())
+  // Check for an explicit @_fixed_layout or @_frozen attribute.
+  if (getAttrs().hasAttribute<FixedLayoutAttr>() ||
+      getAttrs().hasAttribute<FrozenAttr>()) {
     return false;
+  }
 
   // Structs and enums imported from C *always* have a fixed layout.
   // We know their size, and pass them as values in SIL and IRGen.

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2757,6 +2757,9 @@ namespace {
             Impl.importSourceLoc(decl->getLocation()), None, nullptr, enumDC);
         enumDecl->computeType();
 
+        // FIXME: Actually distinguish frozen and non-frozen enums.
+        enumDecl->getAttrs().add(new (C) FrozenAttr(/*implicit*/true));
+
         // Set up the C underlying type as its Swift raw type.
         enumDecl->setRawType(underlyingType);
 

--- a/lib/ClangImporter/ImportEnumInfo.h
+++ b/lib/ClangImporter/ImportEnumInfo.h
@@ -35,11 +35,14 @@ namespace importer {
 /// into Swift. All of the possibilities have the same storage
 /// representation, but can be used in different ways.
 enum class EnumKind {
-  /// The enumeration type should map to an enum, which means that
-  /// all of the cases are independent.
-  Enum,
-  /// The enumeration type should map to an option set, which means
-  /// that
+  /// The enumeration type should map to a frozen enum, which means that
+  /// all of the cases are independent and there are no private cases.
+  FrozenEnum,
+  /// The enumeration type should map to a non-frozen enum, which means that
+  /// all of the cases are independent, but there may be values not represented
+  /// in the listed cases.
+  NonFrozenEnum,
+  /// The enumeration type should map to an option set, which means that
   /// the constants represent combinations of independent flags.
   Options,
   /// The enumeration type should map to a distinct type, but we don't
@@ -76,7 +79,15 @@ public:
 
   /// Whether this maps to an enum who also provides an error domain
   bool isErrorEnum() const {
-    return getKind() == EnumKind::Enum && !nsErrorDomain.empty();
+    switch (getKind()) {
+    case EnumKind::FrozenEnum:
+    case EnumKind::NonFrozenEnum:
+      return !nsErrorDomain.empty();
+    case EnumKind::Options:
+    case EnumKind::Unknown:
+    case EnumKind::Constants:
+      return false;
+    }
   }
 
   /// For this error enum, extract the name of the error domain constant

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -887,7 +887,8 @@ NameImporter::determineEffectiveContext(const clang::NamedDecl *decl,
   if (isa<clang::EnumConstantDecl>(decl)) {
     auto enumDecl = cast<clang::EnumDecl>(dc);
     switch (getEnumKind(enumDecl)) {
-    case EnumKind::Enum:
+    case EnumKind::NonFrozenEnum:
+    case EnumKind::FrozenEnum:
     case EnumKind::Options:
       // Enums are mapped to Swift enums, Options to Swift option sets.
       if (version != ImportNameVersion::raw()) {
@@ -1005,7 +1006,8 @@ static bool shouldBeSwiftPrivate(NameImporter &nameImporter,
   if (auto *ECD = dyn_cast<clang::EnumConstantDecl>(decl)) {
     auto *ED = cast<clang::EnumDecl>(ECD->getDeclContext());
     switch (nameImporter.getEnumKind(ED)) {
-    case EnumKind::Enum:
+    case EnumKind::NonFrozenEnum:
+    case EnumKind::FrozenEnum:
     case EnumKind::Options:
       if (version != ImportNameVersion::raw())
         break;

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -807,7 +807,8 @@ namespace {
         // Import the underlying integer type.
         return Visit(clangDecl->getIntegerType());
       }
-      case EnumKind::Enum:
+      case EnumKind::NonFrozenEnum:
+      case EnumKind::FrozenEnum:
       case EnumKind::Unknown:
       case EnumKind::Options: {
         auto decl = dyn_cast_or_null<TypeDecl>(

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -309,6 +309,11 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
                    OPT_disable_nskeyedarchiver_diagnostics,
                    Opts.EnableNSKeyedArchiverDiagnostics);
 
+  Opts.EnableNonFrozenEnumExhaustivityDiagnostics =
+    Args.hasFlag(OPT_enable_nonfrozen_enum_exhaustivity_diagnostics,
+                 OPT_disable_nonfrozen_enum_exhaustivity_diagnostics,
+                 Opts.EnableNonFrozenEnumExhaustivityDiagnostics);
+
   if (Arg *A = Args.getLastArg(OPT_Rpass_EQ))
     Opts.OptimizationRemarkPassedPattern =
         generateOptimizationRemarkRegex(Diags, Args, A);

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -421,7 +421,9 @@ private:
       os << ", " << customName
          << ", \"" << ED->getName() << "\"";
     }
-    os << ") {\n";
+    os << ", " << (ED->isExhaustive(/*useDC*/nullptr) ? "closed" : "open")
+       << ") {\n";
+
     for (auto Elt : ED->getAllElements()) {
       printDocumentationComment(Elt);
 
@@ -2569,24 +2571,26 @@ public:
            "#if !defined(SWIFT_ENUM_ATTR)\n"
            "# if defined(__has_attribute) && "
              "__has_attribute(enum_extensibility)\n"
-           "#  define SWIFT_ENUM_ATTR "
-             "__attribute__((enum_extensibility(open)))\n"
+           "#  define SWIFT_ENUM_ATTR(_extensibility) "
+             "__attribute__((enum_extensibility(_extensibility)))\n"
            "# else\n"
-           "#  define SWIFT_ENUM_ATTR\n"
+           "#  define SWIFT_ENUM_ATTR(_extensibility)\n"
            "# endif\n"
            "#endif\n"
            "#if !defined(SWIFT_ENUM)\n"
-           "# define SWIFT_ENUM(_type, _name) "
+           "# define SWIFT_ENUM(_type, _name, _extensibility) "
              "enum _name : _type _name; "
-             "enum SWIFT_ENUM_ATTR SWIFT_ENUM_EXTRA _name : _type\n"
+             "enum SWIFT_ENUM_ATTR(_extensibility) SWIFT_ENUM_EXTRA "
+             "_name : _type\n"
            "# if __has_feature(generalized_swift_name)\n"
-           "#  define SWIFT_ENUM_NAMED(_type, _name, SWIFT_NAME) "
+           "#  define SWIFT_ENUM_NAMED(_type, _name, SWIFT_NAME, "
+             "_extensibility) "
              "enum _name : _type _name SWIFT_COMPILE_NAME(SWIFT_NAME); "
-             "enum SWIFT_COMPILE_NAME(SWIFT_NAME) SWIFT_ENUM_ATTR "
-             "SWIFT_ENUM_EXTRA _name : _type\n"
+             "enum SWIFT_COMPILE_NAME(SWIFT_NAME) "
+             "SWIFT_ENUM_ATTR(_extensibility) SWIFT_ENUM_EXTRA _name : _type\n"
            "# else\n"
-           "#  define SWIFT_ENUM_NAMED(_type, _name, SWIFT_NAME) "
-             "SWIFT_ENUM(_type, _name)\n"
+           "#  define SWIFT_ENUM_NAMED(_type, _name, SWIFT_NAME, "
+             "_extensibility) SWIFT_ENUM(_type, _name, _extensibility)\n"
            "# endif\n"
            "#endif\n"
            "#if !defined(SWIFT_UNAVAILABLE)\n"

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -79,6 +79,7 @@ public:
   IGNORED_ATTR(Effects)
   IGNORED_ATTR(Exported)
   IGNORED_ATTR(FixedLayout)
+  IGNORED_ATTR(Frozen)
   IGNORED_ATTR(Implements)
   IGNORED_ATTR(ImplicitlyUnwrappedOptional)
   IGNORED_ATTR(Infix)
@@ -886,6 +887,8 @@ public:
 
   void visitDiscardableResultAttr(DiscardableResultAttr *attr);
   void visitImplementsAttr(ImplementsAttr *attr);
+
+  void visitFrozenAttr(FrozenAttr *attr);
 };
 } // end anonymous namespace
 
@@ -2100,6 +2103,22 @@ void AttributeChecker::visitImplementsAttr(ImplementsAttr *attr) {
                 diag::implements_attr_non_protocol_type)
       .highlight(ProtoTypeLoc.getTypeRepr()->getSourceRange());
   }
+}
+
+void AttributeChecker::visitFrozenAttr(FrozenAttr *attr) {
+  switch (D->getModuleContext()->getResilienceStrategy()) {
+  case ResilienceStrategy::Default:
+    diagnoseAndRemoveAttr(attr, diag::enum_frozen_nonresilient, attr);
+    return;
+  case ResilienceStrategy::Resilient:
+    break;
+  }
+
+  if (cast<EnumDecl>(D)->getFormalAccess() >= AccessLevel::Public)
+    return;
+  if (D->getAttrs().hasAttribute<VersionedAttr>())
+    return;
+  diagnoseAndRemoveAttr(attr, diag::enum_frozen_nonpublic, attr);
 }
 
 void TypeChecker::checkDeclAttributes(Decl *D) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6524,6 +6524,7 @@ public:
     UNINTERESTING_ATTR(ImplicitlyUnwrappedOptional)
     UNINTERESTING_ATTR(ClangImporterSynthesizedType)
     UNINTERESTING_ATTR(WeakLinked)
+    UNINTERESTING_ATTR(Frozen)
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -940,7 +940,7 @@ public:
     }
 
     if (!S->isImplicit()) {
-      TC.checkSwitchExhaustiveness(S, /*limitChecking*/hadError);
+      TC.checkSwitchExhaustiveness(S, DC, /*limitChecking*/hadError);
     }
 
     return S;

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -74,11 +74,11 @@ namespace {
   /// condition is empty.
   struct SpaceEngine {
     enum class SpaceKind : uint8_t {
-      Empty           = 1 << 0,
-      Type            = 1 << 1,
-      Constructor     = 1 << 2,
-      Disjunct        = 1 << 3,
-      BooleanConstant = 1 << 4,
+      Empty,
+      Type,
+      Constructor,
+      Disjunct,
+      BooleanConstant
     };
 
     /// A data structure for conveniently pattern-matching on the kinds of

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1731,10 +1731,12 @@ public:
   ///
   /// \param stmt The switch statement to be type-checked.  No modification of
   /// the statement occurs.
+  /// \param DC The decl context containing \p stmt.
   /// \param limitChecking The checking process relies on the switch statement
   /// being well-formed.  If it is not, pass true to this flag to run a limited
   /// form of analysis.
-  void checkSwitchExhaustiveness(SwitchStmt *stmt, bool limitChecking);
+  void checkSwitchExhaustiveness(const SwitchStmt *stmt, const DeclContext *DC,
+                                 bool limitChecking);
 
   /// \brief Type check the given expression as a condition, which converts
   /// it to a logic value.

--- a/stdlib/public/Platform/MachError.swift
+++ b/stdlib/public/Platform/MachError.swift
@@ -12,7 +12,6 @@
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 /// Enumeration describing Mach error codes.
-@_frozen // FIXME(sil-serialize-all)		
 @objc
 public enum MachErrorCode : Int32 {
   case success                  = 0

--- a/stdlib/public/Platform/MachError.swift
+++ b/stdlib/public/Platform/MachError.swift
@@ -12,7 +12,7 @@
 
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 /// Enumeration describing Mach error codes.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)		
 @objc
 public enum MachErrorCode : Int32 {
   case success                  = 0

--- a/stdlib/public/Platform/POSIXError.swift
+++ b/stdlib/public/Platform/POSIXError.swift
@@ -15,7 +15,6 @@
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 
 /// Enumeration describing POSIX error codes.
-@_frozen // FIXME(sil-serialize-all)		
 @objc
 public enum POSIXErrorCode : Int32 {
   /// Operation not permitted.
@@ -269,7 +268,6 @@ public enum POSIXErrorCode : Int32 {
 #elseif os(Linux) || os(Android)
 
 /// Enumeration describing POSIX error codes.
-@_frozen // FIXME(sil-serialize-all)		
 public enum POSIXErrorCode : Int32 {
   /// Operation not permitted.
   case EPERM           = 1

--- a/stdlib/public/Platform/POSIXError.swift
+++ b/stdlib/public/Platform/POSIXError.swift
@@ -15,7 +15,7 @@
 #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 
 /// Enumeration describing POSIX error codes.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)		
 @objc
 public enum POSIXErrorCode : Int32 {
   /// Operation not permitted.
@@ -269,7 +269,7 @@ public enum POSIXErrorCode : Int32 {
 #elseif os(Linux) || os(Android)
 
 /// Enumeration describing POSIX error codes.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)		
 public enum POSIXErrorCode : Int32 {
   /// Operation not permitted.
   case EPERM           = 1

--- a/stdlib/public/SDK/ARKit/ARKit.swift
+++ b/stdlib/public/SDK/ARKit/ARKit.swift
@@ -17,6 +17,7 @@ extension ARCamera {
     /**
      A value describing the camera's tracking state.
      */
+    @_frozen
     public enum TrackingState {
         public enum Reason {
             /** Tracking is limited due to initialization in progress. */

--- a/stdlib/public/SDK/Dispatch/Dispatch.swift
+++ b/stdlib/public/SDK/Dispatch/Dispatch.swift
@@ -121,7 +121,7 @@ public struct DispatchQoS : Equatable {
 }
 
 /// 
-
+@_frozen
 public enum DispatchTimeoutResult {
 	case success
 	case timedOut

--- a/stdlib/public/SwiftOnoneSupport/SwiftOnoneSupport.swift
+++ b/stdlib/public/SwiftOnoneSupport/SwiftOnoneSupport.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 import Swift
 
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)
 @_versioned // FIXME(sil-serialize-all)
 internal enum _Prespecialize {
   // Create specializations for the arrays of most

--- a/stdlib/public/core/ASCII.swift
+++ b/stdlib/public/core/ASCII.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 extension Unicode {
-  @_fixed_layout
+  @_frozen
   public enum ASCII {}
 }
 

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -68,7 +68,7 @@ public struct Character {
   // to discriminate between small and large representations.  Since a grapheme
   // cluster cannot have U+0000 anywhere but in its first scalar, we can store
   // zero in empty code units above the first one.
-  @_fixed_layout // FIXME(sil-serialize-all)
+  @_frozen // FIXME(sil-serialize-all)
   @_versioned
   internal enum Representation {
     case smallUTF16(Builtin.Int63)

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -127,7 +127,7 @@ where Bound: Strideable, Bound.Stride: SignedInteger {
 }
 
 extension ClosedRange where Bound : Strideable, Bound.Stride : SignedInteger {
-  @_fixed_layout // FIXME(resilience)
+  @_frozen // FIXME(resilience)
   public enum Index {
     case pastEnd
     case inRange(Bound)

--- a/stdlib/public/core/Codable.swift.gyb
+++ b/stdlib/public/core/Codable.swift.gyb
@@ -1101,7 +1101,7 @@ public struct CodingUserInfoKey : RawRepresentable, Equatable, Hashable {
 //===----------------------------------------------------------------------===//
 
 /// An error that occurs during the encoding of a value.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)
 public enum EncodingError : Error {
   /// The context in which the error occurred.
   @_fixed_layout // FIXME(sil-serialize-all)
@@ -1190,7 +1190,7 @@ public enum EncodingError : Error {
 }
 
 /// An error that occurs during the decoding of a value.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)
 public enum DecodingError : Error {
   /// The context in which the error occurred.
   @_fixed_layout // FIXME(sil-serialize-all)

--- a/stdlib/public/core/Codable.swift.gyb
+++ b/stdlib/public/core/Codable.swift.gyb
@@ -1101,7 +1101,6 @@ public struct CodingUserInfoKey : RawRepresentable, Equatable, Hashable {
 //===----------------------------------------------------------------------===//
 
 /// An error that occurs during the encoding of a value.
-@_frozen // FIXME(sil-serialize-all)
 public enum EncodingError : Error {
   /// The context in which the error occurred.
   @_fixed_layout // FIXME(sil-serialize-all)
@@ -1190,7 +1189,6 @@ public enum EncodingError : Error {
 }
 
 /// An error that occurs during the decoding of a value.
-@_frozen // FIXME(sil-serialize-all)
 public enum DecodingError : Error {
   /// The context in which the error occurred.
   @_fixed_layout // FIXME(sil-serialize-all)

--- a/stdlib/public/core/CommandLine.swift
+++ b/stdlib/public/core/CommandLine.swift
@@ -13,7 +13,7 @@
 import SwiftShims
 
 /// Command-line arguments for the current process.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)
 public enum CommandLine {
   /// The backing static variable for argument count may come either from the
   /// entry point or it may need to be computed e.g. if we're in the REPL.

--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)
 public enum _DebuggerSupport {
-  @_fixed_layout // FIXME(sil-serialize-all)
+  @_frozen // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal enum CollectionStatus {
     case NotACollection

--- a/stdlib/public/core/DoubleWidth.swift.gyb
+++ b/stdlib/public/core/DoubleWidth.swift.gyb
@@ -212,7 +212,7 @@ extension DoubleWidth : Numeric {
 extension DoubleWidth : FixedWidthInteger {
   @_fixed_layout // FIXME(sil-serialize-all)
   public struct Words : Collection {
-    @_fixed_layout // FIXME(sil-serialize-all)
+    @_frozen // FIXME(sil-serialize-all)
     public enum _IndexValue {
       case low(Low.Words.Index)
       case high(High.Words.Index)

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -1267,7 +1267,6 @@ public enum FloatingPointClassification {
 }
 
 /// A rule for rounding a floating-point number.
-@_frozen // FIXME(sil-serialize-all)
 public enum FloatingPointRoundingRule {
   /// Round to the closest allowed value; if two values are equally close, the
   /// one with greater magnitude is chosen.

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -1218,7 +1218,7 @@ public protocol FloatingPoint: SignedNumeric, Strideable, Hashable {
 }
 
 /// The sign of a floating-point value.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)
 public enum FloatingPointSign: Int {
   /// The sign for a positive value.
   case plus
@@ -1228,7 +1228,7 @@ public enum FloatingPointSign: Int {
 }
 
 /// The IEEE 754 floating-point classes.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)
 public enum FloatingPointClassification {
   /// A signaling NaN ("not a number").
   ///
@@ -1267,7 +1267,7 @@ public enum FloatingPointClassification {
 }
 
 /// A rule for rounding a floating-point number.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)
 public enum FloatingPointRoundingRule {
   /// Round to the closest allowed value; if two values are equally close, the
   /// one with greater magnitude is chosen.

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -2831,7 +2831,7 @@ extension Dictionary : CustomStringConvertible, CustomDebugStringConvertible {
 }
 
 @_versioned // FIXME(sil-serialize-all)
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)
 internal enum _MergeError : Error {
   case keyCollision
 }
@@ -4835,7 +4835,7 @@ internal struct _Cocoa${Self}Buffer : _HashBuffer {
 #endif
 
 @_versioned
-@_fixed_layout
+@_frozen
 internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
 
   internal typealias NativeBuffer = _Native${Self}Buffer<${TypeParameters}>
@@ -5993,7 +5993,7 @@ extension _Cocoa${Self}Index {
 }
 #endif
 
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)
 @_versioned // FIXME(sil-serialize-all)
 internal enum ${Self}IndexRepresentation<${TypeParametersDecl}> {
   typealias _Index = ${Self}Index<${TypeParameters}>
@@ -6266,7 +6266,7 @@ final internal class _Cocoa${Self}Iterator : IteratorProtocol {
 #endif
 
 @_versioned
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)
 internal enum ${Self}IteratorRepresentation<${TypeParametersDecl}> {
   internal typealias _Iterator = ${Self}Iterator<${TypeParameters}>
   internal typealias _NativeBuffer =

--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -23,7 +23,7 @@
 
 import SwiftShims
 
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)
 public // @testable
 enum _HashingDetail {
 

--- a/stdlib/public/core/Join.swift
+++ b/stdlib/public/core/Join.swift
@@ -48,7 +48,7 @@ extension JoinedSequence {
     @_versioned // FIXME(sil-serialize-all)
     internal var _separator: ContiguousArray<Element>.Iterator?
     
-    @_fixed_layout // FIXME(sil-serialize-all)
+    @_frozen // FIXME(sil-serialize-all)
     @_versioned // FIXME(sil-serialize-all)
     internal enum JoinIteratorState {
       case start

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -167,7 +167,7 @@ public class AnyKeyPath: Hashable, _AppendKeyPath {
 public class PartialKeyPath<Root>: AnyKeyPath { }
 
 // MARK: Concrete implementations
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)
 @_versioned // FIXME(sil-serialize-all)
 internal enum KeyPathKind { case readOnly, value, reference }
 
@@ -404,7 +404,7 @@ public class ReferenceWritableKeyPath<
 
 // MARK: Implementation details
 
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)
 @_versioned // FIXME(sil-serialize-all)
 internal enum KeyPathComponentKind {
   /// The keypath projects within the storage of the outer value, like a
@@ -495,7 +495,7 @@ internal struct ComputedArgumentWitnesses {
   internal let hash: Hash
 }
 
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)
 @_versioned // FIXME(sil-serialize-all)
 internal enum KeyPathComponent: Hashable {
   @_fixed_layout // FIXME(sil-serialize-all)
@@ -1209,7 +1209,7 @@ internal struct RawKeyPathComponent {
       count: buffer.count - componentSize)
   }
 
-  @_fixed_layout // FIXME(sil-serialize-all)
+  @_frozen // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal enum ProjectionResult<NewValue, LeafValue> {
     /// Continue projecting the key path with the given new value.

--- a/stdlib/public/core/MemoryLayout.swift
+++ b/stdlib/public/core/MemoryLayout.swift
@@ -39,7 +39,7 @@
 ///     let pointPointer = UnsafeMutableRawPointer.allocate(
 ///             bytes: count * MemoryLayout<Point>.stride,
 ///             alignedTo: MemoryLayout<Point>.alignment)
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)
 public enum MemoryLayout<T> {
   /// The contiguous memory footprint of `T`, in bytes.
   ///

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -45,7 +45,7 @@ public struct Mirror {
   /// Note that the effect of this setting goes no deeper than the
   /// nearest descendant class that overrides `customMirror`, which
   /// in turn can determine representation of *its* descendants.
-  @_fixed_layout // FIXME(sil-serialize-all)
+  @_frozen // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal enum _DefaultDescendantRepresentation {
     /// Generate a default mirror for descendant classes that don't
@@ -69,7 +69,7 @@ public struct Mirror {
   /// its mirror represents ancestor classes by initializing the mirror
   /// with an `AncestorRepresentation`. This setting has no effect on mirrors
   /// reflecting value type instances.
-  @_fixed_layout // FIXME(sil-serialize-all)
+  @_frozen // FIXME(sil-serialize-all)
   public enum AncestorRepresentation {
 
     /// Generates a default mirror for all ancestor classes.
@@ -152,7 +152,7 @@ public struct Mirror {
   /// Playgrounds and the debugger will show a representation similar
   /// to the one used for instances of the kind indicated by the
   /// `DisplayStyle` case name when the mirror is used for display.
-  @_fixed_layout // FIXME(sil-serialize-all)
+  @_frozen // FIXME(sil-serialize-all)
   public enum DisplayStyle {
     case `struct`, `class`, `enum`, tuple, optional, collection
     case dictionary, `set`
@@ -503,7 +503,7 @@ extension Mirror {
 ///         // With Swift 4.0 and Swift 3.2 and earlier, use PlaygroundQuickLook
 ///         // and the CustomPlaygroundQuickLookable protocol.
 ///     #endif
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)
 @available(*, deprecated, message: "PlaygroundQuickLook will be removed in a future Swift version. For customizing how types are presented in playgrounds, use CustomPlaygroundDisplayConvertible instead.")
 public enum PlaygroundQuickLook {
   /// Plain text.

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -69,7 +69,6 @@ public struct Mirror {
   /// its mirror represents ancestor classes by initializing the mirror
   /// with an `AncestorRepresentation`. This setting has no effect on mirrors
   /// reflecting value type instances.
-  @_frozen // FIXME(sil-serialize-all)
   public enum AncestorRepresentation {
 
     /// Generates a default mirror for all ancestor classes.
@@ -152,7 +151,6 @@ public struct Mirror {
   /// Playgrounds and the debugger will show a representation similar
   /// to the one used for instances of the kind indicated by the
   /// `DisplayStyle` case name when the mirror is used for display.
-  @_frozen // FIXME(sil-serialize-all)
   public enum DisplayStyle {
     case `struct`, `class`, `enum`, tuple, optional, collection
     case dictionary, `set`
@@ -503,7 +501,6 @@ extension Mirror {
 ///         // With Swift 4.0 and Swift 3.2 and earlier, use PlaygroundQuickLook
 ///         // and the CustomPlaygroundQuickLookable protocol.
 ///     #endif
-@_frozen // FIXME(sil-serialize-all)
 @available(*, deprecated, message: "PlaygroundQuickLook will be removed in a future Swift version. For customizing how types are presented in playgrounds, use CustomPlaygroundDisplayConvertible instead.")
 public enum PlaygroundQuickLook {
   /// Plain text.

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -118,7 +118,7 @@
 ///
 /// Unconditionally unwrapping a `nil` instance with `!` triggers a runtime
 /// error.
-@_fixed_layout
+@_frozen
 public enum Optional<Wrapped> : ExpressibleByNilLiteral {
   // The compiler has special knowledge of Optional<Wrapped>, including the fact
   // that it is an `enum` with cases named `none` and `some`.

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -25,7 +25,7 @@
 ///     func crashAndBurn() -> Never {
 ///         fatalError("Something very, very bad happened")
 ///     }
-@_fixed_layout
+@_frozen
 public enum Never {}
 
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/core/PrefixWhile.swift
+++ b/stdlib/public/core/PrefixWhile.swift
@@ -141,7 +141,7 @@ extension LazyPrefixWhileCollection: Sequence {
 extension LazyPrefixWhileCollection {
   /// A position in the base collection of a `LazyPrefixWhileCollection` or the
   /// end of that collection.
-  @_fixed_layout // FIXME(sil-serialize-all)
+  @_frozen // FIXME(sil-serialize-all)
   @_versioned
   internal enum _IndexRepresentation {
     case index(Base.Index)

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -750,7 +750,7 @@ extension Comparable {
 ///     let word2 = "grisly"
 ///     let distance = levenshteinDistance(word1[...], word2[...])
 ///     // distance == 2
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)
 public enum UnboundedRange_ {
   // FIXME: replace this with a computed var named `...` when the language makes
   // that possible.

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -956,7 +956,7 @@ extension Sequence {
 }
 
 @_versioned
-@_fixed_layout
+@_frozen
 internal enum _StopIteration : Error {
   case stop
 }

--- a/stdlib/public/core/SipHash.swift.gyb
+++ b/stdlib/public/core/SipHash.swift.gyb
@@ -24,7 +24,7 @@
 word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
 }%
 
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)
 @_versioned
 internal enum _SipHashDetail {
   @_versioned

--- a/stdlib/public/core/StringComparison.swift
+++ b/stdlib/public/core/StringComparison.swift
@@ -157,6 +157,7 @@ extension _FixedArray16 where T == UInt16 {
   }
 }
 
+@_frozen
 @_versioned internal
 enum _Ordering: Int, Equatable {
   case less = -1

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -19,7 +19,7 @@ extension String {
     internal var _cache: _Cache
 
     internal typealias _UTF8Buffer = _ValidUTF8Buffer<UInt64>
-    @_fixed_layout // FIXME(sil-serialize-all)
+    @_frozen // FIXME(sil-serialize-all)
     @_versioned
     internal enum _Cache {
     case utf16

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -24,7 +24,7 @@ struct _StringObject {
   // there are no free bits available to implement it.  We use a single-word
   // enum instead, with an additional word for holding tagged values and (in the
   // non-tagged case) spilled flags.
-  @_fixed_layout
+  @_frozen
   @_versioned
   internal enum _Variant {
     case strong(AnyObject) // _bits stores flags

--- a/stdlib/public/core/UTF16.swift
+++ b/stdlib/public/core/UTF16.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 extension Unicode {
-  @_fixed_layout // FIXME(sil-serialize-all)
+  @_frozen // FIXME(sil-serialize-all)
   public enum UTF16 {
   case _swift3Buffer(Unicode.UTF16.ForwardParser)
   }

--- a/stdlib/public/core/UTF32.swift
+++ b/stdlib/public/core/UTF32.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 extension Unicode {
-  @_fixed_layout // FIXME(sil-serialize-all)
+  @_frozen // FIXME(sil-serialize-all)
   public enum UTF32 {
   case _swift3Codec
   }

--- a/stdlib/public/core/UTF8.swift
+++ b/stdlib/public/core/UTF8.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 extension Unicode {
-  @_fixed_layout
+  @_frozen
   public enum UTF8 {
   case _swift3Buffer(Unicode.UTF8.ForwardParser)
   }

--- a/stdlib/public/core/Unicode.swift
+++ b/stdlib/public/core/Unicode.swift
@@ -20,7 +20,7 @@ import SwiftShims
 /// Each `UnicodeDecodingResult` instance can represent a Unicode scalar value,
 /// an indication that no more Unicode scalars are available, or an indication
 /// of a decoding error.
-@_fixed_layout
+@_frozen
 public enum UnicodeDecodingResult : Equatable {
   /// A decoded Unicode scalar value.
   case scalarValue(Unicode.Scalar)
@@ -924,6 +924,6 @@ public func transcode<Input, InputEncoding, OutputEncoding>(
 }
 
 /// A namespace for Unicode utilities.
-@_fixed_layout // FIXME(sil-serialize-all)
+@_frozen // FIXME(sil-serialize-all)
 public enum Unicode {}
 

--- a/stdlib/public/core/UnicodeParser.swift
+++ b/stdlib/public/core/UnicodeParser.swift
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 extension Unicode {
   /// The result of attempting to parse a `T` from some input.
-  @_fixed_layout // FIXME(sil-serialize-all)
+  @_frozen // FIXME(sil-serialize-all)
   public enum ParseResult<T> {
   /// A `T` was parsed successfully
   case valid(T)

--- a/test/ClangImporter/CoreGraphics_test.swift
+++ b/test/ClangImporter/CoreGraphics_test.swift
@@ -19,7 +19,7 @@ public func testEnums(_ model: CGColorSpaceModel) -> Int {
      case .indexed : return 67
      case .pattern : return 71
 
-     default: return 0
+     default: return -1
   }
 // CHECK:   [[GEP:%.+]] = getelementptr inbounds [8 x i64], [8 x i64]* [[SWITCHTABLE]], i64 0, i64 %{{.*}}
 // CHECK:   [[LOAD:%.+]] = load i64, i64* [[GEP]], align 8

--- a/test/ClangImporter/Inputs/custom-modules/EnumExhaustivity.apinotes
+++ b/test/ClangImporter/Inputs/custom-modules/EnumExhaustivity.apinotes
@@ -1,0 +1,4 @@
+Name: EnumExhaustivity
+Tags:
+- Name: RegularEnumTurnedExhaustiveThenBackViaAPINotes
+  EnumExtensibility: open

--- a/test/ClangImporter/Inputs/custom-modules/EnumExhaustivity.h
+++ b/test/ClangImporter/Inputs/custom-modules/EnumExhaustivity.h
@@ -13,3 +13,31 @@ typedef MY_EXHAUSTIVE_ENUM(ExhaustiveEnum) {
   ExhaustiveEnumA,
   ExhaustiveEnumB
 };
+
+typedef MY_ENUM(RegularEnumTurnedExhaustive) {
+  RegularEnumTurnedExhaustiveA,
+  RegularEnumTurnedExhaustiveB
+} __attribute__((enum_extensibility(closed)));
+
+enum AnotherRegularEnumTurnedExhaustive {
+  AnotherRegularEnumTurnedExhaustiveA,
+  AnotherRegularEnumTurnedExhaustiveB
+} __attribute__((enum_extensibility(open))) __attribute__((enum_extensibility(closed)));
+
+typedef MY_ENUM(RegularEnumTurnedExhaustiveThenBackViaAPINotes) {
+  RegularEnumTurnedExhaustiveThenBackViaAPINotesA,
+  RegularEnumTurnedExhaustiveThenBackViaAPINotesB
+} __attribute__((enum_extensibility(closed)));
+
+typedef MY_ENUM(ForwardDeclaredTurnedExhaustive);
+enum ForwardDeclaredTurnedExhaustive {
+  ForwardDeclaredTurnedExhaustiveA,
+  ForwardDeclaredTurnedExhaustiveB
+} __attribute__((enum_extensibility(closed)));
+
+enum __attribute__((enum_extensibility(open))) ForwardDeclaredOnly;
+enum __attribute__((enum_extensibility(closed))) ForwardDeclaredOnly;
+enum ForwardDeclaredOnly {
+  ForwardDeclaredOnlyA,
+  ForwardDeclaredOnlyB
+};

--- a/test/ClangImporter/Inputs/custom-modules/EnumExhaustivity.h
+++ b/test/ClangImporter/Inputs/custom-modules/EnumExhaustivity.h
@@ -1,0 +1,15 @@
+#define MY_ENUM(_name) \
+  enum _name _name; \
+  enum __attribute__((enum_extensibility(open))) _name
+#define MY_EXHAUSTIVE_ENUM(_name) \
+  enum _name _name; \
+  enum __attribute__((enum_extensibility(closed))) _name
+
+typedef MY_ENUM(RegularEnum) {
+  RegularEnumA,
+  RegularEnumB
+};
+typedef MY_EXHAUSTIVE_ENUM(ExhaustiveEnum) {
+  ExhaustiveEnumA,
+  ExhaustiveEnumB
+};

--- a/test/ClangImporter/Inputs/custom-modules/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/module.map
@@ -41,6 +41,11 @@ module ctypes_bits_exported {
   export *
 }
 
+module EnumExhaustivity {
+  header "EnumExhaustivity.h"
+  export *
+}
+
 module ExternIntX { header "x.h" }
 
 module HasSubmodule {

--- a/test/ClangImporter/Inputs/enum-error.h
+++ b/test/ClangImporter/Inputs/enum-error.h
@@ -1,19 +1,26 @@
 #import <Foundation/Foundation.h>
 
-#define NS_ERROR_ENUM(_type, _name, _domain)                                   \
+#define MY_ERROR_ENUM(_type, _name, _domain)                                   \
   enum _name : _type _name;                                                    \
   enum __attribute__((ns_error_domain(_domain))) _name : _type
 
 @class NSString;
 extern NSString *const TestErrorDomain;
-typedef NS_ERROR_ENUM(int, TestError, TestErrorDomain) {
+typedef MY_ERROR_ENUM(int, TestError, TestErrorDomain) {
   TENone,
   TEOne,
   TETwo,
 };
 
+extern NSString *const ExhaustiveErrorDomain;
+typedef MY_ERROR_ENUM(int, ExhaustiveError, ExhaustiveErrorDomain) {
+  EENone,
+  EEOne,
+  EETwo,
+} __attribute__((enum_extensibility(closed)));
+
 extern NSString *const OtherErrorDomain;
-typedef NS_ERROR_ENUM(int, OtherErrorCode, OtherErrorDomain) {
+typedef MY_ERROR_ENUM(int, OtherErrorCode, OtherErrorDomain) {
   OtherA,
   OtherB,
   OtherC,
@@ -25,4 +32,5 @@ typedef enum __attribute__((ns_error_domain(TypedefOnlyErrorDomain))) {
 } TypedefOnlyError;
 
 
-TestError getErr();
+TestError getErr(void);
+ExhaustiveError getExhaustiveErr(void);

--- a/test/ClangImporter/Inputs/enum-inferred-exhaustivity.h
+++ b/test/ClangImporter/Inputs/enum-inferred-exhaustivity.h
@@ -1,0 +1,10 @@
+#if defined(CF_ENUM)
+# error "This test requires controlling the definition of CF_ENUM"
+#endif
+
+// Make this C-compatible by leaving out the type.
+#define CF_ENUM(_name) enum _name _name; enum _name
+
+typedef CF_ENUM(EnumWithDefaultExhaustivity) {
+  EnumWithDefaultExhaustivityLoneCase
+};

--- a/test/ClangImporter/Inputs/enum-inferred-exhaustivity.h
+++ b/test/ClangImporter/Inputs/enum-inferred-exhaustivity.h
@@ -8,3 +8,9 @@
 typedef CF_ENUM(EnumWithDefaultExhaustivity) {
   EnumWithDefaultExhaustivityLoneCase
 };
+
+// This name is also specially recognized by Swift.
+#define __CF_ENUM_ATTRIBUTES __attribute__((enum_extensibility(open)))
+typedef CF_ENUM(EnumWithSpecialAttributes) {
+  EnumWithSpecialAttributesLoneCase
+} __CF_ENUM_ATTRIBUTES;

--- a/test/ClangImporter/Inputs/enum-objc.h
+++ b/test/ClangImporter/Inputs/enum-objc.h
@@ -2,11 +2,18 @@
 
 #define SWIFT_COMPILE_NAME(X) __attribute__((swift_name(X)))
 #define SWIFT_ENUM_NAMED(_type, _name, SWIFT_NAME) enum _name : _type _name SWIFT_COMPILE_NAME(SWIFT_NAME); enum SWIFT_COMPILE_NAME(SWIFT_NAME) __attribute__((enum_extensibility(open))) SWIFT_ENUM_EXTRA _name : _type
+#define SWIFT_EXHAUSTIVE_ENUM(_type, _name) enum _name : _type _name; enum __attribute__((enum_extensibility(closed))) SWIFT_ENUM_EXTRA _name : _type
 
 typedef SWIFT_ENUM_NAMED(NSInteger, ObjCEnum, "SwiftEnum") {
     ObjCEnumOne = 1,
     ObjCEnumTwo,
     ObjCEnumThree
+};
+
+typedef SWIFT_EXHAUSTIVE_ENUM(NSInteger, ExhaustiveEnum) {
+    ExhaustiveEnumOne = 1,
+    ExhaustiveEnumTwo,
+    ExhaustiveEnumThree
 };
 
 enum BareForwardEnum;

--- a/test/ClangImporter/enum-error.swift
+++ b/test/ClangImporter/enum-error.swift
@@ -8,7 +8,7 @@
 // RUN: %target-swift-frontend -DCATCHAS -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=CATCHAS
 // RUN: %target-swift-frontend -DGENERICONLY -emit-sil %s -import-objc-header %S/Inputs/enum-error.h | %FileCheck %s -check-prefix=GENERICONLY
 
-// RUN: not %target-swift-frontend -DEXHAUSTIVE -emit-sil %s -import-objc-header %S/Inputs/enum-error.h 2>&1 | %FileCheck %s -check-prefix=EXHAUSTIVE
+// RUN: not %target-swift-frontend -DEXHAUSTIVE -emit-sil %s -import-objc-header %S/Inputs/enum-error.h  -enable-nonfrozen-enum-exhaustivity-diagnostics 2>&1 | %FileCheck %s -check-prefix=EXHAUSTIVE
 // RUN: %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/enum-error.h -DERRORS -verify
 
 // RUN: echo '#include "enum-error.h"' > %t.m
@@ -84,18 +84,32 @@ func testError() {
 
 #elseif EXHAUSTIVE
 // CHECK: sil_witness_table shared [serialized] TestError: _BridgedStoredNSError module __ObjC
+// CHECK: sil_witness_table shared [serialized] ExhaustiveError: _BridgedStoredNSError module __ObjC
   let terr = getErr()
-  switch (terr) { case .TENone, .TEOne, .TETwo: break } // ok
+  switch (terr) { case .TENone, .TEOne, .TETwo: break }
+  // EXHAUSTIVE: [[@LINE-1]]:{{.+}}: warning: switch must be exhaustive
+  // EXHAUSTIVE: [[@LINE-2]]:{{.+}}: note: do you want to add a default clause?
 
+  // FIXME: This should still be an error because there are /known/ cases that
+  // aren't covered.
   switch (terr) { case .TENone, .TEOne: break }
-  // EXHAUSTIVE: [[@LINE-1]]:{{.+}}: error: switch must be exhaustive
-  // EXHAUSTIVE: [[@LINE-2]]:{{.+}}: note: add missing case: '.TETwo'
+  // EXHAUSTIVE: [[@LINE-1]]:{{.+}}: warning: switch must be exhaustive
+  // EXHAUSTIVE: [[@LINE-2]]:{{.+}}: note: do you want to add a default clause?
+
   let _ = TestError.Code(rawValue: 2)!
 
   do {
     throw TestError(.TEOne)
   } catch is TestError {
   } catch {}
+
+  // Allow exhaustive error codes as well.
+  let eerr = getExhaustiveErr()
+  switch eerr { case .EENone, .EEOne, .EETwo: break } // ok
+
+  switch eerr { case .EENone, .EEOne: break }
+  // EXHAUSTIVE: [[@LINE-1]]:{{.+}}: error: switch must be exhaustive
+  // EXHAUSTIVE: [[@LINE-2]]:{{.+}}: note: add missing case: '.EETwo'
 
 #endif
 

--- a/test/ClangImporter/enum-exhaustivity.swift
+++ b/test/ClangImporter/enum-exhaustivity.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules -verify -warnings-as-errors -enable-nonfrozen-enum-exhaustivity-diagnostics
 
-// RUN: %target-swift-ide-test -source-filename %s -print-module -module-to-print EnumExhaustivity -I %S/Inputs/custom-modules | %FileCheck -check-prefix=CHECK %s
+// RUN: %target-swift-ide-test -source-filename %s -print-module -module-to-print EnumExhaustivity -I %S/Inputs/custom-modules | %FileCheck %s
 
 // CHECK-LABEL: {{^}}enum RegularEnum : {{.+}} {
 // CHECK:      case A
@@ -13,6 +13,7 @@
 // CHECK-NEXT: case B
 // CHECK-NEXT: {{^}$}}
 
+
 import EnumExhaustivity
 
 func test(_ value: RegularEnum, _ exhaustiveValue: ExhaustiveEnum) {
@@ -24,5 +25,33 @@ func test(_ value: RegularEnum, _ exhaustiveValue: ExhaustiveEnum) {
   switch exhaustiveValue { // always okay
   case .A: break
   case .B: break
+  }
+}
+
+func testAttributes(
+  _ rete: RegularEnumTurnedExhaustive,
+  _ arete: AnotherRegularEnumTurnedExhaustive,
+  _ retetb: RegularEnumTurnedExhaustiveThenBackViaAPINotes,
+  _ fdte: ForwardDeclaredTurnedExhaustive,
+  _ fdo: ForwardDeclaredOnly
+) {
+  switch rete {
+  case .A, .B: break
+  }
+
+  switch arete {
+  case .A, .B: break
+  }
+
+  switch retetb { // expected-error {{switch must be exhaustive}} expected-note {{do you want to add a default clause?}}
+  case .A, .B: break
+  }
+
+  switch fdte {
+  case .A, .B: break
+  }
+
+  switch fdo {
+  case .A, .B: break
   }
 }

--- a/test/ClangImporter/enum-exhaustivity.swift
+++ b/test/ClangImporter/enum-exhaustivity.swift
@@ -1,0 +1,28 @@
+// RUN: %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules -verify -warnings-as-errors -enable-nonfrozen-enum-exhaustivity-diagnostics
+
+// RUN: %target-swift-ide-test -source-filename %s -print-module -module-to-print EnumExhaustivity -I %S/Inputs/custom-modules | %FileCheck -check-prefix=CHECK %s
+
+// CHECK-LABEL: {{^}}enum RegularEnum : {{.+}} {
+// CHECK:      case A
+// CHECK-NEXT: case B
+// CHECK-NEXT: {{^}$}}
+
+// Note that we don't print '@_frozen' here yet.
+// CHECK-LABEL: {{^}}enum ExhaustiveEnum : {{.+}} {
+// CHECK:      case A
+// CHECK-NEXT: case B
+// CHECK-NEXT: {{^}$}}
+
+import EnumExhaustivity
+
+func test(_ value: RegularEnum, _ exhaustiveValue: ExhaustiveEnum) {
+  switch value { // expected-error {{switch must be exhaustive}} expected-note {{do you want to add a default clause?}}
+  case .A: break
+  case .B: break
+  }
+
+  switch exhaustiveValue { // always okay
+  case .A: break
+  case .B: break
+  }
+}

--- a/test/ClangImporter/enum-inferred-exhaustivity.swift
+++ b/test/ClangImporter/enum-inferred-exhaustivity.swift
@@ -10,3 +10,10 @@ func test(_ value: EnumWithDefaultExhaustivity) {
   case .loneCase: break
   }
 }
+
+func test(_ value: EnumWithSpecialAttributes) {
+  // Same, but with the attributes macro shipped in the Xcode 9 SDKs.
+  switch value { // expected-error {{switch must be exhaustive}} expected-note {{do you want to add a default clause?}}
+  case .loneCase: break
+  }
+}

--- a/test/ClangImporter/enum-inferred-exhaustivity.swift
+++ b/test/ClangImporter/enum-inferred-exhaustivity.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/enum-inferred-exhaustivity.h -verify -enable-nonfrozen-enum-exhaustivity-diagnostics -warnings-as-errors
+
+// This is testing what happens with a CF_ENUM definition that doesn't include
+// any enum_extensibility attributes. As such, the test deliberately avoids
+// importing anything that might pull in CoreFoundation, even from the mock SDK.
+
+func test(_ value: EnumWithDefaultExhaustivity) {
+  // We want to assume such enums are non-frozen.
+  switch value { // expected-error {{switch must be exhaustive}} expected-note {{do you want to add a default clause?}}
+  case .loneCase: break
+  }
+}

--- a/test/Compatibility/exhaustive_switch.swift
+++ b/test/Compatibility/exhaustive_switch.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-resilience
+// RUN: %target-typecheck-verify-swift -swift-version 3 -enable-resilience
+// RUN: %target-typecheck-verify-swift -swift-version 4 -enable-resilience
 
 func foo(a: Int?, b: Int?) -> Int {
   switch (a, b) {
@@ -460,7 +461,6 @@ func quiteBigEnough() -> Bool {
   case (.case11, .case11): return true
   }
 
-  // No diagnostic
   switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) { // expected-error {{switch must be exhaustive}}
   // expected-note@-1 {{do you want to add a default clause?}}
   case (.case0, _): return true
@@ -509,7 +509,7 @@ func quiteBigEnough() -> Bool {
   case (_, .case11): return true
   }
 
-  // No diagnostic
+  // No diagnostic 
   switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) {
   case (_, _): return true
   }
@@ -523,7 +523,7 @@ func quiteBigEnough() -> Bool {
   case _: return true
   }
   
-  // No diagnostic
+  // No diagnostic 
   switch ContainsOverlyLargeEnum.one(.case0) {
   case .one: return true
   case .two: return true
@@ -801,15 +801,6 @@ func sr6975() {
   case .a: // expected-warning {{case is already handled by previous patterns; consider removing it}}
     print("second a")
   }
-
-  func foo(_ str: String) -> Int {
-    switch str { // expected-error {{switch must be exhaustive}}
-    // expected-note@-1 {{do you want to add a default clause?}}
-    case let (x as Int) as Any:
-      return x
-    }
-  }
-  _ = foo("wtf")
 }
 
 public enum NonExhaustive {
@@ -829,11 +820,11 @@ public enum NonExhaustive {
 // case.
 @_inlineable
 public func testNonExhaustive(_ value: NonExhaustive, for interval: TemporalProxy, flag: Bool) {
-  switch value { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{do you want to add a default clause?}} {{3-3=default:\n<#code#>\n}}
+  switch value { // expected-warning {{switch must be exhaustive}} {{none}} expected-note {{do you want to add a default clause?}} {{3-3=default:\n<#code#>\n}}
   case .a: break
   }
 
-  switch value { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{do you want to add a default clause?}} {{3-3=default:\n<#code#>\n}}
+  switch value { // expected-warning {{switch must be exhaustive}} {{none}} expected-note {{do you want to add a default clause?}} {{3-3=default:\n<#code#>\n}}
   case .a: break
   case .b: break
   }
@@ -845,7 +836,7 @@ public func testNonExhaustive(_ value: NonExhaustive, for interval: TemporalProx
   }
 
   // Test being part of other spaces.
-  switch value as Optional { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.some(_)'}}
+  switch value as Optional { // expected-warning {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.some(_)'}}
   case .a?: break
   case .b?: break
   case nil: break
@@ -856,20 +847,20 @@ public func testNonExhaustive(_ value: NonExhaustive, for interval: TemporalProx
   case nil: break
   } // no-warning
 
-  switch (value, flag) { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '(_, false)'}}
+  switch (value, flag) { // expected-warning {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '(_, false)'}}
   case (.a, _): break
   case (.b, false): break
   case (_, true): break
   }
 
-  switch (flag, value) { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '(false, _)'}}
+  switch (flag, value) { // expected-warning {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '(false, _)'}}
   case (_, .a): break
   case (false, .b): break
   case (true, _): break
   }
 
   // Test interaction with @_downgrade_exhaustivity_check.
-  switch (value, interval) { // expected-error {{switch must be exhaustive}} {{none}}
+  switch (value, interval) { // expected-warning {{switch must be exhaustive}} {{none}}
   // expected-note@-1 {{add missing case: '(_, .milliseconds(_))'}}
   // expected-note@-2 {{add missing case: '(_, .microseconds(_))'}}
   // expected-note@-3 {{add missing case: '(_, .nanoseconds(_))'}}
@@ -879,7 +870,7 @@ public func testNonExhaustive(_ value: NonExhaustive, for interval: TemporalProx
   case (.b, _): break
   }
 
-  switch (value, interval) { // expected-error {{switch must be exhaustive}} {{none}}
+  switch (value, interval) { // expected-warning {{switch must be exhaustive}} {{none}}
   // expected-note@-1 {{add missing case: '(_, .seconds(_))'}}
   // expected-note@-2 {{add missing case: '(_, .milliseconds(_))'}}
   // expected-note@-3 {{add missing case: '(_, .microseconds(_))'}}

--- a/test/Compatibility/exhaustive_switch.swift
+++ b/test/Compatibility/exhaustive_switch.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -swift-version 3 -enable-resilience
-// RUN: %target-typecheck-verify-swift -swift-version 4 -enable-resilience
+// RUN: %target-typecheck-verify-swift -swift-version 3 -enable-resilience -enable-nonfrozen-enum-exhaustivity-diagnostics
+// RUN: %target-typecheck-verify-swift -swift-version 4 -enable-resilience -enable-nonfrozen-enum-exhaustivity-diagnostics
 
 func foo(a: Int?, b: Int?) -> Int {
   switch (a, b) {

--- a/test/IRGen/enum_resilience.swift
+++ b/test/IRGen/enum_resilience.swift
@@ -38,7 +38,7 @@ public struct Reference {
   public var n: Class
 }
 
-@_fixed_layout public enum Either {
+@_frozen public enum Either {
   case Left(Reference)
   case Right(Reference)
 }
@@ -57,7 +57,7 @@ enum InternalEither {
   public var n: Class
 }
 
-@_fixed_layout public enum EitherFast {
+@_frozen public enum EitherFast {
   case Left(ReferenceFast)
   case Right(ReferenceFast)
 }
@@ -261,6 +261,25 @@ extension ResilientMultiPayloadGenericEnum {
   public func getTypeParameter() -> T.Type {
     return T.self
   }
+}
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S15enum_resilience39constructExhaustiveWithResilientMembers010resilient_A011SimpleShapeOyF"(%T14resilient_enum11SimpleShapeO* noalias nocapture sret)
+// CHECK: [[BUFFER:%.*]] = bitcast %T14resilient_enum11SimpleShapeO* %0 to %swift.opaque*
+// CHECK: [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S16resilient_struct4SizeVMa"([[INT]] 0)
+// CHECK-NEXT: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK: [[STORE_TAG:%.*]] = bitcast i8* {{%.+}} to void (%swift.opaque*, i32, i32, %swift.type*)* 
+// CHECK-NEXT: call void [[STORE_TAG]](%swift.opaque* noalias [[BUFFER]], i32 0, i32 1, %swift.type* [[METADATA]])
+// CHECK-NEXT: ret void
+// CHECK-NEXT: {{^}$}}
+public func constructExhaustiveWithResilientMembers() -> SimpleShape {
+  return .KleinBottle
+}
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc { i{{64|32}}, i8 } @"$S15enum_resilience19constructFullyFixed010resilient_A00dE6LayoutOyF"()
+// CHECK: ret { [[INT]], i8 } { [[INT]] 0, i8 1 }
+// CHECK-NEXT: {{^}$}}
+public func constructFullyFixed() -> FullyFixedLayout {
+  return .noPayload
 }
 
 // CHECK-LABEL: define{{( protected)?}} private void @initialize_metadata_EnumWithResilientPayload(i8*)

--- a/test/Inputs/resilient_enum.swift
+++ b/test/Inputs/resilient_enum.swift
@@ -1,20 +1,20 @@
 import resilient_struct
 
 // Fixed-layout enum with resilient members
-@_fixed_layout public enum SimpleShape {
+@_fixed_layout @_frozen public enum SimpleShape {
   case KleinBottle
   case Triangle(Size)
 }
 
 // Fixed-layout enum with resilient members
-@_fixed_layout public enum Shape {
+@_fixed_layout @_frozen public enum Shape {
   case Point
   case Rect(Size)
   case RoundedRect(Size, Size)
 }
 
 // Fixed-layout enum with indirect resilient members
-@_fixed_layout public enum FunnyShape {
+@_fixed_layout @_frozen public enum FunnyShape {
   indirect case Parallelogram(Size)
   indirect case Trapezoid(Size)
 }
@@ -33,7 +33,7 @@ public struct Color {
   }
 }
 
-@_fixed_layout public enum CustomColor {
+@_fixed_layout @_frozen public enum CustomColor {
   case Black
   case White
   case Custom(Color)

--- a/test/Inputs/resilient_enum.swift
+++ b/test/Inputs/resilient_enum.swift
@@ -1,22 +1,27 @@
 import resilient_struct
 
 // Fixed-layout enum with resilient members
-@_fixed_layout @_frozen public enum SimpleShape {
+@_frozen public enum SimpleShape {
   case KleinBottle
   case Triangle(Size)
 }
 
 // Fixed-layout enum with resilient members
-@_fixed_layout @_frozen public enum Shape {
+@_frozen public enum Shape {
   case Point
   case Rect(Size)
   case RoundedRect(Size, Size)
 }
 
 // Fixed-layout enum with indirect resilient members
-@_fixed_layout @_frozen public enum FunnyShape {
+@_frozen public enum FunnyShape {
   indirect case Parallelogram(Size)
   indirect case Trapezoid(Size)
+}
+
+@_frozen public enum FullyFixedLayout {
+  case noPayload
+  case hasPayload(Int)
 }
 
 // The enum payload has fixed layout inside this module, but
@@ -33,7 +38,7 @@ public struct Color {
   }
 }
 
-@_fixed_layout @_frozen public enum CustomColor {
+@_frozen public enum CustomColor {
   case Black
   case White
   case Custom(Color)

--- a/test/PrintAsObjC/enums-frozen.swift
+++ b/test/PrintAsObjC/enums-frozen.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-module -emit-module-doc -o %t %s -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module -enable-resilience -module-name enums
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/enums.swiftmodule -typecheck -emit-objc-header-path %t/enums.h -import-objc-header %S/Inputs/enums.h -disable-objc-attr-requires-foundation-module -enable-resilience
+// RUN: %FileCheck %s < %t/enums.h
+// RUN: %check-in-clang %t/enums.h
+// RUN: %check-in-clang -fno-modules -Qunused-arguments %t/enums.h -include Foundation.h -include ctypes.h -include CoreFoundation.h
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+// CHECK-LABEL: typedef SWIFT_ENUM(NSInteger, FrozenEnum, closed) {
+@objc @_frozen public enum FrozenEnum: Int {
+  case yes
+  case no
+}
+
+// CHECK-LABEL: typedef SWIFT_ENUM(NSInteger, NonFrozenEnum, open) {
+@objc public enum NonFrozenEnum: Int {
+  case yes
+  case no
+  case fileNotFound
+}

--- a/test/PrintAsObjC/enums.swift
+++ b/test/PrintAsObjC/enums.swift
@@ -36,7 +36,7 @@ import Foundation
   @objc func acceptMemberImported(a: Wrapper.Raw, b: Wrapper.Enum, c: Wrapper.Options, d: Wrapper.Typedef, e: Wrapper.Anon, ee: Wrapper.Anon2) {}
 }
 
-// CHECK-LABEL: typedef SWIFT_ENUM_NAMED(NSInteger, ObjcEnumNamed, "EnumNamed") {
+// CHECK-LABEL: typedef SWIFT_ENUM_NAMED(NSInteger, ObjcEnumNamed, "EnumNamed", closed) {
 // CHECK-NEXT:   ObjcEnumNamedA = 0,
 // CHECK-NEXT:   ObjcEnumNamedB = 1,
 // CHECK-NEXT:   ObjcEnumNamedC = 2,
@@ -48,7 +48,7 @@ import Foundation
   case A, B, C, d, helloDolly
 }
 
-// CHECK-LABEL: typedef SWIFT_ENUM(NSInteger, EnumWithNamedConstants) {
+// CHECK-LABEL: typedef SWIFT_ENUM(NSInteger, EnumWithNamedConstants, closed) {
 // CHECK-NEXT:   kEnumA SWIFT_COMPILE_NAME("A") = 0,
 // CHECK-NEXT:   kEnumB SWIFT_COMPILE_NAME("B") = 1,
 // CHECK-NEXT:   kEnumC SWIFT_COMPILE_NAME("C") = 2,
@@ -60,7 +60,7 @@ import Foundation
   @objc(kEnumC) case C
 }
 
-// CHECK-LABEL: typedef SWIFT_ENUM(unsigned int, ExplicitValues) {
+// CHECK-LABEL: typedef SWIFT_ENUM(unsigned int, ExplicitValues, closed) {
 // CHECK-NEXT:   ExplicitValuesZim = 0,
 // CHECK-NEXT:   ExplicitValuesZang = 219,
 // CHECK-NEXT:   ExplicitValuesZung = 220,
@@ -74,7 +74,7 @@ import Foundation
 }
 
 // CHECK: /// Foo: A feer, a female feer.
-// CHECK-NEXT: typedef SWIFT_ENUM(NSInteger, FooComments) {
+// CHECK-NEXT: typedef SWIFT_ENUM(NSInteger, FooComments, closed) {
 // CHECK: /// Zim: A zeer, a female zeer.
 // CHECK-NEXT:   FooCommentsZim = 0,
 // CHECK-NEXT:   FooCommentsZang = 1,
@@ -88,7 +88,7 @@ import Foundation
   case Zang, Zung
 }
 
-// CHECK-LABEL: typedef SWIFT_ENUM(int16_t, NegativeValues) {
+// CHECK-LABEL: typedef SWIFT_ENUM(int16_t, NegativeValues, closed) {
 // CHECK-NEXT:   Zang = -219,
 // CHECK-NEXT:   Zung = -218,
 // CHECK-NEXT: };
@@ -98,7 +98,7 @@ import Foundation
   func methodNotExportedToObjC() {}
 }
 
-// CHECK-LABEL: typedef SWIFT_ENUM(NSInteger, SomeError) {
+// CHECK-LABEL: typedef SWIFT_ENUM(NSInteger, SomeError, closed) {
 // CHECK-NEXT:   SomeErrorBadness = 9001,
 // CHECK-NEXT:   SomeErrorWorseness = 9002,
 // CHECK-NEXT: };
@@ -108,7 +108,7 @@ import Foundation
   case Worseness
 }
 
-// CHECK-LABEL: typedef SWIFT_ENUM(NSInteger, SomeOtherError) {
+// CHECK-LABEL: typedef SWIFT_ENUM(NSInteger, SomeOtherError, closed) {
 // CHECK-NEXT:   SomeOtherErrorDomain = 0,
 // CHECK-NEXT: };
 // NEGATIVE-NOT: NSString * _Nonnull const SomeOtherErrorDomain
@@ -116,7 +116,7 @@ import Foundation
   case Domain // collision!
 }
 
-// CHECK-LABEL: typedef SWIFT_ENUM_NAMED(NSInteger, ObjcErrorType, "SomeRenamedErrorType") {
+// CHECK-LABEL: typedef SWIFT_ENUM_NAMED(NSInteger, ObjcErrorType, "SomeRenamedErrorType", closed) {
 // CHECK-NEXT:   ObjcErrorTypeBadStuff = 0,
 // CHECK-NEXT: };
 // CHECK-NEXT: static NSString * _Nonnull const ObjcErrorTypeDomain = @"enums.SomeRenamedErrorType";
@@ -133,4 +133,3 @@ import Foundation
     return .Zung
   }
 }
-

--- a/test/PrintAsObjC/swift_name.swift
+++ b/test/PrintAsObjC/swift_name.swift
@@ -38,6 +38,6 @@ public enum TestE : Int{
 	case A1
 	case B1
 }
-// CHECK: typedef SWIFT_ENUM(NSInteger, TestE)
+// CHECK: typedef SWIFT_ENUM(NSInteger, TestE, closed)
 // CHECK-NEXT: {{^}} A2 SWIFT_COMPILE_NAME("A1") = 0,
 // CHECK-NEXT: {{^}} TestEB1 = 1,

--- a/test/SILGen/enum_resilience_testable.swift
+++ b/test/SILGen/enum_resilience_testable.swift
@@ -1,0 +1,55 @@
+// REQUIRES: plus_zero_runtime
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_enum.swiftmodule -module-name=resilient_enum -I %t %S/../Inputs/resilient_enum.swift -enable-testing
+// RUN: %target-swift-frontend -module-name enum_resilience_testable -I %t -enable-sil-ownership -emit-silgen -enable-nonfrozen-enum-exhaustivity-diagnostics -swift-version 5 %s | %FileCheck %s
+
+// This is mostly testing the same things as enum_resilienc.swift, just in a
+// context where the user will never be forced to write a default case. It's the
+// same effect as -swift-version 4 and ignoring the exhaustivity warning,
+// though.
+
+@testable import resilient_enum
+
+// Resilient enums are always address-only, and switches must include
+// a default case
+
+// CHECK-LABEL: sil hidden @$S24enum_resilience_testable15resilientSwitchyy0d1_A06MediumOF : $@convention(thin) (@in_guaranteed Medium) -> ()
+// CHECK:         [[BOX:%.*]] = alloc_stack $Medium
+// CHECK-NEXT:    copy_addr %0 to [initialization] [[BOX]]
+// CHECK-NEXT:    switch_enum_addr [[BOX]] : $*Medium, case #Medium.Paper!enumelt: bb1, case #Medium.Canvas!enumelt: bb2, case #Medium.Pamphlet!enumelt.1: bb3, case #Medium.Postcard!enumelt.1: bb4, default bb5
+// CHECK:       bb1:
+// CHECK-NEXT:    dealloc_stack [[BOX]]
+// CHECK-NEXT:    br bb6
+// CHECK:       bb2:
+// CHECK-NEXT:    dealloc_stack [[BOX]]
+// CHECK-NEXT:    br bb6
+// CHECK:       bb3:
+// CHECK-NEXT:    [[INDIRECT_ADDR:%.*]] = unchecked_take_enum_data_addr [[BOX]]
+// CHECK-NEXT:    [[INDIRECT:%.*]] = load [take] [[INDIRECT_ADDR]]
+// CHECK-NEXT:    [[PAYLOAD:%.*]] = project_box [[INDIRECT]]
+// CHECK-NEXT:    destroy_value [[INDIRECT]]
+// CHECK-NEXT:    dealloc_stack [[BOX]]
+// CHECK-NEXT:    br bb6
+// CHECK:       bb4:
+// CHECK-NEXT:    [[PAYLOAD_ADDR:%.*]] = unchecked_take_enum_data_addr [[BOX]]
+// CHECK-NEXT:    destroy_addr [[PAYLOAD_ADDR]]
+// CHECK-NEXT:    dealloc_stack [[BOX]]
+// CHECK-NEXT:    br bb6
+// CHECK:       bb5:
+// CHECK-NEXT:    builtin "int_trap"()
+// CHECK-NEXT:    unreachable
+// CHECK:       bb6:
+// CHECK-NOT:    destroy_addr %0
+// CHECK-NEXT:    [[RESULT:%.*]] = tuple ()
+// CHECK-NEXT:    return [[RESULT]]
+
+func resilientSwitch(_ m: Medium) {
+  switch m {
+  case .Paper: ()
+  case .Canvas: ()
+  case .Pamphlet: ()
+  case .Postcard: ()
+  }
+}

--- a/test/Sema/Inputs/exhaustive_switch_testable_helper.swift
+++ b/test/Sema/Inputs/exhaustive_switch_testable_helper.swift
@@ -1,0 +1,7 @@
+@_frozen public enum FrozenEnum {
+  case a, b, c
+}
+
+/*non-frozen*/public enum NonFrozenEnum {
+  case a, b, c
+}

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-resilience
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-resilience -enable-nonfrozen-enum-exhaustivity-diagnostics
 
 func foo(a: Int?, b: Int?) -> Int {
   switch (a, b) {

--- a/test/Sema/exhaustive_switch_testable.swift
+++ b/test/Sema/exhaustive_switch_testable.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -swift-version 5 -enable-resilience -enable-testing %S/Inputs/exhaustive_switch_testable_helper.swift -emit-module -o %t
+// RUN: %target-swift-frontend -typecheck %s -swift-version 5 -enable-nonfrozen-enum-exhaustivity-diagnostics -I %t -DTESTABLE -verify
+// RUN: not %target-swift-frontend -typecheck %s -swift-version 5 -enable-nonfrozen-enum-exhaustivity-diagnostics -I %t 2>&1 | %FileCheck -check-prefix=VERIFY-NON-FROZEN %s
+
+#if TESTABLE
+@testable import exhaustive_switch_testable_helper
+#else
+import exhaustive_switch_testable_helper
+#endif
+
+func testFrozen(_ e: FrozenEnum) -> Int {
+  switch e {
+  case .a: return 1
+  case .b, .c: return 2
+  }
+}
+
+func testNonFrozen(_ e: NonFrozenEnum) -> Int {
+  // VERIFY-NON-FROZEN: exhaustive_switch_testable.swift:[[@LINE+1]]:{{[0-9]+}}: error: switch must be exhaustive
+  switch e {
+  case .a: return 1
+  case .b, .c: return 2
+  }
+}

--- a/test/Serialization/Inputs/def_enum.swift
+++ b/test/Serialization/Inputs/def_enum.swift
@@ -37,3 +37,5 @@ public enum Breakfast<Champions> : Int {
   case Bacon
   case Coffee
 }
+
+@_frozen public enum Exhaustive {}

--- a/test/Serialization/enum.swift
+++ b/test/Serialization/enum.swift
@@ -1,10 +1,14 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -module-name def_enum -o %t %S/Inputs/def_enum.swift %S/Inputs/def_enum_derived.swift
+// RUN: %target-swift-frontend -emit-module -module-name def_enum -o %t %S/Inputs/def_enum.swift %S/Inputs/def_enum_derived.swift -enable-resilience
 // RUN: llvm-bcanalyzer %t/def_enum.swiftmodule | %FileCheck %s
 // RUN: %target-swift-frontend -typecheck -I %t %s -o /dev/null
 // RUN: %target-swift-frontend -emit-sil -I %t %s -o /dev/null
 
+// RUN: %target-swift-ide-test(mock-sdk: %clang-importer-sdk) -print-module -module-to-print=def_enum -I %t -source-filename=%s | %FileCheck -check-prefix=CHECK-PRINT %s
+
 // CHECK-NOT: UnknownCode
+
+// CHECK-PRINT-DAG: @_frozen enum Exhaustive {
 
 import def_enum
 

--- a/test/attr/attr_fixed_layout.swift
+++ b/test/attr/attr_fixed_layout.swift
@@ -1,21 +1,21 @@
 // RUN: %target-swift-frontend -typecheck -verify -dump-ast -enable-resilience %s 2>&1 | %FileCheck --check-prefix=RESILIENCE-ON %s
 // RUN: %target-swift-frontend -typecheck -verify -dump-ast -enable-resilience -enable-testing %s 2>&1 | %FileCheck --check-prefix=RESILIENCE-ON %s
-// RUN: %target-swift-frontend -typecheck -verify -dump-ast %s 2>&1 | %FileCheck --check-prefix=RESILIENCE-OFF %s
-// RUN: %target-swift-frontend -typecheck -verify -dump-ast %s -enable-testing 2>&1 | %FileCheck --check-prefix=RESILIENCE-OFF %s
+// RUN: not %target-swift-frontend -typecheck -dump-ast %s 2>&1 | %FileCheck --check-prefix=RESILIENCE-OFF %s
+// RUN: not %target-swift-frontend -typecheck -dump-ast %s -enable-testing 2>&1 | %FileCheck --check-prefix=RESILIENCE-OFF %s
 
 //
 // Public types with @_fixed_layout are always fixed layout
 //
 
-// RESILIENCE-ON: struct_decl "Point" interface type='Point.Type' access=public @_fixed_layout
-// RESILIENCE-OFF: struct_decl "Point" interface type='Point.Type' access=public @_fixed_layout
+// RESILIENCE-ON: struct_decl "Point" interface type='Point.Type' access=public non-resilient
+// RESILIENCE-OFF: struct_decl "Point" interface type='Point.Type' access=public non-resilient
 @_fixed_layout public struct Point {
   let x, y: Int
 }
 
-// RESILIENCE-ON: enum_decl "ChooseYourOwnAdventure" interface type='ChooseYourOwnAdventure.Type' access=public @_fixed_layout
-// RESILIENCE-OFF: enum_decl "ChooseYourOwnAdventure" interface type='ChooseYourOwnAdventure.Type' access=public @_fixed_layout
-@_fixed_layout public enum ChooseYourOwnAdventure {
+// RESILIENCE-ON: enum_decl "ChooseYourOwnAdventure" interface type='ChooseYourOwnAdventure.Type' access=public non-resilient
+// RESILIENCE-OFF: enum_decl "ChooseYourOwnAdventure" interface type='ChooseYourOwnAdventure.Type' access=public non-resilient
+@_frozen public enum ChooseYourOwnAdventure {
   case JumpIntoRabbitHole
   case EatMushroom
 }
@@ -24,14 +24,14 @@
 // Public types are resilient when -enable-resilience is on
 //
 
-// RESILIENCE-ON: struct_decl "Size" interface type='Size.Type' access=public @_resilient_layout
-// RESILIENCE-OFF: struct_decl "Size" interface type='Size.Type' access=public @_fixed_layout
+// RESILIENCE-ON: struct_decl "Size" interface type='Size.Type' access=public resilient
+// RESILIENCE-OFF: struct_decl "Size" interface type='Size.Type' access=public non-resilient
 public struct Size {
   let w, h: Int
 }
 
-// RESILIENCE-ON: enum_decl "TaxCredit" interface type='TaxCredit.Type' access=public @_resilient_layout
-// RESILIENCE-OFF: enum_decl "TaxCredit" interface type='TaxCredit.Type' access=public @_fixed_layout
+// RESILIENCE-ON: enum_decl "TaxCredit" interface type='TaxCredit.Type' access=public resilient
+// RESILIENCE-OFF: enum_decl "TaxCredit" interface type='TaxCredit.Type' access=public non-resilient
 public enum TaxCredit {
   case EarnedIncome
   case MortgageDeduction
@@ -41,8 +41,8 @@ public enum TaxCredit {
 // Internal types are always fixed layout
 //
 
-// RESILIENCE-ON: struct_decl "Rectangle" interface type='Rectangle.Type' access=internal @_fixed_layout
-// RESILIENCE-OFF: struct_decl "Rectangle" interface type='Rectangle.Type' access=internal @_fixed_layout
+// RESILIENCE-ON: struct_decl "Rectangle" interface type='Rectangle.Type' access=internal non-resilient
+// RESILIENCE-OFF: struct_decl "Rectangle" interface type='Rectangle.Type' access=internal non-resilient
 struct Rectangle {
   let topLeft: Point
   let bottomRight: Size

--- a/test/decl/enum/frozen-nonresilient.swift
+++ b/test/decl/enum/frozen-nonresilient.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift
+
+@_frozen public enum Exhaustive {} // expected-warning {{@_frozen has no effect without -enable-resilience}} {{1-10=}}
+
+@_frozen enum NotPublic {} // expected-warning {{@_frozen has no effect without -enable-resilience}} {{1-10=}}

--- a/test/decl/enum/frozen.swift
+++ b/test/decl/enum/frozen.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift -enable-resilience
+
+@_frozen public enum Exhaustive {} // no-warning
+
+@_frozen enum NotPublic {} // expected-warning {{@_frozen has no effect on non-public enums}} {{1-10=}}
+
+internal enum Outer {
+  @_frozen public enum ButThisIsOK {} // no-warning
+}
+
+@_frozen @_versioned enum NotPublicButVersioned {} // no-warning

--- a/validation-test/Evolution/Inputs/enum_change_size.swift
+++ b/validation-test/Evolution/Inputs/enum_change_size.swift
@@ -33,7 +33,7 @@ public struct ChangeSize {
 #endif
 }
 
-@_fixed_layout public enum SingletonEnum {
+@_frozen public enum SingletonEnum {
   case X(ChangeSize)
 }
 
@@ -42,7 +42,7 @@ public func getSingletonEnumValues(_ c: ChangeSize)
   return [.X(c), nil]
 }
 
-@_fixed_layout public enum SinglePayloadEnum {
+@_frozen public enum SinglePayloadEnum {
   case X(ChangeSize)
   case Y
   case Z
@@ -53,7 +53,7 @@ public func getSinglePayloadEnumValues(_ c: ChangeSize)
   return [.X(c), .Y, .Z, nil]
 }
 
-@_fixed_layout public enum MultiPayloadEnum {
+@_frozen public enum MultiPayloadEnum {
   case X(ChangeSize)
   case Y(ChangeSize)
   case Z


### PR DESCRIPTION
An alternative to #11961 that only makes a frozen / non-frozen distinction for imported C enums and for Swift enums in the stdlib/overlays. (Really, it's "libraries compiled with `-enable-resilience`", and exactly what that means has not been discussed publicly and is not part of SE-0192.)

This does not include the implementation of `unknown case`, or whatever we end up naming it. That's a big enough change on its own that it deserves its own PR, and this part can land first.

The diagnostics part of this is behind a frontend flag, `-enable-nonfrozen-enum-exhaustivity-diagnostics`.