### PR TITLE
AST: Fix for name lookup not finding initializers in protocols

### DIFF
--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1709,7 +1709,8 @@ bool DeclContext::lookupQualified(Type type,
     // Filter out designated initializers, if requested.
     if (onlyCompleteObjectInits) {
       if (auto ctor = dyn_cast<ConstructorDecl>(decl)) {
-        if (!ctor->isInheritable())
+        if (isa<ClassDecl>(ctor->getDeclContext()) &&
+            !ctor->isInheritable())
           return false;
       } else {
         return false;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2472,19 +2472,6 @@ ConstraintSystem::simplifyConstructionConstraint(
     return SolutionKind::Error;
   }
 
-  NameLookupOptions lookupOptions = defaultConstructorLookupOptions;
-  if (isa<AbstractFunctionDecl>(useDC))
-    lookupOptions |= NameLookupFlags::KnownPrivate;
-
-  auto instanceType = valueType;
-  if (auto *selfType = instanceType->getAs<DynamicSelfType>())
-    instanceType = selfType->getSelfType();
-
-  auto ctors = TC.lookupConstructors(useDC, instanceType, lookupOptions);
-  if (!ctors)
-    return SolutionKind::Error;
-
-  auto name = DeclBaseName::createConstructor();
   auto applyLocator = getConstraintLocator(locator,
                                            ConstraintLocator::ApplyArgument);
   auto fnLocator = getConstraintLocator(locator,
@@ -2497,7 +2484,8 @@ ConstraintSystem::simplifyConstructionConstraint(
   // The constructor will have function type T -> T2, for a fresh type
   // variable T. T2 is the result type provided via the construction
   // constraint itself.
-  addValueMemberConstraint(MetatypeType::get(valueType, TC.Context), name,
+  addValueMemberConstraint(MetatypeType::get(valueType, TC.Context),
+                           DeclBaseName::createConstructor(),
                            FunctionType::get(tv, resultType),
                            useDC, functionRefKind,
                            getConstraintLocator(

--- a/test/Generics/superclass_constraint.swift
+++ b/test/Generics/superclass_constraint.swift
@@ -188,3 +188,20 @@ protocol X {
 // CHECK-DAG: .noRedundancyWarning@
 // CHECK: Generic signature: <C where C : X, C.Y == B>
 func noRedundancyWarning<C : X>(_ wrapper: C) where C.Y == B {}
+
+// Qualified lookup bug -- <https://bugs.swift.org/browse/SR-2190>
+
+protocol Init {
+  init(x: ())
+}
+
+class Base {
+  required init(y: ()) {}
+}
+
+class Derived : Base {}
+
+func g<T : Init & Derived>(_: T.Type) {
+  _ = T(x: ())
+  _ = T(y: ())
+}

--- a/test/decl/protocol/special/coding/class_codable_inheritance_diagnostics.swift
+++ b/test/decl/protocol/special/coding/class_codable_inheritance_diagnostics.swift
@@ -42,9 +42,9 @@ class FailableNonDecodableSub : FailableNonDecodableSuper, Decodable { // expect
 
 // Subclasses of classes whose Decodable synthesis fails should not inherit
 // conformance.
-class FailedSynthesisDecodableSuper : Decodable { // expected-error {{type 'FailedSynthesisDecodableSuper' does not conform to protocol 'Decodable'}}
+class FailedSynthesisDecodableSuper : Decodable { // expected-error 2{{type 'FailedSynthesisDecodableSuper' does not conform to protocol 'Decodable'}}
   enum CodingKeys : String, CodingKey {
-    case nonexistent // expected-note {{CodingKey case 'nonexistent' does not match any stored properties}}
+    case nonexistent // expected-note 2{{CodingKey case 'nonexistent' does not match any stored properties}}
   }
 }
 


### PR DESCRIPTION
If a generic parameter has both a class and protocol constraint,
walking up to the class's superclass would cause us to subsequently
ignore any initializer requirements in the protocol.

Fixes <https://bugs.swift.org/browse/SR-1663>, <rdar://problem/22722738>.