### PR TITLE
[stdlib] Rename index(...) methods to firstIndex(...)

### DIFF
--- a/benchmark/single-source/CSVParsing.swift
+++ b/benchmark/single-source/CSVParsing.swift
@@ -31,7 +31,7 @@ func parseQuotedField(_ remainder: inout Substring) throws -> Substring? {
     var result: Substring = "" // we accumulate the result
 
     while !remainder.isEmpty {
-        guard let nextQuoteIndex = remainder.index(of: "\"") else {
+        guard let nextQuoteIndex = remainder.firstIndex(of: "\"") else {
             throw ParseError(message: "Expected a closing \"")
         }
 

--- a/benchmark/single-source/RemoveWhere.swift
+++ b/benchmark/single-source/RemoveWhere.swift
@@ -46,7 +46,7 @@ extension RangeReplaceableCollection {
 
 extension RangeReplaceableCollection where Self: MutableCollection {
   mutating func removeWhere_move(where match: (Element) throws -> Bool) rethrows  {
-    guard var i = try index(where: match) else { return }
+    guard var i = try firstIndex(where: match) else { return }
 
     var j = index(after: i)
     while j != endIndex {
@@ -62,7 +62,7 @@ extension RangeReplaceableCollection where Self: MutableCollection {
   }
 
   mutating func removeWhere_swap(where match: (Element) throws -> Bool) rethrows {
-    guard var i = try index(where: match) else { return }
+    guard var i = try firstIndex(where: match) else { return }
 
     var j = index(after: i)
     while j != endIndex {

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift
@@ -814,13 +814,13 @@ extension TestSuite {
     }
 
     //===------------------------------------------------------------------===//
-    // index(of:)/index(where:)
+    // firstIndex(of:)/firstIndex(where:)
     //===------------------------------------------------------------------===//
 
-    self.test("\(testNamePrefix).index(of:)/semantics") {
+    self.test("\(testNamePrefix).firstIndex(of:)/semantics") {
       for test in findTests {
         let c = makeWrappedCollectionWithEquatableElement(test.sequence)
-        var result = c.index(of: wrapValueIntoEquatable(test.element))
+        var result = c.firstIndex(of: wrapValueIntoEquatable(test.element))
         expectType(
           Optional<CollectionWithEquatableElement.Index>.self,
           &result)
@@ -834,12 +834,12 @@ extension TestSuite {
       }
     }
 
-    self.test("\(testNamePrefix).index(where:)/semantics") {
+    self.test("\(testNamePrefix).firstIndex(where:)/semantics") {
       for test in findTests {
         let closureLifetimeTracker = LifetimeTracked(0)
         expectEqual(1, LifetimeTracked.instances)
         let c = makeWrappedCollectionWithEquatableElement(test.sequence)
-        let result = c.index {
+        let result = c.firstIndex {
           (candidate) in
           _blackHole(closureLifetimeTracker)
           return

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -1935,17 +1935,17 @@ self.test("\(testNamePrefix).forEach/semantics") {
 }
 
 //===----------------------------------------------------------------------===//
-// first()
+// first(where:)
 //===----------------------------------------------------------------------===//
 
-self.test("\(testNamePrefix).first/semantics") {
+self.test("\(testNamePrefix).first(where:)/semantics") {
   for test in findTests {
     let s = makeWrappedSequenceWithEquatableElement(test.sequence)
     let closureLifetimeTracker = LifetimeTracked(0)
-    let found = s.first {
+    let found = s.first(where: {
       _blackHole(closureLifetimeTracker)
       return $0 == wrapValueIntoEquatable(test.element)
-    }
+    })
     expectEqual(
       test.expected == nil ? nil : wrapValueIntoEquatable(test.element),
       found,

--- a/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift
+++ b/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift
@@ -333,7 +333,7 @@ internal struct _CollectionStateTransition {
       transitions = Box<[_CollectionStateTransition]>([])
       _CollectionStateTransition._allTransitions[previousState] = transitions
     }
-    if let i = transitions!.value.index(where: { $0._operation == operation }) {
+    if let i = transitions!.value.firstIndex(where: { $0._operation == operation }) {
       self = transitions!.value[i]
       return
     }

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -137,12 +137,12 @@ if True:
 /// tasked with finding the first two days with absences in the session. To
 /// find the indices of the two days in question, follow these steps:
 ///
-/// 1) Call `index(where:)` to find the index of the first element in the
+/// 1) Call `firstIndex(where:)` to find the index of the first element in the
 ///    `absences` array that is greater than zero.
 /// 2) Create a slice of the `absences` array starting after the index found in
 ///    step 1.
-/// 3) Call `index(where:)` again, this time on the slice created in step 2.
-///    Where in some languages you might pass a starting index into an
+/// 3) Call `firstIndex(where:)` again, this time on the slice created in step
+///    2. Where in some languages you might pass a starting index into an
 ///    `indexOf` method to find the second day, in Swift you perform the same
 ///    operation on a slice of the original array.
 /// 4) Print the results using the indices found in steps 1 and 3 on the
@@ -150,9 +150,9 @@ if True:
 ///
 /// Here's an implementation of those steps:
 ///
-///     if let i = absences.index(where: { $0 > 0 }) {                      // 1
+///     if let i = absences.firstIndex(where: { $0 > 0 }) {                 // 1
 ///         let absencesAfterFirst = absences[(i + 1)...]                   // 2
-///         if let j = absencesAfterFirst.index(where: { $0 > 0 }) {        // 3
+///         if let j = absencesAfterFirst.firstIndex(where: { $0 > 0 }) {   // 3
 ///             print("The first day with absences had \(absences[i]).")    // 4
 ///             print("The second day with absences had \(absences[j]).")
 ///         }
@@ -293,7 +293,7 @@ if True:
 /// You can replace an existing element with a new value by assigning the new
 /// value to the subscript.
 ///
-///     if let i = students.index(of: "Maxime") {
+///     if let i = students.firstIndex(of: "Maxime") {
 ///         students[i] = "Max"
 ///     }
 ///     // ["Ivy", "Jordell", "Liam", "Max", "Shakia"]
@@ -533,7 +533,7 @@ extension ${Self}: RandomAccessCollection, MutableCollection {
   /// safe to use with `endIndex`. For example:
   ///
   ///     let numbers = [10, 20, 30, 40, 50]
-  ///     if let i = numbers.index(of: 30) {
+  ///     if let i = numbers.firstIndex(of: 30) {
   ///         print(numbers[i ..< numbers.endIndex])
   ///     }
   ///     // Prints "[30, 40, 50]"
@@ -784,7 +784,7 @@ extension ${Self}: RandomAccessCollection, MutableCollection {
   ///     print(streetsSlice)
   ///     // Prints "["Channing", "Douglas", "Evarts"]"
   ///
-  ///     let i = streetsSlice.index(of: "Evarts")    // 4
+  ///     let i = streetsSlice.firstIndex(of: "Evarts")    // 4
   ///     print(streets[i!])
   ///     // Prints "Evarts"
   ///

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -119,7 +119,7 @@ where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
   ///     print(streetsSlice)
   ///     // Prints "["Channing", "Douglas", "Evarts"]"
   ///
-  ///     let index = streetsSlice.index(of: "Evarts")    // 4
+  ///     let index = streetsSlice.firstIndex(of: "Evarts")    // 4
   ///     print(streets[index!])
   ///     // Prints "Evarts"
   ///

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -161,7 +161,7 @@ extension IndexingIterator: IteratorProtocol, Sequence {
 /// that position.
 ///
 ///     let text = "Buffalo buffalo buffalo buffalo."
-///     if let firstSpace = text.index(of: " ") {
+///     if let firstSpace = text.firstIndex(of: " ") {
 ///         print(text[..<firstSpace])
 ///     }
 ///     // Prints "Buffalo"
@@ -226,7 +226,7 @@ extension IndexingIterator: IteratorProtocol, Sequence {
 /// You can retrieve the same slice using the string's ranged subscript, which
 /// takes a range expression.
 ///
-///     if let firstSpace = text.index(of: " ") {
+///     if let firstSpace = text.firstIndex(of: " ") {
 ///         print(text[..<firstSpace]
 ///         // Prints "Buffalo"
 ///     }
@@ -373,7 +373,7 @@ public protocol Collection: Sequence where SubSequence: Collection {
   /// safe to use with `endIndex`. For example:
   ///
   ///     let numbers = [10, 20, 30, 40, 50]
-  ///     if let index = numbers.index(of: 30) {
+  ///     if let index = numbers.firstIndex(of: 30) {
   ///         print(numbers[index ..< numbers.endIndex])
   ///     }
   ///     // Prints "[30, 40, 50]"
@@ -439,7 +439,7 @@ public protocol Collection: Sequence where SubSequence: Collection {
   /// original collection. This example searches `streetsSlice` for one of the
   /// strings in the slice, and then uses that index in the original array.
   ///
-  ///     let index = streetsSlice.index(of: "Evarts")!    // 4
+  ///     let index = streetsSlice.firstIndex(of: "Evarts")!    // 4
   ///     print(streets[index])
   ///     // "Evarts"
   ///
@@ -497,7 +497,7 @@ public protocol Collection: Sequence where SubSequence: Collection {
   /// but not including, that index:
   ///
   ///     let numbers = [10, 20, 30, 40, 50, 60]
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers.prefix(upTo: i))
   ///     }
   ///     // Prints "[10, 20, 30]"
@@ -512,7 +512,7 @@ public protocol Collection: Sequence where SubSequence: Collection {
   /// half-open range as the collection's subscript. The subscript notation is
   /// preferred over `prefix(upTo:)`.
   ///
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers[..<i])
   ///     }
   ///     // Prints "[10, 20, 30]"
@@ -532,7 +532,7 @@ public protocol Collection: Sequence where SubSequence: Collection {
   /// that index:
   ///
   ///     let numbers = [10, 20, 30, 40, 50, 60]
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers.suffix(from: i))
   ///     }
   ///     // Prints "[40, 50, 60]"
@@ -547,7 +547,7 @@ public protocol Collection: Sequence where SubSequence: Collection {
   /// from the index as the collection's subscript. The subscript notation is
   /// preferred over `suffix(from:)`.
   ///
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers[i...])
   ///     }
   ///     // Prints "[40, 50, 60]"
@@ -568,7 +568,7 @@ public protocol Collection: Sequence where SubSequence: Collection {
   /// including, that index:
   ///
   ///     let numbers = [10, 20, 30, 40, 50, 60]
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers.prefix(through: i))
   ///     }
   ///     // Prints "[10, 20, 30, 40]"
@@ -577,7 +577,7 @@ public protocol Collection: Sequence where SubSequence: Collection {
   /// closed range as the collection's subscript. The subscript notation is
   /// preferred over `prefix(through:)`.
   ///
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers[...i])
   ///     }
   ///     // Prints "[10, 20, 30, 40]"
@@ -621,8 +621,9 @@ public protocol Collection: Sequence where SubSequence: Collection {
   ///   of the collection.
   var count: Int { get }
   
-  // The following requirement enables dispatching for index(of:) when
+  // The following requirements enable dispatching for firstIndex(of:) when
   // the element type is Equatable.
+
   /// Returns `Optional(Optional(index))` if an element was found
   /// or `Optional(nil)` if an element was determined to be missing;
   /// otherwise, `nil`.
@@ -1067,7 +1068,7 @@ extension Collection where SubSequence == Slice<Self> {
   ///     print(streetsSlice)
   ///     // Prints "["Channing", "Douglas", "Evarts"]"
   ///
-  ///     let index = streetsSlice.index(of: "Evarts")    // 4
+  ///     let index = streetsSlice.firstIndex(of: "Evarts")    // 4
   ///     print(streets[index!])
   ///     // Prints "Evarts"
   ///
@@ -1180,7 +1181,7 @@ extension Collection {
   }
 
   // TODO: swift-3-indexing-model - rename the following to _customIndexOfEquatable(element)?
-  /// Customization point for `Collection.index(of:)`.
+  /// Customization point for `Collection.firstIndex(of:)`.
   ///
   /// Define this method if the collection can find an element in less than
   /// O(*n*) by exploiting collection-specific knowledge.
@@ -1189,7 +1190,7 @@ extension Collection {
   ///   `Optional(nil)` if the element was not found, or
   ///   `Optional(Optional(index))` if an element was found.
   ///
-  /// - Complexity: O(`count`).
+  /// - Complexity: Hopefully less than O(`count`).
   @inlinable
   public // dispatching
   func _customIndexOfEquatableElement(_: Iterator.Element) -> Index?? {
@@ -1402,7 +1403,7 @@ extension Collection {
   /// but not including, that index:
   ///
   ///     let numbers = [10, 20, 30, 40, 50, 60]
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers.prefix(upTo: i))
   ///     }
   ///     // Prints "[10, 20, 30]"
@@ -1417,7 +1418,7 @@ extension Collection {
   /// half-open range as the collection's subscript. The subscript notation is
   /// preferred over `prefix(upTo:)`.
   ///
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers[..<i])
   ///     }
   ///     // Prints "[10, 20, 30]"
@@ -1440,7 +1441,7 @@ extension Collection {
   /// that index:
   ///
   ///     let numbers = [10, 20, 30, 40, 50, 60]
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers.suffix(from: i))
   ///     }
   ///     // Prints "[40, 50, 60]"
@@ -1455,7 +1456,7 @@ extension Collection {
   /// from the index as the collection's subscript. The subscript notation is
   /// preferred over `suffix(from:)`.
   ///
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers[i...])
   ///     }
   ///     // Prints "[40, 50, 60]"
@@ -1479,7 +1480,7 @@ extension Collection {
   /// including, that index:
   ///
   ///     let numbers = [10, 20, 30, 40, 50, 60]
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers.prefix(through: i))
   ///     }
   ///     // Prints "[10, 20, 30, 40]"
@@ -1488,7 +1489,7 @@ extension Collection {
   /// closed range as the collection's subscript. The subscript notation is
   /// preferred over `prefix(through:)`.
   ///
-  ///     if let i = numbers.index(of: 40) {
+  ///     if let i = numbers.firstIndex(of: 40) {
   ///         print(numbers[...i])
   ///     }
   ///     // Prints "[10, 20, 30, 40]"

--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -31,20 +31,20 @@ extension BidirectionalCollection {
 }
 
 //===----------------------------------------------------------------------===//
-// index(of:)/index(where:)
+// firstIndex(of:)/firstIndex(where:)
 //===----------------------------------------------------------------------===//
 
 extension Collection where Element : Equatable {
   /// Returns the first index where the specified value appears in the
   /// collection.
   ///
-  /// After using `index(of:)` to find the position of a particular element in
-  /// a collection, you can use it to access the element by subscripting. This
-  /// example shows how you can modify one of the names in an array of
+  /// After using `firstIndex(of:)` to find the position of a particular element
+  /// in a collection, you can use it to access the element by subscripting.
+  /// This example shows how you can modify one of the names in an array of
   /// students.
   ///
   ///     var students = ["Ben", "Ivy", "Jordell", "Maxime"]
-  ///     if let i = students.index(of: "Maxime") {
+  ///     if let i = students.firstIndex(of: "Maxime") {
   ///         students[i] = "Max"
   ///     }
   ///     print(students)
@@ -54,7 +54,7 @@ extension Collection where Element : Equatable {
   /// - Returns: The first index where `element` is found. If `element` is not
   ///   found in the collection, returns `nil`.
   @inlinable
-  public func index(of element: Element) -> Index? {
+  public func firstIndex(of element: Element) -> Index? {
     if let result = _customIndexOfEquatableElement(element) {
       return result
     }
@@ -68,6 +68,13 @@ extension Collection where Element : Equatable {
     }
     return nil
   }
+  
+  /// Returns the first index where the specified value appears in the
+  /// collection.
+  @inlinable
+  public func index(of _element: Element) -> Index? {
+    return firstIndex(of: _element)
+  }
 }
 
 extension Collection {
@@ -80,7 +87,7 @@ extension Collection {
   /// begins with the letter "A":
   ///
   ///     let students = ["Kofi", "Abena", "Peter", "Kweku", "Akosua"]
-  ///     if let i = students.index(where: { $0.hasPrefix("A") }) {
+  ///     if let i = students.firstIndex(where: { $0.hasPrefix("A") }) {
   ///         print("\(students[i]) starts with 'A'!")
   ///     }
   ///     // Prints "Abena starts with 'A'!"
@@ -92,7 +99,7 @@ extension Collection {
   ///   `true`. If no elements in the collection satisfy the given predicate,
   ///   returns `nil`.
   @inlinable
-  public func index(
+  public func firstIndex(
     where predicate: (Element) throws -> Bool
   ) rethrows -> Index? {
     var i = self.startIndex
@@ -103,6 +110,15 @@ extension Collection {
       self.formIndex(after: &i)
     }
     return nil
+  }
+  
+  /// Returns the first index in which an element of the collection satisfies
+  /// the given predicate.
+  @inlinable
+  public func index(
+    where _predicate: (Element) throws -> Bool
+  ) rethrows -> Index? {
+    return try firstIndex(where: _predicate)
   }
 }
 

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -328,11 +328,11 @@ import SwiftShims
 /// provides, see the `DictionaryLiteral` type for an alternative.
 ///
 /// You can search a dictionary's contents for a particular value using the
-/// `contains(where:)` or `index(where:)` methods supplied by default
+/// `contains(where:)` or `firstIndex(where:)` methods supplied by default
 /// implementation. The following example checks to see if `imagePaths` contains
 /// any paths in the `"/glyphs"` directory:
 ///
-///     let glyphIndex = imagePaths.index { $0.value.hasPrefix("/glyphs") }
+///     let glyphIndex = imagePaths.firstIndex(where: { $0.value.hasPrefix("/glyphs") })
 ///     if let index = glyphIndex {
 ///         print("The '\(imagesPaths[index].key)' image is a glyph.")
 ///     } else {
@@ -668,10 +668,10 @@ extension Dictionary: Collection {
   /// this subscript with the resulting value.
   ///
   /// For example, to find the key for a particular value in a dictionary, use
-  /// the `index(where:)` method.
+  /// the `firstIndex(where:)` method.
   ///
   ///     let countryCodes = ["BR": "Brazil", "GH": "Ghana", "JP": "Japan"]
-  ///     if let index = countryCodes.index(where: { $0.value == "Japan" }) {
+  ///     if let index = countryCodes.firstIndex(where: { $0.value == "Japan" }) {
   ///         print(countryCodes[index])
   ///         print("Japan's country code is '\(countryCodes[index].key)'.")
   ///     } else {

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -422,7 +422,7 @@ extension Mirror {
   ///         i0 != children.endIndex
   ///     {
   ///         let grandChildren = Mirror(reflecting: children[i0].value).children
-  ///         if let i1 = grandChildren.index(where: { $0.label == "two" }) {
+  ///         if let i1 = grandChildren.firstIndex(where: { $0.label == "two" }) {
   ///             let greatGrandChildren =
   ///                 Mirror(reflecting: grandChildren[i1].value).children
   ///             if let i2 = greatGrandChildren.index(
@@ -459,7 +459,7 @@ extension Mirror {
       let children = Mirror(reflecting: result).children
       let position: Children.Index
       if case let label as String = e {
-        position = children.index { $0.label == label } ?? children.endIndex
+        position = children.firstIndex { $0.label == label } ?? children.endIndex
       }
       else if let offset = e as? Int {
         position = children.index(children.startIndex,
@@ -665,11 +665,11 @@ public protocol _DefaultCustomPlaygroundQuickLookable {
 /// Some operations that are efficient on a dictionary are slower when using
 /// `DictionaryLiteral`. In particular, to find the value matching a key, you
 /// must search through every element of the collection. The call to
-/// `index(where:)` in the following example must traverse the whole
+/// `firstIndex(where:)` in the following example must traverse the whole
 /// collection to find the element that matches the predicate:
 ///
 ///     let runner = "Marlies Gohr"
-///     if let index = recordTimes.index(where: { $0.0 == runner }) {
+///     if let index = recordTimes.firstIndex(where: { $0.0 == runner }) {
 ///         let time = recordTimes[index].1
 ///         print("\(runner) set a 100m record of \(time) seconds.")
 ///     } else {

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -25,7 +25,7 @@ public typealias MutableIndexable = MutableCollection
 /// modify one of the names in an array of students.
 ///
 ///     var students = ["Ben", "Ivy", "Jordell", "Maxime"]
-///     if let i = students.index(of: "Maxime") {
+///     if let i = students.firstIndex(of: "Maxime") {
 ///         students[i] = "Max"
 ///     }
 ///     print(students)
@@ -112,7 +112,7 @@ where SubSequence: MutableCollection
   ///     print(streetsSlice)
   ///     // Prints "["Channing", "Douglas", "Evarts"]"
   ///
-  ///     let index = streetsSlice.index(of: "Evarts")    // 4
+  ///     let index = streetsSlice.firstIndex(of: "Evarts")    // 4
   ///     streets[index!] = "Eustace"
   ///     print(streets[index!])
   ///     // Prints "Eustace"
@@ -211,7 +211,7 @@ extension MutableCollection {
   ///     print(streetsSlice)
   ///     // Prints "["Channing", "Douglas", "Evarts"]"
   ///
-  ///     let index = streetsSlice.index(of: "Evarts")    // 4
+  ///     let index = streetsSlice.firstIndex(of: "Evarts")    // 4
   ///     streets[index!] = "Eustace"
   ///     print(streets[index!])
   ///     // Prints "Eustace"

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -87,7 +87,7 @@ where SubSequence: RandomAccessCollection, Indices: RandomAccessCollection
   ///     print(streetsSlice)
   ///     // Prints "["Channing", "Douglas", "Evarts"]"
   ///
-  ///     let index = streetsSlice.index(of: "Evarts")    // 4
+  ///     let index = streetsSlice.firstIndex(of: "Evarts")    // 4
   ///     print(streets[index!])
   ///     // Prints "Evarts"
   ///

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -814,7 +814,7 @@ extension Collection {
   /// of the strings in the slice, and then uses that index in the original
   /// array.
   ///
-  ///     let index = streetsSlice.index(of: "Evarts")    // 4
+  ///     let index = streetsSlice.firstIndex(of: "Evarts")    // 4
   ///     print(streets[index!])
   ///     // "Evarts"
   ///

--- a/stdlib/public/core/RangeReplaceableCollection.swift
+++ b/stdlib/public/core/RangeReplaceableCollection.swift
@@ -1097,7 +1097,7 @@ extension RangeReplaceableCollection where Self: MutableCollection {
   public mutating func removeAll(
     where predicate: (Element) throws -> Bool
   ) rethrows {
-    if var i = try index(where: predicate) {
+    if var i = try firstIndex(where: predicate) {
       var j = index(after: i)
       while j != endIndex {
         if try !predicate(self[j]) {

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -129,7 +129,7 @@ extension ReversedCollection {
     ///
     ///     func indexOfLastEven(_ numbers: [Int]) -> Int? {
     ///         let reversedNumbers = numbers.reversed()
-    ///         guard let i = reversedNumbers.index(where: { $0 % 2 == 0 })
+    ///         guard let i = reversedNumbers.firstIndex(where: { $0 % 2 == 0 })
     ///             else { return nil }
     ///
     ///         return numbers.index(before: i.base)
@@ -152,7 +152,7 @@ extension ReversedCollection {
     /// `"a"` character in a string's character view.
     ///
     ///     let name = "Horatio"
-    ///     let aIndex = name.index(of: "a")!
+    ///     let aIndex = name.firstIndex(of: "a")!
     ///     // name[aIndex] == "a"
     ///
     ///     let reversedName = name.reversed()

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -349,7 +349,7 @@ extension Set: Collection {
   ///
   /// - Complexity: O(1)
   @inlinable // FIXME(sil-serialize-all)
-  public func index(of member: Element) -> Index? {
+  public func firstIndex(of member: Element) -> Index? {
     return _variantBuffer.index(forKey: member)
   }
 
@@ -357,7 +357,7 @@ extension Set: Collection {
   public func _customIndexOfEquatableElement(
      _ member: Element
     ) -> Index?? {
-    return Optional(index(of: member))
+    return Optional(firstIndex(of: member))
   }
 
   /// The number of elements in the set.

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -362,7 +362,7 @@ extension String {
 /// that point:
 ///
 ///     let name = "Marie Curie"
-///     let firstSpace = name.index(of: " ") ?? name.endIndex
+///     let firstSpace = name.firstIndex(of: " ") ?? name.endIndex
 ///     let firstName = name[..<firstSpace]
 ///     // firstName == "Marie"
 ///
@@ -513,7 +513,7 @@ extension String {
 /// of the string up to that point.
 ///
 ///     let name = "Marie Curie"
-///     let firstSpace = name.index(of: " ") ?? name.endIndex
+///     let firstSpace = name.firstIndex(of: " ") ?? name.endIndex
 ///     let firstName = name[..<firstSpace]
 ///     print(firstName)
 ///     // Prints "Marie"

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -52,7 +52,7 @@ extension String {
   /// using the `String` type's `init(_:)` initializer.
   ///
   ///     let name = "Marie Curie"
-  ///     if let firstSpace = name.characters.index(of: " ") {
+  ///     if let firstSpace = name.characters.firstIndex(of: " ") {
   ///         let firstName = String(name.characters[..<firstSpace])
   ///         print(firstName)
   ///     }
@@ -121,7 +121,7 @@ extension String {
   ///     var str = "All this happened, more or less."
   ///     let afterSpace = str.withMutableCharacters {
   ///         chars -> String.CharacterView in
-  ///         if let i = chars.index(of: " ") {
+  ///         if let i = chars.firstIndex(of: " ") {
   ///             let result = chars[chars.index(after: i)...]
   ///             chars.removeSubrange(i...)
   ///             return result
@@ -274,7 +274,7 @@ extension String._CharacterView : BidirectionalCollection {
   /// letter and then prints the character at the found index:
   ///
   ///     let greeting = "Hello, friend!"
-  ///     if let i = greeting.characters.index(where: { "A"..."Z" ~= $0 }) {
+  ///     if let i = greeting.characters.firstIndex(where: { "A"..."Z" ~= $0 }) {
   ///         print("First capital letter: \(greeting.characters[i])")
   ///     }
   ///     // Prints "First capital letter: H"
@@ -361,7 +361,7 @@ extension String._CharacterView {
   /// not including, the first comma (`","`) in the string.
   ///
   ///     let str = "All this happened, more or less."
-  ///     let i = str.characters.index(of: ",")!
+  ///     let i = str.characters.firstIndex(of: ",")!
   ///     let substring = str.characters[str.characters.startIndex ..< i]
   ///     print(String(substring))
   ///     // Prints "All this happened"

--- a/stdlib/public/core/StringIndexConversions.swift
+++ b/stdlib/public/core/StringIndexConversions.swift
@@ -26,7 +26,7 @@ extension String.Index {
   ///     print(cafe)
   ///     // Prints "Café"
   ///
-  ///     let scalarsIndex = cafe.unicodeScalars.index(of: "e")!
+  ///     let scalarsIndex = cafe.unicodeScalars.firstIndex(of: "e")!
   ///     let stringIndex = String.Index(scalarsIndex, within: cafe)!
   ///
   ///     print(cafe[...stringIndex])
@@ -67,7 +67,7 @@ extension String.Index {
   /// uses this method find the same position in the string's `utf8` view.
   ///
   ///     let cafe = "Café"
-  ///     if let i = cafe.index(of: "é") {
+  ///     if let i = cafe.firstIndex(of: "é") {
   ///         let j = i.samePosition(in: cafe.utf8)!
   ///         print(Array(cafe.utf8[j...]))
   ///     }
@@ -96,7 +96,7 @@ extension String.Index {
   /// uses this method find the same position in the string's `utf16` view.
   ///
   ///     let cafe = "Café"
-  ///     if let i = cafe.index(of: "é") {
+  ///     if let i = cafe.firstIndex(of: "é") {
   ///         let j = i.samePosition(in: cafe.utf16)!
   ///         print(cafe.utf16[j])
   ///     }

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift
@@ -258,9 +258,9 @@ extension String : StringProtocol, RangeReplaceableCollection {
   /// For example, this code finds the first letter after the first space:
   ///
   ///     let str = "Greetings, friend! How are you?"
-  ///     let firstSpace = str.index(of: " ") ?? str.endIndex
+  ///     let firstSpace = str.firstIndex(of: " ") ?? str.endIndex
   ///     let substr = str[firstSpace...]
-  ///     if let nextCapital = substr.index(where: { $0 >= "A" && $0 <= "Z" }) {
+  ///     if let nextCapital = substr.firstIndex(where: { $0 >= "A" && $0 <= "Z" }) {
   ///         print("Capital after a space: \(str[nextCapital])")
   ///     }
   ///     // Prints "Capital after a space: H"
@@ -436,7 +436,7 @@ extension String {
   /// removes the hyphen from the middle of a string.
   ///
   ///     var nonempty = "non-empty"
-  ///     if let i = nonempty.index(of: "-") {
+  ///     if let i = nonempty.firstIndex(of: "-") {
   ///         nonempty.remove(at: i)
   ///     }
   ///     print(nonempty)

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -55,7 +55,7 @@ extension String {
   /// `String` type's `init(_:)` initializer.
   ///
   ///     let favemoji = "My favorite emoji is 🎉"
-  ///     if let i = favemoji.utf16.index(where: { $0 >= 128 }) {
+  ///     if let i = favemoji.utf16.firstIndex(where: { $0 >= 128 }) {
   ///         let asciiPrefix = String(favemoji.utf16[..<i])
   ///         print(asciiPrefix)
   ///     }
@@ -303,7 +303,7 @@ extension String {
   /// another string's `utf16` view.
   ///
   ///     let picnicGuest = "Deserving porcupine"
-  ///     if let i = picnicGuest.utf16.index(of: 32) {
+  ///     if let i = picnicGuest.utf16.firstIndex(of: 32) {
   ///         let adjective = String(picnicGuest.utf16[..<i])
   ///         print(adjective)
   ///     }
@@ -379,7 +379,7 @@ extension String.UTF16View.Index {
   ///
   ///     let cafe = "Café 🍵"
   ///
-  ///     let stringIndex = cafe.index(of: "é")!
+  ///     let stringIndex = cafe.firstIndex(of: "é")!
   ///     let utf16Index = String.Index(stringIndex, within: cafe.utf16)!
   ///
   ///     print(cafe.utf16[...utf16Index])
@@ -407,7 +407,7 @@ extension String.UTF16View.Index {
   /// position in the string's `unicodeScalars` view.
   ///
   ///     let cafe = "Café 🍵"
-  ///     let i = cafe.utf16.index(of: 32)!
+  ///     let i = cafe.utf16.firstIndex(of: 32)!
   ///     let j = i.samePosition(in: cafe.unicodeScalars)!
   ///     print(cafe.unicodeScalars[..<j])
   ///     // Prints "Café"

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -390,7 +390,7 @@ extension String {
   /// another string's `utf8` view.
   ///
   ///     let picnicGuest = "Deserving porcupine"
-  ///     if let i = picnicGuest.utf8.index(of: 32) {
+  ///     if let i = picnicGuest.utf8.firstIndex(of: 32) {
   ///         let adjective = String(picnicGuest.utf8[..<i])
   ///         print(adjective)
   ///     }
@@ -583,7 +583,7 @@ extension String.UTF8View.Index {
   ///
   ///     let cafe = "Café 🍵"
   ///
-  ///     let utf16Index = cafe.utf16.index(of: 32)!
+  ///     let utf16Index = cafe.utf16.firstIndex(of: 32)!
   ///     let utf8Index = String.UTF8View.Index(utf16Index, within: cafe.utf8)!
   ///
   ///     print(Array(cafe.utf8[..<utf8Index]))

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -52,7 +52,7 @@ extension String {
   /// using the `String` type's `init(_:)` initializer.
   ///
   ///     let favemoji = "My favorite emoji is 🎉"
-  ///     if let i = favemoji.unicodeScalars.index(where: { $0.value >= 128 }) {
+  ///     if let i = favemoji.unicodeScalars.firstIndex(where: { $0.value >= 128 }) {
   ///         let asciiPrefix = String(favemoji.unicodeScalars[..<i])
   ///         print(asciiPrefix)
   ///     }
@@ -156,7 +156,7 @@ extension String {
     /// at the found index:
     ///
     ///     let greeting = "Hello, friend!"
-    ///     if let i = greeting.unicodeScalars.index(where: { "A"..."Z" ~= $0 }) {
+    ///     if let i = greeting.unicodeScalars.firstIndex(where: { "A"..."Z" ~= $0 }) {
     ///         print("First capital letter: \(greeting.unicodeScalars[i])")
     ///         print("Unicode scalar value: \(greeting.unicodeScalars[i].value)")
     ///     }
@@ -277,7 +277,7 @@ extension String {
   /// another string's `unicodeScalars` view.
   ///
   ///     let picnicGuest = "Deserving porcupine"
-  ///     if let i = picnicGuest.unicodeScalars.index(of: " ") {
+  ///     if let i = picnicGuest.unicodeScalars.firstIndex(of: " ") {
   ///         let adjective = String(picnicGuest.unicodeScalars[..<i])
   ///         print(adjective)
   ///     }
@@ -474,7 +474,7 @@ extension String.UnicodeScalarIndex {
   ///
   ///     let cafe = "Café 🍵"
   ///
-  ///     let utf16Index = cafe.utf16.index(of: 32)!
+  ///     let utf16Index = cafe.utf16.firstIndex(of: 32)!
   ///     let scalarIndex = String.Index(utf16Index, within: cafe.unicodeScalars)!
   ///
   ///     print(String(cafe.unicodeScalars[..<scalarIndex]))
@@ -507,7 +507,7 @@ extension String.UnicodeScalarIndex {
   /// in the string.
   ///
   ///     let cafe = "Café 🍵"
-  ///     let i = cafe.unicodeScalars.index(of: "🍵")
+  ///     let i = cafe.unicodeScalars.firstIndex(of: "🍵")
   ///     let j = i.samePosition(in: cafe)!
   ///     print(cafe[j...])
   ///     // Prints "🍵"
@@ -625,7 +625,7 @@ extension String.UnicodeScalarView {
   /// to, but not including, the first comma (`","`) in the string.
   ///
   ///     let str = "All this happened, more or less."
-  ///     let i = str.unicodeScalars.index(of: ",")!
+  ///     let i = str.unicodeScalars.firstIndex(of: ",")!
   ///     let substring = str.unicodeScalars[str.unicodeScalars.startIndex ..< i]
   ///     print(String(substring))
   ///     // Prints "All this happened"

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -37,7 +37,7 @@ extension String {
 /// substring of the first sentence:
 ///
 ///     let greeting = "Hi there! It's nice to meet you! 👋"
-///     let endOfSentence = greeting.index(of: "!")!
+///     let endOfSentence = greeting.firstIndex(of: "!")!
 ///     let firstSentence = greeting[...endOfSentence]
 ///     // firstSentence == "Hi there!"
 ///

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -295,7 +295,7 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
   ///         let streetSlice = buffer[2..<buffer.endIndex]
   ///         print(Array(streetSlice))
   ///         // Prints "["Channing", "Douglas", "Evarts"]"
-  ///         let index = streetSlice.index(of: "Evarts")    // 4
+  ///         let index = streetSlice.firstIndex(of: "Evarts")    // 4
   ///         buffer[index!] = "Eustace"
   ///     }
   ///     print(streets.last!)
@@ -306,7 +306,7 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
   ///         let streetSlice = buffer[2..<buffer.endIndex]
   ///         print(Array(streetSlice))
   ///         // Prints "["Channing", "Douglas", "Evarts"]"
-  ///         let index = streetSlice.index(of: "Evarts")    // 4
+  ///         let index = streetSlice.firstIndex(of: "Evarts")    // 4
   ///         print(buffer[index!])
   ///         // Prints "Evarts"
   ///     }

--- a/test/IDE/complete_from_stdlib.swift
+++ b/test/IDE/complete_from_stdlib.swift
@@ -93,7 +93,7 @@ func protocolExtCollection1a<C : Collection>(_ a: C) {
 // PRIVATE_NOMINAL_MEMBERS_2A: Begin completions
 // PRIVATE_NOMINAL_MEMBERS_2A-DAG: map({#(transform): (C.Element) throws -> T##(C.Element) throws -> T#})[' rethrows'][#[T]#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_2A: End completions
-// NEGATIVE_PRIVATE_NOMINAL_MEMBERS_2A-NOT: Decl{{.*}}: last
+// NEGATIVE_PRIVATE_NOMINAL_MEMBERS_2A-NOT: Decl{{.*}}: index({#before: Comparable#})
 
 func protocolExtCollection1b(_ a: Collection) {
   a.#^PRIVATE_NOMINAL_MEMBERS_2B^#
@@ -102,7 +102,7 @@ func protocolExtCollection1b(_ a: Collection) {
 // PRIVATE_NOMINAL_MEMBERS_2B: Begin completions
 // PRIVATE_NOMINAL_MEMBERS_2B-DAG: map({#(transform): (Collection.Element) throws -> T##(Collection.Element) throws -> T#})[' rethrows'][#[T]#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_2B: End completions
-// NEGATIVE_PRIVATE_NOMINAL_MEMBERS_2B-NOT: Decl{{.*}}: last
+// NEGATIVE_PRIVATE_NOMINAL_MEMBERS_2B-NOT: Decl{{.*}}: index({#before: Comparable#})
 
 func protocolExtCollection2<C : Collection where C.Index : BidirectionalIndex>(_ a: C) {
   a.#^PRIVATE_NOMINAL_MEMBERS_3^#
@@ -111,9 +111,9 @@ func protocolExtCollection2<C : Collection where C.Index : BidirectionalIndex>(_
 // PRIVATE_NOMINAL_MEMBERS_3: Begin completions
 // PRIVATE_NOMINAL_MEMBERS_3-DAG: Decl[InstanceMethod]/Super:         map({#(transform): (C.Element) throws -> T##(C.Element) throws -> T#})[' rethrows'][#[T]#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_3-DAG: Decl[InstanceVar]/Super:            lazy[#LazySequence<Collection>#]{{; name=.+}}
-// PRIVATE_NOMINAL_MEMBERS_3-DAG: index({#where: (C.Element) throws -> Bool##(C.Element) throws -> Bool#})[' rethrows'][#Comparable?#]{{; name=.+}}
+// PRIVATE_NOMINAL_MEMBERS_3-DAG: firstIndex({#where: (C.Element) throws -> Bool##(C.Element) throws -> Bool#})[' rethrows'][#Comparable?#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_3: End completions
-// NEGATIVE_PRIVATE_NOMINAL_MEMBERS_3-NOT: Decl{{.*}}:         index({#({{.*}}): Self.Iterator.Element
+// NEGATIVE_PRIVATE_NOMINAL_MEMBERS_3-NOT: Decl{{.*}}:         firstIndex({#({{.*}}): Self.Iterator.Element
 
 func protocolExtArray<T : Equatable>(_ a: [T]) {
   a.#^PRIVATE_NOMINAL_MEMBERS_4^#
@@ -121,8 +121,8 @@ func protocolExtArray<T : Equatable>(_ a: [T]) {
 // PRIVATE_NOMINAL_MEMBERS_4: Begin completions
 // PRIVATE_NOMINAL_MEMBERS_4-DAG: Decl[InstanceMethod]/Super:         map({#(transform): (Equatable) throws -> T##(Equatable) throws -> T#})[' rethrows'][#[T]#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_4-DAG: Decl[InstanceVar]/Super:            last[#Equatable?#]{{; name=.+}}
-// PRIVATE_NOMINAL_MEMBERS_4-DAG: Decl[InstanceMethod]/Super:         index({#of: Equatable#})[#Int?#]{{; name=.+}}
-// PRIVATE_NOMINAL_MEMBERS_4-DAG: Decl[InstanceMethod]/Super:         index({#where: (Equatable) throws -> Bool##(Equatable) throws -> Bool#})[' rethrows'][#Int?#]{{; name=.+}}
+// PRIVATE_NOMINAL_MEMBERS_4-DAG: Decl[InstanceMethod]/Super:         firstIndex({#of: Equatable#})[#Int?#]{{; name=.+}}
+// PRIVATE_NOMINAL_MEMBERS_4-DAG: Decl[InstanceMethod]/Super:         firstIndex({#where: (Equatable) throws -> Bool##(Equatable) throws -> Bool#})[' rethrows'][#Int?#]{{; name=.+}}
 // PRIVATE_NOMINAL_MEMBERS_4: End completions
 
 func testArchetypeReplacement1<FOO : Equatable>(_ a: [FOO]) {

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -208,7 +208,7 @@ public func testGetFunc() {
 // CHECK: [[T0:%.*]] = call swiftcc %swift.metadata_response @"$SSayy22big_types_corner_cases9BigStructVcSgGMa"
 // CHECK: [[CALL1:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK: [[CALL2:%.*]] = call i8** @"$SSayy22big_types_corner_cases9BigStructVcSgGSayxGs10CollectionsWl
-// CHECK: call swiftcc void @"$Ss10CollectionPsE5index5where5IndexQzSgSb7ElementQzKXE_tKF"(%TSq.{{.*}}* noalias nocapture sret {{.*}}, i8* bitcast (i1 (%T22big_types_corner_cases9BigStructVytIegnr_Sg*, %swift.refcounted*, %swift.error**)* @"$S22big_types_corner_cases9BigStructVIegy_SgSbs5Error_pIggdzo_ACytIegnr_SgSbsAE_pIegndzo_TRTA" to i8*), %swift.opaque* {{.*}}, %swift.type* [[CALL1]], i8** [[CALL2]], %swift.opaque* noalias nocapture swiftself
+// CHECK: call swiftcc void @"$Ss10CollectionPsE10firstIndex5where0C0QzSgSb7ElementQzKXE_tKF"(%TSq.{{.*}}* noalias nocapture sret {{.*}}, i8* bitcast (i1 (%T22big_types_corner_cases9BigStructVytIegnr_Sg*, %swift.refcounted*, %swift.error**)* @"$S22big_types_corner_cases9BigStructVIegy_SgSbs5Error_pIggdzo_ACytIegnr_SgSbsAE_pIegndzo_TRTA" to i8*), %swift.opaque* {{.*}}, %swift.type* [[CALL1]], i8** [[CALL2]], %swift.opaque* noalias nocapture swiftself
 // CHECK: ret void
 
 // CHECK-LABEL: define{{( protected)?}} hidden swiftcc void @"$S22big_types_corner_cases7TestBigC5test2yyF"(%T22big_types_corner_cases7TestBigC* swiftself)
@@ -222,7 +222,7 @@ class TestBig {
 
     func test() {
         let arr = [Handler?]()
-        let d = arr.index(where: { _ in true })
+        let d = arr.firstIndex(where: { _ in true })
     }
     
     func test2() {

--- a/test/Interpreter/SDK/Foundation_test.swift
+++ b/test/Interpreter/SDK/Foundation_test.swift
@@ -163,8 +163,8 @@ FoundationTestSuite.test("RangeConversion") {
   expectEqual("{0, 5}", NSStringFromRange(nsrFromPartial))
 
   let s = "Hello, 🌎!"
-  let b = s.index(of: ",")!
-  let e = s.index(of: "!")!
+  let b = s.firstIndex(of: ",")!
+  let e = s.firstIndex(of: "!")!
   let nsr = NSRange(b..<e, in: s)
   expectEqual(nsr.location, 5)
   expectEqual(nsr.length, 4)

--- a/test/Interpreter/SDK/equatable_hashable.swift
+++ b/test/Interpreter/SDK/equatable_hashable.swift
@@ -32,7 +32,7 @@ func testEquatable<E: Equatable>(_ x: E) {}
 func test_Equatable() {
   // CHECK-NEXT: Found 2.5 at index 1
   let array: [NSNumber] = [1, 2.5, 3.14159]
-  if let index = array.index(of: 2.5) {
+  if let index = array.firstIndex(of: 2.5) {
     print("Found \(array[index]) at index \(index)")
   } else {
     print("Did not find 2.5?")

--- a/test/Prototypes/BigInt.swift
+++ b/test/Prototypes/BigInt.swift
@@ -712,7 +712,7 @@ public struct _BigInt<Word: FixedWidthInteger & UnsignedInteger> :
       return 0
     }
 
-    let i = _data.index(where: { $0 != 0 })!
+    let i = _data.firstIndex(where: { $0 != 0 })!
     _sanityCheck(_data[i] != 0)
     return i * Word.bitWidth + _data[i].trailingZeroBitCount
   }

--- a/test/Prototypes/CollectionTransformers.swift
+++ b/test/Prototypes/CollectionTransformers.swift
@@ -680,7 +680,7 @@ final public class ForkJoinPool {
       _runningThreadsMutex.withLock {
         _submissionQueuesMutex.withLock {
           _workDequesMutex.withLock {
-            let i = _runningThreads.index { $0 === thread }!
+            let i = _runningThreads.firstIndex { $0 === thread }!
             ForkJoinPool._threadRegistry[thread._tid!] = nil
             _runningThreads.remove(at: i)
             _submissionQueues.remove(at: i)

--- a/test/api-digester/stdlib-stable.json
+++ b/test/api-digester/stdlib-stable.json
@@ -74020,7 +74020,7 @@
         {
           "kind": "Function",
           "name": "index",
-          "printedName": "index(of:)",
+          "printedName": "firstIndex(of:)",
           "declKind": "Func",
           "usr": "s:FesRxs10CollectionWx8Iterator7Element_s9EquatablerS_5indexFT2ofWxS0_S1___GSqwx5Index_",
           "location": "",
@@ -78173,7 +78173,7 @@
         {
           "kind": "Function",
           "name": "index",
-          "printedName": "index(of:)",
+          "printedName": "firstIndex(of:)",
           "declKind": "Func",
           "usr": "s:FVs3Set5indexFT2ofx_GSqGVs8SetIndexx__",
           "location": "",

--- a/test/stdlib/ErrorHandling.swift
+++ b/test/stdlib/ErrorHandling.swift
@@ -95,9 +95,9 @@ ErrorHandlingTests.test("ErrorHandling/withCString extends lifetime") {
   // TODO: Some way to check string was deallocated?
 }
 
-ErrorHandlingTests.test("ErrorHandling/index(where:)") {
+ErrorHandlingTests.test("ErrorHandling/firstIndex(where:)") {
   do {
-    let _: Int? = try [1, 2, 3].index {
+    let _: Int? = try [1, 2, 3].firstIndex {
       throw SillyError.JazzHands
       return $0 == $0
     }

--- a/test/stdlib/IndexOfRenaming.swift
+++ b/test/stdlib/IndexOfRenaming.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift
+
+let a = [10, 20, 30, 40, 50, 60]
+
+_ = a.index(of: 30)
+_ = a.firstIndex(of: 30)
+_ = a.index(where: { $0 > 30 })
+_ = a.firstIndex(where: { $0 > 30 })

--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -112,7 +112,7 @@ mirrors.test("BidirectionalStructure") {
   let description = y.testDescription
   expectEqual(
     "[nil: \"a\", nil: \"b\", nil: \"c\", nil: \"",
-    description[description.startIndex..<description.index(of: "d")!])
+    description[description.startIndex..<description.firstIndex(of: "d")!])
 }
 
 mirrors.test("LabeledStructure") {

--- a/test/stdlib/PrintFloat.swift.gyb
+++ b/test/stdlib/PrintFloat.swift.gyb
@@ -514,7 +514,7 @@ fileprivate func exponentialPowerOfTen(_ power: Int) -> String {
 // this logic to help verify that the output does not depend on
 // the C locale.
 PrintTests.setUp {
-  if let localeArgIndex = CommandLine.arguments.index(of: "--locale") {
+  if let localeArgIndex = CommandLine.arguments.firstIndex(of: "--locale") {
     let locale = CommandLine.arguments[localeArgIndex + 1]
     expectEqual("ru_RU.UTF-8", locale)
     setlocale(LC_ALL, locale)

--- a/test/stdlib/SetTraps.swift
+++ b/test/stdlib/SetTraps.swift
@@ -51,7 +51,7 @@ SetTraps.test("RemoveInvalidIndex4")
     reason: "this trap is not guaranteed to happen in -Ounchecked"))
   .code {
   var s: Set<Int> = [ 10 ]
-  let index = s.index(of: 10)!
+  let index = s.firstIndex(of: 10)!
   s.remove(at: index)
   expectFalse(s.contains(10))
   expectCrashLater()

--- a/test/stdlib/subString.swift
+++ b/test/stdlib/subString.swift
@@ -43,7 +43,7 @@ SubstringTests.test("Equality") {
   expectNotEqual(s.dropLast(2), s.dropLast(1))
   expectEqual(s.dropFirst(1), s.dropFirst(1))
   expectTrue(s != s[...].dropFirst(1))
-  let i = emoji.index(of: "😄")!
+  let i = emoji.firstIndex(of: "😄")!
   expectEqual("😄👍🏽" as String, emoji[i...].prefix(2))
   expectTrue("😄👍🏽🇫🇷👩‍👩‍👧‍👦🙈😡🇧🇪" as String == emoji[i...].dropLast(2))
   expectTrue("🇫🇷👩‍👩‍👧‍👦🙈😡🇧🇪" as String == emoji[i...].dropLast(2).dropFirst(2))

--- a/validation-test/Sema/type_checker_crashers_fixed/rdar28145033.swift
+++ b/validation-test/Sema/type_checker_crashers_fixed/rdar28145033.swift
@@ -1,4 +1,4 @@
 // RUN: not %target-swift-frontend %s -typecheck
 
 let a = [1]
-_ = a.index(of: a.min()) // a.min() returns an optional
+_ = a.firstIndex(of: a.min()) // a.min() returns an optional

--- a/validation-test/stdlib/CollectionType.swift.gyb
+++ b/validation-test/stdlib/CollectionType.swift.gyb
@@ -624,12 +624,12 @@ CollectionTypeTests.test("count/dispatch") {
 }
 
 //===----------------------------------------------------------------------===//
-// index(of:)
+// firstIndex(of:)
 //===----------------------------------------------------------------------===//
 
-CollectionTypeTests.test("index(of:)/WhereElementIsEquatable/dispatch") {
+CollectionTypeTests.test("firstIndex(of:)/WhereElementIsEquatable/dispatch") {
   let tester = CollectionLog.dispatchTester([MinimalEquatableValue(1)])
-  _ = tester.index(of: MinimalEquatableValue(1))
+  _ = tester.firstIndex(of: MinimalEquatableValue(1))
   expectCustomizable(tester, tester.log._customIndexOfEquatableElement)
 }
 
@@ -640,14 +640,14 @@ func callGenericFind_<
   C : Collection
 >(_ collection: C, _ element: C.Iterator.Element) -> C.Index? 
 where C.Iterator.Element : Equatable {
-  return collection.index(of: element)
+  return collection.firstIndex(of: element)
 }
 
 func callStaticFind_(
   _ set: Set<MinimalHashableValue>,
   _ element: MinimalHashableValue
 ) -> Set<MinimalHashableValue>.Index? {
-  return set.index(of: element)
+  return set.firstIndex(of: element)
 }
 
 % for dispatch in [ 'Static', 'Generic' ]:
@@ -702,7 +702,7 @@ extension Collection where
   func _test_indicesOf(_ element: Iterator.Element) -> [Index] {
     var result: [Index] = []
     var tail = self[startIndex..<endIndex]
-    while let foundIndex = tail.index(of: element) {
+    while let foundIndex = tail.firstIndex(of: element) {
       result.append(foundIndex)
       tail = tail[index(after: foundIndex)..<endIndex]
     }
@@ -710,7 +710,7 @@ extension Collection where
   }
 }
 
-CollectionTypeTests.test("index(of:)/ContinueSearch") {
+CollectionTypeTests.test("firstIndex(of:)/ContinueSearch") {
   do {
     let c = MinimalCollection(elements: [] as [MinimalEquatableValue])
     expectEqualSequence(

--- a/validation-test/stdlib/Dictionary.swift
+++ b/validation-test/stdlib/Dictionary.swift
@@ -1398,9 +1398,9 @@ DictionaryTestSuite.test("COW.Fast.KeysAccessDoesNotReallocate") {
     var lastKey: MinimalHashableValue = d2.first!.key
     for i in d2.indices { lastKey = d2[i].key }
 
-    // index(where:) - linear search
+    // firstIndex(where:) - linear search
     MinimalHashableValue.timesEqualEqualWasCalled = 0
-    let j = d2.index(where: { (k, _) in k == lastKey })!
+    let j = d2.firstIndex(where: { (k, _) in k == lastKey })!
     expectGE(MinimalHashableValue.timesEqualEqualWasCalled, 8)
 
     // index(forKey:) - O(1) bucket + linear search
@@ -1408,9 +1408,9 @@ DictionaryTestSuite.test("COW.Fast.KeysAccessDoesNotReallocate") {
     let k = d2.index(forKey: lastKey)!
     expectLE(MinimalHashableValue.timesEqualEqualWasCalled, 4)
     
-    // keys.index(of:) - O(1) bucket + linear search
+    // keys.firstIndex(of:) - O(1) bucket + linear search
     MinimalHashableValue.timesEqualEqualWasCalled = 0
-    let l = d2.keys.index(of: lastKey)!
+    let l = d2.keys.firstIndex(of: lastKey)!
 #if swift(>=4.0)
     expectLE(MinimalHashableValue.timesEqualEqualWasCalled, 4)
 #endif
@@ -4464,11 +4464,11 @@ DictionaryTestSuite.test("misc") {
     expectOptionalEqual(4, d3["four"])
     expectOptionalEqual(5, d3["five"])
 
-    expectEqual(3, d.values[d.keys.index(of: "three")!])
-    expectEqual(4, d.values[d.keys.index(of: "four")!])
+    expectEqual(3, d.values[d.keys.firstIndex(of: "three")!])
+    expectEqual(4, d.values[d.keys.firstIndex(of: "four")!])
 
-    expectEqual(3, d3.values[d3.keys.index(of: "three")!])
-    expectEqual(4, d3.values[d3.keys.index(of: "four")!])
+    expectEqual(3, d3.values[d3.keys.firstIndex(of: "three")!])
+    expectEqual(4, d3.values[d3.keys.firstIndex(of: "four")!])
   }
 }
 

--- a/validation-test/stdlib/ExistentialCollection.swift.gyb
+++ b/validation-test/stdlib/ExistentialCollection.swift.gyb
@@ -358,7 +358,7 @@ tests.test("ForwardCollection") {
   let a1 = ContiguousArray(fc0)
   expectEqual(a0, a1)
   for e in a0 {
-    let i = fc0.index(of: e)
+    let i = fc0.firstIndex(of: e)
     expectNotNil(i)
     expectEqual(e, fc0[i!])
   }
@@ -386,7 +386,7 @@ tests.test("BidirectionalCollection") {
   let a1 = ContiguousArray(bc0.lazy.reversed())
   expectEqual(a0, a1)
   for e in a0 {
-    let i = bc0.index(of: e)
+    let i = bc0.firstIndex(of: e)
     expectNotNil(i)
     expectEqual(e, bc0[i!])
   }
@@ -421,7 +421,7 @@ tests.test("RandomAccessCollection") {
   let a1 = ContiguousArray(rc0.lazy.reversed())
   expectEqual(a0, a1)
   for e in a0 {
-    let i = rc0.index(of: e)
+    let i = rc0.firstIndex(of: e)
     expectNotNil(i)
     expectEqual(e, rc0[i!])
   }

--- a/validation-test/stdlib/Set.swift
+++ b/validation-test/stdlib/Set.swift
@@ -599,10 +599,10 @@ SetTestSuite.test("COW.Fast.IndexForMemberDoesNotReallocate") {
 
   // Find an existing key.
   do {
-    var foundIndex1 = s.index(of: 1010)!
+    var foundIndex1 = s.firstIndex(of: 1010)!
     expectEqual(identity1, s._rawIdentifier())
 
-    var foundIndex2 = s.index(of: 1010)!
+    var foundIndex2 = s.firstIndex(of: 1010)!
     expectEqual(foundIndex1, foundIndex2)
 
     expectEqual(1010, s[foundIndex1])
@@ -611,7 +611,7 @@ SetTestSuite.test("COW.Fast.IndexForMemberDoesNotReallocate") {
 
   // Try to find a key that is not present.
   do {
-    var foundIndex1 = s.index(of: 1111)
+    var foundIndex1 = s.firstIndex(of: 1111)
     expectNil(foundIndex1)
     expectEqual(identity1, s._rawIdentifier())
   }
@@ -620,7 +620,7 @@ SetTestSuite.test("COW.Fast.IndexForMemberDoesNotReallocate") {
     var s2: Set<MinimalHashableValue> = []
     MinimalHashableValue.timesEqualEqualWasCalled = 0
     MinimalHashableValue.timesHashIntoWasCalled = 0
-    expectNil(s2.index(of: MinimalHashableValue(42)))
+    expectNil(s2.firstIndex(of: MinimalHashableValue(42)))
 
     // If the set is empty, we shouldn't be computing the hash value of the
     // provided key.
@@ -635,10 +635,10 @@ SetTestSuite.test("COW.Slow.IndexForMemberDoesNotReallocate") {
 
   // Find an existing key.
   do {
-    var foundIndex1 = s.index(of: TestKeyTy(1010))!
+    var foundIndex1 = s.firstIndex(of: TestKeyTy(1010))!
     expectEqual(identity1, s._rawIdentifier())
 
-    var foundIndex2 = s.index(of: TestKeyTy(1010))!
+    var foundIndex2 = s.firstIndex(of: TestKeyTy(1010))!
     expectEqual(foundIndex1, foundIndex2)
 
     expectEqual(TestKeyTy(1010), s[foundIndex1])
@@ -647,7 +647,7 @@ SetTestSuite.test("COW.Slow.IndexForMemberDoesNotReallocate") {
 
   // Try to find a key that is not present.
   do {
-    var foundIndex1 = s.index(of: TestKeyTy(1111))
+    var foundIndex1 = s.firstIndex(of: TestKeyTy(1111))
     expectNil(foundIndex1)
     expectEqual(identity1, s._rawIdentifier())
   }
@@ -656,7 +656,7 @@ SetTestSuite.test("COW.Slow.IndexForMemberDoesNotReallocate") {
     var s2: Set<MinimalHashableClass> = []
     MinimalHashableClass.timesEqualEqualWasCalled = 0
     MinimalHashableClass.timesHashIntoWasCalled = 0
-    expectNil(s2.index(of: MinimalHashableClass(42)))
+    expectNil(s2.firstIndex(of: MinimalHashableClass(42)))
 
     // If the set is empty, we shouldn't be computing the hash value of the
     // provided key.
@@ -671,7 +671,7 @@ SetTestSuite.test("COW.Fast.RemoveAtDoesNotReallocate")
     var s = getCOWFastSet()
     var identity1 = s._rawIdentifier()
 
-    let foundIndex1 = s.index(of: 1010)!
+    let foundIndex1 = s.firstIndex(of: 1010)!
     expectEqual(identity1, s._rawIdentifier())
 
     expectEqual(1010, s[foundIndex1])
@@ -680,7 +680,7 @@ SetTestSuite.test("COW.Fast.RemoveAtDoesNotReallocate")
     expectEqual(1010, removed)
 
     expectEqual(identity1, s._rawIdentifier())
-    expectNil(s.index(of: 1010))
+    expectNil(s.firstIndex(of: 1010))
   }
 
   do {
@@ -691,7 +691,7 @@ SetTestSuite.test("COW.Fast.RemoveAtDoesNotReallocate")
     expectEqual(identity1, s1._rawIdentifier())
     expectEqual(identity1, s2._rawIdentifier())
 
-    var foundIndex1 = s2.index(of: 1010)!
+    var foundIndex1 = s2.firstIndex(of: 1010)!
     expectEqual(1010, s2[foundIndex1])
     expectEqual(identity1, s1._rawIdentifier())
     expectEqual(identity1, s2._rawIdentifier())
@@ -701,7 +701,7 @@ SetTestSuite.test("COW.Fast.RemoveAtDoesNotReallocate")
 
     expectEqual(identity1, s1._rawIdentifier())
     expectNotEqual(identity1, s2._rawIdentifier())
-    expectNil(s2.index(of: 1010))
+    expectNil(s2.firstIndex(of: 1010))
   }
 }
 
@@ -711,7 +711,7 @@ SetTestSuite.test("COW.Slow.RemoveAtDoesNotReallocate")
     var s = getCOWSlowSet()
     var identity1 = s._rawIdentifier()
 
-    let foundIndex1 = s.index(of: TestKeyTy(1010))!
+    let foundIndex1 = s.firstIndex(of: TestKeyTy(1010))!
     expectEqual(identity1, s._rawIdentifier())
 
     expectEqual(TestKeyTy(1010), s[foundIndex1])
@@ -720,7 +720,7 @@ SetTestSuite.test("COW.Slow.RemoveAtDoesNotReallocate")
     expectEqual(TestKeyTy(1010), removed)
 
     expectEqual(identity1, s._rawIdentifier())
-    expectNil(s.index(of: TestKeyTy(1010)))
+    expectNil(s.firstIndex(of: TestKeyTy(1010)))
   }
 
   do {
@@ -731,7 +731,7 @@ SetTestSuite.test("COW.Slow.RemoveAtDoesNotReallocate")
     expectEqual(identity1, s1._rawIdentifier())
     expectEqual(identity1, s2._rawIdentifier())
 
-    var foundIndex1 = s2.index(of: TestKeyTy(1010))!
+    var foundIndex1 = s2.firstIndex(of: TestKeyTy(1010))!
     expectEqual(TestKeyTy(1010), s2[foundIndex1])
     expectEqual(identity1, s1._rawIdentifier())
     expectEqual(identity1, s2._rawIdentifier())
@@ -741,7 +741,7 @@ SetTestSuite.test("COW.Slow.RemoveAtDoesNotReallocate")
 
     expectEqual(identity1, s1._rawIdentifier())
     expectNotEqual(identity1, s2._rawIdentifier())
-    expectNil(s2.index(of: TestKeyTy(1010)))
+    expectNil(s2.firstIndex(of: TestKeyTy(1010)))
   }
 }
 
@@ -1354,17 +1354,17 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.IndexForMember") {
   expectTrue(isCocoaSet(s))
 
   // Find an existing key.
-  var member = s[s.index(of: TestObjCKeyTy(1010))!]
+  var member = s[s.firstIndex(of: TestObjCKeyTy(1010))!]
   expectEqual(TestObjCKeyTy(1010), member)
 
-  member = s[s.index(of: TestObjCKeyTy(2020))!]
+  member = s[s.firstIndex(of: TestObjCKeyTy(2020))!]
   expectEqual(TestObjCKeyTy(2020), member)
 
-  member = s[s.index(of: TestObjCKeyTy(3030))!]
+  member = s[s.firstIndex(of: TestObjCKeyTy(3030))!]
   expectEqual(TestObjCKeyTy(3030), member)
 
   // Try to find a key that does not exist.
-  expectNil(s.index(of: TestObjCKeyTy(4040)))
+  expectNil(s.firstIndex(of: TestObjCKeyTy(4040)))
   expectEqual(identity1, s._rawIdentifier())
 }
 
@@ -1373,17 +1373,17 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.IndexForMember") {
   var identity1 = s._rawIdentifier()
 
   do {
-    var member = s[s.index(of: TestBridgedKeyTy(1010))!]
+    var member = s[s.firstIndex(of: TestBridgedKeyTy(1010))!]
     expectEqual(TestBridgedKeyTy(1010), member)
 
-    member = s[s.index(of: TestBridgedKeyTy(2020))!]
+    member = s[s.firstIndex(of: TestBridgedKeyTy(2020))!]
     expectEqual(TestBridgedKeyTy(2020), member)
 
-    member = s[s.index(of: TestBridgedKeyTy(3030))!]
+    member = s[s.firstIndex(of: TestBridgedKeyTy(3030))!]
     expectEqual(TestBridgedKeyTy(3030), member)
   }
 
-  expectNil(s.index(of: TestBridgedKeyTy(4040)))
+  expectNil(s.firstIndex(of: TestBridgedKeyTy(4040)))
   expectEqual(identity1, s._rawIdentifier())
 }
 
@@ -1649,7 +1649,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAt") {
   let identity1 = s._rawIdentifier()
   expectTrue(isCocoaSet(s))
 
-  let foundIndex1 = s.index(of: TestObjCKeyTy(1010))!
+  let foundIndex1 = s.firstIndex(of: TestObjCKeyTy(1010))!
   expectEqual(TestObjCKeyTy(1010), s[foundIndex1])
   expectEqual(identity1, s._rawIdentifier())
 
@@ -1658,7 +1658,7 @@ SetTestSuite.test("BridgedFromObjC.Verbatim.RemoveAt") {
   expectTrue(isNativeSet(s))
   expectEqual(2, s.count)
   expectEqual(TestObjCKeyTy(1010), removedElement)
-  expectNil(s.index(of: TestObjCKeyTy(1010)))
+  expectNil(s.firstIndex(of: TestObjCKeyTy(1010)))
 }
 
 SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAt")
@@ -1667,7 +1667,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAt")
   let identity1 = s._rawIdentifier()
   expectTrue(isNativeSet(s))
 
-  let foundIndex1 = s.index(of: TestBridgedKeyTy(1010))!
+  let foundIndex1 = s.firstIndex(of: TestBridgedKeyTy(1010))!
   expectEqual(1010, s[foundIndex1].value)
   expectEqual(identity1, s._rawIdentifier())
 
@@ -1676,7 +1676,7 @@ SetTestSuite.test("BridgedFromObjC.Nonverbatim.RemoveAt")
   expectTrue(isNativeSet(s))
   expectEqual(1010, removedElement.value)
   expectEqual(2, s.count)
-  expectNil(s.index(of: TestBridgedKeyTy(1010)))
+  expectNil(s.firstIndex(of: TestBridgedKeyTy(1010)))
 }
 
 SetTestSuite.test("BridgedFromObjC.Verbatim.Remove") {
@@ -3171,7 +3171,7 @@ SetTestSuite.test("contains") {
 SetTestSuite.test("memberAtIndex") {
   let s1 = Set([1010, 2020, 3030])
 
-  let foundIndex = s1.index(of: 1010)!
+  let foundIndex = s1.firstIndex(of: 1010)!
   expectEqual(1010, s1[foundIndex])
 }
 
@@ -3345,12 +3345,12 @@ SetTestSuite.test("_customContainsEquatableElement") {
   expectFalse(Set<Int>()._customContainsEquatableElement(1010)!)
 }
 
-SetTestSuite.test("index(of:)") {
+SetTestSuite.test("firstIndex(of:)") {
   let s1 = Set([1010, 2020, 3030, 4040, 5050, 6060])
-  let foundIndex1 = s1.index(of: 1010)!
+  let foundIndex1 = s1.firstIndex(of: 1010)!
   expectEqual(1010, s1[foundIndex1])
 
-  expectNil(s1.index(of: 999))
+  expectNil(s1.firstIndex(of: 999))
 }
 
 SetTestSuite.test("popFirst") {
@@ -3381,10 +3381,10 @@ SetTestSuite.test("removeAt") {
   // Test removing from the startIndex, the middle, and the end of a set.
   for i in 1...3 {
     var s = Set<Int>([1010, 2020, 3030])
-    let removed = s.remove(at: s.index(of: i*1010)!)
+    let removed = s.remove(at: s.firstIndex(of: i*1010)!)
     expectEqual(i*1010, removed)
     expectEqual(2, s.count)
-    expectNil(s.index(of: i*1010))
+    expectNil(s.firstIndex(of: i*1010))
     let origKeys: [Int] = [1010, 2020, 3030]
     expectEqual(origKeys.filter { $0 != (i*1010) }, [Int](s).sorted())
   }

--- a/validation-test/stdlib/SetAnyHashableExtensions.swift
+++ b/validation-test/stdlib/SetAnyHashableExtensions.swift
@@ -43,13 +43,13 @@ SetTests.test("index<Hashable>(of:)") {
   let s: Set<AnyHashable> = [
     AnyHashable(1010), AnyHashable(2020), AnyHashable(3030.0)
   ]
-  expectEqual(AnyHashable(1010), s[s.index(of: 1010)!])
-  expectEqual(AnyHashable(2020), s[s.index(of: 2020)!])
-  expectEqual(AnyHashable(3030.0), s[s.index(of: 3030.0)!])
+  expectEqual(AnyHashable(1010), s[s.firstIndex(of: 1010)!])
+  expectEqual(AnyHashable(2020), s[s.firstIndex(of: 2020)!])
+  expectEqual(AnyHashable(3030.0), s[s.firstIndex(of: 3030.0)!])
 
-  expectNil(s.index(of: 1010.0))
-  expectNil(s.index(of: 2020.0))
-  expectNil(s.index(of: 3030))
+  expectNil(s.firstIndex(of: 1010.0))
+  expectNil(s.firstIndex(of: 2020.0))
+  expectNil(s.firstIndex(of: 3030))
 }
 
 SetTests.test("insert<Hashable>(_:)") {


### PR DESCRIPTION
A la SE-204. This pulls the `index(of:)` —> `firstIndex(of:)` changes out of https://github.com/apple/swift/pull/13337.