### PR TITLE
[+0-all-args] When casting a value to NSError, release the value pass…

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -1973,7 +1973,11 @@ static id dynamicCastValueToNSError(OpaqueValue *src,
 
   BoxPair errorBox = swift_allocError(srcType, srcErrorWitness, src,
                             /*isTake*/ flags & DynamicCastFlags::TakeOnSuccess);
-  return _swift_stdlib_bridgeErrorToNSError((SwiftError*)errorBox.object);
+  auto *error = (SwiftError *)errorBox.object;
+  id result =  _swift_stdlib_bridgeErrorToNSError(error);
+  // Now that we have bridged the error to nserror, release the error.
+  SWIFT_CC_PLUSZERO_GUARD(swift_errorRelease(error));
+  return result;
 }
 
 #endif


### PR DESCRIPTION
…ed to _swift_stdlib_bridgeErrorToNSError since it is at +0 now.

rdar://34222540

----

NFC when +0 is not enabled.