### PR TITLE
Full IRGen support for begin_access [no_nested_conflict].

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -4260,8 +4260,8 @@ static SILAccessEnforcement getEffectiveEnforcement(IRGenFunction &IGF,
   return enforcement;
 }
 
-template <class Inst>
-static ExclusivityFlags getExclusivityFlags(Inst *i) {
+template <class BeginAccessInst>
+static ExclusivityFlags getExclusivityFlags(BeginAccessInst *i) {
   return getExclusivityFlags(i->getModule(), i->getAccessKind(),
                              i->hasNoNestedConflict());
 }
@@ -4363,6 +4363,9 @@ void IRGenSILFunction::visitEndAccessInst(EndAccessInst *i) {
     return;
 
   case SILAccessEnforcement::Dynamic: {
+    if (access->hasNoNestedConflict())
+      return;
+
     auto scratch = getLoweredDynamicEnforcementScratchBuffer(access);
 
     auto call = Builder.CreateCall(IGM.getEndAccessFn(), { scratch });

--- a/test/IRGen/access_markers.sil
+++ b/test/IRGen/access_markers.sil
@@ -155,6 +155,7 @@ bb0(%0 : $A):
   // CHECK: call void @swift_beginAccess(i8* %{{.*}}, [[BUFFER]]* %{{.*}}, [[SIZE]] 0, i8* null)
   %3 = begin_access [read] [dynamic] [no_nested_conflict] %2 : $*Int
   copy_addr %3 to [initialization] %1 : $*Int
+  // CHECK-NOT: end_access
   end_access %3 : $*Int
   %9 = alloc_stack $Builtin.UnsafeValueBuffer
   // CHECK: call void @swift_beginAccess(i8* %{{.*}}, [[BUFFER]]* %{{.*}}, [[SIZE]] 0, i8* null)


### PR DESCRIPTION
Suppress generation of the endAccess runtime call when the
begin_access was a "non-tracking" access.
