### PR TITLE
[benchmark] Add benchmarks for Dictionary.swapAt(_:,_:)

### DIFF
--- a/benchmark/single-source/DictionarySwap.swift
+++ b/benchmark/single-source/DictionarySwap.swift
@@ -17,6 +17,8 @@ import TestsUtils
 public let DictionarySwap = [
   BenchmarkInfo(name: "DictionarySwap", runFunction: run_DictionarySwap, tags: [.validation, .api, .Dictionary]),
   BenchmarkInfo(name: "DictionarySwapOfObjects", runFunction: run_DictionarySwapOfObjects, tags: [.validation, .api, .Dictionary]),
+  BenchmarkInfo(name: "DictionarySwapAt", runFunction: run_DictionarySwapAt, tags: [.validation, .api, .Dictionary]),
+  BenchmarkInfo(name: "DictionarySwapAtOfObjects", runFunction: run_DictionarySwapAtOfObjects, tags: [.validation, .api, .Dictionary]),
 ]
 
 @inline(never)
@@ -40,6 +42,32 @@ public func run_DictionarySwap(_ N: Int) {
     }
 
     CheckResults(swappedCorrectly(swapped, dict[25]!, dict[75]!))
+}
+
+@inline(never)
+public func run_DictionarySwapAt(_ N: Int) {
+  let size = 100
+  var dict = [Int: Int](minimumCapacity: size)
+
+  // Fill dictionary
+  for i in 1...size {
+    dict[i] = i
+  }
+  CheckResults(dict.count == size)
+
+  var swapped = false
+  for _ in 1...10000*N {
+    let i25 = dict.index(forKey: 25)!
+    let i75 = dict.index(forKey: 75)!
+
+    dict.values.swapAt(i25, i75)
+    swapped = !swapped
+    if !swappedCorrectly(swapped, dict[25]!, dict[75]!) {
+      break
+    }
+  }
+
+  CheckResults(swappedCorrectly(swapped, dict[25]!, dict[75]!))
 }
 
 // Return true if correctly swapped, false otherwise
@@ -87,4 +115,32 @@ public func run_DictionarySwapOfObjects(_ N: Int) {
     }
 
     CheckResults(swappedCorrectly(swapped, dict[Box(25)]!.value, dict[Box(75)]!.value))
+}
+
+@inline(never)
+public func run_DictionarySwapAtOfObjects(_ N: Int) {
+  let size = 100
+  var dict = [Box<Int>: Box<Int>](minimumCapacity: size)
+
+  // Fill dictionary
+  for i in 1...size {
+    dict[Box(i)] = Box(i)
+  }
+  CheckResults(dict.count == size)
+
+  var swapped = false
+  for _ in 1...10000*N {
+    let b25 = Box(25)
+    let b75 = Box(75)
+    let i25 = dict.index(forKey: b25)!
+    let i75 = dict.index(forKey: b75)!
+
+    dict.values.swapAt(i25, i75)
+    swapped = !swapped
+    if !swappedCorrectly(swapped, dict[Box(25)]!.value, dict[Box(75)]!.value) {
+      break
+    }
+  }
+
+  CheckResults(swappedCorrectly(swapped, dict[Box(25)]!.value, dict[Box(75)]!.value))
 }


### PR DESCRIPTION
This adds benchmarks for `Dictionary.Values.swapAt(_:,_:)`, comparable to existing benchmarks swapping elements using tuple-assignment.

`swapAt` currently measures as slower, which demonstrates a nice opportunity for optimization.