### PR TITLE
[test] Make sure directory exists before putting a module cache in it

### DIFF
--- a/test/Driver/swift-version-default.swift
+++ b/test/Driver/swift-version-default.swift
@@ -1,3 +1,4 @@
+// RUN: %empty-directory(%t)
 // RUN: %swiftc_driver_plain -target %target-triple -module-cache-path %t -typecheck -Xfrontend -verify %s
 
 // This test should be updated to match the expected default Swift version


### PR DESCRIPTION
This test uses `%swiftc_driver_plain` instead of `%swiftc_driver` or `%target-build-swift` because it's testing what the driver does when invoked with no `-swift-version` argument, but that means we have to manually set up things like a module cache path. This will then fail if it's the first Driver test run in a clean build directory (because of where lit.py decides to put temporary files).

rdar://problem/38354843