### PR TITLE
Cleanup attr.def

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -98,255 +98,281 @@ TYPE_ATTR(thick)
 // SIMPLE_DECL_ATTR is the same, but the class becomes
 // SimpleDeclAttr<DAK_##NAME>.
 //
+// Please help ease code review/audits:
+// - Please indent once, not to the opening '('.
+// - Please place the "OnXYZ" flags together on the next line.
+// - Please place the non-OnXYZ flags together on the next to last line.
+// - Please place the unique number on the last line. If the attribute is NOT
+//   serialized, then please place that flag on the last line too. For example:
+//     123)
+//     NotSerialized, 321)
+// - Please sort attributes by serialization number.
+// - Please create a "NOTE" comment if a unique number is skipped.
 
 DECL_ATTR(_silgen_name, SILGenName,
-          OnFunc | OnConstructor | OnDestructor | LongAttribute |
-          UserInaccessible, 0)
-
+  OnAbstractFunction |
+  LongAttribute | UserInaccessible,
+  0)
 DECL_ATTR(available, Available,
-          OnFunc | OnStruct | OnEnum | OnClass | OnProtocol | OnVar |
-          OnConstructor | OnDestructor | OnTypeAlias | OnSubscript |
-          OnEnumElement | OnExtension | AllowMultipleAttributes | LongAttribute, 1)
-
-CONTEXTUAL_SIMPLE_DECL_ATTR(final, Final, DeclModifier |
-                            OnClass | OnFunc | OnVar | OnSubscript,
-                            2)
-
+  OnAbstractFunction | OnGenericType | OnVar | OnSubscript | OnEnumElement |
+  OnExtension |
+  AllowMultipleAttributes | LongAttribute,
+  1)
+CONTEXTUAL_SIMPLE_DECL_ATTR(final, Final,
+  OnClass | OnFunc | OnAccessor | OnVar | OnSubscript |
+  DeclModifier,
+  2)
 DECL_ATTR(objc, ObjC,
-          OnFunc | OnClass | OnProtocol | OnExtension | OnVar | OnSubscript |
-          OnConstructor | OnDestructor | OnEnum | OnEnumElement, 3)
-
-CONTEXTUAL_SIMPLE_DECL_ATTR(required, Required, DeclModifier |
-                            OnConstructor,
-                            4)
-
-CONTEXTUAL_SIMPLE_DECL_ATTR(optional, Optional, DeclModifier |
-                            OnConstructor | OnFunc | OnVar | OnSubscript,
-                            5)
-
-/// NOTE: 6 is unused
-
-SIMPLE_DECL_ATTR(noreturn, NoReturn, OnFunc, 7)
-
-SIMPLE_DECL_ATTR(_exported, Exported, OnImport | UserInaccessible, 8)
-
+  OnAbstractFunction | OnClass | OnProtocol | OnExtension | OnVar |
+  OnSubscript | OnEnum | OnEnumElement,
+  3)
+CONTEXTUAL_SIMPLE_DECL_ATTR(required, Required,
+  OnConstructor |
+  DeclModifier,
+  4)
+CONTEXTUAL_SIMPLE_DECL_ATTR(optional, Optional,
+  OnConstructor | OnFunc | OnAccessor | OnVar | OnSubscript |
+  DeclModifier,
+  5)
+// NOTE: 6 is unused
+SIMPLE_DECL_ATTR(noreturn, NoReturn,
+  OnFunc | OnAccessor,
+  7)
+SIMPLE_DECL_ATTR(_exported, Exported,
+  OnImport |
+  UserInaccessible,
+  8)
 SIMPLE_DECL_ATTR(dynamicMemberLookup, DynamicMemberLookup,
-                 OnClass | OnStruct | OnEnum | OnProtocol, 9)
-
+  OnNominalType,
+  9)
 SIMPLE_DECL_ATTR(NSCopying, NSCopying,
-                 OnVar, 10)
-
+  OnVar,
+  10)
 SIMPLE_DECL_ATTR(IBAction, IBAction,
-                 OnFunc, 11)
-
+  OnFunc,
+  11)
 SIMPLE_DECL_ATTR(IBDesignable, IBDesignable,
-                 OnClass | OnExtension, 12)
-
+  OnClass | OnExtension,
+  12)
 SIMPLE_DECL_ATTR(IBInspectable, IBInspectable,
-                 OnVar, 13)
-
+  OnVar,
+  13)
 SIMPLE_DECL_ATTR(IBOutlet, IBOutlet,
-                 OnVar, 14)
-
-SIMPLE_DECL_ATTR(NSManaged, NSManaged, OnVar | OnFunc, 15)
-
+  OnVar,
+  14)
+SIMPLE_DECL_ATTR(NSManaged, NSManaged,
+  OnVar | OnFunc | OnAccessor,
+  15)
 CONTEXTUAL_SIMPLE_DECL_ATTR(lazy, Lazy, DeclModifier |
-                            OnVar,
-                            16)
-
-SIMPLE_DECL_ATTR(LLDBDebuggerFunction, LLDBDebuggerFunction, OnFunc |
-                UserInaccessible, 17)
-
+  OnVar,
+  16)
+SIMPLE_DECL_ATTR(LLDBDebuggerFunction, LLDBDebuggerFunction,
+  OnFunc |
+  UserInaccessible,
+  17)
 SIMPLE_DECL_ATTR(UIApplicationMain, UIApplicationMain,
-                 OnClass, 18)
-
+  OnClass,
+  18)
 SIMPLE_DECL_ATTR(unsafe_no_objc_tagged_pointer, UnsafeNoObjCTaggedPointer,
-                 OnProtocol | UserInaccessible, 19)
-
-DECL_ATTR(inline, Inline, OnFunc | OnConstructor, 20)
-
+  OnProtocol |
+  UserInaccessible,
+  19)
+DECL_ATTR(inline, Inline,
+  OnFunc | OnAccessor | OnConstructor,
+  20)
 DECL_ATTR(_semantics, Semantics,
-          OnFunc | OnConstructor | OnDestructor | OnSubscript |
-          AllowMultipleAttributes | UserInaccessible, 21)
-
-CONTEXTUAL_SIMPLE_DECL_ATTR(dynamic, Dynamic, DeclModifier |
-                            OnFunc | OnVar | OnSubscript | OnConstructor,
-                            22)
-
-CONTEXTUAL_SIMPLE_DECL_ATTR(infix, Infix, DeclModifier |
-                            OnFunc | OnOperator,
-                            23)
-
-CONTEXTUAL_SIMPLE_DECL_ATTR(prefix, Prefix, DeclModifier |
-                            OnFunc | OnOperator,
-                            24)
-
-CONTEXTUAL_SIMPLE_DECL_ATTR(postfix, Postfix, DeclModifier |
-                            OnFunc | OnOperator,
-                            25)
-
+  OnAbstractFunction | OnSubscript |
+  AllowMultipleAttributes | UserInaccessible,
+  21)
+CONTEXTUAL_SIMPLE_DECL_ATTR(dynamic, Dynamic,
+  OnFunc | OnAccessor | OnVar | OnSubscript | OnConstructor |
+  DeclModifier,
+  22)
+CONTEXTUAL_SIMPLE_DECL_ATTR(infix, Infix,
+  OnFunc | OnOperator |
+  DeclModifier,
+  23)
+CONTEXTUAL_SIMPLE_DECL_ATTR(prefix, Prefix,
+  OnFunc | OnOperator |
+  DeclModifier,
+  24)
+CONTEXTUAL_SIMPLE_DECL_ATTR(postfix, Postfix,
+  OnFunc | OnOperator |
+  DeclModifier,
+  25)
 SIMPLE_DECL_ATTR(_transparent, Transparent,
-                 OnFunc|OnConstructor|OnVar|UserInaccessible, 26)
+  OnFunc | OnAccessor | OnConstructor | OnVar | UserInaccessible,
+  26)
 SIMPLE_DECL_ATTR(requires_stored_property_inits, RequiresStoredPropertyInits,
-                 OnClass, 27)
-
+  OnClass,
+  27)
 SIMPLE_DECL_ATTR(nonobjc, NonObjC,
-                 OnExtension | OnFunc | OnVar | OnSubscript | OnConstructor, 30)
-
+  OnExtension | OnFunc | OnAccessor | OnVar | OnSubscript | OnConstructor,
+  30)
 SIMPLE_DECL_ATTR(_fixed_layout, FixedLayout,
-                 OnVar | OnClass | OnStruct | UserInaccessible, 31)
-
+  OnVar | OnClass | OnStruct |
+  UserInaccessible,
+  31)
 SIMPLE_DECL_ATTR(inlinable, Inlinable,
-                 OnVar | OnSubscript | OnFunc | OnConstructor | OnDestructor |
-                 UserInaccessible, 32)
-
+  OnVar | OnSubscript | OnAbstractFunction |
+  UserInaccessible,
+  32)
 DECL_ATTR(_specialize, Specialize,
-          OnConstructor | OnFunc | AllowMultipleAttributes | LongAttribute
-          | UserInaccessible, 33)
-
-SIMPLE_DECL_ATTR(objcMembers, ObjCMembers, OnClass, 34)
-
-CONTEXTUAL_SIMPLE_DECL_ATTR(__consuming, Consuming, DeclModifier |
-                            OnFunc |
-                            NotSerialized, 40)
-
-CONTEXTUAL_SIMPLE_DECL_ATTR(mutating, Mutating, DeclModifier |
-                            OnFunc |
-                            NotSerialized, 41)
-
-CONTEXTUAL_SIMPLE_DECL_ATTR(nonmutating, NonMutating, DeclModifier |
-                            OnFunc |
-                            NotSerialized, 42)
-
+  OnConstructor | OnFunc | OnAccessor |
+  AllowMultipleAttributes | LongAttribute | UserInaccessible,
+  33)
+SIMPLE_DECL_ATTR(objcMembers, ObjCMembers,
+  OnClass,
+  34)
+CONTEXTUAL_SIMPLE_DECL_ATTR(__consuming, Consuming,
+  OnFunc | OnAccessor |
+  DeclModifier |
+  NotSerialized, 40)
+CONTEXTUAL_SIMPLE_DECL_ATTR(mutating, Mutating,
+  OnFunc | OnAccessor |
+  DeclModifier |
+  NotSerialized, 41)
+CONTEXTUAL_SIMPLE_DECL_ATTR(nonmutating, NonMutating,
+  OnFunc | OnAccessor |
+  DeclModifier |
+  NotSerialized, 42)
 CONTEXTUAL_SIMPLE_DECL_ATTR(convenience, Convenience,
-                            OnConstructor | DeclModifier | NotSerialized, 43)
-
-CONTEXTUAL_SIMPLE_DECL_ATTR(override, Override, DeclModifier |
-                            OnFunc | OnVar | OnSubscript | OnConstructor |
-                            NotSerialized, 44)
-
-SIMPLE_DECL_ATTR(sil_stored, SILStored, OnVar | NotSerialized | SILOnly,
-                 /* Not serialized */45)
-
+  OnConstructor |
+  DeclModifier |
+  NotSerialized, 43)
+CONTEXTUAL_SIMPLE_DECL_ATTR(override, Override,
+  OnFunc | OnAccessor | OnVar | OnSubscript | OnConstructor |
+  DeclModifier |
+  NotSerialized, 44)
+SIMPLE_DECL_ATTR(sil_stored, SILStored,
+  OnVar |
+  SILOnly |
+  NotSerialized, 45)
 DECL_ATTR(private, AccessControl,
-          OnFunc | OnExtension | OnTypeAlias | OnStruct | OnEnum |
-          OnClass | OnProtocol | OnVar | OnSubscript | OnConstructor |
-          DeclModifier | NotSerialized,
-          /* Not serialized */ 46)
+  OnFunc | OnAccessor | OnExtension | OnGenericType | OnVar | OnSubscript |
+  OnConstructor |
+  DeclModifier |
+  NotSerialized, 46)
 DECL_ATTR_ALIAS(fileprivate, AccessControl)
 DECL_ATTR_ALIAS(internal, AccessControl)
 DECL_ATTR_ALIAS(public, AccessControl)
 CONTEXTUAL_DECL_ATTR_ALIAS(open, AccessControl)
