### PR TITLE
IRGen: Add nil checks to scalarCheckedCasts

### DIFF
--- a/test/IRGen/casts.sil
+++ b/test/IRGen/casts.sil
@@ -271,6 +271,31 @@ nay:
   unreachable
 }
 
+// CHECK: define swiftcc {{.*}} @checked_downcast_optional_class_to_ex([[INT]])
+// CHECK: entry:
+// CHECK:   [[V1:%.*]] = inttoptr [[INT]] %0 to %T5casts1AC*
+// CHECK:   [[V2:%.*]] = icmp ne %T5casts1AC* [[V1]], null
+// CHECK:   br i1 [[V2]], label %[[LBL:.*]], label
+// CHECK:    [[LBL]]:
+// CHECK:   [[V4:%.*]] = bitcast %T5casts1AC* [[V1]] to %swift.type**
+// CHECK:    load %swift.type*, %swift.type** [[V4]]
+sil @checked_downcast_optional_class_to_ex : $@convention(thin) (@guaranteed Optional<A>) -> @owned Optional<CP> {
+bb0(%0 : $Optional<A>):
+  checked_cast_br %0 : $Optional<A> to $CP, bb1, bb2
+
+bb1(%3 : $CP):
+  %4 = enum $Optional<CP>, #Optional.some!enumelt.1, %3 : $CP
+  retain_value %0 : $Optional<A>
+  br bb3(%4 : $Optional<CP>)
+
+bb2:
+  %7 = enum $Optional<CP>, #Optional.none!enumelt
+  br bb3(%7 : $Optional<CP>)
+
+bb3(%9 : $Optional<CP>):
+  return %9 : $Optional<CP>
+}
+
 // CHECK-LABEL: define{{( protected)?}} swiftcc void @checked_metatype_to_object_casts
 sil @checked_metatype_to_object_casts : $@convention(thin) <T> (@thick Any.Type) -> () {
 entry(%e : $@thick Any.Type):

--- a/test/Interpreter/casts.swift
+++ b/test/Interpreter/casts.swift
@@ -1,0 +1,78 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import StdlibUnittest
+import Foundation
+
+protocol P : class { }
+protocol C : class { }
+
+class Foo : NSObject {}
+var Casts = TestSuite("Casts")
+
+
+@inline(never)
+func castit<ObjectType>(_ o: NSObject?, _ t: ObjectType.Type) -> ObjectType? {
+  return o as? ObjectType
+}
+
+@inline(never)
+func castitExistential<ObjectType>(_ o: C?, _ t: ObjectType.Type) -> ObjectType? {
+  return o as? ObjectType
+}
+
+Casts.test("cast optional<nsobject> to protocol") {
+  if let obj = castit(nil, P.self) {
+    print("fail")
+    expectUnreachable()
+  } else {
+    print("success")
+  }
+}
+
+Casts.test("cast optional<nsobject> to protocol meta") {
+  if let obj = castit(nil, P.Type.self) {
+    print("fail")
+    expectUnreachable()
+  } else {
+    print("success")
+  }
+}
+Casts.test("cast optional<protocol> to protocol") {
+  if let obj = castitExistential(nil, P.self) {
+    print("fail")
+    expectUnreachable()
+  } else {
+    print("success")
+  }
+}
+
+Casts.test("cast optional<protocol> to class") {
+  if let obj = castitExistential(nil, Foo.self) {
+    print("fail")
+    expectUnreachable()
+  } else {
+    print("success")
+  }
+}
+
+Casts.test("cast optional<protocol> to protocol meta") {
+  if let obj = castitExistential(nil, P.Type.self) {
+    expectUnreachable()
+    print("fail")
+  } else {
+    print("success")
+  }
+}
+
+Casts.test("cast optional<protocol> to class meta") {
+  if let obj = castitExistential(nil, Foo.Type.self) {
+    expectUnreachable()
+    print("fail")
+  } else {
+    print("success")
+  }
+}
+
+runAllTests()


### PR DESCRIPTION
We claim to handle optional input types but not all paths of this function actually do.

rdar://39195672
