### PR TITLE
[ASTMangler] Allow to mangle any generic decl type

### DIFF
--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -837,20 +837,23 @@ void ASTMangler::appendType(Type type) {
     case TypeKind::Struct:
     case TypeKind::BoundGenericClass:
     case TypeKind::BoundGenericEnum:
-    case TypeKind::BoundGenericStruct:
+    case TypeKind::BoundGenericStruct: {
+      // We can't use getAnyNominal here because this can be TypeAliasDecl only
+      // in case of UnboundGenericType. Such mangling happens in, for instance,
+      // SourceKit 'cursorinfo' request.
+      auto *Decl = type->getAnyGeneric();
       if (type->isSpecialized()) {
         // Try to mangle the entire name as a substitution.
-        if (tryMangleSubstitution(type.getPointer()))
+        if (tryMangleSubstitution(tybase))
           return;
 
-        NominalTypeDecl *NDecl = type->getAnyNominal();
-        if (isStdlibType(NDecl) && NDecl->getName().str() == "Optional") {
+        if (isStdlibType(Decl) && Decl->getName().str() == "Optional") {
           auto GenArgs = type->castTo<BoundGenericType>()->getGenericArgs();
           assert(GenArgs.size() == 1);
           appendType(GenArgs[0]);
           appendOperator("Sg");
         } else {
-          appendAnyGenericType(NDecl);
+          appendAnyGenericType(Decl);
           bool isFirstArgList = true;
           appendBoundGenericArgs(type, isFirstArgList);
           appendRetroactiveConformances(type);
@@ -859,8 +862,9 @@ void ASTMangler::appendType(Type type) {
         addSubstitution(type.getPointer());
         return;
       }
-      appendAnyGenericType(tybase->getAnyNominal());
+      appendAnyGenericType(Decl);
       return;
+    }
 
     case TypeKind::SILFunction:
       return appendImplFunctionType(cast<SILFunctionType>(tybase));

--- a/test/SourceKit/CursorInfo/rdar_34348776.swift
+++ b/test/SourceKit/CursorInfo/rdar_34348776.swift
@@ -1,0 +1,13 @@
+public struct MyStruct<T> {}
+public typealias Alias<T> = MyStruct<T>
+public typealias Aliased = Alias
+
+// RUN: %sourcekitd-test -req=cursor -pos=3:18 %s -- %s | %FileCheck %s
+
+// CHECK: source.lang.swift.decl.typealias (3:18-3:25)
+// CHECK-NEXT: Aliased
+// CHECK-NEXT: s:13rdar_343487767Aliaseda
+// CHECK-NEXT: Alias.Type
+// CHECK-NEXT: $S13rdar_343487765AliasamD
+// CHECK-NEXT: <Declaration>public typealias Aliased = <Type usr="s:13rdar_343487765Aliasa">Alias</Type></Declaration>
+// CHECK-NEXT: <decl.typealias><syntaxtype.keyword>public</syntaxtype.keyword> <syntaxtype.keyword>typealias</syntaxtype.keyword> <decl.name>Aliased</decl.name> = <ref.typealias usr="s:13rdar_343487765Aliasa">Alias</ref.typealias></decl.typealias>


### PR DESCRIPTION
More specifically, generic `typealias` type.
For instance:

```swift
typealias Pair<T, T> = (T, T)
typealias PairAlias = Pair
```

Interface type of `PairAlias` is `Pair.Type`, not `(T, T).Type`.
Limiting this to `NominalDecl` type used to cause a crash in sourcekit `cursorinfo`.

rdar://problem/34348776