### PR TITLE
[AST] ParenType needs enough bits to store ValueOwnership::Owned.

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -290,7 +290,7 @@ protected:
     HasCachedType : 1
   );
 
-  enum { NumFlagBits = 5 };
+  enum { NumFlagBits = 8 };
   SWIFT_INLINE_BITFIELD(ParenType, SugarType, NumFlagBits,
     /// Whether there is an original type.
     Flags : NumFlagBits

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -35,19 +35,22 @@ _ = f0(X2(), {$0.g()})
 
 func inoutToSharedConversions() {
   func fooOW<T, U>(_ f : (__owned T) -> U) {}
-  fooOW({ (x : Int) in return Int(5) }) // '__owned'-to-'__owned' allowed
+  fooOW({ (x : Int) in return Int(5) }) // defaut-to-'__owned' allowed
+  fooOW({ (x : __owned Int) in return Int(5) }) // '__owned'-to-'__owned' allowed
   fooOW({ (x : __shared Int) in return Int(5) }) // '__shared'-to-'__owned' allowed
-  fooOW({ (x : inout Int) in return Int(5) }) // expected-error {{cannot convert value of type '(inout Int) -> Int' to expected argument type '(_) -> _'}}
+  fooOW({ (x : inout Int) in return Int(5) }) // expected-error {{cannot convert value of type '(inout Int) -> Int' to expected argument type '(__owned _) -> _'}}
   
   func fooIO<T, U>(_ f : (inout T) -> U) {}
   fooIO({ (x : inout Int) in return Int(5) }) // 'inout'-to-'inout' allowed
-  fooIO({ (x : __shared Int) in return Int(5) }) // expected-error {{cannot convert value of type '(__shared Int) -> Int' to expected argument type '(inout _) -> _'}}
   fooIO({ (x : Int) in return Int(5) }) // expected-error {{cannot convert value of type '(inout Int) -> Int' to expected argument type '(inout _) -> _'}}
+  fooIO({ (x : __shared Int) in return Int(5) }) // expected-error {{cannot convert value of type '(__shared Int) -> Int' to expected argument type '(inout _) -> _'}}
+  fooIO({ (x : __owned Int) in return Int(5) }) // expected-error {{cannot convert value of type '(__owned Int) -> Int' to expected argument type '(inout _) -> _'}}
 
   func fooSH<T, U>(_ f : (__shared T) -> U) {}
   fooSH({ (x : __shared Int) in return Int(5) }) // '__shared'-to-'__shared' allowed
+  fooSH({ (x : __owned Int) in return Int(5) }) // '__owned'-to-'__shared' allowed
   fooSH({ (x : inout Int) in return Int(5) }) // expected-error {{cannot convert value of type '(inout Int) -> Int' to expected argument type '(__shared _) -> _'}}
-  fooSH({ (x : Int) in return Int(5) }) // '__owned'-to-'__shared' allowed
+  fooSH({ (x : Int) in return Int(5) }) // default-to-'__shared' allowed
 }
 
 // Autoclosure

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -68,7 +68,7 @@ DemangleToMetadataTests.test("function types") {
 
   // Ownership parameters.
   expectEqual(type(of: f1_shared), _typeByMangledName("yyyXlhc")!)
-  expectEqual(type(of: f1_owned), _typeByMangledName("yyyXlc")!)
+  expectEqual(type(of: f1_owned), _typeByMangledName("yyyXlnc")!)
 
   // Mix-and-match.
   expectEqual(type(of: f2_variadic_inout), _typeByMangledName("yyytd_ytztc")!)

--- a/test/SILGen/owned.swift
+++ b/test/SILGen/owned.swift
@@ -22,3 +22,9 @@ struct Foo {
         let r = ref
     }
 }
+
+// rdar://problem/38390524
+// CHECK-LABEL: sil hidden @$S5owned19oneUnnamedArgument1yyAA14ValueAggregateVnF : $@convention(thin) (@owned ValueAggregate) -> () {
+func oneUnnamedArgument1(_: __owned ValueAggregate) {}
+// CHECK-LABEL: sil hidden @$S5owned19oneUnnamedArgument2yyAA12RefAggregateCnF : $@convention(thin) (@owned RefAggregate) -> () {
+func oneUnnamedArgument2(_: __owned RefAggregate) {}


### PR DESCRIPTION
The truncation here meant func foo(_: __owned X) {} was the same as
foo(_: X), so @guaranteed when that's the default.

Fixes rdar://problem/38390524.