### PR TITLE
[stdlib][SR-4818] Add overflow assignment operators

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -590,12 +590,13 @@ def assignmentOperatorComment(operator, fixedWidth):
   ///   - rhs: The value to divide `lhs` by. `rhs` must not be zero.
 """,
         '&+': """\
-  /// Stores the sum of the two given values in the left-hand-size variable, discarding any overflow.
+  /// Adds two values and stores the result in the left-hand-side variable, 
+  /// discarding any overflow.
   ///
-  /// The masking addition operator (`&+`) silently discards any overflow that
-  /// occurs during the operation. In the following example, the sum of `100`
-  /// and `121` is greater than the maximum representable `Int8` value, so the
-  /// result is the overflowed value:
+  /// The masking addition assignment operator (`&+=`) silently discards any 
+  /// overflow that occurs during the operation. In the following example, the 
+  /// sum of `100` and `121` is greater than the maximum representable `Int8` 
+  /// value, so the result is the overflowed value:
   ///
   ///     var x: Int8 = 10
   ///     x &+= 21
@@ -609,14 +610,15 @@ def assignmentOperatorComment(operator, fixedWidth):
   ///   - rhs: The second value to add.
 """,
         '&-': """\
-  /// Stores the difference of the two given values in the left-hand-size variable, discarding any overflow.
+  /// Subtracts the second value from the first and stores the difference in the
+  /// left-hand-side variable, discarding any overflow.
   ///
-  /// The masking subtraction operator (`&-`) silently discards any overflow
-  /// that occurs during the operation. In the following example, the
+  /// The masking subtraction assignment operator (`&-=`) silently discards any
+  /// overflow that occurs during the operation. In the following example, the
   /// difference of `10` and `21` is less than zero, the minimum representable
   /// `UInt` value, so the result is the overflowed value:
   ///
-  ///     var x: Int8 = 21l
+  ///     var x: Int8 = 21
   ///     x &-= 10
   ///     // x == 11
   ///     var y: UInt8 = 10
@@ -628,12 +630,13 @@ def assignmentOperatorComment(operator, fixedWidth):
   ///   - rhs: The value to subtract from `lhs`.
 """,
         '&*': """\
-  /// Stores the product of the two given values in the left-hand-size variable, discarding any overflow.
+  /// Multiplies two values and stores the result in the left-hand-side
+  /// variable, discarding any overflow.
   ///
-  /// The masking multiplication operator (`&*`) silently discards any overflow
-  /// that occurs during the operation. In the following example, the product
-  /// of `10` and `50` is greater than the maximum representable `Int8` value,
-  /// so the result is the overflowed value:
+  /// The masking multiplication assignment operator (`&*=`) silently discards 
+  /// any overflow that occurs during the operation. In the following example, 
+  /// the product of `10` and `50` is greater than the maximum representable 
+  /// `Int8` value, so the result is the overflowed value:
   ///
   ///     var x: Int8 = 10
   ///     x &*= 5
