### PR TITLE
Only test debug NaN printing on x86_64

### DIFF
--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -406,12 +406,51 @@ fileprivate func expectNaN<T>(_ expected: String, _ object: T, ${TRACE}) where T
   // quiet, discard payloads, or clear sign bits.  In some cases, just passing a
   // NaN into a function (via an FP register) is enough to mangle the value.
 
-  // So we just skip the debugDescription check on most architectures,
-  // verifying it only on x86_64 (which has complete and well-documented
-  // NaN handling).
 #if arch(x86_64)
+  // Verify the exact debugDescription value only on x86_64, where we
+  // know the exact expected String:
   expectEqual(expected, object.debugDescription, ${trace})
 #endif
+
+  // On all platforms, we verify that the generated debugDescription text
+  // follows the expected format, even when we can't verify the exact value.
+  var actual = object.debugDescription
+
+  // Optional leading "-"
+  if actual.hasPrefix("-") {
+    actual = String(actual.dropFirst())
+  }
+
+  // Optional leading "s"
+  if actual.hasPrefix("s") {
+    actual = String(actual.dropFirst())
+  }
+
+  // Fixed text "nan"
+  if actual.prefix(3) != "nan" {
+    expectationFailure("Badly formatted NaN debug description (expected 'nan'): \(object.debugDescription)", trace: ${trace})
+    return
+  }
+  actual = String(actual.dropFirst(3))
+
+  // Optional parenthesized payload after "nan"
+  if actual.hasPrefix("(0x") {
+    actual = String(actual.dropFirst(3))
+    while !actual.isEmpty {
+      if actual.hasPrefix(")") {
+        if actual != ")" {
+          expectationFailure("Malformed NaN: extra text after payload: \(object.debugDescription)", trace: ${trace})
+        }
+        return
+      } else {
+        // TODO: verify hex digit
+      }
+      actual = String(actual.dropFirst())
+    }
+    expectationFailure("Malformed NaN: no closing parenthesis after payload: \(object.debugDescription)", trace: ${trace})
+  } else if !actual.isEmpty {
+    expectationFailure("Badly formatted NaN debug description has invalid text after 'nan'.  Expected '(0x': \(object.debugDescription)", trace: ${trace})
+  }
 }
 
 // Foundation's String(format:) isn't available here, so

--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -400,8 +400,18 @@ fileprivate func expectAccurateDescription(_ object: ${FloatType}, ${TRACE}) {
 fileprivate func expectNaN<T>(_ expected: String, _ object: T, ${TRACE}) where T: FloatingPoint & CustomDebugStringConvertible & CustomStringConvertible {
   // Regular description always returns "nan"
   expectEqual("nan", object.description, ${trace})
-  // Debug description returns a more detailed form:
+
+  // debugDescription prints full details about NaNs, which is tricky to test
+  // because NaNs often get truncated: various implementations force all NaNs
+  // quiet, discard payloads, or clear sign bits.  In some cases, just passing a
+  // NaN into a function (via an FP register) is enough to mangle the value.
+
+  // So we just skip the debugDescription check on most architectures,
+  // verifying it only on x86_64 (which has complete and well-documented
+  // NaN handling).
+#if arch(x86_64)
   expectEqual(expected, object.debugDescription, ${trace})
+#endif
 }
 
 // Foundation's String(format:) isn't available here, so
@@ -529,19 +539,13 @@ PrintTests.test("Printable_Float") {
   expectNaN("nan(0xffff)", Float(nan: 65535, signaling: false))
   expectNaN("nan(0x1fffff)", Float(bitPattern: 0x7fff_ffff))
   expectNaN("nan(0x1fffff)", Float(bitPattern: 0x7fdf_ffff))
-#if !arch(arm)
-  // ARM doesn't have negative Float nans
   expectNaN("-nan", -Float.nan)
-  expectNaN("-nan(0xffff)", -Float(nan: 65535, signaling: false)) // fail
-#endif
-#if !arch(i386) && !arch(arm)
-  // 32-bit i386 and ARM lack signaling Float nans
+  expectNaN("-nan(0xffff)", -Float(nan: 65535, signaling: false))
   expectNaN("snan", Float.signalingNaN)
   expectNaN("-snan", -Float.signalingNaN)
   expectNaN("snan(0xffff)", Float(nan: 65535, signaling: true))
   expectNaN("-snan(0xffff)", -Float(nan: 65535, signaling: true))
   expectNaN("snan(0x1fffff)", Float(bitPattern: 0x7fbf_ffff))
-#endif
 
   // Every power of 10 should print with only a single digit '1'
   for power in -45 ... 38 {
@@ -640,20 +644,6 @@ PrintTests.test("Printable_Double") {
   // Verify NaNs
   expectNaN("nan", Double.nan)
   expectNaN("-nan", -Double.nan)
-#if arch(i386)
-  expectNaN("nan", Double(nan: 65535, signaling: false))
-  expectNaN("nan", Float64(bitPattern: 0x7fff_ffff_ffff_ffff))
-  expectNaN("nan", Float64(bitPattern: 0x7ffb_ffff_ffff_ffff))
-  expectNaN("-nan", -Double(nan: 65535, signaling: false))
-  if _isDebugAssertConfiguration() {
-    expectNaN("nan", Double.signalingNaN)
-    expectNaN("-nan", -Double.signalingNaN)
-    expectNaN("nan", Double(nan: 65535, signaling: true))
-    expectNaN("-nan", -Double(nan: 65535, signaling: true))
-    expectNaN("nan", Float64(bitPattern: 0x7ff7_ffff_ffff_ffff))
-  }
-#else
-  // 32-bit i386 lacks signaling Double nans or payloads on NaNs
   expectNaN("nan(0xffff)", Double(nan: 65535, signaling: false))
   expectNaN("nan(0x3ffffffffffff)", Float64(bitPattern: 0x7fff_ffff_ffff_ffff))
   expectNaN("nan(0x3ffffffffffff)", Float64(bitPattern: 0x7ffb_ffff_ffff_ffff))
@@ -663,7 +653,6 @@ PrintTests.test("Printable_Double") {
   expectNaN("snan(0xffff)", Double(nan: 65535, signaling: true))
   expectNaN("-snan(0xffff)", -Double(nan: 65535, signaling: true))
   expectNaN("snan(0x3ffffffffffff)", Float64(bitPattern: 0x7ff7_ffff_ffff_ffff))
-#endif
 
   // We know how every power of 10 should print
   for power in -323 ... 308 {


### PR DESCRIPTION
NaNs are mangled in various ways on various platforms.  Some
of the fun possibilities:
* sign bits sometimes can be cleared
* payloads get zeroed
* NaNs get forced to quiet
* Merely passing a value into a function can trigger these behaviors
* Trivial changes to the generated assembly can change this

This makes it very hard to validate the printing of NaN
details, since we can't be certain what value the formatter
actually saw.

So I'm simply disabling the checks for debugDescription on
NaNs except on x86_64, which has pretty well-understood NaN
support.

This should fix a test failure recently seen on 64-bit ARM hardware.

Note: Eventually, it might be nice to verify that the
debugDescription output always matches the expected
format:
```
   -?s?nan(\(0x[0-9a-f]+\))?
```
But it's not clear that anything stronger is really feasible.
