### PR TITLE
Introduce a simple request evaluator. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,24 @@ Swift 5.0
 Swift 4.2
 ---------
 
+* [SE-0194][]
+
+  The new CaseIterable protocol describes types which have a static
+  “allCases” property that is used to describe all of the cases of the
+  type. Swift will synthesize this “allCases” property for enums that
+  have no associated values. For example:
+
+  ```swift
+  enum Suit: CaseIterable {
+    case heart
+    case club
+    case diamond
+    case spade
+  }
+
+  print(Suit.allCases) // prints [Suit.heart, Suit.club, Suit.diamond, Suit.spade]
+  ```
+
 * [SE-0185][]
 
   Protocol conformances are now able to be synthesized in extensions in the same

--- a/include/swift/AST/AnyRequest.h
+++ b/include/swift/AST/AnyRequest.h
@@ -20,6 +20,7 @@
 #include "swift/Basic/TypeID.h"
 #include "llvm/ADT/DenseMapInfo.h"
 #include "llvm/ADT/Hashing.h"
+#include <string>
 
 namespace llvm {
 class raw_ostream;
@@ -209,6 +210,9 @@ public:
   friend void simple_display(llvm::raw_ostream &out, const AnyRequest &any) {
     any.stored->display(out);
   }
+
+  /// Return the result of calling simple_display as a string.
+  std::string getAsString() const;
 
   static AnyRequest getEmptyKey() {
     return AnyRequest(StorageKind::Empty);

--- a/include/swift/AST/AnyRequest.h
+++ b/include/swift/AST/AnyRequest.h
@@ -1,0 +1,227 @@
+//===--- AnyRequest.h - Requests Instances ----------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines the AnyRequest class, which describes a stored request.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_ANYREQUEST_H
+#define SWIFT_AST_ANYREQUEST_H
+
+#include "swift/Basic/TypeID.h"
+#include "llvm/ADT/DenseMapInfo.h"
+#include "llvm/ADT/Hashing.h"
+
+namespace swift {
+
+using llvm::hash_code;
+using llvm::hash_value;
+
+class DiagnosticEngine;
+
+/// Stores a request (for the \c Evaluator class) of any kind.
+///
+/// Requests must be value types and provide the following API to be stored in
+/// an \c AnyRequest instance:
+///
+///   - Copy constructor
+///   - Equality operator (==)
+///   - Hashing support (hash_value)
+///   - TypeID support (see swift/Basic/TypeID.h)
+///   - Cycle diagnostics operations:
+///
+///       void diagnoseCycle(DiagnosticEngine &diags) const;
+///       void noteCycleStep(DiagnosticEngine &diags) const;
+///
+class AnyRequest {
+  /// Abstract base class used to hold the specific request kind.
+  class HolderBase {
+  public:
+    /// The type ID of the request being stored.
+    const uint64_t typeID;
+
+    /// Hash value for the request itself.
+    const hash_code hash;
+
+  protected:
+    /// Initialize base with type ID and hash code.
+    HolderBase(uint64_t typeID, hash_code hash)
+      : typeID(typeID), hash(hash_combine(hash_value(typeID), hash)) { }
+
+  public:
+    virtual ~HolderBase();
+
+    /// Determine whether this request is equivalent to the \c other
+    /// request.
+    virtual bool equals(const HolderBase &other) const = 0;
+
+    /// Diagnose a cycle detected for this request.
+    virtual void diagnoseCycle(DiagnosticEngine &diags) const = 0;
+
+    /// Note that this request is part of a cycle.
+    virtual void noteCycleStep(DiagnosticEngine &diags) const = 0;
+  };
+
+  /// Holds a value that can be used as a request input/output.
+  template<typename Request>
+  class Holder final : public HolderBase {
+  public:
+    const Request request;
+
+    Holder(const Request &request)
+      : HolderBase(TypeID<Request>::value, hash_value(request)),
+        request(request) { }
+
+    Holder(Request &&request)
+      : HolderBase(TypeID<Request>::value, hash_value(request)),
+        request(std::move(request)) { }
+
+    virtual ~Holder() { }
+
+    /// Determine whether this request is equivalent to another.
+    ///
+    /// The caller guarantees that the typeIDs are the same.
+    virtual bool equals(const HolderBase &other) const override {
+      assert(typeID == other.typeID && "Caller should match typeIDs");
+      return request == static_cast<const Holder<Request> &>(other).request;
+    }
+
+    /// Diagnose a cycle detected for this request.
+    virtual void diagnoseCycle(DiagnosticEngine &diags) const override {
+      request.diagnoseCycle(diags);
+    }
+
+    /// Note that this request is part of a cycle.
+    virtual void noteCycleStep(DiagnosticEngine &diags) const override {
+      request.noteCycleStep(diags);
+    }
+  };
+
+  /// FIXME: Inefficient. Use the low bits.
+  enum class StorageKind {
+    Normal,
+    Empty,
+    Tombstone,
+  } storageKind = StorageKind::Normal;
+
+  /// The data stored in this value.
+  std::shared_ptr<HolderBase> stored;
+
+  AnyRequest(StorageKind storageKind) : storageKind(storageKind) {
+    assert(storageKind != StorageKind::Normal);
+  }
+
+public:
+  AnyRequest(const AnyRequest &other) = default;
+  AnyRequest(AnyRequest &&other) = default;
+  AnyRequest &operator=(const AnyRequest &other) = default;
+  AnyRequest &operator=(AnyRequest &&other) = default;
+
+  AnyRequest(AnyRequest &other)
+    : storageKind(other.storageKind), stored(other.stored) { }
+
+  AnyRequest(const AnyRequest &&other)
+    : storageKind(other.storageKind), stored(other.stored) { }
+
+  /// Construct a new instance with the given value.
+  template<typename T>
+  AnyRequest(T&& value) : storageKind(StorageKind::Normal) {
+    using ValueType =
+      typename std::remove_cv<typename std::remove_reference<T>::type>::type;
+    stored.reset(new Holder<ValueType>(std::forward<T>(value)));
+  }
+
+  /// Cast to a specific (known) type.
+  template<typename Request>
+  const Request &castTo() const {
+    assert(stored->typeID == TypeID<Request>::value && "wrong type in cast");
+    return static_cast<const Holder<Request> *>(stored.get())->value;
+  }
+
+  /// Try casting to a specific (known) type, returning \c nullptr on
+  /// failure.
+  template<typename Request>
+  const Request *getAs() const {
+    if (stored->typeID != TypeID<Request>::value)
+      return nullptr;
+
+    return &static_cast<const Holder<Request> *>(stored.get())->value;
+  }
+
+  /// Diagnose a cycle detected for this request.
+  void diagnoseCycle(DiagnosticEngine &diags) const {
+    stored->diagnoseCycle(diags);
+  }
+
+  /// Note that this request is part of a cycle.
+  void noteCycleStep(DiagnosticEngine &diags) const {
+    stored->noteCycleStep(diags);
+  }
+
+  /// Compare two instances for equality.
+  friend bool operator==(const AnyRequest &lhs, const AnyRequest &rhs) {
+    if (lhs.storageKind != rhs.storageKind) {
+      return false;
+    }
+
+    if (lhs.storageKind != StorageKind::Normal)
+      return true;
+
+    if (lhs.stored->typeID != rhs.stored->typeID)
+      return false;
+
+    return lhs.stored->equals(*rhs.stored);
+  }
+
+  friend bool operator!=(const AnyRequest &lhs, const AnyRequest &rhs) {
+    return !(lhs == rhs);
+  }
+
+  friend hash_code hash_value(const AnyRequest &any) {
+    if (any.storageKind != StorageKind::Normal)
+      return 1;
+
+    return any.stored->hash;
+  }
+
+  static AnyRequest getEmptyKey() {
+    return AnyRequest(StorageKind::Empty);
+  }
+
+  static AnyRequest getTombstoneKey() {
+    return AnyRequest(StorageKind::Tombstone);
+  }
+};
+
+} // end namespace swift
+
+namespace llvm {
+  template<>
+  struct DenseMapInfo<swift::AnyRequest> {
+    static inline swift::AnyRequest getEmptyKey() {
+      return swift::AnyRequest::getEmptyKey();
+    }
+    static inline swift::AnyRequest getTombstoneKey() {
+      return swift::AnyRequest::getTombstoneKey();
+    }
+    static unsigned getHashValue(const swift::AnyRequest &request) {
+      return hash_value(request);
+    }
+    static bool isEqual(const swift::AnyRequest &lhs,
+                        const swift::AnyRequest &rhs) {
+      return lhs == rhs;
+    }
+  };
+
+} // end namespace llvm
+
+#endif // SWIFT_AST_ANYREQUEST_H

--- a/include/swift/AST/Evaluator.h
+++ b/include/swift/AST/Evaluator.h
@@ -60,7 +60,7 @@ class DiagnosticEngine;
 ///
 ///       void diagnoseCycle(DiagnosticEngine &diags) const;
 ///       void noteCycleStep(DiagnosticEngine &diags) const;
-///       OutputType breakCycle() Const;
+///       OutputType breakCycle() const;
 ///   - Caching policy:
 ///
 ///     static const bool isEverCached;
@@ -145,7 +145,7 @@ private:
   /// request.
   void diagnoseCycle(const AnyRequest &request);
 
-  /// Retrieve the result of produced by evaluating a request that can
+  /// Retrieve the result produced by evaluating a request that can
   /// be cached.
   template<typename Request,
            typename std::enable_if<Request::isEverCached>::type * = nullptr>
@@ -159,7 +159,7 @@ private:
     return getResultUncached(request);
   }
 
-  /// Retrieve the result of produced by evaluating a request that
+  /// Retrieve the result produced by evaluating a request that
   /// will never be cached.
   template<typename Request,
            typename std::enable_if<!Request::isEverCached>::type * = nullptr>

--- a/include/swift/AST/Evaluator.h
+++ b/include/swift/AST/Evaluator.h
@@ -1,0 +1,264 @@
+//===--- Evaluator.h - Request Evaluator ------------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the Evaluator class that evaluates and caches
+// requests.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_AST_EVALUATOR_H
+#define SWIFT_AST_EVALUATOR_H
+
+#include "swift/AST/AnyRequest.h"
+#include "swift/Basic/AnyValue.h"
+#include "swift/Basic/Defer.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/Optional.h"
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
+namespace swift {
+
+using llvm::Optional;
+using llvm::None;
+
+class DiagnosticEngine;
+
+/// Evaluation engine that evaluates and caches "requests", checking for cyclic
+/// dependencies along the way.
+///
+/// Each request is a function object that accepts a reference to the evaluator
+/// itself (through which it can request other values) and produces a
+/// value. That value can then be cached by the evaluator for subsequent access,
+/// using a policy dictated by the request itself.
+///
+/// The evaluator keeps track of all in-flight requests so that it can detect
+/// and diagnose cyclic dependencies.
+///
+/// Each request should be its own function object, supporting the following
+/// API:
+///
+///   - Copy constructor
+///   - Equality operator (==)
+///   - Hashing support (hash_value)
+///   - TypeID support (see swift/Basic/TypeID.h)
+///   - The output type (described via a nested type OutputType), which
+///     must itself by a value type that supports TypeID.
+///   - Evaluation via the function call operator:
+///       OutputType operator()(Evaluator &evaluator) const;
+///   - Cycle breaking and diagnostics operations:
+///
+///       void diagnoseCycle(DiagnosticEngine &diags) const;
+///       void noteCycleStep(DiagnosticEngine &diags) const;
+///       OutputType breakCycle() Const;
+///   - Caching policy:
+///
+///     static const bool isEverCached;
+///
+///       When false, the request's result will never be cached. Note that this
+///       also precludes cycle detection.  When true, the result will be
+///       cached on completion. How it is cached depends on the following.
+///
+///     bool isCached() const;
+///
+///       Dynamically indicates whether to cache this particular instance of the
+///       request, so that (for example) requests for which a quick check
+///       usually suffices can avoid caching a trivial result.
+///
+///     static const bool hasExternalCache;
+///
+///       When false, the results will be cached within the evaluator and
+///       cannot be accessed except through the evaluator. This is the
+///       best approach, because it ensures that all accesses to the result
+///       are tracked.
+///
+///       When true, the request itself must provide an way to cache the
+///       results, e.g., in some external data structure. External caching
+///       should only be used when staging in the use of the evaluator into
+///       existing mutable data structures; new computations should not depend
+///       on it. Externally-cached requests must provide additional API:
+///
+///         Optional<OutputType> getCachedResult() const;
+///
+///           Retrieve the cached result, or \c None if there is no such
+///           result.
+///
+///         void cacheResult(OutputType value) const;
+///
+///            Cache the given result.
+///
+///         bool isInFlight() const;
+///
+///           Whether we're already computing this value.
+///
+///         void setInFlight() const;
+///
+///           Indicate that we're about to compute this value. After this,
+///           \c isInFlight() should return \c true until \c cacheResult()
+///           is called.
+class Evaluator {
+  /// The diagnostics engine through which any cyclic-dependency
+  /// diagnostics will be emitted.
+  DiagnosticEngine &diags;
+
+  /// A vector containing all of the active evaluation requests, which
+  /// is treated as a stack.
+  std::vector<AnyRequest> activeRequests;
+
+  /// A cache that stores the results of requests.
+  llvm::DenseMap<AnyRequest, Optional<AnyValue>> cache;
+
+public:
+  /// Construct a new evaluator that can emit cyclic-dependency
+  /// diagnostics through the given diagnostics engine.
+  Evaluator(DiagnosticEngine &diags);
+
+  /// Evaluate the given request and produce its result,
+  /// consulting/populating the cache as required.
+  template<typename Request>
+  typename Request::OutputType operator()(const Request &request) {
+    return getResult(request);
+  }
+
+  /// Evaluate a set of requests and return their results as a tuple.
+  ///
+  /// Use this to describe cases where there are multiple (known)
+  /// requests that all need to be satisfied.
+  template<typename ...Requests>
+  std::tuple<typename Requests::OutputType...>
+  operator()(const Requests &...requests) {
+    return std::tuple<typename Requests::OutputType...>((*this)(requests)...);
+  }
+
+private:
+  /// Diagnose a cycle detected in the evaluation of the given
+  /// request.
+  void diagnoseCycle(const AnyRequest &request);
+
+  /// Retrieve the result of produced by evaluating a request that can
+  /// be cached.
+  template<typename Request,
+           typename std::enable_if<Request::isEverCached>::type * = nullptr>
+  typename Request::OutputType getResult(const Request &request) {
+    // The request can be cached, but check a predicate to determine
+    // whether this particular instance is cached. This allows more
+    // fine-grained control over which instances get cache.
+    if (request.isCached())
+      return getResultCached(request);
+
+    return getResultUncached(request);
+  }
+
+  /// Retrieve the result of produced by evaluating a request that
+  /// will never be cached.
+  template<typename Request,
+           typename std::enable_if<!Request::isEverCached>::type * = nullptr>
+  typename Request::OutputType getResult(const Request &request) {
+    return getResultUncached(request);
+  }
+
+  /// Produce the result of the request without caching.
+  template<typename Request>
+  typename Request::OutputType getResultUncached(const Request &request) {
+    // Push this request onto the active-requests stack while we
+    // evaluate it.
+    activeRequests.push_back(request);
+    SWIFT_DEFER {
+      activeRequests.pop_back();
+    };
+
+    return request(*this);
+  }
+
+  /// Get the result of a request, consulting an external cache
+  /// provided by the request to retrieve previously-computed results
+  /// and detect recursion.
+  template<typename Request,
+           typename std::enable_if<Request::hasExternalCache>::type * = nullptr>
+  typename Request::OutputType getResultCached(const Request &request) {
+    // If the request is still in flight, diagnose it.
+    if (request.isInFlight()) {
+      diagnoseCycle(request);
+
+      // Break the cache and cache the result, so we don't attempt
+      // this operation again.
+      request.cacheResult(request.breakCycle());
+    }
+
+    // If there is a cached result, return it.
+    if (auto cached = request.getCachedResult())
+      return *cached;
+
+    // Push this request onto the active-requests stack while we
+    // evaluate it.
+    activeRequests.push_back(request);
+    SWIFT_DEFER {
+      activeRequests.pop_back();
+    };
+
+    // Compute the result.
+    request.setInFlight();
+    auto result = request(*this);
+
+    // Cache it.
+    request.cacheResult(result);
+
+    // Return it.
+    return result;
+  }
+
+  /// Get the result of a request, consulting the general cache to
+  /// retrieve previously-computed results and detect recursion.
+  template<
+      typename Request,
+      typename std::enable_if<!Request::hasExternalCache>::type * = nullptr>
+  typename Request::OutputType getResultCached(const Request &request) {
+    AnyRequest anyRequest{request};
+
+    // Find an existing entry for this request in the cache, or create
+    // an empty entry if none exists yet.
+    auto cached = cache.insert({anyRequest, None});
+    if (!cached.second) {
+      // There was already an entry in the cache.
+
+      // If the existing cache entry had no value, we have a
+      // cycle. Diagnose the cycle and have the request break the
+      // cycle by providing a placeholder value.
+      if (!cached.first->second) {
+        diagnoseCycle(anyRequest);
+        cached.first->second = request.breakCycle();
+      }
+
+      // Return the cached value, which might be the placeholder above.
+      return cached.first->second->castTo<typename Request::OutputType>();
+    }
+
+    // Push this request onto the active-requests stack while we
+    // evaluate it.
+    activeRequests.push_back(anyRequest);
+    SWIFT_DEFER {
+      activeRequests.pop_back();
+    };
+
+    // Evaluate the request.
+    auto result = request(*this);
+
+    // Cache the result.
+    cache[anyRequest] = result;
+    return result;
+  }
+};
+
+} // end namespace evaluator
+
+#endif // SWIFT_AST_EVALUATOR_H

--- a/include/swift/AST/Evaluator.h
+++ b/include/swift/AST/Evaluator.h
@@ -280,6 +280,14 @@ public:
   LLVM_ATTRIBUTE_DEPRECATED(
     void dumpDependencies(const AnyRequest &request) const LLVM_ATTRIBUTE_USED,
     "Only meant for use in the debugger");
+
+  /// Print all dependencies known to the evaluator as a single Graphviz
+  /// directed graph.
+  void printDependenciesGraphviz(llvm::raw_ostream &out) const;
+
+  LLVM_ATTRIBUTE_DEPRECATED(
+    void dumpDependenciesGraphviz() const LLVM_ATTRIBUTE_USED,
+    "Only meant for use in the debugger");
 };
 
 } // end namespace evaluator

