### PR TITLE
[4.1] Make CopyForwarding more conservative about shrinking lifetimes.

### DIFF
--- a/lib/SILOptimizer/Transforms/CopyForwarding.cpp
+++ b/lib/SILOptimizer/Transforms/CopyForwarding.cpp
@@ -65,6 +65,7 @@
 #include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
 #include "swift/SILOptimizer/Analysis/DominanceAnalysis.h"
 #include "swift/SILOptimizer/Analysis/PostOrderAnalysis.h"
+#include "swift/SILOptimizer/Analysis/RCIdentityAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
 #include "swift/SILOptimizer/Utils/CFG.h"
@@ -165,6 +166,19 @@ static SILArgumentConvention getAddressArgConvention(ApplyInst *Apply,
   }
   assert(Oper && "Address value not passed as an argument to this call.");
   return Apply->getArgumentConvention(FoundArgIdx.getValue());
+}
+
+/// If the given instruction is a store, return the stored value.
+static SILValue getStoredValue(SILInstruction *I) {
+  switch (I->getKind()) {
+  case SILInstructionKind::StoreInst:
+  case SILInstructionKind::StoreBorrowInst:
+  case SILInstructionKind::StoreUnownedInst:
+  case SILInstructionKind::StoreWeakInst:
+    return I->getOperand(0);
+  default:
+    return SILValue();
+  }
 }
 
 //===----------------------------------------------------------------------===//
