### PR TITLE
[stdlib] Add compatibility typealias for CountablePartialRangeFrom

### DIFF
--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -498,6 +498,7 @@ extension ClosedRange {
 
 @available(*, deprecated, renamed: "ClosedRange.Index")
 public typealias ClosedRangeIndex<T> = ClosedRange<T>.Index where T: Strideable, T.Stride: SignedInteger
-@available(*, deprecated, renamed: "ClosedRange")
+
+@available(*, deprecated: 4.2, renamed: "ClosedRange")
 public typealias CountableClosedRange<Bound: Strideable> = ClosedRange<Bound>
   where Bound.Stride : SignedInteger

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -911,11 +911,3 @@ public typealias CountableRange<Bound: Strideable> = Range<Bound>
 @available(*, deprecated: 4.2, renamed: "PartialRangeFrom")
 public typealias CountablePartialRangeFrom<Bound: Strideable> = PartialRangeFrom<Bound>
   where Bound.Stride : SignedInteger
-
-@available(*, deprecated: 4.2, renamed: "PartialRangeUpTo")
-public typealias CountablePartialRangeUpTo<Bound: Strideable> = PartialRangeUpTo<Bound>
-  where Bound.Stride : SignedInteger
-
-@available(*, deprecated: 4.2, renamed: "PartialRangeThrough")
-public typealias CountablePartialRangeThrough<Bound: Strideable> = PartialRangeThrough<Bound>
-  where Bound.Stride : SignedInteger

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -907,3 +907,15 @@ extension Range {
 @available(*, deprecated, renamed: "Range")
 public typealias CountableRange<Bound: Strideable> = Range<Bound>
   where Bound.Stride : SignedInteger
+
+@available(*, deprecated: 4.2, renamed: "PartialRangeFrom")
+public typealias CountablePartialRangeFrom<Bound: Strideable> = PartialRangeFrom<Bound>
+  where Bound.Stride : SignedInteger
+
+@available(*, deprecated: 4.2, renamed: "PartialRangeUpTo")
+public typealias CountablePartialRangeUpTo<Bound: Strideable> = PartialRangeUpTo<Bound>
+  where Bound.Stride : SignedInteger
+
+@available(*, deprecated: 4.2, renamed: "PartialRangeThrough")
+public typealias CountablePartialRangeThrough<Bound: Strideable> = PartialRangeThrough<Bound>
+  where Bound.Stride : SignedInteger

--- a/validation-test/stdlib/Range.swift.gyb
+++ b/validation-test/stdlib/Range.swift.gyb
@@ -790,8 +790,6 @@ MiscTestSuite.test("reversed()") {
 
 MiscTestSuite.test("Compatibility typealiases") {
   let _: CountablePartialRangeFrom = 1...
-  let _: CountablePartialRangeUpTo = ..<2
-  let _: CountablePartialRangeThrough = ...3
   let _: CountableRange = MinimalStrideableValue(3)..<MinimalStrideableValue(3)
   let _: CountableClosedRange = MinimalStrideableValue(3)...MinimalStrideableValue(3)
 }

--- a/validation-test/stdlib/Range.swift.gyb
+++ b/validation-test/stdlib/Range.swift.gyb
@@ -788,5 +788,13 @@ MiscTestSuite.test("reversed()") {
     result)
 }
 
+MiscTestSuite.test("Compatibility typealiases") {
+  let _: CountablePartialRangeFrom = 1...
+  let _: CountablePartialRangeUpTo = ..<2
+  let _: CountablePartialRangeThrough = ...3
+  let _: CountableRange = MinimalStrideableValue(3)..<MinimalStrideableValue(3)
+  let _: CountableClosedRange = MinimalStrideableValue(3)...MinimalStrideableValue(3)
+}
+
 runAllTests()
 


### PR DESCRIPTION
These type aliases for partial ranges were missed in the removal of `CountableRange`