### PR TITLE
[GSB] Infer requirements from uses of generic typealiases.

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4171,7 +4171,7 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
 
     auto inheritedReqResult =
       addInheritedRequirements(proto, selfType.getUnresolvedType(), source,
-                               /*inferForModule=*/nullptr);
+                               proto->getModuleContext());
     if (isErrorResult(inheritedReqResult))
       return inheritedReqResult;
   }
@@ -4187,7 +4187,7 @@ ConstraintResult GenericSignatureBuilder::expandConformanceRequirement(
       auto innerSource = FloatingRequirementSource::viaProtocolRequirement(
           source, proto, &req, /*inferred=*/false);
       addRequirement(&req, innerSource, &protocolSubMap,
-                     /*inferForModule=*/nullptr);
+                     proto->getModuleContext());
     }
   }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3154,6 +3154,8 @@ Type TypeResolver::buildProtocolType(
 Type TypeChecker::substMemberTypeWithBase(ModuleDecl *module,
                                           TypeDecl *member,
                                           Type baseTy) {
+  Type sugaredBaseTy = baseTy;
+
   // For type members of a base class, make sure we use the right
   // derived class as the parent type.
   if (auto *ownerClass = member->getDeclContext()
@@ -3207,7 +3209,8 @@ Type TypeChecker::substMemberTypeWithBase(ModuleDecl *module,
   // If we're referring to a typealias within a generic context, build
   // a sugared alias type.
   if (aliasDecl && aliasDecl->getGenericSignature()) {
-    resultType = BoundNameAliasType::get(aliasDecl, baseTy, subs, resultType);
+    resultType = BoundNameAliasType::get(aliasDecl, sugaredBaseTy, subs,
+                                         resultType);
   }
 
   return resultType;

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -460,3 +460,30 @@ func conditionalNested1<U>(_: [ConditionalNested<U>.Inner?]) {}
 // CHECK: Generic signature: <U where U : P35, U : P36>
 // CHECK: Canonical generic signature: <τ_0_0 where τ_0_0 : P35, τ_0_0 : P36>
 func conditionalNested2<U>(_: [ConditionalNested<U>.Inner.Inner2?]) {}
+
+//
+// Generate typalias adds requirements that can be inferred
+//
+typealias X1WithP2<T: P2> = X1<T>
+
+// Inferred requirement T: P2 from the typealias
+func testX1WithP2<T>(_: X1WithP2<T>) {
+  _ = X5<T>() // requires P2
+}
+
+// Overload based on the inferred requirement.
+func testX1WithP2Overloading<T>(_: X1<T>) {
+  _ = X5<T>() // expected-error{{type 'T' does not conform to protocol 'P2'}}
+}
+
+func testX1WithP2Overloading<T>(_: X1WithP2<T>) {
+  _ = X5<T>() // requires P2
+}
+
+// Extend using the inferred requirement.
+// FIXME: Currently broken.
+extension X1WithP2 {
+  func f() {
+    _ = X5<T>() // FIXME: expected-error{{type 'T' does not conform to protocol 'P2'}}
+  }
+}

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -typecheck %s -verify
-// RUN: %target-typecheck-verify-swift -typecheck -debug-generic-signatures %s > %t.dump 2>&1 
+// RUN: %target-typecheck-verify-swift -typecheck -verify
+// RUN: %target-typecheck-verify-swift -typecheck -debug-generic-signatures > %t.dump 2>&1
 // RUN: %FileCheck %s < %t.dump
 
 protocol P1 { 
@@ -485,5 +485,16 @@ func testX1WithP2Overloading<T>(_: X1WithP2<T>) {
 extension X1WithP2 {
   func f() {
     _ = X5<T>() // FIXME: expected-error{{type 'T' does not conform to protocol 'P2'}}
+  }
+}
+
+// Inference from protocol inheritance clauses.
+typealias ExistentialP4WithP2Assoc<T: P4> = P4 where T.P4Assoc : P2
+
+protocol P37 : ExistentialP4WithP2Assoc<Self> { }
+
+extension P37 {
+  func f() {
+    _ = X5<P4Assoc>() // requires P2
   }
 }

--- a/test/decl/typealias/dependent_types.swift
+++ b/test/decl/typealias/dependent_types.swift
@@ -58,3 +58,15 @@ let _: GenericStruct.MetaAlias = metaFoo()
 // ... but if the typealias has a fully concrete underlying type,
 // we are OK.
 let _: GenericStruct.Concrete = foo()
+
+class SuperG<T, U> {
+  typealias Composed = (T, U)
+}
+
+class SubG<T> : SuperG<T, T> { }
+
+typealias SubGX<T> = SubG<T?>
+
+func checkSugar(gs: SubGX<Int>.Composed) {
+  let i4: Int = gs // expected-error{{cannot convert value of type 'SubGX<Int>.Composed' (aka '(Optional<Int>, Optional<Int>)') to specified type 'Int'}}
+}


### PR DESCRIPTION
Generic typealiases can add requirements that aren't used by their
underlying type. For example, `CountableRange` in the standard library:

```
  public typealias CountableRange<Bound: Comparable> = Range<Bound>
```

Perform requirement inference based on uses of generic typealiases,
such that a generic function like this:

```
  func f<T>(_: CountableRange<T>) { }
```

will infer `T: Bound` from the use of `CountableRange`.

Note that this does not yet work for extensions, but it does fix rdar://problem/29231937