### PR TITLE
[Parse] Remove unnecessary Lexer fields 

### DIFF
--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -92,22 +92,6 @@ class Lexer {
   /// Pointer to the next not consumed character.
   const char *CurPtr;
 
-  /// @{
-  /// Members that are *not* permanent lexer state.  The values only make sense
-  /// during the lexImpl() invocation.  These variables are declared as members
-  /// rather than locals so that we don't have to thread them through to all
-  /// lexing helpers.
-
-  /// Points to the point in the source buffer where we started scanning for
-  /// the current token.  Thus, the range [LastCommentBlockStart, CurPtr)
-  /// covers all comments and whitespace that we skipped, and the token itself.
-  const char *LastCommentBlockStart = nullptr;
-
-  /// True if we have seen a comment while scanning for the current token.
-  bool SeenComment = false;
-
-  /// @}
-
   Token NextToken;
   
   /// \brief This is true if we're lexing a .sil file instead of a .swift

--- a/include/swift/Syntax/Trivia.h.gyb
+++ b/include/swift/Syntax/Trivia.h.gyb
@@ -170,6 +170,8 @@ public:
     }
   }
 
+  bool isComment() const;
+
   void accumulateAbsolutePosition(AbsolutePosition &Pos) const;
   
   /// Try to compose this and Next to one TriviaPiece.

--- a/lib/Syntax/Trivia.cpp.gyb
+++ b/lib/Syntax/Trivia.cpp.gyb
@@ -44,6 +44,19 @@ void TriviaPiece::dump(llvm::raw_ostream &OS, unsigned Indent) const {
   OS << ')';
 }
 
+bool TriviaPiece::isComment() const {
+  switch (Kind) {
+% for trivia in TRIVIAS:
+  case TriviaKind::${trivia.name}:
+% if trivia.is_comment:
+    return true;
+% else:
+    return false;
+% end
+% end
+  }
+}
+
 void TriviaPiece::accumulateAbsolutePosition(AbsolutePosition &Pos) const {
   switch (Kind) {
 % for trivia in TRIVIAS:

--- a/utils/gyb_syntax_support/Trivia.py
+++ b/utils/gyb_syntax_support/Trivia.py
@@ -3,12 +3,13 @@ from kinds import lowercase_first_word
 
 class Trivia(object):
     def __init__(self, name, comment, characters=[], swift_characters=[],
-                 is_new_line=False):
+                 is_new_line=False, is_comment=False):
         self.name = name
         self.comment = comment
         self.characters = characters
         self.lower_name = lowercase_first_word(name)
         self.is_new_line = is_new_line
+        self.is_comment = is_comment
 
         # Swift sometimes doesn't support escaped characters like \f or \v;
         # we should allow specifying alternatives explicitly.
@@ -44,14 +45,18 @@ TRIVIAS = [
            'A backtick \'`\' character, used to escape identifiers.',
            characters=['`']),
 
-    Trivia('LineComment', 'A developer line comment, starting with \'//\''),
+    Trivia('LineComment', 'A developer line comment, starting with \'//\'',
+           is_comment=True),
     Trivia('BlockComment',
            'A developer block comment, starting with \'/*\' and ending with'
-           ' \'*/\'.'),
+           ' \'*/\'.',
+           is_comment=True),
     Trivia('DocLineComment',
-           'A documentation line comment, starting with \'///\'.'),
+           'A documentation line comment, starting with \'///\'.',
+           is_comment=True),
     Trivia('DocBlockComment',
            'A documentation block comment, starting with \'/**\' and ending '
-           'with \'*/\'.'),
+           'with \'*/\'.',
+           is_comment=True),
     Trivia('GarbageText', 'Any skipped garbage text.'),
 ]


### PR DESCRIPTION
This PR removes Lexer fields which are `LastCommentBlockStart` and `SeenComment`.
Lexer tracks leading trivia always now.
So we can compute `CommentLength` from `LeadingTrivia`.

It can reduce Lexer's state handling and make code simple.