### PR TITLE
[GSB] withoutRedundantSubpath should leave Concrete RequirementSource as Concrete.

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1309,7 +1309,7 @@ const RequirementSource *RequirementSource::withoutRedundantSubpath(
 
   case Concrete:
     return parent->withoutRedundantSubpath(builder, start, end)
-      ->viaParent(builder, getAssociatedType());
+      ->viaConcrete(builder, getProtocolConformance());
 
   case Derived:
     return parent->withoutRedundantSubpath(builder, start, end)

--- a/validation-test/compiler_crashers_2_fixed/0152-sr-7397.swift
+++ b/validation-test/compiler_crashers_2_fixed/0152-sr-7397.swift
@@ -1,0 +1,19 @@
+// RUN: %target-typecheck-verify-swift %s
+
+protocol _UnicodeParser_ {
+    associatedtype Encoding: _UnicodeEncoding_
+}
+protocol _UnicodeEncoding_ {
+    associatedtype CodeUnit : BinaryInteger_
+    associatedtype ForwardParser : _UnicodeParser_
+      where ForwardParser.Encoding == Self
+
+}
+protocol BinaryInteger_ {
+    associatedtype Words: Collection_ where Words.Index == Int_
+}
+protocol Collection_ {
+    associatedtype Index: Comparable_
+}
+protocol Comparable_ {}
+struct Int_: Comparable_ {}


### PR DESCRIPTION
Fixes rdar://problem/39316039 and https://bugs.swift.org/browse/SR-7397.