### PR TITLE
Prevent associated type witnesses from referring to Objective-C type parameters.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1503,6 +1503,10 @@ ERROR(type_witness_not_accessible_type,none,
       "%0 %1 must be as accessible as its enclosing type because it "
       "matches a requirement in protocol %3",
       (DescriptiveDeclKind, DeclName, AccessLevel, DeclName))
+ERROR(type_witness_objc_generic_parameter,none,
+      "type %0 involving Objective-C type parameter%select{| %1}2 cannot be "
+      "used for associated type %3 of protocol %4",
+      (Type, Type, bool, DeclName, DeclName))
 
 ERROR(protocol_refine_access,none,
       "%select{protocol must be declared %select{"

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -552,6 +552,11 @@ class ConformanceChecker : public WitnessChecker {
   /// Record that the given requirement has no valid witness.
   void recordInvalidWitness(ValueDecl *requirement);
 
+  /// Check for ill-formed uses of Objective-C generics in a type witness.
+  bool checkObjCTypeErasedGenerics(AssociatedTypeDecl *assocType,
+                                   Type type,
+                                   TypeDecl *typeDecl);
+
   /// Record a type witness.
   ///
   /// \param assocType The associated type whose witness is being recorded.

--- a/test/ClangImporter/objc_generics_conformance.swift
+++ b/test/ClangImporter/objc_generics_conformance.swift
@@ -1,0 +1,33 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -verify -swift-version 4 -I %S/Inputs/custom-modules %s
+
+// REQUIRES: objc_interop
+
+// Objective-C generic classes can conform to protocols, but for type witnesses
+// (for associated types) cannot depend on the type parameters.
+
+import Foundation
+import objc_generics
+
+// rdar://problem/34979938
+protocol WithAssocT {
+  associatedtype T
+}
+
+extension GenericClass : WithAssocT { // expected-error{{type 'T' involving Objective-C type parameter 'T' cannot be used for associated type 'T' of protocol 'WithAssocT'}}
+}
+
+protocol WithAssocOther {
+  associatedtype Other
+}
+
+extension GenericClass : WithAssocOther {
+  typealias Other = [T] // expected-error{{'GenericClass.Other' involving Objective-C type parameter cannot be used for associated type 'Other' of protocol 'WithAssocOther'}}
+}
+
+protocol WithAssocElement {
+  associatedtype Element
+}
+
+extension GenericClass : WithAssocElement {
+  typealias Element = Int
+}

--- a/test/SILGen/objc_imported_generic.swift
+++ b/test/SILGen/objc_imported_generic.swift
@@ -73,14 +73,6 @@ public protocol ThingHolder {
   var propertyArrayOfThings: [Thing]? { get set }
 }
 
-// TODO: Crashes in IRGen because the type metadata for `T` is not found in
-// the witness thunk to satisfy the associated type requirement. This could be
-// addressed by teaching IRGen to fulfill erased type parameters from protocol
-// witness tables (rdar://problem/26602097).
-#if !IRGEN_INTEGRATION_TEST
-extension GenericClass: ThingHolder {}
-#endif
-
 public protocol Ansible: class {
   associatedtype Anser: ThingHolder
 }


### PR DESCRIPTION
Objective-C type parameters are not recoverable from an instance of
a generic Objective-C class, so we cannot refer to them anywhere in
type metadata. However, they could slip in via associated type
inference, which bypassed the existing checks. This would always crash
later in IRGen; ban it in the type checker so that doesn't happen.

Fixes rdar://problem/34979938.
