### PR TITLE
[stdlib] Adjust floating-point nextUp test for NaN

### DIFF
--- a/test/stdlib/FloatingPoint.swift.gyb
+++ b/test/stdlib/FloatingPoint.swift.gyb
@@ -529,7 +529,6 @@ FloatingPoint.test("${Self}.significandWidth") {
 %end
 
 let floatNextUpDownTests: [(Float, Float)] = [
-  (.nan, .nan),
   (.greatestFiniteMagnitude, .infinity),
   (0x1.ffff_fe__p-1, 1.0), (1.0, 0x1.0000_02__p+0),
   (0.0, .leastNonzeroMagnitude),
@@ -553,7 +552,6 @@ FloatingPoint.test("Float.nextUp, .nextDown")
 }
 
 let doubleNextUpDownTests: [(Double, Double)] = [
-  (.nan, .nan),
   (.greatestFiniteMagnitude, .infinity),
   (0x1.ffff_ffff_ffff_fp-1, 1.0), (1.0, 0x1.0000_0000_0000_1p+0),
   (0.0, .leastNonzeroMagnitude),
@@ -575,6 +573,16 @@ FloatingPoint.test("Double.nextUp, .nextDown")
   expectBitwiseEqual(-succ, (-prev).nextDown)
   expectBitwiseEqual(-prev, (-succ).nextUp)
 }
+
+%for Self in ['Float', 'Double']:
+FloatingPoint.test("${Self}.nextUp, .nextDown/nan") {
+  let x = ${Self}.nan
+  expectBitwiseEqual(x, x.nextUp)
+  expectBitwiseEqual(x, x.nextDown)
+  expectTrue((-x).nextDown.isNaN)
+  expectTrue((-x).nextUp.isNaN)
+}
+%end
 
 #if arch(i386) || arch(x86_64)
 


### PR DESCRIPTION
In #15021, we used `self + 0` to silence signaling NaN, as is appropriate.

In Swift, addition of zero does not preserve the sign of NaN (although it does preserve any payload). Rather, `(-Double.nan + 0).sign == .plus`. Since IEEE 754-2008 §6.2 permits implementations to make their own best effort at propagating NaN diagnostics, this behavior seems to be fine.

What it does mean, however, is testing for a specific bit pattern will fail when it comes to `(-Double.nan).nextUp` after we change our implementation. Therefore, let's change the test before we try to restore #15021.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->