### PR TITLE
[Syntax] Redesign IfConfigDecl syntax

### DIFF
--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -648,46 +648,25 @@ static Expr *findAnyLikelySimulatorEnvironmentTest(Expr *Condition) {
 ParserResult<IfConfigDecl> Parser::parseIfConfig(
     llvm::function_ref<void(SmallVectorImpl<ASTNode> &, bool)> parseElements) {
   SyntaxParsingContext IfConfigCtx(SyntaxContext, SyntaxKind::IfConfigDecl);
+
   SmallVector<IfConfigClause, 4> Clauses;
   Parser::StructureMarkerRAII ParsingDecl(
       *this, Tok.getLoc(), Parser::StructureMarkerKind::IfConfig);
 
   bool foundActive = false;
   bool isVersionCondition = false;
-  enum class ClauseKind {
-    If,
-    ElseIf,
-    Else,
-  };
   while (1) {
-    ClauseKind ClKind;
-    if (Tok.is(tok::pound_if)) {
-      ClKind = ClauseKind::If;
-    } else if (Tok.is(tok::pound_elseif)) {
-      ClKind = ClauseKind::ElseIf;
-    } else {
-      ClKind = ClauseKind::Else;
-    }
-    if (ClKind == ClauseKind::Else) {
-      // Collect all #elseif to a list.
-      SyntaxContext->collectNodesInPlace(SyntaxKind::ElseifDirectiveClauseList);
-    }
     SyntaxParsingContext ClauseContext(SyntaxContext,
-                                       ClKind == ClauseKind::Else ?
-                                        SyntaxKind::ElseDirectiveClause :
-                                        SyntaxKind::ElseifDirectiveClause);
-    SWIFT_DEFER {
-      // Avoid making a clause for if
-      if (ClKind == ClauseKind::If)
-        ClauseContext.setTransparent();
-    };
+                                       SyntaxKind::IfConfigClause);
+
+    bool isElse = Tok.is(tok::pound_else);
     SourceLoc ClauseLoc = consumeToken();
     Expr *Condition = nullptr;
     bool isActive = false;
 
     // Parse the condition.  Evaluate it to determine the active
     // clause unless we're doing a parse-only pass.
-    if (ClKind == ClauseKind::Else) {
+    if (isElse) {
       isActive = !foundActive && State->PerformConditionEvaluation;
     } else {
       llvm::SaveAndRestore<bool> S(InPoundIfEnvironment, true);
@@ -739,9 +718,10 @@ ParserResult<IfConfigDecl> Parser::parseIfConfig(
     if (Tok.isNot(tok::pound_elseif, tok::pound_else))
       break;
 
-    if (ClKind == ClauseKind::Else)
+    if (isElse)
       diagnose(Tok, diag::expected_close_after_else_directive);
   }
+  SyntaxContext->collectNodesInPlace(SyntaxKind::IfConfigClauseList);
 
   SourceLoc EndLoc;
   bool HadMissingEnd = parseEndIfDirective(EndLoc);

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -16,7 +16,7 @@ import <AccessPathComponent>A.</AccessPathComponent><AccessPathComponent>B.</Acc
 import struct <AccessPathComponent>A.</AccessPathComponent><AccessPathComponent>B</AccessPathComponent></ImportDecl><PoundWarningDecl>
 
 #warning(<StringLiteralExpr>"test warning"</StringLiteralExpr>)</PoundWarningDecl><PoundErrorDecl>
-#error(<StringLiteralExpr>"test error"</StringLiteralExpr>)</PoundErrorDecl><IfConfigDecl>
+#error(<StringLiteralExpr>"test error"</StringLiteralExpr>)</PoundErrorDecl><IfConfigDecl><IfConfigClause>
 
 #if <IdentifierExpr>Blah</IdentifierExpr><ClassDecl>
 class C <MemberDeclBlock>{<FunctionDecl>
@@ -118,16 +118,16 @@ protocol PP <MemberDeclBlock>{<AssociatedtypeDecl>
   associatedtype E<TypeInheritanceClause>: <InheritedType><SimpleTypeIdentifier>Sequence </SimpleTypeIdentifier></InheritedType></TypeInheritanceClause><TypeInitializerClause>= <ArrayType>[<ArrayType>[<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>]</ArrayType>] </ArrayType></TypeInitializerClause><GenericWhereClause>where <ConformanceRequirement><MemberTypeIdentifier><SimpleTypeIdentifier>A</SimpleTypeIdentifier>.Element </MemberTypeIdentifier>: <SimpleTypeIdentifier>Sequence</SimpleTypeIdentifier></ConformanceRequirement></GenericWhereClause></AssociatedtypeDecl><AssociatedtypeDecl><DeclModifier>
   private </DeclModifier>associatedtype F</AssociatedtypeDecl><AssociatedtypeDecl><Attribute>
   @objc </Attribute>associatedtype G</AssociatedtypeDecl>
-}</MemberDeclBlock></ProtocolDecl>
+}</MemberDeclBlock></ProtocolDecl></IfConfigClause>
 
-#endif</IfConfigDecl><IfConfigDecl>
+#endif</IfConfigDecl><IfConfigDecl><IfConfigClause>
 
 #if <IdentifierExpr>blah</IdentifierExpr><TypealiasDecl>
-typealias A <TypeInitializerClause>= <SimpleTypeIdentifier>Any</SimpleTypeIdentifier></TypeInitializerClause></TypealiasDecl><ElseifDirectiveClause>
+typealias A <TypeInitializerClause>= <SimpleTypeIdentifier>Any</SimpleTypeIdentifier></TypeInitializerClause></TypealiasDecl></IfConfigClause><IfConfigClause>
 #elseif <IdentifierExpr>blahblah</IdentifierExpr><TypealiasDecl>
-typealias B <TypeInitializerClause>= <TupleType>(<TupleTypeElement><MemberTypeIdentifier><SimpleTypeIdentifier>Array<GenericArgumentClause><<GenericArgument><SimpleTypeIdentifier>Array<GenericArgumentClause><<GenericArgument><SimpleTypeIdentifier>Any</SimpleTypeIdentifier></GenericArgument>></GenericArgumentClause></SimpleTypeIdentifier></GenericArgument>></GenericArgumentClause></SimpleTypeIdentifier>.Element</MemberTypeIdentifier>, </TupleTypeElement><TupleTypeElement>x: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier></TupleTypeElement>)</TupleType></TypeInitializerClause></TypealiasDecl></ElseifDirectiveClause><ElseDirectiveClause>
+typealias B <TypeInitializerClause>= <TupleType>(<TupleTypeElement><MemberTypeIdentifier><SimpleTypeIdentifier>Array<GenericArgumentClause><<GenericArgument><SimpleTypeIdentifier>Array<GenericArgumentClause><<GenericArgument><SimpleTypeIdentifier>Any</SimpleTypeIdentifier></GenericArgument>></GenericArgumentClause></SimpleTypeIdentifier></GenericArgument>></GenericArgumentClause></SimpleTypeIdentifier>.Element</MemberTypeIdentifier>, </TupleTypeElement><TupleTypeElement>x: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier></TupleTypeElement>)</TupleType></TypeInitializerClause></TypealiasDecl></IfConfigClause><IfConfigClause>
 #else<TypealiasDecl>
-typealias C <TypeInitializerClause>= <ArrayType>[<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>]</ArrayType></TypeInitializerClause></TypealiasDecl></ElseDirectiveClause>
+typealias C <TypeInitializerClause>= <ArrayType>[<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>]</ArrayType></TypeInitializerClause></TypealiasDecl></IfConfigClause>
 #endif</IfConfigDecl><TypealiasDecl>
 typealias D <TypeInitializerClause>= <DictionaryType>[<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>: <SimpleTypeIdentifier>String</SimpleTypeIdentifier>]</DictionaryType></TypeInitializerClause></TypealiasDecl><TypealiasDecl>
 typealias E <TypeInitializerClause>= <MetatypeType><OptionalType><SimpleTypeIdentifier>Int</SimpleTypeIdentifier>?</OptionalType>.Protocol</MetatypeType></TypeInitializerClause></TypealiasDecl><TypealiasDecl>
@@ -207,7 +207,7 @@ private </DeclModifier>protocol foo <TypeInheritanceClause>: <InheritedType><Sim
 protocol foo <MemberDeclBlock>{ <FunctionDecl>func foo<FunctionSignature><ParameterClause>() </ParameterClause></FunctionSignature></FunctionDecl>}</MemberDeclBlock></ProtocolDecl><ProtocolDecl><DeclModifier>
 private </DeclModifier>protocol foo<MemberDeclBlock>{}</MemberDeclBlock></ProtocolDecl><ProtocolDecl><Attribute>
 @objc</Attribute><DeclModifier>
-public </DeclModifier>protocol foo <GenericWhereClause>where <ConformanceRequirement><SimpleTypeIdentifier>A</SimpleTypeIdentifier>:<SimpleTypeIdentifier>B </SimpleTypeIdentifier></ConformanceRequirement></GenericWhereClause><MemberDeclBlock>{}</MemberDeclBlock></ProtocolDecl><IfConfigDecl>
+public </DeclModifier>protocol foo <GenericWhereClause>where <ConformanceRequirement><SimpleTypeIdentifier>A</SimpleTypeIdentifier>:<SimpleTypeIdentifier>B </SimpleTypeIdentifier></ConformanceRequirement></GenericWhereClause><MemberDeclBlock>{}</MemberDeclBlock></ProtocolDecl><IfConfigDecl><IfConfigClause>
 
 #if <IdentifierExpr>blah</IdentifierExpr><FunctionDecl>
 func tryfoo<FunctionSignature><ParameterClause>() </ParameterClause></FunctionSignature><CodeBlock>{<TryExpr>
@@ -215,7 +215,7 @@ func tryfoo<FunctionSignature><ParameterClause>() </ParameterClause></FunctionSi
   try! <FunctionCallExpr><IdentifierExpr>foo</IdentifierExpr>()</FunctionCallExpr></TryExpr><TryExpr>
   try? <FunctionCallExpr><IdentifierExpr>foo</IdentifierExpr>()</FunctionCallExpr></TryExpr><TryExpr>
   try! <FunctionCallExpr><MemberAccessExpr><FunctionCallExpr><MemberAccessExpr><FunctionCallExpr><MemberAccessExpr><FunctionCallExpr><IdentifierExpr>foo</IdentifierExpr>()</FunctionCallExpr>.bar</MemberAccessExpr>()</FunctionCallExpr>.foo</MemberAccessExpr>()</FunctionCallExpr>.bar</MemberAccessExpr>()</FunctionCallExpr></TryExpr>
-}</CodeBlock></FunctionDecl><ElseDirectiveClause>
+}</CodeBlock></FunctionDecl></IfConfigClause><IfConfigClause>
 #else<FunctionDecl>
 func closure<FunctionSignature><ParameterClause>() </ParameterClause></FunctionSignature><CodeBlock>{<SequenceExpr><DiscardAssignmentExpr>
   _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><ClosureExpr>{<ClosureSignature><ClosureCaptureSignature>[<ClosureCaptureItem>weak <IdentifierExpr>a</IdentifierExpr>,</ClosureCaptureItem><ClosureCaptureItem>
@@ -241,7 +241,7 @@ func closure<FunctionSignature><ParameterClause>() </ParameterClause></FunctionS
   _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><ClosureExpr>{}</ClosureExpr></SequenceExpr><SequenceExpr><DiscardAssignmentExpr>
   _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><ClosureExpr>{ <ClosureSignature><ClosureParam>s1, </ClosureParam><ClosureParam>s2 </ClosureParam>in </ClosureSignature><SequenceExpr><IdentifierExpr>s1 </IdentifierExpr><BinaryOperatorExpr>> </BinaryOperatorExpr><IdentifierExpr>s2 </IdentifierExpr></SequenceExpr>}</ClosureExpr></SequenceExpr><SequenceExpr><DiscardAssignmentExpr>
   _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><ClosureExpr>{ <SequenceExpr><IdentifierExpr>$0 </IdentifierExpr><BinaryOperatorExpr>> </BinaryOperatorExpr><IdentifierExpr>$1 </IdentifierExpr></SequenceExpr>}</ClosureExpr></SequenceExpr>
-}</CodeBlock></FunctionDecl></ElseDirectiveClause>
+}</CodeBlock></FunctionDecl></IfConfigClause>
 #endif</IfConfigDecl><FunctionDecl>
 
 func postfix<FunctionSignature><ParameterClause>() </ParameterClause></FunctionSignature><CodeBlock>{<FunctionCallExpr><IdentifierExpr>
@@ -268,10 +268,10 @@ func postfix<FunctionSignature><ParameterClause>() </ParameterClause></FunctionS
   _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><MemberAccessExpr><IdentifierExpr>x</IdentifierExpr>.foo<DeclNameArguments>(<DeclNameArgument>x:</DeclNameArgument><DeclNameArgument>y:</DeclNameArgument>)</DeclNameArguments></MemberAccessExpr></SequenceExpr><SequenceExpr><DiscardAssignmentExpr>
   _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><FunctionCallExpr><IdentifierExpr>foo</IdentifierExpr>(<FunctionCallArgument><InOutExpr>&<IdentifierExpr>d</IdentifierExpr></InOutExpr></FunctionCallArgument>)</FunctionCallExpr></SequenceExpr><SequenceExpr><DiscardAssignmentExpr>
   _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><EditorPlaceholderExpr><#Placeholder#> </EditorPlaceholderExpr><BinaryOperatorExpr>+ </BinaryOperatorExpr><EditorPlaceholderExpr><#T##(Int) -> Int#></EditorPlaceholderExpr></SequenceExpr>
-}</CodeBlock></FunctionDecl><IfConfigDecl>
+}</CodeBlock></FunctionDecl><IfConfigDecl><IfConfigClause>
 
-#if <IdentifierExpr>blah</IdentifierExpr><ElseDirectiveClause>
-#else</ElseDirectiveClause>
+#if <IdentifierExpr>blah</IdentifierExpr></IfConfigClause><IfConfigClause>
+#else</IfConfigClause>
 #endif</IfConfigDecl><ClassDecl>
 
 class C <MemberDeclBlock>{<VariableDecl>
@@ -367,10 +367,16 @@ func statementTests<FunctionSignature><ParameterClause>() </ParameterClause></Fu
     case <CaseItem><ExpressionPattern><IdentifierExpr>n1</IdentifierExpr></ExpressionPattern></CaseItem>:</SwitchCaseLabel><BreakStmt>
       break</BreakStmt></SwitchCase><SwitchCase><SwitchCaseLabel>
     case <CaseItem><ExpressionPattern><IdentifierExpr>n2</IdentifierExpr></ExpressionPattern>, </CaseItem><CaseItem><ExpressionPattern><IdentifierExpr>n3l</IdentifierExpr></ExpressionPattern></CaseItem>:</SwitchCaseLabel><BreakStmt>
-      break</BreakStmt></SwitchCase><IfConfigDecl>
+      break</BreakStmt></SwitchCase><IfConfigDecl><IfConfigClause>
 #if <IdentifierExpr>FOO</IdentifierExpr><SwitchCase><SwitchCaseLabel>
     case <CaseItem><ValueBindingPattern>let <ExpressionPattern><TupleExpr>(<TupleElement><UnresolvedPatternExpr><IdentifierPattern>x</IdentifierPattern></UnresolvedPatternExpr>, </TupleElement><TupleElement><UnresolvedPatternExpr><IdentifierPattern>y</IdentifierPattern></UnresolvedPatternExpr></TupleElement>)  </TupleExpr></ExpressionPattern></ValueBindingPattern><WhereClause>where <PrefixOperatorExpr>!<IdentifierExpr>x</IdentifierExpr></PrefixOperatorExpr></WhereClause>, </CaseItem><CaseItem><ExpressionPattern><IdentifierExpr>n3l </IdentifierExpr></ExpressionPattern><WhereClause>where <BooleanLiteralExpr>false</BooleanLiteralExpr></WhereClause></CaseItem>:</SwitchCaseLabel><BreakStmt>
-      break</BreakStmt></SwitchCase>
+      break</BreakStmt></SwitchCase></IfConfigClause><IfConfigClause>
+#elseif <IdentifierExpr>BAR</IdentifierExpr><SwitchCase><SwitchCaseLabel>
+    case <CaseItem><ValueBindingPattern>let <IdentifierPattern>y</IdentifierPattern></ValueBindingPattern></CaseItem>:</SwitchCaseLabel><BreakStmt>
+      break</BreakStmt></SwitchCase></IfConfigClause><IfConfigClause>
+#else<SwitchCase><SwitchCaseLabel>
+    case <CaseItem><ExpressionPattern><FunctionCallExpr><ImplicitMemberExpr>.foo</ImplicitMemberExpr>(<FunctionCallArgument><UnresolvedPatternExpr><ValueBindingPattern>let <IdentifierPattern>x</IdentifierPattern></ValueBindingPattern></UnresolvedPatternExpr></FunctionCallArgument>)</FunctionCallExpr></ExpressionPattern></CaseItem>:</SwitchCaseLabel><BreakStmt>
+      break</BreakStmt></SwitchCase></IfConfigClause>
 #endif</IfConfigDecl><SwitchCase><SwitchDefaultLabel>
     default:</SwitchDefaultLabel><BreakStmt>
       break</BreakStmt></SwitchCase>

--- a/test/Syntax/round_trip_parse_gen.swift
+++ b/test/Syntax/round_trip_parse_gen.swift
@@ -371,6 +371,12 @@ func statementTests() {
 #if FOO
     case let (x, y)  where !x, n3l where false:
       break
+#elseif BAR
+    case let y:
+      break
+#else
+    case .foo(let x):
+      break
 #endif
     default:
       break

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -84,29 +84,32 @@ DECL_NODES = [
              Child('Output', kind='ReturnClause', is_optional=True),
          ]),
 
-    # else-if-directive-clause -> '#elseif' expr stmt-list
-    Node('ElseifDirectiveClause', kind='Syntax',
-         traits=['WithStatements'],
+    # if-config-clause ->
+    #    ('#if' | '#elseif' | '#else') expr? (stmt-list | switch-case-list)
+    Node('IfConfigClause', kind='Syntax',
          children=[
-             Child('PoundElseif', kind='PoundElseifToken'),
-             Child('Condition', kind='Expr'),
-             Child('Statements', kind='CodeBlockItemList'),
+             Child('PoundKeyword', kind='Token',
+                   token_choices=[
+                       'PoundIfToken',
+                       'PoundElseifToken',
+                       'PoundElseToken',
+                   ]),
+             Child('Condition', kind='Expr',
+                   is_optional=True),
+             Child('Elements', kind='Syntax',
+                   node_choices=[
+                      Child('Statements', kind='CodeBlockItemList'),
+                      Child('SwitchCases', kind='SwitchCaseList')]),
          ]),
+
+    Node('IfConfigClauseList', kind='SyntaxCollection',
+         element='IfConfigClause'),
 
     # if-config-decl -> '#if' expr stmt-list else-if-directive-clause-list
     #   else-clause? '#endif'
     Node('IfConfigDecl', kind='Decl',
          children=[
-             Child('PoundIf', kind='PoundIfToken'),
-             Child('Condition', kind='Expr'),
-             Child('Elements', kind='Syntax',
-                   node_choices=[
-                      Child('Statements', kind='CodeBlockItemList'),
-                      Child('SwitchCases', kind='SwitchCaseList')]),
-             Child('ElseifDirectiveClauses', kind='ElseifDirectiveClauseList',
-                   is_optional=True),
-             Child('ElseClause', kind='ElseDirectiveClause',
-                   is_optional=True),
+             Child('Clauses', kind='IfConfigClauseList'),
              Child('PoundEndif', kind='PoundEndifToken'),
          ]),
 
@@ -404,19 +407,6 @@ DECL_NODES = [
                    is_optional=True),
              # the body is not necessary inside a protocol definition
              Child('Accessor', kind='AccessorBlock', is_optional=True),
-         ]),
-
-    # else-if-directive-clause-list -> else-if-directive-clause
-    #   else-if-directive-clause-list?
-    Node('ElseifDirectiveClauseList', kind='SyntaxCollection',
-         element='ElseifDirectiveClause'),
-
-    # else-directive-clause -> '#else' stmt-list
-    Node('ElseDirectiveClause', kind='Syntax',
-         traits=['WithStatements'],
-         children=[
-             Child('PoundElse', kind='PoundElseToken'),
-             Child('Statements', kind='CodeBlockItemList'),
          ]),
 
     # access-level-modifier -> 'private' | 'private' '(' 'set' ')'


### PR DESCRIPTION
```
ifconfig-clause → ('#if' | '#elseif' | '#else') expr? (codeblockitem-list | switchcase-list)
ifconfig-clause-list → ifconfig-clause+
decl-ifconfig → ifconfig-clause-list '#endif'
```
This simplify both the syntax definition (utils/gyb_syntax_support/DeclNodes.py) and parsing (lib/Parse/ParseIfConfig.cpp).
Also, consumers are able to iterate `ifconfig-clause` in `ifconfig-clause-list`.