### PR TITLE
Coverage: fix handling of constructors and top-level decls  (SR-7446)…

### DIFF
--- a/lib/SIL/SILProfiler.cpp
+++ b/lib/SIL/SILProfiler.cpp
@@ -25,7 +25,8 @@
 
 using namespace swift;
 
-static bool isClosureWithBody(AbstractClosureExpr *ACE) {
+/// Check if a closure has a body.
+static bool doesClosureHaveBody(AbstractClosureExpr *ACE) {
   if (auto *CE = dyn_cast<ClosureExpr>(ACE))
     return CE->getBody();
   if (auto *autoCE = dyn_cast<AutoClosureExpr>(ACE))
@@ -33,79 +34,43 @@ static bool isClosureWithBody(AbstractClosureExpr *ACE) {
   return false;
 }
 
+/// Check whether a root AST node is unmapped, i.e not profiled.
 static bool isUnmapped(ASTNode N) {
   if (auto *E = N.dyn_cast<Expr *>()) {
     auto *CE = dyn_cast<AbstractClosureExpr>(E);
-    return !CE || (!isa<AutoClosureExpr>(CE) && CE->isImplicit()) ||
-           !isClosureWithBody(CE);
+
+    // Only map closure expressions with bodies.
+    if (!CE || !doesClosureHaveBody(CE))
+      return true;
+
+    // Don't map implicit closures, unless they're autoclosures.
+    if (!isa<AutoClosureExpr>(CE) && CE->isImplicit())
+      return true;
+
+    return false;
   }
 
   auto *D = N.get<Decl *>();
   if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D)) {
+    // Don't map functions without bodies.
     if (!AFD->getBody())
       return true;
 
+    // Map all *structors, even if they are implicit.
+    if (isa<ConstructorDecl>(D) || isa<DestructorDecl>(D))
+      return false;
+
+    // Map implicit getters.
     if (auto *accessor = dyn_cast<AccessorDecl>(AFD))
       if (accessor->isImplicit() && accessor->isGetter())
         return false;
   }
 
-  if (isa<ConstructorDecl>(D) || isa<DestructorDecl>(D))
-    return false;
+  // Skip any remaining implicit, or otherwise unsupported decls.
+  if (D->isImplicit() || isa<EnumCaseDecl>(D))
+    return true;
 
-  return D->isImplicit() || isa<EnumCaseDecl>(D);
-}
-
-/// A simple heuristic to determine whether \p E contains a definition of a
-/// closure. This is not complete, but it suffices to cheaply filter away some
-/// redundant coverage mappings.
-static bool containsClosure(Expr *E) {
-  Expr *candidateExpr = E;
-  if (auto *ce = dyn_cast<CallExpr>(E))
-    candidateExpr = ce->getDirectCallee();
-  return dyn_cast_or_null<AbstractClosureExpr>(candidateExpr);
-}
-
-/// Walk the non-static initializers in \p PBD.
-static void walkPatternForProfiling(PatternBindingDecl *PBD, ASTWalker &Walker,
-                                    bool AllowClosures = true) {
-  if (PBD && !PBD->isStatic())
-    for (auto E : PBD->getPatternList())
-      if (E.getInit())
-        if (AllowClosures || !containsClosure(E.getInit()))
-          E.getInit()->walk(Walker);
-}
-
-/// Walk the AST of \c Root and related nodes that are relevant for profiling.
-static void walkFunctionForProfiling(AbstractFunctionDecl *Root,
-                                     ASTWalker &Walker) {
-  Root->walk(Walker);
-
-  // We treat non-closure member initializers as part of the constructor for
-  // profiling.
-  if (auto *CD = dyn_cast<ConstructorDecl>(Root)) {
-    auto *NominalType =
-        CD->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
-    for (auto *Member : NominalType->getMembers()) {
-      // Find pattern binding declarations that have initializers.
-      if (auto *PBD = dyn_cast<PatternBindingDecl>(Member))
-        walkPatternForProfiling(PBD, Walker, /*AllowClosures=*/false);
-    }
-  }
-}
-
-/// Walk \p D for profiling.
-static void walkForProfiling(ASTNode N, ASTWalker &Walker) {
-  if (auto *D = N.dyn_cast<Decl *>()) {
-    if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D))
-      walkFunctionForProfiling(AFD, Walker);
-    else if (auto *PBD = dyn_cast<PatternBindingDecl>(D))
-      walkPatternForProfiling(PBD, Walker);
-    else if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D))
-      TLCD->walk(Walker);
-  } else if (auto *E = N.dyn_cast<Expr *>()) {
-    cast<AbstractClosureExpr>(E)->walk(Walker);
-  }
+  return false;
 }
 
 namespace swift {
@@ -122,26 +87,42 @@ static bool hasASTBeenTypeChecked(ASTNode N) {
   return !SF || SF->ASTStage >= SourceFile::TypeChecked;
 }
 
+/// Check whether a mapped AST node requires a new profiler.
+static bool canCreateProfilerForAST(ASTNode N) {
+  assert(hasASTBeenTypeChecked(N) && "Cannot use this AST for profiling");
+
+  if (auto *D = N.dyn_cast<Decl *>()) {
+    // Any mapped function may be profiled. There's an exception for
+    // constructors because all of the constructors for a type share a single
+    // profiler.
+    if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D))
+      return !isa<ConstructorDecl>(AFD);
+
+    if (isa<TopLevelCodeDecl>(D))
+      return true;
+
+    if (isa<NominalTypeDecl>(D))
+      return true;
+  } else {
+    auto *E = N.get<Expr *>();
+    if (isa<AbstractClosureExpr>(E))
+      return true;
+  }
+  return false;
+}
+
 SILProfiler *SILProfiler::create(SILModule &M, ForDefinition_t forDefinition,
                                  ASTNode N) {
   // Avoid generating profiling state for declarations.
   if (!forDefinition)
     return nullptr;
 
-  assert(hasASTBeenTypeChecked(N) && "Cannot use this AST for code coverage");
-
-  if (auto *D = N.dyn_cast<Decl *>()) {
-    assert(isa<AbstractFunctionDecl>(D) ||
-           isa<TopLevelCodeDecl>(D) && "Cannot create profiler");
-  } else if (auto *E = N.dyn_cast<Expr *>()) {
-    assert(isa<AbstractClosureExpr>(E) && "Cannot create profiler");
-  } else {
-    llvm_unreachable("Invalid AST node for profiling");
-  }
-
   const auto &Opts = M.getOptions();
   if (!doesASTRequireProfiling(M, N) && Opts.UseProfile.empty())
     return nullptr;
+
+  if (!canCreateProfilerForAST(N))
+    llvm_unreachable("Invalid AST node for profiling");
 
   auto *Buf = M.allocate<SILProfiler>(1);
   auto *SP = ::new (Buf) SILProfiler(M, N, Opts.EmitProfileCoverageMapping);
@@ -150,6 +131,15 @@ SILProfiler *SILProfiler::create(SILModule &M, ForDefinition_t forDefinition,
 }
 
 namespace {
+
+/// Walk the non-static initializers in \p PBD.
+static void walkPatternForProfiling(PatternBindingDecl *PBD,
+                                    ASTWalker &Walker) {
+  if (PBD && !PBD->isStatic())
+    for (auto E : PBD->getPatternList())
+      if (E.getInit())
+        E.getInit()->walk(Walker);
+}
 
 /// Special logic for handling closure visitation.
 ///
@@ -169,25 +159,35 @@ std::pair<bool, Expr *> visitClosureExpr(ASTWalker &Walker,
 /// An ASTWalker that maps ASTNodes to profiling counters.
 struct MapRegionCounters : public ASTWalker {
   /// The next counter value to assign.
-  unsigned NextCounter;
+  unsigned NextCounter = 0;
 
   /// The map of statements to counters.
   llvm::DenseMap<ASTNode, unsigned> &CounterMap;
 
+  /// A flag indicating whether we're walking a nominal type.
+  bool WithinNominalType = false;
+
   MapRegionCounters(llvm::DenseMap<ASTNode, unsigned> &CounterMap)
-      : NextCounter(0), CounterMap(CounterMap) {}
+      : CounterMap(CounterMap) {}
 
   bool walkToDeclPre(Decl *D) override {
     if (isUnmapped(D))
       return false;
+
     if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D)) {
-      bool FirstDecl = Parent.isNull();
-      if (FirstDecl)
+      // Don't map a nested function unless it's a constructor.
+      bool continueWalk = Parent.isNull() || isa<ConstructorDecl>(AFD);
+      if (continueWalk)
         CounterMap[AFD->getBody()] = NextCounter++;
-      return FirstDecl;
-    }
-    if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D))
+      return continueWalk;
+    } else if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
       CounterMap[TLCD->getBody()] = NextCounter++;
