### PR TITLE
[4.2][stdlib] Add compatibility typealias for CountablePartialRangeFrom

### DIFF
--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -478,6 +478,7 @@ extension ClosedRange {
 
 @available(*, deprecated, renamed: "ClosedRange.Index")
 public typealias ClosedRangeIndex<T> = ClosedRange<T>.Index where T: Strideable, T.Stride: SignedInteger
-@available(*, deprecated, renamed: "ClosedRange")
+
+@available(*, deprecated: 4.2, renamed: "ClosedRange")
 public typealias CountableClosedRange<Bound: Strideable> = ClosedRange<Bound>
   where Bound.Stride : SignedInteger

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -880,3 +880,7 @@ extension Range {
 @available(*, deprecated, renamed: "Range")
 public typealias CountableRange<Bound: Strideable> = Range<Bound>
   where Bound.Stride : SignedInteger
+
+@available(*, deprecated: 4.2, renamed: "PartialRangeFrom")
+public typealias CountablePartialRangeFrom<Bound: Strideable> = PartialRangeFrom<Bound>
+  where Bound.Stride : SignedInteger

--- a/validation-test/stdlib/Range.swift.gyb
+++ b/validation-test/stdlib/Range.swift.gyb
@@ -788,5 +788,11 @@ MiscTestSuite.test("reversed()") {
     result)
 }
 
+MiscTestSuite.test("Compatibility typealiases") {
+  let _: CountablePartialRangeFrom = 1...
+  let _: CountableRange = MinimalStrideableValue(3)..<MinimalStrideableValue(3)
+  let _: CountableClosedRange = MinimalStrideableValue(3)...MinimalStrideableValue(3)
+}
+
 runAllTests()
 


### PR DESCRIPTION
4.2 version of #15989 
