### PR TITLE
[4.2] Use SwiftObject's old name when building for the pre-stable ABI.

### DIFF
--- a/include/swift/AST/KnownIdentifiers.def
+++ b/include/swift/AST/KnownIdentifiers.def
@@ -95,7 +95,12 @@ IDENTIFIER(stringValue)
 IDENTIFIER(super)
 IDENTIFIER(superDecoder)
 IDENTIFIER(superEncoder)
+#if __APPLE__ && !SWIFT_DARWIN_ENABLE_STABLE_ABI_BIT
+// Pre-stable ABI uses un-mangled name for SwiftObject.
+IDENTIFIER(SwiftObject)
+#else
 IDENTIFIER_WITH_NAME(SwiftObject, "_TtCs12_SwiftObject")
+#endif
 IDENTIFIER(to)
 IDENTIFIER(toRaw)
 IDENTIFIER(Type)

--- a/stdlib/public/runtime/SwiftObject.h
+++ b/stdlib/public/runtime/SwiftObject.h
@@ -30,9 +30,13 @@
 
 #if SWIFT_OBJC_INTEROP
 
+#if __APPLE__ && !SWIFT_DARWIN_ENABLE_STABLE_ABI_BIT
+// Pre-stable ABI uses un-mangled name for SwiftObject
+#else
 // Source code: "SwiftObject"
 // Real class name: mangled "Swift._SwiftObject"
 #define SwiftObject _TtCs12_SwiftObject
+#endif
 
 #if __has_attribute(objc_root_class)
 __attribute__((__objc_root_class__))

--- a/test/IRGen/class.sil
+++ b/test/IRGen/class.sil
@@ -37,7 +37,7 @@ sil_vtable C {}
 // \ CHECK:   void ([[C_CLASS]]*)* @"$S5class1CCfD",
 // \ CHECK:   i8** @"$SBoWV",
 // \ CHECK:   i64 ptrtoint ([[OBJCCLASS]]* @"$S5class1CCMm" to i64),
-// \ CHECK:   [[OBJCCLASS]]* @"OBJC_CLASS_$__TtCs12_SwiftObject",
+// \ CHECK:   [[OBJCCLASS]]* @"OBJC_CLASS_$_{{(_TtCs12_)?}}SwiftObject",
 // \ CHECK:   [[OPAQUE]]* @_objc_empty_cache,
 // \ CHECK:   [[OPAQUE]]* null,
 // \ CHECK:   i64 add (i64 ptrtoint ({{.*}}* @_DATA__TtC5class1C to i64), i64 1)

--- a/test/IRGen/generic_classes.sil
+++ b/test/IRGen/generic_classes.sil
@@ -96,7 +96,7 @@ import Swift
 // CHECK-SAME-native: %swift.type* null,
 // CHECK-SAME-native: %swift.opaque* null,
 // CHECK-SAME-objc:   i64 ptrtoint (%objc_class* @"$S15generic_classes14RootNonGenericCMm" to i64),
-// CHECK-SAME-objc:   %objc_class* @"OBJC_CLASS_$__TtCs12_SwiftObject",
+// CHECK-SAME-objc:   %objc_class* @"OBJC_CLASS_$_{{(_TtCs12_)?}}SwiftObject",
 // CHECK-SAME-objc:   %swift.opaque* @_objc_empty_cache,
 // CHECK-SAME:   %swift.opaque* null,
 // CHECK-SAME-native: i64 1,

--- a/test/IRGen/objc_class_export.swift
+++ b/test/IRGen/objc_class_export.swift
@@ -16,8 +16,8 @@
 // CHECK-DAG: [[OBJC:%objc_object]] = type opaque
 
 // CHECK: @"OBJC_METACLASS_$__TtC17objc_class_export3Foo" = hidden global %objc_class {
