### PR TITLE
[lldb-with-tools] Add disassemble-to-file.

### DIFF
--- a/utils/lldb/lldbToolBox.py
+++ b/utils/lldb/lldbToolBox.py
@@ -7,8 +7,11 @@ This will also import LLVM data formatters as well, assuming that llvm is next
 to the swift checkout.
 """
 
+import argparse
 import os
+import shlex
 import subprocess
+import sys
 import tempfile
 
 REPO_BASE = os.path.abspath(os.path.join(__file__, os.pardir, os.pardir,
@@ -52,7 +55,22 @@ def create_swift_disassemble_viewcfg(debugger, command, exec_ctx, result,
         p1.stdout.close()  # Allow p1 to receive a SIGPIPE if p2 exits.
 
 
+def disassemble_to_file(debugger, command, exec_ctx, result, internal_dict):
+    """This function disassembles the current assembly frame into a file specified
+    by the user.
+    """
+    parser = argparse.ArgumentParser(prog='disassemble-to-file', description="""
+    Dump the disassembly of the current frame to the specified file.
+    """)
+    parser.add_argument('file', type=argparse.FileType('w'),
+                        default=sys.stdout)
+    args = parser.parse_args(shlex.split(command))
+    args.file.write(exec_ctx.frame.disassembly)
+
+
 def __lldb_init_module(debugger, internal_dict):
     import_llvm_dataformatters(debugger)
     debugger.HandleCommand('command script add disassemble-asm-cfg '
                            '-f lldbToolBox.create_swift_disassemble_viewcfg')
+    debugger.HandleCommand('command script add disassemble-to-file '
+                           '-f lldbToolBox.disassemble_to_file')


### PR DESCRIPTION
Sometimes it is really useful to be able to dump the disassembly from lldb into
a file so that one can work with the disassembly in an editor. The disassemble
command in lldb does not provide such facility today. So this lldb function in
the lldb toolbox provides such a facility.