### PR TITLE
test: add a helper to join and normalise paths (NFC)

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -37,13 +37,16 @@ import site
 site.addsitedir(os.path.dirname(__file__))
 import swift_test
 
+def make_path(*args):
+    return os.path.normpath(os.path.join(*args))
+
 #
 # Helper functions.
 #
 
 def darwin_get_sdk_version(sdk_path):
-    system_version_plist_path = os.path.join(
-        sdk_path, "System", "Library", "CoreServices", "SystemVersion.plist")
+    system_version_plist_path = make_path(sdk_path, "System", "Library",
+                                          "CoreServices", "SystemVersion.plist")
     name = subprocess.check_output(
         ["defaults", "read", system_version_plist_path,
          "ProductName"]).rstrip()
@@ -194,7 +197,7 @@ if swift_obj_root is not None:
     append_to_env_path(llvm_tools_dir)
 
     build_mode = lit_config.params.get('build_mode', '')
-    append_to_env_path(os.path.join(swift_obj_root, build_mode, 'bin'))
+    append_to_env_path(make_path(swift_obj_root, build_mode, 'bin'))
 
 native_llvm_tools_path = lit_config.params.get('native_llvm_tools_path')
 if native_llvm_tools_path is not None:
@@ -269,21 +272,21 @@ config.complete_test = inferSwiftBinary('complete-test')
 config.swift_api_digester = inferSwiftBinary('swift-api-digester')
 config.swift_refactor = inferSwiftBinary('swift-refactor')
 
-config.swift_utils = os.path.join(config.swift_src_root, 'utils')
-config.line_directive = os.path.join(config.swift_utils, 'line-directive')
-config.gyb = os.path.join(config.swift_utils, 'gyb')
-config.rth = os.path.join(config.swift_utils, 'rth') # Resilience test helper
-config.scale_test = os.path.join(config.swift_utils, 'scale-test')
-config.PathSanitizingFileCheck = os.path.join(config.swift_utils, 'PathSanitizingFileCheck')
-config.swift_lib_dir = os.path.join(os.path.dirname(os.path.dirname(config.swift)), 'lib')
-config.round_trip_syntax_test = os.path.join(config.swift_utils, 'round-trip-syntax-test')
+config.swift_utils = make_path(config.swift_src_root, 'utils')
+config.line_directive = make_path(config.swift_utils, 'line-directive')
+config.gyb = make_path(config.swift_utils, 'gyb')
+config.rth = make_path(config.swift_utils, 'rth') # Resilience test helper
+config.scale_test = make_path(config.swift_utils, 'scale-test')
+config.PathSanitizingFileCheck = make_path(config.swift_utils, 'PathSanitizingFileCheck')
+config.swift_lib_dir = make_path(config.swift, '..', '..', 'lib')
+config.round_trip_syntax_test = make_path(config.swift_utils, 'round-trip-syntax-test')
 
 # Find the resource directory.  Assume it's near the swift compiler if not set.
 test_resource_dir = lit_config.params.get('test_resource_dir')
 if test_resource_dir:
     resource_dir_opt = ("-resource-dir %s" % test_resource_dir)
 else:
-    test_resource_dir = os.path.join(config.swift_lib_dir, 'swift')
+    test_resource_dir = make_path(config.swift_lib_dir, 'swift')
     resource_dir_opt = ""
 stdlib_resource_dir_opt = resource_dir_opt
 sourcekitd_framework_dir = config.swift_lib_dir
@@ -300,8 +303,8 @@ test_sdk_overlay_dir = lit_config.params.get('test_sdk_overlay_dir', None)
 if test_sdk_overlay_dir is not None:
     config.available_features.add('sdk_overlay')
 
