### PR TITLE
[SR-1046] Pass lit path argument to xctest explicitly

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2875,6 +2875,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 XCTEST_BUILD_DIR=$(build_directory ${host} xctest)
                 call "${XCTEST_SOURCE_DIR}"/build_script.py test \
                     --swiftc="${SWIFTC_BIN}" \
+                    --lit="${LLVM_SOURCE_DIR}/utils/lit/lit.py" \
                     --foundation-build-dir="${FOUNDATION_BUILD_DIR}/Foundation" \
                     ${LIBDISPATCH_BUILD_ARGS} \
                     $XCTEST_BUILD_ARGS \


### PR DESCRIPTION
<!-- What's in this pull request? -->
swift-corelibs-xctest uses the LLVM lit test runner to compile test cases and run them. The Swift build script, utils/build-script, does the same. The Swift build script already contains logic to find a lit executable. XCTest should use the same lit executable.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-1046](https://bugs.swift.org/browse/SR-1046).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
