### PR TITLE
Remove even more usages of DeclChecker::IsFirstPass

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6356,14 +6356,14 @@ public:
 
   void visitDestructorDecl(DestructorDecl *DD) {
     if (!IsFirstPass) {
-      if (DD->getBody())
-        TC.definedFunctions.push_back(DD);
-
       return;
     }
 
     TC.validateDecl(DD);
     TC.checkDeclAttributes(DD);
+
+    if (DD->hasBody())
+      TC.definedFunctions.push_back(DD);
   }
 };
 } // end anonymous namespace

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4771,22 +4771,20 @@ public:
   }
 
   void visitFuncDecl(FuncDecl *FD) {
-    if (!IsFirstPass) {
-      if (FD->hasBody()) {
-        // Record the body.
-        TC.definedFunctions.push_back(FD);
-      } else if (requiresDefinition(FD)) {
-        // Complain if we should have a body.
-        TC.diagnose(FD->getLoc(), diag::func_decl_without_brace);
-      }
-
+    if (!IsFirstPass)
       return;
-    }
 
     TC.validateDecl(FD);
     checkAccessControl(TC, FD);
-  }
 
+    if (FD->hasBody()) {
+      // Record the body.
+      TC.definedFunctions.push_back(FD);
+    } else if (requiresDefinition(FD)) {
+      // Complain if we should have a body.
+      TC.diagnose(FD->getLoc(), diag::func_decl_without_brace);
+    }
+  }
 
   void visitModuleDecl(ModuleDecl *) { }
 

--- a/test/attr/attr_inlinable.swift
+++ b/test/attr/attr_inlinable.swift
@@ -206,6 +206,27 @@ class Derived : Middle {
   }
 }
 
+// More inherited initializers
+@_fixed_layout
+public class Base2 {
+  @inlinable
+  public init(x: Int) {}
+}
+
+@_fixed_layout
+@usableFromInline
+class Middle2 : Base2 {}
+
+@_fixed_layout
+@usableFromInline
+class Derived2 : Middle2 {
+  @usableFromInline
+  @inlinable
+  init(y: Int) {
+    super.init(x: y)
+  }
+}
+
 // Stored property initializer expressions.
 //
 // Note the behavior here does not depend on the state of the -enable-resilience

--- a/test/decl/overload.swift
+++ b/test/decl/overload.swift
@@ -219,7 +219,9 @@ struct X6<T> {
 
 extension X6 {
   var k: Int { return 0 } // expected-note{{previously declared here}}
-  func k() // expected-error{{invalid redeclaration of 'k()'}}
+  func k()
+  // expected-error@-1{{invalid redeclaration of 'k()'}}
+  // expected-error@-2{{expected '{' in body of function declaration}}
 }
 
 // Subscripting


### PR DESCRIPTION
Follow-up to #15703. Now, we add function bodies to the 'to be typechecked' list in the first pass.