### PR TITLE
[SILVerifier] Loosen verification for debug info scopes holes.

### DIFF
--- a/include/swift/SIL/DebugUtils.h
+++ b/include/swift/SIL/DebugUtils.h
@@ -49,6 +49,12 @@ inline bool isDebugInst(SILInstruction *Inst) {
   return isa<DebugValueInst>(Inst) || isa<DebugValueAddrInst>(Inst);
 }
 
+/// Returns true if the instruction \p Inst is a maintenance instructions which
+/// is relevant for debug information and does not get lowered to an instruction.
+inline bool isMaintenanceInst(SILInstruction *Inst) {
+  return isDebugInst(Inst) || isa<AllocStackInst>(Inst);
+}
+
 /// Deletes all of the debug instructions that use \p Inst.
 inline void deleteAllDebugUses(ValueBase *Inst) {
   for (auto UI = Inst->use_begin(), E = Inst->use_end(); UI != E;) {

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/Types.h"
 #include "swift/Basic/Range.h"
 #include "swift/ClangImporter/ClangModule.h"
+#include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/Dominance.h"
 #include "swift/SIL/DynamicCasts.h"
 #include "swift/SIL/PostOrder.h"
@@ -4544,16 +4545,14 @@ public:
 
     const SILDebugScope *LastSeenScope = nullptr;
     for (SILInstruction &SI : *BB) {
-      if (isa<AllocStackInst>(SI))
+      if (isMaintenanceInst(&SI))
         continue;
       LastSeenScope = SI.getDebugScope();
       AlreadySeenScopes.insert(LastSeenScope);
       break;
     }
     for (SILInstruction &SI : *BB) {
-      // `alloc_stack` can create false positive, so we skip it
-      // for now.
-      if (isa<AllocStackInst>(SI))
+      if (isMaintenanceInst(&SI))
         continue;
 
       // If we haven't seen this debug scope yet, update the


### PR DESCRIPTION
We should also skip debug info as they don't really are lowered
to anything real. Add an helper so that we can use it in passes
as well.