### PR TITLE
[4.1] [SR-7182] Allow ownership keywords on properties in @objc protocols.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2091,8 +2091,10 @@ void TypeChecker::checkOwnershipAttr(VarDecl *var, OwnershipAttr *attr) {
 
     diagnose(var->getStartLoc(), D, (unsigned) ownershipKind, underlyingType);
     attr->setInvalid();
-  } else if (dyn_cast<ProtocolDecl>(var->getDeclContext())) {
-    // Ownership does not make sense in protocols.
+  } else if (isa<ProtocolDecl>(var->getDeclContext()) &&
+             !cast<ProtocolDecl>(var->getDeclContext())->isObjC()) {
+    // Ownership does not make sense in protocols, except for "weak" on
+    // properties of Objective-C protocols.
     if (Context.isSwiftVersionAtLeast(5))
       diagnose(attr->getLocation(),
         diag::ownership_invalid_in_protocols,

--- a/test/PrintAsObjC/protocols.swift
+++ b/test/PrintAsObjC/protocols.swift
@@ -190,5 +190,17 @@ extension NSString : A, ZZZ {}
 // CHECK-LABEL: @interface Subclass : RootClass1 <ZZZ>{{$}}
 @objc class Subclass : RootClass1, ZZZ {}
 
+// CHECK-LABEL: @protocol UnownedProperty
+// CHECK-NEXT: @property (nonatomic, assign) id _Nonnull unownedProp;
+@objc protocol UnownedProperty {
+  unowned var unownedProp: AnyObject { get set }
+}
+
+// CHECK-LABEL: @protocol WeakProperty
+// CHECK-NEXT: @property (nonatomic, weak) id _Nullable weakProp;
+@objc protocol WeakProperty {
+  weak var weakProp: AnyObject? { get set }
+}
+
 // Deliberately at the end of the file.
 @objc protocol ZZZ {}

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2294,3 +2294,13 @@ class BadClass {
   @_versioned @objc dynamic func badMethod2() {}
   // expected-error@-1 {{'@_versioned' attribute cannot be applied to 'dynamic' declarations}}
 }
+
+@objc
+protocol ObjCProtocolWithWeakProperty {
+   weak var weakProp: AnyObject? { get set } // okay
+}
+
+@objc
+protocol ObjCProtocolWithUnownedProperty {
+   unowned var unownedProp: AnyObject { get set } // okay
+}


### PR DESCRIPTION
**Explanation:** [SE-0186](https://github.com/apple/swift-evolution/blob/master/proposals/0186-remove-ownership-keyword-support-in-protocols.md) removed support for ownership keywords (`weak` and `unowned`) on properties in protocols. However, these keywords do have meaning for `@objc` protocols, where they affect the `@property` declaration that is created in the generated header. Allow these keywords (again) on properties of `@objc` protocols.
**Scope:** Affects projects that define `@objc` protocols with `weak` or `unowned` properties, which were accepted in Swift < 4.1 and started getting warnings in Swift 4.2.
**Risk:** Effectively none; we're re-enabling something we've had since Swift 1.0 and that was recently disabled.
**Testing:** Compiler regression tests, including new tests
**Reviewer:** @jrose-apple 
**SR / Radar:** [SR-7182](https://bugs.swift.org/browse/SR-7182) / rdar://problem/38418112.