### PR TITLE
SR-6243 _fastEnumerationStorageMutationsPtr

### DIFF
--- a/stdlib/public/SDK/Foundation/NSFastEnumeration.swift
+++ b/stdlib/public/SDK/Foundation/NSFastEnumeration.swift
@@ -12,6 +12,10 @@
 
 @_exported import Foundation // Clang module
 
+/// A dummy value to be used as the target for `mutationsPtr` in fast enumeration implementations.
+fileprivate var _fastEnumerationMutationsTarget: CUnsignedLong = 0
+/// A dummy pointer to be used as `mutationsPtr` in fast enumeration implementations.
+fileprivate let _fastEnumerationMutationsPtr = UnsafeMutablePointer<CUnsignedLong>(&_fastEnumerationMutationsTarget)
 
 //===----------------------------------------------------------------------===//
 // Fast enumeration
@@ -19,7 +23,7 @@
 public struct NSFastEnumerationIterator : IteratorProtocol {
     var enumerable: NSFastEnumeration
     var objects: (Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?, Unmanaged<AnyObject>?) = (nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
-    var state = NSFastEnumerationState(state: 0, itemsPtr: nil, mutationsPtr: _fastEnumerationStorageMutationsPtr, extra: (0, 0, 0, 0, 0))
+    var state = NSFastEnumerationState(state: 0, itemsPtr: nil, mutationsPtr: _fastEnumerationMutationsPtr, extra: (0, 0, 0, 0, 0))
     var index = 0
     var count = 0
     var useObjectsBuffer = false

--- a/stdlib/public/core/Shims.swift
+++ b/stdlib/public/core/Shims.swift
@@ -28,17 +28,11 @@ internal func _makeSwiftNSFastEnumerationState()
 /// A dummy value to be used as the target for `mutationsPtr` in fast
 /// enumeration implementations.
 @usableFromInline // FIXME(sil-serialize-all)
-@_fixed_layout
 internal var _fastEnumerationStorageMutationsTarget: CUnsignedLong = 0
 
 /// A dummy pointer to be used as `mutationsPtr` in fast enumeration
 /// implementations.
-@inlinable // FIXME(sil-serialize-all)
-public // SPI(Foundation)
-var _fastEnumerationStorageMutationsPtr: UnsafeMutablePointer<CUnsignedLong> {
-  // Note that either _fastEnumerationStorageMutationsPtr should be
-  // @_fixed_layout, or this function should not be @inlinable.
-  return UnsafeMutablePointer(
-      Builtin.addressof(&_fastEnumerationStorageMutationsTarget))
-}
+@usableFromInline // FIXME(sil-serialize-all)
+internal let _fastEnumerationStorageMutationsPtr =
+  UnsafeMutablePointer<CUnsignedLong>(Builtin.addressof(&_fastEnumerationStorageMutationsTarget))
 #endif


### PR DESCRIPTION
<!-- What's in this pull request? -->
Make _fastEnumerationStorageMutationsPtr internal in Shims.swift and make Foundation use it's own fileprivate _fastEnumerationStorageMutationsPtr

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-6243](https://bugs.swift.org/browse/SR-6243).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->