### PR TITLE
Add 'Sema' to Lexicon

### DIFF
--- a/docs/Lexicon.rst
+++ b/docs/Lexicon.rst
@@ -339,6 +339,10 @@ source code, tests, and commit messages. See also the `LLVM lexicon`_.
 
   script mode
     The parsing mode that allows top-level imperative code in a source file.
+    
+  Sema
+    Short for 'Semantic Analysis', the compiler pass that performs type checking,
+    validation, and expression rewriting before SILGen.
 
   SIL
     "Swift Intermediate Language". A high-level IR used by the Swift compiler


### PR DESCRIPTION
Adds a small but useful definition of 'Sema' to the Lexicon. I personally thought it had something to do with Semaphores when I started contributing.