### PR TITLE
[4.1] Fix regression from hack for SR-6796.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1212,8 +1212,13 @@ ConstraintSystem::matchFunctionTypes(FunctionType *func1, FunctionType *func2,
       if (last->getKind() == ConstraintLocator::ApplyArgToParam) {
         if (auto *paren1 = dyn_cast<ParenType>(func1Input.getPointer())) {
           auto innerTy = paren1->getUnderlyingType();
-          if (func2Input->isVoid() && innerTy->isVoid())
+          if (func2Input->isVoid() && innerTy->isVoid()) {
             func1Input = innerTy;
+            // If the other input is also parenthesized, remove one
+            // layer of parens from it as well.
+            if (auto *paren2 = dyn_cast<ParenType>(func2Input.getPointer()))
+              func2Input = paren2->getUnderlyingType();
+          }
         }
       }
     }

--- a/test/Compatibility/tuple_arguments_4.swift
+++ b/test/Compatibility/tuple_arguments_4.swift
@@ -1670,3 +1670,13 @@ do {
   func h(_: ()) {} // expected-note {{'h' declared here}}
   h() // expected-error {{missing argument for parameter #1 in call}}
 }
+
+
+// https://bugs.swift.org/browse/SR-7191
+class Mappable<T> {
+  init(_: T) { }
+  func map<U>(_ body: (T) -> U) -> U { fatalError() }
+}
+
+let x = Mappable(())
+_ = x.map { (_: Void) in return () }


### PR DESCRIPTION
- Explanation: In certain cases we regressed when working with functions taking Void as an argument.
- Scope of Issue: People relying on being able to pass Void as an argument and compiling with -swift-version 4.
- Origination: A workaround for a regression found in the lead-up to releasing Swift 4.1 introduced a new regression.
- Risk: Very low. It only touches code that is hit in the case where the original workaround was implemented.
- Reviewed By: Doug Gregor
- Testing: Regression test suite including source compatibility suite.
