### PR TITLE
Zero-initialize uninitialized Dictionary variables for the debugger.

### DIFF
--- a/test/DebugInfo/uninitialized.swift
+++ b/test/DebugInfo/uninitialized.swift
@@ -1,11 +1,27 @@
 // RUN: %target-swift-frontend %s -emit-ir -g -o - | %FileCheck %s
+// RUN: %target-swift-frontend %s -O -emit-ir -g -o - | %FileCheck %s --check-prefix=OPT
 class MyClass {}
 
-// CHECK: define {{.*}} @"$S13uninitialized1fyyF"
+// CHECK-LABEL: define {{.*}} @"$S13uninitialized1fyyF"
+// OPT-LABEL: define {{.*}} @"$S13uninitialized1fyyF"
 public func f() {
   var object: MyClass
-  // CHECK: %[[OBJ:.*]] = alloca %[[T:.*]]*, align
-  // CHECK: call void @llvm.dbg.declare(metadata %[[T]]** %[[OBJ]],
-  // CHECK: %[[BC:.*]] = bitcast %[[T]]** %[[OBJ]] to %swift.opaque**, !dbg
-  // CHECK: store %swift.opaque* null, %swift.opaque** %[[BC]], align {{.*}}, !dbg
+  // CHECK: %[[OBJ:.*]] = alloca %[[T1:.*]]*, align
+  // CHECK: call void @llvm.dbg.declare(metadata %[[T1]]** %[[OBJ]],
+  // CHECK: %[[BC1:.*]] = bitcast %[[T1]]** %[[OBJ]] to %swift.opaque**, !dbg
+  // CHECK: store %swift.opaque* null, %swift.opaque** %[[BC1]], align {{.*}}, !dbg
+  // OPT-NOT: store
+  // OPT: ret
+}
+
+// CHECK-LABEL: define {{.*}} @"$S13uninitialized1gyyF"
+// OPT-LABEL: define {{.*}} @"$S13uninitialized1gyyF"
+public func g() {
+  var dict: Dictionary<Int64, Int64>
+  // CHECK: %[[DICT:.*]] = alloca %[[T2:.*]], align
+  // CHECK: call void @llvm.dbg.declare(metadata %[[T2]]* %[[DICT]],
+  // CHECK: %[[BC2:.*]] = bitcast %[[T2]]* %[[DICT]] to %swift.opaque**, !dbg
+  // CHECK: store %swift.opaque* null, %swift.opaque** %[[BC2]], align {{.*}}, !dbg
+  // OPT-NOT: store
+  // OPT: ret
 }


### PR DESCRIPTION
To avoid the debugger displaying garbage or having expressions crash
when inspecting an uninitialized dictionary variable, zero-initialize
the first word of the alloca at -Onone.

rdar://problem/36619561

(cherry picked from commit 49b40e743d45bf7843481ece17d062d5dbaaa116)
