### PR TITLE
Revert "Disable test/stdlib/ErrorBridgedStatic.swift on no_asserts builds"

### DIFF
--- a/test/stdlib/ErrorBridgedStatic.swift
+++ b/test/stdlib/ErrorBridgedStatic.swift
@@ -8,9 +8,6 @@
 // REQUIRES: objc_interop
 // REQUIRES: static_stdlib
 
-// rdar://39473208
-// REQUIRES: asserts
-
 import StdlibUnittest
 
 class Bar: Foo {


### PR DESCRIPTION
Reverts apple/swift#16072

Doing this to see it fail to determine potential causes.