### PR TITLE
LargeLoadableTypes: fix a corner case with optional function types

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -91,6 +91,14 @@ static bool shouldTransformParameter(GenericEnvironment *env,
   return (param != newParam);
 }
 
+static bool isFuncOrOptionalFuncType(SILType Ty) {
+  SILType nonOptionalType = Ty;
+  if (auto optType = Ty.getOptionalObjectType()) {
+    nonOptionalType = optType;
+  }
+  return nonOptionalType.is<SILFunctionType>();
+}
+
 static bool shouldTransformFunctionType(GenericEnvironment *env,
                                         CanSILFunctionType fnType,
                                         irgen::IRGenModule &IGM) {
@@ -1742,7 +1750,7 @@ static void createResultTyInstrAndLoad(LoadableStorageAllocation &allocator,
   instr->getParent()->erase(instr);
 
   // If the load is of a function type - do not replace it.
-  if (loadArg->getType().is<SILFunctionType>()) {
+  if (isFuncOrOptionalFuncType(loadArg->getType())) {
     return;
   }
 
@@ -1803,7 +1811,7 @@ static void rewriteFunction(StructLoweringState &pass,
           loadArg->setOperand(newArg);
 
           // If the load is of a function type - do not replace it.
-          if (loadArg->getType().is<SILFunctionType>()) {
+          if (isFuncOrOptionalFuncType(loadArg->getType())) {
             continue;
           }
 
@@ -1843,7 +1851,7 @@ static void rewriteFunction(StructLoweringState &pass,
             allocateAndSetForArgumentOperand(pass, currOperand, applyInst);
           } else if (auto *load = dyn_cast<LoadInst>(currOperandInstr)) {
             // If the load is of a function type - do not replace it.
-            if (load->getType().is<SILFunctionType>()) {
+            if (isFuncOrOptionalFuncType(load->getType())) {
               continue;
             }
 
@@ -2215,7 +2223,11 @@ static SILValue
 getOperandTypeWithCastIfNecessary(SILInstruction *containingInstr, SILValue op,
                                   IRGenModule &Mod, SILBuilder &builder) {
   SILType currSILType = op->getType();
-  if (auto funcType = currSILType.getAs<SILFunctionType>()) {
+  SILType nonOptionalType = currSILType;
+  if (auto optType = currSILType.getOptionalObjectType()) {
+    nonOptionalType = optType;
+  }
+  if (auto funcType = nonOptionalType.getAs<SILFunctionType>()) {
     GenericEnvironment *genEnv =
         containingInstr->getFunction()->getGenericEnvironment();
     if (!genEnv && funcType->isPolymorphic()) {
@@ -2223,8 +2235,16 @@ getOperandTypeWithCastIfNecessary(SILInstruction *containingInstr, SILValue op,
     }
     auto newFnType = getNewSILFunctionType(genEnv, funcType, Mod);
     SILType newSILType = SILType::getPrimitiveObjectType(newFnType);
+    if (nonOptionalType.isAddress()) {
+      newSILType = newSILType.getAddressType();
+    }
+    if (nonOptionalType != currSILType) {
+      newSILType = SILType::getOptionalType(newSILType);
+    }
     if (currSILType.isAddress()) {
-      newSILType = newSILType.getAddressType(); // we need address for loads
+      newSILType = newSILType.getAddressType();
+    }
+    if (currSILType.isAddress()) {
       if (newSILType != currSILType) {
         auto castInstr = builder.createUncheckedAddrCast(
             containingInstr->getLoc(), op, newSILType);

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -234,3 +234,23 @@ class TestBig {
         }
     }
 }
+
+struct BigStructWithFunc {
+    var incSize : BigStruct
+    var foo: ((BigStruct) -> Void)?
+}
+
+// CHECK-LABEL: define{{( protected)?}} hidden swiftcc void @"$S22big_types_corner_cases20UseBigStructWithFuncC5crashyyF"(%T22big_types_corner_cases20UseBigStructWithFuncC* swiftself)
+// CHECK: call swiftcc void @"$S22big_types_corner_cases20UseBigStructWithFuncC10callMethod
+// CHECK: ret void
+class UseBigStructWithFunc {
+    var optBigStructWithFunc: BigStructWithFunc?
+
+    func crash() {
+        guard let bigStr = optBigStructWithFunc else { return }
+        callMethod(ptr: bigStr.foo)
+    }
+
+    private func callMethod(ptr: ((BigStruct) -> Void)?) -> () {
+    }
+}


### PR DESCRIPTION
radar rdar://problem/39050300

Fixes a bug where we have an optional function type for which we changed the signature, and, in addition, gotten said type via a modified struct/enum extract
That is, the function type is contained inside a large loadable type which we transformed into its address variant
There is a check that we have to explode (load instruction) the extract value if it is a function type, however, we did not check if it is an optional function type.