### PR TITLE
[Syntax] Parse invalid characters as trivia

### DIFF
--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -525,14 +525,15 @@ private:
   void lexEscapedIdentifier();
 
   void tryLexEditorPlaceholder();
-  const char *findEndOfCurlyQuoteStringLiteral(const char*);
+  const char *findEndOfCurlyQuoteStringLiteral(const char *,
+                                               bool EmitDiagnostics);
 
   /// Try to lex conflict markers by checking for the presence of the start and
   /// end of the marker in diff3 or Perforce style respectively.
   bool tryLexConflictMarker(bool EatNewline);
 
   /// Returns it should be tokenize.
-  bool lexUnknown();
+  bool lexUnknown(bool EmitDiagnosticsIfToken);
 
   NulCharacterKind getNulCharacterKind(const char *Ptr) const;
 };

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -531,6 +531,9 @@ private:
   /// end of the marker in diff3 or Perforce style respectively.
   bool tryLexConflictMarker(bool EatNewline);
 
+  /// Returns it should be tokenize.
+  bool lexUnknown();
+
   NulCharacterKind getNulCharacterKind(const char *Ptr) const;
 };
   

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2106,59 +2106,61 @@ Restart:
       // start, attempt to recover by eating more continuation characters.
       diagnose(CurPtr-1, diag::lex_invalid_identifier_start_character);
       while (advanceIfValidContinuationOfIdentifier(Tmp, BufferEnd));
