### PR TITLE
[Sema] Only directly access members within didSet if accessed on 'self'

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2351,7 +2351,13 @@ public:
   /// Determines the kind of access that should be performed by a
   /// DeclRefExpr or MemberRefExpr use of this value in the specified
   /// context.
-  AccessSemantics getAccessSemanticsFromContext(const DeclContext *DC) const;
+  ///
+  /// \param DC The declaration context.
+  ///
+  /// \param base If querying for a MemberRefExpr, this is its base expression.
+  ///             Otherwise, \c nullptr.
+  AccessSemantics getAccessSemanticsFromContext(const DeclContext *DC,
+                                                Expr *base) const;
 
   /// Print a reference to the given declaration.
   std::string printRef() const;

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2354,10 +2354,10 @@ public:
   ///
   /// \param DC The declaration context.
   ///
-  /// \param base If querying for a MemberRefExpr, this is its base expression.
-  ///             Otherwise, \c nullptr.
+  /// \param isAccessOnSelf Whether this is a member access on the implicit
+  ///        'self' declaration of the declaration context.
   AccessSemantics getAccessSemanticsFromContext(const DeclContext *DC,
-                                                Expr *base) const;
+                                                bool isAccessOnSelf) const;
 
   /// Print a reference to the given declaration.
   std::string printRef() const;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -248,7 +248,7 @@ getImplicitMemberReferenceAccessSemantics(Expr *base, VarDecl *member,
   }
 
   // If the value is always directly accessed from this context, do it.
-  return member->getAccessSemanticsFromContext(DC);
+  return member->getAccessSemanticsFromContext(DC, base);
 }
 
 void ConstraintSystem::propagateLValueAccessKind(Expr *E, AccessKind accessKind,

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -247,8 +247,16 @@ getImplicitMemberReferenceAccessSemantics(Expr *base, VarDecl *member,
     }
   }
 
+  // Check whether this is a member access on 'self'.
+  bool isAccessOnSelf = false;
+  if (auto *baseDRE = dyn_cast<DeclRefExpr>(base->getValueProvidingExpr()))
+    if (auto *AFD = dyn_cast<AbstractFunctionDecl>(DC))
+      if (auto *selfDecl = AFD->getImplicitSelfDecl())
+        if (baseDRE->getDecl() == selfDecl)
+          isAccessOnSelf = true;
+
   // If the value is always directly accessed from this context, do it.
