### PR TITLE
[Stats] Interpret ru_maxrss differently by platform.

### DIFF
--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -45,8 +45,14 @@ getChildrenMaxResidentSetSize() {
   struct rusage RU;
   ::getrusage(RUSAGE_CHILDREN, &RU);
   int64_t M = static_cast<int64_t>(RU.ru_maxrss);
-  if (M < 0)
+  if (M < 0) {
     M = std::numeric_limits<int64_t>::max();
+  } else {
+#ifndef __APPLE__
+    // Apple systems report bytes; everything else appears to report KB.
+    M <<= 10;
+#endif
+  }
   return M;
 #else
   return 0;

--- a/test/Misc/stats_dir_plausible_maxrss.swift
+++ b/test/Misc/stats_dir_plausible_maxrss.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: touch %t/main.swift
+// RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t %t/main.swift
+// RUN: %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv %t
+// RUN: %FileCheck -input-file %t/frontend.csv %s
+
+// This test checks that we're reporting some number that's "at least 10MB" and
+// "not more than 999MB", because for a while we were incorrectly reporting KB
+// as bytes on non-macOS, so claiming we took (say) "100KB". If we ever manage
+// to get the swift frontend to use less than 10MB, celebrate! And change this
+// test. Likewise (minus celebration) if compiling a function like the following
+// ever takes more than 1GB.
+//
+// CHECK: {{"Driver.ChildrenMaxRSS"	[1-9][0-9]{7,8}$}}
+
+public func foo() {
+    print("hello")
+}


### PR DESCRIPTION
Apparently there is not 100% agreement in the world about the units of the `ru_maxrss` field of `struct rusage`. Most systems report KB, though macOS reports bytes. This is horrible. Anyways, here's a patch that exists because of that.