### PR TITLE
[TypeReconstruction] Fix reconstructions for allocator.

### DIFF
--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -1217,7 +1217,7 @@ static void VisitLocalDeclVariableName(ASTContext *ast,
       name->getText());
 }
 
-// VisitNodeFunction gets used for Function, Variable and Allocator:
+// VisitNodeFunction gets used for Function and Variable.
 static void VisitNodeFunction(
     ASTContext *ast,
     Demangle::NodePointer cur_node, VisitNodeResult &result) {
@@ -1346,25 +1346,6 @@ static void VisitNodeFunction(
       break;
     }
   } while (0);
-
-  //                    if (node_kind == Demangle::Node::Kind::Allocator)
-  //                    {
-  //                        // For allocators we don't have an identifier for
-  //                        the name, we will
-  //                        // need to extract it from the class or struct in
-  //                        "identifier_result"
-  //                        //Find
-  //                        if (identifier_result.HasSingleType())
-  //                        {
-  //                            // This contains the class or struct
-  //                            StringRef init_name("init");
-  //
-  //                            if (FindFirstNamedDeclWithKind(ast, init_name,
-  //                            DeclKind::Constructor, identifier_result))
-  //                            {
-  //                            }
-  //                        }
-  //                    }
 
   if (identifier_result._types.size() == 1) {
     result._module = identifier_result._module;
@@ -2229,6 +2210,7 @@ static void VisitNode(
     VisitAllChildNodes(ast, node, result);
     break;
 
+  case Demangle::Node::Kind::Allocator:
   case Demangle::Node::Kind::Constructor:
     VisitNodeConstructor(ast, node, result);
     break;
@@ -2254,7 +2236,6 @@ static void VisitNode(
     break;
 
   case Demangle::Node::Kind::Function:
-  case Demangle::Node::Kind::Allocator:
   case Demangle::Node::Kind::Variable:
   case Demangle::Node::Kind::Subscript: // Out of order on purpose
     VisitNodeFunction(ast, node, result);

--- a/test/DebugInfo/DumpDeclFromMangledName.swift
+++ b/test/DebugInfo/DumpDeclFromMangledName.swift
@@ -7,7 +7,7 @@
 // RUN: sed -ne '/--->/s/^.*---> *//p' < %S/Inputs/decl-reconstr-names.txt > %t.check
 
 // RUN: %target-build-swift -emit-executable %s -g -o %t/DeclReconstr -emit-module
-// RUN: %lldb-moduleimport-test %t/DeclReconstr \
+// RUN: %lldb-moduleimport-test %t/DeclReconstr -target-triple %target-triple \
 // RUN:   -decl-from-mangled=%t.input > %t.output 2>&1
 // RUN: diff %t.check %t.output
 

--- a/test/DebugInfo/Inputs/decl-reconstr-names.txt
+++ b/test/DebugInfo/Inputs/decl-reconstr-names.txt
@@ -1,2 +1,2 @@
 $S12DeclReconstr8patatinoSiyF ---> func patatino() -> Int
-$S12DeclReconstr1SVACycfC ---> Can't resolve decl of $S12DeclReconstr1SVACycfC
+$S12DeclReconstr1SVACycfC ---> init()

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -138,6 +138,10 @@ int main(int argc, char **argv) {
   llvm::cl::opt<std::string> DumpTypeFromMangled(
       "type-from-mangled", llvm::cl::desc("dump type from mangled names list"));
 
+  // FIXME: we should infer this from the module.
+  llvm::cl::opt<std::string> TargetTriple(
+      "target-triple", llvm::cl::desc("specify target triple"));
+
   llvm::cl::ParseCommandLineOptions(argc, argv);
   // Unregister our options so they don't interfere with the command line
   // parsing in CodeGen/BackendUtil.cpp.
@@ -148,6 +152,7 @@ int main(int argc, char **argv) {
   DumpTypeFromMangled.removeArgument();
   SDK.removeArgument();
   InputNames.removeArgument();
+  TargetTriple.removeArgument();
 
   // If no SDK was specified via -sdk, check environment variable SDKROOT.
   if (SDK.getNumOccurrences() == 0) {
@@ -166,7 +171,13 @@ int main(int argc, char **argv) {
           reinterpret_cast<void *>(&anchorForGetMainExecutable)));
 
   Invocation.setSDKPath(SDK);
-  Invocation.setTargetTriple(llvm::sys::getDefaultTargetTriple());
+
+  // FIXME: we should infer this from the module.
+  if (!TargetTriple.empty())
+    Invocation.setTargetTriple(TargetTriple);
+  else
+    Invocation.setTargetTriple(llvm::sys::getDefaultTargetTriple());
+
   Invocation.setModuleName("lldbtest");
   Invocation.getClangImporterOptions().ModuleCachePath = ModuleCachePath;
   Invocation.setImportSearchPaths(ImportPaths);


### PR DESCRIPTION
Adrian reported this bug he discovered as part of his
work on improving generics in swift/lldb.
Allocators were treated as `function`, when the demangle
tree suggests they're much more akin to constructors. On
top of that, the code for handling them was commented out,
so type reconstruction was always failing. I'm not entirely
sure this is always correct, but it seems to be an improvement
on what currently type reconstruction does. At least now
we have tests so if something will break, we're going to
notice.

<rdar://problem/38720742>