### PR TITLE
[Coverage] Avoid emitting duplicate coverage mappings

### DIFF
--- a/lib/SIL/SILCoverageMap.cpp
+++ b/lib/SIL/SILCoverageMap.cpp
@@ -15,6 +15,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/ADT/STLExtras.h"
 #include "swift/SIL/SILCoverageMap.h"
 #include "swift/SIL/SILModule.h"
 
@@ -39,6 +40,13 @@ SILCoverageMap::create(SILModule &M, StringRef Filename, StringRef Name,
   // rather than relying on the flexible array trick.
   CM->MappedRegions = M.allocateCopy(MappedRegions);
   CM->Expressions = M.allocateCopy(Expressions);
+
+  // Assert that this coverage map is unique.
+  assert(llvm::none_of(M.coverageMaps,
+                       [&](const SILCoverageMap &OtherCM) {
+                         return OtherCM.PGOFuncName == CM->PGOFuncName;
+                       }) &&
+         "Duplicate coverage mapping for function");
 
   M.coverageMaps.push_back(CM);
   return CM;

--- a/lib/SIL/SILProfiler.cpp
+++ b/lib/SIL/SILProfiler.cpp
@@ -166,8 +166,12 @@ struct MapRegionCounters : public ASTWalker {
   bool walkToDeclPre(Decl *D) override {
     if (isUnmapped(D))
       return false;
-    if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D))
-      CounterMap[AFD->getBody()] = NextCounter++;
+    if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D)) {
+      bool FirstDecl = Parent.isNull();
+      if (FirstDecl)
+        CounterMap[AFD->getBody()] = NextCounter++;
+      return FirstDecl;
+    }
     if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D))
       CounterMap[TLCD->getBody()] = NextCounter++;
     return true;
@@ -749,8 +753,12 @@ public:
   bool walkToDeclPre(Decl *D) override {
     if (isUnmapped(D))
       return false;
-    if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D))
-      assignCounter(AFD->getBody());
+    if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D)) {
+      bool FirstDecl = Parent.isNull();
+      if (FirstDecl)
+        assignCounter(AFD->getBody());
+      return FirstDecl;
+    }
     else if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D))
       assignCounter(TLCD->getBody());
     return true;

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -483,6 +483,10 @@ static bool hasSILBody(FuncDecl *fd) {
   return fd->getBody(/*canSynthesize=*/false);
 }
 
