### PR TITLE
[IDE] Don't emit “Convert to Trailing Closure” for trailing closure

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -2695,6 +2695,10 @@ static CallExpr *findTrailingClosureTarget(SourceManager &SM,
     return nullptr;
   CallExpr *CE = cast<CallExpr>(Finder.getContexts().back().get<Expr*>());
 
+  if (CE->hasTrailingClosure())
+    // Call expression already has a trailing closure.
+    return nullptr;
+
   // The last arugment is a closure?
   Expr *Args = CE->getArg();
   if (!Args)

--- a/test/refactoring/RefactoringKind/trailingclosure.swift
+++ b/test/refactoring/RefactoringKind/trailingclosure.swift
@@ -12,6 +12,10 @@ func testTrailingClosure() -> String {
   [1,2,3]
     .filter({ $0 % 2 == 0 })
     .map({ $0 + 1 })
+
+  Foo.foo { 1 }
+  Foo.bar { print(3); return 1 }
+  Foo().qux(x: 1) { 1 }
 }
 
 // RUN: %refactor -source-filename %s -pos=7:3 | %FileCheck %s -check-prefix=CHECK-TRAILING-CLOSURE
@@ -38,6 +42,10 @@ func testTrailingClosure() -> String {
 // RUN: %refactor -source-filename %s -pos=12:4 | %FileCheck %s -check-prefix=CHECK-NO-TRAILING-CLOSURE
 // RUN: %refactor -source-filename %s -pos=13:5 | %FileCheck %s -check-prefix=CHECK-TRAILING-CLOSURE
 // RUN: %refactor -source-filename %s -pos=14:5 | %FileCheck %s -check-prefix=CHECK-TRAILING-CLOSURE
+
+// RUN: %refactor -source-filename %s -pos=16:7 | %FileCheck %s -check-prefix=CHECK-NO-TRAILING-CLOSURE
+// RUN: %refactor -source-filename %s -pos=17:7 | %FileCheck %s -check-prefix=CHECK-NO-TRAILING-CLOSURE
+// RUN: %refactor -source-filename %s -pos=18:9 | %FileCheck %s -check-prefix=CHECK-NO-TRAILING-CLOSURE
 
 // CHECK-TRAILING-CLOSURE: Convert To Trailing Closure
 


### PR DESCRIPTION
Previously, it didn't consider whether the call is already using trailing closure.

rdar://problem/39253640

