### PR TITLE
[CSGen] Mark visitDynamicMemberRefExpr as unreachable to match ExprRewriter and update SanitizeExpr to handle them

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1406,9 +1406,7 @@ namespace {
     }
     
     Type visitDynamicMemberRefExpr(DynamicMemberRefExpr *expr) {
-      return addMemberRefConstraints(expr, expr->getBase(),
-                                     expr->getMember().getDecl(),
-                                     /*FIXME:*/FunctionRefKind::DoubleApply);
+      llvm_unreachable("Already typechecked");
     }
     
     virtual Type visitUnresolvedMemberExpr(UnresolvedMemberExpr *expr) {
@@ -3110,6 +3108,17 @@ namespace {
                                     memberAndFunctionRef.first,
                                     memberLoc,
                                     expr->isImplicit());
+        }
+      }
+
+      if (auto *dynamicMember = dyn_cast<DynamicMemberRefExpr>(expr)) {
+        if (auto memberRef = dynamicMember->getMember()) {
+          auto base = skipImplicitConversions(dynamicMember->getBase());
+          return new (TC.Context) MemberRefExpr(base,
+                                                dynamicMember->getDotLoc(),
+                                                memberRef,
+                                                dynamicMember->getNameLoc(),
+                                                expr->isImplicit());
         }
       }
 

--- a/validation-test/compiler_crashers_2_fixed/0150-rdar39055736.swift
+++ b/validation-test/compiler_crashers_2_fixed/0150-rdar39055736.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc class Foo: NSObject {
+  let x: Int = 0
+}
+@objc protocol Bar {
+  @objc optional var foo: Foo {get}
+}
+
+func baz(bar: Bar) {
+  max(bar, bar.foo?.x ?? 0)
+  // expected-error@-1 {{cannot invoke 'max' with an argument list of type '(Bar, Int)'}}
+  // expected-note@-2 {{expected an argument list of type '(T, T)'}}
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
We were hitting an unreachable in `visitDynamicMemberRefExpr` in `ExprRewriter` when re-typechecking within salvage. Check for these earlier (in CSGen) and update SanitizeExpr to handle them.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->