### PR TITLE
test: use %empty-directory more heavily

### DIFF
--- a/test/ClangImporter/MixedSource/can_import_objc_idempotent.swift
+++ b/test/ClangImporter/MixedSource/can_import_objc_idempotent.swift
@@ -9,7 +9,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -import-objc-header %t/mixed-target/header.h -emit-module-path %t/MixedWithHeader.swiftmodule %S/Inputs/mixed-with-header.swift %S/../../Inputs/empty.swift -module-name MixedWithHeader -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -typecheck %s -verify
 
-// RUN: rm -rf %t/mixed-target/
+// RUN: %empty-directory(%t/mixed-target)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -typecheck %s -verify
 
 // REQUIRES: objc_interop

--- a/test/ClangImporter/MixedSource/import-mixed-with-header.swift
+++ b/test/ClangImporter/MixedSource/import-mixed-with-header.swift
@@ -9,7 +9,7 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -import-objc-header %t/mixed-target/header.h -emit-module-path %t/MixedWithHeader.swiftmodule %S/Inputs/mixed-with-header.swift %S/../../Inputs/empty.swift -module-name MixedWithHeader -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -typecheck %s -verify
 
-// RUN: rm -rf %t/mixed-target/
+// RUN: %empty-directory(%t/mixed-target)
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -typecheck %s -verify
 
 // XFAIL: linux

--- a/test/ClangImporter/clang_builtin_pcm.swift
+++ b/test/ClangImporter/clang_builtin_pcm.swift
@@ -1,6 +1,6 @@
 // Note: this test intentionally uses a private module cache.
 //
-// RUN: rm -rf %t/clang-module-cache
+// RUN: %empty-directory(%t/clang-module-cache)
 // RUN: %target-swift-frontend -typecheck -verify -module-cache-path %t/clang-module-cache %s
 // RUN: ls -lR %t/clang-module-cache | %FileCheck %s
 

--- a/test/ClangImporter/no-sdk.swift
+++ b/test/ClangImporter/no-sdk.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -typecheck -sdk "" -I %S/Inputs/custom-modules %s
 
 // Verify that we can still import modules even without an SDK.

--- a/test/ClangImporter/pch-bridging-header-vs-modular-interface-defn.swift
+++ b/test/ClangImporter/pch-bridging-header-vs-modular-interface-defn.swift
@@ -74,7 +74,7 @@
 // well as interfaces.
 //
 
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/Headers/Simple
 // RUN: ln -s %S/Inputs/frameworks/Simple.framework/Headers/Simple.h %t/Headers/Simple/Simple.h
 // RUN: %target-build-swift -emit-module -module-name test -Xfrontend -disable-deserialization-recovery -v -F %S/Inputs/frameworks -Xcc "-I%t/Headers" -module-cache-path %t/clang-module-cache -import-objc-header %S/Inputs/pch-bridging-header-with-non-modular-import.h %S/Inputs/other.swift %s

--- a/test/ClangImporter/private_frameworks.swift
+++ b/test/ClangImporter/private_frameworks.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 
 // FIXME: BEGIN -enable-source-import hackaround

--- a/test/ClangImporter/sdk-protocol-class.swift
+++ b/test/ClangImporter/sdk-protocol-class.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -typecheck %s
 
 // RUN: %target-swift-frontend -typecheck %S/Inputs/sdk-protocol-class/os1.swift

--- a/test/ClangImporter/system-framework-search-path.swift
+++ b/test/ClangImporter/system-framework-search-path.swift
@@ -1,6 +1,6 @@
 // The clang module triggers a warning, make sure that -Fsystem has the effect of importing as system, which will suppress the warning.
 
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/systemframeworks -module-cache-path %t/mcp1 %s 2> %t/stderr-as-user.txt

--- a/test/Compatibility/MixAndMatch/witness_change.swift
+++ b/test/Compatibility/MixAndMatch/witness_change.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t/SomeObjCModule.swiftmodule -module-name SomeObjCModule -I %t -I %S/Inputs -swift-version 3 %S/Inputs/SomeObjCModuleX.swift
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t/SomeSwift3Module.swiftmodule -module-name SomeSwift3Module -I %t -I %S/Inputs -swift-version 3 %s

--- a/test/Compatibility/bridging-nsnumber-and-nsvalue.swift.gyb
+++ b/test/Compatibility/bridging-nsnumber-and-nsvalue.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %gyb %s -o %t/bridging-nsnumber-and-nsvalue.swift
 // RUN: %target-swift-frontend -typecheck -verify %t/bridging-nsnumber-and-nsvalue.swift -swift-version 3

--- a/test/Constraints/bridging-nsnumber-and-nsvalue.swift.gyb
+++ b/test/Constraints/bridging-nsnumber-and-nsvalue.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %gyb %s -o %t/bridging-nsnumber-and-nsvalue.swift
 // RUN: %target-swift-frontend -typecheck -verify %t/bridging-nsnumber-and-nsvalue.swift -swift-version 4

--- a/test/Driver/Dependencies/README.txt
+++ b/test/Driver/Dependencies/README.txt
@@ -8,7 +8,8 @@ a --> b         File 'b' privately depends on file 'a' (normal dependencies casc
 
 Because of the way the tests are set up, the dependency information is put into the .swift files; any such test needs to start by "building" everything to copy that information into .swiftdeps files. To avoid timestamp issues, most of these tests start with:
 
-    // RUN: rm -rf %t && cp -r %S/Inputs/<TEST_GRAPH>/ %t
+    // RUN: %empty-directory(%t)
+    // RUN: cp -r %S/Inputs/<TEST_GRAPH>/ %t
     // RUN: touch -t 201401240005 %t/*
 
 
@@ -21,6 +22,7 @@ In order to correctly run these tests, the "before" information is put into .swi
 
 Most of these tests start with:
 
-    // RUN: rm -rf %t && cp -r %S/Inputs/<TEST_GRAPH>/ %t
+    // RUN: %empty-directory(%t)
+    // RUN: cp -r %S/Inputs/<TEST_GRAPH>/ %t
     // RUN: touch -t 201401240005 %t/*.swift
     // RUN: touch -t 201401240006 %t/*.o

--- a/test/Driver/Dependencies/bindings-build-record-options.swift
+++ b/test/Driver/Dependencies/bindings-build-record-options.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/bindings-build-record/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/bindings-build-record/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -module-name main -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=MUST-EXEC-INITIAL

--- a/test/Driver/Dependencies/bindings-build-record.swift
+++ b/test/Driver/Dependencies/bindings-build-record.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/bindings-build-record/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/bindings-build-record/ %t
 // RUN: %S/Inputs/touch.py 443865900 %t/*
 
 // RUN: cd %t && %swiftc_driver -driver-print-bindings ./main.swift ./other.swift ./yet-another.swift -incremental -output-file-map %t/output.json 2>&1 | %FileCheck %s -check-prefix=MUST-EXEC

--- a/test/Driver/Dependencies/build-record-invalid.swift
+++ b/test/Driver/Dependencies/build-record-invalid.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/bindings-build-record/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/bindings-build-record/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s -check-prefix=CHECK-ALL-BUILT

--- a/test/Driver/Dependencies/chained-additional-kinds.swift
+++ b/test/Driver/Dependencies/chained-additional-kinds.swift
@@ -1,6 +1,7 @@
 // other ==> main ==> yet-another
 
-// RUN: rm -rf %t && cp -r %S/Inputs/chained-additional-kinds/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/chained-additional-kinds/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/chained-after.swift
+++ b/test/Driver/Dependencies/chained-after.swift
@@ -1,7 +1,8 @@
 /// other ==> main | yet-another
 /// other ==> main +==> yet-another
 
-// RUN: rm -rf %t && cp -r %S/Inputs/chained-after/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/chained-after/ %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...

--- a/test/Driver/Dependencies/chained-private-after-multiple-nominal-members.swift
+++ b/test/Driver/Dependencies/chained-private-after-multiple-nominal-members.swift
@@ -1,7 +1,8 @@
 /// other --> main ==> yet-another
 /// other ==>+ main ==> yet-another
 
-// RUN: rm -rf %t && cp -r %S/Inputs/chained-private-after-multiple-nominal-members/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/chained-private-after-multiple-nominal-members/ %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...

--- a/test/Driver/Dependencies/chained-private-after-multiple.swift
+++ b/test/Driver/Dependencies/chained-private-after-multiple.swift
@@ -1,7 +1,8 @@
 /// other --> main ==> yet-another
 /// other ==>+ main ==> yet-another
 
-// RUN: rm -rf %t && cp -r %S/Inputs/chained-private-after-multiple/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/chained-private-after-multiple/ %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...

--- a/test/Driver/Dependencies/chained-private-after.swift
+++ b/test/Driver/Dependencies/chained-private-after.swift
@@ -1,7 +1,8 @@
 /// other --> main ==> yet-another
 /// other ==>+ main ==> yet-another
 
-// RUN: rm -rf %t && cp -r %S/Inputs/chained-private-after/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/chained-private-after/ %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...

--- a/test/Driver/Dependencies/chained-private.swift
+++ b/test/Driver/Dependencies/chained-private.swift
@@ -1,6 +1,7 @@
 /// other --> main ==> yet-another
 
-// RUN: rm -rf %t && cp -r %S/Inputs/chained-private/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/chained-private/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/chained.swift
+++ b/test/Driver/Dependencies/chained.swift
@@ -1,6 +1,7 @@
 // other ==> main ==> yet-another
 
-// RUN: rm -rf %t && cp -r %S/Inputs/chained/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/chained/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift ./yet-another.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/crash-added.swift
+++ b/test/Driver/Dependencies/crash-added.swift
@@ -1,6 +1,7 @@
 /// crash ==> main | crash --> other
 
-// RUN: rm -rf %t && cp -r %S/Inputs/crash-simple/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/crash-simple/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
@@ -21,7 +22,8 @@
 // CHECK-RECORD-ADDED-DAG: "./other.swift": [
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/crash-simple/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/crash-simple/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s

--- a/test/Driver/Dependencies/crash-new.swift
+++ b/test/Driver/Dependencies/crash-new.swift
@@ -1,6 +1,7 @@
 /// crash ==> main | crash --> other
 
-// RUN: rm -rf %t && cp -r %S/Inputs/crash-simple/ %t
+// RUN: %empty-directoy(%t)
+// RUN: cp -r %S/Inputs/crash-simple/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies-bad.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s

--- a/test/Driver/Dependencies/crash-simple.swift
+++ b/test/Driver/Dependencies/crash-simple.swift
@@ -1,6 +1,7 @@
 /// crash ==> main | crash --> other
 
-// RUN: rm -rf %t && cp -r %S/Inputs/crash-simple/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/crash-simple/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./crash.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/dependencies-preservation.swift
+++ b/test/Driver/Dependencies/dependencies-preservation.swift
@@ -1,7 +1,8 @@
 // Verify that the top-level build record file from the last incremental
 // compilation is preserved with the same name, suffixed by a '~'.
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/ %t
 // RUN: %S/Inputs/touch.py 443865900 %t/*
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -c ./main.swift ./other.swift -module-name main -incremental -v -driver-show-incremental -output-file-map %t/output.json

--- a/test/Driver/Dependencies/driver-show-incremental-arguments.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-arguments.swift
@@ -8,7 +8,8 @@
 // is disabled.
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/ %t
 // RUN: %S/Inputs/touch.py 443865900 %t/*
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
 

--- a/test/Driver/Dependencies/driver-show-incremental-conflicting-arguments.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-conflicting-arguments.swift
@@ -8,7 +8,8 @@
 // is disabled. If both are specified, the driver should only print one message.
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/ %t
 // RUN: %S/Inputs/touch.py 443865900 %t/*
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
 

--- a/test/Driver/Dependencies/driver-show-incremental-inputs.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-inputs.swift
@@ -8,7 +8,8 @@
 // is disabled.
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/ %t
 // RUN: %S/Inputs/touch.py 443865900 %t/*
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps
 

--- a/test/Driver/Dependencies/driver-show-incremental-malformed.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-malformed.swift
@@ -7,7 +7,8 @@
 // is disabled.
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/ %t
 // RUN: %S/Inputs/touch.py 443865900 %t/*
 
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps

--- a/test/Driver/Dependencies/driver-show-incremental-mutual.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-mutual.swift
@@ -1,6 +1,7 @@
 /// main <==> other
 
-// RUN: rm -rf %t && cp -r %S/Inputs/mutual/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/mutual/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v -driver-show-incremental 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/driver-show-incremental-swift-version.swift
+++ b/test/Driver/Dependencies/driver-show-incremental-swift-version.swift
@@ -8,7 +8,8 @@
 // is disabled.
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/ %t
 // RUN: %S/Inputs/touch.py 443865900 %t/*
 
 // RUN: echo '{version: "'$(%swiftc_driver_plain -version | head -n1)'", inputs: {"./main.swift": [443865900, 0], "./other.swift": [443865900, 0]}}' > %t/main~buildrecord.swiftdeps

--- a/test/Driver/Dependencies/embed-bitcode-parallel.swift
+++ b/test/Driver/Dependencies/embed-bitcode-parallel.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/fake-build-for-bitcode.py -output-file-map %t/output.json -incremental ./main.swift ./other.swift -embed-bitcode -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/fail-added.swift
+++ b/test/Driver/Dependencies/fail-added.swift
@@ -1,6 +1,7 @@
 /// bad ==> main | bad --> other
 
-// RUN: rm -rf %t && cp -r %S/Inputs/fail-simple/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-simple/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s
@@ -21,7 +22,8 @@
 // CHECK-RECORD-ADDED-DAG: "./other.swift": [
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/fail-simple/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-simple/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s

--- a/test/Driver/Dependencies/fail-chained.swift
+++ b/test/Driver/Dependencies/fail-chained.swift
@@ -1,6 +1,7 @@
 /// a ==> bad ==> c ==> d | b --> bad --> e ==> f
 
-// RUN: rm -rf %t && cp -r %S/Inputs/fail-chained/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-chained/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
@@ -60,7 +61,8 @@
 // NEGATIVE-A2-NOT: Handled f.swift
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/fail-chained/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-chained/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
@@ -101,7 +103,8 @@
 // NEGATIVE-B2-NOT: Handled f.swift
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/fail-chained/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-chained/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift ./f.swift ./bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/fail-interface-hash.swift
+++ b/test/Driver/Dependencies/fail-interface-hash.swift
@@ -1,6 +1,7 @@
 /// main ==> depends-on-main | bad ==> depends-on-bad
 
-// RUN: rm -rf %t && cp -r %S/Inputs/fail-interface-hash/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/fail-interface-hash/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/fail-new.swift
+++ b/test/Driver/Dependencies/fail-new.swift
@@ -1,6 +1,6 @@
 /// bad ==> main | bad --> other
 
-// RUN: rm -rf %t && cp -r %S/Inputs/fail-simple/ %t
+// RUN: %empty-directory(%t) && cp -r %S/Inputs/fail-simple/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies-bad.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s

--- a/test/Driver/Dependencies/fail-simple.swift
+++ b/test/Driver/Dependencies/fail-simple.swift
@@ -1,6 +1,6 @@
 /// bad ==> main | bad --> other
 
-// RUN: rm -rf %t && cp -r %S/Inputs/fail-simple/ %t
+// RUN: %empty-directory(%t) && cp -r %S/Inputs/fail-simple/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./bad.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/fail-with-bad-deps.swift
+++ b/test/Driver/Dependencies/fail-with-bad-deps.swift
@@ -1,6 +1,6 @@
 /// main ==> depends-on-main | bad ==> depends-on-bad
 
-// RUN: rm -rf %t && cp -r %S/Inputs/fail-with-bad-deps/ %t
+// RUN: %empty-directory(%t) && cp -r %S/Inputs/fail-with-bad-deps/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental ./main.swift ./bad.swift ./depends-on-main.swift ./depends-on-bad.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/file-added.swift
+++ b/test/Driver/Dependencies/file-added.swift
@@ -1,6 +1,6 @@
 /// other ==> main
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t) && cp -r %S/Inputs/one-way/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/independent-half-dirty.swift
+++ b/test/Driver/Dependencies/independent-half-dirty.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/independent/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/independent/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/independent-parseable.swift
+++ b/test/Driver/Dependencies/independent-parseable.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/independent/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/independent/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
@@ -28,7 +29,8 @@
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/independent/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/independent/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s

