### PR TITLE
XFAIL pointer_conversion_objc without asserts

### DIFF
--- a/test/SILOptimizer/pointer_conversion_objc.swift
+++ b/test/SILOptimizer/pointer_conversion_objc.swift
@@ -2,6 +2,7 @@
 
 // REQUIRES: optimized_stdlib
 // REQUIRES: objc_interop
+// REQUIRES: swift_stdlib_asserts
 
 // Opaque, unoptimizable functions to call.
 @_silgen_name("takesConstRawPointer")


### PR DESCRIPTION
radar rdar://38767510

Require asserts for the test - temporary workaround until @gottesmm looks into this issue 