### PR TITLE
[WIP] SwiftSyntax: Implement APIs for Syntax nodes to calculate absolute positions.

### DIFF
--- a/test/SwiftSyntax/AbsolutePosition.swift
+++ b/test/SwiftSyntax/AbsolutePosition.swift
@@ -1,0 +1,79 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+// REQUIRES: objc_interop
+
+import StdlibUnittest
+import Foundation
+import SwiftSyntax
+import SwiftLang
+
+func getInput(_ file: String) -> URL {
+  var result = URL(fileURLWithPath: #file)
+  result.deleteLastPathComponent()
+  result.appendPathComponent("Inputs")
+  result.appendPathComponent(file)
+  return result
+}
+
+
+class FuncRenamer: SyntaxRewriter {
+  override func visit(_ node: FunctionDeclSyntax) ->DeclSyntax {
+    return (super.visit(node) as! FunctionDeclSyntax).withIdentifier(
+      SyntaxFactory.makeIdentifier("anotherName"))
+  }
+}
+
+var PositionTests = TestSuite("AbsolutePositionTests")
+
+PositionTests.test("Visitor") {
+  expectDoesNotThrow({
+    let content = try SwiftLang.parse(getInput("visitor.swift"))
+    let source = try String(contentsOf: getInput("visitor.swift"))
+    let parsed = try SourceFileSyntax.decodeSourceFileSyntax(content)
+    expectEqual(parsed.eofToken.positionAfterSkippingLeadingTrivia.offset,
+                source.count)
+    expectEqual(parsed.byteSize, source.count)
+  })
+}
+
+PositionTests.test("Closure") {
+  expectDoesNotThrow({
+    let content = try SwiftLang.parse(getInput("closure.swift"))
+    let source = try String(contentsOf: getInput("closure.swift"))
+    let parsed = try SourceFileSyntax.decodeSourceFileSyntax(content)
+    expectEqual(parsed.eofToken.positionAfterSkippingLeadingTrivia.offset,
+                source.count)
+    expectEqual(parsed.byteSize, source.count)
+  })
+}
+
+PositionTests.test("Rename") {
+  expectDoesNotThrow({
+    let content = try SwiftLang.parse(getInput("visitor.swift"))
+    let source = try String(contentsOf: getInput("visitor.swift"))
+    let parsed = try SourceFileSyntax.decodeSourceFileSyntax(content)
+    let renamed = FuncRenamer().visit(parsed) as! SourceFileSyntax
+    let renamedSource = renamed.description
+    expectEqual(renamed.eofToken.positionAfterSkippingLeadingTrivia.offset,
+                renamedSource.count)
+    expectEqual(renamed.byteSize, renamedSource.count)
+  })
+}
+
+PositionTests.test("CurrentFile") {
+  expectDoesNotThrow({
+    let content = try SwiftLang.parse(URL(fileURLWithPath: #file))
+    let parsed = try SourceFileSyntax.decodeSourceFileSyntax(content)
+    class Visitor: SyntaxVisitor {
+      override func visitPre(_ node: Syntax) {
+        _ = node.position
+        _ = node.byteSize
+        _ = node.positionAfterSkippingLeadingTrivia
+      }
+    }
+    Visitor().visit(parsed)
+  })
+}
+
+runAllTests()

--- a/tools/SwiftSyntax/RawSyntax.swift
+++ b/tools/SwiftSyntax/RawSyntax.swift
@@ -232,4 +232,13 @@ extension RawSyntax {
       return true
     }
   }
+
+  var isSourceFile: Bool {
+    switch self {
+    case .node(let kind, _, _):
+      return kind == SyntaxKind.sourceFile
+    default:
+      return false
+    }
+  }
 }

--- a/tools/SwiftSyntax/RawSyntax.swift
+++ b/tools/SwiftSyntax/RawSyntax.swift
@@ -193,3 +193,43 @@ extension RawSyntax: TextOutputStreamable {
     }
   }
 }
