### PR TITLE
[4.2] [strliteral-upgrade] Change Strings.h constants to be constexpr static instead of static.

### DIFF
--- a/include/swift/Strings.h
+++ b/include/swift/Strings.h
@@ -14,73 +14,75 @@
 #define SWIFT_STRINGS_H
 
 namespace swift {
-  /// The extension for serialized modules.
-  static const char SERIALIZED_MODULE_EXTENSION[] = "swiftmodule";
-  /// The extension for serialized documentation comments.
-  static const char SERIALIZED_MODULE_DOC_EXTENSION[] = "swiftdoc";
-  /// The extension for PCH files.
-  static const char PCH_EXTENSION[] = "pch";
-  /// The extension for replacement map files.
-  static const char REMAP_EXTENSION[] = "remap";
-  /// The extension for SIL files.
-  static const char SIL_EXTENSION[] = "sil";
-  /// The extension for SIB files.
-  static const char SIB_EXTENSION[] = "sib";
-  /// The extension for LLVM IR files.
-  static const char LLVM_BC_EXTENSION[] = "bc";
-  static const char LLVM_IR_EXTENSION[] = "ll";
-  /// The name of the standard library, which is a reserved module name.
-  static const char STDLIB_NAME[] = "Swift";
-  /// The name of the Onone support library, which is a reserved module name.
-  static const char SWIFT_ONONE_SUPPORT[] = "SwiftOnoneSupport";
-  /// The name of the SwiftShims module, which contains private stdlib decls.
-  static const char SWIFT_SHIMS_NAME[] = "SwiftShims";
-  /// The name of the Builtin module, which contains Builtin functions.
-  static const char BUILTIN_NAME[] = "Builtin";
-  /// The prefix of module names used by LLDB to capture Swift expressions
-  static const char LLDB_EXPRESSIONS_MODULE_NAME_PREFIX[] = "__lldb_expr_";
 
-  /// The name of the fake module used to hold imported Objective-C things.
-  static const char MANGLING_MODULE_OBJC[] = "__C";
-  /// The name of the fake module used to hold synthesized ClangImporter things.
-  static const char MANGLING_MODULE_CLANG_IMPORTER[] = "__C_Synthesized";
+/// The extension for serialized modules.
+static const char SERIALIZED_MODULE_EXTENSION[] = "swiftmodule";
+/// The extension for serialized documentation comments.
+static const char SERIALIZED_MODULE_DOC_EXTENSION[] = "swiftdoc";
+/// The extension for PCH files.
+static const char PCH_EXTENSION[] = "pch";
+/// The extension for replacement map files.
+static const char REMAP_EXTENSION[] = "remap";
+/// The extension for SIL files.
+static const char SIL_EXTENSION[] = "sil";
+/// The extension for SIB files.
+static const char SIB_EXTENSION[] = "sib";
+/// The extension for LLVM IR files.
+static const char LLVM_BC_EXTENSION[] = "bc";
+static const char LLVM_IR_EXTENSION[] = "ll";
+/// The name of the standard library, which is a reserved module name.
+static const char STDLIB_NAME[] = "Swift";
+/// The name of the Onone support library, which is a reserved module name.
+static const char SWIFT_ONONE_SUPPORT[] = "SwiftOnoneSupport";
+/// The name of the SwiftShims module, which contains private stdlib decls.
+static const char SWIFT_SHIMS_NAME[] = "SwiftShims";
+/// The name of the Builtin module, which contains Builtin functions.
+static const char BUILTIN_NAME[] = "Builtin";
+/// The prefix of module names used by LLDB to capture Swift expressions
+static const char LLDB_EXPRESSIONS_MODULE_NAME_PREFIX[] = "__lldb_expr_";
 
-  /// The name of the Builtin type prefix
-  static const char BUILTIN_TYPE_NAME_PREFIX[] = "Builtin.";
-  /// The name of the Builtin type for Int
-  static const char BUILTIN_TYPE_NAME_INT[] = "Builtin.Int";
-  /// The name of the Builtin type for Int8
-  static const char BUILTIN_TYPE_NAME_INT8[] = "Builtin.Int8";
-  /// The name of the Builtin type for Int16
-  static const char BUILTIN_TYPE_NAME_INT16[] = "Builtin.Int16";
-  /// The name of the Builtin type for Int32
-  static const char BUILTIN_TYPE_NAME_INT32[] = "Builtin.Int32";
-  /// The name of the Builtin type for Int64
-  static const char BUILTIN_TYPE_NAME_INT64[] = "Builtin.Int64";
-  /// The name of the Builtin type for Int128
-  static const char BUILTIN_TYPE_NAME_INT128[] = "Builtin.Int128";
-  /// The name of the Builtin type for Int256
-  static const char BUILTIN_TYPE_NAME_INT256[] = "Builtin.Int256";
-  /// The name of the Builtin type for Int512
-  static const char BUILTIN_TYPE_NAME_INT512[] = "Builtin.Int512";
-  /// The name of the Builtin type for Float
-  static const char BUILTIN_TYPE_NAME_FLOAT[] = "Builtin.Float";
-  /// The name of the Builtin type for NativeObject
-  static const char BUILTIN_TYPE_NAME_NATIVEOBJECT[] = "Builtin.NativeObject";
-  /// The name of the Builtin type for BridgeObject
-  static const char BUILTIN_TYPE_NAME_BRIDGEOBJECT[] = "Builtin.BridgeObject";
-  /// The name of the Builtin type for RawPointer
-  static const char BUILTIN_TYPE_NAME_RAWPOINTER[] = "Builtin.RawPointer";
-  /// The name of the Builtin type for UnsafeValueBuffer
-  static const char BUILTIN_TYPE_NAME_UNSAFEVALUEBUFFER[] = "Builtin.UnsafeValueBuffer";
-  /// The name of the Builtin type for UnknownObject
-  static const char BUILTIN_TYPE_NAME_UNKNOWNOBJECT[] = "Builtin.UnknownObject";
-  /// The name of the Builtin type for Vector
-  static const char BUILTIN_TYPE_NAME_VEC[] = "Builtin.Vec";
-  /// The name of the Builtin type for SILToken
-  static const char BUILTIN_TYPE_NAME_SILTOKEN[] = "Builtin.SILToken";
-  /// The name of the Builtin type for Word
-  static const char BUILTIN_TYPE_NAME_WORD[] = "Builtin.Word";
+/// The name of the fake module used to hold imported Objective-C things.
+static const char MANGLING_MODULE_OBJC[] = "__C";
+/// The name of the fake module used to hold synthesized ClangImporter things.
+static const char MANGLING_MODULE_CLANG_IMPORTER[] = "__C_Synthesized";
+
+/// The name of the Builtin type prefix
+static const char BUILTIN_TYPE_NAME_PREFIX[] = "Builtin.";
+/// The name of the Builtin type for Int
+static const char BUILTIN_TYPE_NAME_INT[] = "Builtin.Int";
+/// The name of the Builtin type for Int8
+static const char BUILTIN_TYPE_NAME_INT8[] = "Builtin.Int8";
+/// The name of the Builtin type for Int16
+static const char BUILTIN_TYPE_NAME_INT16[] = "Builtin.Int16";
+/// The name of the Builtin type for Int32
+static const char BUILTIN_TYPE_NAME_INT32[] = "Builtin.Int32";
+/// The name of the Builtin type for Int64
+static const char BUILTIN_TYPE_NAME_INT64[] = "Builtin.Int64";
+/// The name of the Builtin type for Int128
+static const char BUILTIN_TYPE_NAME_INT128[] = "Builtin.Int128";
+/// The name of the Builtin type for Int256
+static const char BUILTIN_TYPE_NAME_INT256[] = "Builtin.Int256";
+/// The name of the Builtin type for Int512
+static const char BUILTIN_TYPE_NAME_INT512[] = "Builtin.Int512";
+/// The name of the Builtin type for Float
+static const char BUILTIN_TYPE_NAME_FLOAT[] = "Builtin.Float";
+/// The name of the Builtin type for NativeObject
+static const char BUILTIN_TYPE_NAME_NATIVEOBJECT[] = "Builtin.NativeObject";
+/// The name of the Builtin type for BridgeObject
+static const char BUILTIN_TYPE_NAME_BRIDGEOBJECT[] = "Builtin.BridgeObject";
+/// The name of the Builtin type for RawPointer
+static const char BUILTIN_TYPE_NAME_RAWPOINTER[] = "Builtin.RawPointer";
+/// The name of the Builtin type for UnsafeValueBuffer
+static const char BUILTIN_TYPE_NAME_UNSAFEVALUEBUFFER[] = "Builtin.UnsafeValueBuffer";
+/// The name of the Builtin type for UnknownObject
+static const char BUILTIN_TYPE_NAME_UNKNOWNOBJECT[] = "Builtin.UnknownObject";
+/// The name of the Builtin type for Vector
+static const char BUILTIN_TYPE_NAME_VEC[] = "Builtin.Vec";
+/// The name of the Builtin type for SILToken
+static const char BUILTIN_TYPE_NAME_SILTOKEN[] = "Builtin.SILToken";
+/// The name of the Builtin type for Word
+static const char BUILTIN_TYPE_NAME_WORD[] = "Builtin.Word";
+
 } // end namespace swift
 
 #endif // SWIFT_STRINGS_H

