### PR TITLE
[SR-7165] Excise iostream from reflection

### DIFF
--- a/include/swift/Demangling/Demangler.h
+++ b/include/swift/Demangling/Demangler.h
@@ -24,7 +24,7 @@
 //#define NODE_FACTORY_DEBUGGING
 
 #ifdef NODE_FACTORY_DEBUGGING
-#include <iostream>
+#include "llvm/Support/raw_ostream.h"
 #endif
 
 
@@ -74,14 +74,14 @@ public:
 
   NodeFactory() {
 #ifdef NODE_FACTORY_DEBUGGING
-    std::cerr << "## New NodeFactory " << this << "\n";
+    llvm::errs() << "## New NodeFactory " << this << "\n";
 #endif
   }
   
   virtual ~NodeFactory() {
     freeSlabs(CurrentSlab);
 #ifdef NODE_FACTORY_DEBUGGING
-    std::cerr << "Delete NodeFactory " << this << "\n";
+    llvm::errs() << "Delete NodeFactory " << this << "\n";
 #endif
   }
   
@@ -92,7 +92,7 @@ public:
     size_t ObjectSize = NumObjects * sizeof(T);
     CurPtr = align(CurPtr, alignof(T));
 #ifdef NODE_FACTORY_DEBUGGING
-    std::cerr << "  alloc " << ObjectSize << ", CurPtr = "
+    llvm::errs() << "  alloc " << ObjectSize << ", CurPtr = "
               << (void *)CurPtr << "\n";
 #endif
 
@@ -113,7 +113,7 @@ public:
       End = (char *)newSlab + AllocSize;
       assert(CurPtr + ObjectSize <= End);
 #ifdef NODE_FACTORY_DEBUGGING
-      std::cerr << "    ** new slab " << newSlab << ", allocsize = "
+      llvm::errs() << "    ** new slab " << newSlab << ", allocsize = "
                 << AllocSize << ", CurPtr = " << (void *)CurPtr
                 << ", End = " << (void *)End << "\n";
 #endif
@@ -138,7 +138,7 @@ public:
     size_t AdditionalAlloc = MinGrowth * sizeof(T);
 
 #ifdef NODE_FACTORY_DEBUGGING
-    std::cerr << "  realloc " << Objects << ", num = " << NumObjects
+    llvm::errs() << "  realloc " << Objects << ", num = " << NumObjects
               << " (size = " << OldAllocSize << "), Growth = " << Growth
               << " (size = " << AdditionalAlloc << ")\n";
 #endif
@@ -149,7 +149,7 @@ public:
       CurPtr += AdditionalAlloc;
       Capacity += MinGrowth;
 #ifdef NODE_FACTORY_DEBUGGING
-      std::cerr << "    ** can grow: CurPtr = " << (void *)CurPtr << "\n";
+      llvm::errs() << "    ** can grow: CurPtr = " << (void *)CurPtr << "\n";
 #endif
       return;
     }

--- a/include/swift/Reflection/MetadataSource.h
+++ b/include/swift/Reflection/MetadataSource.h
@@ -24,11 +24,11 @@
 
 #include "llvm/ADT/Optional.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/raw_ostream.h"
 
 using llvm::cast;
 
 #include <climits>
