### PR TITLE
IRGen: Set CurSourceFile for SIL functions using the module's associa…

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1554,7 +1554,7 @@ void IRGenModule::emitSILFunction(SILFunction *f) {
 
   PrettyStackTraceSILFunction stackTrace("emitting IR", f);
   llvm::SaveAndRestore<SourceFile *> SetCurSourceFile(CurSourceFile);
-  if (auto dc = f->getDeclContext()) {
+  if (auto dc = f->getModule().getAssociatedContext()) {
     if (auto sf = dc->getParentSourceFile()) {
       CurSourceFile = sf;
     }


### PR DESCRIPTION
…ted context.

SIL functions might be associated with decls from other source files whose symbols we can't necessarily locally link to. The module should be associated with the SourceFile that was compiled.

rdar://problem/38397927 | SR-7181