### PR TITLE
[stdlib] Adjust floating-point nextUp test for NaN on ARM

### DIFF
--- a/test/stdlib/FloatingPoint.swift.gyb
+++ b/test/stdlib/FloatingPoint.swift.gyb
@@ -574,20 +574,15 @@ FloatingPoint.test("Double.nextUp, .nextDown")
   expectBitwiseEqual(-prev, (-succ).nextUp)
 }
 
-// FIXME: This test is failing on armv4: SR-7159
-#if arch(i386) || arch(x86_64)
-
 %for Self in ['Float', 'Double']:
 FloatingPoint.test("${Self}.nextUp, .nextDown/nan") {
   let x = ${Self}.nan
-  expectBitwiseEqual(x, x.nextUp)
-  expectBitwiseEqual(x, x.nextDown)
+  expectTrue(x.nextUp.isNaN)
+  expectTrue(x.nextDown.isNaN)
   expectTrue((-x).nextDown.isNaN)
   expectTrue((-x).nextUp.isNaN)
 }
 %end
-
-#endif
 
 #if arch(i386) || arch(x86_64)
 


### PR DESCRIPTION
This is a follow-up to #15051, removing the last of the bitwise comparisons for NaN in tests of `nextUp`. As discussed in that PR, those comparisons are unnecessarily stringent.

In the case of ARMv7, `.nan + 0` apparently does not have the same bit pattern as `.nan` (nor is it required to do so by IEEE 754), so we should not look for that during testing. This has been the source of test failures described in #15117.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7159](https://bugs.swift.org/browse/SR-7159).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->