### PR TITLE
[Test] Replace unused variable with _

### DIFF
--- a/test/stdlib/Filter.swift
+++ b/test/stdlib/Filter.swift
@@ -64,12 +64,12 @@ FilterTests.test("single-count") {
   }
     
   let f0 = (0..<30).makeIterator().lazy.filter(mod7AndCount)
-  let a0 = Array(f0)
+  let _ = Array(f0)
   expectEqual(30, count)
 
   count = 0
   let f1 = LazyFilterCollection(_base: 0..<30, mod7AndCount)
-  let a1 = Array(f1)
+  let _ = Array(f1)
   expectEqual(30, count)
 }
 

--- a/test/stdlib/Filter.swift
+++ b/test/stdlib/Filter.swift
@@ -64,12 +64,12 @@ FilterTests.test("single-count") {
   }
     
   let f0 = (0..<30).makeIterator().lazy.filter(mod7AndCount)
-  let _ = Array(f0)
+  _ = Array(f0)
   expectEqual(30, count)
 
   count = 0
   let f1 = LazyFilterCollection(_base: 0..<30, mod7AndCount)
-  let _ = Array(f1)
+  _ = Array(f1)
   expectEqual(30, count)
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Replace unused variable `a0` and `a1` with `_` in a test file. This used to show a warning when some test case in this file failed.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->