### PR TITLE
unittests/AST: Fix link library ordering for Linux

### DIFF
--- a/lib/Parse/CMakeLists.txt
+++ b/lib/Parse/CMakeLists.txt
@@ -13,7 +13,7 @@ add_swift_library(swiftParse STATIC
   Scope.cpp
   SyntaxParsingContext.cpp
   LINK_LIBRARIES
-    swiftAST
     swiftSyntax
 )
 
+target_link_libraries(swiftParse INTERFACE swiftAST)

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -8,9 +8,9 @@ add_swift_unittest(SwiftASTTests
 
 target_link_libraries(SwiftASTTests
    PRIVATE
-   swiftAST
    # FIXME: Circular dependencies.
    swiftParse
+   swiftAST # Ordering matters, swiftAST needs to be after swiftParse
    swiftSema
    swiftSIL
 )


### PR DESCRIPTION
This is unforutante, but swiftAST needs to be after swiftParse, otherwise
SwiftASTTests will fail to link, saying that libParse can't find a symbol in
libAST, specifically:
(swift::DeclNameLoc::DeclNameLoc(swift::ASTContext&, swift::SourceLoc, swift::SourceLoc, llvm::ArrayRef<swift::SourceLoc>, swift::SourceLoc))