### PR TITLE
[+0-normal-args] Be sure if we are forwarding arguments into memory, …

### DIFF
--- a/lib/SILGen/ArgumentSource.cpp
+++ b/lib/SILGen/ArgumentSource.cpp
@@ -236,7 +236,7 @@ void ArgumentSource::forwardInto(SILGenFunction &SGF, Initialization *dest) && {
     llvm_unreachable("cannot forward an l-value");
   case Kind::RValue: {
     auto loc = getKnownRValueLocation();
-    std::move(*this).asKnownRValue(SGF).forwardInto(SGF, loc, dest);
+    std::move(*this).asKnownRValue(SGF).ensurePlusOne(SGF, loc).forwardInto(SGF, loc, dest);
     return;
   }
   case Kind::Expr: {
@@ -248,7 +248,7 @@ void ArgumentSource::forwardInto(SILGenFunction &SGF, Initialization *dest) && {
     auto loc = getKnownTupleLocation();
     auto rvalue = std::move(*this).getKnownTupleAsRValue(SGF, SGFContext(dest));
     if (!rvalue.isInContext())
-      std::move(rvalue).forwardInto(SGF, loc, dest);
+      std::move(rvalue).ensurePlusOne(SGF, loc).forwardInto(SGF, loc, dest);
     return;
   }
   }


### PR DESCRIPTION
…that we do it at +1.

This can only happen when +0 is enabled. The reason why is that guaranteed self
is immutable so can not be passed inout without going through a var. There are
no other cases I can think of where an ArgumentSource will put self into
memory.

This is tested by the updated SILGen +0 tests.

rdar://34222540
