### PR TITLE
Fill in the field-offset vector and payload size for fixed-layout value metadata

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -397,7 +397,7 @@ initializeValueMetadataFromPattern(ValueMetadata *metadata,
 
   if (pattern->hasExtraDataPattern()) {
     void **metadataExtraData =
-      reinterpret_cast<void**>(rawMetadata) + sizeof(ValueMetadata);
+      reinterpret_cast<void**>(rawMetadata + sizeof(ValueMetadata));
     auto extraDataPattern = pattern->getExtraDataPattern();
 
     // Zero memory up to the offset.

--- a/test/IRGen/enum_value_semantics.sil
+++ b/test/IRGen/enum_value_semantics.sil
@@ -159,8 +159,10 @@ enum GenericFixedLayout<T> {
 // CHECK-SAME:    @"$S20enum_value_semantics18GenericFixedLayoutOMP"
 
 // CHECK-LABEL: @"$S20enum_value_semantics18GenericFixedLayoutOMP" = internal constant <{ {{.*}} }> <{
+//   Instantiation function.
 // CHECK-SAME:    i32 trunc (i64 sub (i64 ptrtoint (%swift.type* (%swift.type_descriptor*, i8**, i8**)* @"$S20enum_value_semantics18GenericFixedLayoutOMi" to i64), i64 ptrtoint (<{ i32, i32, i32, i32 }>* @"$S20enum_value_semantics18GenericFixedLayoutOMP" to i64)) to i32),
-// CHECK-SAME:    @"$S20enum_value_semantics18GenericFixedLayoutOMr"
+//   Completion function.
+// CHECK-SAME:    i32 0,
 //   Pattern flags.  0x400000 == (MetadataKind::Enum << 21).
 // CHECK-SAME:    i32 4194304,
 //   Value witness table.

--- a/test/IRGen/generic_structs.sil
+++ b/test/IRGen/generic_structs.sil
@@ -6,6 +6,23 @@
 
 import Builtin
 
+// -- Generic structs with fixed layout should have no completion function
+//    and emit the field offset vector as part of the pattern.
+// CHECK:       [[PATTERN:@.*]] = internal constant [3 x i64] [i64 0, i64 1, i64 8]
+// CHECK-LABEL: @"$S15generic_structs18FixedLayoutGenericVMP" = internal constant <{ {{.*}} }> <{
+// -- instantiation function
+// CHECK-SAME:   %swift.type* (%swift.type_descriptor*, i8**, i8**)* @"$S15generic_structs18FixedLayoutGenericVMi"
+// -- completion function
+// CHECK-SAME:   i32 0,
+// -- pattern flags
+// CHECK-SAME:   i32 2097153,
+// -- vwtable pointer
+// CHECK-SAME:   @"$S15generic_structs18FixedLayoutGenericVWV"
+// -- extra data pattern
+// CHECK-SAME: [3 x i64]* [[PATTERN]]
+// CHECK-SAME: i16 1,
+// CHECK-SAME: i16 3 }>
+
 // -- Generic structs with dynamic layout contain the vwtable pattern as part
 //    of the metadata pattern, and no independent vwtable symbol
 // CHECK: @"$S15generic_structs13SingleDynamicVWV" = internal constant
@@ -87,6 +104,12 @@ import Builtin
 // CHECK: @"$S15generic_structs8StringlyVMf" = internal constant <{ {{.*}} i64, i64, i64 }> <{
 // CHECK-SAME:   i64 0, i64 8, i64 16
 // CHECK-SAME: }>
+
+struct FixedLayoutGeneric<T> {
+  var x: Byteful
+  var y: Byteful
+  var z: Intish
+}
 
 struct SingleDynamic<T> {
   var x : T


### PR DESCRIPTION
This regression wasn't caught by normal code-generation pattern testing because the emission pattern substantially changed anyway, breaking tests that were looking for the field-offset vector, and because normal execution testing doesn't actually use the field-offset vector and enum payload size fields.

Reflection, which does use these fields, was skating by for common types because metadata is typically allocated out of freshly zeroed pages and most such types have only one field.  But that doesn't always happen, so there was a non-determinstic failure that caught it.

Also, don't emit a completion function for value metadata with fixed layout.

We really shouldn't have to emit field-offset vectors for fixed-layout types; the layout should just go in the type descriptor.  But for now, this is what we have to do.