### PR TITLE
[Parse] Eliminate {l,r}_square_lit tokens.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1187,14 +1187,15 @@ ERROR(expected_rsquare_array_expr,PointsToFirstBadToken,
       "expected ']' in container literal expression", ())
 
 // Object literal expressions
-ERROR(expected_object_literal_identifier,none,
-      "expected identifier after '#' in object literal expression", ())
-ERROR(expected_arg_list_in_object_literal,none,
+ERROR(expected_arg_list_in_object_literal,PointsToFirstBadToken,
       "expected argument list in object literal", ())
-ERROR(object_literal_legacy_name,none,
-      "'%0' has been renamed to '%1", (StringRef, StringRef))
-ERROR(legacy_object_literal_syntax,none,
-       "object literal syntax no longer uses '[# ... #]'", ())
+ERROR(legacy_object_literal,none,
+      "'%select{|[}0#%1(...)%select{|#]}0' has been renamed to '#%2(...)'",
+      (bool, StringRef, StringRef))
+
+// Unknown pound expression.
+ERROR(unknown_pound_expr,none,
+      "use of unknown directive '#%0'", (StringRef))
 
 // If expressions
 ERROR(expected_expr_after_if_question,none,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1281,10 +1281,8 @@ public:
   /// Parse an object literal.
   ///
   /// \param LK The literal kind as determined by the first token.
-  /// \param NewName New name for a legacy literal.
   ParserResult<Expr> parseExprObjectLiteral(ObjectLiteralExpr::LiteralKind LK,
-                                            bool isExprBasic,
-                                            StringRef NewName = StringRef());
+                                            bool isExprBasic);
   ParserResult<Expr> parseExprCallSuffix(ParserResult<Expr> fn,
                                          bool isExprBasic);
   ParserResult<Expr> parseExprCollection(SourceLoc LSquareLoc = SourceLoc());

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1285,7 +1285,7 @@ public:
                                             bool isExprBasic);
   ParserResult<Expr> parseExprCallSuffix(ParserResult<Expr> fn,
                                          bool isExprBasic);
-  ParserResult<Expr> parseExprCollection(SourceLoc LSquareLoc = SourceLoc());
+  ParserResult<Expr> parseExprCollection();
   ParserResult<Expr> parseExprArray(SourceLoc LSquareLoc);
   ParserResult<Expr> parseExprDictionary(SourceLoc LSquareLoc);
   ParserResult<Expr> parseExprPoundUnknown(SourceLoc LSquareLoc);

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1288,6 +1288,7 @@ public:
   ParserResult<Expr> parseExprCollection(SourceLoc LSquareLoc = SourceLoc());
   ParserResult<Expr> parseExprArray(SourceLoc LSquareLoc);
   ParserResult<Expr> parseExprDictionary(SourceLoc LSquareLoc);
+  ParserResult<Expr> parseExprPoundUnknown(SourceLoc LSquareLoc);
 
   UnresolvedDeclRefExpr *parseExprOperator();
 

--- a/include/swift/Syntax/TokenKinds.def
+++ b/include/swift/Syntax/TokenKinds.def
@@ -261,11 +261,6 @@ PUNCTUATOR(sil_exclamation, "!")    // Only in SIL mode.
 PUNCTUATOR(string_quote, "\"")
 PUNCTUATOR(multiline_string_quote, "\"\"\"")
 
-// Legacy punctuators used for migrating old object literal syntax.
-// NOTE: Remove in the future.
-PUNCTUATOR(l_square_lit,  "[#")
-PUNCTUATOR(r_square_lit,  "#]")
-
 // Keywords prefixed with a '#'.  "keyPath" becomes "tok::pound_keyPath".
 POUND_KEYWORD(keyPath)
 POUND_KEYWORD(line)

--- a/include/swift/Syntax/TokenKinds.def
+++ b/include/swift/Syntax/TokenKinds.def
@@ -22,7 +22,6 @@
 ///     SIL_KEYWORD(kw)
 ///   POUND_KEYWORD(kw)
 ///     POUND_OBJECT_LITERAL(kw, desc, proto)
-///     POUND_OLD_OBJECT_LITERAL(kw, new_kw, old_arg, new_arg)
 ///     POUND_CONFIG(kw)
 ///     POUND_DIRECTIVE_KEYWORD(kw)
 ///       POUND_COND_DIRECTIVE_KEYWORD(kw)