--- a/include/swift/AST/SimpleRequest.h
+++ b/include/swift/AST/SimpleRequest.h
@@ -29,37 +29,50 @@ namespace swift {
 
 class Evaluator;
 
+/// Describes how the result for a particular request will be cached.
+enum class CacheKind {
+  /// The result for a particular request should never be cached.
+  Uncached,
+  /// The result for a particular request should be cached within the
+  /// evaluator itself.
+  Cached,
+  /// The result of a particular request will be cached via some separate
+  /// mechanism, such as a mutable data structure.
+  SeparatelyCached,
+};
+
 /// CRTP base class that describes a request operation that takes values
 /// with the given input types (\c Inputs...) and produces an output of
 /// the given type.
 ///
 /// \tparam Derived The final, derived class type for the request.
+/// \tparam Caching Describes how the output value is cached, if at all.
 /// \tparam Output The type of the result produced by evaluating this request.
 /// \tparam Inputs The types of the inputs to this request, i.e., the values
 /// that comprise the request itself. These will determine the uniqueness of
 /// the request.
 ///
-/// The Derived class needs to implement several operations. The most important
-/// one takes an evaluator and the input values, then computes the final
-/// result:
+/// The \c Derived class needs to implement several operations. The most
+/// important one takes an evaluator and the input values, then computes the
+/// final result:
 /// \code
 ///   Output operator()(Evaluator &evaluator, Inputs...) const;
 /// \endcode
 ///
-/// The Derived class will also need to implement an operation to break a
+/// The \c Derived class will also need to implement an operation to break a
 /// cycle if one is found, i.e.,
 /// \code
 ///   OutputType breakCycle() const;
 /// \endcode
 ///
-/// Cycle diagnostics can be handled in one of two ways. Either the Derived
+/// Cycle diagnostics can be handled in one of two ways. Either the \c Derived
 /// class can implement the two cycle-diagnosing operations directly:
 /// \code
 ///   void diagnoseCycle(DiagnosticEngine &diags) const;
 ///   void noteCycleStep(DiagnosticEngine &diags) const;
 /// \endcode
 ///
-/// Or the Derived class can provide a "diagnostic location" operation and
+/// Or the \c Derived class can provide a "diagnostic location" operation and
 /// diagnostic values for the main cycle diagnostic and a "note" describing a
 /// step within the chain of diagnostics:
 /// \code
@@ -67,7 +80,17 @@ class Evaluator;
 ///   static constexpr Diag<Inputs...> cycleDiagnostic = ...;
 ///   static constexpr Diag<Inputs...> cycleStepDiagnostic = ...;
 /// \endcode
-template<typename Derived, typename Output, typename ...Inputs>
+///
+/// Value caching is determined by the \c Caching parameter. When
+/// \c Caching == CacheKind::SeparatelyCached, the \c Derived class is
+/// responsible for implementing the two operations responsible to managing
+/// the cache:
+/// \code
+///   Optional<Output> getCachedResult() const;
+///   void cacheResult(Output value) const;
+/// \endcode
+template<typename Derived, CacheKind Caching, typename Output,
+         typename ...Inputs>
 class SimpleRequest {
   std::tuple<Inputs...> storage;
 
@@ -99,6 +122,9 @@ protected:
   const std::tuple<Inputs...> &getStorage() const { return storage; }
 
 public:
+  static const bool isEverCached = (Caching != CacheKind::Uncached);
+  static const bool hasExternalCache = (Caching == CacheKind::SeparatelyCached);
+
   using OutputType = Output;
   
   explicit SimpleRequest(const Inputs& ...inputs)

--- a/include/swift/Basic/AnyValue.h
+++ b/include/swift/Basic/AnyValue.h
@@ -139,6 +139,9 @@ public:
   friend void simple_display(llvm::raw_ostream &out, const AnyValue &value) {
     value.stored->display(out);
   }
+
+  /// Return the result of calling simple_display as a string.
+  std::string getAsString() const;
 };
 
 } // end namespace swift

