### PR TITLE
SR-7154: Pass the build directory containing swift libs to swiftpm

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1710,6 +1710,7 @@ function set_swiftpm_bootstrap_command() {
     if [[ "${VERBOSE_BUILD}" ]] ; then
         swiftpm_bootstrap_command+=(-v)
     fi
+    swiftpm_bootstrap_command+=(--swift-lib-dir=${SWIFT_BUILD_PATH}/lib/swift/${SWIFT_HOST_VARIANT}/${SWIFT_HOST_VARIANT_ARCH})
     # FIXME CROSSCOMPILING:
     # SwiftPM needs to be told about the target, sysroot and linker to use
     # when cross-compiling


### PR DESCRIPTION
This PR works with https://github.com/apple/swift-package-manager/pull/1544 (and needs to be tested together) to pass the build directory containing the swift libs (incl `libswiftSwiftOnone.so`).

When building swift using the `--debug-foundation` flag, the swift package manager tests use `libFoundation` but currently fail because it cant find `libswiftSwiftOnone`, one of its dependancies.

Test in conjunction with https://github.com/apple/swift-package-manager/pull/1544.