### PR TITLE
Disable Lazy.swift on Ubuntu 16.04.

### DIFF
--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -15,7 +15,8 @@
 // <rdar://35797159> [Associated Type Inference]
 // heap-use-after-free ASTContext::getSpecializedConformance
 // llvm::FoldingSetBase::InsertNode
-// REQUIRES: OS=macosx || no_asan
+// OR corrupted doubly linked list
+// REQUIRES: OS=macosx
 
 import StdlibUnittest
 import StdlibCollectionUnittest


### PR DESCRIPTION
Even without ASAN this failes with "corrupted double-linked list".

<rdar://problem/35797159> [Associated Type Inference] Swift CI: 1. OSS - Swift ASAN - Ubuntu 16.04 (master) heap-use-after-free ASTContext::getSpecializedConformance llvm::FoldingSetBase::InsertNode

