### PR TITLE
Add sequence command to lldbToolBox

### DIFF
--- a/docs/DebuggingTheCompiler.rst
+++ b/docs/DebuggingTheCompiler.rst
@@ -417,6 +417,13 @@ debugging the swift compiler. These commands live in
 ``SWIFT_BINARY_DIR/bin/lldb-with-tools`` which launches lldb with those
 commands loaded.
 
+A command named ``sequence`` is included in lldbToolBox. ``sequence`` runs
+multiple semicolon separated commands together as one command. This can be used
+to define custom commands using just other lldb commands. For example,
+``custom_step()`` function defined above could be defined as::
+
+    (lldb) command alias cs sequence p/x $rax; stepi
+
 Reducing SIL test cases using bug_reducer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/utils/lldb/lldbToolBox.py
+++ b/utils/lldb/lldbToolBox.py
@@ -75,10 +75,14 @@ def sequence(debugger, command, exec_ctx, result, internal_dict):
     This command is particularly useful for defining aliases and breakpoint
     commands. Some examples:
 
+        # Define an alias that prints rax and also steps one instruction.
         command alias xs sequence p/x $rax; stepi
 
+        # Breakpoint command to show the frame's info and arguments.
         breakpoint command add -o 'seq frame info; reg read arg1 arg2 arg3'
 
+        # Override `b` to allow a condition to be specified. For example:
+        #     b someMethod if someVar > 2
         command regex b
         s/(.+) if (.+)/seq _regexp-break %1; break mod -c "%2"/
         s/(.*)/_regexp-break %1/

--- a/utils/lldb/lldbToolBox.py
+++ b/utils/lldb/lldbToolBox.py
@@ -80,7 +80,7 @@ def sequence(debugger, command, exec_ctx, result, internal_dict):
         breakpoint command add -o 'seq frame info; reg read arg1 arg2 arg3'
 
         command regex b
-        s/b (.+) if (.+)/seq _regexp-break %1; break mod -c "%2"/
+        s/(.+) if (.+)/seq _regexp-break %1; break mod -c "%2"/
         s/(.*)/_regexp-break %1/
     """
     interpreter = debugger.GetCommandInterpreter()

--- a/utils/lldb/lldbToolBox.py
+++ b/utils/lldb/lldbToolBox.py
@@ -89,8 +89,12 @@ def sequence(debugger, command, exec_ctx, result, internal_dict):
     """
     interpreter = debugger.GetCommandInterpreter()
     for subcommand in command.split(';'):
+        subcommand = subcommand.strip()
+        if not subcommand:
+            continue # skip empty commands
+
         ret = lldb.SBCommandReturnObject()
-        interpreter.HandleCommand(subcommand.strip(), exec_ctx, ret)
+        interpreter.HandleCommand(subcommand, exec_ctx, ret)
         if ret.GetOutput():
             print >>result, ret.GetOutput().strip()
 

--- a/utils/lldb/lldbToolBox.py
+++ b/utils/lldb/lldbToolBox.py
@@ -8,12 +8,13 @@ to the swift checkout.
 """
 
 import argparse
-import lldb
 import os
 import shlex
 import subprocess
 import sys
 import tempfile
+
+import lldb
 
 REPO_BASE = os.path.abspath(os.path.join(__file__, os.pardir, os.pardir,
                                          os.pardir, os.pardir))
@@ -91,7 +92,7 @@ def sequence(debugger, command, exec_ctx, result, internal_dict):
     for subcommand in command.split(';'):
         subcommand = subcommand.strip()
         if not subcommand:
-            continue # skip empty commands
+            continue  # skip empty commands
 
         ret = lldb.SBCommandReturnObject()
         interpreter.HandleCommand(subcommand, exec_ctx, ret)


### PR DESCRIPTION
A recent addition to the debugging docs #15613 provides some exposure to using lldb's python API. This pull request adds an lldb command named `sequence` which is for running multiple commands as though they were a single command. This may sound too simple, but it can be quite useful.

The python example shown in #15613 can be implemented with `sequence` and without resorting (which I say with love) to python.

```
command alias cs sequence p/x $rax; stepi
```

I've also found `sequence` useful for breakpoint commands, and for writing `command regex` aliases. 

As an example of `command regex` (and to expand on the example shown in the header doc), gdb has a convenient and mnemonic `break ... if ...` command. Using `sequence`, lldb's `b` alias can be _extended_ to support breakpoint conditions too:

```
command regex b
s/(.+) if (.+)/seq _regexp-break %1; break mod -c "%2"/
s/(.*)/_regexp-break %1/
```

By default, `b` is an alias for `_regexp-break`. This means anyone can write a custom `b` that just builds on top of `_regexp-break`, which is what's happening here. This override allows for breakpoints to be created in this way: `b someMethod if someVar > 2`.