### PR TITLE
migrator: handle return value migration introduced by string enum changes.

### DIFF
--- a/include/swift/Migrator/EditorAdapter.h
+++ b/include/swift/Migrator/EditorAdapter.h
@@ -51,6 +51,8 @@ class EditorAdapter {
   /// below. That doesn't handle duplicate or redundant changes.
   mutable llvm::SmallSet<Replacement, 32> Replacements;
 
+  bool CacheEnabled;
+
   /// A running transactional collection of basic edit operations.
   /// Clang uses this transaction concept to cancel a batch of edits due to
   /// incompatibilities, such as those due to macro expansions, but we don't
@@ -82,7 +84,7 @@ class EditorAdapter {
 public:
   EditorAdapter(swift::SourceManager &SwiftSrcMgr,
                 clang::SourceManager &ClangSrcMgr)
-    : SwiftSrcMgr(SwiftSrcMgr), ClangSrcMgr(ClangSrcMgr),
+    : SwiftSrcMgr(SwiftSrcMgr), ClangSrcMgr(ClangSrcMgr), CacheEnabled(true),
       Edits(clang::edit::Commit(ClangSrcMgr, clang::LangOptions())) {}
 
   /// Lookup the BufferID in the SwiftToClangBufferMap. If it doesn't exist,
@@ -128,6 +130,8 @@ public:
   const clang::edit::Commit &getEdits() const {
     return Edits;
   }
+  void enableCache() { CacheEnabled = true; }
+  void disableCache() { CacheEnabled = false; }
 };
 
 } // end namespace migrator

--- a/lib/Migrator/EditorAdapter.cpp
+++ b/lib/Migrator/EditorAdapter.cpp
@@ -29,6 +29,8 @@ EditorAdapter::getLocInfo(swift::SourceLoc Loc) const {
 
 bool
 EditorAdapter::cacheReplacement(CharSourceRange Range, StringRef Text) const {
+  if (!CacheEnabled)
+    return false;
   unsigned SwiftBufferID, Offset;
   std::tie(SwiftBufferID, Offset) = getLocInfo(Range.getStart());
   Replacement R { Offset, Range.getByteLength(), Text };

--- a/test/Migrator/Inputs/Cities.swift
+++ b/test/Migrator/Inputs/Cities.swift
@@ -42,4 +42,12 @@ public class Container {
   public init(optionalAttributes: [String: Any]?) {}
   public func adding(attrArray: [String]) {}
   public init(optionalAttrArray: [String]?) {}
+  public func add(single: String) {}
+  public func add(singleOptional: String?) {}
+  public func getAttrArray() -> [String] { return [] }
+  public func getOptionalAttrArray() -> [String]? { return [] }
+  public func getAttrDictionary() -> [String: Any] { return [:] }
+  public func getOptionalAttrDictionary() -> [String: Any]? { return nil }
+  public func getSingleAttr() -> String { return "" }
+  public func getOptionalSingleAttr() -> String? { return nil }
 }

--- a/test/Migrator/Inputs/string-representable.json
+++ b/test/Migrator/Inputs/string-representable.json
@@ -76,4 +76,92 @@
     "RightComment": "SimpleAttribute",
     "ModuleName": "Cities"
   },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "SimpleStringRepresentableUpdate",
+    "ChildIndex": "1",
+    "LeftUsr": "s:6Cities9ContainerC3add6singleySS_tF",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "SimpleAttribute",
+    "ModuleName": "Cities"
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "SimpleOptionalStringRepresentableUpdate",
+    "ChildIndex": "1",
+    "LeftUsr": "s:6Cities9ContainerC3add14singleOptionalySSSg_tF",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "SimpleAttribute",
+    "ModuleName": "Cities"
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "SimpleStringRepresentableUpdate",
+    "ChildIndex": "0",
+    "LeftUsr": "s:6Cities9ContainerC13getSingleAttrSSyF",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "SimpleAttribute",
+    "ModuleName": "Cities"
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "SimpleOptionalStringRepresentableUpdate",
+    "ChildIndex": "0",
+    "LeftUsr": "s:6Cities9ContainerC21getOptionalSingleAttrSSSgyF",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "SimpleAttribute",
+    "ModuleName": "Cities"
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "ArrayMemberUpdate",
+    "ChildIndex": "0",
+    "LeftUsr": "s:6Cities9ContainerC12getAttrArraySaySSGyF",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "SimpleAttribute",
+    "ModuleName": "Cities"
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "OptionalArrayMemberUpdate",
+    "ChildIndex": "0",
+    "LeftUsr": "s:6Cities9ContainerC20getOptionalAttrArraySaySSGSgyF",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "SimpleAttribute",
+    "ModuleName": "Cities"
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "OptionalDictionaryKeyUpdate",
+    "ChildIndex": "0",
+    "LeftUsr": "s:6Cities9ContainerC25getOptionalAttrDictionarys0F0VySSypGSgyF",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "SimpleAttribute",
+    "ModuleName": "Cities"
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "DictionaryKeyUpdate",
+    "ChildIndex": "0",
+    "LeftUsr": "s:6Cities9ContainerC17getAttrDictionarys0E0VySSypGyF",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "SimpleAttribute",
+    "ModuleName": "Cities"
+  },
 ]

