### PR TITLE
[Sema] NFC: More TVO_CanBindToInOut removal

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1098,6 +1098,8 @@ ERROR(expected_operator_ref,none,
       "expected operator name in operator reference", ())
 ERROR(invalid_postfix_operator,none,
       "operator with postfix spacing cannot start a subexpression", ())
+ERROR(extraneous_amp_prefix,none,
+      "use of extraneous '&'", ())
 
 ERROR(expected_member_name,PointsToFirstBadToken,
       "expected member name following '.'", ())

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1156,19 +1156,21 @@ public:
 
   //===--------------------------------------------------------------------===//
   // Expression Parsing
-  ParserResult<Expr> parseExpr(Diag<> ID) {
-    return parseExprImpl(ID, /*isExprBasic=*/false);
+  ParserResult<Expr> parseExpr(Diag<> ID, bool allowAmpPrefix = false) {
+    return parseExprImpl(ID, /*isExprBasic=*/false, allowAmpPrefix);
   }
   ParserResult<Expr> parseExprBasic(Diag<> ID) {
     return parseExprImpl(ID, /*isExprBasic=*/true);
   }
-  ParserResult<Expr> parseExprImpl(Diag<> ID, bool isExprBasic = false);
+  ParserResult<Expr> parseExprImpl(Diag<> ID, bool isExprBasic,
+                                   bool allowAmpPrefix = false);
   ParserResult<Expr> parseExprIs();
   ParserResult<Expr> parseExprAs();
   ParserResult<Expr> parseExprArrow();
   ParserResult<Expr> parseExprSequence(Diag<> ID,
                                        bool isExprBasic,
-                                       bool isForConditionalDirective = false);
+                                       bool isForConditionalDirective = false,
+                                       bool allowAmpPrefix = false);
   ParserResult<Expr> parseExprSequenceElement(Diag<> ID,
                                               bool isExprBasic);
   ParserResult<Expr> parseExprPostfixSuffix(ParserResult<Expr> inner,
@@ -1272,7 +1274,8 @@ public:
                              SmallVectorImpl<SourceLoc> &exprLabelLocs,
                              SourceLoc &rightLoc,
                              Expr *&trailingClosure,
-                             syntax::SyntaxKind Kind);
+                             syntax::SyntaxKind Kind,
+                             bool allowAmpPrefix = false);
 
   ParserResult<Expr> parseTrailingClosure(SourceRange calleeRange);
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -40,7 +40,9 @@ using namespace swift::syntax;
 ///     expr-sequence(basic | trailing-closure)
 ///
 /// \param isExprBasic Whether we're only parsing an expr-basic.
