### PR TITLE
[+0-all-args] Fix SILGenBuilder::createFunctionInputArgument(...) for…

### DIFF
--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -255,7 +255,20 @@ public:
   ManagedValue createLoadCopy(SILLocation loc, ManagedValue addr,
                               const TypeLowering &lowering);
 
-  ManagedValue createFunctionArgument(SILType type, ValueDecl *decl);
+  /// Create a SILArgument for an input parameter. Asserts if used to create a
+  /// function argument for an out parameter.
+  ManagedValue createInputFunctionArgument(SILType type, ValueDecl *decl);
+
+  /// Create a SILArgument for an input parameter. Uses \p loc to create any
+  /// copies necessary. Asserts if used to create a function argument for an out
+  /// parameter.
+  ///
+  /// *NOTE* This API purposely used an Optional<SILLocation> to distinguish
+  /// this API from the ValueDecl * API in C++. This is necessary since
+  /// ValueDecl * can implicitly convert to SILLocation. The optional forces the
+  /// user to be explicit that they want to use this API.
+  ManagedValue createInputFunctionArgument(SILType type,
+                                           Optional<SILLocation> loc);
 
   using SILBuilder::createEnum;
   ManagedValue createEnum(SILLocation loc, ManagedValue payload,

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -598,7 +598,7 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
                               ctor->hasThrows());
 
   SILType selfTy = getLoweredLoadableType(selfDecl->getType());
