### PR TITLE
[Testing] Don't fill up /tmp while bisecting

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -21,9 +21,9 @@
 import os
 import platform
 import re
+import shutil
 import subprocess
 import sys
-import tempfile
 import socket
 import glob
 import pipes
@@ -326,13 +326,15 @@ config.swift_frontend_test_options = os.environ.get('SWIFT_FRONTEND_TEST_OPTIONS
 config.swift_driver_test_options = os.environ.get('SWIFT_DRIVER_TEST_OPTIONS', '')
 config.sil_test_options = os.environ.get('SIL_TEST_OPTIONS', '')
 
-clang_module_cache_path = tempfile.mkdtemp(prefix="swift-testsuite-clang-module-cache")
+clang_module_cache_path = config.swift_test_results_dir + "/clang-module-cache"
+shutil.rmtree(clang_module_cache_path, ignore_errors=True)
 mcp_opt = "-module-cache-path %r" % clang_module_cache_path
 clang_mcp_opt = "-fmodules-cache-path=%r" % clang_module_cache_path
 lit_config.note("Using Clang module cache: " + clang_module_cache_path)
 lit_config.note("Using test results dir: " + config.swift_test_results_dir)
 
-completion_cache_path = tempfile.mkdtemp(prefix="swift-testsuite-completion-cache")
+completion_cache_path = config.swift_test_results_dir + "/completion-cache"
+shutil.rmtree(completion_cache_path, ignore_errors=True)
 ccp_opt = "-completion-cache-path %r" % completion_cache_path
 lit_config.note("Using code completion cache: " + completion_cache_path)
 


### PR DESCRIPTION
Rather than leaving hundreds of temporary directories in /tmp, use the results directory for holding caches.