### PR TITLE
[SwiftSyntax] Make traits conform to Syntax

### DIFF
--- a/tools/SwiftSyntax/SyntaxNodes.swift.gyb
+++ b/tools/SwiftSyntax/SyntaxNodes.swift.gyb
@@ -196,7 +196,7 @@ public struct ${node.name}: ${base_type}, _SyntaxBase, Hashable {
 % end
 
 % for trait in TRAITS:
-public protocol ${trait.trait_name}Syntax {
+public protocol ${trait.trait_name}Syntax: Syntax {
 % for child in trait.children:
 %   ret_type = child.type_name
 %   if child.is_optional:


### PR DESCRIPTION
Previously, traits didn't require conformance to Syntax, so you couldn't return a `ParenthesizedSyntax` from a visitor that returned `Syntax`. This just ensures all the traits are also `Syntax`.