### PR TITLE
stdlib: Collapse some multi-line closures to single-line closures.

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
+++ b/stdlib/private/StdlibCollectionUnittest/CheckMutableCollectionType.swift.gyb
@@ -446,8 +446,7 @@ self.test("\(testNamePrefix)._withUnsafeMutableBufferPointerIfSupported()/semant
     var c = makeWrappedCollection(test.collection)
     var result = c._withUnsafeMutableBufferPointerIfSupported {
       (bufferPointer) -> OpaqueValue<Array<OpaqueValue<Int>>> in
-      let value = OpaqueValue(bufferPointer.map(extractValue))
-      return value
+      return OpaqueValue(bufferPointer.map(extractValue))
     }
     expectType(Optional<OpaqueValue<Array<OpaqueValue<Int>>>>.self, &result)
     if withUnsafeMutableBufferPointerIsSupported {

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1640,8 +1640,7 @@ extension ${Self} : RangeReplaceableCollection, ArrayProtocol {
   ) rethrows -> R? {
     return try withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
-      let r = try body(&bufferPointer)
-      return r
+      return try body(&bufferPointer)
     }
   }
 

--- a/test/stdlib/Inputs/CommonArrayTests.gyb
+++ b/test/stdlib/Inputs/CommonArrayTests.gyb
@@ -274,8 +274,7 @@ ${Suite}.test("${ArrayType}/_withUnsafeMutableBufferPointerIfSupported")
       // Read.
       var result = a._withUnsafeMutableBufferPointerIfSupported {
         (bufferPointer) -> OpaqueValue<[OpaqueValue<Int>]> in
-        let r = OpaqueValue(Array(bufferPointer))
-        return r
+        return OpaqueValue(Array(bufferPointer))
       }
       expectType(Optional<OpaqueValue<Array<OpaqueValue<Int>>>>.self, &result)
       expectEqualSequence(test.sequence, result!.value.map { $0.value })


### PR DESCRIPTION
The change in `CheckMutableCollectionType.swift.gyb` previously resulted
in a runtime failure, and before that a compiler crash.

It appears that whatever type checker bug(s) were causing the issue
have been resolved in the last few months, so I'm returning this
closure to a single-expression form and cleaning up a couple other
places where we had an unneeded temporary as well.

Resolves rdar://problem/33781464.
