### PR TITLE
[4.1][AST] Disable comment printing while emitting diagnostics

### DIFF
--- a/include/swift/AST/PrintOptions.h
+++ b/include/swift/AST/PrintOptions.h
@@ -397,6 +397,7 @@ struct PrintOptions {
     result.PrintIfConfig = false;
     result.ShouldQualifyNestedDeclarations =
         QualifyNestedDeclarations::TypesOnly;
+    result.PrintDocumentationComments = false;
     return result;
   }
 
@@ -413,6 +414,7 @@ struct PrintOptions {
     result.ElevateDocCommentFromConformance = true;
     result.ShouldQualifyNestedDeclarations =
         QualifyNestedDeclarations::Always;
+    result.PrintDocumentationComments = true;
     return result;
   }
 


### PR DESCRIPTION
• **Explanation**:  There is a problem in PCH builds where source manager might
end up having unorderable source locations for comments, to work
around this (which is going to be fixed separately) let's
disable comment printing while emitting diagnostics since
such comments are not required.
• **Scope of Issue**: Today any decls we print for diagnostics are either inserted text (see TypeCheckProtocol's use of `PrintOptions::printForDiagnostics`, which disables this flag already) or something to show on the command line, which only prints one line of context anyway. 
• **Risk**: Low risk; Changes for diagnostics emitter
• **Reviewed By**: @jrose-apple 
• **Testing**: Swift Source Compatibility
• **Radar / SR**: rdar://problem/38203776

Resolves: rdar://problem/38203776
(cherry picked from commit 28d9d8e77188033f896b1e69e5ae7e74e2b4cf20)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
