### PR TITLE
[Gardening] Changed lowercaseString to lowercased() in comments.

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1211,7 +1211,7 @@ extension Collection {
   /// to lowercase strings and then to count their characters.
   ///
   ///     let cast = ["Vivien", "Marlon", "Kim", "Karl"]
-  ///     let lowercaseNames = cast.map { $0.lowercaseString }
+  ///     let lowercaseNames = cast.map { $0.lowercased() }
   ///     // 'lowercaseNames' == ["vivien", "marlon", "kim", "karl"]
   ///     let letterCounts = cast.map { $0.count }
   ///     // 'letterCounts' == [6, 6, 3, 4]

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -1337,7 +1337,7 @@ extension String {
       var guts = _guts
       guts.withMutableASCIIStorage(unusedCapacity: 0) { storage in
         for i in 0..<storage._value.count {
-          // See the comment above in lowercaseString.
+          // See the comment above in lowercased.
           let value = storage._value.start[i]
           let isLower =
             _asciiLowerCaseTable &>>


### PR DESCRIPTION
This emends two comments that refer to `lowercaseString` rather than `lowercased()`.
