### PR TITLE
change icu version check in UnicodeNormalization to 59

### DIFF
--- a/stdlib/public/stubs/UnicodeNormalization.cpp
+++ b/stdlib/public/stubs/UnicodeNormalization.cpp
@@ -292,8 +292,8 @@ int32_t swift::__swift_stdlib_unorm2_normalize(
     const __swift_stdlib_UNormalizer2 *norm, const __swift_stdlib_UChar *src,
     __swift_int32_t len, __swift_stdlib_UChar *dst, __swift_int32_t capacity,
     __swift_stdlib_UErrorCode *err) {
-  // TODO remove this compatibility when we require ICU >= 60 on Linux
-#if defined(__APPLE__) || U_ICU_VERSION_MAJOR_NUM >= 60
+  // TODO remove this compatibility when we require ICU >= 59 on Linux
+#if defined(__APPLE__) || U_ICU_VERSION_MAJOR_NUM >= 59
   return unorm2_normalize(ptr_cast<UNormalizer2>(norm), src, len, dst, capacity,
                           ptr_cast<UErrorCode>(err));
 #else


### PR DESCRIPTION
Modify the libicu version checked in stdlib/public/stubs/UnicodeNormalization.cpp.