### PR TITLE
SIL Linker: Redo calculation of result value of processFunction()

### DIFF
--- a/test/SILOptimizer/devirt_covariant_return.swift
+++ b/test/SILOptimizer/devirt_covariant_return.swift
@@ -10,8 +10,7 @@
 
 // CHECK-LABEL: sil hidden @$S23devirt_covariant_return6driveryyF : $@convention(thin) () -> () {
 // CHECK: bb0
-// CHECK: alloc_ref
-// CHECK: alloc_ref
+// CHECK-NOT: alloc_ref
 // CHECK: function_ref @unknown1a : $@convention(thin) () -> ()
 // CHECK: apply
 // CHECK: function_ref @defenestrate : $@convention(thin) () -> ()


### PR DESCRIPTION
Instead of threading a boolean through the whole visitor, just
set an instance variable when we do deserialize something.

Note that previously, processFunction() almost always returned
true. As a result, the SILLinker pass would call invalidateAnalysis()
for every function with a body. Fixing this changed optimizer
output in one test; this warrants further investigation.