### PR TITLE
[sourcekitd] Fix some compiler warnings

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -865,7 +865,6 @@ static bool canonicalizeFilterName(const char *origName,
       continue;
     }
   }
-  llvm_unreachable("exit is on null byte");
 }
 
 static void translateFilterRules(ArrayRef<FilterRule> rawFilterRules,

--- a/tools/SourceKit/tools/sourcekitd/include/sourcekitd/sourcekitd.h
+++ b/tools/SourceKit/tools/sourcekitd/include/sourcekitd/sourcekitd.h
@@ -351,7 +351,7 @@ SOURCEKITD_PUBLIC SOURCEKITD_NONNULL1 SOURCEKITD_WARN_RESULT
 sourcekitd_variant_t
 sourcekitd_response_get_value(sourcekitd_response_t resp);
 
-SOURCEKITD_PUBLIC SOURCEKITD_NONNULL_ALL SOURCEKITD_WARN_RESULT
+SOURCEKITD_PUBLIC SOURCEKITD_WARN_RESULT
 sourcekitd_variant_type_t
 sourcekitd_variant_get_type(sourcekitd_variant_t obj);
 

--- a/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/sourcekitdAPI-XPC.cpp
@@ -583,9 +583,9 @@ sourcekitd_response_get_value(sourcekitd_response_t resp) {
 #define XPC_OBJ(var) ((xpc_object_t)(var).data[1])
 
 #define CUSTOM_BUF_KIND(xobj) \
-  ((CustomBufferKind)*(uint64_t*)xpc_data_get_bytes_ptr(xobj))
+  ((CustomBufferKind)*(const uint64_t*)xpc_data_get_bytes_ptr(xobj))
 #define CUSTOM_BUF_START(xobj) \
-  ((void*)(((uint64_t*)xpc_data_get_bytes_ptr(xobj))+1))
+  ((const void*)(((const uint64_t*)xpc_data_get_bytes_ptr(xobj))+1))
 
 static sourcekitd_variant_type_t XPCVar_get_type(sourcekitd_variant_t var) {
   xpc_object_t obj = XPC_OBJ(var);


### PR DESCRIPTION
* remove nullability attribute from a non-pointer argument
* const-correctness on custom buffer casts
* remove statically unreachable code
