### PR TITLE
[ClangImporter] Carefully reset state after doing PCH validation

### DIFF
--- a/test/ClangImporter/Inputs/pch-bridging-header-with-another-bridging-header/app.h
+++ b/test/ClangImporter/Inputs/pch-bridging-header-with-another-bridging-header/app.h
@@ -1,0 +1,5 @@
+#include "has_warning.h"
+
+static inline int app_function(int x) {
+  return x + 27;
+}

--- a/test/ClangImporter/Inputs/pch-bridging-header-with-another-bridging-header/has_warning.h
+++ b/test/ClangImporter/Inputs/pch-bridging-header-with-another-bridging-header/has_warning.h
@@ -1,0 +1,6 @@
+#ifndef HAS_WARNING_H
+#define HAS_WARNING_H
+
+#warning "warning in bridging header"
+
+#endif

--- a/test/ClangImporter/Inputs/pch-bridging-header-with-another-bridging-header/unit-tests.h
+++ b/test/ClangImporter/Inputs/pch-bridging-header-with-another-bridging-header/unit-tests.h
@@ -1,0 +1,1 @@
+#include "has_warning.h"

--- a/test/ClangImporter/pch-bridging-header-with-another-bridging-header.swift
+++ b/test/ClangImporter/pch-bridging-header-with-another-bridging-header.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-module -import-objc-header %S/Inputs/pch-bridging-header-with-another-bridging-header/app.h -I %S/Inputs/pch-bridging-header-with-another-bridging-header -module-name App -emit-module-path %t/App.swiftmodule %S/../Inputs/empty.swift
+// RUN: llvm-bcanalyzer -dump %t/App.swiftmodule | %FileCheck %s
+
+// CHECK: IMPORTED_HEADER{{.*}}Inputs/pch-bridging-header-with-another-bridging-header/app.h
+
+// Now load the app-module-with-bridging-header along with another bridging
+// header that we precompile. This is going to the frontend directly to make
+// sure we validate PCH inputs (because -pch-disable-validation wasn't passed).
+// This is deliberately run twice to test what happens when the PCH is already
+// there. (It used to crash.)
+
+// RUN: cp %S/Inputs/pch-bridging-header-with-another-bridging-header/unit-tests.h %t/unit-tests.h
+// RUN: %target-swift-frontend -typecheck -pch-output-dir %t -import-objc-header %t/unit-tests.h -I %S/Inputs/pch-bridging-header-with-another-bridging-header -I %t %s
+// RUN: %target-swift-frontend -typecheck -pch-output-dir %t -import-objc-header %t/unit-tests.h -I %S/Inputs/pch-bridging-header-with-another-bridging-header -I %t %s
+// RUN: echo >> %t/unit-tests.h
+// RUN: %target-swift-frontend -typecheck -pch-output-dir %t -import-objc-header %t/unit-tests.h -I %S/Inputs/pch-bridging-header-with-another-bridging-header -I %t %s
+
+import App
+
+_ = app_function(2)


### PR DESCRIPTION
This logic reuses parts of the main clang::CompilerInstance because it's not necessarily cheap or convenient to set up a new one, but that leaves us open to problems where Clang doesn't expect these objects to go away. Fix the one people were hitting most recently (thanks, ASan!).

rdar://problem/38454494