### PR TITLE
stdlib: silence truncation warning on Windows

### DIFF
--- a/stdlib/public/stubs/Stubs.cpp
+++ b/stdlib/public/stubs/Stubs.cpp
@@ -473,9 +473,9 @@ static const char *_swift_stdlib_strtoX_clocale_impl(
   ValueStream >> ParsedValue;
   *outResult = ParsedValue;
 
-  int pos = ValueStream.tellg();
+  std::streamoff pos = ValueStream.tellg();
   if (ValueStream.eof())
-    pos = strlen(nptr);
+    pos = static_cast<std::streamoff>(strlen(nptr));
   if (pos <= 0)
     return nullptr;
 


### PR DESCRIPTION
The returned type `std::streamoff` on Windows x64 is a `long long`
rather than `int`.  This results in a 64-to-32 bit shortening of the
value.  Use the appropriate type to avoid the truncation.

`strlen` returns a unsigned value, but `std::streamoff` is an signed
value.  Explicitly cast the value to avoid the warning about the
implicit signed conversion.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