--- a/test/Migrator/string-representable.swift
+++ b/test/Migrator/string-representable.swift
@@ -15,5 +15,17 @@ func foo(_ c: Container) -> String {
   _ = Container(optionalAttributes: nil)
   _ = Container(optionalAttrArray: nil)
   c.adding(attrArray: ["key1", "key2"])
+  c.add(single: "")
+  c.add(singleOptional: nil)
+  _ = c.getAttrDictionary()
+  _ = c.getOptionalAttrDictionary()
+  _ = c.getSingleAttr()
+  _ = c.getOptionalSingleAttr()
+  _ = c.getAttrArray()
+  _ = c.getOptionalAttrArray()
+
+  c.addingAttributes(c.getAttrDictionary())
+  c.adding(optionalAttributes: c.getAttrDictionary())
+
   return c.Value
 }

--- a/test/Migrator/string-representable.swift.expected
+++ b/test/Migrator/string-representable.swift.expected
@@ -15,6 +15,18 @@ func foo(_ c: Container) -> String {
   _ = Container(optionalAttributes: convertToOptionalSimpleAttributeDictionary(nil))
   _ = Container(optionalAttrArray: convertToOptionalSimpleAttributeArray(nil))
   c.adding(attrArray: convertToSimpleAttributeArray(["key1", "key2"]))
+  c.add(single: convertToSimpleAttribute(""))
+  c.add(singleOptional: convertToOptionalSimpleAttribute(nil))
+  _ = convertFromSimpleAttributeDictionary(c.getAttrDictionary())
+  _ = convertFromOptionalSimpleAttributeDictionary(c.getOptionalAttrDictionary())
+  _ = convertFromSimpleAttribute(c.getSingleAttr())
+  _ = convertFromOptionalSimpleAttribute(c.getOptionalSingleAttr())
+  _ = convertFromSimpleAttributeArray(c.getAttrArray())
+  _ = convertFromOptionalSimpleAttributeArray(c.getOptionalAttrArray())
+
+  c.addingAttributes(convertToCitiesContainerAttributeDictionary(convertFromSimpleAttributeDictionary(c.getAttrDictionary())))
+  c.adding(optionalAttributes: convertToOptionalSimpleAttributeDictionary(convertFromSimpleAttributeDictionary(c.getAttrDictionary())))
+
   return c.Value.rawValue
 }
 
@@ -43,4 +55,48 @@ fileprivate func convertToOptionalSimpleAttributeArray(_ input: [String]?) -> [S
 // Helper function inserted by Swift 4.2 migrator.
 fileprivate func convertToSimpleAttributeArray(_ input: [String]) -> [SimpleAttribute] {
 	return input.map { key in SimpleAttribute(key) }
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func convertToSimpleAttribute(_ input: String) -> SimpleAttribute {
+	return SimpleAttribute(rawValue: input)
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func convertToOptionalSimpleAttribute(_ input: String?) -> SimpleAttribute? {
+	guard let input = input else { return nil }
+	return SimpleAttribute(rawValue: input)
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func convertFromSimpleAttributeDictionary(_ input: [SimpleAttribute: Any]) -> [String: Any] {
+	return Dictionary(uniqueKeysWithValues: input.map {key, value in (key.rawValue, value)})
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func convertFromOptionalSimpleAttributeDictionary(_ input: [SimpleAttribute: Any]?) -> [String: Any]? {
+	guard let input = input else { return nil }
+	return Dictionary(uniqueKeysWithValues: input.map {key, value in (key.rawValue, value)})
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func convertFromSimpleAttribute(_ input: SimpleAttribute) -> String {
+	return input.rawValue
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func convertFromOptionalSimpleAttribute(_ input: SimpleAttribute?) -> String? {
+	guard let input = input else { return nil }
+	return input.rawValue
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func convertFromSimpleAttributeArray(_ input: [SimpleAttribute]) -> [String] {
+	return input.map { key in key.rawValue }
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func convertFromOptionalSimpleAttributeArray(_ input: [SimpleAttribute]?) -> [String]? {
+	guard let input = input else { return nil }
+	return input.map { key in key.rawValue }
 }


### PR DESCRIPTION
This patch migrates the function call whose return type used to "String" and
now becomes "StringRepresentableStruct".