### PR TITLE
[Sema] Explicit error for "extension GenericClass : ObjcProtocol".

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1458,6 +1458,11 @@ ERROR(objc_protocol_cannot_have_conditional_conformance,none,
       "type %0 cannot conditionally conform to @objc protocol %1 because "
       "Objective-C does not support conditional conformances",
       (Type, Type))
+ERROR(objc_protocol_in_generic_extension,none,
+      "conformance of "
+      "%select{|subclass of a }2%select{class from generic context|generic class}3"
+      " %0 to @objc protocol %1 cannot be in an extension",
+      (Type, Type, bool, bool))
 ERROR(conditional_conformances_cannot_imply_conformances,none,
       "conditional conformance of type %0 to protocol %1 does not imply conformance to "
       "inherited protocol %2",

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -793,6 +793,23 @@ public:
   /// `A<Int, NSObject>`.
   Type getSuperclassForDecl(const ClassDecl *classDecl);
 
+  /// \brief Whether this type or its superclasses has some form of generic
+  /// context.
+  ///
+  /// For example, given
+  ///
+  /// class A<X> {}
+  /// class B : A<Int> {}
+  /// struct C<T> {
+  ///   struct Inner {}
+  /// }
+  /// class D {}
+  /// class E: D {}
+  ///
+  /// Calling hasGenericAncestry() on `B` returns `A<Int>`, on `C<T>.Inner`
+  /// returns `C<T>.Inner`, but on `E` it returns null.
+  Type getGenericAncestor();
+
   /// \brief True if this type is the superclass of another type, or a generic
   /// type that could be bound to the superclass.
   ///

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3400,24 +3400,18 @@ static bool checkObjCInExtensionContext(TypeChecker &tc,
       return true;
     }
 
-    // Check if any classes in the inheritance hierarchy have generic
+    // Check if any Swift classes in the inheritance hierarchy have generic
     // parameters.
     // FIXME: This is a current limitation, not inherent. We don't have
     // a concrete class to attach Objective-C category metadata to.
-    Type extendedTy = ED->getDeclaredInterfaceType();
-    while (!extendedTy.isNull()) {
-      const ClassDecl *CD = extendedTy->getClassOrBoundGenericClass();
-      if (!CD)
-        break;
-
-      if (!CD->hasClangNode() && CD->getGenericParams()) {
+    if (auto generic = ED->getDeclaredInterfaceType()
+                           ->getGenericAncestor()) {
+      if (!generic->getClassOrBoundGenericClass()->hasClangNode()) {
         if (diagnose) {
           tc.diagnose(value, diag::objc_in_generic_extension);
         }
         return true;
       }
-
-      extendedTy = CD->getSuperclass();
     }
   }
 

--- a/test/decl/ext/extension-generic-objc-protocol.swift
+++ b/test/decl/ext/extension-generic-objc-protocol.swift
@@ -1,0 +1,29 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc protocol P {}
+
+public class C1<T> {}
+extension C1: P {}
+// expected-error@-1 {{conformance of generic class 'C1<T>' to @objc protocol 'P' cannot be in an extension}}
+
+public class C2<T> {}
+public class C3 : C2<Int> {}
+extension C3: P {}
+// expected-error@-1 {{conformance of subclass of a generic class 'C3' to @objc protocol 'P' cannot be in an extension}}
+
+class Outer<T> {
+    class Inner {}
+    class Inner2 {}
+}
+
+extension Outer.Inner: P {}
+// expected-error@-1 {{conformance of class from generic context 'Outer<T>.Inner' to @objc protocol 'P' cannot be in an extension}}
+
+class SubInner: Outer<Int>.Inner2 {}
+
+extension SubInner: P {}
+// expected-error@-1 {{conformance of subclass of a class from generic context 'SubInner' to @objc protocol 'P' cannot be in an extension}}

--- a/test/decl/ext/extension-generic-objc.swift
+++ b/test/decl/ext/extension-generic-objc.swift
@@ -47,3 +47,12 @@ extension D {
     func d2() {}
 }
 
+class Outer<T> {
+    class Inner {}
+}
+
+extension Outer.Inner {
+    @objc func outerInner1() {}
+    // expected-error@-1{{@objc is not supported within extensions of generic classes or classes that inherit from generic classes}}
+    func outerInner2() {}
+}

--- a/validation-test/compiler_crashers_2_fixed/0122-rdar27383752.swift
+++ b/validation-test/compiler_crashers_2_fixed/0122-rdar27383752.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: %target-swift-frontend %s -typecheck -verify
 // REQUIRES: OS=macosx
 
 import Foundation
@@ -27,6 +27,7 @@ class Bar<T>: NSObject {
 
 @available(macOS 10.12, *)
 extension Bar: NSFetchedResultsControllerDelegate {
+    // expected-error@-1 {{conformance of generic class 'Bar<T>' to @objc protocol 'NSFetchedResultsControllerDelegate' cannot be in an extension}}
     @nonobjc func controllerWillChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
     }
 }


### PR DESCRIPTION
If there was any requirements in the @objc protocol, the user got an error in
some form (a complaint about those requirements), but giving the direct error is
better, and handles @objc protocol with no requirements.

Fixes https://bugs.swift.org/browse/SR-7370 and rdar://problem/39239512.
