### PR TITLE
SILGen: Fix issues with class-constrained generics and keypaths.

### DIFF
--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -309,15 +309,16 @@ bool SILType::canRefCast(SILType operTy, SILType resultTy, SILModule &M) {
 }
 
 SILType SILType::getFieldType(VarDecl *field, SILModule &M) const {
-  assert(field->getDeclContext() == getNominalOrBoundGenericNominal());
+  auto baseTy = getSwiftRValueType();
+
   AbstractionPattern origFieldTy = M.Types.getAbstractionPattern(field);
   CanType substFieldTy;
   if (field->hasClangNode()) {
     substFieldTy = origFieldTy.getType();
   } else {
     substFieldTy =
-      getSwiftRValueType()->getTypeOfMember(M.getSwiftModule(),
-                                            field, nullptr)->getCanonicalType();
+      baseTy->getTypeOfMember(M.getSwiftModule(),
+                              field, nullptr)->getCanonicalType();
   }
   auto loweredTy = M.Types.getLoweredType(origFieldTy, substFieldTy);
   if (isAddress() || getClassOrBoundGenericClass() != nullptr) {

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -209,9 +209,12 @@ void verifyKeyPathComponent(SILModule &M,
   switch (auto kind = component.getKind()) {
   case KeyPathPatternComponent::Kind::StoredProperty: {
     auto property = component.getStoredPropertyDecl();
-    require(property->getDeclContext()
-             == baseTy->getAnyNominal(),
-            "property decl should be a member of the component base type");
+    auto fieldTy = baseTy->getTypeOfMember(M.getSwiftModule(), property)
+                         ->getReferenceStorageReferent()
+                         ->getCanonicalType();
+    require(fieldTy == componentTy,
+            "property decl should be a member of the base with the same type "
+            "as the component");
     switch (property->getStorageKind()) {
     case AbstractStorageDecl::Stored:
     case AbstractStorageDecl::StoredWithObservers:

--- a/test/SILGen/keypaths.swift
+++ b/test/SILGen/keypaths.swift
@@ -24,6 +24,10 @@ class C<T> {
   init() { fatalError() }
 }
 
+extension C {
+  var `extension`: S<T> { fatalError() }
+}
+
 protocol P {
   var x: Int { get }
   var y: String { get set }
@@ -38,6 +42,11 @@ extension P {
     nonmutating set { }
   }
 }
+
+/* TODO: When we support superclass requirements on protocols, we should test
+ * this case as well.
+protocol PoC : C<Int> {}
+*/
 
 // CHECK-LABEL: sil hidden @{{.*}}storedProperties
 func storedProperties<T>(_: T) {
@@ -337,4 +346,42 @@ func subscripts<T: Hashable, U: Hashable>(x: T, y: U, s: String) {
 
   _ = \Subscripts<T>.[Bass()]
   _ = \Subscripts<T>.[Treble()]
+}
+
+// CHECK-LABEL: sil hidden @{{.*}}subclass_generics
+func subclass_generics<T: C<Int>, U: C<V>, V/*: PoC*/>(_: T, _: U, _: V) {
+  _ = \T.x
+  _ = \T.z
+  _ = \T.computed
+  _ = \T.extension
+
+  _ = \U.x
+  _ = \U.z
+  _ = \U.computed
+  _ = \U.extension
+
+/*
+  _ = \V.x
+  _ = \V.z
+  _ = \V.computed
+  _ = \V.extension
+ */
+
+  _ = \(C<Int> & P).x
+  _ = \(C<Int> & P).z
+  _ = \(C<Int> & P).computed
+  _ = \(C<Int> & P).extension
+
+  _ = \(C<V> & P).x
+  _ = \(C<V> & P).z
+  _ = \(C<V> & P).computed
+  _ = \(C<V> & P).extension
+
+/* TODO: When we support superclass requirements on protocols, we should test
+ * this case as well.
+  _ = \PoC.x
+  _ = \PoC.z
+  _ = \PoC.computed
+  _ = \PoC.extension
+ */
 }


### PR DESCRIPTION
- Fix some type system issues with looking up member types in/out of context.
- Correctly upcast a class-constrained existential or archetype to the base class when referencing a base class field on a generic type.

Fixes SR-7106 | rdar://problem/38070998.