### PR TITLE
Missing conformance crashers

### DIFF
--- a/test/multifile/Inputs/rdar-34584596-A.swift
+++ b/test/multifile/Inputs/rdar-34584596-A.swift
@@ -1,0 +1,10 @@
+protocol Attributed {
+    var asAttributes: DefaultedAttributes? { get }
+}
+
+extension Attributed {
+    var asAttributes: DefaultedAttributes? { return self as? DefaultedAttributes }
+}
+
+struct Impl: Attributed {
+}

--- a/test/multifile/Inputs/rdar-34584596-B.swift
+++ b/test/multifile/Inputs/rdar-34584596-B.swift
@@ -1,0 +1,12 @@
+protocol DefaultedAttributes: Attributes {
+}
+
+extension DefaultedAttributes {
+    var attributes: [(title: String, description: String)] {
+        var attributes: [(title: String, description: String)] = []
+        return attributes
+    }
+}
+
+extension Impl: DefaultedAttributes {
+}

--- a/test/multifile/Inputs/rdar-34584596-C.swift
+++ b/test/multifile/Inputs/rdar-34584596-C.swift
@@ -1,0 +1,3 @@
+protocol Attributes {
+    var attributes: [(title: String, description: String)] { get }
+}

--- a/test/multifile/Inputs/sr-285-other.swift
+++ b/test/multifile/Inputs/sr-285-other.swift
@@ -1,0 +1,34 @@
+// Natural numbers encoded as types:
+protocol NaturalNumberType { static var intValue: Int { get } }
+struct NaturalNumberZero : NaturalNumberType {
+    static var intValue: Int { return 0 }
+}
+struct NaturalNumberSuccessorOf<T: NaturalNumberType> : NaturalNumberType {
+    static var intValue: Int { return T.intValue + 1 }
+}
+// See FourFloats below for an example of how to use the following:
+protocol StaticStorageType {
+    associatedtype Element
+    associatedtype Count: NaturalNumberType
+}
+extension StaticStorageType {
+    typealias Successor = StaticStorageSuccessorOf<Self>
+}
+struct StaticStorageOfOne<E> : StaticStorageType {
+    typealias Element = E
+    typealias Count = NaturalNumberZero
+    var storage: Element
+}
+struct StaticStorageSuccessorOf<T: StaticStorageType> : StaticStorageType {
+    typealias Element = T.Element
+    typealias Count = NaturalNumberSuccessorOf<T.Count>
+    var storage: (Element, T)
+}
+// Using the StaticStorage-thing:
+typealias FourFloats = StaticStorageOfOne<Float>.Successor.Successor.Successor
+
+//-----------------------------------------------------------------------------
+// This function works and will print the number of bytes of FourFloats, ie 16.
+// But compiler will crash if an identical function is declared in main.swift.
+//-----------------------------------------------------------------------------
+func definedInOther() { print(MemoryLayout<FourFloats>.size) }

--- a/test/multifile/protocol-conformance-rdar-34584596.swift
+++ b/test/multifile/protocol-conformance-rdar-34584596.swift
@@ -1,0 +1,2 @@
+// RUN: not --crash %target-swift-frontend -emit-ir -O -o - -primary-file %S/Inputs/rdar-34584596-A.swift %S/Inputs/rdar-34584596-B.swift %S/Inputs/rdar-34584596-C.swift -module-name main
+

--- a/test/multifile/protocol-conformance-sr-285.swift
+++ b/test/multifile/protocol-conformance-sr-285.swift
@@ -1,0 +1,6 @@
+// RUN: not --crash %target-swift-frontend -emit-ir -o - -primary-file %s %S/Inputs/sr-285-other.swift -module-name main
+
+// SR-285: Crash in IR generation due to missing conformance.
+func definedInMain() { print(MemoryLayout<FourFloats>.size) }
+
+let d = definedInOther()


### PR DESCRIPTION
Add some test cases for places where the type checker doesn't complete conformances, causing a crash later on.