### PR TITLE
[Sema] Attempt to replace usages of `getInput()` with `getParams()`

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1766,6 +1766,10 @@ public:
     return value.toRaw() == other.value.toRaw();
   }
 
+  bool operator!=(const ParameterTypeFlags &other) const {
+    return value.toRaw() != other.value.toRaw();
+  }
+
   uint8_t toRaw() const { return value.toRaw(); }
 };
 
@@ -2654,6 +2658,11 @@ public:
 
     /// Whether the parameter is marked 'owned'
     bool isOwned() const { return Flags.isOwned(); }
+
+    bool operator!=(Param const &b) const {
+      return Label != b.Label || !getType()->isEqual(b.getType()) ||
+             Flags != b.Flags;
+    }
   };
 
   class CanParam : public Param {
@@ -2840,6 +2849,14 @@ public:
                            bool canonicalVararg) {
     return composeInput(ctx, params.getOriginalArray(), canonicalVararg);
   }
+
+  /// \brief Given two arrays of parameters determine if they are equal.
+  static bool equalParams(ArrayRef<AnyFunctionType::Param> a,
+                          ArrayRef<AnyFunctionType::Param> b);
+
+  /// \brief Given an array of parameters and a composed parameter
+  /// type determine if they are equal.
+  static bool equalParams(ArrayRef<AnyFunctionType::Param> a, Type b);
 
   Type getInput() const { return Input; }
   Type getResult() const { return Output; }

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2857,11 +2857,6 @@ public:
   static bool equalParams(ArrayRef<AnyFunctionType::Param> a,
                           ArrayRef<AnyFunctionType::Param> b);
 
-  /// \brief Given an array of parameters and a composed parameter
-  /// type determine if they are equal.
-  static bool equalParams(ASTContext &ctx, ArrayRef<AnyFunctionType::Param> a,
-                          Type composedB);
-
   Type getInput() const { return Input; }
   Type getResult() const { return Output; }
   ArrayRef<AnyFunctionType::Param> getParams() const;

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2663,6 +2663,8 @@ public:
       return Label != b.Label || !getType()->isEqual(b.getType()) ||
              Flags != b.Flags;
     }
