### PR TITLE
[benchmark] Add a new utility script called Benchmark_QuickCheck.

### DIFF
--- a/benchmark/scripts/Benchmark_QuickCheck.in
+++ b/benchmark/scripts/Benchmark_QuickCheck.in
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+
+# ===--- Benchmark_QuickCheck.in -----------------------------------------===//
+#
+#  This source file is part of the Swift.org open source project
+#
+#  Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+#  Licensed under Apache License v2.0 with Runtime Library Exception
+#
+#  See https://swift.org/LICENSE.txt for license information
+#  See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+# ===---------------------------------------------------------------------===//
+
+import json
+import os
+import subprocess
+import sys
+
+sys.path.append("@PATH_TO_DRIVER_LIBRARY@")
+
+import perf_test_driver  # noqa (E402 module level import not at top of file)
+
+# This is a hacked up XFAIL list. It should really be a json file, but it will
+# work for now. Add in the exact name of the pass to XFAIL.
+XFAIL_LIST = [
+]
+
+
+class QuickCheckResult(perf_test_driver.Result):
+
+    def __init__(self, name, success):
+        assert(isinstance(success, bool))
+        did_fail = not success
+        perf_test_driver.Result.__init__(self, name, did_fail, "", XFAIL_LIST)
+
+    def print_data(self, max_test_len):
+        fmt = '{:<%d}{:<10}' % (max_test_len + 5)
+        print(fmt.format(self.get_name(), self.get_result()))
+
+
+class QuickCheckBenchmarkDriver(perf_test_driver.BenchmarkDriver):
+
+    def __init__(self, binary, xfail_list, num_iters):
+        perf_test_driver.BenchmarkDriver.__init__(
+            self, binary, xfail_list,
+            enable_parallel=True)
+        self.num_iters = num_iters
+
+    def print_data_header(self, max_test_len):
+        fmt = '{:<%d}{:<10}{:}' % (max_test_len + 5)
+        print(fmt.format('Name', 'Result', 'RC Delta'))
+
+    # Propagate any data from this class that is needed for individual
+    # tests. The reason this is needed is to avoid issues with attempting to
+    # access a value in a different process.
+    def prepare_input(self, name):
+        return {'num_samples': 1, 'num_iters': self.num_iters}
+
+    def run_test_inner(self, data, num_iters):
+        p = subprocess.Popen([
+            data['path'],
+            "--num-samples={}".format(data['num_samples']),
+            "--num-iters={}".format(num_iters), data['test_name']],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        error_out = p.communicate()[1].split("\n")
+        result = p.returncode
+        if result is None:
+            raise RuntimeError("Expected one line of output")
+        if result != 0:
+            raise RuntimeError("Process segfaulted")
+        return error_out
+
+    def run_test(self, data, num_iters):
+        try:
+            args = [data, num_iters]
+            result = perf_test_driver.run_with_timeout(self.run_test_inner,
+                                                       args)
+        except Exception, e:
+            sys.stderr.write("Child Process Failed! (%s,%s). Error: %s\n" % (
+                data['path'], data['test_name'], e))
+            sys.stderr.flush()
+            return None
+        return True
+
+    def process_input(self, data):
+        test_name = '({},{})'.format(data['opt'], data['test_name'])
+        print("Running {}...".format(test_name))
+        sys.stdout.flush()
+        if self.run_test(data, data['num_iters']) is None:
+            return QuickCheckResult(test_name, success=False)
+        return QuickCheckResult(test_name, success=True)
+
+
+SWIFT_BIN_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+def parse_args():
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-filter', type=str, default=None,
+        help='Filter out any test that does not match the given regex')
+    parser.add_argument('-num-iters', type=int, default=2)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    l = QuickCheckBenchmarkDriver(SWIFT_BIN_DIR, XFAIL_LIST, args.num_iters)
+    if l.run(args.filter):
+        sys.exit(0)
+    else:
+        sys.exit(-1)

--- a/benchmark/scripts/CMakeLists.txt
+++ b/benchmark/scripts/CMakeLists.txt
@@ -9,6 +9,10 @@ configure_file(
   ${CMAKE_CURRENT_BINARY_DIR}/Benchmark_RuntimeLeaksRunner
   @ONLY)
 configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/Benchmark_QuickCheck.in
+  ${CMAKE_CURRENT_BINARY_DIR}/Benchmark_QuickCheck
+  @ONLY)
+configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/Benchmark_DTrace.in
   ${CMAKE_CURRENT_BINARY_DIR}/Benchmark_DTrace
   @ONLY)
@@ -20,6 +24,11 @@ file(COPY ${CMAKE_CURRENT_BINARY_DIR}/Benchmark_GuardMalloc
      GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 
 file(COPY ${CMAKE_CURRENT_BINARY_DIR}/Benchmark_RuntimeLeaksRunner
+     DESTINATION "${swift-bin-dir}"
+     FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ
+     GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+
+file(COPY ${CMAKE_CURRENT_BINARY_DIR}/Benchmark_QuickCheck
      DESTINATION "${swift-bin-dir}"
      FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ
      GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)


### PR DESCRIPTION
This benchmark script is similar to the guard malloc/runtime runner, but it only
runs the tests. The intention is that one can use this to quickly in a
multithreaded way verify that all benchmarks run successfully. In contrast, the
normal driver will run only single threaded since it is meant to test
performance, so is not able to take advantage of all cores on a system.

I wrote this quickly to verify some benchmark tests still worked. No point in
not sharing with everyone else.
