### PR TITLE
[SILGen] Use shared string constant for swift shims name in SILPrint

### DIFF
--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2634,7 +2634,7 @@ void SILModule::print(SILPrintContext &PrintCtx, ModuleDecl *M,
   }
   
   OS << "\n\nimport Builtin\nimport " << STDLIB_NAME
-     << "\nimport SwiftShims" << "\n\n";
+     << "\nimport " << SWIFT_SHIMS_NAME << "\n\n";
 
   // Print the declarations and types from the associated context (origin module or
   // current file).


### PR DESCRIPTION
It used to be "SwiftShims", but it would be better to use `SWIFT_SHIMS_NAME` defined in `String.h` instead in my opinion.