### PR TITLE
Retain type sugar for extension declarations that name generic typealiases

### DIFF
--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -47,15 +47,33 @@ ASTContext &DeclContext::getASTContext() const {
 
 GenericTypeDecl *
 DeclContext::getAsTypeOrTypeExtensionContext() const {
-  if (auto decl = const_cast<Decl*>(getAsDeclOrDeclExtensionContext())) {
-    if (auto ED = dyn_cast<ExtensionDecl>(decl)) {
-      if (auto type = ED->getExtendedType())
-        return type->getAnyNominal();
-      return nullptr;
+  auto decl = const_cast<Decl*>(getAsDeclOrDeclExtensionContext());
+  if (!decl) return nullptr;
+
+  auto ext = dyn_cast<ExtensionDecl>(decl);
+  if (!ext) return dyn_cast<GenericTypeDecl>(decl);
+
+  auto type = ext->getExtendedType();
+  if (!type) return nullptr;
+
+  do {
+    // expected case: we reference a nominal type (potentially through sugar)
+    if (auto nominal = type->getAnyNominal())
+      return nominal;
+
+    // early type checking case: we have a typealias reference that is still
+    // unsugared, so explicitly look through the underlying type if there is
+    // one.
+    if (auto typealias =
+          dyn_cast_or_null<TypeAliasDecl>(type->getAnyGeneric())) {
+      type = typealias->getUnderlyingTypeLoc().getType();
+      if (!type) return nullptr;
+
+      continue;
     }
-    return dyn_cast<GenericTypeDecl>(decl);
-  }
-  return nullptr;
+
+    return nullptr;
+  } while (true);
 }
 
 /// If this DeclContext is a NominalType declaration or an

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -1147,13 +1147,14 @@ GenericEnvironment *TypeChecker::checkGenericEnvironment(
                       bool allowConcreteGenericParams,
                       ExtensionDecl *ext,
                       llvm::function_ref<void(GenericSignatureBuilder &)>
-                        inferRequirements) {
+                        inferRequirements,
+                      bool mustInferRequirements) {
   assert(genericParams && "Missing generic parameters?");
   bool recursivelyVisitGenericParams =
     genericParams->getOuterParameters() && !parentSig;
 
   GenericSignature *sig;
-  if (!ext || ext->getTrailingWhereClause() ||
+  if (!ext || mustInferRequirements || ext->getTrailingWhereClause() ||
       getExtendedTypeGenericDepth(ext) != genericParams->getDepth()) {
     // Collect the generic parameters.
     SmallVector<GenericTypeParamType *, 4> allGenericParams;

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -323,7 +323,8 @@ static void bindExtensionDecl(ExtensionDecl *ED, TypeChecker &TC) {
       auto extendedNominal = aliasDecl->getDeclaredInterfaceType()->getAnyNominal();
       if (extendedNominal) {
         extendedType = extendedNominal->getDeclaredType();
-        ED->getExtendedTypeLoc().setType(extendedType);
+        if (!isPassThroughTypealias(aliasDecl))
+          ED->getExtendedTypeLoc().setType(extendedType);
       }
     }
   }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2540,7 +2540,27 @@ public:
 bool isAcceptableDynamicMemberLookupSubscript(SubscriptDecl *decl,
                                               DeclContext *DC,
                                               TypeChecker &TC);
-  
+
+/// Determine whether this is a "pass-through" typealias, which has the
+/// same type parameters as the nominal type it references and specializes
+/// the underlying nominal type with exactly those type parameters.
+/// For example, the following typealias \c GX is a pass-through typealias:
+///
+/// \code
+/// struct X<T, U> { }
+/// typealias GX<A, B> = X<A, B>
+/// \endcode
+///
+/// whereas \c GX2 and \c GX3 are not pass-through because \c GX2 has
+/// different type parameters and \c GX3 doesn't pass its type parameters
+/// directly through.
+///
+/// \code
+/// typealias GX2<A> = X<A, A>
+/// typealias GX3<A, B> = X<B, A>
+/// \endcode
+bool isPassThroughTypealias(TypeAliasDecl *typealias);
+
 } // end namespace swift
 
 #endif

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1419,7 +1419,8 @@ public:
                         bool allowConcreteGenericParams,
                         ExtensionDecl *ext,
                         llvm::function_ref<void(GenericSignatureBuilder &)>
-                          inferRequirements);
+                          inferRequirements,
+                        bool mustInferRequirements);
 
   /// Construct a new generic environment for the given declaration context.
   ///
@@ -1439,7 +1440,8 @@ public:
                         ExtensionDecl *ext) {
     return checkGenericEnvironment(genericParams, dc, outerSignature,
                                    allowConcreteGenericParams, ext,
-                                   [&](GenericSignatureBuilder &) { });
+                                   [&](GenericSignatureBuilder &) { },
+                                   /*mustInferRequirements=*/false);
   }
 
   /// Validate the signature of a generic type.

