### PR TITLE
Finish the first stage of incomplete type metadata support

### DIFF
--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -167,7 +167,7 @@ struct RuntimeErrorDetails {
   uintptr_t framesToSkip;
 
   // Address of some associated object (if there's any).
-  void *memoryAddress;
+  const void *memoryAddress;
 
   // A structure describing an extra thread (and its stack) that is related.
   struct Thread {

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -1868,6 +1868,10 @@ struct TargetTupleTypeMetadata : public TargetMetadata<Runtime> {
     OpaqueValue *findIn(OpaqueValue *tuple) const {
       return (OpaqueValue*) (((char*) tuple) + Offset);
     }
+
+    const TypeLayout *getTypeLayout() const {
+      return Type->getTypeLayout();
+    }
   };
 
   Element *getElements() {
@@ -4180,21 +4184,24 @@ swift_getForeignTypeMetadata(ForeignTypeMetadata *nonUnique);
 /// \param proposedWitnesses - an optional proposed set of value witnesses.
 ///   This is useful when working with a non-dependent tuple type
 ///   where the entrypoint is just being used to unique the metadata.
-SWIFT_RUNTIME_EXPORT
-const TupleTypeMetadata *
-swift_getTupleTypeMetadata(TupleTypeFlags flags,
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
+MetadataResponse
+swift_getTupleTypeMetadata(MetadataRequest request,
+                           TupleTypeFlags flags,
                            const Metadata * const *elements,
                            const char *labels,
                            const ValueWitnessTable *proposedWitnesses);
 
-SWIFT_RUNTIME_EXPORT
-const TupleTypeMetadata *
-swift_getTupleTypeMetadata2(const Metadata *elt0, const Metadata *elt1,
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
+MetadataResponse
+swift_getTupleTypeMetadata2(MetadataRequest request,
+                            const Metadata *elt0, const Metadata *elt1,
                             const char *labels,
                             const ValueWitnessTable *proposedWitnesses);
-SWIFT_RUNTIME_EXPORT
-const TupleTypeMetadata *
-swift_getTupleTypeMetadata3(const Metadata *elt0, const Metadata *elt1,
+SWIFT_RUNTIME_EXPORT SWIFT_CC(swift)
+MetadataResponse
+swift_getTupleTypeMetadata3(MetadataRequest request,
+                            const Metadata *elt0, const Metadata *elt1,
                             const Metadata *elt2, const char *labels,
                             const ValueWitnessTable *proposedWitnesses);
 

--- a/include/swift/Runtime/RuntimeFunctions.def
+++ b/include/swift/Runtime/RuntimeFunctions.def
@@ -869,31 +869,35 @@ FUNCTION(GetObjCClassFromMetadata, swift_getObjCClassFromMetadata, C_CC,
          ARGS(TypeMetadataPtrTy),
          ATTRS(NoUnwind, ReadNone))
 
-// Metadata *swift_getTupleTypeMetadata(TupleTypeFlags flags,
-//                                      Metadata * const *elts,
-//                                      const char *labels,
-//                                      value_witness_table_t *proposed);
-FUNCTION(GetTupleMetadata, swift_getTupleTypeMetadata, C_CC,
-         RETURNS(TypeMetadataPtrTy),
-         ARGS(SizeTy, TypeMetadataPtrTy->getPointerTo(0),
+// MetadataResponse swift_getTupleTypeMetadata(MetadataRequest request,
+//                                             TupleTypeFlags flags,
+//                                             Metadata * const *elts,
+//                                             const char *labels,
+//                                             value_witness_table_t *proposed);
+FUNCTION(GetTupleMetadata, swift_getTupleTypeMetadata, SwiftCC,
+         RETURNS(TypeMetadataResponseTy),
+         ARGS(SizeTy, SizeTy, TypeMetadataPtrTy->getPointerTo(0),
               Int8PtrTy, WitnessTablePtrTy),
          ATTRS(NoUnwind, ReadOnly))
 
-// Metadata *swift_getTupleTypeMetadata2(Metadata *elt0, Metadata *elt1,
-//                                       const char *labels,
-//                                       value_witness_table_t *proposed);
-FUNCTION(GetTupleMetadata2, swift_getTupleTypeMetadata2, C_CC,
-         RETURNS(TypeMetadataPtrTy),
-         ARGS(TypeMetadataPtrTy, TypeMetadataPtrTy,
+// MetadataResponse swift_getTupleTypeMetadata2(MetadataRequest request,
+//                                              Metadata *elt0, Metadata *elt1,
+//                                              const char *labels,
+//                                              value_witness_table_t *proposed);
+FUNCTION(GetTupleMetadata2, swift_getTupleTypeMetadata2, SwiftCC,
+         RETURNS(TypeMetadataResponseTy),
+         ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrTy,
               Int8PtrTy, WitnessTablePtrTy),
          ATTRS(NoUnwind, ReadOnly))
 
-// Metadata *swift_getTupleTypeMetadata3(Metadata *elt0, Metadata *elt1,
-//                                       Metadata *elt2, const char *labels,
-//                                       value_witness_table_t *proposed);
-FUNCTION(GetTupleMetadata3, swift_getTupleTypeMetadata3, C_CC,
-         RETURNS(TypeMetadataPtrTy),
-         ARGS(TypeMetadataPtrTy, TypeMetadataPtrTy, TypeMetadataPtrTy,
+// MetadataResponse swift_getTupleTypeMetadata3(MetadataRequest request,
+//                                              Metadata *elt0, Metadata *elt1,
+//                                              Metadata *elt2,
+//                                              const char *labels,
+//                                              value_witness_table_t *proposed);
+FUNCTION(GetTupleMetadata3, swift_getTupleTypeMetadata3, SwiftCC,
+         RETURNS(TypeMetadataResponseTy),
+         ARGS(SizeTy, TypeMetadataPtrTy, TypeMetadataPtrTy, TypeMetadataPtrTy,
               Int8PtrTy, WitnessTablePtrTy),
          ATTRS(NoUnwind, ReadOnly))
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -169,23 +169,21 @@ swift::getResilientImmediateMembersOffset(const ClassDescriptor *description) {
 }
 
 static bool
-areAllTransitiveMetadataComplete_cheap(const Metadata *metadata,
-                                 const TypeContextDescriptor *description);
+areAllTransitiveMetadataComplete_cheap(const Metadata *metadata);
 
 static MetadataDependency
-checkTransitiveCompleteness(const Metadata *metadata,
-                            const TypeContextDescriptor *description);
+checkTransitiveCompleteness(const Metadata *metadata);
 
 namespace {
-  struct GenericCacheEntry final : MetadataCacheEntryBase<GenericCacheEntry> {
+  struct GenericCacheEntry final :
+      VariadicMetadataCacheEntryBase<GenericCacheEntry> {
     static const char *getName() { return "GenericCache"; }
 
     template <class... Args>
     GenericCacheEntry(MetadataCacheKey key, Args &&...args)
-      : MetadataCacheEntryBase(key) {}
+      : VariadicMetadataCacheEntryBase(key) {}
 
-    AllocationResult allocate(MetadataRequest request,
-                              const TypeContextDescriptor *description,
+    AllocationResult allocate(const TypeContextDescriptor *description,
                               const void * const *arguments) {
       // Find a pattern.  Currently we always use the default pattern.
       auto &generics = description->getFullGenericContextHeader();
@@ -201,7 +199,7 @@ namespace {
       // some extra locking.
       PrivateMetadataState state;
       if (pattern->CompletionFunction.isNull()) {
-        if (areAllTransitiveMetadataComplete_cheap(metadata, description)) {
+        if (areAllTransitiveMetadataComplete_cheap(metadata)) {
           state = PrivateMetadataState::Complete;
         } else {
           state = PrivateMetadataState::NonTransitiveComplete;
@@ -221,20 +219,22 @@ namespace {
       return PrivateMetadataState::LayoutComplete;
     }
 
-    // Note that we have to pass 'arguments' separately here instead of
-    // using the key data because there might be non-key arguments,
-    // like protocol conformances.
+    static const TypeContextDescriptor *getDescription(Metadata *type) {
+      if (auto classType = dyn_cast<ClassMetadata>(type))
+        return classType->getDescription();
+      else
+        return cast<ValueMetadata>(type)->getDescription();
+    }
+
     TryInitializeResult tryInitialize(Metadata *metadata,
                                       PrivateMetadataState state,
-                                      PrivateMetadataCompletionContext *context,
-                                      const TypeContextDescriptor *description,
-                                      const void * const *arguments) {
+                               PrivateMetadataCompletionContext *context) {
       assert(state != PrivateMetadataState::Complete);
 
       // Finish the completion function.
       if (state < PrivateMetadataState::NonTransitiveComplete) {
         // Find a pattern.  Currently we always use the default pattern.
-        auto &generics = description->getFullGenericContextHeader();
+        auto &generics = getDescription(metadata)->getFullGenericContextHeader();
         auto pattern = generics.DefaultInstantiationPattern.get();
 
         // Complete the metadata's instantiation.
@@ -249,7 +249,7 @@ namespace {
       }
 
       // Check for transitive completeness.
-      if (auto dependency = checkTransitiveCompleteness(metadata, description)){
+      if (auto dependency = checkTransitiveCompleteness(metadata)) {
         return { PrivateMetadataState::NonTransitiveComplete, dependency };
       }
 
@@ -784,8 +784,12 @@ FunctionCacheEntry::FunctionCacheEntry(const Key &key) {
 
 namespace {
 
-class TupleCacheEntry {
+class TupleCacheEntry
+    : public MetadataCacheEntryBase<TupleCacheEntry,
+                                    TupleTypeMetadata::Element> {
 public:
+  static const char *getName() { return "TupleCache"; }
+
   // NOTE: if you change the layout of this type, you'll also need
   // to update tuple_getValueWitnesses().
   ExtraInhabitantsValueWitnessTable Witnesses;
@@ -797,7 +801,28 @@ public:
     const char *Labels;
   };
 
-  TupleCacheEntry(const Key &key, const ValueWitnessTable *proposedWitnesses);
+  ValueType getValue() {
+    return &Data;
+  }
+  void setValue(ValueType value) {
+    assert(value == &Data);
+  }
+
+  TupleCacheEntry(const Key &key, MetadataRequest request,
+                  const ValueWitnessTable *proposedWitnesses);
+
+  AllocationResult allocate(const ValueWitnessTable *proposedWitnesses);
+
+  TryInitializeResult tryInitialize(Metadata *metadata,
+                                    PrivateMetadataState state,
+                                    PrivateMetadataCompletionContext *context);
+
+  TryInitializeResult checkTransitiveCompleteness() {
+    auto dependency = ::checkTransitiveCompleteness(&Data);
+    return { dependency ? PrivateMetadataState::NonTransitiveComplete
+                        : PrivateMetadataState::Complete,
+             dependency };
+  }
 
   size_t getNumElements() const {
     return Data.NumElements;
@@ -817,7 +842,7 @@ public:
     // The element types.
     for (size_t i = 0, e = key.NumElements; i != e; ++i) {
       if (auto result = comparePointers(key.Elements[i],
-                                        Data.getElements()[i].Type))
+                                        Data.getElement(i).Type))
         return result;
     }
 
@@ -837,19 +862,35 @@ public:
     return 0;
   }
 
-  static size_t getExtraAllocationSize(const Key &key,
-                                       const ValueWitnessTable *proposed) {
-    return key.NumElements * sizeof(TupleTypeMetadata::Element);
+  size_t numTrailingObjects(OverloadToken<TupleTypeMetadata::Element>) const {
+    return getNumElements();
   }
-  size_t getExtraAllocationSize() const {
-    return Data.NumElements * sizeof(TupleTypeMetadata::Element);
+
+  template <class... Args>
+  static size_t numTrailingObjects(OverloadToken<TupleTypeMetadata::Element>,
+                                   const Key &key,
+                                   Args &&...extraArgs) {
+    return key.NumElements;
+  }
+};
+
+class TupleCache : public MetadataCache<TupleCacheEntry, false, TupleCache> {
+public:
+  static TupleCacheEntry *
+  resolveExistingEntry(const TupleTypeMetadata *metadata) {
+    // The correctness of this arithmetic is verified by an assertion in
+    // the TupleCacheEntry constructor.
+    auto bytes = reinterpret_cast<const char*>(asFullMetadata(metadata));
+    bytes -= offsetof(TupleCacheEntry, Data);
+    auto entry = reinterpret_cast<const TupleCacheEntry*>(bytes);
+    return const_cast<TupleCacheEntry*>(entry);
   }
 };
 
 } // end anonymous namespace
 
 /// The uniquing structure for tuple type metadata.
-static SimpleGlobalCache<TupleCacheEntry> TupleTypes;
+static Lazy<TupleCache> TupleTypes;
 
 /// Given a metatype pointer, produce the value-witness table for it.
 /// This is equivalent to metatype->ValueWitnesses but more efficient.
@@ -1138,26 +1179,31 @@ static size_t roundUpToAlignMask(size_t size, size_t alignMask) {
 /// Perform basic sequential layout given a vector of metadata pointers,
 /// calling a functor with the offset of each field, and returning the
 /// final layout characteristics of the type.
-/// FUNCTOR should have signature:
-///   void (size_t index, const Metadata *type, size_t offset)
-template<typename FUNCTOR, typename LAYOUT>
+///
+/// GetLayoutFn should have signature:
+///   const TypeLayout *(ElementType &type);
+///
+/// SetOffsetFn should have signature:
+///   void (size_t index, ElementType &type, size_t offset)
+template<typename ElementType, typename GetLayoutFn, typename SetOffsetFn>
 static void performBasicLayout(TypeLayout &layout,
-                               const LAYOUT * const *elements,
+                               ElementType *elements,
                                size_t numElements,
-                               FUNCTOR &&f) {
+                               GetLayoutFn &&getLayout,
+                               SetOffsetFn &&setOffset) {
   size_t size = layout.size;
   size_t alignMask = layout.flags.getAlignmentMask();
   bool isPOD = layout.flags.isPOD();
   bool isBitwiseTakable = layout.flags.isBitwiseTakable();
   for (unsigned i = 0; i != numElements; ++i) {
-    auto elt = elements[i];
+    auto &elt = elements[i];
 
     // Lay out this element.
-    const TypeLayout *eltLayout = elt->getTypeLayout();
+    const TypeLayout *eltLayout = getLayout(elt);
     size = roundUpToAlignMask(size, eltLayout->flags.getAlignmentMask());
 
     // Report this record to the functor.
-    f(i, elt, size);
+    setOffset(i, elt, size);
 
     // Update the size and alignment of the aggregate..
     size += eltLayout->size;
@@ -1175,8 +1221,9 @@ static void performBasicLayout(TypeLayout &layout,
   layout.stride = std::max(size_t(1), roundUpToAlignMask(size, alignMask));
 }
 
-const TupleTypeMetadata *
-swift::swift_getTupleTypeMetadata(TupleTypeFlags flags,
+MetadataResponse
+swift::swift_getTupleTypeMetadata(MetadataRequest request,
+                                  TupleTypeFlags flags,
                                   const Metadata * const *elements,
                                   const char *labels,
                                   const ValueWitnessTable *proposedWitnesses) {
@@ -1184,54 +1231,122 @@ swift::swift_getTupleTypeMetadata(TupleTypeFlags flags,
 
   // Bypass the cache for the empty tuple. We might reasonably get called
   // by generic code, like a demangler that produces type objects.
-  if (numElements == 0) return &METADATA_SYM(EMPTY_TUPLE_MANGLING);
+  if (numElements == 0)
+    return { &METADATA_SYM(EMPTY_TUPLE_MANGLING), MetadataState::Complete };
 
   // Search the cache.
   TupleCacheEntry::Key key = { numElements, elements, labels };
 
+  auto &cache = TupleTypes.get();
+
   // If we have constant labels, directly check the cache.
   if (!flags.hasNonConstantLabels())
-    return &TupleTypes.getOrInsert(key, proposedWitnesses).first->Data;
+    return cache.getOrInsert(key, request, proposedWitnesses).second;
 
   // If we have non-constant labels, we can't simply record the result.
   // Look for an existing result, first.
-  if (auto found = TupleTypes.find(key))
-    return &found->Data;
+  if (auto response = cache.tryAwaitExisting(key, request))
+    return *response;
 
   // Allocate a copy of the labels string within the tuple type allocator.
   size_t labelsLen = strlen(labels);
   size_t labelsAllocSize = roundUpToAlignment(labelsLen + 1, sizeof(void*));
   char *newLabels =
-    (char *)TupleTypes.getAllocator().Allocate(labelsAllocSize, alignof(char));
+    (char *) cache.getAllocator().Allocate(labelsAllocSize, alignof(char));
   strcpy(newLabels, labels);
   key.Labels = newLabels;
 
   // Update the metadata cache.
-  auto result = TupleTypes.getOrInsert(key, proposedWitnesses);
+  auto result = cache.getOrInsert(key, request, proposedWitnesses).second;
 
   // If we didn't manage to perform the insertion, free the memory associated
   // with the copy of the labels: nobody else can reference it.
-  if (!result.second) {
-    TupleTypes.getAllocator().Deallocate(newLabels, labelsAllocSize);
+  if (cast<TupleTypeMetadata>(result.Value)->Labels != newLabels) {
+    cache.getAllocator().Deallocate(newLabels, labelsAllocSize);
   }
 
   // Done.
-  return &result.first->Data;
+  return result;
 }
 
-TupleCacheEntry::TupleCacheEntry(const Key &key,
+TupleCacheEntry::TupleCacheEntry(const Key &key, MetadataRequest request,
                                  const ValueWitnessTable *proposedWitnesses) {
   Data.setKind(MetadataKind::Tuple);
-  Data.ValueWitnesses = &Witnesses;
   Data.NumElements = key.NumElements;
   Data.Labels = key.Labels;
 
+  // Stash the proposed witnesses in the value-witnesses slot for now.
+  Data.ValueWitnesses = proposedWitnesses;
+
+  for (size_t i = 0, e = key.NumElements; i != e; ++i)
+    Data.getElement(i).Type = key.Elements[i];
+
+  assert(TupleCache::resolveExistingEntry(&Data) == this);
+}
+
+TupleCacheEntry::AllocationResult
+TupleCacheEntry::allocate(const ValueWitnessTable *proposedWitnesses) {
+  // All the work we can reasonably do here was done in the constructor.
+  return { &Data, PrivateMetadataState::Abstract };
+}
+
+TupleCacheEntry::TryInitializeResult
+TupleCacheEntry::tryInitialize(Metadata *metadata,
+                               PrivateMetadataState state,
+                               PrivateMetadataCompletionContext *context) {
+  // If we've already reached non-transitive completeness, just check that.
+  if (state == PrivateMetadataState::NonTransitiveComplete)
+    return checkTransitiveCompleteness();
+
+  // Otherwise, we must still be abstract, because tuples don't have an
+  // intermediate state between that and non-transitive completeness.
+  assert(state == PrivateMetadataState::Abstract);
+
+  bool allElementsTransitivelyComplete = true;
+  const Metadata *knownIncompleteElement = nullptr;
+
+  // Require all of the elements to be layout-complete.
+  for (size_t i = 0, e = Data.NumElements; i != e; ++i) {
+    auto request = MetadataRequest(MetadataState::LayoutComplete,
+                                   /*non-blocking*/ true);
+    auto eltType = Data.getElement(i).Type;
+    auto response = swift_checkMetadataState(request, eltType);
+
+    // Immediately continue in the most common scenario, which is that
+    // the element is transitively complete.
+    if (response.State == MetadataState::Complete)
+      continue;
+
+    // If the metadata is not layout-complete, we have to suspend.
+    if (!isAtLeast(response.State, MetadataState::LayoutComplete))
+      return { PrivateMetadataState::Abstract,
+               MetadataDependency(eltType, MetadataState::LayoutComplete) };
+
+    // Remember that there's a non-fully-complete element.
+    allElementsTransitivelyComplete = false;
+
+    // Remember the first element that's not even non-transitively complete.
+    if (!knownIncompleteElement &&
+        !isAtLeast(response.State, MetadataState::NonTransitiveComplete))
+      knownIncompleteElement = eltType;
+  }
+
+  // Okay, we're going to succeed now.
+
+  // Reload the proposed witness from where we stashed them.
+  auto proposedWitnesses = Data.ValueWitnesses;
+
+  // Set the real value-witness table.
+  Data.ValueWitnesses = &Witnesses;
+
   // Perform basic layout on the tuple.
   auto layout = getInitialLayoutForValueType();
-  performBasicLayout(layout, key.Elements, key.NumElements,
-    [&](size_t i, const Metadata *elt, size_t offset) {
-      Data.getElement(i).Type = elt;
-      Data.getElement(i).Offset = offset;
+  performBasicLayout(layout, Data.getElements(), Data.NumElements,
+    [](const TupleTypeMetadata::Element &elt) {
+      return elt.getTypeLayout();
+    },
+    [](size_t i, TupleTypeMetadata::Element &elt, size_t offset) {
+      elt.Offset = offset;
     });
 
   Witnesses.size = layout.size;
@@ -1242,7 +1357,7 @@ TupleCacheEntry::TupleCacheEntry(const Key &key,
   // FIXME: generalize this.
   bool hasExtraInhabitants = false;
   if (auto firstEltEIVWT = dyn_cast<ExtraInhabitantsValueWitnessTable>(
-                             key.Elements[0]->getValueWitnesses())) {
+                                Data.getElement(0).Type->getValueWitnesses())) {
     hasExtraInhabitants = true;
     Witnesses.flags = Witnesses.flags.withExtraInhabitants(true);
     Witnesses.extraInhabitantFlags = firstEltEIVWT->extraInhabitantFlags;
@@ -1253,15 +1368,8 @@ TupleCacheEntry::TupleCacheEntry(const Key &key,
   // Copy the function witnesses in, either from the proposed
   // witnesses or from the standard table.
   if (!proposedWitnesses) {
-    // For a tuple with a single element, just use the witnesses for
-    // the element type.
-    if (key.NumElements == 1) {
-      proposedWitnesses = key.Elements[0]->getValueWitnesses();
-
-      // Otherwise, use generic witnesses (when we can't pattern-match
-      // into something better).
-    } else if (layout.flags.isInlineStorage()
-               && layout.flags.isPOD()) {
+    // Try to pattern-match into something better than the generic witnesses.
+    if (layout.flags.isInlineStorage() && layout.flags.isPOD()) {
       if (!hasExtraInhabitants && layout.size == 8 && layout.flags.getAlignmentMask() == 7)
         proposedWitnesses = &VALUE_WITNESS_SYM(Bi64_);
       else if (!hasExtraInhabitants && layout.size == 4 && layout.flags.getAlignmentMask() == 3)
@@ -1289,24 +1397,47 @@ TupleCacheEntry::TupleCacheEntry(const Key &key,
   Witnesses.LOWER_ID = proposedWitnesses->LOWER_ID;
 #define DATA_VALUE_WITNESS(LOWER_ID, UPPER_ID, TYPE)
 #include "swift/ABI/ValueWitness.def"
+
+  // Okay, we're all done with layout and setting up the elements.
+  // Check transitive completeness.
+
+  // We don't need to check the element statuses again in a couple of cases:
+
+  // - If all the elements are transitively complete, we are, too.
+  if (allElementsTransitivelyComplete)
+    return { PrivateMetadataState::Complete, MetadataDependency() };
+
+  // - If there was an incomplete element, wait for it to be become
+  //   at least non-transitively complete.
+  if (knownIncompleteElement)
+    return { PrivateMetadataState::NonTransitiveComplete,
+             MetadataDependency(knownIncompleteElement,
+                                MetadataState::NonTransitiveComplete) };
+
+  // Otherwise, we need to do a more expensive check.
+  return checkTransitiveCompleteness();
 }
 
-const TupleTypeMetadata *
-swift::swift_getTupleTypeMetadata2(const Metadata *elt0, const Metadata *elt1,
+MetadataResponse
+swift::swift_getTupleTypeMetadata2(MetadataRequest request,
+                                   const Metadata *elt0, const Metadata *elt1,
                                    const char *labels,
                                    const ValueWitnessTable *proposedWitnesses) {
   const Metadata *elts[] = { elt0, elt1 };
-  return swift_getTupleTypeMetadata(TupleTypeFlags().withNumElements(2),
+  return swift_getTupleTypeMetadata(request,
+                                    TupleTypeFlags().withNumElements(2),
                                     elts, labels, proposedWitnesses);
 }
 
-const TupleTypeMetadata *
-swift::swift_getTupleTypeMetadata3(const Metadata *elt0, const Metadata *elt1,
+MetadataResponse
+swift::swift_getTupleTypeMetadata3(MetadataRequest request,
+                                   const Metadata *elt0, const Metadata *elt1,
                                    const Metadata *elt2,
                                    const char *labels,
                                    const ValueWitnessTable *proposedWitnesses) {
   const Metadata *elts[] = { elt0, elt1, elt2 };
-  return swift_getTupleTypeMetadata(TupleTypeFlags().withNumElements(3),
+  return swift_getTupleTypeMetadata(request,
+                                    TupleTypeFlags().withNumElements(3),
                                     elts, labels, proposedWitnesses);
 }
 
@@ -1631,6 +1762,7 @@ void swift::swift_initStructMetadata(StructMetadata *structType,
                                      size_t *fieldOffsets) {
   auto layout = getInitialLayoutForValueType();
   performBasicLayout(layout, fieldTypes, numFields,
+    [&](const TypeLayout *fieldType) { return fieldType; },
     [&](size_t i, const TypeLayout *fieldType, size_t offset) {
       assignUnlessEqual(fieldOffsets[i], offset);
     });
@@ -3307,6 +3439,11 @@ static Result performOnMetadataCache(const Metadata *metadata,
     description = classMetadata->getDescription();
   } else if (auto valueMetadata = dyn_cast<ValueMetadata>(metadata)) {
     description = valueMetadata->getDescription();
+  } else if (auto tupleMetadata = dyn_cast<TupleTypeMetadata>(metadata)) {
+    // The empty tuple is special and doesn't belong to a metadata cache.
+    if (tupleMetadata->NumElements == 0)
+      return std::move(callbacks).forOtherMetadata(tupleMetadata);
+    return std::move(callbacks).forTupleMetadata(tupleMetadata);
   } else {
     return std::move(callbacks).forOtherMetadata(metadata);
   }
@@ -3340,6 +3477,10 @@ bool swift::addToMetadataQueue(MetadataCompletionQueueEntry *queueEntry,
       return cache.enqueue(key, QueueEntry, Dependency);
     }
 
+    bool forTupleMetadata(const TupleTypeMetadata *metadata) {
+      return TupleTypes.get().enqueue(metadata, QueueEntry, Dependency);
+    }
+
     bool forOtherMetadata(const Metadata *metadata) && {
       swift_runtime_unreachable("metadata should always be complete");
     }
@@ -3352,22 +3493,15 @@ void swift::resumeMetadataCompletion(MetadataCompletionQueueEntry *queueEntry) {
   struct ResumeCallbacks {
     MetadataCompletionQueueEntry *QueueEntry;
 
-    static MetadataRequest getRequest() {
-      return MetadataRequest(MetadataState::Complete,
-                             /*non-blocking*/ true);
-    }
-
     void forGenericMetadata(const Metadata *metadata,
                             const TypeContextDescriptor *description,
                             GenericMetadataCache &cache,
                             MetadataCacheKey key) && {
-      cache.resumeInitialization(key, QueueEntry,
-                                 getRequest(),
-                                 description,
-                                 // This array comes from the metadata, so
-                                 // we can just "unslice" it to get the
-                                 // non-key arguments.
-                                 key.begin());
+      cache.resumeInitialization(key, QueueEntry);
+    }
+
+    void forTupleMetadata(const TupleTypeMetadata *metadata) {
+      TupleTypes.get().resumeInitialization(metadata, QueueEntry);
     }
 
     void forOtherMetadata(const Metadata *metadata) && {
@@ -3392,6 +3526,10 @@ MetadataResponse swift::swift_checkMetadataState(MetadataRequest request,
       return cache.await(key, Request);
     }
 
+    MetadataResponse forTupleMetadata(const TupleTypeMetadata *metadata) {
+      return TupleTypes.get().await(metadata, Request);
+    }
+
     /// All other type metadata are always complete.
     MetadataResponse forOtherMetadata(const Metadata *type) && {
       return MetadataResponse{type, MetadataState::Complete};
@@ -3404,19 +3542,33 @@ MetadataResponse swift::swift_checkMetadataState(MetadataRequest request,
 /// Search all the metadata that the given type has transitive completeness
 /// requirements on for something that matches the given predicate.
 template <class T>
-static bool findAnyTransitiveMetadata(const Metadata *type,
-                                      const TypeContextDescriptor *description,
-                                      T &&predicate) {
-  // Classes require their superclass to be transitively complete.
-  //
-  // We check for a class by looking at the type descriptor because we'll be
-  // loading the descriptor flags again when checking for a generic type,
-  // whereas we won't otherwise be touching the metadata kind.
-  if (isa<ClassDescriptor>(description)) {
-    if (auto super = cast<ClassMetadata>(type)->Superclass) {
+static bool findAnyTransitiveMetadata(const Metadata *type, T &&predicate) {
+  const TypeContextDescriptor *description;
+
+  // Classes require their superclass to be transitively complete,
+  // and they can be generic.
+  if (auto classType = dyn_cast<ClassMetadata>(type)) {
+    description = classType->getDescription();
+    if (auto super = classType->Superclass) {
       if (super->isTypeMetadata() && predicate(super))
         return true;
     }
+
+  // Value types can be generic.
+  } else if (auto valueType = dyn_cast<ValueMetadata>(type)) {
+    description = valueType->getDescription();
+
+  // Tuples require their element types to be transitively complete.
+  } else if (auto tupleType = dyn_cast<TupleTypeMetadata>(type)) {
+    for (size_t i = 0, e = tupleType->NumElements; i != e; ++i)
+      if (predicate(tupleType->getElement(i).Type))
+        return true;
+
+    return false;
+
+  // Other types do not have transitive completeness requirements.
+  } else {
+    return false;
   }
 
   // Generic types require their type arguments to be transitively complete.
@@ -3444,11 +3596,9 @@ static bool findAnyTransitiveMetadata(const Metadata *type,
 
 /// Do a quick check to see if all the transitive type metadata are complete.
 static bool
-areAllTransitiveMetadataComplete_cheap(const Metadata *type,
-                                     const TypeContextDescriptor *description) {
+areAllTransitiveMetadataComplete_cheap(const Metadata *type) {
   // Look for any transitive metadata that's incomplete.
-  return !findAnyTransitiveMetadata(type, description,
-                                    [](const Metadata *type) {
+  return !findAnyTransitiveMetadata(type, [](const Metadata *type) {
     struct IsIncompleteCallbacks {
       bool forGenericMetadata(const Metadata *type,
                               const TypeContextDescriptor *description,
@@ -3456,6 +3606,11 @@ areAllTransitiveMetadataComplete_cheap(const Metadata *type,
                               MetadataCacheKey key) && {
         // Metadata cache lookups aren't really cheap enough for this
         // optimization.
+        return true;
+      }
+
+      bool forTupleMetadata(const TupleTypeMetadata *metadata) {
+        // TODO: this could be cheap enough.
         return true;
       }
 
@@ -3478,8 +3633,7 @@ areAllTransitiveMetadataComplete_cheap(const Metadata *type,
 /// incomplete.  If we don't find anything, then we know all the transitive
 /// dependencies actually hold, and we can keep going.
 static MetadataDependency
-checkTransitiveCompleteness(const Metadata *initialType,
-                            const TypeContextDescriptor *initialDescription) {
+checkTransitiveCompleteness(const Metadata *initialType) {
   // TODO: it would nice to avoid allocating memory in common cases here.
   // In particular, we don't usually add *anything* to the worklist, and we
   // usually only add a handful of types to the map.
@@ -3521,7 +3675,7 @@ checkTransitiveCompleteness(const Metadata *initialType,
   // Consider the type itself to be presumed-complete.  We're looking for
   // a greatest fixed point.
   presumedCompleteTypes.insert(initialType);
-  if (findAnyTransitiveMetadata(initialType, initialDescription, isIncomplete))
+  if (findAnyTransitiveMetadata(initialType, isIncomplete))
     return dependency;
 
   // Drain the worklist.  The order we do things in doesn't really matter,
@@ -3530,17 +3684,9 @@ checkTransitiveCompleteness(const Metadata *initialType,
     auto type = worklist.back();
     worklist.pop_back();
 
-    // Only nominal types have transitive dependencies (for now).
-    const TypeContextDescriptor *description;
-    if (auto classType = dyn_cast<ClassMetadata>(type)) {
-      description = classType->getDescription();
-    } else {
-      description = cast<ValueMetadata>(type)->getDescription();
-    }
-
     // Search for incomplete dependencies.  This will set Dependency
     // if it finds anything.
-    if (findAnyTransitiveMetadata(type, description, isIncomplete))
+    if (findAnyTransitiveMetadata(type, isIncomplete))
       return dependency;
   }
 
@@ -3618,6 +3764,10 @@ checkMetadataDependency(MetadataDependency dependency) {
                                           GenericMetadataCache &cache,
                                           MetadataCacheKey key) && {
       return cache.checkDependency(key, Requirement);
+    }
+
+    MetadataDependency forTupleMetadata(const TupleTypeMetadata *metadata) {
+      return TupleTypes.get().checkDependency(metadata, Requirement);
     }
 
     MetadataDependency forOtherMetadata(const Metadata *type) && {

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3377,7 +3377,7 @@ void swift::resumeMetadataCompletion(
                                  // This array comes from the metadata, so
                                  // we can just "unslice" it to get the
                                  // non-key arguments.
-                                 key.KeyData.begin());
+                                 key.begin());
     }
 
     void forOtherMetadata(const Metadata *metadata) && {

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -927,9 +927,10 @@ public:
     auto flags = TupleTypeFlags().withNumElements(elements.size());
     if (!labels.empty())
       flags = flags.withNonConstantLabels(true);
-    return swift_getTupleTypeMetadata(flags, elements.data(),
+    return swift_getTupleTypeMetadata(MetadataState::Complete,
+                                      flags, elements.data(),
                                       labels.empty() ? nullptr : labels.c_str(),
-                                      /*proposedWitnesses=*/nullptr);
+                                      /*proposedWitnesses=*/nullptr).Value;
   }
 
   BuiltType createDependentMemberType(StringRef name, BuiltType base,

--- a/test/IRGen/closure.swift
+++ b/test/IRGen/closure.swift
@@ -47,7 +47,8 @@ func b<T : Ordinable>(seq seq: T) -> (Int) -> Int {
 // -- <rdar://problem/14443343> Boxing of tuples with generic elements
 // CHECK: define hidden swiftcc { i8*, %swift.refcounted* } @"$S7closure14captures_tuple1xx_q_tycx_q_t_tr0_lF"(%swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T, %swift.type* %U)
 func captures_tuple<T, U>(x x: (T, U)) -> () -> (T, U) {
-  // CHECK: [[METADATA:%.*]] = call %swift.type* @swift_getTupleTypeMetadata2(%swift.type* %T, %swift.type* %U, i8* null, i8** null)
+  // CHECK: [[T0:%.*]] = call swiftcc %swift.metadata_response @swift_getTupleTypeMetadata2(i64 0, %swift.type* %T, %swift.type* %U, i8* null, i8** null)
+  // CHECK-NEXT: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
   // CHECK-NOT: @swift_getTupleTypeMetadata2
   // CHECK: [[BOX:%.*]] = call swiftcc { %swift.refcounted*, %swift.opaque* } @swift_allocBox(%swift.type* [[METADATA]])
   // CHECK: [[ADDR:%.*]] = extractvalue { %swift.refcounted*, %swift.opaque* } [[BOX]], 1

--- a/test/IRGen/generic_metatypes.swift
+++ b/test/IRGen/generic_metatypes.swift
@@ -111,7 +111,7 @@ func makeGenericMetatypes() {
 }
 
 // CHECK: define linkonce_odr hidden swiftcc %swift.metadata_response @"$S17generic_metatypes6OneArgVyAA3FooVGMa"([[INT]]) [[NOUNWIND_READNONE_OPT:#[0-9]+]]
-// CHECK:   call swiftcc %swift.metadata_response @"$S17generic_metatypes6OneArgVMa"([[INT]] 0, %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}) [[NOUNWIND_READNONE:#[0-9]+]]
+// CHECK:   call swiftcc %swift.metadata_response @"$S17generic_metatypes6OneArgVMa"([[INT]] %0, %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}) [[NOUNWIND_READNONE:#[0-9]+]]
 
 // CHECK-LABEL: define hidden swiftcc %swift.metadata_response @"$S17generic_metatypes6OneArgVMa"
 // CHECK-SAME:    ([[INT]], %swift.type*)
@@ -128,7 +128,7 @@ func makeGenericMetatypes() {
 // CHECK-SAME:    ([[INT]]) [[NOUNWIND_READNONE_OPT]]
 // CHECK:   [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S17generic_metatypes3BarCMa"([[INT]] 255)
 // CHECK:   [[BAR:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
-// CHECK:   call swiftcc %swift.metadata_response @"$S17generic_metatypes7TwoArgsVMa"([[INT]] 0, %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, %swift.type* [[BAR]])
+// CHECK:   call swiftcc %swift.metadata_response @"$S17generic_metatypes7TwoArgsVMa"([[INT]] %0, %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, %swift.type* [[BAR]])
 
 // CHECK-LABEL: define hidden swiftcc %swift.metadata_response @"$S17generic_metatypes7TwoArgsVMa"
 // CHECK-SAME:    ([[INT]], %swift.type*, %swift.type*)
@@ -147,7 +147,7 @@ func makeGenericMetatypes() {
 // CHECK-SAME:    ([[INT]]) [[NOUNWIND_READNONE_OPT]]
 // CHECK:   [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S17generic_metatypes3BarCMa"([[INT]] 255)
 // CHECK:   [[BAR:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
-// CHECK:   call swiftcc %swift.metadata_response @"$S17generic_metatypes9ThreeArgsVMa"([[INT]] 0, %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, %swift.type* [[BAR]], %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}) [[NOUNWIND_READNONE]]
+// CHECK:   call swiftcc %swift.metadata_response @"$S17generic_metatypes9ThreeArgsVMa"([[INT]] %0, %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}, %swift.type* [[BAR]], %swift.type* {{.*}} @"$S17generic_metatypes3FooVMf", {{.*}}) [[NOUNWIND_READNONE]]
 
 // CHECK-LABEL: define hidden swiftcc %swift.metadata_response @"$S17generic_metatypes9ThreeArgsVMa"
 // CHECK-SAME:    ({{i[0-9]+}}, %swift.type*, %swift.type*, %swift.type*)
@@ -181,14 +181,14 @@ func makeGenericMetatypes() {
 // CHECK-NEXT: [[T0:%.*]] = bitcast %swift.type* [[BAR]] to i8*
 // CHECK-NEXT: store i8* [[T0]], i8** [[SLOT_3]]
 // CHECK-NEXT: [[BUFFER_PTR:%.*]] = bitcast [4 x i8*]* [[BUFFER]] to i8**
-// CHECK-NEXT: call swiftcc %swift.metadata_response @"$S17generic_metatypes8FourArgsVMa"([[INT]] 0, i8** [[BUFFER_PTR]]) [[NOUNWIND_ARGMEM:#[0-9]+]]
+// CHECK-NEXT: call swiftcc %swift.metadata_response @"$S17generic_metatypes8FourArgsVMa"([[INT]] %0, i8** [[BUFFER_PTR]]) [[NOUNWIND_ARGMEM:#[0-9]+]]
 // CHECK: call void @llvm.lifetime.end.p0i8
 
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$S17generic_metatypes8FiveArgsVyAA3FooVAA3BarCAegEGMa"
 // CHECK-SAME:    ([[INT]]) [[NOUNWIND_READNONE_OPT]]
 // CHECK:   [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S17generic_metatypes3BarCMa"([[INT]] 255)
 // CHECK:   [[BAR:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
-// CHECK:   call swiftcc %swift.metadata_response @"$S17generic_metatypes8FiveArgsVMa"([[INT]] 0, i8**
+// CHECK:   call swiftcc %swift.metadata_response @"$S17generic_metatypes8FiveArgsVMa"([[INT]] %0, i8**
 
 // CHECK-LABEL: define hidden swiftcc %swift.metadata_response @"$S17generic_metatypes8FiveArgsVMa"
 // CHECK-SAME:    ([[INT]], i8**) [[NOUNWIND_OPT:#[0-9]+]]

--- a/test/IRGen/generic_tuples.swift
+++ b/test/IRGen/generic_tuples.swift
@@ -105,17 +105,17 @@ func tuple_existentials() {
   // 2 element tuple
   var t2 = (1,2.0)
   a = t2
-  // CHECK: call %swift.type* @swift_getTupleTypeMetadata2({{.*}}@"$SSiN{{.*}}",{{.*}}@"$SSdN{{.*}}", i8* null, i8** null)
+  // CHECK: call swiftcc %swift.metadata_response @swift_getTupleTypeMetadata2(i64 %0, {{.*}}@"$SSiN{{.*}}",{{.*}}@"$SSdN{{.*}}", i8* null, i8** null)
 
 
   // 3 element tuple
   var t3 = ((),(),())
   a = t3
-  // CHECK: call %swift.type* @swift_getTupleTypeMetadata3({{.*}}@"$SytN{{.*}},{{.*}}@"$SytN{{.*}},{{.*}}@"$SytN{{.*}}, i8* null, i8** null)
+  // CHECK: call swiftcc %swift.metadata_response @swift_getTupleTypeMetadata3(i64 %0, {{.*}}@"$SytN{{.*}},{{.*}}@"$SytN{{.*}},{{.*}}@"$SytN{{.*}}, i8* null, i8** null)
 
   // 4 element tuple
   var t4 = (1,2,3,4)
   a = t4
-  // CHECK: call %swift.type* @swift_getTupleTypeMetadata(i64 4, {{.*}}, i8* null, i8** null)
+  // CHECK: call swiftcc %swift.metadata_response @swift_getTupleTypeMetadata(i64 %0, i64 4, {{.*}}, i8* null, i8** null)
 }
 

--- a/test/IRGen/nested_generics.swift
+++ b/test/IRGen/nested_generics.swift
@@ -15,7 +15,7 @@ public func makeAMetadata() {
 
 // Type constructor for OuterGenericStruct<Int>.InnerGenericStruct<String>
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$S15nested_generics18OuterGenericStructV05InnerdE0VySi_SSGMa"(i64)
-// CHECK: call swiftcc %swift.metadata_response @"$S15nested_generics18OuterGenericStructV05InnerdE0VMa"(i64 0, %swift.type* @"$SSiN", %swift.type* @"$SSSN")
+// CHECK: call swiftcc %swift.metadata_response @"$S15nested_generics18OuterGenericStructV05InnerdE0VMa"(i64 %0, %swift.type* @"$SSiN", %swift.type* @"$SSSN")
 // CHECK: ret %swift.metadata_response
 
 // Type constructor for OuterGenericStruct<T>.InnerGenericStruct<U>
@@ -23,7 +23,7 @@ public func makeAMetadata() {
 
 // Type constructor for OuterGenericStruct<Int>.InnerConcreteStruct
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$S15nested_generics18OuterGenericStructV013InnerConcreteE0VySi_GMa"(i64)
-// CHECK: call swiftcc %swift.metadata_response @"$S15nested_generics18OuterGenericStructV013InnerConcreteE0VMa"(i64 0, %swift.type* @"$SSiN")
+// CHECK: call swiftcc %swift.metadata_response @"$S15nested_generics18OuterGenericStructV013InnerConcreteE0VMa"(i64 %0, %swift.type* @"$SSiN")
 // CHECK: ret %swift.metadata_response
 
 // Type constructor for OuterGenericStruct<T>.InnerConcreteStruct
@@ -46,14 +46,14 @@ public struct OuterGenericStruct<T> {
 
 // Type constructor for OuterGenericClass<Int>.InnerGenericClass<String>
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$S15nested_generics17OuterGenericClassC05InnerdE0CySi_SSGMa"(i64)
-// CHECK: call swiftcc %swift.metadata_response @"$S15nested_generics17OuterGenericClassC05InnerdE0CMa"(i64 0, %swift.type* @"$SSiN", %swift.type* @"$SSSN")
+// CHECK: call swiftcc %swift.metadata_response @"$S15nested_generics17OuterGenericClassC05InnerdE0CMa"(i64 %0, %swift.type* @"$SSiN", %swift.type* @"$SSSN")
 
 // Type constructor for OuterGenericClass<T>.InnerGenericClass<U>
 // CHECK-LABEL: define{{( protected)?}} swiftcc %swift.metadata_response @"$S15nested_generics17OuterGenericClassC05InnerdE0CMa"(i64, %swift.type*, %swift.type*)
 
 // Type constructor for OuterGenericClass<Int>.InnerConcreteClass
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$S15nested_generics17OuterGenericClassC013InnerConcreteE0CySi_GMa"(i64)
-// CHECK: call swiftcc %swift.metadata_response @"$S15nested_generics17OuterGenericClassC013InnerConcreteE0CMa"(i64 0, %swift.type* @"$SSiN")
+// CHECK: call swiftcc %swift.metadata_response @"$S15nested_generics17OuterGenericClassC013InnerConcreteE0CMa"(i64 %0, %swift.type* @"$SSiN")
 // CHECK: ret %swift.metadata_response
 
 // Type constructor for OuterGenericClass<T>.InnerConcreteClass

--- a/test/IRGen/objc_generic_class_metadata.sil
+++ b/test/IRGen/objc_generic_class_metadata.sil
@@ -86,10 +86,10 @@ entry(%0: $Subclass, %1: $NSDictionary):
 // CHECK-SAME:    ([[INT]])
 // CHECK:         [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$SSo12GenericClassC_SitMa"([[INT]] 255)
 // CHECK:         [[TUPLE:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
-// CHECK:         call swiftcc %swift.metadata_response @"$SSaMa"([[INT]] 0, %swift.type* [[TUPLE]])
+// CHECK:         call swiftcc %swift.metadata_response @"$SSaMa"([[INT]] %0, %swift.type* [[TUPLE]])
 
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$SSo12GenericClassC_SitMa"
 // CHECK-SAME:    ([[INT]])
-// CHECK:         [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$SSo12GenericClassCMa"([[INT]] 0)
+// CHECK:         [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$SSo12GenericClassCMa"([[INT]] 255)
 // CHECK:         [[CLASS:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
-// CHECK:         call %swift.type* @swift_getTupleTypeMetadata2(%swift.type* [[CLASS]], %swift.type* @"$SSiN",
+// CHECK:         call swiftcc %swift.metadata_response @swift_getTupleTypeMetadata2([[INT]] %0, %swift.type* [[CLASS]], %swift.type* @"$SSiN", i8* null,

--- a/test/IRGen/typemetadata.sil
+++ b/test/IRGen/typemetadata.sil
@@ -45,14 +45,20 @@ bb0:
 // CHECK:      [[T0:%.*]] = load %swift.type*, %swift.type**  @"$S12typemetadata1SV_AA1CCtML", align 8
 // CHECK-NEXT: [[T1:%.*]] = icmp eq %swift.type* [[T0]], null
 // CHECK-NEXT: br i1 [[T1]]
-// CHECK:      [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S12typemetadata1CCMa"([[INT]] 0)
+// CHECK:      [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S12typemetadata1CCMa"([[INT]] 255)
 // CHECK:      [[T0:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
-// CHECK-NEXT: [[T1:%.*]] = call %swift.type* @swift_getTupleTypeMetadata2(%swift.type* {{.*}} @"$S12typemetadata1SVMf", {{.*}} %swift.type* [[T0]], i8* null, i8** null)
-// CHECK-NEXT: store atomic %swift.type* [[T1]], %swift.type** @"$S12typemetadata1SV_AA1CCtML" release, align 8
+// CHECK-NEXT: extractvalue %swift.metadata_response [[TMP]], 1
+// CHECK-NEXT: [[T1:%.*]] = call swiftcc %swift.metadata_response @swift_getTupleTypeMetadata2([[INT]] %0, %swift.type* {{.*}} @"$S12typemetadata1SVMf", {{.*}} %swift.type* [[T0]], i8* null, i8** null)
+// CHECK-NEXT: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[T1]], 0
+// CHECK-NEXT: [[STATE:%.*]] = extractvalue %swift.metadata_response [[T1]], 1
+// CHECK-NEXT: [[T0:%.*]] = icmp eq [[INT]] [[STATE]], 0
+// CHECK-NEXT: br i1 [[T0]],
+// CHECK:      store atomic %swift.type* [[METADATA]], %swift.type** @"$S12typemetadata1SV_AA1CCtML" release, align 8
 // CHECK-NEXT: br label
-// CHECK:      [[RES:%.*]] = phi
+// CHECK:      [[RES:%.*]] = phi %swift.type*
+// CHECK-NEXT: [[RES_STATE:%.*]] = phi [[INT]]
 // CHECK-NEXT: [[T0:%.*]] = insertvalue %swift.metadata_response undef, %swift.type* [[RES]], 0
-// CHECK-NEXT: [[T1:%.*]] = insertvalue %swift.metadata_response [[T0]], i64 0, 1
+// CHECK-NEXT: [[T1:%.*]] = insertvalue %swift.metadata_response [[T0]], [[INT]] [[RES_STATE]], 1
 // CHECK-NEXT: ret %swift.metadata_response [[T1]]
 
 // OSIZE: define hidden swiftcc %swift.metadata_response @"$S12typemetadata1CCMa"

--- a/test/Interpreter/metadata_cycles.swift
+++ b/test/Interpreter/metadata_cycles.swift
@@ -1,0 +1,80 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+var MetadataCycleTests = TestSuite("Metadata cycle tests")
+
+// rdar://18448285
+class test0_GenericClass<T> {
+  func foo() {}
+}
+class test0_GenericSubclass<T> : test0_GenericClass<test0_GenericSubclass> {}
+MetadataCycleTests.test("rdar://18448285") {
+  test0_GenericSubclass<Int>().foo()
+}
+
+// rdar://18685206
+final class test1_Box<T> {
+  init(_ value: T) {
+    self.value = value
+  }
+  let value: T
+}
+enum test1_List<T> {
+  case Nil
+  case Cons(T, test1_Box<test1_List<T>>)
+  var head: T? {
+    switch self {
+    case .Nil:
+      return nil
+    case .Cons(let h, _):
+      return h
+    }
+  }
+}
+MetadataCycleTests.test("rdar://18685206") {
+  let x: test1_List<Int> = .Nil
+  _ = x.head
+}
+
+// rdar://18847269
+struct test2_Thunk<T> {}
+enum test2_List<T> {
+  case Nil
+  case Cons(T, test2_Thunk<test2_List>)
+}
+MetadataCycleTests.test("rdar://18847269") {
+  let il0: test2_List<Int> = .Nil
+  _ = il0
+}
+
+// rdar://18903483
+final class test3_Box<T> {
+  private let _value : () -> T
+  init(_ value : T) {
+    self._value = { value }
+  }
+}
+enum test3_List<A> {
+  case Nil
+  case Cons(A, test3_Box<test3_List<A>>)
+}
+MetadataCycleTests.test("rdar://18903483") {
+  let x : test3_List<Int> = .Nil
+  _ = x
+
+  // rdar://19371082
+  _ = test3_List.Cons(7, test3_Box(test3_List.Nil)) 
+}
+
+// rdar://19320857
+struct test4_RoseTree<T> {
+  let value: T
+  let branches: [test4_RoseTree]
+}
+MetadataCycleTests.test("rdar://19320857") {
+  _ = test4_RoseTree(value: 1, branches: [])
+}
+
+runAllTests()


### PR DESCRIPTION
The next major piece of work here, as described in #15511, is to improve the resilient access pattern to support two-phase metadata initialization.  I don't expect to pick that up right away, though.