### PR TITLE
[Conformance checking] Better handling of escaping function types

### DIFF
--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -852,6 +852,13 @@ RequirementMatch matchWitness(TypeChecker &tc,
 AssociatedTypeDecl *getReferencedAssocTypeOfProtocol(Type type,
                                                      ProtocolDecl *proto);
 
+/// Perform any necessary adjustments to the inferred associated type to
+/// make it suitable for later use.
+///
+/// \param noescapeToEscaping Will be set \c true if this operation performed
+/// the noescape-to-escaping adjustment.
+Type adjustInferredAssociatedType(Type type, bool &noescapeToEscaping);
+
 }
 
 #endif // SWIFT_SEMA_PROTOCOL_H

--- a/test/SILGen/witnesses.swift
+++ b/test/SILGen/witnesses.swift
@@ -510,3 +510,16 @@ class CrashableBase {
 // CHECK-NEXT: return [[RESULT]] : $()
 
 class GenericCrashable<T> : CrashableBase, Crashable {}
+
+// rdar://problem/35297911: allow witness with a noescape parameter to
+// match a requirement with an escaping paameter.
+protocol EscapingReq {
+  func f(_: @escaping (Int) -> Int)
+}
+
+// CHECK-LABEL: sil private [transparent] [thunk] @$S9witnesses18EscapingCovarianceVAA0B3ReqA2aDP1fyyS2icFTW : $@convention(witness_method: EscapingReq) (@owned @callee_guaranteed (Int) -> Int, @in_guaranteed EscapingCovariance) -> ()
+// CHECK-NOT: return
+// CHECK: convert_escape_to_noescape %0
+struct EscapingCovariance: EscapingReq {
+  func f(_: (Int) -> Int) { }
+}

--- a/test/decl/protocol/conforms/associated_type.swift
+++ b/test/decl/protocol/conforms/associated_type.swift
@@ -38,8 +38,6 @@ protocol P1 {
   associatedtype A
 
   func f(_: A)
-  // expected-note@-1 {{protocol requires function 'f' with type '(X1c.A) -> ()' (aka '((Int) -> Int) -> ()'); do you want to add a stub?}}
-  // expected-note@-2 {{protocol requires function 'f' with type '((Int) -> Int) -> ()'; do you want to add a stub?}}
 }
 
 struct X1a : P1 {
@@ -52,12 +50,24 @@ struct X1b : P1 {
   func f(_: @escaping (Int) -> Int) { }
 }
 
-struct X1c : P1 { // expected-error{{type 'X1c' does not conform to protocol 'P1'}}
+struct X1c : P1 {
   typealias A = (Int) -> Int
 
-  func f(_: (Int) -> Int) { } // expected-note{{candidate has non-matching type '((Int) -> Int) -> ()'}}
+  func f(_: (Int) -> Int) { }
 }
 
-struct X1d : P1 { // expected-error{{type 'X1d' does not conform to protocol 'P1'}}
-  func f(_: (Int) -> Int) { } // expected-note{{candidate has non-matching type '((Int) -> Int) -> ()' [with A = (Int) -> Int]}}
+struct X1d : P1 {
+  func f(_: (Int) -> Int) { }
+}
+
+protocol P2 {
+  func f(_: (Int) -> Int) // expected-note{{protocol requires function 'f' with type '((Int) -> Int) -> ()'; do you want to add a stub?}}
+}
+
+struct X2a : P2 {
+  func f(_: (Int) -> Int) { }
+}
+
+struct X2b : P2 { // expected-error{{type 'X2b' does not conform to protocol 'P2'}}
+  func f(_: @escaping (Int) -> Int) { } // expected-note{{candidate has non-matching type '(@escaping (Int) -> Int) -> ()'}}
 }

--- a/test/decl/protocol/conforms/associated_type.swift
+++ b/test/decl/protocol/conforms/associated_type.swift
@@ -32,3 +32,32 @@ class Foo: FooType {
     func foo(action: (Bar) -> Void) {
     }
 }
+
+// rdar://problem/35297911: noescape function types
+protocol P1 {
+  associatedtype A
+
+  func f(_: A)
+  // expected-note@-1 {{protocol requires function 'f' with type '(X1c.A) -> ()' (aka '((Int) -> Int) -> ()'); do you want to add a stub?}}
+  // expected-note@-2 {{protocol requires function 'f' with type '((Int) -> Int) -> ()'; do you want to add a stub?}}
+}
+
+struct X1a : P1 {
+  func f(_: @escaping (Int) -> Int) { }
+}
+
+struct X1b : P1 {
+  typealias A = (Int) -> Int
+
+  func f(_: @escaping (Int) -> Int) { }
+}
+
+struct X1c : P1 { // expected-error{{type 'X1c' does not conform to protocol 'P1'}}
+  typealias A = (Int) -> Int
+
+  func f(_: (Int) -> Int) { } // expected-note{{candidate has non-matching type '((Int) -> Int) -> ()'}}
+}
+
+struct X1d : P1 { // expected-error{{type 'X1d' does not conform to protocol 'P1'}}
+  func f(_: (Int) -> Int) { } // expected-note{{candidate has non-matching type '((Int) -> Int) -> ()' [with A = (Int) -> Int]}}
+}


### PR DESCRIPTION
Improve our handling of (non-)escaping function types in conformance checking in two ways to tighten up type soundness:

* Never infer a non-escaping function type as an associated type witness. In particular, when matching an associated type in a requirement to a potential witness with a `noescape` function type, adjust the function type to be escaping. This addresses a type soundness issue, where values of non-escaping function type could arbitrarily escape through type witnesses.
* Allow a witness with a parameter of `noescape` function type match a requirement with a compatible escaping function type. While this limited form of witness covariance is generally a good idea, it is also necessary because closing the type soundness hole describe above would break some existing code.

Fixes rdar://problem/35297911