### PR TITLE
Change various uses of SWIFT_SDK_${SDK}_PATH to its architecture specific vairant

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -123,10 +123,11 @@ function(_add_variant_c_compile_link_flags)
     list(APPEND result "-target" "${SWIFT_SDK_${CFLAGS_SDK}_ARCH_${CFLAGS_ARCH}_TRIPLE}${DEPLOYMENT_VERSION}")
   endif()
 
+  set(_sysroot "${SWIFT_SDK_${CFLAGS_SDK}_ARCH_${CFLAGS_ARCH}_PATH}")
   if(IS_DARWIN)
-    list(APPEND result "-isysroot" "${SWIFT_SDK_${CFLAGS_SDK}_PATH}")
-  elseif(NOT SWIFT_COMPILER_IS_MSVC_LIKE AND NOT "${SWIFT_SDK_${CFLAGS_SDK}_PATH}" STREQUAL "/")
-    list(APPEND result "--sysroot=${SWIFT_SDK_${CFLAGS_SDK}_PATH}")
+    list(APPEND result "-isysroot" "${_sysroot}")
+  elseif(NOT SWIFT_COMPILER_IS_MSVC_LIKE AND NOT "${_sysroot}" STREQUAL "/")
+    list(APPEND result "--sysroot=${_sysroot}")
   endif()
 
   if("${CFLAGS_SDK}" STREQUAL "ANDROID")
@@ -294,9 +295,9 @@ function(_add_variant_swift_compile_flags
     sdk arch build_type enable_assertions result_var_name)
   set(result ${${result_var_name}})
 
