### PR TITLE
IRGen: Generalize the nullable optimization for single-payload enums.

### DIFF
--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -463,8 +463,10 @@ public:
 
   void emitResilientTagIndices(IRGenModule &IGM) const;
 
-protected:
-
+  virtual bool canValueWitnessExtraInhabitantsUpTo(IRGenModule &IGM,
+                                                   unsigned index) const {
+    return false;
+  }
 
 private:
   EnumImplStrategy(const EnumImplStrategy &) = delete;

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -1049,6 +1049,11 @@ public:
     if (refcounting) *refcounting = Refcounting;
     return getNumStoredProtocols() == 0;
   }
+  
+  bool canValueWitnessExtraInhabitantsUpTo(IRGenModule &IGM,
+                                           unsigned index) const override {
+    return index == 0;
+  }
 
   const LoadableTypeInfo &
   getValueTypeInfoForExtraInhabitants(IRGenModule &IGM) const {

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -595,6 +595,28 @@ public:
     return 0;
   }
 
+  bool canValueWitnessExtraInhabitantsUpTo(IRGenModule &IGM,
+                                           unsigned index) const override {
+    if (auto field = asImpl().getFixedExtraInhabitantProvidingField(IGM)) {
+      // The non-extra-inhabitant-providing fields of the type must be
+      // trivial, because an enum may contain garbage values in those fields'
+      // storage which the value witness operation won't handle.
+      for (auto &otherField : asImpl().getFields()) {
+        if (field == &otherField)
+          continue;
+        auto &ti = otherField.getTypeInfo();
+        if (!ti.isPOD(ResilienceExpansion::Maximal)) {
+          return false;
+        }
+      }
+
+      return field->getTypeInfo()
+        .canValueWitnessExtraInhabitantsUpTo(IGM, index);
+    }
+    
+    return false;
+  }
+
   APInt getFixedExtraInhabitantValue(IRGenModule &IGM,
                                      unsigned bits,
                                      unsigned index) const override {

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -219,7 +219,7 @@ namespace {
         return false;
       return fields[0].getTypeInfo().isSingleRetainablePointer(expansion, rc);
     }
-    
+       
     void verify(IRGenTypeVerifierFunction &IGF,
                 llvm::Value *metadata,
                 SILType structType) const override {

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -1245,6 +1245,18 @@ FixedPacking TypeInfo::getFixedPacking(IRGenModule &IGM) const {
   return FixedPacking::Allocate;
 }
 
+bool TypeInfo::canValueWitnessExtraInhabitantsUpTo(IRGenModule &IGM,
+                                                   unsigned index) const {
+  // If this type is POD, then its value witnesses are trivial, so can handle
+  // any bit pattern.
+  if (isPOD(ResilienceExpansion::Maximal)) {
+    return true;
+  }
+  
+  // By default, assume that extra inhabitants must be branched out on.
+  return false;
+}
+
 Address TypeInfo::indexArray(IRGenFunction &IGF, Address base,
                              llvm::Value *index, SILType T) const {
   // The stride of a Swift type may not match its LLVM size. If we know we have

--- a/lib/IRGen/HeapTypeInfo.h
+++ b/lib/IRGen/HeapTypeInfo.h
@@ -75,6 +75,13 @@ public:
     return true;
   }
   
+  bool canValueWitnessExtraInhabitantsUpTo(IRGenModule &IGM,
+                                           unsigned index) const override {
+    // Refcounting functions are no-ops when passed a null pointer, which is the
+    // first extra inhabitant.
+    return index == 0;
+  }
+  
   IsaEncoding getIsaEncoding(ResilienceExpansion expansion) const {
     switch (asDerived().getReferenceCounting()) {
     // We can access the isa of pure Swift heap objects directly.

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -408,6 +408,17 @@ public:
   /// have extra inhabitants based on type arguments?
   virtual bool mayHaveExtraInhabitants(IRGenModule &IGM) const = 0;
 
+  /// Returns true if the value witness operations on this type work correctly
+  /// with extra inhabitants up to the given index.
+  ///
+  /// An example of this is retainable pointers. The first extra inhabitant for
+  /// these types is the null pointer, on which swift_retain is a harmless
+  /// no-op. If this predicate returns true, then a single-payload enum with
+  /// this type as its payload (like Optional<T>) can avoid additional branching
+  /// on the enum tag for value witness operations.
+  virtual bool canValueWitnessExtraInhabitantsUpTo(IRGenModule &IGM,
+                                                   unsigned index) const;
+  
   /// Get the tag of a single payload enum with a payload of this type (\p T) e.g
   /// Optional<T>.
   virtual llvm::Value *getEnumTagSinglePayload(IRGenFunction &IGF,

--- a/test/IRGen/enum_single_payload_forward_to_payload.swift
+++ b/test/IRGen/enum_single_payload_forward_to_payload.swift
@@ -1,0 +1,59 @@
+// RUN: %target-swift-frontend -emit-ir %s | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+public protocol CP: AnyObject {}
+
+public func classExistential(_: __owned CP?) {}
+// CHECK-LABEL: define{{.*}}16classExistential
+// CHECK-NOT:     Os"
+// CHECK-NOT:     Oe"
+// CHECK:         swift_{{.*}}elease
+
+public func classExistential2(_: __owned CP??) {}
+// CHECK-LABEL: define{{.*}}17classExistential2
+// CHECK:         2CP_pSgSgWOe"
+
+// TODO: 32-bit String layout still triggers an out-of-line constructor
+public func string(_: __owned String?) {}
+// CHECK-64-LABEL: define{{.*}}6string
+// CHECK-64-NOT:     Os"
+// CHECK-64-NOT:     Oe"
+// CHECK-64:         swift_{{.*}}elease
+
+public func array(_: __owned [String]?) {}
+// CHECK-LABEL: define{{.*}}5array
+// CHECK-NOT:     Os"
+// CHECK-NOT:     Oe"
+// CHECK:         swift_{{.*}}elease
+
+public func dict(_: __owned [String: String]?) {}
+// CHECK-LABEL: define{{.*}}4dict
+// CHECK-NOT:     Os"
+// CHECK-NOT:     Oe"
+// CHECK:         swift_{{.*}}elease
+
+// Should get its extra inhabitant from x. The other "junk" fields are trivial
+// so we can avoid branching the value witness operations.
+public struct TrivialJunkFields {
+  var w: Int
+  var x: [String]
+  var y: Int
+}
+
+public func trivialJunkFields(_: __owned TrivialJunkFields?) {}
+// CHECK-LABEL: define{{.*}}17trivialJunkFields
+// CHECK-NOT:     Os"
+// CHECK-NOT:     Oe"
+// CHECK:         swift_{{.*}}elease
+
+
+// Should get its extra inhabitants from `y`. We can't avoid branching
+// in the value witness because the bits of `x` are undefined if an enum
+// is used.
+public struct NontrivialJunkFields {
+  var w: Int
+  var x: [String]
+  var y: [String]
+}
+
+public func nontrivialJunkFields(_: __owned NontrivialJunkFields?) {}
+// CHECK-LABEL: define{{.*}}20nontrivialJunkFields
+// CHECK:     20NontrivialJunkFieldsVSgW{{Os|Oe}}"

--- a/test/IRGen/weak.sil
+++ b/test/IRGen/weak.sil
@@ -76,7 +76,7 @@ bb0(%0 : $*B, %1 : $Optional<P>):
 // CHECK-NEXT: store i8** [[TMPTAB]], i8*** [[T0]], align 8
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds { [[WEAK]], i8** }, { [[WEAK]], i8** }* [[X]], i32 0, i32 0
 // CHECK-NEXT: call [[WEAK]]* @swift_unknownObjectWeakAssign([[WEAK]]* returned [[T0]], [[UNKNOWN]]* [[TMPOBJ]])
-// CHECK: call void @"$s4weak1P_pSgWOe"
+// CHECK: call void @swift_unknownObjectRelease
 
 sil @test_weak_alloc_stack : $@convention(thin) (Optional<P>) -> () {
 bb0(%0 : $Optional<P>):


### PR DESCRIPTION
Augment the `isSingleRetainablePointer` check that allows IRGen to avoid adding branching around retain/release operations on enums that use the null pointer extra inhabitant with a more general "can value witness extra inhabitants" method on TypeInfo, which says whether a type's retain/release operations are safe to invoke on some or all of its extra inhabitants. This lets us generalize the optimization to include things like `String?` or `ClassProtocol?` which are common types with a nullable pointer in them.