### PR TITLE
Apply generic metadata patterns to all types and change their layout.

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1177,6 +1177,47 @@ enum class GenericRequirementLayoutKind : uint32_t {
   Class = 0,
 };
 
+/// Flags used by generic metadata patterns.
+class GenericMetadataPatternFlags : public FlagSet<uint32_t> {
+  enum {
+    // All of these values are bit offsets or widths.
+    // General flags build up from 0.
+    // Kind-specific flags build down from 31.
+
+    /// Does this pattern have an extra-data pattern?
+    HasExtraDataPattern = 0,
+
+    // Class-specific flags.
+
+    /// Does this pattern have an immediate-members pattern?
+    Class_HasImmediateMembersPattern = 31,
+
+    // Value-specific flags.
+
+    /// For value metadata: the metadata kind of the type.
+    Value_MetadataKind = 21,
+    Value_MetadataKind_width = 11,
+  };
+
+public:
+  explicit GenericMetadataPatternFlags(uint32_t bits) : FlagSet(bits) {}
+  constexpr GenericMetadataPatternFlags() {}
+
+  FLAGSET_DEFINE_FLAG_ACCESSORS(Class_HasImmediateMembersPattern,
+                                class_hasImmediateMembersPattern,
+                                class_setHasImmediateMembersPattern)
+
+  FLAGSET_DEFINE_FLAG_ACCESSORS(HasExtraDataPattern,
+                                hasExtraDataPattern,
+                                setHasExtraDataPattern)
+
+  FLAGSET_DEFINE_FIELD_ACCESSORS(Value_MetadataKind,
+                                 Value_MetadataKind_width,
+                                 MetadataKind,
+                                 value_getMetadataKind,
+                                 value_setMetadataKind)
+};
+
 } // end namespace swift
 
 #endif /* SWIFT_ABI_METADATAVALUES_H */

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -800,19 +800,19 @@ FUNCTION(GetGenericMetadata, swift_getGenericMetadata, C_CC,
 
 // Metadata *swift_allocateGenericClassMetadata(ClassDescriptor *type,
 //                                              const void * const *arguments,
-//                                              const void *template);
+//                                              const void * const *template);
 FUNCTION(AllocateGenericClassMetadata, swift_allocateGenericClassMetadata,
          C_CC, RETURNS(TypeMetadataPtrTy),
          ARGS(TypeContextDescriptorPtrTy, Int8PtrPtrTy, Int8PtrPtrTy),
          ATTRS(NoUnwind))
 
 // Metadata *swift_allocateGenericValueMetadata(ValueTypeDescriptor *type,
-//                                              const void *template,
-//                                              size_t templateSize,
-//                                              const void * const *arguments);
+//                                              const void * const *arguments,
+//                                              const void * const *template,
+//                                              size_t extraSize);
 FUNCTION(AllocateGenericValueMetadata, swift_allocateGenericValueMetadata,
          C_CC, RETURNS(TypeMetadataPtrTy),
-         ARGS(TypeContextDescriptorPtrTy, Int8PtrPtrTy, SizeTy, Int8PtrPtrTy),
+         ARGS(TypeContextDescriptorPtrTy, Int8PtrPtrTy, Int8PtrPtrTy, SizeTy),
          ATTRS(NoUnwind))
 
 // const ProtocolWitnessTable *

--- a/lib/IRGen/EnumMetadataVisitor.h
+++ b/lib/IRGen/EnumMetadataVisitor.h
@@ -50,7 +50,8 @@ public:
     // EnumMetadata header.
     asImpl().addNominalTypeDescriptor();
 
-    // Instantiation-specific.
+    // Everything after this is type-specific.
+    asImpl().noteStartOfTypeSpecificMembers();
 
     // Generic arguments.
     // This must always be the first piece of trailing data.
@@ -85,6 +86,7 @@ public:
     addPointer();
   }
   void addPayloadSize() { addPointer(); }
