### PR TITLE
[4.2][stdlib] Make sure _SwiftNewtypeWrapper hashes the same way as its RawValue

### DIFF
--- a/stdlib/public/core/NewtypeWrapper.swift
+++ b/stdlib/public/core/NewtypeWrapper.swift
@@ -15,10 +15,15 @@
 /// attribute.
 public protocol _SwiftNewtypeWrapper : RawRepresentable { }
 
-extension _SwiftNewtypeWrapper where Self.RawValue : Hashable {
+extension _SwiftNewtypeWrapper where Self: Hashable, Self.RawValue : Hashable {
   @_inlineable // FIXME(sil-serialize-all)
   public var hashValue: Int {
     return rawValue.hashValue
+  }
+
+  @_inlineable // FIXME(sil-serialize-all)
+  public func _hash(into hasher: inout _Hasher) {
+    hasher.append(rawValue)
   }
 }
 


### PR DESCRIPTION

`_SwiftNewtypeWrapper` forwarded hashValue to its rawValue, but it failed to do the same for `_hash(into:)`, which resulted in the wrapper struct having subtly different hashing than the raw value.

This violated an implicit invariant when dictionaries/sets of such types were bridged to Objective-C through `AnyHashable`, leading to nondeterministic but frequent crashes.

rdar://problem/39398060

(cherry picked from commit 6c5a6a6a16d0c080876bfe1b31ce366c7c33d1b9)
