### PR TITLE
[AST verifier] Remove the $.*lldb name-matching hack.

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -450,12 +450,6 @@ public:
       // AST invariants involving archetypes.
       if (typealias->isDebuggerAlias()) return false;
 
-      // FIXME: Temporary hack to bridge the gap until LLDB starts setting
-      // the "debugger alias" flag.
-      if (typealias->getName().str().startswith("$") &&
-          typealias->getName().str().contains("lldb"))
-        return false;
-
       return true;
     }
 


### PR DESCRIPTION
Once LLDB is setting the "debugger typealias" bit for its invariant-breaking
type aliases, we don't need this hack.
