### PR TITLE
Don't emit keypath descriptors for properties with mutating getters

### DIFF
--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1172,6 +1172,10 @@ static bool doesPropertyNeedDescriptor(AbstractStorageDecl *decl) {
   if (!decl->getGetter())
     return false;
 
+  // If the getter is mutating, we cannot form a keypath to it at all.
+  if (decl->isGetterMutating())
+    return false;
+
   // TODO: If previous versions of an ABI-stable binary needed the descriptor,
   // then we still do.
 

--- a/test/SILGen/keypath_property_descriptors.swift
+++ b/test/SILGen/keypath_property_descriptors.swift
@@ -76,5 +76,18 @@ public struct A {
   internal subscript<T>(d x: T) -> T { return x }
   fileprivate subscript<T>(e x: T) -> T { return x }
   private subscript<T>(f x: T) -> T { return x }
+
+  // no descriptor
+  public var count: Int {
+    mutating get {
+      _count += 1
+      return _count
+    }
+    set {
+      _count = newValue
+    }
+  }
+
+  private var _count: Int = 0
 }
 


### PR DESCRIPTION
Fixes <https://bugs.swift.org/browse/SR-7176>, <rdar://problem/38439418>.