-
 DECL_ATTR(__setter_access, SetterAccess,
-          OnVar | OnSubscript | DeclModifier | NotSerialized | RejectByParser,
-          /* Not serialized */ 47)
-
-DECL_ATTR(__raw_doc_comment, RawDocComment, OnAnyDecl |
-          NotSerialized | RejectByParser, /* Not serialized */48)
-
-// Also handles unowned and unowned(weak).
-CONTEXTUAL_DECL_ATTR(weak, ReferenceOwnership, DeclModifier |
-                     OnVar | OnParam |
-                     NotSerialized, 49)
-
+  OnVar | OnSubscript |
+  DeclModifier | RejectByParser |
+  NotSerialized, 47)
+DECL_ATTR(__raw_doc_comment, RawDocComment,
+  OnAnyDecl |
+  RejectByParser |
+  NotSerialized, 48)
+CONTEXTUAL_DECL_ATTR(weak, ReferenceOwnership,
+  OnVar | OnParam |
+  DeclModifier |
+  NotSerialized, 49)
 CONTEXTUAL_DECL_ATTR_ALIAS(unowned, ReferenceOwnership)
-
-DECL_ATTR(effects, Effects, OnFunc | OnConstructor | OnDestructor |
-          UserInaccessible, 50)
-
-DECL_ATTR(__objc_bridged, ObjCBridged, OnClass | NotSerialized | RejectByParser,
-          /* Not serialized */51)
-
+DECL_ATTR(effects, Effects,
+  OnAbstractFunction |
+  UserInaccessible,
+  50)
+DECL_ATTR(__objc_bridged, ObjCBridged,
+  OnClass |
+  RejectByParser |
+  NotSerialized, 51)
 SIMPLE_DECL_ATTR(NSApplicationMain, NSApplicationMain,
-                 OnClass, 52)
-
+  OnClass,
+  52)
 SIMPLE_DECL_ATTR(_objc_non_lazy_realization, ObjCNonLazyRealization,
-                 OnClass | UserInaccessible, 53)
-
+  OnClass |
+  UserInaccessible,
+  53)
 DECL_ATTR(__synthesized_protocol, SynthesizedProtocol,
-          OnStruct | OnEnum | OnClass | NotSerialized | RejectByParser,
-          /* Not serialized */54)
-
+  OnConcreteNominalType |
+  RejectByParser |
+  NotSerialized, 54)
 SIMPLE_DECL_ATTR(testable, Testable,
-                 OnImport | NotSerialized | UserInaccessible,
-                 /* Not serialized */ 55)
-
-DECL_ATTR(_alignment, Alignment, OnStruct | OnEnum | UserInaccessible, 56)
-
+  OnImport |
+  UserInaccessible |
+  NotSerialized, 55)
+DECL_ATTR(_alignment, Alignment,
+  OnStruct | OnEnum |
+  UserInaccessible,
+  56)
 SIMPLE_DECL_ATTR(rethrows, Rethrows,
-                 OnFunc | OnConstructor | RejectByParser, 57)
-
+  OnFunc | OnAccessor | OnConstructor |
+  RejectByParser,
+  57)
 DECL_ATTR(_swift_native_objc_runtime_base, SwiftNativeObjCRuntimeBase,
-          OnClass | UserInaccessible, 59)
-
+  OnClass |
+  UserInaccessible,
+  59)
 CONTEXTUAL_SIMPLE_DECL_ATTR(indirect, Indirect, DeclModifier |
-                            OnEnum | OnEnumElement,
-                            60)
-
+  OnEnum | OnEnumElement,
+  60)
 SIMPLE_DECL_ATTR(warn_unqualified_access, WarnUnqualifiedAccess,
-                 OnFunc /*| OnVar*/ | LongAttribute, 61)
-
+  OnFunc | OnAccessor /*| OnVar*/ |
+  LongAttribute,
+  61)
 SIMPLE_DECL_ATTR(_show_in_interface, ShowInInterface,
-                 OnProtocol | UserInaccessible, 62)
-
+  OnProtocol |
+  UserInaccessible,
+  62)
 DECL_ATTR(_cdecl, CDecl,
-          OnFunc | LongAttribute | UserInaccessible, 63)
-
+  OnFunc | OnAccessor |
+  LongAttribute | UserInaccessible,
+  63)
 SIMPLE_DECL_ATTR(usableFromInline, UsableFromInline,
-                 OnFunc | OnVar | OnSubscript | OnConstructor |
-                 OnDestructor | OnStruct | OnEnum | OnClass |
-                 OnProtocol | LongAttribute | UserInaccessible,
-                 64)
-
+  OnAbstractFunction | OnVar | OnSubscript | OnNominalType |
+  LongAttribute | UserInaccessible,
+  64)
 SIMPLE_DECL_ATTR(discardableResult, DiscardableResult,
-                 OnFunc | OnConstructor | LongAttribute, 65)
-
-SIMPLE_DECL_ATTR(GKInspectable, GKInspectable, OnVar, 66)
-
+  OnFunc | OnAccessor | OnConstructor |
+  LongAttribute,
+  65)
+SIMPLE_DECL_ATTR(GKInspectable, GKInspectable,
+  OnVar,
+  66)
 DECL_ATTR(_implements, Implements,
-          OnFunc | OnVar | OnSubscript | OnTypeAlias
-          | NotSerialized | UserInaccessible,
-          /* Not serialized */ 67)
-
+  OnFunc | OnAccessor | OnVar | OnSubscript | OnTypeAlias |
+  UserInaccessible |
+  NotSerialized, 67)
 DECL_ATTR(_objcRuntimeName, ObjCRuntimeName,
-          OnClass | NotSerialized | UserInaccessible | RejectByParser,
-          /*Not serialized */ 68)
-
+  OnClass |
+  UserInaccessible | RejectByParser |
+  NotSerialized, 68)
 SIMPLE_DECL_ATTR(_staticInitializeObjCMetadata, StaticInitializeObjCMetadata,
-                 OnClass | NotSerialized | LongAttribute | RejectByParser,
-                 /*Not serialized */ 69)
-
+  OnClass | LongAttribute | RejectByParser |
+  NotSerialized, 69)
 DECL_ATTR(_restatedObjCConformance, RestatedObjCConformance,
-          OnProtocol | NotSerialized | LongAttribute | RejectByParser,
-         /*Not serialized */ 70)
-
+  OnProtocol |
+  LongAttribute | RejectByParser |
+  NotSerialized, 70)
 // HACK: Attribute needed to preserve source compatibility by downgrading errors
 // due to an SDK change in Dispatch
 SIMPLE_DECL_ATTR(_downgrade_exhaustivity_check, DowngradeExhaustivityCheck,
-                 OnEnumElement | LongAttribute | UserInaccessible, 71)
-
-SIMPLE_DECL_ATTR(_implicitly_unwrapped_optional,
-                 ImplicitlyUnwrappedOptional,
-                 OnFunc | OnVar | OnParam | OnSubscript | OnConstructor
-                 | RejectByParser, 72)
-
+  OnEnumElement |
+  LongAttribute | UserInaccessible,
+  71)
+SIMPLE_DECL_ATTR(_implicitly_unwrapped_optional, ImplicitlyUnwrappedOptional,
+  OnFunc | OnAccessor | OnVar | OnParam | OnSubscript | OnConstructor |
+  RejectByParser,
+  72)
 DECL_ATTR(_optimize, Optimize,
-          OnFunc | OnConstructor | OnDestructor | OnSubscript | OnVar |
-          UserInaccessible, 73)
-
+  OnAbstractFunction | OnSubscript | OnVar |
+  UserInaccessible,
+  73)
 DECL_ATTR(_clangImporterSynthesizedType, ClangImporterSynthesizedType,
-          OnClass | OnStruct | OnEnum | OnProtocol | OnTypeAlias |
-          LongAttribute | NotSerialized | RejectByParser | UserInaccessible,
-          /*Not serialized*/74)
-
+  OnGenericType |
+  LongAttribute | RejectByParser | UserInaccessible |
+  NotSerialized, 74)
 SIMPLE_DECL_ATTR(_weakLinked, WeakLinked,
-                 OnEnum | OnStruct | OnClass | OnProtocol |
-                 OnFunc | OnVar | OnSubscript | OnConstructor | OnEnumElement |
-                 UserInaccessible,
-                 75)
-
-SIMPLE_DECL_ATTR(_frozen, Frozen, OnEnum | UserInaccessible, 76)
+  OnNominalType | OnFunc | OnAccessor | OnVar | OnSubscript | OnConstructor |
+  OnEnumElement |
+  UserInaccessible,
+  75)
+SIMPLE_DECL_ATTR(_frozen, Frozen,
+  OnEnum |
+  UserInaccessible,
+  76)
 
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS

