### PR TITLE
[Parse] Reduce branches by running lexTrivia always

### DIFF
--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -195,8 +195,10 @@ public:
   void lex(Token &Result, syntax::Trivia &LeadingTriviaResult,
            syntax::Trivia &TrailingTriviaResult) {
     Result = NextToken;
-    LeadingTriviaResult = {LeadingTrivia};
-    TrailingTriviaResult = {TrailingTrivia};
+    if (TriviaRetention == TriviaRetentionMode::WithTrivia) {
+      LeadingTriviaResult = {LeadingTrivia};
+      TrailingTriviaResult = {TrailingTrivia};
+    }
     if (Result.isNot(tok::eof))
       lexImpl();
   }


### PR DESCRIPTION
This PR reduce branches in Lexer by running `lexTrivia` always for leading trivia in `lexImpl`.
Especially, `Restart` label and loop flow also eliminated in `lexImpl`.

For compatibility to current result with `WithoutTrivia`,
`LeadingTrivia` and `TrailingTrivia` are filter out in `lex`.
And skip `lexTrivia` for trailing trivia in `formToken` if `WithoutTrivia`.

By our recently achievement of perfect trivia lexing (and diagnostics), 
we don't need trivia skipping logic in `lexImpl` anymore.

The idea of this PR got from my previous PR and conversation with @rintaro about it.
https://github.com/apple/swift/pull/15081