### PR TITLE
[stdlib] Arrays: Include the count as a discriminator value

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -2270,6 +2270,7 @@ extension ${Self}: Hashable where Element: Hashable {
 
   @inlinable // FIXME(sil-serialize-all)
   public func _hash(into hasher: inout _Hasher) {
+    hasher.combine(count) // discriminator
     for element in self {
       hasher.combine(element)
     }

--- a/validation-test/stdlib/Arrays.swift.gyb
+++ b/validation-test/stdlib/Arrays.swift.gyb
@@ -190,21 +190,55 @@ ArrayTestSuite.test("init(repeating:count:)") {
 }
 
 ArrayTestSuite.test("Hashable") {
-  let a1: Array<Int> = [1, 2, 3]
-  let a2: Array<Int> = [1, 3, 2]
-  let a3: Array<Int> = [3, 1, 2]
-  let a4: Array<Int> = [1, 2]
-  let a5: Array<Int> = [1]
-  let a6: Array<Int> = []
-  let a7: Array<Int> = [1, 1, 1]
-  checkHashable([a1, a2, a3, a4, a5, a6, a7], equalityOracle: { $0 == $1 })
+  let a1: [Array<Int>] = [
+    [1, 2, 3],
+    [1, 3, 2],
+    [3, 1, 2],
+    [1, 2],
+    [1],
+    [],
+    [1, 1, 1]
+  ]
+  checkHashable(a1, equalityOracle: { $0 == $1 })
 
-  let aa1: Array<Array<Int>> = [[], [1], [1, 2], [2, 1]]
-  let aa2: Array<Array<Int>> = [[], [1], [2, 1], [2, 1]]
-  let aa3: Array<Array<Int>> = [[1], [], [2, 1], [2, 1]]
-  let aa4: Array<Array<Int>> = [[1], [], [2, 1], [2]]
-  let aa5: Array<Array<Int>> = [[1], [], [2, 1]]
-  checkHashable([aa1, aa2, aa3, aa4, aa5], equalityOracle: { $0 == $1 })
+  let a2: [Array<Array<Int>>] = [
+    [[], [1], [1, 2], [2, 1]],
+    [[], [1], [2, 1], [2, 1]],
+    [[1], [], [2, 1], [2, 1]],
+    [[1], [], [2, 1], [2]],
+    [[1], [], [2, 1]]
+  ]
+  checkHashable(a2, equalityOracle: { $0 == $1 })
+
+  // These arrays share the same sequence of leaf integers, but they must
+  // still all hash differently.
+  let a3: [Array<Array<Int>>] = [
+    // Grouping changes must perturb the hash.
+    [[1], [2], [3], [4], [5]],
+    [[1, 2], [3], [4], [5]],
+
+    [[1], [2, 3], [4], [5]],
+    [[1], [2], [3, 4], [5]],
+    [[1], [2], [3], [4, 5]],
+
+    [[1, 2, 3], [4], [5]],
+    [[1], [2, 3, 4], [5]],
+    [[1], [2], [3, 4, 5]],
+
+    [[1, 2, 3, 4], [5]],
+    [[1], [2, 3, 4, 5]],
+
+    [[1, 2], [3, 4], [5]],
+    [[1], [2, 3], [4, 5]],
+    [[1, 2, 3, 4, 5]],
+
+    // Empty arrays must perturb the hash.
+    [[], [1], [2], [3], [4], [5]],
+    [[1], [], [2], [3], [4], [5]],
+    [[1], [2], [3], [4], [5], []],
+    [[1], [], [], [2], [3], [], [4], [], [5]],
+  ]
+  checkHashable(a3, equalityOracle: { $0 == $1 })
 }
 
 


### PR DESCRIPTION
This makes the hash encoding unambiguous when arrays are hashed in sequence.
