### PR TITLE
[Diag] QoI: Add ReferenceOwnership to DiagnosticArgumentKind

### DIFF
--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -30,6 +30,7 @@ namespace swift {
   class ValueDecl;
   
   enum class PatternKind : uint8_t;
+  enum class ReferenceOwnership : uint8_t;
   enum class StaticSpellingKind : uint8_t;
   enum class DescriptiveDeclKind : uint8_t;
   enum DeclAttrKind : unsigned;
@@ -76,6 +77,7 @@ namespace swift {
     Type,
     TypeRepr,
     PatternKind,
+    ReferenceOwnership,
     StaticSpellingKind,
     DescriptiveDeclKind,
     DeclAttribute,
@@ -103,6 +105,7 @@ namespace swift {
       Type TypeVal;
       TypeRepr *TyR;
       PatternKind PatternKindVal;
+      ReferenceOwnership ReferenceOwnershipVal;
       StaticSpellingKind StaticSpellingKindVal;
       DescriptiveDeclKind DescriptiveDeclKindVal;
       const DeclAttribute *DeclAttributeVal;
@@ -161,6 +164,10 @@ namespace swift {
 
     DiagnosticArgument(PatternKind K)
         : Kind(DiagnosticArgumentKind::PatternKind), PatternKindVal(K) {}
+
+    DiagnosticArgument(ReferenceOwnership RO)
+        : Kind(DiagnosticArgumentKind::ReferenceOwnership),
+          ReferenceOwnershipVal(RO) {}
 
     DiagnosticArgument(StaticSpellingKind SSK)
         : Kind(DiagnosticArgumentKind::StaticSpellingKind),
@@ -235,6 +242,11 @@ namespace swift {
     PatternKind getAsPatternKind() const {
       assert(Kind == DiagnosticArgumentKind::PatternKind);
       return PatternKindVal;
+    }
+
+    ReferenceOwnership getAsReferenceOwnership() const {
+      assert(Kind == DiagnosticArgumentKind::ReferenceOwnership);
+      return ReferenceOwnershipVal;
     }
 
     StaticSpellingKind getAsStaticSpellingKind() const {

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1960,9 +1960,8 @@ ERROR(override_argument_name_mismatch,none,
       "of overridden %select{method|initializer}0 %2",
       (bool, DeclName, DeclName))
 ERROR(override_ownership_mismatch,none,
-      "cannot override %select{strong|weak|unowned|unowned(unsafe)}0 property "
-      "with %select{strong|weak|unowned|unowned(unsafe)}1 property",
-      (/*ReferenceOwnership*/unsigned, /*ReferenceOwnership*/unsigned))
+      "cannot override %0 property with %1 property",
+      (ReferenceOwnership, ReferenceOwnership))
 ERROR(override_dynamic_self_mismatch,none,
       "cannot override a Self return type with a non-Self return type",
       ())
@@ -3069,10 +3068,9 @@ NOTE(add_explicit_type_annotation_to_silence,none,
      "add an explicit type annotation to silence this warning", ())
 
 WARNING(unowned_assignment_immediate_deallocation,none,
-        "instance will be immediately deallocated as %0 is "
-        "%select{a 'strong'|a 'weak'|an 'unowned'|an 'unowned'}1 "
-        "%select{variable|property}2",
-        (Identifier, /*Ownership*/unsigned, /*Is Property*/unsigned))
+        "instance will be immediately deallocated because "
+        "%select{variable|property}2 %0 is %1",
+        (Identifier, ReferenceOwnership, /*Is Property*/unsigned))
 NOTE(unowned_assignment_requires_strong,none,
      "a strong reference is required to prevent the instance from being "
      "deallocated", ())
@@ -3230,24 +3228,23 @@ ERROR(implicitly_unwrapped_optional_in_illegal_position,none,
 
 // Ownership
 ERROR(invalid_ownership_type,none,
-      "'%select{strong|weak|unowned|unowned}0' may only be applied to "
-      "class and class-bound protocol types, not %1",
-      (/*ReferenceOwnership*/unsigned, Type))
+      "%0 may only be applied to class and class-bound protocol types, not %1",
+      (ReferenceOwnership, Type))
 ERROR(invalid_ownership_protocol_type,none,
-      "'%select{strong|weak|unowned|unowned}0' must not be applied to "
-      "non-class-bound %1; consider adding a protocol conformance that has a class bound",
-      (/*ReferenceOwnership*/unsigned, Type))
+      "%0 must not be applied to non-class-bound %1; "
+      "consider adding a protocol conformance that has a class bound",
+      (ReferenceOwnership, Type))
 ERROR(invalid_weak_ownership_not_optional,none,
       "'weak' variable should have optional type %0", (Type))
 ERROR(invalid_weak_let,none,
       "'weak' must be a mutable variable, because it may change at runtime", ())
 ERROR(ownership_invalid_in_protocols,none,
-      "'%select{strong|weak|unowned|unowned}0' cannot be applied to a property declaration in a protocol",
-      (/*ReferenceOwnership*/unsigned))
+      "%0 cannot be applied to a property declaration in a protocol",
+      (ReferenceOwnership))
 WARNING(ownership_invalid_in_protocols_compat_warning,none,
-      "'%select{strong|weak|unowned|unowned}0' should not be applied to a property declaration "
+      "%0 should not be applied to a property declaration "
       "in a protocol and will be disallowed in future versions",
-      (/*ReferenceOwnership*/unsigned))
+      (ReferenceOwnership))
 
 // required
 ERROR(required_initializer_nonclass,none,

--- a/include/swift/AST/Ownership.h
+++ b/include/swift/AST/Ownership.h
@@ -20,6 +20,7 @@
 #define SWIFT_OWNERSHIP_H
 
 #include "swift/Basic/InlineBitfield.h"
+#include "llvm/Support/raw_ostream.h"
 #include <stdint.h>
 
 namespace swift {
@@ -45,6 +46,9 @@ enum class ReferenceOwnership : uint8_t {
 
 enum : unsigned { NumReferenceOwnershipBits =
   countBitsUsed(static_cast<unsigned>(ReferenceOwnership::Last_Kind)) };
+
+/// Diagnostic printing of \c StaticSpellingKind.
+llvm::raw_ostream &operator<<(llvm::raw_ostream &OS, ReferenceOwnership RO);
 
 /// Different kinds of value ownership supported by Swift.
 enum class ValueOwnership : uint8_t {

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -296,6 +296,17 @@ llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &OS,
   llvm_unreachable("bad StaticSpellingKind");
 }
 
+llvm::raw_ostream &swift::operator<<(llvm::raw_ostream &OS,
+                                     ReferenceOwnership RO) {
+  switch (RO) {
+  case ReferenceOwnership::Strong: return OS << "'strong'";
+  case ReferenceOwnership::Weak: return OS << "'weak'";
+  case ReferenceOwnership::Unowned: return OS << "'unowned'";
+  case ReferenceOwnership::Unmanaged: return OS << "'unowned(unsafe)'";
+  }
+  llvm_unreachable("bad ReferenceOwnership kind");
+}
+
 DeclContext *Decl::getInnermostDeclContext() const {
   if (auto func = dyn_cast<AbstractFunctionDecl>(this))
     return const_cast<AbstractFunctionDecl*>(func);

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -472,6 +472,19 @@ static void formatDiagnosticArgument(StringRef Modifier,
     assert(Modifier.empty() && "Improper modifier for PatternKind argument");
     Out << Arg.getAsPatternKind();
     break;
+
+  case DiagnosticArgumentKind::ReferenceOwnership:
+    if (Modifier == "select") {
+      formatSelectionArgument(ModifierArguments, Args,
+                              unsigned(Arg.getAsReferenceOwnership()),
+                              FormatOpts, Out);
+    } else {
+      assert(Modifier.empty() &&
+             "Improper modifier for ReferenceOwnership argument");
+      Out << Arg.getAsReferenceOwnership();
+    }
+    break;
+
   case DiagnosticArgumentKind::StaticSpellingKind:
     if (Modifier == "select") {
       formatSelectionArgument(ModifierArguments, Args,

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -2128,8 +2128,7 @@ static void diagnoseUnownedImmediateDeallocationImpl(TypeChecker &TC,
     storageKind = SK_Property;
 
   TC.diagnose(diagLoc, diag::unowned_assignment_immediate_deallocation,
-              varDecl->getName(),
-              (unsigned) ownershipAttr->get(), (unsigned) storageKind)
+              varDecl->getName(), ownershipAttr->get(), unsigned(storageKind))
     .highlight(diagRange);
 
   TC.diagnose(diagLoc, diag::unowned_assignment_requires_strong)

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2178,7 +2178,7 @@ void TypeChecker::checkReferenceOwnershipAttr(VarDecl *var,
       D = diag::invalid_ownership_protocol_type;
     }
 
-    diagnose(var->getStartLoc(), D, (unsigned) ownershipKind, underlyingType);
+    diagnose(var->getStartLoc(), D, ownershipKind, underlyingType);
     attr->setInvalid();
   } else if (isa<ProtocolDecl>(var->getDeclContext()) &&
              !cast<ProtocolDecl>(var->getDeclContext())->isObjC()) {
@@ -2186,13 +2186,13 @@ void TypeChecker::checkReferenceOwnershipAttr(VarDecl *var,
     // properties of Objective-C protocols.
     if (Context.isSwiftVersionAtLeast(5))
       diagnose(attr->getLocation(),
-        diag::ownership_invalid_in_protocols,
-        (unsigned) ownershipKind)
+               diag::ownership_invalid_in_protocols,
+               ownershipKind)
         .fixItRemove(attr->getRange());
     else
       diagnose(attr->getLocation(),
-        diag::ownership_invalid_in_protocols_compat_warning,
-        (unsigned) ownershipKind)
+               diag::ownership_invalid_in_protocols_compat_warning,
+               ownershipKind)
         .fixItRemove(attr->getRange());
 
     attr->setInvalid();

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5484,8 +5484,7 @@ public:
         parentOwnership = ReferenceOwnership::Strong;
       if (parentOwnership != ownershipAttr->get()) {
         TC.diagnose(decl, diag::override_ownership_mismatch,
-                    (unsigned)parentOwnership,
-                    (unsigned)ownershipAttr->get());
+                    parentOwnership, ownershipAttr->get());
         TC.diagnose(matchDecl, diag::overridden_here);
       }
     }

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -111,7 +111,7 @@ func test2() {
   weak var w1 : SomeClass?
   _ = w1                // ok: default-initialized
 
-  // expected-warning@+3 {{instance will be immediately deallocated as 'w2' is a 'weak' variable}}
+  // expected-warning@+3 {{instance will be immediately deallocated because variable 'w2' is 'weak'}}
   // expected-note@+2 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@+1 {{'w2' declared here}}
   weak var w2 = SomeClass()
@@ -124,7 +124,7 @@ func test2() {
   unowned var u1 : SomeClass // expected-note {{variable defined here}}
   _ = u1                // expected-error {{variable 'u1' used before being initialized}}
 
-  // expected-warning@+3 {{instance will be immediately deallocated as 'u2' is an 'unowned' variable}}
+  // expected-warning@+3 {{instance will be immediately deallocated because variable 'u2' is 'unowned'}}
   // expected-note@+2 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@+1 {{'u2' declared here}}
   unowned let u2 = SomeClass()

--- a/test/Sema/diag_unowned_immediate_deallocation.swift
+++ b/test/Sema/diag_unowned_immediate_deallocation.swift
@@ -15,256 +15,256 @@ class C : ClassProtocol {
 class D : C {}
 
 func testWeakVariableBindingDiag() throws {
-  weak var c1 = C() // expected-warning {{instance will be immediately deallocated as 'c1' is a 'weak' variable}}
+  weak var c1 = C() // expected-warning {{instance will be immediately deallocated because variable 'c1' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c1' declared here}}
   // expected-note@-3 {{'c1' declared here}}
 
-  c1 = C() // expected-warning {{instance will be immediately deallocated as 'c1' is a 'weak' variable}}
+  c1 = C() // expected-warning {{instance will be immediately deallocated because variable 'c1' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  weak var c2: C? = ModuleName.C() // expected-warning {{instance will be immediately deallocated as 'c2' is a 'weak' variable}}
+  weak var c2: C? = ModuleName.C() // expected-warning {{instance will be immediately deallocated because variable 'c2' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c2' declared here}}
   // expected-note@-3 {{'c2' declared here}}
 
-  c2 = C() // expected-warning {{instance will be immediately deallocated as 'c2' is a 'weak' variable}}
+  c2 = C() // expected-warning {{instance will be immediately deallocated because variable 'c2' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  weak var c3: C? = D() // expected-warning {{instance will be immediately deallocated as 'c3' is a 'weak' variable}}
+  weak var c3: C? = D() // expected-warning {{instance will be immediately deallocated because variable 'c3' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c3' declared here}}
   // expected-note@-3 {{'c3' declared here}}
 
-  c3 = D() // expected-warning {{instance will be immediately deallocated as 'c3' is a 'weak' variable}}
+  c3 = D() // expected-warning {{instance will be immediately deallocated because variable 'c3' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  weak var c4 = C(failable: ()) // expected-warning {{instance will be immediately deallocated as 'c4' is a 'weak' variable}}
+  weak var c4 = C(failable: ()) // expected-warning {{instance will be immediately deallocated because variable 'c4' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c4' declared here}}
   // expected-note@-3 {{'c4' declared here}}
 
-  c4 = C(failable: ()) // expected-warning {{instance will be immediately deallocated as 'c4' is a 'weak' variable}}
+  c4 = C(failable: ()) // expected-warning {{instance will be immediately deallocated because variable 'c4' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  weak var c5: C? = C(failable: ()) // expected-warning {{instance will be immediately deallocated as 'c5' is a 'weak' variable}}
+  weak var c5: C? = C(failable: ()) // expected-warning {{instance will be immediately deallocated because variable 'c5' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c5' declared here}}
   // expected-note@-3 {{'c5' declared here}}
 
-  c5 = C(failable: ()) // expected-warning {{instance will be immediately deallocated as 'c5' is a 'weak' variable}}
+  c5 = C(failable: ()) // expected-warning {{instance will be immediately deallocated because variable 'c5' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  weak var c6: C? = D(failable: ()) // expected-warning {{instance will be immediately deallocated as 'c6' is a 'weak' variable}}
+  weak var c6: C? = D(failable: ()) // expected-warning {{instance will be immediately deallocated because variable 'c6' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c6' declared here}}
   // expected-note@-3 {{'c6' declared here}}
 
-  c6 = D(failable: ()) // expected-warning {{instance will be immediately deallocated as 'c6' is a 'weak' variable}}
+  c6 = D(failable: ()) // expected-warning {{instance will be immediately deallocated because variable 'c6' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  weak var c7 = try C(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c7' is a 'weak' variable}}
+  weak var c7 = try C(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c7' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c7' declared here}}
   // expected-note@-3 {{'c7' declared here}}
 
-  c7 = try C(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c7' is a 'weak' variable}}
+  c7 = try C(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c7' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  weak var c8: C? = try C(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c8' is a 'weak' variable}}
+  weak var c8: C? = try C(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c8' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c8' declared here}}
   // expected-note@-3 {{'c8' declared here}}
 
-  c8 = try C(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c8' is a 'weak' variable}}
+  c8 = try C(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c8' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  weak var c9: C? = try D(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c9' is a 'weak' variable}}
+  weak var c9: C? = try D(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c9' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c9' declared here}}
   // expected-note@-3 {{'c9' declared here}}
 
-  c9 = try D(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c9' is a 'weak' variable}}
+  c9 = try D(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c9' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  weak var c10 = try! C(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c10' is a 'weak' variable}}
+  weak var c10 = try! C(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c10' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c10' declared here}}
   // expected-note@-3 {{'c10' declared here}}
 
-  c10 = try! C(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c10' is a 'weak' variable}}
+  c10 = try! C(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c10' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  weak var c11: C? = try! C(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c11' is a 'weak' variable}}
+  weak var c11: C? = try! C(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c11' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c11' declared here}}
   // expected-note@-3 {{'c11' declared here}}
 
-  c11 = try! C(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c11' is a 'weak' variable}}
+  c11 = try! C(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c11' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  weak var c12: C? = try! D(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c12' is a 'weak' variable}}
+  weak var c12: C? = try! D(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c12' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c12' declared here}}
   // expected-note@-3 {{'c12' declared here}}
 
-  c12 = try! D(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c12' is a 'weak' variable}}
+  c12 = try! D(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c12' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  weak var c13 = try? C(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c13' is a 'weak' variable}}
+  weak var c13 = try? C(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c13' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c13' declared here}}
   // expected-note@-3 {{'c13' declared here}}
 
-  c13 = try? C(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c13' is a 'weak' variable}}
+  c13 = try? C(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c13' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  weak var c14: C? = try? C(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c14' is a 'weak' variable}}
+  weak var c14: C? = try? C(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c14' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c14' declared here}}
   // expected-note@-3 {{'c14' declared here}}
 
-  c14 = try? C(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c14' is a 'weak' variable}}
+  c14 = try? C(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c14' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  weak var c15: C? = try? D(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c15' is a 'weak' variable}}
+  weak var c15: C? = try? D(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c15' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c15' declared here}}
   // expected-note@-3 {{'c15' declared here}}
 
