### PR TITLE
[stdlib] Optimize ASCII String hashing

### DIFF
--- a/stdlib/public/core/Hasher.swift
+++ b/stdlib/public/core/Hasher.swift
@@ -250,7 +250,7 @@ internal struct _BufferingHasher<Core: _HasherCore> {
 public struct _Hasher {
   internal typealias Core = _BufferingHasher<_SipHash13Core>
 
-  private var _core: Core
+  internal var _core: Core
 
   @effects(releasenone)
   public init() {

--- a/stdlib/public/core/StringHashable.swift
+++ b/stdlib/public/core/StringHashable.swift
@@ -12,168 +12,112 @@
 
 import SwiftShims
 
-func _emptyASCIIHashBuffer() -> _UIntBuffer<UInt64, UInt8> {
-  var buffer = _UIntBuffer<UInt64, UInt8>()
-  // We don't want the unused bits of a partially filled buffer to collide
-  // with trailing nuls when hashing
-  buffer._storage = UInt64.max
-  return buffer
-}
-
-internal struct ASCIIHasher {
-  private var buffer = _emptyASCIIHashBuffer()
-
-  internal mutating func consume() -> UInt64? {
-    if !buffer.isEmpty {
-      defer { resetBuffer() }
-      return buffer._storage
-    }
-    return nil
-  }
-
-  private mutating func resetBuffer() {
-    buffer = _emptyASCIIHashBuffer()
-  }
-
-  internal mutating func append(_ c: UInt8) -> UInt64? {
-    if buffer.count < buffer.capacity {
-      buffer.append(c)
-    }
-
-    if buffer.count == buffer.capacity {
-      defer { resetBuffer() }
-      return buffer._storage
-    }
-    return nil
-  }
-}
-
 extension _UnmanagedString where CodeUnit == UInt8 {
-  // NOT @usableFromInline
-  @effects(releasenone)
-  internal func hashASCII(into hasher: inout _Hasher) {
-    var asciiHasher = ASCIIHasher()
-    for c in self {
-      if let chunk = asciiHasher.append(UInt8(truncatingIfNeeded: c)) {
-        hasher.combine(chunk)
-      }
-    }
-
-    if let chunk = asciiHasher.consume() {
-      hasher.combine(chunk)
-    }
+  internal func hashASCII(into core: inout _Hasher.Core) {
+    core.combine(bytes: rawBuffer)
   }
 }
 
 extension BidirectionalCollection where Element == UInt16, SubSequence == Self {
-  // NOT @usableFromInline
-  internal func hashUTF16(into hasher: inout _Hasher) {
-    var asciiHasher = ASCIIHasher()
-
+  internal func hashUTF16(into core: inout _Hasher.Core) {
     for i in self.indices {
       let cu = self[i]
       let cuIsASCII = cu <= 0x7F
       let isSingleSegmentScalar = self.hasNormalizationBoundary(after: i)
 
-      guard cuIsASCII && isSingleSegmentScalar else {
-        if let chunk = asciiHasher.consume() {
-          hasher.combine(chunk)
-        }
-
-        let codeUnitSequence = IteratorSequence(
-          _NormalizedCodeUnitIterator(self[i..<endIndex])
-        )
-        for element in codeUnitSequence {
-          hasher.combine(UInt(element))
+      if cuIsASCII && isSingleSegmentScalar {
+        core.combine(UInt8(truncatingIfNeeded: cu))
+      } else {
+        for encodedScalar in Unicode._ParsingIterator(
+          codeUnits: _NormalizedCodeUnitIterator(self[i..<endIndex]),
+          parser: Unicode.UTF16.ForwardParser()
+        ) {
+          let transcoded = Unicode.UTF8.transcode(
+            encodedScalar, from: Unicode.UTF16.self
+          ).unsafelyUnwrapped // never fails
+          let (bytes, count) = transcoded._bytes
+          core.combine(bytes: bytes, count: count)
         }
         return
       }
-
-      if let chunk = asciiHasher.append(UInt8(truncatingIfNeeded: cu)) {
-        hasher.combine(chunk)
-      }
-    }
-
-    if let chunk = asciiHasher.consume() {
-      hasher.combine(chunk)
     }
   }
 }
 
 extension _UnmanagedString where CodeUnit == UInt8 {
-  @effects(releasenone)
-  @usableFromInline
-  internal func computeHashValue(into hasher: inout _Hasher) {
-    self.hashASCII(into: &hasher)
+  internal func hash(into hasher: inout _Hasher) {
+    self.hashASCII(into: &hasher._core)
+    hasher._core.combine(0xFF as UInt8) // terminator
   }
 }
 
 extension _UnmanagedString where CodeUnit == UInt16 {
-  @effects(releasenone)
-  @usableFromInline
-  internal func computeHashValue(into hasher: inout _Hasher) {
-    self.hashUTF16(into: &hasher)
+  internal func hash(into hasher: inout _Hasher) {
+    self.hashUTF16(into: &hasher._core)
+    hasher._core.combine(0xFF as UInt8) // terminator
   }
 }
 
 extension _UnmanagedOpaqueString {
-  @usableFromInline
-  internal func computeHashValue(into hasher: inout _Hasher) {
-    self.hashUTF16(into: &hasher)
+  internal func hash(into hasher: inout _Hasher) {
+    self.hashUTF16(into: &hasher._core)
+    hasher._core.combine(0xFF as UInt8) // terminator
   }
 }
 
 extension _SmallUTF8String {
-  @inlinable
-  internal func computeHashValue(into hasher: inout _Hasher) {
+  internal func hash(into hasher: inout _Hasher) {
 #if arch(i386) || arch(arm)
     unsupportedOn32bit()
 #else
     if isASCII {
-      return self.withUnmanagedASCII { $0.computeHashValue(into: &hasher) }
+      self.withUnmanagedASCII { $0.hash(into: &hasher) }
+      return
     }
-    return self.withUnmanagedUTF16 { $0.computeHashValue(into: &hasher) }
+    self.withUnmanagedUTF16 { $0.hash(into: &hasher) }
 #endif // 64-bit
   }
 }
 
 extension _StringGuts {
+  @effects(releasenone) // FIXME: Is this valid in the opaque case?
   @usableFromInline
-  @effects(releasenone) // FIXME: Is this guaranteed in the opaque case?
   internal func _hash(into hasher: inout _Hasher) {
     if _isSmall {
-      return _smallUTF8String.computeHashValue(into: &hasher)
+      _smallUTF8String.hash(into: &hasher)
+      return
     }
 
     defer { _fixLifetime(self) }
     if _slowPath(_isOpaque) {
-      _asOpaque().computeHashValue(into: &hasher)
+      _asOpaque().hash(into: &hasher)
       return
     }
     if isASCII {
-      _unmanagedASCIIView.computeHashValue(into: &hasher)
+      _unmanagedASCIIView.hash(into: &hasher)
       return
     }
-    _unmanagedUTF16View.computeHashValue(into: &hasher)
+    _unmanagedUTF16View.hash(into: &hasher)
   }
 
+  @effects(releasenone) // FIXME: Is this valid in the opaque case?
   @usableFromInline
-  @effects(releasenone) // FIXME: Is this guaranteed in the opaque case?
   internal func _hash(_ range: Range<Int>, into hasher: inout _Hasher) {
     if _isSmall {
-      return _smallUTF8String[range].computeHashValue(into: &hasher)
+      _smallUTF8String[range].hash(into: &hasher)
+      return
     }
 
     defer { _fixLifetime(self) }
     if _slowPath(_isOpaque) {
-      _asOpaque()[range].computeHashValue(into: &hasher)
+      _asOpaque()[range].hash(into: &hasher)
       return
     }
     if isASCII {
-      _unmanagedASCIIView[range].computeHashValue(into: &hasher)
+      _unmanagedASCIIView[range].hash(into: &hasher)
       return
     }
-    _unmanagedUTF16View[range].computeHashValue(into: &hasher)
+    _unmanagedUTF16View[range].hash(into: &hasher)
   }
 }
 

--- a/stdlib/public/core/ValidUTF8Buffer.swift
+++ b/stdlib/public/core/ValidUTF8Buffer.swift
@@ -217,4 +217,12 @@ extension _ValidUTF8Buffer {
   public static var encodedReplacementCharacter : _ValidUTF8Buffer {
     return _ValidUTF8Buffer(_biasedBits: 0xBD_BF_EF &+ 0x01_01_01)
   }
+
+  @inlinable
+  internal var _bytes: (bytes: UInt64, count: Int) {
+    let count = self.count
+    let mask: UInt64 = 1 &<< (UInt64(truncatingIfNeeded: count) &<< 3) &- 1
+    let unbiased = UInt64(truncatingIfNeeded: _biasedBits) &- 0x0101010101010101
+    return (unbiased & mask, count)
+  }
 }


### PR DESCRIPTION
- String hashing is not inlinable, so it can use _Hasher._core operations directly. Remove custom buffering.
- Speed up ASCII hashing by as much as 5.5x by feeding the storage buffer directly into hasher in a single go.
- For other strings, just feed the UTF-8 encoding of the normalized string to the hasher; don't switch to UTF-16 at the first non-ASCII scalar. (Doing that would make the hash encoding of some string sequences ambiguous, leading to artificial collisions.)
- Add a single unconditional terminator byte, 0xFF. It's not a valid UTF-8 code unit, so it won't ever occur within a normalized string encoding.
