### PR TITLE
[runtime] Collapse hashing parameters into a single struct

### DIFF
--- a/stdlib/public/SwiftShims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/GlobalObjects.h
@@ -78,16 +78,14 @@ struct _SwiftEmptyDictionaryStorage _swiftEmptyDictionaryStorage;
 SWIFT_RUNTIME_STDLIB_INTERFACE
 struct _SwiftEmptySetStorage _swiftEmptySetStorage;
 
-struct _SwiftHashingSeed {
+struct _SwiftHashingParameters {
   __swift_uint64_t seed0;
   __swift_uint64_t seed1;
+  __swift_bool deterministic;
 };
-
+  
 SWIFT_RUNTIME_STDLIB_INTERFACE
-struct _SwiftHashingSeed _swift_stdlib_Hashing_seed;
-
-SWIFT_RUNTIME_STDLIB_INTERFACE
-__swift_bool _swift_stdlib_Hashing_deterministicHashing;
+struct _SwiftHashingParameters _swift_stdlib_Hashing_parameters;
 
 #ifdef __cplusplus
 

--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -225,22 +225,27 @@ public struct _Hasher {
   /// of test results.
   public // SPI
   static var _isDeterministic: Bool {
-    return _swift_stdlib_Hashing_deterministicHashing
+    @_inlineable
+    @inline(__always)
+    get {
+      return _swift_stdlib_Hashing_parameters.deterministic;
+    }
   }
 
   /// The 128-bit hash seed used to initialize the hasher state. Initialized
   /// once during process startup.
   public // SPI
   static var _seed: (UInt64, UInt64) {
+    @_inlineable
+    @inline(__always)
     get {
-      if _isDeterministic { return (0, 0) }
       // The seed itself is defined in C++ code so that it is initialized during
       // static construction.  Almost every Swift program uses hash tables, so
       // initializing the seed during the startup seems to be the right
       // trade-off.
       return (
-        _swift_stdlib_Hashing_seed.seed0,
-        _swift_stdlib_Hashing_seed.seed1)
+        _swift_stdlib_Hashing_parameters.seed0,
+        _swift_stdlib_Hashing_parameters.seed1)
     }
   }
 

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -106,35 +106,33 @@ swift::_SwiftEmptySetStorage swift::_swiftEmptySetStorage = {
   0 // int entries; (zero'd bits)
 };
 
-static swift::_SwiftHashingSeed initializeHashingSeed() {
-#if defined(__APPLE__)
-  // Use arc4random if available.
-  swift::_SwiftHashingSeed seed = { 0, 0 };
-  arc4random_buf(&seed, sizeof(seed));
-  return seed;
-#else
-  std::random_device randomDevice;
-  std::mt19937_64 engine(randomDevice());
-  std::uniform_int_distribution<__swift_uint64_t> distribution;
-  return { distribution(engine), distribution(engine) };
-#endif
-}
-
-static __swift_bool initializeHashingDeterminism() {
+static swift::_SwiftHashingParameters initializeHashingParameters() {
   // Setting the environment variable SWIFT_DETERMINISTIC_HASHING to "1"
   // disables randomized hash seeding. This is useful in cases we need to ensure
   // results are repeatable, e.g., in certain test environments.  (Note that
   // even if the seed override is enabled, hash values aren't guaranteed to
   // remain stable across even minor stdlib releases.)
   auto determinism = getenv("SWIFT_DETERMINISTIC_HASHING");
-  return determinism && 0 == strcmp(determinism, "1");
+  if (determinism && 0 == strcmp(determinism, "1")) {
+    return { 0, 0, true };
+  }
+#if defined(__APPLE__)
+  // Use arc4random if available.
+  __swift_uint64_t seed0 = 0, seed1 = 0;
+  arc4random_buf(&seed0, sizeof(seed0));
+  arc4random_buf(&seed1, sizeof(seed1));
+  return { seed0, seed1, false };
+#else
+  std::random_device randomDevice;
+  std::mt19937_64 engine(randomDevice());
+  std::uniform_int_distribution<__swift_uint64_t> distribution;
+  return { distribution(engine), distribution(engine), false };
+#endif
 }
 
 SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_BEGIN
-swift::_SwiftHashingSeed swift::_swift_stdlib_Hashing_seed =
-  initializeHashingSeed();
-__swift_bool swift::_swift_stdlib_Hashing_deterministicHashing =
-  initializeHashingDeterminism();
+swift::_SwiftHashingParameters swift::_swift_stdlib_Hashing_parameters =
+  initializeHashingParameters();
 SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_END
 
 


### PR DESCRIPTION
Having a single initializer function lets us skip setting up a randomized seed in deterministic mode, slightly simplifying the stdlib.

While we're here, also set up related stdlib properties to be always inlinable.