### PR TITLE
[cmake] Always add local swift compilation jobs to the local job pool.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,18 +11,14 @@ endif()
 list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
-# Make a job pool for things that can't yet be distributed
-cmake_host_system_information(
-  RESULT localhost_logical_cores QUERY NUMBER_OF_LOGICAL_CORES)
-set_property(GLOBAL PROPERTY JOB_POOLS local_jobs=${localhost_logical_cores})
-# Put linking in that category
-set_property(GLOBAL PROPERTY JOB_POOL_LINK local_jobs)
-
 ENABLE_LANGUAGE(C)
 
 # First include general CMake utilities.
+include(SwiftLocalJobPool)
 include(SwiftUtils)
 include(CheckSymbolExists)
+
+initialize_local_jobpool()
 
 #
 # User-configurable options that control the inclusion and default build

--- a/cmake/modules/SwiftLocalJobPool.cmake
+++ b/cmake/modules/SwiftLocalJobPool.cmake
@@ -1,0 +1,15 @@
+
+function(initialize_local_jobpool)
+  # Make a job pool for things that can't yet be distributed
+  cmake_host_system_information(
+    RESULT localhost_logical_cores QUERY NUMBER_OF_LOGICAL_CORES)
+  set_property(GLOBAL PROPERTY JOB_POOLS local_jobs=${localhost_logical_cores})
+  # Put linking in that category.
+  set_property(GLOBAL PROPERTY JOB_POOL_LINK local_jobs)
+endfunction()
+
+function(add_target_to_local_jobpool target)
+  set_property(TARGET ${target} PROPERTY JOB_POOL_COMPILE local_jobs)
+  # We do not need to set link jobs to be in local_jobs since above, we make
+  # linking always local.
+endfunction()

--- a/cmake/modules/SwiftSource.cmake
+++ b/cmake/modules/SwiftSource.cmake
@@ -1,4 +1,5 @@
 include(SwiftUtils)
+include(SwiftLocalJobPool)
 
 # Process the sources within the given variable, pulling out any Swift
 # sources to be compiled with 'swift' directly. This updates
@@ -433,6 +434,7 @@ function(_compile_swift_files
       COMMAND ""
       OUTPUT ${obj_dirs}
       COMMENT "Generating obj dirs for ${first_output}")
+  add_target_to_local_jobpool(${obj_dirs_dependency_target})
 
   # Generate the api notes if we need them.
   if (apinotes_outputs)
@@ -449,6 +451,7 @@ function(_compile_swift_files
           ${depends_create_apinotes}
           ${obj_dirs_dependency_target}
         COMMENT "Generating API notes ${first_output}")
+    add_target_to_local_jobpool(${api_notes_dependency_target})
   endif()
 
   # Then we can compile both the object files and the swiftmodule files
@@ -476,6 +479,7 @@ function(_compile_swift_files
         ${swift_ide_test_dependency} ${api_notes_dependency_target}
         ${obj_dirs_dependency_target}
       COMMENT "Compiling ${first_output}")
+  add_target_to_local_jobpool(${dependency_target})
   set("${dependency_target_out_var_name}" "${dependency_target}" PARENT_SCOPE)
 
   # This is the target to generate:
@@ -511,6 +515,7 @@ function(_compile_swift_files
           ${swift_ide_test_dependency} ${api_notes_dependency_target}
           ${obj_dirs_dependency_target}
         COMMENT "Generating ${module_file}")
+    add_target_to_local_jobpool(${module_dependency_target})
     set("${dependency_module_target_out_var_name}" "${module_dependency_target}" PARENT_SCOPE)
 
     # This is the target to generate the .sib files. It is not built by default.
@@ -528,6 +533,7 @@ function(_compile_swift_files
           ${obj_dirs_dependency_target}
         COMMENT "Generating ${sib_file}"
         EXCLUDE_FROM_ALL)
+    add_target_to_local_jobpool(${sib_dependency_target})
     set("${dependency_sib_target_out_var_name}" "${sib_dependency_target}" PARENT_SCOPE)
 
     add_custom_command_target(
@@ -544,6 +550,7 @@ function(_compile_swift_files
           ${obj_dirs_dependency_target}
         COMMENT "Generating ${sibopt_file}"
         EXCLUDE_FROM_ALL)
+    add_target_to_local_jobpool(${sibopt_dependency_target})
     set("${dependency_sibopt_target_out_var_name}" "${sibopt_dependency_target}" PARENT_SCOPE)
 
     # This is the target to generate the .sibgen files. It is not built by default.
@@ -561,6 +568,7 @@ function(_compile_swift_files
           ${obj_dirs_dependency_target}
           COMMENT "Generating ${sibgen_file}"
           EXCLUDE_FROM_ALL)
+    add_target_to_local_jobpool(${sibgen_dependency_target})
     set("${dependency_sibgen_target_out_var_name}" "${sibgen_dependency_target}" PARENT_SCOPE)
   endif()
 


### PR DESCRIPTION
Compiling swift modules are always compiled local... so put them in the local
job pool.
