### PR TITLE
[4.2][CSBindings] Try to infer bindings from related type variables

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2708,22 +2708,6 @@ private:
       if (x.FullyBound || x.SubtypeOfExistentialType)
         return false;
 
-      llvm::SmallPtrSet<Constraint *, 8> intersection(x.Sources);
-      llvm::set_intersect(intersection, y.Sources);
-
-      // Some relational constraints dictate certain
-      // ordering when it comes to attempting binding
-      // of type variables, where left-hand side is
-      // always more preferrable than right-hand side.
-      for (const auto *constraint : intersection) {
-        if (constraint->getKind() != ConstraintKind::Subtype)
-          continue;
-
-        auto lhs = constraint->getFirstType();
-        if (auto *typeVar = lhs->getAs<TypeVariableType>())
-          return x.TypeVar == typeVar;
-      }
-
       // If the only difference is default types,
       // prioritize bindings with fewer of them.
       return x.NumDefaultableBindings < y.NumDefaultableBindings;

--- a/test/Constraints/generics.swift
+++ b/test/Constraints/generics.swift
@@ -543,3 +543,17 @@ func rdar35541153() {
   foo(x) // Ok
   bar(y, "ultimate question", 42) // Ok
 }
+
+// rdar://problem/38159133 - [SR-7125]: Swift 4.1 Xcode 9.3b4 regression
+
+protocol P_38159133 {}
+
+do {
+  class Super {}
+  class A: Super, P_38159133 {}
+  class B: Super, P_38159133 {}
+
+  func rdar38159133(_ a: A?, _ b: B?) {
+    let _: [P_38159133] = [a, b].compactMap { $0 } // Ok
+  }
+}


### PR DESCRIPTION
Attempt to use potential bindings inferred for related types variables
discoverable through 'subtype' constraints, this helps to build a
more precise bindings domain for each type variable.

Resolves: rdar://problem/38159133
(cherry picked from commit 380ea4a671549dbd9ae1bc5b48b33036ed6a1a51)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
