### PR TITLE
Avoid Float80 test data on platforms that lack Float80

### DIFF
--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -288,6 +288,7 @@ fileprivate let generatedCases_Double: [(Double, String)] = [
   (0x1.63ed4a60c9c91p+324, "4.751595491707413e+97")
 ]
 
+#if !os(Windows) && (arch(i386) || arch(x86_64))
 // Float80 found via Errol technique.
 //
 // As with Double, except for Float80.  The original list in this
@@ -334,6 +335,7 @@ fileprivate let generatedCases_Float80: [(Float80, String)] = [
   (0xd.4d512260c548f17p+242, "9.401053474771583868e+73"),
   (0xc.9240ee0f9d5e4d6p+252, "9.097859174935622588e+76"),
 ]
+#endif
 
 let PrintTests = TestSuite("FloatingPointPrinting")
 


### PR DESCRIPTION
This was an oversight from PR #15474.  Most of the Float80
tests were correctly compiled only on `!Windows && (x86 || i386)`
but I failed to mark some Float80 test data.

Fixes: Radar 39246292
