### PR TITLE
build: allow the user to specify the ICU paths for compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -851,8 +851,20 @@ endif()
 #
 # Find required dependencies.
 #
-if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND "${SWIFT_PATH_TO_LIBICU_BUILD}" STREQUAL "")
-  find_package(ICU REQUIRED COMPONENTS uc i18n)
+
+# ICU is provided through CoreFoundation on Darwin.  On other hosts, assume that
+# we are compiling for the build as the host.  In such a case, if the ICU
+# unicode and i18n include and library paths are not defined, perform a standard
+# package lookup.  Otherwise, rely on the paths specified by the user.  These
+# need to be defined when cross-compiling.
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+  if("${SWIFT_PATH_TO_LIBICU_BUILD}" STREQUAL "" AND
+     ("${SWIFT_${SWIFT_HOST_VARIANT_SDK_default}_ICU_UC_INCLUDE}" STREQUAL "" OR
+      "${SWIFT_${SWIFT_HOST_VARIANT_SDK_default}_ICU_UC}" STREQUAL "" OR
+      "${SWIFT_${SWIFT_HOST_VARIANT_SDK_default}_ICU_I18N_INCLUDE}" STREQUAL "" OR
+      "${SWIFT_${SWIFT_HOST_VARIANT_SDK_default}_ICU_I18N}" STREQUAL ""))
+    find_package(ICU REQUIRED COMPONENTS uc i18n)
+  endif()
 endif()
 
 find_package(PythonInterp REQUIRED)


### PR DESCRIPTION
This brings the default compilation model more in line with the
cross-compilation model by allowing the user to specify the ICU UC/I18N
paths when invoking CMake.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
