### PR TITLE
[AST] Bring BoundNameAliastype up to parity with NameAliasType

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2927,7 +2927,7 @@ BoundNameAliasType *BoundNameAliasType::get(
     if (parent->hasTypeVariable())
       storedProperties |= RecursiveTypeProperties::HasTypeVariable;
   }
-  auto genericSig = typealias->getGenericSignature();
+  auto genericSig = substitutions.getGenericSignature();
   if (genericSig) {
     for (Type gp : genericSig->getGenericParams()) {
       auto substGP = gp.subst(substitutions, SubstFlags::UseErrorType);

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -583,7 +583,7 @@ public:
       }
 
       bool foundError = type->hasArchetype() &&
-      type.findIf([&](Type type) -> bool {
+      type->getCanonicalType().findIf([&](Type type) -> bool {
         if (auto archetype = type->getAs<ArchetypeType>()) {
           // Only visit each archetype once.
           if (!visitedArchetypes.insert(archetype).second)

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -582,7 +582,8 @@ public:
         abort();
       }
 
-      bool foundError = type.findIf([&](Type type) -> bool {
+      bool foundError = type->hasArchetype() &&
+      type.findIf([&](Type type) -> bool {
         if (auto archetype = type->getAs<ArchetypeType>()) {
           // Only visit each archetype once.
           if (!visitedArchetypes.insert(archetype).second)
@@ -2116,6 +2117,7 @@ public:
       // Make sure that there are no archetypes in the interface type.
       if (VD->getDeclContext()->isTypeContext() &&
           !hasEnclosingFunctionContext(VD->getDeclContext()) &&
+          VD->getInterfaceType()->hasArchetype() &&
           VD->getInterfaceType().findIf([](Type type) {
             return type->is<ArchetypeType>();
           })) {

--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -56,7 +56,7 @@ DeclContext::getAsTypeOrTypeExtensionContext() const {
   auto type = ext->getExtendedType();
   if (!type) return nullptr;
 
-  do {
+  while (true) {
     // expected case: we reference a nominal type (potentially through sugar)
     if (auto nominal = type->getAnyNominal())
       return nominal;
@@ -73,7 +73,7 @@ DeclContext::getAsTypeOrTypeExtensionContext() const {
     }
 
     return nullptr;
-  } while (true);
+  }
 }
 
 /// If this DeclContext is a NominalType declaration or an

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -327,30 +327,34 @@ static void formatSelectionArgument(StringRef ModifierArguments,
 }
 
 static bool isInterestingTypealias(Type type) {
-  // Bound name alias types are always interesting.
-  if (isa<BoundNameAliasType>(type.getPointer())) return true;
-
-  auto aliasTy = dyn_cast<NameAliasType>(type.getPointer());
-  if (!aliasTy)
-    return false;
-  if (aliasTy->getDecl() == type->getASTContext().getVoidDecl())
-    return false;
-  if (type->is<BuiltinType>())
+  // Dig out the typealias declaration, if there is one.
+  TypeAliasDecl *aliasDecl = nullptr;
+  if (auto aliasTy = dyn_cast<NameAliasType>(type.getPointer()))
+    aliasDecl = aliasTy->getDecl();
+  else if (auto boundAliasTy = dyn_cast<BoundNameAliasType>(type.getPointer()))
+    aliasDecl = boundAliasTy->getDecl();
+  else
     return false;
 
-  auto aliasDecl = aliasTy->getDecl();
+  if (aliasDecl == type->getASTContext().getVoidDecl())
+    return false;
 
   // The 'Swift.AnyObject' typealias is not 'interesting'.
   if (aliasDecl->getName() ==
-      aliasDecl->getASTContext().getIdentifier("AnyObject") &&
+        aliasDecl->getASTContext().getIdentifier("AnyObject") &&
       aliasDecl->getParentModule()->isStdlibModule()) {
     return false;
   }
 
-  auto underlyingTy = aliasDecl->getUnderlyingTypeLoc().getType();
-
-  if (aliasDecl->isCompatibilityAlias())
+  // Compatibility aliases are only interesting insofar as their underlying
+  // types are interesting.
+  if (aliasDecl->isCompatibilityAlias()) {
+    auto underlyingTy = aliasDecl->getUnderlyingTypeLoc().getType();
     return isInterestingTypealias(underlyingTy);
+  }
+
+  // Builtin types are never interesting typealiases.
+  if (type->is<BuiltinType>()) return false;
 
   return true;
 }

--- a/lib/AST/PrettyStackTrace.cpp
+++ b/lib/AST/PrettyStackTrace.cpp
@@ -167,6 +167,9 @@ namespace {
     Decl *visitNameAliasType(NameAliasType *type) {
       return type->getDecl();
     }
+    Decl *visitBoundNameAliasType(BoundNameAliasType *type) {
+      return type->getDecl();
+    }
   };
 } // end anonymous namespace
 

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -535,6 +535,9 @@ void SubstitutionMap::dump() const {
 }
 
 void SubstitutionMap::profile(llvm::FoldingSetNodeID &id) const {
+  // Generic signature.
+  id.AddPointer(genericSig);
+
   if (empty() || !genericSig) return;
 
   // Replacement types.

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2837,10 +2837,16 @@ static Type getMemberForBaseType(LookupConformanceFn lookupConformances,
 
     // This is a hacky feature allowing code completion to migrate to
     // using Type::subst() without changing output.
-    if (options & SubstFlags::DesugarMemberTypes)
-      if (auto *aliasType = dyn_cast<NameAliasType>(witness.getPointer()))
+    if (options & SubstFlags::DesugarMemberTypes) {
+      if (auto *aliasType = dyn_cast<NameAliasType>(witness.getPointer())) {
         if (!aliasType->is<ErrorType>())
           witness = aliasType->getSinglyDesugaredType();
+      } else if (auto *boundAliasType =
+                   dyn_cast<BoundNameAliasType>(witness.getPointer())) {
+        if (!boundAliasType->is<ErrorType>())
+          witness = boundAliasType->getSinglyDesugaredType();
+      }
+    }
 
     if (witness->is<ErrorType>())
       return failed();

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1299,7 +1299,7 @@ Type SugarType::getSinglyDesugaredTypeSlow() {
 }
 
 SubstitutionMap BoundNameAliasType::getSubstitutionMap() const {
-  if (auto genericSig = typealias->getGenericSignature())
+  if (auto genericSig = getGenericSignature())
     return genericSig->getSubstitutionMap(getSubstitutionList());
 
   return SubstitutionMap();

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2500,6 +2500,14 @@ namespace {
             if (auto *NAT = dyn_cast<NameAliasType>(SwiftType.getPointer()))
               return NAT->getDecl();
 
+            // Don't create an extra typealias in the imported module because
+            // doing so will cause confusion (or even lookup ambiguity) between
+            // the name in the imported module and the same name in the
+            // standard library.
+            if (auto *BNAT =
+                  dyn_cast<BoundNameAliasType>(SwiftType.getPointer()))
+              return BNAT->getDecl();
+
             auto *NTD = SwiftType->getAnyNominal();
             assert(NTD);
             return NTD;

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -197,6 +197,8 @@ namespace {
         return Type();
       if (auto *NAT = dyn_cast<NameAliasType>(T.getPointer()))
         return NAT->getSinglyDesugaredType();
+      if (auto *BNAT = dyn_cast<BoundNameAliasType>(T.getPointer()))
+        return BNAT->getSinglyDesugaredType();
       return T;
     }
     

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2927,9 +2927,10 @@ public:
           Optional<Type> Result = None;
           if (auto AT = MT->getInstanceType()) {
             if (!CD->getInterfaceType()->is<ErrorType>() &&
-                isa<NameAliasType>(AT.getPointer()) &&
-                AT->getDesugaredType() ==
-                    CD->getResultInterfaceType().getPointer())
+                ((isa<NameAliasType>(AT.getPointer()) ||
+                  isa<BoundNameAliasType>(AT.getPointer())) &&
+                  AT->getDesugaredType() ==
+                    CD->getResultInterfaceType().getPointer()))
               Result = AT;
           }
           addConstructorCall(CD, Reason, None, Result);

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3162,8 +3162,10 @@ Type TypeChecker::substMemberTypeWithBase(ModuleDecl *module,
     baseTy = baseTy->getSuperclassForDecl(ownerClass);
   }
 
-  if (baseTy->is<ModuleType>())
+  if (baseTy->is<ModuleType>()) {
     baseTy = Type();
+    sugaredBaseTy = Type();
+  }
 
   // The declared interface type for a generic type will have the type
   // arguments; strip them off.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -611,7 +611,8 @@ Type TypeChecker::applyUnboundGenericArguments(
                                 SubstFlags::UseErrorType);
 
   // Form a sugared typealias reference.
-  if (typealias) {
+  Type parentType = unboundType->getParent();
+  if (typealias && (!parentType || !parentType->isAnyExistentialType())) {
     auto genericSig = typealias->getGenericSignature();
     auto subMap = genericSig->getSubstitutionMap(QueryTypeSubstitutionMap{subs},
                                                  LookUpConformance(*this, dc));
@@ -3209,7 +3210,8 @@ Type TypeChecker::substMemberTypeWithBase(ModuleDecl *module,
 
   // If we're referring to a typealias within a generic context, build
   // a sugared alias type.
-  if (aliasDecl && aliasDecl->getGenericSignature()) {
+  if (aliasDecl && aliasDecl->getGenericSignature() &&
+      (!sugaredBaseTy || !sugaredBaseTy->isAnyExistentialType())) {
     resultType = BoundNameAliasType::get(aliasDecl, sugaredBaseTy, subs,
                                          resultType);
   }


### PR DESCRIPTION
Fix a number of small issues with `BoundNameAliasType` to bring it up to parity with `NameAliasType`, so the former will be able to replace the latter. This includes:

* Making `BoundNameAliasType`s profiling (for `FoldingSet`) and formation more robust against ill-formed ASTs
* Not recording module types or existential parent types in the AST, because serialization cannot handle the former and the latter shouldn't be well-formed at all anyway
* Adding lots of redundant logic so that we handle a `BoundNameAliasType` everywhere that we handle a `NameAliasType`, including for special cases where we currently always get a `NameAliasType`. This part is pure staging.
