### PR TITLE
swift-api-digester: teach the tool to detect [String:Any] changes to [StringRepresentable:Any].

### DIFF
--- a/include/swift/IDE/DigesterEnums.def
+++ b/include/swift/IDE/DigesterEnums.def
@@ -18,6 +18,10 @@
 #define KNOWN_TYPE(NAME)
 #endif
 
+#ifndef KNOWN_PROTOCOL
+#define KNOWN_PROTOCOL(NAME)
+#endif
+
 #ifndef DIFF_ITEM_KIND
 #define DIFF_ITEM_KIND(NAME)
 #endif
@@ -70,6 +74,7 @@ NODE_ANNOTATION(NowThrowing)
 NODE_ANNOTATION(NowMutating)
 NODE_ANNOTATION(StaticChange)
 NODE_ANNOTATION(OwnershipChange)
+NODE_ANNOTATION(DictionaryKeyUpdate)
 
 DECL_ATTR(deprecated)
 DECL_ATTR(fixedLayout)
@@ -100,6 +105,10 @@ KNOWN_TYPE(ImplicitlyUnwrappedOptional)
 KNOWN_TYPE(Void)
 KNOWN_TYPE(Unmanaged)
 KNOWN_TYPE(Function)
+KNOWN_TYPE(Dictionary)
+KNOWN_TYPE(String)
+
+KNOWN_PROTOCOL(RawRepresentable)
 
 DIFF_ITEM_KIND(CommonDiffItem)
 DIFF_ITEM_KIND(TypeMemberDiffItem)
@@ -149,6 +158,7 @@ SPECIAL_CASE_ID(ToUIntMax)
 #undef DIFF_ITEM_KEY_KIND
 #undef DIFF_ITEM_KIND
 #undef KNOWN_TYPE
+#undef KNOWN_PROTOCOL
 #undef KEY
 #undef DECL_ATTR
 #undef NODE_ANNOTATION

--- a/test/api-digester/Outputs/apinotes-migrator-gen.json
+++ b/test/api-digester/Outputs/apinotes-migrator-gen.json
@@ -13,10 +13,32 @@
   {
     "DiffItemKind": "CommonDiffItem",
     "NodeKind": "Function",
+    "NodeAnnotation": "DictionaryKeyUpdate",
+    "ChildIndex": "1",
+    "LeftUsr": "c:objc(cs)AnimalStatusDescriptor(im)animalStatusDescriptorByAddingAttributes:",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "AnimalAttributeName",
+    "ModuleName": "APINotesTest"
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
     "NodeAnnotation": "TypeRewritten",
     "ChildIndex": "1:0",
     "LeftUsr": "c:objc(cs)AnimalStatusDescriptor(im)animalStatusDescriptorByAddingAttributes:",
     "LeftComment": "String",
+    "RightUsr": "",
+    "RightComment": "AnimalAttributeName",
+    "ModuleName": "APINotesTest"
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "DictionaryKeyUpdate",
+    "ChildIndex": "1",
+    "LeftUsr": "c:objc(cs)AnimalStatusDescriptor(im)animalStatusDescriptorByAddingAttributes:",
+    "LeftComment": "",
     "RightUsr": "",
     "RightComment": "AnimalAttributeName",
     "ModuleName": "APINotesTest"


### PR DESCRIPTION
This allows us to migrate string enum changes from the frameworks.

