### PR TITLE
[lldb-moduleimport-test] Refactor the whole tool.

### DIFF
--- a/test/DebugInfo/ASTSection.swift
+++ b/test/DebugInfo/ASTSection.swift
@@ -23,7 +23,6 @@ Double(foo.bar())
 func objCUser(_ obj: ObjCClass) {}
 #endif
 
-// CHECK: Loaded module ASTSection from
 // CHECK: - Target: {{.+}}-{{.+}}-{{.+}}
 // CHECK: Importing ASTSection... ok!
 

--- a/test/DebugInfo/ASTSection_ObjC.swift
+++ b/test/DebugInfo/ASTSection_ObjC.swift
@@ -13,7 +13,6 @@
 // REQUIRES: executable_test
 // REQUIRES: objc_interop
 
-// CHECK: Loaded module ASTSection from
 // CHECK: - Target: {{.+}}-{{.+}}-{{.+}}
 // CHECK: Importing ASTSection... ok!
 

--- a/test/DebugInfo/ASTSection_linker.swift
+++ b/test/DebugInfo/ASTSection_linker.swift
@@ -15,7 +15,6 @@
 
 // REQUIRES: OS=macosx
 
-// CHECK: Loaded module ASTSection from
 // CHECK: - Swift Version: {{.+}}.{{.+}}
 // CHECK: - Target: {{.+}}-{{.+}}-{{.+}}
 // CHECK: - SDK path: /fake/sdk/path{{$}}


### PR DESCRIPTION
This is in preparation for fetching informations directly from
the module instead of specifying them on the cmdline. It will
serve us better as it will mimick more accurately the way lldb
is behaving.

This refactoring moves the validation of the modules earlier
so that we can use the validation info to create the CompileUnit.

<rdar://problem/38867076>
