### PR TITLE
[Tests] Remove dependence on specific deployment target versions

### DIFF
--- a/test/ClangImporter/CoreGraphics_test.swift
+++ b/test/ClangImporter/CoreGraphics_test.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -target x86_64-apple-macosx10.11 -module-name=cgtest -emit-ir -O %s | %FileCheck %s
+// RUN: %target-swift-frontend -module-name=cgtest -emit-ir -O %s | %FileCheck %s
 
 // Test some imported CG APIs
 import CoreGraphics
@@ -75,6 +75,7 @@ public func pdfOperations(_ context: CGContext) {
 // Test some more recently renamed APIs
 
 // CHECK-LABEL: define swiftcc void {{.*}}testColorRenames{{.*}} {
+@available(macOS 10.11, *)
 public func testColorRenames(color: CGColor,
                              intent: CGColorRenderingIntent) {
   let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!

--- a/test/IRGen/objc_retainAutoreleasedReturnValue.swift
+++ b/test/IRGen/objc_retainAutoreleasedReturnValue.swift
@@ -1,6 +1,6 @@
 
-// RUN: %target-swift-frontend -module-name objc_retainAutoreleasedReturnValue -target x86_64-apple-macosx10.12 -assume-parsing-unqualified-ownership-sil -import-objc-header %S/Inputs/StaticInline.h %s -emit-ir | %FileCheck %s
-// RUN: %target-swift-frontend -module-name objc_retainAutoreleasedReturnValue -O -target x86_64-apple-macosx10.12 -assume-parsing-unqualified-ownership-sil -import-objc-header %S/Inputs/StaticInline.h %s -emit-ir | %FileCheck %s --check-prefix=OPT
+// RUN: %target-swift-frontend -module-name objc_retainAutoreleasedReturnValue -assume-parsing-unqualified-ownership-sil -import-objc-header %S/Inputs/StaticInline.h %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -module-name objc_retainAutoreleasedReturnValue -O -assume-parsing-unqualified-ownership-sil -import-objc-header %S/Inputs/StaticInline.h %s -emit-ir | %FileCheck %s --check-prefix=OPT
 
 // REQUIRES: objc_interop
 // REQUIRES: CPU=x86_64

--- a/test/IRGen/osx-targets.swift
+++ b/test/IRGen/osx-targets.swift
@@ -1,11 +1,11 @@
 // RUN: %swift %s -emit-ir | %FileCheck %s
-// RUN: %swift -target x86_64-apple-macosx10.12 %s -emit-ir | %FileCheck -check-prefix=CHECK-SPECIFIC %s
-// RUN: %swift -target x86_64-apple-darwin16 %s -emit-ir | %FileCheck -check-prefix=CHECK-SPECIFIC %s
+// RUN: %swift -target x86_64-apple-macosx10.51 %s -emit-ir | %FileCheck -check-prefix=CHECK-SPECIFIC %s
+// RUN: %swift -target x86_64-apple-darwin55 %s -emit-ir | %FileCheck -check-prefix=CHECK-SPECIFIC %s
 
 // REQUIRES: OS=macosx
 
 // CHECK: target triple = "x86_64-apple-macosx10.
-// CHECK-SPECIFIC: target triple = "x86_64-apple-macosx10.12.0"
+// CHECK-SPECIFIC: target triple = "x86_64-apple-macosx10.51.0"
 
 public func anchor() {}
 anchor()

--- a/test/attr/attr_availability_narrow.swift
+++ b/test/attr/attr_availability_narrow.swift
@@ -4,64 +4,64 @@
 
 import Foundation
 
-@available(macOS 10.12.2, *)
+@available(macOS 10.50.2, *)
 func foo() { }
 
 func useFoo() {
-  if #available(macOS 10.12.1, *) {
-    foo() // expected-error {{'foo()' is only available on OS X 10.12.2 or newer}} {{23-30=10.12.2}}
+  if #available(macOS 10.50.1, *) {
+    foo() // expected-error {{'foo()' is only available on OS X 10.50.2 or newer}} {{23-30=10.50.2}}
   }
 }
 
 func useFooDifferentSpelling() {
-  if #available(OSX 10.12.1, *) {
-    foo() // expected-error {{'foo()' is only available on OS X 10.12.2 or newer}} {{21-28=10.12.2}}
+  if #available(OSX 10.50.1, *) {
+    foo() // expected-error {{'foo()' is only available on OS X 10.50.2 or newer}} {{21-28=10.50.2}}
   }
 }
 
 func useFooAlreadyOkRange() {
-  if #available(OSX 10.13, *) {
+  if #available(OSX 10.51, *) {
     foo()
   }
 }
 
 func useFooUnaffectedSimilarText() {
-  if #available(iOS 10.12.10, OSX 10.12.1, *) {
-    foo() // expected-error {{'foo()' is only available on OS X 10.12.2 or newer}} {{35-42=10.12.2}}
+  if #available(iOS 10.50.10, OSX 10.50.1, *) {
+    foo() // expected-error {{'foo()' is only available on OS X 10.50.2 or newer}} {{35-42=10.50.2}}
   }
 }
 
 func useFooWayOff() {
     // expected-note@-1{{add @available attribute to enclosing global function}}
   if #available(OSX 10.10, *) {
-    foo() // expected-error {{'foo()' is only available on OS X 10.12.2 or newer}}
+    foo() // expected-error {{'foo()' is only available on OS X 10.50.2 or newer}}
     // expected-note@-1{{add 'if #available' version check}}
   }
 }
 
