### PR TITLE
SIL: Move responsibility for external keypath equals/hash to the caller.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -600,6 +600,9 @@ ERROR(sil_keypath_unknown_component_kind,none,
 ERROR(sil_keypath_computed_property_missing_part,none,
       "keypath %select{gettable|settable}0_property component needs an "
       "%select{id and getter|id, getter, and setter}0", (bool))
+ERROR(sil_keypath_external_missing_part,none,
+      "keypath external component with indices needs an indices_equals and "
+      "indices_hash function", ())
 ERROR(sil_keypath_no_components,none,
       "keypath must have at least one component", ())
 ERROR(sil_keypath_no_root,none,

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2276,17 +2276,15 @@ public:
       return Value.DeclRef;
     }
   };
-
+  
   enum class Kind: unsigned {
     StoredProperty,
     GettableProperty,
     SettableProperty,
-    Last_Packed = SettableProperty, // Last enum value that can be packed in
-                                    // a PointerIntPair
+    External,
     OptionalChain,
     OptionalForce,
     OptionalWrap,
-    External,
   };
   
   // Description of a captured index value and its Hashable conformance for a
@@ -2299,72 +2297,92 @@ public:
   };
   
 private:
-  static constexpr const unsigned KindPackingBits = 2;
-  static constexpr const unsigned UnpackedKind = (1u << KindPackingBits) - 1;
-  static_assert((unsigned)Kind::Last_Packed < UnpackedKind,
-                "too many kinds to pack");
-                
+  enum PackedKind: unsigned {
+    PackedStored,
+    PackedComputed,
+    PackedExternal,
+    Unpacked,
+  };
+  
+  static const unsigned KindPackingBits = 2;
+  
+  static unsigned getPackedKind(Kind k) {
+    switch (k) {
+    case Kind::StoredProperty:
+      return PackedStored;
+    case Kind::GettableProperty:
+    case Kind::SettableProperty:
+      return PackedComputed;
+    case Kind::External:
+      return PackedExternal;
+    case Kind::OptionalChain:
+    case Kind::OptionalForce:
+    case Kind::OptionalWrap:
+      return Unpacked;
+    }
+  }
+  
   // Value is the VarDecl* for StoredProperty, the SILFunction* of the
   // Getter for computed properties, or the Kind for other kinds
   llvm::PointerIntPair<void *, KindPackingBits, unsigned> ValueAndKind;
-  llvm::PointerIntPair<SILFunction *, 2,
-                       ComputedPropertyId::KindType> SetterAndIdKind;
-  ComputedPropertyId::ValueType IdValue;
-  ArrayRef<Index> Indices;
   union {
-    // Valid if Kind == GettableProperty || Value == SettableProperty
+    // Valid if Kind == GettableProperty || Kind == SettableProperty
     struct {
-      SILFunction *Equal;
-      SILFunction *Hash;
-    } IndexEquality;
+      llvm::PointerIntPair<SILFunction *, 2,
+                           ComputedPropertyId::KindType> SetterAndIdKind;
+      ComputedPropertyId::ValueType IdValue;
+    } Computed;
     // Valid if Kind == External
     ArrayRef<Substitution> ExternalSubstitutions;
   };
+  ArrayRef<Index> Indices;
+  struct {
+    SILFunction *Equal;
+    SILFunction *Hash;
+  } IndexEquality;
   CanType ComponentType;
   
-  unsigned kindForPacking(Kind k) {
-    auto value = (unsigned)k;
-    assert(value <= (unsigned)Kind::Last_Packed);
-    return value;
-  }
-  
-  KeyPathPatternComponent(Kind kind, CanType ComponentType)
-    : ValueAndKind((void*)((uintptr_t)kind << KindPackingBits), UnpackedKind),
-      ComponentType(ComponentType)
-  {
-    assert(kind > Kind::Last_Packed && "wrong initializer");
-  }
-  
-  KeyPathPatternComponent(VarDecl *storedProp, Kind kind,
+  /// Constructor for stored components
+  KeyPathPatternComponent(VarDecl *storedProp,
                           CanType ComponentType)
-    : ValueAndKind(storedProp, kindForPacking(kind)),
+    : ValueAndKind(storedProp, PackedStored),
       ComponentType(ComponentType) {}
 
-  KeyPathPatternComponent(ComputedPropertyId id, Kind kind,
+  /// Constructor for computed components
+  KeyPathPatternComponent(ComputedPropertyId id,
                           SILFunction *getter,
                           SILFunction *setter,
                           ArrayRef<Index> indices,
                           SILFunction *indicesEqual,
                           SILFunction *indicesHash,
                           CanType ComponentType)
-    : ValueAndKind(getter, kindForPacking(kind)),
-      SetterAndIdKind(setter, id.Kind),
-      IdValue(id.Value),
+    : ValueAndKind(getter, PackedComputed),
+      Computed{{setter, id.Kind}, {id.Value}},
       Indices(indices),
       IndexEquality{indicesEqual, indicesHash},
       ComponentType(ComponentType) {
   }
   
+  /// Constructor for external components
   KeyPathPatternComponent(AbstractStorageDecl *externalStorage,
                           ArrayRef<Substitution> substitutions,
                           ArrayRef<Index> indices,
+                          SILFunction *indicesEqual,
+                          SILFunction *indicesHash,
                           CanType componentType)
-    : ValueAndKind((void*)((uintptr_t)Kind::External << KindPackingBits),
-                   UnpackedKind),
-      IdValue(externalStorage),
-      Indices(indices),
+    : ValueAndKind(externalStorage, PackedExternal),
       ExternalSubstitutions(substitutions),
+      Indices(indices),
+      IndexEquality{indicesEqual, indicesHash},
       ComponentType(componentType) {
+  }
+  
+  /// Constructor for optional components.
+  KeyPathPatternComponent(Kind kind, CanType componentType)
+    : ValueAndKind((void*)((uintptr_t)kind << KindPackingBits), Unpacked),
+      ComponentType(componentType) {
+    assert((unsigned)kind >= (unsigned)Kind::OptionalChain
+           && "not an optional component");
   }
 
 public:
@@ -2376,9 +2394,17 @@ public:
 
   Kind getKind() const {
     auto packedKind = ValueAndKind.getInt();
-    if (packedKind != UnpackedKind)
-      return (Kind)packedKind;
-    return (Kind)((uintptr_t)ValueAndKind.getPointer() >> KindPackingBits);
+    switch ((PackedKind)packedKind) {
+    case PackedStored:
+      return Kind::StoredProperty;
+    case PackedComputed:
+      return Computed.SetterAndIdKind.getPointer()
+        ? Kind::SettableProperty : Kind::GettableProperty;
+    case PackedExternal:
+      return Kind::External;
+    case Unpacked:
+      return (Kind)((uintptr_t)ValueAndKind.getPointer() >> KindPackingBits);
+    }
   }
   
   CanType getComponentType() const {
@@ -2410,7 +2436,8 @@ public:
       llvm_unreachable("not a computed property");
     case Kind::GettableProperty:
     case Kind::SettableProperty:
-      return ComputedPropertyId(IdValue, SetterAndIdKind.getInt());
+      return ComputedPropertyId(Computed.IdValue,
+                                Computed.SetterAndIdKind.getInt());
     }
     llvm_unreachable("unhandled kind");
   }
@@ -2440,7 +2467,7 @@ public:
     case Kind::External:
       llvm_unreachable("not a settable computed property");
     case Kind::SettableProperty:
-      return SetterAndIdKind.getPointer();
+      return Computed.SetterAndIdKind.getPointer();
     }
     llvm_unreachable("unhandled kind");
   }
