### PR TITLE
[runtime] make `swift_getFieldAt` callable from C / Swift

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -4290,7 +4290,7 @@ SWIFT_CC(swift)
 SWIFT_RUNTIME_STDLIB_INTERFACE
 void swift_getFieldAt(
   const Metadata *base, unsigned index, 
-  void (*callback)(const char *name, const Metadata *type));
+  void (*callback)(const char *name, const Metadata *type, void *ctx), void *callbackCtx);
 
 } // end namespace swift
 

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -4286,10 +4286,11 @@ SWIFT_CC(swift)
 SWIFT_RUNTIME_STDLIB_INTERFACE
 const Metadata *_swift_class_getSuperclass(const Metadata *theClass);
 
+SWIFT_CC(swift)
 SWIFT_RUNTIME_STDLIB_INTERFACE
 void swift_getFieldAt(
-    const Metadata *type, unsigned index,
-    std::function<void(llvm::StringRef name, FieldType type)> callback);
+  const Metadata *base, unsigned index, 
+  void (*callback)(const char *name, const Metadata *type));
 
 } // end namespace swift
 

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1049,6 +1049,12 @@ swift_getTypeByMangledName(const char *typeNameStart, size_t typeNameLength,
 }
 
 void swift::swift_getFieldAt(
+  const Metadata *base, unsigned index, 
+  void (*callback)(const char *name, const Metadata *type)) {
+    swift::_swift_getFieldAt(base, index, [&] (llvm::StringRef name, FieldType fieldInfo) { callback(name.data(), fieldInfo.getType()); });
+}
+
+void swift::_swift_getFieldAt(
     const Metadata *base, unsigned index,
     std::function<void(llvm::StringRef name, FieldType fieldInfo)>
         callback) {

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1050,8 +1050,8 @@ swift_getTypeByMangledName(const char *typeNameStart, size_t typeNameLength,
 
 void swift::swift_getFieldAt(
   const Metadata *base, unsigned index, 
-  void (*callback)(const char *name, const Metadata *type)) {
-    swift::_swift_getFieldAt(base, index, [&] (llvm::StringRef name, FieldType fieldInfo) { callback(name.data(), fieldInfo.getType()); });
+  void (*callback)(const char *name, const Metadata *type, void *ctx), void *callbackCtx) {
+    swift::_swift_getFieldAt(base, index, [&] (llvm::StringRef name, FieldType fieldInfo) { callback(name.data(), fieldInfo.getType(), callbackCtx); });
 }
 
 void swift::_swift_getFieldAt(

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -329,6 +329,11 @@ public:
                            const Metadata *type,
                            const ProtocolDescriptor *protocol,
                            const WitnessTable **conformance);
+
+  void _swift_getFieldAt(
+      const Metadata *type, unsigned index,
+      std::function<void(llvm::StringRef name, FieldType type)> callback);
+
 } // end namespace swift
 
 #endif /* SWIFT_RUNTIME_PRIVATE_H */

--- a/stdlib/public/runtime/ReflectionMirror.mm
+++ b/stdlib/public/runtime/ReflectionMirror.mm
@@ -278,7 +278,7 @@ struct StructImpl : ReflectionMirrorImpl {
 
     Any result;
     
-    swift_getFieldAt(type, i, [&](llvm::StringRef name, FieldType fieldInfo) {
+    _swift_getFieldAt(type, i, [&](llvm::StringRef name, FieldType fieldInfo) {
       assert(!fieldInfo.isIndirect() && "indirect struct fields not implemented");
       
       *outName = name.data();
@@ -319,7 +319,7 @@ struct EnumImpl : ReflectionMirrorImpl {
     bool indirect = false;
     
     const char *caseName = nullptr;
-    swift_getFieldAt(type, tag, [&](llvm::StringRef name, FieldType info) {
+    _swift_getFieldAt(type, tag, [&](llvm::StringRef name, FieldType info) {
       caseName = name.data();
       payloadType = info.getType();
       indirect = info.isIndirect();
@@ -435,7 +435,7 @@ struct ClassImpl : ReflectionMirrorImpl {
 
     Any result;
     
-    swift_getFieldAt(type, i, [&](llvm::StringRef name, FieldType fieldInfo) {
+    _swift_getFieldAt(type, i, [&](llvm::StringRef name, FieldType fieldInfo) {
       assert(!fieldInfo.isIndirect() && "class indirect properties not implemented");
       
       auto *bytes = *reinterpret_cast<char * const *>(value);


### PR DESCRIPTION
Field names will no longer be stored in the nominal type descriptor in Swift 4.2. This PR allows the `swift_getFieldAt` function to be callable from C / Swift so that it will still be possible to access the field name data in-process from a Swfit app.

I've tested this from a Swift app and it works now. Prior to this change similar code would result in a bad access exception.

```swift
@_silgen_name("swift_getFieldAt")
func _getFieldAt(
    _ type: Any.Type,
    _ index: Int,
    _ callback: @convention(c) (UnsafePointer<CChar>, UnsafeRawPointer, UnsafeRawPointer) -> Void,
    _ ctx: UnsafeRawPointer
)

final class User {
    var name: String
    var age: Int
    init() { ... }
}

var test = "hello"

_getFieldAt(User.self, 1, { name, type, ctx in
    let name = String(cString: name)
    let type = unsafeBitCast(type, to: Any.Type.self)
    print("\(name): \(type)")
    print(ctx.assumingMemoryBound(to: String.self).pointee)
}, &test) // prints: age: Int, hello
```

Joe noted that I should add a context pointer to the callback which I did. He also said:

> _swift_getFieldAt taking a std::function [should be] implemented in terms of the function-pointer-taking variant

I was a bit confused on how to implement it that way as I've never really used C++ before. I'm not quite sure how to pass the context-capturing std::function through a C closure. Any pointers there would be appreciated!

Related twitter thread: https://twitter.com/jckarter/status/978736605014892544