-  c15 = try? D(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c15' is a 'weak' variable}}
+  c15 = try? D(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c15' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
   _ = c1; _ = c2; _ = c3; _ = c4; _ = c5; _ = c6; _ = c7; _ = c8; _ = c9; _ = c10; _ = c11; _ = c12; _ = c13; _ = c14; _ = c15
 }
 
 func testUnownedVariableBindingDiag() throws {
-  unowned(unsafe) var c = C() // expected-warning {{instance will be immediately deallocated as 'c' is an 'unowned' variable}}
+  unowned(unsafe) var c = C() // expected-warning {{instance will be immediately deallocated because variable 'c' is 'unowned(unsafe)'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c' declared here}}
   // expected-note@-3 {{'c' declared here}}
 
-  c = C() // expected-warning {{instance will be immediately deallocated as 'c' is an 'unowned' variable}}
+  c = C() // expected-warning {{instance will be immediately deallocated because variable 'c' is 'unowned(unsafe)'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  unowned var c1 = C() // expected-warning {{instance will be immediately deallocated as 'c1' is an 'unowned' variable}}
+  unowned var c1 = C() // expected-warning {{instance will be immediately deallocated because variable 'c1' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c1' declared here}}
   // expected-note@-3 {{'c1' declared here}}
 
-  c1 = C() // expected-warning {{instance will be immediately deallocated as 'c1' is an 'unowned' variable}}
+  c1 = C() // expected-warning {{instance will be immediately deallocated because variable 'c1' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  unowned var c2: C = ModuleName.C() // expected-warning {{instance will be immediately deallocated as 'c2' is an 'unowned' variable}}
+  unowned var c2: C = ModuleName.C() // expected-warning {{instance will be immediately deallocated because variable 'c2' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c2' declared here}}
   // expected-note@-3 {{'c2' declared here}}
 
-  c2 = C() // expected-warning {{instance will be immediately deallocated as 'c2' is an 'unowned' variable}}
+  c2 = C() // expected-warning {{instance will be immediately deallocated because variable 'c2' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  unowned var c3: C = D() // expected-warning {{instance will be immediately deallocated as 'c3' is an 'unowned' variable}}
+  unowned var c3: C = D() // expected-warning {{instance will be immediately deallocated because variable 'c3' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c3' declared here}}
   // expected-note@-3 {{'c3' declared here}}
 
-  c3 = D() // expected-warning {{instance will be immediately deallocated as 'c3' is an 'unowned' variable}}
+  c3 = D() // expected-warning {{instance will be immediately deallocated because variable 'c3' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  unowned var c4 = C(failable: ())! // expected-warning {{instance will be immediately deallocated as 'c4' is an 'unowned' variable}}
+  unowned var c4 = C(failable: ())! // expected-warning {{instance will be immediately deallocated because variable 'c4' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c4' declared here}}
   // expected-note@-3 {{'c4' declared here}}
 
-  c4 = C(failable: ())! // expected-warning {{instance will be immediately deallocated as 'c4' is an 'unowned' variable}}
+  c4 = C(failable: ())! // expected-warning {{instance will be immediately deallocated because variable 'c4' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  unowned var c5: C = C(failable: ())! // expected-warning {{instance will be immediately deallocated as 'c5' is an 'unowned' variable}}
+  unowned var c5: C = C(failable: ())! // expected-warning {{instance will be immediately deallocated because variable 'c5' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c5' declared here}}
   // expected-note@-3 {{'c5' declared here}}
 
-  c5 = C(failable: ())! // expected-warning {{instance will be immediately deallocated as 'c5' is an 'unowned' variable}}
+  c5 = C(failable: ())! // expected-warning {{instance will be immediately deallocated because variable 'c5' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  unowned var c6: C = D(failable: ())! // expected-warning {{instance will be immediately deallocated as 'c6' is an 'unowned' variable}}
+  unowned var c6: C = D(failable: ())! // expected-warning {{instance will be immediately deallocated because variable 'c6' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c6' declared here}}
   // expected-note@-3 {{'c6' declared here}}
 
-  c6 = D(failable: ())! // expected-warning {{instance will be immediately deallocated as 'c6' is an 'unowned' variable}}
+  c6 = D(failable: ())! // expected-warning {{instance will be immediately deallocated because variable 'c6' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  unowned var c7 = try C(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c7' is an 'unowned' variable}}
+  unowned var c7 = try C(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c7' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c7' declared here}}
   // expected-note@-3 {{'c7' declared here}}
 
-  c7 = try C(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c7' is an 'unowned' variable}}
+  c7 = try C(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c7' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  unowned var c8: C = try C(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c8' is an 'unowned' variable}}
+  unowned var c8: C = try C(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c8' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c8' declared here}}
   // expected-note@-3 {{'c8' declared here}}
 
