### PR TITLE
[SR-7040] Redundant prefix of compilation flag specific error

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -210,7 +210,7 @@ ERROR(symbol_in_ir_not_in_tbd,none,
       (StringRef, StringRef))
 
 ERROR(redundant_prefix_compilation_flag,none,
-      "did you provide a redundant '-D' in your build settings? (got '-D%0')", 
+      "invalid argument '-D%0'; did you provide a redundant '-D' in your build settings?", 
       (StringRef))    
 
 ERROR(invalid_conditional_compilation_flag,none,

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -209,6 +209,10 @@ ERROR(symbol_in_ir_not_in_tbd,none,
       "symbol '%0' (%1) is in generated IR file, but not in TBD file",
       (StringRef, StringRef))
 
+ERROR(redundant_prefix_compilation_flag,none,
+      "did you provide a redundant '-D' in your build settings? (got '-D%0')", 
+      (StringRef))    
+
 ERROR(invalid_conditional_compilation_flag,none,
       "conditional compilation flags must be valid Swift identifiers (rather than '%0')",
       (StringRef))

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -192,6 +192,9 @@ static void validateArgs(DiagnosticEngine &diags, const ArgList &Args) {
       diags.diagnose(SourceLoc(),
                      diag::cannot_assign_value_to_conditional_compilation_flag,
                      name);
+    else if (name.startswith("-D"))
+      diags.diagnose(SourceLoc(), diag::redundant_prefix_compilation_flag,
+                     name);
     else if (!Lexer::isIdentifier(name))
       diags.diagnose(SourceLoc(), diag::invalid_conditional_compilation_flag,
                      name);

--- a/test/Frontend/unknown-arguments.swift
+++ b/test/Frontend/unknown-arguments.swift
@@ -10,5 +10,5 @@
 // RUN: not %swiftc_driver -D Correct -DAlsoCorrect -D@#%! -D Swift=Cool -D-D -c %s -o %t.o 2>&1 | %FileCheck -check-prefix=INVALID-COND %s
 // INVALID-COND: <unknown>:0: error: conditional compilation flags must be valid Swift identifiers (rather than '@#%!')
 // INVALID-COND-NEXT: <unknown>:0: warning: conditional compilation flags do not have values in Swift; they are either present or absent (rather than 'Swift=Cool')
-// INVALID-COND-NEXT: <unknown>:0: error: conditional compilation flags must be valid Swift identifiers (rather than '-D')
+// INVALID-COND-NEXT: <unknown>:0: error: invalid argument '-D-D'; did you provide a redundant '-D' in your build settings?
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Xcode (and possibly other IDEs) provide a UI over -D flags where you provide the flag name and -D is prepended for you. Users might reasonably add a redundant -D themselves, leading to the invalid flag `-D-DFOO` getting passed into the compiler. The driver could detect this and raise a specific error message alerting the user to their mistake.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7040](https://bugs.swift.org/browse/SR-7040).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
