### PR TITLE
Revert "Mandatory SIL linker pass"

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -226,10 +226,6 @@ PASS(LateReleaseHoisting, "late-release-hoisting",
      "Late SIL release Hoisting Preserving Epilogues")
 IRGEN_PASS(LoadableByAddress, "loadable-address",
      "SIL Large Loadable type by-address lowering.")
-PASS(MandatorySILLinker, "mandatory-linker",
-     "Deserialize all referenced SIL functions that are shared or transparent")
-PASS(PerformanceSILLinker, "performance-linker",
-     "Deserialize all referenced SIL functions")
 PASS(RemovePins, "remove-pins",
      "Remove SIL pin/unpin pairs")
 PASS(TempRValueOpt, "temp-rvalue-opt",
@@ -242,6 +238,8 @@ PASS(SILCombine, "sil-combine",
      "Combine SIL Instructions via Peephole Optimization")
 PASS(SILDebugInfoGenerator, "sil-debuginfo-gen",
      "Generate Debug Information with Source Locations into Textual SIL")
+PASS(SILLinker, "linker",
+     "Link all SIL Referenced within the Module via Deserialization")
 PASS(SROA, "sroa",
      "Scalar Replacement of Aggregate Stack Objects")
 PASS(SROABBArgs, "sroa-bb-args",

--- a/lib/SIL/Linker.cpp
+++ b/lib/SIL/Linker.cpp
@@ -55,21 +55,7 @@ void SILLinkerVisitor::maybeAddFunctionToWorklist(SILFunction *F) {
   if (!F->isExternalDeclaration())
     return;
 
-  // In the performance pipeline, we deserialize all reachable functions.
-  if (isLinkAll())
-    return addFunctionToWorklist(F);
-
-  // Otherwise, make sure to deserialize shared functions; we need to
-  // emit them into the client binary since they're not available
-  // externally.
-  if (hasSharedVisibility(F->getLinkage()))
-    return addFunctionToWorklist(F);
-
-  // Functions with PublicNonABI linkage are deserialized as having
-  // HiddenExternal linkage when they are declarations, then they
-  // become SharedExternal after the body has been deserialized.
-  // So try deserializing HiddenExternal functions too.
-  if (F->getLinkage() == SILLinkage::HiddenExternal)
+  if (isLinkAll() || hasSharedVisibility(F->getLinkage()))
     return addFunctionToWorklist(F);
 }
 

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -90,7 +90,6 @@ static void addMandatoryOptPipeline(SILPassPipelinePlan &P,
   P.addDefiniteInitialization();
   P.addOwnershipModelEliminator();
   P.addMandatoryInlining();
-  P.addMandatorySILLinker();
   P.addPredictableMemoryOptimizations();
 
   // Diagnostic ConstantPropagation must be rerun on deserialized functions
@@ -315,7 +314,7 @@ void addSSAPasses(SILPassPipelinePlan &P, OptimizationLevelKind OpLevel) {
 
 static void addPerfDebugSerializationPipeline(SILPassPipelinePlan &P) {
   P.startPipeline("Performance Debug Serialization");
-  P.addPerformanceSILLinker();
+  P.addSILLinker();
 }
 
 static void addPerfEarlyModulePassPipeline(SILPassPipelinePlan &P) {
@@ -325,7 +324,7 @@ static void addPerfEarlyModulePassPipeline(SILPassPipelinePlan &P) {
   // we do not spend time optimizing them.
   P.addDeadFunctionElimination();
   // Start by cloning functions from stdlib.
-  P.addPerformanceSILLinker();
+  P.addSILLinker();
 
   // Cleanup after SILGen: remove trivial copies to temporaries.
   P.addTempRValueOpt();
@@ -345,7 +344,7 @@ static void addHighLevelEarlyLoopOptPipeline(SILPassPipelinePlan &P) {
 static void addMidModulePassesStackPromotePassPipeline(SILPassPipelinePlan &P) {
   P.startPipeline("MidModulePasses+StackPromote");
   P.addDeadFunctionElimination();
-  P.addPerformanceSILLinker();
+  P.addSILLinker();
   P.addDeadObjectElimination();
   P.addGlobalPropertyOpt();
 

--- a/lib/SILOptimizer/UtilityPasses/Link.cpp
+++ b/lib/SILOptimizer/UtilityPasses/Link.cpp
@@ -25,15 +25,11 @@ namespace {
 /// Copies code from the standard library into the user program to enable
 /// optimizations.
 class SILLinker : public SILModuleTransform {
-  SILModule::LinkingMode LinkMode;
-
-public:
-  explicit SILLinker(SILModule::LinkingMode LinkMode) : LinkMode(LinkMode) {}
 
   void run() override {
     SILModule &M = *getModule();
     for (auto &Fn : M)
-      if (M.linkFunction(&Fn, LinkMode))
+      if (M.linkFunction(&Fn, SILModule::LinkingMode::LinkAll))
         invalidateAnalysis(&Fn, SILAnalysis::InvalidationKind::Everything);
   }
 
@@ -41,10 +37,6 @@ public:
 } // end anonymous namespace
 
 
-SILTransform *swift::createMandatorySILLinker() {
-  return new SILLinker(SILModule::LinkingMode::LinkNormal);
-}
-
-SILTransform *swift::createPerformanceSILLinker() {
-  return new SILLinker(SILModule::LinkingMode::LinkAll);
+SILTransform *swift::createSILLinker() {
+  return new SILLinker();
 }

--- a/test/SIL/Serialization/deserialize_generic.sil
+++ b/test/SIL/Serialization/deserialize_generic.sil
@@ -1,7 +1,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_generic.swift
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -performance-linker -I %t %s | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -linker -I %t %s | %FileCheck %s
 
 // Make sure that SILFunctionType with GenericSignature can match up with
 // SILFunctionType deserialized from module.

--- a/test/SIL/Serialization/deserialize_generic_marker.sil
+++ b/test/SIL/Serialization/deserialize_generic_marker.sil
@@ -1,7 +1,7 @@
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_generic_marker.swift
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -performance-linker -I %t %s | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -linker -I %t %s | %FileCheck %s
 
 // Make sure that SILFunctionType with GenericSignature can match up with
 // SILFunctionType deserialized from module.

--- a/test/SIL/Serialization/function_param_convention.sil
+++ b/test/SIL/Serialization/function_param_convention.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -parse-sil -sil-inline-threshold 0 %S/Inputs/function_param_convention_input.sil -o %t/FunctionInput.swiftmodule -emit-module -parse-as-library -parse-stdlib -module-name FunctionInput -O
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -I %t -performance-linker %s -o - | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -I %t -linker %s -o - | %FileCheck %s
 
 import Swift
 import FunctionInput

--- a/test/SIL/Serialization/public_non_abi.sil
+++ b/test/SIL/Serialization/public_non_abi.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/def_public_non_abi.sil
-// RUN: %target-sil-opt -performance-linker -I %t %s | %FileCheck %s
+// RUN: %target-sil-opt -linker -I %t %s | %FileCheck %s
 
 sil_stage raw
 

--- a/test/SIL/Serialization/shared_function_serialization.sil
+++ b/test/SIL/Serialization/shared_function_serialization.sil
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend %S/Inputs/shared_function_serialization_input.swift -o %t/Swift.swiftmodule -emit-module -parse-as-library -parse-stdlib -module-link-name swiftCore -module-name Swift -O
-// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -I %t -performance-linker -inline %s -o - | %FileCheck %s
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -I %t -linker -inline %s -o - | %FileCheck %s
 
 // CHECK: sil private @top_level_code
 // CHECK: sil public_external [serialized] @$Ss1XVABycfC{{.*}}

--- a/test/SIL/Serialization/vtable_deserialization.swift
+++ b/test/SIL/Serialization/vtable_deserialization.swift
@@ -19,11 +19,10 @@ Class.firstMethod()
 // The other two methods should not be deserialized in the mandatory
 // pipeline.
 
-// FIXME: Temporary regression
-// CHECK-LABEL: sil public_external [serialized] @$S28vtable_deserialization_input5ClassC12secondMethodyyFZ : $@convention(method) (@thick Class.Type) -> () {
+// CHECK-LABEL: sil [serialized] @$S28vtable_deserialization_input5ClassC12secondMethodyyFZ : $@convention(method) (@thick Class.Type) -> (){{$}}
 // OPT-LABEL: sil public_external @$S28vtable_deserialization_input5ClassC12secondMethodyyFZ : $@convention(method) (@thick Class.Type) -> () {
 
-// CHECK-LABEL: sil public_external [serialized] @$S28vtable_deserialization_input5ClassC11thirdMethodyyFZ : $@convention(method) (@thick Class.Type) -> () {
+// CHECK-LABEL: sil [serialized] @$S28vtable_deserialization_input5ClassC11thirdMethodyyFZ : $@convention(method) (@thick Class.Type) -> (){{$}}
 // OPT-LABEL: sil public_external @$S28vtable_deserialization_input5ClassC11thirdMethodyyFZ : $@convention(method) (@thick Class.Type) -> () {
 
 // Make sure we deserialized the vtable.


### PR DESCRIPTION
Reverts apple/swift#15930

PR 15930 was only smoke tested. It's been blocking full PR testing.

SIL verification failed: external declarations of SILFunctions with shared visibility is not allowed: SingleFunction || !hasSharedVisibility(RefF->getLinkage()) || RefF->hasForeignBody()

Verifying instruction:
->   // function_ref specialized FixedWidthInteger.init<A>(truncatingIfNeeded:)
  %928 = function_ref @$Ss17FixedWidthIntegerPsE18truncatingIfNeededxqd___tcs06BinaryC0Rd__lufCqd__s6UInt64VXMTA2FRszsADRd__r__lIetMiyd_Tpq5 : $@convention(method) <τ_0_0 where τ_0_0 == UInt64><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick UInt64.Type) -> UInt64 // user: %929
  %929 = apply %928<Int>(%926, %29) : $@convention(method) <τ_0_0 where τ_0_0 == UInt64><τ_1_0 where τ_1_0 : BinaryInteger> (@in τ_1_0, @thick UInt64.Type) -> UInt64 // user: %930

In function:
// globalinit_33_F417D752D2C4E9330E1C700411CE0C6A_func15
sil private @globalinit_33_F417D752D2C4E9330E1C700411CE0C6A_func15 : $@convention(c) () -> () 

Building Dispatch for WatchSimulator.