### PR TITLE
[Parse] Hoist diagnostics for named 'subscript'/'init'

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -333,8 +333,6 @@ ERROR(associated_type_generic_parameter_list,PointsToFirstBadToken,
 // Func
 ERROR(func_decl_without_paren,PointsToFirstBadToken,
       "expected '(' in argument list of function declaration", ())
-ERROR(enum_element_decl_without_paren,PointsToFirstBadToken,
-      "expected '(' in argument list of enum element declaration", ())
 ERROR(static_func_decl_global_scope,none,
       "%select{%error|static methods|class methods}0 may only be declared on a type",
       (StaticSpellingKind))

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5886,6 +5886,14 @@ Parser::parseDeclSubscript(ParseDeclOptions Flags,
   ParserStatus Status;
   SourceLoc SubscriptLoc = consumeToken(tok::kw_subscript);
 
+  // Diagnose 'subscript' with name.
+  if (Tok.is(tok::identifier) &&
+      (peekToken().is(tok::l_paren) || startsWithLess(peekToken()))) {
+    diagnose(Tok, diag::subscript_has_name)
+      .fixItRemove(Tok.getLoc());
+    consumeToken(tok::identifier);
+  }
+
   // Parse the generic-params, if present.
   Optional<Scope> GenericsScope;
   GenericsScope.emplace(this, ScopeKind::Generics);
@@ -6035,6 +6043,14 @@ Parser::parseDeclInit(ParseDeclOptions Flags, DeclAttributes &Attributes) {
   } else if (Tok.isAny(tok::question_postfix, tok::question_infix)) {
     Failability = OTK_Optional;
     FailabilityLoc = consumeToken();
+  }
+
+  // Reject named 'init'. e.g. 'init withString(string: str)'.
+  if (Tok.is(tok::identifier) &&
+      (peekToken().is(tok::l_paren) || startsWithLess(peekToken()))) {
+    diagnose(Tok, diag::initializer_has_name)
+      .fixItRemove(Tok.getLoc());
+    consumeToken(tok::identifier);
   }
 
   // Parse the generic-params, if present.

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -617,15 +617,13 @@ Parser::parseSingleParameterClause(ParameterContextKind paramContext,
     case ParameterContextKind::Operator:
       diagID = diag::func_decl_without_paren;
       break;
-    case ParameterContextKind::EnumElement:
-      diagID = diag::enum_element_decl_without_paren;
-      break;
     case ParameterContextKind::Subscript:
       diagID = diag::expected_lparen_subscript;
       break;
     case ParameterContextKind::Initializer:
       diagID = diag::expected_lparen_initializer;
       break;
+    case ParameterContextKind::EnumElement:
     case ParameterContextKind::Closure:
     case ParameterContextKind::Curried:
       llvm_unreachable("should never be here");

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -612,7 +612,6 @@ Parser::parseSingleParameterClause(ParameterContextKind paramContext,
   if (!Tok.is(tok::l_paren)) {
     // If we don't have the leading '(', complain.
     Diag<> diagID;
-    bool skipIdentifier = false;
     switch (paramContext) {
     case ParameterContextKind::Function:
     case ParameterContextKind::Operator:
@@ -622,16 +621,10 @@ Parser::parseSingleParameterClause(ParameterContextKind paramContext,
       diagID = diag::enum_element_decl_without_paren;
       break;
     case ParameterContextKind::Subscript:
-      skipIdentifier = Tok.is(tok::identifier) &&
-                       peekToken().is(tok::l_paren);
-      diagID = skipIdentifier ? diag::subscript_has_name
-                              : diag::expected_lparen_subscript;
+      diagID = diag::expected_lparen_subscript;
       break;
     case ParameterContextKind::Initializer:
-      skipIdentifier = Tok.is(tok::identifier) &&
-                       peekToken().is(tok::l_paren);
-      diagID = skipIdentifier ? diag::initializer_has_name
-                              : diag::expected_lparen_initializer;
+      diagID = diag::expected_lparen_initializer;
       break;
     case ParameterContextKind::Closure:
     case ParameterContextKind::Curried:
@@ -642,17 +635,8 @@ Parser::parseSingleParameterClause(ParameterContextKind paramContext,
       auto diag = diagnose(Tok, diagID);
       if (Tok.isAny(tok::l_brace, tok::arrow, tok::kw_throws, tok::kw_rethrows))
         diag.fixItInsertAfter(PreviousLoc, "()");
-
-      if (skipIdentifier)
-        diag.fixItRemove(Tok.getLoc());
     }
 
-    // We might diagnose again down here, so make sure 'diag' is out of scope.
-    if (skipIdentifier) {
-      consumeToken();
-      skipSingle();
-    }
-    
     // Create an empty parameter list to recover.
     return makeParserErrorResult(
         ParameterList::createEmpty(Context, PreviousLoc, PreviousLoc));

--- a/test/Parse/recovery.swift
+++ b/test/Parse/recovery.swift
@@ -624,6 +624,9 @@ struct InitializerWithName {
 
 struct InitializerWithNameAndParam {
   init a(b: Int) {} // expected-error {{initializers cannot have a name}} {{8-9=}}
+  init? c(_ d: Int) {} // expected-error {{initializers cannot have a name}} {{9-10=}}
+  init e<T>(f: T) {} // expected-error {{initializers cannot have a name}} {{8-9=}}
+  init? g<T>(_: T) {} // expected-error {{initializers cannot have a name}} {{9-10=}}
 }
 
 struct InitializerWithLabels {

--- a/test/Parse/subscripting.swift
+++ b/test/Parse/subscripting.swift
@@ -190,6 +190,9 @@ struct A10 {
   subscript x(i: Int) -> Int { // expected-error {{subscripts cannot have a name}} {{13-14=}}
     return 0
   }
+  subscript x<T>(i: T) -> Int { // expected-error {{subscripts cannot have a name}} {{13-14=}}
+    return 0
+  }
 }
 
 struct A11 {


### PR DESCRIPTION
`init something<T>(arg: T)` is probably more common mistake than `init<T> something(arg: T)`.

Also, removed `enum_element_decl_without_paren` diagnostics since it's unreachable.