### PR TITLE
Removed redundant check

### DIFF
--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -208,9 +208,6 @@ struct TestConfig {
     }
 
     if let x = benchArgs.optionalArgsMap["--sleep"] {
-      if x.isEmpty {
-        return .fail("--sleep requires a non-empty integer value")
-      }
       let v: Int? = Int(x)
       if v == nil {
         return .fail("--sleep requires a non-empty integer value")

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -208,11 +208,10 @@ struct TestConfig {
     }
 
     if let x = benchArgs.optionalArgsMap["--sleep"] {
-      let v: Int? = Int(x)
-      if v == nil {
+      guard let v = Int(x) else {
         return .fail("--sleep requires a non-empty integer value")
       }
-      afterRunSleep = v!
+      afterRunSleep = v
     }
 
     if let _ = benchArgs.optionalArgsMap["--list"] {


### PR DESCRIPTION
Because initialising Int with empty string returns nil there is no need for this additional check for empty string. This should simplify this code a bit.