### PR TITLE
migrator: teach the tool to handle ArrayMemberUpdate and OptionalArrayMemberUpdate attributes emitted from swift-api-digester.

### DIFF
--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -708,7 +708,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     OS << "// Helper function inserted by Swift 4.2 migrator.\n";
     OS << "fileprivate func ";
     unsigned FuncNameStart = Buffer.size();
-    OS << "converTo";
+    OS << "convertTo";
     SmallVector<std::string, 8> Segs;
     switch(Anno) {
     case NodeAnnotation::OptionalArrayMemberUpdate:

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -714,7 +714,8 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     case NodeAnnotation::OptionalArrayMemberUpdate:
       Segs = {"Optional", "Array", "[String]?"};
       Segs.push_back((Twine("[") + NewType +"]?").str());
-      Segs.push_back("// Not implemented");
+      Segs.push_back(Twine("\tguard let input = input else { return nil }\n"
+                           "\treturn input.map { key in " + NewType +"(key) }").str());
       break;
     case NodeAnnotation::OptionalDictionaryKeyUpdate:
       Segs = {"Optional", "Dictionary", "[String: Any]?"};
@@ -726,7 +727,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     case NodeAnnotation::ArrayMemberUpdate:
       Segs = {"", "Array", "[String]"};
       Segs.push_back((Twine("[") + NewType +"]").str());
-      Segs.push_back("// Not implemented");
+      Segs.push_back(Twine("\treturn input.map { key in " + NewType +"(key) }").str());
       break;
     case NodeAnnotation::DictionaryKeyUpdate:
       Segs = {"", "Dictionary", "[String: Any]"};
@@ -778,17 +779,21 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
         }
       }
     }
-    if (NewAttributeType.empty() || !ArgIdx)
+    if (NewAttributeType.empty())
       return;
-    ArgIdx --;
-    auto AllArgs = getCallArgInfo(SM, Arg, LabelRangeEndAt::LabelNameOnly);
-    if (AllArgs.size() <= ArgIdx)
-      return;
-    SmallString<256> Buffer;
-    auto FuncName = insertHelperFunction(Kind, NewAttributeType, Buffer);
-    auto Exp = AllArgs[ArgIdx].ArgExp;
-    Editor.insert(Exp->getStartLoc(), (Twine(FuncName) + "(").str());
-    Editor.insertAfterToken(Exp->getEndLoc(), ")");
+    if (ArgIdx) {
+      ArgIdx --;
+      auto AllArgs = getCallArgInfo(SM, Arg, LabelRangeEndAt::LabelNameOnly);
+      if (AllArgs.size() <= ArgIdx)
+        return;
+      SmallString<256> Buffer;
+      auto FuncName = insertHelperFunction(Kind, NewAttributeType, Buffer);
+      auto Exp = AllArgs[ArgIdx].ArgExp;
+      Editor.insert(Exp->getStartLoc(), (Twine(FuncName) + "(").str());
+      Editor.insertAfterToken(Exp->getEndLoc(), ")");
+    } else {
+      // FIXME: return value migration.
+    }
   }
 
   bool walkToExprPre(Expr *E) override {

--- a/test/Migrator/Inputs/Cities.swift
+++ b/test/Migrator/Inputs/Cities.swift
@@ -40,4 +40,6 @@ public class Container {
   public func adding(attributes: [String: Any]) {}
   public func adding(optionalAttributes: [String: Any]?) {}
   public init(optionalAttributes: [String: Any]?) {}
+  public func adding(attrArray: [String]) {}
+  public init(optionalAttrArray: [String]?) {}
 }

--- a/test/Migrator/Inputs/string-representable.json
+++ b/test/Migrator/Inputs/string-representable.json
@@ -54,4 +54,26 @@
     "RightComment": "SimpleAttribute",
     "ModuleName": "Cities"
   },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "ArrayMemberUpdate",
+    "ChildIndex": "1",
+    "LeftUsr": "s:6Cities9ContainerC6adding9attrArrayySaySSG_tF",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "SimpleAttribute",
+    "ModuleName": "Cities"
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "OptionalArrayMemberUpdate",
+    "ChildIndex": "1",
+    "LeftUsr": "s:6Cities9ContainerC17optionalAttrArrayACSaySSGSg_tcfc",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "SimpleAttribute",
+    "ModuleName": "Cities"
+  },
 ]

--- a/test/Migrator/string-representable.swift
+++ b/test/Migrator/string-representable.swift
@@ -13,5 +13,7 @@ func foo(_ c: Container) -> String {
   c.adding(attributes: ["a": 1, "a": 2, "a": 3])
   c.adding(optionalAttributes: ["a": 1, "a": 2, "a": 3])
   _ = Container(optionalAttributes: nil)
+  _ = Container(optionalAttrArray: nil)
+  c.adding(attrArray: ["key1", "key2"])
   return c.Value
 }

--- a/test/Migrator/string-representable.swift.expected
+++ b/test/Migrator/string-representable.swift.expected
@@ -13,6 +13,8 @@ func foo(_ c: Container) -> String {
   c.adding(attributes: converToSimpleAttributeDictionary(["a": 1, "a": 2, "a": 3]))
   c.adding(optionalAttributes: converToOptionalSimpleAttributeDictionary(["a": 1, "a": 2, "a": 3]))
   _ = Container(optionalAttributes: converToOptionalSimpleAttributeDictionary(nil))
+  _ = Container(optionalAttrArray: converToOptionalSimpleAttributeArray(nil))
+  c.adding(attrArray: converToSimpleAttributeArray(["key1", "key2"]))
   return c.Value.rawValue
 }
 