--- a/include/swift/Strings.h
+++ b/include/swift/Strings.h
@@ -16,73 +16,79 @@
 namespace swift {
 
 /// The extension for serialized modules.
-static const char SERIALIZED_MODULE_EXTENSION[] = "swiftmodule";
+constexpr static const char SERIALIZED_MODULE_EXTENSION[] = "swiftmodule";
 /// The extension for serialized documentation comments.
-static const char SERIALIZED_MODULE_DOC_EXTENSION[] = "swiftdoc";
+constexpr static const char SERIALIZED_MODULE_DOC_EXTENSION[] = "swiftdoc";
 /// The extension for PCH files.
-static const char PCH_EXTENSION[] = "pch";
+constexpr static const char PCH_EXTENSION[] = "pch";
 /// The extension for replacement map files.
-static const char REMAP_EXTENSION[] = "remap";
+constexpr static const char REMAP_EXTENSION[] = "remap";
 /// The extension for SIL files.
-static const char SIL_EXTENSION[] = "sil";
+constexpr static const char SIL_EXTENSION[] = "sil";
 /// The extension for SIB files.
-static const char SIB_EXTENSION[] = "sib";
+constexpr static const char SIB_EXTENSION[] = "sib";
 /// The extension for LLVM IR files.
-static const char LLVM_BC_EXTENSION[] = "bc";
-static const char LLVM_IR_EXTENSION[] = "ll";
+constexpr static const char LLVM_BC_EXTENSION[] = "bc";
+constexpr static const char LLVM_IR_EXTENSION[] = "ll";
 /// The name of the standard library, which is a reserved module name.
-static const char STDLIB_NAME[] = "Swift";
+constexpr static const char STDLIB_NAME[] = "Swift";
 /// The name of the Onone support library, which is a reserved module name.
-static const char SWIFT_ONONE_SUPPORT[] = "SwiftOnoneSupport";
+constexpr static const char SWIFT_ONONE_SUPPORT[] = "SwiftOnoneSupport";
 /// The name of the SwiftShims module, which contains private stdlib decls.
-static const char SWIFT_SHIMS_NAME[] = "SwiftShims";
+constexpr static const char SWIFT_SHIMS_NAME[] = "SwiftShims";
 /// The name of the Builtin module, which contains Builtin functions.
-static const char BUILTIN_NAME[] = "Builtin";
+constexpr static const char BUILTIN_NAME[] = "Builtin";
 /// The prefix of module names used by LLDB to capture Swift expressions
-static const char LLDB_EXPRESSIONS_MODULE_NAME_PREFIX[] = "__lldb_expr_";
+constexpr static const char LLDB_EXPRESSIONS_MODULE_NAME_PREFIX[] =
+    "__lldb_expr_";
 
 /// The name of the fake module used to hold imported Objective-C things.
-static const char MANGLING_MODULE_OBJC[] = "__C";
+constexpr static const char MANGLING_MODULE_OBJC[] = "__C";
 /// The name of the fake module used to hold synthesized ClangImporter things.
-static const char MANGLING_MODULE_CLANG_IMPORTER[] = "__C_Synthesized";
+constexpr static const char MANGLING_MODULE_CLANG_IMPORTER[] =
+    "__C_Synthesized";
 
 /// The name of the Builtin type prefix
-static const char BUILTIN_TYPE_NAME_PREFIX[] = "Builtin.";
+constexpr static const char BUILTIN_TYPE_NAME_PREFIX[] = "Builtin.";
 /// The name of the Builtin type for Int
-static const char BUILTIN_TYPE_NAME_INT[] = "Builtin.Int";
+constexpr static const char BUILTIN_TYPE_NAME_INT[] = "Builtin.Int";
 /// The name of the Builtin type for Int8
-static const char BUILTIN_TYPE_NAME_INT8[] = "Builtin.Int8";
+constexpr static const char BUILTIN_TYPE_NAME_INT8[] = "Builtin.Int8";
 /// The name of the Builtin type for Int16
-static const char BUILTIN_TYPE_NAME_INT16[] = "Builtin.Int16";
+constexpr static const char BUILTIN_TYPE_NAME_INT16[] = "Builtin.Int16";
 /// The name of the Builtin type for Int32
-static const char BUILTIN_TYPE_NAME_INT32[] = "Builtin.Int32";
+constexpr static const char BUILTIN_TYPE_NAME_INT32[] = "Builtin.Int32";
 /// The name of the Builtin type for Int64
-static const char BUILTIN_TYPE_NAME_INT64[] = "Builtin.Int64";
+constexpr static const char BUILTIN_TYPE_NAME_INT64[] = "Builtin.Int64";
 /// The name of the Builtin type for Int128
-static const char BUILTIN_TYPE_NAME_INT128[] = "Builtin.Int128";
+constexpr static const char BUILTIN_TYPE_NAME_INT128[] = "Builtin.Int128";
 /// The name of the Builtin type for Int256
-static const char BUILTIN_TYPE_NAME_INT256[] = "Builtin.Int256";
+constexpr static const char BUILTIN_TYPE_NAME_INT256[] = "Builtin.Int256";
 /// The name of the Builtin type for Int512
-static const char BUILTIN_TYPE_NAME_INT512[] = "Builtin.Int512";
+constexpr static const char BUILTIN_TYPE_NAME_INT512[] = "Builtin.Int512";
 /// The name of the Builtin type for Float
-static const char BUILTIN_TYPE_NAME_FLOAT[] = "Builtin.Float";
+constexpr static const char BUILTIN_TYPE_NAME_FLOAT[] = "Builtin.Float";
 /// The name of the Builtin type for NativeObject
-static const char BUILTIN_TYPE_NAME_NATIVEOBJECT[] = "Builtin.NativeObject";
+constexpr static const char BUILTIN_TYPE_NAME_NATIVEOBJECT[] =
+    "Builtin.NativeObject";
 /// The name of the Builtin type for BridgeObject
-static const char BUILTIN_TYPE_NAME_BRIDGEOBJECT[] = "Builtin.BridgeObject";
+constexpr static const char BUILTIN_TYPE_NAME_BRIDGEOBJECT[] =
+    "Builtin.BridgeObject";
 /// The name of the Builtin type for RawPointer
-static const char BUILTIN_TYPE_NAME_RAWPOINTER[] = "Builtin.RawPointer";
+constexpr static const char BUILTIN_TYPE_NAME_RAWPOINTER[] =
+    "Builtin.RawPointer";
 /// The name of the Builtin type for UnsafeValueBuffer
-static const char BUILTIN_TYPE_NAME_UNSAFEVALUEBUFFER[] = "Builtin.UnsafeValueBuffer";
+constexpr static const char BUILTIN_TYPE_NAME_UNSAFEVALUEBUFFER[] =
+    "Builtin.UnsafeValueBuffer";
 /// The name of the Builtin type for UnknownObject
-static const char BUILTIN_TYPE_NAME_UNKNOWNOBJECT[] = "Builtin.UnknownObject";
+constexpr static const char BUILTIN_TYPE_NAME_UNKNOWNOBJECT[] =
+    "Builtin.UnknownObject";
 /// The name of the Builtin type for Vector
-static const char BUILTIN_TYPE_NAME_VEC[] = "Builtin.Vec";
+constexpr static const char BUILTIN_TYPE_NAME_VEC[] = "Builtin.Vec";
 /// The name of the Builtin type for SILToken
-static const char BUILTIN_TYPE_NAME_SILTOKEN[] = "Builtin.SILToken";
+constexpr static const char BUILTIN_TYPE_NAME_SILTOKEN[] = "Builtin.SILToken";
 /// The name of the Builtin type for Word
-static const char BUILTIN_TYPE_NAME_WORD[] = "Builtin.Word";
-
+constexpr static const char BUILTIN_TYPE_NAME_WORD[] = "Builtin.Word";
 } // end namespace swift
 
 #endif // SWIFT_STRINGS_H


### PR DESCRIPTION
[strliteral-upgrade] Change Strings.h constants to be constexpr static instead of static.

Otherwise they can not be passed to StringLiteral. That would prevent me from
landing DaveZ's StringSwitch improvements from apple/swift-llvm#84 since
StringSwitch only takes StringLiterals now.
