### PR TITLE
[PrintAsObjC] Sort imports alphabetically

### DIFF
--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -2064,22 +2064,6 @@ public:
   }
 };
 
-/// A generalization of llvm::SmallSetVector that allows a custom comparator.
-template <typename T, unsigned N, typename C = std::less<T>>
-using SmallSetVector =
-  llvm::SetVector<T, SmallVector<T, N>, llvm::SmallSet<T, N, C>>;
-
-/// A comparator for types with PointerLikeTypeTraits that sorts by opaque
-/// void pointer representation.
-template <typename T>
-struct PointerLikeComparator {
-  using Traits = llvm::PointerLikeTypeTraits<T>;
-  bool operator()(T lhs, T rhs) const {
-    return std::less<void*>()(Traits::getAsVoidPointer(lhs),
-                              Traits::getAsVoidPointer(rhs));
-  }
-};
-
 class ModuleWriter {
   enum class EmissionState {
     NotYetDefined = 0,
@@ -2092,8 +2076,7 @@ class ModuleWriter {
   DelayedMemberSet delayedMembers;
 
   using ImportModuleTy = PointerUnion<ModuleDecl*, const clang::Module*>;
-  SmallSetVector<ImportModuleTy, 8,
-                 PointerLikeComparator<ImportModuleTy>> imports;
+  SmallPtrSet<ImportModuleTy, 8> imports;
 
   std::string bodyBuffer;
   llvm::raw_string_ostream os{bodyBuffer};
@@ -2634,13 +2617,73 @@ public:
     return import == importer->getImportedHeaderModule();
   }
 
+  static void getClangSubmoduleReversePath(SmallVectorImpl<StringRef> &path,
+                                           const clang::Module *module) {
+    // FIXME: This should be an API on clang::Module.
+    do {
+      path.push_back(module->Name);
+      module = module->Parent;
+    } while (module);
+  }
+
+  static int compareImportModulesByName(const ImportModuleTy *left,
+                                        const ImportModuleTy *right) {
+    auto *leftSwiftModule = left->dyn_cast<ModuleDecl *>();
+    auto *rightSwiftModule = right->dyn_cast<ModuleDecl *>();
+
+    if (leftSwiftModule && !rightSwiftModule)
+      return -compareImportModulesByName(right, left);
+
+    if (leftSwiftModule && rightSwiftModule)
+      return leftSwiftModule->getName().compare(rightSwiftModule->getName());
+
+    auto *leftClangModule = left->get<const clang::Module *>();
+    assert(leftClangModule->isSubModule() &&
+           "top-level modules should use a normal swift::ModuleDecl");
+    if (rightSwiftModule) {
+      // Because the Clang module is a submodule, its full name will never be
+      // equal to a Swift module's name, even if the top-level name is the same;
+      // it will always come before or after.
+      if (leftClangModule->getTopLevelModuleName() <
+          rightSwiftModule->getName().str()) {
+        return -1;
+      }
+      return 1;
+    }
+
+    auto *rightClangModule = right->get<const clang::Module *>();
+    assert(rightClangModule->isSubModule() &&
+           "top-level modules should use a normal swift::ModuleDecl");
+
+    SmallVector<StringRef, 8> leftReversePath;
+    SmallVector<StringRef, 8> rightReversePath;
+    getClangSubmoduleReversePath(leftReversePath, leftClangModule);
+    getClangSubmoduleReversePath(rightReversePath, rightClangModule);
+
+    assert(leftReversePath != rightReversePath &&
+           "distinct Clang modules should not have the same full name");
+    if (std::lexicographical_compare(leftReversePath.rbegin(),
+                                     leftReversePath.rend(),
+                                     rightReversePath.rbegin(),
+                                     rightReversePath.rend())) {
+      return -1;
+    }
+    return 1;
+  }
+
   void writeImports(raw_ostream &out) {
     out << "#if __has_feature(modules)\n";
+
+    // Sort alphabetically for determinism and consistency.
+    SmallVector<ImportModuleTy, 8> sortedImports{imports.begin(),
+                                                 imports.end()};
+    llvm::array_pod_sort(sortedImports.begin(), sortedImports.end(),
+                         &compareImportModulesByName);
 
     // Track printed names to handle overlay modules.
     llvm::SmallPtrSet<Identifier, 8> seenImports;
     bool includeUnderlying = false;
-    for (auto import : imports) {
+    for (auto import : sortedImports) {
       if (auto *swiftModule = import.dyn_cast<ModuleDecl *>()) {
         auto Name = swiftModule->getName();
         if (isUnderlyingModule(swiftModule)) {
@@ -2651,13 +2694,11 @@ public:
           out << "@import " << Name.str() << ";\n";
       } else {
         const auto *clangModule = import.get<const clang::Module *>();
+        assert(clangModule->isSubModule() &&
+               "top-level modules should use a normal swift::ModuleDecl");
         out << "@import ";
-        // FIXME: This should be an API on clang::Module.
-        SmallVector<StringRef, 4> submoduleNames;
-        do {
-          submoduleNames.push_back(clangModule->Name);
-          clangModule = clangModule->Parent;
-        } while (clangModule);
+        SmallVector<StringRef, 8> submoduleNames;
+        getClangSubmoduleReversePath(submoduleNames, clangModule);
         interleave(submoduleNames.rbegin(), submoduleNames.rend(),
                    [&out](StringRef next) { out << next; },
                    [&out] { out << "."; });

--- a/test/PrintAsObjC/Inputs/MostlyPrivate1.framework/Headers/MostlyPrivate1.h
+++ b/test/PrintAsObjC/Inputs/MostlyPrivate1.framework/Headers/MostlyPrivate1.h
@@ -1,0 +1,1 @@
+typedef long MP1PublicType;

--- a/test/PrintAsObjC/Inputs/MostlyPrivate1.framework/Modules/module.modulemap
+++ b/test/PrintAsObjC/Inputs/MostlyPrivate1.framework/Modules/module.modulemap
@@ -1,0 +1,5 @@
+framework module MostlyPrivate1 {
+  umbrella header "MostlyPrivate1.h"
+  export *
+  module * { export * }
+}

--- a/test/PrintAsObjC/Inputs/MostlyPrivate1.framework/Modules/module.private.modulemap
+++ b/test/PrintAsObjC/Inputs/MostlyPrivate1.framework/Modules/module.private.modulemap
@@ -1,0 +1,5 @@
+framework module MostlyPrivate1_Private {
+  umbrella header "MostlyPrivate1_Private.h"
+  export *
+  module * { export * }
+}

--- a/test/PrintAsObjC/Inputs/MostlyPrivate1.framework/PrivateHeaders/MostlyPrivate1_Private.h
+++ b/test/PrintAsObjC/Inputs/MostlyPrivate1.framework/PrivateHeaders/MostlyPrivate1_Private.h
@@ -1,0 +1,1 @@
+typedef long MP1PrivateType;

--- a/test/PrintAsObjC/Inputs/MostlyPrivate2.framework/Headers/MostlyPrivate2.h
+++ b/test/PrintAsObjC/Inputs/MostlyPrivate2.framework/Headers/MostlyPrivate2.h
@@ -1,0 +1,1 @@
+typedef long MP2PublicType;

--- a/test/PrintAsObjC/Inputs/MostlyPrivate2.framework/Modules/module.modulemap
+++ b/test/PrintAsObjC/Inputs/MostlyPrivate2.framework/Modules/module.modulemap
@@ -1,0 +1,5 @@
+framework module MostlyPrivate2 {
+  umbrella header "MostlyPrivate2.h"
+  export *
+  module * { export * }
+}

--- a/test/PrintAsObjC/Inputs/MostlyPrivate2.framework/Modules/module.private.modulemap
+++ b/test/PrintAsObjC/Inputs/MostlyPrivate2.framework/Modules/module.private.modulemap
@@ -1,0 +1,5 @@
+framework module MostlyPrivate2_Private {
+  umbrella header "MostlyPrivate2_Private.h"
+  export *
+  module * { export * }
+}

--- a/test/PrintAsObjC/Inputs/MostlyPrivate2.framework/PrivateHeaders/MostlyPrivate2_Private.h
+++ b/test/PrintAsObjC/Inputs/MostlyPrivate2.framework/PrivateHeaders/MostlyPrivate2_Private.h
@@ -1,0 +1,1 @@
+typedef long MP2PrivateType;

--- a/test/PrintAsObjC/classes.swift
+++ b/test/PrintAsObjC/classes.swift
@@ -23,12 +23,13 @@
 // CHECK-NOT: AppKit;
 // CHECK-NOT: Properties;
 // CHECK-NOT: Swift;
-// CHECK-LABEL: @import Foundation;
-// CHECK-NEXT: @import CoreGraphics;
+// CHECK-LABEL: @import CompatibilityAlias;
 // CHECK-NEXT: @import CoreFoundation;
-// CHECK-NEXT: @import objc_generics;
-// CHECK-NEXT: @import CompatibilityAlias;
+// CHECK-NEXT: @import CoreGraphics;
+// CHECK-NEXT: @import Foundation;
+// CHECK-NEXT: @import ObjectiveC;
 // CHECK-NEXT: @import SingleGenericClass;
+// CHECK-NEXT: @import objc_generics;
 // CHECK-NOT: AppKit;
 // CHECK-NOT: Swift;
 import Foundation

--- a/test/PrintAsObjC/imports.swift
+++ b/test/PrintAsObjC/imports.swift
@@ -1,24 +1,28 @@
 // Please keep this file in alphabetical order!
 
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules/ -emit-module -o %t %s -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules/ -parse-as-library %t/imports.swiftmodule -typecheck -emit-objc-header-path %t/imports.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules/ -F %S/Inputs/ -emit-module -o %t %s -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules/ -F %S/Inputs/ -parse-as-library %t/imports.swiftmodule -typecheck -emit-objc-header-path %t/imports.h -import-objc-header %S/../Inputs/empty.h -disable-objc-attr-requires-foundation-module
 // RUN: %FileCheck %s < %t/imports.h
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t/imports.h
-// RUN: %check-in-clang %t/imports.h -I %S/Inputs/custom-modules/
+// RUN: %check-in-clang %t/imports.h -I %S/Inputs/custom-modules/ -F %S/Inputs/
 
 // REQUIRES: objc_interop
 
-// CHECK-DAG: @import ctypes.bits;
-// CHECK-DAG: @import Foundation;
-// CHECK-DAG: @import Base;
-// CHECK-DAG: @import Base.ImplicitSub.ExSub;
-// CHECK-DAG: @import Base.ExplicitSub;
-// CHECK-DAG: @import Base.ExplicitSub.ExSub;
+// CHECK: @import Base;
+// CHECK-NEXT: @import Base.ExplicitSub;
+// CHECK-NEXT: @import Base.ExplicitSub.ExSub;
+// CHECK-NEXT: @import Base.ImplicitSub.ExSub;
+// CHECK-NEXT: @import Foundation;
+// CHECK-NEXT: @import MostlyPrivate1;
+// CHECK-NEXT: @import MostlyPrivate1_Private;
+// CHECK-NEXT: @import MostlyPrivate2_Private;
+// CHECK-NEXT: @import ctypes.bits;
 
 // NEGATIVE-NOT: ctypes;
 // NEGATIVE-NOT: ImSub;
 // NEGATIVE-NOT: ImplicitSub;
+// NEGATIVE-NOT: MostlyPrivate2;
 
 import ctypes.bits
 import Foundation
@@ -31,6 +35,11 @@ import Base.ExplicitSub
 import Base.ExplicitSub.ImSub
 import Base.ExplicitSub.ExSub
 
+import MostlyPrivate1
+import MostlyPrivate1_Private
+// Deliberately not importing MostlyPrivate2
+import MostlyPrivate2_Private
+
 @objc class Test {
   let word: DWORD = 0
   let number: TimeInterval = 0.0
@@ -41,4 +50,10 @@ import Base.ExplicitSub.ExSub
   let baseE: BaseE = 0
   let baseEI: BaseEI = 0
   let baseEE: BaseEE = 0
+
+  // Deliberately use the private type before the public type.
+  let mp1priv: MP1PrivateType = 0
+  let mp1pub: MP1PublicType = 0
+
+  let mp2priv: MP2PrivateType = 0
 }


### PR DESCRIPTION
This ensures that 'Foo' always gets imported before 'Foo_Private'. This shouldn't strictly be necessary but does end up with more reliable results in practice.

rdar://problem/36159006