### PR TITLE
[4.2] Allow ownership keywords on properties in @objc protocols.

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2163,8 +2163,10 @@ void TypeChecker::checkReferenceOwnershipAttr(VarDecl *var,
 
     diagnose(var->getStartLoc(), D, (unsigned) ownershipKind, underlyingType);
     attr->setInvalid();
-  } else if (dyn_cast<ProtocolDecl>(var->getDeclContext())) {
-    // Ownership does not make sense in protocols.
+  } else if (isa<ProtocolDecl>(var->getDeclContext()) &&
+             !cast<ProtocolDecl>(var->getDeclContext())->isObjC()) {
+    // Ownership does not make sense in protocols, except for "weak" on
+    // properties of Objective-C protocols.
     if (Context.isSwiftVersionAtLeast(5))
       diagnose(attr->getLocation(),
         diag::ownership_invalid_in_protocols,

--- a/test/PrintAsObjC/protocols.swift
+++ b/test/PrintAsObjC/protocols.swift
@@ -190,5 +190,17 @@ extension NSString : A, ZZZ {}
 // CHECK-LABEL: @interface Subclass : RootClass1 <ZZZ>{{$}}
 @objc class Subclass : RootClass1, ZZZ {}
 
+// CHECK-LABEL: @protocol UnownedProperty
+// CHECK-NEXT: @property (nonatomic, assign) id _Nonnull unownedProp;
+@objc protocol UnownedProperty {
+  unowned var unownedProp: AnyObject { get set }
+}
+
+// CHECK-LABEL: @protocol WeakProperty
+// CHECK-NEXT: @property (nonatomic, weak) id _Nullable weakProp;
+@objc protocol WeakProperty {
+  weak var weakProp: AnyObject? { get set }
+}
+
 // Deliberately at the end of the file.
 @objc protocol ZZZ {}

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2294,3 +2294,13 @@ class BadClass {
   @_versioned @objc dynamic func badMethod2() {}
   // expected-error@-1 {{'@_versioned' attribute cannot be applied to 'dynamic' declarations}}
 }
+
+@objc
+protocol ObjCProtocolWithWeakProperty {
+   weak var weakProp: AnyObject? { get set } // okay
+}
+
+@objc
+protocol ObjCProtocolWithUnownedProperty {
+   unowned var unownedProp: AnyObject { get set } // okay
+}


### PR DESCRIPTION
Ownership keywords (weak/unmanaged) in @objc protocols do have an
effect on the generated header, because they get reflected as
weak/assign in the Objective-C `@property`. Therefore, allow these
keywords (again) on properties of @objc protocols.

Fixes SR-7182 / rdar://problem/38418112 / rdar://problem/38548361.