### PR TITLE
[stdlib] Review & update hash testing to use Hasher's new features

### DIFF
--- a/stdlib/private/StdlibUnittest/MinimalTypes.swift
+++ b/stdlib/private/StdlibUnittest/MinimalTypes.swift
@@ -51,13 +51,14 @@ public struct MinimalEquatableValue : Equatable {
     self.value = value
     self.identity = identity
   }
-}
-public func == (
-  lhs: MinimalEquatableValue,
-  rhs: MinimalEquatableValue
-) -> Bool {
-  MinimalEquatableValue.timesEqualEqualWasCalled += 1
-  return MinimalEquatableValue.equalImpl.value(lhs.value, rhs.value)
+
+  public static func == (
+    lhs: MinimalEquatableValue,
+    rhs: MinimalEquatableValue
+  ) -> Bool {
+    MinimalEquatableValue.timesEqualEqualWasCalled += 1
+    return MinimalEquatableValue.equalImpl.value(lhs.value, rhs.value)
+  }
 }
 
 /// A type that conforms only to `Equatable` and `Comparable`.
@@ -85,22 +86,22 @@ public struct MinimalComparableValue : Equatable, Comparable {
     self.value = value
     self.identity = identity
   }
-}
 
-public func == (
-  lhs: MinimalComparableValue,
-  rhs: MinimalComparableValue
-) -> Bool {
-  MinimalComparableValue.timesEqualEqualWasCalled.value += 1
-  return MinimalComparableValue.equalImpl.value(lhs.value, rhs.value)
-}
+  public static func == (
+    lhs: MinimalComparableValue,
+    rhs: MinimalComparableValue
+  ) -> Bool {
+    MinimalComparableValue.timesEqualEqualWasCalled.value += 1
+    return MinimalComparableValue.equalImpl.value(lhs.value, rhs.value)
+  }
 
-public func < (
-  lhs: MinimalComparableValue,
-  rhs: MinimalComparableValue
-) -> Bool {
-  MinimalComparableValue.timesLessWasCalled.value += 1
-  return MinimalComparableValue.lessImpl.value(lhs.value, rhs.value)
+  public static func < (
+    lhs: MinimalComparableValue,
+    rhs: MinimalComparableValue
+  ) -> Bool {
+    MinimalComparableValue.timesLessWasCalled.value += 1
+    return MinimalComparableValue.lessImpl.value(lhs.value, rhs.value)
+  }
 }
 
 
@@ -130,19 +131,20 @@ public struct MinimalHashableValue : Equatable, Hashable {
     self.identity = identity
   }
 
+  public static func ==(
+    lhs: MinimalHashableValue,
+    rhs: MinimalHashableValue
+  ) -> Bool {
+    MinimalHashableValue.timesEqualEqualWasCalled += 1
+    return MinimalHashableValue.equalImpl.value(lhs.value, rhs.value)
+  }
+
   public var hashValue: Int {
     MinimalHashableValue.timesHashValueWasCalled += 1
     return MinimalHashableValue.hashValueImpl.value(value)
   }
 }
 
-public func == (
-  lhs: MinimalHashableValue,
-  rhs: MinimalHashableValue
-) -> Bool {
-  MinimalHashableValue.timesEqualEqualWasCalled += 1
-  return MinimalHashableValue.equalImpl.value(lhs.value, rhs.value)
-}
 
 
 /// A type that conforms only to `Equatable` and `Hashable`.
@@ -171,29 +173,34 @@ public class MinimalHashableClass : Equatable, Hashable {
     self.identity = identity
   }
 
+  public static func == (
+    lhs: MinimalHashableClass,
+    rhs: MinimalHashableClass
+  ) -> Bool {
+    MinimalHashableClass.timesEqualEqualWasCalled += 1
+    return MinimalHashableClass.equalImpl.value(lhs.value, rhs.value)
+  }
+
   public var hashValue: Int {
     MinimalHashableClass.timesHashValueWasCalled += 1
     return MinimalHashableClass.hashValueImpl.value(value)
   }
 }
 
-public func == (
-  lhs: MinimalHashableClass,
-  rhs: MinimalHashableClass
-) -> Bool {
-  MinimalHashableClass.timesEqualEqualWasCalled += 1
-  return MinimalHashableClass.equalImpl.value(lhs.value, rhs.value)
-}
 
 
 
 public var GenericMinimalHashableValue_timesEqualEqualWasCalled: Int = 0
 public var GenericMinimalHashableValue_timesHashValueWasCalled: Int = 0
 
-public var GenericMinimalHashableValue_equalImpl = ResettableValue<(Any, Any) -> Bool>(
-  { _, _ in fatalError("GenericMinimalHashableValue_equalImpl is not set yet"); () })
-public var GenericMinimalHashableValue_hashValueImpl = ResettableValue<(Any) -> Int>(
-  { _ in fatalError("GenericMinimalHashableValue_hashValueImpl is not set yet"); () })
+public var GenericMinimalHashableValue_equalImpl =
+  ResettableValue<(Any, Any) -> Bool>({ _, _ in
+    fatalError("GenericMinimalHashableValue_equalImpl is not set yet")
+  })
+public var GenericMinimalHashableValue_hashValueImpl =
+  ResettableValue<(Any) -> Int>({ _ in
+    fatalError("GenericMinimalHashableValue_hashValueImpl is not set yet")
+  })
 
 /// A type that conforms only to `Equatable` and `Hashable`.
 ///
@@ -213,28 +220,32 @@ public struct GenericMinimalHashableValue<Wrapped> : Equatable, Hashable {
     self.identity = identity
   }
 
+  public static func == <Wrapped>(
+    lhs: GenericMinimalHashableValue<Wrapped>,
+    rhs: GenericMinimalHashableValue<Wrapped>
+  ) -> Bool {
+    GenericMinimalHashableValue_timesEqualEqualWasCalled += 1
+    return GenericMinimalHashableValue_equalImpl.value(lhs.value, rhs.value)
+  }
+
   public var hashValue: Int {
     GenericMinimalHashableValue_timesHashValueWasCalled += 1
     return GenericMinimalHashableValue_hashValueImpl.value(value)
   }
 }
 
-public func == <Wrapped>(
-  lhs: GenericMinimalHashableValue<Wrapped>,
-  rhs: GenericMinimalHashableValue<Wrapped>
-) -> Bool {
-  GenericMinimalHashableValue_timesEqualEqualWasCalled += 1
-  return GenericMinimalHashableValue_equalImpl.value(lhs.value, rhs.value)
-}
-
 
 public var GenericMinimalHashableClass_timesEqualEqualWasCalled: Int = 0
 public var GenericMinimalHashableClass_timesHashValueWasCalled: Int = 0
 
