### PR TITLE
Runtime: Handle symbolic references inside other mangling nodes [4.2 4/20]

### DIFF
--- a/include/swift/Demangling/Demangle.h
+++ b/include/swift/Demangling/Demangle.h
@@ -466,6 +466,14 @@ void mangleIdentifier(const char *data, size_t length,
 /// This should always round-trip perfectly with demangleSymbolAsNode.
 std::string mangleNode(const NodePointer &root);
 
+using SymbolicResolver = llvm::function_ref<Demangle::NodePointer (const void *)>;
+
+/// \brief Remangle a demangled parse tree, using a callback to resolve
+/// symbolic references.
+///
+/// This should always round-trip perfectly with demangleSymbolAsNode.
+std::string mangleNode(const NodePointer &root, SymbolicResolver resolver);
+
 /// Remangle in the old mangling scheme.
 ///
 /// This is only used for objc-runtime names and should be removed as soon as

--- a/test/stdlib/Inputs/Mirror/MirrorOther.swift
+++ b/test/stdlib/Inputs/Mirror/MirrorOther.swift
@@ -1,0 +1,7 @@
+struct OtherStruct {
+  let a: OtherOuter.Inner
+  let b: OtherOuterGeneric<Int>.Inner<String>
+}
+
+struct OtherOuter {}
+struct OtherOuterGeneric<T> {}


### PR DESCRIPTION
Previously we could only handle symbolic references at the
top level, but this is insufficient; for example, you can
have a nested type X.Y where X is defined in the current
translation unit and Y is defined in an extension of X in
a different translation unit. In this case, X.Y mangles as
a tree where the child contains a symbolic reference to X.

Handle this by adding a new form of Demangle::mangleNode()
which takes a callback for resolving symbolic references.

Fixes <rdar://problem/39613190>.