### PR TITLE
[Parse] Remove dead code in lexHash

### DIFF
--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -644,15 +644,6 @@ void Lexer::lexHash() {
      ++CurPtr;
      return formToken(tok::r_square_lit, TokStart);
   }
-  
-  // Allow a hashbang #! line at the beginning of the file.
-  if (CurPtr - 1 == ContentStart && *CurPtr == '!') {
-    --CurPtr;
-    if (BufferID != SourceMgr.getHashbangBufferID())
-      diagnose(CurPtr, diag::lex_hashbang_not_allowed);
-    skipHashbang(/*EatNewline=*/true);
-    return lexImpl();
-  }
 
   // Scan for [a-zA-Z]+ to see what we match.
   const char *tmpPtr = CurPtr;


### PR DESCRIPTION
This flow never run because hashbang is eaten by `lexTrivia`.

I should have included this change in this PR. 
https://github.com/apple/swift/pull/15137 
But I missed.