### PR TITLE
[Parse] Don't swallow 'try' at declaration member position

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2433,9 +2433,6 @@ Parser::parseDecl(ParseDeclOptions Flags,
   if (isCodeCompletionFirstPass())
     BeginParserPosition = getParserPosition();
 
-  SourceLoc tryLoc;
-  (void)consumeIf(tok::kw_try, tryLoc);
-
   // Note that we're parsing a declaration.
   StructureMarkerRAII ParsingDecl(*this, Tok.getLoc(),
                                   StructureMarkerKind::Declaration);
@@ -2452,6 +2449,11 @@ Parser::parseDecl(ParseDeclOptions Flags,
   SourceLoc StaticLoc;
   StaticSpellingKind StaticSpelling = StaticSpellingKind::None;
   parseDeclModifierList(Attributes, StaticLoc, StaticSpelling);
+
+  // We emit diagnostics for 'try let ...' in parseDeclVar().
+  SourceLoc tryLoc;
+  if (Tok.is(tok::kw_try) && peekToken().isAny(tok::kw_let, tok::kw_var))
+    tryLoc = consumeToken(tok::kw_try);
 
   ParserResult<Decl> DeclResult;
 

--- a/test/Parse/try.swift
+++ b/test/Parse/try.swift
@@ -91,6 +91,15 @@ try let multi1 = foo(), multi2 = bar() // expected-error {{'try' must be placed 
                                        // expected-note@-1 {{did you mean to use 'try'?}} {{18-18=try }} expected-note@-1 {{did you mean to use 'try'?}} {{34-34=try }}
                                        // expected-note@-2 {{did you mean to handle error as optional value?}} {{18-18=try? }} expected-note@-2 {{did you mean to handle error as optional value?}} {{34-34=try? }}
                                        // expected-note@-3 {{did you mean to disable error propagation?}} {{18-18=try! }} expected-note@-3 {{did you mean to disable error propagation?}} {{34-34=try! }}
+class TryDecl { // expected-note {{in declaration of 'TryDecl'}}
+  try let singleLet = foo() // expected-error {{'try' must be placed on the initial value expression}} {{3-7=}} {{23-23=try }}
+                            // expected-error @-1 {{call can throw, but errors cannot be thrown out of a property initializer}}
+  try var singleVar = foo() // expected-error {{'try' must be placed on the initial value expression}} {{3-7=}} {{23-23=try }}
+                            // expected-error @-1 {{call can throw, but errors cannot be thrown out of a property initializer}}
+
+  try // expected-error {{expected declaration}}
+  func method() {}
+}
 
 func test() throws -> Int {
   try while true { // expected-error {{'try' cannot be used with 'while'}}


### PR DESCRIPTION
Previously, this used to be silently accepted:

```swift
class Foo {
  try func bar() { }
}
```
