### PR TITLE
os: Fix os_log() handling of '%.*P'

### DIFF
--- a/stdlib/public/SDK/os/os_log.m
+++ b/stdlib/public/SDK/os/os_log.m
@@ -149,7 +149,7 @@ _os_log_encode(char buf[OS_LOG_FMT_BUF_SIZE], const char *format, va_list args, 
               percent++;
             } else {
               while (isdigit(percent[1])) {
-                precision = 10 * precision + (ch - '0');
+                precision = 10 * precision + (percent[1] - '0');
                 percent++;
               }
               if (precision > 1024) precision = 1024;
@@ -219,9 +219,9 @@ _os_log_encode(char buf[OS_LOG_FMT_BUF_SIZE], const char *format, va_list args, 
             if (precision > 0) { // only encode a pointer if we have been given a length
               hdr.hdr_flags |= OSLF_HDR_FLAG_HAS_NON_SCALAR;
               cmd.cmd_type = OSLF_CMD_TYPE_DATA;
-              cmd.cmd_size = precision;
+              cmd.cmd_size = sizeof(void *);
               void *p = va_arg(args, void *);
-              _os_log_encode_arg(ob, &cmd, p);
+              _os_log_encode_arg(ob, &cmd, &p);
               hdr.hdr_cmd_cnt++;
               precision = 0;
               done = true;

--- a/test/stdlib/os.swift
+++ b/test/stdlib/os.swift
@@ -16,6 +16,16 @@ if #available(OSX 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
     os_log("test: %d", 42)
     os_log("test2: %@", "test")
   }
+
+  osAPI.test("logData") {
+    let data = "hello logging world".data(using: .utf8)!
+
+    data.withUnsafeBytes { (bytes: UnsafePointer<CChar>) in
+      os_log("%.3P", OpaquePointer(bytes))
+      os_log("%.10P", OpaquePointer(bytes))
+      os_log("%.*P", OpaquePointer(bytes))
+    }
+  }
   osAPI.test("newLog") {
     let newLog = OSLog(subsystem: "com.apple.Swift", category: "Test")
     os_log("test", log: newLog)


### PR DESCRIPTION
- When a count was part of the format string, we looked at the
  wrong character when forming the count.

- The OSLF_CMD_TYPE_DATA command type expects a pointer preceded
  by a OSLF_CMD_TYPE_COUNT command, not 'count' bytes inline.

Fixes <rdar://problem/38080623>.