### PR TITLE
[CMake] Improve Xcode project generation with folders

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -810,6 +810,8 @@ function(_add_swift_library_single target name)
   if(NOT "${SWIFTLIB_SINGLE_MODULE_TARGET}" STREQUAL "" AND NOT "${swift_module_dependency_target}" STREQUAL "")
     add_custom_target("${SWIFTLIB_SINGLE_MODULE_TARGET}"
       DEPENDS ${swift_module_dependency_target})
+    set_target_properties("${SWIFTLIB_SINGLE_MODULE_TARGET}" PROPERTIES
+      FOLDER "Swift libraries/Modules")
   endif()
 
   # For standalone overlay builds to work

--- a/cmake/modules/SwiftSharedCMakeConfig.cmake
+++ b/cmake/modules/SwiftSharedCMakeConfig.cmake
@@ -201,6 +201,9 @@ macro(swift_common_standalone_build_config product is_cross_compiling)
   swift_common_standalone_build_config_llvm(${product} ${is_cross_compiling})
   swift_common_standalone_build_config_clang(${product} ${is_cross_compiling})
   swift_common_standalone_build_config_cmark(${product})
+
+  # Enable groups for IDE generators (Xcode and MSVC).
+  set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 endmacro()
 
 # Common cmake project config for unified builds.

--- a/stdlib/CMakeLists.txt
+++ b/stdlib/CMakeLists.txt
@@ -58,6 +58,15 @@ foreach(SDK ${SWIFT_SDKS})
   add_custom_target("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sib")
   add_custom_target("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sibopt")
   add_custom_target("swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sibgen")
+
+  set_property(TARGET
+      "swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}"
+      "swift-test-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}"
+      "swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sib"
+      "swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sibopt"
+      "swift-stdlib-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-sibgen"
+      PROPERTY FOLDER "Swift libraries/Aggregate")
+
   foreach(ARCH ${SWIFT_SDK_${SDK}_ARCHITECTURES})
     set(VARIANT_SUFFIX "-${SWIFT_SDK_${SDK}_LIB_SUBDIR}-${ARCH}")
     add_custom_target("swift-stdlib${VARIANT_SUFFIX}")
@@ -65,6 +74,14 @@ foreach(SDK ${SWIFT_SDKS})
     add_custom_target("swift-stdlib${VARIANT_SUFFIX}-sibopt")
     add_custom_target("swift-stdlib${VARIANT_SUFFIX}-sibgen")
     add_custom_target("swift-test-stdlib${VARIANT_SUFFIX}")
+
+    set_property(TARGET
+        "swift-stdlib${VARIANT_SUFFIX}"
+        "swift-stdlib${VARIANT_SUFFIX}-sib"
+        "swift-stdlib${VARIANT_SUFFIX}-sibopt"
+        "swift-stdlib${VARIANT_SUFFIX}-sibgen"
+        "swift-test-stdlib${VARIANT_SUFFIX}"
+        PROPERTY FOLDER "Swift libraries/Aggregate")
 
     add_dependencies(swift-stdlib-all "swift-stdlib${VARIANT_SUFFIX}")
     add_dependencies(swift-stdlib-sib-all "swift-stdlib${VARIANT_SUFFIX}-sib")
@@ -94,6 +111,18 @@ add_custom_target(swift-stdlib-sibgen
     DEPENDS "swift-stdlib${SWIFT_PRIMARY_VARIANT_SUFFIX}-sibgen")
 add_custom_target(swift-test-stdlib ALL
     DEPENDS "swift-test-stdlib${SWIFT_PRIMARY_VARIANT_SUFFIX}")
+
+set_property(TARGET
+    swift-stdlib-all
+    swift-stdlib-sib-all
+    swift-stdlib-sibopt-all
+    swift-stdlib-sibgen-all
+    swift-stdlib
+    swift-stdlib-sib
+    swift-stdlib-sibopt
+    swift-stdlib-sibgen
+    swift-test-stdlib
+    PROPERTY FOLDER "Swift libraries/Aggregate")
 
 add_subdirectory(public)
 add_subdirectory(private)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -299,7 +299,9 @@ foreach(SDK ${SWIFT_SDKS})
           set(test_mode_target_suffix "-${test_mode}")
         endif()
 
-        add_custom_target("check-swift${test_subset_target_suffix}${test_mode_target_suffix}${VARIANT_SUFFIX}"
+        set(test_target_name
+            "check-swift${test_subset_target_suffix}${test_mode_target_suffix}${VARIANT_SUFFIX}")
+        add_custom_target("${test_target_name}"
             ${command_upload_stdlib}
             ${command_upload_swift_reflection_test}
             ${command_clean_test_results_dir}
@@ -313,7 +315,7 @@ foreach(SDK ${SWIFT_SDKS})
             COMMENT "Running ${test_subset} Swift tests for ${VARIANT_TRIPLE}"
             USES_TERMINAL)
 
-        add_custom_target("check-swift${test_subset_target_suffix}${test_mode_target_suffix}${VARIANT_SUFFIX}-custom"
+        add_custom_target("${test_target_name}-custom"
             ${command_upload_stdlib}
             ${command_upload_swift_reflection_test}
             ${command_clean_test_results_dir}
@@ -325,6 +327,8 @@ foreach(SDK ${SWIFT_SDKS})
             DEPENDS ${dependencies}
             COMMENT "Running ${test_subset} Swift tests for ${VARIANT_TRIPLE} from custom test locations"
             USES_TERMINAL)
+        set_property(TARGET "${test_target_name}" "${test_target_name}-custom"
+            PROPERTY FOLDER "Tests/check-swift")
       endforeach()
     endforeach()
   endforeach()
@@ -342,7 +346,11 @@ foreach(test_mode ${TEST_MODES})
       set(test_subset_target_suffix "")
     endif()
 
-    add_custom_target(check-swift${test_subset_target_suffix}${test_mode_target_suffix}
-        DEPENDS "check-swift${test_subset_target_suffix}${test_mode_target_suffix}${SWIFT_PRIMARY_VARIANT_SUFFIX}")
+    set(test_target_name
+        "check-swift${test_subset_target_suffix}${test_mode_target_suffix}")
+    add_custom_target("${test_target_name}"
+        DEPENDS "${test_target_name}${SWIFT_PRIMARY_VARIANT_SUFFIX}")
+    set_property(TARGET "${test_target_name}"
+        PROPERTY FOLDER "Tests/check-swift")
   endforeach()
 endforeach()


### PR DESCRIPTION
- Re-enable the use of folders with the USE_FOLDER setting. This got lost a while ago when we stopped including LLVM's top-level CMakeLists.txt.

- Put a bunch of new targets into folders.

Should not affect the built product and definitely shouldn't affect anyone not building with Xcode (or MSVC, I guess).