### PR TITLE
[Lexer] Remove dead code

### DIFF
--- a/include/swift/Parse/Lexer.h
+++ b/include/swift/Parse/Lexer.h
@@ -459,14 +459,6 @@ private:
     return BufferStart + SourceMgr.getLocOffsetInBuffer(Loc, BufferID);
   }
 
-  StringRef getSubstring(const char *Start, unsigned Length) const {
-    assert(Start >= BufferStart && Start <= BufferEnd);
-    unsigned BytesUntilBufferEnd = BufferEnd - Start;
-    if (Length > BytesUntilBufferEnd)
-      Length = BytesUntilBufferEnd;
-    return StringRef(Start, Length);
-  }
-
   void lexImpl();
   InFlightDiagnostic diagnose(const char *Loc, Diagnostic Diag);
   


### PR DESCRIPTION
Remove `Lexer::getSubstring()`
The last usage was deleted in d522cd4270290e73ff4c957c252d4f2e8365b5a2.
