### PR TITLE
[stdlib] optimise DefaultIndices.contains because it is sorted.

### DIFF
--- a/stdlib/public/core/Indices.swift
+++ b/stdlib/public/core/Indices.swift
@@ -83,7 +83,7 @@ extension DefaultIndices: Collection {
     return self
   }
   
-  public func contains(_ element: Element) -> Bool {
+  public func _customContainsEquatableElement(_ element: Element) -> Bool? {
     guard element < endIndex else { return false }
     for index in self {
       if !(index < element) {

--- a/stdlib/public/core/Indices.swift
+++ b/stdlib/public/core/Indices.swift
@@ -82,6 +82,16 @@ extension DefaultIndices: Collection {
   public var indices: Indices {
     return self
   }
+  
+  public func contains(_ element: Element) -> Bool {
+    guard element < endIndex else { return false }
+    for index in self {
+      if !(index < element) {
+        return index == element
+      }
+    }
+    return false
+  }
 }
 
 extension DefaultIndices: BidirectionalCollection


### PR DESCRIPTION
Currently DefaultIndices uses Sequence.contains, which starts from the beginning and checks equality with each index until it finds a match and returns true, or reaches the end and returns false. But the indices of collections are by definition sorted. This commit overrides `contains(_ element: Element)` with a method which returns false immediately if ‘element’ is not less than endIndex. It then goes through each index from the beginning and returns false as soon as it reaches an index that is larger than ‘element’.

The result is the expected on-average 2x performance improvement when searching for _invalid_ indices that are in the range startIndex..<endIndex (tested with [Attabench](https://github.com/attaswift/Attabench) on Swift 4.0.3, as that is the latest version Attabench supports). I used strings for the tests.

To test unit test coverage I tried always returning false. That led to failures in unit tests stdlib/NSSlowString.swift, stdlib/NSStringAPI.swift and stdlib/Runtime.swift.gyb. Always returning true did not lead to any failures.
