### PR TITLE
[string] Add less bad SPI for Foundation

### DIFF
--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -1413,3 +1413,36 @@ extension _StringGuts {
     return UnsafeMutablePointer(mutating: _unmanagedUTF16View.start)
   }
 }
+
+extension _StringGuts {
+  @available(*, deprecated)
+  public // SPI(Foundation)
+  var _isContiguousASCII: Bool {
+    return _object.isContiguousASCII
+  }
+
+  @available(*, deprecated)
+  public // SPI(Foundation)
+  var _isContiguousUTF16: Bool {
+    return _object.isContiguousUTF16
+  }
+
+  @available(*, deprecated)
+  public // SPI(Foundation)
+  func _withUnsafeUTF8CodeUnitsIfAvailable<Result>(
+    _ f: (UnsafeBufferPointer<UInt8>) throws -> Result
+  ) rethrows -> Result? {
+    guard _object.isContiguousASCII else { return nil }
+    return try f(_unmanagedASCIIView.buffer)
+  }
+
+  @available(*, deprecated)
+  public // SPI(Foundation)
+  func _withUnsafeUTF16CodeUnitsIfAvailable<Result>(
+    _ f: (UnsafeBufferPointer<UInt16>) throws -> Result
+  ) rethrows -> Result? {
+    guard _object.isContiguousUTF16 else { return nil }
+    return try f(_unmanagedUTF16View.buffer)
+  }
+}
+


### PR DESCRIPTION
<!-- What's in this pull request? -->
Add a couple scoped SPI for Foundation to use, as the old `_StringCore` based ones are going away soon.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
