### PR TITLE
[Conformance checking] Better handling of escaping function types

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -929,23 +929,19 @@ SILGenFunction::emitBlockToFunc(SILLocation loc,
 
   // Create it in the current function.
   auto thunkValue = B.createFunctionRef(loc, thunk);
-  SingleValueInstruction *thunkedFn = B.createPartialApply(
+  ManagedValue thunkedFn = B.createPartialApply(
       loc, thunkValue, SILType::getPrimitiveObjectType(substFnTy), subs,
-      block.forward(*this),
+      block,
       SILType::getPrimitiveObjectType(loweredFuncTyWithoutNoEscape));
 
   if (!loweredFuncTy->isNoEscape()) {
-    return emitManagedRValueWithCleanup(thunkedFn);
+    return thunkedFn;
   }
 
   // Handle the escaping to noescape conversion.
   assert(loweredFuncTy->isNoEscape());
-
-  auto &funcTL = getTypeLowering(loweredFuncTy);
-  SingleValueInstruction *noEscapeThunkFn =
-      B.createConvertEscapeToNoEscape(loc, thunkedFn, funcTL.getLoweredType());
-  enterPostponedCleanup(thunkedFn);
-  return emitManagedRValueWithCleanup(noEscapeThunkFn);
+  return B.createConvertEscapeToNoEscape(loc, thunkedFn,
+                          SILType::getPrimitiveObjectType(loweredFuncTy));
 }
 
 static ManagedValue emitCBridgedToNativeValue(SILGenFunction &SGF,

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -221,11 +221,9 @@ ManagedValue SILGenBuilder::createConvertEscapeToNoEscape(SILLocation loc,
          !fnType->isNoEscape() && resultFnType->isNoEscape() &&
          "Expect a escaping to noescape conversion");
 
-  bool fnHasCleanup = fn.hasCleanup();
-  SILValue fnValue = fn.forward(getSILGenFunction());
+  SILValue fnValue = fn.ensurePlusOne(SGF, loc).forward(SGF);
   SILValue result = createConvertEscapeToNoEscape(loc, fnValue, resultTy);
-  if (fnHasCleanup)
-    getSILGenFunction().enterPostponedCleanup(fnValue);
+  getSILGenFunction().enterPostponedCleanup(fnValue);
   return ManagedValue::forTrivialObjectRValue(result);
 }
 

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -207,6 +207,28 @@ ManagedValue SILGenBuilder::createConvertFunction(SILLocation loc,
   return cloner.clone(result);
 }
 
+ManagedValue SILGenBuilder::createConvertEscapeToNoEscape(SILLocation loc,
+                                                          ManagedValue fn,
+                                                          SILType resultTy) {
+  auto fnType = fn.getType().castTo<SILFunctionType>();
+  auto resultFnType = resultTy.castTo<SILFunctionType>();
+
+  // Escaping to noescape conversion.
+  assert(resultFnType->getRepresentation() ==
+             SILFunctionTypeRepresentation::Thick &&
+         fnType->getRepresentation() ==
+             SILFunctionTypeRepresentation::Thick &&
+         !fnType->isNoEscape() && resultFnType->isNoEscape() &&
+         "Expect a escaping to noescape conversion");
+
+  bool fnHasCleanup = fn.hasCleanup();
+  SILValue fnValue = fn.forward(getSILGenFunction());
+  SILValue result = createConvertEscapeToNoEscape(loc, fnValue, resultTy);
+  if (fnHasCleanup)
+    getSILGenFunction().enterPostponedCleanup(fnValue);
+  return ManagedValue::forTrivialObjectRValue(result);
+}
+
 ManagedValue SILGenBuilder::createInitExistentialValue(
     SILLocation loc, SILType existentialType, CanType formalConcreteType,
     ManagedValue concrete, ArrayRef<ProtocolConformanceRef> conformances) {

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -360,6 +360,10 @@ public:
   ManagedValue createConvertFunction(SILLocation loc, ManagedValue fn,
                                      SILType resultTy);
 
+  using SILBuilder::createConvertEscapeToNoEscape;
+  ManagedValue createConvertEscapeToNoEscape(SILLocation loc, ManagedValue fn,
+                                             SILType resultTy);
+
   using SILBuilder::createStore;
   /// Forward \p value into \p address.
   ///

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -852,6 +852,13 @@ RequirementMatch matchWitness(TypeChecker &tc,
 AssociatedTypeDecl *getReferencedAssocTypeOfProtocol(Type type,
                                                      ProtocolDecl *proto);
 
+/// Perform any necessary adjustments to the inferred associated type to
+/// make it suitable for later use.
+///
+/// \param noescapeToEscaping Will be set \c true if this operation performed
+/// the noescape-to-escaping adjustment.
+Type adjustInferredAssociatedType(Type type, bool &noescapeToEscaping);
+
 }
 
 #endif // SWIFT_SEMA_PROTOCOL_H

--- a/test/SILGen/witnesses.swift
+++ b/test/SILGen/witnesses.swift
@@ -521,7 +521,8 @@ protocol EscapingReq {
 
 // CHECK-LABEL: sil private [transparent] [thunk] @$S9witnesses18EscapingCovarianceVAA0B3ReqA2aDP1fyyS2icFTW : $@convention(witness_method: EscapingReq) (@guaranteed @callee_guaranteed (Int) -> Int, @in_guaranteed EscapingCovariance) -> ()
 // CHECK-NOT: return
-// CHECK: convert_escape_to_noescape %0
+// CHECK: [[COPIED:%.*]] = copy_value %0
+// CHECK: convert_escape_to_noescape [[COPIED]]
 struct EscapingCovariance: EscapingReq {
   func f(_: (Int) -> Int) { }
 }

--- a/test/SILGen/witnesses.swift
+++ b/test/SILGen/witnesses.swift
@@ -512,3 +512,16 @@ class CrashableBase {
 // CHECK-NEXT: return [[RESULT]] : $()
 
 class GenericCrashable<T> : CrashableBase, Crashable {}
+
+// rdar://problem/35297911: allow witness with a noescape parameter to
+// match a requirement with an escaping paameter.
+protocol EscapingReq {
+  func f(_: @escaping (Int) -> Int)
+}
+
+// CHECK-LABEL: sil private [transparent] [thunk] @$S9witnesses18EscapingCovarianceVAA0B3ReqA2aDP1fyyS2icFTW : $@convention(witness_method: EscapingReq) (@guaranteed @callee_guaranteed (Int) -> Int, @in_guaranteed EscapingCovariance) -> ()
+// CHECK-NOT: return
+// CHECK: convert_escape_to_noescape %0
+struct EscapingCovariance: EscapingReq {
+  func f(_: (Int) -> Int) { }
+}

--- a/test/decl/protocol/conforms/associated_type.swift
+++ b/test/decl/protocol/conforms/associated_type.swift
@@ -38,8 +38,6 @@ protocol P1 {
   associatedtype A
 
   func f(_: A)
-  // expected-note@-1 {{protocol requires function 'f' with type '(X1c.A) -> ()' (aka '((Int) -> Int) -> ()'); do you want to add a stub?}}
-  // expected-note@-2 {{protocol requires function 'f' with type '((Int) -> Int) -> ()'; do you want to add a stub?}}
 }
 
 struct X1a : P1 {
@@ -52,12 +50,24 @@ struct X1b : P1 {
   func f(_: @escaping (Int) -> Int) { }
 }
 
-struct X1c : P1 { // expected-error{{type 'X1c' does not conform to protocol 'P1'}}
+struct X1c : P1 {
   typealias A = (Int) -> Int
 
-  func f(_: (Int) -> Int) { } // expected-note{{candidate has non-matching type '((Int) -> Int) -> ()'}}
+  func f(_: (Int) -> Int) { }
 }
 
-struct X1d : P1 { // expected-error{{type 'X1d' does not conform to protocol 'P1'}}
-  func f(_: (Int) -> Int) { } // expected-note{{candidate has non-matching type '((Int) -> Int) -> ()' [with A = (Int) -> Int]}}
+struct X1d : P1 {
+  func f(_: (Int) -> Int) { }
+}
+
+protocol P2 {
+  func f(_: (Int) -> Int) // expected-note{{protocol requires function 'f' with type '((Int) -> Int) -> ()'; do you want to add a stub?}}
+}
+
+struct X2a : P2 {
+  func f(_: (Int) -> Int) { }
+}
+
+struct X2b : P2 { // expected-error{{type 'X2b' does not conform to protocol 'P2'}}
+  func f(_: @escaping (Int) -> Int) { } // expected-note{{candidate has non-matching type '(@escaping (Int) -> Int) -> ()'}}
 }

--- a/test/decl/protocol/conforms/associated_type.swift
+++ b/test/decl/protocol/conforms/associated_type.swift
@@ -32,3 +32,32 @@ class Foo: FooType {
     func foo(action: (Bar) -> Void) {
     }
 }
+
+// rdar://problem/35297911: noescape function types
+protocol P1 {
+  associatedtype A
+
+  func f(_: A)
+  // expected-note@-1 {{protocol requires function 'f' with type '(X1c.A) -> ()' (aka '((Int) -> Int) -> ()'); do you want to add a stub?}}
+  // expected-note@-2 {{protocol requires function 'f' with type '((Int) -> Int) -> ()'; do you want to add a stub?}}
+}
+
+struct X1a : P1 {
+  func f(_: @escaping (Int) -> Int) { }
+}
+
+struct X1b : P1 {
+  typealias A = (Int) -> Int
+
+  func f(_: @escaping (Int) -> Int) { }
+}
+
+struct X1c : P1 { // expected-error{{type 'X1c' does not conform to protocol 'P1'}}
+  typealias A = (Int) -> Int
+
+  func f(_: (Int) -> Int) { } // expected-note{{candidate has non-matching type '((Int) -> Int) -> ()'}}
+}
+
+struct X1d : P1 { // expected-error{{type 'X1d' does not conform to protocol 'P1'}}
+  func f(_: (Int) -> Int) { } // expected-note{{candidate has non-matching type '((Int) -> Int) -> ()' [with A = (Int) -> Int]}}
+}


### PR DESCRIPTION
Re-land https://github.com/apple/swift/pull/15357 with a fix for ownership.

Improve our handling of (non-)escaping function types in conformance checking in two ways to tighten up type soundness:

* Never infer a non-escaping function type as an associated type witness. In particular, when matching an associated type in a requirement to a potential witness with a `noescape` function type, adjust the function type to be escaping. This addresses a type soundness issue, where values of non-escaping function type could arbitrarily escape through type witnesses.
* Allow a witness with a parameter of `noescape` function type match a requirement with a compatible escaping function type. While this limited form of witness covariance is generally a good idea, it is also necessary because closing the type soundness hole describe above would break some existing code.

Fixes rdar://problem/35297911