### PR TITLE
[CSBindings] Cleanup literal binding inference

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -173,8 +173,10 @@ void ConstraintSystem::PotentialBindings::addPotentialBinding(
   // check whether we can combine it with another
   // supertype binding by computing the 'join' of the types.
   if (binding.Kind == AllowedBindingKind::Supertypes &&
-      !binding.BindingType->hasTypeVariable() && !binding.DefaultedProtocol &&
-      !binding.isDefaultableBinding() && allowJoinMeet) {
+      !binding.BindingType->hasTypeVariable() &&
+      !binding.BindingType->hasUnboundGenericType() &&
+      !binding.DefaultedProtocol && !binding.isDefaultableBinding() &&
+      allowJoinMeet) {
     if (lastSupertypeIndex) {
       auto &lastBinding = Bindings[*lastSupertypeIndex];
       auto lastType = lastBinding.BindingType->getWithoutSpecifierType();
@@ -193,6 +195,9 @@ void ConstraintSystem::PotentialBindings::addPotentialBinding(
     // Record this as the most recent supertype index.
     lastSupertypeIndex = Bindings.size();
   }
+
+  if (auto *literalProtocol = binding.DefaultedProtocol)
+    foundLiteralBinding(literalProtocol);
 
   Bindings.push_back(std::move(binding));
 }
@@ -357,8 +362,8 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
 
   // Consider each of the constraints related to this type variable.
   llvm::SmallPtrSet<CanType, 4> exactTypes;
-  llvm::SmallPtrSet<ProtocolDecl *, 4> literalProtocols;
   SmallVector<Constraint *, 2> defaultableConstraints;
+  SmallVector<PotentialBinding, 4> literalBindings;
   bool addOptionalSupertypeBindings = false;
   auto &tc = getTypeChecker();
   bool hasNonDependentMemberRelationalConstraints = false;
@@ -478,8 +483,6 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
       if (!defaultType)
         continue;
 
-      // Note that we have a literal constraint with this protocol.
-      literalProtocols.insert(constraint->getProtocol());
       hasNonDependentMemberRelationalConstraints = true;
 
       // Handle unspecialized types directly.
@@ -487,10 +490,9 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
         if (!exactTypes.insert(defaultType->getCanonicalType()).second)
           continue;
 
-        result.foundLiteralBinding(constraint->getProtocol());
-        result.addPotentialBinding({defaultType, AllowedBindingKind::Subtypes,
-                                    constraint->getKind(),
-                                    constraint->getProtocol()});
+        literalBindings.push_back({defaultType, AllowedBindingKind::Subtypes,
+                                   constraint->getKind(),
+                                   constraint->getProtocol()});
         continue;
       }
 
@@ -514,11 +516,10 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
       }
 
       if (!matched) {
-        result.foundLiteralBinding(constraint->getProtocol());
         exactTypes.insert(defaultType->getCanonicalType());
-        result.addPotentialBinding({defaultType, AllowedBindingKind::Subtypes,
-                                    constraint->getKind(),
-                                    constraint->getProtocol()});
+        literalBindings.push_back({defaultType, AllowedBindingKind::Subtypes,
+                                   constraint->getKind(),
+                                   constraint->getProtocol()});
       }
 
       break;
@@ -575,14 +576,11 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
   // binding that provides a type that conforms to that literal protocol. In
   // such cases, remove the default binding suggestion because the existing
   // suggestion is better.
