### PR TITLE
Allow designated initializers outside the ClassDecl

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -162,17 +162,6 @@ enum class CircularityCheck {
   Checked
 };
 
-/// Keeps track of whether a given class inherits initializers from its
-/// superclass.
-enum class StoredInheritsSuperclassInits {
-  /// We have not yet checked.
-  Unchecked,
-  /// Superclass initializers are not inherited.
-  NotInherited,
-  /// Convenience initializers in the superclass are inherited.
-  Inherited
-};
-
 /// Describes which spelling was used in the source for the 'static' or 'class'
 /// keyword.
 enum class StaticSpellingKind : uint8_t {
@@ -506,7 +495,7 @@ protected:
     NumRequirementsInSignature : 16
   );
 
-  SWIFT_INLINE_BITFIELD(ClassDecl, NominalTypeDecl, 1+2+2+2+1+3+1+1,
+  SWIFT_INLINE_BITFIELD(ClassDecl, NominalTypeDecl, 1+2+1+2+1+3+1+1,
     /// Whether this class requires all of its instance variables to
     /// have in-class initializers.
     RequiresStoredPropertyInits : 1,
@@ -514,11 +503,8 @@ protected:
     /// The stage of the inheritance circularity check for this class.
     Circularity : 2,
 
-    /// Whether this class inherits its superclass's convenience
-    /// initializers.
-    ///
-    /// This is a value of \c StoredInheritsSuperclassInits.
-    InheritsSuperclassInits : 2,
+    /// Whether this class inherits its superclass's convenience initializers.
+    InheritsSuperclassInits : 1,
 
     /// \see ClassDecl::ForeignKind
     RawForeignKind : 2,
@@ -3471,6 +3457,15 @@ public:
   /// \param resolver Used to resolve the signatures of initializers, which is
   /// required for name lookup.
   bool inheritsSuperclassInitializers(LazyResolver *resolver);
+
+  /// Marks that this class inherits convenience initializers from its
+  /// superclass.
+  ///
+  /// This is computed as part of adding implicit initializers.
+  void setInheritsSuperclassInitializers() {
+    assert(addedImplicitInitializers());
+    Bits.ClassDecl.InheritsSuperclassInits = true;
+  }
 
   /// Figure out if this class has any @objc ancestors, in which case it should
   /// have implicitly @objc members. Note that a class with generic ancestry

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 403; // Last change: `init` special name
+const uint16_t VERSION_MINOR = 404; // Last change: inheritsSuperclassInitializers
 
 using DeclIDField = BCFixed<31>;
 
@@ -887,7 +887,8 @@ namespace decls_block {
     DeclContextIDField,// context decl
     BCFixed<1>,        // implicit?
     BCFixed<1>,        // explicitly objc?
-    BCFixed<1>,        // requires stored property initial values
+    BCFixed<1>,        // requires stored property initial values?
+    BCFixed<1>,        // inherits convenience initializers from its superclass?
     GenericEnvironmentIDField, // generic environment
     TypeIDField,       // superclass
     AccessLevelField, // access level

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4654,7 +4654,6 @@ namespace {
 
       Impl.ImportedDecls[{decl->getCanonicalDecl(), getVersion()}] = result;
       result->setCircularityCheck(CircularityCheck::Checked);
-      result->setAddedImplicitInitializers();
       addObjCAttribute(result, Impl.importIdentifier(decl->getIdentifier()));
 
       if (declaredNative)

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -8894,11 +8894,6 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
 
       // A designated or required initializer has not been overridden.
 
-      // Skip this designated initializer if it's in an extension.
-      // FIXME: We shouldn't allow this.
-      if (isa<ExtensionDecl>(superclassCtor->getDeclContext()))
-        continue;
-
       // If we have already introduced an initializer with this parameter type,
       // don't add one now.
       if (!initializerParamTypes.insert(

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -3548,6 +3548,7 @@ ModuleFile::getDeclCheckedImpl(DeclID DID, Optional<DeclContext *> ForcedContext
     IdentifierID nameID;
     DeclContextID contextID;
     bool isImplicit, isObjC, requiresStoredPropertyInits;
+    bool inheritsSuperclassInitializers;
     GenericEnvironmentID genericEnvID;
     TypeID superclassID;
     uint8_t rawAccessLevel;
@@ -3556,6 +3557,7 @@ ModuleFile::getDeclCheckedImpl(DeclID DID, Optional<DeclContext *> ForcedContext
     decls_block::ClassLayout::readRecord(scratch, nameID, contextID,
                                          isImplicit, isObjC,
                                          requiresStoredPropertyInits,
+                                         inheritsSuperclassInitializers,
                                          genericEnvID, superclassID,
                                          rawAccessLevel, numConformances,
                                          rawInheritedIDs);
@@ -3587,6 +3589,8 @@ ModuleFile::getDeclCheckedImpl(DeclID DID, Optional<DeclContext *> ForcedContext
     theClass->setSuperclass(getType(superclassID));
     if (requiresStoredPropertyInits)
       theClass->setRequiresStoredPropertyInits(true);
+    if (inheritsSuperclassInitializers)
+      theClass->setInheritsSuperclassInitializers();
 
     theClass->computeType();
 

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3046,6 +3046,10 @@ void Serializer::writeDecl(const Decl *D) {
     uint8_t rawAccessLevel =
       getRawStableAccessLevel(theClass->getFormalAccess());
 
+    bool inheritsSuperclassInitializers =
+        const_cast<ClassDecl *>(theClass)->
+          inheritsSuperclassInitializers(nullptr);
+
     unsigned abbrCode = DeclTypeAbbrCodes[ClassLayout::Code];
     ClassLayout::emitRecord(Out, ScratchRecord, abbrCode,
                             addDeclBaseNameRef(theClass->getName()),
@@ -3053,6 +3057,7 @@ void Serializer::writeDecl(const Decl *D) {
                             theClass->isImplicit(),
                             theClass->isObjC(),
                             theClass->requiresStoredPropertyInits(),
+                            inheritsSuperclassInitializers,
                             addGenericEnvironmentRef(
                                              theClass->getGenericEnvironment()),
                             addTypeRef(theClass->getSuperclass()),

--- a/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.h
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCParseExtras.h
@@ -154,6 +154,19 @@ __weak id globalWeakVar;
 - (instancetype)initWithInt:(NSInteger)value __attribute__((objc_designated_initializer));
 @end
 
+@interface DesignatedInitWithClassExtension : DesignatedInitRoot
+- (instancetype)initWithInt:(NSInteger)value __attribute__((objc_designated_initializer));
+- (instancetype)initWithConvenienceInt:(NSInteger)value;
+@end
+@interface DesignatedInitWithClassExtension ()
+- (instancetype)initWithFloat:(float)value __attribute__((objc_designated_initializer));
+@end
+
+@interface DesignatedInitWithClassExtensionInAnotherModule : DesignatedInitRoot
+- (instancetype)initWithInt:(NSInteger)value __attribute__((objc_designated_initializer));
+- (instancetype)initWithConvenienceInt:(NSInteger)value;
+@end
+
 
 @protocol ExplicitSetterProto
 @property (readonly) id foo;

--- a/test/ClangImporter/Inputs/custom-modules/ObjCParseExtrasInitHelper.h
+++ b/test/ClangImporter/Inputs/custom-modules/ObjCParseExtrasInitHelper.h
@@ -1,0 +1,5 @@
+@import ObjCParseExtras;
+
+@interface DesignatedInitWithClassExtensionInAnotherModule (/*ew*/)
+- (instancetype)initWithFloat:(float)value __attribute__((objc_designated_initializer));
+@end

--- a/test/ClangImporter/Inputs/custom-modules/UnimportableMembers.h
+++ b/test/ClangImporter/Inputs/custom-modules/UnimportableMembers.h
@@ -32,3 +32,23 @@ __attribute__((objc_root_class))
 @interface IncompleteUnknownInitializers (CategoryConvenience)
 - (instancetype)initCategory:(long)x;
 @end
+
+@interface IncompleteDesignatedInitializersWithCategory : Base
+- (instancetype)initFirst:(long)x __attribute__((objc_designated_initializer));
+- (instancetype)initMissing:(long)x, ... __attribute__((objc_designated_initializer));
+- (instancetype)initConveniently:(long)x;
+@end
+@interface IncompleteDesignatedInitializersWithCategory (/*class extension*/)
+- (instancetype)initSecond:(long)x __attribute__((objc_designated_initializer));
+- (instancetype)initCategory:(long)x;
+@end
+
+@interface DesignatedInitializerInAnotherModule : Base
+- (instancetype)initFirst:(long)x __attribute__((objc_designated_initializer));
+- (instancetype)initSecond:(long)x __attribute__((objc_designated_initializer));
+- (instancetype)initMissing:(long)x, ... __attribute__((objc_designated_initializer));
+- (instancetype)initConveniently:(long)x;
+@end
+@interface DesignatedInitializerInAnotherModule (CategoryConvenience)
+- (instancetype)initCategory:(long)x;
+@end

--- a/test/ClangImporter/Inputs/custom-modules/UnimportableMembersUser.h
+++ b/test/ClangImporter/Inputs/custom-modules/UnimportableMembersUser.h
@@ -1,0 +1,5 @@
+@import UnimportableMembers;
+
+@interface DesignatedInitializerInAnotherModule (/*evil class extension*/)
+- (instancetype)initFromOtherModule:(long)x __attribute__((objc_designated_initializer));
+@end

--- a/test/ClangImporter/Inputs/custom-modules/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/module.map
@@ -100,6 +100,11 @@ module ObjCParseExtras {
   export *
 }
 
+module ObjCParseExtrasInitHelper {
+  header "ObjCParseExtrasInitHelper.h"
+  export *
+}
+
 module ObjCParseExtrasToo {
   header "ObjCParseExtrasToo.h"
   export *
@@ -158,6 +163,9 @@ module TypeAndValue {
 
 module UnimportableMembers {
   header "UnimportableMembers.h"
+}
+module UnimportableMembersUser {
+  header "UnimportableMembersUser.h"
 }
 
 module UsesSubmodule {

--- a/test/ClangImporter/objc_init.swift
+++ b/test/ClangImporter/objc_init.swift
@@ -6,6 +6,7 @@ import AppKit
 import objc_ext
 import TestProtocols
 import ObjCParseExtras
+import ObjCParseExtrasInitHelper
 
 // rdar://problem/18500201
 extension NSSet {
@@ -164,6 +165,29 @@ class DesignatedInitSub : DesignatedInitBase {
 class DesignedInitSubSub : DesignatedInitSub {
   init(double: Double) { super.init(int: 0) } // okay
   init(string: String) { super.init() } // expected-error {{must call a designated initializer of the superclass 'DesignatedInitSub'}}
+}
+
+class DesignatedInitWithClassExtensionSubImplicit : DesignatedInitWithClassExtension {}
+
+class DesignatedInitWithClassExtensionSub : DesignatedInitWithClassExtension {
+  override init(int: Int) { super.init(int: 0) }
+  override init(float: Float) { super.init(float: 0) }
+}
+
+class DesignatedInitWithClassExtensionInAnotherModuleSub : DesignatedInitWithClassExtensionInAnotherModule {}
+
+func testInitializerInheritance() {
+  _ = DesignatedInitWithClassExtensionSubImplicit(int: 0)
+  _ = DesignatedInitWithClassExtensionSubImplicit(convenienceInt: 0)
+  _ = DesignatedInitWithClassExtensionSubImplicit(float: 0)
+
+  _ = DesignatedInitWithClassExtensionSub(int: 0)
+  _ = DesignatedInitWithClassExtensionSub(convenienceInt: 0)
+  _ = DesignatedInitWithClassExtensionSub(float: 0)
+
+  _ = DesignatedInitWithClassExtensionInAnotherModuleSub(int: 0)
+  _ = DesignatedInitWithClassExtensionInAnotherModuleSub(convenienceInt: 0)
+  _ = DesignatedInitWithClassExtensionInAnotherModuleSub(float: 0)
 }
 
 // Make sure that our magic doesn't think the class property with the type name is an init

--- a/test/ClangImporter/objc_missing_designated_init.swift
+++ b/test/ClangImporter/objc_missing_designated_init.swift
@@ -3,6 +3,7 @@
 // REQUIRES: objc_interop
 
 import UnimportableMembers
+import UnimportableMembersUser
 
 class IncompleteInitSubclassImplicit : IncompleteDesignatedInitializers {
   var myOneNewMember = 1
@@ -16,6 +17,16 @@ class IncompleteInitSubclass : IncompleteDesignatedInitializers {
 class IncompleteConvenienceInitSubclass : IncompleteConvenienceInitializers {}
 
 class IncompleteUnknownInitSubclass : IncompleteUnknownInitializers {}
+
+class IncompleteInitCategorySubclassImplicit : IncompleteDesignatedInitializersWithCategory {}
+
+class IncompleteInitCategorySubclass : IncompleteDesignatedInitializersWithCategory {
+  override init(first: Int) {}
+  override init(second: Int) {}
+}
+
+class DesignatedInitializerInAnotherModuleSubclass : DesignatedInitializerInAnotherModule {}
+
 
 func testBaseClassesBehaveAsExpected() {
   _ = IncompleteDesignatedInitializers(first: 0) // okay
@@ -35,6 +46,19 @@ func testBaseClassesBehaveAsExpected() {
   _ = IncompleteUnknownInitializers(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
   _ = IncompleteUnknownInitializers(conveniently: 0) // okay
   _ = IncompleteUnknownInitializers(category: 0) // okay
+
+  _ = IncompleteDesignatedInitializersWithCategory(first: 0) // okay
+  _ = IncompleteDesignatedInitializersWithCategory(second: 0) // okay
+  _ = IncompleteDesignatedInitializersWithCategory(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteDesignatedInitializersWithCategory(conveniently: 0) // okay
+  _ = IncompleteDesignatedInitializersWithCategory(category: 0) // okay
+
+  _ = DesignatedInitializerInAnotherModule(first: 0) // okay
+  _ = DesignatedInitializerInAnotherModule(second: 0) // okay
+  _ = DesignatedInitializerInAnotherModule(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = DesignatedInitializerInAnotherModule(conveniently: 0) // okay
+  _ = DesignatedInitializerInAnotherModule(category: 0) // okay
+  _ = DesignatedInitializerInAnotherModule(fromOtherModule: 0) // okay
 }
 
 func testSubclasses() {
@@ -60,9 +84,24 @@ func testSubclasses() {
   _ = IncompleteUnknownInitSubclass(second: 0) // okay
   _ = IncompleteUnknownInitSubclass(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
   _ = IncompleteUnknownInitSubclass(conveniently: 0) // okay
+  _ = IncompleteUnknownInitSubclass(category: 0) // okay
 
-  // FIXME: This initializer isn't being inherited for some reason, unrelated
-  // to the non-importable -initMissing:.
-  // https://bugs.swift.org/browse/SR-4566
-  _ = IncompleteUnknownInitSubclass(category: 0) // expected-error {{argument labels '(category:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteInitCategorySubclass(first: 0) // okay
+  _ = IncompleteInitCategorySubclass(second: 0) // okay
+  _ = IncompleteInitCategorySubclass(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteInitCategorySubclass(conveniently: 0) // expected-error {{argument labels '(conveniently:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteInitCategorySubclass(category: 0) // expected-error {{argument labels '(category:)' do not match any available overloads}} expected-note {{overloads}}
+
+  _ = IncompleteInitCategorySubclassImplicit(first: 0) // okay
+  _ = IncompleteInitCategorySubclassImplicit(second: 0) // okay
+  _ = IncompleteInitCategorySubclassImplicit(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteInitCategorySubclassImplicit(conveniently: 0) // expected-error {{argument labels '(conveniently:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = IncompleteInitCategorySubclassImplicit(category: 0) // expected-error {{argument labels '(category:)' do not match any available overloads}} expected-note {{overloads}}
+
+  _ = DesignatedInitializerInAnotherModuleSubclass(first: 0) // okay
+  _ = DesignatedInitializerInAnotherModuleSubclass(second: 0) // okay
+  _ = DesignatedInitializerInAnotherModuleSubclass(missing: 0) // expected-error {{argument labels '(missing:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = DesignatedInitializerInAnotherModuleSubclass(conveniently: 0) // expected-error {{argument labels '(conveniently:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = DesignatedInitializerInAnotherModuleSubclass(category: 0) // expected-error {{argument labels '(category:)' do not match any available overloads}} expected-note {{overloads}}
+  _ = DesignatedInitializerInAnotherModuleSubclass(fromOtherModule: 0) // okay
 }

--- a/test/attr/attr_required.swift
+++ b/test/attr/attr_required.swift
@@ -55,6 +55,12 @@ class C5b : C4 {
   func wibble() { }
 }
 
+class C6 : C {
+  init() { super.init(string: "") }
+  required convenience init(string: String) { self.init() }
+}
+
+
 class Foo {
   required init() { }
   // expected-note@-1{{'required' initializer is declared in superclass here}}
@@ -70,4 +76,29 @@ class Baz : Bar {
 
 class Baz2 : Bar {
   init() { super.init() } // expected-error {{'required' modifier must be present on all overrides of a required initializer}}
+}
+
+
+class HasRequiredConvenienceInit {
+  init() {}
+  required convenience init(conveniently: Int) { self.init() } // expected-note {{here}}
+}
+
+class InheritsAllInits: HasRequiredConvenienceInit {}
+
+class InheritsConvenienceInits: HasRequiredConvenienceInit {
+  override init() {}
+}
+
+class DoesNotInheritConvenienceInits: HasRequiredConvenienceInit {
+  init(value: Int) { super.init() }
+} // expected-error {{'required' initializer 'init(conveniently:)' must be provided by subclass of 'HasRequiredConvenienceInit'}}
+
+class ProvidesNewConvenienceInit: HasRequiredConvenienceInit {
+  init(value: Int) { super.init() }
+  required convenience init(conveniently: Int) { self.init(value: 1) }
+}
+
+class ProvidesNewDesignatedInit: HasRequiredConvenienceInit {
+  required init(conveniently: Int) { super.init() }
 }


### PR DESCRIPTION
Objective-C allows this in "class extensions" (nameless categories); what's worse is that it's actually useful-ish sometimes: when you want to put a particular initializer in an explicit submodule, or only expose it to the current target.

The second commit here is a refactoring to simplify `ClassDecl::inheritsSuperclassInitializers`, which is duplicating a bunch of the logic in the type checker's `resolveImplicitConstructors` operation. Collapse the duplication even though it makes `resolveImplicitConstructors` a little more complicated.

[SR-4566](https://bugs.swift.org/browse/SR-4566) / rdar://problem/37173549