### PR TITLE
[code-completion] Don't try to equate/convert GenericTypeParameterTypes when computing type relations of completion results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,17 @@ Swift 5.0
 Swift 4.2
 ---------
 
+* [SE-0054][]
+
+  `ImplicitlyUnwrappedOptional<T>` is now an unavailable typealias of `Optional<T>`.
+  Declarations annotated with `!` have the type `Optional<T>`. If an
+  expression involving one of these values will not compile successfully with the
+  type `Optional<T>`, it is implicitly unwrapped, producing a value of type `T`.
+
+  In some cases this change will cause code that previously compiled to
+  need to be adjusted. Please see [this blog post](https://swift.org/blog/iuo/)
+  for more information.
+
 * [SE-0206][]
 
     The standard library now uses a high-quality, randomly seeded, universal

--- a/docs/WindowsBuild.md
+++ b/docs/WindowsBuild.md
@@ -126,8 +126,8 @@ set llvm_bin_dir="%swift_source_dir%/build/Ninja-RelWithDebInfoAssert/llvm-windo
 ```
 
 ### 7. Build Swift
-- This must be done from within a developer command prompt and could take up to
-  two hours depending on your system.
+- This must be done from within a developer command prompt and could take hours 
+  depending on your system.
 - You may need to adjust the `SWIFT_WINDOWS_LIB_DIRECTORY` parameter depending on
   your target platform or Windows SDK version.
 ```cmd
@@ -173,8 +173,8 @@ cmake -G "Visual Studio 15" "%swift_source_dir%/swift"^
 ```
 
 ### 8. Build lldb
-- This must be done from within a developer command prompt and could take up to
-  two hours depending on your system.
+- This must be done from within a developer command prompt and could take hours
+  depending on your system.
 ```cmd
 mkdir "%swift_source_dir%/build/Ninja-RelWithDebInfoAssert/lldb-windows-amd64"
 pushd "%swift_source_dir%/build/Ninja-RelWithDebInfoAssert/lldb-windows-amd64"

--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -40,15 +40,23 @@ enum class TypeRefKind {
 
 // MSVC reports an error if we use "template"
 // Clang reports an error if we don't use "template"
-#if defined(__clang__) || defined(__GNUC__)
-#define DEPENDENT_TEMPLATE template
-#if __clang_major__ >= 7
-#define DEPENDENT_TEMPLATE2
+#if defined(__APPLE_CC__)
+#  define DEPENDENT_TEMPLATE template
+#  if __APPLE_CC__ >= 7000
+#    define DEPENDENT_TEMPLATE2
+#  else
+#    define DEPENDENT_TEMPLATE2 template
+#  endif
+#elif defined(__clang__) || defined(__GNUC__)
+#  define DEPENDENT_TEMPLATE template
+#  if __clang_major__ >= 7
+#    define DEPENDENT_TEMPLATE2
+#  else
+#    define DEPENDENT_TEMPLATE2 template
+#  endif
 #else
-#define DEPENDENT_TEMPLATE2 template
-#endif
-#else
-#define DEPENDENT_TEMPLATE
+#  define DEPENDENT_TEMPLATE template
+#  define DEPENDENT_TEMPLATE2
 #endif
 
 #define FIND_OR_CREATE_TYPEREF(Allocator, TypeRefTy, ...)                      \

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -939,10 +939,15 @@ static CodeCompletionResult::ExpectedTypeRelation calculateTypeRelation(
       Ty->is<ErrorType>() ||
       ExpectedTy->is<ErrorType>())
     return CodeCompletionResult::ExpectedTypeRelation::Unrelated;
-  if (Ty->isEqual(ExpectedTy))
-    return CodeCompletionResult::ExpectedTypeRelation::Identical;
-  if (isConvertibleTo(Ty, ExpectedTy, *DC))
-    return CodeCompletionResult::ExpectedTypeRelation::Convertible;
+
+  // Equality/Conversion of GenericTypeParameterType won't account for
+  // requirements – ignore them
+  if (!Ty->hasTypeParameter() && !ExpectedTy->hasTypeParameter()) {
+    if (Ty->isEqual(ExpectedTy))
+      return CodeCompletionResult::ExpectedTypeRelation::Identical;
+    if (isConvertibleTo(Ty, ExpectedTy, *DC))
+      return CodeCompletionResult::ExpectedTypeRelation::Convertible;
+  }
   if (auto FT = Ty->getAs<AnyFunctionType>()) {
     if (FT->getResult()->isVoid())
       return CodeCompletionResult::ExpectedTypeRelation::Invalid;

--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -497,7 +497,7 @@ extension Sequence {
   ///   the passed element satisfies a condition.
   /// - Returns: `true` if the sequence contains only elements that satisfy
   ///   `predicate`; otherwise, `false`.
-  @_inlineable
+  @inlinable
   public func allSatisfy(
     _ predicate: (Element) throws -> Bool
   ) rethrows -> Bool {

--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -488,6 +488,21 @@ extension Sequence {
     }
     return false
   }
+
+  /// Returns a Boolean value indicating whether every element of a sequence
+  /// satisfies a given predicate.
+  ///
+  /// - Parameter predicate: A closure that takes an element of the sequence
+  ///   as its argument and returns a Boolean value that indicates whether
+  ///   the passed element satisfies a condition.
+  /// - Returns: `true` if the sequence contains only elements that satisfy
+  ///   `predicate`; otherwise, `false`.
+  @_inlineable
+  public func allSatisfy(
+    where predicate: (Element) throws -> Bool
+  ) rethrows -> Bool {
+    return try !contains { try !predicate($0) }
+  }
 }
 
 extension Sequence where Element : Equatable {

--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -499,7 +499,7 @@ extension Sequence {
   ///   `predicate`; otherwise, `false`.
   @_inlineable
   public func allSatisfy(
-    where predicate: (Element) throws -> Bool
+    _ predicate: (Element) throws -> Bool
   ) rethrows -> Bool {
     return try !contains { try !predicate($0) }
   }

--- a/test/IDE/complete_call_arg.swift
+++ b/test/IDE/complete_call_arg.swift
@@ -45,6 +45,8 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=BOUND_IUO | %FileCheck %s -check-prefix=MEMBEROF_IUO
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=FORCED_IUO | %FileCheck %s -check-prefix=MEMBEROF_IUO
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENERIC_TO_GENERIC | %FileCheck %s -check-prefix=GENERIC_TO_GENERIC
+
 var i1 = 1
 var i2 = 2
 var oi1 : Int?
@@ -372,6 +374,14 @@ struct TestBoundGeneric1 {
 // BOUND_GENERIC_1: Decl[InstanceVar]/CurrNominal:      x[#[Int]#];
 // BOUND_GENERIC_1: Decl[InstanceVar]/CurrNominal:      y[#[Int]#];
 }
+
+func whereConvertible<T>(lhs: T, rhs: T) where T: Collection {
+  _ = zip(lhs, #^GENERIC_TO_GENERIC^#)
+}
+// GENERIC_TO_GENERIC: Begin completions
+// GENERIC_TO_GENERIC: Decl[LocalVar]/Local: lhs[#Collection#]; name=lhs
+// GENERIC_TO_GENERIC: Decl[LocalVar]/Local: rhs[#Collection#]; name=rhs
+// GENERIC_TO_GENERIC: End completions
 
 func emptyOverload() {}
 func emptyOverload(foo foo: Int) {}

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -614,6 +614,20 @@ SequenceTypeTests.test("contains/Predicate") {
   }
 }
 
+SequenceTypeTests.test("allSatisfy/Predicate") {
+  for test in findTests {
+    let s = MinimalSequence<OpaqueValue<Int>>(
+      elements: test.sequence.map { OpaqueValue($0.value) })
+    expectEqual(
+      test.expected == nil,
+      s.allSatisfy { $0.value != test.element.value },
+      stackTrace: SourceLocStack().with(test.loc))
+    expectEqual(
+      test.expectedLeftoverSequence.map { $0.value }, s.map { $0.value },
+      stackTrace: SourceLocStack().with(test.loc))
+  }
+}
+
 //===----------------------------------------------------------------------===//
 // reduce()
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
<!-- What's in this pull request? -->
For call argument completion, if the expected type and completion result type are
both `GenericTypeParameterTypes`, comparing them doesn't make sense as we can't account
for their different contexts at this point in the code, and hit assertions in the
constraint solver if we try.

For now, don't attempt to add a type relation for this case.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/38153332.
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->