### PR TITLE
Remove the underscored public protocols from overlays

### DIFF
--- a/stdlib/public/SDK/AVFoundation/AVCaptureDevice.swift
+++ b/stdlib/public/SDK/AVFoundation/AVCaptureDevice.swift
@@ -16,12 +16,8 @@ import Foundation
 
 #if os(iOS)
 
-public protocol _AVCaptureDeviceFormatSupportedColorSpaces {
-  @available(iOS, introduced: 10.0)
-  var __supportedColorSpaces: [NSNumber] { get }
-}
-
-extension _AVCaptureDeviceFormatSupportedColorSpaces {
+@available(iOS, introduced: 10.0)
+extension AVCaptureDevice.Format {
   @available(swift, obsoleted: 4.0)
   @available(iOS, introduced: 10.0)
   @nonobjc
@@ -37,9 +33,5 @@ extension _AVCaptureDeviceFormatSupportedColorSpaces {
   }
 }
 
-@available(iOS, introduced: 10.0)
-extension AVCaptureDevice.Format : _AVCaptureDeviceFormatSupportedColorSpaces {
-}
-  
 #endif
 

--- a/stdlib/public/SDK/AVFoundation/AVCapturePhotoOutput.swift
+++ b/stdlib/public/SDK/AVFoundation/AVCapturePhotoOutput.swift
@@ -16,13 +16,8 @@ import Foundation
 
 #if os(iOS)
 
-public protocol _AVCapturePhotoOutputSwiftNativeTypes {
-  var __supportedFlashModes: [NSNumber] { get }
-  var __availablePhotoPixelFormatTypes: [NSNumber] { get }
-  var __availableRawPhotoPixelFormatTypes: [NSNumber] { get }
-}
-
-extension _AVCapturePhotoOutputSwiftNativeTypes {
+@available(iOS, introduced: 10.0)
+extension AVCapturePhotoOutput {
   @available(swift, obsoleted: 4.0)
   @available(iOS, introduced: 10.0)
   @nonobjc
@@ -67,15 +62,7 @@ extension _AVCapturePhotoOutputSwiftNativeTypes {
 }
 
 @available(iOS, introduced: 10.0)
-extension AVCapturePhotoOutput : _AVCapturePhotoOutputSwiftNativeTypes {
-}
-
-
-public protocol _AVCapturePhotoSettingsSwiftNativeTypes {
-  var __availablePreviewPhotoPixelFormatTypes: [NSNumber] { get }
-}
-
-extension _AVCapturePhotoSettingsSwiftNativeTypes {
+extension AVCapturePhotoSettings {
   @available(swift, obsoleted: 4.0)
   @available(iOS, introduced: 10.0)
   @nonobjc
@@ -89,10 +76,6 @@ extension _AVCapturePhotoSettingsSwiftNativeTypes {
   public var availablePreviewPhotoPixelFormatTypes: [OSType] {
     return __availablePreviewPhotoPixelFormatTypes.map { $0.uint32Value } as [OSType]
   }
-}
-
-@available(iOS, introduced: 10.0)
-extension AVCapturePhotoSettings : _AVCapturePhotoSettingsSwiftNativeTypes {
 }
 
 #endif

--- a/stdlib/public/SDK/Intents/INRideOption.swift
+++ b/stdlib/public/SDK/Intents/INRideOption.swift
@@ -15,15 +15,9 @@ import Foundation
 
 #if os(iOS) || os(watchOS)
 
-// Simply extending the INRideOption type doesn't work due to:
-// <rdar://problem/29447066>
-// Compiler incorrectly handles combinations of availability declarations on
-// independent axes.
-public protocol _INRideOptionMeteredFare {
-  var __usesMeteredFare: NSNumber? { get set }
-}
-
-extension _INRideOptionMeteredFare {
+@available(iOS 10.0, watchOS 3.2, *)
+extension INRideOption {
+  @available(iOS 10.0, watchOS 3.2, *)
   @available(swift, obsoleted: 4)
   @nonobjc
   public var usesMeteredFare: NSNumber? {
@@ -35,6 +29,7 @@ extension _INRideOptionMeteredFare {
     }
   }
 
+  @available(iOS 10.0, watchOS 3.2, *)
   @available(swift, introduced: 4.0)
   @nonobjc
   public var usesMeteredFare: Bool? {
@@ -45,10 +40,6 @@ extension _INRideOptionMeteredFare {
       __usesMeteredFare = newUsesMeteredFare.map { NSNumber(value: $0) }
     }
   }
-}
-
-@available(iOS 10.0, watchOS 3.2, *)
-extension INRideOption : _INRideOptionMeteredFare {
 }
 
 #endif


### PR DESCRIPTION
These protocols were introduced to work around the problem where
compiler could not correctly handle instance of multiple @available
attributes (one for the language version and another for teh OS version)
applied to the same member.

Now that the compiler issues has been fixed, it is the right time to get
rid of the workarounds.

Addresses: <rdar://problem/36556261>