@@ -481,6 +495,7 @@ class CopyForwarding {
   // Per-function state.
   PostOrderAnalysis *PostOrder;
   DominanceAnalysis *DomAnalysis;
+  RCIdentityAnalysis *RCIAnalysis;
   bool DoGlobalHoisting;
   bool HasChanged;
   bool HasChangedCFG;
@@ -495,10 +510,15 @@ class CopyForwarding {
   // beyond the value's immediate uses.
   bool IsSrcLoadedFrom;
 
+  // Does the address defined by CurrentDef have unrecognized uses of a
+  // nontrivial value stored at its address?
+  bool HasUnknownStoredValue;
+
   bool HasForwardedToCopy;
   SmallPtrSet<SILInstruction*, 16> SrcUserInsts;
   SmallPtrSet<DebugValueAddrInst*, 4> SrcDebugValueInsts;
   SmallVector<CopyAddrInst*, 4> TakePoints;
+  SmallPtrSet<SILInstruction *, 16> StoredValueUserInsts;
   SmallVector<DestroyAddrInst*, 4> DestroyPoints;
   SmallPtrSet<SILBasicBlock*, 32> DeadInBlocks;
 
@@ -513,6 +533,11 @@ class CopyForwarding {
     virtual bool visitNormalUse(SILInstruction *user) {
       if (isa<LoadInst>(user))
         CPF.IsSrcLoadedFrom = true;
+
+      if (SILValue storedValue = getStoredValue(user)) {
+        if (!CPF.markStoredValueUsers(storedValue))
+          CPF.HasUnknownStoredValue = true;
+      }
 
       // Bail on multiple uses in the same instruction to avoid complexity.
       return CPF.SrcUserInsts.insert(user).second;
@@ -534,10 +559,12 @@ class CopyForwarding {
   };
 
 public:
-  CopyForwarding(PostOrderAnalysis *PO, DominanceAnalysis *DA)
-      : PostOrder(PO), DomAnalysis(DA), DoGlobalHoisting(false),
-        HasChanged(false), HasChangedCFG(false), IsSrcLoadedFrom(false),
-        HasForwardedToCopy(false), CurrentCopy(nullptr) {}
+  CopyForwarding(PostOrderAnalysis *PO, DominanceAnalysis *DA,
+                 RCIdentityAnalysis *RCIAnalysis)
+    : PostOrder(PO), DomAnalysis(DA), RCIAnalysis(RCIAnalysis),
+      DoGlobalHoisting(false), HasChanged(false), HasChangedCFG(false),
+      IsSrcLoadedFrom(false), HasUnknownStoredValue(false),
+      HasForwardedToCopy(false), CurrentCopy(nullptr) {}
 
   void reset(SILFunction *F) {
     // Don't hoist destroy_addr globally in transparent functions. Avoid cloning
@@ -552,13 +579,16 @@ public:
       // We'll invalidate the analysis that are used by other passes at the end.
       DomAnalysis->invalidate(F, SILAnalysis::InvalidationKind::Everything);
       PostOrder->invalidate(F, SILAnalysis::InvalidationKind::Everything);
+      RCIAnalysis->invalidate(F, SILAnalysis::InvalidationKind::Everything);
     }
     CurrentDef = SILValue();
     IsSrcLoadedFrom = false;
+    HasUnknownStoredValue = false;
     HasForwardedToCopy = false;
     SrcUserInsts.clear();
     SrcDebugValueInsts.clear();
     TakePoints.clear();
+    StoredValueUserInsts.clear();
     DestroyPoints.clear();
     DeadInBlocks.clear();
     CurrentCopy = nullptr;
@@ -585,6 +615,8 @@ protected:
 
   typedef llvm::SmallSetVector<SILInstruction *, 16> UserVector;
   bool doesCopyDominateDestUsers(const UserVector &DirectDestUses);
+
+  bool markStoredValueUsers(SILValue storedValue);
 };
 
 class CopyDestUserVisitor : public AddressUserVisitor {
@@ -801,6 +833,51 @@ bool CopyForwarding::doesCopyDominateDestUsers(
     // Check dominance of the parent blocks.
     if (!DT->properlyDominates(CurrentCopy, user))
       return false;
+  }
+  return true;
+}
+
+// Add all recognized users of storedValue to StoredValueUserInsts. Return true
+// if all users were recgonized.
+//
+// To find all SSA users of storedValue, we first find the RC root, then search
+// past any instructions that may propagate the reference.
+bool CopyForwarding::markStoredValueUsers(SILValue storedValue) {
+  if (storedValue->getType().isTrivial(*storedValue->getModule()))
+    return true;
+
+  // Find the RC root, peeking past things like struct_extract.
+  RCIdentityFunctionInfo *RCI = RCIAnalysis->get(storedValue->getFunction());
+  SILValue root = RCI->getRCIdentityRoot(storedValue);
+
+  SmallVector<SILInstruction *, 8> users;
+  RCI->getRCUsers(root, users);
+
+  for (SILInstruction *user : users) {
+    // Recognize any uses that have no results as normal uses. They cannot
+    // transitively propagate a reference.
+    if (user->getResults().empty()) {
+      StoredValueUserInsts.insert(user);
+      continue;
+    }
+    // Recognize full applies as normal uses. They may transitively retain, but
+    // the caller cannot rely on that.
+    if (FullApplySite::isa(user)) {
+      StoredValueUserInsts.insert(user);
+      continue;
+    }
+    // A single-valued use is nontransitive if its result is trivial.
+    if (auto *SVI = dyn_cast<SingleValueInstruction>(user)) {
+      if (SVI->getType().isTrivial(user->getModule())) {
+        StoredValueUserInsts.insert(user);
+        continue;
+      }
+    }
+    // Conservatively treat everything else as potentially transitively
+    // retaining the stored value.
+    DEBUG(llvm::dbgs() << "  Cannot reduce lifetime. May retain " << storedValue
+          << " at: " << *user << "\n");
+    return false;
   }
   return true;
 }
@@ -1112,10 +1189,10 @@ bool CopyForwarding::backwardPropagateCopy() {
 /// The copy will be eliminated if the original is not accessed between the
 /// point of copy and the original's destruction.
 ///
-/// Def = <uniquely identified> // no aliases
+/// CurrentDef = <uniquely identified> // no aliases
 /// ...
 /// Copy = copy_addr [init] Def
-/// ...                    // no access to Def
+/// ...                    // no access to CurrentDef
 /// destroy_addr Def
 ///
 /// Return true if a destroy was inserted, forwarded from a copy, or the
@@ -1137,6 +1214,19 @@ bool CopyForwarding::hoistDestroy(SILInstruction *DestroyPoint,
     --SI;
     SILInstruction *Inst = &*SI;
     if (!SrcUserInsts.count(Inst)) {
+      if (StoredValueUserInsts.count(Inst)) {
+        // The current definition may take ownership of a value stored into its
+        // address. Its lifetime cannot end before the last use of that stored
+        // value.
+        // CurrentDef = ...
+        // Copy = copy_addr CurrentDef to ...
+        // store StoredValue to CurrentDef
+        // ...                    // no access to CurrentDef
+        // retain StoredValue
+        // destroy_addr CurrentDef
+        DEBUG(llvm::dbgs() << "  Cannot hoist above stored value use:" << *Inst);
+        return false;
+      }
       if (!IsWorthHoisting && isa<ApplyInst>(Inst))
         IsWorthHoisting = true;
       continue;
@@ -1185,7 +1275,7 @@ void CopyForwarding::forwardCopiesOf(SILValue Def, SILFunction *F) {
   // TODO: Record all loads during collectUsers. Implement findRetainPoints to
   // peek though projections of the load, like unchecked_enum_data to find the
   // true extent of the lifetime including transitively referenced objects.
-  if (IsSrcLoadedFrom)
+  if (IsSrcLoadedFrom || HasUnknownStoredValue)
     return;
 
   bool HoistedDestroyFound = false;
@@ -1408,7 +1498,8 @@ class CopyForwardingPass : public SILFunctionTransform
 
     auto *PO = getAnalysis<PostOrderAnalysis>();
     auto *DA = getAnalysis<DominanceAnalysis>();
-    auto Forwarding = CopyForwarding(PO, DA);
+    auto *RCIA = getAnalysis<RCIdentityAnalysis>();
+    auto Forwarding = CopyForwarding(PO, DA, RCIA);
 
     for (SILValue Def : CopiedDefs) {
 #ifndef NDEBUG

--- a/test/SILOptimizer/copyforward.sil
+++ b/test/SILOptimizer/copyforward.sil
@@ -773,3 +773,92 @@ bb0(%0 : $*T, %1 : $*T):
   %r1 = tuple ()
   return %r1 : $()
 }
+
+// CHECK-LABEL: sil @testKnownStoredValueUser : $@convention(thin) (@guaranteed AClass) -> @out AClass {
+// CHECK: [[ALLOC:%.*]] = alloc_stack $AClass
+// CHECK: copy_addr [[ALLOC]] to %0 : $*AClass
+// CHECK: strong_retain %1 : $AClass
+// CHECK: destroy_addr [[ALLOC]] : $*AClass
+// CHECK-LABEL: } // end sil function 'testKnownStoredValueUser'
+sil @testKnownStoredValueUser : $@convention(thin) (@guaranteed AClass) -> (@out AClass) {
+bb0(%0 : $*AClass, %1 : $AClass):
+  %2 = alloc_stack $AClass
+  store %1 to %2 : $*AClass
+  copy_addr %2 to %0 : $*AClass
+  strong_retain %1 : $AClass
+  destroy_addr %2 : $*AClass
+  dealloc_stack %2 : $*AClass
+  %999 = tuple ()
+  return %999 : $()
+}
+
+// CHECK-LABEL: sil @testExtractedStoredValueUser1 : $@convention(thin) (@guaranteed ObjWrapper) -> @out AnyObject {
+// CHECK: bb0(%0 : $*AnyObject, %1 : $ObjWrapper):
+// CHECK:   [[ALLOC:%.*]] = alloc_stack $AnyObject
+// CHECK:   [[EXTRACT:%.*]] = struct_extract %1 : $ObjWrapper, #ObjWrapper.obj
+// CHECK:   store [[EXTRACT]] to [[ALLOC]] : $*AnyObject
+// CHECK:   copy_addr [[ALLOC]] to %0 : $*AnyObject
+// CHECK:   strong_retain [[EXTRACT]] : $AnyObject
+// CHECK:   destroy_addr [[ALLOC]] : $*AnyObject
+// CHECK-LABEL: } // end sil function 'testExtractedStoredValueUser1'
+sil @testExtractedStoredValueUser1 : $@convention(thin) (@guaranteed ObjWrapper) -> (@out AnyObject) {
+bb0(%0 : $*AnyObject, %1 : $ObjWrapper):
+  %2 = alloc_stack $AnyObject
+  %3 = struct_extract %1 : $ObjWrapper, #ObjWrapper.obj
+  store %3 to %2 : $*AnyObject
+  copy_addr %2 to %0 : $*AnyObject
+  strong_retain %3 : $AnyObject
+  destroy_addr %2 : $*AnyObject
+  dealloc_stack %2 : $*AnyObject
+  %999 = tuple ()
+  return %999 : $()
+}
+
+// CHECK-LABEL: sil @testExtractedStoredValueUser2 : $@convention(thin) (@guaranteed ObjWrapper) -> @out AnyObject {
+// CHECK: bb0(%0 : $*AnyObject, %1 : $ObjWrapper):
+// CHECK:   [[ALLOC:%.*]] = alloc_stack $AnyObject
+// CHECK:   [[EXTRACT:%.*]] = struct_extract %1 : $ObjWrapper, #ObjWrapper.obj
+// CHECK:   store [[EXTRACT]] to [[ALLOC]] : $*AnyObject
+// CHECK:   copy_addr [[ALLOC]] to %0 : $*AnyObject
+// CHECK:   retain_value %1 : $ObjWrapper
+// CHECK:   destroy_addr [[ALLOC]] : $*AnyObject
+// CHECK-LABEL: } // end sil function 'testExtractedStoredValueUser2'
+sil @testExtractedStoredValueUser2 : $@convention(thin) (@guaranteed ObjWrapper) -> (@out AnyObject) {
+bb0(%0 : $*AnyObject, %1 : $ObjWrapper):
+  %2 = alloc_stack $AnyObject
+  %3 = struct_extract %1 : $ObjWrapper, #ObjWrapper.obj
+  store %3 to %2 : $*AnyObject
+  copy_addr %2 to %0 : $*AnyObject
+  retain_value %1 : $ObjWrapper
+  destroy_addr %2 : $*AnyObject
+  dealloc_stack %2 : $*AnyObject
+  %999 = tuple ()
+  return %999 : $()
+}
+
+struct AClassWrapper {
+  var a: AClass
+  var b: AClass
+}
+
+// CHECK-LABEL: sil @testUnknownStoredValueUser : $@convention(thin) (@guaranteed AClass) -> @out AClass {
+// CHECK: bb0(%0 : $*AClass, %1 : $AClass):
+// CHECK:   [[ALLOC:%.*]] = alloc_stack $AClass
+// CHECK:   store %1 to %2 : $*AClass
+// CHECK:   [[STRUCT:%.*]] = struct $AClassWrapper (%1 : $AClass, %1 : $AClass)
+// CHECK:   copy_addr [[ALLOC]] to %0 : $*AClass
+// CHECK:   retain_value [[STRUCT]] : $AClassWrapper
+// CHECK:   destroy_addr [[ALLOC]] : $*AClass
+// CHECK-LABEL: } // end sil function 'testUnknownStoredValueUser'
+sil @testUnknownStoredValueUser : $@convention(thin) (@guaranteed AClass) -> (@out AClass) {
+bb0(%0 : $*AClass, %1 : $AClass):
+  %2 = alloc_stack $AClass
+  store %1 to %2 : $*AClass
+  %3 = struct $AClassWrapper (%1 : $AClass, %1 : $AClass)
+  copy_addr %2 to %0 : $*AClass
+  retain_value %3 : $AClassWrapper
+  destroy_addr %2 : $*AClass
+  dealloc_stack %2 : $*AClass
+  %999 = tuple ()
+  return %999 : $()
+}


### PR DESCRIPTION
Merge the two commits required to fix a miscompile:
<rdar://problem/39209102> [SR-7354]: Swift 4.1 Regression: EXC_BAD_ACCESS for Optimized Builds in Xcode 9.3