### PR TITLE
[GSB] Allow redundant inheritance for all Objective-C-defined protocols.

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -6178,19 +6178,19 @@ Constraint<T> GenericSignatureBuilder::checkConstraintList(
 
 /// Determine whether this is a redundantly inheritable Objective-C protocol.
 ///
-/// If we do have a redundantly inheritable Objective-C protocol, record that
-/// the conformance was restated on the protocol whose requirement signature
-/// we are computing.
+/// A redundantly-inheritable Objective-C protocol is one where we will
+/// silently accept a directly-stated redundant conformance to this protocol,
+/// and emit this protocol in the list of "inherited" protocols. There are
+/// two cases where we allow this:
 ///
-/// At present, there is only one such protocol that we know about:
-/// JavaScriptCore's JSExport.
+//    1) For a protocol defined in Objective-C, so that we will match Clang's
+///      behavior, and
+///   2) For an @objc protocol defined in Swift that directly inherits from
+///      JavaScriptCore's JSExport, which depends on this behavior.
 static bool isRedundantlyInheritableObjCProtocol(
                                              ProtocolDecl *proto,
                                              const RequirementSource *source) {
   if (!proto->isObjC()) return false;
-
-  // Only JSExport protocol behaves this way.
-  if (!proto->getName().is("JSExport")) return false;
 
   // Only do this for the requirement signature computation.
   auto parentSource = source->parent;
@@ -6198,9 +6198,14 @@ static bool isRedundantlyInheritableObjCProtocol(
       parentSource->kind != RequirementSource::RequirementSignatureSelf)
     return false;
 
+  // Check the two conditions in which we will suppress the diagnostic and
+  // emit the redundant inheritance.
+  auto inheritingProto = parentSource->getProtocolDecl();
+  if (!inheritingProto->hasClangNode() && !proto->getName().is("JSExport"))
+    return false;
+
   // If the inheriting protocol already has @_restatedObjCConformance with
   // this protocol, we're done.
-  auto inheritingProto = parentSource->getProtocolDecl();
   for (auto *attr : inheritingProto->getAttrs()
                       .getAttributes<RestatedObjCConformanceAttr>()) {
     if (attr->Proto == proto) return true;

--- a/test/IRGen/Inputs/usr/include/Gizmo.h
+++ b/test/IRGen/Inputs/usr/include/Gizmo.h
@@ -93,6 +93,12 @@ NSString *NSStringFromRect(struct NSRect r);
 - (void)foo;
 @end
 
+@protocol NSFungingAndRuncing <NSRuncing, NSFunging>
+@end
+
+@protocol NSDoubleInheritedFunging <NSFungingAndRuncing, NSFunging>
+@end
+
 typedef NS_ENUM(unsigned short, NSRuncingOptions) {
   NSRuncingMince = 123,
   NSRuncingQuinceSliced = 4567,

--- a/test/IRGen/objc_protocols.swift
+++ b/test/IRGen/objc_protocols.swift
@@ -120,6 +120,8 @@ protocol InheritingProtocol : BaseProtocol { }
 // CHECK: @_PROTOCOLS__TtC14objc_protocols17ImplementingClass {{.*}} @_PROTOCOL__TtP14objc_protocols12BaseProtocol_
 class ImplementingClass : InheritingProtocol { }
 
+// CHECK: @_PROTOCOL_PROTOCOLS_NSDoubleInheritedFunging = private constant{{.*}}i64 2{{.*}} @_PROTOCOL_NSFungingAndRuncing {{.*}}@_PROTOCOL_NSFunging
+
 // -- Force generation of witness for Zim.
 // CHECK: define hidden swiftcc { %objc_object*, i8** } @"$S14objc_protocols22mixed_heritage_erasure{{[_0-9a-zA-Z]*}}F"
 func mixed_heritage_erasure(_ x: Zim) -> Frungible {
@@ -208,4 +210,9 @@ func canter<T : Palomino>(_ t: Stirrup<T>) {}
 
 func gallop<T : Vanner>(_ t: Stirrup<T>) {
   canter(t)
+}
+
+// SR-7130
+func triggerDoubleInheritedFunging() -> AnyObject {
+  return NSDoubleInheritedFunging.self as AnyObject
 }


### PR DESCRIPTION
Swift complains about redundant inheritance of a protocol, and
canonicalizes away such redundancies in its metadata. Clang does not
warn about such redundancies, nor does the Objective-C "conforms to
protocol" check take inheritance into account. Extend the existing
"redundant inheritance" hack (designed for JSExport) to cover all
protocols defined in Objective-C, so we match Clang's output of
Objective-C metadata.

Fixes [SR-7130](https://bugs.swift.org/browse/SR-7130) / rdar://problem/38394637.