### PR TITLE
[sourcekit] Add optional compile notifications

### DIFF
--- a/test/SourceKit/CompileNotifications/args.swift
+++ b/test/SourceKit/CompileNotifications/args.swift
@@ -1,0 +1,17 @@
+// RUN: %sourcekitd-test -req=track-compiles == -req=sema %s -- %s | %FileCheck %s -check-prefix=ARGS1
+// ARGS1: {
+// ARGS1:  key.notification: source.notification.compile-will-start
+// ARGS1:  key.filepath: "[[PATH:.*]]"
+// ARGS1:  key.compilerargs: [
+// ARGS1-NEXT:    [[PATH]]
+// ARGS1-NEXT:  ]
+
+// RUN: %sourcekitd-test -req=track-compiles == -req=sema %s -- %s -j 1000 | %FileCheck %s -check-prefix=ARGS2
+// ARGS2: {
+// ARGS2:  key.notification: source.notification.compile-will-start
+// ARGS2:  key.filepath: "[[PATH:.*]]"
+// ARGS2:  key.compilerargs: [
+// ARGS2-NEXT:    [[PATH]]
+// ARGS2-NEXT:    "-j"
+// ARGS2-NEXT:    "1000"
+// ARGS2-NEXT:  ]

--- a/test/SourceKit/CompileNotifications/code-completion.swift
+++ b/test/SourceKit/CompileNotifications/code-completion.swift
@@ -1,0 +1,12 @@
+// RUN: %sourcekitd-test -req=track-compiles == -req=complete %s -offset=0 -- %s | %FileCheck %s -check-prefix=COMPILE_1
+// COMPILE_1: {
+// COMPILE_1:  key.notification: source.notification.compile-will-start,
+// COMPILE_1:  key.filepath: "SOURCE_DIR{{.*}}code-completion.swift",
+// COMPILE_1:  key.compileid: [[CID1:".*"]]
+// COMPILE_1: }
+// COMPILE_1: {
+// COMPILE_1:   key.notification: source.notification.compile-did-finish,
+// COMPILE_1:   key.compileid: [[CID1]]
+// COMPILE_1: }
+// COMPILE_1-NOT: compile-will-start
+// COMPILE_1-NOT: compile-did-finish

--- a/test/SourceKit/CompileNotifications/cursor-info.swift
+++ b/test/SourceKit/CompileNotifications/cursor-info.swift
@@ -1,0 +1,12 @@
+// RUN: %sourcekitd-test -req=track-compiles == -req=cursor %s -offset=0 -- %s | %FileCheck %s -check-prefix=COMPILE_1
+// COMPILE_1: {
+// COMPILE_1:  key.notification: source.notification.compile-will-start,
+// COMPILE_1:  key.filepath: "SOURCE_DIR{{.*}}cursor-info.swift",
+// COMPILE_1:  key.compileid: [[CID1:".*"]]
+// COMPILE_1: }
+// COMPILE_1: {
+// COMPILE_1:   key.notification: source.notification.compile-did-finish,
+// COMPILE_1:   key.compileid: [[CID1]]
+// COMPILE_1: }
+// COMPILE_1-NOT: compile-will-start
+// COMPILE_1-NOT: compile-did-finish

--- a/test/SourceKit/CompileNotifications/edits.swift
+++ b/test/SourceKit/CompileNotifications/edits.swift
@@ -1,0 +1,44 @@
+// RUN: %sourcekitd-test -req=track-compiles \
+// RUN:     == -req=sema %s -- %s \
+// RUN:     == -req=edit %s -replace="" | %FileCheck %s -check-prefix=COMPILE_1
+// COMPILE_1: {
+// COMPILE_1:  key.notification: source.notification.compile-will-start,
+// COMPILE_1:  key.compileid: [[CID1:".*"]]
+// COMPILE_1: }
+// COMPILE_1: {
+// COMPILE_1:   key.notification: source.notification.compile-did-finish,
+// COMPILE_1:   key.compileid: [[CID1]]
+// COMPILE_1: }
+// COMPILE_1-NOT: compile-will-start
+// COMPILE_1-NOT: compile-did-finish
+
+// RUN: %sourcekitd-test -req=track-compiles \
+// RUN:     == -req=sema %s -- %s \
+// RUN:     == -req=edit %s -replace="asdf" \
+// RUN:     == -req=edit %s -replace="//" | %FileCheck %s -check-prefix=COMPILE_3
+// COMPILE_3: {
+// COMPILE_3:  key.notification: source.notification.compile-will-start,
+// COMPILE_3:  key.compileid: [[CID1:".*"]]
+// COMPILE_3: }
+// COMPILE_3: {
+// COMPILE_3:   key.notification: source.notification.compile-did-finish,
+// COMPILE_3:   key.compileid: [[CID1]]
+// COMPILE_3: }
+// COMPILE_3: {
+// COMPILE_3:  key.notification: source.notification.compile-will-start,
+// COMPILE_3:  key.compileid: [[CID2:".*"]]
+// COMPILE_3: }
+// COMPILE_3: {
+// COMPILE_3:   key.notification: source.notification.compile-did-finish,
+// COMPILE_3:   key.compileid: [[CID2]]
+// COMPILE_3: }
+// COMPILE_3: {
+// COMPILE_3:  key.notification: source.notification.compile-will-start,
+// COMPILE_3:  key.compileid: [[CID3:".*"]]
+// COMPILE_3: }
+// COMPILE_3: {
+// COMPILE_3:   key.notification: source.notification.compile-did-finish,
+// COMPILE_3:   key.compileid: [[CID3]]
+// COMPILE_3: }
+// COMPILE_3-NOT: compile-will-start
+// COMPILE_3-NOT: compile-did-finish