--- a/test/Driver/Dependencies/independent.swift
+++ b/test/Driver/Dependencies/independent.swift
@@ -1,6 +1,7 @@
 // main | other
 
-// RUN: rm -rf %t && cp -r %S/Inputs/independent/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/independent/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
@@ -20,7 +21,8 @@
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/independent/ %t
+// RUN: %empty-directory(%t)
+// cp -r %S/Inputs/independent/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
@@ -34,7 +36,8 @@
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST-MULTI %s
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/independent/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/independent/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SINGLE %s

--- a/test/Driver/Dependencies/malformed-but-valid-yaml.swift
+++ b/test/Driver/Dependencies/malformed-but-valid-yaml.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/malformed-but-valid-yaml/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/malformed-but-valid-yaml/ %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
@@ -24,7 +25,8 @@
 // CHECK-THIRD: Handled main.swift
 // CHECK-THIRD: Handled other.swift
 
-// RUN: rm -rf %t && cp -r %S/Inputs/malformed-but-valid-yaml/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/malformed-but-valid-yaml/ %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...

--- a/test/Driver/Dependencies/malformed.swift
+++ b/test/Driver/Dependencies/malformed.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/malformed-after/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/malformed-after/ %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
@@ -24,7 +25,8 @@
 // CHECK-THIRD: Handled main.swift
 // CHECK-THIRD: Handled other.swift
 
-// RUN: rm -rf %t && cp -r %S/Inputs/malformed-after/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/malformed-after/ %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...

--- a/test/Driver/Dependencies/mutual-interface-hash.swift
+++ b/test/Driver/Dependencies/mutual-interface-hash.swift
@@ -1,6 +1,7 @@
 /// does-change <==> does-not-change
 
-// RUN: rm -rf %t && cp -r %S/Inputs/mutual-interface-hash/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/mutual-interface-hash/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // Generate the build record...

--- a/test/Driver/Dependencies/mutual.swift
+++ b/test/Driver/Dependencies/mutual.swift
@@ -1,6 +1,7 @@
 /// main <==> other
 
-// RUN: rm -rf %t && cp -r %S/Inputs/mutual/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/mutual/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/nominal-members.swift
+++ b/test/Driver/Dependencies/nominal-members.swift
@@ -1,6 +1,7 @@
 /// a ==> depends-on-a-ext, depends-on-a-foo | a-ext ==> depends-on-a-ext
 
-// RUN: rm -rf %t && cp -r %S/Inputs/nominal-members/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/nominal-members/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./a-ext.swift ./depends-on-a-foo.swift ./depends-on-a-ext.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s

--- a/test/Driver/Dependencies/one-way-depends-after.swift
+++ b/test/Driver/Dependencies/one-way-depends-after.swift
@@ -1,7 +1,8 @@
 /// other | main
 /// other ==>+ main
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way-depends-after/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-depends-after/ %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
@@ -26,7 +27,8 @@
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way-depends-after/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-depends-after/ %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...

--- a/test/Driver/Dependencies/one-way-depends-before.swift
+++ b/test/Driver/Dependencies/one-way-depends-before.swift
@@ -1,7 +1,8 @@
 /// other ==>+ main
 /// other | main
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way-depends-before/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-depends-before/ %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
@@ -29,7 +30,8 @@
 // CHECK-THIRD-NOT: Handled main.swift
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way-depends-before/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-depends-before/ %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...

--- a/test/Driver/Dependencies/one-way-external-delete.swift
+++ b/test/Driver/Dependencies/one-way-external-delete.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way-external/ %t
+// RUN: %empty-directory(%t) && cp -r %S/Inputs/one-way-external/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
@@ -22,7 +22,8 @@
 // CHECK-THIRD-DAG: Handled main.swift
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way-external/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-external/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/one-way-external.swift
+++ b/test/Driver/Dependencies/one-way-external.swift
@@ -4,7 +4,8 @@
 /// "./other1-external" ==> other
 /// "./other2-external" ==> other
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way-external/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-external/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/one-way-merge-module.swift
+++ b/test/Driver/Dependencies/one-way-merge-module.swift
@@ -1,6 +1,7 @@
 /// other ==> main
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -emit-module-path %t/master.swiftmodule -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/one-way-parallel.swift
+++ b/test/Driver/Dependencies/one-way-parallel.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/one-way-parseable.swift
+++ b/test/Driver/Dependencies/one-way-parseable.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -parseable-output 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/Dependencies/one-way-provides-after.swift
+++ b/test/Driver/Dependencies/one-way-provides-after.swift
@@ -1,7 +1,8 @@
 /// other | main
 /// other +==> main
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way-provides-after/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-provides-after/ %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
@@ -24,7 +25,8 @@
 // RUN: touch -t 201401240007 %t/other.swift
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-SECOND %s
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way-provides-after/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-provides-after/ %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...

--- a/test/Driver/Dependencies/one-way-provides-before.swift
+++ b/test/Driver/Dependencies/one-way-provides-before.swift
@@ -1,7 +1,8 @@
 /// other +==> main
 /// other | main
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way-provides-before/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-provides-before/ %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
@@ -28,7 +29,8 @@
 // CHECK-THIRD: Handled other.swift
 // CHECK-THIRD-NOT: Handled main.swift
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way-provides-before/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way-provides-before/ %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...

--- a/test/Driver/Dependencies/one-way-while-editing.swift
+++ b/test/Driver/Dependencies/one-way-while-editing.swift
@@ -1,6 +1,7 @@
 /// other ==> main
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && not %swiftc_driver -c -driver-use-frontend-path %S/Inputs/modify-non-primary-files.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck %s

--- a/test/Driver/Dependencies/one-way.swift
+++ b/test/Driver/Dependencies/one-way.swift
@@ -1,6 +1,7 @@
 /// other ==> main
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
@@ -37,7 +38,8 @@
 // CHECK-FIFTH-NOT: Handled main.swift
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/ %t
 // RUN: touch -t 201401240005 %t/*
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s
 
@@ -49,7 +51,8 @@
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FOURTH %s
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./other.swift ./main.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-REV-FIRST %s

--- a/test/Driver/Dependencies/only-skip-once.swift
+++ b/test/Driver/Dependencies/only-skip-once.swift
@@ -1,5 +1,6 @@
 // XFAIL: linux
-// RUN: rm -rf %t && cp -r %S/Inputs/only-skip-once/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/only-skip-once/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %target-swiftc_driver -driver-show-job-lifecycle -output-file-map %t/output-file-map.json -incremental main.swift file1.swift file2.swift -j1 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s

--- a/test/Driver/Dependencies/private-after.swift
+++ b/test/Driver/Dependencies/private-after.swift
@@ -1,7 +1,8 @@
 /// a --> b ==> c | a ==> d |    e ==> b |       f ==> g
 /// a --> b ==> c | a ==> d +==> e +==> b, e --> f ==> g
 
-// RUN: rm -rf %t && cp -r %S/Inputs/private-after/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/private-after/ %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...
@@ -29,7 +30,8 @@
 // CHECK-A-NEG-NOT: Handled g.swift
 
 
-// RUN: rm -rf %t && cp -r %S/Inputs/private-after/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/private-after/ %t
 // RUN: touch -t 201401240005 %t/*.swift
 
 // Generate the build record...

--- a/test/Driver/Dependencies/private.swift
+++ b/test/Driver/Dependencies/private.swift
@@ -1,6 +1,7 @@
 // a ==> b --> c ==> d | e ==> c
 
-// RUN: rm -rf %t && cp -r %S/Inputs/private/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/private/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/update-dependencies.py -output-file-map %t/output.json -incremental -driver-always-rebuild-dependents ./a.swift ./b.swift ./c.swift ./d.swift ./e.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-INITIAL %s

--- a/test/Driver/Dependencies/whole-module-build-record.swift
+++ b/test/Driver/Dependencies/whole-module-build-record.swift
@@ -1,6 +1,7 @@
 /// other ==> main
 
-// RUN: rm -rf %t && cp -r %S/Inputs/one-way/ %t
+// RUN: %empty-directory(%t)
+// RUN: cp -r %S/Inputs/one-way/ %t
 // RUN: touch -t 201401240005 %t/*
 
 // RUN: cd %t && %swiftc_driver -c -driver-use-frontend-path %S/Inputs/fake-build-whole-module.py -output-file-map %t/output.json -whole-module-optimization ./main.swift ./other.swift -module-name main -j1 -v 2>&1 | %FileCheck -check-prefix=CHECK-FIRST %s

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -313,7 +313,7 @@
 // Test ld detection. We use hard links to make sure
 // the Swift driver really thinks it's been moved.
 
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: %empty-directory(%t/DISTINCTIVE-PATH/usr/bin)
 // RUN: touch %t/DISTINCTIVE-PATH/usr/bin/ld
 // RUN: chmod +x %t/DISTINCTIVE-PATH/usr/bin/ld

--- a/test/Driver/options-repl.swift
+++ b/test/Driver/options-repl.swift
@@ -5,7 +5,7 @@
 
 // REPL_NO_FILES: REPL mode requires no input files
 
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/usr/bin
 // RUN: %hardlink-or-copy(from: %swift_driver_plain, to: %t/usr/bin/swift)
 

--- a/test/Driver/subcommands.swift
+++ b/test/Driver/subcommands.swift
@@ -2,7 +2,7 @@
 //
 // REQUIRES: swift_interpreter
 //
-// RUN: rm -rf %t.dir
+// RUN: %empty-directory(%t.dir)
 // RUN: mkdir -p %t.dir/usr/bin
 // RUN: %hardlink-or-copy(from: %swift_driver_plain, to: %t.dir/usr/bin/swift)
 

--- a/test/Frontend/sil-merge-partial-modules.swift
+++ b/test/Frontend/sil-merge-partial-modules.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 
 // RUN: %target-swift-frontend -emit-module -primary-file %s %S/Inputs/sil-merge-partial-modules-other.swift -module-name test -enable-resilience -o %t/partial.a.swiftmodule

--- a/test/IRGen/autolink-coff-x86.swift
+++ b/test/IRGen/autolink-coff-x86.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 
 // RUN: %swift -target x86_64--windows-gnu -parse-as-library -parse-stdlib -emit-module-path %t/module.swiftmodule -module-name module -module-link-name module %s

--- a/test/IRGen/cf.sil
+++ b/test/IRGen/cf.sil
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %utils/chex.py < %s > %t/cf.sil
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs %t/cf.sil -emit-ir -import-cf-types | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize %t/cf.sil
 

--- a/test/IRGen/generic_classes.sil
+++ b/test/IRGen/generic_classes.sil
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %utils/chex.py < %s > %t/generic_classes.sil
 // RUN: %target-swift-frontend %t/generic_classes.sil -emit-ir | %FileCheck %t/generic_classes.sil --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
 // RUN: %target-swift-frontend -Osize %t/generic_classes.sil -emit-ir | %FileCheck %t/generic_classes.sil --check-prefix=OSIZE

--- a/test/IRGen/generic_structs.sil
+++ b/test/IRGen/generic_structs.sil
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %utils/chex.py < %s > %t/generic_structs.sil
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %t/generic_structs.sil -emit-ir | %FileCheck %t/generic_structs.sil
 

--- a/test/IRGen/generic_vtable.swift
+++ b/test/IRGen/generic_vtable.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %utils/chex.py < %s > %t/generic_vtable.swift
 // RUN: %target-swift-frontend %t/generic_vtable.swift -emit-ir | %FileCheck %t/generic_vtable.swift --check-prefix=CHECK
 

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // -- Convert <i32 0x...> constants to decimal constants that LLVM will print
 // RUN: %utils/chex.py < %s > %t/keypaths.sil
 // RUN: %target-swift-frontend -emit-ir %s | %FileCheck %t/keypaths.sil --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-os

--- a/test/IRGen/keypaths_objc.sil
+++ b/test/IRGen/keypaths_objc.sil
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %utils/chex.py < %s > %t/keypaths_objc.sil
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir %t/keypaths_objc.sil | %FileCheck %t/keypaths_objc.sil --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 // REQUIRES: objc_interop

--- a/test/IRGen/mixed_mode_class_with_unimportable_fields.sil
+++ b/test/IRGen/mixed_mode_class_with_unimportable_fields.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-swift-frontend -emit-module -o %t/UsingObjCStuff.swiftmodule -module-name UsingObjCStuff -I %t -I %S/Inputs/mixed_mode -swift-version 4 %S/Inputs/mixed_mode/UsingObjCStuff.swift
 // RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 3 %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize

--- a/test/IRGen/mixed_mode_class_with_unimportable_fields.swift
+++ b/test/IRGen/mixed_mode_class_with_unimportable_fields.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-swift-frontend -emit-module -o %t/UsingObjCStuff.swiftmodule -module-name UsingObjCStuff -I %t -I %S/Inputs/mixed_mode -swift-version 4 %S/Inputs/mixed_mode/UsingObjCStuff.swift
 // RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/mixed_mode -module-name main -swift-version 3 %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-V3

--- a/test/IRGen/objc_types_as_member.sil
+++ b/test/IRGen/objc_types_as_member.sil
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %build-irgen-test-overlays
 // RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t) %s -emit-ir | %FileCheck %s
 

--- a/test/IRGen/playground.swift
+++ b/test/IRGen/playground.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -use-jit -playground -parse-stdlib %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s
 
 // REQUIRES: OS=macosx

--- a/test/IRGen/two_tag_enums.swift.gyb
+++ b/test/IRGen/two_tag_enums.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %gyb %s > %t/main.swift
 // RUN: %target-swift-frontend -emit-ir %t/main.swift | %FileCheck %s

--- a/test/Index/Store/output-failure.swift
+++ b/test/Index/Store/output-failure.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t
 // RUN: mkdir %t/idx
 
 // Before indexing, do a dry-run to ensure any clang modules are cached. We

--- a/test/Index/Store/record-comments.swift
+++ b/test/Index/Store/record-comments.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -index-store-path %t/idx -o %t.o -typecheck %s
 // RUN: c-index-test core -print-record %t/idx | %FileCheck %s
 

