### PR TITLE
[IRGenSIL] Force early materialization of liverange-extended values

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -646,6 +646,41 @@ public:
     return Name;
   }
 
+  /// Try to emit an inline assembly gadget which extends the lifetime of
+  /// \p Var. Returns whether or not this was successful.
+  bool emitLifetimeExtendingUse(llvm::Value *Var) {
+    llvm::Type *ArgTys;
+    auto *Ty = Var->getType();
+    // Vectors, Pointers and Floats are expected to fit into a register.
+    if (Ty->isPointerTy() || Ty->isFloatingPointTy() || Ty->isVectorTy())
+      ArgTys = {Ty};
+    else {
+      // If this is not a scalar or vector type, we can't handle it.
+      if (isa<llvm::CompositeType>(Ty))
+        return false;
+      // The storage is guaranteed to be no larger than the register width.
+      // Extend the storage so it would fit into a register.
+      llvm::Type *IntTy;
+      switch (IGM.getClangASTContext().getTargetInfo().getRegisterWidth()) {
+      case 64:
+        IntTy = IGM.Int64Ty;
+        break;
+      case 32:
+        IntTy = IGM.Int32Ty;
+        break;
+      default:
+        llvm_unreachable("unsupported register width");
+      }
+      ArgTys = {IntTy};
+      Var = Builder.CreateZExtOrBitCast(Var, IntTy);
+    }
+    // Emit an empty inline assembler expression depending on the register.
+    auto *AsmFnTy = llvm::FunctionType::get(IGM.VoidTy, ArgTys, false);
+    auto *InlineAsm = llvm::InlineAsm::get(AsmFnTy, "", "r", true);
+    Builder.CreateAsmCall(InlineAsm, Var);
+    return true;
+  }
+
   /// At -Onone, forcibly keep all LLVM values that are tracked by
   /// debug variables alive by inserting an empty inline assembler
   /// expression depending on the value in the blocks dominated by the