-    } else {
-      // This character isn't allowed in Swift source.
-      uint32_t Codepoint = validateUTF8CharacterAndAdvance(Tmp, BufferEnd);
-      if (Codepoint == ~0U) {
-        diagnose(CurPtr-1, diag::lex_invalid_utf8)
-          .fixItReplaceChars(getSourceLoc(CurPtr-1), getSourceLoc(Tmp), " ");
-        CurPtr = Tmp;
-        goto Restart;  // Skip presumed whitespace.
-      } else if (Codepoint == 0x0000201D) {
-        // If this is an end curly quote, just diagnose it with a fixit hint.
-        diagnose(CurPtr-1, diag::lex_invalid_curly_quote)
-          .fixItReplaceChars(getSourceLoc(CurPtr-1), getSourceLoc(Tmp), "\"");
-      } else if (Codepoint == 0x0000201C) {
-        auto EndPtr = Tmp;
-        // If this is a start curly quote, do a fuzzy match of a string literal
-        // to improve recovery.
-        if (auto Tmp2 = findEndOfCurlyQuoteStringLiteral(Tmp))
-          Tmp = Tmp2;
+      CurPtr = Tmp;
+      return formToken(tok::unknown, TokStart);
+    }
 
-        // Note, we intentionally diagnose the end quote before the start quote,
-        // so that the IDE suggests fixing the end quote before the start quote.
-        // This, in turn, works better with our error recovery because we won't
-        // diagnose an end curly quote in the middle of a straight quoted
-        // literal.
-        diagnose(CurPtr-1, diag::lex_invalid_curly_quote)
-          .fixItReplaceChars(getSourceLoc(CurPtr-1), getSourceLoc(EndPtr),"\"");
+    // This character isn't allowed in Swift source.
+    uint32_t Codepoint = validateUTF8CharacterAndAdvance(Tmp, BufferEnd);
+    if (Codepoint == ~0U) {
+      diagnose(CurPtr - 1, diag::lex_invalid_utf8)
+          .fixItReplaceChars(getSourceLoc(CurPtr - 1), getSourceLoc(Tmp), " ");
+      CurPtr = Tmp;
+      goto Restart; // Skip presumed whitespace.
+    } else if (Codepoint == 0x0000201D) {
+      // If this is an end curly quote, just diagnose it with a fixit hint.
+      diagnose(CurPtr - 1, diag::lex_invalid_curly_quote)
+          .fixItReplaceChars(getSourceLoc(CurPtr - 1), getSourceLoc(Tmp), "\"");
+      CurPtr = Tmp;
+      return formToken(tok::unknown, TokStart);
+    } else if (Codepoint == 0x0000201C) {
+      auto EndPtr = Tmp;
+      // If this is a start curly quote, do a fuzzy match of a string literal
+      // to improve recovery.
+      if (auto Tmp2 = findEndOfCurlyQuoteStringLiteral(Tmp))
+        Tmp = Tmp2;
 
-      } else {
-        diagnose(CurPtr-1, diag::lex_invalid_character)
-          .fixItReplaceChars(getSourceLoc(CurPtr-1), getSourceLoc(Tmp), " ");
+      // Note, we intentionally diagnose the end quote before the start quote,
+      // so that the IDE suggests fixing the end quote before the start quote.
+      // This, in turn, works better with our error recovery because we won't
+      // diagnose an end curly quote in the middle of a straight quoted
+      // literal.
+      diagnose(CurPtr - 1, diag::lex_invalid_curly_quote)
+          .fixItReplaceChars(getSourceLoc(CurPtr - 1), getSourceLoc(EndPtr),
+                             "\"");
+      CurPtr = Tmp;
+      return formToken(tok::unknown, TokStart);
+    }
 
-        char ExpectedCodepoint;
-        if ((ExpectedCodepoint =
-            confusable::tryConvertConfusableCharacterToASCII(Codepoint))) {
+    diagnose(CurPtr - 1, diag::lex_invalid_character)
+        .fixItReplaceChars(getSourceLoc(CurPtr - 1), getSourceLoc(Tmp), " ");
 
-          llvm::SmallString<4> ConfusedChar;
-          EncodeToUTF8(Codepoint, ConfusedChar);
-          llvm::SmallString<1> ExpectedChar;
-          ExpectedChar += ExpectedCodepoint;
-          diagnose(CurPtr-1, diag::lex_confusable_character,
-                   ConfusedChar, ExpectedChar)
-            .fixItReplaceChars(getSourceLoc(CurPtr-1),
-                               getSourceLoc(Tmp),
-                               ExpectedChar);
-        }
+    char ExpectedCodepoint;
+    if ((ExpectedCodepoint =
+             confusable::tryConvertConfusableCharacterToASCII(Codepoint))) {
 
-        CurPtr = Tmp;
-        goto Restart;  // Skip presumed whitespace.
-      }
+      llvm::SmallString<4> ConfusedChar;
+      EncodeToUTF8(Codepoint, ConfusedChar);
+      llvm::SmallString<1> ExpectedChar;
+      ExpectedChar += ExpectedCodepoint;
+      diagnose(CurPtr - 1, diag::lex_confusable_character, ConfusedChar,
+               ExpectedChar)
+          .fixItReplaceChars(getSourceLoc(CurPtr - 1), getSourceLoc(Tmp),
+                             ExpectedChar);
     }
 
     CurPtr = Tmp;
