### PR TITLE
test: enable additional tests on Linux

### DIFF
--- a/test/IRGen/builtin_math.swift
+++ b/test/IRGen/builtin_math.swift
@@ -1,13 +1,23 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -O %s | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -O %s | %FileCheck %s -check-prefix CHECK-%target-os
 
-// XFAIL: linux
-
+#if os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 import Darwin
+#elseif os(Android) || os(Cygwin) || os(FreeBSD) || os(Linux)
+import Glibc
+#elseif os(Windows)
+import MSVCRT
+#endif
 
 // Make sure we use an intrinsic for functions such as exp.
 
 // CHECK-LABEL: define {{.*}}test1
-// CHECK: call float @llvm.exp.f32
+// CHECK-ios: call float @llvm.exp.f32
+// CHECK-macosx: call float @llvm.exp.f32
+// CHECK-tvos: call float @llvm.exp.f32
+// CHECK-watchos: call float @llvm.exp.f32
+// CHECK-darwin: call float @llvm.exp.f32
+// CHECK-linux-gnu: call float @expf
+// CHECK-windows: call float @expf
 
 public func test1(f : Float) -> Float {
   return exp(f)

--- a/test/IRGen/casts.sil
+++ b/test/IRGen/casts.sil
@@ -1,7 +1,6 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -disable-objc-attr-requires-foundation-module | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir -enable-objc-interop -disable-objc-attr-requires-foundation-module | %FileCheck %s -DINT=i%target-ptrsize
 
 // REQUIRES: CPU=i386 || CPU=x86_64
-// XFAIL: linux
 
 sil_stage canonical
 
@@ -271,7 +270,7 @@ nay:
   unreachable
 }
 
-// CHECK: define {{(dllexport )?}}swiftcc {{.*}} @checked_downcast_optional_class_to_ex([[INT]])
+// CHECK: define {{(dllexport )?}}{{(protected )?}}swiftcc {{.*}} @checked_downcast_optional_class_to_ex([[INT]])
 // CHECK: entry:
 // CHECK:   [[V1:%.*]] = inttoptr [[INT]] %0 to %T5casts1AC*
 // CHECK:   [[V2:%.*]] = icmp ne %T5casts1AC* [[V1]], null

--- a/test/IRGen/clang_inline.swift
+++ b/test/IRGen/clang_inline.swift
@@ -1,12 +1,11 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs -primary-file %s -O -disable-sil-perf-optzns -disable-llvm-optzns -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -enable-objc-interop -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs -primary-file %s -O -disable-sil-perf-optzns -disable-llvm-optzns -emit-ir -Xcc -fstack-protector | %FileCheck %s
 
 // RUN: %empty-directory(%t/Empty.framework/Modules/Empty.swiftmodule)
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-module-path %t/Empty.framework/Modules/Empty.swiftmodule/%target-swiftmodule-name %S/../Inputs/empty.swift -module-name Empty
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs -primary-file %s -F %t -DIMPORT_EMPTY -O -disable-sil-perf-optzns -disable-llvm-optzns -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs -primary-file %s -F %t -DIMPORT_EMPTY -O -disable-sil-perf-optzns -disable-llvm-optzns -emit-ir -Xcc -fstack-protector -enable-objc-interop | %FileCheck %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
-// XFAIL: linux
 
 #if IMPORT_EMPTY
   import Empty

--- a/test/IRGen/clang_inline_reverse.swift
+++ b/test/IRGen/clang_inline_reverse.swift
@@ -1,9 +1,8 @@
 // Same test as clang_inline.swift, but with the order swapped.
 
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs -primary-file %s -emit-ir -module-name clang_inline | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs -primary-file %s -enable-objc-interop -emit-ir -module-name clang_inline | %FileCheck %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
-// XFAIL: linux
 
 import gizmo
 

--- a/test/IRGen/class_bounded_generics.swift
+++ b/test/IRGen/class_bounded_generics.swift
@@ -1,8 +1,6 @@
-
-// RUN: %target-swift-frontend -module-name class_bounded_generics -emit-ir -primary-file %s -disable-objc-attr-requires-foundation-module | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -module-name class_bounded_generics -enable-objc-interop -emit-ir -primary-file %s -disable-objc-attr-requires-foundation-module | %FileCheck %s -DINT=i%target-ptrsize
 
 // REQUIRES: CPU=x86_64