@@ -94,13 +93,6 @@
 ///   Every keyword prefixed with a '#' representing an object literal.
 #ifndef POUND_OBJECT_LITERAL
 #define POUND_OBJECT_LITERAL(kw, desc, proto) POUND_KEYWORD(kw)
-#endif
-
-/// POUND_OLD_OBJECT_LITERAL(kw, new_kw, old_arg, new_arg)
-///   Every keyword prefixed with a '#' representing the obsoleted form of an
-///   object literal.
-#ifndef POUND_OLD_OBJECT_LITERAL
-#define POUND_OLD_OBJECT_LITERAL(kw, new_kw, old_arg, new_arg) POUND_KEYWORD(kw)
 #endif
 
 /// POUND_CONFIG(kw)
@@ -289,10 +281,6 @@ POUND_OBJECT_LITERAL(fileLiteral, "file reference", ExpressibleByFileReferenceLi
 POUND_OBJECT_LITERAL(imageLiteral, "image", ExpressibleByImageLiteral)
 POUND_OBJECT_LITERAL(colorLiteral, "color", ExpressibleByColorLiteral)
 
-POUND_OLD_OBJECT_LITERAL(FileReference, fileLiteral, fileReferenceLiteral, resourceName)
-POUND_OLD_OBJECT_LITERAL(Image, imageLiteral, imageLiteral, resourceName)
-POUND_OLD_OBJECT_LITERAL(Color, colorLiteral, colorLiteralRed, red)
-
 // Single-token literals
 LITERAL(integer_literal)
 LITERAL(floating_literal)
@@ -325,7 +313,6 @@ MISC(string_interpolation_anchor)
 #undef SIL_KEYWORD
 #undef POUND_KEYWORD
 #undef POUND_OBJECT_LITERAL
-#undef POUND_OLD_OBJECT_LITERAL
 #undef POUND_CONFIG
 #undef POUND_DIRECTIVE_KEYWORD
 #undef POUND_COND_DIRECTIVE_KEYWORD

--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -100,8 +100,6 @@ SyntaxModelContext::SyntaxModelContext(SourceFile &SrcFile)
         Kind = SyntaxNodeKind::Keyword;
         break;
 
-#define POUND_OLD_OBJECT_LITERAL(Name, NewName, OldArg, NewArg) \
-      case tok::pound_##Name:
 #define POUND_OBJECT_LITERAL(Name, Desc, Proto) case tok::pound_##Name:
 #include "swift/Syntax/TokenKinds.def"
         LiteralStartLoc = Loc;
@@ -119,7 +117,6 @@ SyntaxModelContext::SyntaxModelContext(SourceFile &SrcFile)
         break;
 
 #define POUND_OBJECT_LITERAL(Name, Desc, Proto)
-#define POUND_OLD_OBJECT_LITERAL(Name, NewName, OldArg, NewArg)
 #define POUND_DIRECTIVE_KEYWORD(Name)
 #define POUND_KEYWORD(Name) case tok::pound_##Name:
 #include "swift/Syntax/TokenKinds.def"

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -637,12 +637,6 @@ void Lexer::lexIdentifier() {
 void Lexer::lexHash() {
   const char *TokStart = CurPtr-1;
 
-  // NOTE: legacy punctuator.  Remove in the future.
-  if (*CurPtr == ']') { // #]
-     ++CurPtr;
-     return formToken(tok::r_square_lit, TokStart);
-  }
-
   // Scan for [a-zA-Z]+ to see what we match.
   const char *tmpPtr = CurPtr;
   if (clang::isIdentifierHead(*tmpPtr)) {
@@ -2224,29 +2218,16 @@ void Lexer::lexImpl() {
 
   case '@': return formToken(tok::at_sign, TokStart);
   case '{': return formToken(tok::l_brace, TokStart);
-  case '[': {
-     // NOTE: Legacy punctuator for old object literal syntax.
-     // Remove in the future.
-     if (*CurPtr == '#') { // [#
-       // NOTE: Do NOT include the '#' in the token, unlike in earlier
-       // versions of Swift that supported the old object literal syntax
-       // directly.  The '#' will be lexed as part of the object literal
-       // keyword token itself.
-       return formToken(tok::l_square_lit, TokStart);
-     }
-     return formToken(tok::l_square, TokStart);
-  }
+  case '[': return formToken(tok::l_square, TokStart);
   case '(': return formToken(tok::l_paren, TokStart);
   case '}': return formToken(tok::r_brace, TokStart);
   case ']': return formToken(tok::r_square, TokStart);
-  case ')':
-    return formToken(tok::r_paren, TokStart);
+  case ')': return formToken(tok::r_paren, TokStart);
 
   case ',': return formToken(tok::comma, TokStart);
   case ';': return formToken(tok::semi, TokStart);
   case ':': return formToken(tok::colon, TokStart);
-  case '\\':
-    return formToken(tok::backslash, TokStart);
+  case '\\': return formToken(tok::backslash, TokStart);
 
   case '#':
     return lexHash();

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3252,12 +3252,9 @@ Parser::parseExprCallSuffix(ParserResult<Expr> fn, bool isExprBasic) {
 ///     expr-array
 ///     expr-dictionary
 //      lsquare-starting ']'
-ParserResult<Expr> Parser::parseExprCollection(SourceLoc LSquareLoc) {
+ParserResult<Expr> Parser::parseExprCollection() {
   SyntaxParsingContext ArrayOrDictContext(SyntaxContext);
-
-  // If the caller didn't already consume the '[', do so now.
-  if (LSquareLoc.isInvalid())
-    LSquareLoc = consumeToken(tok::l_square);
+  SourceLoc LSquareLoc = consumeToken(tok::l_square);
 
   Parser::StructureMarkerRAII ParsingCollection(
                                 *this, LSquareLoc,

--- a/test/Parse/object_literals.swift
+++ b/test/Parse/object_literals.swift
@@ -1,8 +1,19 @@
 // RUN: %target-typecheck-verify-swift
-// XFAIL: *
-// TODO: Add back diagnostics for legacy object literal
 
-let _ = [##] // expected-error{{expected identifier after '#' in object literal expression}} expected-error{{object literal syntax no longer uses '[# ... #]'}} {{9-10=}} {{11-13=}}
-let _ = [#what#] // expected-error{{object literal syntax no longer uses '[# ... #]'}} {{9-10=}} {{15-17=}}
-let _ = [#what()#] // expected-error{{object literal syntax no longer uses '[# ... #]'}} {{9-10=}} {{17-19=}}
-let _ = [#colorLiteral( // expected-error@+1 {{expected expression in list of expressions}}
+let _ = [#Color(colorLiteralRed: red, green: green, blue: blue, alpha: alpha)#] // expected-error {{'[#Color(...)#]' has been renamed to '#colorLiteral(...)}} {{9-10=}} {{11-16=colorLiteral}} {{17-32=red}} {{78-80=}}
+let _ = [#Image(imageLiteral: localResourceNameAsString)#] // expected-error {{'[#Image(...)#]' has been renamed to '#imageLiteral(...)'}} {{9-10=}} {{11-16=imageLiteral}} {{17-29=resourceName}} {{57-59=}}
+let _ = [#FileReference(fileReferenceLiteral: localResourceNameAsString)#] // expected-error {{'[#FileReference(...)#]' has been renamed to '#fileLiteral(...)'}} {{9-10=}} {{11-24=fileLiteral}} {{25-45=resourceName}} {{73-75=}}
+
+let _ = #Color(colorLiteralRed: red, green: green, blue: blue, alpha: alpha) // expected-error {{'#Color(...)' has been renamed to '#colorLiteral(...)}} {{10-15=colorLiteral}} {{16-31=red}}
+let _ = #Image(imageLiteral: localResourceNameAsString) // expected-error {{'#Image(...)' has been renamed to '#imageLiteral(...)'}} {{10-15=imageLiteral}} {{16-28=resourceName}}
+let _ = #FileReference(fileReferenceLiteral: localResourceNameAsString) // expected-error {{'#FileReference(...)' has been renamed to '#fileLiteral(...)'}} {{10-23=fileLiteral}} {{24-44=resourceName}}
+
+let _ = #notAPound // expected-error {{use of unknown directive '#notAPound'}}
+let _ = #notAPound(1, 2) // expected-error {{use of unknown directive '#notAPound'}}
+let _ = #Color // expected-error {{expected argument list in object literal}} {{none}}
+
+let _ = [##] // expected-error {{expected expression in container literal}} {{none}}
+let _ = [#Color(_: 1, green: 1, 2) // expected-error {{'[#Color(...)#]' has been renamed to '#colorLiteral(...)'}} {{9-10=}} {{11-16=colorLiteral}} {{17-18=red}}
+let _ = [#Color(red: 1, green: 1, blue: 1)# // expected-error {{'[#Color(...)#]' has been renamed to '#colorLiteral(...)'}} {{9-10=}} {{11-16=colorLiteral}} {{17-20=red}} {{43-44=}} 
+let _ = [#Color(withRed: 1, green: 1, whatever: 2)#] // expected-error {{'[#Color(...)#]' has been renamed to '#colorLiteral(...)'}} {{9-10=}} {{11-16=colorLiteral}} {{17-24=red}} {{51-53=}}
+let _ = #Color(_: 1, green: 1) // expected-error {{'#Color(...)' has been renamed to '#colorLiteral(...)'}} {{10-15=colorLiteral}} {{16-17=red}}

--- a/test/Parse/object_literals.swift
+++ b/test/Parse/object_literals.swift
@@ -1,4 +1,6 @@
 // RUN: %target-typecheck-verify-swift
+// XFAIL: *
+// TODO: Add back diagnostics for legacy object literal
 
 let _ = [##] // expected-error{{expected identifier after '#' in object literal expression}} expected-error{{object literal syntax no longer uses '[# ... #]'}} {{9-10=}} {{11-13=}}
 let _ = [#what#] // expected-error{{object literal syntax no longer uses '[# ... #]'}} {{9-10=}} {{15-17=}}

--- a/test/expr/postfix/keypath/keypath-objc.swift
+++ b/test/expr/postfix/keypath/keypath-objc.swift
@@ -112,6 +112,7 @@ func testKeyPath(a: A, b: B) {
 
   let dict: [String: Int] = [:]
   let _: Int? = dict[#keyPath(A.propB)]
+  let _ = [#keyPath(A.propB)]
 }
 
 func testAsStaticString() {

--- a/test/expr/unary/selector/selector.swift
+++ b/test/expr/unary/selector/selector.swift
@@ -86,6 +86,7 @@ func testSelector(_ c1: C1, p1: P1, obj: AnyObject) {
 
   let dict: [Selector: Int] = [:]
   let _: Int? = dict[#selector(c1.method1)]
+  let _ = [#selector(c1.method1)]
 }
 
 func testAmbiguity() {


### PR DESCRIPTION
Removed `l_square_lit`, `r_square_lit`, `pound_Color`, `pound_Image`, and `pound_FileReference` token kinds.

They existed sorely for migration diagnostics for legacy object literals (e.g. `[#Color(colorLiteralRed: red, green: ...)#]`) which was removed in [SE-0039](https://github.com/apple/swift-evolution/blob/master/proposals/0039-playgroundliterals.md). Since we don't want to handle them in `libSyntax`, I removed them from the token kind declarations.

`[#Color#]` is now tokenized as `{l_square, pound, identifier, pound, r_square}`.
I rewrote diagnostics to cope with these tokens. Also, I incidentally implemented diagnostics for general unknown pound expressions (e.g. `#foobar(...)`).

Previously:
```
test.swift:1:10: error: '#Image' has been renamed to '#imageLiteral
let _ = [#Image(imageLiteral: localResourceNameAsString)#]
         ^~~~~~ ~~~~~~~~~~~~
         #imageLiteral resourceName
test.swift:1:9: error: object literal syntax no longer uses '[# ... #]'
let _ = [#Image(imageLiteral: localResourceNameAsString)#]
        ^                                               ~~
                                                        
test.swift:2:9: error: '#Image' has been renamed to '#imageLiteral
let _ = #Image(imageLiteral: localResourceNameAsString)
        ^~~~~~ ~~~~~~~~~~~~
        #imageLiteral resourceName
test.swift:3:9: error: expected initial value after '='
let _ = #Unknown
        ^
test.swift:3:8: error: consecutive statements on a line must be separated by ';'
let _ = #Unknown
       ^
       ;
test.swift:3:9: error: expected expression
let _ = #Unknown
        ^
```
Now:
```
test.swift:1:9: error: '[#Image(...)#]' has been renamed to '#imageLiteral(...)'
let _ = [#Image(imageLiteral: localResourceNameAsString)#]
        ^ ~~~~~ ~~~~~~~~~~~~                            ~~
          imageLiteral resourceName                     
test.swift:2:9: error: '#Image(...)' has been renamed to '#imageLiteral(...)'
let _ = #Image(imageLiteral: localResourceNameAsString)
        ^~~~~~ ~~~~~~~~~~~~
         imageLiteral resourceName
test.swift:3:9: error: use of unknown directive '#Unknown'
let _ = #Unknown
        ^
```