### PR TITLE
SwiftSyntax: allow any Syntax nodes to access their leading/trailing trivia.

### DIFF
--- a/test/SwiftSyntax/AbsolutePosition.swift
+++ b/test/SwiftSyntax/AbsolutePosition.swift
@@ -101,4 +101,31 @@ PositionTests.test("Recursion") {
   })
 }
 
+PositionTests.test("Trivias") {
+  expectDoesNotThrow({
+    var l = [CodeBlockItemSyntax]()
+    let leading = Trivia.newlines(1).appending(TriviaPiece.backticks(1))
+      .appending(TriviaPiece.docLineComment("/// some comment"))
+    let trailing = Trivia.docLineComment("/// This is comment\n")
+    let idx = 5
+    for _ in 0...idx {
+      l.append(SyntaxFactory.makeCodeBlockItem(
+        item: SyntaxFactory.makeReturnStmt(
+          returnKeyword: SyntaxFactory.makeToken(.returnKeyword, presence: .present)
+            .withTrailingTrivia(trailing).withLeadingTrivia(leading)
+            , expression: nil), semicolon: nil))
+    }
+    let root = SyntaxFactory.makeSourceFile(
+      statements: SyntaxFactory.makeCodeBlockItemList(l),
+      eofToken: SyntaxFactory.makeToken(.eof, presence: .present))
+    expectEqual(root.leadingTrivia!.count, 3)
+    expectEqual(root.trailingTrivia!.count, 0)
+    let state = root.statements[idx]
+    expectEqual(state.leadingTrivia!.count, 3)
+    expectEqual(state.trailingTrivia!.count, 1)
+    expectEqual(state.leadingTrivia!.byteSize + state.trailingTrivia!.byteSize
+      + state.byteSizeAfterTrimmingTrivia, state.byteSize)
+  })
+}
+
 runAllTests()

--- a/test/SwiftSyntax/AbsolutePosition.swift
+++ b/test/SwiftSyntax/AbsolutePosition.swift
@@ -103,21 +103,25 @@ PositionTests.test("Recursion") {
 
 PositionTests.test("Trivias") {
   expectDoesNotThrow({
-    var l = [CodeBlockItemSyntax]()
-    let leading = Trivia.newlines(1).appending(TriviaPiece.backticks(1))
-      .appending(TriviaPiece.docLineComment("/// some comment"))
+    let leading = Trivia(pieces: [
+      .newlines(1),
+      .backticks(1),
+      .docLineComment("/// some comment")
+      ])
     let trailing = Trivia.docLineComment("/// This is comment\n")
     let idx = 5
-    for _ in 0...idx {
-      l.append(SyntaxFactory.makeCodeBlockItem(
-        item: SyntaxFactory.makeReturnStmt(
-          returnKeyword: SyntaxFactory.makeToken(.returnKeyword, presence: .present)
-            .withTrailingTrivia(trailing).withLeadingTrivia(leading)
-            , expression: nil), semicolon: nil))
-    }
+    let items : [CodeBlockItemSyntax] =
+      [CodeBlockItemSyntax](repeating: CodeBlockItemSyntax {
+        $0.useItem(ReturnStmtSyntax {
+          $0.useReturnKeyword(
+            SyntaxFactory.makeReturnKeyword(
+              leadingTrivia: leading,
+              trailingTrivia: trailing))
+        })}, count: idx + 1)
     let root = SyntaxFactory.makeSourceFile(
-      statements: SyntaxFactory.makeCodeBlockItemList(l),
+      statements: SyntaxFactory.makeCodeBlockItemList(items),
       eofToken: SyntaxFactory.makeToken(.eof, presence: .present))
+
     expectEqual(root.leadingTrivia!.count, 3)
     expectEqual(root.trailingTrivia!.count, 0)
     let state = root.statements[idx]

--- a/tools/SwiftSyntax/RawSyntax.swift
+++ b/tools/SwiftSyntax/RawSyntax.swift
@@ -214,22 +214,40 @@ extension RawSyntax {
     }
   }
 
-  func accumulateLeadingTrivia(_ pos: AbsolutePosition) -> Bool {
+  var leadingTrivia: Trivia? {
     switch self {
     case .node(_, let layout, _):
       for child in layout {
         guard let child = child else { continue }
-        if child.accumulateLeadingTrivia(pos) {
-          return true
-        }
+        guard let result = child.leadingTrivia else { continue }
+        return result
       }
-      return false
+      return nil
     case let .token(_, leadingTrivia, _, presence):
-      guard case .present = presence else { return false }
-      for piece in leadingTrivia {
-        piece.accumulateAbsolutePosition(pos)
+      guard case .present = presence else { return nil }
+      return leadingTrivia
+    }
+  }
+
+  var trailingTrivia: Trivia? {
+    switch self {
+    case .node(_, let layout, _):
+      for child in layout.reversed() {
+        guard let child = child else { continue }
+        guard let result = child.trailingTrivia else { continue }
+        return result
       }
-      return true
+      return nil
+    case let .token(_, _, trailingTrivia, presence):
+      guard case .present = presence else { return nil }
+      return trailingTrivia
+    }
+  }
+
+  func accumulateLeadingTrivia(_ pos: AbsolutePosition) {
+    guard let trivia = leadingTrivia else { return }
+    for piece in trivia {
+      piece.accumulateAbsolutePosition(pos)
     }
   }
 

--- a/tools/SwiftSyntax/Syntax.swift
+++ b/tools/SwiftSyntax/Syntax.swift
@@ -154,9 +154,8 @@ extension Syntax {
 
   /// The textual byte length of this node exluding leading and trailing trivia.
   public var byteSizeAfterTrimmingTrivia: Int {
-    return data.byteSize -
-      (leadingTrivia == nil ? 0 : leadingTrivia!.byteSize) -
-      (trailingTrivia == nil ? 0 : trailingTrivia!.byteSize)
+    return data.byteSize - (leadingTrivia?.byteSize ?? 0) -
+      (trailingTrivia?.byteSize ?? 0)
   }
 
   /// The root of the tree in which this node resides.

--- a/tools/SwiftSyntax/Syntax.swift
+++ b/tools/SwiftSyntax/Syntax.swift
@@ -138,6 +138,27 @@ extension Syntax {
     return data.byteSize
   }
 
+  /// The leading trivia of this syntax node. Leading trivia is attached to
+  /// the first token syntax contained by this node. Without such token, this
+  /// property will return nil.
+  public var leadingTrivia: Trivia? {
+    return raw.leadingTrivia
+  }
+
+  /// The trailing trivia of this syntax node. Trailing trivia is attached to
+  /// the last token syntax contained by this node. Without such token, this
+  /// property will return nil.
+  public var trailingTrivia: Trivia? {
+    return raw.trailingTrivia
+  }
+
+  /// The textual byte length of this node exluding leading and trailing trivia.
+  public var byteSizeAfterTrimmingTrivia: Int {
+    return data.byteSize -
+      (leadingTrivia == nil ? 0 : leadingTrivia!.byteSize) -
+      (trailingTrivia == nil ? 0 : trailingTrivia!.byteSize)
+  }
+
   /// The root of the tree in which this node resides.
   public var root: Syntax {
     return makeSyntax(root: _root,  data: _root)


### PR DESCRIPTION
Although libSyntax is designed in a way that trivia is attached to
tokens, we shouldn't restrict clients to access trivia only from a token.
An example can be doc-comment, which conceptually attaches to a declaration rather
than the start token of a declaration, like at-attributes.
