### PR TITLE
Fix importer support for Float80 - add missing #if block

### DIFF
--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -203,11 +203,16 @@ public func ${ufunc}(_ x: ${T}) -> ${T} {
 // UnaryFunctions, we define overlays only for OverlayFloatTypes.
 % for ufunc in UnaryIntrinsicFunctions:
 %     for T, CT, f in OverlayFloatTypes():
+%       if T == 'Float80':
+#if arch(i386) || arch(x86_64)
+%       end
 @_transparent
 public func ${ufunc}(_ x: ${T}) -> ${T} {
   return ${T}(${ufunc}${f}(${CT}(x)))
 }
-
+%       if T == 'Float80':
+#endif
+%       end
 %     end
 % end
 #endif


### PR DESCRIPTION
As discussed in https://github.com/apple/swift/pull/14971, adding the missing `#if` block.
Tagging @jrose-apple for his attention.  Thanks.