### PR TITLE
Merge pull request #15520 from davidungar/PR-18-15-num-threads-fix

### DIFF
--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -83,6 +83,8 @@ ERROR(error_unknown_arg,none,
   "unknown argument: '%0'", (StringRef))
 ERROR(error_invalid_arg_value,none,
   "invalid value '%1' in '%0'", (StringRef, StringRef))
+WARNING(warning_cannot_multithread_batch_mode,none,
+  "ignoring -num-threads argument; cannot multithread batch mode", ())
 ERROR(error_unsupported_option_argument,none,
   "unsupported argument '%1' to option '%0'", (StringRef, StringRef))
 ERROR(error_immediate_mode_missing_stdlib,none,

--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -242,7 +242,8 @@ public:
   /// information.
   void buildOutputInfo(const ToolChain &TC,
                        const llvm::opt::DerivedArgList &Args,
-                       const InputFileList &Inputs, OutputInfo &OI) const;
+                       const bool BatchMode, const InputFileList &Inputs,
+                       OutputInfo &OI) const;
 
   /// Construct the list of Actions to perform for the given arguments,
   /// which are only done for a single architecture.

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -1154,6 +1154,9 @@ static bool writeFilelistIfNecessary(const Job *job, const ArgList &args,
       else {
         // The normal case for non-single-compile jobs.
         for (const Action *A : job->getSource().getInputs()) {
+          // A could be a GeneratePCHJobAction
+          if (!isa<InputAction>(A))
+            continue;
           const auto *IA = cast<InputAction>(A);
           out << IA->getInputArg().getValue() << "\n";
         }

--- a/test/Driver/batch_mode_with_num-threads.swift
+++ b/test/Driver/batch_mode_with_num-threads.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+// RUN: echo 'print("Hello, World!")' >%t/main.swift
+// RUN: touch %t/bridgingHeader.h
+//
+// Make sure the proper warning is emitted:
+//
+// RUN: %swiftc_driver -enable-batch-mode -num-threads 2 %t/main.swift -import-objc-header %t/bridgingHeader.h -### 2>&1 | %FileCheck %s
+//
+// CHECK: ignoring -num-threads argument; cannot multithread batch mode
+//
+// Make sure that it actually works. (The link step fails if -num-threads is not ignored.)
+//
+// RUN: %swiftc_driver -enable-batch-mode -num-threads 2 %t/main.swift -import-objc-header %t/bridgingHeader.h

--- a/test/Driver/batch_mode_with_pch.swift
+++ b/test/Driver/batch_mode_with_pch.swift
@@ -1,0 +1,5 @@
+// RUN: %empty-directory(%t)
+// RUN: echo 'print("Hello, World!")' >%t/main.swift
+// RUN: touch %t/bridgingHeader.h
+//
+// RUN: %swiftc_driver -driver-use-filelists -enable-batch-mode -num-threads 2 %t/main.swift -import-objc-header %t/bridgingHeader.h


### PR DESCRIPTION
Explanation: Regarding command-line arguments: -enable-batch-mode tells the swift compiler to compile >1 primary file at a time. But if used in conjunction with either -num-threads or -import-objc-header the compilation won't work, failing an assertion, or producing a link-time error.
Scope of issue: Build breakage if -enable-batch-mode is present with either -num-threads or -import-objc-header.
Origination: When the driver was enhanced to support batch-mode, these cases were not addressed.
Risk: A user could get discouraged when he/she tries out batch mode and things break for no apparent reason.
Reviewed by: Jordan Rose and Graydon Hoare
Testing by: Normal smoke tests.
Radar: rdar://problem/38924422



<!-- What's in this pull request? -->
 This PR changes the driver to ignore -num-threads in batch mode and emit a warning when it does so. It also adds an assertion at the point where the driver would go wrong if both flags were present. Finally, it includes a test.

Likewise, fix a crash that occurs if -enable-batch-mode is present with-import-objc-header and a primary filelist is used. Also includes a test for this condition.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
