### PR TITLE
[BatchMode] Accumulate SILModule counters across batch constituents.

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -512,22 +512,22 @@ static void countStatsPostSILGen(UnifiedStatsReporter &Stats,
                                  const SILModule& Module) {
   auto &C = Stats.getFrontendCounters();
   // FIXME: calculate these in constant time, via the dense maps.
-  C.NumSILGenFunctions = Module.getFunctionList().size();
-  C.NumSILGenVtables = Module.getVTableList().size();
-  C.NumSILGenWitnessTables = Module.getWitnessTableList().size();
-  C.NumSILGenDefaultWitnessTables = Module.getDefaultWitnessTableList().size();
-  C.NumSILGenGlobalVariables = Module.getSILGlobalList().size();
+  C.NumSILGenFunctions += Module.getFunctionList().size();
+  C.NumSILGenVtables += Module.getVTableList().size();
+  C.NumSILGenWitnessTables += Module.getWitnessTableList().size();
+  C.NumSILGenDefaultWitnessTables += Module.getDefaultWitnessTableList().size();
+  C.NumSILGenGlobalVariables += Module.getSILGlobalList().size();
 }
 
 static void countStatsPostSILOpt(UnifiedStatsReporter &Stats,
                                  const SILModule& Module) {
   auto &C = Stats.getFrontendCounters();
   // FIXME: calculate these in constant time, via the dense maps.
-  C.NumSILOptFunctions = Module.getFunctionList().size();
-  C.NumSILOptVtables = Module.getVTableList().size();
-  C.NumSILOptWitnessTables = Module.getWitnessTableList().size();
-  C.NumSILOptDefaultWitnessTables = Module.getDefaultWitnessTableList().size();
-  C.NumSILOptGlobalVariables = Module.getSILGlobalList().size();
+  C.NumSILOptFunctions += Module.getFunctionList().size();
+  C.NumSILOptVtables += Module.getVTableList().size();
+  C.NumSILOptWitnessTables += Module.getWitnessTableList().size();
+  C.NumSILOptDefaultWitnessTables += Module.getDefaultWitnessTableList().size();
+  C.NumSILOptGlobalVariables += Module.getSILGlobalList().size();
 }
 
 static std::unique_ptr<llvm::raw_fd_ostream>


### PR DESCRIPTION
This just fixes FrontendTool counters to be correct vis-a-vis batch mode / generally any time one makes multiple SILModules in the same frontend.