### PR TITLE
Demangler: Reserve space for more kinds of symbolic reference in the future.

### DIFF
--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -130,8 +130,10 @@ swift::Demangle::makeSymbolicMangledNameStringRef(const char *base) {
   auto end = base;
   while (*end != '\0') {
     // Skip over symbolic references.
-    if (*end == '\1')
-      end += 4;
+    if (*end >= '\x01' && *end <= '\x17')
+      end += sizeof(uint32_t);
+    if (*end >= '\x18' && *end <= '\x1F')
+      end += sizeof(void*);
     ++end;
   }
   return StringRef(base, end - base);


### PR DESCRIPTION
Carve out the C0 control code space as symbolic reference introducers—U+0001 through U+0017 as relative symbolic references, and U+0018 through U+001F as absolute symbolic references (if we ever need them).