### PR TITLE
Link in ubsan when -sanitize=fuzzer is used

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -1763,8 +1763,8 @@ toolchains::GenericUnix::constructInvocation(const LinkJobAction &job,
       }
 
       if (needsUbsan)
-        addLinkSanitizerLibArgsForLinux(context.Args, Arguments, "ubsan", *this);
-
+        addLinkSanitizerLibArgsForLinux(context.Args, Arguments,
+                                        "ubsan_standalone", *this);
     }
   }
 

--- a/test/Driver/fuzzer.swift
+++ b/test/Driver/fuzzer.swift
@@ -1,6 +1,13 @@
 // RUN: %swiftc_driver -driver-print-jobs -sanitize=fuzzer,address -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=LIBFUZZER %s
+// RUN: %swiftc_driver -driver-print-jobs -sanitize=fuzzer -resource-dir %S/Inputs/fake-resource-dir/lib/swift/ %s | %FileCheck -check-prefix=LIBFUZZER_NO_ASAN %s
 
 // LIBFUZZER: libclang_rt.fuzzer
+// LIBFUZZER: libclang_rt.asan
+// LIBFUZZER-NOT: libclang_rt.ubsan
+
+
+// LIBFUZZER_NO_ASAN: libclang_rt.fuzzer
+// LIBFUZZER_NO_ASAN: libclang_rt.ubsan
 @_cdecl("LLVMFuzzerTestOneInput") public func fuzzOneInput(Data: UnsafePointer<CChar>, Size: CLong) -> CInt {
   return 0;
 }


### PR DESCRIPTION
In the absence of tsan and asan, needed symbolication symbols are provided by ubsan.
Otherwise, fuzzing crashes produce no symbolicated traces and complain about missing symbols.