### PR TITLE
[build-script] Re-introduce change to run lldb tests with lldb-dotest

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2841,23 +2841,37 @@ for host in "${ALL_HOSTS[@]}"; do
                 fi
                 call mkdir -p "${results_dir}"
 
+                # Prefer to use lldb-dotest, as building it guarantees that we build all
+                # test dependencies. Ultimately we want to delete as much lldb-specific logic
+                # from this file as possible and just have a single call to lldb-dotest.
                 if [[ "$using_xcodebuild" == "FALSE" ]] ; then
                     with_pushd ${lldb_build_dir} \
                         ${NINJA_BIN} lldb-dotest
-                fi
 
-                with_pushd "${results_dir}" \
-                    call env SWIFTCC="$(build_directory $LOCAL_HOST swift)/bin/swiftc" \
-                    SWIFTLIBS="${swift_build_dir}/lib/swift" \
-                    "${LLDB_SOURCE_DIR}"/test/dotest.py \
-                    --executable "${lldb_executable}" \
-                    ${LLDB_TEST_DEBUG_SERVER} \
-                    ${LLDB_TEST_SUBDIR_CLAUSE} \
-                    ${LLDB_TEST_CATEGORIES} \
-                    ${LLDB_DOTEST_CC_OPTS} \
-                    ${LLDB_FORMATTER_OPTS} \
-                    --build-dir "${lldb_build_dir}/lldb-test-build.noindex" \
-                    -E "${DOTEST_EXTRA}"
+                    lldb_dotest="${lldb_build_dir}"/bin/lldb-dotest
+                    with_pushd ${results_dir} \
+                        call env SWIFTCC="$(build_directory $LOCAL_HOST swift)/bin/swiftc" \
+                        SWIFTLIBS="${swift_build_dir}/lib/swift" \
+                        ${lldb_dotest} \
+                        ${LLDB_TEST_SUBDIR_CLAUSE} \
+                        ${LLDB_TEST_CATEGORIES} \
+                        ${LLDB_FORMATTER_OPTS} \
+                        --build-dir "${lldb_build_dir}/lldb-test-build.noindex" \
+                        -E "${DOTEST_EXTRA}"
+                else
+                    with_pushd "${results_dir}" \
+                        call env SWIFTCC="$(build_directory $LOCAL_HOST swift)/bin/swiftc" \
+                        SWIFTLIBS="${swift_build_dir}/lib/swift" \
+                        "${LLDB_SOURCE_DIR}"/test/dotest.py \
+                        --executable "${lldb_executable}" \
+                        ${LLDB_TEST_DEBUG_SERVER} \
+                        ${LLDB_TEST_SUBDIR_CLAUSE} \
+                        ${LLDB_TEST_CATEGORIES} \
+                        ${LLDB_DOTEST_CC_OPTS} \
+                        ${LLDB_FORMATTER_OPTS} \
+                        --build-dir "${lldb_build_dir}/lldb-test-build.noindex" \
+                        -E "${DOTEST_EXTRA}"
+                fi
 
                 continue
                 ;;


### PR DESCRIPTION
This re-introduces the change to run the lldb with lldb-dotest. This was reverted in `c1a34be32f1da30a8a83803cfb604f846861491a` because we didn't properly wrap arguments containing a space. The fix is twofold: one part in the lldb-dotest wrapper to wrap the arguments, and a small change to the build-script to pass `$DOTEST_EXTRA` as a single argument to `-E`.

This depends on https://github.com/apple/swift-lldb/pull/430