-  # On Windows, we don't set SWIFT_SDK_WINDOWS_PATH, so don't include it.
+  # On Windows, we don't set SWIFT_SDK_WINDOWS_PATH_ARCH_{ARCH}_PATH, so don't include it.
   if (NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
-    list(APPEND result "-sdk" "${SWIFT_SDK_${sdk}_PATH}")
+    list(APPEND result "-sdk" "${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}")
   endif()
 
   is_darwin_based_sdk("${sdk}" IS_DARWIN)
@@ -314,7 +315,7 @@ function(_add_variant_swift_compile_flags
 
   if(IS_DARWIN)
     list(APPEND result
-        "-F" "${SWIFT_SDK_${sdk}_PATH}/../../../Developer/Library/Frameworks")
+      "-F" "${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}/../../../Developer/Library/Frameworks")
   endif()
 
   is_build_type_optimized("${build_type}" optimized)
@@ -1619,7 +1620,7 @@ function(add_swift_library name)
         # Add PrivateFrameworks, rdar://28466433
         set(swiftlib_link_flags_all ${SWIFTLIB_LINK_FLAGS})
         if(SWIFTLIB_IS_SDK_OVERLAY)
-          list(APPEND swiftlib_swift_compile_flags_all "-Fsystem" "${SWIFT_SDK_${sdk}_PATH}/System/Library/PrivateFrameworks/")
+          list(APPEND swiftlib_swift_compile_flags_all "-Fsystem" "${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}/System/Library/PrivateFrameworks/")
         endif()
        
        if("${sdk}" STREQUAL "IOS_SIMULATOR")

--- a/cmake/modules/SwiftConfigureSDK.cmake
+++ b/cmake/modules/SwiftConfigureSDK.cmake
@@ -22,7 +22,6 @@ function(_report_sdk prefix)
       message(STATUS "  ${arch} LIB: ${${arch}_LIB}")
     endforeach()
   else()
-    message(STATUS "  Path: ${SWIFT_SDK_${prefix}_PATH}")
     foreach(arch ${SWIFT_SDK_${prefix}_ARCHITECTURES})
       message(STATUS "  ${arch} Path: ${SWIFT_SDK_${prefix}_ARCH_${arch}_PATH}")
     endforeach()
@@ -145,7 +144,6 @@ macro(configure_sdk_unix
 
   # Todo: this only supports building an SDK for one target arch only.
   set(SWIFT_SDK_${prefix}_NAME "${name}")
-  set(SWIFT_SDK_${prefix}_PATH "${sdkpath}")
   set(SWIFT_SDK_${prefix}_ARCH_${arch}_PATH "${sdkpath}")
   set(SWIFT_SDK_${prefix}_VERSION "don't use")
   set(SWIFT_SDK_${prefix}_BUILD_NUMBER "don't use")
@@ -173,10 +171,6 @@ macro(configure_sdk_windows prefix sdk_name environment architectures)
   # variables.
 
   set(SWIFT_SDK_${prefix}_NAME "${sdk_name}")
-  # NOTE: set the path to / to avoid a spurious `--sysroot` from being passed
-  # to the driver -- rely on the `INCLUDE` AND `LIB` environment variables
-  # instead.
-  set(SWIFT_SDK_${prefix}_PATH "/")
   set(SWIFT_SDK_${prefix}_VERSION "NOTFOUND")
   set(SWIFT_SDK_${prefix}_BUILD_NUMBER "NOTFOUND")
   set(SWIFT_SDK_${prefix}_DEPLOYMENT_VERSION "")
@@ -194,6 +188,9 @@ macro(configure_sdk_windows prefix sdk_name environment architectures)
       set(SWIFT_SDK_${prefix}_ARCH_${arch}_TRIPLE
           "${arch}-unknown-windows-${environment}")
     endif()
+    # NOTE: set the path to / to avoid a spurious `--sysroot` from being passed
+    # to the driver -- rely on the `INCLUDE` AND `LIB` environment variables
+    # instead.
     set(SWIFT_SDK_${prefix}_ARCH_${arch}_PATH "/")
   endforeach()
 

--- a/stdlib/public/Platform/CMakeLists.txt
+++ b/stdlib/public/Platform/CMakeLists.txt
@@ -52,11 +52,11 @@ foreach(sdk ${SWIFT_SDKS})
       # at /system/develop/headers.
       set(GLIBC_INCLUDE_PATH "/system/develop/headers/posix")
       set(GLIBC_ARCH_INCLUDE_PATH "/system/develop/headers/posix")
-      set(GLIBC_SYSROOT_RELATIVE_INCLUDE_PATH "/system/develop/headers/")
+      set(GLIBC_SYSROOT_RELATIVE_ARCH_INCLUDE_PATH "/system/develop/headers/")
     else()
       # Determine the location of glibc headers based on the target.
       set(GLIBC_SYSROOT_RELATIVE_INCLUDE_PATH "/usr/include")
-      set(GLIBC_SYSROOT_RELATIVE_ARCH_INCLUDE_PATH ${GLIBC_SYSROOT_RELATIVE_INCLUDE_PATH})
+      set(GLIBC_SYSROOT_RELATIVE_ARCH_INCLUDE_PATH "${GLIBC_SYSROOT_RELATIVE_INCLUDE_PATH}")
     endif()
 
     # Some SDKs place their headers in architecture-specific subfolders.
@@ -64,9 +64,12 @@ foreach(sdk ${SWIFT_SDKS})
       set(GLIBC_SYSROOT_RELATIVE_ARCH_INCLUDE_PATH "${GLIBC_SYSROOT_RELATIVE_ARCH_INCLUDE_PATH}/${CMAKE_LIBRARY_ARCHITECTURE}")
     endif()
 
-    if(NOT "${sdk}" STREQUAL "HAIKU")
-      set(GLIBC_INCLUDE_PATH "${SWIFT_SDK_${sdk}_PATH}/${GLIBC_SYSROOT_RELATIVE_INCLUDE_PATH}")
-      set(GLIBC_ARCH_INCLUDE_PATH "${SWIFT_SDK_${sdk}_PATH}/${GLIBC_SYSROOT_RELATIVE_ARCH_INCLUDE_PATH}")
+    set(GLIBC_INCLUDE_PATH "${GLIBC_SYSROOT_RELATIVE_INCLUDE_PATH}")
+    set(GLIBC_ARCH_INCLUDE_PATH "${GLIBC_SYSROOT_RELATIVE_ARCH_INCLUDE_PATH}")
+
+    if(NOT "${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}" STREQUAL "/")
+      set(GLIBC_INCLUDE_PATH "${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}${GLIBC_INCLUDE_PATH}")
+      set(GLIBC_ARCH_INCLUDE_PATH "${SWIFT_SDK_${sdk}_ARCH_${arch}_PATH}${GLIBC_ARCH_INCLUDE_PATH}")
     endif()
 
     set(glibc_modulemap_source "glibc.modulemap.gyb")
@@ -88,7 +91,7 @@ foreach(sdk ${SWIFT_SDKS})
 
     # If this SDK is a target for a non-native host, create a native modulemap
     # without a sysroot prefix. This is the one we'll install instead.
-    if(NOT "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_PATH}" STREQUAL "/")
+    if(NOT "${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_ARCH_${arch}_PATH}" STREQUAL "/")
 
       set(glibc_sysroot_relative_modulemap_out "${module_dir}/sysroot-relative-modulemaps/glibc.modulemap")
       handle_gyb_source_single(glibc_modulemap_native_target
@@ -106,7 +109,7 @@ foreach(sdk ${SWIFT_SDKS})
     # FIXME: When SDK is a cross-compile target (SDK != Host), the generated
     #        modulemap will be relative to the Host, with hardcoded paths.
     #        It is not relocatable to the target platform itself.
-    #        This only affects ANDROID right now, but could affect cross-compiled LINUX targets
+    #        This affects any cross-comipled targets that use glibc.modulemap.
 
     swift_install_in_component(sdk-overlay
         FILES "${glibc_modulemap_out}"

--- a/stdlib/public/Platform/glibc.modulemap.gyb
+++ b/stdlib/public/Platform/glibc.modulemap.gyb
@@ -38,6 +38,15 @@ module SwiftGlibc [system] {
 
   // C standard library
   module C {
+% if CMAKE_SDK in ["LINUX", "ANDROID", "CYGWIN"]:
+    module features {
+% if CMAKE_SDK == "LINUX":
+      header "${GLIBC_INCLUDE_PATH}/stdc-predef.h"
+% end
+      header "${GLIBC_INCLUDE_PATH}/features.h"
+      export *
+    }
+% end
 % if CMAKE_SDK in ["LINUX", "FREEBSD", "CYGWIN", "HAIKU"]:
     module complex {
       header "${GLIBC_INCLUDE_PATH}/complex.h"
@@ -67,13 +76,6 @@ module SwiftGlibc [system] {
 % if CMAKE_SDK == "HAIKU":
     module pty {
       header "${GLIBC_INCLUDE_PATH}/../bsd/pty.h"
-      export *
-    }
-% end
-
-% if CMAKE_SDK in ["LINUX", "ANDROID", "CYGWIN"]:
-    module features {
-      header "${GLIBC_INCLUDE_PATH}/features.h"
       export *
     }
 % end

--- a/stdlib/public/stubs/CMakeLists.txt
+++ b/stdlib/public/stubs/CMakeLists.txt
@@ -19,18 +19,6 @@ set(LLVM_OPTIONAL_SOURCES
     ${swift_stubs_objc_sources}
     ${swift_stubs_unicode_normalization_sources})
 
-# ICU isn't required on Darwin, but is on every other platform.
-# Now in case we're cross-compiling from Darwin for another platform,
-# the find_package should still be executed.
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-  set(icu_required "")
-else()
-  set(icu_required "REQUIRED")
-endif()
-
-find_package(ICU ${icu_required} COMPONENTS uc)
-set(ICU_UC_LIBRARY "")
-
 set(swift_stubs_c_compile_flags ${SWIFT_RUNTIME_CORE_CXX_FLAGS})
 list(APPEND swift_stubs_c_compile_flags -DswiftCore_EXPORTS)
 list(APPEND swift_stubs_c_compile_flags -I${SWIFT_SOURCE_DIR}/include)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -160,7 +160,7 @@ foreach(SDK ${SWIFT_SDKS})
     # Configure variables for this subdirectory.
     set(VARIANT_SUFFIX "-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-${ARCH}")
     set(VARIANT_TRIPLE "${SWIFT_SDK_${SDK}_ARCH_${ARCH}_TRIPLE}${SWIFT_SDK_${SDK}_DEPLOYMENT_VERSION}")
-    set(VARIANT_SDK "${SWIFT_SDK_${SDK}_PATH}")
+    set(VARIANT_SDK "${SWIFT_SDK_${SDK}_ARCH_${ARCH}_PATH}")
 
     # A directory where to put the xUnit-style XML test results.
     set(SWIFT_TEST_RESULTS_DIR


### PR DESCRIPTION
Cross-compilation for multiple architectures & sdks require various
variables to be split to specify the arch/adk variant being focused on.
This change modifies various uses of the `SWIFT_SDK_${SDK}_PATH` to
`SWIFT_SDK_${SDK}_ARCH_${ARCH}`