### PR TITLE
Support incomplete type metadata

### DIFF
--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -98,8 +98,8 @@ public:
 private:
   int_type Data;
 
-  constexpr TargetValueWitnessFlags(int_type data) : Data(data) {}
 public:
+  explicit constexpr TargetValueWitnessFlags(int_type data) : Data(data) {}
   constexpr TargetValueWitnessFlags() : Data(0) {}
 
   /// The required alignment of the first byte of an object of this

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1442,6 +1442,7 @@ public:
   FLAGSET_DEFINE_FLAG_ACCESSORS(NonBlocking_bit,
                                 isNonBlocking,
                                 setIsNonBlocking)
+  bool isBlocking() const { return !isNonBlocking(); }
 };
 using MetadataRequest =
   TargetMetadataRequest<size_t>;

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1421,6 +1421,8 @@ inline bool isAtLeast(MetadataState lhs, MetadataState rhs) {
 class MetadataRequest : public FlagSet<size_t> {
   using IntType = size_t;
   using super = FlagSet<IntType>;
+
+public:
   enum : IntType {
     State_bit = 0,
     State_width = 8,
@@ -1434,7 +1436,6 @@ class MetadataRequest : public FlagSet<size_t> {
     NonBlocking_bit = 8,
   };
 
-public:
   MetadataRequest(MetadataState state, bool isNonBlocking = false) {
     setState(state);
     setIsNonBlocking(isNonBlocking);
@@ -1454,6 +1455,11 @@ public:
                                 isNonBlocking,
                                 setIsNonBlocking)
   bool isBlocking() const { return !isNonBlocking(); }
+
+  /// Is this request satisfied by a metadata that's in the given state?
+  bool isSatisfiedBy(MetadataState state) const {
+    return isAtLeast(state, getState());
+  }
 };
 
 } // end namespace swift

--- a/include/swift/ABI/MetadataValues.h
+++ b/include/swift/ABI/MetadataValues.h
@@ -1383,36 +1383,47 @@ public:
                                  value_setMetadataKind)
 };
 
+/// The public state of a metadata.
+enum class MetadataState : size_t {
+  /// A request for fully-completed metadata.  The metadata must be
+  /// prepared for all supported type operations.  This is a superset
+  /// of the requirements of LayoutComplete.
+  ///
+  /// For example, a class must be ready for subclassing and instantiation:
+  /// it must have a completed instance layout and (under ObjCInterop)
+  /// must have been realized by the Objective-C runtime.
+  Complete,
+
+  /// A request for metadata that can be used for type layout; that is,
+  /// the type's value witness table must be completely initialized.
+  LayoutComplete,
+
+  /// A request for a metadata pointer that fully identifies the type.
+  /// Basic type structure, such as the type context descriptor and the
+  /// list of generic arguments, should have been installed, but there is
+  /// no requirement for a valid value witness table.
+  Abstract,
+};
+
+/// Something that can be static_asserted in all the places where we depend
+/// on metadata state ordering.
+constexpr const bool MetadataStateIsReverseOrdered = true;
+
+/// Return true if the first metadata state is at least as advanced as the
+/// second.
+inline bool isAtLeast(MetadataState lhs, MetadataState rhs) {
+  static_assert(MetadataStateIsReverseOrdered,
+                "relying on the ordering of MetadataState here");
+  return size_t(lhs) <= size_t(rhs);
+}
+
 /// Kinds of requests for metadata.