-// CHECK:   %objc_class* @"OBJC_METACLASS_$__TtCs12_SwiftObject",
-// CHECK:   %objc_class* @"OBJC_METACLASS_$__TtCs12_SwiftObject",
+// CHECK:   %objc_class* @"OBJC_METACLASS_$_{{(_TtCs12_)?}}SwiftObject",
+// CHECK:   %objc_class* @"OBJC_METACLASS_$_{{(_TtCs12_)?}}SwiftObject",
 // CHECK:   %swift.opaque* @_objc_empty_cache,
 // CHECK:   %swift.opaque* null,
 // CHECK:   i64 ptrtoint ({{.*}}* @_METACLASS_DATA__TtC17objc_class_export3Foo to i64)
@@ -53,7 +53,7 @@
 // CHECK:   void ([[FOO]]*)* @"$S17objc_class_export3FooCfD",
 // CHECK:   i8** @"$SBOWV",
 // CHECK:   i64 ptrtoint (%objc_class* @"OBJC_METACLASS_$__TtC17objc_class_export3Foo" to i64),
-// CHECK:   %objc_class* @"OBJC_CLASS_$__TtCs12_SwiftObject",
+// CHECK:   %objc_class* @"OBJC_CLASS_$_{{(_TtCs12_)?}}SwiftObject",
 // CHECK:   %swift.opaque* @_objc_empty_cache,
 // CHECK:   %swift.opaque* null,
 // CHECK:   i64 add (i64 ptrtoint ({{.*}}* @_DATA__TtC17objc_class_export3Foo to i64), i64 1),

--- a/test/IRGen/subclass.swift
+++ b/test/IRGen/subclass.swift
@@ -16,7 +16,7 @@
 // CHECK:   void ([[A]]*)* @"$S8subclass1ACfD",
 // CHECK:   i8** @"$SBoWV",
 // CHECK:   i64 ptrtoint ([[OBJC_CLASS]]* @"$S8subclass1ACMm" to i64),
-// CHECK:   [[OBJC_CLASS]]* @"OBJC_CLASS_$__TtCs12_SwiftObject",
+// CHECK:   [[OBJC_CLASS]]* @"OBJC_CLASS_$_{{(_TtCs12_)?}}SwiftObject",
 // CHECK:   [[OPAQUE]]* @_objc_empty_cache,
 // CHECK:   [[OPAQUE]]* null,
 // CHECK:   i64 add (i64 ptrtoint ({ {{.*}} }* @_DATA__TtC8subclass1A to i64), i64 1),

--- a/test/IRGen/vtable.sil
+++ b/test/IRGen/vtable.sil
@@ -23,7 +23,7 @@ sil @$S6vtable1CCfD : $@convention(method) (@owned C) -> ()
 // CHECK-objc: void ([[C]]*)* @"$S6vtable1CCfD",
 // CHECK-objc: i8** @"$SBoWV",
 // CHECK-objc: i64 ptrtoint (%objc_class* @"$S6vtable1CCMm" to i64),
-// CHECK-objc: %objc_class* @"OBJC_CLASS_$__TtCs12_SwiftObject",
+// CHECK-objc: %objc_class* @"OBJC_CLASS_$_{{(_TtCs12_)?}}SwiftObject",
 // CHECK-objc: %swift.opaque* @_objc_empty_cache,
 // CHECK-objc: %swift.opaque* null,
 // CHECK-objc: i64 add (i64 ptrtoint ({ i32, i32, i32, i32, i8*, i8*, i8*, i8*, i8*, i8*, i8* }* @_DATA__TtC6vtable1C to i64), i64 {{1|2}}),

--- a/test/stdlib/Inputs/SwiftObjectNSObject/SwiftObjectNSObject.m
+++ b/test/stdlib/Inputs/SwiftObjectNSObject/SwiftObjectNSObject.m
@@ -52,8 +52,14 @@ static int Errors;
 
 // Add methods to class SwiftObject that can be called by performSelector: et al
 
