### PR TITLE
SwiftSyntax: add an API to teach Trivia to calculate byte size.

### DIFF
--- a/test/SwiftSyntax/AbsolutePosition.swift
+++ b/test/SwiftSyntax/AbsolutePosition.swift
@@ -73,6 +73,10 @@ PositionTests.test("CurrentFile") {
         _ = node.byteSize
         _ = node.positionAfterSkippingLeadingTrivia
       }
+      override func visit(_ node: TokenSyntax) {
+        expectEqual(node.position.byteOffset + node.leadingTrivia.byteSize,
+                    node.positionAfterSkippingLeadingTrivia.byteOffset)
+      }
     }
     Visitor().visit(parsed)
   })

--- a/tools/SwiftSyntax/Syntax.swift
+++ b/tools/SwiftSyntax/Syntax.swift
@@ -120,7 +120,7 @@ extension Syntax {
     return data.indexInParent
   }
 
-  /// The absolute position of the starting point this node. If the first token
+  /// The absolute position of the starting point of this node. If the first token
   /// is with leading trivia, the position points to the start of the leading
   /// trivia.
   public var position: AbsolutePosition {

--- a/tools/SwiftSyntax/Trivia.swift.gyb
+++ b/tools/SwiftSyntax/Trivia.swift.gyb
@@ -242,6 +242,15 @@ extension Trivia: Collection {
   public subscript(_ index: Int) -> TriviaPiece {
     return pieces[index]
   }
+
+  /// Get the byteSize of this trivia
+  public var byteSize: Int {
+    let pos = AbsolutePosition()
+    for piece in pieces {
+      piece.accumulateAbsolutePosition(pos)
+    }
+    return pos.byteOffset
+  }
 }
 
 


### PR DESCRIPTION
This missing piece will allow clients to customize the size of
SyntaxNode better.