-@available(OSX 10.12, *)
+@available(OSX 10.50, *)
 class FooUser {
   func useFoo() {
-    foo() // expected-error {{'foo()' is only available on OS X 10.12.2 or newer}} {{16-21=10.12.2}}
+    foo() // expected-error {{'foo()' is only available on OS X 10.50.2 or newer}} {{16-21=10.50.2}}
   }
 }
 
-@available(OSX, introduced: 10.12, obsoleted: 10.12.4)
+@available(OSX, introduced: 10.50, obsoleted: 10.50.4)
 class FooUser2 {
   func useFoo() {
-    foo() // expected-error {{'foo()' is only available on OS X 10.12.2 or newer}} {{29-34=10.12.2}}
+    foo() // expected-error {{'foo()' is only available on OS X 10.50.2 or newer}} {{29-34=10.50.2}}
   }
 }
 
-@available(OSX, introduced: 10.12, obsoleted: 10.12.4)
+@available(OSX, introduced: 10.50, obsoleted: 10.50.4)
 @objc
 class FooUser3 : NSObject {
   func useFoo() {
-    foo() // expected-error {{'foo()' is only available on OS X 10.12.2 or newer}} {{29-34=10.12.2}}
+    foo() // expected-error {{'foo()' is only available on OS X 10.50.2 or newer}} {{29-34=10.50.2}}
   }
 }
 
-@available(OSX, introduced: 10.12.4)
+@available(OSX, introduced: 10.50.4)
 class FooUserOkRange {
   func useFoo() {
     foo()

--- a/test/decl/protocol/conforms/nscoding_availability_osx.swift
+++ b/test/decl/protocol/conforms/nscoding_availability_osx.swift
@@ -1,6 +1,6 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -target x86_64-apple-macosx10.11 -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -target x86_64-apple-macosx10.50 -verify
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -target x86_64-apple-macosx10.11 -dump-ast 2> %t.ast
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -parse-as-library -swift-version 4 %s -target x86_64-apple-macosx10.50 -dump-ast 2> %t.ast
 // RUN: %FileCheck %s < %t.ast
 
 // REQUIRES: objc_interop
@@ -9,13 +9,13 @@
 import Foundation
 
 // Nested classes that aren't available in our deployment target.
-@available(OSX 10.12, *)
+@available(OSX 10.51, *)
 class CodingI : NSObject, NSCoding {
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
 }
 
-@available(OSX 10.12, *)
+@available(OSX 10.51, *)
 class OuterCodingJ {
   // CHECK-NOT: class_decl "NestedJ"{{.*}}@_staticInitializeObjCMetadata
   class NestedJ : CodingI { }


### PR DESCRIPTION
Generalize severral tests so they are not locked to specific deployment target
versions.
