### PR TITLE
Clear any LLVMArgs when initializing the CompilerInvocation for SourceKit's ASTManager

### DIFF
--- a/test/SourceKit/CursorInfo/ignore-llvm-args.swift
+++ b/test/SourceKit/CursorInfo/ignore-llvm-args.swift
@@ -1,0 +1,6 @@
+_ = ""
+
+// rdar://problem/38314383
+// RUN: %sourcekitd-test -req=cursor -offset=0 %s -- -Xllvm -aarch64-use-tbi %s | %FileCheck %s
+
+// CHECK: <empty cursor info>

--- a/tools/SourceKit/lib/Support/Logging.cpp
+++ b/tools/SourceKit/lib/Support/Logging.cpp
@@ -63,7 +63,7 @@ Logger::~Logger() {
   OS << llvm::format("%7.4f] ", TR.getWallTime() - sBeginTR.getWallTime());
   OS << Msg.str();
 
-  llvm::errs() << LoggerName << ": " << LogMsg.str() << '\n';
+  fprintf(stderr, "%s: %s", LoggerName.c_str(), LogMsg.c_str());
 
 #if __APPLE__
   // Use the Apple System Log facility.

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -459,6 +459,9 @@ bool SwiftASTManager::initCompilerInvocation(CompilerInvocation &Invocation,
   // SwiftONoneSupport module.
   FrontendOpts.RequestedAction = FrontendOptions::ActionType::Typecheck;
 
+  // We don't care about LLVMArgs
+  FrontendOpts.LLVMArgs.clear();
+
   return false;
 }
 


### PR DESCRIPTION
SourceKit doesn't use them and if any unrecognised LLVM options are passed to `llvm::cl::ParseCommandLineOptions()` it calls `exit()`, bringing down SourceKit.

Also use `fprintf` in Logging.cpp instead of `llvm::errs()` which uses a global C++ object that had already been destructed when logging the above failure.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/38314383

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->