### PR TITLE
Declare some FloatingPointSign members explicitly for @inlinable

### DIFF
--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -1225,6 +1225,31 @@ public enum FloatingPointSign: Int {
 
   /// The sign for a negative value.
   case minus
+
+  // Explicit declarations of otherwise-synthesized members to make them
+  // @inlinable, promising that we will never change the implementation.
+
+  @inlinable
+  public init?(rawValue: Int) {
+    switch rawValue {
+    case 0: self = .plus
+    case 1: self = .minus
+    default: return nil
+    }
+  }
+
+  @inlinable
+  public var rawValue: Int {
+    switch self {
+    case .plus: return 0
+    case .minus: return 1
+    }
+  }
+
+  @inlinable
+  public static func ==(a: FloatingPointSign, b: FloatingPointSign) -> Bool {
+    return a.rawValue == b.rawValue
+  }
 }
 
 /// The IEEE 754 floating-point classes.


### PR DESCRIPTION
The compiler can synthesize these, but it doesn't mark them @inlinable, since in the general case they're just a "default" implementation and not "the only implementation forever". But for a two-element enum that's based on a part of IEEE 754, it's probably safe to assume this is the only implementation forever, and that can be important for performance.

[SR-7094](https://bugs.swift.org/browse/SR-7094) / rdar://problem/38030106