### PR TITLE
[+0-all-args] Mark the storage parameter to _adoptStorage as a +1 par…

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1177,7 +1177,7 @@ extension ${Self} : RangeReplaceableCollection, ArrayProtocol {
   @_versioned
   @_semantics("array.uninitialized")
   internal static func _adoptStorage(
-    _ storage: _ContiguousArrayStorage<Element>, count: Int
+    _ storage: __owned _ContiguousArrayStorage<Element>, count: Int
   ) -> (Array, UnsafeMutablePointer<Element>) {
 
     let innerBuffer = _ContiguousArrayBuffer<Element>(

--- a/test/SILOptimizer/optionset.swift
+++ b/test/SILOptimizer/optionset.swift
@@ -2,8 +2,6 @@
 // RUN: %target-swift-frontend  -parse-as-library -primary-file %s -Osize -sil-verify-all -module-name=test -emit-sil | %FileCheck %s
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 
-// XFAIL: plus_zero_runtime
-
 public struct TestOptions: OptionSet {
     public let rawValue: Int
     public init(rawValue: Int) { self.rawValue = rawValue }


### PR DESCRIPTION
…ameter.

This fixes the optionset test with +0 enabled. It is now re-enabled.

rdar://38152291
(cherry picked from commit a1089a2923bf5501ddb629ac8026e6be7c4107da)
