### PR TITLE
[BatchMode] Remove uses of -bypass-batch-mode-checks in tests, no longer needed.

### DIFF
--- a/test/Driver/batch_mode_parseable_output.swift
+++ b/test/Driver/batch_mode_parseable_output.swift
@@ -2,7 +2,7 @@
 // RUN: touch %t/file-01.swift %t/file-02.swift %t/file-03.swift
 // RUN: echo 'public func main() {}' >%t/main.swift
 //
-// RUN: %swiftc_driver -enable-batch-mode -Xfrontend -bypass-batch-mode-checks -parseable-output -c -emit-module -module-name main -j 2 %t/file-01.swift %t/file-02.swift %t/file-03.swift %t/main.swift 2>&1 | %FileCheck %s
+// RUN: %swiftc_driver -enable-batch-mode -parseable-output -c -emit-module -module-name main -j 2 %t/file-01.swift %t/file-02.swift %t/file-03.swift %t/main.swift 2>&1 | %FileCheck %s
 //
 //
 // CHECK: {{[1-9][0-9]*}}

--- a/test/Frontend/batch-mode.swift
+++ b/test/Frontend/batch-mode.swift
@@ -3,7 +3,7 @@
 // RUN: echo 'public func b() { }' >%t/b.swift
 // RUN: echo 'public func c() { }' >%t/c.swift
 // RUN: echo 'public func main() {a(); b(); c()}' >%t/main.swift
-// RUN: %target-swift-frontend -c -enable-batch-mode -bypass-batch-mode-checks -module-name foo -primary-file %t/a.swift -primary-file %t/b.swift -primary-file %t/c.swift -primary-file %t/main.swift -o %t/a.o -o %t/b.o -o %t/c.o -o %t/main.o
+// RUN: %target-swift-frontend -c -enable-batch-mode -module-name foo -primary-file %t/a.swift -primary-file %t/b.swift -primary-file %t/c.swift -primary-file %t/main.swift -o %t/a.o -o %t/b.o -o %t/c.o -o %t/main.o
 //
 // RUN: llvm-objdump -t %t/a.o | swift-demangle | %FileCheck -check-prefix=CHECK-A %s
 // RUN: llvm-objdump -t %t/b.o | swift-demangle | %FileCheck -check-prefix=CHECK-B %s

--- a/test/Frontend/dependencies-selective-supplementaries.swift
+++ b/test/Frontend/dependencies-selective-supplementaries.swift
@@ -5,7 +5,7 @@
 // RUN: %empty-directory(%t)
 // RUN: echo 'public func a() { }' >%t/a.swift
 // RUN: echo 'public func main() {a()}' >%t/main.swift
-// RUN: %target-swift-frontend -c -enable-batch-mode -bypass-batch-mode-checks -module-name foo -primary-file %t/a.swift -primary-file %t/main.swift -emit-dependencies-path %t/a.d -emit-dependencies-path %t/main.d  -o %t/a.o -o %t/main.o -emit-module-path %t/a.swiftmodule -emit-module-path %t/main.swiftmodule
+// RUN: %target-swift-frontend -c -enable-batch-mode -module-name foo -primary-file %t/a.swift -primary-file %t/main.swift -emit-dependencies-path %t/a.d -emit-dependencies-path %t/main.d  -o %t/a.o -o %t/main.o -emit-module-path %t/a.swiftmodule -emit-module-path %t/main.swiftmodule
 // RUN: %FileCheck -check-prefix=CHECK-MAIN %s <%t/main.d
 // RUN: %FileCheck -check-prefix=NEGATIVE-MAIN %s <%t/main.d
 //


### PR DESCRIPTION
Just removes a flag we don't need to be passing.

cc @davidungar and @jrose-apple for observability, but I don't imagine this is contentions.