### PR TITLE
runtime: avoid some pedantic warnings from CPP (NFC)

### DIFF
--- a/include/swift/Runtime/Config.h
+++ b/include/swift/Runtime/Config.h
@@ -54,7 +54,7 @@
 /// above, information other than the class pointer could be contained in the
 /// ISA.
 #ifndef SWIFT_HAS_OPAQUE_ISAS
-#if __ARM_ARCH_7K__ >= 2
+#if defined(__arm__) && __ARM_ARCH_7K__ >= 2
 #define SWIFT_HAS_OPAQUE_ISAS 1
 #else
 #define SWIFT_HAS_OPAQUE_ISAS 0
@@ -68,7 +68,7 @@
 /// Which bits in the class metadata are used to distinguish Swift classes
 /// from ObjC classes?
 #ifndef SWIFT_CLASS_IS_SWIFT_MASK
-# if __APPLE__ && SWIFT_OBJC_INTEROP && SWIFT_DARWIN_ENABLE_STABLE_ABI_BIT
+# if defined(__APPLE__) && SWIFT_OBJC_INTEROP && SWIFT_DARWIN_ENABLE_STABLE_ABI_BIT
 #  define SWIFT_CLASS_IS_SWIFT_MASK 2ULL
 # else
 #  define SWIFT_CLASS_IS_SWIFT_MASK 1ULL


### PR DESCRIPTION
Expansion of undefined macros is 0.  This results in warnings when
building the runtime on Windows.  Ensure that the macros are defined
when checking the conditions.  NFC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
