### PR TITLE
platform: enhance the VisualC modulemap

### DIFF
--- a/stdlib/public/Platform/visualc.modulemap
+++ b/stdlib/public/Platform/visualc.modulemap
@@ -15,5 +15,15 @@ module visualc [system] {
     header "sal.h"
     export *
   }
+
+  module vadefs {
+    header "vadefs.h"
+    export *
+  }
+
+  module stdint {
+    header "stdint.h"
+    export *
+  }
 }
 


### PR DESCRIPTION
Add the `vadefs` and `stdint` submodules.  These are required to get the
importing of the standard types (`intmax_t` and `uintptr_t`) correct
with the Visual C runtime.  This allows building the libdispatch Swift
overlay.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
