### PR TITLE
[+0-all-args] For staging in purposes, add in a lit feature to distin…

### DIFF
--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -89,6 +89,11 @@ config.available_features.add("CMAKE_GENERATOR=@CMAKE_GENERATOR@")
 if "@SWIFT_ENABLE_SOURCEKIT_TESTS@" == "TRUE":
     config.available_features.add('sourcekit')
 
+if "@SWIFT_ENABLE_GUARANTEED_NORMAL_ARGUMENTS@" == "FALSE":
+   config.available_features.add('plus_one_runtime')
+else:
+   config.available_features.add('plus_zero_runtime')
+
 # Let the main config do the real work.
 if config.test_exec_root is None:
     config.test_exec_root = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
…guish in between tests that must run with a +0/+1 runtime.

This will enable me to have a small commit to enable +0 and the ability to
easily revert if needed. It makes sense to do this since +0 is a disruptive
change and the number of tests modified is not /that/ big (i.e. ~200).

This shouldn't last for more than a week or two.

rdar://34222540