### PR TITLE
[SwiftSyntax] Add accessors for source locations and test diagnostic emission

### DIFF
--- a/test/SwiftSyntax/DiagnosticTest.swift
+++ b/test/SwiftSyntax/DiagnosticTest.swift
@@ -36,6 +36,9 @@ extension Diagnostic.Message {
   static func badFunction(_ name: TokenSyntax) -> Diagnostic.Message {
     return .init(.error, "bad function '\(name.text)'")
   }
+  static func endOfFunction(_ name: TokenSyntax) -> Diagnostic.Message {
+    return .init(.warning, "end of function '\(name.text)'")
+  }
 }
 
 var Diagnostics = TestSuite("Diagnostics")
@@ -84,11 +87,12 @@ Diagnostics.test("SourceLocations") {
     }
     override func visit(_ function: FunctionDeclSyntax) {
       let startLoc = function.identifier.startLocation(in: url)
-      let endLoc = function.identifier.endLocation(in: url)
+      let endLoc = function.endLocation(in: url)
+      print("\(function.identifier.text): startLoc: \(startLoc), endLoc: \(endLoc)")
       engine.diagnose(.badFunction(function.identifier), location: startLoc) {
         $0.highlight(function.identifier.sourceRange(in: self.url))
       }
-      engine.diagnose(.badFunction(function.identifier), location: endLoc)
+      engine.diagnose(.endOfFunction(function.identifier), location: endLoc)
     }
   }
 
@@ -101,7 +105,7 @@ Diagnostics.test("SourceLocations") {
   let lines = Set(engine.diagnostics.compactMap { $0.location?.line })
   expectEqual([1, 3, 5, 7, 9, 11], lines)
   let columns = Set(engine.diagnostics.compactMap { $0.location?.column })
-  expectEqual([6, 1], columns)
+  expectEqual([6, 2], columns)
 }
 
 runAllTests()

--- a/test/SwiftSyntax/DiagnosticTest.swift
+++ b/test/SwiftSyntax/DiagnosticTest.swift
@@ -84,9 +84,11 @@ Diagnostics.test("SourceLocations") {
     }
     override func visit(_ function: FunctionDeclSyntax) {
       let startLoc = function.identifier.startLocation(in: url)
+      let endLoc = function.identifier.endLocation(in: url)
       engine.diagnose(.badFunction(function.identifier), location: startLoc) {
         $0.highlight(function.identifier.sourceRange(in: self.url))
       }
+      engine.diagnose(.badFunction(function.identifier), location: endLoc)
     }
   }
 
@@ -95,11 +97,11 @@ Diagnostics.test("SourceLocations") {
     Visitor(url: url, engine: engine).visit(file)
   })
 
-  expectEqual(3, engine.diagnostics.count)
+  expectEqual(6, engine.diagnostics.count)
   let lines = Set(engine.diagnostics.compactMap { $0.location?.line })
-  expectEqual([1, 5, 9], lines)
+  expectEqual([1, 3, 5, 7, 9, 11], lines)
   let columns = Set(engine.diagnostics.compactMap { $0.location?.column })
-  expectEqual([6], columns)
+  expectEqual([6, 1], columns)
 }
 
 runAllTests()

--- a/test/SwiftSyntax/DiagnosticTest.swift
+++ b/test/SwiftSyntax/DiagnosticTest.swift
@@ -12,6 +12,14 @@ func loc(_ file: String = #file, line: Int = #line,
   return SourceLocation(line: line, column: column, offset: 0, file: file)
 }
 
