### PR TITLE
NFC: Use enum class for ActionClass.

### DIFF
--- a/include/swift/Driver/Action.h
+++ b/include/swift/Driver/Action.h
@@ -38,7 +38,7 @@ public:
   typedef ArrayRef<const Action *>::iterator iterator;
   typedef ArrayRef<const Action *>::const_iterator const_iterator;
 
-  enum ActionClass {
+  enum class Kind : unsigned {
     Input = 0,
     CompileJob,
     InterpretJob,
@@ -52,14 +52,14 @@ public:
     VerifyDebugInfoJob,
     GeneratePCHJob,
 
-    JobFirst=CompileJob,
-    JobLast=GeneratePCHJob
+    JobFirst = CompileJob,
+    JobLast = GeneratePCHJob
   };
 
-  static const char *getClassName(ActionClass AC);
+  static const char *getClassName(Kind AC);
 
 private:
-  unsigned Kind : 4;
+  unsigned RawKind : 4;
   unsigned Type : 28;
 
   friend class Compilation;
@@ -67,8 +67,9 @@ private:
   void *operator new(size_t size) { return ::operator new(size); };
 
 protected:
-  Action(ActionClass Kind, file_types::ID Type) : Kind(Kind), Type(Type) {
-    assert(Kind == getKind() && "not enough bits");
+  Action(Kind K, file_types::ID Type)
+      : RawKind(unsigned(K)), Type(Type) {
+    assert(K == getKind() && "not enough bits");
     assert(Type == getType() && "not enough bits");
   }
 
@@ -77,7 +78,7 @@ public:
 
   const char *getClassName() const { return Action::getClassName(getKind()); }
 
-  ActionClass getKind() const { return static_cast<ActionClass>(Kind); }
+  Kind getKind() const { return static_cast<Kind>(RawKind); }
   file_types::ID getType() const { return static_cast<file_types::ID>(Type); }
 };
 
@@ -87,11 +88,11 @@ class InputAction : public Action {
 
 public:
   InputAction(const llvm::opt::Arg &Input, file_types::ID Type)
-      : Action(Action::Input, Type), Input(Input) {}
+      : Action(Action::Kind::Input, Type), Input(Input) {}
   const llvm::opt::Arg &getInputArg() const { return Input; }
 
   static bool classof(const Action *A) {
-    return A->getKind() == Action::Input;
+    return A->getKind() == Action::Kind::Input;
   }
 };
 
@@ -99,7 +100,7 @@ class JobAction : public Action {
   TinyPtrVector<const Action *> Inputs;
   virtual void anchor();
 protected:
-  JobAction(ActionClass Kind, ArrayRef<const Action *> Inputs,
+  JobAction(Kind Kind, ArrayRef<const Action *> Inputs,
             file_types::ID Type)
       : Action(Kind, Type), Inputs(Inputs) {}
 
@@ -120,8 +121,8 @@ public:
   virtual size_t getInputIndex() const { return 0; }
 
   static bool classof(const Action *A) {
-    return (A->getKind() >= ActionClass::JobFirst &&
-            A->getKind() <= ActionClass::JobLast);
+    return (A->getKind() >= Kind::JobFirst &&
+            A->getKind() <= Kind::JobLast);
   }
 };
 
@@ -152,17 +153,19 @@ private:
 
 public:
   CompileJobAction(file_types::ID OutputType)
-      : JobAction(Action::CompileJob, None, OutputType), inputInfo() {}
+      : JobAction(Action::Kind::CompileJob, None, OutputType),
+        inputInfo() {}
 
   CompileJobAction(Action *Input, file_types::ID OutputType, InputInfo info)
-      : JobAction(Action::CompileJob, Input, OutputType), inputInfo(info) {}
+      : JobAction(Action::Kind::CompileJob, Input, OutputType),
+        inputInfo(info) {}
 
   InputInfo getInputInfo() const {
     return inputInfo;
   }
 
   static bool classof(const Action *A) {
-    return A->getKind() == Action::CompileJob;
+    return A->getKind() == Action::Kind::CompileJob;
   }
 };
 
@@ -172,10 +175,11 @@ private:
 
 public:
   explicit InterpretJobAction()
-      : JobAction(Action::InterpretJob, llvm::None, file_types::TY_Nothing) {}
+      : JobAction(Action::Kind::InterpretJob, llvm::None,
+                  file_types::TY_Nothing) {}
 
   static bool classof(const Action *A) {
-    return A->getKind() == Action::InterpretJob;
+    return A->getKind() == Action::Kind::InterpretJob;
   }
 };
 
