### PR TITLE
[DebuggerSupport] Expose a way to query the reference counts.

### DIFF
--- a/include/swift/Runtime/HeapObject.h
+++ b/include/swift/Runtime/HeapObject.h
@@ -231,6 +231,8 @@ SWIFT_RUNTIME_EXPORT
 size_t swift_retainCount(HeapObject *object);
 SWIFT_RUNTIME_EXPORT
 size_t swift_unownedRetainCount(HeapObject *object);
+SWIFT_RUNTIME_EXPORT
+size_t swift_weakRetainCount(HeapObject *object);
 
 /// Is this pointer a non-null unique reference to an object
 /// that uses Swift reference counting?

--- a/stdlib/public/SwiftShims/HeapObject.h
+++ b/stdlib/public/SwiftShims/HeapObject.h
@@ -13,6 +13,7 @@
 #define SWIFT_STDLIB_SHIMS_HEAPOBJECT_H
 
 #include "RefCount.h"
+#include "SwiftStddef.h"
 #include "System.h"
 
 #define SWIFT_ABI_HEAP_OBJECT_HEADER_SIZE_64 16
@@ -30,6 +31,7 @@ template <typename Target> struct TargetHeapMetadata;
 using HeapMetadata = TargetHeapMetadata<InProcess>;
 #else
 typedef struct HeapMetadata HeapMetadata;
+typedef struct HeapObject HeapObject;
 #endif
 
 // The members of the HeapObject header that are not shared by a
@@ -68,6 +70,15 @@ extern "C" {
 SWIFT_RUNTIME_STDLIB_INTERFACE
 void _swift_instantiateInertHeapObject(void *address,
                                        const HeapMetadata *metadata);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+__swift_size_t swift_retainCount(HeapObject *obj);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+__swift_size_t swift_unownedRetainCount(HeapObject *obj);
+
+SWIFT_RUNTIME_STDLIB_INTERFACE
+__swift_size_t swift_weakRetainCount(HeapObject *obj);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/stdlib/public/core/DebuggerSupport.swift
+++ b/stdlib/public/core/DebuggerSupport.swift
@@ -10,6 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftShims
+
 @_frozen // FIXME(sil-serialize-all)
 public enum _DebuggerSupport {
   @_frozen // FIXME(sil-serialize-all)
@@ -345,3 +347,11 @@ func _stringForPrintObject(_ value: Any) -> String {
 public
 func _debuggerTestingCheckExpect(_ checked_value: String,
                                  _ expected_value: String) {}
+
+// Utilities to get refcount(s) of class objects.
+@_silgen_name("swift_retainCount")
+public func _getRetainCount(_ Value: AnyObject) -> UInt
+@_silgen_name("swift_unownedRetainCount")
+public func _getUnownedRetainCount(_ Value : AnyObject) -> UInt
+@_silgen_name("swift_weakRetainCount")
+public func _getWeakRetainCount(_ Value : AnyObject) -> UInt

--- a/stdlib/public/runtime/HeapObject.cpp
+++ b/stdlib/public/runtime/HeapObject.cpp
@@ -372,6 +372,10 @@ size_t swift::swift_unownedRetainCount(HeapObject *object) {
   return object->refCounts.getUnownedCount();
 }
 
+size_t swift::swift_weakRetainCount(HeapObject *object) {
+  return object->refCounts.getWeakCount();
+}
+
 HeapObject *swift::swift_unownedRetain(HeapObject *object) {
   SWIFT_RT_TRACK_INVOCATION(object, swift_unownedRetain);
   if (!isValidPointerForNativeRetain(object))

--- a/test/stdlib/DebuggerSupport.swift
+++ b/test/stdlib/DebuggerSupport.swift
@@ -1,5 +1,6 @@
 // RUN: %target-run-simple-swift
 // REQUIRES: executable_test
+// REQUIRES: optimized_stdlib
 
 import StdlibUnittest
 
@@ -112,10 +113,18 @@ class RefCountedObj {
 let RefcountTests = TestSuite("RefCount")
 RefcountTests.test("Basic") {
   var Obj = RefCountedObj(47);
-  expectEqual(_getRetainCount(Obj), 2);
-  expectEqual(_getWeakRetainCount(Obj), 1);
-  expectEqual(_getUnownedRetainCount(Obj), 1);
-  let _ = Obj.f() // try to keep the object live here.
+
+  // Counters for live objects should be always positive.
+  // We try to be a little bit more lax here because optimizations
+  // or different stdlib versions might impact the exact value of
+  // refcounting, and we're just interested in testing whether the
+  // stub works properly.
+  expectGT(_getRetainCount(Obj), 0);
+  expectGT(_getWeakRetainCount(Obj), 0);
+  expectGT(_getUnownedRetainCount(Obj), 0);
+
+  // Try to keep the object live here.
+  let _ = Obj.f()
 }
 
 runAllTests()

--- a/test/stdlib/DebuggerSupport.swift
+++ b/test/stdlib/DebuggerSupport.swift
@@ -99,4 +99,23 @@ StringForPrintObjectTests.test("DontBridgeThisStruct") {
 }
 #endif
 
+class RefCountedObj {
+  var patatino : Int
+  init(_ p : Int) {
+    self.patatino = p
+  }
+  public func f() -> Int {
+    return self.patatino
+  }
+}
+
+let RefcountTests = TestSuite("RefCount")
+RefcountTests.test("Basic") {
+  var Obj = RefCountedObj(47);
+  expectEqual(_getRetainCount(Obj), 2);
+  expectEqual(_getWeakRetainCount(Obj), 1);
+  expectEqual(_getUnownedRetainCount(Obj), 1);
+  let _ = Obj.f() // try to keep the object live here.
+}
+
 runAllTests()


### PR DESCRIPTION
lldb will use it to reimplement `language swift refcount <obj>`
which is currently not working. Asking the compiler allows us
to avoid maintinaing a bunch of information in the debugger which
are likely to change and break.

<rdar://problem/30538363>

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
