### PR TITLE
[Coverage] Avoid emitting duplicate coverage mappings (#15835)

### DIFF
--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -39,6 +39,7 @@
 #include "swift/SIL/TypeLowering.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/FoldingSet.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/PointerIntPair.h"
 #include "llvm/ADT/SetVector.h"
@@ -107,7 +108,8 @@ public:
   using PropertyListType = llvm::ilist<SILProperty>;
   using WitnessTableListType = llvm::ilist<SILWitnessTable>;
   using DefaultWitnessTableListType = llvm::ilist<SILDefaultWitnessTable>;
-  using CoverageMapListType = llvm::ilist<SILCoverageMap>;
+  using CoverageMapCollectionType =
+      llvm::MapVector<StringRef, SILCoverageMap *>;
   using LinkingMode = SILOptions::LinkingMode;
   using ActionCallback = std::function<void()>;
 
@@ -185,8 +187,8 @@ private:
   /// The list of SILGlobalVariables in the module.
   GlobalListType silGlobals;
 
-  // The list of SILCoverageMaps in the module.
-  CoverageMapListType coverageMaps;
+  // The map of SILCoverageMaps in the module.
+  CoverageMapCollectionType coverageMaps;
   
   // The list of SILProperties in the module.
   PropertyListType properties;
@@ -455,10 +457,12 @@ public:
     return {silGlobals.begin(), silGlobals.end()};
   }
 
