### PR TITLE
[4.1] IRGen: fix a wrong tail-call attribute in a partial apply forwarder

### DIFF
--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -1050,6 +1050,7 @@ static llvm::Function *emitPartialApplicationForwarder(IRGenModule &IGM,
       if (RetainableValue->getType() != subIGF.IGM.RefCountedPtrTy)
         RetainableValue = subIGF.Builder.CreateBitCast(
             RetainableValue, subIGF.IGM.RefCountedPtrTy);
+      needsAllocas = true;
       auto temporary = subIGF.createAlloca(RetainableValue->getType(),
                                            subIGF.IGM.getPointerAlignment(),
                                            "partial-apply.context");

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -131,7 +131,7 @@ sil public_external @indirect_consumed_captured_class_param : $@convention(thin)
 // CHECK-NOT:     load
 // CHECK-NOT:     retain
 // CHECK-NOT:     release
-// CHECK:         [[RESULT:%.*]] = tail call swiftcc i64 @indirect_consumed_captured_class_param(i64 %0, %T13partial_apply10SwiftClassC** noalias nocapture dereferenceable({{.*}}) [[X_CAST]])
+// CHECK:         [[RESULT:%.*]] = call swiftcc i64 @indirect_consumed_captured_class_param(i64 %0, %T13partial_apply10SwiftClassC** noalias nocapture dereferenceable({{.*}}) [[X_CAST]])
 // CHECK-NOT:     retain
 // CHECK-NOT:     release
 // CHECK:         ret i64 [[RESULT]]


### PR DESCRIPTION
When an alloca'd memory is passed to a function it must not be a tail call, because otherwise llvm's dead store elimination would eliminate all stores to it.

rdar://problem/39250070
https://bugs.swift.org/browse/SR-7064

* Explanation: When we create a partial apply forwarder thunk in IRGen we try to create a tail-call to the destination function. But this is not valid if the thunk contains any stack allocated memory. We check for this but missed one case. The result is that llvm's dead store elimination removed the store which initialized that memory. It resulted in a crash of an test app which uses RxSwift.
* Scope of Issue: It looks like that this scenario is not very common. On the other hand, it's hard to describe when it can happen.
* Origination: It seems that the bug was already there since a longer time, but uncovered by other changes in swift 4.1.
* Risk: Very low. It just makes the optimization to create a tail-call more conservative. The "needsAllocas" flag is only used to check if a tail-call can be created instead of a regular call.
* Reviewed By: Arnold
* Testing: There is a regression test for it