--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -280,7 +280,27 @@ public:
 #define DECL(Name, _) On##Name = 1ull << unsigned(DeclKindIndex::Name),
 #include "swift/AST/DeclNodes.def"
 
-    // More coarse-grained aggregations for use in Attr.def.
+    // Abstract class aggregations for use in Attr.def.
+    OnValue = 0
+#define DECL(Name, _)
+#define VALUE_DECL(Name, _) |On##Name
+#include "swift/AST/DeclNodes.def"
+    ,
+
+    OnNominalType = 0
+#define DECL(Name, _)
+#define NOMINAL_TYPE_DECL(Name, _) |On##Name
+#include "swift/AST/DeclNodes.def"
+    ,
+    OnConcreteNominalType = OnNominalType & ~OnProtocol,
+    OnGenericType = OnNominalType | OnTypeAlias,
+
+    OnAbstractFunction = 0
+#define DECL(Name, _)
+#define ABSTRACT_FUNCTION_DECL(Name, _) |On##Name
+#include "swift/AST/DeclNodes.def"
+    ,
+
     OnOperator = 0
 #define DECL(Name, _)
 #define OPERATOR_DECL(Name, _) |On##Name

--- a/include/swift/AST/DeclNodes.def
+++ b/include/swift/AST/DeclNodes.def
@@ -116,6 +116,13 @@
 #define NOMINAL_TYPE_DECL(Id, Parent) ITERABLE_GENERIC_VALUE_DECL(Id, Parent)
 #endif
 
