### PR TITLE
migrator: handle simple attribute assignment and reference.

### DIFF
--- a/include/swift/IDE/APIDigesterData.h
+++ b/include/swift/IDE/APIDigesterData.h
@@ -129,6 +129,20 @@ public:
     }
   }
 
+  bool isStringRepresentableChange() const {
+    switch(DiffKind) {
+    case NodeAnnotation::DictionaryKeyUpdate:
+    case NodeAnnotation::OptionalDictionaryKeyUpdate:
+    case NodeAnnotation::ArrayMemberUpdate:
+    case NodeAnnotation::OptionalArrayMemberUpdate:
+    case NodeAnnotation::SimpleStringRepresentableUpdate:
+    case NodeAnnotation::SimpleOptionalStringRepresentableUpdate:
+      return true;
+    default:
+      return false;
+    }
+  }
+
   StringRef getNewName() const { assert(isRename()); return RightComment; }
   APIDiffItemKind getKind() const override {
     return APIDiffItemKind::ADK_CommonDiffItem;

--- a/test/Migrator/Inputs/Cities.swift
+++ b/test/Migrator/Inputs/Cities.swift
@@ -33,3 +33,7 @@ public func globalCityFunc3(_ c : Cities, _ p : Int) -> Int { return 0 }
 public func globalCityFunc4(_ c : Cities, _ p : Int, _ q: Int) -> Int { return 0 }
 public func globalCityFunc5() -> Int { return 0 }
 public func globalCityPointerTaker(_ c : UnsafePointer<Cities>, _ p : Int, _ q: Int) -> Int { return 0 }
+
+public class Container {
+  public var Value: String = ""
+}

--- a/test/Migrator/Inputs/string-representable.json
+++ b/test/Migrator/Inputs/string-representable.json
@@ -1,0 +1,13 @@
+[
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Var",
+    "NodeAnnotation": "SimpleStringRepresentableUpdate",
+    "ChildIndex": "0",
+    "LeftUsr": "s:6Cities9ContainerC5ValueSSvp",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "NewAttribute",
+    "ModuleName": "Cities"
+  },
+]

--- a/test/Migrator/string-representable.swift
+++ b/test/Migrator/string-representable.swift
@@ -1,0 +1,12 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t.mod)
+// RUN: %target-swift-frontend -emit-module -o %t.mod/Cities.swiftmodule %S/Inputs/Cities.swift -module-name Cities -parse-as-library
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s  -I %t.mod -api-diff-data-file %S/Inputs/string-representable.json -emit-migrated-file-path %t/string-representable.swift.result -disable-migrator-fixits -o /dev/null
+// RUN: diff -u %S/string-representable.swift.expected %t/string-representable.swift.result
+
+import Cities
+
+func foo(_ c: Container) -> String {
+  c.Value = ""
+  return c.Value
+}

--- a/test/Migrator/string-representable.swift.expected
+++ b/test/Migrator/string-representable.swift.expected
@@ -1,0 +1,12 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t.mod)
+// RUN: %target-swift-frontend -emit-module -o %t.mod/Cities.swiftmodule %S/Inputs/Cities.swift -module-name Cities -parse-as-library
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s  -I %t.mod -api-diff-data-file %S/Inputs/string-representable.json -emit-migrated-file-path %t/string-representable.swift.result -disable-migrator-fixits -o /dev/null
+// RUN: diff -u %S/string-representable.swift.expected %t/string-representable.swift.result
+
+import Cities
+
+func foo(_ c: Container) -> String {
+  c.Value = NewAttribute(rawValue: "")
+  return c.Value.rawValue
+}


### PR DESCRIPTION
This patch migrates simple attribute assignment and reference when the
attribute used to be of type String and later became StringRepresentable struct.

Related: rdar://38192995
