### PR TITLE
swift-api-digester: add a new action to dump name correction template.

### DIFF
--- a/include/swift/IDE/APIDigesterData.h
+++ b/include/swift/IDE/APIDigesterData.h
@@ -334,6 +334,21 @@ struct OverloadedFuncInfo: public APIDiffItem {
   }
 };
 
+struct NameCorrectionInfo {
+  StringRef OriginalName;
+  StringRef CorrectedName;
+  StringRef ModuleName;
+  NameCorrectionInfo(StringRef OriginalName, StringRef CorrectedName,
+    StringRef ModuleName): OriginalName(OriginalName),
+    CorrectedName(CorrectedName), ModuleName(ModuleName) {}
+  bool operator<(NameCorrectionInfo Other) const {
+    if (ModuleName != Other.ModuleName)
+      return ModuleName.compare(Other.ModuleName) < 0;
+    else
+      return OriginalName.compare(Other.OriginalName) < 0;
+  }
+};
+
 /// APIDiffItem store is the interface that migrator should communicates with;
 /// Given a key, usually the usr of the system entity under migration, the store
 /// should return a slice of related changes in the same format of
@@ -343,6 +358,7 @@ struct APIDiffItemStore {
   struct Implementation;
   Implementation &Impl;
   static void serialize(llvm::raw_ostream &os, ArrayRef<APIDiffItem*> Items);
+  static void serialize(llvm::raw_ostream &os, ArrayRef<NameCorrectionInfo> Items);
   APIDiffItemStore(const APIDiffItemStore& that) = delete;
   APIDiffItemStore();
   ~APIDiffItemStore();

--- a/lib/IDE/APIDigesterData.cpp
+++ b/lib/IDE/APIDigesterData.cpp
@@ -444,11 +444,36 @@ struct ArrayTraits<ArrayRef<APIDiffItem*>> {
     return const_cast<APIDiffItem *&>(seq[index]);
   }
 };
+
+template<>
+struct ObjectTraits<NameCorrectionInfo> {
+  static void mapping(Output &out, NameCorrectionInfo &value) {
+    out.mapRequired(getKeyContent(DiffItemKeyKind::KK_OldPrintedName),value.OriginalName);
+    out.mapRequired(getKeyContent(DiffItemKeyKind::KK_NewPrintedName), value.CorrectedName);
+    out.mapRequired(getKeyContent(DiffItemKeyKind::KK_ModuleName), value.ModuleName);
+  }
+};
+template<>
+struct ArrayTraits<ArrayRef<NameCorrectionInfo>> {
+  static size_t size(Output &out, ArrayRef<NameCorrectionInfo> &seq) {
+    return seq.size();
+  }
+  static NameCorrectionInfo &element(Output &, ArrayRef<NameCorrectionInfo> &seq,
+                                     size_t index) {
+    return const_cast<NameCorrectionInfo&>(seq[index]);
+  }
+};
 } // namespace json
 } // namespace swift
 
 void swift::ide::api::APIDiffItemStore::
 serialize(llvm::raw_ostream &os, ArrayRef<APIDiffItem*> Items) {
+  json::Output yout(os);
+  yout << Items;
+}
+
+void swift::ide::api::APIDiffItemStore::
+serialize(llvm::raw_ostream &os, ArrayRef<NameCorrectionInfo> Items) {
   json::Output yout(os);
   yout << Items;
 }


### PR DESCRIPTION
Rename detection in the tool may not reflect overlay additions; thus we
mistakes a new name to be an underscored one. This new action searches
migration scripts for suspicious ones and generates a template for us to
specify the correct names.
