### PR TITLE
[Runtime] Reference ObjC class objects indirectly in conformance records

### DIFF
--- a/include/swift/IRGen/Linking.h
+++ b/include/swift/IRGen/Linking.h
@@ -766,6 +766,9 @@ public:
   bool isForeignTypeMetadataCandidate() const {
     return getKind() == Kind::ForeignTypeMetadataCandidate;
   }
+  bool isObjCClassRef() const {
+    return getKind() == Kind::ObjCClassRef;
+  }
 
   /// Determine whether this entity will be weak-imported.
   bool isWeakImported(ModuleDecl *module) const {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2445,6 +2445,15 @@ IRGenModule::getAddrOfLLVMVariableOrGOTEquivalent(LinkEntity entity,
                               Alignment alignment,
                               llvm::Type *defaultType,
                               ConstantReference::Directness forceIndirectness) {
+  // ObjC class references can always be directly referenced, even in
+  // the weird cases where we don't see a definition.
+  if (entity.isObjCClassRef()) {
+    auto value = getAddrOfObjCClassRef(
+      const_cast<ClassDecl *>(cast<ClassDecl>(entity.getDecl())));
+    return { cast<llvm::Constant>(value.getAddress()),
+             ConstantReference::Direct };
+  }
+
   // Ensure the variable is at least forward-declared.
   if (entity.isForeignTypeMetadataCandidate()) {
     auto foreignCandidate
@@ -2522,7 +2531,7 @@ IRGenModule::getTypeEntityReference(NominalTypeDecl *decl) {
 
     kind = TypeMetadataRecordKind::IndirectObjCClass;
     defaultTy = TypeMetadataPtrTy;
-    entity = LinkEntity::forObjCClass(clas);
+    entity = LinkEntity::forObjCClassRef(clas);
   } else {
     // A reference to a concrete type.
     // TODO: consider using a symbolic reference (i.e. a symbol string
@@ -2537,8 +2546,8 @@ IRGenModule::getTypeEntityReference(NominalTypeDecl *decl) {
 
   // Adjust the flags now that we know whether the reference to this
   // entity will be indirect.
-  if (ref.isIndirect() &&
-      kind == TypeMetadataRecordKind::DirectNominalTypeDescriptor) {
+  if (ref.isIndirect()) {
+    assert(kind == TypeMetadataRecordKind::DirectNominalTypeDescriptor);
     kind = TypeMetadataRecordKind::IndirectNominalTypeDescriptor;
   }
 

--- a/lib/IRGen/Linking.cpp
+++ b/lib/IRGen/Linking.cpp
@@ -191,7 +191,7 @@ std::string LinkEntity::mangleAsString() const {
     case Kind::ObjCClassRef: {
       llvm::SmallString<64> tempBuffer;
       StringRef name = cast<ClassDecl>(getDecl())->getObjCRuntimeName(tempBuffer);
-      std::string Result("OBJC_CLASS_REF_$_");
+      std::string Result("\01l_OBJC_CLASS_REF_$_");
       Result.append(name.data(), name.size());
       return Result;
     }

--- a/test/ClangImporter/attr-swift_private.swift
+++ b/test/ClangImporter/attr-swift_private.swift
@@ -92,7 +92,7 @@ public func testTopLevel() {
 }
 
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$SSo10PrivFooSubCMa{{.*}} {
-// CHECK: %objc_class** @"OBJC_CLASS_REF_$_PrivFooSub"
+// CHECK: %objc_class** @"\01l_OBJC_CLASS_REF_$_PrivFooSub"
 // CHECK: }
 
 // CHECK-LABEL: define linkonce_odr hidden {{.+}} @"$SSo3BarC8__noArgsABSgyt_tcfcTO"

--- a/test/ClangImporter/objc_ir.swift
+++ b/test/ClangImporter/objc_ir.swift
@@ -74,7 +74,7 @@ func propertyAccess(b b: B) {
    // CHECK: load i8*, i8** @"\01L_selector(setCounter:)"
    b.counter = b.counter + 1
 
-   // CHECK: load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_B"
+   // CHECK: load %objc_class*, %objc_class** @"\01l_OBJC_CLASS_REF_$_B"
    // CHECK: load i8*, i8** @"\01L_selector(sharedCounter)"
    // CHECK: load i8*, i8** @"\01L_selector(setSharedCounter:)"
    B.sharedCounter = B.sharedCounter + 1
@@ -82,7 +82,7 @@ func propertyAccess(b b: B) {
 
 // CHECK-LABEL: define hidden swiftcc %TSo1BC* @"$S7objc_ir8downcast1aSo1BCSo1AC_tF"(
 func downcast(a a: A) -> B {
-  // CHECK: [[CLASS:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_B"
+  // CHECK: [[CLASS:%.*]] = load %objc_class*, %objc_class** @"\01l_OBJC_CLASS_REF_$_B"
   // CHECK: [[T0:%.*]] = call %objc_class* @swift_getInitializedObjCClass(%objc_class* [[CLASS]])
   // CHECK: [[T1:%.*]] = bitcast %objc_class* [[T0]] to i8*
   // CHECK: call i8* @swift_dynamicCastObjCClassUnconditional(i8* [[A:%.*]], i8* [[T1]]) [[NOUNWIND:#[0-9]+]]

--- a/test/IRGen/COFF-objc-sections.swift
+++ b/test/IRGen/COFF-objc-sections.swift
@@ -21,7 +21,7 @@ class D {
 // CHECK-COFF-NOT: @"$S4main1CCMf" = {{.*}}, section "__DATA,__objc_data, regular"
 // CHECK-COFF: @"\01l_OBJC_LABEL_PROTOCOL_$_P" = {{.*}}, section ".objc_protolist$B"
 // CHECK-COFF: @"\01l_OBJC_PROTOCOL_REFERENCE_$_P" = {{.*}}, section ".objc_protorefs$B"
-// CHECK-COFF: @"OBJC_CLASS_REF_$_I" = {{.*}}, section ".objc_classrefs$B"
+// CHECK-COFF: @"\01l_OBJC_CLASS_REF_$_I" = {{.*}}, section ".objc_classrefs$B"
 // CHECK-COFF: @"\01L_selector(init)" = {{.*}}, section ".objc_selrefs$B"
 // CHECK-COFF: @objc_classes = {{.*}}, section ".objc_classlist$B"
 // CHECK-COFF: @objc_categories = {{.*}}, section ".objc_catlist$B"

--- a/test/IRGen/ELF-objc-sections.swift
+++ b/test/IRGen/ELF-objc-sections.swift
@@ -21,7 +21,7 @@ class D {
 // CHECK-ELF-NOT: @"$S4main1CCMf" = {{.*}}, section "__DATA,__objc_data, regular"
 // CHECK-ELF: @"\01l_OBJC_LABEL_PROTOCOL_$_P" = {{.*}}, section "objc_protolist"
 // CHECK-ELF: @"\01l_OBJC_PROTOCOL_REFERENCE_$_P" = {{.*}}, section "objc_protorefs", align 8
-// CHECK-ELF: @"OBJC_CLASS_REF_$_I" = {{.*}}, section "objc_classrefs", align 8
+// CHECK-ELF: @"\01l_OBJC_CLASS_REF_$_I" = {{.*}}, section "objc_classrefs", align 8
 // CHECK-ELF: @"\01L_selector(init)" = {{.*}}, section "objc_selrefs"
 // CHECK-ELF: @objc_classes = {{.*}}, section "objc_classlist"
 // CHECK-ELF: @objc_categories = {{.*}}, section "objc_catlist"

--- a/test/IRGen/objc_bridged_generic_conformance.swift
+++ b/test/IRGen/objc_bridged_generic_conformance.swift
@@ -3,7 +3,7 @@
 
 // CHECK-NOT: _TMnCSo
 
-// CHECK: @"$SSo6ThingyCyxG32objc_bridged_generic_conformance1PADMc" = hidden constant %swift.protocol_conformance_descriptor {{.*}} @"got.OBJC_CLASS_$_Thingy"
+// CHECK: @"$SSo6ThingyCyxG32objc_bridged_generic_conformance1PADMc" = hidden constant %swift.protocol_conformance_descriptor {{.*}} @"\01l_OBJC_CLASS_REF_$_Thingy"
 
 // CHECK-NOT: _TMnCSo
 

--- a/test/IRGen/objc_casts.sil
+++ b/test/IRGen/objc_casts.sil
@@ -28,7 +28,7 @@ bb0(%unused : $@thick T.Type, %obj : $NSObject):
 // CHECK:       [[T0:%.*]] = call %objc_object* @swift_dynamicCastMetatypeToObjectUnconditional(%swift.type* %0)
 //   TODO: is this really necessary? also, this really shouldn't use a direct reference
 // CHECK-NEXT:  [[T1:%.*]] = bitcast %objc_object* [[T0]] to i8*
-// CHECK-NEXT:  [[T2a:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_Foo"
+// CHECK-NEXT:  [[T2a:%.*]] = load %objc_class*, %objc_class** @"\01l_OBJC_CLASS_REF_$_Foo"
 // CHECK-NEXT:  [[T2:%.*]] = call %objc_class* @swift_getInitializedObjCClass(%objc_class* [[T2a]])
 // CHECK-NEXT:  [[T3:%.*]] = bitcast %objc_class* [[T2]] to i8*
 // CHECK-NEXT:  call i8* @swift_dynamicCastObjCClassUnconditional(i8* [[T1]], i8* [[T3]])
@@ -44,7 +44,7 @@ bb0(%metatype : $@thick T.Type):
 // CHECK:       [[T0:%.*]] = call %objc_object* @swift_dynamicCastMetatypeToObjectUnconditional(%swift.type* [[ARG]])
 //   TODO: is this really necessary? also, this really shouldn't use a direct reference
 // CHECK-NEXT:  [[T1:%.*]] = bitcast %objc_object* [[T0]] to i8*
-// CHECK-NEXT:  [[T2a:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_Foo"
+// CHECK-NEXT:  [[T2a:%.*]] = load %objc_class*, %objc_class** @"\01l_OBJC_CLASS_REF_$_Foo"
 // CHECK-NEXT:  [[T2:%.*]] = call %objc_class* @swift_getInitializedObjCClass(%objc_class* [[T2a]])
 // CHECK-NEXT:  [[T3:%.*]] = bitcast %objc_class* [[T2]] to i8*
 // CHECK-NEXT:  call i8* @swift_dynamicCastObjCClassUnconditional(i8* [[T1]], i8* [[T3]])

--- a/test/IRGen/objc_generic_class_metadata.sil
+++ b/test/IRGen/objc_generic_class_metadata.sil
@@ -39,7 +39,7 @@ entry:
   %b = metatype $@thick GenericClass<NSObject>.Type
   apply %z<GenericClass<NSObject>>(%b) : $@convention(thin) <T> (@thick T.Type) -> ()
 
-  // CHECK: [[T0:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_GenericClass",
+  // CHECK: [[T0:%.*]] = load %objc_class*, %objc_class** @"\01l_OBJC_CLASS_REF_$_GenericClass",
   // CHECK: [[OBJC_CLASS:%.*]] = call %objc_class* @swift_getInitializedObjCClass(%objc_class* [[T0]])
   // CHECK: call swiftcc void @objc_class_sink(%objc_class* [[OBJC_CLASS]], %swift.type* [[METADATA]])
   %c = metatype $@objc_metatype GenericClass<NSString>.Type
@@ -79,7 +79,7 @@ entry(%0: $Subclass, %1: $NSDictionary):
 }
 
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$SSo12GenericClassCMa"(
-// CHECK:         [[T0:%.*]] = load %objc_class*, %objc_class** @"OBJC_CLASS_REF_$_GenericClass",
+// CHECK:         [[T0:%.*]] = load %objc_class*, %objc_class** @"\01l_OBJC_CLASS_REF_$_GenericClass",
 // CHECK:         call %objc_class* @swift_getInitializedObjCClass(%objc_class* [[T0]])
 
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$SSaySo12GenericClassC_SitGMa"

--- a/test/IRGen/protocol_conformance_records_objc.swift
+++ b/test/IRGen/protocol_conformance_records_objc.swift
@@ -30,7 +30,7 @@ extension NSRect: Runcible {
 // -- protocol descriptor
 // CHECK-SAME:           [[RUNCIBLE]]
 // -- class object reference
-// CHECK-SAME:           @"got.OBJC_CLASS_$_Gizmo"
+// CHECK-SAME:           @"\01l_OBJC_CLASS_REF_$_Gizmo"
 // -- witness table
 // CHECK-SAME:           @"$SSo5GizmoC33protocol_conformance_records_objc8RuncibleACWP"
 // -- flags


### PR DESCRIPTION
Within conformance records, reference Objective-C class objects
indirectly so the runtime can update those references appropriately.
We don't need to do this for classes with Swift metadata.

Make all OBJC_CLASS_REF symbols object-local using "\01l", which
prevents the linker from producing incorrect relative addresses.

Fixes the ABI-affecting part of rdar://problem/36310179.
