### PR TITLE
Runtime: Handle `getDescription` correctly in +0 mode.

### DIFF
--- a/stdlib/public/SDK/Foundation/NSString.swift
+++ b/stdlib/public/SDK/Foundation/NSString.swift
@@ -22,11 +22,6 @@ public class NSSimpleCString {}
 @available(*, unavailable, message: "Please use String or NSString")
 public class NSConstantString {}
 
-// Called by the SwiftObject implementation.
-public func _getDescription<T>(_ x: T) -> NSString {
-  return String(reflecting: x)._bridgeToObjectiveC()
-}
-
 extension NSString : ExpressibleByStringLiteral {
   /// Create an instance initialized to `value`.
   public required convenience init(stringLiteral value: StaticString) {

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -368,6 +368,14 @@ extension String {
   }
 }
 
+// Called by the SwiftObject implementation to get the description of a value
+// as an NSString.
+@_silgen_name("swift_stdlib_getDescription")
+public func _getDescription<T>(_ x: T) -> AnyObject {
+  return String(reflecting: x)._bridgeToObjectiveCImpl()
+}
+
+
 #else // !_runtime(_ObjC)
 
 @_fixed_layout // FIXME(sil-serialize-all)

--- a/stdlib/public/runtime/SwiftObject.mm
+++ b/stdlib/public/runtime/SwiftObject.mm
@@ -147,20 +147,14 @@ static SwiftObject *_allocHelper(Class cls) {
     class_getInstanceSize(cls), mask));
 }
 
-NSString *swift::getDescription(OpaqueValue *value, const Metadata *type) {
-  typedef SWIFT_CC(swift) NSString *GetDescriptionFn(OpaqueValue*, const Metadata*);
-  auto getDescription = SWIFT_LAZY_CONSTANT(
-    reinterpret_cast<GetDescriptionFn*>(dlsym(RTLD_DEFAULT,
-    MANGLE_AS_STRING(MANGLE_SYM(10Foundation15_getDescriptionySo8NSStringCxlF)))));
-  
-  // If Foundation hasn't loaded yet, fall back to returning the static string
-  // "Swift._SwiftObject". The likelihood of someone invoking -description without
-  // ObjC interop is low.
-  if (!getDescription) {
-    return @"Swift._SwiftObject";
-  }
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE
+NSString *swift_stdlib_getDescription(OpaqueValue *value,
+                                      const Metadata *type);
 
-  return [getDescription(value, type) autorelease];
+NSString *swift::getDescription(OpaqueValue *value, const Metadata *type) {
+  auto result = swift_stdlib_getDescription(value, type);
+  SWIFT_CC_PLUSZERO_GUARD(type->vw_destroy(value));
+  return [result autorelease];
 }
 
 static NSString *_getObjectDescription(SwiftObject *obj) {


### PR DESCRIPTION
This can eventually be made more efficient by avoiding copies in all the
callees, but this is the minimal fix. Remove an unnecessary bit of
reverse-dependency on the Foundation overlay while we're here.

rdar://34222540
