### PR TITLE
stdlib: Fix some `@_inlineable`/`Builtin.addressof` bad interactions.

### DIFF
--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -328,10 +328,13 @@ extension _StringObject {
 //
 
 #if arch(i386) || arch(arm)
-@_versioned // FIXME(sil-serialize-all)
 internal var _emptyStringStorage: UInt32 = 0
 
-@_inlineable // FIXME(sil-serialize-all)
+// NB: This function *cannot* be @inlinable because it expects to project
+// and escape the physical storage of `_emptyStringStorage`.
+// Marking it inlinable will cause it to resiliently use accessors to
+// project `_emptyStringStorage` as a computed
+// property.
 @_versioned // FIXME(sil-serialize-all)
 internal var _emptyStringAddressBits: UInt {
   let p = UnsafeRawPointer(Builtin.addressof(&_emptyStringStorage))

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -502,7 +502,11 @@ final internal class _VaListBuilder {
     appendWords(arg._cVarArgEncoding)
   }
 
-  @_inlineable // FIXME(sil-serialize-all)
+  // NB: This function *cannot* be @inlinable because it expects to project
+  // and escape the physical storage of `_VaListBuilder.alignedStorageForEmptyVaLists`.
+  // Marking it inlinable will cause it to resiliently use accessors to
+  // project `_VaListBuilder.alignedStorageForEmptyVaLists` as a computed
+  // property.
   @_versioned // FIXME(sil-serialize-all)
   internal func va_list() -> CVaListPointer {
     // Use Builtin.addressof to emphasize that we are deliberately escaping this
@@ -587,7 +591,6 @@ final internal class _VaListBuilder {
   @_versioned // FIXME(sil-serialize-all)
   internal var storage: UnsafeMutablePointer<Int>?
 
-  @_versioned // FIXME(sil-serialize-all)
   internal static var alignedStorageForEmptyVaLists: Double = 0
 }
 


### PR DESCRIPTION
The resilience model forces inlinable code to use resiliently conservative access paths for properties in the same module, but some stdlib methods by design escapes storage of a global variable. The additional `Builtin.addressof` validation introduced in #15608 exposed the latent issue here.