### PR TITLE
[lldb-moduleimport-test] Add a way to test getTypeFromMangledSymbolName.

### DIFF
--- a/test/DebugInfo/ASTSection.swift
+++ b/test/DebugInfo/ASTSection.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-build-swift -emit-executable %s -g -o %t/ASTSection -emit-module
-// RUN: %lldb-moduleimport-test %t/ASTSection | %FileCheck %s
+// RUN: %lldb-moduleimport-test -verbose %t/ASTSection | %FileCheck %s
 
 // REQUIRES: executable_test
 

--- a/test/DebugInfo/ASTSection_ObjC.swift
+++ b/test/DebugInfo/ASTSection_ObjC.swift
@@ -2,13 +2,13 @@
 
 // RUN: cp %S/Inputs/serialized-objc-header.h %t
 // RUN: %target-build-swift -emit-executable %S/ASTSection.swift -g -o %t/ASTSection-with-ObjC -import-objc-header %t/serialized-objc-header.h -DOBJC -module-name ASTSection -emit-module
-// RUN: %lldb-moduleimport-test %t/ASTSection-with-ObjC | %FileCheck %s
+// RUN: %lldb-moduleimport-test -verbose %t/ASTSection-with-ObjC | %FileCheck %s
 
 // RUN: rm %t/serialized-objc-header.h
-// RUN: %lldb-moduleimport-test %t/ASTSection-with-ObjC | %FileCheck %s
+// RUN: %lldb-moduleimport-test -verbose %t/ASTSection-with-ObjC | %FileCheck %s
 
 // RUN: %target-build-swift -emit-executable %S/ASTSection.swift -gline-tables-only -o %t/ASTSection -emit-module
-// RUN: %lldb-moduleimport-test %t/ASTSection | %FileCheck %s --allow-empty --check-prefix=LINETABLE-CHECK
+// RUN: %lldb-moduleimport-test -verbose %t/ASTSection | %FileCheck %s --allow-empty --check-prefix=LINETABLE-CHECK
 
 // REQUIRES: executable_test
 // REQUIRES: objc_interop

--- a/test/DebugInfo/ASTSection_linker.swift
+++ b/test/DebugInfo/ASTSection_linker.swift
@@ -7,11 +7,11 @@
 
 // Test the inline section mechanism.
 // RUN: %target-ld %t/ASTSection.o -sectcreate __SWIFT __ast %t/ASTSection.swiftmodule -o %t/ASTSection.dylib -dylib -lSystem -lobjc
-// RUN: %lldb-moduleimport-test %t/ASTSection.dylib | %FileCheck %s
+// RUN: %lldb-moduleimport-test -verbose %t/ASTSection.dylib | %FileCheck %s
 
 // Test the symbol table entry.
 // RUN: %target-ld %t/ASTSection.o -add_ast_path %t/ASTSection.swiftmodule -o %t/ASTSection.dylib -dylib -lSystem -lobjc
-// RUN: %lldb-moduleimport-test %t/ASTSection.dylib | %FileCheck %s
+// RUN: %lldb-moduleimport-test -verbose %t/ASTSection.dylib | %FileCheck %s
 
 // REQUIRES: OS=macosx
 

--- a/test/DebugInfo/DumpTypeFromMangledName.swift
+++ b/test/DebugInfo/DumpTypeFromMangledName.swift
@@ -1,0 +1,17 @@
+// RUN: %empty-directory(%t)
+
+// %t.input: "A ---> B" ==> "A"
+// RUN: sed -ne '/--->/s/ *--->.*$//p' < %S/Inputs/type-reconstr-names.txt > %t.input
+
+// %t.check: "A ---> B" ==> "B"
+// RUN: sed -ne '/--->/s/^.*---> *//p' < %S/Inputs/type-reconstr-names.txt > %t.check
+
+// RUN: %target-build-swift -emit-executable %s -g -o %t/TypeReconstr -emit-module
+// RUN: %lldb-moduleimport-test %t/TypeReconstr \
+// RUN:   -type-from-mangled=%t.input > %t.output 2>&1
+// RUN: diff %t.check %t.output
+
+// REQUIRES: executable_test
+func main() {
+  struct Patatino {}
+}

--- a/test/DebugInfo/Inputs/type-reconstr-names.txt
+++ b/test/DebugInfo/Inputs/type-reconstr-names.txt
@@ -1,0 +1,4 @@
+$S4blah4mainyyF ---> () -> ()
+$SytD ---> ()
+$Ss5Int32VD ---> Int32
+$S4blah4mainyyF8PatatinoL_VMa ---> Can't resolve type of $S4blah4mainyyF8PatatinoL_VMa


### PR DESCRIPTION
The only way we had to test this path was through swift-ide-test,
which takes an input a source file, instead of a serialized module.

This is not the scenario that lldb tests, hence this patch.

<rdar://problem/38323564>

