### PR TITLE
[GSB] Always ensure that we wire up typealiases in protocol extensions.

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3743,13 +3743,11 @@ ResolvedType GenericSignatureBuilder::maybeResolveEquivalenceClass(
     if (!nestedPA)
       return ResolvedType::forUnresolved(baseEquivClass);
 
-    if (resolutionKind != ArchetypeResolutionKind::AlreadyKnown) {
-      // Update for all of the concrete decls with this name, which will
-      // introduce various same-type constraints.
-      for (auto concreteDecl : concreteDecls) {
-        (void)basePA->updateNestedTypeForConformance(*this, concreteDecl,
-                                                     resolutionKind);
-      }
+    // Update for all of the concrete decls with this name, which will
+    // introduce various same-type constraints.
+    for (auto concreteDecl : concreteDecls) {
+      (void)basePA->updateNestedTypeForConformance(*this, concreteDecl,
+                                                   resolutionKind);
     }
 
     // If base resolved to the anchor, then the nested potential archetype

--- a/validation-test/compiler_crashers_2_fixed/0145-sr7097.swift
+++ b/validation-test/compiler_crashers_2_fixed/0145-sr7097.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend %s -emit-ir -o - | %FileCheck %s
+
+protocol P1 { }
+
+protocol P2 {
+  associatedtype Assoc
+}
+
+protocol P3 : P2 { }
+
+struct S0<M: P3> where M.Assoc: P1 { }
+
+struct ConformsToP1: P1 { }
+
+extension P3 {
+  typealias Assoc = ConformsToP1
+}
+
+protocol P5 {
+}
+
+extension P5 {
+  func testSR7097<M>(_: S0<M>.Type) {}
+}
+
+


### PR DESCRIPTION
We were only wiring up typealiases in protocol extensions under some
circumstances, which meant that we could miss some equivalences between a
typealias in one protocol and an associated type in an inherited protocol,
which could manifest as a crash in IR generation.

Fixes SR-7097 / rdar://problem/38001269.
