### PR TITLE
[stdlib] Set, Dictionary: Mix the hash table size into the hash seed

### DIFF
--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -3172,6 +3172,9 @@ internal class _RawNative${Self}Storage:
   internal final var values: UnsafeMutableRawPointer
 % end
 
+  @_versioned // FIXME(sil-serialize-all)
+  internal final var seed: (UInt64, UInt64)
+
   // This API is unsafe and needs a `_fixLifetime` in the caller.
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
@@ -3626,6 +3629,19 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
         bucketCount._builtinWordValue, Key.self, Value.self)
     _storage.values = UnsafeMutableRawPointer(valuesAddr)
 %end
+    // We assign a unique hash seed to each distinct hash table size, so that we
+    // avoid certain copy operations becoming quadratic, without breaking value
+    // semantics. (See https://bugs.swift.org/browse/SR-3268)
+    //
+    // We don't need to generate a brand new seed for each table size: it's
+    // enough to change a single bit in the global seed by XORing the bucket
+    // count to it. (The bucket count is always a power of two.)
+    //
+    // FIXME: Use an approximation of true per-instance seeding. We can't just
+    // use the base address, because COW copies need to share the same seed.
+    let seed = _Hasher._seed
+    let perturbation = bucketCount
+    _storage.seed = (seed.0 ^ UInt64(truncatingIfNeeded: perturbation), seed.1)
   }
 
   // Forwarding the individual fields of the storage in various forms
@@ -3986,31 +4002,11 @@ extension _Native${Self}Buffer
     return bucketCount &- 1
   }
 
-  @_inlineable
-  @_versioned
-  internal func _localHasher() -> _Hasher {
-    // We assign a unique seed to each distinct hash table size, so that we
-    // avoid certain copy operations becoming quadratic, without breaking value
-    // semantics. (See https://bugs.swift.org/browse/SR-3268)
-    //
-    // We don't need to generate a brand new seed for each table size: it's
-    // enough to change a single bit in the global seed by XORing the bucket
-    // count to it. (The bucket count is always a power of two.)
-    //
-    // FIXME: Use an approximation of true per-instance seeding. We can't just
-    // use the base address, because COW copies need to share the same seed.
-    // (This will require storing the local seed in the storage class.)
-    let seed = _Hasher._seed
-    let perturbation = bucketCount
-    return _Hasher(
-      seed: (seed.0 ^ UInt64(truncatingIfNeeded: perturbation), seed.1))
-  }
-
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned
   @inline(__always) // For performance reasons.
   internal func _bucket(_ k: Key) -> Int {
-    var hasher = _localHasher()
+    var hasher = _Hasher(seed: _storage.seed)
     hasher.append(k)
     return hasher.finalize() & _bucketMask
   }

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -3990,15 +3990,16 @@ extension _Native${Self}Buffer
   @_versioned
   internal func _localHasher() -> _Hasher {
     // We assign a unique seed to each distinct hash table size, so that we
-    // prevent the quadratic copy problem without breaking value semantics.
-    // See https://bugs.swift.org/browse/SR-3268
+    // avoid certain copy operations becoming quadratic, without breaking value
+    // semantics. (See https://bugs.swift.org/browse/SR-3268)
     //
-    // We don't need to generate brand new seed; changing a few bits in the
-    // global seed by XORing the bucket count prevents the issue just as well.
+    // We don't need to generate a brand new seed for each table size: it's
+    // enough to change a single bit in the global seed by XORing the bucket
+    // count to it. (The bucket count is always a power of two.)
     //
-    // FIXME: Use true per-instance seeding. This requires adding the local seed
-    // into the storage class, because COW copies need to use the same seed as
-    // their original instance.
+    // FIXME: Use an approximation of true per-instance seeding. We can't just
+    // use the base address, because COW copies need to share the same seed.
+    // (This will require storing the local seed in the storage class.)
     let seed = _Hasher._seed
     let perturbation = bucketCount
     return _Hasher(

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -3986,11 +3986,24 @@ extension _Native${Self}Buffer
     return bucketCount &- 1
   }
 
+  @_inlineable
+  @_versioned
+  internal func _localHasher() -> _Hasher {
+    let seed = _Hasher._seed
+    let perturbation = (_Hasher._isDeterministic
+      ? bucketCount
+      : unsafeBitCast(_storage, to: Int.self))
+    return _Hasher(
+      seed: (seed.0 ^ UInt64(truncatingIfNeeded: perturbation), seed.1))
+  }
+
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned
   @inline(__always) // For performance reasons.
   internal func _bucket(_ k: Key) -> Int {
-    return _hashValue(for: k) & _bucketMask
+    var hasher = _localHasher()
+    hasher.append(k)
+    return hasher.finalize() & _bucketMask
   }
 
   @_inlineable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -3989,10 +3989,18 @@ extension _Native${Self}Buffer
   @_inlineable
   @_versioned
   internal func _localHasher() -> _Hasher {
+    // We assign a unique seed to each distinct hash table size, so that we
+    // prevent the quadratic copy problem without breaking value semantics.
+    // See https://bugs.swift.org/browse/SR-3268
+    //
+    // We don't need to generate brand new seed; changing a few bits in the
+    // global seed by XORing the bucket count prevents the issue just as well.
+    //
+    // FIXME: Use true per-instance seeding. This requires adding the local seed
+    // into the storage class, because COW copies need to use the same seed as
+    // their original instance.
     let seed = _Hasher._seed
-    let perturbation = (_Hasher._isDeterministic
-      ? bucketCount
-      : unsafeBitCast(_storage, to: Int.self))
+    let perturbation = bucketCount
     return _Hasher(
       seed: (seed.0 ^ UInt64(truncatingIfNeeded: perturbation), seed.1))
   }


### PR DESCRIPTION
This is done by xoring the bucket count of the hash table to the hash seed. This only flips a single bit in the seed, but avalanche effects make that more than enough to break the correlation between element orderings in tables of different sizes.

This eliminates quadratic performance issues when we copy elements between hash tables of different sizes.

Fixes https://bugs.swift.org/browse/SR-3268