### PR TITLE
demangler: fix crashes for malformed symbols.

### DIFF
--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -1952,10 +1952,10 @@ NodePointer Demangler::demangleSubscript() {
   NodePointer Context = popContext();
 
   NodePointer Subscript = createNode(Node::Kind::Subscript);
-  Subscript->addChild(Context, *this);
-  Subscript->addChild(Type, *this);
+  Subscript = addChild(Subscript, Context);
+  Subscript = addChild(Subscript, Type);
   if (PrivateName)
-    Subscript->addChild(PrivateName, *this);
+    Subscript = addChild(Subscript, PrivateName);
 
   return demangleAccessor(Subscript);
 }

--- a/lib/Demangling/NodePrinter.cpp
+++ b/lib/Demangling/NodePrinter.cpp
@@ -541,7 +541,8 @@ private:
   }
 
   void printFunctionType(NodePointer node) {
-    assert(node->getNumChildren() == 2 || node->getNumChildren() == 3);
+    if (node->getNumChildren() != 2 && node->getNumChildren() != 3)
+      return;
     unsigned startIndex = 0;
     bool throws = false;
     if (node->getNumChildren() == 3) {
@@ -1896,9 +1897,10 @@ printEntity(NodePointer Entity, bool asPrefixContext, TypePrinting TypePr,
   }
   if (TypePr != TypePrinting::NoType) {
     NodePointer type = Entity->getChild(1);
-    if (type->getKind() != Node::Kind::Type)
+    if (type->getKind() != Node::Kind::Type && Entity->getNumChildren() >= 3)
       type = Entity->getChild(2);
-    assert(type->getKind() == Node::Kind::Type);
+    if (type->getKind() != Node::Kind::Type)
+      return nullptr;
     type = type->getChild(0);
     if (TypePr == TypePrinting::FunctionStyle) {
       // We expect to see a function type here, but if we don't, use the colon.

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -278,4 +278,10 @@ _T0So5GizmoC11doSomethingSQyypGSQySaySSGGFToTembnn_ ---> outlined bridged method
 _T0So5GizmoC12modifyStringSQySSGAD_Si10withNumberSQyypG0D6FoobartFToTembnnnb_ ---> outlined bridged method (mbnnnb) of @objc __ObjC.Gizmo.modifyString(Swift.String!, withNumber: Swift.Int, withFoobar: Any!) -> Swift.String!
 _T04test1SVyxGAA1RA2A1ZRzAA1Y2ZZRpzl1A_AhaGPWT ---> {C} associated type witness table accessor for A.ZZ : test.Y in <A where A: test.Z, A.ZZ: test.Y> test.S<A> : test.R in test
 _T0s24_UnicodeScalarExceptions33_0E4228093681F6920F0AB2E48B4F1C69LLVACycfC ---> Swift.(_UnicodeScalarExceptions in _0E4228093681F6920F0AB2E48B4F1C69).init() -> Swift.(_UnicodeScalarExceptions in _0E4228093681F6920F0AB2E48B4F1C69)
+_$S10NibbleSort0A10CollectionVys6UInt64VAEcis ---> _$S10NibbleSort0A10CollectionVys6UInt64VAEcis
+_T0D ---> _T0D
+_T0s3SetVyxGs10CollectiotySivm ---> _T0s3SetVyxGs10CollectiotySivm
+_T0s18ReversedCollectionVyxGs04LazyB8ProtocolfC ---> _T0s18ReversedCollectionVyxGs04LazyB8ProtocolfC
+_T0iW ---> _T0iW
+_T0s5print_9separator10terminatoryypfC ---> _T0s5print_9separator10terminatoryypfC
 


### PR DESCRIPTION
This is a manual cherry pick of e5b1c9d899cd603b8a8c9b8001bb5bb03d7eaff0

rdar://problem/38268809
