### PR TITLE
[SwiftSyntax] Publicize DiagnosticEngine.addConsumer and add hasErrors property

### DIFF
--- a/test/SwiftSyntax/DiagnosticTest.swift
+++ b/test/SwiftSyntax/DiagnosticTest.swift
@@ -33,6 +33,7 @@ Diagnostics.test("DiagnosticEmission") {
   let fixLoc = loc()
 
   let engine = DiagnosticEngine()
+  expectFalse(engine.hasErrors)
 
   engine.diagnose(.cannotConvert(fromType: "Int", toType: "Bool"),
                   location: startLoc) {
@@ -42,10 +43,11 @@ Diagnostics.test("DiagnosticEmission") {
 
   expectEqual(engine.diagnostics.count, 1)
   guard let diag = engine.diagnostics.first else { return }
-  expectEqual(diag.message.text, 
+  expectEqual(diag.message.text,
               "cannot convert value of type 'Int' to 'Bool'")
   expectEqual(diag.message.severity, .error)
   expectEqual(diag.notes.count, 1)
+  expectTrue(engine.hasErrors)
 
   guard let note = diag.notes.first else { return }
   expectEqual(note.message.text, "check for explicit equality to '0'")

--- a/tools/SwiftSyntax/DiagnosticEngine.swift
+++ b/tools/SwiftSyntax/DiagnosticEngine.swift
@@ -53,7 +53,7 @@ public class DiagnosticEngine {
   }
 
   /// If any of the diagnostics in this engine have the `error` severity.
-  var hasErrors: Bool {
+  public var hasErrors: Bool {
     return diagnostics.contains(where: { $0.message.severity == .error })
   }
 

--- a/tools/SwiftSyntax/DiagnosticEngine.swift
+++ b/tools/SwiftSyntax/DiagnosticEngine.swift
@@ -27,7 +27,7 @@ public class DiagnosticEngine {
   public private(set) var diagnostics = [Diagnostic]()
 
   /// Adds the provided consumer to the consumers list.
-  func addConsumer(_ consumer: DiagnosticConsumer) {
+  public func addConsumer(_ consumer: DiagnosticConsumer) {
     consumers.append(consumer)
 
     // Start the consumer with all previous diagnostics.
@@ -44,12 +44,17 @@ public class DiagnosticEngine {
   public func diagnose(_ message: Diagnostic.Message,
                        location: SourceLocation? = nil,
                        actions: ((inout Diagnostic.Builder) -> Void)? = nil) {
-    let diagnostic = Diagnostic(message: message, location: location, 
+    let diagnostic = Diagnostic(message: message, location: location,
                                 actions: actions)
     diagnostics.append(diagnostic)
     for consumer in consumers {
       consumer.handle(diagnostic)
     }
+  }
+
+  /// If any of the diagnostics in this engine have the `error` severity.
+  var hasErrors: Bool {
+    return diagnostics.contains(where: { $0.message.severity == .error })
   }
 
   /// Tells each consumer to finalize their diagnostic output.


### PR DESCRIPTION
This patch adds a property, `hasErrors`, to determine if the `DiagnosticEngine` has registered any errors.

It also publicizes `addConsumer` so clients can add their own consumers.