### PR TITLE
[crashers] NFC: Limit time spent in solver for crashers 28684 and 28686

### DIFF
--- a/validation-test/compiler_crashers_fixed/28684-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
+++ b/validation-test/compiler_crashers_fixed/28684-isactuallycanonicalornull-forming-a-cantype-out-of-a-non-canonical-type.swift
@@ -5,5 +5,5 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not %target-swift-frontend %s -emit-ir
+// RUN: not %target-typecheck-verify-swift -solver-expression-time-threshold=1
 {{{func t(UInt=1 + 1 + 1 + 1 as?Int){{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{$0{{{{{{{{{{{{{{{{{{{{{{{{

--- a/validation-test/compiler_crashers_fixed/28686-swift-typebase-getcanonicaltype.swift
+++ b/validation-test/compiler_crashers_fixed/28686-swift-typebase-getcanonicaltype.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not %target-swift-frontend %s -emit-ir
+// RUN: not %target-typecheck-verify-swift -solver-expression-time-threshold=1
 protocol A.{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{let f&(a=a?Int){{{{{{{{{{{{{{{{{{{{{{{{{{{(_
 }
 }func b(UInt=1 + 1 + 1 + 1 as?Int){{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{(_{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{


### PR DESCRIPTION

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
