### PR TITLE
[+0-all-args] Scope curry thunk emission.

### DIFF
--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -148,6 +148,8 @@ void SILGenFunction::emitCurryThunk(SILDeclRef thunk) {
     (void) fd;
   }
 
+  Scope S(*this, vd);
+
   auto selfTy = vd->getInterfaceType()->castTo<AnyFunctionType>()
     ->getInput();
   selfTy = vd->getInnermostDeclContext()->mapTypeIntoContext(selfTy);
@@ -185,6 +187,7 @@ void SILGenFunction::emitCurryThunk(SILDeclRef thunk) {
           emitCanonicalFunctionThunk(vd, toClosure, closureFnTy, resultFnTy);
     }
   }
+  toClosure = S.popPreservingValue(toClosure);
   B.createReturn(ImplicitReturnLocation::getImplicitReturnLoc(vd), toClosure);
 }
 


### PR DESCRIPTION
Otherwise when we have to copy an @in_guaranteed argument to pass into a
partial_apply, the alloc_stack associated with the copy is never cleaned up.
=><=.

AFAIKT this can not happen with the +1 runtime.

rdar://34222540
