### PR TITLE
 [AST] Optimize collection upcasts of collection literals. 

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -554,7 +554,7 @@ namespace {
                                   Type valueType,
                                   ConstraintLocatorBuilder locator);
 
-    /// Try to peephole the collection upcast, eliminating that need for
+    /// Try to peephole the collection upcast, eliminating the need for
     /// a separate collection-upcast expression.
     ///
     /// \returns true if the peephole operation succeeded, in which case
@@ -6244,22 +6244,18 @@ static Expr *buildElementConversion(ExprRewriter &rewriter,
                                     Expr *element) {
   auto &cs = rewriter.getConstraintSystem();
 
-  Expr *conversion = nullptr;
-
   auto &tc = rewriter.getConstraintSystem().getTypeChecker();
   if (bridged &&
       tc.typeCheckCheckedCast(srcType, destType,
                               CheckedCastContextKind::None, cs.DC,
                               SourceLoc(), nullptr, SourceRange())
         != CheckedCastKind::Coercion) {
-    conversion = rewriter.buildObjCBridgeExpr(element, destType, locator);
+    if (auto conversion =
+          rewriter.buildObjCBridgeExpr(element, destType, locator))
+        return conversion;
   }
 
-  if (!conversion) {
-    conversion = rewriter.coerceToType(element, destType, locator);
-  }
-
-  return conversion;
+  return rewriter.coerceToType(element, destType, locator);
 }
 
 static CollectionUpcastConversionExpr::ConversionPair

--- a/test/expr/primary/literal/collection_upcast_opt.swift
+++ b/test/expr/primary/literal/collection_upcast_opt.swift
@@ -22,3 +22,14 @@ struct TakesArray<T> {
 func arrayUpcast(_ x1: @escaping (P) -> Void, _ x2: @escaping (P) -> Void) {
   _ = TakesArray<X>([x1, x2])
 }
+
+struct TakesDictionary<T> {
+  init(_: [Int : (T) -> Void]) { }
+}
+
+// CHECK-LABEL: func_decl "dictionaryUpcast(_:_:)"
+// CHECK: assign_expr
+// CHECK-NOT: collection_upcast_expr
+func dictionaryUpcast(_ x1: @escaping (P) -> Void, _ x2: @escaping (P) -> Void) {
+  _ = TakesDictionary<X>([1: x1, 2: x2])
+}

--- a/test/expr/primary/literal/collection_upcast_opt.swift
+++ b/test/expr/primary/literal/collection_upcast_opt.swift
@@ -2,7 +2,7 @@
 // RUN: %FileCheck %s < %t.ast
 
 // Verify that upcasts of array literals upcast the individual elements in place
-// rather than
+// rather than introducing a collection_upcast_expr.
 
 protocol P { }
 struct X : P { }

--- a/test/expr/primary/literal/collection_upcast_opt.swift
+++ b/test/expr/primary/literal/collection_upcast_opt.swift
@@ -1,0 +1,24 @@
+// RUN: %target-typecheck-verify-swift -dump-ast 2> %t.ast
+// RUN: %FileCheck %s < %t.ast
+
+// Verify that upcasts of array literals upcast the individual elements in place
+// rather than
+
+protocol P { }
+struct X : P { }
+
+struct TakesArray<T> {
+  init(_: [(T) -> Void]) { }
+}
+
+// CHECK-LABEL: func_decl "arrayUpcast(_:_:)"
+// CHECK: assign_expr
+// CHECK-NOT: collection_upcast_expr
+// CHECK: array_expr type='[(X) -> Void]'
+// CHECK-NEXT: function_conversion_expr implicit type='(X) -> Void'
+// CHECK-NEXT: {{declref_expr.*x1}}
+// CHECK-NEXT: function_conversion_expr implicit type='(X) -> Void'
+// CHECK-NEXT: {{declref_expr.*x2}}
+func arrayUpcast(_ x1: @escaping (P) -> Void, _ x2: @escaping (P) -> Void) {
+  _ = TakesArray<X>([x1, x2])
+}

--- a/test/expr/primary/literal/collection_upcast_opt.swift
+++ b/test/expr/primary/literal/collection_upcast_opt.swift
@@ -30,6 +30,9 @@ struct TakesDictionary<T> {
 // CHECK-LABEL: func_decl "dictionaryUpcast(_:_:)"
 // CHECK: assign_expr
 // CHECK-NOT: collection_upcast_expr
+// CHECK: paren_expr type='([Int : (X) -> Void])'
+// CHECK-NOT: collection_upcast_expr
+// CHECK: (dictionary_expr type='[Int : (X) -> Void]'
 func dictionaryUpcast(_ x1: @escaping (P) -> Void, _ x2: @escaping (P) -> Void) {
-  _ = TakesDictionary<X>([1: x1, 2: x2])
+  _ = TakesDictionary<X>(([1: x1, 2: x2]))
 }


### PR DESCRIPTION
When we form a collection upcast of a collection literal, upcast the
individual elements directly so we avoid a call through the
runtime. This both improves code generation and sidesteps a regression
involving the inability to dynamically cast function types.

Fixes [SR-7362](https://bugs.swift.org/browse/SR-7362) / rdar://problem/39218656.