### PR TITLE
[Conformance checking] Diagnose missing witnesses along "lazy" paths.

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4030,6 +4030,7 @@ void TypeChecker::checkConformanceRequirements(
   llvm::SetVector<ValueDecl *> globalMissingWitnesses;
   ConformanceChecker checker(*this, conformance, globalMissingWitnesses);
   checker.ensureRequirementsAreSatisfied(/*failUnsubstituted=*/true);
+  checker.diagnoseMissingWitnesses(MissingWitnessDiagnosisKind::ErrorFixIt);
 }
 
 /// Determine the score when trying to match two identifiers together.
@@ -4937,6 +4938,7 @@ void TypeChecker::resolveTypeWitness(
     checker.resolveTypeWitnesses();
   else
     checker.resolveSingleTypeWitness(assocType);
+  checker.diagnoseMissingWitnesses(MissingWitnessDiagnosisKind::ErrorFixIt);
 }
 
 void TypeChecker::resolveWitness(const NormalProtocolConformance *conformance,
@@ -4947,6 +4949,7 @@ void TypeChecker::resolveWitness(const NormalProtocolConformance *conformance,
                        const_cast<NormalProtocolConformance*>(conformance),
                        MissingWitnesses);
   checker.resolveSingleWitness(requirement);
+  checker.diagnoseMissingWitnesses(MissingWitnessDiagnosisKind::ErrorFixIt);
 }
 
 ValueDecl *TypeChecker::deriveProtocolRequirement(DeclContext *DC,

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -509,8 +509,7 @@ func testWeakVariable() {
 }
 
 class IncompleteProtocolAdopter : Incomplete, IncompleteOptional { // expected-error {{type 'IncompleteProtocolAdopter' cannot conform to protocol 'Incomplete' because it has requirements that cannot be satisfied}}
-      // expected-error@-1{{type 'IncompleteProtocolAdopter' does not conform to protocol 'Incomplete'}}
-  @objc func getObject() -> AnyObject { return self } // expected-note{{candidate has non-matching type '() -> AnyObject'}}
+  @objc func getObject() -> AnyObject { return self }
 }
 
 func testNullarySelectorPieces(_ obj: AnyObject) {

--- a/validation-test/compiler_crashers_2_fixed/0139-rdar36278079.swift
+++ b/validation-test/compiler_crashers_2_fixed/0139-rdar36278079.swift
@@ -1,0 +1,19 @@
+// RUN: not %target-swift-frontend -typecheck %s
+
+struct S {
+  // presence of a static instance seems to be
+  // necessary to cause this problem
+  static let s = S()
+}
+
+protocol P {
+  associatedtype T
+  init(t: T)
+}
+
+extension S: P {
+// Uncomment to stop assertion:
+//  init(t: Int) {
+//    self = S()
+//  }
+}

--- a/validation-test/compiler_crashers_2_fixed/0155-sr7364.swift
+++ b/validation-test/compiler_crashers_2_fixed/0155-sr7364.swift
@@ -1,0 +1,22 @@
+// RUN: not %target-swift-frontend %s -emit-ir
+
+
+public protocol E {
+	associatedtype F
+	
+	static func g(_: F) -> Self
+}
+
+internal enum CF {
+	case f
+}
+
+internal enum CE: E {
+	case f(CF)
+	
+	static func g(_ f: CF) -> CE {
+		return CE.f(f)
+	}
+	
+	static let cf = CE.g(.f)
+}


### PR DESCRIPTION
When lazily resolving witnesses, we would fail to diagnose missing
witnesses for which we had no specific diagnostic to give, leading to
AST verifier errors and crashes later on. Make sure we call the
operation to diagnose missing witnesses along these paths, too.

Fixes SR-7364 / rdar://problem/39239629 as well as the older
rdar://problem/36278079.