### PR TITLE
[build-script] Disable building llbuild Swift bindings

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2355,7 +2355,6 @@ for host in "${ALL_HOSTS[@]}"; do
                     -DFILECHECK_EXECUTABLE:PATH="$(build_directory_bin ${LOCAL_HOST} llvm)/FileCheck"
                     -DCMAKE_BUILD_TYPE:STRING="${LLBUILD_BUILD_TYPE}"
                     -DLLVM_ENABLE_ASSERTIONS:BOOL=$(true_false "${LLBUILD_ENABLE_ASSERTIONS}")
-                    -DLLBUILD_SUPPORT_BINDINGS:=Swift
                 )
                 ;;
             swiftpm)


### PR DESCRIPTION
The CMake support in llbuild is finding the compiler in the system
instead of the build products. This causes build errors if Swift is old
on a system.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
