### PR TITLE
Swap two conditions to get dynamically looked-up optional requirement…

### DIFF
--- a/test/Constraints/sr7098.swift
+++ b/test/Constraints/sr7098.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+class C : NSObject, NSWobbling {
+  func wobble() {}
+  func returnMyself() -> Self { return self }
+}
+
+func testDynamicOptionalRequirement(_ a: AnyObject) {
+  a.optionalRequirement?()
+}


### PR DESCRIPTION
…s working.

This function (and `getTypeOfMemberReference`) deserve a deeper cleanup,
but for the moment lets unblock a compatibility test.

Fixes SR-7098 / rdar://problem/38394645
