### PR TITLE
[Diag] QoI: Suggest fix-it when 'weak' has non-optional type

### DIFF
--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -1105,6 +1105,7 @@ private:
 };
 
 inline bool TypeRepr::isSimple() const {
+  // NOTE: Please keep this logic in sync with TypeBase::hasSimpleTypeRepr().
   switch (getKind()) {
   case TypeReprKind::Attributed:
   case TypeReprKind::Error:

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -1237,4 +1237,15 @@ struct SR3893 {
   var plain: SR3893Box = SR3893Box(value: 0)
 }
 
+protocol WFI_P1 : class {}
+protocol WFI_P2 : class {}
 
+class WeakFixItTest {
+  init() {}
+
+  // expected-error @+1 {{'weak' variable should have optional type 'WeakFixItTest?'}} {{31-31=?}}
+  weak var foo : WeakFixItTest
+
+  // expected-error @+1 {{'weak' variable should have optional type '(WFI_P1 & WFI_P2)?'}} {{18-18=(}} {{33-33=)?}}
+  weak var bar : WFI_P1 & WFI_P2
+}


### PR DESCRIPTION
Also:
1) Move and rename a type printer helper function to make this easier.
2) Improve @IBOutlet diagnostic QoI at the same time.