--- a/test/SourceKit/CompileNotifications/enable-disable.swift
+++ b/test/SourceKit/CompileNotifications/enable-disable.swift
@@ -1,0 +1,28 @@
+// RUN: %sourcekitd-test -req=sema %s -- %s | %FileCheck %s -check-prefix=NONE
+// RUN: %sourcekitd-test -req=track-compiles == -req=version | %FileCheck %s -check-prefix=NONE
+// RUN: %sourcekitd-test -req=track-compiles -req-opts=value=0 \
+// RUN:     == -req=sema %s -- %s | %FileCheck %s -check-prefix=NONE
+// NONE-NOT: compile-will-start
+// NONE-NOT: compile-did-finish
+
+
+// RUN: %sourcekitd-test -req=track-compiles == -req=sema %s -- %s | %FileCheck %s -check-prefix=COMPILE_1
+// RUN: %sourcekitd-test -req=track-compiles == -req=track-compiles == -req=sema %s -- %s | %FileCheck %s -check-prefix=COMPILE_1
+// RUN: %sourcekitd-test -req=track-compiles \
+// RUN:     == -req=sema %s -- %s \
+// RUN:     == -req=track-compiles -req-opts=value=0 \
+// RUN:     == -req=edit %s -replace="//" | %FileCheck %s -check-prefix=COMPILE_1
+// RUN: %sourcekitd-test -req=sema %s -- %s \
+// RUN:     == -req=track-compiles -req-opts=value=1 \
+// RUN:     == -req=edit %s -replace="//" | %FileCheck %s -check-prefix=COMPILE_1
+// COMPILE_1: {
+// COMPILE_1:  key.notification: source.notification.compile-will-start,
+// COMPILE_1:  key.filepath: "SOURCE_DIR{{.*}}enable-disable.swift",
+// COMPILE_1:  key.compileid: [[CID1:".*"]]
+// COMPILE_1: }
+// COMPILE_1: {
+// COMPILE_1:   key.notification: source.notification.compile-did-finish,
+// COMPILE_1:   key.compileid: [[CID1]]
+// COMPILE_1: }
+// COMPILE_1-NOT: compile-will-start
+// COMPILE_1-NOT: compile-did-finish

