### PR TITLE
Make 'rawValue' and 'init(rawValue:)' inlinable for non-resilient enums

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1984,7 +1984,10 @@ void AttributeChecker::visitUsableFromInlineAttr(UsableFromInlineAttr *attr) {
 
   // On internal declarations, @inlinable implies @usableFromInline.
   if (VD->getAttrs().hasAttribute<InlinableAttr>()) {
-    diagnoseAndRemoveAttr(attr, diag::inlinable_implies_usable_from_inline);
+    if (attr->isImplicit())
+      attr->setInvalid();
+    else
+      diagnoseAndRemoveAttr(attr, diag::inlinable_implies_usable_from_inline);
     return;
   }
 }

--- a/test/SILGen/enum_raw_representable.swift
+++ b/test/SILGen/enum_raw_representable.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership -enable-resilience %s | %FileCheck -check-prefix=CHECK-RESILIENT %s
+
+public enum E: Int {
+  case a, b, c
+}
+
+// CHECK-DAG: sil [serialized] @$S22enum_raw_representable1EO0B5ValueACSgSi_tcfC
+// CHECK-DAG: sil [serialized] @$S22enum_raw_representable1EO0B5ValueSivg
+
+// CHECK-RESILIENT-DAG: sil @$S22enum_raw_representable1EO0B5ValueACSgSi_tcfC
+// CHECK-RESILIENT-DAG: sil @$S22enum_raw_representable1EO0B5ValueSivg


### PR DESCRIPTION
(~including~ only enums in libraries compiled without -enable-resilience)

Small potential perf win...or rather regain, since we apparently used to do this.

[SR-7094](https://bugs.swift.org/browse/SR-7094) / rdar://problem/38030106