### PR TITLE
swift-remoteast-test: mark exported interfaces

### DIFF
--- a/tools/swift-remoteast-test/swift-remoteast-test.cpp
+++ b/tools/swift-remoteast-test/swift-remoteast-test.cpp
@@ -24,6 +24,14 @@
 #include "llvm/Support/raw_ostream.h"
 #include <cassert>
 
+#if defined(__ELF__)
+#define SWIFT_REMOTEAST_TEST_ABI __attribute__((__visibility__("default")))
+#elif defined(__MACH__)
+#define SWIFT_REMOTEAST_TEST_ABI __attribute__((__visibility__("default")))
+#else
+#define SWIFT_REMOTEAST_TEST_ABI __declspec(dllexport)
+#endif
+
 using namespace swift;
 using namespace swift::remote;
 using namespace swift::remoteAST;
@@ -33,7 +41,7 @@ static ASTContext *Context = nullptr;
 
 // FIXME: swiftcall
 /// func printType(forMetadata: Any.Type)
-LLVM_ATTRIBUTE_USED
+LLVM_ATTRIBUTE_USED SWIFT_REMOTEAST_TEST_ABI
 extern "C" void printMetadataType(const Metadata *typeMetadata) {
   assert(Context && "context was not set");
 
@@ -55,7 +63,7 @@ extern "C" void printMetadataType(const Metadata *typeMetadata) {
 
 // FIXME: swiftcall
 /// func printDynamicType(_: AnyObject)
-LLVM_ATTRIBUTE_USED
+LLVM_ATTRIBUTE_USED SWIFT_REMOTEAST_TEST_ABI
 extern "C" void printHeapMetadataType(void *object) {
   assert(Context && "context was not set");
 
@@ -118,7 +126,7 @@ static void printMemberOffset(const Metadata *typeMetadata,
 
 // FIXME: swiftcall
 /// func printTypeMemberOffset(forType: Any.Type, memberName: StaticString)
-LLVM_ATTRIBUTE_USED
+LLVM_ATTRIBUTE_USED SWIFT_REMOTEAST_TEST_ABI
 extern "C" void printTypeMemberOffset(const Metadata *typeMetadata,
                                       const char *memberName) {
   printMemberOffset(typeMetadata, memberName, /*pass metadata*/ false);
@@ -127,7 +135,7 @@ extern "C" void printTypeMemberOffset(const Metadata *typeMetadata,
 // FIXME: swiftcall
 /// func printTypeMetadataMemberOffset(forType: Any.Type,
 ///                                    memberName: StaticString)
-LLVM_ATTRIBUTE_USED
+LLVM_ATTRIBUTE_USED SWIFT_REMOTEAST_TEST_ABI
 extern "C" void printTypeMetadataMemberOffset(const Metadata *typeMetadata,
                                               const char *memberName) {
   printMemberOffset(typeMetadata, memberName, /*pass metadata*/ true);


### PR DESCRIPTION
Mark the exported interfaces in the tool for the `ENABLE_EXPORTS`
to work properly.  This fixes the dependency tracking on Windows
and ensures that the tool is not continuously rebuilt.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
