### PR TITLE
build-toolchain: Use the same behavior on macOS as we do on Linux

### DIFF
--- a/utils/build-toolchain
+++ b/utils/build-toolchain
@@ -23,13 +23,8 @@ function usage() {
   echo "-n --dry-run"
   echo "Do a dry run."
   echo ""
-  if [[ "$(uname -s)" == "Linux" ]] ; then
-    echo "-t --test"
-    echo "Run tests."
-    echo ""
-  fi
-  echo "-nt --no-test"
-  echo "Don't run tests."
+  echo "-t --test"
+  echo "Run tests."
   echo ""
 }
 
@@ -41,7 +36,7 @@ DRY_RUN=
 BUNDLE_PREFIX=
 case $(uname -s) in
   Darwin)
-    SWIFT_PACKAGE=buildbot_osx_package
+    SWIFT_PACKAGE=buildbot_osx_package,no_test
   ;;
   Linux)
     SWIFT_PACKAGE=buildbot_linux,no_test
@@ -63,15 +58,7 @@ while [ $# -ne 0 ]; do
       if [ "$(uname -s)" == "Linux" ]; then
         SWIFT_PACKAGE=buildbot_linux
       else
-        echo "--test is not supported on \"$(uname -s)\". See --help"
-        exit 1
-      fi
-  ;;
-    -nt|--no-test)
-      if [ "$(uname -s)" == "Linux" ]; then
-        SWIFT_PACKAGE=buildbot_linux,no_test
-      else
-        SWIFT_PACKAGE=buildbot_osx_package,no_test
+        SWIFT_PACKAGE=buildbot_osx_package
       fi
   ;;
   -h|--help)


### PR DESCRIPTION
The default is to run no tests. If you want to run tests you need to pass -t (--test).