### PR TITLE
[SILInstruction] Introduce isDebugInstruction().

### DIFF
--- a/include/swift/SIL/DebugUtils.h
+++ b/include/swift/SIL/DebugUtils.h
@@ -43,18 +43,12 @@ namespace swift {
 
 class SILInstruction;
   
-/// Returns true if the instruction \p Inst is an instruction which is only
-/// relevant for debug information and has no other impact on program semantics.
-inline bool isDebugInst(SILInstruction *Inst) {
-  return isa<DebugValueInst>(Inst) || isa<DebugValueAddrInst>(Inst);
-}
-
 /// Deletes all of the debug instructions that use \p Inst.
 inline void deleteAllDebugUses(ValueBase *Inst) {
   for (auto UI = Inst->use_begin(), E = Inst->use_end(); UI != E;) {
     auto *Inst = UI->getUser();
     UI++;
-    if (isDebugInst(Inst))
+    if (Inst->isDebugInstruction())
       Inst->eraseFromParent();
   }
 }
@@ -76,7 +70,7 @@ template <bool nonDebugInsts> class DebugUseIterator
         return;
       
       SILInstruction *User = BaseIterator->getUser();
-      if (isDebugInst(User) != nonDebugInsts)
+      if (User->isDebugInstruction() != nonDebugInsts)
         return;
       
       BaseIterator++;
@@ -188,7 +182,7 @@ inline void eraseFromParentWithDebugInsts(SILInstruction *I,
       while (!result->use_empty()) {
         foundAny = true;
         auto *User = result->use_begin()->getUser();
-        assert(isDebugInst(User));
+        assert(User->isDebugInstruction());
         if (InstIter != SILBasicBlock::iterator() &&
             InstIter != I->getParent()->end() &&
             &*InstIter == User) {

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -597,6 +597,13 @@ public:
   /// you perform such optimizations like e.g. jump-threading.
   bool isTriviallyDuplicatable() const;
 
+  /// Returns true if the instruction is only relevant for debug
+  /// informations and has no other impact on program semantics.
+  bool isDebugInstruction() const {
+    return getKind() == SILInstructionKind::DebugValueInst ||
+           getKind() == SILInstructionKind::DebugValueAddrInst;
+  }
+
   /// Returns true if the instruction is a meta instruction which is
   /// relevant for debug information and does not get lowered to a real
   /// instruction.

--- a/lib/SIL/InstructionUtils.cpp
+++ b/lib/SIL/InstructionUtils.cpp
@@ -275,8 +275,8 @@ bool swift::isEndOfScopeMarker(SILInstruction *user) {
 }
 
 bool swift::isIncidentalUse(SILInstruction *user) {
-  return isEndOfScopeMarker(user) || isDebugInst(user)
-         || isa<FixLifetimeInst>(user);
+  return isEndOfScopeMarker(user) || user->isDebugInstruction() ||
+         isa<FixLifetimeInst>(user);
 }
 
 bool swift::onlyAffectsRefCount(SILInstruction *user) {

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -579,7 +579,7 @@ bool COWArrayOpt::checkSafeArrayAddressUses(UserList &AddressUsers) {
 
   for (auto *UseInst : AddressUsers) {
 
-    if (isDebugInst(UseInst))
+    if (UseInst->isDebugInstruction())
       continue;
 
     if (auto *AI = dyn_cast<ApplyInst>(UseInst)) {
@@ -698,7 +698,7 @@ bool COWArrayOpt::checkSafeArrayValueUses(UserList &ArrayValueUsers) {
     if (isa<MarkDependenceInst>(UseInst))
       continue;
 
-    if (isDebugInst(UseInst))
+    if (UseInst->isDebugInstruction())
       continue;
     
     // Found an unsafe or unknown user. The Array may escape here.
@@ -761,7 +761,7 @@ bool COWArrayOpt::checkSafeArrayElementUse(SILInstruction *UseInst,
   if (isa<MarkDependenceInst>(UseInst))
     return true;
 
-  if (isDebugInst(UseInst))
+  if (UseInst->isDebugInstruction())
     return true;
   
   // If this is an instruction which is a safe array element use if and only if
@@ -1764,7 +1764,7 @@ private:
   bool checkSafeArrayAddressUses(UserList &AddressUsers) {
     for (auto *UseInst : AddressUsers) {
 
-      if (isDebugInst(UseInst))
+      if (UseInst->isDebugInstruction())
         continue;
 
       if (isa<DeallocStackInst>(UseInst)) {

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -934,10 +934,10 @@ static bool isAddressInitializedAtCall(SILValue addr, SILInstruction *AI,
       if (!DT->properlyDominates(AI, user))
         return false;
     } else {
-      assert(isa<CopyAddrInst>(user) || isa<InitExistentialAddrInst>(user)
-             || isa<OpenExistentialAddrInst>(user)
-             || isa<DeallocStackInst>(user)
-             || isDebugInst(user) && "Unexpected instruction");
+      assert(isa<CopyAddrInst>(user) || isa<InitExistentialAddrInst>(user) ||
+             isa<OpenExistentialAddrInst>(user) ||
+             isa<DeallocStackInst>(user) ||
+             user->isDebugInstruction() && "Unexpected instruction");
     }
   }
   return true;

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -415,7 +415,7 @@ SILInstruction *SILCombiner::visitAllocStackInst(AllocStackInst *AS) {
     if (auto *OEAI = dyn_cast<OpenExistentialAddrInst>(Op->getUser())) {
       for (auto *Op : OEAI->getUses()) {
         assert(isa<DestroyAddrInst>(Op->getUser()) ||
-               isDebugInst(Op->getUser()) && "Unexpected instruction");
+               Op->getUser()->isDebugInstruction() && "Unexpected instruction");
         ToDelete.insert(Op->getUser());
       }
     }
@@ -425,7 +425,7 @@ SILInstruction *SILCombiner::visitAllocStackInst(AllocStackInst *AS) {
            isa<DestroyAddrInst>(Op->getUser()) ||
            isa<DeallocStackInst>(Op->getUser()) ||
            isa<DeinitExistentialAddrInst>(Op->getUser()) ||
-           isDebugInst(Op->getUser()) && "Unexpected instruction");
+           Op->getUser()->isDebugInstruction() && "Unexpected instruction");
     ToDelete.insert(Op->getUser());
   }
 
@@ -920,7 +920,7 @@ SILCombiner::visitInjectEnumAddrInst(InjectEnumAddrInst *IEAI) {
       // we don't care about the dealloc stack instructions
       continue;
     }
-    if (isDebugInst(CurrUser) || isa<LoadInst>(CurrUser)) {
+    if (CurrUser->isDebugInstruction() || isa<LoadInst>(CurrUser)) {
       // These Instructions are a non-risky use we can ignore
       continue;
     }

--- a/lib/SILOptimizer/Transforms/ConditionForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/ConditionForwarding.cpp
@@ -160,7 +160,7 @@ bool ConditionForwarding::tryOptimize(SwitchEnumInst *SEI) {
     if (ArgUser == SEI)
       continue;
 
-    if (isDebugInst(ArgUser))
+    if (ArgUser->isDebugInstruction())
       continue;
 
     if (ArgUser->getParent()->getSinglePredecessorBlock() == SEI->getParent()) {
@@ -227,7 +227,7 @@ bool ConditionForwarding::tryOptimize(SwitchEnumInst *SEI) {
   while (!Arg->use_empty()) {
     Operand *ArgUse = *Arg->use_begin();
     SILInstruction *ArgUser = ArgUse->getUser();
-    if (isDebugInst(ArgUser)) {
+    if (ArgUser->isDebugInstruction()) {
       // Don't care about debug instructions. Just remove them.
       ArgUser->eraseFromParent();
       continue;

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -1127,7 +1127,7 @@ static bool onlyHasTerminatorAndDebugInsts(SILBasicBlock *BB) {
   TermInst *Terminator = BB->getTerminator();
   SILBasicBlock::iterator Iter = BB->begin();
   while (&*Iter != Terminator) {
-    if (!isDebugInst(&*Iter))
+    if (!(&*Iter)->isDebugInstruction())
       return false;
     Iter++;
   }

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -2340,7 +2340,7 @@ void swift::trySpecializeApplyOfGeneric(
       SILInstruction *User = Use->getUser();
       if (isa<RefCountingInst>(User))
         continue;
-      if (isDebugInst(User))
+      if (User->isDebugInstruction())
         continue;
 
       auto FAS = FullApplySite::isa(User);


### PR DESCRIPTION
This is a property of an instruction and should be a member
function of `SILInstruction` and not a free function in
`DebugUtils`. Discussed with Adrian.