### PR TITLE
Updates to tgmath functions for CGFloat

### DIFF
--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -83,30 +83,6 @@ public func frexp<T: BinaryFloatingPoint>(_ x: T) -> (T, Int) {
 }
 
 %for T in ['Float','Double']:
-@available(swift, obsoleted: 4.2)
-@_transparent
-public func scalbn(_ x: ${T}, _ n : Int) -> ${T} {
-  return ${T}(sign: .plus, exponent: n, significand: x)
-}
-
-@available(swift, obsoleted: 4.2)
-@_transparent
-public func modf(_ x: ${T}) -> (${T}, ${T}) {
-  // inf/NaN: return canonicalized x, fractional part zero.
-  guard x.isFinite else { return (x+0, 0) }
-  let integral = trunc(x)
-  let fractional = x - integral
-  return (integral, fractional)
-}
-
-@available(swift, obsoleted: 4.2)
-@_transparent
-public func frexp(_ x: ${T}) -> (${T}, Int) {
-  guard x.isFinite else { return (x+0, 0) }
-  guard x != 0 else { return (x, 0) }
-  return (x.significand / 2, Int(x.exponent + 1))
-}
-
 @available(swift, deprecated: 4.2, renamed: "scalbn")
 @_transparent
 public func ldexp(_ x: ${T}, _ n : Int) -> ${T} {

--- a/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
@@ -499,175 +499,36 @@ public func %=(lhs: inout CGFloat, rhs: CGFloat) {
 // tgmath
 //===----------------------------------------------------------------------===//
 
+%{
+UnaryFunctions = [
+  'acos', 'asin', 'atan', 'cos', 'sin', 'tan',
+  'acosh', 'asinh', 'atanh', 'cosh', 'sinh', 'tanh',
+  'exp', 'exp2', 'expm1',
+  'log', 'log10', 'log1p', 'log2', 'logb',
+  'cbrt', 'erf', 'erfc', 'tgamma',
+  'nearbyint', 'rint'
+]
+
+BinaryFunctions = [
+  'atan2', 'hypot', 'pow', 'copysign', 'nextafter', 'fdim', 'fmax', 'fmin'
+]
+}%
+
+%for ufunc in UnaryFunctions:
 @_transparent
-public func acos(_ x: CGFloat) -> CGFloat {
-  return CGFloat(acos(x.native))
+public func ${ufunc}(_ x: CGFloat) -> CGFloat {
+  return CGFloat(${ufunc}(x.native))
 }
 
+%end
+
+%for bfunc in BinaryFunctions:
 @_transparent
-public func cos(_ x: CGFloat) -> CGFloat {
-  return CGFloat(cos(x.native))
+public func ${bfunc}(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
+  return CGFloat(${bfunc}(lhs.native, rhs.native))
 }
 
-@_transparent
-public func sin(_ x: CGFloat) -> CGFloat {
-  return CGFloat(sin(x.native))
-}
-
-@_transparent
-public func asin(_ x: CGFloat) -> CGFloat {
-  return CGFloat(asin(x.native))
-}
-
-@_transparent
-public func atan(_ x: CGFloat) -> CGFloat {
-  return CGFloat(atan(x.native))
-}
-
-@_transparent
-public func tan(_ x: CGFloat) -> CGFloat {
-  return CGFloat(tan(x.native))
-}
-
-@_transparent
-public func acosh(_ x: CGFloat) -> CGFloat {
-  return CGFloat(acosh(x.native))
-}
-
-@_transparent
-public func asinh(_ x: CGFloat) -> CGFloat {
-  return CGFloat(asinh(x.native))
-}
-
-@_transparent
-public func atanh(_ x: CGFloat) -> CGFloat {
-  return CGFloat(atanh(x.native))
-}
-
-@_transparent
-public func cosh(_ x: CGFloat) -> CGFloat {
-  return CGFloat(cosh(x.native))
-}
-
-@_transparent
-public func sinh(_ x: CGFloat) -> CGFloat {
-  return CGFloat(sinh(x.native))
-}
-
-@_transparent
-public func tanh(_ x: CGFloat) -> CGFloat {
-  return CGFloat(tanh(x.native))
-}
-
-@_transparent
-public func exp(_ x: CGFloat) -> CGFloat {
-  return CGFloat(exp(x.native))
-}
-
-@_transparent
-public func exp2(_ x: CGFloat) -> CGFloat {
-  return CGFloat(exp2(x.native))
-}
-
-@_transparent
-public func expm1(_ x: CGFloat) -> CGFloat {
-  return CGFloat(expm1(x.native))
-}
-
-@_transparent
-public func log(_ x: CGFloat) -> CGFloat {
-  return CGFloat(log(x.native))
-}
-
-@_transparent
-public func log10(_ x: CGFloat) -> CGFloat {
-  return CGFloat(log10(x.native))
-}
-
-@_transparent
-public func log2(_ x: CGFloat) -> CGFloat {
-  return CGFloat(log2(x.native))
-}
-
-@_transparent
-public func log1p(_ x: CGFloat) -> CGFloat {
-  return CGFloat(log1p(x.native))
-}
-
-@_transparent
-public func logb(_ x: CGFloat) -> CGFloat {
-  return CGFloat(logb(x.native))
-}
-
-@_transparent
-public func cbrt(_ x: CGFloat) -> CGFloat {
-  return CGFloat(cbrt(x.native))
-}
-
-@_transparent
-public func erf(_ x: CGFloat) -> CGFloat {
-  return CGFloat(erf(x.native))
-}
-
-@_transparent
-public func erfc(_ x: CGFloat) -> CGFloat {
-  return CGFloat(erfc(x.native))
-}
-
-@_transparent
-public func tgamma(_ x: CGFloat) -> CGFloat {
-  return CGFloat(tgamma(x.native))
-}
-
-@_transparent
-public func nearbyint(_ x: CGFloat) -> CGFloat {
-  return CGFloat(nearbyint(x.native))
-}
-
-@_transparent
-public func rint(_ x: CGFloat) -> CGFloat {
-  return CGFloat(rint(x.native))
-}
-
-@_transparent
-public func atan2(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
-  return CGFloat(atan2(lhs.native, rhs.native))
-}
-
-@_transparent
-public func hypot(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
-  return CGFloat(hypot(lhs.native, rhs.native))
-}
-
-@_transparent
-public func pow(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
-  return CGFloat(pow(lhs.native, rhs.native))
-}
-
-@_transparent
-public func copysign(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
-  return CGFloat(copysign(lhs.native, rhs.native))
-}
-
-@_transparent
-public func nextafter(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
-  return CGFloat(nextafter(lhs.native, rhs.native))
-}
-
-@_transparent
-public func fdim(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
-  return CGFloat(fdim(lhs.native, rhs.native))
-}
-
-@_transparent
-public func fmax(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
-  return CGFloat(fmax(lhs.native, rhs.native))
-}
-
-@_transparent
-public func fmin(_ lhs: CGFloat, _ rhs: CGFloat) -> CGFloat {
-  return CGFloat(fmin(lhs.native, rhs.native))
-}
+%end
 
 @_transparent
 @available(*, unavailable, message: "use the floatingPointClass property.")
@@ -690,28 +551,36 @@ public func isnan(_ value: CGFloat) -> Bool { return value.isNaN }
 @available(*, unavailable, message: "use the sign property.")
 public func signbit(_ value: CGFloat) -> Int { return value.sign.rawValue }
 
+// Generic implementation on FloatingPoint as of Swift 4.2
+@available(swift, obsoleted: 4.2)
 @_transparent
 public func modf(_ x: CGFloat) -> (CGFloat, CGFloat) {
   let (ipart, fpart) = modf(x.native)
   return (CGFloat(ipart), CGFloat(fpart))
 }
 
+@available(swift, deprecated: 4.2, renamed: "scalbn")
 @_transparent
 public func ldexp(_ x: CGFloat, _ n: Int) -> CGFloat {
   return CGFloat(ldexp(x.native, n))
 }
 
+// Generic implementation on FloatingPoint as of Swift 4.2
+@available(swift, obsoleted: 4.2)
 @_transparent
 public func frexp(_ x: CGFloat) -> (CGFloat, Int) {
   let (frac, exp) = frexp(x.native)
   return (CGFloat(frac), exp)
 }
 
+@available(swift, deprecated: 4.2, message: "use the exponent property.")
 @_transparent
 public func ilogb(_ x: CGFloat) -> Int {
-  return ilogb(x.native)
+  return Int(x.exponent)
 }
 
+// Generic implementation on FloatingPoint as of Swift 4.2
+@available(swift, obsoleted: 4.2)
 @_transparent
 public func scalbn(_ x: CGFloat, _ n: Int) -> CGFloat {
   return CGFloat(scalbn(x.native, n))
@@ -729,6 +598,8 @@ public func remquo(_ x: CGFloat, _ y: CGFloat) -> (CGFloat, Int) {
   return (CGFloat(rem), quo)
 }
 
+@available(*, deprecated: 4.2, message:
+           "use CGFloat(nan: CGFloat.RawSignificand) instead.")
 @_transparent
 public func nan(_ tag: String) -> CGFloat {
   return CGFloat(nan(tag) as CGFloat.NativeType)

--- a/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
+++ b/stdlib/public/SDK/CoreGraphics/CGFloat.swift.gyb
@@ -551,39 +551,16 @@ public func isnan(_ value: CGFloat) -> Bool { return value.isNaN }
 @available(*, unavailable, message: "use the sign property.")
 public func signbit(_ value: CGFloat) -> Int { return value.sign.rawValue }
 
-// Generic implementation on FloatingPoint as of Swift 4.2
-@available(swift, obsoleted: 4.2)
-@_transparent
-public func modf(_ x: CGFloat) -> (CGFloat, CGFloat) {
-  let (ipart, fpart) = modf(x.native)
-  return (CGFloat(ipart), CGFloat(fpart))
-}
-
 @available(swift, deprecated: 4.2, renamed: "scalbn")
 @_transparent
 public func ldexp(_ x: CGFloat, _ n: Int) -> CGFloat {
   return CGFloat(ldexp(x.native, n))
 }
 
-// Generic implementation on FloatingPoint as of Swift 4.2
-@available(swift, obsoleted: 4.2)
-@_transparent
-public func frexp(_ x: CGFloat) -> (CGFloat, Int) {
-  let (frac, exp) = frexp(x.native)
-  return (CGFloat(frac), exp)
-}
-
 @available(swift, deprecated: 4.2, message: "use the exponent property.")
 @_transparent
 public func ilogb(_ x: CGFloat) -> Int {
   return Int(x.exponent)
-}
-
-// Generic implementation on FloatingPoint as of Swift 4.2
-@available(swift, obsoleted: 4.2)
-@_transparent
-public func scalbn(_ x: CGFloat, _ n: Int) -> CGFloat {
-  return CGFloat(scalbn(x.native, n))
 }
 
 @_transparent

--- a/test/stdlib/tgmath.swift.gyb
+++ b/test/stdlib/tgmath.swift.gyb
@@ -149,7 +149,7 @@ internal extension TGMath {
     expectEqual((0.625, 2), Self._frexp(2.5))
     expectEqual(1, Self._ilogb(2.5))
 #if os(Linux) && arch(x86_64)
-    // double-precisiion remquo is broken in the glibc in 14.04. Disable this
+    // double-precision remquo is broken in the glibc in 14.04. Disable this
     // test for all Linux in the short-term to un-FAIL the build. SR-7234.
     if Self.significandBitCount != 52 {
       expectEqual(-0.25, Self._remquo(16, 0.625).0)

--- a/test/stdlib/tgmath.swift.gyb
+++ b/test/stdlib/tgmath.swift.gyb
@@ -189,8 +189,8 @@ extension ${T}: TGMath {
 
 MathTests.test("${T}") {
   ${T}.allTests()
-% if T == 'Double':
-  //  Functions that are defined only for Double
+% if T in ['Double','CGFloat']:
+  //  Functions that are defined only for Double and CGFloat
   expectEqualWithTolerance(0.99750156206604, j0(0.1), ulps: 16)
   expectEqualWithTolerance(0.049937526036242, j1(0.1), ulps: 16)
   expectEqualWithTolerance(1.2229926610356451e-22, jn(11, 0.1), ulps: 16)


### PR DESCRIPTION
These changes bring CGFloat in line with the other FloatingPoint types.  Some of this stuff is now defined at the protocol level, so we can get rid of it at the concrete type level, with an obsoleted message.  A couple other functions have been deprecated for all types, with protocol or tgmath replacements.