### PR TITLE
SR-7266: Avoid nesting of ReversedCollection

### DIFF
--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -49,8 +49,6 @@ extension MutableCollection where Self: BidirectionalCollection {
 /// * `c.reversed()` does not create new storage
 /// * `c.reversed().map(f)` maps eagerly and returns a new array
 /// * `c.lazy.reversed().map(f)` maps lazily and returns a `LazyMapCollection`
-///
-/// - See also: `ReversedRandomAccessCollection`
 @_fixed_layout
 public struct ReversedCollection<Base: BidirectionalCollection> {
   public let _base: Base
@@ -84,7 +82,7 @@ extension ReversedCollection {
     }
   }
 }
- 
+
 extension ReversedCollection.Iterator: IteratorProtocol, Sequence {
   public typealias Element = Base.Element
   
@@ -252,6 +250,17 @@ extension ReversedCollection: BidirectionalCollection {
 }
 
 extension ReversedCollection: RandomAccessCollection where Base: RandomAccessCollection { }
+
+extension ReversedCollection {
+  /// Reversing a reversed collection returns the original collection.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @available(swift, introduced: 4.2)
+  public func reversed() -> Base {
+    return _base
+  }
+}
 
 extension BidirectionalCollection {
   /// Returns a view presenting the elements of the collection in reverse

--- a/test/stdlib/ReverseCompatibility.swift
+++ b/test/stdlib/ReverseCompatibility.swift
@@ -32,3 +32,5 @@ tests.test("Double reverse type/Collection/\(swiftVersion)") {
   }
   backwardCompatible(Array(0..<10))
 }
+
+runAllTests()

--- a/test/stdlib/ReverseCompatibility.swift
+++ b/test/stdlib/ReverseCompatibility.swift
@@ -1,0 +1,34 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -o %t/a.out3 -swift-version 3 && %target-run %t/a.out3
+// RUN: %target-build-swift %s -o %t/a.out4 -swift-version 4 && %target-run %t/a.out4
+// RUN: %target-build-swift %s -o %t/a.out5 -swift-version 5 && %target-run %t/a.out5
+// REQUIRES: executable_test
+
+import StdlibUnittest
+
+#if swift(>=4.2)
+let swiftVersion = ">=4.2"
+#else
+let swiftVersion = "<4.2"
+#endif
+
+let tests = TestSuite("ReverseCompatibility")
+
+tests.test("Double reverse type/Collection/\(swiftVersion)") {
+  func reverse<C : BidirectionalCollection>(_ xs: C) {
+    var result = xs.reversed().reversed()
+#if swift(>=4.2)
+    expectType(C.self, &result)
+#else
+    expectType(ReversedCollection<ReversedCollection<C>>.self, &result)
+#endif
+  }
+  reverse(Array(0..<10))
+
+  func backwardCompatible<C : BidirectionalCollection>(_ xs: C) {
+    typealias ExpectedType = ReversedCollection<ReversedCollection<C>>
+    var result: ExpectedType = xs.reversed().reversed()
+    expectType(ExpectedType.self, &result)
+  }
+  backwardCompatible(Array(0..<10))
+}


### PR DESCRIPTION
Applying reversed() two times should return original collection.

<!-- What's in this pull request? -->
First round of fixes for the SR-7266, to avoid nesting multiple ReversedCollections and instead return the original collection with two consecutive .reversed() functions.

Does not yet fix the .lazy use case.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7266](https://bugs.swift.org/browse/SR-7266).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->