### PR TITLE
[CSBindings] Delay binding type variables which are dependent on other constraints

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -239,8 +239,15 @@ ConstraintSystem::getPotentialBindingForRelationalConstraint(
     SmallPtrSet<TypeVariableType *, 4> typeVars;
     findInferableTypeVars(first, typeVars);
     findInferableTypeVars(second, typeVars);
-    if (typeVars.size() > 1 && typeVars.count(typeVar))
+    if (typeVars.size() > 1 && typeVars.count(typeVar)) {
       result.InvolvesTypeVariables = true;
+      // Delay binding type variable that has constraints
+      // that have it nested inside some other type e.g.  for `T2`
+      // `T0 arg conv [T2]` and `T conv $T0.ArrayLiteralElement`,
+      // because until related constraints are simplified
+      // there is no way to get full set of bindings for it.
+      result.FullyBound = true;
+    }
     return None;
   }
 

--- a/test/Constraints/bridging.swift
+++ b/test/Constraints/bridging.swift
@@ -296,7 +296,7 @@ func rdar20029786(_ ns: NSString?) {
 
   let s3: NSString? = "str" as String? // expected-error {{cannot convert value of type 'String?' to specified type 'NSString?'}}
 
-  var s4: String = ns ?? "str" // expected-error{{cannot convert value of type 'NSString' to specified type 'String'}}
+  var s4: String = ns ?? "str" // expected-error{{'NSString' is not implicitly convertible to 'String'; did you mean to use 'as' to explicitly convert?}}
   var s5: String = (ns ?? "str") as String // fixed version
 }
 

--- a/test/Constraints/rdar38535743.swift
+++ b/test/Constraints/rdar38535743.swift
@@ -1,0 +1,14 @@
+// RUN: %target-typecheck-verify-swift
+// REQUIRES: objc_interop
+
+import Foundation
+
+protocol P {}
+
+class C {
+    init<T: NSObject>(values: [T]) where T: P {}
+}
+
+func foo<T: NSObject>(value: T) where T: P {
+  _ = C(values: [value]) // Ok
+}

--- a/test/Constraints/tuple.swift
+++ b/test/Constraints/tuple.swift
@@ -169,7 +169,7 @@ struct MagicKingdom<K> : Kingdom {
 }
 func magify<T>(_ t: T) -> MagicKingdom<T> { return MagicKingdom() }
 func foo(_ pair: (Int, Int)) -> Victory<(x: Int, y: Int)> {
-  return Victory(magify(pair)) // expected-error {{cannot convert return expression of type 'Victory<(Int, Int)>' to return type 'Victory<(x: Int, y: Int)>'}}
+  return Victory(magify(pair)) // ok (tuple-to-tuple) conversion on `pair`
 }
 
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar30729643.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar30729643.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --invert-result --begin 7 --end 12 --step 1 --select incrementScopeCounter %s
+// RUN: %scale-test --begin 1 --end 15 --step 1 --select incrementScopeCounter %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 


### PR DESCRIPTION
Delay binding type variable that has constraints
that have it nested inside some other type e.g. for `T2`
`$T0 arg conv [$T2]` and `U conv $T0.ArrayLiteralElement`,
because until related constraints are simplified
there is no way to get full set of bindings for it.

Resolves: rdar://problem/38535743

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
