### PR TITLE
Add ApplyInstBase::getCalleeOrigin helper.

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1755,6 +1755,13 @@ public:
 
   SILValue getCallee() const { return getAllOperands()[Callee].get(); }
 
+  /// Gets the origin of the callee by looking through function type conversions
+  /// until we find a function_ref, partial_apply, or unrecognized value.
+  ///
+  /// This is defined out of line to work around incomplete definition
+  /// issues. It is at the bottom of the file.
+  SILValue getCalleeOrigin() const;
+
   /// Gets the referenced function by looking through partial apply,
   /// convert_function, and thin to thick function until we find a function_ref.
   ///
@@ -7593,6 +7600,12 @@ public:
     FOREACH_IMPL_RETURN(getCallee());
   }
 
+  /// Return the callee value by looking through function conversions until we
+  /// find a function_ref, partial_apply, or unrecognized callee value.
+  SILValue getCalleeOrigin() const {
+    FOREACH_IMPL_RETURN(getCalleeOrigin());
+  }
+
   /// Gets the referenced function by looking through partial apply,
   /// convert_function, and thin to thick function until we find a function_ref.
   SILFunction *getCalleeFunction() const {
@@ -7869,29 +7882,37 @@ public:
 // PartialApplyInst being defined, but PartialApplyInst is a subclass of
 // ApplyInstBase, so we can not place ApplyInstBase after it.
 template <class Impl, class Base>
-SILFunction *ApplyInstBase<Impl, Base, false>::getCalleeFunction() const {
+SILValue ApplyInstBase<Impl, Base, false>::getCalleeOrigin() const {
   SILValue Callee = getCallee();
-
   while (true) {
-    if (auto *FRI = dyn_cast<FunctionRefInst>(Callee)) {
-      return FRI->getReferencedFunction();
-    }
-
-    if (auto *PAI = dyn_cast<PartialApplyInst>(Callee)) {
-      Callee = PAI->getCallee();
-      continue;
-    }
-
     if (auto *TTTFI = dyn_cast<ThinToThickFunctionInst>(Callee)) {
       Callee = TTTFI->getCallee();
       continue;
     }
-
     if (auto *CFI = dyn_cast<ConvertFunctionInst>(Callee)) {
       Callee = CFI->getConverted();
       continue;
     }
+    if (auto *CETN = dyn_cast<ConvertEscapeToNoEscapeInst>(Callee)) {
+      Callee = CETN->getOperand();
+      continue;
+    }
+    return Callee;
+  }
+}
 
+template <class Impl, class Base>
+SILFunction *ApplyInstBase<Impl, Base, false>::getCalleeFunction() const {
+  SILValue Callee = getCalleeOrigin();
+
+  while (true) {
+    if (auto *FRI = dyn_cast<FunctionRefInst>(Callee))
+      return FRI->getReferencedFunction();
+
+    if (auto *PAI = dyn_cast<PartialApplyInst>(Callee)) {
+      Callee = PAI->getCalleeOrigin();
+      continue;
+    }
     return nullptr;
   }
 }


### PR DESCRIPTION
Centralize the logic for finding a callee while ignoring conversions. We already
use getCalleeFunction() in many places, but sometimes you want to know if the
callee is a partial_apply.

This may be a functional change because the existing getCalleeFunction() helper
now uses the new helper, which also looks through ConvertEscapeToNoescape.

I want to use this utility to fix a theoretical hole in exclusivity enforcement. The following PR will included an additional use of getCalleeOrigin() (other than the use-by-refactoring in this commit), and a unit test.