### PR TITLE
[SILOptimizer] shouldExpand can't expand address only types

### DIFF
--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -1330,11 +1330,11 @@ bool swift::simplifyUsers(SingleValueInstruction *I) {
 /// True if a type can be expanded
 /// without a significant increase to code size.
 bool swift::shouldExpand(SILModule &Module, SILType Ty) {
-  if (EnableExpandAll) {
-    return true;
-  }
   if (Ty.isAddressOnly(Module)) {
     return false;
+  }
+  if (EnableExpandAll) {
+    return true;
   }
   unsigned numFields = Module.Types.countNumberOfFields(Ty);
   if (numFields > 6) {


### PR DESCRIPTION
 fix a bug wherein EnableExpandAll overrode that.

rdar://problem/33767770
