### PR TITLE
[SE-0155] Implement (Most of) The Proposal

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -90,7 +90,7 @@ public:
   std::string mangleGlobalGetterEntity(const ValueDecl *decl,
                                        SymbolKind SKind = SymbolKind::Default);
 
-  std::string mangleDefaultArgumentEntity(const DeclContext *func,
+  std::string mangleDefaultArgumentEntity(const ValueDecl *decl,
                                           unsigned index,
                                           SymbolKind SKind);
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3223,6 +3223,12 @@ ERROR(type_pattern_missing_is,none,
 ERROR(pattern_type_mismatch_context,none,
       "type annotation does not match contextual type %0", (Type))
 
+ERROR(paren_pattern_in_tuple_context,none,
+      "parenthesized pattern cannot match value of tuple type %0", (Type))
+WARNING(paren_pattern_in_tuple_context_warn_swift3,none,
+        "parenthesized pattern matches value of tuple type %0; this may be "
+        "unintended and will be removed in a future version of Swift", (Type))
+
 ERROR(tuple_pattern_in_non_tuple_context,none,
       "tuple pattern cannot match values of the non-tuple type %0", (Type))
 ERROR(closure_argument_list_tuple,none,
@@ -3250,10 +3256,18 @@ ERROR(enum_element_pattern_assoc_values_mismatch,none,
       (Identifier))
 NOTE(enum_element_pattern_assoc_values_remove,none,
      "remove associated values to make the pattern match", ())
+
 ERROR(tuple_pattern_length_mismatch,none,
       "tuple pattern has the wrong length for tuple type %0", (Type))
 ERROR(tuple_pattern_label_mismatch,none,
       "tuple pattern element label %0 must be %1", (Identifier, Identifier))
+ERROR(tuple_pattern_label_missing,none,
+      "tuple pattern mentioning element labels must also specify label '%0'",
+      (Identifier))
+ERROR(tuple_pattern_label_should_be_elided,none,
+      "tuple pattern not mentioning element labels may not specify label %0",
+      (Identifier))
+
 ERROR(enum_element_pattern_member_not_found,none,
       "enum case '%0' not found in type %1", (StringRef, Type))
 ERROR(optional_element_pattern_not_valid_type,none,
@@ -3283,6 +3297,16 @@ NOTE(unowned_assignment_requires_strong,none,
 ERROR(isa_collection_downcast_pattern_value_unimplemented,none,
       "collection downcast in cast pattern is not implemented; use an explicit "
       "downcast to %0 instead", (Type))
+
+WARNING(swift3_ignore_specialized_enum_element_call,none,
+        "cannot specialize enum case; ignoring generic argument, "
+        "which will be rejected in future version of Swift", ())
+
+ERROR(ambiguous_enum_element_in_pattern,none,
+      "enum case %0 is ambiguous without explicit pattern matching "
+      "associated values", (Identifier))
+NOTE(ambiguous_enum_element_candidate,none,
+     "found potentially matching case %0", (DeclName))
 
 //------------------------------------------------------------------------------
 // MARK: Error-handling diagnostics

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -159,11 +159,15 @@ std::string ASTMangler::mangleGlobalGetterEntity(const ValueDecl *decl,
   return finalize();
 }
 
-std::string ASTMangler::mangleDefaultArgumentEntity(const DeclContext *func,
+std::string ASTMangler::mangleDefaultArgumentEntity(const ValueDecl *decl,
                                                     unsigned index,
                                                     SymbolKind SKind) {
   beginMangling();
-  appendDefaultArgumentEntity(func, index);
+  if (auto *AFD = dyn_cast<AbstractFunctionDecl>(decl)) {
+    appendDefaultArgumentEntity(AFD, index);
+  } else {
+    appendDefaultArgumentEntity(decl->getDeclContext(), index);
+  }
   appendSymbolKind(SKind);
   return finalize();
 }

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -285,6 +285,9 @@ ResilienceExpansion DeclContext::getResilienceExpansion() const {
     // Default argument initializer contexts have their resilience expansion
     // set when they're type checked.
     if (isa<DefaultArgumentInitializer>(dc)) {
+      if (auto *ED = dyn_cast<EnumDecl>(dc->getParent())) {
+        return ED->getResilienceExpansion();
+      }
       return cast<AbstractFunctionDecl>(dc->getParent())
           ->getDefaultArgumentResilienceExpansion();
     }

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -91,6 +91,7 @@ static ParserStatus parseDefaultArgument(
   case Parser::ParameterContextKind::Function:
   case Parser::ParameterContextKind::Operator:
   case Parser::ParameterContextKind::Initializer:
+  case Parser::ParameterContextKind::EnumElement:
     break;
   case Parser::ParameterContextKind::Closure:
     diagID = diag::no_default_arg_closure;
@@ -100,9 +101,6 @@ static ParserStatus parseDefaultArgument(
     break;
   case Parser::ParameterContextKind::Curried:
     diagID = diag::no_default_arg_curried;
-    break;
-  case Parser::ParameterContextKind::EnumElement:
-    diagID = diag::no_default_arg_enum_elt;
     break;
   }
   
@@ -409,7 +407,7 @@ validateParameterWithSpecifier(Parser &parser,
   if (parsingEnumElt) {
     return new (parser.Context) T(type, loc);
   }
-  
+
   if (isa<SpecifierTypeRepr>(type)) {
     parser.diagnose(loc, diag::parameter_specifier_repeated).fixItRemove(loc);
   } else {

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -832,6 +832,9 @@ void SILGenModule::emitConstructor(ConstructorDecl *decl) {
 void SILGenModule::emitEnumConstructor(EnumElementDecl *decl) {
   // Enum element constructors are always emitted by need, so don't need
   // delayed emission.
+  if (auto params = decl->getParameterList())
+    emitDefaultArgGenerators(decl, params);
+
   SILDeclRef constant(decl);
   SILFunction *f = getFunction(constant, ForDefinition);
   preEmitFunction(constant, decl, f, decl);

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -580,13 +580,13 @@ public:
       assert(Substitutions.empty());
       return IndirectValue;
 
+    case Kind::EnumElement:
+      LLVM_FALLTHROUGH;
     case Kind::StandaloneFunction: {
       auto constantInfo = SGF.getConstantInfo(*constant);
       SILValue ref = SGF.emitGlobalFunctionRef(Loc, *constant, constantInfo);
       return ManagedValue::forUnmanaged(ref);
     }
-    case Kind::EnumElement:
-      llvm_unreachable("Should have been curried");
     case Kind::ClassMethod: {
       auto methodTy = SGF.SGM.Types.getConstantOverrideType(*constant);
 
@@ -683,8 +683,11 @@ public:
       auto constantInfo = SGF.getConstantInfo(*constant);
       return createCalleeTypeInfo(SGF, constant, constantInfo.getSILType());
     }
-    case Kind::EnumElement:
-      llvm_unreachable("Should have been curried");
+    case Kind::EnumElement: {
+      // Emit a direct call to the element constructor thunk.
+      auto constantInfo = SGF.getConstantInfo(*constant);
+      return createCalleeTypeInfo(SGF, constant, constantInfo.getSILType());
+    }
     case Kind::ClassMethod: {
       auto constantInfo = SGF.SGM.Types.getConstantOverrideInfo(*constant);
       return createCalleeTypeInfo(SGF, constant, constantInfo.getSILType());

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -115,6 +115,9 @@ DeclName SILGenModule::getMagicFunctionName(SILDeclRef ref) {
   case SILDeclRef::Kind::GlobalAccessor:
     return getMagicFunctionName(cast<VarDecl>(ref.getDecl())->getDeclContext());
   case SILDeclRef::Kind::DefaultArgGenerator:
+    if (auto *ED = dyn_cast<EnumElementDecl>(ref.getDecl())) {
+      return ED->getFullName();
+    }
     return getMagicFunctionName(cast<AbstractFunctionDecl>(ref.getDecl()));
   case SILDeclRef::Kind::StoredPropertyInitializer:
     return getMagicFunctionName(cast<VarDecl>(ref.getDecl())->getDeclContext());

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4954,7 +4954,14 @@ getCallerDefaultArg(ConstraintSystem &cs, DeclContext *dc,
                     unsigned index) {
   auto &tc = cs.getTypeChecker();
 
-  auto defArg = getDefaultArgumentInfo(cast<ValueDecl>(owner.getDecl()), index);
+  std::pair<DefaultArgumentKind, Type> defArg;
+  if (auto *AFD = dyn_cast<AbstractFunctionDecl>(owner.getDecl())) {
+    defArg = getDefaultArgumentInfo(AFD->getParameters(), index);
+  } else {
+    defArg = getDefaultArgumentInfo(
+                 cast<EnumElementDecl>(owner.getDecl())->getParameterList(),
+                 index);
+  }
   Expr *init = nullptr;
   switch (defArg.first) {
   case DefaultArgumentKind::None:

--- a/test/Sema/enum_case_apply.swift
+++ b/test/Sema/enum_case_apply.swift
@@ -1,0 +1,28 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+
+enum E1 {
+  case payload(a: Int) // expected-note {{found this candidate}}
+  case payload(b: Int) // expected-note {{found this candidate}}
+  case payload(a: Int, b: Int)
+}
+
+func testCompoundEnumCase(a: Int, b: Int) {
+  _ = E1.payload(a: a) // okay: direct call requires argument labels
+  _ = E1.payload(b: a) // okay: direct call requires argument labels
+  _ = E1.payload(a: a, b: a) // okay: direct call requires argument labels
+  _ = (E1.payload)(a: a, b: a) // okay: direct call requires argument labels
+  _ = ((E1.payload))(a: a, b: a) // okay: direct call requires argument labels
+
+  _ = E1.payload(a:b:)(a, a) // compound name suppresses argument labels
+
+  let _: E1 = .payload(a: a) // okay: direct call requires argument labels
+  let _: E1 = .payload(b: a) // okay: direct call requires argument labels
+  let _: E1 = .payload(a: a, b: a) // okay: direct call requires argument labels
+
+  let _: (Int, Int) -> E1 = E1.payload // contextual types can pick out members without labels
+
+  // ambiguity
+  let _: (Int) -> E1 = E1.payload // expected-error {{ambiguous use of 'payload'}}
+  // match the behavior of contextual applies in functions
+  let _ : E1 = .payload(a:b:)(a, a) // expected-error {{missing argument labels 'a:b:' in call}}
+}

--- a/test/decl/func/keyword-argument-defaults.swift
+++ b/test/decl/func/keyword-argument-defaults.swift
@@ -119,3 +119,9 @@ func +(_ a: String,
 func +(a: Double, b: String) -> (Int) -> (_ d: Int) -> () {
   return { c in { e in () } }
 }
+
+// Enum elements
+enum TestEnumElements {
+  case element(_ a : String,
+               d d : Double) // expected-error {{enum case cannot have keyword arguments}}
+}


### PR DESCRIPTION
This has sat un-reviewed for long enough.  The last part of the patch is some nits in the original proposal [around pattern matching](https://forums.swift.org/t/se-0155-discuss-the-role-of-labels-in-enum-case-patterns/6603). 

<strike>In addition, the Sema and SIL plumbing for default arguments in enum cases is there, but does not work in 100% of cases.  I have disabled it with a diagnostic in Parse.</strike>