### PR TITLE
Fix overload set construction to not have an extra element in the dis…

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1433,7 +1433,7 @@ void ConstraintSystem::addOverloadSet(Type boundType,
     overloads.push_back(bindOverloadConstraint);
   }
   
-  for (auto choice : choices) {
+  for (auto &choice : choices) {
     if (favoredChoice && (favoredChoice == &choice))
       continue;
     


### PR DESCRIPTION
…junction.

Any time we had a favored choice for a disjunction, we attempted to
not add it twice, but that little optimization was faulty.

This should speed up some expression type checking a tiny bit in cases
where the favored choice did not result in a solution.

Noticed by observation.
