### PR TITLE
[BatchMode] Collect InputActions correctly when merging jobs.

### DIFF
--- a/test/Driver/batch_mode_bridging_pch.swift
+++ b/test/Driver/batch_mode_bridging_pch.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: touch %t/file-01.swift %t/file-02.swift %t/file-03.swift
+// RUN: echo 'public func main() {}' >%t/main.swift
+// RUN: echo 'extern int foo;' >%t/foo-bridging-header.h
+//
+// RUN: %swiftc_driver -enable-bridging-pch -v -import-objc-header %t/foo-bridging-header.h -enable-batch-mode -c -emit-module -module-name main -j 2 %t/file-01.swift %t/file-02.swift %t/file-03.swift %t/main.swift %s 2>&1 | %FileCheck %s
+//
+// CHECK: -emit-pch
+// CHECK: -primary-file {{.*}}/file-01.swift -primary-file {{.*}}/file-02.swift
+
+func bar() {
+    print(foo)
+}


### PR DESCRIPTION
This fixes the cause of an assert failure @davidungar observed building a project with bridging PCH and batch mode: we were passing all actions -- InputActions and otherwise -- from the merged jobs' input actions arrays to the JobContext's InputActions field. We need to pass along only the InputActions for that, and independently select and propagate the actions we were selecting before to the synthetic CompileJobAction that accompanies.