### PR TITLE
[stdlib] Change some stdlib method arguments to __owned

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1440,7 +1440,7 @@ extension ${Self} : RangeReplaceableCollection, ArrayProtocol {
   ///   unspecified.
   @_inlineable
   @_semantics("array.append_element")
-  public mutating func append(_ newElement: Element) {
+  public mutating func append(_ newElement: __owned Element) {
     _makeUniqueAndReserveCapacityIfNotUnique()
     let oldCount = _getCount()
     _reserveCapacityAssumingUniqueBuffer(oldCount: oldCount)

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1407,7 +1407,7 @@ extension ${Self} : RangeReplaceableCollection, ArrayProtocol {
   @_semantics("array.mutate_unknown")
   internal mutating func _appendElementAssumeUniqueAndCapacity(
     _ oldCount: Int,
-    newElement: Element
+    newElement: __owned Element
   ) {
     _sanityCheck(_buffer.isMutableAndUniquelyReferenced())
     _sanityCheck(_buffer.capacity >= _buffer.count + 1)

--- a/stdlib/public/core/FixedArray.swift.gyb
+++ b/stdlib/public/core/FixedArray.swift.gyb
@@ -125,7 +125,7 @@ extension _FixedArray${N} : RandomAccessCollection, MutableCollection {
 extension _FixedArray${N} {
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned
-  internal mutating func append(_ newElement: T) {
+  internal mutating func append(_ newElement: __owned T) {
     _sanityCheck(count < capacity)
     _count += 1
     self[count-1] = newElement

--- a/stdlib/public/core/HashedCollections.swift.gyb
+++ b/stdlib/public/core/HashedCollections.swift.gyb
@@ -230,7 +230,7 @@ internal protocol _HashBuffer {
   func maybeGet(_ key: Key) -> Value?
 
   @discardableResult
-  mutating func updateValue(_ value: Value, forKey key: Key) -> Value?
+  mutating func updateValue(_ value: __owned Value, forKey key: Key) -> Value?
 
   @discardableResult
   mutating func insert(
@@ -2223,7 +2223,7 @@ extension Dictionary {
   @_inlineable // FIXME(sil-serialize-all)
   @discardableResult
   public mutating func updateValue(
-    _ value: Value, forKey key: Key
+    _ value: __owned Value, forKey key: Key
   ) -> Value? {
     return _variantBuffer.updateValue(value, forKey: key)
   }
@@ -3809,7 +3809,7 @@ internal struct _Native${Self}Buffer<${TypeParameters}> {
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   @_transparent
-  internal func initializeKey(_ k: Key, value v: Value, at i: Int) {
+  internal func initializeKey(_ k: Key, value v: __owned Value, at i: Int) {
     _sanityCheck(!isInitializedEntry(at: i))
     defer { _fixLifetime(self) }
 
@@ -4082,7 +4082,7 @@ extension _Native${Self}Buffer
 
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
-  internal func unsafeAddNew(key newKey: Key, value: Value) {
+  internal func unsafeAddNew(key newKey: Key, value: __owned Value) {
     let (i, found) = _find(newKey, startBucket: _bucket(newKey))
     _sanityCheck(
       !found, "unsafeAddNew was called, but the key is already present")
@@ -5270,7 +5270,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned // FIXME(sil-serialize-all)
   internal mutating func nativeUpdateValue(
-    _ value: Value, forKey key: Key
+    _ value: __owned Value, forKey key: Key
   ) -> Value? {
     var (i, found) = asNative._find(key, startBucket: asNative._bucket(key))
 
@@ -5311,7 +5311,7 @@ internal enum _Variant${Self}Buffer<${TypeParametersDecl}> : _HashBuffer {
   @_versioned // FIXME(sil-serialize-all)
   @discardableResult
   internal mutating func updateValue(
-    _ value: Value, forKey key: Key
+    _ value: __owned Value, forKey key: Key
   ) -> Value? {
 
     if _fastPath(guaranteedNative) {

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -175,7 +175,7 @@ public protocol RangeReplaceableCollection : Collection
   ///
   /// - Complexity: O(1) on average, over many additions to the same
   ///   collection.
-  mutating func append(_ newElement: Element)
+  mutating func append(_ newElement: __owned Element)
 
   /// Adds the elements of a sequence or collection to the end of this
   /// collection.

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -486,7 +486,7 @@ public struct ${Self}<Pointee>: _Pointer {
 
 %  if mutable:
   @available(swift, deprecated: 4.1, obsoleted: 5.0.0, renamed: "initialize(repeating:count:)")
-  public func initialize(to newValue: Pointee, count: Int = 1) { 
+  public func initialize(to newValue: __owned Pointee, count: Int = 1) { 
     initialize(repeating: newValue, count: count)
   }
 
@@ -524,7 +524,7 @@ public struct ${Self}<Pointee>: _Pointer {
   /// - Parameters:
   ///   - value: The instance to initialize this pointer's pointee to.
   @_inlineable
-  public func initialize(to value: Pointee) {
+  public func initialize(to value: __owned Pointee) {
     Builtin.initialize(value, self._rawValue)
   }
 


### PR DESCRIPTION
Gonna start small at first just with `Array.append(_:)` and go from there.