### PR TITLE
master-next: use separate memcpy/memmove src/dest alignment arguments

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -1331,10 +1331,11 @@ namespace {
                            SILType T) const {
       // If the layout is fixed, the size will be a constant.
       // Otherwise, do a memcpy of the dynamic size of the type.
-      IGF.Builder.CreateMemCpy(dest.getAddress(), src.getAddress(),
-                               TI->getSize(IGF, T),
-                               std::min(dest.getAlignment().getValue(),
-                                        src.getAlignment().getValue()));
+      IGF.Builder.CreateMemCpy(dest.getAddress(),
+                               dest.getAlignment().getValue(),
+                               src.getAddress(),
+                               src.getAlignment().getValue(),
+                               TI->getSize(IGF, T));
     }
 
     void emitPrimitiveStorePayloadAndExtraTag(IRGenFunction &IGF, Address dest,

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -478,9 +478,9 @@ getWitnessTableForComputedComponent(IRGenModule &IGM,
         auto sourceEnv = IGF.Builder.CreateInBoundsGEP(sourceArgsBuf, offset);
         auto destEnv = IGF.Builder.CreateInBoundsGEP(destArgsBuf, offset);
         
-        IGF.Builder.CreateMemCpy(destEnv, sourceEnv,
-          IGM.getPointerSize().getValue() * requirements.size(),
-          IGM.getPointerAlignment().getValue());
+        auto align = IGM.getPointerAlignment().getValue();
+        IGF.Builder.CreateMemCpy(destEnv, align, sourceEnv, align,
+          IGM.getPointerSize().getValue() * requirements.size());
       }
       
       IGF.Builder.CreateRetVoid();
@@ -636,9 +636,9 @@ getInitializerForComputedComponent(IRGenModule &IGM,
         destGenericEnv = IGF.Builder.CreateInBoundsGEP(dest, offset);
       }
       
-      IGF.Builder.CreateMemCpy(destGenericEnv, src,
-                           IGM.getPointerSize().getValue() * requirements.size(),
-                           IGM.getPointerAlignment().getValue());
+      auto align = IGM.getPointerAlignment().getValue();
+      IGF.Builder.CreateMemCpy(destGenericEnv, align, src, align,
+                         IGM.getPointerSize().getValue() * requirements.size());
     }
     IGF.Builder.CreateRetVoid();
   }

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -201,9 +201,11 @@ public:
                           SILType T, bool isOutlined) const override {
     // If we're bitwise-takable, use memcpy.
     if (this->isBitwiseTakable(ResilienceExpansion::Maximal)) {
-      IGF.Builder.CreateMemCpy(dest.getAddress(), src.getAddress(),
-                 asImpl().Impl::getSize(IGF, T),
-                 std::min(dest.getAlignment(), src.getAlignment()).getValue());
+      IGF.Builder.CreateMemCpy(dest.getAddress(),
+                               dest.getAlignment().getValue(),
+                               src.getAddress(),
+                               src.getAlignment().getValue(),
+                 asImpl().Impl::getSize(IGF, T));
       return;
     }
 

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -464,8 +464,8 @@ llvm::Value *FixedTypeInfo::getEnumTagSinglePayload(IRGenFunction &IGF,
 
   // TODO: big endian.
   Builder.CreateMemCpy(
-      Builder.CreateBitCast(extraTagBitsSlot, IGM.Int8PtrTy).getAddress(),
-      extraTagBitsAddr, numExtraTagBytes, 1);
+      Builder.CreateBitCast(extraTagBitsSlot, IGM.Int8PtrTy).getAddress(), 1,
+      extraTagBitsAddr, 1, numExtraTagBytes);
   auto extraTagBits = Builder.CreateLoad(extraTagBitsSlot);
 
   extraTagBitsBB = llvm::BasicBlock::Create(Ctx);

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -1381,8 +1381,10 @@ void TypeInfo::initializeArrayWithCopy(IRGenFunction &IGF,
   if (isPOD(ResilienceExpansion::Maximal)) {
     llvm::Value *stride = getStride(IGF, T);
     llvm::Value *byteCount = IGF.Builder.CreateNUWMul(stride, count);
-    IGF.Builder.CreateMemCpy(dest.getAddress(), src.getAddress(),
-                             byteCount, dest.getAlignment().getValue());
+    IGF.Builder.CreateMemCpy(dest.getAddress(),
+                             dest.getAlignment().getValue(),
+                             src.getAddress(),
+                             src.getAlignment().getValue(), byteCount);
     return;
   }
 
@@ -1395,8 +1397,10 @@ void TypeInfo::initializeArrayWithTakeNoAlias(IRGenFunction &IGF, Address dest,
   if (isBitwiseTakable(ResilienceExpansion::Maximal)) {
     llvm::Value *stride = getStride(IGF, T);
     llvm::Value *byteCount = IGF.Builder.CreateNUWMul(stride, count);
-    IGF.Builder.CreateMemCpy(dest.getAddress(), src.getAddress(), byteCount,
-                             dest.getAlignment().getValue());
+    IGF.Builder.CreateMemCpy(dest.getAddress(),
+                             dest.getAlignment().getValue(),
+                             src.getAddress(),
+                             src.getAlignment().getValue(), byteCount);
     return;
   }
 
@@ -1410,8 +1414,9 @@ const {
   if (isBitwiseTakable(ResilienceExpansion::Maximal)) {
     llvm::Value *stride = getStride(IGF, T);
     llvm::Value *byteCount = IGF.Builder.CreateNUWMul(stride, count);
-    IGF.Builder.CreateMemMove(dest.getAddress(), src.getAddress(),
-                              byteCount, dest.getAlignment().getValue());
+    IGF.Builder.CreateMemMove(dest.getAddress(), dest.getAlignment().getValue(),
+                              src.getAddress(), src.getAlignment().getValue(),
+                              byteCount);
     return;
   }
 
@@ -1425,8 +1430,9 @@ const {
   if (isBitwiseTakable(ResilienceExpansion::Maximal)) {
     llvm::Value *stride = getStride(IGF, T);
     llvm::Value *byteCount = IGF.Builder.CreateNUWMul(stride, count);
-    IGF.Builder.CreateMemMove(dest.getAddress(), src.getAddress(),
-                              byteCount, dest.getAlignment().getValue());
+    IGF.Builder.CreateMemMove(dest.getAddress(), dest.getAlignment().getValue(),
+                              src.getAddress(), src.getAlignment().getValue(),
+                              byteCount);
     return;
   }
 
@@ -1439,8 +1445,10 @@ void TypeInfo::assignArrayWithCopyNoAlias(IRGenFunction &IGF, Address dest,
   if (isPOD(ResilienceExpansion::Maximal)) {
     llvm::Value *stride = getStride(IGF, T);
     llvm::Value *byteCount = IGF.Builder.CreateNUWMul(stride, count);
-    IGF.Builder.CreateMemCpy(dest.getAddress(), src.getAddress(), byteCount,
-                             dest.getAlignment().getValue());
+    IGF.Builder.CreateMemCpy(dest.getAddress(),
+                             dest.getAlignment().getValue(),
+                             src.getAddress(),
+                             src.getAlignment().getValue(), byteCount);
     return;
   }
 
@@ -1453,8 +1461,9 @@ void TypeInfo::assignArrayWithCopyFrontToBack(IRGenFunction &IGF, Address dest,
   if (isPOD(ResilienceExpansion::Maximal)) {
     llvm::Value *stride = getStride(IGF, T);
     llvm::Value *byteCount = IGF.Builder.CreateNUWMul(stride, count);
-    IGF.Builder.CreateMemMove(dest.getAddress(), src.getAddress(),
-                              byteCount, dest.getAlignment().getValue());
+    IGF.Builder.CreateMemMove(dest.getAddress(), dest.getAlignment().getValue(),
+                              src.getAddress(), src.getAlignment().getValue(),
+                              byteCount);
     return;
   }
 
@@ -1467,8 +1476,9 @@ void TypeInfo::assignArrayWithCopyBackToFront(IRGenFunction &IGF, Address dest,
   if (isPOD(ResilienceExpansion::Maximal)) {
     llvm::Value *stride = getStride(IGF, T);
     llvm::Value *byteCount = IGF.Builder.CreateNUWMul(stride, count);
-    IGF.Builder.CreateMemMove(dest.getAddress(), src.getAddress(),
-                              byteCount, dest.getAlignment().getValue());
+    IGF.Builder.CreateMemMove(dest.getAddress(), dest.getAlignment().getValue(),
+                              src.getAddress(), src.getAlignment().getValue(),
+                              byteCount);
     return;
   }
 
@@ -1481,8 +1491,10 @@ void TypeInfo::assignArrayWithTake(IRGenFunction &IGF, Address dest,
   if (isPOD(ResilienceExpansion::Maximal)) {
     llvm::Value *stride = getStride(IGF, T);
     llvm::Value *byteCount = IGF.Builder.CreateNUWMul(stride, count);
-    IGF.Builder.CreateMemCpy(dest.getAddress(), src.getAddress(), byteCount,
-                             dest.getAlignment().getValue());
+    IGF.Builder.CreateMemCpy(dest.getAddress(),
+                             dest.getAlignment().getValue(),
+                             src.getAddress(),
+                             src.getAlignment().getValue(), byteCount);
     return;
   }
 

--- a/lib/IRGen/IRBuilder.h
+++ b/lib/IRGen/IRBuilder.h
@@ -269,10 +269,9 @@ public:
 
   using IRBuilderBase::CreateMemCpy;
   llvm::CallInst *CreateMemCpy(Address dest, Address src, Size size) {
-    return CreateMemCpy(dest.getAddress(), src.getAddress(),
-                        size.getValue(),
-                        std::min(dest.getAlignment(),
-                                 src.getAlignment()).getValue());
+    return CreateMemCpy(dest.getAddress(), dest.getAlignment().getValue(),
+                        src.getAddress(), src.getAlignment().getValue(),
+                        size.getValue());
   }
 
   using IRBuilderBase::CreateMemSet;

--- a/lib/IRGen/IRGenFunction.cpp
+++ b/lib/IRGen/IRGenFunction.cpp
@@ -98,7 +98,7 @@ void IRGenFunction::emitMemCpy(llvm::Value *dest, llvm::Value *src,
 
 void IRGenFunction::emitMemCpy(llvm::Value *dest, llvm::Value *src,
                                llvm::Value *size, Alignment align) {
-  Builder.CreateMemCpy(dest, src, size, align.getValue(), false);
+  Builder.CreateMemCpy(dest, align.getValue(), src, align.getValue(), size);
 }
 
 void IRGenFunction::emitMemCpy(Address dest, Address src, Size size) {


### PR DESCRIPTION
LLVM r323617 changed the IRBuilder's CreateMemCpy and CreateMemMove
functions to take separate arguments for the destination and source
alignments.