### PR TITLE
[build-script] Back out change to run lldb tests with lldb-dotest

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2841,41 +2841,23 @@ for host in "${ALL_HOSTS[@]}"; do
                 fi
                 call mkdir -p "${results_dir}"
 
-                # Prefer to use lldb-dotest, as building it guarantees that we build all
-                # test dependencies. Ultimately we want to delete as much lldb-specific logic
-                # from this file as possible and just have a single call to lldb-dotest.
-                dotest_extra_args=""
-                if [[ ! -z "${DOTEST_EXTRA}" ]] ; then
-                    dotest_extra_args="-E ${DOTEST_EXTRA}"
-                fi
                 if [[ "$using_xcodebuild" == "FALSE" ]] ; then
                     with_pushd ${lldb_build_dir} \
                         ${NINJA_BIN} lldb-dotest
-
-                    lldb_dotest="${lldb_build_dir}"/bin/lldb-dotest
-                    with_pushd ${results_dir} \
-                        call env SWIFTCC="$(build_directory $LOCAL_HOST swift)/bin/swiftc" \
-                        SWIFTLIBS="${swift_build_dir}/lib/swift" \
-                        ${lldb_dotest} \
-                        ${LLDB_TEST_SUBDIR_CLAUSE} \
-                        ${LLDB_TEST_CATEGORIES} \
-                        ${LLDB_FORMATTER_OPTS} \
-                        --build-dir "${lldb_build_dir}/lldb-test-build.noindex" \
-                        ${dotest_extra_args}
-		else
-                    with_pushd "${results_dir}" \
-                        call env SWIFTCC="$(build_directory $LOCAL_HOST swift)/bin/swiftc" \
-                        SWIFTLIBS="${swift_build_dir}/lib/swift" \
-                        "${LLDB_SOURCE_DIR}"/test/dotest.py \
-                        --executable "${lldb_executable}" \
-                        ${LLDB_TEST_DEBUG_SERVER} \
-                        ${LLDB_TEST_SUBDIR_CLAUSE} \
-                        ${LLDB_TEST_CATEGORIES} \
-                        ${LLDB_DOTEST_CC_OPTS} \
-                        ${LLDB_FORMATTER_OPTS} \
-                        --build-dir "${lldb_build_dir}/lldb-test-build.noindex" \
-                        ${dotest_extra_args}
                 fi
+
+                with_pushd "${results_dir}" \
+                    call env SWIFTCC="$(build_directory $LOCAL_HOST swift)/bin/swiftc" \
+                    SWIFTLIBS="${swift_build_dir}/lib/swift" \
+                    "${LLDB_SOURCE_DIR}"/test/dotest.py \
+                    --executable "${lldb_executable}" \
+                    ${LLDB_TEST_DEBUG_SERVER} \
+                    ${LLDB_TEST_SUBDIR_CLAUSE} \
+                    ${LLDB_TEST_CATEGORIES} \
+                    ${LLDB_DOTEST_CC_OPTS} \
+                    ${LLDB_FORMATTER_OPTS} \
+                    --build-dir "${lldb_build_dir}/lldb-test-build.noindex" \
+                    -E "${DOTEST_EXTRA}"
 
                 continue
                 ;;


### PR DESCRIPTION
lldb-dotest does not forward the arguments from DOTEST_EXTRA properly.
For now, just build the lldb-dotest target to ensure the cmake build has
the right dependencies built. Invoke dotest.py manually as before.

Note: This is a dummy PR, as the actual change may be merged as a part of https://github.com/apple/swift/pull/14953. This PR exists to test if a linux build failure is repeatable.