### PR TITLE
[SE-0091][gardening][stdlib/public] Move operators into types

### DIFF
--- a/stdlib/public/Platform/Platform.swift
+++ b/stdlib/public/Platform/Platform.swift
@@ -57,9 +57,10 @@ extension DarwinBoolean : CustomStringConvertible {
   }
 }
 
-extension DarwinBoolean : Equatable {}
-public func ==(lhs: DarwinBoolean, rhs: DarwinBoolean) -> Bool {
-  return lhs.boolValue == rhs.boolValue
+extension DarwinBoolean : Equatable {
+  public static func ==(lhs: DarwinBoolean, rhs: DarwinBoolean) -> Bool {
+    return lhs.boolValue == rhs.boolValue
+  }
 }
 
 public // COMPILER_INTRINSIC

--- a/stdlib/public/SDK/CoreMedia/CMTime.swift
+++ b/stdlib/public/SDK/CoreMedia/CMTime.swift
@@ -99,34 +99,36 @@ public func CMTIME_HAS_BEEN_ROUNDED(_ time: CMTime) -> Bool {
   return time.hasBeenRounded
 }
 
-// CMTimeAdd
-public func + (addend1: CMTime, addend2: CMTime) -> CMTime {
-  return CMTimeAdd(addend1, addend2)
+extension CMTime {
+  // CMTimeAdd
+  public static func + (addend1: CMTime, addend2: CMTime) -> CMTime {
+    return CMTimeAdd(addend1, addend2)
+  }
+  
+  // CMTimeSubtract
+  public static func - (minuend: CMTime, subtrahend: CMTime) -> CMTime {
+    return CMTimeSubtract(minuend, subtrahend)
+  }
 }
-
-// CMTimeSubtract
-public func - (minuend: CMTime, subtrahend: CMTime) -> CMTime {
-  return CMTimeSubtract(minuend, subtrahend)
-}
-
-extension CMTime : Equatable, Comparable {}
 
 // CMTimeCompare
-public func < (time1: CMTime, time2: CMTime) -> Bool {
-  return CMTimeCompare(time1, time2) < 0
-}
-public func <= (time1: CMTime, time2: CMTime) -> Bool {
-  return CMTimeCompare(time1, time2) <= 0
-}
-public func > (time1: CMTime, time2: CMTime) -> Bool {
-  return CMTimeCompare(time1, time2) > 0
-}
-public func >= (time1: CMTime, time2: CMTime) -> Bool {
-  return CMTimeCompare(time1, time2) >= 0
-}
-public func == (time1: CMTime, time2: CMTime) -> Bool {
-  return CMTimeCompare(time1, time2) == 0
-}
-public func != (time1: CMTime, time2: CMTime) -> Bool {
-  return CMTimeCompare(time1, time2) != 0
+extension CMTime : Equatable, Comparable {
+  public static func < (time1: CMTime, time2: CMTime) -> Bool {
+    return CMTimeCompare(time1, time2) < 0
+  }
+  public static func <= (time1: CMTime, time2: CMTime) -> Bool {
+    return CMTimeCompare(time1, time2) <= 0
+  }
+  public static func > (time1: CMTime, time2: CMTime) -> Bool {
+    return CMTimeCompare(time1, time2) > 0
+  }
+  public static func >= (time1: CMTime, time2: CMTime) -> Bool {
+    return CMTimeCompare(time1, time2) >= 0
+  }
+  public static func == (time1: CMTime, time2: CMTime) -> Bool {
+    return CMTimeCompare(time1, time2) == 0
+  }
+  public static func != (time1: CMTime, time2: CMTime) -> Bool {
+    return CMTimeCompare(time1, time2) != 0
+  }
 }

--- a/stdlib/public/SDK/CoreMedia/CMTimeRange.swift
+++ b/stdlib/public/SDK/CoreMedia/CMTimeRange.swift
@@ -74,14 +74,13 @@ public func CMTIMERANGE_IS_EMPTY (_ range: CMTimeRange) -> Bool {
   return range.isEmpty
 }
 
-extension CMTimeRange : Equatable {}
-
 // CMTimeRangeEqual
-public func == (range1: CMTimeRange, range2: CMTimeRange) -> Bool {
-  return CMTimeRangeEqual(range1, range2)
+extension CMTimeRange : Equatable {
+  public static func == (range1: CMTimeRange, range2: CMTimeRange) -> Bool {
+    return CMTimeRangeEqual(range1, range2)
+  }
+  
+  public static func != (range1: CMTimeRange, range2: CMTimeRange) -> Bool {
+    return !CMTimeRangeEqual(range1, range2)
+  }  
 }
-
-public func != (range1: CMTimeRange, range2: CMTimeRange) -> Bool {
-  return !CMTimeRangeEqual(range1, range2)
-}
-

--- a/stdlib/public/SDK/Dispatch/Dispatch.swift
+++ b/stdlib/public/SDK/Dispatch/Dispatch.swift
@@ -114,10 +114,10 @@ public struct DispatchQoS : Equatable {
 		self.qosClass = qosClass
 		self.relativePriority = relativePriority
 	}
-}
 
-public func ==(a: DispatchQoS, b: DispatchQoS) -> Bool {
-	return a.qosClass == b.qosClass && a.relativePriority == b.relativePriority
+	public static func ==(a: DispatchQoS, b: DispatchQoS) -> Bool {
+		return a.qosClass == b.qosClass && a.relativePriority == b.relativePriority
+	}
 }
 
 /// 

--- a/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
+++ b/stdlib/public/SDK/ObjectiveC/ObjectiveC.swift
@@ -112,11 +112,11 @@ public struct Selector : ExpressibleByStringLiteral {
   }
 }
 
-public func ==(lhs: Selector, rhs: Selector) -> Bool {
-  return sel_isEqual(lhs, rhs)
-}
-
 extension Selector : Equatable, Hashable {
+  public static func ==(lhs: Selector, rhs: Selector) -> Bool {
+    return sel_isEqual(lhs, rhs)
+  }
+
   /// The hash value.
   ///
   /// **Axiom:** `x == y` implies `x.hashValue == y.hashValue`
@@ -199,6 +199,10 @@ public var NO: ObjCBool {
 // FIXME: what about NSObjectProtocol?
 
 extension NSObject : Equatable, Hashable {
+  public static func == (lhs: NSObject, rhs: NSObject) -> Bool {
+    return lhs.isEqual(rhs)
+  }
+
   /// The hash value.
   ///
   /// **Axiom:** `x == y` implies `x.hashValue == y.hashValue`
@@ -210,10 +214,6 @@ extension NSObject : Equatable, Hashable {
   open var hashValue: Int {
     return hash
   }
-}
-
-public func == (lhs: NSObject, rhs: NSObject) -> Bool {
-  return lhs.isEqual(rhs)
 }
 
 extension NSObject : CVarArg {

--- a/stdlib/public/SDK/UIKit/UIKit.swift
+++ b/stdlib/public/SDK/UIKit/UIKit.swift
@@ -39,23 +39,23 @@ public extension UIOffset {
 // Equatable types.
 //===----------------------------------------------------------------------===//
 
-@_transparent // @fragile
-public func == (lhs: UIEdgeInsets, rhs: UIEdgeInsets) -> Bool {
-  return lhs.top == rhs.top &&
-         lhs.left == rhs.left &&
-         lhs.bottom == rhs.bottom &&
-         lhs.right == rhs.right
+extension UIEdgeInsets : Equatable {
+  @_transparent // @fragile
+  public static func == (lhs: UIEdgeInsets, rhs: UIEdgeInsets) -> Bool {
+    return lhs.top == rhs.top &&
+           lhs.left == rhs.left &&
+           lhs.bottom == rhs.bottom &&
+           lhs.right == rhs.right
+  }
 }
 
-extension UIEdgeInsets : Equatable {}
-
-@_transparent // @fragile
-public func == (lhs: UIOffset, rhs: UIOffset) -> Bool {
-  return lhs.horizontal == rhs.horizontal &&
-         lhs.vertical == rhs.vertical
+extension UIOffset : Equatable {
+  @_transparent // @fragile
+  public static func == (lhs: UIOffset, rhs: UIOffset) -> Bool {
+    return lhs.horizontal == rhs.horizontal &&
+           lhs.vertical == rhs.vertical
+  }
 }
-
-extension UIOffset : Equatable {}
 
 //===----------------------------------------------------------------------===//
 // Numeric backed types


### PR DESCRIPTION
Looks like operators as static functions are more popular in the codebase.

Ignoring whitespaces: https://github.com/apple/swift/pull/15151/files?w=1