### PR TITLE
[SourceKit] Include trailing where clause in SourceRange

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1425,6 +1425,10 @@ public:
 
   /// Set the generic context of this context.
   void setGenericEnvironment(GenericEnvironment *genericEnv);
+
+  /// Retrieve the position of any where clause for this context's
+  /// generic parameters.
+  SourceRange getGenericTrailingWhereClauseSourceRange() const;
 };
 static_assert(sizeof(_GenericContext) + sizeof(DeclContext) ==
               sizeof(GenericContext), "Please add fields to _GenericContext");

--- a/test/IDE/structure.swift
+++ b/test/IDE/structure.swift
@@ -44,9 +44,21 @@ struct MyStruc {
 
 // CHECK: <protocol>protocol <name>MyProt</name> {
 // CHECK:   <ifunc>func <name>foo()</name></ifunc>
+// CHECK:   <ifunc>func <name>foo2()</name> throws</ifunc>
+// CHECK:   <ifunc>func <name>foo3()</name> throws -> <type>Int</type></ifunc>
+// CHECK:   <ifunc>func <name>foo4<<generic-param><name>T</name></generic-param>>()</name> where T: MyProt</ifunc>
+// CHECK:   <ifunc><name>init()</name></ifunc>
+// CHECK:   <ifunc><name>init(<param><name>a</name>: <type>Int</type></param>)</name> throws</ifunc>
+// CHECK:   <ifunc><name>init<<generic-param><name>T</name></generic-param>>(<param><name>a</name>: <type>T</type></param>)</name> where T: MyProt</ifunc>
 // CHECK: }</protocol>
 protocol MyProt {
   func foo()
+  func foo2() throws
+  func foo3() throws -> Int
+  func foo4<T>() where T: MyProt
+  init()
+  init(a: Int) throws
+  init<T>(a: T) where T: MyProt
 }
 
 // CHECK: <extension>extension <name>MyStruc</name> {
@@ -185,6 +197,9 @@ class A {
 // CHECK: <typealias>typealias <name>OtherA</name> = A</typealias>
 typealias OtherA = A
 
+// CHECK: <typealias>typealias <name>EqBox</name><<generic-param><name>Boxed</name></generic-param>> = Box<Boxed> where Boxed: Equatable</typealias>
+typealias EqBox<Boxed> = Box<Boxed> where Boxed: Equatable
+
 class SubscriptTest {
   subscript(index: Int) -> Int {
     return 0
@@ -228,6 +243,8 @@ protocol FooProtocol {
   // CHECK:  <associatedtype>associatedtype <name>Bar</name></associatedtype>
   associatedtype Baz: Equatable
   // CHECK:  <associatedtype>associatedtype <name>Baz</name>: Equatable</associatedtype>
+  associatedtype Qux where Qux: Equatable
+  // CHECK:  <associatedtype>associatedtype <name>Qux</name> where Qux: Equatable</associatedtype>
 }
 
 // CHECK: <struct>struct <name>Generic</name><<generic-param><name>T</name>: <inherited><elem-typeref>Comparable</elem-typeref></inherited></generic-param>, <generic-param><name>X</name></generic-param>> {


### PR DESCRIPTION
This PR updates the `SourceRange` (sourcekit structure key.offset/key.length) calculation for cases where the last thing in a declaration is a `where` clause [or a `throws`, found in passing].

This is pretty rare - protocol members and typealias/assoctype with `where`.

The current behavior skipping the `where` means that downstream tools using SourceKit doc structure can miss out the throws/where parts when chopping up files.

Added tests - previously these would put the `</ifunc>` etc. too early.

@nkcsgexi could you review please?
