### PR TITLE
Update ErrorType.swift documentation on IntParsingError

### DIFF
--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -35,7 +35,7 @@ import SwiftShims
 ///
 ///     enum IntParsingError: Error {
 ///         case overflow
-///         case invalidInput(String)
+///         case invalidInput(Character)
 ///     }
 ///
 /// The `invalidInput` case includes the invalid character as an associated

--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -48,8 +48,9 @@ import SwiftShims
 ///     extension Int {
 ///         init(validating input: String) throws {
 ///             // ...
-///             if !_isValid(s) {
-///                 throw IntParsingError.invalidInput(s)
+///             let c = _nextCharacter(from: input)
+///             if !_isValid(c) {
+///                 throw IntParsingError.invalidInput(c)
 ///             }
 ///             // ...
 ///         }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Example on `IntParsingError` should have `Character` as the associated value type, not `String`.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
This is purely documentation update. 