### PR TITLE
Add asserts to SIL Instruction Builder functions that should only take loadable types

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -980,6 +980,8 @@ public:
   RetainValueInst *createRetainValue(SILLocation Loc, SILValue operand,
                                      Atomicity atomicity) {
     assert(isParsing || !getFunction().hasQualifiedOwnership());
+    assert(!SILModuleConventions(getModule()).useLoweredAddresses() ||
+           operand->getType().isLoadable(getModule()));
     return insert(new (getModule()) RetainValueInst(getSILDebugLocation(Loc),
                                                       operand, atomicity));
   }
@@ -994,6 +996,8 @@ public:
   ReleaseValueInst *createReleaseValue(SILLocation Loc, SILValue operand,
                                        Atomicity atomicity) {
     assert(isParsing || !getFunction().hasQualifiedOwnership());
+    assert(!SILModuleConventions(getModule()).useLoweredAddresses() ||
+           operand->getType().isLoadable(getModule()));
     return insert(new (getModule()) ReleaseValueInst(getSILDebugLocation(Loc),
                                                        operand, atomicity));
   }
@@ -1010,6 +1014,8 @@ public:
                                                        SILValue operand,
                                                        Atomicity atomicity) {
     assert(getFunction().hasQualifiedOwnership());
+    assert(!SILModuleConventions(getModule()).useLoweredAddresses() ||
+           operand->getType().isLoadable(getModule()));
     return insert(new (getModule()) UnmanagedRetainValueInst(
         getSILDebugLocation(Loc), operand, atomicity));
   }
@@ -1018,6 +1024,8 @@ public:
                                                          SILValue operand,
                                                          Atomicity atomicity) {
     assert(getFunction().hasQualifiedOwnership());
+    assert(!SILModuleConventions(getModule()).useLoweredAddresses() ||
+           operand->getType().isLoadable(getModule()));
     return insert(new (getModule()) UnmanagedReleaseValueInst(
         getSILDebugLocation(Loc), operand, atomicity));
   }
@@ -1034,6 +1042,8 @@ public:
   }
 
   DestroyValueInst *createDestroyValue(SILLocation Loc, SILValue operand) {
+    assert(!SILModuleConventions(getModule()).useLoweredAddresses() ||
+           operand->getType().isLoadable(getModule()));
     return insert(new (getModule())
                       DestroyValueInst(getSILDebugLocation(Loc), operand));
   }