@@ -654,52 +689,35 @@ public:
     if (IGM.IRGen.Opts.shouldOptimize())
       return;
     for (auto &Variable : ValueDomPoints) {
-      auto VarDominancePoint = Variable.second;
-      llvm::Value *Storage = Variable.first;
+      llvm::Instruction *Var = Variable.first;
+      DominancePoint VarDominancePoint = Variable.second;
       if (getActiveDominancePoint() == VarDominancePoint ||
           isActiveDominancePointDominatedBy(VarDominancePoint)) {
-        llvm::Type *ArgTys;
-        auto *Ty = Storage->getType();
-        // Vectors, Pointers and Floats are expected to fit into a register.
-        if (Ty->isPointerTy() || Ty->isFloatingPointTy() || Ty->isVectorTy())
-          ArgTys = { Ty };
-        else {
-          // If this is not a scalar or vector type, we can't handle it.
-          if (isa<llvm::CompositeType>(Ty))
-            continue;
-          // The storage is guaranteed to be no larger than the register width.
-          // Extend the storage so it would fit into a register.
-          llvm::Type *IntTy;
-          switch (IGM.getClangASTContext().getTargetInfo().getRegisterWidth()) {
-          case 64: IntTy = IGM.Int64Ty; break;
-          case 32: IntTy = IGM.Int32Ty; break;
-          default: llvm_unreachable("unsupported register width");
-          }
-          ArgTys = { IntTy };
-          Storage = Builder.CreateZExtOrBitCast(Storage, IntTy);
-        }
-        // Emit an empty inline assembler expression depending on the register.
-        auto *AsmFnTy = llvm::FunctionType::get(IGM.VoidTy, ArgTys, false);
-        auto *InlineAsm = llvm::InlineAsm::get(AsmFnTy, "", "r", true);
-        Builder.CreateAsmCall(InlineAsm, Storage);
-        // Propagate the dbg.value intrinsics into the later basic blocks.  Note
+        bool ExtendedLifetime = emitLifetimeExtendingUse(Var);
+        if (!ExtendedLifetime)
+          continue;
+
+        // Propagate dbg.values for Var into the current basic block. Note
         // that this shouldn't be necessary. LiveDebugValues should be doing
         // this but can't in general because it currently only tracks register
         // locations.
-        llvm::Instruction *Value = Variable.first;
-        auto It = llvm::BasicBlock::iterator(Value);
-        auto *BB = Value->getParent();
-        auto *CurBB = Builder.GetInsertBlock();
-        if (BB != CurBB)
-          for (auto I = std::next(It), E = BB->end(); I != E; ++I) {
-            auto *DVI = dyn_cast<llvm::DbgValueInst>(I);
-            if (DVI && DVI->getValue() == Value)
-              IGM.DebugInfo->getBuilder().insertDbgValueIntrinsic(
-                  DVI->getValue(), DVI->getVariable(), DVI->getExpression(),
-                  DVI->getDebugLoc(), &*CurBB->getFirstInsertionPt());
-            else
-              // Found all dbg.value intrinsics describing this location.
-              break;
+        llvm::BasicBlock *BB = Var->getParent();
+        llvm::BasicBlock *CurBB = Builder.GetInsertBlock();
+        if (BB == CurBB)
+          // The current basic block must be a successor of the dbg.value().
+          continue;
+
+        auto It = llvm::BasicBlock::iterator(Var);
+        for (auto I = std::next(It), E = BB->end(); I != E; ++I) {
+          auto *DVI = dyn_cast<llvm::DbgValueInst>(I);
+          if (DVI && DVI->getValue() == Var)
+            IGM.DebugInfo->getBuilder().insertDbgValueIntrinsic(
+                DVI->getValue(), DVI->getVariable(), DVI->getExpression(),
+                DVI->getDebugLoc(), &*CurBB->getFirstInsertionPt());
+          else
+            // Found all dbg.value intrinsics describing this location.
+            // FIXME: How do we know that there aren't more dbg.values?
+            break;
         }
       }
     }

--- a/test/DebugInfo/liverange-extension.swift
+++ b/test/DebugInfo/liverange-extension.swift
@@ -1,27 +1,63 @@
 // RUN: %target-swift-frontend %s -g -emit-ir -o - | %FileCheck %s
 
+// REQUIRES: CPU=x86_64
+//
+// We require x86_64 to make the test easier to read. Without this,
+// writing check lines that ensure our asm gadgets match up with the
+// right values is painfully hard to do.
+
 func use<T>(_ x: T) {}
 
 func getInt32() -> Int32 { return -1 }
 
+// CHECK-LABEL: define {{.*}}rangeExtension
 public func rangeExtension(_ b: Bool) {
-  // CHECK: define {{.*}}rangeExtension
   let i = getInt32()
-  // CHECK: llvm.dbg.value(metadata i32 [[I:.*]], metadata {{.*}}, metadata
+  // CHECK: [[I:%.*]] = call swiftcc i32 @"{{.*}}getInt32
+  // CHECK-NEXT: [[I_ZEXT:%.*]] = zext i32 [[I]] to i64
+  // CHECK-NEXT: call void asm sideeffect "", "r"(i64 [[I_ZEXT]])
+  // CHECK-NEXT: llvm.dbg.value(metadata i32 [[I]], metadata [[MD_I:!.*]], metadata
+
   use(i)
+
+  // CHECK: br i1
+
   if b {
+    // CHECK: llvm.dbg.value(metadata i32 [[I]], metadata [[MD_I]]
+
     let j = getInt32()
-    // CHECK: llvm.dbg.value(metadata i32 [[I]], metadata {{.*}}, metadata
-    // CHECK: llvm.dbg.value(metadata i32 [[J:.*]], metadata {{.*}}, metadata
+    // CHECK: [[J:%.*]] = call swiftcc i32 @"{{.*}}getInt32
+    // CHECK-NEXT: [[J_ZEXT:%.*]] = zext i32 [[J]] to i64
+    // CHECK-NEXT: call void asm sideeffect "", "r"(i64 [[J_ZEXT]])
+    // CHECK: llvm.dbg.value(metadata i32 [[J]], metadata [[MD_J:!.*]], metadata
+
     use(j)
-    // CHECK-DAG: {{(asm sideeffect "", "r".*)|(zext i32)}} [[J]]
-    // CHECK-DAG: asm sideeffect "", "r"
+    // CHECK: call swiftcc void @"{{.*}}use
+
+    // CHECK: [[I_ZEXT:%.*]] = zext i32 [[I]] to i64
+    // CHECK-NEXT: call void asm sideeffect "", "r"(i64 [[I_ZEXT]])
+    // CHECK-NEXT: [[J_ZEXT:%.*]] = zext i32 [[J]] to i64
+    // CHECK-NEXT: call void asm sideeffect "", "r"(i64 [[J_ZEXT]])
+
+    // CHECK: br label
   }
+
+  // CHECK-NOT: llvm.dbg.value(metadata i32 [[J]]
+  // CHECK: llvm.dbg.value(metadata i32 [[I]]
+
   let z = getInt32()
+  // CHECK: [[Z:%.*]] = call swiftcc i32 @"{{.*}}getInt32
+  // CHECK: llvm.dbg.value(metadata i32 [[Z]], metadata [[MD_Z:!.*]], metadata
+
   use(z)
-  // CHECK-NOT: llvm.dbg.value(metadata i32 [[J]], metadata {{.*}}, metadata
-  // CHECK-DAG: llvm.dbg.value(metadata i32 [[I]], metadata {{.*}}, metadata
-  // CHECK-DAG: llvm.dbg.value(metadata i32 [[Z:.*]], metadata {{.*}}, metadata
-  // CHECK-DAG: {{(asm sideeffect "", "r".*)|(zext i32)}} [[I]]
-  // CHECK-DAG: asm sideeffect "", "r"
+  // CHECK: call swiftcc void @"{{.*}}use
+
+  // CHECK: [[I_ZEXT:%.*]] = zext i32 [[I]] to i64
+  // CHECK-NEXT: call void asm sideeffect "", "r"(i64 [[I_ZEXT]])
+  // CHECK-NEXT: [[Z_ZEXT:%.*]] = zext i32 [[Z]] to i64
+  // CHECK-NEXT: call void asm sideeffect "", "r"(i64 [[Z_ZEXT]])
 }
+
+// CHECK-DAG: [[MD_I]] = !DILocalVariable(name: "i"
+// CHECK-DAG: [[MD_J]] = !DILocalVariable(name: "j"
+// CHECK-DAG: [[MD_Z]] = !DILocalVariable(name: "z"


### PR DESCRIPTION
At -Onone, we may opt to extend the liverange of a value by inserting
fake uses of the value in blocks which postdominate its def. This keeps
values available throughout the entirety of a function when stepping
through it in a debugger.

This patch makes it so that we also insert a fake use at the start of a
value's lifetime. This forces early materialization of the value, i.e it
becomes available for inspection in a debugger as soon as it's defined.

This is useful when a value has no uses except fake uses. In such cases,
ISel may (correctly!) decide to materialize the value at the end of its
scope. This is really unintuitive and unhelpful for users, because you
need to be done stepping through the value's scope before you can
inspect it.

For the same reasons, forcing early materialization is also useful when
a value *does* have uses. Consider:

  let d = ...
  print("Here is the value of d: \(d)")

Without early materialization, if you set a breakpoint on the line
containing the print, you would not be able to inspect "d". That's
because "d" would be materialized right before string interpolation
happens, which is *after* the breakpoint PC.

rdar://38465084
(cherry picked from commit 3bdcb00)