### PR TITLE
Batch mode formation minor fixes

### DIFF
--- a/lib/Driver/ToolChain.cpp
+++ b/lib/Driver/ToolChain.cpp
@@ -287,14 +287,6 @@ std::unique_ptr<Job>
 ToolChain::constructBatchJob(ArrayRef<const Job *> jobs,
                              Compilation &C) const
 {
-#ifndef NDEBUG
-  // Verify that the equivalence relation on the jobs also holds pairwise.
-  for (auto *A : jobs) {
-    for (auto *B : jobs) {
-      assert(jobsAreBatchCombinable(C, A, B));
-    }
-  }
-#endif
   if (jobs.empty())
     return nullptr;
 

--- a/lib/Driver/ToolChain.cpp
+++ b/lib/Driver/ToolChain.cpp
@@ -280,6 +280,35 @@ mergeBatchInputs(ArrayRef<const Job *> jobs,
   return false;
 }
 
+/// Debugging only: return whether the set of \p jobs is an ordered subsequence
+/// of the sequence of top-level input files in the \c Compilation \p C.
+static bool
+jobsAreSubsequenceOfCompilationInputs(ArrayRef<const Job *> jobs,
+                                      Compilation &C) {
+  llvm::SmallVector<const Job *, 16> sortedJobs;
+  llvm::StringMap<const Job *> jobsByInput;
+  for (const Job *J : jobs) {
+    const CompileJobAction *CJA = cast<CompileJobAction>(&J->getSource());
+    const InputAction* IA = findSingleSwiftInput(CJA);
+    auto R = jobsByInput.insert(std::make_pair(IA->getInputArg().getValue(),
+                                               J));
+    assert(R.second);
+  }
+  for (const InputPair &P : C.getInputFiles()) {
+    auto I = jobsByInput.find(P.second->getValue());
+    if (I != jobsByInput.end()) {
+      sortedJobs.push_back(I->second);
+    }
+  }
+  if (sortedJobs.size() != jobs.size())
+    return false;
+  for (size_t i = 0; i < sortedJobs.size(); ++i) {
+    if (sortedJobs[i] != jobs[i])
+      return false;
+  }
+  return true;
+}
+
 /// Construct a \c BatchJob by merging the constituent \p jobs' CommandOutput,
 /// input \c Job and \c Action members. Call through to \c constructInvocation
 /// on \p BatchJob, to build the \c InvocationInfo.
@@ -289,6 +318,8 @@ ToolChain::constructBatchJob(ArrayRef<const Job *> jobs,
 {
   if (jobs.empty())
     return nullptr;
+
+  assert(jobsAreSubsequenceOfCompilationInputs(jobs, C));
 
   // Synthetic OutputInfo is a slightly-modified version of the initial
   // compilation's OI.

--- a/test/Driver/batch_mode_aux_file_order.swift
+++ b/test/Driver/batch_mode_aux_file_order.swift
@@ -1,0 +1,20 @@
+// When multiple additional-outputs on the same command-line are no longer
+// supported (i.e. when we've moved to mandatory use of output file maps for
+// communicating multiple additional-outputs to frontends) this test will no
+// longer make sense, and should be removed.
+//
+// RUN: %empty-directory(%t)
+// RUN: touch %t/file-01.swift %t/file-02.swift %t/file-03.swift %t/file-04.swift %t/file-05.swift
+// RUN: touch %t/file-06.swift %t/file-07.swift %t/file-08.swift %t/file-09.swift
+//
+// RUN: %swiftc_driver -enable-batch-mode -driver-batch-seed 1 -driver-print-jobs -driver-skip-execution -j 3 -emit-module -module-name foo %t/file-01.swift %t/file-02.swift %t/file-03.swift %t/file-04.swift %t/file-05.swift %t/file-06.swift %t/file-07.swift %t/file-08.swift %t/file-09.swift >%t/out.txt
+// RUN: %FileCheck %s <%t/out.txt
+//
+// Each batch should get 3 primaries; check that each has 3 modules _in the same numeric order_.
+//
+// CHECK: {{.*}}/swift {{.*}}-primary-file {{[^ ]*}}/file-[[A1:[0-9]+]].swift {{.*}}-primary-file {{[^ ]*}}/file-[[A2:[0-9]+]].swift {{.*}}-primary-file {{[^ ]*}}/file-[[A3:[0-9]+]].swift
+// CHECK-SAME: -o {{.*}}/file-[[A1]]-{{[a-z0-9]+}}.swiftmodule -o {{.*}}/file-[[A2]]-{{[a-z0-9]+}}.swiftmodule -o {{.*}}/file-[[A3]]-{{[a-z0-9]+}}.swiftmodule
+// CHECK: {{.*}}/swift {{.*}}-primary-file {{[^ ]*}}/file-[[B1:[0-9]+]].swift {{.*}}-primary-file {{[^ ]*}}/file-[[B2:[0-9]+]].swift {{.*}}-primary-file {{[^ ]*}}/file-[[B3:[0-9]+]].swift
+// CHECK-SAME: -o {{.*}}/file-[[B1]]-{{[a-z0-9]+}}.swiftmodule -o {{.*}}/file-[[B2]]-{{[a-z0-9]+}}.swiftmodule -o {{.*}}/file-[[B3]]-{{[a-z0-9]+}}.swiftmodule
+// CHECK: {{.*}}/swift {{.*}}-primary-file {{[^ ]*}}/file-[[C1:[0-9]+]].swift {{.*}}-primary-file {{[^ ]*}}/file-[[C2:[0-9]+]].swift {{.*}}-primary-file {{[^ ]*}}/file-[[C3:[0-9]+]].swift
+// CHECK-SAME: -o {{.*}}/file-[[C1]]-{{[a-z0-9]+}}.swiftmodule -o {{.*}}/file-[[C2]]-{{[a-z0-9]+}}.swiftmodule -o {{.*}}/file-[[C3]]-{{[a-z0-9]+}}.swiftmodule


### PR DESCRIPTION
This fixes a couple minor issues that arose while testing batch mode. Neither is critical to correct functioning, they just help testing.

The first eliminates a quadratic assert, which I incorrectly assumed was cheaper than a path I thought was already occurring at worse-than-quadratic complexity (relative to batch size). This is not true and to keep things moving quickly on large batches I believe it's not worth making this assertion; it doesn't check a condition that's very plausible anyways.

The second fixes a _potential_ mismatch between the emitted order of primary-file arguments and additional output arguments passed to the frontend. This doesn't happen in normal runs, but when shuffling the batch constituents with -driver-batch-seed -- as happens when doing randomized testing -- it does. And in general it's a condition we ought to be ensuring regardless (at least until we do away with positionally pairing-up primaries and their additionals on the frontend command line).
