### PR TITLE
[IDE] Refactoring to change function bodies to "fatalError()".

### DIFF
--- a/include/swift/IDE/RefactoringKinds.def
+++ b/include/swift/IDE/RefactoringKinds.def
@@ -60,6 +60,8 @@ RANGE_REFACTORING(ExpandTernaryExpr, "Expand Ternary Expression", expand.ternary
 
 RANGE_REFACTORING(ConvertToTernaryExpr, "Convert To Ternary Expression", convert.ternary.expr)
 
+RANGE_REFACTORING(ReplaceBodiesWithFatalError, "Replace function bodies with fatalError", replace.bodies.with.fatalError)
+
 #undef CURSOR_REFACTORING
 #undef RANGE_REFACTORING
 #undef SEMANTIC_REFACTORING

--- a/test/refactoring/ReplaceBodiesWithFatalError/Outputs/basic/L12-14.swift.expected
+++ b/test/refactoring/ReplaceBodiesWithFatalError/Outputs/basic/L12-14.swift.expected
@@ -1,0 +1,68 @@
+var foo: Int = 0
+
+var bar: Int {
+    return 0
+}
+
+var qux: Int = 0 {
+    willSet { print("hi") }
+    didSet { print("bye") }
+}
+
+func generic<T>(_: T) -> Int { fatalError() }
+
+class Foo {
+    var foo: Int
+
+    var bar: Int {
+        return 0
+    }
+
+    var baz: Int {
+        get { return 0 }
+        set { foo = newValue }
+    }
+
+    var qux: Int {
+        willSet { print("hi") }
+        didSet { print("bye") }
+    }
+
+    init() {
+        foo = 0
+        qux = 1
+    }
+
+    func nonGeneric() -> Int {
+        return 0
+    }
+
+    func generic<T>(_: T) -> Int {
+        return 0
+    }
+
+    deinit {
+        print("bye")
+    }
+}
+
+extension Foo {
+    func nonGeneric2() -> Int {
+        return 0
+    }
+
+    func generic2<T>(_: T) -> Int {
+        return 0
+    }
+}
+
+
+// FIXME: we should be able to run on the whole file.
+
+
+
+
+
+
+
+

--- a/test/refactoring/ReplaceBodiesWithFatalError/Outputs/basic/L16-49.swift.expected
+++ b/test/refactoring/ReplaceBodiesWithFatalError/Outputs/basic/L16-49.swift.expected
@@ -1,0 +1,59 @@
+var foo: Int = 0
+
+var bar: Int {
+    return 0
+}
+
+var qux: Int = 0 {
+    willSet { print("hi") }
+    didSet { print("bye") }
+}
+
+func generic<T>(_: T) -> Int {
+    return 0
+}
+
+class Foo {
+    var foo: Int
+
+    var bar: Int { fatalError() }
+
+    var baz: Int {
+        get { fatalError() }
+        set { fatalError() }
+    }
+
+    var qux: Int {
+        willSet { fatalError() }
+        didSet { fatalError() }
+    }
+
+    init() { fatalError() }
+
+    func nonGeneric() -> Int { fatalError() }
+
+    func generic<T>(_: T) -> Int { fatalError() }
+
+    deinit { fatalError() }
+}
+
+extension Foo {
+    func nonGeneric2() -> Int {
+        return 0
+    }
+
+    func generic2<T>(_: T) -> Int {
+        return 0
+    }
+}
+
+
+// FIXME: we should be able to run on the whole file.
+
+
+
+
+
+
+
+

--- a/test/refactoring/ReplaceBodiesWithFatalError/Outputs/basic/L19-22.swift.expected
+++ b/test/refactoring/ReplaceBodiesWithFatalError/Outputs/basic/L19-22.swift.expected
@@ -1,0 +1,68 @@
+var foo: Int = 0
+
+var bar: Int {
+    return 0
+}
+
+var qux: Int = 0 {
+    willSet { print("hi") }
+    didSet { print("bye") }
+}
+
+func generic<T>(_: T) -> Int {
+    return 0
+}
+
+class Foo {
+    var foo: Int
+
+    var bar: Int { fatalError() }
+
+    var baz: Int {
+        get { return 0 }
+        set { foo = newValue }
+    }
+
+    var qux: Int {
+        willSet { print("hi") }
+        didSet { print("bye") }
+    }
+
+    init() {
+        foo = 0
+        qux = 1
+    }
+
+    func nonGeneric() -> Int {
+        return 0
+    }
+
+    func generic<T>(_: T) -> Int {
+        return 0
+    }
+
+    deinit {
+        print("bye")
+    }
+}
+
+extension Foo {
+    func nonGeneric2() -> Int {
+        return 0
+    }
+
+    func generic2<T>(_: T) -> Int {
+        return 0
+    }
+}
+
+
+// FIXME: we should be able to run on the whole file.
+
+
+
+
+
+
+
+

--- a/test/refactoring/ReplaceBodiesWithFatalError/Outputs/basic/L3-5.swift.expected
+++ b/test/refactoring/ReplaceBodiesWithFatalError/Outputs/basic/L3-5.swift.expected
@@ -1,0 +1,68 @@
+var foo: Int = 0
+
+var bar: Int { fatalError() }
+
+var qux: Int = 0 {
+    willSet { print("hi") }
+    didSet { print("bye") }
+}
+
+func generic<T>(_: T) -> Int {
+    return 0
+}
+
+class Foo {
+    var foo: Int
+
+    var bar: Int {
+        return 0
+    }
+
+    var baz: Int {
+        get { return 0 }
+        set { foo = newValue }
+    }
+
+    var qux: Int {
+        willSet { print("hi") }
+        didSet { print("bye") }
+    }
+
+    init() {
+        foo = 0
+        qux = 1
+    }
+
+    func nonGeneric() -> Int {
+        return 0
+    }
+
+    func generic<T>(_: T) -> Int {
+        return 0
+    }
+
+    deinit {
+        print("bye")
+    }
+}
+
+extension Foo {
+    func nonGeneric2() -> Int {
+        return 0
+    }
+
+    func generic2<T>(_: T) -> Int {
+        return 0
+    }
+}
+
+
+// FIXME: we should be able to run on the whole file.
+
+
+
+
+
+
+
+

--- a/test/refactoring/ReplaceBodiesWithFatalError/Outputs/basic/L30-44.swift.expected
+++ b/test/refactoring/ReplaceBodiesWithFatalError/Outputs/basic/L30-44.swift.expected
@@ -1,0 +1,63 @@
+var foo: Int = 0
+
+var bar: Int {
+    return 0
+}
+
+var qux: Int = 0 {
+    willSet { print("hi") }
+    didSet { print("bye") }
+}
+
+func generic<T>(_: T) -> Int {
+    return 0
+}
+
+class Foo {
+    var foo: Int
+
+    var bar: Int {
+        return 0
+    }
+
+    var baz: Int {
+        get { return 0 }
+        set { foo = newValue }
+    }
+
+    var qux: Int {
+        willSet { print("hi") }
+        didSet { fatalError() }
+    }
+
+    init() { fatalError() }
+
+    func nonGeneric() -> Int { fatalError() }
+
+    func generic<T>(_: T) -> Int { fatalError() }
+
+    deinit {
+        print("bye")
+    }
+}
+
+extension Foo {
+    func nonGeneric2() -> Int {
+        return 0
+    }
+
+    func generic2<T>(_: T) -> Int {
+        return 0
+    }
+}
+
+
+// FIXME: we should be able to run on the whole file.
+
+
+
+
+
+
+
+

--- a/test/refactoring/ReplaceBodiesWithFatalError/Outputs/basic/L51-59.swift.expected
+++ b/test/refactoring/ReplaceBodiesWithFatalError/Outputs/basic/L51-59.swift.expected
@@ -1,0 +1,66 @@
+var foo: Int = 0
+
+var bar: Int {
+    return 0
+}
+
+var qux: Int = 0 {
+    willSet { print("hi") }
+    didSet { print("bye") }
+}
+
+func generic<T>(_: T) -> Int {
+    return 0
+}
+
+class Foo {
+    var foo: Int
+
+    var bar: Int {
+        return 0
+    }
+
+    var baz: Int {
+        get { return 0 }
+        set { foo = newValue }
+    }
+
+    var qux: Int {
+        willSet { print("hi") }
+        didSet { print("bye") }
+    }
+
+    init() {
+        foo = 0
+        qux = 1
+    }
+
+    func nonGeneric() -> Int {
+        return 0
+    }
+
+    func generic<T>(_: T) -> Int {
+        return 0
+    }
+
+    deinit {
+        print("bye")
+    }
+}
+
+extension Foo {
+    func nonGeneric2() -> Int { fatalError() }
+
+    func generic2<T>(_: T) -> Int { fatalError() }
+}
+
+
+// FIXME: we should be able to run on the whole file.
+
+
+
+
+
+
+
+

--- a/test/refactoring/ReplaceBodiesWithFatalError/Outputs/basic/L7-10.swift.expected
+++ b/test/refactoring/ReplaceBodiesWithFatalError/Outputs/basic/L7-10.swift.expected
@@ -1,0 +1,70 @@
+var foo: Int = 0
+
+var bar: Int {
+    return 0
+}
+
+var qux: Int = 0 {
+    willSet { fatalError() }
+    didSet { fatalError() }
+}
+
+func generic<T>(_: T) -> Int {
+    return 0
+}
+
+class Foo {
+    var foo: Int
+
+    var bar: Int {
+        return 0
+    }
+
+    var baz: Int {
+        get { return 0 }
+        set { foo = newValue }
+    }
+
+    var qux: Int {
+        willSet { print("hi") }
+        didSet { print("bye") }
+    }
+
+    init() {
+        foo = 0
+        qux = 1
+    }
+
+    func nonGeneric() -> Int {
+        return 0
+    }
+
+    func generic<T>(_: T) -> Int {
+        return 0
+    }
+
+    deinit {
+        print("bye")
+    }
+}
+
+extension Foo {
+    func nonGeneric2() -> Int {
+        return 0
+    }
+
+    func generic2<T>(_: T) -> Int {
+        return 0
+    }
+}
+
+
+// FIXME: we should be able to run on the whole file.
+
+
+
+
+
+
+
+

--- a/test/refactoring/ReplaceBodiesWithFatalError/Outputs/basic/L8.swift.expected
+++ b/test/refactoring/ReplaceBodiesWithFatalError/Outputs/basic/L8.swift.expected
@@ -1,0 +1,70 @@
+var foo: Int = 0
+
+var bar: Int {
+    return 0
+}
+
+var qux: Int = 0 {
+    willSet { fatalError() }
+    didSet { print("bye") }
+}
+
+func generic<T>(_: T) -> Int {
+    return 0
+}
+
+class Foo {
+    var foo: Int
+
+    var bar: Int {
+        return 0
+    }
+
+    var baz: Int {
+        get { return 0 }
+        set { foo = newValue }
+    }
+
+    var qux: Int {
+        willSet { print("hi") }
+        didSet { print("bye") }
+    }
+
+    init() {
+        foo = 0
+        qux = 1
+    }
+
+    func nonGeneric() -> Int {
+        return 0
+    }
+
+    func generic<T>(_: T) -> Int {
+        return 0
+    }
+
+    deinit {
+        print("bye")
+    }
+}
+
+extension Foo {
+    func nonGeneric2() -> Int {
+        return 0
+    }
+
+    func generic2<T>(_: T) -> Int {
+        return 0
+    }
+}
+
+
+// FIXME: we should be able to run on the whole file.
+
+
+
+
+
+
+
+

--- a/test/refactoring/ReplaceBodiesWithFatalError/basic.swift
+++ b/test/refactoring/ReplaceBodiesWithFatalError/basic.swift
@@ -1,0 +1,88 @@
+var foo: Int = 0
+
+var bar: Int {
+    return 0
+}
+
+var qux: Int = 0 {
+    willSet { print("hi") }
+    didSet { print("bye") }
+}
+
+func generic<T>(_: T) -> Int {
+    return 0
+}
+
+class Foo {
+    var foo: Int
+
+    var bar: Int {
+        return 0
+    }
+
+    var baz: Int {
+        get { return 0 }
+        set { foo = newValue }
+    }
+
+    var qux: Int {
+        willSet { print("hi") }
+        didSet { print("bye") }
+    }
+
+    init() {
+        foo = 0
+        qux = 1
+    }
+
+    func nonGeneric() -> Int {
+        return 0
+    }
+
+    func generic<T>(_: T) -> Int {
+        return 0
+    }
+
+    deinit {
+        print("bye")
+    }
+}
+
+extension Foo {
+    func nonGeneric2() -> Int {
+        return 0
+    }
+
+    func generic2<T>(_: T) -> Int {
+        return 0
+    }
+}
+
+// RUN: %empty-directory(%t.result)
+
+// FIXME: we should be able to run on the whole file.
+// RUN: not %refactor -replace-bodies-with-fatalError -source-filename %s -pos=1:1 -end-pos=59:2
+
+// RUN: %refactor -replace-bodies-with-fatalError -source-filename %s -pos=3:1 -end-pos=5:2 > %t.result/L3-5.swift
+// RUN: diff -u %S/Outputs/basic/L3-5.swift.expected %t.result/L3-5.swift
+
+// RUN: %refactor -replace-bodies-with-fatalError -source-filename %s -pos=7:1 -end-pos=10:2 > %t.result/L7-10.swift
+// RUN: diff -u %S/Outputs/basic/L7-10.swift.expected %t.result/L7-10.swift
+
+// RUN: %refactor -replace-bodies-with-fatalError -source-filename %s -pos=8:1 -end-pos=8:28 > %t.result/L8.swift
+// RUN: diff -u %S/Outputs/basic/L8.swift.expected %t.result/L8.swift
+
+// RUN: %refactor -replace-bodies-with-fatalError -source-filename %s -pos=12:1 -end-pos=14:2 > %t.result/L12-14.swift
+// RUN: diff -u %S/Outputs/basic/L12-14.swift.expected %t.result/L12-14.swift
+
+// RUN: %refactor -replace-bodies-with-fatalError -source-filename %s -pos=16:1 -end-pos=49:2 > %t.result/L16-49.swift
+// RUN: diff -u %S/Outputs/basic/L16-49.swift.expected %t.result/L16-49.swift
+
+// RUN: %refactor -replace-bodies-with-fatalError -source-filename %s -pos=19:1 -end-pos=22:1 > %t.result/L19-22.swift
+// RUN: diff -u %S/Outputs/basic/L19-22.swift.expected %t.result/L19-22.swift
+
+// RUN: %refactor -replace-bodies-with-fatalError -source-filename %s -pos=30:1 -end-pos=44:6 > %t.result/L30-44.swift
+// RUN: diff -u %S/Outputs/basic/L30-44.swift.expected %t.result/L30-44.swift
+
+// RUN: %refactor -replace-bodies-with-fatalError -source-filename %s -pos=51:1 -end-pos=59:2 > %t.result/L51-59.swift
+// RUN: diff -u %S/Outputs/basic/L51-59.swift.expected %t.result/L51-59.swift

--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -64,7 +64,9 @@ Action(llvm::cl::desc("kind:"), llvm::cl::init(RefactoringKind::None),
            clEnumValN(RefactoringKind::FindLocalRenameRanges,
                       "find-local-rename-ranges", "Find detailed ranges for local rename"),
            clEnumValN(RefactoringKind::TrailingClosure,
-                      "trailingclosure", "Perform trailing closure refactoring")));
+                      "trailingclosure", "Perform trailing closure refactoring"),
+           clEnumValN(RefactoringKind::ReplaceBodiesWithFatalError,
+                      "replace-bodies-with-fatalError", "Perform trailing closure refactoring")));
 
 
 static llvm::cl::opt<std::string>


### PR DESCRIPTION
This is immensely useful when working on generic code, where the signatures
of (many) functions are all that is required, and removing the bodies makes
things compile faster, allows tools like creduce to work better and results in
less noise in a debugger.

Unfortunately the design of refactoring means this currently only works on a
single top-level decl, or multiple decls inside a type.
