### PR TITLE
Skip invalid declarations in SourceLookupCache

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -190,6 +190,12 @@ void SourceLookupCache::doPopulateCache(Range decls,
       }
     if (auto *NTD = dyn_cast<NominalTypeDecl>(D))
       doPopulateCache(NTD->getMembers(), true);
+
+    // Avoid populating the cache with the members of invalid extension
+    // declarations.  These members can be used to point validation inside of
+    // a malformed context.
+    if (D->isInvalid()) continue;
+
     if (auto *ED = dyn_cast<ExtensionDecl>(D))
       doPopulateCache(ED->getMembers(), true);
   }

--- a/validation-test/compiler_crashers_fixed/28598-issatisfied-request.swift
+++ b/validation-test/compiler_crashers_fixed/28598-issatisfied-request.swift
@@ -5,8 +5,8 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// RUN: not --crash %target-swift-frontend %s -emit-ir
-// REQUIRES: asserts
+// RUN: not %target-swift-frontend %s -emit-ir
+
 class a{
 let d= <H
 class B{extension{protocol A{{

--- a/validation-test/compiler_crashers_fixed/28778-hasaccessibility-accessibility-not-computed-yet.swift
+++ b/validation-test/compiler_crashers_fixed/28778-hasaccessibility-accessibility-not-computed-yet.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+
+// RUN: not %target-swift-frontend %s -emit-ir
 extension{let d=r protocol A{{}extension{func<(Int=


### PR DESCRIPTION
Crashers 28598 and 28778 are creating invalid validation requests for the ITC
by using unqualified lookup to get the validator to jump inside of a
transitively invalid DeclContext.

Just don't load these members.

@swift-ci please smoke test