### PR TITLE
Restrict a recent XFAILing long_test to assert configurations, rdar://38631299

### DIFF
--- a/validation-test/SIL/parse_stdlib.sil
+++ b/validation-test/SIL/parse_stdlib.sil
@@ -5,4 +5,4 @@
 // REQUIRES: nonexecutable_test
 
 // <rdar://problem/36754225> Swift CI: parse_stdlib.sil tests failing with vtable verification
-// XFAIL: objc_interop
+// XFAIL: (objc_interop && asserts)


### PR DESCRIPTION
This recent XFAIL only actually fails when asserts are on. More-recently the construction of a builder that does long_tests in non-assert mode XPASSes here. Fixing the test accordingly, cc @jrose-apple 

rdar://38631299