+
+    Param getWithoutLabel() const { return Param(Ty, Identifier(), Flags); }
   };
 
   class CanParam : public Param {

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3002,7 +3002,8 @@ decomposeArgType(Type type, ArrayRef<Identifier> argumentLabels);
 /// Break the parameter list into an array of booleans describing whether
 /// the argument type at each index has a default argument associated with
 /// it.
-void computeDefaultMap(Type type, const ValueDecl *paramOwner, unsigned level,
+void computeDefaultMap(ArrayRef<AnyFunctionType::Param> params,
+                       const ValueDecl *paramOwner, unsigned level,
                        SmallVectorImpl<bool> &outDefaultMap);
   
 /// Turn a param list into a symbolic and printable representation that does not

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2659,10 +2659,11 @@ public:
     /// Whether the parameter is marked 'owned'
     bool isOwned() const { return Flags.isOwned(); }
 
-    bool operator!=(Param const &b) const {
-      return Label != b.Label || !getType()->isEqual(b.getType()) ||
-             Flags != b.Flags;
+    bool operator==(Param const &b) const {
+      return Label == b.Label && getType()->isEqual(b.getType()) &&
+             Flags == b.Flags;
     }
+    bool operator!=(Param const &b) const { return !(*this == b); }
 
     Param getWithoutLabel() const { return Param(Ty, Identifier(), Flags); }
   };

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2858,7 +2858,8 @@ public:
 
   /// \brief Given an array of parameters and a composed parameter
   /// type determine if they are equal.
-  static bool equalParams(ArrayRef<AnyFunctionType::Param> a, Type b);
+  static bool equalParams(ASTContext &ctx, ArrayRef<AnyFunctionType::Param> a,
+                          Type composedB);
 
   Type getInput() const { return Input; }
   Type getResult() const { return Output; }

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3692,11 +3692,11 @@ bool AnyFunctionType::equalParams(ArrayRef<AnyFunctionType::Param> a,
   return true;
 }
 
-bool AnyFunctionType::equalParams(ArrayRef<AnyFunctionType::Param> a,
+bool AnyFunctionType::equalParams(ASTContext &ctx,
+                                  ArrayRef<AnyFunctionType::Param> a,
                                   Type composedB) {
-  llvm::SmallVector<AnyFunctionType::Param, 4> b;
-  AnyFunctionType::decomposeInput(composedB, b);
-  return equalParams(a, b);
+  auto composedA = AnyFunctionType::composeInput(ctx, a, false);
+  return composedA->isEqual(composedB);
 }
 
 FunctionType *FunctionType::get(ArrayRef<AnyFunctionType::Param> params,

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3679,6 +3679,26 @@ Type AnyFunctionType::composeInput(ASTContext &ctx, ArrayRef<Param> params,
   return TupleType::get(elements, ctx);
 }
 
+bool AnyFunctionType::equalParams(ArrayRef<AnyFunctionType::Param> a,
+                                  ArrayRef<AnyFunctionType::Param> b) {
+  if (a.size() != b.size())
+    return false;
+
+  for (unsigned i = 0, n = a.size(); i != n; ++i) {
+    if (a[i] != b[i])
+      return false;
+  }
+
+  return true;
+}
+
+bool AnyFunctionType::equalParams(ArrayRef<AnyFunctionType::Param> a,
+                                  Type composedB) {
+  llvm::SmallVector<AnyFunctionType::Param, 4> b;
+  AnyFunctionType::decomposeInput(composedB, b);
+  return equalParams(a, b);
+}
+
 FunctionType *FunctionType::get(ArrayRef<AnyFunctionType::Param> params,
                                 Type result, const ExtInfo &info,
                                 bool canonicalVararg) {

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3692,13 +3692,6 @@ bool AnyFunctionType::equalParams(ArrayRef<AnyFunctionType::Param> a,
   return true;
 }
 
-bool AnyFunctionType::equalParams(ASTContext &ctx,
-                                  ArrayRef<AnyFunctionType::Param> a,
-                                  Type composedB) {
-  auto composedA = AnyFunctionType::composeInput(ctx, a, false);
-  return composedA->isEqual(composedB);
-}
-
 FunctionType *FunctionType::get(ArrayRef<AnyFunctionType::Param> params,
                                 Type result, const ExtInfo &info,
                                 bool canonicalVararg) {

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1539,7 +1539,7 @@ protocolForLiteralKind(CodeCompletionLiteralKind kind) {
 static bool hasTrivialTrailingClosure(const FuncDecl *FD,
                                       AnyFunctionType *funcType) {
   SmallVector<bool, 4> defaultMap;
-  computeDefaultMap(funcType->getInput(), FD,
+  computeDefaultMap(funcType->getParams(), FD,
                     /*level*/ FD->isInstanceMember() ? 1 : 0, defaultMap);
   
   bool OneArg = defaultMap.size() == 1;

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5761,7 +5761,6 @@ Expr *ExprRewriter::coerceCallArguments(
     }
   }
 
-  auto origFunc = funcType;
   // If you value your sanity, ignore the body of this 'if' statement.
   if (cs.getASTContext().isSwiftVersion3() && params.size() == 1) {
     const auto &param = params.front();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5783,7 +5783,7 @@ Expr *ExprRewriter::coerceCallArguments(
   // Determine the parameter bindings.
   auto params = funcType->getParams();
   SmallVector<bool, 4> defaultMap;
-  computeDefaultMap(paramType, callee.getDecl(), level, defaultMap);
+  computeDefaultMap(params, callee.getDecl(), level, defaultMap);
   auto args = decomposeArgType(cs.getType(arg), argLabels);
 
   // Quickly test if any further fix-ups for the argument types are necessary.

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -575,6 +575,18 @@ namespace {
     Expr *buildObjCBridgeExpr(Expr *expr, Type toType,
                               ConstraintLocatorBuilder locator);
 
+    static Type getBaseType(AnyFunctionType *fnType,
+                            bool wantsRValueInstanceType = true) {
+      auto params = fnType->getParams();
+      assert(params.size() == 1);
+
+      const auto &base = params.front();
+      if (wantsRValueInstanceType)
+        return base.getType()->getRValueInstanceType();
+
+      return base.getType();
+    }
+
   public:
     /// \brief Build a reference to the given declaration.
     Expr *buildDeclRef(OverloadChoice choice, DeclNameLoc loc, Type openedType,
@@ -593,7 +605,7 @@ namespace {
         auto openedFnType = openedType->castTo<FunctionType>();
         auto simplifiedFnType
           = simplifyType(openedFnType)->castTo<FunctionType>();
-        auto baseTy = simplifiedFnType->getInput()->getRValueInstanceType();
+        auto baseTy = getBaseType(simplifiedFnType);
 
         // Handle operator requirements found in protocols.
         if (auto proto = dyn_cast<ProtocolDecl>(decl->getDeclContext())) {
@@ -989,9 +1001,7 @@ namespace {
       }
 
       // The formal type of the 'self' value for the member's declaration.
-      Type containerTy =
-          refTy->castTo<FunctionType>()
-              ->getInput()->getRValueInstanceType();
+      Type containerTy = getBaseType(refTy->castTo<FunctionType>());
 
       // If we have an opened existential, selfTy and baseTy will both be
       // the same opened existential type.
@@ -1510,12 +1520,11 @@ namespace {
 
         index = cs.coerceToRValue(index);
         // The index argument should be (keyPath: KeyPath<Root, Value>).
-        // Dig the key path expression out of the argument tuple.
+        // Dig the key path expression out of the arguments.
         auto indexKP = cast<TupleExpr>(index)->getElement(0);
         auto keyPathExprTy = cs.getType(indexKP);
-        auto keyPathTy = applicationTy->getInput()->castTo<TupleType>()
-          ->getElementType(0);
-        
+        auto keyPathTy = applicationTy->getParams().front().getType();
+
         Type valueTy;
         Type baseTy;
         bool resultIsLValue;
@@ -1670,7 +1679,8 @@ namespace {
 
       // Convert the base.
       auto openedFullFnType = selected.openedFullType->castTo<FunctionType>();
-      auto openedBaseType = openedFullFnType->getInput();
+      auto openedBaseType =
+          getBaseType(openedFullFnType, /*wantsRValue*/ false);
       auto containerTy = solution.simplifyType(openedBaseType);
       base = coerceObjectArgumentToType(
         base, containerTy, subscript, AccessSemantics::Ordinary,
@@ -1711,8 +1721,7 @@ namespace {
       // initializer type. Map the former into the latter.
       auto resultTy = solution.simplifyType(openedFullType);
 
-      auto selfTy = resultTy->castTo<FunctionType>()->getInput()
-        ->getRValueInstanceType();
+      auto selfTy = getBaseType(resultTy->castTo<FunctionType>());
 
       // Also replace the result type with the base type, so that calls
       // to constructors defined in a superclass will know to cast the
@@ -5733,8 +5742,8 @@ Expr *ExprRewriter::coerceCallArguments(
     ArrayRef<Identifier> argLabels,
     bool hasTrailingClosure,
     ConstraintLocatorBuilder locator) {
-  
-  auto paramType = funcType->getInput();
+
+  auto params = funcType->getParams();
   // Local function to produce a locator to refer to the ith element of the
   // argument tuple.
   auto getArgLocator = [&](unsigned argIdx, unsigned paramIdx)
@@ -5745,33 +5754,43 @@ Expr *ExprRewriter::coerceCallArguments(
 
   bool matchCanFail = false;
 
-  if (paramType->hasUnresolvedType())
-    matchCanFail = true;
+  for (const auto &param : params) {
+    if (param.getType()->hasUnresolvedType()) {
+      matchCanFail = true;
+      break;
+    }
+  }
 
+  auto origFunc = funcType;
   // If you value your sanity, ignore the body of this 'if' statement.
-  if (cs.getASTContext().isSwiftVersion3()) {
+  if (cs.getASTContext().isSwiftVersion3() && params.size() == 1) {
+    const auto &param = params.front();
+    auto paramType = param.getType();
+
     // Total hack: In Swift 3 mode, we can end up with an arity mismatch due to
     // loss of ParenType sugar.
-    if (isa<TupleExpr>(arg))
-      if (auto *parenType = dyn_cast<ParenType>(paramType.getPointer()))
-        if (isa<TupleType>(parenType->getUnderlyingType().getPointer()))
-          paramType = parenType->getUnderlyingType();
+    if (isa<TupleExpr>(arg)) {
+      if (!param.hasLabel() && !param.isVariadic() &&
+          isa<TupleType>(paramType.getPointer())) {
+        // Rebuild the function type.
+        funcType = FunctionType::get(paramType, funcType->getResult());
+        params = funcType->getParams();
+      }
+    }
 
     // Total hack: In Swift 3 mode, argument labels are ignored when calling
     // function type with a single Any parameter.
-    if (paramType->isAny()) {
-      if (auto tupleArgType = dyn_cast<TupleType>(cs.getType(arg).getPointer())) {
-        if (tupleArgType->getNumElements() == 1) {
+    if (params.size() == 1 && params.front().getType()->isAny()) {
+      auto argType = cs.getType(arg);
+      if (auto *tupleArgType = dyn_cast<TupleType>(argType.getPointer())) {
+        if (tupleArgType->getNumElements() == 1)
           matchCanFail = true;
-        }
       }
     }
-    
-    // Rebuild the function type.
-    funcType = FunctionType::get(paramType, funcType->getResult());
   }
 
-  bool allParamsMatch = cs.getType(arg)->isEqual(paramType);
+  bool allParamsMatch =
+      AnyFunctionType::equalParams(cs.getASTContext(), params, cs.getType(arg));
 
   // Find the callee declaration.
   ConcreteDeclRef callee =
@@ -5781,7 +5800,6 @@ Expr *ExprRewriter::coerceCallArguments(
   unsigned level = apply ? computeCallLevel(cs, callee, apply) : 0;
 
   // Determine the parameter bindings.
-  auto params = funcType->getParams();
   SmallVector<bool, 4> defaultMap;
   computeDefaultMap(params, callee.getDecl(), level, defaultMap);
   auto args = decomposeArgType(cs.getType(arg), argLabels);
@@ -6028,6 +6046,7 @@ Expr *ExprRewriter::coerceCallArguments(
   }
 
   // If we don't have to shuffle anything, we're done.
+  auto paramType = AnyFunctionType::composeInput(tc.Context, params, false);
   if (cs.getType(arg)->isEqual(paramType))
     return arg;
 
@@ -6135,10 +6154,8 @@ ClosureExpr *ExprRewriter::coerceClosureExprToVoid(ClosureExpr *closureExpr) {
   
   // Finally, compute the proper type for the closure.
   auto fnType = cs.getType(closureExpr)->getAs<FunctionType>();
-  Type inputType = fnType->getInput();
-  auto newClosureType = FunctionType::get(inputType,
-                                          tc.Context.TheEmptyTupleType,
-                                          fnType->getExtInfo());
+  auto newClosureType = FunctionType::get(
+      fnType->getParams(), tc.Context.TheEmptyTupleType, fnType->getExtInfo());
   cs.setType(closureExpr, newClosureType);
   return closureExpr;
 }
@@ -6555,12 +6572,15 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
           auto *fn2 = obj2->getAs<AnyFunctionType>();
 
           if (fn1 && fn2) {
-            auto *params1 = fn1->getInput()->getAs<TupleType>();
-            auto *params2 = fn2->getInput()->getAs<TupleType>();
+            auto params1 = fn1->getParams();
+            auto params2 = fn2->getParams();
 
             // This handles situations like argument: (()), parameter: ().
-            if (params1 && params2 && params1->isEqual(params2))
-              break;
+            if (params1.size() == 1 && params2.empty()) {
+              auto tupleTy = params1.front().getType()->getAs<TupleType>();
+              if (tupleTy && tupleTy->getNumElements() == 0)
+                break;
+            }
           }
         }
       }
@@ -6916,12 +6936,10 @@ Expr *ExprRewriter::coerceToType(Expr *expr, Type toType,
       // bit to the closure without invalidating prior analysis.
       auto fromEI = fromFunc->getExtInfo();
       if (toEI.isNoEscape() && !fromEI.isNoEscape()) {
-        auto newFromFuncType = FunctionType::get(fromFunc->getInput(),
-                                             fromFunc->getResult(),
-                                             fromEI.withNoEscape());
+        auto newFromFuncType = fromFunc->withExtInfo(fromEI.withNoEscape());
         if (!isInDefaultArgumentContext &&
             applyTypeToClosureExpr(cs, expr, newFromFuncType)) {
-          fromFunc = newFromFuncType;
+          fromFunc = newFromFuncType->castTo<FunctionType>();
           // Propagating the 'no escape' bit might have satisfied the entire
           // conversion.  If so, we're done, otherwise keep converting.
           if (fromFunc->isEqual(toType))
@@ -7430,7 +7448,7 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
         auto body = arg->getElements()[1];
         auto bodyTy = cs.getType(body)->getWithoutSpecifierType();
         auto bodyFnTy = bodyTy->castTo<FunctionType>();
-        auto escapableType = bodyFnTy->getInput();
+        auto escapableParams = bodyFnTy->getParams();
         auto resultType = bodyFnTy->getResult();
         
         // The body is immediately called, so is obviously noescape.
@@ -7441,7 +7459,8 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
         
         auto escapable = new (tc.Context)
           OpaqueValueExpr(apply->getFn()->getLoc(), Type());
-        cs.setType(escapable, escapableType);
+        cs.setType(escapable, FunctionType::composeInput(
+                                  tc.Context, escapableParams, false));
 
         auto getType = [&](const Expr *E) -> Type {
           return cs.getType(E);
@@ -7472,7 +7491,7 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
         auto body = cs.coerceToRValue(arg->getElements()[1]);
 
         auto bodyFnTy = cs.getType(body)->castTo<FunctionType>();
-        auto openedTy = bodyFnTy->getInput();
+        auto openedTy = getBaseType(bodyFnTy, /*wantsRValue*/ false);
         auto resultTy = bodyFnTy->getResult();
 
         // The body is immediately called, so is obviously noescape.
@@ -8414,11 +8433,12 @@ Expr *TypeChecker::callWitness(Expr *base, DeclContext *dc,
   cs.cacheSubExprTypes(call);
 
   // Add the conversion from the argument to the function parameter type.
-  cs.addConstraint(ConstraintKind::ArgumentTupleConversion,
-                   cs.getType(call->getArg()),
-                   openedType->castTo<FunctionType>()->getInput(),
-                   cs.getConstraintLocator(call,
-                                           ConstraintLocator::ApplyArgument));
+  auto openedFuncType = openedType->castTo<FunctionType>();
+  cs.addConstraint(
+      ConstraintKind::ArgumentTupleConversion, cs.getType(call->getArg()),
+      FunctionType::composeInput(cs.getASTContext(),
+                                 openedFuncType->getParams(), false),
+      cs.getConstraintLocator(call, ConstraintLocator::ApplyArgument));
 
   // Solve the system.
   SmallVector<Solution, 1> solutions;

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3440,7 +3440,7 @@ typeCheckArgumentChildIndependently(Expr *argExpr, Type argType,
     if (candidates.empty()) {
       defaultMap.assign(params.size(), false);
     } else {
-      computeDefaultMap(argType, candidates[0].getDecl(),
+      computeDefaultMap(params, candidates[0].getDecl(),
                         candidates[0].level, defaultMap);
     }
 
@@ -3833,8 +3833,7 @@ static bool
 diagnoseInstanceMethodAsCurriedMemberOnType(CalleeCandidateInfo &CCI,
                                             Expr *fnExpr, Expr *argExpr) {
   for (auto &candidate : CCI.candidates) {
-    auto argTy = candidate.getArgumentType();
-    if (!argTy)
+    if (!candidate.hasParameters())
       return false;
 
     auto *decl = candidate.getDecl();
@@ -3849,9 +3848,10 @@ diagnoseInstanceMethodAsCurriedMemberOnType(CalleeCandidateInfo &CCI,
         (decl->isInstanceMember() && candidate.level == 1))
       continue;
 
-    auto params = candidate.getUncurriedFunctionType()->getParams();
+    auto params = candidate.getParameters();
+
     SmallVector<bool, 4> defaultMap;
-    computeDefaultMap(argTy, decl, candidate.level, defaultMap);
+    computeDefaultMap(params, decl, candidate.level, defaultMap);
     // If one of the candidates is an instance method with a single parameter
     // at the level 0, this might be viable situation for calling instance
     // method as curried member of type problem.
@@ -4352,14 +4352,13 @@ diagnoseSingleCandidateFailures(CalleeCandidateInfo &CCI, Expr *fnExpr,
   auto candidate = CCI[0];
   auto &TC = CCI.CS.TC;
 
-  auto argTy = candidate.getArgumentType();
-  if (!argTy)
+  if (!candidate.hasParameters())
     return false;
 
-  auto params = candidate.getUncurriedFunctionType()->getParams();
+  auto params = candidate.getParameters();
+
   SmallVector<bool, 4> defaultMap;
-  computeDefaultMap(argTy, candidate.getDecl(), candidate.level,
-                    defaultMap);
+  computeDefaultMap(params, candidate.getDecl(), candidate.level, defaultMap);
   auto args = decomposeArgType(CCI.CS.getType(argExpr), argLabels);
 
   // Check the case where a raw-representable type is constructed from an
@@ -4475,11 +4474,13 @@ static bool diagnoseRawRepresentableMismatch(CalleeCandidateInfo &CCI,
     if (!decl)
       continue;
 
-    auto parameters = candidate.getUncurriedFunctionType()->getParams();
-    SmallVector<bool, 4> defaultMap;
-    computeDefaultMap(candidate.getArgumentType(), decl,
-                      candidate.level, defaultMap);
+    if (!candidate.hasParameters())
+      continue;
 
+    auto parameters = candidate.getParameters();
+
+    SmallVector<bool, 4> defaultMap;
+    computeDefaultMap(parameters, decl, candidate.level, defaultMap);
     if (parameters.size() != arguments.size())
       continue;
 
@@ -4979,11 +4980,13 @@ bool FailureDiagnosis::diagnoseArgumentGenericRequirements(
     return false;
 
   auto const &candidate = candidates.candidates[0];
-  auto params = candidate.getUncurriedFunctionType()->getParams();
-  SmallVector<bool, 4> defaultMap;
-  computeDefaultMap(candidate.getArgumentType(), candidate.getDecl(),
-                    candidate.level, defaultMap);
 
+  if (!candidate.hasParameters())
+    return false;
+
+  auto params = candidate.getParameters();
+  SmallVector<bool, 4> defaultMap;
+  computeDefaultMap(params, candidate.getDecl(), candidate.level, defaultMap);
   auto args = decomposeArgType(CS.getType(argExpr), argLabels);
 
   SmallVector<ParamBinding, 4> bindings;

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -789,8 +789,10 @@ namespace {
           }
         }
 
-        return AnyFunctionType::equalParams(CS.getASTContext(),
-                                            fnTy->getParams(), favoredTy);
+        auto paramTy =
+            AnyFunctionType::composeInput(CS.getASTContext(), fnTy->getParams(),
+                                          /*canonicalVararg*/ false);
+        return favoredTy->isEqual(paramTy);
       };
 
       // This is a hack to ensure we always consider the protocol requirement

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -712,8 +712,9 @@ namespace {
       if (value->getDeclContext()->isTypeContext()) {
         fnTy = fnTy->getResult()->castTo<AnyFunctionType>();
       }
-      
-      Type paramTy = fnTy->getInput();
+
+      Type paramTy = FunctionType::composeInput(CS.getASTContext(),
+                                                fnTy->getParams(), false);
       auto resultTy = fnTy->getResult();
       auto contextualTy = CS.getContextualType(expr);
 
@@ -787,8 +788,8 @@ namespace {
             }
           }
         }
-        Type paramTy = fnTy->getInput();
-        return favoredTy->isEqual(paramTy);
+
+        return AnyFunctionType::equalParams(fnTy->getParams(), favoredTy);
       };
 
       // This is a hack to ensure we always consider the protocol requirement
@@ -884,15 +885,14 @@ namespace {
       if (value->getDeclContext()->isTypeContext()) {
         fnTy = fnTy->getResult()->castTo<AnyFunctionType>();
       }
-      
-      Type paramTy = fnTy->getInput();
-      auto paramTupleTy = paramTy->getAs<TupleType>();
-      if (!paramTupleTy || paramTupleTy->getNumElements() != 2)
+
+      auto params = fnTy->getParams();
+      if (params.size() != 2)
         return false;
-      
-      auto firstParamTy = paramTupleTy->getElement(0).getType();
-      auto secondParamTy = paramTupleTy->getElement(1).getType();
-      
+
+      auto firstParamTy = params[0].getType();
+      auto secondParamTy = params[1].getType();
+
       auto resultTy = fnTy->getResult();
       auto contextualTy = CS.getContextualType(expr);
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -789,7 +789,8 @@ namespace {
           }
         }
 
-        return AnyFunctionType::equalParams(fnTy->getParams(), favoredTy);
+        return AnyFunctionType::equalParams(CS.getASTContext(),
+                                            fnTy->getParams(), favoredTy);
       };
 
       // This is a hack to ensure we always consider the protocol requirement

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -597,8 +597,7 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
         auto params1 = funcTy1->getParams();
         auto params2 = funcTy2->getParams();
         SmallVector<bool, 4> defaultMapType2;
-        computeDefaultMap(funcTy2->getInput(), decl2,
-                          outerDC2->isTypeContext(),
+        computeDefaultMap(params2, decl2, outerDC2->isTypeContext(),
                           defaultMapType2);
 
         unsigned numParams1 = params1.size();

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -103,8 +103,8 @@ areConservativelyCompatibleArgumentLabels(ValueDecl *decl,
   
   auto params = levelTy->getParams();
   SmallVector<bool, 4> defaultMap;
-  computeDefaultMap(levelTy->getInput(), decl, parameterDepth, defaultMap);
-  
+  computeDefaultMap(params, decl, parameterDepth, defaultMap);
+
   MatchCallArgumentListener listener;
   SmallVector<ParamBinding, 8> unusedParamBindings;
 
@@ -702,7 +702,7 @@ matchCallArguments(ConstraintSystem &cs, ConstraintKind kind,
   AnyFunctionType::decomposeInput(paramType, params);
   
   SmallVector<bool, 4> defaultMap;
-  computeDefaultMap(paramType, callee, calleeLevel, defaultMap);
+  computeDefaultMap(params, callee, calleeLevel, defaultMap);
   
   if (callee && cs.getASTContext().isSwiftVersion3()
       && argType->is<TupleType>()) {
@@ -1033,7 +1033,7 @@ ConstraintSystem::matchFunctionParamTypes(ArrayRef<AnyFunctionType::Param> type1
   }
   
   SmallVector<bool, 4> defaultMap;
-  computeDefaultMap(argType, callee, calleeLevel, defaultMap);
+  computeDefaultMap(type1, callee, calleeLevel, defaultMap);
   
   // Match up the call arguments to the parameters.
   MatchCallArgumentListener listener;

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -316,11 +316,14 @@ CalleeCandidateInfo::evaluateCloseness(UncurriedCandidate candidate,
   auto *dc = candidate.getDecl()
   ? candidate.getDecl()->getInnermostDeclContext()
   : nullptr;
-  
-  auto candArgs = candidate.getUncurriedFunctionType()->getParams();
+
+  if (!candidate.hasParameters())
+    return {CC_GeneralMismatch, {}};
+
+  auto candArgs = candidate.getParameters();
   SmallVector<bool, 4> candDefaultMap;
-  computeDefaultMap(candidate.getArgumentType(), candidate.getDecl(),
-                    candidate.level, candDefaultMap);
+  computeDefaultMap(candArgs, candidate.getDecl(), candidate.level,
+                    candDefaultMap);
   
   struct OurListener : public MatchCallArgumentListener {
     CandidateCloseness result = CC_ExactMatch;

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -84,20 +84,6 @@ UncurriedCandidate::UncurriedCandidate(ValueDecl *decl, unsigned level)
   }
 }
 
-/// Helper to gather the argument labels from a tuple or paren type, for use
-/// when the AST doesn't store argument-label information properly.
-static void gatherArgumentLabels(Type type,
-                                 SmallVectorImpl<Identifier> &labels) {
-  // Handle tuple types.
-  if (auto tupleTy = dyn_cast<TupleType>(type.getPointer())) {
-    for (auto i : range(tupleTy->getNumElements()))
-      labels.push_back(tupleTy->getElement(i).getName());
-    return;
-  }
-  
-  labels.push_back(Identifier());
-}
-
 ArrayRef<Identifier> UncurriedCandidate::getArgumentLabels(
                                        SmallVectorImpl<Identifier> &scratch) {
   scratch.clear();
@@ -129,13 +115,14 @@ ArrayRef<Identifier> UncurriedCandidate::getArgumentLabels(
       }
     }
   }
-  
-  if (auto argType = getArgumentType()) {
-    gatherArgumentLabels(argType, scratch);
-    return scratch;
-  }
-  
-  return { };
+
+  if (!hasParameters())
+    return {};
+
+  for (const auto &param : getParameters())
+    scratch.push_back(param.getLabel());
+
+  return scratch;
 }
 
 void UncurriedCandidate::dump() const {
@@ -766,7 +753,8 @@ void CalleeCandidateInfo::filterListArgs(ArrayRef<AnyFunctionType::Param> actual
   filterList([&](UncurriedCandidate candidate) -> ClosenessResultTy {
     // If this isn't a function or isn't valid at this uncurry level, treat it
     // as a general mismatch.
-    if (!candidate.getArgumentType()) return { CC_GeneralMismatch, {}};
+    if (!candidate.hasParameters())
+      return {CC_GeneralMismatch, {}};
     return evaluateCloseness(candidate, actualArgs);
   });
 }
@@ -777,10 +765,10 @@ void CalleeCandidateInfo::filterContextualMemberList(Expr *argExpr) {
   // If the argument is not present then we expect members without arguments.
   if (!argExpr) {
     return filterList([&](UncurriedCandidate candidate) -> ClosenessResultTy {
-      auto inputType = candidate.getArgumentType();
       // If this candidate has no arguments, then we're a match.
-      if (!inputType) return { CC_ExactMatch, {}};
-      
+      if (!candidate.hasParameters())
+        return {CC_ExactMatch, {}};
+
       // Otherwise, if this is a function candidate with an argument, we
       // mismatch argument count.
       return { CC_ArgumentCountMismatch, {}};
@@ -893,7 +881,8 @@ suggestPotentialOverloads(SourceLoc loc, bool isResult) {
   // FIXME2: For (T,T) & (Self, Self), emit this as two candidates, one using
   // the LHS and one using the RHS type for T's.
   for (auto cand : candidates) {
-    auto type = isResult ? cand.getResultType() : cand.getArgumentType();
+    auto type = isResult ? cand.getResultType()
+                         : cand.getArgumentType(CS.getASTContext());
     if (type.isNull())
       continue;
     

--- a/lib/Sema/CalleeCandidateInfo.h
+++ b/lib/Sema/CalleeCandidateInfo.h
@@ -109,6 +109,15 @@ namespace swift {
         return funcTy->getInput();
       return Type();
     }
+
+    bool hasParameters() const {
+      return getUncurriedFunctionType();
+    }
+
+    ArrayRef<AnyFunctionType::Param> getParameters() const {
+      assert(hasParameters());
+      return getUncurriedFunctionType()->getParams();
+    }
     
     /// Given a function candidate with an uncurry level, return the parameter
     /// type at the specified uncurry level.  If there is an error getting to

--- a/lib/Sema/CalleeCandidateInfo.h
+++ b/lib/Sema/CalleeCandidateInfo.h
@@ -104,10 +104,12 @@ namespace swift {
     /// Given a function candidate with an uncurry level, return the parameter
     /// type at the specified uncurry level.  If there is an error getting to
     /// the specified input, this returns a null Type.
-    Type getArgumentType() const {
-      if (auto *funcTy = getUncurriedFunctionType())
-        return funcTy->getInput();
-      return Type();
+    Type getArgumentType(ASTContext &ctx) const {
+      if (!hasParameters())
+        return Type();
+
+      auto params = getParameters();
+      return FunctionType::composeInput(ctx, params, false);
     }
 
     bool hasParameters() const {

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -534,20 +534,15 @@ static Type removeArgumentLabels(Type type, unsigned numArgumentLabels) {
   auto fnType = type->getAs<FunctionType>();
 
   // Drop argument labels from the input type.
-  Type inputType = fnType->getInput();
-  if (auto tupleTy = dyn_cast<TupleType>(inputType.getPointer())) {
-    SmallVector<TupleTypeElt, 4> elements;
-    elements.reserve(tupleTy->getNumElements());
-    for (const auto &elt : tupleTy->getElements()) {
-      elements.push_back(elt.getWithoutName());
-    }
-    inputType = TupleType::get(elements, type->getASTContext());
-  }
+  llvm::SmallVector<AnyFunctionType::Param, 4> unlabeledParams;
+  unlabeledParams.reserve(fnType->getNumParams());
+  for (const auto &param : fnType->getParams())
+    unlabeledParams.push_back(param.getWithoutLabel());
 
-  return FunctionType::get(inputType,
-                           removeArgumentLabels(fnType->getResult(),
-                                                numArgumentLabels - 1),
-                           fnType->getExtInfo());
+  return FunctionType::get(
+      unlabeledParams,
+      removeArgumentLabels(fnType->getResult(), numArgumentLabels - 1),
+      fnType->getExtInfo());
 }
 
 Type ConstraintSystem::openFunctionType(
@@ -569,14 +564,21 @@ Type ConstraintSystem::openFunctionType(
                 locator,
                 replacements);
 
-    // Transform the input and output types.
-    auto inputTy = openType(genericFn->getInput(), replacements);
+    // Transform the parameters and output type.
+    llvm::SmallVector<AnyFunctionType::Param, 4> openedParams;
+    openedParams.reserve(genericFn->getNumParams());
+    for (const auto &param : genericFn->getParams()) {
+      auto type = openType(param.getPlainType(), replacements);
+      openedParams.push_back(AnyFunctionType::Param(type, param.getLabel(),
+                                                    param.getParameterFlags()));
+    }
+
     auto resultTy = openType(genericFn->getResult(), replacements);
 
     // Build the resulting (non-generic) function type.
-    funcType = FunctionType::get(inputTy, resultTy,
-                                 FunctionType::ExtInfo().
-                                   withThrows(genericFn->throws()));
+    funcType = FunctionType::get(
+        openedParams, resultTy,
+        FunctionType::ExtInfo().withThrows(genericFn->throws()));
   }
 
   return removeArgumentLabels(funcType, numArgumentLabelsToRemove);
@@ -897,7 +899,9 @@ ConstraintSystem::getTypeOfReference(ValueDecl *value,
     // DynamicSelf with the actual object type.
     if (!func->getDeclContext()->getAsProtocolOrProtocolExtensionContext()) {
       if (func->hasDynamicSelf()) {
-        Type selfTy = openedFnType->getInput()->getRValueInstanceType();
+        auto params = openedFnType->getParams();
+        assert(params.size() == 1);
+        Type selfTy = params.front().getType()->getRValueInstanceType();
         openedType = openedType->replaceCovariantResultType(
                        selfTy,
                        func->getNumParameterLists());
@@ -1358,7 +1362,10 @@ ConstraintSystem::getTypeOfMemberReference(
 
   // Constrain the 'self' object type.
   auto openedFnType = openedType->castTo<FunctionType>();
-  Type selfObjTy = openedFnType->getInput()->getRValueInstanceType();
+  auto openedParams = openedFnType->getParams();
+  assert(openedParams.size() == 1);
+
+  Type selfObjTy = openedParams.front().getType()->getRValueInstanceType();
   if (outerDC->getAsProtocolOrProtocolExtensionContext()) {
     // For a protocol, substitute the base object directly. We don't need a
     // conformance constraint because we wouldn't have found the declaration
@@ -1887,10 +1894,8 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
         
       if (boundFunctionType &&
           CD->hasThrows() != boundFunctionType->throws()) {
-        boundType = FunctionType::get(boundFunctionType->getInput(),
-                                      boundFunctionType->getResult(),
-                                      boundFunctionType->getExtInfo().
-                                                          withThrows());
+        boundType = boundFunctionType->withExtInfo(
+            boundFunctionType->getExtInfo().withThrows());
       }
     }
   }

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -554,14 +554,11 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       // We care about whether the parameter list of the callee syntactically
       // has more than one argument.  It has to *syntactically* have a tuple
       // type as its argument.  A ParenType wrapping a TupleType is a single
-      // parameter. 
-      if (isa<TupleType>(FT->getInput().getPointer())) {
-        auto TT = FT->getInput()->getAs<TupleType>();
-        if (TT->getNumElements() > 1) {
-          TC.diagnose(Call->getLoc(), diag::tuple_splat_use,
-                      TT->getNumElements())
-            .highlight(Call->getArg()->getSourceRange());
-        }
+      // parameter.
+      auto params = FT->getParams();
+      if (params.size() > 1) {
+        TC.diagnose(Call->getLoc(), diag::tuple_splat_use, params.size())
+          .highlight(Call->getArg()->getSourceRange());
       }
     }
 

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2094,7 +2094,15 @@ bool isSubscriptReturningString(const ValueDecl *D, ASTContext &Context) {
 
   // We're only going to warn for BoundGenericStructType with a single
   // type argument that is not Int!
-  auto inputTy = fnTy->getInput()->getAs<BoundGenericStructType>();
+  auto params = fnTy->getParams();
+  if (params.size() != 1)
+    return false;
+
+  const auto &param = params.front();
+  if (param.hasLabel() || param.isVariadic())
+    return false;
+
+  auto inputTy = param.getType()->getAs<BoundGenericStructType>();
   if (!inputTy)
     return false;
 

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -162,7 +162,9 @@ public:
         }
       });
 
-      gft->getInput().walk(walker);
+      for (const auto &param : gft->getParams())
+        param.getType().walk(walker);
+
       gft->getResult().walk(walker);
     }
   }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -219,12 +219,18 @@ static unsigned getNumArgs(ValueDecl *value) {
   AnyFunctionType *fnTy = value->getInterfaceType()->castTo<AnyFunctionType>();
   if (value->getDeclContext()->isTypeContext())
     fnTy = fnTy->getResult()->castTo<AnyFunctionType>();
-  Type argTy = fnTy->getInput();
-  if (auto tuple = argTy->getAs<TupleType>()) {
-    return tuple->getNumElements();
-  } else {
-    return 1;
+
+  auto params = fnTy->getParams();
+  if (params.size() == 1) {
+    const auto &param = params.front();
+    if (param.hasLabel() || param.isVariadic())
+      return 1;
+
+    if (auto *tuple = param.getType()->getAs<TupleType>())
+      return tuple->getNumElements();
   }
+
+  return params.size();
 }
 
 static bool matchesDeclRefKind(ValueDecl *value, DeclRefKind refKind) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4822,18 +4822,18 @@ public:
 
     // Determine the input and result types of this function.
     auto fnType = type->castTo<AnyFunctionType>();
-    Type inputType = fnType->getInput();
+    auto parameters = fnType->getParams();
     Type resultType = dropResultOptionality(fnType->getResult(),
                                             uncurryLevel - 1);
 
     // Produce the resulting function type.
     if (auto genericFn = dyn_cast<GenericFunctionType>(fnType)) {
       return GenericFunctionType::get(genericFn->getGenericSignature(),
-                                      inputType, resultType,
+                                      parameters, resultType,
                                       fnType->getExtInfo());
     }
 
-    return FunctionType::get(inputType, resultType, fnType->getExtInfo());
+    return FunctionType::get(parameters, resultType, fnType->getExtInfo());
   }
 
   static bool
@@ -5031,8 +5031,12 @@ public:
       if (auto *baseInit = dyn_cast<ConstructorDecl>(base)) {
         // Special-case initializers, whose "type" isn't useful besides the
         // input arguments.
-        baseTy = baseTy->getAs<AnyFunctionType>()->getResult();
-        Type argTy = baseTy->getAs<AnyFunctionType>()->getInput();
+        auto *fnType = baseTy->getAs<AnyFunctionType>();
+        baseTy = fnType->getResult();
+        Type argTy = FunctionType::composeInput(TC.Context,
+                                                baseTy->getAs<AnyFunctionType>()
+                                                      ->getParams(),
+                                                false);
         auto diagKind = diag::override_type_mismatch_with_fixits_init;
         unsigned numArgs = baseInit->getParameters()->size();
         activeDiag.emplace(TC.diagnose(decl, diagKind,
@@ -5225,8 +5229,9 @@ public:
       // For subscripts, we don't have a 'Self' type, but turn it
       // into a monomorphic function type.
       auto funcTy = declTy->castTo<AnyFunctionType>();
-      declTy = FunctionType::get(funcTy->getInput(),
-                                 funcTy->getResult());
+      declTy = FunctionType::get(funcTy->getParams(),
+                                 funcTy->getResult(),
+                                 FunctionType::ExtInfo());
     } else {
       // For properties, strip off ownership.
       declTy = declTy->getReferenceStorageReferent();

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -102,7 +102,7 @@ Expr *TypeChecker::substituteInputSugarTypeForResult(ApplyExpr *E) {
     // constructed.  Apply the sugar onto it.
     if (auto FT = E->getType()->getAs<FunctionType>())
       if (FT->getResult()->isEqual(resultSugar) && !resultSugar->isCanonical()){
-        auto NFT = FunctionType::get(FT->getInput(), resultSugar,
+        auto NFT = FunctionType::get(FT->getParams(), resultSugar,
                                      FT->getExtInfo());
         E->setType(NFT);
         return E;

--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -667,7 +667,8 @@ static void checkReferencedGenericParams(GenericContext *dc,
   // return type.
   ReferencedGenericTypeWalker paramsAndResultWalker;
   auto *funcTy = decl->getInterfaceType()->castTo<GenericFunctionType>();
-  funcTy->getInput().walk(paramsAndResultWalker);
+  for (const auto &param : funcTy->getParams())
+    param.getType().walk(paramsAndResultWalker);
   funcTy->getResult().walk(paramsAndResultWalker);
 
   // Set of generic params referenced in parameter types,

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1660,7 +1660,7 @@ static Type getTypeForDisplay(ModuleDecl *module, ValueDecl *decl) {
       auto sigWithoutReqts
         = GenericSignature::get(genericFn->getGenericParams(), {});
       return GenericFunctionType::get(sigWithoutReqts,
-                                      resultFn->getInput(),
+                                      resultFn->getParams(),
                                       resultFn->getResult(),
                                       resultFn->getExtInfo());
     }

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -503,7 +503,7 @@ static Type getWitnessTypeForMatching(TypeChecker &tc,
   // common, because most of the recursion involves the requirements
   // of the generic type.
   if (auto genericFn = type->getAs<GenericFunctionType>()) {
-    type = FunctionType::get(genericFn->getInput(),
+    type = FunctionType::get(genericFn->getParams(),
                              genericFn->getResult(),
                              genericFn->getExtInfo());
   }

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -1467,7 +1467,7 @@ static Type applyNonEscapingFromContext(DeclContext *DC,
     // which would wrap the NameAliasType or ParenType, and apply the
     // isNoEscape bit when de-sugaring.
     // <https://bugs.swift.org/browse/SR-2520>
-    return FunctionType::get(funcTy->getInput(), funcTy->getResult(), extInfo);
+    return FunctionType::get(funcTy->getParams(), funcTy->getResult(), extInfo);
   }
 
   // Note: original sugared type

--- a/test/Constraints/closures.swift
+++ b/test/Constraints/closures.swift
@@ -299,7 +299,7 @@ struct Thing {
   init?() {}
 }
 // This throws a compiler error
-let things = Thing().map { thing in  // expected-error {{unable to infer complex closure return type; add explicit type to disambiguate}} {{34-34=-> (Thing) }}
+let things = Thing().map { thing in  // expected-error {{unable to infer complex closure return type; add explicit type to disambiguate}} {{34-34=-> Thing }}
   // Commenting out this makes it compile
   _ = thing
   return thing
@@ -552,7 +552,7 @@ extension A_SR_5030 {
   func foo() -> B_SR_5030<Int> {
     let tt : B_SR_5030<Int> = sr5030_exFalso()
     return tt.map { x in (idx: x) }
-    // expected-error@-1 {{cannot convert value of type '(idx: (Int))' to closure result type 'Int'}}
+    // expected-error@-1 {{cannot convert value of type '(idx: Int)' to closure result type 'Int'}}
   }
 }
 

--- a/test/IDE/complete_in_closures.swift
+++ b/test/IDE/complete_in_closures.swift
@@ -320,7 +320,7 @@ func testClosureParam1() {
   }
 }
 // CLOSURE_PARAM_1: Begin completions
-// CLOSURE_PARAM_1-DAG: Decl[LocalVar]/Local:         theValue[#(Int)#]{{; name=.+$}}
+// CLOSURE_PARAM_1-DAG: Decl[LocalVar]/Local:         theValue[#Int#]{{; name=.+$}}
 func testClosureParam2() {
   closureTaker2 { (Value1, Value2) -> () in
     #^CLOSURE_PARAM_2^#


### PR DESCRIPTION
Attempt to replace `AnyFunctionType::getInput()` calls with `getParams()` in Sema.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
