### PR TITLE
[AST] Allow the computation of an extensions type for unresolved type aliases

### DIFF
--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -146,9 +146,14 @@ static Type computeExtensionType(const ExtensionDecl *ED, DeclTypeKind kind) {
     return type->getAnyNominal()->getDeclaredType();
   case DeclTypeKind::DeclaredTypeInContext:
     return type;
-  case DeclTypeKind::DeclaredInterfaceType:
+  case DeclTypeKind::DeclaredInterfaceType: {
     // FIXME: Need a sugar-preserving getExtendedInterfaceType for extensions
-    return type->getAnyNominal()->getDeclaredInterfaceType();
+    if (auto nominal = type->getAnyNominal())
+      return nominal->getDeclaredInterfaceType();
+
+    auto typealias = cast<TypeAliasDecl>(type->getAnyGeneric());
+    return typealias->getUnderlyingTypeLoc().getType();
+  }
   }
 
   llvm_unreachable("Unhandled DeclTypeKind in switch.");

--- a/test/Compatibility/stdlib_generic_typealiases.swift
+++ b/test/Compatibility/stdlib_generic_typealiases.swift
@@ -22,3 +22,9 @@ extension DictionaryIndex {
     _ = RequiresHashable<Key>()
   }
 }
+
+extension CountableRange where Element == Int {
+  // expected-warning@-1{{'CountableRange' is deprecated: renamed to 'Range'}}
+  // expected-note@-2{{use 'Range' instead}}
+  func getLowerBoundAsInt() -> Int { return lowerBound }
+}


### PR DESCRIPTION
If an extension refers to a generic typealias that has yet to resolve to
a fully-sugared type, look through the underlying type.

Fixes rdar://problem/39023438.
