### PR TITLE
[Exclusivity] Enforce exclusive access for class offsets in KeyPaths

### DIFF
--- a/include/swift/Runtime/Exclusivity.h
+++ b/include/swift/Runtime/Exclusivity.h
@@ -58,6 +58,19 @@ void swift_endAccess(ValueBuffer *buffer);
 SWIFT_RUNTIME_EXPORT
 bool _swift_disableExclusivityChecking;
 
+#ifndef NDEBUG
+
+/// Dump all accesses currently tracked by the runtime.
+///
+/// This is a debug routine that is intended to be used from the debugger and is
+/// compiled out when asserts are disabled. The intention is that it allows one
+/// to dump the access state to easily see if/when exclusivity violations will
+/// happen. This eases debugging.
+SWIFT_RUNTIME_EXPORT
+void swift_dumpTrackedAccesses();
+
+#endif
+
 } // end namespace swift
 
 #endif

--- a/include/swift/Strings.h
+++ b/include/swift/Strings.h
@@ -13,6 +13,9 @@
 #ifndef SWIFT_STRINGS_H
 #define SWIFT_STRINGS_H
 
+#include "swift/Basic/LLVM.h"
+#include "llvm/ADT/StringRef.h"
+
 namespace swift {
 
 /// The extension for serialized modules.
@@ -89,6 +92,10 @@ constexpr static const char BUILTIN_TYPE_NAME_VEC[] = "Builtin.Vec";
 constexpr static const char BUILTIN_TYPE_NAME_SILTOKEN[] = "Builtin.SILToken";
 /// The name of the Builtin type for Word
 constexpr static const char BUILTIN_TYPE_NAME_WORD[] = "Builtin.Word";
+
+constexpr static StringLiteral OPTIMIZE_SIL_PRESERVE_EXCLUSIVITY =
+    "optimize.sil.preserve_exclusivity";
+
 } // end namespace swift
 
 #endif // SWIFT_STRINGS_H

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2317,7 +2317,8 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(SILFunction *f,
                                llvm::Attribute::NoInline);
     break;
   case AlwaysInline:
