### PR TITLE
No need to repeat the same test twice

### DIFF
--- a/test/stdlib/DictionaryLiteral.swift
+++ b/test/stdlib/DictionaryLiteral.swift
@@ -49,8 +49,5 @@ let anNSString = "Foo" as NSString
 var stringNSStringLet: DictionaryLiteral = [ "a": aString as NSString, "b": anNSString]
 expectType(DictionaryLiteral<String, NSString>.self, &stringNSStringLet)
 
-var hetero1: DictionaryLiteral = ["a": 1 as NSNumber, "b": "Foo" as NSString]
-expectType(DictionaryLiteral<String, NSObject>.self, &hetero1)
-
-var hetero2: DictionaryLiteral = ["a": 1 as NSNumber, "b": "Foo" as NSString]
-expectType(DictionaryLiteral<String, NSObject>.self, &hetero2)
+var hetero: DictionaryLiteral = ["a": 1 as NSNumber, "b": "Foo" as NSString]
+expectType(DictionaryLiteral<String, NSObject>.self, &hetero)


### PR DESCRIPTION
It might be due to a historical reason before bridging works as it does now. There should be no need to repeat the same assertion twice here.

### What's in this pull request?
Removing the same expectation assertion in `DictionLiteral` test for stdlib. It's an improvement of the test so there is no external link.
