### PR TITLE
[SR-7111] Class function override `T??` to `T`.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2209,8 +2209,10 @@ static bool matches(CanType t1, CanType t2, TypeMatchOptions matchMode,
   if (t1 == t2) return true;
 
   // First try unwrapping optionals.
-  // Make sure we only unwrap at most one layer of optional.
-  if (insideOptional == OptionalUnwrapping::None) {
+  // Unwrap optional as much as possible.
+  if (insideOptional == OptionalUnwrapping::None ||
+      insideOptional == OptionalUnwrapping::OptionalToOptional ||
+      insideOptional == OptionalUnwrapping::ValueToOptional) {
     // Value-to-optional and optional-to-optional.
     if (auto obj2 = t2.getOptionalObjectType()) {
       // Optional-to-optional.

--- a/test/decl/class/override.swift
+++ b/test/decl/class/override.swift
@@ -101,11 +101,11 @@ class B : A {
 }
 
 class C<T> {
-  func ret_T() -> T {} 
+  func ret_T() -> T {}
 }
 
 class D<T> : C<[T]> {
-  override func ret_T() -> [T] {} 
+  override func ret_T() -> [T] {}
 }
 
 class E {
@@ -120,6 +120,10 @@ class E {
   var var_class_uoptional_rev: E { get { return self } set {} } // expected-note{{attempt to override property here}}
   var var_class_optional_uoptional: F? { get { return .none } set {} }
   var var_class_optional_uoptional_rev: E! { get { return self } set {} }
+  var var_nonclass_nested_optional: Int?? { get { return .none } set {} } // expected-note{{attempt to override property here}}
+  var var_nonclass_nested_optional_rev: Int { get { return 0 } set {} } // expected-note{{attempt to override property here}}
+  var var_class_nested_optional: E?? { get { return .none } set {} } // expected-note{{attempt to override property here}}
+  var var_class_nested_optional_rev: F { get { return F() } set {} } // expected-note{{attempt to override property here}}
 
   var ro_sametype: Int { return 0 }
   var ro_subclass: E { return self }
@@ -132,6 +136,10 @@ class E {
   var ro_class_uoptional_rev: E { return self } // expected-note{{attempt to override property here}}
   var ro_class_optional_uoptional: F? { return .none }
   var ro_class_optional_uoptional_rev: E! { return self }
+  var ro_nonclass_nested_optional: Int?? { return 0 }
+  var ro_nonclass_nested_optional_rev: Int { return 0 } // expected-note{{attempt to override property here}}
+  var ro_class_nested_optional: E?? { return .none }
+  var ro_class_nested_optional_rev: F { return F() } // expected-note{{attempt to override property here}}
 }
 
 class F : E {
@@ -146,6 +154,11 @@ class F : E {
   override var var_class_uoptional_rev: E! { get { return self }  set {} } // expected-error{{property 'var_class_uoptional_rev' with type 'E?' cannot override a property with type 'E'}}
   override var var_class_optional_uoptional: F! { get { return .none } set {} }
   override var var_class_optional_uoptional_rev: E? { get { return self } set {} }
+  override var var_nonclass_nested_optional: Int { get { return 0 } set {} } // expected-error{{cannot override mutable property 'var_nonclass_nested_optional' of type 'Int??' with covariant type 'Int'}}
+  override var var_nonclass_nested_optional_rev: Int?? { get { return 0 } set {} } // expected-error{{property 'var_nonclass_nested_optional_rev' with type 'Int??' cannot override a property with type 'Int'}}
+  override var var_class_nested_optional: F { get { return self } set {} } // expected-error{{cannot override mutable property 'var_class_nested_optional' of type 'E??' with covariant type 'F'}}
+  override var var_class_nested_optional_rev: E?? { get { return self } set {} } // expected-error{{property 'var_class_nested_optional_rev' with type 'E??' cannot override a property with type 'F'}}
+
 
   override var ro_sametype: Int { return 0 }
   override var ro_subclass: E { return self }
@@ -158,6 +171,10 @@ class F : E {
   override var ro_class_uoptional_rev: E! { return self } // expected-error{{property 'ro_class_uoptional_rev' with type 'E?' cannot override a property with type 'E'}}
   override var ro_class_optional_uoptional: F! { return .none }
   override var ro_class_optional_uoptional_rev: E? { return self }
+  override var ro_nonclass_nested_optional: Int { return 0 }
+  override var ro_nonclass_nested_optional_rev: Int?? { return 0 } // expected-error{{property 'ro_nonclass_nested_optional_rev' with type 'Int??' cannot override a property with type 'Int'}}
+  override var ro_class_nested_optional: F { return self }
+  override var ro_class_nested_optional_rev: E?? { return .none } // expected-error{{property 'ro_class_nested_optional_rev' with type 'E??' cannot override a property with type 'F'}}
 }
 
 
@@ -243,7 +260,7 @@ class IUOTestSubclass : IUOTestBaseClass {
   // expected-note@-1 2 {{remove '!' to make the parameter required}}
   // expected-note@-2 2 {{add parentheses to silence this warning}}
   override func manyB(_ a: AnyObject!, b: AnyObject!) {} // expected-warning 2 {{overriding instance method parameter of type 'AnyObject' with implicitly unwrapped optional type 'AnyObject?'}}
-  // expected-note@-1 2 {{remove '!' to make the parameter required}} 
+  // expected-note@-1 2 {{remove '!' to make the parameter required}}
   // expected-note@-2 2 {{add parentheses to silence this warning}}
 
   override func result() -> AnyObject! { return nil } // expected-warning {{overriding instance method optional result type 'AnyObject?' with implicitly unwrapped optional type 'AnyObject?'}}

--- a/test/decl/class/override.swift
+++ b/test/decl/class/override.swift
@@ -18,6 +18,12 @@ class A {
   func ret_subclass_uoptional_rev() -> B { return B() }
   func ret_subclass_optional_uoptional() -> A? { return .none }
   func ret_subclass_optional_uoptional_rev() -> B! { return B() }
+  func ret_nonclass_nested_optional() -> Int?? { return .none } // expected-note{{potential overridden instance method 'ret_nonclass_nested_optional()'}}
+  func ret_nonclass_nested_optional_rev() -> Int { return 0 }
+  func ret_class_nested_optional() -> B?? { return .none } // expected-note{{potential overridden instance method 'ret_class_nested_optional()'}}
+  func ret_class_nested_optional_rev() -> A { return self }
+  func ret_subclass_nested_optional() -> A?? { return .none } // expected-note{{potential overridden instance method 'ret_subclass_nested_optional()'}}
+  func ret_subclass_nested_optional_rev() -> B { return B() }
 
   func param_sametype(_ x : Int) {}
   func param_subclass(_ x : B) {}
@@ -36,6 +42,12 @@ class A {
   func param_subclass_uoptional_rev(_ x : A!) {}
   func param_subclass_optional_uoptional(_ x : B!) {}
   func param_subclass_optional_uoptional_rev(_ x : A?) {}
+  func param_nonclass_nested_optional(_ x : Int) {} // expected-note{{potential overridden instance method 'param_nonclass_nested_optional'}}
+  func param_nonclass_nested_optional_rev(_ x : Int??) {}
+  func param_class_nested_optional(_ x : B) {} // expected-note{{potential overridden instance method 'param_class_nested_optional'}}
+  func param_class_nested_optional_rev(_ x : B??) {}
+  func param_subclass_nested_optional(_ x : B) {} // expected-note{{potential overridden instance method 'param_subclass_nested_optional'}}
+  func param_subclass_nested_optional_rev(_ x : A??) {}
 }
 
 class B : A {
@@ -56,6 +68,12 @@ class B : A {
   func ret_subclass_uoptional_rev() -> A! { return self }
   override func ret_subclass_optional_uoptional() -> B! { return self }
   func ret_subclass_optional_uoptional_rev() -> A? { return self }
+  override func ret_nonclass_nested_optional() -> Int { return 0 } // expected-error{{method does not override any method from its superclass}}
+  func ret_nonclass_nested_optional_rev() -> Int? { return 0 }
+  override func ret_class_nested_optional() -> B { return self } // expected-error{{method does not override any method from its superclass}}
+  func ret_class_nested_optional_rev() -> A? { return self }
+  override func ret_subclass_nested_optional() -> B { return self } // expected-error{{method does not override any method from its superclass}}
+  func ret_subclass_nested_optional_rev() -> A? { return self }
 
   override func param_sametype(_ x : Int) {}
   override func param_subclass(_ x : A) {}
@@ -74,6 +92,12 @@ class B : A {
   func param_subclass_uoptional_rev(_ x : B) {}
   override func param_subclass_optional_uoptional(_ x : A?) {}
   func param_subclass_optional_uoptional_rev(_ x : B!) {}
+  override func param_nonclass_nested_optional(_ x : Int??) {} // expected-error{{method does not override any method from its superclass}}
+  func param_nonclass_nested_optional_rev(_ x : Int) {}
+  override func param_class_nested_optional(_ x : B??) {} // expected-error{{method does not override any method from its superclass}}
+  func param_class_nested_optional_rev(_ x : B) {}
+  override func param_subclass_nested_optional(_ x : A??) {} // expected-error{{method does not override any method from its superclass}}
+  func param_subclass_nested_optional_rev(_ x : B) {}
 }
 
 class C<T> {

--- a/test/decl/class/override.swift
+++ b/test/decl/class/override.swift
@@ -12,6 +12,12 @@ class A {
   func ret_class_uoptional_rev() -> A { return self }
   func ret_class_optional_uoptional() -> B? { return .none }
   func ret_class_optional_uoptional_rev() -> A! { return self }
+  func ret_subclass_optional() -> A? { return .none }
+  func ret_subclass_optional_rev() -> B { return B() }
+  func ret_subclass_uoptional() -> A! { return self }
+  func ret_subclass_uoptional_rev() -> B { return B() }
+  func ret_subclass_optional_uoptional() -> A? { return .none }
+  func ret_subclass_optional_uoptional_rev() -> B! { return B() }
 
   func param_sametype(_ x : Int) {}
   func param_subclass(_ x : B) {}
@@ -24,6 +30,12 @@ class A {
   func param_class_uoptional_rev(_ x : B!) {}
   func param_class_optional_uoptional(_ x : B!) {}
   func param_class_optional_uoptional_rev(_ x : B?) {}
+  func param_subclass_optional(_ x : B) {}
+  func param_subclass_optional_rev(_ x : A?) {}
+  func param_subclass_uoptional(_ x : B) {}
+  func param_subclass_uoptional_rev(_ x : A!) {}
+  func param_subclass_optional_uoptional(_ x : B!) {}
+  func param_subclass_optional_uoptional_rev(_ x : A?) {}
 }
 
 class B : A {
@@ -38,6 +50,12 @@ class B : A {
   func ret_class_uoptional_rev() -> A! { return self }
   override func ret_class_optional_uoptional() -> B! { return self }
   override func ret_class_optional_uoptional_rev() -> A? { return self }
+  override func ret_subclass_optional() -> B { return self }
+  func ret_subclass_optional_rev() -> A? { return self }
+  override func ret_subclass_uoptional() -> B { return self }
+  func ret_subclass_uoptional_rev() -> A! { return self }
+  override func ret_subclass_optional_uoptional() -> B! { return self }
+  func ret_subclass_optional_uoptional_rev() -> A? { return self }
 
   override func param_sametype(_ x : Int) {}
   override func param_subclass(_ x : A) {}
@@ -50,6 +68,12 @@ class B : A {
   func param_class_uoptional_rev(_ x : B) {}
   override func param_class_optional_uoptional(_ x : B?) {}
   override func param_class_optional_uoptional_rev(_ x : B!) {}
+  override func param_subclass_optional(_ x : A?) {}
+  func param_subclass_optional_rev(_ x : B) {}
+  override func param_subclass_uoptional(_ x : A!) {}
+  func param_subclass_uoptional_rev(_ x : B) {}
+  override func param_subclass_optional_uoptional(_ x : A?) {}
+  func param_subclass_optional_uoptional_rev(_ x : B!) {}
 }
 
 class C<T> {

--- a/test/decl/class/override.swift
+++ b/test/decl/class/override.swift
@@ -18,11 +18,11 @@ class A {
   func ret_subclass_uoptional_rev() -> B { return B() }
   func ret_subclass_optional_uoptional() -> A? { return .none }
   func ret_subclass_optional_uoptional_rev() -> B! { return B() }
-  func ret_nonclass_nested_optional() -> Int?? { return .none } // expected-note{{potential overridden instance method 'ret_nonclass_nested_optional()'}}
+  func ret_nonclass_nested_optional() -> Int?? { return .none }
   func ret_nonclass_nested_optional_rev() -> Int { return 0 }
-  func ret_class_nested_optional() -> B?? { return .none } // expected-note{{potential overridden instance method 'ret_class_nested_optional()'}}
+  func ret_class_nested_optional() -> B?? { return .none }
   func ret_class_nested_optional_rev() -> A { return self }
-  func ret_subclass_nested_optional() -> A?? { return .none } // expected-note{{potential overridden instance method 'ret_subclass_nested_optional()'}}
+  func ret_subclass_nested_optional() -> A?? { return .none }
   func ret_subclass_nested_optional_rev() -> B { return B() }
 
   func param_sametype(_ x : Int) {}
@@ -42,11 +42,11 @@ class A {
   func param_subclass_uoptional_rev(_ x : A!) {}
   func param_subclass_optional_uoptional(_ x : B!) {}
   func param_subclass_optional_uoptional_rev(_ x : A?) {}
-  func param_nonclass_nested_optional(_ x : Int) {} // expected-note{{potential overridden instance method 'param_nonclass_nested_optional'}}
+  func param_nonclass_nested_optional(_ x : Int) {}
   func param_nonclass_nested_optional_rev(_ x : Int??) {}
-  func param_class_nested_optional(_ x : B) {} // expected-note{{potential overridden instance method 'param_class_nested_optional'}}
+  func param_class_nested_optional(_ x : B) {}
   func param_class_nested_optional_rev(_ x : B??) {}
-  func param_subclass_nested_optional(_ x : B) {} // expected-note{{potential overridden instance method 'param_subclass_nested_optional'}}
+  func param_subclass_nested_optional(_ x : B) {}
   func param_subclass_nested_optional_rev(_ x : A??) {}
 }
 
@@ -68,11 +68,11 @@ class B : A {
   func ret_subclass_uoptional_rev() -> A! { return self }
   override func ret_subclass_optional_uoptional() -> B! { return self }
   func ret_subclass_optional_uoptional_rev() -> A? { return self }
-  override func ret_nonclass_nested_optional() -> Int { return 0 } // expected-error{{method does not override any method from its superclass}}
+  override func ret_nonclass_nested_optional() -> Int { return 0 }
   func ret_nonclass_nested_optional_rev() -> Int? { return 0 }
-  override func ret_class_nested_optional() -> B { return self } // expected-error{{method does not override any method from its superclass}}
+  override func ret_class_nested_optional() -> B { return self }
   func ret_class_nested_optional_rev() -> A? { return self }
-  override func ret_subclass_nested_optional() -> B { return self } // expected-error{{method does not override any method from its superclass}}
+  override func ret_subclass_nested_optional() -> B { return self }
   func ret_subclass_nested_optional_rev() -> A? { return self }
 
   override func param_sametype(_ x : Int) {}
@@ -92,11 +92,11 @@ class B : A {
   func param_subclass_uoptional_rev(_ x : B) {}
   override func param_subclass_optional_uoptional(_ x : A?) {}
   func param_subclass_optional_uoptional_rev(_ x : B!) {}
-  override func param_nonclass_nested_optional(_ x : Int??) {} // expected-error{{method does not override any method from its superclass}}
+  override func param_nonclass_nested_optional(_ x : Int??) {}
   func param_nonclass_nested_optional_rev(_ x : Int) {}
-  override func param_class_nested_optional(_ x : B??) {} // expected-error{{method does not override any method from its superclass}}
+  override func param_class_nested_optional(_ x : B??) {}
   func param_class_nested_optional_rev(_ x : B) {}
-  override func param_subclass_nested_optional(_ x : A??) {} // expected-error{{method does not override any method from its superclass}}
+  override func param_subclass_nested_optional(_ x : A??) {}
   func param_subclass_nested_optional_rev(_ x : B) {}
 }
 


### PR DESCRIPTION
Resolves [SR-7111](https://bugs.swift.org/browse/SR-7111).