### PR TITLE
Fix SE-0025 edge case involving public member of protocol extension of private protocol

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2265,6 +2265,18 @@ public:
     return result;
   }
 
+  /// If this declaration is a member of a protocol extension, return the
+  /// minimum of the given access level and the protocol's access level.
+  ///
+  /// Otherwise, return the given access level unmodified.
+  ///
+  /// This is used when checking name lookup visibility. Protocol extension
+  /// members can be found when performing name lookup on a concrete type;
+  /// if the concrete type is visible from the lookup context but the
+  /// protocol is not, we do not want the protocol extension members to be
+  /// visible.
+  AccessLevel adjustAccessLevelForProtocolExtension(AccessLevel access) const;
+
   /// Determine whether this Decl has either Private or FilePrivate access.
   bool isOutermostPrivateOrFilePrivateScope() const;
 
@@ -2325,7 +2337,14 @@ public:
   /// A public declaration is accessible everywhere.
   ///
   /// If \p DC is null, returns true only if this declaration is public.
-  bool isAccessibleFrom(const DeclContext *DC) const;
+  ///
+  /// If \p forConformance is true, we ignore the visibility of the protocol
+  /// when evaluating protocol extension members. This language rule allows a
+  /// protocol extension of a private protocol to provide default
+  /// implementations for the requirements of a public protocol, even when
+  /// the default implementations are not visible to name lookup.
+  bool isAccessibleFrom(const DeclContext *DC,
+                        bool forConformance = false) const;
 
   /// Retrieve the "interface" type of this value, which uses
   /// GenericTypeParamType if the declaration is generic. For a generic
@@ -4449,7 +4468,11 @@ public:
   /// context.
   ///
   /// If \p DC is null, returns true only if the setter is public.
