### PR TITLE
SIL Deserializer: Don't deserialize during "lowered" stage.

### DIFF
--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -186,6 +186,18 @@ SILModule::lookUpWitnessTable(const ProtocolConformance *C,
   if (wtable->isDefinition())
     return wtable;
 
+  // If the module is at or past the Lowered stage, then we can't do any
+  // further deserialization, since pre-IRGen SIL lowering changes the types
+  // of definitions to make them incompatible with canonical serialized SIL.
+  switch (getStage()) {
+  case SILStage::Canonical:
+  case SILStage::Raw:
+    break;
+    
+  case SILStage::Lowered:
+    return wtable;
+  }
+
   // Otherwise try to deserialize it. If we succeed return the deserialized
   // function.
   //

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -387,6 +387,19 @@ SILFunction *SILDeserializer::readSILFunction(DeclID FID,
                                               StringRef name,
                                               bool declarationOnly,
                                               bool errorIfEmptyBody) {
+  // We can't deserialize function bodies after IRGen lowering passes have
+  // happened since other definitions in the module will no longer be in
+  // canonical SIL form.
+  switch (SILMod.getStage()) {
+  case SILStage::Raw:
+  case SILStage::Canonical:
+    break;
+    
+  case SILStage::Lowered:
+    llvm_unreachable("cannot deserialize into a module that has entered "
+                     "Lowered stage");
+  }
+  
   if (FID == 0)
     return nullptr;
   assert(FID <= Funcs.size() && "invalid SILFunction ID");


### PR DESCRIPTION
Pre-IRGen lowering passes take SIL out of canonical form, making it potentially incompatible with the serialized canonical SIL.

rdar://problem/39211830