### PR TITLE
[Syntax]Add a deserializer that convert json to libSyntax tree

### DIFF
--- a/include/swift/Syntax/Serialization/SyntaxDeserialization.h
+++ b/include/swift/Syntax/Serialization/SyntaxDeserialization.h
@@ -1,0 +1,193 @@
+//===--- SyntaxDeserialization.h - Swift Syntax Deserialization --*- C++-*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file provides the deserialization from JSON to RawSyntax nodes and their
+// constituent parts.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SYNTAX_SERIALIZATION_SYNTAXDESERIALIZATION_H
+#define SWIFT_SYNTAX_SERIALIZATION_SYNTAXDESERIALIZATION_H
+
+#include "swift/Basic/StringExtras.h"
+#include "swift/Syntax/RawSyntax.h"
+#include "swift/Syntax/SyntaxNodes.h"
+#include "llvm/ADT/StringSwitch.h"
+#include "llvm/Support/YAMLTraits.h"
+#include <forward_list>
+
+namespace llvm {
+namespace yaml {
+
+/// Deserialization traits for SourcePresence.
+template <> struct ScalarEnumerationTraits<swift::SourcePresence> {
+  static void enumeration(IO &in, swift::SourcePresence &value) {
+    in.enumCase(value, "Present", swift::SourcePresence::Present);
+    in.enumCase(value, "Missing", swift::SourcePresence::Missing);
+  }
+};
+
+/// Deserialization traits for swift::tok.
+template <> struct ScalarEnumerationTraits<swift::tok> {
+  static void enumeration(IO &in, swift::tok &value) {
+#define TOKEN(name) in.enumCase(value, #name, swift::tok::name);
+#include "swift/Syntax/TokenKinds.def"
+  }
+};
+
+/// Deserialization traits for Trivia.
+/// An array of the underlying TriviaPieces will be deserialized as Trivia.
+template <typename Context> swift::TriviaPiece yamlize(IO &io, Context &Ctx) {
+  io.beginMapping();
+  auto ret = MappingTraits<swift::TriviaPiece>::mapping(io);
+  io.endMapping();
+  return ret;
+}
+
+template <typename Context>
+void yamlize(IO &io, std::vector<swift::TriviaPiece> &Seq, bool, Context &Ctx) {
+  unsigned incnt = io.beginSequence();
+  for (unsigned i = 0; i < incnt; ++i) {
+    void *SaveInfo;
+    if (io.preflightElement(i, SaveInfo)) {
+      Seq.push_back(yamlize(io, Ctx));
+      io.postflightElement(SaveInfo);
+    }
+  }
+  io.endSequence();
+}
+
+template <> struct SequenceTraits<std::vector<swift::TriviaPiece>> {
+  static size_t size(IO &in, std::vector<swift::TriviaPiece> &seq) {
+    return seq.size();
+  }
+};
+
+/// Deserialization traits for RawSyntax list.
+template <> struct SequenceTraits<std::vector<swift::RC<swift::RawSyntax>>> {
+  static size_t size(IO &in, std::vector<swift::RC<swift::RawSyntax>> &seq) {
+    return seq.size();
+  }
+  static swift::RC<swift::RawSyntax> &
+  element(IO &in, std::vector<swift::RC<swift::RawSyntax>> &seq, size_t index) {
+    if (seq.size() <= index) {
+      seq.resize(index + 1);
+    }
+    return const_cast<swift::RC<swift::RawSyntax> &>(seq[index]);
+  }
+};
+
+/// An adapter struct that provides a nested structure for token content.
+struct TokenDescription {
+  bool hasValue = false;
+  swift::tok Kind;
+  StringRef Text;
+};
+
+/// Desrialization traits for TokenDescription.
+/// TokenDescriptions always serialized with a token kind, which is
+/// the stringified version of their name in the tok:: enum.
+/// ```
+/// {
+///   "kind": <token name, e.g. "kw_struct">,
+/// }
+/// ```
+///
+/// For tokens that have some kind of text attached, like literals or
+/// identifiers, the serialized form will also have a "text" key containing
+/// that text as the value.
+template <> struct MappingTraits<TokenDescription> {
+  static void mapping(IO &in, TokenDescription &value) {
+    in.mapRequired("kind", value.Kind);
+    value.hasValue = true;
+    if (!swift::isTokenTextDetermined(value.Kind)) {
+      in.mapRequired("text", value.Text);
+    } else {
+      value.Text = swift::getTokenText(value.Kind);
+    }
+  }
+};
+
+/// Deserialization traits for RC<RawSyntax>.
+/// First it will check whether the node is null.
+/// Then this will be different depending if the raw syntax node is a Token or
+/// not. Token nodes will always have this structure:
+/// ```
+/// {
+///   "tokenKind": { "kind": <token kind>, "text": <token text> },
+///   "leadingTrivia": [ <trivia pieces...> ],
+///   "trailingTrivia": [ <trivia pieces...> ],
+///   "presence": <"Present" or "Missing">
+/// }
+/// ```
+/// All other raw syntax nodes will have this structure:
+/// ```
+/// {
+///   "kind": <syntax kind>,
+///   "layout": [ <raw syntax nodes...> ],
+///   "presence": <"Present" or "Missing">
+/// }
+/// ```
+
+template <> struct MappingTraits<swift::RC<swift::RawSyntax>> {
+  static void mapping(IO &in, swift::RC<swift::RawSyntax> &value) {
+    TokenDescription description;
+    auto input = static_cast<Input *>(&in);
+    /// Check whether this is null
+    if (input->getCurrentNode()->getType() != Node::NodeKind::NK_Mapping) {
+      return;
+    }
+    in.mapOptional("tokenKind", description);
+    if (description.hasValue) {
+      swift::tok tokenKind = description.Kind;
+      StringRef text = description.Text;
+      std::vector<swift::TriviaPiece> leadingTrivia;
+      in.mapRequired("leadingTrivia", leadingTrivia);
+      std::vector<swift::TriviaPiece> trailingTrivia;
+      in.mapRequired("trailingTrivia", trailingTrivia);
+      swift::SourcePresence presence;
+      in.mapRequired("presence", presence);
+      value = swift::RawSyntax::make(tokenKind, text, leadingTrivia,
+                                     trailingTrivia, presence, nullptr);
+    } else {
+      swift::SyntaxKind kind;
+      in.mapRequired("kind", kind);
+      std::vector<swift::RC<swift::RawSyntax>> layout;
+      in.mapRequired("layout", layout);
+      swift::SourcePresence presence;
+      in.mapRequired("presence", presence);
+      value = swift::RawSyntax::make(kind, layout, presence, nullptr);
+    }
+  }
+};
+
+} // end namespace yaml
+} // end namespace llvm
+
+namespace swift {
+namespace json {
+class SyntaxDeserializer {
+  llvm::yaml::Input Input;
+
+public:
+  SyntaxDeserializer(llvm::StringRef InputContent) : Input(InputContent) {}
+  SyntaxDeserializer(llvm::MemoryBufferRef buffer) : Input(buffer) {}
+  llvm::Optional<swift::SourceFileSyntax> getSourceFileSyntax() {
+    swift::RC<swift::RawSyntax> raw;
+    Input >> raw;
+    return swift::make<swift::SourceFileSyntax>(raw);
+  }
+};
+} // namespace json
+} // namespace swift
+
+#endif /* SWIFT_SYNTAX_SERIALIZATION_SYNTAXDESERIALIZATION_H */