+#if __APPLE__ && !SWIFT_DARWIN_ENABLE_STABLE_ABI_BIT
+// Pre-stable ABI uses un-mangled name for SwiftObject.
+#define SwiftObjectDemangledName "SwiftObject"
+#else
 // mangled Swift._SwiftObject
 #define SwiftObject _TtCs12_SwiftObject
+#define SwiftObjectDemangledName "Swift._SwiftObject"
+#endif
 
 @interface SwiftObject /* trust me, I know what I'm doing */ @end
 @implementation SwiftObject (MethodsToPerform)
@@ -77,7 +83,7 @@ void TestSwiftObjectNSObject(id c, id d)
 {
   printf("TestSwiftObjectNSObject\n");
 
-  Class S = objc_getClass("Swift._SwiftObject");
+  Class S = objc_getClass(SwiftObjectDemangledName);
   Class C = objc_getClass("SwiftObjectNSObject.C");
   Class D = objc_getClass("SwiftObjectNSObject.D");
 
@@ -405,10 +411,10 @@ void TestSwiftObjectNSObject(id c, id d)
   expectTrue ([[c description] isEqual:@"SwiftObjectNSObject.C"]);
   expectTrue ([[D description] isEqual:@"SwiftObjectNSObject.D"]);
   expectTrue ([[C description] isEqual:@"SwiftObjectNSObject.C"]);
-  expectTrue ([[S description] isEqual:@"Swift._SwiftObject"]);
+  expectTrue ([[S description] isEqual:@ SwiftObjectDemangledName]);
   expectTrue ([[D_meta description] isEqual:@"SwiftObjectNSObject.D"]);
   expectTrue ([[C_meta description] isEqual:@"SwiftObjectNSObject.C"]);
-  expectTrue ([[S_meta description] isEqual:@"Swift._SwiftObject"]);
+  expectTrue ([[S_meta description] isEqual:@ SwiftObjectDemangledName]);
 
   // NSLog() calls -description and also some private methods.
   // This output is checked by FileCheck in SwiftObjectNSObject.swift.
@@ -423,10 +429,10 @@ void TestSwiftObjectNSObject(id c, id d)
   expectTrue ([[c debugDescription] isEqual:@"SwiftObjectNSObject.C"]);
   expectTrue ([[D debugDescription] isEqual:@"SwiftObjectNSObject.D"]);
   expectTrue ([[C debugDescription] isEqual:@"SwiftObjectNSObject.C"]);
-  expectTrue ([[S debugDescription] isEqual:@"Swift._SwiftObject"]);
+  expectTrue ([[S debugDescription] isEqual:@ SwiftObjectDemangledName]);
   expectTrue ([[D_meta debugDescription] isEqual:@"SwiftObjectNSObject.D"]);
   expectTrue ([[C_meta debugDescription] isEqual:@"SwiftObjectNSObject.C"]);
-  expectTrue ([[S_meta debugDescription] isEqual:@"Swift._SwiftObject"]);
+  expectTrue ([[S_meta debugDescription] isEqual:@ SwiftObjectDemangledName]);
 
 
   printf("NSObjectProtocol.performSelector\n");

--- a/test/stdlib/SwiftObjectNSObject.swift
+++ b/test/stdlib/SwiftObjectNSObject.swift
@@ -40,7 +40,7 @@ func TestSwiftObjectNSObject(_ c: C, _ d: D)
 // This check is for NSLog() output from TestSwiftObjectNSObject().
 // CHECK: c ##SwiftObjectNSObject.C##
 // CHECK-NEXT: d ##SwiftObjectNSObject.D##
-// CHECK-NEXT: S ##Swift._SwiftObject##
+// CHECK-NEXT: S ##{{(Swift._)?}}SwiftObject##
 
 TestSwiftObjectNSObject(C(), D())
 // does not return


### PR DESCRIPTION
rdar://35554345