### PR TITLE
[string] Comparison bug fix: Kelvin

### DIFF
--- a/stdlib/public/core/StringComparison.swift
+++ b/stdlib/public/core/StringComparison.swift
@@ -937,26 +937,29 @@ extension _UnmanagedString where CodeUnit == UInt8 {
       if _fastPath(
         other._parseRawScalar(startingFrom: idx).0._isNormalizedSuperASCII
       ) {
-       return .less
+        return .less
       }
-    } else {
-      let selfASCIIChar = UInt16(self[idx])
-      _sanityCheck(selfASCIIChar != otherCU, "should be different")
-      if idx+1 == other.count {
-        return _lexicographicalCompare(selfASCIIChar, otherCU)
-      }
-      if _fastPath(other.hasNormalizationBoundary(after: idx)) {
-        return _lexicographicalCompare(selfASCIIChar, otherCU)
-      }
+
+      // Rare pathological case, e.g. Kelvin symbol
+      var selfIterator = _NormalizedCodeUnitIterator(self)
+      return selfIterator.compare(with: _NormalizedCodeUnitIterator(other))
+    }
+
+    let selfASCIIChar = UInt16(self[idx])
+    _sanityCheck(selfASCIIChar != otherCU, "should be different")
+    if idx+1 == other.count {
+      return _lexicographicalCompare(selfASCIIChar, otherCU)
+    }
+    if _fastPath(other.hasNormalizationBoundary(after: idx)) {
+      return _lexicographicalCompare(selfASCIIChar, otherCU)
     }
 
     //
     // Otherwise, need to normalize the segment and then compare
     //
-    let selfASCIIChar = UInt16(self[idx])
     return _compareStringsPostSuffix(
-      selfASCIIChar: selfASCIIChar, otherUTF16: other[idx...]
-      )
+      selfASCIIChar: selfASCIIChar, otherUTF16WithLeadingASCII: other[idx...]
+    )
   }
 }
 
@@ -1008,15 +1011,17 @@ extension BidirectionalCollection where Element == UInt16, SubSequence == Self {
   }
 }
 
+@inline(never) // @outlined
 private func _compareStringsPostSuffix(
   selfASCIIChar: UInt16,
-  otherUTF16: _UnmanagedString<UInt16>
+  otherUTF16WithLeadingASCII: _UnmanagedString<UInt16>
 ) -> _Ordering {
-  let otherCU = otherUTF16[0]
+  let otherCU = otherUTF16WithLeadingASCII[0]
   _sanityCheck(otherCU <= 0x7F, "should be ASCII, otherwise no need to call")
 
-  let segmentEndIdx = otherUTF16._findNormalizationSegmentEnd(startingFrom: 0)
-  let segment = otherUTF16[..<segmentEndIdx]
+  let segmentEndIdx = otherUTF16WithLeadingASCII._findNormalizationSegmentEnd(
+    startingFrom: 0)
+  let segment = otherUTF16WithLeadingASCII[..<segmentEndIdx]
 
   // Fast path: If prenormal, we're done.
   if _Normalization._prenormalQuickCheckYes(segment) {

--- a/test/stdlib/StringAPI.swift
+++ b/test/stdlib/StringAPI.swift
@@ -135,6 +135,9 @@ let tests = [
   ComparisonTest(.eq, "\u{0301}", "\u{0341}"),
   ComparisonTest(.lt, "\u{0301}", "\u{0954}"),
   ComparisonTest(.lt, "\u{0341}", "\u{0954}"),
+
+  // (U+212A KELVIN SIGN) normalizes to ASCII "K"
+  ComparisonTest(.eq, "K", "\u{212A}"),
 ]
 
 func checkStringComparison(


### PR DESCRIPTION
Unicode Kelvin sign normalizes to ASCII 'K', but our comparison logic
didn't handle this situation when the other side was single-byte all
ASCII. Fall back to the slow comparison path if the point of
difference between an all-ASCII string and a UTF-16 string falls on
such a non-ASCII-yet-normalizes-to-ASCII scalar (rare).

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
