### PR TITLE
[benchmark] Add a benchmark for .lazy.filter.map chaining...

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -49,6 +49,7 @@ set(SWIFT_BENCH_MODULES
     single-source/CSVParsing
     single-source/Calculator
     single-source/CaptureProp
+    single-source/ChainedFilterMap
     single-source/CharacterLiteralsLarge
     single-source/CharacterLiteralsSmall
     single-source/CharacterProperties

--- a/benchmark/single-source/ChainedFilterMap.swift
+++ b/benchmark/single-source/ChainedFilterMap.swift
@@ -1,0 +1,40 @@
+import TestsUtils
+
+public var ChainedFilterMap = [
+  BenchmarkInfo(name: "ChainedFilterMap", runFunction: run_ChainedFilterMap, tags: [.algorithm]),
+  BenchmarkInfo(name: "FatCompactMap", runFunction: run_FatCompactMap, tags: [.algorithm])
+]
+
+public let first100k = Array(0...100_000-1)
+
+@inline(never)
+public func run_ChainedFilterMap(_ N: Int) {
+  var result = 0
+  for _ in 1...10*N {
+    let numbers = first100k.lazy
+      .filter { $0 % 3 == 0 }
+      .map { $0 * 2 }
+      .filter { $0 % 8 == 0 }
+      .map { $0 / 2 + 1}
+    result = numbers.reduce(into: 0) { $0 += $1 }
+  }
+
+  CheckResults(result == 416691666)
+}
+
+@inline(never)
+public func run_FatCompactMap(_ N: Int) {
+  var result = 0
+  for _ in 1...10*N {
+    let numbers = first100k.lazy
+      .compactMap { (x: Int) -> Int? in
+        if x % 3 != 0 { return nil }
+        let y = x * 2
+        if y % 8 != 0 { return nil }
+        let z = y / 2 + 1
+        return z
+      }
+    result = numbers.reduce(into: 0) { $0 += $1 }
+  }
+  CheckResults(result == 416691666)
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -36,6 +36,7 @@ import CString
 import CSVParsing
 import Calculator
 import CaptureProp
+import ChainedFilterMap
 import CharacterLiteralsLarge
 import CharacterLiteralsSmall
 import CharacterProperties
@@ -183,6 +184,7 @@ registerBenchmark(CSVParsingAlt)
 registerBenchmark(CSVParsingAltIndices)
 registerBenchmark(Calculator)
 registerBenchmark(CaptureProp)
+registerBenchmark(ChainedFilterMap)
 registerBenchmark(CharacterLiteralsLarge)
 registerBenchmark(CharacterLiteralsSmall)
 registerBenchmark(CharacterPropertiesFetch)


### PR DESCRIPTION
... and functionally equivalent single call to .lazy.compactMap.

See https://forums.swift.org/t/introduce-lazy-version-of-compactmap/9835
for more info.