+  void noteStartOfTypeSpecificMembers() {}
 
 private:
   void addPointer() {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3376,7 +3376,14 @@ IRGenModule::getAddrOfTypeMetadataInstantiationFunction(NominalTypeDecl *D,
     return entry;
   }
 
-  llvm::Type *argTys[] = {TypeContextDescriptorPtrTy, Int8PtrPtrTy};
+  llvm::Type *argTys[] = {
+    /// Type descriptor.
+    TypeContextDescriptorPtrTy,
+    /// Generic arguments.
+    Int8PtrPtrTy,
+    /// Generic metadata pattern.
+    Int8PtrPtrTy
+  };
   auto fnType = llvm::FunctionType::get(TypeMetadataPtrTy,
                                         argTys, /*isVarArg*/ false);
   Signature signature(fnType, llvm::AttributeList(), DefaultCC);

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2643,21 +2643,21 @@ namespace {
     
     /// Fill in the fields of a TypeGenericContextDescriptorHeader.
     void addGenericParametersHeader() {
-      asImpl().addMetadataInstantiationFunction();
       asImpl().addMetadataInstantiationCache();
+
+      asImpl().addMetadataInstantiationPattern();
 
       super::addGenericParametersHeader();
     }
 
-    void addMetadataInstantiationFunction() {
+    void addMetadataInstantiationPattern() {
       if (!HasMetadata) {
         B.addInt32(0);
         return;
       }
 
-      auto function =
-        IGM.getAddrOfTypeMetadataInstantiationFunction(Type, NotForDefinition);
-      B.addRelativeAddress(function);
+      auto pattern = IGM.getAddrOfTypeMetadataPattern(Type);
+      B.addRelativeAddress(pattern);
     }
 
     void addMetadataInstantiationCache() {
@@ -3202,11 +3202,7 @@ void IRGenModule::addFieldTypes(ArrayRef<CanType> fieldTypes) {
 namespace {
   /// An adapter class which turns a metadata layout class into a
   /// generic metadata layout class.
-  ///
-  /// If AddGenericArguments is false, fill ops will be added for the
-  /// arguments, but space for them won't actually be built into the
-  /// pattern.
-  template <class Impl, class Base, bool AddGenericArguments = true>
+  template <class Impl, class Base>
   class GenericMetadataBuilderBase : public Base {
     typedef Base super;
 
@@ -3218,17 +3214,11 @@ namespace {
     SmallVector<FillOp, 8> FillOps;
 
   protected:
-    /// The offset of the address point in the type we're emitting.
-    Size AddressPoint = Size::invalid();
-
-    /// The total size of the template (following any header).
-    Size TemplateSize = Size::invalid();
-
-    IRGenModule &IGM = super::IGM;
+    using super::IGM;
     using super::asImpl;
     using super::Target;
     using super::B;
-    
+
     /// Set to true if the metadata record for the generic type has fields
     /// outside of the generic parameter vector.
     bool HasDependentMetadata = false;
@@ -3270,6 +3260,7 @@ namespace {
       Explosion params = IGF.collectParameters();
       llvm::Value *descriptor = params.claimNext();
       llvm::Value *args = params.claimNext();
+      llvm::Value *templatePointer = params.claimNext();
 
       // Bind the generic arguments.
       if (Target->isGenericContext()) {
@@ -3279,7 +3270,7 @@ namespace {
 
       // Allocate the metadata.
       llvm::Value *metadataValue =
-        asImpl().emitAllocateMetadata(IGF, descriptor, args);
+        asImpl().emitAllocateMetadata(IGF, descriptor, args, templatePointer);
 
       // Execute the fill ops. Cast the parameters to word pointers because the
       // fill indexes are word-indexed.
@@ -3319,55 +3310,167 @@ namespace {
       IGF.Builder.CreateRet(metadataValue);
     }
 
+    /// The information necessary to fill in a GenericMetadataPartialPattern
+    /// structure.
+    struct PartialPattern {
+      llvm::Constant *Data;
+      Size DataOffset;
+      Size DataSize;
+    };
+    void addPartialPattern(PartialPattern pattern) {
+      // RelativeDirectPointer<void*> Pattern;
+      B.addRelativeAddress(pattern.Data);
+
+      // uint16_t OffsetInWords;
+      B.addInt16(IGM.getOffsetInWords(pattern.DataOffset));
+
+      // uint16_t SizeInWords;
+      B.addInt16(IGM.getOffsetInWords(pattern.DataSize));
+    }
+
   public:
     void createMetadataAccessFunction() {
       (void) getGenericTypeMetadataAccessFunction(IGM, Target, ForDefinition);
     }
 
     void layout() {
-      asImpl().addDependentData();
-      
-      // Lay out the template data.
-      super::layout();
+      asImpl().layoutHeader();
 
-      TemplateSize = getNextOffsetFromTemplateHeader();
+      if (asImpl().hasExtraDataPattern()) {
+        asImpl().addExtraDataPattern();
+      }
+
+      // Immediate-members pattern.  This is only valid for classes.
+      if (asImpl().hasImmediateMembersPattern()) {
+        asImpl().addImmediateMembersPattern();
+      }
+
+      // We're done with the pattern now.
+#ifndef NDEBUG
+      auto finalOffset = B.getNextOffsetFromGlobal();
+#endif
 
       asImpl().emitInstantiationDefinitions();
+
+      assert(finalOffset == B.getNextOffsetFromGlobal() &&
+             "emitInstantiationDefinitions added members to the pattern!");
+    }
+
+    // Emit the fields of GenericMetadataPattern.
+    void layoutHeader() {
+      // RelativePointer<InstantiationFunction_t> InstantiationFunction;
+      asImpl().addInstantiationFunction();
+
+      // ClassMetadataPatternFlags PatternFlags;
+      asImpl().addPatternFlags();
+    }
+
+    void addInstantiationFunction() {
+      auto function = IGM.getAddrOfTypeMetadataInstantiationFunction(Target,
+                                                              NotForDefinition);
+      B.addRelativeAddress(function);
+    }
+
+    void addPatternFlags() {
+      GenericMetadataPatternFlags flags = asImpl().getPatternFlags();
+      B.addInt32(flags.getOpaqueValue());
+    }
+
+    GenericMetadataPatternFlags getPatternFlags() {
+      GenericMetadataPatternFlags flags;
+
+      if (asImpl().hasExtraDataPattern())
+        flags.setHasExtraDataPattern(true);
+
+      return flags;
+    }
+
+    bool hasExtraDataPattern() {
+      return false;
+    }
+    void addExtraDataPattern() {
+      asImpl().addPartialPattern(asImpl().buildExtraDataPattern());
+    }
+    PartialPattern buildExtraDataPattern() {
+      llvm_unreachable("no extra data pattern!");
+    }
+
+    bool hasImmediateMembersPattern() {
+      return false;
+    }
+    void addImmediateMembersPattern() {
+      asImpl().addPartialPattern(asImpl().buildImmediateMembersPattern());
+    }
+    PartialPattern buildImmediateMembersPattern() {
+      llvm_unreachable("no immediate members pattern!");
     }
 
     void emitInstantiationDefinitions() {
+      // Register fill ops for all the immediate type arguments.
+      // This must happen before we emit the instantiation function below.
+      asImpl().addGenericFields(Target, Target->getDeclaredTypeInContext());
+
+      // Force the emission of the nominal type descriptor, although we
+      // don't use it yet.
+      (void) asImpl().emitNominalTypeDescriptor();
+
+      // Emit the instantiation function.
       asImpl().emitCreateFunction();
+
+      // Emit the instantiation cache.
       asImpl().emitInstantiationCache();
-    }
-
-    /// Write down the index of the address point.
-    void noteAddressPoint() {
-      AddressPoint = getNextOffsetFromTemplateHeader();
-      super::noteAddressPoint();
-    }
-
-    /// Ignore any preallocated header on the template.
-    Size getNextOffsetFromTemplateHeader() const {
-      return B.getNextOffsetFromGlobal();
     }
 
     template <class... T>
     void addGenericArgument(CanType type, T &&...args) {
       FillOps.push_back({type, None});
-      if (AddGenericArguments)
-        super::addGenericArgument(type, std::forward<T>(args)...);
     }
 
     template <class... T>
     void addGenericWitnessTable(CanType type, ProtocolConformanceRef conf,
                                 T &&...args) {
       FillOps.push_back({type, conf});
-      if (AddGenericArguments)
-        super::addGenericWitnessTable(type, conf, std::forward<T>(args)...);
     }
-    
-    // Can be overridden by subclassers to emit other dependent metadata.
-    void addDependentData() {}
+  };
+
+  template <class Impl, class Base>
+  class GenericValueMetadataBuilderBase
+         : public GenericMetadataBuilderBase<Impl, Base> {
+    using super = GenericMetadataBuilderBase<Impl, Base>;
+  protected:
+    using super::IGM;
+    using super::asImpl;
+    using super::Target;
+    using super::B;
+
+    template <class... T>
+    GenericValueMetadataBuilderBase(IRGenModule &IGM, T &&...args)
+      : super(IGM, std::forward<T>(args)...) {}
+
+  public:
+    /// Emit the fields of a GenericValueMetadataPattern.
+    void layoutHeader() {
+      super::layoutHeader();
+
+      // RelativeIndirectablePointer<const ValueWitnessTable> ValueWitnesses;
+      asImpl().addValueWitnessTable();
+
+    }
+
+    GenericMetadataPatternFlags getPatternFlags() {
+      auto flags = super::getPatternFlags();
+
+      flags.value_setMetadataKind(asImpl().getMetadataKind());
+
+      assert(!asImpl().hasImmediateMembersPattern());
+
+      return flags;
+    }
+
+    void addValueWitnessTable() {
+      auto table = asImpl().emitValueWitnessTable();
+      B.addRelativeAddress(table);
+    }
   };
 } // end anonymous namespace
 
@@ -3669,11 +3772,8 @@ namespace {
     }
 
     void addDestructorFunction() {
-      auto dtorRef = SILDeclRef(Target->getDestructor(),
-                                SILDeclRef::Kind::Deallocator);
-      SILFunction *dtorFunc = IGM.getSILModule().lookUpFunction(dtorRef);
-      if (dtorFunc) {
-        B.add(IGM.getAddrOfSILFunction(dtorFunc, NotForDefinition));
+      if (auto ptr = getAddrOfDestructorFunction()) {
+        B.add(*ptr);
       } else {
         // In case the optimizer removed the function. See comment in
         // addMethod().
@@ -3681,22 +3781,37 @@ namespace {
       }
     }
 
+    Optional<llvm::Constant *> getAddrOfDestructorFunction() {
+      auto dtorRef = SILDeclRef(Target->getDestructor(),
+                                SILDeclRef::Kind::Deallocator);
+      SILFunction *dtorFunc = IGM.getSILModule().lookUpFunction(dtorRef);
+      if (!dtorFunc) return llvm::None;
+      return IGM.getAddrOfSILFunction(dtorFunc, NotForDefinition);
+    }
+
     void addNominalTypeDescriptor() {
-      auto descriptor =
-        ClassContextDescriptorBuilder(IGM, Target, RequireMetadata).emit();
+      auto descriptor = asImpl().emitNominalTypeDescriptor();
       B.add(descriptor);
     }
 
+    llvm::Constant *emitNominalTypeDescriptor() {
+      return ClassContextDescriptorBuilder(IGM, Target, RequireMetadata).emit();
+    }
+
     void addIVarDestroyer() {
-      auto dtorFunc = IGM.getAddrOfIVarInitDestroy(Target,
-                                                   /*isDestroyer=*/ true,
-                                                   /*isForeign=*/ false,
-                                                   NotForDefinition);
+      auto dtorFunc = getAddrOfIVarDestroyer();
       if (dtorFunc) {
         B.add(*dtorFunc);
       } else {
         B.addNullPointer(IGM.FunctionPtrTy);
       }
+    }
+
+    Optional<llvm::Function *> getAddrOfIVarDestroyer() {
+      return IGM.getAddrOfIVarInitDestroy(Target,
+                                          /*isDestroyer=*/ true,
+                                          /*isForeign=*/ false,
+                                          NotForDefinition);
     }
 
     bool addReferenceToHeapMetadata(CanType type, bool allowUninitialized) {
@@ -4129,14 +4244,12 @@ namespace {
   class GenericClassMetadataBuilder :
     public GenericMetadataBuilderBase<GenericClassMetadataBuilder,
                       ClassMetadataBuilderBase<GenericClassMetadataBuilder,
-                                               ResilientClassMemberBuilder>,
-                                      /*add generic arguments*/ false>
+                                               ResilientClassMemberBuilder>>
   {
     typedef GenericMetadataBuilderBase super;
 
     Optional<ConstantAggregateBuilderBase::PlaceholderPosition>
-      NumExtraDataWords, ClassRODataOffset, MetaclassObjectOffset,
-      MetaclassRODataOffset;
+      ClassRODataOffset, MetaclassObjectOffset, MetaclassRODataOffset;
   public:
     GenericClassMetadataBuilder(IRGenModule &IGM, ClassDecl *theClass,
                                 ConstantStructBuilder &B,
@@ -4149,107 +4262,103 @@ namespace {
       HasDependentMetadata = true;
     }
 
-    void layout() {
-      // HeapObjectDestroyer *Destroy;
+    void layoutHeader() {
+      super::layoutHeader();
+
+      // RelativePointer<HeapObjectDestroyer> Destroy;
       addDestructorFunction();
 
-      // ClassIVarDestroyer *IVarDestroyer;
+      // RelativePointer<ClassIVarDestroyer> IVarDestroyer;
       addIVarDestroyer();
 
       // ClassFlags Flags;
       addClassFlags();
 
-      // TODO: consider using this to initialize the field offsets (and then
-      // suppress dynamic layout for them).
-      // uint16_t ImmediateMembersPattern_Size;
-      // uint16_t ImmediateMembersPattern_TargetOffset;
-      B.addInt16(0);
-      B.addInt16(0);
-
-      // uint16_t NumExtraDataWords;
-      NumExtraDataWords = B.addPlaceholderWithSize(IGM.Int16Ty);
-
       // uint16_t ClassRODataOffset;
-      ClassRODataOffset = B.addPlaceholderWithSize(IGM.Int16Ty);
+      if (IGM.ObjCInterop)
+        ClassRODataOffset = B.addPlaceholderWithSize(IGM.Int16Ty);
+      else
+        B.addInt16(0);
 
       // uint16_t MetaclassObjectOffset;
-      MetaclassObjectOffset = B.addPlaceholderWithSize(IGM.Int16Ty);
+      if (IGM.ObjCInterop)
+        MetaclassObjectOffset = B.addPlaceholderWithSize(IGM.Int16Ty);
+      else
+        B.addInt16(0);
 
       // uint16_t MetadataRODataOffset;
-      MetaclassRODataOffset = B.addPlaceholderWithSize(IGM.Int16Ty);
+      if (IGM.ObjCInterop)
+        MetaclassRODataOffset = B.addPlaceholderWithSize(IGM.Int16Ty);
+      else
+        B.addInt16(0);
 
-      // Immediate members pattern:
-      //   (currently we don't take advantage of this)
+      // uint16_t Reserved;
+      B.addInt16(0);
+    }
 
-      // Extra data pattern:
-      addExtraDataPattern();
+    GenericMetadataPatternFlags getPatternFlags() {
+      auto flags = super::getPatternFlags();
 
-      // We're done with the pattern now.
-#ifndef NDEBUG
-      auto finalOffset = getNextOffsetFromTemplateHeader();
-#endif
+      flags.class_setHasImmediateMembersPattern(hasImmediateMembersPattern());
 
+      return flags;
+    }
+
+    void emitInstantiationDefinitions() {
       // Emit the base-offset variable.
       emitClassMetadataBaseOffset();
 
-      // Emit the nominal type descriptor.
-      (void) ClassContextDescriptorBuilder(IGM, Target, RequireMetadata).emit();
-
-      // Register fill ops for all the immediate type arguments.
-      addGenericFields(Target, Target->getDeclaredTypeInContext(), Target);
-
-      // Emit instantiation information.
-      emitInstantiationDefinitions();
-
-      assert(finalOffset == getNextOffsetFromTemplateHeader() &&
-             "shouldn't have added anything to the pattern");
+      super::emitInstantiationDefinitions();
     }
 
-    uint16_t getOffsetInWords(Size begin, Size offset) {
-      // Subtract the offset from the initial offset and divide by the
-      // pointer size, rounding up.
-      auto result =
-        (offset - begin + IGM.getPointerSize() - Size(1))
-          / IGM.getPointerSize();
-      assert(result < (1 << 16));
-      return uint16_t(result);
-    };
+    void addDestructorFunction() {
+      auto function = getAddrOfDestructorFunction();
+      B.addRelativeAddressOrNull(function ? *function : nullptr);
+    }
 
-    void addExtraDataPattern() {
-      Size extraDataBegin = getNextOffsetFromTemplateHeader();
+    void addIVarDestroyer() {
+      auto function = getAddrOfIVarDestroyer();
+      B.addRelativeAddressOrNull(function ? *function : nullptr);
+    }
 
-      uint16_t classRODataOffsetWords = 0;
-      uint16_t metaclassObjectOffsetWords = 0;
-      uint16_t metaclassRODataOffsetWords = 0;
+    bool hasExtraDataPattern() {
+      return IGM.ObjCInterop;
+    }
+
+    PartialPattern buildExtraDataPattern() {
+      ConstantInitBuilder subBuilder(IGM);
+      auto subB = subBuilder.beginStruct();
+      subB.setPacked(true);
+
+      // The offset of the pattern bytes in the overall extra-data section.
+      // Any bytes before this will be zeroed.  Currently we don't take
+      // advantage of this.
+      Size patternOffset = Size(0);
+
       if (IGM.ObjCInterop) {
         // Add the metaclass object.
-        metaclassObjectOffsetWords =
-          getOffsetInWords(extraDataBegin, getNextOffsetFromTemplateHeader());
-        addMetaclassObject();
+        B.fillPlaceholderWithInt(*MetaclassObjectOffset, IGM.Int16Ty,
+          IGM.getOffsetInWords(patternOffset + subB.getNextOffsetFromGlobal()));
+        addMetaclassObject(subB);
 
         // Add the RO-data objects.
         auto roDataPoints =
-          emitClassPrivateDataFields(IGM, B, Target);
-        classRODataOffsetWords =
-          getOffsetInWords(extraDataBegin, roDataPoints.first);
-        metaclassRODataOffsetWords =
-          getOffsetInWords(extraDataBegin, roDataPoints.second);
+          emitClassPrivateDataFields(IGM, subB, Target);
+        B.fillPlaceholderWithInt(*ClassRODataOffset, IGM.Int16Ty,
+          IGM.getOffsetInWords(patternOffset + roDataPoints.first));
+        B.fillPlaceholderWithInt(*MetaclassRODataOffset, IGM.Int16Ty,
+          IGM.getOffsetInWords(patternOffset + roDataPoints.second));
       }
 
-      auto extraDataEnd = getNextOffsetFromTemplateHeader();
-      auto numExtraDataWords = getOffsetInWords(extraDataBegin, extraDataEnd);
+      auto patternSize = subB.getNextOffsetFromGlobal();
 
-      B.fillPlaceholderWithInt(*NumExtraDataWords, IGM.Int16Ty,
-                               numExtraDataWords);
-      B.fillPlaceholderWithInt(*ClassRODataOffset, IGM.Int16Ty,
-                               classRODataOffsetWords);
-      B.fillPlaceholderWithInt(*MetaclassObjectOffset, IGM.Int16Ty,
-                               metaclassObjectOffsetWords);
-      B.fillPlaceholderWithInt(*MetaclassRODataOffset, IGM.Int16Ty,
-                               metaclassRODataOffsetWords);
+      auto global = subB.finishAndCreateGlobal("", IGM.getPointerAlignment(),
+                                               /*constant*/ true);
+
+      return { global, patternOffset, patternSize };
     }
 
-    void addMetaclassObject() {
+    void addMetaclassObject(ConstantStructBuilder &B) {
       // isa
       ClassDecl *rootClass = getRootClassForMetaclass(IGM, Target);
       auto isa = IGM.getAddrOfMetaclassObject(rootClass, NotForDefinition);
@@ -4263,38 +4372,16 @@ namespace {
       // rodata, which is always dependent
       B.addInt(IGM.IntPtrTy, 0);
     }
-                            
-    // Suppress GenericMetadataBuilderBase's default behavior of introducing
-    // fill ops for generic arguments unless they belong directly to the target
-    // class and not its ancestors.
 
-    void addGenericArgument(CanType type, ClassDecl *forClass) {
-      if (forClass == Target) {
-        // Introduce the fill op.
-        GenericMetadataBuilderBase::addGenericArgument(type, forClass);
-      } else {
-        // Lay out the field, but don't fill it in, we will copy it from
-        // the superclass.
-        ClassMetadataBuilderBase::addGenericArgument(type, forClass);
-      }
-    }
-    
-    void addGenericWitnessTable(CanType type, ProtocolConformanceRef conf,
-                                ClassDecl *forClass) {
-      if (forClass == Target) {
-        // Introduce the fill op.
-        GenericMetadataBuilderBase::addGenericWitnessTable(type, conf,forClass);
-      } else {
-        // Lay out the field, but don't provide the fill op, which we'll get
-        // from the superclass.
-        ClassMetadataBuilderBase::addGenericWitnessTable(type, conf, forClass);
-      }
+    bool hasImmediateMembersPattern() {
+      // TODO: use the real field offsets if they're known statically.
+      return false;
     }
 
     llvm::Value *emitAllocateMetadata(IRGenFunction &IGF,
                                       llvm::Value *descriptor,
-                                      llvm::Value *arguments) {
-      auto templatePointer = IGM.getAddrOfTypeMetadataPattern(Target);
+                                      llvm::Value *arguments,
+                                      llvm::Value *templatePointer) {
       auto metadata =
         IGF.Builder.CreateCall(IGM.getAllocateGenericClassMetadataFn(),
                                {descriptor, arguments, templatePointer});
@@ -4877,14 +4964,33 @@ namespace {
     }
 
   public:
+    void noteStartOfTypeSpecificMembers() {}
+
+    MetadataKind getMetadataKind() {
+      return MetadataKind::Struct;
+    }
+
     void addMetadataFlags() {
-      B.addInt(IGM.MetadataKindTy, unsigned(MetadataKind::Struct));
+      B.addInt(IGM.MetadataKindTy, unsigned(getMetadataKind()));
+    }
+
+    llvm::Constant *emitNominalTypeDescriptor() {
+      auto descriptor =
+        StructContextDescriptorBuilder(IGM, Target, RequireMetadata).emit();
+      return descriptor;
     }
 
     void addNominalTypeDescriptor() {
-      auto *descriptor =
-        StructContextDescriptorBuilder(IGM, Target, RequireMetadata).emit();
-      B.add(descriptor);
+      B.add(emitNominalTypeDescriptor());
+    }
+
+    llvm::Constant *emitValueWitnessTable() {
+      auto type = this->Target->getDeclaredType()->getCanonicalType();
+      return irgen::emitValueWitnessTable(IGM, type, false);
+    }
+
+    void addValueWitnessTable() {
+      B.add(emitValueWitnessTable());
     }
 
     void addFieldOffset(VarDecl *var) {
@@ -4931,11 +5037,6 @@ namespace {
       return !HasUnfilledFieldOffset;
     }
 
-    void addValueWitnessTable() {
-      auto type = this->Target->getDeclaredType()->getCanonicalType();
-      B.add(emitValueWitnessTable(IGM, type, false));
-    }
-
     void createMetadataAccessFunction() {
       createInPlaceValueTypeMetadataAccessFunction(IGM, Target);
     }
@@ -4957,10 +5058,10 @@ namespace {
   
   /// A builder for metadata templates.
   class GenericStructMetadataBuilder :
-    public GenericMetadataBuilderBase<GenericStructMetadataBuilder,
+    public GenericValueMetadataBuilderBase<GenericStructMetadataBuilder,
                       StructMetadataBuilderBase<GenericStructMetadataBuilder>> {
 
-    typedef GenericMetadataBuilderBase super;
+    typedef GenericValueMetadataBuilderBase super;
                         
   public:
     GenericStructMetadataBuilder(IRGenModule &IGM, StructDecl *theStruct,
@@ -4969,24 +5070,25 @@ namespace {
 
     llvm::Value *emitAllocateMetadata(IRGenFunction &IGF,
                                       llvm::Value *descriptor,
-                                      llvm::Value *arguments) {
-      auto templatePointer = IGM.getAddrOfTypeMetadataPattern(Target);
-      auto templateSize = IGM.getSize(TemplateSize);
-      assert(AddressPoint == IGM.getPointerSize() &&
-             "address point is not equal to value expected by runtime");
+                                      llvm::Value *arguments,
+                                      llvm::Value *templatePointer) {
+      auto &layout = IGM.getMetadataLayout(Target);
+      auto extraSize = layout.getSize().getOffsetToEnd()
+                         - IGM.getOffsetOfStructTypeSpecificMetadataMembers();
+      auto extraSizeV = IGM.getSize(extraSize);
 
       return IGF.Builder.CreateCall(IGM.getAllocateGenericValueMetadataFn(),
-                                    {descriptor, templatePointer, templateSize,
-                                     arguments});
+                                    {descriptor, arguments, templatePointer,
+                                     extraSizeV});
     }
 
     void flagUnfilledFieldOffset() {
       // We just assume this might happen.
     }
     
-    void addValueWitnessTable() {
-      B.add(getValueWitnessTableForGenericValueType(IGM, Target,
-                                                    HasDependentVWT));
+    llvm::Constant *emitValueWitnessTable() {
+      return getValueWitnessTableForGenericValueType(IGM, Target,
+                                                     HasDependentVWT);
     }
                         
     void emitInitializeMetadata(IRGenFunction &IGF,
@@ -5048,22 +5150,41 @@ namespace {
     using super::IGM;
     using super::Target;
 
-  public:
     EnumMetadataBuilderBase(IRGenModule &IGM, EnumDecl *theEnum,
                             ConstantStructBuilder &B)
-    : super(IGM, theEnum), B(B) {
+      : super(IGM, theEnum), B(B) {
+    }
+
+  public:
+    void noteStartOfTypeSpecificMembers() {}
+
+    MetadataKind getMetadataKind() {
+      return Target->isOptionalDecl() ? MetadataKind::Optional
+                                      : MetadataKind::Enum;
     }
 
     void addMetadataFlags() {
-      auto kind = Target->isOptionalDecl() ? MetadataKind::Optional
-                                           : MetadataKind::Enum;
+      auto kind = getMetadataKind();
       B.addInt(IGM.MetadataKindTy, unsigned(kind));
     }
 
-    void addNominalTypeDescriptor() {
+    llvm::Constant *emitValueWitnessTable() {
+      auto type = Target->getDeclaredType()->getCanonicalType();
+      return irgen::emitValueWitnessTable(IGM, type, false);
+    }
+
+    void addValueWitnessTable() {
+      B.add(emitValueWitnessTable());
+    }
+
+    llvm::Constant *emitNominalTypeDescriptor() {
       auto descriptor =
         EnumContextDescriptorBuilder(IGM, Target, RequireMetadata).emit();
-      B.add(descriptor);
+      return descriptor;
+    }
+
+    void addNominalTypeDescriptor() {
+      B.add(emitNominalTypeDescriptor());
     }
 
     void addGenericArgument(CanType type) {
@@ -5083,11 +5204,6 @@ namespace {
     EnumMetadataBuilder(IRGenModule &IGM, EnumDecl *theEnum,
                         ConstantStructBuilder &B)
       : EnumMetadataBuilderBase(IGM, theEnum, B) {}
-
-    void addValueWitnessTable() {
-      auto type = Target->getDeclaredType()->getCanonicalType();
-      B.add(emitValueWitnessTable(IGM, type, false));
-    }
 
     void addPayloadSize() {
       auto enumTy = Target->getDeclaredTypeInContext()->getCanonicalType();
@@ -5114,41 +5230,33 @@ namespace {
   };
 
   class GenericEnumMetadataBuilder
-    : public GenericMetadataBuilderBase<GenericEnumMetadataBuilder,
+    : public GenericValueMetadataBuilderBase<GenericEnumMetadataBuilder,
                           EnumMetadataBuilderBase<GenericEnumMetadataBuilder>>
   {
   public:
+    using super = GenericValueMetadataBuilderBase;
+
     GenericEnumMetadataBuilder(IRGenModule &IGM, EnumDecl *theEnum,
                                ConstantStructBuilder &B)
-      : GenericMetadataBuilderBase(IGM, theEnum, B) {}
+      : super(IGM, theEnum, B) {}
 
     llvm::Value *emitAllocateMetadata(IRGenFunction &IGF,
                                       llvm::Value *descriptor,
-                                      llvm::Value *arguments) {
-      auto templatePointer = IGM.getAddrOfTypeMetadataPattern(Target);
-      auto templateSize = IGM.getSize(TemplateSize);
-      assert(AddressPoint == IGM.getPointerSize() &&
-             "address point is not equal to value expected by runtime");
+                                      llvm::Value *arguments,
+                                      llvm::Value *templatePointer) {
+      auto &layout = IGM.getMetadataLayout(Target);
+      auto extraSize = layout.getSize().getOffsetToEnd()
+                         - IGM.getOffsetOfEnumTypeSpecificMetadataMembers();
+      auto extraSizeV = IGM.getSize(extraSize);
 
       return IGF.Builder.CreateCall(IGM.getAllocateGenericValueMetadataFn(),
-                                    {descriptor, templatePointer, templateSize,
-                                     arguments});
+                                    {descriptor, arguments, templatePointer,
+                                     extraSizeV});
     }
 
-    void addValueWitnessTable() {
-      B.add(getValueWitnessTableForGenericValueType(IGM, Target,
-                                                    HasDependentVWT));
-    }
-
-    void addPayloadSize() {
-      // In all cases where a payload size is demanded in the metadata, it's
-      // runtime-dependent, so fill in a zero here.
-      auto enumTy = Target->getDeclaredTypeInContext()->getCanonicalType();
-      auto &enumTI = IGM.getTypeInfoForUnlowered(enumTy);
-      (void) enumTI;
-      assert(!enumTI.isFixedSize(ResilienceExpansion::Minimal) &&
-             "non-generic, non-resilient enums don't need payload size in metadata");
-      B.addInt(IGM.IntPtrTy, 0);
+    llvm::Constant *emitValueWitnessTable() {
+      return getValueWitnessTableForGenericValueType(IGM, Target,
+                                                     HasDependentVWT);
     }
 
     void emitInitializeMetadata(IRGenFunction &IGF,
@@ -5436,8 +5544,7 @@ namespace {
     void emitInitialization(IRGenFunction &IGF, llvm::Value *metadata) {}
 
     void addValueWitnessTable() {
-      auto type = this->Target->getDeclaredType()->getCanonicalType();
-      B.add(emitValueWitnessTable(IGM, type, false));
+      B.add(emitValueWitnessTable());
     }
 
     void flagUnfilledFieldOffset() {
@@ -5465,8 +5572,7 @@ namespace {
     void emitInitialization(IRGenFunction &IGF, llvm::Value *metadata) {}
 
     void addValueWitnessTable() {
-      auto type = this->Target->getDeclaredType()->getCanonicalType();
-      B.add(emitValueWitnessTable(IGM, type, false));
+      B.add(emitValueWitnessTable());
     }
     
     void addPayloadSize() const {

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -591,6 +591,18 @@ public:
     return getPointerAlignment();
   }
 
+  /// Return the offset, relative to the address point, of the start of the
+  /// type-specific members of an enum metadata.
+  Size getOffsetOfEnumTypeSpecificMetadataMembers() {
+    return getPointerSize() * 2;
+  }
+
+  /// Return the offset, relative to the address point, of the start of the
+  /// type-specific members of a struct metadata.
+  Size getOffsetOfStructTypeSpecificMetadataMembers() {
+    return getPointerSize() * 2;
+  }
+
   Size::int_type getOffsetInWords(Size offset) {
     assert(offset.isMultipleOf(getPointerSize()));
     return offset / getPointerSize();

--- a/lib/IRGen/MetadataLayout.cpp
+++ b/lib/IRGen/MetadataLayout.cpp
@@ -492,6 +492,11 @@ EnumMetadataLayout::EnumMetadataLayout(IRGenModule &IGM, EnumDecl *decl)
     Scanner(IRGenModule &IGM, EnumDecl *decl, EnumMetadataLayout &layout)
       : super(IGM, decl), Layout(layout) {}
 
+    void noteStartOfTypeSpecificMembers() {
+      assert(getNextOffset().getStaticOffset() ==
+               IGM.getOffsetOfEnumTypeSpecificMetadataMembers());
+    }
+
     void addPayloadSize() {
       Layout.PayloadSizeOffset = getNextOffset();
       super::addPayloadSize();
@@ -528,6 +533,11 @@ StructMetadataLayout::StructMetadataLayout(IRGenModule &IGM, StructDecl *decl)
     StructMetadataLayout &Layout;
     Scanner(IRGenModule &IGM, StructDecl *decl, StructMetadataLayout &layout)
       : super(IGM, decl), Layout(layout) {}
+
+    void noteStartOfTypeSpecificMembers() {
+      assert(getNextOffset().getStaticOffset() ==
+               IGM.getOffsetOfStructTypeSpecificMetadataMembers());
+    }
 
     void noteStartOfGenericRequirements() {
       Layout.GenericRequirements = getNextOffset();

--- a/lib/IRGen/StructMetadataVisitor.h
+++ b/lib/IRGen/StructMetadataVisitor.h
@@ -48,7 +48,8 @@ public:
     // StructMetadata header.
     asImpl().addNominalTypeDescriptor();
 
-    // Instantiation-specific.
+    // Everything after this is type-specific.
+    asImpl().noteStartOfTypeSpecificMembers();
 
     // Generic arguments.
     // This must always be the first piece of trailing data.
@@ -84,6 +85,7 @@ public:
   void addGenericWitnessTable(CanType argument, ProtocolConformanceRef conf) {
     addPointer();
   }
+  void noteStartOfTypeSpecificMembers() {}
 
 private:
   void addPointer() {

--- a/test/IRGen/class_bounded_generics.swift
+++ b/test/IRGen/class_bounded_generics.swift
@@ -55,9 +55,9 @@ class ClassProtocolFieldClass {
   }
 }
 
-// CHECK: %T22class_bounded_generics017ClassGenericFieldD0C = type <{ %swift.refcounted, %TSi, %objc_object*, %TSi }>
-// CHECK: %T22class_bounded_generics23ClassGenericFieldStructV = type <{ %TSi, %objc_object*, %TSi }>
-// CHECK: %T22class_bounded_generics24ClassProtocolFieldStructV = type <{ %TSi, %T22class_bounded_generics10ClassBoundP, %TSi }>
+// CHECK-DAG: %T22class_bounded_generics017ClassGenericFieldD0C = type <{ %swift.refcounted, %TSi, %objc_object*, %TSi }>
+// CHECK-DAG: %T22class_bounded_generics23ClassGenericFieldStructV = type <{ %TSi, %objc_object*, %TSi }>
+// CHECK-DAG: %T22class_bounded_generics24ClassProtocolFieldStructV = type <{ %TSi, %T22class_bounded_generics10ClassBoundP, %TSi }>
 
 // CHECK-LABEL: define hidden swiftcc %objc_object* @"$S22class_bounded_generics0a1_B10_archetype{{[_0-9a-zA-Z]*}}F"(%objc_object*, %swift.type* %T, i8** %T.ClassBound)
 func class_bounded_archetype<T : ClassBound>(_ x: T) -> T {

--- a/test/IRGen/class_metadata.swift
+++ b/test/IRGen/class_metadata.swift
@@ -75,10 +75,10 @@ class C<T> : B {}
 //   Field offset vector offset.
 // CHECK-32-SAME: i32 15,
 // CHECK-64-SAME: i32 12,
-//   Instantiation function.
-// CHECK-SAME: i32 {{.*}} @"$S14class_metadata1CCMi"
 //   Instantiation cache.
 // CHECK-SAME: i32 {{.*}} @"$S14class_metadata1CCMI"
+//   Instantiation pattern.
+// CHECK-SAME: i32 {{.*}} @"$S14class_metadata1CCMP"
 //   Generic parameter count.
 // CHECK-SAME: i32 1,
 //   Generic requirement count.
@@ -93,6 +93,10 @@ class C<T> : B {}
 // CHECK-SAME: i8 0,
 // CHECK-SAME: i8 0,
 // CHECK-SAME: i8 0 }>, section
+
+// CHECK-LABEL: @"$S14class_metadata1CCMP" =
+//   Instantiation function.
+// CHECK-SAME:  i32 {{.*}} @"$S14class_metadata1CCMi"
 
 // For stupid reasons, when we declare the superclass after the subclass,
 // we end up using an indirect reference to the nominal type descriptor.

--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -441,11 +441,11 @@ extension ResilientGenericOutsideParent {
 
 // ResilientGenericChild metadata initialization function
 
-// CHECK-LABEL: define internal %swift.type* @"$S16class_resilience21ResilientGenericChildCMi"(%swift.type_descriptor*, i8**)
+// CHECK-LABEL: define internal %swift.type* @"$S16class_resilience21ResilientGenericChildCMi"(%swift.type_descriptor*, i8**, i8**)
 
 // Get the superclass size and address point...
 
-// CHECK:              [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_descriptor* %0, i8** %1, i8** bitcast ({{.*}} @"$S16class_resilience21ResilientGenericChildCMP" to i8**))
+// CHECK:              [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_descriptor* %0, i8** %1, i8** %2)
 
 // Initialize the superclass pointer...
 // CHECK:              [[SUPER:%.*]] = call %swift.type* @"$S15resilient_class29ResilientGenericOutsideParentCMa"(%swift.type* %T)

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -116,17 +116,17 @@ import Swift
 // CHECK-SAME:   i32 1,
 // --       No empty cases
 // CHECK-SAME:   i32 0,
-// --       generic instantiation function
-// CHECK-SAME:   @"$S4enum16DynamicSingletonOMi"
+// --       generic instantiation pattern
+// CHECK-SAME:   @"$S4enum16DynamicSingletonOMP"
 // --       generic parameters, requirements, key, extra
 // CHECK-SAME:   i32 1, i32 0, i32 1, i32 0
 // --       generic param
 // CHECK-SAME:   i8 -128,
 // CHECK-SAME: }>
 
-// CHECK: @"$S4enum16DynamicSingletonOMP" = internal constant <{ {{.*}}, %swift.type* }> <{
+// CHECK: @"$S4enum16DynamicSingletonOMP" = internal constant <{ {{.*}} }> <{
+// CHECK-SAME:   @"$S4enum16DynamicSingletonOMi"
 // CHECK-SAME:   [18 x i8*]* @"$S4enum16DynamicSingletonOWV"
-// CHECK-SAME:   @"$S4enum16DynamicSingletonOMn"
 
 // -- No-payload enums have extra inhabitants in
 //    their value witness table.
@@ -169,7 +169,8 @@ import Swift
 // CHECK-SAME:   i8* bitcast (void (%swift.opaque*, i32, %swift.type*)* @"$S4enum20DynamicSinglePayloadOwxs" to i8*)
 // CHECK-SAME:   i8* bitcast (i32 (%swift.opaque*, %swift.type*)* @"$S4enum20DynamicSinglePayloadOwxg" to i8*)
 
-// CHECK: @"$S4enum20DynamicSinglePayloadOMP" = internal constant <{ {{.*}}, %swift.type* }> <{
+// CHECK: @"$S4enum20DynamicSinglePayloadOMP" = internal constant <{ {{.*}} }> <{
+// CHECK-SAME:   @"$S4enum20DynamicSinglePayloadOMi"
 // CHECK-SAME:   [18 x i8*]* @"$S4enum20DynamicSinglePayloadOWV"
 
 // CHECK: @"$S4enum18MultiPayloadNestedOWV" = internal constant [18 x i8*] [
@@ -2677,10 +2678,10 @@ entry(%x : $*MyOptional):
 }
 
 // -- Fill function for dynamic singleton.
-// CHECK: define{{( protected)?}} internal %swift.type* @"$S4enum16DynamicSingletonOMi"(%swift.type_descriptor*, i8**) {{.*}} {
+// CHECK: define{{( protected)?}} internal %swift.type* @"$S4enum16DynamicSingletonOMi"(%swift.type_descriptor*, i8**, i8**) {{.*}} {
 // CHECK:   [[T0:%.*]] = bitcast i8** %1 to %swift.type**
 // CHECK:   [[T:%T]] = load %swift.type*, %swift.type** [[T0]],
-// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata(%swift.type_descriptor* %0, i8** bitcast ({{.*}} @"$S4enum16DynamicSingletonOMP" to i8**), [[WORD]] {{16|32}}, i8** %1)
+// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata(%swift.type_descriptor* %0, i8** %1, i8** %2, [[WORD]] {{4|8}})
 // CHECK:   [[METADATA_ARRAY:%.*]] = bitcast %swift.type* [[METADATA]] to i8**
 // CHECK:   [[T1:%.*]] = getelementptr inbounds i8*, i8** [[METADATA_ARRAY]], [[WORD]] 2
 // CHECK:   [[T0:%.*]] = bitcast %swift.type* [[T]] to i8*
@@ -2694,7 +2695,8 @@ entry(%x : $*MyOptional):
 
 // -- Fill function for dynamic single-payload. Call into the runtime to
 //    calculate the size.
-// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$S4enum20DynamicSinglePayloadOMi"(%swift.type_descriptor*, i8**) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$S4enum20DynamicSinglePayloadOMi"(%swift.type_descriptor*, i8**, i8**) {{.*}} {
+// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata
 // CHECK:   call void @swift_initEnumMetadataSinglePayload(%swift.type* [[METADATA]], [[WORD]] 0, i8** [[T_LAYOUT]], i32 3)
 
 // CHECK-64-LABEL: define linkonce_odr hidden void @"$S4enum17StructWithWeakVarVwxs"(%swift.opaque* noalias %dest, i32 %index, %swift.type* %StructWithWeakVar)

--- a/test/IRGen/enum_dynamic_multi_payload.sil
+++ b/test/IRGen/enum_dynamic_multi_payload.sil
@@ -417,7 +417,7 @@ entry(%a : $*EitherOr<T, C>, %b : $*EitherOr<T, C>):
   return undef : $()
 }
 
-// CHECK: define{{( protected)?}} internal %swift.type* @"$S26enum_dynamic_multi_payload8EitherOrOMi"(%swift.type_descriptor*, i8**) {{.*}} {
+// CHECK: define{{( protected)?}} internal %swift.type* @"$S26enum_dynamic_multi_payload8EitherOrOMi"(%swift.type_descriptor*, i8**, i8**) {{.*}} {
 // CHECK:   [[BUF:%.*]] = alloca [2 x i8**]
 // CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata
 

--- a/test/IRGen/enum_value_semantics.sil
+++ b/test/IRGen/enum_value_semantics.sil
@@ -155,15 +155,16 @@ enum GenericFixedLayout<T> {
 
 
 // CHECK-LABEL: @"$S20enum_value_semantics18GenericFixedLayoutOMn" = hidden constant
-// CHECK-SAME:    %swift.type* (%swift.type_descriptor*, i8**)* @"$S20enum_value_semantics18GenericFixedLayoutOMi"
 // CHECK-SAME:    [16 x i8*]* @"$S20enum_value_semantics18GenericFixedLayoutOMI"
+// CHECK-SAME:    @"$S20enum_value_semantics18GenericFixedLayoutOMP"
 
-// CHECK-LABEL: @"$S20enum_value_semantics18GenericFixedLayoutOMP" = internal constant <{{[{].*\* [}]}}> <{
-// CHECK:   i8** getelementptr inbounds ([18 x i8*], [18 x i8*]* @"$S20enum_value_semantics18GenericFixedLayoutOWV", i32 0, i32 0),
-// CHECK:   i64 2,
-// CHECK:   {{.*}}* @"$S20enum_value_semantics18GenericFixedLayoutOMn"
-// CHECK:   i{{32|64}} 0
-// CHECK: }>
+// CHECK-LABEL: @"$S20enum_value_semantics18GenericFixedLayoutOMP" = internal constant <{ {{.*}} }> <{
+// CHECK-SAME:    i32 trunc (i64 sub (i64 ptrtoint (%swift.type* (%swift.type_descriptor*, i8**, i8**)* @"$S20enum_value_semantics18GenericFixedLayoutOMi" to i64), i64 ptrtoint (<{ i32, i32, i32 }>* @"$S20enum_value_semantics18GenericFixedLayoutOMP" to i64)) to i32),
+//   Pattern flags.  0x400000 == (MetadataKind::Enum << 21).
+// CHECK-SAME:    i32 4194304,
+//   Value witness table.
+// CHECK-SAME:    i32 trunc (i64 sub (i64 ptrtoint ([18 x i8*]* @"$S20enum_value_semantics18GenericFixedLayoutOWV" to i64), i64 ptrtoint (i32* getelementptr inbounds (<{ i32, i32, i32 }>, <{ i32, i32, i32 }>* @"$S20enum_value_semantics18GenericFixedLayoutOMP", i32 0, i32 2) to i64)) to i32)
+// CHECK-SAME:  }>
 
 sil @single_payload_nontrivial_copy_destroy : $(@owned SinglePayloadNontrivial) -> () {
 bb0(%0 : $SinglePayloadNontrivial):

--- a/test/IRGen/generic_classes.sil
+++ b/test/IRGen/generic_classes.sil
@@ -29,10 +29,10 @@ import Swift
 // CHECK-SAME:   i32 3,
 // --       field offset vector offset
 // CHECK-SAME:   i32 15,
-// --       template instantiation function
-// CHECK-SAME:   %swift.type* (%swift.type_descriptor*, i8**)* @"$S15generic_classes11RootGenericCMi"
 // --       template instantiation cache
 // CHECK-SAME:   [16 x i8*]* @"$S15generic_classes11RootGenericCMI"
+// --       template instantiation pattern
+// CHECK-SAME:   @"$S15generic_classes11RootGenericCMP"
 // --       generic parameters, requirements, key arguments, extra arguments
 // CHECK-SAME:   i32 1, i32 0, i32 1, i32 0
 // --       vtable offset
@@ -43,10 +43,12 @@ import Swift
 
 // CHECK-LABEL: @"$S15generic_classes11RootGenericCMP" = internal constant
 // CHECK-SAME: <{
+// --       template instantiation function
+// CHECK-SAME:   %swift.type* (%swift.type_descriptor*, i8**, i8**)* @"$S15generic_classes11RootGenericCMi"
 // --       heap destructor
 // CHECK-SAME:   @"$S15generic_classes11RootGenericCfD"
 // --       ivar destroyer
-// CHECK-SAME:   i8* null,
+// CHECK-SAME:   i32 0,
 // --       flags
 // CHECK_SAME:   i32 3,
 // --       immediate pattern size
@@ -106,22 +108,24 @@ import Swift
 // CHECK-SAME: }>
 
 // CHECK: @"$S15generic_classes015GenericInheritsC0CMn" = hidden constant
-// --       template instantiation function
-// CHECK-SAME:   %swift.type* (%swift.type_descriptor*, i8**)* @"$S15generic_classes015GenericInheritsC0CMi"
+// --       template instantiation pattern
+// CHECK-SAME:   @"$S15generic_classes015GenericInheritsC0CMP"
 
 // CHECK: @"$S15generic_classes015GenericInheritsC0CMP" = internal constant
+// --       template instantiation function
+// CHECK-SAME:   %swift.type* (%swift.type_descriptor*, i8**, i8**)* @"$S15generic_classes015GenericInheritsC0CMi"
+// --       pattern flags (1 == has extra data pattern)
+// CHECK-SAME-native: i32 0,
+// CHECK-SAME-objc:   i32 1,
 // --       heap destructor
 // CHECK-SAME:   @"$S15generic_classes015GenericInheritsC0CfD"
 // --       ivar destroyer
-// CHECK-SAME:   i8* null,
-// --       flags
+// CHECK-SAME:   i32 0,
+// --       class flags
 // CHECK_SAME:   i32 3,
-// --       immediate pattern size
-// CHECK-SAME:   i16 0,
-// --       immediate pattern target offset
-// CHECK-SAME:   i16 0,
-// --       extra data size
-// CHECK-SAME-native:   i16 0,
+// --       extra data pattern offset
+// CHECK-SAME-objc:     i16 0,
+// --       extra data pattern size
 // CHECK-SAME-objc:     i16 23,
 // --       class ro-data offset
 // CHECK-SAME-native:   i16 0,
@@ -130,8 +134,10 @@ import Swift
 // CHECK-SAME-native:   i16 0,
 // CHECK-SAME-objc:     i16 0,
 // --       class ro-data offset
-// CHECK-SAME-native:   i16 0
+// CHECK-SAME-native:   i16 0,
 // CHECK-SAME-objc:     i16 14,
+// --       reserved
+// CHECK-SAME:          i16 0
 // CHECK-SAME: }
 
 // CHECK: @"$S15generic_classes018GenericInheritsNonC0CMP"
@@ -332,25 +338,25 @@ entry(%c : $RootGeneric<Int32>):
 }
  */
 
-// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$S15generic_classes11RootGenericCMi"(%swift.type_descriptor*, i8**) {{.*}} {
-// CHECK:   [[METADATA:%.*]] ={{( tail)?}} call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_descriptor* %0, i8** %1, {{.*}} @"$S15generic_classes11RootGenericCMP"{{.*}})
+// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$S15generic_classes11RootGenericCMi"(%swift.type_descriptor*, i8**, i8**) {{.*}} {
+// CHECK:   [[METADATA:%.*]] ={{( tail)?}} call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_descriptor* %0, i8** %1, i8** %2)
 // -- initialize the dependent field offsets
 // CHECK:   call void @swift_initClassMetadata_UniversalStrategy(%swift.type* [[METADATA]], i64 3, i8*** {{%.*}}, i64* {{%.*}})
 // CHECK: }
 
-// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$S15generic_classes22RootGenericFixedLayoutCMi"(%swift.type_descriptor*, i8**) {{.*}} {
-// CHECK:   [[METADATA:%.*]] ={{( tail)?}} call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_descriptor* %0, i8** %1, {{.*}} @"$S15generic_classes22RootGenericFixedLayoutCMP"{{.*}})
+// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$S15generic_classes22RootGenericFixedLayoutCMi"(%swift.type_descriptor*, i8**, i8**) {{.*}} {
+// CHECK:   [[METADATA:%.*]] ={{( tail)?}} call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_descriptor* %0, i8** %1, i8** %2)
 // CHECK:   call void @swift_initClassMetadata_UniversalStrategy(%swift.type* [[METADATA]], i64 3, i8*** {{%.*}}, i64* {{%.*}})
 // CHECK: }
 
-// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$S15generic_classes015GenericInheritsC0CMi"(%swift.type_descriptor*, i8**) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$S15generic_classes015GenericInheritsC0CMi"(%swift.type_descriptor*, i8**, i8**) {{.*}} {
 //   Bind the generic parameters.
 // CHECK:   [[T0:%.*]] = bitcast i8** %1 to %swift.type**
 // CHECK:   %A  = load %swift.type*, %swift.type** [[T0]]
 // CHECK:   [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i32 1
 // CHECK:   %B  = load %swift.type*, %swift.type** [[T1]]
 //   Construct the superclass.
-// CHECK:   [[METADATA:%.*]] ={{( tail)?}} call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_descriptor* %0, i8** %1, {{.*}} @"$S15generic_classes015GenericInheritsC0CMP"{{.*}})
+// CHECK:   [[METADATA:%.*]] ={{( tail)?}} call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_descriptor* %0, i8** %1, i8** %2)
 // CHECK:   [[METADATA_ARRAY:%.*]] = bitcast %swift.type* [[METADATA]] to i8**
 //   Put the generic arguments in their correct positions.
 // CHECK:   [[A_ADDR:%.*]] = getelementptr inbounds i8*, i8** [[METADATA_ARRAY:%.*]], i64 18

--- a/test/IRGen/generic_structs.sil
+++ b/test/IRGen/generic_structs.sil
@@ -30,20 +30,18 @@ import Builtin
 // --       field offset vector offset
 // CHECK-SAME:   i32 3,
 // --       generic instantiation info
-// CHECK-SAME:   %swift.type* (%swift.type_descriptor*, i8**)* @"$S15generic_structs13SingleDynamicVMi"
 // CHECK-SAME:   [{{[0-9]+}} x i8*]* @"$S15generic_structs13SingleDynamicVMI"
+// CHECK-SAME:   @"$S15generic_structs13SingleDynamicVMP"
 // --       generic params, requirements, key args, extra args
 // CHECK-SAME:   i32 1, i32 0, i32 1, i32 0
 // --       generic parameters
 // CHECK-SAME:   <i8 0x80>
 // CHECK-SAME: }>
 // CHECK: @"$S15generic_structs13SingleDynamicVMP" = internal constant <{ {{.*}} }> <{
+// -- instantiation function
+// CHECK-SAME:   %swift.type* (%swift.type_descriptor*, i8**, i8**)* @"$S15generic_structs13SingleDynamicVMi"
 // -- vwtable pointer
 // CHECK-SAME:   @"$S15generic_structs13SingleDynamicVWV"
-// -- address point
-// CHECK-SAME:   i64 1, {{.*}}* @"$S15generic_structs13SingleDynamicVMn"
-// -- field offset vector; generic parameter vector
-// CHECK-SAME:   %swift.type* null, i64 0 }>
 
 // -- Nominal type descriptor for generic struct with protocol requirements
 //    FIXME: Strings should be unnamed_addr. rdar://problem/22674524
@@ -78,8 +76,6 @@ import Builtin
 // CHECK-SAME: }>
 
 // CHECK: @"$S15generic_structs23DynamicWithRequirementsVMP" = internal constant <{ {{.*}} }> <{
-// -- field offset vector; generic parameter vector
-// CHECK:   %swift.type* null, %swift.type* null, i8** null, i8** null, i64 0, i64 0 }>
 
 // -- Fixed-layout struct metadata contains fixed field offsets
 // CHECK: @"$S15generic_structs6IntishVMf" = internal constant <{ {{.*}} i64 }> <{
@@ -176,6 +172,23 @@ entry(%0 : $*ComplexDynamic<A, B>, %1 : $*Byteful, %2 : $*A, %3 : $*B, %4 : $*Ch
   return %v : $()
 }
 
+// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$S15generic_structs13SingleDynamicVMi"(%swift.type_descriptor*, i8**, i8**)
+// CHECK:   [[T0:%.*]] = bitcast i8** %1 to %swift.type**
+// CHECK:   %T = load %swift.type*, %swift.type** [[T0]], align 8
+// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata(%swift.type_descriptor* %0, i8** %1, i8** %2, i64 16)
+// CHECK:   [[SELF_ARRAY:%.*]] = bitcast %swift.type* [[METADATA]] to i8**
+//   Fill type argument.
+// CHECK:   [[T1:%.*]] = getelementptr inbounds i8*, i8** [[SELF_ARRAY]], i64 2
+// CHECK:   [[T0:%.*]] = bitcast %swift.type* %T to i8*
+// CHECK:   store i8* [[T0]], i8** [[T1]], align 8
+//   Lay out fields.
+// CHECK:   [[T0:%.*]] = bitcast %swift.type* [[METADATA]] to i64*
+// CHECK:   [[T1:%.*]] = getelementptr inbounds i64, i64* [[T0]], i64 3
+// CHECK:   [[T2:%.*]] = getelementptr inbounds i8**, i8*** [[TYPES:%.*]], i32 0
+// CHECK:   call void @swift_initStructMetadata(%swift.type* [[METADATA]], i64 0, i64 1, i8*** [[TYPES]], i64* [[T1]])
+// CHECK:   ret %swift.type* [[METADATA]]
+// CHECK: }
+
 // Check that we directly delegate buffer witnesses to a single dynamic field:
 
 //   initializeBufferWithCopyOfBuffer
@@ -205,23 +218,6 @@ entry(%0 : $*ComplexDynamic<A, B>, %1 : $*Byteful, %2 : $*A, %3 : $*B, %4 : $*Ch
 // CHECK-NEXT: [[T1:%.*]] = bitcast %swift.opaque* [[T0]] to {{.*}}
 // CHECK-NEXT: [[T2:%.*]] = bitcast {{.*}} [[T1]] to %swift.opaque*
 // CHECK-NEXT: ret %swift.opaque* [[T2]]
-
-// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$S15generic_structs13SingleDynamicVMi"(%swift.type_descriptor*, i8**)
-// CHECK:   [[T0:%.*]] = bitcast i8** %1 to %swift.type**
-// CHECK:   %T = load %swift.type*, %swift.type** [[T0]], align 8
-// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata(%swift.type_descriptor* %0, i8** bitcast ({{.*}} @"$S15generic_structs13SingleDynamicVMP" to i8**), i64 40, i8** %1)
-// CHECK:   [[SELF_ARRAY:%.*]] = bitcast %swift.type* [[METADATA]] to i8**
-//   Fill type argument.
-// CHECK:   [[T1:%.*]] = getelementptr inbounds i8*, i8** [[SELF_ARRAY]], i64 2
-// CHECK:   [[T0:%.*]] = bitcast %swift.type* %T to i8*
-// CHECK:   store i8* [[T0]], i8** [[T1]], align 8
-//   Lay out fields.
-// CHECK:   [[T0:%.*]] = bitcast %swift.type* [[METADATA]] to i64*
-// CHECK:   [[T1:%.*]] = getelementptr inbounds i64, i64* [[T0]], i64 3
-// CHECK:   [[T2:%.*]] = getelementptr inbounds i8**, i8*** [[TYPES:%.*]], i32 0
-// CHECK:   call void @swift_initStructMetadata(%swift.type* [[METADATA]], i64 0, i64 1, i8*** [[TYPES]], i64* [[T1]])
-// CHECK:   ret %swift.type* [[METADATA]]
-// CHECK: }
 
 protocol HasAssociatedType {
   associatedtype Assoc

--- a/test/IRGen/generic_types.swift
+++ b/test/IRGen/generic_types.swift
@@ -27,10 +27,10 @@
 // CHECK-SAME:   i32 1,
 // -- field offset vector offset
 // CHECK-SAME:   i32 16,
-// -- instantiation function
-// CHECK-SAME:   @"$S13generic_types1ACMi"
 // -- instantiation cache
 // CHECK-SAME:   @"$S13generic_types1ACMI"
+// -- instantiation pattern
+// CHECK-SAME:   @"$S13generic_types1ACMP"
 // -- num generic params
 // CHECK-SAME:   i32 1,
 // -- num generic requirement
@@ -43,9 +43,12 @@
 // CHECK-SAME:   i8 -128,
 
 // CHECK-LABEL: @"$S13generic_types1ACMP" = internal constant
-// CHECK-SAME:   void ([[A]]*)* @"$S13generic_types1ACfD",
+// -- instantiation function
+// CHECK-SAME:   @"$S13generic_types1ACMi"
+// -- heap destructor
+// CHECK-SAME:   void ([[A]]*)* @"$S13generic_types1ACfD"
 // -- ivar destroyer
-// CHECK-SAME:   i8* null,
+// CHECK-SAME:   i32 0,
 // -- flags
 // CHECK-SAME:   i32 {{3|2}},
 // CHECK-SAME: }
@@ -54,34 +57,46 @@
 
 // CHECK-LABEL: @"$S13generic_types1BCMn" = hidden constant
 // CHECK-SAME:   @"$S13generic_types1BCMa"
-// CHECK-SAME:   @"$S13generic_types1BCMi"
 // CHECK-SAME:   @"$S13generic_types1BCMI"
+// CHECK-SAME:   @"$S13generic_types1BCMP"
 
 // CHECK-LABEL: @"$S13generic_types1BCMP" = internal constant
-// CHECK-SAME:   void ([[B]]*)* @"$S13generic_types1BCfD",
+// -- instantiation function
+// CHECK-SAME:   @"$S13generic_types1BCMi"
+// -- heap destructor
+// CHECK-SAME:   void ([[B]]*)* @"$S13generic_types1BCfD"
 // -- ivar destroyer
-// CHECK-SAME:   i8* null
+// CHECK-SAME:   i32 0,
+// -- class flags
 // CHECK-SAME:   i32 {{3|2}},
 // CHECK-SAME: }
 
 // CHECK-LABEL: @"$S13generic_types1CCMP" = internal constant
-// CHECK-SAME:   void ([[C]]*)* @"$S13generic_types1CCfD",
+// -- instantiation function
+// CHECK-SAME:   @"$S13generic_types1CCMi"
+// -- heap destructor
+// CHECK-SAME:   void ([[C]]*)* @"$S13generic_types1CCfD"
 // -- ivar destroyer
-// CHECK-SAME:   i8* null
+// CHECK-SAME:   i32 0,
+// -- class flags
 // CHECK-SAME:   i32 {{3|2}},
 // CHECK-SAME: }
 
 // CHECK-LABEL: @"$S13generic_types1DCMP" = internal constant
-// CHECK-SAME:   void ([[D]]*)* @"$S13generic_types1DCfD",
+// -- instantiation function
+// CHECK-SAME:   @"$S13generic_types1DCMi"
+// -- heap destructor
+// CHECK-SAME:   void ([[D]]*)* @"$S13generic_types1DCfD"
 // -- ivar destroyer
-// CHECK-SAME:   i8* null
+// CHECK-SAME:   i32 0,
+// -- class flags
 // CHECK-SAME:   i32 {{3|2}},
 // CHECK-SAME: }
 
-// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$S13generic_types1ACMi"(%swift.type_descriptor*, i8**) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$S13generic_types1ACMi"(%swift.type_descriptor*, i8**, i8**) {{.*}} {
 // CHECK:   [[T0:%.*]] = bitcast i8** %1 to %swift.type**
 // CHECK:   %T = load %swift.type*, %swift.type** [[T0]],
-// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_descriptor* %0, i8** %1, i8** bitcast ({{.*}}* @"$S13generic_types1ACMP" to i8**))
+// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_descriptor* %0, i8** %1, i8** %2)
 // CHECK:   [[SELF_ARRAY:%.*]] = bitcast %swift.type* [[METADATA]] to i8**
 // CHECK:   [[T1:%.*]] = getelementptr inbounds i8*, i8** [[SELF_ARRAY]], i64 10
 // CHECK:   [[T0:%.*]] = bitcast %swift.type* %T to i8*
@@ -89,10 +104,10 @@
 // CHECK:   ret %swift.type* [[METADATA]]
 // CHECK: }
 
-// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$S13generic_types1BCMi"(%swift.type_descriptor*, i8**) {{.*}} {
+// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$S13generic_types1BCMi"(%swift.type_descriptor*, i8**, i8**) {{.*}} {
 // CHECK:   [[T0:%.*]] = bitcast i8** %1 to %swift.type**
 // CHECK:   %T = load %swift.type*, %swift.type** [[T0]],
-// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_descriptor* %0, i8** %1, i8** bitcast ({{.*}}* @"$S13generic_types1BCMP" to i8**))
+// CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_descriptor* %0, i8** %1, i8** %2)
 // CHECK:   [[SELF_ARRAY:%.*]] = bitcast %swift.type* [[METADATA]] to i8**
 // CHECK:   [[T1:%.*]] = getelementptr inbounds i8*, i8** [[SELF_ARRAY]], i64 10
 // CHECK:   [[T0:%.*]] = bitcast %swift.type* %T to i8*

--- a/test/IRGen/generic_vtable.swift
+++ b/test/IRGen/generic_vtable.swift
@@ -64,7 +64,7 @@ public class Concrete : Derived<Int> {
 
 // CHECK-LABEL: @"$S14generic_vtable7DerivedCMP" = internal constant <{{.*}}> <{
 // -- ivar destroyer
-// CHECK-SAME: i8* null
+// CHECK-SAME: i32 0
 // --
 // CHECK-SAME: }>, align 8
 
@@ -98,12 +98,12 @@ public class Concrete : Derived<Int> {
 //// Metadata initialization function for 'Derived' copies superclass vtable
 //// and installs overrides for 'm2()' and 'init()'.
 
-// CHECK-LABEL: define internal %swift.type* @"$S14generic_vtable7DerivedCMi"(%swift.type_descriptor*, i8**)
+// CHECK-LABEL: define internal %swift.type* @"$S14generic_vtable7DerivedCMi"(%swift.type_descriptor*, i8**, i8**)
 
 // - 2 immediate members:
 //   - type metadata for generic parameter T,
 //   - and vtable entry for 'm3()'
-// CHECK: [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_descriptor* %0, i8** %1, i8** bitcast ({{.*}} @"$S14generic_vtable7DerivedCMP" to i8**))
+// CHECK: [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_descriptor* %0, i8** %1, i8** %2)
 
 // CHECK: call void @swift_initClassMetadata_UniversalStrategy(%swift.type* [[METADATA]], i64 0, {{.*}})
 

--- a/test/IRGen/type_layout.swift
+++ b/test/IRGen/type_layout.swift
@@ -21,7 +21,7 @@ struct FourInts { var x,y,z,w: Int32 }
 @_alignment(16)
 struct AlignedFourInts { var x: FourInts }
 
-// CHECK:       @"$S11type_layout14TypeLayoutTestVMn" = hidden constant {{.*}} @"$S11type_layout14TypeLayoutTestVMi"
+// CHECK:       @"$S11type_layout14TypeLayoutTestVMn" = hidden constant {{.*}} @"$S11type_layout14TypeLayoutTestVMP"
 // CHECK:       define internal %swift.type* @"$S11type_layout14TypeLayoutTestVMi"
 struct TypeLayoutTest<T> {
   // -- dynamic layout, projected from metadata

--- a/test/IRGen/type_layout_objc.swift
+++ b/test/IRGen/type_layout_objc.swift
@@ -20,7 +20,7 @@ enum EMult { case X(Int64), Y(Int64) }
 @_alignment(4)
 struct CommonLayout { var x,y,z,w: Int8 }
 
-// CHECK:       @"$S16type_layout_objc14TypeLayoutTestVMn" = hidden constant {{.*}} @"$S16type_layout_objc14TypeLayoutTestVMi"
+// CHECK:       @"$S16type_layout_objc14TypeLayoutTestVMn" = hidden constant {{.*}} @"$S16type_layout_objc14TypeLayoutTestVMP"
 // CHECK:       define internal %swift.type* @"$S16type_layout_objc14TypeLayoutTestVMi"
 struct TypeLayoutTest<T> {
   // -- dynamic layout, projected from metadata

--- a/test/IRGen/type_layout_reference_storage.swift
+++ b/test/IRGen/type_layout_reference_storage.swift
@@ -4,7 +4,7 @@ class C {}
 protocol P: class {}
 protocol Q: class {}
 
-// CHECK: @"$S29type_layout_reference_storage26ReferenceStorageTypeLayoutVMn" = hidden constant {{.*}} @"$S29type_layout_reference_storage26ReferenceStorageTypeLayoutVMi"
+// CHECK: @"$S29type_layout_reference_storage26ReferenceStorageTypeLayoutVMn" = hidden constant {{.*}} @"$S29type_layout_reference_storage26ReferenceStorageTypeLayoutVMP"
 // CHECK: define internal %swift.type* @"$S29type_layout_reference_storage26ReferenceStorageTypeLayoutVMi"
 struct ReferenceStorageTypeLayout<T, Native : C, Unknown : AnyObject> {
   var z: T
@@ -96,7 +96,7 @@ struct ReferenceStorageTypeLayout<T, Native : C, Unknown : AnyObject> {
 public class Base {
    var a: UInt32 = 0
 }
-// CHECK-LABEL: %swift.type* @{{.*}}7DerivedCMi"(%swift.type_descriptor*, i8**)
+// CHECK-LABEL: %swift.type* @{{.*}}7DerivedCMi"(%swift.type_descriptor*, i8**, i8**)
 // CHECK-NOT: store {{.*}}getelementptr{{.*}}SBomWV
 // CHECK: call %swift.type* @"$S29type_layout_reference_storage1P_pXmTMa"()
 // CHECK: store {{.*}}getelementptr{{.*}}SBoWV

--- a/test/IRGen/type_layout_reference_storage_objc.swift
+++ b/test/IRGen/type_layout_reference_storage_objc.swift
@@ -9,7 +9,7 @@ class C: NSObject {}
 @objc protocol Q {}
 protocol NonObjC: class {}
 
-// CHECK: @"$S34type_layout_reference_storage_objc26ReferenceStorageTypeLayoutVMn" = hidden constant {{.*}} @"$S34type_layout_reference_storage_objc26ReferenceStorageTypeLayoutVMi"
+// CHECK: @"$S34type_layout_reference_storage_objc26ReferenceStorageTypeLayoutVMn" = hidden constant {{.*}} @"$S34type_layout_reference_storage_objc26ReferenceStorageTypeLayoutVMP"
 // CHECK: define internal %swift.type* @"$S34type_layout_reference_storage_objc26ReferenceStorageTypeLayoutVMi"
 struct ReferenceStorageTypeLayout<T, ObjC: C> {
   var z: T

--- a/test/multifile/require-layout-generic-arg-closure.swift
+++ b/test/multifile/require-layout-generic-arg-closure.swift
@@ -18,9 +18,9 @@
 public func requestType2<T>(x: T) {
   requestTypeThrough(closure: { x in print(x) }, arg: x)
 }
-// FILE2-LABEL: define internal %swift.type* @"$S4test3SubCMi"(%swift.type_descriptor*, i8**)
+// FILE2-LABEL: define internal %swift.type* @"$S4test3SubCMi"(%swift.type_descriptor*, i8**, i8**)
 // FILE2:   [[T_ADDR:%.*]] = bitcast i8** %1 to %swift.type**
-// FILE2:   [[T:%.*]] = load %swift.type*, %swift.type** %2
+// FILE2:   [[T:%.*]] = load %swift.type*, %swift.type** [[T_ADDR]]
 // FILE2:   [[CLASSMETADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata
 // FILE2:   [[ADDR:%.*]] = bitcast %swift.type* [[CLASSMETADATA]] to i8**
 // This offset of T here needs to be the same as the offset above.

--- a/test/multifile/require-layout-generic-arg-subscript.swift
+++ b/test/multifile/require-layout-generic-arg-subscript.swift
@@ -22,9 +22,9 @@ public class AccessorTest {
   }
 }
 
-// FILE2-LABEL: define internal %swift.type* @"$S4test3SubCMi"(%swift.type_descriptor*, i8**)
+// FILE2-LABEL: define internal %swift.type* @"$S4test3SubCMi"(%swift.type_descriptor*, i8**, i8**)
 // FILE2:   [[T_ADDR:%.*]] = bitcast i8** %1 to %swift.type**
-// FILE2:   [[T:%.*]] = load %swift.type*, %swift.type** %2
+// FILE2:   [[T:%.*]] = load %swift.type*, %swift.type** [[T_ADDR]]
 // FILE2:   [[CLASSMETADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata
 // FILE2:   [[ADDR:%.*]] = bitcast %swift.type* [[CLASSMETADATA]] to i8**
 // This offset must match the offset above.

--- a/test/multifile/require-layout-generic-arg.swift
+++ b/test/multifile/require-layout-generic-arg.swift
@@ -16,9 +16,9 @@ public func requestType<T>(_ c: Sub<T>) {
   print(T.self)
 }
 
-// FILE2-LABEL: define internal %swift.type* @"$S4test3SubCMi"(%swift.type_descriptor*, i8**)
+// FILE2-LABEL: define internal %swift.type* @"$S4test3SubCMi"(%swift.type_descriptor*, i8**, i8**)
 // FILE2:   [[T_ADDR:%.*]] = bitcast i8** %1 to %swift.type**
-// FILE2:   [[T:%.*]] = load %swift.type*, %swift.type** %2
+// FILE2:   [[T:%.*]] = load %swift.type*, %swift.type** [[T_ADDR]]
 // FILE2:   [[CLASSMETADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata
 // FILE2:   [[ADDR:%.*]] = bitcast %swift.type* [[CLASSMETADATA]] to i8**
 // This offset must match the offset above.


### PR DESCRIPTION
The layout changes to become relative-address based.  For this to be truly immutable (at least on Darwin), things like the RO data patterns must be moved out of the pattern header.  Additionally, compress the pattern header so that we do not include metadata about patterns that are not needed for the type.

Value metadata patterns just include the metadata kind and VWT.

The design here is meant to accomodate non-default instantiation patterns should that become an interesting thing to support in the future, e.g. for v-table specialization.