+static bool haveProfiledAssociatedFuncDecl(SILDeclRef constant) {
+  return constant.isDefaultArgGenerator() || constant.isForeign;
+}
+
 SILFunction *SILGenModule::getFunction(SILDeclRef constant,
                                        ForDefinition_t forDefinition) {
   // If we already emitted the function, return it (potentially preparing it
@@ -496,7 +500,7 @@ SILFunction *SILGenModule::getFunction(SILDeclRef constant,
                                   constant, forDefinition);
 
   ASTNode profiledNode;
-  if (constant.hasDecl()) {
+  if (constant.hasDecl() && !haveProfiledAssociatedFuncDecl(constant)) {
     if (auto *fd = constant.getFuncDecl()) {
       if (hasSILBody(fd)) {
         // Set up the function for profiling instrumentation.

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -407,7 +407,6 @@ void SILGenFunction::emitClosure(AbstractClosureExpr *ace) {
   prepareEpilog(ace->getResultType(), ace->isBodyThrowing(),
                 CleanupLocation(ace));
   if (auto *ce = dyn_cast<ClosureExpr>(ace)) {
-    emitProfilerIncrement(ce);
     emitStmt(ce->getBody());
   } else {
     auto *autoclosure = cast<AutoClosureExpr>(ace);

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -412,7 +412,6 @@ void SILGenFunction::emitClosure(AbstractClosureExpr *ace) {
     auto *autoclosure = cast<AutoClosureExpr>(ace);
     // Closure expressions implicitly return the result of their body
     // expression.
-    emitProfilerIncrement(autoclosure);
     emitReturnExpr(ImplicitReturnLocation(ace),
                    autoclosure->getSingleExpressionBody());
   }

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -406,6 +406,7 @@ void SILGenFunction::emitClosure(AbstractClosureExpr *ace) {
              ace->isBodyThrowing());
   prepareEpilog(ace->getResultType(), ace->isBodyThrowing(),
                 CleanupLocation(ace));
+  emitProfilerIncrement(ace);
   if (auto *ce = dyn_cast<ClosureExpr>(ace)) {
     emitStmt(ce->getBody());
   } else {

--- a/test/SILGen/coverage_closures.swift
+++ b/test/SILGen/coverage_closures.swift
@@ -39,8 +39,11 @@ func foo() {
   let c1 = { (i1 : Int32, i2 : Int32) -> Bool in i1 < i2 }
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// f1 #1 ((Swift.Int32, Swift.Int32) -> Swift.Bool) -> Swift.Bool in coverage_closures.foo()
-// CHECK-NEXT: [[@LINE+2]]:55 -> [[@LINE+4]]:4 : 0
-// CHECK-NEXT: [[@LINE+2]]:29 -> [[@LINE+2]]:42 : 1
+// CHECK-NEXT: [[@LINE+5]]:55 -> [[@LINE+7]]:4 : 0
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// implicit closure #1 : @autoclosure () throws -> Swift.Bool in f1
+// CHECK-NEXT: [[@LINE+2]]:29 -> [[@LINE+2]]:42 : 0
   func f1(_ closure : (Int32, Int32) -> Bool) -> Bool {
     return closure(0, 1) && closure(1, 0)
   }
@@ -52,12 +55,15 @@ func foo() {
   f1 { i1, i2 in i1 > i2 }
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// closure #3 (Swift.Int32, Swift.Int32) -> Swift.Bool in coverage_closures.foo()
-// CHECK-NEXT: [[@LINE+2]]:6 -> [[@LINE+2]]:48 : 0
-// CHECK-NEXT: [[@LINE+1]]:36 -> [[@LINE+1]]:46 : 1
+// CHECK-NEXT: [[@LINE+5]]:6 -> [[@LINE+5]]:48 : 0
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// implicit closure #1 : @autoclosure () throws -> {{.*}} in coverage_closures.foo
+// CHECK-NEXT: [[@LINE+1]]:36 -> [[@LINE+1]]:46 : 0
   f1 { left, right in left == 0 || right == 1 }
 }
 // CHECK-LABEL: sil_coverage_map {{.*}}// closure #1 (Swift.Int32, Swift.Int32) -> Swift.Bool in coverage_closures.foo()
-// CHECK-NEXT: [[@LINE-21]]:12 -> [[@LINE-21]]:59 : 0
+// CHECK-NEXT: [[@LINE-27]]:12 -> [[@LINE-27]]:59 : 0
 
 // SR-2615: Implicit constructor decl has no body, and shouldn't be mapped
 struct C1 {

--- a/test/SILGen/coverage_closures.swift
+++ b/test/SILGen/coverage_closures.swift
@@ -1,8 +1,34 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_closures %s | %FileCheck %s
 
+// rdar://39200851: Closure in init method covered twice
+
+class C2 {
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_closures.C2.__allocating_init()
+// CHECK-NEXT:  [[@LINE+7]]:10 -> [[@LINE+11]]:4 : 0
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// closure #1 () -> () in coverage_closures.C2.init()
+// CHECK-NEXT:  [[@LINE+4]]:13 -> [[@LINE+6]]:6 : 0
+// CHECK-NEXT: }
+
+  init() {
+    let _ = { () in
+      print("hello")
+    }
+  }
+}
+
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_closures.bar
+// CHECK-NEXT:  [[@LINE+9]]:35 -> [[@LINE+13]]:2 : 0
+// CHECK-NEXT:  [[@LINE+9]]:44 -> [[@LINE+11]]:4 : 1
+// CHECK-NEXT:  [[@LINE+10]]:4 -> [[@LINE+11]]:2 : 0
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// closure #2 (Swift.Int32) -> Swift.Int32 in coverage_closures.bar
+// CHECK-NEXT:  [[@LINE+4]]:13 -> [[@LINE+4]]:42 : 0
+// CHECK-NEXT: }
+
 func bar(arr: [(Int32) -> Int32]) {
-  // CHECK: [[@LINE+1]]:13 -> [[@LINE+1]]:42
   for a in [{ (b : Int32) -> Int32 in b }] {
     a(0)
   }
@@ -10,22 +36,28 @@ func bar(arr: [(Int32) -> Int32]) {
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_closures.foo
 func foo() {
-  // CHECK: [[@LINE+1]]:12 -> [[@LINE+1]]:59 : 1
   let c1 = { (i1 : Int32, i2 : Int32) -> Bool in i1 < i2 }
 
+// CHECK-LABEL: sil_coverage_map {{.*}}// f1 #1 ((Swift.Int32, Swift.Int32) -> Swift.Bool) -> Swift.Bool in coverage_closures.foo()
+// CHECK-NEXT: [[@LINE+2]]:55 -> [[@LINE+4]]:4 : 0
+// CHECK-NEXT: [[@LINE+2]]:29 -> [[@LINE+2]]:42 : 1
   func f1(_ closure : (Int32, Int32) -> Bool) -> Bool {
-    // CHECK: [[@LINE-1]]:55 -> [[@LINE+3]]:4 : 2
-    // CHECK: [[@LINE+1]]:29 -> [[@LINE+1]]:42 : 3
     return closure(0, 1) && closure(1, 0)
   }
 
   f1(c1)
-  // CHECK: [[@LINE+1]]:6 -> [[@LINE+1]]:27 : 4
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// closure #2 (Swift.Int32, Swift.Int32) -> Swift.Bool in coverage_closures.foo()
+// CHECK-NEXT: [[@LINE+1]]:6 -> [[@LINE+1]]:27 : 0
   f1 { i1, i2 in i1 > i2 }
-  // CHECK: [[@LINE+2]]:6 -> [[@LINE+2]]:48 : 5
-  // CHECK: [[@LINE+1]]:36 -> [[@LINE+1]]:46 : 6
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// closure #3 (Swift.Int32, Swift.Int32) -> Swift.Bool in coverage_closures.foo()
+// CHECK-NEXT: [[@LINE+2]]:6 -> [[@LINE+2]]:48 : 0
+// CHECK-NEXT: [[@LINE+1]]:36 -> [[@LINE+1]]:46 : 1
   f1 { left, right in left == 0 || right == 1 }
 }
+// CHECK-LABEL: sil_coverage_map {{.*}}// closure #1 (Swift.Int32, Swift.Int32) -> Swift.Bool in coverage_closures.foo()
+// CHECK-NEXT: [[@LINE-21]]:12 -> [[@LINE-21]]:59 : 0
 
 // SR-2615: Implicit constructor decl has no body, and shouldn't be mapped
 struct C1 {
@@ -35,3 +67,4 @@ struct C1 {
 
 bar(arr: [{ x in x }])
 foo()
+let _ = C2()

--- a/test/SILGen/coverage_curry.swift
+++ b/test/SILGen/coverage_curry.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sil -module-name coverage_curry %s | %FileCheck %s
+
+struct S0 {
+  init(a: Int, b: Int) { }
+  func f1(a: Int, b: Int) -> Int { return a }
+}
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_curry.testS0CurriedInstanceMethods(s0: coverage_curry.S0, a: Swift.Int, b: Swift.Int)
+// CHECK-NEXT: [[@LINE+2]]:59 -> [[@LINE+8]]:2 : 0
+// CHECK-NEXT: }
+func testS0CurriedInstanceMethods(s0: S0, a: Int, b: Int) {
+  _ = S0.f1(s0)(a: a, b: a)
+  _ = (S0.f1)(s0)(a: a, b: a)
+  _ = ((S0.f1))(s0)(a: a, b: a)
+  _ = S0.f1(a:b:)(s0)(a, b)
+  let f1OneLevel = S0.f1(s0)
+}

--- a/test/SILGen/coverage_default_args.swift
+++ b/test/SILGen/coverage_default_args.swift
@@ -1,7 +1,8 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_default_args %s | %FileCheck %s
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_default_args.closureInArgs(f: (Swift.Int) -> Swift.Int) -> ()
-// CHECK-NEXT: [[@LINE+4]]:59 -> [[@LINE+6]]:2 : 0
+// CHECK-NEXT: [[@LINE+5]]:59 -> [[@LINE+7]]:2 : 0
+// CHECK-NOT: [[@LINE+4]]:59 -> [[@LINE+6]]:2 : 0
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// closure #1 (Swift.Int) -> Swift.Int in default argument 0 of coverage_default_args.closureInArgs(f: (Swift.Int) -> Swift.Int) -> ()
 // CHECK-NEXT: [[@LINE+1]]:41 -> [[@LINE+1]]:57 : 0

--- a/test/SILGen/coverage_default_args.swift
+++ b/test/SILGen/coverage_default_args.swift
@@ -1,8 +1,10 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_default_args %s | %FileCheck %s
 
-// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_default_args.closureInArgs
-// CHECK: [[@LINE+2]]:41 -> [[@LINE+2]]:57 : 1
-// CHECK: [[@LINE+1]]:59 -> {{[0-9]+}}:2 : 0
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_default_args.closureInArgs(f: (Swift.Int) -> Swift.Int) -> ()
+// CHECK-NEXT: [[@LINE+4]]:59 -> [[@LINE+6]]:2 : 0
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// closure #1 (Swift.Int) -> Swift.Int in default argument 0 of coverage_default_args.closureInArgs(f: (Swift.Int) -> Swift.Int) -> ()
+// CHECK-NEXT: [[@LINE+1]]:41 -> [[@LINE+1]]:57 : 0
 func closureInArgs(f : ((Int) -> Int) = { i1 in i1 + 1 }) {
   f(3)
 }

--- a/test/SILGen/coverage_nested_func.swift
+++ b/test/SILGen/coverage_nested_func.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sil -module-name coverage_autoclosure %s | %FileCheck %s
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_autoclosure.call_auto_closure()
+// CHECK-NEXT: [[@LINE+3]]:26 -> [[@LINE+10]]:2 : 0
+// CHECK-NEXT: }
+
+func call_auto_closure() {
+// CHECK-LABEL: sil_coverage_map {{.*}}// use_auto_closure #1 (@autoclosure () -> Swift.Bool) -> Swift.Bool in coverage_autoclosure.call_auto_closure()
+// CHECK-NEXT: [[@LINE+1]]:63 -> [[@LINE+3]]:4 : 0
+  func use_auto_closure(_ x: @autoclosure () -> Bool) -> Bool {
+    return x() // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+  }
+  let _ = use_auto_closure(false || true)
+}

--- a/test/SILGen/coverage_smoke.swift
+++ b/test/SILGen/coverage_smoke.swift
@@ -35,7 +35,7 @@ class Class1 {
   deinit {}
 }
 
-// CHECK-MAIN: Maximum function count: 1
+// CHECK-MAIN: Maximum function count: 3
 func main() {
 // CHECK-COV: {{ *}}[[@LINE+1]]|{{ *}}1{{.*}}f_public
   f_public()
@@ -79,10 +79,10 @@ func call_closure() { // CHECK-COV: {{ *}}[[@LINE]]|
 func call_auto_closure() {
   func use_auto_closure(_ x: @autoclosure () -> Bool) -> Bool {
     return x() && // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
-           x() || // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+           x() && // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
            x()    // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
   }
-  let _ = use_auto_closure(false || true) // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+  let _ = use_auto_closure(true) // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}3
 }
 
 main() // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1

--- a/test/SILGen/coverage_smoke.swift
+++ b/test/SILGen/coverage_smoke.swift
@@ -7,6 +7,7 @@
 // RUN: %llvm-profdata show %t/default.profdata -function=f_public | %FileCheck %s --check-prefix=CHECK-PUBLIC
 // RUN: %llvm-profdata show %t/default.profdata -function=main | %FileCheck %s --check-prefix=CHECK-MAIN
 // RUN: %llvm-cov show %t/main -instr-profile=%t/default.profdata | %FileCheck %s --check-prefix=CHECK-COV
+// RUN: %llvm-cov report %t/main -instr-profile=%t/default.profdata -show-functions %s | %FileCheck %s --check-prefix=CHECK-REPORT
 // RUN: rm -rf %t
 
 // REQUIRES: profile_runtime
@@ -68,5 +69,25 @@ repeat {             // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
   g1 += 1            // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
 } while g1 == 0      // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
 
+func call_closure() { // CHECK-COV: {{ *}}[[@LINE]]|
+  var x : Int32 = 0   // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+  ({ () -> () in      // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+    x += 1            // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+  })()                // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+}
+
+func call_auto_closure() {
+  func use_auto_closure(_ x: @autoclosure () -> Bool) -> Bool {
+    return x() && // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+           x() || // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+           x()    // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+  }
+  let _ = use_auto_closure(false || true) // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+}
+
 main() // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
 foo()  // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+call_closure()
+call_auto_closure()
+
+// CHECK-REPORT: TOTAL {{.*}} 100.00% {{.*}} 100.00%

--- a/test/SILGen/coverage_uikit.swift
+++ b/test/SILGen/coverage_uikit.swift
@@ -1,0 +1,14 @@
+// REQUIRES: OS=ios
+// REQUIRES: objc_interop
+
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sil -module-name coverage_uikit %s | %FileCheck %s
+
+import UIKit
+
+class ViewController: UIViewController {
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_uikit.ViewController.viewDidLoad() -> ()
+// CHECK-NEXT: [[@LINE+1]]:31 -> [[@LINE+3]]:4 : 0
+  override func viewDidLoad() {
+    super.viewDidLoad()
+  }
+}

--- a/test/SILGen/coverage_var_init.swift
+++ b/test/SILGen/coverage_var_init.swift
@@ -1,13 +1,13 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_var_init %s | %FileCheck %s
 
 final class VarInit {
-  // CHECK: sil_coverage_map {{.*}} $S17coverage_var_init7VarInitC04lazydE033_49373CB2DFB47C8DC62FA963604688DFLLSSvg 
-  // CHECK-NEXT: [[@LINE+1]]:42 -> [[@LINE+3]]:4 : 2
+  // CHECK: sil_coverage_map {{.*}} $S17coverage_var_init7VarInitC04lazydE033_49373CB2DFB47C8DC62FA963604688DFLLSSvgSSyXEfU_
+  // CHECK-NEXT: [[@LINE+1]]:42 -> [[@LINE+3]]:4 : 0
   private lazy var lazyVarInit: String = {
-    return "Hello"
+    return "lazyVarInit"
   }()
 
-  // CHECK: sil_coverage_map {{.*}} $S17coverage_var_init7VarInitC05basicdE033_49373CB2DFB47C8DC62FA963604688DFLLSSvpfiSSyXEfU_ 
+  // CHECK: sil_coverage_map {{.*}} $S17coverage_var_init7VarInitC05basicdE033_49373CB2DFB47C8DC62FA963604688DFLLSSvpfiSSyXEfU_
   // CHECK-NEXT: [[@LINE+1]]:38 -> [[@LINE+3]]:4 : 0
   private var basicVarInit: String = {
     return "Hello"

--- a/test/SILGen/instrprof_operators.swift
+++ b/test/SILGen/instrprof_operators.swift
@@ -3,7 +3,7 @@
 // CHECK: sil hidden @[[F_OPERATORS:.*operators.*]] :
 // CHECK: %[[NAME:.*]] = string_literal utf8 "{{.*}}instrprof_operators.swift:[[F_OPERATORS]]"
 // CHECK: %[[HASH:.*]] = integer_literal $Builtin.Int64,
-// CHECK: %[[NCOUNTS:.*]] = integer_literal $Builtin.Int32, 4
+// CHECK: %[[NCOUNTS:.*]] = integer_literal $Builtin.Int32, 2
 // CHECK: %[[INDEX:.*]] = integer_literal $Builtin.Int32, 0
 // CHECK: builtin "int_instrprof_increment"(%[[NAME]] : {{.*}}, %[[HASH]] : {{.*}}, %[[NCOUNTS]] : {{.*}}, %[[INDEX]] : {{.*}})
 func operators(a : Bool, b : Bool) {
@@ -12,8 +12,8 @@ func operators(a : Bool, b : Bool) {
 
 // CHECK: %[[NAME:.*]] = string_literal utf8 "{{.*}}instrprof_operators.swift:[[F_OPERATORS]]"
 // CHECK: %[[HASH:.*]] = integer_literal $Builtin.Int64,
-// CHECK: %[[NCOUNTS:.*]] = integer_literal $Builtin.Int32, 4
-// CHECK: %[[INDEX:.*]] = integer_literal $Builtin.Int32, 3
+// CHECK: %[[NCOUNTS:.*]] = integer_literal $Builtin.Int32, 2
+// CHECK: %[[INDEX:.*]] = integer_literal $Builtin.Int32, 1
 // CHECK: builtin "int_instrprof_increment"(%[[NAME]] : {{.*}}, %[[HASH]] : {{.*}}, %[[NCOUNTS]] : {{.*}}, %[[INDEX]] : {{.*}})
   let e = c ? a : b
 
@@ -21,17 +21,17 @@ func operators(a : Bool, b : Bool) {
 }
 
 // CHECK: implicit closure
-// CHECK: %[[NAME:.*]] = string_literal utf8 "{{.*}}instrprof_operators.swift:[[F_OPERATORS]]"
+// CHECK: %[[NAME:.*]] = string_literal utf8 "{{.*}}:$S19instrprof_operators0B01a1bySb_SbtFSbyKXKfu_"
 // CHECK: %[[HASH:.*]] = integer_literal $Builtin.Int64,
-// CHECK: %[[NCOUNTS:.*]] = integer_literal $Builtin.Int32, 4
-// CHECK: %[[INDEX:.*]] = integer_literal $Builtin.Int32, 1
+// CHECK: %[[NCOUNTS:.*]] = integer_literal $Builtin.Int32, 1
+// CHECK: %[[INDEX:.*]] = integer_literal $Builtin.Int32, 0
 // CHECK: builtin "int_instrprof_increment"(%[[NAME]] : {{.*}}, %[[HASH]] : {{.*}}, %[[NCOUNTS]] : {{.*}}, %[[INDEX]] : {{.*}})
 // CHECK-NOT: builtin "int_instrprof_increment"
 
 // CHECK: implicit closure
-// CHECK: %[[NAME:.*]] = string_literal utf8 "{{.*}}instrprof_operators.swift:[[F_OPERATORS]]"
+// CHECK: %[[NAME:.*]] = string_literal utf8 "{{.*}}:$S19instrprof_operators0B01a1bySb_SbtFSbyKXKfu0_"
 // CHECK: %[[HASH:.*]] = integer_literal $Builtin.Int64,
-// CHECK: %[[NCOUNTS:.*]] = integer_literal $Builtin.Int32, 4
-// CHECK: %[[INDEX:.*]] = integer_literal $Builtin.Int32, 2
+// CHECK: %[[NCOUNTS:.*]] = integer_literal $Builtin.Int32, 1
+// CHECK: %[[INDEX:.*]] = integer_literal $Builtin.Int32, 0
 // CHECK: builtin "int_instrprof_increment"(%[[NAME]] : {{.*}}, %[[HASH]] : {{.*}}, %[[NCOUNTS]] : {{.*}}, %[[INDEX]] : {{.*}})
 // CHECK-NOT: builtin "int_instrprof_increment"


### PR DESCRIPTION
- Only instrument closures and nested functions once.
- Only visit functions to build coverage mappings once (and assert that we don't create duplicate coverage mappings).

Addresses rdar://39200851 and rdar://39297172.