### PR TITLE
Make sure open existential ref only takes objects.

### DIFF
--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -1762,6 +1762,8 @@ OpenExistentialAddrInst::OpenExistentialAddrInst(
 OpenExistentialRefInst::OpenExistentialRefInst(
     SILDebugLocation DebugLoc, SILValue Operand, SILType Ty)
     : UnaryInstructionBase(DebugLoc, Operand, Ty) {
+  assert(Operand->getType().isObject() && "Operand must be an object.");
+  assert(Ty.isObject() && "Result type must be an object type.");
 }
 
 OpenExistentialMetatypeInst::OpenExistentialMetatypeInst(


### PR DESCRIPTION
We already have this assert in the verifier, but by placing the assert here we
catch the error right where the error occurs instead of later. This just lowers
triage time for such errors.
