### PR TITLE
SIL Optimizer: Re-run predictable memory optimizations in performance pipeline

### DIFF
--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -222,6 +222,10 @@ void addSSAPasses(SILPassPipelinePlan &P, OptimizationLevelKind OpLevel) {
   // Split up operations on stack-allocated aggregates (struct, tuple).
   P.addSROA();
 
+  // Re-run predictable memory optimizations, since previous optimization
+  // passes sometimes expose oppotunities here.
+  P.addPredictableMemoryOptimizations();
+
   // Promote stack allocations to values.
   P.addMem2Reg();
 


### PR DESCRIPTION
Should recover the performance degradation observed in https://github.com/apple/swift/pull/15894.