### PR TITLE
[SwiftSyntax] Add replace method to SyntaxCollections

### DIFF
--- a/test/SwiftSyntax/SyntaxCollections.swift
+++ b/test/SwiftSyntax/SyntaxCollections.swift
@@ -24,6 +24,7 @@ SyntaxCollectionsAPI.test("AppendingElement") {
     let newArrayElementList = arrayElementList.appending(integerLiteralElement(1))
     
     expectEqual(newArrayElementList.count, 2)
+    expectNotNil(newArrayElementList.child(at: 1))
     expectEqual("\(newArrayElementList.child(at: 1)!)", "1")
 }
 
@@ -35,11 +36,13 @@ SyntaxCollectionsAPI.test("InsertingElement") {
     var newArrayElementList = arrayElementList.inserting(integerLiteralElement(0), at: 0)
     
     expectEqual(newArrayElementList.count, 2)
+    expectNotNil(newArrayElementList.child(at: 0))
     expectEqual("\(newArrayElementList.child(at: 0)!)", "0")
     
     newArrayElementList = newArrayElementList.inserting(integerLiteralElement(2), at: 2)
     
     expectEqual(newArrayElementList.count, 3)
+    expectNotNil(newArrayElementList.child(at: 2))
     expectEqual("\(newArrayElementList.child(at: 2)!)", "2")
 }
 
@@ -51,6 +54,7 @@ SyntaxCollectionsAPI.test("PrependingElement") {
     let newArrayElementList = arrayElementList.prepending(integerLiteralElement(0))
     
     expectEqual(newArrayElementList.count, 2)
+    expectNotNil(newArrayElementList.child(at: 0))
     expectEqual("\(newArrayElementList.child(at: 0)!)", "0")
 }
 
@@ -63,6 +67,7 @@ SyntaxCollectionsAPI.test("RemovingFirstElement") {
     let newArrayElementList = arrayElementList.removingFirst()
     
     expectEqual(newArrayElementList.count, 1)
+    expectNotNil(newArrayElementList.child(at: 0))
     expectEqual("\(newArrayElementList.child(at: 0)!)", "1")
 }
 
@@ -75,6 +80,7 @@ SyntaxCollectionsAPI.test("RemovingLastElement") {
     let newArrayElementList = arrayElementList.removingLast()
     
     expectEqual(newArrayElementList.count, 1)
+    expectNotNil(newArrayElementList.child(at: 0))
     expectEqual("\(newArrayElementList.child(at: 0)!)", "0")
 }
 
@@ -96,9 +102,10 @@ SyntaxCollectionsAPI.test("ReplacingElement") {
         integerLiteralElement(2)
     ])
     
-    let newArrayElementList.replacing(childAt: 2,
-                                      with: integerLiteralElement(3))
+    let newArrayElementList = arrayElementList.replacing(childAt: 2,
+                                                         with: integerLiteralElement(3))
     
+    expectNotNil(newArrayElementList.child(at: 2))
     expectEqual("\(newArrayElementList.child(at: 2)!)", "3")
 }
 

--- a/test/SwiftSyntax/SyntaxCollections.swift
+++ b/test/SwiftSyntax/SyntaxCollections.swift
@@ -7,73 +7,80 @@ import Foundation
 import StdlibUnittest
 import SwiftSyntax
 