+    } else if (isa<NominalTypeDecl>(D)) {
+      bool continueWalk = Parent.isNull();
+      if (continueWalk)
+        WithinNominalType = true;
+      return continueWalk;
+    }
     return true;
   }
 
@@ -559,7 +559,11 @@ private:
   /// \brief A stack of active repeat-while loops.
   std::vector<RepeatWhileStmt *> RepeatWhileStack;
 
-  CounterExpr *ExitCounter;
+  CounterExpr *ExitCounter = nullptr;
+
+  Stmt *ImplicitTopLevelBody = nullptr;
+
+  NominalTypeDecl *ParentNominalType = nullptr;
 
   /// \brief Return true if \c Node has an associated counter.
   bool hasCounter(ASTNode Node) { return CounterMap.count(Node); }
@@ -761,19 +765,40 @@ public:
   bool walkToDeclPre(Decl *D) override {
     if (isUnmapped(D))
       return false;
+
     if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D)) {
-      bool FirstDecl = Parent.isNull();
-      if (FirstDecl)
-        assignCounter(AFD->getBody());
-      return FirstDecl;
-    }
-    else if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D))
+      // Don't map a nested function unless it's a constructor.
+      bool continueWalk = Parent.isNull() || isa<ConstructorDecl>(AFD);
+      if (continueWalk) {
+        CounterExpr &funcCounter = assignCounter(AFD->getBody());
+
+        if (isa<ConstructorDecl>(AFD))
+          addToCounter(ParentNominalType, funcCounter);
+      }
+      return continueWalk;
+    } else if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
       assignCounter(TLCD->getBody());
