### PR TITLE
[Testing] Mark two latent long tests as 'long_test'

### DIFF
--- a/validation-test/stdlib/ParameterPassing.swift.gyb
+++ b/validation-test/stdlib/ParameterPassing.swift.gyb
@@ -1,4 +1,4 @@
-//===--- SIMDParameterPassing.swift ---------------------------*- swift -*-===//
+//===--- ParameterPassing.swift -------------------------------*- swift -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -10,21 +10,15 @@
 //
 //===----------------------------------------------------------------------===//
 // RUN: %empty-directory(%t)
-// RUN: %gyb %s -o %t/SIMDParameterPassing.swift
-// RUN: %line-directive %t/SIMDParameterPassing.swift -- %target-build-swift %t/SIMDParameterPassing.swift -o %t/a.out_Release -O
+// RUN: %gyb %s -o %t/ParameterPassing.swift
+// RUN: %line-directive %t/ParameterPassing.swift -- %target-build-swift %t/ParameterPassing.swift -o %t/a.out_Release -O
 // RUN: %target-run %t/a.out_Release
-
 // REQUIRES: executable_test
-// XFAIL: linux
+// REQUIRES: long_test
 
 import StdlibUnittest
-import simd
 
-% scalar_types = ['Float', 'Double', 'Int32', 'UInt32']
-% float_types = ['Float', 'Double']
-% ctype = { 'Float':'float', 'Double':'double', 'Int32':'int', 'UInt32':'uint'}
-
-let tests = TestSuite("SIMDParameterPassing")
+let tests = TestSuite("ParameterPassing")
 
 struct MyError : Error {
    let val = 127
@@ -50,87 +44,68 @@ struct MyError : Error {
 
 // Integer values.
 % for TestType in 'UInt8', 'UInt16', 'UInt32', 'UInt64', 'Int8', 'Int16', 'Int32', 'Int64':
+
+  enum Enum${TestType} : Equatable {
+    case Empty
+    case Value(${TestType})
+  }
+  func == (lhs: Enum${TestType}, rhs: Enum${TestType}) -> Bool {
+    switch lhs {
+      case .Empty:
+        switch rhs {
+          case .Empty:
+            return true
+          case .Value(_):
+            return false
+        }
+      case .Value(let lhsVal):
+        switch lhs {
+           case .Empty:
+             return false
+           case .Value(let rhsVal):
+            return lhsVal == rhsVal
+        }
+    }
+  }
+
+  struct Struct${TestType} : Equatable {
+    let f0 : ${TestType}
+    let f1: Float
+    let f2: Double
+    init(f0: ${TestType}, f1: Float, f2: Double) {
+      self.f0 = f0
+      self.f1 = f1
+      self.f2 = f2
+    }
+  }
+  func ==(lhs: Struct${TestType}, rhs: Struct${TestType}) -> Bool {
+    return lhs.f0 == rhs.f0 && lhs.f1 == rhs.f1 && lhs.f2 == rhs.f2
+  }
+
 % for Num in range(0, 10):
   @inline(__always)
   func value${TestType}${Num}() -> ${TestType} {
     return ${Num+1}
   }
-% end
-% end
-
-// Vector values.
-% for type in scalar_types:
-% for cols in [2,3,4]:
-% TestType = ctype[type] + str(cols)
-
-// arm64 isel crashes when passing float3.
-% if cols == 3:
-#if !arch(arm64)
-% end
-
-enum Enum${TestType} : Equatable {
-  case Empty
-  case Value(${TestType})
-}
-func == (lhs: Enum${TestType}, rhs: Enum${TestType}) -> Bool {
-  switch lhs {
-    case .Empty:
-      switch rhs {
-        case .Empty:
-          return true
-        case .Value(_):
-          return false
-      }
-    case .Value(let lhsVal):
-      switch lhs {
-         case .Empty:
-           return false
-         case .Value(let rhsVal):
-          return lhsVal == rhsVal
-      }
-  }
-}
-
-struct Struct${TestType} : Equatable {
-  let f0 : Int8
-  let f1 : Enum${TestType}
-  let f2: Float
-  let f3: Double
-
-  init(f0: Int8, f1: Enum${TestType}, f2: Float, f3: Double) {
-    self.f0 = f0
-    self.f1 = f1
-    self.f2 = f2
-    self.f3 = f3
-  }
-}
-func ==(lhs: Struct${TestType}, rhs: Struct${TestType}) -> Bool {
-  return lhs.f0 == rhs.f0 && lhs.f1 == rhs.f1 && lhs.f2 == rhs.f2 &&
-    lhs.f3 == rhs.f3
-}
-
-
-% for Num in range(0, 10):
-  @inline(__always)
-  func value${TestType}${Num}() -> ${TestType} {
-    return ${TestType}(${', '.join(map(lambda i: str(i), range(Num, Num+cols)))})
-  }
   @inline(__always)
   func valueEnum${TestType}${Num}() -> Enum${TestType} {
-    return Enum${TestType}.Value(value${TestType}${Num}())
+    return Enum${TestType}.Value(${Num+1})
   }
   func valueStruct${TestType}${Num}() -> Struct${TestType} {
-    return Struct${TestType}(f0: ${Num+1}, f1: valueEnum${TestType}${Num}(), f2: 1.${Num}, f3: 2.${Num})
+    return Struct${TestType}(f0: ${Num+1}, f1: 1.${Num}, f2: 2.${Num})
   }
 % end
+% end
 
-// arm64 isel crashes when passing float3.
-% if cols == 3:
+// Float80 values.
+#if arch(i386) || arch(x86_64)
+% for Num in range(0, 10):
+  @inline(__always)
+  func valueFloat80${Num}() -> Float80 {
+    return 1.${Num+1}
+  }
+% end
 #endif
-% end
-
-% end
-% end
 
 % for (FuncName, Throw, MayThrow, DoesThrow) in errorMethodTypes:
 
@@ -155,14 +130,20 @@ func clobber${FuncName}(
 
 %end
 
-% for type in scalar_types:
-% for cols in [2,3,4]:
-// arm64 isel crashes when passing float3.
-% if cols == 3:
-#if !arch(arm64)
+%{ testTypes = [
+     'Float', 'Float80', 'Double', 'UInt8', 'UInt16', 'UInt32', 'UInt64',
+     'Int8', 'Int16', 'Int32', 'Int64',
+     'EnumUInt8', 'EnumUInt16', 'EnumUInt32', 'EnumUInt64', 'EnumInt8',
+     'EnumInt16', 'EnumInt32', 'EnumInt64',
+     'StructUInt8', 'StructUInt16', 'StructUInt32', 'StructUInt64',
+     'StructInt8', 'StructInt16', 'StructInt32', 'StructInt64',
+   ]
+}%
+% for TestType in testTypes:
+
+% if TestType == 'Float80':
+#if arch(i386) || arch(x86_64)
 % end
-% for typePrefix in [ '', 'Enum', 'Struct']:
-% TestType = typePrefix + ctype[type] + str(cols)
 
 % for (FuncName, Throw, MayThrow, DoesThrow) in errorMethodTypes:
 
@@ -632,12 +613,10 @@ tests.test("${TestType}/RetAndParamWitnessMethod${FuncName}") {
 
 % end
 
-% end
-// arm64 isel crashes when passing float3.
-% if cols == 3:
+% if TestType == 'Float80':
 #endif
 % end
-% end
+
 % end
 
 runAllTests()

--- a/validation-test/stdlib/SIMDParameterPassing.swift.gyb
+++ b/validation-test/stdlib/SIMDParameterPassing.swift.gyb
@@ -1,4 +1,4 @@
-//===--- ParameterPassing.swift -------------------------------*- swift -*-===//
+//===--- SIMDParameterPassing.swift ---------------------------*- swift -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -10,14 +10,22 @@
 //
 //===----------------------------------------------------------------------===//
 // RUN: %empty-directory(%t)
-// RUN: %gyb %s -o %t/ParameterPassing.swift
-// RUN: %line-directive %t/ParameterPassing.swift -- %target-build-swift %t/ParameterPassing.swift -o %t/a.out_Release -O
+// RUN: %gyb %s -o %t/SIMDParameterPassing.swift
+// RUN: %line-directive %t/SIMDParameterPassing.swift -- %target-build-swift %t/SIMDParameterPassing.swift -o %t/a.out_Release -O
 // RUN: %target-run %t/a.out_Release
+
 // REQUIRES: executable_test
+// REQUIRES: long_test
+// XFAIL: linux
 
 import StdlibUnittest
+import simd
 
-let tests = TestSuite("ParameterPassing")
+% scalar_types = ['Float', 'Double', 'Int32', 'UInt32']
+% float_types = ['Float', 'Double']
+% ctype = { 'Float':'float', 'Double':'double', 'Int32':'int', 'UInt32':'uint'}
+
+let tests = TestSuite("SIMDParameterPassing")
 
 struct MyError : Error {
    let val = 127
@@ -43,68 +51,87 @@ struct MyError : Error {
 
 // Integer values.
 % for TestType in 'UInt8', 'UInt16', 'UInt32', 'UInt64', 'Int8', 'Int16', 'Int32', 'Int64':
-
-  enum Enum${TestType} : Equatable {
-    case Empty
-    case Value(${TestType})
-  }
-  func == (lhs: Enum${TestType}, rhs: Enum${TestType}) -> Bool {
-    switch lhs {
-      case .Empty:
-        switch rhs {
-          case .Empty:
-            return true
-          case .Value(_):
-            return false
-        }
-      case .Value(let lhsVal):
-        switch lhs {
-           case .Empty:
-             return false
-           case .Value(let rhsVal):
-            return lhsVal == rhsVal
-        }
-    }
-  }
-
-  struct Struct${TestType} : Equatable {
-    let f0 : ${TestType}
-    let f1: Float
-    let f2: Double
-    init(f0: ${TestType}, f1: Float, f2: Double) {
-      self.f0 = f0
-      self.f1 = f1
-      self.f2 = f2
-    }
-  }
-  func ==(lhs: Struct${TestType}, rhs: Struct${TestType}) -> Bool {
-    return lhs.f0 == rhs.f0 && lhs.f1 == rhs.f1 && lhs.f2 == rhs.f2
-  }
-
 % for Num in range(0, 10):
   @inline(__always)
   func value${TestType}${Num}() -> ${TestType} {
     return ${Num+1}
   }
-  @inline(__always)
-  func valueEnum${TestType}${Num}() -> Enum${TestType} {
-    return Enum${TestType}.Value(${Num+1})
-  }
-  func valueStruct${TestType}${Num}() -> Struct${TestType} {
-    return Struct${TestType}(f0: ${Num+1}, f1: 1.${Num}, f2: 2.${Num})
-  }
 % end
 % end
 
-// Float80 values.
-#if arch(i386) || arch(x86_64)
+// Vector values.
+% for type in scalar_types:
+% for cols in [2,3,4]:
+% TestType = ctype[type] + str(cols)
+
+// arm64 isel crashes when passing float3.
+% if cols == 3:
+#if !arch(arm64)
+% end
+
+enum Enum${TestType} : Equatable {
+  case Empty
+  case Value(${TestType})
+}
+func == (lhs: Enum${TestType}, rhs: Enum${TestType}) -> Bool {
+  switch lhs {
+    case .Empty:
+      switch rhs {
+        case .Empty:
+          return true
+        case .Value(_):
+          return false
+      }
+    case .Value(let lhsVal):
+      switch lhs {
+         case .Empty:
+           return false
+         case .Value(let rhsVal):
+          return lhsVal == rhsVal
+      }
+  }
+}
+
+struct Struct${TestType} : Equatable {
+  let f0 : Int8
+  let f1 : Enum${TestType}
+  let f2: Float
+  let f3: Double
+
+  init(f0: Int8, f1: Enum${TestType}, f2: Float, f3: Double) {
+    self.f0 = f0
+    self.f1 = f1
+    self.f2 = f2
+    self.f3 = f3
+  }
+}
+func ==(lhs: Struct${TestType}, rhs: Struct${TestType}) -> Bool {
+  return lhs.f0 == rhs.f0 && lhs.f1 == rhs.f1 && lhs.f2 == rhs.f2 &&
+    lhs.f3 == rhs.f3
+}
+
+
 % for Num in range(0, 10):
   @inline(__always)
-  func valueFloat80${Num}() -> Float80 {
-    return 1.${Num+1}
+  func value${TestType}${Num}() -> ${TestType} {
+    return ${TestType}(${', '.join(map(lambda i: str(i), range(Num, Num+cols)))})
+  }
+  @inline(__always)
+  func valueEnum${TestType}${Num}() -> Enum${TestType} {
+    return Enum${TestType}.Value(value${TestType}${Num}())
+  }
+  func valueStruct${TestType}${Num}() -> Struct${TestType} {
+    return Struct${TestType}(f0: ${Num+1}, f1: valueEnum${TestType}${Num}(), f2: 1.${Num}, f3: 2.${Num})
   }
 % end
+
+// arm64 isel crashes when passing float3.
+% if cols == 3:
 #endif
+% end
+
+% end
+% end
 
 % for (FuncName, Throw, MayThrow, DoesThrow) in errorMethodTypes:
 
@@ -129,20 +156,14 @@ func clobber${FuncName}(
 
 %end
 
-%{ testTypes = [
-     'Float', 'Float80', 'Double', 'UInt8', 'UInt16', 'UInt32', 'UInt64',
-     'Int8', 'Int16', 'Int32', 'Int64',
-     'EnumUInt8', 'EnumUInt16', 'EnumUInt32', 'EnumUInt64', 'EnumInt8',
-     'EnumInt16', 'EnumInt32', 'EnumInt64',
-     'StructUInt8', 'StructUInt16', 'StructUInt32', 'StructUInt64',
-     'StructInt8', 'StructInt16', 'StructInt32', 'StructInt64',
-   ]
-}%
-% for TestType in testTypes:
-
-% if TestType == 'Float80':
-#if arch(i386) || arch(x86_64)
+% for type in scalar_types:
+% for cols in [2,3,4]:
+// arm64 isel crashes when passing float3.
+% if cols == 3:
+#if !arch(arm64)
 % end
+% for typePrefix in [ '', 'Enum', 'Struct']:
+% TestType = typePrefix + ctype[type] + str(cols)
 
 % for (FuncName, Throw, MayThrow, DoesThrow) in errorMethodTypes:
 
@@ -612,10 +633,12 @@ tests.test("${TestType}/RetAndParamWitnessMethod${FuncName}") {
 
 % end
 
-% if TestType == 'Float80':
+% end
+// arm64 isel crashes when passing float3.
+% if cols == 3:
 #endif
 % end
-
+% end
 % end
 
 runAllTests()


### PR DESCRIPTION
This improves `ninja check-swift-validation` performance by about 2.9x on my Linux desktop. Also, move them to `validation-test` where the other long tests live.