### PR TITLE
Fix crash in typechecking invalid CodingKeys alias

### DIFF
--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -300,9 +300,17 @@ static CodingKeysValidity hasValidCodingKeysEnum(TypeChecker &tc,
   if (!tc.conformsToProtocol(codingKeysType, codingKeyProto,
                              target->getDeclContext(),
                              ConformanceCheckFlags::Used)) {
-    tc.diagnose(codingKeysTypeDecl->getLoc(),
-                diag::codable_codingkeys_type_does_not_conform_here,
+    // If CodingKeys is a typealias which doesn't point to a valid nominal type,
+    // codingKeysTypeDecl will be nullptr here. In that case, we need to warn on
+    // the location of the usage, since there isn't an underlying type to
+    // diagnose on.
+    SourceLoc loc = codingKeysTypeDecl ?
+                    codingKeysTypeDecl->getLoc() :
+                    cast<TypeDecl>(result)->getLoc();
+
+    tc.diagnose(loc, diag::codable_codingkeys_type_does_not_conform_here,
                 proto->getDeclaredType());
+
     return CodingKeysValidity(/*hasType=*/true, /*isValid=*/false);
   }
 

--- a/test/decl/protocol/special/coding/class_codable_codingkeys_typealias.swift
+++ b/test/decl/protocol/special/coding/class_codable_codingkeys_typealias.swift
@@ -25,3 +25,12 @@ let _ = SimpleClass.encode(to:)
 // The synthesized CodingKeys type should not be accessible from outside the
 // class.
 let _ = SimpleClass.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}
+
+// Classes with CodingKeys which are typealiases that don't point to a valid
+// nominal type should produce errors.
+struct ClassWithUndecredCodingKeys : Codable { // expected-error {{type 'ClassWithUndecredCodingKeys' does not conform to protocol 'Decodable'}}
+  // expected-error@-1 {{type 'ClassWithUndecredCodingKeys' does not conform to protocol 'Encodable'}}
+  private typealias CodingKeys = NonExistentType // expected-error {{use of undeclared type 'NonExistentType'}}
+  // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey}}
+  // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey}}
+}

--- a/test/decl/protocol/special/coding/struct_codable_codingkeys_typealias.swift
+++ b/test/decl/protocol/special/coding/struct_codable_codingkeys_typealias.swift
@@ -25,3 +25,12 @@ let _ = SimpleStruct.encode(to:)
 // The synthesized CodingKeys type should not be accessible from outside the
 // struct.
 let _ = SimpleStruct.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}
+
+// Structs with CodingKeys which are typealiases that don't point to a valid
+// nominal type should produce errors.
+struct StructWithUndeclaredCodingKeys : Codable { // expected-error {{type 'StructWithUndeclaredCodingKeys' does not conform to protocol 'Decodable'}}
+  // expected-error@-1 {{type 'StructWithUndeclaredCodingKeys' does not conform to protocol 'Encodable'}}
+  private typealias CodingKeys = NonExistentType // expected-error {{use of undeclared type 'NonExistentType'}}
+  // expected-note@-1 {{cannot automatically synthesize 'Decodable' because 'CodingKeys' does not conform to CodingKey}}
+  // expected-note@-2 {{cannot automatically synthesize 'Encodable' because 'CodingKeys' does not conform to CodingKey}}
+}


### PR DESCRIPTION
**What's in this pull request?**
Resolves a crash which would happen if your `Codable` type declared its `CodingKeys` enum as a typealias to a nonexistent type. This allows us to diagnose on the usage of the undeclared identifier instead of crashing.

Resolves rdar://problem/39021733.