### PR TITLE
[IRGen] Cond. conformance witness table count isn't needed dynamically.

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -2145,7 +2145,7 @@ struct TargetGenericWitnessTable {
   /// The instantiation function, which is called after the template is copied.
   RelativeDirectPointer<void(TargetWitnessTable<Runtime> *instantiatedTable,
                              const TargetMetadata<Runtime> *type,
-                             void * const *instantiationArgs),
+                             void ** const *instantiationArgs),
                         /*nullable*/ true> Instantiator;
 
   using PrivateDataType = void *[swift::NumGenericMetadataPrivateDataWords];
@@ -3435,7 +3435,7 @@ SWIFT_RUNTIME_EXPORT
 const WitnessTable *
 swift_getGenericWitnessTable(GenericWitnessTable *genericTable,
                              const Metadata *type,
-                             void * const *instantiationArgs);
+                             void **const *instantiationArgs);
 
 /// \brief Fetch a uniqued metadata for a function type.
 SWIFT_RUNTIME_EXPORT

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -823,12 +823,12 @@ FUNCTION(AllocateGenericValueMetadata, swift_allocateGenericValueMetadata,
 // const ProtocolWitnessTable *
 // swift_getGenericWitnessTable(GenericProtocolWitnessTable *genericTable,
 //                              const Metadata *type,
-//                              void * const *instantiationArgs);
+//                              void ** const *instantiationArgs);
 FUNCTION(GetGenericWitnessTable, swift_getGenericWitnessTable, C_CC,
          RETURNS(WitnessTablePtrTy),
          ARGS(getGenericWitnessTableCacheTy()->getPointerTo(),
               TypeMetadataPtrTy,
-              Int8PtrPtrTy),
+              WitnessTablePtrPtrTy),
          ATTRS(NoUnwind, ReadOnly))
 
 // Metadata *swift_getMetatypeMetadata(Metadata *instanceTy);

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3986,8 +3986,7 @@ IRGenModule::getAddrOfWitnessTableAccessFunction(
     // conditional requirements are passed indirectly, as an array of witness
     // tables.
     fnType = llvm::FunctionType::get(
-        WitnessTablePtrTy, {TypeMetadataPtrTy, WitnessTablePtrPtrTy, SizeTy},
-        false);
+        WitnessTablePtrTy, {TypeMetadataPtrTy, WitnessTablePtrPtrTy}, false);
   } else {
     fnType = llvm::FunctionType::get(WitnessTablePtrTy, false);
   }

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1760,12 +1760,11 @@ void WitnessTableBuilder::buildAccessFunction(llvm::Constant *wtable) {
 
   if (Conformance.witnessTableAccessorRequiresArguments()) {
     metadata = params.claimNext();
-    auto conditionalReqtWtables = params.claimNext();
-    instantiationArgs =
-        IGF.Builder.CreateBitCast(conditionalReqtWtables, IGF.IGM.Int8PtrPtrTy);
+    instantiationArgs = params.claimNext();
   } else {
     metadata = llvm::ConstantPointerNull::get(IGF.IGM.TypeMetadataPtrTy);
-    instantiationArgs = llvm::ConstantPointerNull::get(IGF.IGM.Int8PtrPtrTy);
+    instantiationArgs =
+        llvm::ConstantPointerNull::get(IGF.IGM.WitnessTablePtrPtrTy);
   }
 
   // Okay, we need a cache.  Build the cache structure.

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -990,7 +990,7 @@ public:
                                               CanType conformingType) const = 0;
 };
 
-static std::pair<llvm::Value *, llvm::Value *>
+static llvm::Value *
 emitConditionalConformancesBuffer(IRGenFunction &IGF, CanType conformingType,
                                   const ProtocolConformance *conformance) {
   // Pointers to the witness tables, in the right order, which will be included
@@ -1034,13 +1034,9 @@ emitConditionalConformancesBuffer(IRGenFunction &IGF, CanType conformingType,
         return /*finished?*/ false;
       });
 
