### PR TITLE
[+0-all-args] Remove autoreleasepool on non-x86_64 platforms from Str…

### DIFF
--- a/stdlib/public/stubs/SwiftNativeNSXXXBaseARC.m
+++ b/stdlib/public/stubs/SwiftNativeNSXXXBaseARC.m
@@ -31,19 +31,21 @@
 // decomposedStringWithCanonicalMapping implementation. Instead, we use a local
 // autorelease pool to prevent leaking of the temporary object into the callers
 // autorelease pool.
-#if defined(__i386__)
-#define AUTORELEASEPOOL @autoreleasepool
-#else
-// On other platforms we rely on the remove from autorelease pool optimization.
 //
-// PLUS ZERO TODO: Right now we force an autoreleasepool here where we really do
-// not want to do so. The reason why is that without the autoreleasepool (or
+//
+// FIXME: Right now we force an autoreleasepool here on x86_64 where we really
+// do not want to do so. The reason why is that without the autoreleasepool (or
 // really something like a defer), we tail call
 // objc_retainAutoreleasedReturnValue which blocks the hand shake. Evidently
 // this is something that we do not want to do. See:
 // b79ff50f1bca97ecfd053372f5f6dc9d017398bc. Until that is resolved, just create
-// an autoreleasepool here.
+// an autoreleasepool here on x86_64. On arm/arm64 we do not have such an issue
+// since we use an assembly marker instead.
+#if defined(__i386__) || defined(__x86_64__)
 #define AUTORELEASEPOOL @autoreleasepool
+#else
+// On other platforms we rely on the remove from autorelease pool optimization.
+#define AUTORELEASEPOOL
 #endif
 
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERFACE


### PR DESCRIPTION
…ing stubs.

This is only necessary on x86-64. On arm/arm64 we are already ok since the
assembly marker that we use there does not suffer from this issue.

For x86-64 we need to solve the problem upstream by not tailing calling
objc_retainAutoreleasedReturnValue.

rdar://38675842