### PR TITLE
Suppress NRVO in copy forwarding unless the copy is just a move.

### DIFF
--- a/lib/SILOptimizer/Transforms/CopyForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/CopyForwarding.cpp
@@ -1301,6 +1301,18 @@ void CopyForwarding::forwardCopiesOf(SILValue Def, SILFunction *F) {
 ///   ... // no writes
 ///   return
 static bool canNRVO(CopyAddrInst *CopyInst) {
+  // Don't perform NRVO unless the copy is a [take]. This is the easiest way
+  // to determine that the local variable has ownership of its value and ensures
+  // that removing a copy is a reference count neutral operation. For example,
+  // this copy can't be trivially eliminated without adding a retain.
+  //   sil @f : $@convention(thin) (@guaranteed T) -> @out T
+  //   bb0(%in : $*T, %out : $T):
+  //     %local = alloc_stack $T
+  //     store %in to %local : $*T
+  //     copy_addr %local to [initialization] %out : $*T
+  if (!CopyInst->isTakeOfSrc())
+    return false;
+
   if (!isa<AllocStackInst>(CopyInst->getSrc()))
     return false;
 

--- a/test/SILOptimizer/copyforward.sil
+++ b/test/SILOptimizer/copyforward.sil
@@ -776,3 +776,21 @@ bb0(%0 : $*T, %1 : $*T):
   %r1 = tuple ()
   return %r1 : $()
 }
+
+// Suppress NRVO when a guaranteed argument is stored into a local without
+// making a copy first. By eliminating the copy into the outgoing argument, NRVO
+// would be propagating an unowned (+0) local value into an owned (+1) result.
+// CHECK-LABEL: sil @foo : $@convention(thin) (@guaranteed Builtin.NativeObject) -> @out Builtin.NativeObject {
+// CHECK: bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject):
+// CHECK: [[LOCAL:%.*]] = alloc_stack $Builtin.NativeObject
+// CHECK: copy_addr [[LOCAL]] to [initialization] %0 : $*Builtin.NativeObject
+// CHECK-LABEL: } // end sil function 'foo'
+sil @foo : $@convention(thin) (@guaranteed Builtin.NativeObject) -> @out Builtin.NativeObject {
+bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject):
+  %2 = alloc_stack $Builtin.NativeObject
+  store %1 to %2 : $*Builtin.NativeObject
+  copy_addr %2 to [initialization] %0 : $*Builtin.NativeObject
+  dealloc_stack %2 : $*Builtin.NativeObject
+  %6 = tuple ()
+  return %6 : $()
+}


### PR DESCRIPTION
Fixes <rdar://problem/39059402> CopyForwarding + Guaranteed Bug

