### PR TITLE
[Batch mode] Merge pull request #15578 from davidungar/PR-19-warn-WMO-batch

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -141,6 +141,9 @@ WARNING(warn_opt_remark_disabled, none,
         "requires a single compiler invocation: consider enabling the "
         "-whole-module-optimization flag", ())
 
+WARNING(warn_ignoring_batch_mode,none,
+"ignoring '-enable-batch-mode' because '%0' was also specified", (StringRef))
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -237,6 +237,8 @@ public:
   ///
   /// \param TC The current tool chain.
   /// \param Args The input arguments.
+  /// \param BatchMode Whether the driver has been explicitly or implicitly
+  /// instructed to use batch mode.
   /// \param Inputs The inputs to the driver.
   /// \param[out] OI The OutputInfo in which to store the resulting output
   /// information.
@@ -382,6 +384,13 @@ private:
   /// \param Args The arguments passed to the driver (excluding the path to the
   /// driver)
   void parseDriverKind(ArrayRef<const char *> Args);
+
+  /// Examine potentially conficting arguments and warn the user if
+  /// there is an actual conflict.
+  /// \param Args The input arguments.
+  /// \param Inputs The inputs to the driver.
+  OutputInfo::Mode computeCompilerMode(const llvm::opt::DerivedArgList &Args,
+                                       const InputFileList &Inputs) const;
 };
 
 } // end namespace driver

--- a/test/Driver/batch_mode_with_WMO_or_index.swift
+++ b/test/Driver/batch_mode_with_WMO_or_index.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+//
+// RUN: %swiftc_driver -whole-module-optimization -enable-batch-mode  %S/../Inputs/empty.swift -### 2>%t/stderr_WMO_batch | %FileCheck %s
+// RUN: %swiftc_driver -enable-batch-mode -whole-module-optimization  %S/../Inputs/empty.swift -### 2>%t/stderr_batch_WMO | %FileCheck %s
+// CHECK-NOT: -primary-file
+// RUN: %FileCheck -check-prefix CHECK-WMO %s <%t/stderr_WMO_batch
+// RUN: %FileCheck -check-prefix CHECK-WMO %s <%t/stderr_batch_WMO
+// CHECK-WMO: warning: ignoring '-enable-batch-mode' because '-whole-module-optimization' was also specified
+//
+// RUN: %swiftc_driver -index-file -enable-batch-mode  %S/../Inputs/empty.swift -### 2>%t/stderr_index_batch | %FileCheck %s
+// RUN: %swiftc_driver -enable-batch-mode -index-file  %S/../Inputs/empty.swift -### 2>%t/stderr_batch_index | %FileCheck %s
+// RUN: %FileCheck -check-prefix CHECK-INDEX %s <%t/stderr_index_batch
+// RUN: %FileCheck -check-prefix CHECK-INDEX %s <%t/stderr_batch_index
+// CHECK-INDEX: warning: ignoring '-enable-batch-mode' because '-index-file' was also specified


### PR DESCRIPTION
[Batch mode] Warn the user if -enable-batch-mode gets overridden by -whole-module-optimization or -index-file.

<!-- What's in this pull request? -->
Explanation: Issue a warning to prevent confusion when the compiler ignores -enable-batch-mode because of either -whole-module-optimization or -index-file.
Scope of Issue: Users trying out batch mode will think it does no good because the compiler silently ignores their requests.
Origination: Issue has existed since we implemented batch mode.
Risk: Minimal, because only functional change is a warning. There is a tiny bit of refactoring, which has been carefully reviewed.
Reviewed by: Jordan Rose & Graydon Hoare.
Testing: Normal regression tests + this PR includes a new test of the new functionality
Radar: rdar://39012584

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->



<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
