### PR TITLE
[stdlib][WIP DNM] Add Sequence.Prefix associated type

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
@@ -85,13 +85,13 @@ internal func _mapInPlace<C : MutableCollection>(
 
 internal func makeBufferAccessLoggingMutableCollection<
   C
->(wrapping c: C) -> BufferAccessLoggingMutableBidirectionalCollection<C> {
+>(wrapping c: C) -> BufferAccessLoggingMutableBidirectionalCollection<C>  where C.Prefix == C.SubSequence{
   return BufferAccessLoggingMutableBidirectionalCollection(wrapping: c)
 }
 
 internal func makeBufferAccessLoggingMutableCollection<
   C
->(wrapping c: C) -> BufferAccessLoggingMutableRandomAccessCollection<C> {
+>(wrapping c: C) -> BufferAccessLoggingMutableRandomAccessCollection<C> where C.Prefix == C.SubSequence{
   return BufferAccessLoggingMutableRandomAccessCollection(wrapping: c)
 }
 
@@ -858,7 +858,8 @@ self.test("\(testNamePrefix).reverse()") {
 //===----------------------------------------------------------------------===//
 // partition(by:)
 //===----------------------------------------------------------------------===//
-
+// FIXME: same-type constraint Prefix == SubSequence needed to make this compile
+/*
 self.test("\(testNamePrefix).partition/DispatchesThrough_withUnsafeMutableBufferPointerIfSupported") {
   let sequence = [ 5, 4, 3, 2, 1 ]
   let elements: [OpaqueValue<Int>] =
@@ -885,7 +886,7 @@ self.test("\(testNamePrefix).partition/DispatchesThrough_withUnsafeMutableBuffer
   expectEqualsUnordered([1, 2, 3, 4], lc.prefix(upTo: pivot).map { extractValue($0).value })
   expectEqualsUnordered([5], lc.suffix(from: pivot).map { extractValue($0).value })
 }
-
+*/
 //===----------------------------------------------------------------------===//
 
   } // addMutableBidirectionalCollectionTests

--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift.gyb
@@ -247,6 +247,7 @@ public struct ${Self}<
   }
 
   public typealias SubSequence = Base.SubSequence
+  public typealias Prefix = Base.Prefix
 
   public func dropFirst(_ n: Int) -> SubSequence {
     Log.dropFirst[selfType] += 1
@@ -265,14 +266,14 @@ public struct ${Self}<
     return try base.drop(while: predicate)
   }
 
-  public func prefix(_ maxLength: Int) -> SubSequence {
+  public func prefix(_ maxLength: Int) -> Prefix {
     Log.prefixMaxLength[selfType] += 1
     return base.prefix(maxLength)
   }
 
   public func prefix(
     while predicate: (Base.Iterator.Element) throws -> Bool
-  ) rethrows -> SubSequence {
+  ) rethrows -> Prefix {
     Log.prefixWhile[selfType] += 1
     return try base.prefix(while: predicate)
   }
@@ -592,13 +593,14 @@ public struct ${Self}<
 /// are uncounted by the standard logging collection wrapper.
 public struct ${Self}<
   Base : MutableCollection & ${collectionForTraversal(Traversal)}
-> : MutableCollection, ${collectionForTraversal(Traversal)}, LoggingType {
+> : MutableCollection, ${collectionForTraversal(Traversal)}, LoggingType where Base.Prefix == Base.SubSequence {
 
   public var base: Base
 
   public typealias Log = MutableCollectionLog
 
   public typealias SubSequence = Base.SubSequence
+  public typealias Prefix = SubSequence
   public typealias Iterator = Base.Iterator
   public typealias Element = Base.Element
 

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -45,7 +45,10 @@ public typealias BidirectionalIndexable = BidirectionalCollection
 /// - If `i > c.startIndex && i <= c.endIndex`
 ///   `c.index(after: c.index(before: i)) == i`.
 public protocol BidirectionalCollection: Collection
-where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
+where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection
+// FIXME: should be constrained by Collection where Prefix == SubSequence
+, Prefix: BidirectionalCollection 
+{
   // FIXME(ABI): Associated type inference requires this.
   associatedtype Element
 
@@ -54,6 +57,9 @@ where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
 
   // FIXME(ABI): Associated type inference requires this.
   associatedtype SubSequence
+
+  // FIXME(ABI): Associated type inference requires this.
+  associatedtype Prefix
 
   // FIXME(ABI): Associated type inference requires this.
   associatedtype Indices

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -534,12 +534,12 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
   internal override func _prefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> _Any${Kind}Box<Element> {
-    return try _${Kind}Box<S.SubSequence>(_base: _base.prefix(while: predicate))
+    return try _${Kind}Box<S.Prefix>(_base: _base.prefix(while: predicate))
   }
   @_versioned
   @_inlineable
   internal override func _prefix(_ maxLength: Int) -> _Any${Kind}Box<Element> {
-    return _${Kind}Box<S.SubSequence>(_base: _base.prefix(maxLength))
+    return _${Kind}Box<S.Prefix>(_base: _base.prefix(maxLength))
   }
   @_versioned
   @_inlineable

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -67,6 +67,8 @@ public typealias MutableIndexable = MutableCollection
 ///     let y = x
 public protocol MutableCollection: Collection
 where SubSequence: MutableCollection
+// FIXME: should be constrained by Collection where Prefix == SubSequence
+, Prefix: MutableCollection
 {
   // FIXME(ABI): Associated type inference requires this.
   associatedtype Element
@@ -76,6 +78,9 @@ where SubSequence: MutableCollection
 
   // FIXME(ABI): Associated type inference requires this.
   associatedtype SubSequence
+
+  // FIXME(ABI): Associated type inference requires this.
+  associatedtype Prefix
 
   /// Accesses the element at the specified position.
   ///

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -40,6 +40,8 @@ public typealias RandomAccessIndexable = RandomAccessCollection
 /// `distance(from:to:)` methods with O(1) efficiency.
 public protocol RandomAccessCollection: BidirectionalCollection
 where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
+// FIXME: should be constrained by Collection where Prefix == SubSequence
+, Prefix: RandomAccessCollection
 {
   // FIXME(ABI): Associated type inference requires this.
   associatedtype Element
@@ -49,6 +51,9 @@ where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
 
   // FIXME(ABI): Associated type inference requires this.
   associatedtype SubSequence
+
+  // FIXME(ABI): Associated type inference requires this.
+  associatedtype Prefix
 
   // FIXME(ABI): Associated type inference requires this.
   associatedtype Indices

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -71,9 +71,15 @@ public typealias RangeReplaceableIndexable = RangeReplaceableCollection
 /// parameter. You can override any of the protocol's required methods to 
 /// provide your own custom implementation.
 public protocol RangeReplaceableCollection : Collection
-  where SubSequence : RangeReplaceableCollection {
+where SubSequence : RangeReplaceableCollection
+// FIXME: should be constrained by Collection where Prefix == SubSequence
+, Prefix: RangeReplaceableCollection 
+{
   // FIXME(ABI): Associated type inference requires this.
   associatedtype SubSequence
+
+  // FIXME(ABI): Associated type inference requires this.
+  associatedtype Prefix
 
   //===--- Fundamental Requirements ---------------------------------------===//
 

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -1107,22 +1107,20 @@ extension Sequence where Prefix == PrefixSequence<Self> {
     }
     return PrefixSequence(self, maxLength: i)
   }
-}
 
-extension Sequence {
-  @available(*, deprecated, message: "Sequence now has a separate Prefix type")
-  public func prefix(_ maxLength: Int) -> AnySequence<Element> {
-    _precondition(maxLength >= 0, "Can't take a prefix of negative length from a sequence")
-    return AnySequence(self.prefix(maxLength) as Prefix)
-  }
-
-  @_inlineable
-  @available(*, deprecated, message: "Sequence now has a separate Prefix type")
-  public func prefix(
-    while predicate: (Element) throws -> Bool
-  ) rethrows -> AnySequence<Element> {
-    return AnySequence(try self.prefix(while: predicate) as Prefix)
-  }
+  // @available(*, deprecated, message: "Sequence now has a separate Prefix type")
+  // public func prefix(_ maxLength: Int) -> AnySequence<Element> {
+  //   _precondition(maxLength >= 0, "Can't take a prefix of negative length from a sequence")
+  //   return AnySequence(self.prefix(maxLength) as Prefix)
+  // }
+  //
+  // @_inlineable
+  // @available(*, deprecated, message: "Sequence now has a separate Prefix type")
+  // public func prefix(
+  //   while predicate: (Element) throws -> Bool
+  // ) rethrows -> AnySequence<Element> {
+  //   return AnySequence(try self.prefix(while: predicate) as Prefix)
+  // }
 }
 
 extension Sequence where SubSequence == AnySequence<Element> {

--- a/stdlib/public/core/SequenceWrapper.swift
+++ b/stdlib/public/core/SequenceWrapper.swift
@@ -89,6 +89,20 @@ extension _SequenceWrapper {
   }
 }
 
+extension _SequenceWrapper where Prefix == Base.Prefix {
+  @_inlineable // FIXME(sil-serialize-all)
+  public func prefix(_ maxLength: Int) -> Prefix {
+    return _base.prefix(maxLength)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public func prefix(
+    while predicate: (Element) throws -> Bool
+  ) rethrows -> Prefix {
+    return try _base.prefix(while: predicate)
+  }
+}
+
 extension _SequenceWrapper where SubSequence == Base.SubSequence {
   @_inlineable // FIXME(sil-serialize-all)
   public func dropFirst(_ n: Int) -> SubSequence {
@@ -97,10 +111,6 @@ extension _SequenceWrapper where SubSequence == Base.SubSequence {
   @_inlineable // FIXME(sil-serialize-all)
   public func dropLast(_ n: Int) -> SubSequence {
     return _base.dropLast(n)
-  }
-  @_inlineable // FIXME(sil-serialize-all)
-  public func prefix(_ maxLength: Int) -> SubSequence {
-    return _base.prefix(maxLength)
   }
   @_inlineable // FIXME(sil-serialize-all)
   public func suffix(_ maxLength: Int) -> SubSequence {
@@ -114,13 +124,6 @@ extension _SequenceWrapper where SubSequence == Base.SubSequence {
     return try _base.drop(while: predicate)
   }
 
-  @_inlineable // FIXME(sil-serialize-all)
-  public func prefix(
-    while predicate: (Element) throws -> Bool
-  ) rethrows -> SubSequence {
-    return try _base.prefix(while: predicate)
-  }
-  
   @_inlineable // FIXME(sil-serialize-all)
   public func split(
     maxSplits: Int, omittingEmptySubsequences: Bool,


### PR DESCRIPTION
A prototype PoC to see if we can disentangle prefixes and suffixes, allowing them to have separate types.

Source-breaking in current form mainly because of a missing `Collection.Prefix == Collection.SubSequence` constraint, as it currently crashes the compiler. Also this has some pretty ugly impact on std lib build time.