### PR TITLE
[IDE] Fix type reconstructions for PrivateDeclName.

### DIFF
--- a/test/IDE/reconstruct_type_from_mangled_name.swift
+++ b/test/IDE/reconstruct_type_from_mangled_name.swift
@@ -267,8 +267,7 @@ func hasLocalDecls() {
 
 fileprivate struct VeryPrivateData {}
 
-// FIXME
-// CHECK: decl: FAILURE for 'privateFunction'
+// CHECK: decl: fileprivate func privateFunction(_ d: VeryPrivateData) for 'privateFunction'
 fileprivate func privateFunction(_ d: VeryPrivateData) {}
 
 struct HasSubscript {
@@ -305,4 +304,13 @@ struct HasGenericSubscript<T> {
     // CHECK: decl: set {}	for '' usr=s:14swift_ide_test19HasGenericSubscriptVyqd__xcluis
     set {}
   }
+}
+
+private
+// CHECK: decl: private func patatino<T>(_ vers1: T, _ vers2: T) -> Bool where T : Comparable for
+func patatino<T: Comparable>(_ vers1: T, _ vers2: T) -> Bool {
+  // CHECK: decl: FAILURE   for 'T' usr=s:14swift_ide_test8patatino33_D7B956AE2D93947DFA67A1ECF93EF238LLySbx_xts10ComparableRzlF1TL_xmfp decl
+  // CHECK: decl: let vers1: T      for 'vers1' usr=s:14swift_ide_test8patatino33_D7B956AE2D93947DFA67A1ECF93EF238LLySbx_xts10ComparableRzlF5vers1L_xvp
+  // CHECK: decl: let vers2: T      for 'vers2' usr=s:14swift_ide_test8patatino33_D7B956AE2D93947DFA67A1ECF93EF238LLySbx_xts10ComparableRzlF5vers2L_xvp
+  return vers1 < vers2;
 }


### PR DESCRIPTION
Without this fix, the type reconstruction logic chokes on
demangled subtree of the kind:

kind=DeclContext
  kind=Function
    kind=Module, text="swift_ide_test"
    kind=PrivateDeclName
      kind=Identifier, text="_0830B395847924C73A6666B87EFD2ADF"
      kind=Identifier, text="patatino"

Fixes the compiler part of <rdar://problem/38248403>
