### PR TITLE
[+0-all-args] Swift expects the returned object from bridgeErrorToNSE…

### DIFF
--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -409,8 +409,10 @@ swift::_swift_stdlib_bridgeErrorToNSError(SwiftError *errorObject) {
   // initialization of the object happens-before the domain initialization so
   // that the domain can be used alone as a flag for the initialization of the
   // object.
-  if (errorObject->domain.load(std::memory_order_acquire))
+  if (errorObject->domain.load(std::memory_order_acquire)) {
+    SWIFT_CC_PLUSZERO_GUARD([ns retain]);
     return ns;
+  }
 
   // Otherwise, calculate the domain, code, and user info, and
   // initialize the NSError.
@@ -451,6 +453,7 @@ swift::_swift_stdlib_bridgeErrorToNSError(SwiftError *errorObject) {
                                                    std::memory_order_acq_rel))
     objc_release(domain);
 
+  SWIFT_CC_PLUSZERO_GUARD([ns retain]);
   return ns;
 }
 


### PR DESCRIPTION
…rror to be at +1 even if the bridge is a no-op.

rdar://34222540

----

This can only affect the +0 runtime due to the plus zero guards.