### PR TITLE
 Represent indirect function arguments in the DWARF expression instead…

### DIFF
--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -96,11 +96,9 @@ public:
   /// LValues, inout args, and Archetypes are implicitly indirect by
   /// virtue of their DWARF type.
   //
-  // FIXME: Should this check if the lowered SILType is address only
-  // instead? Otherwise optionals of archetypes etc will still have
-  // 'isImplicitlyIndirect()' return false.
+  // FIXME: There exists an inverse workaround in LLDB. Both should be removed.
   bool isImplicitlyIndirect() const {
-    return Type->hasLValueType() || isArchetype() || Type->is<InOutType>();
+    return isArchetype();
   }
 
   bool isNull() const { return Type == nullptr; }

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3693,8 +3693,6 @@ void IRGenSILFunction::visitDebugValueAddrInst(DebugValueAddrInst *i) {
   auto Addr = getLoweredAddress(SILVal).getAddress();
   SILType SILTy = SILVal->getType();
   auto RealType = SILTy.getSwiftRValueType();
-  if (SILTy.isAddress() && !IsLoadablyByAddress)
-    RealType = CanInOutType::get(RealType);
   // Unwrap implicitly indirect types and types that are passed by
   // reference only at the SIL level and below.
   //
@@ -4178,8 +4176,6 @@ void IRGenSILFunction::visitAllocBoxInst(swift::AllocBoxInst *i) {
            && "box for a local variable should only have one field");
     auto SILTy = i->getBoxType()->getFieldType(IGM.getSILModule(), 0);
     auto RealType = SILTy.getSwiftRValueType();
-    if (SILTy.isAddress())
-      RealType = CanInOutType::get(RealType);
     auto DbgTy = DebugTypeInfo::getLocalVariable(
         CurSILFn->getDeclContext(), CurSILFn->getGenericEnvironment(), Decl,
         RealType, type, /*Unwrap=*/false);

--- a/test/DebugInfo/byref-capture.swift
+++ b/test/DebugInfo/byref-capture.swift
@@ -7,11 +7,10 @@ func makeIncrementor(_ inc : Int64) -> () -> Int64
   func inner() -> Int64 {
     // CHECK: call void @llvm.dbg.declare(metadata %Ts5Int64V**
     // CHECK-SAME:                        metadata ![[SUM_CAPTURE:[0-9]+]],
-    // CHECK-SAME:                        metadata !DIExpression())
-    // CHECK: ![[INOUTTY:[0-9]+]] = !DICompositeType({{.*}}identifier: "$Ss5Int64VzD"
-    //                                                              ^ inout type.
+    // CHECK-SAME:                        metadata !DIExpression(DW_OP_deref))
+    // CHECK: ![[INOUTTY:[0-9]+]] = !DICompositeType({{.*}}identifier: "$Ss5Int64VD"
     // CHECK: ![[SUM_CAPTURE]] = !DILocalVariable(name: "sum", arg: 1,
-    // CHECK-SAME:     line: [[@LINE-9]], type: ![[INOUTTY]]
+    // CHECK-SAME:     line: [[@LINE-8]], type: ![[INOUTTY]]
     sum += inc
     return sum
   }

--- a/test/DebugInfo/inout.swift
+++ b/test/DebugInfo/inout.swift
@@ -16,15 +16,14 @@ typealias MyFloat = Float
 // Closure with promoted capture.
 // PROMO-CHECK: define {{.*}}@"$S5inout13modifyFooHeapyys5Int64Vz_SftFADyXEfU_"
 // PROMO-CHECK: call void @llvm.dbg.declare(metadata %Ts5Int64V** %
-// PROMO-CHECK-SAME:   metadata ![[A1:[0-9]+]], metadata !DIExpression())
+// PROMO-CHECK-SAME:   metadata ![[A1:[0-9]+]], metadata !DIExpression(DW_OP_deref))
 
 // PROMO-CHECK-DAG: ![[INT:.*]] = !DICompositeType({{.*}}identifier: "$Ss5Int64VD"
-// PROMO-CHECK-DAG: ![[INT:.*]] = !DICompositeType({{.*}}identifier: "$Ss5Int64VzD"
 // PROMO-CHECK: ![[A1]] = !DILocalVariable(name: "a", arg: 1
 // PROMO-CHECK-SAME:                       type: ![[INT]]
 func modifyFooHeap(_ a: inout Int64,
   // CHECK-DAG: ![[A]] = !DILocalVariable(name: "a", arg: 1{{.*}} line: [[@LINE-1]],{{.*}} type: ![[RINT:[0-9]+]]
-  // CHECK-DAG: ![[RINT]] = !DICompositeType({{.*}}identifier: "$Ss5Int64VzD"
+  // CHECK-DAG: ![[RINT]] = !DICompositeType({{.*}}identifier: "$Ss5Int64VD"
                    _ b: MyFloat)
 {
     let b = b
@@ -39,11 +38,11 @@ func modifyFooHeap(_ a: inout Int64,
 // Inout reference type.
 // FOO-CHECK: define {{.*}}@"$S5inout9modifyFooyys5Int64Vz_SftF"
 // FOO-CHECK: call void @llvm.dbg.declare(metadata %Ts5Int64V** %
-// FOO-CHECK-SAME:          metadata ![[U:[0-9]+]], metadata !DIExpression())
+// FOO-CHECK-SAME:          metadata ![[U:[0-9]+]], metadata !DIExpression(DW_OP_deref))
 func modifyFoo(_ u: inout Int64,
 // FOO-CHECK-DAG: !DILocalVariable(name: "v", arg: 2{{.*}} line: [[@LINE+3]],{{.*}} type: ![[MYFLOAT:[0-9]+]]
   // FOO-CHECK-DAG: [[U]] = !DILocalVariable(name: "u", arg: 1{{.*}} line: [[@LINE-2]],{{.*}} type: ![[RINT:[0-9]+]]
-  // FOO-CHECK-DAG: ![[RINT]] = !DICompositeType({{.*}}identifier: "$Ss5Int64VzD"
+  // FOO-CHECK-DAG: ![[RINT]] = !DICompositeType({{.*}}identifier: "$Ss5Int64VD"
                _ v: MyFloat)
 // FOO-CHECK-DAG: ![[MYFLOAT]] = !DIDerivedType(tag: DW_TAG_typedef, name: "$S5inout7MyFloataD",{{.*}} baseType: ![[FLOAT:[0-9]+]]
 // FOO-CHECK-DAG: ![[FLOAT]] = !DICompositeType({{.*}}identifier: "$SSfD"

--- a/test/DebugInfo/weak-self-capture.swift
+++ b/test/DebugInfo/weak-self-capture.swift
@@ -1,0 +1,19 @@
+// RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
+public class ClosureMaker {
+    var a : Int
+
+    init (a : Int) { self.a = a }
+
+    public func getClosure() -> (() -> Int) {
+        return { [weak self] () -> Int in
+          if let _self = self {
+                return _self.a
+            } else {
+                return 0
+            }
+        }
+    }
+}
+
+// CHECK: define {{.*}} @"$S4main12ClosureMakerC03getB0SiycyFSiycfU_"
+// CHECK: call void @llvm.dbg.declare(metadata %swift.weak** %{{.*}} !DIExpression(DW_OP_deref)),


### PR DESCRIPTION
… of the type.

The current approach has several problems:

- Types that are not inout types but loadable may incorrectly get
  marked as inout types.

- When inout arguments get inlined or otherwise optimized LLDB cannot
  rely on the type to decide to dereference that value.

- One argument may get represented by different types in the same
  function depending on what code is generated for it.

Fixes rdar://problem/39023374
