### PR TITLE
[Coverage] Use a MapVector to store coverage maps in a module, NFC

### DIFF
--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -39,6 +39,7 @@
 #include "swift/SIL/TypeLowering.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FoldingSet.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/SetVector.h"
@@ -107,7 +108,8 @@ public:
   using PropertyListType = llvm::ilist<SILProperty>;
   using WitnessTableListType = llvm::ilist<SILWitnessTable>;
   using DefaultWitnessTableListType = llvm::ilist<SILDefaultWitnessTable>;
-  using CoverageMapListType = llvm::ilist<SILCoverageMap>;
+  using CoverageMapCollectionType =
+      llvm::MapVector<StringRef, SILCoverageMap *>;
   using LinkingMode = SILOptions::LinkingMode;
   using ActionCallback = std::function<void()>;
 
@@ -185,8 +187,8 @@ private:
   /// The list of SILGlobalVariables in the module.
   GlobalListType silGlobals;
 
-  // The list of SILCoverageMaps in the module.
-  CoverageMapListType coverageMaps;
+  // The map of SILCoverageMaps in the module.
+  CoverageMapCollectionType coverageMaps;
   
   // The list of SILProperties in the module.
   PropertyListType properties;
@@ -455,10 +457,12 @@ public:
     return {silGlobals.begin(), silGlobals.end()};
   }
 
-  using coverage_map_iterator = CoverageMapListType::iterator;
-  using coverage_map_const_iterator = CoverageMapListType::const_iterator;
-  CoverageMapListType &getCoverageMapList() { return coverageMaps; }
-  const CoverageMapListType &getCoverageMapList() const { return coverageMaps; }
+  using coverage_map_iterator = CoverageMapCollectionType::iterator;
+  using coverage_map_const_iterator = CoverageMapCollectionType::const_iterator;
+  CoverageMapCollectionType &getCoverageMaps() { return coverageMaps; }
+  const CoverageMapCollectionType &getCoverageMaps() const {
+    return coverageMaps;
+  }
 
   llvm::yaml::Output *getOptRecordStream() { return OptRecordStream.get(); }
   void setOptRecordStream(std::unique_ptr<llvm::yaml::Output> &&Stream,

--- a/lib/IRGen/GenCoverage.cpp
+++ b/lib/IRGen/GenCoverage.cpp
@@ -39,9 +39,9 @@ static std::string getCoverageSection(IRGenModule &IGM) {
 
 void IRGenModule::emitCoverageMapping() {
   std::vector<const SILCoverageMap *> Mappings;
-  for (const auto &M : getSILModule().getCoverageMapList())
-    if (M.hasSymtabEntry())
-      Mappings.push_back(&M);
+  for (const auto &M : getSILModule().getCoverageMaps())
+    if (M.second->hasSymtabEntry())
+      Mappings.push_back(M.second);
 
   // If there aren't any coverage maps, there's nothing to emit.
   if (Mappings.empty())

--- a/lib/SIL/SILCoverageMap.cpp
+++ b/lib/SIL/SILCoverageMap.cpp
@@ -41,14 +41,11 @@ SILCoverageMap::create(SILModule &M, StringRef Filename, StringRef Name,
   CM->MappedRegions = M.allocateCopy(MappedRegions);
   CM->Expressions = M.allocateCopy(Expressions);
 
-  // Assert that this coverage map is unique.
-  assert(llvm::none_of(M.coverageMaps,
-                       [&](const SILCoverageMap &OtherCM) {
-                         return OtherCM.PGOFuncName == CM->PGOFuncName;
-                       }) &&
-         "Duplicate coverage mapping for function");
+  auto result = M.coverageMaps.insert({CM->PGOFuncName, CM});
 
-  M.coverageMaps.push_back(CM);
+  // Assert that this coverage map is unique.
+  assert(result.second && "Duplicate coverage mapping for function");
+
   return CM;
 }
 

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2589,17 +2589,17 @@ printSILDefaultWitnessTables(SILPrintContext &Ctx,
 
 static void
 printSILCoverageMaps(SILPrintContext &Ctx,
-                     const SILModule::CoverageMapListType &CoverageMaps) {
+                     const SILModule::CoverageMapCollectionType &CoverageMaps) {
   if (!Ctx.sortSIL()) {
-    for (const SILCoverageMap &M : CoverageMaps)
-      M.print(Ctx);
+    for (const auto &M : CoverageMaps)
+      M.second->print(Ctx);
     return;
   }
 
   std::vector<const SILCoverageMap *> Maps;
   Maps.reserve(CoverageMaps.size());
-  for (const SILCoverageMap &M : CoverageMaps)
-    Maps.push_back(&M);
+  for (const auto &M : CoverageMaps)
+    Maps.push_back(M.second);
   std::sort(Maps.begin(), Maps.end(),
             [](const SILCoverageMap *LHS, const SILCoverageMap *RHS) -> bool {
               return LHS->getName().compare(RHS->getName()) == -1;
@@ -2696,7 +2696,7 @@ void SILModule::print(SILPrintContext &PrintCtx, ModuleDecl *M,
   printSILVTables(PrintCtx, getVTableList());
   printSILWitnessTables(PrintCtx, getWitnessTableList());
   printSILDefaultWitnessTables(PrintCtx, getDefaultWitnessTableList());
-  printSILCoverageMaps(PrintCtx, getCoverageMapList());
+  printSILCoverageMaps(PrintCtx, getCoverageMaps());
   printSILProperties(PrintCtx, getPropertyList());
   
   OS << "\n\n";


### PR DESCRIPTION
Using a MapVector allows coverage maps to be printed in a deterministic
order, and to be queried by function name. This makes an assertion
cheaper.

Depends on https://github.com/apple/swift/pull/15835.