### PR TITLE
Coverage: fix handling of constructors and top-level decls  (SR-7446)

### DIFF
--- a/lib/SIL/SILProfiler.cpp
+++ b/lib/SIL/SILProfiler.cpp
@@ -100,8 +100,6 @@ static void walkForProfiling(ASTNode N, ASTWalker &Walker) {
   if (auto *D = N.dyn_cast<Decl *>()) {
     if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D))
       walkFunctionForProfiling(AFD, Walker);
-    else if (auto *PBD = dyn_cast<PatternBindingDecl>(D))
-      walkPatternForProfiling(PBD, Walker);
     else if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D))
       TLCD->walk(Walker);
   } else if (auto *E = N.dyn_cast<Expr *>()) {

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -488,6 +488,20 @@ static bool haveProfiledAssociatedFunction(SILDeclRef constant) {
          constant.isCurried;
 }
 
+SILProfiler *
+SILGenModule::getOrCreateProfilerForConstructors(NominalTypeDecl *decl) {
+  assert(decl && "No nominal type for constructor lookup");
+
+  const auto &Opts = M.getOptions();
+  if (!Opts.GenerateProfile && Opts.UseProfile.empty())
+    return nullptr;
+
+  SILProfiler *&profiler = constructorProfilers[decl];
+  if (!profiler)
+    profiler = SILProfiler::create(M, ForDefinition, decl);
+  return profiler;
+}
+
 SILFunction *SILGenModule::getFunction(SILDeclRef constant,
                                        ForDefinition_t forDefinition) {
   // If we already emitted the function, return it (potentially preparing it
@@ -737,10 +751,11 @@ void SILGenModule::emitConstructor(ConstructorDecl *decl) {
     return;
 
   SILDeclRef constant(decl);
+  DeclContext *declCtx = decl->getDeclContext();
 
   bool ForCoverageMapping = doesASTRequireProfiling(M, decl);
 
-  if (decl->getDeclContext()->getAsClassOrClassExtensionContext()) {
+  if (auto *clsDecl = declCtx->getAsClassOrClassExtensionContext()) {
     // Class constructors have separate entry points for allocation and
     // initialization.
     emitOrDelayFunction(
@@ -757,11 +772,11 @@ void SILGenModule::emitConstructor(ConstructorDecl *decl) {
       SILDeclRef initConstant(decl, SILDeclRef::Kind::Initializer);
       emitOrDelayFunction(
           *this, initConstant,
-          [this, initConstant, decl](SILFunction *initF) {
+          [this, initConstant, decl, clsDecl](SILFunction *initF) {
             preEmitFunction(initConstant, decl, initF, decl);
             PrettyStackTraceSILFunction X("silgen constructor initializer",
                                           initF);
-            initF->createProfiler(decl, ForDefinition);
+            initF->setProfiler(getOrCreateProfilerForConstructors(clsDecl));
             SILGenFunction(*this, *initF).emitClassConstructorInitializer(decl);
             postEmitFunction(initConstant, initF);
           },
@@ -769,11 +784,12 @@ void SILGenModule::emitConstructor(ConstructorDecl *decl) {
     }
   } else {
     // Struct and enum constructors do everything in a single function.
+    auto *nomDecl = declCtx->getAsNominalTypeOrNominalTypeExtensionContext();
     emitOrDelayFunction(
-        *this, constant, [this, constant, decl](SILFunction *f) {
+        *this, constant, [this, constant, decl, nomDecl](SILFunction *f) {
           preEmitFunction(constant, decl, f, decl);
           PrettyStackTraceSILFunction X("silgen emitConstructor", f);
-          f->createProfiler(decl, ForDefinition);
+          f->setProfiler(getOrCreateProfilerForConstructors(nomDecl));
           SILGenFunction(*this, *f).emitValueConstructor(decl);
           postEmitFunction(constant, f);
         });
@@ -976,9 +992,16 @@ emitStoredPropertyInitialization(PatternBindingDecl *pbd, unsigned i) {
   auto *init = pbdEntry.getInit();
 
   SILDeclRef constant(var, SILDeclRef::Kind::StoredPropertyInitializer);
-  emitOrDelayFunction(*this, constant, [this,constant,init](SILFunction *f) {
+  emitOrDelayFunction(*this, constant, [this,constant,init,var](SILFunction *f) {
     preEmitFunction(constant, init, f, init);
     PrettyStackTraceSILFunction X("silgen emitStoredPropertyInitialization", f);
+
+    // Inherit a profiler instance from the constructor.
+    auto *nominalDecl =
+        var->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+    if (nominalDecl)
+      f->setProfiler(getOrCreateProfilerForConstructors(nominalDecl));
+
     SILGenFunction(*this, *f).emitGeneratorFunction(constant, init);
     postEmitFunction(constant, f);
   });

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -96,6 +96,10 @@ public:
   /// The most recent conformance...
   NormalProtocolConformance *lastEmittedConformance = nullptr;
 
+  /// Profiler instances for constructors, grouped by associated nominal type.
+  /// Each profiler is shared by all member initializers for a nominal type.
+  llvm::DenseMap<NominalTypeDecl *, SILProfiler *> constructorProfilers;
+
   SILFunction *emitTopLevelFunction(SILLocation Loc);
 
   size_t anonymousSymbolCounter = 0;
@@ -435,6 +439,9 @@ public:
 
   /// Emit a property descriptor for the given storage decl if it needs one.
   void tryEmitPropertyDescriptor(AbstractStorageDecl *decl);
+
+  /// Get or create the profiler instance for a nominal type's constructors.
+  SILProfiler *getOrCreateProfilerForConstructors(NominalTypeDecl *decl);
   
 private:
   /// Emit the deallocator for a class that uses the objc allocator.

--- a/test/SILGen/coverage_class.swift
+++ b/test/SILGen/coverage_class.swift
@@ -3,7 +3,8 @@
 class C {
   // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.C.foo
   func foo() {}
-  // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.C.__allocating_init
+  // CHECK: sil_coverage_map {{.*}}// __ntd_C_line:[[@LINE-3]]:1
+  // CHECK-NEXT: [[@LINE+1]]:10 -> [[@LINE+1]]:12
   init() {}
   // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.C.__deallocating_deinit
   deinit {}
@@ -17,7 +18,7 @@ extension C {
 struct S {
   // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.S.foo
   func foo() {}
-  // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.S.init
+  // CHECK: sil_coverage_map {{.*}}// __ntd_S_line:[[@LINE-3]]:1
   init() {}
 }
 
@@ -25,6 +26,16 @@ enum E {
   case X, Y, Z
   // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.E.foo
   func foo() {}
-  // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.E.init
+  // CHECK: sil_coverage_map {{.*}}// __ntd_E_line:[[@LINE-4]]:1
+  // CHECK-NEXT: [[@LINE+1]]:10 -> [[@LINE+1]]:23
   init() { self = .Y }
+}
+
+var g1: Bool = true
+
+struct S2 {
+  // CHECK: sil_coverage_map {{.*}}// __ntd_S2_line:[[@LINE-1]]:1
+  // CHECK-NEXT: [[@LINE+2]]:22 -> [[@LINE+2]]:23 : 0
+  // CHECK-NEXT: [[@LINE+1]]:26 -> [[@LINE+1]]:27 : (1 - 0)
+  var m1: Int = g1 ? 0 : 1
 }

--- a/test/SILGen/coverage_closures.swift
+++ b/test/SILGen/coverage_closures.swift
@@ -3,15 +3,10 @@
 // rdar://39200851: Closure in init method covered twice
 
 class C2 {
-// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_closures.C2.__allocating_init()
-// CHECK-NEXT:  [[@LINE+7]]:10 -> [[@LINE+11]]:4 : 0
-// CHECK-NEXT: }
-
-// CHECK-LABEL: sil_coverage_map {{.*}}// closure #1 () -> () in coverage_closures.C2.init()
-// CHECK-NEXT:  [[@LINE+4]]:13 -> [[@LINE+6]]:6 : 0
-// CHECK-NEXT: }
-
   init() {
+// CHECK-LABEL: sil_coverage_map {{.*}}// closure #1 () -> () in coverage_closures.C2.init()
+// CHECK-NEXT:  [[@LINE+2]]:13 -> [[@LINE+4]]:6 : 0
+// CHECK-NEXT: }
     let _ = { () in
       print("hello")
     }

--- a/test/SILGen/coverage_exceptions.swift
+++ b/test/SILGen/coverage_exceptions.swift
@@ -5,17 +5,6 @@ enum SomeErr : Error {
   case Err2
 }
 
-struct S {
-  // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.S.init
-  init() {
-    do {
-      throw SomeErr.Err1
-    } catch {
-      // CHECK: [[@LINE-1]]:13 -> [[@LINE+1]]:6 : 2
-    } // CHECK: [[@LINE]]:6 -> [[@LINE+1]]:4 : 1
-  }
-}
-
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.bar
 func bar() throws {
   // CHECK-NEXT: [[@LINE-1]]:19 -> [[@LINE+2]]:2 : 0
@@ -62,3 +51,14 @@ func foo() -> Int32 {
 }
 
 foo()
+
+struct S {
+  // CHECK: sil_coverage_map {{.*}}// __ntd_S_line:[[@LINE-1]]
+  init() {
+    do {
+      throw SomeErr.Err1
+    } catch {
+      // CHECK: [[@LINE-1]]:13 -> [[@LINE+1]]:6 : 2
+    } // CHECK: [[@LINE]]:6 -> [[@LINE+1]]:4 : 1
+  }
+}

--- a/test/SILGen/coverage_member_closure.swift
+++ b/test/SILGen/coverage_member_closure.swift
@@ -1,13 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sil -module-name coverage_member_closure %s | %FileCheck %s
 
 class C {
-  // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_member_closure.C.__allocating_init
-  init() {
-    if (false) { // CHECK: [[@LINE]]:16 -> [[@LINE+2]]:6 : 1
-      // ...
-    }
-  }
-
   // Closures in members receive their own coverage mapping.
   // CHECK: sil_coverage_map {{.*}} $S23coverage_member_closure1CC17completionHandleryySS_SaySSGtcvpfiySS_AEtcfU_
   // CHECK: [[@LINE+1]]:55 -> [[@LINE+1]]:79 : 0

--- a/test/SILGen/coverage_smoke.swift
+++ b/test/SILGen/coverage_smoke.swift
@@ -35,7 +35,7 @@ class Class1 {
   deinit {}
 }
 
-// CHECK-MAIN: Maximum function count: 3
+// CHECK-MAIN: Maximum function count: 4
 func main() {
 // CHECK-COV: {{ *}}[[@LINE+1]]|{{ *}}1{{.*}}f_public
   f_public()
@@ -91,9 +91,46 @@ class Class2 {
     if field > 0 {
       self.field = 0 // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
     } else {
+      self.field = 1 // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}3
+    }
+  }
+}
+
+extension Class2 {
+  convenience init() {
+    self.init(field: 0) // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+  }
+}
+
+class SubClass1: Class2 {
+  override init(field: Int) {
+    super.init(field: field) // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+  }
+}
+
+struct Struct1 {
+  var field: Int
+  init(field: Int) {
+    if field > 0 {
+      self.field = 0 // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+    } else {
       self.field = 1 // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
     }
   }
+}
+
+extension Struct1 {
+  init() {
+    self.init(field: 0) // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+  }
+}
+
+var g2: Int = 0
+
+class Class3 {
+  var m1 = g2 == 0
+             ? "false" // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+             : "true"; // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
 }
 
 main() // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
@@ -103,5 +140,14 @@ call_auto_closure()
 
 let _ = Class2(field: 0)
 let _ = Class2(field: 1)
+let _ = Class2()
+let _ = SubClass1(field: 0)
+
+let _ = Class3()
+g2 = 1
+let _ = Class3()
+
+let _ = Struct1(field: 1)
+let _ = Struct1()
 
 // CHECK-REPORT: TOTAL {{.*}} 100.00% {{.*}} 100.00%

--- a/test/SILGen/coverage_smoke.swift
+++ b/test/SILGen/coverage_smoke.swift
@@ -85,9 +85,23 @@ func call_auto_closure() {
   let _ = use_auto_closure(true) // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}3
 }
 
+class Class2 {
+  var field: Int
+  init(field: Int) {
+    if field > 0 {
+      self.field = 0 // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+    } else {
+      self.field = 1 // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+    }
+  }
+}
+
 main() // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
 foo()  // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
 call_closure()
 call_auto_closure()
+
+let _ = Class2(field: 0)
+let _ = Class2(field: 1)
 
 // CHECK-REPORT: TOTAL {{.*}} 100.00% {{.*}} 100.00%

--- a/test/SILGen/coverage_ternary.swift
+++ b/test/SILGen/coverage_ternary.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_ternary %s | %FileCheck %s
 
-// CHECK-LABEL: sil hidden @$S16coverage_ternary3barCACycfC
+// CHECK-LABEL: sil hidden @$S16coverage_ternary3barCACycfc
 // CHECK-NOT: return
 // CHECK: builtin "int_instrprof_increment"
 

--- a/test/SILGen/coverage_ternary.swift
+++ b/test/SILGen/coverage_ternary.swift
@@ -8,13 +8,7 @@
 // CHECK-NOT: return
 // CHECK: builtin "int_instrprof_increment"
 
-// rdar://problem/23256795 - Avoid crash if an if_expr has no parent
-// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_ternary.bar.__allocating_init
-class bar {
-  var m1 = 0 == 1
-             ? "false" // CHECK: [[@LINE]]:16 -> [[@LINE]]:23 : 1
-             : "true"; // CHECK: [[@LINE]]:16 -> [[@LINE]]:22 : 0
-}
+var flag: Int = 0
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_ternary.foo
 func foo(_ x : Int32) -> Int32 {
@@ -26,6 +20,14 @@ func foo(_ x : Int32) -> Int32 {
 foo(1)
 foo(2)
 foo(3)
+
+// rdar://problem/23256795 - Avoid crash if an if_expr has no parent
+// CHECK: sil_coverage_map {{.*}}// __ntd_bar_line:[[@LINE+1]]
+class bar {
+  var m1 = flag == 0
+             ? "false" // CHECK: [[@LINE]]:16 -> [[@LINE]]:23 : 0
+             : "true"; // CHECK: [[@LINE]]:16 -> [[@LINE]]:22 : (1 - 0)
+}
 
 // Note: We didn't instantiate bar, but we still expect to see instrumentation
 // for its *structors, and coverage mapping information for it.

--- a/test/SILGen/coverage_toplevel.swift
+++ b/test/SILGen/coverage_toplevel.swift
@@ -17,7 +17,7 @@ while (i < 10) {
 
 // CHECK: sil_coverage_map{{.*}}__tlcd_line:[[@LINE+3]]:1
 // CHECK-NEXT:  [[@LINE+2]]:17 -> [[@LINE+2]]:18 : 1
-// CHECK-NEXT:  [[@LINE+1]]:21 -> [[@LINE+1]]:22 : 0
+// CHECK-NEXT:  [[@LINE+1]]:21 -> [[@LINE+1]]:22 : (0 - 1)
 var i2 = true ? 1 : 0;
 
 // CHECK: sil_coverage_map{{.*}}__tlcd_line:[[@LINE+4]]:1


### PR DESCRIPTION
1) Instrument constructor initializers, instead of the delegating constructors which just call them.

2) Once that's done, make sure that a parent region is available inside of member initializers and top-level code decls. This fixes a reporting bug for if-exprs by getting rid of the RegionStack.empty() case.

3) Remove some defensive heuristic code which dealt with closures and if-exprs within member initializers.