### PR TITLE
[generic-specializer] Promote non-trivial in_guaranteed => guaranteed.

### DIFF
--- a/lib/SILOptimizer/Transforms/CopyForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/CopyForwarding.cpp
@@ -1301,6 +1301,18 @@ void CopyForwarding::forwardCopiesOf(SILValue Def, SILFunction *F) {
 ///   ... // no writes
 ///   return
 static bool canNRVO(CopyAddrInst *CopyInst) {
+  // Don't perform NRVO unless the copy is a [take]. This is the easiest way
+  // to determine that the local variable has ownership of its value and ensures
+  // that removing a copy is a reference count neutral operation. For example,
+  // this copy can't be trivially eliminated without adding a retain.
+  //   sil @f : $@convention(thin) (@guaranteed T) -> @out T
+  //   bb0(%in : $*T, %out : $T):
+  //     %local = alloc_stack $T
+  //     store %in to %local : $*T
+  //     copy_addr %local to [initialization] %out : $*T
+  if (!CopyInst->isTakeOfSrc())
+    return false;
+
   if (!isa<AllocStackInst>(CopyInst->getSrc()))
     return false;
 

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -684,12 +684,19 @@ void ReabstractionInfo::createSubstitutedAndSpecializedTypes() {
     if (!substConv.getSILType(PI).isLoadable(M)) {
       continue;
     }
-    if (PI.getConvention() == ParameterConvention::Indirect_In) {
+
+    switch (PI.getConvention()) {
+    case ParameterConvention::Indirect_In:
+    case ParameterConvention::Indirect_In_Guaranteed:
       Conversions.set(IdxToInsert);
-    }
-    if ((PI.getConvention() == ParameterConvention::Indirect_In_Guaranteed) &&
-        substConv.getSILType(PI).isTrivial(M)) {
-      Conversions.set(IdxToInsert);
+      break;
+    case ParameterConvention::Indirect_In_Constant:
+    case ParameterConvention::Indirect_Inout:
+    case ParameterConvention::Indirect_InoutAliasable:
+    case ParameterConvention::Direct_Owned:
+    case ParameterConvention::Direct_Unowned:
+    case ParameterConvention::Direct_Guaranteed:
+      break;
     }
   }
 

--- a/test/SILOptimizer/array_contentof_opt.swift
+++ b/test/SILOptimizer/array_contentof_opt.swift
@@ -1,8 +1,6 @@
 // RUN: %target-swift-frontend -O -sil-verify-all -emit-sil  %s | %FileCheck %s
 // REQUIRES: swift_stdlib_no_asserts,optimized_stdlib
 
-// XFAIL: plus_zero_runtime
-
 // This is an end-to-end test of the array(contentsOf) -> array(Element) optimization
 
 // CHECK-LABEL: sil @{{.*}}testInt

--- a/test/SILOptimizer/copyforward.sil
+++ b/test/SILOptimizer/copyforward.sil
@@ -776,3 +776,21 @@ bb0(%0 : $*T, %1 : $*T):
   %r1 = tuple ()
   return %r1 : $()
 }
+
+// Suppress NRVO when a guaranteed argument is stored into a local without
+// making a copy first. By eliminating the copy into the outgoing argument, NRVO
+// would be propagating an unowned (+0) local value into an owned (+1) result.
+// CHECK-LABEL: sil @foo : $@convention(thin) (@guaranteed Builtin.NativeObject) -> @out Builtin.NativeObject {
+// CHECK: bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject):
+// CHECK: [[LOCAL:%.*]] = alloc_stack $Builtin.NativeObject
+// CHECK: copy_addr [[LOCAL]] to [initialization] %0 : $*Builtin.NativeObject
+// CHECK-LABEL: } // end sil function 'foo'
+sil @foo : $@convention(thin) (@guaranteed Builtin.NativeObject) -> @out Builtin.NativeObject {
+bb0(%0 : $*Builtin.NativeObject, %1 : $Builtin.NativeObject):
+  %2 = alloc_stack $Builtin.NativeObject
+  store %1 to %2 : $*Builtin.NativeObject
+  copy_addr %2 to [initialization] %0 : $*Builtin.NativeObject
+  dealloc_stack %2 : $*Builtin.NativeObject
+  %6 = tuple ()
+  return %6 : $()
+}

--- a/test/SILOptimizer/devirt_witness_method_conformance.swift
+++ b/test/SILOptimizer/devirt_witness_method_conformance.swift
@@ -14,6 +14,7 @@ protocol X {
   func foo()
 }
 extension X {
+  @_optimize(none)
   func foo() {}
 }
 public class Base: X {}

--- a/test/SILOptimizer/spec_archetype_method.swift
+++ b/test/SILOptimizer/spec_archetype_method.swift
@@ -32,7 +32,7 @@ func useFoo<T>(x x: T) {
 //CHECK-LABEL: sil @$S21spec_archetype_method21interesting_code_hereyyF
 //CHECK: function_ref @$S21spec_archetype_method12generic_call{{[_0-9a-zA-Z]*}}FAA3ABCC_Tg5
 //CHECK-NEXT: apply
-//CHECK:  function_ref @$S21spec_archetype_method6useFoo{{[_0-9a-zA-Z]*}}FAA3ABCC_Tg5 : $@convention(thin) (@in_guaranteed ABC) -> ()
+//CHECK:  function_ref @$S21spec_archetype_method6useFoo{{[_0-9a-zA-Z]*}}FAA3ABCC_Tg5 : $@convention(thin) (@guaranteed ABC) -> ()
 //CHECK-NEXT: apply
 //CHECK: return
 public

--- a/test/SILOptimizer/specialize_checked_cast_branch.swift
+++ b/test/SILOptimizer/specialize_checked_cast_branch.swift
@@ -1,5 +1,4 @@
-
-// RUN: %target-swift-frontend -module-name specialize_checked_cast_branch -emit-sil -O -sil-inline-threshold 0 %s -o - | %FileCheck %s
+// RUN: %target-swift-frontend -module-name specialize_checked_cast_branch -emit-sil -O -sil-inline-threshold 0 -Xllvm -sil-disable-pass=function-signature-opts %s -o - | %FileCheck %s
 
 class C {}
 class D : C {}
@@ -18,6 +17,7 @@ var o : AnyObject = c
 ////////////////////////
 // Arch to Arch Casts //
 ////////////////////////
+
 public func ArchetypeToArchetypeCast<T1, T2>(t1 : T1, t2 : T2) -> T2 {
   if let x = t1 as? T2 {
     return x
@@ -25,82 +25,72 @@ public func ArchetypeToArchetypeCast<T1, T2>(t1 : T1, t2 : T2) -> T2 {
   _preconditionFailure("??? Profit?")
 }
 
-// x -> y where x and y are unrelated.
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA1ECTg5 : $@convention(thin) (@in_guaranteed C, @in_guaranteed E) -> @owned E {
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA1DCTg5 : $@convention(thin) (@guaranteed C, @guaranteed D) -> @owned D
+// CHECK: bb0([[ARG:%.*]] : $C, [[ARG2:%.*]] : $D):
+// CHECK:  checked_cast_br [[ARG]] : $C to $D, bb1, bb2
+//
+// CHECK: bb1([[T0:%.*]] : $D):
+// CHECK:   strong_retain [[ARG]]
+// CHECK:   return [[T0]]
+//
+// CHECK: bb2
+// CHECK:   integer_literal $Builtin.Int1, -1
+// CHECK:   cond_fail
+// CHECK:   unreachable
+// CHECK: } // end sil function '$S30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA1DCTg5'
+_ = ArchetypeToArchetypeCast(t1: c, t2: d)
+
+// x -> x where x is a class.
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AFTg5 : $@convention(thin) (@guaranteed C, @guaranteed C) -> @owned C {
 // CHECK: bb0
 // CHECK-NOT: bb1
-// CHECK: %2 = integer_literal $Builtin.Int1, -1
-// CHECK: cond_fail %2 : $Builtin.Int1
-// CHECK: unreachable
+// CHECK: strong_retain %0 : $C
+// CHECK: return %0 : $C
+// CHECK: } // end sil function '$S30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AFTg5'
+_ = ArchetypeToArchetypeCast(t1: c, t2: c)
 
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch28ArchetypeToConcreteCastUInt81tAA03NotI0Vx_tlFAE_Tg5 : $@convention(thin) (NotUInt8) -> NotUInt8 {
-// CHECK: bb0
-// CHECK: return %0 : $NotUInt8
+// TODO: x -> x where x is not a class.
+_ = ArchetypeToArchetypeCast(t1: b, t2: b)
 
-// CHECK-LABEL: sil shared [thunk] [always_inline] @$S30specialize_checked_cast_branch24ArchetypeToConcreteCastC1tAA1CCx_tlFAE_Tg5 : $@convention(thin) (@in_guaranteed C) -> @owned C {
-// CHECK: bb0
-// CHECK:  [[REF:%.*]] = function_ref @$S30specialize_checked_cast_branch24ArchetypeToConcreteCastC1tAA1CCx_tlFAE_Tg5Tf4n_g : $@convention(thin) (@in_guaranteed C) -> C
-// CHECK:  [[RET:%.*]] = apply [[REF]](%0) : $@convention(thin) (@in_guaranteed C) -> C
-// CHECK:  strong_retain [[RET]]
-// CHECK: return [[RET]] : $C
-
-// CHECK-LABEL: sil shared [thunk] [always_inline] @$S30specialize_checked_cast_branch24ArchetypeToConcreteCastC1tAA1CCx_tlFAA1DC_Tg5 : $@convention(thin) (@in_guaranteed D) -> @owned C {
-// CHECK: bb0
-// CHECK:  [[REF:%.*]] = function_ref @$S30specialize_checked_cast_branch24ArchetypeToConcreteCastC1tAA1CCx_tlFAA1DC_Tg5Tf4n_g : $@convention(thin) (@in_guaranteed D) -> C
-// CHECK:  [[RET:%.*]] = apply [[REF]](%0) : $@convention(thin) (@in_guaranteed D) -> C
-// CHECK:  strong_retain [[RET]]
-// CHECK: return [[RET]] : $C
-
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch24ArchetypeToConcreteCastE1tAA1ECx_tlFAA1CC_Tg5 : $@convention(thin) (@in_guaranteed C) -> @owned E {
-// CHECK: bb0
-// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
-// CHECK: cond_fail [[TRUE]]
-// CHECK: unreachable
-
-// x -> x where x is not a class.
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA8NotUInt8V_AFTg5Tf4nd_n : $@convention(thin) (NotUInt8) -> NotUInt8 {
-// CHECK: bb0
-// CHECK-NOT: bb1
-// CHECK: return %0 : $NotUInt8
-
-// x -> y where x,y are not classes and x is a different type from y.
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA8NotUInt8V_AA0J6UInt64VTg5Tf4dd_n : $@convention(thin) () -> NotUInt64 {
-// CHECK: bb0
-// CHECK-NOT: bb1
-// CHECK: %0 = integer_literal $Builtin.Int1, -1
-// CHECK: cond_fail %0 : $Builtin.Int1
-// CHECK: unreachable
+// TODO: x -> y where x is not a class and y is not a class.
+_ = ArchetypeToArchetypeCast(t1: b, t2: f)
 
 // x -> y where x is not a class but y is.
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA8NotUInt8V_AA1CCTg5Tf4dn_n : $@convention(thin) (@in_guaranteed C) -> @owned C {
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA8NotUInt8V_AA1CCTg5 : $@convention(thin) (NotUInt8, @guaranteed C) -> @owned C {
 // CHECK: bb0
 // CHECK-NOT: bb1
-// CHECK: %1 = integer_literal $Builtin.Int1, -1
-// CHECK: cond_fail %1 : $Builtin.Int1
+// CHECK: [[VAL:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK: cond_fail [[VAL]] : $Builtin.Int1
 // CHECK: unreachable
+// CHECK: } // end sil function '$S30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA8NotUInt8V_AA1CCTg5'
+_ = ArchetypeToArchetypeCast(t1: b, t2: c)
 
 // y -> x where x is a class but y is not.
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA8NotUInt8VTg5Tf4nd_n : $@convention(thin) (@in_guaranteed C) -> NotUInt8 {
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA8NotUInt8VTg5 : $@convention(thin) (@guaranteed C, NotUInt8) -> NotUInt8 {
 // CHECK: bb0
 // CHECK-NOT: bb1
-// CHECK: %1 = integer_literal $Builtin.Int1, -1
-// CHECK: cond_fail %1 : $Builtin.Int1
+// CHECK: [[VAL:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK: cond_fail [[VAL]] : $Builtin.Int1
 // CHECK: unreachable
+// CHECK: } // end sil function '$S30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA8NotUInt8VTg5'
+_ = ArchetypeToArchetypeCast(t1: c, t2: b)
 
 // y -> x where x is a super class of y.
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1DC_AA1CCTg5Tf4nn_g : $@convention(thin) (@in_guaranteed D, @in_guaranteed C) -> C {
-// CHECK: [[T0:%.*]] = load %0 : $*D
-// CHECK: [[T1:%.*]] = upcast [[T0]] : $D to $C
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1DC_AA1CCTg5 : $@convention(thin) (@guaranteed D, @guaranteed C) -> @owned C {
+// CHECK: [[T1:%.*]] = upcast %0 : $D to $C
+// CHECK: strong_retain %0 : $D
 // CHECK: return [[T1]] : $C
-
-
-_ = ArchetypeToArchetypeCast(t1: c, t2: d)
-_ = ArchetypeToArchetypeCast(t1: c, t2: c)
-_ = ArchetypeToArchetypeCast(t1: b, t2: b)
-_ = ArchetypeToArchetypeCast(t1: b, t2: f)
-_ = ArchetypeToArchetypeCast(t1: b, t2: c)
-_ = ArchetypeToArchetypeCast(t1: c, t2: b)
+// CHECK: } // end sil function '$S30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1DC_AA1CCTg5'
 _ = ArchetypeToArchetypeCast(t1: d, t2: c)
+
+// x -> y where x and y are unrelated.
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA1ECTg5 : $@convention(thin) (@guaranteed C, @guaranteed E) -> @owned E {
+// CHECK: bb0
+// CHECK-NOT: bb1
+// CHECK: [[VAL:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK: cond_fail [[VAL]] : $Builtin.Int1
+// CHECK: unreachable
+// CHECK: } // end sil function '$S30specialize_checked_cast_branch011ArchetypeToE4Cast2t12t2q_x_q_tr0_lFAA1CC_AA1ECTg5'
 _ = ArchetypeToArchetypeCast(t1: c, t2: e)
 
 ///////////////////////////
@@ -135,47 +125,83 @@ func ArchetypeToConcreteCastE<T>(t : T) -> E {
   _preconditionFailure("??? Profit?")
 }
 
+// uint8 -> uint8
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch28ArchetypeToConcreteCastUInt81tAA03NotI0Vx_tlFAE_Tg5 : $@convention(thin) (NotUInt8) -> NotUInt8 {
+// CHECK: bb0([[ARG:%.*]] :
+// CHECK:   return [[ARG]] : $NotUInt8
+// CHECK: } // end sil function '$S30specialize_checked_cast_branch28ArchetypeToConcreteCastUInt81tAA03NotI0Vx_tlFAE_Tg5'
 _ = ArchetypeToConcreteCastUInt8(t: b)
 
-
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch28ArchetypeToConcreteCastUInt81tAA03NotI0Vx_tlFAA0J6UInt64V_Tg5Tf4d_n : $@convention(thin) () -> NotUInt8 {
-// CHECK: bb0
-// CHECK-NOT: checked_cast_br
-// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
-// CHECK: cond_fail [[TRUE]]
-// CHECK: unreachable
-
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch24ArchetypeToConcreteCastC1tAA1CCx_tlFAA8NotUInt8V_Tg5Tf4d_n : $@convention(thin) () -> @owned C {
-// CHECK: bb0
-// CHECK-NOT: checked_cast_br
-// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
-// CHECK: cond_fail [[TRUE]]
-// CHECK: unreachable
-
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch24ArchetypeToConcreteCastC1tAA1CCx_tlFAA1DC_Tg5Tf4n_g : $@convention(thin) (@in_guaranteed D) -> C {
-// CHECK: bb0
-// CHECK:  [[LOAD:%.*]] = load %0 : $*D
-// CHECK:  [[CAST:%.*]] = upcast [[LOAD]] : $D to $C
-// CHECK: return [[CAST]]
-
-// x -> y where x is a super class of y.
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch24ArchetypeToConcreteCastD1tAA1DCx_tlFAA1CC_Tg5Tf4n_g : $@convention(thin) (@in_guaranteed C) -> D {
-// CHECK:  [[LOAD:%.*]] = load %0 : $*C
-// CHECK: checked_cast_br [[LOAD]] : $C to $D,
-// CHECK: bb1([[T0:%.*]] : $D):
-// CHECK: return [[T0]] : $D
-// CHECK: bb2:
-// CHECK: integer_literal $Builtin.Int1, -1
-// CHECK: cond_fail
-// CHECK: unreachable
-
+// TODO: This needs FileCheck love.
 _ = ArchetypeToConcreteCastUInt8(t: c)
+
+// UInt64 -> Uint8
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch28ArchetypeToConcreteCastUInt81tAA03NotI0Vx_tlFAA0J6UInt64V_Tg5 : $@convention(thin) (NotUInt64) -> NotUInt8 {
+// CHECK: bb0
+// CHECK-NOT: checked_cast_br
+// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK: cond_fail [[TRUE]]
+// CHECK: unreachable
 _ = ArchetypeToConcreteCastUInt8(t: f)
-_ = ArchetypeToConcreteCastC(t: c)
+
+// NotUInt8 -> C
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch24ArchetypeToConcreteCastC1tAA1CCx_tlFAA8NotUInt8V_Tg5 : $@convention(thin) (NotUInt8) -> @owned C {
+// CHECK: bb0
+// CHECK-NOT: checked_cast_br
+// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK: cond_fail [[TRUE]]
+// CHECK: unreachable
+// CHECK: } // end sil function '$S30specialize_checked_cast_branch24ArchetypeToConcreteCastC1tAA1CCx_tlFAA8NotUInt8V_Tg5'
 _ = ArchetypeToConcreteCastC(t: b)
+
+// C -> C
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch24ArchetypeToConcreteCastC1tAA1CCx_tlFAE_Tg5 : $@convention(thin) (@guaranteed C) -> @owned C {
+// CHECK: bb0([[ARG:%.*]] : $C)
+// CHECK:   strong_retain [[ARG]]
+// CHECK:   return [[ARG]] : $C
+// CHECK: } // end sil function '$S30specialize_checked_cast_branch24ArchetypeToConcreteCastC1tAA1CCx_tlFAE_Tg5'
+_ = ArchetypeToConcreteCastC(t: c)
+
+// D -> C
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch24ArchetypeToConcreteCastC1tAA1CCx_tlFAA1DC_Tg5 : $@convention(thin) (@guaranteed D) -> @owned C {
+// CHECK: bb0([[ARG:%.*]] : $D):
+// CHECK:  [[CAST:%.*]] = upcast [[ARG]] : $D to $C
+// CHECK:  strong_retain [[ARG]]
+// CHECK:  return [[CAST]]
+// CHECK: } // end sil function '$S30specialize_checked_cast_branch24ArchetypeToConcreteCastC1tAA1CCx_tlFAA1DC_Tg5'
 _ = ArchetypeToConcreteCastC(t: d)
+
+// E -> C
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch24ArchetypeToConcreteCastC1tAA1CCx_tlFAA1EC_Tg5 : $@convention(thin) (@guaranteed E) -> @owned C {
+// CHECK: bb0
+// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK: cond_fail [[TRUE]]
+// CHECK: unreachable
 _ = ArchetypeToConcreteCastC(t: e)
+
+// C -> D
+// x -> y where x is a super class of y.
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch24ArchetypeToConcreteCastD1tAA1DCx_tlFAA1CC_Tg5 : $@convention(thin) (@guaranteed C) -> @owned D {
+// CHECK: bb0([[ARG:%.*]] : $C):
+// CHECK:   checked_cast_br [[ARG]] : $C to $D, [[SUCC_BB:bb[0-9]+]], [[FAIL_BB:bb[0-9]+]]
+//
+// CHECK: [[SUCC_BB]]([[T0:%.*]] : $D):
+// CHECK:   strong_retain [[ARG]]
+// CHECK:   return [[T0]] : $D
+//
+// CHECK: [[FAIL_BB]]:
+// CHECK:   [[VAL:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK:   cond_fail [[VAL]]
+// CHECK:   unreachable
+// CHECK: } // end sil function '$S30specialize_checked_cast_branch24ArchetypeToConcreteCastD1tAA1DCx_tlFAA1CC_Tg5'
 _ = ArchetypeToConcreteCastD(t: c)
+
+// C -> E
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch24ArchetypeToConcreteCastE1tAA1ECx_tlFAA1CC_Tg5 : $@convention(thin) (@guaranteed C) -> @owned E {
+// CHECK: bb0
+// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK: cond_fail [[TRUE]]
+// CHECK: unreachable
 _ = ArchetypeToConcreteCastE(t: c)
 
 ///////////////////////////
@@ -201,70 +227,60 @@ func ConcreteToArchetypeCastD<T>(t: D, t2: T) -> T {
   _preconditionFailure("??? Profit?")
 }
 
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAF_Tg5Tf4nd_n : $@convention(thin) (NotUInt8) -> NotUInt8
+// x -> x where x is not a class.
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAF_Tg5 : $@convention(thin) (NotUInt8, NotUInt8) -> NotUInt8 {
+// CHECK: bb0
+// CHECK-NOT: bb1
+// CHECK: return %0 : $NotUInt8
+// CHECK: } // end sil function '$S30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAF_Tg5'
+_ = ConcreteToArchetypeCastUInt8(t: b, t2: b)
+
+// x -> y where x,y are not classes and x is a different type from y.
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAA0K6UInt64V_Tg5 : $@convention(thin) (NotUInt8, NotUInt64) -> NotUInt64 {
+// CHECK: bb0
+// CHECK-NOT: bb1
+// CHECK: [[VAL:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK: cond_fail [[VAL]] : $Builtin.Int1
+// CHECK: unreachable
+// CHECK: } // end sil function '$S30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAA0K6UInt64V_Tg5
+_ = ConcreteToArchetypeCastUInt8(t: b, t2: f)
+
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAA1CC_Tg5 : $@convention(thin) (NotUInt8, @guaranteed C) -> @owned C
+// CHECK: bb0
+// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
+// CHECK: cond_fail [[TRUE]]
+// CHECK: unreachable
+_ = ConcreteToArchetypeCastUInt8(t: b, t2: c)
+
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAF_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed C) -> @owned C
 // CHECK: bb0
 // CHECK: return %0
+_ = ConcreteToArchetypeCastC(t: c, t2: c)
 
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAA1CC_Tg5Tf4dn_n : $@convention(thin) (@in_guaranteed C) -> @owned C {
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAA8NotUInt8V_Tg5 : $@convention(thin) (@guaranteed C, NotUInt8) -> NotUInt8
 // CHECK: bb0
 // CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
 // CHECK: cond_fail [[TRUE]]
 // CHECK: unreachable
+_ = ConcreteToArchetypeCastC(t: c, t2: b)
 
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch28ConcreteToArchetypeCastUInt81t2t2xAA03NotI0V_xtlFAA0K6UInt64V_Tg5Tf4dd_n : $@convention(thin) () -> NotUInt64
-// CHECK: bb0
-// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
-// CHECK: cond_fail [[TRUE]]
-// CHECK: unreachable
-
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAF_Tg5Tf4nn_g : $@convention(thin) (@guaranteed C, @in_guaranteed C) -> C {
-// CHECK: bb0
-// CHECK: return %0
-
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAA8NotUInt8V_Tg5Tf4dd_n : $@convention(thin) () -> NotUInt8
-// CHECK: bb0
-// CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
-// CHECK: cond_fail [[TRUE]]
-// CHECK: unreachable
-
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAA1DC_Tg5Tf4nn_g : $@convention(thin) (@guaranteed C, @in_guaranteed D) -> D {
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAA1DC_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed D) -> @owned D
 // CHECK: bb0
 // CHECK:  checked_cast_br %0 : $C to $D
 // CHECK: bb1
+_ = ConcreteToArchetypeCastC(t: c, t2: d)
 
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAA1EC_Tg5Tf4dn_n : $@convention(thin) (@in_guaranteed E) -> @owned E {
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch24ConcreteToArchetypeCastC1t2t2xAA1CC_xtlFAA1EC_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed E) -> @owned E
 // CHECK: bb0
 // CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
 // CHECK: cond_fail [[TRUE]]
 // CHECK: unreachable
+_ = ConcreteToArchetypeCastC(t: c, t2: e)
 
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch24ConcreteToArchetypeCastD1t2t2xAA1DC_xtlFAA1CC_Tg5Tf4nn_g : $@convention(thin) (@guaranteed D, @in_guaranteed C) -> C {
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch24ConcreteToArchetypeCastD1t2t2xAA1DC_xtlFAA1CC_Tg5 : $@convention(thin) (@guaranteed D, @guaranteed C) -> @owned C
 // CHECK: bb0
 // CHECK:  [[T0:%.*]] = upcast %0 : $D to $C
 // CHECK:  return [[T0]]
-
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch21SuperToArchetypeCastC1c1txAA1CC_xtlFAF_Tg5Tf4nn_g : $@convention(thin) (@guaranteed C, @in_guaranteed C) -> C {
-// CHECK: bb0
-// CHECK-NOT: bb1
-// CHECK: return %0 : $C
-
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch21SuperToArchetypeCastC1c1txAA1CC_xtlFAA1DC_Tg5Tf4nn_g : $@convention(thin) (@guaranteed C, @in_guaranteed D) -> D {
-// CHECK: bb0
-// CHECK:  checked_cast_br %0 : $C to $D, bb1, bb2
-// CHECK: bb1(
-// CHECK:   return
-// CHECK: bb2
-// CHECK:   integer_literal $Builtin.Int1, -1
-// CHECK:   cond_fail
-// CHECK:   unreachable
-
-_ = ConcreteToArchetypeCastUInt8(t: b, t2: b)
-_ = ConcreteToArchetypeCastUInt8(t: b, t2: c)
-_ = ConcreteToArchetypeCastUInt8(t: b, t2: f)
-_ = ConcreteToArchetypeCastC(t: c, t2: c)
-_ = ConcreteToArchetypeCastC(t: c, t2: b)
-_ = ConcreteToArchetypeCastC(t: c, t2: d)
-_ = ConcreteToArchetypeCastC(t: c, t2: e)
 _ = ConcreteToArchetypeCastD(t: d, t2: c)
 
 ////////////////////////
@@ -285,25 +301,33 @@ func SuperToArchetypeCastD<T>(d : D, t : T) -> T {
   _preconditionFailure("??? Profit?")
 }
 
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch21SuperToArchetypeCastC1c1txAA1CC_xtlFAA8NotUInt8V_Tg5Tf4dd_n : $@convention(thin) () -> NotUInt8 {
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch21SuperToArchetypeCastC1c1txAA1CC_xtlFAF_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed C) -> @owned C
+// CHECK: bb0
+// CHECK: return %0 : $C
+_ = SuperToArchetypeCastC(c: c, t: c)
+
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch21SuperToArchetypeCastC1c1txAA1CC_xtlFAA1DC_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed D) -> @owned D
+// CHECK: bb0
+// CHECK:  checked_cast_br %0 : $C to $D
+// CHECK: bb1
+_ = SuperToArchetypeCastC(c: c, t: d)
+
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch21SuperToArchetypeCastC1c1txAA1CC_xtlFAA8NotUInt8V_Tg5 : $@convention(thin) (@guaranteed C, NotUInt8) -> NotUInt8
 // CHECK: bb0
 // CHECK: [[TRUE:%.*]] = integer_literal $Builtin.Int1, -1
 // CHECK: cond_fail [[TRUE]]
 // CHECK: unreachable
+_ = SuperToArchetypeCastC(c: c, t: b)
 
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch21SuperToArchetypeCastD1d1txAA1DC_xtlFAA1CC_Tg5Tf4nn_g : $@convention(thin) (@guaranteed D, @in_guaranteed C) -> C {
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch21SuperToArchetypeCastD1d1txAA1DC_xtlFAA1CC_Tg5 : $@convention(thin) (@guaranteed D, @guaranteed C) -> @owned C
 // CHECK: bb0
 // CHECK:  [[T0:%.*]] = upcast %0 : $D to $C
 // CHECK:  return [[T0]]
+_ = SuperToArchetypeCastD(d: d, t: c)
 
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch21SuperToArchetypeCastD1d1txAA1DC_xtlFAF_Tg5Tf4nn_g : $@convention(thin) (@guaranteed D, @in_guaranteed D) -> D {
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch21SuperToArchetypeCastD1d1txAA1DC_xtlFAF_Tg5 : $@convention(thin) (@guaranteed D, @guaranteed D) -> @owned D
 // CHECK: bb0
 // CHECK: return %0 : $D
-
-_ = SuperToArchetypeCastC(c: c, t: c)
-_ = SuperToArchetypeCastC(c: c, t: d)
-_ = SuperToArchetypeCastC(c: c, t: b)
-_ = SuperToArchetypeCastD(d: d, t: c)
 _ = SuperToArchetypeCastD(d: d, t: d)
 
 //////////////////////////////
@@ -317,22 +341,21 @@ func ExistentialToArchetypeCast<T>(o : AnyObject, t : T) -> T {
   _preconditionFailure("??? Profit?")
 }
 
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFAA1CC_Tg5Tf4nn_g : $@convention(thin) (@guaranteed AnyObject, @in_guaranteed C) -> C {
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFAA1CC_Tg5 : $@convention(thin) (@guaranteed AnyObject, @guaranteed C) -> @owned C
 // CHECK: bb0
 // CHECK:  checked_cast_br %0 : $AnyObject to $C
 // CHECK: bb1
+_ = ExistentialToArchetypeCast(o: o, t: c)
 
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFAA8NotUInt8V_Tg5Tf4nd_n : $@convention(thin) (@guaranteed AnyObject) -> NotUInt8 {
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFAA8NotUInt8V_Tg5 : $@convention(thin) (@guaranteed AnyObject, NotUInt8) -> NotUInt8
 // CHECK: bb0
 // CHECK:  checked_cast_addr_br take_always AnyObject in {{%.*}} : $*AnyObject to NotUInt8 in {{%.*}} : $*NotUInt8,
 // CHECK: bb1
+_ = ExistentialToArchetypeCast(o: o, t: b)
 
-// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFyXl_Tg5Tf4nn_g : $@convention(thin) (@guaranteed AnyObject, @in_guaranteed AnyObject) -> AnyObject
+// CHECK-LABEL: sil shared @$S30specialize_checked_cast_branch26ExistentialToArchetypeCast1o1txyXl_xtlFyXl_Tg5 : $@convention(thin) (@guaranteed AnyObject, @guaranteed AnyObject) -> @owned AnyObject
 // CHECK: bb0
 // CHECK-NOT: checked_cast_br %
 // CHECK: return %0 : $AnyObject
 // CHECK-NOT: checked_cast_br %
-
-_ = ExistentialToArchetypeCast(o: o, t: c)
-_ = ExistentialToArchetypeCast(o: o, t: b)
 _ = ExistentialToArchetypeCast(o: o, t: o)

--- a/test/SILOptimizer/specialize_inherited_multifile.swift
+++ b/test/SILOptimizer/specialize_inherited_multifile.swift
@@ -9,7 +9,7 @@
 
 // Make sure the ConcreteDerived : Base conformance is available here.
 
-// CHECK-LABEL: sil shared [noinline] @$S30specialize_inherited_multifile17takesHasAssocType1tyx_tAA0efG0RzlFAA08ConcreteefG0C_Tg5 : $@convention(thin) (@in_guaranteed ConcreteHasAssocType) -> ()
+// CHECK-LABEL: sil shared [noinline] @$S30specialize_inherited_multifile17takesHasAssocType1tyx_tAA0efG0RzlFAA08ConcreteefG0C_Tg5 : $@convention(thin) (@guaranteed ConcreteHasAssocType) -> ()
 // CHECK: [[FN:%.*]] = function_ref @$S30specialize_inherited_multifile9takesBase1tyx_tAA0E0RzlF
 // CHECK: apply [[FN]]<ConcreteDerived>({{%.*}})
 // CHECK: return

--- a/test/SILOptimizer/specialize_unconditional_checked_cast.swift
+++ b/test/SILOptimizer/specialize_unconditional_checked_cast.swift
@@ -42,36 +42,36 @@ ArchetypeToArchetype(t: b, t2: f)
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 
 // x -> x where x is a class.
-// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC{{.*}}Tg5 : $@convention(thin) (@in_guaranteed C, @in_guaranteed C) -> @owned C {
+// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC{{.*}}Tg5 : $@convention(thin) (@guaranteed C, @guaranteed C) -> @owned C {
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 
 // x -> y where x is not a class but y is.
-// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA8NotUInt8V_AA1CCTg5 : $@convention(thin) (NotUInt8, @in_guaranteed C) -> @owned C {
+// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA8NotUInt8V_AA1CCTg5 : $@convention(thin) (NotUInt8, @guaranteed C) -> @owned C {
 // CHECK-NOT: unconditional_checked_cast_addr
 // CHECK-NOT: unconditional_checked_cast_addr
 // CHECK:     builtin "int_trap"
 // CHECK-NOT: unconditional_checked_cast_addr
 
 // y -> x where x is not a class but y is.
-// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC_AA8NotUInt8VTg5 : $@convention(thin) (@in_guaranteed C, NotUInt8) -> NotUInt8 {
+// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC_AA8NotUInt8VTg5 : $@convention(thin) (@guaranteed C, NotUInt8) -> NotUInt8 {
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 // CHECK: builtin "int_trap"
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 
 // x -> y where x is a super class of y.
-// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC_AA1DCTg5 : $@convention(thin) (@in_guaranteed C, @in_guaranteed D) -> @owned D {
+// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC_AA1DCTg5 : $@convention(thin) (@guaranteed C, @guaranteed D) -> @owned D {
 // CHECK: [[STACK:%[0-9]+]] = alloc_stack $C
 // TODO: This should be optimized to an unconditional_checked_cast without the need of alloc_stack: rdar://problem/24775038
 // CHECK: unconditional_checked_cast_addr C in [[STACK]] : $*C to D in
 
 // y -> x where x is a super class of y.
-// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1DC_AA1CCTg5 : $@convention(thin) (@in_guaranteed D, @in_guaranteed C) -> @owned C {
+// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1DC_AA1CCTg5 : $@convention(thin) (@guaranteed D, @guaranteed C) -> @owned C {
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 // CHECK: upcast {{%[0-9]+}} : $D to $C
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 
 // x -> y where x and y are unrelated classes.
-// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC_AA1ECTg5 : $@convention(thin) (@in_guaranteed C, @in_guaranteed E) -> @owned E {
+// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast011ArchetypeToE0{{[_0-9a-zA-Z]*}}FAA1CC_AA1ECTg5 : $@convention(thin) (@guaranteed C, @guaranteed E) -> @owned E {
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
 // CHECK: builtin "int_trap"
 // CHECK-NOT: unconditional_checked_cast archetype_to_archetype
@@ -117,11 +117,12 @@ ArchetypeToConcreteConvertUInt8(t: f)
 // CHECK-NEXT: }
 
 // x -> x where x is a class.
-// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast27ArchetypeToConcreteConvertC{{[_0-9a-zA-Z]*}}Tg5 : $@convention(thin) (@in_guaranteed C) -> @owned C {
-// CHECK: bb0
-// CHECK-NEXT: debug_value_addr %0
-// CHECK-NEXT: %2 = load %0 : $*C
-// CHECK: return %2
+// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast27ArchetypeToConcreteConvertC{{[_0-9a-zA-Z]*}}Tg5 : $@convention(thin) (@guaranteed C) -> @owned C {
+// CHECK: bb0([[ARG:%.*]] : $C)
+// CHECK-NEXT: debug_value [[ARG]]
+// CHECK-NEXT: debug_value [[ARG]]
+// CHECK-NEXT: strong_retain [[ARG]]
+// CHECK-NEXT: return [[ARG]]
 
 // x -> y where x is a class but y is not.
 // CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast27ArchetypeToConcreteConvertC{{[_0-9a-zA-Z]*}}FAA8NotUInt8V_Tg5
@@ -131,12 +132,12 @@ ArchetypeToConcreteConvertUInt8(t: f)
 // CHECK-NEXT: }
 
 // x -> y where x,y are classes and x is a super class of y.
-// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast27ArchetypeToConcreteConvertC{{[_0-9a-zA-Z]*}}FAA1DC_Tg5 : $@convention(thin) (@in_guaranteed D) -> @owned C {
-// CHECK: bb0
-// CHECK-NEXT: debug_value_addr %0
-// CHECK-NEXT: %2 = load %0 : $*D
-// CHECK: [[UC:%[0-9]+]] = upcast %2
-// CHECK: return [[UC]]
+// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast27ArchetypeToConcreteConvertC{{[_0-9a-zA-Z]*}}FAA1DC_Tg5 : $@convention(thin) (@guaranteed D) -> @owned C {
+// CHECK: bb0([[ARG:%.*]] : $D):
+// CHECK:   [[UPCAST:%.*]] = upcast [[ARG]] : $D to $C
+// CHECK:   strong_retain [[ARG]]
+// CHECK:   return [[UPCAST]]
+// CHECK: } // end sil function '$S37specialize_unconditional_checked_cast27ArchetypeToConcreteConvertC{{[_0-9a-zA-Z]*}}FAA1DC_Tg5'
 
 // x -> y where x,y are classes, but x is unrelated to y.
 // CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast27ArchetypeToConcreteConvertC{{[_0-9a-zA-Z]*}}FAA1EC_Tg5
@@ -163,8 +164,8 @@ public func ArchetypeToConcreteConvertD<T>(t t: T) -> D {
 ArchetypeToConcreteConvertD(t: c)
 
 // x -> y where x,y are classes and x is a sub class of y.
-// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast27ArchetypeToConcreteConvertD{{[_0-9a-zA-Z]*}}FAA1CC_Tg5 : $@convention(thin) (@in_guaranteed C) -> @owned D {
-// CHECK: bb0(%0 : $*C):
+// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast27ArchetypeToConcreteConvertD{{[_0-9a-zA-Z]*}}FAA1CC_Tg5 : $@convention(thin) (@guaranteed C) -> @owned D {
+// CHECK: bb0(%0 : $C):
 // CHECK-DAG: [[STACK_C:%[0-9]+]] = alloc_stack $C
 // CHECK-DAG: store {{.*}} to [[STACK_C]]
 // CHECK-DAG: [[STACK_D:%[0-9]+]] = alloc_stack $D
@@ -210,7 +211,7 @@ ConcreteToArchetypeConvertUInt8(t: b, t2: f)
 // CHECK-NEXT: return %0
 
 // x -> y where x is not a class but y is a class.
-// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast31ConcreteToArchetypeConvertUInt8{{[_0-9a-zA-Z]*}}FAA1CC_Tg5 : $@convention(thin) (NotUInt8, @in_guaranteed C) -> @owned C {
+// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast31ConcreteToArchetypeConvertUInt8{{[_0-9a-zA-Z]*}}FAA1CC_Tg5 : $@convention(thin) (NotUInt8, @guaranteed C) -> @owned C {
 // CHECK: bb0
 // CHECK: builtin "int_trap"
 // CHECK: unreachable
@@ -235,8 +236,8 @@ ConcreteToArchetypeConvertC(t: c, t2: e)
 
 
 // x -> x where x is a class.
-// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{[_0-9a-zA-Z]*}}Tg5 : $@convention(thin) (@guaranteed C, @in_guaranteed C) -> @owned C {
-// CHECK: bb0(%0 : $C, %1 : $*C):
+// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{[_0-9a-zA-Z]*}}Tg5 : $@convention(thin) (@guaranteed C, @guaranteed C) -> @owned C {
+// CHECK: bb0(%0 : $C, %1 : $C):
 // CHECK: return %0
 
 // x -> y where x is a class but y is not.
@@ -247,8 +248,8 @@ ConcreteToArchetypeConvertC(t: c, t2: e)
 // CHECK-NEXT: }
 
 // x -> y where x is a super class of y.
-// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{[_0-9a-zA-Z]*}}FAA1DC_Tg5 : $@convention(thin) (@guaranteed C, @in_guaranteed D) -> @owned D {
-// CHECK: bb0(%0 : $C, %1 : $*D):
+// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{[_0-9a-zA-Z]*}}FAA1DC_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed D) -> @owned D {
+// CHECK: bb0(%0 : $C, %1 : $D):
 // CHECK-DAG: [[STACK_C:%[0-9]+]] = alloc_stack $C
 // CHECK-DAG: store %0 to [[STACK_C]]
 // CHECK-DAG: [[STACK_D:%[0-9]+]] = alloc_stack $D
@@ -258,8 +259,8 @@ ConcreteToArchetypeConvertC(t: c, t2: e)
 // CHECK: return [[LOAD]]
 
 // x -> y where x and y are unrelated classes.
-// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{[_0-9a-zA-Z]*}}FAA1EC_Tg5 : $@convention(thin) (@guaranteed C, @in_guaranteed E) -> @owned E {
-// CHECK: bb0(%0 : $C, %1 : $*E):
+// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertC{{[_0-9a-zA-Z]*}}FAA1EC_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed E) -> @owned E {
+// CHECK: bb0(%0 : $C, %1 : $E):
 // CHECK-NEXT: builtin "int_trap"
 // CHECK-NEXT: unreachable
 // CHECK-NEXT: }
@@ -272,8 +273,8 @@ public func ConcreteToArchetypeConvertD<T>(t t: D, t2: T) -> T {
 ConcreteToArchetypeConvertD(t: d, t2: c)
 
 // x -> y where x is a subclass of y.
-// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertD{{[_0-9a-zA-Z]*}}FAA1CC_Tg5 : $@convention(thin) (@guaranteed D, @in_guaranteed C) -> @owned C {
-// CHECK: bb0(%0 : $D, %1 : $*C):
+// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast27ConcreteToArchetypeConvertD{{[_0-9a-zA-Z]*}}FAA1CC_Tg5 : $@convention(thin) (@guaranteed D, @guaranteed C) -> @owned C {
+// CHECK: bb0(%0 : $D, %1 : $C):
 // CHECK-DAG: [[UC:%[0-9]+]] = upcast %0
 // CHECK: return [[UC]]
 
@@ -293,12 +294,12 @@ SuperToArchetypeC(c: c, t: b)
 
 
 // x -> x where x is a class.
-// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast17SuperToArchetypeC{{[_0-9a-zA-Z]*}}Tg5 : $@convention(thin) (@guaranteed C, @in_guaranteed C) -> @owned C {
-// CHECK: bb0(%0 : $C, %1 : $*C):
+// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast17SuperToArchetypeC{{[_0-9a-zA-Z]*}}Tg5 : $@convention(thin) (@guaranteed C, @guaranteed C) -> @owned C {
+// CHECK: bb0(%0 : $C, %1 : $C):
 // CHECK: return %0
 
 // x -> y where x is a super class of y.
-// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast17SuperToArchetypeC{{[_0-9a-zA-Z]*}}FAA1DC_Tg5 : $@convention(thin) (@guaranteed C, @in_guaranteed D) -> @owned D {
+// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast17SuperToArchetypeC{{[_0-9a-zA-Z]*}}FAA1DC_Tg5 : $@convention(thin) (@guaranteed C, @guaranteed D) -> @owned D {
 // CHECK: bb0
 // CHECK: unconditional_checked_cast_addr C in
 
@@ -319,13 +320,13 @@ SuperToArchetypeD(d: d, t: d)
 
 // *NOTE* The frontend is smart enough to turn this into an upcast. When this
 // test is converted to SIL, this should be fixed appropriately.
-// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast17SuperToArchetypeD{{[_0-9a-zA-Z]*}}FAA1CC_Tg5 : $@convention(thin) (@guaranteed D, @in_guaranteed C) -> @owned C {
+// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast17SuperToArchetypeD{{[_0-9a-zA-Z]*}}FAA1CC_Tg5 : $@convention(thin) (@guaranteed D, @guaranteed C) -> @owned C {
 // CHECK-NOT: unconditional_checked_cast super_to_archetype
 // CHECK: upcast
 // CHECK-NOT: unconditional_checked_cast super_to_archetype
 
-// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast17SuperToArchetypeD{{[_0-9a-zA-Z]*}}Tg5 : $@convention(thin) (@guaranteed D, @in_guaranteed D) -> @owned D {
-// CHECK: bb0(%0 : $D, %1 : $*D):
+// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast17SuperToArchetypeD{{[_0-9a-zA-Z]*}}Tg5 : $@convention(thin) (@guaranteed D, @guaranteed D) -> @owned D {
+// CHECK: bb0(%0 : $D, %1 : $D):
 // CHECK: return %0
 
 //////////////////////////////
@@ -338,7 +339,7 @@ public func ExistentialToArchetype<T>(o o : AnyObject, t : T) -> T {
 }
 
 // AnyObject -> Class.
-// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast22ExistentialToArchetype{{[_0-9a-zA-Z]*}}FAA1CC_Tg5 : $@convention(thin) (@guaranteed AnyObject, @in_guaranteed C) -> @owned C {
+// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast22ExistentialToArchetype{{[_0-9a-zA-Z]*}}FAA1CC_Tg5 : $@convention(thin) (@guaranteed AnyObject, @guaranteed C) -> @owned C {
 // CHECK: unconditional_checked_cast_addr AnyObject in {{%.*}} : $*AnyObject to C
 
 // AnyObject -> Non Class (should always fail)
@@ -348,8 +349,8 @@ public func ExistentialToArchetype<T>(o o : AnyObject, t : T) -> T {
 // CHECK: return
 
 // AnyObject -> AnyObject
-// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast22ExistentialToArchetype{{[_0-9a-zA-Z]*}}yXl{{.*}}Tg5 : $@convention(thin) (@guaranteed AnyObject, @in_guaranteed AnyObject) -> @owned AnyObject {
-// CHECK: bb0(%0 : $AnyObject, %1 : $*AnyObject):
+// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast22ExistentialToArchetype{{[_0-9a-zA-Z]*}}yXl{{.*}}Tg5 : $@convention(thin) (@guaranteed AnyObject, @guaranteed AnyObject) -> @owned AnyObject {
+// CHECK: bb0(%0 : $AnyObject, %1 : $AnyObject):
 // CHECK: return %0
 
 ExistentialToArchetype(o: o, t: c)
@@ -360,12 +361,12 @@ ExistentialToArchetype(o: o, t: o)
 // value cast. We could do the promotion, but the optimizer would need
 // to insert the Optional unwrapping logic before the cast.
 //
-// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast15genericDownCastyq_x_q_mtr0_lFAA1CCSg_AA1DCTg5 : $@convention(thin) (@in_guaranteed Optional<C>, @thick D.Type) -> @owned D {
-// CHECK: bb0(%0 : $*Optional<C>, %1 : $@thick D.Type):
+// CHECK-LABEL: sil shared [noinline] @$S37specialize_unconditional_checked_cast15genericDownCastyq_x_q_mtr0_lFAA1CCSg_AA1DCTg5 : $@convention(thin) (@guaranteed Optional<C>, @thick D.Type) -> @owned D {
+// CHECK: bb0(%0 : $Optional<C>, %1 : $@thick D.Type):
 // CHECK-DAG: [[STACK_D:%[0-9]+]] = alloc_stack $D
 // CHECK-DAG: [[STACK_C:%[0-9]+]] = alloc_stack $Optional<C>
-// CHECK-DAG: %5 = load %0 : $*Optional<C>
-// CHECK-DAG: store %5 to [[STACK_C]]
+// CHECK-DAG: store [[ARG]] to [[STACK_C]]
+// CHECK-DAG: retain_value [[ARG]]
 // TODO: This should be optimized to an unconditional_checked_cast without the need of alloc_stack: rdar://problem/24775038
 // CHECK-DAG: unconditional_checked_cast_addr Optional<C> in [[STACK_C]] : $*Optional<C> to D in [[STACK_D]] : $*D
 // CHECK-DAG: [[LOAD:%[0-9]+]] = load [[STACK_D]]


### PR DESCRIPTION
We did this for @in => @owned for all parameters before enabling +0. We decided
to defer this work to after +0 was turned back on.

This also fixes the array_contentof_opt test without making append(contentOf: )
take the container at +1.

rdar://38152291