### PR TITLE
[4.2] Enable `@unknown default` warnings by default in Swift 5 mode

### DIFF
--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -312,7 +312,7 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
   Opts.EnableNonFrozenEnumExhaustivityDiagnostics =
     Args.hasFlag(OPT_enable_nonfrozen_enum_exhaustivity_diagnostics,
                  OPT_disable_nonfrozen_enum_exhaustivity_diagnostics,
-                 Opts.EnableNonFrozenEnumExhaustivityDiagnostics);
+                 Opts.isSwiftVersionAtLeast(5));
 
   if (Arg *A = Args.getLastArg(OPT_Rpass_EQ))
     Opts.OptimizationRemarkPassedPattern =

--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1381,10 +1381,8 @@ namespace {
           // playgrounds.
           return;
         }
-        if (!TC.Context.isSwiftVersionAtLeast(5)) {
-          // Downgrade missing '@unknown' to a warning in Swift 4 and below.
-          mainDiagType = diag::non_exhaustive_switch_warn;
-        }
+        // Missing '@unknown' is just a warning.
+        mainDiagType = diag::non_exhaustive_switch_warn;
         break;
       }
 

--- a/test/Compatibility/exhaustive_switch.swift
+++ b/test/Compatibility/exhaustive_switch.swift
@@ -1,5 +1,5 @@
-// RUN: %target-typecheck-verify-swift -swift-version 3 -enable-resilience -enable-nonfrozen-enum-exhaustivity-diagnostics
-// RUN: %target-typecheck-verify-swift -swift-version 4 -enable-resilience -enable-nonfrozen-enum-exhaustivity-diagnostics
+// RUN: %target-typecheck-verify-swift -swift-version 3 -enable-resilience
+// RUN: %target-typecheck-verify-swift -swift-version 4 -enable-resilience
 
 func foo(a: Int?, b: Int?) -> Int {
   switch (a, b) {
@@ -543,7 +543,7 @@ func quiteBigEnough() -> Bool {
   }
 
   // Make sure we haven't just stopped emitting diagnostics.
-  switch OverlyLargeSpaceEnum.case1 { // expected-error {{switch must be exhaustive}} expected-note 12 {{add missing case}} expected-note {{handle unknown values}}
+  switch OverlyLargeSpaceEnum.case1 { // expected-error {{switch must be exhaustive}} expected-note 12 {{add missing case}}
   }
 }
 
@@ -840,11 +840,11 @@ public enum NonExhaustivePayload {
 // case.
 @inlinable
 public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePayload, for interval: TemporalProxy, flag: Bool) {
-  switch value { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.b'}} {{none}} expected-note {{handle unknown values using "@unknown default"}} {{none}}
+  switch value { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.b'}} {{none}}
   case .a: break
   }
 
-  switch value { // expected-warning {{switch must be exhaustive}} {{none}} expected-note {{handle unknown values using "@unknown default"}} {{3-3=@unknown default:\n<#fatalError#>()\n}}
+  switch value { // no-warning
   case .a: break
   case .b: break
   }
@@ -876,7 +876,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   }
 
   // Test being part of other spaces.
-  switch value as Optional { // expected-warning {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.some(_)'}}
+  switch value as Optional { // no-warning
   case .a?: break
   case .b?: break
   case nil: break
@@ -894,7 +894,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   @unknown case _: break
   } // no-warning
 
-  switch (value, flag) { // expected-warning {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '(_, false)'}}
+  switch (value, flag) { // no-warning
   case (.a, _): break
   case (.b, false): break
   case (_, true): break
@@ -907,7 +907,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   @unknown case _: break
   } // no-warning
 
-  switch (flag, value) { // expected-warning {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '(false, _)'}}
+  switch (flag, value) { // no-warning
   case (_, .a): break
   case (false, .b): break
   case (true, _): break
@@ -920,7 +920,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   @unknown case _: break
   } // no-warning
 
-  switch (value, value) { // expected-warning {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '(_, _)'}}
+  switch (value, value) { // no-warning
   case (.a, _), (_, .a): break
   case (.b, _), (_, .b): break
   }
@@ -932,21 +932,13 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   } // no-warning
 
   // Test interaction with @_downgrade_exhaustivity_check.
-  switch (value, interval) { // expected-warning {{switch must be exhaustive}} {{none}}
-  // expected-note@-1 {{add missing case: '(_, .milliseconds(_))'}}
-  // expected-note@-2 {{add missing case: '(_, .microseconds(_))'}}
-  // expected-note@-3 {{add missing case: '(_, .nanoseconds(_))'}}
-  // expected-note@-4 {{add missing case: '(_, .never)'}}
+  switch (value, interval) { // no-warning
   case (_, .seconds): break
   case (.a, _): break
   case (.b, _): break
   }
 
-  switch (value, interval) { // expected-warning {{switch must be exhaustive}} {{none}}
-  // expected-note@-1 {{add missing case: '(_, .seconds(_))'}}
-  // expected-note@-2 {{add missing case: '(_, .milliseconds(_))'}}
-  // expected-note@-3 {{add missing case: '(_, .microseconds(_))'}}
-  // expected-note@-4 {{add missing case: '(_, .nanoseconds(_))'}}
+  switch (value, interval) { // no-warning
   case (_, .never): break
   case (.a, _): break
   case (.b, _): break
@@ -954,11 +946,11 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
 
 
   // Test payloaded enums.
-  switch payload { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.b(_)'}} {{none}} expected-note {{handle unknown values using "@unknown default"}} {{none}}
+  switch payload { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.b(_)'}} {{none}}
   case .a: break
   }
 
-  switch payload { // expected-warning {{switch must be exhaustive}} {{none}} expected-note {{handle unknown values using "@unknown default"}} {{3-3=@unknown default:\n<#fatalError#>()\n}}
+  switch payload { // no-warning
   case .a: break
   case .b: break
   }
@@ -980,7 +972,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   @unknown case _: break
   }
 
-  switch payload { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.b(true)'}} {{none}} expected-note {{handle unknown values using "@unknown default"}} {{none}}
+  switch payload { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.b(true)'}} {{none}}
   case .a: break
   case .b(false): break
   }

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -1,4 +1,5 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-resilience -enable-nonfrozen-enum-exhaustivity-diagnostics
+// RUN: %target-typecheck-verify-swift -swift-version 5 -enable-resilience
+// RUN: %target-typecheck-verify-swift -swift-version 4 -enable-resilience -enable-nonfrozen-enum-exhaustivity-diagnostics
 
 func foo(a: Int?, b: Int?) -> Int {
   switch (a, b) {
@@ -852,7 +853,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   case .a: break
   }
 
-  switch value { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{handle unknown values using "@unknown default"}} {{3-3=@unknown default:\n<#fatalError#>()\n}}
+  switch value { // expected-warning {{switch must be exhaustive}} {{none}} expected-note {{handle unknown values using "@unknown default"}} {{3-3=@unknown default:\n<#fatalError#>()\n}}
   case .a: break
   case .b: break
   }
@@ -884,7 +885,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   }
 
   // Test being part of other spaces.
-  switch value as Optional { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.some(_)'}}
+  switch value as Optional { // expected-warning {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '.some(_)'}}
   case .a?: break
   case .b?: break
   case nil: break
@@ -902,7 +903,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   case nil: break
   } // no-warning
 
-  switch (value, flag) { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '(_, false)'}}
+  switch (value, flag) { // expected-warning {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '(_, false)'}}
   case (.a, _): break
   case (.b, false): break
   case (_, true): break
@@ -915,7 +916,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   @unknown case _: break
   } // no-warning
 
-  switch (flag, value) { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '(false, _)'}}
+  switch (flag, value) { // expected-warning {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '(false, _)'}}
   case (_, .a): break
   case (false, .b): break
   case (true, _): break
@@ -928,7 +929,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   @unknown case _: break
   } // no-warning
 
-  switch (value, value) { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '(_, _)'}}
+  switch (value, value) { // expected-warning {{switch must be exhaustive}} {{none}} expected-note {{add missing case: '(_, _)'}}
   case (.a, _), (_, .a): break
   case (.b, _), (_, .b): break
   }
@@ -940,7 +941,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   } // no-warning
 
   // Test interaction with @_downgrade_exhaustivity_check.
-  switch (value, interval) { // expected-error {{switch must be exhaustive}} {{none}}
+  switch (value, interval) { // expected-warning {{switch must be exhaustive}} {{none}}
   // expected-note@-1 {{add missing case: '(_, .milliseconds(_))'}}
   // expected-note@-2 {{add missing case: '(_, .microseconds(_))'}}
   // expected-note@-3 {{add missing case: '(_, .nanoseconds(_))'}}
@@ -950,7 +951,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   case (.b, _): break
   }
 
-  switch (value, interval) { // expected-error {{switch must be exhaustive}} {{none}}
+  switch (value, interval) { // expected-warning {{switch must be exhaustive}} {{none}}
   // expected-note@-1 {{add missing case: '(_, .seconds(_))'}}
   // expected-note@-2 {{add missing case: '(_, .milliseconds(_))'}}
   // expected-note@-3 {{add missing case: '(_, .microseconds(_))'}}
@@ -965,7 +966,7 @@ public func testNonExhaustive(_ value: NonExhaustive, _ payload: NonExhaustivePa
   case .a: break
   }
 
-  switch payload { // expected-error {{switch must be exhaustive}} {{none}} expected-note {{handle unknown values using "@unknown default"}} {{3-3=@unknown default:\n<#fatalError#>()\n}}
+  switch payload { // expected-warning {{switch must be exhaustive}} {{none}} expected-note {{handle unknown values using "@unknown default"}} {{3-3=@unknown default:\n<#fatalError#>()\n}}
   case .a: break
   case .b: break
   }

--- a/test/Sema/exhaustive_switch_testable.swift
+++ b/test/Sema/exhaustive_switch_testable.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -swift-version 5 -enable-resilience -enable-testing %S/Inputs/exhaustive_switch_testable_helper.swift -emit-module -o %t
-// RUN: %target-swift-frontend -typecheck %s -swift-version 5 -enable-nonfrozen-enum-exhaustivity-diagnostics -I %t -DTESTABLE -verify
-// RUN: not %target-swift-frontend -typecheck %s -swift-version 5 -enable-nonfrozen-enum-exhaustivity-diagnostics -I %t 2>&1 | %FileCheck -check-prefix=VERIFY-NON-FROZEN %s
+// RUN: %target-swift-frontend -typecheck %s -swift-version 5 -I %t -DTESTABLE -verify
+// RUN: %target-swift-frontend -typecheck %s -swift-version 5 -I %t 2>&1 | %FileCheck -check-prefix=VERIFY-NON-FROZEN %s
 
 #if TESTABLE
 @testable import exhaustive_switch_testable_helper
@@ -17,7 +17,7 @@ func testFrozen(_ e: FrozenEnum) -> Int {
 }
 
 func testNonFrozen(_ e: NonFrozenEnum) -> Int {
-  // VERIFY-NON-FROZEN: exhaustive_switch_testable.swift:[[@LINE+1]]:{{[0-9]+}}: error: switch must be exhaustive
+  // VERIFY-NON-FROZEN: exhaustive_switch_testable.swift:[[@LINE+1]]:{{[0-9]+}}: warning: switch must be exhaustive
   switch e {
   case .a: return 1
   case .b, .c: return 2


### PR DESCRIPTION
Cherry-pick of #16045 to swift-4.2-branch, reviewed by @xedin. This has no effect in non-Swift-5 mode; it's just to make things easier to test later on.

rdar://problem/29324688