### PR TITLE
[code-completion] Fix assertion hit in getTypeOfReference via code completion

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3453,6 +3453,7 @@ bool swift::typeCheckUnresolvedExpr(DeclContext &DC,
 
   ConstraintSystemOptions Options = ConstraintSystemFlags::AllowFixes;
   auto *TC = static_cast<TypeChecker*>(DC.getASTContext().getLazyResolver());
+  Parent = Parent->walk(SanitizeExpr(*TC));
   ConstraintSystem CS(*TC, &DC, Options);
   CleanupIllFormedExpressionRAII cleanup(TC->Context, Parent);
   InferUnresolvedMemberConstraintGenerator MCG(E, CS);

--- a/test/IDE/complete_enum_elements.swift
+++ b/test/IDE/complete_enum_elements.swift
@@ -66,6 +66,8 @@
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=WITH_INVALID_DOT_1 | %FileCheck %s -check-prefix=WITH_INVALID_DOT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_1 | %FileCheck %s -check-prefix=UNRESOLVED_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_2 | %FileCheck %s -check-prefix=UNRESOLVED_2
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=UNRESOLVED_3 | %FileCheck %s -check-prefix=UNRESOLVED_3
 
 //===---
 //===--- Test that we can complete enum elements.
@@ -380,4 +382,17 @@ func testWithInvalid1() {
 // UNRESOLVED_1-DAG:  Decl[EnumElement]/ExprSpecific:     Qux1[#QuxEnum#]; name=Qux1
 // UNRESOLVED_1-DAG:  Decl[EnumElement]/ExprSpecific:     Qux2[#QuxEnum#]; name=Qux2
 // UNRESOLVED_1-NOT:  Okay
+}
+
+func testUnqualified1(x: QuxEnum) {
+  _ = x == .Qux1 || x == .#^UNRESOLVED_2^#Qux2
+  // UNRESOLVED_2: Begin completions, 2 items
+  // UNRESOLVED_2-DAG: Decl[EnumElement]/ExprSpecific:     Qux1[#QuxEnum#]; name=Qux1
+  // UNRESOLVED_2-DAG: Decl[EnumElement]/ExprSpecific:     Qux2[#QuxEnum#]; name=Qux2
+  // UNRESOLVED_2: End completions
+
+  _ = (x == .Qux1#^UNRESOLVED_3^#)
+  // UNRESOLVED_3: Begin completions
+  // UNRESOLVED_3: End completions
+
 }

--- a/validation-test/IDE/crashers_2/0016-operator-unresolved-dot.swift
+++ b/validation-test/IDE/crashers_2/0016-operator-unresolved-dot.swift
@@ -1,4 +1,0 @@
-// RUN: not --crash %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
-// REQUIRES: asserts
-
-struct a { func b(c d: a) { b(c: d) == .#^A^#

--- a/validation-test/IDE/crashers_2_fixed/0016-operator-unresolved-dot.swift
+++ b/validation-test/IDE/crashers_2_fixed/0016-operator-unresolved-dot.swift
@@ -1,0 +1,4 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+// REQUIRES: asserts
+
+struct a { func b(c d: a) { b(c: d) == .#^A^#


### PR DESCRIPTION
<!-- What's in this pull request? -->
```
enum QuxEnum : Int {
  case Qux1 = 10
  case Qux2 = 20
}

func foo(x: QuxEnum) {
  _ = x == .Qux1 || x == ./* code complete here */Qux2
}
```
Code completion is re-typechecking the assignment in `func foo` above. On the first pass the `UnresolvedMemberExpr`s corresponding to the enum elements are transformed into `DotSyntaxCallExpr`s. When it later re-typechecks via `typeCheckUnresolvedExpr` with the assignment as the parent, the type checker ends up in `getTypeOfReference` where references to `EnumElementDecl`s are assumed to not occur.  It looks like `typeCheckUnresolvedExpr` calls an overload of solve() that bypasses the SanitizeExpr ASTWalker, which cleans up ASTs for the constraint-based type checker. Adding that along this path seems to resolve the issue.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves Resolves rdar://problem/38144409.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->