### PR TITLE
[Driver] Add -driver-filelist-threshold to set the number of inputs beyond which filelists are used

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -144,6 +144,10 @@ WARNING(warn_opt_remark_disabled, none,
 WARNING(warn_ignoring_batch_mode,none,
 "ignoring '-enable-batch-mode' because '%0' was also specified", (StringRef))
 
+WARNING(warn_use_filelists_deprecated, none,
+        "the option '-driver-use-filelists' is deprecated; use "
+        "'-driver-filelist-threshold=0' instead", ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -72,6 +72,10 @@ enum class PreserveOnSignal : bool {
 
 class Compilation {
   friend class PerformJobsState;
+public:
+  /// The filelist threshold value to pass to ensure file lists are never used
+  static const size_t NEVER_USE_FILELIST = SIZE_MAX;
+
 private:
   /// The DiagnosticEngine to which this Compilation should emit diagnostics.
   DiagnosticEngine &Diags;
@@ -204,6 +208,10 @@ private:
   /// -emit-loaded-module-trace, so no other job needs to do it.
   bool PassedEmitLoadedModuleTraceToFrontendJob = false;
 
+  /// The limit for the number of files to pass on the command line. Beyond this
+  /// limit filelists will be used.
+  size_t FilelistThreshold;
+
   template <typename T>
   static T *unwrap(const std::unique_ptr<T> &p) {
     return p.get();
@@ -224,6 +232,7 @@ public:
               bool OutputCompilationRecordForModuleOnlyBuild,
               StringRef ArgsHash, llvm::sys::TimePoint<> StartTime,
               llvm::sys::TimePoint<> LastBuildTime,
+              size_t FilelistThreshold,
               unsigned NumberOfParallelCommands = 1,
               bool EnableIncrementalBuild = false,
               bool EnableBatchMode = false,
@@ -306,6 +315,10 @@ public:
 
   void setShowJobLifecycle(bool value = true) {
     ShowJobLifecycle = value;
+  }
+
+  size_t getFilelistThreshold() const {
+    return FilelistThreshold;
   }
 
   /// Requests the path to a file containing all input source files. This can

--- a/include/swift/Driver/ToolChain.h
+++ b/include/swift/Driver/ToolChain.h
@@ -54,9 +54,6 @@ protected:
   private:
     Compilation &C;
 
-    /// The limit for passing a list of files on the command line.
-    static const size_t TOO_MANY_FILES = 128;
-
   public:
     ArrayRef<const Job *> Inputs;
     ArrayRef<const Action *> InputActions;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -102,6 +102,11 @@ def driver_show_job_lifecycle : Flag<["-"], "driver-show-job-lifecycle">,
   HelpText<"Show every step in the lifecycle of driver jobs">;
 def driver_use_filelists : Flag<["-"], "driver-use-filelists">,
   InternalDebugOpt, HelpText<"Pass input files as filelists whenever possible">;
+def driver_filelist_threshold : Separate<["-"], "driver-filelist-threshold">,
+  InternalDebugOpt, HelpText<"Pass input files as filelists if there are more than <n>">,
+  MetaVarName<"<n>">;
+def driver_filelist_threshold_EQ : Joined<["-"], "driver-filelist-threshold=">,
+  Alias<driver_filelist_threshold>;
 def driver_batch_seed : Separate<["-"], "driver-batch-seed">,
   InternalDebugOpt,
   HelpText<"Use the given seed value to randomize batch-mode partitions">;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -103,7 +103,7 @@ def driver_show_job_lifecycle : Flag<["-"], "driver-show-job-lifecycle">,
 def driver_use_filelists : Flag<["-"], "driver-use-filelists">,
   InternalDebugOpt, HelpText<"Pass input files as filelists whenever possible">;
 def driver_filelist_threshold : Separate<["-"], "driver-filelist-threshold">,
-  InternalDebugOpt, HelpText<"Pass input files as filelists if there are more than <n>">,
+  InternalDebugOpt, HelpText<"Pass input or output file names as filelists if there are more than <n>">,
   MetaVarName<"<n>">;
 def driver_filelist_threshold_EQ : Joined<["-"], "driver-filelist-threshold=">,
   Alias<driver_filelist_threshold>;

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -107,6 +107,7 @@ Compilation::Compilation(DiagnosticEngine &Diags,
                          StringRef ArgsHash,
                          llvm::sys::TimePoint<> StartTime,
                          llvm::sys::TimePoint<> LastBuildTime,
+                         size_t FilelistThreshold,
                          unsigned NumberOfParallelCommands,
                          bool EnableIncrementalBuild,
                          bool EnableBatchMode,
@@ -136,7 +137,8 @@ Compilation::Compilation(DiagnosticEngine &Diags,
     ForceOneBatchRepartition(ForceOneBatchRepartition),
     SaveTemps(SaveTemps),
     ShowDriverTimeCompilation(ShowDriverTimeCompilation),
-    Stats(std::move(StatsReporter)) {
+    Stats(std::move(StatsReporter)),
+    FilelistThreshold(FilelistThreshold) {
 };
 
 static bool writeFilelistIfNecessary(const Job *job, const ArgList &args,

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -545,6 +545,31 @@ static void validateEmbedBitcode(DerivedArgList &Args, OutputInfo &OI,
   }
 }
 
+/// Gets the filelist threshold to use. Diagnoses and returns true on error.
+static bool getFilelistThreshold(DerivedArgList &Args, size_t &FilelistThreshold,
+                                   DiagnosticEngine &Diags) {
+  FilelistThreshold = 128;
+
+  // claim and diagnose deprecated -driver-use-filelists
+  bool HasUseFilelists = Args.hasArg(options::OPT_driver_use_filelists);
+  if (HasUseFilelists)
+    Diags.diagnose(SourceLoc(), diag::warn_use_filelists_deprecated);
+
+  if (const Arg *A = Args.getLastArg(options::OPT_driver_filelist_threshold)) {
+    // Use the supplied threshold
+    if (StringRef(A->getValue()).getAsInteger(10, FilelistThreshold)) {
+      Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
+                     A->getAsString(Args), A->getValue());
+      return true;
+    }
+  } else if (HasUseFilelists) {
+    // Treat -driver-use-filelists as -driver-filelist-threshold=0
+    FilelistThreshold = 0;
+  } // else stick with the default
+
+  return false;
+}
+
 std::unique_ptr<Compilation>
 Driver::buildCompilation(const ToolChain &TC,
                          std::unique_ptr<llvm::opt::InputArgList> ArgList) {
@@ -708,6 +733,10 @@ Driver::buildCompilation(const ToolChain &TC,
     }
   }
 
+  size_t DriverFilelistThreshold;
+  if (getFilelistThreshold(*TranslatedArgList, DriverFilelistThreshold, Diags))
+    return nullptr;
+
   OutputLevel Level = OutputLevel::Normal;
   if (const Arg *A =
           ArgList->getLastArg(options::OPT_driver_print_jobs, options::OPT_v,
@@ -732,6 +761,7 @@ Driver::buildCompilation(const ToolChain &TC,
                       ArgsHash,
                       StartTime,
                       LastBuildTime,
+                      DriverFilelistThreshold,
                       NumberOfParallelCommands,
                       Incremental,
                       BatchMode,

--- a/lib/Driver/FrontendUtil.cpp
+++ b/lib/Driver/FrontendUtil.cpp
@@ -34,6 +34,12 @@ swift::driver::createCompilerInvocation(ArrayRef<const char *> Argv,
   // frontend command.
   Args.push_back("-force-single-frontend-invocation");
 
+  // Avoid using filelists
+  std::string neverThreshold =
+      std::to_string(Compilation::NEVER_USE_FILELIST);
+  Args.push_back("-driver-filelist-threshold");
+  Args.push_back(neverThreshold.c_str());
+
   // Force the driver into batch mode by specifying "swiftc" as the name.
   Driver TheDriver("swiftc", "swiftc", Args, Diags);
 

--- a/test/Driver/batch_mode_with_pch.swift
+++ b/test/Driver/batch_mode_with_pch.swift
@@ -2,4 +2,4 @@
 // RUN: echo 'print("Hello, World!")' >%t/main.swift
 // RUN: touch %t/bridgingHeader.h
 //
-// RUN: %swiftc_driver -driver-use-filelists -enable-batch-mode -num-threads 2 %t/main.swift -import-objc-header %t/bridgingHeader.h
+// RUN: %swiftc_driver -driver-filelist-threshold=0 -enable-batch-mode -num-threads 2 %t/main.swift -import-objc-header %t/bridgingHeader.h

--- a/test/Driver/batch_mode_with_supplementary_filelist.swift
+++ b/test/Driver/batch_mode_with_supplementary_filelist.swift
@@ -4,6 +4,6 @@
 //
 // Ensure that the supplementary output filelist argument is passed to the frontend:
 //
-// RUN: %swiftc_driver -enable-batch-mode -driver-use-filelists -j2 %t/main.swift %t/file-01.swift %t/file-02.swift %t/file-03.swift -o %t/file-01.o -o %t/file-02.o -o %t/file-03.o -### | %FileCheck %s -check-prefix=CHECK-SUPPLEMENTARY-OUTPUT-FILELIST
+// RUN: %swiftc_driver -enable-batch-mode -driver-filelist-threshold=0 -j2 %t/main.swift %t/file-01.swift %t/file-02.swift %t/file-03.swift -o %t/file-01.o -o %t/file-02.o -o %t/file-03.o -### | %FileCheck %s -check-prefix=CHECK-SUPPLEMENTARY-OUTPUT-FILELIST
 //
 // CHECK-SUPPLEMENTARY-OUTPUT-FILELIST: -supplementary-output-file-map {{.*}}/supplementaryOutputs-

--- a/test/Driver/batch_mode_with_supplementary_filelist_execution.swift
+++ b/test/Driver/batch_mode_with_supplementary_filelist_execution.swift
@@ -6,6 +6,6 @@
 // Ensure that the supplementary output filelist argument is passed to the frontend.
 // Also use some characters outside the BMP.
 //
-// RUN: %target-build-swift -emit-dependencies -serialize-diagnostics -driver-use-filelists -j2 %t/main.swift  %t/𝔼-file-01.swift %t/😂-file-02.swift %t/Ω-file-03.swift -o %t/a.out
+// RUN: %target-build-swift -emit-dependencies -serialize-diagnostics -driver-filelist-threshold=0 -j2 %t/main.swift  %t/𝔼-file-01.swift %t/😂-file-02.swift %t/Ω-file-03.swift -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-HELLO-WORLD
 // CHECK-HELLO-WORLD: Hello, World!

--- a/test/Driver/batch_mode_with_supplementary_filelist_unicode.swift
+++ b/test/Driver/batch_mode_with_supplementary_filelist_unicode.swift
@@ -5,5 +5,5 @@
 // If the supplementary output file map does not escape the characters in the
 // source files, the frontend won't recognize the desired outputs.
 //
-// RUN: (cd %t && %target-build-swift -c -emit-dependencies -serialize-diagnostics -driver-use-filelists -j2 main.swift  𝔼-file-01.swift 😂-file-02.swift Ω-file-03.swift -module-name mod)
+// RUN: (cd %t && %target-build-swift -c -emit-dependencies -serialize-diagnostics -driver-filelist-threshold=0 -j2 main.swift  𝔼-file-01.swift 😂-file-02.swift Ω-file-03.swift -module-name mod)
 // RUN: (cd %t && test -e 😂-file-02.d -a -e 😂-file-02.dia -a -e 😂-file-02.o -a -e 😂-file-02.swift -a -e 𝔼-file-01.d -a -e 𝔼-file-01.dia -a -e 𝔼-file-01.o -a -e 𝔼-file-01.swift -a -e main.d -a -e main.dia -a -e Ω-file-03.d -a -e Ω-file-03.dia -a -e Ω-file-03.o -a -e Ω-file-03.swift)

--- a/test/Driver/driver-compile.swift
+++ b/test/Driver/driver-compile.swift
@@ -35,7 +35,7 @@
 // RUN: cp %s %t
 // RUN: not %swiftc_driver -driver-print-jobs -c -target x86_64-apple-macosx10.9 %s %t/driver-compile.swift 2>&1 | %FileCheck -check-prefix DUPLICATE-NAME %s
 
-// RUN: %swiftc_driver -driver-print-jobs -c -target x86_64-apple-macosx10.9 %s %S/../Inputs/empty.swift -module-name main -driver-use-filelists 2>&1 | %FileCheck -check-prefix=FILELIST %s
+// RUN: %swiftc_driver -driver-print-jobs -c -target x86_64-apple-macosx10.9 %s %S/../Inputs/empty.swift -module-name main -driver-filelist-threshold=0 2>&1 | %FileCheck -check-prefix=FILELIST %s
 
 // RUN: %empty-directory(%t)/DISTINCTIVE-PATH/usr/bin/
 // RUN: %hardlink-or-copy(from: %swift_driver_plain, to: %t/DISTINCTIVE-PATH/usr/bin/swiftc)

--- a/test/Driver/filelist-threshold.swift
+++ b/test/Driver/filelist-threshold.swift
@@ -9,7 +9,7 @@
 // UNDERTHRESHOLD-NOT: -output-filelist
 
 
-// RUN: %swiftc_driver -driver-print-jobs -c -target x86_64-apple-macosx10.9 %t/a.swift %t/b.swift %S/../Inputs/empty.swift -module-name main -driver-filelist-threshold=0 | %FileCheck -check-prefix=OVERTHRESHOLD --input-file %t/out.txt %s
+// RUN: %swiftc_driver -driver-print-jobs -c -target x86_64-apple-macosx10.9 %t/a.swift %t/b.swift %S/../Inputs/empty.swift -module-name main -driver-filelist-threshold=0 | %FileCheck -check-prefix=OVERTHRESHOLD %s
 // RUN: %swiftc_driver -driver-print-jobs -c -target x86_64-apple-macosx10.9 %t/a.swift %t/b.swift %S/../Inputs/empty.swift -module-name main -driver-use-filelists > %t/out.txt 2>&1
 // RUN: %FileCheck -check-prefixes=OVERTHRESHOLD,DEPRECATED --input-file %t/out.txt %s
 
@@ -28,7 +28,7 @@
 // OVERTHRESHOLD: -output-filelist
 
 
-// RUN: %swiftc_driver -driver-print-jobs -c -target x86_64-apple-macosx10.9 %t/a.swift %t/b.swift %S/../Inputs/empty.swift -module-name main -driver-filelist-threshold=1 | %FileCheck -check-prefix=MIXEDTHRESHOLD --input-file %t/out.txt %s
+// RUN: %swiftc_driver -driver-print-jobs -c -target x86_64-apple-macosx10.9 %t/a.swift %t/b.swift %S/../Inputs/empty.swift -module-name main -driver-filelist-threshold=1 | %FileCheck -check-prefix=MIXEDTHRESHOLD %s
 
 // MIXEDTHRESHOLD: -filelist
 // MIXEDTHRESHOLD-NOT: -primary-filelist

--- a/test/Driver/filelist-threshold.swift
+++ b/test/Driver/filelist-threshold.swift
@@ -1,0 +1,44 @@
+// RUN: %empty-directory(%t)
+// RUN: touch %t/a.swift %t/b.swift
+
+// RUN: %swiftc_driver -driver-print-jobs -c -target x86_64-apple-macosx10.9 %t/a.swift %t/b.swift %S/../Inputs/empty.swift -module-name main -driver-filelist-threshold=99 2>&1 | %FileCheck -check-prefix=UNDERTHRESHOLD %s
+
+// UNDERTHRESHOLD-NOT: -filelist
+// UNDERTHRESHOLD-NOT: -primary-filelist
+// UNDERTHRESHOLD-NOT: -supplementary-output-file-map
+// UNDERTHRESHOLD-NOT: -output-filelist
+
+
+// RUN: %swiftc_driver -driver-print-jobs -c -target x86_64-apple-macosx10.9 %t/a.swift %t/b.swift %S/../Inputs/empty.swift -module-name main -driver-filelist-threshold=0 | %FileCheck -check-prefix=OVERTHRESHOLD --input-file %t/out.txt %s
+// RUN: %swiftc_driver -driver-print-jobs -c -target x86_64-apple-macosx10.9 %t/a.swift %t/b.swift %S/../Inputs/empty.swift -module-name main -driver-use-filelists > %t/out.txt 2>&1
+// RUN: %FileCheck -check-prefixes=OVERTHRESHOLD,DEPRECATED --input-file %t/out.txt %s
+
+// DEPRECATED: warning: the option '-driver-use-filelists' is deprecated; use '-driver-filelist-threshold=0' instead
+// OVERTHRESHOLD: -filelist
+// OVERTHRESHOLD: -primary-filelist
+// OVERTHRESHOLD: -supplementary-output-file-map
+// OVERTHRESHOLD: -output-filelist
+// OVERTHRESHOLD: -filelist
+// OVERTHRESHOLD: -primary-filelist
+// OVERTHRESHOLD: -supplementary-output-file-map
+// OVERTHRESHOLD: -output-filelist
+// OVERTHRESHOLD: -filelist
+// OVERTHRESHOLD: -primary-filelist
+// OVERTHRESHOLD: -supplementary-output-file-map
+// OVERTHRESHOLD: -output-filelist
+
+
+// RUN: %swiftc_driver -driver-print-jobs -c -target x86_64-apple-macosx10.9 %t/a.swift %t/b.swift %S/../Inputs/empty.swift -module-name main -driver-filelist-threshold=1 | %FileCheck -check-prefix=MIXEDTHRESHOLD --input-file %t/out.txt %s
+
+// MIXEDTHRESHOLD: -filelist
+// MIXEDTHRESHOLD-NOT: -primary-filelist
+// MIXEDTHRESHOLD: -supplementary-output-file-map
+// MIXEDTHRESHOLD-NOT: -output-filelist
+// MIXEDTHRESHOLD: -filelist
+// MIXEDTHRESHOLD-NOT: -primary-filelist
+// MIXEDTHRESHOLD: -supplementary-output-file-map
+// MIXEDTHRESHOLD-NOT: -output-filelist
+// MIXEDTHRESHOLD: -filelist
+// MIXEDTHRESHOLD-NOT: -primary-filelist
+// MIXEDTHRESHOLD: -supplementary-output-file-map
+// MIXEDTHRESHOLD-NOT: -output-filelist

--- a/test/Driver/filelists.swift
+++ b/test/Driver/filelists.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: touch %t/a.swift %t/b.swift %t/c.swift
 
-// RUN: (cd %t && %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -emit-module ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-use-filelists -output-file-map=%S/Inputs/filelists/output.json 2>&1 | %FileCheck %s)
+// RUN: (cd %t && %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -emit-module ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -output-file-map=%S/Inputs/filelists/output.json 2>&1 | %FileCheck %s)
 
 // CHECK-NOT: Handled
 // CHECK: Handled a.swift
@@ -21,7 +21,7 @@
 
 
 
-// RUN: %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -c %t/a.swift %t/b.swift %t/c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-use-filelists -force-single-frontend-invocation 2>&1 | %FileCheck -check-prefix=CHECK-WMO %s
+// RUN: %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -c %t/a.swift %t/b.swift %t/c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -force-single-frontend-invocation 2>&1 | %FileCheck -check-prefix=CHECK-WMO %s
 
 // CHECK-WMO-NOT: Handled
 // CHECK-WMO: Handled all
@@ -34,10 +34,10 @@
 // RUN: %empty-directory(%t/bin)
 // RUN: ln -s %S/Inputs/filelists/fake-ld.py %t/bin/ld
 
-// RUN: (cd %t && %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-use-filelists -output-file-map=%S/Inputs/filelists/output.json -force-single-frontend-invocation -num-threads 1 2>&1 | %FileCheck -check-prefix=CHECK-WMO-THREADED %s)
-// RUN: (cd %t && %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-use-filelists -output-file-map=%S/Inputs/filelists/output.json -force-single-frontend-invocation -num-threads 1 -embed-bitcode 2>&1 | %FileCheck -check-prefix=CHECK-WMO-THREADED %s)
+// RUN: (cd %t && %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -output-file-map=%S/Inputs/filelists/output.json -force-single-frontend-invocation -num-threads 1 2>&1 | %FileCheck -check-prefix=CHECK-WMO-THREADED %s)
+// RUN: (cd %t && %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -output-file-map=%S/Inputs/filelists/output.json -force-single-frontend-invocation -num-threads 1 -embed-bitcode 2>&1 | %FileCheck -check-prefix=CHECK-WMO-THREADED %s)
 // RUN: %empty-directory(%t/tmp)
-// RUN: (cd %t && env TMPDIR="%t/tmp/" %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-use-filelists -output-file-map=%S/Inputs/filelists/output.json -force-single-frontend-invocation -num-threads 1 -save-temps 2>&1 | %FileCheck -check-prefix=CHECK-WMO-THREADED %s)
+// RUN: (cd %t && env TMPDIR="%t/tmp/" %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -output-file-map=%S/Inputs/filelists/output.json -force-single-frontend-invocation -num-threads 1 -save-temps 2>&1 | %FileCheck -check-prefix=CHECK-WMO-THREADED %s)
 // RUN: ls %t/tmp/sources-* %t/tmp/outputs-*
 
 // CHECK-WMO-THREADED-NOT: Handled
@@ -52,17 +52,17 @@
 // CHECK-WMO-THREADED-NOT: Handled
 
 // RUN: mkdir -p %t/tmp-fail/
-// RUN: (cd %t && not env TMPDIR="%t/tmp-fail/" %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/fail.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-use-filelists -output-file-map=%S/Inputs/filelists/output.json -force-single-frontend-invocation -num-threads 1)
+// RUN: (cd %t && not env TMPDIR="%t/tmp-fail/" %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/fail.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -output-file-map=%S/Inputs/filelists/output.json -force-single-frontend-invocation -num-threads 1)
 // RUN: not ls %t/tmp-fail/sources-*
 // RUN: not ls %t/tmp-fail/outputs-*
 
 // RUN: mkdir -p %t/tmp-crash/
-// RUN: (cd %t && not env TMPDIR="%t/tmp-crash/" %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/crash.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-use-filelists -output-file-map=%S/Inputs/filelists/output.json -force-single-frontend-invocation -num-threads 1)
+// RUN: (cd %t && not env TMPDIR="%t/tmp-crash/" %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/crash.py -c ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -output-file-map=%S/Inputs/filelists/output.json -force-single-frontend-invocation -num-threads 1)
 // RUN: ls %t/tmp-crash/sources-* %t/tmp-crash/outputs-*
 
 
-// RUN: (cd %t && env PATH="%t/bin/:$PATH" %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -emit-library ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-use-filelists -output-file-map=%S/Inputs/filelists/output.json 2>&1 | %FileCheck -check-prefix=CHECK-LINK %s)
-// RUN: (cd %t && env PATH="%t/bin/:$PATH" %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -emit-library ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-use-filelists -output-file-map=%S/Inputs/filelists/output.json -force-single-frontend-invocation -num-threads 1 2>&1 | %FileCheck -check-prefix=CHECK-LINK %s)
+// RUN: (cd %t && env PATH="%t/bin/:$PATH" %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -emit-library ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -output-file-map=%S/Inputs/filelists/output.json 2>&1 | %FileCheck -check-prefix=CHECK-LINK %s)
+// RUN: (cd %t && env PATH="%t/bin/:$PATH" %swiftc_driver_plain -driver-use-frontend-path %S/Inputs/filelists/check-filelist-abc.py -emit-library ./a.swift ./b.swift ./c.swift -module-name main -target x86_64-apple-macosx10.9 -driver-filelist-threshold=0 -output-file-map=%S/Inputs/filelists/output.json -force-single-frontend-invocation -num-threads 1 2>&1 | %FileCheck -check-prefix=CHECK-LINK %s)
 
 // CHECK-LINK: Handled link
 

--- a/test/Driver/linker.swift
+++ b/test/Driver/linker.swift
@@ -56,7 +56,7 @@
 // RUN: %empty-directory(%t)
 // RUN: touch %t/a.o
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s %t/a.o -o linker 2>&1 | %FileCheck -check-prefix COMPILE_AND_LINK %s
-// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s %t/a.o -driver-use-filelists -o linker 2>&1 | %FileCheck -check-prefix FILELIST %s
+// RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 %s %t/a.o -driver-filelist-threshold=0 -o linker 2>&1 | %FileCheck -check-prefix FILELIST %s
 
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-apple-macosx10.9 -emit-library %s -module-name LINKER | %FileCheck -check-prefix INFERRED_NAME_DARWIN %s
 // RUN: %swiftc_driver -driver-print-jobs -target x86_64-unknown-linux-gnu -emit-library %s -module-name LINKER | %FileCheck -check-prefix INFERRED_NAME_LINUX %s

--- a/test/Driver/merge-module.swift
+++ b/test/Driver/merge-module.swift
@@ -14,7 +14,7 @@
 // RUN: %FileCheck %s < %t.complex.txt
 // RUN: %FileCheck -check-prefix THREE-OUTPUTS %s < %t.complex.txt
 
-// RUN: %swiftc_driver -emit-module -driver-print-jobs -driver-use-filelists %s %S/../Inputs/empty.swift -module-name main 2>&1 | %FileCheck -check-prefix FILELISTS %s
+// RUN: %swiftc_driver -emit-module -driver-print-jobs -driver-filelist-threshold=0 %s %S/../Inputs/empty.swift -module-name main 2>&1 | %FileCheck -check-prefix FILELISTS %s
 
 // CHECK: bin/swift{{c?}} -frontend
 // CHECK: -module-name {{[^ ]+}}

--- a/test/SourceKit/Misc/handle-filelists.swift
+++ b/test/SourceKit/Misc/handle-filelists.swift
@@ -1,0 +1,5 @@
+let x = 10
+x.
+
+// RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -driver-filelist-threshold=0 %s | %FileCheck %s -check-prefix=COMPLETE
+// COMPLETE: littleEndian


### PR DESCRIPTION
When generating a compiler invocation in `driver::createCompilerInvocation()` we end up using filelists if the number of inputs is > 128 (to work around command line arg limits). We never actually write them out though, and so fail when parsing the frontend arguments that reference them.

As this function is called frequently by SourceKit and command line limits aren't a concern here, this patch makes the 128 threshold value configurable via a new `-driver-filelist-threshold` option. This is set to its maximum value in `driver::createCompilerInvocation()` to ensure filelists aren't used. 

This new option makes the existing `-driver-use-filelists` flag (that forces filelists to be used) redundant as it's now equivalent to `-driver-filelist-threshold=0`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves rdar://problem/38231888

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->