### PR TITLE
Make the naming of underlying builtin for FP + Vector match Integer.

### DIFF
--- a/stdlib/public/SDK/simd/simd.swift.gyb
+++ b/stdlib/public/SDK/simd/simd.swift.gyb
@@ -43,20 +43,20 @@ cardinal = { 2:'two', 3:'three', 4:'four'}
 @_alignment(${vecsize})
 public struct ${vectype} {
 
-  public var _vector: Builtin.${llvm_vectype}
+  public var _value: Builtin.${llvm_vectype}
 
 % for i in xrange(count):
   public var ${component[i]} : ${scalar} {
     @_transparent
     get {
-      let elt = Builtin.${extractelement}(_vector,
+      let elt = Builtin.${extractelement}(_value,
         (${i} as Int32)._value)
 
-      return ${scalar}(_bits: elt)
+      return ${scalar}(elt)
     }
     @_transparent
     set {
-      _vector = Builtin.${insertelement}(_vector,
+      _value = Builtin.${insertelement}(_value,
         newValue._value,
         (${i} as Int32)._value)
     }
@@ -68,8 +68,8 @@ public struct ${vectype} {
   public init() { self.init(0) }
 
   @_transparent
-  public init(_bits: Builtin.${llvm_vectype}) {
-    _vector = _bits
+  public init(_ _value: Builtin.${llvm_vectype}) {
+    self._value = _value
   }
 
   /// Initialize a vector with the specified elements.
@@ -81,7 +81,7 @@ public struct ${vectype} {
       ${component[i]}._value,
       (${i} as Int32)._value)
 % end
-    _vector = v
+    _value = v
   }
 
   /// Initialize a vector with the specified elements.
@@ -113,15 +113,15 @@ public struct ${vectype} {
     get {
       _precondition(index >= 0, "Vector index out of range")
       _precondition(index < ${count}, "Vector index out of range")
-      let elt = Builtin.${extractelement}(_vector,
+      let elt = Builtin.${extractelement}(_value,
         Int32(index)._value)
-      return ${scalar}(_bits: elt)
+      return ${scalar}(elt)
     }
     @_transparent
     set(value) {
       _precondition(index >= 0, "Vector index out of range")
       _precondition(index < ${count}, "Vector index out of range")
-      _vector = Builtin.${insertelement}(_vector,
+      _value = Builtin.${insertelement}(_value,
         value._value,
         Int32(index)._value)
     }
@@ -183,15 +183,13 @@ extension ${vectype} {
   /// Vector (elementwise) sum of `lhs` and `rhs`.
   @_transparent
   public static func ${wrap}+(lhs: ${vectype}, rhs: ${vectype}) -> ${vectype} {
-    return ${vectype}(_bits:
-      Builtin.${prefix}add_${llvm_vectype}(lhs._vector, rhs._vector))
+    return ${vectype}(Builtin.${prefix}add_${llvm_vectype}(lhs._value, rhs._value))
   }
 
   /// Vector (elementwise) difference of `lhs` and `rhs`.
   @_transparent
   public static func ${wrap}-(lhs: ${vectype}, rhs: ${vectype}) -> ${vectype} {
-    return ${vectype}(_bits:
-      Builtin.${prefix}sub_${llvm_vectype}(lhs._vector, rhs._vector))
+    return ${vectype}(Builtin.${prefix}sub_${llvm_vectype}(lhs._value, rhs._value))
   }
 
   /// Negation of `rhs`.
@@ -204,8 +202,7 @@ extension ${vectype} {
   /// vector product).
   @_transparent
   public static func ${wrap}*(lhs: ${vectype}, rhs: ${vectype}) -> ${vectype} {
-    return ${vectype}(_bits:
-      Builtin.${prefix}mul_${llvm_vectype}(lhs._vector, rhs._vector))
+    return ${vectype}(Builtin.${prefix}mul_${llvm_vectype}(lhs._value, rhs._value))
   }
 
   /// Scalar-Vector product.
@@ -223,8 +220,7 @@ extension ${vectype} {
   /// Elementwise quotient of `lhs` and `rhs`.
   @_transparent
   public static func /(lhs: ${vectype}, rhs: ${vectype}) -> ${vectype} {
-    return ${vectype}(_bits:
-      Builtin.${divide}_${llvm_vectype}(lhs._vector, rhs._vector))
+    return ${vectype}(Builtin.${divide}_${llvm_vectype}(lhs._value, rhs._value))
   }
 
   /// Divide vector by scalar.

--- a/stdlib/public/core/BuiltinMath.swift.gyb
+++ b/stdlib/public/core/BuiltinMath.swift.gyb
@@ -67,7 +67,7 @@ def TypedUnaryIntrinsicFunctions():
 @_inlineable // FIXME(sil-serialize-all)
 @_transparent
 public func _${ufunc}(_ x: ${T}) -> ${T} {
-  return ${T}(_bits: Builtin.int_${ufunc}_FPIEEE${bits}(x._value))
+  return ${T}(Builtin.int_${ufunc}_FPIEEE${bits}(x._value))
 }
 %  if bits == 80:
 #endif

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -74,8 +74,8 @@ public struct ${Self} {
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   public // @testable
-  init(_bits v: Builtin.FPIEEE${bits}) {
-    self._value = v
+  init(_ _value: Builtin.FPIEEE${bits}) {
+    self._value = _value
   }
 }
 
@@ -214,7 +214,7 @@ extension ${Self}: BinaryFloatingPoint {
   /// - Parameter bitPattern: The integer encoding of a `${Self}` instance.
   @_inlineable // FIXME(sil-serialize-all)
   public init(bitPattern: UInt${bits}) {
-    self.init(_bits: Builtin.bitcast_Int${bits}_FPIEEE${bits}(bitPattern._value))
+    self.init(Builtin.bitcast_Int${bits}_FPIEEE${bits}(bitPattern._value))
   }
 
   /// The sign of the floating-point value.
@@ -1449,7 +1449,7 @@ extension ${Self} : _ExpressibleByBuiltinIntegerLiteral, ExpressibleByIntegerLit
   @_transparent
   public
   init(_builtinIntegerLiteral value: Builtin.Int${builtinIntLiteralBits}){
-    self = ${Self}(_bits: Builtin.itofp_with_overflow_Int${builtinIntLiteralBits}_FPIEEE${bits}(value))
+    self = ${Self}(Builtin.itofp_with_overflow_Int${builtinIntLiteralBits}_FPIEEE${bits}(value))
   }
 
   /// Creates a new value from the given integer literal.
@@ -1468,7 +1468,7 @@ extension ${Self} : _ExpressibleByBuiltinIntegerLiteral, ExpressibleByIntegerLit
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   public init(integerLiteral value: Int64) {
-    self = ${Self}(_bits: Builtin.sitofp_Int64_FPIEEE${bits}(value._value))
+    self = ${Self}(Builtin.sitofp_Int64_FPIEEE${bits}(value._value))
   }
 }
 
@@ -1483,9 +1483,9 @@ extension ${Self} : _ExpressibleByBuiltinFloatLiteral {
   public
   init(_builtinFloatLiteral value: Builtin.FPIEEE${builtinFloatLiteralBits}) {
 %   if bits == builtinFloatLiteralBits:
-    self = ${Self}(_bits: value)
+    self = ${Self}(value)
 %   elif bits < builtinFloatLiteralBits:
-    self = ${Self}(_bits: Builtin.fptrunc_FPIEEE${builtinFloatLiteralBits}_FPIEEE${bits}(value))
+    self = ${Self}(Builtin.fptrunc_FPIEEE${builtinFloatLiteralBits}_FPIEEE${bits}(value))
 %   else:
     // FIXME: This is actually losing precision <rdar://problem/14073102>.
     self = ${Self}(Builtin.fpext_FPIEEE${builtinFloatLiteralBits}_FPIEEE${bits}(value))
@@ -1503,10 +1503,10 @@ extension ${Self} : _ExpressibleByBuiltinFloatLiteral {
   public
   init(_builtinFloatLiteral value: Builtin.FPIEEE${builtinFloatLiteralBits}) {
 %   if bits == builtinFloatLiteralBits:
-    self = ${Self}(_bits: value)
+    self = ${Self}(value)
 %   elif bits < builtinFloatLiteralBits:
     // FIXME: This can result in double rounding errors (SR-7124).
-    self = ${Self}(_bits: Builtin.fptrunc_FPIEEE${builtinFloatLiteralBits}_FPIEEE${bits}(value))
+    self = ${Self}(Builtin.fptrunc_FPIEEE${builtinFloatLiteralBits}_FPIEEE${bits}(value))
 %   else:
     // FIXME: This is actually losing precision <rdar://problem/14073102>.
     self = ${Self}(Builtin.fpext_FPIEEE${builtinFloatLiteralBits}_FPIEEE${bits}(value))
@@ -1569,7 +1569,7 @@ extension ${Self} {
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   public var magnitude: ${Self} {
-    return ${Self}(_bits: Builtin.int_fabs_FPIEEE${bits}(_value))
+    return ${Self}(Builtin.int_fabs_FPIEEE${bits}(_value))
   }
 }
 
@@ -1577,7 +1577,7 @@ extension ${Self} {
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   public static prefix func - (x: ${Self}) -> ${Self} {
-    return ${Self}(_bits: Builtin.fneg_FPIEEE${bits}(x._value))
+    return ${Self}(Builtin.fneg_FPIEEE${bits}(x._value))
   }
 }
 

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -3290,14 +3290,6 @@ ${assignmentOperatorComment('%', True)}
     self._value = _value
   }
 
-  // FIXME(integers): in order to remove this, the simd.swift.gyb should be
-  // updated
-  @_inlineable // FIXME(sil-serialize-all)
-  @_transparent
-  public init(_bits: Builtin.Int${bits}) {
-    self._value = _bits
-  }
-
 % for x in binaryBitwise:
 ${assignmentOperatorComment(x.operator, True)}
   @_inlineable // FIXME(sil-serialize-all)

--- a/test/DebugInfo/vector.swift
+++ b/test/DebugInfo/vector.swift
@@ -14,7 +14,7 @@ public struct float2 {
     get {
       let elt = Builtin.extractelement_Vec2xFPIEEE32_Int32(_vector,
         Int32(index)._value)
-      return Float(_bits: elt)
+      return Float(elt)
     }
   }
 }

--- a/test/stdlib/FloatingPoint.swift.gyb
+++ b/test/stdlib/FloatingPoint.swift.gyb
@@ -49,7 +49,7 @@ extension Float80 {
       Builtin.zextOrBitCast_Int64_Int80((64 as Int64)._value))
     result = Builtin.or_Int80(
       result, Builtin.zextOrBitCast_Int64_Int80(bitPattern.significand._value))
-    self = Float80(_bits: Builtin.bitcast_Int80_FPIEEE80(result))
+    self = Float80(Builtin.bitcast_Int80_FPIEEE80(result))
   }
 }
 


### PR DESCRIPTION
For stdlib integer types, these are named `_value` and `init(_ _value: Builtin.xxx)`. This patch adopts the same scheme for stdlib floating point and SDK overlay vector types, and removes a legacy init for integers that was only needed to support them. There should be no changes visible outside of the stdlib, and no functional change within the stdlib; the naming of some implementation details is simply more uniform now.