### PR TITLE
[Driver] Separate build record filename for emit-module only mode

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -269,7 +269,7 @@ class Driver::InputInfoMap
 using InputInfoMap = Driver::InputInfoMap;
 
 static bool failedToReadOutOfDateMap(bool ShowIncrementalBuildDecisions,
-                                     StringRef buildRecordPath,
+                                     llvm::Twine buildRecordPath,
                                      StringRef reason = "") {
   if (ShowIncrementalBuildDecisions) {
     llvm::outs() << "Incremental compilation has been disabled due to "
@@ -284,7 +284,7 @@ static bool failedToReadOutOfDateMap(bool ShowIncrementalBuildDecisions,
 
 static bool populateOutOfDateMap(InputInfoMap &map, StringRef argsHashStr,
                                  const InputFileList &inputs,
-                                 StringRef buildRecordPath,
+                                 llvm::Twine buildRecordPath,
                                  bool ShowIncrementalBuildDecisions) {
   // Treat a missing file as "no previous build".
   auto buffer = llvm::MemoryBuffer::getFile(buildRecordPath);
@@ -649,12 +649,9 @@ Driver::buildCompilation(const ToolChain &TC,
       Diags.diagnose(SourceLoc(), diag::incremental_requires_output_file_map);
 
     } else {
-      StringRef buildRecordPath;
-      if (auto *masterOutputMap = OFM->getOutputMapForSingleOutput()) {
-        auto iter = masterOutputMap->find(types::TY_SwiftDeps);
-        if (iter != masterOutputMap->end())
-          buildRecordPath = iter->second;
-      }
+      std::string buildRecordPath;
+      if (auto *masterOutputMap = OFM->getOutputMapForSingleOutput())
+        buildRecordPath = masterOutputMap->lookup(types::TY_SwiftDeps);
 
       if (buildRecordPath.empty()) {
         Diags.diagnose(SourceLoc(),
@@ -663,6 +660,31 @@ Driver::buildCompilation(const ToolChain &TC,
         rebuildEverything = true;
 
       } else {
+
+        // In 'emit-module' only mode, if '~moduleonly' suffixed build record
+        // exists and it's newer than normal build record, read from it.
+        // Otherwise, read from normal build record file since it's compatible
+        // with 'emit-module' only mode.
+        bool useModuleOnlybuildRecordPath = false;
+        if (OI.CompilerOutputType == types::TY_SwiftModuleFile) {
+          llvm::sys::fs::file_status Stat;
+          if (!llvm::sys::fs::status(buildRecordPath + "~moduleonly", Stat)) {
+            auto ModuleOnlyModTime = Stat.getLastModificationTime();
+            if (!llvm::sys::fs::status(buildRecordPath, Stat)) {
+              if (ModuleOnlyModTime > Stat.getLastModificationTime()) {
+                // '~moduleonly' suffixed one is newer than normal one.
+                useModuleOnlybuildRecordPath = true;
+              }
+            } else {
+              // Only '~moduleonly' suffixed one exists.
+              useModuleOnlybuildRecordPath = true;
+            }
+          }
+        }
+        if (useModuleOnlybuildRecordPath) {
+          buildRecordPath = buildRecordPath.append("~moduleonly");
+        }
+
         if (populateOutOfDateMap(outOfDateMap, ArgsHash, Inputs,
                                  buildRecordPath,
                                  ShowIncrementalBuildDecisions)) {
@@ -750,7 +772,12 @@ Driver::buildCompilation(const ToolChain &TC,
 
   if (OFM) {
     if (auto *masterOutputMap = OFM->getOutputMapForSingleOutput()) {
-      C->setCompilationRecordPath(masterOutputMap->lookup(types::TY_SwiftDeps));
+      auto buildRecordFilename = masterOutputMap->lookup(types::TY_SwiftDeps);
+      // In 'emit-module' only mode, append '~moduleonly' to the build record
+      // filename. To keep build record for main compilation clean.
+      if (OI.CompilerOutputType == types::TY_SwiftModuleFile)
+        buildRecordFilename = buildRecordFilename.append("~moduleonly");
+      C->setCompilationRecordPath(buildRecordFilename);
 
       auto buildEntry = outOfDateMap.find(nullptr);
       if (buildEntry != outOfDateMap.end())

--- a/test/Driver/Dependencies/Inputs/moduleonly/bar.swift
+++ b/test/Driver/Dependencies/Inputs/moduleonly/bar.swift
@@ -1,0 +1,2 @@
+public func bar() { }
+

--- a/test/Driver/Dependencies/Inputs/moduleonly/baz.swift
+++ b/test/Driver/Dependencies/Inputs/moduleonly/baz.swift
@@ -1,0 +1,1 @@
+public func baz() {}

--- a/test/Driver/Dependencies/Inputs/moduleonly/foo.swift
+++ b/test/Driver/Dependencies/Inputs/moduleonly/foo.swift
@@ -1,0 +1,2 @@
+public func foo() { }
+

--- a/test/Driver/Dependencies/Inputs/moduleonly/output.json
+++ b/test/Driver/Dependencies/Inputs/moduleonly/output.json
@@ -1,0 +1,21 @@
+{
+  "./foo.swift": {
+    "object": "./foo.o",
+    "swift-dependencies": "./foo.swiftdeps",
+    "swiftmodule": "./foo~partial.swiftmodule"
+  },
+  "./bar.swift": {
+    "object": "./bar.o",
+    "swift-dependencies": "./bar.swiftdeps",
+    "swiftmodule": "./bar~partial.swiftmodule"
+  },
+  "./baz.swift": {
+    "object": "./baz.o",
+    "swift-dependencies": "./baz.swiftdeps",
+    "swiftmodule": "./baz~partial.swiftmodule"
+  },
+  "": {
+    "swift-dependencies": "./buildrecord.swiftdeps"
+  }
+}
+

--- a/test/Driver/Dependencies/moduleonly.swift
+++ b/test/Driver/Dependencies/moduleonly.swift
@@ -1,0 +1,46 @@
+// RUN: rm -rf %t && cp -r %S/Inputs/moduleonly/ %t
+// RUN: touch -t 201801230045 %t/*.swift
+
+// RUN: cd %t && %swiftc_driver -emit-module -output-file-map ./output.json -incremental ./foo.swift ./bar.swift ./baz.swift -module-name testmodule -v 2>&1 | %FileCheck -check-prefix=CHECK1 %s
+// RUN: test -f %t/buildrecord.swiftdeps~moduleonly
+// RUN: test ! -f %t/buildrecord.swiftdeps
+
+// CHECK1-DAG: -primary-file ./foo.swift
+// CHECK1-DAG: -primary-file ./bar.swift
+// CHECK1-DAG: -primary-file ./baz.swift
+
+// RUN: cd %t && %swiftc_driver -c -emit-module -output-file-map ./output.json -incremental ./foo.swift ./bar.swift ./baz.swift -module-name testmodule -v 2>&1 | %FileCheck -check-prefix=CHECK2 %s
+// RUN: test -f %t/buildrecord.swiftdeps~moduleonly
+// RUN: test -f %t/buildrecord.swiftdeps
+
+// CHECK2-DAG: -primary-file ./foo.swift
+// CHECK2-DAG: -primary-file ./bar.swift
+// CHECK2-DAG: -primary-file ./baz.swift
+
+// RUN: cd %t && %swiftc_driver -emit-module -output-file-map ./output.json -incremental ./foo.swift ./bar.swift ./baz.swift -module-name testmodule -v 2>&1 | %FileCheck -check-prefix=CHECK3 %s
+// RUN: test -f %t/buildrecord.swiftdeps~moduleonly
+// RUN: test -f %t/buildrecord.swiftdeps
+
+// CHECK3-NOT: -primary-file ./foo.swift
+// CHECK3-NOT: -primary-file ./bar.swift
+// CHECK3-NOT: -primary-file ./baz.swift
+
+// RUN: touch -t 201801230123 %t/bar.swift
+// RUN: cd %t && %swiftc_driver -emit-module -output-file-map ./output.json -incremental ./foo.swift ./bar.swift ./baz.swift -module-name testmodule -v 2>&1 | %FileCheck -check-prefix=CHECK4 %s
+
+// CHECK4-NOT: -primary-file ./foo.swift
+// CHECK4-NOT: -primary-file ./baz.swift
+// CHECK4-DAG: -primary-file ./bar.swift
+
+// RUN: touch -t 201801230145 %t/baz.swift
+// RUN: cd %t && %swiftc_driver -c -emit-module -output-file-map ./output.json -incremental ./foo.swift ./bar.swift ./baz.swift -module-name testmodule -v 2>&1 | %FileCheck -check-prefix=CHECK5 %s
+
+// CHECK5-NOT: -primary-file ./foo.swift
+// CHECK5-DAG: -primary-file ./bar.swift
+// CHECK5-DAG: -primary-file ./baz.swift
+
+// RUN: cd %t && %swiftc_driver -emit-module -output-file-map ./output.json -incremental ./foo.swift ./bar.swift ./baz.swift -module-name testmodule -v 2>&1 | %FileCheck -check-prefix=CHECK6 %s
+
+// CHECK6-NOT: -primary-file ./foo.swift
+// CHECK6-NOT: -primary-file ./bar.swift
+// CHECK6-NOT: -primary-file ./baz.swift


### PR DESCRIPTION
This ensures that `-emit-module -incremental` mode doesn't mess up build record file (`.swiftdeps`) for normal incremental builds.

rdar://problem/38455047