### PR TITLE
[stdlib] Set, Dictionary: Clarify assert message when a duplicate key is found

### DIFF
--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -2538,8 +2538,8 @@ extension _NativeDictionaryBuffer where Key: Hashable
   @_versioned // FIXME(sil-serialize-all)
   internal func unsafeAddNew(key newKey: Key, value: Value) {
     let (i, found) = _find(newKey, startBucket: _bucket(newKey))
-    _sanityCheck(
-      !found, "unsafeAddNew was called, but the key is already present")
+    _precondition(
+      !found, "Duplicate key found in Dictionary. Keys may have been mutated after insertion")
     initializeKey(newKey, value: value, at: i.offset)
   }
 

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -2161,8 +2161,8 @@ extension _NativeSetBuffer where Element: Hashable
   @_versioned // FIXME(sil-serialize-all)
   internal func unsafeAddNew(key newKey: Element) {
     let (i, found) = _find(newKey, startBucket: _bucket(newKey))
-    _sanityCheck(
-      !found, "unsafeAddNew was called, but the key is already present")
+    _precondition(
+      !found, "Duplicate element found in Set. Elements may have been mutated after insertion")
     initializeKey(newKey, at: i.offset)
   }
 


### PR DESCRIPTION
When a duplicate key is found during rehashing, it is usually either because a key was mutated after insertion, or because the dictionary itself was mutated from multiple threads at the same time.

Both of these are serious programmer errors. Promote the sanity check for duplicate keys to a full precondition and improve the error message to point out the most probable cause of the failure.
