### PR TITLE
[4.2] [BatchMode] Avoid spurious warnings in sourcekitd and indexing

### DIFF
--- a/lib/Driver/FrontendUtil.cpp
+++ b/lib/Driver/FrontendUtil.cpp
@@ -34,6 +34,11 @@ swift::driver::createCompilerInvocation(ArrayRef<const char *> Argv,
   // frontend command.
   Args.push_back("-force-single-frontend-invocation");
 
+  // Explictly disable batch mode to avoid a spurious warning when combining
+  // -enable-batch-mode with -force-single-frontend-invocation.  This is an
+  // implementation detail.
+  Args.push_back("-disable-batch-mode");
+
   // Avoid using filelists
   std::string neverThreshold =
       std::to_string(Compilation::NEVER_USE_FILELIST);

--- a/test/Driver/batch_mode_with_WMO_or_index.swift
+++ b/test/Driver/batch_mode_with_WMO_or_index.swift
@@ -13,6 +13,12 @@
 // RUN: %FileCheck -check-prefix CHECK-INDEX %s <%t/stderr_batch_index
 // CHECK-INDEX: warning: ignoring '-enable-batch-mode' because '-index-file' was also specified
 //
+// The following test is verifying that -disable-batch-mode overrides an earlier
+// -enable-batch-mode and silences the warning about mixing batch mode with
+// -index-file. Tools that take an existing command line and add -index-file can
+// thus add -disable-batch-mode without having to otherwise interpret the
+// arguments.
+//
 // RUN: %swiftc_driver -disable-batch-mode -index-file  %S/../Inputs/empty.swift -### 2>%t/stderr_nobatch_index | %FileCheck %s
 // RUN: %swiftc_driver -enable-batch-mode -index-file  %S/../Inputs/empty.swift -disable-batch-mode -### 2>%t/stderr_batch_nobatch_index | %FileCheck %s
 // RUN: %FileCheck -allow-empty -check-prefix CHECK-INDEX-DISABLED %s <%t/stderr_nobatch_index

--- a/test/Driver/batch_mode_with_WMO_or_index.swift
+++ b/test/Driver/batch_mode_with_WMO_or_index.swift
@@ -13,6 +13,12 @@
 // RUN: %FileCheck -check-prefix CHECK-INDEX %s <%t/stderr_batch_index
 // CHECK-INDEX: warning: ignoring '-enable-batch-mode' because '-index-file' was also specified
 //
+// RUN: %swiftc_driver -disable-batch-mode -index-file  %S/../Inputs/empty.swift -### 2>%t/stderr_nobatch_index | %FileCheck %s
+// RUN: %swiftc_driver -enable-batch-mode -index-file  %S/../Inputs/empty.swift -disable-batch-mode -### 2>%t/stderr_batch_nobatch_index | %FileCheck %s
+// RUN: %FileCheck -allow-empty -check-prefix CHECK-INDEX-DISABLED %s <%t/stderr_nobatch_index
+// RUN: %FileCheck -allow-empty -check-prefix CHECK-INDEX-DISABLED %s <%t/stderr_batch_nobatch_index
+// CHECK-INDEX-DISABLED-NOT: warning
+//
 // This next one is a regression test for a specific failure in the past: wmo +
 // batch mode should not just result in wmo, but also preserve the num-threads
 // argument and (crucially) the resulting fact that the single wmo subprocess

--- a/test/Driver/createCompilerInvocation.swift
+++ b/test/Driver/createCompilerInvocation.swift
@@ -3,5 +3,7 @@
 // RUN: %swift-ide-test_plain -test-createCompilerInvocation -c %s %S/Input/main.swift %S/Input/lib.swift -module-name createCompilerInvocation -emit-module -emit-objc-header 2>&1
 // RUN: not %swift-ide-test_plain -test-createCompilerInvocation -typecheck %s -emit-module-path %t.swiftmodule 2>&1 | %FileCheck --check-prefix=CHECK-FAIL %s
 // RUN: not %swift-ide-test_plain -test-createCompilerInvocation -v 2>&1 | %FileCheck --check-prefix=CHECK-FAIL %s
+// RUN: %swift-ide-test_plain -test-createCompilerInvocation %s -enable-batch-mode 2>&1 | %FileCheck -allow-empty -check-prefix=CHECK-NOWARN %s
 
 // CHECK-FAIL: error: unable to create a CompilerInvocation
+// CHECK-NOWARN-NOT: warning

--- a/test/SourceKit/CompileNotifications/diagnostics.swift
+++ b/test/SourceKit/CompileNotifications/diagnostics.swift
@@ -64,3 +64,7 @@
 // INVALID_ARG_CLANG-NEXT:     key.severity: source.diagnostic.severity.warning,
 // INVALID_ARG_CLANG-NEXT:     key.offset: 0
 // INVALID_ARG_CLANG-NEXT:     key.description: "argument unused
+
+// Ignore the spurious -wmo + -enable-batch-mode warning.
+// RUN: %sourcekitd-test -req=track-compiles == -req=sema %s -- %s -enable-batch-mode | %FileCheck %s -check-prefix=NODIAGS
+// RUN: %sourcekitd-test -req=track-compiles == -req=complete -offset=0 %s -- %s -enable-batch-mode | %FileCheck %s -check-prefix=NODIAGS


### PR DESCRIPTION
Cherry-pick #16067 and #16074 

---

Explicitly disable batch mode in createCompilerInvocation, since it uses
-force-single-frontend-invocation. Previously we were getting spurious
warnings. Also add a test that -disable-batch-mode will allow commands
that use -index-file to avoid the same warning, since that is likely
what they want to do as well.

rdar://39581506