### PR TITLE
[Sema] Fix `PreCheckExpression` to avoid walking into capture lists

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -824,7 +824,12 @@ namespace {
           TC.typeCheckDecl(capture.Var, true);
           TC.typeCheckDecl(capture.Var, false);
         }
-        return finish(true, expr);
+
+        // Since closure expression is contained by capture list
+        // let's handle it directly to avoid walking into capture
+        // list itself.
+        captureList->getClosureBody()->walk(*this);
+        return finish(false, expr);
       }
 
       // For closures, type-check the patterns and result type as written,

--- a/validation-test/compiler_crashers_2_fixed/0149-rdar34852808.swift
+++ b/validation-test/compiler_crashers_2_fixed/0149-rdar34852808.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift %s
+
+func foo(optional: Int?) {
+  _ = { [value = optional ?? 0]
+    in
+    _ = value
+  }
+
+  _ = [1].map { [number = optional ?? 1] value -> String in
+    return number.description
+  }
+}


### PR DESCRIPTION
`PreCheckExpression` should only walk into associated closure if
it's a single statement, and should avoid list itself since it should
already be properly type-checked by `typeCheckDecl`.

Resolves: rdar://problem/34852808
Resolves [SR-7115](https://bugs.swift.org/browse/SR-7115).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
