### PR TITLE
[exclusivity] Teach LetPropertiesOpt how to handle begin_access.

### DIFF
--- a/include/swift/SIL/InstructionUtils.h
+++ b/include/swift/SIL/InstructionUtils.h
@@ -48,6 +48,11 @@ SILValue stripUpCasts(SILValue V);
 /// upcasts and downcasts.
 SILValue stripClassCasts(SILValue V);
 
+/// Return the underlying SILValue after stripping off non-projection address
+/// casts. The result will still be an address--this does not look through
+/// pointer-to-address.
+SILValue stripAddressAccess(SILValue V);
+
 /// Return the underlying SILValue after stripping off all address projection
 /// instructions.
 SILValue stripAddressProjections(SILValue V);

--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -181,6 +181,18 @@ SILValue swift::stripClassCasts(SILValue V) {
   }
 }
 
+SILValue swift::stripAddressAccess(SILValue V) {
+  while (true) {
+    switch (V->getKind()) {
+    default:
+      return V;
+    case ValueKind::BeginBorrowInst:
+    case ValueKind::BeginAccessInst:
+      return stripAddressAccess(cast<SingleValueInstruction>(V)->getOperand(0));
+    }
+  }
+}
+
 SILValue swift::stripAddressProjections(SILValue V) {
   while (true) {
     V = stripSinglePredecessorArgs(V);

--- a/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
+++ b/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
@@ -19,9 +19,10 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "let-properties-opt"
-#include "swift/SIL/SILInstruction.h"
-#include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/DebugUtils.h"
+#include "swift/SIL/InstructionUtils.h"
+#include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILLinkage.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
@@ -201,7 +202,10 @@ void LetPropertiesOpt::optimizeLetPropertyAccess(VarDecl *Property,
     };
 
     // Look for any instructions accessing let properties.
-    if (auto proj = dyn_cast<RefElementAddrInst>(Load)) {
+    if (isa<RefElementAddrInst>(Load) || isa<StructElementAddrInst>(Load)
+        || isa<BeginAccessInst>(Load)) {
+      auto proj = cast<SingleValueInstruction>(Load);
+
       // Copy the initializer into the function
       // Replace the access to a let property by the value
       // computed by this initializer.
@@ -210,6 +214,14 @@ void LetPropertiesOpt::optimizeLetPropertyAccess(VarDecl *Property,
       for (auto UI = proj->use_begin(), E = proj->use_end(); UI != E;) {
         auto *User = UI->getUser();
         ++UI;
+
+        if (isIncidentalUse(User))
+          continue;
+
+        // A nested begin_access will be mapped as a separate "Load".
+        if (isa<BeginAccessInst>(User))
+          continue;
+
         if (isa<StoreInst>(User))
           continue;
 
@@ -230,23 +242,6 @@ void LetPropertiesOpt::optimizeLetPropertyAccess(VarDecl *Property,
 
       proj->eraseFromParent();
       ++NumReplaced;
-      ChangedFunctions.insert(F);
-    }  else if (auto proj = dyn_cast<StructElementAddrInst>(Load)) {
-      // Copy the initializer into the function
-      // Replace the access to a let property by the value
-      // computed by this initializer.
-      SILValue clonedInit = cloneInitAt(proj);
-      SILBuilderWithScope B(proj);
-      for (auto UI = proj->use_begin(), E = proj->use_end(); UI != E;) {
-        auto *User = UI->getUser();
-        ++UI;
-        if (isa<StoreInst>(User))
-          continue;
-        replaceLoadSequence(User, clonedInit, B);
-        eraseUsesOfInstruction(User);
-        User->eraseFromParent();
-        ++NumReplaced;
-      }
       ChangedFunctions.insert(F);
     }
   }
@@ -422,7 +417,7 @@ LetPropertiesOpt::analyzeInitValue(SILInstruction *I, VarDecl *Property) {
   if (auto SI = dyn_cast<StructInst>(I)) {
     value = SI->getFieldValue(Property);
   } else if (auto SI = dyn_cast<StoreInst>(I)) {
-    auto Dest = SI->getDest();
+    auto Dest = stripAddressAccess(SI->getDest());
 
     assert(((isa<RefElementAddrInst>(Dest) &&
              cast<RefElementAddrInst>(Dest)->getField() == Property) ||
@@ -524,9 +519,12 @@ static bool isValidPropertyLoad(SILInstruction *I) {
 
   if (isa<StructElementAddrInst>(I) || isa<TupleElementAddrInst>(I)) {
     auto projection = cast<SingleValueInstruction>(I);
-    for (auto Use : getNonDebugUses(projection))
+    for (auto Use : getNonDebugUses(projection)) {
+      if (isIncidentalUse(Use->getUser()))
+        continue;
       if (!isValidPropertyLoad(Use->getUser()))
         return false;
+    }
     return true;
   }
 
@@ -545,11 +543,19 @@ void LetPropertiesOpt::collectPropertyAccess(SILInstruction *I,
                      << "':\n";
         llvm::dbgs() << "The instructions are:\n"; I->dumpInContext());
 
-  if (isa<RefElementAddrInst>(I) || isa<StructElementAddrInst>(I)) {
+  if (isa<RefElementAddrInst>(I) || isa<StructElementAddrInst>(I)
+      || isa<BeginAccessInst>(I)) {
     // Check if there is a store to this property.
     auto projection = cast<SingleValueInstruction>(I);
     for (auto Use : getNonDebugUses(projection)) {
       auto *User = Use->getUser();
+      if (isIncidentalUse(User))
+        continue;
+
+      // Each begin_access is analyzed as a separate property access. Do not
+      // consider a begin_access a use of the current projection.
+      if (isa<BeginAccessInst>(User))
+        continue;
 
       if (auto *SI = dyn_cast<StoreInst>(User)) {
         // There is a store into this property.
@@ -595,7 +601,12 @@ void LetPropertiesOpt::run(SILModuleTransform *T) {
         // It includes referencing this specific property (both reads and
         // stores), as well as implicit stores by means of e.g.
         // a struct instruction.
-        if (auto *REAI = dyn_cast<RefElementAddrInst>(&I)) {
+        if (auto *BAI = dyn_cast<BeginAccessInst>(&I)) {
+          if (auto *REAI =
+                  dyn_cast<RefElementAddrInst>(stripAddressAccess(BAI))) {
+            collectPropertyAccess(BAI, REAI->getField(), NonRemovable);
+          }
+        } else if (auto *REAI = dyn_cast<RefElementAddrInst>(&I)) {
           collectPropertyAccess(REAI, REAI->getField(), NonRemovable);
         } else if (auto *SEI = dyn_cast<StructExtractInst>(&I)) {
           collectPropertyAccess(SEI, SEI->getField(), NonRemovable);

--- a/test/SILOptimizer/let_properties_opts.swift
+++ b/test/SILOptimizer/let_properties_opts.swift
@@ -1,5 +1,5 @@
 // REQUIRES: plus_one_runtime
-// RUN: %target-swift-frontend %s -O -emit-sil | %FileCheck -check-prefix=CHECK-WMO %s
+// RUN: %target-swift-frontend %s -O -enforce-exclusivity=checked -emit-sil | %FileCheck -check-prefix=CHECK-WMO %s
 // RUN: %target-swift-frontend -primary-file %s -O -emit-sil | %FileCheck %s
 
 // Test propagation of non-static let properties with compile-time constant values.


### PR DESCRIPTION
Also, keep an eye out for places that SIL ownership will break the optimizer.