--- a/test/Index/Store/record-dependency.swift
+++ b/test/Index/Store/record-dependency.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -index-store-path %t/idx -o %t/file.o -typecheck %s
 // RUN: c-index-test core -print-unit %t/idx | %FileCheck %s
 // CHECK: DEPEND START

--- a/test/Index/Store/record-empty.swift
+++ b/test/Index/Store/record-empty.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -index-store-path %t/idx -o %t/file.o -typecheck -primary-file %s
 // RUN: %target-swift-frontend -index-store-path %t/idx -o %t/file.o -typecheck %s
 // RUN: c-index-test core -print-unit %t/idx | %FileCheck %s

--- a/test/Index/Store/record-hashing.swift
+++ b/test/Index/Store/record-hashing.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t
 // RUN: echo "func foo() {}" > %t/theinput.swift
 
 // RUN: %target-swift-frontend -index-store-path %t/idx -typecheck %t/theinput.swift -o %t/s.o

--- a/test/Index/Store/record-sourcefile.swift
+++ b/test/Index/Store/record-sourcefile.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -index-store-path %t/idx1 -o %t/file.o -typecheck %s
 // RUN: %target-swift-frontend -index-store-path %t/idx2 -o %t/file.o -typecheck -primary-file %s
 // RUN: c-index-test core -print-record %t/idx1 | %FileCheck %s

--- a/test/Index/Store/record-with-compile-error.swift
+++ b/test/Index/Store/record-with-compile-error.swift
@@ -1,6 +1,6 @@
 // XFAIL: linux
 
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir %t
 // RUN: %target-swift-frontend -index-store-path %t/idx -o %t/file.o -typecheck %s -verify
 // RUN: c-index-test core -print-record %t/idx | %FileCheck %s

--- a/test/Index/Store/unit-from-compile.swift
+++ b/test/Index/Store/unit-from-compile.swift
@@ -1,6 +1,6 @@
 // XFAIL: linux
 
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir %t
 // RUN: %target-swift-frontend -c -index-store-path %t/idx %s -o %t/file1.o -module-name some_module_test
 // RUN: c-index-test core -print-unit %t/idx | %FileCheck %s

--- a/test/Index/Store/unit-multiple-sourcefiles.swift
+++ b/test/Index/Store/unit-multiple-sourcefiles.swift
@@ -2,7 +2,8 @@
 
 //===--- Building source files separately with a module merge at the end
 
-// RUN: rm -rf %t && mkdir %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t
 // RUN: touch %t/s1.swift %t/s2.swift
 // RUN: %target-swift-frontend -index-store-path %t/idx -primary-file %t/s1.swift %t/s2.swift -o %t/s1.o -c -module-name main -emit-module -emit-module-path %t/s1.swiftmodule
 // RUN: %target-swift-frontend -index-store-path %t/idx %t/s1.swift -primary-file %t/s2.swift -o %t/s2.o -c -module-name main -emit-module -emit-module-path %t/s2.swiftmodule
@@ -11,7 +12,8 @@
 
 //===--- Building source files together (e.g. WMO)
 
-// RUN: rm -rf %t && mkdir %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t
 // RUN: touch %t/s1.swift %t/s2.swift
 // RUN: %target-swift-frontend -index-store-path %t/idx %t/s1.swift %t/s2.swift -o %t/s1.o -o %t/s2.o -c -module-name main -emit-module -emit-module-path %t/main.swiftmodule
 // RUN: c-index-test core -print-unit %t/idx | %FileCheck %s

--- a/test/Index/Store/unit-one-file-multi-file-invocation.swift
+++ b/test/Index/Store/unit-one-file-multi-file-invocation.swift
@@ -1,6 +1,6 @@
 // XFAIL: linux
 
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: %target-build-swift -index-file -index-file-path %s %s %S/Inputs/SwiftModuleA.swift -module-name unit_one_test -o %t.output_for_index -index-store-path %t/idx
 // RUN: c-index-test core -print-unit %t/idx | %FileCheck %s -check-prefix=UNIT
 

--- a/test/Index/Store/unit-one-sourcefile.swift
+++ b/test/Index/Store/unit-one-sourcefile.swift
@@ -1,15 +1,17 @@
 // XFAIL: linux
 
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -index-store-path %t/idx %s -o %t/file1.o -typecheck
 // RUN: c-index-test core -print-unit %t/idx | %FileCheck %s -check-prefix=FILE1
 
-// RUN: rm -rf %t && mkdir %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t
 // RUN: touch %t/s2.swift
 // RUN: %target-swift-frontend -index-store-path %t/idx -primary-file %s %t/s2.swift -o %t/file1.o -typecheck
 // RUN: c-index-test core -print-unit %t/idx | %FileCheck %s -check-prefix=FILE1
 
-// RUN: rm -rf %t && mkdir %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t
 // RUN: touch %t/s2.swift
 // RUN: %target-swift-frontend -index-store-path %t/idx %s -primary-file %t/s2.swift -o %t/file2.o -typecheck
 // RUN: c-index-test core -print-unit %t/idx | %FileCheck %s -check-prefix=FILE2

--- a/test/Index/Store/unit-pcm-dependency.swift
+++ b/test/Index/Store/unit-pcm-dependency.swift
@@ -1,15 +1,16 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -index-store-path %t/idx -primary-file %s -o %t/s1.o -I %S/Inputs -typecheck -module-cache-path %t/mcp
 // RUN: c-index-test core -print-unit %t/idx | %FileCheck %s -check-prefix=FILE1
 
 // If the module cache already exists, the pcm gets indexed.
-// RUN: rm -rf %t/idx
+// RUN: %empty-directory(%t/idx)
 // RUN: %target-swift-frontend -index-store-path %t/idx -primary-file %s -o %t/s1.o -I %S/Inputs -typecheck -module-cache-path %t/mcp
 // RUN: c-index-test core -print-unit %t/idx | %FileCheck %s -check-prefix=FILE1
 
 // FIXME: index the bridging header!
 
-// RUN: rm -rf %t && mkdir %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t
 // RUN: echo 'import ClangModuleA' > %t/s2.swift
 // RUN: %target-swift-frontend -index-store-path %t/idx %s %t/s2.swift -o %t/s1.o -o %t/s2.o -I %S/Inputs -c -emit-module -module-name main -emit-module-path %t/main.swiftmodule -module-cache-path %t/mcp
 // RUN: c-index-test core -print-unit %t/idx > %t/both.txt

--- a/test/Index/Store/unit-swiftmodule-dependency.swift
+++ b/test/Index/Store/unit-swiftmodule-dependency.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t
 
 // RUN: %target-swift-frontend -index-store-path %t/idx %S/Inputs/SwiftModuleA.swift -emit-module -o %t/SwiftModuleA.swiftmodule
 // RUN: %target-swift-frontend -index-store-path %t/idx %S/Inputs/SwiftModuleB.swift -emit-module -o %t/SwiftModuleB.swiftmodule -I %t

--- a/test/Index/Store/unit-with-bridging-header.swift
+++ b/test/Index/Store/unit-with-bridging-header.swift
@@ -1,6 +1,6 @@
 // XFAIL: linux
 
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir %t
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-pch -index-store-path %t/idx -o %t/bridge-head.pch %S/Inputs/bridge-head.h
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -import-objc-header %t/bridge-head.pch -primary-file %s -o %t/s1.o -index-store-path %t/idx

--- a/test/Index/index_module.swift
+++ b/test/Index/index_module.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 //
 // RUN: %target-swift-frontend -emit-module -o %t %s

--- a/test/Index/index_system_module.swift
+++ b/test/Index/index_system_module.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 //
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/my_system_overlay/my_system_overlay.swift -Xcc -I -Xcc %S/Inputs/my_system_overlay

--- a/test/Index/roles.swift
+++ b/test/Index/roles.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 //
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/imported_swift_module.swift

--- a/test/Interpreter/SDK/mixed_mode_class_with_missing_properties.swift
+++ b/test/Interpreter/SDK/mixed_mode_class_with_missing_properties.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -whole-module-optimization -emit-module-path %t/UsingObjCStuff.swiftmodule -c -o %t/UsingObjCStuff.o -module-name UsingObjCStuff -I %t -I %S/Inputs/mixed_mode -swift-version 4 -parse-as-library %S/Inputs/mixed_mode/UsingObjCStuff.swift

--- a/test/Interpreter/SDK/objc_swift3_deprecated_objc_inference.swift
+++ b/test/Interpreter/SDK/objc_swift3_deprecated_objc_inference.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %target-build-swift -swift-version 4 -Xfrontend -enable-swift3-objc-inference %s -o %t/a.out
 // RUN: %target-run %t/a.out 2>&1 | %FileCheck %s -check-prefix=CHECK_WARNINGS
 // RUN: env SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=0 SIMCTL_CHILD_SWIFT_DEBUG_IMPLICIT_OBJC_ENTRYPOINT=0 %target-run %t/a.out 2>&1 | %FileCheck %s -check-prefix=CHECK_NOTHING

--- a/test/Interpreter/conditional_conformances_runtime.swift
+++ b/test/Interpreter/conditional_conformances_runtime.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %target-build-swift %s -o %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test

--- a/test/Interpreter/enforce_exclusive_access.swift
+++ b/test/Interpreter/enforce_exclusive_access.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-build-swift -swift-version 4 %s -o %t/a.out -enforce-exclusivity=checked -Onone
 //

--- a/test/Interpreter/enforce_exclusive_access_backtrace.swift
+++ b/test/Interpreter/enforce_exclusive_access_backtrace.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-build-swift -swift-version 3 %s -o %t/a.out -enforce-exclusivity=checked -Onone
 //

--- a/test/Interpreter/objc_types_as_members.swift
+++ b/test/Interpreter/objc_types_as_members.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 //
 // RUN: %target-clang -fobjc-arc %S/Inputs/ObjCClasses/ObjCClasses.m -c -o %t/ObjCClasses.o

--- a/test/Interpreter/protocol_initializers.swift
+++ b/test/Interpreter/protocol_initializers.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-build-swift -swift-version 5 %s -o %t/a.out
 //

--- a/test/Interpreter/protocol_initializers_class.swift
+++ b/test/Interpreter/protocol_initializers_class.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-build-swift -swift-version 5 %s -o %t/a.out
 //

--- a/test/Interpreter/subclass_existentials.swift
+++ b/test/Interpreter/subclass_existentials.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-build-swift %s -o %t/a.out
 // RUN: %target-run %t/a.out

--- a/test/Interpreter/subclass_existentials_objc.swift
+++ b/test/Interpreter/subclass_existentials_objc.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-build-swift %s -o %t/a.out
 // RUN: %target-run %t/a.out

--- a/test/Migrator/always_remove_old_remap_file.swift
+++ b/test/Migrator/always_remove_old_remap_file.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t && cp %s %t/input.swift
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t && cp %s %t/input.swift
 // RUN: %target-swift-frontend -c -update-code -primary-file %t/input.swift -emit-migrated-file-path %t/always_remove_old_remap_file.result -emit-remap-file-path %t/always_remove_old_remap_file.remap -o /dev/null
 // RUN: ls %t/always_remove_old_remap_file.remap
 

--- a/test/Migrator/double_fixit_ok.swift
+++ b/test/Migrator/double_fixit_ok.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -typecheck %s -swift-version 3
-// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -typecheck -update-code -primary-file %s -emit-migrated-file-path %t/double_fixit_ok.result -swift-version 3
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t && %target-swift-frontend -typecheck -update-code -primary-file %s -emit-migrated-file-path %t/double_fixit_ok.result -swift-version 3
 // RUN: diff -u %s.expected %t/double_fixit_ok.result
 // RUN: %target-swift-frontend -typecheck %s.expected -swift-version 4
 

--- a/test/Migrator/double_fixit_ok.swift.expected
+++ b/test/Migrator/double_fixit_ok.swift.expected
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -typecheck %s -swift-version 3
-// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -typecheck -update-code -primary-file %s -emit-migrated-file-path %t/double_fixit_ok.result -swift-version 3
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t && %target-swift-frontend -typecheck -update-code -primary-file %s -emit-migrated-file-path %t/double_fixit_ok.result -swift-version 3
 // RUN: diff -u %s.expected %t/double_fixit_ok.result
 // RUN: %target-swift-frontend -typecheck %s.expected -swift-version 4
 

--- a/test/Migrator/no_double_edit_ast_pass.swift
+++ b/test/Migrator/no_double_edit_ast_pass.swift
@@ -1,7 +1,8 @@
 // REQUIRES: OS=macosx
 // REQUIRES: objc_interop
 // RUN: %target-swift-frontend -typecheck %s -F %S/mock-sdk -swift-version 3
-// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -F %S/mock-sdk -api-diff-data-file %S/DoubleEditAPI.json -update-code -primary-file %s -emit-migrated-file-path %t/no_double_edit_ast_pass.result -swift-version 3 -o /dev/null
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t && %target-swift-frontend -c -F %S/mock-sdk -api-diff-data-file %S/DoubleEditAPI.json -update-code -primary-file %s -emit-migrated-file-path %t/no_double_edit_ast_pass.result -swift-version 3 -o /dev/null
 // RUN: diff -u %s.expected %t/no_double_edit_ast_pass.result
 
 import Bar

--- a/test/Migrator/no_double_edit_ast_pass.swift.expected
+++ b/test/Migrator/no_double_edit_ast_pass.swift.expected
@@ -1,7 +1,8 @@
 // REQUIRES: OS=macosx
 // REQUIRES: objc_interop
 // RUN: %target-swift-frontend -typecheck %s -F %S/mock-sdk -swift-version 3
-// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -F %S/mock-sdk -api-diff-data-file %S/DoubleEditAPI.json -update-code -primary-file %s -emit-migrated-file-path %t/no_double_edit_ast_pass.result -swift-version 3 -o /dev/null
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t && %target-swift-frontend -c -F %S/mock-sdk -api-diff-data-file %S/DoubleEditAPI.json -update-code -primary-file %s -emit-migrated-file-path %t/no_double_edit_ast_pass.result -swift-version 3 -o /dev/null
 // RUN: diff -u %s.expected %t/no_double_edit_ast_pass.result
 
 import Bar

--- a/test/Migrator/no_duplicate_aarch64_use_tbi.swift
+++ b/test/Migrator/no_duplicate_aarch64_use_tbi.swift
@@ -1,7 +1,8 @@
 // REQUIRES: OS=ios
 // REQUIRES: CPU=arm64
 // RUN: %target-swift-frontend -typecheck %s -swift-version 3
-// RUN: rm -rf %t && mkdir -p %t && cd %t && %swiftc_driver -c -update-code -target arm64-apple-ios10.3 -output-file-map %S/Inputs/no_duplicate_aarch64_use_tbi_ofm.json -swift-version 3 %s -v
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t && cd %t && %swiftc_driver -c -update-code -target arm64-apple-ios10.3 -output-file-map %S/Inputs/no_duplicate_aarch64_use_tbi_ofm.json -swift-version 3 %s -v
 // RUN: cd %t && %swiftc_driver -c -update-code -target arm64-apple-ios10.3 -output-file-map %S/Inputs/no_duplicate_aarch64_use_tbi_ofm.json -swift-version 3 %s -### > %t/driver_actions.txt
 // RUN: %FileCheck --check-prefix=CHECK-REMAP %s < %t/no_duplicate_aarch64_use_tbi.remap
 // RUN: %FileCheck --check-prefix=CHECK-ACTIONS %s < %t/driver_actions.txt

