### PR TITLE
[Diagnostics] Fix a crash when using `withoutActuallyEscaping` incorrectly

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/0148-rdar35773761.swift
+++ b/validation-test/compiler_crashers_2_fixed/0148-rdar35773761.swift
@@ -1,0 +1,4 @@
+// RUN: %target-typecheck-verify-swift %s
+
+let b: () -> Void = withoutActuallyEscaping({ print("hello crash") }, do: { $0() })
+// expected-error@-1 {{cannot convert value of type '()' to specified type '() -> Void'}}


### PR DESCRIPTION
Teach `eraseOpenedExistentials` how to handle `OpaqueValueExpr`
associated with `MakeTemporarilyEscapableExpr`.

Resolves: rdar://problem/35773761

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
