### PR TITLE
[4.2][SourceKit] For the swift header interface request, accept the swift version as a string

### DIFF
--- a/test/SourceKit/InterfaceGen/gen_header.swift
+++ b/test/SourceKit/InterfaceGen/gen_header.swift
@@ -9,6 +9,15 @@
 // RUN: diff -u %s.header2.response %t.header2.response
 
 // RUN: echo '#include "header2.h"' > %t.m
-// RUN: %sourcekitd-test -req=interface-gen -header %S/Inputs/header2.h -swift-version=4 -- -fsyntax-only %t.m -I %S/Inputs > %t.header2.swift4.response
+// RUN: %sourcekitd-test -req=interface-gen -header %S/Inputs/header2.h -swift-version=3 -- -fsyntax-only %t.m -I %S/Inputs > %t.header2.response
+// RUN: diff -u %s.header2.response %t.header2.response
+
+// RUN: echo '#include "header2.h"' > %t.m
+// RUN: %sourcekitd-test -req=interface-gen -header %S/Inputs/header2.h -swift-version=4 -pass-version-as-string -- -fsyntax-only %t.m -I %S/Inputs > %t.header2.swift4.response
 // RUN: %FileCheck -input-file %t.header2.swift4.response %s -check-prefix=SWIFT4
 // SWIFT4: public func show_only_for_swift_4()
+
+// RUN: echo '#include "header2.h"' > %t.m
+// RUN: %sourcekitd-test -req=interface-gen -header %S/Inputs/header2.h -swift-version=4 -pass-version-as-string -- -fsyntax-only %t.m -I %S/Inputs > %t.header2.swift4.response
+// RUN: %FileCheck -input-file %t.header2.swift4.response %s -check-prefix=SWIFT4-STR
+// SWIFT4-STR: public func show_only_for_swift_4()

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -540,7 +540,7 @@ public:
                                          ArrayRef<const char *> Args,
                                          bool UsingSwiftArgs,
                                          bool SynthesizedExtensions,
-                                         Optional<unsigned> swiftVersion) = 0;
+                                         StringRef swiftVersion) = 0;
 
   virtual void editorOpenSwiftSourceInterface(StringRef Name,
                                               StringRef SourceName,

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -805,7 +805,7 @@ void SwiftLangSupport::editorOpenHeaderInterface(EditorConsumer &Consumer,
                                                  ArrayRef<const char *> Args,
                                                  bool UsingSwiftArgs,
                                                  bool SynthesizedExtensions,
-                                              Optional<unsigned> swiftVersion) {
+                                                 StringRef swiftVersion) {
   CompilerInstance CI;
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
@@ -838,9 +838,12 @@ void SwiftLangSupport::editorOpenHeaderInterface(EditorConsumer &Consumer,
   }
 
   Invocation.getClangImporterOptions().ImportForwardDeclarations = true;
-  if (swiftVersion.hasValue()) {
-    auto swiftVer = version::Version({swiftVersion.getValue()});
-    Invocation.getLangOptions().EffectiveLanguageVersion = swiftVer;
+  if (!swiftVersion.empty()) {
+    auto swiftVer = version::Version::parseVersionString(swiftVersion,
+                                                         SourceLoc(), nullptr);
+    if (swiftVer.hasValue())
+      Invocation.getLangOptions().EffectiveLanguageVersion =
+          swiftVer.getValue();
   }
   auto IFaceGenRef = SwiftInterfaceGenContext::create(Name,
                                                       /*IsModule=*/false,

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -418,7 +418,7 @@ public:
                                  ArrayRef<const char *> Args,
                                  bool UsingSwiftArgs,
                                  bool SynthesizedExtensions,
-                                 Optional<unsigned> swiftVersion) override;
+                                 StringRef swiftVersion) override;
 
   void editorOpenSwiftSourceInterface(StringRef Name,
                                       StringRef SourceName,

--- a/tools/SourceKit/tools/sourcekitd-test/Options.td
+++ b/tools/SourceKit/tools/sourcekitd-test/Options.td
@@ -104,6 +104,9 @@ def end_pos_EQ : Joined<["-"], "end-pos=">, Alias<end_pos>;
 def swift_version : Separate<["-"], "swift-version">, HelpText<"the swift version to use">;
 def swift_version_EQ : Joined<["-"], "swift-version=">, Alias<swift_version>;
 
+def pass_version_as_string : Flag<["-"], "pass-version-as-string">,
+  HelpText<"Pass swift-version as string">;
+
 def swift_name : Separate<["-"], "swift-name">,
   HelpText<"Swift name to translate from">;
 

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -200,15 +200,13 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
       break;
     }
 
-      case OPT_swift_version: {
-        unsigned ver;
-        if (StringRef(InputArg->getValue()).getAsInteger(10, ver)) {
-          llvm::errs() << "error: expected integer for 'swift-version'\n";
-          return true;
-        }
-        SwiftVersion = ver;
-        break;
-      }
+    case OPT_swift_version:
+      SwiftVersion = InputArg->getValue();
+      break;
+
+    case OPT_pass_version_as_string:
+      PassVersionAsString = true;
+      break;
 
     case OPT_line:
       if (StringRef(InputArg->getValue()).getAsInteger(10, Line)) {

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -78,7 +78,8 @@ struct TestOptions {
   unsigned EndCol = 0;
   unsigned Offset = 0;
   unsigned Length = 0;
-  llvm::Optional<unsigned> SwiftVersion;
+  std::string SwiftVersion;
+  bool PassVersionAsString = false;
   llvm::Optional<std::string> ReplaceText;
   std::string ModuleName;
   std::string HeaderPath;

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -743,9 +743,18 @@ static int handleTestInvocation(ArrayRef<const char *> Args,
                                             *Opts.CancelOnSubsequentRequest);
   }
 
-  if (Opts.SwiftVersion.hasValue()) {
-    sourcekitd_request_dictionary_set_int64(Req, KeySwiftVersion,
-                                             Opts.SwiftVersion.getValue());
+  if (!Opts.SwiftVersion.empty()) {
+    if (Opts.PassVersionAsString) {
+      sourcekitd_request_dictionary_set_string(Req, KeySwiftVersion,
+                                               Opts.SwiftVersion.c_str());
+    } else {
+      unsigned ver;
+      if (StringRef(Opts.SwiftVersion).getAsInteger(10, ver)) {
+        llvm::errs() << "error: expected integer for 'swift-version'\n";
+        return true;
+      }
+      sourcekitd_request_dictionary_set_int64(Req, KeySwiftVersion, ver);
+    }
   }
 
   if (Opts.PrintRequest)


### PR DESCRIPTION
This is so we can pass the version as "4.2".

rdar://38673625

master: https://github.com/apple/swift/pull/15440