### PR TITLE
[SIL] Enable verification of debug info scopes at -Onone.

### DIFF
--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -60,7 +60,7 @@ static llvm::cl::opt<bool> AbortOnFailure(
 
 static llvm::cl::opt<bool> VerifyDIHoles(
                               "verify-di-holes",
-                              llvm::cl::init(false));
+                              llvm::cl::init(true));
 
 // The verifier is basically all assertions, so don't compile it with NDEBUG to
 // prevent release builds from triggering spurious unused variable warnings.
@@ -4590,6 +4590,9 @@ public:
       }
       if (DS != LastSeenScope) {
         DEBUG(llvm::dbgs() << "Broken instruction!\n"; SI.dump());
+        DEBUG(llvm::dbgs() << "Please report a bug on bugs.swift.org\n");
+        DEBUG(llvm::dbgs() <<
+          "Pass -Xllvm -verify-di-holes=false to disable the verification\n");
         require(
             DS == LastSeenScope,
             "Basic block contains a non-contiguous lexical scope at -Onone");


### PR DESCRIPTION
This will allow us to not regress debug info when we make changes in passes run as part of the `-Onone` pipeline. I did a fair amount of qualification and made sure I fixed all the bugs I found. I'll do another full round of test & source-compatibility testsuite and pull the trigger. 

This commit also specifies where to report the bugs and how to disable the verification. Hopefully it won't be too disruptive. I think it's important because it's one step further towards better swift debuggability at `-Onone`.