### PR TITLE
[benchmark] Add binary floating-point properties benchmarks

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -41,6 +41,7 @@ set(SWIFT_BENCH_MODULES
     single-source/ArraySetElement
     single-source/ArraySubscript
     single-source/BinaryFloatingPointConversionFromBinaryInteger
+    single-source/BinaryFloatingPointProperties
     single-source/BitCount
     single-source/ByteSwap
     single-source/COWTree

--- a/benchmark/single-source/BinaryFloatingPointProperties.swift
+++ b/benchmark/single-source/BinaryFloatingPointProperties.swift
@@ -1,0 +1,74 @@
+//===--- BinaryFloatingPointProperties.swift ------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import TestsUtils
+
+public let BinaryFloatingPointPropertiesBinade = BenchmarkInfo(
+  name: "BinaryFloatingPointPropertiesBinade",
+  runFunction: run_BinaryFloatingPointPropertiesBinade,
+  tags: [.validation, .algorithm]
+)
+
+public let BinaryFloatingPointPropertiesNextUp = BenchmarkInfo(
+  name: "BinaryFloatingPointPropertiesNextUp",
+  runFunction: run_BinaryFloatingPointPropertiesNextUp,
+  tags: [.validation, .algorithm]
+)
+
+public let BinaryFloatingPointPropertiesUlp = BenchmarkInfo(
+  name: "BinaryFloatingPointPropertiesUlp",
+  runFunction: run_BinaryFloatingPointPropertiesUlp,
+  tags: [.validation, .algorithm]
+)
+
+@inline(never)
+public func run_BinaryFloatingPointPropertiesBinade(_ N: Int) {
+  var xs = [Double]()
+  xs.reserveCapacity(N)
+  for _ in 1...N {
+    var x = 0 as Double
+    for i in 0..<10000 {
+      x += Double(getInt(i)).binade
+    }
+    xs.append(x)
+  }
+  CheckResults(xs[getInt(0)] == 37180757)
+}
+
+@inline(never)
+public func run_BinaryFloatingPointPropertiesNextUp(_ N: Int) {
+  var xs = [Int]()
+  xs.reserveCapacity(N)
+  for _ in 1...N {
+    var x = 0 as Int
+    for i in 0..<10000 {
+      x += Int(Double(getInt(i)).nextUp)
+    }
+    xs.append(x)
+  }
+  CheckResults(xs[getInt(0)] == 49995000)
+}
+
+@inline(never)
+public func run_BinaryFloatingPointPropertiesUlp(_ N: Int) {
+  var xs = [Int]()
+  xs.reserveCapacity(N)
+  for _ in 1...N {
+    var x = 0 as Int
+    for i in 0..<10000 {
+      x += Int(Double(getInt(i)).ulp)
+    }
+    xs.append(x)
+  }
+  CheckResults(xs[getInt(0)] == 0)
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -28,6 +28,7 @@ import ArrayOfRef
 import ArraySetElement
 import ArraySubscript
 import BinaryFloatingPointConversionFromBinaryInteger
+import BinaryFloatingPointProperties
 import BitCount
 import ByteSwap
 import COWTree
@@ -169,6 +170,9 @@ registerBenchmark(ArrayOfRef)
 registerBenchmark(ArraySetElement)
 registerBenchmark(ArraySubscript)
 registerBenchmark(BinaryFloatingPointConversionFromBinaryInteger)
+registerBenchmark(BinaryFloatingPointPropertiesBinade)
+registerBenchmark(BinaryFloatingPointPropertiesNextUp)
+registerBenchmark(BinaryFloatingPointPropertiesUlp)
 registerBenchmark(BitCount)
 registerBenchmark(ByteSwap)
 registerBenchmark(COWTree)


### PR DESCRIPTION
It's been reported that certain properties such as `nextUp` are hundreds of times slower than they need to be. This PR adds some benchmarks in preparation for fixing the issue.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
