### PR TITLE
[Runtime] Teach BridgeObjectBox::retain() not to drop the "not native" bit.

### DIFF
--- a/stdlib/public/runtime/MetadataImpl.h
+++ b/stdlib/public/runtime/MetadataImpl.h
@@ -410,7 +410,8 @@ struct BridgeObjectBox :
   static constexpr unsigned numExtraInhabitants = 1;
       
   static void *retain(void *obj) {
-    return swift_bridgeObjectRetain(obj);
+    (void)swift_bridgeObjectRetain(obj);
+    return obj;
   }
 
   static void release(void *obj) {

--- a/test/stdlib/Mirror.swift
+++ b/test/stdlib/Mirror.swift
@@ -464,6 +464,31 @@ mirrors.test("class/ObjCCustomizedSuper/Synthesized") {
     }
   }
 }
+
+// rdar://problem/39629937
+@objc class ObjCClass : NSObject {
+  let value: Int
+
+  init(value: Int) { self.value = value }
+
+  override var description: String {
+    return "\(value)"
+  }
+}
+
+struct WrapObjCClassArray {
+  var array: [ObjCClass]
+}
+
+mirrors.test("struct/WrapNSArray") {
+  let nsArray: NSArray = [
+    ObjCClass(value: 1), ObjCClass(value: 2),
+    ObjCClass(value: 3), ObjCClass(value: 4)
+  ]
+  let s = String(describing: WrapObjCClassArray(array: nsArray as! [ObjCClass]))
+  expectEqual("WrapObjCClassArray(array: [1, 2, 3, 4])", s)
+}
+
 #endif // _runtime(_ObjC)
 
 //===--- Suppressed Superclass Mirrors ------------------------------------===//


### PR DESCRIPTION
The "not native" bit in a BridgeObject is important, because it tells
us when we need to go through the Objective-C -retain method
vs. swift_retain. Losing the bit means that swift_retain() will stomp
on some memory within an Objective-C object, thinking its the inline
reference count.

Co-debugged with Arnold, who then found where this bit was getting dropped.
Fixes rdar://problem/39629937.
