### PR TITLE
[func-sig-opts] Extract out creation of function names/types onto the…

### DIFF
--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -87,7 +87,7 @@ static SILInstruction *findOnlyApply(SILFunction *F) {
 }
 
 //===----------------------------------------------------------------------===//
-//                        Function Signature Transform
+//                  Function Signature Transform Descriptor
 //===----------------------------------------------------------------------===//
 
 namespace {
@@ -107,158 +107,39 @@ struct FunctionSignatureTransformDescriptor {
   /// TODO: Rename to willModifySelfArgument.
   bool shouldModifySelfArgument;
 
-  /// Keep a "view" of precompiled information on arguments that we use 
+  /// Keep a "view" of precompiled information on arguments that we use
   /// during our optimization.
   MutableArrayRef<ArgumentDescriptor> ArgumentDescList;
 
   /// Keep a "view" of precompiled information on the direct results that we
   /// will use during our optimization.
   MutableArrayRef<ResultDescriptor> ResultDescList;
-};
 
-} // end anonymous namespace
-
-namespace {
-
-class FunctionSignatureTransform {
-  /// A struct that contains all data that we use during our
-  /// transformation. This is an initial step towards splitting this struct into
-  /// multiple "transforms" that can be tested independently of each other.
-  FunctionSignatureTransformDescriptor TransformDescriptor;
-
-  /// The RC identity analysis we are using.
-  RCIdentityAnalysis *RCIA;
-
-  /// Post order analysis we are using.
-  EpilogueARCAnalysis *EA;
-
-  // The function signature mangler we are using.
-  Mangle::FunctionSignatureSpecializationMangler &Mangler;
-
-  /// Return a function name based on ArgumentDescList and ResultDescList.
+  /// Return a function name based on the current state of ArgumentDescList and
+  /// ResultDescList.
+  ///
+  /// FIXME: Change this to take a SmallString as an out parameter?
   std::string createOptimizedSILFunctionName();
 
-  /// Return a function type based on ArgumentDescList and ResultDescList.
+  /// Return a function type based on the current state of ArgumentDescList and
+  /// ResultDescList.
   CanSILFunctionType createOptimizedSILFunctionType();
 
-private:
-  /// ----------------------------------------------------------///
-  /// Dead argument transformation.                             ///
-  /// ----------------------------------------------------------///
-  /// Find any dead argument opportunities.
-  bool DeadArgumentAnalyzeParameters();
-  /// Modify the current function so that later function signature analysis
-  /// are more effective.
-  void DeadArgumentTransformFunction();
-  /// Remove the dead argument once the new function is created.
-  void DeadArgumentFinalizeOptimizedFunction();
-
-  /// ----------------------------------------------------------///
-  /// Owned to guaranteed transformation.                       ///
-  /// ----------------------------------------------------------///
-  bool OwnedToGuaranteedAnalyzeResults();
-  bool OwnedToGuaranteedAnalyzeParameters();
-
-  /// Modify the current function so that later function signature analysis
-  /// are more effective.
-  void OwnedToGuaranteedTransformFunctionResults();
-  void OwnedToGuaranteedTransformFunctionParameters();
-
-  /// Find any owned to guaranteed opportunities.
-  bool OwnedToGuaranteedAnalyze();
-
-  /// Do the actual owned to guaranteed transformations.
-  void OwnedToGuaranteedTransform();
-
-  /// Set up epilogue work for the thunk result based in the given argument.
-  void OwnedToGuaranteedAddResultRelease(ResultDescriptor &RD,
-                                         SILBuilder &Builder,
-                                         SILFunction *F);
-
-  /// Set up epilogue work for the thunk argument based in the given argument.
-  void OwnedToGuaranteedAddArgumentRelease(ArgumentDescriptor &AD,
-                                           SILBuilder &Builder,
-                                           SILFunction *F); 
-
-  /// Add the release for converted arguments and result.
-  void OwnedToGuaranteedFinalizeThunkFunction(SILBuilder &B, SILFunction *F);
-
-  /// ----------------------------------------------------------///
-  /// Argument explosion transformation.                        ///
-  /// ----------------------------------------------------------///
-  /// Find any argument explosion opportunities.
-  bool ArgumentExplosionAnalyzeParameters();
-  /// Explode the argument in the optimized function and replace the uses of
-  /// the original argument.
-  void ArgumentExplosionFinalizeOptimizedFunction();
-
-  /// Setup the thunk arguments based on the given argument descriptor info.
-  /// Every transformation must defines this interface. Default implementation
-  /// simply passes it through.
-  void addThunkArgument(ArgumentDescriptor &AD, SILBuilder &Builder,
-                        SILBasicBlock *BB,
-                        llvm::SmallVectorImpl<SILValue> &NewArgs);
-
-  /// Take ArgumentDescList and ResultDescList and create an optimized function
-  /// based on the current function we are analyzing. This also has the side effect
-  /// of turning the current function into a thunk.
-  void createFunctionSignatureOptimizedFunction();
-
-  /// Compute the optimized function type based on the given argument descriptor.
-  void computeOptimizedArgInterface(ArgumentDescriptor &A, SILParameterInfoList &O);
-
-public:
-  /// Constructor.
-  FunctionSignatureTransform(
-      SILFunction *F, RCIdentityAnalysis *RCIA, EpilogueARCAnalysis *EA,
-      Mangle::FunctionSignatureSpecializationMangler &Mangler,
-      ArgumentIndexMap &AIM, llvm::SmallVector<ArgumentDescriptor, 4> &ADL,
-      llvm::SmallVector<ResultDescriptor, 4> &RDL)
-      : TransformDescriptor{F, nullptr, AIM, false, ADL, RDL}, RCIA(RCIA),
-        EA(EA), Mangler(Mangler) {}
-
-  /// Return the optimized function.
-  SILFunction *getOptimizedFunction() {
-    return TransformDescriptor.OptimizedFunction.getPtrOrNull();
-  }
-
-  /// Run the optimization.
-  bool run(bool hasCaller);
-
-  /// Run dead argument elimination of partially applied functions.
-  ///
-  /// After this optimization CapturePropagation can replace the partial_apply
-  /// by a direct reference to the specialized function.
-  bool removeDeadArgs(int minPartialAppliedArgs);
+  /// Compute the optimized function type based on the given argument
+  /// descriptor.
+  void computeOptimizedArgInterface(ArgumentDescriptor &A,
+                                    SILParameterInfoList &O);
 };
-
-void FunctionSignatureTransform::addThunkArgument(
-    ArgumentDescriptor &AD, SILBuilder &Builder, SILBasicBlock *BB,
-    llvm::SmallVectorImpl<SILValue> &NewArgs) {
-  // Dead argument.
-  if (AD.IsEntirelyDead) {
-    return;
-  }
-
-  // Explode the argument.
-  if (AD.Explode) {
-    llvm::SmallVector<SILValue, 4> LeafValues;
-    AD.ProjTree.createTreeFromValue(Builder, BB->getParent()->getLocation(),
-                                    BB->getArgument(AD.Index), LeafValues);
-    NewArgs.append(LeafValues.begin(), LeafValues.end());
-    return;
-  }
-
-  // All other arguments get pushed as what they are.
-  NewArgs.push_back(BB->getArgument(AD.Index));
-}
 
 } // end anonymous namespace
 
