### PR TITLE
[SourceKit] Update demangle for new mangling

### DIFF
--- a/test/SourceKit/Demangle/demangle.swift
+++ b/test/SourceKit/Demangle/demangle.swift
@@ -1,15 +1,17 @@
-// RUN: %sourcekitd-test -req=demangle unmangled _TtBf80_  _TtP3foo3bar_ | %FileCheck %s
+// RUN: %sourcekitd-test -req=demangle unmangled _TtBf80_  _TtP3foo3bar_ '$S3Foo11AppDelegateC29applicationDidFinishLaunchingyy10Foundation12NotificationVF' | %FileCheck %s
 // CHECK:      START DEMANGLE
 // CHECK-NEXT: <empty>
 // CHECK-NEXT: Builtin.Float80
 // CHECK-NEXT: foo.bar
+// CHECK-NEXT: Foo.AppDelegate.applicationDidFinishLaunching(Foundation.Notification) -> ()
 // CHECK-NEXT: END DEMANGLE
 
-// RUN: %sourcekitd-test -req=demangle unmangled _TtBf80_  _TtP3foo3bar_ -simplified-demangling | %FileCheck %s -check-prefix=SIMPLIFIED
+// RUN: %sourcekitd-test -req=demangle unmangled _TtBf80_  _TtP3foo3bar_ '$S3Foo11AppDelegateC29applicationDidFinishLaunchingyy10Foundation12NotificationVF' -simplified-demangling | %FileCheck %s -check-prefix=SIMPLIFIED
 // SIMPLIFIED:      START DEMANGLE
 // SIMPLIFIED-NEXT: <empty>
 // SIMPLIFIED-NEXT: Builtin.Float80
 // SIMPLIFIED-NEXT: bar
+// SIMPLIFIED-NEXT: AppDelegate.applicationDidFinishLaunching(_:)
 // SIMPLIFIED-NEXT: END DEMANGLE
 
 // RUN: %sourcekitd-test -req=mangle Foo.Baru Swift.Beer | %FileCheck %s -check-prefix=MANGLED

--- a/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
+++ b/tools/SourceKit/tools/sourcekitd-test/sourcekitd-test.cpp
@@ -1663,10 +1663,13 @@ static void prepareDemangleRequest(sourcekitd_object_t Req,
     llvm::StringRef inputContents = input.get()->getBuffer();
 
     // This doesn't handle Unicode symbols, but maybe that's okay.
-    llvm::Regex maybeSymbol("(_T|" MANGLING_PREFIX_STR ")[_a-zA-Z0-9$]+");
+    // Also accept the future mangling prefix.
+    llvm::Regex maybeSymbol("(_T|_?\\$[Ss])[_a-zA-Z0-9$.]+");
     llvm::SmallVector<llvm::StringRef, 1> matches;
     while (maybeSymbol.match(inputContents, &matches)) {
       addName(matches.front());
+      auto offset = matches.front().data() - inputContents.data();
+      inputContents = inputContents.substr(offset + matches.front().size());
     }
 
   } else {

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -1230,13 +1230,6 @@ public:
 };
 } // end anonymous namespace
 
-static bool isSwiftPrefixed(StringRef MangledName) {
-  if (MangledName.size() < 2)
-    return false;
-  return MangledName[0] == '_' &&
-         (MangledName[1] == 'T' || MangledName[1] == MANGLING_PREFIX_STR[1]);
-}
-
 static sourcekitd_response_t demangleNames(ArrayRef<const char *> MangledNames,
                                            bool Simplified) {
   swift::Demangle::DemangleOptions DemangleOptions;
@@ -1246,7 +1239,7 @@ static sourcekitd_response_t demangleNames(ArrayRef<const char *> MangledNames,
   }
 
   auto getDemangledName = [&](StringRef MangledName) -> std::string {
-    if (!isSwiftPrefixed(MangledName))
+    if (!swift::Demangle::isSwiftSymbol(MangledName))
       return std::string(); // Not a mangled name
 
     std::string Result = swift::Demangle::demangleSymbolAsString(

--- a/tools/swift-demangle/swift-demangle.cpp
+++ b/tools/swift-demangle/swift-demangle.cpp
@@ -174,7 +174,6 @@ static void demangle(llvm::raw_ostream &os, llvm::StringRef name,
 static int demangleSTDIN(const swift::Demangle::DemangleOptions &options) {
   // This doesn't handle Unicode symbols, but maybe that's okay.
   // Also accept the future mangling prefix.
-  // TODO: remove the "_S" as soon as MANGLING_PREFIX_STR gets "_S".
   llvm::Regex maybeSymbol("(_T|_?\\$[Ss])[_a-zA-Z0-9$.]+");
 
   swift::Demangle::Context DCtx;


### PR DESCRIPTION
`demangle` request stopped working because prefix for mangled name has changed.
For pre-checking, use `swift::Demangle::isSwiftSymbol()` instead of homemade function.

rdar://problem/39286958