### PR TITLE
Document `init(uniqueKeysAndValues:)` precondition

### DIFF
--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -1776,6 +1776,7 @@ public struct Dictionary<Key : Hashable, Value> {
   ///   the new dictionary. Every key in `keysAndValues` must be unique.
   /// - Returns: A new dictionary initialized with the elements of
   ///   `keysAndValues`.
+  /// - Precondition: The sequence must not have duplicate keys.
   @_inlineable // FIXME(sil-serialize-all)
   public init<S: Sequence>(
     uniqueKeysWithValues keysAndValues: S


### PR DESCRIPTION
<!-- What's in this pull request? -->

Per discussion here: https://forums.swift.org/t/when-should-standard-library-functions-crash/10661

This runtime crash has bit me and several other folks, so taking an incremental step to ensure the precondition is a bit louder in the pop-up docs.