### PR TITLE
stdlib: disable FP80 patterns on Windows

### DIFF
--- a/stdlib/public/core/BuiltinMath.swift.gyb
+++ b/stdlib/public/core/BuiltinMath.swift.gyb
@@ -62,7 +62,7 @@ def TypedUnaryIntrinsicFunctions():
 // Note these have a corresponding LLVM intrinsic
 % for T, CT, bits, ufunc in TypedUnaryIntrinsicFunctions():
 %  if bits == 80:
-#if arch(i386) || arch(x86_64)
+#if !os(Windows) && (arch(i386) || arch(x86_64))
 %  end
 @_inlineable // FIXME(sil-serialize-all)
 @_transparent


### PR DESCRIPTION
Windows does not support FP80 operations even on x86 and x86_64.
Disable the generation of those operations on that target.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
