### PR TITLE
 AST: Exclude noncanonical params from `GenericSignature::enumeratePairedRequirements`.

### DIFF
--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -345,17 +345,30 @@ bool GenericSignature::enumeratePairedRequirements(
   auto genericParams = getGenericParams();
   unsigned curGenericParamIdx = 0, numGenericParams = genericParams.size();
 
-  // Figure out which generic parameters are complete.
-  SmallVector<bool, 4> genericParamsAreConcrete(genericParams.size(), false);
+  // Figure out which generic parameters are concrete or same-typed to another
+  // generic parameter.
+  auto genericParamsAreNonCanonical =
+    SmallVector<bool, 4>(genericParams.size(), false);
   for (auto req : reqs) {
     if (req.getKind() != RequirementKind::SameType) continue;
-    if (req.getSecondType()->isTypeParameter()) continue;
-
-    auto gp = req.getFirstType()->getAs<GenericTypeParamType>();
-    if (!gp) continue;
+    
+    GenericTypeParamType *gp;
+    if (auto secondGP = req.getSecondType()->getAs<GenericTypeParamType>()) {
+      // If two generic parameters are same-typed, then the left-hand one
+      // is canonical.
+      gp = secondGP;
+    } else {
+      // If an associated type is same-typed, it doesn't constrain the generic
+      // parameter itself.
+      if (req.getSecondType()->isTypeParameter()) continue;
+      
+      // Otherwise, the generic parameter is concrete.
+      gp = req.getFirstType()->getAs<GenericTypeParamType>();
+      if (!gp) continue;
+    }
 
     unsigned index = GenericParamKey(gp).findIndexIn(genericParams);
-    genericParamsAreConcrete[index] = true;
+    genericParamsAreNonCanonical[index] = true;
   }
 
   /// Local function to 'catch up' to the next dependent type we're going to
@@ -382,7 +395,7 @@ bool GenericSignature::enumeratePairedRequirements(
       if (curGenericParam->getDepth() < stopDepth ||
           (curGenericParam->getDepth() == stopDepth &&
            curGenericParam->getIndex() < stopIndex)) {
-        if (!genericParamsAreConcrete[curGenericParamIdx] &&
+        if (!genericParamsAreNonCanonical[curGenericParamIdx] &&
             fn(curGenericParam, { }))
           return true;
 
@@ -441,7 +454,7 @@ bool GenericSignature::enumeratePairedRequirements(
     // parameter we can't skip, invoke the callback.
     if ((startIdx != endIdx ||
          (isa<GenericTypeParamType>(depTy) &&
-          !genericParamsAreConcrete[
+          !genericParamsAreNonCanonical[
             GenericParamKey(cast<GenericTypeParamType>(depTy))
               .findIndexIn(genericParams)])) &&
         fn(depTy, reqs.slice(startIdx, endIdx-startIdx)))
@@ -807,7 +820,7 @@ bool GenericSignature::isCanonicalTypeInContext(Type type) {
 }
 
 bool GenericSignature::isCanonicalTypeInContext(Type type,
-                                                GenericSignatureBuilder &builder) {
+                                             GenericSignatureBuilder &builder) {
   // If the type isn't independently canonical, it's certainly not canonical
   // in this context.
   if (!type->isCanonical())
@@ -835,7 +848,7 @@ bool GenericSignature::isCanonicalTypeInContext(Type type,
 }
 
 CanType GenericSignature::getCanonicalTypeInContext(Type type,
-                                                    GenericSignatureBuilder &builder) {
+                                             GenericSignatureBuilder &builder) {
   type = type->getCanonicalType();
 
   // All the contextual canonicality rules apply to type parameters, so if the

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1031,7 +1031,7 @@ swift::_getTypeByMangledName(StringRef typeName,
       // Call the associated type access function.
       // TODO: can we just request abstract metadata?  If so, do we have
       //   a responsibility to try to finish it later?
-      return ((const AssociatedTypeAccessFunction * const *)witnessTable)[*assocTypeReqIndex]
+      return ((AssociatedTypeAccessFunction * const *)witnessTable)[*assocTypeReqIndex]
                 (MetadataState::Complete, base, witnessTable).Value;
     });
 

--- a/test/IRGen/same_type_constraints.swift
+++ b/test/IRGen/same_type_constraints.swift
@@ -62,3 +62,40 @@ where Self : CodingType,
 
 // OSIZE: define internal swiftcc i8** @"$S21same_type_constraints12GenericKlazzCyxq_GAA1EAA4Data_AA0F4TypePWT"(%swift.type* %"GenericKlazz<T, R>.Data", %swift.type* nocapture readonly %"GenericKlazz<T, R>", i8** nocapture readnone %"GenericKlazz<T, R>.E") [[ATTRS:#[0-9]+]] {
 // OSIZE: [[ATTRS]] = {{{.*}}noinline
+
+// Check that same-typing two generic parameters together lowers correctly.
+
+protocol P1 {}
+protocol P2 {}
+protocol P3 {}
+struct ConformsToP1: P1 {}
+struct ConformsToP2: P2 {}
+struct ConformsToP3: P3 {}
+
+struct SG11<T: P1, U: P2> {}
+
+struct ConformsToP1AndP2 : P1, P2 { }
+
+extension SG11 where U == T {
+  struct InnerTEqualsU<V: P3> { }
+}
+
+extension SG11 where T == ConformsToP1 {
+  struct InnerTEqualsConformsToP1<V: P3> { }
+}
+
+extension SG11 where U == ConformsToP2 {
+  struct InnerUEqualsConformsToP2<V: P3> { }
+}
+
+func inner1() -> Any.Type {
+  return SG11<ConformsToP1AndP2, ConformsToP1AndP2>.InnerTEqualsU<ConformsToP3>.self
+}
+
+func inner2() -> Any.Type {
+  return SG11<ConformsToP1, ConformsToP2>.InnerTEqualsConformsToP1<ConformsToP3>.self
+}
+
+func inner3() -> Any.Type {
+  return SG11<ConformsToP1, ConformsToP2>.InnerTEqualsConformsToP1<ConformsToP3>.self
+}


### PR DESCRIPTION
Fixes a bug where having two generic params same-typed together would lead to crashes in IRGen, and maybe other places, that only expect to deal with canonical params.