### PR TITLE
build-presets.ini: Add a PR-test-like preset with resilience enabled

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1162,6 +1162,14 @@ skip-test-tvos-host
 skip-test-watchos-host
 
 
+# Like the regular PR testing preset, but with resilience enabled
+[preset: buildbot_all_platforms,tools=RA,stdlib=RA,resilience]
+mixin-preset=buildbot_all_platforms,tools=RA,stdlib=RA
+
+swift-stdlib-enable-resilience
+
+
+
 #===------------------------------------------------------------------------===#
 # Test watchOS on OS X builder
 #===------------------------------------------------------------------------===#


### PR DESCRIPTION
...so that we can test PRs with resilience enabled. ("PR-test-like" = the preset used by "Please test macOS platform" by default)