### PR TITLE
[CSGen][CSDiag] Update SanitizeExpr to sanitize OpenExistentialExpr

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3369,6 +3369,12 @@ TypeVariableType *TypeVariableType::getNew(const ASTContext &C, unsigned ID,
 /// underlying forced downcast expression.
 ForcedCheckedCastExpr *findForcedDowncast(ASTContext &ctx, Expr *expr);
 
+
+// Erases any opened existentials from the given expression.
+// Note: this may update the provided expr pointer.
+void eraseOpenedExistentials(constraints::ConstraintSystem &CS, Expr *&expr);
+
+
 /// ExprCleaner - This class is used by shrink to ensure that in
 /// no situation will an expr node be left with a dangling type variable stuck
 /// to it.  Often type checking will create new AST nodes and replace old ones

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -208,3 +208,21 @@ S_RDAR_28991372(x: #^RDAR_28991372^#, y: <#T##Int#>)
 
 protocol P where #^RDAR_31981486^#
 // RDAR_31981486: Begin completions
+
+
+// rdar://problem/38149042
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RDAR_38149042 | %FileCheck %s -check-prefix=RDAR_38149042
+class Baz_38149042 {
+  let x: Int = 0
+}
+protocol Bar_38149042 {
+  var foo: Baz_38149042? {get}
+}
+func foo_38149042(bar: Bar_38149042) {
+  _ = bar.foo? #^RDAR_38149042^# .x
+}
+// RDAR_38149042: Begin completions, 3 items
+// RDAR_38149042-DAG: Decl[InstanceVar]/CurrNominal:                  .x[#Int#]; name=x
+// RDAR_38149042-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]: [' ']=== {#AnyObject?#}[#Bool#]; name==== AnyObject?
+// RDAR_38149042-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]: [' ']!== {#AnyObject?#}[#Bool#]; name=!== AnyObject?
+// RDAR_38149042: End completions


### PR DESCRIPTION
<!-- What's in this pull request? -->
They can show up when re-typechecking during failure diagnosis or code-completion and were
only being sanitized out in one place in CSDiag. Moved that logic into
CSGen's `SanitizeExpr`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/38149042

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->