### PR TITLE
master-next: Use InitLLVM from LLVM r330046

### DIFF
--- a/include/swift/Basic/LLVMInitialize.h
+++ b/include/swift/Basic/LLVMInitialize.h
@@ -19,15 +19,14 @@
 #ifndef SWIFT_BASIC_LLVMINITIALIZE_H
 #define SWIFT_BASIC_LLVMINITIALIZE_H
 
+#include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/PrettyStackTrace.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/TargetSelect.h"
 
 #define PROGRAM_START(argc, argv) \
-  llvm::sys::PrintStackTraceOnErrorSignal(argv[0]); \
-  llvm::PrettyStackTraceProgram _INITIALIZE_LLVM_STACKTRACE(argc, argv); \
-  llvm::llvm_shutdown_obj _INITIALIZE_LLVM_SHUTDOWN_OBJ
+  llvm::InitLLVM _INITIALIZE_LLVM(argc, argv)
 
 #define INITIALIZE_LLVM() \
   do { \


### PR DESCRIPTION
This is needed to work with other related changes, especially on Windows.