### PR TITLE
Outliner: Clear IsBridgedArgument state in between matching

### DIFF
--- a/lib/SILOptimizer/Transforms/Outliner.cpp
+++ b/lib/SILOptimizer/Transforms/Outliner.cpp
@@ -905,6 +905,7 @@ void ObjCMethodCall::clearState() {
   BridgedCall = nullptr;
   BridgedArguments.clear();
   OutlinedName.clear();
+  IsBridgedArgument.clear();
 }
 
 std::pair<SILFunction *, SILBasicBlock::iterator>

--- a/test/SILOptimizer/outliner.swift
+++ b/test/SILOptimizer/outliner.swift
@@ -157,3 +157,11 @@ public func dontCrash2(_ c: SomeGenericClass) -> Bool {
 
   return true
 }
+
+func dontCrash3() -> String? {
+  let bundle = Bundle.main
+  let resource = "common parameter"
+
+  return bundle.path(forResource: resource, ofType: "png")
+      ?? bundle.path(forResource: resource, ofType: "apng")
+}


### PR DESCRIPTION
Otherwise, when we mangle a signature of bridged/not_bridged arguments
we can see the state from the previous match of another instruction.

SR-7426
rdar://39414272
