### PR TITLE
[Metadata] Define _objc_empty_cache under SWIF_OBJC_INTEROP.

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -226,7 +226,7 @@ static GenericMetadataCache &unsafeGetInitializedCache(
   return lazyCache->unsafeGetAlreadyInitialized();
 }
 
-#ifndef NDEBUG
+#if SWIFT_OBJC_INTEROP
 extern "C" void *_objc_empty_cache;
 #endif
 


### PR DESCRIPTION
Later code uses the variable under this macro, so defining it
under NDEBUG breaks debug builds of stdlib.