### PR TITLE
[refactoring] Avoid producing empty string/comment categorized edit ranges when renaming init. Also disallow renaming inits with no arguments.

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -313,6 +313,14 @@ public:
     bool IsSubscript = Old.base() == "subscript" && Config.IsFunctionLike;
     bool IsInit = Old.base() == "init" && Config.IsFunctionLike;
     bool IsKeywordBase = IsInit || IsSubscript;
+    
+    // Filter out non-semantic keyword basename locations with no labels.
+    // We've already filtered out those in active code, so these are
+    // any appearance of just 'init' or 'subscript' in strings, comments, and
+    // inactive code.
+    if (IsKeywordBase && (Config.Usage == NameUsage::Unknown &&
+                           Resolved.LabelType == LabelRangeType::None))
+      return RegionType::Unmatched;
 
     if (!Config.IsFunctionLike || !IsKeywordBase) {
       if (renameBase(Resolved.Range, RefactoringRangeKind::BaseName))
@@ -352,7 +360,8 @@ public:
                         Resolved.LabelType == LabelRangeType::CallArg;
 
       if (renameLabels(Resolved.LabelRanges, Resolved.LabelType, isCallSite))
-        return RegionType::Mismatch;
+        return Config.Usage == NameUsage::Unknown ?
+            RegionType::Unmatched : RegionType::Mismatch;
     }
 
     return RegionKind;
