### PR TITLE
[Parse] Refactor Lexer to unify logic into Trivia Lexer by using its comapibility

### DIFF
--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -49,6 +49,7 @@ enum class CommentRetentionMode {
 enum class TriviaRetentionMode {
   WithoutTrivia,
   WithTrivia,
+  WithOnlyLeadingTrivia
 };
 
 /// Kinds of conflict marker which the lexer might encounter.
@@ -210,6 +211,16 @@ public:
     return RetainComments == CommentRetentionMode::ReturnAsTokens;
   }
 
+  bool isWithTrivia() const {
+    switch (TriviaRetention) {
+    case TriviaRetentionMode::WithTrivia:
+    case TriviaRetentionMode::WithOnlyLeadingTrivia:
+      return true;
+    case TriviaRetentionMode::WithoutTrivia:
+      return false;
+    }
+  }
+
   unsigned getBufferID() const { return BufferID; }
 
   /// peekNextToken - Return the next token to be returned by Lex without
@@ -234,7 +245,7 @@ public:
     if (TokStart.isInvalid())
       TokStart = Tok.getLoc();
     auto S = getStateForBeginningOfTokenLoc(TokStart);
-    if (TriviaRetention == TriviaRetentionMode::WithTrivia)
+    if (isWithTrivia())
       S.LeadingTrivia = LeadingTrivia;
     return S;
   }
@@ -259,7 +270,7 @@ public:
     lexImpl();
 
     // Restore Trivia.
-    if (TriviaRetention == TriviaRetentionMode::WithTrivia)
+    if (isWithTrivia())
       if (auto &LTrivia = S.LeadingTrivia)
         LeadingTrivia = std::move(*LTrivia);
   }

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -134,7 +134,9 @@ class Lexer {
   /// This is only preserved if this Lexer was constructed with
   /// `TriviaRetentionMode::WithTrivia`.
   syntax::Trivia TrailingTrivia;
-  
+
+  std::unique_ptr<Lexer> TriviaLexer;
+
   Lexer(const Lexer&) = delete;
   void operator=(const Lexer&) = delete;
 
@@ -477,6 +479,9 @@ private:
   }
 
   void lexImpl();
+
+  void lexImplByTriviaLexer();
+
   InFlightDiagnostic diagnose(const char *Loc, Diagnostic Diag);
   
   template<typename ...DiagArgTypes, typename ...ArgTypes>

--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -93,22 +93,6 @@ class Lexer {
   /// Pointer to the next not consumed character.
   const char *CurPtr;
 
-  /// @{
-  /// Members that are *not* permanent lexer state.  The values only make sense
-  /// during the lexImpl() invocation.  These variables are declared as members
-  /// rather than locals so that we don't have to thread them through to all
-  /// lexing helpers.
-
-  /// Points to the point in the source buffer where we started scanning for
-  /// the current token.  Thus, the range [LastCommentBlockStart, CurPtr)
-  /// covers all comments and whitespace that we skipped, and the token itself.
-  const char *LastCommentBlockStart = nullptr;
-
-  /// True if we have seen a comment while scanning for the current token.
-  bool SeenComment = false;
-
-  /// @}
-
   Token NextToken;
   
   /// \brief This is true if we're lexing a .sil file instead of a .swift


### PR DESCRIPTION
This PR refactor Lexer and simplify logic flow.

Currently, Lexer has many behavior variation and it makes logic complex.
There are 6 mode from 3 comment handling x 2 trivia handling.
So we need to care about some lexing logics orthogonality and dependency.

To resolve this, 3 modes without trivia are delegated to `WithTrivia` mode.
So we can stop to consider about `WithoutTrivia` behavior.

To give compatibility for these 3 modes to `WithTrivia` mode,
I add new `WithOnlyLeadingTrivia`.
This mode is almost same as `WithTrivia` except it does not lex trailing trivia.

And to make more stateless code,
I remove `LastCommentBlockStart` and `SeenComment` field.
Trivia information is sufficient to work what these fields did.

I think this PR drastically changes logic from before.
Please review carefully.
I checked that this passes validation-test locally.
