### PR TITLE
IRGen: Lower property descriptors.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -2478,7 +2478,7 @@ public:
     case Kind::OptionalChain:
     case Kind::OptionalForce:
     case Kind::OptionalWrap:
-      llvm_unreachable("not a computed property");
+      return {};
     case Kind::GettableProperty:
     case Kind::SettableProperty:
     case Kind::External:

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1089,6 +1089,12 @@ void IRGenerator::emitGlobalTopLevel() {
     }
   }
   
+  // Emit property descriptors.
+  for (auto &prop : PrimaryIGM->getSILModule().getPropertyList()) {
+    CurrentIGMPtr IGM = getGenModule(prop.getDecl()->getInnermostDeclContext());
+    IGM->emitSILProperty(&prop);
+  }
+  
   for (auto Iter : *this) {
     IRGenModule *IGM = Iter.second;
     IGM->finishEmitAfterTopLevel();

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -23,6 +23,7 @@
 #include "GenMeta.h"
 #include "GenProto.h"
 #include "GenStruct.h"
+#include "GenType.h"
 #include "GenericRequirement.h"
 #include "IRGenDebugInfo.h"
 #include "IRGenFunction.h"
@@ -39,9 +40,11 @@
 #include "swift/ABI/KeyPath.h"
 #include "swift/ABI/HeapObject.h"
 #include "swift/AST/ASTContext.h"
+#include "swift/AST/Decl.h"
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/DiagnosticsIRGen.h"
 #include "swift/AST/GenericEnvironment.h"
+#include "swift/AST/ParameterList.h"
 #include "swift/AST/Types.h"
 #include "swift/IRGen/Linking.h"
 
@@ -61,14 +64,15 @@ bindPolymorphicArgumentsFromComponentIndices(IRGenFunction &IGF,
                                      GenericEnvironment *genericEnv,
                                      ArrayRef<GenericRequirement> requirements,
                                      llvm::Value *args,
-                                     llvm::Value *size) {
+                                     llvm::Value *size,
+                                     bool hasSubscriptIndices) {
   if (!genericEnv)
     return;
   
   // The generic environment is marshaled into the end of the component
   // argument area inside the instance. Bind the generic information out of
   // the buffer.
-  if (!component.getSubscriptIndices().empty()) {
+  if (hasSubscriptIndices) {
     auto genericArgsSize = llvm::ConstantInt::get(IGF.IGM.SizeTy,
       requirements.size() * IGF.IGM.getPointerSize().getValue());
 
@@ -87,7 +91,8 @@ getAccessorForComputedComponent(IRGenModule &IGM,
                                 const KeyPathPatternComponent &component,
                                 KeyPathAccessor whichAccessor,
                                 GenericEnvironment *genericEnv,
-                                ArrayRef<GenericRequirement> requirements) {
+                                ArrayRef<GenericRequirement> requirements,
+                                bool hasSubscriptIndices) {
   SILFunction *accessor;
   switch (whichAccessor) {
   case Getter:
@@ -202,8 +207,9 @@ getAccessorForComputedComponent(IRGenModule &IGM,
     case Setter:
       // The component arguments are passed alongside the base being projected.
       componentArgsBuf = params.claimNext();
-      // Pass the argument pointer down to the underlying function.
-      if (!component.getSubscriptIndices().empty()) {
+      // Pass the argument pointer down to the underlying function, if it
+      // wants it.
+      if (hasSubscriptIndices) {
         forwardedArgs.add(componentArgsBuf);
       }
       break;
@@ -217,7 +223,8 @@ getAccessorForComputedComponent(IRGenModule &IGM,
     bindPolymorphicArgumentsFromComponentIndices(IGF, component,
                                                  genericEnv, requirements,
                                                  componentArgsBuf,
-                                                 componentArgsBufSize);
+                                                 componentArgsBufSize,
+                                                 hasSubscriptIndices);
     
     // Use the bound generic metadata to form a call to the original generic
     // accessor.
@@ -374,9 +381,10 @@ getWitnessTableForComputedComponent(IRGenModule &IGM,
       auto componentArgsBuf = params.claimNext();
       auto componentArgsBufSize = params.claimNext();
       bindPolymorphicArgumentsFromComponentIndices(IGF, component,
-                                                   genericEnv, requirements,
-                                                   componentArgsBuf,
-                                                   componentArgsBufSize);
+                                     genericEnv, requirements,
+                                     componentArgsBuf,
+                                     componentArgsBufSize,
+                                     !component.getSubscriptIndices().empty());
       
       llvm::Value *offset = nullptr;
       for (auto &component : component.getSubscriptIndices()) {
@@ -422,9 +430,10 @@ getWitnessTableForComputedComponent(IRGenModule &IGM,
       auto destArgsBuf = params.claimNext();
       auto componentArgsBufSize = params.claimNext();
       bindPolymorphicArgumentsFromComponentIndices(IGF, component,
-                                                   genericEnv, requirements,
-                                                   sourceArgsBuf,
-                                                   componentArgsBufSize);
+                                     genericEnv, requirements,
+                                     sourceArgsBuf,
+                                     componentArgsBufSize,
+                                     !component.getSubscriptIndices().empty());
       
       // Copy over the index values.
       llvm::Value *offset = nullptr;
@@ -477,9 +486,11 @@ getWitnessTableForComputedComponent(IRGenModule &IGM,
   }
   
   auto equals = getAccessorForComputedComponent(IGM, component, Equals,
-                                                genericEnv, requirements);
+                                      genericEnv, requirements,
+                                      !component.getSubscriptIndices().empty());
   auto hash = getAccessorForComputedComponent(IGM, component, Hash,
-                                              genericEnv, requirements);
+                                      genericEnv, requirements,
+                                      !component.getSubscriptIndices().empty());
   
   auto witnesses = llvm::ConstantStruct::getAnon({destroy, copy, equals, hash});
   return new llvm::GlobalVariable(IGM.Module, witnesses->getType(),
@@ -631,6 +642,435 @@ getInitializerForComputedComponent(IRGenModule &IGM,
   return initFn;
 }
 
+/// Emit a generator function to produce a reference to a type or
+/// protocol conformance metadata record.
+/// TODO: It would be much better to emit typeref strings and use runtime
+/// demangling here.
+static llvm::Function *
+emitGeneratorForKeyPath(IRGenModule &IGM,
+                        StringRef name, CanType type, llvm::Type *returnType,
+                        GenericEnvironment *genericEnv,
+                        ArrayRef<GenericRequirement> requirements,
+                        llvm::function_ref<void(IRGenFunction&,CanType)> emit) {
+  // TODO: Use the standard metadata accessor when there are no arguments
+  // and the metadata accessor is defined.
+
+  // Build a stub that loads the necessary bindings from the key path's
+  // argument buffer then fetches the metadata.
+  auto fnTy = llvm::FunctionType::get(returnType,
+                                      {IGM.Int8PtrTy}, /*vararg*/ false);
+  auto accessorThunk = llvm::Function::Create(fnTy,
+                                          llvm::GlobalValue::PrivateLinkage,
+                                          name, IGM.getModule());
+  accessorThunk->setAttributes(IGM.constructInitialAttributes());
+  {
+    IRGenFunction IGF(IGM, accessorThunk);
+    if (IGM.DebugInfo)
+      IGM.DebugInfo->emitArtificialFunction(IGF, accessorThunk);
+    
+    if (type->hasTypeParameter()) {
+      auto bindingsBufPtr = IGF.collectParameters().claimNext();
+      
+      bindFromGenericRequirementsBuffer(IGF, requirements,
+            Address(bindingsBufPtr, IGM.getPointerAlignment()),
+            [&](CanType t) {
+              return genericEnv->mapTypeIntoContext(t)->getCanonicalType();
+            });
+      
+      type = genericEnv->mapTypeIntoContext(type)->getCanonicalType();
+    }
+    emit(IGF, type);
+  }
+  return accessorThunk;
+}
+
+static llvm::Function *
+emitMetadataGeneratorForKeyPath(IRGenModule &IGM,
+                                CanType type,
+                                GenericEnvironment *genericEnv,
+                                ArrayRef<GenericRequirement> requirements) {
+  // TODO: Use the standard metadata accessor when there are no arguments
+  // and the metadata accessor is defined.
+  return emitGeneratorForKeyPath(IGM, "keypath_get_type", type,
+    IGM.TypeMetadataPtrTy,
+    genericEnv, requirements,
+    [&](IRGenFunction &IGF, CanType substType) {
+      auto ret = IGF.emitTypeMetadataRef(substType);
+      IGF.Builder.CreateRet(ret);
+    });
+};
+
+static llvm::Function *
+emitWitnessTableGeneratorForKeyPath(IRGenModule &IGM,
+                                    CanType type,
+                                    ProtocolConformanceRef conformance,
+                                    GenericEnvironment *genericEnv,
+                                    ArrayRef<GenericRequirement> requirements) {
+  // TODO: Use the standard conformance accessor when there are no arguments
+  // and the conformance accessor is defined.
+  return emitGeneratorForKeyPath(IGM, "keypath_get_witness_table", type,
+    IGM.WitnessTablePtrTy,
+    genericEnv, requirements,
+    [&](IRGenFunction &IGF, CanType substType) {
+      if (type->hasTypeParameter())
+        conformance = conformance.subst(type,
+          QueryInterfaceTypeSubstitutions(genericEnv),
+          LookUpConformanceInSignature(*genericEnv->getGenericSignature()));
+      auto ret = emitWitnessTableRef(IGF, substType, conformance);
+      IGF.Builder.CreateRet(ret);
+    });
+}
+
+
+static void
+emitKeyPathComponent(IRGenModule &IGM,
+                     ConstantStructBuilder &fields,
+                     const KeyPathPatternComponent &component,
+                     bool isInstantiableInPlace,
+                     GenericEnvironment *genericEnv,
+                     ArrayRef<GenericRequirement> requirements,
+                     CanType baseTy,
+                     ArrayRef<KeyPathIndexOperand> operands,
+                     bool hasSubscriptIndices) {
+  assert(fields.getNextOffsetFromGlobal() % IGM.getPointerAlignment() == Size(0)
+         && "must be pointer-aligned here");
+
+  SILType loweredBaseTy;
+  GenericContextScope scope(IGM,
+         genericEnv ? genericEnv->getGenericSignature()->getCanonicalSignature()
+                    : nullptr);
+  loweredBaseTy = IGM.getLoweredType(AbstractionPattern::getOpaque(),
+                                     baseTy->getWithoutSpecifierType());
+  switch (auto kind = component.getKind()) {
+  case KeyPathPatternComponent::Kind::External: {
+    fields.addInt32(KeyPathComponentHeader::forExternalComponent().getData());
+    // Emit accessors for all of the external declaration's necessary
+    // bindings.
+    SmallVector<llvm::Constant*, 4> descriptorArgs;
+    auto componentSig = component.getExternalDecl()->getInnermostDeclContext()
+      ->getGenericSignatureOfContext();
+    auto subs = componentSig->getSubstitutionMap(
+                                        component.getExternalSubstitutions());
+    enumerateGenericSignatureRequirements(
+      componentSig->getCanonicalSignature(),
+      [&](GenericRequirement reqt) {
+        auto substType = reqt.TypeParameter.subst(subs)
+          ->getCanonicalType();
+        if (!reqt.Protocol) {
+          // Type requirement.
+          descriptorArgs.push_back(
+            emitMetadataGeneratorForKeyPath(IGM, substType,
+                                            genericEnv, requirements));
+        } else {
+          // Protocol requirement.
+          auto conformance = subs.lookupConformance(
+                       reqt.TypeParameter->getCanonicalType(), reqt.Protocol);
+          descriptorArgs.push_back(
+            emitWitnessTableGeneratorForKeyPath(IGM, substType,
+                                                *conformance,
+                                                genericEnv, requirements));
+        }
+      });
+    // If instantiable in-place, pad out the argument count here to ensure
+    // there's room enough to instantiate a settable computed property
+    // with two captured words in-place. The runtime instantiation of the
+    // external component will ignore the padding, and this will make in-place
+    // instantiation more likely to avoid needing an allocation.
+    unsigned argSize = descriptorArgs.size();
+    if (isInstantiableInPlace) {
+      argSize = std::max(argSize, 3u);
+    }
+    
+    fields.addInt32(argSize);
+    fields.add(IGM.getAddrOfPropertyDescriptor(component.getExternalDecl()));
+    
+    // Add an initializer function that copies generic arguments out of the
+    // pattern argument buffer into the instantiated object, along with the
+    // index equality/hash operations we have from our perspective, or null
+    // if there are no arguments.
+    if (component.getSubscriptIndices().empty()) {
+      fields.addInt(IGM.IntPtrTy, 0);
+      fields.addInt(IGM.IntPtrTy, 0);
+      fields.addInt(IGM.IntPtrTy, 0);
+    } else {
+      fields.add(getInitializerForComputedComponent(IGM, component,
+                                                    operands,
+                                                    genericEnv,
+                                                    requirements));
+      fields.add(IGM.getAddrOfSILFunction(component.getSubscriptIndexEquals(),
+                                          NotForDefinition));
+      fields.add(IGM.getAddrOfSILFunction(component.getSubscriptIndexHash(),
+                                          NotForDefinition));
+    }
+    
+    // Add the generic arguments for the external context.
+    for (auto arg : descriptorArgs)
+      fields.add(arg);
+    
+    // Add padding.
+    for (unsigned i = descriptorArgs.size(); i < argSize; ++i)
+      fields.addInt(IGM.IntPtrTy, 0);
+    break;
+  }
+  case KeyPathPatternComponent::Kind::StoredProperty: {
+    auto property = cast<VarDecl>(component.getStoredPropertyDecl());
+    
+    auto addFixedOffset = [&](bool isStruct, llvm::Constant *offset) {
+      if (auto offsetInt = dyn_cast_or_null<llvm::ConstantInt>(offset)) {
+        auto offsetValue = offsetInt->getValue().getZExtValue();
+        if (KeyPathComponentHeader::offsetCanBeInline(offsetValue)) {
+          auto header = isStruct
+            ? KeyPathComponentHeader
+                ::forStructComponentWithInlineOffset(offsetValue)
+            : KeyPathComponentHeader
+                ::forClassComponentWithInlineOffset(offsetValue);
+          fields.addInt32(header.getData());
+          return;
+        }
+      }
+      auto header = isStruct
+        ? KeyPathComponentHeader::forStructComponentWithOutOfLineOffset()
+        : KeyPathComponentHeader::forClassComponentWithOutOfLineOffset();
+      fields.addInt32(header.getData());
+      fields.add(llvm::ConstantExpr::getTruncOrBitCast(offset, IGM.Int32Ty));
+    };
+    
+    // For a struct stored property, we may know the fixed offset of the field,
+    // or we may need to fetch it out of the type's metadata at instantiation
+    // time.
+    if (auto theStruct = loweredBaseTy.getStructOrBoundGenericStruct()) {
+      if (auto offset = emitPhysicalStructMemberFixedOffset(IGM,
+                                                            loweredBaseTy,
+                                                            property)) {
+        // We have a known constant fixed offset.
+        addFixedOffset(/*struct*/ true, offset);
+        break;
+      }
+
+      // If the offset isn't fixed, try instead to get the field offset out
+      // of the type metadata at instantiation time.
+      auto &metadataLayout = IGM.getMetadataLayout(theStruct);
+      auto fieldOffset = metadataLayout.getStaticFieldOffset(property);
+
+      auto header = KeyPathComponentHeader
+        ::forStructComponentWithUnresolvedFieldOffset();
+      fields.addInt32(header.getData());
+      fields.addInt32(fieldOffset.getValue());
+      break;
+    }
+    
+    // For a class, we may know the fixed offset of a field at compile time,
+    // or we may need to fetch it at instantiation time. Depending on the
+    // ObjC-ness and resilience of the class hierarchy, there might be a few
+    // different ways we need to go about this.
+    if (loweredBaseTy.getClassOrBoundGenericClass()) {
+      switch (getClassFieldAccess(IGM, loweredBaseTy, property)) {
+      case FieldAccess::ConstantDirect: {
+        // Known constant fixed offset.
+        auto offset = tryEmitConstantClassFragilePhysicalMemberOffset(IGM,
+                                                                loweredBaseTy,
+                                                                property);
+        assert(offset && "no constant offset for ConstantDirect field?!");
+        addFixedOffset(/*struct*/ false, offset);
+        break;
+      }
+      case FieldAccess::NonConstantDirect: {
+        // A constant offset that's determined at class realization time.
+        // We have to load the offset from a global ivar.
+        auto header = KeyPathComponentHeader
+          ::forClassComponentWithUnresolvedIndirectOffset();
+        fields.addInt32(header.getData());
+        fields.addAlignmentPadding(IGM.getPointerAlignment());
+        auto offsetVar = IGM.getAddrOfFieldOffset(property, NotForDefinition);
+        fields.add(cast<llvm::Constant>(offsetVar.getAddress()));
+        break;
+      }
+      case FieldAccess::ConstantIndirect: {
+        // An offset that depends on the instance's generic parameterization,
+        // but whose field offset is at a known vtable offset.
+        auto header =
+          KeyPathComponentHeader::forClassComponentWithUnresolvedFieldOffset();
+        fields.addInt32(header.getData());
+        auto fieldOffset =
+          getClassFieldOffsetOffset(IGM,
+                                    loweredBaseTy.getClassOrBoundGenericClass(),
+                                    property);
+        fields.addInt32(fieldOffset.getValue());
+        break;
+      }
+      }
+      break;
+    }
+    llvm_unreachable("not struct or class");
+  }
+  case KeyPathPatternComponent::Kind::GettableProperty:
+  case KeyPathPatternComponent::Kind::SettableProperty: {
+    // Encode the settability.
+    bool settable = kind == KeyPathPatternComponent::Kind::SettableProperty;
+    KeyPathComponentHeader::ComputedPropertyKind componentKind;
+    if (settable) {
+      componentKind = component.isComputedSettablePropertyMutating()
+        ? KeyPathComponentHeader::SettableMutating
+        : KeyPathComponentHeader::SettableNonmutating;
+    } else {
+      componentKind = KeyPathComponentHeader::GetOnly;
+    }
+    
+    // Lower the id reference.
+    auto id = component.getComputedPropertyId();
+    KeyPathComponentHeader::ComputedPropertyIDKind idKind;
+    llvm::Constant *idValue;
+    bool idResolved;
+    switch (id.getKind()) {
+    case KeyPathPatternComponent::ComputedPropertyId::Function:
+      idKind = KeyPathComponentHeader::Pointer;
+      idValue = IGM.getAddrOfSILFunction(id.getFunction(), NotForDefinition);
+      idResolved = true;
+      break;
+    case KeyPathPatternComponent::ComputedPropertyId::DeclRef: {
+      auto declRef = id.getDeclRef();
+    
+      // Foreign method refs identify using a selector
+      // reference, which is doubly-indirected and filled in with a unique
+      // pointer by dyld.
+      if (declRef.isForeign) {
+        assert(IGM.ObjCInterop && "foreign keypath component w/o objc interop?!");
+        idKind = KeyPathComponentHeader::Pointer;
+        idValue = IGM.getAddrOfObjCSelectorRef(declRef);
+        idResolved = false;
+      } else {
+        idKind = KeyPathComponentHeader::VTableOffset;
+        auto dc = declRef.getDecl()->getDeclContext();
+        if (isa<ClassDecl>(dc) && !cast<ClassDecl>(dc)->isForeign()) {
+          auto overridden = declRef.getOverriddenVTableEntry();
+          auto declaringClass =
+            cast<ClassDecl>(overridden.getDecl()->getDeclContext());
+          auto &metadataLayout = IGM.getClassMetadataLayout(declaringClass);
+          // FIXME: Resilience. We don't want vtable layout to be ABI, so this
+          // should be encoded as a reference to the method dispatch thunk
+          // instead.
+          auto offset = metadataLayout.getStaticMethodOffset(overridden);
+          idValue = llvm::ConstantInt::get(IGM.SizeTy, offset.getValue());
+          idResolved = true;
+        } else if (auto methodProto = dyn_cast<ProtocolDecl>(dc)) {
+          // FIXME: Resilience. We don't want witness table layout to be ABI,
+          // so this should be encoded as a reference to the method dispatch
+          // thunk instead.
+          auto &protoInfo = IGM.getProtocolInfo(methodProto);
+          auto index = protoInfo.getFunctionIndex(
+                               cast<AbstractFunctionDecl>(declRef.getDecl()));
+          idValue = llvm::ConstantInt::get(IGM.SizeTy, -index.getValue());
+          idResolved = true;
+        } else {
+          llvm_unreachable("neither a class nor protocol dynamic method?");
+        }
+      }
+      break;
+    }
+    case KeyPathPatternComponent::ComputedPropertyId::Property:
+      // Use the index of the stored property within the aggregate to key
+      // the property.
+      auto property = id.getProperty();
+      idKind = KeyPathComponentHeader::StoredPropertyIndex;
+      if (auto struc = baseTy->getStructOrBoundGenericStruct()) {
+        // Scan the stored properties of the struct to find the index. We should
+        // only ever use a struct field as a uniquing key from inside the
+        // struct's own module, so this is OK.
+        idResolved = true;
+        Optional<unsigned> structIdx;
+        unsigned i = 0;
+        for (auto storedProp : struc->getStoredProperties()) {
+          if (storedProp == property) {
+            structIdx = i;
+            break;
+          }
+          ++i;
+        }
+        assert(structIdx && "not a stored property of the struct?!");
+        idValue = llvm::ConstantInt::get(IGM.SizeTy, structIdx.getValue());
+      } else if (baseTy->getClassOrBoundGenericClass()) {
+        // TODO: This field index would require runtime resolution with Swift
+        // native class resilience. We never directly access ObjC-imported
+        // ivars so we can disregard ObjC ivar resilience for this computation
+        // and start counting at the Swift native root.
+        switch (getClassFieldAccess(IGM, loweredBaseTy, property)) {
+        case FieldAccess::ConstantDirect:
+        case FieldAccess::ConstantIndirect:
+        case FieldAccess::NonConstantDirect:
+          idResolved = true;
+          idValue = llvm::ConstantInt::get(IGM.SizeTy,
+            getClassFieldIndex(IGM,
+                         SILType::getPrimitiveAddressType(baseTy), property));
+          break;
+        }
+        
+      } else {
+        llvm_unreachable("neither struct nor class");
+      }
+      break;
+    }
+    
+    auto header = KeyPathComponentHeader::forComputedProperty(componentKind,
+                                  idKind, !isInstantiableInPlace, idResolved);
+    
+    fields.addInt32(header.getData());
+    fields.addAlignmentPadding(IGM.getPointerAlignment());
+    fields.add(idValue);
+    
+    if (isInstantiableInPlace) {
+      // No generic arguments or indexes, so we can invoke the
+      // getter/setter as is.
+      fields.add(IGM.getAddrOfSILFunction(component.getComputedPropertyGetter(),
+                                          NotForDefinition));
+      if (settable)
+        fields.add(IGM.getAddrOfSILFunction(component.getComputedPropertySetter(),
+                                            NotForDefinition));
+    } else {
+      // If there's generic context or subscript indexes, embed as
+      // arguments in the component. Thunk the SIL-level accessors to give the
+      // runtime implementation a polymorphically-callable interface.
+      
+      // Push the accessors, possibly thunked to marshal generic environment.
+      fields.add(getAccessorForComputedComponent(IGM, component, Getter,
+                                                 genericEnv, requirements,
+                                                 hasSubscriptIndices));
+      if (settable)
+        fields.add(getAccessorForComputedComponent(IGM, component, Setter,
+                                                   genericEnv, requirements,
+                                                   hasSubscriptIndices));
+      
+      fields.add(getLayoutFunctionForComputedComponent(IGM, component,
+                                                     genericEnv, requirements));
+      
+      // Set up a "witness table" for the component that handles copying,
+      // destroying, equating, and hashing the captured contents of the
+      // component.
+      // If there are only generic parameters, we can use a prefab witness
+      // table from the runtime.
+      // For subscripts we generate functions that dispatch out to
+      // the copy/destroy/equals/hash functionality of the subscript indexes.
+      fields.add(getWitnessTableForComputedComponent(IGM, component,
+                                                   genericEnv, requirements));
+      
+      // Add an initializer function that copies generic arguments out of the
+      // pattern argument buffer into the instantiated object.
+      fields.add(getInitializerForComputedComponent(IGM, component, operands,
+                                                   genericEnv, requirements));
+    }
+    break;
+  }
+  case KeyPathPatternComponent::Kind::OptionalChain:
+    fields.addInt32(KeyPathComponentHeader::forOptionalChain().getData());
+    break;
+  case KeyPathPatternComponent::Kind::OptionalForce:
+    fields.addInt32(KeyPathComponentHeader::forOptionalForce().getData());
+    break;
+  case KeyPathPatternComponent::Kind::OptionalWrap:
+    fields.addInt32(KeyPathComponentHeader::forOptionalWrap().getData());
+    break;
+  }
+}
+
 llvm::Constant *
 IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
                                      SILLocation diagLoc) {
@@ -658,70 +1098,6 @@ IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
       [&](GenericRequirement reqt) { requirements.push_back(reqt); });
   }
 
-  auto emitGenerator =
-    [&](StringRef name, CanType type, llvm::Type *returnType,
-        llvm::function_ref<void (IRGenFunction&, CanType)> emit)
-    -> llvm::Function * {
-      // TODO: Use the standard metadata accessor when there are no arguments
-      // and the metadata accessor is defined.
-      
-      // Build a stub that loads the necessary bindings from the key path's
-      // argument buffer then fetches the metadata.
-      auto fnTy = llvm::FunctionType::get(returnType,
-                                          {Int8PtrTy}, /*vararg*/ false);
-      auto accessorThunk = llvm::Function::Create(fnTy,
-                                              llvm::GlobalValue::PrivateLinkage,
-                                              name, getModule());
-      accessorThunk->setAttributes(constructInitialAttributes());
-      {
-        IRGenFunction IGF(*this, accessorThunk);
-        if (DebugInfo)
-          DebugInfo->emitArtificialFunction(IGF, accessorThunk);
-        
-        if (type->hasTypeParameter()) {
-          auto bindingsBufPtr = IGF.collectParameters().claimNext();
-          
-          bindFromGenericRequirementsBuffer(IGF, requirements,
-                Address(bindingsBufPtr, getPointerAlignment()),
-                [&](CanType t) {
-                  return genericEnv->mapTypeIntoContext(t)->getCanonicalType();
-                });
-          
-          type = genericEnv->mapTypeIntoContext(type)->getCanonicalType();
-        }
-        emit(IGF, type);
-      }
-      return accessorThunk;
-    };
-
-  /// Generate a metadata accessor that produces metadata for the given type
-  /// using arguments from the generic context of the key path.
-  auto emitMetadataGenerator = [&](CanType type) -> llvm::Function * {
-    // TODO: Use the standard metadata accessor when there are no arguments
-    // and the metadata accessor is defined.
-    return emitGenerator("keypath_get_type", type, TypeMetadataPtrTy,
-      [&](IRGenFunction &IGF, CanType substType) {
-        auto ret = IGF.emitTypeMetadataRef(substType);
-        IGF.Builder.CreateRet(ret);
-      });
-  };
-    
-  auto emitWitnessTableGenerator =
-    [&](CanType type,
-        ProtocolConformanceRef conformance) -> llvm::Function * {
-      // TODO: Use the standard conformance accessor when there are no arguments
-      // and the conformance accessor is defined.
-      return emitGenerator("keypath_get_witness_table", type, WitnessTablePtrTy,
-        [&](IRGenFunction &IGF, CanType substType) {
-          if (type->hasTypeParameter())
-            conformance = conformance.subst(type,
-              QueryInterfaceTypeSubstitutions(genericEnv),
-              LookUpConformanceInSignature(*genericEnv->getGenericSignature()));
-          auto ret = emitWitnessTableRef(IGF, substType, conformance);
-          IGF.Builder.CreateRet(ret);
-        });
-    };
-  
   // Start building the key path pattern.
   ConstantInitBuilder builder(*this);
   ConstantStructBuilder fields = builder.beginStruct();
@@ -736,8 +1112,10 @@ IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
   // Store references to metadata generator functions to generate the metadata
   // for the root and leaf. These sit in the "isa" and object header parts of
   // the final object.
-  fields.add(emitMetadataGenerator(rootTy));
-  fields.add(emitMetadataGenerator(valueTy));
+  fields.add(emitMetadataGeneratorForKeyPath(*this, rootTy,
+                                             genericEnv, requirements));
+  fields.add(emitMetadataGeneratorForKeyPath(*this, valueTy,
+                                             genericEnv, requirements));
   
 #ifndef NDEBUG
   auto endOfObjectHeader = fields.getNextOffsetFromGlobal();
@@ -773,11 +1151,6 @@ IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
   // Build out the components.
   auto baseTy = rootTy;
   
-  auto assertPointerAlignment = [&]{
-    assert(fields.getNextOffsetFromGlobal() % getPointerAlignment() == Size(0)
-           && "must be pointer-aligned here");
-  };
-  
   // Collect the order and types of any captured index operands, which will
   // determine the layout of the buffer that gets passed to the initializer
   // for each component.
@@ -802,329 +1175,19 @@ IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
   }
   
   for (unsigned i : indices(pattern->getComponents())) {
-    assertPointerAlignment();
-    SILType loweredBaseTy;
-    Lowering::GenericContextScope scope(getSILTypes(),
-                                        pattern->getGenericSignature());
-    loweredBaseTy = getLoweredType(AbstractionPattern::getOpaque(),
-                                   baseTy->getWithoutSpecifierType());
     auto &component = pattern->getComponents()[i];
-    switch (auto kind = component.getKind()) {
-    case KeyPathPatternComponent::Kind::External: {
-      fields.addInt32(KeyPathComponentHeader::forExternalComponent().getData());
-      // Emit accessors for all of the external declaration's necessary
-      // bindings.
-      SmallVector<llvm::Constant*, 4> descriptorArgs;
-      auto componentSig = component.getExternalDecl()->getInnermostDeclContext()
-        ->getGenericSignatureOfContext();
-      auto subs = componentSig->getSubstitutionMap(
-                                          component.getExternalSubstitutions());
-      enumerateGenericSignatureRequirements(
-        componentSig->getCanonicalSignature(),
-        [&](GenericRequirement reqt) {
-          auto substType = reqt.TypeParameter.subst(subs)
-            ->getCanonicalType();
-          if (!reqt.Protocol) {
-            // Type requirement.
-            descriptorArgs.push_back(emitMetadataGenerator(substType));
-          } else {
-            // Protocol requirement.
-            auto conformance = subs.lookupConformance(
-                         reqt.TypeParameter->getCanonicalType(), reqt.Protocol);
-            descriptorArgs.push_back(emitWitnessTableGenerator(substType,
-                                                               *conformance));
-          }
-        });
-      // If instantiable in-place, pad out the argument count here to ensure
-      // there's room enough to instantiate a settable computed property
-      // with two captured words in-place. The runtime instantiation of the
-      // external component will ignore the padding, and this will make in-place
-      // instantiation more likely to avoid needing an allocation.
-      unsigned argSize = descriptorArgs.size();
-      if (isInstantiableInPlace) {
-        argSize = std::max(argSize, 3u);
-      }
-      
-      fields.addInt32(argSize);
-      fields.add(getAddrOfPropertyDescriptor(component.getExternalDecl()));
-      
-      // Add an initializer function that copies generic arguments out of the
-      // pattern argument buffer into the instantiated object, along with the
-      // index equality/hash operations we have from our perspective, or null
-      // if there are no arguments.
-      if (component.getSubscriptIndices().empty()) {
-        fields.addInt(IntPtrTy, 0);
-        fields.addInt(IntPtrTy, 0);
-        fields.addInt(IntPtrTy, 0);
-      } else {
-        fields.add(getInitializerForComputedComponent(*this, component,
-                                                      operands,
-                                                      genericEnv,
-                                                      requirements));
-        fields.add(getAddrOfSILFunction(component.getSubscriptIndexEquals(),
-                                        NotForDefinition));
-        fields.add(getAddrOfSILFunction(component.getSubscriptIndexHash(),
-                                        NotForDefinition));
-      }
-      
-      // Add the generic arguments for the external context.
-      for (auto arg : descriptorArgs)
-        fields.add(arg);
-      
-      // Add padding.
-      for (unsigned i = descriptorArgs.size(); i < argSize; ++i)
-        fields.addInt(IntPtrTy, 0);
-      break;
-    }
-    case KeyPathPatternComponent::Kind::StoredProperty: {
-      auto property = cast<VarDecl>(component.getStoredPropertyDecl());
-      
-      auto addFixedOffset = [&](bool isStruct, llvm::Constant *offset) {
-        if (auto offsetInt = dyn_cast_or_null<llvm::ConstantInt>(offset)) {
-          auto offsetValue = offsetInt->getValue().getZExtValue();
-          if (KeyPathComponentHeader::offsetCanBeInline(offsetValue)) {
-            auto header = isStruct
-              ? KeyPathComponentHeader
-                  ::forStructComponentWithInlineOffset(offsetValue)
-              : KeyPathComponentHeader
-                  ::forClassComponentWithInlineOffset(offsetValue);
-            fields.addInt32(header.getData());
-            return;
-          }
-        }
-        auto header = isStruct
-          ? KeyPathComponentHeader::forStructComponentWithOutOfLineOffset()
-          : KeyPathComponentHeader::forClassComponentWithOutOfLineOffset();
-        fields.addInt32(header.getData());
-        fields.add(llvm::ConstantExpr::getTruncOrBitCast(offset, Int32Ty));
-      };
-      
-      // For a struct stored property, we may know the fixed offset of the field,
-      // or we may need to fetch it out of the type's metadata at instantiation
-      // time.
-      if (auto theStruct = loweredBaseTy.getStructOrBoundGenericStruct()) {
-        if (auto offset = emitPhysicalStructMemberFixedOffset(*this,
-                                                              loweredBaseTy,
-                                                              property)) {
-          // We have a known constant fixed offset.
-          addFixedOffset(/*struct*/ true, offset);
-          break;
-        }
-
-        // If the offset isn't fixed, try instead to get the field offset out
-        // of the type metadata at instantiation time.
-        auto &metadataLayout = getMetadataLayout(theStruct);
-        auto fieldOffset = metadataLayout.getStaticFieldOffset(property);
-
-        auto header = KeyPathComponentHeader
-          ::forStructComponentWithUnresolvedFieldOffset();
-        fields.addInt32(header.getData());
-        fields.addInt32(fieldOffset.getValue());
-        break;
-      }
-      
-      // For a class, we may know the fixed offset of a field at compile time,
-      // or we may need to fetch it at instantiation time. Depending on the
-      // ObjC-ness and resilience of the class hierarchy, there might be a few
-      // different ways we need to go about this.
-      if (loweredBaseTy.getClassOrBoundGenericClass()) {
-        switch (getClassFieldAccess(*this, loweredBaseTy, property)) {
-        case FieldAccess::ConstantDirect: {
-          // Known constant fixed offset.
-          auto offset = tryEmitConstantClassFragilePhysicalMemberOffset(*this,
-                                                                  loweredBaseTy,
-                                                                  property);
-          assert(offset && "no constant offset for ConstantDirect field?!");
-          addFixedOffset(/*struct*/ false, offset);
-          break;
-        }
-        case FieldAccess::NonConstantDirect: {
-          // A constant offset that's determined at class realization time.
-          // We have to load the offset from a global ivar.
-          auto header = KeyPathComponentHeader
-            ::forClassComponentWithUnresolvedIndirectOffset();
-          fields.addInt32(header.getData());
-          fields.addAlignmentPadding(getPointerAlignment());
-          auto offsetVar = getAddrOfFieldOffset(property, NotForDefinition);
-          fields.add(cast<llvm::Constant>(offsetVar.getAddress()));
-          break;
-        }
-        case FieldAccess::ConstantIndirect: {
-          // An offset that depends on the instance's generic parameterization,
-          // but whose field offset is at a known vtable offset.
-          auto header =
-            KeyPathComponentHeader::forClassComponentWithUnresolvedFieldOffset();
-          fields.addInt32(header.getData());
-          auto fieldOffset =
-            getClassFieldOffsetOffset(*this, loweredBaseTy.getClassOrBoundGenericClass(),
-                                      property);
-          fields.addInt32(fieldOffset.getValue());
-          break;
-        }
-        }
-        break;
-      }
-      llvm_unreachable("not struct or class");
-    }
-    case KeyPathPatternComponent::Kind::GettableProperty:
-    case KeyPathPatternComponent::Kind::SettableProperty: {
-      // Encode the settability.
-      bool settable = kind == KeyPathPatternComponent::Kind::SettableProperty;
-      KeyPathComponentHeader::ComputedPropertyKind componentKind;
-      if (settable) {
-        componentKind = component.isComputedSettablePropertyMutating()
-          ? KeyPathComponentHeader::SettableMutating
-          : KeyPathComponentHeader::SettableNonmutating;
-      } else {
-        componentKind = KeyPathComponentHeader::GetOnly;
-      }
-      
-      // Lower the id reference.
-      auto id = component.getComputedPropertyId();
-      KeyPathComponentHeader::ComputedPropertyIDKind idKind;
-      llvm::Constant *idValue;
-      bool idResolved;
-      switch (id.getKind()) {
-      case KeyPathPatternComponent::ComputedPropertyId::Function:
-        idKind = KeyPathComponentHeader::Pointer;
-        idValue = getAddrOfSILFunction(id.getFunction(), NotForDefinition);
-        idResolved = true;
-        break;
-      case KeyPathPatternComponent::ComputedPropertyId::DeclRef: {
-        auto declRef = id.getDeclRef();
-      
-        // Foreign method refs identify using a selector
-        // reference, which is doubly-indirected and filled in with a unique
-        // pointer by dyld.
-        if (declRef.isForeign) {
-          assert(ObjCInterop && "foreign keypath component w/o objc interop?!");
-          idKind = KeyPathComponentHeader::Pointer;
-          idValue = getAddrOfObjCSelectorRef(declRef);
-          idResolved = false;
-        } else {
-          idKind = KeyPathComponentHeader::VTableOffset;
-          auto dc = declRef.getDecl()->getDeclContext();
-          if (isa<ClassDecl>(dc) && !cast<ClassDecl>(dc)->isForeign()) {
-            auto overridden = declRef.getOverriddenVTableEntry();
-            auto declaringClass =
-              cast<ClassDecl>(overridden.getDecl()->getDeclContext());
-            auto &metadataLayout = getClassMetadataLayout(declaringClass);
-            // FIXME: Resilience. We don't want vtable layout to be ABI, so this
-            // should be encoded as a reference to the method dispatch thunk
-            // instead.
-            auto offset = metadataLayout.getStaticMethodOffset(overridden);
-            idValue = llvm::ConstantInt::get(SizeTy, offset.getValue());
-            idResolved = true;
-          } else if (auto methodProto = dyn_cast<ProtocolDecl>(dc)) {
-            // FIXME: Resilience. We don't want witness table layout to be ABI,
-            // so this should be encoded as a reference to the method dispatch
-            // thunk instead.
-            auto &protoInfo = getProtocolInfo(methodProto);
-            auto index = protoInfo.getFunctionIndex(
-                                 cast<AbstractFunctionDecl>(declRef.getDecl()));
-            idValue = llvm::ConstantInt::get(SizeTy, -index.getValue());
-            idResolved = true;
-          } else {
-            llvm_unreachable("neither a class nor protocol dynamic method?");
-          }
-        }
-        break;
-      }
-      case KeyPathPatternComponent::ComputedPropertyId::Property:
-        // Use the index of the stored property within the aggregate to key
-        // the property.
-        auto property = id.getProperty();
-        idKind = KeyPathComponentHeader::StoredPropertyIndex;
-        if (baseTy->getStructOrBoundGenericStruct()) {
-          idResolved = true;
-          Optional<unsigned> structIdx =  getPhysicalStructFieldIndex(*this,
-                            SILType::getPrimitiveAddressType(baseTy), property);
-          assert(structIdx.hasValue() && "empty property");
-          idValue = llvm::ConstantInt::get(SizeTy, structIdx.getValue());
-        } else if (baseTy->getClassOrBoundGenericClass()) {
-          // TODO: This field index would require runtime resolution with Swift
-          // native class resilience. We never directly access ObjC-imported
-          // ivars so we can disregard ObjC ivar resilience for this computation
-          // and start counting at the Swift native root.
-          switch (getClassFieldAccess(*this, loweredBaseTy, property)) {
-          case FieldAccess::ConstantDirect:
-          case FieldAccess::ConstantIndirect:
-          case FieldAccess::NonConstantDirect:
-            idResolved = true;
-            idValue = llvm::ConstantInt::get(SizeTy,
-              getClassFieldIndex(*this,
-                           SILType::getPrimitiveAddressType(baseTy), property));
-            break;
-          }
-          
-        } else {
-          llvm_unreachable("neither struct nor class");
-        }
-        break;
-      }
-      
-      auto header = KeyPathComponentHeader::forComputedProperty(componentKind,
-                                    idKind, !isInstantiableInPlace, idResolved);
-      
-      fields.addInt32(header.getData());
-      fields.addAlignmentPadding(getPointerAlignment());
-      fields.add(idValue);
-      
-      if (isInstantiableInPlace) {
-        // No generic arguments or indexes, so we can invoke the
-        // getter/setter as is.
-        fields.add(getAddrOfSILFunction(component.getComputedPropertyGetter(),
-                                        NotForDefinition));
-        if (settable)
-          fields.add(getAddrOfSILFunction(component.getComputedPropertySetter(),
-                                          NotForDefinition));
-      } else {
-        // If there's generic context or subscript indexes, embed as
-        // arguments in the component. Thunk the SIL-level accessors to give the
-        // runtime implementation a polymorphically-callable interface.
-        
-        // Push the accessors, possibly thunked to marshal generic environment.
-        fields.add(getAccessorForComputedComponent(*this, component, Getter,
-                                                     genericEnv, requirements));
-        if (settable)
-          fields.add(getAccessorForComputedComponent(*this, component, Setter,
-                                                     genericEnv, requirements));
-                                                     
-        fields.add(getLayoutFunctionForComputedComponent(*this, component,
-                                                     genericEnv, requirements));
-                                                     
-        // Set up a "witness table" for the component that handles copying,
-        // destroying, equating, and hashing the captured contents of the
-        // component.
-        // If there are only generic parameters, we can use a prefab witness
-        // table from the runtime.
-        // For subscripts we generate functions that dispatch out to
-        // the copy/destroy/equals/hash functionality of the subscript indexes.
-        fields.add(getWitnessTableForComputedComponent(*this, component,
-                                                     genericEnv, requirements));
-        
-        // Add an initializer function that copies generic arguments out of the
-        // pattern argument buffer into the instantiated object.
-        fields.add(getInitializerForComputedComponent(*this, component, operands,
-                                                     genericEnv, requirements));
-      }
-      break;
-    }
-    case KeyPathPatternComponent::Kind::OptionalChain:
-      fields.addInt32(KeyPathComponentHeader::forOptionalChain().getData());
-      break;
-    case KeyPathPatternComponent::Kind::OptionalForce:
-      fields.addInt32(KeyPathComponentHeader::forOptionalForce().getData());
-      break;
-    case KeyPathPatternComponent::Kind::OptionalWrap:
-      fields.addInt32(KeyPathComponentHeader::forOptionalWrap().getData());
-      break;
-    }
+    
+    emitKeyPathComponent(*this, fields, component, isInstantiableInPlace,
+                         genericEnv, requirements,
+                         baseTy, operands,
+                         !component.getSubscriptIndices().empty());
     
     // For all but the last component, we pack in the type of the component.
     if (i + 1 != pattern->getComponents().size()) {
       fields.addAlignmentPadding(getPointerAlignment());
-      fields.add(emitMetadataGenerator(component.getComponentType()));
+      fields.add(
+        emitMetadataGeneratorForKeyPath(*this, component.getComponentType(),
+                                        genericEnv, requirements));
     }
     baseTy = component.getComponentType();
   }
@@ -1150,4 +1213,55 @@ IRGenModule::getAddrOfKeyPathPattern(KeyPathPattern *pattern,
                                           llvm::GlobalVariable::PrivateLinkage);
   KeyPathPatterns.insert({pattern, patternVar});
   return patternVar;
+}
+
+void IRGenModule::emitSILProperty(SILProperty *prop) {
+  ConstantInitBuilder builder(*this);
+  ConstantStructBuilder fields = builder.beginStruct();
+  fields.setPacked(true);
+  
+  bool hasSubscriptIndices = false;
+  bool isInstantiableInPlace = true;
+  if (prop->getDecl()->getInnermostDeclContext()->isGenericContext()) {
+    isInstantiableInPlace = false;
+  }
+  
+  if (auto subscript = dyn_cast<SubscriptDecl>(prop->getDecl())) {
+    hasSubscriptIndices = subscript->getIndices()->size() != 0;
+    isInstantiableInPlace &= !hasSubscriptIndices;
+  }
+  
+  auto genericEnv = prop->getDecl()->getInnermostDeclContext()
+                        ->getGenericEnvironmentOfContext();
+  SmallVector<GenericRequirement, 4> requirements;
+  CanGenericSignature genericSig;
+  if (genericEnv) {
+    genericSig = prop->getDecl()->getInnermostDeclContext()
+                                ->getGenericSignatureOfContext()
+                                ->getCanonicalSignature();
+    enumerateGenericSignatureRequirements(genericSig,
+      [&](GenericRequirement reqt) { requirements.push_back(reqt); });
+  }
+  
+  emitKeyPathComponent(*this, fields, prop->getComponent(),
+                       isInstantiableInPlace, genericEnv, requirements,
+                       prop->getDecl()->getInnermostDeclContext()
+                                      ->getInnermostTypeContext()
+                                      ->getSelfInterfaceType()
+                                      ->getCanonicalType(genericSig),
+                       {},
+                       hasSubscriptIndices);
+  
+  auto size = fields.getNextOffsetFromGlobal();
+  
+  auto var = cast<llvm::GlobalVariable>(
+    getAddrOfPropertyDescriptor(prop->getDecl(),
+                                fields.finishAndCreateFuture()));
+  var->setConstant(true);
+  // A simple stored component descriptor can fit in four bytes. Anything else
+  // needs pointer alignment.
+  if (size <= Size(4))
+    var->setAlignment(4);
+  else
+    var->setAlignment(getPointerAlignment().getValue());
 }

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1070,6 +1070,10 @@ void TypeConverter::pushGenericContext(CanGenericSignature signature) {
   // Push the generic context down to the SIL TypeConverter, so we can share
   // archetypes with SIL.
   IGM.getSILTypes().pushGenericContext(signature);
+
+  // Clear the dependent type info cache since we have a new active signature
+  // now.
+  Types.DependentCache.clear();
 }
 
 void TypeConverter::popGenericContext(CanGenericSignature signature) {

--- a/lib/IRGen/GenType.h
+++ b/lib/IRGen/GenType.h
@@ -188,6 +188,7 @@ private:
                                                            NominalTypeDecl *D);
     friend void TypeConverter::addForwardDecl(TypeBase*, llvm::Type*);
     friend ArchetypeType *TypeConverter::getExemplarArchetype(ArchetypeType *t);
+    friend void TypeConverter::pushGenericContext(CanGenericSignature signature);
     friend void TypeConverter::popGenericContext(CanGenericSignature signature);
     
 #ifndef NDEBUG

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -92,6 +92,7 @@ namespace swift {
   struct SILDeclRef;
   class SILGlobalVariable;
   class SILModule;
+  class SILProperty;
   class SILType;
   class SILWitnessTable;
   class SourceLoc;
@@ -1095,6 +1096,7 @@ public:
   void emitCoverageMapping();
   void emitSILFunction(SILFunction *f);
   void emitSILWitnessTable(SILWitnessTable *wt);
+  void emitSILProperty(SILProperty *prop);
   void emitSILStaticInitializers();
   llvm::Constant *emitFixedTypeLayout(CanType t, const FixedTypeInfo &ti);
   void emitProtocolConformance(const NormalProtocolConformance *conformance);

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -264,6 +264,7 @@ ParserStatus Parser::parseBraceItems(SmallVectorImpl<ASTNode> &Entries,
          Tok.isNot(tok::kw_sil_global) &&
          Tok.isNot(tok::kw_sil_witness_table) &&
          Tok.isNot(tok::kw_sil_default_witness_table) &&
+         Tok.isNot(tok::kw_sil_property) &&
          (isConditionalBlock ||
           !isTerminatorForBraceItemListKind(Kind, Entries))) {
 

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -5385,11 +5385,18 @@ bool SILParserTUState::parseSILProperty(Parser &P) {
   generics = P.maybeParseGenericParams().getPtrOrNull();
   patternEnv = handleSILGenericParams(P.Context, generics, &P.SF);
   
-  if (patternEnv->getGenericSignature()->getCanonicalSignature()
-        != VD->getInnermostDeclContext()->getGenericSignatureOfContext()
-      ->getCanonicalSignature()) {
-    P.diagnose(loc, diag::sil_property_generic_signature_mismatch);
-    return true;
+  if (patternEnv) {
+    if (patternEnv->getGenericSignature()->getCanonicalSignature()
+           != VD->getInnermostDeclContext()->getGenericSignatureOfContext()
+                ->getCanonicalSignature()) {
+      P.diagnose(loc, diag::sil_property_generic_signature_mismatch);
+      return true;
+    }
+  } else {
+    if (VD->getInnermostDeclContext()->getGenericSignatureOfContext()) {
+      P.diagnose(loc, diag::sil_property_generic_signature_mismatch);
+      return true;
+    }
   }
 
   Identifier ComponentKind;

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1205,6 +1205,9 @@ static bool doesPropertyNeedDescriptor(AbstractStorageDecl *decl) {
 }
 
 void SILGenModule::tryEmitPropertyDescriptor(AbstractStorageDecl *decl) {
+  if (!M.getASTContext().LangOpts.EnableKeyPathResilience)
+    return;
+  
   // TODO: Key path code emission doesn't handle opaque values properly yet.
   if (!SILModuleConventions(M).useLoweredAddresses())
     return;

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -191,57 +191,56 @@ protected:
 
   /// Marks the declarations referenced by a key path pattern as alive if they
   /// aren't yet.
-  void ensureKeyPathComponentsAreAlive(KeyPathPattern *KP) {
-    for (auto &component : KP->getComponents()) {
-      switch (component.getKind()) {
-      case KeyPathPatternComponent::Kind::SettableProperty:
-        ensureAlive(component.getComputedPropertySetter());
-        LLVM_FALLTHROUGH;
-      case KeyPathPatternComponent::Kind::GettableProperty: {
-        ensureAlive(component.getComputedPropertyGetter());
-        auto id = component.getComputedPropertyId();
-        switch (id.getKind()) {
-        case KeyPathPatternComponent::ComputedPropertyId::DeclRef: {
-          auto declRef = id.getDeclRef();
-          if (declRef.isForeign) {
-            // Nothing to do here: foreign functions aren't ours to be deleting.
-            // (And even if they were, they're ObjC-dispatched and thus anchored
-            // already: see isAnchorFunction)
+  void
+  ensureKeyPathComponentIsAlive(const KeyPathPatternComponent &component) {
+    switch (component.getKind()) {
+    case KeyPathPatternComponent::Kind::SettableProperty:
+      ensureAlive(component.getComputedPropertySetter());
+      LLVM_FALLTHROUGH;
+    case KeyPathPatternComponent::Kind::GettableProperty: {
+      ensureAlive(component.getComputedPropertyGetter());
+      auto id = component.getComputedPropertyId();
+      switch (id.getKind()) {
+      case KeyPathPatternComponent::ComputedPropertyId::DeclRef: {
+        auto declRef = id.getDeclRef();
+        if (declRef.isForeign) {
+          // Nothing to do here: foreign functions aren't ours to be deleting.
+          // (And even if they were, they're ObjC-dispatched and thus anchored
+          // already: see isAnchorFunction)
+        } else {
+          auto decl = cast<AbstractFunctionDecl>(declRef.getDecl());
+          if (auto clas = dyn_cast<ClassDecl>(decl->getDeclContext())) {
+            ensureAliveClassMethod(getMethodInfo(decl, /*witness*/ false),
+                                   dyn_cast<FuncDecl>(decl),
+                                   clas);
+          } else if (isa<ProtocolDecl>(decl->getDeclContext())) {
+            ensureAliveProtocolMethod(getMethodInfo(decl, /*witness*/ true));
           } else {
-            auto decl = cast<AbstractFunctionDecl>(declRef.getDecl());
-            if (auto clas = dyn_cast<ClassDecl>(decl->getDeclContext())) {
-              ensureAliveClassMethod(getMethodInfo(decl, /*witness*/ false),
-                                     dyn_cast<FuncDecl>(decl),
-                                     clas);
-            } else if (isa<ProtocolDecl>(decl->getDeclContext())) {
-              ensureAliveProtocolMethod(getMethodInfo(decl, /*witness*/ true));
-            } else {
-              llvm_unreachable("key path keyed by a non-class, non-protocol method");
-            }
+            llvm_unreachable("key path keyed by a non-class, non-protocol method");
           }
-          break;
         }
-        case KeyPathPatternComponent::ComputedPropertyId::Function:
-          ensureAlive(id.getFunction());
-          break;
-        case KeyPathPatternComponent::ComputedPropertyId::Property:
-          break;
-        }
-
-        if (auto equals = component.getSubscriptIndexEquals())
-          ensureAlive(equals);
-        if (auto hash = component.getSubscriptIndexHash())
-          ensureAlive(hash);
-
-        continue;
+        break;
       }
-      case KeyPathPatternComponent::Kind::StoredProperty:
-      case KeyPathPatternComponent::Kind::OptionalChain:
-      case KeyPathPatternComponent::Kind::OptionalForce:
-      case KeyPathPatternComponent::Kind::OptionalWrap:
-      case KeyPathPatternComponent::Kind::External:
-        continue;
+      case KeyPathPatternComponent::ComputedPropertyId::Function:
+        ensureAlive(id.getFunction());
+        break;
+      case KeyPathPatternComponent::ComputedPropertyId::Property:
+        break;
       }
+
+      if (auto equals = component.getSubscriptIndexEquals())
+        ensureAlive(equals);
+      if (auto hash = component.getSubscriptIndexHash())
+        ensureAlive(hash);
+
+      break;
+    }
+    case KeyPathPatternComponent::Kind::StoredProperty:
+    case KeyPathPatternComponent::Kind::OptionalChain:
+    case KeyPathPatternComponent::Kind::OptionalForce:
+    case KeyPathPatternComponent::Kind::OptionalWrap:
+    case KeyPathPatternComponent::Kind::External:
+      break;
     }
   }
 
@@ -367,7 +366,8 @@ protected:
         } else if (auto *FRI = dyn_cast<FunctionRefInst>(&I)) {
           ensureAlive(FRI->getReferencedFunction());
         } else if (auto *KPI = dyn_cast<KeyPathInst>(&I)) {
-          ensureKeyPathComponentsAreAlive(KPI->getPattern());
+          for (auto &component : KPI->getPattern()->getComponents())
+            ensureKeyPathComponentIsAlive(component);
         }
       }
     }
@@ -510,8 +510,6 @@ class DeadFunctionElimination : FunctionLivenessComputation {
         mi->addWitnessFunction(F, nullptr);
       }
     }
-
-
   }
 
   /// DeadFunctionElimination pass takes functions
@@ -600,6 +598,11 @@ class DeadFunctionElimination : FunctionLivenessComputation {
         }
       }
     }
+    // Check property descriptor implementations.
+    for (SILProperty &P : Module->getPropertyList()) {
+      ensureKeyPathComponentIsAlive(P.getComponent());
+    }
+
   }
 
   /// Removes all dead methods from vtables and witness tables.

--- a/test/IRGen/property_descriptor.sil
+++ b/test/IRGen/property_descriptor.sil
@@ -1,0 +1,137 @@
+// RUN: %empty-directory(%t)
+// RUN: %utils/chex.py < %s > %t/property_descriptor.sil
+// RUN: %target-swift-frontend -emit-ir %t/property_descriptor.sil | %FileCheck --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK %t/property_descriptor.sil
+
+sil_stage canonical
+
+import Swift
+
+public struct ExternalGeneric<T: Comparable> {
+  public let ro: T
+  public var rw: T
+
+  public var computedRO: T { get }
+  public var computedRW: T { get set }
+
+  public subscript<U: Hashable>(_: U) -> T { get set }
+
+  init()
+}
+
+public struct External {
+  public let ro: Int
+  public var rw: Int
+
+  public var computedRO: Int { get }
+  public var computedRW: Int { get set }
+
+  public subscript(_: String) -> Int { get set }
+
+  init()
+}
+
+public struct ExternalReabstractions<T> {
+  public var ro: T
+  public var reabstracted: () -> ()
+}
+
+// -- 0xff_fffe - struct property, offset resolved from field offset vector in metadata
+// CHECK-64: @"$S19property_descriptor15ExternalGenericV2roxvpMV" ={{( protected)?}}{{( protected)?}} constant
+// CHECK-64-SAME: <{ <i32 0x00ff_fffe>, i32 32 }>, align 8
+// CHECK-32: @"$S19property_descriptor15ExternalGenericV2roxvpMV" ={{( protected)?}}{{( protected)?}} constant
+// CHECK-32-SAME: <{ <i32 0x00ff_fffe>, i32 16 }>, align 8
+sil_property #ExternalGeneric.ro <T: Comparable> (
+  stored_property #ExternalGeneric.ro : $T)
+// CHECK-64: @"$S19property_descriptor15ExternalGenericV2rwxvpMV" ={{( protected)?}}{{( protected)?}} constant
+// CHECK-64-SAME: <{ <i32 0x00ff_fffe>, i32 40 }>, align 8
+// CHECK-32: @"$S19property_descriptor15ExternalGenericV2rwxvpMV" ={{( protected)?}} constant
+// CHECK-32-SAME: <{ <i32 0x00ff_fffe>, i32 20 }>, align 8
+sil_property #ExternalGeneric.rw <T: Comparable> (
+  stored_property #ExternalGeneric.rw : $T)
+
+// CHECK: @"$S19property_descriptor15ExternalGenericV10computedROxvpMV" ={{( protected)?}} constant
+// -- 0x0108_0000 - computed, readonly, has arguments
+// CHECK-SAME:  <{ <i32 0x0108_0000>,
+// CHECK-SAME:     @id_computed, 
+// CHECK-SAME:     [[GET_COMPUTEDRO:@keypath_get[.0-9]*]],
+// CHECK-SAME:     [[GET_ARG_LAYOUT_COMPUTEDRO:@keypath_get_arg_layout[.0-9]*]],
+// CHECK-SAME:     @swift_keyPathGenericWitnessTable,
+// CHECK-SAME:     [[ARG_INIT_COMPUTEDRO:@keypath_arg_init[.0-9]*]] }>
+sil_property #ExternalGeneric.computedRO <T: Comparable> (
+  gettable_property $T,
+    id @id_computed : $@convention(thin) () -> (),
+    getter @get_computed_generic : $@convention(thin) <T: Comparable> (@in_guaranteed ExternalGeneric<T>) -> @out T)
+
+// CHECK: @"$S19property_descriptor15ExternalGenericV10computedRWxvpMV" ={{( protected)?}} constant
+// -- 0x01c8_0000 - computed, settable, mutating, has arguments
+// CHECK-SAME:  <{ <i32 0x01c8_0000>, 
+// CHECK-SAME:     @id_computed,
+// CHECK-SAME:     [[GET_COMPUTEDRW:@keypath_get[.0-9]*]],
+// CHECK-SAME:     [[SET_COMPUTEDRW:@keypath_set[.0-9]*]],
+// CHECK-SAME:     [[GET_ARG_LAYOUT_COMPUTEDRW:@keypath_get_arg_layout[.0-9]*]],
+// CHECK-SAME:     @swift_keyPathGenericWitnessTable,
+// CHECK-SAME:     [[ARG_INIT_COMPUTEDRW:@keypath_arg_init[.0-9]*]] }>
+sil_property #ExternalGeneric.computedRW <T: Comparable> (
+  settable_property $T,
+    id @id_computed : $@convention(thin) () -> (),
+    getter @get_computed_generic : $@convention(thin) <T: Comparable> (@in_guaranteed ExternalGeneric<T>) -> @out T,
+    setter @set_computed_generic : $@convention(thin) <T: Comparable> (@in_guaranteed T, @inout ExternalGeneric<T>) -> ())
+
+// CHECK: @"$S19property_descriptor15ExternalGenericVyxqd__cs8HashableRd__luipMV" ={{( protected)?}} constant
+// -- 0x01c8_0000 - computed, settable, mutating, has arguments
+// CHECK-SAME:  <{ <i32 0x01c8_0000>, 
+// CHECK-SAME:     @id_computed,
+// CHECK-SAME:     [[GET_SUBSCRIPT:@keypath_get[.0-9]*]],
+// CHECK-SAME:     [[SET_SUBSCRIPT:@keypath_set[.0-9]*]],
+// CHECK-SAME:     [[GET_ARG_LAYOUT_SUBSCRIPT:@keypath_get_arg_layout[.0-9]*]],
+// CHECK-SAME:     @swift_keyPathGenericWitnessTable,
+// CHECK-SAME:     [[ARG_INIT_SUBSCRIPT:@keypath_arg_init[.0-9]*]] }>
+sil_property #ExternalGeneric.subscript <T: Comparable><U: Hashable> (
+  settable_property $T,
+    id @id_computed : $@convention(thin) () -> (),
+    getter @get_computed_generic_subscript : $@convention(thin) <T: Comparable><U: Hashable> (@in_guaranteed ExternalGeneric<T>, UnsafeRawPointer) -> @out T,
+    setter @set_computed_generic_subscript : $@convention(thin) <T: Comparable><U: Hashable> (@in_guaranteed T, @inout ExternalGeneric<T>, UnsafeRawPointer) -> ())
+
+// CHECK: @"$S19property_descriptor8ExternalV2roSivpMV" ={{( protected)?}} constant <{ i32 }> zeroinitializer, align 4
+// CHECK: @"$S19property_descriptor8ExternalV2rwSivpMV" ={{( protected)?}} constant <{ i32 }> <{ i32 8 }>, align 4
+sil_property #External.ro (stored_property #External.ro : $Int)
+sil_property #External.rw (stored_property #External.rw : $Int)
+sil_property #External.computedRO (
+  gettable_property $Int,
+    id @id_computed : $@convention(thin) () -> (),
+    getter @get_computed : $@convention(thin) (@in_guaranteed External) -> @out Int)
+sil_property #External.computedRW (
+  settable_property $Int,
+    id @id_computed : $@convention(thin) () -> (),
+    getter @get_computed : $@convention(thin) (@in_guaranteed External) -> @out Int,
+    setter @set_computed : $@convention(thin) (@in_guaranteed Int, @inout External) -> ())
+sil_property #External.subscript (
+  settable_property $Int,
+    id @id_computed : $@convention(thin) () -> (),
+    getter @get_computed_subscript : $@convention(thin) (@in_guaranteed External, UnsafeRawPointer) -> @out Int,
+    setter @set_computed_subscript : $@convention(thin) (@in_guaranteed Int, @inout External, UnsafeRawPointer) -> ())
+
+sil_property #ExternalReabstractions.ro <T> (
+  stored_property #ExternalReabstractions.ro : $T)
+
+sil_property #ExternalReabstractions.reabstracted <T> (
+  settable_property $() -> (),
+    id ##ExternalReabstractions.reabstracted,
+    getter @get_reabstracted : $@convention(thin) <T> (@in_guaranteed ExternalReabstractions<T>) -> @out @callee_guaranteed (@in_guaranteed ()) -> @out (),
+    setter @set_reabstracted : $@convention(thin) <T> (@in_guaranteed @callee_guaranteed (@in_guaranteed ()) -> @out (), @inout ExternalReabstractions<T>) -> ())
+
+sil @id_computed : $@convention(thin) () -> ()
+sil @get_computed : $@convention(thin) (@in_guaranteed External) -> @out Int
+sil @set_computed : $@convention(thin) (@in_guaranteed Int, @inout External) -> ()
+
+sil @get_computed_subscript : $@convention(thin) (@in_guaranteed External, UnsafeRawPointer) -> @out Int
+sil @set_computed_subscript : $@convention(thin) (@in_guaranteed Int, @inout External, UnsafeRawPointer) -> ()
+
+sil @get_computed_generic : $@convention(thin) <T: Comparable> (@in_guaranteed ExternalGeneric<T>) -> @out T
+sil @set_computed_generic : $@convention(thin) <T: Comparable> (@in_guaranteed T, @inout ExternalGeneric<T>) -> ()
+
+sil @get_computed_generic_subscript : $@convention(thin) <T: Comparable><U: Hashable> (@in_guaranteed ExternalGeneric<T>, UnsafeRawPointer) -> @out T
+sil @set_computed_generic_subscript : $@convention(thin) <T: Comparable><U: Hashable> (@in_guaranteed T, @inout ExternalGeneric<T>, UnsafeRawPointer) -> ()
+
+sil @get_reabstracted : $@convention(thin) <T> (@in_guaranteed ExternalReabstractions<T>) -> @out @callee_guaranteed (@in_guaranteed ()) -> @out ()
+sil @set_reabstracted : $@convention(thin) <T> (@in_guaranteed @callee_guaranteed (@in_guaranteed ()) -> @out (), @inout ExternalReabstractions<T>) -> ()

--- a/test/SILGen/keypath_property_descriptors.swift
+++ b/test/SILGen/keypath_property_descriptors.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-key-path-resilience %s | %FileCheck %s
 
 // TODO: globals should get descriptors
 public var a: Int = 0


### PR DESCRIPTION
Factor out the code generation for key path components so we can reuse it to generate the component representing a key path.