### PR TITLE
[AST] QoI: fix incomplete assert() in ReferenceStorageType::get()

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -398,6 +398,7 @@ class CanType : public Type {
   static bool isExistentialTypeImpl(CanType type);
   static bool isAnyExistentialTypeImpl(CanType type);
   static bool isObjCExistentialTypeImpl(CanType type);
+  static bool isOptionalTypeImpl(CanType type);
   static CanType getOptionalObjectTypeImpl(CanType type);
   static CanType getReferenceStorageReferentImpl(CanType type);
   static CanType getWithoutSpecifierTypeImpl(CanType type);
@@ -464,6 +465,10 @@ public:
   CanType getNominalParent() const; // in Types.h
   NominalTypeDecl *getAnyNominal() const;
   GenericTypeDecl *getAnyGeneric() const;
+
+  bool isOptionalType() const {
+    return isOptionalTypeImpl(*this);
+  }
 
   CanType getOptionalObjectType() const {
     return getOptionalObjectTypeImpl(*this);

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1042,6 +1042,9 @@ public:
                                       const ValueDecl *derivedDecl,
                                       Type memberType);
 
+  /// Return true if this type is Optional<T>; otherwise false;
+  bool isOptionalType();
+
   /// Return T if this type is Optional<T>; otherwise, return the null type.
   Type getOptionalObjectType();
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -3469,6 +3469,9 @@ ReferenceStorageType *ReferenceStorageType::get(Type T,
                                                 const ASTContext &C) {
   assert(ownership != ReferenceOwnership::Strong &&
          "ReferenceStorageType is unnecessary for strong ownership");
+  assert((ownership == ReferenceOwnership::Weak) == T->isOptionalType() &&
+         "optionalness of ReferenceStorageType does not match "
+         "optionalness of type");
   assert(!T->hasTypeVariable()); // not meaningful in type-checker
   auto properties = T->getRecursiveProperties();
   auto arena = getArena(properties);
@@ -3485,8 +3488,6 @@ ReferenceStorageType *ReferenceStorageType::get(Type T,
     return entry = new (C, arena) UnownedStorageType(
                T, T->isCanonical() ? &C : nullptr, properties);
   case ReferenceOwnership::Weak:
-    assert(T->getOptionalObjectType() &&
-           "object of weak storage type is not optional");
     return entry = new (C, arena)
                WeakStorageType(T, T->isCanonical() ? &C : nullptr, properties);
   case ReferenceOwnership::Unmanaged:

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -551,6 +551,18 @@ Type TypeBase::getRValueType() {
     });
 }
 
+bool TypeBase::isOptionalType() {
+  if (auto boundTy = getAs<BoundGenericEnumType>())
+    return boundTy->getDecl()->isOptionalDecl();
+  return false;
+}
+
+bool CanType::isOptionalTypeImpl(CanType type) {
+  if (auto boundTy = dyn_cast<BoundGenericEnumType>(type))
+    return boundTy->getDecl()->isOptionalDecl();
+  return false;
+}
+
 Type TypeBase::getOptionalObjectType() {
   if (auto boundTy = getAs<BoundGenericEnumType>())
     if (boundTy->getDecl()->isOptionalDecl())
@@ -562,7 +574,6 @@ CanType CanType::getOptionalObjectTypeImpl(CanType type) {
   if (auto boundTy = dyn_cast<BoundGenericEnumType>(type))
     if (boundTy->getDecl()->isOptionalDecl())
       return boundTy.getGenericArgs()[0];
-
   return CanType();
 }
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2056,20 +2056,13 @@ applyPropertyOwnership(VarDecl *prop,
     prop->getAttrs().add(new (ctx) NSCopyingAttr(false));
     return;
   }
-  if (attrs & clang::ObjCPropertyDecl::OBJC_PR_weak) {
+  if ((attrs & clang::ObjCPropertyDecl::OBJC_PR_weak) ||
+      (attrs & clang::ObjCPropertyDecl::OBJC_PR_assign) ||
+      (attrs & clang::ObjCPropertyDecl::OBJC_PR_unsafe_unretained)) {
     prop->getAttrs().add(new (ctx)
                              ReferenceOwnershipAttr(ReferenceOwnership::Weak));
     prop->setType(WeakStorageType::get(prop->getType(), ctx));
     prop->setInterfaceType(WeakStorageType::get(
-        prop->getInterfaceType(), ctx));
-    return;
-  }
-  if ((attrs & clang::ObjCPropertyDecl::OBJC_PR_assign) ||
-      (attrs & clang::ObjCPropertyDecl::OBJC_PR_unsafe_unretained)) {
-    prop->getAttrs().add(
-        new (ctx) ReferenceOwnershipAttr(ReferenceOwnership::Unmanaged));
-    prop->setType(UnmanagedStorageType::get(prop->getType(), ctx));
-    prop->setInterfaceType(UnmanagedStorageType::get(
         prop->getInterfaceType(), ctx));
     return;
   }

--- a/test/SIL/Parser/unmanaged.sil
+++ b/test/SIL/Parser/unmanaged.sil
@@ -5,22 +5,22 @@ import Builtin
 
 class C {}
 
-sil @test : $@convention(thin) <U where U : AnyObject> (@inout Optional<U>) -> () {
-bb0(%0 : $*Optional<U>):
-  %1 = load [copy] %0 : $*Optional<U>
-  %2 = ref_to_unmanaged %1 : $Optional<U> to $@sil_unmanaged Optional<U>
-  %3 = unmanaged_to_ref %2 : $@sil_unmanaged Optional<U> to $Optional<U>
-  destroy_value %1 : $Optional<U>
+sil @test : $@convention(thin) <U where U : AnyObject> (@inout U) -> () {
+bb0(%0 : $*U):
+  %1 = load [copy] %0 : $*U
+  %2 = ref_to_unmanaged %1 : $U to $@sil_unmanaged U
+  %3 = unmanaged_to_ref %2 : $@sil_unmanaged U to $U
+  destroy_value %1 : $U
   %9999 = tuple ()
   return %9999 : $()
 }
 
-sil @retain_release : $@convention(thin) (@sil_unmanaged Optional<C>) -> () {
-bb0(%0 : $@sil_unmanaged Optional<C>):
-  %1 = unmanaged_to_ref %0 : $@sil_unmanaged Optional<C> to $Optional<C>
-  unmanaged_retain_value %1 : $Optional<C>
-  unmanaged_autorelease_value %1 : $Optional<C>
-  unmanaged_release_value %1 : $Optional<C>
+sil @retain_release : $@convention(thin) (@sil_unmanaged C) -> () {
+bb0(%0 : $@sil_unmanaged C):
+  %1 = unmanaged_to_ref %0 : $@sil_unmanaged C to $C
+  unmanaged_retain_value %1 : $C
+  unmanaged_autorelease_value %1 : $C
+  unmanaged_release_value %1 : $C
   %9999 = tuple()
   return %9999 : $()
 }

--- a/test/SIL/Serialization/unmanaged.sil
+++ b/test/SIL/Serialization/unmanaged.sil
@@ -9,34 +9,34 @@ import Builtin
 
 class C {}
 
-// CHECK-LABEL: sil [serialized] @retain_release : $@convention(thin) (@sil_unmanaged Optional<C>) -> () {
-// CHECK: bb0([[ARG:%.*]] : $@sil_unmanaged Optional<C>):
-// CHECK: [[REF:%.*]] = unmanaged_to_ref [[ARG]] : $@sil_unmanaged Optional<C> to $Optional<C>
+// CHECK-LABEL: sil [serialized] @retain_release : $@convention(thin) (@sil_unmanaged C) -> () {
+// CHECK: bb0([[ARG:%.*]] : $@sil_unmanaged C):
+// CHECK: [[REF:%.*]] = unmanaged_to_ref [[ARG]] : $@sil_unmanaged C to $C
 // CHECK: unmanaged_retain_value [[REF]]
 // CHECK: unmanaged_autorelease_value [[REF]]
 // CHECK: unmanaged_release_value [[REF]]
-sil [serialized] @retain_release : $@convention(thin) (@sil_unmanaged Optional<C>) -> () {
-bb0(%0 : $@sil_unmanaged Optional<C>):
-  %1 = unmanaged_to_ref %0 : $@sil_unmanaged Optional<C> to $Optional<C>
-  unmanaged_retain_value %1 : $Optional<C>
-  unmanaged_autorelease_value %1 : $Optional<C>
-  unmanaged_release_value %1 : $Optional<C>
+sil [serialized] @retain_release : $@convention(thin) (@sil_unmanaged C) -> () {
+bb0(%0 : $@sil_unmanaged C):
+  %1 = unmanaged_to_ref %0 : $@sil_unmanaged C to $C
+  unmanaged_retain_value %1 : $C
+  unmanaged_autorelease_value %1 : $C
+  unmanaged_release_value %1 : $C
   %9999 = tuple()
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil [serialized] @test : $@convention(thin) <U where U : AnyObject> (@inout Optional<U>) -> () {
-// CHECK: bb0([[ARG:%.*]] : $*Optional<U>):
+// CHECK-LABEL: sil [serialized] @test : $@convention(thin) <U where U : AnyObject> (@inout U) -> () {
+// CHECK: bb0([[ARG:%.*]] : $*U):
 // CHECK: [[LOADED_ARG:%.*]] = load [copy] [[ARG]]
-// CHECK: [[UNMANAGED_LOADED_ARG:%.*]] = ref_to_unmanaged [[LOADED_ARG]] : $Optional<U> to $@sil_unmanaged Optional<U>
-// CHECK: {{%.*}} = unmanaged_to_ref [[UNMANAGED_LOADED_ARG]] : $@sil_unmanaged Optional<U> to $Optional<U>
+// CHECK: [[UNMANAGED_LOADED_ARG:%.*]] = ref_to_unmanaged [[LOADED_ARG]] : $U to $@sil_unmanaged U
+// CHECK: {{%.*}} = unmanaged_to_ref [[UNMANAGED_LOADED_ARG]] : $@sil_unmanaged U to $U
 // CHECK: destroy_value [[LOADED_ARG]]
-sil [serialized] @test : $@convention(thin) <U where U : AnyObject> (@inout Optional<U>) -> () {
-bb0(%0 : $*Optional<U>):
-  %1 = load [copy] %0 : $*Optional<U>
-  %2 = ref_to_unmanaged %1 : $Optional<U> to $@sil_unmanaged Optional<U>
-  %3 = unmanaged_to_ref %2 : $@sil_unmanaged Optional<U> to $Optional<U>
-  destroy_value %1 : $Optional<U>
+sil [serialized] @test : $@convention(thin) <U where U : AnyObject> (@inout U) -> () {
+bb0(%0 : $*U):
+  %1 = load [copy] %0 : $*U
+  %2 = ref_to_unmanaged %1 : $U to $@sil_unmanaged U
+  %3 = unmanaged_to_ref %2 : $@sil_unmanaged U to $U
+  destroy_value %1 : $U
   %9999 = tuple ()
   return %9999 : $()
 }


### PR DESCRIPTION
Semantic analysis prevents optional unowned/unmanged types, but `ReferenceStorageType::get()` doesn't verify this condition. This lets bogus SIL code slip through.

Found while converting the reference storage types to meta-programming to make adding new reference storage types easier.