### PR TITLE
LargeLoadableTypes: fix a corner case with optional function types

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -92,6 +92,14 @@ static bool shouldTransformParameter(GenericEnvironment *env,
   return (param != newParam);
 }
 
+static bool isFuncOrOptionalFuncType(SILType Ty) {
+  SILType nonOptionalType = Ty;
+  if (auto optType = Ty.getAnyOptionalObjectType()) {
+    nonOptionalType = optType;
+  }
+  return nonOptionalType.is<SILFunctionType>();
+}
+
 static bool shouldTransformFunctionType(GenericEnvironment *env,
                                         CanSILFunctionType fnType,
                                         irgen::IRGenModule &IGM) {
@@ -1716,8 +1724,7 @@ static void rewriteFunction(StructLoweringState &pass,
 
           // If the load is of a function type - do not replace it.
           auto loadedType = loadArg->getType();
-          auto canLoadedType = loadedType.getSwiftRValueType();
-          if (dyn_cast<SILFunctionType>(canLoadedType.getPointer())) {
+          if (isFuncOrOptionalFuncType(loadedType)) {
             continue;
           }
 
@@ -1760,8 +1767,7 @@ static void rewriteFunction(StructLoweringState &pass,
 
       // If the load is of a function type - do not replace it.
       auto loadedType = loadArg->getType();
-      auto canLoadedType = loadedType.getSwiftRValueType();
-      if (dyn_cast<SILFunctionType>(canLoadedType.getPointer())) {
+      if (isFuncOrOptionalFuncType(loadedType)) {
         continue;
       }
 
@@ -1792,8 +1798,7 @@ static void rewriteFunction(StructLoweringState &pass,
           } else if (auto *load = dyn_cast<LoadInst>(currOperandInstr)) {
             // If the load is of a function type - do not replace it.
             auto loadedType = load->getType();
-            auto canLoadedType = loadedType.getSwiftRValueType();
-            if (dyn_cast<SILFunctionType>(canLoadedType.getPointer())) {
+            if (isFuncOrOptionalFuncType(loadedType)) {
               continue;
             }
 
@@ -2161,7 +2166,11 @@ static SILValue
 getOperandTypeWithCastIfNecessary(SILInstruction *containingInstr, SILValue op,
                                   IRGenModule &Mod, SILBuilder &builder) {
   SILType currSILType = op->getType();
-  if (auto funcType = currSILType.getAs<SILFunctionType>()) {
+  SILType nonOptionalType = currSILType;
+  if (auto optType = currSILType.getAnyOptionalObjectType()) {
+    nonOptionalType = optType;
+  }
+  if (auto funcType = nonOptionalType.getAs<SILFunctionType>()) {
     CanSILFunctionType canFuncType = CanSILFunctionType(funcType);
     GenericEnvironment *genEnv =
         containingInstr->getFunction()->getGenericEnvironment();
@@ -2170,8 +2179,16 @@ getOperandTypeWithCastIfNecessary(SILInstruction *containingInstr, SILValue op,
     }
     auto newFnType = getNewSILFunctionType(genEnv, funcType, Mod);
     SILType newSILType = SILType::getPrimitiveObjectType(newFnType);
+    if (nonOptionalType.isAddress()) {
+      newSILType = newSILType.getAddressType();
+    }
+    if (nonOptionalType != currSILType) {
+      newSILType = SILType::getOptionalType(newSILType);
+    }
     if (currSILType.isAddress()) {
-      newSILType = newSILType.getAddressType(); // we need address for loads
+      newSILType = newSILType.getAddressType();
+    }
+    if (currSILType.isAddress()) {
       if (newSILType != currSILType) {
         auto castInstr = builder.createUncheckedAddrCast(
             containingInstr->getLoc(), op, newSILType);

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -220,3 +220,23 @@ class TestBig {
         let d = arr.index(where: { _ in true })
     }
 }
+
+struct BigStructWithFunc {
+    var incSize : BigStruct
+    var foo: ((BigStruct) -> Void)?
+}
+
+// CHECK-LABEL: define{{( protected)?}} hidden swiftcc void @_T022big_types_corner_cases20UseBigStructWithFuncC5crashyyF(%T22big_types_corner_cases20UseBigStructWithFuncC* swiftself)
+// CHECK: call swiftcc void @_T022big_types_corner_cases20UseBigStructWithFuncC10callMethod
+// CHECK: ret void
+class UseBigStructWithFunc {
+    var optBigStructWithFunc: BigStructWithFunc?
+
+    func crash() {
+        guard let bigStr = optBigStructWithFunc else { return }
+        callMethod(ptr: bigStr.foo)
+    }
+
+    private func callMethod(ptr: ((BigStruct) -> Void)?) -> () {
+    }
+}


### PR DESCRIPTION
radar rdar://problem/39050300


Explanation: Fixes a bug where we have an optional function type for which we changed the signature, and, in addition, gotten said type via a modified struct/enum extract instruction.
That is, the function type is contained inside a large loadable type which we transformed into its address variant
There is a check that we have to explode (load instruction) the extract value if it is a function type, however, we did not check if it is an optional function type.

Scope of Issue: Corner-case for code wherein people define a large loadable type containing an optional closure / function ref.

Origination: Swift 4.1 Regression - Found via External Developer test-case/bug-report

Risk: Low

Reviewed By: @aschwaighofer 