### PR TITLE
[lldb-moduleimport] Add the logic for testing getDeclBySymbolName().

### DIFF
--- a/test/DebugInfo/DumpDeclFromMangledName.swift
+++ b/test/DebugInfo/DumpDeclFromMangledName.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+
+// %t.input: "A ---> B" ==> "A"
+// RUN: sed -ne '/--->/s/ *--->.*$//p' < %S/Inputs/decl-reconstr-names.txt > %t.input
+
+// %t.check: "A ---> B" ==> "B"
+// RUN: sed -ne '/--->/s/^.*---> *//p' < %S/Inputs/decl-reconstr-names.txt > %t.check
+
+// RUN: %target-build-swift -emit-executable %s -g -o %t/DeclReconstr -emit-module
+// RUN: %lldb-moduleimport-test %t/DeclReconstr \
+// RUN:   -decl-from-mangled=%t.input > %t.output 2>&1
+// RUN: diff %t.check %t.output
+
+// REQUIRES: executable_test
+struct S {
+  init() {
+  }
+}
+
+func patatino() -> Int {
+  let s = S()
+  return 0
+}
+
+patatino()

--- a/test/DebugInfo/Inputs/decl-reconstr-names.txt
+++ b/test/DebugInfo/Inputs/decl-reconstr-names.txt
@@ -1,0 +1,2 @@
+$S12DeclReconstr8patatinoSiyF ---> func patatino() -> Int
+$S12DeclReconstr1SVACycfC ---> Can't resolve decl of $S12DeclReconstr1SVACycfC

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -63,7 +63,7 @@ static void printValidationInfo(llvm::StringRef data) {
 }
 
 static void resolveTypeFromMangledNameList(
-    swift::ASTContext &Ctx, llvm::SmallVector<std::string, 8> &MangledNames) {
+    swift::ASTContext &Ctx, llvm::ArrayRef<std::string> MangledNames) {
   std::string Error;
   for (auto &Mangled : MangledNames) {
     swift::Type ResolvedType =
@@ -78,8 +78,8 @@ static void resolveTypeFromMangledNameList(
 }
 
 static void
-collectMangledNames(std::string &FilePath,
-                    llvm::SmallVector<std::string, 8> &MangledNames) {
+collectMangledNames(const std::string &FilePath,
+                    llvm::SmallVectorImpl<std::string> &MangledNames) {
   std::string Name;
   std::ifstream InputStream(FilePath);
   while (std::getline(InputStream, Name)) {

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -62,6 +62,21 @@ static void printValidationInfo(llvm::StringRef data) {
   }
 }
 
+static void resolveDeclFromMangledNameList(
+    swift::ASTContext &Ctx, llvm::ArrayRef<std::string> MangledNames) {
+  std::string Error;
+  for (auto &Mangled : MangledNames) {
+    swift::Decl *ResolvedDecl =
+        swift::ide::getDeclFromMangledSymbolName(Ctx, Mangled, Error);
+    if (!ResolvedDecl) {
+      llvm::errs() << "Can't resolve decl of " << Mangled << "\n";
+    } else {
+      ResolvedDecl->print(llvm::errs());
+      llvm::errs() << "\n";
+    }
+  }
+}
+
 static void resolveTypeFromMangledNameList(
     swift::ASTContext &Ctx, llvm::ArrayRef<std::string> MangledNames) {
   std::string Error;
@@ -117,8 +132,11 @@ int main(int argc, char **argv) {
   llvm::cl::list<std::string> FrameworkPaths(
     "F", llvm::cl::desc("add a directory to the framework search path"));
 
+  llvm::cl::opt<std::string> DumpDeclFromMangled(
+      "decl-from-mangled", llvm::cl::desc("dump decl from mangled names list"));
+
   llvm::cl::opt<std::string> DumpTypeFromMangled(
-      "type-from-mangled", llvm::cl::desc("dump type from mangled name"));
+      "type-from-mangled", llvm::cl::desc("dump type from mangled names list"));
 
   llvm::cl::ParseCommandLineOptions(argc, argv);
   // Unregister our options so they don't interfere with the command line
@@ -268,6 +286,11 @@ int main(int argc, char **argv) {
       llvm::SmallVector<std::string, 8> MangledNames;
       collectMangledNames(DumpTypeFromMangled, MangledNames);
       resolveTypeFromMangledNameList(CI.getASTContext(), MangledNames);
+    }
+    if (!DumpDeclFromMangled.empty()) {
+      llvm::SmallVector<std::string, 8> MangledNames;
+      collectMangledNames(DumpDeclFromMangled, MangledNames);
+      resolveDeclFromMangledNameList(CI.getASTContext(), MangledNames);
     }
   }
   return 0;


### PR DESCRIPTION
Adrian already found and reported a bug, which I'm going to fix
in a later commit. Eventually this will go away, but in the meanwhile,
we should add test for this codepath.

<rdar://problem/38720742>

(I also decided to sneak in another commit to address Jordan's post commit reviews).