### PR TITLE
[IRGen] Fix a bug In creating outlined copy_addr of generic structs

### DIFF
--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -267,8 +267,6 @@ public:
       llvm::MapVector<CanType, llvm::Value *> &typeToMetadataVec,
       SILType T) const override {
     auto canType = T.getSwiftRValueType();
-    // get the size before insertions
-    auto SZ = typeToMetadataVec.size();
     for (auto &field : getFields()) {
       if (field.isEmpty())
         continue;
@@ -277,7 +275,7 @@ public:
                                                    fType);
     }
     if (typeToMetadataVec.find(canType) == typeToMetadataVec.end() &&
-        typeToMetadataVec.size() != SZ) {
+        typeToMetadataVec.size() != 0) {
       auto *metadata = IGF.emitTypeMetadataRefForLayout(T);
       assert(metadata && "Expected Type Metadata Ref");
       typeToMetadataVec.insert(std::make_pair(canType, metadata));

--- a/test/IRGen/outlined_copy_addr.swift
+++ b/test/IRGen/outlined_copy_addr.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend -emit-ir  -module-name outcopyaddr -primary-file %s | %FileCheck %s
+
+public protocol BaseProt {
+}
+
+public protocol ChildProt: BaseProt {
+}
+
+public struct BaseStruct<T: BaseProt> {
+    public typealias Element = T
+    public var elem1: Element
+    public var elem2: Element
+}
+
+public struct StructWithBaseStruct<T: BaseProt> {
+    public typealias Element = T
+    var elem1: Element
+    var elem2: BaseStruct<Element>
+}
+
+// CHECK-LABEL: define hidden swiftcc void @"$S11outcopyaddr010StructWithbc4BaseB0V4elemAA0bcdB0VyxGvg"(%T11outcopyaddr014StructWithBaseB0V.0* noalias nocapture sret, %swift.type* %"StructWithStructWithBaseStruct<T>", %T11outcopyaddr010StructWithbc4BaseB0V* noalias nocapture swiftself)
+// CHECK: call %T11outcopyaddr014StructWithBaseB0V.0* @"$S11outcopyaddrytWc3_"
+public struct StructWithStructWithBaseStruct<T: ChildProt> {
+    public typealias Element = T
+    let elem: StructWithBaseStruct<Element>
+}


### PR DESCRIPTION
radar rdar://problem/38388006

When dealing with record types, the outliner had a peephole optimization that is apparently invalid in a corner-case (see new test case)
If we added an archetypes then we *have* to emit type metadata for any containing record type, else we might skip one of the “child” records in our recursive type walk