### PR TITLE
[4.1] Fix wrong usage of escape analysis in MemBehavior

### DIFF
--- a/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/EscapeAnalysis.h
@@ -769,12 +769,6 @@ public:
   /// address of a contained property escapes, but not the object itself.
   bool canEscapeTo(SILValue V, FullApplySite FAS);
 
-  /// Returns true if the value \p V or its content can escape to the
-  /// function call \p FAS.
-  /// This is the same as above, except that it returns true if an address of
-  /// a contained property escapes.
-  bool canObjectOrContentEscapeTo(SILValue V, FullApplySite FAS);
-
   /// Returns true if the value \p V can escape to the release-instruction \p
   /// RI. This means that \p RI may release \p V or any called destructor may
   /// access (or release) \p V.

--- a/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
+++ b/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
@@ -225,7 +225,7 @@ MemBehavior MemoryBehaviorVisitor::visitBuiltinInst(BuiltinInst *BI) {
 MemBehavior MemoryBehaviorVisitor::visitTryApplyInst(TryApplyInst *AI) {
   MemBehavior Behavior = MemBehavior::MayHaveSideEffects;
   // Ask escape analysis.
-  if (!EA->canObjectOrContentEscapeTo(V, AI))
+  if (!EA->canEscapeTo(V, AI))
     Behavior = MemBehavior::None;
 
   // Otherwise be conservative and return that we may have side effects.
@@ -284,7 +284,7 @@ MemBehavior MemoryBehaviorVisitor::visitApplyInst(ApplyInst *AI) {
       Behavior = MemBehavior::MayRead;
 
     // Ask escape analysis.
-    if (!EA->canObjectOrContentEscapeTo(V, AI))
+    if (!EA->canEscapeTo(V, AI))
       Behavior = MemBehavior::None;
   }
   DEBUG(llvm::dbgs() << "  Found apply, returning " << Behavior << '\n');

--- a/test/SILOptimizer/retain_release_code_motion.sil
+++ b/test/SILOptimizer/retain_release_code_motion.sil
@@ -603,3 +603,30 @@ bb11:
   %26 = tuple ()
   return %26 : $()
 }
+
+// CHECK-LABEL: sil @detect_escape_of_bbarg
+// CHECK:      bb3({{.*}}):
+// CHECK-NEXT:   strong_retain
+// CHECK-NEXT:   apply
+// CHECK-NEXT:   strong_release
+sil @detect_escape_of_bbarg : $@convention(thin) () -> () {
+bb0:
+  %f = function_ref @use_C2 : $@convention(thin) (C2) -> ()
+  cond_br undef, bb1, bb2
+
+bb1:
+  %a = alloc_ref $C2
+  br bb3(%a: $C2, %a: $C2)
+
+bb2:
+  %b = alloc_ref $C2
+  br bb3(%b: $C2, %b: $C2)
+
+bb3(%p1: $C2, %p2: $C2):
+  strong_retain %p1: $C2 // This retain must not be moved over the apply
+  %c = apply %f(%p2) : $@convention(thin) (C2) -> ()
+  strong_release %p2: $C2
+  %10 = tuple ()
+  return %10 : $()
+}
+


### PR DESCRIPTION
The EscapeAnalysis:canEscapeTo function was actually broken, because it did not detect all escapes of a reference/pointer.
I replaced the implementation of canEscapeTo with the already existing implementation of canObjectOrContentEscapeTo, which is more conservative.
Fixes a miscompile.

rdar://problem/39161309

* Explanation: Due to a bug in escape analysis we ended up moving an object retain across a function call,  which actually released the object. The result is a use-after-free crash.
* Scope of Issue: It's impossible to narrow down the scope. Although it seems that the chances are low, it can happen in every code.
* Origination: The bug was in the compiler since a long time.
* Risk: Low. It makes the escaping-check more conservative. No new code is introduced . The change just moved the correct (more conservative) implementation to the function which was missing the check.
* Reviewed By: @gottesmm
* Testing: There is a regression test for it