### PR TITLE
[Coverage] Only instrument functions which are definitions

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -266,9 +266,9 @@ public:
     Profiler = InheritedProfiler;
   }
 
-  void createProfiler(ASTNode Root) {
+  void createProfiler(ASTNode Root, ForDefinition_t forDefinition) {
     assert(!Profiler && "Function already has a profiler");
-    Profiler = SILProfiler::create(Module, Root);
+    Profiler = SILProfiler::create(Module, forDefinition, Root);
   }
 
   void discardProfiler() { Profiler = nullptr; }

--- a/include/swift/SIL/SILProfiler.h
+++ b/include/swift/SIL/SILProfiler.h
@@ -22,12 +22,14 @@
 #include "swift/AST/Stmt.h"
 #include "swift/Basic/ProfileCounter.h"
 #include "swift/SIL/SILAllocated.h"
+#include "swift/SIL/SILDeclRef.h"
 #include "llvm/ADT/DenseMap.h"
 
 namespace swift {
 
 class AbstractFunctionDecl;
 class SILCoverageMap;
+class SILFunction;
 class SILModule;
 
 /// SILProfiler - Maps AST nodes to profile counters.
@@ -61,7 +63,8 @@ private:
       : M(M), Root(Root), EmitCoverageMapping(EmitCoverageMapping) {}
 
 public:
-  static SILProfiler *create(SILModule &M, ASTNode N);
+  static SILProfiler *create(SILModule &M, ForDefinition_t forDefinition,
+                             ASTNode N);
 
   /// Check if the function is set up for profiling.
   bool hasRegionCounters() const { return NumRegionCounters != 0; }

--- a/lib/SIL/SILProfiler.cpp
+++ b/lib/SIL/SILProfiler.cpp
@@ -100,19 +100,21 @@ static void walkForProfiling(ASTNode N, ASTWalker &Walker) {
   }
 }
 
+/// Check that the input AST has at least been type-checked.
+static bool hasASTBeenTypeChecked(ASTNode N) {
+  DeclContext *DC = N.getAsDeclContext();
+  assert(DC && "Invalid AST node for profiling");
+  SourceFile *SF = DC->getParentSourceFile();
+  return !SF || SF->ASTStage >= SourceFile::TypeChecked;
+}
+
 SILProfiler *SILProfiler::create(SILModule &M, ForDefinition_t forDefinition,
                                  ASTNode N) {
   // Avoid generating profiling state for declarations.
   if (!forDefinition)
     return nullptr;
 
-  // Assert that the input AST has at least been type-checked.
-  assert([&] {
-    DeclContext *DC = N.getAsDeclContext();
-    assert(DC && "Invalid AST node for profiling");
-    SourceFile *SF = DC->getParentSourceFile();
-    return !SF || SF->ASTStage >= SourceFile::TypeChecked;
-  }() && "Cannot use this AST for code coverage");
+  assert(hasASTBeenTypeChecked(N) && "Cannot use this AST for code coverage");
 
   if (auto *D = N.dyn_cast<Decl *>()) {
     assert(isa<AbstractFunctionDecl>(D) ||

--- a/lib/SIL/SILProfiler.cpp
+++ b/lib/SIL/SILProfiler.cpp
@@ -478,21 +478,21 @@ struct PGOMapping : public ASTWalker {
       CounterMap[thenExpr] = NextCounter++;
       auto thenCount = loadExecutionCount(thenExpr);
       LoadedCounterMap[thenExpr] = thenCount;
-      if (auto elseExpr = IE->getElseExpr()) {
-        CounterMap[elseExpr] = parent;
-        auto count = loadExecutionCount(elseExpr);
-        if (!parent) {
-          auto thenVal = thenCount.getValue();
-          for (auto pCount = NextCounter - 1; pCount > 0; --pCount) {
-            auto cCount = LoadedCounts->Counts[pCount];
-            if (cCount > thenVal) {
-              count = cCount;
-              break;
-            }
+      auto elseExpr = IE->getElseExpr();
+      assert(elseExpr && "An if-expr must have an else subexpression");
+      CounterMap[elseExpr] = parent;
+      auto count = loadExecutionCount(elseExpr);
+      if (!parent) {
+        auto thenVal = thenCount.getValue();
+        for (auto pCount = NextCounter - 1; pCount > 0; --pCount) {
+          auto cCount = LoadedCounts->Counts[pCount];
+          if (cCount > thenVal) {
+            count = cCount;
+            break;
           }
         }
-        LoadedCounterMap[elseExpr] = subtract(count, thenCount);
       }
+      LoadedCounterMap[elseExpr] = subtract(count, thenCount);
     } else if (isa<AutoClosureExpr>(E) || isa<ClosureExpr>(E)) {
       CounterMap[E] = NextCounter++;
       auto eCount = loadExecutionCount(E);

--- a/test/SILGen/Inputs/coverage_imports.swift
+++ b/test/SILGen/Inputs/coverage_imports.swift
@@ -1,0 +1,7 @@
+public struct Box {
+  public lazy var x: Int = {
+    return true ? 0 : 1
+  }()
+
+  public init() {}
+}

--- a/test/SILGen/coverage_decls.swift
+++ b/test/SILGen/coverage_decls.swift
@@ -1,0 +1,6 @@
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_decls -primary-file %s %S/Inputs/coverage_imports.swift
+
+func main() {
+  var b = Box()
+  let _ = b.x
+}

--- a/test/SILGen/coverage_decls.swift
+++ b/test/SILGen/coverage_decls.swift
@@ -1,4 +1,7 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_decls -primary-file %s %S/Inputs/coverage_imports.swift
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_decls -primary-file %s %S/Inputs/coverage_imports.swift | %FileCheck %s
+
+// CHECK: sil_coverage_map {{.*}} $S14coverage_decls4mainyyF
+// CHECK-NOT: sil_coverage_map
 
 func main() {
   var b = Box()


### PR DESCRIPTION
The ASTs for functions which aren't definitions may not be fully
typechecked or well-formed, so: avoid looking at them.

This fixes at least one assertion failure seen while building a project
with coverage, and is probably good for some substantial compile-time
improvements with coverage enabled.

rdar://39069115