### PR TITLE
[AST] Avoid getProtocols on a temporary ExistentialLayout now and forever.

### DIFF
--- a/include/swift/AST/ExistentialLayout.h
+++ b/include/swift/AST/ExistentialLayout.h
@@ -70,18 +70,22 @@ struct ExistentialLayout {
   }
   typedef ArrayRefView<Type,ProtocolType*,getProtocolType> ProtocolTypeArrayRef;
 
-  ProtocolTypeArrayRef getProtocols() const {
+  ProtocolTypeArrayRef getProtocols() const & {
+    if (singleProtocol)
+      return llvm::makeArrayRef(&singleProtocol, 1);
     return protocols;
   }
+  /// The returned ArrayRef may point directly to \c this->singleProtocol, so
+  /// calling this on a temporary is likely to be incorrect.
+  ProtocolTypeArrayRef getProtocols() const && = delete;
 
   LayoutConstraint getLayoutConstraint() const;
 
 private:
-  // Inline storage for 'protocols' member above when computing
-  // layout of a single ProtocolType
+  // The protocol from a ProtocolType
   Type singleProtocol;
 
-  /// Zero or more protocol constraints.
+  /// Zero or more protocol constraints from a ProtocolCompositionType
   ArrayRef<Type> protocols;
 };
 

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -249,7 +249,6 @@ ExistentialLayout::ExistentialLayout(ProtocolType *type) {
   containsNonObjCProtocol = !protoDecl->isObjC();
 
   singleProtocol = type;
-  protocols = { &singleProtocol, 1 };
 }
 
 ExistentialLayout::ExistentialLayout(ProtocolCompositionType *type) {

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -430,7 +430,8 @@ void TypeChecker::resolveExtensionForConformanceConstruction(
       type = resolveType(inherited.getTypeRepr(), ext, options, &resolver);
 
     if (type && type->isExistentialType()) {
-      for (auto proto : type->getExistentialLayout().getProtocols())
+      auto layout = type->getExistentialLayout();
+      for (auto proto : layout.getProtocols())
         protocols.push_back({inherited.getLoc(), proto->getDecl()});
     }
   }


### PR DESCRIPTION
Also, make ExistentialLayout non-self-referential, by moving that logic to the
point where it is used. The construction of the one-element-ArrayRef is so cheap
that it doesn't need to be cached.
