### PR TITLE
[silgen] When forwarding an rvalue into memory to pass as an argument…

### DIFF
--- a/lib/SILGen/ArgumentSource.cpp
+++ b/lib/SILGen/ArgumentSource.cpp
@@ -174,7 +174,9 @@ ManagedValue ArgumentSource::getAsSingleValue(SILGenFunction &SGF,
   case Kind::RValue: {
     auto loc = getKnownRValueLocation();
     if (auto init = C.getEmitInto()) {
-      std::move(*this).asKnownRValue(SGF).forwardInto(SGF, loc, init);
+      std::move(*this).asKnownRValue(SGF)
+                      .ensurePlusOne(SGF, loc)
+                      .forwardInto(SGF, loc, init);
       return ManagedValue::forInContext();
     } else {
       return std::move(*this).asKnownRValue(SGF).getAsSingleValue(SGF, loc);


### PR DESCRIPTION
…, make sure it is at plus 1.

This can only come up with the +1 runtime if we need to pass a +0 value into
memory. As with the other ArgumentSource change, I don't think such code can be
emitted today. It does happen often with the +0 runtime though.

rdar://34222540
