### PR TITLE
[Parse] Refactor Lexer initialization

### DIFF
--- a/unittests/Parse/LexerTests.cpp
+++ b/unittests/Parse/LexerTests.cpp
@@ -773,10 +773,8 @@ TEST_F(LexerTest, DiagnoseEmbeddedNulOffset) {
           TriviaRetentionMode::WithTrivia,
           /*Offset=*/5, /*EndOffset=*/SourceLen);
 
-  // Current implementation has a bug.
-  // It must be FALSE because Offset = 5.
-  ASSERT_TRUE(containsPrefix(DiagConsumer.messages,
-                             "1, 2: nul character embedded in middle of file"));
-  ASSERT_TRUE(containsPrefix(DiagConsumer.messages,
-                             "1, 4: nul character embedded in middle of file"));
+  ASSERT_FALSE(containsPrefix(
+      DiagConsumer.messages, "1, 2: nul character embedded in middle of file"));
+  ASSERT_FALSE(containsPrefix(
+      DiagConsumer.messages, "1, 4: nul character embedded in middle of file"));
 }


### PR DESCRIPTION
I think that current Lexer initialization code is too complex to do what is needed essentially in here.
This PR refactor around initialization, simplify and makes it more readable.

What I think bad is follow.

- Principal constructor and convenience constructor overloads are verify similar,
  they are distinguished by the order of 3rd(`BufferID`) and 4th(`Diags`) argument swapping.
  Its hard to see which constructor is called in other constructor initialization section.

- `primeLexer` function and `initSubLexer` function are difficult to understand their purpose and relation.  Particularly, `initSubLexer` also call `primeLexer`.

- It seems there are 2 behavior modes in Lexer which one lex whole buffer and other do subrange specified,  but from viewpoint of lexing implementation,
  there are no difference logically in meaning of that we lex string which has begin and end.
  `ArtificialEOF` may not be null or be null, but its meaningless state.

- `lexImpl` is called twice in one constructor invocation via `initSubLexer` > `primeLexer` > `lexImpl` and `initSubLexer` > `restoreState` > `lexImpl`. 
  This is wasteful computation and make debugging and reading code hard.

- I found a small bug around it.
  Because first call of `lexImpl` is running with initial `CurPtr`,
  If Lexer emit diagnostics during lexing first token,
  Diagnose is happened in constructor even if 
  user passed `Offset` argument which points after first token.

To improve this, I refactored as follow.

- Using tagged overload to specify principal constructor. I made `Lexer::PrincipalTag` for this.

- Remove all function body from principal constructor.
  Its just for simple fields initialization.

- Make `initialize` function which must be called from other convenience constructor.
  It takes `Offset` and `EndOffset`.
  Whole buffer lexing is a just parameter variation of this.
  It process below.
  - `BufferStart`, `BufferEnd` initialization.
  - Getting information about UTF8-BOM.
  - `CodeCompletionPtr` initialization.
  - `ArtificialEOF` initialization. This is always not null now.
  - Initial `CurPtr` setting.
  - Invoking `lexImpl` for first token. Its start from `Offset`.

- Remove `primeLexer` and `initSubLexer`.

This PR contains 2 commits.

- First is test case to observe current buggy behavior about diagnostics I wrote above.
- Second is all changes for this improvement.