-public var GenericMinimalHashableClass_equalImpl = ResettableValue<(Any, Any) -> Bool>(
-  { _, _ in fatalError("GenericMinimalHashableClass_equalImpl is not set yet"); () })
-public var GenericMinimalHashableClass_hashValueImpl = ResettableValue<(Any) -> Int>(
-  { _ in fatalError("GenericMinimalHashableClass_hashValueImpl is not set yet"); () })
+public var GenericMinimalHashableClass_equalImpl =
+  ResettableValue<(Any, Any) -> Bool>({ _, _ in
+    fatalError("GenericMinimalHashableClass_equalImpl is not set yet")
+  })
+public var GenericMinimalHashableClass_hashValueImpl =
+  ResettableValue<(Any) -> Int>({ _ in
+    fatalError("GenericMinimalHashableClass_hashValueImpl is not set yet")
+  })
 
 /// A type that conforms only to `Equatable` and `Hashable`.
 ///
@@ -254,19 +265,20 @@ public class GenericMinimalHashableClass<Wrapped> : Equatable, Hashable {
     self.identity = identity
   }
 
+  public static func == <Wrapped>(
+    lhs: GenericMinimalHashableClass<Wrapped>,
+    rhs: GenericMinimalHashableClass<Wrapped>
+  ) -> Bool {
+    GenericMinimalHashableClass_timesEqualEqualWasCalled += 1
+    return GenericMinimalHashableClass_equalImpl.value(lhs.value, rhs.value)
+  }
+
   public var hashValue: Int {
     GenericMinimalHashableClass_timesHashValueWasCalled += 1
     return GenericMinimalHashableClass_hashValueImpl.value(value)
   }
 }
 
-public func == <Wrapped>(
-  lhs: GenericMinimalHashableClass<Wrapped>,
-  rhs: GenericMinimalHashableClass<Wrapped>
-) -> Bool {
-  GenericMinimalHashableClass_timesEqualEqualWasCalled += 1
-  return GenericMinimalHashableClass_equalImpl.value(lhs.value, rhs.value)
-}
 
 
 /// A type that conforms only to `Equatable`, `Comparable`, and `Strideable`.
@@ -299,6 +311,22 @@ public struct MinimalStrideableValue : Equatable, Comparable, Strideable {
 
   public typealias Stride = Int
 
+  public static func == (
+    lhs: MinimalStrideableValue,
+    rhs: MinimalStrideableValue
+  ) -> Bool {
+    MinimalStrideableValue.timesEqualEqualWasCalled.value += 1
+    return MinimalStrideableValue.equalImpl.value(lhs.value, rhs.value)
+  }
+
+  public static func < (
+    lhs: MinimalStrideableValue,
+    rhs: MinimalStrideableValue
+  ) -> Bool {
+    MinimalStrideableValue.timesLessWasCalled.value += 1
+    return MinimalStrideableValue.lessImpl.value(lhs.value, rhs.value)
+  }
+
   public func distance(to other: MinimalStrideableValue) -> Stride {
     MinimalStrideableValue.timesDistanceWasCalled.value += 1
     return other.value - self.value
@@ -310,21 +338,6 @@ public struct MinimalStrideableValue : Equatable, Comparable, Strideable {
   }
 }
 
-public func == (
-  lhs: MinimalStrideableValue,
-  rhs: MinimalStrideableValue
-) -> Bool {
-  MinimalStrideableValue.timesEqualEqualWasCalled.value += 1
-  return MinimalStrideableValue.equalImpl.value(lhs.value, rhs.value)
-}
-
-public func < (
-  lhs: MinimalStrideableValue,
-  rhs: MinimalStrideableValue
-) -> Bool {
-  MinimalStrideableValue.timesLessWasCalled.value += 1
-  return MinimalStrideableValue.lessImpl.value(lhs.value, rhs.value)
-}
 
 // Local Variables:
 // eval: (read-only-mode 1)

--- a/stdlib/private/StdlibUnittest/MinimalTypes.swift
+++ b/stdlib/private/StdlibUnittest/MinimalTypes.swift
@@ -145,6 +145,11 @@ public struct MinimalHashableValue : Equatable, Hashable {
   }
 }
 
+extension MinimalHashableValue: CustomStringConvertible {
+  public var description: String {
+    return "MinimalHashableValue(value: \(value), identity: \(identity))"
+  }
+}
 
 
 /// A type that conforms only to `Equatable` and `Hashable`.
@@ -187,6 +192,11 @@ public class MinimalHashableClass : Equatable, Hashable {
   }
 }
 
+extension MinimalHashableClass: CustomStringConvertible {
+  public var description: String {
+    return "MinimalHashableClass(value: \(value), identity: \(identity))"
+  }
+}
 
 
 
@@ -234,6 +244,11 @@ public struct GenericMinimalHashableValue<Wrapped> : Equatable, Hashable {
   }
 }
 
+extension GenericMinimalHashableValue: CustomStringConvertible {
+  public var description: String {
+    return "GenericMinimalHashableValue(value: \(value), identity: \(identity))"
+  }
+}
 
 public var GenericMinimalHashableClass_timesEqualEqualWasCalled: Int = 0
 public var GenericMinimalHashableClass_timesHashValueWasCalled: Int = 0
@@ -279,6 +294,11 @@ public class GenericMinimalHashableClass<Wrapped> : Equatable, Hashable {
   }
 }
 
+extension GenericMinimalHashableClass: CustomStringConvertible {
+  public var description: String {
+    return "GenericMinimalHashableClass(value: \(value), identity: \(identity))"
+  }
+}
 
 
 /// A type that conforms only to `Equatable`, `Comparable`, and `Strideable`.

