### PR TITLE
Remove swiftImageInspectionShared

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -245,11 +245,6 @@ if(SWIFT_CHECK_ESSENTIAL_STDLIB)
 endif()
 
 
-set(shared_only_libs)
-if(SWIFT_BUILD_STATIC_STDLIB AND "${SWIFT_HOST_VARIANT_SDK}" STREQUAL "LINUX")
-   list(APPEND shared_only_libs swiftImageInspectionShared)
-endif()
-
 add_swift_library(swiftCore ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB IS_STDLIB_CORE
   ${SWIFTLIB_SOURCES}
   # The copy_shim_headers target dependency is required to let the
@@ -264,6 +259,5 @@ add_swift_library(swiftCore ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB IS_STD
   LINK_FLAGS ${swift_core_link_flags}
   PRIVATE_LINK_LIBRARIES ${swift_core_private_link_libraries}
   INCORPORATE_OBJECT_LIBRARIES swiftRuntime swiftStdlibStubs
-  INCORPORATE_OBJECT_LIBRARIES_SHARED_ONLY ${shared_only_libs}
   FRAMEWORK_DEPENDS ${swift_core_framework_depends}
   INSTALL_IN_COMPONENT stdlib)

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -1,6 +1,16 @@
 set(swift_runtime_compile_flags ${SWIFT_RUNTIME_CORE_CXX_FLAGS})
 set(swift_runtime_linker_flags ${SWIFT_RUNTIME_CORE_LINK_FLAGS})
 
+set(ELFISH_SDKS)
+set(COFF_SDKS)
+foreach(sdk ${SWIFT_CONFIGURED_SDKS})
+  if("${SWIFT_SDK_${sdk}_OBJECT_FORMAT}" STREQUAL "ELF")
+    list(APPEND ELFISH_SDKS ${sdk})
+  elseif("${SWIFT_SDK_${sdk}_OBJECT_FORMAT}" STREQUAL "COFF")
+    list(APPEND COFF_SDKS ${sdk})
+  endif()
+endforeach()
+
 if(SWIFT_DARWIN_ENABLE_STABLE_ABI_BIT)
   list(APPEND swift_runtime_compile_flags
       "-DSWIFT_DARWIN_ENABLE_STABLE_ABI_BIT=1")
@@ -88,47 +98,28 @@ set(swift_runtime_library_compile_flags ${swift_runtime_compile_flags})
 list(APPEND swift_runtime_library_compile_flags -DswiftCore_EXPORTS)
 list(APPEND swift_runtime_library_compile_flags -I${SWIFT_SOURCE_DIR}/include)
 
-set(sdk "${SWIFT_HOST_VARIANT_SDK}")
-if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
-  list(REMOVE_ITEM swift_runtime_sources ImageInspectionELF.cpp)
+if(SWIFT_BUILD_STATIC_STDLIB)
   set(static_binary_lnk_file_list)
-  string(TOLOWER "${sdk}" lowercase_sdk)
+  foreach(sdk ${ELFISH_SDKS})
 
-  # These two libraries are only used with the static swiftcore
-  add_swift_library(swiftImageInspectionShared STATIC
-    ImageInspectionELF.cpp
-    C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
-    LINK_FLAGS ${swift_runtime_linker_flags})
-  set_target_properties(swiftImageInspectionShared PROPERTIES
-    ARCHIVE_OUTPUT_DIRECTORY "${SWIFTSTATICLIB_DIR}/${lowercase_sdk}")
+    string(TOLOWER "${sdk}" lowercase_sdk)
+    set(linkfile "${lowercase_sdk}/static-executable-args.lnk")
+    add_custom_command_target(swift_static_binary_${sdk}_args
+      COMMAND
+        "${CMAKE_COMMAND}" -E copy
+        "${SWIFT_SOURCE_DIR}/utils/static-executable-args.lnk"
+        "${SWIFTSTATICLIB_DIR}/${linkfile}"
+      OUTPUT
+        "${SWIFTSTATICLIB_DIR}/${linkfile}"
+      DEPENDS
+        "${SWIFT_SOURCE_DIR}/utils/static-executable-args.lnk")
 
-  swift_install_in_component(stdlib
-    TARGETS swiftImageInspectionShared
-    DESTINATION "lib/swift_static/${lowercase_sdk}")
-
-  # Generate the static-executable-args.lnk file used for ELF systems (eg linux)
-  set(linkfile "${lowercase_sdk}/static-executable-args.lnk")
-  add_custom_command_target(swift_static_binary_${sdk}_args
-    COMMAND
-      "${CMAKE_COMMAND}" -E copy
-      "${SWIFT_SOURCE_DIR}/utils/static-executable-args.lnk"
-      "${SWIFTSTATICLIB_DIR}/${linkfile}"
-    OUTPUT
-      "${SWIFTSTATICLIB_DIR}/${linkfile}"
-    DEPENDS
-      "${SWIFT_SOURCE_DIR}/utils/static-executable-args.lnk")
-
-  list(APPEND static_binary_lnk_file_list ${swift_static_binary_${sdk}_args})
-  swift_install_in_component(stdlib
-    FILES "${SWIFTSTATICLIB_DIR}/${linkfile}"
-    DESTINATION "lib/swift_static/${lowercase_sdk}")
+    list(APPEND static_binary_lnk_file_list ${swift_static_binary_${sdk}_args})
+    swift_install_in_component(stdlib
+      FILES "${SWIFTSTATICLIB_DIR}/${linkfile}"
+      DESTINATION "lib/swift_static/${lowercase_sdk}")
+  endforeach() 
   add_custom_target(static_binary_magic ALL DEPENDS ${static_binary_lnk_file_list})
-
-  add_swift_library(swiftImageInspectionShared OBJECT_LIBRARY TARGET_LIBRARY
-    ImageInspectionELF.cpp
-    C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
-    LINK_FLAGS ${swift_runtime_linker_flags}
-    INSTALL_IN_COMPONENT never_install)
 endif()
 
 add_swift_library(swiftRuntime OBJECT_LIBRARY TARGET_LIBRARY
@@ -138,16 +129,6 @@ add_swift_library(swiftRuntime OBJECT_LIBRARY TARGET_LIBRARY
   C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
   LINK_FLAGS ${swift_runtime_linker_flags}
   INSTALL_IN_COMPONENT never_install)
-
-set(ELFISH_SDKS)
-set(COFF_SDKS)
-foreach(sdk ${SWIFT_CONFIGURED_SDKS})
-  if("${SWIFT_SDK_${sdk}_OBJECT_FORMAT}" STREQUAL "ELF")
-    list(APPEND ELFISH_SDKS ${sdk})
-  elseif("${SWIFT_SDK_${sdk}_OBJECT_FORMAT}" STREQUAL "COFF")
-    list(APPEND COFF_SDKS ${sdk})
-  endif()
-endforeach()
 
 add_swift_library(swiftImageRegistrationObjectELF
                   OBJECT_LIBRARY IS_STDLIB IS_STDLIB_CORE

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -1,11 +1,6 @@
 if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
    ("${SWIFT_HOST_VARIANT_ARCH}" STREQUAL "${SWIFT_PRIMARY_VARIANT_ARCH}"))
 
-  set(swift_runtime_test_extra_libraries)
-  if(SWIFT_BUILD_STATIC_STDLIB AND "${SWIFT_HOST_VARIANT_SDK}" STREQUAL "LINUX")
-    list(APPEND swift_runtime_test_extra_libraries swiftImageInspectionShared)
-  endif()
-
   add_subdirectory(LongTests)
 
   set(PLATFORM_SOURCES)
@@ -59,7 +54,6 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
     PRIVATE
     swiftCore${SWIFT_PRIMARY_VARIANT_SUFFIX}
     ${PLATFORM_TARGET_LINK_LIBRARIES}
-    ${swift_runtime_test_extra_libraries}
     )
 endif()
 

--- a/utils/gen-static-stdlib-link-args
+++ b/utils/gen-static-stdlib-link-args
@@ -64,7 +64,6 @@ function write_linkfile {
 -latomic
 -lswiftCore
 -latomic
--lswiftImageInspectionShared
 $ICU_LIBS
 -Xlinker
 -export-dynamic

--- a/utils/static-executable-args.lnk
+++ b/utils/static-executable-args.lnk
@@ -1,6 +1,5 @@
 -static
 -lswiftCore
--lswiftImageInspectionShared
 -Xlinker
 --defsym=__import_pthread_self=pthread_self
 -Xlinker


### PR DESCRIPTION
Remove the `swiftImageInspectionShared` since https://github.com/apple/swift/pull/12758 removed the need for it's existence. 