-  using coverage_map_iterator = CoverageMapListType::iterator;
-  using coverage_map_const_iterator = CoverageMapListType::const_iterator;
-  CoverageMapListType &getCoverageMapList() { return coverageMaps; }
-  const CoverageMapListType &getCoverageMapList() const { return coverageMaps; }
+  using coverage_map_iterator = CoverageMapCollectionType::iterator;
+  using coverage_map_const_iterator = CoverageMapCollectionType::const_iterator;
+  CoverageMapCollectionType &getCoverageMaps() { return coverageMaps; }
+  const CoverageMapCollectionType &getCoverageMaps() const {
+    return coverageMaps;
+  }
 
   llvm::yaml::Output *getOptRecordStream() { return OptRecordStream.get(); }
   void setOptRecordStream(std::unique_ptr<llvm::yaml::Output> &&Stream,

--- a/lib/IRGen/GenCoverage.cpp
+++ b/lib/IRGen/GenCoverage.cpp
@@ -39,9 +39,9 @@ static std::string getCoverageSection(IRGenModule &IGM) {
 
 void IRGenModule::emitCoverageMapping() {
   std::vector<const SILCoverageMap *> Mappings;
-  for (const auto &M : getSILModule().getCoverageMapList())
-    if (M.hasSymtabEntry())
-      Mappings.push_back(&M);
+  for (const auto &M : getSILModule().getCoverageMaps())
+    if (M.second->hasSymtabEntry())
+      Mappings.push_back(M.second);
 
   // If there aren't any coverage maps, there's nothing to emit.
   if (Mappings.empty())

--- a/lib/SIL/SILCoverageMap.cpp
+++ b/lib/SIL/SILCoverageMap.cpp
@@ -41,14 +41,11 @@ SILCoverageMap::create(SILModule &M, StringRef Filename, StringRef Name,
   CM->MappedRegions = M.allocateCopy(MappedRegions);
   CM->Expressions = M.allocateCopy(Expressions);
 
-  // Assert that this coverage map is unique.
-  assert(llvm::none_of(M.coverageMaps,
-                       [&](const SILCoverageMap &OtherCM) {
-                         return OtherCM.PGOFuncName == CM->PGOFuncName;
-                       }) &&
-         "Duplicate coverage mapping for function");
+  auto result = M.coverageMaps.insert({CM->PGOFuncName, CM});
 
-  M.coverageMaps.push_back(CM);
+  // Assert that this coverage map is unique.
+  assert(result.second && "Duplicate coverage mapping for function");
+
   return CM;
 }
 

--- a/lib/SIL/SILCoverageMap.cpp
+++ b/lib/SIL/SILCoverageMap.cpp
@@ -15,6 +15,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "llvm/ADT/STLExtras.h"
 #include "swift/SIL/SILCoverageMap.h"
 #include "swift/SIL/SILModule.h"
 
@@ -39,6 +40,13 @@ SILCoverageMap::create(SILModule &M, StringRef Filename, StringRef Name,
   // rather than relying on the flexible array trick.
   CM->MappedRegions = M.allocateCopy(MappedRegions);
   CM->Expressions = M.allocateCopy(Expressions);
+
+  // Assert that this coverage map is unique.
+  assert(llvm::none_of(M.coverageMaps,
+                       [&](const SILCoverageMap &OtherCM) {
+                         return OtherCM.PGOFuncName == CM->PGOFuncName;
+                       }) &&
+         "Duplicate coverage mapping for function");
 
   M.coverageMaps.push_back(CM);
   return CM;

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2587,17 +2587,17 @@ printSILDefaultWitnessTables(SILPrintContext &Ctx,
 
 static void
 printSILCoverageMaps(SILPrintContext &Ctx,
-                     const SILModule::CoverageMapListType &CoverageMaps) {
+                     const SILModule::CoverageMapCollectionType &CoverageMaps) {
   if (!Ctx.sortSIL()) {
-    for (const SILCoverageMap &M : CoverageMaps)
-      M.print(Ctx);
+    for (const auto &M : CoverageMaps)
+      M.second->print(Ctx);
     return;
   }
 
   std::vector<const SILCoverageMap *> Maps;
   Maps.reserve(CoverageMaps.size());
-  for (const SILCoverageMap &M : CoverageMaps)
-    Maps.push_back(&M);
+  for (const auto &M : CoverageMaps)
+    Maps.push_back(M.second);
   std::sort(Maps.begin(), Maps.end(),
             [](const SILCoverageMap *LHS, const SILCoverageMap *RHS) -> bool {
               return LHS->getName().compare(RHS->getName()) == -1;
@@ -2694,7 +2694,7 @@ void SILModule::print(SILPrintContext &PrintCtx, ModuleDecl *M,
   printSILVTables(PrintCtx, getVTableList());
   printSILWitnessTables(PrintCtx, getWitnessTableList());
   printSILDefaultWitnessTables(PrintCtx, getDefaultWitnessTableList());
-  printSILCoverageMaps(PrintCtx, getCoverageMapList());
+  printSILCoverageMaps(PrintCtx, getCoverageMaps());
   printSILProperties(PrintCtx, getPropertyList());
   
   OS << "\n\n";

--- a/lib/SIL/SILProfiler.cpp
+++ b/lib/SIL/SILProfiler.cpp
@@ -25,10 +25,19 @@
 
 using namespace swift;
 
+static bool isClosureWithBody(AbstractClosureExpr *ACE) {
+  if (auto *CE = dyn_cast<ClosureExpr>(ACE))
+    return CE->getBody();
+  if (auto *autoCE = dyn_cast<AutoClosureExpr>(ACE))
+    return autoCE->getBody();
+  return false;
+}
+
 static bool isUnmapped(ASTNode N) {
   if (auto *E = N.dyn_cast<Expr *>()) {
-    auto *CE = dyn_cast<ClosureExpr>(E);
-    return !CE || CE->isImplicit() || !CE->getBody();
+    auto *CE = dyn_cast<AbstractClosureExpr>(E);
+    return !CE || (!isa<AutoClosureExpr>(CE) && CE->isImplicit()) ||
+           !isClosureWithBody(CE);
   }
 
   auto *D = N.get<Decl *>();
@@ -95,7 +104,7 @@ static void walkForProfiling(ASTNode N, ASTWalker &Walker) {
     else if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D))
       TLCD->walk(Walker);
   } else if (auto *E = N.dyn_cast<Expr *>()) {
-    cast<ClosureExpr>(E)->walk(Walker);
+    cast<AbstractClosureExpr>(E)->walk(Walker);
   }
 }
 
@@ -136,6 +145,21 @@ SILProfiler *SILProfiler::create(SILModule &M, ForDefinition_t forDefinition,
 
 namespace {
 
+/// Special logic for handling closure visitation.
+///
+/// To prevent a closure from being mapped twice, avoid recursively walking
+/// into one unless the closure's function definition is being profiled.
+///
+/// Apply \p Func if the closure can be visited.
+template <typename F>
+std::pair<bool, Expr *> visitClosureExpr(ASTWalker &Walker,
+                                         AbstractClosureExpr *CE, F Func) {
+  if (!Walker.Parent.isNull())
+    return {false, CE};
+  Func();
+  return {true, CE};
+}
+
 /// An ASTWalker that maps ASTNodes to profiling counters.
 struct MapRegionCounters : public ASTWalker {
   /// The next counter value to assign.
@@ -150,8 +174,12 @@ struct MapRegionCounters : public ASTWalker {
   bool walkToDeclPre(Decl *D) override {
     if (isUnmapped(D))
       return false;
-    if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D))
-      CounterMap[AFD->getBody()] = NextCounter++;
+    if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D)) {
+      bool FirstDecl = Parent.isNull();
+      if (FirstDecl)
+        CounterMap[AFD->getBody()] = NextCounter++;
+      return FirstDecl;
+    }
     if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D))
       CounterMap[TLCD->getBody()] = NextCounter++;
     return true;
@@ -184,8 +212,9 @@ struct MapRegionCounters : public ASTWalker {
   std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
     if (auto *IE = dyn_cast<IfExpr>(E)) {
       CounterMap[IE->getThenExpr()] = NextCounter++;
-    } else if (isa<AutoClosureExpr>(E) || isa<ClosureExpr>(E)) {
-      CounterMap[E] = NextCounter++;
+    } else if (auto *ACE = dyn_cast<AbstractClosureExpr>(E)) {
+      return visitClosureExpr(*this, ACE,
+                              [&] { CounterMap[ACE] = NextCounter++; });
     }
     return {true, E};
   }
@@ -494,10 +523,12 @@ struct PGOMapping : public ASTWalker {
         }
       }
       LoadedCounterMap[elseExpr] = subtract(count, thenCount);
-    } else if (isa<AutoClosureExpr>(E) || isa<ClosureExpr>(E)) {
-      CounterMap[E] = NextCounter++;
-      auto eCount = loadExecutionCount(E);
-      LoadedCounterMap[E] = eCount;
+    } else if (auto *ACE = dyn_cast<AbstractClosureExpr>(E)) {
+      return visitClosureExpr(*this, ACE, [&] {
+        CounterMap[E] = NextCounter++;
+        auto eCount = loadExecutionCount(E);
+        LoadedCounterMap[E] = eCount;
+      });
     }
     return {true, E};
   }
@@ -724,8 +755,12 @@ public:
   bool walkToDeclPre(Decl *D) override {
     if (isUnmapped(D))
       return false;
-    if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D))
-      assignCounter(AFD->getBody());
+    if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D)) {
+      bool FirstDecl = Parent.isNull();
+      if (FirstDecl)
+        assignCounter(AFD->getBody());
+      return FirstDecl;
+    }
     else if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D))
       assignCounter(TLCD->getBody());
     return true;