-ParserResult<Expr> Parser::parseExprImpl(Diag<> Message, bool isExprBasic) {
+ParserResult<Expr> Parser::parseExprImpl(Diag<> Message,
+                                         bool isExprBasic,
+                                         bool allowAmpPrefix) {
   // Start a context for creating expression syntax.
   SyntaxParsingContext ExprParsingContext(SyntaxContext, SyntaxContextKind::Expr);
 
@@ -61,7 +63,9 @@ ParserResult<Expr> Parser::parseExprImpl(Diag<> Message, bool isExprBasic) {
     return makeParserResult(new (Context) UnresolvedPatternExpr(pattern.get()));
   }
   
-  ParserResult<Expr> expr = parseExprSequence(Message, isExprBasic);
+  auto expr = parseExprSequence(Message, isExprBasic,
+                                /*forConditionalDirective*/false,
+                                allowAmpPrefix);
   if (expr.hasCodeCompletion())
     return expr;
   if (expr.isNull())
@@ -166,7 +170,8 @@ ParserResult<Expr> Parser::parseExprArrow() {
 /// apply to everything to its right.
 ParserResult<Expr> Parser::parseExprSequence(Diag<> Message,
                                              bool isExprBasic,
-                                             bool isForConditionalDirective) {
+                                             bool isForConditionalDirective,
+                                             bool allowAmpPrefix) {
   SyntaxParsingContext ExprSequnceContext(SyntaxContext, SyntaxContextKind::Expr);
 
   SmallVector<Expr*, 8> SequencedExprs;
@@ -178,9 +183,36 @@ ParserResult<Expr> Parser::parseExprSequence(Diag<> Message,
     if (isForConditionalDirective && Tok.isAtStartOfLine())
       break;
     
-    // Parse a unary expression.
-    ParserResult<Expr> Primary =
-      parseExprSequenceElement(Message, isExprBasic);
+    ParserResult<Expr> Primary;
+
+    SourceLoc AmpPrefix;
+    if (Tok.is(tok::amp_prefix)) {
+      SyntaxParsingContext AmpCtx(SyntaxContext, SyntaxKind::InOutExpr);
+      AmpPrefix = consumeToken(tok::amp_prefix);
+
+      auto SubExpr = parseExprUnary(Message, isExprBasic);
+      auto allowNextAmpPrefix = Tok.isBinaryOperator();
+      if (SubExpr.hasCodeCompletion()) {
+        Primary = makeParserCodeCompletionResult<Expr>();
+      } else if (SubExpr.isNull()) {
+        Primary = nullptr;
+      } else if (allowAmpPrefix || allowNextAmpPrefix) {
+        Primary = makeParserResult(
+            new (Context) InOutExpr(AmpPrefix, SubExpr.get(), Type()));
+      } else {
+        diagnose(AmpPrefix, diag::extraneous_amp_prefix);
+        // In the long run, we should assign SubExpr to Primary to improve
+        // single-pass diagnostic completeness, but for now, doing so exposes
+        // diagnostic bugs in Sema where '&' is wrongly suggested as a fix.
+        Primary = makeParserErrorResult(new (Context) ErrorExpr(
+            {AmpPrefix, SubExpr.get()->getSourceRange().End}));
+      }
+      allowAmpPrefix = allowNextAmpPrefix;
+    } else {
+      // Parse a unary expression.
+      Primary = parseExprSequenceElement(Message, isExprBasic);
+    }
+
     HasCodeCompletion |= Primary.hasCodeCompletion();
     if (Primary.isNull()) {
       if (Primary.hasCodeCompletion()) {
@@ -224,6 +256,7 @@ parse_operator:
                                            SyntaxKind::BinaryOperatorExpr);
       Expr *Operator = parseExprOperator();
       SequencedExprs.push_back(Operator);
+      allowAmpPrefix = true;
       
       // The message is only valid for the first subexpr.
       Message = diag::expected_expr_after_operator;
@@ -474,19 +507,6 @@ ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
   default:
     // If the next token is not an operator, just parse this as expr-postfix.
     return parseExprPostfix(Message, isExprBasic);
-
-  case tok::amp_prefix: {
-    SyntaxParsingContext AmpCtx(SyntaxContext, SyntaxKind::InOutExpr);
-    SourceLoc Loc = consumeToken(tok::amp_prefix);
-
-    ParserResult<Expr> SubExpr = parseExprUnary(Message, isExprBasic);
-    if (SubExpr.hasCodeCompletion())
-      return makeParserCodeCompletionResult<Expr>();
-    if (SubExpr.isNull())
-      return nullptr;
-    return makeParserResult(
-        new (Context) InOutExpr(Loc, SubExpr.get(), Type()));
-  }
 
   case tok::backslash:
     return parseExprKeyPath();
@@ -897,7 +917,8 @@ ParserResult<Expr> Parser::parseExprSuper(bool isExprBasic) {
                                         indexArgLabelLocs,
                                         rSquareLoc,
                                         trailingClosure,
-                                        SyntaxKind::FunctionCallArgumentList);
+                                        SyntaxKind::FunctionCallArgumentList,
+                                        /*allowAmpPrefix*/true);
     if (status.hasCodeCompletion())
       return makeParserCodeCompletionResult<Expr>();
     if (status.isError())
@@ -1245,7 +1266,8 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
           tok::l_square, tok::r_square,
           /*isPostfix=*/true, isExprBasic, lSquareLoc, indexArgs,
           indexArgLabels, indexArgLabelLocs, rSquareLoc, trailingClosure,
-          SyntaxKind::FunctionCallArgumentList);
+          SyntaxKind::FunctionCallArgumentList,
+          /*allowAmpPrefix*/true);
       if (status.hasCodeCompletion())
         return makeParserCodeCompletionResult<Expr>();
       if (status.isError() || Result.isNull())
@@ -1676,7 +1698,8 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
                                           argLabelLocs,
                                           rParenLoc,
                                           trailingClosure,
-                                          SyntaxKind::FunctionCallArgumentList);
+                                          SyntaxKind::FunctionCallArgumentList,
+                                          /*allowAmpPrefix*/true);
       if (status.isError())
         return nullptr;
 
@@ -2911,7 +2934,8 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
                                    SmallVectorImpl<SourceLoc> &exprLabelLocs,
                                    SourceLoc &rightLoc,
                                    Expr *&trailingClosure,
-                                   SyntaxKind Kind) {
+                                   SyntaxKind Kind,
+                                   bool allowAmpPrefix) {
   trailingClosure = nullptr;
 
   StructureMarkerRAII ParsingExprList(*this, Tok);
@@ -2948,8 +2972,8 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
                                                    DeclRefKind::Ordinary,
                                                    DeclNameLoc(Loc));
     } else {
-      ParserResult<Expr> ParsedSubExpr 
-        = parseExpr(diag::expected_expr_in_expr_list);
+      auto ParsedSubExpr = parseExpr(diag::expected_expr_in_expr_list,
+                                     /*allowAmpPrefix*/allowAmpPrefix);
       SubExpr = ParsedSubExpr.getPtrOrNull();
       Status = ParsedSubExpr;
     }
