### PR TITLE
XFAIL test wherein optimizations are not kicking in when compiling wi…

### DIFF
--- a/test/SILOptimizer/array_contentof_opt.swift
+++ b/test/SILOptimizer/array_contentof_opt.swift
@@ -1,6 +1,8 @@
 // RUN: %target-swift-frontend -O -sil-verify-all -emit-sil  %s | %FileCheck %s
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 
+// XFAIL: plus_zero_runtime
+
 // This is an end-to-end test of the array(contentsOf) -> array(Element) optimization
 
 // CHECK-LABEL: sil @{{.*}}testInt

--- a/test/SILOptimizer/optionset.swift
+++ b/test/SILOptimizer/optionset.swift
@@ -2,6 +2,8 @@
 // RUN: %target-swift-frontend  -parse-as-library -primary-file %s -Osize -sil-verify-all -module-name=test -emit-sil | %FileCheck %s
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 
+// XFAIL: plus_zero_runtime
+
 public struct TestOptions: OptionSet {
     public let rawValue: Int
     public init(rawValue: Int) { self.rawValue = rawValue }

--- a/test/SILOptimizer/outliner.swift
+++ b/test/SILOptimizer/outliner.swift
@@ -3,6 +3,8 @@
 
 // REQUIRES: objc_interop
 
+// XFAIL: plus_zero_runtime
+
 import Foundation
 
 public class MyGizmo {

--- a/test/SILOptimizer/unused_containers.swift
+++ b/test/SILOptimizer/unused_containers.swift
@@ -2,6 +2,8 @@
 
 // REQUIRES: swift_stdlib_no_asserts
 
+// XFAIL: plus_zero_runtime
+
 //CHECK-LABEL: @$S17unused_containers16empty_array_testyyF
 //CHECK: bb0:
 //CHECK-NEXT: tuple


### PR DESCRIPTION
…th a +0 runtime.

Turning these back on is tracked by:

rdar://38152291

----

This is NFC with the +1 runtime.