+/// ABSTRACT_FUNCTION_DECL(Id, Parent)
+///   Used for subclasses of AbstractFunction. The default behavior is
+///   to do the same as for GENERIC_VALUE_DECL.
+#ifndef ABSTRACT_FUNCTION_DECL
+#define ABSTRACT_FUNCTION_DECL(Id, Parent) GENERIC_VALUE_DECL(Id, Parent)
+#endif
+
 /// VALUE_DECL(Id, Parent)
 ///   Used for subclasses of ValueDecl.  The default behavior is to do
 ///   the same as for Decl.
@@ -159,10 +166,10 @@ ABSTRACT_DECL(Value, Decl)
     GENERIC_VALUE_DECL(Subscript, AbstractStorageDecl)
     DECL_RANGE(AbstractStorage, Var, Subscript)
   ABSTRACT_DECL(AbstractFunction, ValueDecl)
-    GENERIC_VALUE_DECL(Constructor, AbstractFunctionDecl)
-    GENERIC_VALUE_DECL(Destructor, AbstractFunctionDecl)
-    GENERIC_VALUE_DECL(Func, AbstractFunctionDecl)
-      GENERIC_VALUE_DECL(Accessor, FuncDecl)
+    ABSTRACT_FUNCTION_DECL(Constructor, AbstractFunctionDecl)
+    ABSTRACT_FUNCTION_DECL(Destructor, AbstractFunctionDecl)
+    ABSTRACT_FUNCTION_DECL(Func, AbstractFunctionDecl)
+      ABSTRACT_FUNCTION_DECL(Accessor, FuncDecl)
     DECL_RANGE(AbstractFunction, Constructor, Accessor)
   VALUE_DECL(EnumElement, ValueDecl)
   DECL_RANGE(Value, Enum, EnumElement)
