### PR TITLE
[GSB] Always ensure that we wire up typealiases in protocol extensions.

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/0145-sr7097.swift
+++ b/validation-test/compiler_crashers_2_fixed/0145-sr7097.swift
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -o -
+
+protocol P1 { }
+
+protocol P2 {
+  associatedtype Assoc // expected-note{{'Assoc' declared here}}
+}
+
+// CHECK-LABEL: .P3@
+// CHECK-NEXT: Requirement signature: <Self where Self : P2, Self.Assoc == ConformsToP1>
+protocol P3 : P2 { }
+
+struct S0<M: P3> where M.Assoc: P1 { } // expected-warning{{redundant conformance constraint 'M.Assoc': 'P1'}}
+// expected-note@-1{{conformance constraint 'M.Assoc': 'P1' implied here}}
+
+struct ConformsToP1: P1 { }
+
+extension P3 {
+  typealias Assoc = ConformsToP1 // expected-warning{{typealias overriding associated type 'Assoc' from protocol 'P2' is better expressed as same-type constraint on the protocol}}
+}
+
+protocol P5 {
+}
+
+extension P5 {
+  // CHECK-LABEL: P5.testSR7097
+  // CHECK-NEXT: Generic signature: <Self, M where Self : P5, M : P3>
+  // CHECK-NEXT: <τ_0_0, τ_1_0 where τ_0_0 : P5, τ_1_0 : P3>
+  func testSR7097<M>(_: S0<M>.Type) {}
+}
+
+


### PR DESCRIPTION
During "expansion" of the requirements of a protocol, we check all of
the inherited associated types against definitions within the
protocol. Also look for concrete types within extensions of that
protocol, so we can identify more places where developers have used
typealiases in inheriting protocols to effect a same-type constraint
on an inherited associated type.

Fixes SR-7097 / rdar://problem/38001269.
