### PR TITLE
[Runtime] Don't use NULL as a conformance cache key.

### DIFF
--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -217,7 +217,9 @@ namespace {
     const ProtocolDescriptor *Proto;
 
     ConformanceCacheKey(const void *type, const ProtocolDescriptor *proto)
-      : Type(type), Proto(proto) {}
+        : Type(type), Proto(proto) {
+      assert(type);
+    }
   };
 
   struct ConformanceCacheEntry {
@@ -401,6 +403,15 @@ struct ConformanceCacheResult {
   }
 };
 
+/// Retrieve the type key from the given metadata, to be used when looking
+/// into the conformance cache.
+static const void *getConformanceCacheTypeKey(const Metadata *type) {
+  if (auto description = type->getTypeContextDescriptor())
+    return description;
+
+  return type;
+}
+
 /// Search for a witness table in the ConformanceCache.
 static
 ConformanceCacheResult
@@ -455,10 +466,10 @@ recur:
     // For generic and resilient types, nondependent conformances
     // are keyed by the nominal type descriptor rather than the
     // metadata, so try that.
-    const auto *description = type->getTypeContextDescriptor();
+    auto typeKey = getConformanceCacheTypeKey(type);
 
     // Hash and lookup the type-protocol pair in the cache.
-    if (auto *Value = C.findCached(description, protocol)) {
+    if (auto *Value = C.findCached(typeKey, protocol)) {
       if (Value->isSuccessful())
         return ConformanceCacheResult::cachedSuccess(Value->getWitnessTable());
 
@@ -505,7 +516,7 @@ bool isRelatedType(const Metadata *type, const void *candidate,
     if (!candidateIsMetadata) {
       const auto *description = type->getTypeContextDescriptor();
       auto candidateDescription =
-      static_cast<const TypeContextDescriptor *>(candidate);
+        static_cast<const TypeContextDescriptor *>(candidate);
       if (description && equalContexts(description, candidateDescription))
         return true;
     }

--- a/test/Interpreter/SDK/objc_dynamic_subclass_protocol_lookup.swift
+++ b/test/Interpreter/SDK/objc_dynamic_subclass_protocol_lookup.swift
@@ -1,0 +1,81 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+
+// REQUIRES: objc_interop
+
+import StdlibUnittest
+import Foundation
+
+protocol P { }
+protocol Q { }
+
+class Supermodel : NSObject { }
+
+class Model1 : Supermodel {
+  @objc dynamic var name = ""
+}
+
+class Model2 : NSObject, Q {
+  @objc dynamic var name = ""
+}
+
+
+extension Supermodel: P { }
+
+var kvoContext = 0
+
+class Observer: NSObject {
+  let model1 = Model1()
+  let model2 = Model2()
+
+  override init() {
+    super.init()
+    model1.addObserver(self, forKeyPath: "name", options: [], context: &kvoContext)
+    model2.addObserver(self, forKeyPath: "name", options: [], context: &kvoContext)
+  }
+
+  deinit {
+    model1.removeObserver(self, forKeyPath: "name")
+    model2.removeObserver(self, forKeyPath: "name")
+  }
+}
+
+let allTests = TestSuite("Dynamic subclasses conformance lookups")
+
+allTests.test("Lookup via dynamic subclasses") {
+  let observer = Observer()
+
+  // Check via "AnyObject"
+  let model1obj: AnyObject = observer.model1
+  let model2obj: AnyObject = observer.model2
+
+  expectTrue(model1obj is P)
+  expectFalse(model1obj is Q)
+  expectFalse(model2obj is P)
+  expectTrue(model2obj is Q)
+
+  expectNotNil(model1obj as? P)
+  expectNil(model1obj as? Q)
+  expectNil(model2obj as? P)
+  expectNotNil(model2obj as? Q)
+  
+  // Check via "Any"
+  let model1: Any = observer.model1
+  let model2: Any = observer.model2
+
+  expectTrue(model1 is P)
+  expectFalse(model1 is Q)
+  expectFalse(model2 is P)
+  expectTrue(model2 is Q)
+
+  expectNotNil(model1 as? P)
+  expectNil(model1 as? Q)
+  expectNil(model2 as? P)
+  expectNotNil(model2 as? Q)
+  
+  print(model1)
+  print(model2)
+}
+
+runAllTests()


### PR DESCRIPTION
The runtime hash table for protocol conformances is keyed by (type, protocol),
where the type can be either a type metadata pointer or a type context
descriptor. The latter is preferred for generic and resilient types, because
a single entry in the cache can work for any instantiation.

However, not all type metadata has a corresponding type context descriptor.
For example, a class that is dynamically subclassed by the Objective-C
runtime won't have a type context descriptor. In such cases, our key
into the hash table was (NULL, protocol) leading to mistaken
conformances for different dynamically-subclassed types.

Introduce a NULL check for the type of the hash table key, which
illustrates the problem in a number of existing tests that exercise
the runtime, and teach the runtime to use the type context descriptor
as the key only when it's non-NULL, falling back to the type metadata
pointer otherwise.

Fixes rdar://problem/38053213.
