### PR TITLE
[Diagnostics] Check member name kind before trying to get its identifier

### DIFF
--- a/test/Constraints/members.swift
+++ b/test/Constraints/members.swift
@@ -463,3 +463,6 @@ struct Outer {
     }
   }
 }
+
+// rdar://problem/39514009 - don't crash when trying to diagnose members with special names
+print("hello")[0] // expected-error {{value of tuple type '()' has no member 'subscript'}}


### PR DESCRIPTION
Declarations with special names (e.g. (de-)init and subscript) don't have
identifiers so while trying to diagnose specific problems related to
members check if they have a kind appropriate to the situation.

Resolves [SR-7451](https://bugs.swift.org/browse/SR-7451).
Resolves: rdar://problem/39514009

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