-    return formToken(tok::unknown, TokStart);
+    goto Restart; // Skip presumed whitespace.
   }
 
   case '\n':

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2094,36 +2094,36 @@ Restart:
   
   switch ((signed char)*CurPtr++) {
   default: {
-    char const *tmp = CurPtr-1;
-    if (advanceIfValidStartOfIdentifier(tmp, BufferEnd))
+    char const *Tmp = CurPtr-1;
+    if (advanceIfValidStartOfIdentifier(Tmp, BufferEnd))
       return lexIdentifier();
     
-    if (advanceIfValidStartOfOperator(tmp, BufferEnd))
+    if (advanceIfValidStartOfOperator(Tmp, BufferEnd))
       return lexOperatorIdentifier();
     
-    if (advanceIfValidContinuationOfIdentifier(tmp, BufferEnd)) {
+    if (advanceIfValidContinuationOfIdentifier(Tmp, BufferEnd)) {
       // If this is a valid identifier continuation, but not a valid identifier
       // start, attempt to recover by eating more continuation characters.
       diagnose(CurPtr-1, diag::lex_invalid_identifier_start_character);
-      while (advanceIfValidContinuationOfIdentifier(tmp, BufferEnd));
+      while (advanceIfValidContinuationOfIdentifier(Tmp, BufferEnd));
     } else {
       // This character isn't allowed in Swift source.
-      uint32_t codepoint = validateUTF8CharacterAndAdvance(tmp, BufferEnd);
-      if (codepoint == ~0U) {
+      uint32_t Codepoint = validateUTF8CharacterAndAdvance(Tmp, BufferEnd);
+      if (Codepoint == ~0U) {
         diagnose(CurPtr-1, diag::lex_invalid_utf8)
-          .fixItReplaceChars(getSourceLoc(CurPtr-1), getSourceLoc(tmp), " ");
-        CurPtr = tmp;
+          .fixItReplaceChars(getSourceLoc(CurPtr-1), getSourceLoc(Tmp), " ");
+        CurPtr = Tmp;
         goto Restart;  // Skip presumed whitespace.
-      } else if (codepoint == 0x0000201D) {
+      } else if (Codepoint == 0x0000201D) {
         // If this is an end curly quote, just diagnose it with a fixit hint.
         diagnose(CurPtr-1, diag::lex_invalid_curly_quote)
-          .fixItReplaceChars(getSourceLoc(CurPtr-1), getSourceLoc(tmp), "\"");
-      } else if (codepoint == 0x0000201C) {
-        auto endPtr = tmp;
+          .fixItReplaceChars(getSourceLoc(CurPtr-1), getSourceLoc(Tmp), "\"");
+      } else if (Codepoint == 0x0000201C) {
+        auto EndPtr = Tmp;
         // If this is a start curly quote, do a fuzzy match of a string literal
         // to improve recovery.
-        if (auto tmp2 = findEndOfCurlyQuoteStringLiteral(tmp))
-          tmp = tmp2;
+        if (auto Tmp2 = findEndOfCurlyQuoteStringLiteral(Tmp))
+          Tmp = Tmp2;
 
         // Note, we intentionally diagnose the end quote before the start quote,
         // so that the IDE suggests fixing the end quote before the start quote.
@@ -2131,33 +2131,33 @@ Restart:
         // diagnose an end curly quote in the middle of a straight quoted
         // literal.
         diagnose(CurPtr-1, diag::lex_invalid_curly_quote)
-          .fixItReplaceChars(getSourceLoc(CurPtr-1), getSourceLoc(endPtr),"\"");
+          .fixItReplaceChars(getSourceLoc(CurPtr-1), getSourceLoc(EndPtr),"\"");
 
       } else {
         diagnose(CurPtr-1, diag::lex_invalid_character)
-          .fixItReplaceChars(getSourceLoc(CurPtr-1), getSourceLoc(tmp), " ");
+          .fixItReplaceChars(getSourceLoc(CurPtr-1), getSourceLoc(Tmp), " ");
 
-        char expectedCodepoint;
-        if ((expectedCodepoint =
-            confusable::tryConvertConfusableCharacterToASCII(codepoint))) {
+        char ExpectedCodepoint;
+        if ((ExpectedCodepoint =
+            confusable::tryConvertConfusableCharacterToASCII(Codepoint))) {
 
-          llvm::SmallString<4> confusedChar;
-          EncodeToUTF8(codepoint, confusedChar);
-          llvm::SmallString<1> expectedChar;
-          expectedChar += expectedCodepoint;
+          llvm::SmallString<4> ConfusedChar;
+          EncodeToUTF8(Codepoint, ConfusedChar);
+          llvm::SmallString<1> ExpectedChar;
+          ExpectedChar += ExpectedCodepoint;
           diagnose(CurPtr-1, diag::lex_confusable_character,
-                   confusedChar, expectedChar)
+                   ConfusedChar, ExpectedChar)
             .fixItReplaceChars(getSourceLoc(CurPtr-1),
-                               getSourceLoc(tmp),
-                               expectedChar);
+                               getSourceLoc(Tmp),
+                               ExpectedChar);
         }
 
-        CurPtr = tmp;
+        CurPtr = Tmp;
         goto Restart;  // Skip presumed whitespace.
       }
     }
 
-    CurPtr = tmp;
+    CurPtr = Tmp;
     return formToken(tok::unknown, TokStart);
   }
 

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1864,6 +1864,72 @@ bool Lexer::tryLexConflictMarker(bool EatNewline) {
   return false;
 }
 
+bool Lexer::lexUnknown() {
+  const char *Tmp = CurPtr - 1;
+
+  if (advanceIfValidContinuationOfIdentifier(Tmp, BufferEnd)) {
+    // If this is a valid identifier continuation, but not a valid identifier
+    // start, attempt to recover by eating more continuation characters.
+    diagnose(CurPtr - 1, diag::lex_invalid_identifier_start_character);
+    while (advanceIfValidContinuationOfIdentifier(Tmp, BufferEnd))
+      ;
+    CurPtr = Tmp;
+    return true;
+  }
+
+  // This character isn't allowed in Swift source.
+  uint32_t Codepoint = validateUTF8CharacterAndAdvance(Tmp, BufferEnd);
+  if (Codepoint == ~0U) {
+    diagnose(CurPtr - 1, diag::lex_invalid_utf8)
+        .fixItReplaceChars(getSourceLoc(CurPtr - 1), getSourceLoc(Tmp), " ");
+    CurPtr = Tmp;
+    return false; // Skip presumed whitespace.
+  } else if (Codepoint == 0x0000201D) {
+    // If this is an end curly quote, just diagnose it with a fixit hint.
+    diagnose(CurPtr - 1, diag::lex_invalid_curly_quote)
+        .fixItReplaceChars(getSourceLoc(CurPtr - 1), getSourceLoc(Tmp), "\"");
+    CurPtr = Tmp;
+    return true;
+  } else if (Codepoint == 0x0000201C) {
+    auto EndPtr = Tmp;
+    // If this is a start curly quote, do a fuzzy match of a string literal
+    // to improve recovery.
+    if (auto Tmp2 = findEndOfCurlyQuoteStringLiteral(Tmp))
+      Tmp = Tmp2;
+
+    // Note, we intentionally diagnose the end quote before the start quote,
+    // so that the IDE suggests fixing the end quote before the start quote.
+    // This, in turn, works better with our error recovery because we won't
+    // diagnose an end curly quote in the middle of a straight quoted
+    // literal.
+    diagnose(CurPtr - 1, diag::lex_invalid_curly_quote)
+        .fixItReplaceChars(getSourceLoc(CurPtr - 1), getSourceLoc(EndPtr),
+                           "\"");
+    CurPtr = Tmp;
+    return true;
+  }
+
+  diagnose(CurPtr - 1, diag::lex_invalid_character)
+      .fixItReplaceChars(getSourceLoc(CurPtr - 1), getSourceLoc(Tmp), " ");
+
+  char ExpectedCodepoint;
+  if ((ExpectedCodepoint =
+           confusable::tryConvertConfusableCharacterToASCII(Codepoint))) {
+
+    llvm::SmallString<4> ConfusedChar;
+    EncodeToUTF8(Codepoint, ConfusedChar);
+    llvm::SmallString<1> ExpectedChar;
+    ExpectedChar += ExpectedCodepoint;
+    diagnose(CurPtr - 1, diag::lex_confusable_character, ConfusedChar,
+             ExpectedChar)
+        .fixItReplaceChars(getSourceLoc(CurPtr - 1), getSourceLoc(Tmp),
+                           ExpectedChar);
+  }
+
+  CurPtr = Tmp;
+  return false; // Skip presumed whitespace.
+}
+
 Lexer::NulCharacterKind Lexer::getNulCharacterKind(const char *Ptr) const {
   assert(Ptr != nullptr && *Ptr == 0);
   if (Ptr == CodeCompletionPtr) {
@@ -2100,66 +2166,11 @@ Restart:
     
     if (advanceIfValidStartOfOperator(Tmp, BufferEnd))
       return lexOperatorIdentifier();
-    
-    if (advanceIfValidContinuationOfIdentifier(Tmp, BufferEnd)) {
-      // If this is a valid identifier continuation, but not a valid identifier
-      // start, attempt to recover by eating more continuation characters.
-      diagnose(CurPtr-1, diag::lex_invalid_identifier_start_character);
-      while (advanceIfValidContinuationOfIdentifier(Tmp, BufferEnd));
-      CurPtr = Tmp;
+
+    bool ShouldTokenize = lexUnknown();
+    if (ShouldTokenize) {
       return formToken(tok::unknown, TokStart);
     }
-
-    // This character isn't allowed in Swift source.
-    uint32_t Codepoint = validateUTF8CharacterAndAdvance(Tmp, BufferEnd);
-    if (Codepoint == ~0U) {
-      diagnose(CurPtr - 1, diag::lex_invalid_utf8)
-          .fixItReplaceChars(getSourceLoc(CurPtr - 1), getSourceLoc(Tmp), " ");
-      CurPtr = Tmp;
-      goto Restart; // Skip presumed whitespace.
-    } else if (Codepoint == 0x0000201D) {
-      // If this is an end curly quote, just diagnose it with a fixit hint.
-      diagnose(CurPtr - 1, diag::lex_invalid_curly_quote)
-          .fixItReplaceChars(getSourceLoc(CurPtr - 1), getSourceLoc(Tmp), "\"");
-      CurPtr = Tmp;
-      return formToken(tok::unknown, TokStart);
-    } else if (Codepoint == 0x0000201C) {
-      auto EndPtr = Tmp;
-      // If this is a start curly quote, do a fuzzy match of a string literal
-      // to improve recovery.
-      if (auto Tmp2 = findEndOfCurlyQuoteStringLiteral(Tmp))
-        Tmp = Tmp2;
-
-      // Note, we intentionally diagnose the end quote before the start quote,
-      // so that the IDE suggests fixing the end quote before the start quote.
-      // This, in turn, works better with our error recovery because we won't
-      // diagnose an end curly quote in the middle of a straight quoted
-      // literal.
-      diagnose(CurPtr - 1, diag::lex_invalid_curly_quote)
-          .fixItReplaceChars(getSourceLoc(CurPtr - 1), getSourceLoc(EndPtr),
-                             "\"");
-      CurPtr = Tmp;
-      return formToken(tok::unknown, TokStart);
-    }
-
-    diagnose(CurPtr - 1, diag::lex_invalid_character)
-        .fixItReplaceChars(getSourceLoc(CurPtr - 1), getSourceLoc(Tmp), " ");
-
-    char ExpectedCodepoint;
-    if ((ExpectedCodepoint =
-             confusable::tryConvertConfusableCharacterToASCII(Codepoint))) {
-
-      llvm::SmallString<4> ConfusedChar;
-      EncodeToUTF8(Codepoint, ConfusedChar);
-      llvm::SmallString<1> ExpectedChar;
-      ExpectedChar += ExpectedCodepoint;
-      diagnose(CurPtr - 1, diag::lex_confusable_character, ConfusedChar,
-               ExpectedChar)
-          .fixItReplaceChars(getSourceLoc(CurPtr - 1), getSourceLoc(Tmp),
-                             ExpectedChar);
-    }
-
-    CurPtr = Tmp;
     goto Restart; // Skip presumed whitespace.
   }
 

--- a/test/Syntax/tokens_unknown_and_invalid.swift
+++ b/test/Syntax/tokens_unknown_and_invalid.swift
@@ -1,0 +1,127 @@
+// To embed test byte sequence,
+// this source replace marker to byte sequence first in runtime.
+// Marker(N) have `ZN` style format. Z is Z, N is number.
+// Byte sequence is represented in escape sequence.
+// To avoid replace marker in sed command by sed itself,
+// marker is also represented in escape sequence.
+
+// RUN: cat %s | sed \
+
+// [0xC2] is utf8 2 byte character start byte.
+// 0xC2 without second byte is invalid UTF-8 sequence.
+// It becomes garbage text trivia.
+// Marker(1) is replaced to this sequence.
+
+// RUN: -e 's/'$(echo -ne "\x5a1")'/'$(echo -ne "\xc2")'/g' \
+
+// [0xCC, 0x82] in UTF-8 is U+0302.
+// This character is invalid for identifier start, but valid for identifier body.
+// It becomes unknown token.
+// If this type characters are conitguous, they are concatenated to one long unknown token.
+// Marker(2) is replaced to this sequence.
+
+// RUN: -e 's/'$(echo -ne "\x5a2")'/'$(echo -ne "\xcc\x82")'/g' \
+
+// [0xE2, 0x80, 0x9C] in UTF-8 is U+201C, left quote.
+// It becomes single character unknown token.
+// If this left quote and right quote enclosure text,
+// they become one long unknown token.
+// Marker(3) is replaced to this sequence.
+
+// RUN: -e 's/'$(echo -ne "\x5a3")'/'$(echo -ne "\xe2\x80\x9c")'/g' \
+
+// [0xE2, 0x80, 0x9D] in UTF-8 is U+201D, right quote.
+// It becomes single character unknown token.
+// Marker(4) is replaced to this sequence.
+
+// RUN: -e 's/'$(echo -ne "\x5a4")'/'$(echo -ne "\xe2\x80\x9d")'/g' \
+
+// [0xE1, 0x9A, 0x80] in UTF-8 is U+1680.
+// This character is invalid for swift source.
+// It becomes garbage trivia.
+// Marker(5) is replaced to this sequence.
+
+// RUN: -e 's/'$(echo -ne "\x5a5")'/'$(echo -ne "\xe1\x9a\x80")'/g' \
+
+// RUN: > %t
+
+// RUN: %swift-syntax-test -input-source-filename %t -dump-full-tokens 2>&1 | %FileCheck %t
+// RUN: %round-trip-syntax-test --swift-syntax-test %swift-syntax-test --file %t
+
+aaa
+Z1 bbb Z1
+
+ccc Z2
+
+ddd Z2Z2Z2Z2
+
+eee Z3Z3
+
+fff Z3hello worldZ4
+
+ggg Z4
+
+hhh
+Z5 iii Z5
+jjj
+
+// Diagnostics
+// CHECK: 52:1: error: invalid UTF-8 found in source file
+// CHECK: 52:7: error: invalid UTF-8 found in source file
+// CHECK: 54:5: error: an identifier cannot begin with this character
+// CHECK: 56:5: error: an identifier cannot begin with this character
+// CHECK: 58:5: error: unicode curly quote found
+// CHECK: 58:8: error: unicode curly quote found
+// CHECK: 60:19: error: unicode curly quote found
+// CHECK: 60:5: error: unicode curly quote found
+// CHECK: 62:5: error: unicode curly quote found
+// CHECK: 65:1: error: invalid character in source file
+// CHECK: 65:9: error: invalid character in source file
+
+// Checks around bbb
+// CHECK-LABEL: 52:3
+// CHECK-NEXT:  (Token identifier
+// CHECK-NEXT:   (trivia newline 1)
+// CHECK-NEXT:   (trivia garbage_text \302)
+// CHECK-NEXT:   (trivia space 1)
+// CHECK-NEXT:   (text="bbb")
+// CHECK-NEXT:   (trivia space 1)
+// CHECK-NEXT:   (trivia garbage_text \302))
+
+// Checks around ccc
+// CHECK-LABEL: 54:5
+// CHECK-NEXT:  (Token unknown
+// CHECK-NEXT:   (text="\xCC\x82"))
+
+// Checks around ddd
+// CHECK-LABEL: 56:5
+// CHECK-NEXT:  (Token unknown
+// CHECK-NEXT:   (text="\xCC\x82\xCC\x82\xCC\x82\xCC\x82"))
+
+// Checks around eee
+// CHECK-LABEL: 58:5
+// CHECK-NEXT:  (Token unknown
+// CHECK-NEXT:   (text="\xE2\x80\x9C"))
+// CHECK-LABEL: 58:8
+// CHECK-NEXT:  (Token unknown
+// CHECK-NEXT:   (text="\xE2\x80\x9C"))
+
+// Checks around fff
+// CHECK-LABEL: 60:5
+// CHECK-NEXT:  (Token unknown
+// CHECK-NEXT:   (text="\xE2\x80\x9Chello world\xE2\x80\x9D"))
+
+// Checks around ggg
+// CHECK-LABEL: 62:5
+// CHECK-NEXT:  (Token unknown
+// CHECK-NEXT:   (text="\xE2\x80\x9D"))
+
+// Checks around iii
+// CHECK-LABEL: 65:5
+// CHECK-NEXT:  (Token identifier
+// CHECK-NEXT:   (trivia newline 1)
+// CHECK-NEXT:   (trivia garbage_text \341\232\200)
+// CHECK-NEXT:   (trivia space 1)
+// CHECK-NEXT:   (text="iii")
+// CHECK-NEXT:   (trivia space 1)
+// CHECK-NEXT:   (trivia garbage_text \341\232\200))


### PR DESCRIPTION
This PR update Lexer to parse invalid characters as trivia.

Invalid chars means here is invalid UTF-8 byte sequence and unicode code point which is invalid in Swift source.
They are just skipped in lexImpl before.

By this PR, libSyntax get perfect round trip with source code which has arbitrary binary even if it contains broken UTF-8 byte sequence.

This is my third retry for same purpose.
First is https://github.com/apple/swift/pull/14967.
Second is https://github.com/apple/swift/pull/14979.
In this time, I covered all considerations and retrieved review.

I rearranged concepts around here.
There are 2 kind of things.

First is `unknown token`.
There are some rules to lex `unknown token` in Lexer.
When hit these tokens in `lexImpl`, Lexer need to stop reading and position start of token.

Second is `garbage text trivia`.
They come from invalid byte sequences and unicode codepoint which is invalid in Swift source.

To detect both cases in `lexTrivia`,
I added some new `case` branches and I minimize them.
Specifically, to minimize,
`case` below are handled in `advanceIfValidStartOfIdentifier` in `default` branch.

```
case 'A': case 'B': case 'C': case 'D': case 'E': case 'F': case 'G':
case 'H': case 'I': case 'J': case 'K': case 'L': case 'M': case 'N':
case 'O': case 'P': case 'Q': case 'R': case 'S': case 'T': case 'U':
case 'V': case 'W': case 'X': case 'Y': case 'Z':
case 'a': case 'b': case 'c': case 'd': case 'e': case 'f': case 'g':
case 'h': case 'i': case 'j': case 'k': case 'l': case 'm': case 'n':
case 'o': case 'p': case 'q': case 'r': case 's': case 't': case 'u':
case 'v': case 'w': case 'x': case 'y': case 'z':
case '_': 
```

`case` below are handled in `advanceIfValidStartOfOperator` in `default` branch too.

```
case '%': case '!': case '?':case '=':
case '-': case '+': case '*': 
case '&': case '|': case '^': case '~': case '.':
```

First 4 commits does not change behavior of Lexer.
They are step by step refactoring to prepare new function.

Last commit implement lexing and adding test cases.

Please review this. @rintaro @harlanhaskins @nkcsgexi 

