### PR TITLE
[GenBuiltin] Avoid lowering ill-formed profiling intrinsics

### DIFF
--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -214,25 +214,32 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
     // Extract the PGO function name.
     auto *NameGEP = cast<llvm::User>(args.claimNext());
     auto *NameGV = dyn_cast<llvm::GlobalVariable>(NameGEP->stripPointerCasts());
-    if (NameGV) {
-      auto *NameC = NameGV->getInitializer();
-      StringRef Name = cast<llvm::ConstantDataArray>(NameC)->getRawDataValues();
-      StringRef PGOFuncName = Name.rtrim(StringRef("\0", 1));
 
-      // Point the increment call to the right function name variable.
-      std::string PGOFuncNameVar = llvm::getPGOFuncNameVarName(
-          PGOFuncName, llvm::GlobalValue::LinkOnceAnyLinkage);
-      auto *FuncNamePtr = IGF.IGM.Module.getNamedGlobal(PGOFuncNameVar);
-      if (!FuncNamePtr)
-        FuncNamePtr = llvm::createPGOFuncNameVar(
-            *IGF.IGM.getModule(), llvm::GlobalValue::LinkOnceAnyLinkage,
-            PGOFuncName);
-
-      llvm::SmallVector<llvm::Value *, 2> Indices(2, NameGEP->getOperand(1));
-      NameGEP = llvm::ConstantExpr::getGetElementPtr(
-          ((llvm::PointerType *)FuncNamePtr->getType())->getElementType(),
-          FuncNamePtr, makeArrayRef(Indices));
+    // TODO: The SIL optimizer may rewrite the name argument in a way that
+    // makes it impossible to lower. Until that issue is fixed, defensively
+    // refuse to lower ill-formed intrinsics (rdar://39146527).
+    if (!NameGV) {
+      (void)args.claimAll();
+      return;
     }
+
+    auto *NameC = NameGV->getInitializer();
+    StringRef Name = cast<llvm::ConstantDataArray>(NameC)->getRawDataValues();
+    StringRef PGOFuncName = Name.rtrim(StringRef("\0", 1));
+
+    // Point the increment call to the right function name variable.
+    std::string PGOFuncNameVar = llvm::getPGOFuncNameVarName(
+        PGOFuncName, llvm::GlobalValue::LinkOnceAnyLinkage);
+    auto *FuncNamePtr = IGF.IGM.Module.getNamedGlobal(PGOFuncNameVar);
+    if (!FuncNamePtr)
+      FuncNamePtr = llvm::createPGOFuncNameVar(
+          *IGF.IGM.getModule(), llvm::GlobalValue::LinkOnceAnyLinkage,
+          PGOFuncName);
+
+    llvm::SmallVector<llvm::Value *, 2> Indices(2, NameGEP->getOperand(1));
+    NameGEP = llvm::ConstantExpr::getGetElementPtr(
+        ((llvm::PointerType *)FuncNamePtr->getType())->getElementType(),
+        FuncNamePtr, makeArrayRef(Indices));
 
     // Replace the placeholder value with the new GEP.
     Explosion replacement;

--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -206,8 +206,10 @@ void irgen::emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &Builtin,
   if (IID == llvm::Intrinsic::instrprof_increment) {
     // If we import profiling intrinsics from a swift module but profiling is
     // not enabled, ignore the increment.
-    if (!IGF.getSILModule().getOptions().GenerateProfile)
+    if (!IGF.getSILModule().getOptions().GenerateProfile) {
+      (void)args.claimAll();
       return;
+    }
 
     // Extract the PGO function name.
     auto *NameGEP = cast<llvm::User>(args.claimNext());

--- a/test/IRGen/coverage_ignored.swift
+++ b/test/IRGen/coverage_ignored.swift
@@ -1,7 +1,7 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -profile-generate -emit-sil -o %t.sil
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -profile-generate -emit-sil -o %t.sil
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %t.sil -module-name=coverage_ignored -emit-ir -o - | %FileCheck %s -check-prefix=CHECK-IGNORED
 
-// CHECK-NOT: llvm.instrprof
-// CHECK-NOT: profc
+// CHECK-IGNORED-NOT: llvm.instrprof
+// CHECK-IGNORED-NOT: profc
 func foo() {}
 foo()


### PR DESCRIPTION
The SIL optimizer may rewrite the name argument to profiling intrinsics
in a way that makes them impossible to lower.

Avoid lowering ill-formed intrinsics until the issue is addressed
(r://39146527).

rdar://38926982
(cherry picked from commit 5eacb57921db24cb49672dc7c78579b96d46b0e6)