### PR TITLE
[4.2] IRGen: Exact casts cannot fail

### DIFF
--- a/lib/IRGen/GenCast.cpp
+++ b/lib/IRGen/GenCast.cpp
@@ -98,7 +98,6 @@ FailableCastResult irgen::emitClassIdenticalCast(IRGenFunction &IGF,
     toType = IGF.IGM.getLoweredType(metaType.getInstanceType());
   }
   // Emit a reference to the heap metadata for the target type.
-  const bool allowConservative = true;
 
   // If we're allowed to do a conservative check, try to just use the
   // global class symbol.  If the class has been re-allocated, this
@@ -106,17 +105,16 @@ FailableCastResult irgen::emitClassIdenticalCast(IRGenFunction &IGF,
   // test might fail; but it's a much faster check.
   // TODO: use ObjC class references
   llvm::Value *targetMetadata;
-  if (allowConservative &&
-      (targetMetadata =
-        tryEmitConstantHeapMetadataRef(IGF.IGM, toType.getSwiftRValueType(),
-                                       /*allowUninitialized*/ true))) {
+  if ((targetMetadata =
+           tryEmitConstantHeapMetadataRef(IGF.IGM, toType.getSwiftRValueType(),
+                                          /*allowUninitialized*/ false))) {
     // ok
   } else {
     targetMetadata
       = emitClassHeapMetadataRef(IGF, toType.getSwiftRValueType(),
                                  MetadataValueType::ObjCClass,
                                  MetadataState::Complete,
-                                 /*allowUninitialized*/ allowConservative);
+                                 /*allowUninitialized*/ false);
   }
 
   // Handle checking a metatype object's type by directly comparing the address

--- a/test/IRGen/exactcast.sil
+++ b/test/IRGen/exactcast.sil
@@ -23,7 +23,7 @@ class ParentNode : Node {
 
 sil @_test_exact_checked_cast_branch : $@convention(method) (@guaranteed Node) -> Int {
 bb0(%0 : $Node):
-//CHECK-LABEL: @_test_exact_checked_cast_branch
+//CHECK-LABEL: define{{.*}}@_test_exact_checked_cast_branch
 //CHECK:       = load %swift.type
 //CHECK-NEXT:  = icmp eq %swift.type
 //CHECK-NEXT:  = bitcast
@@ -38,6 +38,43 @@ bb2(%5 : $ParentNode):                            // Preds: bb0
 
 bb3:                                              // Preds: bb0
   br bb1                              // id: %12
+}
+
+class BaseBase {
+  @inline(never) func foo()
+  init()
+  deinit
+}
+
+class Base<T> : BaseBase {
+  override init()
+  deinit
+}
+
+final class DerivedInt : Base<Int> {
+  @inline(never) override final func foo()
+  override init()
+  deinit
+}
+
+sil @test_exact_checked_cast_branch_dynamic_init : $@convention(thin) (@guaranteed BaseBase) -> Int {
+bb0(%0 : $BaseBase):
+//CHECK-LABEL: define{{.*}}@test_exact_checked_cast_branch_dynamic_init
+//CHECK: call swiftcc {{.*}}@"$S9exactcast10DerivedIntCMa"({{.*}})
+//CHECK: load
+//CHECK: bitcast
+//CHECK: icmp eq %swift.type
+//CHECK: br
+  checked_cast_br [exact] %0 : $BaseBase to $DerivedInt, bb2, bb3 // id: %2
+
+bb1:
+  return undef : $Int
+
+bb2(%5 : $DerivedInt):
+  br bb1
+
+bb3:
+  br bb1
 }
 
 sil @_TFC9pic_crash4NodecfMS0_FT5indexSi_S0_ : $@convention(method) (Int, @owned Node) -> @owned Node
@@ -64,3 +101,23 @@ sil_vtable ParentNode {
   #ParentNode.init!initializer.1: @_TFC9pic_crash10ParentNodecfMS0_FT4leftCS_4Node5rightS1_5indexSi_S0_	// pic_crash.ParentNode.init (pic_crash.ParentNode.Type)(left : pic_crash.Node, right : pic_crash.Node, index : Swift.Int) -> pic_crash.ParentNode
 }
 
+sil @$S5test104BaseB0C3fooyyF : $@convention(method) (@guaranteed BaseBase) -> ()
+sil @$S5test104BaseB0CfD : $@convention(method) (@owned BaseBase) -> ()
+sil @$S5test14BaseCfD : $@convention(method) (@owned BaseBase) -> ()
+sil @$S5test110DerivedIntC3fooyyF : $@convention(method) (@guaranteed DerivedInt) -> ()
+sil @$S5test110DerivedIntCfD : $@convention(method) (@owned DerivedInt) -> ()
+
+sil_vtable BaseBase {
+  #BaseBase.foo!1: (BaseBase) -> () -> () : @$S5test104BaseB0C3fooyyF
+  #BaseBase.deinit!deallocator: @$S5test104BaseB0CfD
+}
+
+sil_vtable Base {
+  #BaseBase.foo!1: (BaseBase) -> () -> () : @$S5test104BaseB0C3fooyyF [inherited]
+  #Base.deinit!deallocator: @$S5test14BaseCfD
+}
+
+sil_vtable DerivedInt {
+  #BaseBase.foo!1: (BaseBase) -> () -> () : @$S5test110DerivedIntC3fooyyF [override]
+  #DerivedInt.deinit!deallocator: @$S5test110DerivedIntCfD
+}


### PR DESCRIPTION
Use initialized metadata in exact checks otherwise we will fail in
[exact] checks when we shouldn't.

rdar://38885852

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
