### PR TITLE
[Test] Ensure '-emit-module' emits identical module file with full build

### DIFF
--- a/test/Driver/Dependencies/Inputs/moduleonly/bar.swift
+++ b/test/Driver/Dependencies/Inputs/moduleonly/bar.swift
@@ -1,2 +1,28 @@
 public func bar() { }
 
+public class Bar {
+  @usableFromInline internal class Inner {
+
+    /// makeX is declared in foo.swift
+    var x = makeX([1,2,3,4])
+
+    @usableFromInline internal func f() {
+      print("Bar.Inner.f")
+    }
+  }
+}
+
+#if _runtime(_ObjC) && canImport(Foundation)
+
+import Foundation
+
+public class ObjCBar : NSObject {
+
+  @objc(foo)
+  public func bar() -> String {
+    return ""
+  }
+
+}
+
+#endif

--- a/test/Driver/Dependencies/Inputs/moduleonly/baz.swift
+++ b/test/Driver/Dependencies/Inputs/moduleonly/baz.swift
@@ -1,1 +1,20 @@
 public func baz() {}
+
+public protocol BazProtocol {
+  associatedtype Ret
+  func method1() -> Ret?
+}
+
+public enum Baz<T: Collection> : BazProtocol {
+  case collection(T)
+  case other
+
+  public func method1() -> T.SubSequence? {
+    switch self {
+    case .collection(let collection):
+      return makeX(collection)
+    default:
+      return nil
+    }
+  }
+}

--- a/test/Driver/Dependencies/Inputs/moduleonly/foo.swift
+++ b/test/Driver/Dependencies/Inputs/moduleonly/foo.swift
@@ -1,2 +1,28 @@
-public func foo() { }
+@inlinable
+public func foo(x: Int) -> Int {
+  return x + 1
+}
 
+/// something
+func makeX<T: Collection>(_ seed: T) -> T.SubSequence {
+  return seed.dropFirst(1)
+}
+
+public struct Foo : BazProtocol {
+  /// varx
+  public var x = makeX("foobar")
+
+  /// method
+  public func method1() -> Int? { return 1 }
+
+  /* Foo Bar */
+  @_transparent
+  public func method2(x: Int) -> Int {
+    return x * 12
+  }
+
+  @inlinable
+  public func method3<T: Equatable>(x: T, y: T) -> T {
+    return x == y ? x : y
+  }
+}

--- a/test/Driver/Dependencies/moduleonly.swift
+++ b/test/Driver/Dependencies/moduleonly.swift
@@ -63,3 +63,18 @@
 // RUN: test ! -f %t/buildrecord.swiftdeps~moduleonly
 // RUN: test   -f %t/buildrecord.swiftdeps
 // RUN: test   -f %t/foo~partial.swiftmodule
+
+// Ensure '-emit-module' and '-c -emit-module' emits identical 'swiftmodule' and 'swiftdoc' file.
+//
+// RUN: rm -f %t-moduleonly.swiftmodule
+// RUN: rm -f %t-moduleonly.swiftdoc
+// RUN: rm -rf %t && cp -r %S/Inputs/moduleonly/ %t
+// RUN: touch -t 201801230045 %t/*.swift
+// RUN: cd %t && %target-build-swift -emit-module -output-file-map ./output.json -incremental ./foo.swift ./bar.swift ./baz.swift -module-name testmodule -v 2>&1
+// RUN: cp -f %t/testmodule.swiftmodule %t-moduleonly.swiftmodule
+// RUN: cp -f %t/testmodule.swiftdoc %t-moduleonly.swiftdoc
+// RUN: rm -rf %t && cp -r %S/Inputs/moduleonly/ %t
+// RUN: touch -t 201801230045 %t/*.swift
+// RUN: cd %t && %target-build-swift -c -emit-module -output-file-map ./output.json -incremental ./foo.swift ./bar.swift ./baz.swift -module-name testmodule -v 2>&1
+// RUN: diff %t/testmodule.swiftmodule %t-moduleonly.swiftmodule
+// RUN: diff %t/testmodule.swiftdoc %t-moduleonly.swiftdoc


### PR DESCRIPTION
Add test which ensures `-c -emit-module` and `-emit-module`(only) mode emit identical `swiftmodule`/`swiftdoc` file.
