### PR TITLE
Add `count(where:)` and tests

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -56,6 +56,7 @@ set(SWIFT_BENCH_MODULES
     single-source/Chars
     single-source/ClassArrayGetter
     single-source/Combos
+    single-source/CountAlgo
     single-source/DataBenchmarks
     single-source/DeadArray
     single-source/DictOfArraysToArrayOfDicts

--- a/benchmark/single-source/CountAlgo.swift
+++ b/benchmark/single-source/CountAlgo.swift
@@ -13,8 +13,8 @@ import TestsUtils
 
 public let CountAlgo = [
   BenchmarkInfo(
-    name: "CountAlgoRange",
-    runFunction: run_CountAlgoRange,
+    name: "CountAlgoArray",
+    runFunction: run_CountAlgoArray,
     tags: [.validation, .api]),
   BenchmarkInfo(
     name: "CountAlgoString",
@@ -23,9 +23,9 @@ public let CountAlgo = [
 ]
 
 @inline(never)
-public func run_CountAlgoRange(_ N: Int) {
-  for _ in 1...N {
-    CheckResults((0..<10_000_000).count(where: { $0 & 65535 == 0 }) == 153)
+public func run_CountAlgoArray(_ N: Int) {
+  for _ in 1...10*N {
+    CheckResults(numbers.count(where: { $0 & 4095 == 0 }) == 25)
   }
 }
 
@@ -36,6 +36,8 @@ public func run_CountAlgoString(_ N: Int) {
     CheckResults(text.count(where: vowels.contains) == 2014)
   }
 }
+
+let numbers = Array(0..<100_000)
 
 let text = """
     Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tempus

--- a/benchmark/single-source/CountAlgo.swift
+++ b/benchmark/single-source/CountAlgo.swift
@@ -1,0 +1,124 @@
+//===--- CountAlgo.swift --------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import TestsUtils
+
+public let CountAlgo = [
+  BenchmarkInfo(
+    name: "CountAlgoRange",
+    runFunction: run_CountAlgoRange,
+    tags: [.validation, .api]),
+  BenchmarkInfo(
+    name: "CountAlgoString",
+    runFunction: run_CountAlgoString,
+    tags: [.validation, .api]),
+]
+
+@inline(never)
+public func run_CountAlgoRange(_ N: Int) {
+  for _ in 1...N {
+    CheckResults((0..<10_000_000).count(where: { $0 & 65535 == 0 }) == 153)
+  }
+}
+
+@inline(never)
+public func run_CountAlgoString(_ N: Int) {
+  let vowels = Set("aeiou")
+  for _ in 1...5*N {
+    CheckResults(text.count(where: vowels.contains) == 2014)
+  }
+}
+
+let text = """
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tempus
+    dictum tellus placerat ultrices. Proin mauris risus, eleifend a elit ut,
+    semper consectetur nibh. Nulla ultricies est a vehicula rhoncus. Morbi
+    sollicitudin efficitur est a hendrerit. Interdum et malesuada fames ac ante
+    ipsum primis in faucibus. Lorem ipsum dolor sit amet, consectetur
+    adipiscing elit. Nulla facilisi. Sed euismod sagittis laoreet. Ut elementum
+    tempus ultrices. Donec convallis mauris at faucibus maximus.
+    Nullam in nunc sit amet ante tristique elementum quis ut eros. Fusce
+    dignissim, ante at efficitur dapibus, ex massa convallis nibh, et venenatis
+    leo leo sit amet nisl. Lorem ipsum dolor sit amet, consectetur adipiscing
+    elit. Quisque sed mi eu mi rutrum accumsan vel non massa. Nunc condimentum,
+    arcu eget interdum hendrerit, ipsum mi pretium felis, ut mollis erat metus
+    non est. Donec eu sapien id urna lobortis eleifend et eu ipsum. Mauris
+    purus dolor, consequat ac nulla a, vehicula sollicitudin nulla.
+    Phasellus a congue diam. Curabitur sed orci at sem laoreet facilisis eget
+    quis est. Pellentesque habitant morbi tristique senectus et netus et
+    malesuada fames ac turpis egestas. Maecenas justo tellus, efficitur id
+    velit at, mollis pellentesque mi. Vivamus maximus nibh et ipsum porttitor
+    facilisis. Curabitur cursus lobortis erat. Sed vitae eros et dolor feugiat
+    consequat. In ac massa in odio gravida dignissim. Praesent aliquam gravida
+    ullamcorper.
+    Etiam feugiat sit amet odio sed tincidunt. Duis dolor odio, posuere at
+    pretium sed, dignissim eu diam. Aenean eu convallis orci, vitae finibus
+    erat. Aliquam nec mollis tellus. Morbi luctus sed quam et vestibulum.
+    Praesent id diam tempus, consectetur tortor vel, auctor orci. Aliquam
+    congue ex eu sagittis sodales. Suspendisse non convallis nulla. Praesent
+    elementum semper augue, et fringilla risus ullamcorper id. Fusce eu lorem
+    sit amet augue fermentum tincidunt. In aliquam libero sit amet dui rhoncus,
+    ac scelerisque sem porttitor. Cras venenatis, nisi quis ullamcorper
+    dapibus, odio dolor rutrum magna, vel pellentesque sem lectus in tellus.
+    Proin faucibus leo iaculis nulla egestas molestie.
+    Phasellus vitae tortor vitae erat elementum feugiat vel vel enim. Phasellus
+    fringilla lacus sed venenatis dapibus. Phasellus sagittis vel neque ut
+    varius. Proin aliquam, lectus sit amet auctor finibus, lorem libero
+    pellentesque turpis, ac condimentum augue felis sit amet sem. Pellentesque
+    pharetra nisl nec est congue, in posuere felis maximus. In ut nulla
+    sodales, pharetra neque et, venenatis dui. Mauris imperdiet, arcu vel
+    hendrerit vehicula, elit massa consectetur purus, eu blandit nunc orci sit
+    amet turpis. Vestibulum ultricies id lorem id maximus. Pellentesque
+    feugiat, lacus et aliquet consequat, mi leo vehicula justo, dapibus dictum
+    mi quam convallis magna. Quisque id pulvinar dui, consequat gravida nisl.
+    Nam nec justo venenatis, tincidunt enim a, iaculis odio. Maecenas eget
+    lorem posuere, euismod nisl vel, pulvinar ex. Maecenas vitae risus ipsum.
+    Proin congue sem ante, sit amet sagittis odio mattis sit amet. Nullam et
+    nisi nulla.
+    Donec vel hendrerit metus. Praesent quis finibus erat. Aliquam erat
+    volutpat. Fusce sit amet ultricies tellus, vitae dictum dolor. Morbi auctor
+    dolor vel ligula pretium aliquam. Aenean lobortis vel magna vel ultricies.
+    Aenean porta urna vitae ornare porta. Quisque pretium dui diam, quis
+    iaculis odio venenatis non. Maecenas at lacus et ligula tincidunt feugiat
+    eu vel ipsum. Proin fermentum elit et quam tempus, eget pulvinar nisl
+    pharetra.
+    Mauris sodales tempus erat in lobortis. Duis vitae lacinia sapien.
+    Pellentesque vitae massa eget orci sodales aliquet. Orci varius natoque
+    penatibus et magnis dis parturient montes, nascetur ridiculus mus. Fusce
+    nisi arcu, egestas vel consectetur eu, auctor et metus. In ultricies ligula
+    felis, vitae pellentesque dolor tempor ac. Praesent mi magna, ultrices ut
+    ultrices vel, sollicitudin a leo.
+    Nam porta, nisi in scelerisque consequat, leo lacus accumsan massa,
+    venenatis faucibus tellus quam eget tellus. Curabitur pulvinar, tellus ac
+    facilisis consectetur, lacus lacus venenatis est, eu pretium orci augue
+    gravida nunc. Aenean odio tellus, facilisis et finibus id, varius vitae
+    diam. Aenean at suscipit sem. Suspendisse porta neque at nibh semper, sit
+    amet suscipit libero egestas. Donec commodo vitae justo vitae laoreet.
+    Suspendisse dignissim erat id ante maximus porta. Curabitur hendrerit
+    maximus odio, et maximus felis malesuada eu. Integer dapibus finibus diam,
+    quis convallis metus bibendum non.
+    In vel vulputate nisi, non lacinia nunc. Nullam vitae ligula finibus,
+    varius arcu in, pellentesque ipsum. Morbi vel velit tincidunt quam cursus
+    lacinia non in neque. Suspendisse id feugiat nibh. Vestibulum egestas eu
+    leo viverra fringilla. Curabitur ultrices sollicitudin libero, non sagittis
+    felis consectetur id. Aenean non metus eget leo ornare porta sed in metus.
+    Nullam quis fermentum sapien, sit amet sodales mi. Maecenas nec purus urna.
+    Phasellus condimentum enim nec magna convallis, eu lacinia libero
+    scelerisque. Suspendisse justo libero, maximus in auctor id, euismod quis
+    risus. Nam eget augue diam. Ut id risus pulvinar elit consectetur varius.
+    Aliquam tincidunt tortor pretium feugiat tempor. Nunc nec feugiat ex.
+    Ut pulvinar augue eget pharetra vehicula. Phasellus malesuada tempor sem,
+    ut tincidunt velit convallis in. Vivamus luctus libero vitae massa tempus,
+    id elementum urna iaculis. Sed eleifend quis purus quis convallis. In
+    rhoncus interdum mollis. Pellentesque dictum euismod felis, eget lacinia
+    elit blandit vel. Praesent elit velit, pharetra a sodales in, cursus vitae
+    tortor. In vitae scelerisque tellus.
+    """

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -43,6 +43,7 @@ import CharacterProperties
 import Chars
 import ClassArrayGetter
 import Combos
+import CountAlgo
 import DataBenchmarks
 import DeadArray
 import DictOfArraysToArrayOfDicts
@@ -195,6 +196,7 @@ registerBenchmark(CharacterPropertiesStashedMemo)
 registerBenchmark(CharacterPropertiesPrecomputed)
 registerBenchmark(Chars)
 registerBenchmark(Combos)
+registerBenchmark(CountAlgo)
 registerBenchmark(ClassArrayGetter)
 registerBenchmark(DataBenchmarks)
 registerBenchmark(DeadArray)

--- a/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckSequenceType.swift
@@ -140,6 +140,25 @@ public struct FilterTest {
   }
 }
 
+public struct PredicateCountTest {
+  public let expected: Int
+  public let sequence: [Int]
+  public let includeElement: (Int) -> Bool
+  public let loc: SourceLoc
+
+  public init(
+    _ expected: Int,
+    _ sequence: [Int],
+    _ includeElement: @escaping (Int) -> Bool,
+    file: String = #file, line: UInt = #line
+  ) {
+    self.expected = expected
+    self.sequence = sequence
+    self.includeElement = includeElement
+    self.loc = SourceLoc(file, line, comment: "test data")
+  }
+}
+
 public struct FindTest {
   public let expected: Int?
   public let element: MinimalEquatableValue
@@ -521,6 +540,21 @@ public let filterTests = [
     [ 0, 30, 90 ], [ 0, 30, 10, 90 ], { (x: Int) -> Bool in x % 3 == 0 }
   ),
 ]
+
+public let predicateCountTests = [
+  PredicateCountTest(
+    0, [],
+    { _ -> Bool in expectUnreachable(); return true }),
+
+  PredicateCountTest(0, [ 0, 30, 10, 90 ], { _ -> Bool in false }),
+  PredicateCountTest(
+    4, [ 0, 30, 10, 90 ], { _ -> Bool in true }
+  ),
+  PredicateCountTest(
+    3, [ 0, 30, 10, 90 ], { (x: Int) -> Bool in x % 3 == 0 }
+  ),
+]
+
 
 public let findTests = [
   FindTest(

--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -521,8 +521,8 @@ extension Sequence where Element : Equatable {
 //===----------------------------------------------------------------------===//
 
 extension Sequence {
-  /// Returns the number of many elements in the sequence that satisfy the
-  /// given predicate.
+  /// Returns the number of elements in the sequence that satisfy the given
+  /// predicate.
   ///
   /// You can use this method to count the number of elements that pass a test.
   /// For example, this code finds the number of names that are fewer than

--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -521,33 +521,31 @@ extension Sequence where Element : Equatable {
 //===----------------------------------------------------------------------===//
 
 extension Sequence {
-  /// Returns a Int value indicating how many elements in the sequence
-  /// satisfy the given predicate.
+  /// Returns the number of many elements in the sequence that satisfy the
+  /// given predicate.
   ///
-  /// You can use the predicate to check for an element of a type that
-  /// doesn't conform to the `Equatable` protocol, such as the
-  /// `HTTPResponse` enumeration in this example.
+  /// You can use this method to count the number of elements that pass a test.
+  /// For example, this code finds the number of names that are fewer than
+  /// five characters long:
   ///
-  ///     enum HTTPResponse {
-  ///         case ok
-  ///         case error(Int)
-  ///     }
+  ///     let names = ["Jacqueline", "Ian", "Amy", "Juan", "Soroush", "Tiffany"]
+  ///     let shortNameCount = names.count(where: { $0.count < 5 })
+  ///     // shortNameCount == 3
   ///
-  ///     let responses: [HTTPResponse] = [.ok, .error(500), .error(404)]
-  ///     let numberOfErrors = responses.count { element in
-  ///         if case .error = element {
-  ///             return true
-  ///         } else {
-  ///             return false
-  ///         }
-  ///     }
-  ///     // 'numberOfErrors' == 2
+  /// To find the number of times a specific element appears in the sequence,
+  /// use the equal-to operator (`==`) in the closure to test for a match.
   ///
-  /// - Parameter predicate: A closure that takes an element of the sequence
-  ///   as its argument and returns a Boolean value that indicates whether
-  ///   the passed element should be included in the count.
-  /// - Returns: a value indicating how many elements in the sequence
-  ///   satisfy the given predicate.
+  ///     let birds = ["duck", "duck", "duck", "duck", "goose"]
+  ///     let duckCount = birds.count(where: { $0 == "duck" })
+  ///     // duckCount == 4
+  ///
+  /// The sequence must be finite.
+  ///
+  /// - Parameter predicate: A closure that takes each element of the sequence
+  ///   as its argument and returns a Boolean value indicating whether
+  ///   the element should be included in the count.
+  /// - Returns: The number of elements in the sequence that satisfy the given
+  ///   predicate.
   @inlinable
   public func count(
     where predicate: (Element) throws -> Bool

--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -517,6 +517,52 @@ extension Sequence where Element : Equatable {
 }
 
 //===----------------------------------------------------------------------===//
+// count(where:)
+//===----------------------------------------------------------------------===//
+
+extension Sequence {
+  /// Returns a Int value indicating how many elements in the sequence
+  /// satisfy the given predicate.
+  ///
+  /// You can use the predicate to check for an element of a type that
+  /// doesn't conform to the `Equatable` protocol, such as the
+  /// `HTTPResponse` enumeration in this example.
+  ///
+  ///     enum HTTPResponse {
+  ///         case ok
+  ///         case error(Int)
+  ///     }
+  ///
+  ///     let responses: [HTTPResponse] = [.ok, .error(500), .error(404)]
+  ///     let numberOfErrors = responses.count { element in
+  ///         if case .error = element {
+  ///             return true
+  ///         } else {
+  ///             return false
+  ///         }
+  ///     }
+  ///     // 'numberOfErrors' == 2
+  ///
+  /// - Parameter predicate: A closure that takes an element of the sequence
+  ///   as its argument and returns a Boolean value that indicates whether
+  ///   the passed element should be included in the count.
+  /// - Returns: a value indicating how many elements in the sequence
+  ///   satisfy the given predicate.
+  @inlinable
+  public func count(
+    where predicate: (Element) throws -> Bool
+  ) rethrows -> Int {
+    var count = 0
+    for e in self {
+      if try predicate(e) {
+        count += 1
+      }
+    }
+    return count
+  }
+}
+
+//===----------------------------------------------------------------------===//
 // reduce()
 //===----------------------------------------------------------------------===//
 

--- a/validation-test/stdlib/SequenceType.swift.gyb
+++ b/validation-test/stdlib/SequenceType.swift.gyb
@@ -615,6 +615,21 @@ SequenceTypeTests.test("contains/Predicate") {
 }
 
 //===----------------------------------------------------------------------===//
+// count(where:)
+//===----------------------------------------------------------------------===//
+
+SequenceTypeTests.test("count/Predicate") {
+  for test in predicateCountTests {
+    let s = MinimalSequence<OpaqueValue<Int>>(
+      elements: test.sequence.map { OpaqueValue($0) })
+    expectEqual(
+      test.expected,
+      s.count(where: { test.includeElement($0.value) }),
+      stackTrace: SourceLocStack().with(test.loc))
+  }
+}
+
+//===----------------------------------------------------------------------===//
 // reduce()
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
This pull request is a reference implementation and tests for the `count(where:)` function on `Sequence`. The relevant pitch thread can be found [here](https://forums.swift.org/t/count-where-on-sequence/11186).

Several notes:
* There's currently a failing diagnostic test:

      // <rdar://problem/21080030> Bad diagnostic for invalid method call in boolean expression: (_, ExpressibleByIntegerLiteral)' is not convertible to 'ExpressibleByIntegerLiteral
      func rdar21080030() {
        var s = "Hello"
        if s.count() == 0 {} // expected-error{{cannot call value of non-function type 'Int'}}{{13-15=}}
      }

    This makes sense, because `count` is now a property _and_ a function. Not sure what the recommended approach is here: do we delete this test? Do we change the expected error to "wrong number of parameters"?
* I didn't include `count(of:)` where `Element` is `Equatable`, but I can, depending on what the temperature of the review is. If we do add `count(of:)`, I think we probably also want to add specializations for ranges, sets, etc.
* `count(of:)` also might need special consideration for `NSCountedSet`.