### PR TITLE
[SILOptimizer] Don't optimize casts to protocols with a conditional conformance.

### DIFF
--- a/test/SILOptimizer/cast_folding_conditional_conformance.swift
+++ b/test/SILOptimizer/cast_folding_conditional_conformance.swift
@@ -1,0 +1,22 @@
+// RUN: %target-swift-frontend %s -emit-sil -O -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -emit-ir -o /dev/null
+
+// rdar://problem/38694450
+
+protocol P {}
+extension Array: P where Element: P {}
+struct X {}
+// CHECK-LABEL: sil @$S36cast_folding_conditional_conformance5arrayyyF : $@convention(thin) () -> () {
+public func array() {
+    // CHECK: unconditional_checked_cast_addr Array<X> in {{%[0-9]*}} : $*Array<X> to P in {{%[0-9]*}} : $*P
+    var x = [X()] as! P
+}
+
+struct Y<T> {}
+extension Y: P where T: P {}
+// CHECK-LABEL: sil @$S36cast_folding_conditional_conformance3fooyyxmlF : $@convention(thin) <T> (@thick T.Type) -> () {
+public func foo<T>(_: T.Type) {
+    // CHECK: unconditional_checked_cast_addr Y<T> in {{%[0-9]*}} : $*Y<T> to P in {{%[0-9]*}} : $*P
+    var x = Y<T>() as! P
+}
+


### PR DESCRIPTION
The conformance existing isn't enough to be sure the cast will succeed,
there may be dynamic information, so we just assume they're always
dynamic.

Fixes rdar://problem/38694450.
