### PR TITLE
[4.1] IRGen: Fix witness-table accessors for conditional conformances

### DIFF
--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -1064,6 +1064,7 @@ static llvm::Value *emitWitnessTableAccessorCall(
   // If the conformance is generic, the accessor takes the metatype plus
   // possible conditional conformances arguments.
   llvm::CallInst *call;
+  bool requiresMemoryArguments = false;
   if (conformance->witnessTableAccessorRequiresArguments()) {
     // Emit the source metadata if we haven't yet.
     if (!*srcMetadataCache) {
@@ -1076,13 +1077,14 @@ static llvm::Value *emitWitnessTableAccessorCall(
 
     call = IGF.Builder.CreateCall(
         accessor, {*srcMetadataCache, conditionalTables, numConditionalTables});
-
+    requiresMemoryArguments = true;
   } else {
     call = IGF.Builder.CreateCall(accessor, {});
   }
 
   call->setCallingConv(IGF.IGM.DefaultCC);
-  call->setDoesNotAccessMemory();
+  if (!requiresMemoryArguments)
+    call->setDoesNotAccessMemory();
   call->setDoesNotThrow();
 
   return call;

--- a/test/Inputs/conditional_conformance_basic_conformances.swift
+++ b/test/Inputs/conditional_conformance_basic_conformances.swift
@@ -102,7 +102,7 @@ public func single_concrete() {
 // CHECK-NEXT:    [[A_P2_PTR:%.*]] = getelementptr inbounds i8**, i8*** [[CONDITIONAL_REQUIREMENTS]], i32 0
 // CHECK-NEXT:    store i8** getelementptr inbounds ([0 x i8*], [0 x i8*]* @_T042conditional_conformance_basic_conformances4IsP2VAA0F0AAWP, i32 0, i32 0), i8*** [[A_P2_PTR]], align 8
 
-// CHECK-NEXT:    [[Single_P1:%.*]] = call i8** @_T042conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWa(%swift.type* [[Single_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]], i64 1)
+// CHECK-NEXT:    [[Single_P1:%.*]] = call i8** @_T042conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWa(%swift.type* [[Single_TYPE]], i8*** [[CONDITIONAL_REQUIREMENTS]], i64 1) [[ATTRS:#[0-9]+]]
 // CHECK-NEXT:    store atomic i8** [[Single_P1]], i8*** @_T042conditional_conformance_basic_conformances6SingleVyAA4IsP2VGACyxGAA2P1A2A0G0RzlWL release, align 8
 // CHECK-NEXT:    br label %cont
 
@@ -323,3 +323,5 @@ public func double_concrete_concrete() {
 func dynamicCastToP1(_ value: Any) -> P1? {
   return value as? P1
 }
+
+// CHECK: attributes [[ATTRS]] = { nounwind }


### PR DESCRIPTION
Explanation: After adding conditional conformances witness table
accessors are no longer readnone because the witnesses are passed as an
in memory argument. In optimized mode LLVM will optimize away the store
of the witnesses because it believes the accessor function is readnone
leading to crashes

Scope: Introduced with conditional conformances, potentially affects any project
that emit witness-table accessors on based types with conditional
conformances

Risk: Very low since the fix is to not emit LLVM's readnone attribute
(which should do no harm)

Testing: The project on which this was reported was tested and a CI test
added

SR-7228
rdar://38624842
