### PR TITLE
[CSSolver] Clarify generic disjunction choice favoring conditions

### DIFF
--- a/test/Constraints/rdar38625824.swift
+++ b/test/Constraints/rdar38625824.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
+func foo<T>(_: Any) -> T {
+  fatalError()
+}
+
+func foo<T>(_: Any?) -> T {
+  fatalError()
+}
+
+// CHECK: function_ref @$S12rdar386258243fooyxyplF : $@convention(thin) <τ_0_0> (@in_guaranteed Any) -> @out τ_0_0
+var _: String = foo("hello")


### PR DESCRIPTION
Attempt to avoid trying to optimize binary generic disjunctions
when one of the choices has `Any` or `Any?` since it's risky to
assume which one is better without solving.

Resolves: rdar://problem/38625824

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
