### PR TITLE
[+0-normal-args] Make sure to use |= when enabling +0 in sil-opt.

### DIFF
--- a/tools/sil-opt/SILOpt.cpp
+++ b/tools/sil-opt/SILOpt.cpp
@@ -326,7 +326,7 @@ int main(int argc, char **argv) {
   SILOpts.EnableSILOwnership = EnableSILOwnershipOpt;
   SILOpts.AssumeUnqualifiedOwnershipWhenParsing =
     AssumeUnqualifiedOwnershipWhenParsing;
-  SILOpts.EnableGuaranteedNormalArguments =
+  SILOpts.EnableGuaranteedNormalArguments |=
     EnableGuaranteedNormalArguments;
 
   SILOpts.VerifyExclusivity = VerifyExclusivity;


### PR DESCRIPTION
Previously, we were just assigning from the llvm option. This made it impossible
to turn on +0 by default, since sil-opt would always assign false to the
SILOption... *doh*.

rdar://34222540
