### PR TITLE
Basic: simplify conversion deduction

### DIFF
--- a/lib/Basic/Default/TaskQueue.inc
+++ b/lib/Basic/Default/TaskQueue.inc
@@ -99,7 +99,7 @@ bool TaskQueue::execute(TaskBeganCallback Began, TaskFinishedCallback Finished,
     bool ExecutionFailed = false;
     ProcessInfo PI = ExecuteNoWait(T->ExecPath, Argv.data(),
                                    (const char **)envp,
-                                   /*redirects*/nullptr, /*memoryLimit*/0,
+                                   /*redirects*/None, /*memoryLimit*/0,
                                    /*ErrMsg*/nullptr, &ExecutionFailed);
     if (ExecutionFailed) {
       return true;


### PR DESCRIPTION
The `redirects` parameter is of type `ArrayRef` which is default constructed
through the special `None` type.  Use `None` rather than `nullptr` which would
attempt to create a 0-sized array with a `nullptr`.  This fixes the build on
Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
