### PR TITLE
Delay import-as-member resolution even without an explicit swift_name.

### DIFF
--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -446,13 +446,10 @@ void SwiftLookupTable::addEntry(DeclName name, SingleEntry newEntry,
   // Translate the context.
   auto contextOpt = translateContext(effectiveContext);
   if (!contextOpt) {
-    // If it is a declaration with a swift_name attribute, we might be
-    // able to resolve this later.
+    // We might be able to resolve this later.
     if (auto decl = newEntry.dyn_cast<clang::NamedDecl *>()) {
-      if (decl->hasAttr<clang::SwiftNameAttr>()) {
-        UnresolvedEntries.push_back(
-          std::make_tuple(name, newEntry, effectiveContext));
-      }
+      UnresolvedEntries.push_back(
+        std::make_tuple(name, newEntry, effectiveContext));
     }
 
     return;
@@ -1787,9 +1784,11 @@ void importer::finalizeLookupTable(SwiftLookupTable &table,
       auto decl = entry.get<clang::NamedDecl *>();
       auto swiftName = decl->getAttr<clang::SwiftNameAttr>();
 
-      nameImporter.getContext().Diags.diagnose(
-          SourceLoc(), diag::unresolvable_clang_decl, decl->getNameAsString(),
-          swiftName->getName());
+      if (swiftName) {
+        nameImporter.getContext().Diags.diagnose(
+            SourceLoc(), diag::unresolvable_clang_decl, decl->getNameAsString(),
+            swiftName->getName());
+      }
     }
   }
 }

--- a/test/ClangImporter/Inputs/ImportAsMemberSwiftVersioned_a.swift
+++ b/test/ClangImporter/Inputs/ImportAsMemberSwiftVersioned_a.swift
@@ -1,0 +1,6 @@
+import Foundation
+import ImportAsMember.Class
+
+@_versioned
+internal func foo(_ x: IncompleteImportTargetName) -> Any { return x }
+

--- a/test/ClangImporter/Inputs/ImportAsMemberSwiftVersioned_b.swift
+++ b/test/ClangImporter/Inputs/ImportAsMemberSwiftVersioned_b.swift
@@ -1,0 +1,6 @@
+import Foundation
+import ImportAsMember.Class
+
+@inline(__always) public func call_foo() -> Any {
+  return foo("hello" as IncompleteImportTargetName)
+}

--- a/test/ClangImporter/import-as-member-versioned.swift
+++ b/test/ClangImporter/import-as-member-versioned.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: mkdir -p %t/modules
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -module-name ImportAsMemberSwiftVersioned -o %t/modules/ImportAsMemberSwiftVersioned_a.partial.swiftmodule -swift-version 3 -I %S/../IDE/Inputs/custom-modules -primary-file %S/Inputs/ImportAsMemberSwiftVersioned_a.swift %S/Inputs/ImportAsMemberSwiftVersioned_b.swift
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -module-name ImportAsMemberSwiftVersioned -o %t/modules/ImportAsMemberSwiftVersioned_b.partial.swiftmodule -swift-version 3 -I %S/../IDE/Inputs/custom-modules -primary-file %S/Inputs/ImportAsMemberSwiftVersioned_b.swift %S/Inputs/ImportAsMemberSwiftVersioned_a.swift
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -merge-modules -swift-version 3 -emit-module -module-name ImportAsMemberSwiftVersioned -I %S/../IDE/Inputs/custom-modules -o %t/modules/ImportAsMemberSwiftVersioned.swiftmodule %t/modules/ImportAsMemberSwiftVersioned_a.partial.swiftmodule %t/modules/ImportAsMemberSwiftVersioned_b.partial.swiftmodule
+
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -swift-version 4 -O -I %S/../IDE/Inputs/custom-modules -o - %s -I %t/modules | %FileCheck %s
+
+// REQUIRES: objc_interop
+import Foundation
+import ImportAsMember.Class
+import ImportAsMemberSwiftVersioned
+
+// CHECK: function_ref {{.*}}call_foo
+public func callFoo() -> Any {
+  return call_foo()
+}

--- a/test/IDE/Inputs/custom-modules/ImportAsMember.apinotes
+++ b/test/IDE/Inputs/custom-modules/ImportAsMember.apinotes
@@ -12,6 +12,8 @@ Functions:
 Typedefs:
 - Name: IAMStruct1APINoteType
   SwiftName: Struct1.NewApiNoteType
+- Name: IncompleteImportTargetName
+  SwiftName: IncompleteImportTarget.Name
 SwiftVersions:
 - Version: 3
   Globals:
@@ -27,3 +29,5 @@ SwiftVersions:
   Typedefs:
   - Name: IAMStruct1APINoteType
     SwiftName: Struct1.OldApiNoteType
+  - Name: IncompleteImportTargetName
+    SwiftWrapper: none

--- a/test/IDE/Inputs/custom-modules/ImportAsMemberClass.h
+++ b/test/IDE/Inputs/custom-modules/ImportAsMemberClass.h
@@ -44,6 +44,11 @@ __attribute__((swift_name("Panda")))
 @interface PKPanda : NSObject
 @end
 
+typedef NSString *IncompleteImportTargetName __attribute__((swift_wrapper(struct)));
+
+@interface IncompleteImportTarget : NSObject
+@end
+
 #pragma clang assume_nonnull end
 
 #endif


### PR DESCRIPTION
When forming the Swift name lookup tables, import-as-member'd
declarations can precede the declaration of the context into which
they'll be imported as a member. In such cases, we already had logic
to delay the resolution until the end of the module (when the context
must be complete).

However, we would only delay when there is a swift_name attribute on
the declaration, which is... conceptually correct. If the swift_name
exists but is versioned (e.g., it is present only for Swift 4+), and
we're building before the swift_name took effect (e.g., in Swift 3
mode), the swift_name is buried under a "versioned" attribute in the
Clang AST. Therefore, we would end up dropping the declaration from
the name lookup table, which almost doesn't matter, except...

Serialization records the newest names for such declarations (e.g.,
Swift 4+ name in this case), so deserialization would fail to find the
declaration that had been dropped, causing a crash.

Eliminate the "optimization" that looks for the swift_name attribute
before delaying the resolution of such a declaration, so we'll visit
these later. Fixes rdar://problem/39115605.
