### PR TITLE
[4.2] swift-api-digester: refine diagnostic messages for removed type alias.

### DIFF
--- a/test/api-digester/Inputs/APINotesRight/APINotesTest.apinotes
+++ b/test/api-digester/Inputs/APINotesRight/APINotesTest.apinotes
@@ -5,3 +5,10 @@ Globals:
 Protocols:
   - Name: TypeWithMethod
     SwiftName: SwiftTypeWithMethodRight
+
+SwiftVersions:
+- Version: 3
+  Typedefs:
+  - Name: AnimalAttributeName
+    SwiftName: AnimalAttributeName
+    SwiftWrapper: none

--- a/test/api-digester/Outputs/Cake.txt
+++ b/test/api-digester/Outputs/Cake.txt
@@ -1,4 +1,6 @@
 
+/* RawRepresentable Changes */
+
 /* Removed Decls */
 cake1: Constructor Somestruct2.init(_:) has been removed
 cake1: Func C4.foo() has been removed

--- a/test/api-digester/Outputs/apinotes-diags-3-4.txt
+++ b/test/api-digester/Outputs/apinotes-diags-3-4.txt
@@ -1,0 +1,14 @@
+
+/* RawRepresentable Changes */
+APINotesTest(APINotesTest.h): TypeAlias AnimalAttributeName(NSString) is now String representable
+
+/* Removed Decls */
+
+/* Moved Decls */
+
+/* Renamed Decls */
+
+/* Type Changes */
+APINotesTest(APINotesTest.h): Func AnimalStatusDescriptor.addingAttributes(_:) has parameter 0 type change from [String : Any] to [AnimalAttributeName : Any]
+
+/* Decl Attribute changes */

--- a/test/api-digester/Outputs/apinotes-diags.txt
+++ b/test/api-digester/Outputs/apinotes-diags.txt
@@ -1,4 +1,6 @@
 
+/* RawRepresentable Changes */
+
 /* Removed Decls */
 APINotesTest(APINotesTest.h): Func ObjcProt.protMemberFunc2() has been removed
 APINotesTest(APINotesTest.h): Func ObjcProt.protMemberFunc3() has been removed

--- a/test/api-digester/apinotes-diags.swift
+++ b/test/api-digester/apinotes-diags.swift
@@ -2,7 +2,10 @@
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)
-// RUN: %api-digester %clang-importer-sdk-nosource -dump-sdk -module APINotesTest -o %t.dump1.json -module-cache-path %t.module-cache -swift-version 3 -I %S/Inputs/APINotesLeft
+// RUN: %api-digester %clang-importer-sdk-nosource -dump-sdk -module APINotesTest -o %t.dump1.json -module-cache-path %t.module-cache -swift-version 4 -I %S/Inputs/APINotesLeft
 // RUN: %api-digester %clang-importer-sdk-nosource -dump-sdk -module APINotesTest -o %t.dump2.json -module-cache-path %t.module-cache -swift-version 3 -I %S/Inputs/APINotesRight
-// RUN: %api-digester -diagnose-sdk -print-module -input-paths %t.dump1.json -input-paths %t.dump2.json > %t.result
+// RUN: %api-digester %clang-importer-sdk-nosource -dump-sdk -module APINotesTest -o %t.dump3.json -module-cache-path %t.module-cache -swift-version 4 -I %S/Inputs/APINotesRight
+// RUN: %api-digester -diagnose-sdk -print-module -input-paths %t.dump1.json -input-paths %t.dump3.json > %t.result
 // RUN: diff -u %S/Outputs/apinotes-diags.txt %t.result
+// RUN: %api-digester -diagnose-sdk -print-module -input-paths %t.dump2.json -input-paths %t.dump3.json > %t.result
+// RUN: diff -u %S/Outputs/apinotes-diags-3-4.txt %t.result

--- a/test/api-digester/apinotes-migrator-gen.swift
+++ b/test/api-digester/apinotes-migrator-gen.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t.mod)
 // RUN: %empty-directory(%t.sdk)
 // RUN: %empty-directory(%t.module-cache)
-// RUN: %api-digester -dump-sdk -module APINotesTest -o %t.dump1.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -swift-version 3 -I %S/Inputs/APINotesLeft
-// RUN: %api-digester -dump-sdk -module APINotesTest -o %t.dump2.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -swift-version 3 -I %S/Inputs/APINotesRight
+// RUN: %api-digester -dump-sdk -module APINotesTest -o %t.dump1.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -swift-version 4 -I %S/Inputs/APINotesLeft
+// RUN: %api-digester -dump-sdk -module APINotesTest -o %t.dump2.json -module-cache-path %t.module-cache %clang-importer-sdk-nosource -swift-version 4 -I %S/Inputs/APINotesRight
 // RUN: %api-digester -compare-sdk --input-paths %t.dump1.json -input-paths %t.dump2.json -o %t.result -json
 // RUN: diff -u %S/Outputs/apinotes-migrator-gen.json %t.result


### PR DESCRIPTION
Framework authors can use SwiftWraper:none to bring back string enums
to type alias of String. When diagnosing source breaking changes, these
type alias are shown as removed. Therefore, it's hard to tell whether these
changes are automatically migratable. This patch refines the
removed-type-alias by further analyzing whether a
RawRepresentable with the same usr appeared in the later version of
SDK. If there is, another kind of message is emitted for differentiation.
