### PR TITLE
[CMake] Fix a few dependencies

### DIFF
--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -104,7 +104,10 @@ add_swift_library(swiftBasic STATIC
   LINK_LIBRARIES
     swiftDemangling
     ${UUID_LIBRARIES}
-  LLVM_COMPONENT_DEPENDS support)
+  LLVM_COMPONENT_DEPENDS
+    core
+    support
+  )
 
 message(STATUS "Swift version: ${SWIFT_VERSION}")
 message(STATUS "Swift vendor: ${SWIFT_VENDOR}")

--- a/lib/Frontend/CMakeLists.txt
+++ b/lib/Frontend/CMakeLists.txt
@@ -13,7 +13,6 @@ add_swift_library(swiftFrontend STATIC
     SwiftOptions
   LINK_LIBRARIES
     swiftSIL
-    swiftMigrator
     swiftOption
     swiftParseSIL
     swiftSema

--- a/lib/LLVMPasses/CMakeLists.txt
+++ b/lib/LLVMPasses/CMakeLists.txt
@@ -7,6 +7,8 @@ add_swift_library(swiftLLVMPasses STATIC
   LLVMMergeFunctions.cpp
 
   LLVM_COMPONENT_DEPENDS
-  analysis
+    core
+    support
+    analysis
   )
 

--- a/lib/Markup/CMakeLists.txt
+++ b/lib/Markup/CMakeLists.txt
@@ -3,6 +3,10 @@ add_swift_library(swiftMarkup STATIC
   LineList.cpp
   Markup.cpp
   
+  LLVM_COMPONENT_DEPENDS
+    support
+
   LINK_LIBRARIES
+    swiftBasic
     libcmark_static)
 

--- a/lib/Syntax/CMakeLists.txt
+++ b/lib/Syntax/CMakeLists.txt
@@ -15,4 +15,8 @@ add_swift_library(swiftSyntax STATIC
   Syntax.cpp
   SyntaxArena.cpp
   SyntaxData.cpp
-  UnknownSyntax.cpp)
+  UnknownSyntax.cpp
+
+  LLVM_COMPONENT_DEPENDS
+    support
+  )


### PR DESCRIPTION
Found while trying to enable LLVM's developer-only 'BUILD_SHARED_LIBS' feature. There are two real cyclic problems left that I know of before BUILD_SHARED_LIBS can be considered:

*** swiftLLVMPasses <-> swiftIRGen ***
The former needs swift::getRuntimeFn() from the latter.

*** swiftBasic <-> swiftAST ***
The former needs minor statistics tracking logic from the latter.