### PR TITLE
[benchmark] WordCount: Initialize global variables in setUpFunction.

### DIFF
--- a/benchmark/single-source/WordCount.swift
+++ b/benchmark/single-source/WordCount.swift
@@ -26,28 +26,39 @@ public let WordCount = [
   BenchmarkInfo(
     name: "WordSplitASCII",
     runFunction: run_WordSplitASCII,
-    tags: [.validation, .api, .String, .algorithm]),
+    tags: [.validation, .api, .String, .algorithm],
+    setUpFunction: { blackHole(someAlphanumerics) }
+  ),
   BenchmarkInfo(
     name: "WordSplitUTF16",
     runFunction: run_WordSplitUTF16,
-    tags: [.validation, .api, .String, .algorithm]),
+    tags: [.validation, .api, .String, .algorithm],
+    setUpFunction: { blackHole(someAlphanumerics) }
+  ),
   BenchmarkInfo(
     name: "WordCountUniqueASCII",
     runFunction: run_WordCountUniqueASCII,
-    tags: [.validation, .api, .String, .Dictionary, .algorithm]),
+    tags: [.validation, .api, .String, .Dictionary, .algorithm],
+    setUpFunction: { blackHole(asciiWords) }
+  ),
   BenchmarkInfo(
     name: "WordCountUniqueUTF16",
     runFunction: run_WordCountUniqueUTF16,
-    tags: [.validation, .api, .String, .Dictionary, .algorithm]),
+    tags: [.validation, .api, .String, .Dictionary, .algorithm],
+    setUpFunction: { blackHole(utf16Words) }
+  ),
   BenchmarkInfo(
     name: "WordCountHistogramASCII",
     runFunction: run_WordCountHistogramASCII,
-    tags: [.validation, .api, .String, .Dictionary, .algorithm]),
+    tags: [.validation, .api, .String, .Dictionary, .algorithm],
+    setUpFunction: { blackHole(asciiWords) }
+  ),
   BenchmarkInfo(
     name: "WordCountHistogramUTF16",
     runFunction: run_WordCountHistogramUTF16,
-    tags: [.validation, .api, .String, .Dictionary, .algorithm]),
-  
+    tags: [.validation, .api, .String, .Dictionary, .algorithm],
+    setUpFunction: { blackHole(utf16Words) }
+  ),
 ]
 
 let asciiText = """

--- a/benchmark/single-source/WordCount.swift
+++ b/benchmark/single-source/WordCount.swift
@@ -27,37 +27,37 @@ public let WordCount = [
     name: "WordSplitASCII",
     runFunction: run_WordSplitASCII,
     tags: [.validation, .api, .String, .algorithm],
-    setUpFunction: { blackHole(someAlphanumerics) }
+    setUpFunction: { buildWorkload() }
   ),
   BenchmarkInfo(
     name: "WordSplitUTF16",
     runFunction: run_WordSplitUTF16,
     tags: [.validation, .api, .String, .algorithm],
-    setUpFunction: { blackHole(someAlphanumerics) }
+    setUpFunction: { buildWorkload() }
   ),
   BenchmarkInfo(
     name: "WordCountUniqueASCII",
     runFunction: run_WordCountUniqueASCII,
     tags: [.validation, .api, .String, .Dictionary, .algorithm],
-    setUpFunction: { blackHole(asciiWords) }
+    setUpFunction: { buildWorkload() }
   ),
   BenchmarkInfo(
     name: "WordCountUniqueUTF16",
     runFunction: run_WordCountUniqueUTF16,
     tags: [.validation, .api, .String, .Dictionary, .algorithm],
-    setUpFunction: { blackHole(utf16Words) }
+    setUpFunction: { buildWorkload() }
   ),
   BenchmarkInfo(
     name: "WordCountHistogramASCII",
     runFunction: run_WordCountHistogramASCII,
     tags: [.validation, .api, .String, .Dictionary, .algorithm],
-    setUpFunction: { blackHole(asciiWords) }
+    setUpFunction: { buildWorkload() }
   ),
   BenchmarkInfo(
     name: "WordCountHistogramUTF16",
     runFunction: run_WordCountHistogramUTF16,
     tags: [.validation, .api, .String, .Dictionary, .algorithm],
-    setUpFunction: { blackHole(utf16Words) }
+    setUpFunction: { buildWorkload() }
   ),
 ]
 
@@ -139,6 +139,13 @@ environment. Tö build from source you will need 2 GB of disk space for thé
 source code and over 20 GB of disk space for thé build artifacts. A clean build
 can take multiple hours, but incremental builds will finish much faster.
 """
+
+@inline(never)
+func buildWorkload() {
+  blackHole(someAlphanumerics)
+  blackHole(asciiWords)
+  blackHole(utf16Words)
+}
 
 // A partial set of Unicode alphanumeric characters. (ASCII letters with at most
 // one diacritic (of a limited selection), plus ASCII digits.)

--- a/benchmark/single-source/WordCount.swift
+++ b/benchmark/single-source/WordCount.swift
@@ -195,16 +195,18 @@ struct Words: IteratorProtocol, Sequence {
 @inline(never)
 public func run_WordSplitASCII(_ N: Int) {
   for _ in 1...10*N {
-    let count = Array(Words(identity(asciiText))).count
-    CheckResults(count == 280)
+    let words = Array(Words(identity(asciiText)))
+    CheckResults(words.count == 280)
+    blackHole(words)
   }
 }
 
 @inline(never)
 public func run_WordSplitUTF16(_ N: Int) {
   for _ in 1...10*N {
-    let count = Array(Words(identity(utf16Text))).count
-    CheckResults(count == 280)
+    let words = Array(Words(identity(utf16Text)))
+    CheckResults(words.count == 280)
+    blackHole(words)
   }
 }
 


### PR DESCRIPTION
WordCount shows significant variance between iterations, which is apparently caused by the initialization of someAlphanumerics and asciiWords/utf16Words leaking into the measured part of the benchmark.

Making sure these variables are initialized before we start measuring elapsed time stabilizes the results.