+
+extension RawSyntax {
+  func accumulateAbsolutePosition(_ pos: AbsolutePosition) {
+    switch self {
+    case .node(_, let layout, _):
+      for child in layout {
+        guard let child = child else { continue }
+        child.accumulateAbsolutePosition(pos)
+      }
+    case let .token(kind, leadingTrivia, trailingTrivia, presence):
+      guard case .present = presence else { return }
+      for piece in leadingTrivia {
+        piece.accumulateAbsolutePosition(pos)
+      }
+      pos.add(text: kind.text)
+      for piece in trailingTrivia {
+        piece.accumulateAbsolutePosition(pos)
+      }
+    }
+  }
+
+  func accumulateLeadingTrivia(_ pos: AbsolutePosition) -> Bool {
+    switch self {
+    case .node(_, let layout, _):
+      for child in layout {
+        guard let child = child else { continue }
+        if child.accumulateLeadingTrivia(pos) {
+          return true
+        }
+      }
+      return false
+    case let .token(_, leadingTrivia, _, presence):
+      guard case .present = presence else { return false }
+      for piece in leadingTrivia {
+        piece.accumulateAbsolutePosition(pos)
+      }
+      return true
+    }
+  }
+}

--- a/tools/SwiftSyntax/Syntax.swift
+++ b/tools/SwiftSyntax/Syntax.swift
@@ -120,6 +120,24 @@ extension Syntax {
     return data.indexInParent
   }
 
+  /// The absolute position of the starting point this node. If the first token
+  /// is with leading trivia, the position points to the start of the leading
+  /// trivia.
+  public var position: AbsolutePosition {
+    return data.position
+  }
+
+  /// The absolute position of the starting point of this node, skipping any
+  /// leading trivia attached to the first token syntax.
+  public var positionAfterSkippingLeadingTrivia: AbsolutePosition {
+    return data.positionAfterSkippingLeadingTrivia
+  }
+
+  /// The textual byte length of this node including leading and trailing trivia.
+  public var byteSize: Int {
+    return data.byteSize
+  }
+
   /// The root of the tree in which this node resides.
   public var root: Syntax {
     return makeSyntax(root: _root,  data: _root)

--- a/tools/SwiftSyntax/Trivia.swift.gyb
+++ b/tools/SwiftSyntax/Trivia.swift.gyb
@@ -256,3 +256,22 @@ extension Trivia: ExpressibleByArrayLiteral {
 public func +(lhs: Trivia, rhs: Trivia) -> Trivia {
   return Trivia(pieces: lhs.pieces + rhs.pieces)
 }
+
+extension TriviaPiece {
+  func accumulateAbsolutePosition(_ pos: AbsolutePosition) {
+    switch self {
+% for trivia in TRIVIAS:
+%   if trivia.is_new_line:
+    case let .${trivia.lower_name}s(count):
+      pos.add(lines: count, size: ${trivia.characters_len()})
+%   elif trivia.is_collection():
+    case let .${trivia.lower_name}s(count):
+      pos.add(columns: count)
+%   else:
+    case let .${trivia.lower_name}(text):
+      pos.add(text: text)
+%   end
+% end
+  }
+  }
+}


### PR DESCRIPTION
Syntax nodes are designed as reusable blocks to construct Swift source
code. For this reason, we don't track absolute position in each node;
instead, the absolute position should be calculated on the fly when
needed. We recently found absolute positions are useful to bridge with
sourcekitd, which typically speaks in the language of line, column and
offset. Therefore, this patch tries to add a computed
property on SyntaxNode to get its absolute position.

To compute the absolute position of a SyntaxNode from scratch requires tree traversal. 
However, getting the absolute position from these added APIs doesn't necessarily 
mean we'll traverse since SyntaxData will actively cache the computed position. 
Also, since we recursively compute the absolute position, all the position caches 
for a SyntaxNode's previous siblings and ancestors will be populated as well during 
the calculation of this SyntaxNode. 




