### PR TITLE
[codable] When generated encode for a property, distinguish in betwee…

### DIFF
--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -604,10 +604,16 @@ static void deriveBodyEncodable_encode(AbstractFunctionDecl *encodeDecl) {
   // Now need to generate `try container.encode(x, forKey: .x)` for all
   // existing properties. Optional properties get `encodeIfPresent`.
   for (auto *elt : codingKeysEnum->getAllElements()) {
-    VarDecl *varDecl;
-    for (auto decl : targetDecl->lookupDirect(DeclName(elt->getName())))
-      if ((varDecl = dyn_cast<VarDecl>(decl)))
-        break;
+    VarDecl *varDecl = nullptr;
+    for (auto decl : targetDecl->lookupDirect(DeclName(elt->getName()))) {
+      if (auto *vd = dyn_cast<VarDecl>(decl)) {
+        if (!vd->isStatic()) {
+          varDecl = vd;
+          break;
+        }
+      }
+    }
+    assert(varDecl && "Should have found at least 1 var decl");
 
     // self.x
     auto *selfRef = createSelfDeclRef(encodeDecl);

--- a/test/SILGen/codable/struct_codable_member_type_lookup.swift
+++ b/test/SILGen/codable/struct_codable_member_type_lookup.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -emit-silgen -enable-sil-ownership %s | %FileCheck %s
+
+// Make sure we have an int, not a float.
+//
+// CHECK-LABEL: sil hidden @$S33struct_codable_member_type_lookup32StaticInstanceNameDisambiguationV6encode2to{{.*}}F : $@convention(method) (@in_guaranteed Encoder, StaticInstanceNameDisambiguation) -> @error Error {
+// CHECK: bb0([[ENCODER:%.*]] : @trivial $*Encoder, [[INPUT:%.*]] : @trivial $StaticInstanceNameDisambiguation):
+// CHECK:   [[INT_VALUE:%.*]] = struct_extract [[INPUT]]
+// CHECK:   [[FUNC:%.*]] = function_ref @$Ss22KeyedEncodingContainerV6encode_6forKeyySi_xtKF : $@convention(method) <τ_0_0 where τ_0_0 : CodingKey> (Int, @in_guaranteed τ_0_0, @inout KeyedEncodingContainer<τ_0_0>) -> @error Error
+// CHECK:   try_apply [[FUNC]]<StaticInstanceNameDisambiguation.CodingKeys>([[INT_VALUE]],
+// CHECK: } // end sil function '$S33struct_codable_member_type_lookup32StaticInstanceNameDisambiguationV6encode2toys7Encoder_p_tKF'
+struct StaticInstanceNameDisambiguation : Codable {
+  static let version: Float = 0.42
+  let version: Int = 42
+}

--- a/test/decl/protocol/special/coding/struct_codable_member_type_lookup.swift
+++ b/test/decl/protocol/special/coding/struct_codable_member_type_lookup.swift
@@ -654,3 +654,10 @@ struct sr6886 {
   struct Nested : Codable {}
   let Nested: Nested // Don't crash with a coding key that is the same as a nested type name
 }
+
+// Don't crash if we have a static property with the same name as an ivar that
+// we will encode. We check the actual codegen in a SILGen test.
+struct StaticInstanceNameDisambiguation : Codable {
+  static let version: Float = 0.42
+  let version: Int = 42
+}


### PR DESCRIPTION
…n static/instance properties.

Previously, we just took the first match so:

1. We would try to emit a metatype lookup of the property but had prepared an instance lookup.
2. Could get the wrong type if the static/instance property had different types.

rdar://39669212
