### PR TITLE
[func-sig-opts] hasNonTrivialNonDebugUse => hasNonTrivialNonDebugTran…

### DIFF
--- a/include/swift/SIL/DebugUtils.h
+++ b/include/swift/SIL/DebugUtils.h
@@ -210,6 +210,11 @@ inline void eraseFromParentWithDebugInsts(SILInstruction *I) {
   eraseFromParentWithDebugInsts(I, nullIter);
 }
 
+/// Return true if the def-use graph rooted at \p V contains any non-debug,
+/// non-trivial users.
+bool hasNonTrivialNonDebugTransitiveUsers(
+    PointerUnion<SILInstruction *, SILArgument *> V);
+
 } // end namespace swift
 
 #endif /* SWIFT_SIL_DEBUGUTILS_H */

--- a/include/swift/SILOptimizer/Utils/FunctionSignatureOptUtils.h
+++ b/include/swift/SILOptimizer/Utils/FunctionSignatureOptUtils.h
@@ -200,9 +200,6 @@ bool canSpecializeFunction(SILFunction *F,
                            const CallerAnalysis::FunctionInfo *FuncInfo,
                            bool OptForPartialApply);
 
-/// Return true if this argument is used in a non-trivial way.
-bool hasNonTrivialNonDebugUse(SILArgument *Arg);
-
 } // end namespace swift
 
 #endif

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -2,6 +2,7 @@ add_swift_library(swiftSIL STATIC
   AbstractionPattern.cpp
   BasicBlockUtils.cpp
   Bridging.cpp
+  DebugUtils.cpp
   Dominance.cpp
   DynamicCasts.cpp
   InstructionUtils.cpp

--- a/lib/SIL/DebugUtils.cpp
+++ b/lib/SIL/DebugUtils.cpp
@@ -1,0 +1,66 @@
+//===--- DebugUtils.cpp ---------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/SIL/DebugUtils.h"
+#include "swift/Basic/STLExtras.h"
+#include "swift/SIL/SILArgument.h"
+#include "swift/SIL/SILInstruction.h"
+#include "llvm/ADT/PointerIntPair.h"
+#include "llvm/ADT/SmallPtrSet.h"
+
+using namespace swift;
+
+bool swift::hasNonTrivialNonDebugTransitiveUsers(
+    PointerUnion<SILInstruction *, SILArgument *> V) {
+  llvm::SmallVector<SILInstruction *, 8> Worklist;
+  llvm::SmallPtrSet<SILInstruction *, 8> SeenInsts;
+
+  // Initialize our worklist.
+  if (auto *A = V.dyn_cast<SILArgument *>()) {
+    for (Operand *Op : getNonDebugUses(SILValue(A))) {
+      auto *User = Op->getUser();
+      if (!SeenInsts.insert(User).second)
+        continue;
+      Worklist.push_back(User);
+    }
+  } else {
+    auto *I = V.get<SILInstruction *>();
+    SeenInsts.insert(I);
+    Worklist.push_back(I);
+  }
+
+  while (!Worklist.empty()) {
+    SILInstruction *U = Worklist.pop_back_val();
+    assert(SeenInsts.count(U) &&
+           "Worklist should only contain seen instructions?!");
+
+    // If U is a terminator inst, return false.
+    if (isa<TermInst>(U))
+      return true;
+
+    // If U has side effects...
+    if (U->mayHaveSideEffects())
+      return true;
+
+    // Otherwise add all non-debug uses of I that we have not seen yet to the
+    // worklist.
+    for (SILValue Result : U->getResults()) {
+      for (Operand *I : getNonDebugUses(Result)) {
+        auto *User = I->getUser();
+        if (!SeenInsts.insert(User).second)
+          continue;
+        Worklist.push_back(User);
+      }
+    }
+  }
+  return false;
+}

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -837,7 +837,7 @@ bool FunctionSignatureTransform::DeadArgumentAnalyzeParameters() {
     }
 
     // Check whether argument is dead.
-    if (!hasNonTrivialNonDebugUse(Args[i])) {
+    if (!hasNonTrivialNonDebugTransitiveUsers(Args[i])) {
       A.IsEntirelyDead = true;
       SignatureOptimize = true;
       if (Args[i]->isSelf())

--- a/lib/SILOptimizer/Utils/FunctionSignatureOptUtils.cpp
+++ b/lib/SILOptimizer/Utils/FunctionSignatureOptUtils.cpp
@@ -28,35 +28,6 @@ llvm::cl::opt<bool> FSOEnableGenerics(
     llvm::cl::desc("Support function signature optimization "
                    "of generic functions"));
 
-bool swift::hasNonTrivialNonDebugUse(SILArgument *Arg) {
-  llvm::SmallVector<SILInstruction *, 8> Worklist;
-  llvm::SmallPtrSet<SILInstruction *, 8> SeenInsts;
-
-  for (Operand *I : getNonDebugUses(SILValue(Arg)))
-    Worklist.push_back(I->getUser());
-
-  while (!Worklist.empty()) {
-    SILInstruction *U = Worklist.pop_back_val();
-    if (!SeenInsts.insert(U).second)
-      continue;
-
-    // If U is a terminator inst, return false.
-    if (isa<TermInst>(U))
-      return true;
-
-    // If U has side effects...
-    if (U->mayHaveSideEffects()) 
-      return true;
-
-    // Otherwise add all non-debug uses of I to the worklist.
-    for (auto result : U->getResults()) {
-      for (Operand *I : getNonDebugUses(result))
-        Worklist.push_back(I->getUser());
-    }
-  }
-  return false;
-}
-
 static bool isSpecializableRepresentation(SILFunctionTypeRepresentation Rep,
                                           bool OptForPartialApply) {
   switch (Rep) {


### PR DESCRIPTION
…sitiveUsers and move to DebugUtils.

I am getting rid of FunctionSignatureOptUtils. It is only used by
FunctionSignatureOpts, so it should either be a local utility file whose header
lives in ./lib or integrated into FunctionSignatureOpts. Beyond this utility
function (which seems like a generally useful thing that should be in
DebugUtils), the only other thing left in FunctionSignatureOptUtils is part of
the heuristic of FunctionSignatureOpts. It should really be in that file.

rdar://38196046