+      ImplicitTopLevelBody = TLCD->getBody();
+    } else if (auto *NTD = dyn_cast<NominalTypeDecl>(D)) {
+      bool continueWalk = Parent.isNull();
+      if (continueWalk) {
+        ParentNominalType = NTD;
+        assignCounter(NTD, CounterExpr::Zero());
+        pushRegion(NTD);
+      }
+      return continueWalk;
+    }
+    return true;
+  }
+
+  bool walkToDeclPost(Decl *D) override {
+    if (isa<TopLevelCodeDecl>(D))
+      ImplicitTopLevelBody = nullptr;
     return true;
   }
 
   std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
-    if (S->isImplicit())
+    if (S->isImplicit() && S != ImplicitTopLevelBody)
       return {true, S};
 
     if (!RegionStack.empty())
@@ -834,7 +859,7 @@ public:
   }
 
   Stmt *walkToStmtPost(Stmt *S) override {
-    if (S->isImplicit())
+    if (S->isImplicit() && S != ImplicitTopLevelBody)
       return S;
 
     if (isa<BraceStmt>(S)) {
@@ -906,11 +931,8 @@ public:
         return Result;
     } else if (auto *IE = dyn_cast<IfExpr>(E)) {
       CounterExpr &ThenCounter = assignCounter(IE->getThenExpr());
-      if (RegionStack.empty())
-        assignCounter(IE->getElseExpr());
-      else
-        assignCounter(IE->getElseExpr(),
-                      CounterExpr::Sub(getCurrentCounter(), ThenCounter));
+      assignCounter(IE->getElseExpr(),
+                    CounterExpr::Sub(getCurrentCounter(), ThenCounter));
     }
 
     if (hasCounter(E))
@@ -951,6 +973,16 @@ static StringRef getCurrentFileName(ASTNode Root) {
   return {};
 }
 
+static void walkTopLevelNodeForProfiling(ASTNode Root, ASTWalker &Walker) {
+  Root.walk(Walker);
+
+  // Visit extensions when walking through a nominal type.
+  auto *NTD = dyn_cast_or_null<NominalTypeDecl>(Root.dyn_cast<Decl *>());
+  if (NTD)
+    for (ExtensionDecl *ED : NTD->getExtensions())
+      ED->walk(Walker);
+}
+
 void SILProfiler::assignRegionCounters() {
   const auto &SM = M.getASTContext().SourceMgr;
 
@@ -970,23 +1002,23 @@ void SILProfiler::assignRegionCounters() {
       TLCD->getStartLoc().printLineAndColumn(OS, SM);
       CurrentFuncLinkage = FormalLinkage::HiddenUnique;
     } else {
-      llvm_unreachable("Unsupported decl");
+      auto *NTD = cast<NominalTypeDecl>(D);
+      llvm::raw_string_ostream OS{CurrentFuncName};
+      OS << "__ntd_" << NTD->getNameStr() << "_";
+      NTD->getStartLoc().printLineAndColumn(OS, SM);
+      CurrentFuncLinkage = FormalLinkage::HiddenUnique;
     }
   } else {
-    auto *E = Root.get<Expr *>();
-    if (auto *CE = dyn_cast<AbstractClosureExpr>(E)) {
-      CurrentFuncName = SILDeclRef(CE).mangle();
-      CurrentFuncLinkage = FormalLinkage::HiddenUnique;
-    } else {
-      llvm_unreachable("Unsupported expr");
-    }
+    auto *CE = cast<AbstractClosureExpr>(Root.get<Expr *>());
+    CurrentFuncName = SILDeclRef(CE).mangle();
+    CurrentFuncLinkage = FormalLinkage::HiddenUnique;
   }
 
   PGOFuncName = llvm::getPGOFuncName(
       CurrentFuncName, getEquivalentPGOLinkage(CurrentFuncLinkage),
       CurrentFileName);
 
-  walkForProfiling(Root, Mapper);
+  walkTopLevelNodeForProfiling(Root, Mapper);
 
   NumRegionCounters = Mapper.NextCounter;
   // TODO: Mapper needs to calculate a function hash as it goes.
@@ -994,7 +1026,7 @@ void SILProfiler::assignRegionCounters() {
 
   if (EmitCoverageMapping) {
     CoverageMapping Coverage(SM);
-    walkForProfiling(Root, Coverage);
+    walkTopLevelNodeForProfiling(Root, Coverage);
     CovMap =
         Coverage.emitSourceRegions(M, CurrentFuncName, PGOFuncName, PGOFuncHash,
                                    RegionCounterMap, CurrentFileName);
@@ -1012,7 +1044,7 @@ void SILProfiler::assignRegionCounters() {
     }
     PGOMapping pgoMapper(RegionLoadedCounterMap, LoadedCounts,
                          RegionCondToParentMap);
-    walkForProfiling(Root, pgoMapper);
+    walkTopLevelNodeForProfiling(Root, pgoMapper);
   }
 }
 

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -488,6 +488,20 @@ static bool haveProfiledAssociatedFunction(SILDeclRef constant) {
          constant.isCurried;
 }
 
+SILProfiler *
+SILGenModule::getOrCreateProfilerForConstructors(NominalTypeDecl *decl) {
+  assert(decl && "No nominal type for constructor lookup");
+
+  const auto &Opts = M.getOptions();
+  if (!Opts.GenerateProfile && Opts.UseProfile.empty())
+    return nullptr;
+
+  SILProfiler *&profiler = constructorProfilers[decl];
+  if (!profiler)
+    profiler = SILProfiler::create(M, ForDefinition, decl);
+  return profiler;
+}
+
 SILFunction *SILGenModule::getFunction(SILDeclRef constant,
                                        ForDefinition_t forDefinition) {
   // If we already emitted the function, return it (potentially preparing it
@@ -737,42 +751,45 @@ void SILGenModule::emitConstructor(ConstructorDecl *decl) {
     return;
 
   SILDeclRef constant(decl);
+  DeclContext *declCtx = decl->getDeclContext();
 
   bool ForCoverageMapping = doesASTRequireProfiling(M, decl);
 
-  if (decl->getDeclContext()->getAsClassOrClassExtensionContext()) {
+  if (auto *clsDecl = declCtx->getAsClassOrClassExtensionContext()) {
     // Class constructors have separate entry points for allocation and
     // initialization.
     emitOrDelayFunction(
-        *this, constant,
-        [this, constant, decl](SILFunction *f) {
+        *this, constant, [this, constant, decl](SILFunction *f) {
           preEmitFunction(constant, decl, f, decl);
           PrettyStackTraceSILFunction X("silgen emitConstructor", f);
-          f->createProfiler(decl, ForDefinition);
           SILGenFunction(*this, *f).emitClassConstructorAllocator(decl);
           postEmitFunction(constant, f);
-        },
-        /*forceEmission=*/ForCoverageMapping);
+        });
 
     // If this constructor was imported, we don't need the initializing
     // constructor to be emitted.
     if (!decl->hasClangNode()) {
       SILDeclRef initConstant(decl, SILDeclRef::Kind::Initializer);
-      emitOrDelayFunction(*this, initConstant,
-                          [this,initConstant,decl](SILFunction *initF){
-        preEmitFunction(initConstant, decl, initF, decl);
-        PrettyStackTraceSILFunction X("silgen constructor initializer", initF);
-        SILGenFunction(*this, *initF).emitClassConstructorInitializer(decl);
-        postEmitFunction(initConstant, initF);
-      });
+      emitOrDelayFunction(
+          *this, initConstant,
+          [this, initConstant, decl, clsDecl](SILFunction *initF) {
+            preEmitFunction(initConstant, decl, initF, decl);
+            PrettyStackTraceSILFunction X("silgen constructor initializer",
+                                          initF);
+            initF->setProfiler(getOrCreateProfilerForConstructors(clsDecl));
+            SILGenFunction(*this, *initF).emitClassConstructorInitializer(decl);
+            postEmitFunction(initConstant, initF);
+          },
+          /*forceEmission=*/ForCoverageMapping);
     }
   } else {
     // Struct and enum constructors do everything in a single function.
+    auto *nomDecl = declCtx->getAsNominalTypeOrNominalTypeExtensionContext();
     emitOrDelayFunction(
-        *this, constant, [this, constant, decl](SILFunction *f) {
+        *this, constant, [this, constant, decl, nomDecl](SILFunction *f) {
           preEmitFunction(constant, decl, f, decl);
           PrettyStackTraceSILFunction X("silgen emitConstructor", f);
-          f->createProfiler(decl, ForDefinition);
+          f->setProfiler(getOrCreateProfilerForConstructors(nomDecl));
           SILGenFunction(*this, *f).emitValueConstructor(decl);
           postEmitFunction(constant, f);
         });
@@ -975,9 +992,16 @@ emitStoredPropertyInitialization(PatternBindingDecl *pbd, unsigned i) {
   auto *init = pbdEntry.getInit();
 
   SILDeclRef constant(var, SILDeclRef::Kind::StoredPropertyInitializer);
-  emitOrDelayFunction(*this, constant, [this,constant,init](SILFunction *f) {
+  emitOrDelayFunction(*this, constant, [this,constant,init,var](SILFunction *f) {
     preEmitFunction(constant, init, f, init);
     PrettyStackTraceSILFunction X("silgen emitStoredPropertyInitialization", f);
+
+    // Inherit a profiler instance from the constructor.
+    auto *nominalDecl =
+        var->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+    if (nominalDecl)
+      f->setProfiler(getOrCreateProfilerForConstructors(nominalDecl));
+
     SILGenFunction(*this, *f).emitGeneratorFunction(constant, init);
     postEmitFunction(constant, f);
   });

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -96,6 +96,10 @@ public:
   /// The most recent conformance...
   NormalProtocolConformance *lastEmittedConformance = nullptr;
 
+  /// Profiler instances for constructors, grouped by associated nominal type.
+  /// Each profiler is shared by all member initializers for a nominal type.
+  llvm::DenseMap<NominalTypeDecl *, SILProfiler *> constructorProfilers;
+
   SILFunction *emitTopLevelFunction(SILLocation Loc);
 
   size_t anonymousSymbolCounter = 0;
@@ -435,6 +439,9 @@ public:
 
   /// Emit a property descriptor for the given storage decl if it needs one.
   void tryEmitPropertyDescriptor(AbstractStorageDecl *decl);
+
+  /// Get or create the profiler instance for a nominal type's constructors.
+  SILProfiler *getOrCreateProfilerForConstructors(NominalTypeDecl *decl);
   
 private:
   /// Emit the deallocator for a class that uses the objc allocator.

--- a/test/SILGen/coverage_class.swift
+++ b/test/SILGen/coverage_class.swift
@@ -3,7 +3,8 @@
 class C {
   // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.C.foo
   func foo() {}
-  // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.C.__allocating_init
+  // CHECK: sil_coverage_map {{.*}}// __ntd_C_line:[[@LINE-3]]:1
+  // CHECK-NEXT: [[@LINE+1]]:10 -> [[@LINE+1]]:12
   init() {}
   // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.C.__deallocating_deinit
   deinit {}
@@ -17,7 +18,7 @@ extension C {
 struct S {
   // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.S.foo
   func foo() {}
-  // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.S.init
+  // CHECK: sil_coverage_map {{.*}}// __ntd_S_line:[[@LINE-3]]:1
   init() {}
 }
 
@@ -25,6 +26,16 @@ enum E {
   case X, Y, Z
   // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.E.foo
   func foo() {}
-  // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_class.E.init
+  // CHECK: sil_coverage_map {{.*}}// __ntd_E_line:[[@LINE-4]]:1
+  // CHECK-NEXT: [[@LINE+1]]:10 -> [[@LINE+1]]:23
   init() { self = .Y }
+}
+
+var g1: Bool = true
+
+struct S2 {
+  // CHECK: sil_coverage_map {{.*}}// __ntd_S2_line:[[@LINE-1]]:1
+  // CHECK-NEXT: [[@LINE+2]]:22 -> [[@LINE+2]]:23 : 0
+  // CHECK-NEXT: [[@LINE+1]]:26 -> [[@LINE+1]]:27 : (1 - 0)
+  var m1: Int = g1 ? 0 : 1
 }

--- a/test/SILGen/coverage_closures.swift
+++ b/test/SILGen/coverage_closures.swift
@@ -3,15 +3,10 @@
 // rdar://39200851: Closure in init method covered twice
 
 class C2 {
-// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_closures.C2.__allocating_init()
-// CHECK-NEXT:  [[@LINE+7]]:10 -> [[@LINE+11]]:4 : 0
-// CHECK-NEXT: }
-
-// CHECK-LABEL: sil_coverage_map {{.*}}// closure #1 () -> () in coverage_closures.C2.init()
-// CHECK-NEXT:  [[@LINE+4]]:13 -> [[@LINE+6]]:6 : 0
-// CHECK-NEXT: }
-
   init() {
+// CHECK-LABEL: sil_coverage_map {{.*}}// closure #1 () -> () in coverage_closures.C2.init()
+// CHECK-NEXT:  [[@LINE+2]]:13 -> [[@LINE+4]]:6 : 0
+// CHECK-NEXT: }
     let _ = { () in
       print("hello")
     }

--- a/test/SILGen/coverage_exceptions.swift
+++ b/test/SILGen/coverage_exceptions.swift
@@ -5,17 +5,6 @@ enum SomeErr : Error {
   case Err2
 }
 
-struct S {
-  // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.S.init
-  init() {
-    do {
-      throw SomeErr.Err1
-    } catch {
-      // CHECK: [[@LINE-1]]:13 -> [[@LINE+1]]:6 : 2
-    } // CHECK: [[@LINE]]:6 -> [[@LINE+1]]:4 : 1
-  }
-}
-
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_catch.bar
 func bar() throws {
   // CHECK-NEXT: [[@LINE-1]]:19 -> [[@LINE+2]]:2 : 0
@@ -62,3 +51,14 @@ func foo() -> Int32 {
 }
 
 foo()
+
+struct S {
+  // CHECK: sil_coverage_map {{.*}}// __ntd_S_line:[[@LINE-1]]
+  init() {
+    do {
+      throw SomeErr.Err1
+    } catch {
+      // CHECK: [[@LINE-1]]:13 -> [[@LINE+1]]:6 : 2
+    } // CHECK: [[@LINE]]:6 -> [[@LINE+1]]:4 : 1
+  }
+}

--- a/test/SILGen/coverage_member_closure.swift
+++ b/test/SILGen/coverage_member_closure.swift
@@ -1,13 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sil -module-name coverage_member_closure %s | %FileCheck %s
 
 class C {
-  // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_member_closure.C.__allocating_init
-  init() {
-    if (false) { // CHECK: [[@LINE]]:16 -> [[@LINE+2]]:6 : 1
-      // ...
-    }
-  }
-
   // Closures in members receive their own coverage mapping.
   // CHECK: sil_coverage_map {{.*}} $S23coverage_member_closure1CC17completionHandleryySS_SaySSGtcvpfiySS_AEtcfU_
   // CHECK: [[@LINE+1]]:55 -> [[@LINE+1]]:79 : 0

--- a/test/SILGen/coverage_smoke.swift
+++ b/test/SILGen/coverage_smoke.swift
@@ -35,7 +35,7 @@ class Class1 {
   deinit {}
 }
 
-// CHECK-MAIN: Maximum function count: 3
+// CHECK-MAIN: Maximum function count: 4
 func main() {
 // CHECK-COV: {{ *}}[[@LINE+1]]|{{ *}}1{{.*}}f_public
   f_public()
@@ -85,9 +85,69 @@ func call_auto_closure() {
   let _ = use_auto_closure(true) // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}3
 }
 
+class Class2 {
+  var field: Int
+  init(field: Int) {
+    if field > 0 {
+      self.field = 0 // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+    } else {
+      self.field = 1 // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}3
+    }
+  }
+}
+
+extension Class2 {
+  convenience init() {
+    self.init(field: 0) // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+  }
+}
+
+class SubClass1: Class2 {
+  override init(field: Int) {
+    super.init(field: field) // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+  }
+}
+
+struct Struct1 {
+  var field: Int
+  init(field: Int) {
+    if field > 0 {
+      self.field = 0 // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+    } else {
+      self.field = 1 // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+    }
+  }
+}
+
+extension Struct1 {
+  init() {
+    self.init(field: 0) // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+  }
+}
+
+var g2: Int = 0
+
+class Class3 {
+  var m1 = g2 == 0
+             ? "false" // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+             : "true"; // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
+}
+
 main() // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
 foo()  // CHECK-COV: {{ *}}[[@LINE]]|{{ *}}1
 call_closure()
 call_auto_closure()
+
+let _ = Class2(field: 0)
+let _ = Class2(field: 1)
+let _ = Class2()
+let _ = SubClass1(field: 0)
+
+let _ = Class3()
+g2 = 1
+let _ = Class3()
+
+let _ = Struct1(field: 1)
+let _ = Struct1()
 
 // CHECK-REPORT: TOTAL {{.*}} 100.00% {{.*}} 100.00%

--- a/test/SILGen/coverage_ternary.swift
+++ b/test/SILGen/coverage_ternary.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_ternary %s | %FileCheck %s
 
-// CHECK-LABEL: sil hidden @$S16coverage_ternary3barCACycfC
+// CHECK-LABEL: sil hidden @$S16coverage_ternary3barCACycfc
 // CHECK-NOT: return
 // CHECK: builtin "int_instrprof_increment"
 
@@ -8,13 +8,7 @@
 // CHECK-NOT: return
 // CHECK: builtin "int_instrprof_increment"
 
-// rdar://problem/23256795 - Avoid crash if an if_expr has no parent
-// CHECK-LABEL: sil_coverage_map {{.*}}// coverage_ternary.bar.__allocating_init
-class bar {
-  var m1 = 0 == 1
-             ? "false" // CHECK: [[@LINE]]:16 -> [[@LINE]]:23 : 1
-             : "true"; // CHECK: [[@LINE]]:16 -> [[@LINE]]:22 : 0
-}
+var flag: Int = 0
 
 // CHECK-LABEL: sil_coverage_map {{.*}}// coverage_ternary.foo
 func foo(_ x : Int32) -> Int32 {
@@ -26,6 +20,14 @@ func foo(_ x : Int32) -> Int32 {
 foo(1)
 foo(2)
 foo(3)
+
+// rdar://problem/23256795 - Avoid crash if an if_expr has no parent
+// CHECK: sil_coverage_map {{.*}}// __ntd_bar_line:[[@LINE+1]]
+class bar {
+  var m1 = flag == 0
+             ? "false" // CHECK: [[@LINE]]:16 -> [[@LINE]]:23 : 0
+             : "true"; // CHECK: [[@LINE]]:16 -> [[@LINE]]:22 : (1 - 0)
+}
 
 // Note: We didn't instantiate bar, but we still expect to see instrumentation
 // for its *structors, and coverage mapping information for it.

--- a/test/SILGen/coverage_toplevel.swift
+++ b/test/SILGen/coverage_toplevel.swift
@@ -17,7 +17,7 @@ while (i < 10) {
 
 // CHECK: sil_coverage_map{{.*}}__tlcd_line:[[@LINE+3]]:1
 // CHECK-NEXT:  [[@LINE+2]]:17 -> [[@LINE+2]]:18 : 1
-// CHECK-NEXT:  [[@LINE+1]]:21 -> [[@LINE+1]]:22 : 0
+// CHECK-NEXT:  [[@LINE+1]]:21 -> [[@LINE+1]]:22 : (0 - 1)
 var i2 = true ? 1 : 0;
 
 // CHECK: sil_coverage_map{{.*}}__tlcd_line:[[@LINE+4]]:1


### PR DESCRIPTION
… (#15966)

* [Coverage] Instrument constructor initializers (SR-7446)

We need to instrument constructor initializers, instead of the
delegating constructors which just call them.

rdar://39460313

* [Coverage] Remove dead code, NFC

* [Coverage] Use a shared profiler for constructors and member initializers

This fixes coverage reporting for member initializers and cuts down on
repeated AST traversals of pattern bindings within nominal type decls.

This allows us to remove some defensive heuristic code which dealt with
closures and if-exprs within member initializers.

(cherry picked from commit 8a003a41dac7f500866bc0facee323c79780d9b1)

Resolves [SR-7446](https://bugs.swift.org/browse/SR-7446).
