### PR TITLE
[SR-7297][TypeChecker] Discarding a function from a discardableResult method causes a compiler error

### DIFF
--- a/lib/Sema/TypeCheckStmt.cpp
+++ b/lib/Sema/TypeCheckStmt.cpp
@@ -1145,6 +1145,9 @@ void TypeChecker::checkIgnoredExpr(Expr *E) {
   if (E->getType()->is<AnyFunctionType>()) {
     bool isDiscardable = false;
     if (auto *Fn = dyn_cast<ApplyExpr>(E)) {
+      while (isa<ApplyExpr>(Fn->getFn())) {
+        Fn = cast<ApplyExpr>(Fn->getFn());
+      }
       if (auto *declRef = dyn_cast<DeclRefExpr>(Fn->getFn())) {
         if (auto *funcDecl = dyn_cast<AbstractFunctionDecl>(declRef->getDecl())) {
           if (funcDecl->getAttrs().hasAttribute<DiscardableResultAttr>()) {

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -600,6 +600,11 @@ class C {
   init(other: C?) { x = other }
 
   func method() {}
+
+  func method2() -> () -> String { return { "" } }
+
+  @discardableResult
+  func method3() -> () -> String { return { "" } }
 }
 
 _ = C(3) // expected-error {{missing argument label 'other:' in call}}
@@ -702,6 +707,12 @@ func unusedExpressionResults() {
   let optionalc:C? = nil
   optionalc?.method()  // ok
   optionalc?.method  // expected-error {{expression resolves to an unused function}}
+
+  optionalc?.method2 // expected-error {{expression resolves to an unused function}}
+  optionalc?.method2() // expected-error {{expression resolves to an unused function}}
+
+  optionalc?.method3 // ok
+  optionalc?.method3() // ok
 }
 
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

From the ticket:

This example doesn't compile:

```swift
struct S {
  @discardableResult
  func foo() -> () -> String { fatalError() }
}

let s = S()
s.foo() // error: Expression resolves to an unused function
```

But really it should.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7297](https://bugs.swift.org/browse/SR-7297).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