-  // No conditional requirements means no need for a buffer, and size == 0 means
-  // no reading of the pointer.
-  // FIXME(cond. conf. assert): once the dynamic assertion is removed from the
-  // instantiation function, we can have size as undef too.
+  // No conditional requirements means no need for a buffer.
   if (tables.empty()) {
-    return {llvm::UndefValue::get(IGF.IGM.WitnessTablePtrPtrTy),
-            llvm::ConstantInt::get(IGF.IGM.SizeTy, 0)};
+    return llvm::UndefValue::get(IGF.IGM.WitnessTablePtrPtrTy);
   }
 
   auto buffer = IGF.createAlloca(
@@ -1055,8 +1051,7 @@ emitConditionalConformancesBuffer(IRGenFunction &IGF, CanType conformingType,
     IGF.Builder.CreateStore(tables[idx], slot);
   }
 
-  auto count = llvm::ConstantInt::get(IGF.IGM.SizeTy, tables.size());
-  return {buffer.getAddress(), count};
+  return buffer.getAddress();
 }
 
 static llvm::Value *emitWitnessTableAccessorCall(
@@ -1074,12 +1069,11 @@ static llvm::Value *emitWitnessTableAccessorCall(
       *srcMetadataCache = IGF.emitTypeMetadataRef(conformingType);
     }
 
-    llvm::Value *conditionalTables, *numConditionalTables;
-    std::tie(conditionalTables, numConditionalTables) =
+    auto conditionalTables =
         emitConditionalConformancesBuffer(IGF, conformingType, conformance);
 
-    call = IGF.Builder.CreateCall(
-        accessor, {*srcMetadataCache, conditionalTables, numConditionalTables});
+    call = IGF.Builder.CreateCall(accessor,
+                                  {*srcMetadataCache, conditionalTables});
 
   } else {
     call = IGF.Builder.CreateCall(accessor, {});
@@ -1762,17 +1756,16 @@ void WitnessTableBuilder::buildAccessFunction(llvm::Constant *wtable) {
 
   Explosion params = IGF.collectParameters();
   llvm::Value *metadata;
-  llvm::Value *conditionalReqtWtables;
-  llvm::Value *numConditionalReqtWtables;
+  llvm::Value *instantiationArgs;
 
   if (Conformance.witnessTableAccessorRequiresArguments()) {
     metadata = params.claimNext();
-    conditionalReqtWtables = params.claimNext();
-    numConditionalReqtWtables = params.claimNext();
+    auto conditionalReqtWtables = params.claimNext();
+    instantiationArgs =
+        IGF.Builder.CreateBitCast(conditionalReqtWtables, IGF.IGM.Int8PtrPtrTy);
   } else {
     metadata = llvm::ConstantPointerNull::get(IGF.IGM.TypeMetadataPtrTy);
-    conditionalReqtWtables = nullptr;
-    numConditionalReqtWtables = llvm::ConstantInt::get(IGF.IGM.SizeTy, 0);
+    instantiationArgs = llvm::ConstantPointerNull::get(IGF.IGM.Int8PtrPtrTy);
   }
 
   // Okay, we need a cache.  Build the cache structure.
@@ -1803,7 +1796,6 @@ void WitnessTableBuilder::buildAccessFunction(llvm::Constant *wtable) {
 
   // We need an instantiation function if the base conformance
   // is non-dependent.
-  // TODO: the conformance might be conditional.
   llvm::Constant *instantiationFn;
   if (SpecializedBaseConformances.empty() &&
       ConditionalRequirementPrivateDataIndices.empty()) {
@@ -1845,31 +1837,9 @@ void WitnessTableBuilder::buildAccessFunction(llvm::Constant *wtable) {
   cacheData.finishAndSetAsInitializer(cache);
   cache->setConstant(true);
 
-  // Create the slice structure for the conditional conformances, which is
-  // passed as the last argument to the instantiation function.
-  // FIXME(cond. conf. assert): Elide this local/replace it with `undef` once
-  // the size assertion in the instantiation function is gone.
-  auto conditionalSlice =
-      IGF.createAlloca(IGF.IGM.WitnessTableSliceTy,
-                       IGF.IGM.getPointerAlignment(), "conditional.tables");
+  auto call = IGF.Builder.CreateCall(IGM.getGetGenericWitnessTableFn(),
+                                     {cache, metadata, instantiationArgs});
 
-  // Only store a pointer if it will be read. If not (i.e. size == 0/this
-  // conformance is unconditional), we can leave it as undef.
-  if (conditionalReqtWtables) {
-    auto tableSlot = IGF.Builder.CreateStructGEP(conditionalSlice, 0, Size(0));
-    IGF.Builder.CreateStore(conditionalReqtWtables, tableSlot);
-  }
-
-  auto sizeSlot = IGF.Builder.CreateStructGEP(conditionalSlice, 1,
-                                              Size(IGF.IGM.getPointerSize()));
-  IGF.Builder.CreateStore(numConditionalReqtWtables, sizeSlot);
-
-  auto instantiationArgs =
-      IGF.Builder.CreateBitCast(conditionalSlice, IGM.Int8PtrPtrTy);
-
-  auto call =
-      IGF.Builder.CreateCall(IGM.getGetGenericWitnessTableFn(),
-                             {cache, metadata, instantiationArgs.getAddress()});
   call->setDoesNotThrow();
 
   IGF.Builder.CreateRet(call);
@@ -1889,39 +1859,11 @@ llvm::Constant *WitnessTableBuilder::buildInstantiationFunction() {
   Explosion params = IGF.collectParameters();
   Address wtable(params.claimNext(), PointerAlignment);
   llvm::Value *metadata = params.claimNext();
-  Address instantiationArgs(params.claimNext(), PointerAlignment);
-
-  // The details of any conditional conformances are in the last argument, as a
-  // pointer/size pair.
-  auto conditionalTablesSlice = IGF.Builder.CreateElementBitCast(
-      instantiationArgs, IGF.IGM.WitnessTableSliceTy);
-
-  auto conditionalTablesPtr =
-      IGF.Builder.CreateStructGEP(conditionalTablesSlice, 0, Size(0));
-  Address conditionalTables(IGF.Builder.CreateLoad(conditionalTablesPtr),
-                            PointerAlignment);
-
-  auto numConditionalTablesPtr =
-    IGF.Builder.CreateStructGEP(conditionalTablesSlice, 1, Size(PointerSize));
-  auto numConditionalTables = IGF.Builder.CreateLoad(numConditionalTablesPtr);
-
-  // Assert that the number of witness tables passed in is the number required
-  // for the conditional conformances of this witness table.
-
-  // FIXME(cond. conf. assert): remove this once we're confident in conditional
-  // conformances and especially dynamic casting. (Look for the other
-  // 'cond. conf. assert' FIXMEs too.)
-  auto failBB = IGF.createBasicBlock("bad_witness_table_count");
-  auto contBB = IGF.createBasicBlock("cont");
-
-  auto cmp = IGF.Builder.CreateICmpEQ(
-      numConditionalTables,
-      llvm::ConstantInt::get(IGM.SizeTy,
-                             ConditionalRequirementPrivateDataIndices.size()));
-  IGF.Builder.CreateCondBr(cmp, contBB, failBB);
-
-  // All good: now we can actually fill in the witness table.
-  IGF.Builder.emitBlock(contBB);
+  llvm::Value *instantiationArgs = params.claimNext();
+  Address conditionalTables(
+      IGF.Builder.CreateBitCast(instantiationArgs,
+                                IGF.IGM.WitnessTablePtrPtrTy),
+      PointerAlignment);
 
   /// Run through the conditional conformance witness tables, pulling them out
   /// of the slice and putting them into the private data of the witness table.
@@ -1965,10 +1907,6 @@ llvm::Constant *WitnessTableBuilder::buildInstantiationFunction() {
 
 
   IGF.Builder.CreateRetVoid();
-
-  // The counts didn't match; abort.
-  IGF.Builder.emitBlock(failBB);
-  IGF.emitTrap(/*EmitUnreachable=*/true);
 
   return fn;
 }

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -398,8 +398,6 @@ IRGenModule::IRGenModule(IRGenerator &irgen,
   OpenedErrorTriplePtrTy = OpenedErrorTripleTy->getPointerTo(DefaultAS);
 
   WitnessTablePtrPtrTy = WitnessTablePtrTy->getPointerTo(DefaultAS);
-  WitnessTableSliceTy = createStructType(*this, "swift.witness_table_slice",
-                                         {WitnessTablePtrPtrTy, SizeTy});
 
   InvariantMetadataID = LLVMContext.getMDKindID("invariant.load");
   InvariantNode = llvm::MDNode::get(LLVMContext, {});

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -544,7 +544,6 @@ public:
   llvm::StructType *OpenedErrorTripleTy; /// { %swift.opaque*, %swift.type*, i8** }
   llvm::PointerType *OpenedErrorTriplePtrTy; /// { %swift.opaque*, %swift.type*, i8** }*
   llvm::PointerType *WitnessTablePtrPtrTy;   /// i8***
-  llvm::StructType *WitnessTableSliceTy;     /// { witness_table**, i64 }
 
   /// Used to create unique names for class layout types with tail allocated
   /// elements.

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2872,9 +2872,10 @@ allocateWitnessTable(GenericWitnessTable *genericTable,
   return entry;
 }
 
-const WitnessTable *swift::swift_getGenericWitnessTable(
-    GenericWitnessTable *genericTable, const Metadata *type,
-    void *const *instantiationArgs) {
+const WitnessTable *
+swift::swift_getGenericWitnessTable(GenericWitnessTable *genericTable,
+                                    const Metadata *type,
+                                    void **const *instantiationArgs) {
   if (doesNotRequireInstantiation(genericTable)) {
     return genericTable->Pattern;
   }

--- a/test/IRGen/associated_type_witness.swift
+++ b/test/IRGen/associated_type_witness.swift
@@ -136,8 +136,7 @@ struct Computed<T, U> : Assocked {
 //   Witness table accessor function for Computed : Assocked.
 // CHECK-LABEL: define hidden i8** @"$S23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWa"(%swift.type*, i8***)
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:     [[CAST_CONDITIONAL_TABLES:%.*]] = bitcast i8*** %1 to i8**
-// CHECK-NEXT:     [[WTABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWG", %swift.type* %0, i8** [[CAST_CONDITIONAL_TABLES]])
+// CHECK-NEXT:     [[WTABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWG", %swift.type* %0, i8*** %1)
 // CHECK-NEXT:     ret i8** [[WTABLE]]
 
 
@@ -180,8 +179,7 @@ struct GenericComputed<T: P> : DerivedFromSimpleAssoc {
 //   Witness table accessor function for GenericComputed : HasSimpleAssoc..
 // CHECK-LABEL: define hidden i8** @"$S23associated_type_witness15GenericComputedVyxGAA14HasSimpleAssocAAWa"(%swift.type*, i8***)
 // CHECK-NEXT:   entry:
-// CHECK-NEXT:    [[CAST_CONDITIONAL_TABLES:%.*]] = bitcast i8*** %1 to i8**
-// CHECK-NEXT:    [[WTABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S23associated_type_witness15GenericComputedVyxGAA14HasSimpleAssocAAWG", %swift.type* %0, i8** [[CAST_CONDITIONAL_TABLES]])
+// CHECK-NEXT:    [[WTABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S23associated_type_witness15GenericComputedVyxGAA14HasSimpleAssocAAWG", %swift.type* %0, i8*** %1)
 // CHECK-NEXT:    ret i8** [[WTABLE]]
 
 

--- a/test/IRGen/associated_type_witness.swift
+++ b/test/IRGen/associated_type_witness.swift
@@ -134,15 +134,10 @@ struct Computed<T, U> : Assocked {
 // CHECK-NEXT:    br label %cont
 
 //   Witness table accessor function for Computed : Assocked.
-// CHECK-LABEL: define hidden i8** @"$S23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWa"(%swift.type*, i8***, i64)
-// CHECK:         entry:
-// CHECK-NEXT:     %conditional.tables = alloca %swift.witness_table_slice, align 8
-// CHECK-NEXT:     [[TABLES:%.*]] = getelementptr inbounds %swift.witness_table_slice, %swift.witness_table_slice* %conditional.tables, i32 0, i32 0
-// CHECK-NEXT:     store i8*** %1, i8**** [[TABLES]], align 8
-// CHECK-NEXT:     [[COUNT:%.*]] = getelementptr inbounds %swift.witness_table_slice, %swift.witness_table_slice* %conditional.tables, i32 0, i32 1
-// CHECK-NEXT:     store i64 %2, i64* [[COUNT]], align 8
-// CHECK-NEXT:     [[INSTANTIATION_ARGS:%.*]] = bitcast %swift.witness_table_slice* %conditional.tables to i8**
-// CHECK-NEXT:     [[WTABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWG", %swift.type* %0, i8** [[INSTANTIATION_ARGS]])
+// CHECK-LABEL: define hidden i8** @"$S23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWa"(%swift.type*, i8***)
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:     [[CAST_CONDITIONAL_TABLES:%.*]] = bitcast i8*** %1 to i8**
+// CHECK-NEXT:     [[WTABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWG", %swift.type* %0, i8** [[CAST_CONDITIONAL_TABLES]])
 // CHECK-NEXT:     ret i8** [[WTABLE]]
 
 
@@ -176,22 +171,17 @@ struct GenericComputed<T: P> : DerivedFromSimpleAssoc {
 
 //   Instantiation function for GenericComputed : DerivedFromSimpleAssoc.
 // CHECK-LABEL: define internal void @"$S23associated_type_witness15GenericComputedVyxGAA22DerivedFromSimpleAssocAAWI"(i8**, %swift.type*, i8**)
-// CHECK:         [[T0:%.*]] = call i8** @"$S23associated_type_witness15GenericComputedVyxGAA14HasSimpleAssocAAWa"(%swift.type* %1, i8*** undef, i64 0)
+// CHECK:         [[T0:%.*]] = call i8** @"$S23associated_type_witness15GenericComputedVyxGAA14HasSimpleAssocAAWa"(%swift.type* %1, i8*** undef)
 // CHECK-NEXT:    [[T1:%.*]] = bitcast i8** [[T0]] to i8*
 // CHECK-NEXT:    [[T2:%.*]] = getelementptr inbounds i8*, i8** %0, i32 1
 // CHECK-NEXT:    store i8* [[T1]], i8** [[T2]], align 8
 // CHECK-NEXT:    ret void
 
 //   Witness table accessor function for GenericComputed : HasSimpleAssoc..
-// CHECK-LABEL: define hidden i8** @"$S23associated_type_witness15GenericComputedVyxGAA14HasSimpleAssocAAWa"(%swift.type*, i8***, i64)
+// CHECK-LABEL: define hidden i8** @"$S23associated_type_witness15GenericComputedVyxGAA14HasSimpleAssocAAWa"(%swift.type*, i8***)
 // CHECK-NEXT:   entry:
-// CHECK-NEXT:    %conditional.tables = alloca %swift.witness_table_slice, align 8
-// CHECK-NEXT:    [[TABLES:%.*]] = getelementptr inbounds %swift.witness_table_slice, %swift.witness_table_slice* %conditional.tables, i32 0, i32 0
-// CHECK-NEXT:    store i8*** %1, i8**** [[TABLES]], align 8
-// CHECK-NEXT:    [[COUNT:%.*]] = getelementptr inbounds %swift.witness_table_slice, %swift.witness_table_slice* %conditional.tables, i32 0, i32 1
-// CHECK-NEXT:    store i64 %2, i64* [[COUNT]], align 8
-// CHECK-NEXT:    [[INSTANTIATION_ARGS:%.*]] = bitcast %swift.witness_table_slice* %conditional.tables to i8**
-// CHECK-NEXT:    [[WTABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S23associated_type_witness15GenericComputedVyxGAA14HasSimpleAssocAAWG", %swift.type* %0, i8** [[INSTANTIATION_ARGS]])
+// CHECK-NEXT:    [[CAST_CONDITIONAL_TABLES:%.*]] = bitcast i8*** %1 to i8**
+// CHECK-NEXT:    [[WTABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S23associated_type_witness15GenericComputedVyxGAA14HasSimpleAssocAAWG", %swift.type* %0, i8** [[CAST_CONDITIONAL_TABLES]])
 // CHECK-NEXT:    ret i8** [[WTABLE]]
 
 

--- a/test/IRGen/partial_apply_forwarder.sil
+++ b/test/IRGen/partial_apply_forwarder.sil
@@ -94,7 +94,7 @@ sil hidden_external @takingEmptyAndQ : $@convention(thin) <τ_0_0 where  τ_0_0 
 // CHECK:   [[GENPARAMSADDR:%.*]] = bitcast %swift.type* [[TY]] to %swift.type**
 // CHECK:   [[PARAMTYADDR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[GENPARAMSADDR]], {{(i64 10|i32 13)}}
 // CHECK:   %"BaseProducer<\CF\84_0_1>" = load %swift.type*, %swift.type** [[PARAMTYADDR]]
-// CHECK:   [[WITNESS:%.*]] = call i8** @"$S23partial_apply_forwarder12BaseProducerVyxGAA1QAAWa"(%swift.type* %"BaseProducer<\CF\84_0_1>", i8*** undef, {{i32|i64}} 0)
+// CHECK:   [[WITNESS:%.*]] = call i8** @"$S23partial_apply_forwarder12BaseProducerVyxGAA1QAAWa"(%swift.type* %"BaseProducer<\CF\84_0_1>", i8*** undef)
 // CHECK:   [[OBJ:%.*]] = bitcast %swift.refcounted* %0 to %T23partial_apply_forwarder7WeakBoxC.1*
 // CHECK:   tail call swiftcc void @takingQ(%T23partial_apply_forwarder7WeakBoxC.1* [[OBJ]], i8** [[WITNESS]])
 // CHECK: }
@@ -151,7 +151,7 @@ bb0(%0 : $*τ_0_1, %2: $EmptyType):
 // CHECK:   [[TYPARAMSADDR:%.*]] = bitcast %swift.type* [[TY]] to %swift.type**
 // CHECK:   [[TYPARAM:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[TYPARAMSADDR]], {{(i64 10|i32 13)}}
 // CHECK:   %"BaseProducer<\CF\84_0_1>" = load %swift.type*, %swift.type** [[TYPARAM]]
-// CHECK:   [[WITNESS:%.*]] = call i8** @"$S23partial_apply_forwarder12BaseProducerVyxGAA1QAAWa"(%swift.type* %"BaseProducer<\CF\84_0_1>", i8*** undef, {{i32|i64}} 0)
+// CHECK:   [[WITNESS:%.*]] = call i8** @"$S23partial_apply_forwarder12BaseProducerVyxGAA1QAAWa"(%swift.type* %"BaseProducer<\CF\84_0_1>", i8*** undef)
 // CHECK:   tail call swiftcc void @takingQ(%T23partial_apply_forwarder7WeakBoxC.1* [[CAST]], i8** [[WITNESS]])
 // CHECK:   ret void
 
@@ -203,7 +203,7 @@ sil hidden_external @takingQAndS : $@convention(thin) <τ_0_0 where  τ_0_0 : Q>
 // CHECK:   [[GENPARAMSADDR:%.*]] = bitcast %swift.type* [[TY]] to %swift.type**
 // CHECK:   [[GENPARAMADDR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[GENPARAMSADDR]], {{(i64 10|i32 13)}}
 // CHECK:   %"BaseProducer<\CF\84_0_1>" = load %swift.type*, %swift.type** [[GENPARAMADDR]]
-// CHECK:   [[WITNESS:%.*]] = call i8** @"$S23partial_apply_forwarder12BaseProducerVyxGAA1QAAWa"(%swift.type* %"BaseProducer<\CF\84_0_1>", i8*** undef, {{i32|i64}} 0)
+// CHECK:   [[WITNESS:%.*]] = call i8** @"$S23partial_apply_forwarder12BaseProducerVyxGAA1QAAWa"(%swift.type* %"BaseProducer<\CF\84_0_1>", i8*** undef)
 // CHECK:   tail call swiftcc void @takingQAndS(i64 [[X]], %T23partial_apply_forwarder7WeakBoxC.1* %.asUnsubstituted, i8** [[WITNESS]])
 
 sil public @bind_polymorphic_param_from_context_with_layout : $@convention(thin) <τ_0_1>(@in τ_0_1, S) -> @owned @callee_owned () -> () {

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -296,7 +296,7 @@ bb0(%0 : $*ResilientConformingType):
 
 // CHECK-LABEL: define{{( protected)?}} i8** @"$S19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWa"()
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[WTABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWG", %swift.type* null, i8** null)
+// CHECK-NEXT:    [[WTABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWG", %swift.type* null, i8*** null)
 // CHECK-NEXT:    ret i8** [[WTABLE]]
 
 

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -296,11 +296,7 @@ bb0(%0 : $*ResilientConformingType):
 
 // CHECK-LABEL: define{{( protected)?}} i8** @"$S19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWa"()
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    %conditional.tables = alloca %swift.witness_table_slice
-// CHECK-NEXT:    [[COUNT_PTR:%.*]] = getelementptr inbounds %swift.witness_table_slice, %swift.witness_table_slice* %conditional.tables, i32 0, i32 1
-// CHECK-NEXT:    store [[WORD:i(32|64)]] 0, [[WORD:i(32|64)]]* [[COUNT_PTR]]
-// CHECK-NEXT:    [[INSTANTIATION_ARGS:%.*]] = bitcast %swift.witness_table_slice* %conditional.tables to i8**
-// CHECK-NEXT:    [[WTABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWG", %swift.type* null, i8** [[INSTANTIATION_ARGS]])
+// CHECK-NEXT:    [[WTABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWG", %swift.type* null, i8** null)
 // CHECK-NEXT:    ret i8** [[WTABLE]]
 
 

--- a/test/IRGen/witness_method.sil
+++ b/test/IRGen/witness_method.sil
@@ -65,7 +65,7 @@ struct SyncUp<Deliverable> : Synergy {
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @testGenericWitnessMethod(%swift.opaque* noalias nocapture sret, %T14witness_method6SyncUpV* noalias nocapture, %swift.type* %T)
 // CHECK: entry:
 // CHECK:   [[METADATA:%.*]] = call %swift.type* @"$S14witness_method6SyncUpVMa"(%swift.type* %T)
-// CHECK:   [[WTABLE:%.*]] = call i8** @"$S14witness_method6SyncUpVyxGAA7SynergyAAWa"(%swift.type* [[METADATA]], i8*** undef, {{i32|i64}} 0)
+// CHECK:   [[WTABLE:%.*]] = call i8** @"$S14witness_method6SyncUpVyxGAA7SynergyAAWa"(%swift.type* [[METADATA]], i8*** undef)
 // CHECK:   [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** [[WTABLE]], i32 2
 // CHECK:   [[WITNESS_FN:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
 // CHECK:   [[WITNESS:%.*]] = bitcast i8* [[WITNESS_FN]] to void (%swift.opaque*, %swift.opaque*, %swift.type*, i8**)*

--- a/test/Inputs/conditional_conformance_basic_conformances.swift
+++ b/test/Inputs/conditional_conformance_basic_conformances.swift
@@ -54,21 +54,16 @@ public func single_generic<T: P2>(_: T.Type) {
 // CHECK-NEXT:    [[CONDITIONAL_REQUIREMENTS:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* %conditional.requirement.buffer, i32 0, i32 0
 // CHECK-NEXT:    [[T_P2_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 0
 // CHECK-NEXT:    store i8** %T.P2, i8*** [[T_P2_PTR]], align 8
-// CHECK-NEXT:    [[Single_P1:%.*]] = call i8** @"$S42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWa"(%swift.type* [[Single_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]], i64 1)
+// CHECK-NEXT:    [[Single_P1:%.*]] = call i8** @"$S42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWa"(%swift.type* [[Single_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
 // CHECK-NEXT:    call swiftcc void @"$S42conditional_conformance_basic_conformances8takes_p1yyxmAA2P1RzlF"(%swift.type* [[Single_TYPE]], %swift.type* [[Single_TYPE]], i8** [[Single_P1]])
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
 
 // Witness table accessor for Single : P1
 
-// CHECK-LABEL: define{{( protected)?}} i8** @"$S42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWa"(%swift.type*, i8***, i64)
+// CHECK-LABEL: define{{( protected)?}} i8** @"$S42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWa"(%swift.type*, i8***)
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    %conditional.tables = alloca %swift.witness_table_slice, align 8
-// CHECK-NEXT:    [[TABLES_PTR:%.*]] = getelementptr inbounds %swift.witness_table_slice, %swift.witness_table_slice* %conditional.tables, i32 0, i32 0
-// CHECK-NEXT:    store i8*** %1, i8**** [[TABLES_PTR]], align 8
-// CHECK-NEXT:    [[COUNT_PTR:%.*]] = getelementptr inbounds %swift.witness_table_slice, %swift.witness_table_slice* %conditional.tables, i32 0, i32 1
-// CHECK-NEXT:    store i64 %2, i64* [[COUNT_PTR]], align 8
-// CHECK-NEXT:    [[CAST_CONDITIONAL_TABLES:%.*]] = bitcast %swift.witness_table_slice* %conditional.tables to i8**
+// CHECK-NEXT:    [[CAST_CONDITIONAL_TABLES:%.*]] = bitcast i8*** %1 to i8**
 // CHECK-NEXT:    [[TABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWG", %swift.type* %0, i8** [[CAST_CONDITIONAL_TABLES]])
 // CHECK-NEXT:    ret i8** [[TABLE]]
 // CHECK-NEXT:  }
@@ -102,7 +97,7 @@ public func single_concrete() {
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 0
 // CHECK-NEXT:    store i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$S42conditional_conformance_basic_conformances4IsP2VAA0F0AAWP", i32 0, i32 0), i8*** [[A_P2_PTR]], align 8
 
-// CHECK-NEXT:    [[Single_P1:%.*]] = call i8** @"$S42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWa"(%swift.type* [[Single_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]], i64 1)
+// CHECK-NEXT:    [[Single_P1:%.*]] = call i8** @"$S42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWa"(%swift.type* [[Single_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
 // CHECK-NEXT:    store atomic i8** [[Single_P1]], i8*** @"$S42conditional_conformance_basic_conformances6SingleVyAA4IsP2VGACyxGAA2P1A2A0G0RzlWL" release, align 8
 // CHECK-NEXT:    br label %cont
 
@@ -182,21 +177,16 @@ public func double_generic_generic<U: P2, V: P3>(_: U.Type, _: V.Type) {
 // CHECK-NEXT:    [[C_P3_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 1
 // CHECK-NEXT:    store i8** %V.P3, i8*** [[C_P3_PTR]], align 8
 
-// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @"$S42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlWa"(%swift.type* [[Double_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]], i64 2)
+// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @"$S42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlWa"(%swift.type* [[Double_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
 // CHECK-NEXT:    call swiftcc void @"$S42conditional_conformance_basic_conformances8takes_p1yyxmAA2P1RzlF"(%swift.type* [[Double_TYPE]], %swift.type* [[Double_TYPE]], i8** [[Double_P1]])
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
 
 // witness table accessor for Double : P1
 
-// CHECK-LABEL: define{{( protected)?}} i8** @"$S42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlWa"(%swift.type*, i8***, i64)
+// CHECK-LABEL: define{{( protected)?}} i8** @"$S42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlWa"(%swift.type*, i8***)
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    %conditional.tables = alloca %swift.witness_table_slice, align 8
-// CHECK-NEXT:    [[TABLES_PTR:%.*]] = getelementptr inbounds %swift.witness_table_slice, %swift.witness_table_slice* %conditional.tables, i32 0, i32 0
-// CHECK-NEXT:    store i8*** %1, i8**** [[TABLES_PTR]], align 8
-// CHECK-NEXT:    [[COUNT_PTR:%.*]] = getelementptr inbounds %swift.witness_table_slice, %swift.witness_table_slice* %conditional.tables, i32 0, i32 1
-// CHECK-NEXT:    store i64 %2, i64* [[COUNT_PTR]], align 8
-// CHECK-NEXT:    [[CAST_CONDITIONAL_TABLES:%.*]] = bitcast %swift.witness_table_slice* %conditional.tables to i8**
+// CHECK-NEXT:    [[CAST_CONDITIONAL_TABLES:%.*]] = bitcast i8*** %1 to i8**
 // CHECK-NEXT:    [[TABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlWG", %swift.type* %0, i8** [[CAST_CONDITIONAL_TABLES]])
 // CHECK-NEXT:    ret i8** [[TABLE]]
 // CHECK-NEXT:  }
@@ -216,7 +206,7 @@ public func double_generic_concrete<X: P2>(_: X.Type) {
 // CHECK-NEXT:    [[C_P3_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 1
 // CHECK-NEXT:    store i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$S42conditional_conformance_basic_conformances4IsP3VAA0F0AAWP", i32 0, i32 0), i8*** [[C_P3_PTR]], align 8
 
-// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @"$S42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlWa"(%swift.type* %1, i8*** [[CONDITIONAL_REQUIREMENTS]], i64 2)
+// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @"$S42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlWa"(%swift.type* %1, i8*** [[CONDITIONAL_REQUIREMENTS]])
 // CHECK-NEXT:    call swiftcc void @"$S42conditional_conformance_basic_conformances8takes_p1yyxmAA2P1RzlF"(%swift.type* [[Double_TYPE]], %swift.type* [[Double_TYPE]], i8** [[Double_P1]])
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
@@ -250,7 +240,7 @@ public func double_concrete_concrete() {
 // CHECK-NEXT:    [[C_P3_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 1
 // CHECK-NEXT:    store i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$S42conditional_conformance_basic_conformances4IsP3VAA0F0AAWP", i32 0, i32 0), i8*** [[C_P3_PTR]], align 8
 
-// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @"$S42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlWa"(%swift.type* [[Double_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]], i64 2)
+// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @"$S42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlWa"(%swift.type* [[Double_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
 // CHECK-NEXT:    store atomic i8** [[Double_P1]], i8*** @"$S42conditional_conformance_basic_conformances6DoubleVyAA4IsP2VAA0F2P3VGACyxq_GAA2P1A2A0G0RzAA0H0R_rlWL" release, align 8
 // CHECK-NEXT:    br label %cont
 
@@ -266,15 +256,8 @@ public func double_concrete_concrete() {
 
 // CHECK-LABEL: define internal void @"$S42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWI"(i8**, %swift.type*, i8**)
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CONDITIONAL_TABLE_SLICE:%.*]] = bitcast i8** %2 to %swift.witness_table_slice*
-// CHECK-NEXT:    [[TABLES_PTR:%.*]] = getelementptr inbounds %swift.witness_table_slice, %swift.witness_table_slice* [[CONDITIONAL_TABLE_SLICE]], i32 0, i32 0
-// CHECK-NEXT:    [[TABLES:%.*]] = load i8***, i8**** [[TABLES_PTR]], align 8
-// CHECK-NEXT:    [[COUNT_PTR:%.*]] = getelementptr inbounds %swift.witness_table_slice, %swift.witness_table_slice* [[CONDITIONAL_TABLE_SLICE]], i32 0, i32 1
-// CHECK-NEXT:    [[COUNT:%.*]] = load i64, i64* [[COUNT_PTR]], align 8
-// CHECK-NEXT:    [[COND:%.*]] = icmp eq i64 [[COUNT]], 1
-// CHECK-NEXT:    br i1 [[COND]], label %cont, label %bad_witness_table_count
+// CHECK-NEXT:    [[TABLES:%.*]] = bitcast i8** %2 to i8***
 
-// CHECK:       cont:
 // CHECK-NEXT:    [[A_P2_SRC:%.*]] = getelementptr inbounds i8**, i8*** [[TABLES]], i32 0
 // CHECK-NEXT:    [[A_P2_DEST:%.*]] = getelementptr inbounds i8*, i8** %0, i32 -1
 // CHECK-NEXT:    [[A_P2:%.*]] = load i8**, i8*** [[A_P2_SRC]], align 8
@@ -282,25 +265,14 @@ public func double_concrete_concrete() {
 // CHECK-NEXT:    store i8** [[A_P2]], i8*** [[CAST_A_P2_DEST]], align 8
 
 // CHECK-NEXT:    ret void
-
-// CHECK:       bad_witness_table_count:
-// CHECK-NEXT:    call void @llvm.trap()
-// CHECK-NEXT:    unreachable
 // CHECK-NEXT:  }
 
 // witness table instantiator for Double : P1
 
 // CHECK-LABEL: define internal void @"$S42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlWI"(i8**, %swift.type*, i8**)
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CONDITIONAL_TABLE_SLICE:%.*]] = bitcast i8** %2 to %swift.witness_table_slice*
-// CHECK-NEXT:    [[TABLES_PTR:%.*]] = getelementptr inbounds %swift.witness_table_slice, %swift.witness_table_slice* [[CONDITIONAL_TABLE_SLICE]], i32 0, i32 0
-// CHECK-NEXT:    [[TABLES:%.*]] = load i8***, i8**** [[TABLES_PTR]], align 8
-// CHECK-NEXT:    [[COUNT_PTR:%.*]] = getelementptr inbounds %swift.witness_table_slice, %swift.witness_table_slice* [[CONDITIONAL_TABLE_SLICE]], i32 0, i32 1
-// CHECK-NEXT:    [[COUNT:%.*]] = load i64, i64* [[COUNT_PTR]], align 8
-// CHECK-NEXT:    [[COND:%.*]] = icmp eq i64 [[COUNT]], 2
-// CHECK-NEXT:    br i1 [[COND]], label %cont, label %bad_witness_table_count
+// CHECK-NEXT:    [[TABLES:%.*]] = bitcast i8** %2 to i8***
 
-// CHECK:       cont:
 // CHECK-NEXT:    [[B_P2_SRC:%.*]] = getelementptr inbounds i8**, i8*** [[TABLES]], i32 0
 // CHECK-NEXT:    [[B_P2_DEST:%.*]] = getelementptr inbounds i8*, i8** %0, i32 -1
 // CHECK-NEXT:    [[B_P2:%.*]] = load i8**, i8*** [[B_P2_SRC]], align 8
@@ -314,10 +286,6 @@ public func double_concrete_concrete() {
 // CHECK-NEXT:    store i8** [[C_P3]], i8*** [[CAST_C_P3_DEST]], align 8
 
 // CHECK-NEXT:    ret void
-
-// CHECK:       bad_witness_table_count:
-// CHECK-NEXT:    call void @llvm.trap()
-// CHECK-NEXT:    unreachable
 // CHECK-NEXT:  }
 
 func dynamicCastToP1(_ value: Any) -> P1? {

--- a/test/Inputs/conditional_conformance_basic_conformances.swift
+++ b/test/Inputs/conditional_conformance_basic_conformances.swift
@@ -63,8 +63,7 @@ public func single_generic<T: P2>(_: T.Type) {
 
 // CHECK-LABEL: define{{( protected)?}} i8** @"$S42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWa"(%swift.type*, i8***)
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CAST_CONDITIONAL_TABLES:%.*]] = bitcast i8*** %1 to i8**
-// CHECK-NEXT:    [[TABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWG", %swift.type* %0, i8** [[CAST_CONDITIONAL_TABLES]])
+// CHECK-NEXT:    [[TABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWG", %swift.type* %0, i8*** %1)
 // CHECK-NEXT:    ret i8** [[TABLE]]
 // CHECK-NEXT:  }
 
@@ -186,8 +185,7 @@ public func double_generic_generic<U: P2, V: P3>(_: U.Type, _: V.Type) {
 
 // CHECK-LABEL: define{{( protected)?}} i8** @"$S42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlWa"(%swift.type*, i8***)
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CAST_CONDITIONAL_TABLES:%.*]] = bitcast i8*** %1 to i8**
-// CHECK-NEXT:    [[TABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlWG", %swift.type* %0, i8** [[CAST_CONDITIONAL_TABLES]])
+// CHECK-NEXT:    [[TABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlWG", %swift.type* %0, i8*** %1)
 // CHECK-NEXT:    ret i8** [[TABLE]]
 // CHECK-NEXT:  }
 

--- a/test/Inputs/conditional_conformance_recursive.swift
+++ b/test/Inputs/conditional_conformance_recursive.swift
@@ -44,4 +44,4 @@ extension Wrapper: P3 where T: P3 { }
 // CHECK-LABEL: define internal i8** @"$S33conditional_conformance_recursive7WrapperVyxGAA2P2A2aERzrl1A_AaEPWT"
 // CHECK: [[CONDITIONAL_REQ_BUFFER:%.*]] = alloca [1 x i8**]
 // CHECK: [[FIRST_REQ:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* [[CONDITIONAL_REQ_BUFFER]]
-// CHECK: call i8** @"$S33conditional_conformance_recursive7WrapperVyxGAA2P2A2aERzrlWa"(%swift.type* [[WRAPPER_TO_A:%.*]], i8*** [[FIRST_REQ]], i64 1)
+// CHECK: call i8** @"$S33conditional_conformance_recursive7WrapperVyxGAA2P2A2aERzrlWa"(%swift.type* [[WRAPPER_TO_A:%.*]], i8*** [[FIRST_REQ]])

--- a/test/Inputs/conditional_conformance_subclass.swift
+++ b/test/Inputs/conditional_conformance_subclass.swift
@@ -63,8 +63,7 @@ public func subclassgeneric_generic<T: P2>(_: T.Type) {
 
 // CHECK-LABEL: define{{( protected)?}} i8** @"$S32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlWa"(%swift.type*, i8***)
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CAST_CONDITIONAL_TABLES:%.*]] = bitcast i8*** %1 to i8**
-// CHECK-NEXT:    [[TABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlWG", %swift.type* %0, i8** [[CAST_CONDITIONAL_TABLES]])
+// CHECK-NEXT:    [[TABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlWG", %swift.type* %0, i8*** %1)
 // CHECK-NEXT:    ret i8** [[TABLE]]
 // CHECK-NEXT:  }
 

--- a/test/Inputs/conditional_conformance_subclass.swift
+++ b/test/Inputs/conditional_conformance_subclass.swift
@@ -54,21 +54,16 @@ public func subclassgeneric_generic<T: P2>(_: T.Type) {
 // CHECK-NEXT:    [[CONDITIONAL_REQUIREMENTS:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* %conditional.requirement.buffer, i32 0, i32 0
 // CHECK-NEXT:    [[T_P2_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 0
 // CHECK-NEXT:    store i8** %T.P2, i8*** [[T_P2_PTR]], align 8
-// CHECK-NEXT:    [[Base_P1:%.*]] = call i8** @"$S32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlWa"(%swift.type* [[SubclassGeneric_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]], i64 1)
+// CHECK-NEXT:    [[Base_P1:%.*]] = call i8** @"$S32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlWa"(%swift.type* [[SubclassGeneric_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
 // CHECK-NEXT:    call swiftcc void @"$S32conditional_conformance_subclass8takes_p1yyxmAA2P1RzlF"(%swift.type* [[SubclassGeneric_TYPE]], %swift.type* [[SubclassGeneric_TYPE]], i8** [[Base_P1]])
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
 
 // witness table accessor for Base : P1
 
-// CHECK-LABEL: define{{( protected)?}} i8** @"$S32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlWa"(%swift.type*, i8***, i64)
+// CHECK-LABEL: define{{( protected)?}} i8** @"$S32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlWa"(%swift.type*, i8***)
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    %conditional.tables = alloca %swift.witness_table_slice, align 8
-// CHECK-NEXT:    [[TABLES_PTR:%.*]] = getelementptr inbounds %swift.witness_table_slice, %swift.witness_table_slice* %conditional.tables, i32 0, i32 0
-// CHECK-NEXT:    store i8*** %1, i8**** [[TABLES_PTR]], align 8
-// CHECK-NEXT:    [[COUNT_PTR:%.*]] = getelementptr inbounds %swift.witness_table_slice, %swift.witness_table_slice* %conditional.tables, i32 0, i32 1
-// CHECK-NEXT:    store i64 %2, i64* [[COUNT_PTR]], align 8
-// CHECK-NEXT:    [[CAST_CONDITIONAL_TABLES:%.*]] = bitcast %swift.witness_table_slice* %conditional.tables to i8**
+// CHECK-NEXT:    [[CAST_CONDITIONAL_TABLES:%.*]] = bitcast i8*** %1 to i8**
 // CHECK-NEXT:    [[TABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlWG", %swift.type* %0, i8** [[CAST_CONDITIONAL_TABLES]])
 // CHECK-NEXT:    ret i8** [[TABLE]]
 // CHECK-NEXT:  }
@@ -99,7 +94,7 @@ public func subclassgeneric_concrete() {
 // CHECK-NEXT:    [[CONDITIONAL_REQUIREMENTS:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* %conditional.requirement.buffer, i32 0, i32 0
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 0
 // CHECK-NEXT:    store i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$S32conditional_conformance_subclass4IsP2VAA0E0AAWP", i32 0, i32 0), i8*** [[A_P2_PTR]], align 8
-// CHECK-NEXT:    [[Base_P1:%.*]] = call i8** @"$S32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlWa"(%swift.type* [[SubclassGeneric_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]], i64 1)
+// CHECK-NEXT:    [[Base_P1:%.*]] = call i8** @"$S32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlWa"(%swift.type* [[SubclassGeneric_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
 // CHECK-NEXT:    store atomic i8** [[Base_P1]], i8*** @"$S32conditional_conformance_subclass15SubclassGenericCyAA4IsP2VGAA4BaseCyxGAA2P1A2A0G0RzlWL" release, align 8
 // CHECK-NEXT:    br label %cont
 
@@ -132,7 +127,7 @@ public func subclassconcrete() {
 // CHECK-NEXT:    [[CONDITIONAL_REQUIREMENTS:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* %conditional.requirement.buffer, i32 0, i32 0
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 0
 // CHECK-NEXT:    store i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$S32conditional_conformance_subclass4IsP2VAA0E0AAWP", i32 0, i32 0), i8*** [[A_P2_PTR]], align 8
-// CHECK-NEXT:    [[Base_P1:%.*]] = call i8** @"$S32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlWa"(%swift.type* [[SubclassGeneric_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]], i64 1)
+// CHECK-NEXT:    [[Base_P1:%.*]] = call i8** @"$S32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlWa"(%swift.type* [[SubclassGeneric_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
 // CHECK-NEXT:    store atomic i8** [[Base_P1]], i8*** @"$S32conditional_conformance_subclass16SubclassConcreteCAA4BaseCyxGAA2P1A2A2P2RzlWL" release, align 8
 // CHECK-NEXT:    br label %cont
 
@@ -165,7 +160,7 @@ public func subclassgenericconcrete() {
 // CHECK-NEXT:    [[CONDITIONAL_REQUIREMENTS:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* %conditional.requirement.buffer, i32 0, i32 0
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 0
 // CHECK-NEXT:    store i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$S32conditional_conformance_subclass4IsP2VAA0E0AAWP", i32 0, i32 0), i8*** [[A_P2_PTR]], align 8
-// CHECK-NEXT:    [[Base_P1:%.*]] = call i8** @"$S32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlWa"(%swift.type* [[SubclassGeneric_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]], i64 1)
+// CHECK-NEXT:    [[Base_P1:%.*]] = call i8** @"$S32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlWa"(%swift.type* [[SubclassGeneric_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
 // CHECK-NEXT:    store atomic i8** [[Base_P1]], i8*** @"$S32conditional_conformance_subclass23SubclassGenericConcreteCAA4BaseCyxGAA2P1A2A2P2RzlWL" release, align 8
 // CHECK-NEXT:    br label %cont
 
@@ -179,25 +174,15 @@ public func subclassgenericconcrete() {
 
 // CHECK-LABEL: define internal void @"$S32conditional_conformance_subclass4BaseCyxGAA2P1A2A2P2RzlWI"(i8**, %swift.type*, i8**)
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CONDITIONAL_TABLE_SLICE:%.*]] = bitcast i8** %2 to %swift.witness_table_slice*
-// CHECK-NEXT:    [[TABLES_PTR:%.*]] = getelementptr inbounds %swift.witness_table_slice, %swift.witness_table_slice* [[CONDITIONAL_TABLE_SLICE]], i32 0, i32 0
-// CHECK-NEXT:    [[TABLES:%.*]] = load i8***, i8**** [[TABLES_PTR]], align 8
-// CHECK-NEXT:    [[COUNT_PTR:%.*]] = getelementptr inbounds %swift.witness_table_slice, %swift.witness_table_slice* [[CONDITIONAL_TABLE_SLICE]], i32 0, i32 1
-// CHECK-NEXT:    [[COUNT:%.*]] = load i64, i64* [[COUNT_PTR]], align 8
-// CHECK-NEXT:    [[COND:%.*]] = icmp eq i64 [[COUNT]], 1
-// CHECK-NEXT:    br i1 [[COND]], label %cont, label %bad_witness_table_count
+// CHECK-NEXT:    [[TABLES:%.*]] = bitcast i8** %2 to i8***
 
-// CHECK:       cont:
 // CHECK-NEXT:    [[A_P2_SRC:%.*]] = getelementptr inbounds i8**, i8*** [[TABLES]], i32 0
 // CHECK-NEXT:    [[A_P2_DEST:%.*]] = getelementptr inbounds i8*, i8** %0, i32 -1
 // CHECK-NEXT:    [[A_P2:%.*]] = load i8**, i8*** [[A_P2_SRC]], align 8
 // CHECK-NEXT:    [[CAST_A_P2_DEST:%.*]] = bitcast i8** [[A_P2_DEST]] to i8***
 // CHECK-NEXT:    store i8** [[A_P2]], i8*** [[CAST_A_P2_DEST]], align 8
-// CHECK-NEXT:    ret void
 
-// CHECK:       bad_witness_table_count:
-// CHECK-NEXT:    call void @llvm.trap()
-// CHECK-NEXT:    unreachable
+// CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
 
 

--- a/test/Inputs/conditional_conformance_with_assoc.swift
+++ b/test/Inputs/conditional_conformance_with_assoc.swift
@@ -122,7 +122,7 @@ public func generic_generic<T: P2, U>(_: T.Type, _: U.Type)
 // CHECK-NEXT:    [[B_AT2_AT2_AT3_P3_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 2
 // CHECK-NEXT:    store i8** %T.AT2.AT2.AT3.P3, i8*** [[B_AT2_AT2_AT3_P3_PTR]], align 8
 
-// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @"$S34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlWa"(%swift.type* [[Double_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]], i64 3)
+// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @"$S34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlWa"(%swift.type* [[Double_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
 // CHECK-NEXT:    call swiftcc void @"$S34conditional_conformance_with_assoc8takes_p1yyxmAA2P1RzlF"(%swift.type* [[Double_TYPE]], %swift.type* [[Double_TYPE]], i8** [[Double_P1]])
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
@@ -145,7 +145,7 @@ public func generic_concrete<T: P2>(_: T.Type)
 // CHECK-NEXT:    [[B_AT2_AT2_AT3_P3_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 2
 // CHECK-NEXT:    store i8** %T.AT2.AT2.AT3.P3, i8*** [[B_AT2_AT2_AT3_P3_PTR]], align 8
 
-// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @"$S34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlWa"(%swift.type* [[Double_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]], i64 3)
+// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @"$S34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlWa"(%swift.type* [[Double_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
 // CHECK-NEXT:    call swiftcc void @"$S34conditional_conformance_with_assoc8takes_p1yyxmAA2P1RzlF"(%swift.type* [[Double_TYPE]], %swift.type* [[Double_TYPE]], i8** [[Double_P1]])
 // CHECK-NEXT:    ret void
 // CHECK-NEXT:  }
@@ -168,7 +168,7 @@ public func concrete_generic<U>(_: U.Type)
 // CHECK-NEXT:  store i8** getelementptr inbounds ([3 x i8*], [3 x i8*]* @"$S34conditional_conformance_with_assoc6IsBothVAA2P2AAWP", i32 0, i32 0), i8*** [[B_AT2_P2_PTR]], align 8
 // CHECK-NEXT:  [[B_AT2_AT2_AT3_P3_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 2
 // CHECK-NEXT:  store i8** getelementptr inbounds ([2 x i8*], [2 x i8*]* @"$S34conditional_conformance_with_assoc4IsP3VAA0F0AAWP", i32 0, i32 0), i8*** [[B_AT2_AT2_AT3_P3_PTR]], align 8
-// CHECK-NEXT:  [[Double_P1:%.*]] = call i8** @"$S34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlWa"(%swift.type* [[Double_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]], i64 3)
+// CHECK-NEXT:  [[Double_P1:%.*]] = call i8** @"$S34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlWa"(%swift.type* [[Double_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
 // CHECK-NEXT:  call swiftcc void @"$S34conditional_conformance_with_assoc8takes_p1yyxmAA2P1RzlF"(%swift.type* [[Double_TYPE]], %swift.type* [[Double_TYPE]], i8** [[Double_P1]])
 // CHECK-NEXT:  ret void
 // CHECK-NEXT:}
@@ -204,7 +204,7 @@ public func concrete_concrete() {
 // CHECK-NEXT:    store i8** getelementptr inbounds ([3 x i8*], [3 x i8*]* @"$S34conditional_conformance_with_assoc6IsBothVAA2P2AAWP", i32 0, i32 0), i8*** [[B_AT2_P2_PTR]], align 8
 // CHECK-NEXT:    [[B_AT2_AT2_AT3_P3_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 2
 // CHECK-NEXT:    store i8** getelementptr inbounds ([2 x i8*], [2 x i8*]* @"$S34conditional_conformance_with_assoc4IsP3VAA0F0AAWP", i32 0, i32 0), i8*** [[B_AT2_AT2_AT3_P3_PTR]], align 8
-// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @"$S34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlWa"(%swift.type* [[Double_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]], i64 3)
+// CHECK-NEXT:    [[Double_P1:%.*]] = call i8** @"$S34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlWa"(%swift.type* [[Double_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
 // CHECK-NEXT:    store atomic i8** [[Double_P1]], i8*** @"$S34conditional_conformance_with_assoc6DoubleVyAA8IsAlsoP2VAA0F2P3VGACyxq_GAA2P1A2A0I0R_AA0H03AT2RpzAakM_AmaLP3AT3RPzrlWL" release, align 8
 // CHECK-NEXT:    br label %cont
 
@@ -219,15 +219,8 @@ public func concrete_concrete() {
 
 // CHECK-LABEL: define internal void @"$S34conditional_conformance_with_assoc6DoubleVyxq_GAA2P1A2A2P3R_AA2P23AT2RpzAafH_AhaGP3AT3RPzrlWI"(i8**, %swift.type*, i8**)
 // CHECK-NEXT:  entry:
-// CHECK-NEXT:    [[CONDITIONAL_TABLE_SLICE:%.*]] = bitcast i8** %2 to %swift.witness_table_slice*
-// CHECK-NEXT:    [[TABLES_PTR:%.*]] = getelementptr inbounds %swift.witness_table_slice, %swift.witness_table_slice* [[CONDITIONAL_TABLE_SLICE]], i32 0, i32 0
-// CHECK-NEXT:    [[TABLES:%.*]] = load i8***, i8**** [[TABLES_PTR]], align 8
-// CHECK-NEXT:    [[COUNT_PTR:%.*]] = getelementptr inbounds %swift.witness_table_slice, %swift.witness_table_slice* [[CONDITIONAL_TABLE_SLICE]], i32 0, i32 1
-// CHECK-NEXT:    [[COUNT:%.*]] = load i64, i64* [[COUNT_PTR]], align 8
-// CHECK-NEXT:    [[COND:%.*]] = icmp eq i64 [[COUNT]],
-// CHECK-NEXT:    br i1 [[COND]], label %cont, label %bad_witness_table_count
+// CHECK-NEXT:    [[TABLES:%.*]] = bitcast i8** %2 to i8***
 
-// CHECK:       cont:
 // CHECK-NEXT:    [[C_P3_SRC:%.*]] = getelementptr inbounds i8**, i8*** [[TABLES]], i32 0
 // CHECK-NEXT:    [[C_P3_DEST:%.*]] = getelementptr inbounds i8*, i8** %0, i32 -1
 // CHECK-NEXT:    [[C_P3:%.*]] = load i8**, i8*** [[C_P3_SRC]], align 8
@@ -247,9 +240,5 @@ public func concrete_concrete() {
 // CHECK-NEXT:    store i8** [[B_AT2_AT2_AT3_P3]], i8*** [[CAST_B_AT2_AT2_AT3_P3_DEST]], align 8
 
 // CHECK-NEXT:    ret void
-
-// CHECK:       bad_witness_table_count:
-// CHECK-NEXT:    call void @llvm.trap()
-// CHECK-NEXT:    unreachable
 // CHECK-NEXT:  }
 

--- a/unittests/runtime/Metadata.cpp
+++ b/unittests/runtime/Metadata.cpp
@@ -774,7 +774,7 @@ static void initializeRelativePointer(int32_t *ptr, T value) {
 
 static void witnessTableInstantiator(WitnessTable *instantiatedTable,
                                      const Metadata *type,
-                                     void * const *instantiationArgs) {
+                                     void **const *instantiationArgs) {
   EXPECT_EQ(type, nullptr);
 
   EXPECT_EQ(((void **) instantiatedTable)[1], (void*) 123);
@@ -903,7 +903,7 @@ TEST(WitnessTableTest, getGenericWitnessTable) {
     RaceTest_ExpectEqual<const WitnessTable *>(
       [&]() -> const WitnessTable * {
         const WitnessTable *instantiatedTable = swift_getGenericWitnessTable(
-            table, nullptr, (void **)conditionalTablesBuffer);
+            table, nullptr, (void ***)conditionalTablesBuffer);
 
         EXPECT_NE(instantiatedTable, table->Pattern.get());
 
@@ -942,7 +942,7 @@ TEST(WitnessTableTest, getGenericWitnessTable) {
     RaceTest_ExpectEqual<const WitnessTable *>(
       [&]() -> const WitnessTable * {
         const WitnessTable *instantiatedTable = swift_getGenericWitnessTable(
-            table, nullptr, (void **)conditionalTablesBuffer);
+            table, nullptr, (void ***)conditionalTablesBuffer);
 
         EXPECT_NE(instantiatedTable, table->Pattern.get());
 
@@ -982,7 +982,7 @@ TEST(WitnessTableTest, getGenericWitnessTable) {
     RaceTest_ExpectEqual<const WitnessTable *>(
       [&]() -> const WitnessTable * {
         const WitnessTable *instantiatedTable = swift_getGenericWitnessTable(
-            table, nullptr, (void **)conditionalTablesBuffer);
+            table, nullptr, (void ***)conditionalTablesBuffer);
 
         EXPECT_NE(instantiatedTable, table->Pattern.get());
 

--- a/unittests/runtime/Metadata.cpp
+++ b/unittests/runtime/Metadata.cpp
@@ -772,11 +772,6 @@ static void initializeRelativePointer(int32_t *ptr, T value) {
 // Tests for resilient witness table instantiation, with runtime-provided
 // default requirements
 
-struct WitnessTableSlice {
-  WitnessTable **tables;
-  size_t count;
-};
-
 static void witnessTableInstantiator(WitnessTable *instantiatedTable,
                                      const Metadata *type,
                                      void * const *instantiationArgs) {
@@ -789,11 +784,10 @@ static void witnessTableInstantiator(WitnessTable *instantiatedTable,
   ((void **) instantiatedTable)[3] = (void *) 345;
 
   auto conditionalTables =
-      reinterpret_cast<const WitnessTableSlice *>(instantiationArgs);
+      reinterpret_cast<const WitnessTable *const *>(instantiationArgs);
 
-  EXPECT_EQ(conditionalTables->count, 1UL);
-  EXPECT_EQ(conditionalTables->tables[0], (void *)678);
-  ((void **)instantiatedTable)[-1] = conditionalTables->tables[0];
+  EXPECT_EQ(conditionalTables[0], (void *)678);
+  ((void **)instantiatedTable)[-1] = (void *)conditionalTables[0];
 }
 
 static void fakeDefaultWitness1() {}
@@ -860,7 +854,6 @@ const void *witnesses[] = {
 };
 
 WitnessTable *conditionalTablesBuffer[] = {(WitnessTable *)678};
-WitnessTableSlice conditionalTablesSlice = {conditionalTablesBuffer, 1};
 
 TEST(WitnessTableTest, getGenericWitnessTable) {
   EXPECT_EQ(sizeof(GenericWitnessTableStorage), sizeof(GenericWitnessTable));
@@ -910,7 +903,7 @@ TEST(WitnessTableTest, getGenericWitnessTable) {
     RaceTest_ExpectEqual<const WitnessTable *>(
       [&]() -> const WitnessTable * {
         const WitnessTable *instantiatedTable = swift_getGenericWitnessTable(
-            table, nullptr, (void**)&conditionalTablesSlice);
+            table, nullptr, (void **)conditionalTablesBuffer);
 
         EXPECT_NE(instantiatedTable, table->Pattern.get());
 
@@ -949,7 +942,7 @@ TEST(WitnessTableTest, getGenericWitnessTable) {
     RaceTest_ExpectEqual<const WitnessTable *>(
       [&]() -> const WitnessTable * {
         const WitnessTable *instantiatedTable = swift_getGenericWitnessTable(
-            table, nullptr, (void**)&conditionalTablesSlice);
+            table, nullptr, (void **)conditionalTablesBuffer);
 
         EXPECT_NE(instantiatedTable, table->Pattern.get());
 
@@ -989,7 +982,7 @@ TEST(WitnessTableTest, getGenericWitnessTable) {
     RaceTest_ExpectEqual<const WitnessTable *>(
       [&]() -> const WitnessTable * {
         const WitnessTable *instantiatedTable = swift_getGenericWitnessTable(
-            table, nullptr, (void**)&conditionalTablesSlice);
+            table, nullptr, (void **)conditionalTablesBuffer);
 
         EXPECT_NE(instantiatedTable, table->Pattern.get());
 


### PR DESCRIPTION
The count of the number of witness tables was designed to be an
assertion/check that we've hooked up all the infrastructure
correctly. Everything is now implemented, and the assertion has never
triggered, so it can be removed, saving some work.
