### PR TITLE
Link in ubsan when -sanitize=fuzzer is used.

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1374,9 +1374,12 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
 
   // Only link in libFuzzer for executables.
   if (job.getKind() == LinkKind::Executable &&
-      (context.OI.SelectedSanitizers & SanitizerKind::Fuzzer))
+      (context.OI.SelectedSanitizers & SanitizerKind::Fuzzer)) {
     addLinkSanitizerLibArgsForDarwin(
         context.Args, Arguments, "fuzzer", *this, /*shared=*/false);
+    addLinkSanitizerLibArgsForDarwin(
+        context.Args, Arguments, "ubsan", *this, /*shared=*/true);
+  }
 
   if (context.Args.hasArg(options::OPT_embed_bitcode,
                           options::OPT_embed_bitcode_marker)) {
@@ -1731,10 +1734,14 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
       if (context.OI.SelectedSanitizers & SanitizerKind::Thread)
         addLinkSanitizerLibArgsForLinux(context.Args, Arguments, "tsan", *this);
 
-      if (context.OI.SelectedSanitizers & SanitizerKind::Fuzzer)
+      if (context.OI.SelectedSanitizers & SanitizerKind::Fuzzer) {
         addLinkRuntimeLibForLinux(context.Args, Arguments,
             getSanitizerRuntimeLibNameForLinux(
                 "fuzzer", this->getTriple()), *this);
+        addLinkRuntimeLibForLinux(context.Args, Arguments,
+            getSanitizerRuntimeLibNameForLinux(
+                "ubsan", this->getTriple()), *this);
+      }
     }
   }
 

--- a/test/Driver/fuzzer.swift
+++ b/test/Driver/fuzzer.swift
@@ -1,6 +1,7 @@
 // RUN: %swiftc_driver -driver-print-jobs -sanitize=fuzzer,address -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=LIBFUZZER %s
 
 // LIBFUZZER: libclang_rt.fuzzer
+// LIBFUZZER-NEXT: libclang_rt.ubsan
 @_cdecl("LLVMFuzzerTestOneInput") public func fuzzOneInput(Data: UnsafePointer<CChar>, Size: CLong) -> CInt {
   return 0;
 }


### PR DESCRIPTION
In the absence of address sanitizer, ubsan is used for symbolication.
