### PR TITLE
[Batch mode] WIP: Use minimum -j argument to help when testing.

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -83,6 +83,8 @@ ERROR(error_unknown_arg,none,
   "unknown argument: '%0'", (StringRef))
 ERROR(error_invalid_arg_value,none,
   "invalid value '%1' in '%0'", (StringRef, StringRef))
+NOTE(note_multiple_js,none,
+  "multiple -j arguments, using the smallest ('%0')", (unsigned))
 ERROR(error_unsupported_option_argument,none,
   "unsupported argument '%1' to option '%0'", (StringRef, StringRef))
 ERROR(error_immediate_mode_missing_stdlib,none,


### PR DESCRIPTION
<!-- What's in this pull request? -->
In order to be able to test batch mode with fewer jobs than Xcode specifies, use the minimum value when there are several -j's and utter a diagnostic.
Have not tested this yet.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
