### PR TITLE
[CSApply] Don't try to force propagate l-value access in "shallow" mode

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2031,8 +2031,7 @@ public:
   /// Call Expr::propagateLValueAccessKind on the given expression,
   /// using a custom accessor for the type on the expression that
   /// reads the type from the ConstraintSystem expression type map.
-  void propagateLValueAccessKind(Expr *E,
-                                 AccessKind accessKind,
+  void propagateLValueAccessKind(Expr *E, AccessKind accessKind, bool isShallow,
                                  bool allowOverwrite = false);
 
   /// Call Expr::isTypeReference on the given expression, using a

--- a/validation-test/compiler_crashers_2_fixed/0146-rdar38309176.swift
+++ b/validation-test/compiler_crashers_2_fixed/0146-rdar38309176.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift %s
+
+func foo(_ msg: Int) {}
+func foo(_ msg: Double) {}
+
+func rdar38309176(_ errors: inout [String]) {
+  foo("error: \(errors[0])") // expected-error {{cannot invoke 'foo' with an argument list of type '(String)'}}
+  // expected-note@-1 {{overloads for 'foo' exist with these partially matching parameter lists: (Int), (Double)}}
+}


### PR DESCRIPTION
Some of the expressions call into `typeCheckExpressionShallow` while trying to
apply solutions, we need to respect the fact that sub-expressions might be
already properly type-checked while propagating l-value access kind.

Resolves: rdar://problem/38309176

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