@@ -3193,7 +3217,8 @@ Parser::parseExprCallSuffix(ParserResult<Expr> fn, bool isExprBasic) {
                                       argLabelLocs,
                                       rParenLoc,
                                       trailingClosure,
-                                      SyntaxKind::FunctionCallArgumentList);
+                                      SyntaxKind::FunctionCallArgumentList,
+                                      /*allowAmpPrefix*/true);
 
   // Form the call.
   auto Result = makeParserResult(status | fn, 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2006,7 +2006,7 @@ namespace {
           if (ty)
             return ty;
           return CS.createTypeVariable(CS.getConstraintLocator(locator),
-                                       TVO_CanBindToInOut);
+                                       /*options*/0);
         case ReferenceOwnership::Weak:
           // For weak variables, use Optional<T>.
           if (ty && ty->getOptionalObjectType())
@@ -2014,7 +2014,7 @@ namespace {
           // Create a fresh type variable to handle overloaded expressions.
           if (!ty || ty->is<TypeVariableType>())
             ty = CS.createTypeVariable(CS.getConstraintLocator(locator),
-                                       TVO_CanBindToInOut);
+                                       /*options*/0);
           return CS.getTypeChecker().getOptionalType(var->getLoc(), ty);
         }
 
@@ -2055,7 +2055,7 @@ namespace {
         // TODO: we could try harder here, e.g. for enum elements to provide the
         // enum type.
         return CS.createTypeVariable(CS.getConstraintLocator(locator),
-                                     TVO_CanBindToInOut);
+                                     /*options*/0);
       }
 
       llvm_unreachable("Unhandled pattern kind");