-// XFAIL: linux
 
 protocol ClassBound : class {
   func classBoundMethod()

--- a/test/IRGen/local_types.swift
+++ b/test/IRGen/local_types.swift
@@ -1,10 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-module %S/Inputs/local_types_helper.swift -o %t
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir -parse-as-library %s -I %t > %t.ll
-// RUN: %FileCheck %s < %t.ll
-// RUN: %FileCheck -check-prefix=NEGATIVE %s < %t.ll
-
-// XFAIL: linux
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-objc-interop -emit-ir -parse-as-library %s -I %t | %FileCheck -check-prefix CHECK -check-prefix NEGATIVE %s
 
 import local_types_helper
 

--- a/test/IRGen/metatype_casts.sil
+++ b/test/IRGen/metatype_casts.sil
@@ -1,7 +1,8 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -enable-objc-interop -emit-ir | %FileCheck %s -DINT=i%target-ptrsize
 
 // REQUIRES: CPU=i386 || CPU=x86_64
-// XFAIL: linux
+
+// TODO: missing `-enable-objc-interop` results in an assertion
 
 import Swift
 

--- a/test/IRGen/pic.swift
+++ b/test/IRGen/pic.swift
@@ -3,23 +3,21 @@
 
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -module-name main -S -o - | %FileCheck -check-prefix=%target-cpu %s
 
-// XFAIL: linux
-
 var global: Int = 0
 
 public func use_global() -> Int {
   return global
 }
 
-// x86_64-LABEL: _$S4main10use_globalSiyF:
-// x86_64:         movq _$S4main6globalSivp(%rip), %rax
+// x86_64-LABEL: {{_?}}$S4main10use_globalSiyF:
+// x86_64:         movq {{_?}}{{[(]?}}$S4main6globalSivp{{[)]?}}(%rip), %rax
 
-// i386-LABEL: _$S4main10use_globalSiyF:
+// i386-LABEL: {{_?}}$S4main10use_globalSiyF:
 // i386:       [[PIC_BLOCK:^L.*\$pb]]:{{$}}
 // i386:         popl [[PIC_REG:%[a-z]+]]
-// i386:         movl _$S4main6globalSivp-[[PIC_BLOCK]]([[PIC_REG]]), {{%[a-z]+}}
+// i386:         movl {{_?}}$S4main6globalSivp-[[PIC_BLOCK]]([[PIC_REG]]), {{%[a-z]+}}
 
-// armv7-LABEL: _$S4main10use_globalSiyF:
+// armv7-LABEL: {{_?}}$S4main10use_globalSiyF:
 // Check for the runtime memory enforcement call. The global address may be
 // materialized in a different register prior to that call.
 // armv7:         bl _swift_beginAccess
@@ -29,7 +27,7 @@ public func use_global() -> Int {
 // armv7:         add [[R_ADR]], pc
 // armv7:         ldr [[R_ADR]], {{\[}}[[R_ADR]]{{\]}}
 
-// armv7s-LABEL: _$S4main10use_globalSiyF:
+// armv7s-LABEL: {{_?}}$S4main10use_globalSiyF:
 // armv7s:         bl _swift_beginAccess
 // armv7s:         movw [[R_ADR:r.*]], :lower16:(_$S4main6globalSivp-([[PIC_0:L.*]]+4))
 // armv7s:         movt [[R_ADR]], :upper16:(_$S4main6globalSivp-([[PIC_0]]+4))
@@ -37,7 +35,7 @@ public func use_global() -> Int {
 // armv7s:         add [[R_ADR]], pc
 // armv7s:         ldr [[R_ADR]], {{\[}}[[R_ADR]]{{\]}}
 
-// armv7k-LABEL: _$S4main10use_globalSiyF:
+// armv7k-LABEL: {{_?}}$S4main10use_globalSiyF:
 // armv7k:         bl _swift_beginAccess
 // armv7k:        movw [[R_ADR:r.*]], :lower16:(_$S4main6globalSivp-([[PIC_0:L.*]]+4))
 // armv7k:        movt [[R_ADR]], :upper16:(_$S4main6globalSivp-([[PIC_0]]+4))
@@ -45,7 +43,7 @@ public func use_global() -> Int {
 // armv7k:        add [[R_ADR]], pc
 // armv7k:        ldr [[R_ADR]], {{\[}}[[R_ADR]]{{\]}}
 
-// arm64-LABEL: _$S4main10use_globalSiyF:
+// arm64-LABEL: {{_?}}$S4main10use_globalSiyF:
 // arm64:         bl _swift_beginAccess
 // arm64:         adrp [[REG1:x[0-9]+]], _$S4main6globalSivp@PAGE
 // arm64:         add [[REG2:x[0-9]+]], [[REG1]], _$S4main6globalSivp@PAGEOFF

--- a/test/IRGen/typemetadata.sil
+++ b/test/IRGen/typemetadata.sil
@@ -1,8 +1,7 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
-// RUN: %target-swift-frontend -Osize -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s --check-prefix=OSIZE -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-objc-interop -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -Osize -assume-parsing-unqualified-ownership-sil -enable-objc-interop -emit-ir %s | %FileCheck %s --check-prefix=OSIZE -DINT=i%target-ptrsize
 
 // REQUIRES: CPU=x86_64
-// XFAIL: linux
 
 sil_stage canonical
 

--- a/test/IRGen/unowned_objc.sil
+++ b/test/IRGen/unowned_objc.sil
@@ -1,7 +1,6 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-objc-interop -emit-ir %s | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
-// XFAIL: linux
 
 import Builtin
 

--- a/test/IRGen/weak.sil
+++ b/test/IRGen/weak.sil
@@ -1,8 +1,7 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-objc-interop -emit-ir %s | %FileCheck %s
 // RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -O -S %s | %FileCheck %s --check-prefix=TAILCALL
 
 // REQUIRES: CPU=x86_64
-// XFAIL: linux
 
 // CHECK-DAG: [[TYPE:%swift.type]] = type
 // CHECK-DAG: [[OPAQUE:%swift.opaque]] = type opaque
@@ -113,8 +112,8 @@ bb0(%0 : $Optional<P>):
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
 // CHECK-NEXT: ret [[OPAQUE]]* [[T0]]
 
-// TAILCALL: _$S4weak1AVwCP:
-// TAILCALL:  jmp     _swift_weakCopyInit
+// TAILCALL: {{_?}}$S4weak1AVwCP:
+// TAILCALL:  jmp     {{_?}}swift_weakCopyInit
 
 //   destroy
 // CHECK:    define linkonce_odr hidden void @"$S4weak1AVwxx"([[OPAQUE]]* noalias [[ARG:%.*]], [[TYPE]]*
@@ -123,8 +122,8 @@ bb0(%0 : $Optional<P>):
 // CHECK-NEXT: call void @swift_weakDestroy([[WEAK]]* [[T1]])
 // CHECK-NEXT: ret void
 
-// TAILCALL: _$S4weak1AVwxx:
-// TAILCALL:  jmp     _swift_weakDestroy
+// TAILCALL: {{_?}}$S4weak1AVwxx:
+// TAILCALL:  jmp     {{_?}}swift_weakDestroy
 
 //   initializeWithCopy
 // CHECK:    define linkonce_odr hidden [[OPAQUE]]* @"$S4weak1AVwcp"([[OPAQUE]]* noalias [[DEST_OPQ:%.*]], [[OPAQUE]]* noalias [[SRC_OPQ:%.*]], [[TYPE]]*
@@ -136,8 +135,8 @@ bb0(%0 : $Optional<P>):
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
 // CHECK-NEXT: ret [[OPAQUE]]* [[T0]]
 
-// TAILCALL: _$S4weak1AVwcp:
-// TAILCALL:  jmp     _swift_weakCopyInit
+// TAILCALL: {{_?}}$S4weak1AVwcp:
+// TAILCALL:  jmp     {{_?}}swift_weakCopyInit
 
 //   assignWithCopy
 // CHECK:    define linkonce_odr hidden [[OPAQUE]]* @"$S4weak1AVwca"([[OPAQUE]]* [[DEST_OPQ:%.*]], [[OPAQUE]]* [[SRC_OPQ:%.*]], [[TYPE]]*
@@ -149,8 +148,8 @@ bb0(%0 : $Optional<P>):
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
 // CHECK-NEXT: ret [[OPAQUE]]* [[T0]]
 
-// TAILCALL: _$S4weak1AVwca:
-// TAILCALL:  jmp     _swift_weakCopyAssign
+// TAILCALL: {{_?}}$S4weak1AVwca:
+// TAILCALL:  jmp     {{_?}}swift_weakCopyAssign
 
 //   assignWithTake
 // CHECK:    define linkonce_odr hidden [[OPAQUE]]* @"$S4weak1AVwta"([[OPAQUE]]* noalias [[DEST_OPQ:%.*]], [[OPAQUE]]* noalias [[SRC_OPQ:%.*]], [[TYPE]]*
@@ -162,11 +161,11 @@ bb0(%0 : $Optional<P>):
 // CHECK-NEXT: [[T0:%.*]] = bitcast [[A]]* [[DEST]] to [[OPAQUE]]*
 // CHECK-NEXT: ret [[OPAQUE]]* [[T0]]
 
-// TAILCALL: _$S4weak1AVwtk:
-// TAILCALL:  jmp     _swift_weakTakeInit
+// TAILCALL: {{_?}}$S4weak1AVwtk:
+// TAILCALL:  jmp     {{_?}}swift_weakTakeInit
 
-// TAILCALL: _$S4weak1AVwta:
-// TAILCALL:  jmp     _swift_weakTakeAssign
+// TAILCALL: {{_?}}$S4weak1AVwta:
+// TAILCALL:  jmp     {{_?}}swift_weakTakeAssign
 
-// TAILCALL: _$S4weak1AVwTK:
-// TAILCALL:  jmp     _swift_weakTakeInit
+// TAILCALL: {{_?}}$S4weak1AVwTK:
+// TAILCALL:  jmp     {{_?}}swift_weakTakeInit

--- a/test/Serialization/comments-framework.swift
+++ b/test/Serialization/comments-framework.swift
@@ -7,8 +7,6 @@
 // RUN: cp -r %t/comments.framework/Modules/comments.swiftmodule %t/comments.swiftmodule
 // RUN: %target-swift-ide-test -print-module-comments -module-to-print=comments -source-filename %s -I %t | %FileCheck %s
 
-// XFAIL: linux
-
 /// first_decl_class_1 Aaa.
 public class first_decl_class_1 {
 

--- a/test/Serialization/failed-clang-module.swift
+++ b/test/Serialization/failed-clang-module.swift
@@ -15,8 +15,6 @@
 // RUN: %target-swift-frontend -typecheck %s -I %t -module-cache-path %t/mcp
 // RUN: %target-swift-frontend -typecheck %s -Xcc -DFAIL -I %t -module-cache-path %t/mcp -show-diagnostics-after-fatal -verify -verify-ignore-unknown
 
-// XFAIL: linux
-
 import SwiftModB // expected-error {{missing required module}}
 _ = TyB() // expected-error {{use of unresolved identifier 'TyB'}}
 

--- a/test/Serialization/search-paths-relative.swift
+++ b/test/Serialization/search-paths-relative.swift
@@ -12,8 +12,6 @@
 // RUN: %FileCheck %s < %t/has_xref.swiftmodule.txt
 // RUN: %FileCheck -check-prefix=NEGATIVE %s < %t/has_xref.swiftmodule.txt
 
-// XFAIL: linux
-
 import has_xref
 
 numeric(42)

--- a/test/Serialization/search-paths.swift
+++ b/test/Serialization/search-paths.swift
@@ -25,8 +25,6 @@
 // RUN: %target-swift-frontend %s -emit-module -o %t/main.swiftmodule -I %t -I %t/secret -F %t/Frameworks -Fsystem %t/SystemFrameworks
 // RUN: llvm-bcanalyzer -dump %t/main.swiftmodule | %FileCheck %s
 
-// XFAIL: linux
-
 import has_xref // expected-error {{missing required modules: 'has_alias', 'struct_with_operators'}}
 
 numeric(42) // expected-error {{use of unresolved identifier 'numeric'}}

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -779,6 +779,8 @@ elif run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'wi
       config.target_object_format = "elf"
       config.target_dylib_extension = "so"
       config.target_sdk_name = "linux"
+    config.target_swiftmodule_name = run_cpu + ".swiftmodule"
+    config.target_swiftdoc_name = run_cpu + ".swiftdoc"
     config.target_runtime = "native"
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
     config.target_build_swift = (


### PR DESCRIPTION
Un-XFAIL tests on Linux now that ObjC interop is controllable.  There
are a couple of tests that remain which are dependent on Foundation.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
