### PR TITLE
Don't include unavailable cases in switch exhaustivity checking

### DIFF
--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1048,6 +1048,13 @@ namespace {
             if (!eed->hasInterfaceType()) {
               return Space();
             }
+
+            // Don't force people to match unavailable cases; they can't even
+            // write them.
+            if (AvailableAttr::isUnavailable(eed)) {
+              return Space();
+            }
+
             auto eedTy = tp->getCanonicalType()
                            ->getTypeOfMember(E->getModuleContext(), eed,
                                              eed->getArgumentInterfaceType());

--- a/test/ClangImporter/Inputs/custom-modules/EnumExhaustivity.h
+++ b/test/ClangImporter/Inputs/custom-modules/EnumExhaustivity.h
@@ -41,3 +41,9 @@ enum ForwardDeclaredOnly {
   ForwardDeclaredOnlyA,
   ForwardDeclaredOnlyB
 };
+
+enum __attribute__((enum_extensibility(closed))) UnavailableCases {
+  UnavailableCasesA,
+  UnavailableCasesB,
+  UnavailableCasesThisIsTheUnavailableOne __attribute__((availability(swift, unavailable)))
+};

--- a/test/ClangImporter/enum-exhaustivity.swift
+++ b/test/ClangImporter/enum-exhaustivity.swift
@@ -55,3 +55,10 @@ func testAttributes(
   case .A, .B: break
   }
 }
+
+func testUnavailableCases(_ value: UnavailableCases) {
+  switch value { // okay
+  case .A: break
+  case .B: break
+  }
+}

--- a/test/Compatibility/exhaustive_switch.swift
+++ b/test/Compatibility/exhaustive_switch.swift
@@ -1124,3 +1124,52 @@ public func testNonExhaustiveWithinModule(_ value: NonExhaustive, _ payload: Non
   @unknown case _: break
   }
 }
+
+enum UnavailableCase {
+  case a
+  case b
+  @available(*, unavailable)
+  case oopsThisWasABadIdea
+}
+
+enum UnavailableCaseOSSpecific {
+  case a
+  case b
+
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  @available(macOS, unavailable)
+  @available(iOS, unavailable)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  case unavailableOnAllTheseApplePlatforms
+#else
+  @available(*, unavailable)
+  case dummyCaseForOtherPlatforms
+#endif
+}
+
+enum UnavailableCaseOSIntroduced {
+  case a
+  case b
+
+  @available(macOS 50, iOS 50, tvOS 50, watchOS 50, *)
+  case notYetIntroduced
+}
+
+func testUnavailableCases(_ x: UnavailableCase, _ y: UnavailableCaseOSSpecific, _ z: UnavailableCaseOSIntroduced) {
+  switch x {
+  case .a: break
+  case .b: break
+  } // no-error
+
+  switch y {
+  case .a: break
+  case .b: break
+  } // no-error
+
+  switch z {
+  case .a: break
+  case .b: break
+  case .notYetIntroduced: break
+  } // no-error
+}

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -1131,3 +1131,52 @@ public func testNonExhaustiveWithinModule(_ value: NonExhaustive, _ payload: Non
   @unknown case _: break
   }
 }
+
+enum UnavailableCase {
+  case a
+  case b
+  @available(*, unavailable)
+  case oopsThisWasABadIdea
+}
+
+enum UnavailableCaseOSSpecific {
+  case a
+  case b
+
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  @available(macOS, unavailable)
+  @available(iOS, unavailable)
+  @available(tvOS, unavailable)
+  @available(watchOS, unavailable)
+  case unavailableOnAllTheseApplePlatforms
+#else
+  @available(*, unavailable)
+  case dummyCaseForOtherPlatforms
+#endif
+}
+
+enum UnavailableCaseOSIntroduced {
+  case a
+  case b
+
+  @available(macOS 50, iOS 50, tvOS 50, watchOS 50, *)
+  case notYetIntroduced
+}
+
+func testUnavailableCases(_ x: UnavailableCase, _ y: UnavailableCaseOSSpecific, _ z: UnavailableCaseOSIntroduced) {
+  switch x {
+  case .a: break
+  case .b: break
+  } // no-error
+
+  switch y {
+  case .a: break
+  case .b: break
+  } // no-error
+
+  switch z {
+  case .a: break
+  case .b: break
+  case .notYetIntroduced: break
+  } // no-error
+}


### PR DESCRIPTION
The compiler won't let you use them in matches, so people have had to use catch-all cases instead. SILGen already handles this because of `@_downgrade_exhaustivity_check`, as well as non-exhaustive enums in Swift 4 mode.

rdar://problem/33246586