### PR TITLE
[Coverage] Instrument code in primary files only

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -830,6 +830,9 @@ private:
   /// May be -1, to indicate no association with a buffer.
   int BufferID;
 
+  /// \brief Whether this file is sourced from a primary input.
+  bool IsPrimaryInput;
+
   /// The list of protocol conformances that were "used" within this
   /// source file.
   llvm::SetVector<NormalProtocolConformance *> UsedConformances;
@@ -899,7 +902,7 @@ public:
 
   SourceFile(ModuleDecl &M, SourceFileKind K, Optional<unsigned> bufferID,
              ImplicitModuleImportKind ModImpKind, bool KeepParsedTokens = false,
-             bool KeepSyntaxTree = false);
+             bool KeepSyntaxTree = false, bool IsPrimary = false);
 
   void
   addImports(ArrayRef<std::pair<ModuleDecl::ImportedModule, ImportOptions>> IM);
@@ -988,6 +991,9 @@ public:
       return None;
     return BufferID;
   }
+
+  /// Returns whether this file is sourced from a primary input.
+  bool isPrimaryInput() const { return IsPrimaryInput; }
 
   /// If this buffer corresponds to a file on disk, returns the path.
   /// Otherwise, return an empty string.

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1330,10 +1330,11 @@ static void performAutoImport(
 SourceFile::SourceFile(ModuleDecl &M, SourceFileKind K,
                        Optional<unsigned> bufferID,
                        ImplicitModuleImportKind ModImpKind,
-                       bool KeepParsedTokens, bool BuildSyntaxTree)
-  : FileUnit(FileUnitKind::Source, M),
-    BufferID(bufferID ? *bufferID : -1),
-    Kind(K), SyntaxInfo(*new SourceFileSyntaxInfo(BuildSyntaxTree)) {
+                       bool KeepParsedTokens, bool BuildSyntaxTree,
+                       bool IsPrimary)
+    : FileUnit(FileUnitKind::Source, M), BufferID(bufferID ? *bufferID : -1),
+      IsPrimaryInput(IsPrimary), Kind(K),
+      SyntaxInfo(*new SourceFileSyntaxInfo(BuildSyntaxTree)) {
   M.getASTContext().addDestructorCleanup(*this);
   performAutoImport(*this, ModImpKind);
 

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -804,13 +804,14 @@ SourceFile *CompilerInstance::createSourceFileForMainModule(
     SourceFileKind fileKind, SourceFile::ImplicitModuleImportKind importKind,
     Optional<unsigned> bufferID) {
   ModuleDecl *mainModule = getMainModule();
+  bool isPrimary = bufferID && isPrimaryInput(*bufferID);
   SourceFile *inputFile = new (*Context)
       SourceFile(*mainModule, fileKind, bufferID, importKind,
                  Invocation.getLangOptions().CollectParsedToken,
-                 Invocation.getLangOptions().BuildSyntaxTree);
+                 Invocation.getLangOptions().BuildSyntaxTree, isPrimary);
   MainModule->addFile(*inputFile);
 
-  if (bufferID && isPrimaryInput(*bufferID)) {
+  if (isPrimary) {
     recordPrimarySourceFile(inputFile);
   }
 

--- a/lib/SIL/SILProfiler.cpp
+++ b/lib/SIL/SILProfiler.cpp
@@ -480,21 +480,20 @@ struct PGOMapping : public ASTWalker {
       CounterMap[thenExpr] = NextCounter++;
       auto thenCount = loadExecutionCount(thenExpr);
       LoadedCounterMap[thenExpr] = thenCount;
-      if (auto elseExpr = IE->getElseExpr()) {
-        CounterMap[elseExpr] = parent;
-        auto count = loadExecutionCount(elseExpr);
-        if (!parent) {
-          auto thenVal = thenCount.getValue();
-          for (auto pCount = NextCounter - 1; pCount > 0; --pCount) {
-            auto cCount = LoadedCounts->Counts[pCount];
-            if (cCount > thenVal) {
-              count = cCount;
-              break;
-            }
+      auto elseExpr = IE->getElseExpr();
+      CounterMap[elseExpr] = parent;
+      auto count = loadExecutionCount(elseExpr);
+      if (!parent) {
+        auto thenVal = thenCount.getValue();
+        for (auto pCount = NextCounter - 1; pCount > 0; --pCount) {
+          auto cCount = LoadedCounts->Counts[pCount];
+          if (cCount > thenVal) {
+            count = cCount;
+            break;
           }
         }
-        LoadedCounterMap[elseExpr] = subtract(count, thenCount);
       }
+      LoadedCounterMap[elseExpr] = subtract(count, thenCount);
     } else if (isa<AutoClosureExpr>(E) || isa<ClosureExpr>(E)) {
       CounterMap[E] = NextCounter++;
       auto eCount = loadExecutionCount(E);

--- a/test/SILGen/Inputs/empty-func.swift
+++ b/test/SILGen/Inputs/empty-func.swift
@@ -1,0 +1,1 @@
+func empty_func() {}

--- a/test/SILGen/coverage_multi_file.swift
+++ b/test/SILGen/coverage_multi_file.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -primary-file %s %S/Inputs/empty-func.swift -emit-sil -emit-sorted-sil -Xllvm -sil-full-demangle -module-name multi | %FileCheck %s -check-prefix=PRIMARY
+// RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping %s %S/Inputs/empty-func.swift -emit-sil -emit-sorted-sil -Xllvm -sil-full-demangle -module-name multi | %FileCheck %s -check-prefix=WMO
+// RUN: %target-swift-frontend -profile-generate -profile-coverage-mapping -primary-file %s -primary-file %S/Inputs/empty-func.swift -emit-sil -emit-sorted-sil -Xllvm -sil-full-demangle -module-name multi | %FileCheck %s -check-prefix=BOTH-PRIMARY
+
+// PRIMARY-NOT: sil_coverage_map {{.*}} $S5multi10empty_funcyyF
+// PRIMARY: sil_coverage_map {{.*}} $S5multi4mainyyF
+
+// WMO: sil_coverage_map {{.*}} $S5multi10empty_funcyyF
+// WMO: sil_coverage_map {{.*}} $S5multi4mainyyF
+
+// BOTH-PRIMARY: sil_coverage_map {{.*}} $S5multi10empty_funcyyF
+// BOTH-PRIMARY: sil_coverage_map {{.*}} $S5multi4mainyyF
+
+func main() {
+  empty_func()
+}


### PR DESCRIPTION
Unless there are no primary inputs (WMO), code outside of a primary input file
may not be fully typechecked or well-formed. Defer instrumenting non-primary
files with the expectation that that code will be visited later.

This fixes at least one assertion failure seen while building a project
with coverage, and is probably good for some substantial compile-time
improvements with coverage enabled.

rdar://39069115