### PR TITLE
SILGen: Emit property descriptors for (some) decls that need them.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2353,9 +2353,6 @@ private:
       Indices(indices),
       IndexEquality{indicesEqual, indicesHash},
       ComponentType(ComponentType) {
-    assert(indices.empty() == !indicesEqual
-           && indices.empty() == !indicesHash
-           && "must have equals/hash functions iff there are indices");
   }
   
   KeyPathPatternComponent(AbstractStorageDecl *externalStorage,

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -339,6 +339,16 @@ public:
                                  AccessKind accessKind);
   SILDeclRef getMaterializeForSetDeclRef(AbstractStorageDecl *decl);
 
+  KeyPathPatternComponent
+  emitKeyPathComponentForDecl(SILLocation loc,
+                              GenericEnvironment *genericEnv,
+                              unsigned &baseOperand,
+                              bool &needsGenericContext,
+                              SubstitutionList subs,
+                              AbstractStorageDecl *storage,
+                              ArrayRef<ProtocolConformanceRef> indexHashables,
+                              CanType baseTy);
+
   /// Known functions for bridging.
   SILDeclRef getStringToNSStringFn();
   SILDeclRef getNSStringToStringFn();

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -5011,6 +5011,9 @@ ArgumentSource SILGenFunction::prepareAccessorBaseArg(SILLocation loc,
                                                       ManagedValue base,
                                                       CanType baseFormalType,
                                                       SILDeclRef accessor) {
+  if (!base)
+    return ArgumentSource();
+
   AccessorBaseArgPreparer Preparer(*this, loc, base, baseFormalType, accessor);
   return Preparer.prepare();
 }

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -2607,7 +2607,8 @@ SILVTable *SILDeserializer::readVTable(DeclID VId) {
   // Another SIL_VTABLE record means the end of this VTable.
   while (kind != SIL_VTABLE && kind != SIL_WITNESS_TABLE &&
          kind != SIL_DEFAULT_WITNESS_TABLE &&
-         kind != SIL_FUNCTION) {
+         kind != SIL_FUNCTION &&
+         kind != SIL_PROPERTY) {
     assert(kind == SIL_VTABLE_ENTRY &&
            "Content of Vtable should be in SIL_VTABLE_ENTRY.");
     ArrayRef<uint64_t> ListOfValues;

--- a/test/SILGen/keypath_property_descriptors.swift
+++ b/test/SILGen/keypath_property_descriptors.swift
@@ -1,0 +1,80 @@
+// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+
+// TODO: globals should get descriptors
+public var a: Int = 0
+
+@_inlineable
+public var b: Int { return 0 }
+
+@_versioned
+internal var c: Int = 0
+
+// no descriptor
+// CHECK-NOT: sil_property #d
+internal var d: Int = 0
+// CHECK-NOT: sil_property #e
+private var e: Int = 0
+
+public struct A {
+  // CHECK-LABEL: sil_property #A.a
+  public var a: Int = 0
+
+  // CHECK-LABEL: sil_property #A.b
+  @_inlineable
+  public var b: Int { return 0 }
+
+  // CHECK-LABEL: sil_property #A.c
+  @_versioned
+  internal var c: Int = 0
+
+  // no descriptor
+  // CHECK-NOT: sil_property #A.d
+  internal var d: Int = 0
+  // CHECK-NOT: sil_property #A.e
+  fileprivate var e: Int = 0
+  // CHECK-NOT: sil_property #A.f
+  private var f: Int = 0
+
+  // TODO: static vars should get descriptors
+  public static var a: Int = 0
+  @_inlineable
+  public static var b: Int { return 0 }
+  @_versioned
+  internal static var c: Int = 0
+
+  // no descriptor
+  // CHECK-NOT: sil_property #A.d
+  internal static var d: Int = 0
+  // CHECK-NOT: sil_property #A.e
+  fileprivate static var e: Int = 0
+  // CHECK-NOT: sil_property #A.f
+  private static var f: Int = 0
+
+  // CHECK-LABEL: sil_property #A.subscript
+  public subscript(a x: Int) -> Int { return x }
+  // CHECK-LABEL: sil_property #A.subscript
+  @_inlineable
+  public subscript(b x: Int) -> Int { return x }
+  // CHECK-LABEL: sil_property #A.subscript
+  @_versioned
+  internal subscript(c x: Int) -> Int { return x }
+  
+  // no descriptor
+  // CHECK-NOT: sil_property #A.subscript
+  internal subscript(d x: Int) -> Int { return x }
+  fileprivate subscript(e x: Int) -> Int { return x }
+  private subscript(f x: Int) -> Int { return x }
+
+  // TODO: Subscripts with non-hashable subscripts should get descriptors
+  public subscript<T>(a x: T) -> T { return x }
+  @_inlineable
+  public subscript<T>(b x: T) -> T { return x }
+  @_versioned
+  internal subscript<T>(c x: T) -> T { return x }
+  
+  // no descriptor
+  internal subscript<T>(d x: T) -> T { return x }
+  fileprivate subscript<T>(e x: T) -> T { return x }
+  private subscript<T>(f x: T) -> T { return x }
+}
+


### PR DESCRIPTION
If a property or subscript is referenceable from other modules, we need to give it a descriptor so that we can reliably build an equivalent key path in or out of that module.

There are some cases that we should handle but don't yet:

- Global and static properties ought to be key-path-able someday, so we should make descriptors for them, but this might need a new key path component kind.
- Subscripts with indexes that aren't Hashable in the current module ought to get descriptors too, in case we ever support non-hashable key path components, and also because a generic subscript might be substituted with Hashable types by an external user, or an external module might post-hoc extend a type to be Hashable, so we really need to change things so that the client supplies the hashing and equality implementations for the indexes instead of the descriptor.