### PR TITLE
[Do not merge] [Syntax] support invalid characters as trivia

### DIFF
--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -525,7 +525,8 @@ private:
   void lexEscapedIdentifier();
 
   void tryLexEditorPlaceholder();
-  const char *findEndOfCurlyQuoteStringLiteral(const char*);
+  const char *findEndOfCurlyQuoteStringLiteral(const char *,
+                                               bool EmitDiagnostics);
 
   /// Try to lex conflict markers by checking for the presence of the start and
   /// end of the marker in diff3 or Perforce style respectively.
@@ -534,7 +535,7 @@ private:
   NulCharacterKind getNulCharacterKind(const char *Ptr) const;
 
   /// Lex invalid characters and return which it should be tokenized.
-  bool lexInvalidCharacters(const char *&Ptr);
+  bool lexInvalidCharacters(const char *&Ptr, bool InLexTrivia);
 };
   
 /// Given an ordered token \param Array , get the iterator pointing to the first

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -532,6 +532,9 @@ private:
   bool tryLexConflictMarker(bool EatNewline);
 
   NulCharacterKind getNulCharacterKind(const char *Ptr) const;
+
+  /// Lex invalid characters and return which it should be tokenized.
+  bool lexInvalidCharacters(const char *&Ptr);
 };
   
 /// Given an ordered token \param Array , get the iterator pointing to the first

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1739,8 +1739,9 @@ void Lexer::lexStringLiteral() {
 /// string literal, diagnose the problem and return a pointer to the end of the
 /// entire string literal.  This helps us avoid parsing the body of the string
 /// as program tokens, which will only lead to massive confusion.
-const char *Lexer::findEndOfCurlyQuoteStringLiteral(const char *Body) {
-  
+const char *Lexer::findEndOfCurlyQuoteStringLiteral(const char *Body,
+                                                    bool EmitDiagnostics) {
+
   while (true) {
     // Don't bother with string interpolations.
     if (*Body == '\\' && *(Body + 1) == '(')
@@ -1752,7 +1753,7 @@ const char *Lexer::findEndOfCurlyQuoteStringLiteral(const char *Body) {
 
     // Get the next character.
     const char *CharStart = Body;
-    unsigned CharValue = lexCharacter(Body, '\0', false);
+    unsigned CharValue = lexCharacter(Body, '\0', /*EmitDiagnostics=*/false);
     // If the character was incorrectly encoded, give up.
     if (CharValue == ~1U) return nullptr;
     
@@ -1764,8 +1765,11 @@ const char *Lexer::findEndOfCurlyQuoteStringLiteral(const char *Body) {
     // If we found an ending curly quote (common since this thing started with
     // an opening curly quote) diagnose it with a fixit and then return.
     if (CharValue == 0x0000201D) {
-      diagnose(CharStart, diag::lex_invalid_curly_quote)
-        .fixItReplaceChars(getSourceLoc(CharStart), getSourceLoc(Body), "\"");
+      if (EmitDiagnostics) {
+        diagnose(CharStart, diag::lex_invalid_curly_quote)
+            .fixItReplaceChars(getSourceLoc(CharStart), getSourceLoc(Body),
+                               "\"");
+      }
       return Body;
     }
     
@@ -1875,7 +1879,9 @@ Lexer::NulCharacterKind Lexer::getNulCharacterKind(const char *Ptr) const {
   return NulCharacterKind::Embedded;
 }
 
-bool Lexer::lexInvalidCharacters(const char *&Ptr) {
+bool Lexer::lexInvalidCharacters(const char *&Ptr, bool InLexTrivia) {
+  // in lexTrivia, diagnose only when its should not be tokenize.
+
   assert(Ptr != nullptr);
 
   const char *const StartPtr = Ptr;
@@ -1883,7 +1889,9 @@ bool Lexer::lexInvalidCharacters(const char *&Ptr) {
   if (advanceIfValidContinuationOfIdentifier(Ptr, BufferEnd)) {
     // If this is a valid identifier continuation, but not a valid identifier
     // start, attempt to recover by eating more continuation characters.
-    diagnose(StartPtr, diag::lex_invalid_identifier_start_character);
+    if (!InLexTrivia) {
+      diagnose(StartPtr, diag::lex_invalid_identifier_start_character);
+    }
     while (advanceIfValidContinuationOfIdentifier(Ptr, BufferEnd))
       ;
     return true;
@@ -1900,18 +1908,21 @@ bool Lexer::lexInvalidCharacters(const char *&Ptr) {
 
   if (codepoint == 0x0000201D) {
     // If this is an end curly quote, just diagnose it with a fixit hint.
-    diagnose(CurPtr - 1, diag::lex_invalid_curly_quote)
-        .fixItReplaceChars(getSourceLoc(StartPtr), getSourceLoc(Ptr), "\"");
+    if (!InLexTrivia) {
+      diagnose(CurPtr - 1, diag::lex_invalid_curly_quote)
+          .fixItReplaceChars(getSourceLoc(StartPtr), getSourceLoc(Ptr), "\"");
+    }
     return true;
   }
 
   if (codepoint == 0x0000201C) {
     const char *const LeftQuoteEndPtr = Ptr;
+    bool EmitDiagnostics = !InLexTrivia;
 
     // If this is a start curly quote, do a fuzzy match of a string literal
     // to improve recovery.
     if (const char *const RightQuoteEndPtr =
-            findEndOfCurlyQuoteStringLiteral(Ptr)) {
+            findEndOfCurlyQuoteStringLiteral(Ptr, EmitDiagnostics)) {
       Ptr = RightQuoteEndPtr;
     }
 
@@ -1920,10 +1931,11 @@ bool Lexer::lexInvalidCharacters(const char *&Ptr) {
     // This, in turn, works better with our error recovery because we won't
     // diagnose an end curly quote in the middle of a straight quoted
     // literal.
-    diagnose(StartPtr, diag::lex_invalid_curly_quote)
-        .fixItReplaceChars(getSourceLoc(StartPtr),
-                           getSourceLoc(LeftQuoteEndPtr), "\"");
-
+    if (EmitDiagnostics) {
+      diagnose(StartPtr, diag::lex_invalid_curly_quote)
+          .fixItReplaceChars(getSourceLoc(StartPtr),
+                             getSourceLoc(LeftQuoteEndPtr), "\"");
+    }
     return true;
   }
 
@@ -2174,7 +2186,7 @@ Restart:
     if (advanceIfValidStartOfOperator(tmp, BufferEnd))
       return lexOperatorIdentifier();
 
-    bool ShouldTokenize = lexInvalidCharacters(tmp);
+    bool ShouldTokenize = lexInvalidCharacters(tmp, /*InLexTrivia=*/false);
     CurPtr = tmp;
 
     if (ShouldTokenize) {

--- a/test/Syntax/round_trip_invalids.swift
+++ b/test/Syntax/round_trip_invalids.swift
@@ -1,0 +1,23 @@
+// To know about setup, see `tokens_invalids.swift`.
+
+// RUN: cat %s > %t
+// RUN: cat %t | sed 's/'$(echo -ne "\x5a1")'/'$(echo -ne "\xc2")'/g' > %t.sed
+// RUN: cp -f %t.sed %t
+// RUN: cat %t | sed 's/'$(echo -ne "\x5a2")'/'$(echo -ne "\xcc\x82")'/g' > %t.sed
+// RUN: cp -f %t.sed %t
+// RUN: cat %t | sed 's/'$(echo -ne "\x5a3")'/'$(echo -ne "\xe2\x80\x9d")'/g' > %t.sed
+// RUN: cp -f %t.sed %t
+// RUN: cat %t | sed 's/'$(echo -ne "\x5a4")'/'$(echo -ne "\xe2\x80\x9c")'/g' > %t.sed
+// RUN: cp -f %t.sed %t
+// RUN: cat %t | sed 's/'$(echo -ne "\x5a5")'/'$(echo -ne "\xe1\x9a\x80")'/g' > %t.sed
+// RUN: cp -f %t.sed %t
+
+// RUN: %round-trip-syntax-test --swift-syntax-test %swift-syntax-test --file %t
+
+x
+Z1 x
+Z2
+Z3
+Z4
+Z4 abcdef Z3
+Z5 x

--- a/test/Syntax/tokens_invalids.swift
+++ b/test/Syntax/tokens_invalids.swift
@@ -1,0 +1,79 @@
+// RUN: cat %s > %t
+
+// 5a is Z. "ZN" style marker is used for marker. N is number.
+
+// C2 is utf8 2 byte character start byte.
+// RUN: cat %t | sed 's/'$(echo -ne "\x5a1")'/'$(echo -ne "\xc2")'/g' > %t.sed
+// RUN: cp -f %t.sed %t
+
+// CC 82 is U+0302, invalid for identifier start, valid for identifier body.
+// RUN: cat %t | sed 's/'$(echo -ne "\x5a2")'/'$(echo -ne "\xcc\x82")'/g' > %t.sed
+// RUN: cp -f %t.sed %t
+
+// E2 80 9D is U+201D, right quote.
+// RUN: cat %t | sed 's/'$(echo -ne "\x5a3")'/'$(echo -ne "\xe2\x80\x9d")'/g' > %t.sed
+// RUN: cp -f %t.sed %t
+
+// E2 80 9C is U+201C, left quote.
+// RUN: cat %t | sed 's/'$(echo -ne "\x5a4")'/'$(echo -ne "\xe2\x80\x9c")'/g' > %t.sed
+// RUN: cp -f %t.sed %t
+
+// E1 9A 80 is U+1680, invalid for swift source.
+// RUN: cat %t | sed 's/'$(echo -ne "\x5a5")'/'$(echo -ne "\xe1\x9a\x80")'/g' > %t.sed
+// RUN: cp -f %t.sed %t
+
+// RUN: %swift-syntax-test -input-source-filename %t -dump-full-tokens 2>&1 | %FileCheck %t
+
+x
+Z1 x
+Z2
+Z3
+Z4
+Z4 abcdef Z3
+Z5 x
+
+// test diagnostics.
+
+// CHECK: 28:1: error: invalid UTF-8 found in source file
+// CHECK: 29:1: error: an identifier cannot begin with this character
+// CHECK: 30:1: error: unicode curly quote found
+// CHECK: 31:1: error: unicode curly quote found
+// CHECK: 32:12: error: unicode curly quote found
+// CHECK: 32:1: error: unicode curly quote found
+// CHECK: 33:1: error: invalid character in source file
+
+// test tokens and trivias.
+
+// CHECK-LABEL: 28:3
+// CHECK-NEXT:  (Token identifier
+// CHECK-NEXT:   (trivia newline 1)
+// CHECK-NEXT:   (trivia garbage_text \302)
+// CHECK-NEXT:   (trivia space 1)
+// CHECK-NEXT:   (text="x"))
+
+// CHECK-LABEL: 29:1
+// CHECK-NEXT:  (Token unknown
+// CHECK-NEXT:   (trivia newline 1)
+// CHECK-NEXT:   (text="\xCC\x82"))
+
+// CHECK-LABEL: 30:1
+// CHECK-NEXT:  (Token unknown
+// CHECK-NEXT:   (trivia newline 1)
+// CHECK-NEXT:   (text="\xE2\x80\x9D"))
+
+// CHECK-LABEL: 31:1
+// CHECK-NEXT:  (Token unknown
+// CHECK-NEXT:   (trivia newline 1)
+// CHECK-NEXT:   (text="\xE2\x80\x9C"))
+
+// CHECK-LABEL: 32:1
+// CHECK-NEXT:  (Token unknown
+// CHECK-NEXT:   (trivia newline 1)
+// CHECK-NEXT:   (text="\xE2\x80\x9C abcdef \xE2\x80\x9D"))
+
+// CHECK-LABEL: 33:5
+// CHECK-NEXT:  (Token identifier
+// CHECK-NEXT:   (trivia newline 1)
+// CHECK-NEXT:   (trivia garbage_text \341\232\200)
+// CHECK-NEXT:   (trivia space 1)
+// CHECK-NEXT:   (text="x"))


### PR DESCRIPTION
~~This PR follows my previous PR #14962.
I will rebase this after previous PR is merged.~~

This PR update Lexer to support invalid characters as trivia.
Currently, libSyntax does not support them, so round trip conversion is failed if source file contains them.

Invalid characters meaning in here are invalid utf-8 byte sequence and invalid unicode code point for Swift source.
`lexImpl` skip them and diagnose to replace them to white space.
In others, contiguous characters which is valid for body of identifier but not start becomes to unknown token.
U+201D (unicode right quote) becomes single character unknown token.
U+201C (unicode left quote) becomes single character unknown token.
U+201C [text...] U+201D becomes one long unknown token.

To keep this behavior and convert skipping case to trivia,
I split logic into `lexInvalidCharacters` function from `lexImpl`.
And I made `isStartOfInvalidCharacters` function which judge a position is start point of this.

Implementation of `isStartOfInvalidCharacters` repeats logic in switch-case flow in `lexImpl`, 
so I think that is bad. But I still not have better idea.

A test case `round_trip_invalids.swift` checks round trip about these characters.
A test case `tokens_invalids.swift` checks diagnostic messages about them and token, trivia conversion.
If invalid bytes and chars written in test file directly,
it makes hard to read and edit.
So I use `sed` in `RUN` to embed these bytes to file in runtime.

I think that finally this PR makes libSyntax perfect for round trip functionality
with arbitraly source code even if it is not valid UTF-8 text.