-    // We do not transfer AlwaysInline since we get weird test failures.
+    // FIXME: We do not currently transfer AlwaysInline since doing so results
+    // in test failures, which must be investigated first.
   case InlineDefault:
     break;
   }

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2310,11 +2310,18 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(SILFunction *f,
 
   LinkInfo link = LinkInfo::get(*this, entity, forDefinition);
 
-  if (f->getInlineStrategy() == NoInline) {
+  switch (f->getInlineStrategy()) {
+  case NoInline:
     attrs = attrs.addAttribute(signature.getType()->getContext(),
                                llvm::AttributeList::FunctionIndex,
                                llvm::Attribute::NoInline);
+    break;
+  case AlwaysInline:
+    // We do not transfer AlwaysInline since we get weird test failures.
+  case InlineDefault:
+    break;
   }
+
   if (isReadOnlyFunction(f)) {
     attrs = attrs.addAttribute(signature.getType()->getContext(),
                                llvm::AttributeList::FunctionIndex,

--- a/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
@@ -25,6 +25,7 @@
 #include "swift/Basic/Range.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/Strings.h"
 #include "llvm/Support/CommandLine.h"
 
 using namespace swift;
@@ -167,6 +168,12 @@ struct AccessMarkerEliminationPass : SILModuleTransform {
   void run() override {
     auto &M = *getModule();
     for (auto &F : M) {
+      if (F.hasSemanticsAttr(OPTIMIZE_SIL_PRESERVE_EXCLUSIVITY)) {
+        DEBUG(llvm::dbgs() << "Skipping " << F.getName() << ". Found "
+                           << OPTIMIZE_SIL_PRESERVE_EXCLUSIVITY << " tag!\n");
+        continue;
+      }
+
       bool removedAny = AccessMarkerElimination(&F).stripMarkers();
 
       // Only invalidate analyses if we removed some markers.

--- a/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
@@ -19,6 +19,12 @@
 /// test cases through the pipeline and exercising SIL verification before all
 /// passes support access markers.
 ///
+/// This must only run before inlining _semantic calls. If we inline and drop
+/// the @_semantics("optimize.sil.preserve_exclusivity") attribute, the inlined
+/// markers will be eliminated, but the noninlined markers will not. This would
+/// result in inconsistent begin/end_unpaired_access resulting in unpredictable,
+/// potentially catastrophic runtime behavior.
+///
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "access-marker-elim"

--- a/lib/SILOptimizer/Mandatory/IRGenPrepare.cpp
+++ b/lib/SILOptimizer/Mandatory/IRGenPrepare.cpp
@@ -72,14 +72,6 @@ class IRGenPrepare : public SILFunctionTransform {
   void run() override {
     SILFunction *F = getFunction();
 
-    if (F->hasSemanticsAttr(OPTIMIZE_SIL_PRESERVE_EXCLUSIVITY)) {
-      assert(F->getInlineStrategy() == NoInline &&
-             "All OPTIMIZE_SIL_PRESERVE_EXCLUSIVITY functions should have "
-             "no-inline");
-      // We always want to inline these at the llvm level.
-      F->setInlineStrategy(AlwaysInline);
-    }
-
     bool shouldInvalidate = cleanFunction(*F);
 
     if (shouldInvalidate)

--- a/lib/SILOptimizer/Mandatory/IRGenPrepare.cpp
+++ b/lib/SILOptimizer/Mandatory/IRGenPrepare.cpp
@@ -20,12 +20,14 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#include "swift/SILOptimizer/PassManager/Passes.h"
+#define DEBUG_TYPE "sil-cleanup"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILModule.h"
-#include "swift/SILOptimizer/Utils/Local.h"
+#include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/Local.h"
+#include "swift/Strings.h"
 
 using namespace swift;
 
@@ -68,10 +70,20 @@ namespace {
 
 class IRGenPrepare : public SILFunctionTransform {
   void run() override {
-    bool shouldInvalidate = cleanFunction(*getFunction());
-    if (!shouldInvalidate)
-      return;
-    invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
+    SILFunction *F = getFunction();
+
+    if (F->hasSemanticsAttr(OPTIMIZE_SIL_PRESERVE_EXCLUSIVITY)) {
+      assert(F->getInlineStrategy() == NoInline &&
+             "All OPTIMIZE_SIL_PRESERVE_EXCLUSIVITY functions should have "
+             "no-inline");
+      // We always want to inline these at the llvm level.
+      F->setInlineStrategy(AlwaysInline);
+    }
+
+    bool shouldInvalidate = cleanFunction(*F);
+
+    if (shouldInvalidate)
+      invalidateAnalysis(SILAnalysis::InvalidationKind::Instructions);
   }
 };
 

--- a/stdlib/public/runtime/Exclusivity.cpp
+++ b/stdlib/public/runtime/Exclusivity.cpp
@@ -260,6 +260,16 @@ public:
 
     swift_runtime_unreachable("access not found in set");
   }
+
+#ifndef NDEBUG
+  /// Only available with asserts. Intended to be used with
+  /// swift_dumpTrackedAccess().
+  void forEach(std::function<void (Access *)> action) {
+    for (auto *iter = Head; iter != nullptr; iter = iter->getNext()) {
+      action(iter);
+    }
+  }
+#endif
 };
 
 } // end anonymous namespace
@@ -348,3 +358,17 @@ void swift::swift_endAccess(ValueBuffer *buffer) {
 
   getAccessSet().remove(access);
 }
+
+#ifndef NDEBUG
+
+// Dump the accesses that are currently being tracked by the runtime.
+//
+// This is only intended to be used in the debugger.
+void swift::swift_dumpTrackedAccesses() {
+  getAccessSet().forEach([](Access *a) {
+      fprintf(stderr, "Access. Pointer: %p. PC: %p. AccessAction: %s",
+              a->Pointer, a->PC, getAccessName(a->getAccessAction()));
+  });
+}
+
+#endif

--- a/test/IRGen/preserve_exclusivity.swift
+++ b/test/IRGen/preserve_exclusivity.swift
@@ -1,0 +1,102 @@
+// RUN: %target-swift-frontend -parse-stdlib -parse-stdlib -emit-ir -Onone %s | %FileCheck --check-prefix=IR-Onone %s
+
+// We check separately that:
+//
+// 1. We properly emit our special functions as inline always.
+// 2. end-to-end we inline the access markers.
+
+// RUN: %target-swift-frontend -parse-stdlib -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xllvm -sil-disable-pass=GenericSpecializer -parse-stdlib -emit-ir -O -disable-llvm-optzns %s | %FileCheck --check-prefix=IR-Osil %s
+// RUN: %target-swift-frontend -parse-stdlib -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xllvm -sil-disable-pass=GenericSpecializer -parse-stdlib -emit-ir -O %s | %FileCheck --check-prefix=IR-Ollvm %s
+
+@_silgen_name("marker1")
+func marker1() -> ()
+
+@_silgen_name("marker2")
+func marker2() -> ()
+
+@_silgen_name("marker3")
+func marker3() -> ()
+
+@_silgen_name("marker4")
+func marker4() -> ()
+
+// IR-Onone: define swiftcc void @"$S20preserve_exclusivity10beginNoOptyyBp_BpxmtlF"(i8*, i8*, %swift.type*, %swift.type* %T1)
+// IR-Onone: call void @swift_beginAccess
+// IR-Onone-NEXT: ret void
+
+// IR-Osil: define swiftcc void @"$S20preserve_exclusivity10beginNoOptyyBp_BpxmtlF"(i8*, i8*, %swift.type*, %swift.type* %T1) [[ATTR:#[0-9][0-9]*]] {
+// IR-Osil:   call void @swift_beginAccess
+// IR-Osil-NEXT: ret void
+
+@inline(never)
+@_semantics("optimize.sil.preserve_exclusivity")
+public func beginNoOpt<T1>(_ address: Builtin.RawPointer, _ scratch: Builtin.RawPointer, _ ty1: T1.Type) {
+  marker1()
+  Builtin.beginUnpairedModifyAccess(address, scratch, ty1);
+}
+
+// IR-Onone: define swiftcc void @"$S20preserve_exclusivity8endNoOptyyBpF"(i8*)
+// IR-Onone: call void @swift_endAccess
+// IR-Onone-NEXT: ret void
+
+// IR-Osil: define swiftcc void @"$S20preserve_exclusivity8endNoOptyyBpF"(i8*) [[ATTR]]
+// IR-Osil:   call void @swift_endAccess
+// IR-Osil-NEXT: ret void
+@inline(never)
+@_semantics("optimize.sil.preserve_exclusivity")
+public func endNoOpt(_ address: Builtin.RawPointer) {
+  marker2()
+  Builtin.endUnpairedAccess(address)
+}
+
+class Klass {}
+
+// Make sure testNoOpt properly inlines in our functions.
+//
+// IR-Ollvm: define swiftcc void @"$S20preserve_exclusivity9testNoOptyyBpF"(i8*)
+// IR-Ollvm: call swiftcc void @marker1
+// IR-Ollvm: call void @swift_beginAccess
+// IR-Ollvm: call swiftcc void @marker2
+// IR-Ollvm: call void @swift_endAccess
+// IR-Ollvm-NEXT: ret void
+public func testNoOpt(_ k1: Builtin.RawPointer) {
+  beginNoOpt(k1, k1, Builtin.RawPointer.self)
+  endNoOpt(k1)
+}
+
+// IR-Onone: define swiftcc void @"$S20preserve_exclusivity8beginOptyyBp_BpxmtlF"(i8*, i8*, %swift.type*, %swift.type* %T1)
+// IR-Onone: call void @swift_beginAccess
+// IR-Onone-NEXT: ret void
+
+// IR-Osil: define swiftcc void @"$S20preserve_exclusivity8beginOptyyBp_BpxmtlF"(i8*, i8*, %swift.type*, %swift.type* %T1)
+// IR-Osil-NEXT: entry
+// IR-Osil-NEXT: call swiftcc void @marker3
+// IR-Osil-NEXT: ret void
+
+@inline(never)
+public func beginOpt<T1>(_ address: Builtin.RawPointer, _ scratch: Builtin.RawPointer, _ ty1: T1.Type) {
+  marker3()
+  Builtin.beginUnpairedModifyAccess(address, scratch, ty1);
+}
+
+// IR-Onone: define swiftcc void @"$S20preserve_exclusivity6endOptyyBpF"(i8*)
+// IR-Onone: call void @swift_endAccess
+// IR-Onone-NEXT: ret void
+
+// IR-Osil: define swiftcc void @"$S20preserve_exclusivity6endOptyyBpF"(i8*)
+// IR-Osil-NEXT: entry
+// IR-Osil-NEXT: call swiftcc void @marker4
+// IR-Osil-NEXT: ret void
+
+@inline(never)
+public func endOpt(_ address: Builtin.RawPointer) {
+  marker4()
+  Builtin.endUnpairedAccess(address)
+}
+
+public func testOpt(_ k1: Builtin.RawPointer) {
+  beginOpt(k1, k1, Builtin.RawPointer.self)
+  endOpt(k1)
+}
+
+// IR-Osil: attributes [[ATTR]] = { alwaysinline

--- a/test/IRGen/preserve_exclusivity.swift
+++ b/test/IRGen/preserve_exclusivity.swift
@@ -1,12 +1,10 @@
-// RUN: %target-swift-frontend -parse-stdlib -parse-stdlib -emit-ir -Onone %s | %FileCheck --check-prefix=IR-Onone %s
-
-// We check separately that:
+// RUN: %target-swift-frontend -parse-stdlib -emit-ir -Onone %s | %FileCheck --check-prefix=IR-Onone %s
 //
-// 1. We properly emit our special functions as inline always.
-// 2. end-to-end we inline the access markers.
+// Check that access markers in @_semantics("optimize.sil.preserve_exclusivity") functions generate runtime calls.
 
-// RUN: %target-swift-frontend -parse-stdlib -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xllvm -sil-disable-pass=GenericSpecializer -parse-stdlib -emit-ir -O -disable-llvm-optzns %s | %FileCheck --check-prefix=IR-Osil %s
-// RUN: %target-swift-frontend -parse-stdlib -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xllvm -sil-disable-pass=GenericSpecializer -parse-stdlib -emit-ir -O %s | %FileCheck --check-prefix=IR-Ollvm %s
+// RUN: %target-swift-frontend -parse-stdlib -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xllvm -sil-disable-pass=GenericSpecializer -emit-ir -O %s | %FileCheck --check-prefix=IR-O %s
+//
+// Check that the -O pipeline preserves the runtime calls for @_semantics("optimize.sil.preserve_exclusivity") functions.
 
 @_silgen_name("marker1")
 func marker1() -> ()
@@ -20,83 +18,119 @@ func marker3() -> ()
 @_silgen_name("marker4")
 func marker4() -> ()
 
-// IR-Onone: define swiftcc void @"$S20preserve_exclusivity10beginNoOptyyBp_BpxmtlF"(i8*, i8*, %swift.type*, %swift.type* %T1)
+@_silgen_name("marker5")
+func marker5() -> ()
+
+@_silgen_name("marker6")
+func marker6() -> ()
+
+// IR-Onone-LABEL: define {{.*}}swiftcc void @"$S20preserve_exclusivity10beginNoOptyyBp_BpxmtlF"(i8*, i8*, %swift.type*, %swift.type* %T1)
 // IR-Onone: call void @swift_beginAccess
 // IR-Onone-NEXT: ret void
 
-// IR-Osil: define swiftcc void @"$S20preserve_exclusivity10beginNoOptyyBp_BpxmtlF"(i8*, i8*, %swift.type*, %swift.type* %T1) [[ATTR:#[0-9][0-9]*]] {
-// IR-Osil:   call void @swift_beginAccess
-// IR-Osil-NEXT: ret void
+// IR-O-LABEL: define {{.*}}swiftcc void @"$S20preserve_exclusivity10beginNoOptyyBp_BpxmtlF"(i8*, i8*, %swift.type*{{.*}}, %swift.type*{{.*}} %T1)
+// IR-O:   call void @swift_beginAccess
+// IR-O-NEXT: ret void
 
-@inline(never)
 @_semantics("optimize.sil.preserve_exclusivity")
 public func beginNoOpt<T1>(_ address: Builtin.RawPointer, _ scratch: Builtin.RawPointer, _ ty1: T1.Type) {
   marker1()
   Builtin.beginUnpairedModifyAccess(address, scratch, ty1);
 }
 
-// IR-Onone: define swiftcc void @"$S20preserve_exclusivity8endNoOptyyBpF"(i8*)
+// IR-Onone-LABEL: define {{.*}}swiftcc void @"$S20preserve_exclusivity8endNoOptyyBpF"(i8*)
 // IR-Onone: call void @swift_endAccess
 // IR-Onone-NEXT: ret void
 
-// IR-Osil: define swiftcc void @"$S20preserve_exclusivity8endNoOptyyBpF"(i8*) [[ATTR]]
-// IR-Osil:   call void @swift_endAccess
-// IR-Osil-NEXT: ret void
-@inline(never)
+// IR-O-LABEL: define {{.*}}swiftcc void @"$S20preserve_exclusivity8endNoOptyyBpF"(i8*)
+// IR-O:   call void @swift_endAccess
+// IR-O-NEXT: ret void
 @_semantics("optimize.sil.preserve_exclusivity")
 public func endNoOpt(_ address: Builtin.RawPointer) {
   marker2()
   Builtin.endUnpairedAccess(address)
 }
 
-class Klass {}
+// IR-Onone-LABEL: define {{.*}}swiftcc void @"$S20preserve_exclusivity9readNoOptyyBp_xmtlF"(i8*, %swift.type*, %swift.type* %T1)
+// IR-Onone: call void @swift_beginAccess
+// IR-Onone: ret void
+
+// IR-O-LABEL: define {{.*}}swiftcc void @"$S20preserve_exclusivity9readNoOptyyBp_xmtlF"(i8*, %swift.type*{{.*}}, %swift.type*{{.*}} %T1)
+// IR-O:   call void @swift_beginAccess
+// IR-O: ret void
+@_semantics("optimize.sil.preserve_exclusivity")
+public func readNoOpt<T1>(_ address: Builtin.RawPointer, _ ty1: T1.Type) {
+  marker3()
+  Builtin.performInstantaneousReadAccess(address, ty1);
+}
 
 // Make sure testNoOpt properly inlines in our functions.
 //
-// IR-Ollvm: define swiftcc void @"$S20preserve_exclusivity9testNoOptyyBpF"(i8*)
-// IR-Ollvm: call swiftcc void @marker1
-// IR-Ollvm: call void @swift_beginAccess
-// IR-Ollvm: call swiftcc void @marker2
-// IR-Ollvm: call void @swift_endAccess
-// IR-Ollvm-NEXT: ret void
+// IR-O-LABEL: define {{.*}}swiftcc void @"$S20preserve_exclusivity9testNoOptyyBpF"(i8*)
+// IR-O: call swiftcc void @marker1
+// IR-O: call void @swift_beginAccess
+// IR-O: call swiftcc void @marker2
+// IR-O: call void @swift_endAccess
+// IR-O: call swiftcc void @marker3
+// IR-O: call void @swift_beginAccess
+// IR-O: ret void
 public func testNoOpt(_ k1: Builtin.RawPointer) {
   beginNoOpt(k1, k1, Builtin.RawPointer.self)
   endNoOpt(k1)
+  readNoOpt(k1, Builtin.RawPointer.self)
 }
 
-// IR-Onone: define swiftcc void @"$S20preserve_exclusivity8beginOptyyBp_BpxmtlF"(i8*, i8*, %swift.type*, %swift.type* %T1)
+// IR-Onone-LABEL: define {{.*}}swiftcc void @"$S20preserve_exclusivity8beginOptyyBp_BpxmtlF"(i8*, i8*, %swift.type*, %swift.type* %T1)
 // IR-Onone: call void @swift_beginAccess
 // IR-Onone-NEXT: ret void
 
-// IR-Osil: define swiftcc void @"$S20preserve_exclusivity8beginOptyyBp_BpxmtlF"(i8*, i8*, %swift.type*, %swift.type* %T1)
-// IR-Osil-NEXT: entry
-// IR-Osil-NEXT: call swiftcc void @marker3
-// IR-Osil-NEXT: ret void
+// IR-O-LABEL: define {{.*}}swiftcc void @"$S20preserve_exclusivity8beginOptyyBp_BpxmtlF"(i8*{{.*}}, i8*{{.*}}, %swift.type*{{.*}}, %swift.type*{{.*}} %T1)
+// IR-O-NEXT: entry
+// IR-O-NEXT: call swiftcc void @marker4
+// IR-O-NEXT: ret void
 
-@inline(never)
 public func beginOpt<T1>(_ address: Builtin.RawPointer, _ scratch: Builtin.RawPointer, _ ty1: T1.Type) {
-  marker3()
+  marker4()
   Builtin.beginUnpairedModifyAccess(address, scratch, ty1);
 }
 
-// IR-Onone: define swiftcc void @"$S20preserve_exclusivity6endOptyyBpF"(i8*)
+// IR-Onone-LABEL: define {{.*}}swiftcc void @"$S20preserve_exclusivity6endOptyyBpF"(i8*)
 // IR-Onone: call void @swift_endAccess
 // IR-Onone-NEXT: ret void
 
-// IR-Osil: define swiftcc void @"$S20preserve_exclusivity6endOptyyBpF"(i8*)
-// IR-Osil-NEXT: entry
-// IR-Osil-NEXT: call swiftcc void @marker4
-// IR-Osil-NEXT: ret void
+// IR-O-LABEL: define {{.*}}swiftcc void @"$S20preserve_exclusivity6endOptyyBpF"(i8*{{.*}})
+// IR-O-NEXT: entry
+// IR-O-NEXT: call swiftcc void @marker5
+// IR-O-NEXT: ret void
 
-@inline(never)
 public func endOpt(_ address: Builtin.RawPointer) {
-  marker4()
+  marker5()
   Builtin.endUnpairedAccess(address)
 }
 
+// IR-Onone-LABEL: define {{.*}}swiftcc void @"$S20preserve_exclusivity7readOptyyBp_xmtlF"(i8*, %swift.type*, %swift.type* %T1)
+// IR-Onone: call void @swift_beginAccess
+// IR-Onone: ret void
+
+// IR-O-LABEL: define {{.*}}swiftcc void @"$S20preserve_exclusivity7readOptyyBp_xmtlF"(i8*{{.*}}, %swift.type*{{.*}}, %swift.type*{{.*}} %T1)
+// IR-O-NEXT: entry
+// IR-O-NEXT: call swiftcc void @marker6
+// IR-O-NEXT: ret void
+
+public func readOpt<T1>(_ address: Builtin.RawPointer, _ ty1: T1.Type) {
+  marker6()
+  Builtin.performInstantaneousReadAccess(address, ty1);
+}
+
+// Make sure testOpt properly inlines in our functions.
+//
+// IR-O-LABEL: define {{.*}}swiftcc void @"$S20preserve_exclusivity7testOptyyBpF"(i8*{{.*}})
+// IR-O: call swiftcc void @marker4
+// IR-O: call swiftcc void @marker5
+// IR-O: call swiftcc void @marker6
+// IR-O: ret void
 public func testOpt(_ k1: Builtin.RawPointer) {
   beginOpt(k1, k1, Builtin.RawPointer.self)
   endOpt(k1)
+  readOpt(k1, Builtin.RawPointer.self)
 }
-
-// IR-Osil: attributes [[ATTR]] = { alwaysinline

--- a/test/Interpreter/enforce_exclusive_access.swift
+++ b/test/Interpreter/enforce_exclusive_access.swift
@@ -241,26 +241,95 @@ ExclusiveAccessTestSuite.test("InoutWriteEscapeWrite")
 }
 
 class ClassWithStoredProperty {
-  var f = 7
+  final var f = 7
 }
 
-// FIXME: This should trap with a modify/modify violation at run time.
-ExclusiveAccessTestSuite.test("KeyPathClassStoredProp")
+ExclusiveAccessTestSuite.test("KeyPathInoutDirectWriteClassStoredProp")
   .skip(.custom(
     { _isFastAssertConfiguration() },
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
-//  .crashOutputMatches("Previous access (a modification) started at")
-//  .crashOutputMatches("Current access (a modification) started at")
+  .crashOutputMatches("Previous access (a modification) started at")
+  .crashOutputMatches("Current access (a modification) started at")
   .code
 {
   let getF = \ClassWithStoredProperty.f
   let c = ClassWithStoredProperty()
 
-//  expectCrashLater()
+  expectCrashLater()
+  modifyAndPerform(&c[keyPath: getF]) {
+    c.f = 12
+  }
+}
+
+ExclusiveAccessTestSuite.test("KeyPathInoutDirectReadClassStoredProp")
+  .skip(.custom(
+    { _isFastAssertConfiguration() },
+    reason: "this trap is not guaranteed to happen in -Ounchecked"))
+  .crashOutputMatches("Previous access (a modification) started at")
+  .crashOutputMatches("Current access (a read) started at")
+  .code
+{
+  let getF = \ClassWithStoredProperty.f
+  let c = ClassWithStoredProperty()
+
+  expectCrashLater()
+  modifyAndPerform(&c[keyPath: getF]) {
+    let x = c.f
+    _blackHole(x)
+  }
+}
+
+// Unlike inout accesses, read-only inout-to-pointer conversions on key paths for
+// final stored-properties do not perform a long-term read access. Instead, they
+// materialize a location on the stack, perform an instantaneous read
+// from the storage indicated by the key path and write the read value to the
+// stack location. The stack location is then passed as the pointer for the
+// inout-to-pointer conversion.
+//
+// This means that there is no conflict between a read-only inout-to-pointer
+// conversion of the key path location for a call and an access to the
+// the same location within the call.
+ExclusiveAccessTestSuite.test("KeyPathReadOnlyInoutToPtrDirectWriteClassStoredProp") {
+  let getF = \ClassWithStoredProperty.f
+  let c = ClassWithStoredProperty()
+
+  // This performs an instantaneous read
+  readAndPerform(&c[keyPath: getF]) {
+    c.f = 12 // no-trap
+  }
+}
+
+ExclusiveAccessTestSuite.test("SequentialKeyPathWritesDontOverlap") {
+  let getF = \ClassWithStoredProperty.f
+  let c = ClassWithStoredProperty()
+
+  c[keyPath: getF] = 7
+  c[keyPath: getF] = 8 // no-trap
+  c[keyPath: getF] += c[keyPath: getF] + 1 // no-trap
+}
+
+// This does not trap, for now, because the standard library (and thus KeyPath) is
+// compiled in Swift 3 mode and we currently log rather than trap in Swift mode.
+ExclusiveAccessTestSuite.test("KeyPathInoutKeyPathWriteClassStoredProp")
+{
+  let getF = \ClassWithStoredProperty.f
+  let c = ClassWithStoredProperty()
+
   modifyAndPerform(&c[keyPath: getF]) {
     c[keyPath: getF] = 12
   }
 }
 
+// This does not currently trap because the standard library is compiled in Swift 3 mode,
+// which logs.
+ExclusiveAccessTestSuite.test("KeyPathInoutKeyPathReadClassStoredProp") {
+  let getF = \ClassWithStoredProperty.f
+  let c = ClassWithStoredProperty()
+
+  modifyAndPerform(&c[keyPath: getF]) {
+    let y = c[keyPath: getF]
+    _blackHole(y)
+  }
+}
 
 runAllTests()

--- a/test/Interpreter/enforce_exclusive_access_backtrace.swift
+++ b/test/Interpreter/enforce_exclusive_access_backtrace.swift
@@ -17,16 +17,61 @@ func readAndPerform<T>(_ _: UnsafePointer<T>, closure: () ->()) {
   closure()
 }
 
+func writeAndPerform<T>(_ _: UnsafeMutablePointer<T>, closure: () ->()) {
+  closure()
+}
+
 var globalX = X()
 withUnsafePointer(to: &globalX) { _ = fputs(String(format: "globalX: 0x%lx\n", Int(bitPattern: $0)), stderr) }
 // CHECK: globalX: [[ADDR:0x.*]]
 
+fputs("Global Access\n", stderr);
 readAndPerform(&globalX) {
   globalX = X()
+  // CHECK-LABEL: Global Access
   // CHECK: Simultaneous accesses to [[ADDR]], but modification requires exclusive access.
   // CHECK: Previous access (a read) started at a.out`main + {{.*}} (0x{{.*}}).
   // CHECK: Current access (a modification) started at:
   // CHECK: a.out {{.*}} closure
   // CHECK: a.out {{.*}} readAndPerform
+  // CHECK: a.out {{.*}} main
+}
+
+class C {
+  final var f = 7
+}
+
+var c = C()
+withUnsafePointer(to: &c.f) { _ = fputs(String(format: "c.f: 0x%lx\n", Int(bitPattern: $0)), stderr) }
+// CHECK: c.f: [[C_F_ADDR:0x.*]]
+
+// Key path accesses are performed in the Standard Library. The Standard Library
+// is currently compiled in Swift 3 mode and the compiler currently logs conflicts
+// (rather than trapping on them) code compiled in Swift 3 mode. For this reason
+// conflicts where the second conflicting access is via a key path will log rather than
+// trap.
+
+fputs("Overlapping Key Path Write Accesses\n", stderr);
+writeAndPerform(&c[keyPath: \C.f]) {
+  c[keyPath: \C.f] = 8
+  // CHECK-LABEL: Overlapping Key Path Write Accesses
+  // CHECK: Simultaneous accesses to [[C_F_ADDR]], but modification requires exclusive access.
+  // CHECK: Previous access (a modification)
+  // CHECK: Current access (a modification)
+  // CHECK: a.out {{.*}} closure
+  // CHECK: a.out {{.*}} writeAndPerform
+  // CHECK: a.out {{.*}} main
+}
+
+fputs("Overlapping Key Path Write Access and Key Path Read Access\n", stderr);
+writeAndPerform(&c[keyPath: \C.f]) {
+  let x = c[keyPath: \C.f]
+  _blackHole(x)
+  // CHECK-LABEL: Overlapping Key Path Write Access and Key Path Read Access
+  // CHECK: Simultaneous accesses to [[C_F_ADDR]], but modification requires exclusive access.
+  // CHECK: Previous access (a modification)
+  // CHECK: Current access (a read)
+  // CHECK: a.out {{.*}} closure
+  // CHECK: a.out {{.*}} writeAndPerform
   // CHECK: a.out {{.*}} main
 }

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -370,31 +370,26 @@ func getTailAddr<T1, T2>(start: Builtin.RawPointer, i: Builtin.Word, ty1: T1.Typ
 }
 
 // CHECK-LABEL: sil hidden @$S8builtins25beginUnpairedModifyAccess{{[_0-9a-zA-Z]*}}F
-// CHECK: [[P2A_ADDR:%.*]] = pointer_to_address %0
-// CHECK: [[P2A_SCRATCH:%.*]] = pointer_to_address %1
-// CHECK: begin_unpaired_access [modify] [dynamic] [[P2A_ADDR]] : $*T1, [[P2A_SCRATCH]] : $*Builtin.UnsafeValueBuffer
-// CHECK: [[RESULT:%.*]] = tuple ()
-// CHECK: [[RETURN:%.*]] = tuple ()
-// CHECK: return [[RETURN]] : $()
-// CHECK: } // end sil function '$S8builtins25beginUnpairedModifyAccess{{[_0-9a-zA-Z]*}}F'
 func beginUnpairedModifyAccess<T1>(address: Builtin.RawPointer, scratch: Builtin.RawPointer, ty1: T1.Type) {
+  // CHECK: [[P2A_ADDR:%.*]] = pointer_to_address %0
+  // CHECK: [[P2A_SCRATCH:%.*]] = pointer_to_address %1
+  // CHECK: begin_unpaired_access [modify] [dynamic] [[P2A_ADDR]] : $*T1, [[P2A_SCRATCH]] : $*Builtin.UnsafeValueBuffer
+  // CHECK: [[RESULT:%.*]] = tuple ()
+  // CHECK: [[RETURN:%.*]] = tuple ()
+  // CHECK: return [[RETURN]] : $()
+
   Builtin.beginUnpairedModifyAccess(address, scratch, ty1);
 }
 
-// CHECK-LABEL: sil hidden @$S8builtins17endUnpairedAccess{{[_0-9a-zA-Z]*}}F : $@convention(thin) (Builtin.RawPointer) -> () {
-// CHECK: [[P2A_ADDR:%.*]] = pointer_to_address %0
-// CHECK: end_unpaired_access [dynamic] [[P2A_ADDR]]
-// CHECK: } // end sil function '$S8builtins17endUnpairedAccess{{[_0-9a-zA-Z]*}}F'
-func endUnpairedAccess(address: Builtin.RawPointer) {
-  Builtin.endUnpairedAccess(address)
-}
-
 // CHECK-LABEL: sil hidden @$S8builtins30performInstantaneousReadAccess{{[_0-9a-zA-Z]*}}F
-// CHECK: [[P2A_ADDR:%.*]] = pointer_to_address %0
-// CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[P2A_ADDR]] : $*T1
-// CHECK-NEXT: end_access [[ACCESS]] : $*T1
-// CHECK: } // end sil function '$S8builtins30performInstantaneousReadAccess{{[_0-9a-zA-Z]*}}F'
 func performInstantaneousReadAccess<T1>(address: Builtin.RawPointer, scratch: Builtin.RawPointer, ty1: T1.Type) {
+  // CHECK: [[P2A_ADDR:%.*]] = pointer_to_address %0
+  // CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[P2A_ADDR]] : $*T1
+  // CHECK-NEXT: end_access [[ACCESS]] : $*T1
+  // CHECK: [[RESULT:%.*]] = tuple ()
+  // CHECK: [[RETURN:%.*]] = tuple ()
+  // CHECK: return [[RETURN]] : $()
+
   Builtin.performInstantaneousReadAccess(address, ty1);
 }
 

--- a/test/SILGen/builtins.swift
+++ b/test/SILGen/builtins.swift
@@ -384,8 +384,9 @@ func beginUnpairedModifyAccess<T1>(address: Builtin.RawPointer, scratch: Builtin
 // CHECK-LABEL: sil hidden @$S8builtins30performInstantaneousReadAccess{{[_0-9a-zA-Z]*}}F
 func performInstantaneousReadAccess<T1>(address: Builtin.RawPointer, scratch: Builtin.RawPointer, ty1: T1.Type) {
   // CHECK: [[P2A_ADDR:%.*]] = pointer_to_address %0
-  // CHECK: [[ACCESS:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[P2A_ADDR]] : $*T1
-  // CHECK-NEXT: end_access [[ACCESS]] : $*T1
+  // CHECK: [[SCRATCH:%.*]] = alloc_stack $Builtin.UnsafeValueBuffer
+  // CHECK: begin_unpaired_access [read] [dynamic] [no_nested_conflict] [[P2A_ADDR]] : $*T1, [[SCRATCH]] : $*Builtin.UnsafeValueBuffer
+  // CHECK-NOT: end_{{.*}}access
   // CHECK: [[RESULT:%.*]] = tuple ()
   // CHECK: [[RETURN:%.*]] = tuple ()
   // CHECK: return [[RETURN]] : $()

--- a/test/SILGen/preserve_exclusivity.swift
+++ b/test/SILGen/preserve_exclusivity.swift
@@ -1,0 +1,84 @@
+// RUN: %target-swift-frontend -parse-stdlib -parse-stdlib -emit-silgen %s | %FileCheck --check-prefix=SILGEN %s
+// RUN: %target-swift-frontend -parse-stdlib -parse-stdlib -emit-sil -Onone %s | %FileCheck --check-prefix=CANONICAL %s
+
+@_silgen_name("marker1")
+func marker1() -> ()
+
+@_silgen_name("marker2")
+func marker2() -> ()
+
+@_silgen_name("marker3")
+func marker3() -> ()
+
+@_silgen_name("marker4")
+func marker4() -> ()
+
+// SILGEN: sil [noinline] [_semantics "optimize.sil.preserve_exclusivity"] @$S20preserve_exclusivity10beginNoOptyyBp_BpxmtlF : $@convention(thin) <T1> (Builtin.RawPointer, Builtin.RawPointer, @thick T1.Type) -> () {
+// SILGEN:   begin_unpaired_access
+// SILGEN: } // end sil function '$S20preserve_exclusivity10beginNoOptyyBp_BpxmtlF
+
+// CANONICAL: sil [noinline] [_semantics "optimize.sil.preserve_exclusivity"] @$S20preserve_exclusivity10beginNoOptyyBp_BpxmtlF : $@convention(thin) <T1> (Builtin.RawPointer, Builtin.RawPointer, @thick T1.Type) -> () {
+// CANONICAL:   begin_unpaired_access
+// CANONICAL: } // end sil function '$S20preserve_exclusivity10beginNoOptyyBp_BpxmtlF
+
+@inline(never)
+@_semantics("optimize.sil.preserve_exclusivity")
+public func beginNoOpt<T1>(_ address: Builtin.RawPointer, _ scratch: Builtin.RawPointer, _ ty1: T1.Type) {
+  marker1()
+  Builtin.beginUnpairedModifyAccess(address, scratch, ty1);
+}
+
+// SILGEN: sil [noinline] [_semantics "optimize.sil.preserve_exclusivity"] @$S20preserve_exclusivity8endNoOptyyBpF : $@convention(thin) (Builtin.RawPointer) -> () {
+// SILGEN:   end_unpaired_access
+// SILGEN: } // end sil function '$S20preserve_exclusivity8endNoOptyyBpF'
+
+// CANONICAL: sil [noinline] [_semantics "optimize.sil.preserve_exclusivity"] @$S20preserve_exclusivity8endNoOptyyBpF : $@convention(thin) (Builtin.RawPointer) -> () {
+// CANONICAL:   end_unpaired_access
+// CANONICAL: } // end sil function '$S20preserve_exclusivity8endNoOptyyBpF'
+
+@inline(never)
+@_semantics("optimize.sil.preserve_exclusivity")
+public func endNoOpt(_ address: Builtin.RawPointer) {
+  marker2()
+  Builtin.endUnpairedAccess(address)
+}
+
+class Klass {}
+
+public func testNoOpt(_ k1: Builtin.RawPointer) {
+  beginNoOpt(k1, k1, Builtin.RawPointer.self)
+  endNoOpt(k1)
+}
+
+// SILGEN: sil [noinline] @$S20preserve_exclusivity8beginOptyyBp_BpxmtlF : $@convention(thin) <T1> (Builtin.RawPointer, Builtin.RawPointer, @thick T1.Type) -> () {
+// SILGEN: begin_unpaired_access
+// SILGEN: } // end sil function '$S20preserve_exclusivity8beginOptyyBp_BpxmtlF'
+
+// CANONICAL: sil [noinline] @$S20preserve_exclusivity8beginOptyyBp_BpxmtlF : $@convention(thin) <T1> (Builtin.RawPointer, Builtin.RawPointer, @thick T1.Type) -> () {
+// CANONICAL: begin_unpaired_access
+// CANONICAL: } // end sil function '$S20preserve_exclusivity8beginOptyyBp_BpxmtlF'
+
+@inline(never)
+public func beginOpt<T1>(_ address: Builtin.RawPointer, _ scratch: Builtin.RawPointer, _ ty1: T1.Type) {
+  marker3()
+  Builtin.beginUnpairedModifyAccess(address, scratch, ty1);
+}
+
+// SILGEN: sil [noinline] @$S20preserve_exclusivity6endOptyyBpF : $@convention(thin) (Builtin.RawPointer) -> () {
+// SILGEN: end_unpaired_access
+// SILGEN: } // end sil function '$S20preserve_exclusivity6endOptyyBpF'
+
+// CANONICAL: sil [noinline] @$S20preserve_exclusivity6endOptyyBpF : $@convention(thin) (Builtin.RawPointer) -> () {
+// CANONICAL: end_unpaired_access
+// CANONICAL: } // end sil function '$S20preserve_exclusivity6endOptyyBpF'
+
+@inline(never)
+public func endOpt(_ address: Builtin.RawPointer) {
+  marker4()
+  Builtin.endUnpairedAccess(address)
+}
+
+public func testOpt(_ k1: Builtin.RawPointer) {
+  beginOpt(k1, k1, Builtin.RawPointer.self)
+  endOpt(k1)
+}

--- a/test/SILOptimizer/preserve_exclusivity.swift
+++ b/test/SILOptimizer/preserve_exclusivity.swift
@@ -1,67 +1,150 @@
-// RUN: %target-swift-frontend -parse-stdlib -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xllvm -sil-disable-pass=GenericSpecializer -parse-stdlib -emit-sil -O %s | %FileCheck %s
+// RUN: %target-swift-frontend -parse-stdlib -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xllvm -sil-disable-pass=GenericSpecializer -emit-sil -O %s | %FileCheck %s
+//
+// The -O pipeline should respect
+// @_semantics("optimize.sil.preserve_exclusivity") and avoid eliminating access
+// markers as long as the semantics call is not inlined.
 
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -parse-stdlib -emit-module -O -primary-file %s -emit-module-path %t/preserve_exclusivity.swiftmodule
+// RUN: %target-sil-opt %t/preserve_exclusivity.swiftmodule -emit-sorted-sil -verify -o - | %FileCheck --check-prefix=DESERIALIZED %s
+//
+// Access markers cannot be stripped prior to module serialization, even when their functions are inlined.
+
+@usableFromInline
 @_silgen_name("marker1")
 func marker1() -> ()
 
+@usableFromInline
 @_silgen_name("marker2")
 func marker2() -> ()
 
+@usableFromInline
 @_silgen_name("marker3")
 func marker3() -> ()
 
+@usableFromInline
 @_silgen_name("marker4")
 func marker4() -> ()
 
-// CHECK: sil [noinline] [_semantics "optimize.sil.preserve_exclusivity"] @$S20preserve_exclusivity10beginNoOptyyBp_BpxmtlF : $@convention(thin) <T1> (Builtin.RawPointer, Builtin.RawPointer, @thick T1.Type) -> () {
-// CHECK:   begin_unpaired_access
-// CHECK: } // end sil function '$S20preserve_exclusivity10beginNoOptyyBp_BpxmtlF'
+@usableFromInline
+@_silgen_name("marker5")
+func marker5() -> ()
 
-@inline(never)
+@usableFromInline
+@_silgen_name("marker6")
+func marker6() -> ()
+
+// CHECK-LABEL: sil [_semantics "optimize.sil.preserve_exclusivity"] @$S20preserve_exclusivity13f1_beginNoOptyyBp_BpxmtlF : $@convention(thin) <T1> (Builtin.RawPointer, Builtin.RawPointer, @thick T1.Type) -> () {
+// CHECK:   begin_unpaired_access
+// CHECK: } // end sil function '$S20preserve_exclusivity13f1_beginNoOptyyBp_BpxmtlF'
+
+// DESERIALIZED-LABEL: sil [serialized] [_semantics "optimize.sil.preserve_exclusivity"] [canonical] @$S20preserve_exclusivity13f1_beginNoOptyyBp_BpxmtlF : $@convention(thin) <T1> (Builtin.RawPointer, Builtin.RawPointer, @thick T1.Type) -> () {
+// DESERIALIZED:   begin_unpaired_access
+// DESERIALIZED: } // end sil function '$S20preserve_exclusivity13f1_beginNoOptyyBp_BpxmtlF'
+
+@inlinable
 @_semantics("optimize.sil.preserve_exclusivity")
-public func beginNoOpt<T1>(_ address: Builtin.RawPointer, _ scratch: Builtin.RawPointer, _ ty1: T1.Type) {
+public func f1_beginNoOpt<T1>(_ address: Builtin.RawPointer, _ scratch: Builtin.RawPointer, _ ty1: T1.Type) {
   marker1()
   Builtin.beginUnpairedModifyAccess(address, scratch, ty1);
 }
 
-// CHECK: sil [noinline] [_semantics "optimize.sil.preserve_exclusivity"] @$S20preserve_exclusivity8endNoOptyyBpF : $@convention(thin) (Builtin.RawPointer) -> () {
+// CHECK-LABEL: sil [_semantics "optimize.sil.preserve_exclusivity"] @$S20preserve_exclusivity13f2___endNoOptyyBpF : $@convention(thin) (Builtin.RawPointer) -> () {
 // CHECK:   end_unpaired_access
-// CHECK: } // end sil function '$S20preserve_exclusivity8endNoOptyyBpF'
+// CHECK: } // end sil function '$S20preserve_exclusivity13f2___endNoOptyyBpF'
 
-@inline(never)
+// DESERIALIZED-LABEL: sil [serialized] [_semantics "optimize.sil.preserve_exclusivity"] [canonical] @$S20preserve_exclusivity13f2___endNoOptyyBpF : $@convention(thin) (Builtin.RawPointer) -> () {
+// DESERIALIZED:   end_unpaired_access
+// DESERIALIZED: } // end sil function '$S20preserve_exclusivity13f2___endNoOptyyBpF'
+
+@inlinable
 @_semantics("optimize.sil.preserve_exclusivity")
-public func endNoOpt(_ address: Builtin.RawPointer) {
+public func f2___endNoOpt(_ address: Builtin.RawPointer) {
   marker2()
   Builtin.endUnpairedAccess(address)
 }
 
-class Klass {}
+// CHECK-LABEL: sil [_semantics "optimize.sil.preserve_exclusivity"] @$S20preserve_exclusivity13f3__readNoOptyyBp_BpmtF : $@convention(thin) (Builtin.RawPointer, @thin Builtin.RawPointer.Type) -> () {
+// CHECK:   begin_unpaired_access
+// CHECK: } // end sil function '$S20preserve_exclusivity13f3__readNoOptyyBp_BpmtF
 
-public func testNoOpt(_ k1: Builtin.RawPointer) {
-  beginNoOpt(k1, k1, Builtin.RawPointer.self)
-  endNoOpt(k1)
+// DESERIALIZED-LABEL: sil [serialized] [_semantics "optimize.sil.preserve_exclusivity"] [canonical] @$S20preserve_exclusivity13f3__readNoOptyyBp_BpmtF : $@convention(thin) (Builtin.RawPointer, @thin Builtin.RawPointer.Type) -> () {
+// DESERIALIZED:   begin_unpaired_access
+// DESERIALIZED: } // end sil function '$S20preserve_exclusivity13f3__readNoOptyyBp_BpmtF
+
+@inlinable
+@_semantics("optimize.sil.preserve_exclusivity")
+public func f3__readNoOpt(_ address: Builtin.RawPointer, _ ty1: Builtin.RawPointer.Type) {
+  marker3()
+  Builtin.performInstantaneousReadAccess(address, ty1);
 }
 
-// CHECK: sil [noinline] @$S20preserve_exclusivity8beginOptyyBp_BpxmtlF : $@convention(thin) <T1> (Builtin.RawPointer, Builtin.RawPointer, @thick T1.Type) -> () {
-// CHECK-NOT: begin_unpaired_access
-// CHECK: } // end sil function '$S20preserve_exclusivity8beginOptyyBp_BpxmtlF'
+// DESERIALIZED-LABEL: sil [serialized] [canonical] @$S20preserve_exclusivity13f4__testNoOptyyBpF : $@convention(thin) (Builtin.RawPointer) -> () {
+// DESERIALIZED: marker1
+// DESERIALIZED: begin_unpaired_access
+// DESERIALIZED: marker2
+// DESERIALIZED: end_unpaired_access
+// DESERIALIZED: marker3
+// DESERIALIZED: begin_unpaired_access
+// DESERIALIZED: return
 
-@inline(never)
-public func beginOpt<T1>(_ address: Builtin.RawPointer, _ scratch: Builtin.RawPointer, _ ty1: T1.Type) {
-  marker3()
+@inlinable
+public func f4__testNoOpt(_ k1: Builtin.RawPointer) {
+  f1_beginNoOpt(k1, k1, Builtin.RawPointer.self)
+  f2___endNoOpt(k1)
+  f3__readNoOpt(k1, Builtin.RawPointer.self)
+}
+
+// CHECK-LABEL: sil @$S20preserve_exclusivity13f5_beginDoOptyyBp_BpxmtlF : $@convention(thin) <T1> (Builtin.RawPointer, Builtin.RawPointer, @thick T1.Type) -> () {
+// CHECK-NOT: begin_unpaired_access
+// CHECK: } // end sil function '$S20preserve_exclusivity13f5_beginDoOptyyBp_BpxmtlF'
+
+// DESERIALIZED-LABEL: sil [serialized] [canonical] @$S20preserve_exclusivity13f5_beginDoOptyyBp_BpxmtlF : $@convention(thin) <T1> (Builtin.RawPointer, Builtin.RawPointer, @thick T1.Type) -> () {
+// DESERIALIZED-NOT: begin_unpaired_access
+// DESERIALIZED: } // end sil function '$S20preserve_exclusivity13f5_beginDoOptyyBp_BpxmtlF'
+
+@inlinable
+public func f5_beginDoOpt<T1>(_ address: Builtin.RawPointer, _ scratch: Builtin.RawPointer, _ ty1: T1.Type) {
+  marker4()
   Builtin.beginUnpairedModifyAccess(address, scratch, ty1);
 }
 
-// CHECK: sil [noinline] @$S20preserve_exclusivity6endOptyyBpF : $@convention(thin) (Builtin.RawPointer) -> () {
+// CHECK-LABEL: sil @$S20preserve_exclusivity13f6___endDoOptyyBpF : $@convention(thin) (Builtin.RawPointer) -> () {
 // CHECK-NOT: end_unpaired_access
-// CHECK: } // end sil function '$S20preserve_exclusivity6endOptyyBpF'
+// CHECK: } // end sil function '$S20preserve_exclusivity13f6___endDoOptyyBpF'
 
-@inline(never)
-public func endOpt(_ address: Builtin.RawPointer) {
-  marker4()
+// DESERIALIZED-LABEL: sil [serialized] [canonical] @$S20preserve_exclusivity13f6___endDoOptyyBpF : $@convention(thin) (Builtin.RawPointer) -> () {
+// DESERIALIZED-NOT: end_unpaired_access
+// DESERIALIZED: } // end sil function '$S20preserve_exclusivity13f6___endDoOptyyBpF'
+
+@inlinable
+public func f6___endDoOpt(_ address: Builtin.RawPointer) {
+  marker5()
   Builtin.endUnpairedAccess(address)
 }
 
-public func testOpt(_ k1: Builtin.RawPointer) {
-  beginOpt(k1, k1, Builtin.RawPointer.self)
-  endOpt(k1)
+// CHECK-LABEL: sil @$S20preserve_exclusivity13f7__readDoOptyyBp_BpmtF : $@convention(thin) (Builtin.RawPointer, @thin Builtin.RawPointer.Type) -> () {
+// CHECK-NOT: begin_unpaired_access
+// CHECK: } // end sil function '$S20preserve_exclusivity13f7__readDoOptyyBp_BpmtF'
+
+// DESERIALIZED-LABEL: sil [serialized] [canonical] @$S20preserve_exclusivity13f7__readDoOptyyBp_BpmtF : $@convention(thin) (Builtin.RawPointer, @thin Builtin.RawPointer.Type) -> () {
+// DESERIALIZED-NOT: begin_unpaired_access
+// DESERIALIZED: } // end sil function '$S20preserve_exclusivity13f7__readDoOptyyBp_BpmtF'
+
+@inlinable
+public func f7__readDoOpt(_ address: Builtin.RawPointer, _ ty1: Builtin.RawPointer.Type) {
+  marker6()
+  Builtin.performInstantaneousReadAccess(address, ty1);
+}
+
+// DESERIALIZED-LABEL: sil [serialized] [canonical] @$S20preserve_exclusivity13f8__testDoOptyyBpF : $@convention(thin) (Builtin.RawPointer) -> () {
+// DESERIALIZED: marker4
+// DESERIALIZED: marker5
+// DESERIALIZED: marker6
+// DESERIALIZED: return
+@inlinable
+public func f8__testDoOpt(_ k1: Builtin.RawPointer) {
+  f5_beginDoOpt(k1, k1, Builtin.RawPointer.self)
+  f6___endDoOpt(k1)
+  f7__readDoOpt(k1, Builtin.RawPointer.self)
 }

--- a/test/SILOptimizer/preserve_exclusivity.swift
+++ b/test/SILOptimizer/preserve_exclusivity.swift
@@ -1,0 +1,67 @@
+// RUN: %target-swift-frontend -parse-stdlib -Xllvm -sil-disable-pass=FunctionSignatureOpts -Xllvm -sil-disable-pass=GenericSpecializer -parse-stdlib -emit-sil -O %s | %FileCheck %s
+
+@_silgen_name("marker1")
+func marker1() -> ()
+
+@_silgen_name("marker2")
+func marker2() -> ()
+
+@_silgen_name("marker3")
+func marker3() -> ()
+
+@_silgen_name("marker4")
+func marker4() -> ()
+
+// CHECK: sil [noinline] [_semantics "optimize.sil.preserve_exclusivity"] @$S20preserve_exclusivity10beginNoOptyyBp_BpxmtlF : $@convention(thin) <T1> (Builtin.RawPointer, Builtin.RawPointer, @thick T1.Type) -> () {
+// CHECK:   begin_unpaired_access
+// CHECK: } // end sil function '$S20preserve_exclusivity10beginNoOptyyBp_BpxmtlF'
+
+@inline(never)
+@_semantics("optimize.sil.preserve_exclusivity")
+public func beginNoOpt<T1>(_ address: Builtin.RawPointer, _ scratch: Builtin.RawPointer, _ ty1: T1.Type) {
+  marker1()
+  Builtin.beginUnpairedModifyAccess(address, scratch, ty1);
+}
+
+// CHECK: sil [noinline] [_semantics "optimize.sil.preserve_exclusivity"] @$S20preserve_exclusivity8endNoOptyyBpF : $@convention(thin) (Builtin.RawPointer) -> () {
+// CHECK:   end_unpaired_access
+// CHECK: } // end sil function '$S20preserve_exclusivity8endNoOptyyBpF'
+
+@inline(never)
+@_semantics("optimize.sil.preserve_exclusivity")
+public func endNoOpt(_ address: Builtin.RawPointer) {
+  marker2()
+  Builtin.endUnpairedAccess(address)
+}
+
+class Klass {}
+
+public func testNoOpt(_ k1: Builtin.RawPointer) {
+  beginNoOpt(k1, k1, Builtin.RawPointer.self)
+  endNoOpt(k1)
+}
+
+// CHECK: sil [noinline] @$S20preserve_exclusivity8beginOptyyBp_BpxmtlF : $@convention(thin) <T1> (Builtin.RawPointer, Builtin.RawPointer, @thick T1.Type) -> () {
+// CHECK-NOT: begin_unpaired_access
+// CHECK: } // end sil function '$S20preserve_exclusivity8beginOptyyBp_BpxmtlF'
+
+@inline(never)
+public func beginOpt<T1>(_ address: Builtin.RawPointer, _ scratch: Builtin.RawPointer, _ ty1: T1.Type) {
+  marker3()
+  Builtin.beginUnpairedModifyAccess(address, scratch, ty1);
+}
+
+// CHECK: sil [noinline] @$S20preserve_exclusivity6endOptyyBpF : $@convention(thin) (Builtin.RawPointer) -> () {
+// CHECK-NOT: end_unpaired_access
+// CHECK: } // end sil function '$S20preserve_exclusivity6endOptyyBpF'
+
+@inline(never)
+public func endOpt(_ address: Builtin.RawPointer) {
+  marker4()
+  Builtin.endUnpairedAccess(address)
+}
+
+public func testOpt(_ k1: Builtin.RawPointer) {
+  beginOpt(k1, k1, Builtin.RawPointer.self)
+  endOpt(k1)
+}


### PR DESCRIPTION
Add dynamic enforcement of exclusive access when a KeyPath directly accesses a final
stored property on an instance of a class. For read-only projections, this begins and ends
the access immediately. For mutable projections, this uses the ClassHolder to perform
a long-term access that lasts as long as the lifetime of the ClassHolder.

rdar://problem/31972680

Follow up on: @devincoughlin https://github.com/apple/swift/pull/15502
and: @gottesmm https://github.com/apple/swift/pull/16016