### PR TITLE
Temporarily disable an optimization to avoid some crashes.

### DIFF
--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -1143,7 +1143,8 @@ getAddrOfKnownValueWitnessTable(IRGenModule &IGM, CanType type) {
       witnessSurrogate = C.TheUnknownObjectType;
       break;
     case ReferenceCounting::Bridge:
-      witnessSurrogate = C.TheBridgeObjectType;
+      // FIXME: Temporarily disable this optimization (rdar://problem/39697747)
+      // witnessSurrogate = C.TheBridgeObjectType;
       break;
     case ReferenceCounting::Error:
       break;


### PR DESCRIPTION
We are seeing some crashes due to this optimization where a type
contains a single retainable pointer. Temporarily disable it while
we get to the root cause.

rdar://problem/39629937