### PR TITLE
Remove unused and slow 'protocol implementations' analysis

### DIFF
--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -493,13 +493,6 @@ public:
   bool linkFunction(SILFunction *Fun,
                     LinkingMode LinkAll = LinkingMode::LinkNormal);
 
-  /// Attempt to link a function by mangled name. Returns true if linking
-  /// succeeded, false otherwise.
-  ///
-  /// \return false if the linking failed.
-  bool linkFunction(StringRef Name,
-                    LinkingMode LinkAll = LinkingMode::LinkNormal);
-
   /// Check if a given function exists in any of the modules with a
   /// required linkage, i.e. it can be linked by linkFunction.
   ///

--- a/include/swift/SILOptimizer/Analysis/ClassHierarchyAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/ClassHierarchyAnalysis.h
@@ -80,10 +80,6 @@ public:
     return IndirectSubclassesCache[C];
   }
 
-  const NominalTypeList &getProtocolImplementations(ProtocolDecl *P) {
-    return ProtocolImplementationsCache[P];
-  }
-
   /// Returns true if the class is inherited by another class in this module.
   bool hasKnownDirectSubclasses(ClassDecl *C) {
     return DirectSubclassesCache.count(C);
@@ -94,11 +90,6 @@ public:
   bool hasKnownIndirectSubclasses(ClassDecl *C) {
     return IndirectSubclassesCache.count(C) &&
            !IndirectSubclassesCache[C].empty();
-  }
-
-  /// Returns true if the protocol is implemented by any class in this module.
-  bool hasKnownImplementations(ProtocolDecl *C) {
-    return ProtocolImplementationsCache.count(C);
   }
 
 private:
@@ -114,9 +105,6 @@ private:
 
   /// A cache that maps a class to all of its known indirect subclasses.
   llvm::DenseMap<ClassDecl*, ClassList> IndirectSubclassesCache;
-
-  /// A cache that maps a protocol to all of its known implementations.
-  ProtocolImplementations ProtocolImplementationsCache;
 };
 
 }

--- a/lib/SIL/Linker.cpp
+++ b/lib/SIL/Linker.cpp
@@ -56,49 +56,6 @@ bool SILLinkerVisitor::processFunction(SILFunction *F) {
   return true;
 }
 
-/// Process Decl, recursively deserializing any thing Decl may reference.
-bool SILLinkerVisitor::processFunction(StringRef Name) {
-  if (Mode == LinkingMode::LinkNone)
-    return false;
-
-  // If F is a declaration, first deserialize it.
-  auto *NewFn = Loader->lookupSILFunction(Name);
-
-  if (!NewFn || NewFn->isExternalDeclaration())
-    return false;
-
-  ++NumFuncLinked;
-
-  // Try to transitively deserialize everything referenced by NewFn.
-  Worklist.push_back(NewFn);
-  process();
-
-  // Since we successfully processed at least one function, return true.
-  return true;
-}
-
-/// Process Decl, recursively deserializing any thing Decl may reference.
-SILFunction *SILLinkerVisitor::lookupFunction(StringRef Name,
-                                              SILLinkage Linkage) {
-
-  auto *NewFn = Loader->lookupSILFunction(Name, /* declarationOnly */ true,
-                                          Linkage);
-
-  if (!NewFn)
-    return nullptr;
-
-  assert(NewFn->isExternalDeclaration() &&
-         "SIL function lookup should never read function bodies");
-
-  return NewFn;
-}
-
-/// Process Decl, recursively deserializing any thing Decl may reference.
-bool SILLinkerVisitor::hasFunction(StringRef Name,
-                                   Optional<SILLinkage> Linkage) {
-  return Loader->hasSILFunction(Name, Linkage);
-}
-
 /// Deserialize the VTable mapped to C if it exists and all SIL the VTable
 /// transitively references.
 ///

--- a/lib/SIL/Linker.h
+++ b/lib/SIL/Linker.h
@@ -50,18 +50,6 @@ public:
   /// Process F, recursively deserializing any thing F may reference.
   bool processFunction(SILFunction *F);
 
-  /// Process Name, recursively deserializing any thing function with name Name
-  /// may reference.
-  bool processFunction(StringRef Name);
-
-  /// Process Name, try to deserialize a declaration of a function with
-  /// this Name.
-  SILFunction *lookupFunction(StringRef Name, SILLinkage Linkage);
-
-  /// Process Name, try to check if there is a declaration of a function
-  /// with this Name.
-  bool hasFunction(StringRef Name, Optional<SILLinkage> Linkage = None);
-
   /// Deserialize the VTable mapped to C if it exists and all SIL the VTable
   /// transitively references.
   ///


### PR DESCRIPTION
We were walking the entire AST for all source files once per SIL module -- which is still once per source file in batch mode, so its quadratic. And the results of the analysis were unused, so nuke it.

Also, remove some code from the SIL linker that was completely dead.