### PR TITLE
[TypeChecker] Extend test-case for rdar://problem/39401774

### DIFF
--- a/test/Constraints/rdar39401774.swift
+++ b/test/Constraints/rdar39401774.swift
@@ -1,20 +1,26 @@
 // RUN: %target-typecheck-verify-swift
 
-class A {
-  var foo: Int? { return 42 } // expected-note {{found this candidate}}
+class A<T> {
+  var foo: Int? { return 42 }      // expected-note {{found this candidate}}
+  func baz() -> T { fatalError() } // expected-note {{found this candidate}}
+  func fiz() -> Int { return 42 }  // expected-note {{found this candidate}}
 }
 
 protocol P1 {
+  associatedtype T
   var foo: Int? { get } // expected-note {{found this candidate}}
+  func baz() -> T       // expected-note {{found this candidate}}
+  func fiz() -> Int     // expected-note {{found this candidate}}
 }
 
 protocol P2 : P1 {
   var bar: Int? { get }
 }
 
-extension P2 where Self: A {
+extension P2 where Self: A<Int> {
   var bar: Int? {
     guard let foo = foo else { return 0 } // expected-error {{ambiguous use of 'foo'}}
-    return foo
+    let _ = baz() // expected-error {{ambiguous use of 'baz()'}}
+    return fiz()  // expected-error {{ambiguous use of 'fiz()'}}
   }
 }


### PR DESCRIPTION
Add generic and non-generic method resolution ambiguities.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
