### PR TITLE
New compiler directive to replace _compiler_version

### DIFF
--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -278,7 +278,8 @@ public:
     }
 
     // 'swift' '(' '>=' float-literal ( '.' integer-literal )* ')'
-    if (*KindName == "swift") {
+    // 'compiler' '(' '>=' float-literal ( '.' integer-literal )* ')'
+    if (*KindName == "swift" || *KindName == "compiler") {
       auto PUE = dyn_cast<PrefixUnaryExpr>(Arg);
       llvm::Optional<StringRef> PrefixName = PUE ?
         getDeclRefStr(PUE->getFn(), DeclRefKind::PrefixOperator) : None;
@@ -452,6 +453,13 @@ public:
           Str, SourceLoc(), nullptr).getValue();
       auto thisVersion = Ctx.LangOpts.EffectiveLanguageVersion;
       return thisVersion >= Val;
+    } else if (KindName == "compiler") {
+      auto PUE = cast<PrefixUnaryExpr>(Arg);
+      auto Str = extractExprSource(Ctx.SourceMgr, PUE->getArg());
+      auto Val = version::Version::parseVersionString(
+          Str, SourceLoc(), nullptr).getValue();
+      auto thisVersion = version::Version::getCurrentLanguageVersion();
+      return thisVersion >= Val;
     } else if (KindName == "canImport") {
       auto Str = extractExprSource(Ctx.SourceMgr, Arg);
       return Ctx.canImportModule({ Ctx.getIdentifier(Str) , E->getLoc()  });
@@ -539,7 +547,8 @@ public:
 
   bool visitCallExpr(CallExpr *E) {
     auto KindName = getDeclRefStr(E->getFn());
-    return KindName == "_compiler_version" || KindName == "swift";
+    return KindName == "_compiler_version" || KindName == "swift" ||
+        KindName == "compiler";
   }
 
   bool visitPrefixUnaryExpr(PrefixUnaryExpr *E) { return visit(E->getArg()); }

--- a/lib/Parse/ParseIfConfig.cpp
+++ b/lib/Parse/ParseIfConfig.cpp
@@ -446,20 +446,18 @@ public:
           Str, SourceLoc(), nullptr).getValue();
       auto thisVersion = version::Version::getCurrentCompilerVersion();
       return thisVersion >= Val;
-    } else if (KindName == "swift") {
+    } else if ((KindName == "swift") || (KindName == "compiler")) {
       auto PUE = cast<PrefixUnaryExpr>(Arg);
       auto Str = extractExprSource(Ctx.SourceMgr, PUE->getArg());
       auto Val = version::Version::parseVersionString(
           Str, SourceLoc(), nullptr).getValue();
-      auto thisVersion = Ctx.LangOpts.EffectiveLanguageVersion;
-      return thisVersion >= Val;
-    } else if (KindName == "compiler") {
-      auto PUE = cast<PrefixUnaryExpr>(Arg);
-      auto Str = extractExprSource(Ctx.SourceMgr, PUE->getArg());
-      auto Val = version::Version::parseVersionString(
-          Str, SourceLoc(), nullptr).getValue();
-      auto thisVersion = version::Version::getCurrentLanguageVersion();
-      return thisVersion >= Val;
+      if (KindName == "swift") {
+        return Ctx.LangOpts.EffectiveLanguageVersion >= Val;  
+      } else if (KindName == "compiler") {
+        return version::Version::getCurrentLanguageVersion() >= Val;
+      } else {
+        llvm_unreachable("unsupported version conditional");
+      }
     } else if (KindName == "canImport") {
       auto Str = extractExprSource(Ctx.SourceMgr, Arg);
       return Ctx.canImportModule({ Ctx.getIdentifier(Str) , E->getLoc()  });

--- a/test/Compatibility/conditional_compilation_expr.swift
+++ b/test/Compatibility/conditional_compilation_expr.swift
@@ -69,7 +69,21 @@ foo bar
 let _: Int = 1
 #endif
 
+#if !compiler(>=4.1)
+// There should be no error here.
+foo bar
+#else
+let _: Int = 1
+#endif
+
 #if (swift(>=2.2))
+let _: Int = 1
+#else
+// There should be no error here.
+foo bar
+#endif
+
+#if (compiler(>=4.1))
 let _: Int = 1
 #else
 // There should be no error here.
@@ -83,13 +97,33 @@ foo bar baz // expected-error 2 {{consecutive statements}}
 undefinedElse() // expected-error {{use of unresolved identifier 'undefinedElse'}}
 #endif
 
+#if compiler(>=99.0) || compiler(>=88.1.1)
+// There should be no error here.
+foo bar baz // expected-error 2 {{consecutive statements}}
+#else
+undefinedElse() // expected-error {{use of unresolved identifier 'undefinedElse'}}
+#endif
+
 #if swift(>=99.0) || FOO
 undefinedIf() // expected-error {{use of unresolved identifier 'undefinedIf'}}
 #else
 undefinedElse()
 #endif
 
+#if compiler(>=99.0) || FOO
+undefinedIf() // expected-error {{use of unresolved identifier 'undefinedIf'}}
+#else
+undefinedElse()
+#endif
+
 #if swift(>=99.0) && FOO
+// There should be no error here.
+foo bar baz // expected-error 2 {{consecutive statements}}
+#else
+undefinedElse() // expected-error {{use of unresolved identifier 'undefinedElse'}}
+#endif
+
+#if compiler(>=99.0) && FOO
 // There should be no error here.
 foo bar baz // expected-error 2 {{consecutive statements}}
 #else
@@ -103,7 +137,21 @@ undefinedIf() // expected-error {{use of unresolved identifier 'undefinedIf'}}
 foo bar baz // expected-error 2 {{consecutive statements}}
 #endif
 
+#if FOO && compiler(>=4.0)
+undefinedIf() // expected-error {{use of unresolved identifier 'undefinedIf'}}
+#else
+// There should be no error here.
+foo bar baz // expected-error 2 {{consecutive statements}}
+#endif
+
 #if swift(>=2.2) && swift(>=1)
+undefinedIf() // expected-error {{use of unresolved identifier 'undefinedIf'}}
+#else
+// There should be no error here.
+foo bar baz // expected-error 2 {{consecutive statements}}
+#endif
+
+#if compiler(>=4.1) && compiler(>=4)
 undefinedIf() // expected-error {{use of unresolved identifier 'undefinedIf'}}
 #else
 // There should be no error here.


### PR DESCRIPTION
This is implementation for the `Compiler Version Directive` proposal: https://github.com/apple/swift-evolution/pull/833