### PR TITLE
test: construct paths using python

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -326,14 +326,14 @@ config.swift_frontend_test_options = os.environ.get('SWIFT_FRONTEND_TEST_OPTIONS
 config.swift_driver_test_options = os.environ.get('SWIFT_DRIVER_TEST_OPTIONS', '')
 config.sil_test_options = os.environ.get('SIL_TEST_OPTIONS', '')
 
-clang_module_cache_path = config.swift_test_results_dir + "/clang-module-cache"
+clang_module_cache_path = os.path.join(config.swift_test_results_dir, "clang-module-cache")
 shutil.rmtree(clang_module_cache_path, ignore_errors=True)
 mcp_opt = "-module-cache-path %r" % clang_module_cache_path
 clang_mcp_opt = "-fmodules-cache-path=%r" % clang_module_cache_path
 lit_config.note("Using Clang module cache: " + clang_module_cache_path)
 lit_config.note("Using test results dir: " + config.swift_test_results_dir)
 
-completion_cache_path = config.swift_test_results_dir + "/completion-cache"
+completion_cache_path = os.path.join(config.swift_test_results_dir, "completion-cache")
 shutil.rmtree(completion_cache_path, ignore_errors=True)
 ccp_opt = "-completion-cache-path %r" % completion_cache_path
 lit_config.note("Using code completion cache: " + completion_cache_path)
@@ -379,23 +379,16 @@ config.substitutions.append(
   '%target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift'))
 
 # FIXME: BEGIN -enable-source-import hackaround
-config.substitutions.append(
-    ('%clang-importer-sdk-path',
-     '%r/Inputs/clang-importer-sdk' %
-        (config.test_source_root) ) )
+config.substitutions.append(('%clang-importer-sdk-path',
+                             '%r' % (os.path.join(config.test_source_root, 'Inputs', 'clang-importer-sdk'))))
 
-config.substitutions.append(
-    ('%clang-importer-sdk-nosource',
-     '-sdk %r/Inputs/clang-importer-sdk ' %
-        (config.test_source_root) ) )
+config.substitutions.append(('%clang-importer-sdk-nosource',
+                             '-sdk %r' % (os.path.join(config.test_source_root, 'Inputs', 'clang-importer-sdk'))))
 # FIXME: END -enable-source-import hackaround
 
-config.substitutions.append(
-    ('%clang-importer-sdk',
-     '-enable-source-import '
-     '-sdk %r/Inputs/clang-importer-sdk '
-     '-I %r/Inputs/clang-importer-sdk/swift-modules ' %
-        (config.test_source_root, config.test_source_root) ) )
+config.substitutions.append(('%clang-importer-sdk',
+                             '-enable-source-import -sdk %r -I %r ' % (os.path.join(config.test_source_root, 'Inputs', 'clang-importer-sdk'),
+                                                                       os.path.join(config.test_source_root, 'Inputs', 'clang-importer-sdk', 'swift-modules'))))
 
 config.substitutions.append( ('%clang_apinotes',
                               "%r -cc1apinotes" %


### PR DESCRIPTION
This makes the path construction more portable for Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
