### PR TITLE
upstream-update: adjust for SVN r326602

### DIFF
--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -53,9 +53,9 @@ importer::getNonNullArgs(const clang::Decl *decl,
     if (result.empty())
       result.resize(params.size(), false);
 
-    for (unsigned idx : nonnull->args()) {
-      if (idx < result.size())
-        result.set(idx);
+    for (const clang::ParamIdx &idx : nonnull->args()) {
+      if (idx.getASTIndex() < result.size())
+        result.set(idx.getASTIndex());
     }
   }
 


### PR DESCRIPTION
ParamIdx has been replaced with a custom class representing the type.
Adjust for the API change.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
