### PR TITLE
[BatchMode] Fix non-portable test that relies on std::shuffle implementation.

### DIFF
--- a/test/Driver/batch_mode.swift
+++ b/test/Driver/batch_mode.swift
@@ -18,10 +18,32 @@
 // SEED0: Forming into 4 batches
 // SEED0: Adding {compile: {{file-01-.*}} <= file-01.swift} to batch 0
 // SEED0: Adding {compile: {{file-02-.*}} <= file-02.swift} to batch 0
+// SEED0: Adding {compile: {{file-03-.*}} <= file-03.swift} to batch 0
+// SEED0: Adding {compile: {{file-04-.*}} <= file-04.swift} to batch 0
+// SEED0: Adding {compile: {{file-05-.*}} <= file-05.swift} to batch 0
+// SEED0: Adding {compile: {{file-06-.*}} <= file-06.swift} to batch 0
+// SEED0: Adding {compile: {{file-07-.*}} <= file-07.swift} to batch 0
+// SEED0: Adding {compile: {{file-08-.*}} <= file-08.swift} to batch 0
 // SEED0: Adding {compile: {{file-09-.*}} <= file-09.swift} to batch 1
 // SEED0: Adding {compile: {{file-10-.*}} <= file-10.swift} to batch 1
+// SEED0: Adding {compile: {{file-11-.*}} <= file-11.swift} to batch 1
+// SEED0: Adding {compile: {{file-12-.*}} <= file-12.swift} to batch 1
+// SEED0: Adding {compile: {{file-13-.*}} <= file-13.swift} to batch 1
+// SEED0: Adding {compile: {{file-14-.*}} <= file-14.swift} to batch 1
+// SEED0: Adding {compile: {{file-15-.*}} <= file-15.swift} to batch 1
+// SEED0: Adding {compile: {{file-16-.*}} <= file-16.swift} to batch 1
+// SEED0: Adding {compile: {{file-17-.*}} <= file-17.swift} to batch 2
+// SEED0: Adding {compile: {{file-18-.*}} <= file-18.swift} to batch 2
 // SEED0: Adding {compile: {{file-19-.*}} <= file-19.swift} to batch 2
 // SEED0: Adding {compile: {{file-20-.*}} <= file-20.swift} to batch 2
+// SEED0: Adding {compile: {{file-21-.*}} <= file-21.swift} to batch 2
+// SEED0: Adding {compile: {{file-22-.*}} <= file-22.swift} to batch 2
+// SEED0: Adding {compile: {{file-23-.*}} <= file-23.swift} to batch 2
+// SEED0: Adding {compile: {{file-24-.*}} <= file-24.swift} to batch 3
+// SEED0: Adding {compile: {{file-25-.*}} <= file-25.swift} to batch 3
+// SEED0: Adding {compile: {{file-26-.*}} <= file-26.swift} to batch 3
+// SEED0: Adding {compile: {{file-27-.*}} <= file-27.swift} to batch 3
+// SEED0: Adding {compile: {{file-28-.*}} <= file-28.swift} to batch 3
 // SEED0: Adding {compile: {{file-29-.*}} <= file-29.swift} to batch 3
 // SEED0: Adding {compile: {{file-30-.*}} <= file-30.swift} to batch 3
 // SEED0: Forming batch job from 8 constituents
@@ -35,10 +57,36 @@
 //
 // SEED1: Found 30 batchable jobs
 // SEED1: Forming into 4 batches
