### PR TITLE
[Mangler] Fix mangling for associated types.

### DIFF
--- a/docs/ABI/Mangling.rst
+++ b/docs/ABI/Mangling.rst
@@ -209,6 +209,7 @@ Entities
   entity-spec ::= decl-name label-list? type 'v' ACCESSOR                           // variable
   entity-spec ::= decl-name type 'fp'                                               // generic type parameter
   entity-spec ::= decl-name type 'fo'                                               // enum element (currently not used)
+  entity-spec ::= identifier 'Qa'                                                   // associated type declaration
 
   ACCESSOR ::= 'm'                           // materializeForSet
   ACCESSOR ::= 's'                           // setter

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -503,6 +503,7 @@ std::string ASTMangler::mangleDeclAsUSR(const ValueDecl *Decl,
   } else if (isa<AssociatedTypeDecl>(Decl)) {
     appendContextOf(Decl);
     appendDeclName(Decl);
+    appendOperator("Qa");
   } else {
     appendEntity(Decl);
   }

--- a/test/IDE/comment_inherited_protocol.swift
+++ b/test/IDE/comment_inherited_protocol.swift
@@ -15,7 +15,7 @@ protocol ParentProtocol1 {
 
   /// ParentProtocol.AssocType
   associatedtype AssocType
-  // CHECK: AssociatedType/ParentProtocol1.AssocType {{.*}} DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>AssocType</Name><USR>s:14swift_ide_test15ParentProtocol1P9AssocType</USR><Declaration>associatedtype AssocType</Declaration><CommentParts><Abstract><Para>ParentProtocol.AssocType</Para></Abstract></CommentParts></Other>]
+  // CHECK: AssociatedType/ParentProtocol1.AssocType {{.*}} DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>AssocType</Name><USR>s:14swift_ide_test15ParentProtocol1P9AssocTypeQa</USR><Declaration>associatedtype AssocType</Declaration><CommentParts><Abstract><Para>ParentProtocol.AssocType</Para></Abstract></CommentParts></Other>]
 
   /// ParentProtocol1.commonParentRequirement()
   func commonParentRequirement()
@@ -75,7 +75,7 @@ extension ChildProtocol {
 
   // Should come from ParentProtocol1.
   typealias AssocType = Int
-  // CHECK: TypeAlias/AssocType {{.*}} DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>AssocType</Name><USR>s:14swift_ide_test15ParentProtocol1P9AssocType</USR><Declaration>associatedtype AssocType</Declaration><CommentParts><Abstract><Para>ParentProtocol.AssocType</Para></Abstract></CommentParts></Other>]
+  // CHECK: TypeAlias/AssocType {{.*}} DocCommentAsXML=[<Other file="{{.*}}" line="{{.*}}" column="{{.*}}"><Name>AssocType</Name><USR>s:14swift_ide_test15ParentProtocol1P9AssocTypeQa</USR><Declaration>associatedtype AssocType</Declaration><CommentParts><Abstract><Para>ParentProtocol.AssocType</Para></Abstract></CommentParts></Other>]
 
   // Should come from ParentProtocol2.
   func onlyParent2() {}

--- a/test/IDE/print_usrs.swift
+++ b/test/IDE/print_usrs.swift
@@ -83,7 +83,7 @@ class GenericClass {
 
 // CHECK: [[@LINE+1]]:10 s:14swift_ide_test4ProtP{{$}}
 protocol Prot {
-  // CHECK: [[@LINE+1]]:18 s:14swift_ide_test4ProtP5Blarg{{$}}
+  // CHECK: [[@LINE+1]]:18 s:14swift_ide_test4ProtP5BlargQa{{$}}
   associatedtype Blarg
   // CHECK: [[@LINE+1]]:8 s:14swift_ide_test4ProtP8protMethy5BlargQzAFF{{$}}
   func protMeth(_ x: Blarg) -> Blarg

--- a/test/Index/kinds.swift
+++ b/test/Index/kinds.swift
@@ -134,7 +134,7 @@ protocol AProtocol {
 
   // AssociatedType
   associatedtype T
-  // CHECK: [[@LINE-1]]:18 | type-alias/associated-type/Swift | T | s:14swift_ide_test9AProtocolP1T | Def,RelChild | rel: 1
+  // CHECK: [[@LINE-1]]:18 | type-alias/associated-type/Swift | T | s:14swift_ide_test9AProtocolP1TQa | Def,RelChild | rel: 1
   // CHECK-NEXT: RelChild | protocol/Swift | AProtocol | s:14swift_ide_test9AProtocolP
 }
 

--- a/test/SourceKit/DocSupport/doc_source_file.swift.response
+++ b/test/SourceKit/DocSupport/doc_source_file.swift.response
@@ -1664,7 +1664,7 @@
   {
     key.kind: source.lang.swift.ref.associatedtype,
     key.name: "Element",
-    key.usr: "s:4main5Prot2P7Element",
+    key.usr: "s:4main5Prot2P7ElementQa",
     key.offset: 1935,
     key.length: 7
   },
@@ -2381,7 +2381,7 @@
       {
         key.kind: source.lang.swift.decl.associatedtype,
         key.name: "Element",
-        key.usr: "s:4main5Prot2P7Element",
+        key.usr: "s:4main5Prot2P7ElementQa",
         key.offset: 1752,
         key.length: 15,
         key.fully_annotated_decl: "<decl.associatedtype><syntaxtype.keyword>associatedtype</syntaxtype.keyword> <decl.name>Element</decl.name></decl.associatedtype>"

--- a/test/SourceKit/DocSupport/doc_swift_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_swift_module.swift.response
@@ -1988,7 +1988,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
       {
         key.kind: source.lang.swift.decl.associatedtype,
         key.name: "T",
-        key.usr: "s:4cake2P3P1T",
+        key.usr: "s:4cake2P3P1TQa",
         key.offset: 962,
         key.length: 16,
         key.fully_annotated_decl: "<decl.associatedtype><syntaxtype.keyword>associatedtype</syntaxtype.keyword> <decl.name>T</decl.name></decl.associatedtype>"
@@ -2014,7 +2014,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
       {
         key.kind: source.lang.swift.decl.associatedtype,
         key.name: "Element",
-        key.usr: "s:4cake2P5P7Element",
+        key.usr: "s:4cake2P5P7ElementQa",
         key.offset: 1018,
         key.length: 22,
         key.fully_annotated_decl: "<decl.associatedtype><syntaxtype.keyword>associatedtype</syntaxtype.keyword> <decl.name>Element</decl.name></decl.associatedtype>"
@@ -2067,7 +2067,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
       {
         key.kind: source.lang.swift.decl.associatedtype,
         key.name: "Element",
-        key.usr: "s:4cake4ProtP7Element",
+        key.usr: "s:4cake4ProtP7ElementQa",
         key.offset: 1142,
         key.length: 22,
         key.fully_annotated_decl: "<decl.associatedtype><syntaxtype.keyword>associatedtype</syntaxtype.keyword> <decl.name>Element</decl.name></decl.associatedtype>"
@@ -2337,7 +2337,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
           {
             key.kind: source.lang.swift.ref.associatedtype,
             key.name: "Element",
-            key.usr: "s:4cake2P5P7Element"
+            key.usr: "s:4cake2P5P7ElementQa"
           }
         ]
       }


### PR DESCRIPTION
Now that this is fixed, we can probably revert the workaround in type reconstruction.
Thanks to @eeckstein for the help!