### PR TITLE
[globalopt] Eliminate unused field.

### DIFF
--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -84,10 +84,8 @@ class SILGlobalOpt {
   /// The set of functions that have had their loops analyzed.
   llvm::DenseSet<SILFunction *> LoopCheckedFunctions;
 
-  /// Keep track of cold blocks.
-  ColdBlockInfo ColdBlocks;
-
-  /// Whether we see a "once" call to callees that we currently don't handle.
+  /// Whether we have seen any "once" calls to callees that we currently don't
+  /// handle.
   bool UnhandledOnceCallee = false;
 
   /// A map from a globalinit_func to the number of times "once" has called the
@@ -95,7 +93,7 @@ class SILGlobalOpt {
   llvm::DenseMap<SILFunction *, unsigned> InitializerCount;
 public:
   SILGlobalOpt(SILModule *M, DominanceAnalysis *DA)
-      : Module(M), DA(DA), ColdBlocks(DA) {}
+      : Module(M), DA(DA) {}
 
   bool run();
 


### PR DESCRIPTION
Some time ago I believe due to compile time I believe, we started to use
ColdBlockInfo in a per function way. So for each function, we instantiate a new
ColdBlockInfo and never use this one. So there is no reason for it to exist...