--- a/stdlib/private/StdlibUnittest/MinimalTypes.swift
+++ b/stdlib/private/StdlibUnittest/MinimalTypes.swift
@@ -111,12 +111,12 @@ public struct MinimalComparableValue : Equatable, Comparable {
 /// other conformances.
 public struct MinimalHashableValue : Equatable, Hashable {
   public static var timesEqualEqualWasCalled: Int = 0
-  public static var timesHashValueWasCalled: Int = 0
+  public static var timesHashIntoWasCalled: Int = 0
 
   public static var equalImpl =
     ResettableValue<(Int, Int) -> Bool>({ $0 == $1 })
-  public static var hashValueImpl =
-    ResettableValue<(Int) -> Int>({ $0.hashValue })
+  public static var hashIntoImpl =
+    ResettableValue<(Int, inout _Hasher) -> Void>({ $1.combine($0) })
 
   public var value: Int
   public var identity: Int
@@ -140,8 +140,14 @@ public struct MinimalHashableValue : Equatable, Hashable {
   }
 
   public var hashValue: Int {
-    MinimalHashableValue.timesHashValueWasCalled += 1
-    return MinimalHashableValue.hashValueImpl.value(value)
+    var hasher = _Hasher()
+    hasher.combine(self)
+    return hasher.finalize()
+  }
+
+  public func _hash(into hasher: inout _Hasher) {
+    MinimalHashableValue.timesHashIntoWasCalled += 1
+    MinimalHashableValue.hashIntoImpl.value(value, &hasher)
   }
 }
 
@@ -158,12 +164,12 @@ extension MinimalHashableValue: CustomStringConvertible {
 /// other conformances.
 public class MinimalHashableClass : Equatable, Hashable {
   public static var timesEqualEqualWasCalled: Int = 0
-  public static var timesHashValueWasCalled: Int = 0
+  public static var timesHashIntoWasCalled: Int = 0
 
   public static var equalImpl =
     ResettableValue<(Int, Int) -> Bool>({ $0 == $1 })
-  public static var hashValueImpl =
-    ResettableValue<(Int) -> Int>({ $0.hashValue })
+  public static var hashIntoImpl =
+  ResettableValue<(Int, inout _Hasher) -> Void>({ $1.combine($0) })
 
   public var value: Int
   public var identity: Int
@@ -187,8 +193,14 @@ public class MinimalHashableClass : Equatable, Hashable {
   }
 
   public var hashValue: Int {
-    MinimalHashableClass.timesHashValueWasCalled += 1
-    return MinimalHashableClass.hashValueImpl.value(value)
+    var hasher = _Hasher()
+    hasher.combine(self)
+    return hasher.finalize()
+  }
+
+  public func _hash(into hasher: inout _Hasher) {
+    MinimalHashableClass.timesHashIntoWasCalled += 1
+    MinimalHashableClass.hashIntoImpl.value(value, &hasher)
   }
 }
 
@@ -201,15 +213,15 @@ extension MinimalHashableClass: CustomStringConvertible {
 
 
 public var GenericMinimalHashableValue_timesEqualEqualWasCalled: Int = 0
-public var GenericMinimalHashableValue_timesHashValueWasCalled: Int = 0
+public var GenericMinimalHashableValue_timesHashIntoWasCalled: Int = 0
 
 public var GenericMinimalHashableValue_equalImpl =
   ResettableValue<(Any, Any) -> Bool>({ _, _ in
     fatalError("GenericMinimalHashableValue_equalImpl is not set yet")
   })
-public var GenericMinimalHashableValue_hashValueImpl =
-  ResettableValue<(Any) -> Int>({ _ in
-    fatalError("GenericMinimalHashableValue_hashValueImpl is not set yet")
+public var GenericMinimalHashableValue_hashIntoImpl =
+  ResettableValue<(Any, inout _Hasher) -> Void>({ _ in
+    fatalError("GenericMinimalHashableValue_hashIntoImpl is not set yet")
   })
 
 /// A type that conforms only to `Equatable` and `Hashable`.
@@ -239,8 +251,14 @@ public struct GenericMinimalHashableValue<Wrapped> : Equatable, Hashable {
   }
 
   public var hashValue: Int {
-    GenericMinimalHashableValue_timesHashValueWasCalled += 1
-    return GenericMinimalHashableValue_hashValueImpl.value(value)
+    var hasher = _Hasher()
+    hasher.combine(self)
+    return hasher.finalize()
+  }
+
+  public func _hash(into hasher: inout _Hasher) {
+    GenericMinimalHashableValue_timesHashIntoWasCalled += 1
+    GenericMinimalHashableValue_hashIntoImpl.value(value, &hasher)
   }
 }
 
@@ -251,15 +269,15 @@ extension GenericMinimalHashableValue: CustomStringConvertible {
 }
 
 public var GenericMinimalHashableClass_timesEqualEqualWasCalled: Int = 0
-public var GenericMinimalHashableClass_timesHashValueWasCalled: Int = 0
+public var GenericMinimalHashableClass_timesHashIntoWasCalled: Int = 0
 
 public var GenericMinimalHashableClass_equalImpl =
   ResettableValue<(Any, Any) -> Bool>({ _, _ in
     fatalError("GenericMinimalHashableClass_equalImpl is not set yet")
   })
-public var GenericMinimalHashableClass_hashValueImpl =
-  ResettableValue<(Any) -> Int>({ _ in
-    fatalError("GenericMinimalHashableClass_hashValueImpl is not set yet")
+public var GenericMinimalHashableClass_hashIntoImpl =
+  ResettableValue<(Any, inout _Hasher) -> Void>({ _ in
+    fatalError("GenericMinimalHashableClass_hashIntoImpl is not set yet")
   })
 
 /// A type that conforms only to `Equatable` and `Hashable`.
@@ -289,8 +307,14 @@ public class GenericMinimalHashableClass<Wrapped> : Equatable, Hashable {
   }
 
   public var hashValue: Int {
-    GenericMinimalHashableClass_timesHashValueWasCalled += 1
-    return GenericMinimalHashableClass_hashValueImpl.value(value)
+    var hasher = _Hasher()
+    hasher.combine(self)
+    return hasher.finalize()
+  }
+
+  public func _hash(into hasher: inout _Hasher) {
+    GenericMinimalHashableClass_timesHashIntoWasCalled += 1
+    GenericMinimalHashableClass_hashIntoImpl.value(value, &hasher)
   }
 }
 

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -2397,24 +2397,55 @@ public func checkEquatable<T : Equatable>(
   checkEquatable(
     [lhs, rhs],
     oracle: { expectedEqual || $0 == $1 }, message(),
-    stackTrace: stackTrace.pushIf(showFrame, file: file, line: line), showFrame: false)
+    stackTrace: stackTrace.pushIf(showFrame, file: file, line: line),
+    showFrame: false)
+}
+
+internal func hash<H: Hashable>(_ value: H, seed: Int? = nil) -> Int {
+  var hasher = _Hasher()
+  if let seed = seed {
+    hasher.combine(seed)
+  }
+  hasher.combine(value)
+  return hasher.finalize()
+}
+
+/// Test that the elements of `instances` satisfy the semantic requirements of
+/// `Hashable`, using `equalityOracle` to generate equality and hashing
+/// expectations from pairs of positions in `instances`.
+public func checkHashable<Instances: Collection>(
+  _ instances: Instances,
+  equalityOracle: (Instances.Index, Instances.Index) -> Bool,
+  allowBrokenTransitivity: Bool = false,
+  _ message: @autoclosure () -> String = "",
+  stackTrace: SourceLocStack = SourceLocStack(),
+  showFrame: Bool = true,
+  file: String = #file, line: UInt = #line
+) where Instances.Iterator.Element: Hashable {
+  checkHashable(
+    instances,
+    equalityOracle: equalityOracle,
+    hashEqualityOracle: equalityOracle,
+    allowBrokenTransitivity: allowBrokenTransitivity,
+    stackTrace: stackTrace.pushIf(showFrame, file: file, line: line),
+    showFrame: false)
 }
 
 /// Test that the elements of `instances` satisfy the semantic
 /// requirements of `Hashable`, using `equalityOracle` to generate
-/// equality expectations from pairs of positions in `instances`.
-public func checkHashable<Instances : Collection>(
+/// equality expectations from pairs of positions in `instances`,
+/// and `hashEqualityOracle` to do the same for hashing.
+public func checkHashable<Instances: Collection>(
   _ instances: Instances,
   equalityOracle: (Instances.Index, Instances.Index) -> Bool,
+  hashEqualityOracle: (Instances.Index, Instances.Index) -> Bool,
   allowBrokenTransitivity: Bool = false,
-
   _ message: @autoclosure () -> String = "",
   stackTrace: SourceLocStack = SourceLocStack(),
   showFrame: Bool = true,
   file: String = #file, line: UInt = #line
 ) where
   Instances.Iterator.Element : Hashable {
-
   checkEquatable(
     instances,
     oracle: equalityOracle,
@@ -2426,11 +2457,51 @@ public func checkHashable<Instances : Collection>(
     let x = instances[i]
     for j in instances.indices {
       let y = instances[j]
+      let predicted = hashEqualityOracle(i, j)
+      expectEqual(
+        predicted, hashEqualityOracle(j, i),
+        "bad hash oracle: broken symmetry between indices \(i), \(j)",
+        stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
       if x == y {
+        expectTrue(
+          predicted,
+          """
+          bad hash oracle: equality must imply hash equality
+          lhs (at index \(i)): \(x)
+          rhs (at index \(j)): \(y)
+          """,
+          stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
+      }
+      if predicted {
+        expectEqual(
+          hash(x), hash(y),
+          """
+          hash(into:) expected to match, found to differ
+          lhs (at index \(i)): \(x)
+          rhs (at index \(j)): \(y)
+          """,
+          stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
         expectEqual(
           x.hashValue, y.hashValue,
-          "lhs (at index \(i)): \(x)\nrhs (at index \(j)): \(y)",
-            stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
+          """
+          hashValue expected to match, found to differ
+          lhs (at index \(i)): \(x)
+          rhs (at index \(j)): \(y)
+          """,
+          stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
+      } else {
+        // Try a few different seeds; at least one of them should discriminate
+        // between the hashes. It is extremely unlikely this check will fail
+        // all ten attempts, unless the type's hash encoding is not unique,
+        // or unless the hash equality oracle is wrong.
+        expectTrue(
+          (0..<10).contains { hash(x, seed: $0) != hash(y, seed: $0) },
+          """
+          _hash(into:) expected to differ, found to match
+          lhs (at index \(i)): \(x)
+          rhs (at index \(j)): \(y)
+          """,
+          stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
       }
     }
   }

--- a/validation-test/stdlib/AnyHashable.swift.gyb
+++ b/validation-test/stdlib/AnyHashable.swift.gyb
@@ -175,7 +175,13 @@ AnyHashableTests.test("AnyHashable(mixed minimal hashables)/Hashable") {
 %   end
 % end
 
-  checkHashable(xs, equalityOracle: { $0 / 2 == $1 / 2 })
+  checkHashable(
+    xs,
+    equalityOracle: { $0 / 2 == $1 / 2 },
+    // FIXME: Types that hash the same way will produce hash collisions when
+    // converted to AnyHashable. Arguably, the type id should be used as a hash
+    // discriminator.
+    hashEqualityOracle: { $0 / 2 % 6 == $1 / 2 % 6 })
 }
 
 % for (kw, name) in [
@@ -575,18 +581,27 @@ let interestingBitVectorArrays: [[UInt8]] = [
 AnyHashableTests.test("AnyHashable(CFBitVector)/Hashable, .base") {
   let bitVectors: [CFBitVector] =
     interestingBitVectorArrays.map(CFBitVector.makeImmutable)
+  let hashEqualityOracle: (Int, Int) -> Bool = {
+    // CFBitVector returns its count as the hash.
+    interestingBitVectorArrays[$0].count == interestingBitVectorArrays[$1].count
+  }
   let arrays = bitVectors.map { $0.asArray }
   func isEq(_ lhs: [[UInt8]], _ rhs: [[UInt8]]) -> Bool {
     return zip(lhs, rhs).map { $0 == $1 }.reduce(true, { $0 && $1 })
   }
   expectEqualTest(interestingBitVectorArrays, arrays, sameValue: isEq)
-  checkHashable(bitVectors, equalityOracle: { $0 == $1 })
+  checkHashable(
+    bitVectors,
+    equalityOracle: { $0 == $1 },
+    hashEqualityOracle: hashEqualityOracle)
 
   do {
     expectEqual(.foreignClass, SwiftRuntime.metadataKind(of: bitVectors.first!))
 
     let anyHashables = bitVectors.map(AnyHashable.init)
-    checkHashable(anyHashables, equalityOracle: { $0 == $1 })
+    checkHashable(anyHashables,
+      equalityOracle: { $0 == $1 },
+      hashEqualityOracle: hashEqualityOracle)
 
     let v = anyHashables.first!.base
     expectTrue(type(of: v) is CFBitVector.Type)
@@ -600,7 +615,9 @@ AnyHashableTests.test("AnyHashable(CFBitVector)/Hashable, .base") {
       SwiftRuntime.metadataKind(of: bitVectorsAsAnyObjects.first!))
 
     let anyHashables = bitVectorsAsAnyObjects.map(AnyHashable.init)
-    checkHashable(anyHashables, equalityOracle: { $0 == $1 })
+    checkHashable(anyHashables,
+      equalityOracle: { $0 == $1 },
+      hashEqualityOracle: hashEqualityOracle)
 
     let v = anyHashables.first!.base
     expectTrue(type(of: v) is CFBitVector.Type)
@@ -612,12 +629,19 @@ AnyHashableTests.test("AnyHashable(CFMutableBitVector)/Hashable, .base") {
   // CFBitVector.
   let bitVectors: [CFMutableBitVector] =
     interestingBitVectorArrays.map(CFMutableBitVector.makeMutable)
+  let hashEqualityOracle: (Int, Int) -> Bool = {
+    // CFBitVector returns its count as the hash.
+    interestingBitVectorArrays[$0].count == interestingBitVectorArrays[$1].count
+  }
   let arrays = bitVectors.map { $0.asArray }
   func isEq(_ lhs: [[UInt8]], _ rhs: [[UInt8]]) -> Bool {
     return zip(lhs, rhs).map { $0 == $1 }.reduce(true, { $0 && $1 })
   }
   expectEqualTest(interestingBitVectorArrays, arrays, sameValue: isEq)
-  checkHashable(bitVectors, equalityOracle: { $0 == $1 })
+  checkHashable(
+    bitVectors,
+    equalityOracle: { $0 == $1 },
+    hashEqualityOracle: hashEqualityOracle)
 
   do {
     expectEqual(
@@ -625,7 +649,10 @@ AnyHashableTests.test("AnyHashable(CFMutableBitVector)/Hashable, .base") {
       SwiftRuntime.metadataKind(of: bitVectors.first!))
 
     let anyHashables = bitVectors.map(AnyHashable.init)
-    checkHashable(anyHashables, equalityOracle: { $0 == $1 })
+    checkHashable(
+      anyHashables,
+      equalityOracle: { $0 == $1 },
+      hashEqualityOracle: hashEqualityOracle)
 
     let v = anyHashables.first!.base
     expectTrue(type(of: v) is CFMutableBitVector.Type)
@@ -634,14 +661,20 @@ AnyHashableTests.test("AnyHashable(CFMutableBitVector)/Hashable, .base") {
     let bitVectorsAsAnyObjects: [NSObject] = bitVectors.map {
       ($0 as AnyObject) as! NSObject
     }
-    checkHashable(bitVectorsAsAnyObjects, equalityOracle: { $0 == $1 })
+    checkHashable(
+      bitVectorsAsAnyObjects,
+      equalityOracle: { $0 == $1 },
+      hashEqualityOracle: hashEqualityOracle)
 
     expectEqual(
       .objCClassWrapper,
       SwiftRuntime.metadataKind(of: bitVectorsAsAnyObjects.first!))
 
     let anyHashables = bitVectorsAsAnyObjects.map(AnyHashable.init)
-    checkHashable(anyHashables, equalityOracle: { $0 == $1 })
+    checkHashable(
+      anyHashables,
+      equalityOracle: { $0 == $1 },
+      hashEqualityOracle: hashEqualityOracle)
 
     let v = anyHashables.first!.base
     expectTrue(type(of: v) is CFMutableBitVector.Type)
@@ -717,10 +750,14 @@ AnyHashableTests.test("AnyHashable(MinimalHashableRCSwiftError)/Hashable") {
     .caseC(LifetimeTracked(2)), .caseC(LifetimeTracked(2)),
   ]
   expectEqual(.enum, SwiftRuntime.metadataKind(of: xs.first!))
-  checkHashable(xs, equalityOracle: { $0 / 2 == $1 / 2 })
+  checkHashable(
+    xs,
+    equalityOracle: { $0 / 2 == $1 / 2 },
+    hashEqualityOracle: { $0 / 4 == $1 / 4 })
   checkHashable(
     xs.map(AnyHashable.init),
-    equalityOracle: { $0 / 2 == $1 / 2 })
+    equalityOracle: { $0 / 2 == $1 / 2 },
+    hashEqualityOracle: { $0 / 4 == $1 / 4 })
 }
 
 AnyHashableTests.test("AnyHashable(MinimalHashableRCSwiftError).base") {
@@ -763,8 +800,16 @@ AnyHashableTests.test("AnyHashable(Wrappers)/Hashable") {
     return lhs == rhs
   }
 
-  checkHashable(values, equalityOracle: equalityOracle,
-                allowBrokenTransitivity: true)
+  func hashEqualityOracle(_ lhs: Int, _ rhs: Int) -> Bool {
+    // Elements in [0, 3] hash the same, as do elements in [4, 7].
+    return lhs / 4 == rhs / 4
+  }
+
+  checkHashable(
+    values,
+    equalityOracle: equalityOracle,
+    hashEqualityOracle: hashEqualityOracle,
+    allowBrokenTransitivity: true)
 }
 
 AnyHashableTests.test("AnyHashable(Set)/Hashable") {
@@ -789,8 +834,10 @@ AnyHashableTests.test("AnyHashable(Set)/Hashable") {
     }
   }
 
-  checkHashable(values, equalityOracle: equalityOracle,
-                allowBrokenTransitivity: true)
+  checkHashable(
+    values,
+    equalityOracle: equalityOracle,
+    allowBrokenTransitivity: true)
 }
 
 AnyHashableTests.test("AnyHashable(Array)/Hashable") {
@@ -902,6 +949,12 @@ AnyHashableTests.test("AnyHashable(_SwiftNativeNSError(MinimalHashableRCSwiftErr
     .caseC(LifetimeTracked(1)), .caseC(LifetimeTracked(1)),
     .caseC(LifetimeTracked(2)), .caseC(LifetimeTracked(2)),
   ]
+  checkHashable(
+    swiftErrors,
+    equalityOracle: { $0 / 2 == $1 / 2 },
+    hashEqualityOracle: { $0 / 4 == $1 / 4 },
+    allowBrokenTransitivity: false)
+
   let nsErrors: [NSError] = swiftErrors.flatMap {
     swiftError -> [NSError] in
     let bridgedNSError = swiftError as NSError
@@ -938,16 +991,23 @@ AnyHashableTests.test("AnyHashable(_SwiftNativeNSError(MinimalHashableRCSwiftErr
     return false
   }
 
+  func hashEqualityOracle(_ lhs: Int, _ rhs: Int) -> Bool {
+    // Every NSError that has the same domain and code hash the same way.
+    return lhs / 8 == rhs / 8
+  }
+
   // FIXME: transitivity is broken because pure `NSError`s can compare equal to
   // Swift errors with payloads just based on the domain and code, and Swift
   // errors with payloads don't compare equal when payloads differ.
   checkHashable(
     nsErrors,
     equalityOracle: equalityOracle,
+    hashEqualityOracle: hashEqualityOracle,
     allowBrokenTransitivity: true)
   checkHashable(
     nsErrors.map(AnyHashable.init),
     equalityOracle: equalityOracle,
+    hashEqualityOracle: hashEqualityOracle,
     allowBrokenTransitivity: true)
 
   // FIXME(id-as-any): run `checkHashable` on an array of mixed

--- a/validation-test/stdlib/AnyHashable.swift.gyb
+++ b/validation-test/stdlib/AnyHashable.swift.gyb
@@ -58,7 +58,7 @@ import Foundation
 let AnyHashableTests = TestSuite("AnyHashableTests")
 
 AnyHashableTests.test("CustomStringConvertible, CustomDebugStringConvertible, CustomReflectable") {
-  var v = AnyHashable(CustomPrintableValue(1))
+  let v = AnyHashable(CustomPrintableValue(1))
   expectPrinted("(value: 1).description", v)
   expectDebugPrinted("AnyHashable((value: 1).debugDescription)", v)
   expectDumped(
@@ -117,8 +117,8 @@ AnyHashableTests.test("AnyHashable(${wrapped}<OpaqueValue<Int>>)/Hashable") {
   ${wrapped}_equalImpl.value = {
     ($0 as! ${payload}).value == ($1 as! ${payload}).value
   }
-  ${wrapped}_hashValueImpl.value = {
-    ($0 as! ${payload}).value
+  ${wrapped}_hashIntoImpl.value = {
+    $1.combine(($0 as! ${payload}).value)
   }
   let xs = (0...5).flatMap {
     [ ${wrapped}(${payload}($0), identity: 0),
@@ -142,7 +142,7 @@ AnyHashableTests.test("AnyHashable(mixed minimal hashables)/Hashable") {
   var xs: [AnyHashable] = []
 
 % for wrapped in ['MinimalHashableValue', 'MinimalHashableClass']:
-  xs += (0...5).flatMap {
+  xs += (0..<6).flatMap {
     [ ${wrapped}($0, identity: 0),
       ${wrapped}($0, identity: 1) ].map(AnyHashable.init)
   }
@@ -157,18 +157,18 @@ AnyHashableTests.test("AnyHashable(mixed minimal hashables)/Hashable") {
     }
     return (lhs as! LifetimeTracked) == (rhs as! LifetimeTracked)
   }
-  ${wrapped}_hashValueImpl.value = {
-    payload in
+  ${wrapped}_hashIntoImpl.value = { payload, hasher in
     if let x = payload as? OpaqueValue<Int> {
-      return x.value
+      hasher.combine(x.value)
+      return
     }
-    return (payload as! LifetimeTracked).value
+    hasher.combine((payload as! LifetimeTracked).value)
   }
 % end
 
 % for wrapped in ['GenericMinimalHashableValue', 'GenericMinimalHashableClass']:
 %   for payload in [ 'OpaqueValue<Int>', 'LifetimeTracked' ]:
-  xs += (0...5).flatMap {
+  xs += (0..<6).flatMap {
     [ ${wrapped}(${payload}($0), identity: 0),
       ${wrapped}(${payload}($0), identity: 1) ].map(AnyHashable.init)
   }
@@ -311,8 +311,8 @@ AnyHashableTests.test("AnyHashable(${genericWrapped}<${payload}>)/Hashable") {
   GenericMinimalHashableValue_equalImpl.value = {
     ($0 as! ${payload}).value == ($1 as! ${payload}).value
   }
-  GenericMinimalHashableValue_hashValueImpl.value = {
-    ($0 as! ${payload}).value
+  GenericMinimalHashableValue_hashIntoImpl.value = { v, hasher in
+    hasher.combine((v as! ${payload}).value)
   }
   let xs = (-2...2).flatMap {
     [ ${genericWrapped}(
@@ -379,8 +379,8 @@ AnyHashableTests.test("AnyHashable containing values with recursive custom repre
   GenericMinimalHashableValue_equalImpl.value = {
     ($0 as! ${payload}).value == ($1 as! ${payload}).value
   }
-  GenericMinimalHashableValue_hashValueImpl.value = {
-    ($0 as! ${payload}).value
+  GenericMinimalHashableValue_hashIntoImpl.value = { v, hasher in
+    hasher.combine((v as! ${payload}).value)
   }
   // If the custom representation has its own custom representation,
   // we ignore it.

--- a/validation-test/stdlib/AnyHashable.swift.gyb
+++ b/validation-test/stdlib/AnyHashable.swift.gyb
@@ -443,18 +443,20 @@ class ${hashable_base.full_name} : ${', '.join([b.full_name for b in bases])} {
   init(_ value: Int) {
     self.value = value
   }
-  ${'override' if 'ObjC' in prefix else ''} var hashValue: Int {
+%   if 'ObjC' in prefix:
+  override var hash: Int {
     return value
   }
-%   if 'ObjC' in prefix:
   override func isEqual(_ object: Any?) -> Bool {
     guard let rhs = object as? ${hashable_base.full_name} else {
       return false
     }
     return self.value == rhs.value
   }
-%   end
-%   if not 'ObjC' in prefix:
+%   else:
+  var hashValue: Int {
+    return value
+  }
   static func == ${hashable_base.generic_parameters_decl} (
     lhs: ${hashable_base.full_name},
     rhs: ${hashable_base.full_name}

--- a/validation-test/stdlib/CollectionType.swift.gyb
+++ b/validation-test/stdlib/CollectionType.swift.gyb
@@ -659,7 +659,7 @@ CollectionTypeTests.test("Set<T>.find/CustomImplementation/${dispatch}") {
     let s = Set<MinimalHashableValue>(
       test.sequence.map { MinimalHashableValue($0.value) })
     MinimalHashableValue.timesEqualEqualWasCalled = 0
-    MinimalHashableValue.timesHashValueWasCalled = 0
+    MinimalHashableValue.timesHashIntoWasCalled = 0
     expectEqual(
       test.expected
         .map { _ in MinimalHashableValue(test.element.value) },
@@ -671,11 +671,11 @@ CollectionTypeTests.test("Set<T>.find/CustomImplementation/${dispatch}") {
         0, MinimalHashableValue.timesEqualEqualWasCalled,
         stackTrace: SourceLocStack().with(test.loc))
       expectEqual(
-        0, MinimalHashableValue.timesHashValueWasCalled,
+        0, MinimalHashableValue.timesHashIntoWasCalled,
         stackTrace: SourceLocStack().with(test.loc))
     } else {
       expectNotEqual(
-        0, MinimalHashableValue.timesHashValueWasCalled,
+        0, MinimalHashableValue.timesHashIntoWasCalled,
         stackTrace: SourceLocStack().with(test.loc))
     }
     if test.expected != nil {

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -274,13 +274,13 @@ DictionaryTestSuite.test("COW.Fast.SubscriptWithKeyDoesNotReallocate")
   do {
     var d2: [MinimalHashableValue : OpaqueValue<Int>] = [:]
     MinimalHashableValue.timesEqualEqualWasCalled = 0
-    MinimalHashableValue.timesHashValueWasCalled = 0
+    MinimalHashableValue.timesHashIntoWasCalled = 0
     expectNil(d2[MinimalHashableValue(42)])
 
     // If the dictionary is empty, we shouldn't be computing the hash value of
     // the provided key.
     expectEqual(0, MinimalHashableValue.timesEqualEqualWasCalled)
-    expectEqual(0, MinimalHashableValue.timesHashValueWasCalled)
+    expectEqual(0, MinimalHashableValue.timesHashIntoWasCalled)
   }
 }
 
@@ -330,14 +330,14 @@ DictionaryTestSuite.test("COW.Slow.SubscriptWithKeyDoesNotReallocate")
   do {
     var d2: [MinimalHashableClass : OpaqueValue<Int>] = [:]
     MinimalHashableClass.timesEqualEqualWasCalled = 0
-    MinimalHashableClass.timesHashValueWasCalled = 0
+    MinimalHashableClass.timesHashIntoWasCalled = 0
 
     expectNil(d2[MinimalHashableClass(42)])
 
     // If the dictionary is empty, we shouldn't be computing the hash value of
     // the provided key.
     expectEqual(0, MinimalHashableClass.timesEqualEqualWasCalled)
-    expectEqual(0, MinimalHashableClass.timesHashValueWasCalled)
+    expectEqual(0, MinimalHashableClass.timesHashIntoWasCalled)
   }
 }
 
@@ -864,13 +864,13 @@ DictionaryTestSuite.test("COW.Fast.IndexForKeyDoesNotReallocate") {
   do {
     var d2: [MinimalHashableValue : OpaqueValue<Int>] = [:]
     MinimalHashableValue.timesEqualEqualWasCalled = 0
-    MinimalHashableValue.timesHashValueWasCalled = 0
+    MinimalHashableValue.timesHashIntoWasCalled = 0
     expectNil(d2.index(forKey: MinimalHashableValue(42)))
 
     // If the dictionary is empty, we shouldn't be computing the hash value of
     // the provided key.
     expectEqual(0, MinimalHashableValue.timesEqualEqualWasCalled)
-    expectEqual(0, MinimalHashableValue.timesHashValueWasCalled)
+    expectEqual(0, MinimalHashableValue.timesHashIntoWasCalled)
   }
 }
 
@@ -901,13 +901,13 @@ DictionaryTestSuite.test("COW.Slow.IndexForKeyDoesNotReallocate") {
   do {
     var d2: [MinimalHashableClass : OpaqueValue<Int>] = [:]
     MinimalHashableClass.timesEqualEqualWasCalled = 0
-    MinimalHashableClass.timesHashValueWasCalled = 0
+    MinimalHashableClass.timesHashIntoWasCalled = 0
     expectNil(d2.index(forKey: MinimalHashableClass(42)))
 
     // If the dictionary is empty, we shouldn't be computing the hash value of
     // the provided key.
     expectEqual(0, MinimalHashableClass.timesEqualEqualWasCalled)
-    expectEqual(0, MinimalHashableClass.timesHashValueWasCalled)
+    expectEqual(0, MinimalHashableClass.timesHashIntoWasCalled)
   }
 }
 
@@ -1713,13 +1713,13 @@ DictionaryTestSuite.test("mapValues(_:)") {
       uniqueKeysWithValues: d1.lazy.map { (MinimalHashableValue($0), $1) })
     expectEqual(d3.count, 3)
     MinimalHashableValue.timesEqualEqualWasCalled = 0
-    MinimalHashableValue.timesHashValueWasCalled = 0
+    MinimalHashableValue.timesHashIntoWasCalled = 0
 
     // Calling mapValues shouldn't ever recalculate any hashes.
     let d4 = d3.mapValues(String.init)
     expectEqual(d4.count, d3.count)
     expectEqual(0, MinimalHashableValue.timesEqualEqualWasCalled)
-    expectEqual(0, MinimalHashableValue.timesHashValueWasCalled)
+    expectEqual(0, MinimalHashableValue.timesHashIntoWasCalled)
   }
 }
 

--- a/validation-test/stdlib/ObjectiveC.swift
+++ b/validation-test/stdlib/ObjectiveC.swift
@@ -10,6 +10,9 @@ import StdlibUnittest
 var ObjectiveCTests = TestSuite("ObjectiveC")
 
 class NSObjectWithCustomHashable : NSObject {
+  var _value: Int
+  var _hashValue: Int
+
   init(value: Int, hashValue: Int) {
     self._value = value
     self._hashValue = hashValue
@@ -20,24 +23,22 @@ class NSObjectWithCustomHashable : NSObject {
     return self._value == other_._value
   }
 
-  override var hashValue: Int {
+  override var hash: Int {
     return _hashValue
   }
-
-  var _value: Int
-  var _hashValue: Int
 }
 
 ObjectiveCTests.test("NSObject/Hashable") {
-  let instances: [(order: Int, object: NSObject)] = [
-    (10, NSObjectWithCustomHashable(value: 10, hashValue: 100)),
-    (10, NSObjectWithCustomHashable(value: 10, hashValue: 100)),
-    (20, NSObjectWithCustomHashable(value: 20, hashValue: 100)),
-    (30, NSObjectWithCustomHashable(value: 30, hashValue: 300)),
+  let instances: [(order: Int, hashOrder: Int, object: NSObject)] = [
+    (10, 1, NSObjectWithCustomHashable(value: 10, hashValue: 100)),
+    (10, 1, NSObjectWithCustomHashable(value: 10, hashValue: 100)),
+    (20, 1, NSObjectWithCustomHashable(value: 20, hashValue: 100)),
+    (30, 2, NSObjectWithCustomHashable(value: 30, hashValue: 300)),
   ]
   checkHashable(
     instances.map { $0.object },
-    equalityOracle: { instances[$0].order == instances[$1].order })
+    equalityOracle: { instances[$0].order == instances[$1].order },
+    hashEqualityOracle: { instances[$0].hashOrder == instances[$1].hashOrder })
 }
 
 runAllTests()

--- a/validation-test/stdlib/Prototypes/PersistentVector.swift.gyb
+++ b/validation-test/stdlib/Prototypes/PersistentVector.swift.gyb
@@ -100,6 +100,13 @@ Memory layout:
 import Swift
 import SwiftShims
 
+// This prototype is only partially implemented, and it relies on specific hash
+// values. To keep it working, define an alternative hashing interface emulating
+// pre-SE-0206 Hashable.
+protocol LegacyHashable: Equatable {
+  var legacyHashValue: Int { get }
+}
+
 //
 // Standard library extras
 //
@@ -252,7 +259,7 @@ struct _PVSparseVectorNodeLayoutParameters {
   var keyCount: Int
 }
 
-struct _PVSparseVectorNodePointer<Key : Hashable, Value>
+struct _PVSparseVectorNodePointer<Key : LegacyHashable, Value>
   : CustomReflectable {
   typealias _Self = _PVSparseVectorNodePointer
 
@@ -917,7 +924,7 @@ struct _PVSparseVectorNodePointer<Key : Hashable, Value>
   }
 }
 
-struct _PVArrayNodePointer<Key : Hashable, Value>
+struct _PVArrayNodePointer<Key : LegacyHashable, Value>
   : CustomReflectable {
 
   typealias _Self = _PVArrayNodePointer
@@ -1158,7 +1165,7 @@ struct _PVCollisionNodePointerLayoutParameters {
   var keyCount: Int
 }
 
-struct _PVCollisionNodePointer<Key : Hashable, Value>
+struct _PVCollisionNodePointer<Key : LegacyHashable, Value>
   : CustomReflectable {
 
   typealias _Self = _PVCollisionNodePointer
@@ -1461,7 +1468,7 @@ struct _PVCollisionNodePointer<Key : Hashable, Value>
   }
 }
 
-struct _PVAnyNodePointer<Key : Hashable, Value>
+struct _PVAnyNodePointer<Key : LegacyHashable, Value>
   : CustomReflectable, Equatable {
 
   let taggedPointer: UnsafeMutableRawPointer
@@ -1654,7 +1661,8 @@ func == <Key, Value> (
   return lhs.taggedPointer == rhs.taggedPointer
 }
 
-final internal class _NativePVDictionaryStorageRef<Key : Hashable, Value> {
+final internal
+class _NativePVDictionaryStorageRef<Key : LegacyHashable, Value> {
 
   var _rootNode: _PVAnyNodePointer<Key, Value>?
   var _count: Int
@@ -1675,7 +1683,7 @@ final internal class _NativePVDictionaryStorageRef<Key : Hashable, Value> {
   }
 }
 
-struct _NativePVDictionaryStorage<Key : Hashable, Value> {
+struct _NativePVDictionaryStorage<Key : LegacyHashable, Value> {
   var _storageRef: _NativePVDictionaryStorageRef<Key, Value>
 
   var _rootNode: _PVAnyNodePointer<Key, Value>? {
@@ -1715,13 +1723,13 @@ struct _NativePVDictionaryStorage<Key : Hashable, Value> {
 
   func assertingGet(key: Key) -> Value {
     let valuePointer = _rootNode!.unsafeMaybeGet(
-      key: key, hashValue: key.hashValue, depth: 0)
+      key: key, hashValue: key.legacyHashValue, depth: 0)
     return valuePointer!.pointee
   }
 
   func maybeGet(key: Key) -> Value? {
     let valuePointer = _rootNode?.unsafeMaybeGet(
-      key: key, hashValue: key.hashValue, depth: 0)
+      key: key, hashValue: key.legacyHashValue, depth: 0)
     return valuePointer.map { $0.pointee }
   }
 
@@ -1748,7 +1756,7 @@ struct _NativePVDictionaryStorage<Key : Hashable, Value> {
   }
 
   mutating func updateValue(_ value: Value, forKey key: Key) -> Value? {
-    let hashValue = key.hashValue
+    let hashValue = key.legacyHashValue
     guard let oldRootNode = _rootNode else {
       let layout = _PVSparseVectorNodeLayoutParameters(
         childNodeCount: 0,
@@ -1787,7 +1795,7 @@ struct _NativePVDictionaryStorage<Key : Hashable, Value> {
     guard let oldRootNode = _rootNode else {
       return nil
     }
-    let hashValue = key.hashValue
+    let hashValue = key.legacyHashValue
     let isUnique = isKnownUniquelyReferenced(&_storageRef)
     let (oldValue, newRootNode) = oldRootNode.removeValue(
       forKey: key,
@@ -1856,6 +1864,12 @@ Bitmap.test("setBitIndices") {
   bm[7] = true
   bm[31] = true
   expectEqualSequence([ 0, 4, 5, 7, 31 ], Array(bm.setBitIndices))
+}
+
+extension MinimalHashableValue: LegacyHashable {
+  var legacyHashValue: Int {
+    return self.value % 10000
+  }
 }
 
 var PersistentVectorTests = TestSuite("PersistentVector")
@@ -1991,10 +2005,6 @@ func testDictionary(
 ) {
   if debugDictionaryTests {
     print("---------------------------------------")
-  }
-
-  MinimalHashableValue.hashValueImpl.value = {
-    return $0 % 10000
   }
 
   typealias MyDictionary = _NativePVDictionaryStorage<

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -573,7 +573,7 @@ SequenceTypeTests.test("Set<T>.contains/CustomImplementation/${dispatch}") {
     let s = Set<MinimalHashableValue>(
       test.sequence.map { MinimalHashableValue($0.value) })
     MinimalHashableValue.timesEqualEqualWasCalled = 0
-    MinimalHashableValue.timesHashValueWasCalled = 0
+    MinimalHashableValue.timesHashIntoWasCalled = 0
     expectEqual(
       test.expected != nil,
       call${dispatch}Contains(s, MinimalHashableValue(test.element.value)),
@@ -583,11 +583,11 @@ SequenceTypeTests.test("Set<T>.contains/CustomImplementation/${dispatch}") {
         0, MinimalHashableValue.timesEqualEqualWasCalled,
         stackTrace: SourceLocStack().with(test.loc))
       expectEqual(
-        0, MinimalHashableValue.timesHashValueWasCalled,
+        0, MinimalHashableValue.timesHashIntoWasCalled,
         stackTrace: SourceLocStack().with(test.loc))
     } else {
       expectNotEqual(
-        0, MinimalHashableValue.timesHashValueWasCalled,
+        0, MinimalHashableValue.timesHashIntoWasCalled,
         stackTrace: SourceLocStack().with(test.loc))
     }
     if test.expected != nil {

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -442,13 +442,13 @@ SetTestSuite.test("COW.Fast.ContainsDoesNotReallocate") {
   do {
     var s2: Set<MinimalHashableValue> = []
     MinimalHashableValue.timesEqualEqualWasCalled = 0
-    MinimalHashableValue.timesHashValueWasCalled = 0
+    MinimalHashableValue.timesHashIntoWasCalled = 0
     expectFalse(s2.contains(MinimalHashableValue(42)))
 
     // If the set is empty, we shouldn't be computing the hash value of the
     // provided key.
     expectEqual(0, MinimalHashableValue.timesEqualEqualWasCalled)
-    expectEqual(0, MinimalHashableValue.timesHashValueWasCalled)
+    expectEqual(0, MinimalHashableValue.timesHashIntoWasCalled)
   }
 }
 
@@ -488,13 +488,13 @@ SetTestSuite.test("COW.Slow.ContainsDoesNotReallocate")
   do {
     var s2: Set<MinimalHashableClass> = []
     MinimalHashableClass.timesEqualEqualWasCalled = 0
-    MinimalHashableClass.timesHashValueWasCalled = 0
+    MinimalHashableClass.timesHashIntoWasCalled = 0
     expectFalse(s2.contains(MinimalHashableClass(42)))
 
     // If the set is empty, we shouldn't be computing the hash value of the
     // provided key.
     expectEqual(0, MinimalHashableClass.timesEqualEqualWasCalled)
-    expectEqual(0, MinimalHashableClass.timesHashValueWasCalled)
+    expectEqual(0, MinimalHashableClass.timesHashIntoWasCalled)
   }
 }
 
@@ -619,13 +619,13 @@ SetTestSuite.test("COW.Fast.IndexForMemberDoesNotReallocate") {
   do {
     var s2: Set<MinimalHashableValue> = []
     MinimalHashableValue.timesEqualEqualWasCalled = 0
-    MinimalHashableValue.timesHashValueWasCalled = 0
+    MinimalHashableValue.timesHashIntoWasCalled = 0
     expectNil(s2.index(of: MinimalHashableValue(42)))
 
     // If the set is empty, we shouldn't be computing the hash value of the
     // provided key.
     expectEqual(0, MinimalHashableValue.timesEqualEqualWasCalled)
-    expectEqual(0, MinimalHashableValue.timesHashValueWasCalled)
+    expectEqual(0, MinimalHashableValue.timesHashIntoWasCalled)
   }
 }
 
@@ -655,13 +655,13 @@ SetTestSuite.test("COW.Slow.IndexForMemberDoesNotReallocate") {
   do {
     var s2: Set<MinimalHashableClass> = []
     MinimalHashableClass.timesEqualEqualWasCalled = 0
-    MinimalHashableClass.timesHashValueWasCalled = 0
+    MinimalHashableClass.timesHashIntoWasCalled = 0
     expectNil(s2.index(of: MinimalHashableClass(42)))
 
     // If the set is empty, we shouldn't be computing the hash value of the
     // provided key.
     expectEqual(0, MinimalHashableClass.timesEqualEqualWasCalled)
-    expectEqual(0, MinimalHashableClass.timesHashValueWasCalled)
+    expectEqual(0, MinimalHashableClass.timesHashIntoWasCalled)
   }
 }
 


### PR DESCRIPTION
- Update `checkHashable` to verify that different values hash differently -- we can do this with `hash(into:)` because we can eliminate hash collisions by trying different seeds.
- Switch `MinimalHashable*` types to use `_hash(into:)` as the primary hashing interface.