@@ -1069,6 +1079,8 @@ public:
 
   StructInst *createStruct(SILLocation Loc, SILType Ty,
                            ArrayRef<SILValue> Elements) {
+    assert(!SILModuleConventions(getModule()).useLoweredAddresses() ||
+           Ty.isLoadable(getModule()));
     return insert(
         StructInst::create(getSILDebugLocation(Loc), Ty, Elements,
                            getModule()));
@@ -1076,6 +1088,8 @@ public:
 
   TupleInst *createTuple(SILLocation Loc, SILType Ty,
                          ArrayRef<SILValue> Elements) {
+    assert(!SILModuleConventions(getModule()).useLoweredAddresses() ||
+           Ty.isLoadable(getModule()));
     return insert(
         TupleInst::create(getSILDebugLocation(Loc), Ty, Elements,
                           getModule()));
@@ -1085,18 +1099,24 @@ public:
 
   EnumInst *createEnum(SILLocation Loc, SILValue Operand,
                        EnumElementDecl *Element, SILType Ty) {
+    assert(!SILModuleConventions(getModule()).useLoweredAddresses() ||
+           Ty.isLoadable(getModule()));
     return insert(new (getModule()) EnumInst(getSILDebugLocation(Loc),
                                                Operand, Element, Ty));
   }
 
   /// Inject a loadable value into the corresponding optional type.
   EnumInst *createOptionalSome(SILLocation Loc, SILValue operand, SILType ty) {
+    assert(!SILModuleConventions(getModule()).useLoweredAddresses() ||
+           ty.isLoadable(getModule()));
     auto someDecl = getModule().getASTContext().getOptionalSomeDecl();
     return createEnum(Loc, operand, someDecl, ty);
   }
 
   /// Create the nil value of a loadable optional type.
   EnumInst *createOptionalNone(SILLocation Loc, SILType ty) {
+    assert(!SILModuleConventions(getModule()).useLoweredAddresses() ||
+           ty.isLoadable(getModule()));
     auto noneDecl = getModule().getASTContext().getOptionalNoneDecl();
     return createEnum(Loc, nullptr, noneDecl, ty);
   }
@@ -1113,6 +1133,8 @@ public:
                                                  SILValue Operand,
                                                  EnumElementDecl *Element,
                                                  SILType Ty) {
+    assert(!SILModuleConventions(getModule()).useLoweredAddresses() ||
+           Ty.isLoadable(getModule()));
     return insert(new (getModule()) UncheckedEnumDataInst(
         getSILDebugLocation(Loc), Operand, Element, Ty));
   }
@@ -1152,6 +1174,8 @@ public:
                    ArrayRef<std::pair<EnumElementDecl *, SILValue>> CaseValues,
                    Optional<ArrayRef<ProfileCounter>> CaseCounts = None,
                    ProfileCounter DefaultCount = ProfileCounter()) {
+    assert(!SILModuleConventions(getModule()).useLoweredAddresses() ||
+           Ty.isLoadable(getModule()));
     return insert(SelectEnumInst::create(
         getSILDebugLocation(Loc), Operand, Ty, DefaultValue, CaseValues,
         getFunction(), CaseCounts, DefaultCount));

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -251,6 +251,10 @@ public:
   bool isLoadable(SILModule &M) const {
     return !isAddressOnly(M);
   }
+  /// True if either:
+  /// 1) The type, or the referenced type of an address type, is loadable.
+  /// 2) The SIL Module conventions uses lowered addresses
+  bool isLoadableOrLowered(SILModule &M) const;
   /// True if the type, or the referenced type of an address type, is
   /// address-only. This is the opposite of isLoadable.
   bool isAddressOnly(SILModule &M) const;

--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -117,6 +117,8 @@ SILBuilder::createClassifyBridgeObject(SILLocation Loc, SILValue value) {
 // Create the appropriate cast instruction based on result type.
 SingleValueInstruction *
 SILBuilder::createUncheckedBitCast(SILLocation Loc, SILValue Op, SILType Ty) {
+  assert(!SILModuleConventions(getModule()).useLoweredAddresses() ||
+         Ty.isLoadable(getModule()));
   if (Ty.isTrivial(getModule()))
     return insert(UncheckedTrivialBitCastInst::create(
         getSILDebugLocation(Loc), Op, Ty, getFunction(), OpenedArchetypes));
@@ -524,6 +526,8 @@ void SILBuilder::emitShallowDestructureAddressOperation(
 
 DebugValueInst *SILBuilder::createDebugValue(SILLocation Loc, SILValue src,
                                              SILDebugVariable Var) {
+  assert(!SILModuleConventions(getModule()).useLoweredAddresses() ||
+         src->getType().isLoadable(getModule()));
   // Debug location overrides cannot apply to debug value instructions.
   DebugLocOverrideRAII LocOverride{*this, None};
   return insert(

--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -117,8 +117,7 @@ SILBuilder::createClassifyBridgeObject(SILLocation Loc, SILValue value) {
 // Create the appropriate cast instruction based on result type.
 SingleValueInstruction *
 SILBuilder::createUncheckedBitCast(SILLocation Loc, SILValue Op, SILType Ty) {
-  assert(!SILModuleConventions(getModule()).useLoweredAddresses() ||
-         Ty.isLoadable(getModule()));
+  assert(Ty.isLoadableOrLowered(getModule()));
   if (Ty.isTrivial(getModule()))
     return insert(UncheckedTrivialBitCastInst::create(
         getSILDebugLocation(Loc), Op, Ty, getFunction(), OpenedArchetypes));
@@ -526,8 +525,7 @@ void SILBuilder::emitShallowDestructureAddressOperation(
 
 DebugValueInst *SILBuilder::createDebugValue(SILLocation Loc, SILValue src,
                                              SILDebugVariable Var) {
-  assert(!SILModuleConventions(getModule()).useLoweredAddresses() ||
-         src->getType().isLoadable(getModule()));
+  assert(src->getType().isLoadableOrLowered(getModule()));
   // Debug location overrides cannot apply to debug value instructions.
   DebugLocOverrideRAII LocOverride{*this, None};
   return insert(

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -14,9 +14,10 @@
 #include "swift/AST/ExistentialLayout.h"
 #include "swift/AST/GenericEnvironment.h"
 #include "swift/AST/Type.h"
+#include "swift/SIL/AbstractionPattern.h"
+#include "swift/SIL/SILFunctionConventions.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/TypeLowering.h"
-#include "swift/SIL/AbstractionPattern.h"
 
 using namespace swift;
 using namespace swift::Lowering;
@@ -351,6 +352,10 @@ SILType SILType::getEnumElementType(EnumElementDecl *elt, SILModule &M) const {
     M.Types.getLoweredType(M.Types.getAbstractionPattern(elt), substEltTy);
 
   return SILType(loweredTy.getSwiftRValueType(), getCategory());
+}
+
+bool SILType::isLoadableOrLowered(SILModule &M) const {
+  return isLoadable(M) || !SILModuleConventions(M).useLoweredAddresses();
 }
 
 /// True if the type, or the referenced type of an address type, is


### PR DESCRIPTION
radar rdar://problem/33767770