### PR TITLE
Ensure we account for force unwrapping in scoring solutions.

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2414,6 +2414,13 @@ public:
   void
   buildDisjunctionForOptionalVsUnderlying(Type boundTy, Type type,
                                           ConstraintLocator *locator) {
+    // NOTE: If we use other locator kinds for these disjunctions, we
+    // need to account for it in solution scores for forced-unwraps.
+    assert(locator->getPath().back().getKind() ==
+               ConstraintLocator::ImplicitlyUnwrappedDisjunctionChoice ||
+           locator->getPath().back().getKind() ==
+               ConstraintLocator::DynamicLookupResult);
+
     // Create the constraint to bind to the optional type and make it
     // the favored choice.
     auto *bindToOptional =

--- a/test/Constraints/iuo.swift
+++ b/test/Constraints/iuo.swift
@@ -213,3 +213,13 @@ func conditionalDowncastToObject(b: B?) -> D {
   return b as? D! // expected-error {{value of optional type 'D?' not unwrapped; did you mean to use '!' or '?'?}}
   // expected-warning@-1 {{using '!' here is deprecated and will be removed in a future release}}
 }
+
+// Ensure that we select the overload that does *not* involve forcing an IUO.
+func sr6988(x: Int?, y: Int?) -> Int { return x! }
+func sr6988(x: Int, y: Int) -> Float { return Float(x) }
+
+var x: Int! = nil
+var y: Int = 2
+
+let r = sr6988(x: x, y: y)
+let _: Int = r


### PR DESCRIPTION
This disappeared in the rework of IUOs but is needed when we have
multiple potential solutions involving different sets of overloads or
type bindings.

Fixes rdar://problem/37475971.
