### PR TITLE
[Batch Mode] Add frontend check to ensure that all primaries are present in the supplementary output filemap.

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -136,6 +136,9 @@ ERROR(error_underlying_module_not_found,none,
 ERROR(error_unable_to_load_supplementary_output_file_map, none,
       "unable to load supplementary output file map '%0': %1", (StringRef, StringRef))
 
+ERROR(error_missing_entry_in_supplementary_output_file_map, none,
+      "supplementary output file map '%0' is missing an entry for '%1' (this likely indicates a compiler issue; please file a bug report)", (StringRef, StringRef))
+
 ERROR(error_repl_requires_no_input_files,none,
   "REPL mode requires no input files", ())
 ERROR(error_mode_requires_one_input_file,none,

--- a/include/swift/Frontend/ArgsToFrontendOutputsConverter.h
+++ b/include/swift/Frontend/ArgsToFrontendOutputsConverter.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 namespace swift {
+class OutputFileMap;
 
 /// Given the command line arguments and information about the inputs,
 /// Fill in all the information in FrontendInputsAndOutputs.

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -518,13 +518,23 @@ SupplementaryOutputPathsComputer::readSupplementaryOutputFileMap() const {
   }
 
   std::vector<SupplementaryOutputPaths> outputPaths;
+  bool hadError = false;
   InputsAndOutputs.forEachInputProducingSupplementaryOutput(
       [&](const InputFile &input) -> bool {
         const TypeToPathMap *mapForInput =
             OFM->getOutputMapForInput(input.file());
+        if (!mapForInput) {
+          Diags.diagnose(
+              SourceLoc(),
+              diag::error_missing_entry_in_supplementary_output_file_map,
+              supplementaryFileMapPath, input.file());
+          hadError = true;
+        }
         outputPaths.push_back(createFromTypeToPathMap(mapForInput));
         return false;
       });
+  if (hadError)
+    return None;
 
   return outputPaths;
 }

--- a/test/Frontend/Inputs/supplementary_output_filemap_missing_a_primary.yaml
+++ b/test/Frontend/Inputs/supplementary_output_filemap_missing_a_primary.yaml
@@ -1,0 +1,4 @@
+"main.swift":
+  object: "main.o"
+  dependencies: "main.d"
+  diagnostics: "main.dia"

--- a/test/Frontend/batch_mode_output_file_map_missing_primary.swift
+++ b/test/Frontend/batch_mode_output_file_map_missing_primary.swift
@@ -1,0 +1,6 @@
+// RUN: %empty-directory(%t)
+// RUN: echo 'print("Hello, World!")' >%t/main.swift
+// RUN: touch %t/file-01.swift
+// RUN: (cd %t && not %target-swift-frontend -parse -primary-file main.swift -primary-file file-01.swift -supplementary-output-file-map %S/Inputs/supplementary_output_filemap_missing_a_primary.yaml >%t/errs.txt 2>&1)
+// RUN: %FileCheck %s <%t/errs.txt
+// CHECK: error: supplementary output file map '{{.*}}supplementary_output_filemap_missing_a_primary.yaml' is missing an entry for 'file-01.swift' (this likely indicates a compiler issue; please file a bug report)


### PR DESCRIPTION
…pplementary output filemap.

<!-- What's in this pull request? -->
If the supplementary output file map does not get transmitted correctly from the driver into the frontend, one symptom can be that not all primary inputs are represented when the frontend parses the map. This PR adds a check for that condition to the compiler.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