@@ -859,16 +894,10 @@ public:
     if (!RegionStack.empty())
       extendRegion(E);
 
-    if (isa<AutoClosureExpr>(E)) {
-      // Autoclosures look strange if there isn't a region, since it looks like
-      // control flow starts partway through an expression. For now we skip
-      // these so we don't get odd behavior in default arguments and the like,
-      // but in the future we should consider creating appropriate regions for
-      // those expressions.
-      if (!RegionStack.empty())
-        assignCounter(E);
-    } else if (isa<ClosureExpr>(E)) {
-      assignCounter(E);
+    if (auto *ACE = dyn_cast<AbstractClosureExpr>(E)) {
+      auto Result = visitClosureExpr(*this, ACE, [&] { assignCounter(ACE); });
+      if (!Result.first)
+        return Result;
     } else if (auto *IE = dyn_cast<IfExpr>(E)) {
       CounterExpr &ThenCounter = assignCounter(IE->getThenExpr());
       if (RegionStack.empty())
@@ -939,7 +968,7 @@ void SILProfiler::assignRegionCounters() {
     }
   } else {
     auto *E = Root.get<Expr *>();
-    if (auto *CE = dyn_cast<ClosureExpr>(E)) {
+    if (auto *CE = dyn_cast<AbstractClosureExpr>(E)) {
       CurrentFuncName = SILDeclRef(CE).mangle();
       CurrentFuncLinkage = FormalLinkage::HiddenUnique;
     } else {

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -406,14 +406,13 @@ void SILGenFunction::emitClosure(AbstractClosureExpr *ace) {
              ace->isBodyThrowing());
   prepareEpilog(ace->getResultType(), ace->isBodyThrowing(),
                 CleanupLocation(ace));
+  emitProfilerIncrement(ace);
   if (auto *ce = dyn_cast<ClosureExpr>(ace)) {
-    emitProfilerIncrement(ce);
     emitStmt(ce->getBody());
   } else {
     auto *autoclosure = cast<AutoClosureExpr>(ace);
     // Closure expressions implicitly return the result of their body
     // expression.
-    emitProfilerIncrement(autoclosure);
     emitReturnExpr(ImplicitReturnLocation(ace),
                    autoclosure->getSingleExpressionBody());
   }

--- a/test/SILGen/coverage_closures.swift
+++ b/test/SILGen/coverage_closures.swift
@@ -1,8 +1,34 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_closures %s | %FileCheck %s
 
+// rdar://39200851: Closure in init method covered twice
+
+class C2 {
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_closures.C2.__allocating_init()
+// CHECK-NEXT:  [[@LINE+7]]:10 -> [[@LINE+11]]:4 : 0
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// closure #1 () -> () in coverage_closures.C2.init()
+// CHECK-NEXT:  [[@LINE+4]]:13 -> [[@LINE+6]]:6 : 0
+// CHECK-NEXT: }
+
+  init() {
+    let _ = { () in
+      print("hello")
+    }
+  }
+}
+
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_closures.bar
+// CHECK-NEXT:  [[@LINE+9]]:35 -> [[@LINE+13]]:2 : 0
+// CHECK-NEXT:  [[@LINE+9]]:44 -> [[@LINE+11]]:4 : 1
+// CHECK-NEXT:  [[@LINE+10]]:4 -> [[@LINE+11]]:2 : 0
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// closure #2 (Swift.Int32) -> Swift.Int32 in coverage_closures.bar
+// CHECK-NEXT:  [[@LINE+4]]:13 -> [[@LINE+4]]:42 : 0
+// CHECK-NEXT: }
+
 func bar(arr: [(Int32) -> Int32]) {
-  // CHECK: [[@LINE+1]]:13 -> [[@LINE+1]]:42
   for a in [{ (b : Int32) -> Int32 in b }] {
     a(0)
   }
@@ -10,22 +36,34 @@ func bar(arr: [(Int32) -> Int32]) {
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_closures.foo
 func foo() {
-  // CHECK: [[@LINE+1]]:12 -> [[@LINE+1]]:59 : 1
   let c1 = { (i1 : Int32, i2 : Int32) -> Bool in i1 < i2 }
 
+// CHECK-LABEL: sil_coverage_map {{.*}}// f1 #1 ((Swift.Int32, Swift.Int32) -> Swift.Bool) -> Swift.Bool in coverage_closures.foo()
+// CHECK-NEXT: [[@LINE+5]]:55 -> [[@LINE+7]]:4 : 0
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// implicit closure #1 : @autoclosure () throws -> Swift.Bool in f1
+// CHECK-NEXT: [[@LINE+2]]:29 -> [[@LINE+2]]:42 : 0
   func f1(_ closure : (Int32, Int32) -> Bool) -> Bool {
-    // CHECK: [[@LINE-1]]:55 -> [[@LINE+3]]:4 : 2
-    // CHECK: [[@LINE+1]]:29 -> [[@LINE+1]]:42 : 3
     return closure(0, 1) && closure(1, 0)
   }
 
   f1(c1)
-  // CHECK: [[@LINE+1]]:6 -> [[@LINE+1]]:27 : 4
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// closure #2 (Swift.Int32, Swift.Int32) -> Swift.Bool in coverage_closures.foo()
+// CHECK-NEXT: [[@LINE+1]]:6 -> [[@LINE+1]]:27 : 0
   f1 { i1, i2 in i1 > i2 }
-  // CHECK: [[@LINE+2]]:6 -> [[@LINE+2]]:48 : 5
-  // CHECK: [[@LINE+1]]:36 -> [[@LINE+1]]:46 : 6
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// closure #3 (Swift.Int32, Swift.Int32) -> Swift.Bool in coverage_closures.foo()
+// CHECK-NEXT: [[@LINE+5]]:6 -> [[@LINE+5]]:48 : 0
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// implicit closure #1 : @autoclosure () throws -> {{.*}} in coverage_closures.foo
+// CHECK-NEXT: [[@LINE+1]]:36 -> [[@LINE+1]]:46 : 0
   f1 { left, right in left == 0 || right == 1 }
 }
+// CHECK-LABEL: sil_coverage_map {{.*}}// closure #1 (Swift.Int32, Swift.Int32) -> Swift.Bool in coverage_closures.foo()
+// CHECK-NEXT: [[@LINE-27]]:12 -> [[@LINE-27]]:59 : 0
 
 // SR-2615: Implicit constructor decl has no body, and shouldn't be mapped
 struct C1 {
@@ -35,3 +73,4 @@ struct C1 {
 
 bar(arr: [{ x in x }])
 foo()
+let _ = C2()

--- a/test/SILGen/coverage_curry.swift
+++ b/test/SILGen/coverage_curry.swift
@@ -1,0 +1,17 @@
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sil -module-name coverage_curry %s | %FileCheck %s
+
+struct S0 {
+  init(a: Int, b: Int) { }
+  func f1(a: Int, b: Int) -> Int { return a }
+}
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_curry.testS0CurriedInstanceMethods(s0: coverage_curry.S0, a: Swift.Int, b: Swift.Int)
+// CHECK-NEXT: [[@LINE+2]]:59 -> [[@LINE+8]]:2 : 0
+// CHECK-NEXT: }
+func testS0CurriedInstanceMethods(s0: S0, a: Int, b: Int) {
+  _ = S0.f1(s0)(a: a, b: a)
+  _ = (S0.f1)(s0)(a: a, b: a)
+  _ = ((S0.f1))(s0)(a: a, b: a)
+  _ = S0.f1(a:b:)(s0)(a, b)
+  let f1OneLevel = S0.f1(s0)
+}

--- a/test/SILGen/coverage_default_args.swift
+++ b/test/SILGen/coverage_default_args.swift
@@ -1,8 +1,11 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_default_args %s | %FileCheck %s
 
-// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_default_args.closureInArgs
-// CHECK: [[@LINE+2]]:41 -> [[@LINE+2]]:57 : 1
-// CHECK: [[@LINE+1]]:59 -> {{[0-9]+}}:2 : 0
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_default_args.closureInArgs(f: (Swift.Int) -> Swift.Int) -> ()
+// CHECK-NEXT: [[@LINE+5]]:59 -> [[@LINE+7]]:2 : 0
+// CHECK-NOT: [[@LINE+4]]:59 -> [[@LINE+6]]:2 : 0
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// closure #1 (Swift.Int) -> Swift.Int in default argument 0 of coverage_default_args.closureInArgs(f: (Swift.Int) -> Swift.Int) -> ()
+// CHECK-NEXT: [[@LINE+1]]:41 -> [[@LINE+1]]:57 : 0
 func closureInArgs(f : ((Int) -> Int) = { i1 in i1 + 1 }) {
   f(3)
 }

--- a/test/SILGen/coverage_nested_func.swift
+++ b/test/SILGen/coverage_nested_func.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sil -module-name coverage_autoclosure %s | %FileCheck %s
+
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_autoclosure.call_auto_closure()
+// CHECK-NEXT: [[@LINE+3]]:26 -> [[@LINE+10]]:2 : 0
+// CHECK-NEXT: }
+
+func call_auto_closure() {
+// CHECK-LABEL: sil_coverage_map {{.*}}// use_auto_closure #1 (@autoclosure () -> Swift.Bool) -> Swift.Bool in coverage_autoclosure.call_auto_closure()
+// CHECK-NEXT: [[@LINE+1]]:63 -> [[@LINE+3]]:4 : 0
+  func use_auto_closure(_ x: @autoclosure () -> Bool) -> Bool {
+    return x() // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+  }
+  let _ = use_auto_closure(false || true)
+}

--- a/test/SILGen/coverage_smoke.swift
+++ b/test/SILGen/coverage_smoke.swift
@@ -7,6 +7,7 @@
 // RUN: %llvm-profdata show %t/default.profdata -function=f_public | %FileCheck %s --check-prefix=CHECK-PUBLIC
 // RUN: %llvm-profdata show %t/default.profdata -function=main | %FileCheck %s --check-prefix=CHECK-MAIN
 // RUN: %llvm-cov show %t/main -instr-profile=%t/default.profdata | %FileCheck %s --check-prefix=CHECK-COV
+// RUN: %llvm-cov report %t/main -instr-profile=%t/default.profdata -show-functions %s | %FileCheck %s --check-prefix=CHECK-REPORT
 // RUN: rm -rf %t
 
 // REQUIRES: profile_runtime
@@ -34,7 +35,7 @@ class Class1 {
   deinit {}
 }
 
-// CHECK-MAIN: Maximum function count: 1
+// CHECK-MAIN: Maximum function count: 3
 func main() {
 // CHECK-COV: {{ *}}[[@LINE+1]]|{{ *}}1{{.*}}f_public
   f_public()
@@ -68,5 +69,25 @@ repeat {             // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
   g1 += 1            // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
 } while g1 == 0      // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
 
+func call_closure() { // CHECK-COV: {{ *}}[[@LINE]]|
+  var x : Int32 = 0   // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+  ({ () -> () in      // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+    x += 1            // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+  })()                // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+}
+
+func call_auto_closure() {
+  func use_auto_closure(_ x: @autoclosure () -> Bool) -> Bool {
+    return x() && // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+           x() && // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+           x()    // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+  }
+  let _ = use_auto_closure(true) // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}3
+}
+
 main() // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
 foo()  // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+call_closure()
+call_auto_closure()
+
+// CHECK-REPORT: TOTAL {{.*}} 100.00% {{.*}} 100.00%

--- a/test/SILGen/coverage_uikit.swift
+++ b/test/SILGen/coverage_uikit.swift
@@ -1,0 +1,14 @@
+// REQUIRES: OS=ios
+// REQUIRES: objc_interop
+
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sil -module-name coverage_uikit %s | %FileCheck %s
+
+import UIKit
+
+class ViewController: UIViewController {
+// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_uikit.ViewController.viewDidLoad() -> ()
+// CHECK-NEXT: [[@LINE+1]]:31 -> [[@LINE+3]]:4 : 0
+  override func viewDidLoad() {
+    super.viewDidLoad()
+  }
+}

--- a/test/SILGen/coverage_var_init.swift
+++ b/test/SILGen/coverage_var_init.swift
@@ -1,13 +1,13 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_var_init %s | %FileCheck %s
 
 final class VarInit {
-  // CHECK: sil_coverage_map {{.*}} $S17coverage_var_init7VarInitC04lazydE033_49373CB2DFB47C8DC62FA963604688DFLLSSvg 
-  // CHECK-NEXT: [[@LINE+1]]:42 -> [[@LINE+3]]:4 : 2
+  // CHECK: sil_coverage_map {{.*}} $S17coverage_var_init7VarInitC04lazydE033_49373CB2DFB47C8DC62FA963604688DFLLSSvgSSyXEfU_
+  // CHECK-NEXT: [[@LINE+1]]:42 -> [[@LINE+3]]:4 : 0
   private lazy var lazyVarInit: String = {
-    return "Hello"
+    return "lazyVarInit"
   }()
 
-  // CHECK: sil_coverage_map {{.*}} $S17coverage_var_init7VarInitC05basicdE033_49373CB2DFB47C8DC62FA963604688DFLLSSvpfiSSyXEfU_ 
+  // CHECK: sil_coverage_map {{.*}} $S17coverage_var_init7VarInitC05basicdE033_49373CB2DFB47C8DC62FA963604688DFLLSSvpfiSSyXEfU_
   // CHECK-NEXT: [[@LINE+1]]:38 -> [[@LINE+3]]:4 : 0
   private var basicVarInit: String = {
     return "Hello"

--- a/test/SILGen/instrprof_operators.swift
+++ b/test/SILGen/instrprof_operators.swift
@@ -3,7 +3,7 @@
 // CHECK: sil hidden @[[F_OPERATORS:.*operators.*]] :
 // CHECK: %[[NAME:.*]] = string_literal utf8 "{{.*}}instrprof_operators.swift:[[F_OPERATORS]]"
 // CHECK: %[[HASH:.*]] = integer_literal $Builtin.Int64,
-// CHECK: %[[NCOUNTS:.*]] = integer_literal $Builtin.Int32, 4
+// CHECK: %[[NCOUNTS:.*]] = integer_literal $Builtin.Int32, 2
 // CHECK: %[[INDEX:.*]] = integer_literal $Builtin.Int32, 0
 // CHECK: builtin "int_instrprof_increment"(%[[NAME]] : {{.*}}, %[[HASH]] : {{.*}}, %[[NCOUNTS]] : {{.*}}, %[[INDEX]] : {{.*}})
 func operators(a : Bool, b : Bool) {
@@ -12,8 +12,8 @@ func operators(a : Bool, b : Bool) {
 
 // CHECK: %[[NAME:.*]] = string_literal utf8 "{{.*}}instrprof_operators.swift:[[F_OPERATORS]]"
 // CHECK: %[[HASH:.*]] = integer_literal $Builtin.Int64,
-// CHECK: %[[NCOUNTS:.*]] = integer_literal $Builtin.Int32, 4
-// CHECK: %[[INDEX:.*]] = integer_literal $Builtin.Int32, 3
+// CHECK: %[[NCOUNTS:.*]] = integer_literal $Builtin.Int32, 2
+// CHECK: %[[INDEX:.*]] = integer_literal $Builtin.Int32, 1
 // CHECK: builtin "int_instrprof_increment"(%[[NAME]] : {{.*}}, %[[HASH]] : {{.*}}, %[[NCOUNTS]] : {{.*}}, %[[INDEX]] : {{.*}})
   let e = c ? a : b
 
@@ -21,17 +21,17 @@ func operators(a : Bool, b : Bool) {
 }
 
 // CHECK: implicit closure
-// CHECK: %[[NAME:.*]] = string_literal utf8 "{{.*}}instrprof_operators.swift:[[F_OPERATORS]]"
+// CHECK: %[[NAME:.*]] = string_literal utf8 "{{.*}}:$S19instrprof_operators0B01a1bySb_SbtFSbyKXKfu_"
 // CHECK: %[[HASH:.*]] = integer_literal $Builtin.Int64,
-// CHECK: %[[NCOUNTS:.*]] = integer_literal $Builtin.Int32, 4
-// CHECK: %[[INDEX:.*]] = integer_literal $Builtin.Int32, 1
+// CHECK: %[[NCOUNTS:.*]] = integer_literal $Builtin.Int32, 1
+// CHECK: %[[INDEX:.*]] = integer_literal $Builtin.Int32, 0
 // CHECK: builtin "int_instrprof_increment"(%[[NAME]] : {{.*}}, %[[HASH]] : {{.*}}, %[[NCOUNTS]] : {{.*}}, %[[INDEX]] : {{.*}})
 // CHECK-NOT: builtin "int_instrprof_increment"
 
 // CHECK: implicit closure
-// CHECK: %[[NAME:.*]] = string_literal utf8 "{{.*}}instrprof_operators.swift:[[F_OPERATORS]]"
+// CHECK: %[[NAME:.*]] = string_literal utf8 "{{.*}}:$S19instrprof_operators0B01a1bySb_SbtFSbyKXKfu0_"
 // CHECK: %[[HASH:.*]] = integer_literal $Builtin.Int64,
-// CHECK: %[[NCOUNTS:.*]] = integer_literal $Builtin.Int32, 4
-// CHECK: %[[INDEX:.*]] = integer_literal $Builtin.Int32, 2
+// CHECK: %[[NCOUNTS:.*]] = integer_literal $Builtin.Int32, 1
+// CHECK: %[[INDEX:.*]] = integer_literal $Builtin.Int32, 0
 // CHECK: builtin "int_instrprof_increment"(%[[NAME]] : {{.*}}, %[[HASH]] : {{.*}}, %[[NCOUNTS]] : {{.*}}, %[[INDEX]] : {{.*}})
 // CHECK-NOT: builtin "int_instrprof_increment"


### PR DESCRIPTION
* [Coverage] Only instrument ClosureExprs once

ClosureExprs should only be visited for profiling purposes once, when
the SILFunction definition for the closure is being emitted.

This fixes an issue where the coverage tooling can't figure out how to
attribute the code coverage data of a closure to the right function.

rdar://39200851

* [Coverage] Assert that we don't emit duplicate coverage mappings

While generating SIL for a function with a default argument, we don't
need to emit two identical coverage mappings for the function body. The
same goes for functions which reference foreign functions.

This PR introduces an assertion which should catch similar problems in
the future.

rdar://39297172

* [Coverage] Only instrument nested functions once

Coverage counters for a nested function can be assigned once (in its
parent's scope), and then again (in its own scope). Nested functions
should only be visited for coverage mapping purposes once.

This is related to r://39200851, which is the same bug but for closures.

* [Coverage] Remove special handling of autoclosures

Treating AutoClosureExprs the same as ClosureExprs allows for some nice
code simplifications, and should be more robust.

* [Coverage] Only instrument curried instance methods once

Another fix related to r://39297172, in which we avoid instrumenting the
function associated with a curried thunk more than once.

(cherry picked from commit b36a551)