-std::string FunctionSignatureTransform::createOptimizedSILFunctionName() {
-  SILFunction *F = TransformDescriptor.OriginalFunction;
-  auto ArgumentDescList = TransformDescriptor.ArgumentDescList;
-  auto ResultDescList = TransformDescriptor.ResultDescList;
+std::string
+FunctionSignatureTransformDescriptor::createOptimizedSILFunctionName() {
+  SILFunction *F = OriginalFunction;
+
+  auto P = Demangle::SpecializationPass::FunctionSignatureOpts;
+  Mangle::FunctionSignatureSpecializationMangler Mangler(P, F->isSerialized(),
+                                                         F);
 
   // Handle arguments' changes.
   for (unsigned i : indices(ArgumentDescList)) {
@@ -267,7 +148,7 @@ std::string FunctionSignatureTransform::createOptimizedSILFunctionName() {
       Mangler.setArgumentDead(i);
       // No point setting other attribute if argument is dead.
       continue;
-    }   
+    }
 
     // If we have an @owned argument and found a callee release for it,
     // convert the argument to guaranteed.
@@ -295,84 +176,8 @@ std::string FunctionSignatureTransform::createOptimizedSILFunctionName() {
     MangledName = Mangler.mangle(UniqueID);
     ++UniqueID;
   } while (M.hasFunction(MangledName));
-  
+
   return MangledName;
-}
-
-/// Compute what the function interface will look like based on the
-/// optimization we are doing on the given argument descriptor. Default
-/// implementation simply passes it through.
-void
-FunctionSignatureTransform::
-computeOptimizedArgInterface(ArgumentDescriptor &AD, SILParameterInfoList &Out) {
-  // If this argument is live, but we cannot optimize it.
-  if (!AD.canOptimizeLiveArg()) {
-    if (AD.PInfo.hasValue())
-      Out.push_back(AD.PInfo.getValue());
-    return;
-  }
-
-  // If we have a dead argument, bail.
-  if (AD.IsEntirelyDead) {
-    ++NumDeadArgsEliminated;
-    return;
-  }
-
-  // Explode the argument or not ?
-  if (AD.Explode) {
-    ++NumSROAArguments;
-    llvm::SmallVector<const ProjectionTreeNode*, 8> LeafNodes;
-    AD.ProjTree.getLeafNodes(LeafNodes);
-    for (auto Node : LeafNodes) {
-      SILType Ty = Node->getType();
-      DEBUG(llvm::dbgs() << "                " << Ty << "\n");
-      // If Ty is trivial, just pass it directly.
-      if (Ty.isTrivial(AD.Arg->getModule())) {
-        SILParameterInfo NewInfo(Ty.getSwiftRValueType(),
-                                 ParameterConvention::Direct_Unowned);
-        Out.push_back(NewInfo);
-        continue;
-      }
-
-      // Ty is not trivial, pass it through as the original calling convention.
-      auto ParameterConvention = AD.PInfo.getValue().getConvention();
-      if (AD.OwnedToGuaranteed) {
-        if (ParameterConvention == ParameterConvention::Direct_Owned)
-          ParameterConvention = ParameterConvention::Direct_Guaranteed;
-        else if (ParameterConvention == ParameterConvention::Indirect_In)
-          ParameterConvention = ParameterConvention::Indirect_In_Guaranteed;
-        else {
-          llvm_unreachable("Unknown parameter convention transformation");
-        }
-      }
-      SILParameterInfo NewInfo(Ty.getSwiftRValueType(), ParameterConvention);
-      Out.push_back(NewInfo);
-    }
-    return;
-  }
-
-  // If we cannot explode this value, handle callee release and return.
-  // If we found releases in the callee in the last BB on an @owned
-  // parameter, change the parameter to @guaranteed and continue...
-  if (AD.OwnedToGuaranteed) {
-    ++NumOwnedConvertedToGuaranteed;
-    auto ParameterConvention = AD.PInfo.getValue().getConvention();
-    if (ParameterConvention == ParameterConvention::Direct_Owned)
-      ParameterConvention = ParameterConvention::Direct_Guaranteed;
-    else if (ParameterConvention == ParameterConvention::Indirect_In)
-      ParameterConvention = ParameterConvention::Indirect_In_Guaranteed;
-    else {
-      llvm_unreachable("Unknown parameter convention transformation");
-    }
-
-    SILParameterInfo NewInfo(AD.PInfo.getValue().getType(),
-                             ParameterConvention);
-    Out.push_back(NewInfo);
-    return;
-  }
-
-  // Otherwise just propagate through the parameter info.
-  Out.push_back(AD.PInfo.getValue());
 }
 
 /// Collect all archetypes used by a function.
@@ -448,43 +253,42 @@ static bool usesGenerics(SILFunction *F,
 
 // Map the parameter, result and error types out of context to get the interface
 // type.
-static void
-mapInterfaceTypes(SILFunction *F,
-                  MutableArrayRef<SILParameterInfo> InterfaceParams,
-                  MutableArrayRef<SILResultInfo> InterfaceResults,
-                  Optional<SILResultInfo> &InterfaceErrorResult) {
+static void mapInterfaceTypes(SILFunction *F,
+                              MutableArrayRef<SILParameterInfo> InterfaceParams,
+                              MutableArrayRef<SILResultInfo> InterfaceResults,
+                              Optional<SILResultInfo> &InterfaceErrorResult) {
 
   for (auto &Param : InterfaceParams) {
     if (!Param.getType()->hasArchetype())
       continue;
     Param = SILParameterInfo(
-      Param.getType()->mapTypeOutOfContext()->getCanonicalType(),
-      Param.getConvention());
+        Param.getType()->mapTypeOutOfContext()->getCanonicalType(),
+        Param.getConvention());
   }
 
   for (auto &Result : InterfaceResults) {
     if (!Result.getType()->hasArchetype())
       continue;
     auto InterfaceResult = Result.getWithType(
-      Result.getType()->mapTypeOutOfContext()->getCanonicalType());
+        Result.getType()->mapTypeOutOfContext()->getCanonicalType());
     Result = InterfaceResult;
   }
 
   if (InterfaceErrorResult.hasValue()) {
     if (InterfaceErrorResult.getValue().getType()->hasArchetype()) {
-      InterfaceErrorResult = SILResultInfo(
-          InterfaceErrorResult.getValue().getType()->mapTypeOutOfContext()
-              ->getCanonicalType(),
-          InterfaceErrorResult.getValue().getConvention());
+      InterfaceErrorResult =
+          SILResultInfo(InterfaceErrorResult.getValue()
+                            .getType()
+                            ->mapTypeOutOfContext()
+                            ->getCanonicalType(),
+                        InterfaceErrorResult.getValue().getConvention());
     }
   }
 }
 
-CanSILFunctionType FunctionSignatureTransform::createOptimizedSILFunctionType() {
-  SILFunction *F = TransformDescriptor.OriginalFunction;
-  auto ArgumentDescList = TransformDescriptor.ArgumentDescList;
-  auto ResultDescList = TransformDescriptor.ResultDescList;
-
+CanSILFunctionType
+FunctionSignatureTransformDescriptor::createOptimizedSILFunctionType() {
+  SILFunction *F = OriginalFunction;
   CanSILFunctionType FTy = F->getLoweredFunctionType();
   auto ExpectedFTy = F->getLoweredType().castTo<SILFunctionType>();
   auto HasGenericSignature = FTy->getGenericSignature() != nullptr;
@@ -557,7 +361,7 @@ CanSILFunctionType FunctionSignatureTransform::createOptimizedSILFunctionType() 
   // Don't use a method representation if we modified self.
   auto ExtInfo = FTy->getExtInfo();
   auto witnessMethodConformance = FTy->getWitnessMethodConformanceOrNone();
-  if (TransformDescriptor.shouldModifySelfArgument) {
+  if (shouldModifySelfArgument) {
     ExtInfo = ExtInfo.withRepresentation(SILFunctionTypeRepresentation::Thin);
     witnessMethodConformance = None;
   }
@@ -580,16 +384,218 @@ CanSILFunctionType FunctionSignatureTransform::createOptimizedSILFunctionType() 
       F->getModule().getASTContext(), witnessMethodConformance);
 }
 
+/// Compute what the function interface will look like based on the
+/// optimization we are doing on the given argument descriptor. Default
+/// implementation simply passes it through.
+void FunctionSignatureTransformDescriptor::computeOptimizedArgInterface(
+    ArgumentDescriptor &AD, SILParameterInfoList &Out) {
+  // If this argument is live, but we cannot optimize it.
+  if (!AD.canOptimizeLiveArg()) {
+    if (AD.PInfo.hasValue())
+      Out.push_back(AD.PInfo.getValue());
+    return;
+  }
+
+  // If we have a dead argument, bail.
+  if (AD.IsEntirelyDead) {
+    ++NumDeadArgsEliminated;
+    return;
+  }
+
+  // Explode the argument or not ?
+  if (AD.Explode) {
+    ++NumSROAArguments;
+    llvm::SmallVector<const ProjectionTreeNode *, 8> LeafNodes;
+    AD.ProjTree.getLeafNodes(LeafNodes);
+    for (auto Node : LeafNodes) {
+      SILType Ty = Node->getType();
+      DEBUG(llvm::dbgs() << "                " << Ty << "\n");
+      // If Ty is trivial, just pass it directly.
+      if (Ty.isTrivial(AD.Arg->getModule())) {
+        SILParameterInfo NewInfo(Ty.getSwiftRValueType(),
+                                 ParameterConvention::Direct_Unowned);
+        Out.push_back(NewInfo);
+        continue;
+      }
+
+      // Ty is not trivial, pass it through as the original calling convention.
+      auto ParameterConvention = AD.PInfo.getValue().getConvention();
+      if (AD.OwnedToGuaranteed) {
+        if (ParameterConvention == ParameterConvention::Direct_Owned)
+          ParameterConvention = ParameterConvention::Direct_Guaranteed;
+        else if (ParameterConvention == ParameterConvention::Indirect_In)
+          ParameterConvention = ParameterConvention::Indirect_In_Guaranteed;
+        else {
+          llvm_unreachable("Unknown parameter convention transformation");
+        }
+      }
+      SILParameterInfo NewInfo(Ty.getSwiftRValueType(), ParameterConvention);
+      Out.push_back(NewInfo);
+    }
+    return;
+  }
+
+  // If we cannot explode this value, handle callee release and return.
+  // If we found releases in the callee in the last BB on an @owned
+  // parameter, change the parameter to @guaranteed and continue...
+  if (AD.OwnedToGuaranteed) {
+    ++NumOwnedConvertedToGuaranteed;
+    auto ParameterConvention = AD.PInfo.getValue().getConvention();
+    if (ParameterConvention == ParameterConvention::Direct_Owned)
+      ParameterConvention = ParameterConvention::Direct_Guaranteed;
+    else if (ParameterConvention == ParameterConvention::Indirect_In)
+      ParameterConvention = ParameterConvention::Indirect_In_Guaranteed;
+    else {
+      llvm_unreachable("Unknown parameter convention transformation");
+    }
+
+    SILParameterInfo NewInfo(AD.PInfo.getValue().getType(),
+                             ParameterConvention);
+    Out.push_back(NewInfo);
+    return;
+  }
+
+  // Otherwise just propagate through the parameter info.
+  Out.push_back(AD.PInfo.getValue());
+}
+
+//===----------------------------------------------------------------------===//
+//                        Function Signature Transform
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+class FunctionSignatureTransform {
+  /// A struct that contains all data that we use during our
+  /// transformation. This is an initial step towards splitting this struct into
+  /// multiple "transforms" that can be tested independently of each other.
+  FunctionSignatureTransformDescriptor TransformDescriptor;
+
+  /// The RC identity analysis we are using.
+  RCIdentityAnalysis *RCIA;
+
+  /// Post order analysis we are using.
+  EpilogueARCAnalysis *EA;
+
+private:
+  /// ----------------------------------------------------------///
+  /// Dead argument transformation.                             ///
+  /// ----------------------------------------------------------///
+  /// Find any dead argument opportunities.
+  bool DeadArgumentAnalyzeParameters();
+  /// Modify the current function so that later function signature analysis
+  /// are more effective.
+  void DeadArgumentTransformFunction();
+  /// Remove the dead argument once the new function is created.
+  void DeadArgumentFinalizeOptimizedFunction();
+
+  /// ----------------------------------------------------------///
+  /// Owned to guaranteed transformation.                       ///
+  /// ----------------------------------------------------------///
+  bool OwnedToGuaranteedAnalyzeResults();
+  bool OwnedToGuaranteedAnalyzeParameters();
+
+  /// Modify the current function so that later function signature analysis
+  /// are more effective.
+  void OwnedToGuaranteedTransformFunctionResults();
+  void OwnedToGuaranteedTransformFunctionParameters();
+
+  /// Find any owned to guaranteed opportunities.
+  bool OwnedToGuaranteedAnalyze();
+
+  /// Do the actual owned to guaranteed transformations.
+  void OwnedToGuaranteedTransform();
+
+  /// Set up epilogue work for the thunk result based in the given argument.
+  void OwnedToGuaranteedAddResultRelease(ResultDescriptor &RD,
+                                         SILBuilder &Builder, SILFunction *F);
+
+  /// Set up epilogue work for the thunk argument based in the given argument.
+  void OwnedToGuaranteedAddArgumentRelease(ArgumentDescriptor &AD,
+                                           SILBuilder &Builder, SILFunction *F);
+
+  /// Add the release for converted arguments and result.
+  void OwnedToGuaranteedFinalizeThunkFunction(SILBuilder &B, SILFunction *F);
+
+  /// ----------------------------------------------------------///
+  /// Argument explosion transformation.                        ///
+  /// ----------------------------------------------------------///
+  /// Find any argument explosion opportunities.
+  bool ArgumentExplosionAnalyzeParameters();
+  /// Explode the argument in the optimized function and replace the uses of
+  /// the original argument.
+  void ArgumentExplosionFinalizeOptimizedFunction();
+
+  /// Setup the thunk arguments based on the given argument descriptor info.
+  /// Every transformation must defines this interface. Default implementation
+  /// simply passes it through.
+  void addThunkArgument(ArgumentDescriptor &AD, SILBuilder &Builder,
+                        SILBasicBlock *BB,
+                        llvm::SmallVectorImpl<SILValue> &NewArgs);
+
+  /// Take ArgumentDescList and ResultDescList and create an optimized function
+  /// based on the current function we are analyzing. This also has the side
+  /// effect of turning the current function into a thunk.
+  void createFunctionSignatureOptimizedFunction();
+
+public:
+  /// Constructor.
+  FunctionSignatureTransform(
+      SILFunction *F, RCIdentityAnalysis *RCIA, EpilogueARCAnalysis *EA,
+      Mangle::FunctionSignatureSpecializationMangler &Mangler,
+      ArgumentIndexMap &AIM, llvm::SmallVector<ArgumentDescriptor, 4> &ADL,
+      llvm::SmallVector<ResultDescriptor, 4> &RDL)
+      : TransformDescriptor{F, nullptr, AIM, false, ADL, RDL}, RCIA(RCIA),
+        EA(EA) {}
+
+  /// Return the optimized function.
+  SILFunction *getOptimizedFunction() {
+    return TransformDescriptor.OptimizedFunction.getPtrOrNull();
+  }
+
+  /// Run the optimization.
+  bool run(bool hasCaller);
+
+  /// Run dead argument elimination of partially applied functions.
+  ///
+  /// After this optimization CapturePropagation can replace the partial_apply
+  /// by a direct reference to the specialized function.
+  bool removeDeadArgs(int minPartialAppliedArgs);
+};
+
+void FunctionSignatureTransform::addThunkArgument(
+    ArgumentDescriptor &AD, SILBuilder &Builder, SILBasicBlock *BB,
+    llvm::SmallVectorImpl<SILValue> &NewArgs) {
+  // Dead argument.
+  if (AD.IsEntirelyDead) {
+    return;
+  }
+
+  // Explode the argument.
+  if (AD.Explode) {
+    llvm::SmallVector<SILValue, 4> LeafValues;
+    AD.ProjTree.createTreeFromValue(Builder, BB->getParent()->getLocation(),
+                                    BB->getArgument(AD.Index), LeafValues);
+    NewArgs.append(LeafValues.begin(), LeafValues.end());
+    return;
+  }
+
+  // All other arguments get pushed as what they are.
+  NewArgs.push_back(BB->getArgument(AD.Index));
+}
+
+} // end anonymous namespace
+
 void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
   // Create the optimized function!
   SILFunction *F = TransformDescriptor.OriginalFunction;
   SILModule &M = F->getModule();
-  std::string Name = createOptimizedSILFunctionName();
+  std::string Name = TransformDescriptor.createOptimizedSILFunctionName();
   SILLinkage linkage = getSpecializedLinkage(F, F->getLinkage());
 
   DEBUG(llvm::dbgs() << "  -> create specialized function " << Name << "\n");
 
-  auto NewFTy = createOptimizedSILFunctionType();
+  auto NewFTy = TransformDescriptor.createOptimizedSILFunctionType();
   GenericEnvironment *NewFGenericEnv;
   if (NewFTy->getGenericSignature()) {
     NewFGenericEnv = F->getGenericEnvironment();
@@ -749,7 +755,8 @@ bool FunctionSignatureTransform::run(bool hasCaller) {
   // Check if generic signature of the function could be changed by
   // removed some unused generic arguments.
   if (F->getLoweredFunctionType()->isPolymorphic() &&
-      createOptimizedSILFunctionType() != F->getLoweredFunctionType()) {
+      TransformDescriptor.createOptimizedSILFunctionType() !=
+          F->getLoweredFunctionType()) {
     Changed = true;
   }
 


### PR DESCRIPTION
… transform descriptor.

The two methods on FunctionSignatureTransform in question:

    createOptimizedSILFunctionName()
    createOptimizedSILFunctionType()

are pure computation on the transform descriptor on the
FunctionSignatureTransform. So there really isn't a reason not to make it a
getter method on FunctionSignatureTransformDescriptor. This helps me to thin out
FunctionSignatureTransform even further in prepration for splitting it.

rdar://38196046