### PR TITLE
 [IRGen] Centralize the hack to collect autolink libraries from externals.

### DIFF
--- a/include/swift/IRGen/IRGenPublic.h
+++ b/include/swift/IRGen/IRGenPublic.h
@@ -14,9 +14,12 @@
 
 namespace llvm {
   class LLVMContext;
+  template<typename T, unsigned N> class SmallVector;
 }
 
 namespace swift {
+class ASTContext;
+class LinkLibrary;
 class SILModule;
 
 namespace irgen {
@@ -32,6 +35,16 @@ createIRGenModule(SILModule *SILMod, StringRef OutputFilename,
 
 /// Delete the IRGenModule and IRGenerator obtained by the above call.
 void deleteIRGenModule(std::pair<IRGenerator *, IRGenModule *> &Module);
+
+/// Collect the set of libraries to autolink against by mining the
+/// external definitions stored in an AST context.
+///
+/// This entire thing is a hack that we shouldn't need, but it reflects the
+/// fact that we can end up referencing something via an external definition
+/// (e.g., an imported Clang declaration) indirectly via the Clang importer
+/// that would not be visible directly. In such cases, we would fail to
+llvm::SmallVector<LinkLibrary, 4> collectLinkLibrariesFromExternals(
+                                                           ASTContext &ctx);
 
 } // end namespace irgen
 } // end namespace swift

--- a/include/swift/IRGen/IRGenPublic.h
+++ b/include/swift/IRGen/IRGenPublic.h
@@ -43,6 +43,10 @@ void deleteIRGenModule(std::pair<IRGenerator *, IRGenModule *> &Module);
 /// fact that we can end up referencing something via an external definition
 /// (e.g., an imported Clang declaration) indirectly via the Clang importer
 /// that would not be visible directly. In such cases, we would fail to
+/// link against the shared library that defines the entity or an overlay that
+/// is needed as part of its import from Clang (e.g., the Foundation overlay
+/// is needed when bridging NSString, even if there is no other mention of
+/// an entity from the Foundation overlay).
 llvm::SmallVector<LinkLibrary, 4> collectLinkLibrariesFromExternals(
                                                            ASTContext &ctx);
 

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2878,12 +2878,13 @@ void ProtocolConformance::dump(llvm::raw_ostream &out, unsigned indent) const {
         }
         PrintWithColorRAII(out, ParenthesisColor) << ')';
       });
+
+      for (auto conformance : normal->getSignatureConformances()) {
+        out << '\n';
+        conformance.dump(out, indent + 2);
+      }
     }
 
-    for (auto conformance : normal->getSignatureConformances()) {
-      out << '\n';
-      conformance.dump(out, indent + 2);
-    }
     for (auto requirement : normal->getConditionalRequirements()) {
       out << '\n';
       out.indent(indent + 2);

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1208,8 +1208,14 @@ void ModuleDecl::collectLinkLibraries(LinkLibraryCallback callback) {
 
 void
 SourceFile::collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const {
-  for (auto importPair : Imports)
-    importPair.first.second->collectLinkLibraries(callback);
+
+  const_cast<SourceFile *>(this)->forAllVisibleModules([&](swift::ModuleDecl::ImportedModule import) {
+    swift::ModuleDecl *next = import.second;
+    if (next->getName() == getParentModule()->getName())
+      return;
+
+    next->collectLinkLibraries(callback);
+  });
 }
 
 bool ModuleDecl::walk(ASTWalker &Walker) {

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -483,14 +483,8 @@ void IRGenModule::emitSourceFile(SourceFile &SF, unsigned StartElem) {
   for (auto *localDecl : SF.LocalTypeDecls)
     emitGlobalDecl(localDecl);
 
-  SF.forAllVisibleModules([&](swift::ModuleDecl::ImportedModule import) {
-    swift::ModuleDecl *next = import.second;
-    if (next->getName() == SF.getParentModule()->getName())
-      return;
-
-    next->collectLinkLibraries([this](LinkLibrary linkLib) {
+  SF.collectLinkLibraries([this](LinkLibrary linkLib) {
       this->addLinkLibrary(linkLib);
-    });
   });
 
   if (ObjCInterop)

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -27,6 +27,7 @@
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/LLVMContext.h"
 #include "swift/Frontend/Frontend.h"
+#include "swift/IRGen/IRGenPublic.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Config/config.h"
@@ -224,13 +225,9 @@ bool swift::immediate::IRGenImportedModules(
   });
 
   // Hack to handle thunks eagerly synthesized by the Clang importer.
-  swift::ModuleDecl *prev = nullptr;
-  for (auto external : CI.getASTContext().ExternalDefinitions) {
-    swift::ModuleDecl *next = external->getModuleContext();
-    if (next == prev)
-      continue;
-    next->collectLinkLibraries(addLinkLibrary);
-    prev = next;
+  for (const auto &linkLib :
+          irgen::collectLinkLibrariesFromExternals(CI.getASTContext())) {
+    addLinkLibrary(linkLib);
   }
 
   tryLoadLibraries(AllLinkLibraries, CI.getASTContext().SearchPathOpts,

--- a/stdlib/public/Reflection/CMakeLists.txt
+++ b/stdlib/public/Reflection/CMakeLists.txt
@@ -1,3 +1,12 @@
+set(swift_extra_sources)
+
+# When we're building with assertions, include the demangle node dumper to aid
+# in debugging.
+if (LLVM_ENABLE_ASSERTIONS)
+  list(APPEND swift_extra_sources "${SWIFT_SOURCE_DIR}/lib/Demangling/NodeDumper.cpp")
+endif(LLVM_ENABLE_ASSERTIONS)
+
+
 add_swift_library(swiftReflection STATIC TARGET_LIBRARY FORCE_BUILD_FOR_HOST_SDK
   MetadataSource.cpp
   TypeLowering.cpp
@@ -11,7 +20,8 @@ add_swift_library(swiftReflection STATIC TARGET_LIBRARY FORCE_BUILD_FOR_HOST_SDK
   "${SWIFT_SOURCE_DIR}/lib/Demangling/Punycode.cpp"
   "${SWIFT_SOURCE_DIR}/lib/Demangling/Remangler.cpp"
   "${SWIFT_SOURCE_DIR}/lib/Demangling/TypeDecoder.cpp"
-
+  ${swift_extra_sources}
   C_COMPILE_FLAGS ${SWIFT_RUNTIME_CXX_FLAGS}
   LINK_FLAGS ${SWIFT_RUNTIME_LINK_FLAGS}
   INSTALL_IN_COMPONENT dev)
+

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -73,6 +73,12 @@ set(swift_runtime_sources
     "${SWIFT_SOURCE_DIR}/lib/Demangling/ManglingUtils.cpp"
     "${SWIFT_SOURCE_DIR}/lib/Demangling/Punycode.cpp")
 
+# When we're building with assertions, include the demangle node dumper to aid
+# in debugging.
+if (LLVM_ENABLE_ASSERTIONS)
+  list(APPEND swift_runtime_sources "${SWIFT_SOURCE_DIR}/lib/Demangling/NodeDumper.cpp")
+endif(LLVM_ENABLE_ASSERTIONS)
+
 # Acknowledge that the following sources are known.
 set(LLVM_OPTIONAL_SOURCES
     MutexPThread.cpp


### PR DESCRIPTION
We had three copies of this code, each of which did a bit more work than
was actually necessary. Consolidate them and avoid calling
`collectLinkLibraries()` on a given module more than once within this
path.

... plus two trivial cleanups lying around.