### PR TITLE
When assigning into memory via builtin assign, be sure that we store …

### DIFF
--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -268,7 +268,7 @@ static ManagedValue emitBuiltinAssign(SILGenFunction &SGF,
   // Build the value to be assigned, reconstructing tuples if needed.
   auto src = RValue(SGF, args.slice(0, args.size() - 1), assignFormalType);
   
-  std::move(src).assignInto(SGF, loc, addr);
+  std::move(src).ensurePlusOne(SGF, loc).assignInto(SGF, loc, addr);
 
   return ManagedValue::forUnmanaged(SGF.emitEmptyTuple(loc));
 }


### PR DESCRIPTION
…a +1 value.

NOTE:

1. This can not happen today with the +1 runtime.
2. This is tested by an updated builtins.swift test for +0 that I am going to
commit in a little bit.
3. We immediately forward the value when we put it into memory.

rdar://34222540
