### PR TITLE
build-script: Implement support for --(no-)lldb-assertions

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -490,6 +490,8 @@ class BuildScriptInvocation(object):
                 args.swift_analyze_code_coverage).lower(),
             "--llbuild-enable-assertions", str(
                 args.llbuild_assertions).lower(),
+            "--lldb-assertions", str(
+                args.lldb_assertions).lower(),
             "--cmake-generator", args.cmake_generator,
             "--build-jobs", str(args.build_jobs),
             "--common-cmake-options=%s" % ' '.join(

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -59,6 +59,7 @@ KNOWN_SETTINGS=(
     lldb-test-swift-only        "1"               "when running lldb tests, only include Swift-specific tests"
     lldb-no-debugserver         ""               "delete debugserver after building it, and don't try to codesign it"
     lldb-use-system-debugserver ""               "don't try to codesign debugserver, and use the system's debugserver instead"
+    lldb-assertions             "1"              "build lldb with assertions enabled"
     llvm-build-type             "Debug"          "the CMake build variant for LLVM and Clang (Debug, RelWithDebInfo, Release, MinSizeRel).  Defaults to Debug."
     swift-build-type            "Debug"          "the CMake build variant for Swift"
     swift-enable-assertions     "1"              "enable assertions in Swift"
@@ -1779,6 +1780,12 @@ function set_lldb_xcodebuild_options() {
 	    "${lldb_xcodebuild_options[@]}"
 	    ENABLE_UNDEFINED_BEHAVIOR_SANITIZER="YES"
 	    -enableUndefinedBehaviorSanitizer=YES
+	)
+    fi
+    if [[ "$(true_false ${LLDB_ASSERTIONS})" == "FALSE" ]]; then
+	lldb_xcodebuild_options=(
+	    "${lldb_xcodebuild_options[@]}"
+	    OTHER_CFLAGS="-DNDEBUG"
 	)
     fi
 }

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -108,6 +108,9 @@ def _apply_default_arguments(args):
     if args.llbuild_assertions is None:
         args.llbuild_assertions = args.assertions
 
+    if args.lldb_assertions is None:
+        args.lldb_assertions = args.assertions
+
     # Set the default CMake generator.
     if args.cmake_generator is None:
         args.cmake_generator = 'Ninja'

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -136,7 +136,7 @@ EXPECTED_DEFAULTS = {
     'libicu_build_variant': 'Debug',
     'lit_args': '-sv',
     'llbuild_assertions': True,
-    'lldb_assertions': None,
+    'lldb_assertions': True,
     'lldb_build_variant': 'Debug',
     'lldb_build_with_xcode': '1',
     'llvm_assertions': True,


### PR DESCRIPTION
* LLDB assertions are on by default, like swift assertions

* LLDB assertions can be enabled/disabled globally with the --assertions
  and --no-assertions options

Partially addresses: rdar://38524846