### PR TITLE
IRGen: New way of bypassing resilience for LLDB

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -152,6 +152,9 @@ public:
   /// Enables resilient class layout.
   unsigned EnableClassResilience : 1;
 
+  /// Bypass resilience when accessing resilient frameworks.
+  unsigned EnableResilienceBypass : 1;
+
   /// Should we try to build incrementally by not emitting an object file if it
   /// has the same IR hash as the module that we are preparing to emit?
   ///
@@ -185,8 +188,8 @@ public:
         EmbedMode(IRGenEmbedMode::None), HasValueNamesSetting(false),
         ValueNames(false), EnableReflectionMetadata(true),
         EnableReflectionNames(true), EnableClassResilience(false),
-        UseIncrementalLLVMCodeGen(true), UseSwiftCall(false),
-        GenerateProfile(false), CmdArgs(),
+        EnableResilienceBypass(false), UseIncrementalLLVMCodeGen(true),
+        UseSwiftCall(false), GenerateProfile(false), CmdArgs(),
         SanitizeCoverage(llvm::SanitizerCoverageOptions()) {}
 
   // Get a hash of all options which influence the llvm compilation but are not

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -450,6 +450,9 @@ def enable_resilience : Flag<["-"], "enable-resilience">,
 def enable_class_resilience : Flag<["-"], "enable-class-resilience">,
    HelpText<"Enable resilient layout for classes containing resilient value types">;
 
+def enable_resilience_bypass : Flag<["-"], "enable-resilience-bypass">,
+   HelpText<"Completely bypass resilience when accessing types in resilient frameworks">;
+
 def group_info_path : Separate<["-"], "group-info-path">,
   HelpText<"The path to collect the group information of the compiled module">;
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -903,6 +903,10 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
     Opts.EnableClassResilience = true;
   }
 
+  if (Args.hasArg(OPT_enable_resilience_bypass)) {
+    Opts.EnableResilienceBypass = true;
+  }
+
   for (const auto &Lib : Args.getAllArgValues(options::OPT_autolink_library))
     Opts.LinkLibraries.push_back(LinkLibrary(Lib, LibraryKind::Library));
 

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1064,7 +1064,15 @@ static ProtocolInfo *invalidProtocolInfo() { return (ProtocolInfo*) 1; }
 TypeConverter::TypeConverter(IRGenModule &IGM)
   : IGM(IGM),
     FirstType(invalidTypeInfo()),
