### PR TITLE
SILGen: Open-code materializeForSet in more situations.

### DIFF
--- a/lib/SILGen/SILGenMaterializeForSet.cpp
+++ b/lib/SILGen/SILGenMaterializeForSet.cpp
@@ -370,12 +370,36 @@ public:
       return true;
 
     // We also need to open-code if the witness is defined in a
-    // protocol context because IRGen won't know how to reconstruct
-    // the type parameters.  (In principle, this can be done in the
-    // callback storage if we need to.)
+    // context that isn't ABI-compatible with the protocol witness,
+    // because IRGen won't know how to reconstruct
+    // the type parameters.  (In principle, this could be done in the
+    // callback storage.)
+    
+    // This can happen if the witness is in a protocol extension...
     if (Witness->getDeclContext()->getAsProtocolOrProtocolExtensionContext())
       return true;
 
+    // ...if the witness is in a constrained extension that adds protocol
+    // requirements...
+    if (auto ext = dyn_cast<ExtensionDecl>(Witness->getDeclContext())) {
+      if (ext->isConstrainedExtension()) {
+        // TODO: We could perhaps avoid open coding if the extension only adds
+        // same type or superclass constraints, which don't require any
+        // additional generic arguments.
+        return true;
+      }
+    }
+    
+    // ...or if the witness is a generic subscript with more general
+    // subscript-level constraints than the requirement.
+    if (auto witnessSub = dyn_cast<SubscriptDecl>(Witness->getStorage())) {
+      // TODO: We only really need to open-code if the witness has more general
+      // subscript-level constraints than the requirement. Our generic signature
+      // representation makes testing this difficult, unfortunately.
+      if (witnessSub->isGeneric())
+        return true;
+    }
+    
     return false;
   }
 

