### PR TITLE
[gardening] [stdlib] Match actual method names in an internal comment

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -884,8 +884,8 @@ def overflowOperationComment(operator):
 # operator:
 #     +   unsafeAdding(_:)
 #     -   unsafeSubtracting(_:)
-#     *   unsafeMultiplying(_:)
-#     /   unsafeDividing(by:)
+#     *   unsafeMultiplied(by:)
+#     /   unsafeDivided(by:)
 def unsafeOperationComment(operator):
     comments = {
         '+': """\


### PR DESCRIPTION
Align the names of some `unsafe*` operations in an internal comment to the actual names of these methods.

I get these wrong all the time, but it'd be nice if the internal comments didn't.
NFC.
