### PR TITLE
Foundation: resolve some warnings

### DIFF
--- a/stdlib/public/SDK/Foundation/JSONEncoder.swift
+++ b/stdlib/public/SDK/Foundation/JSONEncoder.swift
@@ -2374,7 +2374,7 @@ extension _JSONDecoder {
                                                                         debugDescription: "Invalid URL string."))
             }
 
-            return url as! T
+            return (url as! T)
         } else if type == Decimal.self || type == NSDecimalNumber.self {
             return try self.unbox(value, as: Decimal.self) as? T
         } else {

--- a/stdlib/public/SDK/Foundation/NSObject.swift
+++ b/stdlib/public/SDK/Foundation/NSObject.swift
@@ -130,12 +130,12 @@ func _bridgeStringToKeyPath(_ keyPath:String) -> AnyKeyPath? {
 
 public class NSKeyValueObservation : NSObject {
     
-    weak var object : NSObject?
-    let callback : (NSObject, NSKeyValueObservedChange<Any>) -> Void
-    let path : String
+    @nonobjc weak var object : NSObject?
+    @nonobjc let callback : (NSObject, NSKeyValueObservedChange<Any>) -> Void
+    @nonobjc let path : String
     
     //workaround for <rdar://problem/31640524> Erroneous (?) error when using bridging in the Foundation overlay
-    static var swizzler : NSKeyValueObservation? = {
+    @nonobjc static var swizzler : NSKeyValueObservation? = {
         let bridgeClass: AnyClass = NSKeyValueObservation.self
         let observeSel = #selector(NSObject.observeValue(forKeyPath:of:change:context:))
         let swapSel = #selector(NSKeyValueObservation._swizzle_me_observeValue(forKeyPath:of:change:context:))
@@ -157,7 +157,7 @@ public class NSKeyValueObservation : NSObject {
     }
     
     ///invalidate() will be called automatically when an NSKeyValueObservation is deinited
-    public func invalidate() {
+    @objc public func invalidate() {
         object?.removeObserver(self, forKeyPath: path, context: nil)
         object = nil
     }

--- a/stdlib/public/SDK/Foundation/NSStringAPI.swift
+++ b/stdlib/public/SDK/Foundation/NSStringAPI.swift
@@ -436,7 +436,6 @@ extension StringProtocol where Index == String.Index {
   // self can be a Substring so we need to subtract/add this offset when
   // passing _ns to the Foundation APIs. Will be 0 if self is String.
   @inlinable
-  @usableFromInline
   internal var _substringOffset: Int {
     return self.startIndex.encodedOffset
   }
@@ -448,7 +447,6 @@ extension StringProtocol where Index == String.Index {
   }
 
   @inlinable
-  @usableFromInline
   internal func _toRelativeNSRange(_ r: Range<String.Index>) -> NSRange {
     return NSRange(
       location: r.lowerBound.encodedOffset - _substringOffset,


### PR DESCRIPTION
- JSONEncoder.swift: tell the compiler that yes, this is supposed to be casting to 'T' and not 'T?'.

- NSObject.swift: mark NSKeyValueObservation members explicitly `@objc` and `@nonobjc`.

- NSStringAPI.swift: remove unnecessary `@usableFromInline`.

No intended functionality change.