### PR TITLE
[Testing] Correctly handle unset SWIFT_ENABLE_GUARANTEED_NORMAL_ARGUMENTS

### DIFF
--- a/test/lit.site.cfg.in
+++ b/test/lit.site.cfg.in
@@ -36,6 +36,8 @@ config.android_ndk_gcc_version = "@SWIFT_ANDROID_NDK_GCC_VERSION@"
 config.coverage_mode = "@SWIFT_ANALYZE_CODE_COVERAGE@"
 config.lldb_build_root = "@LLDB_BUILD_DIR@"
 
+# Please remember to handle empty strings and/or unset variables correctly.
+
 if "@SWIFT_ASAN_BUILD@" == "TRUE":
     config.available_features.add("asan")
 else:
@@ -89,10 +91,10 @@ config.available_features.add("CMAKE_GENERATOR=@CMAKE_GENERATOR@")
 if "@SWIFT_ENABLE_SOURCEKIT_TESTS@" == "TRUE":
     config.available_features.add('sourcekit')
 
-if "@SWIFT_ENABLE_GUARANTEED_NORMAL_ARGUMENTS@" == "FALSE":
-   config.available_features.add('plus_one_runtime')
-else:
+if "@SWIFT_ENABLE_GUARANTEED_NORMAL_ARGUMENTS@" == "TRUE":
    config.available_features.add('plus_zero_runtime')
+else:
+   config.available_features.add('plus_one_runtime')
 
 # Let the main config do the real work.
 if config.test_exec_root is None:


### PR DESCRIPTION
This unbreaks unified builds which don't pass the above flag to cmake.