### PR TITLE
[Syntax] Don't pretty-print -emit-syntax JSON output

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -288,7 +288,7 @@ static bool emitSyntax(SourceFile *SF, LangOptions &LangOpts,
   auto os = getFileOutputStream(OutputFilename, SF->getASTContext());
   if (!os) return true;
 
-  json::Output jsonOut(*os);
+  json::Output jsonOut(*os, /*PrettyPrint=*/false);
   auto Root = SF->getSyntaxRoot().getRaw();
   jsonOut << *Root;
   *os << "\n";

--- a/test/Frontend/emit-syntax.swift
+++ b/test/Frontend/emit-syntax.swift
@@ -1,20 +1,20 @@
 // RUN: %target-swift-frontend -emit-syntax %s | %FileCheck %s
 
-// CHECK: "kind": "kw_struct"
-// CHECK: "kind": "identifier",
-// CHECK: "text": "Foo"
-// CHECK: "kind": "l_brace"
+// CHECK: "kind":"kw_struct"
+// CHECK: "kind":"identifier",
+// CHECK: "text":"Foo"
+// CHECK: "kind":"l_brace"
 struct Foo {
-  // CHECK: "kind": "kw_let"
-  // CHECK: "kind": "colon"
-  // CHECK: "kind": "identifier"
-  // CHECK: "text": "Int"
+  // CHECK: "kind":"kw_let"
+  // CHECK: "kind":"colon"
+  // CHECK: "kind":"identifier"
+  // CHECK: "text":"Int"
   let x: Int
-// CHECK: "kind": "r_brace"
+// CHECK: "kind":"r_brace"
 }
 
-// CHECK: "leadingTrivia": [
-// CHECK: "kind": "LineComment",
-// CHECK: "value": "\/\/ Comment at the end of the file"
+// CHECK: "leadingTrivia":[
+// CHECK: "kind":"LineComment",
+// CHECK: "value":"\/\/ Comment at the end of the file"
 
 // Comment at the end of the file

--- a/test/SourceKit/SyntaxTree/basic.swift
+++ b/test/SourceKit/SyntaxTree/basic.swift
@@ -1,4 +1,4 @@
-// RUN: %swift-syntax-test -input-source-filename %s -serialize-raw-tree > %t.emit
+// RUN: %target-swift-frontend -emit-syntax %s > %t.emit
 // RUN: %sourcekitd-test -req=syntax-tree %s > %t.sourcekit
 // RUN: diff %t.emit %t.sourcekit
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1798,7 +1798,7 @@ void SwiftEditorDocument::readSyntaxInfo(EditorConsumer &Consumer) {
   if (Consumer.syntaxTreeEnabled()) {
     std::string SyntaxContent;
     llvm::raw_string_ostream OS(SyntaxContent);
-    json::Output JsonOut(OS);
+    json::Output JsonOut(OS, /*PrettyPrint=*/false);
     auto Root = Impl.SyntaxInfo->getSourceFile().getSyntaxRoot().getRaw();
     JsonOut << *Root;
     Consumer.handleSerializedSyntaxTree(OS.str());


### PR DESCRIPTION
This patch turns off pretty-printing for `swiftc -frontend -emit-syntax`. Since these structures nest very deep, there's a LOT of wasted memory printing `' '` characters, and wasted parse time skipping them, which slows down deserialization in SwiftSyntax.