### PR TITLE
[SourceKit] Disable invalid_offset.swift on Linux

### DIFF
--- a/test/SourceKit/CursorInfo/invalid_offset.swift
+++ b/test/SourceKit/CursorInfo/invalid_offset.swift
@@ -9,4 +9,7 @@ let a = 12
 // RUN:   -req=cursor -offset=250 %s -- %s \
 // RUN: | %FileCheck %s
 
+// rdar://problem/38162017
+// REQUIRES: OS=macosx
+
 // CHECK: <empty cursor info>


### PR DESCRIPTION
This test seems occasionally fail on Linux.
https://ci.swift.org/job/swift-PR-Linux-smoke-test/4858/console

Disable it while we investigate it.
rdar://problem/38162017
