### PR TITLE
Rewrite MetadataCache to be a more natural extension of ConcurrentMap

### DIFF
--- a/include/swift/Runtime/Concurrent.h
+++ b/include/swift/Runtime/Concurrent.h
@@ -127,6 +127,13 @@ template <class ElemTy> struct ConcurrentList {
   std::atomic<ConcurrentListNode<ElemTy> *> First;
 };
 
+/// A utility function for ordering two integers, which is useful
+/// for implementing compareWithKey.
+template <class T>
+static inline int compareIntegers(T left, T right) {
+  return (left == right ? 0 : left < right ? -1 : 1);
+}
+
 /// A utility function for ordering two pointers, which is useful
 /// for implementing compareWithKey.
 template <class T>


### PR DESCRIPTION
Change generic witness table instantiation to use a more lightweight entry scheme that allocates the witness table as part of the entry.

In contrast, change generic metadata instantiation to use a more straightforward allocation scheme where the metadata is a totally independent allocation.

This is preparation for proper cyclic-dependency handling.