### PR TITLE
IRGen: Fix handling of empty fields in Clang-imported types.

### DIFF
--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -164,7 +164,8 @@ namespace {
     llvm::Constant *getConstantFieldOffset(IRGenModule &IGM,
                                            VarDecl *field) const {
       auto &fieldInfo = getFieldInfo(field);
-      if (fieldInfo.getKind() == ElementLayout::Kind::Fixed) {
+      if (fieldInfo.getKind() == ElementLayout::Kind::Fixed
+          || fieldInfo.getKind() == ElementLayout::Kind::Empty) {
         return llvm::ConstantInt::get(IGM.SizeTy,
                                     fieldInfo.getFixedByteOffset().getValue());
       }
@@ -773,14 +774,22 @@ private:
     unsigned explosionEnd = NextExplosionIndex;
 
     ElementLayout layout = ElementLayout::getIncomplete(fieldType);
-    layout.completeFixed(fieldType.isPOD(ResilienceExpansion::Maximal),
-                         NextOffset, LLVMFields.size());
+    auto isEmpty = fieldType.isKnownEmpty(ResilienceExpansion::Maximal);
+    if (isEmpty)
+      layout.completeEmpty(fieldType.isPOD(ResilienceExpansion::Maximal),
+                           NextOffset);
+    else
+      layout.completeFixed(fieldType.isPOD(ResilienceExpansion::Maximal),
+                           NextOffset, LLVMFields.size());
 
     FieldInfos.push_back(
            ClangFieldInfo(swiftField, layout, explosionBegin, explosionEnd));
-    LLVMFields.push_back(fieldType.getStorageType());
-    NextOffset += fieldType.getFixedSize();
-    SpareBits.append(fieldType.getSpareBits());
+    
+    if (!isEmpty) {
+      LLVMFields.push_back(fieldType.getStorageType());
+      NextOffset += fieldType.getFixedSize();
+      SpareBits.append(fieldType.getSpareBits());
+    }
   }
 
   /// Add padding to get up to the given offset.

--- a/test/IRGen/Inputs/clang_empty_type.h
+++ b/test/IRGen/Inputs/clang_empty_type.h
@@ -1,0 +1,4 @@
+struct TrailingArray {
+  int size;
+  char buffer[0];
+};

--- a/test/IRGen/clang_empty_type.swift
+++ b/test/IRGen/clang_empty_type.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -emit-ir -verify -import-objc-header %S/Inputs/clang_empty_type.h %s
+
+public func projectTrailingArray(x: inout TrailingArray) {
+  x.size = 2
+  x.buffer = ()
+}


### PR DESCRIPTION
Clang allows C structs to have zero-sized array fields for things like trailing buffers. Lower these correctly into Swift types in IRGen so that Swift codegen knows to treat them as empty types. Fixes rdar://problem/31042794.