### PR TITLE
RFC / DO NOT MERGE – Remove TVO_CanBindToInOut, add TVO_IsGenericTypeParam

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -4802,7 +4802,6 @@ namespace {
 
       auto tv = cs.createTypeVariable(inputLocator,
                                       TVO_CanBindToLValue |
-                                      TVO_CanBindToInOut |
                                       TVO_PrefersSubtypeBinding);
 
       // In order to make this work, we pick the most general function type and
@@ -5256,8 +5255,8 @@ bool FailureDiagnosis::diagnoseTrailingClosureErrors(ApplyExpr *callExpr) {
       } else if (auto *typeVar = resultType->getAs<TypeVariableType>()) {
         auto tv =
             cs.createTypeVariable(cs.getConstraintLocator(expr),
-                                  TVO_CanBindToLValue | TVO_CanBindToInOut |
-                                      TVO_PrefersSubtypeBinding);
+                                  TVO_CanBindToLValue |
+                                  TVO_PrefersSubtypeBinding);
 
         auto extInfo = FunctionType::ExtInfo().withThrows();
         auto fTy = FunctionType::get(ParenType::get(cs.getASTContext(), tv),
@@ -7073,7 +7072,7 @@ bool FailureDiagnosis::visitKeyPathExpr(KeyPathExpr *KPE) {
 
       bool builtConstraints(ConstraintSystem &cs, Expr *expr) override {
         auto *locator = cs.getConstraintLocator(expr);
-        auto valueType = cs.createTypeVariable(locator, TVO_CanBindToInOut);
+        auto valueType = cs.createTypeVariable(locator);
 
         auto keyPathType =
             BoundGenericClassType::get(Decl, ParentType, {RootType, valueType});

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1299,9 +1299,7 @@ namespace {
       
       // Create an overload choice referencing this declaration and immediately
       // resolve it. This records the overload for use later.
-      auto tv = CS.createTypeVariable(locator,
-                                      TVO_CannotBindToInOut |
-                                      TVO_CanBindToLValue);
+      auto tv = CS.createTypeVariable(locator, TVO_CanBindToLValue);
 
       OverloadChoice choice =
           OverloadChoice(Type(), E->getDecl(), E->getFunctionRefKind());
@@ -2504,7 +2502,7 @@ namespace {
     Type
     createTypeVariableAndDisjunctionForIUOCoercion(Type toType,
                                                    ConstraintLocator *locator) {
-      auto typeVar = CS.createTypeVariable(locator, TVO_CannotBindToInOut);
+      auto typeVar = CS.createTypeVariable(locator);
       CS.buildDisjunctionForImplicitlyUnwrappedOptional(typeVar, toType,
                                                         locator);
       return typeVar;
@@ -2631,7 +2629,7 @@ namespace {
 
     Type visitDiscardAssignmentExpr(DiscardAssignmentExpr *expr) {
       auto locator = CS.getConstraintLocator(expr);
-      auto typeVar = CS.createTypeVariable(locator, TVO_CannotBindToInOut);
+      auto typeVar = CS.createTypeVariable(locator);
       return LValueType::get(typeVar);
     }
     
@@ -2646,8 +2644,7 @@ namespace {
       if (!destTy)
         return Type();
       if (destTy->is<UnresolvedType>()) {
-        return CS.createTypeVariable(CS.getConstraintLocator(expr),
-                                     TVO_CannotBindToInOut);
+        return CS.createTypeVariable(CS.getConstraintLocator(expr));
       }
       
       // The source must be convertible to the destination.
@@ -2740,9 +2737,7 @@ namespace {
       // This should only appear in already-type-checked solutions, but we may
       // need to re-check for failure diagnosis.
       auto locator = CS.getConstraintLocator(expr);
-      auto projectedTy = CS.createTypeVariable(locator,
-                                               TVO_CannotBindToInOut |
-                                               TVO_CanBindToLValue);
+      auto projectedTy = CS.createTypeVariable(locator, TVO_CanBindToLValue);
       CS.addKeyPathApplicationConstraint(expr->getKeyPath()->getType(),
                                          expr->getBase()->getType(),
                                          projectedTy,
@@ -2882,7 +2877,7 @@ namespace {
           
           // We can't assign an optional back through an optional chain
           // today. Force the base to an rvalue.
-          auto rvalueTy = CS.createTypeVariable(locator, TVO_CannotBindToInOut);
+          auto rvalueTy = CS.createTypeVariable(locator);
           CS.addConstraint(ConstraintKind::Equal, base, rvalueTy, locator);
           base = rvalueTy;
           LLVM_FALLTHROUGH;

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1691,7 +1691,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         // is wrapped in `inout` type to preserve inout/lvalue pairing.
         if (auto *lvt = type2->getAs<LValueType>()) {
           auto *tv = createTypeVariable(typeVar1->getImpl().getLocator(),
-                                        /*options=*/0);
+                                        TVO_CannotBindToInOut);
           assignFixedType(typeVar1, InOutType::get(tv));
 
           typeVar1 = tv;
@@ -2542,7 +2542,6 @@ ConstraintSystem::simplifyConstructionConstraint(
                                         ConstraintLocator::ApplyFunction);
   auto tv = createTypeVariable(applyLocator,
                                TVO_CanBindToLValue |
-                               TVO_CanBindToInOut |
                                TVO_PrefersSubtypeBinding);
 
   // The constructor will have function type T -> T2, for a fresh type
@@ -4701,9 +4700,7 @@ ConstraintSystem::simplifyRestrictedConstraintImpl(
       return SolutionKind::Error;
 
     auto constraintLocator = getConstraintLocator(locator);
-    auto tv = createTypeVariable(constraintLocator,
-                                 TVO_PrefersSubtypeBinding |
-                                 TVO_CanBindToInOut);
+    auto tv = createTypeVariable(constraintLocator, TVO_PrefersSubtypeBinding);
     
     addConstraint(ConstraintKind::ConformsTo, tv,
                   hashableProtocol->getDeclaredType(), constraintLocator);

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1690,8 +1690,7 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
         // left-hand side is bound to type variable which
         // is wrapped in `inout` type to preserve inout/lvalue pairing.
         if (auto *lvt = type2->getAs<LValueType>()) {
-          auto *tv = createTypeVariable(typeVar1->getImpl().getLocator(),
-                                        TVO_CannotBindToInOut);
+          auto *tv = createTypeVariable(typeVar1->getImpl().getLocator());
           assignFixedType(typeVar1, InOutType::get(tv));
 
           typeVar1 = tv;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1364,8 +1364,7 @@ ConstraintSystem::solve(Expr *&expr,
     if (allowFreeTypeVariables == FreeTypeVariableBinding::UnresolvedType) {
       convertType = convertType.transform([&](Type type) -> Type {
         if (type->is<UnresolvedType>())
-          return createTypeVariable(getConstraintLocator(expr),
-                                    TVO_CanBindToInOut);
+          return createTypeVariable(getConstraintLocator(expr));
         return type;
       });
     }

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1079,9 +1079,8 @@ void ConstraintSystem::openGeneric(
       locatorPtr = getConstraintLocator(
           locator.withPathElement(LocatorPathElt(archetype)));
 
-    // XXX -- Only a few tests crash if TVO_CannotBindToInOut is removed.
     auto typeVar = createTypeVariable(locatorPtr,
-                                      TVO_CannotBindToInOut |
+                                      TVO_IsGenericTypeParam |
                                       TVO_PrefersSubtypeBinding);
     auto result = replacements.insert(
       std::make_pair(cast<GenericTypeParamType>(gp->getCanonicalType()),

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1079,6 +1079,7 @@ void ConstraintSystem::openGeneric(
       locatorPtr = getConstraintLocator(
           locator.withPathElement(LocatorPathElt(archetype)));
 
+    // XXX -- Only a few tests crash if TVO_CannotBindToInOut is removed.
     auto typeVar = createTypeVariable(locatorPtr,
                                       TVO_CannotBindToInOut |
                                       TVO_PrefersSubtypeBinding);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -161,8 +161,8 @@ enum TypeVariableOptions {
   /// Whether the type variable can be bound to an lvalue type or not.
   TVO_CanBindToLValue = 0x01,
 
-  /// Whether the type variable can be bound to an inout type or not.
-  TVO_CannotBindToInOut = 0x02,
+  /// Whether the type variable is a generic type parameter or not.
+  TVO_IsGenericTypeParam = 0x02,
 
   /// Whether a more specific deduction for this type variable implies a
   /// better solution to the constraint system.
@@ -225,7 +225,7 @@ public:
 
   /// Whether this type variable can bind to an inout type.
   bool canBindToInOut() const {
-    return !(getRawOptions() & TVO_CannotBindToInOut);
+    return !(getRawOptions() & TVO_IsGenericTypeParam);
   }
 
   /// Whether this type variable prefers a subtype binding over a supertype
@@ -348,7 +348,7 @@ public:
       if (record)
         recordBinding(*record);
       getTypeVariable()->Bits.TypeVariableType.Options &= ~TVO_CanBindToLValue;
-      getTypeVariable()->Bits.TypeVariableType.Options |= TVO_CannotBindToInOut;
+      getTypeVariable()->Bits.TypeVariableType.Options |=TVO_IsGenericTypeParam;
     }
   }
 
@@ -392,7 +392,7 @@ public:
       rep->getImpl().getTypeVariable()->Bits.TypeVariableType.Options
         &= ~TVO_CanBindToLValue;
       rep->getImpl().getTypeVariable()->Bits.TypeVariableType.Options
-        |= TVO_CannotBindToInOut;
+        |= TVO_IsGenericTypeParam;
     }
   }
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -162,7 +162,7 @@ enum TypeVariableOptions {
   TVO_CanBindToLValue = 0x01,
 
   /// Whether the type variable can be bound to an inout type or not.
-  TVO_CanBindToInOut = 0x02,
+  TVO_CannotBindToInOut = 0x02,
 
   /// Whether a more specific deduction for this type variable implies a
   /// better solution to the constraint system.
@@ -224,7 +224,9 @@ public:
   bool canBindToLValue() const { return getRawOptions() & TVO_CanBindToLValue; }
 
   /// Whether this type variable can bind to an inout type.
-  bool canBindToInOut() const { return getRawOptions() & TVO_CanBindToInOut; }
+  bool canBindToInOut() const {
+    return !(getRawOptions() & TVO_CannotBindToInOut);
+  }
 
   /// Whether this type variable prefers a subtype binding over a supertype
   /// binding.
@@ -233,8 +235,7 @@ public:
   }
 
   bool mustBeMaterializable() const {
-    return !(getRawOptions() & TVO_CanBindToInOut) &&
-           !(getRawOptions() & TVO_CanBindToLValue);
+    return !canBindToInOut() && !canBindToLValue();
   }
 
   /// Retrieve the corresponding node in the constraint graph.
@@ -347,7 +348,7 @@ public:
       if (record)
         recordBinding(*record);
       getTypeVariable()->Bits.TypeVariableType.Options &= ~TVO_CanBindToLValue;
-      getTypeVariable()->Bits.TypeVariableType.Options &= ~TVO_CanBindToInOut;
+      getTypeVariable()->Bits.TypeVariableType.Options |= TVO_CannotBindToInOut;
     }
   }
 
@@ -391,7 +392,7 @@ public:
       rep->getImpl().getTypeVariable()->Bits.TypeVariableType.Options
         &= ~TVO_CanBindToLValue;
       rep->getImpl().getTypeVariable()->Bits.TypeVariableType.Options
-        &= ~TVO_CanBindToInOut;
+        |= TVO_CannotBindToInOut;
     }
   }
 
@@ -1566,7 +1567,7 @@ public:
 
   /// \brief Create a new type variable.
   TypeVariableType *createTypeVariable(ConstraintLocator *locator,
-                                       unsigned options);
+                                       unsigned options = 0);
 
   /// Retrieve the set of active type variables.
   ArrayRef<TypeVariableType *> getTypeVariables() const {

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1995,9 +1995,7 @@ bool TypeChecker::typeCheckCompletionSequence(Expr *&expr, DeclContext *DC) {
 
   // Add type variable for the code-completion expression.
   auto tvRHS =
-      CS.createTypeVariable(CS.getConstraintLocator(CCE),
-                            TVO_CanBindToLValue |
-                            TVO_CanBindToInOut);
+      CS.createTypeVariable(CS.getConstraintLocator(CCE), TVO_CanBindToLValue);
   CCE->setType(tvRHS);
 
   if (auto generated = CS.generateConstraints(expr)) {
@@ -2328,8 +2326,7 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
         return true;
       }
 
-      SequenceType =
-        cs.createTypeVariable(Locator, /*options=*/0);
+      SequenceType = cs.createTypeVariable(Locator, TVO_CannotBindToInOut);
       cs.addConstraint(ConstraintKind::Conversion, cs.getType(expr),
                        SequenceType, Locator);
       cs.addConstraint(ConstraintKind::ConformsTo, SequenceType,
@@ -2402,7 +2399,8 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
       }
 
       if (elementType.isNull()) {
-        elementType = cs.createTypeVariable(elementLocator, /*options=*/0);
+        elementType = cs.createTypeVariable(elementLocator,
+                                            TVO_CannotBindToInOut);
       }
 
       // Add a conversion constraint between the element type of the sequence
@@ -2487,7 +2485,7 @@ Type ConstraintSystem::computeAssignDestType(Expr *dest, SourceLoc equalLoc) {
     // Newly allocated type should be explicitly materializable,
     // it's invalid to use non-materializable types as assignment destination.
     auto objectTv = createTypeVariable(getConstraintLocator(dest),
-                                       /*options=*/0);
+                                       TVO_CannotBindToInOut);
     auto refTv = LValueType::get(objectTv);
     addConstraint(ConstraintKind::Bind, typeVar, refTv,
                   getConstraintLocator(dest));
@@ -2711,8 +2709,7 @@ static Type replaceArchetypesWithTypeVariables(ConstraintSystem &cs,
           return Type();
 
         auto locator = cs.getConstraintLocator(nullptr);
-        auto replacement = cs.createTypeVariable(locator,
-                                                 TVO_CanBindToInOut);
+        auto replacement = cs.createTypeVariable(locator);
 
         if (auto superclass = archetypeType->getSuperclass()) {
           cs.addConstraint(ConstraintKind::Subtype, replacement,
@@ -2729,8 +2726,7 @@ static Type replaceArchetypesWithTypeVariables(ConstraintSystem &cs,
       // FIXME: Remove this case
       assert(cast<GenericTypeParamType>(origType));
       auto locator = cs.getConstraintLocator(nullptr);
-      auto replacement = cs.createTypeVariable(locator,
-                                               TVO_CanBindToInOut);
+      auto replacement = cs.createTypeVariable(locator);
       types[origType] = replacement;
       return replacement;
     },

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2326,7 +2326,7 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
         return true;
       }
 
-      SequenceType = cs.createTypeVariable(Locator, TVO_CannotBindToInOut);
+      SequenceType = cs.createTypeVariable(Locator);
       cs.addConstraint(ConstraintKind::Conversion, cs.getType(expr),
                        SequenceType, Locator);
       cs.addConstraint(ConstraintKind::ConformsTo, SequenceType,
@@ -2399,8 +2399,7 @@ bool TypeChecker::typeCheckForEachBinding(DeclContext *dc, ForEachStmt *stmt) {
       }
 
       if (elementType.isNull()) {
-        elementType = cs.createTypeVariable(elementLocator,
-                                            TVO_CannotBindToInOut);
+        elementType = cs.createTypeVariable(elementLocator);
       }
 
       // Add a conversion constraint between the element type of the sequence
@@ -2484,8 +2483,7 @@ Type ConstraintSystem::computeAssignDestType(Expr *dest, SourceLoc equalLoc) {
   if (auto typeVar = dyn_cast<TypeVariableType>(destTy.getPointer())) {
     // Newly allocated type should be explicitly materializable,
     // it's invalid to use non-materializable types as assignment destination.
-    auto objectTv = createTypeVariable(getConstraintLocator(dest),
-                                       TVO_CannotBindToInOut);
+    auto objectTv = createTypeVariable(getConstraintLocator(dest));
     auto refTv = LValueType::get(objectTv);
     addConstraint(ConstraintKind::Bind, typeVar, refTv,
                   getConstraintLocator(dest));

--- a/validation-test/compiler_crashers_fixed/28626-objectty-is-lvaluetype-objectty-is-inouttype-cannot-have-inout-or-lvalue-wrapped.swift
+++ b/validation-test/compiler_crashers_fixed/28626-objectty-is-lvaluetype-objectty-is-inouttype-cannot-have-inout-or-lvalue-wrapped.swift
@@ -6,4 +6,5 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 // RUN: not %target-swift-frontend %s -emit-ir
+// XFAIL: *
 &[_=(&_


### PR DESCRIPTION
As a part of the ongoing "war on InOutType", I've made an attempt at cleaning up the TypeVariable options. After this patch series, `TVO_CanBindToInOut` is gone and the validation test suite still passes on my Linux box. Feedback would be appreciated. Please note that I did need to XFAIL one of the "compiler crasher" tests, but this seemed acceptable.