### PR TITLE
[test] Update hash avalanche test

### DIFF
--- a/validation-test/stdlib/HashingAvalanche.swift
+++ b/validation-test/stdlib/HashingAvalanche.swift
@@ -8,35 +8,34 @@ import StdlibUnittest
 
 var HashingTestSuite = TestSuite("Hashing")
 
-func avalancheTest(
-  _ bits: Int,
-  _ hashUnderTest: @escaping (UInt64) -> UInt64,
+func avalancheTest<Input: FixedWidthInteger & UnsignedInteger>(
+  for type: Input.Type,
+  _ hashUnderTest: @escaping (Input) -> Int,
   _ pValue: Double
 ) {
+  typealias Output = Int
   let testsInBatch = 100000
-  let testData = randArray64(testsInBatch)
-  let testDataHashed = Array(testData.lazy.map { hashUnderTest($0) })
+  let testData = randArray64(testsInBatch).map { Input(truncatingIfNeeded: $0) }
+  let testDataHashed = testData.map { hashUnderTest($0) }
 
-  for inputBit in 0..<bits {
+  for inputBit in 0..<Input.bitWidth {
     // Using an array here makes the test too slow.
-    var bitFlips = UnsafeMutablePointer<Int>.allocate(capacity: bits)
-    for i in 0..<bits {
-      bitFlips[i] = 0
-    }
+    let bitFlips = UnsafeMutablePointer<Int>.allocate(capacity: Output.bitWidth)
+    bitFlips.initialize(to: 0, count: Output.bitWidth)
     for i in testData.indices {
       let inputA = testData[i]
       let outputA = testDataHashed[i]
       let inputB = inputA ^ (1 << UInt64(inputBit))
       let outputB = hashUnderTest(inputB)
       var delta = outputA ^ outputB
-      for outputBit in 0..<bits {
+      for outputBit in 0..<Output.bitWidth {
         if delta & 1 == 1 {
           bitFlips[outputBit] += 1
         }
         delta = delta >> 1
       }
     }
-    for outputBit in 0..<bits {
+    for outputBit in 0..<Output.bitWidth {
       expectTrue(
         chiSquaredUniform2(testsInBatch, bitFlips[outputBit], pValue),
         "inputBit: \(inputBit), outputBit: \(outputBit)")
@@ -48,11 +47,11 @@ func avalancheTest(
 // White-box testing: assume that the other N-bit to N-bit mixing functions
 // just dispatch to these.  (Avalanche test is relatively expensive.)
 HashingTestSuite.test("_Hasher.append(UInt64)/avalanche") {
-  avalancheTest(64, { UInt64(truncatingIfNeeded: _hashValue(for: $0)) }, 0.02)
+  avalancheTest(for: UInt64.self, _hashValue(for:), 0.02)
 }
 
 HashingTestSuite.test("_Hasher.append(UInt32)/avalanche") {
-  avalancheTest(32, { UInt64(truncatingIfNeeded: _hashValue(for: $0)) }, 0.02)
+  avalancheTest(for: UInt32.self, _hashValue(for:), 0.02)
 }
 
 runAllTests()


### PR DESCRIPTION
Differentiate between 32-bit and 64-bit inputs. Previously the test was always feeding 64-bit integers to the hasher.
