### PR TITLE
[stringref-upgrade] Inject llvm::StringLiteral into the Swift namespa…

### DIFF
--- a/include/swift/Basic/LLVM.h
+++ b/include/swift/Basic/LLVM.h
@@ -30,6 +30,7 @@
 namespace llvm {
   // Containers.
   class StringRef;
+  class StringLiteral;
   class Twine;
   template <typename T> class SmallPtrSetImpl;
   template <typename T, unsigned N> class SmallPtrSet;
@@ -64,6 +65,7 @@ namespace swift {
   using llvm::SmallPtrSet;
   using llvm::SmallString;
   using llvm::StringRef;
+  using llvm::StringLiteral;
   using llvm::Twine;
   using llvm::SmallVectorImpl;
   using llvm::SmallVector;


### PR DESCRIPTION
…ce like we have done with StringRef.

StringLiteral is a subclass of StringRef that is intended to be used for global
constant strings in a constexpr context.

I am going to be refactoring some uses of const char foo[] = ""; to use this
instead.