### PR TITLE
[4.1] IRGen: The type layout of a metatype is not the same as the NativeObject.Type

### DIFF
--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -1902,6 +1902,10 @@ namespace {
         return emitFromValueWitnessTable(IGF.IGM.Context.TheEmptyTupleType);
       }
       case MetatypeRepresentation::Thick:
+        if (isa<ExistentialMetatypeType>(type)) {
+          return emitFromTypeMetadata(type);
+        }
+        // Otherwise, this is a metatype that looks like a pointer.
       case MetatypeRepresentation::ObjC:
         // Thick metatypes look like pointers with spare bits.
         return emitFromValueWitnessTable(

--- a/test/IRGen/type_layout_reference_storage.swift
+++ b/test/IRGen/type_layout_reference_storage.swift
@@ -91,3 +91,20 @@ struct ReferenceStorageTypeLayout<T, Native : C, Unknown : AnyObject> {
   // CHECK: store i8** getelementptr inbounds (i8*, i8** @_T0[[UNKNOWN]]SgXwWV, i32 9)
   weak            var uwi: Unknown!
 }
+
+
+public class Base {
+   var a: UInt32 = 0
+}
+// CHECK-LABEL: %swift.type* @{{.*}}7DerivedCMi"(%swift.type_descriptor*, i8**)
+// CHECK-NOT: store {{.*}}getelementptr{{.*}}SBomWV
+// CHECK: call %swift.type* @"$S29type_layout_reference_storage1P_pXmTMa"()
+// CHECK: store {{.*}}getelementptr{{.*}}SBoWV
+// CHECK: ret
+public class Derived<T> : Base {
+  var type : P.Type
+  var k = C()
+  init(_ t: P.Type) {
+    type = t
+  }
+}

--- a/test/IRGen/type_layout_reference_storage.swift
+++ b/test/IRGen/type_layout_reference_storage.swift
@@ -96,10 +96,11 @@ struct ReferenceStorageTypeLayout<T, Native : C, Unknown : AnyObject> {
 public class Base {
    var a: UInt32 = 0
 }
-// CHECK-LABEL: %swift.type* @{{.*}}7DerivedCMi"(%swift.type_descriptor*, i8**)
-// CHECK-NOT: store {{.*}}getelementptr{{.*}}SBomWV
-// CHECK: call %swift.type* @"$S29type_layout_reference_storage1P_pXmTMa"()
-// CHECK: store {{.*}}getelementptr{{.*}}SBoWV
+
+// CHECK-LABEL: %swift.type* @create_generic_metadata_Derived(%swift.type_pattern*, i8**)
+// CHECK-NOT: store {{.*}}getelementptr{{.*}}T0BomWV
+// CHECK: call %swift.type* @{{.*}}type_layout_reference_storage1P_pXmTMa()
+// CHECK: store {{.*}}getelementptr{{.*}}T0BoWV
 // CHECK: ret
 public class Derived<T> : Base {
   var type : P.Type

--- a/test/Interpreter/metatype.swift
+++ b/test/Interpreter/metatype.swift
@@ -1,0 +1,29 @@
+// RUN: %target-run-simple-swift | %FileCheck %s
+// REQUIRES: executable_test
+
+protocol Bar : class {
+}
+
+public class Foo : Bar {
+}
+
+public class Base {
+   final fileprivate(set) var a: UInt32 = 0
+}
+
+public class Derived<T> : Base {
+  final var type : Bar.Type
+  final var k = Foo()
+
+  init(_ t: Bar.Type, _ kl: Foo ) {
+    type = t
+    k = kl
+  }
+}
+
+public func dontCrash() {
+  // CHECK: Derived<Swift.Int>
+  print(Derived<Int>(Foo.self, Foo()))
+}
+
+dontCrash()


### PR DESCRIPTION
* Description: Generic classes with protocol meta type stored properties crash during initialization because we ignored the second word of storage of existential meta types.

* Scope: This regression was introduced because we more often initialize generic class metadata which exercises the code path the causes the crash.

* Testing: CI test added.

* Risk: Low

* Reviewed: Joe G.

rdar://37924505