### PR TITLE
[silgen] Change SwitchEnumBuilder to invalidate the insertion point u…

### DIFF
--- a/lib/SILGen/SwitchEnumBuilder.cpp
+++ b/lib/SILGen/SwitchEnumBuilder.cpp
@@ -106,7 +106,7 @@ void SwitchEnumBuilder::emit() && {
       input = builder.createOwnedPHIArgument(optional.getType());
     }
     handler(input, presentScope);
-    assert(!builder.hasValidInsertionPoint());
+    builder.clearInsertionPoint();
   }
 
   for (NormalCaseData &caseData : caseDataArray) {
@@ -133,7 +133,7 @@ void SwitchEnumBuilder::emit() && {
       }
     }
     handler(input, presentScope);
-    assert(!builder.hasValidInsertionPoint());
+    builder.clearInsertionPoint();
   }
 
   // If we are asked to create a default block and it is specified that the
@@ -154,6 +154,6 @@ void SwitchEnumBuilder::emit() && {
       input = builder.createOwnedPHIArgument(optional.getType());
     }
     handler(input, presentScope);
-    assert(!builder.hasValidInsertionPoint());
+    builder.clearInsertionPoint();
   }
 }


### PR DESCRIPTION
…nconditonally after emitting a block, rather than asserting so.

If we perform an exit and do not use a terminator, then we will still have a set
insertion point. By unconditionally unsetting it, we gain the property that we
want and are nice to the normal exit case.