### PR TITLE
Add test that we correctly serialize SIL functions whose bodies are emitted by Clang

### DIFF
--- a/test/ClangImporter/Inputs/static_inline.swift
+++ b/test/ClangImporter/Inputs/static_inline.swift
@@ -1,0 +1,3 @@
+@_inlineable public func testit(x: Int32) -> Int32 {
+  return c_inline_func(x)
+}

--- a/test/ClangImporter/static_inline.swift
+++ b/test/ClangImporter/static_inline.swift
@@ -2,16 +2,18 @@
 
 // Check if SIL printing+parsing of a clang imported function works.
 
-// RUN: %target-swift-frontend -parse-as-library -module-name=test -emit-sil %s -import-objc-header %S/Inputs/static_inline.h -o %t/test.sil
-// RUN: %FileCheck < %t/test.sil %s
-// RUN: %target-swift-frontend -parse-as-library -module-name=test -O -emit-ir %t/test.sil -import-objc-header %S/Inputs/static_inline.h | %FileCheck --check-prefix=CHECK-IR %s
+// RUN: %target-swift-frontend -parse-as-library -module-name=static_inline -emit-sil %S/Inputs/static_inline.swift -import-objc-header %S/Inputs/static_inline.h -o %t/static_inline.sil
+// RUN: %FileCheck < %t/static_inline.sil %s
+// RUN: %target-swift-frontend -parse-as-library -module-name=static_inline -O -emit-ir %t/static_inline.sil -import-objc-header %S/Inputs/static_inline.h | %FileCheck --check-prefix=CHECK-IR %s
 
 // CHECK: sil shared [serializable] [clang c_inline_func] @c_inline_func : $@convention(c) (Int32) -> Int32
 
-// CHECK-IR-LABEL: define{{.*}} i32 @"$S4test6testit1xs5Int32VAE_tF"(i32)
+// CHECK-IR-LABEL: define{{.*}} i32 @"$S13static_inline6testit1xs5Int32VAE_tF"(i32)
 // CHECK-IR: = add {{.*}}, 27
 // CHECK-IR: ret
 
-public func testit(x: Int32) -> Int32 {
-  return c_inline_func(x)
+import static_inline
+
+public func mytest(x: Int32) -> Int32 {
+  return testit(x: x)
 }

--- a/test/ClangImporter/static_inline_serialize.swift
+++ b/test/ClangImporter/static_inline_serialize.swift
@@ -1,0 +1,19 @@
+// RUN: %empty-directory(%t)
+
+// Try serialization of clang-generated functions.
+
+// RUN: %target-swift-frontend -parse-as-library -module-name=static_inline -emit-module %S/Inputs/static_inline.swift -import-objc-header %S/Inputs/static_inline.h -o %t/static_inline.swiftmodule
+// RUN: %target-swift-frontend -module-name test -O -emit-sil %s -I %t | %FileCheck %s
+// RUN: %target-swift-frontend -module-name test -O -emit-ir %s -I %t | %FileCheck --check-prefix=CHECK-IR %s
+
+// CHECK: sil shared_external [clang c_inline_func] @c_inline_func : $@convention(c) (Int32) -> Int32
+
+// CHECK-IR-LABEL: define{{.*}} i32 @"$S4test6mytest1xs5Int32VAE_tF"(i32)
+// CHECK-IR: = add {{.*}}, 27
+// CHECK-IR: ret
+
+import static_inline
+
+public func mytest(x: Int32) -> Int32 {
+  return testit(x: x)
+}


### PR DESCRIPTION
This closes out <rdar://problem/19978257>, which was implemented
a while ago in c2b8bb22ba73610c12bbd27c15c9590daecd8004, but that
commit did not add any tests.