### PR TITLE
Add local types to SourceFile when type checking and not when parsing

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2161,10 +2161,6 @@ void Parser::setLocalDiscriminator(ValueDecl *D) {
   if (!CurLocalContext || !D->getDeclContext()->isLocalContext())
     return;
 
-  if (auto TD = dyn_cast<TypeDecl>(D))
-    if (!getScopeInfo().isInactiveConfigBlock())
-      SF.LocalTypeDecls.insert(TD);
-
   Identifier name = D->getBaseName().getIdentifier();
   unsigned discriminator = CurLocalContext->claimNextNamedDiscriminator(name);
   D->setLocalDiscriminator(discriminator);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4010,6 +4010,15 @@ public:
             .fixItReplace(VD->getNameLoc(),
                           "`" + VD->getBaseName().userFacingName().str() + "`");
       }
+
+      // Add local types to per-source file list.
+      if (auto *TD = dyn_cast<TypeDecl>(VD)) {
+        auto *DC = TD->getDeclContext();
+        if (DC->isLocalContext()) {
+          auto *SF = DC->getParentSourceFile();
+          SF->LocalTypeDecls.insert(TD);
+        }
+      }
     }
 
     if (!IsFirstPass) {

--- a/test/SILGen/local_types.swift
+++ b/test/SILGen/local_types.swift
@@ -1,10 +1,22 @@
 // RUN: %target-swift-frontend  -parse-as-library -emit-silgen -enable-sil-ownership %s -verify | %FileCheck %s
 // RUN: %target-swift-frontend  -parse-as-library -emit-ir -enable-sil-ownership %s
 
-func function() {
+func function1() {
   return
 
   class UnreachableClass {} // expected-warning {{code after 'return' will never be executed}}
 }
+
+func function2() {
+  let _ = [
+    {
+      struct S {
+        var x = 0
+      }
+    }
+  ]
+}
+
+// CHECK-LABEL: sil private [transparent] @$S11local_types9function2yyFyycfU0_1SL_V1xSivpfi : $@convention(thin) () -> Int
 
 // CHECK-LABEL: sil_vtable UnreachableClass


### PR DESCRIPTION
Otherwise we end up adding phantom declarations that
don't get erased when we backtrack.

Fixes <https://bugs.swift.org/browse/SR-7283>,
<rdar://problem/38913395>.