--- a/test/Migrator/nsopengl_openglversion.swift
+++ b/test/Migrator/nsopengl_openglversion.swift
@@ -1,7 +1,8 @@
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
 // RUN: %target-swift-frontend -typecheck -swift-version 3 %s
-// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -update-code -disable-migrator-fixits -primary-file %s -emit-migrated-file-path %t/nsopengl_openglversion.swift.result -o /dev/null
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t && %target-swift-frontend -c -update-code -disable-migrator-fixits -primary-file %s -emit-migrated-file-path %t/nsopengl_openglversion.swift.result -o /dev/null
 // RUN: diff -u %S/nsopengl_openglversion.swift.expected %t/nsopengl_openglversion.swift.result
 // RUN: %target-swift-frontend -typecheck -swift-version 4 %t/nsopengl_openglversion.swift.result
 

--- a/test/Migrator/nsopengl_openglversion.swift.expected
+++ b/test/Migrator/nsopengl_openglversion.swift.expected
@@ -1,7 +1,8 @@
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
 // RUN: %target-swift-frontend -typecheck -swift-version 3 %s
-// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -update-code -disable-migrator-fixits -primary-file %s -emit-migrated-file-path %t/nsopengl_openglversion.swift.result -o /dev/null
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t && %target-swift-frontend -c -update-code -disable-migrator-fixits -primary-file %s -emit-migrated-file-path %t/nsopengl_openglversion.swift.result -o /dev/null
 // RUN: diff -u %S/nsopengl_openglversion.swift.expected %t/nsopengl_openglversion.swift.result
 // RUN: %target-swift-frontend -typecheck -swift-version 4 %t/nsopengl_openglversion.swift.result
 

