### PR TITLE
[Sema] NFC - Bypass more Pattern type variables

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1991,12 +1991,9 @@ namespace {
         // tuples, nested arrays, and dictionary literals.
         //
         // Otherwise, create a new type variable.
-        auto boundExpr = locator.trySimplifyToExpr();
-
-        if (boundExpr) {
-          auto boundExprTy = CS.getType(boundExpr);
-          if (!boundExprTy->is<InOutType>())
-            return boundExprTy->getRValueType();
+        if (auto boundExpr = locator.trySimplifyToExpr()) {
+          if (!boundExpr->isSemanticallyInOutExpr())
+            return CS.getType(boundExpr)->getRValueType();
         }
 
         return CS.createTypeVariable(CS.getConstraintLocator(locator),
@@ -2022,9 +2019,8 @@ namespace {
         case ReferenceOwnership::Unmanaged:
           if (!var->hasNonPatternBindingInit()) {
             if (auto boundExpr = locator.trySimplifyToExpr()) {
-              auto boundExprTy = CS.getType(boundExpr);
-              if (!boundExprTy->is<InOutType>())
-                return boundExprTy->getRValueType();
+              if (!boundExpr->isSemanticallyInOutExpr())
+                return CS.getType(boundExpr)->getRValueType();
             }
           }
           break;


### PR DESCRIPTION
Rather than throw away the result of simplifying the expression if the resulting is InOutType, see if the user explicitly created the InOutType. If they did not, then the RValue type is fine.

Hi @rudkx – Based on our conversation in #15542, this change makes InOut on the right hand side work. Right?