+func getInput(_ file: String) -> URL {
+  var result = URL(fileURLWithPath: #file)
+  result.deleteLastPathComponent()
+  result.appendPathComponent("Inputs")
+  result.appendPathComponent(file)
+  return result
+}
+
 /// Adds static constants to Diagnostic.Message.
 extension Diagnostic.Message {
   /// Error thrown when a conversion between two types is impossible.
@@ -24,6 +32,10 @@ extension Diagnostic.Message {
   /// Suggestion for the user to explicitly check a value does not equal zero.
   static let checkEqualToZero =
     Diagnostic.Message(.note, "check for explicit equality to '0'")
+
+  static func badFunction(_ name: TokenSyntax) -> Diagnostic.Message {
+    return .init(.error, "bad function '\(name.text)'")
+  }
 }
 
 var Diagnostics = TestSuite("Diagnostics")
@@ -56,6 +68,38 @@ Diagnostics.test("DiagnosticEmission") {
 
   guard let fixIt = note.fixIts.first else { return }
   expectEqual(fixIt.text, " != 0")
+}
+
+Diagnostics.test("SourceLocations") {
+  let engine = DiagnosticEngine()
+  engine.addConsumer(PrintingDiagnosticConsumer())
+  let url = getInput("diagnostics.swift")
+
+  class Visitor: SyntaxVisitor {
+    let url: URL
+    let engine: DiagnosticEngine
+    init(url: URL, engine: DiagnosticEngine) {
+      self.url = url
+      self.engine = engine
+    }
+    override func visit(_ function: FunctionDeclSyntax) {
+      let startLoc = function.identifier.startLocation(in: url)
+      engine.diagnose(.badFunction(function.identifier), location: startLoc) {
+        $0.highlight(function.identifier.sourceRange(in: self.url))
+      }
+    }
+  }
+
+  expectDoesNotThrow({
+    let file = try SourceFileSyntax.parse(url)
+    Visitor(url: url, engine: engine).visit(file)
+  })
+
+  expectEqual(3, engine.diagnostics.count)
+  let lines = Set(engine.diagnostics.compactMap { $0.location?.line })
+  expectEqual([1, 5, 9], lines)
+  let columns = Set(engine.diagnostics.compactMap { $0.location?.column })
+  expectEqual([6], columns)
 }
 
 runAllTests()

--- a/test/SwiftSyntax/Inputs/diagnostics.swift
+++ b/test/SwiftSyntax/Inputs/diagnostics.swift
@@ -1,0 +1,11 @@
+func foo() {
+
+}
+
+func bar() {
+
+}
+
+func baz() {
+
+}

--- a/tools/SwiftSyntax/RawSyntax.swift
+++ b/tools/SwiftSyntax/RawSyntax.swift
@@ -251,6 +251,13 @@ extension RawSyntax {
     }
   }
 
+  func accumulateTrailingTrivia(_ pos: AbsolutePosition) {
+    guard let trivia = trailingTrivia else { return }
+    for piece in trivia {
+      piece.accumulateAbsolutePosition(pos)
+    }
+  }
+
   var isSourceFile: Bool {
     switch self {
     case .node(let kind, _, _):

--- a/tools/SwiftSyntax/Syntax.swift
+++ b/tools/SwiftSyntax/Syntax.swift
@@ -213,8 +213,8 @@ extension Syntax {
     afterLeadingTrivia: Bool = true
   ) -> SourceLocation {
     let pos = afterLeadingTrivia ? 
-      data.position :
-      data.positionAfterSkippingLeadingTrivia
+      data.position.copy() :
+      data.positionAfterSkippingLeadingTrivia.copy()
     return SourceLocation(file: file.path, position: pos)
   }
 
@@ -228,7 +228,7 @@ extension Syntax {
     in file: URL,
     afterTrailingTrivia: Bool = false
   ) -> SourceLocation {
-    let pos = data.positionAfterSkippingLeadingTrivia
+    let pos = data.position.copy()
     raw.accumulateAbsolutePosition(pos)
     if afterTrailingTrivia {
       raw.accumulateTrailingTrivia(pos)

--- a/tools/SwiftSyntax/Syntax.swift
+++ b/tools/SwiftSyntax/Syntax.swift
@@ -202,6 +202,56 @@ extension Syntax {
     where Target: TextOutputStream {
     data.raw.write(to: &target)
   }
+
+  /// The starting location, in the provided file, of this Syntax node.
+  /// - Parameters:
+  ///   - file: The file URL this node resides in.
+  ///   - afterLeadingTrivia: Whether to skip leading trivia when getting
+  ///                         the node's location. Defaults to `true`.
+  public func startLocation(
+    in file: URL,
+    afterLeadingTrivia: Bool = true
+  ) -> SourceLocation {
+    let pos = afterLeadingTrivia ? 
+      data.position :
+      data.positionAfterSkippingLeadingTrivia
+    return SourceLocation(file: file.path, position: pos)
+  }
+
+
+  /// The ending location, in the provided file, of this Syntax node.
+  /// - Parameters:
+  ///   - file: The file URL this node resides in.
+  ///   - afterTrailingTrivia: Whether to skip trailing trivia when getting
+  ///                          the node's location. Defaults to `false`.
+  public func endLocation(
+    in file: URL,
+    afterTrailingTrivia: Bool = false
+  ) -> SourceLocation {
+    let pos = data.positionAfterSkippingLeadingTrivia
+    raw.accumulateAbsolutePosition(pos)
+    if afterTrailingTrivia {
+      raw.accumulateTrailingTrivia(pos)
+    }
+    return SourceLocation(file: file.path, position: pos)
+  }
+
+  /// The source range, in the provided file, of this Syntax node.
+  /// - Parameters:
+  ///   - file: The file URL this node resides in.
+  ///   - afterLeadingTrivia: Whether to skip leading trivia when getting
+  ///                          the node's start location. Defaults to `true`.
+  ///   - afterTrailingTrivia: Whether to skip trailing trivia when getting
+  ///                          the node's end location. Defaults to `false`.
+  public func sourceRange(
+    in file: URL,
+    afterLeadingTrivia: Bool = true,
+    afterTrailingTrivia: Bool = false
+  ) -> SourceRange {
+    let start = startLocation(in: file, afterLeadingTrivia: afterLeadingTrivia)
+    let end = endLocation(in: file, afterTrailingTrivia: afterTrailingTrivia)
+    return SourceRange(start: start, end: end)
+  }
 }
 
 /// Determines if two nodes are equal to each other.


### PR DESCRIPTION
This patch adds accessors on `Syntax` for `startLocation`, `endLocation`, and `sourceRange`. They have to take a file URL, because the Syntax tree is independent of a file.

Also add a test in the DiagnosticTest that gets the source locations of a file.