### PR TITLE
[SILGen] Show a message when an unexpected enum value is switched on

### DIFF
--- a/include/swift/AST/KnownDecls.def
+++ b/include/swift/AST/KnownDecls.def
@@ -63,6 +63,8 @@ FUNC_DECL(BridgeAnyObjectToAny,
 FUNC_DECL(ConvertToAnyHashable, "_convertToAnyHashable")
 
 FUNC_DECL(DiagnoseUnexpectedNilOptional, "_diagnoseUnexpectedNilOptional")
+FUNC_DECL(DiagnoseUnexpectedEnumCase, "_diagnoseUnexpectedEnumCase")
+FUNC_DECL(DiagnoseUnexpectedEnumCaseValue, "_diagnoseUnexpectedEnumCaseValue")
 
 FUNC_DECL(GetErrorEmbeddedNSError, "_getErrorEmbeddedNSError")
 

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -22,7 +22,9 @@
 #include "swift/AST/DiagnosticsSIL.h"
 #include "swift/AST/Pattern.h"
 #include "swift/AST/SILOptions.h"
+#include "swift/AST/SubstitutionMap.h"
 #include "swift/AST/Types.h"
+#include "swift/Basic/Defer.h"
 #include "swift/Basic/ProfileCounter.h"
 #include "swift/Basic/STLExtras.h"
 #include "swift/SIL/DynamicCasts.h"
@@ -2555,19 +2557,78 @@ void SILGenFunction::usingImplicitVariablesForPattern(Pattern *pattern, CaseStmt
   variableSwapper();
 }
 
+static void emitDiagnoseOfUnexpectedEnumCaseValue(SILGenFunction &SGF,
+                                                  SILLocation loc,
+                                                  ManagedValue value,
+                                                  const EnumDecl *enumDecl) {
+  ASTContext &ctx = SGF.getASTContext();
+  auto diagnoseFailure = ctx.getDiagnoseUnexpectedEnumCaseValue(nullptr);
+  if (!diagnoseFailure) {
+    SGF.B.createBuiltinTrap(loc);
+    return;
+  }
+
+  assert(enumDecl->isObjC());
+  assert(enumDecl->hasRawType());
+  assert(value.getType().isTrivial(SGF.getModule()));
+
+  // Get the enum type as an Any.Type value.
+  CanType switchedValueSwiftType = value.getType().getSwiftRValueType();
+  SILType metatypeType = SGF.getLoweredType(
+      CanMetatypeType::get(switchedValueSwiftType,
+                           MetatypeRepresentation::Thick));
+  SILValue metatype = SGF.B.createMetatype(loc, metatypeType);
+
+  // Bitcast the enum value to its raw type. (This is only safe for @objc
+  // enums.)
+  SILType loweredRawType = SGF.getLoweredType(enumDecl->getRawType());
+  assert(loweredRawType.isTrivial(SGF.getModule()));
+  assert(loweredRawType.isObject());
+  auto rawValue = SGF.B.createUncheckedTrivialBitCast(loc, value,
+                                                      loweredRawType);
+  auto materializedRawValue = rawValue.materialize(SGF, loc);
+
+  Substitution subs[] = {
+    {switchedValueSwiftType, /*Conformances*/None},
+    {enumDecl->getRawType(), /*Conformances*/None},
+  };
+
+  SGF.emitApplyOfLibraryIntrinsic(loc, diagnoseFailure, subs,
+                                  {ManagedValue::forUnmanaged(metatype),
+                                   materializedRawValue},
+                                  SGFContext());
+}
+
+static void emitDiagnoseOfUnexpectedEnumCase(SILGenFunction &SGF,
+                                             SILLocation loc,
+                                             ManagedValue value) {
+  ASTContext &ctx = SGF.getASTContext();
+  auto diagnoseFailure = ctx.getDiagnoseUnexpectedEnumCase(nullptr);
+  if (!diagnoseFailure) {
+    SGF.B.createBuiltinTrap(loc);
+    return;
+  }
+
+  // Get the switched-upon value's type.
+  CanType switchedValueSwiftType = value.getType().getSwiftRValueType();
+  SILType metatypeType = SGF.getLoweredType(
+      CanMetatypeType::get(switchedValueSwiftType,
+                           MetatypeRepresentation::Thick));
+  ManagedValue metatype = SGF.B.createValueMetatype(loc, metatypeType, value);
+
+  Substitution sub{switchedValueSwiftType, /*Conformances*/None};
+  auto genericArgsMap =
+      diagnoseFailure->getGenericSignature()->getSubstitutionMap(sub);
+
+  SGF.emitApplyOfLibraryIntrinsic(loc, diagnoseFailure, sub,
+                                  metatype,
+                                  SGFContext());
+}
+
 void SILGenFunction::emitSwitchStmt(SwitchStmt *S) {
   DEBUG(llvm::dbgs() << "emitting switch stmt\n";
         S->print(llvm::dbgs());
         llvm::dbgs() << '\n');
-  auto failure = [this](SILLocation location) {
-    // If we fail to match anything, we trap. This can happen with a switch
-    // over an @objc enum, which may contain any value of its underlying type.
-    // FIXME: Even if we can't say what the invalid value was, we should at
-    // least mention that this was because of a non-exhaustive enum.
-    B.createBuiltinTrap(location);
-    B.createUnreachable(location);
-  };
-  
   // If the subject expression is uninhabited, we're already dead.
   // Emit an unreachable in place of the switch statement.
   if (S->getSubjectExpr()->getType()->isStructurallyUninhabited()) {
@@ -2651,10 +2712,7 @@ void SILGenFunction::emitSwitchStmt(SwitchStmt *S) {
   PatternMatchEmission emission(*this, S, completionHandler);
 
   // Add a row for each label of each case.
-  //
-  // We use std::vector because it supports emplace_back; moving a ClauseRow is
-  // expensive.
-  std::vector<ClauseRow> clauseRows;
+  SmallVector<ClauseRow, 8> clauseRows;
   clauseRows.reserve(S->getRawCases().size());
   bool hasFallthrough = false;
   for (auto caseBlock : S->getCases()) {
@@ -2694,6 +2752,27 @@ void SILGenFunction::emitSwitchStmt(SwitchStmt *S) {
   // Emit the subject value. Dispatching will consume it.
   ManagedValue subjectMV = emitRValueAsSingleValue(S->getSubjectExpr());
   auto subject = ConsumableManagedValue::forOwned(subjectMV);
+
+  auto failure = [&](SILLocation location) {
+    // If we fail to match anything, we trap. This can happen with a switch
+    // over an @objc enum, which may contain any value of its underlying type,
+    // or a switch over a non-frozen Swift enum when the user hasn't written a
+    // catch-all case.
+    SWIFT_DEFER { B.createUnreachable(location); };
+
+    // Special case: if it's a single @objc enum, we can print the raw value.
+    CanType ty = S->getSubjectExpr()->getType()->getCanonicalType();
+    if (auto *singleEnumDecl = ty->getEnumOrBoundGenericEnum()) {
+      if (singleEnumDecl->isObjC()) {
+        emitDiagnoseOfUnexpectedEnumCaseValue(*this, location,
+                                              subject.getFinalManagedValue(),
+                                              singleEnumDecl);
+        return;
+      }
+    }
+    emitDiagnoseOfUnexpectedEnumCase(*this, location,
+                                     subject.getFinalManagedValue());
+  };
 
   // Set up an initial clause matrix.
   ClauseMatrix clauses(clauseRows);

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -137,6 +137,31 @@ internal func _assertionFailure(
   Builtin.int_trap()
 }
 
+/// This function should be used only in the implementation of user-level
+/// assertions.
+///
+/// This function should not be inlined because it is cold and inlining just
+/// bloats code.
+@_versioned // FIXME(sil-serialize-all)
+@inline(never)
+internal func _assertionFailure(
+  _ prefix: StaticString, _ message: String,
+  flags: UInt32
+) -> Never {
+  prefix.withUTF8Buffer {
+    (prefix) -> Void in
+    message._withUnsafeBufferPointerToUTF8 {
+      (messageUTF8) -> Void in
+      _swift_stdlib_reportFatalError(
+        prefix.baseAddress!, CInt(prefix.count),
+        messageUTF8.baseAddress!, CInt(messageUTF8.count),
+        flags)
+    }
+  }
+
+  Builtin.int_trap()
+}
+
 /// This function should be used only in the implementation of stdlib
 /// assertions.
 ///
@@ -237,4 +262,38 @@ func _undefined<T>(
   file: StaticString = #file, line: UInt = #line
 ) -> T {
   _assertionFailure("Fatal error", message(), file: file, line: line, flags: 0)
+}
+
+/// Called when falling off the end of a switch and the type can be represented
+/// as a raw value.
+///
+/// This function should not be inlined because it is cold and inlining just
+/// bloats code. It doesn't take a source location because it's most important
+/// in release builds anyway (old apps that are run on new OSs).
+@inline(never)
+@_versioned // COMPILER_INTRINSIC
+internal func _diagnoseUnexpectedEnumCaseValue<SwitchedValue, RawValue>(
+  type: SwitchedValue.Type,
+  rawValue: RawValue
+) -> Never {
+  _assertionFailure("Fatal error",
+                    "unexpected enum case '\(type)(rawValue: \(rawValue))'",
+                    flags: _fatalErrorFlags())
+}
+
+/// Called when falling off the end of a switch and the value is not safe to
+/// print.
+///
+/// This function should not be inlined because it is cold and inlining just
+/// bloats code. It doesn't take a source location because it's most important
+/// in release builds anyway (old apps that are run on new OSs).
+@inline(never)
+@_versioned // COMPILER_INTRINSIC
+internal func _diagnoseUnexpectedEnumCase<SwitchedValue>(
+  type: SwitchedValue.Type
+) -> Never {
+  _assertionFailure(
+    "Fatal error",
+    "unexpected enum case while switching on value of type '\(type)'",
+    flags: _fatalErrorFlags())
 }

--- a/test/IRGen/objc_enum_multi_file.swift
+++ b/test/IRGen/objc_enum_multi_file.swift
@@ -34,7 +34,7 @@ func useFoo(_ x: Foo) -> Int32 {
   }
 
   // CHECK: <label>:[[DEFAULT]]
-  // CHECK-NEXT: call void @llvm.trap()
+  // CHECK: call swiftcc void @"$Ss32_diagnoseUnexpectedEnumCaseValue{{.+}}"(%swift.type* @"$S{{.+}}3FooON", %swift.opaque* noalias nocapture %{{.+}}, %swift.type* @"$Ss5Int32VN")
   // CHECK-NEXT: unreachable
 
   // CHECK: <label>:[[FINAL]]
@@ -68,7 +68,7 @@ func useBar(_ x: Bar) -> Int32 {
   }
 
   // CHECK: <label>:[[DEFAULT]]
-  // CHECK-NEXT: call void @llvm.trap()
+  // CHECK: call swiftcc void @"$Ss32_diagnoseUnexpectedEnumCaseValue{{.+}}"(%swift.type* @"$S{{.+}}3BarON", %swift.opaque* noalias nocapture %{{.+}}, %swift.type* @"$Ss5Int32VN")
   // CHECK-NEXT: unreachable
 
   // CHECK: <label>:[[FINAL]]

--- a/test/SILGen/downgrade_exhaustivity_swift3.swift
+++ b/test/SILGen/downgrade_exhaustivity_swift3.swift
@@ -18,7 +18,10 @@ func testDowngradableOmittedPatternIsUnreachable(pat : Downgradable?) {
   case .hat:
     break
   // CHECK: [[DEFAULT_CASE]]({{%.*}} : @trivial $Downgradable):
-  // CHECK-NEXT:   builtin "int_trap"()
+  // CHECK-NEXT:    [[METATYPE:%.+]] = value_metatype $@thick Downgradable.Type, {{%.*}} : $Downgradable
+  // CHECK-NEXT:    // function_ref
+  // CHECK-NEXT:    [[DIAGNOSE:%.+]] = function_ref @$Ss27_diagnoseUnexpectedEnumCase
+  // CHECK-NEXT:    = apply [[DIAGNOSE]]<Downgradable>([[METATYPE]]) : $@convention(thin) <τ_0_0> (@thick τ_0_0.Type) -> Never
   // CHECK-NEXT:   unreachable
   }
   
@@ -34,17 +37,26 @@ func testDowngradableOmittedPatternIsUnreachable(pat : Downgradable?) {
   case (.hat, .hat):
     break
   // CHECK: [[TUPLE_DEFAULT_CASE_2]]({{%.*}} : @trivial $Downgradable):
-  // CHECK-NEXT:   builtin "int_trap"()
+  // CHECK-NEXT:    [[METATYPE:%.+]] = value_metatype $@thick (Downgradable, Downgradable).Type, {{%.*}} : $(Downgradable, Downgradable)
+  // CHECK-NEXT:    // function_ref
+  // CHECK-NEXT:    [[DIAGNOSE:%.+]] = function_ref @$Ss27_diagnoseUnexpectedEnumCase
+  // CHECK-NEXT:    = apply [[DIAGNOSE]]<(Downgradable, Downgradable)>([[METATYPE]]) : $@convention(thin) <τ_0_0> (@thick τ_0_0.Type) -> Never
   // CHECK-NEXT:   unreachable
     
   // CHECK: switch_enum [[Y]] : $Downgradable, case #Downgradable.spoon!enumelt: {{bb[0-9]+}}, case #Downgradable.hat!enumelt: {{bb[0-9]+}}, default [[TUPLE_DEFAULT_CASE_3:bb[0-9]+]]
     
   // CHECK: [[TUPLE_DEFAULT_CASE_3]]({{%.*}} : @trivial $Downgradable):
-  // CHECK-NEXT:   builtin "int_trap"()
+  // CHECK-NEXT:    [[METATYPE:%.+]] = value_metatype $@thick (Downgradable, Downgradable).Type, {{%.*}} : $(Downgradable, Downgradable)
+  // CHECK-NEXT:    // function_ref
+  // CHECK-NEXT:    [[DIAGNOSE:%.+]] = function_ref @$Ss27_diagnoseUnexpectedEnumCase
+  // CHECK-NEXT:    = apply [[DIAGNOSE]]<(Downgradable, Downgradable)>([[METATYPE]]) : $@convention(thin) <τ_0_0> (@thick τ_0_0.Type) -> Never
   // CHECK-NEXT:   unreachable
     
   // CHECK: [[TUPLE_DEFAULT_CASE_1]]({{%.*}} : @trivial $Downgradable):
-  // CHECK-NEXT:   builtin "int_trap"()
+  // CHECK-NEXT:    [[METATYPE:%.+]] = value_metatype $@thick (Downgradable, Downgradable).Type, {{%.*}} : $(Downgradable, Downgradable)
+  // CHECK-NEXT:    // function_ref
+  // CHECK-NEXT:    [[DIAGNOSE:%.+]] = function_ref @$Ss27_diagnoseUnexpectedEnumCase
+  // CHECK-NEXT:    = apply [[DIAGNOSE]]<(Downgradable, Downgradable)>([[METATYPE]]) : $@convention(thin) <τ_0_0> (@thick τ_0_0.Type) -> Never
   // CHECK-NEXT:   unreachable
   }
   

--- a/test/SILGen/enum_resilience.swift
+++ b/test/SILGen/enum_resilience.swift
@@ -32,7 +32,10 @@ import resilient_enum
 // CHECK-NEXT:    dealloc_stack [[BOX]]
 // CHECK-NEXT:    br bb6
 // CHECK:       bb5:
-// CHECK-NEXT:    builtin "int_trap"()
+// CHECK-NEXT:    [[METATYPE:%.+]] = value_metatype $@thick Medium.Type, [[BOX]] : $*Medium
+// CHECK-NEXT:    // function_ref
+// CHECK-NEXT:    [[DIAGNOSE:%.+]] = function_ref @$Ss27_diagnoseUnexpectedEnumCase
+// CHECK-NEXT:    = apply [[DIAGNOSE]]<Medium>([[METATYPE]]) : $@convention(thin) <τ_0_0> (@thick τ_0_0.Type) -> Never
 // CHECK-NEXT:    unreachable
 // CHECK:       bb6:
 // CHECK-NOT:    destroy_addr %0

--- a/test/SILGen/enum_resilience_testable.swift
+++ b/test/SILGen/enum_resilience_testable.swift
@@ -38,7 +38,10 @@
 // CHECK-NEXT:    dealloc_stack [[BOX]]
 // CHECK-NEXT:    br bb6
 // CHECK:       bb5:
-// CHECK-NEXT:    builtin "int_trap"()
+// CHECK-NEXT:    [[METATYPE:%.+]] = value_metatype $@thick Medium.Type, [[BOX]] : $*Medium
+// CHECK-NEXT:    // function_ref
+// CHECK-NEXT:    [[DIAGNOSE:%.+]] = function_ref @$Ss27_diagnoseUnexpectedEnumCase
+// CHECK-NEXT:    = apply [[DIAGNOSE]]<Medium>([[METATYPE]]) : $@convention(thin) <τ_0_0> (@thick τ_0_0.Type) -> Never
 // CHECK-NEXT:    unreachable
 // CHECK:       bb6:
 // CHECK-NOT:    destroy_addr %0

--- a/validation-test/Evolution/Inputs/enum_add_cases_trap.swift
+++ b/validation-test/Evolution/Inputs/enum_add_cases_trap.swift
@@ -1,0 +1,152 @@
+public func getVersion() -> Int {
+#if BEFORE
+  return 0
+#else
+  return 1
+#endif
+}
+
+public var starfishCount: Int = 0
+
+public class Starfish {
+  public init() {
+    starfishCount += 1
+  }
+
+  deinit {
+    starfishCount -= 1
+  }
+}
+
+///////////////////////////////////////////////////////////////////////
+
+public enum AddNoPayloadToSingleton {
+  case Noses
+#if AFTER
+  case Tummies
+  case Tails
+#endif
+}
+
+public func addNoPayloadToSingletonCases() -> [AddNoPayloadToSingleton] {
+#if BEFORE
+  return [.Noses]
+#else
+  return [.Noses, .Tummies, .Tails]
+#endif
+}
+
+///////////////////////////////////////////////////////////////////////
+
+public enum AddPayloadToSingleton {
+  case Cats
+#if AFTER
+  case Horses(Starfish)
+#endif
+}
+
+public func addPayloadToSingletonCases(_ s: Starfish)
+    -> [AddPayloadToSingleton] {
+#if BEFORE
+  return [.Cats]
+#else
+  return [.Cats, .Horses(s)]
+#endif
+}
+
+///////////////////////////////////////////////////////////////////////
+
+public enum AddPayloadsToSingleton {
+  case Cats
+#if AFTER
+  case Horses(Starfish)
+  case Foxes(Starfish, Starfish)
+#endif
+}
+
+public func addPayloadsToSingletonCases(_ s: Starfish)
+    -> [AddPayloadsToSingleton] {
+#if BEFORE
+  return [.Cats]
+#else
+  return [.Cats, .Horses(s), .Foxes(s, s)]
+#endif
+}
+
+///////////////////////////////////////////////////////////////////////
+
+public enum AddNoPayloadToSinglePayload {
+  case Cats(Starfish)
+  case Noses
+#if AFTER
+  case Tummies
+#endif
+}
+
+public func addNoPayloadToSinglePayloadCases(_ s: Starfish)
+    -> [AddNoPayloadToSinglePayload] {
+#if BEFORE
+  return [.Cats(s), .Noses]
+#else
+  return [.Cats(s), .Noses, .Tummies]
+#endif
+}
+
+///////////////////////////////////////////////////////////////////////
+
+public enum AddPayloadToSinglePayload {
+  case Cats
+  case Paws(Starfish)
+#if AFTER
+  case Tails(Starfish)
+#endif
+}
+
+public func addPayloadToSinglePayloadCases(_ s: Starfish)
+    -> [AddPayloadToSinglePayload] {
+#if BEFORE
+  return [.Cats, .Paws(s)]
+#else
+  return [.Cats, .Paws(s), .Tails(s)]
+#endif
+}
+
+///////////////////////////////////////////////////////////////////////
+
+public enum AddNoPayloadToMultiPayload {
+  case Cats(Starfish)
+  case Puppies(Starfish)
+#if AFTER
+  case Lambs
+  case Piglets
+#endif
+}
+
+public func addNoPayloadToMultiPayloadCases(_ s: Starfish)
+    -> [AddNoPayloadToMultiPayload] {
+#if BEFORE
+  return [.Cats(s), .Puppies(s)]
+#else
+  return [.Cats(s), .Puppies(s), .Lambs, .Piglets]
+#endif
+}
+
+///////////////////////////////////////////////////////////////////////
+
+public enum AddPayloadToMultiPayload {
+  case Cats(Starfish)
+  case Ponies(Starfish)
+  case Pandas
+#if AFTER
+  case Piglets(Int64)
+#endif
+}
+
+public func addPayloadToMultiPayloadCases(_ s: Starfish)
+    -> [AddPayloadToMultiPayload] {
+#if BEFORE
+  return [.Cats(s), .Ponies(s), .Pandas]
+#else
+  return [.Cats(s), .Ponies(s), .Pandas, .Piglets(1234321)]
+#endif
+}

--- a/validation-test/Evolution/test_enum_add_cases_trap.swift
+++ b/validation-test/Evolution/test_enum_add_cases_trap.swift
@@ -1,0 +1,218 @@
+// RUN: %target-resilience-test
+// REQUIRES: executable_test
+
+import StdlibUnittest
+import enum_add_cases_trap
+
+
+var EnumAddCasesTest = TestSuite("EnumAddCasesTrap")
+
+extension TestSuite {
+  func testCrashOnNewLibrary(_ typeName: String, code: @escaping () -> Void) {
+    let newTest = self.test(typeName)
+    if getVersion() == 0 {
+      newTest.code(code)
+    } else {
+      newTest.crashOutputMatches("'\(typeName)'").code {
+        expectCrashLater()
+        code()
+      }
+    }
+  }
+}
+
+
+func evaluateAddNoPayloadToSingletonCases(_ e: [AddNoPayloadToSingleton]) -> [Int] {
+  return e.map {
+    switch $0 {
+    case .Noses:
+      return 0
+#if AFTER
+    default:
+      fatalError("dummy error for '\(type(of: $0))'")
+#endif
+    }
+  }
+}
+
+EnumAddCasesTest.testCrashOnNewLibrary("AddNoPayloadToSingleton") {
+  if getVersion() == 0 {
+    expectEqual([0],
+        evaluateAddNoPayloadToSingletonCases(addNoPayloadToSingletonCases()))
+  } else {
+    _ = evaluateAddNoPayloadToSingletonCases(addNoPayloadToSingletonCases())
+  }
+}
+
+///////////////////////////////////////////////////////////////////////
+
+func evaluateAddPayloadToSingletonCases(_ e: [AddPayloadToSingleton]) -> [Int] {
+  return e.map {
+    switch $0 {
+    case .Cats:
+      return 0
+#if AFTER
+    default:
+      fatalError("dummy error for '\(type(of: $0))'")
+#endif
+    }
+  }
+}
+
+EnumAddCasesTest.testCrashOnNewLibrary("AddPayloadToSingleton") {
+  do {
+    let s = Starfish()
+
+    if getVersion() == 0 {
+      expectEqual([0],
+          evaluateAddPayloadToSingletonCases(addPayloadToSingletonCases(s)))
+    } else {
+      _ = evaluateAddPayloadToSingletonCases(addPayloadToSingletonCases(s))
+    }
+  }
+
+  expectEqual(starfishCount, 0)
+}
+
+///////////////////////////////////////////////////////////////////////
+
+func evaluateAddNoPayloadToSinglePayloadCases(_ s: Starfish,
+                                            _ e: [AddNoPayloadToSinglePayload])
+    -> [Int] {
+  return e.map {
+    switch $0 {
+    case .Cats(let ss):
+      expectTrue(s === ss)
+      return 0
+    case .Noses:
+      return 1
+#if AFTER
+    default:
+      fatalError("dummy error for '\(type(of: $0))'")
+#endif
+    }
+  }
+}
+
+EnumAddCasesTest.testCrashOnNewLibrary("AddNoPayloadToSinglePayload") {
+  do {
+    let s = Starfish()
+    if getVersion() == 0 {
+      expectEqual([0, 1],
+          evaluateAddNoPayloadToSinglePayloadCases(s, addNoPayloadToSinglePayloadCases(s)))
+    } else {
+      _ = evaluateAddNoPayloadToSinglePayloadCases(s, addNoPayloadToSinglePayloadCases(s))
+    }
+  }
+  expectEqual(starfishCount, 0)
+}
+
+///////////////////////////////////////////////////////////////////////
+
+func evaluateAddPayloadToSinglePayloadCases(_ s: Starfish,
+                                            _ e: [AddPayloadToSinglePayload])
+    -> [Int] {
+  return e.map {
+    switch $0 {
+    case .Cats:
+      return 0
+    case .Paws(let ss):
+      expectTrue(s === ss)
+      return 1
+#if AFTER
+    default:
+      fatalError("dummy error for '\(type(of: $0))'")
+#endif
+    }
+  }
+}
+
+EnumAddCasesTest.testCrashOnNewLibrary("AddPayloadToSinglePayload") {
+  do {
+    let s = Starfish()
+
+    if getVersion() == 0 {
+      expectEqual([0, 1],
+          evaluateAddPayloadToSinglePayloadCases(s, addPayloadToSinglePayloadCases(s)))
+    } else {
+      _ = evaluateAddPayloadToSinglePayloadCases(s, addPayloadToSinglePayloadCases(s))
+    }
+  }
+  expectEqual(starfishCount, 0)
+}
+
+///////////////////////////////////////////////////////////////////////
+
+func evaluateAddNoPayloadToMultiPayloadCases(_ s: Starfish,
+                                            _ e: [AddNoPayloadToMultiPayload])
+    -> [Int] {
+  return e.map {
+    switch $0 {
+    case .Cats(let ss):
+      expectTrue(s === ss)
+      return 0
+    case .Puppies(let ss):
+      expectTrue(s === ss)
+      return 1
+#if AFTER
+    default:
+      fatalError("dummy error for '\(type(of: $0))'")
+#endif
+    }
+  }
+}
+
+EnumAddCasesTest.testCrashOnNewLibrary("AddNoPayloadToMultiPayload") {
+  do {
+    let s = Starfish()
+
+    if getVersion() == 0 {
+      expectEqual([0, 1],
+          evaluateAddNoPayloadToMultiPayloadCases(s, addNoPayloadToMultiPayloadCases(s)))
+    } else {
+      _ = evaluateAddNoPayloadToMultiPayloadCases(s, addNoPayloadToMultiPayloadCases(s))
+    }
+  }
+  expectEqual(starfishCount, 0)
+}
+
+
+///////////////////////////////////////////////////////////////////////
+
+func evaluateAddPayloadToMultiPayloadCases(_ s: Starfish,
+                                            _ e: [AddPayloadToMultiPayload])
+    -> [Int] {
+  return e.map {
+    switch $0 {
+    case .Cats(let ss):
+      expectTrue(s === ss)
+      return 0
+    case .Ponies(let ss):
+      expectTrue(s === ss)
+      return 1
+    case .Pandas:
+      return 2
+#if AFTER
+    default:
+      fatalError("dummy error for '\(type(of: $0))'")
+#endif
+    }
+  }
+}
+
+EnumAddCasesTest.testCrashOnNewLibrary("AddPayloadToMultiPayload") {
+  do {
+    let s = Starfish()
+
+    if getVersion() == 0 {
+      expectEqual([0, 1, 2],
+          evaluateAddPayloadToMultiPayloadCases(s, addPayloadToMultiPayloadCases(s)))
+    } else {
+      _ = evaluateAddPayloadToMultiPayloadCases(s, addPayloadToMultiPayloadCases(s))
+    }
+  }
+  expectEqual(starfishCount, 0)
+}
+
+runAllTests()
+


### PR DESCRIPTION
Builds on #14724 to emit a message instead of just trapping when a switch over a non-frozen enum ends up not matching anything. If the enum is known to be an `@objc` enum, the message is

```
unexpected enum case 'MyEnum(rawValue: -42)'
```

and if it's anything else (a Swift enum, a tuple containing enums, whatever), it's a more opaque

```
unexpected enum case while switching on value of type 'MyEnum'
```

The reason for this is to avoid calling `String(describing:)` or `String(reflecting:)` an arbitrary value when the enum might conform to CustomStringConvertible and therefore *itself* have a switch that's going to fall off the end. By handling plain `@objc` enums (using a bitcast), we've at least covered the 90% case.

rdar://problem/37728359