--- a/include/swift/Syntax/SyntaxKind.h.gyb
+++ b/include/swift/Syntax/SyntaxKind.h.gyb
@@ -13,7 +13,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -26,6 +26,7 @@
 
 #include "swift/Basic/InlineBitfield.h"
 #include "swift/Basic/JSONSerialization.h"
+#include "llvm/Support/YAMLTraits.h"
 
 namespace swift {
 namespace syntax {
@@ -90,4 +91,21 @@ struct ScalarEnumerationTraits<syntax::SyntaxKind> {
 } // end namespace json
 } // end namespace swift
 
+namespace llvm {
+namespace yaml {
+
+/// Deserialization traits for SyntaxKind.
+template <>
+struct ScalarEnumerationTraits<swift::syntax::SyntaxKind> {
+  static void enumeration(IO &in, swift::syntax::SyntaxKind &value) {
+    in.enumCase(value, "Token", swift::syntax::SyntaxKind::Token);
+    in.enumCase(value, "Unknown", swift::syntax::SyntaxKind::Unknown);
+% for node in SYNTAX_NODES:
+    in.enumCase(value, "${node.syntax_kind}", swift::syntax::SyntaxKind::${node.syntax_kind});
+% end
+  }
+};
+
+} // end namespace yaml
+} // end namespace llvm
 #endif // SWIFT_SYNTAX_KIND_H

--- a/include/swift/Syntax/Trivia.h.gyb
+++ b/include/swift/Syntax/Trivia.h.gyb
@@ -10,7 +10,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -91,6 +91,7 @@
 #include "swift/Basic/JSONSerialization.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/YAMLTraits.h"
 
 #include <vector>
 
@@ -129,6 +130,7 @@ class TriviaPiece {
       : Kind(Kind), Count(Count), Text() {}
 
   friend struct json::ObjectTraits<TriviaPiece>;
+  friend struct llvm::yaml::MappingTraits<TriviaPiece>;
 
 public:
 
@@ -412,4 +414,57 @@ struct ScalarEnumerationTraits<syntax::TriviaKind> {
 };
 } // namespace json
 } // namespace swift
