### PR TITLE
build: PIC-ify the dynamic SDK overlay

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -439,6 +439,11 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
       SHIMS_INCLUDE_FLAG, searchPathOpts.RuntimeResourcePath,
   });
 
+  // Enable Position Independence.  `-fPIC` is not supported on Windows, which
+  // is implicitly position independent.
+  if (!triple.isOSWindows())
+    invocationArgStrs.insert(invocationArgStrs.end(), {"-fPIC"});
+
   // Enable modules.
   invocationArgStrs.insert(invocationArgStrs.end(), {
       "-fmodules",


### PR DESCRIPTION
The dynamic SDK overlay needs to be built with -fPIC.  Ensure that the
clang importer is marking the external globals appropriately.  This was
caught by building the swiftGlibc SDK overlay component in a dynamic
configuration.  Failure to do so will create RIP-relative references on
x86_64 which may overflow at runtime.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
