### PR TITLE
IDE: Don't crash in type reconstruction if local types contain subscripts

### DIFF
--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -583,6 +583,13 @@ FindNamedDecls(ASTContext *ast, const DeclBaseName &name, VisitNodeResult &resul
         }
 
       } else if (auto FD = dyn_cast<AbstractFunctionDecl>(parent_decl)) {
+        // FIXME: We should not end up here at all. For some reason we're trying
+        // to look up members of a local type inside the parent context of the
+        // local type.
+        //
+        // This code path is broken and is about to be replaced.
+        if (name.isSpecial())
+          return result._decls.size();
 
         // Do a local lookup into the function, using the end loc to approximate
         // being able to see all the local variables.

--- a/test/IDE/reconstruct_type_from_mangled_name.swift
+++ b/test/IDE/reconstruct_type_from_mangled_name.swift
@@ -257,9 +257,27 @@ func hasLocalDecls() {
 
   // FIXME
   // CHECK: decl: FAILURE for 'LocalType'
-  // The following is the implicit ctor
-  // CHECK: decl: FAILURE for ''
-  struct LocalType {}
+  struct LocalType {
+    // CHECK: FAILURE for 'localMethod'
+    func localMethod() {}
+
+    // CHECK: FAILURE for 'subscript'
+    subscript(x: Int) { get {} set {} }
+
+    // CHECK: decl: FAILURE for ''
+    // CHECK: decl: FAILURE for ''
+    // CHECK: decl: FAILURE for ''
+
+  }
+
+  // FIXME
+  // CHECK: decl: FAILURE for 'LocalClass'
+  class LocalClass {
+    // CHECK: FAILURE for 'deinit'
+    deinit {}
+
+    // CHECK: decl: FAILURE for ''
+  }
 
   // CHECK: decl: FAILURE for 'LocalAlias'
   typealias LocalAlias = LocalType


### PR DESCRIPTION
This is just a workaround to unblock something else I'm doing.
We're still not able to find the local declarations properly.