### PR TITLE
Small fixes for fragile class layout [4.2]

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -184,8 +184,9 @@ public:
         EmitStackPromotionChecks(false), PrintInlineTree(false),
         EmbedMode(IRGenEmbedMode::None), HasValueNamesSetting(false),
         ValueNames(false), EnableReflectionMetadata(true),
-        EnableReflectionNames(true), UseIncrementalLLVMCodeGen(true),
-        UseSwiftCall(false), GenerateProfile(false), CmdArgs(),
+        EnableReflectionNames(true), EnableClassResilience(false),
+        UseIncrementalLLVMCodeGen(true), UseSwiftCall(false),
+        GenerateProfile(false), CmdArgs(),
         SanitizeCoverage(llvm::SanitizerCoverageOptions()) {}
 
   // Get a hash of all options which influence the llvm compilation but are not

--- a/test/IRGen/objc_class_resilience.swift
+++ b/test/IRGen/objc_class_resilience.swift
@@ -1,0 +1,45 @@
+// RUN: %empty-directory(%t)
+// RUN: %utils/chex.py < %s > %t/objc_class_resilience.swift
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t)  -I %t -emit-ir -enable-resilience %t/objc_class_resilience.swift | %FileCheck %t/objc_class_resilience.swift --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend(mock-sdk: -sdk %S/Inputs -I %t)  -I %t -emit-ir -enable-resilience -O %t/objc_class_resilience.swift
+
+// REQUIRES: objc_interop
+
+import ObjectiveC
+import resilient_struct
+
+// CHECK-32-LABEL: @"$S21objc_class_resilience23ClassWithResilientFieldC5firstSivpWvd" = hidden global i32 4
+// CHECK-64-LABEL: @"$S21objc_class_resilience23ClassWithResilientFieldC5firstSivpWvd" = hidden global i64 8
+
+// CHECK-32-LABEL: @"$S21objc_class_resilience23ClassWithResilientFieldC6second16resilient_struct4SizeVvpWvd" = hidden global i32 8
+// CHECK-64-LABEL: @"$S21objc_class_resilience23ClassWithResilientFieldC6second16resilient_struct4SizeVvpWvd" = hidden global i64 16
+
+// CHECK-32-LABEL: @"$S21objc_class_resilience23ClassWithResilientFieldC5thirdSivpWvd" = hidden global i32 16
+// CHECK-64-LABEL: @"$S21objc_class_resilience23ClassWithResilientFieldC5thirdSivpWvd" = hidden global i64 32
+
+// CHECK-LABEL: @"OBJC_CLASS_$__TtC21objc_class_resilience23ClassWithResilientField" = alias
+
+// CHECK-LABEL: define hidden swiftcc {{i32|i64}} @"$S21objc_class_resilience23ClassWithResilientFieldC5firstSivg"(%T21objc_class_resilience23ClassWithResilientFieldC* swiftself) {{.*}} {
+// CHECK: %offset = load [[INT]], [[INT]]* @"$S21objc_class_resilience23ClassWithResilientFieldC5firstSivpWvd"
+// CHECK: }
+
+// CHECK-LABEL: define hidden swiftcc void @"$S21objc_class_resilience23ClassWithResilientFieldC6second16resilient_struct4SizeVvg"(%swift.opaque* noalias nocapture sret, %T21objc_class_resilience23ClassWithResilientFieldC* swiftself) {{.*}} {
+// CHECK: %offset = load [[INT]], [[INT]]* @"$S21objc_class_resilience23ClassWithResilientFieldC6second16resilient_struct4SizeVvpWvd"
+// CHECK: }
+
+// CHECK-LABEL: define hidden swiftcc {{i32|i64}} @"$S21objc_class_resilience23ClassWithResilientFieldC5thirdSivg"(%T21objc_class_resilience23ClassWithResilientFieldC* swiftself) {{.*}} {
+// CHECK: %offset = load [[INT]], [[INT]]* @"$S21objc_class_resilience23ClassWithResilientFieldC5thirdSivpWvd"
+// CHECK: }
+
+public class ClassWithResilientField : NSObject {
+  var first: Int
+  var second: Size
+  var third: Int
+
+  init(x: Int, y: Size, z: Int) {
+    self.first = x
+    self.second = y
+    self.third = z
+  }
+}

--- a/test/Interpreter/class_resilience.swift
+++ b/test/Interpreter/class_resilience.swift
@@ -1,19 +1,19 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-build-swift-dylib(%t/libresilient_struct.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
+// RUN: %target-build-swift-dylib(%t/libresilient_struct.%target-dylib-extension) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct
 // RUN: %target-codesign %t/libresilient_struct.%target-dylib-extension
 
-// RUN: %target-build-swift-dylib(%t/libresilient_class.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
+// RUN: %target-build-swift-dylib(%t/libresilient_class.%target-dylib-extension) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct
 // RUN: %target-codesign %t/libresilient_class.%target-dylib-extension
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct -lresilient_class -o %t/main -Xlinker -rpath -Xlinker %t
 
 // RUN: %target-run %t/main %t/libresilient_struct.%target-dylib-extension %t/libresilient_class.%target-dylib-extension
 
-// RUN: %target-build-swift-dylib(%t/libresilient_struct_wmo.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
+// RUN: %target-build-swift-dylib(%t/libresilient_struct_wmo.%target-dylib-extension) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_struct.swift -emit-module -emit-module-path %t/resilient_struct.swiftmodule -module-name resilient_struct -whole-module-optimization
 // RUN: %target-codesign %t/libresilient_struct_wmo.%target-dylib-extension
 
-// RUN: %target-build-swift-dylib(%t/libresilient_class_wmo.%target-dylib-extension) -Xfrontend -enable-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
+// RUN: %target-build-swift-dylib(%t/libresilient_class_wmo.%target-dylib-extension) -Xfrontend -enable-resilience -Xfrontend -enable-class-resilience %S/../Inputs/resilient_class.swift -emit-module -emit-module-path %t/resilient_class.swiftmodule -module-name resilient_class -I%t -L%t -lresilient_struct_wmo -whole-module-optimization
 // RUN: %target-codesign %t/libresilient_class_wmo.%target-dylib-extension
 
 // RUN: %target-build-swift %s -L %t -I %t -lresilient_struct_wmo -lresilient_class_wmo -o %t/main -Xlinker -rpath -Xlinker %t


### PR DESCRIPTION
- Narrow the fix to classes with @objc ancestry only

- Pass -enable-class-resilience in class resilience executable test so that
  we exercise resilience there

- Only enable fragile layout if the class has @objc ancestry

- Add an IRGen test