### PR TITLE
[benchmark] Driver: stabilize Dictionary/Set benchmarks

### DIFF
--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -192,6 +192,13 @@ def run_benchmarks(driver, benchmarks=[], num_samples=10, verbose=False,
     compatible with `parse_results`. If `benchmarks` is not empty,
     only run tests included in it.
     """
+    # Set a constant hash seed. Some tests are currently sensitive to
+    # fluctuations in the number of hash collisions.
+    #
+    # FIXME: This should only be set in the environment of the child process
+    # that runs the tests.
+    os.environ["SWIFT_DETERMINISTIC_HASHING"] = "1"
+
     (total_tests, total_min, total_max, total_mean) = (0, 0, 0, 0)
     output = []
     headings = ['#', 'TEST', 'SAMPLES', 'MIN(μs)', 'MAX(μs)', 'MEAN(μs)',


### PR DESCRIPTION
Disable the random hash seed while benchmarking. By its nature, it makes the number of hash collisions fluctuate between runs, adding unnecessary noise to benchmark results.

I expect we'll be able to re-enable random seeding here once we have made hash collisions cheaper -- they are currently always resolved by calling the Key's Equatable implementation, which can be expensive.
