### PR TITLE
[stdlib] Add conditional Hashable conformance to optional

### DIFF
--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -409,6 +409,30 @@ extension Optional : Equatable where Wrapped : Equatable {
   }
 }
 
+extension Optional: Hashable where Wrapped: Hashable {
+  /// The hash value for the optional instance.
+  ///
+  /// Two optionals that are equal will always have equal hash values.
+  ///
+  /// Hash values are not guaranteed to be equal across different executions of
+  /// your program. Do not save hash values to use during a future execution.
+  @_inlineable // FIXME(sil-serialize-all)
+  public var hashValue: Int {
+    return _hashValue(for: self)
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public func _hash(into hasher: inout _Hasher) {
+    switch self {
+    case .none:
+      hasher.append(0 as UInt8)
+    case .some(let wrapped):
+      hasher.append(1 as UInt8)
+      hasher.append(wrapped)
+    }
+  }
+}
+
 // Enable pattern matching against the nil literal, even if the element type
 // isn't equatable.
 @_fixed_layout

--- a/test/stdlib/Optional.swift
+++ b/test/stdlib/Optional.swift
@@ -69,6 +69,19 @@ OptionalTests.test("Equatable") {
   expectEqual([false, true, true, true, true, false], testRelation(!=))
 }
 
+OptionalTests.test("Hashable") {
+    let o1: Optional<Int> = .some(1010)
+    let o2: Optional<Int> = .some(2020)
+    let o3: Optional<Int> = .none
+    checkHashable([o1, o2, o3], equalityOracle: { $0 == $1 })
+
+    let oo1: Optional<Optional<Int>> = .some(.some(1010))
+    let oo2: Optional<Optional<Int>> = .some(.some(2010))
+    let oo3: Optional<Optional<Int>> = .some(.none)
+    let oo4: Optional<Optional<Int>> = .none
+    checkHashable([oo1, oo2, oo3, oo4], equalityOracle: { $0 == $1 })
+}
+
 OptionalTests.test("CustomReflectable") {
   // Test with a non-refcountable type.
   do {


### PR DESCRIPTION
This is a spin-off of PR #15382, which is currently stuck in review limbo.

Implements part of SE-0143’s Hashable amendments.

rdar://problem/38432751