### PR TITLE
[Parse] Enable self rebinding (to self)

### DIFF
--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1537,6 +1537,7 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
   }
       
   case tok::identifier:  // foo
+  case tok::kw_self:     // self
     // Attempt to parse for 'type(of: <expr>)'.
     if (canParseTypeOf(*this)) {
       return parseExprTypeOf();
@@ -1571,7 +1572,6 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
     }
 
     LLVM_FALLTHROUGH;
-  case tok::kw_self:     // self
   case tok::kw_Self:     // Self
     return makeParserResult(parseExprIdentifier());
 

--- a/test/Parse/self_rebinding.swift
+++ b/test/Parse/self_rebinding.swift
@@ -1,0 +1,60 @@
+// RUN: %target-typecheck-verify-swift
+
+class Writer {
+    private var articleWritten = 47
+
+    func stop() {
+        let rest: () -> Void = { [weak self] in
+            let articleWritten = self?.articleWritten ?? 0
+            guard let `self` = self else {
+                return
+            }
+
+            self.articleWritten = articleWritten
+        }
+
+        fatalError("I'm running out of time")
+        rest()
+    }
+
+    func nonStop() {
+        let write: () -> Void = { [weak self] in
+            self?.articleWritten += 1
+
+            if let self = self {
+                self.articleWritten += 1
+            }
+
+            if let `self` = self {
+                self.articleWritten += 1
+            }
+
+            guard let self = self else {
+                return
+            }
+
+            self.articleWritten += 1
+        }
+
+        write()
+    }
+}
+
+struct T {
+    var mutable: Int = 0
+    func f() {
+        // expected-error @+2 {{keyword 'self' cannot be used as an identifier here}}
+        // expected-note @+1 {{if this name is unavoidable, use backticks to escape it}}
+        let self = self
+    }
+}
+
+class MyCls {
+    func something() {}
+
+    func test() {
+        // expected-warning @+1 {{initialization of immutable value 'self' was never used}}
+        let `self` = Writer() // Even if `self` is shadowed,
+        something() // this should still refer `MyCls.something`.
+    }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
As discussed in this [thread](https://forums.swift.org/t/the-future-of-weak-self-rebinding/10846), this patch allows "self" to be an identifier bound to `self` (see added tests for examples), and is useful in closures where `self` is weakly captured to avoid retain cycles. The current behavior of allowing 

```swift
guard let `self` = self else { ... }
```

remains for source compatibility.

Instead of parsing identifiers and fallthrough to parsing self, treat `kw_self` the same as identifiers.