### PR TITLE
tests: disable a floating point test for arm

### DIFF
--- a/test/stdlib/FloatingPoint.swift.gyb
+++ b/test/stdlib/FloatingPoint.swift.gyb
@@ -574,6 +574,9 @@ FloatingPoint.test("Double.nextUp, .nextDown")
   expectBitwiseEqual(-prev, (-succ).nextUp)
 }
 
+// FIXME: This test is failing on armv4: SR-7159
+#if arch(i386) || arch(x86_64)
+
 %for Self in ['Float', 'Double']:
 FloatingPoint.test("${Self}.nextUp, .nextDown/nan") {
   let x = ${Self}.nan
@@ -583,6 +586,8 @@ FloatingPoint.test("${Self}.nextUp, .nextDown/nan") {
   expectTrue((-x).nextUp.isNaN)
 }
 %end
+
+#endif
 
 #if arch(i386) || arch(x86_64)
 


### PR DESCRIPTION
See also: https://bugs.swift.org/browse/SR-7159