### PR TITLE
[stringref-upgrade] Return a StringRef from suffixForPrincipalOutputF…

### DIFF
--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -296,7 +296,7 @@ public:
   static bool doesActionProduceOutput(ActionType);
   static bool doesActionProduceTextualOutput(ActionType);
   static bool needsProperModuleName(ActionType);
-  static const char *suffixForPrincipalOutputFileForAction(ActionType);
+  static StringRef suffixForPrincipalOutputFileForAction(ActionType);
 };
 
 }

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -127,11 +127,11 @@ void FrontendOptions::forAllOutputPaths(
   }
 }
 
-const char *
+StringRef
 FrontendOptions::suffixForPrincipalOutputFileForAction(ActionType action) {
   switch (action) {
   case ActionType::NoneAction:
-    return nullptr;
+    return StringRef();
 
   case ActionType::Parse:
   case ActionType::Typecheck:
@@ -142,7 +142,7 @@ FrontendOptions::suffixForPrincipalOutputFileForAction(ActionType action) {
   case ActionType::PrintAST:
   case ActionType::DumpScopeMaps:
   case ActionType::DumpTypeRefinementContexts:
-    return nullptr;
+    return StringRef();
 
   case ActionType::EmitPCH:
     return PCH_EXTENSION;
@@ -162,7 +162,7 @@ FrontendOptions::suffixForPrincipalOutputFileForAction(ActionType action) {
   case ActionType::Immediate:
   case ActionType::REPL:
     // These modes have no frontend-generated output.
-    return nullptr;
+    return StringRef();
 
   case ActionType::EmitAssembly:
     return "s";


### PR DESCRIPTION
…ileForAction instead of a const char *.

This is in prepration for changing Strings.h to use StringLiteral.