+func integerLiteralElement(_ int: Int) -> ArrayElementSyntax {
+    let literal = SyntaxFactory.makeIntegerLiteral("\(int)")
+    return SyntaxFactory.makeArrayElement(
+        expression: SyntaxFactory.makeIntegerLiteralExpr(digits: literal),
+        trailingComma: nil)
+}
+
 var SyntaxCollectionsAPI = TestSuite("SyntaxCollectionsAPI")
 
 SyntaxCollectionsAPI.test("AppendingElement") {
     let arrayElementList = SyntaxFactory.makeArrayElementList([
-        SyntaxFactory.makeArrayElement(expression: SyntaxFactory.makeIntegerLiteral("0"), trailingComma: nil)
+        integerLiteralElement(0)
     ])
     
-    let newArrayElementList = arrayElementList.appending(SyntaxFactory.makeIntegerLiteral("1"))
+    let newArrayElementList = arrayElementList.appending(integerLiteralElement(1))
     
     expectEqual(newArrayElementList.count, 2)
-    expectEqual("\(arrayElementList.child(at: 1)!)", "1")
+    expectEqual("\(newArrayElementList.child(at: 1)!)", "1")
 }
 
 SyntaxCollectionsAPI.test("InsertingElement") {
     let arrayElementList = SyntaxFactory.makeArrayElementList([
-        SyntaxFactory.makeArrayElement(expression: SyntaxFactory.makeIntegerLiteral("1"), trailingComma: nil)
+        integerLiteralElement(1)
     ])
     
-    var newArrayElementList = arrayElementList.inserting(SyntaxFactory.makeIntegerLiteral("0"), at: 0)
+    var newArrayElementList = arrayElementList.inserting(integerLiteralElement(0), at: 0)
     
     expectEqual(newArrayElementList.count, 2)
-    expectEqual("\(arrayElementList.child(at: 0)!)", "0")
+    expectEqual("\(newArrayElementList.child(at: 0)!)", "0")
     
-    newArrayElementList = newArrayElementList.inserting(SyntaxFactory.makeIntegerLiteral("2"), at: 2)
+    newArrayElementList = newArrayElementList.inserting(integerLiteralElement(2), at: 2)
     
     expectEqual(newArrayElementList.count, 3)
-    expectEqual("\(arrayElementList.child(at: 2)!)", "2")
+    expectEqual("\(newArrayElementList.child(at: 2)!)", "2")
 }
 
 SyntaxCollectionsAPI.test("PrependingElement") {
     let arrayElementList = SyntaxFactory.makeArrayElementList([
-        SyntaxFactory.makeArrayElement(expression: SyntaxFactory.makeIntegerLiteral("1"), trailingComma: nil)
+        integerLiteralElement(1)
     ])
     
-    let newArrayElementList = arrayElementList.prepending(SyntaxFactory.makeIntegerLiteral("0"))
+    let newArrayElementList = arrayElementList.prepending(integerLiteralElement(0))
     
     expectEqual(newArrayElementList.count, 2)
-    expectEqual("\(arrayElementList.child(at: 0)!)", "0")
+    expectEqual("\(newArrayElementList.child(at: 0)!)", "0")
 }
 
 SyntaxCollectionsAPI.test("RemovingFirstElement") {
     let arrayElementList = SyntaxFactory.makeArrayElementList([
-        SyntaxFactory.makeArrayElement(expression: SyntaxFactory.makeIntegerLiteral("0"), trailingComma: nil),
-        SyntaxFactory.makeArrayElement(expression: SyntaxFactory.makeIntegerLiteral("1"), trailingComma: nil)
+        integerLiteralElement(0),
+        integerLiteralElement(1)
     ])
     
     let newArrayElementList = arrayElementList.removingFirst()
     
     expectEqual(newArrayElementList.count, 1)
-    expectEqual("\(arrayElementList.child(at: 0)!)", "1")
+    expectEqual("\(newArrayElementList.child(at: 0)!)", "1")
 }
 
 SyntaxCollectionsAPI.test("RemovingLastElement") {
     let arrayElementList = SyntaxFactory.makeArrayElementList([
-        SyntaxFactory.makeArrayElement(expression: SyntaxFactory.makeIntegerLiteral("0"), trailingComma: nil),
-        SyntaxFactory.makeArrayElement(expression: SyntaxFactory.makeIntegerLiteral("1"), trailingComma: nil)
+        integerLiteralElement(0),
+        integerLiteralElement(1)
     ])
     
     let newArrayElementList = arrayElementList.removingLast()
     
     expectEqual(newArrayElementList.count, 1)
-    expectEqual("\(arrayElementList.child(at: 0)!)", "0")
+    expectEqual("\(newArrayElementList.child(at: 0)!)", "0")
 }
 
 SyntaxCollectionsAPI.test("RemovingElement") {
     let arrayElementList = SyntaxFactory.makeArrayElementList([
-        SyntaxFactory.makeArrayElement(expression: SyntaxFactory.makeIntegerLiteral("0"), trailingComma: nil)
+        integerLiteralElement(0)
     ])
     
     let newArrayElementList = arrayElementList.removing(childAt: 0)
@@ -84,15 +91,15 @@ SyntaxCollectionsAPI.test("RemovingElement") {
 
 SyntaxCollectionsAPI.test("ReplacingElement") {
     let arrayElementList = SyntaxFactory.makeArrayElementList([
-        SyntaxFactory.makeArrayElement(expression: SyntaxFactory.makeIntegerLiteral("0"), trailingComma: nil),
-        SyntaxFactory.makeArrayElement(expression: SyntaxFactory.makeIntegerLiteral("1"), trailingComma: nil),
-        SyntaxFactory.makeArrayElement(expression: SyntaxFactory.makeIntegerLiteral("2"), trailingComma: nil)
+        integerLiteralElement(0),
+        integerLiteralElement(1),
+        integerLiteralElement(2)
     ])
     
-    arrayElementList.replacing(childAt: 2,
-                               with: SyntaxFactory.makeIntegerLiteral("3"))
+    let newArrayElementList.replacing(childAt: 2,
+                                      with: integerLiteralElement(3))
     
-    expectEqual("\(arrayElementList.child(at: 2)!)", "3")
+    expectEqual("\(newArrayElementList.child(at: 2)!)", "3")
 }
 
 runAllTests()

--- a/test/SwiftSyntax/SyntaxCollections.swift
+++ b/test/SwiftSyntax/SyntaxCollections.swift
@@ -1,0 +1,98 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: OS=macosx
+// REQUIRES: objc_interop
+
+import Foundation
+import StdlibUnittest
+import SwiftSyntax
+
+var SyntaxCollectionsAPI = TestSuite("SyntaxCollectionsAPI")
+
+SyntaxCollectionsAPI.test("AppendingElement") {
+    let arrayElementList = SyntaxFactory.makeArrayElementList([
+        SyntaxFactory.makeArrayElement(expression: SyntaxFactory.makeIntegerLiteral("0"), trailingComma: nil)
+    ])
+    
+    let newArrayElementList = arrayElementList.appending(SyntaxFactory.makeIntegerLiteral("1"))
+    
+    expectEqual(newArrayElementList.count, 2)
+    expectEqual("\(arrayElementList.child(at: 1)!)", "1")
+}
+
+SyntaxCollectionsAPI.test("InsertingElement") {
+    let arrayElementList = SyntaxFactory.makeArrayElementList([
+        SyntaxFactory.makeArrayElement(expression: SyntaxFactory.makeIntegerLiteral("1"), trailingComma: nil)
+    ])
+    
+    var newArrayElementList = arrayElementList.inserting(SyntaxFactory.makeIntegerLiteral("0"), at: 0)
+    
+    expectEqual(newArrayElementList.count, 2)
+    expectEqual("\(arrayElementList.child(at: 0)!)", "0")
+    
+    newArrayElementList = newArrayElementList.inserting(SyntaxFactory.makeIntegerLiteral("2"), at: 2)
+    
+    expectEqual(newArrayElementList.count, 3)
+    expectEqual("\(arrayElementList.child(at: 2)!)", "2")
+}
+
+SyntaxCollectionsAPI.test("PrependingElement") {
+    let arrayElementList = SyntaxFactory.makeArrayElementList([
+        SyntaxFactory.makeArrayElement(expression: SyntaxFactory.makeIntegerLiteral("1"), trailingComma: nil)
+    ])
+    
+    let newArrayElementList = arrayElementList.prepending(SyntaxFactory.makeIntegerLiteral("0"))
+    
+    expectEqual(newArrayElementList.count, 2)
+    expectEqual("\(arrayElementList.child(at: 0)!)", "0")
+}
+
+SyntaxCollectionsAPI.test("RemovingFirstElement") {
+    let arrayElementList = SyntaxFactory.makeArrayElementList([
+        SyntaxFactory.makeArrayElement(expression: SyntaxFactory.makeIntegerLiteral("0"), trailingComma: nil),
+        SyntaxFactory.makeArrayElement(expression: SyntaxFactory.makeIntegerLiteral("1"), trailingComma: nil)
+    ])
+    
+    let newArrayElementList = arrayElementList.removingFirst()
+    
+    expectEqual(newArrayElementList.count, 1)
+    expectEqual("\(arrayElementList.child(at: 0)!)", "1")
+}
+
+SyntaxCollectionsAPI.test("RemovingLastElement") {
+    let arrayElementList = SyntaxFactory.makeArrayElementList([
+        SyntaxFactory.makeArrayElement(expression: SyntaxFactory.makeIntegerLiteral("0"), trailingComma: nil),
+        SyntaxFactory.makeArrayElement(expression: SyntaxFactory.makeIntegerLiteral("1"), trailingComma: nil)
+    ])
+    
+    let newArrayElementList = arrayElementList.removingLast()
+    
+    expectEqual(newArrayElementList.count, 1)
+    expectEqual("\(arrayElementList.child(at: 0)!)", "0")
+}
+
+SyntaxCollectionsAPI.test("RemovingElement") {
+    let arrayElementList = SyntaxFactory.makeArrayElementList([
+        SyntaxFactory.makeArrayElement(expression: SyntaxFactory.makeIntegerLiteral("0"), trailingComma: nil)
+    ])
+    
+    let newArrayElementList = arrayElementList.removing(childAt: 0)
+    
+    expectEqual(newArrayElementList.count, 0)
+    expectNil(newArrayElementList.child(at: 0))
+}
+
+SyntaxCollectionsAPI.test("ReplacingElement") {
+    let arrayElementList = SyntaxFactory.makeArrayElementList([
+        SyntaxFactory.makeArrayElement(expression: SyntaxFactory.makeIntegerLiteral("0"), trailingComma: nil),
+        SyntaxFactory.makeArrayElement(expression: SyntaxFactory.makeIntegerLiteral("1"), trailingComma: nil),
+        SyntaxFactory.makeArrayElement(expression: SyntaxFactory.makeIntegerLiteral("2"), trailingComma: nil)
+    ])
+    
+    arrayElementList.replacing(childAt: 2,
+                               with: SyntaxFactory.makeIntegerLiteral("3"))
+    
+    expectEqual("\(arrayElementList.child(at: 2)!)", "3")
+}
+
+runAllTests()

--- a/tools/SwiftSyntax/SyntaxCollections.swift.gyb
+++ b/tools/SwiftSyntax/SyntaxCollections.swift.gyb
@@ -107,7 +107,7 @@ public struct ${node.name}: _SyntaxBase {
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
                  "replacing node at invalid index \(index)")
-    newLayout.replaceSubrange(index...index, with: [syntax])
+    newLayout[index] = syntax
     return replacingLayout(newLayout)
   }
 

--- a/tools/SwiftSyntax/SyntaxCollections.swift.gyb
+++ b/tools/SwiftSyntax/SyntaxCollections.swift.gyb
@@ -107,7 +107,7 @@ public struct ${node.name}: _SyntaxBase {
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
                  "replacing node at invalid index \(index)")
-    newLayout[index] = syntax
+    newLayout[index] = syntax.raw
     return replacingLayout(newLayout)
   }
 