-#include <iostream>
 
 namespace swift {
 namespace reflection {
@@ -177,7 +177,7 @@ public:
   }
 
   void dump() const;
-  void dump(std::ostream &OS, unsigned Indent = 0) const;
+  void dump(llvm::raw_ostream &OS, unsigned Indent = 0) const;
   template <typename Allocator>
   static const MetadataSource *decode(Allocator &A, const std::string &str) {
     auto begin = str.begin();

--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -29,8 +29,8 @@
 #include "swift/Reflection/TypeRef.h"
 #include "swift/Reflection/TypeRefBuilder.h"
 #include "swift/Runtime/Unreachable.h"
+#include "llvm/Support/raw_ostream.h"
 
-#include <iostream>
 #include <set>
 #include <vector>
 #include <unordered_map>
@@ -107,7 +107,7 @@ public:
     return sizeof(StoredPointer) * 2;
   }
 
-  void dumpAllSections(std::ostream &OS) {
+  void dumpAllSections(llvm::raw_ostream &OS) {
     getBuilder().dumpAllSections();
   }
 

--- a/include/swift/Reflection/TypeLowering.h
+++ b/include/swift/Reflection/TypeLowering.h
@@ -21,8 +21,8 @@
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/Support/Casting.h"
+#include "llvm/Support/raw_ostream.h"
 
-#include <iostream>
 #include <memory>
 
 namespace swift {
@@ -129,7 +129,7 @@ public:
   unsigned getNumExtraInhabitants() const { return NumExtraInhabitants; }
 
   void dump() const;
-  void dump(std::ostream &OS, unsigned Indent = 0) const;
+  void dump(llvm::raw_ostream &OS, unsigned Indent = 0) const;
 };
 
 struct FieldInfo {

--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -23,8 +23,7 @@
 #include "swift/ABI/MetadataValues.h"
 #include "swift/Remote/MetadataReader.h"
 #include "swift/Runtime/Unreachable.h"
-
-#include <iostream>
+#include "llvm/Support/raw_ostream.h"
 
 namespace swift {
 namespace reflection {
@@ -150,7 +149,7 @@ public:
   }
 
   void dump() const;
-  void dump(std::ostream &OS, unsigned Indent = 0) const;
+  void dump(llvm::raw_ostream &OS, unsigned Indent = 0) const;
 
   bool isConcrete() const;
   bool isConcreteAfterSubstitutions(const GenericArgumentMap &Subs) const;

--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -24,8 +24,8 @@
 #include "swift/Reflection/TypeLowering.h"
 #include "swift/Reflection/TypeRef.h"
 #include "llvm/ADT/Optional.h"
+#include "llvm/Support/raw_ostream.h"
 
-#include <iostream>
 #include <vector>
 #include <unordered_map>
 
@@ -122,7 +122,7 @@ struct ClosureContextInfo {
   unsigned NumBindings = 0;
 
   void dump() const;
-  void dump(std::ostream &OS) const;
+  void dump(llvm::raw_ostream &OS) const;
 };
 
 struct FieldTypeInfo {
@@ -402,12 +402,12 @@ public:
   ///
 
   void dumpTypeRef(llvm::StringRef MangledName,
-                   std::ostream &OS, bool printTypeName = false);
-  void dumpFieldSection(std::ostream &OS);
-  void dumpAssociatedTypeSection(std::ostream &OS);
-  void dumpBuiltinTypeSection(std::ostream &OS);
-  void dumpCaptureSection(std::ostream &OS);
-  void dumpAllSections(std::ostream &OS);
+                   llvm::raw_ostream &OS, bool printTypeName = false);
+  void dumpFieldSection(llvm::raw_ostream &OS);
+  void dumpAssociatedTypeSection(llvm::raw_ostream &OS);
+  void dumpBuiltinTypeSection(llvm::raw_ostream &OS);
+  void dumpCaptureSection(llvm::raw_ostream &OS);
+  void dumpAllSections(llvm::raw_ostream &OS);
 };
 
 

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -307,7 +307,7 @@ void NodeFactory::freeSlabs(Slab *slab) {
   while (slab) {
     Slab *prev = slab->Previous;
 #ifdef NODE_FACTORY_DEBUGGING
-    std::cerr << "  free slab = " << slab << "\n";
+    llvm::errs() << "  free slab = " << slab << "\n";
 #endif
     free(slab);
     slab = prev;

--- a/stdlib/public/Reflection/MetadataSource.cpp
+++ b/stdlib/public/Reflection/MetadataSource.cpp
@@ -19,22 +19,22 @@ using namespace reflection;
 
 class PrintMetadataSource
   : public MetadataSourceVisitor<PrintMetadataSource, void> {
-  std::ostream &OS;
+  llvm::raw_ostream &OS;
   unsigned Indent;
 
-  std::ostream &indent(unsigned Amount) {
+  llvm::raw_ostream &indent(unsigned Amount) {
     for (unsigned i = 0; i < Amount; ++i)
       OS << ' ';
     return OS;
   }
 
-  std::ostream &printHeader(std::string Name) {
+  llvm::raw_ostream &printHeader(std::string Name) {
     indent(Indent) << '(' << Name;
     return OS;
   }
 
   template<typename T>
-  std::ostream &printField(std::string name, const T &value) {
+  llvm::raw_ostream &printField(std::string name, const T &value) {
     if (!name.empty())
       OS << " " << name << "=" << value;
     else
@@ -55,7 +55,7 @@ class PrintMetadataSource
   }
 
 public:
-  PrintMetadataSource(std::ostream &OS, unsigned Indent)
+  PrintMetadataSource(llvm::raw_ostream &OS, unsigned Indent)
     : OS(OS), Indent(Indent) {}
 
   void
@@ -100,10 +100,10 @@ public:
 };
 
 void MetadataSource::dump() const {
-  dump(std::cerr, 0);
+  dump(llvm::errs(), 0);
 }
 
-void MetadataSource::dump(std::ostream &OS, unsigned Indent) const {
+void MetadataSource::dump(llvm::raw_ostream &OS, unsigned Indent) const {
   PrintMetadataSource(OS, Indent).visit(this);
   OS << '\n';
 }

--- a/stdlib/public/Reflection/TypeRef.cpp
+++ b/stdlib/public/Reflection/TypeRef.cpp
@@ -24,22 +24,22 @@ using namespace swift;
 using namespace reflection;
 
 class PrintTypeRef : public TypeRefVisitor<PrintTypeRef, void> {
-  std::ostream &OS;
+  llvm::raw_ostream &OS;
   unsigned Indent;
 
-  std::ostream &indent(unsigned Amount) {
+  llvm::raw_ostream &indent(unsigned Amount) {
     for (unsigned i = 0; i < Amount; ++i)
       OS << ' ';
     return OS;
   }
 
-  std::ostream &printHeader(std::string Name) {
+  llvm::raw_ostream &printHeader(std::string Name) {
     indent(Indent) << '(' << Name;
     return OS;
   }
 
   template<typename T>
-  std::ostream &printField(std::string name, const T &value) {
+  llvm::raw_ostream &printField(std::string name, const T &value) {
     if (!name.empty())
       OS << " " << name << "=" << value;
     else
@@ -56,7 +56,7 @@ class PrintTypeRef : public TypeRefVisitor<PrintTypeRef, void> {
   }
 
 public:
-  PrintTypeRef(std::ostream &OS, unsigned Indent)
+  PrintTypeRef(llvm::raw_ostream &OS, unsigned Indent)
     : OS(OS), Indent(Indent) {}
 
   void visitBuiltinTypeRef(const BuiltinTypeRef *B) {
@@ -374,12 +374,12 @@ const OpaqueTypeRef *OpaqueTypeRef::get() {
 }
 
 void TypeRef::dump() const {
-  dump(std::cerr);
+  dump(llvm::errs());
 }
 
-void TypeRef::dump(std::ostream &OS, unsigned Indent) const {
+void TypeRef::dump(llvm::raw_ostream &OS, unsigned Indent) const {
   PrintTypeRef(OS, Indent).visit(this);
-  OS << std::endl;
+  OS << '\n';
 }
 
 bool TypeRef::isConcrete() const {

--- a/stdlib/public/Reflection/TypeRefBuilder.cpp
+++ b/stdlib/public/Reflection/TypeRefBuilder.cpp
@@ -285,7 +285,7 @@ TypeRefBuilder::getClosureContextInfo(const CaptureDescriptor &CD,
 
 void
 TypeRefBuilder::dumpTypeRef(StringRef MangledName,
-                            std::ostream &OS, bool printTypeName) {
+                            llvm::raw_ostream &OS, bool printTypeName) {
   auto DemangleTree = Dem.demangleType(MangledName);
   auto TypeName = nodeToString(DemangleTree);
   OS << TypeName << '\n';
@@ -300,7 +300,7 @@ TypeRefBuilder::dumpTypeRef(StringRef MangledName,
   OS << '\n';
 }
 
-void TypeRefBuilder::dumpFieldSection(std::ostream &OS) {
+void TypeRefBuilder::dumpFieldSection(llvm::raw_ostream &OS) {
   for (const auto &sections : ReflectionInfos) {
     uintptr_t TypeRefOffset = sections.Field.SectionOffset
                             - sections.TypeReference.SectionOffset;
@@ -328,7 +328,7 @@ void TypeRefBuilder::dumpFieldSection(std::ostream &OS) {
   }
 }
 
-void TypeRefBuilder::dumpAssociatedTypeSection(std::ostream &OS) {
+void TypeRefBuilder::dumpAssociatedTypeSection(llvm::raw_ostream &OS) {
   for (const auto &sections : ReflectionInfos) {
     uintptr_t TypeRefOffset = sections.AssociatedType.SectionOffset
                             - sections.TypeReference.SectionOffset;
@@ -355,7 +355,7 @@ void TypeRefBuilder::dumpAssociatedTypeSection(std::ostream &OS) {
   }
 }
 
-void TypeRefBuilder::dumpBuiltinTypeSection(std::ostream &OS) {
+void TypeRefBuilder::dumpBuiltinTypeSection(llvm::raw_ostream &OS) {
   for (const auto &sections : ReflectionInfos) {
     uintptr_t TypeRefOffset = sections.Builtin.SectionOffset
                             - sections.TypeReference.SectionOffset;
@@ -374,10 +374,10 @@ void TypeRefBuilder::dumpBuiltinTypeSection(std::ostream &OS) {
 }
 
 void ClosureContextInfo::dump() const {
-  dump(std::cerr);
+  dump(llvm::errs());
 }
 
-void ClosureContextInfo::dump(std::ostream &OS) const {
+void ClosureContextInfo::dump(llvm::raw_ostream &OS) const {
   OS << "- Capture types:\n";
   for (auto *TR : CaptureTypes) {
     if (TR == nullptr)
@@ -399,7 +399,7 @@ void ClosureContextInfo::dump(std::ostream &OS) const {
   OS << "\n";
 }
 
-void TypeRefBuilder::dumpCaptureSection(std::ostream &OS) {
+void TypeRefBuilder::dumpCaptureSection(llvm::raw_ostream &OS) {
   for (const auto &sections : ReflectionInfos) {
     uintptr_t TypeRefOffset = sections.Capture.SectionOffset
                             - sections.TypeReference.SectionOffset;
@@ -410,7 +410,7 @@ void TypeRefBuilder::dumpCaptureSection(std::ostream &OS) {
   }
 }
 
-void TypeRefBuilder::dumpAllSections(std::ostream &OS) {
+void TypeRefBuilder::dumpAllSections(llvm::raw_ostream &OS) {
   OS << "FIELDS:\n";
   OS << "=======\n";
   dumpFieldSection(OS);

--- a/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
+++ b/stdlib/public/SwiftRemoteMirror/CMakeLists.txt
@@ -1,5 +1,6 @@
 # HACK: Force this library to build with undefined symbols.
 string(REGEX REPLACE "-Wl,-z,defs" "" CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
+append("-undefined dynamic_lookup" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
 
 # libswiftRemoteMirror.dylib should not have runtime dependencies; it's
 # always built as a shared library.

--- a/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
+++ b/stdlib/public/SwiftRemoteMirror/SwiftRemoteMirror.cpp
@@ -408,9 +408,9 @@ int swift_reflection_projectExistential(SwiftReflectionContextRef ContextRef,
 void swift_reflection_dumpTypeRef(swift_typeref_t OpaqueTypeRef) {
   auto TR = reinterpret_cast<const TypeRef *>(OpaqueTypeRef);
   if (TR == nullptr) {
-    std::cout << "<null type reference>\n";
+    llvm::outs() << "<null type reference>\n";
   } else {
-    TR->dump(std::cout);
+    TR->dump(llvm::outs());
   }
 }
 
@@ -420,9 +420,9 @@ void swift_reflection_dumpInfoForTypeRef(SwiftReflectionContextRef ContextRef,
   auto TR = reinterpret_cast<const TypeRef *>(OpaqueTypeRef);
   auto TI = Context->getTypeInfo(TR);
   if (TI == nullptr) {
-    std::cout << "<null type info>\n";
+    llvm::outs() << "<null type info>\n";
   } else {
-    TI->dump(std::cout);
+    TI->dump(llvm::outs());
   }
 }
 
@@ -431,9 +431,9 @@ void swift_reflection_dumpInfoForMetadata(SwiftReflectionContextRef ContextRef,
   auto Context = ContextRef->nativeContext;
   auto TI = Context->getMetadataTypeInfo(Metadata);
   if (TI == nullptr) {
-    std::cout << "<null type info>\n";
+    llvm::outs() << "<null type info>\n";
   } else {
-    TI->dump(std::cout);
+    TI->dump(llvm::outs());
   }
 }
 
@@ -442,9 +442,9 @@ void swift_reflection_dumpInfoForInstance(SwiftReflectionContextRef ContextRef,
   auto Context = ContextRef->nativeContext;
   auto TI = Context->getInstanceTypeInfo(Object);
   if (TI == nullptr) {
-    std::cout << "<null type info>\n";
+    llvm::outs() << "<null type info>\n";
   } else {
-    TI->dump(std::cout);
+    TI->dump(llvm::outs());
   }
 }
 

--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -37,6 +37,7 @@
 #endif
 
 #include <algorithm>
+#include <iostream>
 #include <csignal>
 
 using llvm::dyn_cast;

--- a/tools/swift-reflection-dump/swift-reflection-dump.cpp
+++ b/tools/swift-reflection-dump/swift-reflection-dump.cpp
@@ -28,6 +28,7 @@
 #include "llvm/Object/ELF.h"
 #include "llvm/Object/ELFObjectFile.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/Support/raw_ostream.h"
 
 #if defined(_WIN32)
 #include <io.h>
@@ -36,7 +37,6 @@
 #endif
 
 #include <algorithm>
-#include <iostream>
 #include <csignal>
 
 using llvm::dyn_cast;
@@ -228,7 +228,7 @@ public:
 static int doDumpReflectionSections(ArrayRef<std::string> binaryFilenames,
                                     StringRef arch,
                                     ActionType action,
-                                    std::ostream &OS) {
+                                    llvm::raw_ostream &OS) {
   // Note: binaryOrError and objectOrError own the memory for our ObjectFile;
   // once they go out of scope, we can no longer do anything.
   std::vector<OwningBinary<Binary>> binaryOwners;


### PR DESCRIPTION
<!-- What's in this pull request? -->
Replace iostream with [raw_ostream](http://www.llvm.org/docs/CodingStandards.html#raw-ostream) to follow [LLVM Coding Standards](http://www.llvm.org/docs/CodingStandards.html#include-iostream-is-forbidden).
With this PR, we still use iostream for reading in tools/swift-reflection-dump/swift-reflection-dump.cpp.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7165](https://bugs.swift.org/browse/SR-7165).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
