### PR TITLE
[Syntax] Parse 'enum' and 'case' declaration

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2487,10 +2487,12 @@ Parser::parseDecl(ParseDeclOptions Flags,
     DeclResult = parseDeclAssociatedType(Flags, Attributes);
     break;
   case tok::kw_enum:
+    DeclParsingContext.setCreateSyntax(SyntaxKind::EnumDecl);
     DeclResult = parseDeclEnum(Flags, Attributes);
     break;
   case tok::kw_case: {
     llvm::SmallVector<Decl *, 4> Entries;
+    DeclParsingContext.setCreateSyntax(SyntaxKind::EnumCaseDecl);
     DeclResult = parseDeclEnumCase(Flags, Attributes, Entries);
     std::for_each(Entries.begin(), Entries.end(), Handler);
     if (auto *D = DeclResult.getPtrOrNull())
@@ -5391,6 +5393,7 @@ ParserResult<EnumDecl> Parser::parseDeclEnum(ParseDeclOptions Flags,
 
   ED->setGenericParams(GenericParams);
 
+  SyntaxParsingContext BlockContext(SyntaxContext, SyntaxKind::MemberDeclBlock);
   SourceLoc LBLoc, RBLoc;
   if (parseToken(tok::l_brace, LBLoc, diag::expected_lbrace_enum)) {
     LBLoc = PreviousLoc;
@@ -5431,6 +5434,8 @@ Parser::parseDeclEnumCase(ParseDeclOptions Flags,
   
   SourceLoc CommaLoc;
   for (;;) {
+    SyntaxParsingContext ElementContext(SyntaxContext,
+                                        SyntaxKind::EnumCaseElement);
     Identifier Name;
     SourceLoc NameLoc;
 
@@ -5499,6 +5504,9 @@ Parser::parseDeclEnumCase(ParseDeclOptions Flags,
     ParserResult<Expr> RawValueExpr;
     LiteralExpr *LiteralRawValueExpr = nullptr;
     if (Tok.is(tok::equal)) {
+      SyntaxParsingContext InitContext(SyntaxContext,
+                                       SyntaxKind::InitializerClause);
+
       EqualsLoc = consumeToken();
       {
         CodeCompletionCallbacks::InEnumElementRawValueRAII
@@ -5569,6 +5577,7 @@ Parser::parseDeclEnumCase(ParseDeclOptions Flags,
       break;
     CommaLoc = consumeToken(tok::comma);
   }
+  SyntaxContext->collectNodesInPlace(SyntaxKind::EnumCaseElementList);
   
   if (!(Flags & PD_AllowEnumElement)) {
     diagnose(CaseLoc, diag::disallowed_enum_element);

--- a/lib/Syntax/Status.md
+++ b/lib/Syntax/Status.md
@@ -65,17 +65,14 @@
   * SubscriptDecl
   * ConstructorDecl
   * DestructorDecl
-
-### In-progress (UnknownDecl):
+  * EnumDecl
+  * EnumCaseDecl
 
 ### Not-started (UnknownDecl):
-  * EnumCaseDecl
   * PrecedenceGroupDecl
   * InfixOperatorDecl
   * PrefixOperatorDecl
   * PostfixOperatorDecl
-  * EnumDecl
-  * EnumElementDecl
 
 ## Statement
 ### Done:

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -238,6 +238,7 @@ func closure<FunctionSignature><ParameterClause>() </ParameterClause></FunctionS
     return <IntegerLiteralExpr>2</IntegerLiteralExpr></ReturnStmt>
   }</ClosureExpr></SequenceExpr><SequenceExpr><DiscardAssignmentExpr>
   _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><ClosureExpr>{ <ClosureSignature><ClosureParam>a, </ClosureParam><ClosureParam>b </ClosureParam>in </ClosureSignature>}</ClosureExpr></SequenceExpr><SequenceExpr><DiscardAssignmentExpr>
+  _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><ClosureExpr>{ <ClosureSignature><ParameterClause>(<FunctionParameter>a, </FunctionParameter><FunctionParameter>b</FunctionParameter>) </ParameterClause>in </ClosureSignature>}</ClosureExpr></SequenceExpr><SequenceExpr><DiscardAssignmentExpr>
   _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><ClosureExpr>{}</ClosureExpr></SequenceExpr><SequenceExpr><DiscardAssignmentExpr>
   _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><ClosureExpr>{ <ClosureSignature><ClosureParam>s1, </ClosureParam><ClosureParam>s2 </ClosureParam>in </ClosureSignature><SequenceExpr><IdentifierExpr>s1 </IdentifierExpr><BinaryOperatorExpr>> </BinaryOperatorExpr><IdentifierExpr>s2 </IdentifierExpr></SequenceExpr>}</ClosureExpr></SequenceExpr><SequenceExpr><DiscardAssignmentExpr>
   _ </DiscardAssignmentExpr><AssignmentExpr>= </AssignmentExpr><ClosureExpr>{ <SequenceExpr><IdentifierExpr>$0 </IdentifierExpr><BinaryOperatorExpr>> </BinaryOperatorExpr><IdentifierExpr>$1 </IdentifierExpr></SequenceExpr>}</ClosureExpr></SequenceExpr>
@@ -425,4 +426,14 @@ func objectLiterals<FunctionSignature><ParameterClause>() </ParameterClause></Fu
   #file</PoundFileExpr><PoundFunctionExpr>
   #function</PoundFunctionExpr><PoundDsohandleExpr>
   #dsohandle</PoundDsohandleExpr>
-}</CodeBlock></FunctionDecl>
+}</CodeBlock></FunctionDecl><EnumDecl>
+
+enum E1 <TypeInheritanceClause>: <InheritedType><SimpleTypeIdentifier>String </SimpleTypeIdentifier></InheritedType></TypeInheritanceClause><MemberDeclBlock>{<EnumCaseDecl>
+  case <EnumCaseElement>foo <InitializerClause>= <IntegerLiteralExpr>1</IntegerLiteralExpr></InitializerClause></EnumCaseElement></EnumCaseDecl><EnumCaseDecl>
+  case <EnumCaseElement>bar <InitializerClause>= <StringLiteralExpr>"test"</StringLiteralExpr></InitializerClause>, </EnumCaseElement><EnumCaseElement>baz<ParameterClause>(<FunctionParameter>x: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier>, </FunctionParameter><FunctionParameter><SimpleTypeIdentifier>String</SimpleTypeIdentifier></FunctionParameter>) </ParameterClause><InitializerClause>= <IntegerLiteralExpr>12</IntegerLiteralExpr></InitializerClause></EnumCaseElement></EnumCaseDecl><EnumCaseDecl><DeclModifier>
+  indirect </DeclModifier>case <EnumCaseElement>qux<ParameterClause>(<FunctionParameter><SimpleTypeIdentifier>E1</SimpleTypeIdentifier></FunctionParameter>)</ParameterClause></EnumCaseElement></EnumCaseDecl><EnumDecl><DeclModifier>
+
+  indirect </DeclModifier><DeclModifier>private </DeclModifier>enum E2<GenericParameterClause><<GenericParameter>T</GenericParameter>></GenericParameterClause><TypeInheritanceClause>: <InheritedType><SimpleTypeIdentifier>String </SimpleTypeIdentifier></InheritedType></TypeInheritanceClause><GenericWhereClause>where <ConformanceRequirement><SimpleTypeIdentifier>T</SimpleTypeIdentifier>: <SimpleTypeIdentifier>SomeProtocol </SimpleTypeIdentifier></ConformanceRequirement></GenericWhereClause><MemberDeclBlock>{<EnumCaseDecl>
+    case <EnumCaseElement>foo, </EnumCaseElement><EnumCaseElement>bar, </EnumCaseElement><EnumCaseElement>baz</EnumCaseElement></EnumCaseDecl>
+  }</MemberDeclBlock></EnumDecl>
+}</MemberDeclBlock></EnumDecl>

--- a/test/Syntax/round_trip_parse_gen.swift
+++ b/test/Syntax/round_trip_parse_gen.swift
@@ -238,6 +238,7 @@ func closure() {
     return 2
   }
   _ = { a, b in }
+  _ = { (a, b) in }
   _ = {}
   _ = { s1, s2 in s1 > s2 }
   _ = { $0 > $1 }
@@ -425,4 +426,14 @@ func objectLiterals() {
   #file
   #function
   #dsohandle
+}
+
+enum E1 : String {
+  case foo = 1
+  case bar = "test", baz(x: Int, String) = 12
+  indirect case qux(E1)
+
+  indirect private enum E2<T>: String where T: SomeProtocol {
+    case foo, bar, baz
+  }
 }

--- a/unittests/Syntax/DeclSyntaxTests.cpp
+++ b/unittests/Syntax/DeclSyntaxTests.cpp
@@ -259,13 +259,13 @@ TEST(DeclSyntaxTests, FunctionParameterGetAPIs) {
                                                     NoEllipsis, DefaultArg,
                                                     Comma);
 
-  ASSERT_EQ(ExternalName.getRaw(), Param.getFirstName().getRaw());
+  ASSERT_EQ(ExternalName.getRaw(), Param.getFirstName()->getRaw());
   ASSERT_EQ(LocalName.getRaw(), Param.getSecondName()->getRaw());
-  ASSERT_EQ(Colon.getRaw(), Param.getColon().getRaw());
+  ASSERT_EQ(Colon.getRaw(), Param.getColon()->getRaw());
 
-  auto GottenType = Param.getTypeAnnotation();
-  auto GottenType2 = Param.getTypeAnnotation();
-  ASSERT_TRUE(GottenType.hasSameIdentityAs(GottenType2));
+  auto GottenType = Param.getType();
+  auto GottenType2 = Param.getType();
+  ASSERT_TRUE(GottenType->hasSameIdentityAs(*GottenType2));
 
   ASSERT_EQ(DefaultArg.getRaw(), Param.getDefaultArgument()->getRaw());
 
@@ -277,10 +277,10 @@ TEST(DeclSyntaxTests, FunctionParameterGetAPIs) {
 
   // Test that llvm::None is returned for non-token missing children:
   auto Decimated = Param
-    .withTypeAnnotation(llvm::None)
+    .withType(llvm::None)
     .withDefaultArgument(llvm::None);
 
-  ASSERT_TRUE(Decimated.getTypeAnnotation().isMissing());
+  ASSERT_FALSE(Decimated.getType().hasValue());
   ASSERT_FALSE(Decimated.getDefaultArgument().hasValue());
 }
 
@@ -307,7 +307,7 @@ TEST(DeclSyntaxTests, FunctionParameterWithAPIs) {
       .withFirstName(ExternalName)
       .withSecondName(LocalName)
       .withColon(Colon)
-      .withTypeAnnotation(Int)
+      .withType(Int)
       .withDefaultArgument(DefaultArg)
       .withTrailingComma(Comma)
       .print(OS);
@@ -317,7 +317,7 @@ TEST(DeclSyntaxTests, FunctionParameterWithAPIs) {
     SmallString<48> Scratch;
     llvm::raw_svector_ostream OS(Scratch);
     getCannedFunctionParameter()
-      .withTypeAnnotation(llvm::None)
+      .withType(llvm::None)
       .withDefaultArgument(llvm::None)
       .print(OS);
     ASSERT_EQ(OS.str().str(), "with radius: , ");

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -137,7 +137,7 @@ DECL_NODES = [
                        'lazy', 'optional', 'override', 'postfix', 'prefix',
                        'required', 'static', 'unowned', 'weak', 'private',
                        'fileprivate', 'internal', 'public', 'open',
-                       'mutating', 'nonmutating',
+                       'mutating', 'nonmutating', 'indirect',
                    ]),
              Child('Detail', kind='TokenList', is_optional=True),
          ]),
@@ -280,7 +280,8 @@ DECL_NODES = [
                    token_choices=[
                        'IdentifierToken',
                        'WildcardToken',
-                   ]),
+                   ],
+                   is_optional=True),
              # One of these two names needs be optional, we choose the second
              # name to avoid backtracking.
              Child('SecondName', kind='Token',
@@ -289,8 +290,10 @@ DECL_NODES = [
                        'WildcardToken',
                    ],
                    is_optional=True),
-             Child('Colon', kind='ColonToken'),
-             Child('TypeAnnotation', kind='Type'),
+             Child('Colon', kind='ColonToken',
+                   is_optional=True),
+             Child('Type', kind='Type',
+                   is_optional=True),
              Child('Ellipsis', kind='Token',
                    is_optional=True),
              Child('DefaultArgument', kind='InitializerClause',
@@ -509,13 +512,9 @@ DECL_NODES = [
          children=[
              Child('Identifier', kind='IdentifierToken',
                    description='The name of this case.'),
-             Child('AssociatedValue', kind='TupleType', is_optional=True,
+             Child('AssociatedValue', kind='ParameterClause', is_optional=True,
                    description='The set of associated values of the case.'),
-             Child('EqualsToken', kind='EqualsToken', is_optional=True,
-                   description='''
-                   The equals token, if this case is assigned to a raw value.
-                   '''),
-             Child('RawValue', kind='Expr', is_optional=True,
+             Child('RawValue', kind='InitializerClause', is_optional=True,
                    description='''
                    The raw value of this enum element, if present.
                    '''),
@@ -537,9 +536,13 @@ DECL_NODES = [
          enum.
          ''',
          children=[
-             Child('IndirectKeyword', kind='IndirectToken', is_optional=True,
+             Child('Attributes', kind='AttributeList', is_optional=True,
                    description='''
-                   The `indirect` keyword, if this case is indirect.
+                   The attributes applied to the case declaration.
+                   '''),
+             Child('Modifiers', kind='ModifierList', is_optional=True,
+                   description='''
+                   The declaration modifiers applied to the case declaration.
                    '''),
              Child('CaseKeyword', kind='CaseToken',
                    description='The `case` keyword for this case.'),
@@ -557,11 +560,6 @@ DECL_NODES = [
              Child('Modifiers', kind='ModifierList', is_optional=True,
                    description='''
                    The declaration modifiers applied to the enum declaration.
-                   '''),
-             Child('IndirectKeyword', kind='IndirectToken', is_optional=True,
-                   description='''
-                   The `indirect` keyword that applies to all cases in this \
-                   enum.
                    '''),
              Child('EnumKeyword', kind='EnumToken',
                    description='''
@@ -583,14 +581,14 @@ DECL_NODES = [
                    values for this enum.
                    '''),
              Child('GenericWhereClause', kind='GenericWhereClause',
-                  is_optional=True,
-                  description='''
-                  The `where` clause that applies to the generic parameters of \
-                  this enum.
-                  '''),
+                   is_optional=True,
+                   description='''
+                   The `where` clause that applies to the generic parameters of \
+                   this enum.
+                   '''),
              Child('Members', kind='MemberDeclBlock',
-                  description='''
-                  The cases and other members of this enum.
-                  ''')
+                   description='''
+                   The cases and other members of this enum.
+                   ''')
          ]),
 ]


### PR DESCRIPTION
Resolves #49179
Modification for node declaration:
* Associated values for `EnumCaseElement` is now `ParameterClause`. https://github.com/apple/swift/pull/15562
* Make all fields in `ParameterClause` optional. https://github.com/apple/swift/pull/15562#issuecomment-376763641
* Use `InitializerClause` for `RawValue` of `EnumCaseElement`.
* Removed `IndirectKeyword` from `EnumCaseDecl` and `EnumDecl`. This is parsed as a part of `ModifierList`.
* Renamed `TypeAnnotation` to `Type` in `ParameterClause`. If we name it "TypeAnnotation", it should contain `:`.