### PR TITLE
Disable test/stdlib/ErrorBridgedStatic.swift on no_asserts builds

### DIFF
--- a/test/stdlib/ErrorBridgedStatic.swift
+++ b/test/stdlib/ErrorBridgedStatic.swift
@@ -8,6 +8,9 @@
 // REQUIRES: objc_interop
 // REQUIRES: static_stdlib
 
+// rdar://39473208
+// REQUIRES: asserts
+
 import StdlibUnittest
 
 class Bar: Foo {


### PR DESCRIPTION
For some reason this test fails on the bots.
I could not reproduce the failure locally.

rdar://39473208