### PR TITLE
[Foundation] Reorder _DataStorage to save 14 bytes of overhead

### DIFF
--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -96,10 +96,10 @@ public final class _DataStorage {
     public var _bytes: UnsafeMutableRawPointer?
     public var _length: Int
     public var _capacity: Int
-    public var _needToZero: Bool
+    public var _offset: Int
     public var _deallocator: ((UnsafeMutableRawPointer, Int) -> Void)?
     public var _backing: Backing = .swift
-    public var _offset: Int
+    public var _needToZero: Bool
     
     public var bytes: UnsafeRawPointer? {
         @inline(__always)


### PR DESCRIPTION
The backing storage for Data (_DataStorage) previously would require an allocation size of 72 bytes for the overs, however re-ordering the members to a more compact layout can easily yield considerably less. We can shave off 14 bytes and hit a mark of 58 bytes per storage for the ivars; which can easily fit into a smaller bucket size (not accounting for the class information).

This resolves the following issues:
<rdar://problem/38150740>