### PR TITLE
[TypeChecker] Fix lookup of the dependent type through typealias

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1300,10 +1300,9 @@ static Type resolveNestedIdentTypeComponent(
   // If the parent is a type parameter, the member is a dependent member,
   // and we skip much of the work below.
   if (parentTy->isTypeParameter()) {
-    auto memberType = resolver->resolveDependentMemberType(parentTy, DC,
-                                                      parentRange, comp);
-    assert(memberType && "Received null dependent member type");
-    return memberType;
+    if (auto memberType = resolver->resolveDependentMemberType(
+            parentTy, DC, parentRange, comp))
+      return memberType;
   }
 
   // Phase 2: If a declaration has already been bound, use it.

--- a/validation-test/compiler_crashers_2_fixed/0152-rdar39253925.swift
+++ b/validation-test/compiler_crashers_2_fixed/0152-rdar39253925.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift %s
+
+struct S {}
+
+protocol P {
+  typealias A<T> = A_<T, Self>
+}
+
+struct A_<T, P> {}
+
+extension S {
+  subscript<T : P, U>(_: T, _: KeyPath<T, T.A<U>>) -> U {
+    fatalError()
+  }
+}

--- a/validation-test/compiler_crashers_fixed/28785-membertype-received-null-dependent-member-type.swift
+++ b/validation-test/compiler_crashers_fixed/28785-membertype-received-null-dependent-member-type.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol b{{}class a<a{}func a:Self.a


### PR DESCRIPTION
While trying to resolve nested type component with type parameter
as a parent, try to resolve it as dependent member directly but
if that fails go through longer resolution path which is required
in case member type is accessed using `typealias`.

Resolves: rdar://problem/39253925

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
