### PR TITLE
Translate effective version name of '4.x' to '4.2' for ImportNameVersion.

### DIFF
--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -61,7 +61,9 @@ public:
     // importing of names.  We treat that with a rawValue of 5, and treat
     // all major values of 5 or higher as being rawValue = majorversion + 1.
     const auto &version = langOpts.EffectiveLanguageVersion;
-    if (version.size() > 1 && version[0] == 4 && version[1] == 2) {
+    // If the effective version is 4.x, where x >= 2, the import version
+    // is 4.2.
+    if (version.size() > 1 && version[0] == 4 && version[1] >= 2) {
       return ImportNameVersion::swift4_2();
     }
     unsigned major = version[0];


### PR DESCRIPTION
The effective version for 4.x may be greater than '2', even with `-swift-version 4.2`.  However, that should be canonicalized to 4.2.