### PR TITLE
[Do not merge] [Syntax] parse invalid chars as trivia

### DIFF
--- a/test/Syntax/round_trip_invalids.swift
+++ b/test/Syntax/round_trip_invalids.swift
@@ -1,0 +1,23 @@
+// To know about setup, see `tokens_invalids.swift`.
+
+// RUN: cat %s > %t
+// RUN: cat %t | sed 's/'$(echo -ne "\x5a1")'/'$(echo -ne "\xc2")'/g' > %t.sed
+// RUN: cp -f %t.sed %t
+// RUN: cat %t | sed 's/'$(echo -ne "\x5a2")'/'$(echo -ne "\xcc\x82")'/g' > %t.sed
+// RUN: cp -f %t.sed %t
+// RUN: cat %t | sed 's/'$(echo -ne "\x5a3")'/'$(echo -ne "\xe2\x80\x9d")'/g' > %t.sed
+// RUN: cp -f %t.sed %t
+// RUN: cat %t | sed 's/'$(echo -ne "\x5a4")'/'$(echo -ne "\xe2\x80\x9c")'/g' > %t.sed
+// RUN: cp -f %t.sed %t
+// RUN: cat %t | sed 's/'$(echo -ne "\x5a5")'/'$(echo -ne "\xe1\x9a\x80")'/g' > %t.sed
+// RUN: cp -f %t.sed %t
+
+// RUN: %round-trip-syntax-test --swift-syntax-test %swift-syntax-test --file %t
+
+x
+Z1 x
+Z2
+Z3
+Z4
+Z4 abcdef Z3
+Z5 x

--- a/test/Syntax/tokens_invalids.swift
+++ b/test/Syntax/tokens_invalids.swift
@@ -1,0 +1,79 @@
+// RUN: cat %s > %t
+
+// 5a is Z. "ZN" style marker is used for marker. N is number.
+
+// C2 is utf8 2 byte character start byte.
+// RUN: cat %t | sed 's/'$(echo -ne "\x5a1")'/'$(echo -ne "\xc2")'/g' > %t.sed
+// RUN: cp -f %t.sed %t
+
+// CC 82 is U+0302, invalid for identifier start, valid for identifier body.
+// RUN: cat %t | sed 's/'$(echo -ne "\x5a2")'/'$(echo -ne "\xcc\x82")'/g' > %t.sed
+// RUN: cp -f %t.sed %t
+
+// E2 80 9D is U+201D, right quote.
+// RUN: cat %t | sed 's/'$(echo -ne "\x5a3")'/'$(echo -ne "\xe2\x80\x9d")'/g' > %t.sed
+// RUN: cp -f %t.sed %t
+
+// E2 80 9C is U+201C, left quote.
+// RUN: cat %t | sed 's/'$(echo -ne "\x5a4")'/'$(echo -ne "\xe2\x80\x9c")'/g' > %t.sed
+// RUN: cp -f %t.sed %t
+
+// E1 9A 80 is U+1680, invalid for swift source.
+// RUN: cat %t | sed 's/'$(echo -ne "\x5a5")'/'$(echo -ne "\xe1\x9a\x80")'/g' > %t.sed
+// RUN: cp -f %t.sed %t
+
+// RUN: %swift-syntax-test -input-source-filename %t -dump-full-tokens 2>&1 | %FileCheck %t
+
+x
+Z1 x
+Z2
+Z3
+Z4
+Z4 abcdef Z3
+Z5 x
+
+// test diagnostics.
+
+// CHECK: 28:1: error: invalid UTF-8 found in source file
+// CHECK: 29:1: error: an identifier cannot begin with this character
+// CHECK: 30:1: error: unicode curly quote found
+// CHECK: 31:1: error: unicode curly quote found
+// CHECK: 32:12: error: unicode curly quote found
+// CHECK: 32:1: error: unicode curly quote found
+// CHECK: 33:1: error: invalid character in source file
+
+// test tokens and trivias.
+
+// CHECK-LABEL: 28:3
+// CHECK-NEXT:  (Token identifier
+// CHECK-NEXT:   (trivia newline 1)
+// CHECK-NEXT:   (trivia garbage_text \302)
+// CHECK-NEXT:   (trivia space 1)
+// CHECK-NEXT:   (text="x"))
+
+// CHECK-LABEL: 29:1
+// CHECK-NEXT:  (Token unknown
+// CHECK-NEXT:   (trivia newline 1)
+// CHECK-NEXT:   (text="\xCC\x82"))
+
+// CHECK-LABEL: 30:1
+// CHECK-NEXT:  (Token unknown
+// CHECK-NEXT:   (trivia newline 1)
+// CHECK-NEXT:   (text="\xE2\x80\x9D"))
+
+// CHECK-LABEL: 31:1
+// CHECK-NEXT:  (Token unknown
+// CHECK-NEXT:   (trivia newline 1)
+// CHECK-NEXT:   (text="\xE2\x80\x9C"))
+
+// CHECK-LABEL: 32:1
+// CHECK-NEXT:  (Token unknown
+// CHECK-NEXT:   (trivia newline 1)
+// CHECK-NEXT:   (text="\xE2\x80\x9C abcdef \xE2\x80\x9D"))
+
+// CHECK-LABEL: 33:5
+// CHECK-NEXT:  (Token identifier
+// CHECK-NEXT:   (trivia newline 1)
+// CHECK-NEXT:   (trivia garbage_text \341\232\200)
+// CHECK-NEXT:   (trivia space 1)
+// CHECK-NEXT:   (text="x"))


### PR DESCRIPTION
__I reject my PR and will reconstruct improved one.__

This implementation does not lex invalid chars in trailing trivia. 
Token sequence is split at invalid byte sequence and it becomes leading trivia.
It keeps round trip but does not follow ground trivia lexing rules.
I believe that to achieve this perfectly is very important for user of libSyntax in future.

I will close this PR later after reviewers read my response to each review comment.

I submitted new PR.
https://github.com/apple/swift/pull/15011

---

This PR add ability to Lexer that it handles invalid chars as trivia.
It makes libSyntax can round trip convert swift source which contains invalid chars.

Invalid chars means here is invalid UTF-8 byte sequence and invalid Unicode codepoint in Swift.
~~They are skipped in `lexTrivia`.~~
They are skipped in `lexImpl` before.

I added logic that push them to `LeadingTrivia`.

I refactor around there to make code more readable.

And I add round trip test case and token, trivia syntax handling.

I use replacing trick to embed such invalid byte sequence to test input.

I submitted another PR #14967 before which achieve same purpose with this PR.
But I found better design so write this PR and rejected #14967 by myself.

I think that finally this PR makes libSyntax perfect for round trip functionality
with arbitraly source code even if it is not valid UTF-8 text.

Please review this PR.