### PR TITLE
[Sema] NFC: Ensure that Decls have one-way validation state

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6990,8 +6990,13 @@ void TypeChecker::validateDecl(ValueDecl *D) {
             validateAccessControl(aliasDecl);
 
             // Check generic parameters, if needed.
-            aliasDecl->setIsBeingValidated();
-            SWIFT_DEFER { aliasDecl->setIsBeingValidated(false); };
+            bool validated = aliasDecl->hasValidationStarted();
+            if (!validated)
+              aliasDecl->setIsBeingValidated();
+            SWIFT_DEFER {
+              if (!validated)
+                aliasDecl->setIsBeingValidated(false);
+            };
 
             validateTypealiasType(*this, aliasDecl);
           }


### PR DESCRIPTION
I also tried to move the early attribute validation bit into this enum, but as it turns out, decls aren't consistent about when they do early attribute checking relative to calling `setIsBeingValidated()`. Some do early attribute checking before validation, others do it after, and some do it during. I tried to make early attribute checking be consistently early, but that broke a few tests.