### PR TITLE
[SwiftSyntax] Use RawSyntax presence state properties in Syntax

### DIFF
--- a/tools/SwiftSyntax/Syntax.swift
+++ b/tools/SwiftSyntax/Syntax.swift
@@ -76,12 +76,12 @@ extension Syntax {
 
   /// Whether or not this node it marked as `present`.
   public var isPresent: Bool {
-    return raw.presence == .present
+    return raw.isPresent
   }
 
   /// Whether or not this node it marked as `missing`.
   public var isMissing: Bool {
-    return raw.presence == .missing
+    return raw.isMissing
   }
 
   /// Whether or not this node represents an Expression.


### PR DESCRIPTION
Instead of using presence property directly for comparison in `isPresent` and `isMissing` it's better to use properties of `RawSyntax` which hides all this logic. This is similar to what is used to determine node type (`isExpr`, `isDecl`,  etc).