### PR TITLE
IRGen: Fix assert

### DIFF
--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1920,7 +1920,7 @@ void CallEmission::setFromCallee() {
 
     // Fill in the context pointer if necessary.
     if (!contextPtr) {
-      assert(!CurCallee.getOrigFunctionType()->isNoEscape() &&
+      assert(!CurCallee.getOrigFunctionType()->getExtInfo().hasContext() &&
              "Missing context?");
       contextPtr = llvm::UndefValue::get(IGF.IGM.RefCountedPtrTy);
     }


### PR DESCRIPTION
We only need a contextPtr if the function type requires a context

rdar://38241155
SR-7138