-  ManagedValue selfArg = B.createFunctionArgument(selfTy, selfDecl);
+  ManagedValue selfArg = B.createInputFunctionArgument(selfTy, selfDecl);
 
   if (!NeedsBoxForSelf) {
     SILLocation PrologueLoc(selfDecl);

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -785,40 +785,6 @@ ManagedValue Transform::transformTuple(ManagedValue inputTuple,
   return SGF.emitManagedRValueWithCleanup(outputTuple, outputTL);
 }
 
-static ManagedValue manageParam(SILGenFunction &SGF,
-                                SILLocation loc,
-                                SILValue paramValue,
-                                SILParameterInfo info) {
-  switch (info.getConvention()) {
-  case ParameterConvention::Indirect_In_Guaranteed:
-    if (SGF.silConv.useLoweredAddresses())
-      return ManagedValue::forUnmanaged(paramValue);
-    LLVM_FALLTHROUGH;
-  case ParameterConvention::Direct_Guaranteed:
-    return SGF.emitManagedBeginBorrow(loc, paramValue);
-  // Unowned parameters are only guaranteed at the instant of the call, so we
-  // must retain them even if we're in a context that can accept a +0 value.
-  case ParameterConvention::Direct_Unowned:
-    paramValue = SGF.getTypeLowering(paramValue->getType())
-        .emitCopyValue(SGF.B, loc, paramValue);
-    LLVM_FALLTHROUGH;
-  case ParameterConvention::Direct_Owned:
-    return SGF.emitManagedRValueWithCleanup(paramValue);
-
-  case ParameterConvention::Indirect_In:
-    if (SGF.silConv.useLoweredAddresses())
-      return SGF.emitManagedBufferWithCleanup(paramValue);
-    return SGF.emitManagedRValueWithCleanup(paramValue);
-
-  case ParameterConvention::Indirect_Inout:
-  case ParameterConvention::Indirect_InoutAliasable:
-    return ManagedValue::forLValue(paramValue);
-  case ParameterConvention::Indirect_In_Constant:
-    break;
-  }
-  llvm_unreachable("bad parameter convention");
-}
-
 void SILGenFunction::collectThunkParams(
     SILLocation loc, SmallVectorImpl<ManagedValue> &params,
     SmallVectorImpl<SILArgument *> *indirectResults) {
@@ -834,9 +800,7 @@ void SILGenFunction::collectThunkParams(
   auto paramTypes = F.getLoweredFunctionType()->getParameters();
   for (auto param : paramTypes) {
     auto paramTy = F.mapTypeIntoContext(F.getConventions().getSILType(param));
-    auto paramValue = F.begin()->createFunctionArgument(paramTy);
-    auto paramMV = manageParam(*this, loc, paramValue, param);
-    params.push_back(paramMV);
+    params.push_back(B.createInputFunctionArgument(paramTy, loc));
   }
 }
 

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -92,39 +92,6 @@ public:
     : SGF(sgf), parent(parent), loc(l), functionArgs(functionArgs),
       parameters(parameters) {}
 
-  ManagedValue getManagedValue(SILValue arg, CanType t,
-                               SILParameterInfo parameterInfo) const {
-    switch (parameterInfo.getConvention()) {
-    case ParameterConvention::Direct_Guaranteed:
-    case ParameterConvention::Indirect_In_Guaranteed:
-      // If we have a guaranteed parameter, it is passed in at +0, and its
-      // lifetime is guaranteed. We can potentially use the argument as-is
-      // if the parameter is bound as a 'let' without cleaning up.
-      return ManagedValue::forUnmanaged(arg);
-
-    case ParameterConvention::Direct_Unowned:
-      // An unowned parameter is passed at +0, like guaranteed, but it isn't
-      // kept alive by the caller, so we need to retain and manage it
-      // regardless.
-      return SGF.emitManagedRetain(loc, arg);
-
-    case ParameterConvention::Indirect_Inout:
-    case ParameterConvention::Indirect_InoutAliasable:
-      // An inout parameter is +0 and guaranteed, but represents an lvalue.
-      return ManagedValue::forLValue(arg);
-
-    case ParameterConvention::Direct_Owned:
-    case ParameterConvention::Indirect_In:
-      // An owned or 'in' parameter is passed in at +1. We can claim ownership
-      // of the parameter and clean it up when it goes out of scope.
-      return SGF.emitManagedRValueWithCleanup(arg);
-
-    case ParameterConvention::Indirect_In_Constant:
-      break;
-    }
-    llvm_unreachable("bad parameter convention");
-  }
-
   ManagedValue visitType(CanType t) {
     auto argType = SGF.getLoweredType(t);
     // Pop the next parameter info.
@@ -136,9 +103,8 @@ public:
                    SGF.getSILType(parameterInfo))
         && "argument does not have same type as specified by parameter info");
 
-    SILValue arg =
-        parent->createFunctionArgument(argType, loc.getAsASTNode<ValueDecl>());
-    ManagedValue mv = getManagedValue(arg, t, parameterInfo);
+    ManagedValue mv = SGF.B.createInputFunctionArgument(
+        argType, loc.getAsASTNode<ValueDecl>());
 
     // If the value is a (possibly optional) ObjC block passed into the entry
     // point of the function, then copy it so we can treat the value reliably

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -152,7 +152,7 @@ void SILGenFunction::emitCurryThunk(SILDeclRef thunk) {
     ->getInput();
   selfTy = vd->getInnermostDeclContext()->mapTypeIntoContext(selfTy);
   ManagedValue selfArg =
-      B.createFunctionArgument(getLoweredType(selfTy), nullptr);
+    B.createInputFunctionArgument(getLoweredType(selfTy), SILLocation(vd));
 
   // Forward substitutions.
   auto subs = F.getForwardingSubstitutions();


### PR DESCRIPTION
… in_guaranteed parameters

This method was not distinguishing in between in_guaranteed and in
parameters. This would cause the curry thunk where this is used to not copy
in_guaranteed parameters before passing in the parameter to the
partial_apply. This can not affect +1 code since the curry thunk will always
have self at +1.

I also refactored code in:

1. SILGenPoly.
2. SILGenProlog.
3. SILGenConstructor.

to use this function instead of their own reimplementations of the same thing.

This should be NFC for +1 code and is tested by test updates when +0 is enabled.

rdar://34222540