### PR TITLE
Opportunistic fix to allow \Derived.property to be inferred as \Base.…

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2828,8 +2828,10 @@ namespace {
         if (!rootObjectTy || rootObjectTy->hasError())
           return Type();
         rootObjectTy = CS.openUnboundGenericType(rootObjectTy, locator);
-        CS.addConstraint(ConstraintKind::Bind, root, rootObjectTy,
-                         locator);
+        // Allow \Derived.property to be inferred as \Base.property to
+        // simulate a sort of covariant conversion from
+        // KeyPath<Derived, T> to KeyPath<Base, T>.
+        CS.addConstraint(ConstraintKind::Subtype, rootObjectTy, root, locator);
       }
       
       bool didOptionalChain = false;

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -545,6 +545,18 @@ struct VisibilityTesting2 {
   }
 }
 
+protocol PP {}
+class Base : PP { var i: Int = 0 }
+class Derived : Base {}
+
+func testSubtypeKeypathClass(_ keyPath: ReferenceWritableKeyPath<Base, Int>) {
+  testSubtypeKeypathClass(\Derived.i)
+}
+
+func testSubtypeKeypathProtocol(_ keyPath: ReferenceWritableKeyPath<PP, Int>) {
+  testSubtypeKeypathProtocol(\Base.i) // expected-error {{type 'PP' has no member 'i'}}
+}
+
 func testSyntaxErrors() { // expected-note{{}}
   _ = \.  ; // expected-error{{expected member name following '.'}}
   _ = \.a ;


### PR DESCRIPTION
…property.

Noticed this opportunity while reading through the keypath type checking code.
