### PR TITLE
IRGen: Ensure collocation of relative pointers in resilient witness tables

### DIFF
--- a/lib/IRGen/IRGen.cpp
+++ b/lib/IRGen/IRGen.cpp
@@ -933,8 +933,8 @@ static void performParallelIRGeneration(
   }
 
   // Emit the module contents.
-  irgen.emitGlobalTopLevel();
-  
+  irgen.emitGlobalTopLevel(true /*emitForParallelEmission*/);
+
   for (auto *File : M->getFiles()) {
     if (auto *SF = dyn_cast<SourceFile>(File)) {
       IRGenModule *IGM = irgen.getGenModule(SF);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -309,7 +309,11 @@ public:
   
   /// Emit functions, variables and tables which are needed anyway, e.g. because
   /// they are externally visible.
-  void emitGlobalTopLevel();
+  /// If \p emitForParallelEmission is true ensures that symbols that are
+  /// expressed as relative pointers are collocated in the same output module
+  /// with their base symbol. For example, witness methods need to be collocated
+  /// with the witness table in the same LLVM module.
+  void emitGlobalTopLevel(bool emitForParallelEmission = false);
 
   /// Emit references to each of the protocol descriptors defined in this
   /// IR module.
@@ -1256,6 +1260,8 @@ public:
   void addSwiftErrorAttributes(llvm::AttributeList &attrs, unsigned argIndex);
 
   void emitSharedContextDescriptor(DeclContext *dc);
+
+  void ensureRelativeSymbolCollocation(SILWitnessTable &wt);
 
 private:
   llvm::Constant *

--- a/test/multifile/Inputs/resilient-witness-2.swift
+++ b/test/multifile/Inputs/resilient-witness-2.swift
@@ -1,0 +1,3 @@
+public func test() {
+  inlineThis(Character("1"))
+}

--- a/test/multifile/resilient-witness.swift
+++ b/test/multifile/resilient-witness.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -module-name test -num-threads 1 -O -c -g %S/Inputs/resilient-witness-2.swift %s -o %t/resilient-witness-2.o -o %t/resilient-witness.o
+// RUN: %target-swift-frontend -module-name test -num-threads 1 -O -emit-ir -g %S/Inputs/resilient-witness-2.swift %s -o %t/resilient-witness-2.ll -o %t/resilient-witness.ll
+// RUN: %FileCheck %s < %t/resilient-witness.ll
+
+// We used to crash on this test case during code generation because the
+// resilient witness table and the witness of the equatable conformance was
+// emitted into different files. Because the witness is expressed as a relative
+// pointer this was problematic.
+
+class Context {
+  enum SomeEnum: Int {
+    case One = 1
+    case MinusOne = -1
+
+    init?(_ delimiter: Character) {
+      switch delimiter {
+      case "1":
+        self = .One
+      case "-":
+        self = .MinusOne
+      default:
+        return nil
+      }
+    }
+  }
+  private struct SomeEnumStruct {
+    var e: SomeEnum?
+  }
+
+  private var arr: [SomeEnumStruct?] = []
+}
+
+public func inlineThis(_ char: Character) {
+  if Context.SomeEnum(char) == .MinusOne {
+    print("foobar")
+  }
+}
+
+// The witness table and witness definition need to be in the same file.
+
+// CHECK: @"$S4test7ContextC8SomeEnumOs9EquatableAAWr" = {{.*}}sub {{.*}} @"$S4test7ContextC8SomeEnumOs9EquatableAAsAFP2eeoiySbx_xtFZTW" {{.*}} @"$S4test7ContextC8SomeEnumOs9EquatableAAWr"
+
+// CHECK: define{{.*}}@"$S4test7ContextC8SomeEnumOs9EquatableAAsAFP2eeoiySbx_xtFZTW"({{.*}}){{.*}} {
+// CHECK-NEXT: entry:


### PR DESCRIPTION

Ensure collocation by recording the dependence between witness table and
witness before functions are processed. Debug info of inlined function
scopes can reference the witness and will cause the wrong IRGenModule to
be associated before lazy witness tables are processed.

No, I am not sure that this is the only instance of this but the same
solution can apply to other instances if we find them.

rdar://39116991