+
+namespace llvm {
+namespace yaml {
+
+/// Deserialization traits for TriviaPiece.
+/// - All trivia pieces will have a "kind" key that contains the serialized
+///   name of the trivia kind.
+/// - Comment trivia will have the associated text of the comment under the
+///   "value" key.
+/// - All other trivia will have the associated integer count of their
+///   occurrences under the "value" key.
+template<>
+struct MappingTraits<swift::syntax::TriviaPiece> {
+  static swift::syntax::TriviaPiece mapping(IO &in) {
+    swift::syntax::TriviaKind kind;
+    in.mapRequired("kind", kind);
+    switch (kind) {
+% for trivia in TRIVIAS:
+    case swift::syntax::TriviaKind::${trivia.name}: {
+% if trivia.is_collection():
+
+/// FIXME: This is a workaround for existing bug from llvm yaml parser
+/// which would raise error when deserializing number with trailing character
+/// like "1\n". See https://bugs.llvm.org/show_bug.cgi?id=15505
+      StringRef str;
+      in.mapRequired("value", str);
+      unsigned count = std::atoi(str.data());
+      return swift::syntax::TriviaPiece(kind, count);
+% else:
+      StringRef text;
+      in.mapRequired("value", text);
+      return swift::syntax::TriviaPiece(kind, text);
+% end
+      break;
+    }
+% end
+    }
+  }
+};
+
+/// Deserialization traits for TriviaKind.
+template <>
+struct ScalarEnumerationTraits<swift::syntax::TriviaKind> {
+  static void enumeration(IO &in, swift::syntax::TriviaKind &value) {
+% for trivia in TRIVIAS:
+    in.enumCase(value, "${trivia.name}", swift::syntax::TriviaKind::${trivia.name});
+% end
+  }
+};
+
+
+} // namespace yaml
+} // namespace llvm
 #endif // SWIFT_SYNTAX_TRIVIA_H

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -4,6 +4,10 @@
 // RUN: diff -u %S/Outputs/round_trip_parse_gen.swift.withkinds %t.withkinds
 // RUN: %swift-syntax-test -input-source-filename %s -eof > %t
 // RUN: diff -u %s %t
+// RUN: %empty-directory(%t)
+// RUN: %swift-syntax-test -serialize-raw-tree -input-source-filename %s > %t/serialized.json
+// RUN: %swift-syntax-test -deserialize-raw-tree -input-source-filename %t/serialized.json -output-filename %t/output.swift
+// RUN: diff -u %s %t/output.swift
 
 import <AccessPathComponent>ABC</AccessPathComponent></ImportDecl><ImportDecl>
 import <AccessPathComponent>A.</AccessPathComponent><AccessPathComponent>B.</AccessPathComponent><AccessPathComponent>C</AccessPathComponent></ImportDecl><ImportDecl><Attribute>

--- a/test/Syntax/round_trip_parse_gen.swift
+++ b/test/Syntax/round_trip_parse_gen.swift
@@ -4,6 +4,10 @@
 // RUN: diff -u %S/Outputs/round_trip_parse_gen.swift.withkinds %t.withkinds
 // RUN: %swift-syntax-test -input-source-filename %s -eof > %t
 // RUN: diff -u %s %t
+// RUN: %empty-directory(%t)
+// RUN: %swift-syntax-test -serialize-raw-tree -input-source-filename %s > %t/serialized.json
+// RUN: %swift-syntax-test -deserialize-raw-tree -input-source-filename %t/serialized.json -output-filename %t/output.swift
+// RUN: diff -u %s %t/output.swift
 
 import ABC
 import A.B.C


### PR DESCRIPTION
We already have a serializer generate json from libSyntax tree in https://github.com/apple/swift/blob/master/include/swift/Syntax/Serialization/SyntaxSerialization.h
So I wrote a deserializer that convert json to libSyntax tree, using llvm yaml parser.

@rintaro I don't know how to add and run test in project `swift-syntax-test` 
I've tried passing a swift file as an argument but failed.
Please help me



@swift-ci Please smoke test
