### PR TITLE
IRGen: the runtime is compacted into the stdlib

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1850,11 +1850,21 @@ LinkInfo LinkInfo::get(const UniversalLinkageInfo &linkInfo,
                        ModuleDecl *swiftModule, const LinkEntity &entity,
                        ForDefinition_t isDefinition) {
   LinkInfo result;
+  // FIXME: For anything in the standard library, we assume is locally defined.
+  // The only two ways imported interfaces are currently created is via a shims
+  // interface where the ClangImporter will correctly give us the proper DLL
+  // storage for the declaration.  Otherwise, it is from a `@_silgen_name`
+  // attributed declaration, which we explicitly handle elsewhere.  So, in the
+  // case of a standard library build, just assume everything is locally
+  // defined.  Ideally, we would integrate the linkage calculation properly to
+  // avoid this special casing.
+  ForDefinition_t isStdlibOrDefinition =
+      ForDefinition_t(swiftModule->isStdlibModule() || isDefinition);
 
   entity.mangle(result.Name);
   std::tie(result.Linkage, result.Visibility, result.DLLStorageClass) =
-      getIRLinkage(linkInfo, entity.getLinkage(isDefinition), isDefinition,
-                   entity.isWeakImported(swiftModule));
+      getIRLinkage(linkInfo, entity.getLinkage(isStdlibOrDefinition),
+                   isDefinition, entity.isWeakImported(swiftModule));
   result.ForDefinition = isDefinition;
   return result;
 }
@@ -2332,6 +2342,14 @@ llvm::Function *IRGenModule::getAddrOfSILFunction(SILFunction *f,
   }
   fn = createFunction(*this, link, signature, insertBefore,
                       f->getOptimizationMode());
