### PR TITLE
[+0-all-args] Add a missing +1 guard so this release doesn't happen w…

### DIFF
--- a/stdlib/public/runtime/ErrorDefaultImpls.cpp
+++ b/stdlib/public/runtime/ErrorDefaultImpls.cpp
@@ -54,6 +54,6 @@ intptr_t _swift_stdlib_getDefaultErrorCode(OpaqueValue *error,
   }
 
   // Destroy the value.
-  T->vw_destroy(error);
+  SWIFT_CC_PLUSONE_GUARD(T->vw_destroy(error));
   return result;
 }


### PR DESCRIPTION
…ith a +0 calling convention.

rdar://34222540

----

NFC when +0 is not enabled.