### PR TITLE
[4.2][SR-7342] Teach EmitImportedModules action to evaluate conditional compilation blocks

### DIFF
--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -884,7 +884,8 @@ static bool performCompile(CompilerInstance &Instance,
     return compileLLVMIR(Invocation, Instance, Stats);
 
   if (FrontendOptions::shouldActionOnlyParse(Action))
-    Instance.performParseOnly();
+    Instance.performParseOnly(/*EvaluateConditionals*/
+                    Action == FrontendOptions::ActionType::EmitImportedModules);
   else
     Instance.performSema();
 

--- a/test/Driver/Inputs/imported_modules/imported_modules.importedmodules
+++ b/test/Driver/Inputs/imported_modules/imported_modules.importedmodules
@@ -3,5 +3,6 @@ X
 Y
 Foo
 InvalidOverlay
+Swift
 Z
 Bar

--- a/test/Driver/imported_modules.swift
+++ b/test/Driver/imported_modules.swift
@@ -7,3 +7,13 @@ import Y
 import enum Foo.Member
 // The overlaying Swift module should not be loaded.
 import InvalidOverlay
+
+#if canImport(Swift) // To wit, true
+import Swift
+#else
+import Garbage
+#endif
+
+#if !canImport(Swift) // To wit, false
+import Garbage
+#endif


### PR DESCRIPTION
From #15739.

Resolves SR-7342.