### PR TITLE
SwiftSyntax: bridging absolute location with diagnostics location.

### DIFF
--- a/tools/SwiftSyntax/Diagnostic.swift
+++ b/tools/SwiftSyntax/Diagnostic.swift
@@ -29,6 +29,12 @@ public struct SourceLocation: Codable {
   /// The file in which this location resides.
   public let file: String
 
+  public init(file: String, position: AbsolutePosition) {
+    assert(position is UTF8Position, "must be utf8 position")
+    self.init(line: position.line, column: position.column,
+              offset: position.byteOffset, file: file)
+  }
+
   public init(line: Int, column: Int, offset: Int, file: String) {
     self.line = line
     self.column = column


### PR DESCRIPTION
We have two similar objects for source location. AbsoluteLocation
calculates the offset of a syntax node on the fly. SourceLocation is
designed to serialize a Swift syntax diagnostics to the driver. The only
difference is AbsoluteLocation doesn't contain source file name however
SourceLocation does. This patch bridges them by making AbsoluteLocation
a private member of SourceLocation. We also expect Swift syntax to
be file-name agnostic. The clients should keep track of the file name
when emitting diagnostics.
