### PR TITLE
[Syntax] Add 'unknown' token to 'Token.py' definition

### DIFF
--- a/test/SwiftSyntax/Inputs/visitor.swift
+++ b/test/SwiftSyntax/Inputs/visitor.swift
@@ -1,6 +1,7 @@
 func foo() {
   func foo() {
     func foo() {
+      /*Unknown token */0xG
     }
   }
 }

--- a/tools/SwiftSyntax/TokenKind.swift.gyb
+++ b/tools/SwiftSyntax/TokenKind.swift.gyb
@@ -19,7 +19,6 @@
 
 /// Enumerates the kinds of tokens in the Swift language.
 public enum TokenKind: Codable {
-  case unknown
   case eof
 % for token in SYNTAX_TOKENS:
 %   kind = token.swift_kind()
@@ -35,7 +34,6 @@ public enum TokenKind: Codable {
   /// The textual representation of this token kind.
   var text: String {
     switch self {
-    case .unknown: return "unknown"
     case .eof: return ""
 % for token in SYNTAX_TOKENS:
 %   if token.text:
@@ -60,7 +58,6 @@ public enum TokenKind: Codable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let kind = try container.decode(String.self, forKey: .kind)
     switch kind {
-    case "unknown": self = .unknown
     case "eof": self = .eof
 % for token in SYNTAX_TOKENS:
     case "${token.kind}":
@@ -83,7 +80,6 @@ public enum TokenKind: Codable {
   
   var kind: String {
     switch self {
-    case .unknown: return "unknown"
     case .eof: return "eof"
 % for token in SYNTAX_TOKENS:
 %   kind = token.swift_kind()
@@ -99,7 +95,6 @@ public enum TokenKind: Codable {
 extension TokenKind: Equatable {
   public static func ==(lhs: TokenKind, rhs: TokenKind) -> Bool {
     switch (lhs, rhs) {
-    case (.unknown, .unknown): return true
     case (.eof, .eof): return true
 % for token in SYNTAX_TOKENS:
 %   kind = token.swift_kind()

--- a/utils/gyb_syntax_support/Token.py
+++ b/utils/gyb_syntax_support/Token.py
@@ -157,6 +157,7 @@ SYNTAX_TOKENS = [
     Token('FloatingLiteral', 'floating_literal'),
     Token('StringLiteral', 'string_literal'),
     Token('ContextualKeyword', 'contextual_keyword'),
+    Token('Unknown', 'unknown'),
 ]
 
 SYNTAX_TOKEN_MAP = {token.name + 'Token': token for token in SYNTAX_TOKENS}

--- a/utils/gyb_syntax_support/__init__.py
+++ b/utils/gyb_syntax_support/__init__.py
@@ -23,9 +23,9 @@ def make_missing_child(child):
     """
     if child.is_token():
         token = child.main_token()
-        tok_kind = "tok::" + token.kind if token else "tok::unknown"
+        tok_kind = token.kind if token else "unknown"
         tok_text = token.text if token else ""
-        return 'RawSyntax::missing(%s, "%s")' % (tok_kind, tok_text)
+        return 'RawSyntax::missing(tok::%s, "%s")' % (tok_kind, tok_text)
     else:
         missing_kind = "Unknown" if child.syntax_kind == "Syntax" \
                        else child.syntax_kind

--- a/utils/gyb_syntax_support/__init__.py
+++ b/utils/gyb_syntax_support/__init__.py
@@ -73,7 +73,7 @@ def make_missing_swift_child(child):
     if child.is_token():
         token = child.main_token()
         tok_kind = token.swift_kind() if token else "unknown"
-        if token and not token.text:
+        if not token or not token.text:
             tok_kind += '("")'
         return 'RawSyntax.missingToken(.%s)' % tok_kind
     else:


### PR DESCRIPTION
`unknown` is *not* fixed-text token.

CC: @nkcsgexi @harlanhaskins 