### PR TITLE
IRGen: Conformance records for dependent conformances should referenc…

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -58,6 +58,7 @@
 #include "GenMeta.h"
 #include "GenObjC.h"
 #include "GenOpaque.h"
+#include "GenProto.h"
 #include "GenType.h"
 #include "IRGenDebugInfo.h"
 #include "IRGenFunction.h"
@@ -2728,31 +2729,29 @@ namespace {
     void addWitnessTable() {
       using ConformanceKind = ConformanceFlags::ConformanceKind;
 
-     // Figure out what kind of witness table we have.
-      auto proto = Conformance->getProtocol();
+      // Figure out what kind of witness table we have.
       llvm::Constant *witnessTableVar;
-      if (!IGM.isResilient(proto, ResilienceExpansion::Maximal) &&
-          Conformance->getConditionalRequirements().empty()) {
-        Flags = Flags.withConformanceKind(ConformanceKind::WitnessTable);
 
-        // If the conformance is in this object's table, then the witness table
-        // should also be in this object file, so we can always directly
-        // reference it.
-        witnessTableVar = IGM.getAddrOfWitnessTable(Conformance);
-      } else {
-        if (Conformance->getConditionalRequirements().empty()) {
+      if (Conformance->getConditionalRequirements().empty()) {
+        if (!isDependentConformance(IGM, Conformance,
+                                    ResilienceExpansion::Maximal)) {
+          Flags = Flags.withConformanceKind(ConformanceKind::WitnessTable);
+          witnessTableVar = IGM.getAddrOfWitnessTable(Conformance);
+        } else {
           Flags = Flags.withConformanceKind(
                                         ConformanceKind::WitnessTableAccessor);
-        } else {
-          Flags =
-            Flags.withConformanceKind(
-                ConformanceKind::ConditionalWitnessTableAccessor)
-              .withNumConditionalRequirements(
-                              Conformance->getConditionalRequirements().size());
+          witnessTableVar = IGM.getAddrOfWitnessTableAccessFunction(
+              Conformance, ForDefinition);
         }
+      } else {
+        Flags =
+          Flags.withConformanceKind(
+              ConformanceKind::ConditionalWitnessTableAccessor)
+            .withNumConditionalRequirements(
+              Conformance->getConditionalRequirements().size());
 
         witnessTableVar = IGM.getAddrOfWitnessTableAccessFunction(
-            Conformance, ForDefinition);
+          Conformance, ForDefinition);
       }
 
       // Relative reference to the witness table.

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -941,7 +941,7 @@ static bool isResilientConformance(const NormalProtocolConformance *conformance)
 
 /// Is there anything about the given conformance that requires witness
 /// tables to be dependently-generated?
-static bool isDependentConformance(IRGenModule &IGM,
+bool irgen::isDependentConformance(IRGenModule &IGM,
                              const NormalProtocolConformance *conformance,
                                    ResilienceExpansion expansion) {
   // If the conformance is resilient, this is always true.
@@ -950,6 +950,9 @@ static bool isDependentConformance(IRGenModule &IGM,
 
   // Check whether any of the inherited conformances are dependent.
   for (auto inherited : conformance->getProtocol()->getInheritedProtocols()) {
+    if (inherited->isObjC())
+      continue;
+
     if (isDependentConformance(IGM,
                                conformance->getInheritedConformance(inherited)
                                  ->getRootNormalConformance(),

--- a/lib/IRGen/GenProto.h
+++ b/lib/IRGen/GenProto.h
@@ -255,6 +255,10 @@ namespace irgen {
     CanSILFunctionType fnType,
     GenericParamFulfillmentCallback callback);
 
+  bool isDependentConformance(IRGenModule &IGM,
+                        const NormalProtocolConformance *conformance,
+                              ResilienceExpansion expansion);
+
 } // end namespace irgen
 } // end namespace swift
 

--- a/test/IRGen/protocol_conformance_records.swift
+++ b/test/IRGen/protocol_conformance_records.swift
@@ -4,6 +4,27 @@
 import resilient_struct
 import resilient_protocol
 
+public protocol Associate {
+  associatedtype X
+}
+
+// Dependent conformance
+// CHECK-LABEL: @"$S28protocol_conformance_records9DependentVyxGAA9AssociateAAMc" ={{ protected | }}constant
+// -- protocol descriptor
+// CHECK-SAME:           @"$S28protocol_conformance_records9AssociateMp"
+// -- nominal type descriptor
+// CHECK-SAME:           @"$S28protocol_conformance_records9DependentVMn"
+// -- witness table accessor
+// CHECK-SAME:           @"$S28protocol_conformance_records9DependentVyxGAA9AssociateAAWa"
+// -- flags
+// CHECK-SAME:           i32 1
+// CHECK-SAME:         }
+public struct Dependent<T> {}
+
+extension Dependent : Associate {
+  public typealias X = (T, T)
+}
+
 public protocol Runcible {
   func runce()
 }
@@ -85,7 +106,6 @@ extension Size: Runcible {
 // CHECK-SAME: @"$S28protocol_conformance_records8RuncibleMp"
 // CHECK-SAME: @"$S28protocol_conformance_records5SpoonMp"
 
-// TODO: conformances that need lazy initialization
 public protocol Spoon { }
 
 // Conditional conformances


### PR DESCRIPTION
…e the witness table accessor function

... and not the pattern, which is about to get non-public linkage.

(cherry picked from commit d1da8f34715c037d885643ab7adccf0797013e86)

Fixes rdar://problem/39588499