### PR TITLE
[gardening] Correct comment

### DIFF
--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -21,8 +21,8 @@ public struct ObjectIdentifier {
 
   /// Creates an instance that uniquely identifies the given class instance.
   ///
-  /// The following example creates an example class `A` and compares instances
-  /// of the class using their object identifiers and the identical-to
+  /// The following example creates an example class `IntegerRef` and compares
+  /// instances of the class using their object identifiers and the identical-to
   /// operator (`===`):
   ///
   ///     class IntegerRef {


### PR DESCRIPTION
Fixes a comment which referred to another class name than the one used in the example code.