-    sdk_overlay_dir_opt = ("-I %s" % os.path.join(test_sdk_overlay_dir, run_cpu))
-    sdk_overlay_link_path_dir = os.path.join(test_sdk_overlay_dir, run_cpu)
+    sdk_overlay_dir_opt = ("-I %s" % make_path(test_sdk_overlay_dir, run_cpu))
+    sdk_overlay_link_path_dir = make_path(test_sdk_overlay_dir, run_cpu)
     sdk_overlay_link_path = ("-L %s" % sdk_overlay_link_path_dir)
     sdk_overlay_linker_opt = (
         "-L %s -Xlinker -rpath -Xlinker %s" %
@@ -326,14 +329,14 @@ config.swift_frontend_test_options = os.environ.get('SWIFT_FRONTEND_TEST_OPTIONS
 config.swift_driver_test_options = os.environ.get('SWIFT_DRIVER_TEST_OPTIONS', '')
 config.sil_test_options = os.environ.get('SIL_TEST_OPTIONS', '')
 
-clang_module_cache_path = os.path.join(config.swift_test_results_dir, "clang-module-cache")
+clang_module_cache_path = make_path(config.swift_test_results_dir, "clang-module-cache")
 shutil.rmtree(clang_module_cache_path, ignore_errors=True)
 mcp_opt = "-module-cache-path %r" % clang_module_cache_path
 clang_mcp_opt = "-fmodules-cache-path=%r" % clang_module_cache_path
 lit_config.note("Using Clang module cache: " + clang_module_cache_path)
 lit_config.note("Using test results dir: " + config.swift_test_results_dir)
 
-completion_cache_path = os.path.join(config.swift_test_results_dir, "completion-cache")
+completion_cache_path = make_path(config.swift_test_results_dir, "completion-cache")
 shutil.rmtree(completion_cache_path, ignore_errors=True)
 ccp_opt = "-completion-cache-path %r" % completion_cache_path
 lit_config.note("Using code completion cache: " + completion_cache_path)
@@ -367,8 +370,7 @@ config.substitutions.append(
      "%r -frontend %s -disable-objc-attr-requires-foundation-module %s %s"
        % (config.swift, mcp_opt, config.swift_test_options, config.swift_frontend_test_options)) )
 
-config.clang_include_dir = \
-  os.path.join(os.path.dirname(os.path.dirname(config.swift)), 'include')
+config.clang_include_dir = make_path(config.swift, '..', '..', 'include')
 config.substitutions.append( ('%clang-include-dir', config.clang_include_dir) )
 
 # Use this to build the basic set of Objective-C overlays.
@@ -380,15 +382,15 @@ config.substitutions.append(
 
 # FIXME: BEGIN -enable-source-import hackaround
 config.substitutions.append(('%clang-importer-sdk-path',
-                             '%r' % (os.path.join(config.test_source_root, 'Inputs', 'clang-importer-sdk'))))
+                             '%r' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'))))
 
 config.substitutions.append(('%clang-importer-sdk-nosource',
-                             '-sdk %r' % (os.path.join(config.test_source_root, 'Inputs', 'clang-importer-sdk'))))
+                             '-sdk %r' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'))))
 # FIXME: END -enable-source-import hackaround
 
 config.substitutions.append(('%clang-importer-sdk',
-                             '-enable-source-import -sdk %r -I %r ' % (os.path.join(config.test_source_root, 'Inputs', 'clang-importer-sdk'),
-                                                                       os.path.join(config.test_source_root, 'Inputs', 'clang-importer-sdk', 'swift-modules'))))
+                             '-enable-source-import -sdk %r -I %r ' % (make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk'),
+                                                                       make_path(config.test_source_root, 'Inputs', 'clang-importer-sdk', 'swift-modules'))))
 
 config.substitutions.append( ('%clang_apinotes',
                               "%r -cc1apinotes" %
@@ -567,8 +569,8 @@ if run_vendor == 'apple':
     xcrun_prefix = (
         "xcrun --toolchain %s --sdk %s" %
         (config.darwin_xcrun_toolchain, config.variant_sdk))
-    extra_frameworks_dir = os.path.join(config.variant_sdk,
-        "..", "..", "..", "Developer", "Library", "Frameworks")
+    extra_frameworks_dir = make_path(config.variant_sdk, "..", "..", "..",
+                                     "Developer", "Library", "Frameworks")
     target_options = (
         "-target %s %s %s" %
         (config.variant_triple, resource_dir_opt, mcp_opt))
@@ -711,9 +713,7 @@ if run_vendor == 'apple':
         (sw_vers_name, sw_vers_vers, sw_vers_build))
 
     config.target_sdk_name = xcrun_sdk_name
-    config.target_ld = (
-        "%s ld -L%s" %
-        (xcrun_prefix, os.path.join(test_resource_dir, config.target_sdk_name)))
+    config.target_ld = "%s ld -L%r" % (xcrun_prefix, make_path(test_resource_dir, config.target_sdk_name))
     config.target_swift_frontend = (
         "%s -frontend %s -sdk %s %s %s" %
         (config.swiftc, target_options, config.variant_sdk,
@@ -826,9 +826,7 @@ elif run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'wi
     config.target_clang = (
         "clang++ -target %s %s" %
         (config.variant_triple, clang_mcp_opt))
-    config.target_ld = (
-        "ld -L%s" %
-        (os.path.join(test_resource_dir, config.target_sdk_name)))
+    config.target_ld = "ld -L%r" % (make_path(test_resource_dir, config.target_sdk_name))
 elif run_os == 'linux-androideabi':
     lit_config.note("Testing Android " + config.variant_triple)
     config.target_object_format = "elf"
@@ -837,16 +835,15 @@ elif run_os == 'linux-androideabi':
     config.target_swift_autolink_extract = inferSwiftBinary("swift-autolink-extract")
     config.target_sdk_name = "android"
     android_linker_opt = "-L {libcxx} -L {libgcc}".format(
-        libcxx=os.path.join(config.android_ndk_path,
-                            "sources", "cxx-stl", "llvm-libc++", "libs",
-                            "armeabi-v7a"),
-        libgcc=os.path.join(config.android_ndk_path,
-                            "toolchains",
-                            "arm-linux-androideabi-{}".format(
-                                config.android_ndk_gcc_version),
-                            "prebuilt", "linux-x86_64", "lib", "gcc",
-                            "arm-linux-androideabi",
-                            "{}.x".format(config.android_ndk_gcc_version)))
+        libcxx=make_path(config.android_ndk_path,
+                         "sources", "cxx-stl", "llvm-libc++", "libs",
+                         "armeabi-v7a"),
+        libgcc=make_path(config.android_ndk_path,
+                         "toolchains",
+                         "arm-linux-androideabi-{}".format(config.android_ndk_gcc_version),
+                         "prebuilt", "linux-x86_64", "lib", "gcc",
+                         "arm-linux-androideabi",
+                         "{}.x".format(config.android_ndk_gcc_version)))
     config.target_build_swift = (
         '%s -target %s -sdk %s %s -Xlinker -pie %s %s %s %s %s'
         % (config.swiftc, config.variant_triple, config.variant_sdk,
@@ -864,8 +861,7 @@ elif run_os == 'linux-androideabi':
            config.swift_frontend_test_options))
     subst_target_swift_frontend_mock_sdk = config.target_swift_frontend
     subst_target_swift_frontend_mock_sdk_after = ""
-    config.target_run = os.path.join(
-        config.swift_src_root, 'utils', 'android', 'adb_test_runner.py')
+    config.target_run = make_path(config.swift_src_root, 'utils', 'android', 'adb_test_runner.py')
     # FIXME: Include -sdk in this invocation.
     config.target_sil_opt = (
         '%s -target %s %s %s %s' %
@@ -887,15 +883,10 @@ elif run_os == 'linux-androideabi':
         "clang++ -target %s %s" %
         (config.variant_triple, clang_mcp_opt))
     config.target_ld = "{} -L{}".format(
-        os.path.join(
-            config.android_ndk_path,
-            'toolchains',
-            'arm-linux-androideabi-{}'.format(config.android_ndk_gcc_version),
-            'prebuilt',
-            'linux-x86_64',
-            'arm-linux-androideabi',
-            'bin'),
-        os.path.join(test_resource_dir, config.target_sdk_name))
+        make_path(config.android_ndk_path, 'toolchains',
+                  'arm-linux-androideabi-{}'.format(config.android_ndk_gcc_version),
+                  'prebuilt', 'linux-x86_64', 'arm-linux-androideabi', 'bin'),
+        make_path(test_resource_dir, config.target_sdk_name))
     # The Swift interpreter is not available when targeting Android.
     config.available_features.remove('swift_interpreter')
 
@@ -936,7 +927,7 @@ def source_compiler_rt_libs(path):
                                         if lib.startswith('libclang_rt.')
                                         and config.compiler_rt_platform in lib])
 