@@ -2892,6 +2901,8 @@ swift::ide::FindRenameRangesAnnotatingConsumer::~FindRenameRangesAnnotatingConsu
 void swift::ide::FindRenameRangesAnnotatingConsumer::
 accept(SourceManager &SM, RegionType RegionType,
        ArrayRef<RenameRangeDetail> Ranges) {
+  if (RegionType == RegionType::Mismatch || RegionType == RegionType::Unmatched)
+    return;
   for (const auto &Range : Ranges) {
     Impl.accept(SM, Range);
   }
@@ -2920,6 +2931,12 @@ swift::ide::collectRenameAvailabilityInfo(const ValueDecl *VD,
     // Disallow renaming deinit.
     if (isa<DestructorDecl>(VD))
       return Scratch;
+    
+    // Disallow renaming init with no arguments.
+    if (auto CD = dyn_cast<ConstructorDecl>(VD)) {
+      if (!CD->getParameters()->size())
+        return Scratch;
+    }
   }
 
   // Always return local rename for parameters.

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -940,6 +940,10 @@ swift::ide::SourceEditOutputConsumer::~SourceEditOutputConsumer() { delete &Impl
 void swift::ide::SourceEditOutputConsumer::
 accept(SourceManager &SM, RegionType RegionType,
        ArrayRef<Replacement> Replacements) {
+  // ignore mismatched or
+  if (RegionType == RegionType::Unmatched || RegionType == RegionType::Mismatch)
+    return;
+
   for (const auto &Replacement : Replacements) {
     Impl.accept(SM, Replacement.Range, Replacement.Text);
   }

--- a/test/SourceKit/CursorInfo/cursor_rename.swift
+++ b/test/SourceKit/CursorInfo/cursor_rename.swift
@@ -1,11 +1,19 @@
 class Foo {
   func foo() -> Int { return foo() }
+  init() {}
+  init(_ a: Int) {}
 }
+_ = Foo.init()
+_ = Foo.init(2)
 
 // RUN: %sourcekitd-test -req=cursor -pos=1:9 -cursor-action %s -- %s | %FileCheck -check-prefix=CHECK1 %s
 // RUN: %sourcekitd-test -req=cursor -pos=2:9 %s -- %s | %FileCheck -check-prefix=CHECK2 %s
 // RUN: %sourcekitd-test -req=cursor -pos=2:32 -cursor-action %s -- %s | %FileCheck -check-prefix=CHECK1 %s
 // RUN: %sourcekitd-test -req=cursor -pos=2:18 %s -- %s | %FileCheck -check-prefix=CHECK2 %s
+// RUN: %sourcekitd-test -req=cursor -pos=3:3 -cursor-action %s -- %s | %FileCheck -check-prefix=CHECK2 %s
+// RUN: %sourcekitd-test -req=cursor -pos=4:3 -cursor-action %s -- %s | %FileCheck -check-prefix=CHECK1 %s
+// RUN: %sourcekitd-test -req=cursor -pos=6:9 -cursor-action %s -- %s | %FileCheck -check-prefix=CHECK2 %s
+// RUN: %sourcekitd-test -req=cursor -pos=7:9 -cursor-action %s -- %s | %FileCheck -check-prefix=CHECK1 %s
 
 // CHECK1: Rename
 // CHECK2-NOT: Rename

--- a/test/SourceKit/Refactoring/find-rename-ranges/keywordbase.expected
+++ b/test/SourceKit/Refactoring/find-rename-ranges/keywordbase.expected
@@ -1,0 +1,21 @@
+source.edit.kind.active:
+  95:17-95:18 source.refactoring.range.kind.call-argument-label arg-index=0
+  95:18-95:20 source.refactoring.range.kind.call-argument-colon arg-index=0
+source.edit.kind.active:
+  96:22-96:23 source.refactoring.range.kind.call-argument-label arg-index=0
+  96:23-96:25 source.refactoring.range.kind.call-argument-colon arg-index=0
+source.edit.kind.unknown:
+source.edit.kind.active:
+  97:37-97:38 source.refactoring.range.kind.call-argument-label arg-index=0
+  97:38-97:40 source.refactoring.range.kind.call-argument-colon arg-index=0
+source.edit.kind.active:
+  97:59-97:60 source.refactoring.range.kind.call-argument-label arg-index=0
+  97:60-97:62 source.refactoring.range.kind.call-argument-colon arg-index=0
+source.edit.kind.unknown:
+source.edit.kind.unknown:
+source.edit.kind.unknown:
+source.edit.kind.unknown:
+source.edit.kind.inactive:
+  103:22-103:23 source.refactoring.range.kind.call-argument-label arg-index=0
+  103:23-103:25 source.refactoring.range.kind.call-argument-colon arg-index=0
+source.edit.kind.unknown:

--- a/test/SourceKit/Refactoring/syntactic-rename.swift
+++ b/test/SourceKit/Refactoring/syntactic-rename.swift
@@ -92,6 +92,18 @@ func genfoo<T: P, U, V where U: P>(x: T, y: U, z: V, a: P) -> P where V: P {
   fatalError()
 }
 
+_ = Memberwise1(x: 2)
+_ = Memberwise1.init(x: 2)
+_ = Memberwise2.init(m: Memberwise1(x: 2), n: Memberwise1(x: 34))
+_  = " this init is init "
+// this init is init too
+
+#if NOTDEFINED
+_ = Memberwise1(x: 2)
+_ = Memberwise1.init(x: 2)
+_ = Memberwise2.init(m: 2, n: Memberwise1(x: 34))
+#endif
+
 // RUN: rm -rf %t.result && mkdir -p %t.result
 // RUN: %sourcekitd-test -req=syntactic-rename -rename-spec %S/syntactic-rename/x.in.json %s >> %t.result/x.expected
 // RUN: diff -u %S/syntactic-rename/x.expected %t.result/x.expected
@@ -116,6 +128,8 @@ func genfoo<T: P, U, V where U: P>(x: T, y: U, z: V, a: P) -> P where V: P {
 // RUN: diff -u %S/syntactic-rename/rename-layer.expected %t.result/rename-layer.expected
 // RUN: %sourcekitd-test -req=syntactic-rename -rename-spec %S/syntactic-rename/rename-P.in.json %s -- -swift-version 3 >> %t.result/rename-P.expected
 // RUN: diff -u %S/syntactic-rename/rename-P.expected %t.result/rename-P.expected
+// RUN: %sourcekitd-test -req=syntactic-rename -rename-spec %S/syntactic-rename/keywordbase.in.json %s -- -swift-version 3 >> %t.result/keywordbase.expected
+// RUN: diff -u %S/syntactic-rename/keywordbase.expected %t.result/keywordbase.expected
 
 // RUN: rm -rf %t.ranges && mkdir -p %t.ranges
 // RUN: %sourcekitd-test -req=find-rename-ranges -rename-spec %S/syntactic-rename/x.in.json %s >> %t.ranges/x.expected
@@ -138,3 +152,5 @@ func genfoo<T: P, U, V where U: P>(x: T, y: U, z: V, a: P) -> P where V: P {
 // RUN: diff -u %S/find-rename-ranges/rename-layer.expected %t.ranges/rename-layer.expected
 // RUN: %sourcekitd-test -req=find-rename-ranges -rename-spec %S/syntactic-rename/rename-P.in.json %s -- -swift-version 3 >> %t.ranges/rename-P.expected
 // RUN: diff -u %S/find-rename-ranges/rename-P.expected %t.ranges/rename-P.expected
+// RUN: %sourcekitd-test -req=find-rename-ranges -rename-spec %S/syntactic-rename/keywordbase.in.json %s -- -swift-version 3 >> %t.ranges/keywordbase.expected
+// RUN: diff -u %S/find-rename-ranges/keywordbase.expected %t.ranges/keywordbase.expected

--- a/test/SourceKit/Refactoring/syntactic-rename/keywordbase.expected
+++ b/test/SourceKit/Refactoring/syntactic-rename/keywordbase.expected
@@ -1,0 +1,16 @@
+source.edit.kind.active:
+  95:17-95:18 "y"
+source.edit.kind.active:
+  96:22-96:23 "y"
+source.edit.kind.unknown:
+source.edit.kind.active:
+  97:37-97:38 "y"
+source.edit.kind.active:
+  97:59-97:60 "y"
+source.edit.kind.unknown:
+source.edit.kind.unknown:
+source.edit.kind.unknown:
+source.edit.kind.unknown:
+source.edit.kind.inactive:
+  103:22-103:23 "y"
+source.edit.kind.unknown:

--- a/test/SourceKit/Refactoring/syntactic-rename/keywordbase.in.json
+++ b/test/SourceKit/Refactoring/syntactic-rename/keywordbase.in.json
@@ -1,0 +1,65 @@
+[
+  {
+    "key.name": "init(x:)",
+    "key.newname": "init(y:)",
+    "key.is_function_like": 1,
+    "key.is_non_protocol_type": 0,
+    "key.locations": [
+      {
+        "key.line": 95,
+        "key.column": 5,
+        "key.nametype": source.syntacticrename.call
+      },
+      {
+        "key.line": 96,
+        "key.column": 17,
+        "key.nametype": source.syntacticrename.call
+      },
+      {
+        "key.line": 97,
+        "key.column": 17,
+        "key.nametype": source.syntacticrename.unknown
+      },
+      {
+        "key.line": 97,
+        "key.column": 25,
+        "key.nametype": source.syntacticrename.call
+      },
+      {
+        "key.line": 97,
+        "key.column": 47,
+        "key.nametype": source.syntacticrename.call
+      },
+      {
+        "key.line": 98,
+        "key.column": 13,
+        "key.nametype": source.syntacticrename.unknown
+      },
+      {
+        "key.line": 98,
+        "key.column": 21,
+        "key.nametype": source.syntacticrename.unknown
+      },
+      {
+        "key.line": 99,
+        "key.column": 9,
+        "key.nametype": source.syntacticrename.unknown
+      },
+      {
+        "key.line": 99,
+        "key.column": 17,
+        "key.nametype": source.syntacticrename.unknown
+      },
+      {
+        "key.line": 103,
+        "key.column": 17,
+        "key.nametype": source.syntacticrename.unknown
+      },
+      {
+        "key.line": 104,
+        "key.column": 17,
+        "key.nametype": source.syntacticrename.unknown
+      }
+    ]
+  }
+]


### PR DESCRIPTION
<!-- What's in this pull request? -->
When renaming an initializer we don't try to pick up argument labels and also don't record the base name location, since you can't actually rename it. This means there are no ranges to rename, but we still return a categorized edit of type string/comment with no location information. This patch changes the category returned to unmatched, rather than string/comment, to indicate they shouldn't be handled.

Also stop showing rename as available on initializers that take no arguments, since nothing can be renamed.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/37905156.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->