### PR TITLE
[BatchMode] Consolidate reasoning about -{enable,disable}-batch-mode flag.

### DIFF
--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -389,8 +389,11 @@ private:
   /// there is an actual conflict.
   /// \param Args The input arguments.
   /// \param Inputs The inputs to the driver.
+  /// \param BatchModeOut An out-parameter flag that indicates whether to
+  /// batch the jobs of the resulting \c Mode::StandardCompile compilation.
   OutputInfo::Mode computeCompilerMode(const llvm::opt::DerivedArgList &Args,
-                                       const InputFileList &Inputs) const;
+                                       const InputFileList &Inputs,
+                                       bool &BatchModeOut) const;
 };
 
 } // end namespace driver

--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -64,7 +64,17 @@ public:
     /// A compilation using a single frontend invocation without -primary-file.
     SingleCompile,
 
-    /// A single process that batches together multiple StandardCompile jobs.
+    /// A single process that batches together multiple StandardCompile Jobs.
+    ///
+    /// Note: this is a transient value to use _only_ for the individual
+    /// BatchJobs that are the temporary containers for multiple StandardCompile
+    /// Jobs built by ToolChain::constructBatchJob.
+    ///
+    /// In particular, the driver treats a batch-mode-enabled Compilation as
+    /// having OutputInfo::CompilerMode == StandardCompile, with the
+    /// Compilation::BatchModeEnabled flag set to true, _not_ as a
+    /// BatchModeCompile Compilation. The top-level OutputInfo::CompilerMode for
+    /// a Compilation should never be BatchModeCompile.
     BatchModeCompile,
 
     /// Invoke the REPL

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1403,19 +1403,18 @@ Driver::computeCompilerMode(const DerivedArgList &Args,
                               options::OPT_disable_batch_mode,
                               false);
 
-  if (ArgRequiringSingleCompile) {
-    // Override batch mode if given -wmo or -index-file.
-    if (BatchModeOut) {
-      BatchModeOut = false;
-      // Emit a warning about such overriding (FIXME: we might conditionalize
-      // this based on the user or xcode passing -disable-batch-mode).
-      Diags.diagnose(SourceLoc(), diag::warn_ignoring_batch_mode,
-                     ArgRequiringSingleCompile->getOption().getPrefixedName());
-    }
-    return OutputInfo::Mode::SingleCompile;
-  }
+  if (!ArgRequiringSingleCompile)
+    return OutputInfo::Mode::StandardCompile;
 
-  return OutputInfo::Mode::StandardCompile;
+  // Override batch mode if given -wmo or -index-file.
+  if (BatchModeOut) {
+    BatchModeOut = false;
+    // Emit a warning about such overriding (FIXME: we might conditionalize
+    // this based on the user or xcode passing -disable-batch-mode).
+    Diags.diagnose(SourceLoc(), diag::warn_ignoring_batch_mode,
+                   ArgRequiringSingleCompile->getOption().getPrefixedName());
+  }
+  return OutputInfo::Mode::SingleCompile;
 }
 
 void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -594,10 +594,6 @@ Driver::buildCompilation(const ToolChain &TC,
     Incremental = false;
   }
 
-  bool BatchMode = ArgList->hasFlag(options::OPT_enable_batch_mode,
-                                    options::OPT_disable_batch_mode,
-                                    false);
-
   bool SaveTemps = ArgList->hasArg(options::OPT_save_temps);
   bool ContinueBuildingAfterErrors =
     ArgList->hasArg(options::OPT_continue_building_after_errors);
