### PR TITLE
Fix bug on OutputFileMap parser when parsing beyond JSON.

### DIFF
--- a/lib/Driver/OutputFileMap.cpp
+++ b/lib/Driver/OutputFileMap.cpp
@@ -144,7 +144,7 @@ bool OutputFileMap::parse(std::unique_ptr<llvm::MemoryBuffer> Buffer,
     return StringRef(PathStorage.data(), PathStorage.size());
   };
 
-  for (auto Pair : *Map) {
+  for (auto &Pair : *Map) {
     llvm::yaml::Node *Key = Pair.getKey();
     llvm::yaml::Node *Value = Pair.getValue();
 
@@ -165,7 +165,7 @@ bool OutputFileMap::parse(std::unique_ptr<llvm::MemoryBuffer> Buffer,
 
     TypeToPathMap OutputMap;
 
-    for (auto OutputPair : *OutputMapNode) {
+    for (auto &OutputPair : *OutputMapNode) {
       llvm::yaml::Node *Key = OutputPair.getKey();
       llvm::yaml::Node *Value = OutputPair.getValue();
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fixes a bug that caused the parser to skip every other line.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->