### PR TITLE
Fix obvious typo. SWIFT_BULID_STDLIB => SWIFT_BUILD_STDLIB.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -827,7 +827,7 @@ message(STATUS "  Assertions: ${LLVM_ENABLE_ASSERTIONS}")
 message(STATUS "  LTO:        ${SWIFT_TOOLS_ENABLE_LTO}")
 message(STATUS "")
 
-if (SWIFT_BULID_STDLIB OR SWIFT_BUILD_SDK_OVERLAY)
+if (SWIFT_BUILD_STDLIB OR SWIFT_BUILD_SDK_OVERLAY)
 
   message(STATUS "Building Swift standard library and overlays for SDKs: ${SWIFT_SDKS}")
   message(STATUS "  Build type: ${SWIFT_STDLIB_BUILD_TYPE}")


### PR DESCRIPTION
I think we didn't catch this since we also check if overlays are enabled here
and generally overlays and stdlib are enabled together. It is NFC from the
actual build's perspective since this just controls whether or not diagnostic
information is printed out about what SDKs/etc is configured to be built.
