### PR TITLE
[migrator] Fix test no_duplicate_aarch64_use_tbi

### DIFF
--- a/test/Migrator/no_duplicate_aarch64_use_tbi.swift
+++ b/test/Migrator/no_duplicate_aarch64_use_tbi.swift
@@ -2,14 +2,14 @@
 // REQUIRES: CPU=arm64
 // RUN: %target-swift-frontend -typecheck %s -swift-version 3
 // RUN: %empty-directory(%t)
-// RUN: cd %t && %swiftc_driver -c -update-code -target arm64-apple-ios10.3 -output-file-map %S/Inputs/no_duplicate_aarch64_use_tbi_ofm.json -swift-version 3 %s -v
-// RUN: cd %t && %swiftc_driver -c -update-code -target arm64-apple-ios10.3 -output-file-map %S/Inputs/no_duplicate_aarch64_use_tbi_ofm.json -swift-version 3 %s -### > %t/driver_actions.txt
+// RUN: cd %t && %target-swiftc_driver -c -update-code -output-file-map %S/Inputs/no_duplicate_aarch64_use_tbi_ofm.json -swift-version 3 %s -v
+// RUN: cd %t && %target-swiftc_driver -c -update-code -output-file-map %S/Inputs/no_duplicate_aarch64_use_tbi_ofm.json -swift-version 3 %s -### > %t/driver_actions.txt
 // RUN: %FileCheck --check-prefix=CHECK-REMAP %s < %t/no_duplicate_aarch64_use_tbi.remap
 // RUN: %FileCheck --check-prefix=CHECK-ACTIONS %s < %t/driver_actions.txt
 
 public func foo(_ f: (Void) -> ()) {}
 
-// CHECK-REMAP: "offset": 673,
+// CHECK-REMAP: "offset": 632,
 // CHECK-REMAP: "remove": 5,
 // CHECK-REMAP: "text": "("
 


### PR DESCRIPTION
This was broken by a recent commit, but because it only runs with
arch=arm64 it was missed (it can be run with lit parameter
swift_test_mode=only_non_executable).

rdar://38248707