### PR TITLE
Revert "Work around compilation problems with clang 3.8"

### DIFF
--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -587,9 +587,8 @@ RemoteASTTypeBuilder::getForeignModuleKind(const Demangle::NodePointer &node) {
     return None;
 
   return llvm::StringSwitch<Optional<ForeignModuleKind>>(node->getText())
-      .Case(llvm::StringLiteral::withInnerNUL(MANGLING_MODULE_OBJC),
-            ForeignModuleKind::Imported)
-      .Case(llvm::StringLiteral::withInnerNUL(MANGLING_MODULE_CLANG_IMPORTER),
+      .Case(MANGLING_MODULE_OBJC, ForeignModuleKind::Imported)
+      .Case(MANGLING_MODULE_CLANG_IMPORTER,
             ForeignModuleKind::SynthesizedByImporter)
       .Default(None);
 }


### PR DESCRIPTION
This reverts commit 609b151b7f6b7e82cbb6b489cae3f98068d21e1b.

I cherry-picked the commits that exposed this failure to swift-4.2:

d515a622008753d0b9c5df347216bd2de1591529
f6ae0f82b006d9c785e164635ae842e9f1e2059a

So now on master, we support this behavior directly so we can get rid of the
difference in between the two branches.
