### PR TITLE
ObjectOutliner: restrict object outlining to tail allocated arrays.

### DIFF
--- a/lib/SILOptimizer/Transforms/ObjectOutliner.cpp
+++ b/lib/SILOptimizer/Transforms/ObjectOutliner.cpp
@@ -286,20 +286,25 @@ bool ObjectOutliner::optimizeObjectAllocation(
   ArrayRef<Operand> TailCounts = ARI->getTailAllocatedCounts();
   SILType TailType;
   unsigned NumTailElems = 0;
-  if (!TailCounts.empty()) {
-    // We only support a single tail allocated array.
-    if (TailCounts.size() > 1)
+
+  // We only support a single tail allocated arrays.
+  // Stdlib's tail allocated arrays don't have any side-effects in the
+  // constructor if the element type is trivial.
+  // TODO: also exclude custom tail allocated arrays which might have
+  // side-effects in the destructor.
+  if (TailCounts.size() != 1)
       return false;
-    // The number of tail allocated elements must be constant.
-    if (auto *ILI = dyn_cast<IntegerLiteralInst>(TailCounts[0].get())) {
-      if (ILI->getValue().getActiveBits() > 20)
-        return false;
-      NumTailElems = ILI->getValue().getZExtValue();
-      TailType = ARI->getTailAllocatedTypes()[0];
-    } else {
+
+  // The number of tail allocated elements must be constant.
+  if (auto *ILI = dyn_cast<IntegerLiteralInst>(TailCounts[0].get())) {
+    if (ILI->getValue().getActiveBits() > 20)
       return false;
-    }
+    NumTailElems = ILI->getValue().getZExtValue();
+    TailType = ARI->getTailAllocatedTypes()[0];
+  } else {
+    return false;
   }
+
   SILType Ty = ARI->getType();
   ClassDecl *Cl = Ty.getClassOrBoundGenericClass();
   if (!Cl)

--- a/test/SILOptimizer/globalopt-iter.sil
+++ b/test/SILOptimizer/globalopt-iter.sil
@@ -8,7 +8,8 @@ class E : B { }
 
 // CHECK: sil @patatino : $@convention(thin) () -> () {
 // CHECK: bb0:
-// CHECK-NEXT:   %0 = global_value @patatinoTv_ : $B
+// CHECK-NEXT:   integer_literal
+// CHECK-NEXT:   global_value @patatinoTv_ : $B
 // CHECK-NEXT:   strong_retain
 // CHECK-NEXT:   strong_release
 // CHECK-NEXT:   tuple ()
@@ -16,9 +17,10 @@ class E : B { }
 // CHECK-NEXT: }
 
 sil @patatino : $@convention(thin) () -> () {
-  %1 = alloc_ref [stack] $B
+  %0 = integer_literal $Builtin.Word, 0
+  %1 = alloc_ref [tail_elems $Int64 * %0 : $Builtin.Word] $B
   set_deallocating %1 : $B
-  dealloc_ref [stack] %1 : $B
+  dealloc_ref %1 : $B
   %45 = tuple ()
   return %45 : $()
 }

--- a/test/SILOptimizer/objectoutliner.sil
+++ b/test/SILOptimizer/objectoutliner.sil
@@ -35,9 +35,10 @@ class Obj {
 // CHECK: return
 sil @outline_global_simple : $@convention(thin) () -> () {
 bb0:
+  %0 = integer_literal $Builtin.Word, 0
   %1 = integer_literal $Builtin.Int64, 1
   %4 = struct $Int64 (%1 : $Builtin.Int64)
-  %7 = alloc_ref $Obj
+  %7 = alloc_ref [tail_elems $Int64 * %0 : $Builtin.Word] $Obj
   %9 = ref_element_addr %7 : $Obj, #Obj.value
   store %4 to %9 : $*Int64
   strong_release %7 : $Obj
@@ -83,13 +84,30 @@ bb0:
 // CHECK-NEXT: return
 sil @handle_deallocation : $@convention(thin) () -> () {
 bb0:
+  %0 = integer_literal $Builtin.Word, 0
   %3 = integer_literal $Builtin.Int64, 3
   %4 = struct $Int64 (%3 : $Builtin.Int64)
-  %5 = alloc_ref $Obj
+  %5 = alloc_ref [tail_elems $Int64 * %0 : $Builtin.Word] $Obj
   %6 = ref_element_addr %5 : $Obj, #Obj.value
   store %4 to %6 : $*Int64
   set_deallocating %5 : $Obj
   dealloc_ref %5 : $Obj
+  %r = tuple ()
+  return %r : $()
+}
+
+// CHECK-LABEL: sil @dont_outline_without_tail_elems
+// CHECK: alloc_ref
+// CHECK: store
+// CHECK: return
+sil @dont_outline_without_tail_elems : $@convention(thin) () -> () {
+bb0:
+  %1 = integer_literal $Builtin.Int64, 1
+  %4 = struct $Int64 (%1 : $Builtin.Int64)
+  %7 = alloc_ref $Obj
+  %9 = ref_element_addr %7 : $Obj, #Obj.value
+  store %4 to %9 : $*Int64
+  strong_release %7 : $Obj
   %r = tuple ()
   return %r : $()
 }
@@ -100,9 +118,10 @@ bb0:
 // CHECK: return
 sil @dont_outline_global_double_store : $@convention(thin) () -> () {
 bb0:
+  %0 = integer_literal $Builtin.Word, 0
   %1 = integer_literal $Builtin.Int64, 1
   %4 = struct $Int64 (%1 : $Builtin.Int64)
-  %7 = alloc_ref $Obj
+  %7 = alloc_ref [tail_elems $Int64 * %0 : $Builtin.Word] $Obj
   %9 = ref_element_addr %7 : $Obj, #Obj.value
   store %4 to %9 : $*Int64
   store %4 to %9 : $*Int64
@@ -116,9 +135,10 @@ bb0:
 // CHECK: return
 sil @dont_outline_global_missing_store : $@convention(thin) () -> () {
 bb0:
+  %0 = integer_literal $Builtin.Word, 0
   %1 = integer_literal $Builtin.Int64, 1
   %4 = struct $Int64 (%1 : $Builtin.Int64)
-  %7 = alloc_ref $Obj
+  %7 = alloc_ref [tail_elems $Int64 * %0 : $Builtin.Word] $Obj
   %9 = ref_element_addr %7 : $Obj, #Obj.value
   strong_release %7 : $Obj
   %r = tuple ()
@@ -148,9 +168,10 @@ sil @take_pointer : $@convention(thin) (Builtin.RawPointer) -> ()
 // CHECK: return
 sil @dont_outline_global_unknown_addr_use : $@convention(thin) () -> () {
 bb0:
+  %0 = integer_literal $Builtin.Word, 0
   %1 = integer_literal $Builtin.Int64, 1
   %4 = struct $Int64 (%1 : $Builtin.Int64)
-  %7 = alloc_ref $Obj
+  %7 = alloc_ref [tail_elems $Int64 * %0 : $Builtin.Word] $Obj
   %9 = ref_element_addr %7 : $Obj, #Obj.value
   store %4 to %9 : $*Int64
   %10 = address_to_pointer %9 : $*Int64 to $Builtin.RawPointer
@@ -167,8 +188,9 @@ bb0:
 sil @dont_outline_global_escaping_obj : $@convention(thin) (@inout Obj) -> () {
 bb0(%0: $*Obj):
   %1 = integer_literal $Builtin.Int64, 1
+  %2 = integer_literal $Builtin.Word, 0
   %4 = struct $Int64 (%1 : $Builtin.Int64)
-  %7 = alloc_ref $Obj
+  %7 = alloc_ref [tail_elems $Int64 * %2 : $Builtin.Word] $Obj
   %9 = ref_element_addr %7 : $Obj, #Obj.value
   store %4 to %9 : $*Int64
   store %7 to %0 : $*Obj

--- a/test/stdlib/ErrorHandling.swift
+++ b/test/stdlib/ErrorHandling.swift
@@ -1,9 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
 
-// FIXME: <https://bugs.swift.org/browse/SR-7146> 2 tests are failing on linux in optimized mode
-// UNSUPPORTED: OS=linux-gnu
-
 //
 // Tests for error handling in standard library APIs.
 //


### PR DESCRIPTION
SR-7146, rdar://problem/38302248
