### PR TITLE
[Coverage] Disable forced emission for unmapped decls (#15909)

### DIFF
--- a/include/swift/SIL/SILProfiler.h
+++ b/include/swift/SIL/SILProfiler.h
@@ -33,6 +33,9 @@ class SILCoverageMap;
 class SILFunction;
 class SILModule;
 
+/// Returns whether the given AST node requires profiling instrumentation.
+bool doesASTRequireProfiling(SILModule &M, ASTNode N);
+
 /// SILProfiler - Maps AST nodes to profile counters.
 class SILProfiler : public SILAllocated<SILProfiler> {
 private:

--- a/lib/SIL/SILProfiler.cpp
+++ b/lib/SIL/SILProfiler.cpp
@@ -108,6 +108,12 @@ static void walkForProfiling(ASTNode N, ASTWalker &Walker) {
   }
 }
 
+namespace swift {
+bool doesASTRequireProfiling(SILModule &M, ASTNode N) {
+  return M.getOptions().GenerateProfile && !isUnmapped(N);
+}
+} // namespace swift
+
 /// Check that the input AST has at least been type-checked.
 static bool hasASTBeenTypeChecked(ASTNode N) {
   DeclContext *DC = N.getAsDeclContext();
@@ -134,7 +140,7 @@ SILProfiler *SILProfiler::create(SILModule &M, ForDefinition_t forDefinition,
   }
 
   const auto &Opts = M.getOptions();
-  if ((!Opts.GenerateProfile && Opts.UseProfile.empty()) || isUnmapped(N))
+  if (!doesASTRequireProfiling(M, N) && Opts.UseProfile.empty())
     return nullptr;
 
   auto *Buf = M.allocate<SILProfiler>(1);

--- a/test/SILGen/coverage_force_emission.swift
+++ b/test/SILGen/coverage_force_emission.swift
@@ -1,20 +1,24 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_force_emission %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_force_emission %s | %FileCheck %s -check-prefix=COVERAGE
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -emit-sorted-sil -emit-sil -module-name coverage_force_emission %s | %FileCheck %s -check-prefix=PGO
 
 final class VarInit {
-  // coverage_force_emission.VarInit.(lazyVarInit in _7D375D72BA8B0C53C9AD7E4DBC7FF493).getter : Swift.String
-  // CHECK: sil_coverage_map {{.*}} $S23coverage_force_emission7VarInitC04lazydE033_7D375D72BA8B0C53C9AD7E4DBC7FF493LLSSvg
+  // COVERAGE: sil_coverage_map {{.*}} $S23coverage_force_emission7VarInitC04lazydE033_7D375D72BA8B0C53C9AD7E4DBC7FF493LLSSvg
+  // PGO-LABEL: coverage_force_emission.VarInit.(lazyVarInit in _7D375D72BA8B0C53C9AD7E4DBC7FF493).getter : Swift.String
+  // PGO: int_instrprof_increment
   private lazy var lazyVarInit: String = {
     return "Hello"
   }()
 
-  // closure #1 () -> Swift.String in variable initialization expression of coverage_force_emission.VarInit.(basicVarInit in _7D375D72BA8B0C53C9AD7E4DBC7FF493) : Swift.String
   // CHECK: sil_coverage_map {{.*}} $S23coverage_force_emission7VarInitC05basicdE033_7D375D72BA8B0C53C9AD7E4DBC7FF493LLSSvpfiSSyXEfU_
+  // PGO-LABEL: closure #1 () -> Swift.String in variable initialization expression of coverage_force_emission.VarInit.(basicVarInit in _7D375D72BA8B0C53C9AD7E4DBC7FF493) : Swift.String
+  // PGO: int_instrprof_increment
   private var basicVarInit: String = {
     return "Hello"
   }()
 
-  // coverage_force_emission.VarInit.(simpleVar in _7D375D72BA8B0C53C9AD7E4DBC7FF493).getter : Swift.String
   // CHECK: sil_coverage_map {{.*}} $S23coverage_force_emission7VarInitC06simpleD033_7D375D72BA8B0C53C9AD7E4DBC7FF493LLSSvg
+  // PGO-LABEL: coverage_force_emission.VarInit.(simpleVar in _7D375D72BA8B0C53C9AD7E4DBC7FF493).getter : Swift.String
+  // PGO: int_instrprof_increment
   private var simpleVar: String {
     return "Hello"
   }


### PR DESCRIPTION
Disable forced SILGen for lazy functions which are not used for code
coverage reporting.

As a drive-by, fix the forced emission logic for functions profiled for
PGO.

This helps address a compile-time issue (r://39332957).

(cherry picked from commit bb567886d8f42c2d5607df7aacaaf1ed3f986ef6)