### PR TITLE
AST-verify that 'open' is only used where appropriate

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -6703,7 +6703,8 @@ inline bool ValueDecl::isImportAsMember() const {
 inline bool Decl::isPotentiallyOverridable() const {
   if (isa<VarDecl>(this) ||
       isa<SubscriptDecl>(this) ||
-      isa<FuncDecl>(this)) {
+      isa<FuncDecl>(this) ||
+      isa<DestructorDecl>(this)) {
     return getDeclContext()->getAsClassOrClassExtensionContext();
   } else {
     return false;

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2114,11 +2114,20 @@ public:
     }
 
     void verifyChecked(ValueDecl *VD) {
-      if (!VD->hasAccess() && !VD->getDeclContext()->isLocalContext() &&
-          !isa<GenericTypeParamDecl>(VD) && !isa<ParamDecl>(VD)) {
-        dumpRef(VD);
-        Out << " does not have access";
-        abort();
+      if (VD->hasAccess()) {
+        if (VD->getFormalAccess() == AccessLevel::Open &&
+            !isa<ClassDecl>(VD) && !VD->isPotentiallyOverridable()) {
+          Out << "decl cannot be 'open'\n";
+          VD->dump(Out);
+          abort();
+        }
+      } else {
+        if (!VD->getDeclContext()->isLocalContext() &&
+            !isa<GenericTypeParamDecl>(VD) && !isa<ParamDecl>(VD)) {
+          dumpRef(VD);
+          Out << " does not have access";
+          abort();
+        }
       }
 
       // Make sure that there are no archetypes in the interface type.

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2282,7 +2282,8 @@ void ValueDecl::copyFormalAccessFrom(const ValueDecl *source,
   // Inherit the @usableFromInline attribute.
   if (source->getAttrs().hasAttribute<UsableFromInlineAttr>() &&
       !getAttrs().hasAttribute<UsableFromInlineAttr>() &&
-      !getAttrs().hasAttribute<InlinableAttr>()) {
+      !getAttrs().hasAttribute<InlinableAttr>() &&
+      DeclAttribute::canAttributeAppearOnDecl(DAK_UsableFromInline, this)) {
     auto &ctx = getASTContext();
     auto *clonedAttr = new (ctx) UsableFromInlineAttr(/*implicit=*/true);
     getAttrs().add(clonedAttr);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -105,9 +105,9 @@ static bool isInSystemModule(DeclContext *D) {
   return cast<ClangModuleUnit>(D->getModuleScopeContext())->isSystemModule();
 }
 
-static AccessLevel getOverridableAccessLevel(DeclContext *dc) {
-  return (dc->getAsProtocolOrProtocolExtensionContext()
-            ? AccessLevel::Public : AccessLevel::Open);
+static AccessLevel getOverridableAccessLevel(const DeclContext *dc) {
+  return (dc->getAsClassOrClassExtensionContext()
+            ? AccessLevel::Open : AccessLevel::Public);
 }
 
 /// Create a typedpattern(namedpattern(decl))

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2178,9 +2178,7 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
       // a typealias added for an internal protocol shouldn't need to be
       // public---but that can be problematic if the same type conforms to two
       // protocols with different access levels.
-      AccessLevel aliasAccess = nominal->getFormalAccess();
-      aliasAccess = std::max(aliasAccess, AccessLevel::Internal);
-      aliasDecl->setAccess(aliasAccess);
+      aliasDecl->copyFormalAccessFrom(nominal, /*sourceIsParentContext*/true);
 
       if (nominal == DC) {
         nominal->addMember(aliasDecl);

--- a/test/attr/accessibility_print.swift
+++ b/test/attr/accessibility_print.swift
@@ -345,8 +345,8 @@ public class IC_PublicAssocTypeImpl: IA_PublicAssocTypeProto, IB_FilePrivateAsso
 private class ID_PrivateAssocTypeImpl: IA_PublicAssocTypeProto, IB_FilePrivateAssocTypeProto {
   public var publicValue: Int = 0
   public var filePrivateValue: Int = 0
-  // CHECK-DAG: {{^}} internal typealias PublicValue
-  // CHECK-DAG: {{^}} internal typealias FilePrivateValue
+  // CHECK-DAG: {{^}} fileprivate typealias PublicValue
+  // CHECK-DAG: {{^}} fileprivate typealias FilePrivateValue
 } // CHECK: {{^[}]}}
 
 // CHECK-LABEL: class MultipleAttributes {


### PR DESCRIPTION
...and fix places where it was being used inappropriately. This should have no effect in practice, but it does change the formal access level of some declarations from 'open' to 'public' (where 'open' didn't make sense) and from 'internal' down to 'fileprivate' (where 'internal' was overly generous for some synthesized declarations).