@@ -30,4 +32,15 @@ fileprivate func converToSimpleAttributeDictionary(_ input: [String: Any]) -> [S
 fileprivate func converToOptionalSimpleAttributeDictionary(_ input: [String: Any]?) -> [SimpleAttribute: Any]? {
 	guard let input = input else { return nil }
 	return Dictionary(uniqueKeysWithValues: input.map { key, value in (SimpleAttribute(rawValue: key), value)})
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func converToOptionalSimpleAttributeArray(_ input: [String]?) -> [SimpleAttribute]? {
+	guard let input = input else { return nil }
+	return input.map { key in SimpleAttribute(key) }
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func converToSimpleAttributeArray(_ input: [String]) -> [SimpleAttribute] {
+	return input.map { key in SimpleAttribute(key) }
 }

--- a/test/Migrator/string-representable.swift.expected
+++ b/test/Migrator/string-representable.swift.expected
@@ -8,39 +8,39 @@ import Cities
 
 func foo(_ c: Container) -> String {
   c.Value = NewAttribute(rawValue: "")
-  c.addingAttributes(converToCitiesContainerAttributeDictionary(["a": "b", "a": "b", "a": "b"]))
-  c.addingAttributes(converToCitiesContainerAttributeDictionary(["a": "b", "a": "b", "a": "b"]))
-  c.adding(attributes: converToSimpleAttributeDictionary(["a": 1, "a": 2, "a": 3]))
-  c.adding(optionalAttributes: converToOptionalSimpleAttributeDictionary(["a": 1, "a": 2, "a": 3]))
-  _ = Container(optionalAttributes: converToOptionalSimpleAttributeDictionary(nil))
-  _ = Container(optionalAttrArray: converToOptionalSimpleAttributeArray(nil))
-  c.adding(attrArray: converToSimpleAttributeArray(["key1", "key2"]))
+  c.addingAttributes(convertToCitiesContainerAttributeDictionary(["a": "b", "a": "b", "a": "b"]))
+  c.addingAttributes(convertToCitiesContainerAttributeDictionary(["a": "b", "a": "b", "a": "b"]))
+  c.adding(attributes: convertToSimpleAttributeDictionary(["a": 1, "a": 2, "a": 3]))
+  c.adding(optionalAttributes: convertToOptionalSimpleAttributeDictionary(["a": 1, "a": 2, "a": 3]))
+  _ = Container(optionalAttributes: convertToOptionalSimpleAttributeDictionary(nil))
+  _ = Container(optionalAttrArray: convertToOptionalSimpleAttributeArray(nil))
+  c.adding(attrArray: convertToSimpleAttributeArray(["key1", "key2"]))
   return c.Value.rawValue
 }
 
 // Helper function inserted by Swift 4.2 migrator.
-fileprivate func converToCitiesContainerAttributeDictionary(_ input: [String: Any]) -> [Cities.Container.Attribute: Any] {
+fileprivate func convertToCitiesContainerAttributeDictionary(_ input: [String: Any]) -> [Cities.Container.Attribute: Any] {
 	return Dictionary(uniqueKeysWithValues: input.map { key, value in (Cities.Container.Attribute(rawValue: key), value)})
 }
 
 // Helper function inserted by Swift 4.2 migrator.
-fileprivate func converToSimpleAttributeDictionary(_ input: [String: Any]) -> [SimpleAttribute: Any] {
+fileprivate func convertToSimpleAttributeDictionary(_ input: [String: Any]) -> [SimpleAttribute: Any] {
 	return Dictionary(uniqueKeysWithValues: input.map { key, value in (SimpleAttribute(rawValue: key), value)})
 }
 
 // Helper function inserted by Swift 4.2 migrator.
-fileprivate func converToOptionalSimpleAttributeDictionary(_ input: [String: Any]?) -> [SimpleAttribute: Any]? {
+fileprivate func convertToOptionalSimpleAttributeDictionary(_ input: [String: Any]?) -> [SimpleAttribute: Any]? {
 	guard let input = input else { return nil }
 	return Dictionary(uniqueKeysWithValues: input.map { key, value in (SimpleAttribute(rawValue: key), value)})
 }
 
 // Helper function inserted by Swift 4.2 migrator.
-fileprivate func converToOptionalSimpleAttributeArray(_ input: [String]?) -> [SimpleAttribute]? {
+fileprivate func convertToOptionalSimpleAttributeArray(_ input: [String]?) -> [SimpleAttribute]? {
 	guard let input = input else { return nil }
 	return input.map { key in SimpleAttribute(key) }
 }
 
 // Helper function inserted by Swift 4.2 migrator.
-fileprivate func converToSimpleAttributeArray(_ input: [String]) -> [SimpleAttribute] {
+fileprivate func convertToSimpleAttributeArray(_ input: [String]) -> [SimpleAttribute] {
 	return input.map { key in SimpleAttribute(key) }
 }


### PR DESCRIPTION
This bridges the function call arguments that used to be of type [String] and
now become [StringRepresentableStruct].