### PR TITLE
SIL Optimizer: Re-run predictable memory optimizations in performance pipeline

### DIFF
--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -1394,13 +1394,11 @@ namespace {
 
 class PredictableMemoryOptimizations : public SILFunctionTransform {
   /// The entry point to the transformation.
-  ///
-  /// FIXME: This pass should not need to rerun on deserialized
-  /// functions. Nothing should have changed in the upstream pipeline after
-  /// deserialization. However, rerunning does improve some benchmarks. This
-  /// either indicates that this pass missing some opportunities the first time,
-  /// or has a pass order dependency on other early passes.
   void run() override {
+    // Don't rerun predictable memory optimizations on deserialized functions.
+    if (getFunction()->wasDeserializedCanonical())
+      return;
+
     if (optimizeMemoryAllocations(*getFunction()))
       invalidateAnalysis(SILAnalysis::InvalidationKind::FunctionBody);
   }

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -345,6 +345,13 @@ static void addMidModulePassesStackPromotePassPipeline(SILPassPipelinePlan &P) {
   P.startPipeline("MidModulePasses+StackPromote");
   P.addDeadFunctionElimination();
   P.addSILLinker();
+
+  // Re-run predictable memory optimizations, since previous optimization
+  // passes sometimes expose opportunities here.
+  //
+  // FIXME: Figure out why this is necessary.
+  P.addPredictableMemoryOptimizations();
+
   P.addDeadObjectElimination();
   P.addGlobalPropertyOpt();
 


### PR DESCRIPTION
Should recover the performance degradation observed in #15894.