### PR TITLE
☣️ [stdlib] Extract and re-use ClosedRange.Index

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -92,6 +92,7 @@ set(SWIFTLIB_ESSENTIAL
   Optional.swift
   OptionSet.swift
   OutputStream.swift
+  PastEndIndex.swift
   Pointer.swift
   Policy.swift
   PrefixWhile.swift

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -126,66 +126,6 @@ where Bound: Strideable, Bound.Stride: SignedInteger {
   public typealias Iterator = IndexingIterator<ClosedRange<Bound>>
 }
 
-extension ClosedRange {
-  @_frozen // FIXME(resilience)
-  public enum Index {
-    case pastEnd
-    case inRange(Bound)
-  }
-}
-
-extension ClosedRange.Index: Equatable where Bound: Equatable {
-  @inlinable
-  public static func == (
-    lhs: ClosedRange<Bound>.Index,
-    rhs: ClosedRange<Bound>.Index
-  ) -> Bool {
-    switch (lhs, rhs) {
-    case (.inRange(let l), .inRange(let r)):
-      return l == r
-    case (.pastEnd, .pastEnd):
-      return true
-    default:
-      return false
-    }
-  }
-}
-
-extension ClosedRange.Index: Comparable where Bound: Comparable {
-  @inlinable
-  public static func < (
-    lhs: ClosedRange<Bound>.Index,
-    rhs: ClosedRange<Bound>.Index
-  ) -> Bool {
-    switch (lhs, rhs) {
-    case (.inRange(let l), .inRange(let r)):
-      return l < r
-    case (.inRange(_), .pastEnd):
-      return true
-    default:
-      return false
-    }
-  }
-}
-
-extension ClosedRange.Index: Hashable where Bound: Hashable {
-  @inlinable // FIXME(sil-serialize-all)
-  public var hashValue: Int {
-    return _hashValue(for: self)
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
-  public func _hash(into hasher: inout _Hasher) {
-    switch self {
-    case .inRange(let value):
-      hasher.append(0 as Int8)
-      hasher.append(value)
-    case .pastEnd:
-      hasher.append(1 as Int8)
-    }
-  }
-}
-
 // FIXME: this should only be conformance to RandomAccessCollection but
 // the compiler balks without all 3
 extension ClosedRange: Collection, BidirectionalCollection, RandomAccessCollection
@@ -193,6 +133,7 @@ where Bound : Strideable, Bound.Stride : SignedInteger {
   // while a ClosedRange can't be empty, a _slice_ of a ClosedRange can,
   // so ClosedRange can't be its own self-slice unlike Range
   public typealias SubSequence = Slice<ClosedRange<Bound>>
+  public typealias Index = PastEndIndex<Bound>
 
   /// The position of the first element in the range.
   @inlinable

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -126,7 +126,7 @@ where Bound: Strideable, Bound.Stride: SignedInteger {
   public typealias Iterator = IndexingIterator<ClosedRange<Bound>>
 }
 
-extension ClosedRange where Bound : Strideable, Bound.Stride : SignedInteger {
+extension ClosedRange {
   @_frozen // FIXME(resilience)
   public enum Index {
     case pastEnd
@@ -134,7 +134,7 @@ extension ClosedRange where Bound : Strideable, Bound.Stride : SignedInteger {
   }
 }
 
-extension ClosedRange.Index : Comparable {
+extension ClosedRange.Index: Equatable where Bound: Equatable {
   @inlinable
   public static func == (
     lhs: ClosedRange<Bound>.Index,
@@ -149,7 +149,9 @@ extension ClosedRange.Index : Comparable {
       return false
     }
   }
+}
 
+extension ClosedRange.Index: Comparable where Bound: Comparable {
   @inlinable
   public static func < (
     lhs: ClosedRange<Bound>.Index,
@@ -166,8 +168,7 @@ extension ClosedRange.Index : Comparable {
   }
 }
 
-extension ClosedRange.Index: Hashable
-where Bound: Strideable, Bound.Stride: SignedInteger, Bound: Hashable {
+extension ClosedRange.Index: Hashable where Bound: Hashable {
   @inlinable // FIXME(sil-serialize-all)
   public var hashValue: Int {
     return _hashValue(for: self)
@@ -188,8 +189,7 @@ where Bound: Strideable, Bound.Stride: SignedInteger, Bound: Hashable {
 // FIXME: this should only be conformance to RandomAccessCollection but
 // the compiler balks without all 3
 extension ClosedRange: Collection, BidirectionalCollection, RandomAccessCollection
-where Bound : Strideable, Bound.Stride : SignedInteger
-{
+where Bound : Strideable, Bound.Stride : SignedInteger {
   // while a ClosedRange can't be empty, a _slice_ of a ClosedRange can,
   // so ClosedRange can't be its own self-slice unlike Range
   public typealias SubSequence = Slice<ClosedRange<Bound>>

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -74,6 +74,7 @@
     "WriteBackMutableSlice.swift",
     "UnfoldSequence.swift",
     "UIntBuffer.swift",
+    "PastEndIndex.swift",
     {
       "Type-erased": [
         "ExistentialCollection.swift"

--- a/stdlib/public/core/PastEndIndex.swift
+++ b/stdlib/public/core/PastEndIndex.swift
@@ -1,0 +1,57 @@
+//===--- PastEndIndex.swift -----------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// FIXME: docs
+@_frozen
+public enum PastEndIndex<Bound> {
+  case pastEnd
+  case inRange(Bound)
+}
+
+extension PastEndIndex: Equatable where Bound: Equatable {
+  @inlinable
+  public static func == (lhs: PastEndIndex, rhs: PastEndIndex) -> Bool {
+    switch (lhs, rhs) {
+    case (.inRange(let l), .inRange(let r)):
+      return l == r
+    case (.pastEnd, .pastEnd):
+      return true
+    default:
+      return false
+    }
+  }
+}
+
+extension PastEndIndex: Comparable where Bound: Comparable {
+  @inlinable
+  public static func < (lhs: PastEndIndex, rhs: PastEndIndex) -> Bool {
+    switch (lhs, rhs) {
+    case (.inRange(let l), .inRange(let r)):
+      return l < r
+    case (.inRange(_), .pastEnd):
+      return true
+    default:
+      return false
+    }
+  }
+}
+
+extension PastEndIndex: Hashable where Bound: Hashable {
+  public var hashValue: Int {
+    switch self {
+    case .inRange(let value):
+      return value.hashValue
+    case .pastEnd:
+      return .max
+    }
+  }
+}

--- a/stdlib/public/core/PastEndIndex.swift
+++ b/stdlib/public/core/PastEndIndex.swift
@@ -47,11 +47,15 @@ extension PastEndIndex: Comparable where Bound: Comparable {
 
 extension PastEndIndex: Hashable where Bound: Hashable {
   public var hashValue: Int {
+    return _hashValue(for: self)
+  }
+
+  public func _hash(into hasher: inout _Hasher) {
     switch self {
     case .inRange(let value):
-      return value.hashValue
+      return hasher.append(value)
     case .pastEnd:
-      return .max
+      return hasher.append(Int.max)
     }
   }
 }


### PR DESCRIPTION
The type formerly known as `ClosedRange.Index` proves to be quite useful even outside `ClosedRange` (if we remove the requirements imposed on it by it's parent type). One example of such re-use can be found in [apple/swift#14288](https://github.com/apple/swift/pull/14288), where `StrideThrough`'s `Collection` conformance takes advantage of it. Another example is presented here: `LazyPrefixWhileCollection` apparently used a similar type as its `Index`.

I believe this warrants the promotion to the top level, as well as a new name. Please welcome: `PastEndIndex`.