@@ -631,6 +627,8 @@ Driver::buildCompilation(const ToolChain &TC,
 
   // Determine the OutputInfo for the driver.
   OutputInfo OI;
+  bool BatchMode = false;
+  OI.CompilerMode = computeCompilerMode(*TranslatedArgList, Inputs, BatchMode);
   buildOutputInfo(TC, *TranslatedArgList, BatchMode, Inputs, OI);
 
   if (Diags.hadAnyError())
@@ -1122,8 +1120,6 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
                               ? file_types::TY_Nothing
                               : file_types::TY_Object;
 
-  OI.CompilerMode = computeCompilerMode(Args, Inputs);
-
   if (const Arg *A = Args.getLastArg(options::OPT_num_threads)) {
     if (BatchMode) {
       Diags.diagnose(SourceLoc(), diag::warning_cannot_multithread_batch_mode);
@@ -1393,27 +1389,33 @@ void Driver::buildOutputInfo(const ToolChain &TC, const DerivedArgList &Args,
 
 OutputInfo::Mode
 Driver::computeCompilerMode(const DerivedArgList &Args,
-                            const InputFileList &Inputs) const {
+                            const InputFileList &Inputs,
+                            bool &BatchModeOut) const {
 
   if (driverKind == Driver::DriverKind::Interactive)
     return Inputs.empty() ? OutputInfo::Mode::REPL
                           : OutputInfo::Mode::Immediate;
 
-  const Arg *ArgRequiringWMO = Args.getLastArg(
+  const Arg *ArgRequiringSingleCompile = Args.getLastArg(
       options::OPT_whole_module_optimization, options::OPT_index_file);
 
-  if (!ArgRequiringWMO)
-    return OutputInfo::Mode::StandardCompile;
+  BatchModeOut = Args.hasFlag(options::OPT_enable_batch_mode,
+                              options::OPT_disable_batch_mode,
+                              false);
 
-  // Test for -enable-batch-mode, rather than the BatchMode flag that is
-  // passed into the caller because the diagnostic is intended to warn against
-  // overriding *explicit* batch mode. No warning should be given if in batch
-  // mode by default.
-  if (Args.hasArg(options::OPT_enable_batch_mode))
-    Diags.diagnose(SourceLoc(), diag::warn_ignoring_batch_mode,
-                   ArgRequiringWMO->getOption().getPrefixedName());
+  if (ArgRequiringSingleCompile) {
+    // Override batch mode if given -wmo or -index-file.
+    if (BatchModeOut) {
+      BatchModeOut = false;
+      // Emit a warning about such overriding (FIXME: we might conditionalize
+      // this based on the user or xcode passing -disable-batch-mode).
+      Diags.diagnose(SourceLoc(), diag::warn_ignoring_batch_mode,
+                     ArgRequiringSingleCompile->getOption().getPrefixedName());
+    }
+    return OutputInfo::Mode::SingleCompile;
+  }
 
-  return OutputInfo::Mode::SingleCompile;
+  return OutputInfo::Mode::StandardCompile;
 }
 
 void Driver::buildActions(SmallVectorImpl<const Action *> &TopLevelActions,

--- a/test/Driver/batch_mode_with_WMO_or_index.swift
+++ b/test/Driver/batch_mode_with_WMO_or_index.swift
@@ -12,3 +12,15 @@
 // RUN: %FileCheck -check-prefix CHECK-INDEX %s <%t/stderr_index_batch
 // RUN: %FileCheck -check-prefix CHECK-INDEX %s <%t/stderr_batch_index
 // CHECK-INDEX: warning: ignoring '-enable-batch-mode' because '-index-file' was also specified
+//
+// This next one is a regression test for a specific failure in the past: wmo +
+// batch mode should not just result in wmo, but also preserve the num-threads
+// argument and (crucially) the resulting fact that the single wmo subprocess
+// generates multiple output files. The build system that invokes swiftc expects
+// multiple outputs.
+//
+// RUN: touch %t/a.swift %t/b.swift %t/c.swift
+// RUN: %swiftc_driver %t/a.swift %t/b.swift %t/c.swift -num-threads 4 -whole-module-optimization -enable-batch-mode -### >%t/stdout_mt_wmo 2>%t/stderr_mt_wmo
+// RUN: %FileCheck --check-prefix CHECK-WMO %s <%t/stderr_mt_wmo
+// RUN: %FileCheck --check-prefix CHECK-MULTITHREADED-WMO-ARGS %s <%t/stdout_mt_wmo
+// CHECK-MULTITHREADED-WMO-ARGS: -num-threads 4 {{.*}}-o {{.*}}/a-{{[a-z0-9]+}}.o -o {{.*}}/b-{{[a-z0-9]+}}.o -o {{.*}}/c-{{[a-z0-9]+}}.o


### PR DESCRIPTION
Previous to this change, the initial inspection of the -{enable,disable}-batch-mode flag was made separate from the subsequent overriding by -wmo; this in turn meant that the driver might decide it's "in batch mode" in one place (in particular, when judging whether to ignore the -num-threads flag) and "in wmo mode" elsewhere (when judging whether to emit one or multiple outputs, which depends on the -num-threads flag).
    
Divergence between these two views caused the driver to effectively drop the -num-threads flag even when overriding batch mode with wmo; since xcode assumes that passing -wmo -num-threads _will_ cause multiple outputs, this in turn caused linking to fail since the expected output files were not found.

rdar://39191323