--- a/include/swift/Basic/AnyValue.h
+++ b/include/swift/Basic/AnyValue.h
@@ -22,8 +22,8 @@
 
 namespace swift {
 
-/// Stores a value of any type satisfies a small set of requirements
-/// (currenrly, just equatability).
+/// Stores a value of any type that satisfies a small set of requirements
+/// (currently, just equatability).
 class AnyValue {
   /// Abstract base class used to hold on to a value.
   class HolderBase {
@@ -85,6 +85,7 @@ public:
   /// Cast to a specific (known) type.
   template<typename T>
   const T &castTo() const {
+    assert(stored->typeID == TypeID<T>::value);
     return static_cast<const Holder<T> *>(stored.get())->value;
   }
 

--- a/include/swift/Basic/AnyValue.h
+++ b/include/swift/Basic/AnyValue.h
@@ -1,0 +1,118 @@
+//===--- AnyValue.h - Any Value Existential ---------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines the AnyValue class, which is used to store an
+//  immutable value of any type.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_ANYVALUE_H
+#define SWIFT_BASIC_ANYVALUE_H
+
+#include "swift/Basic/TypeID.h"
+
+namespace swift {
+
+/// Stores a value of any type satisfies a small set of requirements
+/// (currenrly, just equatability).
+class AnyValue {
+  /// Abstract base class used to hold on to a value.
+  class HolderBase {
+  public:
+    /// Type ID number.
+    const uint64_t typeID;
+
+    HolderBase() = delete;
+    HolderBase(const HolderBase &) = delete;
+    HolderBase(HolderBase &&) = delete;
+    HolderBase &operator=(const HolderBase &) = delete;
+    HolderBase &operator=(HolderBase &&) = delete;
+
+    /// Initialize base with type ID.
+    HolderBase(uint64_t typeID) : typeID(typeID) { }
+
+    virtual ~HolderBase();
+
+    /// Determine whether this value is equivalent to another.
+    ///
+    /// The caller guarantees that the type IDs are the same.
+    virtual bool equals(const HolderBase &other) const = 0;
+  };
+
+  /// Holds a value that can be used as a request input/output.
+  template<typename T>
+  class Holder final : public HolderBase {
+  public:
+    const T value;
+
+    Holder(T &&value)
+      : HolderBase(TypeID<T>::value),
+        value(std::move(value)) { }
+
+    Holder(const T &value) : HolderBase(TypeID<T>::value), value(value) { }
+
+    virtual ~Holder() { }
+
+    /// Determine whether this value is equivalent to another.
+    ///
+    /// The caller guarantees that the type IDs are the same.
+    virtual bool equals(const HolderBase &other) const override {
+      assert(typeID == other.typeID && "Caller should match type IDs");
+      return value == static_cast<const Holder<T> &>(other).value;
+    }
+  };
+
+  /// The data stored in this value.
+  std::shared_ptr<HolderBase> stored;
+
+public:
+  /// Construct a new instance with the given value.
+  template<typename T>
+  AnyValue(T&& value) {
+    using ValueType = typename std::remove_reference<T>::type;
+    stored.reset(new Holder<ValueType>(std::forward<T>(value)));
+  }
+
+  /// Cast to a specific (known) type.
+  template<typename T>
+  const T &castTo() const {
+    return static_cast<const Holder<T> *>(stored.get())->value;
+  }
+
+  /// Try casting to a specific (known) type, returning \c nullptr on
+  /// failure.
+  template<typename T>
+  const T *getAs() const {
+    if (stored->typeID != TypeID<T>::value)
+      return nullptr;
+
+    return &static_cast<const Holder<T> *>(stored.get())->value;
+  }
+
+  /// Compare two instances for equality.
+  friend bool operator==(const AnyValue &lhs, const AnyValue &rhs) {
+    if (lhs.stored->typeID != rhs.stored->typeID)
+      return false;
+
+    return lhs.stored->equals(*rhs.stored);
+  }
+
+  friend bool operator!=(const AnyValue &lhs, const AnyValue &rhs) {
+    return !(lhs == rhs);
+  }
+};
+
+} // end namespace swift
+
+#endif //
+
+

--- a/include/swift/Basic/CTypeIDZone.def
+++ b/include/swift/Basic/CTypeIDZone.def
@@ -1,0 +1,37 @@
+//===--- CTypeIDZone.def - Define the C++ TypeID Zone -----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This definition file describes the types  in the "C++" TypeID zone,
+//  for use with the TypeID template.
+//
+//===----------------------------------------------------------------------===//
+
+// C types.
+SWIFT_TYPEID_NAMED(unsigned char, UnsignedChar)
+SWIFT_TYPEID_NAMED(signed char, SignedChar)
+SWIFT_TYPEID_NAMED(char, Char)
+SWIFT_TYPEID_NAMED(short, Short)
+SWIFT_TYPEID_NAMED(unsigned short, UnsignedShort)
+SWIFT_TYPEID_NAMED(int, Int)
+SWIFT_TYPEID_NAMED(unsigned int, UnsignedInt)
+SWIFT_TYPEID_NAMED(long, Long)
+SWIFT_TYPEID_NAMED(unsigned long, UnsignedLong)
+SWIFT_TYPEID_NAMED(long long, LongLong)
+SWIFT_TYPEID_NAMED(unsigned long long, UnsignedLongLong)
+SWIFT_TYPEID_NAMED(float, Float)
+SWIFT_TYPEID_NAMED(double, Double)
+SWIFT_TYPEID_NAMED(bool, Bool)
+SWIFT_TYPEID_NAMED(decltype(nullptr), NullPtr)
+SWIFT_TYPEID_NAMED(void, Void)
+
+// C++ standard library types.
+SWIFT_TYPEID_TEMPLATE1_NAMED(std::vector, Vector, typename T, T)

--- a/include/swift/Basic/DefineTypeIDZone.h
+++ b/include/swift/Basic/DefineTypeIDZone.h
@@ -46,24 +46,34 @@ template<> struct TypeIDZoneTypes<SWIFT_TYPEID_ZONE> {
 };
 
 // Second pass: create specializations of TypeID for these types.
-#define SWIFT_TYPEID_NAMED(Type, Name)                     \
-template<> struct TypeID<Type> {                           \
-  static const uint64_t value =                            \
-    formTypeID(SWIFT_TYPEID_ZONE,                          \
-               TypeIDZoneTypes<SWIFT_TYPEID_ZONE>::Name);  \
+#define SWIFT_TYPEID_NAMED(Type, Name)                    \
+template<> struct TypeID<Type> {                          \
+  static const uint64_t value =                           \
+    formTypeID(SWIFT_TYPEID_ZONE,                         \
+               TypeIDZoneTypes<SWIFT_TYPEID_ZONE>::Name); \
+                                                          \
+  static llvm::StringRef getName() {                      \
+    return #Name;                                         \
+  }                                                       \
 };
 
-#define SWIFT_TYPEID_TEMPLATE1_NAMED(Template, Name, Param1, Arg1)      \
-template<Param1> struct TypeID<Template<Arg1>> {                        \
-private:                                                                \
-  static const uint64_t templateID =                                    \
-    formTypeID(SWIFT_TYPEID_ZONE,                          \
-               TypeIDZoneTypes<SWIFT_TYPEID_ZONE>::Name);  \
-                                                                        \
-public:                                                                 \
-  static const uint64_t value =                                         \
-    (TypeID<Arg1>::value << 16) | templateID;                           \
-};
+#define SWIFT_TYPEID_TEMPLATE1_NAMED(Template, Name, Param1, Arg1)    \
+template<Param1> struct TypeID<Template<Arg1>> {                      \
+private:                                                              \
+  static const uint64_t templateID =                                  \
+    formTypeID(SWIFT_TYPEID_ZONE,                                     \
+               TypeIDZoneTypes<SWIFT_TYPEID_ZONE>::Name);             \
+                                                                      \
+public:                                                               \
+  static const uint64_t value =                                       \
+    (TypeID<Arg1>::value << 16) | templateID;                         \
+                                                                      \
+  static std::string getName() {                                      \
+    return std::string(#Name) + "<" + TypeID<Arg1>::getName() + ">";  \
+  }                                                                   \
+};                                                                    \
+                                                                      \
+template<Param1> const uint64_t TypeID<Template<Arg1>>::value;
 
 #include SWIFT_TYPEID_HEADER
 #undef SWIFT_TYPEID_NAMED

--- a/include/swift/Basic/DefineTypeIDZone.h
+++ b/include/swift/Basic/DefineTypeIDZone.h
@@ -14,9 +14,9 @@
 //  Two macros should be #define'd before inclusion, and will be #undef'd at
 //  the end of this file:
 //
-//    SWIFT_TYPEID_ZONE: The name of the Zone being defined, e.g.,
-//    SwiftAST for the Swift AST library's zone. All zones need to be defined
-//    a priori as 
+//    SWIFT_TYPEID_ZONE: The ID number of the Zone being defined, which must
+//    be unique. 0 is reserved for basic C and LLVM types; 255 is reserved
+//    for test cases.
 //
 //    SWIFT_TYPEID_HEADER: A (quoted) name of the header to be
 //    included to define the types in the zone.

--- a/include/swift/Basic/DefineTypeIDZone.h
+++ b/include/swift/Basic/DefineTypeIDZone.h
@@ -1,0 +1,74 @@
+//===--- DefineTypeIDZone.h - Define a TypeID Zone --------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file should be #included to define the TypeIDs for a given zone.
+//  Two macros should be #define'd before inclusion, and will be #undef'd at
+//  the end of this file:
+//
+//    SWIFT_TYPEID_ZONE: The name of the Zone being defined, e.g.,
+//    SwiftAST for the Swift AST library's zone. All zones need to be defined
+//    a priori as 
+//
+//    SWIFT_TYPEID_HEADER: A (quoted) name of the header to be
+//    included to define the types in the zone.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_TYPEID_ZONE
+#  error Must define the value of the TypeID zone with the given name.
+#endif
+
+#ifndef SWIFT_TYPEID_HEADER
+#  error Must define the TypeID header name with SWIFT_TYPEID_HEADER
+#endif
+
+// Define a TypeID where the type name and internal name are the same.
+#define SWIFT_TYPEID(Type) SWIFT_TYPEID_NAMED(Type, Type)
+
+// First pass: put all of the names into an enum so we get values for them.
+template<> struct TypeIDZoneTypes<SWIFT_TYPEID_ZONE> {
+  enum Types : uint8_t {
+#define SWIFT_TYPEID_NAMED(Type, Name) Name,
+#define SWIFT_TYPEID_TEMPLATE1_NAMED(Template, Name, Param1, Arg1) Name,
+#include SWIFT_TYPEID_HEADER
+#undef SWIFT_TYPEID_NAMED
+#undef SWIFT_TYPEID_TEMPLATE1_NAMED
+  };
+};
+
+// Second pass: create specializations of TypeID for these types.
+#define SWIFT_TYPEID_NAMED(Type, Name)                     \
+template<> struct TypeID<Type> {                           \
+  static const uint64_t value =                            \
+    formTypeID(SWIFT_TYPEID_ZONE,                          \
+               TypeIDZoneTypes<SWIFT_TYPEID_ZONE>::Name);  \
+};
+
+#define SWIFT_TYPEID_TEMPLATE1_NAMED(Template, Name, Param1, Arg1)      \
+template<Param1> struct TypeID<Template<Arg1>> {                        \
+private:                                                                \
+  static const uint64_t templateID =                                    \
+    formTypeID(SWIFT_TYPEID_ZONE,                          \
+               TypeIDZoneTypes<SWIFT_TYPEID_ZONE>::Name);  \
+                                                                        \
+public:                                                                 \
+  static const uint64_t value =                                         \
+    (TypeID<Arg1>::value << 16) | templateID;                           \
+};
+
+#include SWIFT_TYPEID_HEADER
+#undef SWIFT_TYPEID_NAMED
+#undef SWIFT_TYPEID_TEMPLATE1_NAMED
+
+#undef SWIFT_TYPEID
+#undef SWIFT_TYPEID_ZONE
+#undef SWIFT_TYPEID_HEADER

--- a/include/swift/Basic/ImplementTypeIDZone.h
+++ b/include/swift/Basic/ImplementTypeIDZone.h
@@ -15,9 +15,9 @@
 //  Two macros should be #define'd before inclusion, and will be #undef'd at
 //  the end of this file:
 //
-//    SWIFT_TYPEID_ZONE: The name of the Zone being defined, e.g.,
-//    SwiftAST for the Swift AST library's zone. All zones need to be defined
-//    a priori as 
+//    SWIFT_TYPEID_ZONE: The ID number of the Zone being defined, which must
+//    be unique. 0 is reserved for basic C and LLVM types; 255 is reserved
+//    for test cases.
 //
 //    SWIFT_TYPEID_HEADER: A (quoted) name of the header to be
 //    included to define the types in the zone.

--- a/include/swift/Basic/ImplementTypeIDZone.h
+++ b/include/swift/Basic/ImplementTypeIDZone.h
@@ -1,0 +1,51 @@
+//===--- ImplementTypeIDZone.h - Implement a TypeID Zone --------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file should be #included to implement the TypeIDs for a given zone
+//  in a C++ file.
+//  Two macros should be #define'd before inclusion, and will be #undef'd at
+//  the end of this file:
+//
+//    SWIFT_TYPEID_ZONE: The name of the Zone being defined, e.g.,
+//    SwiftAST for the Swift AST library's zone. All zones need to be defined
+//    a priori as 
+//
+//    SWIFT_TYPEID_HEADER: A (quoted) name of the header to be
+//    included to define the types in the zone.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_TYPEID_ZONE
+#  error Must define the value of the TypeID zone with the given name.
+#endif
+
+#ifndef SWIFT_TYPEID_HEADER
+#  error Must define the TypeID header name with SWIFT_TYPEID_HEADER
+#endif
+
+// Define a TypeID where the type name and internal name are the same.
+#define SWIFT_TYPEID(Type) SWIFT_TYPEID_NAMED(Type, Type)
+
+// Out-of-line definitions.
+#define SWIFT_TYPEID_NAMED(Type, Name)            \
+  const uint64_t TypeID<Type>::value;
+
+#define SWIFT_TYPEID_TEMPLATE1_NAMED(Template, Name, Param1, Arg1)
+
+#include SWIFT_TYPEID_HEADER
+
+#undef SWIFT_TYPEID_NAMED
+#undef SWIFT_TYPEID_TEMPLATE1_NAMED
+
+#undef SWIFT_TYPEID
+#undef SWIFT_TYPEID_ZONE
+#undef SWIFT_TYPEID_HEADER

--- a/include/swift/Basic/SimpleDisplay.h
+++ b/include/swift/Basic/SimpleDisplay.h
@@ -1,0 +1,67 @@
+//===--- SimpleDisplay.h - Simple Type Display ------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines the main customization point, simple_display, for
+//  displaying values of a given type
+//  encoding of (static) type information for use as a simple replacement
+//  for run-time type information.
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_BASIC_SIMPLE_DISPLAY_H
+#define SWIFT_BASIC_SIMPLE_DISPLAY_H
+
+#include "llvm/Support/raw_ostream.h"
+#include <tuple>
+#include <type_traits>
+
+namespace swift {
+  template<typename T>
+  void simple_display(llvm::raw_ostream &out, const T &value) {
+    out << value;
+  }
+
+  template<unsigned I, typename ...Types,
+  typename std::enable_if<I == sizeof...(Types)>::type* = nullptr>
+  void simple_display_tuple(llvm::raw_ostream &out,
+                            const std::tuple<Types...> &value);
+
+  template<unsigned I, typename ...Types,
+           typename std::enable_if<I < sizeof...(Types)>::type* = nullptr>
+  void simple_display_tuple(llvm::raw_ostream &out,
+                            const std::tuple<Types...> &value) {
+    // Start or separator.
+    if (I == 0) out << "(";
+    else out << ", ";
+
+    // Current element.
+    simple_display(out, std::get<I>(value));
+
+    // Print the remaining elements.
+    simple_display_tuple<I+1>(out, value);
+  }
+
+  template<unsigned I, typename ...Types,
+           typename std::enable_if<I == sizeof...(Types)>::type*>
+  void simple_display_tuple(llvm::raw_ostream &out,
+                            const std::tuple<Types...> &value) {
+    // Last element.
+    out << ")";
+  }
+
+  template<typename ...Types>
+  void simple_display(llvm::raw_ostream &out,
+                      const std::tuple<Types...> &value) {
+    simple_display_tuple<0>(out, value);
+  }
+}
+
+#endif // SWIFT_BASIC_SIMPLE_DISPLAY_H

--- a/include/swift/Basic/SimpleRequest.h
+++ b/include/swift/Basic/SimpleRequest.h
@@ -1,0 +1,89 @@
+//===--- SimpleRequest.h - Simple Request Instances -------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines the SimpleRequest class template, which makes it easier
+//  to define new request kinds.
+//
+//===----------------------------------------------------------------------===//
+#ifndef SWIFT_BASIC_SIMPLEREQUEST_H
+#define SWIFT_BASIC_SIMPLEREQUEST_H
+
+#include "swift/Basic/SimpleDisplay.h"
+#include "swift/Basic/TypeID.h"
+#include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/STLExtras.h"
+#include <tuple>
+
+namespace swift {
+
+class Evaluator;
+
+/// CRTP base class that describes a request operation that takes values
+/// with the given input types (\c Inputs...) and produces an output of
+/// the given type.
+template<typename Derived, typename Output, typename ...Inputs>
+class SimpleRequest {
+  std::tuple<Inputs...> storage;
+
+  Derived &asDerived() {
+    return *static_cast<Derived *>(this);
+  }
+
+  const Derived &asDerived() const {
+    return *static_cast<const Derived *>(this);
+  }
+
+  template<size_t ...Indices>
+  Output callDerived(Evaluator &evaluator,
+                     llvm::index_sequence<Indices...>) const {
+    static_assert(sizeof...(Indices) > 0, "Subclass must define operator()");
+    return asDerived()(evaluator, std::get<Indices>(storage)...);
+  }
+
+protected:
+  /// Retrieve the storage value directly.
+  const std::tuple<Inputs...> &getStorage() const { return storage; }
+
+public:
+  using OutputType = Output;
+  
+  explicit SimpleRequest(const Inputs& ...inputs)
+    : storage(inputs...) { }
+
+  OutputType operator()(Evaluator &evaluator) const {
+    return callDerived(evaluator, llvm::index_sequence_for<Inputs...>());
+  }
+  
+  friend bool operator==(const SimpleRequest &lhs, const SimpleRequest &rhs) {
+    return lhs.storage == rhs.storage;
+  }
+
+  friend bool operator!=(const SimpleRequest &lhs, const SimpleRequest &rhs) {
+    return !(lhs == rhs);
+  }
+
+  friend hash_code hash_value(const SimpleRequest &request) {
+    using llvm::hash_combine;
+
+    return hash_combine(TypeID<Derived>::value, request.storage);
+  }
+
+  friend void simple_display(llvm::raw_ostream &out,
+                             const Derived &request) {
+    out << TypeID<Derived>::getName();
+    simple_display(out, request.storage);
+  }
+};
+
+}
+
+#endif // SWIFT_BASIC_SIMPLEREQUEST_H

--- a/include/swift/Basic/TypeID.h
+++ b/include/swift/Basic/TypeID.h
@@ -45,29 +45,23 @@ struct TypeIdZones {
 };
 
 /// Form a type ID given a zone and type value.
-constexpr uint8_t formTypeID(uint8_t zone, uint8_t type) {
-  return (zone << 8) | type;
+constexpr uint64_t formTypeID(uint8_t zone, uint8_t type) {
+  return (uint64_t(zone) << 8) | uint64_t(type);
 }
 
 /// Assign the given type a particular value in the zone.
 #define SWIFT_TYPEID(Zone, Type, Value)                           \
 template<> struct TypeID<Type> {                                        \
   static const uint64_t value = formTypeID(TypeIdZones::Zone, Value);   \
-  static const unsigned depth = 0;                                      \
 }
 
 /// Assign the given single-param template a particular value in the zone.
-#define SWIFT_TYPEID_TEMPLATE1(Zone, Template, Value, Param1, Arg1)     \
-template<Param1> struct TypeID<Template<Arg1>> {                        \
-  static const unsigned depth = TypeID<Arg1>::depth + 1;                \
-  static_assert(depth < 4, "cannot fit type in 64-bit value");          \
-                                                                        \
-private:                                                                \
+#define SWIFT_TYPEID_TEMPLATE1(Zone, Template, Value, Param1, Arg1)       \
+template<Param1> struct TypeID<Template<Arg1>> {                          \
  static const uint64_t templateID = formTypeID(TypeIdZones::Zone, Value); \
-                                                                        \
-public:                                                                 \
-  static const uint64_t value =                                         \
-    (templateID << (depth * 8)) | TypeID<Arg1>::value;                  \
+                                                                          \
+public:                                                                   \
+  static const uint64_t value = (TypeID<Arg1>::value << 16) | templateID; \
 }
 
 // C types.
@@ -85,7 +79,7 @@ SWIFT_TYPEID(C, unsigned long long, 11);
 SWIFT_TYPEID(C, float, 12);
 SWIFT_TYPEID(C, double, 13);
 SWIFT_TYPEID(C, bool, 14);
-  SWIFT_TYPEID(C, decltype(nullptr), 15);
+SWIFT_TYPEID(C, decltype(nullptr), 15);
 SWIFT_TYPEID(C, void, 16);
 
 // C++ standard library types.

--- a/include/swift/Basic/TypeID.h
+++ b/include/swift/Basic/TypeID.h
@@ -19,7 +19,9 @@
 #ifndef SWIFT_BASIC_TYPEID_H
 #define SWIFT_BASIC_TYPEID_H
 
+#include "llvm/ADT/StringRef.h"
 #include <cstdint>
+#include <string>
 #include <vector>
 
 namespace swift {

--- a/include/swift/Basic/TypeID.h
+++ b/include/swift/Basic/TypeID.h
@@ -1,0 +1,96 @@
+//===--- TypeID.h - Simple Type Identification ------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file defines the TypeID template, which provides a numeric
+//  encoding of (static) type information for use as a simple replacement
+//  for run-time type information.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_BASIC_TYPEID_H
+#define SWIFT_BASIC_TYPEID_H
+
+#include <cstdint>
+#include <vector>
+
+namespace swift {
+
+/// Form a unique 64-bit integer value describing the type `T`.
+///
+/// This template needs to be specialized for every type that can
+/// participate in this kind of run-time type information, e.g., so
+/// that it can be stored in \c AnyValue.
+template<typename T>
+struct TypeID;
+
+/// Each type "zone" can contain 256 separate types for use in typeid,
+/// which should be enumerated.
+struct TypeIdZones {
+  enum ZoneValues : uint8_t {
+    /// C/C++ language and standard library types.
+    C = 0,
+
+    /// A zone used only for unit testing.
+    UnitTests = 1,
+  };
+};
+
+/// Form a type ID given a zone and type value.
+constexpr uint8_t formTypeID(uint8_t zone, uint8_t type) {
+  return (zone << 8) | type;
+}
+
+/// Assign the given type a particular value in the zone.
+#define SWIFT_TYPEID(Zone, Type, Value)                           \
+template<> struct TypeID<Type> {                                        \
+  static const uint64_t value = formTypeID(TypeIdZones::Zone, Value);   \
+  static const unsigned depth = 0;                                      \
+}
+
+/// Assign the given single-param template a particular value in the zone.
+#define SWIFT_TYPEID_TEMPLATE1(Zone, Template, Value, Param1, Arg1)     \
+template<Param1> struct TypeID<Template<Arg1>> {                        \
+  static const unsigned depth = TypeID<Arg1>::depth + 1;                \
+  static_assert(depth < 4, "cannot fit type in 64-bit value");          \
+                                                                        \
+private:                                                                \
+ static const uint64_t templateID = formTypeID(TypeIdZones::Zone, Value); \
+                                                                        \
+public:                                                                 \
+  static const uint64_t value =                                         \
+    (templateID << (depth * 8)) | TypeID<Arg1>::value;                  \
+}
+
+// C types.
+SWIFT_TYPEID(C, unsigned char, 1);
+SWIFT_TYPEID(C, signed char, 2);
+SWIFT_TYPEID(C, char, 3);
+SWIFT_TYPEID(C, short, 4);
+SWIFT_TYPEID(C, unsigned short, 5);
+SWIFT_TYPEID(C, int, 6);
+SWIFT_TYPEID(C, unsigned int, 7);
+SWIFT_TYPEID(C, long, 8);
+SWIFT_TYPEID(C, unsigned long, 9);
+SWIFT_TYPEID(C, long long, 10);
+SWIFT_TYPEID(C, unsigned long long, 11);
+SWIFT_TYPEID(C, float, 12);
+SWIFT_TYPEID(C, double, 13);
+SWIFT_TYPEID(C, bool, 14);
+  SWIFT_TYPEID(C, decltype(nullptr), 15);
+SWIFT_TYPEID(C, void, 16);
+
+// C++ standard library types.
+SWIFT_TYPEID_TEMPLATE1(C, std::vector, 100, typename T, T);
+
+} // end namespace swift
+
+#endif // SWIFT_BASIC_TYPEID_H

--- a/include/swift/Basic/TypeID.h
+++ b/include/swift/Basic/TypeID.h
@@ -32,58 +32,19 @@ namespace swift {
 template<typename T>
 struct TypeID;
 
-/// Each type "zone" can contain 256 separate types for use in typeid,
-/// which should be enumerated.
-struct TypeIdZones {
-  enum ZoneValues : uint8_t {
-    /// C/C++ language and standard library types.
-    C = 0,
-
-    /// A zone used only for unit testing.
-    UnitTests = 1,
-  };
-};
+/// Template whose specializations provide the set of type IDs within a
+/// given zone.
+template<uint8_t Zone> struct TypeIDZoneTypes;
 
 /// Form a type ID given a zone and type value.
 constexpr uint64_t formTypeID(uint8_t zone, uint8_t type) {
   return (uint64_t(zone) << 8) | uint64_t(type);
 }
 
-/// Assign the given type a particular value in the zone.
-#define SWIFT_TYPEID(Zone, Type, Value)                           \
-template<> struct TypeID<Type> {                                        \
-  static const uint64_t value = formTypeID(TypeIdZones::Zone, Value);   \
-}
-
-/// Assign the given single-param template a particular value in the zone.
-#define SWIFT_TYPEID_TEMPLATE1(Zone, Template, Value, Param1, Arg1)       \
-template<Param1> struct TypeID<Template<Arg1>> {                          \
- static const uint64_t templateID = formTypeID(TypeIdZones::Zone, Value); \
-                                                                          \
-public:                                                                   \
-  static const uint64_t value = (TypeID<Arg1>::value << 16) | templateID; \
-}
-
-// C types.
-SWIFT_TYPEID(C, unsigned char, 1);
-SWIFT_TYPEID(C, signed char, 2);
-SWIFT_TYPEID(C, char, 3);
-SWIFT_TYPEID(C, short, 4);
-SWIFT_TYPEID(C, unsigned short, 5);
-SWIFT_TYPEID(C, int, 6);
-SWIFT_TYPEID(C, unsigned int, 7);
-SWIFT_TYPEID(C, long, 8);
-SWIFT_TYPEID(C, unsigned long, 9);
-SWIFT_TYPEID(C, long long, 10);
-SWIFT_TYPEID(C, unsigned long long, 11);
-SWIFT_TYPEID(C, float, 12);
-SWIFT_TYPEID(C, double, 13);
-SWIFT_TYPEID(C, bool, 14);
-SWIFT_TYPEID(C, decltype(nullptr), 15);
-SWIFT_TYPEID(C, void, 16);
-
-// C++ standard library types.
-SWIFT_TYPEID_TEMPLATE1(C, std::vector, 100, typename T, T);
+// Define the C type zone (zone 0).
+#define SWIFT_TYPEID_ZONE 0
+#define SWIFT_TYPEID_HEADER "swift/Basic/CTypeIDZone.def"
+#include "swift/Basic/DefineTypeIDZone.h"
 
 } // end namespace swift
 

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -27,6 +27,7 @@ add_swift_library(swiftAST STATIC
   DiagnosticEngine.cpp
   DiagnosticList.cpp
   DocComment.cpp
+  Evaluator.cpp
   Expr.cpp
   GenericEnvironment.cpp
   GenericSignature.cpp

--- a/lib/AST/Evaluator.cpp
+++ b/lib/AST/Evaluator.cpp
@@ -1,0 +1,36 @@
+//===--- Evaluator.cpp - Request Evaluator Implementation -----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the Evaluator class that evaluates and caches
+// requests.
+//
+//===----------------------------------------------------------------------===//
+#include "swift/AST/Evaluator.h"
+#include "swift/Basic/Range.h"
+
+using namespace swift;
+
+AnyRequest::HolderBase::~HolderBase() { }
+
+Evaluator::Evaluator(DiagnosticEngine &diags) : diags(diags) { }
+
+void Evaluator::diagnoseCycle(const AnyRequest &request) {
+  request.diagnoseCycle(diags);
+  for (const auto &step : reversed(activeRequests)) {
+    if (step == request) return;
+
+    step.noteCycleStep(diags);
+  }
+
+  llvm_unreachable("Diagnosed a cycle but it wasn't represented in the stack");
+}
+

--- a/lib/AST/Evaluator.cpp
+++ b/lib/AST/Evaluator.cpp
@@ -69,6 +69,13 @@ void Evaluator::printDependencies(const AnyRequest &request,
   // Print this node.
   simple_display(out, request);
 
+  // Print the cached value, if known.
+  auto cachedValue = cache.find(request);
+  if (cachedValue != cache.end()) {
+    out << " -> ";
+    PrintEscapedString(cachedValue->second.getAsString(), out);
+  }
+
   if (!visited.insert(request).second) {
     // We've already seed this node, so we have a cyclic dependency.
     out.changeColor(llvm::raw_ostream::RED);

--- a/lib/AST/Evaluator.cpp
+++ b/lib/AST/Evaluator.cpp
@@ -23,6 +23,14 @@ AnyRequest::HolderBase::~HolderBase() { }
 
 Evaluator::Evaluator(DiagnosticEngine &diags) : diags(diags) { }
 
+bool Evaluator::checkDependency(const AnyRequest &request) {
+  if (activeRequests.insert(request))
+    return false;
+
+  diagnoseCycle(request);
+  return true;
+}
+
 void Evaluator::diagnoseCycle(const AnyRequest &request) {
   request.diagnoseCycle(diags);
   for (const auto &step : reversed(activeRequests)) {

--- a/lib/AST/Evaluator.cpp
+++ b/lib/AST/Evaluator.cpp
@@ -16,6 +16,7 @@
 //===----------------------------------------------------------------------===//
 #include "swift/AST/Evaluator.h"
 #include "swift/Basic/Range.h"
+#include "llvm/Support/Debug.h"
 
 using namespace swift;
 
@@ -24,8 +25,14 @@ AnyRequest::HolderBase::~HolderBase() { }
 Evaluator::Evaluator(DiagnosticEngine &diags) : diags(diags) { }
 
 bool Evaluator::checkDependency(const AnyRequest &request) {
-  if (activeRequests.insert(request))
+  // If there is an active request, record it's dependency on this request.
+  if (!activeRequests.empty())
+    dependencies[activeRequests.back()].push_back(request);
+
+  // Record this as an active request.
+  if (activeRequests.insert(request)) {
     return false;
+  }
 
   diagnoseCycle(request);
   return true;
@@ -41,4 +48,63 @@ void Evaluator::diagnoseCycle(const AnyRequest &request) {
 
   llvm_unreachable("Diagnosed a cycle but it wasn't represented in the stack");
 }
+
+void Evaluator::printDependencies(const AnyRequest &request,
+                                  llvm::raw_ostream &out,
+                                  llvm::DenseSet<AnyRequest> &visited,
+                                  std::string &prefixStr,
+                                  bool lastChild) const {
+  out << prefixStr << " `--";
+
+  // Print this node.
+  simple_display(out, request);
+
+  if (!visited.insert(request).second) {
+    // We've already seed this node, so we have a cyclic dependency.
+    out.changeColor(llvm::raw_ostream::RED);
+    out << " (cyclic dependency)\n";
+    out.resetColor();
+  } else if (dependencies.count(request) == 0) {
+    // We have not seen this node before, so we don't know its dependencies.
+    out.changeColor(llvm::raw_ostream::GREEN);
+    out << " (dependency not evaluated)\n";
+    out.resetColor();
+
+    // Remove from the visited set.
+    visited.erase(request);
+  } else {
+    // Print children.
+    out << "\n";
+
+    // Setup the prefix to print the children.
+    prefixStr += ' ';
+    prefixStr += (lastChild ? ' ' : '|');
+    prefixStr += "  ";
+
+    // Print the children.
+    auto &dependsOn = dependencies.find(request)->second;
+    for (unsigned i : indices(dependsOn)) {
+      printDependencies(dependsOn[i], out, visited, prefixStr,
+                        i == dependsOn.size()-1);
+    }
+
+    // Drop our changes to the prefix.
+    prefixStr.erase(prefixStr.end() - 4, prefixStr.end());
+
+    // Remove from the visited set.
+    visited.erase(request);
+  }
+}
+
+void Evaluator::printDependencies(const AnyRequest &request,
+                                  llvm::raw_ostream &out) const {
+  std::string prefixStr;
+  llvm::DenseSet<AnyRequest> visited;
+  printDependencies(request, out, visited, prefixStr, /*lastChild=*/true);
+}
+
+void Evaluator::dumpDependencies(const AnyRequest &request) const {
+  printDependencies(request, llvm::dbgs());
+}
+
 

--- a/lib/Basic/AnyValue.cpp
+++ b/lib/Basic/AnyValue.cpp
@@ -18,3 +18,12 @@
 using namespace swift;
 
 AnyValue::HolderBase::~HolderBase() { }
+
+std::string AnyValue::getAsString() const {
+  std::string result;
+  {
+    llvm::raw_string_ostream out(result);
+    simple_display(out, *this);
+  }
+  return result;
+}

--- a/lib/Basic/AnyValue.cpp
+++ b/lib/Basic/AnyValue.cpp
@@ -1,0 +1,20 @@
+//===--- AnyValue.cpp - Out-of-line code for AnyValue ---------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file implements support code for AnyValue.
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Basic/AnyValue.h"
+using namespace swift;
+
+AnyValue::HolderBase::~HolderBase() { }

--- a/lib/Basic/CMakeLists.txt
+++ b/lib/Basic/CMakeLists.txt
@@ -65,6 +65,7 @@ set(version_inc_files
   ${llvm_revision_inc} ${clang_revision_inc} ${swift_revision_inc})
 
 add_swift_library(swiftBasic STATIC
+  AnyValue.cpp
   Cache.cpp
   ClusteredBitVector.cpp
   DiverseStack.cpp

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -186,7 +186,6 @@ where Bound: Strideable, Bound.Stride : SignedInteger {
   public typealias Iterator = IndexingIterator<Range<Bound>>
 }
 
-// FIXME: should just be RandomAccessCollection
 extension Range: Collection, BidirectionalCollection, RandomAccessCollection
 where Bound : Strideable, Bound.Stride : SignedInteger
 {

--- a/unittests/AST/ArithmeticEvaluator.cpp
+++ b/unittests/AST/ArithmeticEvaluator.cpp
@@ -235,6 +235,10 @@ TEST(ArithmeticEvaluator, Simple) {
   EXPECT_EQ(*product->cachedValue, expectedResult);
 
   // Dependency printing.
+
+  // Cache some values first, so they show up in the result.
+  (void)evaluator(InternallyCachedEvaluationRule(product));
+
   std::string productDependencies;
   {
     llvm::raw_string_ostream out(productDependencies);
@@ -260,6 +264,45 @@ TEST(ArithmeticEvaluator, Simple) {
     "     |   `--ExternallyCachedEvaluationRule(Literal: 3.141590e+00)\n"
     "     |   `--ExternallyCachedEvaluationRule(Literal: 2.718280e+00)\n"
     "     `--ExternallyCachedEvaluationRule(Literal: 4.200000e+01)\n");
+
+  // Graphviz printing.
+  std::string allDependencies;
+  {
+    llvm::raw_string_ostream out(allDependencies);
+    evaluator.printDependenciesGraphviz(out);
+  }
+
+  EXPECT_EQ(allDependencies,
+    "digraph Dependencies {\n"
+    "  request_0 -> request_1;\n"
+    "  request_0 -> request_4;\n"
+    "  request_1 -> request_3;\n"
+    "  request_1 -> request_2;\n"
+    "  request_5 -> request_6;\n"
+    "  request_5 -> request_9;\n"
+    "  request_6 -> request_8;\n"
+    "  request_6 -> request_7;\n"
+    "  request_10 -> request_11;\n"
+    "  request_10 -> request_14;\n"
+    "  request_11 -> request_13;\n"
+    "  request_11 -> request_12;\n"
+    "\n"
+    "  request_0 [label=\"ExternallyCachedEvaluationRule(Binary: product)\"];\n"
+    "  request_1 [label=\"ExternallyCachedEvaluationRule(Binary: sum)\"];\n"
+    "  request_2 [label=\"ExternallyCachedEvaluationRule(Literal: 2.718280e+00)\"];\n"
+    "  request_3 [label=\"ExternallyCachedEvaluationRule(Literal: 3.141590e+00)\"];\n"
+    "  request_4 [label=\"ExternallyCachedEvaluationRule(Literal: 4.200000e+01)\"];\n"
+    "  request_5 [label=\"InternallyCachedEvaluationRule(Binary: product) -> 2.461145e+02\"];\n"
+    "  request_6 [label=\"InternallyCachedEvaluationRule(Binary: sum) -> 5.859870e+00\"];\n"
+    "  request_7 [label=\"InternallyCachedEvaluationRule(Literal: 2.718280e+00)\"];\n"
+    "  request_8 [label=\"InternallyCachedEvaluationRule(Literal: 3.141590e+00)\"];\n"
+    "  request_9 [label=\"InternallyCachedEvaluationRule(Literal: 4.200000e+01)\"];\n"
+    "  request_10 [label=\"UncachedEvaluationRule(Binary: product)\"];\n"
+    "  request_11 [label=\"UncachedEvaluationRule(Binary: sum)\"];\n"
+    "  request_12 [label=\"UncachedEvaluationRule(Literal: 2.718280e+00)\"];\n"
+    "  request_13 [label=\"UncachedEvaluationRule(Literal: 3.141590e+00)\"];\n"
+    "  request_14 [label=\"UncachedEvaluationRule(Literal: 4.200000e+01)\"];\n"
+    "}\n");
 
   // Cleanup
   delete pi;

--- a/unittests/AST/ArithmeticEvaluator.cpp
+++ b/unittests/AST/ArithmeticEvaluator.cpp
@@ -169,10 +169,11 @@ struct ExternallyCachedEvaluationRule :
     : EvaluationRule{expr} { }
 };
 
+// Define the arithmetic evaluator's zone.
 namespace swift {
-SWIFT_TYPEID(UnitTests, UncachedEvaluationRule, 1);
-SWIFT_TYPEID(UnitTests, InternallyCachedEvaluationRule, 2);
-SWIFT_TYPEID(UnitTests, ExternallyCachedEvaluationRule, 3);
+#define SWIFT_TYPEID_ZONE 255
+#define SWIFT_TYPEID_HEADER "ArithmeticEvaluatorTypeIDZone.def"
+#include "swift/Basic/DefineTypeIDZone.h"
 }
 
 TEST(ArithmeticEvaluator, Simple) {

--- a/unittests/AST/ArithmeticEvaluator.cpp
+++ b/unittests/AST/ArithmeticEvaluator.cpp
@@ -1,0 +1,256 @@
+//===--- ArithmeticEvaluator.cpp ------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Simple arithmetic evaluator using the Evaluator class.
+//
+//===----------------------------------------------------------------------===//
+#include "swift/AST/DiagnosticEngine.h"
+#include "swift/AST/Evaluator.h"
+#include "swift/Basic/SourceManager.h"
+#include "gtest/gtest.h"
+#include <cmath>
+#include <memory>
+
+using namespace swift;
+using namespace llvm;
+
+class ArithmeticExpr {
+ public:
+  enum class Kind {
+    Literal,
+    Binary,
+  } kind;
+
+  // Note: used for internal caching.
+  bool computingValue = false;
+  Optional<double> cachedValue;
+
+ protected:
+  ArithmeticExpr(Kind kind) : kind(kind) { }
+};
+
+class Literal : public ArithmeticExpr {
+ public:
+  const double value;
+
+  Literal(double value) : ArithmeticExpr(Kind::Literal), value(value) { }
+};
+
+class Binary : public ArithmeticExpr {
+ public:
+  enum class OperatorKind {
+    Sum,
+    Product,
+  } operatorKind;
+
+  ArithmeticExpr *lhs;
+  ArithmeticExpr *rhs;
+
+  Binary(OperatorKind operatorKind, ArithmeticExpr *lhs, ArithmeticExpr *rhs)
+    : ArithmeticExpr(Kind::Binary), operatorKind(operatorKind),
+      lhs(lhs), rhs(rhs) { }
+};
+
+/// Rule to evaluate the value of the expression.
+template<typename Derived>
+struct EvaluationRule {
+  using OutputType = double;
+
+  // The expression to evaluate.
+  ArithmeticExpr *expr;
+
+  double operator()(Evaluator &evaluator) const {
+    switch (expr->kind) {
+    case ArithmeticExpr::Kind::Literal:
+      return static_cast<Literal *>(expr)->value;
+
+    case ArithmeticExpr::Kind::Binary: {
+      auto binary = static_cast<Binary *>(expr);
+
+      // Evaluate the left- and right-hand sides.
+      double lhsValue, rhsValue;
+      std::tie(lhsValue, rhsValue) =
+        evaluator(Derived{binary->lhs}, Derived{binary->rhs});
+      switch (binary->operatorKind) {
+      case Binary::OperatorKind::Sum:
+        return lhsValue + rhsValue;
+
+      case Binary::OperatorKind::Product:
+        return lhsValue * rhsValue;
+      }
+    }
+    }
+  }
+
+  double breakCycle() const {
+    return NAN;
+  }
+
+  void diagnoseCycle(DiagnosticEngine &diags) const { }
+  void noteCycleStep(DiagnosticEngine &diags) const { }
+
+  friend bool operator==(const EvaluationRule &lhs, const EvaluationRule &rhs) {
+    return lhs.expr == rhs.expr;
+  }
+
+  friend bool operator!=(const EvaluationRule &lhs, const EvaluationRule &rhs) {
+    return lhs.expr != rhs.expr;
+  }
+
+  friend hash_code hash_value(const EvaluationRule &er) {
+    return hash_value(er.expr);
+  }
+};
+
+struct InternallyCachedEvaluationRule :
+  EvaluationRule<InternallyCachedEvaluationRule> {
+  static const bool isEverCached = true;
+  static const bool hasExternalCache = false;
+
+  bool isCached() const {
+    switch (expr->kind) {
+    case ArithmeticExpr::Kind::Literal:
+      return false;
+
+    case ArithmeticExpr::Kind::Binary:
+      return true;
+    }
+  }
+
+  InternallyCachedEvaluationRule(ArithmeticExpr *expr)
+    : EvaluationRule{expr} { }
+};
+
+struct UncachedEvaluationRule :
+  EvaluationRule<InternallyCachedEvaluationRule> {
+  static const bool isEverCached = false;
+
+  UncachedEvaluationRule(ArithmeticExpr *expr)
+    : EvaluationRule{expr} { }
+};
+
+struct ExternallyCachedEvaluationRule :
+  EvaluationRule<ExternallyCachedEvaluationRule> {
+  static const bool isEverCached = true;
+  static const bool hasExternalCache = true;
+
+  bool isCached() const {
+    switch (expr->kind) {
+    case ArithmeticExpr::Kind::Literal:
+      return false;
+
+    case ArithmeticExpr::Kind::Binary:
+      return true;
+    }
+  }
+
+  bool isInFlight() const {
+    return expr->computingValue;
+  }
+
+  void setInFlight() const {
+    expr->computingValue = true;
+  }
+
+  Optional<double> getCachedResult() const {
+    return expr->cachedValue;
+  }
+
+  void cacheResult(double value) const {
+    expr->cachedValue = value;
+    expr->computingValue = false;
+  }
+
+  ExternallyCachedEvaluationRule(ArithmeticExpr *expr)
+    : EvaluationRule{expr} { }
+};
+
+namespace swift {
+SWIFT_TYPEID(UnitTests, UncachedEvaluationRule, 1);
+SWIFT_TYPEID(UnitTests, InternallyCachedEvaluationRule, 2);
+SWIFT_TYPEID(UnitTests, ExternallyCachedEvaluationRule, 3);
+}
+
+TEST(ArithmeticEvaluator, Simple) {
+  // (3.14159 + 2.71828) * 42
+  ArithmeticExpr *pi = new Literal(3.14159);
+  ArithmeticExpr *e = new Literal(2.71828);
+  ArithmeticExpr *sum = new Binary(Binary::OperatorKind::Sum, pi, e);
+  ArithmeticExpr *lifeUniverseEverything = new Literal(42.0);
+  ArithmeticExpr *product = new Binary(Binary::OperatorKind::Product, sum,
+                                       lifeUniverseEverything);
+
+  SourceManager sourceMgr;
+  DiagnosticEngine diags(sourceMgr);
+  Evaluator evaluator(diags);
+
+  const double expectedResult = (3.14159 + 2.71828) * 42.0;
+  EXPECT_EQ(evaluator(InternallyCachedEvaluationRule(product)),
+            expectedResult);
+
+  // Cached response.
+  EXPECT_EQ(evaluator(InternallyCachedEvaluationRule(product)),
+            expectedResult);
+
+  // Uncached
+  EXPECT_EQ(evaluator(UncachedEvaluationRule(product)),
+            expectedResult);
+  EXPECT_EQ(evaluator(UncachedEvaluationRule(product)),
+            expectedResult);
+
+  // External cached query.
+  EXPECT_EQ(evaluator(ExternallyCachedEvaluationRule(product)),
+            expectedResult);
+  EXPECT_EQ(*sum->cachedValue, 3.14159 + 2.71828);
+  EXPECT_EQ(*product->cachedValue, expectedResult);
+  EXPECT_EQ(evaluator(ExternallyCachedEvaluationRule(product)),
+            expectedResult);
+  EXPECT_EQ(*sum->cachedValue, 3.14159 + 2.71828);
+  EXPECT_EQ(*product->cachedValue, expectedResult);
+
+  // Cleanup
+  delete pi;
+  delete e;
+  delete sum;
+  delete lifeUniverseEverything;
+  delete product;
+}
+
+TEST(ArithmeticEvaluator, Cycle) {
+  // (3.14159 + 2.71828) * 42
+  ArithmeticExpr *pi = new Literal(3.14159);
+  ArithmeticExpr *e = new Literal(2.71828);
+  Binary *sum = new Binary(Binary::OperatorKind::Sum, pi, e);
+  ArithmeticExpr *lifeUniverseEverything = new Literal(42.0);
+  ArithmeticExpr *product = new Binary(Binary::OperatorKind::Product, sum,
+                                       lifeUniverseEverything);
+
+  // Introduce a cycle.
+  sum->rhs = product;
+
+  SourceManager sourceMgr;
+  DiagnosticEngine diags(sourceMgr);
+  Evaluator evaluator(diags);
+
+  EXPECT_TRUE(isnan(evaluator(InternallyCachedEvaluationRule(product))));
+  EXPECT_TRUE(isnan(evaluator(InternallyCachedEvaluationRule(product))));
+
+  EXPECT_TRUE(isnan(evaluator(ExternallyCachedEvaluationRule(product))));
+  EXPECT_TRUE(isnan(evaluator(ExternallyCachedEvaluationRule(product))));
+
+  // Cleanup
+  delete pi;
+  delete e;
+  delete sum;
+  delete lifeUniverseEverything;
+  delete product;
+}

--- a/unittests/AST/ArithmeticEvaluator.cpp
+++ b/unittests/AST/ArithmeticEvaluator.cpp
@@ -23,6 +23,7 @@
 
 using namespace swift;
 using namespace llvm;
+using std::isnan;
 
 class ArithmeticExpr {
  public:

--- a/unittests/AST/ArithmeticEvaluator.cpp
+++ b/unittests/AST/ArithmeticEvaluator.cpp
@@ -246,8 +246,8 @@ TEST(ArithmeticEvaluator, Simple) {
   }
 
   EXPECT_EQ(productDependencies,
-    " `--InternallyCachedEvaluationRule(Binary: product)\n"
-    "     `--InternallyCachedEvaluationRule(Binary: sum)\n"
+    " `--InternallyCachedEvaluationRule(Binary: product) -> 2.461145e+02\n"
+    "     `--InternallyCachedEvaluationRule(Binary: sum) -> 5.859870e+00\n"
     "     |   `--InternallyCachedEvaluationRule(Literal: 3.141590e+00)\n"
     "     |   `--InternallyCachedEvaluationRule(Literal: 2.718280e+00)\n"
     "     `--InternallyCachedEvaluationRule(Literal: 4.200000e+01)\n");

--- a/unittests/AST/ArithmeticEvaluator.cpp
+++ b/unittests/AST/ArithmeticEvaluator.cpp
@@ -15,7 +15,7 @@
 //===----------------------------------------------------------------------===//
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/AST/Evaluator.h"
-#include "swift/Basic/SimpleRequest.h"
+#include "swift/AST/SimpleRequest.h"
 #include "swift/Basic/SourceManager.h"
 #include "gtest/gtest.h"
 #include <cmath>

--- a/unittests/AST/ArithmeticEvaluatorTypeIDZone.def
+++ b/unittests/AST/ArithmeticEvaluatorTypeIDZone.def
@@ -1,0 +1,19 @@
+//===--- ArithmeticEvaluatorTypeIDZone.def - --------------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+//  This definition file describes the types in the "arithmetic evaluatior"
+//  TypeID zone, for use with the TypeID template.
+//
+//===----------------------------------------------------------------------===//
+SWIFT_TYPEID(UncachedEvaluationRule)
+SWIFT_TYPEID(InternallyCachedEvaluationRule)
+SWIFT_TYPEID(ExternallyCachedEvaluationRule)

--- a/unittests/AST/CMakeLists.txt
+++ b/unittests/AST/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_swift_unittest(SwiftASTTests
+  ArithmeticEvaluator.cpp
   DiagnosticConsumerTests.cpp
   SourceLocTests.cpp
   TestContext.cpp


### PR DESCRIPTION
Meant as a replacement for the barely-started iterative type checker,
introduce a simpler "evaluator" that can evaluate individual requests
(essentially, function objects with some additional API), caching
results as appropriate and detecting cycles. Start stubbing out what
is involved in replacing the iterative type checker with this infrastructure.