### PR TITLE
 [AST] Make TypeBase::adjustSuperclassMemberDeclType() more robust.

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -3412,7 +3412,7 @@ Type TypeBase::adjustSuperclassMemberDeclType(const ValueDecl *baseDecl,
                                    genericMemberType->getExtInfo());
   }
 
-  auto type = memberType.subst(subs);
+  auto type = memberType.subst(subs, SubstFlags::UseErrorType);
 
   if (isa<AbstractFunctionDecl>(baseDecl)) {
     type = type->replaceSelfParameterType(this);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5331,6 +5331,7 @@ public:
         // Check whether the types are identical.
         auto parentDeclTy = owningTy->adjustSuperclassMemberDeclType(
             parentDecl, decl, parentDecl->getInterfaceType());
+        if (parentDeclTy->hasError()) continue;
         parentDeclTy = parentDeclTy->getUnlabeledType(TC.Context);
         if (method) {
           // For methods, strip off the 'Self' type.

--- a/validation-test/compiler_crashers_2_fixed/0123-rdar31164540.swift
+++ b/validation-test/compiler_crashers_2_fixed/0123-rdar31164540.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend -parse-stdlib -DBUILDING_OUTSIDE_STDLIB %s -emit-ir
+// RUN: not %target-swift-frontend -parse-stdlib -DBUILDING_OUTSIDE_STDLIB %s -emit-ir
 // REQUIRES: objc_interop
 
 //===----------------------------------------------------------------------===//

--- a/validation-test/compiler_crashers_2_fixed/0154-sr7457.swift
+++ b/validation-test/compiler_crashers_2_fixed/0154-sr7457.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend %s -emit-ir
+protocol Proto { }
+
+class Class {
+    func foo<A>(callback: (A) -> Void) where A: Proto {
+    }
+
+    func foo<A, B>(callback: (A, B) -> Void) where A: Proto, B: Proto {
+    }
+}
+
+class Child: Class {
+    override func foo<A>(callback: (A) -> Void) where A : Proto {
+    }
+}
+


### PR DESCRIPTION
When performing substitutions in this function, allow them to fail
more gracefully by producing error types. Fixes SR-7457 /
rdar://problem/39492060.
