### PR TITLE
[4.2] Pull in fixes for several crashes

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -193,22 +193,33 @@ struct OverloadSignature {
   DeclName Name;
 
   /// The kind of unary operator.
-  UnaryOperatorKind UnaryOperator = UnaryOperatorKind::None;
+  UnaryOperatorKind UnaryOperator;
 
   /// Whether this is an instance member.
-  bool IsInstanceMember = false;
+  unsigned IsInstanceMember : 1;
 
-  /// Whether this is a property.
-  bool IsProperty = false;
+  /// Whether this is a variable.
+  unsigned IsVariable : 1;
+
+  /// Whether this is a function.
+  unsigned IsFunction : 1;
 
   /// Whether this signature is part of a protocol extension.
-  bool InProtocolExtension = false;
+  unsigned InProtocolExtension : 1;
+
+  OverloadSignature()
+      : UnaryOperator(UnaryOperatorKind::None), IsInstanceMember(false),
+        IsVariable(false), IsFunction(false), InProtocolExtension(false) {}
 };
 
 /// Determine whether two overload signatures conflict.
 bool conflicting(const OverloadSignature& sig1, const OverloadSignature& sig2,
                  bool skipProtocolExtensionCheck = false);
 
+/// Determine whether two overload signatures and overload types conflict.
+bool conflicting(const OverloadSignature& sig1, CanType sig1Type,
+                 const OverloadSignature& sig2, CanType sig2Type,
+                 bool skipProtocolExtensionCheck = false);
 
 /// Decl - Base class for all declarations in Swift.
 class alignas(1 << DeclAlignInBits) Decl {

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -207,9 +207,14 @@ struct OverloadSignature {
   /// Whether this signature is part of a protocol extension.
   unsigned InProtocolExtension : 1;
 
+  /// Whether this signature is of a member defined in an extension of a generic
+  /// type.
+  unsigned InExtensionOfGenericType : 1;
+
   OverloadSignature()
       : UnaryOperator(UnaryOperatorKind::None), IsInstanceMember(false),
-        IsVariable(false), IsFunction(false), InProtocolExtension(false) {}
+        IsVariable(false), IsFunction(false), InProtocolExtension(false),
+        InExtensionOfGenericType(false) {}
 };
 
 /// Determine whether two overload signatures conflict.
@@ -217,7 +222,8 @@ bool conflicting(const OverloadSignature& sig1, const OverloadSignature& sig2,
                  bool skipProtocolExtensionCheck = false);
 
 /// Determine whether two overload signatures and overload types conflict.
-bool conflicting(const OverloadSignature& sig1, CanType sig1Type,
+bool conflicting(ASTContext &ctx,
+                 const OverloadSignature& sig1, CanType sig1Type,
                  const OverloadSignature& sig2, CanType sig2Type,
                  bool skipProtocolExtensionCheck = false);
 

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -218,13 +218,30 @@ struct OverloadSignature {
 };
 
 /// Determine whether two overload signatures conflict.
+///
+/// \param sig1 The overload signature of the first declaration.
+/// \param sig2 The overload signature of the second declaration.
+/// \param skipProtocolExtensionCheck If \c true, members of protocol extensions
+///        will be allowed to conflict with members of protocol declarations.
 bool conflicting(const OverloadSignature& sig1, const OverloadSignature& sig2,
                  bool skipProtocolExtensionCheck = false);
 
 /// Determine whether two overload signatures and overload types conflict.
+///
+/// \param ctx The AST context.
+/// \param sig1 The overload signature of the first declaration.
+/// \param sig1Type The overload type of the first declaration.
+/// \param sig2 The overload signature of the second declaration.
+/// \param sig2Type The overload type of the second declaration.
+/// \param wouldConflictInSwift5 If non-null, the referenced boolean will be set
+///        to \c true iff the function returns \c false for this version of
+///        Swift, but the given overloads will conflict in Swift 5 mode.
+/// \param skipProtocolExtensionCheck If \c true, members of protocol extensions
+///        will be allowed to conflict with members of protocol declarations.
 bool conflicting(ASTContext &ctx,
                  const OverloadSignature& sig1, CanType sig1Type,
                  const OverloadSignature& sig2, CanType sig2Type,
+                 bool *wouldConflictInSwift5 = nullptr,
                  bool skipProtocolExtensionCheck = false);
 
 /// Decl - Base class for all declarations in Swift.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -610,6 +610,10 @@ ERROR(reserved_member_name,none,
       " 'foo.%1' expression", (DeclName, StringRef))
 
 ERROR(invalid_redecl,none,"invalid redeclaration of %0", (DeclName))
+WARNING(invalid_redecl_swift5_warning,none,
+        "redeclaration of %0 is deprecated and will be illegal in Swift 5",
+        (DeclName))
+
 NOTE(invalid_redecl_prev,none,
      "%0 previously declared here", (DeclName))
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -566,7 +566,7 @@ public:
   /// Given a declaration context, returns a function type with the 'self'
   /// type curried as the input if the declaration context describes a type.
   /// Otherwise, returns the type itself.
-  Type addCurriedSelfType(DeclContext *dc);
+  Type addCurriedSelfType(const DeclContext *dc);
 
   /// Map a contextual type to an interface type.
   Type mapTypeOutOfContext();

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -563,6 +563,11 @@ public:
   /// underlying type.
   Type eraseDynamicSelfType();
 
+  /// Given a declaration context, returns a function type with the 'self'
+  /// type curried as the input if the declaration context describes a type.
+  /// Otherwise, returns the type itself.
+  Type addCurriedSelfType(DeclContext *dc);
+
   /// Map a contextual type to an interface type.
   Type mapTypeOutOfContext();
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2945,8 +2945,7 @@ NameAliasType *NameAliasType::get(
 
   // Profile the type.
   llvm::FoldingSetNodeID id;
-  NameAliasType::Profile(id, typealias, parent, substitutions,
-                              underlying);
+  NameAliasType::Profile(id, typealias, parent, substitutions, underlying);
 
   // Did we already record this type?
   void *insertPos;
@@ -2957,13 +2956,12 @@ NameAliasType *NameAliasType::get(
   // Build a new type.
   unsigned numSubstitutions =
     genericSig ? genericSig->getSubstitutionListSize() : 0;
-  assert(static_cast<bool>(genericSig) == numSubstitutions > 0);
   auto size =
     totalSizeToAlloc<Type, GenericSignature *, Substitution>(
                         parent ? 1 : 0, genericSig ? 1 : 0, numSubstitutions);
   auto mem = ctx.Allocate(size, alignof(NameAliasType), arena);
   auto result = new (mem) NameAliasType(typealias, parent, substitutions,
-                                             underlying, storedProperties);
+                                        underlying, storedProperties);
   types.InsertNode(result, insertPos);
   return result;
 }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1709,6 +1709,7 @@ bool swift::conflicting(const OverloadSignature& sig1,
 bool swift::conflicting(ASTContext &ctx,
                         const OverloadSignature& sig1, CanType sig1Type,
                         const OverloadSignature& sig2, CanType sig2Type,
+                        bool *wouldConflictInSwift5,
                         bool skipProtocolExtensionCheck) {
   // If the signatures don't conflict to begin with, we're done.
   if (!conflicting(sig1, sig2, skipProtocolExtensionCheck))
@@ -1726,10 +1727,15 @@ bool swift::conflicting(ASTContext &ctx,
     // Prior to Swift 5, we permitted redeclarations of variables as different
     // declarations if the variable was declared in an extension of a generic
     // type. Make sure we maintain this behaviour in versions < 5.
-    if (!ctx.LangOpts.EffectiveLanguageVersion.isVersionAtLeast(5))
+    if (!ctx.isSwiftVersionAtLeast(5)) {
       if ((sig1.IsVariable && sig1.InExtensionOfGenericType) ||
-          (sig2.IsVariable && sig2.InExtensionOfGenericType))
+          (sig2.IsVariable && sig2.InExtensionOfGenericType)) {
+        if (wouldConflictInSwift5)
+          *wouldConflictInSwift5 = true;
+
         return false;
+      }
+    }
 
     return true;
   }

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1699,11 +1699,33 @@ bool swift::conflicting(const OverloadSignature& sig1,
   // If one is a compound name and the other is not, they do not conflict
   // if one is a property and the other is a non-nullary function.
   if (sig1.Name.isCompoundName() != sig2.Name.isCompoundName()) {
-    return !((sig1.IsProperty && !sig2.Name.getArgumentNames().empty()) ||
-             (sig2.IsProperty && !sig1.Name.getArgumentNames().empty()));
+    return !((sig1.IsVariable && !sig2.Name.getArgumentNames().empty()) ||
+             (sig2.IsVariable && !sig1.Name.getArgumentNames().empty()));
   }
   
   return sig1.Name == sig2.Name;
+}
+
+bool swift::conflicting(const OverloadSignature& sig1, CanType sig1Type,
+                        const OverloadSignature& sig2, CanType sig2Type,
+                        bool skipProtocolExtensionCheck) {
+  // If the signatures don't conflict to begin with, we're done.
+  if (!conflicting(sig1, sig2, skipProtocolExtensionCheck))
+    return false;
+
+  // Variables always conflict with non-variables with the same signature.
+  // (e.g variables with zero argument functions, variables with type
+  //  declarations)
+  if (sig1.IsVariable != sig2.IsVariable)
+    return true;
+
+  // Functions always conflict with non-functions with the same signature.
+  // In practice, this only applies for zero argument functions.
+  if (sig1.IsFunction != sig2.IsFunction)
+    return true;
+
+  // Otherwise, the declarations conflict if the overload types are the same.
+  return sig1Type == sig2Type;
 }
 
 static Type mapSignatureFunctionType(ASTContext &ctx, Type type,
@@ -1815,9 +1837,10 @@ OverloadSignature ValueDecl::getOverloadSignature() const {
 
   signature.Name = getFullName();
   signature.InProtocolExtension
-    = getDeclContext()->getAsProtocolExtensionContext();
+    = static_cast<bool>(getDeclContext()->getAsProtocolExtensionContext());
   signature.IsInstanceMember = isInstanceMember();
-  signature.IsProperty = isa<VarDecl>(this);
+  signature.IsVariable = isa<VarDecl>(this);
+  signature.IsFunction = isa<AbstractFunctionDecl>(this);
 
   if (auto func = dyn_cast<FuncDecl>(this)) {
     if (func->isUnaryOperator()) {
@@ -1838,44 +1861,53 @@ CanType ValueDecl::getOverloadSignatureType() const {
                            afd->getNumParameterLists())->getCanonicalType();
   }
 
-  if (isa<SubscriptDecl>(this)) {
-    CanType interfaceType = getInterfaceType()->getCanonicalType();
+  if (auto *asd = dyn_cast<AbstractStorageDecl>(this)) {
+    auto dc = getDeclContext();
 
-    // If the subscript declaration occurs within a generic extension context,
-    // consider the generic signature of the extension.
-    auto ext = dyn_cast<ExtensionDecl>(getDeclContext());
-    if (!ext) return interfaceType;
-
-    auto genericSig = ext->getGenericSignature();
-    if (!genericSig) return interfaceType;
-
-    if (auto funcTy = interfaceType->getAs<AnyFunctionType>()) {
-      return GenericFunctionType::get(genericSig,
-                                      funcTy->getParams(),
-                                      funcTy->getResult(),
-                                      funcTy->getExtInfo())
-              ->getCanonicalType();
+    // First, get the default overload signature type for the decl. For vars,
+    // this is the empty tuple type, as variables cannot be overloaded directly
+    // by type. For subscripts, it's their interface type.
+    CanType defaultSignatureType;
+    if (isa<VarDecl>(this)) {
+      defaultSignatureType = TupleType::getEmpty(getASTContext());
+    } else {
+      defaultSignatureType = getInterfaceType()->getCanonicalType();
     }
 
-    return interfaceType;
+    // If we're not in a type context, we're done.
+    // Otherwise, we want to curry the default signature type with the 'self'
+    // type of the given context in order to ensure the overload signature type
+    // is unique across different contexts, such as between a protocol extension
+    // and struct decl.
+    if (!dc->isTypeContext())
+      return defaultSignatureType;
+
+    // Treat the declared interface type of the context as the 'self' type to
+    // curry the signature with. Additionally, if the storage decl is static,
+    // work with a metatype.
+    auto selfTy = dc->getDeclaredInterfaceType();
+    if (asd->isStatic())
+      selfTy = MetatypeType::get(selfTy);
+
+    auto parentDecl = dc->getAsDeclOrDeclExtensionContext();
+    auto genericCtx = parentDecl->getAsGenericContext();
+
+    // If we're in a context with a generic signature, return a generic function
+    // type with that signature. Otherwise, return a non-generic type.
+    if (auto genericSig = genericCtx->getGenericSignature()) {
+      return GenericFunctionType::get(genericSig, selfTy, defaultSignatureType,
+                                      AnyFunctionType::ExtInfo())
+               ->getCanonicalType();
+    } else {
+      return FunctionType::get(selfTy, defaultSignatureType)
+               ->getCanonicalType();
+    }
   }
 
-  if (isa<VarDecl>(this)) {
-    // If the variable declaration occurs within a generic extension context,
-    // consider the generic signature of the extension.
-    auto ext = dyn_cast<ExtensionDecl>(getDeclContext());
-    if (!ext) return CanType();
-
-    auto genericSig = ext->getGenericSignature();
-    if (!genericSig) return CanType();
-
-    ASTContext &ctx = getASTContext();
-    return GenericFunctionType::get(genericSig,
-                                    TupleType::getEmpty(ctx),
-                                    TupleType::getEmpty(ctx),
-                                    AnyFunctionType::ExtInfo())
-             ->getCanonicalType();
-  }
+  // Note: If you add more cases to this function, you should update the
+  // implementation of the swift::conflicting overload that deals with
+  // overload types, in order to account for cases where the overload types
+  // don't match, but the decls differ and therefore always conflict.
 
   return CanType();
 }

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -805,7 +805,8 @@ public:
           OtherSignatureType = CT->getCanonicalType();
       }
 
-      if (conflicting(FoundSignature, FoundSignatureType,
+      if (conflicting(VD->getDeclContext()->getASTContext(),
+                      FoundSignature, FoundSignatureType,
                       OtherSignature, OtherSignatureType,
                       /*skipProtocolExtensionCheck*/true)) {
         if (VD->getFormalAccess() > OtherVD->getFormalAccess()) {

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -805,10 +805,9 @@ public:
           OtherSignatureType = CT->getCanonicalType();
       }
 
-      if (conflicting(FoundSignature, OtherSignature, true) &&
-          (FoundSignatureType == OtherSignatureType ||
-           FoundSignature.Name.isCompoundName() !=
-             OtherSignature.Name.isCompoundName())) {
+      if (conflicting(FoundSignature, FoundSignatureType,
+                      OtherSignature, OtherSignatureType,
+                      /*skipProtocolExtensionCheck*/true)) {
         if (VD->getFormalAccess() > OtherVD->getFormalAccess()) {
           PossiblyConflicting.erase(I);
           PossiblyConflicting.insert(VD);

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -805,9 +805,9 @@ public:
           OtherSignatureType = CT->getCanonicalType();
       }
 
-      if (conflicting(VD->getDeclContext()->getASTContext(),
-                      FoundSignature, FoundSignatureType,
+      if (conflicting(M->getASTContext(), FoundSignature, FoundSignatureType,
                       OtherSignature, OtherSignatureType,
+                      /*wouldConflictInSwift5*/nullptr,
                       /*skipProtocolExtensionCheck*/true)) {
         if (VD->getFormalAccess() > OtherVD->getFormalAccess()) {
           PossiblyConflicting.erase(I);

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -402,6 +402,27 @@ Type TypeBase::eraseDynamicSelfType() {
   });
 }
 
+Type TypeBase::addCurriedSelfType(DeclContext *dc) {
+  if (!dc->isTypeContext())
+    return this;
+
+  auto *type = this;
+
+  GenericSignature *sig = dc->getGenericSignatureOfContext();
+  if (auto *genericFn = type->getAs<GenericFunctionType>()) {
+    sig = genericFn->getGenericSignature();
+    type = FunctionType::get(genericFn->getInput(),
+                             genericFn->getResult(),
+                             genericFn->getExtInfo());
+  }
+
+  auto selfTy = dc->getDeclaredInterfaceType();
+  if (sig)
+    return GenericFunctionType::get(sig, selfTy, type,
+                                    AnyFunctionType::ExtInfo());
+  return FunctionType::get(selfTy, type);
+}
+
 void
 TypeBase::getTypeVariables(SmallVectorImpl<TypeVariableType *> &typeVariables) {
   // If we know we don't have any type variables, we're done.

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -402,7 +402,7 @@ Type TypeBase::eraseDynamicSelfType() {
   });
 }
 
-Type TypeBase::addCurriedSelfType(DeclContext *dc) {
+Type TypeBase::addCurriedSelfType(const DeclContext *dc) {
   if (!dc->isTypeContext())
     return this;
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1074,6 +1074,12 @@ static void checkRedeclaration(TypeChecker &tc, ValueDecl *current) {
         tc.diagnose(other, diag::invalid_redecl_prev, other->getFullName());
         markInvalid();
       }
+
+      // Make sure we don't do this checking again for the same decl. We also
+      // set this at the beginning of the function, but we might have swapped
+      // the decls for diagnostics; so ensure we also set this for the actual
+      // decl we diagnosed on.
+      current->setCheckedRedeclaration(true);
       break;
     }
   }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -959,9 +959,12 @@ static void checkRedeclaration(TypeChecker &tc, ValueDecl *current) {
     // Get the overload signature type.
     CanType otherSigType = other->getOverloadSignatureType();
 
+    bool wouldBeSwift5Redeclaration = false;
+    auto isRedeclaration = conflicting(tc.Context, currentSig, currentSigType,
+                                       otherSig, otherSigType,
+                                       &wouldBeSwift5Redeclaration);
     // If there is another conflict, complain.
-    if (conflicting(tc.Context, currentSig, currentSigType,
-                    otherSig, otherSigType)) {
+    if (isRedeclaration || wouldBeSwift5Redeclaration) {
       // If the two declarations occur in the same source file, make sure
       // we get the diagnostic ordering to be sensible.
       if (auto otherFile = other->getDeclContext()->getParentSourceFile()) {
@@ -1060,9 +1063,17 @@ static void checkRedeclaration(TypeChecker &tc, ValueDecl *current) {
           continue;
       }
 
-      tc.diagnose(current, diag::invalid_redecl, current->getFullName());
-      tc.diagnose(other, diag::invalid_redecl_prev, other->getFullName());
-      markInvalid();
+      // If this isn't a redeclaration in the current version of Swift, but
+      // would be in Swift 5 mode, emit a warning instead of an error.
+      if (wouldBeSwift5Redeclaration) {
+        tc.diagnose(current, diag::invalid_redecl_swift5_warning,
+                    current->getFullName());
+        tc.diagnose(other, diag::invalid_redecl_prev, other->getFullName());
+      } else {
+        tc.diagnose(current, diag::invalid_redecl, current->getFullName());
+        tc.diagnose(other, diag::invalid_redecl_prev, other->getFullName());
+        markInvalid();
+      }
       break;
     }
   }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -960,8 +960,7 @@ static void checkRedeclaration(TypeChecker &tc, ValueDecl *current) {
     CanType otherSigType = other->getOverloadSignatureType();
 
     // If there is another conflict, complain.
-    if (currentSigType == otherSigType ||
-        currentSig.Name.isCompoundName() != otherSig.Name.isCompoundName()) {
+    if (conflicting(currentSig, currentSigType, otherSig, otherSigType)) {
       // If the two declarations occur in the same source file, make sure
       // we get the diagnostic ordering to be sensible.
       if (auto otherFile = other->getDeclContext()->getParentSourceFile()) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -960,7 +960,8 @@ static void checkRedeclaration(TypeChecker &tc, ValueDecl *current) {
     CanType otherSigType = other->getOverloadSignatureType();
 
     // If there is another conflict, complain.
-    if (conflicting(currentSig, currentSigType, otherSig, otherSigType)) {
+    if (conflicting(tc.Context, currentSig, currentSigType,
+                    otherSig, otherSigType)) {
       // If the two declarations occur in the same source file, make sure
       // we get the diagnostic ordering to be sensible.
       if (auto otherFile = other->getDeclContext()->getParentSourceFile()) {

--- a/test/IDE/Inputs/multiple-files-1.swift
+++ b/test/IDE/Inputs/multiple-files-1.swift
@@ -1,4 +1,5 @@
 var fooObject: FooStruct = FooStruct()
+var genericFooObject: GenericFooStruct = GenericFooStruct<Void>()
 
 private func privateFunc_ERROR() {}
 

--- a/test/IDE/Inputs/multiple-files-2.swift
+++ b/test/IDE/Inputs/multiple-files-2.swift
@@ -1,8 +1,15 @@
 protocol FooProt {
-    var instanceVar: Int { get }
+  var instanceVar: Int { get }
 }
 
 struct FooStruct : FooProt {
+  var instanceVar: Int = 17
+  func instanceFunc0() {}
+
+  private func privateFunc_ERROR() {}
+}
+
+struct GenericFooStruct<T> : FooProt {
   var instanceVar: Int = 17
   func instanceFunc0() {}
 

--- a/test/IDE/complete_multiple_files.swift
+++ b/test/IDE/complete_multiple_files.swift
@@ -1,6 +1,9 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=T1 \
 // RUN:     %S/Inputs/multiple-files-1.swift %S/Inputs/multiple-files-2.swift | %FileCheck %s -check-prefix=T1
 //
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=T2 \
+// RUN:     %S/Inputs/multiple-files-1.swift %S/Inputs/multiple-files-2.swift | %FileCheck %s -check-prefix=T2
+//
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TOP_LEVEL_1 \
 // RUN:     %S/Inputs/multiple-files-1.swift %S/Inputs/multiple-files-2.swift | %FileCheck %s -check-prefix=TOP_LEVEL_1
 //
@@ -10,9 +13,23 @@ func testObjectExpr() {
   fooObject.#^T1^#
 }
 // T1: Begin completions
-// T1-NEXT: Decl[InstanceVar]/CurrNominal:    instanceVar[#Int#]{{; name=.+$}}
+// T1-NEXT: Decl[InstanceVar]/CurrNominal: instanceVar[#Int#]; name=instanceVar
 // T1-NEXT: Decl[InstanceMethod]/CurrNominal: instanceFunc0()[#Void#]{{; name=.+$}}
+//
+// FIX-ME(SR-7225): We shouldn't duplicate this.
+// T1-NEXT: Decl[InstanceVar]/Super: instanceVar[#Int#]; name=instanceVar
 // T1-NEXT: End completions
+
+func testGenericObjectExpr() {
+  genericFooObject.#^T2^#
+}
+// T2: Begin completions
+// T2-NEXT: Decl[InstanceVar]/CurrNominal:    instanceVar[#Int#]{{; name=.+$}}
+// T2-NEXT: Decl[InstanceMethod]/CurrNominal: instanceFunc0()[#Void#]{{; name=.+$}}
+//
+// FIX-ME(SR-7225): We shouldn't duplicate this.
+// T2-NEXT: Decl[InstanceVar]/Super: instanceVar[#Int#]; name=instanceVar
+// T2-NEXT: End completions
 
 func topLevel1() {
   #^TOP_LEVEL_1^#

--- a/test/IDE/complete_multiple_files.swift
+++ b/test/IDE/complete_multiple_files.swift
@@ -13,11 +13,11 @@ func testObjectExpr() {
   fooObject.#^T1^#
 }
 // T1: Begin completions
-// T1-NEXT: Decl[InstanceVar]/CurrNominal: instanceVar[#Int#]; name=instanceVar
+// T1-NEXT: Decl[InstanceVar]/CurrNominal:    instanceVar[#Int#]{{; name=.+$}}
 // T1-NEXT: Decl[InstanceMethod]/CurrNominal: instanceFunc0()[#Void#]{{; name=.+$}}
 //
 // FIX-ME(SR-7225): We shouldn't duplicate this.
-// T1-NEXT: Decl[InstanceVar]/Super: instanceVar[#Int#]; name=instanceVar
+// T1-NEXT: Decl[InstanceVar]/Super: instanceVar[#Int#]{{; name=.+$}}
 // T1-NEXT: End completions
 
 func testGenericObjectExpr() {
@@ -28,7 +28,7 @@ func testGenericObjectExpr() {
 // T2-NEXT: Decl[InstanceMethod]/CurrNominal: instanceFunc0()[#Void#]{{; name=.+$}}
 //
 // FIX-ME(SR-7225): We shouldn't duplicate this.
-// T2-NEXT: Decl[InstanceVar]/Super: instanceVar[#Int#]; name=instanceVar
+// T2-NEXT: Decl[InstanceVar]/Super: instanceVar[#Int#]{{; name=.+$}}
 // T2-NEXT: End completions
 
 func topLevel1() {

--- a/test/IDE/complete_value_expr.swift
+++ b/test/IDE/complete_value_expr.swift
@@ -1656,17 +1656,15 @@ func testDeDuped(_ x: dedupS) {
 }
 func testDeDuped2(_ x: dedupP) {
   x#^PROTOCOL_EXT_DEDUP_2^#
-// FIXME: Should produce 3 items (?)
-// PROTOCOL_EXT_DEDUP_2: Begin completions, 4 items
+// PROTOCOL_EXT_DEDUP_2: Begin completions, 3 items
 // PROTOCOL_EXT_DEDUP_2: Decl[InstanceMethod]/CurrNominal:   .foo()[#dedupP.T#]; name=foo()
 // PROTOCOL_EXT_DEDUP_2: Decl[InstanceVar]/CurrNominal:      .bar[#dedupP.T#]; name=bar
 // PROTOCOL_EXT_DEDUP_2: Decl[Subscript]/CurrNominal:        [{#Self.T#}][#Self.T#]; name=[Self.T]
 // PROTOCOL_EXT_DEDUP_2: End completions
 }
 func testDeDuped3<T : dedupP where T.T == Int>(_ x: T) {
-// FIXME: Should produce 3 items (?)
   x#^PROTOCOL_EXT_DEDUP_3^#
-// PROTOCOL_EXT_DEDUP_3: Begin completions, 4 items
+// PROTOCOL_EXT_DEDUP_3: Begin completions, 3 items
 // PROTOCOL_EXT_DEDUP_3: Decl[InstanceMethod]/Super:   .foo()[#Int#]; name=foo()
 // PROTOCOL_EXT_DEDUP_3: Decl[InstanceVar]/Super:      .bar[#Int#]; name=bar
 // PROTOCOL_EXT_DEDUP_3: Decl[Subscript]/Super:        [{#Self.T#}][#Self.T#]; name=[Self.T]

--- a/test/decl/overload_swift4.swift
+++ b/test/decl/overload_swift4.swift
@@ -1,13 +1,19 @@
 // RUN: %target-typecheck-verify-swift -swift-version 4
 
 struct SR7251<T> {
-  struct j {}
+  struct j {} // expected-note {{previously declared here}}
   static var k: Int { return 0 } // expected-note {{previously declared here}}
 }
 extension SR7251 {
   static var i: Int { return 0 }
-  struct i {}
-  static var j: Int { return 0 }
+  // expected-note@-1 {{previously declared here}}
+  // expected-note@-2 {{previously declared here}}
+
+  struct i {} // expected-warning {{redeclaration of 'i' is deprecated and will be illegal in Swift 5}}
+  typealias i = Int // expected-warning {{redeclaration of 'i' is deprecated and will be illegal in Swift 5}}
+
+  static var j: Int { return 0 } // expected-warning {{redeclaration of 'j' is deprecated and will be illegal in Swift 5}}
+
   struct k {} // expected-error{{invalid redeclaration of 'k'}}
 }
 

--- a/test/decl/overload_swift4.swift
+++ b/test/decl/overload_swift4.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+struct SR7251<T> {
+  struct j {}
+  static var k: Int { return 0 } // expected-note {{previously declared here}}
+}
+extension SR7251 {
+  static var i: Int { return 0 }
+  struct i {}
+  static var j: Int { return 0 }
+  struct k {} // expected-error{{invalid redeclaration of 'k'}}
+}
+

--- a/test/decl/overload_swift5.swift
+++ b/test/decl/overload_swift5.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+
+struct SR7251<T> {
+  struct j {} // expected-note {{previously declared here}}
+  static var k: Int { return 0 } // expected-note {{previously declared here}}
+}
+extension SR7251 {
+  static var i: Int { return 0 } // expected-note {{previously declared here}}
+  struct i {} // expected-error{{invalid redeclaration of 'i'}}
+  static var j: Int { return 0 } // expected-error{{invalid redeclaration of 'j'}}
+  struct k {} // expected-error{{invalid redeclaration of 'k'}}
+}
+

--- a/validation-test/compiler_crashers_2_fixed/0149-sr-7282.swift
+++ b/validation-test/compiler_crashers_2_fixed/0149-sr-7282.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -primary-file %s -emit-ir -o -
+
+// SR-7282
+struct S<T> {}
+
+extension S where T == Int {
+    typealias Callback = (Bool) -> Void
+
+    func process(callback: Callback) {   
+    }
+}


### PR DESCRIPTION
Pull in fixes for redeclaration crashes ([SR-7249](https://bugs.swift.org/browse/SR-7249), [SR-7250](https://bugs.swift.org/browse/SR-7250) & [SR-7251](https://bugs.swift.org/browse/SR-7251), provided by @hamishknight) as well as eliminating a bogus assertion with the new `NameAliasType` ([SR-7282](https://bugs.swift.org/browse/SR-7282))