-// SEED1: Adding {compile: file-{{.*}} <= file-{{.*}}.swift} to batch 0
-// SEED1: Adding {compile: file-{{.*}} <= file-{{.*}}.swift} to batch 1
-// SEED1: Adding {compile: file-{{.*}} <= file-{{.*}}.swift} to batch 2
-// SEED1: Adding {compile: file-{{.*}} <= file-{{.*}}.swift} to batch 3
+// SEED1: Adding {compile: {{file-01-.*}} <= file-01.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-02-.*}} <= file-02.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-03-.*}} <= file-03.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-04-.*}} <= file-04.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-05-.*}} <= file-05.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-06-.*}} <= file-06.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-07-.*}} <= file-07.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-08-.*}} <= file-08.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-09-.*}} <= file-09.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-10-.*}} <= file-10.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-11-.*}} <= file-11.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-12-.*}} <= file-12.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-13-.*}} <= file-13.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-14-.*}} <= file-14.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-15-.*}} <= file-15.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-16-.*}} <= file-16.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-17-.*}} <= file-17.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-18-.*}} <= file-18.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-19-.*}} <= file-19.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-20-.*}} <= file-20.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-21-.*}} <= file-21.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-22-.*}} <= file-22.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-23-.*}} <= file-23.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-24-.*}} <= file-24.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-25-.*}} <= file-25.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-26-.*}} <= file-26.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-27-.*}} <= file-27.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-28-.*}} <= file-28.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-29-.*}} <= file-29.swift} to batch {{[0-3]}}
+// SEED1: Adding {compile: {{file-30-.*}} <= file-30.swift} to batch {{[0-3]}}
 // SEED1: Forming batch job from 8 constituents
 // SEED1: Forming batch job from 8 constituents
 // SEED1: Forming batch job from 7 constituents
@@ -50,10 +98,36 @@
 //
 // SEED2: Found 30 batchable jobs
 // SEED2: Forming into 4 batches
-// SEED2: Adding {compile: file-{{.*}} <= file-{{.*}}.swift} to batch 0
-// SEED2: Adding {compile: file-{{.*}} <= file-{{.*}}.swift} to batch 1
-// SEED2: Adding {compile: file-{{.*}} <= file-{{.*}}.swift} to batch 2
-// SEED2: Adding {compile: file-{{.*}} <= file-{{.*}}.swift} to batch 3
+// SEED2: Adding {compile: {{file-01-.*}} <= file-01.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-02-.*}} <= file-02.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-03-.*}} <= file-03.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-04-.*}} <= file-04.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-05-.*}} <= file-05.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-06-.*}} <= file-06.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-07-.*}} <= file-07.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-08-.*}} <= file-08.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-09-.*}} <= file-09.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-10-.*}} <= file-10.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-11-.*}} <= file-11.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-12-.*}} <= file-12.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-13-.*}} <= file-13.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-14-.*}} <= file-14.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-15-.*}} <= file-15.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-16-.*}} <= file-16.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-17-.*}} <= file-17.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-18-.*}} <= file-18.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-19-.*}} <= file-19.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-20-.*}} <= file-20.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-21-.*}} <= file-21.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-22-.*}} <= file-22.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-23-.*}} <= file-23.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-24-.*}} <= file-24.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-25-.*}} <= file-25.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-26-.*}} <= file-26.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-27-.*}} <= file-27.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-28-.*}} <= file-28.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-29-.*}} <= file-29.swift} to batch {{[0-3]}}
+// SEED2: Adding {compile: {{file-30-.*}} <= file-30.swift} to batch {{[0-3]}}
 // SEED2: Forming batch job from 8 constituents
 // SEED2: Forming batch job from 8 constituents
 // SEED2: Forming batch job from 7 constituents


### PR DESCRIPTION
A sad little saga of random shuffles: in #15091 I changed the algorithm that the test-only `-driver-batch-seed` mode uses to randomly assign files to batches, to make that algorithm preserve the invariant that batches are a subsequence of the top-level input sequence.

The change made the driver shuffle the batch-selection order and not-shuffle (as it previously did) the file-assignment order. In so doing, I broke one of the existing tests that was supposed to be insensitive to randomization. The test tried to be randomization-insensitive by being insensitive to file-assignment order, but it accidentally remained sensitive to batch-selection order.

As it happens, this didn't break on _my_ workstation because the sequence of batches wired-in to the test was a subsequence of the sequence of batches assigned by `std::shuffle` when running on libcxx. But only on a libcxx implementation. It turns out that `std::shuffle` isn't especially strictly specified, and libstdc++ doesn't use the same shuffling algorithm, so the test breaks on Fedora.

