### PR TITLE
[GSB] Implement minimization of the term-rewriting system

### DIFF
--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -447,7 +447,9 @@ private:
 
   /// Add a rewrite rule that makes \c otherPA a part of the given equivalence
   /// class.
-  void addSameTypeRewriteRule(EquivalenceClass *equivClass,
+  ///
+  /// \returns true if a new rewrite rule was added, and false otherwise.
+  bool addSameTypeRewriteRule(EquivalenceClass *equivClass,
                               PotentialArchetype *otherPA);
 
   /// \brief Add a new conformance requirement specifying that the given

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4143,7 +4143,9 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
         // ... from the same module as the protocol.
         if (type->getModuleContext() != proto->getModuleContext()) continue;
 
-        // Or is constrained.
+        // Ignore types defined in constrained extensions; their equivalence
+        // to the associated type would have to be conditional, which we cannot
+        // model.
         if (auto ext = dyn_cast<ExtensionDecl>(type->getDeclContext())) {
           if (ext->isConstrainedExtension()) continue;
         }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2289,9 +2289,6 @@ Type EquivalenceClass::getAnchor(
     return substAnchor();
   }
 
-  // Always work with a minimized term-rewriting system.
-  builder.Impl->minimizeRewriteTree(builder);
-
   // Form the anchor.
   bool updatedAnchor = false;
   for (auto member : members) {

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -289,7 +289,7 @@ public:
   /// \param path The path to match.
   /// \param prefixLength The length of the prefix leading up to \c path.
   Optional<std::pair<unsigned, RewritePath>>
-  bestMatch(GenericParamKey base, RelativeRewritePath path,
+  bestRewritePath(GenericParamKey base, RelativeRewritePath path,
             unsigned prefixLength);
 
   /// Merge the given rewrite tree into \c other.
@@ -3293,7 +3293,7 @@ void RewriteTreeNode::enumerateRewritePathsImpl(
 }
 
 Optional<std::pair<unsigned, RewritePath>>
-RewriteTreeNode::bestMatch(GenericParamKey base, RelativeRewritePath path,
+RewriteTreeNode::bestRewritePath(GenericParamKey base, RelativeRewritePath path,
                            unsigned prefixLength) {
   Optional<std::pair<unsigned, RewritePath>> best;
   unsigned bestAdjustedLength = 0;
@@ -3525,7 +3525,7 @@ Type GenericSignatureBuilder::getCanonicalTypeParameter(Type type) {
     if (auto rootNode = Impl->getRewriteTreeRootIfPresent(equivClass)) {
       // Find the best rewrite rule for the path starting at startIndex.
       auto match =
-        rootNode->bestMatch(genericParamType,
+        rootNode->bestRewritePath(genericParamType,
                             llvm::makeArrayRef(path).slice(startIndex),
                             startIndex);
 


### PR DESCRIPTION
Minimization of the term-rewriting system in the `GenericSignatureBuilder` involves evaluating each rule to determine whether it can be simplified in some manner:

* If it's right-hand side can be simplified further (e.g., by other rules), perform that simplification and update the right-hand-side with the simplified form. In some cases, this could match the left-hand side and the rule can be removed.
* If it's left-hand side can be simplified to the right-hand side *ignoring the rule itself*, then the rule is redundant and can removed.

The minimization code is currently unused, because it's not profitable to enable it yet (60% slower type-checking of the standard library if we turn it on eagerly). It is expected that we'll enable some form of this once it's able to eliminate other work (e.g., same-type constraint canonicalization), which is still in-progress.