### PR TITLE
[Coverage] Profile extensions separately from their base types

### DIFF
--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -96,9 +96,10 @@ public:
   /// The most recent conformance...
   NormalProtocolConformance *lastEmittedConformance = nullptr;
 
-  /// Profiler instances for constructors, grouped by associated nominal type.
+  /// Profiler instances for constructors, grouped by associated decl.
   /// Each profiler is shared by all member initializers for a nominal type.
-  llvm::DenseMap<NominalTypeDecl *, SILProfiler *> constructorProfilers;
+  /// Constructors within extensions are profiled separately.
+  llvm::DenseMap<Decl *, SILProfiler *> constructorProfilers;
 
   SILFunction *emitTopLevelFunction(SILLocation Loc);
 
@@ -440,9 +441,12 @@ public:
   /// Emit a property descriptor for the given storage decl if it needs one.
   void tryEmitPropertyDescriptor(AbstractStorageDecl *decl);
 
-  /// Get or create the profiler instance for a nominal type's constructors.
-  SILProfiler *getOrCreateProfilerForConstructors(NominalTypeDecl *decl);
-  
+  /// Get or create the shared profiler instance for a type's constructors.
+  /// This takes care to create separate profilers for extensions, which may
+  /// reside in a different file than the one where the base type is defined.
+  SILProfiler *getOrCreateProfilerForConstructors(DeclContext *ctx,
+                                                  ConstructorDecl *cd);
+
 private:
   /// Emit the deallocator for a class that uses the objc allocator.
   void emitObjCAllocatorDestructor(ClassDecl *cd, DestructorDecl *dd);

--- a/test/SILGen/coverage_decls.swift
+++ b/test/SILGen/coverage_decls.swift
@@ -1,7 +1,25 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_decls -primary-file %s %S/Inputs/coverage_imports.swift | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_decls %s %S/Inputs/coverage_imports.swift | %FileCheck %s -check-prefix=ALL
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_decls -primary-file %s %S/Inputs/coverage_imports.swift | %FileCheck %s -check-prefix=PRIMARY
 
-// CHECK: sil_coverage_map {{.*}} $S14coverage_decls4mainyyF
-// CHECK-NOT: sil_coverage_map
+// ALL: sil_coverage_map {{.*}} // closure #1 () -> Swift.Int in coverage_decls.Box.x.getter : Swift.Int
+// ALL: sil_coverage_map {{.*}} // coverage_decls.Box.init(y: Swift.Int) -> coverage_decls.Box
+// ALL: sil_coverage_map {{.*}} // coverage_decls.Box.init(z: Swift.String) -> coverage_decls.Box
+// ALL: sil_coverage_map {{.*}} // coverage_decls.main() -> ()
+// ALL: sil_coverage_map {{.*}} // __ntd_Box
+
+// PRIMARY-NOT: sil_coverage_map
+// PRIMARY: sil_coverage_map {{.*}} // coverage_decls.Box.init(y: Swift.Int) -> coverage_decls.Box
+// PRIMARY: sil_coverage_map {{.*}} // coverage_decls.Box.init(z: Swift.String) -> coverage_decls.Box
+// PRIMARY: sil_coverage_map {{.*}} // coverage_decls.main() -> ()
+// PRIMARY-NOT: sil_coverage_map
+
+extension Box {
+  init(y: Int) { self.init() }
+}
+
+extension Box {
+  init(z: String) { self.init() }
+}
 
 func main() {
   var b = Box()


### PR DESCRIPTION
This patch removes the implicit assumption that nominal types live in
the same source file as their extensions.

It works by visiting extension initializers separately from the
initializers for the base nominal type.

rdar://39548257
(cherry picked from commit e405fc28dfae8e20d3d83559c7f72e0fff000739)