### PR TITLE
build: disable static RTTI on Windows if possible

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -257,11 +257,18 @@ function(_add_variant_c_compile_flags)
     list(APPEND result "-D_ENABLE_ATOMIC_ALIGNMENT_FIX")
 
     # msvcprt's std::function requires RTTI, but we do not want RTTI data.
-    # Emulate /GR-
+    # Emulate /GR-.
+    # TODO(compnerd) when moving up to VS 2017 15.3 and newer, we can disable
+    # RTTI again
     if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)
       list(APPEND result -frtti)
       list(APPEND result -Xclang;-fno-rtti-data)
     endif()
+
+    # NOTE: VS 2017 15.3 introduced this to disable the static components of
+    # RTTI as well.  This requires a newer SDK though and we do not have
+    # guarantees on the SDK version currently.
+    list(APPEND result "-D_HAS_STATIC_RTTI=0")
   endif()
 
   if(CFLAGS_ENABLE_ASSERTIONS)


### PR DESCRIPTION
Newer SDKs have the ability to disable the static RTTI usage as well as
the dynamic.  We had to enable the use of static RTTI previously for the
use of `std::function`.  Disable the static RTTI if possible.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