@@ -2329,7 +2329,7 @@ namespace {
       //
       // where T is a fresh type variable.
       auto lvalue = CS.createTypeVariable(CS.getConstraintLocator(expr),
-                                          TVO_CanBindToInOut);
+                                          /*options*/0);
       auto bound = LValueType::get(lvalue);
       auto result = InOutType::get(lvalue);
       CS.addConstraint(ConstraintKind::Conversion,
@@ -2492,8 +2492,7 @@ namespace {
 
       // The branches must be convertible to a common type.
       auto resultTy = CS.createTypeVariable(CS.getConstraintLocator(expr),
-                                            TVO_PrefersSubtypeBinding |
-                                            TVO_CanBindToInOut);
+                                            TVO_PrefersSubtypeBinding);
       CS.addConstraint(ConstraintKind::Conversion,
                        CS.getType(expr->getThenExpr()), resultTy,
                        CS.getConstraintLocator(expr->getThenExpr()));

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -457,8 +457,7 @@ func testTypeSugar(_ a : Int) {
 
 // <rdar://problem/21974772> SegFault in FailureDiagnosis::visitInOutExpr
 func r21974772(_ y : Int) {
-  let x = &(1.0 + y)  // expected-error {{binary operator '+' cannot be applied to operands of type 'Double' and 'Int'}}
-   //expected-note @-1 {{overloads for '+' exist with these partially matching parameter lists: }}
+  let x = &(1.0 + y) // expected-error {{use of extraneous '&'}}
 }
 
 // <rdar://problem/22020088> QoI: missing member diagnostic on optional gives worse error message than existential/bound generic/etc

--- a/test/Constraints/lvalues.swift
+++ b/test/Constraints/lvalues.swift
@@ -158,8 +158,8 @@ func testInOut(_ arg: inout Int) {
 }
 
 // Don't infer inout types.
-var ir = &i // expected-error{{expression type 'inout Int' is ambiguous without more context}}
-var ir2 = ((&i)) // expected-error{{expression type 'inout Int' is ambiguous without more context}}
+var ir = &i // expected-error {{use of extraneous '&'}}
+var ir2 = ((&i)) // expected-error {{use of extraneous '&'}}
 
 // <rdar://problem/17133089>
 func takeArrayRef(_ x: inout Array<String>) { }

--- a/test/Constraints/lvalues.swift
+++ b/test/Constraints/lvalues.swift
@@ -158,10 +158,8 @@ func testInOut(_ arg: inout Int) {
 }
 
 // Don't infer inout types.
-var ir = &i // expected-error{{variable has type 'inout Int' which includes nested inout parameters}} \
-            // expected-error{{'&' can only appear immediately in a call argument list}}
-var ir2 = ((&i)) // expected-error{{variable has type 'inout Int' which includes nested inout parameters}} \
-                 // expected-error{{'&' can only appear immediately in a call argument list}}
+var ir = &i // expected-error{{expression type 'inout Int' is ambiguous without more context}}
+var ir2 = ((&i)) // expected-error{{expression type 'inout Int' is ambiguous without more context}}
 
 // <rdar://problem/17133089>
 func takeArrayRef(_ x: inout Array<String>) { }

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -62,8 +62,8 @@ func mutablePointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesMutableArrayPointer(&ii)
 
   // We don't allow these conversions outside of function arguments.
-  var x: UnsafeMutablePointer<Int> = &i // expected-error{{cannot pass immutable value as inout argument: 'i' is immutable}}
-  x = &ii // expected-error{{cannot assign value of type 'inout [Int]' to type 'UnsafeMutablePointer<Int>'}}
+  var x: UnsafeMutablePointer<Int> = &i // expected-error {{use of extraneous '&'}}
+  x = &ii // expected-error {{use of extraneous '&'}}
   _ = x
 }
 
@@ -94,9 +94,9 @@ func mutableVoidPointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesMutableVoidPointer(ff) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutableRawPointer${diag_suffix}'}}
 
   // We don't allow these conversions outside of function arguments.
-  var x: UnsafeMutableRawPointer = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafeMutableRawPointer'}}
+  var x: UnsafeMutableRawPointer = &i // expected-error {{use of extraneous '&'}}
   x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafeMutableRawPointer'}}
-  x = &ii // expected-error{{cannot assign value of type 'inout [Int]' to type 'UnsafeMutableRawPointer'}}
+  x = &ii // expected-error {{use of extraneous '&'}}
   _ = x
 }
 
@@ -129,9 +129,9 @@ func mutableRawPointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesMutableRawPointer(ff) // expected-error{{cannot convert value of type '[Int]' to expected argument type 'UnsafeMutableRawPointer${diag_suffix}'}}
 
   // We don't allow these conversions outside of function arguments.
-  var x: UnsafeMutableRawPointer = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafeMutableRawPointer'}}
+  var x: UnsafeMutableRawPointer = &i // expected-error {{use of extraneous '&'}}
   x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafeMutableRawPointer'}}
-  x = &ii // expected-error{{cannot assign value of type 'inout [Int]' to type 'UnsafeMutableRawPointer'}}
+  x = &ii //expected-error {{use of extraneous '&'}}
   _ = x
 }
 
@@ -160,7 +160,7 @@ func constPointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesConstPointer([0.0, 1.0, 2.0]) // expected-error{{cannot convert value of type '[Double]' to expected argument type 'UnsafePointer<Int>}}
 
   // We don't allow these conversions outside of function arguments.
-  var x: UnsafePointer<Int> = &i // expected-error{{cannot pass immutable value as inout argument: 'i' is immutable}}
+  var x: UnsafePointer<Int> = &i // expected-error {{use of extraneous '&'}}
   x = ii // expected-error{{cannot assign value of type '[Int]' to type 'UnsafePointer<Int>'}}
   x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafePointer<Int>'}}
 }
@@ -194,7 +194,7 @@ func constVoidPointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesConstVoidPointer([0.0, 1.0, 2.0])
 
   // We don't allow these conversions outside of function arguments.
-  var x: UnsafeRawPointer = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafeRawPointer'}}
+  var x: UnsafeRawPointer = &i // expected-error {{use of extraneous '&'}}
   x = ii // expected-error{{cannot assign value of type '[Int]' to type 'UnsafeRawPointer'}}
   x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafeRawPointer'}}
   x = fp // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Float>' to type 'UnsafeRawPointer'}}
