### PR TITLE
[libSyntax] Make parsing of attributes more structured

### DIFF
--- a/cmake/modules/SwiftHandleGybSources.cmake
+++ b/cmake/modules/SwiftHandleGybSources.cmake
@@ -116,6 +116,7 @@ function(handle_gyb_sources dependency_out_var_name sources_var_name arch)
       "${SWIFT_SOURCE_DIR}/utils/gyb_syntax_support/kinds.py"
       "${SWIFT_SOURCE_DIR}/utils/gyb_syntax_support/Node.py"
       "${SWIFT_SOURCE_DIR}/utils/gyb_syntax_support/AttributeNodes.py"
+      "${SWIFT_SOURCE_DIR}/utils/gyb_syntax_support/AvailabilityNodes.py"
       "${SWIFT_SOURCE_DIR}/utils/gyb_syntax_support/CommonNodes.py"
       "${SWIFT_SOURCE_DIR}/utils/gyb_syntax_support/DeclNodes.py"
       "${SWIFT_SOURCE_DIR}/utils/gyb_syntax_support/ExprNodes.py"

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -768,15 +768,33 @@ public:
   bool parseDeclAttributeList(DeclAttributes &Attributes,
                               bool &FoundCodeCompletionToken);
 
-  /// Parse the optional modifiers  before a declaration.
+  /// Parse the optional modifiers before a declaration.
   bool parseDeclModifierList(DeclAttributes &Attributes, SourceLoc &StaticLoc,
                              StaticSpellingKind &StaticSpelling);
+
+  /// Parse an availability attribute of the form
+  /// @available(*, introduced: 1.0, deprecated: 3.1).
+  /// \return \p nullptr if the platform name is invalid
+  ParserResult<AvailableAttr>
+  parseExtendedAvailabilitySpecList(SourceLoc AtLoc, SourceLoc AttrLoc,
+                                    StringRef AttrName);
+
+  /// Parse the Objective-C selector inside @objc
+  void parseObjCSelector(SmallVector<Identifier, 4> &Names,
+                         SmallVector<SourceLoc, 4> &NameLocs,
+                         bool &IsNullarySelector);
 
   /// Parse the @_specialize attribute.
   /// \p closingBrace is the expected closing brace, which can be either ) or ]
   /// \p Attr is where to store the parsed attribute
   bool parseSpecializeAttribute(swift::tok ClosingBrace, SourceLoc AtLoc,
                                 SourceLoc Loc, SpecializeAttr *&Attr);
+
+  /// Parse the arguments inside the @_specialize attribute
+  bool parseSpecializeAttributeArguments(
+      swift::tok ClosingBrace, bool &DiscardAttribute, Optional<bool> &Exported,
+      Optional<SpecializeAttr::SpecializationKind> &Kind,
+      TrailingWhereClause *&TrailingWhereClause);
 
   /// Parse the @_implements attribute.
   /// \p Attr is where to store the parsed attribute

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -300,18 +300,257 @@ getStringLiteralIfNotInterpolated(Parser &P, SourceLoc Loc, const Token &Tok,
                                                  Segments.front().Length));
 }
 
