### PR TITLE
[LoadableByAddress] Fix debug info holes when expanding alloc_stack.

### DIFF
--- a/include/swift/SIL/DebugUtils.h
+++ b/include/swift/SIL/DebugUtils.h
@@ -49,12 +49,6 @@ inline bool isDebugInst(SILInstruction *Inst) {
   return isa<DebugValueInst>(Inst) || isa<DebugValueAddrInst>(Inst);
 }
 
-/// Returns true if the instruction \p Inst is a maintenance instructions which
-/// is relevant for debug information and does not get lowered to an instruction.
-inline bool isMaintenanceInst(SILInstruction *Inst) {
-  return isDebugInst(Inst) || isa<AllocStackInst>(Inst);
-}
-
 /// Deletes all of the debug instructions that use \p Inst.
 inline void deleteAllDebugUses(ValueBase *Inst) {
   for (auto UI = Inst->use_begin(), E = Inst->use_end(); UI != E;) {

--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -344,6 +344,11 @@ public:
   /// Used by llvm::LoopInfo.
   bool isLegalToHoistInto() const;
 
+  /// Returns the debug scope of the first non-meta instructions in the
+  /// basic block. SILBuilderWithScope uses this to correctly set up
+  /// the debug scope for newly created instructions.
+  const SILDebugScope *getScopeOfFirstNonMetaInstruction();
+
   //===--------------------------------------------------------------------===//
   // Debugging
   //===--------------------------------------------------------------------===//

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -2082,6 +2082,15 @@ public:
       : SILBuilder(BB) {
     inheritScopeFrom(InheritScopeFrom);
   }
+
+  /// Creates a new SILBuilder with an insertion point at the
+  /// beginning of BB and the debug scope from the first
+  /// non-metainstruction in the BB.
+  explicit SILBuilderWithScope(SILBasicBlock *BB) : SILBuilder(BB->begin()) {
+    const SILDebugScope *DS = BB->getScopeOfFirstNonMetaInstruction();
+    assert(DS && "Instruction without debug scope associated!");
+    setCurrentDebugScope(DS);
+  }
 };
 
 class SavedInsertionPointRAII {

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -597,6 +597,11 @@ public:
   /// you perform such optimizations like e.g. jump-threading.
   bool isTriviallyDuplicatable() const;
 
+  /// Returns true if the instruction is a meta instruction which is
+  /// relevant for debug information and does not get lowered to a real
+  /// instruction.
+  bool isMetaInstruction() const;
+
   /// Verify that all operands of this instruction have compatible ownership
   /// with this instruction.
   void verifyOperandOwnership() const;

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -946,7 +946,7 @@ void LoadableStorageAllocation::replaceLoadWithCopyAddr(
     LoadInst *optimizableLoad) {
   SILValue value = optimizableLoad->getOperand();
 
-  SILBuilderWithScope allocBuilder(pass.F->begin()->begin());
+  SILBuilderWithScope allocBuilder(&*pass.F->begin());
   AllocStackInst *allocInstr =
       allocBuilder.createAllocStack(value.getLoc(), value->getType());
 
@@ -1069,7 +1069,7 @@ void LoadableStorageAllocation::replaceLoadWithCopyAddrForModifiable(
   }
   SILValue value = unoptimizableLoad->getOperand();
 
-  SILBuilderWithScope allocBuilder(pass.F->begin()->begin());
+  SILBuilderWithScope allocBuilder(&*pass.F->begin());
   AllocStackInst *allocInstr =
       allocBuilder.createAllocStack(value.getLoc(), value->getType());
 
@@ -1411,7 +1411,7 @@ void LoadableStorageAllocation::allocateForArg(SILValue value) {
 
   assert(!ApplySite::isa(value) && "Unexpected instruction");
 
-  SILBuilderWithScope allocBuilder(pass.F->begin()->begin());
+  SILBuilderWithScope allocBuilder(&*pass.F->begin());
   AllocStackInst *allocInstr =
       allocBuilder.createAllocStack(value.getLoc(), value->getType());
 
@@ -1438,7 +1438,7 @@ void LoadableStorageAllocation::allocateForArg(SILValue value) {
 AllocStackInst *
 LoadableStorageAllocation::allocateForApply(SILInstruction *apply,
                                             SILType type) {
-  SILBuilderWithScope allocBuilder(pass.F->begin()->begin());
+  SILBuilderWithScope allocBuilder(&*pass.F->begin());
   auto *allocInstr = allocBuilder.createAllocStack(apply->getLoc(), type);
 
   pass.largeLoadableArgs.push_back(allocInstr);
@@ -1524,7 +1524,7 @@ static void setInstrUsers(StructLoweringState &pass, AllocStackInst *allocInstr,
 static void allocateAndSetForInstrOperand(StructLoweringState &pass,
                                           SingleValueInstruction *instrOperand){
   assert(instrOperand->getType().isObject());
-  SILBuilderWithScope allocBuilder(pass.F->begin()->begin());
+  SILBuilderWithScope allocBuilder(&*pass.F->begin());
   AllocStackInst *allocInstr = allocBuilder.createAllocStack(
       instrOperand->getLoc(), instrOperand->getType());
 
@@ -1558,7 +1558,7 @@ static void allocateAndSetForArgumentOperand(StructLoweringState &pass,
   auto *arg = dyn_cast<SILArgument>(value);
   assert(arg && "non-instr operand must be an argument");
 
-  SILBuilderWithScope allocBuilder(pass.F->begin()->begin());
+  SILBuilderWithScope allocBuilder(&*pass.F->begin());
   AllocStackInst *allocInstr =
       allocBuilder.createAllocStack(applyInst->getLoc(), value->getType());
 
@@ -1677,7 +1677,8 @@ static SILValue createCopyOfEnum(StructLoweringState &pass,
   auto value = orig->getOperand();
   auto type = value->getType();
   if (type.isObject()) {
-    SILBuilderWithScope allocBuilder(pass.F->begin()->begin());
+    SILBuilderWithScope allocBuilder(&*pass.F->begin());
+
     // support for non-address operands / enums
     auto *allocInstr = allocBuilder.createAllocStack(orig->getLoc(), type);
     SILBuilderWithScope storeBuilder(orig);
@@ -1696,7 +1697,7 @@ static SILValue createCopyOfEnum(StructLoweringState &pass,
     }
     value = allocInstr;
   }
-  SILBuilderWithScope allocBuilder(pass.F->begin()->begin());
+  SILBuilderWithScope allocBuilder(&*pass.F->begin());
   auto *allocInstr = allocBuilder.createAllocStack(value.getLoc(), type);
 
   SILBuilderWithScope copyBuilder(orig);

--- a/lib/SIL/SILBasicBlock.cpp
+++ b/lib/SIL/SILBasicBlock.cpp
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/ADT/STLExtras.h"
+#include "swift/SIL/DebugUtils.h"
 #include "swift/SIL/SILBasicBlock.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILArgument.h"
@@ -379,4 +380,11 @@ bool SILBasicBlock::isTrampoline() const {
 
 bool SILBasicBlock::isLegalToHoistInto() const {
   return true;
+}
+
+const SILDebugScope *SILBasicBlock::getScopeOfFirstNonMetaInstruction() {
+  for (auto &Inst : *this)
+    if (Inst.isMetaInstruction())
+      return Inst.getDebugScope();
+  return begin()->getDebugScope();
 }

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -1188,6 +1188,20 @@ bool SILInstruction::mayTrap() const {
   }
 }
 
+bool SILInstruction::isMetaInstruction() const {
+  // Every instruction that implements getVarInfo() should be in this list.
+  switch (getKind()) {
+  case SILInstructionKind::AllocBoxInst:
+  case SILInstructionKind::AllocStackInst:
+  case SILInstructionKind::DebugValueInst:
+  case SILInstructionKind::DebugValueAddrInst:
+    return true;
+  default:
+    return false;
+  }
+  llvm_unreachable("Instruction not handled in isMetaInstruction()!");
+}
+
 //===----------------------------------------------------------------------===//
 //                                 Utilities
 //===----------------------------------------------------------------------===//

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -4545,14 +4545,14 @@ public:
 
     const SILDebugScope *LastSeenScope = nullptr;
     for (SILInstruction &SI : *BB) {
-      if (isMaintenanceInst(&SI))
+      if (SI.isMetaInstruction())
         continue;
       LastSeenScope = SI.getDebugScope();
       AlreadySeenScopes.insert(LastSeenScope);
       break;
     }
     for (SILInstruction &SI : *BB) {
-      if (isMaintenanceInst(&SI))
+      if (SI.isMetaInstruction())
         continue;
 
       // If we haven't seen this debug scope yet, update the

--- a/test/DebugInfo/LoadableByAddress-allockstack.swift
+++ b/test/DebugInfo/LoadableByAddress-allockstack.swift
@@ -1,0 +1,49 @@
+// Check we don't crash when verifying debug info.
+// Ideally this should print the output after loadable by address runs
+// but there's no way of doing this in SIL (for IRGen passes).
+// RUN: %target-swift-frontend -emit-sil %s -Onone \
+// RUN:   -sil-verify-all -Xllvm -verify-di-holes -emit-ir \
+// RUN:   -Xllvm -sil-print-debuginfo -g -o - | %FileCheck %s
+
+struct m {
+  let major: Int
+  let minor: Int
+  let n: Int
+  let o: [String]
+  let p: [String]
+  init(major: Int, minor: Int, n: Int, o: [String], p: [String]) {
+    self.major = major
+    self.minor = minor
+    self.n = n
+    self.o = o
+    self.p = p
+  }
+}
+
+enum a {
+  case any
+  case b(m)
+}
+
+struct c<e>  {
+  enum f {
+    case g(a)
+  }
+}
+
+struct h<i>{
+  typealias j = i
+  typealias d = j
+  typealias f = c<d>.f
+  subscript(identifier: d) -> f {
+      return .g(.any)
+  }
+  func k(l: f, identifier: d) -> h {
+    switch (l, self[identifier]) {
+    default:
+        return self
+    }
+  }
+}
+
+// CHECK: define linkonce_odr hidden %swift.opaque* @"$S4main1mVwCP"


### PR DESCRIPTION
We should also skip debug info as they don't really are lowered
to anything real. Add an helper so that we can use it in passes
as well.

@adrian-prantl I'm dealing with a bot failure, but I wanted to put this online so you can take a look and let me know if this is fine. I'm going to add a test & run the tests.

This is the last failure we have before enabling the verifier for debug info, so my plan is to flip the switch today (crossing fingers).