### PR TITLE
[TypeReconstruction] Don't silently swallow invalid mangled names.

### DIFF
--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -2168,6 +2168,7 @@ static void VisitNodeGlobal(ASTContext *ast, Demangle::NodePointer cur_node,
 
     switch (childKind) {
     case Demangle::Node::Kind::Identifier:
+      result._error = "invalid global node";
       break;
     default:
       VisitNode(ast, *child_pos, result);

--- a/test/DebugInfo/Inputs/type-reconstr-names.txt
+++ b/test/DebugInfo/Inputs/type-reconstr-names.txt
@@ -2,4 +2,4 @@ $S4blah4mainyyF ---> () -> ()
 $SytD ---> ()
 $Ss5Int32VD ---> Int32
 $S4blah4mainyyF8PatatinoL_VMa ---> Can't resolve type of $S4blah4mainyyF8PatatinoL_VMa
-$Ss10CollectionP7Element ---> Collection
+$Ss10CollectionP7Element ---> Can't resolve type of $Ss10CollectionP7Element


### PR DESCRIPTION
The mangler had a bug when mangling associated types so we got
an invalid input. Instead of ignoring the fact it's invalid,
throw an error.