### PR TITLE
[swift-ide-test] Bail out when a module couldn't be loaded

### DIFF
--- a/test/IDE/print_module_bad_target.swift
+++ b/test/IDE/print_module_bad_target.swift
@@ -1,0 +1,10 @@
+// RUN: not %swift-ide-test -source-filename %s -print-module -module-to-print Swift -target x86_64-unknown-solaris
+
+// RUN: not %swift-ide-test -source-filename %s -print-module -module-to-print Swift -target x86_64-apple-macosx10.6 -sdk %sdk
+// RUN: not %swift-ide-test -source-filename %s -print-module -module-to-print CoreServices -target x86_64-apple-macosx10.6 -sdk %sdk
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t -module-name Dummy -target x86_64-apple-macosx10.99 %s
+// RUN: not %target-swift-ide-test -source-filename %s -print-module -module-to-print Dummy -I %t
+
+// REQUIRES: OS=macosx

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1490,11 +1490,18 @@ static ModuleDecl *getModuleByFullName(ASTContext &Context, StringRef ModuleName
     AccessPath.push_back(
         { Context.getIdentifier(SubModuleName), SourceLoc() });
   }
-  return Context.getModule(AccessPath);
+  ModuleDecl *Result = Context.getModule(AccessPath);
+  if (!Result || Result->failedToLoad())
+    return nullptr;
+  return Result;
 }
 
 static ModuleDecl *getModuleByFullName(ASTContext &Context, Identifier ModuleName) {
-  return Context.getModule(std::make_pair(ModuleName, SourceLoc()));
+  ModuleDecl *Result = Context.getModule(std::make_pair(ModuleName,
+                                                        SourceLoc()));
+  if (!Result || Result->failedToLoad())
+    return nullptr;
+  return Result;
 }
 
 static int doPrintAST(const CompilerInvocation &InitInvok,


### PR DESCRIPTION
The importer in particular depends on the stdlib and the Foundation overlay being successfully loaded, so if anything *can't* be loaded we have to assume that trying to walk a module's decls will result in a crash.

rdar://problem/37540394