### PR TITLE
[ClangImporter] Add a comment to 'recursivelySubstituteBaseType'

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7828,6 +7828,12 @@ static void finishInheritedConformances(
   }
 }
 
+/// A stripped-down version of Type::subst that only works on non-generic
+/// associated types.
+///
+/// This is used to finish a conformance for a concrete imported type that may
+/// rely on default associated types defined in protocol extensions...without
+/// having to do all the work of gathering conformances from scratch.
 static Type
 recursivelySubstituteBaseType(const NormalProtocolConformance *conformance,
                               DependentMemberType *depMemTy) {


### PR DESCRIPTION
As Doug pointed out in #14682, this isn't the normal way to do a type substitution. However, all the usual methods depend on the conformance's generic signature being fully filled in. Add a comment because, well, I don't have a better answer.