### PR TITLE
Kill off some usages of the DeclChecker::IsFirstPass bit

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2163,10 +2163,6 @@ ERROR(self_in_nominal,none,
       "'Self' is only available in a protocol or as the result of a "
       "method in a class; did you mean '%0'?", (StringRef))
 
-// Duplicate declarations
-ERROR(duplicate_enum_element,none,
-      "duplicate definition of enum element",())
-
 // Property behaviors
 ERROR(property_behavior_not_protocol,none,
       "property behavior name must refer to a protocol", ())

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4366,28 +4366,6 @@ public:
         checkCircularity(TC, ED, diag::circular_enum_inheritance,
                          diag::enum_here, path);
       }
-      {
-        // Check for duplicate enum members.
-        llvm::DenseMap<Identifier, EnumElementDecl *> Elements;
-        bool hasErrors = false;
-        for (auto *EED : ED->getAllElements()) {
-          auto Res = Elements.insert({ EED->getName(), EED });
-          if (!Res.second) {
-            EED->setInvalid();
-
-            auto PreviousEED = Res.first->second;
-            TC.diagnose(EED->getLoc(), diag::duplicate_enum_element);
-            TC.diagnose(PreviousEED->getLoc(),
-                        diag::previous_decldef, true, EED->getName());
-            hasErrors = true;
-          }
-        }
-
-        // If one of the cases is invalid, let's mark
-        // whole enum as invalid as well.
-        if (hasErrors)
-          ED->setInvalid();
-      }
     }
 
     if (!IsFirstPass) {
@@ -4401,7 +4379,7 @@ public:
 
       TC.checkConformancesInContext(ED, ED);
     }
