### PR TITLE
fix documentation comment of flatMap<SegmentOfResult : Sequence>

### DIFF
--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -675,10 +675,10 @@ extension Sequence {
   ///
   ///     let numbers = [1, 2, 3, 4]
   ///
-  ///     let mapped = numbers.map { Array(count: $0, repeatedValue: $0) }
+  ///     let mapped = numbers.map { Array(repeating: $0, count: $0) }
   ///     // [[1], [2, 2], [3, 3, 3], [4, 4, 4, 4]]
   ///
-  ///     let flatMapped = numbers.flatMap { Array(count: $0, repeatedValue: $0) }
+  ///     let flatMapped = numbers.flatMap { Array(repeating: $0, count: $0) }
   ///     // [1, 2, 2, 3, 3, 3, 4, 4, 4, 4]
   ///
   /// In fact, `s.flatMap(transform)`  is equivalent to


### PR DESCRIPTION
Hello, I'm Masa, Swift lover.

I noticed that one documentation comment remained old and doesn't change since 2 years ago, so I fixed it.

Is this PR acceptable?
This PR only includes a fixed single file.
I really appreciate it if you would tell me if there is a defect in this PR.

I'm deeply grateful to you for all your passionate work.

Thank you,
Masa