### PR TITLE
Make JSON fix-it outputs be per-primary in batch mode.

### DIFF
--- a/include/swift/Basic/SupplementaryOutputPaths.h
+++ b/include/swift/Basic/SupplementaryOutputPaths.h
@@ -49,6 +49,9 @@ struct SupplementaryOutputPaths {
   /// frontend invocation.
   std::string SerializedDiagnosticsPath;
 
+  /// The path to which we should output fix-its as source edits.
+  std::string FixItsOutputPath;
+
   /// The path to which we should output a loaded module trace file.
   /// It is currently only used with WMO, but could be generalized.
   std::string LoadedModuleTracePath;

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -55,9 +55,6 @@ public:
   /// The name of the library to link against when using this module.
   std::string ModuleLinkName;
 
-  /// The path to which we should output fixits as source edits.
-  std::string FixitsOutputPath;
-
   /// Arguments which should be passed in immediate mode.
   std::vector<std::string> ImmediateArgv;
 

--- a/include/swift/Frontend/InputFile.h
+++ b/include/swift/Frontend/InputFile.h
@@ -95,6 +95,9 @@ public:
     return getPrimarySpecificPaths().SupplementaryOutputs
         .SerializedDiagnosticsPath;
   }
+  std::string fixItsOutputPath() const {
+    return getPrimarySpecificPaths().SupplementaryOutputs.FixItsOutputPath;
+  }
 };
 } // namespace swift
 

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -117,9 +117,6 @@ bool ArgsToFrontendOptionsConverter::convert() {
   if (checkUnusedSupplementaryOutputPaths())
     return true;
 
-  if (const Arg *A = Args.getLastArg(OPT_emit_fixits_path))
-    Opts.FixitsOutputPath = A->getValue();
-
   if (const Arg *A = Args.getLastArg(OPT_module_link_name))
     Opts.ModuleLinkName = A->getValue();
 

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -283,13 +283,15 @@ SupplementaryOutputPathsComputer::getSupplementaryOutputPathsFromArguments()
       options::OPT_emit_reference_dependencies_path);
   auto serializedDiagnostics = getSupplementaryFilenamesFromArguments(
       options::OPT_serialize_diagnostics_path);
+  auto fixItsOutput = getSupplementaryFilenamesFromArguments(
+      options::OPT_emit_fixits_path);
   auto loadedModuleTrace = getSupplementaryFilenamesFromArguments(
       options::OPT_emit_loaded_module_trace_path);
   auto TBD = getSupplementaryFilenamesFromArguments(options::OPT_emit_tbd_path);
 
   if (!objCHeaderOutput || !moduleOutput || !moduleDocOutput ||
       !dependenciesFile || !referenceDependenciesFile ||
-      !serializedDiagnostics || !loadedModuleTrace || !TBD) {
+      !serializedDiagnostics || !fixItsOutput || !loadedModuleTrace || !TBD) {
     return None;
   }
   std::vector<SupplementaryOutputPaths> result;
@@ -304,6 +306,7 @@ SupplementaryOutputPathsComputer::getSupplementaryOutputPathsFromArguments()
     sop.DependenciesFilePath = (*dependenciesFile)[i];
     sop.ReferenceDependenciesFilePath = (*referenceDependenciesFile)[i];
     sop.SerializedDiagnosticsPath = (*serializedDiagnostics)[i];
+    sop.FixItsOutputPath = (*fixItsOutput)[i];
     sop.LoadedModuleTracePath = (*loadedModuleTrace)[i];
     sop.TBDPath = (*TBD)[i];
 
@@ -356,6 +359,9 @@ SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
       OPT_serialize_diagnostics, pathsFromArguments.SerializedDiagnosticsPath,
       "dia", "", defaultSupplementaryOutputPathExcludingExtension);
 
+  // There is no non-path form of -emit-fixits-path
+  auto fixItsOutputPath = pathsFromArguments.FixItsOutputPath;
+
   auto objcHeaderOutputPath = determineSupplementaryOutputFilename(
       OPT_emit_objc_header, pathsFromArguments.ObjCHeaderOutputPath, "h", "",
       defaultSupplementaryOutputPathExcludingExtension);
@@ -391,6 +397,7 @@ SupplementaryOutputPathsComputer::computeOutputPathsForOneInput(
   sop.DependenciesFilePath = dependenciesFilePath;
   sop.ReferenceDependenciesFilePath = referenceDependenciesFilePath;
   sop.SerializedDiagnosticsPath = serializedDiagnosticsPath;
+  sop.FixItsOutputPath = fixItsOutputPath;
   sop.LoadedModuleTracePath = loadedModuleTracePath;
   sop.TBDPath = tbdPath;
   return sop;

--- a/test/FixCode/Inputs/batch-mode-helper.swift
+++ b/test/FixCode/Inputs/batch-mode-helper.swift
@@ -1,0 +1,10 @@
+enum E2 {
+  case x
+  case y
+  case z
+}
+
+func fooHelper(_ e: E2) {
+  switch e {
+  }
+}

--- a/test/FixCode/batch-mode.swift
+++ b/test/FixCode/batch-mode.swift
@@ -1,0 +1,24 @@
+// RUN: not %swift -typecheck -target %target-triple -primary-file %s  -emit-fixits-path %t.main.remap -primary-file %S/Inputs/batch-mode-helper.swift -emit-fixits-path %t.helper.remap -diagnostics-editor-mode
+// RUN: %FileCheck -check-prefix=CHECK-MAIN %s < %t.main.remap
+// RUN: %FileCheck -check-prefix=NEGATIVE-MAIN %s < %t.main.remap
+// RUN: %FileCheck -check-prefix=CHECK-HELPER %s < %t.helper.remap
+// RUN: %FileCheck -check-prefix=NEGATIVE-HELPER %s < %t.helper.remap
+
+// CHECK-MAIN: "file": "{{.+}}batch-mode.swift"
+// CHECK-MAIN: "text": "case .a:\n<#code#>\ncase .b:\n<#code#>\ncase .c:\n<#code#>\n"
+// NEGATIVE-MAIN-NOT: batch-mode-helper.swift
+
+// CHECK-HELPER: "file": "{{.+}}batch-mode-helper.swift"
+// CHECK-HELPER: "text": "case .x:\n<#code#>\ncase .y:\n<#code#>\ncase .z:\n<#code#>\n"
+// NEGATIVE-HELPER-NOT: batch-mode.swift
+
+enum E1 {
+  case a
+  case b
+  case c
+}
+
+func fooMain(_ e: E1) {
+  switch e {
+  }
+}


### PR DESCRIPTION
This means moving the output path into SupplementaryOutputPaths, and using the same sort of diagnostic dispatching that serialized diagnostics use. This is part of what's needed to run the migrator in batch mode (though it's not sufficient itself).