### PR TITLE
Encode/Decode LosslessStringConvertible keyed Dictionaries as keyed containers.

### DIFF
--- a/stdlib/public/core/Codable.swift.gyb
+++ b/stdlib/public/core/Codable.swift.gyb
@@ -1968,7 +1968,7 @@ extension Set : Decodable where Element : Decodable {
   }
 }
 
-/// A wrapper for dictionary keys which are Strings or Ints.
+/// A wrapper for dictionary keys which conform to LosslessStringConvertible.
 @usableFromInline // FIXME(sil-serialize-all)
 @_fixed_layout // FIXME(sil-serialize-all)
 internal struct _DictionaryCodingKey : CodingKey {
@@ -1994,7 +1994,7 @@ internal struct _DictionaryCodingKey : CodingKey {
 extension Dictionary : Encodable where Key : Encodable, Value : Encodable {
   /// Encodes the contents of this dictionary into the given encoder.
   ///
-  /// If the dictionary uses `String` or `Int` keys, the contents are encoded
+  /// If the dictionary uses LosslessStringConvertible keys, the contents are encoded
   /// in a keyed container. Otherwise, the contents are encoded as alternating
   /// key-value pairs in an unkeyed container.
   ///
@@ -2013,7 +2013,7 @@ extension Dictionary : Encodable where Key : Encodable, Value : Encodable {
         try container.encode(value, forKey: codingKey)
       }
     } else {
-      // Keys are Encodable but not Strings or Ints, so we cannot arbitrarily
+      // Keys are Encodable but not LosslessStringConvertible, so we cannot arbitrarily
       // convert to keys. We can encode as an array of alternating key-value
       // pairs, though.
       var container = encoder.unkeyedContainer()
@@ -2036,7 +2036,6 @@ extension Dictionary : Decodable where Key : Decodable, Value : Decodable {
   public init(from decoder: Decoder) throws {
     self.init()
 
-    // this handles String as well as Int, but also Int8, UInt8, Double, Float and all custom types conforming to LosslessStringConvertible
     if Key.self is LosslessStringConvertible.Type {
         let container = try decoder.container(keyedBy: _DictionaryCodingKey.self)
         for codingKey in container.allKeys {

--- a/stdlib/public/core/Codable.swift.gyb
+++ b/stdlib/public/core/Codable.swift.gyb
@@ -1981,7 +1981,6 @@ internal struct _DictionaryCodingKey : CodingKey {
   @usableFromInline // FIXME(sil-serialize-all)
   internal init?(stringValue: String) {
     self.stringValue = stringValue
-    self.intValue = Int(stringValue)
   }
 
   @inlinable // FIXME(sil-serialize-all)
@@ -2005,18 +2004,12 @@ extension Dictionary : Encodable where Key : Encodable, Value : Encodable {
   /// - Parameter encoder: The encoder to write data to.
   @inlinable // FIXME(sil-serialize-all)
   public func encode(to encoder: Encoder) throws {
-    if Key.self == String.self {
-      // Since the keys are already Strings, we can use them as keys directly.
+    if Key.self is LosslessStringConvertible.Type {
+      // Since the keys are convertible to String without any loss of information
+      // we can create coding keys from their .description values
       var container = encoder.container(keyedBy: _DictionaryCodingKey.self)
       for (key, value) in self {
-        let codingKey = _DictionaryCodingKey(stringValue: key as! String)!
-        try container.encode(value, forKey: codingKey)
-      }
-    } else if Key.self == Int.self {
-      // Since the keys are already Ints, we can use them as keys directly.
-      var container = encoder.container(keyedBy: _DictionaryCodingKey.self)
-      for (key, value) in self {
-        let codingKey = _DictionaryCodingKey(intValue: key as! Int)!
+        let codingKey = _DictionaryCodingKey(stringValue: (key as! LosslessStringConvertible).description)!
         try container.encode(value, forKey: codingKey)
       }
     } else {
@@ -2043,34 +2036,22 @@ extension Dictionary : Decodable where Key : Decodable, Value : Decodable {
   public init(from decoder: Decoder) throws {
     self.init()
 
-    if Key.self == String.self {
-      // The keys are Strings, so we should be able to expect a keyed container.
-      let container = try decoder.container(keyedBy: _DictionaryCodingKey.self)
-      for key in container.allKeys {
-        let value = try container.decode(Value.self, forKey: key)
-        self[key.stringValue as! Key] = value
-      }
-    } else if Key.self == Int.self {
-      // The keys are Ints, so we should be able to expect a keyed container.
-      let container = try decoder.container(keyedBy: _DictionaryCodingKey.self)
-      for key in container.allKeys {
-        guard key.intValue != nil else {
-          // We provide stringValues for Int keys; if an encoder chooses not to
-          // use the actual intValues, we've encoded string keys.
-          // So on init, _DictionaryCodingKey tries to parse string keys as
-          // Ints. If that succeeds, then we would have had an intValue here.
-          // We don't, so this isn't a valid Int key.
-          var codingPath = decoder.codingPath
-          codingPath.append(key)
-          throw DecodingError.typeMismatch(
-            Int.self, DecodingError.Context(
-              codingPath: codingPath,
-              debugDescription: "Expected Int key but found String key instead."))
+    // this handles String as well as Int, but also Int8, UInt8, Double, Float and all custom types conforming to LosslessStringConvertible
+    if Key.self is LosslessStringConvertible.Type {
+        let container = try decoder.container(keyedBy: _DictionaryCodingKey.self)
+        for codingKey in container.allKeys {
+            guard let convertedKey = (Key.self as! LosslessStringConvertible.Type).init(codingKey.stringValue) else {
+                var codingPath = decoder.codingPath
+                codingPath.append(codingKey)
+                throw DecodingError.typeMismatch(
+                  Int.self, DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "Could not convert CodingKey's string value \(codingKey.stringValue) to \(Key.self). Expected convertible string value."))
+            }
+            
+            let value = try container.decode(Value.self, forKey: codingKey)
+            self[convertedKey] = value
         }
-
-        let value = try container.decode(Value.self, forKey: key)
-        self[key.intValue! as! Key] = value
-      }
     } else {
       // We should have encoded as an array of alternating key-value pairs.
       var container = try decoder.unkeyedContainer()


### PR DESCRIPTION
<!-- What's in this pull request? -->
Dictionary encodes as keyed container if Key.self is either String or Int. To me, the limitation to only those two types and not all types conforming to LosslessStringConvertible seems an unnecessary limitation.

The new version will e.g. handle also all (U)Int(8|16|32|64)s the way it is currently handling only Ints. This also applies for numerous other types, like Double, Float, Substring or custom LosslessStringConvertible types. 

My reasons this proposed change are:
 * unified encoding of all integer types
 * in my opinion better readable outputs for Dictionaries in e.g. JSON

In the current version, the decoding code provides no backwards compatibility. 
However it is possible to implement falling back to decoding as unkeyed container if decoding as keyed container fails, so also data encoded with the old code can be decoded, in a relatively simple addition (using switch instead of if for the type check and falling through if an error is thrown when requesting a keyed container).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->