### PR TITLE
Make NS_TYPED_ENUMS ObjectiveCBridgeable when they wrap an object

### DIFF
--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -526,6 +526,38 @@ extension _BridgedStoredNSError {
   }
 }
 
+extension _SwiftNewtypeWrapper where Self.RawValue == Error {
+  @_inlineable // FIXME(sil-serialize-all)
+  public func _bridgeToObjectiveC() -> NSError {
+    return rawValue as NSError
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public static func _forceBridgeFromObjectiveC(
+    _ source: NSError,
+    result: inout Self?
+  ) {
+    result = Self(rawValue: source)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ source: NSError,
+    result: inout Self?
+  ) -> Bool {
+    result = Self(rawValue: source)
+    return result != nil
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ source: NSError?
+  ) -> Self {
+    return Self(rawValue: _convertNSErrorToError(source))!
+  }
+}
+
+
 @available(*, unavailable, renamed: "CocoaError")
 public typealias NSCocoaError = CocoaError
 
@@ -3219,6 +3251,7 @@ extension MachError {
 }
 
 public struct ErrorUserInfoKey : RawRepresentable, _SwiftNewtypeWrapper, Equatable, Hashable, _ObjectiveCBridgeable {
+  public typealias _ObjectiveCType = NSString
   public init(rawValue: String) { self.rawValue = rawValue }
   public var rawValue: String
 }

--- a/stdlib/public/core/NewtypeWrapper.swift
+++ b/stdlib/public/core/NewtypeWrapper.swift
@@ -24,6 +24,9 @@ extension _SwiftNewtypeWrapper where Self.RawValue : Hashable {
 
 #if _runtime(_ObjC)
 extension _SwiftNewtypeWrapper where Self.RawValue : _ObjectiveCBridgeable {
+  // Note: This is the only default typealias for _ObjectiveCType, because
+  // constrained extensions aren't allowed to define types in different ways.
+  // Fortunately the others don't need it.
   public typealias _ObjectiveCType = Self.RawValue._ObjectiveCType
 
   @_inlineable // FIXME(sil-serialize-all)
@@ -59,6 +62,37 @@ extension _SwiftNewtypeWrapper where Self.RawValue : _ObjectiveCBridgeable {
   ) -> Self {
     return Self(
       rawValue: Self.RawValue._unconditionallyBridgeFromObjectiveC(source))!
+  }
+}
+
+extension _SwiftNewtypeWrapper where Self.RawValue: AnyObject {
+  @_inlineable // FIXME(sil-serialize-all)
+  public func _bridgeToObjectiveC() -> Self.RawValue {
+    return rawValue
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public static func _forceBridgeFromObjectiveC(
+    _ source: Self.RawValue,
+    result: inout Self?
+  ) {
+    result = Self(rawValue: source)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ source: Self.RawValue,
+    result: inout Self?
+  ) -> Bool {
+    result = Self(rawValue: source)
+    return result != nil
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ source: Self.RawValue?
+  ) -> Self {
+    return Self(rawValue: source!)!
   }
 }
 #endif

--- a/test/ClangImporter/Inputs/custom-modules/Newtype.h
+++ b/test/ClangImporter/Inputs/custom-modules/Newtype.h
@@ -102,3 +102,8 @@ __attribute((swift_name("NSSomeContext.Name")));
 
 extern const NSSomeContextName NSMyContextName;
 
+
+typedef NSError *ErrorNewType __attribute((swift_newtype(struct)));
+
+void testErrorDictionary(NSDictionary<NSError *, NSString *> * _Nonnull);
+void testErrorDictionaryNewtype(NSDictionary<ErrorNewType, NSString *> * _Nonnull);

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -651,6 +651,10 @@ class NewtypeUser {
   @objc func stringNewtypeOptional(a: SNTErrorDomain?) {} // expected-error {{'SNTErrorDomain' has been renamed to 'ErrorDomain'}}{{39-53=ErrorDomain}}
   @objc func intNewtype(a: MyInt) {}
   @objc func intNewtypeOptional(a: MyInt?) {} // expected-error {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  @objc func intNewtypeArray(a: [MyInt]) {} // expected-error {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  @objc func intNewtypeDictionary(a: [MyInt: NSObject]) {} // expected-error {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  @objc func cfNewtype(a: CFNewType) {}
+  @objc func cfNewtypeArray(a: [CFNewType]) {} // expected-error {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
 }
 
 func testTypeAndValue() {
@@ -676,4 +680,14 @@ func testNonTrivialStructs() {
   _ = NonTrivialToCopy() // expected-error {{use of unresolved identifier 'NonTrivialToCopy'}}
   _ = NonTrivialToCopyWrapper() // expected-error {{use of unresolved identifier 'NonTrivialToCopyWrapper'}}
   _ = TrivialToCopy() // okay
+}
+
+func testErrorNewtype() {
+  _ = ErrorNewType(3) // expected-error {{argument type 'Int' does not conform to expected type 'Error'}}
+
+  // Since we import NSError as Error, and Error is not Hashable...we end up
+  // losing the types for these functions, even though the above assignment 
+  // works.
+  testErrorDictionary(3) // expected-error {{cannot convert value of type 'Int' to expected argument type '[AnyHashable : String]'}}
+  testErrorDictionaryNewtype(3) // expected-error {{cannot convert value of type 'Int' to expected argument type '[AnyHashable : String]'}}
 }

--- a/test/IDE/print_omit_needless_words.swift
+++ b/test/IDE/print_omit_needless_words.swift
@@ -46,7 +46,7 @@
 // CHECK-FOUNDATION: func copy(with: NSZone? = nil) -> Any!
 
 // Note: Objective-C type parameter names.
-// CHECK-FOUNDATION: func object(forKey: NSCopying) -> Any?
+// CHECK-FOUNDATION: func object(forKey: Any) -> Any?
 // CHECK-FOUNDATION: func removeObject(forKey: NSCopying)
 
 // Note: Don't drop the name of the first parameter in an initializer entirely.

--- a/test/Inputs/clang-importer-sdk/swift-modules-without-ns/Foundation.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules-without-ns/Foundation.swift
@@ -184,3 +184,34 @@ public func _convertErrorToNSError(_ error: Error) -> NSError {
   return error as NSError
 }
 
+extension _SwiftNewtypeWrapper where Self.RawValue == Error {
+  @_inlineable // FIXME(sil-serialize-all)
+  public func _bridgeToObjectiveC() -> NSError {
+    return rawValue as NSError
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public static func _forceBridgeFromObjectiveC(
+    _ source: NSError,
+    result: inout Self?
+  ) {
+    result = Self(rawValue: source)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ source: NSError,
+    result: inout Self?
+  ) -> Bool {
+    result = Self(rawValue: source)
+    return result != nil
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ source: NSError?
+  ) -> Self {
+    return Self(rawValue: _convertNSErrorToError(source))!
+  }
+}
+

--- a/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
+++ b/test/Inputs/clang-importer-sdk/swift-modules/Foundation.swift
@@ -245,6 +245,38 @@ public func _convertErrorToNSError(_ x: Error) -> NSError {
   return x as NSError
 }
 
+extension _SwiftNewtypeWrapper where Self.RawValue == Error {
+  @_inlineable // FIXME(sil-serialize-all)
+  public func _bridgeToObjectiveC() -> NSError {
+    return rawValue as NSError
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public static func _forceBridgeFromObjectiveC(
+    _ source: NSError,
+    result: inout Self?
+  ) {
+    result = Self(rawValue: source)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public static func _conditionallyBridgeFromObjectiveC(
+    _ source: NSError,
+    result: inout Self?
+  ) -> Bool {
+    result = Self(rawValue: source)
+    return result != nil
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public static func _unconditionallyBridgeFromObjectiveC(
+    _ source: NSError?
+  ) -> Self {
+    return Self(rawValue: _convertNSErrorToError(source))!
+  }
+}
+
+
 
 extension NSArray {
   @objc(methodIntroducedInOverlay) public func introducedInOverlay() { }

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -150,7 +150,7 @@ __attribute__((availability(ios,introduced=8.0)))
 - (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface NSDictionary<KeyType : id<NSCopying>, ObjectType> : NSObject /*<NSCopying, NSMutableCopying, NSSecureCoding, NSFastEnumeration>*/
+@interface NSDictionary<KeyType, ObjectType> : NSObject /*<NSCopying, NSMutableCopying, NSSecureCoding, NSFastEnumeration>*/
 @property (readonly) NSUInteger count;
 - (nullable ObjectType)objectForKey:(nonnull KeyType)aKey;
 - (nonnull NSEnumerator *)keyEnumerator;

--- a/test/Interpreter/SDK/Inputs/objc_bridge_cast_newtype.h
+++ b/test/Interpreter/SDK/Inputs/objc_bridge_cast_newtype.h
@@ -1,0 +1,80 @@
+@import Foundation;
+
+#define GET_UNTYPED_AND_OPAQUE(Name) \
+  static NSArray * _Nonnull getUntypedNSArrayOf##Name##s() { \
+    return getTypedNSArrayOf##Name##Wrappers(); \
+  } \
+  static id _Nonnull getOpaqueNSArrayOf##Name##s() { \
+    return getTypedNSArrayOf##Name##Wrappers(); \
+  }
+#define CHECK_UNTYPED_AND_OPAQUE(Name) \
+  static BOOL checkUntypedNSArrayOf##Name##s(NSArray * _Nonnull array) { \
+    return checkTypedNSArrayOf##Name##Wrappers(array); \
+  } \
+  static BOOL checkOpaqueNSArrayOf##Name##s(id _Nonnull array) { \
+    return checkTypedNSArrayOf##Name##Wrappers(array); \
+  }
+
+typedef NSString *StringWrapper NS_TYPED_EXTENSIBLE_ENUM;
+static NSArray<StringWrapper> * _Nonnull getTypedNSArrayOfStringWrappers() {
+  return @[@"abc", @"def"];
+}
+static BOOL
+checkTypedNSArrayOfStringWrappers(NSArray<StringWrapper> * _Nonnull array) {
+  return [array isEqual:getTypedNSArrayOfStringWrappers()];
+}
+GET_UNTYPED_AND_OPAQUE(String)
+CHECK_UNTYPED_AND_OPAQUE(String)
+
+
+typedef id <NSCopying, NSCoding> CopyingAndCodingWrapper
+    NS_TYPED_EXTENSIBLE_ENUM;
+static NSArray<CopyingAndCodingWrapper> * _Nonnull
+getTypedNSArrayOfCopyingAndCodingWrappers() {
+  return @[@"abc", @[]];
+}
+static BOOL checkTypedNSArrayOfCopyingAndCodingWrappers(
+    NSArray<CopyingAndCodingWrapper> * _Nonnull array) {
+  return [array isEqual:getTypedNSArrayOfCopyingAndCodingWrappers()];
+}
+GET_UNTYPED_AND_OPAQUE(CopyingAndCoding)
+CHECK_UNTYPED_AND_OPAQUE(CopyingAndCoding)
+
+typedef id <NSCopying> CopyingWrapper NS_TYPED_EXTENSIBLE_ENUM;
+static NSArray<CopyingWrapper> * _Nonnull getTypedNSArrayOfCopyingWrappers() {
+  return getTypedNSArrayOfCopyingAndCodingWrappers();
+}
+static BOOL
+checkTypedNSArrayOfCopyingWrappers(NSArray<CopyingWrapper> * _Nonnull array) {
+  return [array isEqual:getTypedNSArrayOfCopyingWrappers()];
+}
+GET_UNTYPED_AND_OPAQUE(Copying)
+CHECK_UNTYPED_AND_OPAQUE(Copying)
+
+typedef NSObject *ObjectWrapper NS_TYPED_EXTENSIBLE_ENUM;
+static NSArray<ObjectWrapper> * _Nonnull getTypedNSArrayOfObjectWrappers() {
+  return (NSArray<ObjectWrapper> *)getTypedNSArrayOfCopyingAndCodingWrappers();
+}
+static BOOL
+checkTypedNSArrayOfObjectWrappers(NSArray<ObjectWrapper> * _Nonnull array) {
+  return [array isEqual:getTypedNSArrayOfObjectWrappers()];
+}
+GET_UNTYPED_AND_OPAQUE(Object)
+CHECK_UNTYPED_AND_OPAQUE(Object)
+
+typedef NSError *ErrorWrapper NS_TYPED_EXTENSIBLE_ENUM;
+static NSArray<ErrorWrapper> * _Nonnull getTypedNSArrayOfErrorWrappers() {
+  return @[[NSError errorWithDomain:@"x" code:11 userInfo:nil],
+           [NSError errorWithDomain:@"x" code:22 userInfo:nil]];
+}
+static BOOL
+checkTypedNSArrayOfErrorWrappers(NSArray<ErrorWrapper> * _Nonnull array) {
+  return [[array valueForKey:@"code"] isEqual:@[@11, @22]] &&
+         NSNotFound == [array indexOfObjectPassingTest:^BOOL(ErrorWrapper error,
+                                                             NSUInteger idx,
+                                                             BOOL *stop) {
+    return ![error isKindOfClass:[NSError class]];
+  }];
+}
+GET_UNTYPED_AND_OPAQUE(Error)
+CHECK_UNTYPED_AND_OPAQUE(Error)

--- a/test/Interpreter/SDK/objc_bridge_cast_newtype.swift
+++ b/test/Interpreter/SDK/objc_bridge_cast_newtype.swift
@@ -1,0 +1,110 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -o %t/main -import-objc-header %S/Inputs/objc_bridge_cast_newtype.h
+// RUN: %target-run %t/main
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+// Test dynamic casts that bridge value types through the runtime.
+
+import Foundation
+import StdlibUnittest
+
+var importSuite = TestSuite("objc_bridge_cast_newtype.import")
+var exportSuite = TestSuite("objc_bridge_cast_newtype.export")
+
+importSuite.test("NSArrayToArrayOfStringWrappers") {
+  expectEqual(["abc", "def"],
+              (getUntypedNSArrayOfStrings() as? [StringWrapper])?.map { $0.rawValue })
+  expectEqual(["abc", "def"],
+              (getOpaqueNSArrayOfStrings() as? [StringWrapper])?.map { $0.rawValue })
+
+  expectEqual(["abc", "def"],
+              getTypedNSArrayOfStringWrappers().map { $0.rawValue })
+
+  expectEqual(["abc", "def"], getTypedNSArrayOfStringWrappers() as [NSString])
+}
+
+importSuite.test("NSArrayToArrayOfCopyingWrappers") {
+  expectEqual(["abc" as NSString, [] as NSArray],
+              (getUntypedNSArrayOfCopyings() as? [CopyingWrapper])?.map { $0.rawValue } as! [NSObject]?)
+  expectEqual(["abc" as NSString, [] as NSArray],
+              (getOpaqueNSArrayOfCopyings() as? [CopyingWrapper])?.map { $0.rawValue } as! [NSObject]?)
+
+  expectEqual(["abc" as NSString, [] as NSArray],
+              getTypedNSArrayOfCopyingWrappers().map { $0.rawValue } as! [NSObject])
+}
+
+importSuite.test("NSArrayToArrayOfCopyingAndCodingWrappers") {
+  expectEqual(["abc" as NSString, [] as NSArray],
+              (getUntypedNSArrayOfCopyingAndCodings() as? [CopyingAndCodingWrapper])?.map { $0.rawValue } as! [NSObject]?)
+  expectEqual(["abc" as NSString, [] as NSArray],
+              (getOpaqueNSArrayOfCopyingAndCodings() as? [CopyingAndCodingWrapper])?.map { $0.rawValue } as! [NSObject]?)
+
+  expectEqual(["abc" as NSString, [] as NSArray],
+              getTypedNSArrayOfCopyingAndCodingWrappers().map { $0.rawValue } as! [NSObject])
+}
+
+importSuite.test("NSArrayToArrayOfObjectWrappers") {
+  expectEqual(["abc" as NSString, [] as NSArray],
+              (getUntypedNSArrayOfObjects() as? [ObjectWrapper])?.map { $0.rawValue })
+  expectEqual(["abc" as NSString, [] as NSArray],
+              (getOpaqueNSArrayOfObjects() as? [ObjectWrapper])?.map { $0.rawValue })
+
+  expectEqual(["abc" as NSString, [] as NSArray],
+              getTypedNSArrayOfObjectWrappers().map { $0.rawValue })
+}
+
+importSuite.test("NSArrayToArrayOfErrorWrappers") {
+  expectEqual([11, 22],
+              (getUntypedNSArrayOfErrors() as? [ErrorWrapper])?.map { $0.rawValue._code })
+  expectEqual([11, 22],
+              (getOpaqueNSArrayOfErrors() as? [ErrorWrapper])?.map { $0.rawValue._code })
+
+  expectEqual([11, 22],
+              getTypedNSArrayOfErrorWrappers().map { $0.rawValue._code })
+}
+
+exportSuite.test("ArrayOfStringWrappersToNSArray") {
+  let array = [StringWrapper("abc"), StringWrapper("def")]
+  expectTrue(checkUntypedNSArrayOfStrings(array))
+  expectTrue(checkOpaqueNSArrayOfStrings(array))
+  expectTrue(checkTypedNSArrayOfStringWrappers(array))
+}
+
+exportSuite.test("ArrayOfCopyingAndCodingWrappersToNSArray") {
+  let array = [CopyingAndCodingWrapper("abc" as NSString),
+               CopyingAndCodingWrapper([] as NSArray)]
+  expectTrue(checkUntypedNSArrayOfCopyingAndCodings(array))
+  expectTrue(checkOpaqueNSArrayOfCopyingAndCodings(array))
+  expectTrue(checkTypedNSArrayOfCopyingAndCodingWrappers(array))
+}
+
+exportSuite.test("ArrayOfCopyingWrappersToNSArray") {
+  let array = [CopyingWrapper("abc" as NSString), CopyingWrapper([] as NSArray)]
+  expectTrue(checkUntypedNSArrayOfCopyings(array))
+  expectTrue(checkOpaqueNSArrayOfCopyings(array))
+  expectTrue(checkTypedNSArrayOfCopyingWrappers(array))
+}
+
+exportSuite.test("ArrayOfObjectWrappersToNSArray") {
+  let array = [ObjectWrapper("abc" as NSString), ObjectWrapper([] as NSArray)]
+  expectTrue(checkUntypedNSArrayOfObjects(array))
+  expectTrue(checkOpaqueNSArrayOfObjects(array))
+  expectTrue(checkTypedNSArrayOfObjectWrappers(array))
+}
+
+enum CustomError: Int, Error {
+  case twentyTwo = 22
+}
+
+exportSuite.test("ArrayOfErrorWrappersToNSArray") {
+  let array = [ErrorWrapper(NSError(domain: "Swift", code: 11, userInfo: nil)),
+               ErrorWrapper(CustomError.twentyTwo)]
+  expectTrue(checkUntypedNSArrayOfErrors(array))
+  expectTrue(checkOpaqueNSArrayOfErrors(array))
+  expectTrue(checkTypedNSArrayOfErrorWrappers(array))
+}
+
+
+runAllTests()

--- a/test/PrintAsObjC/Inputs/newtype.h
+++ b/test/PrintAsObjC/Inputs/newtype.h
@@ -3,3 +3,6 @@
 
 typedef NSString *StructLikeStringWrapper __attribute__((swift_newtype(struct)));
 typedef NSString *EnumLikeStringWrapper __attribute__((swift_newtype(enum)));
+
+typedef NSObject *StructLikeObjectWrapper __attribute__((swift_newtype(struct)));
+typedef NSError *StructLikeErrorWrapper __attribute__((swift_newtype(struct)));

--- a/test/PrintAsObjC/newtype.swift
+++ b/test/PrintAsObjC/newtype.swift
@@ -43,6 +43,12 @@ class TestStructLike : NSObject {
   @objc func takesNewtypeDictionary(_ a: [StructLikeStringWrapper: StructLikeStringWrapper]) {}
   // CHECK: - (void)takesNewtypeOptional:(StructLikeStringWrapper _Nullable)a;
   @objc func takesNewtypeOptional(_ a: StructLikeStringWrapper?) {}
+
+  // CHECK: - (void)takesNewtypeObjectDictionary:(NSDictionary<StructLikeObjectWrapper, StructLikeObjectWrapper> * _Nonnull)a;
+  @objc func takesNewtypeObjectDictionary(_ a: [StructLikeObjectWrapper: StructLikeObjectWrapper]) {}
+
+  // CHECK: - (void)takesNewtypeErrorArray:(NSArray<StructLikeErrorWrapper> * _Nonnull)a;
+  @objc func takesNewtypeErrorArray(_ a: [StructLikeErrorWrapper]) {}
 }
 // CHECK: @end
 

--- a/validation-test/IRGen/Inputs/sr6844.h
+++ b/validation-test/IRGen/Inputs/sr6844.h
@@ -1,0 +1,12 @@
+@import Foundation;
+
+typedef NSObject *MyJSONKeyPath __attribute__((swift_wrapper(struct)));
+
+@protocol MyJSONSerializing <NSObject>
+@property (copy, readonly, nullable) NSDictionary<NSString *, MyJSONKeyPath> *JSONKeyPathsByPropertyKey NS_SWIFT_NAME(JSONKeyPathsByPropertyKey);
+@end
+
+@interface MyJSONAdapter : NSObject
+- (nonnull instancetype)init;
+- (nonnull __kindof id<MyJSONSerializing>)model NS_REFINED_FOR_SWIFT;
+@end

--- a/validation-test/IRGen/sr6844.swift
+++ b/validation-test/IRGen/sr6844.swift
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -emit-ir %s -import-objc-header %S/Inputs/sr6844.h | %FileCheck %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+// CHECK-LABEL: @_PROTOCOL_INSTANCE_METHODS_MyJSONSerializing = {{.+}} @"\01L_selector_data(JSONKeyPathsByPropertyKey)"
+// CHECK: [[OBJC_PROPNAME:@.+]] = private unnamed_addr constant [{{.+}} x i8] c"JSONKeyPathsByPropertyKey\00"
+// CHECK: [[PROPKIND:@.+]] = private unnamed_addr constant [{{.+}} x i8] c"T@\22NSDictionary\22,N,R\00"
+// CHECK: @_PROTOCOL_PROPERTIES_MyJSONSerializing =
+// CHECK-SAME: [[OBJC_PROPNAME]]
+// CHECK-SAME: [[PROPKIND]]
+
+// CHECK-LABEL: @_PROTOCOL_INSTANCE_METHODS__TtP6sr684418MyJSONSerializing2_ = {{.+}} @"\01L_selector_data(JSONKeyPathsByPropertyKey2)"
+// CHECK: [[SWIFT_PROPNAME:@.+]] = private unnamed_addr constant [{{.+}} x i8] c"JSONKeyPathsByPropertyKey2\00"
+// CHECK: @_PROTOCOL_PROPERTIES__TtP6sr684418MyJSONSerializing2_ =
+// CHECK-SAME: [[SWIFT_PROPNAME]]
+// CHECK-SAME: [[PROPKIND]]
+
+@objc public protocol MyJSONSerializing2 {
+  var JSONKeyPathsByPropertyKey2: [String: MyJSONKeyPath]? { get }
+}
+
+extension MyJSONAdapter {
+  public func model<Model: MyJSONSerializing>(of _: Model.Type = Model.self) throws -> Model {
+    return __model() as! Model
+  }
+  public func model<Model: MyJSONSerializing2>(of _: Model.Type = Model.self) throws -> Model {
+    return __model() as! Model
+  }
+}


### PR DESCRIPTION
This allows them to be used in generic arguments for NSArray et al. We already do this for the ones that wrap bridged values (like NSString/String), but failed to do it for objects that *weren't* bridged to Swift values (class instances and protocol compositions), or for Error-which-is-special.

In addition to this being a sensible thing to do, *not* doing this led to IRGen getting very confused (i.e. crashing) when we imported a Objective-C protocol that actually used an NS_TYPED_ENUM in this way.

(We actually shouldn't be using Swift's IRGen logic to emit protocol descriptors for imported protocols at all, because it's possible we weren't able to import all the requirements. But that's a separate issue.)

[SR-6844](https://bugs.swift.org/browse/SR-6844) / rdar://problem/36911791, possibly others