### PR TITLE
[ASTPrinter] Print typealias generic requirements

### DIFF
--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1947,6 +1947,9 @@ void PrintAST::visitTypeAliasDecl(TypeAliasDecl *decl) {
   if (ShouldPrint) {
     Printer << " = ";
     printTypeLoc(decl->getUnderlyingTypeLoc());
+    if (decl->isGeneric())
+      if (auto *genericSig = decl->getGenericSignature())
+        printGenericSignature(genericSig, PrintRequirements | InnermostOnly);
   }
 }
 

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -611,8 +611,8 @@ private:
                           bool openBracket = true, bool closeBracket = true);
   void printMembers(ArrayRef<Decl *> members, bool needComma = false,
                     bool openBracket = true, bool closeBracket = true);
-  void printNominalDeclGenericParams(NominalTypeDecl *decl);
-  void printNominalDeclGenericRequirements(NominalTypeDecl *decl);
+  void printGenericDeclGenericParams(GenericContext *decl);
+  void printGenericDeclGenericRequirements(GenericContext *decl);
   void printInherited(const Decl *decl);
 
   void printEnumElement(EnumElementDecl *elt);
@@ -1655,13 +1655,13 @@ void PrintAST::printMembers(ArrayRef<Decl *> members, bool needComma,
     Printer << "}";
 }
 