--- a/tools/SwiftSyntax/SyntaxCollections.swift.gyb
+++ b/tools/SwiftSyntax/SyntaxCollections.swift.gyb
@@ -93,6 +93,24 @@ public struct ${node.name}: _SyntaxBase {
     return replacingLayout(newLayout)
   }
 
+  /// Creates a new `${node.name}` by replacing the syntax element
+  /// at the provided index.
+  ///
+  /// - Parameters:
+  ///   - index: The index at which to replace the element in the collection.
+  ///   - syntax: The element to replace with.
+  ///
+  /// - Returns: A new `${node.name}` with the new element at the provided index.
+  public func replacing(childAt index: Int,
+                        with syntax: ${node.collection_element_type}) -> ${node.name} {
+    var newLayout = data.raw.layout
+    /// Make sure the index is a valid index for replacing
+    precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
+                 "replacing node at invalid index \(index)")
+    newLayout.replaceSubrange(index...index, with: [syntax])
+    return replacingLayout(newLayout)
+  }
+
   /// Creates a new `${node.name}` by removing the syntax element at the
   /// provided index.
   ///


### PR DESCRIPTION
I started working closely with SwiftSyntax and realized that I very often face with the situation where I need to replace one element in some kind of SyntaxCollection and for doing such operation we have to call two different methods: one for delete operation and one for insert operation.

This is a typical scenario where you need to update one element in the `ArrayExprSyntax`:
```arrayExpr.elements.removing(childAt: i).inserting(newArrayElement, at: i)```

Instead of this with the new method we can rewrite it in the following way:
```arrayExpr.elements.replacing(childAt: i, with: newArrayElement)```

