### PR TITLE
[AST] Remove a bogus assertion from the NameAliasType creation function.

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2945,8 +2945,7 @@ NameAliasType *NameAliasType::get(
 
   // Profile the type.
   llvm::FoldingSetNodeID id;
-  NameAliasType::Profile(id, typealias, parent, substitutions,
-                              underlying);
+  NameAliasType::Profile(id, typealias, parent, substitutions, underlying);
 
   // Did we already record this type?
   void *insertPos;
@@ -2957,13 +2956,12 @@ NameAliasType *NameAliasType::get(
   // Build a new type.
   unsigned numSubstitutions =
     genericSig ? genericSig->getSubstitutionListSize() : 0;
-  assert(static_cast<bool>(genericSig) == numSubstitutions > 0);
   auto size =
     totalSizeToAlloc<Type, GenericSignature *, Substitution>(
                         parent ? 1 : 0, genericSig ? 1 : 0, numSubstitutions);
   auto mem = ctx.Allocate(size, alignof(NameAliasType), arena);
   auto result = new (mem) NameAliasType(typealias, parent, substitutions,
-                                             underlying, storedProperties);
+                                        underlying, storedProperties);
   types.InsertNode(result, insertPos);
   return result;
 }

--- a/validation-test/compiler_crashers_2_fixed/0149-sr-7282.swift
+++ b/validation-test/compiler_crashers_2_fixed/0149-sr-7282.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -o -
+
+// SR-7282
+struct S<T> {}
+
+extension S where T == Int {
+    typealias Callback = (Bool) -> Void
+
+    func process(callback: Callback) {   
+    }
+}


### PR DESCRIPTION
Fixes SR-7282.