--- a/test/Interpreter/subscripting.swift
+++ b/test/Interpreter/subscripting.swift
@@ -15,3 +15,28 @@ struct Foo {
 let f = Foo()
 print(f[]) // CHECK: subscript
 print(f.subscript()) // CHECK: func
+
+// SR-7418
+
+protocol P {
+  subscript<T : Y>(_: T) -> Int { get set }
+}
+
+struct Q : P {
+  subscript<T : X>(_ idx: T) -> Int {
+    get { return 0 } set { idx.foo() }
+  }
+}
+protocol Y : X {}
+protocol X { func foo() }
+
+struct Idx : Y {
+  func foo() { print("I survived") }
+}
+
+func foo<T : P>(_ t: inout T) {
+  t[Idx()] += 1
+}
+
+var q = Q()
+foo(&q) // CHECK: I survived

--- a/test/SILGen/materializeForSet.swift
+++ b/test/SILGen/materializeForSet.swift
@@ -434,30 +434,12 @@ struct GenericSubscriptWitness : GenericSubscriptProtocol {
   subscript<T>(_: T) -> T { get { } set { } }
 }
 
-// CHECK-LABEL: sil private [transparent] @$S17materializeForSet23GenericSubscriptWitnessVyxxcluimytfU_ : $@convention(method) <T> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout GenericSubscriptWitness, @thick GenericSubscriptWitness.Type) -> () {
-// CHECK:       bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*GenericSubscriptWitness, %3 : $@thick GenericSubscriptWitness.Type):
-// CHECK:         [[BUFFER:%.*]] = project_value_buffer $T in %1 : $*Builtin.UnsafeValueBuffer
-// CHECK-NEXT:    [[INDICES:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*T
-// CHECK:         [[SETTER:%.*]] = function_ref @$S17materializeForSet23GenericSubscriptWitnessVyxxcluis : $@convention(method) <τ_0_0> (@in τ_0_0, @in τ_0_0, @inout GenericSubscriptWitness) -> ()
-// CHECK-NEXT:    apply [[SETTER]]<T>([[INDICES]], [[BUFFER]], %2) : $@convention(method) <τ_0_0> (@in τ_0_0, @in τ_0_0, @inout GenericSubscriptWitness) -> ()
-// CHECK-NEXT:    dealloc_value_buffer $*T in %1 : $*Builtin.UnsafeValueBuffer
-// CHECK-NEXT:    [[RESULT:%.*]] = tuple ()
-// CHECK-NEXT:    return [[RESULT]] : $()
-
-// CHECK-LABEL: sil hidden [transparent] @$S17materializeForSet23GenericSubscriptWitnessVyxxcluim : $@convention(method) <T> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @in_guaranteed T, @inout GenericSubscriptWitness) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
-// CHECK:      bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*T, %3 : $*GenericSubscriptWitness):
-// CHECK-NEXT:   [[BUFFER:%.*]] = alloc_value_buffer $T in %1 : $*Builtin.UnsafeValueBuffer
-// CHECK-NEXT:   copy_addr %2 to [initialization] [[BUFFER]] : $*T
-// CHECK-NEXT:   [[VALUE:%.*]] = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*T
-// CHECK-NEXT:   [[SELF:%.*]] = load [trivial] %3 : $*GenericSubscriptWitness
-// CHECK:        [[GETTER:%.*]] = function_ref @$S17materializeForSet23GenericSubscriptWitnessVyxxcluig : $@convention(method) <τ_0_0> (@in_guaranteed τ_0_0, GenericSubscriptWitness) -> @out τ_0_0
-// CHECK-NEXT:   apply [[GETTER]]<T>([[VALUE]], %2, [[SELF]]) : $@convention(method) <τ_0_0> (@in_guaranteed τ_0_0, GenericSubscriptWitness) -> @out τ_0_0
-// CHECK-NEXT:   [[VALUE_PTR:%.*]] = address_to_pointer [[VALUE]] : $*T to $Builtin.RawPointer
-// CHECK:        [[CALLBACK:%.*]] = function_ref @$S17materializeForSet23GenericSubscriptWitnessVyxxcluimytfU_
-// CHECK-NEXT:   [[CALLBACK_PTR:%.*]] = thin_function_to_pointer [[CALLBACK]] : $@convention(method) <τ_0_0> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @inout GenericSubscriptWitness, @thick GenericSubscriptWitness.Type) -> () to $Builtin.RawPointer
-// CHECK-NEXT:   [[CALLBACK_OPTIONAL:%.*]] = enum $Optional<Builtin.RawPointer>, #Optional.some!enumelt.1, [[CALLBACK_PTR]] : $Builtin.RawPointer
-// CHECK-NEXT:   [[RESULT:%.*]] = tuple ([[VALUE_PTR]] : $Builtin.RawPointer, [[CALLBACK_OPTIONAL]] : $Optional<Builtin.RawPointer>)
-// CHECK-NEXT:   return [[RESULT]] : $(Builtin.RawPointer, Optional<Builtin.RawPointer>)
+// -- materializeForSet for a generic subscript gets open-coded in terms of
+// the concrete getter/setter.
+// CHECK-LABEL: sil private [transparent] @$S17materializeForSet23GenericSubscriptWitnessVAA0dE8ProtocolA2aDPyqd__qd__cluimytfU_TW
+// CHECK:         function_ref @$S17materializeForSet23GenericSubscriptWitnessVyxxcluis
+// CHECK-LABEL: sil private [transparent] [thunk] @$S17materializeForSet23GenericSubscriptWitnessVAA0dE8ProtocolA2aDPyqd__qd__cluimTW
+// CHECK:         function_ref @$S17materializeForSet23GenericSubscriptWitnessVyxxcluig
 
 extension GenericSubscriptProtocol {
   subscript<T>(t: T) -> T { get { } set { } }
@@ -485,7 +467,7 @@ struct InferredRequirementOnSubscript : InferredRequirementOnSubscriptProtocol {
 
 // CHECK-LABEL: sil hidden @$S17materializeForSet30InferredRequirementOnSubscriptVyAA015GenericTypeWithE0VyxGSicAA5MagicRzluis : $@convention(method) <T where T : Magic> (GenericTypeWithRequirement<T>, Int, @inout InferredRequirementOnSubscript) -> ()
 
-// CHECK-LABEL: sil hidden [transparent] @$S17materializeForSet30InferredRequirementOnSubscriptVyAA015GenericTypeWithE0VyxGSicAA5MagicRzluim : $@convention(method) <T where T : Magic> (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, Int, @inout InferredRequirementOnSubscript) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>)
+// CHECK-LABEL: sil private [transparent] [thunk] @$S17materializeForSet30InferredRequirementOnSubscriptVAA0defG8ProtocolA2aDPyAA015GenericTypeWithE0Vyqd__GSicAA5MagicRd__luimTW
 
 // Test for materializeForSet vs static properties of structs.
 
@@ -679,6 +661,25 @@ struct BackwardMutation : BackwardMutationProtocol {
 func doBackwardMutation(m: inout BackwardMutationProtocol) {
   m.value += 1
 }
+
+// materializeForSet for a constrained-extension protocol witness requires
+// open coding.
+
+protocol ConditionalSubscript {
+  subscript(_: Int) -> Self { get set }
+}
+
+struct HasConditionalSubscript<T> {}
+
+extension HasConditionalSubscript: ConditionalSubscript where T: ConditionalSubscript {
+  subscript(_: Int) -> HasConditionalSubscript<T> {
+    get { return self }
+    set { }
+  }
+}
+
+// CHECK-LABEL: sil private [transparent] [thunk] @$S17materializeForSet23HasConditionalSubscriptVyxGAA0eF0A2aERzlAaEPyxSicimTW
+// CHECK:         function_ref @$S17materializeForSet23HasConditionalSubscriptVA2A0eF0RzlEyACyxGSicig
 
 // CHECK-LABEL: sil_vtable DerivedForOverride {
 // CHECK:   #BaseForOverride.valueStored!getter.1: (BaseForOverride) -> () -> Int : @$S17materializeForSet07DerivedB8OverrideC11valueStoredSivg

--- a/validation-test/stdlib/Slice/MutableSlice_Of_MinimalMutableCollection_FullWidth.swift
+++ b/validation-test/stdlib/Slice/MutableSlice_Of_MinimalMutableCollection_FullWidth.swift
@@ -92,4 +92,38 @@ SliceTests.addMutableCollectionTests(
   isFixedLengthCollection: true
 )
 
+// rdar://problem/35760754
+
+func f<C : MutableCollection>(
+  _ elements: inout C
+) { }
+
+var CrashTests = TestSuite("MutableSliceCrash")
+
+extension TestSuite {
+  public func addMyMutableCollectionTests<C : MutableCollection>(
+    _ testNamePrefix: String = "",
+    maker: @escaping ([C.Element]) -> C
+  ) {
+
+    // this runs just fine
+    self.test("\(testNamePrefix).Direct") {
+      var c = makeCollection(elements: [])
+      f(&c[c.startIndex..<c.endIndex])
+    }
+
+    // this used to crash, even though the only difference is it's calling
+    // makeCollection via the argument to the original function
+    self.test("\(testNamePrefix).Indirect") {
+      var c = maker([])
+      f(&c[c.startIndex..<c.endIndex])
+    }
+  }
+}
+
+CrashTests.addMyMutableCollectionTests(
+  "Crasher",
+  maker: makeCollection
+)
+
 runAllTests()


### PR DESCRIPTION
Since this code was first written, we've added more language features that introduce the opportunity for a materializeForSet protocol witness to have an incompatible polymorphic convention with its concrete implementation:

- In a conditional conformance, if a witness comes from a constrained extension with additional protocol requirements, then the witness will require those conformances as additional polymorphic arguments, making its materializeForSet uncallable from code using the protocol witness.
- Given a subscript requirement, the witness may be a generic subscript with a more general signature than the witness, making the generic arguments to the concrete materializeForSet callback incompatible with those expected for the witness.

Longer term, representing materializeForSet patterns using accessor coroutines should obviate the need for this hack. For now, it's necessary for correctness, addressing rdar://problem/35760754.