### PR TITLE
Fix wrong usage of escape analysis in MemBehavior

### DIFF
--- a/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
@@ -769,12 +769,6 @@ public:
   /// address of a contained property escapes, but not the object itself.
   bool canEscapeTo(SILValue V, FullApplySite FAS);
 
-  /// Returns true if the value \p V or its content can escape to the
-  /// function call \p FAS.
-  /// This is the same as above, except that it returns true if an address of
-  /// a contained property escapes.
-  bool canObjectOrContentEscapeTo(SILValue V, FullApplySite FAS);
-
   /// Returns true if the value \p V can escape to the release-instruction \p
   /// RI. This means that \p RI may release \p V or any called destructor may
   /// access (or release) \p V.

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -1824,39 +1824,7 @@ bool EscapeAnalysis::canEscapeToUsePoint(SILValue V, SILNode *UsePoint,
     return true;
 
   // No hidden escapes: check if the Node is reachable from the UsePoint.
-  return ConGraph->isUsePoint(UsePoint, Node);
-}
-
-bool EscapeAnalysis::canEscapeTo(SILValue V, FullApplySite FAS) {
-  // If it's not a local object we don't know anything about the value.
-  if (!pointsToLocalObject(V))
-    return true;
-  auto *ConGraph = getConnectionGraph(FAS.getFunction());
-  return canEscapeToUsePoint(V, FAS.getInstruction(), ConGraph);
-}
-
-static bool hasReferenceSemantics(SILType T) {
-  // Exclude address types.
-  return T.isObject() && T.hasReferenceSemantics();
-}
-
-bool EscapeAnalysis::canObjectOrContentEscapeTo(SILValue V, FullApplySite FAS) {
-  // If it's not a local object we don't know anything about the value.
-  if (!pointsToLocalObject(V))
-    return true;
-
-  auto *ConGraph = getConnectionGraph(FAS.getFunction());
-  CGNode *Node = ConGraph->getNodeOrNull(V, this);
-  if (!Node)
-    return true;
-
-  // First check if there are escape paths which we don't explicitly see
-  // in the graph.
-  if (Node->escapesInsideFunction(isNotAliasingArgument(V)))
-    return true;
-
   // Check if the object itself can escape to the called function.
-  SILInstruction *UsePoint = FAS.getInstruction();
   if (ConGraph->isUsePoint(UsePoint, Node))
     return true;
 
@@ -1878,6 +1846,19 @@ bool EscapeAnalysis::canObjectOrContentEscapeTo(SILValue V, FullApplySite FAS) {
       return true;
   }
   return false;
+}
+
+bool EscapeAnalysis::canEscapeTo(SILValue V, FullApplySite FAS) {
+  // If it's not a local object we don't know anything about the value.
+  if (!pointsToLocalObject(V))
+    return true;
+  auto *ConGraph = getConnectionGraph(FAS.getFunction());
+  return canEscapeToUsePoint(V, FAS.getInstruction(), ConGraph);
+}
+
+static bool hasReferenceSemantics(SILType T) {
+  // Exclude address types.
+  return T.isObject() && T.hasReferenceSemantics();
 }
 
 bool EscapeAnalysis::canEscapeTo(SILValue V, RefCountingInst *RI) {

--- a/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
+++ b/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
@@ -227,7 +227,7 @@ MemBehavior MemoryBehaviorVisitor::visitBuiltinInst(BuiltinInst *BI) {
 MemBehavior MemoryBehaviorVisitor::visitTryApplyInst(TryApplyInst *AI) {
   MemBehavior Behavior = MemBehavior::MayHaveSideEffects;
   // Ask escape analysis.
-  if (!EA->canObjectOrContentEscapeTo(V, AI))
+  if (!EA->canEscapeTo(V, AI))
     Behavior = MemBehavior::None;
 
   // Otherwise be conservative and return that we may have side effects.
@@ -290,7 +290,7 @@ MemBehavior MemoryBehaviorVisitor::visitApplyInst(ApplyInst *AI) {
       Behavior = MemBehavior::MayRead;
 
     // Ask escape analysis.
-    if (!EA->canObjectOrContentEscapeTo(V, AI))
+    if (!EA->canEscapeTo(V, AI))
       Behavior = MemBehavior::None;
   }
   DEBUG(llvm::dbgs() << "  Found apply, returning " << Behavior << '\n');

--- a/test/SILOptimizer/retain_release_code_motion.sil
+++ b/test/SILOptimizer/retain_release_code_motion.sil
@@ -593,3 +593,30 @@ bb11:
   %26 = tuple ()
   return %26 : $()
 }
+
+// CHECK-LABEL: sil @detect_escape_of_bbarg
+// CHECK:      bb3({{.*}}):
+// CHECK-NEXT:   strong_retain
+// CHECK-NEXT:   apply
+// CHECK-NEXT:   strong_release
+sil @detect_escape_of_bbarg : $@convention(thin) () -> () {
+bb0:
+  %f = function_ref @use_C2 : $@convention(thin) (C2) -> ()
+  cond_br undef, bb1, bb2
+
+bb1:
+  %a = alloc_ref $C2
+  br bb3(%a: $C2, %a: $C2)
+
+bb2:
+  %b = alloc_ref $C2
+  br bb3(%b: $C2, %b: $C2)
+
+bb3(%p1: $C2, %p2: $C2):
+  strong_retain %p1: $C2 // This retain must not be moved over the apply
+  %c = apply %f(%p2) : $@convention(thin) (C2) -> ()
+  strong_release %p2: $C2
+  %10 = tuple ()
+  return %10 : $()
+}
+


### PR DESCRIPTION
The EscapeAnalysis:canEscapeTo function was actually broken, because it did not detect all escapes of a reference/pointer.
I completely replaced the implementation with the correct one (canObjectOrContentEscapeTo) and removed the now obsolete canObjectOrContentEscapeTo.
Fixes a miscompile.

rdar://problem/39161309