### PR TITLE
[test] Fix accidental double-escaping in %clang substitution

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -405,7 +405,7 @@ config.substitutions.append( ('%clang_apinotes',
 # Note: %clang is the locally-built clang.
 # To get Xcode's clang, use %target-clang.
 config.substitutions.append( ('%clang',
-                              "%r %r" %
+                              "%r %s" %
                                 (config.clang, clang_mcp_opt)) )
 
 ###


### PR DESCRIPTION
The module cache path option was already escaped using `%r`, so use `%s` when substituting it in later. This matches the behavior elsewhere in the file.