### PR TITLE
AST: Workaround for same-type constraints getting dropped from requirement environment

### DIFF
--- a/lib/AST/RequirementEnvironment.cpp
+++ b/lib/AST/RequirementEnvironment.cpp
@@ -209,13 +209,6 @@ RequirementEnvironment::RequirementEnvironment(
   // Next, add each of the requirements (mapped from the requirement's
   // interface types into the abstract type parameters).
   for (auto &rawReq : reqSig->getRequirements()) {
-    // FIXME: This should not be necessary, since the constraint is redundant,
-    // but we need it to work around some crashes for now.
-    if (rawReq.getKind() == RequirementKind::Conformance &&
-        rawReq.getFirstType()->isEqual(selfType) &&
-        rawReq.getSecondType()->isEqual(proto->getDeclaredType()))
-      continue;
-
     if (auto req = rawReq.subst(reqToSyntheticEnvMap))
       builder.addRequirement(*req, source, conformanceDC->getParentModule());
   }

--- a/test/decl/protocol/conforms/self.swift
+++ b/test/decl/protocol/conforms/self.swift
@@ -70,3 +70,19 @@ extension HasDefault where Self : SeriousClass {
 }
 
 extension SeriousClass : HasDefault {}
+
+// https://bugs.swift.org/browse/SR-7428
+
+protocol Node {
+  associatedtype ValueType = Int
+
+  func addChild<ChildType>(_ child: ChildType)
+    where ChildType: Node, ChildType.ValueType == Self.ValueType
+}
+
+extension Node {
+  func addChild<ChildType>(_ child: ChildType)
+    where ChildType: Node, ChildType.ValueType == Self.ValueType {}
+}
+
+class IntNode: Node {}


### PR DESCRIPTION
The fix for <https://bugs.swift.org/browse/SR-617> introduced
a new kind of requirement environment where 'Self' remains a
generic parameter, but receives a class constraint, instead of
becoming fully concrete.

As before, we would form the synthetic signature by taking
the generic signature of the requirement, and substituting it
the new 'Self' type.

However, whereas previously the 'Self' type was always concrete
and any DependentMemberTypes in the requirement's signature
would become concrete type references, with a class-constrained
'Self' the DependentMemberTypes remain.

Apparently, the GSB cannot handle DependentMemberTypes where
the base is class-constrained.

Work around this by ensuring that we add a conformance constraint
for the 'Self' parameter to the protocol in question, which
allows the DependentMemberTypes to be correctly resolves once
the conformance is made concrete by a superclass constraint.

The FIXME comment being removed here references crashes which
no longer seem to reproduce, so I'm assuming some underlying
GSB issues got fixed and the FIXME is clearly no longer necessary.

However, I still consider this fix somewhat unsatisfying, because
it is not clear if there's some deeper flaw in how the GSB
models superclass constraints. It might resurface again in the
future.

Fixes <rdar://problem/39419121>, <https://bugs.swift.org/browse/SR-7428>.