### PR TITLE
Fix code example in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Swift 5.0
   class Node {
     var children = [Node]()
 
-    var depth: Int {
+    var depth: Int = 0 {
       didSet {
         if depth < 0 {
           // Will not recursively call didSet, as setting depth on self (same
@@ -48,10 +48,6 @@ Swift 5.0
           child.depth = depth + 1
         }
       }
-    }
-
-    init(depth: Int) {
-      self.depth = depth
     }
   }
   ```


### PR DESCRIPTION
The code example for recursive `didSet` updates implies that `didSet` will be called when the property is updated within `init`, but that's not the case. I believe this is misleading.
