### PR TITLE
[stdlib][SR-7164] Excise #include <iostream> from Metadata.cpp. 

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -30,7 +30,6 @@
 #include <algorithm>
 #include <cctype>
 #include <condition_variable>
-#include <iostream>
 #include <new>
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
I excised `#include <iostream>` from `Metadata.cpp` , Because I think that streaming is not used.

Resolves [SR-7164](https://bugs.swift.org/browse/SR-7164).