### PR TITLE
SILCleanup => IRGenPrepare.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -232,8 +232,8 @@ PASS(TempRValueOpt, "temp-rvalue-opt",
      "Remove short-lived immutable temporary copies")
 PASS(SideEffectsDumper, "side-effects-dump",
      "Print Side-Effect Information for all Functions")
-PASS(SILCleanup, "cleanup",
-     "SIL Cleanup Preparation for IRGen")
+PASS(IRGenPrepare, "irgen-prepare",
+     "Cleanup SIL in preparation for IRGen")
 PASS(SILCombine, "sil-combine",
      "Combine SIL Instructions via Peephole Optimization")
 PASS(SILDebugInfoGenerator, "sil-debuginfo-gen",

--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -2,6 +2,7 @@ set(MANDATORY_SOURCES
   Mandatory/AccessEnforcementSelection.cpp
   Mandatory/AccessMarkerElimination.cpp
   Mandatory/AddressLowering.cpp
+  Mandatory/ConstantPropagation.cpp
   Mandatory/DefiniteInitialization.cpp
   Mandatory/DIMemoryUseCollector.cpp
   Mandatory/DIMemoryUseCollectorOwnership.cpp
@@ -10,8 +11,8 @@ set(MANDATORY_SOURCES
   Mandatory/DiagnoseStaticExclusivity.cpp
   Mandatory/DiagnoseUnreachable.cpp
   Mandatory/GuaranteedARCOpts.cpp
+  Mandatory/IRGenPrepare.cpp
   Mandatory/MandatoryInlining.cpp
   Mandatory/PredictableMemOpt.cpp
-  Mandatory/ConstantPropagation.cpp
   Mandatory/SemanticARCOpts.cpp
   PARENT_SCOPE)

--- a/lib/SILOptimizer/Mandatory/IRGenPrepare.cpp
+++ b/lib/SILOptimizer/Mandatory/IRGenPrepare.cpp
@@ -9,10 +9,15 @@
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 //
 //===----------------------------------------------------------------------===//
-//
-// Cleanup SIL to make it suitable for IRGen. Specifically, removes the calls to
-// Builtin.staticReport(), which are not needed post SIL.
-//
+///
+/// \file
+///
+/// Cleanup SIL to make it suitable for IRGen.
+///
+/// We perform the following canonicalizations:
+///
+/// 1. We remove calls to Builtin.staticReport(), which are not needed post SIL.
+///
 //===----------------------------------------------------------------------===//
 
 #include "swift/SILOptimizer/PassManager/Passes.h"
@@ -24,38 +29,52 @@
 
 using namespace swift;
 
-static void cleanFunction(SILFunction &Fn) {
-  for (auto &BB : Fn) {
-    auto I = BB.begin(), E = BB.end();
-    while (I != E) {
+static bool cleanFunction(SILFunction &fn) {
+  bool madeChange = false;
+
+  for (auto &bb : fn) {
+    for (auto i = bb.begin(), e = bb.end(); i != e;) {
       // Make sure there is no iterator invalidation if the inspected
       // instruction gets removed from the block.
-      SILInstruction *Inst = &*I;
-      ++I;
+      SILInstruction *inst = &*i;
+      ++i;
 
       // Remove calls to Builtin.staticReport().
-      if (auto *BI = dyn_cast<BuiltinInst>(Inst)) {
-        const BuiltinInfo &B = BI->getBuiltinInfo();
-        if (B.ID == BuiltinValueKind::StaticReport) {
-          // The call to the builtin should get removed before we reach
-          // IRGen.
-          recursivelyDeleteTriviallyDeadInstructions(BI, /* Force */true);
-        }
+      auto *bi = dyn_cast<BuiltinInst>(inst);
+      if (!bi) {
+        continue;
       }
+
+      const BuiltinInfo &bInfo = bi->getBuiltinInfo();
+      if (bInfo.ID != BuiltinValueKind::StaticReport) {
+        continue;
+      }
+
+      // The call to the builtin should get removed before we reach
+      // IRGen.
+      recursivelyDeleteTriviallyDeadInstructions(bi, /* Force */ true);
+      madeChange = true;
     }
   }
+
+  return madeChange;
 }
 
+//===----------------------------------------------------------------------===//
+//                            Top Level Entrypoint
+//===----------------------------------------------------------------------===//
+
 namespace {
-class IRGenPrepare : public swift::SILFunctionTransform {
 
-  /// The entry point to the transformation.
+class IRGenPrepare : public SILFunctionTransform {
   void run() override {
-    cleanFunction(*getFunction());
-    invalidateAnalysis(SILAnalysis::InvalidationKind::FunctionBody);
+    bool shouldInvalidate = cleanFunction(*getFunction());
+    if (!shouldInvalidate)
+      return;
+    invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
   }
-
 };
+
 } // end anonymous namespace
 
 

--- a/lib/SILOptimizer/Mandatory/IRGenPrepare.cpp
+++ b/lib/SILOptimizer/Mandatory/IRGenPrepare.cpp
@@ -1,8 +1,8 @@
-//===--- SILCleanup.cpp - Removes diagnostics instructions ----------------===//
+//===--- IRGenPrepare.cpp -------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -12,9 +12,6 @@
 //
 // Cleanup SIL to make it suitable for IRGen. Specifically, removes the calls to
 // Builtin.staticReport(), which are not needed post SIL.
-//
-// FIXME: This pass is mandatory so should probably be in
-// SILOptimizer/Mandatory.
 //
 //===----------------------------------------------------------------------===//
 
@@ -50,7 +47,7 @@ static void cleanFunction(SILFunction &Fn) {
 }
 
 namespace {
-class SILCleanup : public swift::SILFunctionTransform {
+class IRGenPrepare : public swift::SILFunctionTransform {
 
   /// The entry point to the transformation.
   void run() override {
@@ -62,6 +59,6 @@ class SILCleanup : public swift::SILFunctionTransform {
 } // end anonymous namespace
 
 
-SILTransform *swift::createSILCleanup() {
-  return new SILCleanup();
+SILTransform *swift::createIRGenPrepare() {
+  return new IRGenPrepare();
 }

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -456,7 +456,7 @@ SILPassPipelinePlan
 SILPassPipelinePlan::getLoweringPassPipeline() {
   SILPassPipelinePlan P;
   P.startPipeline("Address Lowering");
-  P.addSILCleanup();
+  P.addIRGenPrepare();
   P.addAddressLowering();
 
   return P;

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -23,7 +23,6 @@ set(TRANSFORMS_SOURCES
   Transforms/RedundantOverflowCheckRemoval.cpp
   Transforms/ReleaseDevirtualizer.cpp
   Transforms/RemovePin.cpp
-  Transforms/SILCleanup.cpp
   Transforms/SILCodeMotion.cpp
   Transforms/SILLowerAggregateInstrs.cpp
   Transforms/SILMem2Reg.cpp

--- a/utils/pass-pipeline/src/passes.py
+++ b/utils/pass-pipeline/src/passes.py
@@ -40,7 +40,7 @@ NoReturnFolding = Pass('NoReturnFolding')
 PerfInliner = Pass('PerfInliner')
 PerformanceConstantPropagation = Pass('PerformanceConstantPropagation')
 PredictableMemoryOptimizations = Pass('PredictableMemoryOptimizations')
-SILCleanup = Pass('SILCleanup')
+IRGenPrepare = Pass('IRGenPrepare')
 SILCombine = Pass('SILCombine')
 SILLinker = Pass('SILLinker')
 SROA = Pass('SROA')
@@ -89,7 +89,7 @@ PASSES = [
     PerfInliner,
     PerformanceConstantPropagation,
     PredictableMemoryOptimizations,
-    SILCleanup,
+    IRGenPrepare,
     SILCombine,
     SILLinker,
     SROA,


### PR DESCRIPTION
This PR:

1. Renames SILCleanup to IRGenPrepare and moves it to the Mandatory filder.
2. Performs small correctness cleanups such as only invalidating if we actually modified an instruction and only invalidating instructions rather than larger groups of effects.

rdar://39335800

This is in preparation for https://github.com/apple/swift/pull/15502.