### PR TITLE
(WIP) Type metadata access by mangled name

### DIFF
--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -1364,6 +1364,12 @@ FUNCTION(VerifyTypeLayoutAttribute, _swift_debug_verifyTypeLayoutAttribute,
          ARGS(TypeMetadataPtrTy, Int8PtrTy, Int8PtrTy, SizeTy, Int8PtrTy),
          ATTRS(NoUnwind))
 
+FUNCTION(GetConcreteTypeByMangledName, swift_getConcreteTypeByMangledName,
+         SwiftCC,
+         RETURNS(TypeMetadataPtrTy),
+         ARGS(Int8PtrTy),
+         ATTRS(NoUnwind, ArgMemOnly))
+
 #undef RETURNS
 #undef ARGS
 #undef ATTRS

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1155,7 +1155,11 @@ void IRGenerator::emitLazyDefinitions() {
         // Make sure that all of the field type metadata is forced,
         // otherwise there might be a problem when fields are accessed
         // through reflection.
-        (void)irgen::getOrCreateTypeMetadataAccessFunction(IGM, fieldType);
+        // TODO: We really ony care about the side effect of forcing metadata
+        // here, not the accessor function (which is going to be unused if we
+        // didn't emit it already). We should have a type visitor for this case.
+#warning "todo"
+        //(void)irgen::getOrCreateTypeMetadataAccessFunction(IGM, fieldType);
       }
     }
 

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -3084,10 +3084,10 @@ IRGenModule::getAddrOfGenericTypeMetadataAccessFunction(
 /// implementation detail of type metadata access functions.
 llvm::Constant *
 IRGenModule::getAddrOfTypeMetadataLazyCacheVariable(CanType type,
-                                              ForDefinition_t forDefinition) {
+                                                    ConstantInit definition) {
   assert(!type->hasArchetype() && !type->hasTypeParameter());
   LinkEntity entity = LinkEntity::forTypeMetadataLazyCacheVariable(type);
-  return getAddrOfLLVMVariable(entity, getPointerAlignment(), forDefinition,
+  return getAddrOfLLVMVariable(entity, getPointerAlignment(), definition,
                                TypeMetadataPtrTy, DebugTypeInfo());
 }
 

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -302,7 +302,7 @@ namespace irgen {
 
     /// There is no unique accessor function for the given type metadata, but
     /// one should be made automatically.
-    NonUniqueAccessor
+    NonUniqueAccessor,
   };
 
   /// Is it basically trivial to access the given metadata?  If so, we don't

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -447,6 +447,7 @@ namespace RuntimeConstants {
   const auto NoUnwind = llvm::Attribute::NoUnwind;
   const auto ZExt = llvm::Attribute::ZExt;
   const auto FirstParamReturned = llvm::Attribute::Returned;
+  const auto ArgMemOnly = llvm::Attribute::ArgMemOnly;
 } // namespace RuntimeConstants
 
 // We don't use enough attributes to justify generalizing the

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1157,7 +1157,7 @@ public:
                                              ArrayRef<llvm::Type *> genericArgs,
                                              ForDefinition_t forDefinition);
   llvm::Constant *getAddrOfTypeMetadataLazyCacheVariable(CanType type,
-                                               ForDefinition_t forDefinition);
+                                      ConstantInit definition = ConstantInit());
   llvm::Constant *getAddrOfForeignTypeMetadataCandidate(CanType concreteType);
 
   /// Determine whether the given type requires foreign type metadata.

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1048,6 +1048,17 @@ swift_getTypeByMangledName(const char *typeNameStart, size_t typeNameLength,
     });
 }
 
+SWIFT_CC(swift) SWIFT_RUNTIME_EXPORT
+const Metadata * _Nullable
+swift_getConcreteTypeByMangledName(const char *typeNameStart) {
+  auto typeName = makeSymbolicMangledNameStringRef(typeNameStart);
+  
+  return _getTypeByMangledName(typeName,
+    [&](unsigned depth, unsigned index) -> const Metadata * {
+      return nullptr;
+    });
+}
+
 void swift::swift_getFieldAt(
     const Metadata *base, unsigned index,
     std::function<void(llvm::StringRef name, FieldType fieldInfo)>


### PR DESCRIPTION
Experiment with accessing concrete types with complex instantiation sequences by mangling their names and interpreting with `getTypeByMangledName` instead of with open-coded accessors. In my experiments this saves about 128KB of code size in the dylibs.