### PR TITLE
Add overload for appending collections

### DIFF
--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -458,6 +458,12 @@ extension RangeReplaceableCollection {
       append(element)
     }
   }
+  
+  @inlinable
+  public mutating func append<C : Collection>(contentsOf newElements: C)
+    where C.Element == Element {
+      replaceSubrange(endIndex..<endIndex, with: newElements)
+  }
 
   /// Inserts a new element into the collection at the specified position.
   ///


### PR DESCRIPTION
This seems to help the ArrayAppendArrayOfInt benchmark a little bit locally, so let's give this another shot.