### PR TITLE
[Batch mode] Restore -### functionality for batch-mode by extending OutputLevel.

### DIFF
--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -51,6 +51,9 @@ namespace driver {
 enum class OutputLevel {
   /// Indicates that normal output should be produced.
   Normal,
+  
+  /// Indicates that only jobs should be printed and not run. (-###)
+  PrintJobs,
 
   /// Indicates that verbose output should be produced. (-v)
   Verbose,

--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -357,9 +357,6 @@ public:
   /// Print the list of Actions in a Compilation.
   void printActions(const Compilation &C) const;
 
-  /// Print the list of Jobs in a Compilation.
-  void printJobs(const Compilation &C) const;
-
   /// Print the driver version.
   void printVersion(const ToolChain &TC, raw_ostream &OS) const;
 

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -515,9 +515,9 @@ Driver::buildCompilation(const ToolChain &TC,
   bool DriverPrintDerivedOutputFileMap =
     ArgList->hasArg(options::OPT_driver_print_derived_output_file_map);
   DriverPrintBindings = ArgList->hasArg(options::OPT_driver_print_bindings);
-  bool DriverPrintJobs = ArgList->hasArg(options::OPT_driver_print_jobs);
   bool DriverSkipExecution =
-    ArgList->hasArg(options::OPT_driver_skip_execution);
+    ArgList->hasArg(options::OPT_driver_skip_execution,
+                    options::OPT_driver_print_jobs);
   bool ShowIncrementalBuildDecisions =
     ArgList->hasArg(options::OPT_driver_show_incremental);
   bool ShowJobLifecycle =
@@ -679,9 +679,12 @@ Driver::buildCompilation(const ToolChain &TC,
   }
 
   OutputLevel Level = OutputLevel::Normal;
-  if (const Arg *A = ArgList->getLastArg(options::OPT_v,
-                                         options::OPT_parseable_output)) {
-    if (A->getOption().matches(options::OPT_v))
+  if (const Arg *A =
+          ArgList->getLastArg(options::OPT_driver_print_jobs, options::OPT_v,
+                              options::OPT_parseable_output)) {
+    if (A->getOption().matches(options::OPT_driver_print_jobs))
+      Level = OutputLevel::PrintJobs;
+    else if (A->getOption().matches(options::OPT_v))
       Level = OutputLevel::Verbose;
     else if (A->getOption().matches(options::OPT_parseable_output))
       Level = OutputLevel::Parseable;
@@ -753,11 +756,6 @@ Driver::buildCompilation(const ToolChain &TC,
 
   if (DriverPrintBindings)
     return nullptr;
-
-  if (DriverPrintJobs) {
-    printJobs(*C);
-    return nullptr;
-  }
 
   return C;
 }
@@ -2620,11 +2618,6 @@ void Driver::printActions(const Compilation &C) const {
   for (const Action *A : C.getActions()) {
     ::printActions(A, Ids);
   }
-}
-
-void Driver::printJobs(const Compilation &C) const {
-  for (const Job *J : C.getJobs())
-    J->printCommandLineAndEnvironment(llvm::outs());
 }
 
 void Driver::printVersion(const ToolChain &TC, raw_ostream &OS) const {

--- a/test/Driver/batch_mode_print_jobs.swift
+++ b/test/Driver/batch_mode_print_jobs.swift
@@ -1,0 +1,18 @@
+// Ensure that the -### and -driver-print-jobs options work properly in batch
+// mode. They should each do the same thing, so test them both.
+//
+// Test be sure that the output does reflect the batching, in other words
+// multiple primary files. Also test to be sure that the output is on
+// stdout, and NOT stderr.
+
+
+// RUN: %empty-directory(%t)
+// RUN: touch %t/file-01.swift %t/file-02.swift %t/file-03.swift
+// RUN: echo 'public func main() {}' >%t/main.swift
+//
+// RUN: %swiftc_driver -enable-batch-mode -c -emit-module -module-name main -j 2 %t/file-01.swift %t/file-02.swift %t/file-03.swift %t/main.swift  -driver-print-jobs 2>%t/shouldBeEmpty1 | %FileCheck %s -check-prefix=CHECK-COMBINED
+// RUN: %swiftc_driver -enable-batch-mode -c -emit-module -module-name main -j 2 %t/file-01.swift %t/file-02.swift %t/file-03.swift %t/main.swift  -###  2>%t/shouldBeEmpty2 | %FileCheck %s  -check-prefix=CHECK-COMBINED
+// RUN: test -z "`cat %t/shouldBeEmpty1`"
+// RUN: test -z "`cat %t/shouldBeEmpty2`"
+//
+// CHECK-COMBINED: -primary-file {{.*}}/file-01.swift -primary-file {{.*}}/file-02.swift {{.*}}/file-03.swift {{.*}}/main.swift

--- a/test/Driver/embed-bitcode.swift
+++ b/test/Driver/embed-bitcode.swift
@@ -97,15 +97,15 @@
 // CHECK-LIB: -emit-bc
 // CHECK-LIB: -primary-file
 // CHECK-LIB: swift -frontend
+// CHECK-LIB: -c
+// CHECK-LIB: -embed-bitcode
+// CHECK-LIB: -disable-llvm-optzns
+// CHECK-LIB: swift -frontend
+// CHECK-LIB: -c
+// CHECK-LIB: -embed-bitcode
+// CHECK-LIB: -disable-llvm-optzns
+// CHECK-LIB: swift -frontend
 // CHECK-LIB: -emit-module
-// CHECK-LIB: swift -frontend
-// CHECK-LIB: -c
-// CHECK-LIB: -embed-bitcode
-// CHECK-LIB: -disable-llvm-optzns
-// CHECK-LIB: swift -frontend
-// CHECK-LIB: -c
-// CHECK-LIB: -embed-bitcode
-// CHECK-LIB: -disable-llvm-optzns
 // CHECK-LIB-NOT: swift -frontend
 
 // RUN: %target-swiftc_driver -embed-bitcode -emit-module %s 2>&1 -### | %FileCheck %s -check-prefix=WARN-EMBED-BITCODE


### PR DESCRIPTION
<!-- What's in this pull request? -->
The current implementation of the -### does not produce the right results for batch mode. This PR reimplements that drive option by extended the OutputLevel enumeration in the driver. It reuses the machinery that is already there.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->