### PR TITLE
SILGen: Fix a null-dereference bug handling writeback to global computed properties.

### DIFF
--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -303,7 +303,7 @@ void LogicalPathComponent::writeback(SILGenFunction &SGF, SILLocation loc,
   RValue rvalue(SGF, loc, getSubstFormalType(), temporary);
 
   // Don't consume cleanups on the base if this isn't final.
-  if (!isFinal) { base = ManagedValue::forUnmanaged(base.getValue()); }
+  if (base && !isFinal) { base = ManagedValue::forUnmanaged(base.getValue()); }
 
   // Clone the component if this isn't final.
   std::unique_ptr<LogicalPathComponent> clonedComponent =

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -1230,3 +1230,11 @@ protocol NonmutatingProtocol {
 func overlappingLoadExpr(c: inout ReferenceType) {
   _ = c.p.x
 }
+
+var globalOptionalComputed: Int? {
+  didSet { print("hello") }
+}
+
+func updateGlobalOptionalComputed() {
+  globalOptionalComputed? = 123
+}


### PR DESCRIPTION
SR-7220 | rdar://problem/38624843
