### PR TITLE
Foundation overlay: include <pthread.h>

### DIFF
--- a/stdlib/public/SwiftShims/FoundationOverlayShims.h
+++ b/stdlib/public/SwiftShims/FoundationOverlayShims.h
@@ -17,6 +17,7 @@
 #import <alloca.h>
 #import <stdlib.h>
 #import <malloc/malloc.h>
+#import <pthread.h>
 
 #import "FoundationShimSupport.h"
 #import "NSCalendarShims.h"


### PR DESCRIPTION
Found by -Wsystem-headers. Apparently nothing that was already included was actually defining 'pthread_main_np'.