### PR TITLE
 IRGen: Fix witness-table accessors for conditional conformances

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1039,6 +1039,7 @@ static llvm::Value *emitWitnessTableAccessorCall(
   // If the conformance is generic, the accessor takes the metatype plus
   // possible conditional conformances arguments.
   llvm::CallInst *call;
+  bool requiresMemoryArguments = false;
   if (conformance->witnessTableAccessorRequiresArguments()) {
     // Emit the source metadata if we haven't yet.
     if (!*srcMetadataCache) {
@@ -1051,13 +1052,14 @@ static llvm::Value *emitWitnessTableAccessorCall(
 
     call = IGF.Builder.CreateCall(accessor,
                                   {*srcMetadataCache, conditionalTables});
-
+    requiresMemoryArguments = true;
   } else {
     call = IGF.Builder.CreateCall(accessor, {});
   }
 
   call->setCallingConv(IGF.IGM.DefaultCC);
-  call->setDoesNotAccessMemory();
+  if (!requiresMemoryArguments)
+    call->setDoesNotAccessMemory();
   call->setDoesNotThrow();
 
   return call;

--- a/test/Inputs/conditional_conformance_basic_conformances.swift
+++ b/test/Inputs/conditional_conformance_basic_conformances.swift
@@ -99,7 +99,7 @@ public func single_concrete() {
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 0
 // CHECK-NEXT:    store i8** getelementptr inbounds ([1 x i8*], [1 x i8*]* @"$S42conditional_conformance_basic_conformances4IsP2VAA0F0AAWP", i32 0, i32 0), i8*** [[A_P2_PTR]], align 8
 
-// CHECK-NEXT:    [[Single_P1:%.*]] = call i8** @"$S42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWa"(%swift.type* [[Single_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]])
+// CHECK-NEXT:    [[Single_P1:%.*]] = call i8** @"$S42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWa"(%swift.type* [[Single_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]]) [[ATTRS:#[0-9]+]]
 // CHECK-NEXT:    store atomic i8** [[Single_P1]], i8*** @"$S42conditional_conformance_basic_conformances6SingleVyAA4IsP2VGACyxGAA2P1A2A0G0RzlWL" release, align 8
 // CHECK-NEXT:    br label %cont
 
@@ -304,3 +304,4 @@ protocol P5 {}
 struct SR7101<T> {}
 extension SR7101 : P5 where T == P4Typealias {}
 
+// CHECK: atttributes [[ATTRS]] = { nounwind }

--- a/test/Inputs/conditional_conformance_basic_conformances.swift
+++ b/test/Inputs/conditional_conformance_basic_conformances.swift
@@ -304,4 +304,4 @@ protocol P5 {}
 struct SR7101<T> {}
 extension SR7101 : P5 where T == P4Typealias {}
 
-// CHECK: atttributes [[ATTRS]] = { nounwind }
+// CHECK: attributes [[ATTRS]] = { nounwind }


### PR DESCRIPTION
When there is a conditional conformance the witness table accessor is passed one argument in memory. Using ReadNone like we used to do is not correct.

SR-7228
rdar://38624842