### PR TITLE
[AST] Make TypeBase::adjustSuperclassMemberDeclType() more robust.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3412,7 +3412,7 @@ Type TypeBase::adjustSuperclassMemberDeclType(const ValueDecl *baseDecl,
                                    genericMemberType->getExtInfo());
   }
 
-  auto type = memberType.subst(subs);
+  auto type = memberType.subst(subs, SubstFlags::UseErrorType);
 
   if (isa<AbstractFunctionDecl>(baseDecl)) {
     type = type->replaceSelfParameterType(this);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5331,6 +5331,7 @@ public:
         // Check whether the types are identical.
         auto parentDeclTy = owningTy->adjustSuperclassMemberDeclType(
             parentDecl, decl, parentDecl->getInterfaceType());
+        if (parentDeclTy->hasError()) continue;
         parentDeclTy = parentDeclTy->getUnlabeledType(TC.Context);
         if (method) {
           // For methods, strip off the 'Self' type.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4030,6 +4030,7 @@ void TypeChecker::checkConformanceRequirements(
   llvm::SetVector<ValueDecl *> globalMissingWitnesses;
   ConformanceChecker checker(*this, conformance, globalMissingWitnesses);
   checker.ensureRequirementsAreSatisfied(/*failUnsubstituted=*/true);
+  checker.diagnoseMissingWitnesses(MissingWitnessDiagnosisKind::ErrorFixIt);
 }
 
 /// Determine the score when trying to match two identifiers together.
@@ -4937,6 +4938,7 @@ void TypeChecker::resolveTypeWitness(
     checker.resolveTypeWitnesses();
   else
     checker.resolveSingleTypeWitness(assocType);
+  checker.diagnoseMissingWitnesses(MissingWitnessDiagnosisKind::ErrorFixIt);
 }
 
 void TypeChecker::resolveWitness(const NormalProtocolConformance *conformance,
@@ -4947,6 +4949,7 @@ void TypeChecker::resolveWitness(const NormalProtocolConformance *conformance,
                        const_cast<NormalProtocolConformance*>(conformance),
                        MissingWitnesses);
   checker.resolveSingleWitness(requirement);
+  checker.diagnoseMissingWitnesses(MissingWitnessDiagnosisKind::ErrorFixIt);
 }
 
 ValueDecl *TypeChecker::deriveProtocolRequirement(DeclContext *DC,

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -509,8 +509,7 @@ func testWeakVariable() {
 }
 
 class IncompleteProtocolAdopter : Incomplete, IncompleteOptional { // expected-error {{type 'IncompleteProtocolAdopter' cannot conform to protocol 'Incomplete' because it has requirements that cannot be satisfied}}
-      // expected-error@-1{{type 'IncompleteProtocolAdopter' does not conform to protocol 'Incomplete'}}
-  @objc func getObject() -> AnyObject { return self } // expected-note{{candidate has non-matching type '() -> AnyObject'}}
+  @objc func getObject() -> AnyObject { return self }
 }
 
 func testNullarySelectorPieces(_ obj: AnyObject) {

--- a/validation-test/compiler_crashers_2_fixed/0123-rdar31164540.swift
+++ b/validation-test/compiler_crashers_2_fixed/0123-rdar31164540.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend -parse-stdlib -DBUILDING_OUTSIDE_STDLIB %s -emit-ir
+// RUN: not %target-swift-frontend -parse-stdlib -DBUILDING_OUTSIDE_STDLIB %s -emit-ir
 // REQUIRES: objc_interop
 
 //===----------------------------------------------------------------------===//

--- a/validation-test/compiler_crashers_2_fixed/0139-rdar36278079.swift
+++ b/validation-test/compiler_crashers_2_fixed/0139-rdar36278079.swift
@@ -1,0 +1,19 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+struct S {
+  // presence of a static instance seems to be
+  // necessary to cause this problem
+  static let s = S()
+}
+
+protocol P {
+  associatedtype T
+  init(t: T)
+}
+
+extension S: P {
+// Uncomment to stop assertion:
+//  init(t: Int) {
+//    self = S()
+//  }
+}

--- a/validation-test/compiler_crashers_2_fixed/0154-sr7457.swift
+++ b/validation-test/compiler_crashers_2_fixed/0154-sr7457.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend %s -emit-ir
+protocol Proto { }
+
+class Class {
+    func foo<A>(callback: (A) -> Void) where A: Proto {
+    }
+
+    func foo<A, B>(callback: (A, B) -> Void) where A: Proto, B: Proto {
+    }
+}
+
+class Child: Class {
+    override func foo<A>(callback: (A) -> Void) where A : Proto {
+    }
+}
+

--- a/validation-test/compiler_crashers_2_fixed/0155-sr7364.swift
+++ b/validation-test/compiler_crashers_2_fixed/0155-sr7364.swift
@@ -1,0 +1,22 @@
+// RUN: not %target-swift-frontend %s -emit-ir
+
+
+public protocol E {
+	associatedtype F
+	
+	static func g(_: F) -> Self
+}
+
+internal enum CF {
+	case f
+}
+
+internal enum CE: E {
+	case f(CF)
+	
+	static func g(_ f: CF) -> CE {
+		return CE.f(f)
+	}
+	
+	static let cf = CE.g(.f)
+}


### PR DESCRIPTION
When performing substitutions in this function, allow them to fail
more gracefully by producing error types. Fixes SR-7364 /
rdar://problem/39239629.