### PR TITLE
[IRGen] Adjust element size of offset vector to 32-bit for structs

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1706,12 +1706,12 @@ struct TargetStructMetadata : public TargetValueMetadata<Runtime> {
   // argument array.
 
   /// Get a pointer to the field offset vector, if present, or null.
-  const StoredPointer *getFieldOffsets() const {
+  const uint32_t *getFieldOffsets() const {
     auto offset = getDescription()->FieldOffsetVectorOffset;
     if (offset == 0)
       return nullptr;
     auto asWords = reinterpret_cast<const void * const*>(this);
-    return reinterpret_cast<const StoredPointer *>(asWords + offset);
+    return reinterpret_cast<const uint32_t *>(asWords + offset);
   }
 
   static constexpr int32_t getGenericArgumentOffset() {
@@ -4212,7 +4212,7 @@ void swift_initStructMetadata(StructMetadata *self,
                               StructLayoutFlags flags,
                               size_t numFields,
                               const TypeLayout * const *fieldTypes,
-                              size_t *fieldOffsets);
+                              uint32_t *fieldOffsets);
 
 /// Relocate the metadata for a class and copy fields from the given template.
 /// The final size of the metadata is calculated at runtime from the size of

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -942,13 +942,13 @@ FUNCTION(InitClassMetadata,
 //                               StructLayoutFlags flags,
 //                               size_t numFields,
 //                               TypeLayout * const *fieldTypes,
-//                               size_t *fieldOffsets);
+//                               uint32_t *fieldOffsets);
 FUNCTION(InitStructMetadata,
          swift_initStructMetadata, C_CC,
          RETURNS(VoidTy),
          ARGS(TypeMetadataPtrTy, SizeTy, SizeTy,
               Int8PtrPtrTy->getPointerTo(0),
-              SizeTy->getPointerTo()),
+              Int32Ty->getPointerTo()),
          ATTRS(NoUnwind))
 
 // void swift_initEnumMetadataSingleCase(Metadata *enumType,

--- a/lib/IRGen/ConstantBuilder.h
+++ b/lib/IRGen/ConstantBuilder.h
@@ -106,7 +106,7 @@ public:
   Size getNextOffsetFromGlobal() const {
     return Size(super::getNextOffsetFromGlobal().getQuantity());
   }
-  
+
   void addAlignmentPadding(Alignment align) {
     auto misalignment = getNextOffsetFromGlobal() % IGM().getPointerAlignment();
     if (misalignment != Size(0))
@@ -119,10 +119,26 @@ public:
 class ConstantArrayBuilder
     : public clang::CodeGen::ConstantArrayBuilderTemplateBase<
                                                     ConstantInitBuilderTraits> {
+private:
+  llvm::Type *EltTy;
+
 public:
-  template <class... As>
-  ConstantArrayBuilder(As &&... args)
-    : ConstantArrayBuilderTemplateBase(std::forward<As>(args)...) {}
+  ConstantArrayBuilder(InitBuilder &builder,
+                       AggregateBuilderBase *parent,
+                       llvm::Type *eltTy)
+    : ConstantArrayBuilderTemplateBase(builder, parent, eltTy), EltTy(eltTy) {}
+
+  void addAlignmentPadding(Alignment align) {
+    auto misalignment = getNextOffsetFromGlobal() % align;
+    if (misalignment == Size(0))
+      return;
+
+    auto eltSize = IGM().DataLayout.getTypeStoreSize(EltTy);
+    assert(misalignment.getValue() % eltSize == 0);
+
+    for (unsigned i = 0, n = misalignment.getValue() / eltSize; i != n; ++i)
+      add(llvm::Constant::getNullValue(EltTy));
+  }
 };
 
 class ConstantStructBuilder

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -461,7 +461,7 @@ llvm::Value *IRGenFunction::emitByteOffsetGEP(llvm::Value *base,
                                               llvm::Value *offset,
                                               llvm::Type *objectType,
                                               const llvm::Twine &name) {
-  assert(offset->getType() == IGM.SizeTy);
+  assert(offset->getType() == IGM.SizeTy || offset->getType() == IGM.Int32Ty);
   auto addr = Builder.CreateBitCast(base, IGM.Int8PtrTy);
   addr = Builder.CreateInBoundsGEP(addr, offset);
   return Builder.CreateBitCast(addr, objectType->getPointerTo(), name);

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -2629,8 +2629,12 @@ namespace {
         B.add(offset);
       } else {
         asImpl().flagUnfilledFieldOffset();
-        B.addInt(IGM.IntPtrTy, 0);
+        B.addInt(IGM.Int32Ty, 0);
       }
+    }
+
+    void noteEndOfFieldOffsets() {
+      B.addAlignmentPadding(super::IGM.getPointerAlignment());
     }
 
     void addGenericArgument(CanType type) {
@@ -2727,7 +2731,7 @@ namespace {
     /// Fill in a constant field offset vector if possible.
     PartialPattern buildExtraDataPattern() {
       ConstantInitBuilder builder(IGM);
-      auto init = builder.beginArray(IGM.SizeTy);
+      auto init = builder.beginArray(IGM.Int32Ty);
 
       struct Scanner : StructMetadataScanner<Scanner> {
         SILType Type;
@@ -2744,7 +2748,11 @@ namespace {
           }
           assert(IGM.isKnownEmpty(Type.getFieldType(field, IGM.getSILModule()),
                                   ResilienceExpansion::Maximal));
-          B.addInt(IGM.SizeTy, 0);
+          B.addInt32(0);
+        }
+
+        void noteEndOfFieldOffsets() {
+          B.addAlignmentPadding(IGM.getPointerAlignment());
         }
       };
       Scanner(IGM, Target, getLoweredType(), init).layout();

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -158,16 +158,16 @@ namespace {
       auto offsets = asImpl().getNonFixedOffsets(IGF, T);
       return fieldInfo.projectAddress(IGF, addr, offsets);
     }
-       
-    /// Return the constant offset of a field as a SizeTy, or nullptr if the
+
+    /// Return the constant offset of a field as a Int32Ty, or nullptr if the
     /// field is not at a fixed offset.
     llvm::Constant *getConstantFieldOffset(IRGenModule &IGM,
                                            VarDecl *field) const {
       auto &fieldInfo = getFieldInfo(field);
       if (fieldInfo.getKind() == ElementLayout::Kind::Fixed
           || fieldInfo.getKind() == ElementLayout::Kind::Empty) {
-        return llvm::ConstantInt::get(IGM.SizeTy,
-                                    fieldInfo.getFixedByteOffset().getValue());
+        return llvm::ConstantInt::get(
+            IGM.Int32Ty, fieldInfo.getFixedByteOffset().getValue());
       }
       return nullptr;
     }

--- a/lib/IRGen/MetadataLayout.cpp
+++ b/lib/IRGen/MetadataLayout.cpp
@@ -248,7 +248,11 @@ Address irgen::emitAddressOfFieldOffsetVector(IRGenFunction &IGF,
     }
   }();
 
-  return IGF.emitAddressAtOffset(metadata, offset, IGF.IGM.SizeTy,
+  auto *elementSize = IGF.IGM.SizeTy;
+  if (isa<StructDecl>(decl))
+    elementSize = IGF.IGM.Int32Ty;
+
+  return IGF.emitAddressAtOffset(metadata, offset, elementSize,
                                  IGF.IGM.getPointerAlignment());
 }
 
@@ -562,6 +566,10 @@ StructMetadataLayout::StructMetadataLayout(IRGenModule &IGM, StructDecl *decl)
     void addFieldOffset(VarDecl *field) {
       Layout.FieldOffsets.try_emplace(field, getNextOffset());
       super::addFieldOffset(field);
+    }
+
+    void noteEndOfFieldOffsets() {
+      super::noteEndOfFieldOffsets();
     }
 
     void layout() {

--- a/lib/IRGen/StructMetadataVisitor.h
+++ b/lib/IRGen/StructMetadataVisitor.h
@@ -59,10 +59,15 @@ public:
     asImpl().noteStartOfFieldOffsets();
     for (VarDecl *prop : Target->getStoredProperties())
       asImpl().addFieldOffset(prop);
+
+    asImpl().noteEndOfFieldOffsets();
   }
   
   // Note the start of the field offset vector.
   void noteStartOfFieldOffsets() {}
+
+  // Note the end of the field offset vector.
+  void noteEndOfFieldOffsets() {}
 };
 
 /// An "implementation" of StructMetadataVisitor that just scans through
@@ -81,17 +86,22 @@ public:
   void addMetadataFlags() { addPointer(); }
   void addValueWitnessTable() { addPointer(); }
   void addNominalTypeDescriptor() { addPointer(); }
-  void addFieldOffset(VarDecl*) { addPointer(); }
+  void addFieldOffset(VarDecl *) { addInt32(); }
   void addGenericArgument(CanType argument) { addPointer(); }
   void addGenericWitnessTable(CanType argument, ProtocolConformanceRef conf) {
     addPointer();
   }
   void noteStartOfTypeSpecificMembers() {}
 
+  void noteEndOfFieldOffsets() {
+    NextOffset = NextOffset.roundUpToAlignment(super::IGM.getPointerAlignment());
+  }
+
 private:
   void addPointer() {
     NextOffset += super::IGM.getPointerSize();
   }
+  void addInt32() { NextOffset += Size(4); }
 };
 
 } // end namespace irgen

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -2404,8 +2404,16 @@ internal func _instantiateKeyPathBuffer(
         // offset within the metadata object.
         let metadataPtr = unsafeBitCast(base, to: UnsafeRawPointer.self)
         let offsetOfOffset = patternBuffer.pop(UInt32.self)
-        let offset = UInt32(metadataPtr.load(fromByteOffset: Int(offsetOfOffset),
-                                       as: UInt.self))
+
+        let offset: UInt32
+        if (header.kind == .struct) {
+          offset = UInt32(metadataPtr.load(fromByteOffset: Int(offsetOfOffset),
+                                           as: UInt32.self))
+        } else {
+          offset = UInt32(metadataPtr.load(fromByteOffset: Int(offsetOfOffset),
+                                           as: UInt.self))
+        }
+
         // Rewrite the header for a resolved offset.
         var newHeader = header
         newHeader.payload = RawKeyPathComponent.Header.outOfLineOffsetPayload

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -1758,12 +1758,12 @@ static ValueWitnessTable *getMutableVWTableForInit(StructMetadata *self,
 void swift::swift_initStructMetadata(StructMetadata *structType,
                                      StructLayoutFlags layoutFlags,
                                      size_t numFields,
-                                     const TypeLayout * const *fieldTypes,
-                                     size_t *fieldOffsets) {
+                                     const TypeLayout *const *fieldTypes,
+                                     uint32_t *fieldOffsets) {
   auto layout = getInitialLayoutForValueType();
   performBasicLayout(layout, fieldTypes, numFields,
     [&](const TypeLayout *fieldType) { return fieldType; },
-    [&](size_t i, const TypeLayout *fieldType, size_t offset) {
+    [&](size_t i, const TypeLayout *fieldType, uint32_t offset) {
       assignUnlessEqual(fieldOffsets[i], offset);
     });
 

--- a/test/IRGen/foreign_types.sil
+++ b/test/IRGen/foreign_types.sil
@@ -20,8 +20,8 @@ import c_layout
 // CHECK-SAME:  @"$SSo14HasNestedUnionV18__Unnamed_struct_sVWV"
 // CHECK-SAME:  [[INT]] 1,
 // CHECK-SAME:  @"$SSo14HasNestedUnionV18__Unnamed_struct_sVMn"
-// CHECK-SAME:  [[INT]] 0,
-// CHECK-SAME:  [[INT]] 4 }
+// CHECK-SAME:  i32 0,
+// CHECK-SAME:  i32 4 }
 
 // CHECK-LABEL: @"\01l_type_metadata_table" = private constant
 // CHECK-SAME: @"$SSo14HasNestedUnionVMn"

--- a/test/IRGen/generic_structs.sil
+++ b/test/IRGen/generic_structs.sil
@@ -8,7 +8,7 @@ import Builtin
 
 // -- Generic structs with fixed layout should have no completion function
 //    and emit the field offset vector as part of the pattern.
-// CHECK:       [[PATTERN:@.*]] = internal constant [3 x i64] [i64 0, i64 1, i64 8]
+// CHECK:       [[PATTERN:@.*]] = internal constant [4 x i32] [i32 0, i32 1, i32 8, i32 0]
 // CHECK-LABEL: @"$S15generic_structs18FixedLayoutGenericVMP" = internal constant <{ {{.*}} }> <{
 // -- instantiation function
 // CHECK-SAME:   %swift.type* (%swift.type_descriptor*, i8**, i8**)* @"$S15generic_structs18FixedLayoutGenericVMi"
@@ -19,9 +19,9 @@ import Builtin
 // -- vwtable pointer
 // CHECK-SAME:   @"$S15generic_structs18FixedLayoutGenericVWV"
 // -- extra data pattern
-// CHECK-SAME: [3 x i64]* [[PATTERN]]
+// CHECK-SAME: [4 x i32]* [[PATTERN]]
 // CHECK-SAME: i16 1,
-// CHECK-SAME: i16 3 }>
+// CHECK-SAME: i16 2 }>
 
 // -- Generic structs with dynamic layout contain the vwtable pattern as part
 //    of the metadata pattern, and no independent vwtable symbol
@@ -95,14 +95,14 @@ import Builtin
 // CHECK: @"$S15generic_structs23DynamicWithRequirementsVMP" = internal constant <{ {{.*}} }> <{
 
 // -- Fixed-layout struct metadata contains fixed field offsets
-// CHECK: @"$S15generic_structs6IntishVMf" = internal constant <{ {{.*}} i64 }> <{
-// CHECK-SAME:   i64 0
+// CHECK: @"$S15generic_structs6IntishVMf" = internal constant <{ {{.*}} i32, [4 x i8] }> <{
+// CHECK-SAME:   i32 0
 // CHECK-SAME: }>
-// CHECK: @"$S15generic_structs7CharethVMf" = internal constant <{ {{.*}} i64 }> <{
-// CHECK-SAME:   i64 0
+// CHECK: @"$S15generic_structs7CharethVMf" = internal constant <{ {{.*}} i32, [4 x i8] }> <{
+// CHECK-SAME:   i32 0
 // CHECK-SAME: }>
-// CHECK: @"$S15generic_structs8StringlyVMf" = internal constant <{ {{.*}} i64, i64, i64 }> <{
-// CHECK-SAME:   i64 0, i64 8, i64 16
+// CHECK: @"$S15generic_structs8StringlyVMf" = internal constant <{ {{.*}} i32, i32, i32, [4 x i8] }> <{
+// CHECK-SAME:   i32 0, i32 8, i32 16, [4 x i8] zeroinitializer
 // CHECK-SAME: }>
 
 struct FixedLayoutGeneric<T> {
@@ -160,31 +160,31 @@ sil @explode_complex_dynamic : $<A, B> (@in ComplexDynamic<A, B>, @inout Byteful
 entry(%0 : $*ComplexDynamic<A, B>, %1 : $*Byteful, %2 : $*A, %3 : $*B, %4 : $*Chareth):
   %a = struct_element_addr %0 : $*ComplexDynamic<A, B>, #ComplexDynamic.a2
 
-  // CHECK: [[METADATA:%.*]] = bitcast %swift.type* {{%.*}} to i64*
-  // CHECK: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds i64, i64* [[METADATA]], i64 4
-  // CHECK: [[FIELD_OFFSET_ADDR:%.*]] = getelementptr inbounds i64, i64* [[FIELD_OFFSET_VECTOR]], i32 2
-  // CHECK: [[FIELD_OFFSET:%.*]] = load i64, i64* [[FIELD_OFFSET_ADDR]], align 8
+  // CHECK: [[METADATA:%.*]] = bitcast %swift.type* {{%.*}} to i32*
+  // CHECK: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds i32, i32* [[METADATA]], i64 8
+  // CHECK: [[FIELD_OFFSET_ADDR:%.*]] = getelementptr inbounds i32, i32* [[FIELD_OFFSET_VECTOR]], i32 2
+  // CHECK: [[FIELD_OFFSET:%.*]] = load i32, i32* [[FIELD_OFFSET_ADDR]], align 8
   // CHECK: [[BYTES:%.*]] = bitcast %T15generic_structs14ComplexDynamicV* %0 to i8*
-  // CHECK: [[BYTE_OFFSET:%.*]] = getelementptr inbounds i8, i8* [[BYTES]], i64 [[FIELD_OFFSET]]
+  // CHECK: [[BYTE_OFFSET:%.*]] = getelementptr inbounds i8, i8* [[BYTES]], i32 [[FIELD_OFFSET]]
   // CHECK: bitcast i8* [[BYTE_OFFSET]] to %swift.opaque*
   %b = struct_element_addr %0 : $*ComplexDynamic<A, B>, #ComplexDynamic.b
 
-  // CHECK: [[METADATA:%.*]] = bitcast %swift.type* {{%.*}} to i64*
-  // CHECK: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds i64, i64* [[METADATA]], i64 4
-  // CHECK: [[FIELD_OFFSET_ADDR:%.*]] = getelementptr inbounds i64, i64* [[FIELD_OFFSET_VECTOR]], i32 3
-  // CHECK: [[FIELD_OFFSET:%.*]] = load i64, i64* [[FIELD_OFFSET_ADDR]], align 8
+  // CHECK: [[METADATA:%.*]] = bitcast %swift.type* {{%.*}} to i32*
+  // CHECK: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds i32, i32* [[METADATA]], i64 8
+  // CHECK: [[FIELD_OFFSET_ADDR:%.*]] = getelementptr inbounds i32, i32* [[FIELD_OFFSET_VECTOR]], i32 3
+  // CHECK: [[FIELD_OFFSET:%.*]] = load i32, i32* [[FIELD_OFFSET_ADDR]], align 8
   // CHECK: [[BYTES:%.*]] = bitcast %T15generic_structs14ComplexDynamicV* %0 to i8*
-  // CHECK: [[BYTE_OFFSET:%.*]] = getelementptr inbounds i8, i8* [[BYTES]], i64 [[FIELD_OFFSET]]
+  // CHECK: [[BYTE_OFFSET:%.*]] = getelementptr inbounds i8, i8* [[BYTES]], i32 [[FIELD_OFFSET]]
   // CHECK: bitcast i8* [[BYTE_OFFSET]] to %T15generic_structs13SingleDynamicV
   %5 = struct_element_addr %0 : $*ComplexDynamic<A, B>, #ComplexDynamic.c
   %c = struct_element_addr %5 : $*SingleDynamic<B>, #SingleDynamic.x
 
-  // CHECK: [[METADATA:%.*]] = bitcast %swift.type* {{%.*}} to i64*
-  // CHECK: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds i64, i64* [[METADATA]], i64 4
-  // CHECK: [[FIELD_OFFSET_ADDR:%.*]] = getelementptr inbounds i64, i64* [[FIELD_OFFSET_VECTOR]], i32 4
-  // CHECK: [[FIELD_OFFSET:%.*]] = load i64, i64* [[FIELD_OFFSET_ADDR]], align 8
+  // CHECK: [[METADATA:%.*]] = bitcast %swift.type* {{%.*}} to i32*
+  // CHECK: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds i32, i32* [[METADATA]], i64 8
+  // CHECK: [[FIELD_OFFSET_ADDR:%.*]] = getelementptr inbounds i32, i32* [[FIELD_OFFSET_VECTOR]], i32 4
+  // CHECK: [[FIELD_OFFSET:%.*]] = load i32, i32* [[FIELD_OFFSET_ADDR]], align 8
   // CHECK: [[BYTES:%.*]] = bitcast %T15generic_structs14ComplexDynamicV* %0 to i8*
-  // CHECK: [[BYTE_OFFSET:%.*]] = getelementptr inbounds i8, i8* [[BYTES]], i64 [[FIELD_OFFSET]]
+  // CHECK: [[BYTE_OFFSET:%.*]] = getelementptr inbounds i8, i8* [[BYTES]], i32 [[FIELD_OFFSET]]
   // CHECK: bitcast i8* [[BYTE_OFFSET]] to %T15generic_structs7CharethV
   %d = struct_element_addr %0 : $*ComplexDynamic<A, B>, #ComplexDynamic.d
   copy_addr %a to %1 : $*Byteful
@@ -205,10 +205,10 @@ entry(%0 : $*ComplexDynamic<A, B>, %1 : $*Byteful, %2 : $*A, %3 : $*B, %4 : $*Ch
 // CHECK-LABEL: define{{( protected)?}} internal swiftcc %swift.metadata_response @"$S15generic_structs13SingleDynamicVMr"
 // CHECK-SAME:    (%swift.type* [[METADATA:%.*]], i8*, i8**) {{.*}} {
 //   Lay out fields.
-// CHECK:   [[T0:%.*]] = bitcast %swift.type* [[METADATA]] to i64*
-// CHECK:   [[T1:%.*]] = getelementptr inbounds i64, i64* [[T0]], i64 3
+// CHECK:   [[T0:%.*]] = bitcast %swift.type* [[METADATA]] to i32*
+// CHECK:   [[T1:%.*]] = getelementptr inbounds i32, i32* [[T0]], i64 6
 // CHECK:   [[T2:%.*]] = getelementptr inbounds i8**, i8*** [[TYPES:%.*]], i32 0
-// CHECK:   call void @swift_initStructMetadata(%swift.type* [[METADATA]], i64 0, i64 1, i8*** [[TYPES]], i64* [[T1]])
+// CHECK:   call void @swift_initStructMetadata(%swift.type* [[METADATA]], i64 0, i64 1, i8*** [[TYPES]], i32* [[T1]])
 // CHECK:   ret %swift.metadata_response
 // CHECK: }
 

--- a/test/IRGen/generic_structs.swift
+++ b/test/IRGen/generic_structs.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize -DINT_32=i32
 
 struct A<T1, T2>
 {
@@ -41,10 +41,10 @@ public struct GenericStruct<T : Proto> {
 // CHECK-LABEL: define{{.*}} swiftcc void @"$S15generic_structs13GenericStructVACyxGycfC"
 // CHECK:  [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S15generic_structs13GenericStructVMa"([[INT]] 0, %swift.type* %T, i8** %T.Proto)
 // CHECK:  [[TYPE:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
-// CHECK:  [[PTR:%.*]] = bitcast %swift.type* [[TYPE]] to [[INT]]*
-// CHECK:  [[FIELDOFFSETS:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[PTR]], [[INT]] 4
-// CHECK:  [[FIELDOFFSET:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[FIELDOFFSETS]], i32 2
-// CHECK:  [[OFFSET:%.*]] = load [[INT]], [[INT]]* [[FIELDOFFSET]]
-// CHECK:  [[ADDROFOPT:%.*]] = getelementptr inbounds i8, i8* {{.*}}, [[INT]] [[OFFSET]]
+// CHECK:  [[PTR:%.*]] = bitcast %swift.type* [[TYPE]] to [[INT_32]]*
+// CHECK:  [[FIELDOFFSETS:%.*]] = getelementptr inbounds [[INT_32]], [[INT_32]]* [[PTR]], [[INT]] [[IDX:4|8]]
+// CHECK:  [[FIELDOFFSET:%.*]] = getelementptr inbounds [[INT_32]], [[INT_32]]* [[FIELDOFFSETS]], i32 2
+// CHECK:  [[OFFSET:%.*]] = load [[INT_32]], [[INT_32]]* [[FIELDOFFSET]]
+// CHECK:  [[ADDROFOPT:%.*]] = getelementptr inbounds i8, i8* {{.*}}, [[INT_32]] [[OFFSET]]
 // CHECK:  [[OPTPTR:%.*]] = bitcast i8* [[ADDROFOPT]] to %TSq*
 // CHECK:  call %TSq* @"$SxSg15generic_structs5ProtoRzlWOb"(%TSq* {{.*}}, %TSq* [[OPTPTR]]

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -220,7 +220,7 @@ sil_vtable C {}
 //             -- struct with runtime-resolved offset
 // CHECK-SAME: <i32 0x00fffffe>,
 // CHECK-32-SAME: i32 20 }>
-// CHECK-64-SAME: i32 40 }>
+// CHECK-64-SAME: i32 36 }>
 
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @stored_property_fixed_offsets()
 sil @stored_property_fixed_offsets : $@convention(thin) () -> () {

--- a/test/IRGen/property_descriptor.sil
+++ b/test/IRGen/property_descriptor.sil
@@ -43,7 +43,7 @@ public struct ExternalReabstractions<T> {
 sil_property #ExternalGeneric.ro <T: Comparable> (
   stored_property #ExternalGeneric.ro : $T)
 // CHECK-64: @"$S19property_descriptor15ExternalGenericV2rwxvpMV" ={{( protected)?}}{{( protected)?}} constant
-// CHECK-64-SAME: <{ <i32 0x00ff_fffe>, i32 40 }>, align 8
+// CHECK-64-SAME: <{ <i32 0x00ff_fffe>, i32 36 }>, align 8
 // CHECK-32: @"$S19property_descriptor15ExternalGenericV2rwxvpMV" ={{( protected)?}} constant
 // CHECK-32-SAME: <{ <i32 0x00ff_fffe>, i32 20 }>, align 4
 sil_property #ExternalGeneric.rw <T: Comparable> (

--- a/test/IRGen/struct_resilience.swift
+++ b/test/IRGen/struct_resilience.swift
@@ -65,12 +65,12 @@ public func functionWithResilientTypesRectangle(_ r: Rectangle) {
 // CHECK: entry:
 // CHECK-NEXT: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S16resilient_struct9RectangleVMa"([[INT]] 0)
 // CHECK-NEXT: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
-// CHECK-NEXT: [[METADATA_ADDR:%.*]] = bitcast %swift.type* [[METADATA]] to [[INT]]*
-// CHECK-NEXT: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[METADATA_ADDR]], [[INT]] 2
-// CHECK-NEXT: [[FIELD_OFFSET_PTR:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[FIELD_OFFSET_VECTOR]], i32 2
-// CHECK-NEXT: [[FIELD_OFFSET:%.*]] = load [[INT]], [[INT]]* [[FIELD_OFFSET_PTR]]
+// CHECK-NEXT: [[METADATA_ADDR:%.*]] = bitcast %swift.type* [[METADATA]] to i32*
+// CHECK-NEXT: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds i32, i32* [[METADATA_ADDR]], [[INT]] [[IDX:2|4]]
+// CHECK-NEXT: [[FIELD_OFFSET_PTR:%.*]] = getelementptr inbounds i32, i32* [[FIELD_OFFSET_VECTOR]], i32 2
+// CHECK-NEXT: [[FIELD_OFFSET:%.*]] = load i32, i32* [[FIELD_OFFSET_PTR]]
 // CHECK-NEXT: [[STRUCT_ADDR:%.*]] = bitcast %T16resilient_struct9RectangleV* %0 to i8*
-// CHECK-NEXT: [[FIELD_ADDR:%.*]] = getelementptr inbounds i8, i8* [[STRUCT_ADDR]], [[INT]] [[FIELD_OFFSET]]
+// CHECK-NEXT: [[FIELD_ADDR:%.*]] = getelementptr inbounds i8, i8* [[STRUCT_ADDR]], i32 [[FIELD_OFFSET]]
 // CHECK-NEXT: [[FIELD_PTR:%.*]] = bitcast i8* [[FIELD_ADDR]] to %TSi*
 // CHECK-NEXT: [[FIELD_PAYLOAD_PTR:%.*]] = getelementptr inbounds %TSi, %TSi* [[FIELD_PTR]], i32 0, i32 0
 // CHECK-NEXT: [[FIELD_PAYLOAD:%.*]] = load [[INT]], [[INT]]* [[FIELD_PAYLOAD_PTR]]
@@ -123,12 +123,12 @@ public struct StructWithResilientStorage {
 // CHECK-LABEL: define{{( protected)?}} swiftcc {{i32|i64}} @"$S17struct_resilience26StructWithResilientStorageV1nSivg"(%T17struct_resilience26StructWithResilientStorageV* {{.*}})
 // CHECK: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S17struct_resilience26StructWithResilientStorageVMa"([[INT]] 0)
 // CHECK: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
-// CHECK-NEXT: [[METADATA_ADDR:%.*]] = bitcast %swift.type* [[METADATA]] to [[INT]]*
-// CHECK-NEXT: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[METADATA_ADDR]], [[INT]] 2
-// CHECK-NEXT: [[FIELD_OFFSET_PTR:%.*]] = getelementptr inbounds [[INT]], [[INT]]* [[FIELD_OFFSET_VECTOR]], i32 2
-// CHECK-NEXT: [[FIELD_OFFSET:%.*]] = load [[INT]], [[INT]]* [[FIELD_OFFSET_PTR]]
+// CHECK-NEXT: [[METADATA_ADDR:%.*]] = bitcast %swift.type* [[METADATA]] to i32*
+// CHECK-NEXT: [[FIELD_OFFSET_VECTOR:%.*]] = getelementptr inbounds i32, i32* [[METADATA_ADDR]], [[INT]] [[IDX:2|4]]
+// CHECK-NEXT: [[FIELD_OFFSET_PTR:%.*]] = getelementptr inbounds i32, i32* [[FIELD_OFFSET_VECTOR]], i32 2
+// CHECK-NEXT: [[FIELD_OFFSET:%.*]] = load i32, i32* [[FIELD_OFFSET_PTR]]
 // CHECK-NEXT: [[STRUCT_ADDR:%.*]] = bitcast %T17struct_resilience26StructWithResilientStorageV* %0 to i8*
-// CHECK-NEXT: [[FIELD_ADDR:%.*]] = getelementptr inbounds i8, i8* [[STRUCT_ADDR]], [[INT]] [[FIELD_OFFSET]]
+// CHECK-NEXT: [[FIELD_ADDR:%.*]] = getelementptr inbounds i8, i8* [[STRUCT_ADDR]], i32 [[FIELD_OFFSET]]
 // CHECK-NEXT: [[FIELD_PTR:%.*]] = bitcast i8* [[FIELD_ADDR]] to %TSi*
 // CHECK-NEXT: [[FIELD_PAYLOAD_PTR:%.*]] = getelementptr inbounds %TSi, %TSi* [[FIELD_PTR]], i32 0, i32 0
 // CHECK-NEXT: [[FIELD_PAYLOAD:%.*]] = load [[INT]], [[INT]]* [[FIELD_PAYLOAD_PTR]]
@@ -203,6 +203,6 @@ public func partialApplyOfResilientMethod(s: Size) {
 // CHECK: [[FIELD_4:%.*]] = getelementptr inbounds i8**, i8*** [[FIELDS_ADDR]], i32 3
 // CHECK: store i8** [[SIZE_AND_ALIGNMENT:%.*]], i8*** [[FIELD_4]]
 
-// CHECK: call void @swift_initStructMetadata(%swift.type* {{.*}}, [[INT]] 256, [[INT]] 4, i8*** [[FIELDS_ADDR]], [[INT]]* {{.*}})
+// CHECK: call void @swift_initStructMetadata(%swift.type* {{.*}}, [[INT]] 256, [[INT]] 4, i8*** [[FIELDS_ADDR]], i32* {{.*}})
 // CHECK: store atomic %swift.type* {{.*}} @"$S17struct_resilience26StructWithResilientStorageVMf{{.*}}, %swift.type** @"$S17struct_resilience26StructWithResilientStorageVML" release,
 // CHECK: ret void


### PR DESCRIPTION
Type of elements contained by field offsets vector can be adjusted
to 32-bit integers (from being pointer sized) to safe space in the
binary since segment size is limited to 4 GB.

Resolves: rdar://problem/36560486

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