@@ -2465,8 +2492,8 @@ public:
     case Kind::OptionalChain:
     case Kind::OptionalForce:
     case Kind::OptionalWrap:
-    case Kind::External:
       llvm_unreachable("not a computed property");
+    case Kind::External:
     case Kind::GettableProperty:
     case Kind::SettableProperty:
       return IndexEquality.Equal;
@@ -2478,8 +2505,8 @@ public:
     case Kind::OptionalChain:
     case Kind::OptionalForce:
     case Kind::OptionalWrap:
-    case Kind::External:
       llvm_unreachable("not a computed property");
+    case Kind::External:
     case Kind::GettableProperty:
     case Kind::SettableProperty:
       return IndexEquality.Hash;
@@ -2490,13 +2517,13 @@ public:
   
   static KeyPathPatternComponent forStoredProperty(VarDecl *property,
                                                    CanType ty) {
-    return KeyPathPatternComponent(property, Kind::StoredProperty, ty);
+    return KeyPathPatternComponent(property, ty);
   }
   
   AbstractStorageDecl *getExternalDecl() const {
     assert(getKind() == Kind::External
            && "not an external property");
-    return IdValue.Property;
+    return (AbstractStorageDecl*)ValueAndKind.getPointer();
   }
   
   ArrayRef<Substitution> getExternalSubstitutions() const {
@@ -2512,7 +2539,7 @@ public:
                               SILFunction *indicesEquals,
                               SILFunction *indicesHash,
                               CanType ty) {
-    return KeyPathPatternComponent(identifier, Kind::GettableProperty,
+    return KeyPathPatternComponent(identifier,
                                    getter, nullptr, indices,
                                    indicesEquals, indicesHash, ty);
   }
@@ -2525,7 +2552,7 @@ public:
                               SILFunction *indicesEquals,
                               SILFunction *indicesHash,
                               CanType ty) {
-    return KeyPathPatternComponent(identifier, Kind::SettableProperty,
+    return KeyPathPatternComponent(identifier,
                                    getter, setter, indices,
                                    indicesEquals, indicesHash, ty);
   }
@@ -2553,8 +2580,11 @@ public:
   forExternal(AbstractStorageDecl *externalDecl,
               ArrayRef<Substitution> substitutions,
               ArrayRef<Index> indices,
+              SILFunction *indicesEquals,
+              SILFunction *indicesHash,
               CanType ty) {
-    return KeyPathPatternComponent(externalDecl, substitutions, indices, ty);
+    return KeyPathPatternComponent(externalDecl, substitutions,
+                                   indices, indicesEquals, indicesHash, ty);
   }
   
   void incrementRefCounts() const;

--- a/include/swift/SIL/SILProperty.h
+++ b/include/swift/SIL/SILProperty.h
@@ -63,6 +63,9 @@ public:
   const KeyPathPatternComponent &getComponent() const { return Component; }
   
   void print(SILPrintContext &Ctx) const;
+  void dump() const;
+  
+  void verify(const SILModule &M) const;
 };
   
 } // end namespace swift

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2152,6 +2152,17 @@ public:
       }
       
       *this << " : $" << component.getComponentType();
+      
+      if (!component.getSubscriptIndices().empty()) {
+        *this << ", indices_equals ";
+        component.getSubscriptIndexEquals()->printName(PrintState.OS);
+        *this << " : "
+              << component.getSubscriptIndexEquals()->getLoweredType();
+        *this << ", indices_hash ";
+        component.getSubscriptIndexHash()->printName(PrintState.OS);
+        *this << " : "
+              << component.getSubscriptIndexHash()->getLoweredType();
+      }
     }
     }
   }