-  bool isSetterAccessibleFrom(const DeclContext *DC) const;
+  ///
+  /// See \c isAccessibleFrom for a discussion of the \p forConformance
+  /// parameter.
+  bool isSetterAccessibleFrom(const DeclContext *DC,
+                              bool forConformance=false) const;
 
   /// Determine how this storage declaration should actually be accessed.
   AccessStrategy getAccessStrategy(AccessSemantics semantics,

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1546,8 +1546,15 @@ diagnoseUnviableLookupResults(MemberLookupResult &result, Type baseObjTy,
     case MemberLookupResult::UR_Inaccessible: {
       auto decl = result.UnviableCandidates[0].first.getDecl();
       // FIXME: What if the unviable candidates have different levels of access?
+      //
+      // If we found an inaccessible member of a protocol extension, it might
+      // be declared 'public'. This can only happen if the protocol is not
+      // visible to us, but the conforming type is. In this case, we need to
+      // clamp the formal access for diagnostics purposes to the formal access
+      // of the protocol itself.
       diagnose(nameLoc, diag::candidate_inaccessible, decl->getBaseName(),
-               decl->getFormalAccess());
+               decl->adjustAccessLevelForProtocolExtension(
+                 decl->getFormalAccess()));
       for (auto cand : result.UnviableCandidates)
         diagnose(cand.first.getDecl(), diag::decl_declared_here, memberName);
         

--- a/test/SILGen/Inputs/witness_accessibility_other.swift
+++ b/test/SILGen/Inputs/witness_accessibility_other.swift
@@ -1,0 +1,20 @@
+public protocol P {
+  func publicRequirement()
+}
+
+@usableFromInline
+protocol Q : P {
+  func internalRequirement()
+}
+
+fileprivate protocol R : Q {}
+
+extension R {
+  public func publicRequirement() {}
+}
+
+extension Q {
+  public func internalRequirement() {}
+}
+
+public struct S : R {}

--- a/test/SILGen/testable-multifile-other.swift
+++ b/test/SILGen/testable-multifile-other.swift
@@ -12,6 +12,8 @@
 // RUN: %target-swift-frontend -emit-ir -enable-sil-ownership -I %t -primary-file %s %S/testable-multifile.swift -module-name main -o /dev/null
 // RUN: %target-swift-frontend -emit-ir -enable-sil-ownership -I %t -O -primary-file %s %S/testable-multifile.swift -module-name main -o /dev/null
 
+@testable import TestableMultifileHelper
+
 func use<F: Fooable>(_ f: F) { f.foo() }
 func test(internalFoo: FooImpl, publicFoo: PublicFooImpl) {
   use(internalFoo)

--- a/test/SILGen/witness_accessibility_multi.swift
+++ b/test/SILGen/witness_accessibility_multi.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module-path %t/witness_accessibility_other.swiftmodule %S/Inputs/witness_accessibility_other.swift
+// RUN: %target-swift-frontend -I %t -emit-silgen -enable-sil-ownership %s | %FileCheck %s
+// RUN: %target-swift-frontend -I %t -emit-sil -enable-sil-ownership %s
+
+import witness_accessibility_other
+
+// We can see the conformance S : P, but we cannot see the witness for
+// P.publicRequirement() because it is defined in an extension of a
+// private protocol R to which S also conforms.
+//
+// So make sure the witness is invoked via virtual dispatch even with
+// a concrete base type.
+
+// CHECK-LABEL: sil @$S27witness_accessibility_multi22callsPublicRequirement1sy0a1_B6_other1SV_tF : $@convention(thin) (S) -> ()
+public func callsPublicRequirement(s: S) {
+
+  // CHECK: witness_method $S, #P.publicRequirement!1 : <Self where Self : P> (Self) -> () -> () : $@convention(witness_method: P) <τ_0_0 where τ_0_0 : P> (@in_guaranteed τ_0_0) -> ()
+  s.publicRequirement()
+
+  // CHECK: function_ref @$S27witness_accessibility_other1QPAAE19internalRequirementyyF : $@convention(method) <τ_0_0 where τ_0_0 : Q> (@in_guaranteed τ_0_0) -> ()
+  s.internalRequirement()
+
+  // CHECK: return
+}

--- a/test/SILOptimizer/Inputs/opaque_conformance.swift
+++ b/test/SILOptimizer/Inputs/opaque_conformance.swift
@@ -1,0 +1,13 @@
+public protocol PublicProtocol {
+  func publicRequirement()
+}
+
+private protocol PrivateProtocol : PublicProtocol {}
+
+public struct Conformer : PrivateProtocol {}
+
+extension PrivateProtocol {
+  // This implementation is opaque to callers, since we can
+  // only find it via a private protocol.
+  public func publicRequirement() {}
+}

--- a/test/SILOptimizer/devirt_opaque_witness.swift
+++ b/test/SILOptimizer/devirt_opaque_witness.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -emit-module-path %t/opaque_conformance.swiftmodule -primary-file %S/Inputs/opaque_conformance.swift
+// RUN: %target-swift-frontend -O -emit-sil -primary-file %s -I %t | %FileCheck %s
+
+import opaque_conformance
+
+public func callsPublicRequirement(_ c: Conformer) {
+  c.publicRequirement()
+}
+
+// CHECK-LABEL: sil @$S21devirt_opaque_witness22callsPublicRequirementyy0B12_conformance9ConformerVF : $@convention(thin) (Conformer) -> () {
+// CHECK:    bb0(%0 : $Conformer):
+// CHECK:      [[BOX:%.*]] = alloc_stack $Conformer
+// CHECK-NEXT: store %0 to [[BOX]] : $*Conformer
+// CHECK:      [[FN:%.*]] = function_ref @$S18opaque_conformance9ConformerVAA14PublicProtocolA2aDP17publicRequirementyyFTW : $@convention(witness_method: PublicProtocol) (@in_guaranteed Conformer) -> ()
+// CHECK-NEXT: [[RESULT:%.*]] = apply [[FN]]([[BOX]]) : $@convention(witness_method: PublicProtocol) (@in_guaranteed Conformer) -> ()
+// CHECK-NEXT: dealloc_stack [[BOX]] : $*Conformer
+// CHECK-NEXT: [[RESULT:%.*]] = tuple ()
+// CHECK-NEXT: return [[RESULT]] : $()
+
+// Note that [transparent] here doesn't mean anything since there's no body.
+// The important thing is that the witness_method call got devirtualized,
+// and the thunk has public linkage and no serialized body (since the body
+// references a private symbol of the module opaque_conformance).
+// CHECK-LABEL: sil [transparent] [thunk] @$S18opaque_conformance9ConformerVAA14PublicProtocolA2aDP17publicRequirementyyFTW : $@convention(witness_method: PublicProtocol) (@in_guaranteed Conformer) -> ()
+
+// CHECK-LABEL: sil_witness_table public_external Conformer: PublicProtocol module opaque_conformance {
+// CHECK-NEXT:    method #PublicProtocol.publicRequirement!1: <Self where Self : PublicProtocol> (Self) -> () -> () : @$S18opaque_conformance9ConformerVAA14PublicProtocolA2aDP17publicRequirementyyFTW
+// CHECK-NEXT: }

--- a/test/Sema/Inputs/accessibility_multi_other.swift
+++ b/test/Sema/Inputs/accessibility_multi_other.swift
@@ -7,3 +7,15 @@ struct Members {
     set {}
   }
 }
+
+struct PrivateConformance : PrivateProtocol {}
+
+private protocol PrivateProtocol {}
+
+extension PrivateProtocol {
+  public func publicExtensionMember() {}
+  // expected-note@-1 {{'publicExtensionMember' declared here}}
+
+  internal func internalExtensionMember() {}
+  // expected-note@-1 {{'internalExtensionMember' declared here}}
+}

--- a/test/Sema/Inputs/accessibility_multi_other_module.swift
+++ b/test/Sema/Inputs/accessibility_multi_other_module.swift
@@ -1,0 +1,19 @@
+public struct PrivateConformance : PrivateProtocol {}
+
+private protocol PrivateProtocol {}
+
+extension PrivateProtocol {
+  public func publicExtensionMember() {}
+
+  internal func internalExtensionMember() {}
+}
+
+public struct InternalConformance : InternalProtocol {}
+
+internal protocol InternalProtocol {}
+
+extension InternalProtocol {
+  public func publicExtensionMember() {}
+
+  internal func internalExtensionMember() {}
+}

--- a/test/Sema/accessibility_multi.swift
+++ b/test/Sema/accessibility_multi.swift
@@ -21,3 +21,11 @@ func testSubscript(_ instance: Members) {
   instance[] = 42 // expected-error {{cannot assign through subscript: subscript setter is inaccessible}}
   reset(&instance[]) // expected-error {{cannot pass immutable value as inout argument: subscript setter is inaccessible}}
 }
+
+func testPrivateConformance(_ instance: PrivateConformance) {
+  instance.publicExtensionMember()
+  // expected-error@-1 {{'publicExtensionMember' is inaccessible due to 'fileprivate' protection level}}
+
+  instance.internalExtensionMember()
+  // expected-error@-1 {{'internalExtensionMember' is inaccessible due to 'fileprivate' protection level}}
+}

--- a/test/Sema/accessibility_multi_module.swift
+++ b/test/Sema/accessibility_multi_module.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -primary-file %S/Inputs/accessibility_multi_other_module.swift -emit-module-path %t/accessibility_multi_other_module.swiftmodule
+// RUN: %target-swift-frontend -typecheck -I %t -primary-file %s -verify -verify-ignore-unknown
+
+import accessibility_multi_other_module
+
+func testPrivateConformance(_ instance: PrivateConformance) {
+  instance.publicExtensionMember()
+  // expected-error@-1 {{'publicExtensionMember' is inaccessible due to 'fileprivate' protection level}}
+
+  instance.internalExtensionMember()
+  // expected-error@-1 {{'internalExtensionMember' is inaccessible due to 'fileprivate' protection level}}
+}
+
+func testInternalConformance(_ instance: InternalConformance) {
+  instance.publicExtensionMember()
+  // expected-error@-1 {{'publicExtensionMember' is inaccessible due to 'internal' protection level}}
+
+  instance.internalExtensionMember()
+  // expected-error@-1 {{'internalExtensionMember' is inaccessible due to 'internal' protection level}}
+}

--- a/test/decl/protocol/conforms/access_corner_case.swift
+++ b/test/decl/protocol/conforms/access_corner_case.swift
@@ -1,0 +1,61 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+
+// Protocol requirement is witnessed from a member of a
+// less-visible extension
+public protocol P {
+  func publicRequirement()
+}
+
+protocol Q : P {
+  func internalRequirement()
+}
+
+fileprivate protocol R : Q {
+  func fileprivateRequirement()
+}
+
+private protocol S : R {
+  func privateRequirement()
+  func privateRequirementCannotWork()
+  // expected-note@-1 {{protocol requires function 'privateRequirementCannotWork()' with type '() -> ()'; do you want to add a stub?}}
+}
+
+extension S {
+  public func publicRequirement() {}
+  internal func internalRequirement() {}
+  fileprivate func fileprivateRequirement() {}
+  fileprivate func privateRequirement() {}
+
+  // Cannot witness requirement in another protocol!
+  private func privateRequirementCannotWork() {}
+}
+
+
+public struct T : S {}
+// expected-error@-1 {{type 'T' does not conform to protocol 'S'}}
+
+// This is also OK
+@usableFromInline
+internal protocol U : P {}
+
+extension U {
+  public func publicRequirement() {}
+}
+
+public struct SS : U {}
+
+// Currently this is banned
+public protocol P2 {
+  func publicRequirement()
+}
+
+protocol Q2 : P2 {}
+
+extension Q2 {
+  // note: not public
+  func publicRequirement() {}
+  // expected-error@-1 {{method 'publicRequirement()' must be declared public because it matches a requirement in public protocol 'P2'}}
+}
+
+public struct T2 : Q2 {}


### PR DESCRIPTION
The witness table for a conformance to a private protocol is private. For this reason any member of a protocol extension of such a protocol should also be private, since it expects to receive a witness table and therefore there's no way to call it from the outside.

However, the type checker was incorrectly allowing such members to be found by name lookup if a public type conformed to the private protocol. Calling such a member resulted in a linker error.

The type checker also allowed these members to witness protocol requirements of public protocols. Since we cannot break source compatibility, this behavior is preserved. When calling the protocol requirement from outside of the module with the concrete base type, we used to fail with a linker error; now we call the requirement virtually using a `witness_method` instruction.

Fixes <rdar://problem/21380336>, <rdar://problem/29044612>, _let's go search JIRA for dupes..._ https://bugs.swift.org/browse/SR-2315, https://bugs.swift.org/browse/SR-2571, https://bugs.swift.org/browse/SR-2925, https://bugs.swift.org/browse/SR-3312, https://bugs.swift.org/browse/SR-6325, damn...