-    
+
     for (Decl *member : ED->getMembers())
       visit(member);
     

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4268,13 +4268,12 @@ public:
 
   void visitSubscriptDecl(SubscriptDecl *SD) {
     if (!IsFirstPass) {
-      checkAccessControl(TC, SD);
       return;
     }
 
     TC.validateDecl(SD);
-
     TC.checkDeclAttributes(SD);
+    checkAccessControl(TC, SD);
   }
 
   void visitTypeAliasDecl(TypeAliasDecl *TAD) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4392,29 +4392,31 @@ public:
   }
 
   void visitStructDecl(StructDecl *SD) {
+    if (!IsFirstPass) {
+      for (Decl *Member : SD->getMembers())
+        visit(Member);
+
+      return;
+    }
+
     TC.checkDeclAttributesEarly(SD);
     TC.computeAccessLevel(SD);
 
-    if (IsFirstPass) {
-      checkUnsupportedNestedType(SD);
+    checkUnsupportedNestedType(SD);
 
-      TC.validateDecl(SD);
-      TC.DeclsToFinalize.remove(SD);
-      TC.addImplicitConstructors(SD);
-    }
+    TC.validateDecl(SD);
+    TC.DeclsToFinalize.remove(SD);
 
-    if (!IsFirstPass) {
-      checkAccessControl(TC, SD);
+    TC.addImplicitConstructors(SD);
 
-      if (!SD->isInvalid())
-        TC.checkConformancesInContext(SD, SD);
-    }
-
-    // Visit each of the members.
     for (Decl *Member : SD->getMembers())
       visit(Member);
 
     TC.checkDeclAttributes(SD);
+    checkAccessControl(TC, SD);
+
+    if (!SD->isInvalid())
+      TC.checkConformancesInContext(SD, SD);
   }
 
   /// Check whether the given properties can be @NSManaged in this class.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6183,12 +6183,12 @@ public:
 
   void visitEnumElementDecl(EnumElementDecl *EED) {
     if (!IsFirstPass) {
-      checkAccessControl(TC, EED);
       return;
     }
 
     TC.validateDecl(EED);
     TC.checkDeclAttributes(EED);
+    checkAccessControl(TC, EED);
   }
 
   void visitExtensionDecl(ExtensionDecl *ED) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4277,16 +4277,16 @@ public:
   }
 
   void visitTypeAliasDecl(TypeAliasDecl *TAD) {
+    if (!IsFirstPass) {
+      return;
+    }
+
     TC.checkDeclAttributesEarly(TAD);
     TC.computeAccessLevel(TAD);
 
-    if (IsFirstPass)
-      TC.validateDecl(TAD);
-
-    if (!IsFirstPass)
-      checkAccessControl(TC, TAD);
-
+    TC.validateDecl(TAD);
     TC.checkDeclAttributes(TAD);
+    checkAccessControl(TC, TAD);
   }
   
   void visitAssociatedTypeDecl(AssociatedTypeDecl *assocType) {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1910,8 +1910,7 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
 
   assert(!type->hasArchetype() && "Got a contextual type here?");
 
-  if (checkObjCTypeErasedGenerics(assocType, type, typeDecl))
-    type = ErrorType::get(type);
+  checkObjCTypeErasedGenerics(assocType, type, typeDecl);
 
   if (typeDecl) {
     // Check access.

--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -324,40 +324,40 @@ enum RawTypeMismatch : Int { // expected-error {{'RawTypeMismatch' declares raw 
 }
 
 enum DuplicateMembers1 {
-  case Foo // expected-note {{previous definition of 'Foo' is here}}
-  case Foo // expected-error {{duplicate definition of enum element}}
+  case Foo // expected-note {{'Foo' previously declared here}}
+  case Foo // expected-error {{invalid redeclaration of 'Foo'}}
 }
 
 enum DuplicateMembers2 {
-  case Foo, Bar // expected-note {{previous definition of 'Foo' is here}} expected-note {{previous definition of 'Bar' is here}}
-  case Foo // expected-error {{duplicate definition of enum element}}
-  case Bar // expected-error {{duplicate definition of enum element}}
+  case Foo, Bar // expected-note {{'Foo' previously declared here}} expected-note {{'Bar' previously declared here}}
+  case Foo // expected-error {{invalid redeclaration of 'Foo'}}
+  case Bar // expected-error {{invalid redeclaration of 'Bar'}}
 }
 
 enum DuplicateMembers3 {
-  case Foo // expected-note {{previous definition of 'Foo' is here}}
-  case Foo(Int) // expected-error {{duplicate definition of enum element}}
+  case Foo // expected-note {{'Foo' previously declared here}}
+  case Foo(Int) // expected-error {{invalid redeclaration of 'Foo'}}
 }
 
 enum DuplicateMembers4 : Int { // expected-error {{'DuplicateMembers4' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}}
-  case Foo = 1 // expected-note {{previous definition of 'Foo' is here}}
-  case Foo = 2 // expected-error {{duplicate definition of enum element}}
+  case Foo = 1 // expected-note {{'Foo' previously declared here}}
+  case Foo = 2 // expected-error {{invalid redeclaration of 'Foo'}}
 }
 
 enum DuplicateMembers5 : Int { // expected-error {{'DuplicateMembers5' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized}}
-  case Foo = 1 // expected-note {{previous definition of 'Foo' is here}}
-  case Foo = 1 + 1 // expected-error {{duplicate definition of enum element}} expected-error {{raw value for enum case must be a literal}}
+  case Foo = 1 // expected-note {{'Foo' previously declared here}}
+  case Foo = 1 + 1 // expected-error {{invalid redeclaration of 'Foo'}} expected-error {{raw value for enum case must be a literal}}
 }
 
 enum DuplicateMembers6 {
-  case Foo // expected-note 2{{previous definition of 'Foo' is here}}
-  case Foo // expected-error {{duplicate definition of enum element}}
-  case Foo // expected-error {{duplicate definition of enum element}}
+  case Foo // expected-note 2{{'Foo' previously declared here}}
+  case Foo // expected-error {{invalid redeclaration of 'Foo'}}
+  case Foo // expected-error {{invalid redeclaration of 'Foo'}}
 }
 
 enum DuplicateMembers7 : String { // expected-error {{'DuplicateMembers7' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized}}
-  case Foo // expected-note {{previous definition of 'Foo' is here}}
-  case Foo = "Bar" // expected-error {{duplicate definition of enum element}}
+  case Foo // expected-note {{'Foo' previously declared here}}
+  case Foo = "Bar" // expected-error {{invalid redeclaration of 'Foo'}}
 }
 
 // Refs to duplicated enum cases shouldn't crash the compiler.

--- a/test/decl/protocol/req/associated_type_inference.swift
+++ b/test/decl/protocol/req/associated_type_inference.swift
@@ -149,7 +149,7 @@ struct XSubP0b : SubscriptP0 {
 
 struct XSubP0c : SubscriptP0 {
 // expected-error@-1 {{type 'XSubP0c' does not conform to protocol 'SubscriptP0'}}
-  subscript (i: Index) -> Element { get { } } // expected-error{{reference to invalid associated type 'Element' of type 'XSubP0c'}}
+  subscript (i: Index) -> Element { get { } }
 }
 
 struct XSubP0d : SubscriptP0 {

--- a/test/decl/protocol/special/coding/class_codable_failure_diagnostics.swift
+++ b/test/decl/protocol/special/coding/class_codable_failure_diagnostics.swift
@@ -1,66 +1,61 @@
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -verify
 
 // Codable class with non-Codable property.
 class C1 : Codable {
+  // expected-error@-1 {{type 'C1' does not conform to protocol 'Decodable'}}
+  // expected-error@-2 {{type 'C1' does not conform to protocol 'Encodable'}}
+
   class Nested {}
   var a: String = ""
   var b: Int = 0
   var c: Nested = Nested()
-
-  // CHECK: error: type 'C1' does not conform to protocol 'Decodable'
-  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'C1.Nested' does not conform to 'Decodable'
-
-  // CHECK: error: type 'C1' does not conform to protocol 'Encodable'
-  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
-  // CHECK: note: cannot automatically synthesize 'Encodable' because 'C1.Nested' does not conform to 'Encodable'
+  // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'C1.Nested' does not conform to 'Decodable'}}
+  // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'C1.Nested' does not conform to 'Encodable'}}
 }
 
 // Codable class with non-enum CodingKeys.
 class C2 : Codable {
+  // expected-error@-1 {{type 'C2' does not conform to protocol 'Decodable'}}
+  // expected-error@-2 {{type 'C2' does not conform to protocol 'Encodable'}}
+
   var a: String = ""
   var b: Int = 0
   var c: Double?
 
   struct CodingKeys : CodingKey {
+  // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'CodingKeys' is not an enum}}
+  // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'CodingKeys' is not an enum}}
     var stringValue = ""
     var intValue = nil
+    // expected-error@-1 {{'nil' requires a contextual type}}
     init?(stringValue: String) {}
     init?(intValue: Int) {}
   }
-
-  // CHECK: error: type 'C2' does not conform to protocol 'Decodable'
-  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' is not an enum
-
-  // CHECK: error: type 'C2' does not conform to protocol 'Encodable'
-  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
-  // CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' is not an enum
 }
 
 // Codable class with CodingKeys not conforming to CodingKey.
 class C3 : Codable {
+  // expected-error@-1 {{type 'C3' does not conform to protocol 'Decodable'}}
+  // expected-error@-2 {{type 'C3' does not conform to protocol 'Encodable'}}
+
   var a: String = ""
   var b: Int = 0
   var c: Double?
 
   enum CodingKeys : String {
+  // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey}}
+  // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey}}
     case a
     case b
     case c
   }
-
-  // CHECK: error: type 'C3' does not conform to protocol 'Decodable'
-  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey
-
-  // CHECK: error: type 'C3' does not conform to protocol 'Encodable'
-  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
-  // CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey
 }
 
 // Codable class with extraneous CodingKeys
 class C4 : Codable {
+  // expected-error@-1 {{type 'C4' does not conform to protocol 'Decodable'}}
+  // expected-error@-2 {{type 'C4' does not conform to protocol 'Encodable'}}
+
   var a: String = ""
   var b: Int = 0
   var c: Double?
@@ -68,48 +63,40 @@ class C4 : Codable {
   enum CodingKeys : String, CodingKey {
     case a
     case a2
+    // expected-note@-1 2{{CodingKey case 'a2' does not match any stored properties}}
     case b
     case b2
+    // expected-note@-1 2{{CodingKey case 'b2' does not match any stored properties}}
     case c
     case c2
+    // expected-note@-1 2{{CodingKey case 'c2' does not match any stored properties}}
   }
-
-  // CHECK: error: type 'C4' does not conform to protocol 'Decodable'
-  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
-  // CHECK: note: CodingKey case 'a2' does not match any stored properties
-  // CHECK: note: CodingKey case 'b2' does not match any stored properties
-  // CHECK: note: CodingKey case 'c2' does not match any stored properties
-
-  // CHECK: error: type 'C4' does not conform to protocol 'Encodable'
-  // CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
-  // CHECK: note: CodingKey case 'a2' does not match any stored properties
-  // CHECK: note: CodingKey case 'b2' does not match any stored properties
-  // CHECK: note: CodingKey case 'c2' does not match any stored properties
 }
 
 // Codable class with non-decoded property (which has no default value).
 class C5 : Codable {
+  // expected-error@-1 {{type 'C5' does not conform to protocol 'Decodable'}}
+  // expected-error@-2 {{class 'C5' has no initializers}}
+
   var a: String = ""
   var b: Int
+  // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value}}
+  // expected-note@-2 {{stored property 'b' without initial value prevents synthesized initializers}}
   var c: Double?
 
   enum CodingKeys : String, CodingKey {
     case a
     case c
   }
-
-  // CHECK: error: type 'C5' does not conform to protocol 'Decodable'
-  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value
-
-  // CHECK: error: class 'C5' has no initializers
-  // CHECK: note: stored property 'b' without initial value prevents synthesized initializers
 }
 
 // Codable class with non-decoded property (which has no default value).
 class C6 : Codable {
+  // expected-error@-1 {{type 'C6' does not conform to protocol 'Decodable'}}
+
   var a: String = ""
   var b: Int
+  // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value}}
   var c: Double?
 
   enum CodingKeys : String, CodingKey {
@@ -120,14 +107,10 @@ class C6 : Codable {
   init() {
     b = 5
   }
-
-  // CHECK: error: type 'C6' does not conform to protocol 'Decodable'
-  // CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
-  // CHECK: note: cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value
 }
 
 // Classes cannot yet synthesize Encodable or Decodable in extensions.
 class C7 {}
 extension C7 : Codable {}
-// CHECK: error: implementation of 'Decodable' cannot be automatically synthesized in an extension
-// CHECK: error: implementation of 'Encodable' cannot be automatically synthesized in an extension
+// expected-error@-1 {{implementation of 'Decodable' cannot be automatically synthesized in an extension}}
+// expected-error@-2 {{implementation of 'Encodable' cannot be automatically synthesized in an extension}}

--- a/test/decl/protocol/special/coding/struct_codable_failure_diagnostics.swift
+++ b/test/decl/protocol/special/coding/struct_codable_failure_diagnostics.swift
@@ -1,20 +1,30 @@
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -verify
 
 // Codable struct with non-Codable property.
 struct S1 : Codable {
+// expected-error@-1 {{type 'S1' does not conform to protocol 'Decodable'}}
+// expected-error@-2 {{type 'S1' does not conform to protocol 'Encodable'}}
+
   struct Nested {}
   var a: String = ""
   var b: Int = 0
   var c: Nested = Nested()
+  // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'S1.Nested' does not conform to 'Decodable'}}
+  // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'S1.Nested' does not conform to 'Encodable'}}
 }
 
 // Codable struct with non-enum CodingKeys.
 struct S2 : Codable {
+// expected-error@-1 {{type 'S2' does not conform to protocol 'Decodable'}}
+// expected-error@-2 {{type 'S2' does not conform to protocol 'Encodable'}}
+
   var a: String = ""
   var b: Int = 0
   var c: Double?
 
   struct CodingKeys : CodingKey {
+  // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'CodingKeys' is not an enum}}
+  // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'CodingKeys' is not an enum}}
     var stringValue: String = ""
     var intValue: Int? = nil
     init?(stringValue: String) {}
@@ -24,11 +34,16 @@ struct S2 : Codable {
 
 // Codable struct with CodingKeys not conforming to CodingKey.
 struct S3 : Codable {
+// expected-error@-1 {{type 'S3' does not conform to protocol 'Decodable'}}
+// expected-error@-2 {{type 'S3' does not conform to protocol 'Encodable'}}
+
   var a: String = ""
   var b: Int = 0
   var c: Double?
 
   enum CodingKeys : String {
+  // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey}}
+  // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey}}
     case a
     case b
     case c
@@ -37,6 +52,9 @@ struct S3 : Codable {
 
 // Codable struct with extraneous CodingKeys
 struct S4 : Codable {
+// expected-error@-1 {{type 'S4' does not conform to protocol 'Decodable'}}
+// expected-error@-2 {{type 'S4' does not conform to protocol 'Encodable'}}
+
   var a: String = ""
   var b: Int = 0
   var c: Double?
@@ -44,17 +62,26 @@ struct S4 : Codable {
   enum CodingKeys : String, CodingKey {
     case a
     case a2
+    // expected-note@-1 {{CodingKey case 'a2' does not match any stored properties}}
+    // expected-note@-2 {{CodingKey case 'a2' does not match any stored properties}}
     case b
     case b2
+    // expected-note@-1 {{CodingKey case 'b2' does not match any stored properties}}
+    // expected-note@-2 {{CodingKey case 'b2' does not match any stored properties}}
     case c
     case c2
+    // expected-note@-1 {{CodingKey case 'c2' does not match any stored properties}}
+    // expected-note@-2 {{CodingKey case 'c2' does not match any stored properties}}
   }
 }
 
 // Codable struct with non-decoded property (which has no default value).
 struct S5 : Codable {
+// expected-error@-1 {{type 'S5' does not conform to protocol 'Decodable'}}
+
   var a: String = ""
   var b: Int
+  // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value}}
   var c: Double?
 
   enum CodingKeys : String, CodingKey {
@@ -66,55 +93,5 @@ struct S5 : Codable {
 // Structs cannot yet synthesize Encodable or Decodable in extensions.
 struct S6 {}
 extension S6 : Codable {}
-
-// Decodable diagnostics are output first here {
-
-// CHECK: error: type 'S1' does not conform to protocol 'Decodable'
-// CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
-// CHECK: note: cannot automatically synthesize 'Decodable' because 'S1.Nested' does not conform to 'Decodable'
-
-// CHECK: error: type 'S2' does not conform to protocol 'Decodable'
-// CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
-// CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' is not an enum
-
-// CHECK: error: type 'S3' does not conform to protocol 'Decodable'
-// CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
-// CHECK: note: cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey
-
-// CHECK: error: type 'S4' does not conform to protocol 'Decodable'
-// CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
-// CHECK: note: CodingKey case 'a2' does not match any stored properties
-// CHECK: note: CodingKey case 'b2' does not match any stored properties
-// CHECK: note: CodingKey case 'c2' does not match any stored properties
-
-// CHECK: error: type 'S5' does not conform to protocol 'Decodable'
-// CHECK: note: protocol requires initializer 'init(from:)' with type 'Decodable'
-// CHECK: note: cannot automatically synthesize 'Decodable' because 'b' does not have a matching CodingKey and does not have a default value
-
-// CHECK: error: implementation of 'Decodable' cannot be automatically synthesized in an extension
-
-// }
-
-// Encodable {
-
-// CHECK: error: type 'S1' does not conform to protocol 'Encodable'
-// CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
-// CHECK: note: cannot automatically synthesize 'Encodable' because 'S1.Nested' does not conform to 'Encodable'
-
-// CHECK: error: type 'S2' does not conform to protocol 'Encodable'
-// CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
-// CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' is not an enum
-
-// CHECK: error: type 'S3' does not conform to protocol 'Encodable'
-// CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
-// CHECK: note: cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey
-
-// CHECK: error: type 'S4' does not conform to protocol 'Encodable'
-// CHECK: note: protocol requires function 'encode(to:)' with type 'Encodable'
-// CHECK: note: CodingKey case 'a2' does not match any stored properties
-// CHECK: note: CodingKey case 'b2' does not match any stored properties
-// CHECK: note: CodingKey case 'c2' does not match any stored properties
-
-// CHECK: error: implementation of 'Encodable' cannot be automatically synthesized in an extension
-
-// }
+// expected-error@-1 {{implementation of 'Decodable' cannot be automatically synthesized in an extension}}
+// expected-error@-2 {{implementation of 'Encodable' cannot be automatically synthesized in an extension}}


### PR DESCRIPTION
Follow-up to https://github.com/apple/swift/pull/15408. For most declaration kinds, moves all of the type checking work to the 'first pass'. Classes, enums, functions and pattern binding decls still remain. Once those are done, we'll be doing nothing in the 'second pass', at which point the flag and walk over the AST can be removed.