### PR TITLE
tests: annotate dllstorage on IRGen tests

### DIFF
--- a/test/IRGen/access_control.sil
+++ b/test/IRGen/access_control.sil
@@ -4,7 +4,7 @@ import Builtin
 import Swift
 
 public struct PublicStruct { var x: Int }
-// CHECK: @"$S14access_control12PublicStructVMn" = {{(protected )?}}constant
+// CHECK: @"$S14access_control12PublicStructVMn" = {{(dllexport )?}}{{(protected )?}}constant
 // CHECK: @"$S14access_control12PublicStructVMf" = internal constant
 
 internal struct InternalStruct { var x: Int }
@@ -21,7 +21,7 @@ func local() {
   // CHECK: @"$S14access_control5localyyF11LocalStructL_VMf" = internal constant
 }
 
-// CHECK: @"$S14access_control12PublicStructVN" = {{(protected )?}}alias
+// CHECK: @"$S14access_control12PublicStructVN" = {{(dllexport )?}}{{(protected )?}}alias
 // CHECK: @"$S14access_control14InternalStructVN" = hidden alias
 // CHECK: @"$S14access_control13PrivateStruct33_8F630B0A1EEF3ED34B761E3ED76C95A8LLVN" = internal alias
 // CHECK: @"$S14access_control5localyyF11LocalStructL_VN" = internal alias

--- a/test/IRGen/argument_attrs.sil
+++ b/test/IRGen/argument_attrs.sil
@@ -4,7 +4,7 @@ import Builtin
 
 struct Huge { var x, y, z, w, a, b, c, d, e, f: Builtin.Int32 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @arguments_in_def(i32* nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), %T14argument_attrs4HugeV* noalias nocapture dereferenceable(40), %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @arguments_in_def(i32* nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), %T14argument_attrs4HugeV* noalias nocapture dereferenceable(40), %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
 sil @arguments_in_def : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> () {
 entry(%1 : $*Builtin.Int32, %2 : $*Builtin.Int32, %3 : $*Builtin.Int32, %4 : $Huge, %5 : $*T, %6 : $*()):
   // CHECK: call swiftcc void @arguments_in_decl(i32* nocapture dereferenceable(4) {{%.*}}, i32* noalias nocapture dereferenceable(4) {{%.*}}, i32* noalias nocapture dereferenceable(4) {{%.*}}, %T14argument_attrs4HugeV* noalias nocapture dereferenceable(40) {{%.*}}, %swift.opaque* noalias nocapture {{%.*}}, %swift.opaque* noalias nocapture {{%.*}}, %swift.type* %T)
@@ -16,10 +16,10 @@ entry(%1 : $*Builtin.Int32, %2 : $*Builtin.Int32, %3 : $*Builtin.Int32, %4 : $Hu
   return undef : $()
 }
 
-// CHECK-LABEL: declare swiftcc void @arguments_in_decl(i32* nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), %T14argument_attrs4HugeV* noalias nocapture dereferenceable(40), %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type*)
+// CHECK-LABEL: declare{{( dllimport)?}} swiftcc void @arguments_in_decl(i32* nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), %T14argument_attrs4HugeV* noalias nocapture dereferenceable(40), %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type*)
 sil @arguments_in_decl : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> ()
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @arguments_in_def_out(i32* noalias nocapture sret, i32* nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), %T14argument_attrs4HugeV* noalias nocapture dereferenceable(40), %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @arguments_in_def_out(i32* noalias nocapture sret, i32* nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), %T14argument_attrs4HugeV* noalias nocapture dereferenceable(40), %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
 sil @arguments_in_def_out : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> @out Builtin.Int32 {
 entry(%0 : $*Builtin.Int32, %1 : $*Builtin.Int32, %2 : $*Builtin.Int32, %3 : $*Builtin.Int32, %4 : $Huge, %5 : $*T, %6 : $*()):
   // CHECK: call swiftcc void @arguments_in_decl_out(i32* noalias nocapture sret {{%.*}}, i32* nocapture dereferenceable(4) {{%.*}}, i32* noalias nocapture dereferenceable(4) {{%.*}}, i32* noalias nocapture dereferenceable(4) {{%.*}}, %T14argument_attrs4HugeV* noalias nocapture dereferenceable(40) {{%.*}}, %swift.opaque* noalias nocapture {{%.*}}, %swift.opaque* noalias nocapture {{%.*}}, %swift.type* {{%.*}})
@@ -31,10 +31,10 @@ entry(%0 : $*Builtin.Int32, %1 : $*Builtin.Int32, %2 : $*Builtin.Int32, %3 : $*B
   return undef : $()
 }
 
-// CHECK-LABEL: declare swiftcc void @arguments_in_decl_out(i32* noalias nocapture sret, i32* nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), %T14argument_attrs4HugeV* noalias nocapture dereferenceable(40), %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type*)
+// CHECK-LABEL: declare{{( dllimport)?}} swiftcc void @arguments_in_decl_out(i32* noalias nocapture sret, i32* nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), %T14argument_attrs4HugeV* noalias nocapture dereferenceable(40), %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type*)
 sil @arguments_in_decl_out : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> @out Builtin.Int32
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @arguments_in_def_huge_ret(%T14argument_attrs4HugeV* noalias nocapture sret, i32* nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), %T14argument_attrs4HugeV* noalias nocapture dereferenceable(40), %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @arguments_in_def_huge_ret(%T14argument_attrs4HugeV* noalias nocapture sret, i32* nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), %T14argument_attrs4HugeV* noalias nocapture dereferenceable(40), %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type* %T)
 sil @arguments_in_def_huge_ret : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> Huge {
 entry(%1 : $*Builtin.Int32, %2 : $*Builtin.Int32, %3 : $*Builtin.Int32, %4 : $Huge, %5 : $*T, %6 : $*()):
   %f = function_ref @arguments_in_decl_huge_ret : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> Huge
@@ -46,7 +46,7 @@ entry(%1 : $*Builtin.Int32, %2 : $*Builtin.Int32, %3 : $*Builtin.Int32, %4 : $Hu
   return %y : $Huge
 }
 
-// CHECK-LABEL: declare swiftcc void @arguments_in_decl_huge_ret(%T14argument_attrs4HugeV* noalias nocapture sret, i32* nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), %T14argument_attrs4HugeV* noalias nocapture dereferenceable(40), %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type*)
+// CHECK-LABEL: declare{{( dllimport)?}} swiftcc void @arguments_in_decl_huge_ret(%T14argument_attrs4HugeV* noalias nocapture sret, i32* nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), i32* noalias nocapture dereferenceable(4), %T14argument_attrs4HugeV* noalias nocapture dereferenceable(40), %swift.opaque* noalias nocapture, %swift.opaque* noalias nocapture, %swift.type*)
 sil @arguments_in_decl_huge_ret : $@convention(thin) <T> (@inout Builtin.Int32, @in Builtin.Int32, @in_guaranteed Builtin.Int32, Huge, @in T, @in ()) -> Huge
 
 

--- a/test/IRGen/asmname.swift
+++ b/test/IRGen/asmname.swift
@@ -16,7 +16,7 @@ _ = atan2test(0.0, 0.0)
 public   func PlainPublic()   { }
 internal func PlainInternal() { }
 private  func PlainPrivate()  { }
-// CHECK: define{{( protected)?}} swiftcc void @"$S7asmname11PlainPublic
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S7asmname11PlainPublic
 // CHECK-NOT: PlainInternal
 // CHECK-NOT: PlainPrivate
 
@@ -29,7 +29,7 @@ private  func PlainPrivate()  { }
 @_silgen_name("silgen_name_public")   public   func SilgenNamePublic()   { }
 @_silgen_name("silgen_name_internal") internal func SilgenNameInternal() { }
 @_silgen_name("silgen_name_private")  private  func SilgenNamePrivate()  { }
-// CHECK: define{{( protected)?}} swiftcc void @silgen_name_public
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @silgen_name_public
 // CHECK: define hidden swiftcc void @silgen_name_internal
 // CHECK-NOT: silgen_name_private
 // CHECK-NOT: SilgenName
@@ -43,8 +43,8 @@ private  func PlainPrivate()  { }
 @_cdecl("cdecl_public")   public   func CDeclPublic()   { }
 @_cdecl("cdecl_internal") internal func CDeclInternal() { }
 @_cdecl("cdecl_private")  private  func CDeclPrivate()  { }
-// CHECK: define{{( protected)?}} void @cdecl_public
-// CHECK: define{{( protected)?}} swiftcc void @"$S7asmname11CDeclPublic
+// CHECK: define{{( dllexport)?}}{{( protected)?}} void @cdecl_public
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S7asmname11CDeclPublic
 // CHECK: define hidden void @cdecl_internal
 // CHECK: define hidden swiftcc void @"$S7asmname13CDeclInternal
 // CHECK-NOT: cdecl_private

--- a/test/IRGen/big_types_corner_cases.sil
+++ b/test/IRGen/big_types_corner_cases.sil
@@ -36,7 +36,7 @@ public struct BigBigStruct {
   var s : BigStruct
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testBitfieldInBlock
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testBitfieldInBlock
 // CHECK:         call void {{%.*}}(%TSo11BitfieldOneV* noalias nocapture sret {{%.*}}, %objc_block* {{%.*}}, %TSo11BitfieldOneV* byval align 8 {{%.*}})
 sil @testBitfieldInBlock : $@convention(thin) (@owned @convention(block) (BitfieldOne) -> BitfieldOne, BitfieldOne) -> BitfieldOne  {
 entry(%b : $@convention(block) (BitfieldOne) -> BitfieldOne, %x : $BitfieldOne):
@@ -44,7 +44,7 @@ entry(%b : $@convention(block) (BitfieldOne) -> BitfieldOne, %x : $BitfieldOne):
   return %r : $BitfieldOne
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testTupleExtract
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testTupleExtract
 // CHECK:         call void {{%.*}}(%TSo11BitfieldOneV* noalias nocapture sret {{%.*}}, %objc_block* {{%.*}}, %TSo11BitfieldOneV* byval align 8 {{%.*}})
 sil @testTupleExtract : $@convention(thin) (@owned (BitfieldOne, @convention(block) (BitfieldOne) -> BitfieldOne), BitfieldOne) -> BitfieldOne  {
 entry(%b : $(BitfieldOne, @convention(block) (BitfieldOne) -> (BitfieldOne)), %x : $BitfieldOne):
@@ -53,7 +53,7 @@ entry(%b : $(BitfieldOne, @convention(block) (BitfieldOne) -> (BitfieldOne)), %x
   return %r : $BitfieldOne
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testBigTempStruct(%T22big_types_corner_cases13BigTempStructV* noalias nocapture sret, %swift.bridge*, %swift.type* %Element)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testBigTempStruct(%T22big_types_corner_cases13BigTempStructV* noalias nocapture sret, %swift.bridge*, %swift.type* %Element)
 // CHECK: [[ALLOC:%.*]] = alloca %T22big_types_corner_cases13BigTempStructV
 // CHECK: call swiftcc void @testBigTempStruct(%T22big_types_corner_cases13BigTempStructV* noalias nocapture sret [[ALLOC]], %swift.bridge* %1, %swift.type* %Element)
 // CHECK: ret void
@@ -65,7 +65,7 @@ bb0(%0 : $_ArrayBuffer<Element>):
   return %9 : $BigTempStruct<Element>
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testTryApply(%T22big_types_corner_cases9BigStructV* noalias nocapture sret, i8*, %swift.refcounted*, %swift.refcounted* swiftself, %swift.error** swifterror)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testTryApply(%T22big_types_corner_cases9BigStructV* noalias nocapture sret, i8*, %swift.refcounted*, %swift.refcounted* swiftself, %swift.error** swifterror)
 // CHECK: [[ALLOC:%.*]] = alloca %T22big_types_corner_cases9BigStructV
 // CHECK: call swiftcc void {{.*}}(%T22big_types_corner_cases9BigStructV* noalias nocapture sret [[ALLOC]]
 // CHECK: ret void
@@ -81,7 +81,7 @@ bb2(%err : $Error):
   throw %err : $Error
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i8* @testThinFuncPointer(%swift.type* %"BigTempStruct<Element>", %T22big_types_corner_cases13BigTempStructV* noalias nocapture swiftself dereferenceable({{.*}})
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @testThinFuncPointer(%swift.type* %"BigTempStruct<Element>", %T22big_types_corner_cases13BigTempStructV* noalias nocapture swiftself dereferenceable({{.*}})
 // CHECK-NEXT: entry
 // CHECK-NEXT: ret i8* bitcast (i8* (%swift.type*, %T22big_types_corner_cases13BigTempStructV*)* @testThinFuncPointer to i8*)
 sil @testThinFuncPointer : $@convention(method) <Element> (@guaranteed BigTempStruct<Element>) -> @owned Builtin.RawPointer {
@@ -92,7 +92,7 @@ bb0(%0 : $BigTempStruct<Element>):
   return %ret : $Builtin.RawPointer
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testFuncWithModBlockStorageApply({ %objc_block, %swift.function }* nocapture dereferenceable({{.*}}), %T22big_types_corner_cases9BigStructV* noalias nocapture dereferenceable({{.*}})
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testFuncWithModBlockStorageApply({ %objc_block, %swift.function }* nocapture dereferenceable({{.*}}), %T22big_types_corner_cases9BigStructV* noalias nocapture dereferenceable({{.*}})
 // CHECK: call swiftcc void {{.*}}(%T22big_types_corner_cases9BigStructV* noalias nocapture dereferenceable({{.*}}) %1
 // CHECK: ret void
 sil @testFuncWithModBlockStorageApply : $@convention(thin) (@inout_aliasable @block_storage @callee_owned (@owned BigStruct) -> (), BigStruct) -> () {
@@ -112,7 +112,7 @@ bb0(%0 : $*@block_storage @callee_owned (@owned BigStruct) -> (), %1 : $BigStruc
 
 sil public_external @c_return_func : $@convention(thin) () -> () -> @owned BigStruct
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @part_apply_caller()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @part_apply_caller()
 // CHECK: [[CALLEXT:%.*]] = call swiftcc { i8*, %swift.refcounted* } @c_return_func()
 // CHECK: [[VALEXT:%.*]] = extractvalue { i8*, %swift.refcounted* } [[CALLEXT]], 1
 // CHECK: store %swift.refcounted* [[VALEXT]], %swift.refcounted**
@@ -186,7 +186,7 @@ sil @get_optional_none : $@convention(method) <τ_0_0> (@thin Optional<τ_0_0>.T
 sil @short_circuit_operation : $@convention(thin) <τ_0_0> (@in Optional<τ_0_0>, @owned @callee_owned () -> (@out τ_0_0, @error Error)) -> (@out τ_0_0, @error Error)
 sil @autoclosure_partialapply : $@convention(thin) (@owned @callee_owned () -> (BigStruct, @error Error)) -> (@out BigStruct, @error Error)
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @closure(%T22big_types_corner_cases9BigStructV* noalias nocapture sret, %T22big_types_corner_cases8SuperSubC*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @closure(%T22big_types_corner_cases9BigStructV* noalias nocapture sret, %T22big_types_corner_cases8SuperSubC*)
 // CHECK-64: [[ALLOC1:%.*]] = alloca %T22big_types_corner_cases9BigStructV
 // CHECK-64: [[ALLOC2:%.*]] = alloca %T22big_types_corner_cases9BigStructV
 // CHECK-64: [[ALLOC3:%.*]] = alloca %T22big_types_corner_cases9BigStructVSg
@@ -227,7 +227,7 @@ bb2(%24 : $Error):
 
 sil @returnBigStruct : $@convention(thin) () -> @owned BigStruct
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @closureToConvert()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @closureToConvert()
 // CHECK: entry:
 // CHECK:   [[ALLOC:%.*]] = alloca %T22big_types_corner_cases9BigStructV
 // CHECK:   call swiftcc void @returnBigStruct(%T22big_types_corner_cases9BigStructV* noalias nocapture sret [[ALLOC]])
@@ -241,7 +241,7 @@ bb0:
   return %99 : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testConvertFunc()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testConvertFunc()
 // CHECK: entry:
 // CHECK:   call swiftcc void bitcast (void ()* @closureToConvert to void (%swift.refcounted*)*)(%swift.refcounted* swiftself null)
 // CHECK:   ret void

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -35,7 +35,7 @@ class OptionalInoutFuncType {
   }
 }
 
-// CHECK-LABEL: define{{( protected)?}} i32 @main(i32, i8**)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} i32 @main(i32, i8**)
 // CHECK: call void @llvm.lifetime.start
 // CHECK: call void @llvm.memcpy
 // CHECK: call void @llvm.lifetime.end
@@ -44,7 +44,7 @@ let bigStructGlobalArray : [BigStruct] = [
   BigStruct()
 ]
 
-// CHECK-LABEL: define{{( protected)?}} internal swiftcc void @"$S22big_types_corner_cases21OptionalInoutFuncTypeC7executeyys5Error_pSgFyyXEfU_"(%T22big_types_corner_cases9BigStructVSg* nocapture dereferenceable({{.*}}), %T22big_types_corner_cases21OptionalInoutFuncTypeC*, %T22big_types_corner_cases9BigStructVSgs5Error_pSgIegcg_Sg* nocapture dereferenceable({{.*}})
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal swiftcc void @"$S22big_types_corner_cases21OptionalInoutFuncTypeC7executeyys5Error_pSgFyyXEfU_"(%T22big_types_corner_cases9BigStructVSg* nocapture dereferenceable({{.*}}), %T22big_types_corner_cases21OptionalInoutFuncTypeC*, %T22big_types_corner_cases9BigStructVSgs5Error_pSgIegcg_Sg* nocapture dereferenceable({{.*}})
 // CHECK: call void @"$S22big_types_corner_cases9BigStructVSgs5Error_pSgIegcg_SgWOe
 // CHECK: call void @"$S22big_types_corner_cases9BigStructVSgs5Error_pSgIegcg_SgWOy
 // CHECK: ret void
@@ -63,7 +63,7 @@ public func f3_uses_f2() {
   let _ = useOfF2(x)
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S22big_types_corner_cases10f3_uses_f2yyF"()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S22big_types_corner_cases10f3_uses_f2yyF"()
 // CHECK: call swiftcc void @"$S22big_types_corner_cases9BigStructVACycfC"(%T22big_types_corner_cases9BigStructV* noalias nocapture sret 
 // CHECK: call swiftcc { i8*, %swift.refcounted* } @"$S22big_types_corner_cases13f2_returns_f1AA9BigStructVADcyF"()
 // CHECK: call swiftcc void {{.*}}(%T22big_types_corner_cases9BigStructV* noalias nocapture sret {{.*}}, %T22big_types_corner_cases9BigStructV* noalias nocapture dereferenceable({{.*}}) {{.*}}, %swift.refcounted* swiftself {{.*}})
@@ -76,7 +76,7 @@ public func f4_tuple_use_of_f2() {
   let _ = useOfF2(x)
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S22big_types_corner_cases18f4_tuple_use_of_f2yyF"()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S22big_types_corner_cases18f4_tuple_use_of_f2yyF"()
 // CHECK: [[TUPLE:%.*]] = call swiftcc { i8*, %swift.refcounted* } @"$S22big_types_corner_cases13f2_returns_f1AA9BigStructVADcyF"()
 // CHECK: [[TUPLE_EXTRACT:%.*]] = extractvalue { i8*, %swift.refcounted* } [[TUPLE]], 0
 // CHECK: [[CAST_EXTRACT:%.*]] = bitcast i8* [[TUPLE_EXTRACT]] to void (%T22big_types_corner_cases9BigStructV*, %T22big_types_corner_cases9BigStructV*, %swift.refcounted*)*
@@ -94,7 +94,7 @@ public class BigClass {
   }
 }
 
-// CHECK-LABEL: define{{( protected)?}} hidden swiftcc void @"$S22big_types_corner_cases8BigClassC03useE6Struct0aH0yAA0eH0V_tF"(%T22big_types_corner_cases9BigStructV* noalias nocapture dereferenceable({{.*}}), %T22big_types_corner_cases8BigClassC* swiftself)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} hidden swiftcc void @"$S22big_types_corner_cases8BigClassC03useE6Struct0aH0yAA0eH0V_tF"(%T22big_types_corner_cases9BigStructV* noalias nocapture dereferenceable({{.*}}), %T22big_types_corner_cases8BigClassC* swiftself)
 // CHECK: [[BITCAST:%.*]] = bitcast i8* {{.*}} to void (%T22big_types_corner_cases9BigStructV*, %swift.refcounted*)*
 // CHECK: call swiftcc void [[BITCAST]](%T22big_types_corner_cases9BigStructV* noalias nocapture dereferenceable({{.*}}) %0, %swift.refcounted* swiftself 
 // CHECK: ret void
@@ -115,7 +115,7 @@ class Foo {
   func myMethod(_ callback: (MyStruct, Int) -> Void) -> Void { }
 }
 
-// CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden swiftcc { i8*, %swift.refcounted* } @"$S22big_types_corner_cases3FooC8myMethodyyyAA8MyStructV_SitXEFTc"(%T22big_types_corner_cases3FooC*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden swiftcc { i8*, %swift.refcounted* } @"$S22big_types_corner_cases3FooC8myMethodyyyAA8MyStructV_SitXEFTc"(%T22big_types_corner_cases3FooC*)
 // CHECK: getelementptr inbounds %T22big_types_corner_cases3FooC, %T22big_types_corner_cases3FooC*
 // CHECK: getelementptr inbounds void (i8*, %swift.opaque*, %T22big_types_corner_cases3FooC*)*, void (i8*, %swift.opaque*, %T22big_types_corner_cases3FooC*)**
 // CHECK: call noalias %swift.refcounted* @swift_allocObject(%swift.type* getelementptr inbounds (%swift.full_boxmetadata, %swift.full_boxmetadata*
@@ -138,7 +138,7 @@ public func enumCallee(_ x: LargeEnum) {
     case .Empty2: break
   }
 }
-// CHECK-LABEL-64: define{{( protected)?}} swiftcc void @"$S22big_types_corner_cases10enumCalleeyAA9LargeEnumOF"(%T22big_types_corner_cases9LargeEnumO* noalias nocapture dereferenceable({{.*}})) #0 {
+// CHECK-LABEL-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S22big_types_corner_cases10enumCalleeyAA9LargeEnumOF"(%T22big_types_corner_cases9LargeEnumO* noalias nocapture dereferenceable({{.*}})) #0 {
 // CHECK-64: alloca %T22big_types_corner_cases9LargeEnumO05InnerF0O
 // CHECK-64: alloca %T22big_types_corner_cases9LargeEnumO
 // CHECK-64: call void @llvm.memcpy.p0i8.p0i8.i64
@@ -146,7 +146,7 @@ public func enumCallee(_ x: LargeEnum) {
 // CHECK-64: $Ss5print_9separator10terminatoryypd_S2StF
 // CHECK-64: ret void
 
-// CHECK-LABEL: define{{( protected)?}} internal swiftcc void @"$S22big_types_corner_cases8SuperSubC1fyyFAA9BigStructVycfU_"(%T22big_types_corner_cases9BigStructV* noalias nocapture sret, %T22big_types_corner_cases8SuperSubC*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal swiftcc void @"$S22big_types_corner_cases8SuperSubC1fyyFAA9BigStructVycfU_"(%T22big_types_corner_cases9BigStructV* noalias nocapture sret, %T22big_types_corner_cases8SuperSubC*)
 // CHECK-64: [[ALLOC1:%.*]] = alloca %T22big_types_corner_cases9BigStructV
 // CHECK-64: [[ALLOC2:%.*]] = alloca %T22big_types_corner_cases9BigStructV
 // CHECK-64: [[ALLOC3:%.*]] = alloca %T22big_types_corner_cases9BigStructVSg
@@ -169,7 +169,7 @@ class SuperSub : SuperBase {
   }
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S22big_types_corner_cases10MUseStructV16superclassMirrorAA03BigF0VSgvg"(%T22big_types_corner_cases9BigStructVSg* noalias nocapture sret, %T22big_types_corner_cases10MUseStructV* noalias nocapture swiftself dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S22big_types_corner_cases10MUseStructV16superclassMirrorAA03BigF0VSgvg"(%T22big_types_corner_cases9BigStructVSg* noalias nocapture sret, %T22big_types_corner_cases10MUseStructV* noalias nocapture swiftself dereferenceable({{.*}}))
 // CHECK: [[ALLOC:%.*]] = alloca %T22big_types_corner_cases9BigStructVSg
 // CHECK: [[LOAD:%.*]] = load %swift.refcounted*, %swift.refcounted** %.callInternalLet.data
 // CHECK: call swiftcc void %7(%T22big_types_corner_cases9BigStructVSg* noalias nocapture sret [[ALLOC]], %swift.refcounted* swiftself [[LOAD]])
@@ -183,8 +183,8 @@ public struct MUseStruct {
   internal let callInternalLet: () -> BigStruct?
 }
 
-// CHECK-LABEL-64: define{{( protected)?}} swiftcc void @"$S22big_types_corner_cases18stringAndSubstringSS_s0G0VtyF"(<{ %TSS, %Ts9SubstringV }>* noalias nocapture sret) #0 {
-// CHECK-LABEL-32: define{{( protected)?}} swiftcc void @"$S22big_types_corner_cases18stringAndSubstringSS_s0G0VtyF"(<{ %TSS, [4 x i8], %Ts9SubstringV }>* noalias nocapture sret) #0 {
+// CHECK-LABEL-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S22big_types_corner_cases18stringAndSubstringSS_s0G0VtyF"(<{ %TSS, %Ts9SubstringV }>* noalias nocapture sret) #0 {
+// CHECK-LABEL-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S22big_types_corner_cases18stringAndSubstringSS_s0G0VtyF"(<{ %TSS, [4 x i8], %Ts9SubstringV }>* noalias nocapture sret) #0 {
 // CHECK: alloca %Ts9SubstringV
 // CHECK: alloca %Ts9SubstringV
 // CHECK: ret void
@@ -198,20 +198,20 @@ func bigStructGet() -> BigStruct {
   return BigStruct()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S22big_types_corner_cases11testGetFuncyyF"()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S22big_types_corner_cases11testGetFuncyyF"()
 // CHECK: ret void
 public func testGetFunc() {
   let testGetPtr: @convention(thin) () -> BigStruct = bigStructGet
 }
 
-// CHECK-LABEL: define{{( protected)?}} hidden swiftcc void @"$S22big_types_corner_cases7TestBigC4testyyF"(%T22big_types_corner_cases7TestBigC* swiftself)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} hidden swiftcc void @"$S22big_types_corner_cases7TestBigC4testyyF"(%T22big_types_corner_cases7TestBigC* swiftself)
 // CHECK: [[T0:%.*]] = call swiftcc %swift.metadata_response @"$SSayy22big_types_corner_cases9BigStructVcSgGMa"
 // CHECK: [[CALL1:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK: [[CALL2:%.*]] = call i8** @"$SSayy22big_types_corner_cases9BigStructVcSgGSayxGs10CollectionsWl
 // CHECK: call swiftcc void @"$Ss10CollectionPsE10firstIndex5where0C0QzSgSb7ElementQzKXE_tKF"(%TSq.{{.*}}* noalias nocapture sret {{.*}}, i8* bitcast (i1 (%T22big_types_corner_cases9BigStructVytIegnr_Sg*, %swift.refcounted*, %swift.error**)* @"$S22big_types_corner_cases9BigStructVIegy_SgSbs5Error_pIggdzo_ACytIegnr_SgSbsAE_pIegndzo_TRTA" to i8*), %swift.opaque* {{.*}}, %swift.type* [[CALL1]], i8** [[CALL2]], %swift.opaque* noalias nocapture swiftself
 // CHECK: ret void
 
-// CHECK-LABEL: define{{( protected)?}} hidden swiftcc void @"$S22big_types_corner_cases7TestBigC5test2yyF"(%T22big_types_corner_cases7TestBigC* swiftself)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} hidden swiftcc void @"$S22big_types_corner_cases7TestBigC5test2yyF"(%T22big_types_corner_cases7TestBigC* swiftself)
 // CHECK: [[T0:%.*]] = call swiftcc %swift.metadata_response @"$SSaySS2ID_y22big_types_corner_cases9BigStructVcSg7handlertGMa"
 // CHECK: [[CALL1:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK: [[CALL2:%.*]] = call i8** @"$SSaySS2ID_y22big_types_corner_cases9BigStructVcSg7handlertGSayxGs10CollectionsWl"
@@ -240,7 +240,7 @@ struct BigStructWithFunc {
     var foo: ((BigStruct) -> Void)?
 }
 
-// CHECK-LABEL: define{{( protected)?}} hidden swiftcc void @"$S22big_types_corner_cases20UseBigStructWithFuncC5crashyyF"(%T22big_types_corner_cases20UseBigStructWithFuncC* swiftself)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} hidden swiftcc void @"$S22big_types_corner_cases20UseBigStructWithFuncC5crashyyF"(%T22big_types_corner_cases20UseBigStructWithFuncC* swiftself)
 // CHECK: call swiftcc void @"$S22big_types_corner_cases20UseBigStructWithFuncC10callMethod
 // CHECK: ret void
 class UseBigStructWithFunc {

--- a/test/IRGen/big_types_corner_cases_as_library.swift
+++ b/test/IRGen/big_types_corner_cases_as_library.swift
@@ -12,7 +12,7 @@ public struct BigStruct {
   var i8 : Int32 = 8
 }
 
-// CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden %swift.opaque* @"$S33big_types_corner_cases_as_library9BigStructVwCP"
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden %swift.opaque* @"$S33big_types_corner_cases_as_library9BigStructVwCP"
 // CHECK: [[RETVAL:%.*]] = bitcast %T33big_types_corner_cases_as_library9BigStructV* {{.*}} to %swift.opaque*
 // CHECK: ret %swift.opaque* [[RETVAL]]
 let bigStructGlobalArray : [BigStruct] = [

--- a/test/IRGen/big_types_tests.sil
+++ b/test/IRGen/big_types_tests.sil
@@ -19,7 +19,7 @@ public struct BigStruct {
   var i8 : Int32 = 8
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testDestroyValue(%T15big_types_tests9BigStructV* noalias nocapture dereferenceable({{.*}}) #0 {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testDestroyValue(%T15big_types_tests9BigStructV* noalias nocapture dereferenceable({{.*}}) #0 {
 // CHECK-NEXT: entry
 // CHECK-NEXT: call %T15big_types_tests9BigStructV* @"$S15big_types_tests9BigStructVWOh"(%T15big_types_tests9BigStructV* %0)
 // CHECK-NEXT: ret void

--- a/test/IRGen/bitcast.sil
+++ b/test/IRGen/bitcast.sil
@@ -16,7 +16,7 @@ sil_vtable C {}
 
 protocol CP: class {}
 
-// CHECK-i386-LABEL: define{{( protected)?}} swiftcc i32 @bitcast_trivial(%T7bitcast1CC*) {{.*}} {
+// CHECK-i386-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @bitcast_trivial(%T7bitcast1CC*) {{.*}} {
 // CHECK-i386:         [[BUF:%.*]] = alloca %T7bitcast1CC*, align 4
 // CHECK-i386:         store %T7bitcast1CC* %0, %T7bitcast1CC** [[BUF]]
 // CHECK-i386:         [[OUT_BUF:%.*]] = bitcast %T7bitcast1CC** [[BUF]] to %TSi*
@@ -25,7 +25,7 @@ protocol CP: class {}
 // CHECK-i386:         ret i32 [[VALUE]]
 // CHECK-i386:       }
 
-// CHECK-x86_64-LABEL: define{{( protected)?}} swiftcc i64 @bitcast_trivial(%T7bitcast1CC*) {{.*}} {
+// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @bitcast_trivial(%T7bitcast1CC*) {{.*}} {
 // CHECK-x86_64:         [[BUF:%.*]] = alloca %T7bitcast1CC*, align 8
 // CHECK-x86_64:         store %T7bitcast1CC* %0, %T7bitcast1CC** [[BUF]]
 // CHECK-x86_64:         [[OUT_BUF:%.*]] = bitcast %T7bitcast1CC** [[BUF]] to %TSi*
@@ -40,7 +40,7 @@ entry(%c : $C):
 }
 
 
-// CHECK-x86_64-LABEL: define{{( protected)?}} swiftcc { i64, i8 } @bitcast_trivial_optional(i64, i8) {{.*}} {
+// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i8 } @bitcast_trivial_optional(i64, i8) {{.*}} {
 // CHECK-x86_64-NEXT:  entry:
 // CHECK-x86_64-NEXT:   %2 = trunc i8 %1 to i1
 // CHECK-x86_64-NEXT:   %3 = zext i1 %2 to i8
@@ -54,13 +54,13 @@ entry(%c : $Optional<Int>):
   return %i : $Optional<Int>
 }
 
-// CHECK-i386-LABEL: define{{( protected)?}} swiftcc i32 @bitcast_ref(%T7bitcast1CC*) {{.*}} {
+// CHECK-i386-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @bitcast_ref(%T7bitcast1CC*) {{.*}} {
 // CHECK-i386-NEXT:  entry:
 // CHECK-i386-NEXT:    [[VALUE:%.*]] = ptrtoint %T7bitcast1CC* %0 to i32
 // CHECK-i386-NEXT:    ret i32 [[VALUE]]
 // CHECK-i386-NEXT:  }
 
-// CHECK-x86_64-LABEL: define{{( protected)?}} swiftcc i64 @bitcast_ref(%T7bitcast1CC*) {{.*}} {
+// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @bitcast_ref(%T7bitcast1CC*) {{.*}} {
 // CHECK-x86_64-NEXT:  entry:
 // CHECK-x86_64-NEXT:    [[VALUE:%.*]] = ptrtoint %T7bitcast1CC* %0 to i64
 // CHECK-x86_64-NEXT:    ret i64 [[VALUE]]
@@ -116,7 +116,7 @@ bb0(%0 : $Int, %1 : $Int):
   return %i3 : $Int
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @unchecked_ref_cast_addr
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @unchecked_ref_cast_addr
 // CHECK-i386: call i1 @swift_dynamicCast(%swift.opaque* %0, %swift.opaque* %{{.*}}, %swift.type* %T, %swift.type* %U, i32 7)
 // CHECK-x86_64: call i1 @swift_dynamicCast(%swift.opaque* %0, %swift.opaque* %{{.*}}, %swift.type* %T, %swift.type* %U, i64 7)
 sil @unchecked_ref_cast_addr : $@convention(thin) <T, U> (@in T) -> @out U {
@@ -130,11 +130,11 @@ bb0(%0 : $*U, %1 : $*T):
   return %r : $()
 }
 
-// CHECK-i386-LABEL: define{{( protected)?}} swiftcc i32 @unchecked_ref_cast_class_optional
+// CHECK-i386-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @unchecked_ref_cast_class_optional
 // CHECK-i386: ptrtoint %T7bitcast1AC* %0 to i32
 // CHECK-i386-NEXT: ret i32
 
-// CHECK-x86_64-LABEL: define{{( protected)?}} swiftcc i64 @unchecked_ref_cast_class_optional
+// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @unchecked_ref_cast_class_optional
 // CHECK-x86_64: ptrtoint %T7bitcast1AC* %0 to i64
 // CHECK-x86_64-NEXT: ret i64
 sil @unchecked_ref_cast_class_optional : $@convention(thin) (@owned A) -> @owned Optional<AnyObject> {
@@ -143,10 +143,10 @@ bb0(%0 : $A):
   return %2 : $Optional<AnyObject>
 }
 
-// CHECK-i386-LABEL: define{{( protected)?}} swiftcc i32 @unchecked_ref_cast_optional_optional
+// CHECK-i386-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @unchecked_ref_cast_optional_optional
 // CHECK-i386: ret i32 %0
 
-// CHECK-x86_64-LABEL: define{{( protected)?}} swiftcc i64 @unchecked_ref_cast_optional_optional
+// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @unchecked_ref_cast_optional_optional
 // CHECK-x86_64: ret i64 %0
 sil @unchecked_ref_cast_optional_optional : $@convention(thin) (@owned Optional<A>) -> @owned Optional<AnyObject> {
 bb0(%0 : $Optional<A>):
@@ -154,11 +154,11 @@ bb0(%0 : $Optional<A>):
   return %2 : $Optional<AnyObject>
 }
 
-// CHECK-i386-LABEL: define{{( protected)?}} swiftcc i32 @unchecked_ref_cast_proto_optional
+// CHECK-i386-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @unchecked_ref_cast_proto_optional
 // CHECK-i386: ptrtoint {{%objc_object|%swift.refcounted}}* %0 to i32
 // CHECK-i386-NEXT: ret i32
 
-// CHECK-x86_64-LABEL: define{{( protected)?}} swiftcc i64 @unchecked_ref_cast_proto_optional
+// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @unchecked_ref_cast_proto_optional
 // CHECK-x86_64: ptrtoint {{%objc_object|%swift.refcounted}}* %0 to i64
 // CHECK-x86_64-NEXT: ret i64
 sil @unchecked_ref_cast_proto_optional : $@convention(thin) (@owned CP) -> @owned Optional<AnyObject> {
@@ -167,10 +167,10 @@ bb0(%0 : $CP):
   return %2 : $Optional<AnyObject>
 }
 
-// CHECK-i386-LABEL: define{{( protected)?}} swiftcc i32 @unchecked_ref_cast_optionalproto_optional
+// CHECK-i386-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @unchecked_ref_cast_optionalproto_optional
 // CHECK-i386: ret i32 %0
 
-// CHECK-x86_64-LABEL: define{{( protected)?}} swiftcc i64 @unchecked_ref_cast_optionalproto_optional
+// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @unchecked_ref_cast_optionalproto_optional
 // CHECK-x86_64: ret i64 %0
 sil @unchecked_ref_cast_optionalproto_optional : $@convention(thin) (@owned Optional<CP>) -> @owned Optional<AnyObject> {
 bb0(%0 : $Optional<CP>):

--- a/test/IRGen/bitcast_different_size.sil
+++ b/test/IRGen/bitcast_different_size.sil
@@ -7,7 +7,7 @@ sil_stage canonical
 
 import Swift
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i64 @bitcast_different_size1
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @bitcast_different_size1
 
 // OPT-LABEL: define{{.*}}@bitcast_different_size1(i32)
 // OPT:   tail call void asm sideeffect "", "n"(i32 0)

--- a/test/IRGen/boxed_existential.sil
+++ b/test/IRGen/boxed_existential.sil
@@ -4,7 +4,7 @@ import Swift
 
 sil @error_user : $@convention(thin) (@owned Error) -> ()
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @retain_release_boxed_existential(%swift.error*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @retain_release_boxed_existential(%swift.error*)
 sil @retain_release_boxed_existential : $@convention(thin) (@owned Error) -> () {
 entry(%e : $Error):
   // CHECK-objc: @swift_errorRetain
@@ -18,7 +18,7 @@ entry(%e : $Error):
   return undef : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.error* @alloc_boxed_existential(%swift.opaque* noalias nocapture, %swift.type* %T, i8** %T.Error)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.error* @alloc_boxed_existential(%swift.opaque* noalias nocapture, %swift.type* %T, i8** %T.Error)
 sil @alloc_boxed_existential : $@convention(thin) <T: Error> (@in T) -> @owned Error {
 entry(%x : $*T):
   // CHECK: [[BOX_PAIR:%.*]] = call swiftcc { %swift.error*, %swift.opaque* } @swift_allocError(%swift.type* %T, i8** %T.Error, %swift.opaque* null, i1 false)
@@ -37,7 +37,7 @@ struct SomeError: Error {
   let _code: Int
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.error* @alloc_boxed_existential_concrete
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.error* @alloc_boxed_existential_concrete
 sil @alloc_boxed_existential_concrete : $@convention(thin) (@owned SomeError) -> @owned Error {
 entry(%x : $SomeError):
   // CHECK: [[BOX_PAIR:%.*]] = call swiftcc { %swift.error*, %swift.opaque* } @swift_allocError(%swift.type* {{.*}} @"$S17boxed_existential9SomeErrorVMf", {{.*}}, i8** {{%.*|@"\$S17boxed_existential9SomeErrorVs0D0AAWP"}}, %swift.opaque* null, i1 false)
@@ -51,7 +51,7 @@ entry(%x : $SomeError):
   return %b : $Error
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @dealloc_boxed_existential(%swift.error*, %swift.type* %T, i8** %T.Error)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dealloc_boxed_existential(%swift.error*, %swift.type* %T, i8** %T.Error)
 sil @dealloc_boxed_existential : $@convention(thin) <T: Error> (@owned Error) -> () {
 entry(%b : $Error):
   // CHECK: call void @swift_deallocError(%swift.error* %0, %swift.type* %T)
@@ -61,7 +61,7 @@ entry(%b : $Error):
 
 struct Str : Error { }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @alloc_dealloc_box_with_concrete_type
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @alloc_dealloc_box_with_concrete_type
 sil @alloc_dealloc_box_with_concrete_type : $@convention(thin) () -> () {
 bb0:
   // CHECK: call {{.*}} @swift_allocError
@@ -72,7 +72,7 @@ bb0:
   return %r : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc {{i[0-9]+}} @project_boxed_existential(%swift.error*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc {{i[0-9]+}} @project_boxed_existential(%swift.error*)
 sil @project_boxed_existential : $@convention(thin) (@owned Error) -> Int {
 entry(%b : $Error):
   // CHECK: call void @swift_getErrorValue(%swift.error* %0, i8** {{%.*}}, [[TRIPLE:{ %swift.opaque\*, %swift.type\*, i8\*\* }]]* [[OUT:%.*]])

--- a/test/IRGen/bridge_object_arm64.sil
+++ b/test/IRGen/bridge_object_arm64.sil
@@ -25,7 +25,7 @@ entry(%c : $C, %w : $Builtin.Word):
 }
 
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { %objc_object*, i64 } @convert_from_bridge_object
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { %objc_object*, i64 } @convert_from_bridge_object
 // CHECK:         [[BOBITS:%.*]] = ptrtoint [[BRIDGE:%swift.bridge\*]] %0 to i64
 // --                                                     0x8000_0000_0000_0000
 // CHECK:         [[TAGBITS:%.*]] = and i64 [[BOBITS]], -9223372036854775808

--- a/test/IRGen/bridge_object_armv7.sil
+++ b/test/IRGen/bridge_object_armv7.sil
@@ -24,7 +24,7 @@ entry(%c : $C, %w : $Builtin.Word):
   return %b : $Builtin.BridgeObject
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { %objc_object*, i32 } @convert_from_bridge_object
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { %objc_object*, i32 } @convert_from_bridge_object
 // CHECK:         [[BOBITS:%.*]] = ptrtoint [[BRIDGE:%swift.bridge\*]] %0 to i32
 // CHECK:         [[MASKED_BITS:%.*]] = and i32 [[BOBITS]], -4
 // CHECK:         inttoptr i32 [[MASKED_BITS]] to [[C:%objc_object\*]]

--- a/test/IRGen/bridge_object_x86_64.sil
+++ b/test/IRGen/bridge_object_x86_64.sil
@@ -11,7 +11,7 @@ sil_vtable C {}
 
 @objc protocol ObjC {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @retain_release_bridge_object
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @retain_release_bridge_object
 // CHECK:         call [[BRIDGE:%swift.bridge\*]] @swift_bridgeObjectRetain
 // CHECK:         call void @swift_bridgeObjectRelease
 sil @retain_release_bridge_object : $(Builtin.BridgeObject) -> () {
@@ -21,7 +21,7 @@ entry(%b : $Builtin.BridgeObject):
   return undef : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.bridge* @convert_to_bridge_object
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.bridge* @convert_to_bridge_object
 // CHECK:         [[REFBITS:%.*]] = ptrtoint [[C:%T13bridge_object1CC\*]] %0 to i64
 // CHECK:         [[OR:%.*]] = or i64 [[REFBITS]], %1
 // CHECK:         inttoptr i64 [[OR]] to [[BRIDGE]]
@@ -31,7 +31,7 @@ entry(%c : $C, %w : $Builtin.Word):
   return %b : $Builtin.BridgeObject
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { %objc_object*, i64 } @convert_from_bridge_object
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { %objc_object*, i64 } @convert_from_bridge_object
 // CHECK:         [[BOBITS:%.*]] = ptrtoint [[BRIDGE]] %0 to i64
 // --                                                     0x8000_0000_0000_0001
 // CHECK:         [[TAGBITS:%.*]] = and i64 [[BOBITS]], -9223372036854775807
@@ -56,7 +56,7 @@ entry(%b : $Builtin.BridgeObject):
   return %t : $(ObjC, Builtin.Word)
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %T13bridge_object1CC* @convert_from_native_bridge_object
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %T13bridge_object1CC* @convert_from_native_bridge_object
 // CHECK:         [[BOBITS:%.*]] = ptrtoint %swift.bridge* %0 to i64
 // CHECK:         [[MASKED_BITS:%.*]] = and i64 [[BOBITS]], 72057594037927928
 // CHECK:         [[RESULT:%.*]] = inttoptr i64 [[MASKED_BITS]] to [[C:%T13bridge_object1CC\*]]

--- a/test/IRGen/builtin_math.swift
+++ b/test/IRGen/builtin_math.swift
@@ -29,7 +29,8 @@ public func test3(d : Double) -> Double {
 }
 
 // CHECK-LABEL: define {{.*}}test4
-// CHECK: call float @llvm.sqrt.f32
+// CHECK-LINUX: call float @llvm.sqrt.f32
+// CHECK-WINDOWS: call float @llvm.sqrt.f32
 
 public func test4(f : Float) -> Float {
   // This call does not match the signature for the C sqrt function

--- a/test/IRGen/builtins.swift
+++ b/test/IRGen/builtins.swift
@@ -858,7 +858,7 @@ func testForceTry(_ fn: () -> ()) {
   try! createInt(fn)
 }
 
-// CHECK-LABEL: declare swiftcc void @swift_unexpectedError(%swift.error*
+// CHECK-LABEL: declare{{( dllimport)?}} swiftcc void @swift_unexpectedError(%swift.error*
 
 enum MyError : Error {
   case A, B

--- a/test/IRGen/c_function_pointer.sil
+++ b/test/IRGen/c_function_pointer.sil
@@ -2,13 +2,13 @@
 
 import Swift
 
-// CHECK-LABEL: define{{( protected)?}} void @c_native_function_pointer(void ()*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} void @c_native_function_pointer(void ()*)
 sil @c_native_function_pointer : $@convention(c) (@convention(c) () -> ()) -> () {
 entry(%f : $@convention(c) () -> ()):
   return undef : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @call_with_native_c_function_pointer(i8*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @call_with_native_c_function_pointer(i8*)
 sil @call_with_native_c_function_pointer : $@convention(thin) (@convention(c) () -> ()) -> () {
 entry(%f : $@convention(c) () -> ()):
   %c = function_ref @c_native_function_pointer : $@convention(c) (@convention(c) () -> ()) -> ()
@@ -16,7 +16,7 @@ entry(%f : $@convention(c) () -> ()):
   return %z : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.type* @c_function_pointer_metadata()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @c_function_pointer_metadata()
 sil @c_function_pointer_metadata : $@convention(thin) () -> @thick Any.Type {
 entry:
   // CHECK: call swiftcc %swift.metadata_response @"$SyyXCMa"([[INT]] 0)

--- a/test/IRGen/c_layout.sil
+++ b/test/IRGen/c_layout.sil
@@ -106,7 +106,7 @@ bb0:
 sil public_external @createSIMDStruct : $@convention(c) () -> SIMDStruct
 sil public_external @consumeSIMDStruct : $@convention(c) SIMDStruct -> ()
 
-// CHECK-x86_64-LABEL: define{{( protected)?}} swiftcc void @testSIMDStruct()
+// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testSIMDStruct()
 // CHECK-x86_64:         call <3 x float> @createSIMDStruct
 // CHECK-x86_64:         call void @consumeSIMDStruct(<3 x float>
 sil @testSIMDStruct : $() -> () {
@@ -125,7 +125,7 @@ bb0:
   return %s : $Builtin.Word
 }
 
-// CHECK-x86_64-LABEL: define{{( protected)?}} swiftcc void @testIntegerExtension
+// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testIntegerExtension
 // CHECK-x86_64:         call signext i8 @chareth(i8 signext
 // CHECK-x86_64:         call signext i8 @signedChareth(i8 signext
 // CHECK-x86_64:         call zeroext i8 @unsignedChareth(i8 zeroext
@@ -133,15 +133,15 @@ bb0:
 // CHECK-x86_64:         call zeroext i16 @eatMyUnsignedShorts(i16 zeroext
 // CHECK-x86_64:         call i32 @ints(i32 %5)
 // CHECK-x86_64:         call i32 @unsigneds(i32 %6)
-// CHECK-x86_64-LABEL: declare signext i8 @chareth(i8 signext)
-// CHECK-x86_64-LABEL: declare signext i8 @signedChareth(i8 signext)
-// CHECK-x86_64-LABEL: declare zeroext i8 @unsignedChareth(i8 zeroext)
-// CHECK-x86_64-LABEL: declare signext i16 @eatMyShorts(i16 signext)
-// CHECK-x86_64-LABEL: declare zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
-// CHECK-x86_64-LABEL: declare i32 @ints(i32)
-// CHECK-x86_64-LABEL: declare i32 @unsigneds(i32)
+// CHECK-x86_64-LABEL: declare{{( dllimport)?}} signext i8 @chareth(i8 signext)
+// CHECK-x86_64-LABEL: declare{{( dllimport)?}} signext i8 @signedChareth(i8 signext)
+// CHECK-x86_64-LABEL: declare{{( dllimport)?}} zeroext i8 @unsignedChareth(i8 zeroext)
+// CHECK-x86_64-LABEL: declare{{( dllimport)?}} signext i16 @eatMyShorts(i16 signext)
+// CHECK-x86_64-LABEL: declare{{( dllimport)?}} zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
+// CHECK-x86_64-LABEL: declare{{( dllimport)?}} i32 @ints(i32)
+// CHECK-x86_64-LABEL: declare{{( dllimport)?}} i32 @unsigneds(i32)
 
-// CHECK-i386-LABEL: define{{( protected)?}} swiftcc void @testIntegerExtension
+// CHECK-i386-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testIntegerExtension
 // CHECK-i386:         call signext i8 @chareth(i8 signext
 // CHECK-i386:         call signext i8 @signedChareth(i8 signext
 // CHECK-i386:         call zeroext i8 @unsignedChareth(i8 zeroext
@@ -149,15 +149,15 @@ bb0:
 // CHECK-i386:         call zeroext i16 @eatMyUnsignedShorts(i16 zeroext
 // CHECK-i386:         call i32 @ints(i32 %5)
 // CHECK-i386:         call i32 @unsigneds(i32 %6)
-// CHECK-i386-LABEL: declare signext i8 @chareth(i8 signext)
-// CHECK-i386-LABEL: declare signext i8 @signedChareth(i8 signext)
-// CHECK-i386-LABEL: declare zeroext i8 @unsignedChareth(i8 zeroext)
-// CHECK-i386-LABEL: declare signext i16 @eatMyShorts(i16 signext)
-// CHECK-i386-LABEL: declare zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
-// CHECK-i386-LABEL: declare i32 @ints(i32)
-// CHECK-i386-LABEL: declare i32 @unsigneds(i32)
+// CHECK-i386-LABEL: declare{{( dllimport)?}} signext i8 @chareth(i8 signext)
+// CHECK-i386-LABEL: declare{{( dllimport)?}} signext i8 @signedChareth(i8 signext)
+// CHECK-i386-LABEL: declare{{( dllimport)?}} zeroext i8 @unsignedChareth(i8 zeroext)
+// CHECK-i386-LABEL: declare{{( dllimport)?}} signext i16 @eatMyShorts(i16 signext)
+// CHECK-i386-LABEL: declare{{( dllimport)?}} zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
+// CHECK-i386-LABEL: declare{{( dllimport)?}} i32 @ints(i32)
+// CHECK-i386-LABEL: declare{{( dllimport)?}} i32 @unsigneds(i32)
 
-// CHECK-armv7-LABEL: define{{( protected)?}} swiftcc void @testIntegerExtension
+// CHECK-armv7-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testIntegerExtension
 // CHECK-armv7:         call signext i8 @chareth(i8 signext
 // CHECK-armv7:         call signext i8 @signedChareth(i8 signext
 // CHECK-armv7:         call zeroext i8 @unsignedChareth(i8 zeroext
@@ -165,15 +165,15 @@ bb0:
 // CHECK-armv7:         call zeroext i16 @eatMyUnsignedShorts(i16 zeroext
 // CHECK-armv7:         call i32 @ints(i32 %5)
 // CHECK-armv7:         call i32 @unsigneds(i32 %6)
-// CHECK-armv7-LABEL: declare signext i8 @chareth(i8 signext)
-// CHECK-armv7-LABEL: declare signext i8 @signedChareth(i8 signext)
-// CHECK-armv7-LABEL: declare zeroext i8 @unsignedChareth(i8 zeroext)
-// CHECK-armv7-LABEL: declare signext i16 @eatMyShorts(i16 signext)
-// CHECK-armv7-LABEL: declare zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
-// CHECK-armv7-LABEL: declare i32 @ints(i32)
-// CHECK-armv7-LABEL: declare i32 @unsigneds(i32)
+// CHECK-armv7-LABEL: declare{{( dllimport)?}} signext i8 @chareth(i8 signext)
+// CHECK-armv7-LABEL: declare{{( dllimport)?}} signext i8 @signedChareth(i8 signext)
+// CHECK-armv7-LABEL: declare{{( dllimport)?}} zeroext i8 @unsignedChareth(i8 zeroext)
+// CHECK-armv7-LABEL: declare{{( dllimport)?}} signext i16 @eatMyShorts(i16 signext)
+// CHECK-armv7-LABEL: declare{{( dllimport)?}} zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
+// CHECK-armv7-LABEL: declare{{( dllimport)?}} i32 @ints(i32)
+// CHECK-armv7-LABEL: declare{{( dllimport)?}} i32 @unsigneds(i32)
 
-// CHECK-armv7s-LABEL: define{{( protected)?}} swiftcc void @testIntegerExtension
+// CHECK-armv7s-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testIntegerExtension
 // CHECK-armv7s:         call signext i8 @chareth(i8 signext
 // CHECK-armv7s:         call signext i8 @signedChareth(i8 signext
 // CHECK-armv7s:         call zeroext i8 @unsignedChareth(i8 zeroext
@@ -181,15 +181,15 @@ bb0:
 // CHECK-armv7s:         call zeroext i16 @eatMyUnsignedShorts(i16 zeroext
 // CHECK-armv7s:         call i32 @ints(i32 %5)
 // CHECK-armv7s:         call i32 @unsigneds(i32 %6)
-// CHECK-armv7s-LABEL: declare signext i8 @chareth(i8 signext)
-// CHECK-armv7s-LABEL: declare signext i8 @signedChareth(i8 signext)
-// CHECK-armv7s-LABEL: declare zeroext i8 @unsignedChareth(i8 zeroext)
-// CHECK-armv7s-LABEL: declare signext i16 @eatMyShorts(i16 signext)
-// CHECK-armv7s-LABEL: declare zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
-// CHECK-armv7s-LABEL: declare i32 @ints(i32)
-// CHECK-armv7s-LABEL: declare i32 @unsigneds(i32)
+// CHECK-armv7s-LABEL: declare{{( dllimport)?}} signext i8 @chareth(i8 signext)
+// CHECK-armv7s-LABEL: declare{{( dllimport)?}} signext i8 @signedChareth(i8 signext)
+// CHECK-armv7s-LABEL: declare{{( dllimport)?}} zeroext i8 @unsignedChareth(i8 zeroext)
+// CHECK-armv7s-LABEL: declare{{( dllimport)?}} signext i16 @eatMyShorts(i16 signext)
+// CHECK-armv7s-LABEL: declare{{( dllimport)?}} zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
+// CHECK-armv7s-LABEL: declare{{( dllimport)?}} i32 @ints(i32)
+// CHECK-armv7s-LABEL: declare{{( dllimport)?}} i32 @unsigneds(i32)
 
-// CHECK-armv7k-LABEL: define{{( protected)?}} swiftcc void @testIntegerExtension
+// CHECK-armv7k-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testIntegerExtension
 // CHECK-armv7k:         call signext i8 @chareth(i8 signext
 // CHECK-armv7k:         call signext i8 @signedChareth(i8 signext
 // CHECK-armv7k:         call zeroext i8 @unsignedChareth(i8 zeroext
@@ -197,15 +197,15 @@ bb0:
 // CHECK-armv7k:         call zeroext i16 @eatMyUnsignedShorts(i16 zeroext
 // CHECK-armv7k:         call i32 @ints(i32 %5)
 // CHECK-armv7k:         call i32 @unsigneds(i32 %6)
-// CHECK-armv7k-LABEL: declare signext i8 @chareth(i8 signext)
-// CHECK-armv7k-LABEL: declare signext i8 @signedChareth(i8 signext)
-// CHECK-armv7k-LABEL: declare zeroext i8 @unsignedChareth(i8 zeroext)
-// CHECK-armv7k-LABEL: declare signext i16 @eatMyShorts(i16 signext)
-// CHECK-armv7k-LABEL: declare zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
-// CHECK-armv7k-LABEL: declare i32 @ints(i32)
-// CHECK-armv7k-LABEL: declare i32 @unsigneds(i32)
+// CHECK-armv7k-LABEL: declare{{( dllimport)?}} signext i8 @chareth(i8 signext)
+// CHECK-armv7k-LABEL: declare{{( dllimport)?}} signext i8 @signedChareth(i8 signext)
+// CHECK-armv7k-LABEL: declare{{( dllimport)?}} zeroext i8 @unsignedChareth(i8 zeroext)
+// CHECK-armv7k-LABEL: declare{{( dllimport)?}} signext i16 @eatMyShorts(i16 signext)
+// CHECK-armv7k-LABEL: declare{{( dllimport)?}} zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
+// CHECK-armv7k-LABEL: declare{{( dllimport)?}} i32 @ints(i32)
+// CHECK-armv7k-LABEL: declare{{( dllimport)?}} i32 @unsigneds(i32)
 
-// CHECK-arm64-LABEL: define{{( protected)?}} swiftcc void @testIntegerExtension
+// CHECK-arm64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testIntegerExtension
 // CHECK-arm64:         call signext i8 @chareth(i8 signext
 // CHECK-arm64:         call signext i8 @signedChareth(i8 signext
 // CHECK-arm64:         call zeroext i8 @unsignedChareth(i8 zeroext
@@ -213,15 +213,15 @@ bb0:
 // CHECK-arm64:         call zeroext i16 @eatMyUnsignedShorts(i16 zeroext
 // CHECK-arm64:         call i32 @ints(i32 %5)
 // CHECK-arm64:         call i32 @unsigneds(i32 %6)
-// CHECK-arm64-LABEL: declare signext i8 @chareth(i8 signext)
-// CHECK-arm64-LABEL: declare signext i8 @signedChareth(i8 signext)
-// CHECK-arm64-LABEL: declare zeroext i8 @unsignedChareth(i8 zeroext)
-// CHECK-arm64-LABEL: declare signext i16 @eatMyShorts(i16 signext)
-// CHECK-arm64-LABEL: declare zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
-// CHECK-arm64-LABEL: declare i32 @ints(i32)
-// CHECK-arm64-LABEL: declare i32 @unsigneds(i32)
+// CHECK-arm64-LABEL: declare{{( dllimport)?}} signext i8 @chareth(i8 signext)
+// CHECK-arm64-LABEL: declare{{( dllimport)?}} signext i8 @signedChareth(i8 signext)
+// CHECK-arm64-LABEL: declare{{( dllimport)?}} zeroext i8 @unsignedChareth(i8 zeroext)
+// CHECK-arm64-LABEL: declare{{( dllimport)?}} signext i16 @eatMyShorts(i16 signext)
+// CHECK-arm64-LABEL: declare{{( dllimport)?}} zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
+// CHECK-arm64-LABEL: declare{{( dllimport)?}} i32 @ints(i32)
+// CHECK-arm64-LABEL: declare{{( dllimport)?}} i32 @unsigneds(i32)
 
-// CHECK-aarch64-LABEL: define{{( protected)?}} swiftcc void @testIntegerExtension
+// CHECK-aarch64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testIntegerExtension
 // CHECK-aarch64:         call i8 @chareth(i8 %0)
 // CHECK-aarch64:         call i8 @signedChareth(i8 %1)
 // CHECK-aarch64:         call i8 @unsignedChareth(i8 %2)
@@ -229,15 +229,15 @@ bb0:
 // CHECK-aarch64:         call i16 @eatMyUnsignedShorts(i16 %4)
 // CHECK-aarch64:         call i32 @ints(i32 %5)
 // CHECK-aarch64:         call i32 @unsigneds(i32 %6)
-// CHECK-aarch64-LABEL: declare i8 @chareth(i8)
-// CHECK-aarch64-LABEL: declare i8 @signedChareth(i8)
-// CHECK-aarch64-LABEL: declare i8 @unsignedChareth(i8)
-// CHECK-aarch64-LABEL: declare i16 @eatMyShorts(i16)
-// CHECK-aarch64-LABEL: declare i16 @eatMyUnsignedShorts(i16)
-// CHECK-aarch64-LABEL: declare i32 @ints(i32)
-// CHECK-aarch64-LABEL: declare i32 @unsigneds(i32)
+// CHECK-aarch64-LABEL: declare{{( dllimport)?}} i8 @chareth(i8)
+// CHECK-aarch64-LABEL: declare{{( dllimport)?}} i8 @signedChareth(i8)
+// CHECK-aarch64-LABEL: declare{{( dllimport)?}} i8 @unsignedChareth(i8)
+// CHECK-aarch64-LABEL: declare{{( dllimport)?}} i16 @eatMyShorts(i16)
+// CHECK-aarch64-LABEL: declare{{( dllimport)?}} i16 @eatMyUnsignedShorts(i16)
+// CHECK-aarch64-LABEL: declare{{( dllimport)?}} i32 @ints(i32)
+// CHECK-aarch64-LABEL: declare{{( dllimport)?}} i32 @unsigneds(i32)
 
-// CHECK-powerpc64-LABEL: define{{( protected)?}} swiftcc void @testIntegerExtension
+// CHECK-powerpc64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testIntegerExtension
 // CHECK-powerpc64:         call zeroext i8 @chareth(i8 zeroext
 // CHECK-powerpc64:         call zeroext i8 @signedChareth(i8 zeroext
 // CHECK-powerpc64:         call zeroext i8 @unsignedChareth(i8 zeroext
@@ -245,15 +245,15 @@ bb0:
 // CHECK-powerpc64:         call zeroext i16 @eatMyUnsignedShorts(i16 zeroext
 // CHECK-powerpc64:         call signext i32 @ints(i32 signext %5)
 // CHECK-powerpc64:         call zeroext i32 @unsigneds(i32 zeroext %6)
-// CHECK-powerpc64-LABEL: declare zeroext i8 @chareth(i8 zeroext)
-// CHECK-powerpc64-LABEL: declare zeroext i8 @signedChareth(i8 zeroext)
-// CHECK-powerpc64-LABEL: declare zeroext i8 @unsignedChareth(i8 zeroext)
-// CHECK-powerpc64-LABEL: declare signext i16 @eatMyShorts(i16 signext)
-// CHECK-powerpc64-LABEL: declare zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
-// CHECK-powerpc64-LABEL: declare signext i32 @ints(i32 signext)
-// CHECK-powerpc64-LABEL: declare zeroext i32 @unsigneds(i32 zeroext)
+// CHECK-powerpc64-LABEL: declare{{( dllimport)?}} zeroext i8 @chareth(i8 zeroext)
+// CHECK-powerpc64-LABEL: declare{{( dllimport)?}} zeroext i8 @signedChareth(i8 zeroext)
+// CHECK-powerpc64-LABEL: declare{{( dllimport)?}} zeroext i8 @unsignedChareth(i8 zeroext)
+// CHECK-powerpc64-LABEL: declare{{( dllimport)?}} signext i16 @eatMyShorts(i16 signext)
+// CHECK-powerpc64-LABEL: declare{{( dllimport)?}} zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
+// CHECK-powerpc64-LABEL: declare{{( dllimport)?}} signext i32 @ints(i32 signext)
+// CHECK-powerpc64-LABEL: declare{{( dllimport)?}} zeroext i32 @unsigneds(i32 zeroext)
 
-// CHECK-powerpc64le-LABEL: define{{( protected)?}} swiftcc void @testIntegerExtension
+// CHECK-powerpc64le-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testIntegerExtension
 // CHECK-powerpc64le:         call zeroext i8 @chareth(i8 zeroext
 // CHECK-powerpc64le:         call zeroext i8 @signedChareth(i8 zeroext
 // CHECK-powerpc64le:         call zeroext i8 @unsignedChareth(i8 zeroext
@@ -261,15 +261,15 @@ bb0:
 // CHECK-powerpc64le:         call zeroext i16 @eatMyUnsignedShorts(i16 zeroext
 // CHECK-powerpc64le:         call signext i32 @ints(i32 signext %5)
 // CHECK-powerpc64le:         call zeroext i32 @unsigneds(i32 zeroext %6)
-// CHECK-powerpc64le-LABEL: declare zeroext i8 @chareth(i8 zeroext)
-// CHECK-powerpc64le-LABEL: declare zeroext i8 @signedChareth(i8 zeroext)
-// CHECK-powerpc64le-LABEL: declare zeroext i8 @unsignedChareth(i8 zeroext)
-// CHECK-powerpc64le-LABEL: declare signext i16 @eatMyShorts(i16 signext)
-// CHECK-powerpc64le-LABEL: declare zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
-// CHECK-powerpc64le-LABEL: declare signext i32 @ints(i32 signext)
-// CHECK-powerpc64le-LABEL: declare zeroext i32 @unsigneds(i32 zeroext)
+// CHECK-powerpc64le-LABEL: declare{{( dllimport)?}} zeroext i8 @chareth(i8 zeroext)
+// CHECK-powerpc64le-LABEL: declare{{( dllimport)?}} zeroext i8 @signedChareth(i8 zeroext)
+// CHECK-powerpc64le-LABEL: declare{{( dllimport)?}} zeroext i8 @unsignedChareth(i8 zeroext)
+// CHECK-powerpc64le-LABEL: declare{{( dllimport)?}} signext i16 @eatMyShorts(i16 signext)
+// CHECK-powerpc64le-LABEL: declare{{( dllimport)?}} zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
+// CHECK-powerpc64le-LABEL: declare{{( dllimport)?}} signext i32 @ints(i32 signext)
+// CHECK-powerpc64le-LABEL: declare{{( dllimport)?}} zeroext i32 @unsigneds(i32 zeroext)
 
-// CHECK-s390x-LABEL: define{{( protected)?}} swiftcc void @testIntegerExtension
+// CHECK-s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testIntegerExtension
 // CHECK-s390x:         call zeroext i8 @chareth(i8 zeroext
 // CHECK-s390x:         call zeroext i8 @signedChareth(i8 zeroext
 // CHECK-s390x:         call zeroext i8 @unsignedChareth(i8 zeroext
@@ -277,13 +277,13 @@ bb0:
 // CHECK-s390x:         call zeroext i16 @eatMyUnsignedShorts(i16 zeroext
 // CHECK-s390x:         call signext i32 @ints(i32 signext %5)
 // CHECK-s390x:         call zeroext i32 @unsigneds(i32 zeroext %6)
-// CHECK-s390x-LABEL: declare zeroext i8 @chareth(i8 zeroext)
-// CHECK-s390x-LABEL: declare zeroext i8 @signedChareth(i8 zeroext)
-// CHECK-s390x-LABEL: declare zeroext i8 @unsignedChareth(i8 zeroext)
-// CHECK-s390x-LABEL: declare signext i16 @eatMyShorts(i16 signext)
-// CHECK-s390x-LABEL: declare zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
-// CHECK-s390x-LABEL: declare signext i32 @ints(i32 signext)
-// CHECK-s390x-LABEL: declare zeroext i32 @unsigneds(i32 zeroext)
+// CHECK-s390x-LABEL: declare{{( dllimport)?}} zeroext i8 @chareth(i8 zeroext)
+// CHECK-s390x-LABEL: declare{{( dllimport)?}} zeroext i8 @signedChareth(i8 zeroext)
+// CHECK-s390x-LABEL: declare{{( dllimport)?}} zeroext i8 @unsignedChareth(i8 zeroext)
+// CHECK-s390x-LABEL: declare{{( dllimport)?}} signext i16 @eatMyShorts(i16 signext)
+// CHECK-s390x-LABEL: declare{{( dllimport)?}} zeroext i16 @eatMyUnsignedShorts(i16 zeroext)
+// CHECK-s390x-LABEL: declare{{( dllimport)?}} signext i32 @ints(i32 signext)
+// CHECK-s390x-LABEL: declare{{( dllimport)?}} zeroext i32 @unsigneds(i32 zeroext)
 
 sil @testIntegerExtension : $@convention(thin) (CChar, CSignedChar, CUnsignedChar, CShort, CUnsignedShort, CInt, CUnsignedInt) -> () {
 entry(%a : $CChar, %b : $CSignedChar, %c : $CUnsignedChar, %d : $CShort, %e : $CUnsignedShort, %f : $CInt, %g : $CUnsignedInt):
@@ -311,7 +311,7 @@ entry(%a : $CChar, %b : $CSignedChar, %c : $CUnsignedChar, %d : $CShort, %e : $C
   return undef : $()
 }
 
-// CHECK-x86_64-LABEL: define{{( protected)?}} swiftcc i8 @testIntegerExtensionInBlock(%objc_block*, i8)
+// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @testIntegerExtensionInBlock(%objc_block*, i8)
 sil @testIntegerExtensionInBlock : $@convention(thin) (@owned @convention(block) (CChar) -> CChar, CChar) -> CChar {
 entry(%b : $@convention(block) (CChar) -> CChar, %c : $CChar):
 // CHECK-x86_64: call signext i8 {{%.*}}(%objc_block* {{%.*}}, i8 signext {{%.*}})
@@ -319,7 +319,7 @@ entry(%b : $@convention(block) (CChar) -> CChar, %c : $CChar):
   return %r : $CChar
 }
 
-// CHECK-x86_64-LABEL: define{{( protected)?}} swiftcc void @testBitfieldInBlock
+// CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testBitfieldInBlock
 // CHECK-x86_64:         call void {{%.*}}(%TSo11BitfieldOneV* noalias nocapture sret {{%.*}}, %objc_block* {{%.*}}, %TSo11BitfieldOneV* byval align 8 {{%.*}})
 sil @testBitfieldInBlock : $@convention(thin) (@owned @convention(block) (BitfieldOne) -> BitfieldOne, BitfieldOne) -> BitfieldOne  {
 entry(%b : $@convention(block) (BitfieldOne) -> BitfieldOne, %x : $BitfieldOne):

--- a/test/IRGen/casts.sil
+++ b/test/IRGen/casts.sil
@@ -16,7 +16,7 @@ class B: A {}
 sil_vtable A {}
 sil_vtable B {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %T5casts1BC* @unchecked_addr_cast(%T5casts1AC** noalias nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %T5casts1BC* @unchecked_addr_cast(%T5casts1AC** noalias nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK:         bitcast %T5casts1AC** %0 to %T5casts1BC**
 sil @unchecked_addr_cast : $(@in A) -> B {
 entry(%a : $*A):
@@ -29,7 +29,7 @@ protocol CP: class {}
 protocol CP2: class {}
 @objc protocol OP: class {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i8* @ref_to_raw_pointer_existential(%objc_object*, i8**) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @ref_to_raw_pointer_existential(%objc_object*, i8**) {{.*}} {
 // CHECK:         [[CAST:%.*]] = bitcast %objc_object* %0 to i8*
 // CHECK:         ret i8* [[CAST]]
 sil @ref_to_raw_pointer_existential : $@convention(thin) (@owned CP) -> Builtin.RawPointer {
@@ -38,7 +38,7 @@ entry(%p : $CP):
   return %r : $Builtin.RawPointer
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %objc_object* @raw_pointer_to_ref_existential(i8*) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %objc_object* @raw_pointer_to_ref_existential(i8*) {{.*}} {
 // CHECK:         [[CAST:%.*]] = bitcast i8* %0 to %objc_object*
 // CHECK:         ret %objc_object* [[CAST]]
 sil @raw_pointer_to_ref_existential : $@convention(thin) (@owned Builtin.RawPointer) -> AnyObject {
@@ -53,9 +53,9 @@ entry(%n : $Builtin.NativeObject):
   return %r : $AnyObject
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { %objc_object*, i8** } @u_cast_to_class_existential(%objc_object*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { %objc_object*, i8** } @u_cast_to_class_existential(%objc_object*)
 // CHECK:         call { i8*, i8** } @dynamic_cast_existential_1_unconditional(i8* {{%.*}}, %swift.type* {{%.*}}, %swift.protocol* @"$S5casts2CPMp")
-// CHECK-LABEL: define{{( protected)?}} private { i8*, i8** } @dynamic_cast_existential_1_unconditional(i8*, %swift.type*, %swift.protocol*) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} private { i8*, i8** } @dynamic_cast_existential_1_unconditional(i8*, %swift.type*, %swift.protocol*) {{.*}} {
 // CHECK:         [[WITNESS:%.*]] = call i8** @swift_conformsToProtocol(%swift.type* %1, %swift.protocol* %2)
 // CHECK:         [[IS_NULL:%.*]] = icmp eq i8** [[WITNESS]], null
 // CHECK:         br i1 [[IS_NULL]], label %fail, label %cont
@@ -71,7 +71,7 @@ entry(%a : $AnyObject):
   return %p : $CP
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { %swift.type*, i8** } @u_cast_to_existential_metatype(%swift.type*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { %swift.type*, i8** } @u_cast_to_existential_metatype(%swift.type*)
 // CHECK:         call { i8*, i8** } @dynamic_cast_existential_1_unconditional(i8* %1, %swift.type* %0, %swift.protocol* @"$S5casts2CPMp")
 sil @u_cast_to_existential_metatype : $@convention(thin) (@owned @thick Any.Type) -> @owned @thick CP.Type {
 entry(%a : $@thick Any.Type):
@@ -79,9 +79,9 @@ entry(%a : $@thick Any.Type):
   return %p : $@thick CP.Type
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { %objc_object*, i8**, i8** } @u_cast_to_class_existential_2(%objc_object*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { %objc_object*, i8**, i8** } @u_cast_to_class_existential_2(%objc_object*)
 // CHECK:         call { i8*, i8**, i8** } @dynamic_cast_existential_2_unconditional(i8* {{%.*}}, %swift.type* {{%.*}}, %swift.protocol* @"$S5casts2CPMp", %swift.protocol* @"$S5casts3CP2Mp")
-// CHECK-LABEL: define{{( protected)?}} private { i8*, i8**, i8** } @dynamic_cast_existential_2_unconditional(i8*, %swift.type*, %swift.protocol*, %swift.protocol*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} private { i8*, i8**, i8** } @dynamic_cast_existential_2_unconditional(i8*, %swift.type*, %swift.protocol*, %swift.protocol*)
 // CHECK:         [[WITNESS:%.*]] = call i8** @swift_conformsToProtocol(%swift.type* %1, %swift.protocol* %2)
 // CHECK:         [[IS_NULL:%.*]] = icmp eq i8** [[WITNESS]], null
 // CHECK:         br i1 [[IS_NULL]], label %fail, label %cont
@@ -99,7 +99,7 @@ entry(%a : $AnyObject):
   return %p : $CP & CP2
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { %objc_object*, i8**, i8** } @u_cast_to_class_existential_mixed(%objc_object*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { %objc_object*, i8**, i8** } @u_cast_to_class_existential_mixed(%objc_object*)
 // CHECK:         call %objc_object* @swift_dynamicCastObjCProtocolUnconditional
 // CHECK:         call { i8*, i8**, i8** } @dynamic_cast_existential_2_unconditional(i8* {{%.*}}, %swift.type* {{%.*}}, %swift.protocol* @"$S5casts2CPMp", %swift.protocol* @"$S5casts3CP2Mp")
 sil @u_cast_to_class_existential_mixed : $@convention(thin) (@owned AnyObject) -> @owned CP & OP & CP2 {
@@ -108,7 +108,7 @@ entry(%a : $AnyObject):
   return %p : $CP & OP & CP2
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { %swift.type*, i8**, i8** } @u_cast_to_existential_metatype_mixed(%swift.type*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { %swift.type*, i8**, i8** } @u_cast_to_existential_metatype_mixed(%swift.type*)
 // CHECK:         call %swift.type* @swift_dynamicCastTypeToObjCProtocolUnconditional(%swift.type* %0, {{(i32|i64)}} 1, i8** {{%.*}})
 // CHECK:         [[CAST:%.*]] = call { i8*, i8**, i8** } @dynamic_cast_existential_2_unconditional(i8* {{.*}}, %swift.type* %0, %swift.protocol* @"$S5casts2CPMp", %swift.protocol* @"$S5casts3CP2Mp")
 // CHECK:         [[OBJPTR:%.*]] = extractvalue { i8*, i8**, i8** } [[CAST]], 0
@@ -121,9 +121,9 @@ entry(%a : $@thick Any.Type):
 }
 
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { %objc_object*, i8** } @c_cast_to_class_existential(%objc_object*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { %objc_object*, i8** } @c_cast_to_class_existential(%objc_object*)
 // CHECK:         call { i8*, i8** } @dynamic_cast_existential_1_conditional(i8* {{.*}}, %swift.type* %.Type, %swift.protocol* @"$S5casts2CPMp")
-// CHECK-LABEL: define{{( protected)?}} private { i8*, i8** } @dynamic_cast_existential_1_conditional(i8*, %swift.type*, %swift.protocol*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} private { i8*, i8** } @dynamic_cast_existential_1_conditional(i8*, %swift.type*, %swift.protocol*)
 // CHECK:         [[WITNESS:%.*]] = call i8** @swift_conformsToProtocol(%swift.type* %1, %swift.protocol* %2)
 // CHECK:         [[IS_NULL:%.*]] = icmp eq i8** [[WITNESS]], null
 // CHECK:         br i1 [[IS_NULL]], label %fail, label %cont
@@ -140,7 +140,7 @@ nay:
   unreachable
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { %swift.type*, i8** } @c_cast_to_existential_metatype(%swift.type*) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { %swift.type*, i8** } @c_cast_to_existential_metatype(%swift.type*) {{.*}} {
 // CHECK:         call { i8*, i8** } @dynamic_cast_existential_1_conditional(i8* %1, %swift.type* %0, %swift.protocol* @"$S5casts2CPMp")
 sil @c_cast_to_existential_metatype : $@convention(thin) (@owned @thick Any.Type) -> @owned @thick CP.Type {
 entry(%a : $@thick Any.Type):
@@ -151,9 +151,9 @@ nay:
   unreachable
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { %objc_object*, i8**, i8** } @c_cast_to_class_existential_2(%objc_object*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { %objc_object*, i8**, i8** } @c_cast_to_class_existential_2(%objc_object*)
 // CHECK:         call { i8*, i8**, i8** } @dynamic_cast_existential_2_conditional(i8* {{%.*}}, %swift.type* {{%.*}}, %swift.protocol* @"$S5casts2CPMp", %swift.protocol* @"$S5casts3CP2Mp")
-// CHECK-LABEL: define{{( protected)?}} private { i8*, i8**, i8** } @dynamic_cast_existential_2_conditional(i8*, %swift.type*, %swift.protocol*, %swift.protocol*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} private { i8*, i8**, i8** } @dynamic_cast_existential_2_conditional(i8*, %swift.type*, %swift.protocol*, %swift.protocol*)
 // CHECK:         [[WITNESS:%.*]] = call i8** @swift_conformsToProtocol(%swift.type* %1, %swift.protocol* %2)
 // CHECK:         [[IS_NULL:%.*]] = icmp eq i8** [[WITNESS]], null
 // CHECK:         br i1 [[IS_NULL]], label %fail, label %cont
@@ -174,7 +174,7 @@ nay:
   unreachable
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { %objc_object*, i8**, i8** } @c_cast_to_class_existential_mixed(%objc_object*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { %objc_object*, i8**, i8** } @c_cast_to_class_existential_mixed(%objc_object*)
 // CHECK:         [[CAST:%.*]] = call %objc_object* @swift_dynamicCastObjCProtocolConditional
 // CHECK:         [[IS_NULL:%.*]] = icmp eq %objc_object* [[CAST]], null
 // CHECK:         br i1 [[IS_NULL]], label %cont, label %success
@@ -192,7 +192,7 @@ nay:
   unreachable
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { %swift.type*, i8**, i8** } @c_cast_to_existential_metatype_mixed(%swift.type*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { %swift.type*, i8**, i8** } @c_cast_to_existential_metatype_mixed(%swift.type*)
 // CHECK:         [[OBJC_CAST:%.*]] = call %swift.type* @swift_dynamicCastTypeToObjCProtocolConditional(%swift.type* %0, {{(i32|i64)}} 1, i8** {{%.*}})
 // CHECK:         [[IS_NULL:%.*]] = icmp eq %swift.type* [[OBJC_CAST]], null
 // CHECK:         br i1 [[IS_NULL]], label %cont, label %success
@@ -207,7 +207,7 @@ nay:
   unreachable
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %objc_object* @checked_upcast(%T5casts1AC*) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %objc_object* @checked_upcast(%T5casts1AC*) {{.*}} {
 // -- Don't need to check conformance of an object to AnyObject.
 // CHECK-NOT:     call %objc_object* @swift_dynamicCastObjCProtocolConditional
 // CHECK:         phi %objc_object*
@@ -220,7 +220,7 @@ nay:
   unreachable
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %T5casts1AC* @checked_downcast_optional({{(i32|i64)}}) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %T5casts1AC* @checked_downcast_optional({{(i32|i64)}}) {{.*}} {
 // CHECK:         [[T0:%.*]] = inttoptr {{(i32|i64)}} %0 to %T5casts1AC*
 // CHECK:         [[OBJ_PTR:%.*]] = bitcast %T5casts1AC* [[T0]] to i8*
 // CHECK:         [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S5casts1ACMa"([[INT]] 0)
@@ -239,7 +239,7 @@ nay:
   unreachable
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.type* @checked_downcast_optional_metatype({{(i32|i64)}}) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @checked_downcast_optional_metatype({{(i32|i64)}}) {{.*}} {
 // CHECK:         [[VALUE:%.*]] = inttoptr {{(i32|i64)}} %0 to %swift.type*
 // CHECK:         [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S5casts1BCMa"([[INT]] 0)
 // CHECK:         [[METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
@@ -255,7 +255,7 @@ nay:
   unreachable
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.type* @checked_downcast_optional_exmetatype({{(i32, i32|i64, i64)}}) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @checked_downcast_optional_exmetatype({{(i32, i32|i64, i64)}}) {{.*}} {
 // CHECK:         [[VALUE:%.*]] = inttoptr {{(i32|i64)}} %0 to %swift.type*
 // CHECK:         [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S5casts1BCMa"([[INT]] 0)
 // CHECK:         [[METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
@@ -271,7 +271,7 @@ nay:
   unreachable
 }
 
-// CHECK: define swiftcc {{.*}} @checked_downcast_optional_class_to_ex([[INT]])
+// CHECK: define {{(dllexport )?}}swiftcc {{.*}} @checked_downcast_optional_class_to_ex([[INT]])
 // CHECK: entry:
 // CHECK:   [[V1:%.*]] = inttoptr [[INT]] %0 to %T5casts1AC*
 // CHECK:   [[V2:%.*]] = icmp ne %T5casts1AC* [[V1]], null
@@ -296,7 +296,7 @@ bb3(%9 : $Optional<CP>):
   return %9 : $Optional<CP>
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @checked_metatype_to_object_casts
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @checked_metatype_to_object_casts
 sil @checked_metatype_to_object_casts : $@convention(thin) <T> (@thick Any.Type) -> () {
 entry(%e : $@thick Any.Type):
   %a = metatype $@thin NotClass.Type
@@ -345,7 +345,7 @@ entry(%x : $OB):
   return %x : $OB
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %T5casts1BC* @checked_object_to_object_casts(%T5casts1AC*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %T5casts1BC* @checked_object_to_object_casts(%T5casts1AC*)
 // CHECK:         @swift_dynamicCastClassUnconditional
 sil @checked_object_to_object_casts : $@convention(thin) (A) -> B {
 entry(%a : $A):
@@ -353,7 +353,7 @@ entry(%a : $A):
   return %b : $B
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %T5casts2OBC* @checked_objc_object_to_object_casts(%T5casts2OAC*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %T5casts2OBC* @checked_objc_object_to_object_casts(%T5casts2OAC*)
 // CHECK:         @swift_dynamicCastClassUnconditional
 sil @checked_objc_object_to_object_casts : $@convention(thin) (OA) -> OB {
 entry(%a : $OA):

--- a/test/IRGen/cf.sil
+++ b/test/IRGen/cf.sil
@@ -47,7 +47,7 @@ bb0(%0 : $CCRefrigerator, %1: $CCMutableRefrigerator):
   return %5 : $()
 }
 
-// CHECK:    define{{( protected)?}} swiftcc void @call_generic([[REFRIGERATOR]]*, [[MUTABLE_REFRIGERATOR]]*) {{.*}} {
+// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @call_generic([[REFRIGERATOR]]*, [[MUTABLE_REFRIGERATOR]]*) {{.*}} {
 // CHECK:      [[T0:%.*]] = bitcast [[REFRIGERATOR]]* %0 to [[OBJC]]*
 // CHECK-NEXT: [[T1:%.*]] = call swiftcc %swift.metadata_response @"$SSo17CCRefrigeratorRefaMa"([[INT]] 0)
 // CHECK-NEXT: [[T2:%.*]] = extractvalue %swift.metadata_response [[T1]], 0

--- a/test/IRGen/class.sil
+++ b/test/IRGen/class.sil
@@ -44,7 +44,7 @@ sil_vtable C {}
 // \ CHECK: }>
 
 // Destroying destructor
-// CHECK: define{{( protected)?}} swiftcc [[REF]]* @"$S5class1CCfd"([[C_CLASS]]* swiftself) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc [[REF]]* @"$S5class1CCfd"([[C_CLASS]]* swiftself) {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK-NEXT: [[OBJ_PTR:%[a-zA-Z0-9]+]] = bitcast [[C_CLASS]]* %0 to [[REF]]*
 // CHECK-NEXT: ret [[REF]]* [[OBJ_PTR]]
@@ -55,7 +55,7 @@ bb0(%0 : $C):
 }
 
 // Deallocating destructor
-// CHECK: define{{( protected)?}} swiftcc void @"$S5class1CCfD"([[C_CLASS]]* swiftself)
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S5class1CCfD"([[C_CLASS]]* swiftself)
 sil @$S5class1CCfD : $@convention(method) (@owned C) -> () {
 bb0(%0 : $C):
   // CHECK-NEXT: entry
@@ -72,7 +72,7 @@ bb0(%0 : $C):
   return %5 : $()                                 // id: %6
 }
 
-// CHECK: define{{( protected)?}} swiftcc [[REF]]* @unchecked_ref_cast_cast([[C_CLASS]]*)
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc [[REF]]* @unchecked_ref_cast_cast([[C_CLASS]]*)
 // CHECK:   bitcast [[C_CLASS]]* {{%.*}} to [[REF]]*
 sil @unchecked_ref_cast_cast : $@convention(thin) C -> Builtin.NativeObject {
 entry(%c : $C):
@@ -80,7 +80,7 @@ entry(%c : $C):
   return %r : $Builtin.NativeObject
 }
 
-// CHECK: define{{( protected)?}} swiftcc [[OBJCOBJ]]* @ref_to_objc_pointer_cast([[C_CLASS]]*)
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc [[OBJCOBJ]]* @ref_to_objc_pointer_cast([[C_CLASS]]*)
 // CHECK:   bitcast [[C_CLASS]]* %0 to [[OBJCOBJ]]*
 sil @ref_to_objc_pointer_cast : $@convention(thin) C -> Builtin.UnknownObject {
 entry(%c : $C):
@@ -88,7 +88,7 @@ entry(%c : $C):
   return %r : $Builtin.UnknownObject
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %T5class1CC* @alloc_ref_dynamic(%swift.type*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %T5class1CC* @alloc_ref_dynamic(%swift.type*)
 sil @alloc_ref_dynamic : $@convention(thin) (@thick C.Type) -> @owned C {
 bb0(%0 : $@thick C.Type):
   // CHECK:   [[META_PTR:%[0-9]+]] = bitcast %swift.type* %0 to i8*
@@ -105,7 +105,7 @@ bb0(%0 : $@thick C.Type):
   return %1 : $C
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %T5class1CC* @autorelease(%T5class1CC*) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %T5class1CC* @autorelease(%T5class1CC*) {{.*}} {
 // CHECK:         %1 = bitcast %T5class1CC* %0 to %objc_object*
 // CHECK:         call %objc_object* @objc_autorelease(%objc_object* %1)
 // CHECK:         ret %T5class1CC* %0
@@ -115,7 +115,7 @@ entry(%c : $C):
   return %c : $C
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i64 @autorelease_optional(i64) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @autorelease_optional(i64) {{.*}} {
 // CHECK:         %1 = inttoptr i64 %0 to %objc_object*
 // CHECK:         call %objc_object* @objc_autorelease(%objc_object* %1)
 // CHECK:         ret i64 %0
@@ -163,7 +163,7 @@ entry(%x : $ClassConstrainedGenericField<ClassConstraintConformance>):
   %b = load %a : $*ClassConstraintConformance
   return %b : $ClassConstraintConformance
 }
-// CHECK-LABEL: define{{( protected)?}} swiftcc %T5class26ClassConstraintConformanceC* @fixed_class_generic_field(%T5class28ClassConstrainedGenericFieldCyAA0B21ConstraintConformanceCG*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %T5class26ClassConstraintConformanceC* @fixed_class_generic_field(%T5class28ClassConstrainedGenericFieldCyAA0B21ConstraintConformanceCG*)
 // CHECK:         [[FIELD_ADDR_GENERIC:%.*]] = getelementptr inbounds %T5class28ClassConstrainedGenericFieldCyAA0B21ConstraintConformanceCG, %T5class28ClassConstrainedGenericFieldCyAA0B21ConstraintConformanceCG* %0, i32 0, i32 1
 // CHECK:         load %T5class26ClassConstraintConformanceC*, %T5class26ClassConstraintConformanceC** [[FIELD_ADDR_GENERIC]]
 

--- a/test/IRGen/class_isa_pointers.sil
+++ b/test/IRGen/class_isa_pointers.sil
@@ -17,7 +17,7 @@ class Purebred {
 }
 sil_vtable Purebred {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @purebred_method(%T18class_isa_pointers8PurebredC*) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @purebred_method(%T18class_isa_pointers8PurebredC*) {{.*}} {
 // CHECK:         [[ISA_PTR:%.*]] = bitcast %T18class_isa_pointers8PurebredC* %0 to %swift.type**
 // CHECK:         [[ISA:%.*]] = load %swift.type*, %swift.type** [[ISA_PTR]]
 // CHECK:         [[VTABLE:%.*]] = bitcast %swift.type* [[ISA]]
@@ -38,7 +38,7 @@ class Mongrel: Gizmo {
 }
 sil_vtable Mongrel {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @mongrel_method(%T18class_isa_pointers7MongrelC*) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @mongrel_method(%T18class_isa_pointers7MongrelC*) {{.*}} {
 // CHECK:         [[T0:%.*]] = bitcast {{.*}} %0 to i64*
 // CHECK-NEXT:    [[T1:%.*]] = load i64, i64* [[T0]], align 8
 // CHECK-NEXT:    [[T2:%.*]] = load i64, i64* @swift_isaMask, align 8

--- a/test/IRGen/class_isa_pointers_armv7k_watchos.sil
+++ b/test/IRGen/class_isa_pointers_armv7k_watchos.sil
@@ -17,7 +17,7 @@ class Purebred {
 }
 sil_vtable Purebred {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @purebred_method(%T33class_isa_pointers_armv7k_watchos8PurebredC*) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @purebred_method(%T33class_isa_pointers_armv7k_watchos8PurebredC*) {{.*}} {
 // CHECK:         [[ISA_PTR:%.*]] = bitcast %T33class_isa_pointers_armv7k_watchos8PurebredC* %0 to %swift.type**
 // CHECK:         [[ISA:%.*]] = load %swift.type*, %swift.type** [[ISA_PTR]]
 // CHECK:         [[VTABLE:%.*]] = bitcast %swift.type* [[ISA]]
@@ -38,7 +38,7 @@ class Mongrel: Gizmo {
 }
 sil_vtable Mongrel {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @mongrel_method(%T33class_isa_pointers_armv7k_watchos7MongrelC*) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @mongrel_method(%T33class_isa_pointers_armv7k_watchos7MongrelC*) {{.*}} {
 // CHECK:         [[T0:%.*]] = bitcast {{.*}} %0 to %objc_object*
 // CHECK:         [[T1:%.*]] = call %objc_class* @object_getClass(%objc_object* [[T0]])
 // CHECK:         [[ISA:%.*]] = bitcast %objc_class* [[T1]] to %swift.type*

--- a/test/IRGen/class_resilience.sil
+++ b/test/IRGen/class_resilience.sil
@@ -20,7 +20,7 @@ import resilient_class
 // Perhaps we should not serialize allocating initializers, then this would not
 // be an issue.
 
-// CHECK-LABEL: define {{(protected )?}}swiftcc void @allocResilientOutsideParent()
+// CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc void @allocResilientOutsideParent()
 // CHECK:      [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S15resilient_class22ResilientOutsideParentCMa"(i64 0)
 // CHECK-NEXT: [[META:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK-NEXT: [[META_ADDR:%.*]] = bitcast %swift.type* [[META]] to i8*

--- a/test/IRGen/class_resilience.swift
+++ b/test/IRGen/class_resilience.swift
@@ -14,9 +14,9 @@
 
 // CHECK: @"$S16class_resilience14ResilientChildC5fields5Int32VvpWvd" = hidden global [[INT]] {{8|16}}
 
-// CHECK: @"$S16class_resilience21ResilientGenericChildCMo" = {{(protected )?}}global [[BOUNDS:{ (i32|i64), i32, i32 }]] zeroinitializer
+// CHECK: @"$S16class_resilience21ResilientGenericChildCMo" = {{(protected )?}}{{(dllexport )?}}global [[BOUNDS:{ (i32|i64), i32, i32 }]] zeroinitializer
 
-// CHECK: @"$S16class_resilience26ClassWithResilientPropertyCMo" = {{(protected )?}}constant [[BOUNDS]]
+// CHECK: @"$S16class_resilience26ClassWithResilientPropertyCMo" = {{(protected )?}}{{(dllexport )?}}constant [[BOUNDS]]
 // CHECK-SAME-32: { [[INT]] 52, i32 2, i32 13 }
 // CHECK-SAME-64: { [[INT]] 80, i32 2, i32 10 }
 
@@ -28,9 +28,9 @@
 
 // CHECK: [[RESILIENTCHILD_NAME:@.*]] = private constant [15 x i8] c"ResilientChild\00"
 
-// CHECK: @"$S16class_resilience14ResilientChildCMo" = {{(protected )?}}global [[BOUNDS]] zeroinitializer
+// CHECK: @"$S16class_resilience14ResilientChildCMo" = {{(protected )?}}{{(dllexport )?}}global [[BOUNDS]] zeroinitializer
 
-// CHECK: @"$S16class_resilience14ResilientChildCMn" = {{(protected )?}}constant <{{.*}}> <{
+// CHECK: @"$S16class_resilience14ResilientChildCMn" = {{(protected )?}}{{(dllexport )?}}constant <{{.*}}> <{
 // --       flags: class, unique, reflectable, has vtable, has resilient superclass
 // CHECK-SAME:   <i32 0xD004_0050>
 // --       name:
@@ -41,21 +41,21 @@
 // CHECK-SAME:   i32 3,
 // CHECK-SAME: }>
 
-// CHECK: @"$S16class_resilience16FixedLayoutChildCMo" = {{(protected )?}}global [[BOUNDS]] zeroinitializer
+// CHECK: @"$S16class_resilience16FixedLayoutChildCMo" = {{(protected )?}}{{(dllexport )?}}global [[BOUNDS]] zeroinitializer
 
-// CHECK: @"$S16class_resilience17MyResilientParentCMo" = {{(protected )?}}constant [[BOUNDS]]
+// CHECK: @"$S16class_resilience17MyResilientParentCMo" = {{(protected )?}}{{(dllexport )?}}constant [[BOUNDS]]
 // CHECK-SAME-32: { [[INT]] 52, i32 2, i32 13 }
 // CHECK-SAME-64: { [[INT]] 80, i32 2, i32 10 }
 
-// CHECK: @"$S16class_resilience16MyResilientChildCMo" = {{(protected )?}}constant [[BOUNDS]]
+// CHECK: @"$S16class_resilience16MyResilientChildCMo" = {{(protected )?}}{{(dllexport )?}}constant [[BOUNDS]]
 // CHECK-SAME-32: { [[INT]] 60, i32 2, i32 15 }
 // CHECK-SAME-64: { [[INT]] 96, i32 2, i32 12 }
 
-// CHECK: @"$S16class_resilience24MyResilientGenericParentCMo" = {{(protected )?}}constant [[BOUNDS]]
+// CHECK: @"$S16class_resilience24MyResilientGenericParentCMo" = {{(protected )?}}{{(dllexport )?}}constant [[BOUNDS]]
 // CHECK-SAME-32: { [[INT]] 52, i32 2, i32 13 }
 // CHECK-SAME-64: { [[INT]] 80, i32 2, i32 10 }
 
-// CHECK: @"$S16class_resilience24MyResilientConcreteChildCMo" = {{(protected )?}}constant [[BOUNDS]]
+// CHECK: @"$S16class_resilience24MyResilientConcreteChildCMo" = {{(protected )?}}{{(dllexport )?}}constant [[BOUNDS]]
 // CHECK-SAME-32: { [[INT]] 64, i32 2, i32 16 }
 // CHECK-SAME-64: { [[INT]] 104, i32 2, i32 13 }
 
@@ -189,7 +189,7 @@ extension ResilientGenericOutsideParent {
 
 // ClassWithResilientProperty.color getter
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i32 @"$S16class_resilience26ClassWithResilientPropertyC5colors5Int32Vvg"(%T16class_resilience26ClassWithResilientPropertyC* swiftself)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @"$S16class_resilience26ClassWithResilientPropertyC5colors5Int32Vvg"(%T16class_resilience26ClassWithResilientPropertyC* swiftself)
 // CHECK:      [[OFFSET:%.*]] = load [[INT]], [[INT]]* @"$S16class_resilience26ClassWithResilientPropertyC5colors5Int32VvpWvd"
 // CHECK-NEXT: [[PTR:%.*]] = bitcast %T16class_resilience26ClassWithResilientPropertyC* %0 to i8*
 // CHECK-NEXT: [[FIELD_ADDR:%.*]] = getelementptr inbounds i8, i8* [[PTR]], [[INT]] [[OFFSET]]
@@ -200,7 +200,7 @@ extension ResilientGenericOutsideParent {
 
 // ClassWithResilientProperty metadata accessor
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.metadata_response @"$S16class_resilience26ClassWithResilientPropertyCMa"(
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.metadata_response @"$S16class_resilience26ClassWithResilientPropertyCMa"(
 // CHECK:      [[CACHE:%.*]] = load %swift.type*, %swift.type** @"$S16class_resilience26ClassWithResilientPropertyCML"
 // CHECK-NEXT: [[COND:%.*]] = icmp eq %swift.type* [[CACHE]], null
 // CHECK-NEXT: br i1 [[COND]], label %cacheIsNull, label %cont
@@ -218,7 +218,7 @@ extension ResilientGenericOutsideParent {
 
 // ClassWithResilientlySizedProperty.color getter
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i32 @"$S16class_resilience33ClassWithResilientlySizedPropertyC5colors5Int32Vvg"(%T16class_resilience33ClassWithResilientlySizedPropertyC* swiftself)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @"$S16class_resilience33ClassWithResilientlySizedPropertyC5colors5Int32Vvg"(%T16class_resilience33ClassWithResilientlySizedPropertyC* swiftself)
 // CHECK:      [[OFFSET:%.*]] = load [[INT]], [[INT]]* @"$S16class_resilience33ClassWithResilientlySizedPropertyC5colors5Int32VvpWvd"
 // CHECK-NEXT: [[PTR:%.*]] = bitcast %T16class_resilience33ClassWithResilientlySizedPropertyC* %0 to i8*
 // CHECK-NEXT: [[FIELD_ADDR:%.*]] = getelementptr inbounds i8, i8* [[PTR]], [[INT]] [[OFFSET]]
@@ -229,7 +229,7 @@ extension ResilientGenericOutsideParent {
 
 // ClassWithResilientlySizedProperty metadata accessor
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.metadata_response @"$S16class_resilience33ClassWithResilientlySizedPropertyCMa"(
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.metadata_response @"$S16class_resilience33ClassWithResilientlySizedPropertyCMa"(
 // CHECK:      [[CACHE:%.*]] = load %swift.type*, %swift.type** @"$S16class_resilience33ClassWithResilientlySizedPropertyCML"
 // CHECK-NEXT: [[COND:%.*]] = icmp eq %swift.type* [[CACHE]], null
 // CHECK-NEXT: br i1 [[COND]], label %cacheIsNull, label %cont
@@ -247,7 +247,7 @@ extension ResilientGenericOutsideParent {
 
 // ClassWithIndirectResilientEnum.color getter
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i32 @"$S16class_resilience30ClassWithIndirectResilientEnumC5colors5Int32Vvg"(%T16class_resilience30ClassWithIndirectResilientEnumC* swiftself)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @"$S16class_resilience30ClassWithIndirectResilientEnumC5colors5Int32Vvg"(%T16class_resilience30ClassWithIndirectResilientEnumC* swiftself)
 // CHECK:      [[FIELD_PTR:%.*]] = getelementptr inbounds %T16class_resilience30ClassWithIndirectResilientEnumC, %T16class_resilience30ClassWithIndirectResilientEnumC* %0, i32 0, i32 2
 // CHECK-NEXT: [[FIELD_PAYLOAD:%.*]] = getelementptr inbounds %Ts5Int32V, %Ts5Int32V* [[FIELD_PTR]], i32 0, i32 0
 // CHECK-NEXT: [[FIELD_VALUE:%.*]] = load i32, i32* [[FIELD_PAYLOAD]]
@@ -256,7 +256,7 @@ extension ResilientGenericOutsideParent {
 
 // ResilientChild.field getter
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i32 @"$S16class_resilience14ResilientChildC5fields5Int32Vvg"(%T16class_resilience14ResilientChildC* swiftself)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @"$S16class_resilience14ResilientChildC5fields5Int32Vvg"(%T16class_resilience14ResilientChildC* swiftself)
 // CHECK:      [[OFFSET:%.*]] = load [[INT]], [[INT]]* @"$S16class_resilience14ResilientChildC5fields5Int32VvpWvd"
 // CHECK-NEXT: [[PTR:%.*]] = bitcast %T16class_resilience14ResilientChildC* %0 to i8*
 // CHECK-NEXT: [[FIELD_ADDR:%.*]] = getelementptr inbounds i8, i8* [[PTR]], [[INT]] [[OFFSET]]
@@ -269,7 +269,7 @@ extension ResilientGenericOutsideParent {
 
 // ResilientGenericChild.field getter
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i32 @"$S16class_resilience21ResilientGenericChildC5fields5Int32Vvg"(%T16class_resilience21ResilientGenericChildC* swiftself)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @"$S16class_resilience21ResilientGenericChildC5fields5Int32Vvg"(%T16class_resilience21ResilientGenericChildC* swiftself)
 
 // FIXME: we could eliminate the unnecessary isa load by lazily emitting
 // metadata sources in EmitPolymorphicParameters
@@ -296,7 +296,7 @@ extension ResilientGenericOutsideParent {
 
 // MyResilientChild.field getter
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i32 @"$S16class_resilience16MyResilientChildC5fields5Int32Vvg"(%T16class_resilience16MyResilientChildC* swiftself)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @"$S16class_resilience16MyResilientChildC5fields5Int32Vvg"(%T16class_resilience16MyResilientChildC* swiftself)
 // CHECK:      [[FIELD_ADDR:%.*]] = getelementptr inbounds %T16class_resilience16MyResilientChildC, %T16class_resilience16MyResilientChildC* %0, i32 0, i32 2
 // CHECK-NEXT: [[PAYLOAD_ADDR:%.*]] = getelementptr inbounds %Ts5Int32V, %Ts5Int32V* [[FIELD_ADDR]], i32 0, i32 0
 // CHECK-NEXT: [[RESULT:%.*]] = load i32, i32* [[PAYLOAD_ADDR]]
@@ -305,7 +305,7 @@ extension ResilientGenericOutsideParent {
 
 // ResilientGenericOutsideParent.genericExtensionMethod()
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.type* @"$S15resilient_class29ResilientGenericOutsideParentC0B11_resilienceE22genericExtensionMethodxmyF"(%T15resilient_class29ResilientGenericOutsideParentC* swiftself) #0 {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @"$S15resilient_class29ResilientGenericOutsideParentC0B11_resilienceE22genericExtensionMethodxmyF"(%T15resilient_class29ResilientGenericOutsideParentC* swiftself) #0 {
 // CHECK:      [[ISA_ADDR:%.*]] = bitcast %T15resilient_class29ResilientGenericOutsideParentC* %0 to %swift.type**
 // CHECK-NEXT: [[ISA:%.*]] = load %swift.type*, %swift.type** [[ISA_ADDR]]
 // CHECK-NEXT: [[BASE:%.*]] = load [[INT]], [[INT]]* getelementptr inbounds ([[BOUNDS]], [[BOUNDS]]* @"$S15resilient_class29ResilientGenericOutsideParentCMo", i32 0, i32 0)
@@ -395,7 +395,7 @@ extension ResilientGenericOutsideParent {
 
 // ResilientChild.field getter dispatch thunk
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i32 @"$S16class_resilience14ResilientChildC5fields5Int32VvgTj"(%T16class_resilience14ResilientChildC* swiftself)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @"$S16class_resilience14ResilientChildC5fields5Int32VvgTj"(%T16class_resilience14ResilientChildC* swiftself)
 // CHECK:      [[ISA_ADDR:%.*]] = getelementptr inbounds %T16class_resilience14ResilientChildC, %T16class_resilience14ResilientChildC* %0, i32 0, i32 0, i32 0
 // CHECK-NEXT: [[ISA:%.*]] = load %swift.type*, %swift.type** [[ISA_ADDR]]
 // CHECK-NEXT: [[BASE:%.*]] = load [[INT]], [[INT]]* getelementptr inbounds ([[BOUNDS]], [[BOUNDS]]* @"$S16class_resilience14ResilientChildCMo", i32 0, i32 0)
@@ -408,7 +408,7 @@ extension ResilientGenericOutsideParent {
 
 // ResilientChild.field setter dispatch thunk
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S16class_resilience14ResilientChildC5fields5Int32VvsTj"(i32, %T16class_resilience14ResilientChildC* swiftself)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S16class_resilience14ResilientChildC5fields5Int32VvsTj"(i32, %T16class_resilience14ResilientChildC* swiftself)
 // CHECK:      [[ISA_ADDR:%.*]] = getelementptr inbounds %T16class_resilience14ResilientChildC, %T16class_resilience14ResilientChildC* %1, i32 0, i32 0, i32 0
 // CHECK-NEXT: [[ISA:%.*]] = load %swift.type*, %swift.type** [[ISA_ADDR]]
 // CHECK-NEXT: [[BASE:%.*]] = load [[INT]], [[INT]]* getelementptr inbounds ([[BOUNDS]], [[BOUNDS]]* @"$S16class_resilience14ResilientChildCMo", i32 0, i32 0)

--- a/test/IRGen/class_resilience_thunks.swift
+++ b/test/IRGen/class_resilience_thunks.swift
@@ -8,7 +8,7 @@
 
 import resilient_class_thunks
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S23class_resilience_thunks21testDispatchThunkBase1b1ty010resilient_a1_C00G0CyxG_xtlF"(%T22resilient_class_thunks4BaseC*, %swift.opaque* noalias nocapture)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S23class_resilience_thunks21testDispatchThunkBase1b1ty010resilient_a1_C00G0CyxG_xtlF"(%T22resilient_class_thunks4BaseC*, %swift.opaque* noalias nocapture)
 public func testDispatchThunkBase<T>(b: Base<T>, t: T) {
 
   // CHECK: call swiftcc void @"$S22resilient_class_thunks4BaseC6takesTyyxFTj"(%swift.opaque* noalias nocapture {{%.*}}, %T22resilient_class_thunks4BaseC* swiftself %0)
@@ -23,7 +23,7 @@ public func testDispatchThunkBase<T>(b: Base<T>, t: T) {
   // CHECK: ret void
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S23class_resilience_thunks24testDispatchThunkDerived1dy010resilient_a1_C00G0C_tF"(%T22resilient_class_thunks7DerivedC*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S23class_resilience_thunks24testDispatchThunkDerived1dy010resilient_a1_C00G0C_tF"(%T22resilient_class_thunks7DerivedC*)
 public func testDispatchThunkDerived(d: Derived) {
 
   // CHECK: call swiftcc void @"$S22resilient_class_thunks4BaseC6takesTyyxFTj"(%swift.opaque* noalias nocapture dereferenceable({{4|8}}) {{%.*}}, %T22resilient_class_thunks4BaseC* swiftself {{%.*}})

--- a/test/IRGen/class_stack_alloc.sil
+++ b/test/IRGen/class_stack_alloc.sil
@@ -28,7 +28,7 @@ class BigClass {
 sil_vtable TestClass {}
 sil_vtable BigClass {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @simple_promote
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @simple_promote
 // CHECK: %reference.raw = alloca %[[C:[a-zA-Z0-9_]+]], align 8
 // CHECK-NEXT: [[MR:%[0-9]+]] = call swiftcc %swift.metadata_response @"$S17class_stack_alloc9TestClassCMa"([[INT]] 0)
 // CHECK-NEXT: [[M:%.*]] = extractvalue %swift.metadata_response [[MR]], 0
@@ -52,7 +52,7 @@ bb0:
 // A stack promotion limit of 48 bytes allows that one of the two alloc_refs
 // can be allocated on the stack.
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @exceed_limit
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @exceed_limit
 // CHECK: alloca {{.*}}TestClass
 // CHECK: alloca {{.*}}TestStruct
 // CHECK-NOT: alloca
@@ -80,7 +80,7 @@ bb0:
   return %r : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @promoted_with_devirtualized_release
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @promoted_with_devirtualized_release
 // CHECK: %reference.raw = alloca %[[C:[a-zA-Z0-9_]+]], align 8
 // CHECK-NEXT: [[MR:%[0-9]+]] = call swiftcc %swift.metadata_response @"$S17class_stack_alloc9TestClassCMa"([[INT]] 0)
 // CHECK-NEXT: [[M:%.*]] = extractvalue %swift.metadata_response [[MR]], 0
@@ -104,7 +104,7 @@ bb0:
   return %r : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @promoted_with_inlined_devirtualized_release
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @promoted_with_inlined_devirtualized_release
 // CHECK: %reference.raw = alloca %[[C:[a-zA-Z0-9_]+]], align 8
 // CHECK-NEXT: [[MR:%[0-9]+]] = call swiftcc %swift.metadata_response @"$S17class_stack_alloc9TestClassCMa"([[INT]] 0)
 // CHECK-NEXT: [[M:%.*]] = extractvalue %swift.metadata_response [[MR]], 0
@@ -126,7 +126,7 @@ bb0:
   return %r : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @not_promoted_with_inlined_devirtualized_release
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @not_promoted_with_inlined_devirtualized_release
 // CHECK: [[O:%[0-9]+]] = call {{.*}} @swift_allocObject
 // CHECK-NEXT: [[BC:%[0-9]+]] = bitcast %swift.refcounted* [[O]] to
 // CHECK-NEXT: call {{.*}} @swift_setDeallocating {{.*}}({{.*}} [[BC]])

--- a/test/IRGen/concrete_inherits_generic_base.swift
+++ b/test/IRGen/concrete_inherits_generic_base.swift
@@ -75,7 +75,7 @@ presentBase(Derived(x: "two"))
 presentBase(Base(x: "two"))
 presentBase(Base(x: 2))
 
-// CHECK-LABEL: define{{( protected)?}} private void @initialize_metadata_SuperDerived(i8*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} private void @initialize_metadata_SuperDerived(i8*)
 // CHECK:         [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S3foo7DerivedCMa"([[INT]] 1)
 // CHECK:         [[TMP:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK-NEXT:    extractvalue %swift.metadata_response [[T0]], 1

--- a/test/IRGen/dynamic_cast.sil
+++ b/test/IRGen/dynamic_cast.sil
@@ -17,7 +17,7 @@ struct S {
   var v: Int
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testUnconditional0(
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testUnconditional0(
 sil @testUnconditional0 : $@convention(thin) (@in P) -> () {
 bb0(%0 : $*P):
   // CHECK: [[T0:%.*]] = alloca [[S:%.*]], align
@@ -37,7 +37,7 @@ bb0(%0 : $*P):
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$S12dynamic_cast1P_pMa"(
 // CHECK:       call %swift.type* @swift_getExistentialTypeMetadata(
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testUnconditional1(
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testUnconditional1(
 sil @testUnconditional1 : $@convention(thin) (@in P) -> () {
 bb0(%0 : $*P):
   // CHECK: [[T0:%.*]] = alloca [[S:%.*]], align
@@ -54,7 +54,7 @@ bb0(%0 : $*P):
   return %2 : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testConditional0(
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testConditional0(
 sil @testConditional0 : $@convention(thin) (@in P) -> () {
 bb0(%0 : $*P):
   // CHECK: [[T0:%.*]] = alloca [[S:%.*]], align
@@ -75,7 +75,7 @@ bb2:
   return %2 : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testConditional1(
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testConditional1(
 sil @testConditional1 : $@convention(thin) (@in P) -> () {
 bb0(%0 : $*P):
   // CHECK: [[T0:%.*]] = alloca [[S:%.*]], align
@@ -96,7 +96,7 @@ bb2:
   return %2 : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testConditional2(
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testConditional2(
 sil @testConditional2 : $@convention(thin) (@in P) -> () {
 bb0(%0 : $*P):
   // CHECK: [[T0:%.*]] = alloca [[S:%.*]], align

--- a/test/IRGen/dynamic_init.sil
+++ b/test/IRGen/dynamic_init.sil
@@ -16,7 +16,7 @@ sil @$S12dynamic_init1CCACycACmcfc : $@convention(method) (@owned C) -> @owned C
 sil @$S12dynamic_init1CCfd : $@convention(method) (@owned C) -> @owned Builtin.NativeObject
 sil @$S12dynamic_init1CCfD : $@convention(method) (@owned C) -> ()
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S12dynamic_init15testDynamicInityAA1CCm2cm_tF"
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S12dynamic_init15testDynamicInityAA1CCm2cm_tF"
 sil @$S12dynamic_init15testDynamicInityAA1CCm2cm_tF : $@convention(method) (@thick C.Type) -> () {
 bb0(%0 : $@thick C.Type):
   // CHECK:   [[META:%[0-9]+]] = bitcast %swift.type* %0 to %T12dynamic_init1CC* (%swift.type*)**

--- a/test/IRGen/dynamic_lookup.sil
+++ b/test/IRGen/dynamic_lookup.sil
@@ -51,7 +51,7 @@ bb0(%0 : $X):
   return %7 : $Int
 }
 
-// CHECK: define{{( protected)?}} swiftcc void @dynamic_lookup_br(%objc_object*)
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_lookup_br(%objc_object*)
 sil @dynamic_lookup_br : $@convention(thin) (AnyObject) -> () {
 bb0(%0 : $AnyObject):
   %1 = alloc_box $<τ_0_0> { var τ_0_0 } <AnyObject>
@@ -82,7 +82,7 @@ bb3:
   return %43 : $()
 }
 
-// CHECK: define{{( protected)?}} swiftcc void @dynamic_lookup_static_br(%swift.type*)
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_lookup_static_br(%swift.type*)
 sil @dynamic_lookup_static_br : $@convention(thin) (@thick AnyObject.Type) -> () {
 bb0(%0 : $@thick AnyObject.Type):
   // CHECK: [[SEL:%[0-9]+]] = load i8*, i8** @"\01L_selector(g)", align {{(4|8)}}
@@ -126,7 +126,7 @@ bb3:
   return %43 : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @_T1t16opt_to_subscriptFT3objPSo13AnyObject_1iSi_T_(%objc_object*, {{(i32|i64)}})
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @_T1t16opt_to_subscriptFT3objPSo13AnyObject_1iSi_T_(%objc_object*, {{(i32|i64)}})
 sil @_T1t16opt_to_subscriptFT3objPSo13AnyObject_1iSi_T_ : $@convention(thin) (AnyObject, Int) -> () {
 bb0(%0 : $AnyObject, %1 : $Int):
   %2 = alloc_box $<τ_0_0> { var τ_0_0 } <AnyObject>

--- a/test/IRGen/dynamic_self.sil
+++ b/test/IRGen/dynamic_self.sil
@@ -11,7 +11,7 @@ protocol P {
   func f() -> Self
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @_TF12dynamic_self23testExistentialDispatchFT1pPS_1P__T_
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @_TF12dynamic_self23testExistentialDispatchFT1pPS_1P__T_
 sil @_TF12dynamic_self23testExistentialDispatchFT1pPS_1P__T_ : $@convention(thin) (@in P) -> () {
 bb0(%0 : $*P):
   debug_value_addr %0 : $*P, let, name "p" // id: %1

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -201,8 +201,8 @@ enum DynamicSingleton<T> {
   case value(T)
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @singleton_switch(i64, i64) {{.*}} {
-// CHECK-32: define{{( protected)?}} swiftcc void @singleton_switch(%T4enum9SingletonO* noalias nocapture dereferenceable(16)) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch(i64, i64) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch(%T4enum9SingletonO* noalias nocapture dereferenceable(16)) {{.*}} {
 sil @singleton_switch : $(Singleton) -> () {
 // CHECK-64: entry:
 // CHECK-32: entry:
@@ -220,8 +220,8 @@ dest:
   return %x : $()
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @singleton_switch_arg(i64, i64) {{.*}} {
-// CHECK-32: define{{( protected)?}} swiftcc void @singleton_switch_arg(%T4enum9SingletonO* noalias nocapture dereferenceable(16)) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_arg(i64, i64) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_arg(%T4enum9SingletonO* noalias nocapture dereferenceable(16)) {{.*}} {
 sil @singleton_switch_arg : $(Singleton) -> () {
 // CHECK-64: entry:
 // CHECK-32: entry:
@@ -242,7 +242,7 @@ dest(%u2 : $(Builtin.Int64, Builtin.Int64)):
   return %x : $()
 }
 
-// CHECK: define{{( protected)?}} swiftcc void @singleton_switch_indirect(%T4enum9SingletonO* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_switch_indirect(%T4enum9SingletonO* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK: entry:
 // CHECK:   br label %[[DEST:[0-9]+]]
 // CHECK: ; <label>:[[DEST]]
@@ -258,13 +258,13 @@ dest:
   return %x : $()
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc { i64, i64 } @singleton_inject(i64, i64) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i64 } @singleton_inject(i64, i64) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[A:%.*]] = insertvalue { i64, i64 } undef, i64 %0, 0
 // CHECK-64:   [[B:%.*]] = insertvalue { i64, i64 } [[A]], i64 %1, 1
 // CHECK-64:   ret { i64, i64 } [[B]]
 // CHECK-64: }
-// CHECK-32: define{{( protected)?}} swiftcc void @singleton_inject(%T4enum9SingletonO* noalias nocapture sret, i64, i64) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_inject(%T4enum9SingletonO* noalias nocapture sret, i64, i64) {{.*}} {
 // CHECK-32: entry:
 // CHECK-32:  [[CAST:%.*]] = bitcast %T4enum9SingletonO* %0 to <{ i64, i64 }>*
 // CHECK-32:  [[GEP1:%.*]] = getelementptr inbounds <{ i64, i64 }>, <{ i64, i64 }>* [[CAST]], i32 0, i32 0
@@ -280,7 +280,7 @@ entry(%0 : $Builtin.Int64, %1 : $Builtin.Int64):
   return %u : $Singleton
 }
 
-// CHECK: define{{( protected)?}} swiftcc void @singleton_inject_indirect(i64, i64, %T4enum9SingletonO* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @singleton_inject_indirect(i64, i64, %T4enum9SingletonO* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[DATA_ADDR:%.*]] = bitcast %T4enum9SingletonO* %2 to <{ i64, i64 }>*
 // CHECK:   [[DATA_0_ADDR:%.*]] = getelementptr inbounds <{ i64, i64 }>, <{ i64, i64 }>* [[DATA_ADDR]], i32 0, i32 0
@@ -314,7 +314,7 @@ sil @e : $@convention(thin) () -> ()
 sil @f : $@convention(thin) () -> ()
 
 
-// CHECK: define{{( protected)?}} swiftcc void @no_payload_switch(i8) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_switch(i8) {{.*}} {
 sil @no_payload_switch : $@convention(thin) (NoPayloads) -> () {
 // CHECK: entry:
 entry(%u : $NoPayloads):
@@ -356,7 +356,7 @@ end:
   return %x : $()
 }
 
-// CHECK: define{{( protected)?}} swiftcc void @no_payload_switch_indirect(%T4enum10NoPayloadsO* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_switch_indirect(%T4enum10NoPayloadsO* nocapture dereferenceable({{.*}})) {{.*}} {
 sil @no_payload_switch_indirect : $@convention(thin) (@inout NoPayloads) -> () {
 entry(%u : $*NoPayloads):
 // CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds %T4enum10NoPayloadsO, %T4enum10NoPayloadsO* %0, i32 0, i32 0
@@ -375,7 +375,7 @@ end:
   return %x : $()
 }
 
-// CHECK: define{{( protected)?}} swiftcc i8 @no_payload_inject_x() {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @no_payload_inject_x() {{.*}} {
 // CHECK: entry:
 // CHECK:   ret i8 0
 // CHECK: }
@@ -385,7 +385,7 @@ entry:
   return %u : $NoPayloads
 }
 
-// CHECK: define{{( protected)?}} swiftcc i8 @no_payload_inject_y() {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @no_payload_inject_y() {{.*}} {
 // CHECK: entry:
 // CHECK:   ret i8 1
 // CHECK: }
@@ -395,7 +395,7 @@ entry:
   return %u : $NoPayloads
 }
 
-// CHECK: define{{( protected)?}} swiftcc i8 @no_payload_inject_z() {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @no_payload_inject_z() {{.*}} {
 // CHECK: entry:
 // CHECK:   ret i8 2
 // CHECK: }
@@ -405,7 +405,7 @@ entry:
   return %u : $NoPayloads
 }
 
-// CHECK: define{{( protected)?}} swiftcc void @no_payload_inject_z_indirect(%T4enum10NoPayloadsO* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_inject_z_indirect(%T4enum10NoPayloadsO* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[TAG_ADDR:%.*]] = getelementptr inbounds %T4enum10NoPayloadsO, %T4enum10NoPayloadsO* %0, i32 0, i32 0
 // CHECK:   store i8 2, i8* [[TAG_ADDR]]
@@ -428,7 +428,7 @@ enum NoPayloads2 {
   case y
 }
 
-// CHECK: define{{( protected)?}} swiftcc void @no_payload_switch_2(i8) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @no_payload_switch_2(i8) {{.*}} {
 sil @no_payload_switch_2 : $@convention(thin) (NoPayloads2) -> () {
 // CHECK: entry:
 entry(%u : $NoPayloads2):
@@ -474,8 +474,8 @@ enum SinglePayloadNoXI2 {
   case u
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @single_payload_no_xi_switch([[WORD:i64]], i8) {{.*}} {
-// CHECK-32: define{{( protected)?}} swiftcc void @single_payload_no_xi_switch([[WORD:i32]], i8) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_switch([[WORD:i64]], i8) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_switch([[WORD:i32]], i8) {{.*}} {
 sil @single_payload_no_xi_switch : $@convention(thin) (SinglePayloadNoXI2) -> () {
 // CHECK: entry:
 entry(%u : $SinglePayloadNoXI2):
@@ -549,7 +549,7 @@ end:
   return %x : $()
 }
 
-// CHECK: define{{( protected)?}} swiftcc void @single_payload_no_xi_switch_arg([[WORD]], i8) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_switch_arg([[WORD]], i8) {{.*}} {
 sil @single_payload_no_xi_switch_arg : $@convention(thin) (SinglePayloadNoXI2) -> () {
 // CHECK: entry:
 entry(%u : $SinglePayloadNoXI2):
@@ -603,7 +603,7 @@ end:
   return %x : $()
 }
 
-// CHECK: define{{( protected)?}} swiftcc { [[WORD]], i8 } @single_payload_no_xi_inject_x([[WORD]]) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc { [[WORD]], i8 } @single_payload_no_xi_inject_x([[WORD]]) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[A:%.*]] = insertvalue { [[WORD]], i8 } undef, [[WORD]] %0, 0
 // CHECK:   [[B:%.*]] = insertvalue { [[WORD]], i8 } [[A]], i8 0, 1
@@ -615,7 +615,7 @@ entry(%0 : $Builtin.Word):
   return %u : $SinglePayloadNoXI2
 }
 
-// CHECK: define{{( protected)?}} swiftcc void @single_payload_no_xi_inject_x_indirect([[WORD]], %T4enum18SinglePayloadNoXI2O* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_inject_x_indirect([[WORD]], %T4enum18SinglePayloadNoXI2O* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[DATA_ADDR:%.*]] = bitcast %T4enum18SinglePayloadNoXI2O* %1 to [[WORD]]*
 // CHECK:   store [[WORD]] %0, [[WORD]]* [[DATA_ADDR]]
@@ -633,7 +633,7 @@ entry(%0 : $Builtin.Word, %1 : $*SinglePayloadNoXI2):
   return %v : $()
 }
 
-// CHECK: define{{( protected)?}} swiftcc { [[WORD]], i8 } @single_payload_no_xi_inject_y() {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc { [[WORD]], i8 } @single_payload_no_xi_inject_y() {{.*}} {
 // CHECK: entry:
 // CHECK:   ret { [[WORD]], i8 } { [[WORD]] 0, i8 1 }
 // CHECK: }
@@ -643,7 +643,7 @@ entry:
   return %u : $SinglePayloadNoXI2
 }
 
-// CHECK: define{{( protected)?}} swiftcc void @single_payload_no_xi_inject_y_indirect(%T4enum18SinglePayloadNoXI2O* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_no_xi_inject_y_indirect(%T4enum18SinglePayloadNoXI2O* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum18SinglePayloadNoXI2O* %0 to [[WORD]]*
 // CHECK:   store [[WORD]] 0, [[WORD]]* [[PAYLOAD_ADDR]]
@@ -659,7 +659,7 @@ entry(%0 : $*SinglePayloadNoXI2):
   return %v : $()
 }
 
-// CHECK: define{{( protected)?}} swiftcc { [[WORD]], i8 } @single_payload_no_xi_inject_z() {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc { [[WORD]], i8 } @single_payload_no_xi_inject_z() {{.*}} {
 // CHECK: entry:
 // CHECK:   ret { [[WORD]], i8 } { [[WORD]] 1, i8 1 }
 // CHECK: }
@@ -681,7 +681,7 @@ enum AggregateSinglePayload {
 sil @int21_sink : $@convention(thin) (Builtin.Int21) -> ()
 sil @int64_sink : $@convention(thin) (Builtin.Word) -> ()
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @aggregate_single_payload_unpack
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @aggregate_single_payload_unpack
 // CHECK:         ([[WORD]], [[WORD]], i8) {{.*}} {
 sil @aggregate_single_payload_unpack : $@convention(thin) (AggregateSinglePayload) -> () {
 entry(%u : $AggregateSinglePayload):
@@ -704,7 +704,7 @@ end:
   return %x : $()
 }
 
-// CHECK: define{{( protected)?}} swiftcc { [[WORD]], [[WORD]] } @aggregate_single_payload_unsafe_unpack([[WORD]], [[WORD]], i8) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc { [[WORD]], [[WORD]] } @aggregate_single_payload_unsafe_unpack([[WORD]], [[WORD]], i8) {{.*}} {
 // CHECK:  [[A:%.*]] = insertvalue { [[WORD]], [[WORD]] } undef, [[WORD]] %0, 0
 // CHECK:  [[B:%.*]] = insertvalue { [[WORD]], [[WORD]] } [[A]], [[WORD]] %1, 1
 // CHECK:  ret { [[WORD]], [[WORD]] } [[B]]
@@ -714,7 +714,7 @@ entry(%u : $AggregateSinglePayload):
   return %x : $(Builtin.Word, Builtin.Word)
 }
 
-// CHECK: define{{( protected)?}} swiftcc { [[WORD]], [[WORD]], i8 } @aggregate_single_payload_inject([[WORD]], [[WORD]]) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc { [[WORD]], [[WORD]], i8 } @aggregate_single_payload_inject([[WORD]], [[WORD]]) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[RES_0:%.*]] = insertvalue { [[WORD]], [[WORD]], i8 } undef, [[WORD]] %0, 0
 // CHECK:   [[RES_1:%.*]] = insertvalue { [[WORD]], [[WORD]], i8 } [[RES_0]], [[WORD]] %1, 1
@@ -738,8 +738,8 @@ enum AggregateSinglePayload2 {
   case z
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @aggregate_single_payload_unpack_2([[WORD]], [[WORD]], [[WORD]], [[WORD]]) {{.*}} {
-// CHECK-32: define{{( protected)?}}  swiftcc void @aggregate_single_payload_unpack_2(%T4enum23AggregateSinglePayload2O* noalias nocapture dereferenceable(16)) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @aggregate_single_payload_unpack_2([[WORD]], [[WORD]], [[WORD]], [[WORD]]) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}}  swiftcc void @aggregate_single_payload_unpack_2(%T4enum23AggregateSinglePayload2O* noalias nocapture dereferenceable(16)) {{.*}} {
 sil @aggregate_single_payload_unpack_2 : $@convention(thin) (AggregateSinglePayload2) -> () {
 entry(%u : $AggregateSinglePayload2):
   switch_enum %u : $AggregateSinglePayload2, case #AggregateSinglePayload2.x!enumelt.1: x_dest, default end
@@ -757,7 +757,7 @@ end:
   return %x : $()
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc { [[WORD]], [[WORD]], [[WORD]], [[WORD]] } @aggregate_single_payload_2_inject(i32, [[WORD]], [[WORD]], [[WORD]]) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc { [[WORD]], [[WORD]], [[WORD]], [[WORD]] } @aggregate_single_payload_2_inject(i32, [[WORD]], [[WORD]], [[WORD]]) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:  %4 = trunc i32 %0 to i21
 // CHECK-64:  %5 = zext i21 %4 to [[WORD]]
@@ -767,7 +767,7 @@ end:
 // CHECK-64:  %9 = insertvalue { [[WORD]], [[WORD]], [[WORD]], [[WORD]] } %8, [[WORD]] %3, 3
 // CHECK-64:  ret { [[WORD]], [[WORD]], [[WORD]], [[WORD]] } %9
 
-// CHECK-32: define{{( protected)?}} swiftcc void @aggregate_single_payload_2_inject(%T4enum23AggregateSinglePayload2O* noalias nocapture sret, i32, i32, i32, i32) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @aggregate_single_payload_2_inject(%T4enum23AggregateSinglePayload2O* noalias nocapture sret, i32, i32, i32, i32) {{.*}} {
 // CHECK-32:  [[TRUNC:%.*]] = trunc i32 %1 to i21
 // CHECK-32:  [[ZEXT:%.*]] = zext i21 [[TRUNC]] to i32
 // CHECK-32:  [[CAST:%.*]] = bitcast %T4enum23AggregateSinglePayload2O* %0 to { i32, i32, i32, i32 }*
@@ -790,7 +790,7 @@ enum AggregateSinglePayload3 {
   case z
 }
 
-// CHECK: define{{( protected)?}} swiftcc void @aggregate_single_payload_unpack_3([[WORD]], [[WORD]]) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @aggregate_single_payload_unpack_3([[WORD]], [[WORD]]) {{.*}} {
 sil @aggregate_single_payload_unpack_3 : $@convention(thin) (AggregateSinglePayload3) -> () {
 entry(%u : $AggregateSinglePayload3):
   switch_enum %u : $AggregateSinglePayload3, case #AggregateSinglePayload3.x!enumelt.1: x_dest, default end
@@ -815,7 +815,7 @@ end:
   return %x : $()
 }
 
-// CHECK: define{{( protected)?}} swiftcc { [[WORD]], [[WORD]] } @aggregate_single_payload_inject_x3(i32, [[WORD]]) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc { [[WORD]], [[WORD]] } @aggregate_single_payload_inject_x3(i32, [[WORD]]) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[TRUNC:%.*]] = trunc i32 %0 to i21
 // CHECK:   [[ZEXT:%.*]] = zext i21 [[TRUNC]] to [[WORD]]
@@ -830,7 +830,7 @@ entry(%0 : $Builtin.Int21, %1 : $Builtin.Word):
   return %u : $AggregateSinglePayload3
 }
 
-// CHECK: define{{( protected)?}} swiftcc { [[WORD]], [[WORD]] } @aggregate_single_payload_inject_y3() {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc { [[WORD]], [[WORD]] } @aggregate_single_payload_inject_y3() {{.*}} {
 // CHECK: entry:
 // CHECK:   ret { [[WORD]], [[WORD]] } { [[WORD]] 2097152, [[WORD]] 0 }
 // CHECK: }
@@ -847,8 +847,8 @@ enum SinglePayloadSpareBit {
   case z
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @single_payload_spare_bit_switch(i64) {{.*}} {
-// CHECK-32: define{{( protected)?}} swiftcc void @single_payload_spare_bit_switch(i32, i32) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_switch(i64) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_switch(i32, i32) {{.*}} {
 sil @single_payload_spare_bit_switch : $@convention(thin) (SinglePayloadSpareBit) -> () {
 // CHECK: entry:
 entry(%u : $SinglePayloadSpareBit):
@@ -902,7 +902,7 @@ end:
   return %x : $()
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @single_payload_spare_bit_switch_arg(i64) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_switch_arg(i64) {{.*}} {
 sil @single_payload_spare_bit_switch_arg : $@convention(thin) (SinglePayloadSpareBit) -> () {
 // CHECK: entry:
 entry(%u : $SinglePayloadSpareBit):
@@ -975,7 +975,7 @@ end:
   return %x : $()
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc i64 @single_payload_spare_bit_inject_x(i64) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @single_payload_spare_bit_inject_x(i64) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[T:%.*]] = trunc i64 %0 to i63
 // CHECK-64:   [[A:%.*]] = zext i63 [[T]] to i64
@@ -987,7 +987,7 @@ entry(%0 : $Builtin.Int63):
   return %u : $SinglePayloadSpareBit
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_x_indirect(i64, %T4enum21SinglePayloadSpareBitO* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_x_indirect(i64, %T4enum21SinglePayloadSpareBitO* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[T:%.*]] = trunc i64 %0 to i63
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T4enum21SinglePayloadSpareBitO* %1 to i63*
@@ -1003,7 +1003,7 @@ entry(%0 : $Builtin.Int63, %1 : $*SinglePayloadSpareBit):
   return %v : $()
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc i64 @single_payload_spare_bit_inject_y() {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @single_payload_spare_bit_inject_y() {{.*}} {
 // CHECK-64: entry:
 // --              0x8000_0000_0000_0000
 // CHECK-64:   ret i64 -9223372036854775808
@@ -1014,7 +1014,7 @@ entry:
   return %u : $SinglePayloadSpareBit
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_y_indirect(%T4enum21SinglePayloadSpareBitO* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_spare_bit_inject_y_indirect(%T4enum21SinglePayloadSpareBitO* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum21SinglePayloadSpareBitO* %0 to i64*
 // --                0x8000_0000_0000_0000
@@ -1028,7 +1028,7 @@ entry(%0 : $*SinglePayloadSpareBit):
   return %v : $()
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc i64 @single_payload_spare_bit_inject_z() {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @single_payload_spare_bit_inject_z() {{.*}} {
 // CHECK-64: entry:
 //                 0x8000_0000_0000_0001
 // CHECK-64:   ret i64 -9223372036854775807
@@ -1053,7 +1053,7 @@ enum SinglePayloadNestedNested {
   case h
 }
 
-// CHECK: define{{( protected)?}} swiftcc void @single_payload_nested_switch(i8) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_nested_switch(i8) {{.*}} {
 sil @single_payload_nested_switch : $(SinglePayloadNestedNested) -> () {
 entry(%u : $SinglePayloadNestedNested):
 // CHECK:   switch i8 {{%.*}}, label {{%.*}} [
@@ -1122,7 +1122,7 @@ enum SinglePayloadClass {
   case w
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @single_payload_class_switch(i64) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_switch(i64) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   switch i64 %0, label {{%.*}} [
 // CHECK-64:     i64 0, label {{%.*}}
@@ -1132,7 +1132,7 @@ enum SinglePayloadClass {
 // CHECK-64: ; <label>
 // CHECK-64:   inttoptr [[WORD]] %0 to %T4enum1CC*
 
-// CHECK-32: define{{( protected)?}} swiftcc void @single_payload_class_switch(i32) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_switch(i32) {{.*}} {
 // CHECK-32: entry:
 // CHECK-32:   switch i32 %0, label {{%.*}} [
 // CHECK-32:     i32 0, label {{%.*}}
@@ -1172,7 +1172,7 @@ enum SinglePayloadObjCProtocol {
   case y, z, w
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @single_payload_class_protocol_switch(i64, i64) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_protocol_switch(i64, i64) {{.*}} {
 // CHECK-64:   switch i64 %0, label {{%.*}} [
 // CHECK-64:     i64 0, label {{%.*}}
 // CHECK-64:     i64 2, label {{%.*}}
@@ -1183,7 +1183,7 @@ enum SinglePayloadObjCProtocol {
 // CHECK-native-64:   inttoptr i64 %0 to %swift.refcounted*
 // CHECK-64:   inttoptr i64 %1 to i8**
 
-// CHECK-32: define{{( protected)?}} swiftcc void @single_payload_class_protocol_switch(i32, i32) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_protocol_switch(i32, i32) {{.*}} {
 // CHECK-32:   switch i32 %0, label {{%.*}} [
 // CHECK-32:     i32 0, label {{%.*}}
 // CHECK-32:     i32 1, label {{%.*}}
@@ -1211,7 +1211,7 @@ end:
   return undef : $()
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @single_payload_objc_protocol_switch(i64) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_objc_protocol_switch(i64) {{.*}} {
 // CHECK-64:   switch i64 %0, label {{%.*}}
 // CHECK-64:     i64 0, label {{%.*}}
 // CHECK-64:     i64 2, label {{%.*}}
@@ -1220,7 +1220,7 @@ end:
 // CHECK-objc-64:     inttoptr i64 %0 to %objc_object*
 // CHECK-native-64:   inttoptr i64 %0 to %swift.refcounted*
 
-// CHECK-32: define{{( protected)?}} swiftcc void @single_payload_objc_protocol_switch(i32) {{.*}} {
+// CHECK-32: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_objc_protocol_switch(i32) {{.*}} {
 // CHECK-32:   switch i32 %0, label {{%.*}}
 // CHECK-32:     i32 0, label {{%.*}}
 // CHECK-32:     i32 1, label {{%.*}}
@@ -1254,7 +1254,7 @@ enum DynamicSinglePayload<T> {
   case w
 }
 
-// CHECK: define{{( protected)?}} swiftcc void @dynamic_single_payload_switch(%T4enum20DynamicSinglePayloadO* noalias nocapture, %swift.type* %T) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_switch(%T4enum20DynamicSinglePayloadO* noalias nocapture, %swift.type* %T) {{.*}} {
 // CHECK:   [[OPAQUE_ENUM:%.*]] = bitcast %T4enum20DynamicSinglePayloadO* %0 to %swift.opaque*
 // CHECK:   [[TMP:%.*]] = bitcast %swift.type* %T to i8***
 // CHECK:   [[TMP2:%.*]] = getelementptr inbounds i8**, i8*** [[TMP]], i{{.*}} -1
@@ -1285,7 +1285,7 @@ end:
   return %v : $()
 }
 
-// CHECK: define{{( protected)?}} swiftcc void @dynamic_single_payload_inject_x(%T4enum20DynamicSinglePayloadO* noalias nocapture sret, %swift.opaque* noalias nocapture, %swift.type* %T) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_inject_x(%T4enum20DynamicSinglePayloadO* noalias nocapture sret, %swift.opaque* noalias nocapture, %swift.type* %T) {{.*}} {
 // CHECK:   [[OPAQUE_ENUM:%.*]] = bitcast %T4enum20DynamicSinglePayloadO* %0 to %swift.opaque*
 // CHECK:   [[TMP:%.*]] = bitcast %swift.type* %T to i8***
 // CHECK:   [[TMP2:%.*]] = getelementptr inbounds i8**, i8*** [[TMP]], i{{.*}} -1
@@ -1301,7 +1301,7 @@ entry(%r : $*DynamicSinglePayload<T>, %t : $*T):
   return %v : $()
 }
 
-// CHECK: define{{( protected)?}} swiftcc void @dynamic_single_payload_inject_y(%T4enum20DynamicSinglePayloadO* noalias nocapture sret, %swift.type* %T) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_inject_y(%T4enum20DynamicSinglePayloadO* noalias nocapture sret, %swift.type* %T) {{.*}} {
 // CHECK:   [[OPAQUE_ENUM:%.*]] = bitcast %T4enum20DynamicSinglePayloadO* %0 to %swift.opaque*
 // CHECK:   [[TMP:%.*]] = bitcast %swift.type* %T to i8***
 // CHECK:   [[TMP2:%.*]] = getelementptr inbounds i8**, i8*** [[TMP]], i{{.*}} -1
@@ -1320,7 +1320,7 @@ entry(%r : $*DynamicSinglePayload<T>):
 // -- Ensure instantiations of single-payload types with empty payloads work.
 //    Bug discovered by Greg Parker.
 
-// CHECK: define{{( protected)?}} swiftcc void @dynamic_single_payload_empty_payload_switch(i8) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_empty_payload_switch(i8) {{.*}} {
 // CHECK:   switch i8 {{%.*}}, label {{.*}} [
 // CHECK:     i8 0, label {{.*}}
 // CHECK:     i8 1, label {{.*}}
@@ -1350,7 +1350,7 @@ end(%z : $()):
   return %z : $()
 }
 
-// CHECK: define{{( protected)?}} swiftcc i8 @dynamic_single_payload_empty_payload_load([[DYNAMIC_SINGLE_EMPTY_PAYLOAD]]* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @dynamic_single_payload_empty_payload_load([[DYNAMIC_SINGLE_EMPTY_PAYLOAD]]* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK: entry:
 // CHECK:   %1 = bitcast [[DYNAMIC_SINGLE_EMPTY_PAYLOAD]]* %0 to i8*
 // CHECK:   %2 = load i8, i8* %1
@@ -1362,7 +1362,7 @@ entry(%p : $*DynamicSinglePayload<()>):
   return %x : $DynamicSinglePayload<()>
 }
 
-// CHECK: define{{( protected)?}} swiftcc void @dynamic_single_payload_empty_payload_store([[DYNAMIC_SINGLE_EMPTY_PAYLOAD]]* nocapture dereferenceable({{.*}}), i8) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_empty_payload_store([[DYNAMIC_SINGLE_EMPTY_PAYLOAD]]* nocapture dereferenceable({{.*}}), i8) {{.*}} {
 // CHECK: entry:
 // CHECK:   %2 = bitcast [[DYNAMIC_SINGLE_EMPTY_PAYLOAD]]* %0 to i8*
 // CHECK:   store i8 %1, i8* %2
@@ -1375,7 +1375,7 @@ entry(%p : $*DynamicSinglePayload<()>, %x : $DynamicSinglePayload<()>):
   return %v : $()
 }
 
-// CHECK: define{{( protected)?}} swiftcc i8 @dynamic_single_payload_empty_payload_inject_payload() {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @dynamic_single_payload_empty_payload_inject_payload() {{.*}} {
 // CHECK: entry:
 // CHECK:   ret i8 0
 // CHECK: }
@@ -1385,7 +1385,7 @@ sil @dynamic_single_payload_empty_payload_inject_payload : $() -> DynamicSingleP
   return %u : $DynamicSinglePayload<()>
 }
 
-// CHECK: define{{( protected)?}} swiftcc i8 @dynamic_single_payload_empty_payload_inject_no_payload() {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @dynamic_single_payload_empty_payload_inject_no_payload() {{.*}} {
 // CHECK: entry:
 // CHECK:   ret i8 1
 // CHECK: }
@@ -1395,7 +1395,7 @@ sil @dynamic_single_payload_empty_payload_inject_no_payload : $() -> DynamicSing
 }
 
 // <rdar://problem/15383966>
-// CHECK: define{{( protected)?}} swiftcc void @dynamic_single_payload_generic_destroy
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_single_payload_generic_destroy
 // CHECK:   br i1
 // CHECK: <label>
 // CHECK:   call void %destroy
@@ -1416,7 +1416,7 @@ enum MultiPayloadNoSpareBits {
   case c
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @multi_payload_no_spare_bits_switch(i64, i8) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bits_switch(i64, i8) {{.*}} {
 sil @multi_payload_no_spare_bits_switch : $(MultiPayloadNoSpareBits) -> () {
 entry(%u : $MultiPayloadNoSpareBits):
 // CHECK-64:   switch i8 %1, label %[[UNREACHABLE:[0-9]+]] [
@@ -1488,7 +1488,7 @@ end:
   return %v : $()
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @multi_payload_no_spare_bits_switch_indirect(%T4enum23MultiPayloadNoSpareBitsO* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bits_switch_indirect(%T4enum23MultiPayloadNoSpareBitsO* nocapture dereferenceable({{.*}})) {{.*}} {
 sil @multi_payload_no_spare_bits_switch_indirect : $(@inout MultiPayloadNoSpareBits) -> () {
 entry(%u : $*MultiPayloadNoSpareBits):
 // CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum23MultiPayloadNoSpareBitsO* %0 to i64*
@@ -1535,7 +1535,7 @@ end:
   return %v : $()
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc { i64, i8 } @multi_payload_no_spare_bit_inject_x(i64) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i8 } @multi_payload_no_spare_bit_inject_x(i64) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[RES_0:%.*]] = insertvalue { i64, i8 } undef, i64 %0, 0
 // CHECK-64:   [[RES:%.*]] = insertvalue { i64, i8 } [[RES_0]], i8 0, 1
@@ -1547,7 +1547,7 @@ entry(%0 : $Builtin.Int64):
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_x_indirect(i64, %T4enum23MultiPayloadNoSpareBitsO* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_x_indirect(i64, %T4enum23MultiPayloadNoSpareBitsO* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T4enum23MultiPayloadNoSpareBitsO* %1 to i64*
 // CHECK-64:   store i64 %0, i64* [[DATA_ADDR]]
@@ -1565,7 +1565,7 @@ entry(%0 : $Builtin.Int64, %1 : $*MultiPayloadNoSpareBits):
   return %v : $()
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc { i64, i8 } @multi_payload_no_spare_bit_inject_y(i32) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i8 } @multi_payload_no_spare_bit_inject_y(i32) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[ZEXT:%.*]] = zext i32 %0 to i64
 // CHECK-64:   [[RES_0:%.*]] = insertvalue { i64, i8 } undef, i64 [[ZEXT]], 0
@@ -1578,7 +1578,7 @@ entry(%0 : $Builtin.Int32):
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc { i64, i8 } @multi_payload_no_spare_bit_inject_z(i64) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i8 } @multi_payload_no_spare_bit_inject_z(i64) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i63
 // CHECK-64:   [[ZEXT:%.*]] = zext i63 [[NATIVECC_TRUNC]] to i64
@@ -1592,7 +1592,7 @@ entry(%0 : $Builtin.Int63):
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc { i64, i8 } @multi_payload_no_spare_bit_inject_a() {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i8 } @multi_payload_no_spare_bit_inject_a() {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   ret { i64, i8 } { i64 0, i8 3 }
 // CHECK-64: }
@@ -1602,7 +1602,7 @@ entry:
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_a_indirect(%T4enum23MultiPayloadNoSpareBitsO* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_no_spare_bit_inject_a_indirect(%T4enum23MultiPayloadNoSpareBitsO* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum23MultiPayloadNoSpareBitsO* %0 to i64*
 // CHECK-64:   store i64 0, i64* [[PAYLOAD_ADDR]]
@@ -1618,7 +1618,7 @@ entry(%0 : $*MultiPayloadNoSpareBits):
   return %v : $()
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc { i64, i8 } @multi_payload_no_spare_bit_inject_b() {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i8 } @multi_payload_no_spare_bit_inject_b() {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   ret { i64, i8 } { i64 1, i8 3 }
 // CHECK-64: }
@@ -1628,7 +1628,7 @@ entry:
   return %u : $MultiPayloadNoSpareBits
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc { i64, i8 } @multi_payload_no_spare_bit_inject_c() {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i8 } @multi_payload_no_spare_bit_inject_c() {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   ret { i64, i8 } { i64 2, i8 3 }
 // CHECK-64: }
@@ -1647,7 +1647,7 @@ enum MultiPayloadOneSpareBit {
   case c
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_switch(i64, i8) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_switch(i64, i8) {{.*}} {
 sil @multi_payload_one_spare_bit_switch : $(MultiPayloadOneSpareBit) -> () {
 entry(%u : $MultiPayloadOneSpareBit):
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i8 %1 to i1
@@ -1788,7 +1788,7 @@ end:
   return %v : $()
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc { i64, i8 } @multi_payload_one_spare_bit_inject_x(i64) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i8 } @multi_payload_one_spare_bit_inject_x(i64) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i62
 // CHECK-64:   [[ZEXT:%.*]] = zext i62 [[NATIVECC_TRUNC]] to i64
@@ -1802,7 +1802,7 @@ entry(%0 : $Builtin.Int62):
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_x_indirect(i64, %T4enum23MultiPayloadOneSpareBitO* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_x_indirect(i64, %T4enum23MultiPayloadOneSpareBitO* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i62
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T4enum23MultiPayloadOneSpareBitO* %1 to i62*
@@ -1827,7 +1827,7 @@ entry(%0 : $Builtin.Int62, %1 : $*MultiPayloadOneSpareBit):
   return %v : $()
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc { i64, i8 } @multi_payload_one_spare_bit_inject_y(i64) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i8 } @multi_payload_one_spare_bit_inject_y(i64) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i63
 // CHECK-64:   [[ZEXT:%.*]] = zext i63 [[NATIVECC_TRUNC]] to i64
@@ -1843,7 +1843,7 @@ entry(%0 : $Builtin.Int63):
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_y_indirect(i64, %T4enum23MultiPayloadOneSpareBitO* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_y_indirect(i64, %T4enum23MultiPayloadOneSpareBitO* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i63
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T4enum23MultiPayloadOneSpareBitO* %1 to i63*
@@ -1871,7 +1871,7 @@ entry(%0 : $Builtin.Int63, %1 : $*MultiPayloadOneSpareBit):
   return %v : $()
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc { i64, i8 } @multi_payload_one_spare_bit_inject_z(i64) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i8 } @multi_payload_one_spare_bit_inject_z(i64) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i61
 // CHECK-64:   [[ZEXT:%.*]] = zext i61 [[NATIVECC_TRUNC]] to i64
@@ -1885,7 +1885,7 @@ entry(%0 : $Builtin.Int61):
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc { i64, i8 } @multi_payload_one_spare_bit_inject_a() {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i8 } @multi_payload_one_spare_bit_inject_a() {{.*}} {
 // CHECK-64: entry:
 // --                            0x8000_0000_0000_0000
 // CHECK-64:   ret { i64, i8 } { i64 -9223372036854775808, i8 1 }
@@ -1896,7 +1896,7 @@ entry:
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_a_indirect(%T4enum23MultiPayloadOneSpareBitO* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_one_spare_bit_inject_a_indirect(%T4enum23MultiPayloadOneSpareBitO* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum23MultiPayloadOneSpareBitO* %0 to i64*
 // --                0x8000_0000_0000_0000
@@ -1913,7 +1913,7 @@ entry(%0 : $*MultiPayloadOneSpareBit):
   return %v : $()
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc { i64, i8 } @multi_payload_one_spare_bit_inject_b() {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i8 } @multi_payload_one_spare_bit_inject_b() {{.*}} {
 // CHECK-64: entry:
 // --                            0x8000_0000_0000_0001
 // CHECK-64:   ret { i64, i8 } { i64 -9223372036854775807, i8 1 }
@@ -1924,7 +1924,7 @@ entry:
   return %u : $MultiPayloadOneSpareBit
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc { i64, i8 } @multi_payload_one_spare_bit_inject_c() {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i8 } @multi_payload_one_spare_bit_inject_c() {{.*}} {
 // CHECK-64: entry:
 // --                            0x8000_0000_0000_0002
 // CHECK-64:   ret { i64, i8 } { i64 -9223372036854775806, i8 1 }
@@ -1945,7 +1945,7 @@ enum MultiPayloadTwoSpareBits {
   case c
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_switch(i64) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_switch(i64) {{.*}} {
 sil @multi_payload_two_spare_bits_switch : $(MultiPayloadTwoSpareBits) -> () {
 entry(%u : $MultiPayloadTwoSpareBits):
 // CHECK-64:   [[TAG_LSHR:%.*]] = lshr i64 %0, 62
@@ -2030,7 +2030,7 @@ end:
   return %v : $()
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc i64 @multi_payload_two_spare_bits_inject_x(i64) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @multi_payload_two_spare_bits_inject_x(i64) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i62
 // CHECK-64:   [[ZEXT:%.*]] = zext i62 [[NATIVECC_TRUNC]] to i64
@@ -2042,7 +2042,7 @@ entry(%0 : $Builtin.Int62):
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_x_indirect(i64, %T4enum24MultiPayloadTwoSpareBitsO* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_x_indirect(i64, %T4enum24MultiPayloadTwoSpareBitsO* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i62
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T4enum24MultiPayloadTwoSpareBitsO* %1 to i62*
@@ -2064,7 +2064,7 @@ entry(%0 : $Builtin.Int62, %1 : $*MultiPayloadTwoSpareBits):
   return %v : $()
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc i64 @multi_payload_two_spare_bits_inject_y(i64) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @multi_payload_two_spare_bits_inject_y(i64) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i60
 // CHECK-64:   [[ZEXT:%.*]] = zext i60 [[NATIVECC_TRUNC]] to i64
@@ -2078,7 +2078,7 @@ entry(%0 : $Builtin.Int60):
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_y_indirect(i64, %T4enum24MultiPayloadTwoSpareBitsO* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_y_indirect(i64, %T4enum24MultiPayloadTwoSpareBitsO* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i60
 // CHECK-64:   [[DATA_ADDR:%.*]] = bitcast %T4enum24MultiPayloadTwoSpareBitsO* %1 to i60*
@@ -2102,7 +2102,7 @@ entry(%0 : $Builtin.Int60, %1 : $*MultiPayloadTwoSpareBits):
   return %v : $()
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc i64 @multi_payload_two_spare_bits_inject_z(i64) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @multi_payload_two_spare_bits_inject_z(i64) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[NATIVECC_TRUNC:%.*]] = trunc i64 %0 to i61
 // CHECK-64:   [[ZEXT:%.*]] = zext i61 [[NATIVECC_TRUNC]] to i64
@@ -2116,7 +2116,7 @@ entry(%0 : $Builtin.Int61):
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc i64 @multi_payload_two_spare_bits_inject_a() {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @multi_payload_two_spare_bits_inject_a() {{.*}} {
 // CHECK-64: entry:
 // --              0xC000_0000_0000_0000
 // CHECK-64:   ret i64 -4611686018427387904
@@ -2127,7 +2127,7 @@ entry:
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_a_indirect(%T4enum24MultiPayloadTwoSpareBitsO* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_two_spare_bits_inject_a_indirect(%T4enum24MultiPayloadTwoSpareBitsO* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   [[PAYLOAD_ADDR:%.*]] = bitcast %T4enum24MultiPayloadTwoSpareBitsO* %0 to i64*
 // --                0xC000_0000_0000_0000
@@ -2141,7 +2141,7 @@ entry(%0 : $*MultiPayloadTwoSpareBits):
   return %v : $()
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc i64 @multi_payload_two_spare_bits_inject_b() {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @multi_payload_two_spare_bits_inject_b() {{.*}} {
 // CHECK-64: entry:
 // --              0xC000_0000_0000_0001
 // CHECK-64:   ret i64 -4611686018427387903
@@ -2152,7 +2152,7 @@ entry:
   return %u : $MultiPayloadTwoSpareBits
 }
 
-// CHECK-64: define{{( protected)?}} swiftcc i64 @multi_payload_two_spare_bits_inject_c() {{.*}} {
+// CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @multi_payload_two_spare_bits_inject_c() {{.*}} {
 // CHECK-64: entry:
 // --              0xC000_0000_0000_0002
 // CHECK-64:   ret i64 -4611686018427387902
@@ -2175,7 +2175,7 @@ enum MultiPayloadClasses {
   case w
 }
 
-// CHECK-64-LABEL: define{{( protected)?}} swiftcc void @multi_payload_classes_switch(i64) {{.*}} {
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_classes_switch(i64) {{.*}} {
 // CHECK-64:   %1 = lshr i64 %0, 62
 // CHECK-64:   %2 = trunc i64 %1 to i8
 // CHECK-64:   %3 = and i8 %2, 3
@@ -2197,7 +2197,7 @@ enum MultiPayloadClasses {
 // CHECK-64:   [[MASKED:%.*]] = and i64 %0, 4611686018427387903
 // CHECK-64:   inttoptr i64 [[MASKED]] to %T4enum1DC*
 
-// CHECK-32-LABEL: define{{( protected)?}} swiftcc void @multi_payload_classes_switch(i32) {{.*}} {
+// CHECK-32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_classes_switch(i32) {{.*}} {
 // CHECK-32:   %1 = trunc i32 %0 to i8
 // CHECK-32:   %2 = and i8 %1, 3
 // CHECK-32:   switch i8 %2, label {{%.*}} [
@@ -2249,7 +2249,7 @@ enum MultiPayloadSpareBitAggregates {
   case z(S)
 }
 
-// CHECK-64-LABEL: define{{( protected)?}} swiftcc void @multi_payload_spare_bit_aggregate_switch(i64, i64) {{.*}} {
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_spare_bit_aggregate_switch(i64, i64) {{.*}} {
 // CHECK-64:   [[T0:%.*]] = lshr i64 %0, 62
 // CHECK-64:   [[TAG_BYTE:%.*]] = trunc i64 [[T0]] to i8
 // CHECK-64:   [[TAG:%.*]] = and i8 [[TAG_BYTE]], 3
@@ -2298,7 +2298,7 @@ enum MultiPayloadNested {
   case B(MultiPayloadInner)
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @multi_payload_nested_switch
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_nested_switch
 // CHECK:   %1 = bitcast %T4enum18MultiPayloadNestedO* %0 to { [[WORD]], i8 }*
 // CHECK:   %2 = getelementptr
 // CHECK:   %3 = load [[WORD]], [[WORD]]* %2
@@ -2333,7 +2333,7 @@ enum MultiPayloadNestedSpareBits {
   case B(MultiPayloadInnerSpareBits)
 }
 
-// CHECK-64-LABEL: define{{( protected)?}} swiftcc void @multi_payload_nested_spare_bits_switch(%T4enum27MultiPayloadNestedSpareBitsO* noalias nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_nested_spare_bits_switch(%T4enum27MultiPayloadNestedSpareBitsO* noalias nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-64: entry:
 // CHECK-64:   %1 = bitcast %T4enum27MultiPayloadNestedSpareBitsO* %0 to [[WORD]]*
 // CHECK-64:   %2 = load [[WORD]], [[WORD]]* %1
@@ -2385,15 +2385,15 @@ enum MultiPayloadClassGeneric<T: AnyObject> {
   case B(T)
 }
 
-// CHECK-64-LABEL: define{{( protected)?}} swiftcc { i64, i64, i8 } @multi_payload_class_generic_no_spare_bits(i64, i64, i8, %swift.type* %T)
-// CHECK-32-LABEL: define{{( protected)?}} swiftcc { i32, i32, i8 } @multi_payload_class_generic_no_spare_bits(i32, i32, i8, %swift.type* %T)
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i64, i8 } @multi_payload_class_generic_no_spare_bits(i64, i64, i8, %swift.type* %T)
+// CHECK-32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i32, i32, i8 } @multi_payload_class_generic_no_spare_bits(i32, i32, i8, %swift.type* %T)
 sil @multi_payload_class_generic_no_spare_bits : $@convention(thin) <T: AnyObject> (@owned MultiPayloadClassGeneric<T>) -> MultiPayloadClassGeneric<T> {
 entry(%e : $MultiPayloadClassGeneric<T>):
   return %e : $MultiPayloadClassGeneric<T>
 }
 
-// CHECK-64-LABEL: define{{( protected)?}} swiftcc { i64, i64, i8 } @multi_payload_class_instance_no_spare_bits(i64, i64, i8)
-// CHECK-32-LABEL: define{{( protected)?}} swiftcc { i32, i32, i8 } @multi_payload_class_instance_no_spare_bits(i32, i32, i8)
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i64, i8 } @multi_payload_class_instance_no_spare_bits(i64, i64, i8)
+// CHECK-32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i32, i32, i8 } @multi_payload_class_instance_no_spare_bits(i32, i32, i8)
 sil @multi_payload_class_instance_no_spare_bits : $@convention(thin) (@owned MultiPayloadClassGeneric<C>) -> MultiPayloadClassGeneric<C> {
 entry(%e : $MultiPayloadClassGeneric<C>):
   return %e : $MultiPayloadClassGeneric<C>
@@ -2404,7 +2404,7 @@ enum MultiPayloadAddressOnlyFixed {
   case Y(Builtin.Int32)
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @multi_payload_address_only_destroy(%T4enum28MultiPayloadAddressOnlyFixedO* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_address_only_destroy(%T4enum28MultiPayloadAddressOnlyFixedO* noalias nocapture dereferenceable({{.*}}))
 sil @multi_payload_address_only_destroy : $@convention(thin) (@in MultiPayloadAddressOnlyFixed) -> () {
 entry(%m : $*MultiPayloadAddressOnlyFixed):
   destroy_addr %m : $*MultiPayloadAddressOnlyFixed
@@ -2424,7 +2424,7 @@ enum MultiPayloadAddressOnlySpareBits {
   case Y(AddressOnlySpareBitsPayload)
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @multi_payload_address_only_spare_bits(%T4enum32MultiPayloadAddressOnlySpareBitsO* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @multi_payload_address_only_spare_bits(%T4enum32MultiPayloadAddressOnlySpareBitsO* noalias nocapture dereferenceable({{.*}}))
 sil @multi_payload_address_only_spare_bits : $@convention(thin) (@in MultiPayloadAddressOnlySpareBits) -> () {
 entry(%m : $*MultiPayloadAddressOnlySpareBits):
   destroy_addr %m : $*MultiPayloadAddressOnlySpareBits
@@ -2453,7 +2453,7 @@ typealias AllConcreteTestEnums = (
 
 sil_global @x : $AllConcreteTestEnums
 
-// CHECK: define{{( protected)?}} swiftcc void @dynamic_singleton_switch_indirect([[DYNAMIC_SINGLETON]]* noalias nocapture, %swift.type* %T) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_singleton_switch_indirect([[DYNAMIC_SINGLETON]]* noalias nocapture, %swift.type* %T) {{.*}} {
 // CHECK:   bitcast [[DYNAMIC_SINGLETON]]* %0 to %swift.opaque*
 // CHECK:   ret void
 // CHECK: }
@@ -2471,13 +2471,13 @@ dest:
 sil_global @aa : $DynamicSingleton<()>
 sil_global @bb : $DynamicSingleton<NoPayloads>
 
-// CHECK: define{{( protected)?}} swiftcc void @dynamic_singleton_instance_arg_1()
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_singleton_instance_arg_1()
 sil @dynamic_singleton_instance_arg_1 : $(DynamicSingleton<()>) -> () {
 entry(%0 : $DynamicSingleton<()>):
   %v = tuple ()
   return %v : $()
 }
-// CHECK: define{{( protected)?}} swiftcc void @dynamic_singleton_instance_arg_2(i8)
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_singleton_instance_arg_2(i8)
 sil @dynamic_singleton_instance_arg_2 : $(DynamicSingleton<NoPayloads>) -> () {
 entry(%0 : $DynamicSingleton<NoPayloads>):
   %v = tuple ()
@@ -2486,9 +2486,9 @@ entry(%0 : $DynamicSingleton<NoPayloads>):
 
 // Check that payloads get properly masked in nested single-payload enums.
 // rdar://problem/18841262
-// CHECK-64-LABEL: define{{( protected)?}} swiftcc i1 @optional_optional_class_protocol(i64, i64)
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @optional_optional_class_protocol(i64, i64)
 // CHECK-64:         icmp eq i64 %0, 2
-// CHECK-32-LABEL: define{{( protected)?}} swiftcc i1 @optional_optional_class_protocol(i32, i32)
+// CHECK-32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @optional_optional_class_protocol(i32, i32)
 // CHECK-32:         icmp eq i32 %0, 1
 enum Optionable<T> {
   case some(T), none
@@ -2532,7 +2532,7 @@ entry:
   return %t : $(Optionable<ContainsUnownedObjC>, Optionable<Optionable<ContainsUnownedObjC>>)
 }
 
-// CHECK-64-LABEL: define{{( protected)?}} swiftcc { i64, i8 } @empty_payload_enum_in_enum(i32)
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i8 } @empty_payload_enum_in_enum(i32)
 sil @empty_payload_enum_in_enum : $@convention(thin) (Int32) -> Optional<(Optional<()>, Int32)> {
 entry(%x : $Int32):
   %a = tuple ()
@@ -2563,7 +2563,7 @@ struct StructWithWeakVar {
 weak var delegate: delegateProtocol?
 }
 
-// CHECK-64-LABEL: define{{( protected)?}} swiftcc void @weak_optional(%T4enum17StructWithWeakVarVSg* noalias nocapture dereferenceable({{.*}}))
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @weak_optional(%T4enum17StructWithWeakVarVSg* noalias nocapture dereferenceable({{.*}}))
 sil @weak_optional : $@convention(thin) (@in StructWithWeakVar?) -> () {
 entry(%x : $*StructWithWeakVar?):
   // CHECK-64:      icmp eq [[WORD]] {{%.*}}, 0
@@ -2590,7 +2590,7 @@ public enum Result<T, Error: Swift.Error> {
 	case failure(Error)
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @test_inject_enum_addr_with_bound_generic
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_inject_enum_addr_with_bound_generic
 sil @test_inject_enum_addr_with_bound_generic : $@convention(thin) <T> () -> @out Result<T, AnyError> {
 bb0(%0 : $*Result<T, AnyError>):
 // CHECK: call {{.*}} @"$S4enum6ResultOMa"
@@ -2601,7 +2601,7 @@ bb0(%0 : $*Result<T, AnyError>):
   return %r : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @force_global_variables_to_materialize
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @force_global_variables_to_materialize
 sil @force_global_variables_to_materialize : $() -> () {
 entry:
   // Force the global variables to materialize.
@@ -2625,7 +2625,7 @@ enum Target {
 // Ensure that we generate IR that does not run into verification
 // issues for the case where there is a single tag bit and extra
 // inhabitants.
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @generate_conditional_branch
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @generate_conditional_branch
 sil @generate_conditional_branch : $@convention(thin) (@owned Target) -> () {
 bb0(%0 : $Target):
   debug_value %0 : $Target
@@ -2678,7 +2678,7 @@ entry(%x : $*MyOptional):
 }
 
 // -- Fill function for dynamic singleton.
-// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$S4enum16DynamicSingletonOMi"(%swift.type_descriptor*, i8**, i8**) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal %swift.type* @"$S4enum16DynamicSingletonOMi"(%swift.type_descriptor*, i8**, i8**) {{.*}} {
 // CHECK:   [[T0:%.*]] = bitcast i8** %1 to %swift.type**
 // CHECK:   [[T:%T]] = load %swift.type*, %swift.type** [[T0]],
 // CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata(%swift.type_descriptor* %0, i8** %1, i8** %2, [[WORD]] {{4|8}})
@@ -2700,10 +2700,10 @@ entry(%x : $*MyOptional):
 
 // -- Fill function for dynamic single-payload. Call into the runtime to
 //    calculate the size.
-// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$S4enum20DynamicSinglePayloadOMi"
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal %swift.type* @"$S4enum20DynamicSinglePayloadOMi"
 // CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata
 
-// CHECK-LABEL: define{{( protected)?}} internal swiftcc %swift.metadata_response @"$S4enum20DynamicSinglePayloadOMr"
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal swiftcc %swift.metadata_response @"$S4enum20DynamicSinglePayloadOMr"
 // CHECK-SAME:    (%swift.type* [[METADATA:%.*]], i8*, i8**) {{.*}} {
 // CHECK:   [[T0:%.*]] = call{{( tail)?}} swiftcc %swift.metadata_response @swift_checkMetadataState([[WORD]] 319, %swift.type* [[T]])
 // CHECK:   [[T_CHECKED:%.*]] = extractvalue %swift.metadata_response [[T0]], 0

--- a/test/IRGen/enum_32_bit.sil
+++ b/test/IRGen/enum_32_bit.sil
@@ -37,19 +37,19 @@ enum Bas {
   case Z
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @foo(i32)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @foo(i32)
 sil @foo : $@convention(thin) (@owned Foo) -> () {
 entry(%0 : $Foo):
   return undef : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @bar(i32)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @bar(i32)
 sil @bar : $@convention(thin) (@owned Bar) -> () {
 entry(%0 : $Bar):
   return undef : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @bas(i32)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @bas(i32)
 sil @bas : $@convention(thin) (@owned Bas) -> () {
 entry(%0 : $Bas):
   return undef : $()

--- a/test/IRGen/enum_derived.swift
+++ b/test/IRGen/enum_derived.swift
@@ -18,14 +18,14 @@ enum E {
 // Check if the == comparison can be compiled to a simple icmp instruction.
 
 // CHECK-NORMAL-LABEL:define hidden swiftcc i1 @"$S12enum_derived1EO02__b1_A7_equalsySbAC_ACtFZ"(i8, i8)
-// CHECK-TESTABLE-LABEL:define{{( protected)?}} swiftcc i1 @"$S12enum_derived1EO02__b1_A7_equalsySbAC_ACtFZ"(i8, i8)
+// CHECK-TESTABLE-LABEL:define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @"$S12enum_derived1EO02__b1_A7_equalsySbAC_ACtFZ"(i8, i8)
 // CHECK: %2 = icmp eq i8 %0, %1
 // CHECK: ret i1 %2
 
 // Check if the hashValue getter can be compiled to a simple zext instruction.
 
 // CHECK-NORMAL-LABEL:define hidden swiftcc i{{.*}} @"$S12enum_derived1EO9hashValueSivg"(i8)
-// CHECK-TESTABLE-LABEL:define{{( protected)?}} swiftcc i{{.*}} @"$S12enum_derived1EO9hashValueSivg"(i8)
+// CHECK-TESTABLE-LABEL:define{{( dllexport)?}}{{( protected)?}} swiftcc i{{.*}} @"$S12enum_derived1EO9hashValueSivg"(i8)
 // CHECK: [[R:%.*]] = zext i8 %0 to i{{.*}}
 // CHECK: ret i{{.*}} [[R]]
 
@@ -37,7 +37,7 @@ extension def_enum.TrafficLight : Error {}
 extension def_enum.Term : Error {}
 
 // CHECK-NORMAL-LABEL: define hidden {{.*}}i64 @"$S12enum_derived7PhantomO8rawValues5Int64Vvg"(i8, %swift.type* nocapture readnone %T) local_unnamed_addr
-// CHECK-TESTABLE-LABEL: define{{( protected)?}} {{.*}}i64 @"$S12enum_derived7PhantomO8rawValues5Int64Vvg"(i8, %swift.type* nocapture readnone %T)
+// CHECK-TESTABLE-LABEL: define{{( dllexport)?}}{{( protected)?}} {{.*}}i64 @"$S12enum_derived7PhantomO8rawValues5Int64Vvg"(i8, %swift.type* nocapture readnone %T)
 
 enum Phantom<T> : Int64 {
   case Up

--- a/test/IRGen/enum_dynamic_multi_payload.sil
+++ b/test/IRGen/enum_dynamic_multi_payload.sil
@@ -22,15 +22,15 @@ sil_vtable C {}
 
 // -- The runtime doesn't track spare bits, so fixed instances of the dynamic
 //    type can't use them.
-// CHECK-64-LABEL: define{{( protected)?}} swiftcc { i64, i8 } @fixed_instances_dont_use_spare_bits(i64, i8)
-// CHECK-32-LABEL: define{{( protected)?}} swiftcc { i32, i8 } @fixed_instances_dont_use_spare_bits(i32, i8)
+// CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i8 } @fixed_instances_dont_use_spare_bits(i64, i8)
+// CHECK-32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i32, i8 } @fixed_instances_dont_use_spare_bits(i32, i8)
 sil @fixed_instances_dont_use_spare_bits : $@convention(thin) (@owned Either<C, C>) -> @owned Either<C, C> {
 entry(%e : $Either<C, C>):
   return %e : $Either<C, C>
 }
 
 // -- Handle case where all of the payloads become empty.
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @empty_instance(i8) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @empty_instance(i8) {{.*}} {
 sil @empty_instance : $@convention(thin) (Either<(), ()>) -> () {
 // CHECK-NEXT: entry:
 entry(%e : $Either<(), ()>):
@@ -80,7 +80,7 @@ next(%z : $Builtin.Int8):
   return undef : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @empty_instance2(i8) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @empty_instance2(i8) {{.*}} {
 sil @empty_instance2 : $@convention(thin) (EitherOr<(), ()>) -> () {
 // CHECK-NEXT: entry:
 entry(%e : $EitherOr<(), ()>):
@@ -154,7 +154,7 @@ next(%z : $Builtin.Int8):
 
 sil hidden_external @consume_case_test_result : $@convention(thin) (Builtin.Int1, Builtin.Int1, Builtin.Int1, Builtin.Int1) -> ()
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @static_multi_payload_case_test
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @static_multi_payload_case_test
 // CHECK:         call swiftcc void @consume_case_test_result(i1 true, i1 true, i1 true, i1 true)
 sil @static_multi_payload_case_test : $@convention(thin) () -> () {
 entry:
@@ -191,7 +191,7 @@ entry:
   return %r : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @static_multi_payload_case_test_empty
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @static_multi_payload_case_test_empty
 // CHECK:         call swiftcc void @consume_case_test_result(i1 true, i1 true, i1 true, i1 true)
 sil @static_multi_payload_case_test_empty : $@convention(thin) () -> () {
 entry:
@@ -227,7 +227,7 @@ entry:
   return %r : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @dynamic_multi_payload_case_test
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_multi_payload_case_test
 sil @dynamic_multi_payload_case_test : $@convention(thin) <T, U> () -> () {
 entry:
   %t = integer_literal $Builtin.Int1, 1
@@ -263,7 +263,7 @@ entry:
   return %r : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @dynamic_inject
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_inject
 // CHECK:         ([[EITHER_OR:%T26enum_dynamic_multi_payload8EitherOrO.*]]* noalias nocapture sret, %swift.type* %T)
 sil @dynamic_inject : $@convention(thin) <T> () -> @out EitherOr<T, Builtin.Int64> {
 entry(%e : $*EitherOr<T, Builtin.Int64>):
@@ -279,7 +279,7 @@ entry(%e : $*EitherOr<T, Builtin.Int64>):
   return undef : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @dynamic_project
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_project
 // CHECK:         ([[EITHER_OR]]* noalias nocapture sret, %swift.type* %T)
 sil @dynamic_project : $@convention(thin) <T> () -> @out EitherOr<T, Builtin.Int64> {
 entry(%e : $*EitherOr<T, Builtin.Int64>):
@@ -291,7 +291,7 @@ entry(%e : $*EitherOr<T, Builtin.Int64>):
   return undef : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @dynamic_switch
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_switch
 // CHECK:         ([[EITHER_OR]]* noalias nocapture sret, %swift.type* %T)
 sil @dynamic_switch : $@convention(thin) <T> () -> @out EitherOr<T, Builtin.Int64> {
 entry(%e : $*EitherOr<T, Builtin.Int64>):
@@ -332,7 +332,7 @@ next(%x : $Builtin.Int8):
   return undef : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @dynamic_value_semantics
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_value_semantics
 // CHECK:         ([[EITHER_OR]]* noalias nocapture sret, [[EITHER_OR]]* noalias nocapture, %swift.type* %T)
 sil @dynamic_value_semantics : $@convention(thin) <T> (@in EitherOr<T, Builtin.Int64>) -> @out EitherOr<T, Builtin.Int64> {
 entry(%a : $*EitherOr<T, Builtin.Int64>, %b : $*EitherOr<T, Builtin.Int64>):
@@ -366,7 +366,7 @@ entry(%a : $*EitherOr<T, Builtin.Int64>, %b : $*EitherOr<T, Builtin.Int64>):
   return undef : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @dynamic_value_semantics2
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dynamic_value_semantics2
 // CHECK:         ([[EITHER_OR:%T26enum_dynamic_multi_payload8EitherOrO.*]]* noalias nocapture sret, [[EITHER_OR]]* noalias nocapture, %swift.type* %T)
 sil @dynamic_value_semantics2 : $@convention(thin) <T> (@in EitherOr<T, C>) -> @out EitherOr<T, C> {
 entry(%a : $*EitherOr<T, C>, %b : $*EitherOr<T, C>):
@@ -417,7 +417,7 @@ entry(%a : $*EitherOr<T, C>, %b : $*EitherOr<T, C>):
   return undef : $()
 }
 
-// CHECK: define{{( protected)?}} internal %swift.type* @"$S26enum_dynamic_multi_payload8EitherOrOMi"(%swift.type_descriptor*, i8**, i8**) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} internal %swift.type* @"$S26enum_dynamic_multi_payload8EitherOrOMi"(%swift.type_descriptor*, i8**, i8**) {{.*}} {
 // CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericValueMetadata
 
 // CHECK: define{{( protected)?}} internal swiftcc %swift.metadata_response @"$S26enum_dynamic_multi_payload8EitherOrOMr"

--- a/test/IRGen/enum_resilience.swift
+++ b/test/IRGen/enum_resilience.swift
@@ -74,7 +74,7 @@ enum InternalEither {
   case Right(ReferenceFast)
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S15enum_resilience25functionWithResilientEnumy010resilient_A06MediumOAEF"(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S15enum_resilience25functionWithResilientEnumy010resilient_A06MediumOAEF"(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture)
 public func functionWithResilientEnum(_ m: Medium) -> Medium {
 
 // CHECK:      [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S14resilient_enum6MediumOMa"([[INT]] 0)
@@ -92,7 +92,7 @@ public func functionWithResilientEnum(_ m: Medium) -> Medium {
   return m
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S15enum_resilience33functionWithIndirectResilientEnumy010resilient_A00E8ApproachOAEF"(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S15enum_resilience33functionWithIndirectResilientEnumy010resilient_A00E8ApproachOAEF"(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture)
 public func functionWithIndirectResilientEnum(_ ia: IndirectApproach) -> IndirectApproach {
 
 // CHECK:      [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S14resilient_enum16IndirectApproachOMa"([[INT]] 0)
@@ -110,7 +110,7 @@ public func functionWithIndirectResilientEnum(_ ia: IndirectApproach) -> Indirec
   return ia
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S15enum_resilience31constructResilientEnumNoPayload010resilient_A06MediumOyF"
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S15enum_resilience31constructResilientEnumNoPayload010resilient_A06MediumOyF"
 public func constructResilientEnumNoPayload() -> Medium {
 // CHECK:      [[TAG:%.*]] = load i32, i32* @"$S14resilient_enum6MediumO5PaperyA2CmFWC"
 // CHECK:      [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S14resilient_enum6MediumOMa"([[INT]] 0)
@@ -128,7 +128,7 @@ public func constructResilientEnumNoPayload() -> Medium {
   return Medium.Paper
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S15enum_resilience29constructResilientEnumPayloady010resilient_A06MediumO0G7_struct4SizeVF"
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S15enum_resilience29constructResilientEnumPayloady010resilient_A06MediumO0G7_struct4SizeVF"
 public func constructResilientEnumPayload(_ s: Size) -> Medium {
 // CHECK:      [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S16resilient_struct4SizeVMa"([[INT]] 0)
 // CHECK-NEXT: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
@@ -158,7 +158,7 @@ public func constructResilientEnumPayload(_ s: Size) -> Medium {
   return Medium.Postcard(s)
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc {{i32|i64}} @"$S15enum_resilience19resilientSwitchTestySi0c1_A06MediumOF"(%swift.opaque* noalias nocapture)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc {{i32|i64}} @"$S15enum_resilience19resilientSwitchTestySi0c1_A06MediumOF"(%swift.opaque* noalias nocapture)
 // CHECK: [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S14resilient_enum6MediumOMa"([[INT]] 0)
 // CHECK: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK: [[METADATA_ADDR:%.*]] = bitcast %swift.type* [[METADATA]] to i8***
@@ -232,7 +232,7 @@ public func resilientSwitchTest(_ m: Medium) -> Int {
 
 public func reabstraction<T>(_ f: (Medium) -> T) {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S15enum_resilience25resilientEnumPartialApplyyySi0c1_A06MediumOXEF"(i8*, %swift.opaque*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S15enum_resilience25resilientEnumPartialApplyyySi0c1_A06MediumOXEF"(i8*, %swift.opaque*)
 public func resilientEnumPartialApply(_ f: (Medium) -> Int) {
 
 // CHECK:     [[CONTEXT:%.*]] = call noalias %swift.refcounted* @swift_allocObject
@@ -256,7 +256,7 @@ public enum EnumWithResilientPayload {
 // Make sure we call a function to access metadata of enums with
 // resilient layout.
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.type* @"$S15enum_resilience20getResilientEnumTypeypXpyF"()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @"$S15enum_resilience20getResilientEnumTypeypXpyF"()
 // CHECK:      [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S15enum_resilience24EnumWithResilientPayloadOMa"([[INT]] 0)
 // CHECK:      [[METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK-NEXT: ret %swift.type* [[METADATA]]
@@ -266,7 +266,7 @@ public func getResilientEnumType() -> Any.Type {
 }
 
 // Public metadata accessor for our resilient enum
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.metadata_response @"$S15enum_resilience24EnumWithResilientPayloadOMa"(
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.metadata_response @"$S15enum_resilience24EnumWithResilientPayloadOMa"(
 // CHECK: [[METADATA:%.*]] = load %swift.type*, %swift.type** @"$S15enum_resilience24EnumWithResilientPayloadOML"
 // CHECK-NEXT: [[COND:%.*]] = icmp eq %swift.type* [[METADATA]], null
 // CHECK-NEXT: br i1 [[COND]], label %cacheIsNull, label %cont
@@ -283,7 +283,7 @@ public func getResilientEnumType() -> Any.Type {
 // from metadata -- make sure we can do that
 extension ResilientMultiPayloadGenericEnum {
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.type* @"$S14resilient_enum32ResilientMultiPayloadGenericEnumO0B11_resilienceE16getTypeParameterxmyF"(%swift.type* %"ResilientMultiPayloadGenericEnum<T>", %swift.opaque* noalias nocapture swiftself)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @"$S14resilient_enum32ResilientMultiPayloadGenericEnumO0B11_resilienceE16getTypeParameterxmyF"(%swift.type* %"ResilientMultiPayloadGenericEnum<T>", %swift.opaque* noalias nocapture swiftself)
 // CHECK: [[METADATA:%.*]] = bitcast %swift.type* %"ResilientMultiPayloadGenericEnum<T>" to %swift.type**
 // CHECK-NEXT: [[T_ADDR:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[METADATA]], [[INT]] 2
 // CHECK-NEXT: [[T:%.*]] = load %swift.type*, %swift.type** [[T_ADDR]]
@@ -292,7 +292,7 @@ extension ResilientMultiPayloadGenericEnum {
   }
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S15enum_resilience39constructExhaustiveWithResilientMembers010resilient_A011SimpleShapeOyF"(%T14resilient_enum11SimpleShapeO* noalias nocapture sret)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S15enum_resilience39constructExhaustiveWithResilientMembers010resilient_A011SimpleShapeOyF"(%T14resilient_enum11SimpleShapeO* noalias nocapture sret)
 // CHECK: [[BUFFER:%.*]] = bitcast %T14resilient_enum11SimpleShapeO* %0 to %swift.opaque*
 // CHECK: [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S16resilient_struct4SizeVMa"([[INT]] 0)
 // CHECK-NEXT: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
@@ -304,7 +304,7 @@ public func constructExhaustiveWithResilientMembers() -> SimpleShape {
   return .KleinBottle
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i{{64|32}}, i8 } @"$S15enum_resilience19constructFullyFixed010resilient_A00dE6LayoutOyF"()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i{{64|32}}, i8 } @"$S15enum_resilience19constructFullyFixed010resilient_A00dE6LayoutOyF"()
 // CHECK: ret { [[INT]], i8 } { [[INT]] 0, i8 1 }
 // CHECK-NEXT: {{^}$}}
 public func constructFullyFixed() -> FullyFixedLayout {

--- a/test/IRGen/enum_value_semantics.sil
+++ b/test/IRGen/enum_value_semantics.sil
@@ -179,7 +179,7 @@ bb0(%0 : $SinglePayloadNontrivial):
   return %v : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @single_payload_nontrivial_copy_destroy(i64)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_nontrivial_copy_destroy(i64)
 // CHECK:      call void @"$S20enum_value_semantics23SinglePayloadNontrivialOWOy"
 // CHECK-NEXT: call swiftcc void @single_payload_nontrivial_user
 // CHECK-NEXT: call void @"$S20enum_value_semantics23SinglePayloadNontrivialOWOe"

--- a/test/IRGen/errors.sil
+++ b/test/IRGen/errors.sil
@@ -14,13 +14,13 @@ entry:
   unreachable
 }
 
-// CHECK-LABEL-i386:   define{{( protected)?}} swiftcc void @does_throw(%swift.refcounted* swiftself, %swift.error**) {{.*}} {
-// CHECK-LABEL-x86_64: define{{( protected)?}} swiftcc void @does_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
-// CHECK-LABEL-armv7:  define{{( protected)?}} swiftcc void @does_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
-// CHECK-LABEL-armv7s: define{{( protected)?}} swiftcc void @does_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
-// CHECK-LABEL-armv7k: define{{( protected)?}} swiftcc void @does_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
-// CHECK-LABEL-arm64:  define{{( protected)?}} swiftcc void @does_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
-// CHECK-LABEL-aarch64:  define{{( protected)?}} swiftcc void @does_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
+// CHECK-LABEL-i386:   define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(%swift.refcounted* swiftself, %swift.error**) {{.*}} {
+// CHECK-LABEL-x86_64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
+// CHECK-LABEL-armv7:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
+// CHECK-LABEL-armv7s: define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
+// CHECK-LABEL-armv7k: define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
+// CHECK-LABEL-arm64:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
+// CHECK-LABEL-aarch64:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @does_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
 sil @does_throw : $@convention(thin) () -> @error Error {
   // CHECK: [[T0:%.*]] = call swiftcc %swift.error* @create_error()
   %0 = function_ref @create_error : $@convention(thin) () -> @owned Error
@@ -33,13 +33,13 @@ sil @does_throw : $@convention(thin) () -> @error Error {
   throw %1 : $Error
 }
 
-// CHECK-LABEL-i386:   define{{( protected)?}} swiftcc void @doesnt_throw(%swift.refcounted* swiftself, %swift.error**) {{.*}} {
-// CHECK-LABEL-x86_64: define{{( protected)?}} swiftcc void @doesnt_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
-// CHECK-LABEL-armv7:  define{{( protected)?}} swiftcc void @doesnt_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
-// CHECK-LABEL-armv7s: define{{( protected)?}} swiftcc void @doesnt_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
-// CHECK-LABEL-armv7k: define{{( protected)?}} swiftcc void @doesnt_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
-// CHECK-LABEL-arm64:  define{{( protected)?}} swiftcc void @doesnt_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
-// CHECK-LABEL-aarch64:  define{{( protected)?}} swiftcc void @doesnt_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
+// CHECK-LABEL-i386:   define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(%swift.refcounted* swiftself, %swift.error**) {{.*}} {
+// CHECK-LABEL-x86_64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
+// CHECK-LABEL-armv7:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
+// CHECK-LABEL-armv7s: define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
+// CHECK-LABEL-armv7k: define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
+// CHECK-LABEL-arm64:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
+// CHECK-LABEL-aarch64:  define{{( dllexport)?}}{{( protected)?}} swiftcc void @doesnt_throw(%swift.refcounted* swiftself, %swift.error** swifterror) {{.*}} {
 sil @doesnt_throw : $@convention(thin) () -> @error Error {
   //   We don't have to do anything here because the caller always
   //   zeroes the error slot before a call.
@@ -51,8 +51,8 @@ sil @doesnt_throw : $@convention(thin) () -> @error Error {
 
 sil @try_apply_helper : $@convention(thin) (@owned AnyObject) -> (@owned AnyObject, @error Error)
 
-// CHECK-objc-LABEL: define{{( protected)?}} swiftcc void @try_apply(%objc_object*)
-// CHECK-native-LABEL: define{{( protected)?}} swiftcc void @try_apply(%swift.refcounted*)
+// CHECK-objc-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @try_apply(%objc_object*)
+// CHECK-native-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @try_apply(%swift.refcounted*)
 sil @try_apply : $@convention(thin) (@owned AnyObject) -> () {
 entry(%0 : $AnyObject):
   // CHECK-i386:        [[ERRORSLOT:%.*]] = alloca [[SWIFTERROR:.*]]%swift.error*, align
@@ -111,7 +111,7 @@ bb0(%0 : $Error):
 
 // rdar://21084084 - Partial application of throwing functions.
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_single(%T6errors1AC*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_single(%T6errors1AC*)
 // CHECK:       insertvalue { i8*, %swift.refcounted* } { i8* bitcast (void (%swift.refcounted*, %swift.error**)* @"$S27partial_apply_single_helperTA" to i8*), %swift.refcounted* undef },
 // CHECK: define internal swiftcc void @"$S27partial_apply_single_helperTA"(%swift.refcounted* swiftself, %swift.error**{{( )?}}[[SWIFTERROR]])
 // CHECK:       [[T0:%.*]] = bitcast %swift.refcounted* {{%.*}} to %T6errors1AC*

--- a/test/IRGen/existential_metatypes.sil
+++ b/test/IRGen/existential_metatypes.sil
@@ -19,8 +19,8 @@ extension Float : Kindable {
   public var kind: Int { get }
 }
 
-// CHECK: @"$SSi21existential_metatypes8KindableAAWP" = external global i8*, align 8
-// CHECK: @"$SSf21existential_metatypes8KindableAAWP" = external global i8*, align 8
+// CHECK: @"$SSi21existential_metatypes8KindableAAWP" = external{{( dllimport)?}} global i8*, align 8
+// CHECK: @"$SSf21existential_metatypes8KindableAAWP" = external{{( dllimport)?}} global i8*, align 8
 
 sil @int_kind_getter : $@convention(method) (Int) -> Int {
 bb0(%0 : $Int):
@@ -52,7 +52,7 @@ bb0(%0 : $*Float):
   return %3 : $Int
 }
 
-// CHECK: define{{( protected)?}} swiftcc void @test0()
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test0()
 sil @test0 : $@convention(thin) () -> () {
 bb0:
   // CHECK:      [[V:%.*]] = alloca { %swift.type*, i8** }, align 8
@@ -89,7 +89,7 @@ bb0(%0 : $@thick Kindable.Type):
   return %2 : $()
 }
 
-// CHECK: define{{( protected)?}} swiftcc void @test1(i64, i64)
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test1(i64, i64)
 sil @test1 : $@convention(thin) (Optional<@thick Kindable.Type>) -> () {
 bb0(%0 : $Optional<@thick Kindable.Type>):
   // CHECK:     [[TYPE:%.*]] = inttoptr i64 %0 to %swift.type*

--- a/test/IRGen/existentials.sil
+++ b/test/IRGen/existentials.sil
@@ -8,7 +8,7 @@ import Swift
 
 protocol CP: class {}
 
-// CHECK-DAG: define{{( protected)?}} swiftcc { %swift.refcounted*, i8** } @class_existential_unowned(%swift.refcounted*, i8**) {{.*}} {
+// CHECK-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc { %swift.refcounted*, i8** } @class_existential_unowned(%swift.refcounted*, i8**) {{.*}} {
 sil @class_existential_unowned : $@convention(thin) (@owned CP) -> @owned CP {
 entry(%s : $CP):
   %u = ref_to_unowned %s : $CP to $@sil_unowned CP
@@ -33,7 +33,7 @@ entry(%s : $CP):
   return %z : $CP
 }
 
-// CHECK-DAG: define{{( protected)?}} swiftcc void @class_existential_weak({ %swift.weak, i8** }* noalias nocapture sret, i64, i64)
+// CHECK-DAG: define{{( dllexport)?}}{{( protected)?}} swiftcc void @class_existential_weak({ %swift.weak, i8** }* noalias nocapture sret, i64, i64)
 sil @class_existential_weak : $@convention(thin) (@owned CP?) -> @out @sil_weak CP? {
 entry(%w : $*@sil_weak CP?, %a : $CP?):
   // CHECK: [[V:%.*]] = alloca { %swift.weak, i8** }

--- a/test/IRGen/existentials_opaque_boxed.sil
+++ b/test/IRGen/existentials_opaque_boxed.sil
@@ -35,7 +35,7 @@ entry(%0 : $*T):
   return %t : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden %swift.opaque* @__swift_allocate_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden %swift.opaque* @__swift_allocate_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP*)
 // CHECK:  [[METATYPE_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 1
 // CHECK:  [[METATYPE:%.*]] = load %swift.type*, %swift.type** [[METATYPE_ADDR]]
 // CHECK:  [[CAST:%.*]] = bitcast %swift.type* [[METATYPE]]
@@ -109,7 +109,7 @@ entry:
   return %t : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden void @__swift_deallocate_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden void @__swift_deallocate_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP*)
 // CHECK:   [[META_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 1
 // CHECK:   [[META:%.*]] = load %swift.type*, %swift.type** [[META_ADDR]]
 // CHECK:   [[CAST:%.*]] = bitcast %swift.type* [[META]] to i8***
@@ -160,7 +160,7 @@ bb0(%0 : $*Existential):
   return %t : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden %swift.opaque* @__swift_project_boxed_opaque_existential_1([{{(24|12)}} x i8]*, %swift.type*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden %swift.opaque* @__swift_project_boxed_opaque_existential_1([{{(24|12)}} x i8]*, %swift.type*)
 // CHECK:   [[CAST:%.*]] = bitcast %swift.type* %1 to i8***
 // CHECK:   [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[CAST]], {{(i64|i32)}} -1
 // CHECK:   [[VWT:%.*]] = load i8**, i8*** [[VWT_ADDR]]
@@ -188,7 +188,7 @@ bb0(%0 : $*Existential):
 // CHECK:   ret %swift.opaque* [[VALUEADDRBOXED]]
 
 
-// CHECK-LABEL: define{{( protected)?}} {{.*}} @test_open_existential_addr_mutable
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} {{.*}} @test_open_existential_addr_mutable
 // CHECK:  [[META_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 1
 // CHECK:  [[METATYPE:%.*]] = load %swift.type*, %swift.type** [[META_ADDR]]
 // CHECK:  [[VWT_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 2
@@ -203,7 +203,7 @@ bb0(%0 : $*Existential):
   return %t : $()
 }
 
-// CHECK: define{{( protected)?}} linkonce_odr hidden %swift.opaque* @__swift_mutable_project_boxed_opaque_existential_1([{{(24|12)}} x i8]*, %swift.type*)
+// CHECK: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden %swift.opaque* @__swift_mutable_project_boxed_opaque_existential_1([{{(24|12)}} x i8]*, %swift.type*)
 // CHECK:   [[CAST:%.*]] = bitcast %swift.type* %1 to i8***
 // CHECK:   [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[CAST]], {{(i64|i32)}} -1
 // CHECK:   [[VWT:%.*]] = load i8**, i8*** [[VWT_ADDR]]
@@ -227,7 +227,7 @@ bb0(%0 : $*Existential):
 // CHECK:  ret %swift.opaque* [[ADDR]]
 
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @test_destroy_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_destroy_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
 // CHECK:   call void @__swift_destroy_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP* %0)
 // CHECK:   ret void
 sil @test_destroy_existential_addr :$@convention(thin) (@in Existential) -> () {
@@ -237,7 +237,7 @@ bb0(%0 : $*Existential):
   return %t : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden void @__swift_destroy_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden void @__swift_destroy_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP*)
 // CHECK:  [[METADATA_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 1
 // CHECK:  [[METADATA:%.*]] = load %swift.type*, %swift.type** [[METADATA_ADDR]]
 // CHECK:  [[BUFFER_ADDR:%.*]] = getelementptr inbounds %T25existentials_opaque_boxed11ExistentialP, %T25existentials_opaque_boxed11ExistentialP* %0, i32 0, i32 0
@@ -268,7 +268,7 @@ bb0(%0 : $*Existential):
 // CHECK:   call void @swift_release(%swift.refcounted* [[REFERENCE]])
 // CHECK:   ret void
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @test_assignWithCopy_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_assignWithCopy_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
 // CHECK:  [[ALLOCA:%.*]] = alloca %T25existentials_opaque_boxed11ExistentialP
 // CHECK:  call void @__swift_assign_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP* [[ALLOCA]], %T25existentials_opaque_boxed11ExistentialP* %0)
 // CHECK:  ret void
@@ -282,7 +282,7 @@ bb0(%0 : $*Existential):
   return %t : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden void @__swift_assign_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP*, %T25existentials_opaque_boxed11ExistentialP*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden void @__swift_assign_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP*, %T25existentials_opaque_boxed11ExistentialP*)
 // CHECK:  [[TMPBUFFER:%.*]] = alloca [{{(24|12)}} x i8]
 // CHECK:  [[SELFASSIGN:%.*]] = icmp eq %T25existentials_opaque_boxed11ExistentialP* %0, %1
 // CHECK:  br i1 [[SELFASSIGN]], label %done, label %cont
@@ -429,7 +429,7 @@ bb0(%0 : $*Existential):
 // CHECK: done:
 // CHECK:   ret void
 
-// CHECK: define{{( protected)?}} swiftcc void @test_assignWithTake_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_assignWithTake_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
 // CHECK:   [[ALLOCA:%.*]] = alloca %T25existentials_opaque_boxed11ExistentialP
 // CHECK:   call void @__swift_destroy_boxed_opaque_existential_1(%T25existentials_opaque_boxed11ExistentialP* [[ALLOCA]])
 // CHECK:   call %T25existentials_opaque_boxed11ExistentialP* @"$S25existentials_opaque_boxed11Existential_pWOb"(%T25existentials_opaque_boxed11ExistentialP* %0, %T25existentials_opaque_boxed11ExistentialP* [[ALLOCA]])
@@ -463,7 +463,7 @@ bb0(%0 : $*Existential):
 // CHECK:     call %swift.opaque* [[INITWITHTAKEBUFFER]]({{.*}} [[BUFFER_LOCAL_ADDR]], {{.*}} [[BUFFER_ARG_ADDR]], %swift.type* [[METADATA]])
 // CHECK:   ret %T25existentials_opaque_boxed11ExistentialP* %1
 
-// CHECK: define{{( protected)?}} swiftcc void @test_initWithTake_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_initWithTake_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
 // CHECK:   [[LOCAL:%.*]] = alloca %T25existentials_opaque_boxed11ExistentialP
 // CHECK:    call %T25existentials_opaque_boxed11ExistentialP* @"$S25existentials_opaque_boxed11Existential_pWOb"(%T25existentials_opaque_boxed11ExistentialP* %0, %T25existentials_opaque_boxed11ExistentialP* [[LOCAL]])
 // CHECK:   ret void
@@ -476,7 +476,7 @@ bb0(%0 : $*Existential):
   return %t : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @test_initWithCopy_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_initWithCopy_existential_addr(%T25existentials_opaque_boxed11ExistentialP*
 // CHECK:   [[LOCAL:%.*]] = alloca %T25existentials_opaque_boxed11ExistentialP
 // CHECK:   call %T25existentials_opaque_boxed11ExistentialP* @"$S25existentials_opaque_boxed11Existential_pWOc"(%T25existentials_opaque_boxed11ExistentialP* %0, %T25existentials_opaque_boxed11ExistentialP* [[LOCAL]])
 // CHECK:   ret void

--- a/test/IRGen/fixed_size_buffer_peepholes.sil
+++ b/test/IRGen/fixed_size_buffer_peepholes.sil
@@ -4,7 +4,7 @@ import Builtin
 
 protocol P {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @dont_crash(
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dont_crash(
 // CHECK:  [[TYPE_ADDR:%.*]] = getelementptr inbounds %T27fixed_size_buffer_peepholes1PP, %T27fixed_size_buffer_peepholes1PP* %0, i32 0, i32 1
 // CHECK:  [[TYPE:%.*]] = load %swift.type*, %swift.type** [[TYPE_ADDR]]
 // CHECK:  call {{.*}} @__swift_project_boxed_opaque_existential_1

--- a/test/IRGen/fixlifetime.sil
+++ b/test/IRGen/fixlifetime.sil
@@ -8,7 +8,7 @@
 // unnecessary.
 // ONONE-NOT: @__swift_fixLifetime
 
-// CHECK-objc-LABEL: define{{( protected)?}} swiftcc void @test(%T11fixlifetime1CC*, %objc_object*, i8**, i8*, %swift.refcounted*, %T11fixlifetime3AggV* noalias nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-objc-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test(%T11fixlifetime1CC*, %objc_object*, i8**, i8*, %swift.refcounted*, %T11fixlifetime3AggV* noalias nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-objc: entry:
 // CHECK-objc:  call void bitcast (void (%swift.refcounted*)* @__swift_fixLifetime to void (%T11fixlifetime1CC*)*)(%T11fixlifetime1CC*
 // CHECK-objc:  call void bitcast (void (%swift.refcounted*)* @__swift_fixLifetime to void (%objc_object*)*)(%objc_object*
@@ -18,7 +18,7 @@
 // CHECK-objc:  call void @__swift_fixLifetime(%swift.refcounted*
 // CHECK-objc:  call void bitcast (void (%swift.refcounted*)* @__swift_fixLifetime to void (%T11fixlifetime1CC**)*)(%T11fixlifetime1CC**
 
-// CHECK-native-LABEL: define{{( protected)?}} swiftcc void @test(%T11fixlifetime1CC*, %swift.refcounted*, i8**, i8*, %swift.refcounted*, %T11fixlifetime3AggV* noalias nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-native-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test(%T11fixlifetime1CC*, %swift.refcounted*, i8**, i8*, %swift.refcounted*, %T11fixlifetime3AggV* noalias nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-native: entry:
 // CHECK-native:  call void bitcast (void (%swift.refcounted*)* @__swift_fixLifetime to void (%T11fixlifetime1CC*)*)(%T11fixlifetime1CC*
 // CHECK-native:  call void @__swift_fixLifetime(%swift.refcounted*

--- a/test/IRGen/function_param_convention.sil
+++ b/test/IRGen/function_param_convention.sil
@@ -10,7 +10,7 @@ struct X {
 // Make sure we can irgen a SIL function with various parameter attributes
 // without choking. This is just a basic reality check.
 
-// CHECK: define{{( protected)?}} swiftcc void @foo(%T4Test1XV* noalias nocapture sret, %T4Test1XV* noalias nocapture dereferenceable({{.*}}), %T4Test1XV* nocapture dereferenceable({{.*}}), %T4Test1XV* noalias nocapture dereferenceable({{.*}}), i32, i32, i32) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @foo(%T4Test1XV* noalias nocapture sret, %T4Test1XV* noalias nocapture dereferenceable({{.*}}), %T4Test1XV* nocapture dereferenceable({{.*}}), %T4Test1XV* noalias nocapture dereferenceable({{.*}}), i32, i32, i32) {{.*}} {
 
 sil @foo : $@convention(thin) (@in X, @inout X, @in_guaranteed X, @owned X, X, @guaranteed X) -> @out X {
 bb0(%0 : $*X, %1 : $*X, %2 : $*X, %3 : $*X, %4 : $X, %5 : $X, %6 : $X):

--- a/test/IRGen/function_types.sil
+++ b/test/IRGen/function_types.sil
@@ -15,7 +15,7 @@ sil_stage canonical
 public protocol Protocol {}
 struct S : Protocol {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i8* @thin_func_value(i8*) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @thin_func_value(i8*) {{.*}} {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    ret i8* %0
 // CHECK-NEXT:  }
@@ -24,7 +24,7 @@ entry(%x : $@convention(thin) () -> ()):
   return %x : $@convention(thin) () -> ()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @thick_func_value(i8*, %swift.refcounted*) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @thick_func_value(i8*, %swift.refcounted*) {{.*}} {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    call %swift.refcounted* @swift_retain(%swift.refcounted* returned %1) {{#[0-9]+}}
 // CHECK-NEXT:    call void @swift_release(%swift.refcounted* %1) {{#[0-9]+}}
@@ -39,7 +39,7 @@ entry(%x : $() -> ()):
   return %x : $() -> ()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i8* @thin_witness_value(i8*) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @thin_witness_value(i8*) {{.*}} {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    ret i8* %0
 // CHECK-NEXT:  }
@@ -52,7 +52,7 @@ struct X {}
 
 sil @out_void_return : $@convention(thin) () -> @out X
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @use_void_return_value(%T14function_types1XV* noalias nocapture sret) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @use_void_return_value(%T14function_types1XV* noalias nocapture sret) {{.*}} {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    call swiftcc void @out_void_return(%T14function_types1XV* noalias nocapture sret %0)
 // CHECK-NEXT:    ret void
@@ -64,7 +64,7 @@ entry(%x : $*X):
   return %z : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i8* @test_function_to_pointer(i8*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @test_function_to_pointer(i8*)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    ret i8* %0
 sil @test_function_to_pointer : $@convention(thin) (@convention(thin) () -> ()) -> Builtin.RawPointer {
@@ -73,7 +73,7 @@ bb0(%0 : $@convention(thin) () -> ()):
   return %1 : $Builtin.RawPointer
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i8* @test_pointer_to_function(i8*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @test_pointer_to_function(i8*)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    ret i8* %0
 sil @test_pointer_to_function : $@convention(thin) (Builtin.RawPointer) -> @convention(thin) () -> () {

--- a/test/IRGen/generic_classes.sil
+++ b/test/IRGen/generic_classes.sil
@@ -242,7 +242,7 @@ sil_vtable RecursiveGenericInheritsGeneric {}
 sil @$S15generic_classes024RecursiveGenericInheritsD0CfD : $@convention(method) <T, U> (RecursiveGenericInheritsGeneric<T, U>) -> ()
 
 
-// CHECK: define{{( protected)?}} swiftcc [[ROOTGENERIC]]* @RootGeneric_fragile_dependent_alloc
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc [[ROOTGENERIC]]* @RootGeneric_fragile_dependent_alloc
 // CHECK:   [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S15generic_classes11RootGenericCMa"(i64 0, %swift.type* %G)
 // CHECK:   [[METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK:   [[METADATA_ARRAY:%.*]] = bitcast %swift.type* [[METADATA]] to i8*
@@ -262,7 +262,7 @@ entry:
 }
 
 // RootGeneric.x has fixed layout
-// CHECK: define{{( protected)?}} swiftcc i8 @RootGeneric_concrete_fragile_dependent_member_access_x
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @RootGeneric_concrete_fragile_dependent_member_access_x
 // CHECK:   getelementptr inbounds [[ROOTGENERIC]], [[ROOTGENERIC]]* %0, i32 0, i32 1
 sil @RootGeneric_concrete_fragile_dependent_member_access_x : $<F> RootGeneric<F> -> UInt8 {
 entry(%c : $RootGeneric<F>):
@@ -272,7 +272,7 @@ entry(%c : $RootGeneric<F>):
 }
 
 // RootGeneric.y has dependent layout; load the offset from the metadata
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @RootGeneric_concrete_fragile_dependent_member_access_y
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @RootGeneric_concrete_fragile_dependent_member_access_y
 // CHECK:   [[TYPE_METADATA_ARRAY:%.*]] = bitcast %swift.type* {{%.*}} to i64*
 // CHECK:   [[Y_OFFSET_ADDR:%.*]] = getelementptr inbounds i64, i64* [[TYPE_METADATA_ARRAY]], i64 16
 // CHECK:   [[Y_OFFSET:%.*]] = load i64, i64* [[Y_OFFSET_ADDR]], align 8
@@ -287,7 +287,7 @@ entry(%z : $*F, %c : $RootGeneric<F>):
   return %t : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @RootGeneric_subst_concrete_fragile_dependent_member_access_y
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @RootGeneric_subst_concrete_fragile_dependent_member_access_y
 // CHECK:   [[Y_ADDR:%.*]] = getelementptr inbounds {{.*}}, {{.*}}* %1, i32 0, i32 3
 // CHECK:   bitcast %TSi* [[Y_ADDR]] to i8*
 sil @RootGeneric_subst_concrete_fragile_dependent_member_access_y : $(RootGeneric<Int>) -> @out Int {
@@ -299,7 +299,7 @@ entry(%z : $*Int, %c : $RootGeneric<Int>):
 }
 
 // RootGeneric.z has dependent layout; load the offset from the metadata
-// CHECK-LABEL: define{{( protected)?}} swiftcc i8 @RootGeneric_concrete_fragile_dependent_member_access_z
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @RootGeneric_concrete_fragile_dependent_member_access_z
 // CHECK:   [[TYPE_METADATA_ARRAY:%.*]] = bitcast %swift.type* {{%.*}} to i64*
 // CHECK:   [[Z_OFFSET_ADDR:%.*]] = getelementptr inbounds i64, i64* [[TYPE_METADATA_ARRAY]], i64 17
 // CHECK:   [[Z_OFFSET:%.*]] = load i64, i64* [[Z_OFFSET_ADDR]], align 8
@@ -313,7 +313,7 @@ entry(%c : $RootGeneric<F>):
   return %z : $UInt8
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i8 @RootGeneric_subst_concrete_fragile_dependent_member_access_z
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @RootGeneric_subst_concrete_fragile_dependent_member_access_z
 // CHECK:   [[Z_ADDR:%.*]] = getelementptr inbounds {{.*}}, {{.*}}* %0, i32 0, i32 4
 // CHECK:   [[T0:%.*]] = getelementptr inbounds %Ts5UInt8V, %Ts5UInt8V* [[Z_ADDR]], i32 0, i32 0
 // CHECK:   load i8, i8* [[T0]], align
@@ -339,24 +339,24 @@ entry(%c : $RootGeneric<Int32>):
 }
  */
 
-// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$S15generic_classes11RootGenericCMi"(%swift.type_descriptor*, i8**, i8**) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal %swift.type* @"$S15generic_classes11RootGenericCMi"(%swift.type_descriptor*, i8**, i8**) {{.*}} {
 // CHECK:   [[METADATA:%.*]] = call{{( tail)?}} %swift.type* @swift_allocateGenericClassMetadata(%swift.type_descriptor* %0, i8** %1, i8** %2)
 
-// CHECK-LABEL: define{{( protected)?}} internal swiftcc %swift.metadata_response @"$S15generic_classes11RootGenericCMr"
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal swiftcc %swift.metadata_response @"$S15generic_classes11RootGenericCMr"
 // CHECK-SAME:    (%swift.type* [[METADATA:%.*]], i8*, i8**) {{.*}} {
 // -- initialize the dependent field offsets
 // CHECK:   call void @swift_initClassMetadata(%swift.type* [[METADATA]], i64 0, i64 3, i8*** {{%.*}}, i64* {{%.*}})
 // CHECK: }
 
-// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$S15generic_classes22RootGenericFixedLayoutCMi"(%swift.type_descriptor*, i8**, i8**) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal %swift.type* @"$S15generic_classes22RootGenericFixedLayoutCMi"(%swift.type_descriptor*, i8**, i8**) {{.*}} {
 // CHECK:   [[METADATA:%.*]] ={{( tail)?}} call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_descriptor* %0, i8** %1, i8** %2)
 
-// CHECK-LABEL: define{{( protected)?}} internal swiftcc %swift.metadata_response @"$S15generic_classes22RootGenericFixedLayoutCMr"
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal swiftcc %swift.metadata_response @"$S15generic_classes22RootGenericFixedLayoutCMr"
 // CHECK-SAME:    (%swift.type* [[METADATA:%.*]], i8*, i8**) {{.*}} {
 // CHECK:   call void @swift_initClassMetadata(%swift.type* [[METADATA]], i64 0, i64 3, i8*** {{%.*}}, i64* {{%.*}})
 // CHECK: }
 
-// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$S15generic_classes015GenericInheritsC0CMi"(%swift.type_descriptor*, i8**, i8**) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal %swift.type* @"$S15generic_classes015GenericInheritsC0CMi"(%swift.type_descriptor*, i8**, i8**) {{.*}} {
 //   Bind the generic parameters.
 // CHECK:   [[T0:%.*]] = bitcast i8** %1 to %swift.type**
 // CHECK:   %A  = load %swift.type*, %swift.type** [[T0]]

--- a/test/IRGen/generic_structs.sil
+++ b/test/IRGen/generic_structs.sil
@@ -132,7 +132,7 @@ struct Stringly {
   var size : Builtin.Int64
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i64, i32 } @concrete_instances(i64, i32) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i32 } @concrete_instances(i64, i32) {{.*}} {
 // CHECK: entry:
 // CHECK:   %2 = trunc i32 %1 to i21
 // CHECK:   %3 = zext i21 %2 to i32
@@ -155,7 +155,7 @@ struct ComplexDynamic<U, V> {
   var d : Chareth
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @explode_complex_dynamic
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @explode_complex_dynamic
 sil @explode_complex_dynamic : $<A, B> (@in ComplexDynamic<A, B>, @inout Byteful, @inout A, @inout B, @inout Chareth) -> () {
 entry(%0 : $*ComplexDynamic<A, B>, %1 : $*Byteful, %2 : $*A, %3 : $*B, %4 : $*Chareth):
   %a = struct_element_addr %0 : $*ComplexDynamic<A, B>, #ComplexDynamic.a2

--- a/test/IRGen/generic_types.swift
+++ b/test/IRGen/generic_types.swift
@@ -93,14 +93,14 @@
 // CHECK-SAME:   i32 {{3|2}},
 // CHECK-SAME: }
 
-// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$S13generic_types1ACMi"(%swift.type_descriptor*, i8**, i8**) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal %swift.type* @"$S13generic_types1ACMi"(%swift.type_descriptor*, i8**, i8**) {{.*}} {
 // CHECK:   [[T0:%.*]] = bitcast i8** %1 to %swift.type**
 // CHECK:   %T = load %swift.type*, %swift.type** [[T0]],
 // CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_descriptor* %0, i8** %1, i8** %2)
 // CHECK-NEXT:   ret %swift.type* [[METADATA]]
 // CHECK: }
 
-// CHECK-LABEL: define{{( protected)?}} internal %swift.type* @"$S13generic_types1BCMi"(%swift.type_descriptor*, i8**, i8**) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} internal %swift.type* @"$S13generic_types1BCMi"(%swift.type_descriptor*, i8**, i8**) {{.*}} {
 // CHECK:   [[T0:%.*]] = bitcast i8** %1 to %swift.type**
 // CHECK:   %T = load %swift.type*, %swift.type** [[T0]],
 // CHECK:   [[METADATA:%.*]] = call %swift.type* @swift_allocateGenericClassMetadata(%swift.type_descriptor* %0, i8** %1, i8** %2)

--- a/test/IRGen/generic_vtable.swift
+++ b/test/IRGen/generic_vtable.swift
@@ -22,7 +22,7 @@ public class Concrete : Derived<Int> {
 
 //// Nominal type descriptor for 'Base' does not have any method descriptors.
 
-// CHECK-LABEL: @"$S14generic_vtable4BaseCMn" = {{(protected )?}}constant
+// CHECK-LABEL: @"$S14generic_vtable4BaseCMn" = {{(dllexport )?}}{{(protected )?}}constant
 // -- flags: has vtable, reflectable, is class, is unique
 // CHECK-SAME: <i32 0x8004_0050>,
 // -- vtable offset
@@ -47,7 +47,7 @@ public class Concrete : Derived<Int> {
 
 //// Nominal type descriptor for 'Derived' has method descriptors.
 
-// CHECK-LABEL: @"$S14generic_vtable7DerivedCMn" = {{(protected )?}}constant
+// CHECK-LABEL: @"$S14generic_vtable7DerivedCMn" = {{(dllexport )?}}{{(protected )?}}constant
 // -- flags: has vtable, reflectable, is class, is unique, is generic
 // CHECK-SAME: <i32 0x8004_00D0>,
 // -- vtable offset
@@ -71,7 +71,7 @@ public class Concrete : Derived<Int> {
 
 //// Nominal type descriptor for 'Concrete' has method descriptors.
 
-// CHECK-LABEL: @"$S14generic_vtable8ConcreteCMn" = {{(protected )?}}constant
+// CHECK-LABEL: @"$S14generic_vtable8ConcreteCMn" = {{(dllexport )?}}{{(protected )?}}constant
 // -- flags: has vtable, reflectable, is class, is unique
 // CHECK-SAME: <i32 0x8004_0050>,
 // -- vtable offset

--- a/test/IRGen/global_resilience.sil
+++ b/test/IRGen/global_resilience.sil
@@ -19,7 +19,7 @@ public struct SmallResilientStruct {
   let x: Int32 = 0
 }
 
-// CHECK: @smallGlobal = {{(protected )?}}global [[BUFFER:\[(12|24) x i8\]]] zeroinitializer
+// CHECK: @smallGlobal = {{(dllexport )?}}{{(protected )?}}global [[BUFFER:\[(12|24) x i8\]]] zeroinitializer
 sil_global [let] @smallGlobal : $SmallResilientStruct
 
 //
@@ -33,7 +33,7 @@ public struct LargeResilientStruct {
   let z: Int64 = 0
 }
 
-// CHECK: @largeGlobal = {{(protected )?}}global [[BUFFER]] zeroinitializer
+// CHECK: @largeGlobal = {{(dllexport )?}}{{(protected )?}}global [[BUFFER]] zeroinitializer
 sil_global [let] @largeGlobal : $LargeResilientStruct
 
 //
@@ -49,10 +49,10 @@ sil_global hidden @fixedGlobal : $LargeResilientStruct
 // management.
 //
 
-// CHECK: @otherGlobal = {{(protected )?}}global [[BUFFER]] zeroinitializer
+// CHECK: @otherGlobal = {{(dllexport )?}}{{(protected )?}}global [[BUFFER]] zeroinitializer
 sil_global [let] @otherGlobal : $Size
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testSmallGlobal()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testSmallGlobal()
 sil @testSmallGlobal : $@convention(thin) () -> () {
 bb0:
   // This is just a no-op
@@ -70,7 +70,7 @@ bb0:
   return %tuple : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testLargeGlobal()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testLargeGlobal()
 sil @testLargeGlobal : $@convention(thin) () -> () {
 bb0:
   // CHECK: [[ALLOC:%.*]] = call noalias i8* @swift_slowAlloc([[INT]] 32, [[INT]] 7)
@@ -86,7 +86,7 @@ bb0:
   return %tuple : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testFixedGlobal()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testFixedGlobal()
 sil @testFixedGlobal : $@convention(thin) () -> () {
 bb0:
   alloc_global @fixedGlobal

--- a/test/IRGen/globals.swift
+++ b/test/IRGen/globals.swift
@@ -50,7 +50,7 @@ extension A {
 // CHECK-NOT: g8
 // CHECK-NOT: g9
 
-// CHECK: define{{( protected)?}} i32 @main(i32, i8**) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} i32 @main(i32, i8**) {{.*}} {
 // CHECK:      store  i64 {{.*}}, i64* getelementptr inbounds ([[INT]], [[INT]]* @"$S7globals2g0Sivp", i32 0, i32 0), align 8
 
 // FIXME: give these initializers a real mangled name

--- a/test/IRGen/indirect_argument.sil
+++ b/test/IRGen/indirect_argument.sil
@@ -12,7 +12,7 @@ struct HugeAlignment {
 }
 
 // TODO: could be the context param
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @huge_method(%T17indirect_argument4HugeV* noalias nocapture swiftself dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_method(%T17indirect_argument4HugeV* noalias nocapture swiftself dereferenceable({{.*}}))
 // CHECK-NOT:     alloca
 // CHECK:         call swiftcc void @huge_method(%T17indirect_argument4HugeV* noalias nocapture swiftself dereferenceable({{.*}}) %0)
 sil @huge_method : $@convention(method) Huge -> () {
@@ -22,7 +22,7 @@ entry(%x : $Huge):
   return %z : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @huge_param(%T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_param(%T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}))
 // CHECK-NOT:         alloca
 // CHECK:         call swiftcc void @huge_param(%T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}) %0)
 sil @huge_param : $@convention(thin) Huge -> () {
@@ -32,7 +32,7 @@ entry(%x : $Huge):
   return %z : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @huge_alignment_param(%T17indirect_argument13HugeAlignmentV* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_alignment_param(%T17indirect_argument13HugeAlignmentV* noalias nocapture dereferenceable({{.*}}))
 // CHECK-NOT:     alloca
 // CHECK:         call swiftcc void @huge_alignment_param(%T17indirect_argument13HugeAlignmentV* noalias nocapture dereferenceable({{.*}}) %0)
 sil @huge_alignment_param : $@convention(thin) HugeAlignment -> () {
@@ -42,7 +42,7 @@ entry(%x : $HugeAlignment):
   return %z : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @huge_param_and_return(%T17indirect_argument4HugeV* noalias nocapture sret, %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_param_and_return(%T17indirect_argument4HugeV* noalias nocapture sret, %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}))
 // CHECK:         [[TMP_RET:%.*]] = alloca
 // CHECK:         call swiftcc void @huge_param_and_return(%T17indirect_argument4HugeV* noalias nocapture sret [[TMP_RET]], %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}) %1)
 sil @huge_param_and_return : $@convention(thin) Huge -> Huge {
@@ -52,7 +52,7 @@ entry(%x : $Huge):
   return %z : $Huge
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @huge_param_and_indirect_return(%T17indirect_argument4HugeV* noalias nocapture sret, %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_param_and_indirect_return(%T17indirect_argument4HugeV* noalias nocapture sret, %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}))
 // CHECK-NOT:     alloca
 // CHECK:         call swiftcc void @huge_param_and_indirect_return(%T17indirect_argument4HugeV* noalias nocapture sret %0, %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}) %1)
 sil @huge_param_and_indirect_return : $@convention(thin) (Huge) -> @out Huge {
@@ -62,7 +62,7 @@ entry(%o : $*Huge, %x : $Huge):
   return %z : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @huge_partial_application(%T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}), %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_partial_application(%T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}), %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}))
 // CHECK-NOT:     alloca
 // CHECK:         [[CLOSURE:%.*]] = call noalias %swift.refcounted* @swift_allocObject
 // CHECK:         bitcast %swift.refcounted* [[CLOSURE]] to <{ %swift.refcounted, %T17indirect_argument4HugeV }>*
@@ -79,7 +79,7 @@ entry(%x : $Huge, %y : $Huge):
   return %z : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @huge_partial_application_stret(%T17indirect_argument4HugeV* noalias nocapture sret, %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}), %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_partial_application_stret(%T17indirect_argument4HugeV* noalias nocapture sret, %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}), %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}))
 // CHECK:         [[TMP_RET:%.*]] = alloca
 // CHECK:         [[CLOSURE:%.*]] = call noalias %swift.refcounted* @swift_allocObject
 // CHECK:         bitcast %swift.refcounted* [[CLOSURE]] to <{ %swift.refcounted, %T17indirect_argument4HugeV }>*

--- a/test/IRGen/int_to_fp.sil
+++ b/test/IRGen/int_to_fp.sil
@@ -7,7 +7,7 @@ sil_stage canonical
 
 import Builtin
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc float @test_large(i2048* noalias nocapture dereferenceable(256)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc float @test_large(i2048* noalias nocapture dereferenceable(256)
 // CHECK: %1 = load i2048, i2048* %0, align 256
 // CHECK: %2 = trunc i2048 %1 to i64
 // CHECK: %3 = sitofp i64 %2 to float
@@ -18,7 +18,7 @@ bb0(%0 : $Builtin.Int2048):
   return %2 : $Builtin.FPIEEE32
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc float @test_small
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc float @test_small
 // CHECK: %1 = sext i32 %0 to i64
 // CHECK: %2 = sitofp i64 %1 to float
 // CHECK: ret float %2

--- a/test/IRGen/invariant_load.sil
+++ b/test/IRGen/invariant_load.sil
@@ -9,7 +9,7 @@ struct X {
   var z: Builtin.Int32
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @invariant_load
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @invariant_load
 sil @invariant_load : $@convention(thin) (Builtin.RawPointer) -> () {
 entry(%p : $Builtin.RawPointer):
   %a = pointer_to_address %p : $Builtin.RawPointer to [invariant] $*X

--- a/test/IRGen/keypaths.sil
+++ b/test/IRGen/keypaths.sil
@@ -222,7 +222,7 @@ sil_vtable C {}
 // CHECK-32-SAME: i32 20 }>
 // CHECK-64-SAME: i32 36 }>
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @stored_property_fixed_offsets()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @stored_property_fixed_offsets()
 sil @stored_property_fixed_offsets : $@convention(thin) () -> () {
 entry:
   // CHECK: call %swift.refcounted* @swift_getKeyPath(i8* bitcast ({{.*}} [[KP_A]] to i8*), i8* undef)
@@ -269,7 +269,7 @@ struct Foo<T> {
   var foo: T
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @stored_property_generics(%swift.type* %T, %swift.type* %U)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @stored_property_generics(%swift.type* %T, %swift.type* %U)
 sil @stored_property_generics : $@convention(thin) <T, U> () -> () {
 entry:
   // CHECK: [[PTR:%.*]] = bitcast i8* [[ARGS:%.*]] to
@@ -305,7 +305,7 @@ entry:
 // CHECK:   [[A:%.*]] = load %swift.type*, %swift.type** [[BUF]]
 // CHECK:   ret %swift.type* [[A]]
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @computed_property_generics
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @computed_property_generics
 sil @computed_property_generics : $@convention(thin) <T, U> () -> () {
 entry:
   %n = keypath $WritableKeyPath<T, U>, <UUU, TTT> (root $TTT; settable_property $UUU, id @n_get : $@convention(thin) <UU, TT> (@in_guaranteed TT) -> @out UU, getter @n_get : $@convention(thin) <UU, TT> (@in_guaranteed TT) -> @out UU, setter @n_set : $@convention(thin) <UU, TT> (@in_guaranteed UU, @in_guaranteed TT) -> ()) <U, T>

--- a/test/IRGen/lifetime.sil
+++ b/test/IRGen/lifetime.sil
@@ -17,7 +17,7 @@ bb0(%x : $*T):
   %0 = tuple ()
   return %0 : $()
 }
-// CHECK:    define{{( protected)?}} swiftcc void @generic([[OPAQUE]]* noalias nocapture, [[TYPE]]* %T) {{.*}} {
+// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @generic([[OPAQUE]]* noalias nocapture, [[TYPE]]* %T) {{.*}} {
 //   Allocate it.
 // CHECK: [[TYPE_ADDR:%.*]] = bitcast %swift.type* %T to i8***
 // CHECK-NEXT: [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[TYPE_ADDR]], {{(i32|i64)}} -1
@@ -56,7 +56,7 @@ bb0(%x : $*T):
   %0 = tuple ()
   return %0 : $()
 }
-// CHECK:    define{{( protected)?}} swiftcc void @generic_with_reuse([[OPAQUE]]* noalias nocapture, [[TYPE]]* %T) {{.*}} {
+// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @generic_with_reuse([[OPAQUE]]* noalias nocapture, [[TYPE]]* %T) {{.*}} {
 //   Allocate it.
 // CHECK: [[TYPE_ADDR:%.*]] = bitcast %swift.type* %T to i8***
 // CHECK-NEXT: [[VWT_ADDR:%.*]] = getelementptr inbounds i8**, i8*** [[TYPE_ADDR]], {{(i32|i64)}} -1
@@ -99,7 +99,7 @@ bb0(%x : $*Builtin.Int64):
   %0 = tuple ()
   return %0 : $()
 }
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @fixed_size(i64* noalias nocapture dereferenceable(8))
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @fixed_size(i64* noalias nocapture dereferenceable(8))
 // CHECK:         [[XBUF:%.*]] = alloca i64
 // CHECK-NEXT:    [[XBUFLIFE:%.*]] = bitcast i64* [[XBUF]] to i8*
 // CHECK-NEXT:    call void @llvm.lifetime.start.p0i8({{(i32|i64)}} 8, i8* [[XBUFLIFE]])

--- a/test/IRGen/literals.sil
+++ b/test/IRGen/literals.sil
@@ -22,7 +22,7 @@ bb0:
   %0 = string_literal utf8 "help\tme"
   return %0 : $Builtin.RawPointer
 }
-// CHECK: define{{( protected)?}} swiftcc i8* @utf8_literal() {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @utf8_literal() {{.*}} {
 // CHECK:   ret i8* getelementptr inbounds ([8 x i8], [8 x i8]* [[U8_0]], i64 0, i64 0)
 
 sil @utf8_literal_with_nul : $@convention(thin) () -> Builtin.RawPointer {
@@ -30,7 +30,7 @@ bb0:
   %0 = string_literal utf8 "\u{00}x\u{01ab}"
   return %0 : $Builtin.RawPointer
 }
-// CHECK: define{{( protected)?}} swiftcc i8* @utf8_literal_with_nul() {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @utf8_literal_with_nul() {{.*}} {
 // CHECK:   ret i8* getelementptr inbounds ([5 x i8], [5 x i8]* [[U8_1]], i64 0, i64 0)
 
 sil @utf16_literal : $@convention(thin) () -> Builtin.RawPointer {
@@ -38,7 +38,7 @@ bb0:
   %0 = string_literal utf16 "help\tme"
   return %0 : $Builtin.RawPointer
 }
-// CHECK: define{{( protected)?}} swiftcc i8* @utf16_literal() {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @utf16_literal() {{.*}} {
 // CHECK:   ret i8* bitcast ([8 x i16]* [[U16_0]] to i8*)
 
 sil @utf16_literal_with_nul : $@convention(thin) () -> Builtin.RawPointer {
@@ -46,7 +46,7 @@ bb0:
   %0 = string_literal utf16 "\u{00}x\u{01ab}"
   return %0 : $Builtin.RawPointer
 }
-// CHECK: define{{( protected)?}} swiftcc i8* @utf16_literal_with_nul() {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @utf16_literal_with_nul() {{.*}} {
 // CHECK:   ret i8* bitcast ([4 x i16]* [[U16_1]] to i8*)
 
 // CHECK-LABEL: define{{.*}} swiftcc i8* @constant_string_literals_utf16

--- a/test/IRGen/local_types.swift
+++ b/test/IRGen/local_types.swift
@@ -85,7 +85,7 @@ public func innerIfConfig() {
 }
 
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S11local_types8callTestyyF"() {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S11local_types8callTestyyF"() {{.*}} {
 public func callTest() {
   test()
 } // CHECK: {{^[}]$}}

--- a/test/IRGen/metatype.sil
+++ b/test/IRGen/metatype.sil
@@ -19,7 +19,7 @@ sil @_TFC8metatype1Xd : $@convention(method) (@owned X) -> @owned Builtin.Native
 
 sil @_TFC8metatype1XD : $@convention(method) (@owned X) -> ()
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %objc_class* @_TF8metatype22thick_to_objc_metatypeFT2xmMCS_1X_T_(%swift.type*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %objc_class* @_TF8metatype22thick_to_objc_metatypeFT2xmMCS_1X_T_(%swift.type*)
 sil @_TF8metatype22thick_to_objc_metatypeFT2xmMCS_1X_T_ : $@convention(thin) (@thick X.Type) -> @objc_metatype X.Type {
 bb0(%0 : $@thick X.Type):
   // CHECK: [[RESULT:%[0-9a-zA-Z_-]+]] = bitcast %swift.type* %0 to %objc_class*
@@ -28,7 +28,7 @@ bb0(%0 : $@thick X.Type):
   return %1 : $@objc_metatype X.Type
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %objc_class* @foreign_thick_to_objc(%swift.type*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %objc_class* @foreign_thick_to_objc(%swift.type*)
 sil @foreign_thick_to_objc : $@convention(thin) (@thick Gizmo.Type) -> @objc_metatype Gizmo.Type {
 bb0(%0 : $@thick Gizmo.Type):
   // CHECK: call %objc_class* @swift_getObjCClassFromMetadata
@@ -37,7 +37,7 @@ bb0(%0 : $@thick Gizmo.Type):
   return %1 : $@objc_metatype Gizmo.Type
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.type* @_TF8metatype22objc_to_thick_metatypeFT2xmMCS_1X_T_(%objc_class*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @_TF8metatype22objc_to_thick_metatypeFT2xmMCS_1X_T_(%objc_class*)
 sil @_TF8metatype22objc_to_thick_metatypeFT2xmMCS_1X_T_ : $@convention(thin) (@objc_metatype X.Type) -> @thick X.Type {
 bb0(%0 : $@objc_metatype X.Type):
   // CHECK: [[RESULT:%[0-9a-zA-Z_-]+]] = call %swift.type* @swift_getObjCClassMetadata(%objc_class* %0)
@@ -46,7 +46,7 @@ bb0(%0 : $@objc_metatype X.Type):
   return %1 : $@thick X.Type
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.type* @foreign_objc_to_thick(%objc_class*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @foreign_objc_to_thick(%objc_class*)
 sil @foreign_objc_to_thick : $@convention(thin) (@objc_metatype Gizmo.Type) -> @thick Gizmo.Type {
 bb0(%0 : $@objc_metatype Gizmo.Type):
   // CHECK: [[RESULT:%[0-9a-zA-Z_-]+]] = call %swift.type* @swift_getObjCClassMetadata(%objc_class* %0)
@@ -57,7 +57,7 @@ bb0(%0 : $@objc_metatype Gizmo.Type):
 
 protocol CP: class {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %objc_class* @archetype_objc_metatype(%swift.type* %T, i8** %T.CP)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %objc_class* @archetype_objc_metatype(%swift.type* %T, i8** %T.CP)
 // CHECK:         call %objc_class* @swift_getObjCClassFromMetadata
 sil @archetype_objc_metatype : $@convention(thin) <T: CP> () -> @objc_metatype T.Type {
 entry:
@@ -65,7 +65,7 @@ entry:
   return %m : $@objc_metatype T.Type
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %objc_class* @existential_objc_metatype(%objc_object*) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %objc_class* @existential_objc_metatype(%objc_object*) {{.*}} {
 // CHECK: entry:
 // CHECK-NEXT: [[METATYPE:%.*]] = call %objc_class* @swift_getObjCClassFromObject(%objc_object* %0) {{#[0-9]+}}
 // CHECK-NEXT: ret %objc_class* [[METATYPE]]

--- a/test/IRGen/metatype_casts.sil
+++ b/test/IRGen/metatype_casts.sil
@@ -5,7 +5,7 @@
 
 import Swift
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @archetype_metatype_cast
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @archetype_metatype_cast
 // CHECK:         %0 = call %swift.type* @swift_dynamicCastMetatype(%swift.type* %T, %swift.type* %U)
 // CHECK:         %1 = icmp ne %swift.type* %0, null
 sil @archetype_metatype_cast : $@convention(thin) <T, U> () -> () {
@@ -24,7 +24,7 @@ end:
 
 protocol P {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @existential_archetype_metatype_cast(%swift.type*, i8**, %swift.type* %T)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @existential_archetype_metatype_cast(%swift.type*, i8**, %swift.type* %T)
 // CHECK:         [[T0:%.*]] = call %swift.type* @swift_dynamicCastMetatype(%swift.type* %0, %swift.type* %T)
 // CHECK:         [[T1:%.*]] = icmp ne %swift.type* [[T0]], null
 sil @existential_archetype_metatype_cast : $@convention(thin) <T> (@thick P.Type) -> () {
@@ -43,7 +43,7 @@ end:
 class SomeClass {}
 sil_vtable SomeClass {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %objc_object* @metatype_object_conversion(%objc_class*) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %objc_object* @metatype_object_conversion(%objc_class*) {{.*}} {
 // CHECK:         %1 = bitcast %objc_class* %0 to %objc_object*
 // CHECK:         ret %objc_object* %1
 // CHECK:       }
@@ -55,7 +55,7 @@ entry(%m : $@objc_metatype SomeClass.Type):
 
 protocol SomeClassProtocol : class {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %objc_object* @existential_metatype_object_conversion(%objc_class*, i8**) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %objc_object* @existential_metatype_object_conversion(%objc_class*, i8**) {{.*}} {
 // CHECK:         [[T0:%.*]] = bitcast %objc_class* %0 to %objc_object*
 // CHECK:         ret %objc_object* [[T0]]
 // CHECK:       }
@@ -68,7 +68,7 @@ entry(%m : $@objc_metatype SomeClassProtocol.Type):
 class OtherClass : SomeClass {}
 sil_vtable OtherClass {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @value_metatype_cast(%T14metatype_casts9SomeClassC*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @value_metatype_cast(%T14metatype_casts9SomeClassC*)
 // CHECK:         [[T0:%.*]] = bitcast %T14metatype_casts9SomeClassC* %0 to %swift.type**
 // CHECK:         [[T1:%.*]] = load %swift.type*, %swift.type** [[T0]]
 // CHECK:         [[T2:%.*]] = icmp eq %swift.type* [[T1]], {{.*}} @"$S14metatype_casts10OtherClassCMf"
@@ -87,7 +87,7 @@ end:
   return undef : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.type* @checked_cast_to_anyobject_type
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @checked_cast_to_anyobject_type
 // CHECK:         [[T0:%.*]] = bitcast %swift.type* %0 to i8*
 // CHECK:         [[CAST:%.*]] = call { i8* } @dynamic_cast_existential_0_class_unconditional(i8* [[T0]], %swift.type* %0)
 // CHECK:         [[RESULT0:%.*]] = extractvalue { i8* } [[CAST]], 0
@@ -102,7 +102,7 @@ entry(%0 : $@thick Any.Type):
 // Trivial case -- we know the source is a class metatype, so there's nothing
 // to check.
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.type* @checked_cast_class_to_anyobject_type
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @checked_cast_class_to_anyobject_type
 // CHECK:         [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S14metatype_casts9SomeClassCMa"([[INT]] 0)
 // CHECK:         [[METATYPE:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
 // CHECK:         ret %swift.type* [[METATYPE]]

--- a/test/IRGen/method_linkage.swift
+++ b/test/IRGen/method_linkage.swift
@@ -47,12 +47,12 @@ public class PublicClass {
 }
 
 open class OpenClass {
-  // CHECK: define{{( protected)?}} swiftcc void @"$S14method_linkage9OpenClass{{.*}}4pfoo0
+  // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S14method_linkage9OpenClass{{.*}}4pfoo0
   @inline(never)
   fileprivate func pfoo() {
   }
 
-  // CHECK: define{{( protected)?}} swiftcc void @"$S14method_linkage9OpenClassC4pbaryyF
+  // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S14method_linkage9OpenClassC4pbaryyF
   @inline(never)
   internal func pbar() {
   }

--- a/test/IRGen/nested_generics.swift
+++ b/test/IRGen/nested_generics.swift
@@ -4,7 +4,7 @@
 
 func blah<T>(_: T.Type) {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S15nested_generics13makeAMetadatayyF"()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S15nested_generics13makeAMetadatayyF"()
 public func makeAMetadata() {
   blah(OuterGenericStruct<Int>.InnerGenericStruct<String>.self)
   blah(OuterGenericStruct<Int>.InnerConcreteStruct.self)
@@ -19,7 +19,7 @@ public func makeAMetadata() {
 // CHECK: ret %swift.metadata_response
 
 // Type constructor for OuterGenericStruct<T>.InnerGenericStruct<U>
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.metadata_response @"$S15nested_generics18OuterGenericStructV05InnerdE0VMa"(i64, %swift.type*, %swift.type*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.metadata_response @"$S15nested_generics18OuterGenericStructV05InnerdE0VMa"(i64, %swift.type*, %swift.type*)
 
 // Type constructor for OuterGenericStruct<Int>.InnerConcreteStruct
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$S15nested_generics18OuterGenericStructV013InnerConcreteE0VySi_GMa"(i64)
@@ -27,7 +27,7 @@ public func makeAMetadata() {
 // CHECK: ret %swift.metadata_response
 
 // Type constructor for OuterGenericStruct<T>.InnerConcreteStruct
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.metadata_response @"$S15nested_generics18OuterGenericStructV013InnerConcreteE0VMa"(i64, %swift.type*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.metadata_response @"$S15nested_generics18OuterGenericStructV013InnerConcreteE0VMa"(i64, %swift.type*)
 
 public struct OuterGenericStruct<T> {
   public struct InnerGenericStruct<U> {
@@ -49,7 +49,7 @@ public struct OuterGenericStruct<T> {
 // CHECK: call swiftcc %swift.metadata_response @"$S15nested_generics17OuterGenericClassC05InnerdE0CMa"(i64 %0, %swift.type* @"$SSiN", %swift.type* @"$SSSN")
 
 // Type constructor for OuterGenericClass<T>.InnerGenericClass<U>
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.metadata_response @"$S15nested_generics17OuterGenericClassC05InnerdE0CMa"(i64, %swift.type*, %swift.type*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.metadata_response @"$S15nested_generics17OuterGenericClassC05InnerdE0CMa"(i64, %swift.type*, %swift.type*)
 
 // Type constructor for OuterGenericClass<Int>.InnerConcreteClass
 // CHECK-LABEL: define linkonce_odr hidden swiftcc %swift.metadata_response @"$S15nested_generics17OuterGenericClassC013InnerConcreteE0CySi_GMa"(i64)
@@ -57,13 +57,13 @@ public struct OuterGenericStruct<T> {
 // CHECK: ret %swift.metadata_response
 
 // Type constructor for OuterGenericClass<T>.InnerConcreteClass
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.metadata_response @"$S15nested_generics17OuterGenericClassC013InnerConcreteE0CMa"(i64, %swift.type*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.metadata_response @"$S15nested_generics17OuterGenericClassC013InnerConcreteE0CMa"(i64, %swift.type*)
 
 // Type constructor for OuterGenericStruct<T>
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.metadata_response @"$S15nested_generics18OuterGenericStructVMa"(i64, %swift.type*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.metadata_response @"$S15nested_generics18OuterGenericStructVMa"(i64, %swift.type*)
 
 // Type constructor for OuterGenericClass<T>
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.metadata_response @"$S15nested_generics17OuterGenericClassCMa"(i64, %swift.type*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.metadata_response @"$S15nested_generics17OuterGenericClassCMa"(i64, %swift.type*)
 
 public class OuterGenericClass<T> {
   public class InnerGenericClass<U> {

--- a/test/IRGen/nested_types.sil
+++ b/test/IRGen/nested_types.sil
@@ -19,7 +19,7 @@ bb0(%0 : $@thick Outer.Inner.Type):
   %1 = metatype $@thick Outer.Type
   return %1 : $@thick Outer.Type
 }
-// CHECK-LABEL: define{{ | protected }}swiftcc %swift.type* @test0(%swift.type*)
+// CHECK-LABEL: define{{ | dllexport | protected }}swiftcc %swift.type* @test0(%swift.type*)
 // CHECK:      [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S12nested_types5OuterCMa"([[INT]] 0)
 // CHECK-NEXT: [[T1:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
 // CHECK-NEXT: ret %swift.type* [[T1]]

--- a/test/IRGen/nondominant.sil
+++ b/test/IRGen/nondominant.sil
@@ -15,7 +15,7 @@ bb1:
   %0 = integer_literal $Builtin.Int8, 7
   br bb2
 }
-// CHECK:   define{{( protected)?}} swiftcc i8 @test0()
+// CHECK:   define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @test0()
 // CHECK:     br
 // CHECK-NOT: }
 // CHECK:     ret i8 7

--- a/test/IRGen/objc_block.sil
+++ b/test/IRGen/objc_block.sil
@@ -16,7 +16,7 @@ entry(%b : $@convention(block) Foo -> Foo, %x : $Foo):
   %y = apply %b(%x) : $@convention(block) Foo -> Foo
   return %y : $Foo
 }
-// CHECK-LABEL: define{{( protected)?}} swiftcc %T10objc_block3FooC* @call_block(%objc_block*, %T10objc_block3FooC*) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %T10objc_block3FooC* @call_block(%objc_block*, %T10objc_block3FooC*) {{.*}} {
 // CHECK:       entry:
 // CHECK:         [[T0:%.*]] = getelementptr inbounds %objc_block, %objc_block* %0, i32 0, i32 3
 // CHECK:         [[T1:%.*]] = load i8*, i8** [[T0]]
@@ -36,6 +36,6 @@ entry(%b : $*@convention(block) () -> ()):
   return %z : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @generic_with_block(%objc_block** noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @generic_with_block(%objc_block** noalias nocapture dereferenceable({{.*}}))
 // --                                                                               0x100_0001 = block convention, 1 arg
 // CHECK: call %swift.type* @swift_getFunctionTypeMetadata0([[WORD:i(32|64)]] 65536, %swift.type* getelementptr inbounds (%swift.full_type, %swift.full_type* @"$SytN", i32 0, i32 1))

--- a/test/IRGen/objc_block_storage.sil
+++ b/test/IRGen/objc_block_storage.sil
@@ -36,7 +36,7 @@ import gizmo
 // CHECK:   i8* {{.*}} [[NSRECT_BLOCK_SIGNATURE]]
 // CHECK: }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i8* @project_block_storage({ %objc_block, i8* }* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @project_block_storage({ %objc_block, i8* }* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    %1 = getelementptr inbounds { %objc_block, i8* }, { %objc_block, i8* }* %0, i32 0, i32 1
 // CHECK-NEXT:    %2 = load i8*, i8** %1, align 8
@@ -49,7 +49,7 @@ entry(%0 : $*@block_storage Builtin.RawPointer):
   return %p : $Builtin.RawPointer
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc fp128 @overaligned_project_block_storage({ %objc_block, fp128 }* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc fp128 @overaligned_project_block_storage({ %objc_block, fp128 }* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    %1 = getelementptr inbounds { %objc_block, fp128 }, { %objc_block, fp128 }* %0, i32 0, i32 1
 // CHECK-NEXT:    %2 = load fp128, fp128* %1, align 16
@@ -62,7 +62,7 @@ entry(%0 : $*@block_storage Builtin.FPIEEE128):
   return %p : $Builtin.FPIEEE128
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %objc_block* @init_block_header_trivial({ %objc_block, i8* }* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %objc_block* @init_block_header_trivial({ %objc_block, i8* }* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK:         [[HEADER:%.*]] = getelementptr inbounds { %objc_block, i8* }, { %objc_block, i8* }* %0, i32 0, i32 0
 // CHECK:         [[T0:%.*]] = getelementptr inbounds %objc_block, %objc_block* [[HEADER]], i32 0, i32 0
 // CHECK:         store %objc_class* [[BLOCK_ISA]], %objc_class** [[T0]]
@@ -84,7 +84,7 @@ entry(%0 : $*@block_storage Builtin.RawPointer):
   return %b : $@convention(block) () -> ()
 }
 
-// CHECK-LABEL: define{{( protected)?}} void @invoke_trivial(void (...)*) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} void @invoke_trivial(void (...)*) {{.*}} {
 // CHECK:         %1 = bitcast void (...)* %0 to { %objc_block, i8* }*
 // CHECK:         %2 = getelementptr inbounds { %objc_block, i8* }, { %objc_block, i8* }* %1, i32 0, i32 1
 sil @invoke_trivial : $@convention(c) (@inout_aliasable @block_storage Builtin.RawPointer) -> () {
@@ -102,14 +102,14 @@ entry(%0 : $*@block_storage Builtin.RawPointer):
 
 sil @invoke_trivial_block_param : $@convention(c) (@inout_aliasable @block_storage Builtin.RawPointer, @convention(block) (Int) -> Int) -> ()
 
-// CHECK-LABEL: define{{( protected)?}} i64 @invoke_trivial_with_arg(void (...)*, i64) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} i64 @invoke_trivial_with_arg(void (...)*, i64) {{.*}} {
 // CHECK:         ret i64 %1
 sil @invoke_trivial_with_arg : $@convention(c) (@inout_aliasable @block_storage Builtin.RawPointer, Int) -> Int {
 entry(%0 : $*@block_storage Builtin.RawPointer, %1 : $Int):
   return %1 : $Int
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %objc_block* @init_block_header_nontrivial({ %objc_block, %swift.refcounted* }* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %objc_block* @init_block_header_nontrivial({ %objc_block, %swift.refcounted* }* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK:         [[HEADER:%.*]] = getelementptr inbounds
 // CHECK:         [[T0:%.*]] = getelementptr inbounds %objc_block, %objc_block* [[HEADER]], i32 0, i32 0
 // CHECK:         store %objc_class* [[BLOCK_ISA]], %objc_class** [[T0]]
@@ -147,7 +147,7 @@ entry(%0 : $*@block_storage Builtin.NativeObject):
 
 sil public_external @invoke_nontrivial : $@convention(c) (@inout_aliasable @block_storage Builtin.NativeObject) -> ()
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %objc_block* @init_block_header_stret({ %objc_block, i8* }* nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %objc_block* @init_block_header_stret({ %objc_block, i8* }* nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK:         [[HEADER:%.*]] = getelementptr inbounds
 // CHECK:         [[T0:%.*]] = getelementptr inbounds %objc_block, %objc_block* [[HEADER]], i32 0, i32 0
 // CHECK:         store %objc_class* [[BLOCK_ISA]], %objc_class** [[T0]]

--- a/test/IRGen/objc_errors.sil
+++ b/test/IRGen/objc_errors.sil
@@ -7,7 +7,7 @@
 import Swift
 import Foundation
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.error* @errortype_from_nserror(%TSo7NSErrorC*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.error* @errortype_from_nserror(%TSo7NSErrorC*)
 // CHECK:         %1 = bitcast %TSo7NSErrorC* %0 to %swift.error*
 sil @errortype_from_nserror : $@convention(thin) (@owned NSError) -> @owned Error {
 entry(%0 : $NSError):

--- a/test/IRGen/objc_ns_enum.swift
+++ b/test/IRGen/objc_ns_enum.swift
@@ -13,7 +13,7 @@ import gizmo
 // CHECK: @"$SSo16NSRuncingOptionsVN" = linkonce_odr hidden global
 // CHECK: @"$SSo28NeverActuallyMentionedByNameVs9EquatableSCWp" = linkonce_odr hidden constant
 
-// CHECK-LABEL: define{{( protected)?}} i32 @main
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} i32 @main
 // CHECK:         call swiftcc %swift.metadata_response @"$SSo16NSRuncingOptionsVMa"(i64 0)
 
 // CHECK: define hidden swiftcc i16 @"$S12objc_ns_enum09imported_C9_inject_aSo16NSRuncingOptionsVyF"()

--- a/test/IRGen/objc_properties_jit.swift
+++ b/test/IRGen/objc_properties_jit.swift
@@ -15,7 +15,7 @@ extension NSString {
   }
 }
 
-// CHECK-LABEL: define{{( protected)?}} private void @runtime_registration
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} private void @runtime_registration
 // CHECK:         [[GET_CLASS_PROP:%.*]] = call i8* @sel_registerName({{.*}}(classProp)
 // CHECK:         call i8* @class_replaceMethod(%objc_class* @"OBJC_METACLASS_$_NSString", i8* [[GET_CLASS_PROP]]
 // CHECK:         [[SET_CLASS_PROP:%.*]] = call i8* @sel_registerName({{.*}}(setClassProp:)

--- a/test/IRGen/objc_protocol_conversion.sil
+++ b/test/IRGen/objc_protocol_conversion.sil
@@ -12,7 +12,7 @@ import ObjectiveC
 
 @objc protocol OP {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %TSo8ProtocolC* @protocol_conversion() {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %TSo8ProtocolC* @protocol_conversion() {{.*}} {
 // CHECK:         %0 = load i8*, i8** @"\01l_OBJC_PROTOCOL_REFERENCE_$__TtP24objc_protocol_conversion2OP_", align 8
 // CHECK:         %1 = bitcast i8* %0 to %TSo8ProtocolC*
 // CHECK:         ret %TSo8ProtocolC* %1
@@ -26,7 +26,7 @@ entry:
 
 // The Protocol class has been hidden in newer ObjC APIs, so when we need its
 // metadata, we treat it like a foreign class.
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.type* @protocol_metatype()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @protocol_metatype()
 sil @protocol_metatype : $@convention(thin) () -> @thick Protocol.Type {
 entry:
   // CHECK: call %objc_class* @objc_lookUpClass

--- a/test/IRGen/objc_selector.sil
+++ b/test/IRGen/objc_selector.sil
@@ -9,7 +9,7 @@ import Builtin
 // CHECK: @"\01L_selector_data(help:me:)" = private global [9 x i8] c"help:me:\00", section "__TEXT,__objc_methname,cstring_literals"
 // CHECK: @"\01L_selector(help:me:)" = private externally_initialized global i8* getelementptr inbounds ([9 x i8], [9 x i8]* @"\01L_selector_data(help:me:)", {{i(32|64)}} 0, {{i(32|64)}} 0), section "__DATA,__objc_selrefs,literal_pointers,no_dead_strip"
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i8* @objc_selector_literal() #0 {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @objc_selector_literal() #0 {
 sil @objc_selector_literal : $@convention(thin) () -> Builtin.RawPointer {
 bb0:
   // CHECK: [[SEL:%[0-9]+]] = load i8*, i8** @"\01L_selector(help:me:)"

--- a/test/IRGen/objc_simd.sil
+++ b/test/IRGen/objc_simd.sil
@@ -13,33 +13,33 @@ func forceStuff(x: float4, y: float3) -> (Float, Float, Float, Float) {
   }
 }
 
-// x86_64-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
-// i386-LABEL: define{{( protected)?}} <2 x i64> @simd_c_args(<4 x float>)
-// aarch64-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
-// arm64-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
-// armv6-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
-// armv7-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
-// armv7s-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
-// armv7k-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
-// powerpc64-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
-// powerpc64le-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
-// s390x-LABEL: define{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
+// x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
+// i386-LABEL: define{{( dllexport)?}}{{( protected)?}} <2 x i64> @simd_c_args(<4 x float>)
+// aarch64-LABEL: define{{( dllexport)?}}{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
+// arm64-LABEL: define{{( dllexport)?}}{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
+// armv6-LABEL: define{{( dllexport)?}}{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
+// armv7-LABEL: define{{( dllexport)?}}{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
+// armv7s-LABEL: define{{( dllexport)?}}{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
+// armv7k-LABEL: define{{( dllexport)?}}{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
+// powerpc64-LABEL: define{{( dllexport)?}}{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
+// powerpc64le-LABEL: define{{( dllexport)?}}{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
+// s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} <4 x float> @simd_c_args(<4 x float>)
 sil @simd_c_args : $@convention(c) (float4) -> float4 {
 entry(%x : $float4):
   return %x : $float4
 }
 
-// x86_64-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<3 x float>)
-// i386-LABEL: define{{( protected)?}} <2 x i64> @simd_c_args_float3(<3 x float>)
-// aarch64-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
-// arm64-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
-// armv6-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
-// armv7-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
-// armv7s-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
-// armv7k-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
-// powerpc64-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<3 x float>)
-// powerpc64le-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<3 x float>)
-// s390x-LABEL: define{{( protected)?}} <3 x float> @simd_c_args_float3(<3 x float>)
+// x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<3 x float>)
+// i386-LABEL: define{{( dllexport)?}}{{( protected)?}} <2 x i64> @simd_c_args_float3(<3 x float>)
+// aarch64-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
+// arm64-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
+// armv6-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
+// armv7-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
+// armv7s-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
+// armv7k-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<4 x i32>)
+// powerpc64-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<3 x float>)
+// powerpc64le-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<3 x float>)
+// s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} <3 x float> @simd_c_args_float3(<3 x float>)
 sil @simd_c_args_float3 : $@convention(c) (float3) -> float3 {
 entry(%x : $float3):
 // x86_64: [[COERCE:%.*]] = alloca <3 x float>, align 16
@@ -48,17 +48,17 @@ entry(%x : $float3):
   return %x : $float3
 }
 
-// x86_64-LABEL: define{{( protected)?}} swiftcc { i64, i64 } @simd_native_args(i64, i64)
-// i386-LABEL: define{{( protected)?}} swiftcc void @simd_native_args(%T4simd6float4V* noalias nocapture sret, %T4simd6float4V* noalias nocapture dereferenceable({{.*}}))
-// aarch64-LABEL: define{{( protected)?}} swiftcc { i64, i64 } @simd_native_args(i64, i64)
-// arm64-LABEL: define{{( protected)?}} swiftcc { i64, i64 } @simd_native_args(i64, i64)
-// armv6-LABEL: define{{( protected)?}} swiftcc void @simd_native_args(%T4simd6float4V* noalias nocapture sret, %T4simd6float4V* noalias nocapture dereferenceable({{.*}}))
-// armv7-LABEL: define{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float, float, float, float)
-// armv7s-LABEL: define{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float, float, float, float)
-// armv7k-LABEL: define{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float, float, float, float)
-// powerpc64-LABEL: define{{( protected)?}} void @simd_native_args(%T4simd6float4V* noalias nocapture sret, %T4simd6float4V* noalias nocapture dereferenceable({{.*}}))
-// powerpc64le-LABEL: define{{( protected)?}} void @simd_native_args(%T4simd6float4V* noalias nocapture sret, %T4simd6float4V* noalias nocapture dereferenceable({{.*}}))
-// s390x-LABEL: define{{( protected)?}} void @simd_native_args(%T4simd6float4V* noalias nocapture sret, %T4simd6float4V* noalias nocapture dereferenceable({{.*}}))
+// x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i64 } @simd_native_args(i64, i64)
+// i386-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @simd_native_args(%T4simd6float4V* noalias nocapture sret, %T4simd6float4V* noalias nocapture dereferenceable({{.*}}))
+// aarch64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i64 } @simd_native_args(i64, i64)
+// arm64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i64 } @simd_native_args(i64, i64)
+// armv6-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @simd_native_args(%T4simd6float4V* noalias nocapture sret, %T4simd6float4V* noalias nocapture dereferenceable({{.*}}))
+// armv7-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float, float, float, float)
+// armv7s-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float, float, float, float)
+// armv7k-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float, float } @simd_native_args(float, float, float, float)
+// powerpc64-LABEL: define{{( dllexport)?}}{{( protected)?}} void @simd_native_args(%T4simd6float4V* noalias nocapture sret, %T4simd6float4V* noalias nocapture dereferenceable({{.*}}))
+// powerpc64le-LABEL: define{{( dllexport)?}}{{( protected)?}} void @simd_native_args(%T4simd6float4V* noalias nocapture sret, %T4simd6float4V* noalias nocapture dereferenceable({{.*}}))
+// s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} void @simd_native_args(%T4simd6float4V* noalias nocapture sret, %T4simd6float4V* noalias nocapture dereferenceable({{.*}}))
 sil @simd_native_args : $@convention(thin) (float4) -> float4 {
 entry(%x : $float4):
   %f = function_ref @simd_c_args : $@convention(c) (float4) -> float4
@@ -66,17 +66,17 @@ entry(%x : $float4):
   return %y : $float4
 }
 
-// x86_64-LABEL: define{{( protected)?}} swiftcc { i64, float }  @simd_native_args_float3(i64, float)
-// i386-LABEL: define{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float, float, float)
-// aarch64-LABEL: define{{( protected)?}} swiftcc { i64, float } @simd_native_args_float3(i64, float)
-// arm64-LABEL: define{{( protected)?}} swiftcc { i64, float } @simd_native_args_float3(i64, float)
-// armv6-LABEL: define{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float, float, float)
-// armv7-LABEL: define{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float, float, float)
-// armv7s-LABEL: define{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float, float, float)
-// armv7k-LABEL: define{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float, float, float)
-// powerpc64-LABEL: define{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float, float, float)
-// powerpc64le-LABEL: define{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float, float, float)
-// s390x-LABEL: define{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float, float, float)
+// x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, float }  @simd_native_args_float3(i64, float)
+// i386-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float, float, float)
+// aarch64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, float } @simd_native_args_float3(i64, float)
+// arm64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, float } @simd_native_args_float3(i64, float)
+// armv6-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float, float, float)
+// armv7-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float, float, float)
+// armv7s-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float, float, float)
+// armv7k-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float, float, float)
+// powerpc64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float, float, float)
+// powerpc64le-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float, float, float)
+// s390x-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { float, float, float } @simd_native_args_float3(float, float, float)
 sil @simd_native_args_float3 : $@convention(thin) (float3) -> float3 {
 entry(%x : $float3):
   %f = function_ref @simd_c_args_float3 : $@convention(c) (float3) -> float3

--- a/test/IRGen/open_boxed_existential.sil
+++ b/test/IRGen/open_boxed_existential.sil
@@ -2,7 +2,7 @@
 
 import Swift
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc {{i[0-9]+}} @open_boxed_existential(%swift.error*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc {{i[0-9]+}} @open_boxed_existential(%swift.error*)
 sil @open_boxed_existential : $@convention(thin) (@owned Error) -> Int {
 entry(%b : $Error):
   // CHECK: call void @swift_getErrorValue(%swift.error* %0, i8** {{%.*}}, [[TRIPLE:{ %swift.opaque\*, %swift.type\*, i8\*\* }]]* [[OUT:%.*]])

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -11,7 +11,7 @@ sil @$S13partial_apply10SwiftClassCfD : $@convention(method) (SwiftClass) -> ()
 
 sil @partially_applyable_to_class : $@convention(thin) (@owned SwiftClass) -> ()
 
-// CHECK: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_class(%T13partial_apply10SwiftClassC*) {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_class(%T13partial_apply10SwiftClassC*) {{.*}} {
 // CHECK: entry:
 // CHECK:   %1 = bitcast %T13partial_apply10SwiftClassC* %0 to %swift.refcounted*
 // CHECK:   %2 = insertvalue { i8*, %swift.refcounted* } { i8* bitcast (void (%swift.refcounted*)* @"$S28partially_applyable_to_classTA" to i8*), %swift.refcounted* undef }, %swift.refcounted* %1, 1
@@ -66,7 +66,7 @@ entry(%a : $*T):
 
 sil public_external @guaranteed_captured_class_param : $@convention(thin) (Int, @guaranteed SwiftClass) -> Int
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_guaranteed_class_param(%T13partial_apply10SwiftClassC*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_guaranteed_class_param(%T13partial_apply10SwiftClassC*)
 // CHECK:         [[CONTEXT_OBJ:%.*]] = bitcast %T13partial_apply10SwiftClassC* {{%.*}} to %swift.refcounted*
 // CHECK:         [[T0:%.*]] = insertvalue {{.*}} [[PARTIAL_APPLY_FORWARDER:@"\$S[A-Za-z0-9_]+TA"]] {{.*}} [[CONTEXT_OBJ]]
 // CHECK:         ret {{.*}} [[T0]]
@@ -87,7 +87,7 @@ bb0(%x : $SwiftClass):
 
 sil public_external @indirect_guaranteed_captured_class_param : $@convention(thin) (Int, @in_guaranteed SwiftClass) -> Int
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_indirect_guaranteed_class_param(%T13partial_apply10SwiftClassC** noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_indirect_guaranteed_class_param(%T13partial_apply10SwiftClassC** noalias nocapture dereferenceable({{.*}}))
 // CHECK-NOT:     {{retain|release}}
 // CHECK:         [[X:%.*]] = load %T13partial_apply10SwiftClassC*, %T13partial_apply10SwiftClassC** %0
 // CHECK-NEXT:    [[CONTEXT_OBJ:%.*]] = bitcast %T13partial_apply10SwiftClassC* [[X]] to %swift.refcounted*
@@ -116,7 +116,7 @@ bb0(%x : $*SwiftClass):
 
 sil public_external @indirect_consumed_captured_class_param : $@convention(thin) (Int, @in SwiftClass) -> Int
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_indirect_consumed_class_param(%T13partial_apply10SwiftClassC** noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_indirect_consumed_class_param(%T13partial_apply10SwiftClassC** noalias nocapture dereferenceable({{.*}}))
 // CHECK-NOT:     {{retain|release}}
 // CHECK:         [[X:%.*]] = load %T13partial_apply10SwiftClassC*, %T13partial_apply10SwiftClassC** %0
 // CHECK-NEXT:    [[CONTEXT_OBJ:%.*]] = bitcast %T13partial_apply10SwiftClassC* [[X]] to %swift.refcounted*
@@ -152,7 +152,7 @@ struct SwiftClassPair { var x: SwiftClass, y: SwiftClass }
 
 sil public_external @guaranteed_captured_class_pair_param : $@convention(thin) (Int, @guaranteed SwiftClassPair) -> Int
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_guaranteed_class_pair_param(%T13partial_apply10SwiftClassC*, %T13partial_apply10SwiftClassC*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_guaranteed_class_pair_param(%T13partial_apply10SwiftClassC*, %T13partial_apply10SwiftClassC*)
 // CHECK:         [[CONTEXT_OBJ:%.*]] = call noalias %swift.refcounted* @swift_allocObject
 // CHECK:         [[PAIR_ADDR:%.*]] = getelementptr
 // CHECK-NEXT:    [[X_ADDR:%.*]] = getelementptr inbounds %T13partial_apply14SwiftClassPairV, %T13partial_apply14SwiftClassPairV* [[PAIR_ADDR]], i32 0, i32 0
@@ -183,7 +183,7 @@ bb0(%x : $SwiftClassPair):
 
 sil public_external @indirect_guaranteed_captured_class_pair_param : $@convention(thin) (Int, @in_guaranteed SwiftClassPair) -> Int
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_indirect_guaranteed_class_pair_param(%T13partial_apply14SwiftClassPairV* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_indirect_guaranteed_class_pair_param(%T13partial_apply14SwiftClassPairV* noalias nocapture dereferenceable({{.*}}))
 // CHECK:         [[CONTEXT_OBJ:%.*]] = call noalias %swift.refcounted* @swift_allocObject
 // CHECK-NOT:     {{retain|release}}
 // CHECK:         [[T0:%.*]] = insertvalue {{.*}} [[PARTIAL_APPLY_FORWARDER:@"\$S[A-Za-z0-9_]+TA"]] {{.*}} [[CONTEXT_OBJ]]
@@ -206,7 +206,7 @@ bb0(%x : $*SwiftClassPair):
 
 sil public_external @indirect_consumed_captured_class_pair_param : $@convention(thin) (Int, @in SwiftClassPair) -> Int
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_indirect_consumed_class_pair_param(%T13partial_apply14SwiftClassPairV* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_indirect_consumed_class_pair_param(%T13partial_apply14SwiftClassPairV* noalias nocapture dereferenceable({{.*}}))
 // CHECK:         [[CONTEXT_OBJ:%.*]] = call noalias %swift.refcounted* @swift_allocObject
 // CHECK-NOT:     {{retain|release}}
 // CHECK:         [[T0:%.*]] = insertvalue {{.*}} [[PARTIAL_APPLY_FORWARDER:@"\$S[A-Za-z0-9_]+TA"]] {{.*}} [[CONTEXT_OBJ]]
@@ -228,7 +228,7 @@ bb0(%x : $*SwiftClassPair):
 
 sil public_external @captured_fixed_and_dependent_params : $@convention(thin) <A> (@owned SwiftClass, @in A, Int) -> ()
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_indirect_non_fixed_layout(%T13partial_apply10SwiftClassC*, %swift.opaque* noalias nocapture, i64, %swift.type* %T)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_indirect_non_fixed_layout(%T13partial_apply10SwiftClassC*, %swift.opaque* noalias nocapture, i64, %swift.type* %T)
 // -- Round the base offset for the T field up to T's alignment.
 // CHECK:         [[T_METADATA_BASE:%.*]] = bitcast %swift.type* %T to i8***
 // CHECK:         [[T_VWTABLE_ADDR:%.*]] = getelementptr {{.*}} [[T_METADATA_BASE]], [[WORD:i[0-9]+]] -1
@@ -307,7 +307,7 @@ bb0(%x : $Int32, %f : $@callee_owned (Int32) -> @out T):
   return %p : $@callee_owned () -> @out T
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_dynamic_with_out_param
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_dynamic_with_out_param
 // CHECK:         insertvalue {{.*}} [[FORWARDER:@"\$STA[A-Za-z0-9_]*"]]
 // CHECK:       define internal swiftcc void [[FORWARDER]]
 // CHECK:         call swiftcc void {{%.*}}(%swift.opaque* noalias nocapture sret
@@ -329,7 +329,7 @@ bb0(%0 : $Base):
 
 sil public_external @receive_closure : $@convention(thin) <C where C : Base> (@owned @callee_owned () -> (@owned C)) -> ()
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @test_partial_apply(%T13partial_apply4BaseC*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_partial_apply(%T13partial_apply4BaseC*)
 // CHECK:  [[CTX:%.*]] = bitcast %T13partial_apply4BaseC* %0 to %swift.refcounted*
 // CHECK:  [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S13partial_apply3SubCMa"(i64 0)
 // CHECK:  [[TYPE:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
@@ -362,7 +362,7 @@ bb0(%0 : $Base):
 
 sil public_external @partial_empty_box : $@convention(thin) (@owned <τ_0_0> { var τ_0_0 } <()>, @inout ()) -> ()
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @empty_box()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @empty_box()
 sil @empty_box : $@convention(thin) () -> () {
 entry:
   // CHECK: [[BOX:%.*]] = call {{.*}}swift_allocEmptyBox
@@ -388,7 +388,7 @@ bb0(%0 : $Int):
   %result = tuple ()
   return %result : $()
 }
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @partial_apply_complex_generic_function(i64, %swift.type* %T, i8** %T.P2, i8** %T.Y.P2)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @partial_apply_complex_generic_function(i64, %swift.type* %T, i8** %T.P2, i8** %T.Y.P2)
 // CHECK:      [[T0:%.*]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* {{.*}}, i64 48, i64 7)
 // CHECK-NEXT: [[T1:%.*]] = bitcast %swift.refcounted* [[T0]] to <{ %swift.refcounted, [24 x i8], %TSi }>*
 // CHECK-NEXT: [[T2:%.*]] = getelementptr inbounds <{ %swift.refcounted, [24 x i8], %TSi }>, <{ %swift.refcounted, [24 x i8], %TSi }>* [[T1]], i32 0, i32 1

--- a/test/IRGen/partial_apply_forwarder.sil
+++ b/test/IRGen/partial_apply_forwarder.sil
@@ -78,7 +78,7 @@ sil hidden_external @takingQ : $@convention(thin) <τ_0_0 where  τ_0_0 : Q> (@o
 sil hidden_external @takingQAndEmpty : $@convention(thin) <τ_0_0 where  τ_0_0 : Q> (@owned WeakBox<τ_0_0>, EmptyType) -> ()
 sil hidden_external @takingEmptyAndQ : $@convention(thin) <τ_0_0 where  τ_0_0 : Q> (EmptyType, @owned WeakBox<τ_0_0>) -> ()
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @bind_polymorphic_param_from_context(%swift.opaque* noalias nocapture, %swift.type* %"\CF\84_0_1")
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @bind_polymorphic_param_from_context(%swift.opaque* noalias nocapture, %swift.type* %"\CF\84_0_1")
 // CHECK: entry:
 // CHECK:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S23partial_apply_forwarder12BaseProducerVMa"([[INT]] 255, %swift.type* %"\CF\84_0_1")
 // CHECK:   [[BPTYPE:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
@@ -111,7 +111,7 @@ bb0(%0 : $*τ_0_1):
   return %9 : $@callee_owned () -> ()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @bind_polymorphic_param_from_context_2(%swift.opaque* noalias nocapture, %swift.type* %"\CF\84_0_1")
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @bind_polymorphic_param_from_context_2(%swift.opaque* noalias nocapture, %swift.type* %"\CF\84_0_1")
 // CHECK:   [[OBJ:%.*]] = call {{.*}} @swift_allocObject
 // CHECK:   [[WB:%.*]] = bitcast %swift.refcounted* [[OBJ]]
 // CHECK:   [[REF:%.*]] = bitcast {{.*}}* [[WB]] to %swift.refcounted*
@@ -125,7 +125,7 @@ bb0(%0 : $*τ_0_1, %2: $EmptyType):
   return %9 : $@callee_owned () -> ()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @bind_polymorphic_param_from_context_3(%swift.opaque* noalias nocapture, %swift.type* %"\CF\84_0_1")
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @bind_polymorphic_param_from_context_3(%swift.opaque* noalias nocapture, %swift.type* %"\CF\84_0_1")
 // CHECK:   [[OBJ:%.*]] = call {{.*}} @swift_allocObject
 // CHECK:   [[WB:%.*]] = bitcast %swift.refcounted* [[OBJ]]
 // CHECK:   [[REF:%.*]] = bitcast {{.*}}* [[WB]] to %swift.refcounted*
@@ -140,7 +140,7 @@ bb0(%0 : $*τ_0_1, %2: $EmptyType):
   return %9 : $@callee_owned () -> ()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @bind_polymorphic_param_from_forwarder_parameter(%swift.opaque* noalias nocapture, %swift.type* %"\CF\84_0_1")
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @bind_polymorphic_param_from_forwarder_parameter(%swift.opaque* noalias nocapture, %swift.type* %"\CF\84_0_1")
 // CHECK: entry:
 // CHECK:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S23partial_apply_forwarder12BaseProducerVMa"([[INT]] 255, %swift.type* %"\CF\84_0_1")
 // CHECK:   [[BPTY:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
@@ -176,7 +176,7 @@ struct S {
 
 sil hidden_external @takingQAndS : $@convention(thin) <τ_0_0 where  τ_0_0 : Q> (S, @owned WeakBox<τ_0_0>) -> ()
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @bind_polymorphic_param_from_context_with_layout(%swift.opaque* noalias nocapture, i64, %swift.type* %"\CF\84_0_1")
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @bind_polymorphic_param_from_context_with_layout(%swift.opaque* noalias nocapture, i64, %swift.type* %"\CF\84_0_1")
 // CHECK: entry:
 // CHECK:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S23partial_apply_forwarder12BaseProducerVMa"([[INT]] 255, %swift.type* %"\CF\84_0_1")
 // CHECK:   [[BPTY:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0

--- a/test/IRGen/partial_apply_objc.sil
+++ b/test/IRGen/partial_apply_objc.sil
@@ -48,7 +48,7 @@ bb0(%0 : $ObjCClass):
   return %0 : $ObjCClass
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @indirect_partial_apply(i8*, %swift.refcounted*, i64) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @indirect_partial_apply(i8*, %swift.refcounted*, i64) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[T0:%.*]] = bitcast i8* %0 to void (i64, %swift.refcounted*)*
 // CHECK:   [[OBJ:%.*]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* getelementptr inbounds (%swift.full_boxmetadata, %swift.full_boxmetadata* @metadata, i32 0, i32 2), i64 40, i64 7)
@@ -83,7 +83,7 @@ entry(%f : $@callee_owned (Builtin.Word) -> (), %x : $Builtin.Word):
   return %p : $@callee_owned () -> ()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @objc_partial_apply(%T18partial_apply_objc9ObjCClassC*) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @objc_partial_apply(%T18partial_apply_objc9ObjCClassC*) {{.*}} {
 // CHECK: entry:
 // CHECK:   [[OBJ:%.*]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* getelementptr inbounds (%swift.full_boxmetadata, %swift.full_boxmetadata* @metadata.2, i32 0, i32 2), i64 24, i64 7)
 // CHECK:   [[DATA_ADDR:%.*]] = bitcast %swift.refcounted* [[OBJ]] to [[DATA_TYPE:<{ %swift.refcounted, %T18partial_apply_objc9ObjCClassC\* }>]]*
@@ -136,7 +136,7 @@ entry(%c : $ObjCClass):
   return %p : $@callee_owned NSRect -> ()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @objc_partial_apply_consumes_self(%T18partial_apply_objc9ObjCClassC*) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @objc_partial_apply_consumes_self(%T18partial_apply_objc9ObjCClassC*) {{.*}} {
 // CHECK:         bitcast %swift.refcounted* {{%.*}} to [[DATA_TYPE:<{ %swift.refcounted, %T18partial_apply_objc9ObjCClassC\* }>]]*
 // CHECK:         insertvalue {{.*}} [[OBJC_CONSUMES_SELF_PARTIAL_APPLY_STUB:@"\$STa[A-Za-z0-9_.]*"]]
 // CHECK: define internal swiftcc %T18partial_apply_objc9ObjCClassC* [[OBJC_CONSUMES_SELF_PARTIAL_APPLY_STUB]](%swift.refcounted* swiftself) {{.*}} {
@@ -166,7 +166,7 @@ entry(%x : $Int):
   return %v : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @dynamic_lookup_br_partial_apply(%objc_object*) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @dynamic_lookup_br_partial_apply(%objc_object*) {{.*}} {
 // CHECK:   phi i8* [ bitcast (void (i64)* @dummy to i8*), {{%.*}} ], [ bitcast (void (i64, %swift.refcounted*)* [[DYNAMIC_LOOKUP_BR_PARTIAL_APPLY_STUB:@"\$STa[A-Za-z0-9_.]*"]] to i8*), {{%.*}} ]
 // CHECK: define internal swiftcc void [[DYNAMIC_LOOKUP_BR_PARTIAL_APPLY_STUB]](i64, %swift.refcounted* swiftself) {{.*}} {
 // CHECK:   load i8*, i8** @"\01L_selector(methodWithX:)", align 8
@@ -190,7 +190,7 @@ done(%f : $@callee_owned Int -> ()):
 
 sil @partially_applyable_to_pure_objc : $@convention(thin) Gizmo -> ()
 
-// CHECK: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_pure_objc
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_pure_objc
 // CHECK:   @swift_allocObject
 sil @partial_apply_pure_objc : $@convention(thin) Gizmo -> @callee_owned () -> () {
 entry(%c : $Gizmo):

--- a/test/IRGen/playground.swift
+++ b/test/IRGen/playground.swift
@@ -13,7 +13,7 @@ public func anchor() {}
 
 anchor()
 
-// CHECK-LABEL: define{{( protected)?}} i32 @main
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} i32 @main
 // CHECK:         call void @runtime_registration
 // CHECK:         call swiftcc void @"$S10playground6anchoryyF"
 // CHECK:         ret void

--- a/test/IRGen/property_descriptor.sil
+++ b/test/IRGen/property_descriptor.sil
@@ -36,20 +36,20 @@ public struct ExternalReabstractions<T> {
 }
 
 // -- 0xff_fffe - struct property, offset resolved from field offset vector in metadata
-// CHECK-64: @"$S19property_descriptor15ExternalGenericV2roxvpMV" ={{( protected)?}}{{( protected)?}} constant
+// CHECK-64: @"$S19property_descriptor15ExternalGenericV2roxvpMV" ={{( dllexport)?}}{{( protected)?}} constant
 // CHECK-64-SAME: <{ <i32 0x00ff_fffe>, i32 32 }>, align 8
-// CHECK-32: @"$S19property_descriptor15ExternalGenericV2roxvpMV" ={{( protected)?}}{{( protected)?}} constant
+// CHECK-32: @"$S19property_descriptor15ExternalGenericV2roxvpMV" ={{( dllexport)?}}{{( protected)?}} constant
 // CHECK-32-SAME: <{ <i32 0x00ff_fffe>, i32 16 }>, align 4
 sil_property #ExternalGeneric.ro <T: Comparable> (
   stored_property #ExternalGeneric.ro : $T)
-// CHECK-64: @"$S19property_descriptor15ExternalGenericV2rwxvpMV" ={{( protected)?}}{{( protected)?}} constant
+// CHECK-64: @"$S19property_descriptor15ExternalGenericV2rwxvpMV" ={{( dllexport)?}}{{( protected)?}} constant
 // CHECK-64-SAME: <{ <i32 0x00ff_fffe>, i32 36 }>, align 8
-// CHECK-32: @"$S19property_descriptor15ExternalGenericV2rwxvpMV" ={{( protected)?}} constant
+// CHECK-32: @"$S19property_descriptor15ExternalGenericV2rwxvpMV" ={{( dllexport)?}}{{( protected)?}} constant
 // CHECK-32-SAME: <{ <i32 0x00ff_fffe>, i32 20 }>, align 4
 sil_property #ExternalGeneric.rw <T: Comparable> (
   stored_property #ExternalGeneric.rw : $T)
 
-// CHECK: @"$S19property_descriptor15ExternalGenericV10computedROxvpMV" ={{( protected)?}} constant
+// CHECK: @"$S19property_descriptor15ExternalGenericV10computedROxvpMV" ={{( dllexport)?}}{{( protected)?}} constant
 // -- 0x0108_0000 - computed, readonly, has arguments
 // CHECK-SAME:  <{ <i32 0x0108_0000>,
 // CHECK-SAME:     @id_computed, 
@@ -62,7 +62,7 @@ sil_property #ExternalGeneric.computedRO <T: Comparable> (
     id @id_computed : $@convention(thin) () -> (),
     getter @get_computed_generic : $@convention(thin) <T: Comparable> (@in_guaranteed ExternalGeneric<T>) -> @out T)
 
-// CHECK: @"$S19property_descriptor15ExternalGenericV10computedRWxvpMV" ={{( protected)?}} constant
+// CHECK: @"$S19property_descriptor15ExternalGenericV10computedRWxvpMV" ={{( dllexport)?}}{{( protected)?}} constant
 // -- 0x01c8_0000 - computed, settable, mutating, has arguments
 // CHECK-SAME:  <{ <i32 0x01c8_0000>, 
 // CHECK-SAME:     @id_computed,
@@ -77,7 +77,7 @@ sil_property #ExternalGeneric.computedRW <T: Comparable> (
     getter @get_computed_generic : $@convention(thin) <T: Comparable> (@in_guaranteed ExternalGeneric<T>) -> @out T,
     setter @set_computed_generic : $@convention(thin) <T: Comparable> (@in_guaranteed T, @inout ExternalGeneric<T>) -> ())
 
-// CHECK: @"$S19property_descriptor15ExternalGenericVyxqd__cs8HashableRd__luipMV" ={{( protected)?}} constant
+// CHECK: @"$S19property_descriptor15ExternalGenericVyxqd__cs8HashableRd__luipMV" ={{( dllexport)?}}{{( protected)?}} constant
 // -- 0x01c8_0000 - computed, settable, mutating, has arguments
 // CHECK-SAME:  <{ <i32 0x01c8_0000>, 
 // CHECK-SAME:     @id_computed,
@@ -92,9 +92,9 @@ sil_property #ExternalGeneric.subscript <T: Comparable><U: Hashable> (
     getter @get_computed_generic_subscript : $@convention(thin) <T: Comparable><U: Hashable> (@in_guaranteed ExternalGeneric<T>, UnsafeRawPointer) -> @out T,
     setter @set_computed_generic_subscript : $@convention(thin) <T: Comparable><U: Hashable> (@in_guaranteed T, @inout ExternalGeneric<T>, UnsafeRawPointer) -> ())
 
-// CHECK: @"$S19property_descriptor8ExternalV2roSivpMV" ={{( protected)?}} constant <{ i32 }> zeroinitializer, align 4
-// CHECK-64: @"$S19property_descriptor8ExternalV2rwSivpMV" ={{( protected)?}} constant <{ i32 }> <{ i32 8 }>, align 4
-// CHECK-32: @"$S19property_descriptor8ExternalV2rwSivpMV" ={{( protected)?}} constant <{ i32 }> <{ i32 4 }>, align 4
+// CHECK: @"$S19property_descriptor8ExternalV2roSivpMV" ={{( dllexport)?}}{{( protected)?}} constant <{ i32 }> zeroinitializer, align 4
+// CHECK-64: @"$S19property_descriptor8ExternalV2rwSivpMV" ={{( dllexport)?}}{{( protected)?}} constant <{ i32 }> <{ i32 8 }>, align 4
+// CHECK-32: @"$S19property_descriptor8ExternalV2rwSivpMV" ={{( dllexport)?}}{{( protected)?}} constant <{ i32 }> <{ i32 4 }>, align 4
 sil_property #External.ro (stored_property #External.ro : $Int)
 sil_property #External.rw (stored_property #External.rw : $Int)
 sil_property #External.computedRO (

--- a/test/IRGen/protocol_conformance_records.swift
+++ b/test/IRGen/protocol_conformance_records.swift
@@ -9,7 +9,7 @@ public protocol Associate {
 }
 
 // Dependent conformance
-// CHECK-LABEL: @"$S28protocol_conformance_records9DependentVyxGAA9AssociateAAMc" ={{ protected | }}constant
+// CHECK-LABEL: @"$S28protocol_conformance_records9DependentVyxGAA9AssociateAAMc" ={{ dllexport | protected | }}constant
 // -- protocol descriptor
 // CHECK-SAME:           @"$S28protocol_conformance_records9AssociateMp"
 // -- nominal type descriptor
@@ -29,7 +29,7 @@ public protocol Runcible {
   func runce()
 }
 
-// CHECK-LABEL: @"$S28protocol_conformance_records15NativeValueTypeVAA8RuncibleAAMc" ={{ protected | }}constant %swift.protocol_conformance_descriptor {
+// CHECK-LABEL: @"$S28protocol_conformance_records15NativeValueTypeVAA8RuncibleAAMc" ={{ dllexport | protected | }}constant %swift.protocol_conformance_descriptor {
 // -- protocol descriptor
 // CHECK-SAME:           [[RUNCIBLE:@"\$S28protocol_conformance_records8RuncibleMp"]]
 // -- type metadata
@@ -43,7 +43,7 @@ public struct NativeValueType: Runcible {
   public func runce() {}
 }
 
-// CHECK-LABEL:         @"$S28protocol_conformance_records15NativeClassTypeCAA8RuncibleAAMc" ={{ protected | }}constant %swift.protocol_conformance_descriptor {
+// CHECK-LABEL:         @"$S28protocol_conformance_records15NativeClassTypeCAA8RuncibleAAMc" ={{ dllexport | protected | }}constant %swift.protocol_conformance_descriptor {
 // -- protocol descriptor
 // CHECK-SAME:           [[RUNCIBLE]]
 // -- class metadata
@@ -57,7 +57,7 @@ public class NativeClassType: Runcible {
   public func runce() {}
 }
 
-// CHECK-LABEL:         @"$S28protocol_conformance_records17NativeGenericTypeVyxGAA8RuncibleAAMc" ={{ protected | }}constant %swift.protocol_conformance_descriptor {
+// CHECK-LABEL:         @"$S28protocol_conformance_records17NativeGenericTypeVyxGAA8RuncibleAAMc" ={{ dllexport | protected | }}constant %swift.protocol_conformance_descriptor {
 // -- protocol descriptor
 // CHECK-SAME:           [[RUNCIBLE]]
 // -- nominal type descriptor
@@ -71,7 +71,7 @@ public struct NativeGenericType<T>: Runcible {
   public func runce() {}
 }
 
-// CHECK-LABEL:         @"$SSi28protocol_conformance_records8RuncibleAAMc" ={{ protected | }}constant %swift.protocol_conformance_descriptor {
+// CHECK-LABEL:         @"$SSi28protocol_conformance_records8RuncibleAAMc" ={{ dllexport | protected | }}constant %swift.protocol_conformance_descriptor {
 // -- protocol descriptor
 // CHECK-SAME:           [[RUNCIBLE]]
 // -- type metadata
@@ -87,7 +87,7 @@ extension Int: Runcible {
 
 // For a resilient struct, reference the NominalTypeDescriptor
 
-// CHECK-LABEL:         @"$S16resilient_struct4SizeV28protocol_conformance_records8RuncibleADMc" ={{ protected | }}constant %swift.protocol_conformance_descriptor {
+// CHECK-LABEL:         @"$S16resilient_struct4SizeV28protocol_conformance_records8RuncibleADMc" ={{ dllexport | protected | }}constant %swift.protocol_conformance_descriptor {
 // -- protocol descriptor
 // CHECK-SAME:           [[RUNCIBLE]]
 // -- nominal type descriptor
@@ -109,7 +109,7 @@ extension Size: Runcible {
 public protocol Spoon { }
 
 // Conditional conformances
-// CHECK-LABEL: {{^}}@"$S28protocol_conformance_records17NativeGenericTypeVyxGAA5SpoonA2aERzlMc" ={{ protected | }}constant
+// CHECK-LABEL: {{^}}@"$S28protocol_conformance_records17NativeGenericTypeVyxGAA5SpoonA2aERzlMc" ={{ dllexport | protected | }}constant
 // -- protocol descriptor
 // CHECK-SAME:           @"$S28protocol_conformance_records5SpoonMp"
 // -- nominal type descriptor
@@ -128,7 +128,7 @@ extension NativeGenericType : Spoon where T: Spoon {
 }
 
 // Retroactive conformance
-// CHECK-LABEL: @"$SSi18resilient_protocol22OtherResilientProtocol0B20_conformance_recordsMc" ={{ protected | }}constant
+// CHECK-LABEL: @"$SSi18resilient_protocol22OtherResilientProtocol0B20_conformance_recordsMc" ={{ dllexport | protected | }}constant
 // -- protocol descriptor
 // CHECK-SAME:           @"got.$S18resilient_protocol22OtherResilientProtocolMp"
 // -- nominal type descriptor

--- a/test/IRGen/protocol_extensions.sil
+++ b/test/IRGen/protocol_extensions.sil
@@ -24,7 +24,7 @@ bb0(%0 : $*Self):
   return %5 : $()                                 // id: %6
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @_TFP19protocol_extensions2P16extP1bUS0___fQPS0_FT_T_
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @_TFP19protocol_extensions2P16extP1bUS0___fQPS0_FT_T_
 sil @_TFP19protocol_extensions2P16extP1bUS0___fQPS0_FT_T_ : $@convention(method) <Self where Self : P1> (@in Self) -> () {
 bb0(%0 : $*Self):
   debug_value_addr %0 : $*Self, let, name "self" // id: %1

--- a/test/IRGen/protocol_resilience.sil
+++ b/test/IRGen/protocol_resilience.sil
@@ -78,7 +78,7 @@ import resilient_protocol
 
 // Protocol descriptor for ResilientProtocol
 
-// CHECK: @"$S19protocol_resilience17ResilientProtocolMp" = {{(protected )?}}constant %swift.protocol {
+// CHECK: @"$S19protocol_resilience17ResilientProtocolMp" = {{(dllexport )?}}{{(protected )?}}constant %swift.protocol {
 // CHECK-SAME:   i32 1031,
 // CHECK-SAME:   i32 8,
 // CHECK-SAME:   i32{{ | trunc \(i64 }}sub ([[INT]] ptrtoint ([8 x %swift.protocol_requirement]* [[RP_REQTS]] to [[INT]]), [[INT]] ptrtoint (i32* getelementptr inbounds (%swift.protocol, %swift.protocol* @"$S19protocol_resilience17ResilientProtocolMp", i32 0
@@ -167,7 +167,7 @@ protocol InternalProtocol {
 // CHECK-SAME:   i8* bitcast (i8** ()* @"$S19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWa" to i8*)
 // CHECK-SAME: ]
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @defaultC(%swift.opaque* noalias nocapture swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @defaultC(%swift.opaque* noalias nocapture swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 
 sil @defaultC : $@convention(witness_method: ResilientProtocol) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> () {
@@ -178,7 +178,7 @@ bb0(%0 : $*Self):
 }
 
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @defaultD(%swift.opaque* noalias nocapture swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @defaultD(%swift.opaque* noalias nocapture swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 
 sil @defaultD : $@convention(witness_method: ResilientProtocol) <Self where Self : ResilientProtocol> (@in_guaranteed Self) -> () {
@@ -218,7 +218,7 @@ bb0(%0 : $*Self):
 }
 
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @defaultE(%swift.type* swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @defaultE(%swift.type* swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 
 sil @defaultE : $@convention(witness_method: ResilientProtocol) <Self where Self : ResilientProtocol> (@thick Self.Type) -> () {
@@ -258,7 +258,7 @@ bb0(%0 : $@thick Self.Type):
 }
 
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @defaultF(%swift.type* swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @defaultF(%swift.type* swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 
 sil @defaultF : $@convention(witness_method: ResilientProtocol) <Self where Self : ResilientProtocol> (@thick Self.Type) -> () {
@@ -296,7 +296,7 @@ struct ConformingStruct : ResilientProtocol {
   static func defaultF()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @noDefaultA(%T19protocol_resilience16ConformingStructV* noalias nocapture swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @noDefaultA(%T19protocol_resilience16ConformingStructV* noalias nocapture swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 
 sil @noDefaultA : $@convention(witness_method: ResilientProtocol) (@in_guaranteed ConformingStruct) -> () {
@@ -316,7 +316,7 @@ bb0(%0 : $*ConformingStruct):
 }
 
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @noDefaultB(%T19protocol_resilience16ConformingStructV* noalias nocapture swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @noDefaultB(%T19protocol_resilience16ConformingStructV* noalias nocapture swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
 // CHECK-NEXT:  entry:
 
 sil @noDefaultB : $@convention(witness_method: ResilientProtocol) (@in_guaranteed ConformingStruct) -> () {
@@ -354,14 +354,14 @@ sil_witness_table ConformingStruct : ResilientProtocol module protocol_resilienc
 // Make sure resilient conformances are accessed with an accessor function
 //
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @doSomething(%swift.opaque* noalias nocapture, %swift.type* %T, i8** %T.OtherResilientProtocol)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @doSomething(%swift.opaque* noalias nocapture, %swift.type* %T, i8** %T.OtherResilientProtocol)
 sil @doSomething : $@convention(thin) <T : OtherResilientProtocol> (@in T) -> () {
 bb0(%0 : $*T):
   %result = tuple ()
   return %result : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @passConformingType(%T19protocol_resilience23ResilientConformingTypeV* noalias nocapture)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @passConformingType(%T19protocol_resilience23ResilientConformingTypeV* noalias nocapture)
 sil @passConformingType : $@convention(thin) (@in ResilientConformingType) -> () {
 bb0(%0 : $*ResilientConformingType):
 
@@ -380,7 +380,7 @@ bb0(%0 : $*ResilientConformingType):
 
 // Caching witness table accessor
 
-// CHECK-LABEL: define{{( protected)?}} linkonce_odr hidden i8** @"$S19protocol_resilience23ResilientConformingTypeVAC010resilient_A005OtherC8ProtocolAAWl"()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} linkonce_odr hidden i8** @"$S19protocol_resilience23ResilientConformingTypeVAC010resilient_A005OtherC8ProtocolAAWl"()
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[CACHE:%.*]] = load i8**, i8*** @"$S19protocol_resilience23ResilientConformingTypeVAC010resilient_A005OtherC8ProtocolAAWL"
 // CHECK-NEXT:    [[COND:%.*]] = icmp eq i8** [[CACHE]], null
@@ -397,7 +397,7 @@ bb0(%0 : $*ResilientConformingType):
 
 // Resilient conformance -- must call a runtime function
 
-// CHECK-LABEL: define{{( protected)?}} i8** @"$S19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWa"()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} i8** @"$S19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWa"()
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[WTABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S19protocol_resilience23ResilientConformingTypeV010resilient_A005OtherC8ProtocolAAWG", %swift.type* null, i8*** null)
 // CHECK-NEXT:    ret i8** [[WTABLE]]
@@ -419,14 +419,14 @@ sil_witness_table AnotherConformingStruct : RefinesOtherResilientProtocol module
 sil_witness_table hidden AnotherConformingStruct: OtherResilientProtocol module protocol_resilience {
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @doSomethingRefined(%swift.opaque* noalias nocapture, %swift.type* %T, i8** %T.RefinesOtherResilientProtocol)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @doSomethingRefined(%swift.opaque* noalias nocapture, %swift.type* %T, i8** %T.RefinesOtherResilientProtocol)
 sil @doSomethingRefined : $@convention(thin) <T : RefinesOtherResilientProtocol> (@in T) -> () {
 bb0(%0 : $*T):
   %result = tuple ()
   return %result : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @passConformingTypeRefined(%T19protocol_resilience23AnotherConformingStructV* noalias nocapture)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @passConformingTypeRefined(%T19protocol_resilience23AnotherConformingStructV* noalias nocapture)
 sil @passConformingTypeRefined : $@convention(thin) (@in AnotherConformingStruct) -> () {
 bb0(%0 : $*AnotherConformingStruct):
 
@@ -463,14 +463,14 @@ sil_witness_table ConformsWithResilientAssoc : HasResilientAssoc module protocol
   associated_type_protocol (T: OtherResilientProtocol): ResilientConformingType: OtherResilientProtocol module protocol_resilience
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @doSomethingAssoc(%swift.opaque* noalias nocapture, %swift.type* %T, i8** %T.HasResilientAssoc)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @doSomethingAssoc(%swift.opaque* noalias nocapture, %swift.type* %T, i8** %T.HasResilientAssoc)
 sil @doSomethingAssoc : $@convention(thin) <T : HasResilientAssoc> (@in T) -> () {
 bb0(%0 : $*T):
   %result = tuple ()
   return %result : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @passConformingTypeAssoc(%T19protocol_resilience26ConformsWithResilientAssocV* noalias nocapture)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @passConformingTypeAssoc(%T19protocol_resilience26ConformsWithResilientAssocV* noalias nocapture)
 sil @passConformingTypeAssoc : $@convention(thin) (@in ConformsWithResilientAssoc) -> () {
 bb0(%0 : $*ConformsWithResilientAssoc):
 
@@ -515,6 +515,6 @@ sil_witness_table ConformsWithRequirements : ProtocolWithRequirements module pro
 
 // Fragile conformance -- no runtime calls needed
 
-// CHECK-LABEL: define{{( protected)?}} hidden i8** @"$S19protocol_resilience16ConformingStructVAA17ResilientProtocolAAWa"()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} hidden i8** @"$S19protocol_resilience16ConformingStructVAA17ResilientProtocolAAWa"()
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    ret i8** getelementptr inbounds ([9 x i8*], [9 x i8*]* @"$S19protocol_resilience16ConformingStructVAA17ResilientProtocolAAWP", i32 0, i32 0)

--- a/test/IRGen/protocol_resilience_thunks.swift
+++ b/test/IRGen/protocol_resilience_thunks.swift
@@ -7,7 +7,7 @@
 
 import resilient_protocol
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S26protocol_resilience_thunks26callResilientWitnessMethodyyx010resilient_A00E12BaseProtocolRzlF"(%swift.opaque* noalias nocapture, %swift.type* %T, i8** %T.ResilientBaseProtocol)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S26protocol_resilience_thunks26callResilientWitnessMethodyyx010resilient_A00E12BaseProtocolRzlF"(%swift.opaque* noalias nocapture, %swift.type* %T, i8** %T.ResilientBaseProtocol)
 // CHECK: call swiftcc [[INT]] @"$S18resilient_protocol21ResilientBaseProtocolP11requirementSiyFTj"(%swift.opaque* noalias nocapture swiftself %0, %swift.type* %T, i8** %T.ResilientBaseProtocol)
 // CHECK: ret void
 public func callResilientWitnessMethod<T : ResilientBaseProtocol>(_ value: T) {
@@ -27,56 +27,56 @@ public protocol MyResilientProtocol {
   var property: Bool { get set }
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S26protocol_resilience_thunks19MyResilientProtocolP11returnsVoid1xySb_tFTj"(i1, %swift.opaque* noalias nocapture swiftself, %swift.type*, i8**)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S26protocol_resilience_thunks19MyResilientProtocolP11returnsVoid1xySb_tFTj"(i1, %swift.opaque* noalias nocapture swiftself, %swift.type*, i8**)
 // CHECK:      [[WITNESS_GEP:%.*]] = getelementptr inbounds i8*, i8** %3, i32 1
 // CHECK:      [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_GEP]]
 // CHECK-NEXT: [[FN:%.*]] = bitcast i8* [[WITNESS]] to void (i1, %swift.opaque*, %swift.type*, i8**)*
 // CHECK-NEXT: call swiftcc void [[FN]](i1 %0, %swift.opaque* noalias nocapture swiftself %1, %swift.type* %2, i8** %3)
 // CHECK-NEXT: ret void
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i1 @"$S26protocol_resilience_thunks19MyResilientProtocolP11returnsBoolSbyFTj"(%swift.opaque* noalias nocapture swiftself, %swift.type*, i8**)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @"$S26protocol_resilience_thunks19MyResilientProtocolP11returnsBoolSbyFTj"(%swift.opaque* noalias nocapture swiftself, %swift.type*, i8**)
 // CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %2, i32 2
 // CHECK-NEXT: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
 // CHECK-NEXT: [[FN:%.*]] = bitcast i8* [[WITNESS]] to i1 (%swift.opaque*, %swift.type*, i8**)*
 // CHECK-NEXT: [[RESULT:%.*]] = call swiftcc i1 [[FN]](%swift.opaque* noalias nocapture swiftself %0, %swift.type* %1, i8** %2)
 // CHECK-NEXT: ret i1 [[RESULT]]
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S26protocol_resilience_thunks19MyResilientProtocolP10returnsAnyypyFTj"(%Any* noalias nocapture sret, %swift.opaque* noalias nocapture swiftself, %swift.type*, i8**)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S26protocol_resilience_thunks19MyResilientProtocolP10returnsAnyypyFTj"(%Any* noalias nocapture sret, %swift.opaque* noalias nocapture swiftself, %swift.type*, i8**)
 // CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %3, i32 3
 // CHECK-NEXT: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
 // CHECK-NEXT: [[FN:%.*]] = bitcast i8* [[WITNESS]] to void (%Any*, %swift.opaque*, %swift.type*, i8**)*
 // CHECK-NEXT: call swiftcc void [[FN]](%Any* noalias nocapture sret %0, %swift.opaque* noalias nocapture swiftself %1, %swift.type* %2, i8** %3)
 // CHECK-NEXT: ret void
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S26protocol_resilience_thunks19MyResilientProtocolP12throwingFuncyyKFTj"(%swift.opaque* noalias nocapture swiftself, %swift.error**{{( swifterror)?}}, %swift.type*, i8**)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S26protocol_resilience_thunks19MyResilientProtocolP12throwingFuncyyKFTj"(%swift.opaque* noalias nocapture swiftself, %swift.error**{{( swifterror)?}}, %swift.type*, i8**)
 // CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %3, i32 4
 // CHECK-NEXT: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
 // CHECK-NEXT: [[FN:%.*]] = bitcast i8* [[WITNESS]] to void (%swift.opaque*, %swift.error**, %swift.type*, i8**)*
 // CHECK-NEXT: call swiftcc void [[FN]](%swift.opaque* noalias nocapture swiftself %0, %swift.error**{{( swifterror)?}} %1, %swift.type* %2, i8** %3)
 // CHECK-NEXT: ret void
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S26protocol_resilience_thunks19MyResilientProtocolP11genericFuncyqd__qd__lFTj"(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture, %swift.type*, %swift.opaque* noalias nocapture swiftself, %swift.type*, i8**)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S26protocol_resilience_thunks19MyResilientProtocolP11genericFuncyqd__qd__lFTj"(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture, %swift.type*, %swift.opaque* noalias nocapture swiftself, %swift.type*, i8**)
 // CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %5, i32 5
 // CHECK-NEXT: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
 // CHECK-NEXT: [[FN:%.*]] = bitcast i8* [[WITNESS]] to void (%swift.opaque*, %swift.opaque*, %swift.type*, %swift.opaque*, %swift.type*, i8**)*
 // CHECK-NEXT: call swiftcc void [[FN]](%swift.opaque* noalias nocapture sret %0, %swift.opaque* noalias nocapture %1, %swift.type* %2, %swift.opaque* noalias nocapture swiftself %3, %swift.type* %4, i8** %5)
 // CHECK-NEXT: ret void
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i1 @"$S26protocol_resilience_thunks19MyResilientProtocolP8propertySbvgTj"(%swift.opaque* noalias nocapture swiftself, %swift.type*, i8**)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @"$S26protocol_resilience_thunks19MyResilientProtocolP8propertySbvgTj"(%swift.opaque* noalias nocapture swiftself, %swift.type*, i8**)
 // CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %2, i32 6
 // CHECK-NEXT: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
 // CHECK-NEXT: [[FN:%.*]] = bitcast i8* [[WITNESS]] to i1 (%swift.opaque*, %swift.type*, i8**)*
 // CHECK-NEXT: [[RESULT:%.*]] = call swiftcc i1 %5(%swift.opaque* noalias nocapture swiftself %0, %swift.type* %1, i8** %2)
 // CHECK-NEXT: ret i1 [[RESULT]]
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S26protocol_resilience_thunks19MyResilientProtocolP8propertySbvsTj"(i1, %swift.opaque* nocapture swiftself, %swift.type*, i8**)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S26protocol_resilience_thunks19MyResilientProtocolP8propertySbvsTj"(i1, %swift.opaque* nocapture swiftself, %swift.type*, i8**)
 // CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %3, i32 7
 // CHECK-NEXT: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
 // CHECK-NEXT: [[FN:%.*]] = bitcast i8* [[WITNESS]] to void (i1, %swift.opaque*, %swift.type*, i8**)*
 // CHECK-NEXT: call swiftcc void [[FN]](i1 %0, %swift.opaque* nocapture swiftself %1, %swift.type* %2, i8** %3)
 // CHECK-NEXT: ret void
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, {{i32|i64}} } @"$S26protocol_resilience_thunks19MyResilientProtocolP8propertySbvmTj"(i8*, [{{12|24}} x i8]* nocapture dereferenceable({{12|24}}), %swift.opaque* nocapture swiftself, %swift.type*, i8**)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, {{i32|i64}} } @"$S26protocol_resilience_thunks19MyResilientProtocolP8propertySbvmTj"(i8*, [{{12|24}} x i8]* nocapture dereferenceable({{12|24}}), %swift.opaque* nocapture swiftself, %swift.type*, i8**)
 // CHECK:      [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %4, i32 8
 // CHECK-NEXT: [[WITNESS:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
 // CHECK-NEXT: [[FN:%.*]] = bitcast i8* [[WITNESS]] to { i8*, [[INT]] } (i8*, [{{12|24}} x i8]*, %swift.opaque*, %swift.type*, i8**)*

--- a/test/IRGen/readonly.sil
+++ b/test/IRGen/readonly.sil
@@ -18,7 +18,7 @@ sil @XXX_ctor : $@convention(method) (@owned XXX) -> @owned XXX
 // the function body that this function is really read only.
 
 // CHECK-NOT: ; Function Attrs: readonly
-// CHECK: define{{( protected)?}} swiftcc void @function_foo(
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @function_foo(
 sil [readonly] @function_foo : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
   %1 = tuple ()
@@ -31,7 +31,7 @@ bb0(%0 : $Int):
 // the function body that this function is really read only or read none.
 
 // CHECK-NOT: ; Function Attrs: readonly
-// CHECK: define{{( protected)?}} swiftcc void @function_foo2(
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @function_foo2(
 sil [readnone] @function_foo2 : $@convention(thin) (Int) -> () {
 bb0(%0 : $Int):
   %1 = tuple ()
@@ -42,7 +42,7 @@ bb0(%0 : $Int):
 // -- function is not read only at LLVM level
 
 // CHECK-NOT: ; Function Attrs: readonly
-// CHECK: define{{( protected)?}} swiftcc void @function_bar(
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @function_bar(
 sil [readonly] @function_bar : $@convention(thin) (@owned XXX) -> () {
 bb0(%0 : $XXX):
   strong_release %0 : $XXX
@@ -53,7 +53,7 @@ bb0(%0 : $XXX):
 // There's an @out parameter -- function is not read only at LLVM level
 
 // CHECK-NOT: ; Function Attrs: readonly
-// CHECK: define{{( protected)?}} swiftcc void @function_baz(
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @function_baz(
 sil [readonly] @function_baz : $@convention(thin) () -> (@out Any) {
 bb0(%0 : $*Any):
   init_existential_addr %0 : $*Any, $()

--- a/test/IRGen/runtime_calling_conventions.swift
+++ b/test/IRGen/runtime_calling_conventions.swift
@@ -7,11 +7,11 @@
 public class C {
 }
 
-// CHECK-LABEL: define {{(protected )?}}swiftcc void @"$S27runtime_calling_conventions3fooyyAA1CCF"(%T27runtime_calling_conventions1CC*)
+// CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc void @"$S27runtime_calling_conventions3fooyyAA1CCF"(%T27runtime_calling_conventions1CC*)
 // Check that runtime functions use a proper calling convention.
 // CHECK-NOT: call void {{.*}} @swift_release
 
-// OPT-CHECK-LABEL: define {{(protected )?}}swiftcc void @"$S27runtime_calling_conventions3fooyyAA1CCF"(%T27runtime_calling_conventions1CC* nocapture)
+// OPT-CHECK-LABEL: define {{(dllexport )?}}{{(protected )?}}swiftcc void @"$S27runtime_calling_conventions3fooyyAA1CCF"(%T27runtime_calling_conventions1CC* nocapture)
 // Check that runtime functions use a proper calling convention.
 // OPT-CHECK-NOT: tail call void @swift_release
 

--- a/test/IRGen/same_type_constraints.swift
+++ b/test/IRGen/same_type_constraints.swift
@@ -23,13 +23,13 @@ public extension P where Foo == DefaultFoo<Self> {
 }
 
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S21same_type_constraints1PPA2A10DefaultFooVyxG0E0RtzrlE3fooAFyF"
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S21same_type_constraints1PPA2A10DefaultFooVyxG0E0RtzrlE3fooAFyF"
 
 // <rdar://26873036> IRGen crash with derived class declaring same-type constraint on constrained associatedtype.
 public class C1<T: Equatable> { }
 public class C2<T: Equatable, U: P>: C1<T> where T == U.Foo {}
 
-// CHECK: define{{( protected)?}} swiftcc void @"$S21same_type_constraints2C1CfD"
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S21same_type_constraints2C1CfD"
 
 public protocol MyHashable {}
 public protocol DataType : MyHashable {}

--- a/test/IRGen/select_enum.sil
+++ b/test/IRGen/select_enum.sil
@@ -7,7 +7,7 @@ enum SinglePayloadSingleEmpty {
   case DataCase(Builtin.Word)
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @select_enum_SinglePayloadSingleEmpty(%T11select_enum013SinglePayloadC5EmptyO* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @select_enum_SinglePayloadSingleEmpty(%T11select_enum013SinglePayloadC5EmptyO* noalias nocapture dereferenceable({{.*}}))
 sil @select_enum_SinglePayloadSingleEmpty : $@convention(thin) (@in SinglePayloadSingleEmpty) -> () {
 bb0(%0 : $*SinglePayloadSingleEmpty):
   %1 = load %0 : $*SinglePayloadSingleEmpty
@@ -79,7 +79,7 @@ enum NoPayloadSingleton {
   case One
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i1 @testOptionalOfNoPayloadSingleton(i8)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @testOptionalOfNoPayloadSingleton(i8)
 sil @testOptionalOfNoPayloadSingleton : $@convention(thin) (MyOptional<NoPayloadSingleton>) -> Builtin.Int1 {
 bb0(%0 : $MyOptional<NoPayloadSingleton>):
 // CHECK:  [[NATIVECCTRUNC:%.*]] = trunc i8 %0 to i1

--- a/test/IRGen/sil_linkage.sil
+++ b/test/IRGen/sil_linkage.sil
@@ -2,25 +2,25 @@
 
 sil_stage canonical
 
-// CHECK: define{{( protected)?}} swiftcc void @public_fragile_function_test() {{.*}} {
-// CHECK: define{{( protected)?}} swiftcc void @public_transparent_fragile_function_test() {{.*}} {
-// CHECK: define{{( protected)?}} swiftcc void @public_transparent_function_test() {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @public_fragile_function_test() {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @public_transparent_fragile_function_test() {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @public_transparent_function_test() {{.*}} {
 // CHECK: define hidden swiftcc void @public_non_abi_function_test() {{.*}} {
 // CHECK: define hidden swiftcc void @hidden_fragile_function_test() {{.*}} {
 // CHECK: define linkonce_odr hidden swiftcc void @shared_fragile_function_test() {{.*}} {
 // CHECK: define{{( internal)?}} swiftcc void @private_fragile_function_test() {{.*}} {
 // Public external functions are not emitted into clients.
-// CHECK: declare swiftcc void @public_external_fragile_function_def_test()
-// CHECK: define{{( protected)?}} available_externally{{ (hidden)?}} swiftcc void @hidden_external_fragile_function_def_test() {{.*}} {
+// CHECK: declare{{( dllimport)?}} swiftcc void @public_external_fragile_function_def_test()
+// CHECK: define{{( protected)?}} available_externally{{ (hidden)?}}{{( dllimport)?}} swiftcc void @hidden_external_fragile_function_def_test() {{.*}} {
 // CHECK: define linkonce_odr hidden swiftcc void @shared_external_fragile_function_def_test() {{.*}} {
-// CHECK: define{{( protected)?}} available_externally{{ (hidden)?}} swiftcc void @private_external_fragile_function_def_test() {{.*}} {
-// CHECK: define{{( protected)?}} swiftcc void @public_resilient_function_test() {{.*}} {
+// CHECK: define{{( protected)?}} available_externally{{ (hidden)?}}{{( dllimport)?}} swiftcc void @private_external_fragile_function_def_test() {{.*}} {
+// CHECK: define{{( protected)?}}{{( dllexport)?}} swiftcc void @public_resilient_function_test() {{.*}} {
 // CHECK: define hidden swiftcc void @hidden_resilient_function_test() {{.*}} {
 // CHECK: define linkonce_odr hidden swiftcc void @shared_resilient_function_test() {{.*}} {
 // CHECK: define internal swiftcc void @private_resilient_function_test() {{.*}}{
 // Public external functions are not emitted into clients.
-// CHECK: declare swiftcc void @public_external_resilient_function_def_test()
-// CHECK: define{{( protected)?}} available_externally hidden swiftcc void @hidden_external_resilient_function_def_test() {{.*}} {
+// CHECK: declare{{( dllimport)?}} swiftcc void @public_external_resilient_function_def_test()
+// CHECK: define{{( protected)?}} available_externally hidden{{( dllimport)?}} swiftcc void @hidden_external_resilient_function_def_test() {{.*}} {
 // CHECK: define linkonce_odr hidden swiftcc void @shared_external_resilient_function_def_test() {{.*}} {
 
 sil public [serialized] @public_fragile_function_test : $@convention(thin) () -> () {

--- a/test/IRGen/sil_witness_methods.sil
+++ b/test/IRGen/sil_witness_methods.sil
@@ -27,14 +27,14 @@ struct X {}
 struct Y {}
 struct Z {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.type* @concrete_type_concrete_method_witness(%T19sil_witness_methods3FooV* noalias nocapture swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @concrete_type_concrete_method_witness(%T19sil_witness_methods3FooV* noalias nocapture swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
 sil @concrete_type_concrete_method_witness : $@convention(witness_method: P) (@in Foo) -> @thick Foo.Type {
 entry(%x : $*Foo):
   %m = metatype $@thick Foo.Type
   return %m : $@thick Foo.Type
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.type* @generic_type_concrete_method_witness(%T19sil_witness_methods3BarC** noalias nocapture swiftself dereferenceable({{.*}}), %swift.type* %Self, i8** %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @generic_type_concrete_method_witness(%T19sil_witness_methods3BarC** noalias nocapture swiftself dereferenceable({{.*}}), %swift.type* %Self, i8** %SelfWitnessTable)
 // CHECK:         [[T0:%.*]] = bitcast %swift.type* %Self to %swift.type**
 // CHECK:         [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i64 10
 // CHECK:         %T = load %swift.type*, %swift.type** [[T1]], align 8
@@ -56,7 +56,7 @@ entry(%x : $*Bar<T, U, V>):
 
 // TODO: %Self Type arg is redundant for static method witness
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.type* @concrete_type_concrete_static_method_witness(%swift.type* swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @concrete_type_concrete_static_method_witness(%swift.type* swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
 sil @concrete_type_concrete_static_method_witness : $@convention(witness_method: P) (@thick Foo.Type) -> @thick Foo.Type {
 entry(%x : $@thick Foo.Type):
   %m = metatype $@thick Foo.Type
@@ -64,7 +64,7 @@ entry(%x : $@thick Foo.Type):
 }
 
 //   The use of %0 or %Self here is irrelevant.
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.type* @generic_type_concrete_static_method_witness(%swift.type* swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @generic_type_concrete_static_method_witness(%swift.type* swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
 // CHECK:         [[T0:%.*]] = bitcast %swift.type* %Self to %swift.type**
 // CHECK:         [[T1:%.*]] = getelementptr inbounds %swift.type*, %swift.type** [[T0]], i64 10
 // CHECK:         %T = load %swift.type*, %swift.type** [[T1]], align 8
@@ -86,14 +86,14 @@ entry(%x : $@thick Bar<T, U, V>.Type):
 
 // TODO: %Self Type arg is redundant for class method witness
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.type* @concrete_type_generic_method_witness(%swift.opaque* noalias nocapture, %swift.type* %Z, %T19sil_witness_methods3FooV* noalias nocapture swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @concrete_type_generic_method_witness(%swift.opaque* noalias nocapture, %swift.type* %Z, %T19sil_witness_methods3FooV* noalias nocapture swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
 sil @concrete_type_generic_method_witness : $@convention(witness_method: P) <Z> (@in Z, @in Foo) -> @thick Foo.Type {
 entry(%z : $*Z, %x : $*Foo):
   %m = metatype $@thick Foo.Type
   return %m : $@thick Foo.Type
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.type* @generic_type_generic_method_witness(%swift.opaque* noalias nocapture, %swift.type* %Z, %T19sil_witness_methods3BarC{{.*}}** noalias nocapture swiftself dereferenceable(8), %swift.type* %Self, i8** %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @generic_type_generic_method_witness(%swift.opaque* noalias nocapture, %swift.type* %Z, %T19sil_witness_methods3BarC{{.*}}** noalias nocapture swiftself dereferenceable(8), %swift.type* %Self, i8** %SelfWitnessTable)
 sil @generic_type_generic_method_witness : $@convention(witness_method: P) <T, U, V, Z> (@in Z, @in Bar<T, U, V>) -> @thick Bar<T, U, V>.Type {
 entry(%z : $*Z, %x : $*Bar<T, U, V>):
   %t = metatype $@thick T.Type
@@ -104,14 +104,14 @@ entry(%z : $*Z, %x : $*Bar<T, U, V>):
   return %m : $@thick Bar<T, U, V>.Type
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.type* @concrete_type_generic_static_method_witness(%swift.opaque* noalias nocapture, %swift.type* %Z, %swift.type* swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @concrete_type_generic_static_method_witness(%swift.opaque* noalias nocapture, %swift.type* %Z, %swift.type* swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
 sil @concrete_type_generic_static_method_witness : $@convention(witness_method: P) <Z> (@in Z, @thick Foo.Type) -> @thick Foo.Type {
 entry(%z : $*Z, %x : $@thick Foo.Type):
   %m = metatype $@thick Foo.Type
   return %m : $@thick Foo.Type
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.type* @generic_type_generic_static_method_witness(%swift.opaque* noalias nocapture, %swift.type* %Z, %swift.type* swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.type* @generic_type_generic_static_method_witness(%swift.opaque* noalias nocapture, %swift.type* %Z, %swift.type* swiftself, %swift.type* %Self, i8** %SelfWitnessTable)
 sil @generic_type_generic_static_method_witness : $@convention(witness_method: P) <T, U, V, Z> (@in Z, @thick Bar<T, U, V>.Type) -> @thick Bar<T, U, V>.Type {
 entry(%z : $*Z, %x : $@thick Bar<T, U, V>.Type):
   %t = metatype $@thick T.Type
@@ -122,7 +122,7 @@ entry(%z : $*Z, %x : $@thick Bar<T, U, V>.Type):
   return %m : $@thick Bar<T, U, V>.Type
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @call_concrete_witness() {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @call_concrete_witness() {{.*}} {
 // CHECK:         call swiftcc %swift.type* @concrete_type_concrete_method_witness(%T19sil_witness_methods3FooV* {{.*}}, %swift.type* {{.*}} @"$S19sil_witness_methods3FooVMf", {{.*}})
 sil @call_concrete_witness : $(Foo) -> () {
 entry(%x : $Foo):
@@ -134,7 +134,7 @@ entry(%x : $Foo):
   return undef : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @call_concrete_static_witness() {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @call_concrete_static_witness() {{.*}} {
 // CHECK:         call swiftcc %swift.type* @concrete_type_concrete_static_method_witness(%swift.type* {{.*}} @"$S19sil_witness_methods3FooVMf", {{.*}} %swift.type* {{.*}} @"$S19sil_witness_methods3FooVMf", {{.*}})
 sil @call_concrete_static_witness : $() -> () {
 entry:
@@ -144,7 +144,7 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_concrete_witness() {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_concrete_witness() {{.*}} {
 // CHECK:         [[CONTEXT:%.*]] = call noalias %swift.refcounted* @swift_allocObject({{.*}})
 // CHECK:         [[LAYOUT:%.*]] = bitcast %swift.refcounted* [[CONTEXT]] to <{ %swift.refcounted, i8* }>*
 // CHECK:         [[WTABLE:%.*]] = getelementptr inbounds <{ %swift.refcounted, i8* }>, <{ %swift.refcounted, i8* }>* [[LAYOUT]], i32 0, i32 1

--- a/test/IRGen/sil_witness_tables.swift
+++ b/test/IRGen/sil_witness_tables.swift
@@ -36,7 +36,7 @@ struct Conformer: Q, QQ {
   func qMethod() {}
 }
 
-// CHECK: [[EXTERNAL_CONFORMER_EXTERNAL_P_WITNESS_TABLE:@"\$S39sil_witness_tables_external_conformance17ExternalConformerVAA0F1PAAWP"]] = external global i8*, align 8
+// CHECK: [[EXTERNAL_CONFORMER_EXTERNAL_P_WITNESS_TABLE:@"\$S39sil_witness_tables_external_conformance17ExternalConformerVAA0F1PAAWP"]] = external{{( dllimport)?}} global i8*, align 8
 // CHECK: [[CONFORMER_Q_WITNESS_TABLE:@"\$S18sil_witness_tables9ConformerVAA1QAAWP"]] = hidden constant [3 x i8*] [
 // CHECK:   i8* bitcast ([5 x i8*]* [[CONFORMER_P_WITNESS_TABLE:@"\$S18sil_witness_tables9ConformerVAA1PAAWP"]] to i8*),
 // CHECK:   i8* bitcast (void (%T18sil_witness_tables9ConformerV*, %swift.type*, i8**)* @"$S18sil_witness_tables9ConformerVAA1QA2aDP7qMethod{{[_0-9a-zA-Z]*}}FTW" to i8*)

--- a/test/IRGen/sil_witness_tables_external_witnesstable.swift
+++ b/test/IRGen/sil_witness_tables_external_witnesstable.swift
@@ -4,8 +4,8 @@
 
 import Swift
 
-// CHECK: @"$Ss1XVN" = external global %swift.type
-// CHECK: @"$Ss1XVs1PsWP" = external global i8*
+// CHECK: @"$Ss1XVN" = external {{(dllimport )?}}global %swift.type
+// CHECK: @"$Ss1XVs1PsWP" = external {{(dllimport )?}}global i8*
 
 func doSomething<T : P>(_ t : T) -> Y {
   return t.doSomething()

--- a/test/IRGen/special_protocols.sil
+++ b/test/IRGen/special_protocols.sil
@@ -1,14 +1,14 @@
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -parse-stdlib -module-name Swift | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 public protocol Error {}
-// CHECK-LABEL: @"$Ss5ErrorMp" = {{(protected )?}}constant %swift.protocol {
+// CHECK-LABEL: @"$Ss5ErrorMp" = {{(dllexport )?}}{{(protected )?}}constant %swift.protocol {
 // --                 0x0000_0047: special protocol 01, non-class, witness, swift
 // CHECK:         i32 71,
 // CHECK:         i32 0,
 // CHECK:         i32 0 }
 
 public protocol PlainOldProtocol {}
-// CHECK-LABEL: @"$Ss16PlainOldProtocolMp" = {{(protected )?}}constant %swift.protocol {
+// CHECK-LABEL: @"$Ss16PlainOldProtocolMp" = {{(dllexport )?}}{{(protected )?}}constant %swift.protocol {
 // --                 0x0000_0007: no special protocol, non-class, witness, swift
 // CHECK:         i32 7,
 // CHECK:         i32 0,

--- a/test/IRGen/static_initializer.sil
+++ b/test/IRGen/static_initializer.sil
@@ -32,7 +32,7 @@ sil_global @$S2ch1xSiv : $Int32 = {
   %1 = integer_literal $Builtin.Int32, 2
   %initval = struct $Int32 (%1 : $Builtin.Int32)
 }
-// CHECK: @"$S2ch1xSiv" = {{(protected )?}}global %Ts5Int32V <{ i32 2 }>, align 4
+// CHECK: @"$S2ch1xSiv" = {{(dllexport )?}}{{(protected )?}}global %Ts5Int32V <{ i32 2 }>, align 4
 
 sil_global @$S6nested1xAA2S2Vv : $S2 = {
   %1 = integer_literal $Builtin.Int32, 2
@@ -66,7 +66,7 @@ sil_global @static_array : $TestArrayStorage = {
   %5 = struct $Int64 (%2 : $Builtin.Int64)
   %initval = object $TestArrayStorage (%3 : $Int32, [tail_elems] %4 : $Int64, %5 : $Int64)
 }
-// CHECK: @static_array = {{(protected )?}}global %T18static_initializer16TestArrayStorageC_tailelems0c { [1 x i64] zeroinitializer, %T18static_initializer16TestArrayStorageC_tailelems0 <{ %swift.refcounted zeroinitializer, %Ts5Int32V <{ i32 2 }>, [4 x i8] undef, %Ts5Int64V <{ i64 10 }>, %Ts5Int64V <{ i64 20 }> }> }, align 8
+// CHECK: @static_array = {{(dllexport )?}}{{(protected )?}}global %T18static_initializer16TestArrayStorageC_tailelems0c { [1 x i64] zeroinitializer, %T18static_initializer16TestArrayStorageC_tailelems0 <{ %swift.refcounted zeroinitializer, %Ts5Int32V <{ i32 2 }>, [4 x i8] undef, %Ts5Int64V <{ i64 10 }>, %Ts5Int64V <{ i64 20 }> }> }, align 8
 
 sil_global @static_aligned_array : $TestArrayStorage = {
   %0 = integer_literal $Builtin.Int32, 2
@@ -101,9 +101,9 @@ sil_global @static_array_with_empty_element : $TestArrayStorage = {
   %2 = struct $Int32 (%1 : $Builtin.Int32)
   %initval = object $TestArrayStorage (%2 : $Int32, [tail_elems] %0 : $Empty, %0 : $Empty)
 }
-// CHECK: @static_array_with_empty_element = {{(protected )?}}global %T18static_initializer16TestArrayStorageC_tailelems3c { [1 x i64] zeroinitializer, %T18static_initializer16TestArrayStorageC_tailelems3 <{ %swift.refcounted zeroinitializer, %Ts5Int32V <{ i32 2 }>, [1 x i8] undef, [1 x i8] undef }> }, align 8
+// CHECK: @static_array_with_empty_element = {{( dllexport)?}}{{(protected )?}}global %T18static_initializer16TestArrayStorageC_tailelems3c { [1 x i64] zeroinitializer, %T18static_initializer16TestArrayStorageC_tailelems3 <{ %swift.refcounted zeroinitializer, %Ts5Int32V <{ i32 2 }>, [1 x i8] undef, [1 x i8] undef }> }, align 8
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i8* @_TF2cha1xSi() {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @_TF2cha1xSi() {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK-NEXT: ret i8* bitcast (%Ts5Int32V* @"$S2ch1xSiv" to i8*)
 sil [global_init] @_TF2cha1xSi : $@convention(thin) () -> Builtin.RawPointer {
@@ -113,7 +113,7 @@ bb0:
   return %1 : $Builtin.RawPointer
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i32 @"$S2ch1fSiyF"() {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @"$S2ch1fSiyF"() {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK-NEXT: load i32, i32* getelementptr inbounds (%Ts5Int32V, %Ts5Int32V* @"$S2ch1xSiv", i32 0, i32 0)
 // CHECK-NEXT: ret
@@ -124,7 +124,7 @@ bb0:
   return %1 : $Int32
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i8* @_TF6nesteda1xVS_2S2() {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @_TF6nesteda1xVS_2S2() {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK-NEXT: ret i8* bitcast (%T18static_initializer2S2V* @"$S6nested1xAA2S2Vv" to i8*)
 sil [global_init] @_TF6nesteda1xVS_2S2 : $@convention(thin) () -> Builtin.RawPointer {
@@ -134,7 +134,7 @@ bb0:
   return %1 : $Builtin.RawPointer
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i64, i32 } @"$S6nested1fAA2S2VyF"() {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i64, i32 } @"$S6nested1fAA2S2VyF"() {{.*}} {
 // CHECK-NEXT: entry:
 // CHECK: load i32, i32* getelementptr inbounds (%T18static_initializer2S2V, %T18static_initializer2S2V* @"$S6nested1xAA2S2Vv", i32 0, i32 0, i32 0)
 // CHECK-NEXT: load i32, i32* getelementptr inbounds (%T18static_initializer2S2V, %T18static_initializer2S2V* @"$S6nested1xAA2S2Vv", i32 0, i32 1, i32 0)
@@ -146,7 +146,7 @@ bb0:
   return %1 : $S2
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %T18static_initializer16TestArrayStorageC* @return_static_array() {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %T18static_initializer16TestArrayStorageC* @return_static_array() {{.*}} {
 sil @return_static_array : $@convention(thin) () -> TestArray {
 bb0:
   // CHECK: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S18static_initializer16TestArrayStorageCMa"(i64 0)

--- a/test/IRGen/struct_resilience.swift
+++ b/test/IRGen/struct_resilience.swift
@@ -15,7 +15,7 @@ import resilient_enum
 // Resilient structs from outside our resilience domain are manipulated via
 // value witnesses
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S17struct_resilience30functionWithResilientTypesSize_1f010resilient_A00G0VAFn_A2FnXEtF"(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture, i8*, %swift.opaque*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S17struct_resilience30functionWithResilientTypesSize_1f010resilient_A00G0VAFn_A2FnXEtF"(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture, i8*, %swift.opaque*)
 
 public func functionWithResilientTypesSize(_ s: __owned Size, f: (__owned Size) -> Size) -> Size {
 // CHECK: entry:
@@ -51,7 +51,7 @@ public func functionWithResilientTypesSize(_ s: __owned Size, f: (__owned Size) 
   return f(s)
 }
 
-// CHECK-LABEL: declare swiftcc %swift.metadata_response @"$S16resilient_struct4SizeVMa"
+// CHECK-LABEL: declare{{( dllimport)?}} swiftcc %swift.metadata_response @"$S16resilient_struct4SizeVMa"
 // CHECK-SAME:    ([[INT]])
 
 // Rectangle has fixed layout inside its resilience domain, and dynamic
@@ -60,7 +60,7 @@ public func functionWithResilientTypesSize(_ s: __owned Size, f: (__owned Size) 
 // Make sure we use a type metadata accessor function, and load indirect
 // field offsets from it.
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S17struct_resilience35functionWithResilientTypesRectangleyy010resilient_A00G0VF"(%T16resilient_struct9RectangleV* noalias nocapture)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S17struct_resilience35functionWithResilientTypesRectangleyy010resilient_A00G0VF"(%T16resilient_struct9RectangleV* noalias nocapture)
 public func functionWithResilientTypesRectangle(_ r: Rectangle) {
 // CHECK: entry:
 // CHECK-NEXT: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S16resilient_struct9RectangleVMa"([[INT]] 0)
@@ -90,7 +90,7 @@ public struct MySize {
   public let h: Int
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S17struct_resilience32functionWithMyResilientTypesSize_1fAA0eH0VAEn_A2EnXEtF"(%T17struct_resilience6MySizeV* noalias nocapture sret, %T17struct_resilience6MySizeV* noalias nocapture dereferenceable({{8|(16)}}), i8*, %swift.opaque*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S17struct_resilience32functionWithMyResilientTypesSize_1fAA0eH0VAEn_A2EnXEtF"(%T17struct_resilience6MySizeV* noalias nocapture sret, %T17struct_resilience6MySizeV* noalias nocapture dereferenceable({{8|(16)}}), i8*, %swift.opaque*)
 public func functionWithMyResilientTypesSize(_ s: __owned MySize, f: (__owned MySize) -> MySize) -> MySize {
 
 // CHECK: [[TEMP:%.*]] = alloca %T17struct_resilience6MySizeV
@@ -120,7 +120,7 @@ public struct StructWithResilientStorage {
 // resilient layout, and go through the field offset vector in the
 // metadata when accessing stored properties.
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc {{i32|i64}} @"$S17struct_resilience26StructWithResilientStorageV1nSivg"(%T17struct_resilience26StructWithResilientStorageV* {{.*}})
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc {{i32|i64}} @"$S17struct_resilience26StructWithResilientStorageV1nSivg"(%T17struct_resilience26StructWithResilientStorageV* {{.*}})
 // CHECK: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S17struct_resilience26StructWithResilientStorageVMa"([[INT]] 0)
 // CHECK: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
 // CHECK-NEXT: [[METADATA_ADDR:%.*]] = bitcast %swift.type* [[METADATA]] to i32*
@@ -143,7 +143,7 @@ public struct StructWithIndirectResilientEnum {
 }
 
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc {{i32|i64}} @"$S17struct_resilience31StructWithIndirectResilientEnumV1nSivg"(%T17struct_resilience31StructWithIndirectResilientEnumV* {{.*}})
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc {{i32|i64}} @"$S17struct_resilience31StructWithIndirectResilientEnumV1nSivg"(%T17struct_resilience31StructWithIndirectResilientEnumV* {{.*}})
 // CHECK: [[FIELD_PTR:%.*]] = getelementptr inbounds %T17struct_resilience31StructWithIndirectResilientEnumV, %T17struct_resilience31StructWithIndirectResilientEnumV* %0, i32 0, i32 1
 // CHECK-NEXT: [[FIELD_PAYLOAD_PTR:%.*]] = getelementptr inbounds %TSi, %TSi* [[FIELD_PTR]], i32 0, i32 0
 // CHECK-NEXT: [[FIELD_PAYLOAD:%.*]] = load [[INT]], [[INT]]* [[FIELD_PAYLOAD_PTR]]
@@ -158,26 +158,26 @@ public struct ResilientStructWithMethod {
 
 // Corner case -- type is address-only in SIL, but empty in IRGen
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S17struct_resilience29partialApplyOfResilientMethod1ryAA0f10StructWithG0V_tF"(%T17struct_resilience25ResilientStructWithMethodV* noalias nocapture)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S17struct_resilience29partialApplyOfResilientMethod1ryAA0f10StructWithG0V_tF"(%T17struct_resilience25ResilientStructWithMethodV* noalias nocapture)
 public func partialApplyOfResilientMethod(r: ResilientStructWithMethod) {
   _ = r.method
 }
 
 // Type is address-only in SIL, and resilient in IRGen
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S17struct_resilience29partialApplyOfResilientMethod1sy010resilient_A04SizeV_tF"(%swift.opaque* noalias nocapture)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S17struct_resilience29partialApplyOfResilientMethod1sy010resilient_A04SizeV_tF"(%swift.opaque* noalias nocapture)
 public func partialApplyOfResilientMethod(s: Size) {
   _ = s.method
 }
 
 // Public metadata accessor for our resilient struct
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc %swift.metadata_response @"$S17struct_resilience6MySizeVMa"
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %swift.metadata_response @"$S17struct_resilience6MySizeVMa"
 // CHECK-SAME:    ([[INT]])
 // CHECK: ret %swift.metadata_response { %swift.type* bitcast ([[INT]]* getelementptr inbounds {{.*}} @"$S17struct_resilience6MySizeVMf", i32 0, i32 1) to %swift.type*), [[INT]] 0 }
 
 
-// CHECK-LABEL: define{{( protected)?}} private void @initialize_metadata_StructWithResilientStorage(i8*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} private void @initialize_metadata_StructWithResilientStorage(i8*)
 // CHECK: [[FIELDS:%.*]] = alloca [4 x i8**]
 
 // CHECK: [[FIELDS_ADDR:%.*]] = getelementptr inbounds [4 x i8**], [4 x i8**]* [[FIELDS]], i32 0, i32 0

--- a/test/IRGen/subclass_existentials.sil
+++ b/test/IRGen/subclass_existentials.sil
@@ -18,8 +18,8 @@ protocol R {}
 // Make sure we use native reference counting when the existential has a Swift
 // class bound.
 
-// CHECK-objc-LABEL: define{{( protected)?}} swiftcc void @checkRefcounting(%T21subclass_existentials1CC*, i8**, %objc_object*, i8**)
-// CHECK-native-LABEL: define{{( protected)?}} swiftcc void @checkRefcounting(%T21subclass_existentials1CC*, i8**, %swift.refcounted*, i8**)
+// CHECK-objc-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @checkRefcounting(%T21subclass_existentials1CC*, i8**, %objc_object*, i8**)
+// CHECK-native-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @checkRefcounting(%T21subclass_existentials1CC*, i8**, %swift.refcounted*, i8**)
 // CHECK-NEXT: entry:
 // CHECK-objc-NEXT:   call void @swift_unknownRelease(%objc_object* %2)
 // CHECK-native-NEXT: call void @swift_release(%swift.refcounted* %2)
@@ -39,7 +39,7 @@ bb0(%0 : $C & P, %1 : $AnyObject & P):
 
 sil @takesMetadata : $@convention(thin) <T> (@thick T.Type) -> ()
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @checkMetadata()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @checkMetadata()
 // CHECK-NEXT: entry:
 // CHECK-NEXT:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S21subclass_existentials1P_AA1CCXcMa"([[INT]] 0)
 // CHECK-NEXT:   [[TYPE:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
@@ -70,7 +70,7 @@ bb0:
   return %4 : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { %T21subclass_existentials1CC*, i8** } @eraseToExistential(%T21subclass_existentials1DC*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { %T21subclass_existentials1CC*, i8** } @eraseToExistential(%T21subclass_existentials1DC*)
 // CHECK:       [[INSTANCE:%.*]] = bitcast %T21subclass_existentials1DC* %0 to %T21subclass_existentials1CC*
 // CHECK-NEXT:  [[RESULT1:%.*]] = insertvalue { %T21subclass_existentials1CC*, i8** } undef, %T21subclass_existentials1CC* [[INSTANCE]], 0
 // CHECK-NEXT:  [[RESULT2:%.*]] = insertvalue { %T21subclass_existentials1CC*, i8** } [[RESULT1]], i8** @"$S21subclass_existentials1DCAA1PAAWP", 1
@@ -81,7 +81,7 @@ bb0(%0 : $D):
   return %2 : $C & P
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { %T21subclass_existentials1GC*, i8** } @eraseToExistentialWithGeneric(%T21subclass_existentials1EC*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { %T21subclass_existentials1GC*, i8** } @eraseToExistentialWithGeneric(%T21subclass_existentials1EC*)
 // CHECK:       [[INSTANCE:%.*]] = bitcast %T21subclass_existentials1EC* %0 to %T21subclass_existentials1GC*
 // CHECK-NEXT:  [[RESULT1:%.*]] = insertvalue { %T21subclass_existentials1GC*, i8** } undef, %T21subclass_existentials1GC* [[INSTANCE]], 0
 // CHECK-NEXT:  [[RESULT2:%.*]] = insertvalue { %T21subclass_existentials1GC*, i8** } [[RESULT1]], i8** @"$S21subclass_existentials1ECyxGAA1PAAWP", 1
@@ -92,7 +92,7 @@ bb0(%0 : $E<τ_0_0>):
   return %2 : $G<τ_0_0> & P
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @checkExistentialDowncast(%T21subclass_existentials1CC*, %T21subclass_existentials1CC*, i8**)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @checkExistentialDowncast(%T21subclass_existentials1CC*, %T21subclass_existentials1CC*, i8**)
 sil @checkExistentialDowncast : $@convention(thin) (@owned C, @owned C & P) -> () {
 bb0(%0 : $C, %1 : $C & P):
 
@@ -144,7 +144,7 @@ bb0(%0 : $C, %1 : $C & P):
 // CHECK-NEXT:  call void @llvm.trap()
 // CHECK-NEXT:  unreachable
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @checkExistentialSameClassDowncast(%T21subclass_existentials1CC*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @checkExistentialSameClassDowncast(%T21subclass_existentials1CC*)
 sil @checkExistentialSameClassDowncast : $@convention(thin) (@owned C) -> () {
 bb0(%0 : $C):
 
@@ -180,7 +180,7 @@ bb0(%0 : $C):
 // CHECK-NEXT:  call void @llvm.trap()
 // CHECK-NEXT:  unreachable
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @checkExistentialMetatypeDowncast(%swift.type*, %swift.type*, i8**)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @checkExistentialMetatypeDowncast(%swift.type*, %swift.type*, i8**)
 sil @checkExistentialMetatypeDowncast : $@convention(thin) (@owned @thick C.Type, @owned @thick (C & P).Type) -> () {
 bb0(%0 : $@thick C.Type, %1 : $@thick (C & P).Type):
 
@@ -201,7 +201,7 @@ bb0(%0 : $@thick C.Type, %1 : $@thick (C & P).Type):
   return %result : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @checkExistentialSameClassMetatypeDowncast(%swift.type*)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @checkExistentialSameClassMetatypeDowncast(%swift.type*)
 sil @checkExistentialSameClassMetatypeDowncast : $@convention(thin) (@owned @thick C.Type) -> () {
 bb0(%0 : $@thick C.Type):
 

--- a/test/IRGen/super.sil
+++ b/test/IRGen/super.sil
@@ -52,7 +52,7 @@ bb0(%0 : $ChildToResilientParent):
 }
 
 // ChildToResilientParent is in our resilience domain - can load the superclass's metadata directly.
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S5super22ChildToResilientParentC6methodyyF"(%T5super22ChildToResilientParentC* swiftself)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S5super22ChildToResilientParentC6methodyyF"(%T5super22ChildToResilientParentC* swiftself)
 // CHECK: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S15resilient_class22ResilientOutsideParentCMa"([[INT]] 0)
 // CHECK: [[SUPER_METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
 // CHECK: [[BASE:%.*]] = load [[INT]], [[INT]]* getelementptr inbounds ([[BOUNDS:{.*}]], {{.*}}* @"$S15resilient_class22ResilientOutsideParentCMo", i32 0, i32 0)
@@ -75,7 +75,7 @@ bb0(%0 : $@thick ChildToResilientParent.Type):
 }
 
 // ChildToResilientParent is in our resilience domain - can load the superclass's metadata directly.
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S5super22ChildToResilientParentC11classMethodyyFZ"(%swift.type* swiftself)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S5super22ChildToResilientParentC11classMethodyyFZ"(%swift.type* swiftself)
 // CHECK: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S15resilient_class22ResilientOutsideParentCMa"([[INT]] 0)
 // CHECK: [[SUPER_METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
 // CHECK: [[BASE:%.*]] = load [[INT]], [[INT]]* getelementptr inbounds ([[BOUNDS]], [[BOUNDS]]* @"$S15resilient_class22ResilientOutsideParentCMo", i32 0, i32 0)
@@ -106,7 +106,7 @@ bb0(%0 : $ChildToFixedParent):
   return %7 : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S5super18ChildToFixedParentC6methodyyF"(%T5super18ChildToFixedParentC* swiftself)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S5super18ChildToFixedParentC6methodyyF"(%T5super18ChildToFixedParentC* swiftself)
 // CHECK: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S15resilient_class13OutsideParentCMa"([[INT]] 0)
 // CHECK: [[SUPER_METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
 // CHECK: [[OPAQUE_SUPER_METADATA:%.*]] = bitcast %swift.type* [[SUPER_METADATA]] to void (%T15resilient_class13OutsideParentC*)**
@@ -127,7 +127,7 @@ bb0(%0 : $@thick ChildToFixedParent.Type):
 }
 
 // ChildToFixedParent is in our resilience domain - load super metadata directly.
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S5super18ChildToFixedParentC11classMethodyyFZ"(%swift.type* swiftself)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S5super18ChildToFixedParentC11classMethodyyFZ"(%swift.type* swiftself)
 // CHECK: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S15resilient_class13OutsideParentCMa"([[INT]] 0)
 // CHECK: [[SUPER_METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
 // CHECK: [[OPAQUE_SUPER_METADATA:%.*]] = bitcast %swift.type* [[SUPER_METADATA]] to void (%swift.type*)**
@@ -150,7 +150,7 @@ bb0(%0 : $ResilientOutsideChild):
 }
 
 // Extending a resilient class - load super metadata indirectly.
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S15resilient_class21ResilientOutsideChildC5superE15callSuperMethodyyF"(%T15resilient_class21ResilientOutsideChildC* swiftself)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S15resilient_class21ResilientOutsideChildC5superE15callSuperMethodyyF"(%T15resilient_class21ResilientOutsideChildC* swiftself)
 // CHECK: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S15resilient_class21ResilientOutsideChildCMa"([[INT]] 0)
 // CHECK: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
 // CHECK: [[OPAQUE_METADATA:%.*]] = bitcast %swift.type* [[METADATA]] to %swift.type**
@@ -177,7 +177,7 @@ bb0(%0 : $@thick ResilientOutsideChild.Type):
 }
 
 // Extending a resilient class - load super metadata indirectly.
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S15resilient_class21ResilientOutsideChildC5superE20callSuperClassMethodyyFZ"(%swift.type* swiftself)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S15resilient_class21ResilientOutsideChildC5superE20callSuperClassMethodyyFZ"(%swift.type* swiftself)
 // CHECK: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S15resilient_class21ResilientOutsideChildCMa"([[INT]] 0)
 // CHECK: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
 // CHECK: [[OPAQUE_METADATA:%.*]] = bitcast %swift.type* [[METADATA]] to %swift.type**

--- a/test/IRGen/tail_alloc.sil
+++ b/test/IRGen/tail_alloc.sil
@@ -15,7 +15,7 @@ class TestClass {
 
 sil_vtable TestClass {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @alloc_on_stack
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @alloc_on_stack
 // CHECK:      %reference.raw = alloca i8, i32 28, align 8
 // CHECK-NEXT: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S{{[a-zA-Z0-9_]+}}Ma"([[INT]] 0)
 // CHECK-NEXT: [[M:%[0-9]+]] = extractvalue %swift.metadata_response [[TMP]], 0
@@ -34,7 +34,7 @@ bb0:
   return %r : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} {{.*}}* @alloc_on_heap
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} {{.*}}* @alloc_on_heap
 // CHECK:      [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S{{[a-zA-Z0-9_]+}}Ma"([[INT]] 0)
 // CHECK:      [[M:%[0-9]+]] = extractvalue %swift.metadata_response [[TMP]], 0
 // CHECK-NEXT: [[O:%[0-9]+]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* [[M]], i64 28, i64 7)
@@ -47,7 +47,7 @@ bb0:
   return %o1 : $TestClass
 }
 
-// CHECK-LABEL: define{{( protected)?}} {{.*}}* @alloc_3_on_heap
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} {{.*}}* @alloc_3_on_heap
 // CHECK:      [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S{{[a-zA-Z0-9_]+}}CMa"([[INT]] 0)
 // CHECK:      [[M:%[0-9]+]] = extractvalue %swift.metadata_response [[TMP]], 0
 // CHECK-NEXT: [[O:%[0-9]+]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* [[M]], i64 40, i64 7)
@@ -62,7 +62,7 @@ bb0:
   return %o1 : $TestClass
 }
 
-// CHECK-LABEL: define{{( protected)?}} {{.*}}* @alloc_non_const_count
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} {{.*}}* @alloc_non_const_count
 // CHECK:      [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S{{[a-zA-Z0-9_]+}}Ma"([[INT]] 0)
 // CHECK:      [[M:%[0-9]+]] = extractvalue %swift.metadata_response [[TMP]], 0
 // CHECK-NEXT: [[S:%[0-9]+]] = mul i64 4, %0
@@ -76,7 +76,7 @@ bb0(%c : $Builtin.Word):
   return %o1 : $TestClass
 }
 
-// CHECK-LABEL: define{{( protected)?}} {{.*}}* @alloc_2_non_const_count
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} {{.*}}* @alloc_2_non_const_count
 // CHECK:      [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S{{[a-zA-Z0-9_]+}}Ma"([[INT]] 0)
 // CHECK:      [[M:%[0-9]+]] = extractvalue %swift.metadata_response [[TMP]], 0
 // CHECK-NEXT: [[S1:%[0-9]+]] = mul i64 1, %0
@@ -94,7 +94,7 @@ bb0(%c1 : $Builtin.Word, %c2 : $Builtin.Word):
   return %o1 : $TestClass
 }
 
-// CHECK-LABEL: define{{( protected)?}} {{.*}}* @alloc_generic
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} {{.*}}* @alloc_generic
 // CHECK:      [[S1:%[0-9]+]] = add i64 17, %flags.alignmentMask
 // CHECK-NEXT: [[S2:%[0-9]+]] = xor i64 %flags.alignmentMask, -1
 // CHECK-NEXT: [[S3:%[0-9]+]] = and i64 [[S1]], [[S2]]
@@ -110,7 +110,7 @@ bb0(%0 : $Builtin.Word, %1 : $@thick T.Type):
   return %5 : $TestClass
 }
 
-// CHECK-LABEL: define{{( protected)?}} {{.*}}* @alloc_dynamic
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} {{.*}}* @alloc_dynamic
 // CHECK:      [[BYTE_PTR:%[0-9]+]] = bitcast %swift.type* %0 to i8*
 // CHECK-NEXT: [[SIZE_ADDR:%[0-9]+]] = getelementptr inbounds i8, i8* [[BYTE_PTR]], i32 48
 // CHECK-NEXT: [[INT_PTR:%[0-9]+]] = bitcast i8* [[SIZE_ADDR]] to i32*
@@ -134,7 +134,7 @@ bb0(%0 : $@thick TestClass.Type):
   return %o : $TestClass
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i8* @project_tail_byte
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @project_tail_byte
 // CHECK: getelementptr inbounds i8, i8* %{{[0-9]+}}, i64 17
 // CHECK: ret
 sil @project_tail_byte : $@convention(thin) (TestClass) -> Builtin.RawPointer {
@@ -144,7 +144,7 @@ bb0(%0 : $TestClass):
   return %p : $Builtin.RawPointer
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @project_tail_int
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @project_tail_int
 // CHECK: [[S:%[0-9]+]] = getelementptr inbounds i8, i8* %{{[0-9]+}}, i64 20
 // CHECK: bitcast i8* [[S]] to %Ts5Int32V*
 // CHECK: ret
@@ -156,7 +156,7 @@ bb0(%0 : $TestClass, %1 : $Int32):
   return %r : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i8* @project_tail_generic
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @project_tail_generic
 // CHECK:      [[S1:%[0-9]+]] = add i64 17, %flags.alignmentMask
 // CHECK-NEXT: [[S2:%[0-9]+]] = xor i64 %flags.alignmentMask, -1
 // CHECK-NEXT: [[S3:%[0-9]+]] = and i64 [[S1]], [[S2]]
@@ -175,7 +175,7 @@ struct Str<T> {
   var t: T
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i8* @project_tail_generic_struct
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @project_tail_generic_struct
 // CHECK:      [[S1:%[0-9]+]] = add i64 17, %flags.alignmentMask
 // CHECK-NEXT: [[S2:%[0-9]+]] = xor i64 %flags.alignmentMask, -1
 // CHECK-NEXT: [[S3:%[0-9]+]] = and i64 [[S1]], [[S2]]
@@ -190,7 +190,7 @@ bb0(%0 : $TestClass, %1 : $@thick T.Type):
   return %p : $Builtin.RawPointer
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @project_tail_index_byte_to_int
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @project_tail_index_byte_to_int
 // CHECK:      [[S1:%[0-9]+]] = bitcast i8* %0 to %Ts4Int8V*
 // CHECK-NEXT: [[S2:%[0-9]+]] = getelementptr inbounds %Ts4Int8V, %Ts4Int8V* [[S1]], i64 2
 // CHECK-NEXT: [[S3:%[0-9]+]] = ptrtoint %Ts4Int8V* [[S2]] to i64
@@ -209,7 +209,7 @@ bb0(%0 : $Builtin.RawPointer, %1 : $Int32):
   return %r : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i8* @project_tail_index_generic_struct
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @project_tail_index_generic_struct
 // CHECK: call swiftcc %swift.metadata_response @{{.*Str.*}}([[INT]] 0, %swift.type* %T)
 // CHECK: load
 // CHECK: and
@@ -231,7 +231,7 @@ class EmptyClass {
 
 sil_vtable EmptyClass {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i8 @test_align_1_int8
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @test_align_1_int8
 // CHECK: load i8, i8* %{{.*}}, align 1
 // CHECK: ret
 sil @test_align_1_int8 : $@convention(thin) (EmptyClass) -> Int8 {
@@ -243,7 +243,7 @@ bb0(%0 : $EmptyClass):
   return %l : $Int8
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i8 @test_align_2_int8
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @test_align_2_int8
 // CHECK: load i8, i8* %{{.*}}, align 2
 // CHECK: ret
 sil @test_align_2_int8 : $@convention(thin) (EmptyClass) -> Int8 {
@@ -255,7 +255,7 @@ bb0(%0 : $EmptyClass):
   return %l : $Int8
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i32 @test_align_int32
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i32 @test_align_int32
 // CHECK: load i32, i32* %{{.*}}, align 4
 // CHECK: ret
 sil @test_align_int32 : $@convention(thin) (EmptyClass, Builtin.Word) -> Int32 {

--- a/test/IRGen/tsan_instrumentation.sil
+++ b/test/IRGen/tsan_instrumentation.sil
@@ -17,7 +17,7 @@ sil_global hidden @$S20tsan_instrumentation1gSiv : $Int
 // compiler-rt instrumentation. Eventually we will add a specific
 // instrumentation callback for tsan inout accesses to compiler-rt.
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S20tsan_instrumentation11inoutAccessyyF"()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S20tsan_instrumentation11inoutAccessyyF"()
 // foo() -> ()
 sil @$S20tsan_instrumentation11inoutAccessyyF : $@convention(thin) () -> () {
 bb0:

--- a/test/IRGen/typed_boxes.sil
+++ b/test/IRGen/typed_boxes.sil
@@ -4,7 +4,7 @@ sil_stage canonical
 import Builtin
 
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @pod_box_8_8_a
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @pod_box_8_8_a
 sil @pod_box_8_8_a : $@convention(thin) () -> () {
 entry:
   // CHECK: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* {{.*}} [[POD_8_8_METADATA:@metadata[0-9.]*]], i32 0, i32 2), [[WORD:i[0-9]+]] [[POD_8_8_SIZE:[0-9]+]], [[WORD]] 7)
@@ -18,7 +18,7 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @pod_box_8_8_b
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @pod_box_8_8_b
 sil @pod_box_8_8_b : $@convention(thin) () -> () {
 entry:
   // CHECK: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* {{.*}} [[POD_8_8_METADATA]], i32 0, i32 2), [[WORD]] [[POD_8_8_SIZE]], [[WORD]] 7)
@@ -37,7 +37,7 @@ struct OverAligned {
   var x, y, z, w: Builtin.Int64
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @pod_box_32_32
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @pod_box_32_32
 sil @pod_box_32_32 : $@convention(thin) () -> () {
 entry:
   // CHECK: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* {{.*}} [[POD_32_32_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD]] 64, [[WORD]] 31)
@@ -58,7 +58,7 @@ sil_vtable C {}
 class D {}
 sil_vtable D {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @rc_box_a
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @rc_box_a
 sil @rc_box_a : $@convention(thin) () -> () {
 entry:
   // CHECK-32: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* {{.*}} [[NATIVE_RC_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD]] 12, [[WORD]] 3)
@@ -70,7 +70,7 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @rc_box_b
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @rc_box_b
 sil @rc_box_b : $@convention(thin) () -> () {
 entry:
   // TODO: Should reuse metadata
@@ -83,7 +83,7 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @unknown_rc_box
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @unknown_rc_box
 sil @unknown_rc_box : $@convention(thin) () -> () {
 entry:
   // CHECK-32: [[BOX:%.*]] = call noalias %swift.refcounted* @swift_allocObject(%swift.type* {{.*}} [[UNKNOWN_RC_METADATA:@metadata[0-9.]*]], {{.*}} [[WORD]] 12, [[WORD]] 3)
@@ -117,7 +117,7 @@ struct Dyn<T> {
 sil @take_dyn : $@convention(thin) <T> (@in Dyn<T>) -> ()
 sil @take_t : $@convention(thin) <T> (@in T) -> ()
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @dyn_box_a
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dyn_box_a
 sil @dyn_box_a : $@convention(thin) <T> () -> () {
 entry:
   // CHECK: [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S11typed_boxes3DynVMa"([[INT]] 0, %swift.type* %T)
@@ -136,7 +136,7 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @dyn_box_b
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dyn_box_b
 sil @dyn_box_b : $@convention(thin) <T> () -> () {
 entry:
   // CHECK: [[ALLOC:%.*]] = call swiftcc { %swift.refcounted*, %swift.opaque* } @swift_allocBox(%swift.type* %T)
@@ -152,7 +152,7 @@ entry:
   return undef : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i64 @proj_box
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i64 @proj_box
 sil @proj_box : $@convention(thin) (<τ_0_0> { var τ_0_0 } <Builtin.Int64>) -> Builtin.Int64 {
 entry(%0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int64>):
   // CHECK: [[BOX_RAW:%.*]] = bitcast %swift.refcounted* %0 to [[POD_8_8_LAYOUT:<\{ %swift.refcounted, \[8 x i8\] \}>]]*
@@ -165,7 +165,7 @@ entry(%0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int64>):
   return %l : $Builtin.Int64
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @dyn_proj_box_a
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dyn_proj_box_a
 sil @dyn_proj_box_a : $@convention(thin) <T> (<τ_0_0> { var τ_0_0 } <Dyn<T>>) -> () {
 entry(%0 : $<τ_0_0> { var τ_0_0 } <Dyn<T>>):
   // CHECK: [[PTR:%.*]] = call %swift.opaque* @swift_projectBox(%swift.refcounted* %0)
@@ -178,7 +178,7 @@ entry(%0 : $<τ_0_0> { var τ_0_0 } <Dyn<T>>):
 }
 
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @dyn_proj_box_b
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dyn_proj_box_b
 sil @dyn_proj_box_b : $@convention(thin) <T> (<τ_0_0> { var τ_0_0 } <T>) -> () {
 entry(%0 : $<τ_0_0> { var τ_0_0 } <T>):
   // CHECK: [[PTR:%.*]] = call %swift.opaque* @swift_projectBox(%swift.refcounted* %0)

--- a/test/IRGen/unconditional_checked_cast.sil
+++ b/test/IRGen/unconditional_checked_cast.sil
@@ -10,7 +10,7 @@ sil_vtable C {}
 class D : C {}
 sil_vtable D {}
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @downcast_test(%T26unconditional_checked_cast1DC** noalias nocapture sret, %T26unconditional_checked_cast1CC** nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @downcast_test(%T26unconditional_checked_cast1DC** noalias nocapture sret, %T26unconditional_checked_cast1CC** nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK: entry:
 // CHECK-NEXT: [[INPUTPTR:%[0-9]+]] = load %T26unconditional_checked_cast1CC*, %T26unconditional_checked_cast1CC** [[INPUTPTRPTR:%[0-9]+]], align 8
 // CHECK-NEXT: [[I8INPUTPTR:%[0-9]+]] = bitcast %T26unconditional_checked_cast1CC* [[INPUTPTR]] to i8*

--- a/test/IRGen/undef.sil
+++ b/test/IRGen/undef.sil
@@ -4,7 +4,7 @@
 
 import Builtin
 
-// CHECK: define{{( protected)?}} swiftcc void @undefined() {{.*}} {
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @undefined() {{.*}} {
 // CHECK: entry:
 // CHECK:   store i64 undef, i64* undef, align 8
 // CHECK:   store i8 undef, i8* undef, align 8

--- a/test/IRGen/unowned.sil
+++ b/test/IRGen/unowned.sil
@@ -30,7 +30,7 @@ bb0(%0 : $@sil_unowned C):
   %3 = tuple ()
   return %3 : $()
 }
-// CHECK:    define{{( protected)?}} swiftcc void @test_weak_rr_class([[C]]*) {{.*}} {
+// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_weak_rr_class([[C]]*) {{.*}} {
 // CHECK:      call [[C]]* bitcast ([[REF]]* ([[REF]]*)* @swift_unownedRetain to [[C]]* ([[C]]*)*)([[C]]* returned %0)
 // CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_unownedRelease to void ([[C]]*)*)([[C]]* %0)
 // CHECK-NEXT: ret void
@@ -42,7 +42,7 @@ bb0(%0 : $@sil_unowned P):
   %3 = tuple ()
   return %3 : $()
 }
-// CHECK:    define{{( protected)?}} swiftcc void @test_weak_rr_proto(%swift.refcounted*, i8**) {{.*}} {
+// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_weak_rr_proto(%swift.refcounted*, i8**) {{.*}} {
 // CHECK:      call %swift.refcounted* @swift_unownedRetain(%swift.refcounted* returned %0)
 // CHECK:      call void @swift_unownedRelease(%swift.refcounted* %0)
 // CHECK-NEXT: ret void

--- a/test/IRGen/unowned_objc.sil
+++ b/test/IRGen/unowned_objc.sil
@@ -36,12 +36,12 @@ bb0(%0 : $@sil_unowned C):
   %3 = tuple ()
   return %3 : $()
 }
-// CHECK:    define{{( protected)?}} swiftcc void @test_weak_rr_class([[C]]*) {{.*}} {
+// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_weak_rr_class([[C]]*) {{.*}} {
 // CHECK:      call [[C]]* bitcast ([[REF]]* ([[REF]]*)* @swift_unownedRetain to [[C]]* ([[C]]*)*)([[C]]* returned %0)
 // CHECK-NEXT: call void bitcast (void ([[REF]]*)* @swift_unownedRelease to void ([[C]]*)*)([[C]]* %0)
 // CHECK-NEXT: ret void
 
-// CHECK:    define{{( protected)?}} swiftcc void @test_unknown_unowned_copies([[UNKNOWN]]*, i8**, [[UNKNOWN]]*, i8**)
+// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_unknown_unowned_copies([[UNKNOWN]]*, i8**, [[UNKNOWN]]*, i8**)
 sil @test_unknown_unowned_copies : $@convention(thin) (@owned P, @owned P) -> () {
 bb0(%p : $P, %q : $P):
 

--- a/test/IRGen/unused.sil
+++ b/test/IRGen/unused.sil
@@ -50,7 +50,7 @@ bb0:
 
 // CHECK: define linkonce_odr hidden swiftcc void @qux()
 // CHECK: define hidden swiftcc void @fred()
-// CHECK: define{{( protected)?}} swiftcc void @frieda()
+// CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @frieda()
 
 // NEGATIVE-NOT: @foo
 // NEGATIVE-NOT: @bar

--- a/test/IRGen/upcast.sil
+++ b/test/IRGen/upcast.sil
@@ -2,7 +2,7 @@
 
 // Make sure that we are able to lower upcast addresses.
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @upcast_test(%T6upcast1DC** nocapture dereferenceable({{.*}})) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @upcast_test(%T6upcast1DC** nocapture dereferenceable({{.*}})) {{.*}} {
 // CHECK: entry:
 // CHECK-NEXT: bitcast %T6upcast1DC** {{%[0-0]+}} to %T6upcast1CC**
 // CHECK-NEXT: ret void

--- a/test/IRGen/value_buffers.sil
+++ b/test/IRGen/value_buffers.sil
@@ -18,7 +18,7 @@ entry(%b : $*Builtin.UnsafeValueBuffer, %v : $Int):
   %r = tuple ()
   return %r : $()
 }
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @alloc_small([24 x i8]* nocapture dereferenceable({{.*}}), i64)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @alloc_small([24 x i8]* nocapture dereferenceable({{.*}}), i64)
 // CHECK-NEXT: entry:
 // CHECK-NEXT: [[T0:%.*]] = bitcast [24 x i8]* %0 to %TSi*
 // CHECK-NEXT: [[T2:%.*]] = getelementptr inbounds %TSi, %TSi* [[T0]], i32 0, i32 0
@@ -32,7 +32,7 @@ entry(%b : $*Builtin.UnsafeValueBuffer, %v : $Int):
   %r = tuple ()
   return %r : $()
 }
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @project_small([24 x i8]* nocapture dereferenceable({{.*}}), i64)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @project_small([24 x i8]* nocapture dereferenceable({{.*}}), i64)
 // CHECK-NEXT: entry:
 // CHECK-NEXT: [[T0:%.*]] = bitcast [24 x i8]* %0 to %TSi*
 // CHECK-NEXT: [[T2:%.*]] = getelementptr inbounds %TSi, %TSi* [[T0]], i32 0, i32 0
@@ -45,7 +45,7 @@ entry(%b : $*Builtin.UnsafeValueBuffer):
   %r = tuple ()
   return %r : $()
 }
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @dealloc_small([24 x i8]* nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dealloc_small([24 x i8]* nocapture dereferenceable({{.*}}))
 // CHECK-NEXT: entry:
 // CHECK-NEXT: ret void
 
@@ -56,7 +56,7 @@ entry(%b : $*Builtin.UnsafeValueBuffer, %v : $BigStruct):
   %r = tuple ()
   return %r : $()
 }
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @alloc_big([24 x i8]* nocapture dereferenceable({{.*}}), %T13value_buffers9BigStructV* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @alloc_big([24 x i8]* nocapture dereferenceable({{.*}}), %T13value_buffers9BigStructV* noalias nocapture dereferenceable({{.*}}))
 // CHECK-NEXT: entry:
 // CHECK-NEXT: [[T0:%.*]] = call noalias i8* @swift_slowAlloc(i64 48, i64 7)
 // CHECK-NEXT: [[T1:%.*]] = bitcast [24 x i8]* %0 to i8**
@@ -74,7 +74,7 @@ entry(%b : $*Builtin.UnsafeValueBuffer, %v : $BigStruct):
   %r = tuple ()
   return %r : $()
 }
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @project_big([24 x i8]* nocapture dereferenceable({{.*}}), %T13value_buffers9BigStructV* noalias nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @project_big([24 x i8]* nocapture dereferenceable({{.*}}), %T13value_buffers9BigStructV* noalias nocapture dereferenceable({{.*}}))
 // CHECK-NEXT: entry:
 // CHECK-NEXT: [[T0:%.*]] = bitcast [24 x i8]* %0 to %T13value_buffers9BigStructV**
 // CHECK-NEXT: [[ADDR:%.*]] = load %T13value_buffers9BigStructV*, %T13value_buffers9BigStructV** [[T0]], align 8
@@ -89,7 +89,7 @@ entry(%b : $*Builtin.UnsafeValueBuffer):
   %r = tuple ()
   return %r : $()
 }
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @dealloc_big([24 x i8]* nocapture dereferenceable({{.*}}))
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @dealloc_big([24 x i8]* nocapture dereferenceable({{.*}}))
 // CHECK-NEXT: entry:
 // CHECK-NEXT: [[T0:%.*]] = bitcast [24 x i8]* %0 to i8**
 // CHECK-NEXT: [[ADDR:%.*]] = load i8*, i8** [[T0]], align 8

--- a/test/IRGen/weak.sil
+++ b/test/IRGen/weak.sil
@@ -42,7 +42,7 @@ bb0(%0 : $*A, %1 : $Optional<C>):
   %4 = tuple ()
   return %4 : $()
 }
-// CHECK:    define{{( protected)?}} swiftcc void @test_weak_load_store([[A]]* nocapture dereferenceable({{.*}}), i64) {{.*}} {
+// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_weak_load_store([[A]]* nocapture dereferenceable({{.*}}), i64) {{.*}} {
 // CHECK:      [[X:%.*]] = getelementptr inbounds [[A]], [[A]]* %0, i32 0, i32 0
 // CHECK-NEXT: [[T0:%.*]] = call [[C]]* bitcast ([[REF]]* ([[WEAK]]*)* @swift_weakLoadStrong to [[C]]* ([[WEAK]]*)*)([[WEAK]]* [[X]])
 // CHECK-NEXT: %3 = ptrtoint  %T4weak1CC* %2 to i64
@@ -65,7 +65,7 @@ bb0(%0 : $*B, %1 : $Optional<P>):
   %4 = tuple ()
   return %4 : $()
 }
-// CHECK:    define{{( protected)?}} swiftcc void @test_weak_load_store_proto([[B]]* nocapture dereferenceable({{.*}}), i64, i64)
+// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_weak_load_store_proto([[B]]* nocapture dereferenceable({{.*}}), i64, i64)
 // CHECK:      [[X:%.*]] = getelementptr inbounds [[B]], [[B]]* %0, i32 0, i32 0
 // CHECK-NEXT: [[T0:%.*]] = getelementptr inbounds { [[WEAK]], i8** }, { [[WEAK]], i8** }* [[X]], i32 0, i32 0
 // CHECK-NEXT: [[T1:%.*]] = call [[UNKNOWN]]* @swift_unknownWeakLoadStrong([[WEAK]]* [[T0]])
@@ -88,7 +88,7 @@ bb0(%0 : $Optional<P>):
   %4 = tuple ()
   return %4 : $()
 }
-// CHECK:    define{{( protected)?}} swiftcc void @test_weak_alloc_stack(i64, i64)
+// CHECK:    define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_weak_alloc_stack(i64, i64)
 // CHECK:      [[X:%.*]] = alloca { [[WEAK]], i8** }, align 8
 // CHECK: [[TMPOBJ:%.*]] = inttoptr {{.*}} to %objc_object*
 // CHECK: [[TMPTAB:%.*]] = inttoptr {{.*}} to i8**

--- a/test/IRGen/weak_class_protocol.sil
+++ b/test/IRGen/weak_class_protocol.sil
@@ -6,7 +6,7 @@ import Swift
 
 protocol Foo: class { }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @store_weak({ %swift.weak, i8** }* noalias nocapture sret, i64, i64) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @store_weak({ %swift.weak, i8** }* noalias nocapture sret, i64, i64) {{.*}} {
 // CHECK:       entry:
 // CHECK-objc:    [[INSTANCE:%.*]] = inttoptr i64 %1 to %objc_object*
 // CHECK-native:  [[INSTANCE:%.*]] = inttoptr i64 %1 to %swift.refcounted*

--- a/test/IRGen/witness_method.sil
+++ b/test/IRGen/witness_method.sil
@@ -9,7 +9,7 @@ protocol DefCon {
 }
 
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @defcon(%swift.opaque* noalias nocapture sret, %swift.type*, %swift.type* %T, i8** %T.DefCon) {{.*}} {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @defcon(%swift.opaque* noalias nocapture sret, %swift.type*, %swift.type* %T, i8** %T.DefCon) {{.*}} {
 sil @defcon : $@convention(thin) <T: DefCon> (@thick T.Type) -> @out T {
 entry(%0: $*T, %1: $@thick T.Type):
 
@@ -33,7 +33,7 @@ struct ImplementsDerived : Derived {
   func foo() {}
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testInheritedConformance
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testInheritedConformance
 sil @testInheritedConformance : $@convention(thin) (@in ImplementsDerived) -> () {
 entry(%0: $*ImplementsDerived):
   // CHECK: [[WITNESS:%.*]] = load i8*, i8** getelementptr inbounds (i8*, i8** @"$S14witness_method17ImplementsDerivedVAA4BaseAAWP", i32 1)
@@ -62,7 +62,7 @@ struct SyncUp<Deliverable> : Synergy {
   }
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testGenericWitnessMethod(%swift.opaque* noalias nocapture sret, %T14witness_method6SyncUpV* noalias nocapture, %swift.type* %T)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testGenericWitnessMethod(%swift.opaque* noalias nocapture sret, %T14witness_method6SyncUpV* noalias nocapture, %swift.type* %T)
 // CHECK: entry:
 // CHECK:   [[TMP:%.*]] = call swiftcc %swift.metadata_response @"$S14witness_method6SyncUpVMa"([[INT]] 0, %swift.type* %T)
 // CHECK:   [[METADATA:%.*]] = extractvalue %swift.metadata_response [[TMP]], 0
@@ -89,7 +89,7 @@ protocol Strategy {
   func disrupt() -> GrowthHack
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testArchetypeWitnessMethod(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture, %swift.type* %T, i8** %T.Strategy)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testArchetypeWitnessMethod(%swift.opaque* noalias nocapture sret, %swift.opaque* noalias nocapture, %swift.type* %T, i8** %T.Strategy)
 // CHECK: entry:
 // CHECK:   [[WITNESS_ADDR:%.*]] = getelementptr inbounds i8*, i8** %T.Strategy, i32 3
 // CHECK:   [[WITNESS_FN:%.*]] = load i8*, i8** [[WITNESS_ADDR]]
@@ -113,7 +113,7 @@ class TPSReport<CoverSheet> : Strategy {
   func disrupt() -> GrowthHack
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @classArchetypeWitnessMethod(%T14witness_method9TPSReportC** noalias nocapture swiftself dereferenceable({{4|8}}), %swift.type* %Self, i8** %SelfWitnessTable)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @classArchetypeWitnessMethod(%T14witness_method9TPSReportC** noalias nocapture swiftself dereferenceable({{4|8}}), %swift.type* %Self, i8** %SelfWitnessTable)
 
 sil @classArchetypeWitnessMethod : $@convention(witness_method: Strategy) <T><CoverSheet where T : TPSReport<CoverSheet>> (@in_guaranteed T) -> () {
 entry(%self : $*T):
@@ -121,7 +121,7 @@ entry(%self : $*T):
   return %z : $()
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @testClassArchetypeWitnessMethod(%T14witness_method7ToVideoV* noalias nocapture sret, %T14witness_method9TPSReportC** noalias nocapture dereferenceable({{4|8}}), %swift.type* %T, %swift.type* %CoverSheet)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testClassArchetypeWitnessMethod(%T14witness_method7ToVideoV* noalias nocapture sret, %T14witness_method9TPSReportC** noalias nocapture dereferenceable({{4|8}}), %swift.type* %T, %swift.type* %CoverSheet)
 // CHECK: entry:
 // CHECK:  [[WITNESS_FN:%.*]] = load i8*, i8** getelementptr inbounds (i8*, i8** @"$S14witness_method9TPSReportCyxGAA8StrategyAAWP", i32 3)
 // CHECK:  [[WITNESS:%.*]] = bitcast i8* [[WITNESS_FN]] to void (%swift.opaque*, %swift.opaque*, %swift.type*, i8**)*

--- a/test/IRGen/witness_method_phi.sil
+++ b/test/IRGen/witness_method_phi.sil
@@ -3,7 +3,7 @@
 sil_stage canonical
 
 protocol P { func foo() }
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @phi_witness_method(%swift.type* %T, i8** %T.P) #0 {
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @phi_witness_method(%swift.type* %T, i8** %T.P) #0 {
 sil @phi_witness_method : $@convention(thin) <T: P> () -> () {
 entry:
   // CHECK: [[T0_GEP:%.*]] = getelementptr inbounds i8*, i8** %T.P, i32 1

--- a/test/IRGen/yield_once.sil
+++ b/test/IRGen/yield_once.sil
@@ -4,7 +4,7 @@ import Builtin
 
 sil @marker : $(Builtin.Int32) -> ()
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc i8* @test_simple
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i8* @test_simple
 // CHECK-32-SAME:  i8* noalias dereferenceable([[BUFFER_SIZE:16]]))
 // CHECK-64-SAME:  (i8* noalias dereferenceable([[BUFFER_SIZE:32]]))
 sil @test_simple : $@yield_once () -> () {
@@ -42,10 +42,10 @@ unwind:
   // CHECK-NEXT:    unreachable
 }
 
-// CHECK-LABEL:     declare{{( protected)?}} swiftcc void @"$SIet_TC"
+// CHECK-LABEL:     declare{{( dllimport)?}}{{( protected)?}} swiftcc void @"$SIet_TC"
 // CHECK-SAME:      (i8* noalias dereferenceable([[BUFFER_SIZE]]), i1)
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @test_simple_call(i1)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_simple_call(i1)
 sil @test_simple_call : $(Builtin.Int1) -> () {
 entry(%flag : $Builtin.Int1):
   //   Allocate the buffer.

--- a/test/IRGen/yield_once_big.sil
+++ b/test/IRGen/yield_once_big.sil
@@ -27,7 +27,7 @@ struct Big<T: SomeClass> {
 
 sil @make_big : $<T: SomeClass> () -> (@owned Big<T>)
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %T14yield_once_big3BigV* } @test_simple
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %T14yield_once_big3BigV* } @test_simple
 // CHECK-32-SAME:  (i8* noalias dereferenceable([[BUFFER_SIZE:16]]), %swift.type* %C)
 // CHECK-64-SAME:  (i8* noalias dereferenceable([[BUFFER_SIZE:32]]), %swift.type* %C)
 sil @test_simple : $@yield_once <C: SomeClass> () -> (@yields @owned Big<C>) {
@@ -85,10 +85,10 @@ unwind:
   // CHECK-NEXT:    unreachable
 }
 
-// CHECK-LABEL:     declare{{( protected)?}} swiftcc void @"$S14yield_once_big9SomeClassCRbzlIet_TC"
+// CHECK-LABEL:     declare{{( dllimport)?}}{{( protected)?}} swiftcc void @"$S14yield_once_big9SomeClassCRbzlIet_TC"
 // CHECK-SAME:      (i8* noalias dereferenceable([[BUFFER_SIZE]]), i1)
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @test_simple_call(i1)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_simple_call(i1)
 sil @test_simple_call : $(Builtin.Int1) -> () {
 entry(%flag : $Builtin.Int1):
   //   Allocate the buffer.

--- a/test/IRGen/yield_once_biggish.sil
+++ b/test/IRGen/yield_once_biggish.sil
@@ -28,7 +28,7 @@ struct Biggish<T: SomeClass> {
 
 sil @make_biggish : $<T: SomeClass> () -> (@owned Biggish<T>)
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %T18yield_once_biggish9SomeClassC*, %T18yield_once_biggish9SomeClassC*, { %T18yield_once_biggish9SomeClassC*, %T18yield_once_biggish9SomeClassC* }* } @test_simple
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %T18yield_once_biggish9SomeClassC*, %T18yield_once_biggish9SomeClassC*, { %T18yield_once_biggish9SomeClassC*, %T18yield_once_biggish9SomeClassC* }* } @test_simple
 // CHECK-32-SAME:  (i8* noalias dereferenceable([[BUFFER_SIZE:16]]), %swift.type* %C)
 // CHECK-64-SAME:  (i8* noalias dereferenceable([[BUFFER_SIZE:32]]), %swift.type* %C)
 sil @test_simple : $@yield_once <C: SomeClass> () -> (@yields @owned Biggish<C>) {
@@ -94,10 +94,10 @@ unwind:
   // CHECK-NEXT:    unreachable
 }
 
-// CHECK-LABEL:     declare{{( protected)?}} swiftcc void @"$S18yield_once_biggish9SomeClassCRbzlIet_TC"
+// CHECK-LABEL:     declare{{( dllimport)?}}{{( protected)?}} swiftcc void @"$S18yield_once_biggish9SomeClassCRbzlIet_TC"
 // CHECK-SAME:      (i8* noalias dereferenceable([[BUFFER_SIZE]]), i1)
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @test_simple_call(i1)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_simple_call(i1)
 sil @test_simple_call : $(Builtin.Int1) -> () {
 entry(%flag : $Builtin.Int1):
   //   Allocate the buffer.

--- a/test/IRGen/yield_once_indirect.sil
+++ b/test/IRGen/yield_once_indirect.sil
@@ -19,7 +19,7 @@ struct Indirect<T: AnyObject> {
 
 sil @make_indirect : $<T: SomeClass> () -> (@out Indirect<T>)
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc { i8*, %T19yield_once_indirect8IndirectV* } @test_simple
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %T19yield_once_indirect8IndirectV* } @test_simple
 // CHECK-32-SAME:  (i8* noalias dereferenceable([[BUFFER_SIZE:16]]), %swift.type* %C)
 // CHECK-64-SAME:  (i8* noalias dereferenceable([[BUFFER_SIZE:32]]), %swift.type* %C)
 sil @test_simple : $@yield_once <C: SomeClass> () -> (@yields @in Indirect<C>) {
@@ -83,10 +83,10 @@ unwind:
   // CHECK-NEXT:    unreachable
 }
 
-// CHECK-LABEL:     declare{{( protected)?}} swiftcc void @"$S19yield_once_indirect9SomeClassCRbzlIet_TC"
+// CHECK-LABEL:     declare{{( dllimport)?}}{{( protected)?}} swiftcc void @"$S19yield_once_indirect9SomeClassCRbzlIet_TC"
 // CHECK-SAME:      (i8* noalias dereferenceable([[BUFFER_SIZE]]), i1)
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @test_simple_call(i1)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_simple_call(i1)
 sil @test_simple_call : $(Builtin.Int1) -> () {
 entry(%flag : $Builtin.Int1):
   //   Allocate the buffer.

--- a/test/IRGen/zombies.swift
+++ b/test/IRGen/zombies.swift
@@ -8,5 +8,5 @@ class C {
   init(i: Int) { self.i = i }
 }
 
-// CHECK: @"$S7zombies1CC1i33_{{.*}}vg" = hidden alias void (), void ()* @_swift_dead_method_stub
+// CHECK: @"$S7zombies1CC1i33_{{.*}}vg" = hidden {{(dllexport )?}}alias void (), void ()* @_swift_dead_method_stub
 // CHECK: define internal void @_swift_dead_method_stub()

--- a/test/Inputs/conditional_conformance_basic_conformances.swift
+++ b/test/Inputs/conditional_conformance_basic_conformances.swift
@@ -47,7 +47,7 @@ extension Single: P1 where A: P2 {
 public func single_generic<T: P2>(_: T.Type) {
   takes_p1(Single<T>.self)
 }
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S42conditional_conformance_basic_conformances14single_genericyyxmAA2P2RzlF"(%swift.type*, %swift.type* %T, i8** %T.P2)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S42conditional_conformance_basic_conformances14single_genericyyxmAA2P2RzlF"(%swift.type*, %swift.type* %T, i8** %T.P2)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    %conditional.requirement.buffer = alloca [1 x i8**], align 8
 // CHECK-NEXT:    [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S42conditional_conformance_basic_conformances6SingleVMa"(i64 0, %swift.type* %T)
@@ -62,7 +62,7 @@ public func single_generic<T: P2>(_: T.Type) {
 
 // Witness table accessor for Single : P1
 
-// CHECK-LABEL: define{{( protected)?}} i8** @"$S42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWa"(%swift.type*, i8***)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} i8** @"$S42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWa"(%swift.type*, i8***)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S42conditional_conformance_basic_conformances6SingleVyxGAA2P1A2A2P2RzlWG", %swift.type* %0, i8*** %1)
 // CHECK-NEXT:    ret i8** [[TABLE]]
@@ -72,7 +72,7 @@ public func single_generic<T: P2>(_: T.Type) {
 public func single_concrete() {
   takes_p1(Single<IsP2>.self)
 }
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S42conditional_conformance_basic_conformances15single_concreteyyF"()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S42conditional_conformance_basic_conformances15single_concreteyyF"()
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S42conditional_conformance_basic_conformances6SingleVyAA4IsP2VGMa"(i64 0)
 // CHECK-NEXT:    [[Single_TYPE:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
@@ -168,7 +168,7 @@ extension Double: P1 where B: P2, C: P3 {
 public func double_generic_generic<U: P2, V: P3>(_: U.Type, _: V.Type) {
   takes_p1(Double<U, V>.self)
 }
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S42conditional_conformance_basic_conformances015double_generic_F0yyxm_q_mtAA2P2RzAA2P3R_r0_lF"(%swift.type*, %swift.type*, %swift.type* %U, %swift.type* %V, i8** %U.P2, i8** %V.P3)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S42conditional_conformance_basic_conformances015double_generic_F0yyxm_q_mtAA2P2RzAA2P3R_r0_lF"(%swift.type*, %swift.type*, %swift.type* %U, %swift.type* %V, i8** %U.P2, i8** %V.P3)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    %conditional.requirement.buffer = alloca [2 x i8**], align 8
 // CHECK-NEXT:    [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S42conditional_conformance_basic_conformances6DoubleVMa"(i64 0, %swift.type* %U, %swift.type* %V)
@@ -187,7 +187,7 @@ public func double_generic_generic<U: P2, V: P3>(_: U.Type, _: V.Type) {
 
 // witness table accessor for Double : P1
 
-// CHECK-LABEL: define{{( protected)?}} i8** @"$S42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlWa"(%swift.type*, i8***)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} i8** @"$S42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlWa"(%swift.type*, i8***)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[TABLE:%.*]] = call i8** @swift_getGenericWitnessTable(%swift.generic_witness_table_cache* @"$S42conditional_conformance_basic_conformances6DoubleVyxq_GAA2P1A2A2P2RzAA2P3R_rlWG", %swift.type* %0, i8*** %1)
 // CHECK-NEXT:    ret i8** [[TABLE]]
@@ -197,7 +197,7 @@ public func double_generic_generic<U: P2, V: P3>(_: U.Type, _: V.Type) {
 public func double_generic_concrete<X: P2>(_: X.Type) {
   takes_p1(Double<X, IsP3>.self)
 }
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S42conditional_conformance_basic_conformances23double_generic_concreteyyxmAA2P2RzlF"(%swift.type*, %swift.type* %X, i8** %X.P2)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S42conditional_conformance_basic_conformances23double_generic_concreteyyxmAA2P2RzlF"(%swift.type*, %swift.type* %X, i8** %X.P2)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    %conditional.requirement.buffer = alloca [2 x i8**], align 8
 // CHECK-NEXT:    [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S42conditional_conformance_basic_conformances6DoubleVMa"(i64 0, %swift.type* %X, %swift.type* bitcast (i64* getelementptr inbounds (<{ i8**, i64, <{ {{.*}} }>* }>, <{ {{.*}} }>* @"$S42conditional_conformance_basic_conformances4IsP3VMf", i32 0, i32 1) to %swift.type*))
@@ -217,7 +217,7 @@ public func double_generic_concrete<X: P2>(_: X.Type) {
 public func double_concrete_concrete() {
   takes_p1(Double<IsP2, IsP3>.self)
 }
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S42conditional_conformance_basic_conformances016double_concrete_F0yyF"()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S42conditional_conformance_basic_conformances016double_concrete_F0yyF"()
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S42conditional_conformance_basic_conformances6DoubleVyAA4IsP2VAA0F2P3VGMa"(i64 0)
 // CHECK-NEXT:    [[Double_TYPE:%.*]] = extractvalue %swift.metadata_response [[T0]], 0

--- a/test/Inputs/conditional_conformance_with_assoc.swift
+++ b/test/Inputs/conditional_conformance_with_assoc.swift
@@ -109,7 +109,7 @@ public func generic_generic<T: P2, U>(_: T.Type, _: U.Type)
 {
   takes_p1(Double<T, U>.self)
 }
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S34conditional_conformance_with_assoc08generic_E0yyxm_q_mtAA2P2RzAA2P3R_AaC3AT2RpzAadE_AeaCP3AT3RPzr0_lF"(%swift.type*, %swift.type*, %swift.type* %T, %swift.type* %U, i8** %T.P2, i8** %U.P3, i8** %T.AT2.P2, i8** %T.AT2.AT2.AT3.P3)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S34conditional_conformance_with_assoc08generic_E0yyxm_q_mtAA2P2RzAA2P3R_AaC3AT2RpzAadE_AeaCP3AT3RPzr0_lF"(%swift.type*, %swift.type*, %swift.type* %T, %swift.type* %U, i8** %T.P2, i8** %U.P3, i8** %T.AT2.P2, i8** %T.AT2.AT2.AT3.P3)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    %conditional.requirement.buffer = alloca [3 x i8**], align 8
 // CHECK-NEXT:    [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S34conditional_conformance_with_assoc6DoubleVMa"(i64 0, %swift.type* %T, %swift.type* %U, i8** %T.P2)
@@ -133,7 +133,7 @@ public func generic_concrete<T: P2>(_: T.Type)
 {
   takes_p1(Double<T, IsP3>.self)
 }
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S34conditional_conformance_with_assoc16generic_concreteyyxmAA2P2RzAaC3AT2RpzAA2P3AD_AdaCP3AT3RPzlF"(%swift.type*, %swift.type* %T, i8** %T.P2, i8** %T.AT2.P2, i8** %T.AT2.AT2.AT3.P3)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S34conditional_conformance_with_assoc16generic_concreteyyxmAA2P2RzAaC3AT2RpzAA2P3AD_AdaCP3AT3RPzlF"(%swift.type*, %swift.type* %T, i8** %T.P2, i8** %T.AT2.P2, i8** %T.AT2.AT2.AT3.P3)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    %conditional.requirement.buffer = alloca [3 x i8**], align 8
 // CHECK-NEXT:    [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S34conditional_conformance_with_assoc6DoubleVMa"(i64 0, %swift.type* %T, %swift.type* bitcast (i64* getelementptr inbounds (<{ i8**, i64, <{ {{.*}} }>* }>, <{ {{.*}} }>* @"$S34conditional_conformance_with_assoc4IsP3VMf", i32 0, i32 1) to %swift.type*), i8** %T.P2)
@@ -159,7 +159,7 @@ public func concrete_generic<U>(_: U.Type)
   takes_p1(Double<IsAlsoP2, U>.self)
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S34conditional_conformance_with_assoc16concrete_genericyyxmAA2P3RzlF"(%swift.type*, %swift.type* %U, i8** %U.P3)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S34conditional_conformance_with_assoc16concrete_genericyyxmAA2P3RzlF"(%swift.type*, %swift.type* %U, i8** %U.P3)
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:  %conditional.requirement.buffer = alloca [3 x i8**], align 8
 // CHECK-NEXT:  [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S34conditional_conformance_with_assoc6DoubleVMa"(i64 0, %swift.type* bitcast (i64* getelementptr inbounds (<{ {{.*}} }>, <{ {{.*}} }>* @"$S34conditional_conformance_with_assoc8IsAlsoP2VMf", i32 0, i32 1) to %swift.type*), %swift.type* %U, i8** getelementptr inbounds ([3 x i8*], [3 x i8*]* @"$S34conditional_conformance_with_assoc8IsAlsoP2VAA0G0AAWP", i32 0, i32 0))
@@ -181,7 +181,7 @@ public func concrete_concrete() {
   takes_p1(Double<IsAlsoP2, IsP3>.self)
 }
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S34conditional_conformance_with_assoc09concrete_E0yyF"()
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S34conditional_conformance_with_assoc09concrete_E0yyF"()
 // CHECK-NEXT:  entry:
 // CHECK-NEXT:    [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S34conditional_conformance_with_assoc6DoubleVyAA8IsAlsoP2VAA0F2P3VGMa"(i64 0)
 // CHECK-NEXT:    [[X:%.*]] = extractvalue %swift.metadata_response [[T0]], 0


### PR DESCRIPTION
This adds the dllstorage annotations on the tests.  This first pass gets
most of the IRGen tests passing on Windows (though has dependencies on
other changes).  However, this allows for the changes to be merged more
easily as we cannot regress other platforms here.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