--- a/tools/SourceKit/include/SourceKit/Support/Tracing.h
+++ b/tools/SourceKit/include/SourceKit/Support/Tracing.h
@@ -97,10 +97,11 @@ void registerConsumer(TraceConsumer *Consumer);
 
 // Class that utilizes the RAII idiom for the operations being traced
 class TracedOperation final {
+  OperationKind OpKind;
   llvm::Optional<uint64_t> OpId;
 
 public:
-  TracedOperation() {}
+  TracedOperation(OperationKind OpKind) : OpKind(OpKind) {}
   ~TracedOperation() {
     finish();
   }
@@ -110,10 +111,9 @@ public:
   TracedOperation(const TracedOperation &) = delete;
   TracedOperation &operator=(const TracedOperation &) = delete;
 
-  void start(OperationKind OpKind,
-             const SwiftInvocation &Inv,
+  void start(const SwiftInvocation &Inv,
              const StringPairs &OpArgs = StringPairs()) {
-    finish();
+    assert(!OpId.hasValue());
     OpId = startOperation(OpKind, Inv, OpArgs);
   }
 

--- a/tools/SourceKit/lib/Support/Tracing.cpp
+++ b/tools/SourceKit/lib/Support/Tracing.cpp
@@ -14,79 +14,75 @@
 
 #include "swift/Frontend/Frontend.h"
 
+#include "llvm/Support/Mutex.h"
 #include "llvm/Support/YAMLTraits.h"
 
 using namespace SourceKit;
 using namespace llvm;
+using swift::OptionSet;
 
-
-
-//===----------------------------------------------------------------------===//
-// General
-//===----------------------------------------------------------------------===//
-
-static std::atomic<bool> tracing_enabled(false);
-static std::atomic<uint64_t> operation_id(0);
-
-//===----------------------------------------------------------------------===//
-// Consumers
-//===----------------------------------------------------------------------===//
-struct TraceConsumerListNode {
-  trace::TraceConsumer *const Consumer;
-  TraceConsumerListNode *Next;
-};
-static std::atomic<TraceConsumerListNode *> consumers(nullptr);
-
+static llvm::sys::Mutex consumersLock;
+// Must hold consumersLock to access.
+static std::vector<trace::TraceConsumer *> consumers;
+// Must hold consumersLock to modify, but can be read any time.
+static std::atomic<uint64_t> tracedOperations;
 
 //===----------------------------------------------------------------------===//
 // Trace commands
 //===----------------------------------------------------------------------===//
 
 // Is tracing enabled
-bool trace::enabled() {
-  return tracing_enabled;
-}
+bool trace::anyEnabled() { return static_cast<bool>(tracedOperations); }
 
-void trace::enable() {
-  tracing_enabled = true;
-}
-
-void trace::disable() {
-  tracing_enabled = false;
+bool trace::enabled(OperationKind op) {
+  return OptionSet<OperationKind>(tracedOperations).contains(op);
 }
 
 // Trace start of perform sema call, returns OpId
 uint64_t trace::startOperation(trace::OperationKind OpKind,
                                const trace::SwiftInvocation &Inv,
                                const trace::StringPairs &OpArgs) {
-  auto OpId = ++operation_id;
-  if (trace::enabled()) {
-    auto Node = consumers.load(std::memory_order_acquire);
-    while (Node) {
-      Node->Consumer->operationStarted(OpId, OpKind, Inv, OpArgs);
-      Node = Node->Next;
+  static std::atomic<uint64_t> operationId(0);
+  auto OpId = ++operationId;
+  if (trace::anyEnabled()) {
+    llvm::sys::ScopedLock L(consumersLock);
+    for (auto *consumer : consumers) {
+      consumer->operationStarted(OpId, OpKind, Inv, OpArgs);
     }
   }
   return OpId;
 }
 
 // Operation previously started with startXXX has finished
-void trace::operationFinished(uint64_t OpId) {
-  if (trace::enabled()) {
-    auto Node = consumers.load(std::memory_order_acquire);
-    while (Node) {
-      Node->Consumer->operationFinished(OpId);
-      Node = Node->Next;
+void trace::operationFinished(uint64_t OpId, trace::OperationKind OpKind) {
+  if (trace::anyEnabled()) {
+    llvm::sys::ScopedLock L(consumersLock);
+    for (auto *consumer : consumers) {
+      consumer->operationFinished(OpId, OpKind);
     }
   }
 }
 
+// Must be called with consumersLock held.
+static void updateTracedOperations() {
+  OptionSet<trace::OperationKind> operations;
+  for (auto *consumer : consumers) {
+    operations |= consumer->desiredOperations();
+  }
+  // It is safe to store without a compare, because writers hold consumersLock.
+  tracedOperations.store(uint64_t(operations), std::memory_order_relaxed);
+}
+
 // Register trace consumer
 void trace::registerConsumer(trace::TraceConsumer *Consumer) {
-  TraceConsumerListNode *Node = new TraceConsumerListNode {Consumer, nullptr};
-  do {
-    Node->Next = consumers.load(std::memory_order_relaxed);
-  } while (!consumers.compare_exchange_weak(Node->Next, Node,
-                                            std::memory_order_release,
-                                            std::memory_order_relaxed));
+  llvm::sys::ScopedLock L(consumersLock);
+  consumers.push_back(Consumer);
+  updateTracedOperations();
+}
+
+void trace::unregisterConsumer(trace::TraceConsumer *Consumer) {
+  llvm::sys::ScopedLock L(consumersLock);
+  consumers.erase(std::remove(consumers.begin(), consumers.end(), Consumer),
+                  consumers.end());
+  updateTracedOperations();
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -794,7 +794,7 @@ ASTUnitRef ASTProducer::createASTUnit(SwiftASTManager::Implementation &MgrImpl,
 
   trace::TracedOperation TracedOp(trace::OperationKind::PerformSema);
   trace::SwiftInvocation TraceInfo;
-  if (trace::enabled()) {
+  if (TracedOp.enabled()) {
     TraceInfo.Args.PrimaryFile = InvokRef->Impl.Opts.PrimaryFile;
     TraceInfo.Args.Args = InvokRef->Impl.Opts.Args;
   }
@@ -804,7 +804,7 @@ ASTUnitRef ASTProducer::createASTUnit(SwiftASTManager::Implementation &MgrImpl,
     if (Content.Snapshot)
       ASTRef->Impl.Snapshots.push_back(Content.Snapshot);
 
-    if (trace::enabled()) {
+    if (TracedOp.enabled()) {
       TraceInfo.addFile(Content.Buffer->getBufferIdentifier(),
                         Content.Buffer->getBuffer());
     }
@@ -828,7 +828,7 @@ ASTUnitRef ASTProducer::createASTUnit(SwiftASTManager::Implementation &MgrImpl,
     return nullptr;
   }
 
-  if (trace::enabled()) {
+  if (TracedOp.enabled()) {
     TracedOp.start(TraceInfo);
   }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -792,8 +792,8 @@ ASTUnitRef ASTProducer::createASTUnit(SwiftASTManager::Implementation &MgrImpl,
   for (auto &Content : Contents)
     Stamps.push_back(Content.Stamp);
 
+  trace::TracedOperation TracedOp(trace::OperationKind::PerformSema);
   trace::SwiftInvocation TraceInfo;
-
   if (trace::enabled()) {
     TraceInfo.Args.PrimaryFile = InvokRef->Impl.Opts.PrimaryFile;
     TraceInfo.Args.Args = InvokRef->Impl.Opts.Args;
@@ -828,9 +828,8 @@ ASTUnitRef ASTProducer::createASTUnit(SwiftASTManager::Implementation &MgrImpl,
     return nullptr;
   }
 
-  trace::TracedOperation TracedOp;
   if (trace::enabled()) {
-    TracedOp.start(trace::OperationKind::PerformSema, TraceInfo);
+    TracedOp.start(TraceInfo);
   }
 
   CloseClangModuleFiles scopedCloseFiles(

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -112,7 +112,7 @@ static bool swiftCodeCompleteImpl(SwiftLangSupport &Lang,
                                   std::string &Error) {
 
   trace::TracedOperation TracedInit(trace::OperationKind::CodeCompletionInit);
-  if (trace::enabled()) {
+  if (TracedInit.enabled()) {
     trace::SwiftInvocation SwiftArgs;
     trace::initTraceInfo(SwiftArgs,
                          UnresolvedInputFile->getBufferIdentifier(),
@@ -190,7 +190,7 @@ static bool swiftCodeCompleteImpl(SwiftLangSupport &Lang,
 
 
   trace::TracedOperation TracedOp(trace::OperationKind::CodeCompletion);
-  if (trace::enabled()) {
+  if (TracedOp.enabled()) {
     trace::SwiftInvocation SwiftArgs;
     trace::initTraceInfo(SwiftArgs, InputFile->getBufferIdentifier(), Args);
     trace::initTraceFiles(SwiftArgs, CI);

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -111,7 +111,7 @@ static bool swiftCodeCompleteImpl(SwiftLangSupport &Lang,
                                   ArrayRef<const char *> Args,
                                   std::string &Error) {
 
-  trace::TracedOperation TracedOp;
+  trace::TracedOperation TracedInit(trace::OperationKind::CodeCompletionInit);
   if (trace::enabled()) {
     trace::SwiftInvocation SwiftArgs;
     trace::initTraceInfo(SwiftArgs,
@@ -120,7 +120,7 @@ static bool swiftCodeCompleteImpl(SwiftLangSupport &Lang,
     SwiftArgs.addFile(UnresolvedInputFile->getBufferIdentifier(),
                       UnresolvedInputFile->getBuffer());
 
-    TracedOp.start(trace::OperationKind::CodeCompletionInit, SwiftArgs,
+    TracedInit.start(SwiftArgs,
                    { std::make_pair("Offset", std::to_string(Offset)),
                      std::make_pair("InputBufferSize",
                                     std::to_string(UnresolvedInputFile->getBufferSize()))});
@@ -186,8 +186,10 @@ static bool swiftCodeCompleteImpl(SwiftLangSupport &Lang,
     return true;
   }
 
-  TracedOp.finish();
+  TracedInit.finish();
 
+
+  trace::TracedOperation TracedOp(trace::OperationKind::CodeCompletion);
   if (trace::enabled()) {
     trace::SwiftInvocation SwiftArgs;
     trace::initTraceInfo(SwiftArgs, InputFile->getBufferIdentifier(), Args);
@@ -201,7 +203,7 @@ static bool swiftCodeCompleteImpl(SwiftLangSupport &Lang,
                     }
                   });
 
-    TracedOp.start(trace::OperationKind::CodeCompletion, SwiftArgs,
+    TracedOp.start(SwiftArgs,
                    {std::make_pair("OriginalOffset", std::to_string(Offset)),
                     std::make_pair("Offset",
                       std::to_string(CodeCompletionOffset))});

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -658,7 +658,7 @@ public:
     auto &P = Parser->getParser();
 
     trace::TracedOperation TracedOp(trace::OperationKind::SimpleParse);
-    if (trace::enabled()) {
+    if (TracedOp.enabled()) {
       trace::SwiftInvocation Info;
       initArgsAndPrimaryFile(Info);
       auto Text = SM.getLLVMSourceMgr().getMemoryBuffer(BufferID)->getBuffer();
@@ -957,7 +957,7 @@ public:
     unsigned BufferID = AstUnit->getPrimarySourceFile().getBufferID().getValue();
 
     trace::TracedOperation TracedOp(trace::OperationKind::AnnotAndDiag);
-    if (trace::enabled()) {
+    if (TracedOp.enabled()) {
       trace::SwiftInvocation SwiftArgs;
       SemaInfoRef->getInvocation()->raw(SwiftArgs.Args.Args,
                                         SwiftArgs.Args.PrimaryFile);
@@ -1785,7 +1785,7 @@ void SwiftEditorDocument::readSyntaxInfo(EditorConsumer &Consumer) {
   llvm::sys::ScopedLock L(Impl.AccessMtx);
 
   trace::TracedOperation TracedOp(trace::OperationKind::ReadSyntaxInfo);
-  if (trace::enabled()) {
+  if (TracedOp.enabled()) {
     trace::SwiftInvocation Info;
     Impl.buildSwiftInv(Info);
     TracedOp.start(Info);
@@ -1837,7 +1837,7 @@ void SwiftEditorDocument::readSyntaxInfo(EditorConsumer &Consumer) {
 void SwiftEditorDocument::readSemanticInfo(ImmutableTextSnapshotRef Snapshot,
                                            EditorConsumer& Consumer) {
   trace::TracedOperation TracedOp(trace::OperationKind::ReadSemanticInfo);
-  if (trace::enabled()) {
+  if (TracedOp.enabled()) {
     trace::SwiftInvocation Info;
     Impl.buildSwiftInv(Info);
     TracedOp.start(Info);
@@ -1900,7 +1900,7 @@ void SwiftEditorDocument::formatText(unsigned Line, unsigned Length,
   unsigned BufID = SyntaxInfo->getBufferID();
 
   trace::TracedOperation TracedOp(trace::OperationKind::FormatText);
-  if (trace::enabled()) {
+  if (TracedOp.enabled()) {
     trace::SwiftInvocation SwiftArgs;
     // Compiler arguments do not matter
     auto Buf = SM.getLLVMSourceMgr().getMemoryBuffer(BufID);
@@ -1950,7 +1950,7 @@ void SwiftEditorDocument::expandPlaceholder(unsigned Offset, unsigned Length,
   }
 
   trace::TracedOperation TracedOp(trace::OperationKind::ExpandPlaceholder);
-  if (trace::enabled()) {
+  if (TracedOp.enabled()) {
     trace::SwiftInvocation SwiftArgs;
     SyntaxInfo->initArgsAndPrimaryFile(SwiftArgs);
     auto Buf = SM.getLLVMSourceMgr().getMemoryBuffer(BufID);

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -708,7 +708,7 @@ void SwiftLangSupport::editorOpenInterface(EditorConsumer &Consumer,
   }
 
   trace::TracedOperation TracedOp(trace::OperationKind::OpenInterface);
-  if (trace::enabled()) {
+  if (TracedOp.enabled()) {
     trace::SwiftInvocation SwiftArgs;
     SwiftArgs.Args.Args.assign(Args.begin(), Args.end());
     // NOTE: do not use primary file
@@ -784,7 +784,7 @@ void SwiftLangSupport::editorOpenSwiftSourceInterface(StringRef Name,
     return;
   }
   trace::TracedOperation TracedOp(trace::OperationKind::OpenInterface);
-  if (trace::enabled()) {
+  if (TracedOp.enabled()) {
     trace::SwiftInvocation SwiftArgs;
     SwiftArgs.Args.Args.assign(Args.begin(), Args.end());
     // NOTE: do not use primary file
@@ -827,7 +827,7 @@ void SwiftLangSupport::editorOpenHeaderInterface(EditorConsumer &Consumer,
   }
 
   trace::TracedOperation TracedOp(trace::OperationKind::OpenHeaderInterface);
-  if (trace::enabled()) {
+  if (TracedOp.enabled()) {
     trace::SwiftInvocation SwiftArgs;
     SwiftArgs.Args.Args.assign(Args.begin(), Args.end());
     // NOTE: do not use primary file

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditorInterfaceGen.cpp
@@ -707,13 +707,13 @@ void SwiftLangSupport::editorOpenInterface(EditorConsumer &Consumer,
     return;
   }
 
-  trace::TracedOperation TracedOp;
+  trace::TracedOperation TracedOp(trace::OperationKind::OpenInterface);
   if (trace::enabled()) {
     trace::SwiftInvocation SwiftArgs;
     SwiftArgs.Args.Args.assign(Args.begin(), Args.end());
     // NOTE: do not use primary file
     // NOTE: do not use files
-    TracedOp.start(trace::OperationKind::OpenInterface, SwiftArgs,
+    TracedOp.start(SwiftArgs,
                    {std::make_pair("Name", Name),
                     std::make_pair("ModuleName", ModuleName)});
   }
@@ -783,13 +783,13 @@ void SwiftLangSupport::editorOpenSwiftSourceInterface(StringRef Name,
     Consumer->handleRequestError(Error.c_str());
     return;
   }
-  trace::TracedOperation TracedOp;
+  trace::TracedOperation TracedOp(trace::OperationKind::OpenInterface);
   if (trace::enabled()) {
     trace::SwiftInvocation SwiftArgs;
     SwiftArgs.Args.Args.assign(Args.begin(), Args.end());
     // NOTE: do not use primary file
     // NOTE: do not use files
-    TracedOp.start(trace::OperationKind::OpenInterface, SwiftArgs,
+    TracedOp.start(SwiftArgs,
                    {std::make_pair("Name", Name),
                      std::make_pair("SourceName", SourceName)});
   }
@@ -826,13 +826,13 @@ void SwiftLangSupport::editorOpenHeaderInterface(EditorConsumer &Consumer,
     return;
   }
 
-  trace::TracedOperation TracedOp;
+  trace::TracedOperation TracedOp(trace::OperationKind::OpenHeaderInterface);
   if (trace::enabled()) {
     trace::SwiftInvocation SwiftArgs;
     SwiftArgs.Args.Args.assign(Args.begin(), Args.end());
     // NOTE: do not use primary file
     // NOTE: do not use files
-    TracedOp.start(trace::OperationKind::OpenHeaderInterface, SwiftArgs,
+    TracedOp.start(SwiftArgs,
                    {std::make_pair("Name", Name),
                     std::make_pair("HeaderName", HeaderName)});
   }

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -159,7 +159,7 @@ static void indexModule(llvm::MemoryBuffer *Input,
                         CompilerInstance &CI,
                         ArrayRef<const char *> Args) {
   trace::TracedOperation TracedOp(trace::OperationKind::IndexModule);
-  if (trace::enabled()) {
+  if (TracedOp.enabled()) {
     trace::SwiftInvocation SwiftArgs;
     SwiftArgs.Args.Args.assign(Args.begin(), Args.end());
     SwiftArgs.Args.PrimaryFile = Input->getBufferIdentifier();
@@ -293,7 +293,7 @@ void SwiftLangSupport::indexSource(StringRef InputFile,
     return;
 
   trace::TracedOperation TracedOp(trace::OperationKind::IndexSource);
-  if (trace::enabled()) {
+  if (TracedOp.enabled()) {
     trace::SwiftInvocation SwiftArgs;
     trace::initTraceInfo(SwiftArgs, InputFile, Args);
     trace::initTraceFiles(SwiftArgs, CI);

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -158,7 +158,7 @@ static void indexModule(llvm::MemoryBuffer *Input,
                         IndexingConsumer &IdxConsumer,
                         CompilerInstance &CI,
                         ArrayRef<const char *> Args) {
-  trace::TracedOperation TracedOp;
+  trace::TracedOperation TracedOp(trace::OperationKind::IndexModule);
   if (trace::enabled()) {
     trace::SwiftInvocation SwiftArgs;
     SwiftArgs.Args.Args.assign(Args.begin(), Args.end());
@@ -167,7 +167,7 @@ static void indexModule(llvm::MemoryBuffer *Input,
     trace::StringPairs OpArgs;
     OpArgs.push_back(std::make_pair("ModuleName", ModuleName));
     OpArgs.push_back(std::make_pair("Hash", Hash));
-    TracedOp.start(trace::OperationKind::IndexModule, SwiftArgs, OpArgs);
+    TracedOp.start(SwiftArgs, OpArgs);
   }
 
   ASTContext &Ctx = CI.getASTContext();
@@ -292,12 +292,12 @@ void SwiftLangSupport::indexSource(StringRef InputFile,
   if (CI.setup(Invocation))
     return;
 
-  trace::TracedOperation TracedOp;
+  trace::TracedOperation TracedOp(trace::OperationKind::IndexSource);
   if (trace::enabled()) {
     trace::SwiftInvocation SwiftArgs;
     trace::initTraceInfo(SwiftArgs, InputFile, Args);
     trace::initTraceFiles(SwiftArgs, CI);
-    TracedOp.start(trace::OperationKind::IndexSource, SwiftArgs);
+    TracedOp.start(SwiftArgs);
   }
 
   CI.performSema();

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1230,12 +1230,12 @@ static void resolveCursor(SwiftLangSupport &Lang,
         return;
       }
 
-      trace::TracedOperation TracedOp;
+      trace::TracedOperation TracedOp(trace::OperationKind::CursorInfoForSource);
       if (trace::enabled()) {
         trace::SwiftInvocation SwiftArgs;
         ASTInvok->raw(SwiftArgs.Args.Args, SwiftArgs.Args.PrimaryFile);
         trace::initTraceFiles(SwiftArgs, CompIns);
-        TracedOp.start(trace::OperationKind::CursorInfoForSource, SwiftArgs,
+        TracedOp.start(SwiftArgs,
                        {std::make_pair("Offset", std::to_string(Offset))});
       }
 
@@ -1424,12 +1424,12 @@ static void resolveName(SwiftLangSupport &Lang, StringRef InputFile,
         return;
       }
 
-      trace::TracedOperation TracedOp;
+      trace::TracedOperation TracedOp(trace::OperationKind::CursorInfoForSource);
       if (trace::enabled()) {
         trace::SwiftInvocation SwiftArgs;
         ASTInvok->raw(SwiftArgs.Args.Args, SwiftArgs.Args.PrimaryFile);
         trace::initTraceFiles(SwiftArgs, CompIns);
-        TracedOp.start(trace::OperationKind::CursorInfoForSource, SwiftArgs,
+        TracedOp.start(SwiftArgs,
                        {std::make_pair("Offset", std::to_string(Offset))});
       }
 
@@ -1584,7 +1584,7 @@ void SwiftLangSupport::getCursorInfo(
     std::function<void(const CursorInfoData &)> Receiver) {
 
   if (auto IFaceGenRef = IFaceGenContexts.get(InputFile)) {
-    trace::TracedOperation TracedOp;
+    trace::TracedOperation TracedOp(trace::OperationKind::CursorInfoForIFaceGen);
     if (trace::enabled()) {
       trace::SwiftInvocation SwiftArgs;
       trace::initTraceInfo(SwiftArgs, InputFile, Args);
@@ -1593,8 +1593,7 @@ void SwiftLangSupport::getCursorInfo(
         std::make_pair("DocumentName", IFaceGenRef->getDocumentName()),
         std::make_pair("ModuleOrHeaderName", IFaceGenRef->getModuleOrHeaderName()),
         std::make_pair("Offset", std::to_string(Offset))};
-      TracedOp.start(trace::OperationKind::CursorInfoForIFaceGen,
-                     SwiftArgs, OpArgs);
+      TracedOp.start(SwiftArgs, OpArgs);
     }
 
     IFaceGenRef->accessASTAsync([this, IFaceGenRef, Offset, Actionables, Receiver] {
@@ -1666,7 +1665,7 @@ getNameInfo(StringRef InputFile, unsigned Offset, NameTranslatingInfo &Input,
             std::function<void(const NameTranslatingInfo &)> Receiver) {
 
   if (auto IFaceGenRef = IFaceGenContexts.get(InputFile)) {
-    trace::TracedOperation TracedOp;
+    trace::TracedOperation TracedOp(trace::OperationKind::CursorInfoForIFaceGen);
     if (trace::enabled()) {
       trace::SwiftInvocation SwiftArgs;
       trace::initTraceInfo(SwiftArgs, InputFile, Args);
@@ -1675,8 +1674,7 @@ getNameInfo(StringRef InputFile, unsigned Offset, NameTranslatingInfo &Input,
         std::make_pair("DocumentName", IFaceGenRef->getDocumentName()),
         std::make_pair("ModuleOrHeaderName", IFaceGenRef->getModuleOrHeaderName()),
         std::make_pair("Offset", std::to_string(Offset))};
-      TracedOp.start(trace::OperationKind::CursorInfoForIFaceGen,
-                     SwiftArgs, OpArgs);
+      TracedOp.start(SwiftArgs, OpArgs);
     }
 
     IFaceGenRef->accessASTAsync([IFaceGenRef, Offset, Input, Receiver] {
@@ -1762,13 +1760,12 @@ resolveCursorFromUSR(SwiftLangSupport &Lang, StringRef InputFile, StringRef USR,
       unsigned BufferID =
           AstUnit->getPrimarySourceFile().getBufferID().getValue();
 
-      trace::TracedOperation TracedOp;
+      trace::TracedOperation TracedOp(trace::OperationKind::CursorInfoForSource);
       if (trace::enabled()) {
         trace::SwiftInvocation SwiftArgs;
         ASTInvok->raw(SwiftArgs.Args.Args, SwiftArgs.Args.PrimaryFile);
         trace::initTraceFiles(SwiftArgs, CompIns);
-        TracedOp.start(trace::OperationKind::CursorInfoForSource, SwiftArgs,
-                       {std::make_pair("USR", USR)});
+        TracedOp.start(SwiftArgs, {std::make_pair("USR", USR)});
       }
 
       if (USR.startswith("c:")) {
@@ -1956,16 +1953,16 @@ void SwiftLangSupport::findRelatedIdentifiersInFile(
       auto &CompInst = AstUnit->getCompilerInstance();
       auto &SrcFile = AstUnit->getPrimarySourceFile();
 
-      trace::TracedOperation TracedOp;
 
       SmallVector<std::pair<unsigned, unsigned>, 8> Ranges;
 
       auto Action = [&]() {
+        trace::TracedOperation TracedOp(trace::OperationKind::RelatedIdents);
         if (trace::enabled()) {
           trace::SwiftInvocation SwiftArgs;
           Invok->raw(SwiftArgs.Args.Args, SwiftArgs.Args.PrimaryFile);
           trace::initTraceFiles(SwiftArgs, CompInst);
-          TracedOp.start(trace::OperationKind::RelatedIdents, SwiftArgs,
+          TracedOp.start(SwiftArgs,
                         {std::make_pair("Offset", std::to_string(Offset))});
         }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftSourceDocInfo.cpp
@@ -1231,7 +1231,7 @@ static void resolveCursor(SwiftLangSupport &Lang,
       }
 
       trace::TracedOperation TracedOp(trace::OperationKind::CursorInfoForSource);
-      if (trace::enabled()) {
+      if (TracedOp.enabled()) {
         trace::SwiftInvocation SwiftArgs;
         ASTInvok->raw(SwiftArgs.Args.Args, SwiftArgs.Args.PrimaryFile);
         trace::initTraceFiles(SwiftArgs, CompIns);
@@ -1425,7 +1425,7 @@ static void resolveName(SwiftLangSupport &Lang, StringRef InputFile,
       }
 
       trace::TracedOperation TracedOp(trace::OperationKind::CursorInfoForSource);
-      if (trace::enabled()) {
+      if (TracedOp.enabled()) {
         trace::SwiftInvocation SwiftArgs;
         ASTInvok->raw(SwiftArgs.Args.Args, SwiftArgs.Args.PrimaryFile);
         trace::initTraceFiles(SwiftArgs, CompIns);
@@ -1508,9 +1508,7 @@ static void resolveRange(SwiftLangSupport &Lang,
       Receiver(std::move(Receiver)){ }
 
     void handlePrimaryAST(ASTUnitRef AstUnit) override {
-      if (trace::enabled()) {
-        // FIXME: Implement tracing
-      }
+      // FIXME: Implement tracing
       RangeResolver Resolver(AstUnit->getPrimarySourceFile(), Offset, Length);
       ResolvedRangeInfo Info = Resolver.resolve();
 
@@ -1585,7 +1583,7 @@ void SwiftLangSupport::getCursorInfo(
 
   if (auto IFaceGenRef = IFaceGenContexts.get(InputFile)) {
     trace::TracedOperation TracedOp(trace::OperationKind::CursorInfoForIFaceGen);
-    if (trace::enabled()) {
+    if (TracedOp.enabled()) {
       trace::SwiftInvocation SwiftArgs;
       trace::initTraceInfo(SwiftArgs, InputFile, Args);
       // Do we need to record any files? If yes -- which ones?
@@ -1666,7 +1664,7 @@ getNameInfo(StringRef InputFile, unsigned Offset, NameTranslatingInfo &Input,
 
   if (auto IFaceGenRef = IFaceGenContexts.get(InputFile)) {
     trace::TracedOperation TracedOp(trace::OperationKind::CursorInfoForIFaceGen);
-    if (trace::enabled()) {
+    if (TracedOp.enabled()) {
       trace::SwiftInvocation SwiftArgs;
       trace::initTraceInfo(SwiftArgs, InputFile, Args);
       // Do we need to record any files? If yes -- which ones?
@@ -1761,7 +1759,7 @@ resolveCursorFromUSR(SwiftLangSupport &Lang, StringRef InputFile, StringRef USR,
           AstUnit->getPrimarySourceFile().getBufferID().getValue();
 
       trace::TracedOperation TracedOp(trace::OperationKind::CursorInfoForSource);
-      if (trace::enabled()) {
+      if (TracedOp.enabled()) {
         trace::SwiftInvocation SwiftArgs;
         ASTInvok->raw(SwiftArgs.Args.Args, SwiftArgs.Args.PrimaryFile);
         trace::initTraceFiles(SwiftArgs, CompIns);
@@ -1958,7 +1956,7 @@ void SwiftLangSupport::findRelatedIdentifiersInFile(
 
       auto Action = [&]() {
         trace::TracedOperation TracedOp(trace::OperationKind::RelatedIdents);
-        if (trace::enabled()) {
+        if (TracedOp.enabled()) {
           trace::SwiftInvocation SwiftArgs;
           Invok->raw(SwiftArgs.Args.Args, SwiftArgs.Args.PrimaryFile);
           trace::initTraceFiles(SwiftArgs, CompInst);

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.cpp
@@ -148,16 +148,19 @@ bool TestOptions::parseArgs(llvm::ArrayRef<const char *> Args) {
         .Case("localize-string", SourceKitRequest::LocalizeString)
         .Case("markup-xml", SourceKitRequest::MarkupToXML)
         .Case("stats", SourceKitRequest::Statistics)
+        .Case("track-compiles", SourceKitRequest::EnableCompileNotifications)
         .Default(SourceKitRequest::None);
 
       if (Request == SourceKitRequest::None) {
-        llvm::errs() << "error: invalid request, expected one of "
+        llvm::errs() << "error: invalid request '" << InputArg->getValue()
+            << "'\nexpected one of "
             << "version/demangle/mangle/index/complete/complete.open/complete.cursor/"
                "complete.update/complete.cache.ondisk/complete.cache.setpopularapi/"
                "cursor/related-idents/syntax-map/structure/format/expand-placeholder/"
                "doc-info/sema/interface-gen/interface-gen-openfind-usr/find-interface/"
                "open/close/edit/print-annotations/print-diags/extract-comment/module-groups/"
-               "range/syntactic-rename/find-rename-ranges/translate/markup-xml/stats\n";
+               "range/syntactic-rename/find-rename-ranges/translate/markup-xml/stats/"
+               "track-compiles\n";
         return true;
       }
       break;

--- a/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
+++ b/tools/SourceKit/tools/sourcekitd-test/TestOptions.h
@@ -58,6 +58,7 @@ enum class SourceKitRequest {
   MarkupToXML,
   Statistics,
   SyntaxTree,
+  EnableCompileNotifications,
 #define SEMANTIC_REFACTORING(KIND, NAME, ID) KIND,
 #include "swift/IDE/RefactoringKinds.def"
 };

--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/XPCService.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/XPCService.cpp
@@ -291,7 +291,7 @@ static void getInitializationInfo(xpc_connection_t peer) {
   }
 
   if (TracingEnabled) {
-    SourceKit::trace::enable();
+    sourcekitd::trace::enableXPCTracing();
   }
 }
 
@@ -333,7 +333,6 @@ int main(int argc, const char *argv[]) {
   llvm::install_fatal_error_handler(fatal_error_handler, 0);
   sourcekitd::enableLogging("sourcekit-serv");
   sourcekitd::initialize();
-  sourcekitd::trace::initialize();
 
   // Increase the file descriptor limit.
   // FIXME: Portability ?
@@ -374,14 +373,9 @@ void SKUIDToUIDMap::set(sourcekitd_uid_t SKDUID, UIdent UID) {
 }
 
 void sourcekitd::trace::sendTraceMessage(trace::sourcekitd_trace_message_t Msg) {
-  if (!SourceKit::trace::enabled()) {
-    xpc_release(Msg);
-    return;
-  }
-
   xpc_connection_t Peer = MainConnection;
   if (!Peer) {
-    SourceKit::trace::disable();
+    trace::disableXPCTracing();
     xpc_release(Msg);
     return;
   }
@@ -403,7 +397,7 @@ void sourcekitd::trace::sendTraceMessage(trace::sourcekitd_trace_message_t Msg) 
   xpc_release(Message);
 
   if (xpc_get_type(Reply) == XPC_TYPE_ERROR) {
-    SourceKit::trace::disable();
+    trace::disableXPCTracing();
     xpc_release(Reply);
     return;
   }

--- a/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/XpcTracing.cpp
+++ b/tools/SourceKit/tools/sourcekitd/bin/XPC/Service/XpcTracing.cpp
@@ -92,13 +92,13 @@ class XpcTraceConsumer : public SourceKit::trace::TraceConsumer {
 public:
   virtual ~XpcTraceConsumer() = default;
 
-  // Operation previously started with startXXX has finished
-  virtual void operationFinished(uint64_t OpId) override;
-
   // Trace start of SourceKit operation
-  virtual void operationStarted(uint64_t OpId, OperationKind OpKind,
-                                const SwiftInvocation &Inv,
-                                const StringPairs &OpArgs) override;
+  void operationStarted(uint64_t OpId, OperationKind OpKind,
+                        const SwiftInvocation &Inv,
+                        const StringPairs &OpArgs) override;
+
+  // Operation previously started with startXXX has finished
+  void operationFinished(uint64_t OpId, OperationKind OpKind) override;
 };
 
 // Trace start of SourceKit operation
@@ -117,7 +117,7 @@ void XpcTraceConsumer::operationStarted(uint64_t OpId,
 }
 
 // Operation previously started with startXXX has finished
-void XpcTraceConsumer::operationFinished(uint64_t OpId) {
+void XpcTraceConsumer::operationFinished(uint64_t OpId, OperationKind OpKind) {
   xpc_object_t Contents = xpc_array_create(nullptr, 0);
   append(Contents, trace::ActionKind::OperationFinished);
   append(Contents, OpId);
@@ -126,7 +126,10 @@ void XpcTraceConsumer::operationFinished(uint64_t OpId) {
 
 static XpcTraceConsumer Instance;
 
-void trace::initialize() {
+void trace::enableXPCTracing() {
   SourceKit::trace::registerConsumer(&Instance);
 }
 
+void trace::disableXPCTracing() {
+  SourceKit::trace::unregisterConsumer(&Instance);
+}

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/Internal.h
@@ -77,8 +77,10 @@ public:
     void set(SourceKit::UIdent Key, sourcekitd_uid_t UID);
     void set(SourceKit::UIdent Key, const char *Str);
     void set(SourceKit::UIdent Key, llvm::StringRef Str);
+    void set(SourceKit::UIdent Key, const std::string &Str);
     void set(SourceKit::UIdent Key, int64_t val);
     void set(SourceKit::UIdent Key, llvm::ArrayRef<llvm::StringRef> Strs);
+    void set(SourceKit::UIdent Key, llvm::ArrayRef<std::string> Strs);
     void setBool(SourceKit::UIdent Key, bool val);
     Array setArray(SourceKit::UIdent Key);
     Dictionary setDictionary(SourceKit::UIdent Key);

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/XpcTracing.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/XpcTracing.h
@@ -34,7 +34,8 @@ void sendTraceMessage(sourcekitd_trace_message_t Msg);
 
 uint64_t getTracingSession();
 
-void initialize();
+void enableXPCTracing();
+void disableXPCTracing();
 
 } // namespace sourcekitd
 } // namespace trace

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-InProc.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-InProc.cpp
@@ -626,6 +626,11 @@ void ResponseBuilder::Dictionary::set(UIdent Key, StringRef Str) {
                                       new SKDString(Str));
 }
 
+void ResponseBuilder::Dictionary::set(UIdent Key, const std::string &Str) {
+  static_cast<SKDObject *>(Impl)->set(SKDUIDFromUIdent(Key),
+                                      new SKDString(std::string(Str)));
+}
+
 void ResponseBuilder::Dictionary::set(UIdent Key, int64_t Val) {
   static_cast<SKDObject *>(Impl)->set(SKDUIDFromUIdent(Key), new SKDInt64(Val));
 }
@@ -635,6 +640,15 @@ void ResponseBuilder::Dictionary::set(SourceKit::UIdent Key,
   auto ArrayObject = new SKDArray();
   for (auto Str : Strs) {
     ArrayObject->set(SOURCEKITD_ARRAY_APPEND, new SKDString(Str));
+  }
+  static_cast<SKDObject *>(Impl)->set(SKDUIDFromUIdent(Key), ArrayObject);
+}
+
+void ResponseBuilder::Dictionary::set(SourceKit::UIdent Key,
+                                      ArrayRef<std::string> Strs) {
+  auto ArrayObject = new SKDArray();
+  for (auto Str : Strs) {
+    ArrayObject->set(SOURCEKITD_ARRAY_APPEND, new SKDString(std::string(Str)));
   }
   static_cast<SKDObject *>(Impl)->set(SKDUIDFromUIdent(Key), ArrayObject);
 }

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
@@ -204,6 +204,10 @@ void ResponseBuilder::Dictionary::set(UIdent Key, llvm::StringRef Str) {
   xpc_dictionary_set_string(Impl, Key.c_str(), Buf.c_str());
 }
 
+void ResponseBuilder::Dictionary::set(UIdent Key, const std::string &Str) {
+  xpc_dictionary_set_string(Impl, Key.c_str(), Str.c_str());
+}
+
 void ResponseBuilder::Dictionary::set(UIdent Key, int64_t val) {
   xpc_dictionary_set_int64(Impl, Key.c_str(), val);
 }
@@ -215,6 +219,16 @@ void ResponseBuilder::Dictionary::set(SourceKit::UIdent Key,
   for (auto Str : Strs) {
     Buf = Str;
     xpc_array_set_string(arr, XPC_ARRAY_APPEND, Buf.c_str());
+  }
+  xpc_dictionary_set_value(Impl, Key.c_str(), arr);
+  xpc_release(arr);
+}
+
+void ResponseBuilder::Dictionary::set(SourceKit::UIdent Key,
+                                      ArrayRef<std::string> Strs) {
+  xpc_object_t arr = xpc_array_create(nullptr, 0);
+  for (auto Str : Strs) {
+    xpc_array_set_string(arr, XPC_ARRAY_APPEND, Str.c_str());
   }
   xpc_dictionary_set_value(Impl, Key.c_str(), arr);
   xpc_release(arr);

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -154,6 +154,7 @@ UID_KEYS = [
     KEY('RetrieveRefactorActions', 'key.retrieve_refactor_actions'),
     KEY('ActionUID', 'key.actionuid'),
     KEY('ActionUnavailableReason', 'key.actionunavailablereason'),
+    KEY('CompileID', 'key.compileid'),
 ]
 
 
@@ -204,6 +205,8 @@ UID_REQUESTS = [
     REQUEST('FindLocalRenameRanges',
             'source.request.find-local-rename-ranges'),
     REQUEST('SemanticRefactoring', 'source.request.semantic.refactoring'),
+    REQUEST('EnableCompileNotifications',
+            'source.request.enable-compile-notifications'),
 ]
 
 


### PR DESCRIPTION
When enabled, send a notification before/after every "compilation", which for now means `performSema`. This piggy-backs and modifies some existing code that we had for "tracing" operations in sourcekitd that unfortunately was untested.  At least now some of the basic parts are tested via the new notifications.
    
Part of rdar://38438512