--- a/test/Compatibility/CountableRange.swift
+++ b/test/Compatibility/CountableRange.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift
+
+struct RequiresComparable<T: Comparable> { }
+
+extension CountableRange { // expected-warning{{'CountableRange' is deprecated: renamed to 'Range'}}
+  // expected-note@-1{{use 'Range' instead}}{{11-25=Range}}
+  func testComparable() {
+    _ = RequiresComparable<Bound>()
+  }
+}
+

--- a/test/Compatibility/stdlib_generic_typealiases.swift
+++ b/test/Compatibility/stdlib_generic_typealiases.swift
@@ -9,3 +9,10 @@ extension CountableRange { // expected-warning{{'CountableRange' is deprecated: 
   }
 }
 
+struct RequiresHashable<T: Hashable> { }
+
+extension DictionaryIndex {
+  func testHashable() {
+    _ = RequiresHashable<Key>()
+  }
+}

--- a/test/Generics/requirement_inference.swift
+++ b/test/Generics/requirement_inference.swift
@@ -481,10 +481,28 @@ func testX1WithP2Overloading<T>(_: X1WithP2<T>) {
 }
 
 // Extend using the inferred requirement.
-// FIXME: Currently broken.
 extension X1WithP2 {
   func f() {
-    _ = X5<T>() // FIXME: expected-error{{type 'T' does not conform to protocol 'P2'}}
+    _ = X5<T>() // okay: inferred T: P2 from generic typealias
+  }
+}
+
+extension X1: P1 {
+  func p1() { }
+}
+
+typealias X1WithP2Changed<T: P2> = X1<X1<T>>
+typealias X1WithP2MoreArgs<T: P2, U> = X1<T>
+
+extension X1WithP2Changed {
+  func bad1() {
+    _ = X5<T>() // expected-error{{type 'T' does not conform to protocol 'P2'}}
+  }
+}
+
+extension X1WithP2MoreArgs {
+  func bad2() {
+    _ = X5<T>() // expected-error{{type 'T' does not conform to protocol 'P2'}}
   }
 }
 

--- a/validation-test/Serialization/rdar29694978.swift
+++ b/validation-test/Serialization/rdar29694978.swift
@@ -22,7 +22,7 @@ extension MyNonGenericType {}
 
 // CHECK-DAG: typealias MyGenericType<T> = GenericType<T>
 typealias MyGenericType<T: NSObject> = GenericType<T>
-// CHECK-DAG: extension GenericType where Element : AnyObject
+// CHECK-DAG: extension GenericType where Element : NSObject
 extension MyGenericType {}
 // CHECK-DAG: extension GenericType where Element == NSObject
 extension MyGenericType where Element == NSObject {}


### PR DESCRIPTION
When extending a type via a generic typealias, where the type parameters of
the underlying nominal type line up precisely with those of the
generic typealias and its specialization of the underlying nominal
type (a so-called "pass-through" typealias in the new code), maintain
type sugar in the extension declaration.

This new type sugar enables inference of type requirements from the
generic typealias, which is both useful by itself (it lets the type
requirements on generic typealiases be meaningful for extensions like
they are elsewhere), and also addresses a source-compatability
regression where an extension of `CountableRange` will now infer the
requirement `Bound: Comparable`.

Fixes SR-6907 / rdar://problem/29066394.
