### PR TITLE
migrator: handle assignment of attribute dictionary and others.

### DIFF
--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -686,15 +686,14 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
       return false;
     for (auto *Item: getRelatedDiffItems(RD)) {
       if (auto *CI = dyn_cast<CommonDiffItem>(Item)) {
-        switch(CI->DiffKind) {
-        case NodeAnnotation::SimpleStringRepresentableUpdate: {
-          Editor.insertBefore(ASE->getSrc()->getStartLoc(),
-            (Twine(CI->RightComment) + "(rawValue: ").str());
+        if (CI->isStringRepresentableChange() &&
+            CI->NodeKind == SDKNodeKind::DeclVar) {
+          SmallString<256> Buffer;
+          auto Func = insertHelperFunction(CI->DiffKind, CI->RightComment,
+                                           Buffer, true);
+          Editor.insert(ASE->getSrc()->getStartLoc(), (Twine(Func) + "(").str());
           Editor.insertAfterToken(ASE->getSrc()->getEndLoc(), ")");
           return true;
-        }
-        default:
-          continue;
         }
       }
     }

--- a/test/Migrator/Inputs/Cities.swift
+++ b/test/Migrator/Inputs/Cities.swift
@@ -36,6 +36,8 @@ public func globalCityPointerTaker(_ c : UnsafePointer<Cities>, _ p : Int, _ q: 
 
 public class Container {
   public var Value: String = ""
+  public var attrDict: [String: Any] = [:]
+  public var attrArr: [String] = []
   public func addingAttributes(_ input: [String: Any]) {}
   public func adding(attributes: [String: Any]) {}
   public func adding(optionalAttributes: [String: Any]?) {}

--- a/test/Migrator/Inputs/string-representable.json
+++ b/test/Migrator/Inputs/string-representable.json
@@ -164,4 +164,26 @@
     "RightComment": "SimpleAttribute",
     "ModuleName": "Cities"
   },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Var",
+    "NodeAnnotation": "DictionaryKeyUpdate",
+    "ChildIndex": "0",
+    "LeftUsr": "s:6Cities9ContainerC8attrDicts10DictionaryVySSypGvp",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "SimpleAttribute",
+    "ModuleName": "Cities"
+  },
+    {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Var",
+    "NodeAnnotation": "ArrayMemberUpdate",
+    "ChildIndex": "0",
+    "LeftUsr": "s:6Cities9ContainerC7attrArrSaySSGvp",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "SimpleAttribute",
+    "ModuleName": "Cities"
+  },
 ]

--- a/test/Migrator/string-representable.swift
+++ b/test/Migrator/string-representable.swift
@@ -27,5 +27,7 @@ func foo(_ c: Container) -> String {
   c.addingAttributes(c.getAttrDictionary())
   c.adding(optionalAttributes: c.getAttrDictionary())
 
+  c.attrDict = ["a": "b", "a": "b", "a": "b"]
+  c.attrArr = ["key1", "key2"]
   return c.Value
 }

--- a/test/Migrator/string-representable.swift.expected
+++ b/test/Migrator/string-representable.swift.expected
@@ -7,7 +7,7 @@
 import Cities
 
 func foo(_ c: Container) -> String {
-  c.Value = NewAttribute(rawValue: "")
+  c.Value = convertToNewAttribute("")
   c.addingAttributes(convertToCitiesContainerAttributeDictionary(["a": "b", "a": "b", "a": "b"]))
   c.addingAttributes(convertToCitiesContainerAttributeDictionary(["a": "b", "a": "b", "a": "b"]))
   c.adding(attributes: convertToSimpleAttributeDictionary(["a": 1, "a": 2, "a": 3]))
@@ -27,7 +27,14 @@ func foo(_ c: Container) -> String {
   c.addingAttributes(convertToCitiesContainerAttributeDictionary(convertFromSimpleAttributeDictionary(c.getAttrDictionary())))
   c.adding(optionalAttributes: convertToOptionalSimpleAttributeDictionary(convertFromSimpleAttributeDictionary(c.getAttrDictionary())))
 
+  c.attrDict = convertToSimpleAttributeDictionary(["a": "b", "a": "b", "a": "b"])
+  c.attrArr = convertToSimpleAttributeArray(["key1", "key2"])
   return c.Value.rawValue
+}
+
+// Helper function inserted by Swift 4.2 migrator.
+fileprivate func convertToNewAttribute(_ input: String) -> NewAttribute {
+	return NewAttribute(rawValue: input)
 }
 
 // Helper function inserted by Swift 4.2 migrator.


### PR DESCRIPTION
When users' codebase assigns an attribute dictionary that used to be of
type [String: Any], this migration inserts a helper function call on the source of
the assignment to bridge the type.