### PR TITLE
Fix a pair of crashes with '@unknown'

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3925,6 +3925,9 @@ NOTE(missing_several_cases,none,
 NOTE(missing_unknown_case,none,
      "handle unknown values using \"@unknown default\"", ())
 
+NOTE(non_exhaustive_switch_drop_unknown,none,
+     "remove '@unknown' to handle remaining values", ())
+
 NOTE(missing_particular_case,none,
      "add missing case: '%0'", (StringRef))
 WARNING(redundant_particular_case,none,

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1216,7 +1216,7 @@ namespace {
       SmallVector<Space, 4> spaces;
       for (auto *caseBlock : Switch->getCases()) {
         if (caseBlock->hasUnknownAttr()) {
-          assert(unknownCase == nullptr);
+          assert(unknownCase == nullptr && "multiple unknown cases");
           unknownCase = caseBlock;
           continue;
         }

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1342,10 +1342,25 @@ namespace {
 
       // Decide whether we want an error or a warning.
       auto mainDiagType = diag::non_exhaustive_switch;
-      if (!uncovered.isEmpty() && unknownCase) {
-        assert(defaultReason == RequiresDefault::No);
-        mainDiagType = diag::non_exhaustive_switch_warn;
+      if (unknownCase) {
+        switch (defaultReason) {
+        case RequiresDefault::EmptySwitchBody:
+          llvm_unreachable("there's an @unknown case; the body can't be empty");
+        case RequiresDefault::No:
+          if (!uncovered.isEmpty())
+            mainDiagType = diag::non_exhaustive_switch_warn;
+          break;
+        case RequiresDefault::UncoveredSwitch:
+        case RequiresDefault::SpaceTooLarge:
+          TC.diagnose(startLoc, diag::non_exhaustive_switch);
+          TC.diagnose(unknownCase->getLoc(),
+                      diag::non_exhaustive_switch_drop_unknown)
+            .fixItRemoveChars(unknownCase->getStartLoc(),
+                              unknownCase->getLoc());
+          return;
+        }
       }
+
       switch (uncovered.checkDowngradeToWarning()) {
       case DowngradeToWarning::No:
         break;

--- a/test/Compatibility/exhaustive_switch.swift
+++ b/test/Compatibility/exhaustive_switch.swift
@@ -473,6 +473,21 @@ func quiteBigEnough() -> Bool {
   case (.case10, _): return true
   }
 
+  switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) { // expected-error {{switch must be exhaustive}}
+  case (.case0, _): return true
+  case (.case1, _): return true
+  case (.case2, _): return true
+  case (.case3, _): return true
+  case (.case4, _): return true
+  case (.case5, _): return true
+  case (.case6, _): return true
+  case (.case7, _): return true
+  case (.case8, _): return true
+  case (.case9, _): return true
+  case (.case10, _): return true
+  @unknown default: return false // expected-note {{remove '@unknown' to handle remaining values}} {{3-12=}}
+  }
+
 
   // No diagnostic
   switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) {
@@ -525,6 +540,10 @@ func quiteBigEnough() -> Bool {
   case .one: return true
   case .two: return true
   case .three: return true
+  }
+
+  // Make sure we haven't just stopped emitting diagnostics.
+  switch OverlyLargeSpaceEnum.case1 { // expected-error {{switch must be exhaustive}} expected-note 12 {{add missing case}} expected-note {{handle unknown values}}
   }
 }
 

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -427,12 +427,12 @@ case .Thing: // expected-error{{additional 'case' blocks cannot appear after the
   break
 }
 
-switch Whatever.Thing { // expected-warning {{switch must be exhaustive}} expected-note{{add missing case: '.Thing'}}
+switch Whatever.Thing {
 @unknown case _, _: // expected-error {{'@unknown' cannot be applied to multiple patterns}}
   break
 }
 
-switch Whatever.Thing { // expected-warning {{switch must be exhaustive}} expected-note{{add missing case: '.Thing'}}
+switch Whatever.Thing {
 @unknown case _, _, _: // expected-error {{'@unknown' cannot be applied to multiple patterns}}
   break
 }
@@ -537,5 +537,75 @@ switch x { // expected-error {{switch must be exhaustive}}
 
 switch x { // expected-error {{switch must be exhaustive}}
 @unknown default: // expected-note {{remove '@unknown' to handle remaining values}} {{1-10=}}
+  break
+}
+
+switch Whatever.Thing {
+case .Thing:
+  break
+@unknown case _: // expected-error {{'@unknown' can only be applied to the last case in a switch}}
+  break
+@unknown case _:
+  break
+}
+
+switch Whatever.Thing {
+case .Thing:
+  break
+@unknown case _: // expected-error {{'@unknown' can only be applied to the last case in a switch}}
+  break
+@unknown default:
+  break
+}
+
+switch Whatever.Thing {
+case .Thing:
+  break
+@unknown default:
+  break
+@unknown default: // expected-error {{additional 'case' blocks cannot appear after the 'default' block of a 'switch'}}
+  break
+}
+
+switch Whatever.Thing {
+@unknown case _: // expected-error {{'@unknown' can only be applied to the last case in a switch}}
+  break
+@unknown case _:
+  break
+}
+
+switch Whatever.Thing {
+@unknown case _: // expected-error {{'@unknown' can only be applied to the last case in a switch}}
+  break
+@unknown default:
+  break
+}
+
+switch Whatever.Thing {
+@unknown default:
+  break
+@unknown default: // expected-error {{additional 'case' blocks cannot appear after the 'default' block of a 'switch'}}
+  break
+}
+
+
+switch x {
+@unknown case _: // expected-error {{'@unknown' can only be applied to the last case in a switch}}
+  break
+@unknown case _:
+  break
+}
+
+switch x {
+@unknown case _: // expected-error {{'@unknown' can only be applied to the last case in a switch}}
+  break
+@unknown default:
+  break
+}
+
+switch x {
+@unknown default:
+  break
+@unknown default: // expected-error {{additional 'case' blocks cannot appear after the 'default' block of a 'switch'}}
   break
 }

--- a/test/Parse/switch.swift
+++ b/test/Parse/switch.swift
@@ -522,3 +522,20 @@ switch Whatever.Thing { // expected-warning {{switch must be exhaustive}} expect
 case _:
   break
 }
+
+switch x { // expected-error {{switch must be exhaustive}}
+case 1:
+  break
+@unknown case _: // expected-note {{remove '@unknown' to handle remaining values}} {{1-10=}}
+  break
+}
+
+switch x { // expected-error {{switch must be exhaustive}}
+@unknown case _: // expected-note {{remove '@unknown' to handle remaining values}} {{1-10=}}
+  break
+}
+
+switch x { // expected-error {{switch must be exhaustive}}
+@unknown default: // expected-note {{remove '@unknown' to handle remaining values}} {{1-10=}}
+  break
+}

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -472,6 +472,21 @@ func quiteBigEnough() -> Bool {
   case (.case10, _): return true
   }
 
+  switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) { // expected-error {{switch must be exhaustive}}
+  case (.case0, _): return true
+  case (.case1, _): return true
+  case (.case2, _): return true
+  case (.case3, _): return true
+  case (.case4, _): return true
+  case (.case5, _): return true
+  case (.case6, _): return true
+  case (.case7, _): return true
+  case (.case8, _): return true
+  case (.case9, _): return true
+  case (.case10, _): return true
+  @unknown default: return false // expected-note {{remove '@unknown' to handle remaining values}} {{3-12=}}
+  }
+
 
   // No diagnostic
   switch (OverlyLargeSpaceEnum.case1, OverlyLargeSpaceEnum.case2) {
@@ -524,6 +539,10 @@ func quiteBigEnough() -> Bool {
   case .one: return true
   case .two: return true
   case .three: return true
+  }
+
+  // Make sure we haven't just stopped emitting diagnostics.
+  switch OverlyLargeSpaceEnum.case1 { // expected-error {{switch must be exhaustive}} expected-note 12 {{add missing case}} expected-note {{handle unknown values}}
   }
 }
 


### PR DESCRIPTION
Fixes a pair of issues @rintaro caught around misuse of `@unknown default`. Let's not crash on bad user input!

[SR-7408](https://bugs.swift.org/browse/SR-7408), [SR-7409](https://bugs.swift.org/browse/SR-7409)