### PR TITLE
[stdlib] Drop @inlinable if @inline(never).

### DIFF
--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -390,7 +390,7 @@ extension _ArrayBuffer {
   }
 
   @inline(never)
-  @usableFromInline
+  @inlinable // @specializable
   internal func _getElementSlowPath(_ i: Int) -> AnyObject {
     _sanityCheck(
       _isClassOrObjCExistential(Element.self),

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -190,8 +190,8 @@ extension _ArrayBuffer {
   // checks one element. The reason for this is that the ARC optimizer does not
   // handle loops atm. and so can get blocked by the presence of a loop (over
   // the range). This loop is not necessary for a single element access.
-  @inlinable
   @inline(never)
+  @usableFromInline
   internal func _typeCheckSlowPath(_ index: Int) {
     if _fastPath(_isNative) {
       let element: AnyObject = cast(toBufferOf: AnyObject.self)._native[index]
@@ -389,8 +389,8 @@ extension _ArrayBuffer {
     return unsafeBitCast(_getElementSlowPath(i), to: Element.self)
   }
 
-  @inlinable
   @inline(never)
+  @usableFromInline
   internal func _getElementSlowPath(_ i: Int) -> AnyObject {
     _sanityCheck(
       _isClassOrObjCExistential(Element.self),

--- a/stdlib/public/core/ArrayBufferProtocol.swift
+++ b/stdlib/public/core/ArrayBufferProtocol.swift
@@ -134,8 +134,8 @@ extension _ArrayBufferProtocol where Indices == Range<Int>{
   }
 
   // Make sure the compiler does not inline _copyBuffer to reduce code size.
-  @inlinable
   @inline(never)
+  @usableFromInline
   internal init(copying buffer: Self) {
     let newBuffer = _ContiguousArrayBuffer<Element>(
       _uninitializedCount: buffer.count, minimumCapacity: buffer.count)

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1115,8 +1115,8 @@ extension ${Self} : RangeReplaceableCollection, ArrayProtocol {
     }
   }
 
-  @inlinable
   @inline(never)
+  @usableFromInline
   internal static func _allocateBufferUninitialized(
     minimumCapacity: Int
   ) -> _Buffer {
@@ -1337,8 +1337,8 @@ extension ${Self} : RangeReplaceableCollection, ArrayProtocol {
   /// Copy the contents of the current buffer to a new unique mutable buffer.
   /// The count of the new buffer is set to `oldCount`, the capacity of the
   /// new buffer is big enough to hold 'oldCount' + 1 elements.
-  @inlinable
   @inline(never)
+  @usableFromInline
   internal mutating func _copyToNewBuffer(oldCount: Int) {
     let newCount = oldCount + 1
     var newBuffer = _buffer._forceCreateUniqueMutableBuffer(
@@ -1875,8 +1875,8 @@ internal struct _InitializeMemoryFromCollection<
 }
 
 extension _ArrayBufferProtocol {
-  @inlinable
   @inline(never)
+  @usableFromInline
   internal mutating func _arrayOutOfPlaceReplace<C : Collection>(
     _ bounds: Range<Int>,
     with newValues: C,
@@ -1989,8 +1989,8 @@ extension _ArrayBufferProtocol {
   /// The formula used to compute the new buffers capacity is:
   ///   max(requiredCapacity, source.capacity)  if newCount <= source.capacity
   ///   max(requiredCapacity, _growArrayCapacity(source.capacity)) otherwise
-  @inlinable
   @inline(never)
+  @usableFromInline
   internal func _forceCreateUniqueMutableBuffer(
     newCount: Int, requiredCapacity: Int
   ) -> _ContiguousArrayBuffer<Element> {
@@ -2005,8 +2005,8 @@ extension _ArrayBufferProtocol {
   /// The formula used to compute the new buffers capacity is:
   ///   max(minNewCapacity, source.capacity) if minNewCapacity <= source.capacity
   ///   max(minNewCapacity, _growArrayCapacity(source.capacity)) otherwise
-  @inlinable
   @inline(never)
+  @usableFromInline
   internal func _forceCreateUniqueMutableBuffer(
     countForNewBuffer: Int, minNewCapacity: Int
   ) -> _ContiguousArrayBuffer<Element> {
@@ -2054,8 +2054,8 @@ extension _ArrayBufferProtocol {
   ///
   /// As an optimization, may move elements out of source rather than
   /// copying when it isUniquelyReferenced.
-  @inlinable
   @inline(never)
+  @usableFromInline
   internal mutating func _arrayOutOfPlaceUpdate<Initializer>(
     _ dest: inout _ContiguousArrayBuffer<Element>,
     _ headCount: Int, // Count of initial source elements to copy/move
@@ -2138,8 +2138,8 @@ internal struct _IgnorePointer<T> : _PointerFunction {
 }
 
 extension _ArrayBufferProtocol {
-  @inlinable
   @inline(never)
+  @usableFromInline
   internal mutating func _outlinedMakeUniqueBuffer(bufferCount: Int) {
 
     if _fastPath(

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1875,8 +1875,8 @@ internal struct _InitializeMemoryFromCollection<
 }
 
 extension _ArrayBufferProtocol {
+  @inlinable // FIXME @useableFromInline https://bugs.swift.org/browse/SR-7588
   @inline(never)
-  @usableFromInline
   internal mutating func _arrayOutOfPlaceReplace<C : Collection>(
     _ bounds: Range<Int>,
     with newValues: C,

--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -1338,7 +1338,7 @@ extension ${Self} : RangeReplaceableCollection, ArrayProtocol {
   /// The count of the new buffer is set to `oldCount`, the capacity of the
   /// new buffer is big enough to hold 'oldCount' + 1 elements.
   @inline(never)
-  @usableFromInline
+  @inlinable // @specializable
   internal mutating func _copyToNewBuffer(oldCount: Int) {
     let newCount = oldCount + 1
     var newBuffer = _buffer._forceCreateUniqueMutableBuffer(
@@ -1990,7 +1990,7 @@ extension _ArrayBufferProtocol {
   ///   max(requiredCapacity, source.capacity)  if newCount <= source.capacity
   ///   max(requiredCapacity, _growArrayCapacity(source.capacity)) otherwise
   @inline(never)
-  @usableFromInline
+  @inlinable // @specializable
   internal func _forceCreateUniqueMutableBuffer(
     newCount: Int, requiredCapacity: Int
   ) -> _ContiguousArrayBuffer<Element> {
@@ -2006,7 +2006,7 @@ extension _ArrayBufferProtocol {
   ///   max(minNewCapacity, source.capacity) if minNewCapacity <= source.capacity
   ///   max(minNewCapacity, _growArrayCapacity(source.capacity)) otherwise
   @inline(never)
-  @usableFromInline
+  @inlinable // @specializable
   internal func _forceCreateUniqueMutableBuffer(
     countForNewBuffer: Int, minNewCapacity: Int
   ) -> _ContiguousArrayBuffer<Element> {
@@ -2055,7 +2055,7 @@ extension _ArrayBufferProtocol {
   /// As an optimization, may move elements out of source rather than
   /// copying when it isUniquelyReferenced.
   @inline(never)
-  @usableFromInline
+  @inlinable // @specializable
   internal mutating func _arrayOutOfPlaceUpdate<Initializer>(
     _ dest: inout _ContiguousArrayBuffer<Element>,
     _ headCount: Int, // Count of initial source elements to copy/move

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -3299,8 +3299,8 @@ internal enum _VariantDictionaryBuffer<Key: Hashable, Value>: _HashBuffer {
   }
 
 #if _runtime(_ObjC)
-  @inlinable // FIXME(sil-serialize-all)
   @inline(never)
+  @usableFromInline
   internal mutating func migrateDataToNativeBuffer(
     _ cocoaBuffer: _CocoaDictionaryBuffer
   ) {
@@ -3464,8 +3464,8 @@ internal enum _VariantDictionaryBuffer<Key: Hashable, Value>: _HashBuffer {
   }
 
 #if _runtime(_ObjC)
-  @inlinable // FIXME(sil-serialize-all)
   @inline(never)
+  @usableFromInline
   internal static func maybeGetFromCocoaBuffer(
     _ cocoaBuffer: CocoaBuffer, forKey key: Key
   ) -> Value? {

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -24,8 +24,8 @@ from gyb_stdlib_support import (
 
 import SwiftShims
 
-@inlinable // FIXME(sil-serialize-all)
 @inline(never)
+@usableFromInline
 internal func _abstract(
   file: StaticString = #file,
   line: UInt = #line

--- a/stdlib/public/core/IntegerParsing.swift
+++ b/stdlib/public/core/IntegerParsing.swift
@@ -95,9 +95,9 @@ extension FixedWidthInteger {
   // _parseASCII function thunk that prevents inlining used as an implementation
   // detail for FixedWidthInteger.init(_: radix:) on the slow path to save code
   // size.
-  @inlinable // FIXME(sil-serialize-all)
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @inline(never)
+  @usableFromInline
   internal static func _parseASCIISlowPath<
     CodeUnits : IteratorProtocol, Result: FixedWidthInteger
   >(

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -161,7 +161,7 @@ public struct Mirror {
 
   @_semantics("optimize.sil.specialize.generic.never")
   @inline(never)
-  @inlinable // FIXME(sil-serialize-all)
+  @usableFromInline
   internal static func _superclassIterator<Subject>(
     _ subject: Subject, _ ancestorRepresentation: AncestorRepresentation
   ) -> () -> Mirror? {

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -415,8 +415,8 @@ internal func _print_unlocked<T, TargetStream : TextOutputStream>(
 ///
 /// This function is forbidden from being inlined because when building the
 /// standard library inlining makes us drop the special semantics.
-@inlinable
 @inline(never) @effects(readonly)
+@usableFromInline
 internal func _toStringReadOnlyStreamable<
   T : TextOutputStreamable
 >(_ x: T) -> String {
@@ -425,8 +425,8 @@ internal func _toStringReadOnlyStreamable<
   return result
 }
 
-@inlinable
 @inline(never) @effects(readonly)
+@usableFromInline
 internal func _toStringReadOnlyPrintable<
   T : CustomStringConvertible
 >(_ x: T) -> String {
@@ -437,7 +437,6 @@ internal func _toStringReadOnlyPrintable<
 // `debugPrint`
 //===----------------------------------------------------------------------===//
 
-@inlinable // FIXME(sil-serialize-all)
 @_semantics("optimize.sil.specialize.generic.never")
 @inline(never)
 public func _debugPrint_unlocked<T, TargetStream : TextOutputStream>(

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -2836,8 +2836,8 @@ internal enum _VariantSetBuffer<Element: Hashable>: _HashBuffer {
   }
 
 #if _runtime(_ObjC)
-  @inlinable // FIXME(sil-serialize-all)
   @inline(never)
+  @usableFromInline
   internal mutating func migrateDataToNativeBuffer(
     _ cocoaBuffer: _CocoaSetBuffer
   ) {
@@ -2999,8 +2999,8 @@ internal enum _VariantSetBuffer<Element: Hashable>: _HashBuffer {
   }
 
 #if _runtime(_ObjC)
-  @inlinable // FIXME(sil-serialize-all)
   @inline(never)
+  @usableFromInline
   internal static func maybeGetFromCocoaBuffer(
     _ cocoaBuffer: CocoaBuffer, forKey key: Key
   ) -> Value? {

--- a/stdlib/public/core/ThreadLocalStorage.swift
+++ b/stdlib/public/core/ThreadLocalStorage.swift
@@ -123,8 +123,8 @@ internal let _tlsKey: __swift_thread_key_t = {
   return key
 }()
 
-@inlinable // FIXME(sil-serialize-all)
 @inline(never)
+@usableFromInline
 internal func _initializeThreadLocalStorage()
   -> UnsafeMutablePointer<_ThreadLocalStorage>
 {

--- a/stdlib/public/core/UTF8.swift
+++ b/stdlib/public/core/UTF8.swift
@@ -177,7 +177,7 @@ extension UTF8.ReverseParser : Unicode.Parser, _UTFParser {
   /// Returns the length of the invalid sequence that ends with the LSB of
   /// buffer.
   @inline(never)
-  @inlinable // FIXME(sil-serialize-all)
+  @usableFromInline
   internal func _invalidLength() -> UInt8 {
     if _buffer._storage                 & 0b0__1111_0000__1100_0000
                                        == 0b0__1110_0000__1000_0000 {
@@ -254,7 +254,7 @@ extension Unicode.UTF8.ForwardParser : Unicode.Parser, _UTFParser {
   /// Returns the length of the invalid sequence that starts with the LSB of
   /// buffer.
   @inline(never)
-  @inlinable // FIXME(sil-serialize-all)
+  @usableFromInline
   internal func _invalidLength() -> UInt8 {
     if _buffer._storage               & 0b0__1100_0000__1111_0000
                                      == 0b0__1000_0000__1110_0000 {


### PR DESCRIPTION
Aggressively remove all `@inlinable` from any function that's
`@inline(never)` to see the impact.

`@inlinable @inline(never)` is a potential code smell. While it might
expose some optimization and specialization opportunities to the
optimizer, it's most commonly a sign that more thought is needed.

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