-void PrintAST::printNominalDeclGenericParams(NominalTypeDecl *decl) {
+void PrintAST::printGenericDeclGenericParams(GenericContext *decl) {
   if (decl->getGenericParams())
     if (auto GenericSig = decl->getGenericSignature())
       printGenericSignature(GenericSig, PrintParams | InnermostOnly);
 }
 
-void PrintAST::printNominalDeclGenericRequirements(NominalTypeDecl *decl) {
+void PrintAST::printGenericDeclGenericRequirements(GenericContext *decl) {
   if (decl->getGenericParams())
     if (auto GenericSig = decl->getGenericSignature())
       printGenericSignature(GenericSig, PrintRequirements | InnermostOnly);
@@ -1776,10 +1776,7 @@ void PrintAST::printSynthesizedExtension(Type ExtendedType,
 
     printExtendedTypeName(ExtendedType, Printer, Options);
     printInherited(ExtDecl);
-
-    if (ExtDecl->getGenericParams())
-      if (auto *GenericSig = ExtDecl->getGenericSignature())
-        printGenericSignature(GenericSig, PrintRequirements | InnermostOnly);
+    printGenericDeclGenericRequirements(ExtDecl);
   }
   if (Options.TypeDefinitions) {
     printMembersOfDecl(ExtDecl, false,
@@ -1933,9 +1930,7 @@ void PrintAST::visitTypeAliasDecl(TypeAliasDecl *decl) {
     [&]{
       Printer.printName(decl->getName());
     }, [&]{ // Signature
-      if (decl->getGenericParams())
-        if (auto *genericSig = decl->getGenericSignature())
-          printGenericSignature(genericSig, PrintParams | InnermostOnly);
+      printGenericDeclGenericParams(decl);
     });
   bool ShouldPrint = true;
   Type Ty = decl->getUnderlyingTypeLoc().getType();
@@ -1947,9 +1942,7 @@ void PrintAST::visitTypeAliasDecl(TypeAliasDecl *decl) {
   if (ShouldPrint) {
     Printer << " = ";
     printTypeLoc(decl->getUnderlyingTypeLoc());
-    if (decl->isGeneric())
-      if (auto *genericSig = decl->getGenericSignature())
-        printGenericSignature(genericSig, PrintRequirements | InnermostOnly);
+    printGenericDeclGenericRequirements(decl);
   }
 }
 
@@ -2011,10 +2004,10 @@ void PrintAST::visitEnumDecl(EnumDecl *decl) {
       [&]{
         Printer.printName(decl->getName());
       }, [&]{ // Signature
-        printNominalDeclGenericParams(decl);
+        printGenericDeclGenericParams(decl);
       });
     printInherited(decl);
-    printNominalDeclGenericRequirements(decl);
+    printGenericDeclGenericRequirements(decl);
   }
   if (Options.TypeDefinitions) {
     printMembersOfDecl(decl, false, true,
@@ -2039,10 +2032,10 @@ void PrintAST::visitStructDecl(StructDecl *decl) {
       [&]{
         Printer.printName(decl->getName());
       }, [&]{ // Signature
-        printNominalDeclGenericParams(decl);
+        printGenericDeclGenericParams(decl);
       });
     printInherited(decl);
-    printNominalDeclGenericRequirements(decl);
+    printGenericDeclGenericRequirements(decl);
   }
   if (Options.TypeDefinitions) {
     printMembersOfDecl(decl, false, true,
@@ -2067,11 +2060,11 @@ void PrintAST::visitClassDecl(ClassDecl *decl) {
       [&]{
         Printer.printName(decl->getName());
       }, [&]{ // Signature
-        printNominalDeclGenericParams(decl);
+        printGenericDeclGenericParams(decl);
       });
 
     printInherited(decl);
-    printNominalDeclGenericRequirements(decl);
+    printGenericDeclGenericRequirements(decl);
   }
 
   if (Options.TypeDefinitions) {
@@ -2514,10 +2507,7 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
             Printer << " ";
         }
       }, [&] { // Parameters
-        if (decl->isGeneric())
-          if (auto *genericSig = decl->getGenericSignature())
-            printGenericSignature(genericSig, PrintParams | InnermostOnly);
-
+        printGenericDeclGenericParams(decl);
         printFunctionParameters(decl);
       });
 
@@ -2541,9 +2531,7 @@ void PrintAST::visitFuncDecl(FuncDecl *decl) {
         printTypeLoc(ResultTyLoc);
       Printer.printStructurePost(PrintStructureKind::FunctionReturnType);
     }
-    if (decl->isGeneric())
-      if (auto *genericSig = decl->getGenericSignature())
-        printGenericSignature(genericSig, PrintRequirements | InnermostOnly);
+    printGenericDeclGenericRequirements(decl);
   }
 
   if (auto BodyFunc = Options.FunctionBody) {
@@ -2642,10 +2630,7 @@ void PrintAST::visitSubscriptDecl(SubscriptDecl *decl) {
   recordDeclLoc(decl, [&]{
     Printer << "subscript";
   }, [&] { // Parameters
-    if (decl->isGeneric())
-      if (auto *genericSig = decl->getGenericSignature())
-        printGenericSignature(genericSig, PrintParams | InnermostOnly);
-
+    printGenericDeclGenericParams(decl);
     printParameterList(decl->getIndices(),
                        decl->hasInterfaceType()
                          ? decl->getIndicesInterfaceType()
@@ -2664,9 +2649,7 @@ void PrintAST::visitSubscriptDecl(SubscriptDecl *decl) {
   else
     printTypeLoc(elementTy);
   Printer.printStructurePost(PrintStructureKind::FunctionReturnType);
-  if (decl->isGeneric())
-    if (auto *genericSig = decl->getGenericSignature())
-      printGenericSignature(genericSig, PrintRequirements | InnermostOnly);
+  printGenericDeclGenericRequirements(decl);
   printAccessors(decl);
 }
 
@@ -2702,16 +2685,11 @@ void PrintAST::visitConstructorDecl(ConstructorDecl *decl) {
         break;
       }
 
-      if (decl->isGeneric())
-        if (auto *genericSig = decl->getGenericSignature())
-          printGenericSignature(genericSig, PrintParams | InnermostOnly);
-
+      printGenericDeclGenericParams(decl);
       printFunctionParameters(decl);
     });
 
-  if (decl->isGeneric())
-    if (auto *genericSig = decl->getGenericSignature())
-      printGenericSignature(genericSig, PrintRequirements | InnermostOnly);
+  printGenericDeclGenericRequirements(decl);
 
   if (auto BodyFunc = Options.FunctionBody) {
     Printer << " {";

--- a/test/IDE/print_ast_tc_decls.swift
+++ b/test/IDE/print_ast_tc_decls.swift
@@ -1375,3 +1375,5 @@ public typealias MyPairI<B> = MyPair<Int, B>
 // PASS_PRINT_AST: public typealias MyPairI<B> = MyPair<Int, B>
 public typealias MyPairAlias<T, U> = MyPair<T, U>
 // PASS_PRINT_AST: public typealias MyPairAlias<T, U> = MyPair<T, U>
+public typealias MyPairAlias2<T: FooProtocol, U> = MyPair<T, U> where U: BarProtocol
+// PASS_PRINT_AST: public typealias MyPairAlias2<T, U> = MyPair<T, U> where T : FooProtocol, U : BarProtocol

--- a/test/SourceKit/CursorInfo/cursor_info.swift
+++ b/test/SourceKit/CursorInfo/cursor_info.swift
@@ -220,6 +220,8 @@ func funcWithNestedEscaping(a : (@escaping () -> ()) -> ()) {}
 /// doc
 typealias typeWithNestedAutoclosure = (@autoclosure () -> ()) -> ()
 
+typealias GenericAlias<T, U> = MyAlias<T, U> where T: P1
+
 // REQUIRES: objc_interop
 // RUN: %empty-directory(%t.tmp)
 // RUN: %swiftc_driver -emit-module -o %t.tmp/FooSwiftModule.swiftmodule %S/Inputs/FooSwiftModule.swift
@@ -746,3 +748,7 @@ typealias typeWithNestedAutoclosure = (@autoclosure () -> ()) -> ()
 // RUN: %sourcekitd-test -req=cursor -pos=221:11 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK90 %s
 // CHECK90: <Declaration>typealias typeWithNestedAutoclosure = (@autoclosure () -&gt; ()) -&gt; ()</Declaration>
 // CHECK90-NEXT: <decl.var.parameter.type><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@autoclosure</syntaxtype.attribute.name></syntaxtype.attribute.builtin> () -&gt; <decl.function.returntype><tuple>()</tuple></decl.function.returntype></decl.var.parameter.type>
+
+// RUN: %sourcekitd-test -req=cursor -pos=223:11 %s -- -F %S/../Inputs/libIDE-mock-sdk -I %t.tmp %mcp_opt %s | %FileCheck -check-prefix=CHECK91 %s
+// CHECK91: <Declaration>typealias GenericAlias&lt;T, U&gt; = <Type usr="s:11cursor_info7MyAliasa">MyAlias</Type>&lt;<Type usr="s:11cursor_info12GenericAliasa1Txmfp">T</Type>, <Type usr="s:11cursor_info12GenericAliasa1Uq_mfp">U</Type>&gt; where T : <Type usr="s:11cursor_info2P1P">P1</Type></Declaration>
+// CHECK91-NEXT: <decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>GenericAlias</decl.name>&lt;<decl.generic_type_param usr="s:11cursor_info12GenericAliasa1Txmfp"><decl.generic_type_param.name>T</decl.generic_type_param.name></decl.generic_type_param>, <decl.generic_type_param usr="s:11cursor_info12GenericAliasa1Uq_mfp"><decl.generic_type_param.name>U</decl.generic_type_param.name></decl.generic_type_param>&gt; = <ref.typealias usr="s:11cursor_info7MyAliasa">MyAlias</ref.typealias>&lt;<ref.generic_type_param usr="s:11cursor_info12GenericAliasa1Txmfp">T</ref.generic_type_param>, <ref.generic_type_param usr="s:11cursor_info12GenericAliasa1Uq_mfp">U</ref.generic_type_param>&gt; <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement>T : <ref.protocol usr="s:11cursor_info2P1P">P1</ref.protocol></decl.generic_type_requirement></decl.typealias>


### PR DESCRIPTION
This PR prints the 'where' clause for generic type aliases, I think just an oversight this was omitted.
Affects Xcode quick help etc.

First commit fixes the bug, second refactors the various paths that print generic params + reqs.

@benlangmuir could you review please?