### PR TITLE
Disable a test that seems to infinitely recurse on a diagnostic somet…

### DIFF
--- a/validation-test/compiler_crashers/28869-swift-diagnosticengine-formatdiagnostictext-llvm-raw-ostream-llvm-stringref-llvm.swift
+++ b/validation-test/compiler_crashers/28869-swift-diagnosticengine-formatdiagnostictext-llvm-raw-ostream-llvm-stringref-llvm.swift
@@ -6,4 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not --crash %target-swift-frontend %s -emit-ir
+// REQUIRES: rdar38932729
 protocol A:A&CLong


### PR DESCRIPTION
…imes.

Once the associated bug is fixed we can re-enable.
