### PR TITLE
Deserialize fewer SIL functions in -Onone

### DIFF
--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2681,7 +2681,7 @@ void SILModule::print(SILPrintContext &PrintCtx, ModuleDecl *M,
       if (!WholeModuleMode && !(D->getDeclContext() == AssociatedDeclContext))
           continue;
       if ((isa<ValueDecl>(D) || isa<OperatorDecl>(D) ||
-           isa<ExtensionDecl>(D)) &&
+           isa<ExtensionDecl>(D) || isa<ImportDecl>(D)) &&
           !D->isImplicit()) {
         if (isa<AccessorDecl>(D))
           continue;

--- a/lib/SILOptimizer/Transforms/Devirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/Devirtualizer.cpp
@@ -93,11 +93,9 @@ bool Devirtualizer::devirtualizeAppliesInFunction(SILFunction &F,
     assert(CalleeFn && "Expected devirtualized callee!");
 
     // We need to ensure that we link after devirtualizing in order to pull in
-    // everything we reference from another module. This is especially important
-    // for transparent functions, because if transparent functions are not
-    // inlined for some reason, we need to generate code for them.
-    // Note that functions, which are only referenced from witness/vtables, are
-    // not linked upfront by the SILLinker.
+    // everything we reference from another module, which may expose optimization
+    // opportunities and is also needed for correctness if we reference functions
+    // with non-public linkage. See lib/SIL/Linker.cpp for details.
     if (!CalleeFn->isDefinition())
       F.getModule().linkFunction(CalleeFn, SILModule::LinkingMode::LinkAll);
 

--- a/test/SIL/Serialization/Inputs/def_public_non_abi.sil
+++ b/test/SIL/Serialization/Inputs/def_public_non_abi.sil
@@ -1,4 +1,10 @@
+sil non_abi [serialized] @other_public_non_abi_function : $@convention(thin) () -> () {
+  %0 = tuple ()
+  return %0 : $()
+}
+
 sil non_abi [serialized] @public_non_abi_function : $@convention(thin) () -> () {
+  %fn = function_ref @other_public_non_abi_function : $@convention(thin) () -> ()
   %0 = tuple ()
   return %0 : $()
 }

--- a/test/SIL/Serialization/public_non_abi.sil
+++ b/test/SIL/Serialization/public_non_abi.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_public_non_abi.sil
-// RUN: %target-sil-opt -performance-linker -I %t %s | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil -I %t %s | %FileCheck %s
 
 sil_stage raw
 
@@ -20,6 +20,11 @@ bb0:
 }
 
 // Make sure the function body is deserialized.
-// CHECK-LABEL: sil shared_external [serialized] [canonical] @public_non_abi_function : $@convention(thin) () -> ()
+// CHECK-LABEL: sil shared_external [serialized] @public_non_abi_function : $@convention(thin) () -> ()
+// CHECK: function_ref @other_public_non_abi_function
 // CHECK: return
 sil hidden_external [serialized] @public_non_abi_function : $@convention(thin) () -> ()
+
+// Make sure the function body is deserialized.
+// CHECK-LABEL: sil shared_external [serialized] @other_public_non_abi_function : $@convention(thin) () -> ()
+// CHECK: return

--- a/test/SIL/Serialization/vtable_deserialization.swift
+++ b/test/SIL/Serialization/vtable_deserialization.swift
@@ -11,19 +11,15 @@ import vtable_deserialization_input
 Class.firstMethod()
 
 
-// For now, we also deserialize the body of firstMethod(), even though it
-// is not transparent.
-// CHECK-LABEL: sil public_external [serialized] @$S28vtable_deserialization_input5ClassC11firstMethodyyFZ : $@convention(method) (@thick Class.Type) -> () {
+// The methods should not be deserialized in the mandatory pipeline.
+
+// CHECK-LABEL: sil [serialized] @$S28vtable_deserialization_input5ClassC11firstMethodyyFZ : $@convention(method) (@thick Class.Type) -> (){{$}}
 // OPT-LABEL: sil public_external @$S28vtable_deserialization_input5ClassC11firstMethodyyFZ : $@convention(method) (@thick Class.Type) -> () {
 
-// The other two methods should not be deserialized in the mandatory
-// pipeline.
-
-// FIXME: Temporary regression
-// CHECK-LABEL: sil public_external [serialized] @$S28vtable_deserialization_input5ClassC12secondMethodyyFZ : $@convention(method) (@thick Class.Type) -> () {
+// CHECK-LABEL: sil [serialized] @$S28vtable_deserialization_input5ClassC12secondMethodyyFZ : $@convention(method) (@thick Class.Type) -> (){{$}}
 // OPT-LABEL: sil public_external @$S28vtable_deserialization_input5ClassC12secondMethodyyFZ : $@convention(method) (@thick Class.Type) -> () {
 
-// CHECK-LABEL: sil public_external [serialized] @$S28vtable_deserialization_input5ClassC11thirdMethodyyFZ : $@convention(method) (@thick Class.Type) -> () {
+// CHECK-LABEL: sil [serialized] @$S28vtable_deserialization_input5ClassC11thirdMethodyyFZ : $@convention(method) (@thick Class.Type) -> (){{$}}
 // OPT-LABEL: sil public_external @$S28vtable_deserialization_input5ClassC11thirdMethodyyFZ : $@convention(method) (@thick Class.Type) -> () {
 
 // Make sure we deserialized the vtable.

--- a/test/SILOptimizer/Inputs/linker_pass_input.swift
+++ b/test/SILOptimizer/Inputs/linker_pass_input.swift
@@ -2,6 +2,7 @@
 @_silgen_name("unknown")
 public func unknown() -> ()
 
+@inline(never)
 @inlinable
 public func doSomething() {
   unknown()

--- a/test/SILOptimizer/hello-world.swift
+++ b/test/SILOptimizer/hello-world.swift
@@ -1,0 +1,6 @@
+// RUN: rm -rf %t && mkdir -p %t/stats
+// RUN: %target-swift-frontend -emit-sil -stats-output-dir %t/stats %s -o /dev/null
+// RUN: %utils/process-stats-dir.py --evaluate 'NumSILGenFunctions < 10' %t/stats
+// RUN: %utils/process-stats-dir.py --evaluate 'NumSILOptFunctions < 10' %t/stats
+
+print("Hello world")

--- a/test/SILOptimizer/linker.swift
+++ b/test/SILOptimizer/linker.swift
@@ -1,21 +1,23 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module %S/Inputs/linker_pass_input.swift -o %t/Swift.swiftmodule -parse-stdlib -parse-as-library -module-name Swift -module-link-name swiftCore
-// RUN: %target-swift-frontend %s -O -I %t -sil-debug-serialization -o - -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend %s -I %t -emit-sil | %FileCheck %s
+// RUN: %target-swift-frontend %s -I %t -O -emit-sil | %FileCheck %s --check-prefix=OPT
 
-// CHECK: sil public_external [serialized] [canonical] @$Ss11doSomethingyyF : $@convention(thin) () -> () {
+// CHECK: sil [serialized] [noinline] @$Ss11doSomethingyyF : $@convention(thin) () -> (){{$}}
+// OPT: sil public_external [noinline] @$Ss11doSomethingyyF : $@convention(thin) () -> () {
 doSomething()
 
 // CHECK: sil @$Ss12doSomething2yyF : $@convention(thin) () -> ()
 // CHECK-NOT: return
 doSomething2()
 
-// CHECK: sil public_external [serialized] [noinline] [canonical] @$Ss16callDoSomething3yyF
+// CHECK: sil [serialized] [noinline] @$Ss16callDoSomething3yyF : $@convention(thin) () -> (){{$}}
+// OPT: sil public_external [noinline] @$Ss16callDoSomething3yyF : $@convention(thin) () -> () {
 
-// CHECK: sil [canonical] @unknown
+// OPT: sil @unknown
 
-// CHECK: sil [canonical] @$Ss1AVABycfC
+// OPT: sil @$Ss1AVABycfC
 
-// CHECK: sil [noinline] [canonical] @$Ss12doSomething3yyxlF
-// CHECK-NOT: return
+// OPT: sil [noinline] @$Ss12doSomething3yyxlF : $@convention(thin) <τ_0_0> (@in_guaranteed τ_0_0) -> (){{$}}
 
 callDoSomething3()

--- a/test/Serialization/Inputs/def_basic.sil
+++ b/test/Serialization/Inputs/def_basic.sil
@@ -1132,37 +1132,23 @@ entry(%f : $@convention(thin) (Int) -> @out Int, %x : $Int):
   return %y : $Int
 }
 
-// Make sure we serialize the body of closure even without -sil-serialize-all.
-// CHECK_DECL-LABEL:  @partial_apply_with_closure
-sil [transparent] [serialized] [transparent] @partial_apply_with_closure : $@convention(thin) (@owned @callee_owned () -> Bool, @owned String, UnsafePointer<Int8>, Int64) -> () {
+// CHECK-LABEL:  @partial_apply_with_closure
+sil [transparent] [serialized] @partial_apply_with_closure : $@convention(thin) (@owned @callee_owned () -> Bool, @owned String, UnsafePointer<Int8>, Int64) -> () {
 bb0(%0 : $@callee_owned () -> Bool, %1 : $String, %2 : $UnsafePointer<Int8>, %3 : $Int64):
   %17 = function_ref @closure_body : $@convention(thin) (UnsafePointer<Int8>, UnsafePointer<Int8>, Int64) -> ()
-// CHECK_DECL: function_ref @closure_body
+// CHECK: function_ref @closure_body
   %18 = partial_apply %17(%2, %3) : $@convention(thin) (UnsafePointer<Int8>, UnsafePointer<Int8>, Int64) -> ()
-// CHECK_DECL: partial_apply
+// CHECK: partial_apply
   %30 = tuple ()
   return %30 : $()
 }
-
-sil shared [serialized] @closure_body : $@convention(thin) (UnsafePointer<Int8>, UnsafePointer<Int8>, Int64) -> () {
-bb0(%0 : $UnsafePointer<Int8>, %1 : $UnsafePointer<Int8>, %2 : $Int64):
-  %3 = function_ref @assert_fail : $@convention(thin) (UnsafePointer<Int8>, UnsafePointer<Int8>, Int64) -> ()
-  %4 = apply %3(%0, %1, %2) : $@convention(thin) (UnsafePointer<Int8>, UnsafePointer<Int8>, Int64) -> ()
-  %5 = tuple ()
-  return %5 : $()
-}
-
-// CHECK_DECL-LABEL: @closure_body : $@convention(thin) (UnsafePointer<Int8>, UnsafePointer<Int8>, Int64) -> () {
-// CHECK_DECL: function_ref @assert_fail
-
-sil [transparent] [serialized] @assert_fail : $@convention(thin) (UnsafePointer<Int8>, UnsafePointer<Int8>, Int64) -> ()
 
 // rdar: 15893086
 struct GenericStruct<T> {
   var x : T
 }
 
-// CHECK-LABEL: @extract_generic_struct
+// CHECK-LABEL: sil public_external [transparent] [serialized] @extract_generic_struct
 sil [transparent] [serialized] @extract_generic_struct : $@convention(thin) GenericStruct<Int64> -> Int64 {
 entry(%0 : $GenericStruct<Int64>):
   // CHECK: %1 = struct_extract %0 : $GenericStruct<Int64>, #GenericStruct.x
@@ -1346,6 +1332,19 @@ bb0(%0 : $Int32, %1 : $Int, %2 : $Int, %3 : $Foo):
   return %17 : $()
 }
 
+
+sil [transparent] [serialized] @assert_fail : $@convention(thin) (UnsafePointer<Int8>, UnsafePointer<Int8>, Int64) -> ()
+
+sil shared [serialized] @closure_body : $@convention(thin) (UnsafePointer<Int8>, UnsafePointer<Int8>, Int64) -> () {
+bb0(%0 : $UnsafePointer<Int8>, %1 : $UnsafePointer<Int8>, %2 : $Int64):
+  %3 = function_ref @assert_fail : $@convention(thin) (UnsafePointer<Int8>, UnsafePointer<Int8>, Int64) -> ()
+  %4 = apply %3(%0, %1, %2) : $@convention(thin) (UnsafePointer<Int8>, UnsafePointer<Int8>, Int64) -> ()
+  %5 = tuple ()
+  return %5 : $()
+}
+
+// CHECK-LABEL: @closure_body : $@convention(thin) (UnsafePointer<Int8>, UnsafePointer<Int8>, Int64) -> () {
+// CHECK: function_ref @assert_fail
 
 sil_vtable [serialized] Foo {
   #Foo.subscript!getter.1: @$S3tmp3FooC9subscriptSiSi1x_Si1ytcfg

--- a/test/Serialization/Inputs/def_transparent.swift
+++ b/test/Serialization/Inputs/def_transparent.swift
@@ -44,7 +44,8 @@ public enum MaybePair {
   case Right(String)
   case Both(Int32, String)
 }
-@inlinable
+
+@_transparent
 public func do_switch(u u: MaybePair) {
   switch u {
   case .Neither:

--- a/test/Serialization/always_inline.swift
+++ b/test/Serialization/always_inline.swift
@@ -1,11 +1,16 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_always_inline.swift
 // RUN: llvm-bcanalyzer %t/def_always_inline.swiftmodule | %FileCheck %s
-// RUN: %target-swift-frontend -emit-sil -I %t %s | %FileCheck %s -check-prefix=SIL
+// RUN: %target-swift-frontend -emit-sib -I %t %s -o %t/always_inline.sib
+// RUN: %target-sil-opt -performance-linker %t/always_inline.sib -I %t | %FileCheck %s -check-prefix=SIL
 
 // CHECK-NOT: UnknownCode
 
 import def_always_inline
+
+// SIL-LABEL: sil public_external [serialized] [always_inline] [canonical] @$S17def_always_inline22AlwaysInlineInitStructV1xACSb_tcfC : $@convention(method) (Bool, @thin AlwaysInlineInitStruct.Type) -> AlwaysInlineInitStruct {
+
+// SIL-LABEL: sil public_external [serialized] [always_inline] [canonical] @$S17def_always_inline16testAlwaysInline1xS2b_tF : $@convention(thin) (Bool) -> Bool {
 
 // SIL-LABEL: sil @main
 // SIL: [[RAW:%.+]] = global_addr @$S13always_inline3rawSbvp : $*Bool
@@ -16,10 +21,5 @@ var raw = testAlwaysInline(x: false)
 
 // SIL: [[FUNC2:%.+]] = function_ref @$S17def_always_inline22AlwaysInlineInitStructV1xACSb_tcfC : $@convention(method) (Bool, @thin AlwaysInlineInitStruct.Type) -> AlwaysInlineInitStruct
 // SIL: apply [[FUNC2]]({{%.+}}, {{%.+}}) : $@convention(method) (Bool, @thin AlwaysInlineInitStruct.Type) -> AlwaysInlineInitStruct
-
 var a = AlwaysInlineInitStruct(x: false)
-
-// SIL-LABEL: [always_inline] @$S17def_always_inline16testAlwaysInline1xS2b_tF : $@convention(thin) (Bool) -> Bool
-
-// SIL-LABEL: sil public_external [serialized] [always_inline] @$S17def_always_inline22AlwaysInlineInitStructV1xACSb_tcfC : $@convention(method) (Bool, @thin AlwaysInlineInitStruct.Type) -> AlwaysInlineInitStruct {
 

--- a/test/Serialization/basic_sil.swift
+++ b/test/Serialization/basic_sil.swift
@@ -1,11 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend -assume-parsing-unqualified-ownership-sil -emit-module -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -o %t/def_basic.swiftmodule %S/Inputs/def_basic.sil
 // RUN: llvm-bcanalyzer %t/def_basic.swiftmodule | %FileCheck %s
-// RUN: %target-build-swift -emit-sil -I %t %s | %FileCheck %S/Inputs/def_basic.sil
-
-// RUN: %empty-directory(%t)
-// RUN: %target-build-swift  -Xfrontend -assume-parsing-unqualified-ownership-sil -emit-module -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -o %t/def_basic.swiftmodule %S/Inputs/def_basic.sil
-// RUN: %target-build-swift -emit-sil -I %t %s | %FileCheck -check-prefix=CHECK_DECL %S/Inputs/def_basic.sil
+// RUN: %target-build-swift -emit-sil -I %t %s -o %t/basic_sil.sil
+// RUN: %target-sil-opt -I %t %t/basic_sil.sil -performance-linker | %FileCheck %S/Inputs/def_basic.sil
 
 // This test currently is written such that no optimizations are assumed.
 // REQUIRES: swift_test_mode_optimize_none

--- a/test/Serialization/basic_sil_objc.swift
+++ b/test/Serialization/basic_sil_objc.swift
@@ -1,7 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -Xfrontend %clang-importer-sdk -I %S/../Inputs/clang-importer-sdk/swift-modules -emit-module -Xfrontend -disable-diagnostic-passes -force-single-frontend-invocation -o %t/def_basic_objc.swiftmodule %S/Inputs/def_basic_objc.sil
 // RUN: llvm-bcanalyzer %t/def_basic_objc.swiftmodule | %FileCheck %s
-// RUN: %target-build-swift -Xfrontend %clang-importer-sdk -emit-sil -I %t %s | %FileCheck %S/Inputs/def_basic_objc.sil
+
+// RUN: %target-build-swift -Xfrontend %clang-importer-sdk -emit-sil -I %t %s -o %t/basic_sil_objc.sil
+// RUN: %target-sil-opt %t/basic_sil_objc.sil -performance-linker -I %t | %FileCheck %S/Inputs/def_basic_objc.sil
 
 // This test currently is written such that no optimizations are assumed.
 // REQUIRES: swift_test_mode_optimize_none
@@ -10,6 +12,7 @@
 // CHECK-NOT: UnknownCode
 
 import def_basic_objc
+import Foundation
 
 func test_all() {
   serialize_all()

--- a/test/Serialization/noinline.swift
+++ b/test/Serialization/noinline.swift
@@ -1,11 +1,16 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_noinline.swift
 // RUN: llvm-bcanalyzer %t/def_noinline.swiftmodule | %FileCheck %s
-// RUN: %target-swift-frontend -emit-sil -I %t %s | %FileCheck %s -check-prefix=SIL
+// RUN: %target-swift-frontend -emit-sib -I %t %s -o %t/noinline.sib
+// RUN: %target-sil-opt -performance-linker %t/noinline.sib -I %t | %FileCheck %s -check-prefix=SIL
 
 // CHECK-NOT: UnknownCode
 
 import def_noinline
+
+// SIL-LABEL: sil public_external [serialized] [noinline] [canonical] @$S12def_noinline18NoInlineInitStructV1xACSb_tcfC : $@convention(method) (Bool, @thin NoInlineInitStruct.Type) -> NoInlineInitStruct {
+
+// SIL-LABEL: sil public_external [serialized] [noinline] [canonical] @$S12def_noinline12testNoinline1xS2b_tF : $@convention(thin) (Bool) -> Bool {
 
 // SIL-LABEL: sil @main
 // SIL: [[RAW:%.+]] = global_addr @$S8noinline3rawSbvp : $*Bool
@@ -18,7 +23,3 @@ var raw = testNoinline(x: false)
 // SIL: apply [[FUNC2]]({{%.+}}, {{%.+}}) : $@convention(method) (Bool, @thin NoInlineInitStruct.Type) -> NoInlineInitStruct
 
 var a = NoInlineInitStruct(x: false)
-
-// SIL-LABEL: [serialized] [noinline] @$S12def_noinline12testNoinline1xS2b_tF : $@convention(thin) (Bool) -> Bool
-
-// SIL-LABEL: sil public_external [serialized] [noinline] @$S12def_noinline18NoInlineInitStructV1xACSb_tcfC : $@convention(method) (Bool, @thin NoInlineInitStruct.Type) -> NoInlineInitStruct {

--- a/test/Serialization/transparent.swift
+++ b/test/Serialization/transparent.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_transparent.swift
 // RUN: llvm-bcanalyzer %t/def_transparent.swiftmodule | %FileCheck %s
-// RUN: %target-swift-frontend -module-name transparent -emit-sil -I %t %s | tee /tmp/xxx | %FileCheck %s -check-prefix=SIL
+// RUN: %target-swift-frontend -module-name transparent -emit-sil -I %t %s | %FileCheck %s -check-prefix=SIL
 
 // CHECK-NOT: UnknownCode
 
@@ -40,7 +40,7 @@ func wrap_br() {
   test_br()
 }
 
-// SIL-LABEL: sil public_external [serialized] @$S15def_transparent9do_switch1uyAA9MaybePairO_tF : $@convention(thin) (@guaranteed MaybePair) -> () {
+// SIL-LABEL: sil public_external [transparent] [serialized] @$S15def_transparent9do_switch1uyAA9MaybePairO_tF : $@convention(thin) (@guaranteed MaybePair) -> () {
 // SIL: bb0(%0 : $MaybePair):
 // SIL: retain_value %0 : $MaybePair
 // SIL: switch_enum %0 : $MaybePair, case #MaybePair.Neither!enumelt: bb[[CASE1:[0-9]+]], case #MaybePair.Left!enumelt.1: bb[[CASE2:[0-9]+]], case #MaybePair.Right!enumelt.1: bb[[CASE3:[0-9]+]], case #MaybePair.Both!enumelt.1: bb[[CASE4:[0-9]+]]


### PR DESCRIPTION
Get mandatory inlining out of the linking business altogether. Mandatory inlining now only deserializes transparent functions. A separate mandatory linking pass deserializes shared definitions that we need to emit into the client.