### PR TITLE
 Sema: Ensure Equatable conformance is forced for key path indices.

### DIFF
--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -150,6 +150,19 @@ public:
   /// abstraction level of their associated type requirements.
   SILType mapTypeIntoContext(SILModule &M, SILType type) const;
 
+  /// Map an interface type's protocol conformance into the corresponding
+  /// conformance for the contextual type.
+  static std::pair<Type, ProtocolConformanceRef>
+  mapConformanceRefIntoContext(GenericEnvironment *genericEnv,
+                               Type conformingType,
+                               ProtocolConformanceRef conformance);
+
+  /// Map an interface type's protocol conformance into the corresponding
+  /// conformance for the contextual type.
+  std::pair<Type, ProtocolConformanceRef>
+  mapConformanceRefIntoContext(Type conformingType,
+                               ProtocolConformanceRef conformance) const;
+          
   /// Get the sugared form of a generic parameter type.
   GenericTypeParamType *getSugaredType(GenericTypeParamType *type) const;
 

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -133,6 +133,11 @@ public:
   /// Get any additional requirements that are required for this conformance to
   /// be satisfied.
   ArrayRef<Requirement> getConditionalRequirements() const;
+  
+  /// If this is a conformance reference for a protocol that inherits other
+  /// protocols, get a reference to the related conformance for the inherited
+  /// protocol.
+  ProtocolConformanceRef getInheritedConformanceRef(ProtocolDecl *base) const;
 };
 
 } // end namespace swift

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -230,3 +230,25 @@ GenericEnvironment::getForwardingSubstitutions() const {
   genericSig->getSubstitutions(subMap, result);
   return genericSig->getASTContext().AllocateCopy(result);
 }
+
+std::pair<Type, ProtocolConformanceRef>
+GenericEnvironment::mapConformanceRefIntoContext(GenericEnvironment *genericEnv,
+                                           Type conformingType,
+                                           ProtocolConformanceRef conformance) {
+  if (!genericEnv)
+    return {conformingType, conformance};
+  
+  return genericEnv->mapConformanceRefIntoContext(conformingType, conformance);
+}
+
+std::pair<Type, ProtocolConformanceRef>
+GenericEnvironment::mapConformanceRefIntoContext(
+                                     Type conformingInterfaceType,
+                                     ProtocolConformanceRef conformance) const {
+  auto contextConformance = conformance.subst(conformingInterfaceType,
+    QueryInterfaceTypeSubstitutions(this),
+    LookUpConformanceInSignature(*getGenericSignature()));
+  
+  auto contextType = mapTypeIntoContext(conformingInterfaceType);
+  return {contextType, contextConformance};
+}

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4612,6 +4612,8 @@ namespace {
       
         auto hashable =
           cs.getASTContext().getProtocol(KnownProtocolKind::Hashable);
+        auto equatable =
+          cs.getASTContext().getProtocol(KnownProtocolKind::Equatable);
         for (auto indexType : indexTypes) {
           auto conformance =
             cs.TC.conformsToProtocol(indexType.getType(), hashable,
@@ -4626,6 +4628,17 @@ namespace {
             continue;
           }
           hashables.push_back(*conformance);
+          
+          // FIXME: Hashable implies Equatable, but we need to make sure the
+          // Equatable conformance is forced into existence during type checking
+          // so that it's available for SILGen.
+          auto eqConformance =
+            cs.TC.conformsToProtocol(indexType.getType(), equatable,
+                                     cs.DC,
+                                     (ConformanceCheckFlags::Used|
+                                      ConformanceCheckFlags::InExpression));
+          assert(eqConformance.hasValue());
+          (void)eqConformance;
         }
 
         if (allIndexesHashable) {


### PR DESCRIPTION
We need to ensure that the conformance is fully reified during type checking since we will use it during SILGen for the keypath. Speculative fix for SR-7207 | rdar://problem/38506058.