### PR TITLE
[SR-7263] Treat APIs returning unmanaged CF types as NS_RETURNS_INNER…

### DIFF
--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1456,6 +1456,11 @@ public:
     if (tl.isTrivial()) {
       if (Method->hasAttr<clang::ObjCReturnsInnerPointerAttr>())
         return ResultConvention::UnownedInnerPointer;
+
+      auto type = tl.getLoweredType();
+      if (type.unwrapOptionalType().getStructOrBoundGenericStruct()
+          == type.getASTContext().getUnmanagedDecl())
+        return ResultConvention::UnownedInnerPointer;
       return ResultConvention::Unowned;
     }
 

--- a/test/Interpreter/SDK/Inputs/objc_implicit_inner_pointer/objc_implicit_inner_pointer.h
+++ b/test/Interpreter/SDK/Inputs/objc_implicit_inner_pointer/objc_implicit_inner_pointer.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+@interface Foo: NSObject
+
+- (CFTypeRef _Nonnull)bar;
+- (CFTypeRef _Nullable)nullabar;
+
+@end
+

--- a/test/Interpreter/SDK/Inputs/objc_implicit_inner_pointer/objc_implicit_inner_pointer.m
+++ b/test/Interpreter/SDK/Inputs/objc_implicit_inner_pointer/objc_implicit_inner_pointer.m
@@ -1,0 +1,27 @@
+#import "objc_implicit_inner_pointer.h"
+
+@implementation Foo {
+  CFTypeRef _bar;
+}
+
+- (id)init {
+  _bar = (__bridge_retained CFTypeRef)[[NSNumber alloc] initWithInt:1234567891];
+  return self;
+}
+
+- (CFTypeRef)bar {
+  return _bar;
+}
+
+- (CFTypeRef)nullabar {
+  return _bar;
+}
+
+- (void)dealloc {
+  printf("%s", __FUNCTION__);
+
+  if (_bar)
+    CFRelease(_bar);
+}
+
+@end

--- a/test/Interpreter/SDK/Inputs/objc_implicit_inner_pointer/objc_implicit_inner_pointer.m
+++ b/test/Interpreter/SDK/Inputs/objc_implicit_inner_pointer/objc_implicit_inner_pointer.m
@@ -5,7 +5,7 @@
 }
 
 - (id)init {
-  _bar = (__bridge_retained CFTypeRef)[[NSNumber alloc] initWithInt:1234567891];
+  _bar = (__bridge_retained CFTypeRef)[@"1234567891" mutableCopy];
   return self;
 }
 

--- a/test/Interpreter/SDK/objc_implicit_inner_pointer.swift
+++ b/test/Interpreter/SDK/objc_implicit_inner_pointer.swift
@@ -1,0 +1,21 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-clang -fobjc-arc %S/Inputs/objc_implicit_inner_pointer/objc_implicit_inner_pointer.m -c -o %t/objc_implicit_inner_pointer.o
+// RUN: %target-build-swift %s -import-objc-header %S/Inputs/objc_implicit_inner_pointer/objc_implicit_inner_pointer.h %t/objc_implicit_inner_pointer.o -o %t/main
+// RUN: %target-run %t/main | %FileCheck %s
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+do {
+  // The lifetime of Foo() currently gets extended using autorelease.
+  autoreleasepool {
+    let x = Foo().bar().takeUnretainedValue()
+    print(x) // CHECK: 1234567891
+  } // CHECK: -[Foo dealloc]
+
+  autoreleasepool {
+    let y = Foo().nullabar()!.takeUnretainedValue()
+    print(y) // CHECK: 1234567891
+  } // CHECK: -[Foo dealloc]
+}
+

--- a/test/SILGen/cf.swift
+++ b/test/SILGen/cf.swift
@@ -29,7 +29,7 @@ func useEmAll(_ model: CCMagnetismModel) {
 // CHECK: function_ref @CCRefrigeratorDestroy : $@convention(c) (@owned Optional<CCRefrigerator>) -> ()
   CCRefrigeratorDestroy(clone)
 
-// CHECK: objc_method [[ARG]] : $CCMagnetismModel, #CCMagnetismModel.refrigerator!1.foreign : (CCMagnetismModel) -> () -> Unmanaged<CCRefrigerator>?, $@convention(objc_method) (CCMagnetismModel) -> Optional<Unmanaged<CCRefrigerator>>
+// CHECK: objc_method [[ARG]] : $CCMagnetismModel, #CCMagnetismModel.refrigerator!1.foreign : (CCMagnetismModel) -> () -> Unmanaged<CCRefrigerator>?, $@convention(objc_method) (CCMagnetismModel) -> @unowned_inner_pointer Optional<Unmanaged<CCRefrigerator>>
   let f0 = model.refrigerator()
 
 // CHECK: objc_method [[ARG]] : $CCMagnetismModel, #CCMagnetismModel.getRefrigerator!1.foreign : (CCMagnetismModel) -> () -> CCRefrigerator?, $@convention(objc_method) (CCMagnetismModel) -> @autoreleased Optional<CCRefrigerator>


### PR DESCRIPTION
…_POINTER

<!-- What's in this pull request? -->
I've pretty much obeyed the instructions in the bug tracker to the letter, which were pretty straightforward. The only thing I added to that was the optional unwrapping. This is needed to handle when the nullability of the return value is specified as `_Nullable` or isn't specified, which in this case is very likely. I assumed if it was an Optional multiply nested that it shouldn't behave like NS_RETURNS_INNER_POINTER.

This will make `self` autoreleased so this may slightly impact the memory footprint of some code.

The bug mentioned (@jrose-apple) getting someone to suggest some test code to add for this. I can add that if still necessary. There was already a test that failed from this change, so maybe that would suffice...? 🤷‍♂️

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7263](https://bugs.swift.org/browse/SR-7263).

(I've run -r --verification-test on my Mac and everything passes at this point.)

```
Testing Time: 756.14s
  Expected Passes    : 10858
  Expected Failures  : 26
  Unsupported Tests  : 157
-- check-swift-validation-macosx-x86_64 finished --
```