-    FirstProtocol(invalidProtocolInfo()) {}
+    FirstProtocol(invalidProtocolInfo()) {
+  // FIXME: In LLDB, everything is completely fragile, so that IRGen can query
+  // the size of resilient types. Of course this is not the right long term
+  // solution, because it won't work once the swiftmodule file is not in
+  // sync with the binary module. Once LLDB can calculate type layouts at
+  // runtime (using remote mirrors or some other mechanism), we can remove this.
+  if (IGM.IRGen.Opts.EnableResilienceBypass)
+    CompletelyFragile = true;
+}
 
 TypeConverter::~TypeConverter() {
   // Delete all the converted type infos.

--- a/lib/IRGen/GenType.h
+++ b/lib/IRGen/GenType.h
@@ -222,17 +222,21 @@ public:
 
 /// An RAII interface for forcing types to be lowered bypassing resilience.
 class CompletelyFragileScope {
+  bool State;
   TypeConverter &TC;
 public:
   CompletelyFragileScope(TypeConverter &TC) : TC(TC) {
-    TC.pushCompletelyFragile();
+    State = TC.isCompletelyFragile();
+    if (!State)
+      TC.pushCompletelyFragile();
   }
 
   CompletelyFragileScope(IRGenModule &IGM)
     : CompletelyFragileScope(IGM.Types) {}
 
   ~CompletelyFragileScope() {
-    TC.popCompletelyFragile();
+    if (!State)
+      TC.popCompletelyFragile();
   }
 };
 

--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -65,11 +65,18 @@ struct IRGenContext {
 
 private:
   IRGenContext(ASTContext &ctx, ModuleDecl *module)
-    : SILMod(SILModule::createEmptyModule(module, SILOpts)),
+    : IROpts(createIRGenOptions()),
+      SILMod(SILModule::createEmptyModule(module, SILOpts)),
       IRGen(IROpts, *SILMod),
       IGM(IRGen, IRGen.createTargetMachine(), /*SourceFile*/ nullptr,
           LLVMContext, "<fake module name>", "<fake output filename>",
           "<fake main input filename>") {}
+
+  static IRGenOptions createIRGenOptions() {
+    IRGenOptions IROpts;
+    IROpts.EnableResilienceBypass = true;
+    return IROpts;
+  }
 
 public:
   static std::unique_ptr<IRGenContext>

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -200,10 +200,7 @@ FileUnit *SerializedModuleLoader::loadAST(
                        isFramework, loadedModuleFile,
                        &extendedInfo);
   if (loadInfo.status == serialization::Status::Valid) {
-    // In LLDB always use the default resilience strategy, so IRGen can query
-    // the size of resilient types.
-    if (!Ctx.LangOpts.DebuggerSupport)
-      M.setResilienceStrategy(extendedInfo.getResilienceStrategy());
+    M.setResilienceStrategy(extendedInfo.getResilienceStrategy());
 
     // We've loaded the file. Now try to bring it into the AST.
     auto fileUnit = new (Ctx) SerializedASTFile(M, *loadedModuleFile,

--- a/test/DebugInfo/resilience.swift
+++ b/test/DebugInfo/resilience.swift
@@ -9,31 +9,36 @@
 // RUN: %target-swift-frontend -g -I %t -emit-ir -enable-resilience %s  -o - \
 // RUN:  | %FileCheck %s
 //
-// RUN: %target-swift-frontend -g -I %t -emit-sil -enable-resilience %s -o - \
-// RUN:    | %FileCheck %s --check-prefix=CHECK-SIL
-// RUN: %target-swift-frontend -g -I %t -emit-sil -enable-resilience %s -o - \
-// RUN:    -debugger-support | %FileCheck %s --check-prefix=CHECK-LLDB
+// RUN: %target-swift-frontend -g -I %t -emit-ir -enable-resilience %s -o - \
+// RUN:    -enable-resilience-bypass | %FileCheck %s --check-prefix=CHECK-LLDB
 import resilient_struct
 
-func use<T>(_ t: T) {}
-
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S10resilience1fyyF"()
+// CHECK-LLDB-LABEL: define{{( protected)?}} swiftcc void @"$S10resilience1fyyF"()
 public func f() {
   let s1 = Size(w: 1, h: 2)
-  use(s1)
+  takesSize(s1)
   // CHECK: %[[ADDR:.*]] = alloca i8*
   // CHECK: call void @llvm.dbg.declare(metadata i8** %[[ADDR]],
   // CHECK-SAME:                        metadata ![[V1:[0-9]+]],
   // CHECK-SAME:                        metadata !DIExpression(DW_OP_deref))
   // CHECK: %[[S1:.*]] = alloca i8,
   // CHECK: store i8* %[[S1]], i8** %[[ADDR]]
-  // CHECK: ![[V1]] = !DILocalVariable(name: "s1", {{.*}}type: ![[TY:[0-9]+]])
-  // CHECK: ![[TY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Size",
-  // FIXME-NOT: size:
-  // CHECK: =
+
+  // CHECK-LLDB: %[[ADDR:.*]] = alloca %T16resilient_struct4SizeV
+  // CHECK-LLDB: call void @llvm.dbg.declare(metadata %T16resilient_struct4SizeV* %[[ADDR]],
+  // CHECK-LLDB-SAME:                        metadata ![[V1:[0-9]+]],
+  // CHECK-LLDB-SAME:                        metadata !DIExpression())
 }
 
-// CHECK-SIL: // f()
-// CHECK-LLDB: // f()
-// CHECK-SIL: %0 = alloc_stack $Size, let, name "s1"
-// CHECK-LLDB: %0 = metatype $@thin Size.Type
-// CHECK-LLDB: debug_value %{{.*}} : $Size, let, name "s1"
+
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S10resilience9takesSizeyy16resilient_struct0C0VF"(%swift.opaque* noalias nocapture)
+// CHECK-LLDB-LABEL: define{{( protected)?}} swiftcc void @"$S10resilience9takesSizeyy16resilient_struct0C0VF"(%T16resilient_struct4SizeV* noalias nocapture dereferenceable({{8|16}}))
+public func takesSize(_ s: Size) {}
+
+
+// CHECK: ![[V1]] = !DILocalVariable(name: "s1", {{.*}}type: ![[TY:[0-9]+]])
+// CHECK: ![[TY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Size",
+
+// CHECK-LLDB: ![[V1]] = !DILocalVariable(name: "s1", {{.*}}type: ![[TY:[0-9]+]])
+// CHECK-LLDB: ![[TY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Size",


### PR DESCRIPTION
When running Swift from within LLDB, we bypass resilience since LLDB does
not support resilience yet. However, the bypass was done too early, disabling
resilience altogether.

We still want resilience at the SIL level so that function types lower the
same with debugger support turned on and off. Only IRGen needs to bypass
resilience, so that LLDB can calculate fragile layouts of types.

Fixes <rdar://problem/38719739> and <rdar://problem/38483762>.