### PR TITLE
[ClangImporter] Use appropriate link name for export_as

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2837,6 +2837,11 @@ void ClangModuleUnit::collectLinkLibraries(
     ModuleDecl::LinkLibraryCallback callback) const {
   if (!clangModule)
     return;
+
+  // Skip this lib name in favor of export_as name.
+  if (clangModule->UseExportAsModuleLinkName)
+    return;
+
   for (auto clangLinkLib : clangModule->LinkLibraries) {
     LibraryKind kind;
     if (clangLinkLib.IsFramework)

--- a/test/ClangImporter/Inputs/privateframeworks/withprivate-autolink/SomeKit.framework/Headers/SKWidget.h
+++ b/test/ClangImporter/Inputs/privateframeworks/withprivate-autolink/SomeKit.framework/Headers/SKWidget.h
@@ -1,0 +1,1 @@
+#import <SomeKitCore/SKWidget.h>

--- a/test/ClangImporter/Inputs/privateframeworks/withprivate-autolink/SomeKit.framework/Headers/SomeKit.h
+++ b/test/ClangImporter/Inputs/privateframeworks/withprivate-autolink/SomeKit.framework/Headers/SomeKit.h
@@ -1,0 +1,1 @@
+#import <SomeKit/SKWidget.h>

--- a/test/ClangImporter/Inputs/privateframeworks/withprivate-autolink/SomeKit.framework/Modules/module.modulemap
+++ b/test/ClangImporter/Inputs/privateframeworks/withprivate-autolink/SomeKit.framework/Modules/module.modulemap
@@ -1,0 +1,6 @@
+framework module SomeKit {
+  umbrella header "SomeKit.h"
+  module * {
+    export *
+  }
+}

--- a/test/ClangImporter/Inputs/privateframeworks/withprivate-autolink/SomeKit.framework/SomeKit.tbd
+++ b/test/ClangImporter/Inputs/privateframeworks/withprivate-autolink/SomeKit.framework/SomeKit.tbd
@@ -1,0 +1,1 @@
+// dummy file to trigger autolink

--- a/test/ClangImporter/Inputs/privateframeworks/withprivate-autolink/SomeKitCore.framework/Headers/SKWidget.h
+++ b/test/ClangImporter/Inputs/privateframeworks/withprivate-autolink/SomeKitCore.framework/Headers/SKWidget.h
@@ -1,0 +1,27 @@
+@import ObjectiveC;
+@import Foundation;
+
+@interface SKWidget : NSObject
+- (void)someObjCMethod;
+@end
+
+@interface SKWidget(ObjCAPI)
+- (void)someObjCExtensionMethod;
+@property (readwrite,strong,nonnull) NSObject *anObject;
+@end
+
+@interface NSObject (SKWidget)
+- (void)doSomethingWithWidget:(nonnull SKWidget *)widget;
+@end
+
+extern NSString * _Nonnull const SKWidgetErrorDomain;
+typedef enum __attribute__((ns_error_domain(SKWidgetErrorDomain))) __attribute__((swift_name("SKWidget.Error"))) SKWidgetErrorCode : NSInteger {
+  SKWidgetErrorNone = 0,
+  SKWidgetErrorBoom = 1
+} SKWidgetErrorCode;
+
+@interface SKWidget(Erroneous)
+- (SKWidgetErrorCode)getCurrentError;
+@end
+
+extern void someKitGlobalFunc(void);

--- a/test/ClangImporter/Inputs/privateframeworks/withprivate-autolink/SomeKitCore.framework/Headers/SomeKitCore.h
+++ b/test/ClangImporter/Inputs/privateframeworks/withprivate-autolink/SomeKitCore.framework/Headers/SomeKitCore.h
@@ -1,0 +1,1 @@
+#import <SomeKitCore/SKWidget.h>

--- a/test/ClangImporter/Inputs/privateframeworks/withprivate-autolink/SomeKitCore.framework/Modules/module.modulemap
+++ b/test/ClangImporter/Inputs/privateframeworks/withprivate-autolink/SomeKitCore.framework/Modules/module.modulemap
@@ -1,0 +1,7 @@
+framework module SomeKitCore {
+  umbrella header "SomeKitCore.h"
+  export_as SomeKit
+  module * {
+    export *
+  }
+}

--- a/test/ClangImporter/Inputs/privateframeworks/withprivate-autolink/SomeKitCore.framework/SomeKitCore.tbd
+++ b/test/ClangImporter/Inputs/privateframeworks/withprivate-autolink/SomeKitCore.framework/SomeKitCore.tbd
@@ -1,0 +1,1 @@
+// dummy file to trigger autolink

--- a/test/ClangImporter/private_frameworks_autolink.swift
+++ b/test/ClangImporter/private_frameworks_autolink.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
+// FIXME: END -enable-source-import hackaround
+
+// Check that the autolink information is appropriate (do not link against SomeKitCore).
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-ir -o %t/private_frameworks_autolink.ll -F %S/Inputs/privateframeworks/withprivate-autolink %s
+// RUN: %FileCheck %s < %t/private_frameworks_autolink.ll
+// CHECK-NOT: !{!"-framework", !"SomeKitCore"}
+
+// REQUIRES: objc_interop
+
+import SomeKitCore
+import SomeKit

--- a/test/ClangImporter/private_frameworks_autolink2.swift
+++ b/test/ClangImporter/private_frameworks_autolink2.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+
+// FIXME: BEGIN -enable-source-import hackaround
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
+// FIXME: END -enable-source-import hackaround
+
+// Check that the autolink information is appropriate (do not link against SomeKitCore).
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-ir -o %t/private_frameworks_autolink2.ll -F %S/Inputs/privateframeworks/withprivate-autolink %s
+// RUN: %FileCheck %s < %t/private_frameworks_autolink2.ll
+// CHECK-NOT: !{!"-framework", !"SomeKit"}
+// CHECK: !{!"-framework", !"SomeKitCore"}
+
+// REQUIRES: objc_interop
+
+import SomeKitCore


### PR DESCRIPTION
Use appropriate link name for export_as.

Same as https://github.com/apple/swift/pull/15886, but abandoning the other one in favor of doing it on master directly.

rdar://problem/38269782