@@ -2797,18 +2800,15 @@ ${unsafeOperationComment(x.operator)}
 ${operatorComment('&' + x.operator, True)}
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
-  public static func &${x.operator}(lhs: Self, rhs: Self) -> Self {
-    var lhs = lhs
-    lhs &${x.operator}= rhs
-    return lhs
+  public static func &${x.operator} (lhs: Self, rhs: Self) -> Self {
+    return lhs.${x.name}ReportingOverflow(${callLabel}rhs).partialValue
   }
 
 ${assignmentOperatorComment('&' + x.operator, True)}
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
-  public static func &${x.operator}=(lhs: inout Self, rhs: Self) {
-    let result = lhs.${x.name}ReportingOverflow(${callLabel}rhs).partialValue
-    lhs = result
+  public static func &${x.operator}= (lhs: inout Self, rhs: Self) {
+    lhs = lhs &${x.operator} rhs
   }
 %   end
 % end

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -589,6 +589,63 @@ def assignmentOperatorComment(operator, fixedWidth):
   ///   - lhs: The value to divide.
   ///   - rhs: The value to divide `lhs` by. `rhs` must not be zero.
 """,
+        '&+': """\
+  /// Stores the sum of the two given values in the left-hand-size variable, discarding any overflow.
+  ///
+  /// The masking addition operator (`&+`) silently discards any overflow that
+  /// occurs during the operation. In the following example, the sum of `100`
+  /// and `121` is greater than the maximum representable `Int8` value, so the
+  /// result is the overflowed value:
+  ///
+  ///     var x: Int8 = 10
+  ///     x &+= 21
+  ///     // x == 31
+  ///     var y: Int8 = 100
+  ///     y &+= 121
+  ///     // y == -35 (after overflow)
+  ///
+  /// - Parameters:
+  ///   - lhs: The first value to add.
+  ///   - rhs: The second value to add.
+""",
+        '&-': """\
+  /// Stores the difference of the two given values in the left-hand-size variable, discarding any overflow.
+  ///
+  /// The masking subtraction operator (`&-`) silently discards any overflow
+  /// that occurs during the operation. In the following example, the
+  /// difference of `10` and `21` is less than zero, the minimum representable
+  /// `UInt` value, so the result is the overflowed value:
+  ///
+  ///     var x: Int8 = 21l
+  ///     x &-= 10
+  ///     // x == 11
+  ///     var y: UInt8 = 10
+  ///     y &-= 21
+  ///     // y == 245 (after overflow)
+  ///
+  /// - Parameters:
+  ///   - lhs: A numeric value.
+  ///   - rhs: The value to subtract from `lhs`.
+""",
+        '&*': """\
+  /// Stores the product of the two given values in the left-hand-size variable, discarding any overflow.
+  ///
+  /// The masking multiplication operator (`&*`) silently discards any overflow
+  /// that occurs during the operation. In the following example, the product
+  /// of `10` and `50` is greater than the maximum representable `Int8` value,
+  /// so the result is the overflowed value:
+  ///
+  ///     var x: Int8 = 10
+  ///     x &*= 5
+  ///     // x == 50
+  ///     var y: Int8 = 10
+  ///     y &*= 50
+  ///     // y == -12 (after overflow)
+  ///
+  /// - Parameters:
+  ///   - lhs: The first value to multiply.
+  ///   - rhs: The second value to multiply.
+""",
         '&': """\
   /// Stores the result of performing a bitwise AND operation on the two given
   /// values in the left-hand-side variable.
@@ -2740,8 +2797,18 @@ ${unsafeOperationComment(x.operator)}
 ${operatorComment('&' + x.operator, True)}
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
-  public static func &${x.operator} (lhs: Self, rhs: Self) -> Self {
-    return lhs.${x.name}ReportingOverflow(${callLabel}rhs).partialValue
+  public static func &${x.operator}(lhs: Self, rhs: Self) -> Self {
+    var lhs = lhs
+    lhs &${x.operator}= rhs
+    return lhs
+  }
+
+${assignmentOperatorComment('&' + x.operator, True)}
+  @_inlineable // FIXME(sil-serialize-all)
+  @_transparent
+  public static func &${x.operator}=(lhs: inout Self, rhs: Self) {
+    let result = lhs.${x.name}ReportingOverflow(${callLabel}rhs).partialValue
+    lhs = result
   }
 %   end
 % end

--- a/stdlib/public/core/Policy.swift
+++ b/stdlib/public/core/Policy.swift
@@ -698,10 +698,13 @@ infix operator || : LogicalDisjunctionPrecedence
 // Compound
 
 infix operator   *= : AssignmentPrecedence
+infix operator  &*= : AssignmentPrecedence
 infix operator   /= : AssignmentPrecedence
 infix operator   %= : AssignmentPrecedence
 infix operator   += : AssignmentPrecedence
+infix operator  &+= : AssignmentPrecedence
 infix operator   -= : AssignmentPrecedence
+infix operator  &-= : AssignmentPrecedence
 infix operator  <<= : AssignmentPrecedence
 infix operator &<<= : AssignmentPrecedence
 infix operator  >>= : AssignmentPrecedence

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -332,12 +332,20 @@ tests.test("${Type}/Add/Overflow") {
   _ = f(${Type}.max)
 }
 
+tests.test("${Type}/Add/MaskingOverflow") {
+  expectEqual(${Type}.max &+ 1, ${Type}.min)
+}
+
 tests.test("${Type}/Subtract/Underflow") {
   func f(_ x: ${Type}) -> ${Type} {
     return x - 1
   }
   expectCrashLater()
   _ = f(${Type}.min)
+}
+
+tests.test("${Type}/Subtract/MaskingUnderflow") {
+  expectEqual(${Type}.min &- 1, ${Type}.max)
 }
 
 tests.test("${Type}/AddInPlace/Overflow") {
@@ -349,6 +357,12 @@ tests.test("${Type}/AddInPlace/Overflow") {
   f(&x)
 }
 
+tests.test("${Type}/AddInPlace/MaskingOverflow") {
+  var x = ${Type}.max
+  x &+= 1
+  expectEqual(x, ${Type}.min)
+}
+
 tests.test("${Type}/SubtractInPlace/Underflow") {
   func f(_ x: inout ${Type}) {
     x -= 1
@@ -356,6 +370,18 @@ tests.test("${Type}/SubtractInPlace/Underflow") {
   expectCrashLater()
   var x = ${Type}.min
   f(&x)
+}
+
+tests.test("${Type}/SubtractInPlace/MaskingUnderflow") {
+  var x = ${Type}.min
+  x &-= 1
+  expectEqual(x, ${Type}.max)
+}
+
+tests.test("${Type}/MaskingMultiply") {
+  var x = ${Type}.max
+  x &*= 2
+  expectEqual(x, ${Type}.max &* 2)
 }
 %   end
 % end

--- a/test/stdlib/Integers.swift.gyb
+++ b/test/stdlib/Integers.swift.gyb
@@ -333,7 +333,7 @@ tests.test("${Type}/Add/Overflow") {
 }
 
 tests.test("${Type}/Add/MaskingOverflow") {
-  expectEqual(${Type}.max &+ 1, ${Type}.min)
+  expectEqual(${Type}.min, ${Type}.max &+ 1)
 }
 
 tests.test("${Type}/Subtract/Underflow") {
@@ -345,7 +345,11 @@ tests.test("${Type}/Subtract/Underflow") {
 }
 
 tests.test("${Type}/Subtract/MaskingUnderflow") {
-  expectEqual(${Type}.min &- 1, ${Type}.max)
+  expectEqual(${Type}.max, ${Type}.min &- 1)
+}
+
+tests.test("${Type}/Multiply/MaskingOverflow") {
+  expectEqual(${Type}.min, (${Type}.max / 2 + 1) &* 2)
 }
 
 tests.test("${Type}/AddInPlace/Overflow") {
@@ -360,7 +364,7 @@ tests.test("${Type}/AddInPlace/Overflow") {
 tests.test("${Type}/AddInPlace/MaskingOverflow") {
   var x = ${Type}.max
   x &+= 1
-  expectEqual(x, ${Type}.min)
+  expectEqual(${Type}.min, x)
 }
 
 tests.test("${Type}/SubtractInPlace/Underflow") {
@@ -375,13 +379,13 @@ tests.test("${Type}/SubtractInPlace/Underflow") {
 tests.test("${Type}/SubtractInPlace/MaskingUnderflow") {
   var x = ${Type}.min
   x &-= 1
-  expectEqual(x, ${Type}.max)
+  expectEqual(${Type}.max, x)
 }
 
-tests.test("${Type}/MaskingMultiply") {
-  var x = ${Type}.max
+tests.test("${Type}/MultiplyInPlace/MaskingOverflow") {
+  var x = ${Type}.max / 2 + 1
   x &*= 2
-  expectEqual(x, ${Type}.max &* 2)
+  expectEqual(${Type}.min, x)
 }
 %   end
 % end

--- a/utils/SwiftIntTypes.py
+++ b/utils/SwiftIntTypes.py
@@ -122,7 +122,7 @@ def all_integer_or_real_binary_operator_names():
 
 
 def all_integer_assignment_operator_names():
-    return ['%=', '<<=', '>>=', '&*=', '&=', '&+=', '&-=', '^=', '|=']
+    return ['%=', '<<=', '>>=', '&=', '^=', '|=']
 
 
 def all_integer_or_real_assignment_operator_names():

--- a/utils/SwiftIntTypes.py
+++ b/utils/SwiftIntTypes.py
@@ -122,7 +122,7 @@ def all_integer_or_real_binary_operator_names():
 
 
 def all_integer_assignment_operator_names():
-    return ['%=', '<<=', '>>=', '&=', '^=', '|=']
+    return ['%=', '<<=', '>>=', '&*=', '&=', '&+=', '&-=', '^=', '|=']
 
 
 def all_integer_or_real_assignment_operator_names():


### PR DESCRIPTION
<!-- What's in this pull request? -->
This adds the overflow assignment operators (`&+= &-= &*=`) that were missing from integer types.

To match how other operators are written, I moved the regular overflow operator's implementation to the new assignment operators. I am unsure if this will have performance implications, so please let me know if this is a bad idea! I also removed the trailing white space from it's declaration since the other operators did not have one.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-4818](https://bugs.swift.org/browse/SR-4818).
Resolves: <rdar://problem/32035586>

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->