### PR TITLE
☣️[stdlib] Revisit underestimatedCount default implementation for Collection

### DIFF
--- a/benchmark/single-source/Queue.swift
+++ b/benchmark/single-source/Queue.swift
@@ -26,14 +26,6 @@ public let QueueConcrete = BenchmarkInfo(
   setUpFunction: { buildWorkload() },
   tearDownFunction: nil)
  
-// TODO: remove when there is a native equivalent in the std lib
-extension RangeReplaceableCollection where Self: BidirectionalCollection {
-  public mutating func popLast() -> Element? {
-    if isEmpty { return nil}
-    else { return removeLast() }
-  }
-}
-
 public struct Queue<Storage: RangeReplaceableCollection>
 where Storage: BidirectionalCollection {
   public typealias Element = Storage.Element

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1157,13 +1157,10 @@ extension Collection {
 
   /// A value less than or equal to the number of elements in the collection.
   ///
-  /// - Complexity: O(1) if the collection conforms to
-  ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the length
-  ///   of the collection.
+  /// - Complexity: O(1)
   @inlinable
   public var underestimatedCount: Int {
-    // TODO: swift-3-indexing-model - review the following
-    return count
+    return 0
   }
 
   /// The number of elements in the collection.

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -584,6 +584,15 @@ extension Dictionary: Sequence {
   public func makeIterator() -> DictionaryIterator<Key, Value> {
     return _variantBuffer.makeIterator()
   }
+
+  /// A value less than or eequal to the number of key-value pairs in the
+  /// dictionary.
+  ///
+  /// - Complexity: O(1).
+  @_inlineable // FIXME(sil-serialize-all)
+  public var underestimatedCount: Int {
+    return _variantBuffer.count
+  }
 }
 
 // This is not quite Sequence.filter, because that returns [Element], not Self
@@ -1250,6 +1259,14 @@ extension Dictionary {
       return _variantBuffer.count
     }
 
+    /// A value less than or equal to the number of keys in the dictionary.
+    ///
+    /// - Complexity: O(1).
+    @inlinable // FIXME(sil-serialize-all)
+    public var underestimatedCount: Int {
+      return _variantBuffer.count
+    }
+
     @inlinable // FIXME(sil-serialize-all)
     public var isEmpty: Bool {
       return count == 0
@@ -1353,6 +1370,14 @@ extension Dictionary {
     /// - Complexity: O(1).
     @inlinable // FIXME(sil-serialize-all)
     public var count: Int {
+      return _variantBuffer.count
+    }
+
+    /// A value less than or equal to the number of values in the dictionary.
+    ///
+    /// - Complexity: O(1).
+    @inlinable // FIXME(sil-serialize-all)
+    public var underestimatedCount: Int {
       return _variantBuffer.count
     }
 

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -3390,6 +3390,11 @@ ${assignmentOperatorComment(x.operator, True)}
     }
 
     @inlinable // FIXME(sil-serialize-all)
+    public var underestimatedCount: Int {
+      return (${bits} + ${word_bits} - 1) / ${word_bits}
+    }
+
+    @inlinable // FIXME(sil-serialize-all)
     public var count: Int {
       return (${bits} + ${word_bits} - 1) / ${word_bits}
     }

--- a/stdlib/public/core/Map.swift
+++ b/stdlib/public/core/Map.swift
@@ -86,8 +86,7 @@ extension LazyMapSequence: LazySequenceProtocol {
   /// The default implementation returns 0. If you provide your own
   /// implementation, make sure to compute the value nondestructively.
   ///
-  /// - Complexity: O(1), except if the sequence also conforms to `Collection`.
-  ///   In this case, see the documentation of `Collection.underestimatedCount`.
+  /// - Complexity: O(1).
   @inlinable
   public var underestimatedCount: Int {
     return _base.underestimatedCount
@@ -129,9 +128,7 @@ extension LazyMapCollection: Sequence {
   /// A value less than or equal to the number of elements in the sequence,
   /// calculated nondestructively.
   ///
-  /// - Complexity: O(1) if the collection conforms to
-  ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the length
-  ///   of the collection.
+  /// - Complexity: O(1).
   @inlinable
   public var underestimatedCount: Int {
     return _base.underestimatedCount

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -164,6 +164,14 @@ extension RandomAccessCollection {
     }
     return index(i, offsetBy: n)
   }
+
+  /// A value less than or equal to the number of elements in the collection.
+  ///
+  /// - Complexity: O(1)
+  @_inlineable
+  public var underestimatedCount: Int {
+    return count
+  }
 }
 
 // Provides an alternative default associated type witness for Indices

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -110,6 +110,11 @@ extension ReversedCollection: Sequence {
   public func makeIterator() -> Iterator {
     return Iterator(_base: _base)
   }
+
+  @_inlineable
+  public var underestimatedCount: Int {
+    return _base.underestimatedCount
+  }
 }
 
 extension ReversedCollection {

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -344,8 +344,7 @@ public protocol Sequence {
   /// The default implementation returns 0. If you provide your own
   /// implementation, make sure to compute the value nondestructively.
   ///
-  /// - Complexity: O(1), except if the sequence also conforms to `Collection`.
-  ///   In this case, see the documentation of `Collection.underestimatedCount`.
+  /// - Complexity: O(1)
   var underestimatedCount: Int { get }
 
   /// Returns an array containing the results of mapping the given closure

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -245,6 +245,14 @@ extension Set: Sequence {
     return _variantBuffer.makeIterator()
   }
 
+  /// A value less than or eequal to the number of elements in the set.
+  ///
+  /// - Complexity: O(1).
+  @_inlineable // FIXME(sil-serialize-all)
+  public var underestimatedCount: Int {
+    return _variantBuffer.count
+  }
+
   /// Returns a Boolean value that indicates whether the given element exists
   /// in the set.
   ///

--- a/validation-test/stdlib/CollectionType.swift.gyb
+++ b/validation-test/stdlib/CollectionType.swift.gyb
@@ -352,7 +352,7 @@ CollectionTypeTests.test("underestimatedCount/Collection/DefaultImplementation")
   }
   do {
     let s = CollectionWithDefaultUnderestimatedCount(count: 5)
-    expectEqual(5, callGenericUnderestimatedCount(s))
+    expectEqual(0, callGenericUnderestimatedCount(s))
   }
 }
 

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -541,7 +541,7 @@ extension LazyCollection where Base : TestProtocol1 {
 
 LazyTestSuite.test("Lazy${TraversalCollection}.array") {
   let base = Minimal${TraversalCollection}(
-    elements: [ 0, 30, 10, 90 ], underestimatedCount: .value(42))
+    elements: [ 0, 30, 10, 90 ], underestimatedCount: .overestimate)
   let arrayFromLazy = Array(base.lazy)
 
   expectEqual([ 0, 30, 10, 90 ], arrayFromLazy)
@@ -557,7 +557,7 @@ LazyTestSuite.test("Lazy${TraversalCollection}.array") {
 LazyTestSuite.test("Lazy${TraversalCollection}.reversed") {
   let base = Minimal${TraversalCollection}(
     elements: [ 0, 30, 10, 90 ].map(OpaqueValue.init),
-    underestimatedCount: .value(42))
+    underestimatedCount: .precise)
   var reversed = base.lazy.reversed()
   expectType(
     LazyCollection<


### PR DESCRIPTION
Currently the default implementation of `underestimatedCount` property
for a `Collection` is to simply return `count`. Problem with that is
`count` is allowed to be O(n) operation on some collections and can have
a side-effect of iterating over the whole collection, which defeats the
whole purpose of `underestimatedCount`.

The proposed change makes `underestimatedCount` strictly O(1), which
requires a certain pessimization of it's return value for `Collection`
instances that are only forward or bidirectional.
`RandomAccessCollection` instances guarantee constant time `count` and
therefore still can provide a default implementation of
`underestimatedCount` in terms of `count`.

**UPD**: Accidentally addresses https://bugs.swift.org/browse/SR-6693