### PR TITLE
[stringref-upgrade] Change FrontendInputsAndOutputs::numberOfPrimaryI…

### DIFF
--- a/include/swift/Frontend/FrontendInputsAndOutputs.h
+++ b/include/swift/Frontend/FrontendInputsAndOutputs.h
@@ -139,7 +139,7 @@ public:
 
   bool isInputPrimary(StringRef file) const;
 
-  unsigned numberOfPrimaryInputsEndingWith(const char *extension) const;
+  unsigned numberOfPrimaryInputsEndingWith(StringRef extension) const;
 
   // Multi-facet readers
 

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -134,7 +134,7 @@ bool FrontendInputsAndOutputs::isInputPrimary(StringRef file) const {
 }
 
 unsigned FrontendInputsAndOutputs::numberOfPrimaryInputsEndingWith(
-    const char *extension) const {
+    StringRef extension) const {
   unsigned n = 0;
   (void)forEachPrimaryInput([&](const InputFile &input) -> bool {
     if (llvm::sys::path::extension(input.file()).endswith(extension))


### PR DESCRIPTION
…nputsEndingWith to take a StringRef instead of a const char *.

This is in prepration for changing Strings.h to use StringLiteral.
