### PR TITLE
[SourceKit] Fix compiler warning.

### DIFF
--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
@@ -247,7 +247,7 @@ void ResponseBuilder::Dictionary::setCustomBuffer(
   std::unique_ptr<llvm::MemoryBuffer> CustomBuf;
   CustomBuf = llvm::WritableMemoryBuffer::getNewUninitMemBuffer(
       sizeof(uint64_t) + MemBuf->getBufferSize());
-  char *BufPtr = (char*)CustomBuf->getBufferStart();
+  char *BufPtr = const_cast<char*>(CustomBuf->getBufferStart());
   *reinterpret_cast<uint64_t*>(BufPtr) = (uint64_t)Kind;
   BufPtr += sizeof(uint64_t);
   memcpy(BufPtr, MemBuf->getBufferStart(), MemBuf->getBufferSize());

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
@@ -244,10 +244,10 @@ void ResponseBuilder::Dictionary::setCustomBuffer(
       SourceKit::UIdent Key,
       CustomBufferKind Kind, std::unique_ptr<llvm::MemoryBuffer> MemBuf) {
 
-  std::unique_ptr<llvm::MemoryBuffer> CustomBuf;
+  std::unique_ptr<llvm::WritableMemoryBuffer> CustomBuf;
   CustomBuf = llvm::WritableMemoryBuffer::getNewUninitMemBuffer(
       sizeof(uint64_t) + MemBuf->getBufferSize());
-  char *BufPtr = const_cast<char*>(CustomBuf->getBufferStart());
+  char *BufPtr = CustomBuf->getBufferStart();
   *reinterpret_cast<uint64_t*>(BufPtr) = (uint64_t)Kind;
   BufPtr += sizeof(uint64_t);
   memcpy(BufPtr, MemBuf->getBufferStart(), MemBuf->getBufferSize());


### PR DESCRIPTION
Use const_cast instead of C style cast.

<!-- What's in this pull request? -->
Simple warning fix.  Use const cast instead of C-style cast to prevent warning of removing const qualifier.  (I am using this trivial PR to get practice.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
No SR for this one AFAIK.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