-  c8 = try C(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c8' is an 'unowned' variable}}
+  c8 = try C(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c8' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  unowned var c9: C = try D(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c9' is an 'unowned' variable}}
+  unowned var c9: C = try D(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c9' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c9' declared here}}
   // expected-note@-3 {{'c9' declared here}}
 
-  c9 = try D(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c9' is an 'unowned' variable}}
+  c9 = try D(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c9' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  unowned var c10 = try! C(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c10' is an 'unowned' variable}}
+  unowned var c10 = try! C(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c10' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c10' declared here}}
   // expected-note@-3 {{'c10' declared here}}
 
-  c10 = try C(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c10' is an 'unowned' variable}}
+  c10 = try C(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c10' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  unowned var c11: C = try! C(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c11' is an 'unowned' variable}}
+  unowned var c11: C = try! C(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c11' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c11' declared here}}
   // expected-note@-3 {{'c11' declared here}}
 
-  c11 = try C(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c11' is an 'unowned' variable}}
+  c11 = try C(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c11' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  unowned var c12: C = try! D(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c12' is an 'unowned' variable}}
+  unowned var c12: C = try! D(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c12' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c12' declared here}}
   // expected-note@-3 {{'c12' declared here}}
 
-  c12 = try D(throwing: ()) // expected-warning {{instance will be immediately deallocated as 'c12' is an 'unowned' variable}}
+  c12 = try D(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 'c12' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  unowned var c13 = (try? C(throwing: ()))! // expected-warning {{instance will be immediately deallocated as 'c13' is an 'unowned' variable}}
+  unowned var c13 = (try? C(throwing: ()))! // expected-warning {{instance will be immediately deallocated because variable 'c13' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c13' declared here}}
   // expected-note@-3 {{'c13' declared here}}
 
-  c13 = (try? C(throwing: ()))! // expected-warning {{instance will be immediately deallocated as 'c13' is an 'unowned' variable}}
+  c13 = (try? C(throwing: ()))! // expected-warning {{instance will be immediately deallocated because variable 'c13' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  unowned var c14: C = (try? C(throwing: ()))! // expected-warning {{instance will be immediately deallocated as 'c14' is an 'unowned' variable}}
+  unowned var c14: C = (try? C(throwing: ()))! // expected-warning {{instance will be immediately deallocated because variable 'c14' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c14' declared here}}
   // expected-note@-3 {{'c14' declared here}}
 
-  c14 = (try? C(throwing: ()))! // expected-warning {{instance will be immediately deallocated as 'c14' is an 'unowned' variable}}
+  c14 = (try? C(throwing: ()))! // expected-warning {{instance will be immediately deallocated because variable 'c14' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-  unowned var c15: C = (try? D(throwing: ()))! // expected-warning {{instance will be immediately deallocated as 'c15' is an 'unowned' variable}}
+  unowned var c15: C = (try? D(throwing: ()))! // expected-warning {{instance will be immediately deallocated because variable 'c15' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c15' declared here}}
   // expected-note@-3 {{'c15' declared here}}
 
-  c15 = (try? D(throwing: ()))! // expected-warning {{instance will be immediately deallocated as 'c15' is an 'unowned' variable}}
+  c15 = (try? D(throwing: ()))! // expected-warning {{instance will be immediately deallocated because variable 'c15' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
   _ = c; _ = c1; _ = c2; _ = c3; _ = c4; _ = c5; _ = c6; _ = c7; _ = c8; _ = c9; _ = c10; _ = c11; _ = c12; _ = c13; _ = c14; _ = c15
@@ -272,24 +272,24 @@ func testUnownedVariableBindingDiag() throws {
 
 func testMultipleBindingDiag() {
   weak var c1 = C(), c2: C? = C(), c3: C? = D()
-  // expected-warning@-1 {{instance will be immediately deallocated as 'c1' is a 'weak' variable}}
+  // expected-warning@-1 {{instance will be immediately deallocated because variable 'c1' is 'weak'}}
   // expected-note@-2 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-3 {{'c1' declared here}}
-  // expected-warning@-4 {{instance will be immediately deallocated as 'c2' is a 'weak' variable}}
+  // expected-warning@-4 {{instance will be immediately deallocated because variable 'c2' is 'weak'}}
   // expected-note@-5 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-6 {{'c2' declared here}}
-  // expected-warning@-7 {{instance will be immediately deallocated as 'c3' is a 'weak' variable}}
+  // expected-warning@-7 {{instance will be immediately deallocated because variable 'c3' is 'weak'}}
   // expected-note@-8 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-9 {{'c3' declared here}}
 
   unowned let c4 = C(), c5: C = C(), c6: C = D()
-  // expected-warning@-1 {{instance will be immediately deallocated as 'c4' is an 'unowned' variable}}
+  // expected-warning@-1 {{instance will be immediately deallocated because variable 'c4' is 'unowned'}}
   // expected-note@-2 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-3 {{'c4' declared here}}
-  // expected-warning@-4 {{instance will be immediately deallocated as 'c5' is an 'unowned' variable}}
+  // expected-warning@-4 {{instance will be immediately deallocated because variable 'c5' is 'unowned'}}
   // expected-note@-5 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-6 {{'c5' declared here}}
-  // expected-warning@-7 {{instance will be immediately deallocated as 'c6' is an 'unowned' variable}}
+  // expected-warning@-7 {{instance will be immediately deallocated because variable 'c6' is 'unowned'}}
   // expected-note@-8 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-9 {{'c6' declared here}}
 
@@ -298,24 +298,24 @@ func testMultipleBindingDiag() {
 
 func testTupleAndParenBinding() throws {
   weak var ((c1), c2, c3): (C?, C?, C?) = (C() as C, (D()), try D(throwing: ()))
-  // expected-warning@-1 {{instance will be immediately deallocated as 'c1' is a 'weak' variable}}
+  // expected-warning@-1 {{instance will be immediately deallocated because variable 'c1' is 'weak'}}
   // expected-note@-2 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-3 {{'c1' declared here}}
-  // expected-warning@-4 {{instance will be immediately deallocated as 'c2' is a 'weak' variable}}
+  // expected-warning@-4 {{instance will be immediately deallocated because variable 'c2' is 'weak'}}
   // expected-note@-5 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-6 {{'c2' declared here}}
-  // expected-warning@-7 {{instance will be immediately deallocated as 'c3' is a 'weak' variable}}
+  // expected-warning@-7 {{instance will be immediately deallocated because variable 'c3' is 'weak'}}
   // expected-note@-8 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-9 {{'c3' declared here}}
 
   unowned let ((c4), c5, c6): (C, C, C) = (C() as C, (D()), try D(throwing: ()))
-  // expected-warning@-1 {{instance will be immediately deallocated as 'c4' is an 'unowned' variable}}
+  // expected-warning@-1 {{instance will be immediately deallocated because variable 'c4' is 'unowned'}}
   // expected-note@-2 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-3 {{'c4' declared here}}
-  // expected-warning@-4 {{instance will be immediately deallocated as 'c5' is an 'unowned' variable}}
+  // expected-warning@-4 {{instance will be immediately deallocated because variable 'c5' is 'unowned'}}
   // expected-note@-5 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-6 {{'c5' declared here}}
-  // expected-warning@-7 {{instance will be immediately deallocated as 'c6' is an 'unowned' variable}}
+  // expected-warning@-7 {{instance will be immediately deallocated because variable 'c6' is 'unowned'}}
   // expected-note@-8 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-9 {{'c6' declared here}}
 
@@ -323,65 +323,65 @@ func testTupleAndParenBinding() throws {
 }
 
 func testInitializationThroughClassArchetypeDiag<T : ClassProtocol>(_ t: T, _ p: ClassProtocol) throws {
-  weak var t1: T? = T() // expected-warning {{instance will be immediately deallocated as 't1' is a 'weak' variable}}
+  weak var t1: T? = T() // expected-warning {{instance will be immediately deallocated because variable 't1' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'t1' declared here}}
 
-  weak var t2: ClassProtocol? = T(failable: ()) // expected-warning {{instance will be immediately deallocated as 't2' is a 'weak' variable}}
+  weak var t2: ClassProtocol? = T(failable: ()) // expected-warning {{instance will be immediately deallocated because variable 't2' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'t2' declared here}}
 
-  unowned let t3 = try type(of: t).init(throwing: ()) // expected-warning {{instance will be immediately deallocated as 't3' is an 'unowned' variable}}
+  unowned let t3 = try type(of: t).init(throwing: ()) // expected-warning {{instance will be immediately deallocated because variable 't3' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'t3' declared here}}
 
-  unowned(unsafe) let t4 = type(of: p).init() // expected-warning {{instance will be immediately deallocated as 't4' is an 'unowned' variable}}
+  unowned(unsafe) let t4 = type(of: p).init() // expected-warning {{instance will be immediately deallocated because variable 't4' is 'unowned(unsafe)'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'t4' declared here}}
 
   let optionalTType: T.Type? = T.self
   let optionalPType: ClassProtocol.Type? = type(of: p)
 
-  weak var t5 = optionalTType?.init(failable: ()) // expected-warning {{instance will be immediately deallocated as 't5' is a 'weak' variable}}
+  weak var t5 = optionalTType?.init(failable: ()) // expected-warning {{instance will be immediately deallocated because variable 't5' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'t5' declared here}}
 
-  unowned(unsafe) let t6 = try (optionalPType?.init(throwing: ()))! // expected-warning {{instance will be immediately deallocated as 't6' is an 'unowned' variable}}
+  unowned(unsafe) let t6 = try (optionalPType?.init(throwing: ()))! // expected-warning {{instance will be immediately deallocated because variable 't6' is 'unowned(unsafe)'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'t6' declared here}}
 
   _ = t1; _ = t2; _ = t3; _ = t4; _ = t5; _ = t6
 }
 
-weak var topLevelC = C() // expected-warning {{instance will be immediately deallocated as 'topLevelC' is a 'weak' variable}}
+weak var topLevelC = C() // expected-warning {{instance will be immediately deallocated because variable 'topLevelC' is 'weak'}}
 // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 // expected-note@-2 {{'topLevelC' declared here}}
 // expected-note@-3 {{'topLevelC' declared here}}
 
-topLevelC = C() // expected-warning {{instance will be immediately deallocated as 'topLevelC' is a 'weak' variable}}
+topLevelC = C() // expected-warning {{instance will be immediately deallocated because variable 'topLevelC' is 'weak'}}
 // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-unowned var topLevelC1 = C() // expected-warning {{instance will be immediately deallocated as 'topLevelC1' is an 'unowned' variable}}
+unowned var topLevelC1 = C() // expected-warning {{instance will be immediately deallocated because variable 'topLevelC1' is 'unowned'}}
 // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 // expected-note@-2 {{'topLevelC1' declared here}}
 // expected-note@-3 {{'topLevelC1' declared here}}
 
-topLevelC1 = C() // expected-warning {{instance will be immediately deallocated as 'topLevelC1' is an 'unowned' variable}}
+topLevelC1 = C() // expected-warning {{instance will be immediately deallocated because variable 'topLevelC1' is 'unowned'}}
 // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
 struct S {
   weak var c: C? // expected-note {{'c' declared here}}
 
-  unowned var c1 = C() // expected-warning {{instance will be immediately deallocated as 'c1' is an 'unowned' property}}
+  unowned var c1 = C() // expected-warning {{instance will be immediately deallocated because property 'c1' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c1' declared here}}
   // expected-note@-3 {{'c1' declared here}}
 
   mutating func foo() {
-    c = D() // expected-warning {{instance will be immediately deallocated as 'c' is a 'weak' property}}
+    c = D() // expected-warning {{instance will be immediately deallocated because property 'c' is 'weak'}}
     // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-    c1 = D() // expected-warning {{instance will be immediately deallocated as 'c1' is an 'unowned' property}}
+    c1 = D() // expected-warning {{instance will be immediately deallocated because property 'c1' is 'unowned'}}
     // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   }
 }
@@ -389,27 +389,27 @@ struct S {
 class C1 {
   weak var c: C? // expected-note {{'c' declared here}}
 
-  unowned var c1 = C() // expected-warning {{instance will be immediately deallocated as 'c1' is an 'unowned' property}}
+  unowned var c1 = C() // expected-warning {{instance will be immediately deallocated because property 'c1' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c1' declared here}}
   // expected-note@-3 {{'c1' declared here}}
 
   func foo() {
-    c = D() // expected-warning {{instance will be immediately deallocated as 'c' is a 'weak' property}}
+    c = D() // expected-warning {{instance will be immediately deallocated because property 'c' is 'weak'}}
     // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
-    c1 = D() // expected-warning {{instance will be immediately deallocated as 'c1' is an 'unowned' property}}
+    c1 = D() // expected-warning {{instance will be immediately deallocated because property 'c1' is 'unowned'}}
     // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   }
 }
 
 func testInitializationThroughMetaclassDiag(_ t: C.Type) {
-  weak var c1: C? = t.init() // expected-warning {{instance will be immediately deallocated as 'c1' is a 'weak' variable}}
+  weak var c1: C? = t.init() // expected-warning {{instance will be immediately deallocated because variable 'c1' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c1' declared here}}
 
   let optionaCType: C.Type? = t
-  weak var c2 = optionaCType?.init(failable: ()) // expected-warning {{instance will be immediately deallocated as 'c2' is a 'weak' variable}}
+  weak var c2 = optionaCType?.init(failable: ()) // expected-warning {{instance will be immediately deallocated because variable 'c2' is 'weak'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c2' declared here}}
 
@@ -417,19 +417,19 @@ func testInitializationThroughMetaclassDiag(_ t: C.Type) {
 }
 
 func testInitializationThroughTupleElementDiag() {
-  unowned var c1 = ((C() as C, C() as C) as (C, C)).0 // expected-warning {{instance will be immediately deallocated as 'c1' is an 'unowned' variable}}
+  unowned var c1 = ((C() as C, C() as C) as (C, C)).0 // expected-warning {{instance will be immediately deallocated because variable 'c1' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-2 {{'c1' declared here}}
   // expected-note@-3 {{'c1' declared here}}
 
-  c1 = ((C() as C, C() as C) as (C, C)).0 // expected-warning {{instance will be immediately deallocated as 'c1' is an 'unowned' variable}}
+  c1 = ((C() as C, C() as C) as (C, C)).0 // expected-warning {{instance will be immediately deallocated because variable 'c1' is 'unowned'}}
   // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 
   unowned let (c2, c3) = ((C() as C, C()) as (C, C), 5).0
-  // expected-warning@-1 {{instance will be immediately deallocated as 'c2' is an 'unowned' variable}}
+  // expected-warning@-1 {{instance will be immediately deallocated because variable 'c2' is 'unowned'}}
   // expected-note@-2 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-3 {{'c2' declared here}}
-  // expected-warning@-4 {{instance will be immediately deallocated as 'c3' is an 'unowned' variable}}
+  // expected-warning@-4 {{instance will be immediately deallocated because variable 'c3' is 'unowned'}}
   // expected-note@-5 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-6 {{'c3' declared here}}
 
@@ -440,7 +440,7 @@ class E<T> {}
 
 func testGenericWeakClassDiag() {
   weak var e = E<String>()
-  // expected-warning@-1 {{instance will be immediately deallocated as 'e' is a 'weak' variable}}
+  // expected-warning@-1 {{instance will be immediately deallocated because variable 'e' is 'weak'}}
   // expected-note@-2 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-3 {{'e' declared here}}
 

--- a/test/Sema/diag_unowned_immediate_deallocation_global.swift
+++ b/test/Sema/diag_unowned_immediate_deallocation_global.swift
@@ -4,11 +4,11 @@ class C {
   init() {}
 }
 
-weak var globalC = C() // expected-warning {{instance will be immediately deallocated as 'globalC' is a 'weak' variable}}
+weak var globalC = C() // expected-warning {{instance will be immediately deallocated because variable 'globalC' is 'weak'}}
 // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 // expected-note@-2 {{'globalC' declared here}}
 
-unowned var globalC1 = C() // expected-warning {{instance will be immediately deallocated as 'globalC1' is an 'unowned' variable}}
+unowned var globalC1 = C() // expected-warning {{instance will be immediately deallocated because variable 'globalC1' is 'unowned'}}
 // expected-note@-1 {{a strong reference is required to prevent the instance from being deallocated}}
 // expected-note@-2 {{'globalC1' declared here}}
 

--- a/test/attr/attributes.swift
+++ b/test/attr/attributes.swift
@@ -159,12 +159,12 @@ unowned
 var weak7 : Int // expected-error {{'unowned' may only be applied to class and class-bound protocol types, not 'Int'}}
 weak
 var weak8 : Class? = Ty0()
-// expected-warning@-1 {{instance will be immediately deallocated as 'weak8' is a 'weak' variable}}
+// expected-warning@-1 {{instance will be immediately deallocated because variable 'weak8' is 'weak'}}
 // expected-note@-2 {{a strong reference is required to prevent the instance from being deallocated}}
 // expected-note@-3 {{'weak8' declared here}}
 
 unowned var weak9 : Class = Ty0()
-// expected-warning@-1 {{instance will be immediately deallocated as 'weak9' is an 'unowned' variable}}
+// expected-warning@-1 {{instance will be immediately deallocated because variable 'weak9' is 'unowned'}}
 // expected-note@-2 {{a strong reference is required to prevent the instance from being deallocated}}
 // expected-note@-3 {{'weak9' declared here}}
 

--- a/test/decl/protocol/special/coding/class_codable_non_strong_vars.swift
+++ b/test/decl/protocol/special/coding/class_codable_non_strong_vars.swift
@@ -8,12 +8,12 @@ class NonStrongClass : Codable {
   }
 
   weak var x: NestedClass? = NestedClass()
-  // expected-warning@-1 {{instance will be immediately deallocated as 'x' is a 'weak' property}}
+  // expected-warning@-1 {{instance will be immediately deallocated because property 'x' is 'weak'}}
   // expected-note@-2 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-3 {{'x' declared here}}
 
   unowned var y: NestedClass = NestedClass()
-  // expected-warning@-1 {{instance will be immediately deallocated as 'y' is an 'unowned' property}}
+  // expected-warning@-1 {{instance will be immediately deallocated because property 'y' is 'unowned'}}
   // expected-note@-2 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-3 {{'y' declared here}}
 

--- a/test/decl/protocol/special/coding/struct_codable_non_strong_vars.swift
+++ b/test/decl/protocol/special/coding/struct_codable_non_strong_vars.swift
@@ -8,12 +8,12 @@ struct NonStrongStruct : Codable {
   }
 
   weak var x: NestedClass? = NestedClass()
-  // expected-warning@-1 {{instance will be immediately deallocated as 'x' is a 'weak' property}}
+  // expected-warning@-1 {{instance will be immediately deallocated because property 'x' is 'weak'}}
   // expected-note@-2 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-3 {{'x' declared here}}
 
   unowned var y: NestedClass = NestedClass()
-  // expected-warning@-1 {{instance will be immediately deallocated as 'y' is an 'unowned' property}}
+  // expected-warning@-1 {{instance will be immediately deallocated because property 'y' is 'unowned'}}
   // expected-note@-2 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-3 {{'y' declared here}}
 

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -114,7 +114,7 @@ var x15: Int {
   // applied to the getter.
   weak
   var foo: SomeClass? = SomeClass()  // expected-warning {{variable 'foo' was written to, but never read}}
-  // expected-warning@-1 {{instance will be immediately deallocated as 'foo' is a 'weak' variable}}
+  // expected-warning@-1 {{instance will be immediately deallocated because variable 'foo' is 'weak'}}
   // expected-note@-2 {{a strong reference is required to prevent the instance from being deallocated}}
   // expected-note@-3 {{'foo' declared here}}
   return 0
@@ -1106,7 +1106,7 @@ class OwnershipImplicitSub : OwnershipBase {
 }
 
 class OwnershipBadSub : OwnershipBase {
-  override weak var strongVar: AnyObject? { // expected-error {{cannot override strong property with weak property}}
+  override weak var strongVar: AnyObject? { // expected-error {{cannot override 'strong' property with 'weak' property}}
     didSet {}
   }
   override unowned var weakVar: AnyObject? { // expected-error {{'unowned' may only be applied to class and class-bound protocol types, not 'AnyObject?'}}
@@ -1115,7 +1115,7 @@ class OwnershipBadSub : OwnershipBase {
   override weak var unownedVar: AnyObject { // expected-error {{'weak' variable should have optional type 'AnyObject?'}}
     didSet {}
   }
-  override unowned var unownedUnsafeVar: AnyObject { // expected-error {{cannot override unowned(unsafe) property with unowned property}}
+  override unowned var unownedUnsafeVar: AnyObject { // expected-error {{cannot override 'unowned(unsafe)' property with 'unowned' property}}
     didSet {}
   }
 }


### PR DESCRIPTION
By formalizing ReferenceOwnership as a diagnostic argument kind, we get less boilerplate, better type safety, better output consistency, and last but not least: future proofing.