-bool Parser::parseSpecializeAttribute(swift::tok ClosingBrace, SourceLoc AtLoc,
-                                      SourceLoc Loc, SpecializeAttr *&Attr) {
-  assert(ClosingBrace == tok::r_paren || ClosingBrace == tok::r_square);
-  SourceLoc lParenLoc = consumeToken();
-  bool DiscardAttribute = false;
-  StringRef AttrName = "_specialize";
+ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
+    SourceLoc AtLoc, SourceLoc AttrLoc, StringRef AttrName) {
+  // Check 'Tok', return false if ':' or '=' cannot be found.
+  // Complain if '=' is found and suggest replacing it with ": ".
+  auto findAttrValueDelimiter = [&]() -> bool {
+    if (!Tok.is(tok::colon)) {
+      if (!Tok.is(tok::equal))
+        return false;
 
-  Optional<bool> exported;
-  Optional<SpecializeAttr::SpecializationKind> kind;
+      diagnose(Tok.getLoc(), diag::replace_equal_with_colon_for_value)
+          .fixItReplace(Tok.getLoc(), ": ");
+    }
+    return true;
+  };
 
+  StringRef Platform = Tok.getText();
+
+  StringRef Message, Renamed;
+  clang::VersionTuple Introduced, Deprecated, Obsoleted;
+  SourceRange IntroducedRange, DeprecatedRange, ObsoletedRange;
+  auto PlatformAgnostic = PlatformAgnosticAvailabilityKind::None;
+
+  SyntaxParsingContext AvailabilitySpecContext(
+      SyntaxContext, SyntaxKind::AvailabilitySpecList);
+
+  bool HasUpcomingEntry = false;
+
+  {
+    SyntaxParsingContext EntryContext(SyntaxContext,
+                                      SyntaxKind::AvailabilityArgument);
+    consumeToken();
+    if (consumeIf(tok::comma)) {
+      HasUpcomingEntry = true;
+    }
+  }
+
+  bool AnyAnnotations = false;
+  bool AnyArgumentInvalid = false;
+  int ParamIndex = 0;
+
+  while (HasUpcomingEntry) {
+    SyntaxParsingContext EntryContext(SyntaxContext,
+                                      SyntaxKind::AvailabilityArgument);
+    AnyAnnotations = true;
+    StringRef ArgumentKindStr = Tok.getText();
+    ParamIndex++;
+
+    enum {
+      IsMessage, IsRenamed,
+      IsIntroduced, IsDeprecated, IsObsoleted,
+      IsUnavailable,
+      IsInvalid
+    } ArgumentKind = IsInvalid;
+    
+    if (Tok.is(tok::identifier)) {
+      ArgumentKind =
+      llvm::StringSwitch<decltype(ArgumentKind)>(ArgumentKindStr)
+      .Case("message", IsMessage)
+      .Case("renamed", IsRenamed)
+      .Case("introduced", IsIntroduced)
+      .Case("deprecated", IsDeprecated)
+      .Case("obsoleted", IsObsoleted)
+      .Case("unavailable", IsUnavailable)
+      .Default(IsInvalid);
+    }
+
+    if (ArgumentKind == IsInvalid) {
+      diagnose(Tok.getLoc(), diag::attr_availability_expected_option, AttrName)
+          .highlight(SourceRange(Tok.getLoc()));
+      if (Tok.is(tok::code_complete) && CodeCompletion) {
+        CodeCompletion->completeDeclAttrParam(DAK_Available, ParamIndex);
+        consumeToken(tok::code_complete);
+      } else {
+        consumeIf(tok::identifier);
+      }
+      return nullptr;
+    }
+
+    consumeToken();
+
+    switch (ArgumentKind) {
+    case IsMessage:
+    case IsRenamed: {
+      // Items with string arguments.
+      if (findAttrValueDelimiter()) {
+        consumeToken();
+      } else {
+        diagnose(Tok, diag::attr_availability_expected_equal, AttrName,
+                 ArgumentKindStr);
+        AnyArgumentInvalid = true;
+        if (peekToken().isAny(tok::r_paren, tok::comma))
+          consumeToken();
+        break;
+      }
+
+      if (!Tok.is(tok::string_literal)) {
+        diagnose(AttrLoc, diag::attr_expected_string_literal, AttrName);
+        AnyArgumentInvalid = true;
+        if (peekToken().isAny(tok::r_paren, tok::comma))
+          consumeToken();
+        break;
+      }
+
+      auto Value = getStringLiteralIfNotInterpolated(*this, AttrLoc, Tok,
+                                                     ArgumentKindStr);
+      consumeToken();
+      if (!Value) {
+        AnyArgumentInvalid = true;
+        break;
+      }
+
+      if (ArgumentKind == IsMessage) {
+        Message = Value.getValue();
+      } else {
+        ParsedDeclName parsedName = parseDeclName(Value.getValue());
+        if (!parsedName) {
+          diagnose(AttrLoc, diag::attr_availability_invalid_renamed, AttrName);
+          AnyArgumentInvalid = true;
+          break;
+        }
+        Renamed = Value.getValue();
+      }
+
+      SyntaxContext->createNodeInPlace(SyntaxKind::AvailabilityLabeledArgument);
+
+      break;
+    }
+
+    case IsDeprecated:
+      if (!findAttrValueDelimiter()) {
+        if (PlatformAgnostic != PlatformAgnosticAvailabilityKind::None) {
+          diagnose(Tok, diag::attr_availability_unavailable_deprecated,
+                   AttrName);
+        }
+
+        PlatformAgnostic = PlatformAgnosticAvailabilityKind::Deprecated;
+        break;
+      }
+      LLVM_FALLTHROUGH;
+
+    case IsIntroduced:
+    case IsObsoleted: {
+      // Items with version arguments.
+      if (findAttrValueDelimiter()) {
+        consumeToken();
+      } else {
+        diagnose(Tok, diag::attr_availability_expected_equal, AttrName,
+                 ArgumentKindStr);
+        AnyArgumentInvalid = true;
+        if (peekToken().isAny(tok::r_paren, tok::comma))
+          consumeToken();
+        break;
+      }
+
+      auto &VersionArg =
+          (ArgumentKind == IsIntroduced)
+              ? Introduced
+              : (ArgumentKind == IsDeprecated) ? Deprecated : Obsoleted;
+
+      auto &VersionRange = (ArgumentKind == IsIntroduced)
+                               ? IntroducedRange
+                               : (ArgumentKind == IsDeprecated)
+                                     ? DeprecatedRange
+                                     : ObsoletedRange;
+
+      if (parseVersionTuple(
+              VersionArg, VersionRange,
+              Diagnostic(diag::attr_availability_expected_version, AttrName))) {
+        AnyArgumentInvalid = true;
+        if (peekToken().isAny(tok::r_paren, tok::comma))
+          consumeToken();
+      }
+
+      SyntaxContext->createNodeInPlace(SyntaxKind::AvailabilityLabeledArgument);
+
+      break;
+    }
+
+    case IsUnavailable:
+      if (PlatformAgnostic != PlatformAgnosticAvailabilityKind::None) {
+        diagnose(Tok, diag::attr_availability_unavailable_deprecated, AttrName);
+      }
+
+      PlatformAgnostic = PlatformAgnosticAvailabilityKind::Unavailable;
+      break;
+
+    case IsInvalid:
+      llvm_unreachable("handled above");
+    }
+
+    // Parse the trailing comma
+    if (consumeIf(tok::comma)) {
+      HasUpcomingEntry = true;
+    } else {
+      HasUpcomingEntry = false;
+    }
+  }
+
+  if (!AnyAnnotations) {
+    diagnose(Tok.getLoc(), diag::attr_expected_comma, AttrName,
+             /*isDeclModifier*/ false);
+  }
+
+  auto PlatformKind = platformFromString(Platform);
+
+  // Treat 'swift' as a valid version-qualifying token, when
+  // at least some versions were mentioned and no other
+  // platform-agnostic availability spec has been provided.
+  bool SomeVersion = (!Introduced.empty() ||
+                      !Deprecated.empty() ||
+                      !Obsoleted.empty());
+  if (!PlatformKind.hasValue() &&
+      Platform == "swift" &&
+      SomeVersion &&
+      PlatformAgnostic == PlatformAgnosticAvailabilityKind::None) {
+    PlatformKind = PlatformKind::none;
+    PlatformAgnostic = PlatformAgnosticAvailabilityKind::SwiftVersionSpecific;
+  }
+
+
+  if (AnyArgumentInvalid)
+    return nullptr;
+  if (!PlatformKind.hasValue()) {
+    diagnose(AttrLoc, diag::attr_availability_unknown_platform,
+           Platform, AttrName);
+    return nullptr;
+  }
+
+  auto Attr = new (Context)
+  AvailableAttr(AtLoc, SourceRange(AttrLoc, Tok.getLoc()),
+                PlatformKind.getValue(),
+                Message, Renamed,
+                Introduced, IntroducedRange,
+                Deprecated, DeprecatedRange,
+                Obsoleted, ObsoletedRange,
+                PlatformAgnostic,
+                /*Implicit=*/false);
+  return makeParserResult(Attr);
+
+}
+
+bool Parser::parseSpecializeAttributeArguments(
+    swift::tok ClosingBrace, bool &DiscardAttribute, Optional<bool> &Exported,
+    Optional<SpecializeAttr::SpecializationKind> &Kind,
+    swift::TrailingWhereClause *&TrailingWhereClause) {
+  SyntaxParsingContext ContentContext(SyntaxContext,
+                                      SyntaxKind::SpecializeAttributeSpecList);
   // Parse optional "exported" and "kind" labeled parameters.
   while (!Tok.is(tok::kw_where)) {
+    SyntaxParsingContext ArgumentContext(SyntaxContext,
+                                         SyntaxKind::LabeledSpecializeEntry);
     if (Tok.is(tok::identifier)) {
       auto ParamLabel = Tok.getText();
       if (ParamLabel != "exported" && ParamLabel != "kind") {
@@ -334,8 +573,8 @@ bool Parser::parseSpecializeAttribute(swift::tok ClosingBrace, SourceLoc AtLoc,
         DiscardAttribute = true;
         return false;
       }
-      if ((ParamLabel == "exported" && exported.hasValue()) ||
-          (ParamLabel == "kind" && kind.hasValue())) {
+      if ((ParamLabel == "exported" && Exported.hasValue()) ||
+          (ParamLabel == "kind" && Kind.hasValue())) {
         diagnose(Tok.getLoc(), diag::attr_specialize_parameter_already_defined,
                  ParamLabel);
       }
@@ -358,16 +597,16 @@ bool Parser::parseSpecializeAttribute(swift::tok ClosingBrace, SourceLoc AtLoc,
           return false;
         }
         if (ParamLabel == "exported") {
-          exported = isTrue ? true : false;
+          Exported = isTrue ? true : false;
         }
       }
       if (ParamLabel == "kind") {
         SourceLoc paramValueLoc;
         if (Tok.is(tok::identifier)) {
           if (Tok.getText() == "partial") {
-            kind = SpecializeAttr::SpecializationKind::Partial;
+            Kind = SpecializeAttr::SpecializationKind::Partial;
           } else if (Tok.getText() == "full") {
-            kind = SpecializeAttr::SpecializationKind::Full;
+            Kind = SpecializeAttr::SpecializationKind::Full;
           } else {
             diagnose(Tok.getLoc(),
                      diag::attr_specialize_expected_partial_or_full);
@@ -403,15 +642,34 @@ bool Parser::parseSpecializeAttribute(swift::tok ClosingBrace, SourceLoc AtLoc,
   };
 
   // Parse the where clause.
-  TrailingWhereClause *trailingWhereClause = nullptr;
   if (Tok.is(tok::kw_where)) {
     SourceLoc whereLoc;
     SmallVector<RequirementRepr, 4> requirements;
     bool firstTypeInComplete;
     parseGenericWhereClause(whereLoc, requirements, firstTypeInComplete,
                             /* AllowLayoutConstraints */ true);
-    trailingWhereClause =
-      TrailingWhereClause::create(Context, whereLoc, requirements);
+    TrailingWhereClause =
+        TrailingWhereClause::create(Context, whereLoc, requirements);
+  }
+  return true;
+}
+
+bool Parser::parseSpecializeAttribute(swift::tok ClosingBrace, SourceLoc AtLoc,
+                                      SourceLoc Loc, SpecializeAttr *&Attr) {
+  assert(ClosingBrace == tok::r_paren || ClosingBrace == tok::r_square);
+
+  SourceLoc lParenLoc = consumeToken();
+  bool DiscardAttribute = false;
+  StringRef AttrName = "_specialize";
+
+  Optional<bool> exported;
+  Optional<SpecializeAttr::SpecializationKind> kind;
+
+  TrailingWhereClause *trailingWhereClause = nullptr;
+
+  if (!parseSpecializeAttributeArguments(ClosingBrace, DiscardAttribute,
+                                         exported, kind, trailingWhereClause)) {
+    return false;
   }
 
   // Parse the closing ')' or ']'.
@@ -457,25 +715,30 @@ Parser::parseImplementsAttribute(SourceLoc AtLoc, SourceLoc Loc) {
 
   SourceLoc lParenLoc = consumeToken();
 
-  ParserResult<TypeRepr> ProtocolType = parseType();
-  Status |= ProtocolType;
-
-  if (!(Status.shouldStopParsing() || consumeIf(tok::comma))) {
-    diagnose(Tok.getLoc(), diag::attr_expected_comma, AttrName,
-             /*DeclModifier=*/false);
-    Status.setIsParseError();
-  }
-
   DeclNameLoc MemberNameLoc;
   DeclName MemberName;
-  if (!Status.shouldStopParsing()) {
-    MemberName =
-      parseUnqualifiedDeclName(/*afterDot=*/false, MemberNameLoc,
-                               diag::attr_implements_expected_member_name,
-                               /*allowOperators=*/true,
-                               /*allowZeroArgCompoundNames=*/true);
-    if (!MemberName) {
+  ParserResult<TypeRepr> ProtocolType;
+  {
+    SyntaxParsingContext ContentContext(
+        SyntaxContext, SyntaxKind::ImplementsAttributeArguments);
+    ProtocolType = parseType();
+    Status |= ProtocolType;
+
+    if (!(Status.shouldStopParsing() || consumeIf(tok::comma))) {
+      diagnose(Tok.getLoc(), diag::attr_expected_comma, AttrName,
+               /*DeclModifier=*/false);
       Status.setIsParseError();
+    }
+
+    if (!Status.shouldStopParsing()) {
+      MemberName =
+          parseUnqualifiedDeclName(/*afterDot=*/false, MemberNameLoc,
+                                   diag::attr_implements_expected_member_name,
+                                   /*allowOperators=*/true,
+                                   /*allowZeroArgCompoundNames=*/true);
+      if (!MemberName) {
+        Status.setIsParseError();
+      }
     }
   }
 
@@ -499,15 +762,73 @@ Parser::parseImplementsAttribute(SourceLoc AtLoc, SourceLoc Loc) {
                            ProtocolType.get(), MemberName, MemberNameLoc));
 }
 
+void Parser::parseObjCSelector(SmallVector<Identifier, 4> &Names,
+                               SmallVector<SourceLoc, 4> &NameLocs,
+                               bool &IsNullarySelector) {
+  IsNullarySelector = true;
+  SyntaxParsingContext SelectorContext(SyntaxContext, SyntaxKind::ObjCSelector);
+  while (true) {
+    SyntaxParsingContext SelectorPieceContext(SyntaxContext,
+                                              SyntaxKind::ObjCSelectorPiece);
+    // Empty selector piece.
+    if (Tok.is(tok::colon)) {
+      Names.push_back(Identifier());
+      NameLocs.push_back(Tok.getLoc());
+      IsNullarySelector = false;
+      consumeToken();
+      continue;
+    }
+
+    // Name.
+    if (Tok.is(tok::identifier) || Tok.isKeyword()) {
+      Names.push_back(Context.getIdentifier(Tok.getText()));
+      NameLocs.push_back(Tok.getLoc());
+      consumeToken();
+
+      // If we have a colon, consume it.
+      if (Tok.is(tok::colon)) {
+        consumeToken();
+        IsNullarySelector = false;
+        continue;
+      }
+
+      // If we see a closing parentheses, we're done.
+      if (Tok.is(tok::r_paren)) {
+        // If we saw more than one identifier, there's a ':'
+        // missing here. Complain and pretend we saw it.
+        if (Names.size() > 1) {
+          diagnose(Tok, diag::attr_objc_missing_colon)
+          .fixItInsertAfter(NameLocs.back(), ":");
+          IsNullarySelector = false;
+        }
+
+        break;
+      }
+
+      // If we see another identifier or keyword, complain about
+      // the missing colon and keep going.
+      if (Tok.is(tok::identifier) || Tok.isKeyword()) {
+        diagnose(Tok, diag::attr_objc_missing_colon)
+        .fixItInsertAfter(NameLocs.back(), ":");
+        IsNullarySelector = false;
+        continue;
+      }
+
+      // We don't know what happened. Break out.
+      break;
+    }
+
+    // We didn't parse anything, don't create a ObjCSelectorPiece
+    SelectorPieceContext.setTransparent();
+    break;
+  }
+}
+
 bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
                                    DeclAttrKind DK) {
   // Ok, it is a valid attribute, eat it, and then process it.
   StringRef AttrName = Tok.getText();
   SourceLoc Loc = consumeToken();
-
-  // We can only make this attribute a token list intead of an Attribute node
-  // because the attribute node may include '@'
-  SyntaxParsingContext TokListContext(SyntaxContext, SyntaxKind::TokenList);
 
   bool DiscardAttribute = false;
 
@@ -529,20 +850,6 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
   // Filled in during parsing.  If there is a duplicate
   // diagnostic this can be used for better error presentation.
   SourceRange AttrRange;
-
-
-  // Check 'Tok', return false if ':' or '=' cannot be found.
-  // Complain if '=' is found and suggest replacing it with ": ".
-  auto findAttrValueDelimiter = [&]() -> bool {
-    if (!Tok.is(tok::colon)) {
-      if (!Tok.is(tok::equal))
-        return false;
-
-      diagnose(Tok.getLoc(), diag::replace_equal_with_colon_for_value)
-        .fixItReplace(Tok.getLoc(), ": ");
-    }
-    return true;
-  };
 
   switch (DK) {
   case DAK_Count:
@@ -1026,167 +1333,9 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
       break;
     }
 
-    consumeToken();
-
-    StringRef Message, Renamed;
-    clang::VersionTuple Introduced, Deprecated, Obsoleted;
-    SourceRange IntroducedRange, DeprecatedRange, ObsoletedRange;
-    auto PlatformAgnostic = PlatformAgnosticAvailabilityKind::None;
-    bool AnyAnnotations = false;
-    int ParamIndex = 0;
-
-    while (consumeIf(tok::comma)) {
-      AnyAnnotations = true;
-      StringRef ArgumentKindStr = Tok.getText();
-      ParamIndex ++;
-
-      enum {
-        IsMessage, IsRenamed,
-        IsIntroduced, IsDeprecated, IsObsoleted,
-        IsUnavailable,
-        IsInvalid
-      } ArgumentKind = IsInvalid;
-
-      if (Tok.is(tok::identifier)) {
-        ArgumentKind =
-          llvm::StringSwitch<decltype(ArgumentKind)>(ArgumentKindStr)
-            .Case("message", IsMessage)
-            .Case("renamed", IsRenamed)
-            .Case("introduced", IsIntroduced)
-            .Case("deprecated", IsDeprecated)
-            .Case("obsoleted", IsObsoleted)
-            .Case("unavailable", IsUnavailable)
-            .Default(IsInvalid);
-      }
-
-      if (ArgumentKind == IsInvalid) {
-        DiscardAttribute = true;
-        diagnose(Tok.getLoc(), diag::attr_availability_expected_option,
-                 AttrName)
-          .highlight(SourceRange(Tok.getLoc()));
-        if (Tok.is(tok::code_complete) && CodeCompletion) {
-          CodeCompletion->completeDeclAttrParam(DAK_Available, ParamIndex);
-          consumeToken(tok::code_complete);
-        } else {
-          consumeIf(tok::identifier);
-        }
-        break;
-      }
-
-      consumeToken();
-
-      switch (ArgumentKind) {
-      case IsMessage:
-      case IsRenamed: {
-        // Items with string arguments.
-        if (findAttrValueDelimiter()) {
-          consumeToken();
-        } else {
-          diagnose(Tok, diag::attr_availability_expected_equal,
-                   AttrName, ArgumentKindStr);
-          DiscardAttribute = true;
-          if (peekToken().isAny(tok::r_paren, tok::comma))
-            consumeToken();
-          continue;
-        }
-
-        if (!Tok.is(tok::string_literal)) {
-          diagnose(Loc, diag::attr_expected_string_literal, AttrName);
-          DiscardAttribute = true;
-          if (peekToken().isAny(tok::r_paren, tok::comma))
-            consumeToken();
-          continue;
-        }
-
-        auto Value =
-          getStringLiteralIfNotInterpolated(*this, Loc, Tok, ArgumentKindStr);
-        consumeToken();
-        if (!Value) {
-          DiscardAttribute = true;
-          continue;
-        }
-
-        if (ArgumentKind == IsMessage) {
-          Message = Value.getValue();
-        } else {
-          ParsedDeclName parsedName = parseDeclName(Value.getValue());
-          if (!parsedName) {
-            diagnose(Loc, diag::attr_availability_invalid_renamed, AttrName);
-            DiscardAttribute = true;
-            continue;
-          }
-          Renamed = Value.getValue();
-        }
-        break;
-      }
-
-      case IsDeprecated:
-        if (!findAttrValueDelimiter()) {
-          if (PlatformAgnostic != PlatformAgnosticAvailabilityKind::None) {
-            diagnose(Tok, diag::attr_availability_unavailable_deprecated,
-                     AttrName);
-          }
-
-          PlatformAgnostic = PlatformAgnosticAvailabilityKind::Deprecated;
-          break;
-        }
-        LLVM_FALLTHROUGH;
-
-      case IsIntroduced:
-      case IsObsoleted: {
-        // Items with version arguments.
-        if (findAttrValueDelimiter()) {
-          consumeToken();
-        } else {
-          diagnose(Tok, diag::attr_availability_expected_equal,
-                   AttrName, ArgumentKindStr);
-          DiscardAttribute = true;
-          if (peekToken().isAny(tok::r_paren, tok::comma))
-            consumeToken();
-          continue;
-        }
-
-        auto &VersionArg = (ArgumentKind == IsIntroduced) ? Introduced :
-                           (ArgumentKind == IsDeprecated) ? Deprecated :
-                                                            Obsoleted;
-
-        auto &VersionRange = (ArgumentKind == IsIntroduced) ? IntroducedRange :
-                             (ArgumentKind == IsDeprecated) ? DeprecatedRange :
-                                                              ObsoletedRange;
-
-        if (parseVersionTuple(
-                VersionArg, VersionRange,
-                Diagnostic(diag::attr_availability_expected_version,
-                           AttrName))) {
-          DiscardAttribute = true;
-          if (peekToken().isAny(tok::r_paren, tok::comma))
-            consumeToken();
-        }
-
-        break;
-      }
-
-      case IsUnavailable:
-        if (PlatformAgnostic != PlatformAgnosticAvailabilityKind::None) {
-          diagnose(Tok, diag::attr_availability_unavailable_deprecated,
-                   AttrName);
-        }
-
-        PlatformAgnostic = PlatformAgnosticAvailabilityKind::Unavailable;
-        break;
-
-      case IsInvalid:
-        llvm_unreachable("handled above");
-      }
-    }
-
-    if (!AnyAnnotations) {
-      diagnose(Tok.getLoc(), diag::attr_expected_comma, AttrName,
-               DeclAttribute::isDeclModifier(DK));
-      DiscardAttribute = true;
-    }
-
-    AttrRange = SourceRange(Loc, Tok.getLoc());
+    auto AvailabilityAttr = parseExtendedAvailabilitySpecList(AtLoc, Loc,
+                                                              AttrName);
+    DiscardAttribute |= AvailabilityAttr.isParseError();
 
     if (!consumeIf(tok::r_paren)) {
       if (!DiscardAttribute) {
@@ -1197,39 +1346,9 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     }
 
     if (!DiscardAttribute) {
-      auto PlatformKind = platformFromString(Platform);
-
-      // Treat 'swift' as a valid version-qualifying token, when
-      // at least some versions were mentioned and no other
-      // platform-agnostic availability spec has been provided.
-      bool SomeVersion = (!Introduced.empty() ||
-                          !Deprecated.empty() ||
-                          !Obsoleted.empty());
-      if (!PlatformKind.hasValue() &&
-          Platform == "swift" &&
-          SomeVersion &&
-          PlatformAgnostic == PlatformAgnosticAvailabilityKind::None) {
-        PlatformKind = PlatformKind::none;
-        PlatformAgnostic =
-          PlatformAgnosticAvailabilityKind::SwiftVersionSpecific;
-      }
-
-      if (PlatformKind.hasValue()) {
-        Attributes.add(new (Context)
-                       AvailableAttr(AtLoc, AttrRange,
-                                        PlatformKind.getValue(),
-                                        Message, Renamed,
-                                        Introduced, IntroducedRange,
-                                        Deprecated, DeprecatedRange,
-                                        Obsoleted, ObsoletedRange,
-                                        PlatformAgnostic,
-                                        /*Implicit=*/false));
-      } else {
-        // Not a known platform. Just drop the attribute.
-        diagnose(Loc, diag::attr_availability_unknown_platform,
-                 Platform, AttrName);
-        return false;
-      }
+      Attributes.add(AvailabilityAttr.get());
+    } else {
+      return false;
     }
     break;
   }
@@ -1245,62 +1364,13 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
     // Parse the leading '('.
     SourceLoc LParenLoc = consumeToken(tok::l_paren);
 
-    // Parse the names, with trailing colons (if there are present).
+    // Parse the names, with trailing colons (if there are present) and populate
+    // the inout parameters
     SmallVector<Identifier, 4> Names;
     SmallVector<SourceLoc, 4> NameLocs;
-    bool sawColon = false;
-    while (true) {
-      // Empty selector piece.
-      if (Tok.is(tok::colon)) {
-        Names.push_back(Identifier());
-        NameLocs.push_back(Tok.getLoc());
-        sawColon = true;
-        consumeToken();
-        continue;
-      }
+    bool NullarySelector = true;
+    parseObjCSelector(Names, NameLocs, NullarySelector);
 
-      // Name.
-      if (Tok.is(tok::identifier) || Tok.isKeyword()) {
-        Names.push_back(Context.getIdentifier(Tok.getText()));
-        NameLocs.push_back(Tok.getLoc());
-        consumeToken();
-
-        // If we have a colon, consume it.
-        if (Tok.is(tok::colon)) {
-          consumeToken();
-          sawColon = true;
-          continue;
-        } 
-        
-        // If we see a closing parentheses, we're done.
-        if (Tok.is(tok::r_paren)) {
-          // If we saw more than one identifier, there's a ':'
-          // missing here. Complain and pretend we saw it.
-          if (Names.size() > 1) {
-            diagnose(Tok, diag::attr_objc_missing_colon)
-              .fixItInsertAfter(NameLocs.back(), ":");
-            sawColon = true;
-          }
-
-          break;
-        }
-
-        // If we see another identifier or keyword, complain about
-        // the missing colon and keep going.
-        if (Tok.is(tok::identifier) || Tok.isKeyword()) {
-          diagnose(Tok, diag::attr_objc_missing_colon)
-            .fixItInsertAfter(NameLocs.back(), ":");
-          sawColon = true;
-          continue;
-        }
-
-        // We don't know what happened. Break out.
-        break;
-      }
-
-      break;
-    }
-    
     // Parse the matching ')'.
     SourceLoc RParenLoc;
     bool Invalid = parseMatchingToken(tok::r_paren, RParenLoc,
@@ -1313,7 +1383,7 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
       if (!Invalid)
         diagnose(LParenLoc, diag::attr_objc_empty_name);
       attr = ObjCAttr::createUnnamed(Context, AtLoc, Loc);
-    } else if (!sawColon) {
+    } else if (NullarySelector) {
       // When we didn't see a colon, this is a nullary name.
       assert(Names.size() == 1 && "Forgot to set sawColon?");
       attr = ObjCAttr::createNullary(Context, AtLoc, Loc, LParenLoc,
@@ -1371,6 +1441,7 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
 bool Parser::parseVersionTuple(clang::VersionTuple &Version,
                                SourceRange &Range,
                                const Diagnostic &D) {
+  SyntaxParsingContext VersionContext(SyntaxContext, SyntaxKind::VersionTuple);
   // A version number is either an integer (8), a float (8.1), or a
   // float followed by a dot and an integer (8.1.0).
   if (!Tok.isAny(tok::integer_literal, tok::floating_literal)) {
@@ -1655,9 +1726,6 @@ bool Parser::parseTypeAttribute(TypeAttributes &Attributes, bool justChecking) {
   StringRef Text = Tok.getText();
   SourceLoc Loc = consumeToken();
   
-  // Accumulate attribute argument '( ... )' as a token list.
-  SyntaxParsingContext TokListContext(SyntaxContext, SyntaxKind::TokenList);
-
   bool isAutoclosureEscaping = false;
   SourceRange autoclosureEscapingParenRange;
   StringRef conventionName;

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3475,6 +3475,8 @@ ParserResult<AvailabilitySpec> Parser::parseAvailabilitySpec() {
 ///     "swift" version-tuple
 ParserResult<LanguageVersionConstraintAvailabilitySpec>
 Parser::parseLanguageVersionConstraintSpec() {
+  SyntaxParsingContext VersionRestrictionContext(
+      SyntaxContext, SyntaxKind::AvailabilityVersionRestriction);
   SourceLoc SwiftLoc;
   clang::VersionTuple Version;
   SourceRange VersionRange;
@@ -3498,6 +3500,9 @@ Parser::parseLanguageVersionConstraintSpec() {
 ///     identifier version-comparison version-tuple
 ParserResult<PlatformVersionConstraintAvailabilitySpec>
 Parser::parsePlatformVersionConstraintSpec() {
+  SyntaxParsingContext VersionRestrictionContext(
+      SyntaxContext, SyntaxKind::AvailabilityVersionRestriction);
+
   Identifier PlatformIdentifier;
   SourceLoc PlatformLoc;
   if (Tok.is(tok::code_complete)) {

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1150,11 +1150,15 @@ ParserResult<PoundAvailableInfo> Parser::parseStmtConditionPoundAvailable() {
 
 ParserStatus
 Parser::parseAvailabilitySpecList(SmallVectorImpl<AvailabilitySpec *> &Specs) {
+  SyntaxParsingContext AvailabilitySpecContext(
+      SyntaxContext, SyntaxKind::AvailabilitySpecList);
   ParserStatus Status = makeParserSuccess();
 
   // We don't use parseList() because we want to provide more specific
   // diagnostics disallowing operators in version specs.
   while (1) {
+    SyntaxParsingContext AvailabilityEntryContext(
+        SyntaxContext, SyntaxKind::AvailabilityArgument);
     auto SpecResult = parseAvailabilitySpec();
     if (auto *Spec = SpecResult.getPtrOrNull()) {
       Specs.push_back(Spec);

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -173,7 +173,8 @@ void SyntaxParsingContext::createNodeInPlace(SyntaxKind Kind) {
   case SyntaxKind::OptionalChainingExpr:
   case SyntaxKind::ForcedValueExpr:
   case SyntaxKind::PostfixUnaryExpr:
-  case SyntaxKind::TernaryExpr: {
+  case SyntaxKind::TernaryExpr:
+  case SyntaxKind::AvailabilityLabeledArgument: {
     auto Pair = SyntaxFactory::countChildren(Kind);
     assert(Pair.first == Pair.second);
     createNodeInPlace(Kind, Pair.first);

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -151,7 +151,7 @@ class Bar<TypeInheritanceClause>: <InheritedType><SimpleTypeIdentifier>Foo </Sim
 
 class C<GenericParameterClause><<GenericParameter>A, </GenericParameter><GenericParameter>B</GenericParameter>> </GenericParameterClause><GenericWhereClause>where <ConformanceRequirement><SimpleTypeIdentifier>A</SimpleTypeIdentifier>: <SimpleTypeIdentifier>Foo</SimpleTypeIdentifier>, </ConformanceRequirement><SameTypeRequirement><SimpleTypeIdentifier>B </SimpleTypeIdentifier>== <SimpleTypeIdentifier>Bar </SimpleTypeIdentifier></SameTypeRequirement></GenericWhereClause><MemberDeclBlock>{}</MemberDeclBlock></ClassDecl><ClassDecl><Attribute>
 
-@available(*, unavailable)</Attribute><DeclModifier>
+@available(<AvailabilityArgument>*, </AvailabilityArgument><AvailabilityArgument>unavailable</AvailabilityArgument>)</Attribute><DeclModifier>
 private </DeclModifier>class C <MemberDeclBlock>{}</MemberDeclBlock></ClassDecl><StructDecl>
 
 struct foo <MemberDeclBlock>{<StructDecl>
@@ -165,12 +165,15 @@ struct foo <MemberDeclBlock>{<StructDecl>
 }</MemberDeclBlock></StructDecl><StructDecl>
 
 struct foo <MemberDeclBlock>{<StructDecl><Attribute>
-  @available(*, unavailable)</Attribute>
+  @available(<AvailabilityArgument>*, </AvailabilityArgument><AvailabilityArgument>unavailable</AvailabilityArgument>)</Attribute>
   struct foo <MemberDeclBlock>{}</MemberDeclBlock></StructDecl><ClassDecl><DeclModifier>
   public </DeclModifier>class foo <MemberDeclBlock>{<FunctionDecl><Attribute>
-    @available(*, unavailable)</Attribute><Attribute>
-    @objc(fooObjc)</Attribute><DeclModifier>
-    private </DeclModifier><DeclModifier>static </DeclModifier>func foo<FunctionSignature><ParameterClause>() </ParameterClause></FunctionSignature><CodeBlock>{}</CodeBlock></FunctionDecl>
+    @available(<AvailabilityArgument>*, </AvailabilityArgument><AvailabilityArgument>unavailable</AvailabilityArgument>)</Attribute><Attribute>
+    @objc(<ObjCSelectorPiece>fooObjc</ObjCSelectorPiece>)</Attribute><DeclModifier>
+    private </DeclModifier><DeclModifier>static </DeclModifier>func foo<FunctionSignature><ParameterClause>() </ParameterClause></FunctionSignature><CodeBlock>{}</CodeBlock></FunctionDecl><FunctionDecl><Attribute>
+    
+    @objc(<ObjCSelectorPiece>fooObjcBar:</ObjCSelectorPiece><ObjCSelectorPiece>baz:</ObjCSelectorPiece>)</Attribute><DeclModifier>
+    private </DeclModifier><DeclModifier>static </DeclModifier>func foo<FunctionSignature><ParameterClause>(<FunctionParameter>bar: <SimpleTypeIdentifier>String</SimpleTypeIdentifier>, </FunctionParameter><FunctionParameter>baz: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier></FunctionParameter>)</ParameterClause></FunctionSignature></FunctionDecl>
   }</MemberDeclBlock></ClassDecl>
 }</MemberDeclBlock></StructDecl><StructDecl>
 
@@ -195,7 +198,7 @@ func foo<FunctionSignature><ParameterClause>( <FunctionParameter>a: <SimpleTypeI
 
 struct C <MemberDeclBlock>{<FunctionDecl><Attribute>
 @objc</Attribute><Attribute>
-@available(*, unavailable)</Attribute><DeclModifier>
+@available(<AvailabilityArgument>*, </AvailabilityArgument><AvailabilityArgument>unavailable</AvailabilityArgument>)</Attribute><DeclModifier>
 private </DeclModifier><DeclModifier>static </DeclModifier><DeclModifier>override </DeclModifier>func foo<GenericParameterClause><<GenericParameter>a, </GenericParameter><GenericParameter>b, </GenericParameter><GenericParameter>c</GenericParameter>></GenericParameterClause><FunctionSignature><ParameterClause>(<FunctionParameter>a b: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier>, </FunctionParameter><FunctionParameter>c: <SimpleTypeIdentifier>Int</SimpleTypeIdentifier></FunctionParameter>) </ParameterClause>throws <ReturnClause>-> <ArrayType>[<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>] </ArrayType></ReturnClause></FunctionSignature><GenericWhereClause>where <SameTypeRequirement><SimpleTypeIdentifier>a</SimpleTypeIdentifier>==<SimpleTypeIdentifier>p1</SimpleTypeIdentifier>, </SameTypeRequirement><ConformanceRequirement><SimpleTypeIdentifier>b</SimpleTypeIdentifier>:<SimpleTypeIdentifier>p2 </SimpleTypeIdentifier></ConformanceRequirement></GenericWhereClause><CodeBlock>{ <IdentifierExpr>ddd </IdentifierExpr>}</CodeBlock></FunctionDecl><FunctionDecl>
 func rootView<FunctionSignature><ParameterClause>() </ParameterClause><ReturnClause>-> <SimpleTypeIdentifier>Label </SimpleTypeIdentifier></ReturnClause></FunctionSignature><CodeBlock>{}</CodeBlock></FunctionDecl><FunctionDecl><DeclModifier>
 static </DeclModifier>func ==<FunctionSignature><ParameterClause>() </ParameterClause><ReturnClause>-> <SimpleTypeIdentifier>bool </SimpleTypeIdentifier></ReturnClause></FunctionSignature><CodeBlock>{}</CodeBlock></FunctionDecl><FunctionDecl><DeclModifier>
@@ -415,7 +418,7 @@ extension <SimpleTypeIdentifier>ext </SimpleTypeIdentifier><MemberDeclBlock>{<Va
   }</AccessorBlock></PatternBinding></VariableDecl>
 }</MemberDeclBlock></ExtensionDecl><ExtensionDecl><Attribute>
 
-@available(*, unavailable)</Attribute><DeclModifier>
+@available(<AvailabilityArgument>*, </AvailabilityArgument><AvailabilityArgument>unavailable</AvailabilityArgument>)</Attribute><DeclModifier>
 fileprivate </DeclModifier>extension <SimpleTypeIdentifier>ext </SimpleTypeIdentifier><MemberDeclBlock>{}</MemberDeclBlock></ExtensionDecl><ExtensionDecl>
 
 extension <SimpleTypeIdentifier>ext </SimpleTypeIdentifier><TypeInheritanceClause>: <InheritedType><SimpleTypeIdentifier>extProtocol </SimpleTypeIdentifier></InheritedType></TypeInheritanceClause><MemberDeclBlock>{}</MemberDeclBlock></ExtensionDecl><ExtensionDecl>
@@ -490,4 +493,43 @@ postfix </DeclModifier>operator <-</OperatorDecl><FunctionDecl>
 func higherOrderFunc<FunctionSignature><ParameterClause>() </ParameterClause></FunctionSignature><CodeBlock>{<VariableDecl>
   let <PatternBinding><IdentifierPattern>x </IdentifierPattern><InitializerClause>= <ArrayExpr>[<ArrayElement><IntegerLiteralExpr>1</IntegerLiteralExpr>,</ArrayElement><ArrayElement><IntegerLiteralExpr>2</IntegerLiteralExpr>,</ArrayElement><ArrayElement><IntegerLiteralExpr>3</IntegerLiteralExpr></ArrayElement>]</ArrayExpr></InitializerClause></PatternBinding></VariableDecl><FunctionCallExpr><MemberAccessExpr><IdentifierExpr>
   x</IdentifierExpr>.reduce</MemberAccessExpr>(<FunctionCallArgument><IntegerLiteralExpr>0</IntegerLiteralExpr>, </FunctionCallArgument><FunctionCallArgument><IdentifierExpr>+</IdentifierExpr></FunctionCallArgument>)</FunctionCallExpr>
-}</CodeBlock></FunctionDecl>
+}</CodeBlock></FunctionDecl><IfStmt>
+
+if <ConditionElement><AvailabilityCondition>#available(<AvailabilityArgument><AvailabilityVersionRestriction>iOS <VersionTuple>11</VersionTuple></AvailabilityVersionRestriction>, </AvailabilityArgument><AvailabilityArgument><AvailabilityVersionRestriction>macOS <VersionTuple>10.11.2</VersionTuple></AvailabilityVersionRestriction>, </AvailabilityArgument><AvailabilityArgument>*</AvailabilityArgument>) </AvailabilityCondition></ConditionElement><CodeBlock>{}</CodeBlock></IfStmt><FunctionDecl><Attribute>
+
+@_specialize(<GenericWhereClause>where <SameTypeRequirement><SimpleTypeIdentifier>T </SimpleTypeIdentifier>== <SimpleTypeIdentifier>Int</SimpleTypeIdentifier></SameTypeRequirement></GenericWhereClause>)</Attribute><Attribute>
+@_specialize(<LabeledSpecializeEntry>exported: true, </LabeledSpecializeEntry><GenericWhereClause>where <SameTypeRequirement><SimpleTypeIdentifier>T </SimpleTypeIdentifier>== <SimpleTypeIdentifier>String</SimpleTypeIdentifier></SameTypeRequirement></GenericWhereClause>)</Attribute><DeclModifier>
+public </DeclModifier>func specializedGenericFunc<GenericParameterClause><<GenericParameter>T</GenericParameter>></GenericParameterClause><FunctionSignature><ParameterClause>(<FunctionParameter>_ t: <SimpleTypeIdentifier>T</SimpleTypeIdentifier></FunctionParameter>) </ParameterClause><ReturnClause>-> <SimpleTypeIdentifier>T </SimpleTypeIdentifier></ReturnClause></FunctionSignature><CodeBlock>{<ReturnStmt>
+  return <IdentifierExpr>t</IdentifierExpr></ReturnStmt>
+}</CodeBlock></FunctionDecl><ProtocolDecl>
+
+protocol Q <MemberDeclBlock>{<FunctionDecl>
+  func g<FunctionSignature><ParameterClause>()</ParameterClause></FunctionSignature></FunctionDecl><VariableDecl>
+  var <PatternBinding><IdentifierPattern>x</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>String </SimpleTypeIdentifier></TypeAnnotation><AccessorBlock>{ <AccessorDecl>get </AccessorDecl>}</AccessorBlock></PatternBinding></VariableDecl><FunctionDecl>
+  func f<FunctionSignature><ParameterClause>(<FunctionParameter>x:<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>, </FunctionParameter><FunctionParameter>y:<SimpleTypeIdentifier>Int</SimpleTypeIdentifier></FunctionParameter>) </ParameterClause><ReturnClause>-> <SimpleTypeIdentifier>Int</SimpleTypeIdentifier></ReturnClause></FunctionSignature></FunctionDecl>
+  #if <IdentifierExpr>FOO_BAR</IdentifierExpr><VariableDecl>
+  var <PatternBinding><IdentifierPattern>conditionalVar</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>String</SimpleTypeIdentifier></TypeAnnotation></PatternBinding></VariableDecl>
+  #endif
+}</MemberDeclBlock></ProtocolDecl><StructDecl>
+
+struct S <TypeInheritanceClause>: <InheritedType><SimpleTypeIdentifier>Q</SimpleTypeIdentifier>, </InheritedType><InheritedType><SimpleTypeIdentifier>Equatable </SimpleTypeIdentifier></InheritedType></TypeInheritanceClause><MemberDeclBlock>{<FunctionDecl><Attribute>
+  @_implements(<ImplementsAttributeArguments><SimpleTypeIdentifier>Q</SimpleTypeIdentifier>, f<DeclNameArguments>(<DeclNameArgument>x:</DeclNameArgument><DeclNameArgument>y:</DeclNameArgument>)</DeclNameArguments></ImplementsAttributeArguments>)</Attribute>
+  func h<FunctionSignature><ParameterClause>(<FunctionParameter>x:<SimpleTypeIdentifier>Int</SimpleTypeIdentifier>, </FunctionParameter><FunctionParameter>y:<SimpleTypeIdentifier>Int</SimpleTypeIdentifier></FunctionParameter>) </ParameterClause><ReturnClause>-> <SimpleTypeIdentifier>Int </SimpleTypeIdentifier></ReturnClause></FunctionSignature><CodeBlock>{<ReturnStmt>
+    return <IntegerLiteralExpr>6</IntegerLiteralExpr></ReturnStmt>
+  }</CodeBlock></FunctionDecl><FunctionDecl><Attribute>
+
+  @_implements(<ImplementsAttributeArguments><SimpleTypeIdentifier>Equatable</SimpleTypeIdentifier>, ==<DeclNameArguments>(<DeclNameArgument>_:</DeclNameArgument><DeclNameArgument>_:</DeclNameArgument>)</DeclNameArguments></ImplementsAttributeArguments>)</Attribute><DeclModifier>
+  public </DeclModifier><DeclModifier>static </DeclModifier>func isEqual<FunctionSignature><ParameterClause>(<FunctionParameter>_ lhs: <SimpleTypeIdentifier>S</SimpleTypeIdentifier>, </FunctionParameter><FunctionParameter>_ rhs: <SimpleTypeIdentifier>S</SimpleTypeIdentifier></FunctionParameter>) </ParameterClause><ReturnClause>-> <SimpleTypeIdentifier>Bool </SimpleTypeIdentifier></ReturnClause></FunctionSignature><CodeBlock>{<ReturnStmt>
+    return <BooleanLiteralExpr>false</BooleanLiteralExpr></ReturnStmt>
+  }</CodeBlock></FunctionDecl><VariableDecl><Attribute>
+
+  @_implements(<ImplementsAttributeArguments><SimpleTypeIdentifier>P</SimpleTypeIdentifier>, x</ImplementsAttributeArguments>)</Attribute>
+  var <PatternBinding><IdentifierPattern>y</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>String</SimpleTypeIdentifier></TypeAnnotation></PatternBinding></VariableDecl><FunctionDecl><Attribute>
+  @_implements(<ImplementsAttributeArguments><SimpleTypeIdentifier>P</SimpleTypeIdentifier>, g<DeclNameArguments>()</DeclNameArguments></ImplementsAttributeArguments>)</Attribute>
+  func h<FunctionSignature><ParameterClause>() </ParameterClause></FunctionSignature><CodeBlock>{}</CodeBlock></FunctionDecl><VariableDecl><Attribute>
+
+  @available(<AvailabilityArgument>*, </AvailabilityArgument><AvailabilityArgument><AvailabilityLabeledArgument>deprecated: <VersionTuple>1.2</VersionTuple></AvailabilityLabeledArgument>, </AvailabilityArgument><AvailabilityArgument><AvailabilityLabeledArgument>message: "ABC"</AvailabilityLabeledArgument></AvailabilityArgument>)</Attribute><DeclModifier>
+  fileprivate(set) </DeclModifier>var <PatternBinding><IdentifierPattern>x</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>String</SimpleTypeIdentifier></TypeAnnotation></PatternBinding></VariableDecl>
+}</MemberDeclBlock></StructDecl><StructDecl><Attribute>
+
+@_alignment(16) </Attribute><DeclModifier>public </DeclModifier>struct float3 <MemberDeclBlock>{ <VariableDecl><DeclModifier>public </DeclModifier>var <PatternBinding><IdentifierPattern>x</IdentifierPattern>, </PatternBinding><PatternBinding><IdentifierPattern>y</IdentifierPattern>, </PatternBinding><PatternBinding><IdentifierPattern>z</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Float </SimpleTypeIdentifier></TypeAnnotation></PatternBinding></VariableDecl>}</MemberDeclBlock></StructDecl>

--- a/test/Syntax/round_trip_parse_gen.swift
+++ b/test/Syntax/round_trip_parse_gen.swift
@@ -171,6 +171,9 @@ struct foo {
     @available(*, unavailable)
     @objc(fooObjc)
     private static func foo() {}
+    
+    @objc(fooObjcBar:baz:)
+    private static func foo(bar: String, baz: Int)
   }
 }
 
@@ -491,3 +494,42 @@ func higherOrderFunc() {
   let x = [1,2,3]
   x.reduce(0, +)
 }
+
+if #available(iOS 11, macOS 10.11.2, *) {}
+
+@_specialize(where T == Int)
+@_specialize(exported: true, where T == String)
+public func specializedGenericFunc<T>(_ t: T) -> T {
+  return t
+}
+
+protocol Q {
+  func g()
+  var x: String { get }
+  func f(x:Int, y:Int) -> Int
+  #if FOO_BAR
+  var conditionalVar: String
+  #endif
+}
+
+struct S : Q, Equatable {
+  @_implements(Q, f(x:y:))
+  func h(x:Int, y:Int) -> Int {
+    return 6
+  }
+
+  @_implements(Equatable, ==(_:_:))
+  public static func isEqual(_ lhs: S, _ rhs: S) -> Bool {
+    return false
+  }
+
+  @_implements(P, x)
+  var y: String
+  @_implements(P, g())
+  func h() {}
+
+  @available(*, deprecated: 1.2, message: "ABC")
+  fileprivate(set) var x: String
+}
+
+@_alignment(16) public struct float3 { public var x, y, z: Float }

--- a/unittests/Syntax/DeclSyntaxTests.cpp
+++ b/unittests/Syntax/DeclSyntaxTests.cpp
@@ -17,8 +17,7 @@ DeclModifierSyntax getCannedDeclModifier() {
   auto LParen = SyntaxFactory::makeLeftParenToken({}, {});
   auto Set = SyntaxFactory::makeIdentifier("set", {}, {});
   auto RParen = SyntaxFactory::makeRightParenToken({}, {});
-  return SyntaxFactory::makeDeclModifier(Private,
-    SyntaxFactory::makeTokenList({ LParen, Set, RParen}));
+  return SyntaxFactory::makeDeclModifier(Private, LParen, Set, RParen);
 }
 
 TEST(DeclSyntaxTests, DeclModifierMakeAPIs) {
@@ -41,13 +40,12 @@ TEST(DeclSyntaxTests, DeclModifierGetAPIs) {
   auto LParen = SyntaxFactory::makeLeftParenToken({}, {});
   auto Set = SyntaxFactory::makeIdentifier("set", {}, {});
   auto RParen = SyntaxFactory::makeRightParenToken({}, {});
-  auto Mod = SyntaxFactory::makeDeclModifier(Private,
-    SyntaxFactory::makeTokenList({LParen, Set, RParen}));
+  auto Mod = SyntaxFactory::makeDeclModifier(Private, LParen, Set, RParen);
 
   ASSERT_EQ(Private.getRaw(), Mod.getName().getRaw());
-  ASSERT_EQ(LParen.getRaw(), Mod.getDetail().getValue()[0].getRaw());
-  ASSERT_EQ(Set.getRaw(), Mod.getDetail().getValue()[1].getRaw());
-  ASSERT_EQ(RParen.getRaw(), Mod.getDetail().getValue()[2].getRaw());
+  ASSERT_EQ(LParen.getRaw(), Mod.getDetailLeftParen()->getRaw());
+  ASSERT_EQ(Set.getRaw(), Mod.getDetail()->getRaw());
+  ASSERT_EQ(RParen.getRaw(), Mod.getDetailRightParen()->getRaw());
 }
 
 TEST(DeclSyntaxTests, DeclModifierWithAPIs) {
@@ -59,9 +57,11 @@ TEST(DeclSyntaxTests, DeclModifierWithAPIs) {
   SmallString<24> Scratch;
   llvm::raw_svector_ostream OS(Scratch);
   SyntaxFactory::makeBlankDeclModifier()
-    .withName(Private)
-    .withDetail(SyntaxFactory::makeTokenList({LParen, Set, RParen}))
-    .print(OS);
+      .withName(Private)
+      .withDetailLeftParen(LParen)
+      .withDetail(Set)
+      .withDetailRightParen(RParen)
+      .print(OS);
   ASSERT_EQ(OS.str().str(), "private(set)");
 }
 
@@ -467,12 +467,12 @@ ModifierListSyntax getCannedModifiers() {
   auto NoLParen = TokenSyntax::missingToken(tok::l_paren, "(");
   auto NoArgument = TokenSyntax::missingToken(tok::identifier, "");
   auto NoRParen = TokenSyntax::missingToken(tok::r_paren, ")");
-  auto Public = SyntaxFactory::makeDeclModifier(PublicID,
-    SyntaxFactory::makeTokenList({NoLParen, NoArgument, NoRParen}));
+  auto Public =
+      SyntaxFactory::makeDeclModifier(PublicID, NoLParen, NoArgument, NoRParen);
 
   auto StaticKW = SyntaxFactory::makeStaticKeyword({}, Trivia::spaces(1));
-  auto Static = SyntaxFactory::makeDeclModifier(StaticKW,
-    SyntaxFactory::makeTokenList({NoLParen, NoArgument, NoRParen}));
+  auto Static =
+      SyntaxFactory::makeDeclModifier(StaticKW, NoLParen, NoArgument, NoRParen);
 
   return SyntaxFactory::makeBlankModifierList()
     .appending(Public)

--- a/unittests/Syntax/TypeSyntaxTests.cpp
+++ b/unittests/Syntax/TypeSyntaxTests.cpp
@@ -32,14 +32,14 @@ TEST(TypeSyntaxTests, TypeAttributeWithAPIs) {
     auto Convention = SyntaxFactory::makeBlankAttribute()
       .withAtSignToken(At)
       .withAttributeName(conventionID)
-      .withBalancedTokens(SyntaxFactory::makeTokenList({LeftParen, RightParen}));
+      .withLeftParen(LeftParen)
+      .withRightParen(RightParen);
 
     {
       SmallString<48> Scratch;
       llvm::raw_svector_ostream OS { Scratch };
       auto cID = SyntaxFactory::makeIdentifier("c", {}, {});
-      auto cArgs = SyntaxFactory::makeTokenList({LeftParen, cID, RightParen});
-      Convention.withBalancedTokens(cArgs).print(OS);
+      Convention.withArgument(cID).print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(c)");
     }
 
@@ -48,7 +48,7 @@ TEST(TypeSyntaxTests, TypeAttributeWithAPIs) {
       llvm::raw_svector_ostream OS { Scratch };
       auto swiftID = SyntaxFactory::makeIdentifier("swift", {}, {});
       auto swiftArgs = SyntaxFactory::makeTokenList({LeftParen, swiftID, RightParen});
-      Convention.withBalancedTokens(swiftArgs).print(OS);
+      Convention.withArgument(swiftID).print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(swift)");
     }
 
@@ -57,7 +57,7 @@ TEST(TypeSyntaxTests, TypeAttributeWithAPIs) {
       llvm::raw_svector_ostream OS { Scratch };
       auto blockID = SyntaxFactory::makeIdentifier("block", {}, {});
       auto blockArgs = SyntaxFactory::makeTokenList({LeftParen, blockID, RightParen});
-      Convention.withBalancedTokens(blockArgs).print(OS);
+      Convention.withArgument(blockID).print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(block)");
     }
   }
@@ -96,9 +96,9 @@ TEST(TypeSyntaxTests, TypeAttributeMakeAPIs) {
       SmallString<48> Scratch;
       llvm::raw_svector_ostream OS { Scratch };
       auto cID = SyntaxFactory::makeIdentifier("c", {}, {});
-      auto cArgs = SyntaxFactory::makeTokenList({LeftParen, cID, RightParen});
-      SyntaxFactory::makeAttribute(At, conventionID, cArgs)
-        .print(OS);
+      SyntaxFactory::makeAttribute(At, conventionID, LeftParen, cID, RightParen,
+                                   llvm::None)
+          .print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(c)");
     }
 
@@ -106,10 +106,9 @@ TEST(TypeSyntaxTests, TypeAttributeMakeAPIs) {
       SmallString<48> Scratch;
       llvm::raw_svector_ostream OS { Scratch };
       auto swiftID = SyntaxFactory::makeIdentifier("swift", {}, {});
-      auto swiftArgs = SyntaxFactory::makeTokenList({LeftParen, swiftID,
-        RightParen});
-      SyntaxFactory::makeAttribute(At, conventionID, swiftArgs)
-        .print(OS);
+      SyntaxFactory::makeAttribute(At, conventionID, LeftParen, swiftID,
+                                   RightParen, llvm::None)
+          .print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(swift)");
     }
 
@@ -117,10 +116,9 @@ TEST(TypeSyntaxTests, TypeAttributeMakeAPIs) {
       SmallString<48> Scratch;
       llvm::raw_svector_ostream OS { Scratch };
       auto blockID = SyntaxFactory::makeIdentifier("block", {}, {});
-      auto blockArgs = SyntaxFactory::makeTokenList({LeftParen, blockID,
-        RightParen});
-      SyntaxFactory::makeAttribute(At, conventionID, blockArgs)
-        .print(OS);
+      SyntaxFactory::makeAttribute(At, conventionID, LeftParen, blockID,
+                                   RightParen, llvm::None)
+          .print(OS);
       ASSERT_EQ(OS.str().str(), "@convention(block)");
     }
   }

--- a/utils/gyb_syntax_support/AttributeNodes.py
+++ b/utils/gyb_syntax_support/AttributeNodes.py
@@ -6,16 +6,135 @@ ATTRIBUTE_NODES = [
     Node('TokenList', kind='SyntaxCollection',
          element='Token'),
 
-    # attribute -> '@' identifier '('? token-list ')'?
+    # attribute -> '@' identifier '('? 
+    #              ( identifier 
+    #                | string-literal 
+    #                | integer-literal
+    #                | availability-spec-list
+    #                | specialize-attr-spec-list
+    #                | implements-attr-arguments
+    #              )? ')'?
     Node('Attribute', kind='Syntax',
+         description='''
+         An `@` attribute.
+         ''',
          children=[
-             Child('AtSignToken', kind='AtSignToken'),
-             Child('AttributeName', kind='Token'),
-             # FIXME: more structure
-             Child('BalancedTokens', kind='TokenList'),
+             Child('AtSignToken', kind='AtSignToken', 
+                   description='The `@` sign.'),
+             Child('AttributeName', kind='Token', 
+                   description='The name of the attribute.'),
+             Child('LeftParen', kind='LeftParenToken', is_optional=True,
+                   description='''
+                   If the attribute takes arguments, the opening parenthesis.
+                   '''),
+             Child('Argument', kind='Syntax', is_optional=True,
+                   node_choices=[
+                       Child('Identifier', kind='IdentifierToken'),
+                       Child('String', kind='StringLiteralToken'),
+                       Child('Integer', kind='IntegerLiteralToken'),
+                       Child('Availability', kind='AvailabilitySpecList'),
+                       Child('SpecializeArguments', 
+                             kind='SpecializeAttributeSpecList'),
+                       Child('ObjCName', kind='ObjCSelector'),
+                       Child('ImplementsArguments', 
+                             kind='ImplementsAttributeArguments'),
+                   ], description='''
+                   The arguments of the attribute. In case the attribute  \
+                   takes multiple arguments, they are gather in the \
+                   appropriate takes first.
+                   '''),
+             Child('RightParen', kind='RightParenToken', is_optional=True,
+                   description='''
+                   If the attribute takes arguments, the closing parenthesis.
+                   '''),
+             # TokenList to gather remaining tokens of invalid attributes
+             # FIXME: Remove this recovery option entirely
+             Child('TokenList', kind='TokenList', is_optional=True),
          ]),
 
     # attribute-list -> attribute attribute-list?
     Node('AttributeList', kind='SyntaxCollection',
          element='Attribute'),
+
+    # The argument of '@_specialize(...)'
+    # specialize-attr-spec-list -> labeled-specialize-entry 
+    #                                  specialize-spec-attr-list?
+    #                            | generic-where-clause 
+    #                                  specialize-spec-attr-list?
+    Node('SpecializeAttributeSpecList', kind='SyntaxCollection',
+         description='''
+         A collection of arguments for the `@_specialize` attribute
+         ''',
+         element='Syntax',
+         element_choices=[
+             'LabeledSpecializeEntry',
+             'GenericWhereClause',
+         ]),
+
+    # Representation of e.g. 'exported: true,'
+    # labeled-specialize-entry -> identifier ':' token ','?
+    Node('LabeledSpecializeEntry', kind='Syntax',
+         description='''
+         A labeled argument for the `@_specialize` attribute like \
+         `exported: true`
+         ''',
+         traits=['WithTrailingComma'],
+         children=[
+             Child('Label', kind='IdentifierToken', 
+                   description='The label of the argument'),
+             Child('Colon', kind='ColonToken', 
+                   description='The colon separating the label and the value'),
+             Child('Value', kind='Token', 
+                   description='The value for this argument'),
+             Child('TrailingComma', kind='CommaToken',
+                   is_optional=True, description='''
+                   A trailing comma if this argument is followed by another one
+                   '''),
+         ]),
+
+    # The argument of '@_implements(...)'
+    # implements-attr-arguments -> simple-type-identifier ',' 
+    #                              (identifier | operator) decl-name-arguments
+    Node('ImplementsAttributeArguments', kind='Syntax',
+         description='''
+         The arguments for the `@_implements` attribute of the form \
+         `Type, methodName(arg1Label:arg2Label:)`
+         ''',
+         children=[
+             Child('Type', kind='SimpleTypeIdentifier', description='''
+                   The type for which the method with this attribute \
+                   implements a requirement.
+                   '''),
+             Child('Comma', kind='CommaToken', 
+                   description='''
+                   The comma separating the type and method name
+                   '''),
+             Child('DeclBaseName', kind='Syntax', description='''
+                   The base name of the protocol\'s requirement.
+                   ''',
+                   node_choices=[
+                       Child('Identifier', kind='IdentifierToken'),
+                       Child('Operator', kind='PrefixOperatorToken'),
+                   ]),
+             Child('DeclNameArguments', kind='DeclNameArguments', 
+                   is_optional=True, description='''
+                   The argument labels of the protocol\'s requirement if it \
+                   is a function requirement.
+                   '''),
+         ]),
+
+    # objc-selector-piece -> identifier? ':'?
+    Node('ObjCSelectorPiece', kind='Syntax',
+         description='''
+         A piece of an Objective-C selector. Either consisiting of just an \
+         identifier for a nullary selector, an identifier and a colon for a \
+         labeled argument or just a colon for an unlabeled argument
+         ''',
+         children=[
+             Child('Name', kind='IdentifierToken', is_optional=True),
+             Child('Colon', kind='ColonToken', is_optional=True),
+         ]),
+
+    # objc-selector -> objc-selector-piece objc-selector?
+    Node('ObjCSelector', kind='SyntaxCollection', element='ObjCSelectorPiece')
 ]

--- a/utils/gyb_syntax_support/AvailabilityNodes.py
+++ b/utils/gyb_syntax_support/AvailabilityNodes.py
@@ -1,0 +1,104 @@
+from Child import Child
+from Node import Node  # noqa: I201
+
+AVAILABILITY_NODES = [
+    # availability-spec-list -> availability-entry availability-spec-list?
+    Node('AvailabilitySpecList', kind='SyntaxCollection', 
+         element='AvailabilityArgument'),
+
+    # Wrapper for all the different entries that may occur inside @available
+    # availability-entry -> '*' ','? 
+    #                     | identifier ','?
+    #                     | availability-version-restriction ','?
+    #                     | availability-versioned-argument ','?
+    Node('AvailabilityArgument', kind='Syntax',
+         description='''
+         A single argument to an `@available` argument like `*`, `iOS 10.1`, \
+         or `message: "This has been deprecated"`.
+         ''',
+         children=[
+             Child('Entry', kind='Syntax',
+                   description='The actual argument',
+                   node_choices=[
+                       Child('Star', kind='SpacedBinaryOperatorToken',
+                             text_choices=['*']),
+                       Child('IdentifierRestriction', 
+                             kind='IdentifierToken'),
+                       Child('AvailabilityVersionRestriction', 
+                             kind='AvailabilityVersionRestriction'),
+                       Child('AvailabilityLabeledArgument', 
+                             kind='AvailabilityLabeledArgument'),
+                   ]),
+             Child('TrailingComma', kind='CommaToken', is_optional=True,
+                   description='''
+                   A trailing comma if the argument is followed by another \
+                   argument
+                   '''),
+         ]),
+
+    # Representation of 'deprecated: 2.3', 'message: "Hello world"' etc.
+    # availability-versioned-argument -> identifier ':' version-tuple
+    Node('AvailabilityLabeledArgument', kind='Syntax',
+         description='''
+         A argument to an `@available` attribute that consists of a label and \
+         a value, e.g. `message: "This has been deprecated"`.
+         ''',
+         children=[
+             Child('Label', kind='IdentifierToken', 
+                   description='The label of the argument'),
+             Child('Colon', kind='ColonToken', 
+                   description='The colon separating label and value'),
+             Child('Value', kind='Syntax',
+                   node_choices=[
+                       Child('String', 'StringLiteralToken'),
+                       Child('Version', 'VersionTuple'),
+                   ], description='The value of this labeled argument',),
+         ]),
+
+    # Representation for 'iOS 10', 'swift 3.4' etc.
+    # availability-version-restriction -> identifier version-tuple
+    Node('AvailabilityVersionRestriction', kind='Syntax',
+         description='''
+         An argument to `@available` that restricts the availability on a \
+         certain platform to a version, e.g. `iOS 10` or `swift 3.4`.
+         ''',
+         children=[
+             Child('Platform', kind='IdentifierToken', description='''
+             The name of the OS on which the availability should be \
+             restricted or 'swift' if the availability should be restricted \
+             based on a Swift version.
+             '''),
+             Child('Version', kind='VersionTuple'),
+         ]),
+
+    # version-tuple -> integer-literal 
+    #                | float-literal 
+    #                | float-literal '.' integer-literal
+    Node('VersionTuple', kind='Syntax',
+         description='''
+         A version number of the form major.minor.patch in which the minor \
+         and patch part may be ommited.
+         ''',
+         children=[
+             Child('MajorMinor', kind='Syntax',
+                   node_choices=[
+                       Child('Major', kind='IntegerLiteralToken'),
+                       Child('MajorMinor', kind='FloatingLiteralToken')
+                   ], description='''
+                   In case the version consists only of the major version, an \
+                   integer literal that specifies the major version. In case \
+                   the version consists of major and minor version number, a \
+                   floating literal in which the decimal part is interpreted \
+                   as the minor version.
+                   '''),
+             Child('PatchPeriod', kind='PeriodToken', is_optional=True,
+                   description='''
+                   If the version contains a patch number, the period \
+                   separating the minor from the patch number.
+                   '''),
+             Child('PatchVersion', kind='IntegerLiteralToken', 
+                   is_optional=True, description='''
+                   The patch version if specified.
+                   '''),
+         ]),
+]

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -139,7 +139,9 @@ DECL_NODES = [
                        'fileprivate', 'internal', 'public', 'open',
                        'mutating', 'nonmutating', 'indirect',
                    ]),
-             Child('Detail', kind='TokenList', is_optional=True),
+             Child('DetailLeftParen', kind='LeftParenToken', is_optional=True),
+             Child('Detail', kind='IdentifierToken', is_optional=True),
+             Child('DetailRightParen', kind='RightParenToken', is_optional=True),
          ]),
 
     Node('InheritedType', kind='Syntax',

--- a/utils/gyb_syntax_support/StmtNodes.py
+++ b/utils/gyb_syntax_support/StmtNodes.py
@@ -173,10 +173,14 @@ STMT_NODES = [
              Child('TrailingComma', kind='CommaToken',
                    is_optional=True),
          ]),
+
+    # availability-condition -> '#available' '(' availability-spec ')'
     Node('AvailabilityCondition', kind='Syntax',
          children=[
              Child('PoundAvailableKeyword', kind='PoundAvailableToken'),
-             Child('Arguments', kind='TokenList'),
+             Child('LeftParen', kind='LeftParenToken'),
+             Child('AvailabilitySpec', kind='AvailabilitySpecList'),
+             Child('RightParen', kind='RightParenToken'),
          ]),
     Node('MatchingPatternCondition', kind='Syntax',
          children=[

--- a/utils/gyb_syntax_support/__init__.py
+++ b/utils/gyb_syntax_support/__init__.py
@@ -1,5 +1,6 @@
 import textwrap
 from AttributeNodes import ATTRIBUTE_NODES
+from AvailabilityNodes import AVAILABILITY_NODES
 from CommonNodes import COMMON_NODES  # noqa: I201
 from DeclNodes import DECL_NODES  # noqa: I201
 from ExprNodes import EXPR_NODES  # noqa: I201
@@ -12,7 +13,8 @@ from TypeNodes import TYPE_NODES  # noqa: I201
 
 # Re-export global constants
 SYNTAX_NODES = COMMON_NODES + EXPR_NODES + DECL_NODES + ATTRIBUTE_NODES + \
-    STMT_NODES + GENERIC_NODES + TYPE_NODES + PATTERN_NODES
+    STMT_NODES + GENERIC_NODES + TYPE_NODES + PATTERN_NODES + \
+    AVAILABILITY_NODES
 SYNTAX_TOKENS = Token.SYNTAX_TOKENS
 SYNTAX_TOKEN_MAP = Token.SYNTAX_TOKEN_MAP
 


### PR DESCRIPTION
Add significantly more structure to the way the attributes are parsed in libSyntax by no longer parsing the arguments as a `TokenList`. This way we can also parse `@_specialize` attributes correctly which can have a `GenericWhereClause` as one of its arguments.