### PR TITLE
[CMake] Unbreak unified builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,10 @@ option(SWIFT_INCLUDE_DOCS
     "Create targets for building docs."
     TRUE)
 
+option(SWIFT_STDLIB_ENABLE_RESILIENCE
+    "Build the Swift stdlib and overlays with resilience enabled."
+    TRUE)
+
 #
 # Miscellaneous User-configurable options.
 #


### PR DESCRIPTION
Tests are starting to fail if SWIFT_STDLIB_ENABLE_RESILIENCE does not default to true (the build-script sets this to true by default). For example, see the discussion in #15248.