### PR TITLE
[WIP][CSRanking] Extend specialization check to include declarations in pr…

### DIFF
--- a/test/Constraints/rdar33142387.swift
+++ b/test/Constraints/rdar33142387.swift
@@ -1,0 +1,37 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
+
+infix operator +++ : AdditionPrecedence
+protocol P {
+  associatedtype T
+  static func +++(lhs: Self, rhs: Self) -> Self
+}
+
+extension P {
+  static func +++(lhs: Self, rhs: Self) -> Self {
+    print("<default>")
+    return lhs
+  }
+}
+
+extension P where T == Int {
+  static func +++(lhs: Self, rhs: Self) -> Self {
+    print("<int>")
+    return rhs
+  }
+}
+
+struct A<U> : P {
+  typealias T = U
+}
+
+struct B : P {
+  typealias T = Int
+}
+
+var a = A<Int>()
+// CHECK: apply %21<A<Int>>(%8, %14, %19, %10) : $@convention(method) <τ_0_0 where τ_0_0 : P, τ_0_0.T == Int> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0
+let _ = a +++ a
+
+var b = B()
+// CHECK: apply %46<B>(%33, %39, %44, %35) : $@convention(method) <τ_0_0 where τ_0_0 : P, τ_0_0.T == Int> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @thick τ_0_0.Type) -> @out τ_0_0
+let _ = b +++ b

--- a/test/Constraints/rdar39401774.swift
+++ b/test/Constraints/rdar39401774.swift
@@ -1,16 +1,16 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
 
 class A<T> {
-  var foo: Int? { return 42 }      // expected-note {{found this candidate}}
-  func baz() -> T { fatalError() } // expected-note {{found this candidate}}
-  func fiz() -> Int { return 42 }  // expected-note {{found this candidate}}
+  var foo: Int? { return 42 }
+  func baz() -> T { fatalError() }
+  func fiz() -> Int { return 42 }
 }
 
 protocol P1 {
   associatedtype T
-  var foo: Int? { get } // expected-note {{found this candidate}}
-  func baz() -> T       // expected-note {{found this candidate}}
-  func fiz() -> Int     // expected-note {{found this candidate}}
+  var foo: Int? { get }
+  func baz() -> T
+  func fiz() -> Int
 }
 
 protocol P2 : P1 {
@@ -19,8 +19,14 @@ protocol P2 : P1 {
 
 extension P2 where Self: A<Int> {
   var bar: Int? {
-    guard let foo = foo else { return 0 } // expected-error {{ambiguous use of 'foo'}}
-    let _ = baz() // expected-error {{ambiguous use of 'baz()'}}
-    return fiz()  // expected-error {{ambiguous use of 'fiz()'}}
+    // CHECK: %3 = upcast %0 : $Self to $A<Int>
+    // CHECK-NEXT: class_method %3 : $A<Int>, #A.foo!getter.1 : <T> (A<T>) -> () -> Int?
+    guard let foo = foo else { return 0 } // expected-warning {{value 'foo' was defined but never used}}
+    // CHECK: %15 = upcast %0 : $Self to $A<Int>
+    // CHECK-NEXT: class_method %15 : $A<Int>, #A.baz!1 : <T> (A<T>) -> () -> T
+    let _ = baz()
+    // CHECK: %22 = upcast %0 : $Self to $A<Int>
+    // CHECK-NEXT: class_method %22 : $A<Int>, #A.fiz!1 : <T> (A<T>) -> () -> Int
+    return fiz()
   }
 }


### PR DESCRIPTION
…otocols

Extend special handling of overloads declared in protocol extensions to
also consider the ones declarated directly in protocols to make sure
that we always correctly prefer declarations in concrete types vs.
protocols and their extensions, and declarations in more specialized
extensions over ones declared in protocols.

Rules are as follows:

- If both overloads are declared in protocol or protocol extension context:
  * If declarations belong to different protocols, the one lower in inheritance
    chain wins, otherwise wins the one declared directly on the protocol.
  * If declarations belong to the same protocol and generic signatures match
    wins declaration from the protocol, otherwise wins the more special one
    which is determined by checking requirements from one using `Self` type
    from other declaration.
- If only one overload comes from protocol or protocol extension context
  always wins the one delarated one the concrete type.

Resolves: rdar://problem/33142387
Resolves: rdar://problem/39424937

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
