### PR TITLE
[test] Fix tests relying on specific hash values or Set/Dictionary orderings

### DIFF
--- a/test/Interpreter/SDK/Foundation_bridge.swift
+++ b/test/Interpreter/SDK/Foundation_bridge.swift
@@ -106,9 +106,9 @@ do {
 }
 
 // CHECK:      dictionary bridges to {
-// CHECK-NEXT:   2 = World;
-// CHECK-NEXT:   1 = Hello;
-// CHECK-NEXT: }
+// CHECK-DAG:   1 = Hello;
+// CHECK-DAG:   2 = World;
+// CHECK: }
 do {
   var dict: Dictionary<NSNumber, NSString> = [1: "Hello", 2: "World"]
   let obj = _bridgeAnythingToObjectiveC(dict)
@@ -116,9 +116,9 @@ do {
 }
 
 // CHECK:      dictionary bridges to {
-// CHECK-NEXT:   2 = World;
-// CHECK-NEXT:   1 = Hello;
-// CHECK-NEXT: }
+// CHECK-DAG:   1 = Hello;
+// CHECK-DAG:   2 = World;
+// CHECK: }
 do {
   var dict2 = [1: "Hello", 2: "World"]
   let obj = _bridgeAnythingToObjectiveC(dict2)
@@ -126,9 +126,9 @@ do {
 }
 
 // CHECK: dictionary bridges to {
-// CHECK-NEXT:   2 = "(\"World\", 2)";
-// CHECK-NEXT:   1 = "(\"Hello\", 1)";
-// CHECK-NEXT: }
+// CHECK-DAG:   1 = "(\"Hello\", 1)";
+// CHECK-DAG:   2 = "(\"World\", 2)";
+// CHECK: }
 do {
   var dict3 = [1: ("Hello", 1), 2: ("World", 2)]
   let obj = _bridgeAnythingToObjectiveC(dict3)
@@ -141,11 +141,11 @@ var dict4 = propListStr.propertyListFromStringsFileFormat()!
 var hello: NSString = "Hello"
 var world: NSString = "World"
 
-// Print out the keys. We only check one of these because the order is
-// nondeterministic.
-// CHECK: Hello
+// Print out the keys.
+// CHECK-DAG: Bridged key: Hello
+// CHECK-DAG: Bridged key: World
 for key in dict4.keys {
-  print(key.description)
+  print("Bridged key: \(key.description)")
 }
 
 // CHECK: Hello: 1

--- a/test/Interpreter/SDK/equatable_hashable.swift
+++ b/test/Interpreter/SDK/equatable_hashable.swift
@@ -8,12 +8,15 @@ import Foundation
 
 func testHash<H: Hashable>(_ x: H) -> Int { return x.hashValue }
 
+// CHECK: (1 as UInt8): hash = [[HASH:-?[0-9]+]]
+print("(1 as UInt8): hash = \((1 as UInt8).hashValue)")
+
 func test_CBool() {
   let x: CBool = true
   let hash = testHash(x)
   print("C_Bool: hash = \(hash)")
 }
-// CHECK: C_Bool: hash = 1
+// CHECK: C_Bool: hash = [[HASH]]
 test_CBool()
 
 func test_ObjCBool() {
@@ -21,7 +24,7 @@ func test_ObjCBool() {
   let hash = testHash(x.boolValue)
   print("ObjCBool: hash = \(hash)")
 }
-// CHECK-NEXT: ObjCBool: hash = 1
+// CHECK-NEXT: ObjCBool: hash = [[HASH]]
 test_ObjCBool()
 
 func testEquatable<E: Equatable>(_ x: E) {}

--- a/test/Interpreter/repl.swift
+++ b/test/Interpreter/repl.swift
@@ -41,7 +41,7 @@ String(4.0)  // CHECK: String = "4.0"
 
 123 .
 hashValue
-// CHECK: Int = 123{{$}}
+// CHECK: Int = {{-?[0-9]+$}}
 
 // Check that we handle unmatched parentheses in REPL.
 1+1)

--- a/test/stdlib/ReflectionHashing.swift
+++ b/test/stdlib/ReflectionHashing.swift
@@ -2,14 +2,6 @@
 // RUN: %target-run %t.out
 // REQUIRES: executable_test
 
-// This test expects consistent hash code generation. However String instance
-// generate different values on Linux depending on which version of libicu is
-// installed. Therefore we run this test only on non-linux OSes, which is
-// best described as having objc_interop.
-
-// REQUIRES: objc_interop
-
-//
 // This file contains reflection tests that depend on hash values.
 // Don't add other tests here.
 //
@@ -36,46 +28,16 @@ Reflection.test("Dictionary") {
   var output = ""
   dump(dict, to: &output)
 
-#if arch(i386) || arch(arm)
+  // The order of elements in output depends on the hash values of dict's items,
+  // which isn't deterministic. However, iterating over dict will get us the
+  // same elements in the same order.
   var expected = ""
   expected += "▿ 5 key/value pairs\n"
-  expected += "  ▿ (2 elements)\n"
-  expected += "    - key: \"Four\"\n"
-  expected += "    - value: 4\n"
-  expected += "  ▿ (2 elements)\n"
-  expected += "    - key: \"One\"\n"
-  expected += "    - value: 1\n"
-  expected += "  ▿ (2 elements)\n"
-  expected += "    - key: \"Two\"\n"
-  expected += "    - value: 2\n"
-  expected += "  ▿ (2 elements)\n"
-  expected += "    - key: \"Five\"\n"
-  expected += "    - value: 5\n"
-  expected += "  ▿ (2 elements)\n"
-  expected += "    - key: \"Three\"\n"
-  expected += "    - value: 3\n"
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
-  var expected = ""
-  expected += "▿ 5 key/value pairs\n"
-  expected += "  ▿ (2 elements)\n"
-  expected += "    - key: \"Three\"\n"
-  expected += "    - value: 3\n"
-  expected += "  ▿ (2 elements)\n"
-  expected += "    - key: \"Two\"\n"
-  expected += "    - value: 2\n"
-  expected += "  ▿ (2 elements)\n"
-  expected += "    - key: \"Four\"\n"
-  expected += "    - value: 4\n"
-  expected += "  ▿ (2 elements)\n"
-  expected += "    - key: \"One\"\n"
-  expected += "    - value: 1\n"
-  expected += "  ▿ (2 elements)\n"
-  expected += "    - key: \"Five\"\n"
-  expected += "    - value: 5\n"
-#else
-  fatalError("unimplemented")
-#endif
-
+  for (key, value) in dict {
+    expected += "  ▿ (2 elements)\n"
+    expected += "    - key: \"\(key)\"\n"
+    expected += "    - value: \(value)\n"
+  }
   expectEqual(expected, output)
 }
 
@@ -85,25 +47,14 @@ Reflection.test("Set") {
   var output = ""
   dump(s, to: &output)
 
-#if arch(i386) || arch(arm)
+  // The order of elements in output depends on the hash values of dict's items,
+  // which isn't deterministic. However, iterating over dict will get us the
+  // same elements in the same order.
   var expected = ""
   expected += "▿ 5 members\n"
-  expected += "  - 3\n"
-  expected += "  - 1\n"
-  expected += "  - 5\n"
-  expected += "  - 2\n"
-  expected += "  - 4\n"
-#elseif arch(x86_64) || arch(arm64) || arch(powerpc64) || arch(powerpc64le) || arch(s390x)
-  var expected = ""
-  expected += "▿ 5 members\n"
-  expected += "  - 5\n"
-  expected += "  - 2\n"
-  expected += "  - 3\n"
-  expected += "  - 1\n"
-  expected += "  - 4\n"
-#else
-  fatalError("unimplemented")
-#endif
+  for i in s {
+    expected += "  - \(i)\n"
+  }
 
   expectEqual(expected, output)
 }

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -3365,11 +3365,14 @@ SetTestSuite.test("popFirst") {
   do {
     var popped = [Int]()
     var s = Set([1010, 2020, 3030])
-    let expected = Array(s)
+    let expected = [1010, 2020, 3030]
     while let element = s.popFirst() {
       popped.append(element)
     }
-    expectEqualSequence(expected, Array(popped))
+    // Note that removing an element may reorder remaining items, so we
+    // can't compare ordering here.
+    popped.sort()
+    expectEqualSequence(expected, popped)
     expectTrue(s.isEmpty)
   }
 }


### PR DESCRIPTION
We shouldn't need to update regular tests if/when we modify the hash function.