### PR TITLE
[SR-6907] Add appropriate bounds to CountableClosedRange and CountableRange.

### DIFF
--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -479,4 +479,5 @@ extension ClosedRange {
 @available(*, deprecated, renamed: "ClosedRange.Index")
 public typealias ClosedRangeIndex<T> = ClosedRange<T>.Index where T: Strideable, T.Stride: SignedInteger
 @available(*, deprecated, renamed: "ClosedRange")
-public typealias CountableClosedRange<T: Comparable> = ClosedRange<T>
+public typealias CountableClosedRange<Bound: Strideable> = ClosedRange<Bound>
+  where Bound.Stride : SignedInteger

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -878,5 +878,5 @@ extension Range {
 }
 
 @available(*, deprecated, renamed: "Range")
-public typealias CountableRange<Bound: Comparable> = Range<Bound>
-
+public typealias CountableRange<Bound: Strideable> = Range<Bound>
+  where Bound.Stride : SignedInteger

--- a/test/Compatibility/stdlib_generic_typealiases.swift
+++ b/test/Compatibility/stdlib_generic_typealiases.swift
@@ -1,12 +1,18 @@
 // RUN: %target-typecheck-verify-swift
 
-struct RequiresComparable<T: Comparable> { }
+struct RequiresStrideable<T: Strideable> { }
 
 extension CountableRange { // expected-warning{{'CountableRange' is deprecated: renamed to 'Range'}}
   // expected-note@-1{{use 'Range' instead}}{{11-25=Range}}
-  func testComparable() {
-    _ = RequiresComparable<Bound>()
+  func testStrideable() {
+    _ = RequiresStrideable<Bound>()
   }
+
+  func foo() { }
+}
+
+extension Range {
+  func foo() { } // not a redefinition
 }
 
 struct RequiresHashable<T: Hashable> { }


### PR DESCRIPTION
In Swift 4.1 and earlier, both `CountableRange` and `CountableClosedRange` required
their bound types to be `Strideable` with a `Stride` type that conforms to
`SignedInteger`. Those constraints were not present on the generic
typealiases that replaced these structs. Add them back now, which
fixes the GRDB source compatibility regression.

Fixes [SR-6907](https://bugs.swift.org/browse/SR-6907) / rdar://problem/29066394.