### PR TITLE
SILGen: Guard against unexpected nulls passed into ObjC overrides.

### DIFF
--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1336,12 +1336,16 @@ static SILFunctionType *emitObjCThunkArguments(SILGenFunction &SGF,
 
   assert(bridgedArgs.size() == nativeInputs.size());
   for (unsigned i = 0, size = bridgedArgs.size(); i < size; ++i) {
+    // Consider the bridged values to be "call results" since they're coming
+    // from potentially nil-unsound ObjC callers.
     ManagedValue native =
       SGF.emitBridgedToNativeValue(loc,
-                                   bridgedArgs[i],
-                                   bridgedFormalTypes[i],
-                                   nativeFormalTypes[i],
-                        swiftFnTy->getParameters()[i].getSILStorageType());
+                        bridgedArgs[i],
+                        bridgedFormalTypes[i],
+                        nativeFormalTypes[i],
+                        swiftFnTy->getParameters()[i].getSILStorageType(),
+                        SGFContext(),
+                        /*isCallResult*/ true);
     SILValue argValue;
 
     if (nativeInputs[i].isConsumed()) {

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -1076,6 +1076,10 @@ extern NSString *NSHTTPRequestKey;
 
 @end
 
+@protocol NSIdLoving
+- (void)takesIdViaProtocol:(id _Nonnull)x;
+@end
+
 #define NSTimeIntervalSince1970 978307200.0
 #define NS_DO_SOMETHING 17
 

--- a/test/SILGen/objc_bridging_any.swift
+++ b/test/SILGen/objc_bridging_any.swift
@@ -1,4 +1,3 @@
-
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -module-name objc_bridging_any -Xllvm -sil-print-debuginfo -emit-silgen -enable-sil-ownership %s | %FileCheck %s
 // REQUIRES: objc_interop
 
@@ -414,7 +413,7 @@ protocol Anyable {
 // Make sure we generate correct bridging thunks
 class SwiftIdLover : NSObject, Anyable {
 
-  func methodReturningAny() -> Any {}
+  func methodReturningAny() -> Any { fatalError() }
   // SEMANTIC ARC TODO: This is another case of pattern matching the body of one
   // function in a different function... Just pattern match the unreachable case
   // to preserve behavior. We should check if it is correct.
@@ -440,31 +439,19 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK:   return [[OBJC_RESULT]]
   // CHECK: } // end sil function '$S17objc_bridging_any12SwiftIdLoverC18methodReturningAnyypyFTo'
 
-  func methodReturningOptionalAny() -> Any? {}
+  func methodReturningOptionalAny() -> Any? { fatalError() }
   // CHECK-LABEL: sil hidden @$S17objc_bridging_any12SwiftIdLoverC26methodReturningOptionalAnyypSgyF
   // CHECK-LABEL: sil hidden [thunk] @$S17objc_bridging_any12SwiftIdLoverC26methodReturningOptionalAnyypSgyFTo
   // CHECK:       function_ref @$Ss27_bridgeAnythingToObjectiveC{{.*}}F
 
-  @objc func methodTakingAny(a: Any) {}
+  @objc func methodTakingAny(a: Any) { fatalError() }
   // CHECK-LABEL: sil hidden [thunk] @$S17objc_bridging_any12SwiftIdLoverC15methodTakingAny1ayyp_tFTo : $@convention(objc_method) (AnyObject, SwiftIdLover) -> ()
   // CHECK:     bb0([[ARG:%.*]] : @unowned $AnyObject, [[SELF:%.*]] : @unowned $SwiftIdLover):
-  // CHECK-NEXT:  [[ARG_COPY:%.*]] = copy_value [[ARG]]
-  // CHECK-NEXT:  [[SELF_COPY:%.*]] = copy_value [[SELF]]
-  // CHECK-NEXT:  [[OPENED_SELF:%.*]] = open_existential_ref [[ARG_COPY]]
-  // CHECK-NEXT:  [[RESULT:%.*]] = alloc_stack $Any
-  // CHECK-NEXT:  [[INIT:%.*]] = init_existential_addr [[RESULT]] : $*Any
-  // CHECK-NEXT:  store [[OPENED_SELF]] to [init] [[INIT]]
-  // CHECK-NEXT:  [[BORROWED_SELF_COPY:%.*]] = begin_borrow [[SELF_COPY]]
-  // CHECK-NEXT:  // function_ref
-  // CHECK-NEXT:  [[METHOD:%.*]] = function_ref @$S17objc_bridging_any12SwiftIdLoverC15methodTakingAny1ayyp_tF
-  // CHECK-NEXT:  apply [[METHOD]]([[RESULT]], [[BORROWED_SELF_COPY]])
-  // CHECK-NEXT:  end_borrow [[BORROWED_SELF_COPY]] from [[SELF_COPY]]
-  // CHECK-NEXT:  destroy_addr [[RESULT]]
-  // CHECK-NEXT:  dealloc_stack [[RESULT]]
-  // CHECK-NEXT:  destroy_value [[SELF_COPY]]
-  // CHECK-NEXT:  return
+  // CHECK:   function_ref [[BRIDGE_ANYOBJECT_TO_ANY:@\$Ss018_bridgeAnyObjectToB0yypyXlSgF]] : $@convention(thin) (@guaranteed Optional<AnyObject>) -> @out Any
+  // CHECK:  [[METHOD:%.*]] = function_ref @$S17objc_bridging_any12SwiftIdLoverC15methodTakingAny1ayyp_tF
+  // CHECK-NEXT:  apply [[METHOD]]([[RESULT:%.*]], [[BORROWED_SELF_COPY:%.*]]) :
 
-  func methodTakingOptionalAny(a: Any?) {}
+  func methodTakingOptionalAny(a: Any?) { fatalError() }
   // CHECK-LABEL: sil hidden @$S17objc_bridging_any12SwiftIdLoverC23methodTakingOptionalAny1ayypSg_tF
 
   // CHECK-LABEL: sil hidden [thunk] @$S17objc_bridging_any12SwiftIdLoverC23methodTakingOptionalAny1ayypSg_tFTo
@@ -502,7 +489,7 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  dealloc_stack [[TMP]]
   // CHECK-NEXT:  return [[VOID]]
 
-  @objc func methodTakingBlockTakingAny(_: (Any) -> ()) {}
+  @objc func methodTakingBlockTakingAny(_: (Any) -> ()) { fatalError() }
 
   // CHECK-LABEL: sil hidden @$S17objc_bridging_any12SwiftIdLoverC29methodReturningBlockTakingAnyyypcyF : $@convention(method) (@guaranteed SwiftIdLover) -> @owned @callee_guaranteed (@in_guaranteed Any) -> ()
 
@@ -543,9 +530,9 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  destroy_value [[FUNCTION]]
   // CHECK-NEXT:  return [[VOID]] : $()
 
-  @objc func methodTakingBlockTakingOptionalAny(_: (Any?) -> ()) {}
+  @objc func methodTakingBlockTakingOptionalAny(_: (Any?) -> ()) { fatalError() }
 
-  @objc func methodReturningBlockTakingAny() -> ((Any) -> ()) {}
+  @objc func methodReturningBlockTakingAny() -> ((Any) -> ()) { fatalError() }
 
   // CHECK-LABEL: sil hidden @$S17objc_bridging_any12SwiftIdLoverC29methodTakingBlockReturningAnyyyypyXEF : $@convention(method) (@noescape @callee_guaranteed () -> @out Any, @guaranteed SwiftIdLover) -> () {
 
@@ -579,9 +566,9 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  destroy_value [[OPTIONAL]]
   // CHECK-NEXT:  return [[EMPTY]]
 
-  @objc func methodReturningBlockTakingOptionalAny() -> ((Any?) -> ()) {}
+  @objc func methodReturningBlockTakingOptionalAny() -> ((Any?) -> ()) { fatalError() }
 
-  @objc func methodTakingBlockReturningAny(_: () -> Any) {}
+  @objc func methodTakingBlockReturningAny(_: () -> Any) { fatalError() }
 
   // CHECK-LABEL: sil hidden @$S17objc_bridging_any12SwiftIdLoverC020methodReturningBlockH3AnyypycyF : $@convention(method) (@guaranteed SwiftIdLover) -> @owned @callee_guaranteed () -> @out Any
 
@@ -626,26 +613,26 @@ class SwiftIdLover : NSObject, Anyable {
   // CHECK-NEXT:  destroy_value [[FUNCTION]]
   // CHECK-NEXT:  return [[BRIDGED]]
 
-  @objc func methodTakingBlockReturningOptionalAny(_: () -> Any?) {}
+  @objc func methodTakingBlockReturningOptionalAny(_: () -> Any?) { fatalError() }
 
-  @objc func methodReturningBlockReturningAny() -> (() -> Any) {}
+  @objc func methodReturningBlockReturningAny() -> (() -> Any) { fatalError() }
 
-  @objc func methodReturningBlockReturningOptionalAny() -> (() -> Any?) {}
+  @objc func methodReturningBlockReturningOptionalAny() -> (() -> Any?) { fatalError() }
   // CHECK-LABEL: sil shared [transparent] [serializable] [reabstraction_thunk] @$SypSgIegr_yXlSgIeyBa_TR
   // CHECK: function_ref @$Ss27_bridgeAnythingToObjectiveC{{.*}}F
 
-  override init() { super.init() }
-  @objc dynamic required convenience init(any: Any) { self.init() }
-  @objc dynamic required convenience init(anyMaybe: Any?) { self.init() }
+  override init() { fatalError() }
+  @objc dynamic required convenience init(any: Any) { fatalError() }
+  @objc dynamic required convenience init(anyMaybe: Any?) { fatalError() }
   @objc dynamic var anyProperty: Any
   @objc dynamic var maybeAnyProperty: Any?
 
-  subscript(_: IndexForAnySubscript) -> Any { get {} set {} }
+  subscript(_: IndexForAnySubscript) -> Any { get { fatalError() } set { fatalError() } }
 
-  @objc func methodReturningAnyOrError() throws -> Any {}
+  @objc func methodReturningAnyOrError() throws -> Any { fatalError() }
 }
 
-class IndexForAnySubscript {}
+class IndexForAnySubscript { }
 
 func dynamicLookup(x: AnyObject) {
   _ = x.anyProperty
@@ -684,6 +671,28 @@ class AnyHashableClass : NSObject {
 func bridgeOptionalFunctionToAnyObject(fn: (() -> ())?) -> AnyObject {
   return fn as AnyObject
 }
+
+// When bridging `id _Nonnull` values incoming from unknown ObjC code,
+// turn them into `Any` using a runtime call that defends against the
+// possibility they still may be nil.
+
+// CHECK-LABEL: sil hidden @$S17objc_bridging_any22bridgeIncomingAnyValueyypSo9NSIdLoverCF
+func bridgeIncomingAnyValue(_ receiver: NSIdLover) -> Any {
+  // CHECK: function_ref [[BRIDGE_ANYOBJECT_TO_ANY]]
+  return receiver.makesId()
+}
+
+class SwiftAnyEnjoyer: NSIdLover, NSIdLoving {
+  // CHECK-LABEL: sil hidden [thunk] @$S17objc_bridging_any15SwiftAnyEnjoyerC7takesIdyyypFTo
+  // CHECK: function_ref [[BRIDGE_ANYOBJECT_TO_ANY]]
+  override func takesId(_ x: Any) { }
+
+  // CHECK-LABEL: sil hidden [thunk] @$S17objc_bridging_any15SwiftAnyEnjoyerC7takesId11viaProtocolyyp_tFTo 
+  // CHECK: function_ref [[BRIDGE_ANYOBJECT_TO_ANY]]
+  func takesId(viaProtocol x: Any) { }
+}
+
+
 
 // CHECK-LABEL: sil_witness_table shared [serialized] GenericOption: Hashable module objc_generics {
 // CHECK-NEXT: base_protocol Equatable: GenericOption: Equatable module objc_generics


### PR DESCRIPTION
We want to treat arguments to ObjC override and protocol conformance thunks like "call results", since they might be called from ObjC code that doesn't fulfill its nullability promises in practice. Fixes SR-7240 | rdar://problem/38675815.