### PR TITLE
Add .mailmap file to merge email addresses in git shortlog

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,134 @@
+Adrian-Constantin Popescu <epsilon.gamma@gmail.com> <adrian-constantin.popescu@outlook.com>
+Alex Blewitt <alblue@apple.com> <alex.blewitt@gmail.com>
+Alex Hoppen <alex@alexhoppen.de> <alex@ateamer.de>
+Alexis Beingessner <abeingessner@apple.com> <a.beingessner@gmail.com>
+Alper Çugun <github@alper.nl> <alper@users.noreply.github.com>
+Amr Aboelela <amraboelela@gmail.com> <amraboelela@users.noreply.github.com>
+Ankit Aggarwal <ankit_aggarwal@apple.com> <ankit.spd@gmail.com>
+Argyrios Kyrtzidis <kyrtzidis@apple.com> <akyrtzi@gmail.com>
+Arsen Gasparyan <to.arsen.gasparyan@gmail.com> <frootloops@users.noreply.github.com>
+Ben Cohen <ben_cohen@apple.com>
+Ben Cohen <ben_cohen@apple.com> <airspeedswift@users.noreply.github.com>
+Ben Cohen <ben_cohen@apple.com> <ben@airspeedvelocity.net>
+Ben Langmuir <blangmuir@apple.com> <ben.langmuir@gmail.com>
+Brent Royal-Gordon <brent@brentdax.com> <brent@architechies.com>
+Brian Croom <bcroom@apple.com> <brian.s.croom@gmail.com>
+Brian Gesiak <bgesiak@fb.com> <modocache@gmail.com>
+Bryan Chan <bryan.chan@ca.ibm.com> <bryanpkc@gmail.com>
+Calvin Hill <mr_j.c.h@hotmail.com> <return@users.noreply.github.com>
+Chris Bieneman <beanz@apple.com>
+Chris Bieneman <beanz@apple.com> <cbieneman@apple.com>
+Chris Lattner <clattner@nondot.org> <clattner@apple.com>
+Chris Lattner <clattner@nondot.org> <lattner@users.noreply.github.com>
+Chris Lattner <clattner@nondot.org> <sabre@iMac.local>
+Chris Williams <cwilliams@fitbit.com> <ultramiraculous@users.noreply.github.com>
+codester <sahil.profile@gmail.com> codestergit <sahil.profile@gmail.com>
+Dan Liew <dliew@apple.com> <36706441+danliew-apple@users.noreply.github.com>
+Daniel Duan <daniel@duan.org> <danmarner@gmail.com>
+Dante Broggi <34220985+Dante-Broggi@users.noreply.github.com>
+Dave <davesweeris@mac.com>
+Dave Abrahams <dabrahams@apple.com> <dave@boostpro.com>
+Dave Abrahams <dabrahams@apple.com> <dave@fripp.apple.com>
+Dave Abrahams <dabrahams@apple.com> <dave@Skree.local>
+Dave Abrahams <dabrahams@apple.com> <dave@Wingy.local>
+Dave Lee <davelee@lyft.com> <davelee.com@gmail.com>
+David Rönnqvist <david.ronnqvist@gmail.com> <david.ronnqvist@skype.net>
+David Zarzycki <dave@znu.io> <zarzycki@icloud.com>
+David Zarzycki <dave@znu.io> <zarzycki@mac.com>
+Davide Italiano <ditaliano@apple.com> <dcci@users.noreply.github.com>
+Davide Italiano <ditaliano@apple.com> <dccitaliano@gmail.com>
+Dmitri Gribenko <gribozavr@gmail.com> <dgribenko@apple.com>
+Doug Coleman <doug_coleman@apple.com> <doug.coleman@gmail.com>
+Enrico Granata <egranata@apple.com> <egranata@egranata.apple.com>
+Enrico Granata <egranata@apple.com> <granata.enrico@gmail.com>
+Erik Eckstein <eeckstein@apple.com> <eeckstein@apple.com>
+Erik Eckstein <eeckstein@apple.com> <eeckstein@rad-main.corp.apple.com>
+Erik Verbruggen <erik.verbruggen@me.com> <erikjv@users.noreply.github.com>
+Ewa Matejska <ematejska@apple.com> <ematejska@apple.com>
+Ewa Matejska <ematejska@apple.com> <ematejska@Ewas-MacBook-Pro.local>
+Ewa Matejska <ematejska@apple.com> <ewamatejska@Ewas-iMac.local>
+Florent Bruneau <florent.bruneau@intersec.com> <florent.bruneau_github@m4x.org>
+Francis Ricci <fjricci@fb.com> <francisjricci@gmail.com>
+GauravDS <er.gauravds@gmail.com> <gaurav.sharma@punchh.com>
+Graydon Hoare <ghoare@apple.com> <graydon@users.noreply.github.com>
+Greg Parker <gparker@apple.com> <gparker-github@sealiesoftware.com>
+Guillaume Lessard <dhtnstff@gmail.com> <glessard@users.noreply.github.com>
+Hamish <hamish2knight@gmail.com> <hamish2knight@gmail.com>
+Han Sangjin <tinysun@jssolution.co.kr> <tinysun.net@gmail.com>
+Harlan Haskins <harlan@apple.com> <harlan@harlanhaskins.com>
+Hitster GTD <hitstergtd@users.noreply.github.com> <hitstergtd@users.noreply.github.com>
+Huon Wilson <huon@apple.com> <dbau.pp+github@gmail.com>
+Ingmar Stein <IngmarStein@users.noreply.github.com>
+Itai Ferber <iferber@apple.com> <itai@itaiferber.net>
+Jacob Bandes-Storch <jacob@bandes-stor.ch> <jacob@bandes-storch.net>
+Jacob Mizraji <jmizraji@apple.com> <jacobmizraji@gmail.com>
+Janosch Hildebrand <jnosh@jnosh.com> <jnosh+git@jnosh.com>
+Janosch Hildebrand <jnosh@jnosh.com> <jnosh+github@jnosh.com>
+Javier Soto <jsbustos@twitch.tv> <javier.api@gmail.com>
+Javier Soto <jsbustos@twitch.tv> <javiers@twitter.com>
+Joe <joe@iachieved.it>
+Joe <joewillsher@icloud.com>
+joe DeCapo <joe@polka.cat>
+Joe Groff <jgroff@apple.com> <arcata@gmail.com>
+Joe Shajrawi <shajrawi@apple.com> <joeshajrawi@iMac-2.local>
+Joe Shajrawi <shajrawi@apple.com> <joeshajrawi@Joes-iMac-Pro.local>
+Johannes Weiß <johannesweiss@apple.com> <github@tux4u.de>
+John Regner <john@johnregner.com> <regnerjr@gmail.com>
+Karoy Lorentey <klorentey@apple.com> <karoly@lorentey.hu>
+Keith Smiley <k@keith.so> <keithbsmiley@gmail.com>
+Kevin Ballard <kevin@sb.org> <kevin.ballard@postmates.com>
+Kosuke Ogawa <ogawa_kousuke@aratana.jp> <koogawa.app@gmail.com>
+Kuba Mracek <mracek@apple.com> <jbrecka@apple.com>
+Luiz Fernando Silva <luizinho_mack@yahoo.com.br>
+Luqman Aden <luqman@apple.com> <luqman_aden@apple.com>
+Marcelo Fabri <me@marcelofabri.com> <marcelofabri@users.noreply.github.com>
+Mark Lacey <mark.lacey@apple.com> <rudkx@icloud.com>
+Mark Lacey <mark.lacey@apple.com> <rudkx@users.noreply.github.com>
+Matt Rajca <matt.rajca@me.com> <mattrajca@users.noreply.github.com>
+Max Moiseev <moiseev@apple.com> <maxim.moiseev@gmail.com>
+Max Moiseev <moiseev@apple.com> <moiseev@users.noreply.github.com>
+Maxwell Swadling <maxs@apple.com> <maxwellswadling@gmail.com>
+Maxwell Swadling <maxs@apple.com> <mswadling@apple.com>
+Mayur Raiturkar <mayur@mayur.xyz> <mayurkr@users.noreply.github.com>
+Michael Gottesman <mgottesman@apple.com> <gottesmm@users.noreply.github.com>
+Michael Ilseman <milseman@apple.com> <michael.ilseman@gmail.com>
+Mike Ash <mikeash@apple.com> <mike@mikeash.com>
+Mike Ferris <mferris@apple.com> <mike@lorax.com>
+Mishal Awadah <mawadah@apple.com>
+Mishal Shah <mishal_shah@apple.com> <shahmishal@users.noreply.github.com>
+Nadav Rotem <nrotem@apple.com> <nadavrot@users.noreply.github.com>
+Nate Cook <natecook@apple.com> <nate@Nates-MacBook-Pro.local>
+Nate Cook <natecook@apple.com> <natecook@gmail.com>
+Nate Cook <natecook@apple.com> <natecook1000@users.noreply.github.com>
+Nate Cook <natecook@apple.com> <nmersethcook@apple.com>
+Nathan Lanza <lanza@fb.com> <nathan@lanza.io>
+Nicole Jacque <jacque@apple.com>
+Niels Andriesse <andriesseniels@gmail.com> <nielsandriesse@users.noreply.github.com>
+Paul Meng <mno2@mno2.org> <mno2.csie@gmail.com>
+Pavel Yaskevich <pyaskevich@apple.com> <xedin@apache.org>
+Paweł Szot <pszot@pgs-soft.com>
+Paweł Szot <pszot@pgs-soft.com> <qwertyszot@gmail.com>
+Pete Cooper <peter_cooper@apple.com>
+Philip Ridgeway <pridgeway@vernier.com> <philip.ridgeway@gmail.com>
+Richard Wei <rxwei@apple.com> <rxwei@google.com>
+Rintaro Ishizaki <rishizaki@apple.com> <fs.output@gmail.com>
+Robert Widmann <rwidmann@apple.com> <devteam.codafi@gmail.com>
+Roman Levenstein <rlevenstein@apple.com> <swiftix@users.noreply.github.com>
+Ross Bayer <ross.m.bayer@gmail.com> <Rostepher@users.noreply.github.com>
+Russ Bishop <rbishopjr@apple.com> <russ@plangrid.com>
+Ryan Lovelett <ryan@lovelett.me> <RLovelett@users.noreply.github.com>
+Shawn Erickson <shawn.erickson@citrix.com> <shawnce@gmail.com>
+Slava Pestov <spestov@apple.com> <spestov@rad-main.corp.apple.com>
+Slava Pestov <spestov@apple.com> <sviatoslav.pestov@gmail.com>
+Stephen Canon <scanon@apple.com>
+Stephen Canon <scanon@apple.com> <stephentyrone@gmail.com>
+Sukolsak Sakshuwong <sukolsak@gmail.com>
+Todd Fiala <tfiala@apple.com> <todd.fiala@gmail.com>
+Toni Suter <tonisuter@me.com> <tonisuter@users.noreply.github.com>
+Vedant Kumar <vsk@apple.com> <vk@vedantk.com>
+Xi Ge <xi_ge@apple.com> <xi_ge@rad-main.corp.apple.com>
+Xin Tong <xin_tong@apple.com> <trent.xin.tong@gmail.com>
+Xin Tong <xin_tong@apple.com> <trentxintong@Xins-MacBook-Pro.local>
+Yuka Ezura <ezura@users.noreply.github.com> <2020337+ezura@users.noreply.github.com>
+Yurii Samsoniuk <ura@google.com> <mr.sigito@gmail.com>
+Zac Bowling <zbowling@google.com> <zac@zacbowling.com>


### PR DESCRIPTION
This collapses different committer addresses into single users when running `git shortlog`, for the purpose of generating up-to-date lists of contributors. As seen on the forums: https://forums.swift.org/t/credit-where-credit-is-due/11783