### PR TITLE
[DiagnosticsQoI] Bail on nil literal diagnostics if the source is Optional

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3032,6 +3032,10 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
   // If we're diagnostic an issue with 'nil', produce a specific diagnostic,
   // instead of uttering ExpressibleByNilLiteral.
   if (isa<NilLiteralExpr>(expr->getValueProvidingExpr())) {
+    // If the source type is some kind of optional, the contextual conversion
+    // to 'nil' didn't fail, something else did.
+    if (contextualType->getOptionalObjectType())
+      return false;
     diagnose(expr->getLoc(), nilDiag, contextualType);
     if (nilFollowup)
       nilFollowup();

--- a/test/decl/init/nil.swift
+++ b/test/decl/init/nil.swift
@@ -26,3 +26,5 @@ var _: Int = nil
 // expected-error@-1 {{nil cannot initialize specified type 'Int'}} 
 // expected-note@-2 {{add '?' to form the optional type 'Int?'}} {{11-11=?}}
 
+// 'nil' can initialize the specified type, if its generic parameters are bound
+var _: Array? = nil // expected-error {{generic parameter 'Element' could not be inferred}}


### PR DESCRIPTION
A tiny change to get back some QoI because it isn't sufficient to just observe that the initializer of a pattern binding failed a contextual conversion from `nil`.  If we fire the existing diagnostic, it would pile on optional sugar and never tell the user what actually went wrong.

```swift
// Before
var _: Array? = nil // nil cannot initialize specified type 'Array?', add '?' to form the optional type 'Array??'
var _: Array?? = nil // nil cannot initialize specified type 'Array??', add '?' to form the optional type 'Array???'
var _: Array??? = nil // nil cannot initialize specified type 'Array???', add '?' to form the optional type 'Array????'
// ...

// After
var _: Array? = nil // generic parameter 'Element' could not be inferred
```

"Reported" by [a Redditor](https://www.reddit.com/r/swift/comments/898tbr/it_need_to_be_more_optional/?ref=share&ref_source=link).