### PR TITLE
[4.2] [Type checker] Prefer available declarations in AnyObject lookup.

### DIFF
--- a/test/Constraints/dynamic_lookup.swift
+++ b/test/Constraints/dynamic_lookup.swift
@@ -312,3 +312,27 @@ let _: DynamicIUO? = o[dyn_iuo]
 o[dyn_iuo] = dyn_iuo // expected-error {{cannot assign to immutable expression of type 'DynamicIUO??'}}
 o[dyn_iuo]! = dyn_iuo // expected-error {{cannot assign to immutable expression of type 'DynamicIUO?'}}
 o[dyn_iuo]!! = dyn_iuo // expected-error {{cannot assign to immutable expression of type 'DynamicIUO'}}
+
+
+// Check that we avoid picking an unavailable overload if there's an
+// alternative.
+class OverloadedWithUnavailable1 {
+  @objc func overloadedWithUnavailableA() { }
+
+  @objc
+  @available(swift, obsoleted: 3)
+  func overloadedWithUnavailableB() { }
+}
+
+class OverloadedWithUnavailable2 {
+  @available(swift, obsoleted: 3)
+  @objc func overloadedWithUnavailableA() { }
+
+  @objc func overloadedWithUnavailableB() { }
+}
+
+func testOverloadedWithUnavailable(ao: AnyObject) {
+  ao.overloadedWithUnavailableA()
+  ao.overloadedWithUnavailableB()
+}
+


### PR DESCRIPTION
When we perform AnyObject lookup, we can find multiple declarations with
the same signature. When we do so, we pick fairly arbitrarily among them.
However, make sure that we don’t pick an unavailable declaration when
an available declaration is… available.

Fixes rdar://problem/39115471.
