### PR TITLE
[NFC] SideEffectAnalysis refactoring and cleanup.

### DIFF
--- a/include/swift/SILOptimizer/Analysis/SideEffectAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/SideEffectAnalysis.h
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -34,103 +34,215 @@ enum class RetainObserveKind {
   RetainObserveKindEnd
 };
 
-/// The SideEffectAnalysis provides information about side-effects of SIL
-/// functions. Side-effect information is provided per function and includes:
-/// Does the function read or write memory? Does the function retain or release
-/// objects? etc.
-/// For details see SideEffectAnalysis::FunctionEffects and
-/// SideEffectAnalysis::Effects.
-class SideEffectAnalysis : public BottomUpIPAnalysis {
-public:
+/// Generic base class for any bottom up analysis that summarizes per-function
+/// "effects" by first computing local effects, then propagating those effects
+/// bottom-up through the call graph.
+///
+/// FunctionEffects constraints:
+/// - void clear()
+/// - void setWorstEffects()
+/// - bool summarizeFunction(SILFunction *)
+/// - bool summarizeCall(FullApplySite)
+/// - bool mergeFrom(const FunctionSideEffects &)
+/// - bool mergeFromApply(const FunctionEffects &, FullApplySite)
+/// - void analyzeInstruction(SILInstruction *)
+template <typename FunctionEffects>
+class GenericFunctionEffectAnalysis : public BottomUpIPAnalysis {
 
-  using MemoryBehavior = SILInstruction::MemoryBehavior;
-  /// Set \p dest if \p src is set and return true if \p dest was not set
-  /// before.
-  static bool updateFlag(bool &dest, bool src) {
-    if (src && !dest) {
-      dest = src;
-      return true;
-    }
-    return false;
-  }
+  /// Stores the analysis data, e.g. side-effects, for a function.
+  struct FunctionInfo : public FunctionInfoBase<FunctionInfo> {
 
-  /// Side-effect information for the function (global effects) or a specific
-  /// parameter of the function. See FunctionEffects.
-  class Effects {
-    bool Reads = false;
-    bool Writes = false;
-    bool Retains = false;
-    bool Releases = false;
-    
-    /// Sets the most conservative effects.
-    void setWorstEffects() {
-      Reads = true;
-      Writes = true;
-      Retains = true;
-      Releases = true;
-    }
+    /// The function effects.
+    FunctionEffects functionEffects;
 
-    /// Clears all effects.
-    void clear() {
-      Reads = false;
-      Writes = false;
-      Retains = false;
-      Releases = false;
-    }
+    /// Back-link to the function.
+    SILFunction *F;
 
-    friend class SideEffectAnalysis;
-    
-  public:
-    
-    /// Does the function read from memory (excluding reads from locally
-    /// allocated memory)?
-    bool mayRead() const { return Reads; }
+    /// Used during recomputation to indicate if the side-effects of a caller
+    /// must be updated.
+    bool needUpdateCallers = false;
 
-    /// Does the function write to memory (excluding writes to locally
-    /// allocated memory)?
-    bool mayWrite() const { return Writes; }
-    
-    /// Does the function retain objects (excluding retains of locally
-    /// allocated objects)?
-    bool mayRetain() const { return Retains; }
+    FunctionInfo(SILFunction *F) : F(F) {}
 
-    /// Does the function release objects (excluding releases of locally
-    /// allocated objects)?
-    bool mayRelease() const { return Releases; }
-
-    /// Gets the memory behavior considering the global effects and
-    /// all parameter effects. If \p ScanKind equals ignoreRetains then retain
-    /// instructions are considered as side effects.
-    MemoryBehavior getMemBehavior(RetainObserveKind ScanKind) const {
-      if (mayRelease())
-        return MemoryBehavior::MayHaveSideEffects;
-      
-      if (ScanKind == RetainObserveKind::ObserveRetains && mayRetain())
-        return MemoryBehavior::MayHaveSideEffects;
-      
-      if (mayWrite())
-        return mayRead() ? MemoryBehavior::MayReadWrite :
-                           MemoryBehavior::MayWrite;
-      
-      if (mayRead())
-        return MemoryBehavior::MayRead;
-      
-      return MemoryBehavior::None;
-    }
-
-    /// Merge effects from \p RHS.
-    bool mergeFrom(const Effects &RHS) {
-      bool Changed = false;
-      Changed |= updateFlag(Reads, RHS.Reads);
-      Changed |= updateFlag(Writes, RHS.Writes);
-      Changed |= updateFlag(Retains, RHS.Retains);
-      Changed |= updateFlag(Releases, RHS.Releases);
-      return Changed;
-    }
+    /// Clears the analysis data on invalidation.
+    void clear() { functionEffects.clear(); }
   };
 
+  typedef BottomUpFunctionOrder<FunctionInfo> FunctionOrder;
+
+  enum {
+    /// The maximum call-graph recursion depth for recomputing the analysis.
+    /// This is a relatively small number to reduce compile time in case of
+    /// large cycles in the call-graph.
+    /// In case of no cycles, we should not hit this limit at all because the
+    /// pass manager processes functions in bottom-up order.
+    MaxRecursionDepth = 5
+  };
+
+  /// All the function effect information for the whole module.
+  llvm::DenseMap<SILFunction *, FunctionInfo *> functionInfoMap;
+
+  /// The allocator for the map of values in FunctionInfoMap.
+  llvm::SpecificBumpPtrAllocator<FunctionInfo> allocator;
+
+  /// Callee analysis, used for determining the callees at call sites.
+  BasicCalleeAnalysis *BCA;
+
+public:
+  GenericFunctionEffectAnalysis(AnalysisKind kind) : BottomUpIPAnalysis(kind) {}
+
+  const FunctionEffects &getEffects(SILFunction *F) {
+    FunctionInfo *functionInfo = getFunctionInfo(F);
+    if (!functionInfo->isValid())
+      recompute(functionInfo);
+    return functionInfo->functionEffects;
+  }
+
+  /// Get the merged effects of all callees at the given call site from the
+  /// callee's perspective (don't transform parameter effects).
+  void getCalleeEffects(FunctionEffects &calleeEffects,
+                        FullApplySite fullApply);
+
+  /// Get the merge effects of all callees at the given call site from the
+  /// caller's perspective. Parameter effects are translated into information
+  /// for the caller's arguments, and local effects are dropped.
+  void getCallSiteEffects(FunctionEffects &callEffects,
+                          FullApplySite fullApply) {
+    FunctionEffects calleeEffects;
+    getCalleeEffects(calleeEffects, fullApply);
+    callEffects.mergeFromApply(calleeEffects, fullApply);
+  }
+
+  virtual void initialize(SILPassManager *PM) override;
+
+  /// Invalidate all information in this analysis.
+  virtual void invalidate() override;
+
+  /// Invalidate all of the information for a specific function.
+  virtual void invalidate(SILFunction *F, InvalidationKind K) override;
+
+  /// Notify the analysis about a newly created function.
+  virtual void notifyAddFunction(SILFunction *F) override {}
+
+  /// Notify the analysis about a function which will be deleted from the
+  /// module.
+  virtual void notifyDeleteFunction(SILFunction *F) override {
+    invalidate(F, InvalidationKind::Nothing);
+  }
+
+  /// Notify the analysis about changed witness or vtables.
+  virtual void invalidateFunctionTables() override {}
+
+private:
+  /// Gets or creates FunctionEffects for \p F.
+  FunctionInfo *getFunctionInfo(SILFunction *F) {
+    FunctionInfo *&functionInfo = functionInfoMap[F];
+    if (!functionInfo) {
+      functionInfo = new (allocator.Allocate()) FunctionInfo(F);
+    }
+    return functionInfo;
+  }
+
+  /// Analyze the side-effects of a function, including called functions.
+  /// Visited callees are added to \p BottomUpOrder until \p RecursionDepth
+  /// reaches MaxRecursionDepth.
+  void analyzeFunction(FunctionInfo *functionInfo, FunctionOrder &bottomUpOrder,
+                       int recursionDepth);
+
+  void analyzeCall(FunctionInfo *functionInfo, FullApplySite fullApply,
+                   FunctionOrder &bottomUpOrder, int recursionDepth);
+
+  /// Recomputes the side-effect information for the function \p Initial and
+  /// all called functions, up to a recursion depth of MaxRecursionDepth.
+  void recompute(FunctionInfo *initialInfo);
+};
+
+/// Set \p dest if \p src is set and return true if \p dest was not set
+/// before.
+static bool changedFlagByInPlaceOr(bool &dest, bool src) {
+  if (src && !dest) {
+    dest = src;
+    return true;
+  }
+  return false;
+}
+
+/// Side-effect information for the function (global effects) or a specific
+/// parameter of the function. See FunctionSideEffects.
+class FunctionSideEffectFlags {
+  friend class FunctionSideEffects;
+  using MemoryBehavior = SILInstruction::MemoryBehavior;
+
+  bool Reads = false;
+  bool Writes = false;
+  bool Retains = false;
+  bool Releases = false;
+
+  /// Sets the most conservative effects.
+  void setWorstEffects() {
+    Reads = true;
+    Writes = true;
+    Retains = true;
+    Releases = true;
+  }
+
+  /// Clears all effects.
+  void clear() {
+    Reads = false;
+    Writes = false;
+    Retains = false;
+    Releases = false;
+  }
+
+public:
+  /// Does the function read from memory (excluding reads from locally
+  /// allocated memory)?
+  bool mayRead() const { return Reads; }
+
+  /// Does the function write to memory (excluding writes to locally
+  /// allocated memory)?
+  bool mayWrite() const { return Writes; }
+
+  /// Does the function retain objects (excluding retains of locally
+  /// allocated objects)?
+  bool mayRetain() const { return Retains; }
+
+  /// Does the function release objects (excluding releases of locally
+  /// allocated objects)?
+  bool mayRelease() const { return Releases; }
+
+  /// Gets the memory behavior considering the global effects and
+  /// all parameter effects. If \p ScanKind equals ignoreRetains then retain
+  /// instructions are considered as side effects.
+  MemoryBehavior getMemBehavior(RetainObserveKind ScanKind) const {
+    if (mayRelease())
+      return MemoryBehavior::MayHaveSideEffects;
+
+    if (ScanKind == RetainObserveKind::ObserveRetains && mayRetain())
+      return MemoryBehavior::MayHaveSideEffects;
+
+    if (mayWrite())
+      return mayRead() ? MemoryBehavior::MayReadWrite
+                       : MemoryBehavior::MayWrite;
+
+    if (mayRead())
+      return MemoryBehavior::MayRead;
+
+    return MemoryBehavior::None;
+  }
+
+  /// Merge effects from \p RHS.
+  bool mergeFrom(const FunctionSideEffectFlags &RHS) {
+    bool Changed = false;
+    Changed |= changedFlagByInPlaceOr(Reads, RHS.Reads);
+    Changed |= changedFlagByInPlaceOr(Writes, RHS.Writes);
+    Changed |= changedFlagByInPlaceOr(Retains, RHS.Retains);
+    Changed |= changedFlagByInPlaceOr(Releases, RHS.Releases);
+    return Changed;
+  }
+
   friend raw_ostream &operator<<(raw_ostream &os,
-                                 const SideEffectAnalysis::Effects &Effects) {
+                                 const FunctionSideEffectFlags &Effects) {
     if (Effects.mayRead())
       os << 'r';
     if (Effects.mayWrite())
@@ -141,134 +253,169 @@ public:
       os << '-';
     return os;
   }
+};
 
-  /// Summarizes the side-effects of a function. The side-effect information
-  /// is divided into global effects and effects for specific function
-  /// parameters.
-  /// If a side-effect can be associated to a specific function parameter, it is
-  /// not added to the global effects of the function. E.g. if a memory write is
-  /// only done through an @inout parameter, the mayWrite side-effect is only
-  /// accounted for this parameter.
-  /// Effects for a parameter make only sense if the parameter is implemented as
-  /// a pointer or contains a pointer:
-  /// *) The parameter is an address parameter, e.g. @out, @inout, etc.
-  /// *) The parameter is a reference
-  /// *) The parameter is a value type (e.g. struct) and contains a reference.
-  ///    In this case the effects refer to all references in the value type.
-  ///    E.g. if a struct contains 2 references, a mayWrite effect means that
-  ///    memory is written to one of the referenced objects (or to both).
-  class FunctionEffects {
-    
-    /// Side-effects which can be associated to a parameter.
-    llvm::SmallVector<Effects, 6> ParamEffects;
-    
-    /// All other side-effects which cannot be associated to a parameter.
-    Effects GlobalEffects;
-    
-    /// Side-effects on locally allocated storage. Such side-effects are not
-    /// relevant to optimizations. The LocalEffects are only used to return
-    /// "something" for local storage in getEffectsOn().
-    Effects LocalEffects;
-    
-    /// Does the function allocate objects, boxes, etc., i.e. everything which
-    /// has a reference count.
-    bool AllocsObjects = false;
-    
-    /// Can this function trap or exit the program in any way?
-    bool Traps = false;
-    
-    /// Does this function read a reference count other than with retain or
-    /// release instructions, e.g. isUnique?
-    bool ReadsRC = false;
-    
-    /// Returns the effects for an address or reference. This might be a
-    /// parameter, the LocalEffects or, if the value cannot be associated to one
-    /// of them, the GlobalEffects.
-    Effects *getEffectsOn(SILValue Addr);
-    
-    FunctionEffects(unsigned numParams) : ParamEffects(numParams) { }
+/// Summarizes the side-effects of a function. The side-effect information
+/// is divided into global effects and effects for specific function
+/// parameters.
+/// If a side-effect can be associated to a specific function parameter, it is
+/// not added to the global effects of the function. E.g. if a memory write is
+/// only done through an @inout parameter, the mayWrite side-effect is only
+/// accounted for this parameter.
+/// Effects for a parameter make only sense if the parameter is implemented as
+/// a pointer or contains a pointer:
+/// *) The parameter is an address parameter, e.g. @out, @inout, etc.
+/// *) The parameter is a reference
+/// *) The parameter is a value type (e.g. struct) and contains a reference.
+///    In this case the effects refer to all references in the value type.
+///    E.g. if a struct contains 2 references, a mayWrite effect means that
+///    memory is written to one of the referenced objects (or to both).
+class FunctionSideEffects {
+  using MemoryBehavior = SILInstruction::MemoryBehavior;
 
-    /// Sets the most conservative effects, if we don't know anything about the
-    /// function.
-    void setWorstEffects() {
-      GlobalEffects.setWorstEffects();
-      AllocsObjects = true;
-      Traps = true;
-      ReadsRC = true;
-    }
-    
-    /// Clears all effects.
-    void clear() {
-      GlobalEffects.clear();
-      for (Effects &PE : ParamEffects)
-        PE.clear();
-      AllocsObjects = false;
-      Traps = false;
-      ReadsRC = false;
-    }
-  
-    /// Merge the flags from \p RHS.
-    bool mergeFlags(const FunctionEffects &RHS) {
-      bool Changed = false;
-      Changed |= updateFlag(Traps, RHS.Traps);
-      Changed |= updateFlag(AllocsObjects, RHS.AllocsObjects);
-      Changed |= updateFlag(ReadsRC, RHS.ReadsRC);
-      return Changed;
-    }
-    
-    friend class SideEffectAnalysis;
-    
-  public:
-    
-    /// Constructs "empty" function effects.
-    FunctionEffects() { }
+  /// Side-effects which can be associated to a parameter.
+  llvm::SmallVector<FunctionSideEffectFlags, 6> ParamEffects;
 
-    /// Does the function allocate objects, boxes, etc., i.e. everything which
-    /// has a reference count.
-    bool mayAllocObjects() const { return AllocsObjects; }
+  /// All other side-effects which cannot be associated to a parameter.
+  FunctionSideEffectFlags GlobalEffects;
 
-    /// Can this function trap or exit the program in any way?
-    bool mayTrap() const { return Traps; }
+  /// Side-effects on locally allocated storage. Such side-effects are not
+  /// relevant to optimizations. The LocalEffects are only used to return
+  /// "something" for local storage in getEffectsOn().
+  FunctionSideEffectFlags LocalEffects;
 
-    /// Does this function read a reference count other than with retain or
-    /// release instructions, e.g. isUnique?
-    bool mayReadRC() const { return ReadsRC; }
+  /// Does the function allocate objects, boxes, etc., i.e. everything which
+  /// has a reference count.
+  bool AllocsObjects = false;
 
-    /// Gets the memory behavior considering the global effects and
-    /// all parameter effects. If \p ScanKind equals ignoreRetains then retain
-    /// instructions are considered as side effects.
-    MemoryBehavior getMemBehavior(RetainObserveKind ScanKind) const;
+  /// Can this function trap or exit the program in any way?
+  bool Traps = false;
 
-    /// Get the global effects for the function. These are effects which cannot
-    /// be associated to a specific parameter, e.g. writes to global variables
-    /// or writes to unknown pointers.
-    const Effects &getGlobalEffects() const { return GlobalEffects; }
-    
-    /// Get the array of parameter effects. If a side-effect can be associated
-    /// to a specific parameter, it is contained here instead of the global
-    /// effects.
-    /// Note that if a parameter effect is mayRelease(), it means that the
-    /// global function effects can be anything, because the destructor of an
-    /// object can have arbitrary side effects.
-    ArrayRef<Effects> getParameterEffects() const { return ParamEffects; }
-    
-    /// Merge effects from \p RHS.
-    bool mergeFrom(const FunctionEffects &RHS);
+  /// Does this function read a reference count other than with retain or
+  /// release instructions, e.g. isUnique?
+  bool ReadsRC = false;
 
-    /// Merge effects from a function apply site within the function.
-    bool mergeFromApply(const FunctionEffects &CalleeEffects,
-                        SILInstruction *FAS);
+  /// Returns the effects for an address or reference. This might be a
+  /// parameter, the LocalEffects or, if the value cannot be associated to one
+  /// of them, the GlobalEffects.
+  FunctionSideEffectFlags *getEffectsOn(SILValue Addr);
 
-    /// Merge effects from an apply site within the function.
-    bool mergeFromApply(const FunctionEffects &CalleeEffects,
-                        FullApplySite FAS);
-    
-    /// Print the function effects.
-    void dump() const;
-  };
+public:
+  /// Constructs "empty" function effects. This effects object can later be
+  /// populated by summarizeFunction or summarizeCall.
+  FunctionSideEffects() {}
+
+  /// Sets the most conservative effects, if we don't know anything about the
+  /// function.
+  void setWorstEffects() {
+    GlobalEffects.setWorstEffects();
+    AllocsObjects = true;
+    Traps = true;
+    ReadsRC = true;
+  }
+
+  /// Clears all effects.
+  void clear() {
+    ParamEffects.clear();
+    GlobalEffects.clear();
+    AllocsObjects = false;
+    Traps = false;
+    ReadsRC = false;
+  }
+
+  /// Merge the flags from \p RHS.
+  bool mergeFlags(const FunctionSideEffects &RHS) {
+    bool Changed = false;
+    Changed |= changedFlagByInPlaceOr(Traps, RHS.Traps);
+    Changed |= changedFlagByInPlaceOr(AllocsObjects, RHS.AllocsObjects);
+    Changed |= changedFlagByInPlaceOr(ReadsRC, RHS.ReadsRC);
+    return Changed;
+  }
+
+  // Summarize the given function's effects using this FunctionSideEffects
+  // object.
+  //
+  // Return true if the function's' effects have been fully summarized without
+  // visiting it's body.
+  bool summarizeFunction(SILFunction *F);
+
+  /// Summarize the callee side effects of a call instruction using this
+  /// FunctionSideEffects object without analyzing the callee function bodies or
+  /// scheduling the callees for bottom-up propagation.
+  ///
+  /// The side effects are represented from the callee's perspective. Parameter
+  /// effects are not translated into information on the caller's argument, and
+  /// local effects are not dropped.
+  ///
+  /// Return true if this call-site's effects are summarized without visiting
+  /// the callee.
+  bool summarizeCall(FullApplySite fullApply);
+
+  /// Merge effects directly from \p RHS.
+  bool mergeFrom(const FunctionSideEffects &RHS);
+
+  /// Merge the effects represented in CalleeEffects into this
+  /// FunctionSideEffects object. CalleeEffects must correspond to at least one
+  /// callee at the apply site `FAS`. Merging drops any local effects, and
+  /// translates parameter effects into effects on the caller-side arguments.
+  ///
+  /// The full caller-side effects at a call site can be obtained with
+  /// SideEffectsAnalysis::getCallSiteEffects().
+  bool mergeFromApply(const FunctionSideEffects &CalleeEffects,
+                      FullApplySite FAS);
+
+  /// Analyze the side-effects of a single SIL instruction \p I.
+  /// Visited callees are added to \p BottomUpOrder until \p RecursionDepth
+  /// reaches MaxRecursionDepth.
+  void analyzeInstruction(SILInstruction *I);
+
+  /// Print the function effects.
+  void dump() const;
+
+  /// Does the function allocate objects, boxes, etc., i.e. everything which
+  /// has a reference count.
+  bool mayAllocObjects() const { return AllocsObjects; }
+
+  /// Can this function trap or exit the program in any way?
+  bool mayTrap() const { return Traps; }
+
+  /// Does this function read a reference count other than with retain or
+  /// release instructions, e.g. isUnique?
+  bool mayReadRC() const { return ReadsRC; }
+
+  /// Gets the memory behavior considering the global effects and
+  /// all parameter effects. If \p ScanKind equals ignoreRetains then retain
+  /// instructions are considered as side effects.
+  MemoryBehavior getMemBehavior(RetainObserveKind ScanKind) const;
+
+  /// Get the global effects for the function. These are effects which cannot
+  /// be associated to a specific parameter, e.g. writes to global variables
+  /// or writes to unknown pointers.
+  const FunctionSideEffectFlags &getGlobalEffects() const {
+    return GlobalEffects;
+  }
+
+  /// Get the array of parameter effects. If a side-effect can be associated
+  /// to a specific parameter, it is contained here instead of the global
+  /// effects.
+  /// Note that if a parameter effect is mayRelease(), it means that the
+  /// global function effects can be anything, because the destructor of an
+  /// object can have arbitrary side effects.
+  ArrayRef<FunctionSideEffectFlags> getParameterEffects() const {
+    return ParamEffects;
+  }
+
+protected:
+  /// Set the side-effects of a function, which has an @effects attribute.
+  /// Returns true if \a F has an @effects attribute which could be handled.
+  bool setDefinedEffects(SILFunction *F);
+
+  /// Set the side-effects of a semantic call.
+  /// Return true if \p ASC could be handled.
+  bool setSemanticEffects(ArraySemanticsCall ASC);
 
   friend raw_ostream &operator<<(raw_ostream &os,
-                          const SideEffectAnalysis::FunctionEffects &Effects) {
+                                 const FunctionSideEffects &Effects) {
     os << "func=" << Effects.getGlobalEffects();
     int ParamIdx = 0;
     for (auto &E : Effects.getParameterEffects()) {
@@ -282,126 +429,25 @@ public:
       os << ";readrc";
     return os;
   }
+};
 
-private:
-
-  /// Stores the analysis data, i.e. the side-effects, for a function.
-  struct FunctionInfo : public FunctionInfoBase<FunctionInfo> {
-
-    /// The side-effects of the function.
-    FunctionEffects FE;
-
-    /// Back-link to the function.
-    SILFunction *F;
-
-    /// Used during recomputation to indicate if the side-effects of a caller
-    /// must be updated.
-    bool NeedUpdateCallers = false;
-
-    FunctionInfo(SILFunction *F) :
-      FE(F->empty() ? 0 : F->getArguments().size()), F(F) { }
-
-    /// Clears the analysis data on invalidation.
-    void clear() { FE.clear(); }
-  };
-  
-  typedef BottomUpFunctionOrder<FunctionInfo> FunctionOrder;
-
-  enum {
-    /// The maximum call-graph recursion depth for recomputing the analysis.
-    /// This is a relatively small number to reduce compile time in case of
-    /// large cycles in the call-graph.
-    /// In case of no cycles, we should not hit this limit at all because the
-    /// pass manager processes functions in bottom-up order.
-    MaxRecursionDepth = 5
-  };
-
-  /// All the side-effect information for the whole module.
-  llvm::DenseMap<SILFunction *, FunctionInfo *> Function2Info;
-  
-  /// The allocator for the map values in Function2Info.
-  llvm::SpecificBumpPtrAllocator<FunctionInfo> Allocator;
-  
-  /// Callee analysis, used for determining the callees at call sites.
-  BasicCalleeAnalysis *BCA;
-
-  /// Get the side-effects of a function, which has an @effects attribute.
-  /// Returns true if \a F has an @effects attribute which could be handled.
-  static bool getDefinedEffects(FunctionEffects &Effects, SILFunction *F);
-  
-  /// Get the side-effects of a semantic call.
-  /// Return true if \p ASC could be handled.
-  bool getSemanticEffects(FunctionEffects &Effects, ArraySemanticsCall ASC);
-  
-  /// Analyze the side-effects of a function, including called functions.
-  /// Visited callees are added to \p BottomUpOrder until \p RecursionDepth
-  /// reaches MaxRecursionDepth.
-  void analyzeFunction(FunctionInfo *FInfo,
-                       FunctionOrder &BottomUpOrder,
-                       int RecursionDepth);
-
-  /// Analyze the side-effects of a single SIL instruction \p I.
-  /// Visited callees are added to \p BottomUpOrder until \p RecursionDepth
-  /// reaches MaxRecursionDepth.
-  void analyzeInstruction(FunctionInfo *FInfo,
-                          SILInstruction *I,
-                          FunctionOrder &BottomUpOrder,
-                          int RecursionDepth);
-
-  /// Gets or creates FunctionEffects for \p F.
-  FunctionInfo *getFunctionInfo(SILFunction *F) {
-    FunctionInfo *&FInfo = Function2Info[F];
-    if (!FInfo) {
-      FInfo = new (Allocator.Allocate()) FunctionInfo(F);
-    }
-    return FInfo;
-  }
-
-  /// Recomputes the side-effect information for the function \p Initial and
-  /// all called functions, up to a recursion depth of MaxRecursionDepth.
-  void recompute(FunctionInfo *Initial);
-
+/// The SideEffectAnalysis provides information about side-effects of SIL
+/// functions. Side-effect information is provided per function and includes:
+/// Does the function read or write memory? Does the function retain or release
+/// objects? etc.
+/// For details see FunctionSideEffects.
+class SideEffectAnalysis
+    : public GenericFunctionEffectAnalysis<FunctionSideEffects> {
 public:
   SideEffectAnalysis()
-      : BottomUpIPAnalysis(AnalysisKind::SideEffect) {}
+      : GenericFunctionEffectAnalysis<FunctionSideEffects>(
+            AnalysisKind::SideEffect) {}
 
   static bool classof(const SILAnalysis *S) {
     return S->getKind() == AnalysisKind::SideEffect;
   }
-  
-  virtual void initialize(SILPassManager *PM) override;
-  
-  /// Get the side-effects of a function.
-  const FunctionEffects &getEffects(SILFunction *F) {
-    FunctionInfo *FInfo = getFunctionInfo(F);
-    if (!FInfo->isValid())
-      recompute(FInfo);
-    return FInfo->FE;
-  }
-
-  /// Get the side-effects of a call site.
-  void getEffects(FunctionEffects &ApplyEffects, FullApplySite FAS);
-  
-  /// Invalidate all information in this analysis.
-  virtual void invalidate() override;
-  
-  /// Invalidate all of the information for a specific function.
-  virtual void invalidate(SILFunction *F, InvalidationKind K)  override;
-
-  /// Notify the analysis about a newly created function.
-  virtual void notifyAddFunction(SILFunction *F) override { }
-
-  /// Notify the analysis about a function which will be deleted from the
-  /// module.
-  virtual void notifyDeleteFunction(SILFunction *F) override {
-    invalidate(F, InvalidationKind::Nothing);
-  }
-
-  /// Notify the analysis about changed witness or vtables.
-  virtual void invalidateFunctionTables() override { }
 };
 
 } // end namespace swift
 
-#endif
-
+#endif // SWIFT_SILOPTIMIZER_ANALYSIS_SIDEEFFECTANALYSIS_H_

--- a/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AliasAnalysis.cpp
@@ -652,8 +652,8 @@ bool AliasAnalysis::canApplyDecrementRefCount(FullApplySite FAS, SILValue Ptr) {
   if (!EA->canEscapeTo(Ptr, FAS))
     return false;
 
-  SideEffectAnalysis::FunctionEffects ApplyEffects;
-  SEA->getEffects(ApplyEffects, FAS);
+  FunctionSideEffects ApplyEffects;
+  SEA->getCalleeEffects(ApplyEffects, FAS);
 
   auto &GlobalEffects = ApplyEffects.getGlobalEffects();
   if (ApplyEffects.mayReadRC() || GlobalEffects.mayRelease())

--- a/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
+++ b/lib/SILOptimizer/Analysis/MemoryBehavior.cpp
@@ -237,8 +237,8 @@ MemBehavior MemoryBehaviorVisitor::visitTryApplyInst(TryApplyInst *AI) {
 
 MemBehavior MemoryBehaviorVisitor::visitApplyInst(ApplyInst *AI) {
 
-  SideEffectAnalysis::FunctionEffects ApplyEffects;
-  SEA->getEffects(ApplyEffects, AI);
+  FunctionSideEffects ApplyEffects;
+  SEA->getCalleeEffects(ApplyEffects, AI);
 
   MemBehavior Behavior = MemBehavior::None;
 

--- a/lib/SILOptimizer/Analysis/SideEffectAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/SideEffectAnalysis.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -19,12 +19,183 @@
 
 using namespace swift;
 
-using FunctionEffects = SideEffectAnalysis::FunctionEffects;
-using Effects = SideEffectAnalysis::Effects;
+// -----------------------------------------------------------------------------
+// GenericFunctionEffectAnalysis
+// -----------------------------------------------------------------------------
+
+template <typename FunctionEffects>
+void GenericFunctionEffectAnalysis<FunctionEffects>::initialize(
+    SILPassManager *PM) {
+  BCA = PM->getAnalysis<BasicCalleeAnalysis>();
+}
+
+template <typename FunctionEffects>
+void GenericFunctionEffectAnalysis<FunctionEffects>::invalidate() {
+  functionInfoMap.clear();
+  allocator.DestroyAll();
+  DEBUG(llvm::dbgs() << "invalidate all\n");
+}
+
+template <typename FunctionEffects>
+void GenericFunctionEffectAnalysis<FunctionEffects>::invalidate(
+    SILFunction *F, InvalidationKind K) {
+  if (FunctionInfo *FInfo = functionInfoMap.lookup(F)) {
+    DEBUG(llvm::dbgs() << "  invalidate " << FInfo->F->getName() << '\n');
+    invalidateIncludingAllCallers(FInfo);
+  }
+}
+
+template <typename FunctionEffects>
+void GenericFunctionEffectAnalysis<FunctionEffects>::getCalleeEffects(
+    FunctionEffects &calleeEffects, FullApplySite fullApply) {
+  if (calleeEffects.summarizeCall(fullApply))
+    return;
+
+  auto callees = BCA->getCalleeList(fullApply);
+  if (!callees.allCalleesVisible() ||
+      // @callee_owned function calls implicitly release the context, which
+      // may call deinits of boxed values.
+      // TODO: be less conservative about what destructors might be called.
+      fullApply.getOrigCalleeType()->isCalleeConsumed()) {
+    calleeEffects.setWorstEffects();
+    return;
+  }
+
+  // We can see all the callees, so merge the effects from all of them.
+  for (auto *callee : callees)
+    calleeEffects.mergeFrom(getEffects(callee));
+}
+
+template <typename FunctionEffects>
+void GenericFunctionEffectAnalysis<FunctionEffects>::analyzeFunction(
+    FunctionInfo *functionInfo, FunctionOrder &bottomUpOrder,
+    int recursionDepth) {
+  functionInfo->needUpdateCallers = true;
+
+  if (bottomUpOrder.prepareForVisiting(functionInfo))
+    return;
+
+  auto *F = functionInfo->F;
+  if (functionInfo->functionEffects.summarizeFunction(F))
+    return;
+
+  DEBUG(llvm::dbgs() << "  >> analyze " << F->getName() << '\n');
+
+  // Check all instructions of the function
+  for (auto &BB : *F) {
+    for (auto &I : BB) {
+      if (auto fullApply = FullApplySite::isa(&I))
+        analyzeCall(functionInfo, fullApply, bottomUpOrder, recursionDepth);
+      else
+        functionInfo->functionEffects.analyzeInstruction(&I);
+    }
+  }
+  DEBUG(llvm::dbgs() << "  << finished " << F->getName() << '\n');
+}
+
+template <typename FunctionEffects>
+void GenericFunctionEffectAnalysis<FunctionEffects>::analyzeCall(
+    FunctionInfo *functionInfo, FullApplySite fullApply,
+    FunctionOrder &bottomUpOrder, int recursionDepth) {
+
+  FunctionEffects applyEffects;
+  if (applyEffects.summarizeCall(fullApply)) {
+    functionInfo->functionEffects.mergeFromApply(applyEffects, fullApply);
+    return;
+  }
+
+  if (recursionDepth >= MaxRecursionDepth) {
+    functionInfo->functionEffects.setWorstEffects();
+    return;
+  }
+  CalleeList callees = BCA->getCalleeList(fullApply);
+  if (!callees.allCalleesVisible() ||
+      // @callee_owned function calls implicitly release the context, which
+      // may call deinits of boxed values.
+      // TODO: be less conservative about what destructors might be called.
+      fullApply.getOrigCalleeType()->isCalleeConsumed()) {
+    functionInfo->functionEffects.setWorstEffects();
+    return;
+  }
+  // Derive the effects of the apply from the known callees.
+  // Defer merging callee effects until the callee is scheduled
+  for (SILFunction *callee : callees) {
+    FunctionInfo *calleeInfo = getFunctionInfo(callee);
+    calleeInfo->addCaller(functionInfo, fullApply);
+    if (!calleeInfo->isVisited()) {
+      // Recursively visit the called function.
+      analyzeFunction(calleeInfo, bottomUpOrder, recursionDepth + 1);
+      bottomUpOrder.tryToSchedule(calleeInfo);
+    }
+  }
+}
+
+template <typename FunctionEffects>
+void GenericFunctionEffectAnalysis<FunctionEffects>::recompute(
+    FunctionInfo *initialInfo) {
+  allocNewUpdateID();
+
+  DEBUG(llvm::dbgs() << "recompute function-effect analysis with UpdateID "
+                     << getCurrentUpdateID() << '\n');
+
+  // Collect and analyze all functions to recompute, starting at initialInfo.
+  FunctionOrder bottomUpOrder(getCurrentUpdateID());
+  analyzeFunction(initialInfo, bottomUpOrder, 0);
+
+  // Build the bottom-up order.
+  bottomUpOrder.tryToSchedule(initialInfo);
+  bottomUpOrder.finishScheduling();
+
+  // Second step: propagate the side-effect information up the call-graph until
+  // it stabilizes.
+  bool needAnotherIteration;
+  do {
+    DEBUG(llvm::dbgs() << "new iteration\n");
+    needAnotherIteration = false;
+
+    for (FunctionInfo *functionInfo : bottomUpOrder) {
+      if (!functionInfo->needUpdateCallers)
+        continue;
+
+      DEBUG(llvm::dbgs() << "  update callers of " << functionInfo->F->getName()
+                         << '\n');
+      functionInfo->needUpdateCallers = false;
+
+      // Propagate the function effects to all callers.
+      for (const auto &E : functionInfo->getCallers()) {
+        assert(E.isValid());
+
+        // Only include callers which we are actually recomputing.
+        if (!bottomUpOrder.wasRecomputedWithCurrentUpdateID(E.Caller))
+          continue;
+
+        DEBUG(llvm::dbgs() << "    merge into caller " << E.Caller->F->getName()
+                           << '\n');
+
+        if (E.Caller->functionEffects.mergeFromApply(
+                functionInfo->functionEffects, FullApplySite(E.FAS))) {
+          E.Caller->needUpdateCallers = true;
+          if (!E.Caller->isScheduledAfter(functionInfo)) {
+            // This happens if we have a cycle in the call-graph.
+            needAnotherIteration = true;
+          }
+        }
+      }
+    }
+  } while (needAnotherIteration);
+}
+
+// Instantiate template members.
+template class swift::GenericFunctionEffectAnalysis<FunctionSideEffects>;
+
+// -----------------------------------------------------------------------------
+// FunctionSideEffects
+// -----------------------------------------------------------------------------
+
 using MemoryBehavior = SILInstruction::MemoryBehavior;
 
 MemoryBehavior
-FunctionEffects::getMemBehavior(RetainObserveKind ScanKind) const {
+FunctionSideEffects::getMemBehavior(RetainObserveKind ScanKind) const {
 
   bool Observe = (ScanKind == RetainObserveKind::ObserveRetains);
   if ((Observe && mayAllocObjects()) || mayReadRC())
@@ -46,7 +217,7 @@ FunctionEffects::getMemBehavior(RetainObserveKind ScanKind) const {
   return Behavior;
 }
 
-bool FunctionEffects::mergeFrom(const FunctionEffects &RHS) {
+bool FunctionSideEffects::mergeFrom(const FunctionSideEffects &RHS) {
   bool Changed = mergeFlags(RHS);
   Changed |= GlobalEffects.mergeFrom(RHS.GlobalEffects);
   Changed |= LocalEffects.mergeFrom(RHS.LocalEffects);
@@ -64,33 +235,26 @@ bool FunctionEffects::mergeFrom(const FunctionEffects &RHS) {
   return Changed;
 }
 
-bool FunctionEffects::mergeFromApply(
-                  const FunctionEffects &ApplyEffects, FullApplySite FAS) {
-  return mergeFromApply(ApplyEffects, FAS.getInstruction());
-}
-
-bool FunctionEffects::mergeFromApply(
-                  const FunctionEffects &ApplyEffects, SILInstruction *AS) {
+bool FunctionSideEffects::mergeFromApply(
+    const FunctionSideEffects &ApplyEffects, FullApplySite FAS) {
   bool Changed = mergeFlags(ApplyEffects);
   Changed |= GlobalEffects.mergeFrom(ApplyEffects.GlobalEffects);
-  auto FAS = FullApplySite::isa(AS);
-  unsigned numCallerArgs = FAS ? FAS.getNumArguments() : 1;
+  unsigned numCallerArgs = FAS.getNumArguments();
   unsigned numCalleeArgs = ApplyEffects.ParamEffects.size();
   assert(numCalleeArgs >= numCallerArgs);
   for (unsigned Idx = 0; Idx < numCalleeArgs; Idx++) {
     // Map the callee argument effects to parameters of this function.
     // If there are more callee parameters than arguments it means that the
     // callee is the result of a partial_apply.
-    Effects *E = (Idx < numCallerArgs ? getEffectsOn(FAS ? FAS.getArgument(Idx) : AS->getOperand(Idx)) :
-                  &GlobalEffects);
+    FunctionSideEffectFlags *E = (Idx < numCallerArgs
+                                  ? getEffectsOn(FAS.getArgument(Idx))
+                                  : &GlobalEffects);
     Changed |= E->mergeFrom(ApplyEffects.ParamEffects[Idx]);
   }
   return Changed;
 }
 
-void FunctionEffects::dump() const {
-  llvm::errs() << *this << '\n';
-}
+void FunctionSideEffects::dump() const { llvm::errs() << *this << '\n'; }
 
 static SILValue skipAddrProjections(SILValue V) {
   for (;;) {
@@ -130,7 +294,7 @@ static SILValue skipValueProjections(SILValue V) {
   llvm_unreachable("there is no escape from an infinite loop");
 }
 
-Effects *FunctionEffects::getEffectsOn(SILValue Addr) {
+FunctionSideEffectFlags *FunctionSideEffects::getEffectsOn(SILValue Addr) {
   SILValue BaseAddr = skipValueProjections(skipAddrProjections(Addr));
   switch (BaseAddr->getKind()) {
   case swift::ValueKind::SILFunctionArgument: {
@@ -152,17 +316,18 @@ Effects *FunctionEffects::getEffectsOn(SILValue Addr) {
   return &GlobalEffects;
 }
 
-bool SideEffectAnalysis::getDefinedEffects(FunctionEffects &Effects,
-                                           SILFunction *F) {
+// Return true if the given function has defined effects that were successfully
+// recorded in this FunctionSideEffects object.
+bool FunctionSideEffects::setDefinedEffects(SILFunction *F) {
   if (F->hasSemanticsAttr("arc.programtermination_point")) {
-    Effects.Traps = true;
+    Traps = true;
     return true;
   }
   switch (F->getEffectsKind()) {
     case EffectsKind::ReleaseNone:
-      Effects.GlobalEffects.Reads = true;
-      Effects.GlobalEffects.Writes = true;
-      Effects.GlobalEffects.Releases = false;
+      GlobalEffects.Reads = true;
+      GlobalEffects.Writes = true;
+      GlobalEffects.Releases = false;
       return true;
     case EffectsKind::ReadNone:
       return true;
@@ -171,7 +336,7 @@ bool SideEffectAnalysis::getDefinedEffects(FunctionEffects &Effects,
       // the release inside the callee may call a deinit, which itself can do
       // anything.
       if (!F->hasOwnedParameters()) {
-        Effects.GlobalEffects.Reads = true;
+        GlobalEffects.Reads = true;
         return true;
       }
       break;
@@ -182,10 +347,34 @@ bool SideEffectAnalysis::getDefinedEffects(FunctionEffects &Effects,
   return false;
 }
 
-bool SideEffectAnalysis::getSemanticEffects(FunctionEffects &FE,
-                                            ArraySemanticsCall ASC) {
+// Return true if this function's effects have been fully summarized in this
+// FunctionSideEffects object without visiting its body.
+bool FunctionSideEffects::summarizeFunction(SILFunction *F) {
+  assert(ParamEffects.empty() && "Expect uninitialized effects.");
+  if (!F->empty())
+    ParamEffects.resize(F->getArguments().size());
+
+  // Handle @effects attributes
+  if (setDefinedEffects(F)) {
+    DEBUG(llvm::dbgs() << "  -- has defined effects " << F->getName() << '\n');
+    return true;
+  }
+
+  if (!F->isDefinition()) {
+    // We can't assume anything about external functions.
+    DEBUG(llvm::dbgs() << "  -- is external " << F->getName() << '\n');
+    setWorstEffects();
+    return true;
+  }
+  return false;
+}
+
+// Return true if the side effects of this semantic call are fully known without
+// visiting the callee and have been recorded in this FunctionSideEffects
+// object.
+bool FunctionSideEffects::setSemanticEffects(ArraySemanticsCall ASC) {
   assert(ASC.hasSelf());
-  auto &SelfEffects = FE.ParamEffects[FE.ParamEffects.size() - 1];
+  auto &SelfEffects = ParamEffects[ParamEffects.size() - 1];
 
   // Currently we only handle array semantics.
   // TODO: also handle other semantic functions.
@@ -205,7 +394,7 @@ bool SideEffectAnalysis::getSemanticEffects(FunctionEffects &FE,
       if (!ASC.mayHaveBridgedObjectElementType()) {
         SelfEffects.Reads = true;
         SelfEffects.Releases |= !ASC.hasGuaranteedSelf();
-        FE.Traps = true;
+        Traps = true;
         return true;
       }
       return false;
@@ -218,7 +407,7 @@ bool SideEffectAnalysis::getSemanticEffects(FunctionEffects &FE,
                                 ->getOrigCalleeConv()
                                 .getNumIndirectSILResults())) {
           assert(!ASC.hasGetElementDirectResult());
-          FE.ParamEffects[i].Writes = true;
+          ParamEffects[i].Writes = true;
         }
         return true;
       }
@@ -240,9 +429,9 @@ bool SideEffectAnalysis::getSemanticEffects(FunctionEffects &FE,
     case ArrayCallKind::kMakeMutable:
       if (!ASC.mayHaveBridgedObjectElementType()) {
         SelfEffects.Writes = true;
-        FE.GlobalEffects.Releases = true;
-        FE.AllocsObjects = true;
-        FE.ReadsRC = true;
+        GlobalEffects.Releases = true;
+        AllocsObjects = true;
+        ReadsRC = true;
         return true;
       }
       return false;
@@ -252,290 +441,134 @@ bool SideEffectAnalysis::getSemanticEffects(FunctionEffects &FE,
   }
 }
 
-void SideEffectAnalysis::analyzeFunction(FunctionInfo *FInfo,
-                                         FunctionOrder &BottomUpOrder,
-                                         int RecursionDepth) {
-  FInfo->NeedUpdateCallers = true;
+// Summarize the callee side effects of a call instruction using this
+// FunctionSideEffects object without analyzing the callee function bodies or
+// scheduling the callees for bottom-up propagation.
+//
+// Return true if this call-site's effects are summarized without visiting the
+// callee.
+bool FunctionSideEffects::summarizeCall(FullApplySite fullApply) {
+  assert(ParamEffects.empty() && "Expect uninitialized effects.");
+  ParamEffects.resize(fullApply.getNumArguments());
 
-  if (BottomUpOrder.prepareForVisiting(FInfo))
-    return;
-
-  // Handle @effects attributes
-  if (getDefinedEffects(FInfo->FE, FInfo->F)) {
-    DEBUG(llvm::dbgs() << "  -- has defined effects " <<
-          FInfo->F->getName() << '\n');
-    return;
-  }
-  
-  if (!FInfo->F->isDefinition()) {
-    // We can't assume anything about external functions.
-    DEBUG(llvm::dbgs() << "  -- is external " << FInfo->F->getName() << '\n');
-    FInfo->FE.setWorstEffects();
-    return;
-  }
-  
-  DEBUG(llvm::dbgs() << "  >> analyze " << FInfo->F->getName() << '\n');
-
-  // Check all instructions of the function
-  for (auto &BB : *FInfo->F) {
-    for (auto &I : BB) {
-      analyzeInstruction(FInfo, &I, BottomUpOrder, RecursionDepth);
+  // Is this a call to a semantics function?
+  if (auto apply = dyn_cast<ApplyInst>(fullApply.getInstruction())) {
+    ArraySemanticsCall ASC(apply);
+    if (ASC && ASC.hasSelf()) {
+      if (setSemanticEffects(ASC))
+        return true;
     }
   }
-  DEBUG(llvm::dbgs() << "  << finished " << FInfo->F->getName() << '\n');
+
+  if (SILFunction *SingleCallee = fullApply.getReferencedFunction()) {
+    // Does the function have any @effects?
+    if (setDefinedEffects(SingleCallee))
+      return true;
+  }
+  return false;
 }
 
-void SideEffectAnalysis::analyzeInstruction(FunctionInfo *FInfo,
-                                            SILInstruction *I,
-                                            FunctionOrder &BottomUpOrder,
-                                            int RecursionDepth) {
-  if (FullApplySite FAS = FullApplySite::isa(I)) {
-    // Is this a call to a semantics function?
-    if (auto apply = dyn_cast<ApplyInst>(FAS.getInstruction())) {
-      ArraySemanticsCall ASC(apply);
-      if (ASC && ASC.hasSelf()) {
-        FunctionEffects ApplyEffects(FAS.getNumArguments());
-        if (getSemanticEffects(ApplyEffects, ASC)) {
-          FInfo->FE.mergeFromApply(ApplyEffects, FAS);
-          return;
-        }
-      }
-    }
-
-    if (SILFunction *SingleCallee = FAS.getReferencedFunction()) {
-      // Does the function have any @effects?
-      if (getDefinedEffects(FInfo->FE, SingleCallee))
-        return;
-    }
-
-    if (RecursionDepth < MaxRecursionDepth) {
-      CalleeList Callees = BCA->getCalleeList(FAS);
-      if (Callees.allCalleesVisible() &&
-          // @callee_owned function calls implicitly release the context, which
-          // may call deinits of boxed values.
-          // TODO: be less conservative about what destructors might be called.
-          !FAS.getOrigCalleeType()->isCalleeConsumed()) {
-        // Derive the effects of the apply from the known callees.
-        for (SILFunction *Callee : Callees) {
-          FunctionInfo *CalleeInfo = getFunctionInfo(Callee);
-          CalleeInfo->addCaller(FInfo, FAS);
-          if (!CalleeInfo->isVisited()) {
-            // Recursively visit the called function.
-            analyzeFunction(CalleeInfo, BottomUpOrder, RecursionDepth + 1);
-            BottomUpOrder.tryToSchedule(CalleeInfo);
-          }
-        }
-        return;
-      }
-    }
-    // Be conservative for everything else.
-    FInfo->FE.setWorstEffects();
-    return;
-  }
+void FunctionSideEffects::analyzeInstruction(SILInstruction *I) {
   // Handle some kind of instructions specially.
   switch (I->getKind()) {
-    case SILInstructionKind::FixLifetimeInst:
-      // A fix_lifetime instruction acts like a read on the operand. Retains can move after it
-      // but the last release can't move before it.
-      FInfo->FE.getEffectsOn(I->getOperand(0))->Reads = true;
-      return;
-    case SILInstructionKind::AllocStackInst:
-    case SILInstructionKind::DeallocStackInst:
-      return;
-    case SILInstructionKind::StrongRetainInst:
-    case SILInstructionKind::StrongRetainUnownedInst:
-    case SILInstructionKind::RetainValueInst:
-    case SILInstructionKind::UnownedRetainInst:
-      FInfo->FE.getEffectsOn(I->getOperand(0))->Retains = true;
-      return;
-    case SILInstructionKind::StrongReleaseInst:
-    case SILInstructionKind::ReleaseValueInst:
-    case SILInstructionKind::UnownedReleaseInst:
-      FInfo->FE.getEffectsOn(I->getOperand(0))->Releases = true;
-      return;
-    case SILInstructionKind::UnconditionalCheckedCastInst:
-      FInfo->FE.getEffectsOn(cast<UnconditionalCheckedCastInst>(I)->getOperand())->Reads = true;
-      FInfo->FE.Traps = true;
-      return;
-    case SILInstructionKind::LoadInst:
-      FInfo->FE.getEffectsOn(cast<LoadInst>(I)->getOperand())->Reads = true;
-      return;
-    case SILInstructionKind::StoreInst:
-      FInfo->FE.getEffectsOn(cast<StoreInst>(I)->getDest())->Writes = true;
-      return;
-    case SILInstructionKind::CondFailInst:
-      FInfo->FE.Traps = true;
-      return;
-    case SILInstructionKind::PartialApplyInst: {
-      FInfo->FE.AllocsObjects = true;
-      auto *PAI = cast<PartialApplyInst>(I);
-      auto Args = PAI->getArguments();
-      auto Params = PAI->getSubstCalleeType()->getParameters();
-      Params = Params.slice(Params.size() - Args.size(), Args.size());
-      for (unsigned Idx : indices(Args)) {
-        if (isIndirectFormalParameter(Params[Idx].getConvention()))
-          FInfo->FE.getEffectsOn(Args[Idx])->Reads = true;
-      }
-      return;
+  case SILInstructionKind::FixLifetimeInst:
+    // A fix_lifetime instruction acts like a read on the operand. Retains can
+    // move after it but the last release can't move before it.
+    getEffectsOn(I->getOperand(0))->Reads = true;
+    return;
+  case SILInstructionKind::AllocStackInst:
+  case SILInstructionKind::DeallocStackInst:
+    return;
+  case SILInstructionKind::StrongRetainInst:
+  case SILInstructionKind::StrongRetainUnownedInst:
+  case SILInstructionKind::RetainValueInst:
+  case SILInstructionKind::UnownedRetainInst:
+    getEffectsOn(I->getOperand(0))->Retains = true;
+    return;
+  case SILInstructionKind::StrongReleaseInst:
+  case SILInstructionKind::ReleaseValueInst:
+  case SILInstructionKind::UnownedReleaseInst:
+    getEffectsOn(I->getOperand(0))->Releases = true;
+    return;
+  case SILInstructionKind::UnconditionalCheckedCastInst:
+    getEffectsOn(cast<UnconditionalCheckedCastInst>(I)->getOperand())->Reads =
+        true;
+    Traps = true;
+    return;
+  case SILInstructionKind::LoadInst:
+    getEffectsOn(cast<LoadInst>(I)->getOperand())->Reads = true;
+    return;
+  case SILInstructionKind::StoreInst:
+    getEffectsOn(cast<StoreInst>(I)->getDest())->Writes = true;
+    return;
+  case SILInstructionKind::CondFailInst:
+    Traps = true;
+    return;
+  case SILInstructionKind::PartialApplyInst: {
+    AllocsObjects = true;
+    auto *PAI = cast<PartialApplyInst>(I);
+    auto Args = PAI->getArguments();
+    auto Params = PAI->getSubstCalleeType()->getParameters();
+    Params = Params.slice(Params.size() - Args.size(), Args.size());
+    for (unsigned Idx : indices(Args)) {
+      if (isIndirectFormalParameter(Params[Idx].getConvention()))
+        getEffectsOn(Args[Idx])->Reads = true;
     }
-    case SILInstructionKind::BuiltinInst: {
-      auto *BInst = cast<BuiltinInst>(I);
-      auto &BI = BInst->getBuiltinInfo();
-      switch (BI.ID) {
-        case BuiltinValueKind::IsUnique:
-          // TODO: derive this information in a more general way, e.g. add it
-          // to Builtins.def
-          FInfo->FE.ReadsRC = true;
-          break;
-        case BuiltinValueKind::CondUnreachable:
-          FInfo->FE.Traps = true;
-          return;
-        default:
-          break;
-      }
-      const IntrinsicInfo &IInfo = BInst->getIntrinsicInfo();
-      if (IInfo.ID == llvm::Intrinsic::trap) {
-        FInfo->FE.Traps = true;
-        return;
-      }
-      // Detailed memory effects of builtins are handled below by checking the
-      // memory behavior of the instruction.
+    return;
+  }
+  case SILInstructionKind::BuiltinInst: {
+    auto *BInst = cast<BuiltinInst>(I);
+    auto &BI = BInst->getBuiltinInfo();
+    switch (BI.ID) {
+    case BuiltinValueKind::IsUnique:
+      // TODO: derive this information in a more general way, e.g. add it
+      // to Builtins.def
+      ReadsRC = true;
       break;
-    }
+    case BuiltinValueKind::CondUnreachable:
+      Traps = true;
+      return;
     default:
       break;
+    }
+    const IntrinsicInfo &IInfo = BInst->getIntrinsicInfo();
+    if (IInfo.ID == llvm::Intrinsic::trap) {
+      Traps = true;
+      return;
+    }
+    // Detailed memory effects of builtins are handled below by checking the
+    // memory behavior of the instruction.
+    break;
+  }
+  default:
+    break;
   }
 
   if (isa<AllocationInst>(I)) {
     // Excluding AllocStackInst (which is handled above).
-    FInfo->FE.AllocsObjects = true;
+    AllocsObjects = true;
   }
   
   // Check the general memory behavior for instructions we didn't handle above.
   switch (I->getMemoryBehavior()) {
-    case MemoryBehavior::None:
-      break;
-    case MemoryBehavior::MayRead:
-      FInfo->FE.GlobalEffects.Reads = true;
-      break;
-    case MemoryBehavior::MayWrite:
-      FInfo->FE.GlobalEffects.Writes = true;
-      break;
-    case MemoryBehavior::MayReadWrite:
-      FInfo->FE.GlobalEffects.Reads = true;
-      FInfo->FE.GlobalEffects.Writes = true;
-      break;
-    case MemoryBehavior::MayHaveSideEffects:
-      FInfo->FE.setWorstEffects();
-      break;
+  case MemoryBehavior::None:
+    break;
+  case MemoryBehavior::MayRead:
+    GlobalEffects.Reads = true;
+    break;
+  case MemoryBehavior::MayWrite:
+    GlobalEffects.Writes = true;
+    break;
+  case MemoryBehavior::MayReadWrite:
+    GlobalEffects.Reads = true;
+    GlobalEffects.Writes = true;
+    break;
+  case MemoryBehavior::MayHaveSideEffects:
+    setWorstEffects();
+    break;
   }
   if (I->mayTrap())
-    FInfo->FE.Traps = true;
-}
-
-void SideEffectAnalysis::initialize(SILPassManager *PM) {
-  BCA = PM->getAnalysis<BasicCalleeAnalysis>();
-}
-
-void SideEffectAnalysis::recompute(FunctionInfo *Initial) {
-  allocNewUpdateID();
-
-  DEBUG(llvm::dbgs() << "recompute side-effect analysis with UpdateID " <<
-        getCurrentUpdateID() << '\n');
-
-  // Collect and analyze all functions to recompute, starting at Initial.
-  FunctionOrder BottomUpOrder(getCurrentUpdateID());
-  analyzeFunction(Initial, BottomUpOrder, 0);
-
-  // Build the bottom-up order.
-  BottomUpOrder.tryToSchedule(Initial);
-  BottomUpOrder.finishScheduling();
-
-  // Second step: propagate the side-effect information up the call-graph until
-  // it stabilizes.
-  bool NeedAnotherIteration;
-  do {
-    DEBUG(llvm::dbgs() << "new iteration\n");
-    NeedAnotherIteration = false;
-
-    for (FunctionInfo *FInfo : BottomUpOrder) {
-      if (FInfo->NeedUpdateCallers) {
-        DEBUG(llvm::dbgs() << "  update callers of " << FInfo->F->getName() <<
-              '\n');
-        FInfo->NeedUpdateCallers = false;
-
-        // Propagate the side-effects to all callers.
-        for (const auto &E : FInfo->getCallers()) {
-          assert(E.isValid());
-
-          // Only include callers which we are actually recomputing.
-          if (BottomUpOrder.wasRecomputedWithCurrentUpdateID(E.Caller)) {
-            DEBUG(llvm::dbgs() << "    merge into caller " <<
-                  E.Caller->F->getName() << '\n');
-
-            if (E.Caller->FE.mergeFromApply(FInfo->FE, E.FAS)) {
-              E.Caller->NeedUpdateCallers = true;
-              if (!E.Caller->isScheduledAfter(FInfo)) {
-                // This happens if we have a cycle in the call-graph.
-                NeedAnotherIteration = true;
-              }
-            }
-          }
-        }
-      }
-    }
-  } while (NeedAnotherIteration);
-}
-
-void SideEffectAnalysis::getEffects(FunctionEffects &ApplyEffects, FullApplySite FAS) {
-  assert(ApplyEffects.ParamEffects.empty() &&
-         "Not using a new ApplyEffects?");
-  ApplyEffects.ParamEffects.resize(FAS.getNumArguments());
-
-  // Is this a call to a semantics function?
-  if (auto apply = dyn_cast<ApplyInst>(FAS.getInstruction())) {
-    ArraySemanticsCall ASC(apply);
-    if (ASC && ASC.hasSelf()) {
-      if (getSemanticEffects(ApplyEffects, ASC))
-        return;
-    }
-  }
-
-  if (SILFunction *SingleCallee = FAS.getReferencedFunction()) {
-    // Does the function have any @effects?
-    if (getDefinedEffects(ApplyEffects, SingleCallee))
-      return;
-  }
-
-  auto Callees = BCA->getCalleeList(FAS);
-  if (!Callees.allCalleesVisible() ||
-      // @callee_owned function calls implicitly release the context, which
-      // may call deinits of boxed values.
-      // TODO: be less conservative about what destructors might be called.
-      FAS.getOrigCalleeType()->isCalleeConsumed()) {
-    ApplyEffects.setWorstEffects();
-    return;
-  }
-
-  // We can see all the callees. So we just merge the effects from all of
-  // them.
-  for (auto *Callee : Callees) {
-    const FunctionEffects &CalleeFE = getEffects(Callee);
-    ApplyEffects.mergeFrom(CalleeFE);
-  }
-}
-
-void SideEffectAnalysis::invalidate() {
-  Function2Info.clear();
-  Allocator.DestroyAll();
-  DEBUG(llvm::dbgs() << "invalidate all\n");
-}
-
-void SideEffectAnalysis::invalidate(SILFunction *F, InvalidationKind K) {
-  if (FunctionInfo *FInfo = Function2Info.lookup(F)) {
-    DEBUG(llvm::dbgs() << "  invalidate " << FInfo->F->getName() << '\n');
-    invalidateIncludingAllCallers(FInfo);
-  }
+    Traps = true;
 }
 
 SILAnalysis *swift::createSideEffectAnalysis(SILModule *M) {

--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -59,8 +59,8 @@ static bool mayWriteTo(AliasAnalysis *AA, WriteSet &MayWrites, LoadInst *LI) {
 /// alias with any memory which is read by \p AI.
 static bool mayWriteTo(AliasAnalysis *AA, SideEffectAnalysis *SEA,
                        WriteSet &MayWrites, ApplyInst *AI) {
-  SideEffectAnalysis::FunctionEffects E;
-  SEA->getEffects(E, AI);
+  FunctionSideEffects E;
+  SEA->getCalleeEffects(E, AI);
   assert(E.getMemBehavior(RetainObserveKind::IgnoreRetains) <=
          SILInstruction::MemoryBehavior::MayRead &&
          "apply should only read from memory");
@@ -495,8 +495,8 @@ void LoopTreeOptimization::analyzeCurrentLoop(
       if (auto *AI = dyn_cast<ApplyInst>(&Inst)) {
         // In contrast to load instructions, we first collect all read-only
         // function calls and add them later to SafeReads.
-        SideEffectAnalysis::FunctionEffects E;
-        SEA->getEffects(E, AI);
+        FunctionSideEffects E;
+        SEA->getCalleeEffects(E, AI);
 
         auto MB = E.getMemBehavior(RetainObserveKind::ObserveRetains);
         if (MB <= SILInstruction::MemoryBehavior::MayRead)

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -874,8 +874,8 @@ bool CSE::canHandle(SILInstruction *Inst) {
     
     // We can CSE function calls which do not read or write memory and don't
     // have any other side effects.
-    SideEffectAnalysis::FunctionEffects Effects;
-    SEA->getEffects(Effects, AI);
+    FunctionSideEffects Effects;
+    SEA->getCalleeEffects(Effects, AI);
 
     // Note that the function also may not contain any retains. And there are
     // functions which are read-none and have a retain, e.g. functions which

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -852,8 +852,8 @@ bool swift::isPureCall(FullApplySite AI, SideEffectAnalysis *SEA) {
   // If a call has only constant arguments and the call is pure, i.e. has
   // no side effects, then we should always inline it.
   // This includes arguments which are objects initialized with constant values.
-  SideEffectAnalysis::FunctionEffects ApplyEffects;
-  SEA->getEffects(ApplyEffects, AI);
+  FunctionSideEffects ApplyEffects;
+  SEA->getCalleeEffects(ApplyEffects, AI);
   auto GE = ApplyEffects.getGlobalEffects();
   if (GE.mayRead() || GE.mayWrite() || GE.mayRetain() || GE.mayRelease())
     return false;


### PR DESCRIPTION
Make this a generic analysis so that it can be used to analyze any
kind of function effect.

FunctionSideEffect becomes a trivial specialization of the analysis.

The immediate need for this is to introduce an new
AccessedStorageAnalysis, although I foresee it as a generally very
useful utility. This way, new kinds of function effects can be
computed without adding any complexity or compile time to
FunctionSideEffects. We have the flexibility of computing different
kinds of function effects at different points in the pipeline.

In the case of AccessedStorageAnalysis, it will compute both
FunctionSideEffects and FunctionAccessedStorage in the same pass by
implementing a simple wrapper on top of FunctionEffects.

This cleanup reflects my feeling that nested classes make the code
extremely unreadable unless they are very small and either private or
only used directly via its parent class. It's easier to see how these
classes compose with a flat type system.

In addition to enabling new kinds of function effects analyses, I
think this makes the implementation of side effect analysis easier to
understand by separating concerns.