### PR TITLE
[ClangImporter] Honor -Xcc -W* flags for en/disabling Clang warnings

### DIFF
--- a/test/ClangImporter/Inputs/diags_from_header.h
+++ b/test/ClangImporter/Inputs/diags_from_header.h
@@ -1,0 +1,2 @@
+#warning "here is some warning about something"
+#error "but this one is an error"

--- a/test/ClangImporter/diags_from_header.swift
+++ b/test/ClangImporter/diags_from_header.swift
@@ -1,0 +1,7 @@
+// RUN: not %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/diags_from_header.h 2>&1 | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-WARN
+
+// RUN: not %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/diags_from_header.h -Xcc -Wno-#warnings 2>&1 | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-NO-WARN
+
+// CHECK-WARN: diags_from_header.h:{{.*}}:2: warning: "here is some warning about something"
+// CHECK-NO-WARN-NOT: warning about something
+// CHECK: diags_from_header.h:{{.*}}:2: error: "but this one is an error"

--- a/test/ClangImporter/diags_from_module.swift
+++ b/test/ClangImporter/diags_from_module.swift
@@ -1,6 +1,12 @@
 // RUN: not %target-swift-frontend -typecheck %s -F %S/Inputs/frameworks -Xcc -D -Xcc FOO 2> %t.err.txt
 // RUN: %FileCheck -input-file=%t.err.txt %s
 
+// RUN: %target-swift-frontend -typecheck %s -F %S/Inputs/frameworks 2> %t.warn.txt
+// RUN: %FileCheck -input-file=%t.warn.txt %s -check-prefix=CHECK-WARN
+
+// RUN: %target-swift-frontend -typecheck %s -F %S/Inputs/frameworks -Xcc -Wno-#warnings 2> %t.nowarn.txt
+// RUN: %FileCheck -input-file=%t.nowarn.txt %s -check-prefix=CHECK-NO-WARN -allow-empty
+
 // XFAIL: linux
 
 import Module
@@ -9,8 +15,7 @@ import Module
 // CHECK: Sub2.h:2:9: error: could not build module 'Another'
 // CHECK: diags_from_module.swift:[[@LINE-4]]:8: error: could not build Objective-C module 'Module'
 
-// RUN: %target-swift-frontend -typecheck %s -F %S/Inputs/frameworks 2> %tw.err.txt
-// RUN: %FileCheck -input-file=%tw.err.txt %s -check-prefix=CHECK-WARN
-
 // CHECK-WARN: Sub2.h:7:2: warning: here is some warning about something
 // FIXME: show the clang warning: <module-includes>:1:1: warning: umbrella header for module 'Module' does not include header 'NotInModule.h' [-Wincomplete-umbrella]
+
+// CHECK-NO-WARN-NOT: warning about something


### PR DESCRIPTION
Previously we set up the diagnostic options too early for these flags to be honored, in order to diagnose problems in parsing the arguments being passed to Clang. The solution is to decide that that diagnostic engine is a temporary one and to create a proper one later. (And if this sounds like a lousy solution, I don't disagree, but it's what Clang does too.)

rdar://problem/39197895 and possibly something older but I can't find it