### PR TITLE
Add a benchmark cmake flag SWIFT_RUNTIME_ENABLE_LEAK_CHECKER.

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -229,6 +229,14 @@ endif()
 set(SWIFT_BENCHMARK_EXTRA_FLAGS "" CACHE STRING
     "Extra options to pass to swiftc when building the benchmarks")
 
+if (SWIFT_BENCHMARK_BUILT_STANDALONE)
+  # This option's value must match the value of the same option used when
+  # building the swift runtime.
+  option(SWIFT_RUNTIME_ENABLE_LEAK_CHECKER
+    "Should the runtime be built with support for non-thread-safe leak detecting entrypoints"
+    FALSE)
+endif()
+
 set(SWIFT_BENCHMARK_NUM_O_ITERATIONS "" CACHE STRING
     "Number of iterations to perform when running -O benchmarks via cmake")
 set(SWIFT_BENCHMARK_NUM_ONONE_ITERATIONS "" CACHE STRING


### PR DESCRIPTION
This is necessary to build standalone benchmarks with leak checking
enabled. This is useful if you want to debug an internal benchmark failure using
a public swift.
