### PR TITLE
[Parse] Remove dead code

### DIFF
--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -559,7 +559,6 @@ void Parser::markSplitToken(tok Kind, StringRef Txt) {
   SplitTokens.back().setToken(Kind, Txt);
   Trivia EmptyTrivia;
   SyntaxContext->addToken(SplitTokens.back(), LeadingTrivia, EmptyTrivia);
-  LeadingTrivia.empty();
   TokReceiver->receive(SplitTokens.back());
 }
 


### PR DESCRIPTION

https://github.com/apple/swift/commit/0a401b381c0db6dfa9db5930959dc0027a2c55a0#r28404027

`LeadingTrivia.empty()` does nothing. It was meant to be `clear()`, but `clear()` is also meaningless because `LeadingTrivia` is immediately overwritten.