### PR TITLE
[Batch mode] Harden driver against conflicting arguments

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -83,6 +83,11 @@ ERROR(error_unknown_arg,none,
   "unknown argument: '%0'", (StringRef))
 ERROR(error_invalid_arg_value,none,
   "invalid value '%1' in '%0'", (StringRef, StringRef))
+NOTE(note_ignoring_earlier_mode_argument,none,
+  "ignoring earlier '%0' argument in favor of later '%1' argument",
+  (StringRef, StringRef))
+NOTE(note_cannot_multithread_batch_mode,none,
+  "ignoring -num-threads argument, cannot multithread batch mode", ())
 ERROR(error_unsupported_option_argument,none,
   "unsupported argument '%1' to option '%0'", (StringRef, StringRef))
 ERROR(error_immediate_mode_missing_stdlib,none,

--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -237,12 +237,14 @@ public:
   ///
   /// \param TC The current tool chain.
   /// \param Args The input arguments.
+  /// \param BatchMode Was batch modde requested?
   /// \param SingleCompileMode Was single compile (whole-module-optimization)
-  /// requested? \param Inputs The inputs to the driver. \param[out] OI The
+  /// requested?
+  /// \param Inputs The inputs to the driver. \param[out] OI The
   /// OutputInfo in which to store the resulting output information.
   void buildOutputInfo(const ToolChain &TC,
                        const llvm::opt::DerivedArgList &Args,
-                       const bool SingleCompileMode,
+                       const bool BatchMode, const bool SingleCompileMode,
                        const InputFileList &Inputs, OutputInfo &OI) const;
 
   /// Construct the list of Actions to perform for the given arguments,

--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -237,11 +237,12 @@ public:
   ///
   /// \param TC The current tool chain.
   /// \param Args The input arguments.
-  /// \param Inputs The inputs to the driver.
-  /// \param[out] OI The OutputInfo in which to store the resulting output
-  /// information.
+  /// \param SingleCompileMode Was single compile (whole-module-optimization)
+  /// requested? \param Inputs The inputs to the driver. \param[out] OI The
+  /// OutputInfo in which to store the resulting output information.
   void buildOutputInfo(const ToolChain &TC,
                        const llvm::opt::DerivedArgList &Args,
+                       const bool SingleCompileMode,
                        const InputFileList &Inputs, OutputInfo &OI) const;
 
   /// Construct the list of Actions to perform for the given arguments,


### PR DESCRIPTION
<!-- What's in this pull request? -->
What if the driver is invoked with both -enable-batch-mode and -whole-module-optimization?
This PR has the driver obey the last argument instead of -whole-module-optimization and issue a diagnostic.
Also if the driver is invoked with -enable-batch-mode and -num-threads the driver will trip an assertion that does not obviously indicate the problem. This PR adds an assertion with a clear message, and also causes the driver to ignore the -num-threads argument and issue a diagnostic, so that the assertion should never trip.
Finally, handle indexing a bit more nicely.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->