-template <class IntType>
-class TargetMetadataRequest : public FlagSet<IntType> {
+class MetadataRequest : public FlagSet<size_t> {
+  using IntType = size_t;
   using super = FlagSet<IntType>;
-public:
-  enum BasicKind : IntType {
-    /// A request for fully-completed metadata.  The metadata must be
-    /// prepared for all supported type operations.  This is a superset
-    /// of the requirements of LayoutComplete.
-    ///
-    /// For example, a class must be ready for subclassing and instantiation:
-    /// it must have a completed instance layout and (under ObjCInterop)
-    /// must have been realized by the Objective-C runtime.
-    Complete,
-
-    /// A request for metadata that can be used for type layout; that is,
-    /// the type's value witness table must be completely initialized.
-    LayoutComplete,
-
-    /// A request for a metadata pointer that fully identifies the type.
-    /// Basic type structure, such as the type context descriptor and the
-    /// list of generic arguments, should have been installed, but there is
-    /// no requirement for a valid value witness table.
-    Abstract,
-  };
-
-private:
   enum : IntType {
-    BasicKind_bit = 0,
-    BasicKind_width = 8,
+    State_bit = 0,
+    State_width = 8,
 
     /// A blocking request will not return until the runtime is able to produce
     /// metadata with the given kind.  A non-blocking request will return
@@ -1424,28 +1435,26 @@ private:
   };
 
 public:
-  TargetMetadataRequest(BasicKind kind, bool isNonBlocking = false) {
-    setBasicKind(kind);
+  MetadataRequest(MetadataState state, bool isNonBlocking = false) {
+    setState(state);
     setIsNonBlocking(isNonBlocking);
   }
-  explicit TargetMetadataRequest(IntType bits) : super(bits) {}
-  constexpr TargetMetadataRequest() {}
+  explicit MetadataRequest(IntType bits) : super(bits) {}
+  constexpr MetadataRequest() {}
 
-  FLAGSET_DEFINE_EQUALITY(TargetMetadataRequest)
+  FLAGSET_DEFINE_EQUALITY(MetadataRequest)
 
-  FLAGSET_DEFINE_FIELD_ACCESSORS(BasicKind_bit,
-                                 BasicKind_width,
-                                 BasicKind,
-                                 getBasicKind,
-                                 setBasicKind)
+  FLAGSET_DEFINE_FIELD_ACCESSORS(State_bit,
+                                 State_width,
+                                 MetadataState,
+                                 getState,
+                                 setState)
 
   FLAGSET_DEFINE_FLAG_ACCESSORS(NonBlocking_bit,
                                 isNonBlocking,
                                 setIsNonBlocking)
   bool isBlocking() const { return !isNonBlocking(); }
 };
-using MetadataRequest =
-  TargetMetadataRequest<size_t>;
 
 } // end namespace swift
 

--- a/include/swift/AST/CanTypeVisitor.h
+++ b/include/swift/AST/CanTypeVisitor.h
@@ -29,8 +29,7 @@ namespace swift {
 template<typename ImplClass, typename RetTy = void, typename... Args>
 class CanTypeVisitor {
 public:
-
-  template <class... As> RetTy visit(CanType T, Args... args) {
+  RetTy visit(CanType T, Args... args) {
     switch (T->getKind()) {
 #define UNCHECKED_TYPE(CLASS, PARENT) \
     case TypeKind::CLASS:

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -682,9 +682,24 @@ public:
   ///
   /// A type is SIL-illegal if it is:
   ///   - an l-value type,
-  ///   - an AST function type (i.e. subclasses of AnyFunctionType), or
+  ///   - a metatype without a representation,
+  ///   - an AST function type (i.e. subclasses of AnyFunctionType),
+  ///   - an optional whose object type is SIL-illegal, or
   ///   - a tuple type with a SIL-illegal element type.
   bool isLegalSILType();
+
+  /// \brief Determine whether this type is a legal formal type.
+  ///
+  /// A type is illegal as a formal type if it is:
+  ///   - an l-value type,
+  ///   - a reference storage type,
+  ///   - a metatype with a representation,
+  ///   - a lowered function type (i.e. SILFunctionType),
+  ///   - an optional whose object type is not a formal type, or
+  ///   - a tuple type with an element that is not a formal type.
+  ///
+  /// These are the types of the Swift type system.
+  bool isLegalFormalType();
 
   /// \brief Check if this type is equal to the empty tuple type.
   bool isVoid();

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -213,6 +213,7 @@ struct MetadataResponse {
   /// given metadata needs to be in before initialization can continue.
   MetadataRequest::BasicKind State;
 };
+using MetadataDependency = MetadataResponse;
 
 template <typename Runtime> struct TargetProtocolConformanceDescriptor;
 
@@ -3060,9 +3061,9 @@ struct MetadataCompletionContext {
 ///   some other type
 using MetadataCompleter =
   SWIFT_CC(swift)
-  MetadataResponse(const Metadata *type,
-                   MetadataCompletionContext *context,
-                   const TargetGenericMetadataPattern<InProcess> *pattern);
+  MetadataDependency(const Metadata *type,
+                     MetadataCompletionContext *context,
+                     const TargetGenericMetadataPattern<InProcess> *pattern);
 
 /// An instantiation pattern for type metadata.
 template <typename Runtime>
@@ -3277,7 +3278,7 @@ struct TargetTypeGenericContextDescriptorHeader {
 };
 using TypeGenericContextDescriptorHeader =
   TargetTypeGenericContextDescriptorHeader<InProcess>;
-  
+
 /// Wrapper class for the pointer to a metadata access function that provides
 /// operator() overloads to call it with the right calling convention.
 class MetadataAccessFunction {

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -211,7 +211,7 @@ struct MetadataResponse {
   ///
   /// For metadata initialization functions, this is the state that the
   /// given metadata needs to be in before initialization can continue.
-  MetadataRequest::BasicKind State;
+  MetadataState State;
 };
 using MetadataDependency = MetadataResponse;
 

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -3981,6 +3981,11 @@ swift_allocateGenericValueMetadata(const ValueTypeDescriptor *description,
                                    const GenericValueMetadataPattern *pattern,
                                    size_t extraDataSize);
 
+/// \brief Check that the given metadata has the right state.
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
+MetadataResponse swift_checkMetadataState(MetadataRequest request,
+                                          const Metadata *type);
+
 /// Instantiate a resilient or generic protocol witness table.
 ///
 /// \param genericTable - The witness table template for the

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -826,6 +826,13 @@ FUNCTION(AllocateGenericValueMetadata, swift_allocateGenericValueMetadata,
          ARGS(TypeContextDescriptorPtrTy, Int8PtrPtrTy, Int8PtrPtrTy, SizeTy),
          ATTRS(NoUnwind))
 
+// MetadataResponse swift_checkMetadataState(MetadataRequest request,
+//                                           cosnt Metadata *type);
+FUNCTION(CheckMetadataState, swift_checkMetadataState, SwiftCC,
+         RETURNS(TypeMetadataResponseTy),
+         ARGS(SizeTy, TypeMetadataPtrTy),
+         ATTRS(NoUnwind, ReadOnly))
+
 // const ProtocolWitnessTable *
 // swift_getGenericWitnessTable(GenericProtocolWitnessTable *genericTable,
 //                              const Metadata *type,

--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -223,12 +223,6 @@ public:
   static void applyFixedSpareBitsMask(SpareBitVector &mask,
                                       const SpareBitVector &spareBits);
   
-  /// Fixed-size types never need dynamic value witness table instantiation.
-  void initializeMetadata(IRGenFunction &IGF,
-                          llvm::Value *metadata,
-                          bool isVWTMutable,
-                          SILType T) const override {}
-
   void collectArchetypeMetadata(
       IRGenFunction &IGF,
       llvm::MapVector<CanType, llvm::Value *> &typeToMetadataVec,

--- a/lib/IRGen/Fulfillment.cpp
+++ b/lib/IRGen/Fulfillment.cpp
@@ -19,6 +19,7 @@
 #include "IRGenModule.h"
 
 #include "GenericRequirement.h"
+#include "MetadataRequest.h"
 #include "ProtocolInfo.h"
 #include "swift/AST/Decl.h"
 #include "swift/AST/ProtocolConformance.h"
@@ -109,6 +110,7 @@ static bool isLeafTypeMetadata(CanType type) {
 ///   metadata for the given type, false if it might be a subtype
 bool FulfillmentMap::searchTypeMetadata(IRGenModule &IGM, CanType type,
                                         IsExact_t isExact,
+                                        MetadataState metadataState,
                                         unsigned source, MetadataPath &&path,
                                         const InterestingKeysCallback &keys) {
 
@@ -118,26 +120,31 @@ bool FulfillmentMap::searchTypeMetadata(IRGenModule &IGM, CanType type,
     // If the type isn't a leaf type, also check it as an inexact match.
     bool hadFulfillment = false;
     if (!isLeafTypeMetadata(type)) {
-      hadFulfillment |= searchTypeMetadata(IGM, type, IsInexact, source,
-                                           MetadataPath(path), keys);
+      hadFulfillment |= searchTypeMetadata(IGM, type, IsInexact, metadataState,
+                                           source, MetadataPath(path), keys);
     }
 
     // Add the fulfillment.
-    hadFulfillment |= addFulfillment({type, nullptr}, source, std::move(path));
+    hadFulfillment |= addFulfillment({type, nullptr},
+                                     source, std::move(path), metadataState);
     return hadFulfillment;
   }
 
-  if (keys.isInterestingType(type)) {
+  // Search the superclass fields.  We can only do this if the metadata
+  // is complete.
+  if (metadataState == MetadataState::Complete &&
+      keys.isInterestingType(type)) {
     if (auto superclassTy = keys.getSuperclassBound(type)) {
-      return searchNominalTypeMetadata(IGM, superclassTy, source,
-                                       std::move(path), keys);
+      return searchNominalTypeMetadata(IGM, superclassTy, metadataState,
+                                       source, std::move(path), keys);
     }
   }
 
   // Inexact metadata will be a problem if we ever try to use this
   // to remember that we already have the metadata for something.
   if (isa<NominalType>(type) || isa<BoundGenericType>(type)) {
-    return searchNominalTypeMetadata(IGM, type, source, std::move(path), keys);
+    return searchNominalTypeMetadata(IGM, type, metadataState,
+                                     source, std::move(path), keys);
   }
 
   // TODO: tuples
@@ -218,7 +225,8 @@ bool FulfillmentMap::searchWitnessTable(
   // If we're not limiting the set of interesting conformances, or if
   // this is an interesting conformance, record it.
   if (!interestingConformances || interestingConformances->count(protocol)) {
-    hadFulfillment |= addFulfillment({type, protocol}, source, std::move(path));
+    hadFulfillment |= addFulfillment({type, protocol}, source,
+                                     std::move(path), MetadataState::Complete);
   }
 
   return hadFulfillment;
@@ -227,6 +235,7 @@ bool FulfillmentMap::searchWitnessTable(
 
 bool FulfillmentMap::searchNominalTypeMetadata(IRGenModule &IGM,
                                                CanType type,
+                                               MetadataState metadataState,
                                                unsigned source,
                                                MetadataPath &&path,
                                          const InterestingKeysCallback &keys) {
@@ -254,10 +263,12 @@ bool FulfillmentMap::searchNominalTypeMetadata(IRGenModule &IGM,
 
     // If the fulfilled value is type metadata, refine the path.
     if (!conf) {
+      auto argState = getPresumedMetadataStateForTypeArgument(metadataState);
       MetadataPath argPath = path;
       argPath.addNominalTypeArgumentComponent(reqtIndex);
       hadFulfillment |=
-        searchTypeMetadata(IGM, arg, IsExact, source, std::move(argPath), keys);
+        searchTypeMetadata(IGM, arg, IsExact, argState, source,
+                           std::move(argPath), keys);
       return;
     }
 
@@ -280,13 +291,24 @@ bool FulfillmentMap::searchNominalTypeMetadata(IRGenModule &IGM,
 
 /// Testify that there's a fulfillment at the given path.
 bool FulfillmentMap::addFulfillment(FulfillmentKey key,
-                                    unsigned source, MetadataPath &&path) {
+                                    unsigned source,
+                                    MetadataPath &&path,
+                                    MetadataState metadataState) {
   // Only add a fulfillment if we don't have any previous
   // fulfillment for that value or if it 's cheaper than the existing
   // fulfillment.
   auto it = Fulfillments.find(key);
   if (it != Fulfillments.end()) {
-    if (path.cost() >= it->second.Path.cost()) {
+    // If the new fulfillment is worse than the existing one, ignore it.
+    auto existingState = it->second.getState();
+    if (!isAtLeast(metadataState, existingState)) {
+      return false;
+    }
+
+    // Consider cost only if the fulfillments are equivalent in state.
+    // TODO: this is potentially suboptimal, but it generally won't matter.
+    if (metadataState == existingState && 
+        path.cost() >= it->second.Path.cost()) {
       return false;
     }
 
@@ -294,8 +316,17 @@ bool FulfillmentMap::addFulfillment(FulfillmentKey key,
     it->second.Path = std::move(path);
     return true;
   } else {
-    Fulfillments.insert({ key, Fulfillment(source, std::move(path)) });
+    Fulfillments.insert({ key, Fulfillment(source, std::move(path),
+                                           metadataState) });
     return true;
+  }
+}
+
+static StringRef getStateName(MetadataState state) {
+  switch (state) {
+  case MetadataState::Complete: return "complete";
+  case MetadataState::LayoutComplete: return "layout-complete";
+  case MetadataState::Abstract: return "abstract";
   }
 }
 
@@ -306,7 +337,8 @@ void FulfillmentMap::dump() const {
     if (auto proto = entry.first.second) {
       out << ", " << proto->getNameStr();
     }
-    out << ") => sources[" << entry.second.SourceIndex
+    out << ") => " << getStateName(entry.second.getState())
+        << " at sources[" << entry.second.SourceIndex
         << "]." << entry.second.Path << "\n";
   }
 }

--- a/lib/IRGen/Fulfillment.h
+++ b/lib/IRGen/Fulfillment.h
@@ -32,14 +32,19 @@ namespace irgen {
 /// path from the given source.
 struct Fulfillment {
   Fulfillment() = default;
-  Fulfillment(unsigned sourceIndex, MetadataPath &&path)
-    : SourceIndex(sourceIndex), Path(std::move(path)) {}
+  Fulfillment(unsigned sourceIndex, MetadataPath &&path, MetadataState state)
+    : SourceIndex(sourceIndex), State(unsigned(state)), Path(std::move(path)) {}
 
   /// The source index.
-  unsigned SourceIndex;
+  unsigned SourceIndex : 30;
+
+  /// The state of the metadata at the fulfillment.
+  unsigned State : 2;
 
   /// The path from the source metadata.
   MetadataPath Path;
+
+  MetadataState getState() const { return MetadataState(State); }
 };
 
 class FulfillmentMap {
@@ -90,6 +95,7 @@ public:
   ///
   /// \return true if any fulfillments were added by this search.
   bool searchTypeMetadata(IRGenModule &IGM, CanType type, IsExact_t isExact,
+                          MetadataState metadataState,
                           unsigned sourceIndex, MetadataPath &&path,
                           const InterestingKeysCallback &interestingKeys);
 
@@ -109,7 +115,8 @@ public:
   ///
   /// \return true if the fulfillment was added, which won't happen if there's
   ///   already a fulfillment that was at least as good
-  bool addFulfillment(FulfillmentKey key, unsigned source, MetadataPath &&path);
+  bool addFulfillment(FulfillmentKey key, unsigned source,
+                      MetadataPath &&path, MetadataState state);
 
   const Fulfillment *getTypeMetadata(CanType type) const {
     auto it = Fulfillments.find({type, nullptr});
@@ -139,7 +146,8 @@ public:
 
 private:
   bool searchNominalTypeMetadata(IRGenModule &IGM, CanType type,
-                                 unsigned source, MetadataPath &&path,
+                                 MetadataState metadataState, unsigned source,
+                                 MetadataPath &&path,
                                  const InterestingKeysCallback &keys);
 
   /// Search the given witness table for useful fulfillments.

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -73,7 +73,7 @@ irgen::emitArchetypeTypeMetadataRef(IRGenFunction &IGF,
 
   setTypeMetadataName(IGF.IGM, response.getMetadata(), archetype);
 
-  IGF.setScopedLocalTypeMetadata(archetype, request, response);
+  IGF.setScopedLocalTypeMetadata(archetype, response);
 
   return response;
 }
@@ -279,12 +279,15 @@ llvm::Value *irgen::emitArchetypeWitnessTableRef(IRGenFunction &IGF,
   }
   assert(lastProtocol == protocol);
 
-  auto rootWTable = IGF.getLocalTypeData(rootArchetype,
+  auto rootWTable = IGF.tryGetLocalTypeData(rootArchetype,
               LocalTypeDataKind::forAbstractProtocolWitnessTable(rootProtocol));
+  assert(rootWTable && "root witness table not bound in local context!");
 
   wtable = path.followFromWitnessTable(IGF, rootArchetype,
                                        ProtocolConformanceRef(rootProtocol),
-                                       rootWTable, nullptr);
+                                       MetadataResponse::forComplete(rootWTable),
+                                       /*request*/ MetadataState::Complete,
+                                       nullptr).getMetadata();
 
   return wtable;
 }
@@ -300,7 +303,7 @@ irgen::emitAssociatedTypeMetadataRef(IRGenFunction &IGF,
 
   // Find the origin's type metadata.
   llvm::Value *originMetadata =
-    emitArchetypeTypeMetadataRef(IGF, origin, MetadataState::Complete)
+    emitArchetypeTypeMetadataRef(IGF, origin, MetadataState::Abstract)
       .getMetadata();
 
   return emitAssociatedTypeMetadataRef(IGF, originMetadata, wtable,
@@ -378,11 +381,11 @@ const TypeInfo *TypeConverter::convertArchetypeType(ArchetypeType *archetype) {
 
 static void setMetadataRef(IRGenFunction &IGF,
                            ArchetypeType *archetype,
-                           llvm::Value *metadata) {
+                           llvm::Value *metadata,
+                           MetadataState metadataState) {
   assert(metadata->getType() == IGF.IGM.TypeMetadataPtrTy);
-  IGF.setUnscopedLocalTypeData(CanType(archetype),
-                               LocalTypeDataKind::forFormalTypeMetadata(),
-                               metadata);
+  IGF.setUnscopedLocalTypeMetadata(CanType(archetype),
+                         MetadataResponse::forBounded(metadata, metadataState));
 }
 
 static void setWitnessTable(IRGenFunction &IGF,
@@ -401,10 +404,11 @@ static void setWitnessTable(IRGenFunction &IGF,
 /// witness value within this scope.
 void IRGenFunction::bindArchetype(ArchetypeType *archetype,
                                   llvm::Value *metadata,
+                                  MetadataState metadataState,
                                   ArrayRef<llvm::Value*> wtables) {
   // Set the metadata pointer.
   setTypeMetadataName(IGM, metadata, CanType(archetype));
-  setMetadataRef(*this, archetype, metadata);
+  setMetadataRef(*this, archetype, metadata, metadataState);
 
   // Set the protocol witness tables.
 

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -300,7 +300,7 @@ irgen::emitAssociatedTypeMetadataRef(IRGenFunction &IGF,
 
   // Find the origin's type metadata.
   llvm::Value *originMetadata =
-    emitArchetypeTypeMetadataRef(IGF, origin, MetadataRequest::Complete)
+    emitArchetypeTypeMetadataRef(IGF, origin, MetadataState::Complete)
       .getMetadata();
 
   return emitAssociatedTypeMetadataRef(IGF, originMetadata, wtable,
@@ -427,7 +427,7 @@ llvm::Value *irgen::emitDynamicTypeOfOpaqueArchetype(IRGenFunction &IGF,
 
   // Acquire the archetype's static metadata.
   llvm::Value *metadata =
-    emitArchetypeTypeMetadataRef(IGF, archetype, MetadataRequest::Complete)
+    emitArchetypeTypeMetadataRef(IGF, archetype, MetadataState::Complete)
       .getMetadata();
   return IGF.Builder.CreateCall(IGF.IGM.getGetDynamicTypeFn(),
                                 {addr.getAddress(), metadata,

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -73,7 +73,7 @@ irgen::emitArchetypeTypeMetadataRef(IRGenFunction &IGF,
 
   setTypeMetadataName(IGF.IGM, response.getMetadata(), archetype);
 
-  IGF.setScopedLocalTypeMetadata(archetype, response);
+  IGF.setScopedLocalTypeMetadata(archetype, request, response);
 
   return response;
 }
@@ -381,7 +381,7 @@ static void setMetadataRef(IRGenFunction &IGF,
                            llvm::Value *metadata) {
   assert(metadata->getType() == IGF.IGM.TypeMetadataPtrTy);
   IGF.setUnscopedLocalTypeData(CanType(archetype),
-                               LocalTypeDataKind::forTypeMetadata(),
+                               LocalTypeDataKind::forFormalTypeMetadata(),
                                metadata);
 }
 

--- a/lib/IRGen/GenCast.cpp
+++ b/lib/IRGen/GenCast.cpp
@@ -115,6 +115,7 @@ FailableCastResult irgen::emitClassIdenticalCast(IRGenFunction &IGF,
     targetMetadata
       = emitClassHeapMetadataRef(IGF, toType.getSwiftRValueType(),
                                  MetadataValueType::ObjCClass,
+                                 MetadataState::Complete,
                                  /*allowUninitialized*/ allowConservative);
   }
 
@@ -248,7 +249,8 @@ void irgen::emitMetatypeDowncast(IRGenFunction &IGF,
 
     // Get the ObjC metadata for the type we're checking.
     toMetadata = emitClassHeapMetadataRef(IGF, toMetatype.getInstanceType(),
-                                          MetadataValueType::ObjCClass);
+                                          MetadataValueType::ObjCClass,
+                                          MetadataState::Complete);
     switch (mode) {
     case CheckedCastMode::Unconditional:
       castFn = IGF.IGM.getDynamicCastObjCClassMetatypeUnconditionalFn();

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -757,13 +757,15 @@ llvm::Value *irgen::emitClassAllocation(IRGenFunction &IGF, SILType selfType,
   if (objc) {
     llvm::Value *metadata =
       emitClassHeapMetadataRef(IGF, classType, MetadataValueType::ObjCClass,
+                               MetadataState::Complete,
                                /*allow uninitialized*/ true);
     StackAllocSize = -1;
     return emitObjCAllocObjectCall(IGF, metadata, selfType);
   }
 
   llvm::Value *metadata =
-    emitClassHeapMetadataRef(IGF, classType, MetadataValueType::TypeMetadata);
+    emitClassHeapMetadataRef(IGF, classType, MetadataValueType::TypeMetadata,
+                             MetadataState::Complete);
 
   // FIXME: Long-term, we clearly need a specialized runtime entry point.
   llvm::Value *size, *alignMask;
@@ -2440,7 +2442,8 @@ FunctionPointer irgen::emitVirtualMethodValue(IRGenFunction &IGF,
       // dynamically.
 
       metadata = emitClassHeapMetadataRef(IGF, instanceTy.getSwiftRValueType(),
-                                          MetadataValueType::TypeMetadata);
+                                          MetadataValueType::TypeMetadata,
+                                          MetadataState::Complete);
       auto superField = emitAddressOfSuperclassRefInClassMetadata(IGF, metadata);
       metadata = IGF.Builder.CreateLoad(superField);
     } else {
@@ -2448,7 +2451,8 @@ FunctionPointer irgen::emitVirtualMethodValue(IRGenFunction &IGF,
       // metadata.
       auto superTy = instanceTy.getSuperclass();
       metadata = emitClassHeapMetadataRef(IGF, superTy.getSwiftRValueType(),
-                                          MetadataValueType::TypeMetadata);
+                                          MetadataValueType::TypeMetadata,
+                                          MetadataState::Complete);
     }
   } else {
     if ((isa<FuncDecl>(methodDecl) && cast<FuncDecl>(methodDecl)->isStatic()) ||

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -5379,12 +5379,6 @@ namespace {
                         SILType T, bool isOutlined) const override {
       return Strategy.assignWithTake(IGF, dest, src, T, isOutlined);
     }
-    void initializeMetadata(IRGenFunction &IGF,
-                            llvm::Value *metadata,
-                            bool isVWTMutable,
-                            SILType T) const override {
-      return Strategy.initializeMetadata(IGF, metadata, isVWTMutable, T);
-    }
     bool mayHaveExtraInhabitants(IRGenModule &IGM) const override {
       return Strategy.mayHaveExtraInhabitants(IGM);
     }

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -122,6 +122,7 @@
 #include "IRGenMangler.h"
 #include "IRGenModule.h"
 #include "LoadableTypeInfo.h"
+#include "MetadataRequest.h"
 #include "NonFixedTypeInfo.h"
 #include "ResilientTypeInfo.h"
 #include "ScalarTypeInfo.h"
@@ -593,7 +594,8 @@ namespace {
     void initializeMetadata(IRGenFunction &IGF,
                             llvm::Value *metadata,
                             bool isVWTMutable,
-                            SILType T) const override {
+                            SILType T,
+                        MetadataDependencyCollector *collector) const override {
       // Fixed-size enums don't need dynamic witness table initialization.
       if (TIK >= Fixed) return;
 
@@ -602,7 +604,7 @@ namespace {
 
       auto payloadTy = T.getEnumElementType(ElementsWithPayload[0].decl,
                                             IGM.getSILModule());
-      auto payloadLayout = IGF.emitTypeLayoutRef(payloadTy);
+      auto payloadLayout = emitTypeLayoutRef(IGF, payloadTy, collector);
       auto flags = emitEnumLayoutFlags(IGF.IGM, isVWTMutable);
       IGF.Builder.CreateCall(
                     IGF.IGM.getInitEnumMetadataSingleCaseFn(),
@@ -858,7 +860,8 @@ namespace {
     void initializeMetadata(IRGenFunction &IGF,
                             llvm::Value *metadata,
                             bool isVWTMutable,
-                            SILType T) const override {
+                            SILType T,
+                        MetadataDependencyCollector *collector) const override {
       // No-payload enums are always fixed-size so never need dynamic value
       // witness table initialization.
     }
@@ -2829,7 +2832,8 @@ namespace {
     void initializeMetadata(IRGenFunction &IGF,
                             llvm::Value *metadata,
                             bool isVWTMutable,
-                            SILType T) const override {
+                            SILType T,
+                        MetadataDependencyCollector *collector) const override {
       // Fixed-size enums don't need dynamic witness table initialization.
       if (TIK >= Fixed) return;
 
@@ -2837,7 +2841,7 @@ namespace {
       // of empty cases.
       auto payloadTy = T.getEnumElementType(ElementsWithPayload[0].decl,
                                             IGM.getSILModule());
-      auto payloadLayout = IGF.emitTypeLayoutRef(payloadTy);
+      auto payloadLayout = emitTypeLayoutRef(IGF, payloadTy, collector);
       auto emptyCasesVal = llvm::ConstantInt::get(IGF.IGM.Int32Ty,
                                                   ElementsWithNoPayload.size());
       auto flags = emitEnumLayoutFlags(IGF.IGM, isVWTMutable);
@@ -4697,7 +4701,8 @@ namespace {
       }
     }
 
-    llvm::Value *emitPayloadLayoutArray(IRGenFunction &IGF, SILType T) const {
+    llvm::Value *emitPayloadLayoutArray(IRGenFunction &IGF, SILType T,
+                                 MetadataDependencyCollector *collector) const {
       auto numPayloads = ElementsWithPayload.size();
       auto metadataBufferTy = llvm::ArrayType::get(IGF.IGM.Int8PtrPtrTy,
                                                    numPayloads);
@@ -4713,7 +4718,7 @@ namespace {
         
         auto payloadTy = T.getEnumElementType(elt.decl, IGF.getSILModule());
         
-        auto metadata = IGF.emitTypeLayoutRef(payloadTy);
+        auto metadata = emitTypeLayoutRef(IGF, payloadTy, collector);
         
         IGF.Builder.CreateStore(metadata, eltAddr);
       }
@@ -4725,12 +4730,13 @@ namespace {
     void initializeMetadata(IRGenFunction &IGF,
                             llvm::Value *metadata,
                             bool isVWTMutable,
-                            SILType T) const override {
+                            SILType T,
+                        MetadataDependencyCollector *collector) const override {
       // Fixed-size enums don't need dynamic metadata initialization.
       if (TIK >= Fixed) return;
       
       // Ask the runtime to set up the metadata record for a dynamic enum.
-      auto payloadLayoutArray = emitPayloadLayoutArray(IGF, T);
+      auto payloadLayoutArray = emitPayloadLayoutArray(IGF, T, collector);
       auto numPayloadsVal = llvm::ConstantInt::get(IGF.IGM.SizeTy,
                                                    ElementsWithPayload.size());
 
@@ -5136,7 +5142,8 @@ namespace {
     void initializeMetadata(IRGenFunction &IGF,
                             llvm::Value *metadata,
                             bool isVWTMutable,
-                            SILType T) const override {
+                            SILType T,
+                        MetadataDependencyCollector *collector) const override {
       llvm_unreachable("resilient enums cannot be defined");
     }
 

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -38,6 +38,7 @@ namespace irgen {
   class EnumPayload;
   class EnumPayloadSchema;
   class IRGenFunction;
+  class MetadataDependencyCollector;
   class TypeConverter;
   using clang::CodeGen::swiftcall::SwiftAggLowering;
 
@@ -369,7 +370,8 @@ public:
   virtual void initializeMetadata(IRGenFunction &IGF,
                                   llvm::Value *metadata,
                                   bool isVWTMutable,
-                                  SILType T) const = 0;
+                                  SILType T,
+                              MetadataDependencyCollector *collector) const = 0;
 
   virtual bool mayHaveExtraInhabitants(IRGenModule &IGM) const = 0;
 

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -1622,7 +1622,8 @@ Address irgen::emitOpenExistentialBox(IRGenFunction &IGF,
                                                  2 * IGF.IGM.getPointerSize());
   auto witness = IGF.Builder.CreateLoad(witnessAddr);
   
-  IGF.bindArchetype(openedArchetype, metadata, witness);
+  IGF.bindArchetype(openedArchetype, metadata, MetadataState::Complete,
+                    witness);
   return box.getAddress();
 }
 
@@ -1924,7 +1925,8 @@ irgen::emitClassExistentialProjection(IRGenFunction &IGF,
   llvm::Value *value;
   std::tie(wtables, value) = baseTI.getWitnessTablesAndValue(base);
   auto metadata = emitDynamicTypeOfOpaqueHeapObject(IGF, value);
-  IGF.bindArchetype(openedArchetype, metadata, wtables);
+  IGF.bindArchetype(openedArchetype, metadata, MetadataState::Complete,
+                    wtables);
 
   return value;
 }
@@ -1973,7 +1975,8 @@ irgen::emitExistentialMetatypeProjection(IRGenFunction &IGF,
   }
 
   auto openedArchetype = cast<ArchetypeType>(targetType.getInstanceType());
-  IGF.bindArchetype(openedArchetype, metatype, wtables);
+  IGF.bindArchetype(openedArchetype, metatype, MetadataState::Complete,
+                    wtables);
 
   return value;
 }
@@ -2271,7 +2274,8 @@ Address irgen::emitOpaqueBoxedExistentialProjection(
         wtables.push_back(IGF.Builder.CreateLoad(wtableAddr));
       }
 
-      IGF.bindArchetype(openedArchetype, metadata, wtables);
+      IGF.bindArchetype(openedArchetype, metadata, MetadataState::Complete,
+                        wtables);
     }
 
     return valueAddr;
@@ -2289,7 +2293,8 @@ Address irgen::emitOpaqueBoxedExistentialProjection(
     for (unsigned i = 0, n = layout.getNumTables(); i != n; ++i) {
       wtables.push_back(layout.loadWitnessTable(IGF, base, i));
     }
-    IGF.bindArchetype(openedArchetype, metadata, wtables);
+    IGF.bindArchetype(openedArchetype, metadata, MetadataState::Complete,
+                      wtables);
   }
 
   Address buffer = layout.projectExistentialBuffer(IGF, base);

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -933,7 +933,8 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
       // The bindings should be fixed-layout inside the object, so we can
       // pass None here. If they weren't, we'd have a chicken-egg problem.
       auto bindingsAddr = bindingLayout.project(subIGF, data, /*offsets*/ None);
-      layout->getBindings().restore(subIGF, bindingsAddr);
+      layout->getBindings().restore(subIGF, bindingsAddr,
+                                    MetadataState::Complete);
     }
 
   // There's still a placeholder to claim if the target type is thick

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -224,7 +224,7 @@ static llvm::Function *createDtorFn(IRGenModule &IGM,
     // The type metadata bindings should be at a fixed offset, so we can pass
     // None for NonFixedOffsets. If we didn't, we'd have a chicken-egg problem.
     auto bindingsAddr = layout.getElement(0).project(IGF, structAddr, None);
-    layout.getBindings().restore(IGF, bindingsAddr);
+    layout.getBindings().restore(IGF, bindingsAddr, MetadataState::Complete);
   }
 
   // Figure out the non-fixed offsets.

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -81,6 +81,7 @@ bindPolymorphicArgumentsFromComponentIndices(IRGenFunction &IGF,
   }
   bindFromGenericRequirementsBuffer(IGF, requirements,
     Address(args, IGF.IGM.getPointerAlignment()),
+    MetadataState::Complete,
     [&](CanType t) {
       return genericEnv->mapTypeIntoContext(t)->getCanonicalType();
     });
@@ -274,6 +275,7 @@ getLayoutFunctionForComputedComponent(IRGenModule &IGM,
     if (genericEnv) {
       bindFromGenericRequirementsBuffer(IGF, requirements,
         Address(args, IGF.IGM.getPointerAlignment()),
+        MetadataState::Complete,
         [&](CanType t) {
           return genericEnv->mapTypeIntoContext(t)->getCanonicalType();
         });
@@ -547,6 +549,7 @@ getInitializerForComputedComponent(IRGenModule &IGM,
       // Bind the generic environment from the argument buffer.
       bindFromGenericRequirementsBuffer(IGF, requirements,
         Address(src, IGF.IGM.getPointerAlignment()),
+        MetadataState::Complete,
         [&](CanType t) {
           return genericEnv->mapTypeIntoContext(t)->getCanonicalType();
         });
@@ -673,6 +676,7 @@ emitGeneratorForKeyPath(IRGenModule &IGM,
       
       bindFromGenericRequirementsBuffer(IGF, requirements,
             Address(bindingsBufPtr, IGM.getPointerAlignment()),
+            MetadataState::Complete,
             [&](CanType t) {
               return genericEnv->mapTypeIntoContext(t)->getCanonicalType();
             });

--- a/lib/IRGen/GenMeta.h
+++ b/lib/IRGen/GenMeta.h
@@ -110,13 +110,6 @@ namespace irgen {
                              llvm::Function *fn,
                              ArrayRef<FieldTypeInfo> fieldTypes);
 
-  /// \brief Initialize the field offset vector within the given class or struct
-  /// metadata.
-  void emitInitializeFieldOffsetVector(IRGenFunction &IGF,
-                                       SILType T,
-                                       llvm::Value *metadata,
-                                       bool isVWTMutable);
-
   /// Adjustment indices for the address points of various metadata.
   /// Size is in words.
   namespace MetadataAdjustmentIndex {

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -581,6 +581,7 @@ static llvm::Value *emitSuperArgument(IRGenFunction &IGF,
   if (isInstanceMethod) {
     searchValue = emitClassHeapMetadataRef(IGF, searchClass,
                                            MetadataValueType::ObjCClass,
+                                           MetadataState::Complete,
                                            /*allow uninitialized*/ true);
   } else {
     searchClass = cast<MetatypeType>(searchClass).getInstanceType();
@@ -588,6 +589,7 @@ static llvm::Value *emitSuperArgument(IRGenFunction &IGF,
     if (doesClassMetadataRequireDynamicInitialization(IGF.IGM, searchClassDecl)) {
       searchValue = emitClassHeapMetadataRef(IGF, searchClass,
                                              MetadataValueType::ObjCClass,
+                                             MetadataState::Complete,
                                              /*allow uninitialized*/ true);
       searchValue = emitLoadOfObjCHeapMetadataRef(IGF, searchValue);
       searchValue = IGF.Builder.CreateBitCast(searchValue, IGF.IGM.ObjCClassPtrTy);

--- a/lib/IRGen/GenOpaque.cpp
+++ b/lib/IRGen/GenOpaque.cpp
@@ -354,20 +354,18 @@ emitLoadOfValueWitnessFunctionFromMetadata(IRGenFunction &IGF,
   return emitLoadOfValueWitnessFunction(IGF, vwtable, index);
 }
 
-llvm::Value * IRGenFunction::emitValueWitnessValue(SILType type,
-                                                   ValueWitness index) {
+llvm::Value *IRGenFunction::emitValueWitnessValue(SILType type,
+                                                  ValueWitness index) {
   assert(!isValueWitnessFunction(index));
 
-  if (auto witness = tryGetLocalTypeDataForLayout(type,
-                                LocalTypeDataKind::forValueWitness(index))) {
+  auto key = LocalTypeDataKind::forValueWitness(index);
+  if (auto witness = tryGetLocalTypeDataForLayout(type, key)) {
     return witness;
   }
   
   auto vwtable = emitValueWitnessTableRef(type);
   auto witness = emitLoadOfValueWitnessValue(*this, vwtable, index);
-  setScopedLocalTypeDataForLayout(type,
-                                  LocalTypeDataKind::forValueWitness(index),
-                                  witness);
+  setScopedLocalTypeDataForLayout(type, key, witness);
   return witness;
 }
 
@@ -377,8 +375,8 @@ IRGenFunction::emitValueWitnessFunctionRef(SILType type,
                                            ValueWitness index) {
   assert(isValueWitnessFunction(index));
 
-  if (auto witness = tryGetLocalTypeDataForLayout(type,
-                                LocalTypeDataKind::forValueWitness(index))) {
+  auto key = LocalTypeDataKind::forValueWitness(index);
+  if (auto witness = tryGetLocalTypeDataForLayout(type, key)) {
     metadataSlot = emitTypeMetadataRefForLayout(type);
     auto signature = IGM.getValueWitnessSignature(index);
     return FunctionPointer(witness, signature);
@@ -386,9 +384,7 @@ IRGenFunction::emitValueWitnessFunctionRef(SILType type,
   
   auto vwtable = emitValueWitnessTableRef(type, &metadataSlot);
   auto witness = emitLoadOfValueWitnessFunction(*this, vwtable, index);
-  setScopedLocalTypeDataForLayout(type,
-                                  LocalTypeDataKind::forValueWitness(index),
-                                  witness.getPointer());
+  setScopedLocalTypeDataForLayout(type, key, witness.getPointer());
   return witness;
 }
 

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -225,7 +225,8 @@ void PolymorphicConvention::addPseudogenericFulfillments() {
 
     unsigned sourceIndex = 0; // unimportant, since impossible
     Fulfillments.addFulfillment({reqt.TypeParameter, reqt.Protocol},
-                                sourceIndex, std::move(path));
+                                sourceIndex, std::move(path),
+                                MetadataState::Complete);
   });
 }
 
@@ -307,7 +308,8 @@ bool PolymorphicConvention::considerType(CanType type, IsExact_t isExact,
                                          unsigned sourceIndex,
                                          MetadataPath &&path) {
   FulfillmentMapCallback callbacks(*this);
-  return Fulfillments.searchTypeMetadata(IGM, type, isExact, sourceIndex,
+  return Fulfillments.searchTypeMetadata(IGM, type, isExact,
+                                         MetadataState::Complete, sourceIndex,
                                          std::move(path), callbacks);
 }
 
@@ -415,14 +417,16 @@ void PolymorphicConvention::considerParameter(SILParameterInfo param,
 
 void PolymorphicConvention::addSelfMetadataFulfillment(CanType arg) {
   unsigned source = Sources.size() - 1;
-  Fulfillments.addFulfillment({arg, nullptr}, source, MetadataPath());
+  Fulfillments.addFulfillment({arg, nullptr},
+                              source, MetadataPath(), MetadataState::Complete);
 }
 
 void PolymorphicConvention::addSelfWitnessTableFulfillment(
     CanType arg, ProtocolConformanceRef conformance) {
   auto proto = conformance.getRequirement();
   unsigned source = Sources.size() - 1;
-  Fulfillments.addFulfillment({arg, proto}, source, MetadataPath());
+  Fulfillments.addFulfillment({arg, proto},
+                              source, MetadataPath(), MetadataState::Complete);
 
   if (conformance.isConcrete()) {
     FulfillmentMapCallback callbacks(*this);
@@ -521,7 +525,8 @@ void EmitPolymorphicParameters::bindExtraSource(const MetadataSource &source,
       llvm::Value *metadata = in.claimNext();
       setTypeMetadataName(IGF.IGM, metadata, argTy);
 
-      IGF.bindLocalTypeDataFromTypeMetadata(argTy, IsExact, metadata);
+      IGF.bindLocalTypeDataFromTypeMetadata(argTy, IsExact, metadata,
+                                            MetadataState::Complete);
       return;
     }
 
@@ -540,7 +545,8 @@ void EmitPolymorphicParameters::bindExtraSource(const MetadataSource &source,
       // type, and so the self metadata will be inexact. Currently, all
       // conformances are inheritable.
       IGF.bindLocalTypeDataFromTypeMetadata(
-          argTy, (!CD || CD->isFinal()) ? IsExact : IsInexact, metadata);
+          argTy, (!CD || CD->isFinal()) ? IsExact : IsInexact, metadata,
+                                            MetadataState::Complete);
       return;
     }
 
@@ -606,7 +612,8 @@ bindParameterSource(SILParameterInfo param, unsigned paramIndex,
     if (metatype->getRepresentation() == MetatypeRepresentation::Thick) {
       paramType = metatype.getInstanceType();
       llvm::Value *metadata = getParameter(paramIndex);
-      IGF.bindLocalTypeDataFromTypeMetadata(paramType, IsInexact, metadata);
+      IGF.bindLocalTypeDataFromTypeMetadata(paramType, IsInexact, metadata,
+                                            MetadataState::Complete);
     }
     return;
   }
@@ -621,7 +628,8 @@ bindParameterSource(SILParameterInfo param, unsigned paramIndex,
     SILType instanceType = SILType::getPrimitiveObjectType(paramType);
     llvm::Value *metadata =
     emitDynamicTypeOfHeapObject(IGF, instanceRef, instanceType);
-    IGF.bindLocalTypeDataFromTypeMetadata(paramType, IsInexact, metadata);
+    IGF.bindLocalTypeDataFromTypeMetadata(paramType, IsInexact, metadata,
+                                          MetadataState::Complete);
     return;
   }
 }
@@ -679,7 +687,8 @@ void BindPolymorphicParameter::emit(Explosion &nativeParam, unsigned paramIndex)
   SILType instanceType = SILType::getPrimitiveObjectType(paramType);
   llvm::Value *metadata =
     emitDynamicTypeOfHeapObject(IGF, instanceRef, instanceType);
-  IGF.bindLocalTypeDataFromTypeMetadata(paramType, IsInexact, metadata);
+  IGF.bindLocalTypeDataFromTypeMetadata(paramType, IsInexact, metadata,
+                                        MetadataState::Complete);
 }
 
 void irgen::bindPolymorphicParameter(IRGenFunction &IGF,
@@ -1421,6 +1430,7 @@ public:
           }
         } callback;
         Fulfillments->searchTypeMetadata(IGM, ConcreteType, IsExact,
+                                         MetadataState::Abstract,
                                          /*sourceIndex*/ 0, MetadataPath(),
                                          callback);
       }
@@ -1481,21 +1491,27 @@ getAssociatedTypeMetadataAccessFunction(AssociatedType requirement,
   // is expensive.
   if (auto fulfillment =
         getFulfillmentMap().getTypeMetadata(associatedType)) {
-    llvm::Value *metadata =
-      fulfillment->Path.followFromTypeMetadata(IGF, ConcreteType, self,
-                                               /*cache*/ nullptr);
-    auto returnValue = MetadataResponse::forComplete(metadata).combine(IGF);
+    // We don't know that 'self' is any better than an abstract metadata here.
+    auto source = MetadataResponse::forBounded(self, MetadataState::Abstract);
+
+    MetadataResponse response =
+      fulfillment->Path.followFromTypeMetadata(IGF, ConcreteType, source,
+                                               request, /*cache*/ nullptr);
+    response.ensureDynamicState(IGF);
+    auto returnValue = response.combine(IGF);
     IGF.Builder.CreateRet(returnValue);
     return accessor;
   }
 
   // Bind local type data from the metadata argument.
-  IGF.bindLocalTypeDataFromTypeMetadata(ConcreteType, IsExact, self);
+  IGF.bindLocalTypeDataFromTypeMetadata(ConcreteType, IsExact, self,
+                                        MetadataState::Abstract);
 
   // For now, assume that an associated type is cheap enough to access
   // that it doesn't need a new cache entry.
   if (auto archetype = dyn_cast<ArchetypeType>(associatedType)) {
     auto response = emitArchetypeTypeMetadataRef(IGF, archetype, request);
+    response.ensureDynamicState(IGF);
     auto returnValue = response.combine(IGF);
     IGF.Builder.CreateRet(returnValue);
     return accessor;
@@ -1627,17 +1643,24 @@ getAssociatedTypeWitnessTableAccessFunction(AssociatedConformance requirement,
   if (auto fulfillment =
         getFulfillmentMap().getWitnessTable(associatedType,
                                             associatedProtocol)) {
+    // We don't know that 'self' is any better than an abstract metadata here.
+    auto source = MetadataResponse::forBounded(self, MetadataState::Abstract);
+
     llvm::Value *wtable =
-      fulfillment->Path.followFromTypeMetadata(IGF, ConcreteType, self,
-                                               /*cache*/ nullptr);
+      fulfillment->Path.followFromTypeMetadata(IGF, ConcreteType, source,
+                                               MetadataState::Complete,
+                                               /*cache*/ nullptr)
+                       .getMetadata();
     IGF.Builder.CreateRet(wtable);
     return accessor;
   }
 
   // Bind local type data from the metadata arguments.
   IGF.bindLocalTypeDataFromTypeMetadata(associatedType, IsExact,
-                                        associatedTypeMetadata);
-  IGF.bindLocalTypeDataFromTypeMetadata(ConcreteType, IsExact, self);
+                                        associatedTypeMetadata,
+                                        MetadataState::Abstract);
+  IGF.bindLocalTypeDataFromTypeMetadata(ConcreteType, IsExact, self,
+                                        MetadataState::Abstract);
 
   // For now, assume that finding an abstract conformance is always
   // fast enough that it's not worth caching.
@@ -1709,7 +1732,8 @@ emitReturnOfCheckedLoadFromCache(IRGenFunction &IGF, Address destTable,
     resultState->addIncoming(completedState, entryBB);
 
     llvm::Value *returnValue =
-      MetadataResponse(result, resultState).combine(IGF);
+      MetadataResponse(result, resultState, MetadataState::Abstract)
+        .combine(IGF);
     IGF.Builder.CreateRet(returnValue);
   } else {
     IGF.Builder.CreateRet(result);
@@ -1722,11 +1746,14 @@ emitReturnOfCheckedLoadFromCache(IRGenFunction &IGF, Address destTable,
   // The way we jam witness tables into this infrastructure involves
   // pretending that they're statically-complete metadata.
   assert(isReturningResponse || response.isStaticallyKnownComplete());
-  llvm::Value *fetchedResult = response.getMetadata();
-  llvm::Value *fetchedState = nullptr;
 
-  if (isReturningResponse)
-    fetchedState = response.getDynamicState(IGF);
+  llvm::Value *fetchedState = nullptr;
+  if (isReturningResponse) {
+    response.ensureDynamicState(IGF);
+    fetchedState = response.getDynamicState();
+  }
+
+  llvm::Value *fetchedResult = response.getMetadata();
 
   // Skip caching if we're working with responses and the fetched result
   // is not complete.
@@ -2119,36 +2146,39 @@ void EmitPolymorphicParameters::emit(Explosion &in,
   // Collect any concrete type metadata that's been passed separately.
   enumerateUnfulfilledRequirements([&](GenericRequirement requirement) {
     auto value = in.claimNext();
-    bindGenericRequirement(IGF, requirement, value, getInContext);
+    bindGenericRequirement(IGF, requirement, value, MetadataState::Complete,
+                           getInContext);
   });
 
   // Bind all the fulfillments we can from the formal parameters.
   bindParameterSources(getParameter);
 }
 
-llvm::Value *
+MetadataResponse
 MetadataPath::followFromTypeMetadata(IRGenFunction &IGF,
                                      CanType sourceType,
-                                     llvm::Value *source,
-                                     Map<llvm::Value*> *cache) const {
+                                     MetadataResponse source,
+                                     DynamicMetadataRequest request,
+                                     Map<MetadataResponse> *cache) const {
   LocalTypeDataKey key = {
     sourceType,
     LocalTypeDataKind::forFormalTypeMetadata()
   };
-  return follow(IGF, key, source, Path.begin(), Path.end(), cache);
+  return follow(IGF, key, source, Path.begin(), Path.end(), request, cache);
 }
 
-llvm::Value *
+MetadataResponse
 MetadataPath::followFromWitnessTable(IRGenFunction &IGF,
                                      CanType conformingType,
                                      ProtocolConformanceRef conformance,
-                                     llvm::Value *source,
-                                     Map<llvm::Value*> *cache) const {
+                                     MetadataResponse source,
+                                     DynamicMetadataRequest request,
+                                     Map<MetadataResponse> *cache) const {
   LocalTypeDataKey key = {
     conformingType,
     LocalTypeDataKind::forProtocolWitnessTable(conformance)
   };
-  return follow(IGF, key, source, Path.begin(), Path.end(), cache);
+  return follow(IGF, key, source, Path.begin(), Path.end(), request, cache);
 }
 
 /// Follow this metadata path.
@@ -2160,11 +2190,12 @@ MetadataPath::followFromWitnessTable(IRGenFunction &IGF,
 ///   in the IRGenFunction will be used.  This caching system is somewhat
 ///   more efficient than what IGF provides, but it's less general, and it
 ///   should probably be removed.
-llvm::Value *MetadataPath::follow(IRGenFunction &IGF,
-                                  LocalTypeDataKey sourceKey,
-                                  llvm::Value *source,
-                                  iterator begin, iterator end,
-                                  Map<llvm::Value*> *cache) {
+MetadataResponse MetadataPath::follow(IRGenFunction &IGF,
+                                      LocalTypeDataKey sourceKey,
+                                      MetadataResponse source,
+                                      iterator begin, iterator end,
+                                      DynamicMetadataRequest finalRequest,
+                                      Map<MetadataResponse> *cache) {
   assert(source && "no source metadata value!");
 
   // The invariant is that this iterator starts a path from source and
@@ -2189,7 +2220,8 @@ llvm::Value *MetadataPath::follow(IRGenFunction &IGF,
       // Advance the source key past the cached prefix.
       while (i != result.second) {
         Component component = *i++;
-        (void) followComponent(IGF, sourceKey, /*source*/ nullptr, component);
+        (void) followComponent(IGF, sourceKey, MetadataResponse(), component,
+                               MetadataState::Abstract);
       }
     }
 
@@ -2200,17 +2232,21 @@ llvm::Value *MetadataPath::follow(IRGenFunction &IGF,
     LocalTypeDataKey skipKey = sourceKey;
     while (skipI != end) {
       Component component = *skipI++;
-      (void) followComponent(IGF, skipKey, /*source*/ nullptr, component);
+      (void) followComponent(IGF, skipKey, MetadataResponse(), component,
+                             MetadataState::Abstract);
 
       // Check the cache for a concrete value.  We don't want an abstract
-      // entry because, if one exists, we'll just end up here again
+      // cache entry because, if one exists, we'll just end up here again
       // recursively.
-      if (auto skipSource =
-            IGF.tryGetConcreteLocalTypeData(skipKey.getCachingKey())) {
-        // If we found one, advance the info for the source to the current
+      auto skipRequest =
+        (skipI == end ? finalRequest : MetadataState::Abstract);
+      if (auto skipResponse =
+            IGF.tryGetConcreteLocalTypeData(skipKey.getCachingKey(),
+                                            skipRequest)) {
+        // Advance the baseline information for the source to the current
         // point in the path, then continue the search.
         sourceKey = skipKey;
-        source = skipSource;
+        source = skipResponse;
         i = skipI;
       }
     }
@@ -2219,13 +2255,17 @@ llvm::Value *MetadataPath::follow(IRGenFunction &IGF,
   // Drill in on the actual source value.
   while (i != end) {
     auto component = *i++;
-    source = followComponent(IGF, sourceKey, source, component);
+
+    auto componentRequest =
+      (i == end ? finalRequest : MetadataState::Abstract);
+    source = followComponent(IGF, sourceKey, source,
+                             component, componentRequest);
 
     // If we have a cache, remember this in the cache at the next position.
     if (cache) {
       cache->insertNew(begin, i, source);
 
-    // Otherwise, insert it into the global cache.
+    // Otherwise, insert it into the global cache (at the updated source key).
     } else {
       IGF.setScopedLocalTypeData(sourceKey, source);
     }
@@ -2264,10 +2304,11 @@ emitAssociatedTypeWitnessTableRef(IRGenFunction &IGF,
 /// sourceType and sourceDecl will be adjusted to refer to the new
 /// component.  Source can be null, in which case this will be the only
 /// thing done.
-llvm::Value *MetadataPath::followComponent(IRGenFunction &IGF,
-                                           LocalTypeDataKey &sourceKey,
-                                           llvm::Value *source,
-                                           Component component) {
+MetadataResponse MetadataPath::followComponent(IRGenFunction &IGF,
+                                               LocalTypeDataKey &sourceKey,
+                                               MetadataResponse source,
+                                               Component component,
+                                               DynamicMetadataRequest request) {
   switch (component.getKind()) {
   case Component::Kind::NominalTypeArgument:
   case Component::Kind::NominalTypeArgumentConformance: {
@@ -2291,11 +2332,22 @@ llvm::Value *MetadataPath::followComponent(IRGenFunction &IGF,
     // If this is a type argument, we've fully updated sourceKey.
     if (component.getKind() == Component::Kind::NominalTypeArgument) {
       assert(!requirement.Protocol && "index mismatch!");
-      if (source) {
-        source = emitArgumentMetadataRef(IGF, nominal,
-                                         requirements, reqtIndex, source);
-        setTypeMetadataName(IGF.IGM, source, sourceKey.Type);
-      }
+
+      if (!source) return MetadataResponse();
+
+      auto sourceMetadata = source.getMetadata();
+      auto *argMetadata = 
+        emitArgumentMetadataRef(IGF, nominal, requirements, reqtIndex,
+                                sourceMetadata);
+      setTypeMetadataName(IGF.IGM, argMetadata, sourceKey.Type);
+
+      // Assume that the argument metadata is complete if the metadata is.
+      auto argState = getPresumedMetadataStateForTypeArgument(
+                                           source.getStaticLowerBoundOnState());
+      auto response = MetadataResponse::forBounded(argMetadata, argState);
+
+      // Do a dynamic check if necessary to satisfy the request.
+      return emitCheckTypeMetadataState(IGF, request, response);
 
     // Otherwise, we need to switch sourceKey.Kind to the appropriate
     // conformance kind.
@@ -2306,15 +2358,17 @@ llvm::Value *MetadataPath::followComponent(IRGenFunction &IGF,
       assert(conformance.getRequirement() == requirement.Protocol);
       sourceKey.Kind = LocalTypeDataKind::forProtocolWitnessTable(conformance);
 
-      if (source) {
-        auto protocol = conformance.getRequirement();
-        source = emitArgumentWitnessTableRef(IGF, nominal,
-                                             requirements, reqtIndex, source);
-        setProtocolWitnessTableName(IGF.IGM, source, sourceKey.Type, protocol);
-      }
-    }
+      if (!source) return MetadataResponse();
 
-    return source;
+      auto sourceMetadata = source.getMetadata();
+      auto protocol = conformance.getRequirement();
+      auto wtable = emitArgumentWitnessTableRef(IGF, nominal,
+                                                requirements, reqtIndex,
+                                                sourceMetadata);
+      setProtocolWitnessTableName(IGF.IGM, wtable, sourceKey.Type, protocol);
+
+      return MetadataResponse::forComplete(wtable);
+    }
   }
 
   case Component::Kind::OutOfLineBaseProtocol: {
@@ -2337,15 +2391,19 @@ llvm::Value *MetadataPath::followComponent(IRGenFunction &IGF,
       }
     }
 
-    if (source) {
-      WitnessIndex index(component.getPrimaryIndex(), /*prefix*/ false);
-      source = emitInvariantLoadOfOpaqueWitness(IGF, source,
-                                              index.forProtocolWitnessTable());
-      source = IGF.Builder.CreateBitCast(source, IGF.IGM.WitnessTablePtrTy);
-      setProtocolWitnessTableName(IGF.IGM, source, sourceKey.Type,
-                                  inheritedProtocol);
-    }
-    return source;
+    if (!source) return MetadataResponse();
+
+    auto wtable = source.getMetadata();
+    WitnessIndex index(component.getPrimaryIndex(), /*prefix*/ false);
+    auto baseWTable =
+      emitInvariantLoadOfOpaqueWitness(IGF, wtable,
+                                       index.forProtocolWitnessTable());
+    baseWTable =
+      IGF.Builder.CreateBitCast(baseWTable, IGF.IGM.WitnessTablePtrTy);
+    setProtocolWitnessTableName(IGF.IGM, baseWTable, sourceKey.Type,
+                                inheritedProtocol);
+
+    return MetadataResponse::forComplete(baseWTable);
   }
 
   case Component::Kind::AssociatedConformance: {
@@ -2381,17 +2439,21 @@ llvm::Value *MetadataPath::followComponent(IRGenFunction &IGF,
             isa<ArchetypeType>(sourceKey.Type)) &&
            "couldn't find concrete conformance for concrete type");
 
-    if (source) {
-      WitnessIndex index(component.getPrimaryIndex(), /*prefix*/ false);
-      auto sourceMetadata = IGF.emitTypeMetadataRef(sourceType);
-      auto associatedMetadata = IGF.emitTypeMetadataRef(sourceKey.Type);
-      source = emitAssociatedTypeWitnessTableRef(IGF, sourceMetadata, source,
-                                                 index, associatedMetadata);
+    if (!source) return MetadataResponse();
 
-      setProtocolWitnessTableName(IGF.IGM, source, sourceKey.Type,
-                                  associatedRequirement);
-    }
-    return source;
+    WitnessIndex index(component.getPrimaryIndex(), /*prefix*/ false);
+    auto sourceMetadata = IGF.emitTypeMetadataRef(sourceType);
+    auto associatedMetadata = IGF.emitTypeMetadataRef(sourceKey.Type);
+    auto sourceWTable = source.getMetadata();
+
+    auto associatedWTable = 
+      emitAssociatedTypeWitnessTableRef(IGF, sourceMetadata, sourceWTable,
+                                        index, associatedMetadata);
+
+    setProtocolWitnessTableName(IGF.IGM, associatedWTable, sourceKey.Type,
+                                associatedRequirement);
+
+    return MetadataResponse::forComplete(associatedWTable);
   }
 
   case Component::Kind::ConditionalConformance: {
@@ -2416,17 +2478,20 @@ llvm::Value *MetadataPath::followComponent(IRGenFunction &IGF,
     sourceKey.Kind =
         LocalTypeDataKind::forAbstractProtocolWitnessTable(conformingProto);
 
-    if (source) {
-      WitnessIndex index(privateWitnessTableIndexToTableOffset(reqtIndex),
-                         /*prefix*/ false);
+    if (!source) return MetadataResponse();
 
-      source = emitInvariantLoadOfOpaqueWitness(IGF, source, index);
-      source = IGF.Builder.CreateBitCast(source, IGF.IGM.WitnessTablePtrTy);
-      setProtocolWitnessTableName(IGF.IGM, source, sourceKey.Type,
-                                  conformingProto);
-    }
+    WitnessIndex index(privateWitnessTableIndexToTableOffset(reqtIndex),
+                       /*prefix*/ false);
 
-    return source;
+    auto sourceWTable = source.getMetadata();
+    auto capturedWTable =
+      emitInvariantLoadOfOpaqueWitness(IGF, sourceWTable, index);
+    capturedWTable =
+      IGF.Builder.CreateBitCast(capturedWTable, IGF.IGM.WitnessTablePtrTy);
+    setProtocolWitnessTableName(IGF.IGM, capturedWTable, sourceKey.Type,
+                                conformingProto);
+
+    return MetadataResponse::forComplete(capturedWTable);
   }
 
   case Component::Kind::Impossible:
@@ -2506,7 +2571,8 @@ void irgen::emitPolymorphicParameters(IRGenFunction &IGF,
 /// GenericArguments, bind the polymorphic parameters.
 void irgen::emitPolymorphicParametersFromArray(IRGenFunction &IGF,
                                                NominalTypeDecl *typeDecl,
-                                               Address array) {
+                                               Address array,
+                                               MetadataState state) {
   GenericTypeRequirements requirements(IGF.IGM, typeDecl);
 
   array = IGF.Builder.CreateElementBitCast(array, IGF.IGM.TypeMetadataPtrTy);
@@ -2517,7 +2583,7 @@ void irgen::emitPolymorphicParametersFromArray(IRGenFunction &IGF,
   };
 
   // Okay, bind everything else from the context.
-  requirements.bindFromBuffer(IGF, array, getInContext);
+  requirements.bindFromBuffer(IGF, array, state, getInContext);
 }
 
 Size NecessaryBindings::getBufferSize(IRGenModule &IGM) const {
@@ -2525,8 +2591,10 @@ Size NecessaryBindings::getBufferSize(IRGenModule &IGM) const {
   return IGM.getPointerSize() * Requirements.size();
 }
 
-void NecessaryBindings::restore(IRGenFunction &IGF, Address buffer) const {
+void NecessaryBindings::restore(IRGenFunction &IGF, Address buffer,
+                                MetadataState metadataState) const {
   bindFromGenericRequirementsBuffer(IGF, Requirements.getArrayRef(), buffer,
+                                    metadataState,
                                     [&](CanType type) { return type;});
 }
 
@@ -2967,13 +3035,16 @@ irgen::emitGenericRequirementFromSubstitutions(IRGenFunction &IGF,
 
 void GenericTypeRequirements::bindFromBuffer(IRGenFunction &IGF,
                                              Address buffer,
+                                             MetadataState metadataState,
                                     GetTypeParameterInContextFn getInContext) {
-  bindFromGenericRequirementsBuffer(IGF, Requirements, buffer, getInContext);
+  bindFromGenericRequirementsBuffer(IGF, Requirements, buffer,
+                                    metadataState, getInContext);
 }
 
 void irgen::bindFromGenericRequirementsBuffer(IRGenFunction &IGF,
                                     ArrayRef<GenericRequirement> requirements,
                                     Address buffer,
+                                    MetadataState metadataState,
                                     GetTypeParameterInContextFn getInContext) {
   if (requirements.empty()) return;
 
@@ -2994,13 +3065,15 @@ void irgen::bindFromGenericRequirementsBuffer(IRGenFunction &IGF,
     }
 
     llvm::Value *value = IGF.Builder.CreateLoad(slot);
-    bindGenericRequirement(IGF, requirements[index], value, getInContext);
+    bindGenericRequirement(IGF, requirements[index], value, metadataState,
+                           getInContext);
   }
 }
 
 void irgen::bindGenericRequirement(IRGenFunction &IGF,
                                    GenericRequirement requirement,
                                    llvm::Value *value,
+                                   MetadataState metadataState,
                                    GetTypeParameterInContextFn getInContext) {
   // Get the corresponding context type.
   auto type = getInContext(requirement.TypeParameter);
@@ -3014,7 +3087,7 @@ void irgen::bindGenericRequirement(IRGenFunction &IGF,
   } else {
     assert(value->getType() == IGF.IGM.TypeMetadataPtrTy);
     setTypeMetadataName(IGF.IGM, value, type);
-    IGF.bindLocalTypeDataFromTypeMetadata(type, IsExact, value);
+    IGF.bindLocalTypeDataFromTypeMetadata(type, IsExact, value, metadataState);
   }
 }
 

--- a/lib/IRGen/GenProto.h
+++ b/lib/IRGen/GenProto.h
@@ -31,6 +31,7 @@ namespace swift {
   class AssociatedType;
   class CanType;
   class FuncDecl;
+  enum class MetadataState : size_t;
   class ProtocolConformanceRef;
   struct SILDeclRef;
   class SILType;
@@ -131,7 +132,8 @@ namespace irgen {
  
   void emitPolymorphicParametersFromArray(IRGenFunction &IGF,
                                           NominalTypeDecl *typeDecl,
-                                          Address array);
+                                          Address array,
+                                          MetadataState metadataState);
 
   /// When calling a polymorphic call, pass the arguments for the
   /// generics clause.

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -518,13 +518,6 @@ namespace {
       return StructNonFixedOffsets(T).getFieldAccessStrategy(IGM,
                                               field.getNonFixedElementIndex());
     }
-
-    void initializeMetadata(IRGenFunction &IGF,
-                            llvm::Value *metadata,
-                            bool isVWTMutable,
-                            SILType T) const override {
-      emitInitializeFieldOffsetVector(IGF, T, metadata, isVWTMutable);
-    }
   };
 
   class StructTypeBuilder :

--- a/lib/IRGen/GenTuple.cpp
+++ b/lib/IRGen/GenTuple.cpp
@@ -340,15 +340,6 @@ namespace {
                                             SILType T) const {
       return TupleNonFixedOffsets(T);
     }
-
-    void initializeMetadata(IRGenFunction &IGF,
-                            llvm::Value *metadata,
-                            bool isVWTMutable,
-                            SILType T) const override {
-      // Tuple value witness tables are instantiated by the runtime along with
-      // their metadata. We should never try to initialize one in the compiler.
-      llvm_unreachable("initializing value witness table for tuple?!");
-    }
   };
 
   class TupleTypeBuilder :

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -462,7 +462,8 @@ void irgen::getArgAsLocalSelfTypeMetadata(IRGenFunction &IGF, llvm::Value *arg,
          "Self argument is not a type?!");
 
   auto formalType = getFormalTypeInContext(abstractType);
-  IGF.bindLocalTypeDataFromTypeMetadata(formalType, IsExact, arg);
+  IGF.bindLocalTypeDataFromTypeMetadata(formalType, IsExact, arg,
+                                        MetadataState::Complete);
 }
 
 /// Get the next argument and use it as the 'self' type metadata.

--- a/lib/IRGen/GenericRequirement.h
+++ b/lib/IRGen/GenericRequirement.h
@@ -30,6 +30,7 @@ class Value;
 
 namespace swift {
 class CanGenericSignature;
+enum class MetadataState : size_t;
 class ModuleDecl;
 class NominalTypeDecl;
 class ProtocolDecl;
@@ -78,11 +79,13 @@ using GetTypeParameterInContextFn =
 void bindGenericRequirement(IRGenFunction &IGF,
                             GenericRequirement requirement,
                             llvm::Value *requiredValue,
+                            MetadataState metadataState,
                             GetTypeParameterInContextFn getInContext);
 
 void bindFromGenericRequirementsBuffer(IRGenFunction &IGF,
                                        ArrayRef<GenericRequirement> reqts,
                                        Address buffer,
+                                       MetadataState metadataState,
                                        GetTypeParameterInContextFn getInContext);
 
 
@@ -144,7 +147,7 @@ public:
   void emitInitOfBuffer(IRGenFunction &IGF, const SubstitutionMap &subs,
                         Address buffer);
 
-  void bindFromBuffer(IRGenFunction &IGF, Address buffer,
+  void bindFromBuffer(IRGenFunction &IGF, Address buffer, MetadataState state,
                       GetTypeParameterInContextFn getInContext);
 };
 

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -239,6 +239,11 @@ public:
   // correct for all uses of reabstractable values in opaque contexts.
   llvm::Value *emitTypeMetadataRef(CanType type);
 
+  /// Emit a reference to the canonical type metadata record for the given
+  /// formal type.  The metadata is only required to be abstract; that is,
+  /// you cannot use the result for layout.
+  llvm::Value *emitAbstractTypeMetadataRef(CanType type);
+
   MetadataResponse emitTypeMetadataRef(CanType type,
                                        DynamicMetadataRequest request);
 
@@ -258,8 +263,9 @@ public:
   // here, since for some types it's easier to get a shared reference to one
   // than a metadata reference, and it would be more type-safe.
   llvm::Value *emitTypeMetadataRefForLayout(SILType type);
+  llvm::Value *emitTypeMetadataRefForLayout(SILType type,
+                                            DynamicMetadataRequest request);
   
-  llvm::Value *emitValueWitnessTableRef(CanType type);
   llvm::Value *emitValueWitnessTableRef(SILType type,
                                         llvm::Value **metadataSlot = nullptr);
   llvm::Value *emitValueWitnessTableRefForMetadata(llvm::Value *metadata);
@@ -490,7 +496,8 @@ public:
     setScopedLocalTypeData(LocalTypeDataKey{type, kind}, data);
   }
   void setScopedLocalTypeData(LocalTypeDataKey key, llvm::Value *data);
-  void setScopedLocalTypeMetadata(CanType type, MetadataResponse response);
+  void setScopedLocalTypeMetadata(CanType type, DynamicMetadataRequest request,
+                                  MetadataResponse response);
 
   /// The same as tryGetLocalTypeData, just for the Layout metadata.
   ///
@@ -501,6 +508,13 @@ public:
                                             LocalTypeDataKind kind) {
     return tryGetLocalTypeData(type.getSwiftRValueType(), kind);
   }
+
+  MetadataResponse
+  tryGetLocalTypeMetadataForLayout(SILType type,
+                                   DynamicMetadataRequest request);
+  void setScopedLocalTypeMetadataForLayout(SILType type,
+                                           DynamicMetadataRequest request,
+                                           MetadataResponse response);
 
   /// Add a local type-metadata reference, which is valid for the containing
   /// block.

--- a/lib/IRGen/IRGenFunction.h
+++ b/lib/IRGen/IRGenFunction.h
@@ -41,6 +41,7 @@ namespace swift {
   class SILDebugScope;
   class SILType;
   class SourceLoc;
+  enum class MetadataState : size_t;
 
 namespace Lowering {
   class TypeConverter;
@@ -247,12 +248,6 @@ public:
   MetadataResponse emitTypeMetadataRef(CanType type,
                                        DynamicMetadataRequest request);
 
-  // Emit a reference to a type layout record for the given type. The referenced
-  // data is enough to lay out an aggregate containing a value of the type, but
-  // can't uniquely represent the type or perform value witness operations on
-  // it.
-  llvm::Value *emitTypeLayoutRef(SILType type);
-  
   // Emit a reference to a metadata object that can be used for layout, but
   // cannot be used to identify a type. This will produce a layout appropriate
   // to the abstraction level of the given type. It may be able to avoid runtime
@@ -267,6 +262,9 @@ public:
                                             DynamicMetadataRequest request);
   
   llvm::Value *emitValueWitnessTableRef(SILType type,
+                                        llvm::Value **metadataSlot = nullptr);
+  llvm::Value *emitValueWitnessTableRef(SILType type,
+                                        DynamicMetadataRequest request,
                                         llvm::Value **metadataSlot = nullptr);
   llvm::Value *emitValueWitnessTableRefForMetadata(llvm::Value *metadata);
   
@@ -458,75 +456,100 @@ public:
 
   void bindArchetype(ArchetypeType *type,
                      llvm::Value *metadata,
+                     MetadataState metadataState,
                      ArrayRef<llvm::Value*> wtables);
 
 //--- Type emission ------------------------------------------------------------
 public:
-  /// Look up a local type data reference, returning null if no entry was
-  /// found.  This will emit code to materialize the reference if an
-  /// "abstract" entry is present.
-  llvm::Value *tryGetLocalTypeData(CanType type, LocalTypeDataKind kind) {
-    return tryGetLocalTypeData(LocalTypeDataKey{type, kind});
-  }
-  llvm::Value *tryGetLocalTypeData(LocalTypeDataKey key);
-
+  /// Look up a local type metadata reference, returning a null response
+  /// if no entry was found which can satisfy the request.  This may need
+  /// emit code to materialize the reference.
+  ///
+  /// This does a look up for a formal ("AST") type.  If you are looking for
+  /// type metadata that will work for working with a representation
+  /// ("lowered", "SIL") type, use getGetLocalTypeMetadataForLayout.
   MetadataResponse tryGetLocalTypeMetadata(CanType type,
                                            DynamicMetadataRequest request);
 
   /// Look up a local type data reference, returning null if no entry was
-  /// found or if the only viable entries are abstract.  This will never
-  /// emit code.
-  llvm::Value *tryGetConcreteLocalTypeData(LocalTypeDataKey key);
+  /// found.  This may need to emit code to materialize the reference.
+  ///
+  /// The data kind cannot be for type metadata; use tryGetLocalTypeMetadata
+  /// for that.
+  llvm::Value *tryGetLocalTypeData(CanType type, LocalTypeDataKind kind);
 
-  /// Retrieve a local type data reference which is known to exist.
-  llvm::Value *getLocalTypeData(CanType type, LocalTypeDataKind kind);
-
-  /// Add a local type-metadata reference at a point which definitely
-  /// dominates all of its uses.
-  void setUnscopedLocalTypeData(CanType type, LocalTypeDataKind kind,
-                                llvm::Value *data) {
-    setUnscopedLocalTypeData(LocalTypeDataKey{type, kind}, data);
-  }
-  void setUnscopedLocalTypeData(LocalTypeDataKey key, llvm::Value *data);
-  
-  /// Add a local type-metadata reference, valid at the current insertion
-  /// point.
-  void setScopedLocalTypeData(CanType type, LocalTypeDataKind kind,
-                              llvm::Value *data) {
-    setScopedLocalTypeData(LocalTypeDataKey{type, kind}, data);
-  }
-  void setScopedLocalTypeData(LocalTypeDataKey key, llvm::Value *data);
-  void setScopedLocalTypeMetadata(CanType type, DynamicMetadataRequest request,
-                                  MetadataResponse response);
-
-  /// The same as tryGetLocalTypeData, just for the Layout metadata.
+  /// The same as tryGetLocalTypeMetadata, but for representation-compatible
+  /// "layout" metadata.  The returned metadata may not be for a type that
+  /// has anything to do with the formal type that was lowered to the given
+  /// type; however, it is guaranteed to have equivalent characteristics
+  /// in terms of layout, spare bits, POD-ness, and so on.
   ///
   /// We use a separate function name for this to clarify that you should
-  /// only ever be looking type metadata for a lowered SILType for the
-  /// purposes of local layout (e.g. of a tuple).
+  /// only ever be looking for type metadata for a lowered SILType for the
+  /// purposes of local manipulation, such as the layout of a type or
+  /// emitting a value-copy.
+  MetadataResponse tryGetLocalTypeMetadataForLayout(SILType type,
+                                           DynamicMetadataRequest request);
+
+  /// The same as tryGetForLocalTypeData, but for representation-compatible
+  /// "layout" metadata.  See the comment on tryGetLocalTypeMetadataForLayout.
+  ///
+  /// The data kind cannot be for type metadata; use
+  /// tryGetLocalTypeMetadataForLayout for that.
   llvm::Value *tryGetLocalTypeDataForLayout(SILType type,
-                                            LocalTypeDataKind kind) {
-    return tryGetLocalTypeData(type.getSwiftRValueType(), kind);
-  }
+                                            LocalTypeDataKind kind);
 
-  MetadataResponse
-  tryGetLocalTypeMetadataForLayout(SILType type,
-                                   DynamicMetadataRequest request);
-  void setScopedLocalTypeMetadataForLayout(SILType type,
-                                           DynamicMetadataRequest request,
-                                           MetadataResponse response);
+  /// Add a local type metadata reference at a point which definitely
+  /// dominates all of its uses.
+  void setUnscopedLocalTypeMetadata(CanType type,
+                                    MetadataResponse response);
 
-  /// Add a local type-metadata reference, which is valid for the containing
-  /// block.
+  /// Add a local type data reference at a point which definitely
+  /// dominates all of its uses.
+  ///
+  /// The data kind cannot be for type metadata; use
+  /// setUnscopedLocalTypeMetadata for that.
+  void setUnscopedLocalTypeData(CanType type, LocalTypeDataKind kind,
+                                llvm::Value *data);
+
+  /// Add a local type metadata reference that is valid at the current
+  /// insertion point.
+  void setScopedLocalTypeMetadata(CanType type, MetadataResponse value);
+
+  /// Add a local type data reference that is valid at the current
+  /// insertion point.
+  ///
+  /// The data kind cannot be for type metadata; use setScopedLocalTypeMetadata
+  /// for that.
+  void setScopedLocalTypeData(CanType type, LocalTypeDataKind kind,
+                              llvm::Value *data);
+
+  /// The same as setScopedLocalTypeMetadata, but for representation-compatible
+  /// "layout" metadata.  See the comment on tryGetLocalTypeMetadataForLayout.
+  void setScopedLocalTypeMetadataForLayout(SILType type, MetadataResponse value);
+
+  /// The same as setScopedLocalTypeData, but for representation-compatible
+  /// "layout" metadata.  See the comment on tryGetLocalTypeMetadataForLayout.
+  ///
+  /// The data kind cannot be for type metadata; use
+  /// setScopedLocalTypeMetadataForLayout for that.
   void setScopedLocalTypeDataForLayout(SILType type, LocalTypeDataKind kind,
-                                       llvm::Value *data) {
-    setScopedLocalTypeData(type.getSwiftRValueType(), kind, data);
-  }
+                                       llvm::Value *data);
+
+  // These are for the private use of the LocalTypeData subsystem.
+  MetadataResponse tryGetLocalTypeMetadata(LocalTypeDataKey key,
+                                           DynamicMetadataRequest request);
+  llvm::Value *tryGetLocalTypeData(LocalTypeDataKey key);
+  MetadataResponse tryGetConcreteLocalTypeData(LocalTypeDataKey key,
+                                               DynamicMetadataRequest request);
+  void setUnscopedLocalTypeData(LocalTypeDataKey key, MetadataResponse value);
+  void setScopedLocalTypeData(LocalTypeDataKey key, MetadataResponse value);
 
   /// Given a concrete type metadata node, add all the local type data
   /// that we can reach from it.
   void bindLocalTypeDataFromTypeMetadata(CanType type, IsExact_t isExact,
-                                         llvm::Value *metadata);
+                                         llvm::Value *metadata,
+                                         MetadataState metadataState);
 
   /// Given the witness table parameter, bind local type data for
   /// the witness table itself and any conditional requirements.

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -518,7 +518,10 @@ public:
   llvm::FunctionType *DeallocatingDtorTy; /// void (%swift.refcounted*)
   llvm::StructType *TypeMetadataStructTy; /// %swift.type = type { ... }
   llvm::PointerType *TypeMetadataPtrTy;/// %swift.type*
-  llvm::StructType *TypeMetadataResponseTy; /// { %swift.type*, iSize }
+  union {
+    llvm::StructType *TypeMetadataResponseTy;   /// { %swift.type*, iSize }
+    llvm::StructType *TypeMetadataDependencyTy; /// { %swift.type*, iSize }
+  };
   llvm::PointerType *TupleTypeMetadataPtrTy; /// %swift.tuple_type*
   llvm::StructType *FullHeapMetadataStructTy; /// %swift.full_heapmetadata = type { ... }
   llvm::PointerType *FullHeapMetadataPtrTy;/// %swift.full_heapmetadata*

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -1885,7 +1885,8 @@ void IRGenSILFunction::visitGlobalValueInst(GlobalValueInst *i) {
 
   CanType ClassType = loweredTy.getSwiftRValueType();
   llvm::Value *Metadata =
-    emitClassHeapMetadataRef(*this, ClassType, MetadataValueType::TypeMetadata);
+    emitClassHeapMetadataRef(*this, ClassType, MetadataValueType::TypeMetadata,
+                             MetadataState::Complete);
   llvm::Value *CastAddr = Builder.CreateBitCast(Ref, IGM.RefCountedPtrTy);
   llvm::Value *InitRef = emitInitStaticObjectCall(Metadata, CastAddr, "staticref");
   InitRef = Builder.CreateBitCast(InitRef, Ref->getType());

--- a/lib/IRGen/LocalTypeData.cpp
+++ b/lib/IRGen/LocalTypeData.cpp
@@ -59,34 +59,92 @@ void IRGenFunction::destroyLocalTypeData() {
 OperationCost LocalTypeDataCache::CacheEntry::cost() const {
   switch (getKind()) {
   case Kind::Concrete:
-    return static_cast<const ConcreteCacheEntry*>(this)->cost();
+    return cast<ConcreteCacheEntry>(this)->cost();
   case Kind::Abstract:
-    return static_cast<const AbstractCacheEntry*>(this)->cost();
+    return cast<AbstractCacheEntry>(this)->cost();
   }
   llvm_unreachable("bad cache entry kind");
+}
+
+OperationCost
+LocalTypeDataCache::CacheEntry::costForRequest(LocalTypeDataKey key,
+                                        DynamicMetadataRequest request) const {
+  switch (getKind()) {
+  case Kind::Concrete:
+    return cast<ConcreteCacheEntry>(this)->costForRequest(key, request);
+  case Kind::Abstract:
+    return cast<AbstractCacheEntry>(this)->costForRequest(key, request);
+  }
+  llvm_unreachable("bad cache entry kind");
+}
+
+OperationCost
+LocalTypeDataCache::ConcreteCacheEntry::costForRequest(LocalTypeDataKey key,
+                                        DynamicMetadataRequest request) const {
+  auto totalCost = cost();
+  if (!immediatelySatisfies(key, request)) {
+    // Use a lower cost for requests where emitCheckTypeMetadataState can just
+    // branch on the existing response's returned dynamic state.
+    totalCost += getCheckTypeMetadataStateCost(request, Value);
+  }
+  return totalCost;
+}
+
+OperationCost
+LocalTypeDataCache::AbstractCacheEntry::costForRequest(LocalTypeDataKey key,
+                                        DynamicMetadataRequest request) const {
+  auto totalCost = cost();
+  if (!immediatelySatisfies(key, request)) {
+    totalCost += OperationCost::Call;
+  }
+  return totalCost;
 }
 
 void LocalTypeDataCache::CacheEntry::erase() const {
   switch (getKind()) {
   case Kind::Concrete:
-    delete static_cast<const ConcreteCacheEntry*>(this);
+    delete cast<ConcreteCacheEntry>(this);
     return;
   case Kind::Abstract:
-    delete static_cast<const AbstractCacheEntry*>(this);
+    delete cast<AbstractCacheEntry>(this);
     return;
   }
   llvm_unreachable("bad cache entry kind");
 }
 
-static MetadataResponse
-tryGetLocalTypeMetadata(IRGenFunction &IGF, CanType type,
-                        DynamicMetadataRequest request,
-                        LocalTypeDataKind localDataKind) {
-  // For now, these kinds always means *complete* type metadata.
-  if (auto metadata = IGF.tryGetLocalTypeData(type, localDataKind))
-    return MetadataResponse::forComplete(metadata);
+static bool immediatelySatisfies(LocalTypeDataKey key,
+                                 MetadataState storedState,
+                                 DynamicMetadataRequest request) {
+  assert((storedState == MetadataState::Complete ||
+          key.Kind.isAnyTypeMetadata()) &&
+         "non-metadata entry stored with incomplete state");
 
-  return MetadataResponse();
+  return request.isSatisfiedBy(storedState);
+}
+
+bool LocalTypeDataCache::CacheEntry::immediatelySatisfies(
+                                         LocalTypeDataKey key,
+                                         DynamicMetadataRequest request) const {
+  switch (getKind()) {
+  case Kind::Concrete:
+    return cast<ConcreteCacheEntry>(this)->immediatelySatisfies(key, request);
+  case Kind::Abstract:
+    return cast<AbstractCacheEntry>(this)->immediatelySatisfies(key, request);
+  }
+  llvm_unreachable("bad cache entry kind");
+}
+
+bool LocalTypeDataCache::ConcreteCacheEntry::immediatelySatisfies(
+                                         LocalTypeDataKey key,
+                                         DynamicMetadataRequest request) const {
+  return ::immediatelySatisfies(key, Value.getStaticLowerBoundOnState(),
+                                request);
+}
+
+bool LocalTypeDataCache::AbstractCacheEntry::immediatelySatisfies(
+                                         LocalTypeDataKey key,
+                                         DynamicMetadataRequest request) const {
+  return ::immediatelySatisfies(key, getState(), request);
 }
 
 MetadataResponse
@@ -100,63 +158,62 @@ IRGenFunction::tryGetLocalTypeMetadataForLayout(SILType layoutType,
       return response;
   }
 
-  return ::tryGetLocalTypeMetadata(*this, type, request,
+  auto key = LocalTypeDataKey(type,
                             LocalTypeDataKind::forRepresentationTypeMetadata());
+  return tryGetLocalTypeMetadata(key, request);
 }
 
 MetadataResponse
 IRGenFunction::tryGetLocalTypeMetadata(CanType type,
                                        DynamicMetadataRequest request) {
-  return ::tryGetLocalTypeMetadata(*this, type, request,
-                                   LocalTypeDataKind::forFormalTypeMetadata());
+  auto key = LocalTypeDataKey(type, LocalTypeDataKind::forFormalTypeMetadata());
+  return tryGetLocalTypeMetadata(key, request);
 }
 
-static void setScopedLocalTypeMetadata(IRGenFunction &IGF, CanType type,
-                                       DynamicMetadataRequest request,
-                                       MetadataResponse response,
-                                       LocalTypeDataKind localDataKind) {
-  // For now, forTypeMetadata always means *complete* type metadata.
-  if (response.isStaticallyKnownComplete()) {
-    IGF.setScopedLocalTypeData(type, localDataKind, response.getMetadata());
-  }
+MetadataResponse
+IRGenFunction::tryGetLocalTypeMetadata(LocalTypeDataKey key,
+                                       DynamicMetadataRequest request) {
+  assert(key.Kind.isAnyTypeMetadata());
+  if (!LocalTypeData) return MetadataResponse();
+  return LocalTypeData->tryGet(*this, key, /*allow abstract*/ true, request);
 }
 
-void
-IRGenFunction::setScopedLocalTypeMetadataForLayout(SILType type,
-                                               DynamicMetadataRequest request,
-                                               MetadataResponse response) {
-  ::setScopedLocalTypeMetadata(*this, type.getSwiftRValueType(),
-                               request, response,
-                            LocalTypeDataKind::forRepresentationTypeMetadata());
+/// Get local type data if it's possible to do so without emitting code.
+/// Specifically, it doesn't call MetadataPath::follow, and therefore
+/// it's safe to call from MetadataPath::follow.
+///
+/// It's okay to call this with any kind of key.
+MetadataResponse
+IRGenFunction::tryGetConcreteLocalTypeData(LocalTypeDataKey key,
+                                           DynamicMetadataRequest request) {
+  if (!LocalTypeData) return MetadataResponse();
+  return LocalTypeData->tryGet(*this, key, /*allow abstract*/ false, request);
 }
 
-void IRGenFunction::setScopedLocalTypeMetadata(CanType type,
-                                               DynamicMetadataRequest request,
-                                               MetadataResponse response) {
-  ::setScopedLocalTypeMetadata(*this, type, request, response,
-                               LocalTypeDataKind::forFormalTypeMetadata());
+llvm::Value *IRGenFunction::tryGetLocalTypeDataForLayout(SILType type,
+                                                       LocalTypeDataKind kind) {
+  return tryGetLocalTypeData(LocalTypeDataKey(type.getSwiftRValueType(), kind));
 }
 
-llvm::Value *IRGenFunction::getLocalTypeData(CanType type,
-                                             LocalTypeDataKind kind) {
-  assert(LocalTypeData);
-  return LocalTypeData->get(*this, LocalTypeDataCache::getKey(type, kind));
-}
-
-llvm::Value *IRGenFunction::tryGetConcreteLocalTypeData(LocalTypeDataKey key) {
-  if (!LocalTypeData) return nullptr;
-  return LocalTypeData->tryGet(*this, key, /*allow abstract*/ false);
+llvm::Value *IRGenFunction::tryGetLocalTypeData(CanType type,
+                                                LocalTypeDataKind kind) {
+  return tryGetLocalTypeData(LocalTypeDataKey(type, kind));
 }
 
 llvm::Value *IRGenFunction::tryGetLocalTypeData(LocalTypeDataKey key) {
+  assert(!key.Kind.isAnyTypeMetadata());
   if (!LocalTypeData) return nullptr;
-  return LocalTypeData->tryGet(*this, key);
+  if (auto response = LocalTypeData->tryGet(*this, key, /*allow abstract*/ true,
+                                            MetadataState::Complete))
+    return response.getMetadata();
+  return nullptr;
 }
 
-llvm::Value *LocalTypeDataCache::tryGet(IRGenFunction &IGF, Key key,
-                                        bool allowAbstract) {
+MetadataResponse
+LocalTypeDataCache::tryGet(IRGenFunction &IGF, LocalTypeDataKey key,
+                           bool allowAbstract, DynamicMetadataRequest request) {
   auto it = Map.find(key);
-  if (it == Map.end()) return nullptr;
+  if (it == Map.end()) return MetadataResponse();
   auto &chain = it->second;
 
   CacheEntry *best = nullptr;
@@ -168,7 +225,7 @@ llvm::Value *LocalTypeDataCache::tryGet(IRGenFunction &IGF, Key key,
     next = cur->getNext();
 
     // Ignore abstract entries if so requested.
-    if (!allowAbstract && cur->getKind() != CacheEntry::Kind::Concrete)
+    if (!allowAbstract && !isa<ConcreteCacheEntry>(cur))
       continue;
 
     // Ignore unacceptable entries.
@@ -180,11 +237,11 @@ llvm::Value *LocalTypeDataCache::tryGet(IRGenFunction &IGF, Key key,
       // Compute the cost of the best entry if we haven't done so already.
       // If that's zero, go ahead and short-circuit out.
       if (!bestCost) {
-        bestCost = best->cost();
+        bestCost = best->costForRequest(key, request);
         if (*bestCost == OperationCost::Free) break;
       }
 
-      auto curCost = cur->cost();
+      auto curCost = cur->costForRequest(key, request);
       if (curCost >= *bestCost) continue;
 
       // Replace the best cost and fall through.
@@ -194,64 +251,84 @@ llvm::Value *LocalTypeDataCache::tryGet(IRGenFunction &IGF, Key key,
   }
 
   // If we didn't find anything, we're done.
-  if (!best) return nullptr;
+  if (!best) return MetadataResponse();
 
   // Okay, we've found the best entry available.
   switch (best->getKind()) {
 
   // For concrete caches, this is easy.
-  case CacheEntry::Kind::Concrete:
-    return static_cast<ConcreteCacheEntry*>(best)->Value;
+  case CacheEntry::Kind::Concrete: {
+    auto entry = cast<ConcreteCacheEntry>(best);
+
+    if (entry->immediatelySatisfies(key, request))
+      return entry->Value;
+
+    assert(key.Kind.isAnyTypeMetadata());
+
+    // Emit a dynamic check that the type metadata matches the request.
+    // TODO: we could potentially end up calling this redundantly with a
+    //   dynamic request.  Fortunately, those are used only in very narrow
+    //   circumstances.
+    auto response = emitCheckTypeMetadataState(IGF, request, entry->Value);
+
+    // Add a concrete entry for the checked result.
+    IGF.setScopedLocalTypeData(key, response);
+
+    return response;
+  }
 
   // For abstract caches, we need to follow a path.
   case CacheEntry::Kind::Abstract: {
-    auto entry = static_cast<AbstractCacheEntry*>(best);
+    auto entry = cast<AbstractCacheEntry>(best);
 
     // Follow the path.
     auto &source = AbstractSources[entry->SourceIndex];
-    auto result = entry->follow(IGF, source);
+    auto response = entry->follow(IGF, source, request);
 
     // Following the path automatically caches at every point along it,
     // including the end.
     assert(chain.Root->DefinitionPoint == IGF.getActiveDominancePoint());
-    assert(chain.Root->getKind() == CacheEntry::Kind::Concrete);
+    assert(isa<ConcreteCacheEntry>(chain.Root));
 
-    return result;
+    return response;
   }
 
   }
   llvm_unreachable("bad cache entry kind");
 }
 
-llvm::Value *
+MetadataResponse
 LocalTypeDataCache::AbstractCacheEntry::follow(IRGenFunction &IGF,
-                                               AbstractSource &source) const {
+                                               AbstractSource &source,
+                                        DynamicMetadataRequest request) const {
   switch (source.getKind()) {
   case AbstractSource::Kind::TypeMetadata:
     return Path.followFromTypeMetadata(IGF, source.getType(),
-                                       source.getValue(), nullptr);
+                                       source.getValue(), request, nullptr);
 
   case AbstractSource::Kind::ProtocolWitnessTable:
     return Path.followFromWitnessTable(IGF, source.getType(),
                                        source.getProtocolConformance(),
-                                       source.getValue(), nullptr);
+                                       source.getValue(), request, nullptr);
   }
   llvm_unreachable("bad source kind");
 }
 
 static void maybeEmitDebugInfoForLocalTypeData(IRGenFunction &IGF,
                                                LocalTypeDataKey key,
-                                               llvm::Value *data) {
+                                               MetadataResponse value) {
   // Only if debug info is enabled.
   if (!IGF.IGM.DebugInfo) return;
 
-  // Only for type metadata.
+  // Only for formal type metadata.
   if (key.Kind != LocalTypeDataKind::forFormalTypeMetadata()) return;
 
   // Only for archetypes, and not for opened archetypes.
   auto type = dyn_cast<ArchetypeType>(key.Type);
   if (!type) return;
   if (type->getOpenedExistentialType()) return;
+
+  llvm::Value *data = value.getMetadata();
 
   // At -O0, create an alloca to keep the type alive.
   auto name = type->getFullName();
@@ -266,9 +343,39 @@ static void maybeEmitDebugInfoForLocalTypeData(IRGenFunction &IGF,
   IGF.IGM.DebugInfo->emitTypeMetadata(IGF, data, name);
 }
 
-void IRGenFunction::setScopedLocalTypeData(LocalTypeDataKey key,
+void
+IRGenFunction::setScopedLocalTypeMetadataForLayout(SILType type,
+                                                   MetadataResponse response) {
+  auto key = LocalTypeDataKey(type.getSwiftRValueType(),
+                         LocalTypeDataKind::forRepresentationTypeMetadata());
+  setScopedLocalTypeData(key, response);
+}
+
+void IRGenFunction::setScopedLocalTypeMetadata(CanType type,
+                                               MetadataResponse response) {
+  auto key = LocalTypeDataKey(type, LocalTypeDataKind::forFormalTypeMetadata());
+  setScopedLocalTypeData(key, response);
+}
+
+void IRGenFunction::setScopedLocalTypeData(CanType type,
+                                           LocalTypeDataKind kind,
                                            llvm::Value *data) {
-  maybeEmitDebugInfoForLocalTypeData(*this, key, data);
+  assert(!kind.isAnyTypeMetadata());
+  setScopedLocalTypeData(LocalTypeDataKey(type, kind),
+                         MetadataResponse::forComplete(data));
+}
+
+void IRGenFunction::setScopedLocalTypeDataForLayout(SILType type,
+                                                    LocalTypeDataKind kind,
+                                                    llvm::Value *data) {
+  assert(!kind.isAnyTypeMetadata());
+  setScopedLocalTypeData(LocalTypeDataKey(type.getSwiftRValueType(), kind),
+                         MetadataResponse::forComplete(data));
+}
+
+void IRGenFunction::setScopedLocalTypeData(LocalTypeDataKey key,
+                                           MetadataResponse value) {
+  maybeEmitDebugInfoForLocalTypeData(*this, key, value);
 
   // Register with the active ConditionalDominanceScope if necessary.
   bool isConditional = isConditionalDominancePoint();
@@ -277,30 +384,47 @@ void IRGenFunction::setScopedLocalTypeData(LocalTypeDataKey key,
   }
 
   getOrCreateLocalTypeData().addConcrete(getActiveDominancePoint(),
-                                         isConditional, key, data);
+                                         isConditional, key, value);
+}
+
+void IRGenFunction::setUnscopedLocalTypeMetadata(CanType type,
+                                                 MetadataResponse response) {
+  LocalTypeDataKey key(type, LocalTypeDataKind::forFormalTypeMetadata());
+  setUnscopedLocalTypeData(key, response);
+}
+
+void IRGenFunction::setUnscopedLocalTypeData(CanType type,
+                                             LocalTypeDataKind kind,
+                                             llvm::Value *data) {
+  assert(!kind.isAnyTypeMetadata());
+  setUnscopedLocalTypeData(LocalTypeDataKey(type, kind),
+                           MetadataResponse::forComplete(data));
 }
 
 void IRGenFunction::setUnscopedLocalTypeData(LocalTypeDataKey key,
-                                             llvm::Value *data) {
-  maybeEmitDebugInfoForLocalTypeData(*this, key, data);
+                                             MetadataResponse value) {
+  maybeEmitDebugInfoForLocalTypeData(*this, key, value);
 
   // This is supportable, but it would require ensuring that we add the
   // entry after any conditional entries; otherwise the stack discipline
   // will get messed up.
   assert(!isConditionalDominancePoint() &&
          "adding unscoped local type data while in conditional scope");
+
   getOrCreateLocalTypeData().addConcrete(DominancePoint::universal(),
-                                         /*conditional*/ false, key, data);
+                                         /*conditional*/ false, key, value);
 }
 
 void IRGenFunction::bindLocalTypeDataFromTypeMetadata(CanType type,
                                                       IsExact_t isExact,
-                                                      llvm::Value *metadata) {
+                                                      llvm::Value *metadata,
+                                                      MetadataState state) {
+  auto response = MetadataResponse::forBounded(metadata, state);
+
   // Remember that we have this type metadata concretely.
   if (isExact) {
     if (!metadata->hasName()) setTypeMetadataName(IGM, metadata, type);
-    setScopedLocalTypeData(type, LocalTypeDataKind::forFormalTypeMetadata(),
-                           metadata);
+    setScopedLocalTypeMetadata(type, response);
   }
 
   // Don't bother adding abstract fulfillments at a conditional dominance
@@ -309,7 +433,7 @@ void IRGenFunction::bindLocalTypeDataFromTypeMetadata(CanType type,
     return;
 
   getOrCreateLocalTypeData()
-    .addAbstractForTypeMetadata(*this, type, isExact, metadata);
+    .addAbstractForTypeMetadata(*this, type, isExact, response);
 }
 
 void IRGenFunction::bindLocalTypeDataFromSelfWitnessTable(
@@ -343,7 +467,7 @@ void IRGenFunction::bindLocalTypeDataFromSelfWitnessTable(
 void LocalTypeDataCache::addAbstractForTypeMetadata(IRGenFunction &IGF,
                                                     CanType type,
                                                     IsExact_t isExact,
-                                                    llvm::Value *metadata) {
+                                                    MetadataResponse metadata) {
   struct Callback : FulfillmentMap::InterestingKeysCallback {
     bool isInterestingType(CanType type) const override {
       return true;
@@ -370,6 +494,7 @@ void LocalTypeDataCache::addAbstractForTypeMetadata(IRGenFunction &IGF,
   // anything, stop.
   FulfillmentMap fulfillments;
   if (!fulfillments.searchTypeMetadata(IGF.IGM, type, isExact,
+                                       metadata.getStaticLowerBoundOnState(),
                                        /*source*/ 0, MetadataPath(),
                                        callbacks)) {
     return;
@@ -475,7 +600,8 @@ addAbstractForFulfillments(IRGenFunction &IGF, FulfillmentMap &&fulfillments,
     auto newEntry = new AbstractCacheEntry(IGF.getActiveDominancePoint(),
                                            isConditional,
                                            getSourceIndex(),
-                                           std::move(fulfillment.second.Path));
+                                           std::move(fulfillment.second.Path),
+                                           fulfillment.second.getState());
 
     // Add it to the front of the chain.
     chain.push_front(newEntry);
@@ -505,15 +631,16 @@ LLVM_DUMP_METHOD void LocalTypeDataCache::dump() const {
 
       switch (cur->getKind()) {
       case CacheEntry::Kind::Concrete: {
-        auto entry = static_cast<const ConcreteCacheEntry*>(cur);
-        out << "concrete: " << entry->Value << "\n  ";
-        if (!isa<llvm::Instruction>(entry->Value)) out << "  ";
-        entry->Value->dump();
+        auto entry = cast<ConcreteCacheEntry>(cur);
+        auto value = entry->Value.getMetadata();
+        out << "concrete: " << value << "\n  ";
+        if (!isa<llvm::Instruction>(value)) out << "  ";
+        value->dump();
         break;
       }
 
       case CacheEntry::Kind::Abstract: {
-        auto entry = static_cast<const AbstractCacheEntry*>(cur);
+        auto entry = cast<AbstractCacheEntry>(cur);
         out << "abstract: source=" << entry->SourceIndex << "\n";
         break;
       }

--- a/lib/IRGen/LocalTypeData.h
+++ b/lib/IRGen/LocalTypeData.h
@@ -28,6 +28,7 @@
 #include "LocalTypeDataKind.h"
 #include "DominancePoint.h"
 #include "MetadataPath.h"
+#include "MetadataRequest.h"
 #include "swift/AST/Type.h"
 #include "llvm/ADT/STLExtras.h"
 #include <utility>
@@ -36,9 +37,10 @@ namespace swift {
   class TypeBase;
 
 namespace irgen {
+  class DynamicMetadataRequest;
+  class MetadataResponse;
   class FulfillmentMap;
   enum IsExact_t : bool;
-
 
 /// A cache of local type data.
 ///
@@ -53,10 +55,8 @@ namespace irgen {
 ///     ask whether each is acceptable.
 class LocalTypeDataCache {
 public:
-  using Key = LocalTypeDataKey;
-
-  static Key getKey(CanType type, LocalTypeDataKind index) {
-    return { type, index };
+  static LocalTypeDataKey getKey(CanType type, LocalTypeDataKind index) {
+    return LocalTypeDataKey{ type, index };
   }
 
 private:
@@ -81,6 +81,16 @@ private:
     /// Return the abstract cost of evaluating this cache entry.
     OperationCost cost() const;
 
+    /// Return the abstract cost of evaluating this cache entry.
+    OperationCost costForRequest(LocalTypeDataKey key,
+                                 DynamicMetadataRequest request) const;
+
+    /// Return whether following the metadata path immediately produces
+    /// a value that's statically known to satisfy the given request, or
+    /// whether a separate dynamic check is required.
+    bool immediatelySatisfies(LocalTypeDataKey key,
+                              DynamicMetadataRequest request) const;
+
     /// Destruct and deallocate this cache entry.
     void erase() const;
 
@@ -99,13 +109,22 @@ private:
 
   /// A concrete entry in the cache, which directly stores the desired value.
   struct ConcreteCacheEntry : CacheEntry {
-    llvm::Value *Value;
+    MetadataResponse Value;
 
     ConcreteCacheEntry(DominancePoint point, bool isConditional,
-                       llvm::Value *value)
+                       MetadataResponse value)
       : CacheEntry(Kind::Concrete, point, isConditional), Value(value) {}
 
     OperationCost cost() const { return OperationCost::Free; }
+    OperationCost costForRequest(LocalTypeDataKey key,
+                                 DynamicMetadataRequest request) const;
+
+    bool immediatelySatisfies(LocalTypeDataKey key,
+                              DynamicMetadataRequest request) const;
+
+    static bool classof(const CacheEntry *entry) {
+      return entry->getKind() == Kind::Concrete;
+    }
   };
 
   /// A source of concrete data from which abstract cache entries can be
@@ -119,15 +138,16 @@ private:
   private:
     CanType Type;
     void *Conformance;
-    llvm::Value *Value;
+    MetadataResponse Value;
 
   public:
     explicit AbstractSource(CanType type, ProtocolConformanceRef conformance,
                             llvm::Value *value)
-      : Type(type), Conformance(conformance.getOpaqueValue()), Value(value) {
+      : Type(type), Conformance(conformance.getOpaqueValue()),
+        Value(MetadataResponse::forComplete(value)) {
       assert(Conformance != nullptr);
     }
-    explicit AbstractSource(CanType type, llvm::Value *value)
+    explicit AbstractSource(CanType type, MetadataResponse value)
       : Type(type), Conformance(nullptr), Value(value) {}
 
     Kind getKind() const {
@@ -141,7 +161,7 @@ private:
       assert(Conformance && "not a protocol conformance");
       return ProtocolConformanceRef::getFromOpaqueValue(Conformance);
     }
-    llvm::Value *getValue() const {
+    MetadataResponse getValue() const {
       return Value;
     }
   };
@@ -149,17 +169,42 @@ private:
   /// An abstract entry in the cache, which requires some amount of
   /// non-trivial evaluation to derive the desired value.
   struct AbstractCacheEntry : CacheEntry {
-    unsigned SourceIndex;
+    unsigned SourceIndex : 32 - LocalTypeDataValue::StateSize;
+    unsigned State : LocalTypeDataValue::StateSize;
     MetadataPath Path;
 
     AbstractCacheEntry(DominancePoint point, bool isConditional,
-                       unsigned sourceIndex, MetadataPath &&path)
+                       unsigned sourceIndex, MetadataPath &&path,
+                       MetadataState state)
       : CacheEntry(Kind::Abstract, point, isConditional),
-        SourceIndex(sourceIndex), Path(std::move(path)) {}
+        SourceIndex(sourceIndex), State(unsigned(state)),
+        Path(std::move(path)) {}
 
-    llvm::Value *follow(IRGenFunction &IGF, AbstractSource &source) const;
+    MetadataResponse follow(IRGenFunction &IGF, AbstractSource &source,
+                            DynamicMetadataRequest request) const;
+
+    /// Return the natural state of the metadata that would be produced
+    /// by just following the path.  If the path ends in calling a type
+    /// metadata accessor, it's okay to use MetadataState::Complete here
+    /// because it's just as cheap to produce that as anything else.
+    /// But if the path ends in just loading type metadata from somewhere,
+    /// this should be the presumed state of that type metadata so that
+    /// the costing accurately includes the cost of dynamically checking
+    /// the state of that metadata.
+    MetadataState getState() const {
+      return MetadataState(State);
+    }
 
     OperationCost cost() const { return Path.cost(); }
+    OperationCost costForRequest(LocalTypeDataKey key,
+                                 DynamicMetadataRequest request) const;
+
+    bool immediatelySatisfies(LocalTypeDataKey key,
+                              DynamicMetadataRequest request) const;
+
+    static bool classof(const CacheEntry *entry) {
+      return entry->getKind() == Kind::Abstract;
+    }
   };
 
   /// The linked list of cache entries corresponding to a particular key.
@@ -207,7 +252,7 @@ private:
     }
   };
 
-  llvm::DenseMap<Key, CacheEntryChain> Map;
+  llvm::DenseMap<LocalTypeDataKey, CacheEntryChain> Map;
 
   std::vector<AbstractSource> AbstractSources;
 
@@ -223,25 +268,22 @@ public:
 
   /// Load the value from cache if possible.  This may require emitting
   /// code if the value is cached abstractly.
-  llvm::Value *tryGet(IRGenFunction &IGF, Key key, bool allowAbstract = true);
-
-  /// Load the value from cache, asserting its presence.
-  llvm::Value *get(IRGenFunction &IGF, Key key) {
-    auto result = tryGet(IGF, key);
-    assert(result && "get() on unmapped entry?");
-    return result;
-  }
+  MetadataResponse tryGet(IRGenFunction &IGF, LocalTypeDataKey key,
+                          bool allowAbstract, DynamicMetadataRequest request);
 
   /// Add a new concrete entry to the cache at the given definition point.
   void addConcrete(DominancePoint point, bool isConditional,
-                   Key key, llvm::Value *value) {
+                   LocalTypeDataKey key, MetadataResponse value) {
+    assert((key.Kind.isAnyTypeMetadata() ||
+            value.isStaticallyKnownComplete()) &&
+           "only type metadata can be added in a non-complete state");
     auto newEntry = new ConcreteCacheEntry(point, isConditional, value);
     Map[key].push_front(newEntry);
   }
 
   /// Add entries based on what can be fulfilled from the given type metadata.
   void addAbstractForTypeMetadata(IRGenFunction &IGF, CanType type,
-                                  IsExact_t isExact, llvm::Value *metadata);
+                                  IsExact_t isExact, MetadataResponse value);
 
   void dump() const;
 

--- a/lib/IRGen/LocalTypeDataKind.h
+++ b/lib/IRGen/LocalTypeDataKind.h
@@ -47,7 +47,8 @@ private:
   /// to distinguish different kinds of pointer; we just assume that e.g. a
   /// ProtocolConformance will never have the same address as a Decl.
   enum : RawType {
-    TypeMetadata,
+    FormalTypeMetadata,
+    RepresentationTypeMetadata,
     ValueWitnessTable,
     // <- add more special cases here
 
@@ -65,17 +66,24 @@ public:
   
   // The magic values are all odd and so do not collide with pointer values.
   
-  /// A reference to the type metadata.
-  static LocalTypeDataKind forTypeMetadata() {
-    return LocalTypeDataKind(TypeMetadata);
+  /// A reference to the formal type metadata.
+  static LocalTypeDataKind forFormalTypeMetadata() {
+    return LocalTypeDataKind(FormalTypeMetadata);
   }
 
-  /// A reference to the value witness table.
+  /// A reference to type metadata for a representation-compatible type.
+  static LocalTypeDataKind forRepresentationTypeMetadata() {
+    return LocalTypeDataKind(RepresentationTypeMetadata);
+  }
+
+  /// A reference to the value witness table for a representation-compatible
+  /// type.
   static LocalTypeDataKind forValueWitnessTable() {
     return LocalTypeDataKind(ValueWitnessTable);
   }
 
-  /// A reference to a specific value witness.
+  /// A reference to a specific value witness for a representation-compatible
+  /// type.
   static LocalTypeDataKind forValueWitness(ValueWitness witness) {
     return LocalTypeDataKind(ValueWitnessBase + (unsigned)witness);
   }
@@ -180,11 +188,11 @@ template <> struct llvm::DenseMapInfo<swift::irgen::LocalTypeDataKey> {
   using CanTypeInfo = DenseMapInfo<swift::CanType>;
   static inline LocalTypeDataKey getEmptyKey() {
     return { CanTypeInfo::getEmptyKey(),
-             swift::irgen::LocalTypeDataKind::forTypeMetadata() };
+             swift::irgen::LocalTypeDataKind::forFormalTypeMetadata() };
   }
   static inline LocalTypeDataKey getTombstoneKey() {
     return { CanTypeInfo::getTombstoneKey(),
-             swift::irgen::LocalTypeDataKind::forTypeMetadata() };
+             swift::irgen::LocalTypeDataKind::forFormalTypeMetadata() };
   }
   static unsigned getHashValue(const LocalTypeDataKey &key) {
     return combineHashValue(CanTypeInfo::getHashValue(key.Type),

--- a/lib/IRGen/LocalTypeDataKind.h
+++ b/lib/IRGen/LocalTypeDataKind.h
@@ -117,6 +117,11 @@ public:
 
   LocalTypeDataKind getCachingKind() const;
 
+  bool isAnyTypeMetadata() const {
+    return Value == FormalTypeMetadata ||
+           Value == RepresentationTypeMetadata;
+  }
+
   bool isSingletonKind() const {
     return (Value < FirstPayloadValue);
   }
@@ -169,6 +174,9 @@ class LocalTypeDataKey {
 public:
   CanType Type;
   LocalTypeDataKind Kind;
+
+  LocalTypeDataKey(CanType type, LocalTypeDataKind kind)
+    : Type(type), Kind(kind) {}
 
   LocalTypeDataKey getCachingKey() const;
 

--- a/lib/IRGen/MetadataPath.h
+++ b/lib/IRGen/MetadataPath.h
@@ -31,11 +31,32 @@ namespace swift {
   class ProtocolDecl;
   class CanType;
   class Decl;
+  enum class MetadataState : size_t;
 
 namespace irgen {
+  class DynamicMetadataRequest;
   class IRGenFunction;
   class LocalTypeDataKey;
+  class LocalTypeDataValue;
+  class MetadataResponse;
 
+class LocalTypeDataValue {
+public:
+  enum { StateSize = 2 };
+
+private:
+  llvm::PointerIntPair<llvm::Value*, StateSize, MetadataState> Value;
+
+public:
+  LocalTypeDataValue() {}
+  LocalTypeDataValue(llvm::Value *value, MetadataState state)
+    : Value(value, state) {}
+
+  explicit operator bool() const { return Value.getOpaqueValue() != nullptr; }
+
+  llvm::Value *getValue() const { return Value.getPointer(); }
+  MetadataState getState() const { return Value.getInt(); }
+};
 
 /// A path from one source metadata --- either Swift type metadata or a Swift
 /// protocol conformance --- to another.
@@ -187,17 +208,19 @@ public:
   }
 
   /// Given a pointer to type metadata, follow a path from it.
-  llvm::Value *followFromTypeMetadata(IRGenFunction &IGF,
-                                      CanType sourceType,
-                                      llvm::Value *source,
-                                      Map<llvm::Value*> *cache) const;
+  MetadataResponse followFromTypeMetadata(IRGenFunction &IGF,
+                                          CanType sourceType,
+                                          MetadataResponse source,
+                                          DynamicMetadataRequest request,
+                                          Map<MetadataResponse> *cache) const;
 
   /// Given a pointer to a protocol witness table, follow a path from it.
-  llvm::Value *followFromWitnessTable(IRGenFunction &IGF,
-                                      CanType conformingType,
-                                      ProtocolConformanceRef conformance,
-                                      llvm::Value *source,
-                                      Map<llvm::Value*> *cache) const;
+  MetadataResponse followFromWitnessTable(IRGenFunction &IGF,
+                                          CanType conformingType,
+                                          ProtocolConformanceRef conformance,
+                                          MetadataResponse source,
+                                          DynamicMetadataRequest request,
+                                          Map<MetadataResponse> *cache) const;
 
   template <typename Allocator>
   const reflection::MetadataSource *
@@ -227,18 +250,20 @@ public:
   }
 
 private:
-  static llvm::Value *follow(IRGenFunction &IGF,
-                             LocalTypeDataKey key,
-                             llvm::Value *source,
-                             MetadataPath::iterator begin,
-                             MetadataPath::iterator end,
-                             Map<llvm::Value*> *cache);
+  static MetadataResponse follow(IRGenFunction &IGF,
+                                 LocalTypeDataKey key,
+                                 MetadataResponse source,
+                                 MetadataPath::iterator begin,
+                                 MetadataPath::iterator end,
+                                 DynamicMetadataRequest request,
+                                 Map<MetadataResponse> *cache);
 
   /// Follow a single component of a metadata path.
-  static llvm::Value *followComponent(IRGenFunction &IGF,
-                                      LocalTypeDataKey &key,
-                                      llvm::Value *source,
-                                      Component component);
+  static MetadataResponse followComponent(IRGenFunction &IGF,
+                                          LocalTypeDataKey &key,
+                                          MetadataResponse source,
+                                          Component component,
+                                          DynamicMetadataRequest request);
 };
 
 } // end namespace irgen

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -75,7 +75,7 @@ llvm::Value *MetadataResponse::getDynamicState(IRGenFunction &IGF) const {
 }
 
 llvm::Constant *MetadataResponse::getCompletedState(IRGenModule &IGM) {
-  return IGM.getSize(Size(MetadataRequest::Complete));
+  return IGM.getSize(Size(size_t(MetadataState::Complete)));
 }
 
 llvm::Value *MetadataDependency::combine(IRGenFunction &IGF) const {
@@ -90,7 +90,7 @@ llvm::Value *MetadataDependency::combine(IRGenFunction &IGF) const {
 
 llvm::Constant *MetadataDependency::getRequiredState(IRGenFunction &IGF) const {
   assert(isNonTrivial());
-  return IGF.IGM.getSize(Size(RequiredState));
+  return IGF.IGM.getSize(Size(size_t(RequiredState)));
 }
 
 llvm::Constant *MetadataDependency::getTrivialDependency(IRGenModule &IGM) {
@@ -583,7 +583,7 @@ static MetadataResponse emitTupleTypeMetadataRef(IRGenFunction &IGF,
 
   // FIXME: at least propagate dependency failure here.
   // FIXME: allow abstract creation when the runtime supports that.
-  DynamicMetadataRequest eltRequest = MetadataRequest::Complete;
+  DynamicMetadataRequest eltRequest = MetadataState::Complete;
 
   switch (type->getNumElements()) {
   case 0:
@@ -1535,14 +1535,14 @@ emitTypeMetadataAccessFunctionBody(IRGenFunction &IGF,
   // We only take this path for non-generic nominal types.
   auto typeDecl = type->getAnyNominal();
   if (!typeDecl)
-    return emitDirectTypeMetadataRef(IGF, type, MetadataRequest::Complete)
+    return emitDirectTypeMetadataRef(IGF, type, MetadataState::Complete)
              .getMetadata();
 
   if (typeDecl->isGenericContext() &&
       !(isa<ClassDecl>(typeDecl) &&
         isa<ClangModuleUnit>(typeDecl->getModuleScopeContext()))) {
     // This is a metadata accessor for a fully substituted generic type.
-    return emitDirectTypeMetadataRef(IGF, type, MetadataRequest::Complete)
+    return emitDirectTypeMetadataRef(IGF, type, MetadataState::Complete)
              .getMetadata();
   }
 
@@ -1720,12 +1720,12 @@ emitCallToTypeMetadataAccessFunction(IRGenFunction &IGF,
 }
 
 llvm::Value *IRGenFunction::emitAbstractTypeMetadataRef(CanType type) {
-  return emitTypeMetadataRef(type, MetadataRequest::Abstract).getMetadata();
+  return emitTypeMetadataRef(type, MetadataState::Abstract).getMetadata();
 }
 
 /// Produce the type metadata pointer for the given type.
 llvm::Value *IRGenFunction::emitTypeMetadataRef(CanType type) {
-  return emitTypeMetadataRef(type, MetadataRequest::Complete).getMetadata();
+  return emitTypeMetadataRef(type, MetadataState::Complete).getMetadata();
 }
 
 /// Produce the type metadata pointer for the given type.
@@ -1924,7 +1924,7 @@ namespace {
 } // end anonymous namespace
 
 llvm::Value *IRGenFunction::emitTypeMetadataRefForLayout(SILType type) {
-  return emitTypeMetadataRefForLayout(type, MetadataRequest::Complete);
+  return emitTypeMetadataRefForLayout(type, MetadataState::Complete);
 }
 
 llvm::Value *

--- a/lib/IRGen/MetadataRequest.h
+++ b/lib/IRGen/MetadataRequest.h
@@ -24,6 +24,7 @@ namespace llvm {
 class Constant;
 class Function;
 class GlobalVariable;
+class PHINode;
 class Value;
 }
 
@@ -35,19 +36,84 @@ class ConstantReference;
 class Explosion;
 class IRGenFunction;
 class IRGenModule;
+class MetadataDependencyCollector;
+class MetadataResponse;
+enum class OperationCost : unsigned;
 enum class SymbolReferenceKind : unsigned char;
 
-/// A dynamic metadata request.
+/// Given the metadata state for a generic type metadata, return the presumed
+/// state of type metadata for its arguments.
+inline MetadataState
+getPresumedMetadataStateForTypeArgument(MetadataState typeState) {
+  return (typeState == MetadataState::Complete
+            ? MetadataState::Complete
+            : MetadataState::Abstract);
+}
+
+/// The compile-time representation of a metadata request.  There are
+/// essentially three patterns of use here:
+///
+/// - In the first pattern, the request is static and blocking, meaning
+///   that the operation which produces the metadata should not return
+///   until it's able to return a metadata that's in the requested state.
+///   Most places in IRGen will use blocking requests, often for complete
+///   metadata, because operations like allocating a value or passing a
+///   metadata off as a generic parameter (or metatype value) (1) cannot be
+///   performed without the metadata in the right state but also (2) cannot
+///   be suspended to await the production of the metadata.
+///
+/// - In the second pattern, the request is static and non-blocking, and
+///   there is a dependency collector associated with the request.  This is
+///   used in the special case of a type metadata's initialization phase.
+///   This phase can fail, but when it does so, it must report a type
+///   metadata (and its requested state) that it is blocked on.  The runtime
+///   will then delay the initialization of that type metadata until its
+///   dependency is resolved.
+///
+/// - In the final pattern, the request is a dynamic value.  This is used
+///   primarily in type metadata access functions like the global
+///   access functions for generic types or the associated type access
+///   functions on protocol witness tables.  These functions must report
+///   the actual best-known dynamic state of the metadata that they return.
+///   Access functions that memoize their result must therefore suppress the
+///   memoization when the metadata is not yet complete.
 class DynamicMetadataRequest {
   MetadataRequest StaticRequest;
   llvm::Value *DynamicRequest = nullptr;
+  MetadataDependencyCollector *Dependencies = nullptr;
 public:
+  /// Create a blocking request for the given metadata state.
   DynamicMetadataRequest(MetadataState request)
     : DynamicMetadataRequest(MetadataRequest(request)) {}
+
+  /// Create a request for the given static request.
+  ///
+  /// Note that non-blocking requests will generally just propagate out
+  /// in the MetadataResponse, treated as statically abstract, unless
+  /// there's a dependency collector installed.
   DynamicMetadataRequest(MetadataRequest request)
     : StaticRequest(request), DynamicRequest(nullptr) {}
+
+  /// Create a request for the given dynamic request.
   explicit DynamicMetadataRequest(llvm::Value *request)
     : StaticRequest(), DynamicRequest(request) {}
+
+  /// If a collector is provided, create a non-blocking request that
+  /// will branch to the collector's destination if the response doesn't
+  /// satisfy the request.  Otherwise, use a blocking request.
+  ///
+  /// FIXME: ensure the existence of a collector in all the places that
+  /// need one.
+  static DynamicMetadataRequest
+  getNonBlocking(MetadataState requiredState,
+                 MetadataDependencyCollector *collector) {
+    if (!collector) return requiredState;
+
+    DynamicMetadataRequest request =
+      MetadataRequest(requiredState, /*non-blocking*/ true);
+    request.Dependencies = collector;
+    return request;
+  }
 
   bool isStatic() const { return DynamicRequest == nullptr; }
   MetadataRequest getStaticRequest() const {
@@ -60,45 +126,200 @@ public:
     return DynamicRequest;
   }
 
+  MetadataDependencyCollector *getDependencyCollector() const {
+    return Dependencies;
+  }
+
   /// If a function call taking this request returns a MetadataResponse,
   /// can the status of a MetadataResponse be generally ignored?
   bool canResponseStatusBeIgnored() const {
-    return isStatic() && StaticRequest.isBlocking();
+    // If we have a statically satisfied request, it cannot have failed.
+    // If have a dependency collector, we'll have checked the result when
+    // first forming the MetadataResponse.
+    return isStaticallyAlwaysSatisfied() || Dependencies != nullptr;
   }
 
-  /// Is this request statically known to be blocking on success?
-  ///
-  /// This is a useful query because the result of such a request is
-  /// always statically-known complete.
+  /// Is this request statically known to yield a result that satisfies
+  /// the request?
+  bool isStaticallyAlwaysSatisfied() const {
+    return isStatic() &&
+           (StaticRequest.isBlocking() ||
+            StaticRequest.getState() == MetadataState::Abstract);
+  }
+
+  /// Is this request statically known to yield a result that's fully
+  /// completed?
   bool isStaticallyBlockingComplete() const {
     return isStatic() && StaticRequest == MetadataState::Complete;
   }
 
+  /// Is this request statically known to be an abstract request?
+  bool isStaticallyAbstract() const {
+    return isStatic() && StaticRequest == MetadataState::Abstract;
+  }
+
+  /// Does state of the given kind definitely satisfy this request?
+  bool isSatisfiedBy(MetadataState state) const {
+    return isAtLeast(state, getStaticUpperBoundOnRequestedState());
+  }
+
+  /// Is the given metadata response statically known to satisfy this request?
+  bool isSatisfiedBy(MetadataResponse response) const;
+
+  /// Return a conservative bound on the state being requested by this
+  /// request.
+  MetadataState getStaticUpperBoundOnRequestedState() const {
+    return (isStatic() ? StaticRequest.getState() : MetadataState::Complete);
+  }
+
+  /// Return a conservative bound on the result of a MetadataResponse
+  /// arising from this request.
+  MetadataState getStaticLowerBoundOnResponseState() const {
+    // If we have a static request, and it's either blocking or we're
+    // collecting failures as dependencies immediately, then we can use
+    // the static request's kind.
+    //
+    // The dependency-collection rule works because the emitter is obliged
+    // to deal with dominance points appropriately if it's going to try to
+    // recover after the dependency collection.
+    if (isStatic() && canResponseStatusBeIgnored())
+      return StaticRequest.getState();
+
+    // Otherwise, the response can't be assumed to be better than abstract.
+    return MetadataState::Abstract;
+  }
+
+  /// Return this request value as an IR value.
   llvm::Value *get(IRGenFunction &IGF) const;
+
+  /// Project the required state (the basic kind) of this request as
+  /// an IR value.
+  llvm::Value *getRequiredState(IRGenFunction &IGF) const;
 };
 
-/// See the comment for swift::MetadataResponse in Metadata.h.
+/// A response to a metadata request (but see below for other ways in which
+/// this type is used).  In addition to a type metadata reference, the response
+/// includes static and dynamic information about the state of the metadata.
+///
+/// A type metadata technically goes through a progression of phases.  Many
+/// metadata just start in the final "complete" phase, but it's important
+/// to understand this phase progression in order to understand what happens
+/// in the more complex cases.
+///
+/// - The first phase of the metadata is called "allocation", and it ensures
+///   that there is exactly one metadata for a particular type.  We don't
+///   need to say anything else about metadata allocation here, however,
+///   because a metadata object in this phase is never exposed outside of
+///   the runtime (and narrow confines of the metadata allocation function).
+///   This is also why MetadataState does not have an enumerator for this state.
+///
+/// - Once a metadata has been allocated, it is considered to be "abstract".
+///   An abstract metadata only has enough structure to represent its basic
+///   identity as a type: its type kind and the basic components of its
+///   identity.  For example, A<T> will always store the type descriptor
+///   for A and the type metadata for T, but it does not necessarily have
+///   anything else, like a value witness table or a superclass reference.
+///
+/// - A metadata is said to be "layout-complete" if it has a meaningful
+///   "external layout", the principal component of which is a meaningful
+///   value witness table.  Such a metadata allows other types which store
+///   values of the metadata's type to be laid out.  However, there may still
+///   be restrictions on the use of the metadata which make it unready
+///   for general use.
+///
+///   Some types may have no observable abstract phase.  For example, all
+///   class types are layout-complete immediately upon allocation, as are
+///   value types with a fixed layout for all instantiations.
+///
+/// - A metadata is said to be "complete" if it supports all possible
+///   operations on the type.  This includes any necessary "internal layout",
+///   such as the field layout of a class type, as well as any sundry
+///   initialization tasks like the registration of a class type with the
+///   Objective-C runtime.  This is also the first phase of a class metadata
+///   that promises that it has a superclass pointer.  Furthermore, some
+///   types make stronger transitive guarantees about the state of their
+///   stored component types when they are complete than when they are in
+///   earlier stages.
+///
+/// --
+///
+/// A MetadataResponse stores two pieces of information about its state.
+///
+/// The first piece of information is a static lower bound (i.e. a
+/// conservative estimate) on the state.  This will always be at least
+/// MetadataState::Abstract, since no metadata in general circulation can
+/// still be undergoing allocation.  It may be higher than that because of
+/// static information about the request or the type being requested.
+///
+/// The second piece of information is the dynamic state of the metadata.
+/// When metadata is fetched from the runtime, the runtime will report
+/// its current known state.  We cache this state and generally assume that
+/// nothing in the function will cause it to change.  This is okay because:
+///
+/// - with blocking requests, we will generally ignore the dynamic state
+///   and instead just block waiting for the runtime to report that the
+///   metadata has reached the requested state, whereas
+///
+/// - with non-blocking and dynamic requests, ephemeral staleness is
+///   recoverable --- in fact, it has to be, because of course as soon as
+///   the runtime has finished reporting a state, that state has become
+///   potentially stale due to concurrent initialization).
+///
+/// Other than fetching metadata from the runtime, most of the ways that
+/// we produce metadata guarantee that the metadata is complete.  For example,
+/// fixed-layout non-generic value types just provide complete metadata at
+/// known global symbols.  There are a few rare exceptions where we do need
+/// pull metadata from somewhere but don't actually know its dynamic state.
+/// For example, it would be unwise to try to store the dynamic state of
+/// a generic type argument in the generic type's metadata; unlike the
+/// arguments above, such an approach would be highly non-ephemeral and
+/// create substantial staleness problems.  For these situations, the
+/// runtime provides a function, swift_checkMetadataState, to request (or
+/// block on) the current state of a type metadata.
+///
+/// --
+/// 
+/// While this class is principally used to report the response to a type
+/// metadata request, it does have some secondary uses.
+///
+/// The first secondary use is that it is sometimes used to store other
+/// forms of local type data so that common code structures can work with
+/// both them and type metadata.  For example, concrete local type data are
+/// stored in a MetadataResponse even though they aren't always type metadata.
+/// When this is happening, the metadata state will always be statically
+/// complete.
+///
+/// The second secondary use is that it's sometimes used to just store the
+/// known state of a fetched metadata in a more persistent way.  This is
+/// because many of the places that store metadata have at least some case
+/// where it's important to known either the static bound on the metadata
+/// state or, more importantly, to report the actual dynamic state that was
+/// reported when the metadata was first acquired.  Propagating the metadata
+/// as a MetadataResponse makes this straightforward.
 class MetadataResponse {
   llvm::Value *Metadata;
-  llvm::Value *State;
+  llvm::PointerIntPair<llvm::Value*, 2, MetadataState> State;
 
 public:
   MetadataResponse() : Metadata(nullptr) {}
 
   /// A metadata response that might not be dynamically complete.
-  explicit MetadataResponse(llvm::Value *metadata, llvm::Value *state)
-      : Metadata(metadata), State(state) {
+  explicit MetadataResponse(llvm::Value *metadata, llvm::Value *state,
+                            MetadataState staticLowerBoundState)
+      : Metadata(metadata), State(state, staticLowerBoundState) {
     assert(metadata && "must be valid");
-    assert(state && "must be valid");
+  }
+
+  /// A metadata response whose actual dynamic state is unknown but for
+  /// which we do have a static lower-bound.
+  static MetadataResponse forBounded(llvm::Value *metadata,
+                                     MetadataState staticLowerBoundState) {
+    return MetadataResponse(metadata, nullptr, staticLowerBoundState);
   }
 
   /// A metadata response that's known to be complete.
   static MetadataResponse forComplete(llvm::Value *metadata) {
-    assert(metadata && "must be valid");
-    MetadataResponse result;
-    result.Metadata = metadata;
-    result.State = nullptr;
-    return result;
+    return MetadataResponse::forBounded(metadata, MetadataState::Complete);
   }
 
   /// An undef metadata response.
@@ -109,14 +330,35 @@ public:
 
   bool isStaticallyKnownComplete() const {
     assert(isValid());
-    return State == nullptr;
+    return getStaticLowerBoundOnState() == MetadataState::Complete;
   }
 
   llvm::Value *getMetadata() const {
     assert(isValid());
     return Metadata;
   }
-  llvm::Value *getDynamicState(IRGenFunction &IGF) const;
+
+  /// Does this response have a dynamic state value?
+  bool hasDynamicState() const {
+    assert(isValid());
+    return State.getPointer() != nullptr;
+  }
+
+  /// Ensure that this response has a dynamic state value, by re-checking it
+  /// if necessary.
+  void ensureDynamicState(IRGenFunction &IGF) &;
+
+  llvm::Value *getDynamicState() const {
+    assert(isValid());
+    assert(hasDynamicState() && "must ensure dynamic state before fetching it");
+    return State.getPointer();
+  }
+
+  /// Return the best lower bound state on the state of this metadata.
+  MetadataState getStaticLowerBoundOnState() const {
+    assert(isValid());
+    return State.getInt();
+  }
 
   static MetadataResponse handle(IRGenFunction &IGF,
                                  DynamicMetadataRequest request,
@@ -128,22 +370,26 @@ public:
   static llvm::Constant *getCompletedState(IRGenModule &IGM);
 };
 
+inline bool
+DynamicMetadataRequest::isSatisfiedBy(MetadataResponse response) const {
+  return isSatisfiedBy(response.getStaticLowerBoundOnState());
+}
+
 /// A dependency that is blocking a metadata initialization from completing.
 class MetadataDependency {
   llvm::Value *RequiredMetadata;
-  MetadataState RequiredState;
+  llvm::Value *RequiredState;
 public:
   /// Construct the null dependency, i.e. the initialization is not blocked.
-  MetadataDependency()
-      : RequiredMetadata(nullptr), RequiredState(MetadataState::Complete) {}
+  constexpr MetadataDependency()
+      : RequiredMetadata(nullptr), RequiredState(nullptr) {}
 
   /// Construct a non-trivial dependency.
   MetadataDependency(llvm::Value *requiredMetadata,
-                     MetadataState requiredState)
+                     llvm::Value *requiredState)
       : RequiredMetadata(requiredMetadata), RequiredState(requiredState) {
     assert(requiredMetadata != nullptr);
-    assert(requiredState != MetadataState::Abstract &&
-           "cannot have trivial requirement on abstract state!");
+    assert(requiredState != nullptr);
   }
 
   bool isTrivial() const { return RequiredMetadata == nullptr; }
@@ -158,15 +404,38 @@ public:
 
   /// Return the state that the metadata needs to reach before the
   /// initialization is unblocked.
-  MetadataState getRequiredState() const {
+  llvm::Value *getRequiredState() const {
     assert(isNonTrivial());
     return RequiredState;
   }
-  llvm::Constant *getRequiredState(IRGenFunction &IGF) const;
 
-  static llvm::Constant *getTrivialDependency(IRGenModule &IGM);
+  static llvm::Constant *getTrivialCombinedDependency(IRGenModule &IGM);
 
   llvm::Value *combine(IRGenFunction &IGF) const;
+};
+
+/// A class for dynamically collecting metadata dependencies.
+class MetadataDependencyCollector {
+  llvm::PHINode *RequiredMetadata = nullptr;
+  llvm::PHINode *RequiredState = nullptr;
+
+public:
+  MetadataDependencyCollector() = default;
+  MetadataDependencyCollector(const MetadataDependencyCollector &) = delete;
+  MetadataDependencyCollector &operator=(const MetadataDependencyCollector &) = delete;
+  ~MetadataDependencyCollector() {
+    assert(RequiredMetadata == nullptr &&
+           "failed to finish MetadataDependencyCollector");
+  }
+
+  /// Check the dependency.  This takes a metadata and state separately
+  /// instead of taking a MetadataResponse because it's quite important
+  /// that we not rely on anything from MetadataResponse that might assume
+  /// that we've already done dependency collection.
+  void checkDependency(IRGenFunction &IGF, DynamicMetadataRequest request,
+                       llvm::Value *metadata, llvm::Value *state);
+
+  MetadataDependency finish(IRGenFunction &IGF);
 };
 
 enum class MetadataAccessStrategy {
@@ -270,10 +539,13 @@ enum class MetadataValueType { ObjCClass, TypeMetadata };
 
 /// Emit a reference to the heap metadata for a class.
 ///
+/// Only requests whose response status can be ignored can be used.
+///
 /// \returns a value of type ObjCClassPtrTy or TypeMetadataPtrTy,
 ///    depending on desiredType
 llvm::Value *emitClassHeapMetadataRef(IRGenFunction &IGF, CanType type,
                                       MetadataValueType desiredType,
+                                      DynamicMetadataRequest request,
                                       bool allowUninitialized = false);
 
 /// Emit a reference to the (initialized) ObjC heap metadata for a class.
@@ -293,6 +565,29 @@ llvm::Value *emitObjCMetadataRefForMetadata(IRGenFunction &IGF,
 llvm::Value *emitClassHeapMetadataRefForMetatype(IRGenFunction &IGF,
                                                  llvm::Value *metatype,
                                                  CanType type);
+
+/// Emit a reference to a type layout record for the given type. The referenced
+/// data is enough to lay out an aggregate containing a value of the type, but
+/// can't uniquely represent the type or perform value witness operations on
+/// it.
+llvm::Value *emitTypeLayoutRef(IRGenFunction &IGF, SILType type,
+                               MetadataDependencyCollector *collector);
+
+/// Given type metadata that we don't know the dynamic state of,
+/// fetch its dynamic state under the rules of the given request.
+MetadataResponse emitGetTypeMetadataDynamicState(IRGenFunction &IGF,
+                                                 DynamicMetadataRequest request,
+                                                 llvm::Value *metadata);
+
+/// Given a metadata response, ensure that it satisfies the requirements
+/// of the given request.
+MetadataResponse emitCheckTypeMetadataState(IRGenFunction &IGF,
+                                            DynamicMetadataRequest request,
+                                            MetadataResponse response);
+
+/// Return the abstract operational cost of a checkTypeMetadataState operation.
+OperationCost getCheckTypeMetadataStateCost(DynamicMetadataRequest request,
+                                            MetadataResponse response);
 
 } // end namespace irgen
 } // end namespace swift

--- a/lib/IRGen/NecessaryBindings.h
+++ b/lib/IRGen/NecessaryBindings.h
@@ -27,6 +27,7 @@
 
 namespace swift {
   class CanType;
+  enum class MetadataState : size_t;
   class ProtocolDecl;
   class ProtocolConformanceRef;
 
@@ -78,7 +79,7 @@ public:
   void save(IRGenFunction &IGF, Address buffer) const;
 
   /// Restore the necessary bindings from the given buffer.
-  void restore(IRGenFunction &IGF, Address buffer) const;
+  void restore(IRGenFunction &IGF, Address buffer, MetadataState state) const;
 
   const llvm::SetVector<GenericRequirement> &getRequirements() const {
     return Requirements;

--- a/lib/IRGen/ResilientTypeInfo.h
+++ b/lib/IRGen/ResilientTypeInfo.h
@@ -155,15 +155,6 @@ public:
     emitStoreExtraInhabitantCall(IGF, T, index, dest);
   }
 
-  void initializeMetadata(IRGenFunction &IGF,
-                          llvm::Value *metadata,
-                          bool isVWTMutable,
-                          SILType T) const override {
-    // Resilient value types and archetypes always refer to an existing type.
-    // A witness table should never be independently initialized for one.
-    llvm_unreachable("initializing value witness table for opaque type?!");
-  }
-
   llvm::Value *getEnumTagSinglePayload(IRGenFunction &IGF,
                                        llvm::Value *numEmptyCases,
                                        Address enumAddr,

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -388,13 +388,6 @@ public:
                                     Address dest,
                                     SILType T) const = 0;
   
-  /// Initialize a freshly instantiated value witness table. Should be a no-op
-  /// for fixed-size types.
-  virtual void initializeMetadata(IRGenFunction &IGF,
-                                  llvm::Value *metadata,
-                                  bool isVWTMutable,
-                                  SILType T) const = 0;
-
   /// Get the tag of a single payload enum with a payload of this type (\p T) e.g
   /// Optional<T>.
   virtual llvm::Value *getEnumTagSinglePayload(IRGenFunction &IGF,

--- a/stdlib/public/runtime/Enum.cpp
+++ b/stdlib/public/runtime/Enum.cpp
@@ -50,14 +50,17 @@ swift::swift_initEnumMetadataSingleCase(EnumMetadata *self,
                                         const TypeLayout *payloadLayout) {
   auto vwtable = getMutableVWTableForInit(self, layoutFlags);
 
-  vwtable->size = payloadLayout->size;
-  vwtable->stride = payloadLayout->stride;
-  vwtable->flags = payloadLayout->flags.withEnumWitnesses(true);
+  TypeLayout layout;
+  layout.size = payloadLayout->size;
+  layout.stride = payloadLayout->stride;
+  layout.flags = payloadLayout->flags.withEnumWitnesses(true);
 
   if (payloadLayout->flags.hasExtraInhabitants()) {
     auto ew = static_cast<ExtraInhabitantsValueWitnessTable*>(vwtable);
     ew->extraInhabitantFlags = payloadLayout->getExtraInhabitantFlags();
   }
+
+  vwtable->publishLayout(layout);
 }
 
 void
@@ -86,13 +89,14 @@ swift::swift_initEnumMetadataSinglePayload(EnumMetadata *self,
   auto vwtable = getMutableVWTableForInit(self, layoutFlags);
   
   size_t align = payloadLayout->flags.getAlignment();
-  vwtable->size = size;
-  vwtable->flags = payloadLayout->flags
+  TypeLayout layout;
+  layout.size = size;
+  layout.flags = payloadLayout->flags
     .withExtraInhabitants(unusedExtraInhabitants > 0)
     .withEnumWitnesses(true)
     .withInlineStorage(ValueWitnessTable::isValueInline(size, align));
   auto rawStride = llvm::alignTo(size, align);
-  vwtable->stride = rawStride == 0 ? 1 : rawStride;
+  layout.stride = rawStride == 0 ? 1 : rawStride;
   
   // Substitute in better common value witnesses if we have them.
   // If the payload type is a single-refcounted pointer, and the enum has
@@ -116,7 +120,7 @@ swift::swift_initEnumMetadataSinglePayload(EnumMetadata *self,
 #include "swift/ABI/ValueWitness.def"
   } else {
 #endif
-    installCommonValueWitnesses(vwtable);
+    installCommonValueWitnesses(layout, vwtable);
 #if OPTIONAL_OBJECT_OPTIMIZATION
   }
 #endif
@@ -129,6 +133,8 @@ swift::swift_initEnumMetadataSinglePayload(EnumMetadata *self,
     xiVWTable->extraInhabitantFlags = ExtraInhabitantFlags()
       .withNumExtraInhabitants(unusedExtraInhabitants);
   }
+
+  vwtable->publishLayout(layout);
 }
 
 unsigned swift::swift_getEnumCaseSinglePayload(const OpaqueValue *value,
@@ -191,8 +197,9 @@ swift::swift_initEnumMetadataMultiPayload(EnumMetadata *enumType,
   auto vwtable = getMutableVWTableForInit(enumType, layoutFlags);
 
   // Set up the layout info in the vwtable.
-  vwtable->size = totalSize;
-  vwtable->flags = ValueWitnessFlags()
+  TypeLayout layout;
+  layout.size = totalSize;
+  layout.flags = ValueWitnessFlags()
     .withAlignmentMask(alignMask)
     .withPOD(isPOD)
     .withBitwiseTakable(isBT)
@@ -202,9 +209,11 @@ swift::swift_initEnumMetadataMultiPayload(EnumMetadata *enumType,
     .withInlineStorage(ValueWitnessTable::isValueInline(totalSize, alignMask+1))
     ;
   auto rawStride = (totalSize + alignMask) & ~alignMask;
-  vwtable->stride = rawStride == 0 ? 1 : rawStride;
+  layout.stride = rawStride == 0 ? 1 : rawStride;
   
-  installCommonValueWitnesses(vwtable);
+  installCommonValueWitnesses(layout, vwtable);
+
+  vwtable->publishLayout(layout);
 }
 
 namespace {

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -185,21 +185,21 @@ namespace {
       auto metadata =
         pattern->InstantiationFunction(description, arguments, pattern);
 
-      MetadataRequest::BasicKind state;
+      MetadataState state;
       if (pattern->CompletionFunction.isNull()) {
-        state = MetadataRequest::Complete;
+        state = MetadataState::Complete;
       } else {
         state = inferStateForMetadata(metadata);
       }
       return { metadata, state };
     }
 
-    MetadataRequest::BasicKind inferStateForMetadata(Metadata *metadata) {
+    MetadataState inferStateForMetadata(Metadata *metadata) {
       if (metadata->getValueWitnesses()->isIncomplete())
-        return MetadataRequest::Abstract;
+        return MetadataState::Abstract;
 
       // TODO: internal vs. external layout-complete?
-      return MetadataRequest::LayoutComplete;
+      return MetadataState::LayoutComplete;
     }
 
     // Note that we have to pass 'arguments' separately here instead of
@@ -217,7 +217,7 @@ namespace {
       auto dependency = pattern->CompletionFunction(metadata, context, pattern);
 
       auto state = dependency.Value == nullptr
-                     ? MetadataRequest::Complete
+                     ? MetadataState::Complete
                      : inferStateForMetadata(metadata);
 
       return { state, dependency.State, dependency.Value };
@@ -3259,7 +3259,7 @@ static Result performOnMetadataCache(const Metadata *metadata,
 bool swift::addToMetadataQueue(
                   std::unique_ptr<MetadataCompletionQueueEntry> &&queueEntry,
                   const Metadata *dependency,
-                  MetadataRequest::BasicKind dependencyRequirement) {
+                  MetadataState dependencyRequirement) {
   struct EnqueueCallbacks {
     std::unique_ptr<MetadataCompletionQueueEntry> &&QueueEntry;
 
@@ -3283,7 +3283,7 @@ void swift::resumeMetadataCompletion(
     std::unique_ptr<MetadataCompletionQueueEntry> &&QueueEntry;
 
     static MetadataRequest getRequest() {
-      return MetadataRequest(MetadataRequest::Complete,
+      return MetadataRequest(MetadataState::Complete,
                              /*non-blocking*/ true);
     }
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -1087,22 +1087,15 @@ static const ValueWitnessTable tuple_witnesses_nonpod_noninline = {
   0
 };
 
-namespace {
-struct BasicLayout {
-  size_t size;
-  ValueWitnessFlags flags;
-  size_t stride;
+static constexpr TypeLayout getInitialLayoutForValueType() {
+  return {0, ValueWitnessFlags().withAlignment(1).withPOD(true), 0};
+}
 
-  static constexpr BasicLayout initialForValueType() {
-    return {0, ValueWitnessFlags().withAlignment(1).withPOD(true), 0};
-  }
-
-  static constexpr BasicLayout initialForHeapObject() {
-    return {sizeof(HeapObject),
-            ValueWitnessFlags().withAlignment(alignof(HeapObject)),
-            sizeof(HeapObject)};
-  }
-};
+static constexpr TypeLayout getInitialLayoutForHeapObject() {
+  return {sizeof(HeapObject),
+          ValueWitnessFlags().withAlignment(alignof(HeapObject)),
+          sizeof(HeapObject)};
+}
 
 static size_t roundUpToAlignMask(size_t size, size_t alignMask) {
   return (size + alignMask) & ~alignMask;
@@ -1114,10 +1107,10 @@ static size_t roundUpToAlignMask(size_t size, size_t alignMask) {
 /// FUNCTOR should have signature:
 ///   void (size_t index, const Metadata *type, size_t offset)
 template<typename FUNCTOR, typename LAYOUT>
-void performBasicLayout(BasicLayout &layout,
-                        const LAYOUT * const *elements,
-                        size_t numElements,
-                        FUNCTOR &&f) {
+static void performBasicLayout(TypeLayout &layout,
+                               const LAYOUT * const *elements,
+                               size_t numElements,
+                               FUNCTOR &&f) {
   size_t size = layout.size;
   size_t alignMask = layout.flags.getAlignmentMask();
   bool isPOD = layout.flags.isPOD();
@@ -1147,7 +1140,6 @@ void performBasicLayout(BasicLayout &layout,
                                     .withInlineStorage(isInline);
   layout.stride = std::max(size_t(1), roundUpToAlignMask(size, alignMask));
 }
-} // end anonymous namespace
 
 const TupleTypeMetadata *
 swift::swift_getTupleTypeMetadata(TupleTypeFlags flags,
@@ -1201,7 +1193,7 @@ TupleCacheEntry::TupleCacheEntry(const Key &key,
   Data.Labels = key.Labels;
 
   // Perform basic layout on the tuple.
-  auto layout = BasicLayout::initialForValueType();
+  auto layout = getInitialLayoutForValueType();
   performBasicLayout(layout, key.Elements, key.NumElements,
     [&](size_t i, const Metadata *elt, size_t offset) {
       Data.getElement(i).Type = elt;
@@ -1477,15 +1469,16 @@ static constexpr uint64_t sizeWithAlignmentMask(uint64_t size,
   return (hasExtraInhabitants << 48) | (size << 16) | alignmentMask;
 }
 
-void swift::installCommonValueWitnesses(ValueWitnessTable *vwtable) {
-  auto flags = vwtable->flags;
+void swift::installCommonValueWitnesses(const TypeLayout &layout,
+                                        ValueWitnessTable *vwtable) {
+  auto flags = layout.flags;
   if (flags.isPOD()) {
     // Use POD value witnesses.
     // If the value has a common size and alignment, use specialized value
     // witnesses we already have lying around for the builtin types.
     const ValueWitnessTable *commonVWT;
     bool hasExtraInhabitants = flags.hasExtraInhabitants();
-    switch (sizeWithAlignmentMask(vwtable->size, vwtable->getAlignmentMask(),
+    switch (sizeWithAlignmentMask(layout.size, flags.getAlignmentMask(),
                                   hasExtraInhabitants)) {
     default:
       // For uncommon layouts, use value witnesses that work with an arbitrary
@@ -1585,6 +1578,11 @@ static ValueWitnessTable *getMutableVWTableForInit(StructMetadata *self,
                                     alignof(ValueWitnessTable));
     newTable = new (memory) ValueWitnessTable(*oldTable);
   }
+
+  // If we ever need to check layout-completeness asynchronously from
+  // initialization, we'll need this to be a store-release (and rely on
+  // consume ordering on the asynchronous check path); and we'll need to
+  // ensure that the current state says that the type is incomplete.
   self->setValueWitnesses(newTable);
 
   return newTable;
@@ -1597,7 +1595,7 @@ void swift::swift_initStructMetadata(StructMetadata *structType,
                                      size_t numFields,
                                      const TypeLayout * const *fieldTypes,
                                      size_t *fieldOffsets) {
-  auto layout = BasicLayout::initialForValueType();
+  auto layout = getInitialLayoutForValueType();
   performBasicLayout(layout, fieldTypes, numFields,
     [&](size_t i, const TypeLayout *fieldType, size_t offset) {
       assignUnlessEqual(fieldOffsets[i], offset);
@@ -1608,15 +1606,11 @@ void swift::swift_initStructMetadata(StructMetadata *structType,
   auto vwtable =
     getMutableVWTableForInit(structType, layoutFlags, hasExtraInhabitants);
 
-  vwtable->size = layout.size;
-  vwtable->flags = layout.flags;
-  vwtable->stride = layout.stride;
-  
   // We have extra inhabitants if the first element does.
   // FIXME: generalize this.
   if (hasExtraInhabitants) {
-    vwtable->flags = vwtable->flags.withExtraInhabitants(true);
-    auto xiVWT = cast<ExtraInhabitantsValueWitnessTable>(vwtable);
+    layout.flags = layout.flags.withExtraInhabitants(true);
+    auto xiVWT = static_cast<ExtraInhabitantsValueWitnessTable*>(vwtable);
     xiVWT->extraInhabitantFlags = fieldTypes[0]->getExtraInhabitantFlags();
 
     // The compiler should already have initialized these.
@@ -1625,7 +1619,9 @@ void swift::swift_initStructMetadata(StructMetadata *structType,
   }
 
   // Substitute in better value witnesses if we have them.
-  installCommonValueWitnesses(vwtable);
+  installCommonValueWitnesses(layout, vwtable);
+
+  vwtable->publishLayout(layout);
 }
 
 /***************************************************************************/
@@ -1883,7 +1879,7 @@ swift::swift_initClassMetadata(ClassMetadata *self,
 
   // If we don't have a formal superclass, start with the basic heap header.
   } else {
-    auto heapLayout = BasicLayout::initialForHeapObject();
+    auto heapLayout = getInitialLayoutForHeapObject();
     size = heapLayout.size;
     alignMask = heapLayout.flags.getAlignmentMask();
   }

--- a/stdlib/public/runtime/MetadataCache.h
+++ b/stdlib/public/runtime/MetadataCache.h
@@ -176,6 +176,15 @@ public:
 
     return entry->enqueue(*Concurrency, std::forward<ArgTys>(args)...);
   }
+
+  /// Given that an entry already exists, await it.
+  template <class KeyType, class... ArgTys>
+  Status await(KeyType key, ArgTys &&...args) {
+    auto entry = Map.find(key);
+    assert(entry && "entry doesn't already exist!");
+
+    return entry->await(*Concurrency, std::forward<ArgTys>(args)...);
+  }
 };
 
 /// A base class for metadata cache entries which supports an unfailing

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -196,12 +196,17 @@ public:
   /// Replace entries of a freshly-instantiated value witness table with more
   /// efficient common implementations where applicable.
   ///
+  /// All information is taken from the passed-in layout rather than the VWT.
+  /// This is so that we can delay "publishing" the flags in the actual
+  /// value witness table until all required changes have been made.
+  ///
   /// For instance, if the value witness table represents a POD type, this will
   /// insert POD value witnesses into the table. The vwtable's flags must have
   /// been initialized before calling this function.
   ///
   /// Returns true if common value witnesses were used, false otherwise.
-  void installCommonValueWitnesses(ValueWitnessTable *vwtable);
+  void installCommonValueWitnesses(const TypeLayout &layout,
+                                   ValueWitnessTable *vwtable);
 
   const Metadata *
   _matchMetadataByMangledTypeName(const llvm::StringRef metadataNameRef,

--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -321,7 +321,7 @@ extension ResilientGenericOutsideParent {
 
 // CHECK-LABEL: define private void @initialize_metadata_ClassWithResilientProperty
 // CHECK:             [[METADATA:%.*]] = call %swift.type* @swift_relocateClassMetadata({{.*}}, [[INT]] {{60|96}}, [[INT]] 4)
-// CHECK:             [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S16resilient_struct4SizeVMa"([[INT]] 0)
+// CHECK:             [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S16resilient_struct4SizeVMa"([[INT]] 1)
 // CHECK-NEXT:        [[SIZE_METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK:             call void @swift_initClassMetadata(%swift.type* [[METADATA]], [[INT]] 0, [[INT]] 3, {{.*}})
 // CHECK-native:      [[METADATA_PTR:%.*]] = bitcast %swift.type* [[METADATA]] to [[INT]]*
@@ -339,7 +339,7 @@ extension ResilientGenericOutsideParent {
 
 // CHECK-LABEL: define private void @initialize_metadata_ClassWithResilientlySizedProperty
 // CHECK:             [[METADATA:%.*]] = call %swift.type* @swift_relocateClassMetadata({{.*}}, [[INT]] {{60|96}}, [[INT]] 3)
-// CHECK:             [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S16resilient_struct9RectangleVMa"([[INT]] 0)
+// CHECK:             [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S16resilient_struct9RectangleVMa"([[INT]] 1)
 // CHECK-NEXT:        [[RECTANGLE_METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK:             call void @swift_initClassMetadata(%swift.type* [[METADATA]], [[INT]] 0, [[INT]] 2, {{.*}})
 // CHECK-native:      [[METADATA_PTR:%.*]] = bitcast %swift.type* [[METADATA]] to [[INT]]*
@@ -446,11 +446,18 @@ extension ResilientGenericOutsideParent {
 // CHECK-SAME:    (%swift.type* [[METADATA:%.*]], i8*, i8**)
 
 // Initialize the superclass pointer...
-// CHECK:              [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S15resilient_class29ResilientGenericOutsideParentCMa"([[INT]] 0, %swift.type* %T)
+// CHECK:              [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S15resilient_class29ResilientGenericOutsideParentCMa"([[INT]] 256, %swift.type* %T)
 // CHECK:              [[SUPER:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK:              [[SUPER_STATUS:%.*]] = extractvalue %swift.metadata_response [[T0]], 1
+// CHECK:              [[SUPER_OK:%.*]] = icmp ule [[INT]] [[SUPER_STATUS]], 0
+// CHECK:              br i1 [[SUPER_OK]],
 // CHECK:              [[T0:%.*]] = bitcast %swift.type* [[METADATA]] to %swift.type**
 // CHECK:              [[SUPER_ADDR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i32 1
 // CHECK:              store %swift.type* [[SUPER]], %swift.type** [[SUPER_ADDR]],
 
 // CHECK:              call void @swift_initClassMetadata(%swift.type* [[METADATA]], [[INT]] 0,
-// CHECK:              ret %swift.metadata_response zeroinitializer
+// CHECK:              [[DEP:%.*]] = phi %swift.type* [ [[SUPER]], {{.*}} ], [ null, {{.*}} ]
+// CHECK:              [[DEP_REQ:%.*]] = phi [[INT]] [ 0, {{.*}} ], [ 0, {{.*}} ]
+// CHECK:              [[T0:%.*]] = insertvalue %swift.metadata_response undef, %swift.type* [[DEP]], 0
+// CHECK:              [[T1:%.*]] = insertvalue %swift.metadata_response [[T0]], [[INT]] [[DEP_REQ]], 1
+// CHECK:              ret %swift.metadata_response [[T1]]

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -2686,12 +2686,17 @@ entry(%x : $*MyOptional):
 
 // CHECK-LABEL: define{{( protected)?}} internal swiftcc %swift.metadata_response @"$S4enum16DynamicSingletonOMr"
 // CHECK-SAME:    (%swift.type* [[METADATA:%.*]], i8*, i8**) {{.*}} {
-// CHECK:   [[T_VWTS:%.*]] = bitcast %swift.type* [[T]] to i8***
+// CHECK:   [[T0:%.*]] = call{{( tail)?}} swiftcc %swift.metadata_response @swift_checkMetadataState([[WORD]] 257, %swift.type* [[T]])
+// CHECK:   [[T_CHECKED:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK:   [[T_STATUS:%.*]] = extractvalue %swift.metadata_response [[T0]], 1
+// CHECK:   [[T_OK:%.*]] = icmp ule [[WORD]] [[T_STATUS]], 1
+// CHECK:   br i1 [[T_OK]],
+// CHECK:   [[T_VWTS:%.*]] = bitcast %swift.type* [[T_CHECKED]] to i8***
 // CHECK:   [[T_VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[T_VWTS]], [[WORD]] -1
 // CHECK:   [[T_VWT:%.*]] = load i8**, i8*** [[T_VWT_ADDR]]
 // CHECK:   [[T_LAYOUT:%.*]] = getelementptr inbounds i8*, i8** [[T_VWT]], i32 9
 // CHECK:   call void @swift_initEnumMetadataSingleCase(%swift.type* [[METADATA]], [[WORD]] 0, i8** [[T_LAYOUT]])
-// CHECK:   ret %swift.metadata_response zeroinitializer
+// CHECK:   ret %swift.metadata_response
 
 // -- Fill function for dynamic single-payload. Call into the runtime to
 //    calculate the size.
@@ -2700,7 +2705,12 @@ entry(%x : $*MyOptional):
 
 // CHECK-LABEL: define{{( protected)?}} internal swiftcc %swift.metadata_response @"$S4enum20DynamicSinglePayloadOMr"
 // CHECK-SAME:    (%swift.type* [[METADATA:%.*]], i8*, i8**) {{.*}} {
-// CHECK:   [[T_VWTS:%.*]] = bitcast %swift.type* [[T]] to i8***
+// CHECK:   [[T0:%.*]] = call{{( tail)?}} swiftcc %swift.metadata_response @swift_checkMetadataState([[WORD]] 257, %swift.type* [[T]])
+// CHECK:   [[T_CHECKED:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK:   [[T_STATUS:%.*]] = extractvalue %swift.metadata_response [[T0]], 1
+// CHECK:   [[T_OK:%.*]] = icmp ule [[WORD]] [[T_STATUS]], 1
+// CHECK:   br i1 [[T_OK]],
+// CHECK:   [[T_VWTS:%.*]] = bitcast %swift.type* [[T_CHECKED]] to i8***
 // CHECK:   [[T_VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[T_VWTS]], [[WORD]] -1
 // CHECK:   [[T_VWT:%.*]] = load i8**, i8*** [[T_VWT_ADDR]]
 // CHECK:   [[T_LAYOUT:%.*]] = getelementptr inbounds i8*, i8** [[T_VWT]], i32 9

--- a/test/IRGen/enum_dynamic_multi_payload.sil
+++ b/test/IRGen/enum_dynamic_multi_payload.sil
@@ -425,14 +425,24 @@ entry(%a : $*EitherOr<T, C>, %b : $*EitherOr<T, C>):
 
 // CHECK:      [[BUF:%.*]] = alloca [2 x i8**]
 // CHECK:      [[BUF0:%.*]] = getelementptr {{.*}} [[BUF]], i32 0, i32 0
-// CHECK:      [[T0:%.*]] = bitcast %swift.type* %T to i8***
+// CHECK:      [[T0:%.*]] = call{{( tail)?}} swiftcc %swift.metadata_response @swift_checkMetadataState([[INT]] 257, %swift.type* %T)
+// CHECK-NEXT: [[T_CHECKED:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK-NEXT: [[T_STATUS:%.*]] = extractvalue %swift.metadata_response [[T0]], 1
+// CHECK-NEXT: [[T_OK:%.*]] = icmp ule [[INT]] [[T_STATUS]], 1
+// CHECK-NEXT: br i1 [[T_OK]],
+// CHECK:      [[T0:%.*]] = bitcast %swift.type* [[T_CHECKED]] to i8***
 // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds i8**, i8*** [[T0]]
 // CHECK-NEXT: [[VALUE_WITNESSES:%.*]] = load i8**, i8*** [[T1]]
 // CHECK-NEXT: [[LAYOUT:%.*]] = getelementptr inbounds i8*, i8** [[VALUE_WITNESSES]], i32 9
 // CHECK-NEXT: store i8** [[LAYOUT]], {{.*}} [[BUF0]]
 
 // CHECK:      [[BUF1:%.*]] = getelementptr {{.*}} [[BUF]], i32 0, i32 1
-// CHECK:      [[T0:%.*]] = bitcast %swift.type* %U to i8***
+// CHECK:      [[T0:%.*]] = call{{( tail)?}} swiftcc %swift.metadata_response @swift_checkMetadataState([[INT]] 257, %swift.type* %U)
+// CHECK-NEXT: [[U_CHECKED:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK-NEXT: [[U_STATUS:%.*]] = extractvalue %swift.metadata_response [[T0]], 1
+// CHECK-NEXT: [[U_OK:%.*]] = icmp ule [[INT]] [[U_STATUS]], 1
+// CHECK-NEXT: br i1 [[U_OK]],
+// CHECK:      [[T0:%.*]] = bitcast %swift.type* [[U_CHECKED]] to i8***
 // CHECK-NEXT: [[T1:%.*]] = getelementptr inbounds i8**, i8*** [[T0]]
 // CHECK-NEXT: [[VALUE_WITNESSES:%.*]] = load i8**, i8*** [[T1]]
 // CHECK-NEXT: [[LAYOUT:%.*]] = getelementptr inbounds i8*, i8** [[VALUE_WITNESSES]], i32 9

--- a/test/IRGen/generic_classes.sil
+++ b/test/IRGen/generic_classes.sil
@@ -368,8 +368,12 @@ entry(%c : $RootGeneric<Int32>):
 
 // CHECK-LABEL: define{{( protected)?}} internal swiftcc %swift.metadata_response @"$S15generic_classes015GenericInheritsC0CMr"
 // CHECK-SAME:    (%swift.type* [[METADATA:%.*]], i8*, i8**) {{.*}} {
-// CHECK:   [[T0:%.*]] = call{{( tail)?}} swiftcc %swift.metadata_response @"$S15generic_classes11RootGenericCMa"(i64 0, %swift.type* %A)
+// CHECK:   [[T0:%.*]] = call{{( tail)?}} swiftcc %swift.metadata_response @"$S15generic_classes11RootGenericCMa"(i64 256, %swift.type* %A)
 // CHECK:   [[SUPER:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK:   [[SUPER_STATUS:%.*]] = extractvalue %swift.metadata_response [[T0]], 1
+// CHECK:   [[SUPER_OK:%.*]] = icmp ule i64 [[SUPER_STATUS]], 0
+// CHECK:   br i1 [[SUPER_OK]],
+
 // CHECK:   [[T0:%.*]] = bitcast %swift.type* [[METADATA]] to %swift.type**
 // CHECK:   [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i32 1
 // CHECK:   store %swift.type* [[SUPER]], %swift.type** [[T1]],
@@ -377,14 +381,23 @@ entry(%c : $RootGeneric<Int32>):
 // CHECK:   [[METADATA_ARRAY:%.*]] = bitcast %swift.type* [[METADATA]] to i64*
 // CHECK:   [[OFFSETS:%.*]] = getelementptr inbounds i64, i64* [[METADATA_ARRAY]], i64 23
 // CHECK:   [[FIELDS_ADDR:%.*]] = getelementptr inbounds [1 x i8**], [1 x i8**]* %classFields, i32 0, i32 0
-// CHECK:   [[T0:%.*]] = bitcast %swift.type* %B to i8***
+// CHECK:   [[T0:%.*]] = call{{( tail)?}} swiftcc %swift.metadata_response @swift_checkMetadataState(i64 257, %swift.type* %B)
+// CHECK:   [[B_CHECKED:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK:   [[B_STATUS:%.*]] = extractvalue %swift.metadata_response [[T0]], 1
+// CHECK:   [[B_OK:%.*]] = icmp ule i64 [[B_STATUS]], 1
+// CHECK:   br i1 [[B_OK]],
+// CHECK:   [[T0:%.*]] = bitcast %swift.type* [[B_CHECKED]] to i8***
 // CHECK:   [[T1:%.*]] = getelementptr inbounds i8**, i8*** [[T0]], i64 -1
 // CHECK:   [[VWT:%.*]] = load i8**, i8*** [[T1]], align 8
 // CHECK:   [[T0:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 9
 // CHECK:   [[T1:%.*]] = getelementptr inbounds i8**, i8*** [[FIELDS_ADDR]], i32 0
 // CHECK:   store i8** [[T0]], i8*** [[T1]], align 8
 // CHECK:   call void @swift_initClassMetadata(%swift.type* [[METADATA]], i64 0, i64 1, i8*** [[FIELDS_ADDR]], i64* [[OFFSETS]])
-// CHECK:   ret %swift.metadata_response zeroinitializer
+// CHECK:   [[DEP:%.*]] = phi %swift.type* [ [[SUPER]], {{.*}} ], [ [[B_CHECKED]], {{.*}} ], [ null, {{.*}} ]
+// CHECK:   [[DEP_REQ:%.*]] = phi i64 [ 0, {{.*}} ], [ 1, {{.*}}], [ 0, {{.*}} ]
+// CHECK:   [[T0:%.*]] = insertvalue %swift.metadata_response undef, %swift.type* [[DEP]], 0
+// CHECK:   [[T1:%.*]] = insertvalue %swift.metadata_response [[T0]], i64 [[DEP_REQ]], 1
+// CHECK:   ret %swift.metadata_response [[T1]]
 // CHECK: }
 
 // OSIZE: define hidden swiftcc %swift.metadata_response @"$S15generic_classes11RootGenericCMa"(i64, %swift.type*) [[ATTRS:#[0-9]+]] {

--- a/test/IRGen/generic_metatypes.swift
+++ b/test/IRGen/generic_metatypes.swift
@@ -126,7 +126,7 @@ func makeGenericMetatypes() {
 
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$S17generic_metatypes7TwoArgsVyAA3FooVAA3BarCGMa"
 // CHECK-SAME:    ([[INT]]) [[NOUNWIND_READNONE_OPT]]
-// CHECK:   [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S17generic_metatypes3BarCMa"([[INT]] 0)
+// CHECK:   [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S17generic_metatypes3BarCMa"([[INT]] 2)
 // CHECK:   [[BAR:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK:   call swiftcc %swift.metadata_response @"$S17generic_metatypes7TwoArgsVMa"([[INT]] 0, %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, %swift.type* [[BAR]])
 
@@ -145,7 +145,7 @@ func makeGenericMetatypes() {
 
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$S17generic_metatypes9ThreeArgsVyAA3FooVAA3BarCAEGMa"
 // CHECK-SAME:    ([[INT]]) [[NOUNWIND_READNONE_OPT]]
-// CHECK:   [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S17generic_metatypes3BarCMa"([[INT]] 0)
+// CHECK:   [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S17generic_metatypes3BarCMa"([[INT]] 2)
 // CHECK:   [[BAR:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK:   call swiftcc %swift.metadata_response @"$S17generic_metatypes9ThreeArgsVMa"([[INT]] 0, %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, %swift.type* [[BAR]], %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}) [[NOUNWIND_READNONE]]
 
@@ -167,7 +167,7 @@ func makeGenericMetatypes() {
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$S17generic_metatypes8FourArgsVyAA3FooVAA3BarCAeGGMa"
 // CHECK-SAME:    ([[INT]]) [[NOUNWIND_READNONE_OPT]]
 // CHECK:   [[BUFFER:%.*]] = alloca [4 x i8*]
-// CHECK:   [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S17generic_metatypes3BarCMa"([[INT]] 0)
+// CHECK:   [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S17generic_metatypes3BarCMa"([[INT]] 2)
 // CHECK:   [[BAR:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK:   call void @llvm.lifetime.start
 // CHECK-NEXT: [[SLOT_0:%.*]] = getelementptr inbounds [4 x i8*], [4 x i8*]* [[BUFFER]], i32 0, i32 0
@@ -186,7 +186,7 @@ func makeGenericMetatypes() {
 
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$S17generic_metatypes8FiveArgsVyAA3FooVAA3BarCAegEGMa"
 // CHECK-SAME:    ([[INT]]) [[NOUNWIND_READNONE_OPT]]
-// CHECK:   [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S17generic_metatypes3BarCMa"([[INT]] 0)
+// CHECK:   [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S17generic_metatypes3BarCMa"([[INT]] 2)
 // CHECK:   [[BAR:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK:   call swiftcc %swift.metadata_response @"$S17generic_metatypes8FiveArgsVMa"([[INT]] 0, i8**
 

--- a/test/IRGen/generic_structs.sil
+++ b/test/IRGen/generic_structs.sil
@@ -209,7 +209,7 @@ entry(%0 : $*ComplexDynamic<A, B>, %1 : $*Byteful, %2 : $*A, %3 : $*B, %4 : $*Ch
 // CHECK:   [[T1:%.*]] = getelementptr inbounds i64, i64* [[T0]], i64 3
 // CHECK:   [[T2:%.*]] = getelementptr inbounds i8**, i8*** [[TYPES:%.*]], i32 0
 // CHECK:   call void @swift_initStructMetadata(%swift.type* [[METADATA]], i64 0, i64 1, i8*** [[TYPES]], i64* [[T1]])
-// CHECK:   ret %swift.metadata_response zeroinitializer
+// CHECK:   ret %swift.metadata_response
 // CHECK: }
 
 // Check that we directly delegate buffer witnesses to a single dynamic field:
@@ -261,6 +261,11 @@ struct GenericLayoutWithAssocType<T: ParentHasAssociatedType> {
 // CHECK:   %T.ParentHasAssociatedType = load i8**, i8*** [[T2]],
 
 // CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata
+
+// CHECK-LABEL: define internal swiftcc %swift.metadata_response @"$S15generic_structs26GenericLayoutWithAssocTypeVMr"(
+
+// CHECK: [[T0:%.*]] = call{{( tail)?}} swiftcc %swift.metadata_response @swift_checkMetadataState(i64 0, %swift.type* %T)
+// CHECK: [[T_CHECKED:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 
 // CHECK: [[T0_GEP:%.*]] = getelementptr inbounds i8*, i8** %T.ParentHasAssociatedType, i32 1
 // CHECK: [[T0:%.*]] = load i8*, i8** [[T0_GEP]]

--- a/test/IRGen/generic_vtable.swift
+++ b/test/IRGen/generic_vtable.swift
@@ -120,7 +120,7 @@ public class Concrete : Derived<Int> {
 // CHECK: [[VTABLE1:%.*]] = getelementptr inbounds i8*, i8** [[WORDS]], i64 12
 // CHECK: store i8* bitcast (%T14generic_vtable7DerivedC* (%T14generic_vtable7DerivedC*)* @"$S14generic_vtable7DerivedCACyxGycfc" to i8*), i8** [[VTABLE1]], align 8
 
-// CHECK: ret %swift.metadata_response zeroinitializer
+// CHECK: ret %swift.metadata_response
 
 
 //// Metadata initialization function for 'Concrete' copies superclass vtable

--- a/test/IRGen/objc_generic_class_metadata.sil
+++ b/test/IRGen/objc_generic_class_metadata.sil
@@ -84,7 +84,7 @@ entry(%0: $Subclass, %1: $NSDictionary):
 
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$SSaySo12GenericClassC_SitGMa"
 // CHECK-SAME:    ([[INT]])
-// CHECK:         [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$SSo12GenericClassC_SitMa"([[INT]] 0)
+// CHECK:         [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$SSo12GenericClassC_SitMa"([[INT]] 2)
 // CHECK:         [[TUPLE:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
 // CHECK:         call swiftcc %swift.metadata_response @"$SSaMa"([[INT]] 0, %swift.type* [[TUPLE]])
 

--- a/test/IRGen/partial_apply_forwarder.sil
+++ b/test/IRGen/partial_apply_forwarder.sil
@@ -80,7 +80,7 @@ sil hidden_external @takingEmptyAndQ : $@convention(thin) <τ_0_0 where  τ_0_0 
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @bind_polymorphic_param_from_context(%swift.opaque* noalias nocapture, %swift.type* %"\CF\84_0_1")
 // CHECK: entry:
-// CHECK:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S23partial_apply_forwarder12BaseProducerVMa"([[INT]] 0, %swift.type* %"\CF\84_0_1")
+// CHECK:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S23partial_apply_forwarder12BaseProducerVMa"([[INT]] 2, %swift.type* %"\CF\84_0_1")
 // CHECK:   [[BPTYPE:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
 // CHECK:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S23partial_apply_forwarder7WeakBoxCMa"([[INT]] 0, %swift.type* [[BPTYPE]])
 // CHECK:   [[WEAKBOXTYPE:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
@@ -142,7 +142,7 @@ bb0(%0 : $*τ_0_1, %2: $EmptyType):
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @bind_polymorphic_param_from_forwarder_parameter(%swift.opaque* noalias nocapture, %swift.type* %"\CF\84_0_1")
 // CHECK: entry:
-// CHECK:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S23partial_apply_forwarder12BaseProducerVMa"([[INT]] 0, %swift.type* %"\CF\84_0_1")
+// CHECK:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S23partial_apply_forwarder12BaseProducerVMa"([[INT]] 2, %swift.type* %"\CF\84_0_1")
 // CHECK:   [[BPTY:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
 // CHECK:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S23partial_apply_forwarder7WeakBoxCMa"([[INT]] 0, %swift.type* [[BPTY]]
 // CHECK:   [[WBTY:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
@@ -178,7 +178,7 @@ sil hidden_external @takingQAndS : $@convention(thin) <τ_0_0 where  τ_0_0 : Q>
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @bind_polymorphic_param_from_context_with_layout(%swift.opaque* noalias nocapture, i64, %swift.type* %"\CF\84_0_1")
 // CHECK: entry:
-// CHECK:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S23partial_apply_forwarder12BaseProducerVMa"([[INT]] 0, %swift.type* %"\CF\84_0_1")
+// CHECK:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S23partial_apply_forwarder12BaseProducerVMa"([[INT]] 2, %swift.type* %"\CF\84_0_1")
 // CHECK:   [[BPTY:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
 // CHECK:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S23partial_apply_forwarder7WeakBoxCMa"([[INT]] 0, %swift.type* [[BPTY]]
 // CHECK:   [[WBTY:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0

--- a/test/IRGen/subclass_existentials.sil
+++ b/test/IRGen/subclass_existentials.sil
@@ -54,8 +54,9 @@ sil @takesMetadata : $@convention(thin) <T> (@thick T.Type) -> ()
 // CHECK:        [[PROTOCOLS:%.*]] = bitcast [1 x %swift.protocol*]* [[PROTOCOL_ARRAY]] to %swift.protocol**
 // CHECK-NEXT:   [[PROTOCOL:%.*]] = getelementptr inbounds %swift.protocol*, %swift.protocol** [[PROTOCOLS]], i32 0
 // CHECK-NEXT:   store %swift.protocol* @"$S21subclass_existentials1PMp", %swift.protocol** [[PROTOCOL]]
-// CHECK-NEXT:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S21subclass_existentials1CCMa"([[INT]] 0)
+// CHECK-NEXT:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S21subclass_existentials1CCMa"([[INT]] 2)
 // CHECK-NEXT:   [[SUPERCLASS:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
+// CHECK-NEXT:   extractvalue %swift.metadata_response [[TMP]], 1
 // CHECK-NEXT:   [[METATYPE:%.*]] = call %swift.type* @swift_getExistentialTypeMetadata(i1 false, %swift.type* [[SUPERCLASS]], {{i32|i64}} 1, %swift.protocol** [[PROTOCOLS]])
 // CHECK:        ret
 

--- a/test/IRGen/type_layout.swift
+++ b/test/IRGen/type_layout.swift
@@ -23,9 +23,15 @@ struct AlignedFourInts { var x: FourInts }
 
 // CHECK:       @"$S11type_layout14TypeLayoutTestVMn" = hidden constant {{.*}} @"$S11type_layout14TypeLayoutTestVMP"
 // CHECK:       define internal %swift.type* @"$S11type_layout14TypeLayoutTestVMi"
+// CHECK:       define internal swiftcc %swift.metadata_response @"$S11type_layout14TypeLayoutTestVMr"
 struct TypeLayoutTest<T> {
   // -- dynamic layout, projected from metadata
-  // CHECK:       [[T0:%.*]] = bitcast %swift.type* %T to i8***
+  // CHECK:       [[T0:%.*]] = call{{( tail)?}} swiftcc %swift.metadata_response @swift_checkMetadataState([[INT]] 257, %swift.type* %T)
+  // CHECK:       [[T_CHECKED:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+  // CHECK:       [[T_STATUS:%.*]] = extractvalue %swift.metadata_response [[T0]], 1
+  // CHECK:       [[T_OK:%.*]] = icmp ule [[INT]] [[T_STATUS]], 1
+  // CHECK:       br i1 [[T_OK]],
+  // CHECK:       [[T0:%.*]] = bitcast %swift.type* [[T_CHECKED]] to i8***
   // CHECK:       [[T1:%.*]] = getelementptr inbounds i8**, i8*** [[T0]], {{i32|i64}} -1
   // CHECK:       [[T_VALUE_WITNESSES:%.*]] = load i8**, i8*** [[T1]]
   // CHECK:       [[T_LAYOUT:%.*]] = getelementptr inbounds i8*, i8** [[T_VALUE_WITNESSES]], i32 9
@@ -57,8 +63,11 @@ struct TypeLayoutTest<T> {
   // CHECK:       store i8** [[T_LAYOUT]]
   var i: GSing<T>
   // -- Multi-element generic struct, need to derive from metadata
-  // CHECK:       [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S11type_layout5GMultVMa"([[INT]] 0, %swift.type* %T)
+  // CHECK:       [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S11type_layout5GMultVMa"([[INT]] 257, %swift.type* [[T_CHECKED]])
   // CHECK:       [[METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
+  // CHECK:       [[METADATA_STATUS:%.*]] = extractvalue %swift.metadata_response [[TMP]], 1
+  // CHECK:       [[METADATA_OK:%.*]] = icmp ule [[INT]] [[METADATA_STATUS]], 1
+  // CHECK:       br i1 [[METADATA_OK]],
   // CHECK:       [[T0:%.*]] = bitcast %swift.type* [[METADATA]] to i8***
   // CHECK:       [[T1:%.*]] = getelementptr inbounds i8**, i8*** [[T0]], {{i32|i64}} -1
   // CHECK:       [[VALUE_WITNESSES:%.*]] = load i8**, i8*** [[T1]]

--- a/test/IRGen/type_layout_objc.swift
+++ b/test/IRGen/type_layout_objc.swift
@@ -22,9 +22,15 @@ struct CommonLayout { var x,y,z,w: Int8 }
 
 // CHECK:       @"$S16type_layout_objc14TypeLayoutTestVMn" = hidden constant {{.*}} @"$S16type_layout_objc14TypeLayoutTestVMP"
 // CHECK:       define internal %swift.type* @"$S16type_layout_objc14TypeLayoutTestVMi"
+// CHECK:       define internal swiftcc %swift.metadata_response @"$S16type_layout_objc14TypeLayoutTestVMr"
 struct TypeLayoutTest<T> {
   // -- dynamic layout, projected from metadata
-  // CHECK:       [[T0:%.*]] = bitcast %swift.type* %T to i8***
+  // CHECK:       [[T0:%.*]] = call{{( tail)?}} swiftcc %swift.metadata_response @swift_checkMetadataState([[INT]] 257, %swift.type* %T)
+  // CHECK:       [[T_CHECKED:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+  // CHECK:       [[T_STATUS:%.*]] = extractvalue %swift.metadata_response [[T0]], 1
+  // CHECK:       [[T_OK:%.*]] = icmp ule [[INT]] [[T_STATUS]], 1
+  // CHECK:       br i1 [[T_OK]],
+  // CHECK:       [[T0:%.*]] = bitcast %swift.type* [[T_CHECKED]] to i8***
   // CHECK:       [[T1:%.*]] = getelementptr inbounds i8**, i8*** [[T0]], {{i32|i64}} -1
   // CHECK:       [[T_VALUE_WITNESSES:%.*]] = load i8**, i8*** [[T1]]
   // CHECK:       [[T_LAYOUT:%.*]] = getelementptr inbounds i8*, i8** [[T_VALUE_WITNESSES]], i32 9
@@ -59,8 +65,11 @@ struct TypeLayoutTest<T> {
   // CHECK:       store i8** [[T_LAYOUT]]
   var i: GSing<T>
   // -- Multi-element generic struct, need to derive from metadata
-  // CHECK:       [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S16type_layout_objc5GMultVMa"([[INT]] 0, %swift.type* %T)
+  // CHECK:       [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S16type_layout_objc5GMultVMa"([[INT]] 257, %swift.type* [[T_CHECKED]])
   // CHECK:       [[METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
+  // CHECK:       [[METADATA_STATUS:%.*]] = extractvalue %swift.metadata_response [[TMP]], 1
+  // CHECK:       [[METADATA_OK:%.*]] = icmp ule [[INT]] [[METADATA_STATUS]], 1
+  // CHECK:       br i1 [[METADATA_OK]],
   // CHECK:       [[T0:%.*]] = bitcast %swift.type* [[METADATA]] to i8***
   // CHECK:       [[T1:%.*]] = getelementptr inbounds i8**, i8*** [[T0]], {{i32|i64}} -1
   // CHECK:       [[VALUE_WITNESSES:%.*]] = load i8**, i8*** [[T1]]

--- a/unittests/runtime/Array.cpp
+++ b/unittests/runtime/Array.cpp
@@ -20,7 +20,8 @@
 using namespace swift;
 
 namespace swift {
-  void installCommonValueWitnesses(ValueWitnessTable *vwtable);
+  void installCommonValueWitnesses(const TypeLayout &layout,
+                                   ValueWitnessTable *vwtable);
 } // namespace swift
 
 
@@ -33,7 +34,7 @@ static void initialize_pod_witness_table_size_uint32_t_stride_uint64_t(
     .withBitwiseTakable(true)
     .withInlineStorage(true);
   testTable.stride = sizeof(uint64_t);
-  installCommonValueWitnesses(&testTable);
+  installCommonValueWitnesses(*testTable.getTypeLayout(), &testTable);
 }
 
 extern "C" void swift_arrayInitWithCopy(OpaqueValue *dest,

--- a/unittests/runtime/Metadata.cpp
+++ b/unittests/runtime/Metadata.cpp
@@ -707,7 +707,8 @@ TEST(MetadataTest, getExistentialTypeMetadata_subclass) {
 }
 
 namespace swift {
-  void installCommonValueWitnesses(ValueWitnessTable *vwtable);
+  void installCommonValueWitnesses(const TypeLayout &layout,
+                                   ValueWitnessTable *vwtable);
 } // namespace swift
 
 
@@ -726,7 +727,7 @@ TEST(MetadataTest, installCommonValueWitnesses_pod_indirect) {
     .withInlineStorage(false);
   testTable.stride = sizeof(ValueBuffer) + alignof(ValueBuffer);
 
-  installCommonValueWitnesses(&testTable);
+  installCommonValueWitnesses(*testTable.getTypeLayout(), &testTable);
 
   // Replace allocateBuffer and destroyBuffer with logging versions.
   struct {
@@ -1014,7 +1015,7 @@ static void initialize_pod_witness_table(ValueWitnessTable &testTable) {
     .withBitwiseTakable(true)
     .withInlineStorage(true);
   testTable.stride = sizeof(ValueBuffer);
-  installCommonValueWitnesses(&testTable);
+  installCommonValueWitnesses(*testTable.getTypeLayout(), &testTable);
 }
 
 TEST(TestOpaqueExistentialBox, test_assignWithCopy_pod) {
@@ -1093,7 +1094,7 @@ static void initialize_indirect_witness_table(ValueWitnessTable &testTable) {
     .withBitwiseTakable(true)
     .withInlineStorage(false);
   testTable.stride = sizeof(ValueBuffer) + 1;
-  installCommonValueWitnesses(&testTable);
+  installCommonValueWitnesses(*testTable.getTypeLayout(), &testTable);
 }
 
 TEST(TestOpaqueExistentialBox, test_assignWithCopy_indirect_indirect) {

--- a/validation-test/stdlib/MicroStdlib/Inputs/RuntimeStubs.c
+++ b/validation-test/stdlib/MicroStdlib/Inputs/RuntimeStubs.c
@@ -6,6 +6,7 @@ int $SBi64_WV;
 int $SBi8_WV;
 void swift_getEnumCaseSinglePayload(void) {}
 void swift_getGenericMetadata(void) {}
+void swift_checkMetadataState(void) {}
 void swift_slowAlloc(void) {}
 void swift_slowDealloc(void) {}
 void swift_storeEnumTagSinglePayload(void) {}


### PR DESCRIPTION
I'll just copy the summary out of the commit message for the last patch in the sequence:

The design is laid out pretty clearly (I hope) in the comments on DynamicMetadataRequest and MetadataResponse, so I'm not going to belabor it again here.  Instead, I'll list out the work that's still
outstanding:

- I'm sure there are places we're asking for complete metadata where we could be asking for something weaker.

- I need to actually test the runtime behavior to verify that it's breaking the cycles it's supposed to, instead of just not regressing anything else.

- I need to add something to the runtime to actually force all the generic arguments of a generic type to be complete before reporting completion.  I think we can get away with this for now because all existing types construct themselves completely on the first request, but there might be a race condition there if another asks for the type argument, gets an abstract metadata, and constructs a type with it without ever needing it to be completed.

- Non-generic resilient types need to be switched over to an IRGen pattern that supports initialization suspension.

- We should probably space out the MetadataStates so that there's some space between Abstract and Complete.

- The runtime just calmly sits there, never making progress and permanently blocking any waiting threads, if you actually form an unresolvable metadata dependency cycle.  It is possible to set up such a thing in a way that Sema can't diagnose, and we should detect it at runtime.  I've set up some infrastructure so that it should be straightforward to diagnose this, but I haven't actually implemented the diagnostic yet.

- It's not clear to me that swift_checkMetadataState is really cheap enough that it doesn't make sense to use a cache for type-fulfilled metadata in associated type access functions.  Fortunately this is not ABI-affecting, so we can evaluate it anytime.

- Type layout really seems like a lot of code now that we sometimes need to call swift_checkMetadataState for generic arguments.  Maybe we can have the runtime do this by marking low bits or something, so that a TypeLayoutRef is actually either (1) a TypeLayout, (2) a known layout-complete metadata, or (3) a metadata of unknown state.  We could do that later with a flag, but we'll need to at least future-proof by allowing the runtime functions to return a MetadataDependency.