### PR TITLE
Re-insert index(of:/where:) tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,22 @@ Swift 5.0
 Swift 4.2
 ---------
 
+* [SE-0204][]
+
+  Bidirectional collections now have methods for searching from the end
+  for an element or the index of an element matching a predicate, or for
+  the index of an `Equatable` element.
+  
+  ```swift
+  let names = ["Alex", "Beatrice", "Carlos", "Carlos", "Danilo", "Edie"]
+  names.last(where: { $0.contains("o") })       // "Danilo"
+  names.lastIndex(where: { $0.contains("e") })  // 5
+  names.lastIndex(of: "Carlos")                 // 3
+  ```
+  
+  In addition, for parity, `index(of:)` and `index(where:)` have been renamed
+  to `firstIndex(of:)` and `firstIndex(where:)`.
+
 * [SE-0185][]
 
   Protocol conformances are now able to be synthesized in extensions in the same

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionInstance.swift
@@ -1892,7 +1892,7 @@ public func checkRangeReplaceable<C, N>(
         let growth = newCount - oldCount
 
         let expectedCount = source.count + growth
-        let actualCount = numericCast(a.count) as Int
+        let actualCount = a.count
         if actualCount != expectedCount {
           reportFailure(
             &a, "\(actualCount) != expected count \(expectedCount)")

--- a/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift
+++ b/stdlib/private/StdlibCollectionUnittest/CheckCollectionType.swift
@@ -892,7 +892,7 @@ extension TestSuite {
     self.test("\(testNamePrefix).count/semantics") {
       for test in subscriptRangeTests {
         let c = makeWrappedCollection(test.collection)
-        expectEqual(test.count, numericCast(c.count) as Int)
+        expectEqual(test.count, c.count)
       }
     }
 
@@ -908,7 +908,7 @@ extension TestSuite {
           Optional<CollectionWithEquatableElement.Index>.self,
           &result)
         let zeroBasedIndex = result.map {
-          numericCast(c.distance(from: c.startIndex, to: $0)) as Int
+          c.distance(from: c.startIndex, to: $0)
         }
         expectEqual(
           test.expected,
@@ -929,7 +929,47 @@ extension TestSuite {
             extractValueFromEquatable(candidate).value == test.element.value
         }
         let zeroBasedIndex = result.map {
-          numericCast(c.distance(from: c.startIndex, to: $0)) as Int
+          c.distance(from: c.startIndex, to: $0)
+        }
+        expectEqual(
+          test.expected,
+          zeroBasedIndex,
+          stackTrace: SourceLocStack().with(test.loc))
+      }
+    }
+
+    // Echoing these same tests for index(of:)/index(where:), which alias
+  
+    self.test("\(testNamePrefix).index(of:)/semantics") {
+      for test in findTests {
+        let c = makeWrappedCollectionWithEquatableElement(test.sequence)
+        var result = c.index(of: wrapValueIntoEquatable(test.element))
+        expectType(
+          Optional<CollectionWithEquatableElement.Index>.self,
+          &result)
+        let zeroBasedIndex = result.map {
+          c.distance(from: c.startIndex, to: $0)
+        }
+        expectEqual(
+          test.expected,
+          zeroBasedIndex,
+          stackTrace: SourceLocStack().with(test.loc))
+      }
+    }
+
+    self.test("\(testNamePrefix).index(where:)/semantics") {
+      for test in findTests {
+        let closureLifetimeTracker = LifetimeTracked(0)
+        expectEqual(1, LifetimeTracked.instances)
+        let c = makeWrappedCollectionWithEquatableElement(test.sequence)
+        let result = c.index {
+          (candidate) in
+          _blackHole(closureLifetimeTracker)
+          return
+            extractValueFromEquatable(candidate).value == test.element.value
+        }
+        let zeroBasedIndex = result.map {
+          c.distance(from: c.startIndex, to: $0)
         }
         expectEqual(
           test.expected,
@@ -1387,7 +1427,7 @@ extension TestSuite {
           Optional<CollectionWithEquatableElement.Index>.self,
           &result)
         let zeroBasedIndex = result.map {
-          numericCast(c.distance(from: c.startIndex, to: $0)) as Int
+          c.distance(from: c.startIndex, to: $0)
         }
         expectEqual(
           test.expected,
@@ -1416,7 +1456,7 @@ extension TestSuite {
             extractValueFromEquatable(candidate).value == test.element.value
         })
         let zeroBasedIndex = result.map {
-          numericCast(c.distance(from: c.startIndex, to: $0)) as Int
+          c.distance(from: c.startIndex, to: $0)
         }
         expectEqual(
           test.expected,

--- a/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift
+++ b/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift
@@ -3814,7 +3814,7 @@ public struct DefaultedForwardRangeReplaceableSlice<Element>
     let endOffset =
       endIndex.position
       - subRange.count
-      + numericCast(newElements.count) as Int
+      + newElements.count
     Index._failEarlyRangeCheck2(
       rangeStart: subRange.lowerBound,
       rangeEnd: subRange.upperBound,
@@ -3995,7 +3995,7 @@ public struct DefaultedForwardRangeReplaceableSlice<Element>
     let endOffset =
       endIndex.position
       - subRange.count
-      + numericCast(newElements.count) as Int
+      + newElements.count
     Index._failEarlyRangeCheck2(
       rangeStart: subRange.lowerBound,
       rangeEnd: subRange.upperBound,
@@ -4172,7 +4172,7 @@ public struct DefaultedForwardRangeReplaceableSlice<Element>
     let endOffset =
       endIndex.position
       - subRange.count
-      + numericCast(newElements.count) as Int
+      + newElements.count
     Index._failEarlyRangeCheck2(
       rangeStart: subRange.lowerBound,
       rangeEnd: subRange.upperBound,
@@ -4359,7 +4359,7 @@ public struct DefaultedForwardRangeReplaceableSlice<Element>
     let endOffset =
       endIndex.position
       - subRange.count
-      + numericCast(newElements.count) as Int
+      + newElements.count
     Index._failEarlyRangeCheck2(
       rangeStart: subRange.lowerBound,
       rangeEnd: subRange.upperBound,
@@ -4536,7 +4536,7 @@ public struct DefaultedBidirectionalRangeReplaceableSlice<Element>
     let endOffset =
       endIndex.position
       - subRange.count
-      + numericCast(newElements.count) as Int
+      + newElements.count
     Index._failEarlyRangeCheck2(
       rangeStart: subRange.lowerBound,
       rangeEnd: subRange.upperBound,
@@ -4723,7 +4723,7 @@ public struct DefaultedBidirectionalRangeReplaceableSlice<Element>
     let endOffset =
       endIndex.position
       - subRange.count
-      + numericCast(newElements.count) as Int
+      + newElements.count
     Index._failEarlyRangeCheck2(
       rangeStart: subRange.lowerBound,
       rangeEnd: subRange.upperBound,
@@ -4906,7 +4906,7 @@ public struct DefaultedBidirectionalRangeReplaceableSlice<Element>
     let endOffset =
       endIndex.position
       - subRange.count
-      + numericCast(newElements.count) as Int
+      + newElements.count
     Index._failEarlyRangeCheck2(
       rangeStart: subRange.lowerBound,
       rangeEnd: subRange.upperBound,
@@ -5099,7 +5099,7 @@ public struct DefaultedBidirectionalRangeReplaceableSlice<Element>
     let endOffset =
       endIndex.position
       - subRange.count
-      + numericCast(newElements.count) as Int
+      + newElements.count
     Index._failEarlyRangeCheck2(
       rangeStart: subRange.lowerBound,
       rangeEnd: subRange.upperBound,
@@ -5286,7 +5286,7 @@ public struct DefaultedRandomAccessRangeReplaceableSlice<Element>
     let endOffset =
       endIndex.position
       - subRange.count
-      + numericCast(newElements.count) as Int
+      + newElements.count
     Index._failEarlyRangeCheck2(
       rangeStart: subRange.lowerBound,
       rangeEnd: subRange.upperBound,
@@ -5448,7 +5448,7 @@ public struct DefaultedRandomAccessRangeReplaceableSlice<Element>
     let endOffset =
       endIndex.position
       - subRange.count
-      + numericCast(newElements.count) as Int
+      + newElements.count
     Index._failEarlyRangeCheck2(
       rangeStart: subRange.lowerBound,
       rangeEnd: subRange.upperBound,
@@ -5645,7 +5645,7 @@ public struct DefaultedRandomAccessRangeReplaceableSlice<Element>
     let endOffset =
       endIndex.position
       - subRange.count
-      + numericCast(newElements.count) as Int
+      + newElements.count
     Index._failEarlyRangeCheck2(
       rangeStart: subRange.lowerBound,
       rangeEnd: subRange.upperBound,
@@ -5838,7 +5838,7 @@ public struct DefaultedRandomAccessRangeReplaceableSlice<Element>
     let endOffset =
       endIndex.position
       - subRange.count
-      + numericCast(newElements.count) as Int
+      + newElements.count
     Index._failEarlyRangeCheck2(
       rangeStart: subRange.lowerBound,
       rangeEnd: subRange.upperBound,
@@ -6041,7 +6041,7 @@ public struct DefaultedRandomAccessRangeReplaceableSlice<Element>
     let endOffset =
       endIndex.position
       - subRange.count
-      + numericCast(newElements.count) as Int
+      + newElements.count
     Index._failEarlyRangeCheck2(
       rangeStart: subRange.lowerBound,
       rangeEnd: subRange.upperBound,


### PR DESCRIPTION
We need these tests, since index(of:) and index(where:) are still available. This also adds the note to the changelog for SE-204.