### PR TITLE
TESTING / DO NOT MERGE: force-enable batch mode

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -553,7 +553,7 @@ Driver::buildCompilation(const ToolChain &TC,
 
   bool BatchMode = ArgList->hasFlag(options::OPT_enable_batch_mode,
                                     options::OPT_disable_batch_mode,
-                                    false);
+                                    true);
 
   bool SaveTemps = ArgList->hasArg(options::OPT_save_temps);
   bool ContinueBuildingAfterErrors =


### PR DESCRIPTION
This is just a testing PR for evaluating batch mode against various PR-testing sets. Do not merge it.