### PR TITLE
Revert "[build-script] Disable watchpoint testing in lldb"

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2792,14 +2792,13 @@ for host in "${ALL_HOSTS[@]}"; do
                     fi
                 fi
 
-                # Optionally specify a test subdirectory and category filters.
-                # Watchpoint testing is currently disabled: see rdar://38566150.
+                # Handle test subdirectory clause
                 if [[ "$(true_false ${LLDB_TEST_SWIFT_ONLY})" == "TRUE" ]]; then
                     LLDB_TEST_SUBDIR_CLAUSE="--test-subdir lang/swift"
-                    LLDB_TEST_CATEGORIES="--skip-category=watchpoint --skip-category=dwo --skip-category=dsym --skip-category=gmodules -G swiftpr"
+                    LLDB_TEST_CATEGORIES="--skip-category=dwo --skip-category=dsym --skip-category=gmodules -G swiftpr"
                 else
                     LLDB_TEST_SUBDIR_CLAUSE=""
-                    LLDB_TEST_CATEGORIES="--skip-category=watchpoint"
+                    LLDB_TEST_CATEGORIES=""
                 fi
 
                 # figure out which C/C++ compiler we should use for building test inferiors.


### PR DESCRIPTION
This reverts commit 4858cf691e20872e6bc33d7d1597f64b18d2872e
as it breaks the lldb bots.