--- a/test/Migrator/rdar31892850.swift
+++ b/test/Migrator/rdar31892850.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -typecheck -primary-file %s -module-cache-path %t/mcp -emit-remap-file-path %t/edits.remap
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t && %target-swift-frontend -typecheck -primary-file %s -module-cache-path %t/mcp -emit-remap-file-path %t/edits.remap
 // RUN: %FileCheck %s -input-file=%t/edits.remap
 
 enum SomeStringEnum : String {

--- a/test/Migrator/static-abs-swift-abs-float80.swift
+++ b/test/Migrator/static-abs-swift-abs-float80.swift
@@ -1,7 +1,8 @@
 // REQUIRES: objc_interop
 // REQUIRES: CPU=x86_64
 // RUN: %target-swift-frontend -typecheck -swift-version 3 %s
-// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/static-abs-swift-abs-float80.swift.result -emit-remap-file-path %t/static-abs-swift-abs-float80.swift.remap -o /dev/null
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/static-abs-swift-abs-float80.swift.result -emit-remap-file-path %t/static-abs-swift-abs-float80.swift.remap -o /dev/null
 // RUN: diff -u %S/static-abs-swift-abs-float80.swift.expected %t/static-abs-swift-abs-float80.swift.result
 // RUN: %target-swift-frontend -typecheck -swift-version 4 %t/static-abs-swift-abs-float80.swift.result
 

--- a/test/Migrator/static-abs-swift-abs-float80.swift.expected
+++ b/test/Migrator/static-abs-swift-abs-float80.swift.expected
@@ -1,7 +1,8 @@
 // REQUIRES: objc_interop
 // REQUIRES: CPU=x86_64
 // RUN: %target-swift-frontend -typecheck -swift-version 3 %s
-// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/static-abs-swift-abs-float80.swift.result -emit-remap-file-path %t/static-abs-swift-abs-float80.swift.remap -o /dev/null
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/static-abs-swift-abs-float80.swift.result -emit-remap-file-path %t/static-abs-swift-abs-float80.swift.remap -o /dev/null
 // RUN: diff -u %S/static-abs-swift-abs-float80.swift.expected %t/static-abs-swift-abs-float80.swift.result
 // RUN: %target-swift-frontend -typecheck -swift-version 4 %t/static-abs-swift-abs-float80.swift.result
 

--- a/test/Migrator/static-abs-swift-abs.swift
+++ b/test/Migrator/static-abs-swift-abs.swift
@@ -1,6 +1,7 @@
 // REQUIRES: objc_interop
 // RUN: %target-swift-frontend -typecheck -swift-version 3 %s
-// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/static-abs-swift-abs.swift.result -emit-remap-file-path %t/static-abs-swift-abs.swift.remap -o /dev/null
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/static-abs-swift-abs.swift.result -emit-remap-file-path %t/static-abs-swift-abs.swift.remap -o /dev/null
 // RUN: diff -u %S/static-abs-swift-abs.swift.expected %t/static-abs-swift-abs.swift.result
 // RUN: %target-swift-frontend -typecheck -swift-version 4 %t/static-abs-swift-abs.swift.result
 

--- a/test/Migrator/static-abs-swift-abs.swift.expected
+++ b/test/Migrator/static-abs-swift-abs.swift.expected
@@ -1,6 +1,7 @@
 // REQUIRES: objc_interop
 // RUN: %target-swift-frontend -typecheck -swift-version 3 %s
-// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/static-abs-swift-abs.swift.result -emit-remap-file-path %t/static-abs-swift-abs.swift.remap -o /dev/null
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/static-abs-swift-abs.swift.result -emit-remap-file-path %t/static-abs-swift-abs.swift.remap -o /dev/null
 // RUN: diff -u %S/static-abs-swift-abs.swift.expected %t/static-abs-swift-abs.swift.result
 // RUN: %target-swift-frontend -typecheck -swift-version 4 %t/static-abs-swift-abs.swift.result
 

--- a/test/Migrator/to_int_max.swift
+++ b/test/Migrator/to_int_max.swift
@@ -1,6 +1,7 @@
 // REQUIRES: objc_interop
 // RUN: %target-swift-frontend -typecheck -swift-version 3 %s
-// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/to_int_max.result -emit-remap-file-path %t/to_int_max.remap -o /dev/null
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/to_int_max.result -emit-remap-file-path %t/to_int_max.remap -o /dev/null
 // RUN: diff -u %S/to_int_max.swift.expected %t/to_int_max.result
 // RUN: %target-swift-frontend -typecheck -swift-version 4 %t/to_int_max.result
 

--- a/test/Migrator/to_int_max.swift.expected
+++ b/test/Migrator/to_int_max.swift.expected
@@ -1,6 +1,7 @@
 // REQUIRES: objc_interop
 // RUN: %target-swift-frontend -typecheck -swift-version 3 %s
-// RUN: rm -rf %t && mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/to_int_max.result -emit-remap-file-path %t/to_int_max.remap -o /dev/null
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t && %target-swift-frontend -c -update-code -primary-file %s -emit-migrated-file-path %t/to_int_max.result -emit-remap-file-path %t/to_int_max.remap -o /dev/null
 // RUN: diff -u %S/to_int_max.swift.expected %t/to_int_max.result
 // RUN: %target-swift-frontend -typecheck -swift-version 4 %t/to_int_max.result
 

--- a/test/Misc/serialized-diagnostics-file.swift
+++ b/test/Misc/serialized-diagnostics-file.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 
 // RUN: not %target-swift-frontend -typecheck -serialize-diagnostics-path %t/nonexistent/some.dia %s 2>%t.err.txt

--- a/test/Misc/stats_dir.swift
+++ b/test/Misc/stats_dir.swift
@@ -1,23 +1,28 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %target-swift-frontend -c -o %t/out.o -stats-output-dir %t %s
 // RUN: %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv %t
 // RUN: %FileCheck -input-file %t/frontend.csv %s
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %target-swift-frontend -c -o %t/out.o -stats-output-dir %t %s
 // RUN: %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv --exclude-timers %t
 // RUN: %FileCheck -input-file %t/frontend.csv --implicit-check-not '{{time.swift}}' %s
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %target-swift-frontend -c -o %t/out.o -stats-output-dir %t %s
 // RUN: %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv --select-stat NumSourceLines --select-stat NumIRFunctions --select-stat NumLLVMBytesOutput %t
 // RUN: %FileCheck -input-file %t/frontend.csv %s
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %target-swift-frontend -c -wmo -num-threads 4 -o %t/out.o -stats-output-dir %t %s
 // RUN: %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv %t
 // RUN: %FileCheck -input-file %t/frontend.csv %s
 // RUN: echo '9000000000	"LLVM.NumLLVMBytesOutput"	1' >>%t/frontend.csv
 // RUN: not %utils/process-stats-dir.py --compare-to-csv-baseline %t/frontend.csv %t
 
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %target-swiftc_driver -c -o %t/out.o -stats-output-dir %t %s
 // RUN: %utils/process-stats-dir.py --set-csv-baseline %t/driver.csv %t
 // RUN: %FileCheck -input-file %t/driver.csv %s

--- a/test/Misc/stats_dir_failure_count.swift
+++ b/test/Misc/stats_dir_failure_count.swift
@@ -1,5 +1,6 @@
 // Check that a failed process-tree emits nonzero failure counters
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: echo zzz >%t/other.swift
 // RUN: not %target-swiftc_driver -D BROKEN -j 2 -typecheck -stats-output-dir %t %s %t/other.swift
 // RUN: %utils/process-stats-dir.py --set-csv-baseline %t/stats.csv %t
@@ -8,7 +9,8 @@
 // FAILURE: {{"Frontend.NumProcessFailures"	2$}}
 
 // Check that a successful process-tree emits no nonzero failure counters
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: echo 'let x : Int = 1' >%t/other.swift
 // RUN: %target-swiftc_driver -j 2 -typecheck -stats-output-dir %t %s %t/other.swift
 // RUN: %utils/process-stats-dir.py --set-csv-baseline %t/stats.csv %t

--- a/test/Misc/stats_dir_long_path_name.swift
+++ b/test/Misc/stats_dir_long_path_name.swift
@@ -1,5 +1,6 @@
 // REQUIRES: OS=macosx
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: mkdir -p %t/very-long-directory-name-that-contains-over-128-characters-which-is-not-enough-to-be-illegal-on-its-own-but-presents
 // RUN: cp %s %t/very-long-directory-name-that-contains-over-128-characters-which-is-not-enough-to-be-illegal-on-its-own-but-presents/a-problem-when-combined-with-other-long-path-elements-and-filenames-to-exceed-256-characters-combined-because-yay-arbitrary-limits-amirite.swift
 // RUN: touch %t/main.swift

--- a/test/Misc/stats_dir_tracer.swift
+++ b/test/Misc/stats_dir_tracer.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t %s -trace-stats-events
 // RUN: %FileCheck -input-file %t/*.csv %s
 

--- a/test/NameBinding/named_lazy_member_loading_objc_category.swift
+++ b/test/NameBinding/named_lazy_member_loading_objc_category.swift
@@ -1,6 +1,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
-// RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Prime module cache
 // RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -typecheck %s

--- a/test/NameBinding/named_lazy_member_loading_objc_interface.swift
+++ b/test/NameBinding/named_lazy_member_loading_objc_interface.swift
@@ -1,6 +1,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
-// RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Prime module cache
 // RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -typecheck -primary-file %s %S/Inputs/NamedLazyMembers/NamedLazyMembersExt.swift

--- a/test/NameBinding/named_lazy_member_loading_objc_protocol.swift
+++ b/test/NameBinding/named_lazy_member_loading_objc_protocol.swift
@@ -1,6 +1,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
-// RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Prime module cache
 // RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -typecheck %s

--- a/test/NameBinding/named_lazy_member_loading_protocol_mirroring.swift
+++ b/test/NameBinding/named_lazy_member_loading_protocol_mirroring.swift
@@ -1,6 +1,7 @@
 // REQUIRES: objc_interop
 // REQUIRES: OS=macosx
-// RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Prime module cache
 // RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -typecheck %s

--- a/test/NameBinding/named_lazy_member_loading_swift_class.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_class.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Compile swiftmodule with decl member name tables
 // RUN: %target-swift-frontend -emit-module -o %t/NamedLazyMembers.swiftmodule %S/Inputs/NamedLazyMembers/NamedLazyMembers.swift

--- a/test/NameBinding/named_lazy_member_loading_swift_class_type.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_class_type.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Compile swiftmodule with decl member name tables
 // RUN: %target-swift-frontend -emit-module -o %t/NamedLazyMembers.swiftmodule %S/Inputs/NamedLazyMembers/NamedLazyMembers.swift

--- a/test/NameBinding/named_lazy_member_loading_swift_derived_class.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_derived_class.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Compile swiftmodule with decl member name tables
 // RUN: %target-swift-frontend -emit-module -o %t/NamedLazyMembers.swiftmodule %S/Inputs/NamedLazyMembers/NamedLazyMembers.swift

--- a/test/NameBinding/named_lazy_member_loading_swift_derived_class_type.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_derived_class_type.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Compile swiftmodule with decl member name tables
 // RUN: %target-swift-frontend -emit-module -o %t/NamedLazyMembers.swiftmodule %S/Inputs/NamedLazyMembers/NamedLazyMembers.swift

--- a/test/NameBinding/named_lazy_member_loading_swift_enum.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_enum.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Compile swiftmodule with decl member name tables
 // RUN: %target-swift-frontend -emit-module -o %t/NamedLazyMembers.swiftmodule %S/Inputs/NamedLazyMembers/NamedLazyMembers.swift

--- a/test/NameBinding/named_lazy_member_loading_swift_proto.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_proto.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Compile swiftmodule with decl member name tables
 // RUN: %target-swift-frontend -emit-module -o %t/NamedLazyMembers.swiftmodule %S/Inputs/NamedLazyMembers/NamedLazyMembers.swift

--- a/test/NameBinding/named_lazy_member_loading_swift_struct.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_struct.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Compile swiftmodule with decl member name tables
 // RUN: %target-swift-frontend -emit-module -o %t/NamedLazyMembers.swiftmodule %S/Inputs/NamedLazyMembers/NamedLazyMembers.swift

--- a/test/NameBinding/named_lazy_member_loading_swift_struct_ext.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_struct_ext.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Compile swiftmodule with decl member name tables
 // RUN: %target-swift-frontend -emit-module -o %t/NamedLazyMembers.swiftmodule %S/Inputs/NamedLazyMembers/NamedLazyMembers.swift

--- a/test/NameBinding/named_lazy_member_loading_swift_struct_ext_mem.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_struct_ext_mem.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t/stats-pre && mkdir -p %t/stats-post
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/stats-pre && mkdir -p %t/stats-post
 //
 // Compile swiftmodule with decl member name tables
 // RUN: %target-swift-frontend -emit-module -o %t/NamedLazyMembers.swiftmodule %S/Inputs/NamedLazyMembers/NamedLazyMembers.swift

--- a/test/PCMacro/defer.swift
+++ b/test/PCMacro/defer.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift

--- a/test/PCMacro/didset.swift
+++ b/test/PCMacro/didset.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift

--- a/test/PCMacro/else.swift
+++ b/test/PCMacro/else.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift

--- a/test/PCMacro/elseif.swift
+++ b/test/PCMacro/elseif.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift

--- a/test/PCMacro/for.swift
+++ b/test/PCMacro/for.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift

--- a/test/PCMacro/func_decls.swift
+++ b/test/PCMacro/func_decls.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift

--- a/test/PCMacro/func_throw_notype.swift
+++ b/test/PCMacro/func_throw_notype.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift

--- a/test/PCMacro/getset.swift
+++ b/test/PCMacro/getset.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift

--- a/test/PCMacro/if.swift
+++ b/test/PCMacro/if.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift

--- a/test/PCMacro/init.swift
+++ b/test/PCMacro/init.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift

--- a/test/PCMacro/mutation.swift
+++ b/test/PCMacro/mutation.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift

--- a/test/PCMacro/nested_function.swift
+++ b/test/PCMacro/nested_function.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift

--- a/test/PCMacro/operators.swift
+++ b/test/PCMacro/operators.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift

--- a/test/PCMacro/pc_and_log.swift
+++ b/test/PCMacro/pc_and_log.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -Xfrontend -playground-high-performance -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift %S/../PlaygroundTransform/Inputs/PlaygroundsRuntime.swift

--- a/test/PCMacro/plus_equals.swift
+++ b/test/PCMacro/plus_equals.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift

--- a/test/PCMacro/switch.swift
+++ b/test/PCMacro/switch.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -pc-macro -o %t/main %S/Inputs/PCMacroRuntime.swift %t/main.swift

--- a/test/Parse/ConditionalCompilation/can_import_idempotent.swift
+++ b/test/Parse/ConditionalCompilation/can_import_idempotent.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 //
 // RUN: echo "public var dummyVar = Int()" | %target-swift-frontend -module-name DummyModule -emit-module -o %t -

--- a/test/Parse/ConditionalCompilation/switch_case_executable.swift
+++ b/test/Parse/ConditionalCompilation/switch_case_executable.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %target-build-swift %s -o %t/test1 -module-name main -D PATTERN_1 
 // RUN: %target-build-swift %s -o %t/test2 -module-name main -D PATTERN_2
 // RUN: %target-run %t/test1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK1 %s

--- a/test/PlaygroundTransform/generics.swift
+++ b/test/PlaygroundTransform/generics.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: cp %s %t/main.swift
 // RUN: %target-build-swift -Xfrontend -playground -Xfrontend -debugger-support -o %t/main %S/Inputs/PlaygroundsRuntime.swift %t/main.swift

--- a/test/PrintAsObjC/availability.swift
+++ b/test/PrintAsObjC/availability.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/availability.swiftmodule -typecheck -emit-objc-header-path %t/availability.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module

--- a/test/PrintAsObjC/never.swift
+++ b/test/PrintAsObjC/never.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %s -module-name never -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -parse-as-library %t/never.swiftmodule -typecheck -emit-objc-header-path %t/never.h -disable-objc-attr-requires-foundation-module

--- a/test/PrintAsObjC/swift3_deprecated_objc_inference.swift
+++ b/test/PrintAsObjC/swift3_deprecated_objc_inference.swift
@@ -1,6 +1,6 @@
 // REQUIRES: objc_interop
 
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 
 // FIXME: BEGIN -enable-source-import hackaround

--- a/test/PrintAsObjC/versioned.swift
+++ b/test/PrintAsObjC/versioned.swift
@@ -1,6 +1,6 @@
 // REQUIRES: objc_interop
 
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 
 // FIXME: BEGIN -enable-source-import hackaround

--- a/test/Prototypes/BigInt.swift
+++ b/test/Prototypes/BigInt.swift
@@ -10,7 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 // XFAIL: linux
-// RUN: rm -rf %t ; mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %target-build-swift -swift-version 4 -o %t/a.out %s
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test

--- a/test/Prototypes/property_behaviors/lazy.swift
+++ b/test/Prototypes/property_behaviors/lazy.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-build-swift -Xfrontend -enable-experimental-property-behaviors %s -o %t/a.out
 // RUN: %target-run %t/a.out

--- a/test/Runtime/crash_without_backtrace.swift
+++ b/test/Runtime/crash_without_backtrace.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir %t
 // RUN: %target-build-swift %s -o %t/out
 // RUN: not --crash %t/out 2>&1 | %FileCheck %s

--- a/test/Runtime/crash_without_backtrace_optimized.swift
+++ b/test/Runtime/crash_without_backtrace_optimized.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir %t
 // RUN: %target-build-swift -O %s -o %t/out
 // RUN: not --crash %t/out 2>&1 | %FileCheck %s

--- a/test/Runtime/linux-fatal-backtrace.swift
+++ b/test/Runtime/linux-fatal-backtrace.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-build-swift %s -o %t/a.out
 // RUN: not --crash %t/a.out 2>&1 | PYTHONPATH=%lldb-python-path %utils/symbolicate-linux-fatal %t/a.out - | %utils/backtrace-check -u

--- a/test/SILGen/availability_overloads.swift
+++ b/test/SILGen/availability_overloads.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-swift-frontend -emit-module-path %t/availability_overloads_other.swiftmodule -emit-module -primary-file %S/Inputs/availability_overloads_other.swift
 

--- a/test/SILGen/coverage_smoke.swift
+++ b/test/SILGen/coverage_smoke.swift
@@ -7,7 +7,7 @@
 // RUN: %llvm-profdata show %t/default.profdata -function=f_public | %FileCheck %s --check-prefix=CHECK-PUBLIC
 // RUN: %llvm-profdata show %t/default.profdata -function=main | %FileCheck %s --check-prefix=CHECK-MAIN
 // RUN: %llvm-cov show %t/main -instr-profile=%t/default.profdata | %FileCheck %s --check-prefix=CHECK-COV
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 
 // REQUIRES: profile_runtime
 // REQUIRES: OS=macosx

--- a/test/SILGen/external-keypath.swift
+++ b/test/SILGen/external-keypath.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-swift-frontend -emit-module -o %t/ExternalKeyPaths.swiftmodule -module-name ExternalKeyPaths %S/Inputs/ExternalKeyPaths.swift
 // RUN: %target-swift-frontend -enable-key-path-resilience -emit-silgen -I %t %s | %FileCheck %s

--- a/test/SILGen/pgo_checked_cast.swift
+++ b/test/SILGen/pgo_checked_cast.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t
 // RUN: %target-build-swift %s -profile-generate -Xfrontend -disable-incremental-llvm-codegen -module-name pgo_checked_cast -o %t/main
 // RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata

--- a/test/SILGen/pgo_foreach.swift
+++ b/test/SILGen/pgo_foreach.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t
 // RUN: %target-build-swift %s -profile-generate -Xfrontend -disable-incremental-llvm-codegen -module-name pgo_foreach -o %t/main
 // RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata

--- a/test/SILGen/pgo_guard.swift
+++ b/test/SILGen/pgo_guard.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t
 // RUN: %target-build-swift %s -profile-generate -Xfrontend -disable-incremental-llvm-codegen -module-name pgo_guard -o %t/main
 // RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata

--- a/test/SILGen/pgo_if.swift
+++ b/test/SILGen/pgo_if.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t
 // RUN: %target-build-swift %s -profile-generate -Xfrontend -disable-incremental-llvm-codegen -module-name pgo_if -o %t/main
 // RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata

--- a/test/SILGen/pgo_repeatwhile.swift
+++ b/test/SILGen/pgo_repeatwhile.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t
 // RUN: %target-build-swift %s -profile-generate -Xfrontend -disable-incremental-llvm-codegen -module-name pgo_repeatwhile -o %t/main
 // RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata

--- a/test/SILGen/pgo_switchenum.swift
+++ b/test/SILGen/pgo_switchenum.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t
 // RUN: %target-build-swift %s -profile-generate -Xfrontend -disable-incremental-llvm-codegen -module-name pgo_switchenum -o %t/main
 // RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata

--- a/test/SILGen/pgo_while.swift
+++ b/test/SILGen/pgo_while.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t
 // RUN: %target-build-swift %s -profile-generate -Xfrontend -disable-incremental-llvm-codegen -module-name pgo_while -o %t/main
 // RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata

--- a/test/SILGen/same_type_across_generic_depths.swift
+++ b/test/SILGen/same_type_across_generic_depths.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s > %t/out.sil
 // RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %t/out.sil | %FileCheck %s

--- a/test/SILOptimizer/pgo_si_inlinelarge.swift
+++ b/test/SILOptimizer/pgo_si_inlinelarge.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t
 // RUN: %target-build-swift %s -profile-generate -Xfrontend -disable-incremental-llvm-codegen -module-name pgo_si_inlinelarge -o %t/main
 // RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata

--- a/test/SILOptimizer/pgo_si_reduce.swift
+++ b/test/SILOptimizer/pgo_si_reduce.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t
 // RUN: %target-build-swift %s -profile-generate -Xfrontend -disable-incremental-llvm-codegen -module-name pgo_si_reduce -o %t/main
 // RUN: env LLVM_PROFILE_FILE=%t/default.profraw %target-run %t/main
 // RUN: %llvm-profdata merge %t/default.profraw -o %t/default.profdata

--- a/test/Sanitizers/tsan-inout.swift
+++ b/test/Sanitizers/tsan-inout.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t && cd %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t && cd %t
 // RUN: %target-build-swift %S/Inputs/tsan-uninstrumented.swift -target %sanitizers-target-triple -module-name TSanUninstrumented -emit-module -emit-module-path %t/TSanUninstrumented.swiftmodule -parse-as-library
 // RUN: %target-build-swift %S/Inputs/tsan-uninstrumented.swift -target %sanitizers-target-triple -c -module-name TSanUninstrumented -parse-as-library -o %t/TSanUninstrumented.o
 // RUN: %target-swiftc_driver %s %t/TSanUninstrumented.o -target %sanitizers-target-triple -I%t -L%t -g -sanitize=thread -o %t/tsan-binary

--- a/test/Sema/enum_post_hoc_raw_representable_with_raw_type.swift
+++ b/test/Sema/enum_post_hoc_raw_representable_with_raw_type.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-swift-frontend -emit-module -o %t/enum_with_raw_type.swiftmodule %S/Inputs/enum_with_raw_type.swift
 // RUN: %target-swift-frontend -I %t -typecheck -verify %s

--- a/test/Sema/struct_equatable_hashable.swift
+++ b/test/Sema/struct_equatable_hashable.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: cp %s %t/main.swift
 // RUN: %target-swift-frontend -typecheck -verify -primary-file %t/main.swift %S/Inputs/struct_equatable_hashable_other.swift -verify-ignore-unknown
 

--- a/test/Sema/subclass_property_import.swift
+++ b/test/Sema/subclass_property_import.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-swift-frontend -emit-module -o %t/rdar32973206_a.swiftmodule %S/Inputs/rdar32973206_a.swift
 // RUN: %target-swift-frontend -I %t -emit-module -o %t/rdar32973206_b.swiftmodule %S/Inputs/rdar32973206_b.swift

--- a/test/Serialization/apple-default-search-paths.swift
+++ b/test/Serialization/apple-default-search-paths.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/System/Library/Frameworks/TestFramework.framework/Modules/TestFramework.swiftmodule
 // RUN: mkdir -p %t/Library/Frameworks/TestFramework2.framework/Modules/TestFramework2.swiftmodule
 // RUN: %target-build-swift -emit-module -o %t/System/Library/Frameworks/TestFramework.framework/Modules/TestFramework.swiftmodule/%target-swiftmodule-name -module-name TestFramework %s -DFRAMEWORK

--- a/test/Serialization/extension_generation_number_1.swift
+++ b/test/Serialization/extension_generation_number_1.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/extension_generation_number.swift
 // RUN: %target-swift-frontend -typecheck -I %t %s

--- a/test/Serialization/extension_generation_number_2.swift
+++ b/test/Serialization/extension_generation_number_2.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/extension_generation_number.swift
 // RUN: %target-swift-frontend -typecheck -I %t %s

--- a/test/Serialization/generic_subscript.swift
+++ b/test/Serialization/generic_subscript.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/has_generic_subscript.swift
 // RUN: llvm-bcanalyzer %t/has_generic_subscript.swiftmodule | %FileCheck %s

--- a/test/Serialization/imported_enum_merge.swift
+++ b/test/Serialization/imported_enum_merge.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 
 // FIXME: BEGIN -enable-source-import hackaround

--- a/test/Serialization/nested_generic_extension.swift
+++ b/test/Serialization/nested_generic_extension.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/has_nested_generic_extension.swift
 // RUN: llvm-bcanalyzer %t/has_nested_generic_extension.swiftmodule | %FileCheck %s

--- a/test/Serialization/objc_optional_reqs.swift
+++ b/test/Serialization/objc_optional_reqs.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 
 // FIXME: BEGIN -enable-source-import hackaround

--- a/test/Serialization/sil-imported-enums.swift
+++ b/test/Serialization/sil-imported-enums.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 
 // FIXME: BEGIN -enable-source-import hackaround

--- a/test/Serialization/sil_box_types.sil
+++ b/test/Serialization/sil_box_types.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir %t
 // RUN: %target-build-swift -emit-module -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -o %t/sil_box_types.swiftmodule %s
 // RUN: %target-build-swift -emit-sil -Xfrontend -sil-link-all -I %t %s | %FileCheck %s

--- a/test/Serialization/sil_partial_apply_ownership.sil
+++ b/test/Serialization/sil_partial_apply_ownership.sil
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir %t
 // RUN: %target-build-swift -Xfrontend -assume-parsing-unqualified-ownership-sil -emit-module -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -o %t/sil_partial_apply_ownership.swiftmodule %s
 // RUN: %target-build-swift -Xfrontend -assume-parsing-unqualified-ownership-sil -emit-sil -Xfrontend -sil-link-all -I %t %s | %FileCheck %s

--- a/test/SourceKit/CodeComplete/complete_cache.swift
+++ b/test/SourceKit/CodeComplete/complete_cache.swift
@@ -1,7 +1,7 @@
 import Foo
 
 // REQUIRES: objc_interop
-// RUN: rm -rf %t.ccp
+// RUN: %empty-directory(%t.ccp)
 // RUN: %sourcekitd-test -req=complete.cache.ondisk -cache-path=%t.ccp == \
 // RUN:     -req=complete.open -pos=2:1 -req-opts=hidelowpriority=0 %s -- %s -F %S/../Inputs/libIDE-mock-sdk > %t.completions1
 

--- a/test/SourceKit/DocSupport/doc_swift_module1.swift
+++ b/test/SourceKit/DocSupport/doc_swift_module1.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t.mod
+// RUN: %empty-directory(%t.mod)
 // RUN: mkdir -p %t.mod
 // RUN: %swift -emit-module -o %t.mod/cake1.swiftmodule %S/Inputs/cake1.swift -parse-as-library
 // RUN: %sourcekitd-test -req=doc-info -module cake1 -- -I %t.mod > %t.response

--- a/test/SourceKit/Indexing/index_func_import.swift
+++ b/test/SourceKit/Indexing/index_func_import.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %swift -emit-module -o %t/test_module.swiftmodule %S/Inputs/test_module.swift
 

--- a/test/SourceKit/Misc/ignore_index_store_flag.swift
+++ b/test/SourceKit/Misc/ignore_index_store_flag.swift
@@ -1,7 +1,7 @@
 var s = 10
 s.
 
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: touch %t/t.h
 // RUN: %sourcekitd-test -req=sema %s -- %s -import-objc-header %t/t.h -pch-output-dir %t/pch -index-store-path %t/idx | %FileCheck %s -check-prefix=DIAG

--- a/test/SourceKit/Refactoring/ordering.swift
+++ b/test/SourceKit/Refactoring/ordering.swift
@@ -35,6 +35,7 @@ func test(c: C) {
                             /*C_foo3_call_arg2*/b: 2)
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %sourcekitd-test -req=syntactic-rename -rename-spec %S/ordering/ordering.in.json %s >> %t.result/ordering.expected
 // RUN: diff -u %S/ordering/ordering.expected %t.result/ordering.expected

--- a/test/SourceKit/Refactoring/semantic-refactoring/expand-default.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/expand-default.swift
@@ -9,7 +9,8 @@ func foo(e : E) {
   }
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %sourcekitd-test -req=expand-default -pos=7:7 %s -- %s > %t.result/expand-default.swift.expected
 // RUN: diff -u %S/expand-default.swift.expected %t.result/expand-default.swift.expected
 

--- a/test/SourceKit/Refactoring/semantic-refactoring/extract-func-default.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/extract-func-default.swift
@@ -4,7 +4,8 @@ func foo() -> Int {
   return 1
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %sourcekitd-test -req=extract-func -pos=2:1 -end-pos 4:11 %s -- %s > %t.result/extract-func-default.swift.expected
 // RUN: diff -u %S/extract-func-default.swift.expected %t.result/extract-func-default.swift.expected
 

--- a/test/SourceKit/Refactoring/semantic-refactoring/extract-func-with-args.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/extract-func-with-args.swift
@@ -4,7 +4,8 @@ func foo() -> Int {
   return 1
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %sourcekitd-test -req=extract-func -pos=3:1 -end-pos 3:12 -name new_name %s -- %s > %t.result/extract-func-with-args.swift.expected
 // RUN: diff -u %S/extract-func-with-args.swift.expected %t.result/extract-func-with-args.swift.expected
 

--- a/test/SourceKit/Refactoring/semantic-refactoring/extract-func.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/extract-func.swift
@@ -4,7 +4,8 @@ func foo() -> Int {
   return 1
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %sourcekitd-test -req=extract-func -pos=2:1 -end-pos 4:11 -name new_name %s -- %s > %t.result/extract-func.swift.expected
 // RUN: diff -u %S/extract-func.swift.expected %t.result/extract-func.swift.expected
 

--- a/test/SourceKit/Refactoring/semantic-refactoring/extract-repeated-expression.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/extract-repeated-expression.swift
@@ -4,7 +4,8 @@ func foo() -> Int {
   return 1
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %sourcekitd-test -req=extract-repeated -pos=3:11 -end-pos 3:12 -name new_name %s -- %s > %t.result/extract-repeated-expression.swift.expected
 // RUN: diff -u %S/extract-repeated-expression.swift.expected %t.result/extract-repeated-expression.swift.expected
 

--- a/test/SourceKit/Refactoring/semantic-refactoring/fill-stub.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/fill-stub.swift
@@ -4,7 +4,8 @@ protocol P {
 
 class C1 : P {}
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %sourcekitd-test -req=fill-stub -pos=5:8 %s -- %s > %t.result/fill-stub.swift.expected
 // RUN: diff -u %S/fill-stub.swift.expected %t.result/fill-stub.swift.expected
 

--- a/test/SourceKit/Refactoring/semantic-refactoring/local-rename.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/local-rename.swift
@@ -11,7 +11,8 @@ func foo() {
   return 1
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %sourcekitd-test -req=local-rename -pos=2:8 -name new_name %s -- %s > %t.result/local-rename.swift.expected
 // RUN: diff -u %S/local-rename.swift.expected %t.result/local-rename.swift.expected
 // RUN: %sourcekitd-test -req=find-local-rename-ranges -pos=2:8 %s -- %s > %t.result/local-rename-ranges.swift.expected

--- a/test/SourceKit/Refactoring/semantic-refactoring/localize-string.swift
+++ b/test/SourceKit/Refactoring/semantic-refactoring/localize-string.swift
@@ -2,7 +2,8 @@ func foo() -> String {
   return "abc"
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %sourcekitd-test -req=localize-string -pos=2:10 %s -- %s > %t.result/localize-string.swift.expected
 // RUN: diff -u %S/localize-string.swift.expected %t.result/localize-string.swift.expected
 

--- a/test/SourceKit/Refactoring/syntactic-rename.swift
+++ b/test/SourceKit/Refactoring/syntactic-rename.swift
@@ -92,7 +92,8 @@ func genfoo<T: P, U, V where U: P>(x: T, y: U, z: V, a: P) -> P where V: P {
   fatalError()
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %sourcekitd-test -req=syntactic-rename -rename-spec %S/syntactic-rename/x.in.json %s >> %t.result/x.expected
 // RUN: diff -u %S/syntactic-rename/x.expected %t.result/x.expected
 // RUN: %sourcekitd-test -req=syntactic-rename -rename-spec %S/syntactic-rename/z.in.json %s >> %t.result/z.expected
@@ -117,7 +118,8 @@ func genfoo<T: P, U, V where U: P>(x: T, y: U, z: V, a: P) -> P where V: P {
 // RUN: %sourcekitd-test -req=syntactic-rename -rename-spec %S/syntactic-rename/rename-P.in.json %s -- -swift-version 3 >> %t.result/rename-P.expected
 // RUN: diff -u %S/syntactic-rename/rename-P.expected %t.result/rename-P.expected
 
-// RUN: rm -rf %t.ranges && mkdir -p %t.ranges
+// RUN: %empty-directory(%t.ranges)
+// RUN: mkdir -p %t.ranges
 // RUN: %sourcekitd-test -req=find-rename-ranges -rename-spec %S/syntactic-rename/x.in.json %s >> %t.ranges/x.expected
 // RUN: diff -u %S/find-rename-ranges/x.expected %t.ranges/x.expected
 // RUN: %sourcekitd-test -req=find-rename-ranges -rename-spec %S/syntactic-rename/z.in.json %s >> %t.ranges/z.expected

--- a/test/api-digester/source-stability.swift
+++ b/test/api-digester/source-stability.swift
@@ -1,7 +1,9 @@
 // REQUIRES: OS=macosx
-// RUN: rm -rf %t.tmp && mkdir %t.tmp && mkdir %t.tmp/module-cache && mkdir %t.tmp/dummy.sdk
+// RUN: %empty-directory(%t.tmp)
+// RUN: mkdir %t.tmp && mkdir %t.tmp/module-cache && mkdir %t.tmp/dummy.sdk
 // RUN: %api-digester -dump-sdk -module Swift -o %t.tmp/current-stdlib.json -module-cache-path %t.tmp/module-cache -sdk %t.tmp/dummy.sdk -swift-version 3
 // RUN: %api-digester -diagnose-sdk -input-paths %S/stdlib-stable.json -input-paths %t.tmp/current-stdlib.json >> %t.tmp/changes.txt
 // RUN: %clang -E -P -x c %S/source-stability.swift.expected -o - | sed '/^\s*$/d' > %t.tmp/source-stability.swift.expected
 // RUN: %clang -E -P -x c %t.tmp/changes.txt -o - | sed '/^\s*$/d' > %t.tmp/changes.txt.tmp
-// RUN: diff -u %t.tmp/source-stability.swift.expected %t.tmp/changes.txt.tmp ; rm -rf %S/tmp
+// RUN: diff -u %t.tmp/source-stability.swift.expected %t.tmp/changes.txt.tmp
+// RUN: %empty-directory(%S/tmp)

--- a/test/decl/protocol/conforms/redundant_conformance.swift
+++ b/test/decl/protocol/conforms/redundant_conformance.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/redundant_conformance_A.swift

--- a/test/refactoring/CollapseNestedIf/basic.swift
+++ b/test/refactoring/CollapseNestedIf/basic.swift
@@ -22,7 +22,8 @@ func testCaseLetNestedIf() {
     if b != 5 {}
   }
 }
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -collapse-nested-if -source-filename %s -pos=3:3 > %t.result/L3-3.swift
 // RUN: diff -u %S/Outputs/basic/L3-3.swift.expected %t.result/L3-3.swift
 // RUN: %refactor -collapse-nested-if -source-filename %s -pos=9:3 > %t.result/L9-3.swift

--- a/test/refactoring/ConvertForceTryToTryCatch/basic.swift
+++ b/test/refactoring/ConvertForceTryToTryCatch/basic.swift
@@ -2,6 +2,7 @@ func throwingFunc() throws {
     return
 }
 try! throwingFunc()
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -convert-to-do-catch -source-filename %s -pos=4:3 > %t.result/L5.swift
 // RUN: diff -u %S/Outputs/basic/L5.swift.expected %t.result/L5.swift

--- a/test/refactoring/ConvertForceTryToTryCatch/basic_in_func.swift
+++ b/test/refactoring/ConvertForceTryToTryCatch/basic_in_func.swift
@@ -4,6 +4,7 @@ func throwingFunc() throws {
 func foo() {
     try! throwingFunc()
 }
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -convert-to-do-catch -source-filename %s -pos=5:7 > %t.result/L5.swift
 // RUN: diff -u %S/Outputs/basic_in_func/L5.swift.expected %t.result/L5.swift

--- a/test/refactoring/ConvertForceTryToTryCatch/for_loop.swift
+++ b/test/refactoring/ConvertForceTryToTryCatch/for_loop.swift
@@ -4,6 +4,7 @@ func throwingFunc() throws -> [Int] {
 for num in try! throwingFunc() {
     let _ = num
 }
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -convert-to-do-catch -source-filename %s -pos=4:14 > %t.result/L5.swift
 // RUN: diff -u %S/Outputs/for_loop/L5.swift.expected %t.result/L5.swift

--- a/test/refactoring/ConvertForceTryToTryCatch/in_if_clause.swift
+++ b/test/refactoring/ConvertForceTryToTryCatch/in_if_clause.swift
@@ -4,6 +4,7 @@ func throwingFunc() throws -> Bool {
 if try! throwingFunc() { 
     let _ = 3
 }
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -convert-to-do-catch -source-filename %s -pos=4:4 > %t.result/L5.swift
 // RUN: diff -u %S/Outputs/in_if_clause/L5.swift.expected %t.result/L5.swift

--- a/test/refactoring/ConvertForceTryToTryCatch/in_if_clause_nested.swift
+++ b/test/refactoring/ConvertForceTryToTryCatch/in_if_clause_nested.swift
@@ -6,6 +6,7 @@ if 4 > 3 {
         let _ = 3
     }
 }
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -convert-to-do-catch -source-filename %s -pos=5:10 > %t.result/L5.swift
 // RUN: diff -u %S/Outputs/in_if_clause_nested/L5.swift.expected %t.result/L5.swift

--- a/test/refactoring/ConvertForceTryToTryCatch/in_if_clause_with_let_binding.swift
+++ b/test/refactoring/ConvertForceTryToTryCatch/in_if_clause_with_let_binding.swift
@@ -4,6 +4,7 @@ func throwingFunc() throws -> Int? {
 if let val = try! throwingFunc() { 
     let _ = val
 }
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -convert-to-do-catch -source-filename %s -pos=4:16 > %t.result/L5.swift
 // RUN: diff -u %S/Outputs/in_if_clause_with_let_binding/L5.swift.expected %t.result/L5.swift

--- a/test/refactoring/ConvertForceTryToTryCatch/inside_constructor.swift
+++ b/test/refactoring/ConvertForceTryToTryCatch/inside_constructor.swift
@@ -3,6 +3,7 @@ func throwingFunc() throws -> [Int] {
 }
 struct X { let array: [Int] }
 let _ = X(array: try! throwingFunc())
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -convert-to-do-catch -source-filename %s -pos=5:19 > %t.result/L5.swift
 // RUN: diff -u %S/Outputs/inside_constructor/L5.swift.expected %t.result/L5.swift

--- a/test/refactoring/ConvertStringsConcatenationToInterpolation/basic.swift
+++ b/test/refactoring/ConvertStringsConcatenationToInterpolation/basic.swift
@@ -3,6 +3,7 @@ func testStringConcatenation() {
   let bornYear = "1888"
   let _ = "Mr. " + firstName + bornYear
 }
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -strings-concatenation-to-interpolation -source-filename %s -pos=4:11 -end-pos=4:40 > %t.result/L4.swift
 // RUN: diff -u %S/Outputs/basic/L4.swift.expected %t.result/L4.swift

--- a/test/refactoring/ConvertStringsConcatenationToInterpolation/func_calls.swift
+++ b/test/refactoring/ConvertStringsConcatenationToInterpolation/func_calls.swift
@@ -4,6 +4,7 @@ func testStringConcatenation() {
   let closure: () -> String = { return "FOO" }
   let _ = "Mr. " + firstName.debugDescription + closure() + "number: \(number)"
 }
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -strings-concatenation-to-interpolation -source-filename %s -pos=5:11 -end-pos=5:80 > %t.result/L5.swift
 // RUN: diff -u %S/Outputs/func_calls/L5.swift.expected %t.result/L5.swift

--- a/test/refactoring/ConvertToTernaryExpr/basic.swift
+++ b/test/refactoring/ConvertToTernaryExpr/basic.swift
@@ -19,7 +19,8 @@ func testConvertTupleToTernaryExpr() {
   }
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 
 // RUN: %refactor -convert-to-ternary-expr -source-filename %s -pos=4:3 -end-pos=9:4 > %t.result/L4-3.swift
 // RUN: diff -u %S/Outputs/basic/L4-3.swift.expected %t.result/L4-3.swift

--- a/test/refactoring/ExpandDefault/basic.swift
+++ b/test/refactoring/ExpandDefault/basic.swift
@@ -17,6 +17,7 @@ func foo(e: E) -> Int {
   }
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -expand-default -source-filename %s -pos=15:8 >> %t.result/L15.swift
 // RUN: diff -u %S/Outputs/basic/L15.swift.expected %t.result/L15.swift

--- a/test/refactoring/ExpandSwitchCases/basic.swift
+++ b/test/refactoring/ExpandSwitchCases/basic.swift
@@ -8,6 +8,7 @@ enum E {
 func foo(e: E) -> Int {
   switch e { }
 }
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -expand-switch-cases -source-filename %s -pos=9:8 >> %t.result/L10.swift
 // RUN: diff -u %S/Outputs/basic/L10.swift.expected %t.result/L10.swift

--- a/test/refactoring/ExpandSwitchCases/no_space_between_braces.swift
+++ b/test/refactoring/ExpandSwitchCases/no_space_between_braces.swift
@@ -8,6 +8,7 @@ enum E {
 func foo(e: E) -> Int {
   switch e {}
 }
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -expand-switch-cases -source-filename %s -pos=9:8 >> %t.result/L10.swift
 // RUN: diff -u %S/Outputs/no_space_between_braces/L10.swift.expected %t.result/L10.swift

--- a/test/refactoring/ExpandSwitchCases/partially_handled.swift
+++ b/test/refactoring/ExpandSwitchCases/partially_handled.swift
@@ -10,6 +10,7 @@ func foo(e: E) -> Int {
     case .e1: return 5
    }
 }
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -expand-switch-cases -source-filename %s -pos=9:8 >> %t.result/L11.swift
 // RUN: diff -u %S/Outputs/partially_handled/L11.swift.expected %t.result/L11.swift

--- a/test/refactoring/ExpandSwitchCases/with_default.swift
+++ b/test/refactoring/ExpandSwitchCases/with_default.swift
@@ -10,6 +10,7 @@ func foo(e: E) -> Int {
     default: return 3
    }
 }
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -expand-switch-cases -source-filename %s -pos=9:8 >> %t.result/L10.swift
 // RUN: diff -u %S/Outputs/with_default/L10.swift.expected %t.result/L10.swift

--- a/test/refactoring/ExpandTernaryExpr/basic.swift
+++ b/test/refactoring/ExpandTernaryExpr/basic.swift
@@ -24,7 +24,8 @@ func testExpandAssignOnlyTupleTernaryExpr() {
   (x, y) = a < 5 ? (a, b) : (b, a)
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 
 // RUN: %refactor -expand-ternary-expr -source-filename %s -pos=4:3 -end-pos=4:24 > %t.result/L4-3.swift
 // RUN: diff -u %S/Outputs/basic/L4-3.swift.expected %t.result/L4-3.swift

--- a/test/refactoring/ExtractExpr/basic.swift
+++ b/test/refactoring/ExtractExpr/basic.swift
@@ -5,7 +5,8 @@ func foo(_ a : Int) -> Int {
   return 1
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -extract-expr -source-filename %s -pos=4:13 -end-pos=4:18 >> %t.result/C13-18.swift
 // RUN: diff -u %S/Outputs/basic/C13-18.swift.expected %t.result/C13-18.swift
 // RUN: %refactor -extract-expr -source-filename %s -pos=4:13 -end-pos=4:26 >> %t.result/C13-26.swift

--- a/test/refactoring/ExtractExpr/contextual_type.swift
+++ b/test/refactoring/ExtractExpr/contextual_type.swift
@@ -3,6 +3,7 @@ func bar() {
   foo(1+1)  
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -extract-expr -source-filename %s -pos=3:7 -end-pos=3:10 >> %t.result/C7-10.swift
 // RUN: diff -u %S/Outputs/contextual_type/C7-10.swift.expected %t.result/C7-10.swift

--- a/test/refactoring/ExtractExpr/name_collision.swift
+++ b/test/refactoring/ExtractExpr/name_collision.swift
@@ -9,6 +9,7 @@ func foo(_ a : Int) -> Int {
   return 1
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -extract-expr -source-filename %s -pos=8:13 -end-pos=8:22 >> %t.result/C13-22.swift
 // RUN: diff -u %S/Outputs/name_collision/C13-22.swift.expected %t.result/C13-22.swift

--- a/test/refactoring/ExtractFunction/basic.swift
+++ b/test/refactoring/ExtractFunction/basic.swift
@@ -5,7 +5,8 @@ func foo() -> Int{
   return aaa
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -extract-function -source-filename %s -pos=2:1 -end-pos=5:13 >> %t.result/L2-5.swift
 // RUN: diff -u %S/Outputs/basic/L2-5.swift.expected %t.result/L2-5.swift
 // RUN: %refactor -extract-function -source-filename %s -pos=3:1 -end-pos=5:13 >> %t.result/L3-5.swift

--- a/test/refactoring/ExtractFunction/extract_attributes.swift
+++ b/test/refactoring/ExtractFunction/extract_attributes.swift
@@ -8,6 +8,7 @@ public func foo() -> Int{
 }
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -extract-function -source-filename %s -pos=5:1 -end-pos=6:26 >> %t.result/L5-6.swift
 // RUN: diff -u %S/Outputs/extract_attributes/L5-6.swift.expected %t.result/L5-6.swift

--- a/test/refactoring/ExtractFunction/extract_from_accessor.swift
+++ b/test/refactoring/ExtractFunction/extract_from_accessor.swift
@@ -9,7 +9,8 @@ class C {
   }
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -extract-function -source-filename %s -pos=3:13 -end-pos=3:18 >> %t.result/ImplicitGetter.swift
 // RUN: diff -u %S/Outputs/extract_from_accessor/ImplicitGetter.swift.expected %t.result/ImplicitGetter.swift
 

--- a/test/refactoring/ExtractFunction/extract_init.swift
+++ b/test/refactoring/ExtractFunction/extract_init.swift
@@ -7,6 +7,7 @@ class C {
   }
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -extract-function -source-filename %s -pos=5:1 -end-pos=6:15 >> %t.result/L5-6.swift
 // RUN: diff -u %S/Outputs/extract_init/L5-6.swift.expected %t.result/L5-6.swift

--- a/test/refactoring/ExtractFunction/extract_local.swift
+++ b/test/refactoring/ExtractFunction/extract_local.swift
@@ -12,6 +12,7 @@ func returnFifteen() -> Int {
   return y
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -extract-function -source-filename %s -pos=5:1 -end-pos=9:6 >> %t.result/AvoidFilePrivate.swift
 // RUN: diff -u %S/Outputs/extract_local/AvoidFilePrivate.swift.expected %t.result/AvoidFilePrivate.swift

--- a/test/refactoring/ExtractFunction/extract_subscript.swift
+++ b/test/refactoring/ExtractFunction/extract_subscript.swift
@@ -10,7 +10,8 @@ class A {
   }
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -extract-function -source-filename %s -pos=5:1 -end-pos=5:15 >> %t.result/FromGetter.swift
 // RUN: diff -u %S/Outputs/extract_subscript/FromGetter.swift.expected %t.result/FromGetter.swift
 // RUN: %refactor -extract-function -source-filename %s -pos=8:1 -end-pos=8:19 >> %t.result/FromSetter.swift

--- a/test/refactoring/ExtractFunction/extract_sugar.swift
+++ b/test/refactoring/ExtractFunction/extract_sugar.swift
@@ -5,6 +5,7 @@ func foo(_ a : inout [Int]) -> [Int] {
   return a
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -extract-function -source-filename %s -pos=2:1 -end-pos=5:11 >> %t.result/L2-5.swift
 // RUN: diff -u %S/Outputs/extract_sugar/L2-5.swift.expected %t.result/L2-5.swift

--- a/test/refactoring/ExtractFunction/extract_switch.swift
+++ b/test/refactoring/ExtractFunction/extract_switch.swift
@@ -23,9 +23,11 @@ func foo2(_ e : MyEnum) -> Int {
   }
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -extract-function -source-filename %s -pos=8:1 -end-pos=15:4 >> %t.result/Void.swift
 // RUN: diff -u %S/Outputs/extract_switch/Void.swift.expected %t.result/Void.swift
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -extract-function -source-filename %s -pos=16:1 -end-pos=23:4 >> %t.result/Int.swift
 // RUN: diff -u %S/Outputs/extract_switch/Int.swift.expected %t.result/Int.swift

--- a/test/refactoring/ExtractFunction/extract_with_comments.swift
+++ b/test/refactoring/ExtractFunction/extract_with_comments.swift
@@ -11,6 +11,7 @@ public func foo() -> Int{
 }
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -extract-function -source-filename %s -pos=6:1 -end-pos=7:26 >> %t.result/L6-7.swift
 // RUN: diff -u %S/Outputs/extract_with_comments/L6-7.swift.expected %t.result/L6-7.swift

--- a/test/refactoring/ExtractFunction/name_correction.swift
+++ b/test/refactoring/ExtractFunction/name_correction.swift
@@ -12,6 +12,7 @@ public func new_name2() {}
 public func new_name3() {}
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -extract-function -source-filename %s -pos=5:1 -end-pos=6:26 >> %t.result/L5-6.swift
 // RUN: diff -u %S/Outputs/name_correction/L5-6.swift.expected %t.result/L5-6.swift

--- a/test/refactoring/ExtractFunction/static.swift
+++ b/test/refactoring/ExtractFunction/static.swift
@@ -12,7 +12,8 @@ class C {
   }
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -extract-function -source-filename %s -pos=3:1 -end-pos=5:13 >> %t.result/L3-5.swift
 // RUN: diff -u %S/Outputs/static/L3-5.swift.expected %t.result/L3-5.swift
 // RUN: %refactor -extract-function -source-filename %s -pos=9:1 -end-pos=11:13 >> %t.result/L9-11.swift

--- a/test/refactoring/ExtractFunction/throw_errors.swift
+++ b/test/refactoring/ExtractFunction/throw_errors.swift
@@ -17,7 +17,8 @@ func foo2() throws {
   }
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -extract-function -source-filename %s -pos=8:1 -end-pos=8:13 >> %t.result/L8-8.swift
 // RUN: diff -u %S/Outputs/throw_errors/L8-8.swift.expected %t.result/L8-8.swift
 // RUN: %refactor -extract-function -source-filename %s -pos=9:1 -end-pos=9:14 >> %t.result/L9-9.swift

--- a/test/refactoring/ExtractFunction/throw_errors2.swift
+++ b/test/refactoring/ExtractFunction/throw_errors2.swift
@@ -12,6 +12,7 @@ struct RefactorExtractProblem {
   }
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -extract-function -source-filename %s -pos=7:1 -end-pos=11:6 >> %t.result/L7-11.swift
 // RUN: diff -u %S/Outputs/throw_errors2/L7-11.swift.expected %t.result/L7-11.swift

--- a/test/refactoring/ExtractRepeat/basic.swift
+++ b/test/refactoring/ExtractRepeat/basic.swift
@@ -7,7 +7,8 @@ func foo(_ a : Int) -> Int {
   return foo1() + foo1() + foo1() + a1 + a2 + a3
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -extract-repeat -source-filename %s -pos=4:16 -end-pos=4:17 >> %t.result/two.swift
 // RUN: diff -u %S/Outputs/basic/two.swift.expected %t.result/two.swift
 // RUN: %refactor -extract-repeat -source-filename %s -pos=4:12 -end-pos=4:17 >> %t.result/one-plus-two.swift

--- a/test/refactoring/FillStubs/basic.swift
+++ b/test/refactoring/FillStubs/basic.swift
@@ -89,7 +89,8 @@ extension C14: P3 {
   func foo3()
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -fill-stub -source-filename %s -pos=5:8 >> %t.result/P5-8.swift
 // RUN: diff -u %S/Outputs/basic/P5-8.swift.expected %t.result/P5-8.swift
 // RUN: %refactor -fill-stub -source-filename %s -pos=8:8 >> %t.result/P8-8.swift

--- a/test/refactoring/LocalizeString/basic.swift
+++ b/test/refactoring/LocalizeString/basic.swift
@@ -4,6 +4,7 @@ func testStringLiteral() -> String {
   return "abc"
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -localize-string -source-filename %s -pos=4:12 > %t.result/L4.swift
 // RUN: diff -u %S/Outputs/basic/L4.swift.expected %t.result/L4.swift

--- a/test/refactoring/LocalizeString/callexpr.swift
+++ b/test/refactoring/LocalizeString/callexpr.swift
@@ -6,6 +6,7 @@ extension String {
   func foo() -> String { return self }
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -localize-string -source-filename %s -pos=2:10 > %t.result/L2.swift
 // RUN: diff -u %S/Outputs/callexpr/L2.swift.expected %t.result/L2.swift

--- a/test/refactoring/LongNumber/basic.swift
+++ b/test/refactoring/LongNumber/basic.swift
@@ -5,7 +5,8 @@ func foo() {
   _ = -1234567
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -simplify-long-number -source-filename %s -pos=2:9 > %t.result/Integer.swift
 // RUN: diff -u %S/Outputs/Integer.expected %t.result/Integer.swift
 // RUN: %refactor -simplify-long-number -source-filename %s -pos=3:9 > %t.result/Float.swift

--- a/test/refactoring/MoveMembersToExtension/basic.swift
+++ b/test/refactoring/MoveMembersToExtension/basic.swift
@@ -26,19 +26,24 @@ class OtherClass {
   }
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -move-to-extension -source-filename %s -pos=2:1 -end-pos=5:1 > %t.result/L2-5.swift
 // RUN: diff -u %S/Outputs/L2-5.swift.expected %t.result/L2-5.swift
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -move-to-extension -source-filename %s -pos=3:1 -end-pos=5:1 > %t.result/L3-5.swift
 // RUN: diff -u %S/Outputs/L3-5.swift.expected %t.result/L3-5.swift
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -move-to-extension -source-filename %s -pos=6:1 -end-pos=8:1 > %t.result/L6-8.swift
 // RUN: diff -u %S/Outputs/L6-8.swift.expected %t.result/L6-8.swift
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -move-to-extension -source-filename %s -pos=3:1 -end-pos=13:1 > %t.result/L3-13.swift
 // RUN: diff -u %S/Outputs/L3-13.swift.expected %t.result/L3-13.swift
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -move-to-extension -source-filename %s -pos=24:1 -end-pos=27:1 > %t.result/L24-27.swift
 // RUN: diff -u %S/Outputs/L24-27.swift.expected %t.result/L24-27.swift
 // RUN: not %refactor -move-to-extension -source-filename %s -pos=3:1 -end-pos=4:1

--- a/test/refactoring/SyntacticRename/callsites.swift
+++ b/test/refactoring/SyntacticRename/callsites.swift
@@ -64,7 +64,8 @@ func /*mixed:def*/withAllOfTheAbove(x: Int = 2, _: Int..., z: Int = 2, c: () -> 
 // false positives
 /*mixed:call*/withAllOfTheAbove(z: 1, 2, c: {return 1})
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -syntactic-rename -source-filename %s -pos="defaults" -is-function-like -old-name "withDefaults(_:y:x:)" -new-name "betterName(x:y:z:)" >> %t.result/callsites_defaults.swift
 // RUN: diff -u %S/Outputs/callsites/defaults.swift.expected %t.result/callsites_defaults.swift
 // RUN: %refactor -syntactic-rename -source-filename %s -pos="trailing" -is-function-like -old-name "withTrailingClosure(x:y:)" -new-name "betterName(a:b:)" >> %t.result/callsites_trailing.swift
@@ -75,7 +76,8 @@ func /*mixed:def*/withAllOfTheAbove(x: Int = 2, _: Int..., z: Int = 2, c: () -> 
 // RUN: diff -u %S/Outputs/callsites/varargs2.swift.expected %t.result/callsites_varargs2.swift
 // RUN: %refactor -syntactic-rename -source-filename %s -pos="mixed" -is-function-like -old-name "withAllOfTheAbove(x:_:z:c:)" -new-name "betterName(a:b:c:d:)" >> %t.result/callsites_mixed.swift
 // RUN: diff -u %S/Outputs/callsites/mixed.swift.expected %t.result/callsites_mixed.swift
-// RUN: rm -rf %t.ranges && mkdir -p %t.ranges
+// RUN: %empty-directory(%t.ranges)
+// RUN: mkdir -p %t.ranges
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="defaults" -is-function-like -old-name "withDefaults(_:y:x:)" >> %t.ranges/callsites_defaults.swift
 // RUN: diff -u %S/FindRangeOutputs/callsites/defaults.swift.expected %t.ranges/callsites_defaults.swift
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="trailing" -is-function-like -old-name "withTrailingClosure(x:y:)" >> %t.ranges/callsites_trailing.swift

--- a/test/refactoring/SyntacticRename/functions.swift
+++ b/test/refactoring/SyntacticRename/functions.swift
@@ -124,7 +124,8 @@ _ = memberwise . /*memberwise-x:ref*/x
 // RUN: diff -u %S/Outputs/functions/sub.swift.expected %t.result/functions_sub.swift
 // RUN: %refactor -syntactic-rename -source-filename %s -pos="memberwise-x" -old-name "x" -new-name "new_x" >> %t.result/functions_memberwise-x.swift
 // RUN: diff -u %S/Outputs/functions/memberwise-x.swift.expected %t.result/functions_memberwise-x.swift
-// RUN: rm -rf %t.ranges && mkdir -p %t.ranges
+// RUN: %empty-directory(%t.ranges)
+// RUN: mkdir -p %t.ranges
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="bar" -is-function-like -old-name "bar(_:)" >> %t.ranges/functions_bar.swift
 // RUN: diff -u %S/FindRangeOutputs/functions/bar.swift.expected %t.ranges/functions_bar.swift
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="no-args" -is-function-like -old-name "aFunc" >> %t.ranges/functions_no-args.swift

--- a/test/refactoring/SyntacticRename/textual.swift
+++ b/test/refactoring/SyntacticRename/textual.swift
@@ -36,11 +36,13 @@ _ = /*MyClass:unknown*/Mismatch()
 _ = /*MyClass:unknown*/MyClass()
 #endif
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -syntactic-rename -source-filename %s -pos="foo" -is-function-like -old-name "foo" -new-name "bar" >> %t.result/textual_foo.swift
 // RUN: diff -u %S/Outputs/textual/foo.swift.expected %t.result/textual_foo.swift
 // RUN: %refactor -syntactic-rename -source-filename %s -pos="MyClass" -is-non-protocol-type -old-name "MyClass" -new-name "YourClass" >> %t.result/textual_MyClass.swift
 // RUN: diff -u %S/Outputs/textual/MyClass.swift.expected %t.result/textual_MyClass.swift
-// RUN: rm -rf %t.ranges && mkdir -p %t.ranges
+// RUN: %empty-directory(%t.ranges)
+// RUN: mkdir -p %t.ranges
 // RUN: %refactor -find-rename-ranges -source-filename %s -pos="foo" -is-function-like -old-name "foo" >> %t.ranges/textual_foo.swift
 // RUN: diff -u %S/FindRangeOutputs/textual/foo.swift.expected %t.ranges/textual_foo.swift

--- a/test/refactoring/SyntacticRename/types.swift
+++ b/test/refactoring/SyntacticRename/types.swift
@@ -52,7 +52,8 @@ enum /*enum-WithValue:def*/WithValue: Int {
 }
 var _ = /*enum-WithValue*/WithValue . /*case-one*/one
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -syntactic-rename -source-filename %s -pos="class-Foo" -is-non-protocol-type -old-name "Foo" -new-name "MoreFoo" >> %t.result/types_class-Foo.swift
 // RUN: diff -u %S/Outputs/types/class-Foo.swift.expected %t.result/types_class-Foo.swift
 // RUN: %refactor -syntactic-rename -source-filename %s -pos="protocol-Proto" -old-name "Proto" -new-name "NextProto" >> %t.result/types_protocol-Proto.swift

--- a/test/refactoring/SyntacticRename/variables.swift
+++ b/test/refactoring/SyntacticRename/variables.swift
@@ -38,7 +38,8 @@ struct S {
 	}()
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -syntactic-rename -source-filename %s -pos="var-y" -old-name "y" -new-name "yack" >> %t.result/variables_var-y.swift
 // RUN: diff -u %S/Outputs/variables/var-y.swift.expected %t.result/variables_var-y.swift
 // RUN: %refactor -syntactic-rename -source-filename %s -pos="ivar-x" -old-name "x" -new-name "fox" >> %t.result/variables_ivar-x.swift

--- a/test/refactoring/TrailingClosure/basic.swift
+++ b/test/refactoring/TrailingClosure/basic.swift
@@ -13,7 +13,8 @@ func testTrailingClosure() -> String {
     .filter({ $0 % 2 == 0 })
     .map({ $0 + 1 })
 }
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 
 // RUN: %refactor -trailingclosure -source-filename %s -pos=7:3 > %t.result/L7.swift
 // RUN: diff -u %S/Outputs/basic/L7.swift.expected %t.result/L7.swift

--- a/test/refactoring/rename/basic.swift
+++ b/test/refactoring/rename/basic.swift
@@ -19,7 +19,8 @@ guard let top = Optional.some("top") else {
 }
 print(top)
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -rename -source-filename %s -pos=2:15 -new-name new_S1 >> %t.result/S1.swift
 // RUN: diff -u %S/Outputs/basic/S1.swift.expected %t.result/S1.swift
 // RUN: %refactor -rename -source-filename %s -pos=4:16 -new-name new_c1>> %t.result/C1.swift
@@ -46,7 +47,8 @@ print(top)
 // RUN: diff -u %S/Outputs/basic/local.swift.expected %t.result/local.swift
 // RUN: %refactor -rename -source-filename %s -pos=20:7 -new-name 'bottom' > %t.result/top_level.swift
 // RUN: diff -u %S/Outputs/basic/top_level.swift.expected %t.result/top_level.swift
-// RUN: rm -rf %t.ranges && mkdir -p %t.ranges
+// RUN: %empty-directory(%t.ranges)
+// RUN: mkdir -p %t.ranges
 // RUN: %refactor -find-local-rename-ranges -source-filename %s -pos=2:15 > %t.ranges/S1.swift
 // RUN: diff -u %S/Outputs/basic_ranges/S1.swift.expected %t.ranges/S1.swift
 // RUN: %refactor -find-local-rename-ranges -source-filename %s -pos=4:16 > %t.ranges/C1.swift

--- a/test/refactoring/rename/property.swift
+++ b/test/refactoring/rename/property.swift
@@ -3,6 +3,7 @@ var foo: String {
   return name
 }
 
-// RUN: rm -rf %t.result && mkdir -p %t.result
+// RUN: %empty-directory(%t.result)
+// RUN: mkdir -p %t.result
 // RUN: %refactor -find-local-rename-ranges -source-filename %s -pos=2:7 > %t.result/computed_property.swift
 // RUN: diff -u %S/Outputs/property/computed_property.swift.expected %t.result/computed_property.swift

--- a/test/sil-func-extractor/basic.sil
+++ b/test/sil-func-extractor/basic.sil
@@ -1,5 +1,5 @@
 // RUN: %target-sil-func-extractor -assume-parsing-unqualified-ownership-sil %s -func=use_before_init | %FileCheck %s
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir %t
 // RUN: %target-sil-func-extractor -assume-parsing-unqualified-ownership-sil %s -func=use_before_init -emit-sib -o %t/out.sib -module-name main && %target-sil-opt %t/out.sib -module-name main | %FileCheck %s
 

--- a/test/stdlib/AVFoundation_Swift3.swift
+++ b/test/stdlib/AVFoundation_Swift3.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t
 // RUN: %target-build-swift -swift-version 3 %s -o %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: objc_interop

--- a/test/stdlib/AVFoundation_Swift4.swift
+++ b/test/stdlib/AVFoundation_Swift4.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t
 // RUN: %target-build-swift -swift-version 4 %s -o %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: objc_interop

--- a/test/stdlib/AppKit_Swift3.swift
+++ b/test/stdlib/AppKit_Swift3.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t
 // RUN: %target-build-swift -swift-version 3 %s -o %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test

--- a/test/stdlib/AppKit_Swift4.swift
+++ b/test/stdlib/AppKit_Swift4.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t
 // RUN: %target-build-swift -swift-version 4 %s -o %t/a.out
 // RUN: %target-run %t/a.out
 // REQUIRES: executable_test

--- a/test/stdlib/Dispatch.swift
+++ b/test/stdlib/Dispatch.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-build-swift %s -o %t/a.out_swift3 -swift-version 3
 // RUN: %target-build-swift %s -o %t/a.out_swift4 -swift-version 4

--- a/test/stdlib/ErrorBridgedStatic.swift
+++ b/test/stdlib/ErrorBridgedStatic.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-clang -fmodules -c -o %t/ErrorBridgedStaticImpl.o %S/Inputs/ErrorBridgedStaticImpl.m 
 // RUN: %target-build-swift -static-stdlib -o %t/ErrorBridgedStatic %t/ErrorBridgedStaticImpl.o %s -import-objc-header %S/Inputs/ErrorBridgedStaticImpl.h

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -9,7 +9,8 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-// RUN: rm -rf %t ; mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %gyb -DWORD_BITS=%target-ptrsize %s -o %t/Integers.swift
 // RUN: %line-directive %t/Integers.swift -- %target-build-swift %t/Integers.swift -swift-version 4 -Onone -o %t/a.out
 // RUN: %line-directive %t/Integers.swift -- %target-run %t/a.out

--- a/test/stdlib/Intents.swift
+++ b/test/stdlib/Intents.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir %t
 // RUN: %target-build-swift %s -o %t/a.out3 -swift-version 3 && %target-run %t/a.out3
 // RUN: %target-build-swift %s -o %t/a.out4 -swift-version 4 && %target-run %t/a.out4
 // REQUIRES: executable_test

--- a/test/stdlib/LazyCollectionPlus.swift
+++ b/test/stdlib/LazyCollectionPlus.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t ; mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %target-build-swift %s -o %t/a.out3 -swift-version 3 && %target-run %t/a.out3
 // REQUIRES: executable_test
 

--- a/test/stdlib/LazySlice.swift
+++ b/test/stdlib/LazySlice.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t ; mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %target-build-swift %s -o %t/a.out3 -swift-version 3 && %target-run %t/a.out3
 // REQUIRES: executable_test
 

--- a/test/stdlib/MapFilterLayerFoldingCompatibilty.swift
+++ b/test/stdlib/MapFilterLayerFoldingCompatibilty.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t ; mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %target-build-swift %s -o %t/a.out3 -swift-version 3 && %target-run %t/a.out3
 // RUN: %target-build-swift %s -o %t/a.out4 -swift-version 4 && %target-run %t/a.out4
 // RUN: %target-build-swift %s -o %t/a.out5 -swift-version 5 && %target-run %t/a.out5

--- a/test/stdlib/Metal.swift
+++ b/test/stdlib/Metal.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t ; mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %target-build-swift %s -o %t/a.out4 -swift-version 4 && %target-run %t/a.out4
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos

--- a/test/stdlib/MetalKit.swift
+++ b/test/stdlib/MetalKit.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t ; mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %target-build-swift %s -o %t/a.out4 -swift-version 4 && %target-run %t/a.out4
 // REQUIRES: objc_interop
 // UNSUPPORTED: OS=watchos

--- a/test/stdlib/NSStringAPI+Substring.swift
+++ b/test/stdlib/NSStringAPI+Substring.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t ; mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %target-build-swift %s -o %t/a.out4 -swift-version 4 && %target-run %t/a.out4
 // REQUIRES: executable_test
 

--- a/test/stdlib/NSValueBridging.swift.gyb
+++ b/test/stdlib/NSValueBridging.swift.gyb
@@ -9,7 +9,8 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-// RUN: rm -rf %t  &&  mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %gyb %s -o %t/NSValueBridging.swift
 // RUN: %target-build-swift -g -module-name a %t/NSValueBridging.swift -o %t.out
 // RUN: %target-run %t.out

--- a/test/stdlib/ParameterPassing.swift.gyb
+++ b/test/stdlib/ParameterPassing.swift.gyb
@@ -9,7 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %gyb %s -o %t/ParameterPassing.swift
 // RUN: %line-directive %t/ParameterPassing.swift -- %target-build-swift %t/ParameterPassing.swift -o %t/a.out_Release -O

--- a/test/stdlib/RangeReplaceableFilterCompatibility.swift
+++ b/test/stdlib/RangeReplaceableFilterCompatibility.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t ; mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %target-build-swift %s -o %t/a.out3 -swift-version 3 && %target-run %t/a.out3
 // RUN: %target-build-swift %s -o %t/a.out4 -swift-version 4 && %target-run %t/a.out4
 

--- a/test/stdlib/SIMDParameterPassing.swift.gyb
+++ b/test/stdlib/SIMDParameterPassing.swift.gyb
@@ -9,7 +9,7 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %gyb %s -o %t/SIMDParameterPassing.swift
 // RUN: %line-directive %t/SIMDParameterPassing.swift -- %target-build-swift %t/SIMDParameterPassing.swift -o %t/a.out_Release -O

--- a/test/stdlib/StringCompatibility.swift
+++ b/test/stdlib/StringCompatibility.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t ; mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %target-build-swift %s -o %t/a.out3 -swift-version 3 && %target-run %t/a.out3
 // RUN: %target-build-swift %s -o %t/a.out4 -swift-version 4 && %target-run %t/a.out4
 

--- a/test/stdlib/StringFlatMap.swift
+++ b/test/stdlib/StringFlatMap.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t ; mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %target-build-swift %s -o %t/a.out3 -swift-version 3 && %target-run %t/a.out3
 // RUN: %target-build-swift %s -o %t/a.out4 -swift-version 4 && %target-run %t/a.out4
 

--- a/test/stdlib/TestDecimal.swift
+++ b/test/stdlib/TestDecimal.swift
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 //
 // RUN: %target-clang %S/Inputs/FoundationBridge/FoundationBridge.m -c -o %t/FoundationBridgeObjC.o -g

--- a/test/stdlib/TestFileManager.swift
+++ b/test/stdlib/TestFileManager.swift
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 //
 // RUN: %target-clang %S/Inputs/FoundationBridge/FoundationBridge.m -c -o %t/FoundationBridgeObjC.o -g

--- a/test/stdlib/TestNotification.swift
+++ b/test/stdlib/TestNotification.swift
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 //
 // RUN: %target-clang %S/Inputs/FoundationBridge/FoundationBridge.m -c -o %t/FoundationBridgeObjC.o -g

--- a/test/stdlib/UIKit.swift
+++ b/test/stdlib/UIKit.swift
@@ -1,4 +1,5 @@
-// RUN: rm -rf %t && mkdir -p %t
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t
 // RUN: %target-build-swift -swift-version 3 %s -o %t/a.out3 && %target-run %t/a.out3
 // RUN: %target-build-swift -swift-version 4 %s -o %t/a.out4 && %target-run %t/a.out4
 // REQUIRES: executable_test

--- a/test/stdlib/collection-combinatorics.swift.gyb
+++ b/test/stdlib/collection-combinatorics.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %gyb %s > %t/collection-combinatorics.swift
 // RUN: %target-swift-frontend -typecheck -verify %t/collection-combinatorics.swift

--- a/test/stmt/errors_nonobjc.swift
+++ b/test/stmt/errors_nonobjc.swift
@@ -1,4 +1,4 @@
-// RUN: rm -rf %t
+// RUN: %empty-directory(%t)
 // RUN: mkdir -p %t
 // RUN: %target-swift-frontend -emit-module -module-name Foundation -o %t/Foundation.swiftmodule %S/Inputs/Foundation-with-NSError.swift
 // RUN: %target-swift-frontend -I %t -typecheck -verify %s


### PR DESCRIPTION
This replaces most of the `rm -rf` with %empty-directory.  This allows
us to replace it with the appropriate command on different shells.  NFC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
