### PR TITLE
[silgen] When emitting a vtable thunk, verify the thunk after emissio…

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3404,6 +3404,10 @@ SILGenFunction::emitVTableThunk(SILDeclRef derived,
   
   scope.pop();
   B.createReturn(loc, result);
+
+  // Now that the thunk body has been completely emitted, verify the
+  // body early.
+  F.verify();
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
…n rather than when we tear down the SILGenModule.

This makes it easier to find bugs in the vtable thunk emission code since we
just error right where we emit the thunk.