### PR TITLE
libSyntax parsing fixes for class-restricted protocols and operators for higher-order functions

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2848,9 +2848,8 @@ ParserStatus Parser::parseInheritance(SmallVectorImpl<TypeLoc> &Inherited,
     };
     // Parse the 'class' keyword for a class requirement.
     if (Tok.is(tok::kw_class)) {
-      // FIXME: class requirement will turn to an unknown type in libSyntax tree.
       SyntaxParsingContext ClassTypeContext(SyntaxContext,
-                                            SyntaxContextKind::Type);
+                                            SyntaxKind::ClassRestrictionType);
       // If we aren't allowed to have a class requirement here, complain.
       auto classLoc = consumeToken();
       if (!allowClassRequirement) {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2966,7 +2966,7 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
     Expr *SubExpr = nullptr;
     if (Tok.isBinaryOperator() && peekToken().isAny(rightTok, tok::comma)) {
       SyntaxParsingContext operatorContext(SyntaxContext,
-                                           SyntaxContextKind::Expr);
+                                           SyntaxKind::IdentifierExpr);
       SourceLoc Loc;
       Identifier OperName;
       if (parseAnyIdentifier(OperName, Loc, diag::expected_operator_ref)) {

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -234,7 +234,21 @@ public:
                             "expression");
     visitChildren(Node);
   }
-
+  void visit(UnknownStmtSyntax Node) override {
+    RootData.Diags.diagnose(getSourceLoc(Node), diag::unknown_syntax_entity,
+                            "statement");
+    visitChildren(Node);
+  }
+  void visit(UnknownTypeSyntax Node) override {
+    RootData.Diags.diagnose(getSourceLoc(Node), diag::unknown_syntax_entity,
+                            "type");
+    visitChildren(Node);
+  }
+  void visit(UnknownPatternSyntax Node) override {
+    RootData.Diags.diagnose(getSourceLoc(Node), diag::unknown_syntax_entity,
+                            "pattern");
+    visitChildren(Node);
+  }
   void verify(Syntax Node) {
     Node.accept(*this);
   }

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -180,7 +180,7 @@ private </DeclModifier>struct S<GenericParameterClause><<GenericParameter>A, </G
   private </DeclModifier>struct S<TypeInheritanceClause>: <InheritedType><SimpleTypeIdentifier>A</SimpleTypeIdentifier>, </InheritedType><InheritedType><SimpleTypeIdentifier>B </SimpleTypeIdentifier></InheritedType></TypeInheritanceClause><MemberDeclBlock>{}</MemberDeclBlock></StructDecl>
 }</MemberDeclBlock></StructDecl><ProtocolDecl>
 
-protocol P<TypeInheritanceClause>: <InheritedType>class </InheritedType></TypeInheritanceClause><MemberDeclBlock>{}</MemberDeclBlock></ProtocolDecl><FunctionDecl>
+protocol P<TypeInheritanceClause>: <InheritedType><ClassRestrictionType>class </ClassRestrictionType></InheritedType></TypeInheritanceClause><MemberDeclBlock>{}</MemberDeclBlock></ProtocolDecl><FunctionDecl>
 
 func foo<FunctionSignature><ParameterClause>(<FunctionParameter>_ _: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier>,</FunctionParameter><FunctionParameter>
          a b: <SimpleTypeIdentifier>Int </SimpleTypeIdentifier><InitializerClause>= <SequenceExpr><IntegerLiteralExpr>3 </IntegerLiteralExpr><BinaryOperatorExpr>+ </BinaryOperatorExpr><IntegerLiteralExpr>2</IntegerLiteralExpr></SequenceExpr></InitializerClause>,</FunctionParameter><FunctionParameter>

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -485,4 +485,9 @@ precedencegroup BazPrecedence {<PrecedenceGroupAssociativity>
 
 infix </DeclModifier>operator<++><InfixOperatorGroup>:FooPrecedence</InfixOperatorGroup></OperatorDecl><OperatorDecl><DeclModifier>
 prefix </DeclModifier>operator..<<</OperatorDecl><OperatorDecl><DeclModifier>
-postfix </DeclModifier>operator <-</OperatorDecl>
+postfix </DeclModifier>operator <-</OperatorDecl><FunctionDecl>
+
+func higherOrderFunc<FunctionSignature><ParameterClause>() </ParameterClause></FunctionSignature><CodeBlock>{<VariableDecl>
+  let <PatternBinding><IdentifierPattern>x </IdentifierPattern><InitializerClause>= <ArrayExpr>[<ArrayElement><IntegerLiteralExpr>1</IntegerLiteralExpr>,</ArrayElement><ArrayElement><IntegerLiteralExpr>2</IntegerLiteralExpr>,</ArrayElement><ArrayElement><IntegerLiteralExpr>3</IntegerLiteralExpr></ArrayElement>]</ArrayExpr></InitializerClause></PatternBinding></VariableDecl><FunctionCallExpr><MemberAccessExpr><IdentifierExpr>
+  x</IdentifierExpr>.reduce</MemberAccessExpr>(<FunctionCallArgument><IntegerLiteralExpr>0</IntegerLiteralExpr>, </FunctionCallArgument><FunctionCallArgument><IdentifierExpr>+</IdentifierExpr></FunctionCallArgument>)</FunctionCallExpr>
+}</CodeBlock></FunctionDecl>

--- a/test/Syntax/round_trip_parse_gen.swift
+++ b/test/Syntax/round_trip_parse_gen.swift
@@ -486,3 +486,8 @@ precedencegroup BazPrecedence {
 infix operator<++>:FooPrecedence
 prefix operator..<<
 postfix operator <-
+
+func higherOrderFunc() {
+  let x = [1,2,3]
+  x.reduce(0, +)
+}

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -75,6 +75,7 @@ EXPR_NODES = [
                        'SelfToken',
                        'CapitalSelfToken',
                        'DollarIdentifierToken',
+                       'SpacedBinaryOperatorToken',
                    ]),
              Child('DeclNameArguments', kind='DeclNameArguments',
                    is_optional=True),

--- a/utils/gyb_syntax_support/TypeNodes.py
+++ b/utils/gyb_syntax_support/TypeNodes.py
@@ -34,6 +34,11 @@ TYPE_NODES = [
                    is_optional=True),
          ]),
 
+    # class-restriction-type -> 'class'
+    Node('ClassRestrictionType', kind='Type',
+         children=[
+             Child('ClassKeyword', kind='ClassToken'),
+         ]),
     # array-type -> '[' type ']'
     Node('ArrayType', kind='Type',
          children=[


### PR DESCRIPTION
This PR fixes libSyntax parsing for the following syntactic elements, creating corresponding nodes instead of unknown ones:
- Protocol class restrictions, e.g. `protocol P : class {}`
- Operators passed to higher order functions, e.g. `[1,2,3].reduce(0, +)`

It also adds a new option to the `swift-syntax-test` utility: If `input-source-directory` is passed instead of `input-source-filename`, the directory will recursively be searched for `.swift` files and `swift-syntax-test` will be run on every of these files consecutively.