### PR TITLE
Re-enable test. It isn't failing anymore.

### DIFF
--- a/test/SILOptimizer/pointer_conversion_objc.swift
+++ b/test/SILOptimizer/pointer_conversion_objc.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -module-name pointer_conversion -emit-sil -O %s | %FileCheck %s
+
 // REQUIRES: optimized_stdlib
 // REQUIRES: objc_interop
-// REQUIRES: radar38551973
 
 // Opaque, unoptimizable functions to call.
 @_silgen_name("takesConstRawPointer")


### PR DESCRIPTION
I think what happened here is that I originally was trying to change /all/
select_enum+cond_br to switch_enum. This implied I needed to change
SILGenFunction::emitBindOptional to use switch_enum. This caused all sorts of
problems since SILGenLValue uses emitBindOptional in a matter that requires the
input value to be used at +0 and wants to keep the value in memory. This
conflicted with other uses of emitBindOptional that really wanted to use
emitBindOptional as a +1 extract optional payload sort of thing. In the final
commit of +0-all-args, I just worked around this problem by creating a new
entrypoint just for the lvalue case that just uses select_enum_addr. So I think
my final commit, caused this test to go back to its original state. If it fails
again, I will look at it again.

rdar://38551973
