### PR TITLE
test: enable Windows support, un-XFAIL on Linux

### DIFF
--- a/test/IRGen/builtin_math.swift
+++ b/test/IRGen/builtin_math.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -O %s | %FileCheck %s -check-prefix CHECK-%target-os
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -O %s | %FileCheck %s -check-prefix CHECK -check-prefix CHECK-%target-os
 
 #if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 import Darwin

--- a/test/IRGen/c_functions.swift
+++ b/test/IRGen/c_functions.swift
@@ -1,14 +1,13 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -import-objc-header %S/Inputs/c_functions.h -primary-file %s -emit-ir | %FileCheck %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -import-objc-header %S/Inputs/c_functions.h -primary-file %s -emit-ir |  %FileCheck %s --check-prefix=%target-cpu
+// RUN: %target-swift-frontend -enable-objc-interop -import-objc-header %S/Inputs/c_functions.h -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s -check-prefix CHECK -check-prefix %target-cpu
 
 // This is deliberately not a SIL test so that we can test SILGen too.
 
 // CHECK-LABEL: define hidden swiftcc void @"$S11c_functions14testOverloadedyyF"
 func testOverloaded() {
-  // CHECK: call void @_Z10overloadedv()
+  // CHECK: call void @{{_Z10overloadedv|"\\01\?overloaded@@\$\$J0YAXXZ"}}()
   overloaded()
-  // CHECK: call void @_Z10overloadedi(i32{{( signext)?}} 42)
+  // CHECK: call void @{{_Z10overloadedi|"\\01\?overloaded@@\$\$J0YAXH@Z"}}(i32{{( signext)?}} 42)
   overloaded(42)
   // CHECK: call void @{{.*}}test_my_log
   test_my_log()
@@ -19,14 +18,13 @@ func test_indirect_by_val_alignment() {
   log_a_thing(x)
 }
 
+// We only want to test x86_64.
 // x86_64-LABEL: define hidden swiftcc void  @"$S11c_functions30test_indirect_by_val_alignmentyyF"()
 // x86_64: %indirect-temporary = alloca %TSo7a_thinga, align [[ALIGN:[0-9]+]]
 // x86_64: [[CAST:%.*]] = bitcast %TSo7a_thinga* %indirect-temporary to %struct.a_thing*
-// x86_64: call void @log_a_thing(%struct.a_thing* byval align [[ALIGN]] [[CAST]])
-// x86_64: define internal void @log_a_thing(%struct.a_thing* byval align [[ALIGN]]
+// x86_64: call void @log_a_thing(%struct.a_thing* {{(byval align [[ALIGN]] )?}}[[CAST]])
+// x86_64: define internal void @log_a_thing(%struct.a_thing* {{(byval align [[ALIGN]])?}}
 
-
-// We only want to test x86_64.
 // aarch64: define hidden swiftcc void  @"$S11c_functions30test_indirect_by_val_alignmentyyF"()
 // arm64: define hidden swiftcc void  @"$S11c_functions30test_indirect_by_val_alignmentyyF"()
 // armv7k: define hidden swiftcc void  @"$S11c_functions30test_indirect_by_val_alignmentyyF"()

--- a/test/IRGen/c_globals.swift
+++ b/test/IRGen/c_globals.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/abi %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/abi %s -emit-ir -Xcc -mno-omit-leaf-frame-pointer | %FileCheck %s
 
 import c_layout
 

--- a/test/IRGen/cf.sil
+++ b/test/IRGen/cf.sil
@@ -1,9 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %{python} %utils/chex.py < %s > %t/cf.sil
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs %t/cf.sil -emit-ir -import-cf-types | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize %t/cf.sil -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs %t/cf.sil -emit-ir -enable-objc-interop -import-cf-types | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize %t/cf.sil -DINT=i%target-ptrsize
 
 // REQUIRES: CPU=i386 || CPU=x86_64
-// REQUIRES: objc_interop
 
 // CHECK: [[TYPE:%swift.type]] = type
 // CHECK: [[REFRIGERATOR:%TSo17CCRefrigeratorRefa]] = type

--- a/test/IRGen/clang_empty_type.swift
+++ b/test/IRGen/clang_empty_type.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-ir -verify -import-objc-header %S/Inputs/clang_empty_type.h %s
+// RUN: %target-swift-frontend -emit-ir -verify -enable-objc-interop -import-objc-header %S/Inputs/clang_empty_type.h %s
 
 public func projectTrailingArray(x: inout TrailingArray) {
   x.size = 2

--- a/test/IRGen/clang_inline_opt.swift
+++ b/test/IRGen/clang_inline_opt.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -import-objc-header %S/Inputs/c_functions.h -primary-file %s -O -emit-ir -disable-llvm-optzns | %FileCheck %s
+// RUN: %target-swift-frontend -enable-objc-interop -import-objc-header %S/Inputs/c_functions.h -primary-file %s -O -emit-ir -disable-llvm-optzns | %FileCheck %s
 
 func return10() -> UInt32 {
 	return return7() + 3

--- a/test/IRGen/lit.local.cfg
+++ b/test/IRGen/lit.local.cfg
@@ -2,5 +2,5 @@
 config.substitutions = list(config.substitutions)
 
 config.substitutions.insert(0, ('%build-irgen-test-overlays',
-  '%target-swift-frontend -emit-module -o %t -sdk %S/Inputs %S/Inputs/ObjectiveC.swift && '
-  '%target-swift-frontend -emit-module -o %t -sdk %S/Inputs %S/Inputs/Foundation.swift -I %t'))
+                                '%target-swift-frontend -enable-objc-interop -emit-module -o %t -sdk %S/Inputs %S/Inputs/ObjectiveC.swift && '
+                                '%target-swift-frontend -enable-objc-interop -emit-module -o %t -sdk %S/Inputs %S/Inputs/Foundation.swift -I %t'))

--- a/test/IRGen/protocol_conformance_records.swift
+++ b/test/IRGen/protocol_conformance_records.swift
@@ -75,7 +75,7 @@ public struct NativeGenericType<T>: Runcible {
 // -- protocol descriptor
 // CHECK-SAME:           [[RUNCIBLE]]
 // -- type metadata
-// CHECK-SAME:           @"got.$SSiMn"
+// CHECK-SAME:           @"{{got.|__imp_}}$SSiMn"
 // -- witness table
 // CHECK-SAME:           @"$SSi28protocol_conformance_records8RuncibleAAWP"
 // -- reserved
@@ -91,7 +91,7 @@ extension Int: Runcible {
 // -- protocol descriptor
 // CHECK-SAME:           [[RUNCIBLE]]
 // -- nominal type descriptor
-// CHECK-SAME:           @"got.$S16resilient_struct4SizeVMn"
+// CHECK-SAME:           @"{{got.|__imp_}}$S16resilient_struct4SizeVMn"
 // -- witness table
 // CHECK-SAME:           @"$S16resilient_struct4SizeV28protocol_conformance_records8RuncibleADWP"
 // -- reserved
@@ -130,9 +130,9 @@ extension NativeGenericType : Spoon where T: Spoon {
 // Retroactive conformance
 // CHECK-LABEL: @"$SSi18resilient_protocol22OtherResilientProtocol0B20_conformance_recordsMc" ={{ dllexport | protected | }}constant
 // -- protocol descriptor
-// CHECK-SAME:           @"got.$S18resilient_protocol22OtherResilientProtocolMp"
+// CHECK-SAME:           @"{{got.|__imp_}}$S18resilient_protocol22OtherResilientProtocolMp"
 // -- nominal type descriptor
-// CHECK-SAME:           @"got.$SSiMn"
+// CHECK-SAME:           @"{{got.|__imp_}}$SSiMn"
 // -- witness table accessor
 // CHECK-SAME:           @"$SSi18resilient_protocol22OtherResilientProtocol0B20_conformance_recordsWa"
 // -- flags

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -25,7 +25,7 @@ import resilient_protocol
 // CHECK-SAME:   i16 0,
 
 // -- the protocol descriptor
-// CHECK-SAME:   @"got.$S18resilient_protocol22OtherResilientProtocolMp"
+// CHECK-SAME:   @"{{got.|__imp_}}$S18resilient_protocol22OtherResilientProtocolMp"
 
 // -- the template
 // CHECK-SAME:   @"$S19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWp"
@@ -133,7 +133,7 @@ protocol InternalProtocol {
 // CHECK-SAME:   i16 0,
 
 // -- the protocol descriptor
-// CHECK-SAME:   @"got.$S18resilient_protocol24ProtocolWithRequirementsMp"
+// CHECK-SAME:   @"{{got.|__imp_}}$S18resilient_protocol24ProtocolWithRequirementsMp"
 
 // -- the template
 // CHECK-SAME:   @"$S19protocol_resilience24ConformsWithRequirementsV010resilient_A008ProtocoldE0AAWp"
@@ -151,10 +151,10 @@ protocol InternalProtocol {
 
 // CHECK-SAME: internal constant {
 
-// CHECK-SAME: @"got.$S18resilient_protocol24ProtocolWithRequirementsP5firstyyFTj"
+// CHECK-SAME: @"{{got.|__imp_}}$S18resilient_protocol24ProtocolWithRequirementsP5firstyyFTj"
 // CHECK-SAME: @firstWitness
 
-// CHECK-SAME: @"got.$S18resilient_protocol24ProtocolWithRequirementsP6secondyyFTj"
+// CHECK-SAME: @"{{got.|__imp_}}$S18resilient_protocol24ProtocolWithRequirementsP6secondyyFTj"
 // CHECK-SAME: @secondWitness
 
 // CHECK-SAME: }

--- a/test/IRGen/reflection_metadata.swift
+++ b/test/IRGen/reflection_metadata.swift
@@ -2,51 +2,51 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -disable-reflection-names -emit-ir %s | %FileCheck %s --check-prefix=STRIP_REFLECTION_NAMES
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -disable-reflection-metadata -emit-ir %s | %FileCheck %s --check-prefix=STRIP_REFLECTION_METADATA
 
-// STRIP_REFLECTION_NAMES_DAG: {{.*}}swift4_reflect
-// STRIP_REFLECTION_NAMES_DAG: {{.*}}swift4_fieldmd
-// STRIP_REFLECTION_NAMES_DAG: {{.*}}swift4_assocty
-// STRIP_REFLECTION_NAMES-DAG: {{.*}}swift4_capture
-// STRIP_REFLECTION_NAMES-DAG: {{.*}}swift4_typeref
-// STRIP_REFLECTION_NAMES-NOT: {{.*}}swift4_reflstr
-// STRIP_REFLECTION_NAMES-NOT: {{.*}}swift4_builtin
+// STRIP_REFLECTION_NAMES_DAG: {{.*}}section "{{.?swift4_reflect|.sw5rfst\$B}}
+// STRIP_REFLECTION_NAMES_DAG: {{.*}}section "{{.?swift4_fieldmd|.sw5flmd\$B}}
+// STRIP_REFLECTION_NAMES_DAG: {{.*}}section "{{.?swift4_assocty|.sw5asty\$B}}
+// STRIP_REFLECTION_NAMES-DAG: {{.*}}section "{{.?swift4_capture|.sw5cptr\$B}}
+// STRIP_REFLECTION_NAMES-DAG: {{.*}}section "{{.?swift4_typeref|.sw5tyrf\$B}}
+// STRIP_REFLECTION_NAMES-NOT: {{.*}}section "{{.?swift4_reflstr|.sw5rfst\$B}}
+// STRIP_REFLECTION_NAMES-NOT: {{.*}}section "{{.?swift4_builtin|.sw5bltn\$B}}
 
-// STRIP_REFLECTION_NAMES-DAG: @"$S19reflection_metadata10MyProtocol_pMF" = internal constant {{.*}}swift4_fieldmd
+// STRIP_REFLECTION_NAMES-DAG: @"$S19reflection_metadata10MyProtocol_pMF" = internal constant {{.*}}section "{{.?swift4_fieldmd|.sw5flmd\$B}}
 
-// STRIP_REFLECTION_METADATA-NOT: {{.*}}swift4_reflect
-// STRIP_REFLECTION_METADATA-NOT: {{.*}}swift4_fieldmd
-// STRIP_REFLECTION_METADATA-NOT: {{.*}}swift4_assocty
-// STRIP_REFLECTION_METADATA-NOT: {{.*}}swift4_capture
-// STRIP_REFLECTION_METADATA-NOT: {{.*}}swift4_typeref
-// STRIP_REFLECTION_METADATA-NOT: {{.*}}swift4_reflstr
-// STRIP_REFLECTION_METADATA-NOT: {{.*}}swift4_builtin
+// STRIP_REFLECTION_METADATA-NOT: {{.*}}section "{{.?swift4_reflect|.sw5rfst\$B}}
+// STRIP_REFLECTION_METADATA-NOT: {{.*}}section "{{.?swift4_fieldmd|.sw5flmd\$B}}
+// STRIP_REFLECTION_METADATA-NOT: {{.*}}section "{{.?swift4_assocty|.sw5asty\$B}}
+// STRIP_REFLECTION_METADATA-NOT: {{.*}}section "{{.?swift4_capture|.sw5cptr\$B}}
+// STRIP_REFLECTION_METADATA-NOT: {{.*}}section "{{.?swift4_typeref|.sw5tyrf\$B}}
+// STRIP_REFLECTION_METADATA-NOT: {{.*}}section "{{.?swift4_reflstr|.sw5rfst\$B}}
+// STRIP_REFLECTION_METADATA-NOT: {{.*}}section "{{.?swift4_builtin|.sw5bltn\$B}}
 
 // CHECK-DAG: @__swift_reflection_version = linkonce_odr hidden constant i16 {{[0-9]+}}
-// CHECK-DAG: private constant [2 x i8] c"i\00", section "{{[^"]*}}swift4_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [3 x i8] c"ms\00", section "{{[^"]*}}swift4_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [3 x i8] c"me\00", section "{{[^"]*}}swift4_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [3 x i8] c"mc\00", section "{{[^"]*}}swift4_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [2 x i8] c"C\00", section "{{[^"]*}}swift4_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [2 x i8] c"S\00", section "{{[^"]*}}swift4_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [2 x i8] c"E\00", section "{{[^"]*}}swift4_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [2 x i8] c"I\00", section "{{[^"]*}}swift4_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [2 x i8] c"t\00", section "{{[^"]*}}swift4_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [4 x i8] c"mgs\00", section "{{[^"]*}}swift4_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [4 x i8] c"mge\00", section "{{[^"]*}}swift4_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [4 x i8] c"mgc\00", section "{{[^"]*}}swift4_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [3 x i8] c"GC\00", section "{{[^"]*}}swift4_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [3 x i8] c"GS\00", section "{{[^"]*}}swift4_reflstr{{[^"]*}}"
-// CHECK-DAG: private constant [3 x i8] c"GE\00", section "{{[^"]*}}swift4_reflstr{{[^"]*}}"
+// CHECK-DAG: private constant [2 x i8] c"i\00", section "{{[^"]*}}{{.?swift4_reflstr|.sw5rfst\$B}}{{[^"]*}}"
+// CHECK-DAG: private constant [3 x i8] c"ms\00", section "{{[^"]*}}{{.?swift4_reflstr|.sw5rfst\$B}}{{[^"]*}}"
+// CHECK-DAG: private constant [3 x i8] c"me\00", section "{{[^"]*}}{{.?swift4_reflstr|.sw5rfst\$B}}{{[^"]*}}"
+// CHECK-DAG: private constant [3 x i8] c"mc\00", section "{{[^"]*}}{{.?swift4_reflstr|.sw5rfst\$B}}{{[^"]*}}"
+// CHECK-DAG: private constant [2 x i8] c"C\00", section "{{[^"]*}}{{.?swift4_reflstr|.sw5rfst\$B}}{{[^"]*}}"
+// CHECK-DAG: private constant [2 x i8] c"S\00", section "{{[^"]*}}{{.?swift4_reflstr|.sw5rfst\$B}}{{[^"]*}}"
+// CHECK-DAG: private constant [2 x i8] c"E\00", section "{{[^"]*}}{{.?swift4_reflstr|.sw5rfst\$B}}{{[^"]*}}"
+// CHECK-DAG: private constant [2 x i8] c"I\00", section "{{[^"]*}}{{.?swift4_reflstr|.sw5rfst\$B}}{{[^"]*}}"
+// CHECK-DAG: private constant [2 x i8] c"t\00", section "{{[^"]*}}{{.?swift4_reflstr|.sw5rfst\$B}}{{[^"]*}}"
+// CHECK-DAG: private constant [4 x i8] c"mgs\00", section "{{[^"]*}}{{.?swift4_reflstr|.sw5rfst\$B}}{{[^"]*}}"
+// CHECK-DAG: private constant [4 x i8] c"mge\00", section "{{[^"]*}}{{.?swift4_reflstr|.sw5rfst\$B}}{{[^"]*}}"
+// CHECK-DAG: private constant [4 x i8] c"mgc\00", section "{{[^"]*}}{{.?swift4_reflstr|.sw5rfst\$B}}{{[^"]*}}"
+// CHECK-DAG: private constant [3 x i8] c"GC\00", section "{{[^"]*}}{{.?swift4_reflstr|.sw5rfst\$B}}{{[^"]*}}"
+// CHECK-DAG: private constant [3 x i8] c"GS\00", section "{{[^"]*}}{{.?swift4_reflstr|.sw5rfst\$B}}{{[^"]*}}"
+// CHECK-DAG: private constant [3 x i8] c"GE\00", section "{{[^"]*}}{{.?swift4_reflstr|.sw5rfst\$B}}{{[^"]*}}"
 
 // CHECK-DAG: @"\01l__swift4_reflection_descriptor" = private constant { {{.*}} } { i32 1, i32 1, i32 2, {{.*}} }
 
-// CHECK-DAG: @"$S19reflection_metadata10MyProtocol_pMF" = internal constant {{.*}}swift4_fieldmd
-// CHECK-DAG: @"$S19reflection_metadata7MyClassCMF" = internal constant {{.*}}swift4_fieldmd
-// CHECK-DAG: @"$S19reflection_metadata11ConformanceVAA10MyProtocolAAMA" = internal constant {{.*}}swift4_assocty
-// CHECK-DAG: @"$S19reflection_metadata8MyStructVMF" = internal constant {{.*}}swift4_fieldmd
-// CHECK-DAG: @"$S19reflection_metadata6MyEnumOMF" = internal constant {{.*}}swift4_fieldmd
-// CHECK-DAG: @"$S19reflection_metadata14MyGenericClassCMF" = internal constant {{.*}}swift4_fieldmd
-// CHECK-DAG: @"$S19reflection_metadata15MyGenericStructVMF" = internal constant {{.*}}swift4_fieldmd
-// CHECK-DAG: @"$S19reflection_metadata13MyGenericEnumOMF" = internal constant {{.*}}swift4_fieldmd
+// CHECK-DAG: @"$S19reflection_metadata10MyProtocol_pMF" = internal constant {{.*}}section "{{.?swift4_fieldmd|.sw5flmd\$B}}
+// CHECK-DAG: @"$S19reflection_metadata7MyClassCMF" = internal constant {{.*}}section "{{.?swift4_fieldmd|.sw5flmd\$B}}
+// CHECK-DAG: @"$S19reflection_metadata11ConformanceVAA10MyProtocolAAMA" = internal constant {{.*}}section "{{.?swift4_assocty|.sw5asty\$B}}
+// CHECK-DAG: @"$S19reflection_metadata8MyStructVMF" = internal constant {{.*}}section "{{.?swift4_fieldmd|.sw5flmd\$B}}
+// CHECK-DAG: @"$S19reflection_metadata6MyEnumOMF" = internal constant {{.*}}section "{{.?swift4_fieldmd|.sw5flmd\$B}}
+// CHECK-DAG: @"$S19reflection_metadata14MyGenericClassCMF" = internal constant {{.*}}section "{{.?swift4_fieldmd|.sw5flmd\$B}}
+// CHECK-DAG: @"$S19reflection_metadata15MyGenericStructVMF" = internal constant {{.*}}section "{{.?swift4_fieldmd|.sw5flmd\$B}}
+// CHECK-DAG: @"$S19reflection_metadata13MyGenericEnumOMF" = internal constant {{.*}}section "{{.?swift4_fieldmd|.sw5flmd\$B}}
 
 public protocol MyProtocol {
   associatedtype Inner

--- a/test/IRGen/reflection_metadata_imported.swift
+++ b/test/IRGen/reflection_metadata_imported.swift
@@ -4,10 +4,10 @@ import c_layout
 
 // CHECK-DAG: @__swift_reflection_version = linkonce_odr hidden constant i16 {{[0-9]+}}
 
-// CHECK-DAG: @"$S28reflection_metadata_imported15HasImportedTypeVMF" = internal constant {{.*}}swift4_fieldmd
-// CHECK-DAG: @"$SSo1AVMB" = linkonce_odr hidden constant {{.*}}swift4_builtin
-// CHECK-DAG: @"$SSo11CrappyColorVMB" = linkonce_odr hidden constant {{.*}}swift4_builtin
-// CHECK-DAG: @"$SSo11CrappyColorVs16RawRepresentableSCMA" = linkonce_odr hidden constant {{.*}}swift4_assocty
+// CHECK-DAG: @"$S28reflection_metadata_imported15HasImportedTypeVMF" = internal constant {{.*}}section "{{.?swift4_fieldmd|.sw5flmd\$B}}
+// CHECK-DAG: @"$SSo1AVMB" = linkonce_odr hidden constant {{.*}}section "{{.?swift4_builtin|.sw5bltn\$B}}
+// CHECK-DAG: @"$SSo11CrappyColorVMB" = linkonce_odr hidden constant {{.*}}section "{{.?swift4_builtin|.sw5bltn\$B}}
+// CHECK-DAG: @"$SSo11CrappyColorVs16RawRepresentableSCMA" = linkonce_odr hidden constant {{.*}}section "{{.?swift4_assocty|.sw5asty\$B}}
 
 struct HasImportedType {
   let a: A

--- a/test/IRGen/sanitize_coverage.swift
+++ b/test/IRGen/sanitize_coverage.swift
@@ -1,4 +1,3 @@
-// XFAIL: linux
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -sanitize=address -sanitize-coverage=func %s | %FileCheck %s -check-prefix=SANCOV
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -sanitize=address -sanitize-coverage=bb %s | %FileCheck %s -check-prefix=SANCOV
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -sanitize=address -sanitize-coverage=edge %s | %FileCheck %s -check-prefix=SANCOV
@@ -9,14 +8,25 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -sanitize=address -sanitize-coverage=edge,8bit-counters %s | %FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_8BIT_COUNTERS
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -sanitize=fuzzer %s | %FileCheck %s -check-prefix=SANCOV -check-prefix=SANCOV_TRACE_CMP
 
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
 import Darwin
+#elseif os(FreeBSD) || os(Linux) || os(Cygwin) || os(Android)
+import Glibc
+#elseif os(Windows)
+import MSVCRT
+#endif
 
 // FIXME: We should have a reliable way of triggering an indirect call in the
 // LLVM IR generated from this code.
 func test() {
   // Use random numbers so the compiler can't constant fold
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
   let x = arc4random()
   let y = arc4random()
+#else
+  let x = rand()
+  let y = rand()
+#endif
   // Comparison is to trigger insertion of __sanitizer_cov_trace_cmp
   let z = x == y
   print("\(z)")

--- a/test/IRGen/unused.sil
+++ b/test/IRGen/unused.sil
@@ -1,6 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir > %t
-// RUN: %FileCheck %s --check-prefix=CHECK-%target-object-format --check-prefix=CHECK < %t
-// RUN: %FileCheck -check-prefix=NEGATIVE %s < %t
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck -check-prefix CHECK -check-prefix NEGATIVE -check-prefix CHECK-%target-object-format %s
 
 // REQUIRES: CPU=x86_64
 

--- a/test/IRGen/weak.sil
+++ b/test/IRGen/weak.sil
@@ -112,8 +112,8 @@ bb0(%0 : $Optional<P>):
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
 // CHECK-NEXT: ret [[OPAQUE]]* [[T0]]
 
-// TAILCALL: {{_?}}$S4weak1AVwCP:
-// TAILCALL:  jmp     {{_?}}swift_weakCopyInit
+// TAILCALL-LABEL: $S4weak1AVwCP:
+// TAILCALL: jmp{{q?}} {{(\*__imp_)?_?}}swift_weakCopyInit
 
 //   destroy
 // CHECK:    define linkonce_odr hidden void @"$S4weak1AVwxx"([[OPAQUE]]* noalias [[ARG:%.*]], [[TYPE]]*
@@ -122,8 +122,8 @@ bb0(%0 : $Optional<P>):
 // CHECK-NEXT: call void @swift_weakDestroy([[WEAK]]* [[T1]])
 // CHECK-NEXT: ret void
 
-// TAILCALL: {{_?}}$S4weak1AVwxx:
-// TAILCALL:  jmp     {{_?}}swift_weakDestroy
+// TAILCALL-LABEL: $S4weak1AVwxx:
+// TAILCALL: jmp{{q?}} {{(\*__imp_)?_?}}swift_weakDestroy
 
 //   initializeWithCopy
 // CHECK:    define linkonce_odr hidden [[OPAQUE]]* @"$S4weak1AVwcp"([[OPAQUE]]* noalias [[DEST_OPQ:%.*]], [[OPAQUE]]* noalias [[SRC_OPQ:%.*]], [[TYPE]]*
@@ -135,8 +135,8 @@ bb0(%0 : $Optional<P>):
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
 // CHECK-NEXT: ret [[OPAQUE]]* [[T0]]
 
-// TAILCALL: {{_?}}$S4weak1AVwcp:
-// TAILCALL:  jmp     {{_?}}swift_weakCopyInit
+// TAILCALL-LABEL: $S4weak1AVwcp:
+// TAILCALL: jmp{{q?}} {{(\*__imp_)?_?}}swift_weakCopyInit
 
 //   assignWithCopy
 // CHECK:    define linkonce_odr hidden [[OPAQUE]]* @"$S4weak1AVwca"([[OPAQUE]]* [[DEST_OPQ:%.*]], [[OPAQUE]]* [[SRC_OPQ:%.*]], [[TYPE]]*
@@ -148,8 +148,8 @@ bb0(%0 : $Optional<P>):
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
 // CHECK-NEXT: ret [[OPAQUE]]* [[T0]]
 
-// TAILCALL: {{_?}}$S4weak1AVwca:
-// TAILCALL:  jmp     {{_?}}swift_weakCopyAssign
+// TAILCALL-LABEL: $S4weak1AVwca:
+// TAILCALL: jmp{{q?}} {{(\*__imp_)?_?}}swift_weakCopyAssign
 
 //   assignWithTake
 // CHECK:    define linkonce_odr hidden [[OPAQUE]]* @"$S4weak1AVwta"([[OPAQUE]]* noalias [[DEST_OPQ:%.*]], [[OPAQUE]]* noalias [[SRC_OPQ:%.*]], [[TYPE]]*
@@ -161,11 +161,11 @@ bb0(%0 : $Optional<P>):
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
 // CHECK-NEXT: ret [[OPAQUE]]* [[T0]]
 
-// TAILCALL: {{_?}}$S4weak1AVwtk:
-// TAILCALL:  jmp     {{_?}}swift_weakTakeInit
+// TAILCALL-LABEL: $S4weak1AVwtk:
+// TAILCALL: jmp{{q?}} {{(\*__imp_)?_?}}swift_weakTakeInit
 
-// TAILCALL: {{_?}}$S4weak1AVwta:
-// TAILCALL:  jmp     {{_?}}swift_weakTakeAssign
+// TAILCALL-LABEL: $S4weak1AVwta:
+// TAILCALL: jmp{{q?}} {{(\*__imp_)?_?}}swift_weakTakeAssign
 
-// TAILCALL: {{_?}}$S4weak1AVwTK:
-// TAILCALL:  jmp     {{_?}}swift_weakTakeInit
+// TAILCALL-LABEL: $S4weak1AVwTK:
+// TAILCALL: jmp{{q?}} {{(\*__imp_)?_?}}swift_weakTakeInit

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -161,8 +161,16 @@ if platform.system() == 'Darwin':
     config.environment['TOOLCHAINS'] = \
         os.environ.get('TOOLCHAINS', config.darwin_xcrun_toolchain)
 
+# NOTE: this mirrors the kIsWindows from lit.lit.TestRunner in LLVM
+kIsWindows = platform.system() == 'Windows'
+
 # testFormat: The test format to use to interpret tests.
-config.test_format = swift_test.SwiftTest(coverage_mode=config.coverage_mode)
+
+# Choose between list's internal shell pipeline runner and a real shell.  If
+# LIT_USE_INTERNAL_SHELL is in the environment, we use that as an override.
+use_lit_shell = os.environ.get('LIT_USE_INTERNAL_SHELL', not kIsWindows)
+config.test_format = swift_test.SwiftTest(coverage_mode=config.coverage_mode,
+                                          execute_external=use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files.
 config.suffixes = ['.swift', '.ll', '.sil', '.gyb', '.m', '.test-sh']
@@ -280,6 +288,9 @@ config.scale_test = make_path(config.swift_utils, 'scale-test')
 config.PathSanitizingFileCheck = make_path(config.swift_utils, 'PathSanitizingFileCheck')
 config.swift_lib_dir = make_path(config.swift, '..', '..', 'lib')
 config.round_trip_syntax_test = make_path(config.swift_utils, 'round-trip-syntax-test')
+
+config.link = lit.util.which('link', config.environment['PATH']) or            \
+              lit.util.which('lld-link', config.environment['PATH'])
 
 # Find the resource directory.  Assume it's near the swift compiler if not set.
 test_resource_dir = lit_config.params.get('test_resource_dir')
@@ -694,7 +705,7 @@ if run_vendor == 'apple':
             config.target_run_simple_swift = (
                 "%s %%s" % (target_run_base))
             config.target_run_simple_swiftgyb = (
-                'rm -rf %%t && mkdir -p %%t && '
+                '%%empty-directory(%%t) && '
                 '%%gyb %%s -o %%t/main.swift && '
                 '%%line-directive %%t/main.swift -- %s %%t/main.swift'
                 % (target_run_base))
@@ -756,6 +767,55 @@ if run_vendor == 'apple':
         "%s -parse-as-library -emit-library -o '\\1' "
         "-Xlinker -install_name -Xlinker @executable_path/$(basename '\\1')"
         % (config.target_build_swift))
+
+elif run_os in ['windows-msvc']:
+    lit_config.note('Testing Windows ' + config.variant_triple)
+    config.target_object_format = 'coff'
+    config.target_dylib_extension = 'dll'
+    config.target_sdk_name = 'windows'
+    config.target_runtime = 'native'
+    config.target_swiftmodule_name = run_cpu + '.swiftmodule'
+    config.target_swiftdoc_name = run_cpu + '.swiftdoc'
+
+    config.target_build_swift =                                                  \
+            ('%r -target %s %s %s %s %s %s' % (config.swiftc,                    \
+                                               config.variant_triple,            \
+                                               resource_dir_opt, mcp_opt,        \
+                                               config.swift_test_options,        \
+                                               config.swift_driver_test_options, \
+                                               swift_execution_tests_extra_flags))
+    config.target_run = ''
+    config.target_swift_frontend =                                               \
+            ('%r -frontend -target %s %s %s %s %s' % (config.swiftc,             \
+                                                      config.variant_triple,     \
+                                                      resource_dir_opt, mcp_opt, \
+                                                      config.swift_test_options, \
+                                                      config.swift_frontend_test_options))
+    config.target_codesign = ''
+    subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
+    subst_target_swift_frontend_mock_sdk_after = ''
+    config.target_build_swift_dylib =                                            \
+            ("%r -parse-as-library -emit-library -o '\\1'" % (config.target_build_swift))
+    config.target_clang =                                                        \
+            ('clang++ -target %s %s' % (config.variant_triple, clang_mcp_opt))
+    config.target_ld =                                                           \
+            ('%r -libpath:%s' % (config.link, os.path.join(test_resource_dir,    \
+                                                           config.target_sdk_name)))
+    config.target_sil_opt =                                                      \
+            ('%r -target %s %s %s %s' % (config.sil_opt, config.variant_triple,  \
+                                         resource_dir_opt, mcp_opt,              \
+                                         config.sil_test_options))
+    config.target_swift_ide_test =                                               \
+            ('%r -target %s %s %s %s' % (config.swift_ide_test,                  \
+                                         config.variant_triple,                  \
+                                         resource_dir_opt, mcp_opt, ccp_opt))
+    subst_target_swift_ide_test_mock_sdk = config.target_swift_ide_test
+    subst_target_swift_ide_test_mock_sdk_after = ''
+    config.target_swiftc_driver =                                                \
+            ('%r -target %s %s %s' % (config.swiftc, config.variant_triple,      \
+                                      resource_dir_opt, mcp_opt))
+    config.target_swift_modulewrap =                                             \
+            ('%r -modulewrap -target %s' % (config.swiftc, config.variant_triple))
 
 elif run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'windows-gnu']:
     # Linux/FreeBSD/Cygwin
@@ -1041,11 +1101,9 @@ config.substitutions.append(('%target-runtime', config.target_runtime))
 
 config.substitutions.append(('%target-typecheck-verify-swift', config.target_parse_verify_swift))
 
-config.substitutions.append(
-    ('%target-swift-frontend\(mock-sdk:([^)]+)\)',
-     '%s \\1 %s' %
-     (subst_target_swift_frontend_mock_sdk,
-      subst_target_swift_frontend_mock_sdk_after)))
+config.substitutions.append(('%target-swift-frontend\(mock-sdk:([^)]+)\)',
+                             SubstituteCaptures(r'%s \1 %s' % (subst_target_swift_frontend_mock_sdk,
+                                                               subst_target_swift_frontend_mock_sdk_after))))
 config.substitutions.append(('%target-swift-frontend', config.target_swift_frontend))
 
 
@@ -1070,25 +1128,23 @@ config.substitutions.append(
 
 config.substitutions.append(('%utils', config.swift_utils))
 config.substitutions.append(('%line-directive', config.line_directive))
-config.substitutions.append(('%gyb', config.gyb))
+config.substitutions.append(('%gyb', '%r %s' % (sys.executable, config.gyb)))
 config.substitutions.append(('%round-trip-syntax-test', config.round_trip_syntax_test))
 config.substitutions.append(('%rth', config.rth))
 config.substitutions.append(('%scale-test',
                              '{} --swiftc-binary={} --tmpdir=%t'.format(
                                  config.scale_test, config.swiftc)))
-config.substitutions.append(
-    ('%empty-directory\(([^)]+)\)', 'rm -rf \"\\1\" && mkdir -p \"\\1\"'))
+config.substitutions.append(('%empty-directory\(([^)]+)\)',
+                             SubstituteCaptures(r'rm -rf "\1" && mkdir -p "\1"')))
 
 config.substitutions.append(('%target-sil-opt', config.target_sil_opt))
 config.substitutions.append(('%target-sil-func-extractor', config.target_sil_func_extractor))
 config.substitutions.append(('%target-sil-llvm-gen', config.target_sil_llvm_gen))
 config.substitutions.append(('%target-sil-nm', config.target_sil_nm))
-config.substitutions.append(
-    ('%target-swift-ide-test\(mock-sdk:([^)]+)\)',
-     '%s \\1 %s -swift-version %s' %
-     (subst_target_swift_ide_test_mock_sdk,
-      subst_target_swift_ide_test_mock_sdk_after,
-      swift_version)))
+config.substitutions.append(('%target-swift-ide-test\(mock-sdk:([^)]+)\)',
+                             SubstituteCaptures(r'%s \1 %s -swift-version %s' % (subst_target_swift_ide_test_mock_sdk,
+                                                                                 subst_target_swift_ide_test_mock_sdk_after,
+                                                                                 swift_version))))
 config.substitutions.append(('%target-swift-ide-test', "%s -swift-version %s" % (config.target_swift_ide_test, swift_version)))
 config.substitutions.append(('%target-swift-reflection-test', lit.util.which('swift-reflection-test{variant_suffix}'.format(variant_suffix=config.variant_suffix), config.environment['PATH'])))
 config.substitutions.append(('%target-swift-reflection-dump', '{} {} {}'.format(config.swift_reflection_dump, '-arch', run_cpu)))
@@ -1128,13 +1184,12 @@ config.substitutions.append(('%target-resilience-test', config.target_resilience
 config.substitutions.append(('%llvm-profdata', config.llvm_profdata))
 config.substitutions.append(('%llvm-cov', config.llvm_cov))
 
-config.substitutions.append(
-    ('%FileCheck',
-     '%s --sanitize \'BUILD_DIR=%s\' --sanitize \'SOURCE_DIR=%s\' --use-filecheck \'%s\'' %
-      (config.PathSanitizingFileCheck,
-       pipes.quote(swift_obj_root),
-       pipes.quote(config.swift_src_root),
-       pipes.quote(config.filecheck))))
+config.substitutions.append(('%FileCheck',
+                             '%r %r --sanitize BUILD_DIR=%r --sanitize SOURCE_DIR=%r --use-filecheck %r' % (sys.executable,
+                                                                                                            config.PathSanitizingFileCheck,
+                                                                                                            swift_obj_root,
+                                                                                                            config.swift_src_root,
+                                                                                                            config.filecheck)))
 config.substitutions.append(('%raw-FileCheck', pipes.quote(config.filecheck)))
 
 # If static stdlib is present, enable static stdlib tests


### PR DESCRIPTION
Annotate DLL Storage on tests as necessary.  This is needed for Windows
support.  Make some tests pass on Linux as well.  These would be
XFAIL'ed on Windows for the same reason as Linux.  This tightens some
tests, enables some flags, or loosens in other cases.  This allows a
broader set of IRGen tests to run on Linux (and Windows).

Optimize a few tests by collapsing multiple FileCheck invocations or
transferring data through files instead of pipes.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
