### PR TITLE
Take the IUO-ness of a parameter declaration into account in ranking.

### DIFF
--- a/test/Constraints/Inputs/disambiguate_iuo_param.h
+++ b/test/Constraints/Inputs/disambiguate_iuo_param.h
@@ -1,0 +1,9 @@
+@import Foundation;
+
+@interface NSObject (NSMyTest)
+- (BOOL)isEqualTo:(nullable id)object;
+@end
+
+@interface Obj : NSObject
+- (BOOL)isEqualToObject:(id)value;
+@end

--- a/test/Constraints/disambiguate_iuo_param.swift
+++ b/test/Constraints/disambiguate_iuo_param.swift
@@ -1,0 +1,11 @@
+// RUN: %empty-directory(%t)
+// RUN: %build-clang-importer-objc-overlays
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -import-objc-header %S/Inputs/disambiguate_iuo_param.h %s -emit-ir | %FileCheck %s
+// -module-name objc_ir -I %S/Inputs/custom-modules -emit-ir -g -o - -primary-file %s | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+// CHECK: define {{.*}} @main
+// CHECK: load {{.*}}, {{.*}}@"\01L_selector(isEqualToObject:)"
+let c = Obj()
+_ = c.isEqual(to: c)


### PR DESCRIPTION
Normally we wouldn't need this because we do not allow overloading by
parameter optionality. In this case, though, we import two Objective-C
methods that end up getting renamed to the same name in Swift, one of
which has a nullability annotation and the other of which doesn't.

Before IUOs were removed from the type system, we would have failed a
subtype test when ranking overloads, but now that subtype test passes
because we're comparing two optionals of the same type. So the change
here is to compare the optionality of the parameters and reject cases
where we are testing whether a plain optional is a subtype of
something declared to be an IUO.

Fixes rdar://problem/38719575.

(cherry picked from commit 0959f0ce7d0a9c1ae77d7d7129f927c012bbdb16)
