### PR TITLE
[IDE] Fix imbalanced walkToDeclPre/Post calls in SemaAnnotator for IfConfigDecls

### DIFF
--- a/lib/IDE/SourceEntityWalker.cpp
+++ b/lib/IDE/SourceEntityWalker.cpp
@@ -197,7 +197,8 @@ bool SemaAnnotator::walkToDeclPost(Decl *D) {
     ExtDecls.pop_back();
   }
 
-  if (!isa<ValueDecl>(D) && !isa<ExtensionDecl>(D) && !isa<ImportDecl>(D))
+  if (!isa<ValueDecl>(D) && !isa<ExtensionDecl>(D) && !isa<ImportDecl>(D) &&
+      !isa<IfConfigDecl>(D))
     return true;
 
   bool Continue = SEWalker.walkToDeclPost(D);

--- a/test/SourceKit/RangeInfo/basic.swift
+++ b/test/SourceKit/RangeInfo/basic.swift
@@ -10,7 +10,18 @@ class C { func foo() {} }
 struct S { func foo() {} }
 
 // MARK: - Something
-struct Something{}
+struct Something{
+  internal func foo() {
+    #if os(tvOS)
+      let blah = 42
+    #else
+      let blah = 0
+    #endif
+    return blah
+  }
+}
+
+
 
 // RUN: %sourcekitd-test -req=range -pos=2:13 -length 5 %s -- %s | %FileCheck %s -check-prefix=CHECK1
 
@@ -39,6 +50,8 @@ struct Something{}
 // RUN: %sourcekitd-test -req=range -pos=4:1 -end-pos=5:13 %s -- %s | %FileCheck %s -check-prefix=CHECK10
 
 // RUN: %sourcekitd-test -req=range -pos=12:4 -end-pos=12:21 %s -- %s | %FileCheck %s -check-prefix=CHECK11
+
+// RUN: %sourcekitd-test -req=range -pos=14:12 -end-pos=21:4 %s -- %s | %FileCheck %s -check-prefix=CHECK12
 
 // CHECK1-DAG: <kind>source.lang.swift.range.singleexpression</kind>
 // CHECK1-DAG: <content>1 + 2</content>
@@ -87,3 +100,7 @@ struct Something{}
 // CHECK11-DAG: <kind>source.lang.swift.range.invalid</kind>
 // CHECK11-DAG: <content></content>
 // CHECK11-DAG: <type></type>
+
+// CHECK12-DAG: <kind>source.lang.swift.range.invalid</kind>
+// CHECK12-DAG: <content></content>
+// CHECK12-DAG: <type></type>


### PR DESCRIPTION
<!-- What's in this pull request? -->
We were calling `walkToDeclPre` without calling `walkToDeclPost`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/39011293

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->