### PR TITLE
[AST] Initialize Target of break/continue with nullptr

### DIFF
--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -1023,7 +1023,7 @@ class BreakStmt : public Stmt {
   SourceLoc Loc;
   Identifier TargetName; // Named target statement, if specified in the source.
   SourceLoc TargetLoc;
-  LabeledStmt *Target;  // Target stmt, wired up by Sema.
+  LabeledStmt *Target = nullptr;  // Target stmt, wired up by Sema.
 public:
   BreakStmt(SourceLoc Loc, Identifier TargetName, SourceLoc TargetLoc,
             Optional<bool> implicit = None)
@@ -1058,7 +1058,7 @@ class ContinueStmt : public Stmt {
   SourceLoc Loc;
   Identifier TargetName; // Named target statement, if specified in the source.
   SourceLoc TargetLoc;
-  LabeledStmt *Target;
+  LabeledStmt *Target = nullptr;
 
 public:
   ContinueStmt(SourceLoc Loc, Identifier TargetName, SourceLoc TargetLoc,

--- a/test/refactoring/RefactoringKind/crashers.swift
+++ b/test/refactoring/RefactoringKind/crashers.swift
@@ -11,3 +11,12 @@ func foo() {
 // RUN: %refactor -source-filename %s -pos=6:5 -end-pos=6:13 | %FileCheck %s -check-prefix=CHECK1
 // RUN: %refactor -source-filename %s -pos=8:1 -end-pos=8:13 | %FileCheck %s -check-prefix=CHECK1
 // CHECK1: Action begins
+
+// rdar://33972653
+func test() {
+  break FOO
+  continue FOO
+}
+
+// RUN: %refactor -source-filename %s -pos=17:3 -end-pos=18:15 | %FileCheck %s -check-prefix=CHECK2
+// CHECK2: Action begins


### PR DESCRIPTION
Otherwise, it's never initialized in error case. This doesn't affect normal compilation because it doensn't reach SILGen (the only user) due to typecheck error. However, IDE refactoring uses this regardless of the error.

rdar://problem/33972653