### PR TITLE
[CSRanking] Don't prioritize `Any?` over `Any` in parameter comparison

### DIFF
--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -638,6 +638,12 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
           Type paramType1 = getAdjustedParamType(param1);
           Type paramType2 = getAdjustedParamType(param2);
 
+          // Any? is never better than Any.
+          if (auto objType = paramType1->getOptionalObjectType()) {
+            if (objType->isAny() && paramType2->isAny())
+              return false;
+          }
+
           // Check whether the first parameter is a subtype of the second.
           cs.addConstraint(ConstraintKind::Subtype,
                            paramType1, paramType2, locator);

--- a/test/Constraints/rdar38625824.swift
+++ b/test/Constraints/rdar38625824.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
+
+func foo<T>(_: Any) -> T {
+  fatalError()
+}
+
+func foo<T>(_: Any?) -> T {
+  fatalError()
+}
+
+// CHECK: function_ref @$S12rdar386258243fooyxyplF : $@convention(thin) <τ_0_0> (@in_guaranteed Any) -> @out τ_0_0
+var _: String = foo("hello")


### PR DESCRIPTION
`Any?` can't be better than `Any` because it requires more
implicit conversions, so when comparing declarations that
have parameters differ in optionality associated with `Any`
don't try to prefer more optional type.

Resolves: rdar://problem/38625824

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
