### PR TITLE
[gardening][enum class] Replace `unsigned char` with `uint8_t` for consistency

### DIFF
--- a/include/swift/AST/AttrKind.h
+++ b/include/swift/AST/AttrKind.h
@@ -23,7 +23,7 @@
 namespace swift {
 
 /// The associativity of a binary operator.
-enum class Associativity : unsigned char {
+enum class Associativity : uint8_t {
   /// Non-associative operators cannot be written next to other
   /// operators with the same precedence.  Relational operators are
   /// typically non-associative.

--- a/include/swift/AST/Builtins.h
+++ b/include/swift/AST/Builtins.h
@@ -39,7 +39,7 @@ namespace swift {
 Type getBuiltinType(ASTContext &Context, StringRef Name);
 
 /// OverloadedBuiltinKind - Whether and how a builtin is overloaded.
-enum class OverloadedBuiltinKind : unsigned char {
+enum class OverloadedBuiltinKind : uint8_t {
   /// The builtin is not overloaded.
   None,
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3879,7 +3879,7 @@ enum class AccessorKind {
 };
 
 /// The safety semantics of this addressor.
-enum class AddressorKind : unsigned char {
+enum class AddressorKind : uint8_t {
   /// \brief This is not an addressor.
   NotAddressor,
   /// \brief This is an unsafe addressor; it simply returns an address.
@@ -3896,7 +3896,7 @@ enum class AddressorKind : unsigned char {
 };
 
 /// Whether an access to storage is for reading, writing, or both.
-enum class AccessKind : unsigned char {
+enum class AccessKind : uint8_t {
   /// The access is just to read the current value.
   Read,
 
@@ -3908,11 +3908,11 @@ enum class AccessKind : unsigned char {
 };
 
 /// The way to actually evaluate an access to storage.
-enum class AccessStrategy : unsigned char {
+enum class AccessStrategy : uint8_t {
   /// The decl is a VarDecl with its own backing storage; evaluate its
   /// address directly.
   Storage,
-  
+
   /// The decl is a VarDecl with storage defined by a property behavior;
   /// this access may initialize or reassign the storage based on dataflow.
   BehaviorStorage,

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -104,7 +104,7 @@ enum class CheckedCastKind : unsigned {
   Last_CheckedCastKind = Swift3BridgingDowncast,
 };
 
-enum class AccessSemantics : unsigned char {
+enum class AccessSemantics : uint8_t {
   /// On a property or subscript reference, this is a direct access to
   /// the underlying storage.  On a function reference, this is a
   /// non-polymorphic access to a particular implementation.
@@ -113,7 +113,7 @@ enum class AccessSemantics : unsigned char {
   /// On a property or subscript reference, this is a direct,
   /// non-polymorphic access to the getter/setter accessors.
   DirectToAccessor,
-  
+
   /// On a property or subscript reference, this is an access to a property
   /// behavior that may be an initialization. Reads always go through the
   /// 'get' accessor on the property. Writes may go through the 'init' or

--- a/include/swift/AST/LayoutConstraint.h
+++ b/include/swift/AST/LayoutConstraint.h
@@ -31,7 +31,7 @@ class ASTContext;
 class ASTPrinter;
 
 /// Describes a layout constraint information.
-enum class LayoutConstraintKind : unsigned char {
+enum class LayoutConstraintKind : uint8_t {
   // It is not a known layout constraint.
   UnknownLayout,
   // It is a layout constraint representing a trivial type of an unknown size.

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2367,7 +2367,7 @@ BEGIN_CAN_TYPE_WRAPPER(DynamicSelfType, Type)
 END_CAN_TYPE_WRAPPER(DynamicSelfType, Type)
 
 /// A language-level calling convention.
-enum class SILFunctionLanguage : unsigned char {
+enum class SILFunctionLanguage : uint8_t {
   /// A variation of the Swift calling convention.
   Swift = 0,
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -276,7 +276,7 @@ public:
   /// Describes the kind of a lexical structure marker, indicating
   /// what kind of structural element we started parsing at a
   /// particular location.
-  enum class StructureMarkerKind : unsigned char {
+  enum class StructureMarkerKind : uint8_t {
     /// The start of a declaration.
     Declaration,
     /// The start of a statement.

--- a/include/swift/SIL/Consumption.h
+++ b/include/swift/SIL/Consumption.h
@@ -30,7 +30,7 @@ enum IsTake_t : bool { IsNotTake, IsTake };
 enum IsInitialization_t : bool { IsNotInitialization, IsInitialization };
 
 /// The behavior of a dynamic cast operation on the source value.
-enum class CastConsumptionKind : unsigned char {
+enum class CastConsumptionKind : uint8_t {
   /// The source value is always taken, regardless of whether the cast
   /// succeeds.  That is, if the cast fails, the source value is
   /// destroyed.

--- a/include/swift/SIL/SILLinkage.h
+++ b/include/swift/SIL/SILLinkage.h
@@ -29,7 +29,7 @@ namespace swift {
 /// first does not, perhaps by reading a value out of it (and then
 /// ignoring the result) or retaining it (and then releasing it
 /// later).
-enum class SILLinkage : unsigned char {
+enum class SILLinkage : uint8_t {
   /// This object definition is visible to multiple Swift modules (and
   /// thus potentially across linkage-unit boundaries).  There are no
   /// other object definitions with this name in the program.
@@ -79,7 +79,7 @@ enum class SILLinkage : unsigned char {
   /// module. Besides that caveat this should be treated exactly the same as
   /// shared.
   SharedExternal,
-  
+
   /// The same as SharedExternal, except that the definition is private in the
   /// other module. This can only occur if an inlined fragile function from
   /// another module references a private definition in the other module.
@@ -109,7 +109,7 @@ enum IsSerialized_t : unsigned char {
 };
 
 /// The scope in which a subclassable class can be subclassed.
-enum class SubclassScope : unsigned char {
+enum class SubclassScope : uint8_t {
   /// This class can be subclassed in other modules.
   External,
 

--- a/lib/AST/ConformanceLookupTable.h
+++ b/lib/AST/ConformanceLookupTable.h
@@ -42,7 +42,7 @@ class ModuleDecl;
 class ConformanceLookupTable {
   /// Describes the stage at which a particular nominal type or
   /// extension's conformances has been processed.
-  enum class ConformanceStage : unsigned char {
+  enum class ConformanceStage : uint8_t {
     /// The explicit conformances have been recorded in the lookup table.
     RecordedExplicit,
 

--- a/lib/IRGen/GenCast.h
+++ b/lib/IRGen/GenCast.h
@@ -34,7 +34,7 @@ namespace irgen {
   class Explosion;
 
   /// Discriminator for checked cast modes.
-  enum class CheckedCastMode : unsigned char {
+  enum class CheckedCastMode : uint8_t {
     Unconditional,
     Conditional,
   };

--- a/lib/IRGen/HeapTypeInfo.h
+++ b/lib/IRGen/HeapTypeInfo.h
@@ -32,7 +32,7 @@ namespace irgen {
   
 /// The kind of 'isa' encoding a heap object uses to reference its heap
 /// metadata.
-enum class IsaEncoding : unsigned char {
+enum class IsaEncoding : uint8_t {
   /// The object stores a plain pointer to its heap metadata as its first word.
   Pointer,
   /// The object's isa is managed by the Objective-C runtime and must be
@@ -43,7 +43,7 @@ enum class IsaEncoding : unsigned char {
   /// way.
   Unknown = ObjC,
 };
-  
+
 /// HeapTypeInfo - A type designed for use implementing a type
 /// which consists solely of something reference-counted.
 ///

--- a/lib/IRGen/IRGen.h
+++ b/lib/IRGen/IRGen.h
@@ -78,10 +78,10 @@ inline IsBitwiseTakable_t &operator&=(IsBitwiseTakable_t &l, IsBitwiseTakable_t 
 }
 
 /// The kind of reference counting implementation a heap object uses.
-enum class ReferenceCounting : unsigned char {
+enum class ReferenceCounting : uint8_t {
   /// The object uses native Swift reference counting.
   Native,
-  
+
   /// The object uses ObjC reference counting.
   ///
   /// When ObjC interop is enabled, native Swift class objects are also ObjC
@@ -90,20 +90,20 @@ enum class ReferenceCounting : unsigned char {
   ///
   /// Blocks are always ObjC reference counting compatible.
   ObjC,
-  
+
   /// The object uses _Block_copy/_Block_release reference counting.
   ///
   /// This is a strict subset of ObjC; all blocks are also ObjC reference
   /// counting compatible. The block is assumed to have already been moved to
   /// the heap so that _Block_copy returns the same object back.
   Block,
-  
+
   /// The object has an unknown reference counting implementation.
   ///
   /// This uses maximally-compatible reference counting entry points in the
   /// runtime.
   Unknown,
-  
+
   /// Cases prior to this one are binary-compatible with Unknown reference
   /// counting.
   LastUnknownCompatible = Unknown,
@@ -115,7 +115,7 @@ enum class ReferenceCounting : unsigned char {
   /// runtime, with a masking layer on top. A bit inside the pointer is used
   /// to signal native Swift refcounting.
   Bridge,
-  
+
   /// The object uses ErrorType's reference counting entry points.
   Error,
 };
@@ -135,16 +135,16 @@ enum OnHeap_t : unsigned char {
 };
 
 /// Whether a function requires extra data.
-enum class ExtraData : unsigned char {
+enum class ExtraData : uint8_t {
   /// The function requires no extra data.
   None,
 
   /// The function requires a retainable object pointer of extra data.
   Retainable,
-  
+
   /// The function takes its block object as extra data.
   Block,
-  
+
   Last_ExtraData = Block
 };
 
@@ -159,7 +159,7 @@ enum IsExact_t : bool {
 ///
 /// See the comment in RelativePointer.h.
 
-enum class SymbolReferenceKind : unsigned char {
+enum class SymbolReferenceKind : uint8_t {
   /// An absolute reference to the object, i.e. an ordinary pointer.
   ///
   /// Generally well-suited for when C compatibility is a must, dynamic

--- a/lib/IRGen/MemberAccessStrategy.h
+++ b/lib/IRGen/MemberAccessStrategy.h
@@ -27,12 +27,12 @@ namespace irgen {
 /// A class which describes how to access a particular physical member.
 class MemberAccessStrategy {
 public:
-  enum class OffsetKind : unsigned char {
+  enum class OffsetKind : uint8_t {
     /// A word-size offset that represents a number of bytes.
     Bytes_Word,
   };
 
-  enum class Kind : unsigned char {
+  enum class Kind : uint8_t {
     /// The member has complex or overlapping storage.  It cannot be
     /// accessed simply by projecting out to a particular offset.
     Complex,

--- a/lib/SILGen/ArgumentSource.h
+++ b/lib/SILGen/ArgumentSource.h
@@ -49,7 +49,7 @@ class Conversion;
 /// working with multiple ArgumentSources should document the order in
 /// which they plan to evaluate them.
 class ArgumentSource {
-  enum class Kind : unsigned char {
+  enum class Kind : uint8_t {
     Invalid,
     RValue,
     LValue,

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -191,11 +191,7 @@ static void InsertCFGDiamond(SILValue Cond, SILLocation Loc, SILBuilder &B,
 //===----------------------------------------------------------------------===//
 
 namespace {
-  enum class DIKind : unsigned char {
-    No,
-    Yes,
-    Partial
-  };
+enum class DIKind : uint8_t { No, Yes, Partial };
 } // end anonymous namespace
 
 /// This implements the lattice merge operation for 2 optional DIKinds.

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2666,7 +2666,7 @@ public:
 
 private:
   /// The kind of bindings that are permitted.
-  enum class AllowedBindingKind : unsigned char {
+  enum class AllowedBindingKind : uint8_t {
     /// Only the exact type.
     Exact,
     /// Supertypes of the specified type.
@@ -2676,7 +2676,7 @@ private:
   };
 
   /// The kind of literal binding found.
-  enum class LiteralBindingKind : unsigned char {
+  enum class LiteralBindingKind : uint8_t {
     None,
     Collection,
     Float,

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -148,7 +148,7 @@ class RequirementEnvironment;
 
 /// \brief The result of matching a particular declaration to a given
 /// requirement.
-enum class MatchKind : unsigned char {
+enum class MatchKind : uint8_t {
   /// \brief The witness matched the requirement exactly.
   ExactMatch,
 

--- a/tools/SourceKit/include/SourceKit/Support/Logging.h
+++ b/tools/SourceKit/include/SourceKit/Support/Logging.h
@@ -40,7 +40,7 @@ typedef IntrusiveRefCntPtr<Logger> LogRef;
 /// \endcode
 class Logger : public llvm::RefCountedBase<Logger> {
 public:
-  enum class Level : unsigned char {
+  enum class Level : uint8_t {
     /// \brief No logging.
     None = 0,
     /// \brief Warning level.


### PR DESCRIPTION
Before the changes:

- `git grep -E "enum class .+ : uint8_t \{" | wc -l`: 90
- `git grep -E "enum class .+ : unsigned char \{" | wc -l`: 26
