### PR TITLE
[CSBindings] Look through non-value types earlier to avoid producing …

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -253,6 +253,17 @@ ConstraintSystem::getPotentialBindingForRelationalConstraint(
   if (type->hasError())
     return None;
 
+  // Don't deduce autoclosure types or single-element, non-variadic
+  // tuples.
+  if (shouldBindToValueType(constraint)) {
+    if (auto funcTy = type->getAs<FunctionType>()) {
+      if (funcTy->isAutoClosure())
+        type = funcTy->getResult();
+    }
+
+    type = type->getWithoutImmediateLabel();
+  }
+
   // If the source of the binding is 'OptionalObject' constraint
   // and type variable is on the left-hand side, that means
   // that it _has_ to be of optional type, since the right-hand
@@ -304,17 +315,6 @@ ConstraintSystem::getPotentialBindingForRelationalConstraint(
 
     result.InvolvesTypeVariables = true;
     return None;
-  }
-
-  // Don't deduce autoclosure types or single-element, non-variadic
-  // tuples.
-  if (shouldBindToValueType(constraint)) {
-    if (auto funcTy = type->getAs<FunctionType>()) {
-      if (funcTy->isAutoClosure())
-        type = funcTy->getResult();
-    }
-
-    type = type->getWithoutImmediateLabel();
   }
 
   // Make sure we aren't trying to equate type variables with different

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -209,7 +209,6 @@ S_RDAR_28991372(x: #^RDAR_28991372^#, y: <#T##Int#>)
 protocol P where #^RDAR_31981486^#
 // RDAR_31981486: Begin completions
 
-
 // rdar://problem/38149042
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RDAR_38149042 | %FileCheck %s -check-prefix=RDAR_38149042
 class Baz_38149042 {
@@ -226,3 +225,24 @@ func foo_38149042(bar: Bar_38149042) {
 // RDAR_38149042-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]: [' ']=== {#AnyObject?#}[#Bool#]; name==== AnyObject?
 // RDAR_38149042-DAG: Decl[InfixOperatorFunction]/OtherModule[Swift]: [' ']!== {#AnyObject?#}[#Bool#]; name=!== AnyObject?
 // RDAR_38149042: End completions
+
+// rdar://problem/38272904
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RDAR_38272904 | %FileCheck %s -check-prefix=RDAR_38272904
+public protocol P_38272904 {
+    associatedtype A = Error
+    associatedtype B
+}
+
+public func ?? <T: P_38272904>(lhs: T, rhs: @autoclosure() throws -> T.B) rethrows -> T.B {
+  fatalError()
+}
+
+class A_38272904 {
+  open class func foo() -> A_38272904 { fatalError() }
+}
+
+func bar_38272904(a: A_38272904) {}
+func foo_38272904(a: A_38272904) {
+  bar_38272904(a: .foo() #^RDAR_38272904^#)
+}
+// RDAR_38272904: Begin completions


### PR DESCRIPTION
…incorrect bindings

Before checking any requirements of the binding type, let's look
through @autoclosure and/or non-variable types if source constraint
requires that, otherwise we'd end up creating bindings for types
which later on might end up causing infinite recursion like dependent
member types in result position of @autoclosure parameter.

Resolves: rdar://problem/38272904

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
