### PR TITLE
[Parse] Don't allow attributed #errror/#warning

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2419,7 +2419,12 @@ Parser::parseDecl(ParseDeclOptions Flags,
     }
     return IfConfigResult;
   }
-
+  if (Tok.isAny(tok::pound_warning, tok::pound_error)) {
+    auto Result = parseDeclPoundDiagnostic();
+    if (Result.isNonNull())
+      Handler(Result.get());
+    return Result;
+  }
 
   SyntaxParsingContext DeclParsingContext(SyntaxContext,
                                           SyntaxContextKind::Decl);
@@ -2552,20 +2557,11 @@ Parser::parseDecl(ParseDeclOptions Flags,
     // Handled below.
     break;
 
-  case tok::pound_warning:
-    // FIXME: This is discarding attributes/modifiers. Should be hoisted.
-    DeclParsingContext.setCreateSyntax(SyntaxKind::PoundWarningDecl);
-    DeclResult = parseDeclPoundDiagnostic();
-    break;
-  case tok::pound_error:
-    // FIXME: This is discarding attributes/modifiers. Should be hoisted.
-    DeclParsingContext.setCreateSyntax(SyntaxKind::PoundErrorDecl);
-    DeclResult = parseDeclPoundDiagnostic();
-    break;
-
   case tok::pound_if:
   case tok::pound_sourceLocation:
   case tok::pound_line:
+  case tok::pound_warning:
+  case tok::pound_error:
     // We see some attributes right before these pounds.
     // TODO: Emit dedicated errors for them.
     LLVM_FALLTHROUGH;

--- a/test/Sema/pound_diagnostics.swift
+++ b/test/Sema/pound_diagnostics.swift
@@ -62,3 +62,13 @@ func foo() {
   default: break
   }
 }
+
+public // expected-error @+1 {{expected declaration}}
+#warning("public warning") // expected-warning {{public warning}}
+func bar() {}
+
+class C { // expected-note {{in declaration of 'C'}}
+  private // expected-error @+1 {{expected declaration}}
+  #error("private error") // expected-error  {{private error}}
+  func bar() {}
+}


### PR DESCRIPTION
* Hoist `#warning`/`#error` parsing to before attributes parsing. Previously:

  ```swift
  private
  #warning("some warning")
  func foo() {}
  ```
  was accepted with `private` silently ignored.

* Also, for 'libSyntax' node generation, diagnostic directives used to be wrapped with `UnknownDecl`.
  ```
  <UnknownDecl><PoundWarningDecl>#warning(<StringLiteralExpr>"warning"</StringLiteralExpr>)</PoundWarningDecl></UnknownDecl>
  ```