### PR TITLE
[4.2] Fix the handling of IUOs in 'as!' casts.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3678,24 +3678,11 @@ namespace {
 
     // Rewrite ForcedCheckedCastExpr based on what the solver computed.
     Expr *visitForcedCheckedCastExpr(ForcedCheckedCastExpr *expr) {
-      // If we need to insert a force-unwrap for coercions of the form
-      // 'as! T!', do so now.
-      if (hasForcedOptionalResult(expr)) {
-        auto *coerced = handleForcedCheckedCastExpr(expr);
-        if (!coerced)
-          return nullptr;
-
-        return coerceImplicitlyUnwrappedOptionalToValue(
-            coerced, cs.getType(coerced)->getOptionalObjectType());
-      }
-
-      return handleForcedCheckedCastExpr(expr);
-    }
-
-    // Most of the logic for dealing with ForcedCheckedCastExpr.
-    Expr *handleForcedCheckedCastExpr(ForcedCheckedCastExpr *expr) {
       // Simplify the type we're casting to.
       auto toType = simplifyType(cs.getType(expr->getCastTypeLoc()));
+      if (hasForcedOptionalResult(expr))
+        toType = toType->getOptionalObjectType();
+
       expr->getCastTypeLoc().setType(toType, /*validated=*/true);
       checkForImportedUsedConformances(toType);
 

--- a/test/Constraints/iuo.swift
+++ b/test/Constraints/iuo.swift
@@ -178,3 +178,38 @@ class rdar37241550 {
     f(rdar37241550.init) // no error, the failable init is not applicable
   }
 }
+
+class B {}
+class D : B {
+  var i: Int!
+}
+
+func coerceToIUO(d: D?) -> B {
+  return d as B! // expected-warning {{using '!' here is deprecated and will be removed in a future release}}
+}
+
+func forcedDowncastToOptional(b: B?) -> D? {
+  return b as! D! // expected-warning {{using '!' here is deprecated and will be removed in a future release}}
+}
+
+func forcedDowncastToObject(b: B?) -> D {
+  return b as! D! // expected-warning {{using '!' here is deprecated and will be removed in a future release}}
+}
+
+func forcedDowncastToObjectIUOMember(b: B?) -> Int {
+  return (b as! D!).i // expected-warning {{using '!' here is deprecated and will be removed in a future release}}
+}
+
+func forcedUnwrapViaForcedCast(b: B?) -> B {
+  return b as! B! // expected-warning {{forced cast from 'B?' to 'B' only unwraps optionals; did you mean to use '!'?}}
+  // expected-warning@-1 {{using '!' here is deprecated and will be removed in a future release}}
+}
+
+func conditionalDowncastToOptional(b: B?) -> D? {
+  return b as? D! // expected-warning {{using '!' here is deprecated and will be removed in a future release}}
+}
+
+func conditionalDowncastToObject(b: B?) -> D {
+  return b as? D! // expected-error {{value of optional type 'D?' not unwrapped; did you mean to use '!' or '?'?}}
+  // expected-warning@-1 {{using '!' here is deprecated and will be removed in a future release}}
+}

--- a/test/Sema/diag_deprecated_iuo.swift
+++ b/test/Sema/diag_deprecated_iuo.swift
@@ -204,7 +204,7 @@ let x: Int? = 1
 let y0: Int = x as Int! // expected-warning {{using '!' here is deprecated and will be removed in a future release}}
 let y1: Int = (x as Int!)! // expected-warning {{using '!' here is deprecated and will be removed in a future release}}
 let z0: Int = x as! Int! // expected-warning {{using '!' here is deprecated and will be removed in a future release}}
-// expected-warning@-1 {{forced cast of 'Int?' to same type has no effect}}
+// expected-warning@-1 {{forced cast from 'Int?' to 'Int' only unwraps optionals; did you mean to use '!'?}}
 let z1: Int = (x as! Int!)! // expected-warning {{using '!' here is deprecated and will be removed in a future release}}
 // expected-warning@-1 {{forced cast of 'Int?' to same type has no effect}}
 let w0: Int = (x as? Int!)! // expected-warning {{using '!' here is deprecated and will be removed in a future release}}

--- a/test/Sema/diag_erroneous_iuo.swift
+++ b/test/Sema/diag_erroneous_iuo.swift
@@ -201,7 +201,7 @@ let x: Int? = 1
 let y0: Int = x as Int! // expected-error {{using '!' is not allowed here; perhaps '?' was intended?}}{{23-24=?}}
 let y1: Int = (x as Int!)! // expected-error {{using '!' is not allowed here; perhaps '?' was intended?}}{{24-25=?}}
 let z0: Int = x as! Int! // expected-error {{using '!' is not allowed here; perhaps '?' was intended?}}{{24-25=?}}
-// expected-warning@-1 {{forced cast of 'Int?' to same type has no effect}}
+// expected-warning@-1 {{forced cast from 'Int?' to 'Int' only unwraps optionals; did you mean to use '!'?}}
 let z1: Int = (x as! Int!)! // expected-error {{using '!' is not allowed here; perhaps '?' was intended?}}{{25-26=?}}
 // expected-warning@-1 {{forced cast of 'Int?' to same type has no effect}}
 let w0: Int = (x as? Int!)! // expected-warning {{conditional cast from 'Int?' to 'Int?' always succeeds}}


### PR DESCRIPTION
We just needed to select the final type based on which branch of the
disjunction successfully type-checked the expression.

Fixes [SR-7208](https://bugs.swift.org/browse/SR-7208)
  and rdar://problem/37159360.

(cherry picked from commit 4bd648be0552092c9cdfa98967b20f13499deb4e)
