### PR TITLE
Add support for Builtin types to Type::join.

### DIFF
--- a/lib/AST/TypeJoinMeet.cpp
+++ b/lib/AST/TypeJoinMeet.cpp
@@ -73,9 +73,10 @@ struct TypeJoin : CanTypeVisitor<TypeJoin, CanType> {
   CanType visitProtocolCompositionType(CanType second);
   CanType visitLValueType(CanType second);
   CanType visitInOutType(CanType second);
+  CanType visitBuiltinType(CanType second);
 
   CanType visitType(CanType second) {
-    llvm_unreachable("Unimplemented type visitor!");
+    return Unimplemented;
   }
 
 public:
@@ -367,6 +368,13 @@ CanType TypeJoin::visitProtocolCompositionType(CanType second) {
 CanType TypeJoin::visitLValueType(CanType second) { return Unimplemented; }
 
 CanType TypeJoin::visitInOutType(CanType second) { return Unimplemented; }
+
+CanType TypeJoin::visitBuiltinType(CanType second) {
+  assert(First != second);
+
+  // BuiltinType with any non-equal type results in Any.
+  return TheAnyType;
+}
 
 } // namespace
 

--- a/test/Sema/type_join.swift
+++ b/test/Sema/type_join.swift
@@ -34,6 +34,10 @@ expectEqualType(Builtin.type_join(D?.self, Any.self), Any?.self)
 expectEqualType(Builtin.type_join(Any?.self, Any.self), Any?.self)
 expectEqualType(Builtin.type_join(Any.self, Any?.self), Any?.self)
 
+expectEqualType(Builtin.type_join(Builtin.Int1.self, Builtin.Int1.self), Builtin.Int1.self)
+expectEqualType(Builtin.type_join(Builtin.Int32.self, Builtin.Int1.self), Any.self)
+expectEqualType(Builtin.type_join(Builtin.Int1.self, Builtin.Int32.self), Any.self)
+
 func joinFunctions(
   _ escaping: @escaping () -> (),
   _ nonescaping: () -> ()


### PR DESCRIPTION
Also, don't have an llvm_unreachable implying that we have at least
minimal coverage for all cases, since we don't.