@@ -2612,6 +2623,11 @@ void SILProperty::print(SILPrintContext &Ctx) const {
   OS << '(';
   SILPrinter(Ctx).printKeyPathPatternComponent(getComponent());
   OS << ")\n";
+}
+
+void SILProperty::dump() const {
+  SILPrintContext context(llvm::errs());
+  print(context);
 }
 
 static void printSILProperties(SILPrintContext &Ctx,

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1219,7 +1219,9 @@ void SILGenModule::tryEmitPropertyDescriptor(AbstractStorageDecl *decl) {
   
   Type baseTy;
   if (decl->getDeclContext()->isTypeContext()) {
-    baseTy = decl->getDeclContext()->getSelfInterfaceType();
+    baseTy = decl->getDeclContext()->getSelfInterfaceType()
+                 ->getCanonicalType(decl->getInnermostDeclContext()
+                                        ->getGenericSignatureOfContext());
     if (decl->isStatic()) {
       // TODO: Static properties should eventually be referenceable as
       // keypaths from T.Type -> Element
@@ -1237,35 +1239,39 @@ void SILGenModule::tryEmitPropertyDescriptor(AbstractStorageDecl *decl) {
   if (genericEnv)
     subs = genericEnv->getForwardingSubstitutions();
   
-  // TODO: The hashable conformances for the indices need to be provided by the
-  // client, since they may be post-hoc conformances, or a generic subscript
-  // may be invoked with hashable substitutions. We may eventually allow for
-  // non-hashable keypaths as well.
-  SmallVector<ProtocolConformanceRef, 4> indexHashables;
   if (auto sub = dyn_cast<SubscriptDecl>(decl)) {
-    auto hashable = getASTContext().getProtocol(KnownProtocolKind::Hashable);
     for (auto *index : *sub->getIndices()) {
+      // Keypaths can't capture inout indices.
       if (index->isInOut())
         return;
+
+      // TODO: Handle reabstraction and tuple explosion in thunk generation.
+      // This wasn't previously a concern because anything that was Hashable
+      // had only one abstraction level and no explosion.
       auto indexTy = index->getInterfaceType();
+      
+      if (isa<TupleType>(indexTy->getCanonicalType(sub->getGenericSignature())))
+        return;
+      
       if (genericEnv)
         indexTy = genericEnv->mapTypeIntoContext(indexTy);
       
-      auto conformance = sub->getModuleContext()
-                            ->lookupConformance(indexTy, hashable);
-      if (!conformance)
+      auto indexLoweredTy = Types.getLoweredType(indexTy);
+      auto indexOpaqueLoweredTy =
+        Types.getLoweredType(AbstractionPattern::getOpaque(), indexTy);
+      
+      if (indexOpaqueLoweredTy.getAddressType()
+             != indexLoweredTy.getAddressType())
         return;
-      if (!conformance->getConditionalRequirements().empty())
-        return;
-      indexHashables.push_back(*conformance);
     }
   }
-  
+
   auto component = emitKeyPathComponentForDecl(SILLocation(decl),
                                                genericEnv,
                                                baseOperand, needsGenericContext,
-                                               subs, decl, indexHashables,
-                                               baseTy->getCanonicalType());
+                                               subs, decl, {},
+                                               baseTy->getCanonicalType(),
+                                               /*property descriptor*/ true);
   
   (void)SILProperty::create(M, /*serialized*/ false, decl, component);
 }

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -347,7 +347,8 @@ public:
                               SubstitutionList subs,
                               AbstractStorageDecl *storage,
                               ArrayRef<ProtocolConformanceRef> indexHashables,
-                              CanType baseTy);
+                              CanType baseTy,
+                              bool forPropertyDescriptor);
 
   /// Known functions for bridging.
   SILDeclRef getStringToNSStringFn();

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3050,22 +3050,24 @@ emitKeyPathRValueBase(SILGenFunction &subSGF,
   return paramSubstValue;
 }
 
+using IndexTypePair = std::pair<CanType, SILType>;
+
 /// Helper function to load the captured indexes out of a key path component
 /// in order to invoke the accessors on that key path. A component with captured
 /// indexes passes down a pointer to those captures to the accessor thunks,
 /// which we can copy out of to produce values we can pass to the real
 /// accessor functions.
 static RValue loadIndexValuesForKeyPathComponent(SILGenFunction &SGF,
-                         SILLocation loc,
-                         ArrayRef<KeyPathPatternComponent::Index> indexes,
-                         SILValue pointer) {
+                                               SILLocation loc,
+                                               ArrayRef<IndexTypePair> indexes,
+                                               SILValue pointer) {
   // If no indexes, do nothing.
   if (indexes.empty())
     return RValue();
   
   SmallVector<TupleTypeElt, 2> indexElts;
   for (auto &elt : indexes) {
-    indexElts.push_back(SGF.F.mapTypeIntoContext(elt.FormalType));
+    indexElts.push_back(SGF.F.mapTypeIntoContext(elt.first));
   }
   
   auto indexTupleTy = TupleType::get(indexElts, SGF.getASTContext())
@@ -3082,11 +3084,11 @@ static RValue loadIndexValuesForKeyPathComponent(SILGenFunction &SGF,
     if (indexes.size() > 1) {
       eltAddr = SGF.B.createTupleElementAddr(loc, eltAddr, i);
     }
-    auto ty = SGF.F.mapTypeIntoContext(indexes[i].LoweredType);
+    auto ty = SGF.F.mapTypeIntoContext(indexes[i].second);
     auto value = SGF.emitLoad(loc, eltAddr,
                               SGF.getTypeLowering(ty),
                               SGFContext(), IsNotTake);
-    indexValue.addElement(SGF, value, indexes[i].FormalType, loc);
+    indexValue.addElement(SGF, value, indexes[i].first, loc);
   }
   
   return indexValue;
@@ -3098,7 +3100,7 @@ static SILFunction *getOrCreateKeyPathGetter(SILGenModule &SGM,
                          SubstitutionList subs,
                          AccessStrategy strategy,
                          GenericEnvironment *genericEnv,
-                         ArrayRef<KeyPathPatternComponent::Index> indexes,
+                         ArrayRef<IndexTypePair> indexes,
                          CanType baseType,
                          CanType propertyType) {
   auto genericSig = genericEnv
@@ -3219,7 +3221,7 @@ SILFunction *getOrCreateKeyPathSetter(SILGenModule &SGM,
                           SubstitutionList subs,
                           AccessStrategy strategy,
                           GenericEnvironment *genericEnv,
-                          ArrayRef<KeyPathPatternComponent::Index> indexes,
+                          ArrayRef<IndexTypePair> indexes,
                           CanType baseType,
                           CanType propertyType) {
   auto genericSig = genericEnv
@@ -3734,13 +3736,11 @@ getIdForKeyPathComponentComputedProperty(SILGenModule &SGM,
 }
 
 static void
-lowerKeyPathSubscriptIndexPatterns(
+lowerKeyPathSubscriptIndexTypes(
                  SILGenModule &SGM,
-                 SmallVectorImpl<KeyPathPatternComponent::Index> &indexPatterns,
+                 SmallVectorImpl<IndexTypePair> &indexPatterns,
                  SubscriptDecl *subscript,
                  SubstitutionList subscriptSubs,
-                 ArrayRef<ProtocolConformanceRef> indexHashables,
-                 unsigned &baseOperand,
                  bool &needsGenericContext) {
   // Capturing an index value dependent on the generic context means we
   // need the generic context captured in the key path.
@@ -3753,16 +3753,11 @@ lowerKeyPathSubscriptIndexPatterns(
   }
   needsGenericContext |= subscriptSubstTy->hasArchetype();
 
-  unsigned i = 0;
   for (auto *index : *subscript->getIndices()) {
     auto indexTy = index->getInterfaceType();
     if (sig) {
       indexTy = indexTy.subst(subMap);
     }
-    auto hashable = indexHashables[i++];
-    assert(hashable.isAbstract() ||
-           hashable.getConcrete()->getType()->isEqual(indexTy));
-
     auto indexLoweredTy = SGM.Types.getLoweredType(
                                                 AbstractionPattern::getOpaque(),
                                                 indexTy);
@@ -3770,11 +3765,28 @@ lowerKeyPathSubscriptIndexPatterns(
                      indexLoweredTy.getSwiftRValueType()->mapTypeOutOfContext()
                                                         ->getCanonicalType(),
                      indexLoweredTy.getCategory());
-    indexPatterns.push_back({baseOperand++,
-                             indexTy->mapTypeOutOfContext()
+    indexPatterns.push_back({indexTy->mapTypeOutOfContext()
                                     ->getCanonicalType(),
-                             indexLoweredTy,
-                             hashable});
+                             indexLoweredTy});
+  }
+};
+
+static void
+lowerKeyPathSubscriptIndexPatterns(
+                 SmallVectorImpl<KeyPathPatternComponent::Index> &indexPatterns,
+                 ArrayRef<IndexTypePair> indexTypes,
+                 ArrayRef<ProtocolConformanceRef> indexHashables,
+                 unsigned &baseOperand) {
+  for (unsigned i : indices(indexTypes)) {
+    CanType formalTy;
+    SILType loweredTy;
+    std::tie(formalTy, loweredTy) = indexTypes[i];
+    auto hashable = indexHashables[i];
+    assert(hashable.isAbstract() ||
+           hashable.getConcrete()->getType()->mapTypeOutOfContext()
+                                 ->isEqual(formalTy));
+
+    indexPatterns.push_back({baseOperand++, formalTy, loweredTy, hashable});
   }
 };
 
@@ -3786,7 +3798,8 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
                                 SubstitutionList subs,
                                 AbstractStorageDecl *storage,
                                 ArrayRef<ProtocolConformanceRef> indexHashables,
-                                CanType baseTy) {
+                                CanType baseTy,
+                                bool forPropertyDescriptor) {
   if (auto var = dyn_cast<VarDecl>(storage)) {
     CanType componentTy;
     if (!var->getDeclContext()->isTypeContext()) {
@@ -3794,7 +3807,8 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
     } else {
       componentTy = baseTy->getTypeOfMember(SwiftModule, var)
         ->getReferenceStorageReferent()
-        ->getCanonicalType();
+        ->getCanonicalType(genericEnv ? genericEnv->getGenericSignature()
+                                      : nullptr);
     }
   
     switch (auto strategy = var->getAccessStrategy(AccessSemantics::Ordinary,
@@ -3859,26 +3873,31 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
       baseSubscriptTy->mapTypeOutOfContext()->getCanonicalType());
     auto componentTy = baseSubscriptInterfaceTy.getResult();
   
-    SmallVector<KeyPathPatternComponent::Index, 4> indexPatterns;
-    lowerKeyPathSubscriptIndexPatterns(*this, indexPatterns,
-                                       decl, subs, indexHashables,
-                                       baseOperand,
-                                       needsGenericContext);
+    SmallVector<IndexTypePair, 4> indexTypes;
+    lowerKeyPathSubscriptIndexTypes(*this, indexTypes,
+                                    decl, subs,
+                                    needsGenericContext);
     
+    SmallVector<KeyPathPatternComponent::Index, 4> indexPatterns;
     SILFunction *indexEquals = nullptr, *indexHash = nullptr;
-    // TODO: Property descriptors for external key paths should get their
-    // equality and hashing from the client.
-    getOrCreateKeyPathEqualsAndHash(*this, loc,
-             needsGenericContext ? genericEnv : nullptr,
-             indexPatterns,
-             indexEquals, indexHash);
-
+    // Property descriptors get their index information from the client.
+    if (!forPropertyDescriptor) {
+      lowerKeyPathSubscriptIndexPatterns(indexPatterns,
+                                         indexTypes, indexHashables,
+                                         baseOperand);
+      
+      getOrCreateKeyPathEqualsAndHash(*this, loc,
+               needsGenericContext ? genericEnv : nullptr,
+               indexPatterns,
+               indexEquals, indexHash);
+    }
+    
     auto id = getIdForKeyPathComponentComputedProperty(*this, decl, strategy);
     auto getter = getOrCreateKeyPathGetter(*this, loc,
              decl, subs,
              strategy,
              needsGenericContext ? genericEnv : nullptr,
-             indexPatterns,
+             indexTypes,
              baseTy, componentTy);
   
     auto indexPatternsCopy = getASTContext().AllocateCopy(indexPatterns);
@@ -3887,7 +3906,7 @@ SILGenModule::emitKeyPathComponentForDecl(SILLocation loc,
              decl, subs,
              strategy,
              needsGenericContext ? genericEnv : nullptr,
-             indexPatterns,
+             indexTypes,
              baseTy, componentTy);
       return KeyPathPatternComponent::forComputedSettableProperty(id,
                                                            getter, setter,
@@ -3987,23 +4006,30 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
         ty = ty.subst(subMap);
       }
       
+      SILFunction *indexEquals = nullptr, *indexHash = nullptr;
       if (component.getKind() ==  KeyPathExpr::Component::Kind::Subscript) {
         unsigned numOperands = operands.size();
-        lowerKeyPathSubscriptIndexPatterns(SGF.SGM,
-             indices,
-             cast<SubscriptDecl>(component.getDeclRef().getDecl()),
-             component.getDeclRef().getSubstitutions(),
+        SmallVector<IndexTypePair, 4> indexTypes;
+        auto sub = cast<SubscriptDecl>(component.getDeclRef().getDecl());
+        lowerKeyPathSubscriptIndexTypes(SGF.SGM, indexTypes,
+                                sub, component.getDeclRef().getSubstitutions(),
+                                needsGenericContext);
+        lowerKeyPathSubscriptIndexPatterns(indices, indexTypes,
              component.getSubscriptIndexHashableConformances(),
-             numOperands,
-             needsGenericContext);
+             numOperands);
         
         lowerSubscriptOperands(component);
         
         assert(numOperands == operands.size()
                && "operand count out of sync");
+        getOrCreateKeyPathEqualsAndHash(SGF.SGM, SILLocation(E),
+                 needsGenericContext ? SGF.F.getGenericEnvironment() : nullptr,
+                 indices,
+                 indexEquals, indexHash);
       }
       return KeyPathPatternComponent::forExternal(
         decl, subs, SGF.getASTContext().AllocateCopy(indices),
+        indexEquals, indexHash,
         ty->getCanonicalType());
     };
   
@@ -4025,7 +4051,8 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
                               component.getDeclRef().getSubstitutions(),
                               decl,
                               component.getSubscriptIndexHashableConformances(),
-                              baseTy));
+                              baseTy,
+                              /*for descriptor*/ false));
         lowerSubscriptOperands(component);
       
         assert(numOperands == operands.size()

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -798,8 +798,7 @@ SILDeserializer::readKeyPathComponent(ArrayRef<uint64_t> ListOfValues,
     }
     
     indices = MF->getContext().AllocateCopy(indicesBuf);
-    if (!indices.empty() &&
-        kind != KeyPathComponentKindEncoding::External) {
+    if (!indices.empty()) {
       auto indicesEqualsName = MF->getIdentifier(ListOfValues[nextValue++]);
       auto indicesHashName = MF->getIdentifier(ListOfValues[nextValue++]);
       indicesEquals = getFuncForReference(indicesEqualsName.str());
@@ -851,7 +850,8 @@ SILDeserializer::readKeyPathComponent(ArrayRef<uint64_t> ListOfValues,
     }
     handleComputedIndices();
     return KeyPathPatternComponent::forExternal(decl,
-        MF->getContext().AllocateCopy(subs), indices, type);
+        MF->getContext().AllocateCopy(subs),
+        indices, indicesEquals, indicesHash, type);
   }
   }
 }

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -626,8 +626,7 @@ SILSerializer::writeKeyPathPatternComponent(
         ListOfValues.push_back((unsigned)index.LoweredType.getCategory());
         serializeAfter.push_back(index.Hashable);
       }
-      if (!indices.empty() &&
-          component.getKind() != KeyPathPatternComponent::Kind::External) {
+      if (!indices.empty()) {
         ListOfValues.push_back(
           addSILFunctionRef(component.getSubscriptIndexEquals()));
         ListOfValues.push_back(

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -418,13 +418,19 @@ entry(%0 : $*A, %1 : $*B, %2 : $*A, %3 : $*B, %4 : $*A, %5 : $*B):
 
   %u = keypath $KeyPath<G<A>, A>, <X: Hashable, Y: Hashable> (
     root $G<Y>;
-    external #G.subscript<Y, X> [%$0 : $X : $*X] : $Y
+    external #G.subscript<Y, X> [%$0 : $X : $*X] : $Y,
+      indices_equals @s_equals : $@convention(thin) <A: Hashable, B: Hashable> (UnsafeRawPointer, UnsafeRawPointer) -> Bool,
+      indices_hash @s_hash : $@convention(thin) <A: Hashable, B: Hashable> (UnsafeRawPointer) -> Int
   ) <B, A> (%1)
 
   %v = keypath $KeyPath<G<G<B>>, B>, <X: Hashable, Y: Hashable> (
     root $G<G<X>>;
-    external #G.subscript<G<X>, Y> [%$1 : $Y : $*Y] : $G<X>;
-    external #G.subscript<X, X> [%$0 : $X : $*X] : $X
+    external #G.subscript<G<X>, Y> [%$1 : $Y : $*Y] : $G<X>,
+      indices_equals @s_equals : $@convention(thin) <A: Hashable, B: Hashable> (UnsafeRawPointer, UnsafeRawPointer) -> Bool,
+      indices_hash @s_hash : $@convention(thin) <A: Hashable, B: Hashable> (UnsafeRawPointer) -> Int;
+    external #G.subscript<X, X> [%$0 : $X : $*X] : $X,
+      indices_equals @s_equals : $@convention(thin) <A: Hashable, B: Hashable> (UnsafeRawPointer, UnsafeRawPointer) -> Bool,
+      indices_hash @s_hash : $@convention(thin) <A: Hashable, B: Hashable> (UnsafeRawPointer) -> Int
   ) <B, A> (%3, %4)
 
   return undef : $()

--- a/test/SIL/Parser/keypath.sil
+++ b/test/SIL/Parser/keypath.sil
@@ -156,30 +156,32 @@ entry(%z : $*B):
   // CHECK: %3 = keypath $KeyPath<External<Int>, Int>, <τ_0_0> (root $External<τ_0_0>; external #External.ro<τ_0_0> : $τ_0_0) <Int>
   %c = keypath $KeyPath<External<Int>, Int>, <F> (root $External<F>; external #External.ro <F> : $F) <Int>
 
-  // CHECK: %4 = keypath $KeyPath<External<A>, A>, <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (root $External<τ_0_1>; external #External.subscript<τ_0_1, τ_0_0>[%$0 : $τ_0_0 : $*τ_0_0] : $τ_0_1) <B, A> (%0)
-  %d = keypath $KeyPath<External<A>, A>, <G: Hashable, H> (root $External<H>; external #External.subscript <H, G> [%$0 : $G : $*G] : $H) <B, A> (%z)
+  // CHECK: %4 = keypath $KeyPath<External<A>, A>, <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (
+  // CHECK-SAME: root $External<τ_0_1>;
+  // CHECK-SAME: external #External.subscript<τ_0_1, τ_0_0>[%$0 : $τ_0_0 : $*τ_0_0] : $τ_0_1,
+  // CHECK-SAME: indices_equals @equals_external_subscript
+  // CHECK-SAME: indices_hash @hash_external_subscript
+  // CHECK-SAME: ) <B, A> (%0)
+  %d = keypath $KeyPath<External<A>, A>, <G: Hashable, H> (
+    root $External<H>;
+    external #External.subscript <H, G> [%$0 : $G : $*G] : $H,
+      indices_equals @equals_external_subscript : $@convention(thin) <U: Hashable, T> (UnsafeRawPointer, UnsafeRawPointer) -> Bool,
+      indices_hash @hash_external_subscript : $@convention(thin) <U: Hashable, T> (UnsafeRawPointer) -> Int) <B, A> (%z)
 
   return undef : $()
 }
 
 sil @get_external_subscript : $@convention(thin) <T, U: Hashable> (@in External<T>, UnsafeRawPointer) -> @out T
-sil @equals_external_subscript : $@convention(thin) <T, U: Hashable> (UnsafeRawPointer, UnsafeRawPointer) -> Bool
-sil @hash_external_subscript : $@convention(thin) <T, U: Hashable> (UnsafeRawPointer) -> Int
+sil @equals_external_subscript : $@convention(thin) <U: Hashable, T> (UnsafeRawPointer, UnsafeRawPointer) -> Bool
+sil  @hash_external_subscript : $@convention(thin) <U: Hashable, T> (UnsafeRawPointer) -> Int
 
 // CHECK-LABEL: sil_property #External.ro<τ_0_0> (stored_property #External.ro : $τ_0_0)
 sil_property #External.ro <T> (stored_property #External.ro : $T)
 
 // CHECK-LABEL: sil_property #External.subscript<τ_0_0><τ_1_0 where τ_1_0 : Hashable> (gettable_property $τ_0_0,
 // CHECK-SAME:   id @id_a : $@convention(thin) () -> (),
-// CHECK-SAME:   getter @get_external_subscript : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_1 : Hashable> (@in External<τ_0_0>, UnsafeRawPointer) -> @out τ_0_0,
-// CHECK-SAME:   indices [%$0 : $τ_1_0 : $*τ_1_0],
-// CHECK-SAME:   indices_equals @equals_external_subscript : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_1 : Hashable> (UnsafeRawPointer, UnsafeRawPointer) -> Bool,
-// CHECK-SAME:   indices_hash @hash_external_subscript : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_1 : Hashable> (UnsafeRawPointer) -> Int)
+// CHECK-SAME:   getter @get_external_subscript : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_1 : Hashable> (@in External<τ_0_0>, UnsafeRawPointer) -> @out τ_0_0)
 sil_property #External.subscript <T><U: Hashable> (gettable_property $T,
   id @id_a : $@convention(thin) () -> (),
-  getter @get_external_subscript : $@convention(thin) <T, U: Hashable> (@in External<T>, UnsafeRawPointer) -> @out T,
-  indices [%$0 : $U : $*U],
-  indices_equals @equals_external_subscript : $@convention(thin) <T, U: Hashable> (UnsafeRawPointer, UnsafeRawPointer) -> Bool,
-  indices_hash @hash_external_subscript : $@convention(thin) <T, U: Hashable> (UnsafeRawPointer) -> Int)
-
+  getter @get_external_subscript : $@convention(thin) <T, U: Hashable> (@in External<T>, UnsafeRawPointer) -> @out T)
 

--- a/test/SIL/Serialization/keypath.sil
+++ b/test/SIL/Serialization/keypath.sil
@@ -43,9 +43,11 @@ struct Gen<A: P, B: Q, C: R> {
 }
 
 public struct External<T> {
-  var ro: T { get }
+  var ro: T
 
   subscript<U: Hashable>(ro _: U) -> T { get }
+
+  init()
 }
 
 // CHECK-LABEL: sil shared [serialized] @stored_properties
@@ -159,8 +161,17 @@ entry(%z : $*B):
   // CHECK: %3 = keypath $KeyPath<External<Int>, Int>, <τ_0_0> (root $External<τ_0_0>; external #External.ro<τ_0_0> : $τ_0_0) <Int>
   %c = keypath $KeyPath<External<Int>, Int>, <F> (root $External<F>; external #External.ro <F> : $F) <Int>
 
-  // CHECK: %4 = keypath $KeyPath<External<A>, A>, <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (root $External<τ_0_1>; external #External.subscript<τ_0_1, τ_0_0>[%$0 : $τ_0_0 : $*τ_0_0] : $τ_0_1) <B, A> (%0)
-  %d = keypath $KeyPath<External<A>, A>, <G: Hashable, H> (root $External<H>; external #External.subscript <H, G> [%$0 : $G : $*G] : $H) <B, A> (%z)
+  // CHECK: %4 = keypath $KeyPath<External<A>, A>, <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (
+  // CHECK-SAME: root $External<τ_0_1>;
+  // CHECK-SAME: external #External.subscript<τ_0_1, τ_0_0>[%$0 : $τ_0_0 : $*τ_0_0] : $τ_0_1,
+  // CHECK-SAME: indices_equals @equals_external_subscript
+  // CHECK-SAME: indices_hash @hash_external_subscript
+  // CHECK-SAME: ) <B, A> (%0)
+  %d = keypath $KeyPath<External<A>, A>, <G: Hashable, H> (
+    root $External<H>;
+    external #External.subscript <H, G> [%$0 : $G : $*G] : $H,
+      indices_equals @equals_external_subscript : $@convention(thin) <U: Hashable, T> (UnsafeRawPointer, UnsafeRawPointer) -> Bool,
+      indices_hash @hash_external_subscript : $@convention(thin) <U: Hashable, T> (UnsafeRawPointer) -> Int) <B, A> (%z)
 
   return undef : $()
 }
@@ -179,23 +190,17 @@ entry:
 }
 
 sil [serialized] @get_external_subscript : $@convention(thin) <T, U: Hashable> (@in External<T>, UnsafeRawPointer) -> @out T
-sil [serialized] @equals_external_subscript : $@convention(thin) <T, U: Hashable> (UnsafeRawPointer, UnsafeRawPointer) -> Bool
-sil [serialized] @hash_external_subscript : $@convention(thin) <T, U: Hashable> (UnsafeRawPointer) -> Int
+sil [serialized] @equals_external_subscript : $@convention(thin) <U: Hashable, T> (UnsafeRawPointer, UnsafeRawPointer) -> Bool
+sil [serialized] @hash_external_subscript : $@convention(thin) <U: Hashable, T> (UnsafeRawPointer) -> Int
 
 // CHECK-LABEL: sil_property [serialized] #External.ro<τ_0_0> (stored_property #External.ro : $τ_0_0)
 sil_property [serialized] #External.ro <T> (stored_property #External.ro : $T)
 
 // CHECK-LABEL: sil_property [serialized] #External.subscript<τ_0_0><τ_1_0 where τ_1_0 : Hashable> (gettable_property $τ_0_0,
 // CHECK-SAME:   id @id_a : $@convention(thin) () -> (),
-// CHECK-SAME:   getter @get_external_subscript : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_1 : Hashable> (@in External<τ_0_0>, UnsafeRawPointer) -> @out τ_0_0,
-// CHECK-SAME:   indices [%$0 : $τ_1_0 : $*τ_1_0],
-// CHECK-SAME:   indices_equals @equals_external_subscript : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_1 : Hashable> (UnsafeRawPointer, UnsafeRawPointer) -> Bool,
-// CHECK-SAME:   indices_hash @hash_external_subscript : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_1 : Hashable> (UnsafeRawPointer) -> Int)
+// CHECK-SAME:   getter @get_external_subscript : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_1 : Hashable> (@in External<τ_0_0>, UnsafeRawPointer) -> @out τ_0_0)
 sil_property [serialized] #External.subscript <T><U: Hashable> (gettable_property $T,
   id @id_a : $@convention(thin) () -> (),
-  getter @get_external_subscript : $@convention(thin) <T, U: Hashable> (@in External<T>, UnsafeRawPointer) -> @out T,
-  indices [%$0 : $U : $*U],
-  indices_equals @equals_external_subscript : $@convention(thin) <T, U: Hashable> (UnsafeRawPointer, UnsafeRawPointer) -> Bool,
-  indices_hash @hash_external_subscript : $@convention(thin) <T, U: Hashable> (UnsafeRawPointer) -> Int)
+  getter @get_external_subscript : $@convention(thin) <T, U: Hashable> (@in External<T>, UnsafeRawPointer) -> @out T)
 
 

--- a/test/SILGen/Inputs/ExternalKeyPaths.swift
+++ b/test/SILGen/Inputs/ExternalKeyPaths.swift
@@ -3,3 +3,7 @@ public struct External<A> {
   public var intProperty: Int
   public subscript<B: Hashable>(index: B) -> A { return property }
 }
+
+public struct ExternalEmptySubscript {
+  public subscript() -> Int { return 0 }
+}

--- a/test/SILGen/external-keypath.swift
+++ b/test/SILGen/external-keypath.swift
@@ -29,24 +29,29 @@ func externalKeyPaths<T: Hashable, U>(_ x: T, _ y: U, _ z: Int) {
   // CHECK: keypath $WritableKeyPath<External<U>, Int>, <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (root $External<τ_0_1>; external #External.intProperty<U> : $Int) <T, U>
   _ = \External<U>.intProperty
 
-  // CHECK: keypath $KeyPath<External<Int>, Int>, (root $External<Int>; external #External.subscript<Int, Int>[%$0 : $Int : $Int] : $Int) (%2)
+  // CHECK: keypath $KeyPath<External<Int>, Int>, (root $External<Int>; external #External.subscript<Int, Int>[%$0 : $Int : $Int] : $Int, indices_equals @{{.*}}) (%2)
   _ = \External<Int>.[z]
 
-  // CHECK: keypath $KeyPath<External<T>, T>, <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (root $External<τ_0_0>; external #External.subscript<T, T>[%$0 : $τ_0_0 : $*τ_0_0] : $τ_0_0) <T, U> ({{.*}})
+  // CHECK: keypath $KeyPath<External<T>, T>, <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (root $External<τ_0_0>; external #External.subscript<T, T>[%$0 : $τ_0_0 : $*τ_0_0] : $τ_0_0, indices_equals @{{.*}}) <T, U> ({{.*}})
   _ = \External<T>.[x]
 
-  // CHECK: keypath $KeyPath<External<U>, U>, <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (root $External<τ_0_1>; external #External.subscript<U, T>[%$0 : $τ_0_0 : $*τ_0_0] : $τ_0_1) <T, U> ({{.*}})
+  // CHECK: keypath $KeyPath<External<U>, U>, <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (root $External<τ_0_1>; external #External.subscript<U, T>[%$0 : $τ_0_0 : $*τ_0_0] : $τ_0_1, indices_equals @{{.*}}) <T, U> ({{.*}})
   _ = \External<U>.[x]
 
   // CHECK: keypath $KeyPath<External<Local>, Int>, <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (
   // CHECK-SAME: root $External<Local>;
-  // CHECK-SAME: external #External.subscript<Local, T>[%$0 : $τ_0_0 : $*τ_0_0] : $Local;
+  // CHECK-SAME: external #External.subscript<Local, T>[%$0 : $τ_0_0 : $*τ_0_0] : $Local, indices_equals @{{.*}};
   // CHECK-SAME: stored_property #Local.x : $Int) <T, U> ({{.*}})
   _ = \External<Local>.[x].x
 
   // CHECK: keypath $KeyPath<External<Local>, String>, <τ_0_0, τ_0_1 where τ_0_0 : Hashable> (
   // CHECK-SAME: root $External<Local>;
-  // CHECK-SAME: external #External.subscript<Local, T>[%$0 : $τ_0_0 : $*τ_0_0] : $Local;
+  // CHECK-SAME: external #External.subscript<Local, T>[%$0 : $τ_0_0 : $*τ_0_0] : $Local, indices_equals @{{.*}};
   // CHECK-SAME: stored_property #Local.y : $String) <T, U> ({{.*}})
   _ = \External<Local>.[x].y
+
+  // CHECK: keypath $KeyPath<ExternalEmptySubscript, Int>, (
+  // CHECK-SAME: root $ExternalEmptySubscript;
+  // CHECK-SAME: external #ExternalEmptySubscript.subscript : $Int)
+  _ = \ExternalEmptySubscript.[]
 }

--- a/test/SILGen/keypath_property_descriptors.swift
+++ b/test/SILGen/keypath_property_descriptors.swift
@@ -50,12 +50,12 @@ public struct A {
   // CHECK-NOT: sil_property #A.f
   private static var f: Int = 0
 
-  // CHECK-LABEL: sil_property #A.subscript
+  // CHECK-LABEL: sil_property #A.subscript{{.*}} id @{{.*}}1a
   public subscript(a x: Int) -> Int { return x }
-  // CHECK-LABEL: sil_property #A.subscript
+  // CHECK-LABEL: sil_property #A.subscript{{.*}} id @{{.*}}1b
   @_inlineable
   public subscript(b x: Int) -> Int { return x }
-  // CHECK-LABEL: sil_property #A.subscript
+  // CHECK-LABEL: sil_property #A.subscript{{.*}} id @{{.*}}1c
   @_versioned
   internal subscript(c x: Int) -> Int { return x }
   
@@ -65,14 +65,17 @@ public struct A {
   fileprivate subscript(e x: Int) -> Int { return x }
   private subscript(f x: Int) -> Int { return x }
 
-  // TODO: Subscripts with non-hashable subscripts should get descriptors
+  // CHECK-LABEL: sil_property #A.subscript{{.*}} id @{{.*}}1a
   public subscript<T>(a x: T) -> T { return x }
+  // CHECK-LABEL: sil_property #A.subscript{{.*}} id @{{.*}}1b
   @_inlineable
   public subscript<T>(b x: T) -> T { return x }
+  // CHECK-LABEL: sil_property #A.subscript{{.*}} id @{{.*}}1c
   @_versioned
   internal subscript<T>(c x: T) -> T { return x }
   
   // no descriptor
+  // CHECK-NOT: sil_property #A.subscript
   internal subscript<T>(d x: T) -> T { return x }
   fileprivate subscript<T>(e x: T) -> T { return x }
   private subscript<T>(f x: T) -> T { return x }


### PR DESCRIPTION
A public subscript might have generic indexes that aren't unconditionally Hashable, or might use indexes that are retroactively made Hashable, so the property descriptor on the implementer's side can't always resiliently provide this information to the final instantiated KeyPath.