-  if (!literalProtocols.empty()) {
+  if (!literalBindings.empty()) {
     SmallPtrSet<ProtocolDecl *, 5> coveredLiteralProtocols;
     for (auto &binding : result.Bindings) {
-      // Skip defaulted-protocol constraints.
-      if (binding.DefaultedProtocol)
-        continue;
-
       Type testType;
+
       switch (binding.Kind) {
       case AllowedBindingKind::Exact:
         testType = binding.BindingType;
@@ -594,16 +592,32 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
         break;
       }
 
+      // Attempting to check conformance of the type variable,
+      // or unresolved type is invalid since it would result
+      // in lose of viable literal bindings because that check
+      // always returns trivial conformance.
+      if (testType->isTypeVariableOrMember() || testType->is<UnresolvedType>())
+        continue;
+
       // Check each non-covered literal protocol to determine which ones
+      // might be covered by non-defaulted bindings.
       bool updatedBindingType = false;
-      for (auto proto : literalProtocols) {
+      for (auto &literalBinding : literalBindings) {
+        auto *protocol = literalBinding.DefaultedProtocol;
+
+        assert(protocol);
+
+        // Has already been covered by one of the bindings.
+        if (coveredLiteralProtocols.count(protocol))
+          continue;
+
         do {
           // If the type conforms to this protocol, we're covered.
           if (tc.conformsToProtocol(
-                      testType, proto, DC,
-                      (ConformanceCheckFlags::InExpression|
-                       ConformanceCheckFlags::SkipConditionalRequirements))) {
-            coveredLiteralProtocols.insert(proto);
+                  testType, protocol, DC,
+                  (ConformanceCheckFlags::InExpression |
+                   ConformanceCheckFlags::SkipConditionalRequirements))) {
+            coveredLiteralProtocols.insert(protocol);
             break;
           }
 
@@ -627,17 +641,11 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
         binding.BindingType = testType;
     }
 
-    // For any literal type that has been covered, remove the default literal
-    // type.
-    if (!coveredLiteralProtocols.empty()) {
-      result.Bindings.erase(
-          std::remove_if(result.Bindings.begin(), result.Bindings.end(),
-                         [&](PotentialBinding &binding) {
-                           return binding.DefaultedProtocol &&
-                                  coveredLiteralProtocols.count(
-                                      *binding.DefaultedProtocol) > 0;
-                         }),
-          result.Bindings.end());
+    for (auto &literalBinding : literalBindings) {
+      auto *protocol = literalBinding.DefaultedProtocol;
+      // For any literal type that has been covered, skip them.
+      if (coveredLiteralProtocols.count(protocol) == 0)
+        result.addPotentialBinding(std::move(literalBinding));
     }
   }
 
@@ -649,7 +657,7 @@ ConstraintSystem::getPotentialBindings(TypeVariableType *typeVar) {
 
     ++result.NumDefaultableBindings;
     result.addPotentialBinding({type, AllowedBindingKind::Exact,
-                                constraint->getKind(), None,
+                                constraint->getKind(), nullptr,
                                 constraint->getLocator()});
   }
 

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -708,8 +708,8 @@ bool ConstraintSystem::tryTypeVariableBindings(
       // If we have a protocol with a default type, look for alternative
       // types to the default.
       if (tryCount == 0 && binding.DefaultedProtocol) {
-        KnownProtocolKind knownKind 
-          = *((*binding.DefaultedProtocol)->getKnownProtocolKind());
+        KnownProtocolKind knownKind =
+            *(binding.DefaultedProtocol->getKnownProtocolKind());
         for (auto altType : getAlternativeLiteralTypes(knownKind)) {
           if (exploredTypes.insert(altType->getCanonicalType()).second)
             newBindings.push_back({altType, AllowedBindingKind::Subtypes,

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2696,7 +2696,7 @@ private:
     ConstraintKind BindingSource;
 
     /// The defaulted protocol associated with this binding.
-    Optional<ProtocolDecl *> DefaultedProtocol;
+    ProtocolDecl *DefaultedProtocol;
 
     /// If this is a binding that comes from a \c Defaultable constraint,
     /// the locator of that constraint.
@@ -2704,7 +2704,7 @@ private:
 
     PotentialBinding(Type type, AllowedBindingKind kind,
                      ConstraintKind bindingSource,
-                     Optional<ProtocolDecl *> defaultedProtocol = None,
+                     ProtocolDecl *defaultedProtocol = nullptr,
                      ConstraintLocator *defaultableBinding = nullptr)
         : BindingType(type), Kind(kind), BindingSource(bindingSource),
           DefaultedProtocol(defaultedProtocol),
@@ -2839,7 +2839,7 @@ private:
                    }
                    if (binding.DefaultedProtocol)
                      out << "(default from "
-                         << (*binding.DefaultedProtocol)->getName() << ") ";
+                         << binding.DefaultedProtocol->getName() << ") ";
                    out << type.getString();
                  },
                  [&]() { out << "; "; });

--- a/test/Constraints/rdar38535743.swift
+++ b/test/Constraints/rdar38535743.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+protocol P {}
+
+class C {
+    init<T: NSObject>(values: [T]) where T: P {}
+}
+
+func foo<T: NSObject>(value: T) where T: P {
+  _ = C(values: [value]) // Ok
+}

--- a/validation-test/Sema/type_checker_perf/fast/rdar19394804.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar19394804.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --invert-result --begin 1 --end 4 --step 1 --select incrementScopeCounter %s
+// RUN: %scale-test --begin 1 --end 10 --step 1 --select incrementScopeCounter %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/fast/rdar30729643.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar30729643.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --invert-result --begin 7 --end 12 --step 1 --select incrementScopeCounter %s
+// RUN: %scale-test --begin 1 --end 15 --step 1 --select incrementScopeCounter %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/slow/nil_coalescing.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/nil_coalescing.swift.gyb
@@ -1,6 +1,7 @@
-// RUN: not %scale-test --invert-result --begin 1 --end 5 --step 1 --select incrementScopeCounter %s
+// RUN: %scale-test --invert-result --begin 1 --end 5 --step 1 --select incrementScopeCounter %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
+// REQUIRES: rdar38963783
 
 func t(_ x: Int?) -> Int {
   return (x ?? 0)

--- a/validation-test/Sema/type_checker_perf/slow/nil_coalescing.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/nil_coalescing.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --invert-result --begin 1 --end 5 --step 1 --select incrementScopeCounter %s
+// RUN: not %scale-test --invert-result --begin 1 --end 5 --step 1 --select incrementScopeCounter %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 


### PR DESCRIPTION
Don't attempt to store literal bindings directly to `PotentialBindings`
since they might get superseded by non-literal bindings deduced from
other constraints, also don't attempt to check literal protocol conformance
on type variables or member types since such types would always end-up
returning trivial conformance which results in removal of viable literal types.

Resolves: rdar://problem/38535743
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