@@ -234,7 +234,7 @@ func constRawPointerArguments(_ p: UnsafeMutablePointer<Int>,
   takesConstRawPointer([0.0, 1.0, 2.0])
 
   // We don't allow these conversions outside of function arguments.
-  var x: UnsafeRawPointer = &i // expected-error{{cannot convert value of type 'inout Int' to specified type 'UnsafeRawPointer'}}
+  var x: UnsafeRawPointer = &i // expected-error {{use of extraneous '&'}}
   x = ii // expected-error{{cannot assign value of type '[Int]' to type 'UnsafeRawPointer'}}
   x = p // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Int>' to type 'UnsafeRawPointer'}}
   x = fp // expected-error{{cannot assign value of type 'UnsafeMutablePointer<Float>' to type 'UnsafeRawPointer'}}

--- a/test/Parse/pointer_conversion_objc.swift.gyb
+++ b/test/Parse/pointer_conversion_objc.swift.gyb
@@ -70,5 +70,5 @@ func autoreleasingPointerArguments(p: UnsafeMutablePointer<Int>,
   takesAutoreleasingPointer(&cc) // expected-error{{cannot convert value of type '[C]' to expected argument type 'C'}}
   takesAutoreleasingPointer(&dd) // expected-error{{cannot convert value of type '[D]' to expected argument type 'C'}}
 
-  let _: AutoreleasingUnsafeMutablePointer<C> = &c // expected-error{{cannot pass immutable value as inout argument: 'c' is immutable}}
+  let _: AutoreleasingUnsafeMutablePointer<C> = &c // expected-error {{use of extraneous '&'}}
 }

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -749,7 +749,7 @@ func test23550816(ss: [String], s: String) {
 // <rdar://problem/23719432> [practicalswift] Compiler crashes on &(Int:_)
 func test23719432() {
   var x = 42
-  &(Int:x)  // expected-error {{expression type 'inout _' is ambiguous without more context}}
+  &(Int:x) // expected-error {{use of extraneous '&'}}
 }
 
 // <rdar://problem/19911096> QoI: terrible recovery when using '·' for an operator

--- a/test/TypeCoercion/overload_noncall.swift
+++ b/test/TypeCoercion/overload_noncall.swift
@@ -52,7 +52,7 @@ func test_inout() {
   x = accept_XY(&xy);
 
   x = xy
-  x = &xy; // expected-error{{cannot assign value of type 'inout X' to type 'X'}}
+  x = &xy; // expected-error {{use of extraneous '&'}}
   accept_Z(&xy); // expected-error{{cannot convert value of type 'X' to expected argument type 'Z'}}
 }
 

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -533,8 +533,8 @@ func testInOut(_ arg: inout Int) {
   takesExplicitInt(x) // expected-error{{passing value of type 'Int' to an inout parameter requires explicit '&'}} {{20-20=&}}
   takesExplicitInt(&x)
   takesInt(&x) // expected-error{{'&' used with non-inout argument of type 'Int'}}
-  var y = &x // expected-error{{expression type 'inout Int' is ambiguous without more context}}
-  var z = &arg // expected-error{{expression type 'inout Int' is ambiguous without more context}}
+  var y = &x //expected-error {{use of extraneous '&'}}
+  var z = &arg //expected-error {{use of extraneous '&'}}
 
   takesExplicitInt(5) // expected-error {{cannot pass immutable value as inout argument: literals are not mutable}}
 }
@@ -814,18 +814,16 @@ public struct TestPropMethodOverloadGroup {
 // <rdar://problem/18496742> Passing ternary operator expression as inout crashes Swift compiler
 func inoutTests(_ arr: inout Int) {
   var x = 1, y = 2
-  (true ? &x : &y) // expected-error {{type of expression is ambiguous without more context}}
-  let a = (true ? &x : &y) // expected-error {{type of expression is ambiguous without more context}}
+  (true ? &x : &y) // expected-error 2 {{use of extraneous '&'}}
+  let a = (true ? &x : &y) // expected-error 2 {{use of extraneous '&'}}
 
-  inoutTests(true ? &x : &y) // expected-error {{type of expression is ambiguous without more context}}
+  inoutTests(true ? &x : &y) // expected-error {{use of extraneous '&'}}
 
-  &_ // expected-error {{expression type 'inout _' is ambiguous without more context}}
+  &_ // expected-error {{use of extraneous '&'}}
 
-  // The next error is awful, but we don't want regress and let non-immediate
-  // inout usage slip through.
-  inoutTests((&x, 24).0) // expected-error {{cannot pass immutable value of type 'inout Int' as inout argument}}
+  inoutTests((&x, 24).0) // expected-error {{use of extraneous '&'}}
 
-  inoutTests((&x))   // expected-error {{'&' can only appear immediately in a call argument list}}
+  inoutTests((&x)) // expected-error {{use of extraneous '&'}}
   inoutTests(&x)
   
   // <rdar://problem/17489894> inout not rejected as operand to assignment operator
@@ -844,7 +842,7 @@ func inoutTests(_ arr: inout Int) {
 
 // <rdar://problem/20802757> Compiler crash in default argument & inout expr
 var g20802757 = 2
-func r20802757(_ z: inout Int = &g20802757) { // expected-error {{'&' can only appear immediately in a call argument list}}
+func r20802757(_ z: inout Int = &g20802757) { // expected-error {{use of extraneous '&'}}
   print(z)
 }
 

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -533,10 +533,8 @@ func testInOut(_ arg: inout Int) {
   takesExplicitInt(x) // expected-error{{passing value of type 'Int' to an inout parameter requires explicit '&'}} {{20-20=&}}
   takesExplicitInt(&x)
   takesInt(&x) // expected-error{{'&' used with non-inout argument of type 'Int'}}
-  var y = &x // expected-error{{'&' can only appear immediately in a call argument list}} \
-             // expected-error {{variable has type 'inout Int' which includes nested inout parameters}}
-  var z = &arg // expected-error{{'&' can only appear immediately in a call argument list}} \
-             // expected-error {{variable has type 'inout Int' which includes nested inout parameters}}
+  var y = &x // expected-error{{expression type 'inout Int' is ambiguous without more context}}
+  var z = &arg // expected-error{{expression type 'inout Int' is ambiguous without more context}}
 
   takesExplicitInt(5) // expected-error {{cannot pass immutable value as inout argument: literals are not mutable}}
 }
@@ -816,11 +814,10 @@ public struct TestPropMethodOverloadGroup {
 // <rdar://problem/18496742> Passing ternary operator expression as inout crashes Swift compiler
 func inoutTests(_ arr: inout Int) {
   var x = 1, y = 2
-  (true ? &x : &y)  // expected-error 2 {{'&' can only appear immediately in a call argument list}}
-  // expected-warning @-1 {{expression of type 'inout Int' is unused}}
-  let a = (true ? &x : &y)  // expected-error 2 {{'&' can only appear immediately in a call argument list}}
+  (true ? &x : &y) // expected-error {{type of expression is ambiguous without more context}}
+  let a = (true ? &x : &y) // expected-error {{type of expression is ambiguous without more context}}
 
-  inoutTests(true ? &x : &y);  // expected-error 2 {{'&' can only appear immediately in a call argument list}}
+  inoutTests(true ? &x : &y) // expected-error {{type of expression is ambiguous without more context}}
 
   &_ // expected-error {{expression type 'inout _' is ambiguous without more context}}
 

--- a/validation-test/compiler_crashers_fixed/28628-gettype-e-isassignabletype-setting-access-kind-on-non-l-value.swift
+++ b/validation-test/compiler_crashers_fixed/28628-gettype-e-isassignabletype-setting-access-kind-on-non-l-value.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
+// RUN: not %target-swift-frontend %s -emit-ir
+
 &(_=nil?=nil

--- a/validation-test/compiler_crashers_fixed/28834-t-isnull-t-is-inouttype.swift
+++ b/validation-test/compiler_crashers_fixed/28834-t-isnull-t-is-inouttype.swift
@@ -5,7 +5,7 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+
+// RUN: not %target-swift-frontend %s -emit-ir
 switch
 &_{case.o


### PR DESCRIPTION
This is a followup to #15580 and #15574, where @CodaFi pointed out that @slavapestov added TVO_CanBindToInOut to the callers of createTypeVariable out of an "abundance of caution". This pull request removes all-but-one of the remaining uses of TVO_CanBindToInOut.

For the record and unlike #15580, there is a small cost to diagnostic quality in this pull request, but if the goal is to remove `InOutType`, then I imagine that some amount of diagnostic churn is expected and tolerable.