### PR TITLE
Sema: Fix setter visibility computation when checking key path literals.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4033,7 +4033,12 @@ ConstraintSystem::simplifyKeyPathConstraint(Type keyPathTy,
         return SolutionKind::Error;
       }
       
-      if (!storage->isSettable(DC)) {
+      // See whether key paths can store to this component. (Key paths don't
+      // get any special power from being formed in certain contexts, such
+      // as the ability to assign to `let`s in initialization contexts, so
+      // we pass null for the DC to `isSettable` here.)
+      if (!storage->isSettable(nullptr)
+          || !storage->isSetterAccessibleFrom(DC)) {
         // A non-settable component makes the key path read-only, unless
         // a reference-writable component shows up later.
         capability = ReadOnly;

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -499,6 +499,52 @@ func sr6744() {
     _ = get(for: \.value)
 }
 
+struct VisibilityTesting {
+  private(set) var x: Int
+  fileprivate(set) var y: Int
+  let z: Int
+
+  // Key path exprs should not get special dispensation to write to lets
+  // in init contexts
+  init() {
+    var xRef = \VisibilityTesting.x
+    var yRef = \VisibilityTesting.y
+    var zRef = \VisibilityTesting.z
+    expect(&xRef,
+      toHaveType: Exactly<WritableKeyPath<VisibilityTesting, Int>>.self)
+    expect(&yRef,
+      toHaveType: Exactly<WritableKeyPath<VisibilityTesting, Int>>.self)
+    expect(&zRef,
+      toHaveType: Exactly<KeyPath<VisibilityTesting, Int>>.self)
+  }
+
+  func inPrivateContext() {
+    var xRef = \VisibilityTesting.x
+    var yRef = \VisibilityTesting.y
+    var zRef = \VisibilityTesting.z
+    expect(&xRef,
+      toHaveType: Exactly<WritableKeyPath<VisibilityTesting, Int>>.self)
+    expect(&yRef,
+      toHaveType: Exactly<WritableKeyPath<VisibilityTesting, Int>>.self)
+    expect(&zRef,
+      toHaveType: Exactly<KeyPath<VisibilityTesting, Int>>.self)
+  }
+}
+
+struct VisibilityTesting2 {
+  func inFilePrivateContext() {
+    var xRef = \VisibilityTesting.x
+    var yRef = \VisibilityTesting.y
+    var zRef = \VisibilityTesting.z
+    expect(&xRef,
+      toHaveType: Exactly<KeyPath<VisibilityTesting, Int>>.self)
+    expect(&yRef,
+      toHaveType: Exactly<WritableKeyPath<VisibilityTesting, Int>>.self)
+    expect(&zRef,
+      toHaveType: Exactly<KeyPath<VisibilityTesting, Int>>.self)
+  }
+}
+
 func testSyntaxErrors() { // expected-note{{}}
   _ = \.  ; // expected-error{{expected member name following '.'}}
   _ = \.a ;


### PR DESCRIPTION
`AbstractStorageDecl::isSettable` by itself doesn't account for access control, so we need to check `isSetterAccessibleFrom` as well. Furthermore, key paths should not get the special context-sensitive privileges direct accesses do, such as initializers being able to assign into `let` properties. Fix the type checking logic here to only create a statically writable KeyPath value when the referenced declaration has a setter visible independent of current context. Fixes SR-6667 | rdar://problem/36257266.