### PR TITLE
[Coverage] Profile extensions separately from their base types

### DIFF
--- a/lib/SIL/SILProfiler.cpp
+++ b/lib/SIL/SILProfiler.cpp
@@ -93,11 +93,8 @@ static bool canCreateProfilerForAST(ASTNode N) {
   assert(hasASTBeenTypeChecked(N) && "Cannot use this AST for profiling");
 
   if (auto *D = N.dyn_cast<Decl *>()) {
-    // Any mapped function may be profiled. There's an exception for
-    // constructors because all of the constructors for a type share a single
-    // profiler.
     if (auto *AFD = dyn_cast<AbstractFunctionDecl>(D))
-      return !isa<ConstructorDecl>(AFD);
+      return true;
 
     if (isa<TopLevelCodeDecl>(D))
       return true;
@@ -798,7 +795,7 @@ public:
       return visitFunctionDecl(*this, AFD, [&] {
         CounterExpr &funcCounter = assignCounter(AFD->getBody());
 
-        if (isa<ConstructorDecl>(AFD))
+        if (ParentNominalType && isa<ConstructorDecl>(AFD))
           addToCounter(ParentNominalType, funcCounter);
       });
     } else if (auto *TLCD = dyn_cast<TopLevelCodeDecl>(D)) {
@@ -995,16 +992,6 @@ static StringRef getCurrentFileName(ASTNode Root) {
   return {};
 }
 
-static void walkTopLevelNodeForProfiling(ASTNode Root, ASTWalker &Walker) {
-  Root.walk(Walker);
-
-  // Visit extensions when walking through a nominal type.
-  auto *NTD = dyn_cast_or_null<NominalTypeDecl>(Root.dyn_cast<Decl *>());
-  if (NTD)
-    for (ExtensionDecl *ED : NTD->getExtensions())
-      ED->walk(Walker);
-}
-
 void SILProfiler::assignRegionCounters() {
   const auto &SM = M.getASTContext().SourceMgr;
 
@@ -1040,7 +1027,7 @@ void SILProfiler::assignRegionCounters() {
       CurrentFuncName, getEquivalentPGOLinkage(CurrentFuncLinkage),
       CurrentFileName);
 
-  walkTopLevelNodeForProfiling(Root, Mapper);
+  Root.walk(Mapper);
 
   NumRegionCounters = Mapper.NextCounter;
   // TODO: Mapper needs to calculate a function hash as it goes.
@@ -1048,7 +1035,7 @@ void SILProfiler::assignRegionCounters() {
 
   if (EmitCoverageMapping) {
     CoverageMapping Coverage(SM);
-    walkTopLevelNodeForProfiling(Root, Coverage);
+    Root.walk(Coverage);
     CovMap =
         Coverage.emitSourceRegions(M, CurrentFuncName, PGOFuncName, PGOFuncHash,
                                    RegionCounterMap, CurrentFileName);
@@ -1066,7 +1053,7 @@ void SILProfiler::assignRegionCounters() {
     }
     PGOMapping pgoMapper(RegionLoadedCounterMap, LoadedCounts,
                          RegionCondToParentMap);
-    walkTopLevelNodeForProfiling(Root, pgoMapper);
+    Root.walk(pgoMapper);
   }
 }
 

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -96,9 +96,10 @@ public:
   /// The most recent conformance...
   NormalProtocolConformance *lastEmittedConformance = nullptr;
 
-  /// Profiler instances for constructors, grouped by associated nominal type.
+  /// Profiler instances for constructors, grouped by associated decl.
   /// Each profiler is shared by all member initializers for a nominal type.
-  llvm::DenseMap<NominalTypeDecl *, SILProfiler *> constructorProfilers;
+  /// Constructors within extensions are profiled separately.
+  llvm::DenseMap<Decl *, SILProfiler *> constructorProfilers;
 
   SILFunction *emitTopLevelFunction(SILLocation Loc);
 
@@ -440,9 +441,12 @@ public:
   /// Emit a property descriptor for the given storage decl if it needs one.
   void tryEmitPropertyDescriptor(AbstractStorageDecl *decl);
 
-  /// Get or create the profiler instance for a nominal type's constructors.
-  SILProfiler *getOrCreateProfilerForConstructors(NominalTypeDecl *decl);
-  
+  /// Get or create the shared profiler instance for a type's constructors.
+  /// This takes care to create separate profilers for extensions, which may
+  /// reside in a different file than the one where the base type is defined.
+  SILProfiler *getOrCreateProfilerForConstructors(DeclContext *ctx,
+                                                  ConstructorDecl *cd);
+
 private:
   /// Emit the deallocator for a class that uses the objc allocator.
   void emitObjCAllocatorDestructor(ClassDecl *cd, DestructorDecl *dd);

--- a/test/SILGen/coverage_decls.swift
+++ b/test/SILGen/coverage_decls.swift
@@ -1,7 +1,25 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_decls -primary-file %s %S/Inputs/coverage_imports.swift | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_decls %s %S/Inputs/coverage_imports.swift | %FileCheck %s -check-prefix=ALL
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_decls -primary-file %s %S/Inputs/coverage_imports.swift | %FileCheck %s -check-prefix=PRIMARY
 
-// CHECK: sil_coverage_map {{.*}} $S14coverage_decls4mainyyF
-// CHECK-NOT: sil_coverage_map
+// ALL: sil_coverage_map {{.*}} // closure #1 () -> Swift.Int in coverage_decls.Box.x.getter : Swift.Int
+// ALL: sil_coverage_map {{.*}} // coverage_decls.Box.init(y: Swift.Int) -> coverage_decls.Box
+// ALL: sil_coverage_map {{.*}} // coverage_decls.Box.init(z: Swift.String) -> coverage_decls.Box
+// ALL: sil_coverage_map {{.*}} // coverage_decls.main() -> ()
+// ALL: sil_coverage_map {{.*}} // __ntd_Box
+
+// PRIMARY-NOT: sil_coverage_map
+// PRIMARY: sil_coverage_map {{.*}} // coverage_decls.Box.init(y: Swift.Int) -> coverage_decls.Box
+// PRIMARY: sil_coverage_map {{.*}} // coverage_decls.Box.init(z: Swift.String) -> coverage_decls.Box
+// PRIMARY: sil_coverage_map {{.*}} // coverage_decls.main() -> ()
+// PRIMARY-NOT: sil_coverage_map
+
+extension Box {
+  init(y: Int) { self.init() }
+}
+
+extension Box {
+  init(z: String) { self.init() }
+}
 
 func main() {
   var b = Box()


### PR DESCRIPTION
This patch removes the implicit assumption that nominal types live in
the same source file as their extensions.

It works by visiting extension initializers separately from the
initializers for the base nominal type.

rdar://39548257