### PR TITLE
Make sure 'final' decls never get marked as 'open'

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2008,16 +2008,18 @@ ERROR(override_mutable_covariant_property,none,
 ERROR(override_mutable_covariant_subscript,none,
       "cannot override mutable subscript of type %0 with covariant type %1",
       (Type, Type))
-ERROR(decl_already_final,none,
+ERROR(static_decl_already_final,none,
       "static declarations are already final", ())
 ERROR(open_decl_cannot_be_final,none,
       "%0 cannot be declared both 'final' and 'open'", (DescriptiveDeclKind))
-ERROR(let_cannot_be_open,none,
-      "'let' properties are implicitly 'final'; use 'public' instead of "
-      "'open'", ())
-WARNING(let_cannot_be_open_swift4,none,
-        "'let' properties are implicitly 'final'; use 'public' instead of "
-        "'open'", ())
+ERROR(implicitly_final_cannot_be_open,none,
+      "%select{'let' properties|members of 'final' classes|"
+      "static declarations}0 are implicitly 'final'; use 'public' instead of "
+      "'open'", (unsigned))
+WARNING(implicitly_final_cannot_be_open_swift4,none,
+        "%select{'let' properties|members of 'final' classes|"
+        "static declarations}0 are implicitly 'final'; use 'public' instead of "
+        "'open'", (unsigned))
 
 WARNING(override_swift3_objc_inference,none,
         "override of %0 %1 from extension of %2 depends on deprecated "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2012,6 +2012,12 @@ ERROR(decl_already_final,none,
       "static declarations are already final", ())
 ERROR(open_decl_cannot_be_final,none,
       "%0 cannot be declared both 'final' and 'open'", (DescriptiveDeclKind))
+ERROR(let_cannot_be_open,none,
+      "'let' properties are implicitly 'final'; use 'public' instead of "
+      "'open'", ())
+WARNING(let_cannot_be_open_swift4,none,
+        "'let' properties are implicitly 'final'; use 'public' instead of "
+        "'open'", ())
 
 WARNING(override_swift3_objc_inference,none,
         "override of %0 %1 from extension of %2 depends on deprecated "

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2115,11 +2115,17 @@ public:
 
     void verifyChecked(ValueDecl *VD) {
       if (VD->hasAccess()) {
-        if (VD->getFormalAccess() == AccessLevel::Open &&
-            !isa<ClassDecl>(VD) && !VD->isPotentiallyOverridable()) {
-          Out << "decl cannot be 'open'\n";
-          VD->dump(Out);
-          abort();
+        if (VD->getFormalAccess() == AccessLevel::Open) {
+          if (!isa<ClassDecl>(VD) && !VD->isPotentiallyOverridable()) {
+            Out << "decl cannot be 'open'\n";
+            VD->dump(Out);
+            abort();
+          }
+          if (VD->isFinal()) {
+            Out << "decl cannot be both 'open' and 'final'\n";
+            VD->dump(Out);
+            abort();
+          }
         }
       } else {
         if (!VD->getDeclContext()->isLocalContext() &&

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7066,6 +7066,13 @@ void TypeChecker::validateDecl(ValueDecl *D) {
             makeFinal(Context, VD);
           }
         }
+        if (VD->isLet() && VD->getFormalAccess() == AccessLevel::Open) {
+          auto diagID = diag::let_cannot_be_open;
+          if (!Context.isSwiftVersionAtLeast(5))
+            diagID = diag::let_cannot_be_open_swift4;
+          auto inFlightDiag = diagnose(VD, diagID);
+          fixItAccess(inFlightDiag, VD, AccessLevel::Public);
+        }
         if (VD->isStatic()) {
           auto staticSpelling =
             VD->getParentPatternBinding()->getStaticSpelling();

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -513,7 +513,7 @@ struct DidSetWillSetTests: ForceAccessors {
   }
 
   var a: Int {
-    // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
+    // CHECK-LABEL: sil private @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
     willSet(newA) {
       // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
       // CHECK-NEXT: debug_value %0
@@ -548,7 +548,7 @@ struct DidSetWillSetTests: ForceAccessors {
       // CHECK-NEXT: assign [[ZERO]] to [[AADDR]]
     }
 
-    // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vW
+    // CHECK-LABEL: sil private @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vW
     didSet {
       // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
       // CHECK-NEXT: debug
@@ -626,7 +626,7 @@ var global_observing_property : Int = zero {
   // CHECK: properties.zero.unsafeMutableAddressor
   // CHECK: return
 
-  // CHECK-LABEL: sil hidden @$S10properties25global_observing_property{{[_0-9a-zA-Z]*}}vW
+  // CHECK-LABEL: sil private @$S10properties25global_observing_property{{[_0-9a-zA-Z]*}}vW
   didSet {
     // The didSet implementation needs to call takeInt.
     takeInt(global_observing_property)

--- a/test/SILGen/properties_swift4.swift
+++ b/test/SILGen/properties_swift4.swift
@@ -13,7 +13,7 @@ struct DidSetWillSetTests: ForceAccessors {
   }
 
   var a: Int {
-    // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
+    // CHECK-LABEL: sil private @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
     willSet(newA) {
       // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
 
@@ -57,7 +57,7 @@ struct DidSetWillSetTests: ForceAccessors {
       // CHECK-NEXT: end_access [[WRITE]] : $*DidSetWillSetTests
     }
 
-    // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vW
+    // CHECK-LABEL: sil private @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vW
     didSet {
       (self).a = zero  // reassign, but don't infinite loop.
 

--- a/test/SILGen/properties_swift5.swift
+++ b/test/SILGen/properties_swift5.swift
@@ -13,7 +13,7 @@ struct DidSetWillSetTests: ForceAccessors {
   }
 
   var a: Int {
-    // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
+    // CHECK-LABEL: sil private @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vw
     willSet(newA) {
       // CHECK: bb0(%0 : $Int, %1 : $*DidSetWillSetTests):
 
@@ -59,7 +59,7 @@ struct DidSetWillSetTests: ForceAccessors {
       // CHECK-NEXT: end_access [[WRITE]] : $*DidSetWillSetTests
     }
 
-    // CHECK-LABEL: sil hidden @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vW
+    // CHECK-LABEL: sil private @$S10properties010DidSetWillC5TestsV1a{{[_0-9a-zA-Z]*}}vW
     didSet {
       (self).a = zero  // reassign, but don't infinite loop, as accessing on 'self'.
 

--- a/test/attr/open.swift
+++ b/test/attr/open.swift
@@ -49,7 +49,6 @@ open class OpenClassesMustHaveOpenSuperClasses : NonOpenSuperClass {} // expecte
 open class AnOpenClass {
   open func openMethod() {}
   open var openVar: Int = 0
-  open let openLet: Int = 1 // Should this be allowed?
   open typealias MyInt = Int // expected-error {{only classes and overridable class members can be declared 'open'; use 'public'}}
   open subscript(_: MarkerForOpenSubscripts) -> Int {
     return 0

--- a/test/attr/open_swift4.swift
+++ b/test/attr/open_swift4.swift
@@ -3,4 +3,10 @@
 
 open class AnOpenClass {
   open let openLet: Int = 1 // expected-warning {{'let' properties are implicitly 'final'; use 'public' instead of 'open'}} {{3-7=public}}
+  open static func test() {} // expected-warning {{static declarations are implicitly 'final'; use 'public' instead of 'open'}} {{3-7=public}}
+}
+
+final public class NonOpenClass {
+  open func test() {} // expected-warning {{members of 'final' classes are implicitly 'final'; use 'public' instead of 'open'}} {{3-7=public}}
+  open static func test() {} // expected-warning {{static declarations are implicitly 'final'; use 'public' instead of 'open'}} {{3-7=public}}
 }

--- a/test/attr/open_swift4.swift
+++ b/test/attr/open_swift4.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift -swift-version 3
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+open class AnOpenClass {
+  open let openLet: Int = 1 // expected-warning {{'let' properties are implicitly 'final'; use 'public' instead of 'open'}} {{3-7=public}}
+}

--- a/test/attr/open_swift5.swift
+++ b/test/attr/open_swift5.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+
+open class AnOpenClass {
+  open let openLet: Int = 1 // expected-error {{'let' properties are implicitly 'final'; use 'public' instead of 'open'}} {{3-7=public}}
+}

--- a/test/attr/open_swift5.swift
+++ b/test/attr/open_swift5.swift
@@ -2,4 +2,10 @@
 
 open class AnOpenClass {
   open let openLet: Int = 1 // expected-error {{'let' properties are implicitly 'final'; use 'public' instead of 'open'}} {{3-7=public}}
+  open static func test() {} // expected-error {{static declarations are implicitly 'final'; use 'public' instead of 'open'}} {{3-7=public}}
+}
+
+final public class NonOpenClass {
+  open func test() {} // expected-error {{members of 'final' classes are implicitly 'final'; use 'public' instead of 'open'}} {{3-7=public}}
+  open static func test() {} // expected-error {{static declarations are implicitly 'final'; use 'public' instead of 'open'}} {{3-7=public}}
 }


### PR DESCRIPTION
Follow-up to #15996:

- Mark `willSet`/`didSet` accessors as `private`, always. These functions are always immediately inlined into a synthesized setter, and cannot be used with computed properties, so there's no benefit (and some harm) in having their access follow the property's.

- Disallow `open let`, and add a verifier check to make sure we don't mix `open` and `final` in the future. You could *write* `open let` in Swift 4.1, but you couldn't actually override such a property (within the module or outside). To maintain source compatibility, this is just going to emit a warning before Swift 5 (instead of an error), since it wasn't harming anything in practice.

I wouldn't have bothered with the first part right now except that it was the only other place where we ended up with declarations that were both `final` and `open` under the old code.