### PR TITLE
runtime: avoid UB on Windows x86_64 builds

### DIFF
--- a/stdlib/public/runtime/SwiftDtoa.cpp
+++ b/stdlib/public/runtime/SwiftDtoa.cpp
@@ -1090,7 +1090,7 @@ size_t swift_format_double(double d, char *dest, size_t length)
             uint64_t raw = bitPatternForDouble(d);
             const char *sign = signbit(d) ? "-" : "";
             const char *signaling = ((raw >> (significandBitCount - 1)) & 1) ? "" : "s";
-            uint64_t payload = raw & ((1L << (significandBitCount - 2)) - 1);
+            uint64_t payload = raw & ((1ull << (significandBitCount - 2)) - 1);
             char buff[32];
             if (payload != 0) {
                 snprintf(buff, sizeof(buff), "%s%snan(0x%llx)",


### PR DESCRIPTION
Use the `ull` extension rather than `l` for LLP64 environment support.
Fixes UB on the Windows x86_64 port.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
