### PR TITLE
stdlib: Printable_Double signaling nan tests on i386 only in Onone mode

### DIFF
--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -637,11 +637,13 @@ PrintTests.test("Printable_Double") {
   expectNaN("nan", Float64(bitPattern: 0x7fff_ffff_ffff_ffff))
   expectNaN("nan", Float64(bitPattern: 0x7ffb_ffff_ffff_ffff))
   expectNaN("-nan", -Double(nan: 65535, signaling: false))
-  expectNaN("nan", Double.signalingNaN)
-  expectNaN("-nan", -Double.signalingNaN)
-  expectNaN("nan", Double(nan: 65535, signaling: true))
-  expectNaN("-nan", -Double(nan: 65535, signaling: true))
-  expectNaN("nan", Float64(bitPattern: 0x7ff7_ffff_ffff_ffff))
+  if _isDebugAssertConfiguration() {
+    expectNaN("nan", Double.signalingNaN)
+    expectNaN("-nan", -Double.signalingNaN)
+    expectNaN("nan", Double(nan: 65535, signaling: true))
+    expectNaN("-nan", -Double(nan: 65535, signaling: true))
+    expectNaN("nan", Float64(bitPattern: 0x7ff7_ffff_ffff_ffff))
+  }
 #else
   // 32-bit i386 lacks signaling Double nans or payloads on NaNs
   expectNaN("nan(0xffff)", Double(nan: 65535, signaling: false))


### PR DESCRIPTION
i386 does not support signaling nans *accross calls* (SR-1515). However,
after inlining we do get a signaling representation. So only run the
test in Onone mode.

rdar://39104087