### PR TITLE
[NFC][StringExtras] Use llvm::StringSwitch in canBeArgumentLabel as with canBeMemberName

### DIFF
--- a/lib/Basic/StringExtras.cpp
+++ b/lib/Basic/StringExtras.cpp
@@ -29,11 +29,12 @@ using namespace swift;
 using namespace camel_case;
 
 bool swift::canBeArgumentLabel(StringRef identifier) {
-  if (identifier == "var" || identifier == "let" || identifier == "inout" ||
-      identifier == "$")
-    return false;
-
-  return true;
+  return llvm::StringSwitch<bool>(identifier)
+    .Case("var", false)
+    .Case("let", false)
+    .Case("inout", false)
+    .Case("$", false)
+    .Default(true);
 }
 
 bool swift::canBeMemberName(StringRef identifier) {


### PR DESCRIPTION
Is this worth doing or should we change `canBeMemberName` instead?