### PR TITLE
Disable Lazy.swift under Linux ASAN.

### DIFF
--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -12,6 +12,10 @@
 // RUN: %target-run-simple-swiftgyb
 // REQUIRES: executable_test
 
+// <rdar://35797159> [Associated Type Inference]
+// heap-use-after-free ASTContext::getSpecializedConformance
+// llvm::FoldingSetBase::InsertNode
+// REQUIRES: OS=macosx || no_asan
 
 import StdlibUnittest
 import StdlibCollectionUnittest


### PR DESCRIPTION
Waiting for a fix for <rdar://35797159> [Associated Type Inference]
Swift CI: 1. OSS - Swift ASAN - Ubuntu 16.04 (master)
heap-use-after-free ASTContext::getSpecializedConformance
llvm::FoldingSetBase::InsertNode
