### PR TITLE
 SIL: Force Clang-imported protocol conformances to get deserialized when used.

### DIFF
--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -708,6 +708,11 @@ public:
   bool isDefaultAtomic() const {
     return ! getOptions().AssumeSingleThreaded;
   }
+  
+  /// Returns true if SIL entities associated with declarations in the given
+  /// declaration context ought to be serialized as part of this module.
+  bool shouldSerializeEntitiesAssociatedWithDeclContext(const DeclContext *DC)
+    const;
 };
 
 inline llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, const SILModule &M){

--- a/lib/SIL/Linker.h
+++ b/lib/SIL/Linker.h
@@ -31,6 +31,9 @@ class SILLinkerVisitor : public SILInstructionVisitor<SILLinkerVisitor, bool> {
   /// The SILLoader that this visitor is using to link.
   SerializedSILLoader *Loader;
 
+  /// Break cycles visiting recursive protocol conformances.
+  llvm::DenseSet<ProtocolConformance *> VisitedConformances;
+
   /// Worklist of SILFunctions we are processing.
   llvm::SmallVector<SILFunction *, 128> Worklist;
 
@@ -65,6 +68,7 @@ public:
   bool visitFunctionRefInst(FunctionRefInst *FRI);
   bool visitProtocolConformance(ProtocolConformanceRef C,
                                 const Optional<SILDeclRef> &Member);
+  bool visitApplySubstitutions(const SubstitutionMap &subs);
   bool visitWitnessMethodInst(WitnessMethodInst *WMI) {
     return visitProtocolConformance(WMI->getConformance(), WMI->getMember());
   }

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -22,6 +22,7 @@
 #include "Linker.h"
 #include "swift/SIL/SILVisitor.h"
 #include "swift/SIL/SILValue.h"
+#include "swift/ClangImporter/ClangModule.h"
 #include "llvm/ADT/FoldingSet.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringSwitch.h"
@@ -772,6 +773,23 @@ bool SILModule::isNoReturnBuiltinOrIntrinsic(Identifier Name) {
   case BuiltinValueKind::ErrorInMain:
     return true;
   }
+}
+
+bool SILModule::
+shouldSerializeEntitiesAssociatedWithDeclContext(const DeclContext *DC) const {
+  // Serialize entities associated with this module's associated context.
+  if (DC->isChildContextOf(getAssociatedContext())) {
+    return true;
+  }
+  
+  // Serialize entities associated with clang modules, since other entities
+  // may depend on them, and someone who deserializes those entities may not
+  // have their own copy.
+  if (isa<ClangModuleUnit>(DC->getModuleScopeContext())) {
+    return true;
+  }
+  
+  return false;
 }
 
 /// Returns true if it is the OnoneSupport module.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -625,6 +625,8 @@ NormalProtocolConformance *ModuleFile::readNormalConformance(
 
   ASTContext &ctx = getContext();
   DeclContext *dc = getDeclContext(contextID);
+  assert(!isa<ClangModuleUnit>(dc->getModuleScopeContext())
+         && "should not have serialized a conformance from a clang module");
   Type conformingType = dc->getDeclaredInterfaceType();
   PrettyStackTraceType trace(ctx, "reading conformance for", conformingType);
 

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -2814,6 +2814,14 @@ SILWitnessTable *SILDeserializer::readWitnessTable(DeclID WId,
     if (Callback)
       Callback->didDeserialize(MF->getAssociatedModule(), wT);
   }
+  
+  // We may see multiple shared-linkage definitions of the same witness table
+  // for the same conformance.
+  if (wT->isDefinition() && hasSharedVisibility(*Linkage)
+      && hasSharedVisibility(wT->getLinkage())) {
+    wTableOrOffset.set(wT, /*fully deserialized*/ true);
+    return wT;
+  }
 
   assert(wT->isDeclaration() && "Our witness table at this point must be a "
                                 "declaration.");

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1608,7 +1608,9 @@ Serializer::writeConformance(ProtocolConformanceRef conformanceRef,
   switch (conformance->getKind()) {
   case ProtocolConformanceKind::Normal: {
     auto normal = cast<NormalProtocolConformance>(conformance);
-    if (!isDeclXRef(getDeclForContext(normal->getDeclContext()))) {
+    if (!isDeclXRef(getDeclForContext(normal->getDeclContext()))
+        && !isa<ClangModuleUnit>(normal->getDeclContext()
+                                       ->getModuleScopeContext())) {
       // A normal conformance in this module file.
       unsigned abbrCode = abbrCodes[NormalProtocolConformanceIdLayout::Code];
       NormalProtocolConformanceIdLayout::emitRecord(Out, ScratchRecord,

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2454,21 +2454,23 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
   assert(assocDC && "cannot serialize SIL without an associated DeclContext");
   for (const SILVTable &vt : SILMod->getVTables()) {
     if ((ShouldSerializeAll || vt.isSerialized()) &&
-        vt.getClass()->isChildContextOf(assocDC))
+        SILMod->shouldSerializeEntitiesAssociatedWithDeclContext(vt.getClass()))
       writeSILVTable(vt);
   }
   
   // Write out property descriptors.
   for (const SILProperty &prop : SILMod->getPropertyList()) {
     if ((ShouldSerializeAll || prop.isSerialized()) &&
-        prop.getDecl()->getInnermostDeclContext()->isChildContextOf(assocDC))
+        SILMod->shouldSerializeEntitiesAssociatedWithDeclContext(
+                                     prop.getDecl()->getInnermostDeclContext()))
       writeSILProperty(prop);
   }
 
   // Write out fragile WitnessTables.
   for (const SILWitnessTable &wt : SILMod->getWitnessTables()) {
     if ((ShouldSerializeAll || wt.isSerialized()) &&
-        wt.getConformance()->getDeclContext()->isChildContextOf(assocDC))
+        SILMod->shouldSerializeEntitiesAssociatedWithDeclContext(
+                                         wt.getConformance()->getDeclContext()))
       writeSILWitnessTable(wt);
   }
 
@@ -2476,7 +2478,8 @@ void SILSerializer::writeSILBlock(const SILModule *SILMod) {
   for (const SILDefaultWitnessTable &wt : SILMod->getDefaultWitnessTables()) {
     // FIXME: Don't need to serialize private and internal default witness
     // tables.
-    if (wt.getProtocol()->getDeclContext()->isChildContextOf(assocDC))
+    if (SILMod->shouldSerializeEntitiesAssociatedWithDeclContext(
+                                                              wt.getProtocol()))
       writeSILDefaultWitnessTable(wt);
   }
 

--- a/test/IRGen/Inputs/deserialize-clang-importer-witness-tables/regex.swift
+++ b/test/IRGen/Inputs/deserialize-clang-importer-witness-tables/regex.swift
@@ -1,0 +1,25 @@
+
+import Foundation
+
+public struct RegEx {
+    public let pattern: String
+    fileprivate let regex: NSRegularExpression
+    public typealias Options = NSRegularExpression.Options
+    
+    public init(pattern: String, options: Options = []) throws {
+        self.pattern = pattern
+        self.regex = try NSRegularExpression(pattern: pattern, options: options)
+    }
+    
+    /// Returns a match group for the first match, or nil if there was no match.
+    public func firstMatch(in string: String) -> [String]? {
+        let nsString = string as NSString
+        
+        return regex.firstMatch(in: string, range: NSMakeRange(0, nsString.length)).map { match -> [String] in
+            return (1 ..< match.numberOfRanges).map { idx -> String in
+                let range = match.range(at: idx)
+                return range.location == NSNotFound ? "" : nsString.substring(with: range)
+            }
+        }
+    }
+}

--- a/test/IRGen/deserialize-clang-importer-witness-tables.swift
+++ b/test/IRGen/deserialize-clang-importer-witness-tables.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -swift-version 4 -emit-module -o %t/regex.swiftmodule %S/Inputs/deserialize-clang-importer-witness-tables/regex.swift
+// RUN: %target-swift-frontend -swift-version 4 -emit-ir %s -I %t | %FileCheck %s
+// REQUIRES: objc_interop
+import regex
+
+public func foo(line: String) {
+  // The NSRegularExpressionOptions: SetAlgebra conformance is used indirectly
+  // from the default argument expression passed to `RegEx(pattern:options:)`
+  // below. Ensure that a local copy of the definition was deserialized
+  // and lowered to IR.
+  // CHECK-LABEL: define {{.*}} i8** @"$SSo26NSRegularExpressionOptionsVs10SetAlgebraSCWa"
+  // CHECK-LABEL: define {{.*}} void @"$SSo26NSRegularExpressionOptionsVs10SetAlgebraSCsACPxycfCTW"
+  let versionRegex = try! RegEx(pattern: "Apple")
+  _ = versionRegex.firstMatch(in: line)  
+}

--- a/test/SIL/Serialization/Inputs/clang_conformances.sil
+++ b/test/SIL/Serialization/Inputs/clang_conformances.sil
@@ -20,3 +20,11 @@ bb0:
   dealloc_stack %1 : $*ComparisonResult // id: %9
   return %7 : $Bool                               // id: %10
 }
+
+sil @compare_eq : $@convention(witness_method: Equatable) (@in_guaranteed ComparisonResult, @in_guaranteed ComparisonResult, @thick ComparisonResult.Type) -> Bool
+
+sil_witness_table shared [serialized] ComparisonResult: Equatable module __ObjC {
+  method #Equatable."=="!1: @compare_eq
+}
+
+


### PR DESCRIPTION
Code may end up indirectly using a witness table for a Clang-imported type by inlining code that used the conformance from another module, in which case we need to ensure we have a local definition at hand in the inlining module so we can have something to link against independently. This needs to be fixed from both sides:

- During serialization, serialize not only witness tables from the current module, but from Clang-imported modules too
- During deserialization, when the SILLinker walks a loaded module, ensure that all shared conformances get deserialized, including those from ApplyInsts and inherited/associated type protocol requirements.

Fixes rdar://problem/38687726.
