### PR TITLE
migrator: teach the tool to handle OptionalDictionaryKeyUpdate attributes emitted from swift-api-digester.

### DIFF
--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -719,7 +719,9 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     case NodeAnnotation::OptionalDictionaryKeyUpdate:
       Segs = {"Optional", "Dictionary", "[String: Any]?"};
       Segs.push_back((Twine("[") + NewType +": Any]?").str());
-      Segs.push_back("// Not implemented");
+      Segs.push_back((Twine("\tguard let input = input else { return nil }\n"
+                            "\treturn Dictionary(uniqueKeysWithValues: input.map"
+        " { key, value in (") + NewType + "(rawValue: key), value)})").str());
       break;
     case NodeAnnotation::ArrayMemberUpdate:
       Segs = {"", "Array", "[String]"};

--- a/test/Migrator/Inputs/Cities.swift
+++ b/test/Migrator/Inputs/Cities.swift
@@ -38,4 +38,6 @@ public class Container {
   public var Value: String = ""
   public func addingAttributes(_ input: [String: Any]) {}
   public func adding(attributes: [String: Any]) {}
+  public func adding(optionalAttributes: [String: Any]?) {}
+  public init(optionalAttributes: [String: Any]?) {}
 }

--- a/test/Migrator/Inputs/string-representable.json
+++ b/test/Migrator/Inputs/string-representable.json
@@ -32,4 +32,26 @@
     "RightComment": "SimpleAttribute",
     "ModuleName": "Cities"
   },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "OptionalDictionaryKeyUpdate",
+    "ChildIndex": "1",
+    "LeftUsr": "s:6Cities9ContainerC6adding18optionalAttributesys10DictionaryVySSypGSg_tF",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "SimpleAttribute",
+    "ModuleName": "Cities"
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Constructor",
+    "NodeAnnotation": "OptionalDictionaryKeyUpdate",
+    "ChildIndex": "1",
+    "LeftUsr": "s:6Cities9ContainerC18optionalAttributesACs10DictionaryVySSypGSg_tcfc",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "SimpleAttribute",
+    "ModuleName": "Cities"
+  },
 ]

--- a/test/Migrator/string-representable.swift
+++ b/test/Migrator/string-representable.swift
@@ -11,5 +11,7 @@ func foo(_ c: Container) -> String {
   c.addingAttributes(["a": "b", "a": "b", "a": "b"])
   c.addingAttributes(["a": "b", "a": "b", "a": "b"])
   c.adding(attributes: ["a": 1, "a": 2, "a": 3])
+  c.adding(optionalAttributes: ["a": 1, "a": 2, "a": 3])
+  _ = Container(optionalAttributes: nil)
   return c.Value
 }

--- a/test/Migrator/string-representable.swift.expected
+++ b/test/Migrator/string-representable.swift.expected
@@ -11,6 +11,8 @@ func foo(_ c: Container) -> String {
   c.addingAttributes(converToCitiesContainerAttributeDictionary(["a": "b", "a": "b", "a": "b"]))
   c.addingAttributes(converToCitiesContainerAttributeDictionary(["a": "b", "a": "b", "a": "b"]))
   c.adding(attributes: converToSimpleAttributeDictionary(["a": 1, "a": 2, "a": 3]))
+  c.adding(optionalAttributes: converToOptionalSimpleAttributeDictionary(["a": 1, "a": 2, "a": 3]))
+  _ = Container(optionalAttributes: converToOptionalSimpleAttributeDictionary(nil))
   return c.Value.rawValue
 }
 
@@ -21,5 +23,11 @@ fileprivate func converToCitiesContainerAttributeDictionary(_ input: [String: An
 
 // Helper function inserted by Swift 4.2 migrator.
 fileprivate func converToSimpleAttributeDictionary(_ input: [String: Any]) -> [SimpleAttribute: Any] {
+	return Dictionary(uniqueKeysWithValues: input.map { key, value in (SimpleAttribute(rawValue: key), value)})
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func converToOptionalSimpleAttributeDictionary(_ input: [String: Any]?) -> [SimpleAttribute: Any]? {
+	guard let input = input else { return nil }
 	return Dictionary(uniqueKeysWithValues: input.map { key, value in (SimpleAttribute(rawValue: key), value)})
 }


### PR DESCRIPTION
For a function call used to take [String: Any]? as argument and now
takes [StringRepresentableStruct: Any]?, a helper function is inserted
to help the bridging of types.