### PR TITLE
Improve diagnostic when downcast to CoreFoundation Type

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2482,7 +2482,7 @@ NOTE(silence_inject_forced_downcast,none,
      "add parentheses around the cast to silence this warning", ())
 
 ERROR(conditional_downcast_foreign,none,
-      "conditional downcast to CoreFoundation type %0 will always succeed",
+      "conditional downcast to CoreFoundation type %0 will always succeed; did you mean to use 'as!' to force downcast?",
       (Type))
 
 ERROR(optional_used_as_boolean,none,

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3333,7 +3333,9 @@ namespace {
 
               auto &tc = cs.getTypeChecker();
               tc.diagnose(cast->getLoc(), diag::conditional_downcast_foreign,
-                          destValueType);
+                          destValueType)
+                .highlight(cast->getSourceRange())
+                .fixItReplace(cast->getLoc(), "as!");
             }
           }
         }


### PR DESCRIPTION
Improve diagnostic when downcast to CF type.
Resolves [SR-7015](https://bugs.swift.org/browse/SR-7015).
