### PR TITLE
[Parse] Fix error in unsigned char target

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -2384,7 +2384,7 @@ void Lexer::lexTrivia(syntax::Trivia &Pieces, bool IsForTrailingTrivia) {
 Restart:
   const char *TriviaStart = CurPtr;
 
-  switch (*CurPtr++) {
+  switch ((signed char)*CurPtr++) {
   case '\n':
     if (IsForTrailingTrivia)
       break;


### PR DESCRIPTION
This PR fix a compile error issue when `char` is unsigned in target environment.

It resolves issue reported below.
https://forums.swift.org/t/build-failed-on-s390x-with-latest-changes-in-lexer-cpp/10660