-  return member->getAccessSemanticsFromContext(DC, base);
+  return member->getAccessSemanticsFromContext(DC, isAccessOnSelf);
 }
 
 void ConstraintSystem::propagateLValueAccessKind(Expr *E, AccessKind accessKind,

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -250,10 +250,8 @@ getImplicitMemberReferenceAccessSemantics(Expr *base, VarDecl *member,
   // Check whether this is a member access on 'self'.
   bool isAccessOnSelf = false;
   if (auto *baseDRE = dyn_cast<DeclRefExpr>(base->getValueProvidingExpr()))
-    if (auto *AFD = dyn_cast<AbstractFunctionDecl>(DC))
-      if (auto *selfDecl = AFD->getImplicitSelfDecl())
-        if (baseDRE->getDecl() == selfDecl)
-          isAccessOnSelf = true;
+    if (auto *baseVar = dyn_cast<VarDecl>(baseDRE->getDecl()))
+      isAccessOnSelf = baseVar->isSelfParameter();
 
   // If the value is always directly accessed from this context, do it.
   return member->getAccessSemanticsFromContext(DC, isAccessOnSelf);

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -516,7 +516,8 @@ bool TypeChecker::requireArrayLiteralIntrinsics(SourceLoc loc) {
 Expr *TypeChecker::buildCheckedRefExpr(VarDecl *value, DeclContext *UseDC,
                                        DeclNameLoc loc, bool Implicit) {
   auto type = getUnopenedTypeOfReference(value, Type(), UseDC);
-  auto semantics = value->getAccessSemanticsFromContext(UseDC, /*base*/nullptr);
+  auto semantics = value->getAccessSemanticsFromContext(UseDC,
+                                                       /*isAccessOnSelf*/false);
   return new (Context) DeclRefExpr(value, loc, Implicit, semantics, type);
 }
 
@@ -527,7 +528,7 @@ Expr *TypeChecker::buildRefExpr(ArrayRef<ValueDecl *> Decls,
 
   if (Decls.size() == 1 && !isa<ProtocolDecl>(Decls[0]->getDeclContext())) {
     auto semantics = Decls[0]->getAccessSemanticsFromContext(UseDC,
-                                                             /*base*/nullptr);
+                                                       /*isAccessOnSelf*/false);
     return new (Context) DeclRefExpr(Decls[0], NameLoc, Implicit, semantics);
   }
 

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -516,7 +516,7 @@ bool TypeChecker::requireArrayLiteralIntrinsics(SourceLoc loc) {
 Expr *TypeChecker::buildCheckedRefExpr(VarDecl *value, DeclContext *UseDC,
                                        DeclNameLoc loc, bool Implicit) {
   auto type = getUnopenedTypeOfReference(value, Type(), UseDC);
-  AccessSemantics semantics = value->getAccessSemanticsFromContext(UseDC);
+  auto semantics = value->getAccessSemanticsFromContext(UseDC, /*base*/nullptr);
   return new (Context) DeclRefExpr(value, loc, Implicit, semantics, type);
 }
 
@@ -526,7 +526,8 @@ Expr *TypeChecker::buildRefExpr(ArrayRef<ValueDecl *> Decls,
   assert(!Decls.empty() && "Must have at least one declaration");
 
   if (Decls.size() == 1 && !isa<ProtocolDecl>(Decls[0]->getDeclContext())) {
-    AccessSemantics semantics = Decls[0]->getAccessSemanticsFromContext(UseDC);
+    auto semantics = Decls[0]->getAccessSemanticsFromContext(UseDC,
+                                                             /*base*/nullptr);
     return new (Context) DeclRefExpr(Decls[0], NameLoc, Implicit, semantics);
   }
 

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -495,10 +495,31 @@ protocol ForceAccessors {
 }
 
 struct DidSetWillSetTests: ForceAccessors {
+
+  static var defaultValue: DidSetWillSetTests {
+    return DidSetWillSetTests(x: 0)
+  }
+
+  // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV{{[_0-9a-zA-Z]*}}fC
+  init(x : Int) {
+    // Accesses to didset/willset variables are direct in init methods and dtors.
+    a = x
+    a = x
+
+    // CHECK: bb0(%0 : $Int, %1 : $@thin DidSetWillSetTests.Type):
+    // CHECK:        [[SELF:%.*]] = mark_uninitialized [rootself]
+    // CHECK:        [[PB_SELF:%.*]] = project_box [[SELF]]
+    // CHECK:        [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB_SELF]]
+    // CHECK:        [[P1:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+    // CHECK-NEXT:   assign %0 to [[P1]]
+    // CHECK:        [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB_SELF]]
+    // CHECK:        [[P2:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+    // CHECK-NEXT:   assign %0 to [[P2]]
+  }
+
   var a: Int {
+    // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
     willSet(newA) {
-      // CHECK-LABEL: // {{.*}}.DidSetWillSetTests.a.willset
-      // CHECK-NEXT: sil hidden @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
       // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
       // CHECK-NEXT: debug_value %0
       // CHECK-NEXT: debug_value_addr %1 : $*DidSetWillSetTests
@@ -517,11 +538,78 @@ struct DidSetWillSetTests: ForceAccessors {
       // CHECK-NEXT: // function_ref properties.takeInt(Swift.Int) -> ()
       // CHECK-NEXT: [[TAKEINTFN:%.*]] = function_ref @$S10properties7takeInt{{[_0-9a-zA-Z]*}}F
       // CHECK-NEXT: apply [[TAKEINTFN]](%0) : $@convention(thin) (Int) -> ()
+
+      a = zero  // reassign, but don't infinite loop, as accessing on 'self'.
+
+      // CHECK-NEXT: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
+      // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
+      // CHECK-NEXT: [[ZERORAW:%.*]] = apply [[ZEROFN]]() : $@convention(thin) () -> Builtin.RawPointer
+      // CHECK-NEXT: [[ZEROADDR:%.*]] = pointer_to_address [[ZERORAW]] : $Builtin.RawPointer to [strict] $*Int
+      // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [dynamic] [[ZEROADDR]] : $*Int
+      // CHECK-NEXT: [[ZERO:%.*]] = load [trivial] [[READ]]
+      // CHECK-NEXT: end_access [[READ]] : $*Int
+      // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
+      // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+      // CHECK-NEXT: assign [[ZERO]] to [[AADDR]]
+
+      var unrelatedValue = DidSetWillSetTests.defaultValue
+
+      // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "unrelatedValue"
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
+      // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin DidSetWillSetTests.Type
+      // CHECK-NEXT: // function_ref static properties.DidSetWillSetTests.defaultValue.getter : properties.DidSetWillSetTests
+      // CHECK-NEXT: [[DEFAULTVALUE_FN:%.*]] = function_ref @$S10properties{{[_0-9a-zA-Z]*}}vgZ : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
+      // CHECK-NEXT: [[DEFAULTRESULT:%.*]] = apply [[DEFAULTVALUE_FN]]([[METATYPE]]) : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
+      // CHECK-NEXT: store [[DEFAULTRESULT]] to [trivial] [[BOXADDR]] : $*DidSetWillSetTests
+
+      // But if we re-assign to the property when 'self' is not the base, we should not access directly
+      // (even though in this example, we *will* infinitely recurse).
+      unrelatedValue.a = zero
+
+      // CHECK-NEXT: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
+      // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
+      // CHECK-NEXT: [[ZERORAW:%.*]] = apply [[ZEROFN]]() : $@convention(thin) () -> Builtin.RawPointer
+      // CHECK-NEXT: [[ZEROADDR:%.*]] = pointer_to_address [[ZERORAW]] : $Builtin.RawPointer to [strict] $*Int
+      // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [dynamic] [[ZEROADDR]] : $*Int
+      // CHECK-NEXT: [[ZERO:%.*]] = load [trivial] [[READ]]
+      // CHECK-NEXT: end_access [[READ]] : $*Int
+
+      // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] [[BOXADDR]] : $*DidSetWillSetTests
+      // CHECK-NEXT: // function_ref properties.DidSetWillSetTests.a.setter : Swift.Int
+      // CHECK-NEXT: [[SETTERFN:%.*]] = function_ref @$S10properties{{[_0-9a-zA-Z]*}}Sivs : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+      // CHECK-NEXT: apply [[SETTERFN]]([[ZERO]], [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+      // CHECK-NEXT: end_access [[WRITE]] : $*DidSetWillSetTests
     }
 
+    // This is the synthesized setter for the variable.
+
+    // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV1aSivs
+    // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
+    // CHECK-NEXT: debug_value %0
+    // CHECK-NEXT: debug_value_addr %1
+
+    // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [unknown] %1
+    // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[READ]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+    // CHECK-NEXT: [[OLDVAL:%.*]] = load [trivial] [[AADDR]] : $*Int
+    // CHECK-NEXT: end_access [[READ]]
+    // CHECK-NEXT: debug_value [[OLDVAL]] : $Int, let, name "tmp"
+
+    // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
+    // CHECK-NEXT: // function_ref {{.*}}.DidSetWillSetTests.a.willset : Swift.Int
+    // CHECK-NEXT: [[WILLSETFN:%.*]] = function_ref @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
+    // CHECK-NEXT:  apply [[WILLSETFN]](%0, [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+    // CHECK-NEXT: end_access [[WRITE]]
+    // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
+    // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+    // CHECK-NEXT: assign %0 to [[AADDR]] : $*Int
+    // CHECK-NEXT: end_access [[WRITE]]
+    // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
+    // CHECK-NEXT: // function_ref {{.*}}.DidSetWillSetTests.a.didset : Swift.Int
+    // CHECK-NEXT: [[DIDSETFN:%.*]] = function_ref @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vW : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+    // CHECK-NEXT: apply [[DIDSETFN]]([[OLDVAL]], [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+
+    // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vW
     didSet {
-      // CHECK-LABEL: // {{.*}}.DidSetWillSetTests.a.didset
-      // CHECK-NEXT: sil hidden @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vW
       // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
       // CHECK-NEXT: debug
       // CHECK-NEXT: debug_value_addr %1 : $*DidSetWillSetTests
@@ -536,7 +624,7 @@ struct DidSetWillSetTests: ForceAccessors {
       // CHECK-NEXT: [[TAKEINTFN:%.*]] = function_ref @$S10properties7takeInt{{[_0-9a-zA-Z]*}}F
       // CHECK-NEXT: apply [[TAKEINTFN]]([[A]]) : $@convention(thin) (Int) -> ()
 
-      a = zero  // reassign, but don't infinite loop.
+      (self).a = zero  // reassign, but don't infinite loop, as accessing on 'self'.
 
       // CHECK-NEXT: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
       // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
@@ -548,68 +636,110 @@ struct DidSetWillSetTests: ForceAccessors {
       // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
       // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
       // CHECK-NEXT: assign [[ZERO]] to [[AADDR]]
+
+      var unrelatedValue = DidSetWillSetTests.defaultValue
+
+      // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "unrelatedValue"
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
+      // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin DidSetWillSetTests.Type
+      // CHECK-NEXT: // function_ref static properties.DidSetWillSetTests.defaultValue.getter : properties.DidSetWillSetTests
+      // CHECK-NEXT: [[DEFAULTVALUE_FN:%.*]] = function_ref @$S10properties{{[_0-9a-zA-Z]*}}vgZ : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
+      // CHECK-NEXT: [[DEFAULTRESULT:%.*]] = apply [[DEFAULTVALUE_FN]]([[METATYPE]]) : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
+      // CHECK-NEXT: store [[DEFAULTRESULT]] to [trivial] [[BOXADDR]] : $*DidSetWillSetTests
+
+      // But if we re-assign to the property when 'self' is not the base, we should not access directly
+      // (even though in this example, we *will* infinitely recurse).
+      unrelatedValue.a = zero
+
+      // CHECK-NEXT: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
+      // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
+      // CHECK-NEXT: [[ZERORAW:%.*]] = apply [[ZEROFN]]() : $@convention(thin) () -> Builtin.RawPointer
+      // CHECK-NEXT: [[ZEROADDR:%.*]] = pointer_to_address [[ZERORAW]] : $Builtin.RawPointer to [strict] $*Int
+      // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [dynamic] [[ZEROADDR]] : $*Int
+      // CHECK-NEXT: [[ZERO:%.*]] = load [trivial] [[READ]]
+      // CHECK-NEXT: end_access [[READ]] : $*Int
+
+      // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] [[BOXADDR]] : $*DidSetWillSetTests
+      // CHECK-NEXT: // function_ref properties.DidSetWillSetTests.a.setter : Swift.Int
+      // CHECK-NEXT: [[SETTERFN:%.*]] = function_ref @$S10properties{{[_0-9a-zA-Z]*}}Sivs : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+      // CHECK-NEXT: apply [[SETTERFN]]([[ZERO]], [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+      // CHECK-NEXT: end_access [[WRITE]] : $*DidSetWillSetTests
+
+      // Even if the value of the base happens to be self...
+      var other = self
+
+      // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "other"
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
+      // CHECK-NEXT: [[READ_SELF:%.*]] = begin_access [read] [unknown] %1 : $*DidSetWillSetTests
+      // CHECK-NEXT: copy_addr [[READ_SELF]] to [initialization] [[BOXADDR]] : $*DidSetWillSetTests
+      // CHECK-NEXT: end_access [[READ_SELF]] : $*DidSetWillSetTests
+
+      other.a = zero
+
+      // CHECK-NEXT: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
+      // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
+      // CHECK-NEXT: [[ZERORAW:%.*]] = apply [[ZEROFN]]() : $@convention(thin) () -> Builtin.RawPointer
+      // CHECK-NEXT: [[ZEROADDR:%.*]] = pointer_to_address [[ZERORAW]] : $Builtin.RawPointer to [strict] $*Int
+      // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [dynamic] [[ZEROADDR]] : $*Int
+      // CHECK-NEXT: [[ZERO:%.*]] = load [trivial] [[READ]]
+      // CHECK-NEXT: end_access [[READ]] : $*Int
+
+      // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] [[BOXADDR]] : $*DidSetWillSetTests
+      // CHECK-NEXT: // function_ref properties.DidSetWillSetTests.a.setter : Swift.Int
+      // CHECK-NEXT: [[SETTERFN:%.*]] = function_ref @$S10properties{{[_0-9a-zA-Z]*}}Sivs : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+      // CHECK-NEXT: apply [[SETTERFN]]([[ZERO]], [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+      // CHECK-NEXT: end_access [[WRITE]] : $*DidSetWillSetTests
     }
   }
 
-  init(x : Int) {
-    // Accesses to didset/willset variables are direct in init methods and dtors.
-    a = x
-    a = x
-  }
+  // This is the synthesized getter for the willSet/didSet variable.
 
-  // These are the synthesized getter and setter for the willset/didset variable.
-
-  // CHECK-LABEL: // {{.*}}.DidSetWillSetTests.a.getter
-  // CHECK-NEXT: sil hidden [transparent] @$S10properties010DidSetWillC5TestsV1aSivg
+  // CHECK-LABEL: sil hidden [transparent] @$S10properties010DidSetWillC5TestsV1aSivg
   // CHECK: bb0(%0 : $DidSetWillSetTests):
   // CHECK-NEXT:   debug_value %0
   // CHECK-NEXT:   %2 = struct_extract %0 : $DidSetWillSetTests, #DidSetWillSetTests.a
   // CHECK-NEXT:   return %2 : $Int{{.*}}                      // id: %3
-
-  // CHECK-LABEL: // {{.*}}.DidSetWillSetTests.a.setter
-  // CHECK-NEXT: sil hidden @$S10properties010DidSetWillC5TestsV1aSivs
-  // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
-  // CHECK-NEXT: debug_value %0
-  // CHECK-NEXT: debug_value_addr %1
-
-  // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [unknown] %1
-  // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[READ]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
-  // CHECK-NEXT: [[OLDVAL:%.*]] = load [trivial] [[AADDR]] : $*Int
-  // CHECK-NEXT: end_access [[READ]]
-  // CHECK-NEXT: debug_value [[OLDVAL]] : $Int, let, name "tmp"
-
-  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
-  // CHECK-NEXT: // function_ref {{.*}}.DidSetWillSetTests.a.willset : Swift.Int
-  // CHECK-NEXT: [[WILLSETFN:%.*]] = function_ref @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
-  // CHECK-NEXT:  apply [[WILLSETFN]](%0, [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
-  // CHECK-NEXT: end_access [[WRITE]]
-  // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
-  // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
-  // CHECK-NEXT: assign %0 to [[AADDR]] : $*Int
-  // CHECK-NEXT: end_access [[WRITE]]
-  // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
-  // CHECK-NEXT: // function_ref {{.*}}.DidSetWillSetTests.a.didset : Swift.Int
-  // CHECK-NEXT: [[DIDSETFN:%.*]] = function_ref @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vW : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
-  // CHECK-NEXT: apply [[DIDSETFN]]([[OLDVAL]], [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
-
-  // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV{{[_0-9a-zA-Z]*}}fC
-  // CHECK: bb0(%0 : $Int, %1 : $@thin DidSetWillSetTests.Type):
-  // CHECK:        [[SELF:%.*]] = mark_uninitialized [rootself]
-  // CHECK:        [[PB_SELF:%.*]] = project_box [[SELF]]
-  // CHECK:        [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB_SELF]]
-  // CHECK:        [[P1:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
-  // CHECK-NEXT:   assign %0 to [[P1]]
-  // CHECK:        [[WRITE:%.*]] = begin_access [modify] [unknown] [[PB_SELF]]
-  // CHECK:        [[P2:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
-  // CHECK-NEXT:   assign %0 to [[P2]]
 }
 
 
 // Test global observing properties.
 
 var global_observing_property : Int = zero {
+  // The variable is initialized with "zero".
+  // CHECK-LABEL: sil private @globalinit_{{.*}}_func1 : $@convention(c) () -> () {
+  // CHECK: bb0:
+  // CHECK-NEXT: alloc_global @$S10properties25global_observing_propertySiv
+  // CHECK-NEXT: %1 = global_addr @$S10properties25global_observing_propertySivp : $*Int
+  // CHECK: properties.zero.unsafeMutableAddressor
+  // CHECK: return
+
+  // CHECK-LABEL: sil hidden @$S10properties25global_observing_property{{[_0-9a-zA-Z]*}}vW
   didSet {
+    // The didSet implementation needs to call takeInt.
     takeInt(global_observing_property)
+
+    // CHECK: function_ref properties.takeInt
+    // CHECK-NEXT: function_ref @$S10properties7takeInt{{[_0-9a-zA-Z]*}}F
+
+    // Setting the variable from within its own didSet doesn't recursively call didSet.
+    global_observing_property = zero
+
+    // CHECK: // function_ref properties.global_observing_property.unsafeMutableAddressor : Swift.Int
+    // CHECK-NEXT: [[ADDRESSOR:%.*]] = function_ref @$S10properties25global_observing_propertySivau : $@convention(thin) () -> Builtin.RawPointer
+    // CHECK-NEXT: [[ADDRESS:%.*]] = apply [[ADDRESSOR]]() : $@convention(thin) () -> Builtin.RawPointer
+    // CHECK-NEXT: [[POINTER:%.*]] = pointer_to_address [[ADDRESS]] : $Builtin.RawPointer to [strict] $*Int
+    // CHECK-NEXT: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
+    // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
+    // CHECK-NEXT: [[ZERORAW:%.*]] = apply [[ZEROFN]]() : $@convention(thin) () -> Builtin.RawPointer
+    // CHECK-NEXT: [[ZEROADDR:%.*]] = pointer_to_address [[ZERORAW]] : $Builtin.RawPointer to [strict] $*Int
+    // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [dynamic] [[ZEROADDR]] : $*Int
+    // CHECK-NEXT: [[ZERO:%.*]] = load [trivial] [[READ]]
+    // CHECK-NEXT: end_access [[READ]] : $*Int
+    // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [dynamic] [[POINTER]] : $*Int
+    // CHECK-NEXT: assign [[ZERO]] to [[WRITE]] : $*Int
+    // CHECK-NEXT: end_access [[WRITE]] : $*Int
+    // CHECK-NOT: function_ref @$S10properties25global_observing_property{{[_0-9a-zA-Z]*}}vW
+    // CHECK: end sil function
   }
 }
 
@@ -618,21 +748,7 @@ func force_global_observing_property_setter() {
   global_observing_property = x
 }
 
-// The property is initialized with "zero".
-// CHECK-LABEL: sil private @globalinit_{{.*}}_func1 : $@convention(c) () -> () {
-// CHECK: bb0:
-// CHECK-NEXT: alloc_global @$S10properties25global_observing_propertySiv
-// CHECK-NEXT: %1 = global_addr @$S10properties25global_observing_propertySivp : $*Int
-// CHECK: properties.zero.unsafeMutableAddressor
-// CHECK: return
-
-// The didSet implementation needs to call takeInt.
-
-// CHECK-LABEL: sil hidden @$S10properties25global_observing_property{{[_0-9a-zA-Z]*}}vW
-// CHECK: function_ref properties.takeInt
-// CHECK-NEXT: function_ref @$S10properties7takeInt{{[_0-9a-zA-Z]*}}F
-
-// The setter needs to call didSet implementation.
+// global_observing_property's setter needs to call didSet implementation.
 
 // CHECK-LABEL: sil hidden @$S10properties25global_observing_property{{[_0-9a-zA-Z]*}}vs
 // CHECK: function_ref properties.global_observing_property.unsafeMutableAddressor
@@ -643,25 +759,44 @@ func force_global_observing_property_setter() {
 
 // Test local observing properties.
 
+// CHECK-LABEL: sil hidden @$S10properties24local_observing_property{{[_0-9a-zA-Z]*}}SiF
 func local_observing_property(_ arg: Int) {
   var localproperty: Int = arg {
     didSet {
       takeInt(localproperty)
+      localproperty = zero
     }
   }
-  
+
   takeInt(localproperty)
   localproperty = arg
+
+  // Alloc and initialize the property to the argument value.
+  // CHECK: bb0([[ARG:%[0-9]+]] : $Int)
+  // CHECK: [[BOX:%[0-9]+]] = alloc_box ${ var Int }
+  // CHECK: [[PB:%.*]] = project_box [[BOX]]
+  // CHECK: store [[ARG]] to [trivial] [[PB]]
 }
 
-// This is the local_observing_property function itself.  First alloc and 
-// initialize the property to the argument value.
+// didSet of localproperty (above)
+// Ensure that setting the variable from within its own didSet doesn't recursively call didSet.
 
-// CHECK-LABEL: sil hidden @{{.*}}local_observing_property
-// CHECK: bb0([[ARG:%[0-9]+]] : $Int)
-// CHECK: [[BOX:%[0-9]+]] = alloc_box ${ var Int }
-// CHECK: [[PB:%.*]] = project_box [[BOX]]
-// CHECK: store [[ARG]] to [trivial] [[PB]]
+// CHECK-LABEL: sil private @$S10properties24local_observing_property{{[_0-9a-zA-Z]*}}SiF13localproperty{{[_0-9a-zA-Z]*}}SivW
+// CHECK: bb0(%0 : $Int, %1 : ${ var Int })
+// CHECK: [[POINTER:%.*]] = project_box %1 : ${ var Int }, 0
+// CHECK: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
+// CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
+// CHECK-NEXT: [[ZERORAW:%.*]] = apply [[ZEROFN]]() : $@convention(thin) () -> Builtin.RawPointer
+// CHECK-NEXT: [[ZEROADDR:%.*]] = pointer_to_address [[ZERORAW]] : $Builtin.RawPointer to [strict] $*Int
+// CHECK-NEXT: [[READ:%.*]] = begin_access [read] [dynamic] [[ZEROADDR]] : $*Int
+// CHECK-NEXT: [[ZERO:%.*]] = load [trivial] [[READ]]
+// CHECK-NEXT: end_access [[READ]] : $*Int
+
+// CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] [[POINTER]] : $*Int
+// CHECK-NEXT: assign [[ZERO]] to [[WRITE]] : $*Int
+// CHECK-NEXT: end_access [[WRITE]] : $*Int
+// CHECK-NOT: function_ref @$S10properties24local_observing_property{{[_0-9a-zA-Z]*}}SiF13localproperty{{[_0-9a-zA-Z]*}}SivW
+// CHECK: end sil function
 
 func local_generic_observing_property<T>(_ arg: Int, _: T) {
   var localproperty1: Int = arg {

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -495,11 +495,6 @@ protocol ForceAccessors {
 }
 
 struct DidSetWillSetTests: ForceAccessors {
-
-  static var defaultValue: DidSetWillSetTests {
-    return DidSetWillSetTests(x: 0)
-  }
-
   // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV{{[_0-9a-zA-Z]*}}fC
   init(x : Int) {
     // Accesses to didset/willset variables are direct in init methods and dtors.
@@ -539,7 +534,7 @@ struct DidSetWillSetTests: ForceAccessors {
       // CHECK-NEXT: [[TAKEINTFN:%.*]] = function_ref @$S10properties7takeInt{{[_0-9a-zA-Z]*}}F
       // CHECK-NEXT: apply [[TAKEINTFN]](%0) : $@convention(thin) (Int) -> ()
 
-      a = zero  // reassign, but don't infinite loop, as accessing on 'self'.
+      a = zero  // reassign, but don't infinite loop.
 
       // CHECK-NEXT: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
       // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
@@ -551,62 +546,7 @@ struct DidSetWillSetTests: ForceAccessors {
       // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
       // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
       // CHECK-NEXT: assign [[ZERO]] to [[AADDR]]
-
-      var unrelatedValue = DidSetWillSetTests.defaultValue
-
-      // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "unrelatedValue"
-      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
-      // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin DidSetWillSetTests.Type
-      // CHECK-NEXT: // function_ref static properties.DidSetWillSetTests.defaultValue.getter : properties.DidSetWillSetTests
-      // CHECK-NEXT: [[DEFAULTVALUE_FN:%.*]] = function_ref @$S10properties{{[_0-9a-zA-Z]*}}vgZ : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
-      // CHECK-NEXT: [[DEFAULTRESULT:%.*]] = apply [[DEFAULTVALUE_FN]]([[METATYPE]]) : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
-      // CHECK-NEXT: store [[DEFAULTRESULT]] to [trivial] [[BOXADDR]] : $*DidSetWillSetTests
-
-      // But if we re-assign to the property when 'self' is not the base, we should not access directly
-      // (even though in this example, we *will* infinitely recurse).
-      unrelatedValue.a = zero
-
-      // CHECK-NEXT: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
-      // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
-      // CHECK-NEXT: [[ZERORAW:%.*]] = apply [[ZEROFN]]() : $@convention(thin) () -> Builtin.RawPointer
-      // CHECK-NEXT: [[ZEROADDR:%.*]] = pointer_to_address [[ZERORAW]] : $Builtin.RawPointer to [strict] $*Int
-      // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [dynamic] [[ZEROADDR]] : $*Int
-      // CHECK-NEXT: [[ZERO:%.*]] = load [trivial] [[READ]]
-      // CHECK-NEXT: end_access [[READ]] : $*Int
-
-      // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] [[BOXADDR]] : $*DidSetWillSetTests
-      // CHECK-NEXT: // function_ref properties.DidSetWillSetTests.a.setter : Swift.Int
-      // CHECK-NEXT: [[SETTERFN:%.*]] = function_ref @$S10properties{{[_0-9a-zA-Z]*}}Sivs : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
-      // CHECK-NEXT: apply [[SETTERFN]]([[ZERO]], [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
-      // CHECK-NEXT: end_access [[WRITE]] : $*DidSetWillSetTests
     }
-
-    // This is the synthesized setter for the variable.
-
-    // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV1aSivs
-    // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
-    // CHECK-NEXT: debug_value %0
-    // CHECK-NEXT: debug_value_addr %1
-
-    // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [unknown] %1
-    // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[READ]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
-    // CHECK-NEXT: [[OLDVAL:%.*]] = load [trivial] [[AADDR]] : $*Int
-    // CHECK-NEXT: end_access [[READ]]
-    // CHECK-NEXT: debug_value [[OLDVAL]] : $Int, let, name "tmp"
-
-    // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
-    // CHECK-NEXT: // function_ref {{.*}}.DidSetWillSetTests.a.willset : Swift.Int
-    // CHECK-NEXT: [[WILLSETFN:%.*]] = function_ref @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
-    // CHECK-NEXT:  apply [[WILLSETFN]](%0, [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
-    // CHECK-NEXT: end_access [[WRITE]]
-    // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
-    // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
-    // CHECK-NEXT: assign %0 to [[AADDR]] : $*Int
-    // CHECK-NEXT: end_access [[WRITE]]
-    // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
-    // CHECK-NEXT: // function_ref {{.*}}.DidSetWillSetTests.a.didset : Swift.Int
-    // CHECK-NEXT: [[DIDSETFN:%.*]] = function_ref @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vW : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
-    // CHECK-NEXT: apply [[DIDSETFN]]([[OLDVAL]], [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
 
     // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vW
     didSet {
@@ -624,7 +564,7 @@ struct DidSetWillSetTests: ForceAccessors {
       // CHECK-NEXT: [[TAKEINTFN:%.*]] = function_ref @$S10properties7takeInt{{[_0-9a-zA-Z]*}}F
       // CHECK-NEXT: apply [[TAKEINTFN]]([[A]]) : $@convention(thin) (Int) -> ()
 
-      (self).a = zero  // reassign, but don't infinite loop, as accessing on 'self'.
+      (self).a = zero  // reassign, but don't infinite loop.
 
       // CHECK-NEXT: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
       // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
@@ -636,69 +576,42 @@ struct DidSetWillSetTests: ForceAccessors {
       // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
       // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
       // CHECK-NEXT: assign [[ZERO]] to [[AADDR]]
-
-      var unrelatedValue = DidSetWillSetTests.defaultValue
-
-      // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "unrelatedValue"
-      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
-      // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin DidSetWillSetTests.Type
-      // CHECK-NEXT: // function_ref static properties.DidSetWillSetTests.defaultValue.getter : properties.DidSetWillSetTests
-      // CHECK-NEXT: [[DEFAULTVALUE_FN:%.*]] = function_ref @$S10properties{{[_0-9a-zA-Z]*}}vgZ : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
-      // CHECK-NEXT: [[DEFAULTRESULT:%.*]] = apply [[DEFAULTVALUE_FN]]([[METATYPE]]) : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
-      // CHECK-NEXT: store [[DEFAULTRESULT]] to [trivial] [[BOXADDR]] : $*DidSetWillSetTests
-
-      // But if we re-assign to the property when 'self' is not the base, we should not access directly
-      // (even though in this example, we *will* infinitely recurse).
-      unrelatedValue.a = zero
-
-      // CHECK-NEXT: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
-      // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
-      // CHECK-NEXT: [[ZERORAW:%.*]] = apply [[ZEROFN]]() : $@convention(thin) () -> Builtin.RawPointer
-      // CHECK-NEXT: [[ZEROADDR:%.*]] = pointer_to_address [[ZERORAW]] : $Builtin.RawPointer to [strict] $*Int
-      // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [dynamic] [[ZEROADDR]] : $*Int
-      // CHECK-NEXT: [[ZERO:%.*]] = load [trivial] [[READ]]
-      // CHECK-NEXT: end_access [[READ]] : $*Int
-
-      // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] [[BOXADDR]] : $*DidSetWillSetTests
-      // CHECK-NEXT: // function_ref properties.DidSetWillSetTests.a.setter : Swift.Int
-      // CHECK-NEXT: [[SETTERFN:%.*]] = function_ref @$S10properties{{[_0-9a-zA-Z]*}}Sivs : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
-      // CHECK-NEXT: apply [[SETTERFN]]([[ZERO]], [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
-      // CHECK-NEXT: end_access [[WRITE]] : $*DidSetWillSetTests
-
-      // Even if the value of the base happens to be self...
-      var other = self
-
-      // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "other"
-      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
-      // CHECK-NEXT: [[READ_SELF:%.*]] = begin_access [read] [unknown] %1 : $*DidSetWillSetTests
-      // CHECK-NEXT: copy_addr [[READ_SELF]] to [initialization] [[BOXADDR]] : $*DidSetWillSetTests
-      // CHECK-NEXT: end_access [[READ_SELF]] : $*DidSetWillSetTests
-
-      other.a = zero
-
-      // CHECK-NEXT: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
-      // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
-      // CHECK-NEXT: [[ZERORAW:%.*]] = apply [[ZEROFN]]() : $@convention(thin) () -> Builtin.RawPointer
-      // CHECK-NEXT: [[ZEROADDR:%.*]] = pointer_to_address [[ZERORAW]] : $Builtin.RawPointer to [strict] $*Int
-      // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [dynamic] [[ZEROADDR]] : $*Int
-      // CHECK-NEXT: [[ZERO:%.*]] = load [trivial] [[READ]]
-      // CHECK-NEXT: end_access [[READ]] : $*Int
-
-      // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] [[BOXADDR]] : $*DidSetWillSetTests
-      // CHECK-NEXT: // function_ref properties.DidSetWillSetTests.a.setter : Swift.Int
-      // CHECK-NEXT: [[SETTERFN:%.*]] = function_ref @$S10properties{{[_0-9a-zA-Z]*}}Sivs : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
-      // CHECK-NEXT: apply [[SETTERFN]]([[ZERO]], [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
-      // CHECK-NEXT: end_access [[WRITE]] : $*DidSetWillSetTests
     }
   }
 
-  // This is the synthesized getter for the willSet/didSet variable.
+  // This is the synthesized getter and setter for the willset/didset variable.
 
   // CHECK-LABEL: sil hidden [transparent] @$S10properties010DidSetWillC5TestsV1aSivg
   // CHECK: bb0(%0 : $DidSetWillSetTests):
   // CHECK-NEXT:   debug_value %0
   // CHECK-NEXT:   %2 = struct_extract %0 : $DidSetWillSetTests, #DidSetWillSetTests.a
   // CHECK-NEXT:   return %2 : $Int{{.*}}                      // id: %3
+
+
+  // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV1aSivs
+  // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
+  // CHECK-NEXT: debug_value %0
+  // CHECK-NEXT: debug_value_addr %1
+
+  // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [unknown] %1
+  // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[READ]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+  // CHECK-NEXT: [[OLDVAL:%.*]] = load [trivial] [[AADDR]] : $*Int
+  // CHECK-NEXT: end_access [[READ]]
+  // CHECK-NEXT: debug_value [[OLDVAL]] : $Int, let, name "tmp"
+
+  // CHECK: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
+  // CHECK-NEXT: // function_ref {{.*}}.DidSetWillSetTests.a.willset : Swift.Int
+  // CHECK-NEXT: [[WILLSETFN:%.*]] = function_ref @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
+  // CHECK-NEXT:  apply [[WILLSETFN]](%0, [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+  // CHECK-NEXT: end_access [[WRITE]]
+  // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
+  // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+  // CHECK-NEXT: assign %0 to [[AADDR]] : $*Int
+  // CHECK-NEXT: end_access [[WRITE]]
+  // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
+  // CHECK-NEXT: // function_ref {{.*}}.DidSetWillSetTests.a.didset : Swift.Int
+  // CHECK-NEXT: [[DIDSETFN:%.*]] = function_ref @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vW : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+  // CHECK-NEXT: apply [[DIDSETFN]]([[OLDVAL]], [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
 }
 
 
@@ -748,7 +661,7 @@ func force_global_observing_property_setter() {
   global_observing_property = x
 }
 
-// global_observing_property's setter needs to call didSet implementation.
+// global_observing_property's setter needs to call didSet.
 
 // CHECK-LABEL: sil hidden @$S10properties25global_observing_property{{[_0-9a-zA-Z]*}}vs
 // CHECK: function_ref properties.global_observing_property.unsafeMutableAddressor

--- a/test/SILGen/properties_swift4.swift
+++ b/test/SILGen/properties_swift4.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-frontend -swift-version 4 -module-name properties -Xllvm -sil-full-demangle -parse-as-library -emit-silgen -disable-objc-attr-requires-foundation-module %s | %FileCheck %s
+// RUN: %target-swift-frontend -swift-version 4 -module-name properties -Xllvm -sil-full-demangle -parse-as-library -emit-silgen %s | %FileCheck %s
 
 var zero: Int = 0
 

--- a/test/SILGen/properties_swift4.swift
+++ b/test/SILGen/properties_swift4.swift
@@ -1,0 +1,126 @@
+
+// RUN: %target-swift-frontend -swift-version 4 -module-name properties -Xllvm -sil-full-demangle -parse-as-library -emit-silgen -disable-objc-attr-requires-foundation-module %s | %FileCheck %s
+
+var zero: Int = 0
+
+protocol ForceAccessors {
+  var a: Int { get set }
+}
+
+struct DidSetWillSetTests: ForceAccessors {
+  static var defaultValue: DidSetWillSetTests {
+    return DidSetWillSetTests(a: 0)
+  }
+
+  var a: Int {
+    // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
+    willSet(newA) {
+      // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
+
+      a = zero  // reassign, but don't infinite loop.
+
+      // CHECK: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
+      // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
+      // CHECK-NEXT: [[ZERORAW:%.*]] = apply [[ZEROFN]]() : $@convention(thin) () -> Builtin.RawPointer
+      // CHECK-NEXT: [[ZEROADDR:%.*]] = pointer_to_address [[ZERORAW]] : $Builtin.RawPointer to [strict] $*Int
+      // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [dynamic] [[ZEROADDR]] : $*Int
+      // CHECK-NEXT: [[ZERO:%.*]] = load [trivial] [[READ]]
+      // CHECK-NEXT: end_access [[READ]] : $*Int
+      // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
+      // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+      // CHECK-NEXT: assign [[ZERO]] to [[AADDR]]
+
+      var unrelatedValue = DidSetWillSetTests.defaultValue
+
+      // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "unrelatedValue"
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
+      // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin DidSetWillSetTests.Type
+      // CHECK-NEXT: // function_ref static properties.DidSetWillSetTests.defaultValue.getter : properties.DidSetWillSetTests
+      // CHECK-NEXT: [[DEFAULTVALUE_FN:%.*]] = function_ref @$S10properties{{[_0-9a-zA-Z]*}}vgZ : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
+      // CHECK-NEXT: [[DEFAULTRESULT:%.*]] = apply [[DEFAULTVALUE_FN]]([[METATYPE]]) : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
+      // CHECK-NEXT: store [[DEFAULTRESULT]] to [trivial] [[BOXADDR]] : $*DidSetWillSetTests
+
+      // Access directly even when calling on another instance in order to maintain < Swift 5 behaviour.
+      unrelatedValue.a = zero
+
+      // CHECK-NEXT: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
+      // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
+      // CHECK-NEXT: [[ZERORAW:%.*]] = apply [[ZEROFN]]() : $@convention(thin) () -> Builtin.RawPointer
+      // CHECK-NEXT: [[ZEROADDR:%.*]] = pointer_to_address [[ZERORAW]] : $Builtin.RawPointer to [strict] $*Int
+      // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [dynamic] [[ZEROADDR]] : $*Int
+      // CHECK-NEXT: [[ZERO:%.*]] = load [trivial] [[READ]]
+      // CHECK-NEXT: end_access [[READ]] : $*Int
+
+      // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] [[BOXADDR]] : $*DidSetWillSetTests
+      // CHECK-NEXT: [[ELEMADDR:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+      // CHECK-NEXT: assign [[ZERO]] to [[ELEMADDR]] : $*Int
+      // CHECK-NEXT: end_access [[WRITE]] : $*DidSetWillSetTests
+    }
+
+    // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vW
+    didSet {
+      (self).a = zero  // reassign, but don't infinite loop.
+
+      // CHECK: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
+      // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
+      // CHECK-NEXT: [[ZERORAW:%.*]] = apply [[ZEROFN]]() : $@convention(thin) () -> Builtin.RawPointer
+      // CHECK-NEXT: [[ZEROADDR:%.*]] = pointer_to_address [[ZERORAW]] : $Builtin.RawPointer to [strict] $*Int
+      // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [dynamic] [[ZEROADDR]] : $*Int
+      // CHECK-NEXT: [[ZERO:%.*]] = load [trivial] [[READ]]
+      // CHECK-NEXT: end_access [[READ]] : $*Int
+      // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
+      // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+      // CHECK-NEXT: assign [[ZERO]] to [[AADDR]]
+
+      var unrelatedValue = DidSetWillSetTests.defaultValue
+
+      // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "unrelatedValue"
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
+      // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin DidSetWillSetTests.Type
+      // CHECK-NEXT: // function_ref static properties.DidSetWillSetTests.defaultValue.getter : properties.DidSetWillSetTests
+      // CHECK-NEXT: [[DEFAULTVALUE_FN:%.*]] = function_ref @$S10properties{{[_0-9a-zA-Z]*}}vgZ : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
+      // CHECK-NEXT: [[DEFAULTRESULT:%.*]] = apply [[DEFAULTVALUE_FN]]([[METATYPE]]) : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
+      // CHECK-NEXT: store [[DEFAULTRESULT]] to [trivial] [[BOXADDR]] : $*DidSetWillSetTests
+
+      // Access directly even when calling on another instance in order to maintain < Swift 5 behaviour.
+      unrelatedValue.a = zero
+
+      // CHECK-NEXT: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
+      // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
+      // CHECK-NEXT: [[ZERORAW:%.*]] = apply [[ZEROFN]]() : $@convention(thin) () -> Builtin.RawPointer
+      // CHECK-NEXT: [[ZEROADDR:%.*]] = pointer_to_address [[ZERORAW]] : $Builtin.RawPointer to [strict] $*Int
+      // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [dynamic] [[ZEROADDR]] : $*Int
+      // CHECK-NEXT: [[ZERO:%.*]] = load [trivial] [[READ]]
+      // CHECK-NEXT: end_access [[READ]] : $*Int
+
+      // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] [[BOXADDR]] : $*DidSetWillSetTests
+      // CHECK-NEXT: [[ELEMADDR:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+      // CHECK-NEXT: assign [[ZERO]] to [[ELEMADDR]] : $*Int
+      // CHECK-NEXT: end_access [[WRITE]] : $*DidSetWillSetTests
+
+
+      var other = self
+
+      // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "other"
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
+      // CHECK-NEXT: [[READ_SELF:%.*]] = begin_access [read] [unknown] %1 : $*DidSetWillSetTests
+      // CHECK-NEXT: copy_addr [[READ_SELF]] to [initialization] [[BOXADDR]] : $*DidSetWillSetTests
+      // CHECK-NEXT: end_access [[READ_SELF]] : $*DidSetWillSetTests
+
+      other.a = zero
+
+      // CHECK-NEXT: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
+      // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
+      // CHECK-NEXT: [[ZERORAW:%.*]] = apply [[ZEROFN]]() : $@convention(thin) () -> Builtin.RawPointer
+      // CHECK-NEXT: [[ZEROADDR:%.*]] = pointer_to_address [[ZERORAW]] : $Builtin.RawPointer to [strict] $*Int
+      // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [dynamic] [[ZEROADDR]] : $*Int
+      // CHECK-NEXT: [[ZERO:%.*]] = load [trivial] [[READ]]
+      // CHECK-NEXT: end_access [[READ]] : $*Int
+
+      // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] [[BOXADDR]] : $*DidSetWillSetTests
+      // CHECK-NEXT: [[ELEMADDR:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+      // CHECK-NEXT: assign [[ZERO]] to [[ELEMADDR]] : $*Int
+      // CHECK-NEXT: end_access [[WRITE]] : $*DidSetWillSetTests
+    }
+  }
+}

--- a/test/SILGen/properties_swift5.swift
+++ b/test/SILGen/properties_swift5.swift
@@ -1,0 +1,131 @@
+
+// RUN: %target-swift-frontend -swift-version 5 -module-name properties -Xllvm -sil-full-demangle -parse-as-library -emit-silgen -disable-objc-attr-requires-foundation-module %s | %FileCheck %s
+
+var zero: Int = 0
+
+protocol ForceAccessors {
+  var a: Int { get set }
+}
+
+struct DidSetWillSetTests: ForceAccessors {
+  static var defaultValue: DidSetWillSetTests {
+    return DidSetWillSetTests(a: 0)
+  }
+
+  var a: Int {
+    // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
+    willSet(newA) {
+      // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
+
+      a = zero  // reassign, but don't infinite loop, as accessing on 'self'.
+
+      // CHECK: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
+      // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
+      // CHECK-NEXT: [[ZERORAW:%.*]] = apply [[ZEROFN]]() : $@convention(thin) () -> Builtin.RawPointer
+      // CHECK-NEXT: [[ZEROADDR:%.*]] = pointer_to_address [[ZERORAW]] : $Builtin.RawPointer to [strict] $*Int
+      // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [dynamic] [[ZEROADDR]] : $*Int
+      // CHECK-NEXT: [[ZERO:%.*]] = load [trivial] [[READ]]
+      // CHECK-NEXT: end_access [[READ]] : $*Int
+      // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
+      // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+      // CHECK-NEXT: assign [[ZERO]] to [[AADDR]]
+
+      var unrelatedValue = DidSetWillSetTests.defaultValue
+
+      // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "unrelatedValue"
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
+      // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin DidSetWillSetTests.Type
+      // CHECK-NEXT: // function_ref static properties.DidSetWillSetTests.defaultValue.getter : properties.DidSetWillSetTests
+      // CHECK-NEXT: [[DEFAULTVALUE_FN:%.*]] = function_ref @$S10properties{{[_0-9a-zA-Z]*}}vgZ : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
+      // CHECK-NEXT: [[DEFAULTRESULT:%.*]] = apply [[DEFAULTVALUE_FN]]([[METATYPE]]) : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
+      // CHECK-NEXT: store [[DEFAULTRESULT]] to [trivial] [[BOXADDR]] : $*DidSetWillSetTests
+
+      // But if we re-assign to the property when 'self' is not the base, we should not access directly
+      // (even though in this example, we *will* infinitely recurse).
+      unrelatedValue.a = zero
+
+      // CHECK-NEXT: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
+      // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
+      // CHECK-NEXT: [[ZERORAW:%.*]] = apply [[ZEROFN]]() : $@convention(thin) () -> Builtin.RawPointer
+      // CHECK-NEXT: [[ZEROADDR:%.*]] = pointer_to_address [[ZERORAW]] : $Builtin.RawPointer to [strict] $*Int
+      // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [dynamic] [[ZEROADDR]] : $*Int
+      // CHECK-NEXT: [[ZERO:%.*]] = load [trivial] [[READ]]
+      // CHECK-NEXT: end_access [[READ]] : $*Int
+
+      // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] [[BOXADDR]] : $*DidSetWillSetTests
+      // CHECK-NEXT: // function_ref properties.DidSetWillSetTests.a.setter : Swift.Int
+      // CHECK-NEXT: [[SETTERFN:%.*]] = function_ref @$S10properties{{[_0-9a-zA-Z]*}}Sivs : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+      // CHECK-NEXT: apply [[SETTERFN]]([[ZERO]], [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+      // CHECK-NEXT: end_access [[WRITE]] : $*DidSetWillSetTests
+    }
+
+    // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vW
+    didSet {
+      (self).a = zero  // reassign, but don't infinite loop, as accessing on 'self'.
+
+      // CHECK: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
+      // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
+      // CHECK-NEXT: [[ZERORAW:%.*]] = apply [[ZEROFN]]() : $@convention(thin) () -> Builtin.RawPointer
+      // CHECK-NEXT: [[ZEROADDR:%.*]] = pointer_to_address [[ZERORAW]] : $Builtin.RawPointer to [strict] $*Int
+      // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [dynamic] [[ZEROADDR]] : $*Int
+      // CHECK-NEXT: [[ZERO:%.*]] = load [trivial] [[READ]]
+      // CHECK-NEXT: end_access [[READ]] : $*Int
+      // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] %1
+      // CHECK-NEXT: [[AADDR:%.*]] = struct_element_addr [[WRITE]] : $*DidSetWillSetTests, #DidSetWillSetTests.a
+      // CHECK-NEXT: assign [[ZERO]] to [[AADDR]]
+
+      var unrelatedValue = DidSetWillSetTests.defaultValue
+
+      // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "unrelatedValue"
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
+      // CHECK-NEXT: [[METATYPE:%.*]] = metatype $@thin DidSetWillSetTests.Type
+      // CHECK-NEXT: // function_ref static properties.DidSetWillSetTests.defaultValue.getter : properties.DidSetWillSetTests
+      // CHECK-NEXT: [[DEFAULTVALUE_FN:%.*]] = function_ref @$S10properties{{[_0-9a-zA-Z]*}}vgZ : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
+      // CHECK-NEXT: [[DEFAULTRESULT:%.*]] = apply [[DEFAULTVALUE_FN]]([[METATYPE]]) : $@convention(method) (@thin DidSetWillSetTests.Type) -> DidSetWillSetTests
+      // CHECK-NEXT: store [[DEFAULTRESULT]] to [trivial] [[BOXADDR]] : $*DidSetWillSetTests
+
+      // But if we re-assign to the property when 'self' is not the base, we should not access directly
+      // (even though in this example, we *will* infinitely recurse).
+      unrelatedValue.a = zero
+
+      // CHECK-NEXT: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
+      // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
+      // CHECK-NEXT: [[ZERORAW:%.*]] = apply [[ZEROFN]]() : $@convention(thin) () -> Builtin.RawPointer
+      // CHECK-NEXT: [[ZEROADDR:%.*]] = pointer_to_address [[ZERORAW]] : $Builtin.RawPointer to [strict] $*Int
+      // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [dynamic] [[ZEROADDR]] : $*Int
+      // CHECK-NEXT: [[ZERO:%.*]] = load [trivial] [[READ]]
+      // CHECK-NEXT: end_access [[READ]] : $*Int
+
+      // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] [[BOXADDR]] : $*DidSetWillSetTests
+      // CHECK-NEXT: // function_ref properties.DidSetWillSetTests.a.setter : Swift.Int
+      // CHECK-NEXT: [[SETTERFN:%.*]] = function_ref @$S10properties{{[_0-9a-zA-Z]*}}Sivs : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+      // CHECK-NEXT: apply [[SETTERFN]]([[ZERO]], [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+      // CHECK-NEXT: end_access [[WRITE]] : $*DidSetWillSetTests
+
+      // Even if the value of the base happens to be self...
+      var other = self
+
+      // CHECK: [[BOX:%.*]] = alloc_box ${ var DidSetWillSetTests }, var, name "other"
+      // CHECK-NEXT: [[BOXADDR:%.*]] = project_box [[BOX]] : ${ var DidSetWillSetTests }, 0
+      // CHECK-NEXT: [[READ_SELF:%.*]] = begin_access [read] [unknown] %1 : $*DidSetWillSetTests
+      // CHECK-NEXT: copy_addr [[READ_SELF]] to [initialization] [[BOXADDR]] : $*DidSetWillSetTests
+      // CHECK-NEXT: end_access [[READ_SELF]] : $*DidSetWillSetTests
+
+      other.a = zero
+
+      // CHECK-NEXT: // function_ref properties.zero.unsafeMutableAddressor : Swift.Int
+      // CHECK-NEXT: [[ZEROFN:%.*]] = function_ref @$S10properties4zero{{[_0-9a-zA-Z]*}}vau
+      // CHECK-NEXT: [[ZERORAW:%.*]] = apply [[ZEROFN]]() : $@convention(thin) () -> Builtin.RawPointer
+      // CHECK-NEXT: [[ZEROADDR:%.*]] = pointer_to_address [[ZERORAW]] : $Builtin.RawPointer to [strict] $*Int
+      // CHECK-NEXT: [[READ:%.*]] = begin_access [read] [dynamic] [[ZEROADDR]] : $*Int
+      // CHECK-NEXT: [[ZERO:%.*]] = load [trivial] [[READ]]
+      // CHECK-NEXT: end_access [[READ]] : $*Int
+
+      // CHECK-NEXT: [[WRITE:%.*]] = begin_access [modify] [unknown] [[BOXADDR]] : $*DidSetWillSetTests
+      // CHECK-NEXT: // function_ref properties.DidSetWillSetTests.a.setter : Swift.Int
+      // CHECK-NEXT: [[SETTERFN:%.*]] = function_ref @$S10properties{{[_0-9a-zA-Z]*}}Sivs : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+      // CHECK-NEXT: apply [[SETTERFN]]([[ZERO]], [[WRITE]]) : $@convention(method) (Int, @inout DidSetWillSetTests) -> ()
+      // CHECK-NEXT: end_access [[WRITE]] : $*DidSetWillSetTests
+    }
+  }
+}

--- a/test/SILGen/properties_swift5.swift
+++ b/test/SILGen/properties_swift5.swift
@@ -1,5 +1,5 @@
 
-// RUN: %target-swift-frontend -swift-version 5 -module-name properties -Xllvm -sil-full-demangle -parse-as-library -emit-silgen -disable-objc-attr-requires-foundation-module %s | %FileCheck %s
+// RUN: %target-swift-frontend -swift-version 5 -module-name properties -Xllvm -sil-full-demangle -parse-as-library -emit-silgen %s | %FileCheck %s
 
 var zero: Int = 0
 


### PR DESCRIPTION
Currently we always directly access a member when mutating it in its own didSet/willSet observer (in order to prevent infinite recursion). However we do this even when accessing the same member on a *different* instance.

This PR changes the behaviour such that only member accesses on the implicit 'self' declaration are accessed directly within that member's own willSet/didSet.

Note that this change has the potential to cause recursion in cases where it didn't previously, for example this will now infinitely recurse:

    struct S {
      var i = 0 {
        didSet {
          var s = self
          s.i = 5
        }
      }
    }

    var s = S()
    s.i = 2

I don't know how serious this impact is though.

Resolves [SR-419](https://bugs.swift.org/browse/SR-419).