+
+  // If `hasCReferences` is true, then the function is either marked with
+  // @_silgen_name OR @_cdecl.  If it is the latter, it must have a definition
+  // associated with it.  The combination of the two allows us to identify the
+  // @_silgen_name functions.  These are locally defined function thunks used in
+  // the standard library.  Do not give them DLLImport DLL Storage.
+  if (useDllStorage() && f->hasCReferences() && !forDefinition)
+    fn->setDLLStorageClass(llvm::GlobalValue::DefaultStorageClass);
 
   // If we have an order number for this function, set it up as appropriate.
   if (hasOrderNumber) {

--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -466,6 +466,31 @@ static bool isReturnedAttribute(llvm::Attribute::AttrKind Attr) {
   return Attr == llvm::Attribute::Returned;
 }
 
+namespace {
+bool isStandardLibrary(const llvm::Module &M) {
+  if (auto *Flags = M.getNamedMetadata("swift.module.flags")) {
+    for (const auto *F : Flags->operands()) {
+      const auto *Key = dyn_cast_or_null<llvm::MDString>(F->getOperand(0));
+      if (!Key)
+        continue;
+
+      const auto *Value =
+          dyn_cast_or_null<llvm::ConstantAsMetadata>(F->getOperand(1));
+      if (!Value)
+        continue;
+
+      if (Key->getString() == "standard-library")
+        return cast<llvm::ConstantInt>(Value->getValue())->isOne();
+    }
+  }
+  return false;
+}
+}
+
+bool IRGenModule::isStandardLibrary() const {
+  return ::isStandardLibrary(Module);
+}
+
 llvm::Constant *swift::getRuntimeFn(llvm::Module &Module,
                       llvm::Constant *&cache,
                       const char *name,
@@ -493,10 +518,13 @@ llvm::Constant *swift::getRuntimeFn(llvm::Module &Module,
   if (auto fn = dyn_cast<llvm::Function>(cache)) {
     fn->setCallingConv(cc);
 
-    if (::useDllStorage(llvm::Triple(Module.getTargetTriple())) &&
-        ((fn->getLinkage() == llvm::GlobalValue::ExternalLinkage &&
-          fn->isDeclaration()) ||
-         fn->getLinkage() == llvm::GlobalValue::AvailableExternallyLinkage))
+    bool IsExternal =
+        fn->getLinkage() == llvm::GlobalValue::AvailableExternallyLinkage ||
+        (fn->getLinkage() == llvm::GlobalValue::ExternalLinkage &&
+         fn->isDeclaration());
+
+    if (!isStandardLibrary(Module) && IsExternal &&
+        ::useDllStorage(llvm::Triple(Module.getTargetTriple())))
       fn->setDLLStorageClass(llvm::GlobalValue::DLLImportStorageClass);
 
     llvm::AttrBuilder buildFnAttr;
@@ -567,18 +595,16 @@ IRGenModule::createStringConstant(StringRef Str,
   return { global, address };
 }
 
-#define KNOWN_METADATA_ACCESSOR(NAME, SYM) \
-llvm::Constant *IRGenModule::get##NAME() { \
-  if (NAME) \
-    return NAME; \
-  NAME = Module.getOrInsertGlobal( \
-                          SYM, \
-                          FullTypeMetadataStructTy); \
-  if (useDllStorage()) \
-    cast<llvm::GlobalVariable>(NAME) \
-        ->setDLLStorageClass(llvm::GlobalValue::DLLImportStorageClass); \
-  return NAME; \
-}
+#define KNOWN_METADATA_ACCESSOR(NAME, SYM)                                     \
+  llvm::Constant *IRGenModule::get##NAME() {                                   \
+    if (NAME)                                                                  \
+      return NAME;                                                             \
+    NAME = Module.getOrInsertGlobal(SYM, FullTypeMetadataStructTy);            \
+    if (useDllStorage() && !isStandardLibrary())                               \
+      cast<llvm::GlobalVariable>(NAME)->setDLLStorageClass(                    \
+          llvm::GlobalValue::DLLImportStorageClass);                           \
+    return NAME;                                                               \
+  }
 
 KNOWN_METADATA_ACCESSOR(EmptyTupleMetadata,
                         MANGLE_AS_STRING(METADATA_SYM(EMPTY_TUPLE_MANGLING)))

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -1026,6 +1026,8 @@ public:
   llvm::Module *releaseModule();
   llvm::AttributeList getAllocAttrs();
 
+  bool isStandardLibrary() const;
+
 private:
   llvm::Constant *EmptyTupleMetadata = nullptr;
   llvm::Constant *AnyExistentialMetadata = nullptr;

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -432,9 +432,10 @@ llvm::Constant *irgen::tryEmitConstantHeapMetadataRef(IRGenModule &IGM,
 ConstantReference
 irgen::tryEmitConstantTypeMetadataRef(IRGenModule &IGM, CanType type,
                                       SymbolReferenceKind refKind) {
+  if (IGM.isStandardLibrary())
+    return ConstantReference();
   if (!isTypeMetadataAccessTrivial(IGM, type))
     return ConstantReference();
-
   return IGM.getAddrOfTypeMetadata(type, refKind);
 }
 

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -255,20 +255,27 @@ if(SWIFT_BUILD_STATIC_STDLIB AND "${SWIFT_HOST_VARIANT_SDK}" STREQUAL "LINUX")
    list(APPEND swift_core_private_link_libraries swiftImageInspectionShared)
 endif()
 
-add_swift_library(swiftCore ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB IS_STDLIB_CORE
-  ${SWIFTLIB_SOURCES}
-  # The copy_shim_headers target dependency is required to let the
-  # build system know that there's a rule to produce the shims
-  # directory, but is not sufficient to cause the object file to be rebuilt
-  # when the shim header changes.  Therefore, we pass both the target
-  # and the generated directory as dependencies.
-  FILE_DEPENDS
-    copy_shim_headers "${SWIFTLIB_DIR}/shims"
-    ${GROUP_INFO_JSON_FILE}
-  SWIFT_COMPILE_FLAGS ${swift_stdlib_compile_flags}
-  LINK_FLAGS ${swift_core_link_flags}
-  PRIVATE_LINK_LIBRARIES ${swift_core_private_link_libraries}
-  INCORPORATE_OBJECT_LIBRARIES swiftRuntime swiftStdlibStubs
-  INCORPORATE_OBJECT_LIBRARIES_SHARED_ONLY ${shared_only_libs}
-  FRAMEWORK_DEPENDS ${swift_core_framework_depends}
-  INSTALL_IN_COMPONENT stdlib)
+add_swift_library(swiftCore
+                  ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB IS_STDLIB_CORE
+                    ${SWIFTLIB_SOURCES}
+                  # The copy_shim_headers target dependency is required to let the
+                  # build system know that there's a rule to produce the shims
+                  # directory, but is not sufficient to cause the object file to be rebuilt
+                  # when the shim header changes.  Therefore, we pass both the target
+                  # and the generated directory as dependencies.
+                  FILE_DEPENDS
+                    copy_shim_headers "${SWIFTLIB_DIR}/shims" ${GROUP_INFO_JSON_FILE}
+                  SWIFT_COMPILE_FLAGS
+                    ${swift_stdlib_compile_flags} -Xcc -DswiftCore_EXPORTS
+                  LINK_FLAGS
+                    ${swift_core_link_flags}
+                  PRIVATE_LINK_LIBRARIES
+                    ${swift_core_private_link_libraries}
+                  INCORPORATE_OBJECT_LIBRARIES
+                    swiftRuntime swiftStdlibStubs
+                  INCORPORATE_OBJECT_LIBRARIES_SHARED_ONLY
+                    ${shared_only_libs}
+                  FRAMEWORK_DEPENDS
+                    ${swift_core_framework_depends}
+                  INSTALL_IN_COMPONENT
+                    stdlib)


### PR DESCRIPTION
Correct the DLL Storage for runtime functions in the standard library
when building for Windows.  This corrects the non-ARC entry points.
Partially resolves SR-7107.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
