### PR TITLE
Disable timing-sensitive test that's periodically failing in CI, rdar://38378503.

### DIFF
--- a/validation-test/Sema/type_checker_perf/fast/rdar23620262.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar23620262.swift
@@ -1,5 +1,6 @@
 // RUN: %target-typecheck-verify-swift -solver-expression-time-threshold=1
 // REQUIRES: tools-release,no_asserts
+// REQUIRES: rdar38378503
 
 // expected-no-diagnostics
 


### PR DESCRIPTION
Test is on the boundary of fast/slow; failing on some bots. Disabing for now, cc @xedin and @rudkx 

rdar://38378503