### PR TITLE
[Sema] Don't allow member type lookup on existential types

### DIFF
--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -326,16 +326,16 @@ bool TypeChecker::isUnsupportedMemberTypeAccess(Type type, TypeDecl *typeDecl) {
     return true;
   }
 
-  // We don't allow lookups of an associated type or typealias of an
-  // existential type, because we have no way to represent such types.
-  if (typeDecl->getDeclContext()->getAsProtocolOrProtocolExtensionContext()) {
-    if (type->isExistentialType() &&
-        (isa<TypeAliasDecl>(typeDecl) ||
-         isa<AssociatedTypeDecl>(typeDecl))) {
-      if (memberType->hasTypeParameter()) {
-        return true;
-      }
-    }
+  if (type->isExistentialType() &&
+      typeDecl->getDeclContext()->getAsProtocolOrProtocolExtensionContext()) {
+    // TODO: Temporarily allow typealias and associated type lookup on
+    //       existential type iff it doesn't have any type parameters.
+    if (isa<TypeAliasDecl>(typeDecl) || isa<AssociatedTypeDecl>(typeDecl))
+      return memberType->hasTypeParameter();
+
+    // Don't allow lookups of nested types of an existential type,
+    // because there is no way to represent such types.
+    return true;
   }
 
   return false;

--- a/test/decl/nested/protocol.swift
+++ b/test/decl/nested/protocol.swift
@@ -52,12 +52,10 @@ protocol Racoon {
 }
 
 enum SillyRawEnum : SillyProtocol.InnerClass {}
-// expected-error@-1 {{reference to generic type 'SillyProtocol.InnerClass' requires arguments in <...>}}
-// expected-error@-2 {{type 'SillyRawEnum' does not conform to protocol 'RawRepresentable'}}
+// expected-error@-1 {{type 'SillyRawEnum' does not conform to protocol 'RawRepresentable'}}
 
 protocol SillyProtocol {
   class InnerClass<T> {} // expected-error {{type 'InnerClass' cannot be nested in protocol 'SillyProtocol'}}
-  // expected-note@-1 {{generic type 'InnerClass' declared here}}
 }
 
 enum OuterEnum {

--- a/validation-test/compiler_crashers_2_fixed/0147-rdar38505436.swift
+++ b/validation-test/compiler_crashers_2_fixed/0147-rdar38505436.swift
@@ -1,0 +1,23 @@
+// RUN: not %target-typecheck-verify-swift %s
+
+protocol P1 {
+  class N1 {
+    init() {}
+  }
+}
+
+protocol P2 {}
+
+extension P2 {
+  class N2 {
+    init() {}
+  }
+}
+
+class C1: P1.N1 {
+  override init() {}
+}
+
+class C2: P2.N2 {
+  override init() {}
+}


### PR DESCRIPTION
Existential types don't support nested types so let's not
allow the lookup to make such access, with only exception
for typealias or associated types without type parameters,
they are currently allowed.

Resolves: rdar://problem/38505436

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
