### PR TITLE
[Sema] Further revision for SR-6975 

### DIFF
--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1347,15 +1347,12 @@ namespace {
         switch (IP->getCastKind()) {
         case CheckedCastKind::Coercion:
         case CheckedCastKind::BridgingCoercion: {
-          // If the pattern and subpattern types are identical than this is a
-          // non-useful cast that we've already warned about, but it also means
-          // this pattern itself is a no-op and we should examine the subpattern.
           auto *subPattern = IP->getSubPattern();
-          if (subPattern && IP->getType()->isEqual(subPattern->getType()))
+          if (subPattern)
             return projectPattern(TC, subPattern, sawDowngradablePattern);
 
-          // These coercions are irrefutable.  Project with the original type
-          // instead of the cast's target type to maintain consistency with the
+          // With no subpattern coercions are irrefutable.  Project with the original
+          // type instead of the cast's target type to maintain consistency with the
           // scrutinee's type.
           return Space(IP->getType(), Identifier());
         }

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -801,4 +801,13 @@ func sr6975() {
   case .a: // expected-warning {{case is already handled by previous patterns; consider removing it}}
     print("second a")
   }
+
+  func foo(_ str: String) -> Int {
+    switch str { // expected-error {{switch must be exhaustive}}
+    // expected-note@-1 {{do you want to add a default clause?}}
+    case let (x as Int) as Any:
+      return x
+    }
+  }
+  _ = foo("wtf")
 }


### PR DESCRIPTION
After coming back to this and further thought: If we're coercing with no subpattern then we've covered the whole type space of the coercion type (the original code here), but if there is a subpattern, then we're really only covering the subpattern's type space still -- regardless of the coercion type.

Resolves [SR-6975](https://bugs.swift.org/browse/SR-6975).
