### PR TITLE
Sema: Diagnose self.init and super.init inside closures 

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -206,7 +206,7 @@ private:
   struct {
     unsigned TestingEnabled : 1;
     unsigned FailedToLoad : 1;
-    unsigned ResilienceStrategy : 2;
+    unsigned ResilienceStrategy : 1;
   } Flags;
 
   ModuleDecl(Identifier name, ASTContext &ctx);

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -371,15 +371,10 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
             .highlight(IOE->getSubExpr()->getSourceRange());
       }
 
-      // Diagnose 'self.init' or 'super.init' nested in another expression.
+      // Diagnose 'self.init' or 'super.init' nested in another expression
+      // or closure.
       if (auto *rebindSelfExpr = dyn_cast<RebindSelfInConstructorExpr>(E)) {
-        bool inDefer = false;
-        auto *innerDecl = DC->getInnermostDeclarationDeclContext();
-        if (auto *FD = dyn_cast_or_null<FuncDecl>(innerDecl)) {
-          inDefer = FD->isDeferBody();
-        }
-
-        if (!Parent.isNull() || !IsExprStmt || inDefer) {
+        if (!Parent.isNull() || !IsExprStmt || DC->getParent()->isLocalContext()) {
           bool isChainToSuper;
           (void)rebindSelfExpr->getCalledConstructor(isChainToSuper);
           TC.diagnose(E->getLoc(), diag::init_delegation_nested,

--- a/test/expr/postfix/dot/init_ref_delegation.swift
+++ b/test/expr/postfix/dot/init_ref_delegation.swift
@@ -373,6 +373,30 @@ class TestNestedExpr {
   convenience init(i: Int) {
     _ = ((), try! self.init(error: true)) // expected-error {{initializer delegation ('self.init') cannot be nested in another expression}}
   }
+
+  convenience init(j: Int) throws {
+    _ = {
+      try self.init(error: true)
+      // expected-error@-1 {{initializer delegation ('self.init') cannot be nested in another expression}}
+    }
+
+    _ = {
+      do {
+        try self.init(error: true)
+        // expected-error@-1 {{initializer delegation ('self.init') cannot be nested in another expression}}
+      }
+    }
+
+    defer {
+      try! self.init(error: true)
+      // expected-error@-1 {{initializer delegation ('self.init') cannot be nested in another expression}}
+    }
+
+    func local() throws {
+      try self.init(error: true)
+      // expected-error@-1 {{initializer delegation ('self.init') cannot be nested in another expression}}
+    }
+  }
 }
 
 class TestNestedExprSub : TestNestedExpr {


### PR DESCRIPTION
Fixes <rdar://problem/27420414>.