### PR TITLE
[Dispatch][gardening] Use `Optional.map` over `flatMap` where appropriate

### DIFF
--- a/stdlib/public/SDK/Dispatch/IO.swift
+++ b/stdlib/public/SDK/Dispatch/IO.swift
@@ -40,7 +40,7 @@ public extension DispatchIO {
 
 	public class func write(toFileDescriptor: Int32, data: DispatchData, runningHandlerOn queue: DispatchQueue, handler: @escaping (_ data: DispatchData?, _ error: Int32) -> Void) {
 		__dispatch_write(toFileDescriptor, data as __DispatchData, queue) { (data: __DispatchData?, error: Int32) in
-			handler(data.flatMap { DispatchData(data: $0) }, error)
+			handler(data.map { DispatchData(data: $0) }, error)
 		}
 	}
 
@@ -88,13 +88,13 @@ public extension DispatchIO {
 
 	public func read(offset: off_t, length: Int, queue: DispatchQueue, ioHandler: @escaping (_ done: Bool, _ data: DispatchData?, _ error: Int32) -> Void) {
 		__dispatch_io_read(self, offset, length, queue) { (done: Bool, data: __DispatchData?, error: Int32) in
-			ioHandler(done, data.flatMap { DispatchData(data: $0) }, error)
+			ioHandler(done, data.map { DispatchData(data: $0) }, error)
 		}
 	}
 
 	public func write(offset: off_t, data: DispatchData, queue: DispatchQueue, ioHandler: @escaping (_ done: Bool, _ data: DispatchData?, _ error: Int32) -> Void) {
 		__dispatch_io_write(self, offset, data as __DispatchData, queue) { (done: Bool, data: __DispatchData?, error: Int32) in
-			ioHandler(done, data.flatMap { DispatchData(data: $0) }, error)
+			ioHandler(done, data.map { DispatchData(data: $0) }, error)
 		}
 	}
 

--- a/stdlib/public/SDK/Dispatch/Queue.swift
+++ b/stdlib/public/SDK/Dispatch/Queue.swift
@@ -344,8 +344,8 @@ public extension DispatchQueue {
 
 	public func setSpecific<T>(key: DispatchSpecificKey<T>, value: T?) {
 		let k = Unmanaged.passUnretained(key).toOpaque()
-		let v = value.flatMap { _DispatchSpecificValue(value: $0) }
-		let p = v.flatMap { Unmanaged.passRetained($0).toOpaque() }
+		let v = value.map { _DispatchSpecificValue(value: $0) }
+		let p = v.map { Unmanaged.passRetained($0).toOpaque() }
 		__dispatch_queue_set_specific(self, k, p, _destructDispatchSpecificValue)
 	}
 }


### PR DESCRIPTION
The initializers used here are not optional ones, so there is no need to use `flatMap`.

- https://github.com/apple/swift/blob/5e555868feb7bfa7779e61ee8d64d974e8c8993c/stdlib/public/SDK/Dispatch/Data.swift#L87-L89
- https://github.com/apple/swift/blob/5e555868feb7bfa7779e61ee8d64d974e8c8993c/stdlib/public/SDK/Dispatch/Queue.swift#L21-L24