### PR TITLE
[4.2] [driver/index] Fix an issue where the -index-file invocation was not working when there are 5 or more input files

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -750,6 +750,10 @@ def index_store_path : Separate<["-"], "index-store-path">,
   Flags<[FrontendOption, ArgumentIsPath]>, MetaVarName<"<path>">,
   HelpText<"Store indexing data to <path>">;
 
+def index_ignore_system_modules : Flag<["-"], "index-ignore-system-modules">,
+  Flags<[NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
+  HelpText<"Avoid indexing system modules">;
+
 def enforce_exclusivity_EQ : Joined<["-"], "enforce-exclusivity=">,
   Flags<[FrontendOption]>, MetaVarName<"<enforcement>">,
   HelpText<"Enforce law of exclusivity">;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -751,7 +751,7 @@ def index_store_path : Separate<["-"], "index-store-path">,
   HelpText<"Store indexing data to <path>">;
 
 def index_ignore_system_modules : Flag<["-"], "index-ignore-system-modules">,
-  Flags<[NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
+  Flags<[NoInteractiveOption]>,
   HelpText<"Avoid indexing system modules">;
 
 def enforce_exclusivity_EQ : Joined<["-"], "enforce-exclusivity=">,

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2183,6 +2183,7 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
   // 3. Determine the CommandOutput for the job.
   StringRef BaseInput;
   StringRef PrimaryInput;
+
   if (!InputActions.empty()) {
     // Use the first InputAction as our BaseInput and PrimaryInput.
     const InputAction *IA = cast<InputAction>(InputActions[0]);
@@ -2195,6 +2196,16 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
     BaseInput = Out.getBaseInput(i);
     // Use the first Job's Primary Output as our PrimaryInput.
     PrimaryInput = Out.getPrimaryOutputFilenames()[i];
+  }
+
+  // With -index-file option, the primary input is the one passed with
+  // -index-file-path.
+  // FIXME: Figure out how this better fits within the driver infrastructure.
+  if (JA->getType() == file_types::TY_IndexData) {
+    if (Arg *A = C.getArgs().getLastArg(options::OPT_index_file_path)) {
+      BaseInput = A->getValue();
+      PrimaryInput = A->getValue();
+    }
   }
 
   const TypeToPathMap *OutputMap = nullptr;

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2183,7 +2183,6 @@ Job *Driver::buildJobsForAction(Compilation &C, const JobAction *JA,
   // 3. Determine the CommandOutput for the job.
   StringRef BaseInput;
   StringRef PrimaryInput;
-
   if (!InputActions.empty()) {
     // Use the first InputAction as our BaseInput and PrimaryInput.
     const InputAction *IA = cast<InputAction>(InputActions[0]);

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -358,7 +358,8 @@ ToolChain::constructInvocation(const CompileJobAction &job,
 
   if (context.Args.hasArg(options::OPT_index_store_path)) {
     context.Args.AddLastArg(Arguments, options::OPT_index_store_path);
-    Arguments.push_back("-index-system-modules");
+    if (!context.Args.hasArg(options::OPT_index_ignore_system_modules))
+      Arguments.push_back("-index-system-modules");
   }
 
   return II;

--- a/test/Index/Store/driver-multiple-inputs.swift
+++ b/test/Index/Store/driver-multiple-inputs.swift
@@ -1,0 +1,12 @@
+// XFAIL: linux
+
+// Make sure the indexing invocation through the driver works.
+
+// RUN: %empty-directory(%t)
+// RUN: touch %t/s1.swift %t/s2.swift
+// RUN: %target-swiftc_driver -index-store-path %t/idx %t/s1.swift %t/s2.swift -o %t/s1.o -index-file -index-file-path %t/s2.swift -index-ignore-system-modules -driver-filelist-threshold=0
+// RUN: c-index-test core -print-unit %t/idx | %FileCheck %s
+
+// CHECK: s1.o-{{[A-Z0-9]*}}
+// CHECK: --------
+// CHECK: out-file: {{.*}}s1.o


### PR DESCRIPTION
Cherry-pick #15914 
Resolves rdar://39398871