@@ -194,6 +201,7 @@ LAST_DECL(PostfixOperator)
 #undef CONTEXT_VALUE_DECL
 #undef GENERIC_VALUE_DECL
 #undef ITERABLE_GENERIC_VALUE_DECL
+#undef ABSTRACT_FUNCTION_DECL
 #undef VALUE_DECL
 #undef DECL_RANGE
 #undef ABSTRACT_DECL

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -539,16 +539,11 @@ void DeclAttribute::print(llvm::raw_ostream &OS, const Decl *D) const {
 }
 
 uint64_t DeclAttribute::getOptions(DeclAttrKind DK) {
-  // FIXME: Update Attr.def to use OnAccessor.
   switch (DK) {
   case DAK_Count:
     llvm_unreachable("getOptions needs a valid attribute");
 #define DECL_ATTR(_, CLASS, OPTIONS, ...)\
-  case DAK_##CLASS: { \
-    uint64_t options = OPTIONS; \
-    if (options & OnFunc) options |= OnAccessor; \
-    return options; \
-  }
+  case DAK_##CLASS: return OPTIONS;
 #include "swift/AST/Attr.def"
   }
   llvm_unreachable("bad DeclAttrKind");

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -749,35 +749,23 @@ void TypeChecker::checkDeclAttributesEarly(Decl *D) {
     auto PossibleDeclKinds = attr->getOptions() & DeclAttribute::OnAnyDecl;
     StringRef OnlyKind;
     switch (PossibleDeclKinds) {
-    case DeclAttribute::OnImport:
-      OnlyKind = "import";
-      break;
-    case DeclAttribute::OnVar:
-      OnlyKind = "var";
-      break;
-    // FIXME: Update Attr.def to use OnAccessor.
-    case DeclAttribute::OnFunc:
-    case DeclAttribute::OnAccessor:
-    case DeclAttribute::OnFunc | DeclAttribute::OnAccessor:
-      OnlyKind = "func";
-      break;
-    case DeclAttribute::OnClass:
-      OnlyKind = "class";
-      break;
-    case DeclAttribute::OnStruct:
-      OnlyKind = "struct";
-      break;
-    case DeclAttribute::OnConstructor:
-      OnlyKind = "init";
-      break;
-    case DeclAttribute::OnProtocol:
-      OnlyKind = "protocol";
-      break;
-    case DeclAttribute::OnParam:
-      OnlyKind = "parameter";
-      break;
-    default:
-      break;
+    case DeclAttribute::OnAccessor:    OnlyKind = "accessor"; break;
+    case DeclAttribute::OnClass:       OnlyKind = "class"; break;
+    case DeclAttribute::OnConstructor: OnlyKind = "init"; break;
+    case DeclAttribute::OnDestructor:  OnlyKind = "deinit"; break;
+    case DeclAttribute::OnEnum:        OnlyKind = "enum"; break;
+    case DeclAttribute::OnEnumCase:    OnlyKind = "case"; break;
+    case DeclAttribute::OnFunc | DeclAttribute::OnAccessor: // FIXME
+    case DeclAttribute::OnFunc:        OnlyKind = "func"; break;
+    case DeclAttribute::OnImport:      OnlyKind = "import"; break;
+    case DeclAttribute::OnModule:      OnlyKind = "module"; break;
+    case DeclAttribute::OnParam:       OnlyKind = "parameter"; break;
+    case DeclAttribute::OnProtocol:    OnlyKind = "protocol"; break;
+    case DeclAttribute::OnStruct:      OnlyKind = "struct"; break;
+    case DeclAttribute::OnSubscript:   OnlyKind = "subscript"; break;
+    case DeclAttribute::OnTypeAlias:   OnlyKind = "typealias"; break;
+    case DeclAttribute::OnVar:         OnlyKind = "var"; break;
+    default: break;
     }
 
     if (!OnlyKind.empty())

--- a/test/attr/attr_ibaction.swift
+++ b/test/attr/attr_ibaction.swift
@@ -5,6 +5,11 @@
 @IBAction // expected-error {{@IBAction may only be used on 'func' declarations}} {{1-11=}}
 var iboutlet_global: Int
 
+var iboutlet_accessor: Int {
+  @IBAction // expected-error {{@IBAction may only be used on 'func' declarations}} {{3-13=}}
+  get { return 42 }
+}
+
 @IBAction // expected-error {{@IBAction may only be used on 'func' declarations}} {{1-11=}}
 class IBOutletClassTy {}
 @IBAction // expected-error {{@IBAction may only be used on 'func' declarations}} {{1-11=}}

--- a/test/decl/func/debugger_function.swift
+++ b/test/decl/func/debugger_function.swift
@@ -1,5 +1,11 @@
 // RUN: %target-typecheck-verify-swift -enable-throw-without-try -debugger-support
 
+var invalidAccessor : Int {
+  // expected-error@+1 {{@LLDBDebuggerFunction may only be used on 'func' declarations}} {{3-24=}}
+  @LLDBDebuggerFunction
+  get { return 42 }
+}
+
 func foo() throws -> Int { return 0 }
 
 @LLDBDebuggerFunction


### PR DESCRIPTION
This builds on #16014, so please ignore the first commit.

1) Formalize `OnAccessor`. A hack used to alias this to `OnFunc`.
2) New aggregates: `OnNominalType`, `OnGenericType`, `OnAbstractFunction`.
3) Consistent and self-documented (albeit custom) style in Attr.def to ease code review/audits.

@rjmccall and @slavapestov – Review questions:

1) Now that `OnAccessor` is formalized, should it be removed from any attributes?
2) Now that `OnAccessor` is formalized, should `OnFunc` be removed from any attributes?
3) Now that new aggregate "OnXYZ" options exist, it seems like there might be some oversights in the `.def` file. For example, it is intentional that `inline` doesn't work on destructors? Also, why doesn't `_alignment` include `OnClass`? There might be more oversights. Feedback would be appreciated.
4) The following seems to be a common attribute requirement: `OnAbstractFunction & ~OnDestructor`. Should it be formalized? Perhaps `OnNonDestructorFunctions`?