### PR TITLE
Add no-op visitor in SILGenFunction for #warning/#error

### DIFF
--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1682,6 +1682,10 @@ public:
     // No lowering support needed.
   }
 
+  void visitPoundDiagnosticDecl(PoundDiagnosticDecl *D) {
+    // No lowering support needed.
+  }
+
   void visitVarDecl(VarDecl *D);
 
   /// Emit an Initialization for a 'var' or 'let' decl in a pattern.

--- a/test/Sema/pound_diagnostics.swift
+++ b/test/Sema/pound_diagnostics.swift
@@ -1,4 +1,5 @@
 // RUN: %target-typecheck-verify-swift
+// RUN: %target-run-simple-swift
 
 #warning("this should be a warning") // expected-warning {{this should be a warning}}
 #error("this should be an error") // expected-error {{this should be an error}}

--- a/test/Sema/pound_diagnostics.swift
+++ b/test/Sema/pound_diagnostics.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
-// RUN: %target-swift-frontend -c -verify -o /dev/null
+// RUN: %target-swift-frontend -c -verify %s -o /dev/null
 
 #warning("this should be a warning") // expected-warning {{this should be a warning}}
 #error("this should be an error") // expected-error {{this should be an error}}

--- a/test/Sema/pound_diagnostics.swift
+++ b/test/Sema/pound_diagnostics.swift
@@ -1,5 +1,5 @@
 // RUN: %target-typecheck-verify-swift
-// RUN: %target-run-simple-swift
+// RUN: %target-swift-frontend -c -verify -o /dev/null
 
 #warning("this should be a warning") // expected-warning {{this should be a warning}}
 #error("this should be an error") // expected-error {{this should be an error}}


### PR DESCRIPTION
This is a leftover bug from #14048 where it'll assert in SILGenFunction when one of these is encountered. This wasn't caught because the test only ran with `-typecheck -verify`, and I didn't execute the test in a REPL before committing.