### PR TITLE
[ClangImporter] Add missing end-iterator check in Clang diag emission

### DIFF
--- a/lib/ClangImporter/ClangDiagnosticConsumer.cpp
+++ b/lib/ClangImporter/ClangDiagnosticConsumer.cpp
@@ -165,8 +165,10 @@ SourceLoc ClangDiagnosticConsumer::resolveSourceLocation(
                                   const clang::SourceManager *toInsert) {
     return std::less<const clang::SourceManager *>()(inArray.get(), toInsert);
   });
-  if (iter->get() != &clangSrcMgr)
+  if (iter == sourceManagersWithDiagnostics.end() ||
+      iter->get() != &clangSrcMgr) {
     sourceManagersWithDiagnostics.insert(iter, &clangSrcMgr);
+  }
 
   return loc;
 }

--- a/test/ClangImporter/Inputs/custom-modules/Warnings1.h
+++ b/test/ClangImporter/Inputs/custom-modules/Warnings1.h
@@ -1,0 +1,4 @@
+extern void old() __attribute__((deprecated));
+static void warnings1() {
+  old();
+}

--- a/test/ClangImporter/Inputs/custom-modules/Warnings2.h
+++ b/test/ClangImporter/Inputs/custom-modules/Warnings2.h
@@ -1,0 +1,4 @@
+extern void old() __attribute__((deprecated));
+static void warnings2() {
+  old();
+}

--- a/test/ClangImporter/Inputs/custom-modules/Warnings3.h
+++ b/test/ClangImporter/Inputs/custom-modules/Warnings3.h
@@ -1,0 +1,4 @@
+extern void old() __attribute__((deprecated));
+static void warnings3() {
+  old();
+}

--- a/test/ClangImporter/Inputs/custom-modules/Warnings4.h
+++ b/test/ClangImporter/Inputs/custom-modules/Warnings4.h
@@ -1,0 +1,4 @@
+extern void old() __attribute__((deprecated));
+static void warnings4() {
+  old();
+}

--- a/test/ClangImporter/Inputs/custom-modules/Warnings5.h
+++ b/test/ClangImporter/Inputs/custom-modules/Warnings5.h
@@ -1,0 +1,4 @@
+extern void old() __attribute__((deprecated));
+static void warnings5() {
+  old();
+}

--- a/test/ClangImporter/Inputs/custom-modules/Warnings6.h
+++ b/test/ClangImporter/Inputs/custom-modules/Warnings6.h
@@ -1,0 +1,4 @@
+extern void old() __attribute__((deprecated));
+static void warnings6() {
+  old();
+}

--- a/test/ClangImporter/Inputs/custom-modules/Warnings7.h
+++ b/test/ClangImporter/Inputs/custom-modules/Warnings7.h
@@ -1,0 +1,4 @@
+extern void old() __attribute__((deprecated));
+static void warnings7() {
+  old();
+}

--- a/test/ClangImporter/Inputs/custom-modules/Warnings8.h
+++ b/test/ClangImporter/Inputs/custom-modules/Warnings8.h
@@ -1,0 +1,4 @@
+extern void old() __attribute__((deprecated));
+static void warnings8() {
+  old();
+}

--- a/test/ClangImporter/Inputs/custom-modules/Warnings9.h
+++ b/test/ClangImporter/Inputs/custom-modules/Warnings9.h
@@ -1,0 +1,4 @@
+extern void old() __attribute__((deprecated));
+static void warnings9() {
+  old();
+}

--- a/test/ClangImporter/Inputs/custom-modules/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/module.map
@@ -189,3 +189,13 @@ module IndirectFields {
 module ObjCBridgeNonconforming {
   header "ObjCBridgeNonconforming.h"
 }
+
+module Warnings1 { header "Warnings1.h" }
+module Warnings2 { header "Warnings2.h" }
+module Warnings3 { header "Warnings3.h" }
+module Warnings4 { header "Warnings4.h" }
+module Warnings5 { header "Warnings5.h" }
+module Warnings6 { header "Warnings6.h" }
+module Warnings7 { header "Warnings7.h" }
+module Warnings8 { header "Warnings8.h" }
+module Warnings9 { header "Warnings9.h" }

--- a/test/ClangImporter/diags-from-many-modules.swift
+++ b/test/ClangImporter/diags-from-many-modules.swift
@@ -1,0 +1,23 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules -module-cache-path %t 2> %t.err.txt
+// RUN: %FileCheck -input-file=%t.err.txt %s
+
+import Warnings1
+import Warnings2
+import Warnings3
+import Warnings4
+import Warnings5
+import Warnings6
+import Warnings7
+import Warnings8
+import Warnings9
+
+// CHECK: Warnings1.h:{{.+}}: warning: 'old' is deprecated
+// CHECK: Warnings2.h:{{.+}}: warning: 'old' is deprecated
+// CHECK: Warnings3.h:{{.+}}: warning: 'old' is deprecated
+// CHECK: Warnings4.h:{{.+}}: warning: 'old' is deprecated
+// CHECK: Warnings5.h:{{.+}}: warning: 'old' is deprecated
+// CHECK: Warnings6.h:{{.+}}: warning: 'old' is deprecated
+// CHECK: Warnings7.h:{{.+}}: warning: 'old' is deprecated
+// CHECK: Warnings8.h:{{.+}}: warning: 'old' is deprecated
+// CHECK: Warnings9.h:{{.+}}: warning: 'old' is deprecated


### PR DESCRIPTION
This caused non-deterministic crashes when a high number of modules containing diagnostics were compiled for the first time. The 9-entry test case results in a crash on 64-bit macOS when run under Guard Malloc without this change.

rdar://problem/33515925