### PR TITLE
Remove one of the two worklists from the SIL linker

### DIFF
--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -490,11 +490,15 @@ public:
   /// \return null if this module has no such function
   SILFunction *lookUpFunction(SILDeclRef fnRef);
 
+  /// Attempt to deserialize the SILFunction. Returns true if deserialization
+  /// succeeded, false otherwise.
+  bool loadFunction(SILFunction *F);
+
   /// Attempt to link the SILFunction. Returns true if linking succeeded, false
   /// otherwise.
   ///
   /// \return false if the linking failed.
-  bool linkFunction(SILFunction *Fun,
+  bool linkFunction(SILFunction *F,
                     LinkingMode LinkAll = LinkingMode::LinkNormal);
 
   /// Check if a given function exists in any of the modules with a

--- a/lib/SIL/Linker.cpp
+++ b/lib/SIL/Linker.cpp
@@ -73,22 +73,13 @@ bool SILLinkerVisitor::processFunction(SILFunction *F) {
 
   // If F is a declaration, first deserialize it.
   if (F->isExternalDeclaration()) {
-    auto *NewFn = Loader->lookupSILFunction(F);
-
-    if (!NewFn || NewFn->isExternalDeclaration())
+    if (!addFunctionToWorklist(F))
       return false;
-
-    F = NewFn;
+  } else {
+    Worklist.push_back(F);
   }
 
-  ++NumFuncLinked;
-
-  // Try to transitively deserialize everything referenced by this
-  // function.
-  Worklist.push_back(F);
   process();
-
-  // Since we successfully processed at least one function, return true.
   return true;
 }
 

--- a/lib/SIL/Linker.cpp
+++ b/lib/SIL/Linker.cpp
@@ -37,15 +37,13 @@ bool SILLinkerVisitor::addFunctionToWorklist(SILFunction *F) {
 
   DEBUG(llvm::dbgs() << "Imported function: "
                      << F->getName() << "\n");
-  if (auto *NewFn = Loader->lookupSILFunction(F)) {
-    if (NewFn->isExternalDeclaration())
+  if (Mod.loadFunction(F)) {
+    if (F->isExternalDeclaration())
       return false;
 
-    assert(NewFn == F && "This shouldn't happen");
-
-    NewFn->setBare(IsBare);
-    NewFn->verify();
-    Worklist.push_back(NewFn);
+    F->setBare(IsBare);
+    F->verify();
+    Worklist.push_back(F);
     ++NumFuncLinked;
 
     return true;

--- a/lib/SIL/Linker.h
+++ b/lib/SIL/Linker.h
@@ -16,7 +16,6 @@
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILVisitor.h"
 #include "swift/SIL/SILModule.h"
-#include "swift/Serialization/SerializedSILLoader.h"
 #include <functional>
 
 namespace swift {
@@ -27,9 +26,6 @@ class SILLinkerVisitor : public SILInstructionVisitor<SILLinkerVisitor, bool> {
 
   /// The SILModule that we are loading from.
   SILModule &Mod;
-
-  /// The SILLoader that this visitor is using to link.
-  SerializedSILLoader *Loader;
 
   /// Break cycles visiting recursive protocol conformances.
   llvm::DenseSet<ProtocolConformance *> VisitedConformances;
@@ -45,9 +41,8 @@ class SILLinkerVisitor : public SILInstructionVisitor<SILLinkerVisitor, bool> {
   LinkingMode Mode;
 
 public:
-  SILLinkerVisitor(SILModule &M, SerializedSILLoader *L,
-                   SILModule::LinkingMode LinkingMode)
-      : Mod(M), Loader(L), Worklist(), FunctionDeserializationWorklist(),
+  SILLinkerVisitor(SILModule &M, SILModule::LinkingMode LinkingMode)
+      : Mod(M), Worklist(), FunctionDeserializationWorklist(),
         Mode(LinkingMode) {}
 
   /// Process F, recursively deserializing any thing F may reference.

--- a/lib/SIL/Linker.h
+++ b/lib/SIL/Linker.h
@@ -79,10 +79,13 @@ public:
   bool visitMetatypeInst(MetatypeInst *MI);
 
 private:
-  /// Add a function to our function worklist for processing.
-  void addFunctionToWorklist(SILFunction *F) {
-    FunctionDeserializationWorklist.push_back(F);
-  }
+  /// Cause a function to be deserialized, and visit all other functions
+  /// referenced from this function according to the linking mode.
+  bool addFunctionToWorklist(SILFunction *F);
+
+  /// Consider a function for deserialization if the current linking mode
+  /// requires it.
+  bool maybeAddFunctionToWorklist(SILFunction *F);
 
   /// Is the current mode link all? Link all implies we should try and link
   /// everything, not just transparent/shared functions.

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -485,8 +485,17 @@ SILFunction *SILModule::lookUpFunction(SILDeclRef fnRef) {
   return lookUpFunction(name);
 }
 
-bool SILModule::linkFunction(SILFunction *Fun, SILModule::LinkingMode Mode) {
-  return SILLinkerVisitor(*this, getSILLoader(), Mode).processFunction(Fun);
+bool SILModule::loadFunction(SILFunction *F) {
+  SILFunction *NewF = getSILLoader()->lookupSILFunction(F);
+  if (!NewF)
+    return false;
+
+  assert(F == NewF);
+  return true;
+}
+
+bool SILModule::linkFunction(SILFunction *F, SILModule::LinkingMode Mode) {
+  return SILLinkerVisitor(*this, getSILLoader(), Mode).processFunction(F);
 }
 
 SILFunction *SILModule::findFunction(StringRef Name, SILLinkage Linkage) {

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -495,7 +495,7 @@ bool SILModule::loadFunction(SILFunction *F) {
 }
 
 bool SILModule::linkFunction(SILFunction *F, SILModule::LinkingMode Mode) {
-  return SILLinkerVisitor(*this, getSILLoader(), Mode).processFunction(F);
+  return SILLinkerVisitor(*this, Mode).processFunction(F);
 }
 
 SILFunction *SILModule::findFunction(StringRef Name, SILLinkage Linkage) {


### PR DESCRIPTION
I'm re-doing the control flow here in preparation for landing a change making the linker lazier in -Onone.