### PR TITLE
swift-api-digester: keep track of type declarations with fixed layout.

### DIFF
--- a/include/swift/IDE/DigesterEnums.def
+++ b/include/swift/IDE/DigesterEnums.def
@@ -72,6 +72,7 @@ NODE_ANNOTATION(StaticChange)
 NODE_ANNOTATION(OwnershipChange)
 
 DECL_ATTR(deprecated)
+DECL_ATTR(fixedLayout)
 
 KEY(kind)
 KEY(name)

--- a/test/api-digester/Inputs/cake.swift
+++ b/test/api-digester/Inputs/cake.swift
@@ -1,5 +1,7 @@
 public protocol P1 {}
 public protocol P2 {}
+
+@_fixed_layout
 public struct S1: P1 {
   public static func foo1() {}
   mutating public func foo2() {}

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -115,6 +115,9 @@
         "P1",
         "P2"
       ],
+      "declAttributes": [
+        "fixedLayout"
+      ],
       "children": [
         {
           "kind": "Function",

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -433,6 +433,7 @@ public:
   StringRef getFullyQualifiedName() const;
   bool isSDKPrivate() const;
   bool isDeprecated() const;
+  bool hasFixedLayout() const;
   bool isStatic() const { return IsStatic; };
   bool isFromExtension() const { return ExtInfo; }
   const ParentExtensionInfo& getExtensionInfo() const {
@@ -712,6 +713,10 @@ SDKNode *SDKNodeRoot::getInstance(SDKContext &Ctx) {
 
 bool SDKNodeDecl::isDeprecated() const {
   return hasDeclAttribute(SDKDeclAttrKind::DAK_deprecated);
+}
+
+bool SDKNodeDecl::hasFixedLayout() const {
+  return hasDeclAttribute(SDKDeclAttrKind::DAK_fixedLayout);
 }
 
 bool SDKNodeDecl::isSDKPrivate() const {
@@ -1294,6 +1299,11 @@ SDKNodeInitInfo::SDKNodeInitInfo(SDKContext &Ctx, ValueDecl *VD)
   }
   if (VD->getAttrs().getDeprecated(VD->getASTContext()))
     DeclAttrs.push_back(SDKDeclAttrKind::DAK_deprecated);
+
+  // If this is fixed_layout struct.
+  if (VD->getAttrs().hasAttribute<FixedLayoutAttr>()) {
+    DeclAttrs.push_back(SDKDeclAttrKind::DAK_fixedLayout);
+  }
 
   // If the decl is declared in an extension, calculate the extension info.
   if (auto *Ext = dyn_cast_or_null<ExtensionDecl>(VD->getDeclContext())) {


### PR DESCRIPTION
We need special logic to check abi-stability for decls with fixed
layout.