### PR TITLE
☣️ ☠️ Enable the AST verifier unless SWIFT_DISABLE_AST_VERIFIER is defined.

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -3461,14 +3461,14 @@ public:
 } // end anonymous namespace
 
 void swift::verify(SourceFile &SF) {
-#if !(defined(NDEBUG) || defined(SWIFT_DISABLE_AST_VERIFIER))
+#if !defined(SWIFT_DISABLE_AST_VERIFIER)
   Verifier verifier(SF, &SF);
   SF.walk(verifier);
 #endif
 }
 
 bool swift::shouldVerify(const Decl *D, const ASTContext &Context) {
-#if !(defined(NDEBUG) || defined(SWIFT_DISABLE_AST_VERIFIER))
+#if !defined(SWIFT_DISABLE_AST_VERIFIER)
   if (const auto *ED = dyn_cast<ExtensionDecl>(D)) {
     return shouldVerify(ED->getExtendedType()->getAnyNominal(), Context);
   }
@@ -3486,9 +3486,8 @@ bool swift::shouldVerify(const Decl *D, const ASTContext &Context) {
 }
 
 void swift::verify(Decl *D) {
-#if !(defined(NDEBUG) || defined(SWIFT_DISABLE_AST_VERIFIER))
+#if !defined(SWIFT_DISABLE_AST_VERIFIER)
   Verifier V = Verifier::forDecl(D);
   D->walk(V);
 #endif
 }
-


### PR DESCRIPTION
The verifier catches quite a few issues that otherwise end up
resulting in crashes later in compilation.

Let's leave it enabled, even when assertions are disabled.

This change is intentionally only modifying the bodies of
`verify()` and `shouldVerify()`, as opposed to also updating various call
sites that call into these that are currendly under #ifndef NDEBUG.

We can evaluate those particular callsites at a later time. For now,
it useful to run the verifier over the entire file after type
checking.