@@ -190,10 +194,10 @@ private:
 public:
   BackendJobAction(const Action *Input, file_types::ID OutputType,
                    size_t InputIndex)
-      : JobAction(Action::BackendJob, Input, OutputType),
+      : JobAction(Action::Kind::BackendJob, Input, OutputType),
         InputIndex(InputIndex) {}
   static bool classof(const Action *A) {
-    return A->getKind() == Action::BackendJob;
+    return A->getKind() == Action::Kind::BackendJob;
   }
   
   virtual size_t getInputIndex() const { return InputIndex; }
@@ -211,13 +215,14 @@ private:
   Mode RequestedMode;
 public:
   REPLJobAction(Mode mode)
-      : JobAction(Action::REPLJob, llvm::None, file_types::TY_Nothing),
+      : JobAction(Action::Kind::REPLJob, llvm::None,
+                  file_types::TY_Nothing),
         RequestedMode(mode) {}
 
   Mode getRequestedMode() const { return RequestedMode; }
 
   static bool classof(const Action *A) {
-    return A->getKind() == Action::REPLJob;
+    return A->getKind() == Action::Kind::REPLJob;
   }
 };
 
@@ -225,11 +230,11 @@ class MergeModuleJobAction : public JobAction {
   virtual void anchor();
 public:
   MergeModuleJobAction(ArrayRef<const Action *> Inputs)
-      : JobAction(Action::MergeModuleJob, Inputs,
+      : JobAction(Action::Kind::MergeModuleJob, Inputs,
                   file_types::TY_SwiftModuleFile) {}
 
   static bool classof(const Action *A) {
-    return A->getKind() == Action::MergeModuleJob;
+    return A->getKind() == Action::Kind::MergeModuleJob;
   }
 };
 
@@ -237,10 +242,11 @@ class ModuleWrapJobAction : public JobAction {
   virtual void anchor();
 public:
   ModuleWrapJobAction(ArrayRef<const Action *> Inputs)
-      : JobAction(Action::ModuleWrapJob, Inputs, file_types::TY_Object) {}
+      : JobAction(Action::Kind::ModuleWrapJob, Inputs,
+                  file_types::TY_Object) {}
 
   static bool classof(const Action *A) {
-    return A->getKind() == Action::ModuleWrapJob;
+    return A->getKind() == Action::Kind::ModuleWrapJob;
   }
 };
 
@@ -248,11 +254,11 @@ class AutolinkExtractJobAction : public JobAction {
   virtual void anchor();
 public:
   AutolinkExtractJobAction(ArrayRef<const Action *> Inputs)
-      : JobAction(Action::AutolinkExtractJob, Inputs,
+      : JobAction(Action::Kind::AutolinkExtractJob, Inputs,
                   file_types::TY_AutolinkFile) {}
 
   static bool classof(const Action *A) {
-    return A->getKind() == Action::AutolinkExtractJob;
+    return A->getKind() == Action::Kind::AutolinkExtractJob;
   }
 };
 
@@ -260,10 +266,11 @@ class GenerateDSYMJobAction : public JobAction {
   virtual void anchor();
 public:
   explicit GenerateDSYMJobAction(const Action *Input)
-      : JobAction(Action::GenerateDSYMJob, Input, file_types::TY_dSYM) {}
+      : JobAction(Action::Kind::GenerateDSYMJob, Input,
+                  file_types::TY_dSYM) {}
 
   static bool classof(const Action *A) {
-    return A->getKind() == Action::GenerateDSYMJob;
+    return A->getKind() == Action::Kind::GenerateDSYMJob;
   }
 };
 
@@ -271,10 +278,11 @@ class VerifyDebugInfoJobAction : public JobAction {
   virtual void anchor();
 public:
   explicit VerifyDebugInfoJobAction(const Action *Input)
-      : JobAction(Action::VerifyDebugInfoJob, Input, file_types::TY_Nothing) {}
+      : JobAction(Action::Kind::VerifyDebugInfoJob, Input,
+                  file_types::TY_Nothing) {}
 
   static bool classof(const Action *A) {
-    return A->getKind() == Action::VerifyDebugInfoJob;
+    return A->getKind() == Action::Kind::VerifyDebugInfoJob;
   }
 };
   
@@ -284,7 +292,7 @@ class GeneratePCHJobAction : public JobAction {
   virtual void anchor();
 public:
   GeneratePCHJobAction(const Action *Input, StringRef persistentPCHDir)
-      : JobAction(Action::GeneratePCHJob, Input,
+      : JobAction(Action::Kind::GeneratePCHJob, Input,
                   persistentPCHDir.empty() ? file_types::TY_PCH
                                            : file_types::TY_Nothing),
         PersistentPCHDir(persistentPCHDir) {}
@@ -293,7 +301,7 @@ public:
   StringRef getPersistentPCHDir() const { return PersistentPCHDir; }
 
   static bool classof(const Action *A) {
-    return A->getKind() == Action::GeneratePCHJob;
+    return A->getKind() == Action::Kind::GeneratePCHJob;
   }
 };
 
@@ -303,14 +311,15 @@ class LinkJobAction : public JobAction {
 
 public:
   LinkJobAction(ArrayRef<const Action *> Inputs, LinkKind K)
-      : JobAction(Action::LinkJob, Inputs, file_types::TY_Image), Kind(K) {
+      : JobAction(Action::Kind::LinkJob, Inputs, file_types::TY_Image),
+        Kind(K) {
     assert(Kind != LinkKind::None);
   }
 
   LinkKind getKind() const { return Kind; }
 
   static bool classof(const Action *A) {
-    return A->getKind() == Action::LinkJob;
+    return A->getKind() == Action::Kind::LinkJob;
   }
 };
 

--- a/lib/Driver/Action.cpp
+++ b/lib/Driver/Action.cpp
@@ -18,20 +18,20 @@
 using namespace swift::driver;
 using namespace llvm::opt;
 
-const char *Action::getClassName(ActionClass AC) {
+const char *Action::getClassName(Kind AC) {
   switch (AC) {
-    case Input: return "input";
-    case CompileJob: return "compile";
-    case InterpretJob: return "interpret";
-    case BackendJob: return "backend";
-    case MergeModuleJob: return "merge-module";
-    case ModuleWrapJob: return "modulewrap";
-    case AutolinkExtractJob: return "swift-autolink-extract";
-    case REPLJob: return "repl";
-    case LinkJob: return "link";
-    case GenerateDSYMJob: return "generate-dSYM";
-    case VerifyDebugInfoJob: return "verify-debug-info";
-    case GeneratePCHJob: return "generate-pch";
+  case Kind::Input:  return "input";
+  case Kind::CompileJob:  return "compile";
+  case Kind::InterpretJob:  return "interpret";
+  case Kind::BackendJob:  return "backend";
+  case Kind::MergeModuleJob:  return "merge-module";
+  case Kind::ModuleWrapJob:  return "modulewrap";
+  case Kind::AutolinkExtractJob:  return "swift-autolink-extract";
+  case Kind::REPLJob:  return "repl";
+  case Kind::LinkJob:  return "link";
+  case Kind::GenerateDSYMJob:  return "generate-dSYM";
+  case Kind::VerifyDebugInfoJob:  return "verify-debug-info";
+  case Kind::GeneratePCHJob:  return "generate-pch";
   }
 
   llvm_unreachable("invalid class");

--- a/lib/Driver/ToolChain.cpp
+++ b/lib/Driver/ToolChain.cpp
@@ -74,8 +74,9 @@ ToolChain::constructJob(const JobAction &JA,
 
   auto invocationInfo = [&]() -> InvocationInfo {
     switch (JA.getKind()) {
-  #define CASE(K) case Action::K: \
-      return constructInvocation(cast<K##Action>(JA), context);
+#define CASE(K)                                                                \
+  case Action::Kind::K:                                                        \
+    return constructInvocation(cast<K##Action>(JA), context);
     CASE(CompileJob)
     CASE(InterpretJob)
     CASE(BackendJob)
@@ -88,7 +89,7 @@ ToolChain::constructJob(const JobAction &JA,
     CASE(AutolinkExtractJob)
     CASE(REPLJob)
 #undef CASE
-    case Action::Input:
+    case Action::Kind::Input:
       llvm_unreachable("not a JobAction");
     }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
A small driver change inspired by batch mode: replacing an `enum` with an `enum class` to better enable future refactoring.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
