### PR TITLE
tests: adjust inputs for Windows

### DIFF
--- a/test/IRGen/Inputs/usr/include/Gizmo.h
+++ b/test/IRGen/Inputs/usr/include/Gizmo.h
@@ -129,11 +129,19 @@ typedef NS_ENUM(unsigned, NeverActuallyMentionedByName) {
 - (NeverActuallyMentionedByName)getValue;
 @end
 
+#if defined(_WIN32)
+enum RawEnumInGizmo : unsigned {
+  InGizmoOne=0x7FFFFFFF,
+  InGizmoTwo,
+  InGizmoThree
+};
+#else
 enum RawEnumInGizmo {
   InGizmoOne=0x7FFFFFFF,
   InGizmoTwo,
   InGizmoThree
 };
+#endif
 
 struct StructOfNSStrings {
   __unsafe_unretained NSString *a;


### PR DESCRIPTION
Windows does not have unsigned enumerations by default.  Use a typed
enum to ensure that we get unsigned enumerations on Windows.  Fixes the
handling for tests on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
