### PR TITLE
stubs: silence pedantic warning (NFC)

### DIFF
--- a/stdlib/public/stubs/SwiftNativeNSXXXBaseARC.m
+++ b/stdlib/public/stubs/SwiftNativeNSXXXBaseARC.m
@@ -82,4 +82,8 @@ swift_stdlib_NSStringUppercaseString(NSString *SWIFT_NS_RELEASES_ARGUMENT str) {
   }
 }
 
+#else
+
+extern char ignore_pedantic_warning;
+
 #endif


### PR DESCRIPTION
C requires that there is at least one declaration in a translation unit.
Because this file is ObjC and not ObjC++, this restriction applies.  Add
a declaration to silence the warning in the case that ObjC interop is
disabled.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
