### PR TITLE
master-next: update for SVN r330216

### DIFF
--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -113,14 +113,7 @@ extern int apinotes_main(ArrayRef<const char *> Args);
 int main(int argc_, const char **argv_) {
   PROGRAM_START(argc_, argv_);
 
-  SmallVector<const char *, 256> argv;
-  llvm::SpecificBumpPtrAllocator<char> ArgAllocator;
-  std::error_code EC = llvm::sys::Process::GetArgumentVector(
-      argv, llvm::ArrayRef<const char *>(argv_, argc_), ArgAllocator);
-  if (EC) {
-    llvm::errs() << "error: couldn't get arguments: " << EC.message() << '\n';
-    return 1;
-  }
+  SmallVector<const char *, 256> argv(&argv_[0], &argv_[argc_]);
 
   // Expand any response files in the command line argument vector - arguments
   // may be passed through response files in the event of command line length


### PR DESCRIPTION
sys::Process::GetArgumentVector has been removed.  It is unclear if it
was ever needed in the first place.  Simplify the code to avoid the use.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
