### PR TITLE
[swift-syntax-test] Make VerifySyntaxTree a command line option

### DIFF
--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -102,6 +102,12 @@ PrintTrivialNodeKind("print-trivial-node-kind",
                      llvm::cl::init(false));
 
 static llvm::cl::opt<bool>
+VerifySyntaxTree("verify-syntax-tree",
+                 llvm::cl::desc("Emit warnings for unknown nodes"),
+                 llvm::cl::cat(Category),
+                 llvm::cl::init(true));
+
+static llvm::cl::opt<bool>
 Visual("v",
        llvm::cl::desc("Print visually"),
        llvm::cl::cat(Category),
@@ -148,7 +154,7 @@ SourceFile *getSourceFile(CompilerInstance &Instance,
                           const char *MainExecutablePath) {
   CompilerInvocation Invocation;
   Invocation.getLangOptions().BuildSyntaxTree = true;
-  Invocation.getLangOptions().VerifySyntaxTree = true;
+  Invocation.getLangOptions().VerifySyntaxTree = options::VerifySyntaxTree;
   Invocation.getFrontendOptions().InputsAndOutputs.addInputFile(InputFileName);
   Invocation.setMainExecutablePath(
     llvm::sys::fs::getMainExecutable(MainExecutablePath,


### PR DESCRIPTION
Add `-verify-syntax-tree` option to `swift-syntax-test`.
Defaulted to `true`, can be disabled with `-verify-syntax-tree=false`