-source_compiler_rt_libs(os.path.join(test_resource_dir, 'clang', 'lib',
+source_compiler_rt_libs(make_path(test_resource_dir, 'clang', 'lib',
                         platform.system().lower()))
 
 def check_runtime_libs(features_to_check):
@@ -1089,10 +1080,10 @@ if hasattr(config, 'target_swift_autolink_extract'):
 config.substitutions.append(('%target-swift-modulewrap',
                              config.target_swift_modulewrap))
 
-platform_module_dir = os.path.join(test_resource_dir, '%target-sdk-name', run_cpu)
+platform_module_dir = make_path(test_resource_dir, '%target-sdk-name', run_cpu)
 lit_config.note('Using platform module dir: ' + platform_module_dir)
 if test_sdk_overlay_dir is not None:
-    platform_sdk_overlay_dir = os.path.join(test_sdk_overlay_dir, run_cpu)
+    platform_sdk_overlay_dir = make_path(test_sdk_overlay_dir, run_cpu)
 else:
     platform_sdk_overlay_dir = platform_module_dir
 
@@ -1121,8 +1112,8 @@ config.substitutions.append(
 config.substitutions.append(('%raw-FileCheck', pipes.quote(config.filecheck)))
 
 # If static stdlib is present, enable static stdlib tests
-static_stdlib_path = os.path.join(os.path.join(config.swift_lib_dir,"swift_static"), config.target_sdk_name)
-libswiftCore_path = os.path.join(static_stdlib_path,"libswiftCore.a")
+static_stdlib_path = make_path(config.swift_lib_dir, "swift_static", config.target_sdk_name)
+libswiftCore_path = make_path(static_stdlib_path, "libswiftCore.a")
 if os.path.exists(libswiftCore_path):
     config.available_features.add("static_stdlib")
     config.substitutions.append(('%target-static-stdlib-path', static_stdlib_path))


### PR DESCRIPTION
This ensures that all paths that are generated in lit are normalised
after being formed.  This is in preparation for supporting execution of
the tests on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
