### PR TITLE
Dispatch: Simplify DispatchData.append(_: UnsafeBufferPointer<T>)

### DIFF
--- a/stdlib/public/SDK/Dispatch/Data.swift
+++ b/stdlib/public/SDK/Dispatch/Data.swift
@@ -149,9 +149,7 @@ public struct DispatchData : RandomAccessCollection, _ObjectiveCBridgeable {
 	///
 	/// - parameter buffer: The buffer of bytes to append. The size is calculated from `SourceType` and `buffer.count`.
 	public mutating func append<SourceType>(_ buffer : UnsafeBufferPointer<SourceType>) {
-		buffer.baseAddress!.withMemoryRebound(to: UInt8.self, capacity: buffer.count * MemoryLayout<SourceType>.stride) {
-			self.append($0, count: buffer.count * MemoryLayout<SourceType>.stride)
-		}
+		self.append(UnsafeRawBufferPointer(buffer))
 	}
 
 	private func _copyBytesHelper(to pointer: UnsafeMutableRawPointer, from range: Range<Index>) {


### PR DESCRIPTION
The deprecation warning guides us towards UnsafeRawBufferPointer, so sure, let's use that.

No intended functionality change.