### PR TITLE
[4.2] Emit a different diagnostic for Swift 3/4 for 'as T!'.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3157,6 +3157,9 @@ ERROR(tuple_ellipsis,none,
 WARNING(implicitly_unwrapped_optional_in_illegal_position_interpreted_as_optional,none,
         "using '!' is not allowed here; treating this as '?' instead", ())
 
+WARNING(implicitly_unwrapped_optional_deprecated_in_this_position,none,
+        "using '!' here is deprecated and will be removed in a future release", ())
+
 ERROR(implicitly_unwrapped_optional_in_illegal_position,none,
         "using '!' is not allowed here; perhaps '?' was intended?", ())
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2526,6 +2526,9 @@ namespace {
       // Validate the resulting type.
       TypeResolutionOptions options = TypeResolutionFlags::AllowUnboundGenerics;
       options |= TypeResolutionFlags::InExpression;
+      // Prior to Swift 5, we allow 'as T!' and turn it into a disjunction.
+      if (!CS.getASTContext().isSwiftVersionAtLeast(5))
+        options |= TypeResolutionFlags::AllowIUODeprecated;
       if (tc.validateType(expr->getCastTypeLoc(), CS.DC, options))
         return nullptr;
 
@@ -2555,6 +2558,9 @@ namespace {
       // Validate the resulting type.
       TypeResolutionOptions options = TypeResolutionFlags::AllowUnboundGenerics;
       options |= TypeResolutionFlags::InExpression;
+      // Prior to Swift 5, we allow 'as T!' and turn it into a disjunction.
+      if (!CS.getASTContext().isSwiftVersionAtLeast(5))
+        options |= TypeResolutionFlags::AllowIUODeprecated;
       if (tc.validateType(expr->getCastTypeLoc(), CS.DC, options))
         return nullptr;
 
@@ -2589,6 +2595,9 @@ namespace {
       // Validate the resulting type.
       TypeResolutionOptions options = TypeResolutionFlags::AllowUnboundGenerics;
       options |= TypeResolutionFlags::InExpression;
+      // Prior to Swift 5, we allow 'as T!' and turn it into a disjunction.
+      if (!CS.getASTContext().isSwiftVersionAtLeast(5))
+        options |= TypeResolutionFlags::AllowIUODeprecated;
       if (tc.validateType(expr->getCastTypeLoc(), CS.DC, options))
         return nullptr;
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2773,14 +2773,21 @@ Type TypeResolver::resolveImplicitlyUnwrappedOptionalType(
        ImplicitlyUnwrappedOptionalTypeRepr *repr,
        TypeResolutionOptions options) {
   if (!options.contains(TypeResolutionFlags::AllowIUO)) {
-    Diagnostic diag = diag::
-        implicitly_unwrapped_optional_in_illegal_position_interpreted_as_optional;
-
-    if (TC.Context.isSwiftVersionAtLeast(5))
-      diag = diag::implicitly_unwrapped_optional_in_illegal_position;
-
-    TC.diagnose(repr->getStartLoc(), diag)
-        .fixItReplace(repr->getExclamationLoc(), "?");
+    if (options.contains(TypeResolutionFlags::AllowIUODeprecated)) {
+      TC.diagnose(
+          repr->getStartLoc(),
+          diag::implicitly_unwrapped_optional_deprecated_in_this_position);
+    } else if (!TC.Context.isSwiftVersionAtLeast(5)) {
+      TC.diagnose(
+            repr->getStartLoc(),
+            diag::
+                implicitly_unwrapped_optional_in_illegal_position_interpreted_as_optional)
+          .fixItReplace(repr->getExclamationLoc(), "?");
+    } else {
+      TC.diagnose(repr->getStartLoc(),
+                  diag::implicitly_unwrapped_optional_in_illegal_position)
+          .fixItReplace(repr->getExclamationLoc(), "?");
+    }
   }
 
   auto elementOptions = withoutContext(options, true);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -539,6 +539,9 @@ enum class TypeResolutionFlags : unsigned {
 
   /// Is it okay to resolve an IUO sigil ("!") here?
   AllowIUO = 0x4000000,
+
+  /// Is it okay to resolve an IUO sigil ("!") here with a deprecation warning?
+  AllowIUODeprecated = 0x8000000,
 };
 
 /// Option set describing how type resolution should work.

--- a/test/Sema/diag_deprecated_iuo.swift
+++ b/test/Sema/diag_deprecated_iuo.swift
@@ -201,15 +201,15 @@ func returnsFunc2Identifier() -> (Int) -> ImplicitlyUnwrappedOptional<Int> { // 
 let x0 = 1 as ImplicitlyUnwrappedOptional // expected-error {{'ImplicitlyUnwrappedOptional' has been renamed to 'Optional'}}{{15-42=Optional}}
 
 let x: Int? = 1
-let y0: Int = x as Int! // expected-warning {{using '!' is not allowed here; treating this as '?' instead}}{{23-24=?}}
-let y1: Int = (x as Int!)! // expected-warning {{using '!' is not allowed here; treating this as '?' instead}}{{24-25=?}}
-let z0: Int = x as! Int! // expected-warning {{using '!' is not allowed here; treating this as '?' instead}}{{24-25=?}}
+let y0: Int = x as Int! // expected-warning {{using '!' here is deprecated and will be removed in a future release}}
+let y1: Int = (x as Int!)! // expected-warning {{using '!' here is deprecated and will be removed in a future release}}
+let z0: Int = x as! Int! // expected-warning {{using '!' here is deprecated and will be removed in a future release}}
 // expected-warning@-1 {{forced cast of 'Int?' to same type has no effect}}
-let z1: Int = (x as! Int!)! // expected-warning {{using '!' is not allowed here; treating this as '?' instead}}{{25-26=?}}
+let z1: Int = (x as! Int!)! // expected-warning {{using '!' here is deprecated and will be removed in a future release}}
 // expected-warning@-1 {{forced cast of 'Int?' to same type has no effect}}
-let w0: Int = (x as? Int!)! // expected-warning {{using '!' is not allowed here; treating this as '?' instead}}{{25-26=?}}
+let w0: Int = (x as? Int!)! // expected-warning {{using '!' here is deprecated and will be removed in a future release}}
 // expected-warning@-1 {{conditional cast from 'Int?' to 'Int?' always succeeds}}
-let w1: Int = (x as? Int!)!! // expected-warning {{using '!' is not allowed here; treating this as '?' instead}}{{25-26=?}}
+let w1: Int = (x as? Int!)!! // expected-warning {{using '!' here is deprecated and will be removed in a future release}}
 // expected-warning@-1 {{conditional cast from 'Int?' to 'Int?' always succeeds}}
 
 func overloadedByOptionality(_ a: inout Int!) {}


### PR DESCRIPTION
We ended up supporting these coercions for Swift 3/4 via disjunctions,
so change our warning to one saying that it's deprecated rather than
erroneously telling the user that we're treating '!' as if it
were '?'.

Fixes rdar://problem/37121121.
