### PR TITLE
[sourcekitd] Change compile notifications to pass a single args string

### DIFF
--- a/test/SourceKit/CompileNotifications/args.swift
+++ b/test/SourceKit/CompileNotifications/args.swift
@@ -2,16 +2,14 @@
 // ARGS1: {
 // ARGS1:  key.notification: source.notification.compile-will-start
 // ARGS1:  key.filepath: "[[PATH:.*]]"
-// ARGS1:  key.compilerargs: [
-// ARGS1-NEXT:    [[PATH]]
-// ARGS1-NEXT:  ]
+// ARGS1:  key.compilerargs-string: "
+// ARGS1-LINE:    [[PATH]]
 
 // RUN: %sourcekitd-test -req=track-compiles == -req=sema %s -- %s -j 1000 | %FileCheck %s -check-prefix=ARGS2
 // ARGS2: {
 // ARGS2:  key.notification: source.notification.compile-will-start
 // ARGS2:  key.filepath: "[[PATH:.*]]"
-// ARGS2:  key.compilerargs: [
-// ARGS2-NEXT:    [[PATH]]
-// ARGS2-NEXT:    "-j"
-// ARGS2-NEXT:    "1000"
-// ARGS2-NEXT:  ]
+// ARGS2:  key.compilerargs-string: "
+// ARGS2-LINE:    [[PATH]]
+// ARGS2-LINE:    -j
+// ARGS2-LINE:    1000

--- a/tools/SourceKit/include/SourceKit/Support/Tracing.h
+++ b/tools/SourceKit/include/SourceKit/Support/Tracing.h
@@ -28,7 +28,7 @@ namespace trace {
 
 struct SwiftArguments {
   std::string PrimaryFile;
-  std::vector<std::string> Args;
+  std::string Arguments;
 };
 
 enum class OperationKind : uint64_t {

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -795,8 +795,8 @@ ASTUnitRef ASTProducer::createASTUnit(SwiftASTManager::Implementation &MgrImpl,
   trace::TracedOperation TracedOp(trace::OperationKind::PerformSema);
   trace::SwiftInvocation TraceInfo;
   if (TracedOp.enabled()) {
-    TraceInfo.Args.PrimaryFile = InvokRef->Impl.Opts.PrimaryFile;
-    TraceInfo.Args.Args = InvokRef->Impl.Opts.Args;
+    trace::initTraceInfo(TraceInfo, InvokRef->Impl.Opts.PrimaryFile,
+                         InvokRef->Impl.Opts.Args);
   }
 
   ASTUnitRef ASTRef = new ASTUnit(++ASTUnitGeneration, MgrImpl.Stats);

--- a/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftIndexing.cpp
@@ -198,11 +198,25 @@ static void indexModule(llvm::MemoryBuffer *Input,
 // IndexSource
 //===----------------------------------------------------------------------===//
 
+template <typename Str>
+static void initTraceInfoImpl(trace::SwiftInvocation &SwiftArgs,
+                              StringRef InputFile,
+                              ArrayRef<Str> Args) {
+  llvm::raw_string_ostream OS(SwiftArgs.Args.Arguments);
+  interleave(Args, [&OS](StringRef arg) { OS << arg; }, [&OS] { OS << ' '; });
+  SwiftArgs.Args.PrimaryFile = InputFile;
+}
+
 void trace::initTraceInfo(trace::SwiftInvocation &SwiftArgs,
                           StringRef InputFile,
                           ArrayRef<const char *> Args) {
-  SwiftArgs.Args.Args.assign(Args.begin(), Args.end());
-  SwiftArgs.Args.PrimaryFile = InputFile;
+  initTraceInfoImpl(SwiftArgs, InputFile, Args);
+}
+
+void trace::initTraceInfo(trace::SwiftInvocation &SwiftArgs,
+                          StringRef InputFile,
+                          ArrayRef<std::string> Args) {
+  initTraceInfoImpl(SwiftArgs, InputFile, Args);
 }
 
 void SwiftLangSupport::indexSource(StringRef InputFile,

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -516,6 +516,9 @@ namespace trace {
   void initTraceInfo(trace::SwiftInvocation &SwiftArgs,
                      StringRef InputFile,
                      ArrayRef<const char *> Args);
+  void initTraceInfo(trace::SwiftInvocation &SwiftArgs,
+                     StringRef InputFile,
+                     ArrayRef<std::string> Args);
 }
 
 /// When we cannot build any more clang modules, close the .pcm / files to

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -2711,7 +2711,7 @@ void CompileTrackingConsumer::operationStarted(
   Dict.set(KeyCompileID, std::to_string(OpId));
   Dict.set(KeyFilePath, Inv.Args.PrimaryFile);
   // FIXME: OperationKind
-  Dict.set(KeyCompilerArgs, Inv.Args.Args);
+  Dict.set(KeyCompilerArgsString, Inv.Args.Arguments);
   sourcekitd::postNotification(RespBuilder.createResponse());
 }
 

--- a/utils/gyb_sourcekit_support/UIDs.py
+++ b/utils/gyb_sourcekit_support/UIDs.py
@@ -154,6 +154,7 @@ UID_KEYS = [
     KEY('ActionUID', 'key.actionuid'),
     KEY('ActionUnavailableReason', 'key.actionunavailablereason'),
     KEY('CompileID', 'key.compileid'),
+    KEY('CompilerArgsString', 'key.compilerargs-string'),
 ]
 
 


### PR DESCRIPTION
... instead of an array of compiler arguments. This is good enough
for seeing what's going on, and it saves significant time for long
argument strings, because it doesn't create and destroy so many
xpc strings, and more of the string copying that happens is on a large
contiguous string instead of many small strings.

rdar://39538847