### PR TITLE
[benchmark] Replace hashValue implementations with hash(into:)

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -63,6 +63,7 @@ set(SWIFT_BENCH_MODULES
     single-source/DictTest2
     single-source/DictTest3
     single-source/DictTest4
+    single-source/DictTest4Legacy
     single-source/DictionaryBridge
     single-source/DictionaryCopy
     single-source/DictionaryGroup

--- a/benchmark/multi-source/PrimsSplit/Prims.swift
+++ b/benchmark/multi-source/PrimsSplit/Prims.swift
@@ -176,10 +176,9 @@ func ==(lhs: Edge, rhs: Edge) -> Bool {
 }
 
 extension Edge : Hashable {
-  var hashValue: Int {
-    get {
-      return start.hashValue ^ end.hashValue
-    }
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(start)
+    hasher.combine(end)
   }
 }
 

--- a/benchmark/single-source/AnyHashableWithAClass.swift
+++ b/benchmark/single-source/AnyHashableWithAClass.swift
@@ -33,9 +33,11 @@ class TestHashableBase : Hashable {
   init(_ value: Int) {
     self.value = value
   }
-  var hashValue: Int {
-    return value
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
   }
+
   static func == (
     lhs: TestHashableBase,
     rhs: TestHashableBase

--- a/benchmark/single-source/BinaryFloatingPointConversionFromBinaryInteger.swift
+++ b/benchmark/single-source/BinaryFloatingPointConversionFromBinaryInteger.swift
@@ -59,8 +59,8 @@ extension MockBinaryInteger : Comparable {
 }
 
 extension MockBinaryInteger : Hashable {
-  var hashValue: Int {
-    return _value.hashValue
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(_value)
   }
 }
 

--- a/benchmark/single-source/DictTest.swift
+++ b/benchmark/single-source/DictTest.swift
@@ -157,8 +157,8 @@ class Box<T : Hashable> : Hashable {
     value = v
   }
 
-  var hashValue: Int {
-    return value.hashValue
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
   }
 
   static func ==(lhs: Box, rhs: Box) -> Bool {

--- a/benchmark/single-source/DictTest2.swift
+++ b/benchmark/single-source/DictTest2.swift
@@ -49,8 +49,8 @@ class Box<T : Hashable> : Hashable {
     value = v
   }
 
-  var hashValue: Int {
-    return value.hashValue
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
   }
 
   static func ==(lhs: Box, rhs: Box) -> Bool {

--- a/benchmark/single-source/DictTest3.swift
+++ b/benchmark/single-source/DictTest3.swift
@@ -56,10 +56,10 @@ class Box<T : Hashable> : Hashable {
     value = v
   }
 
-  var hashValue: Int {
-    return value.hashValue
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
   }
-  
+
   static func ==(lhs: Box, rhs: Box) -> Bool {
     return lhs.value == rhs.value
   }

--- a/benchmark/single-source/DictTest4Legacy.swift
+++ b/benchmark/single-source/DictTest4Legacy.swift
@@ -13,18 +13,24 @@
 import TestsUtils
 
 // This benchmark mostly measures lookups in dictionaries with complex keys,
-// exercising the default hash compression function.
+// using the legacy hashValue API.
 
-public let Dictionary4 = [
+public let Dictionary4Legacy = [
   BenchmarkInfo(
-    name: "Dictionary4",
-    runFunction: run_Dictionary4,
+    name: "Dictionary4Legacy",
+    runFunction: run_Dictionary4Legacy,
     tags: [.validation, .api, .Dictionary]),
   BenchmarkInfo(
-    name: "Dictionary4OfObjects",
-    runFunction: run_Dictionary4OfObjects,
+    name: "Dictionary4OfObjectsLegacy",
+    runFunction: run_Dictionary4OfObjectsLegacy,
     tags: [.validation, .api, .Dictionary]),
 ]
+
+extension Int {
+  mutating func combine(_ value: Int) {
+    self = 16777619 &* self ^ value
+  }
+}
 
 struct LargeKey: Hashable {
   let i: Int
@@ -36,6 +42,19 @@ struct LargeKey: Hashable {
   let o: Bool
   let p: Bool
   let q: Bool
+
+  var hashValue: Int {
+    var hash = i.hashValue
+    hash.combine(j.hashValue)
+    hash.combine(k.hashValue)
+    hash.combine(l.hashValue)
+    hash.combine(m.hashValue)
+    hash.combine(n.hashValue)
+    hash.combine(o.hashValue)
+    hash.combine(p.hashValue)
+    hash.combine(q.hashValue)
+    return hash
+  }
 
   init(_ value: Int) {
     self.i = value
@@ -51,7 +70,7 @@ struct LargeKey: Hashable {
 }
 
 @inline(never)
-public func run_Dictionary4(_ N: Int) {
+public func run_Dictionary4Legacy(_ N: Int) {
   let size1 = 100
   let reps = 20
   let ref_result = "1 99 \(reps) \(reps * 99)"
@@ -95,13 +114,17 @@ class Box<T : Hashable> : Hashable {
     hasher.combine(value)
   }
 
+  var hashValue: Int {
+    return value.hashValue
+  }
+
   static func ==(lhs: Box, rhs: Box) -> Bool {
     return lhs.value == rhs.value
   }
 }
 
 @inline(never)
-public func run_Dictionary4OfObjects(_ N: Int) {
+public func run_Dictionary4OfObjectsLegacy(_ N: Int) {
   let size1 = 100
   let reps = 20
   let ref_result = "1 99 \(reps) \(reps * 99)"

--- a/benchmark/single-source/DictionaryGroup.swift
+++ b/benchmark/single-source/DictionaryGroup.swift
@@ -36,8 +36,8 @@ class Box<T : Hashable> : Hashable {
     value = v
   }
 
-  var hashValue: Int {
-    return value.hashValue
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
   }
 
   static func ==(lhs: Box, rhs: Box) -> Bool {

--- a/benchmark/single-source/DictionaryRemove.swift
+++ b/benchmark/single-source/DictionaryRemove.swift
@@ -52,8 +52,8 @@ class Box<T : Hashable> : Hashable {
     value = v
   }
 
-  var hashValue: Int {
-    return value.hashValue
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
   }
 
   static func ==(lhs: Box, rhs: Box) -> Bool {

--- a/benchmark/single-source/DictionarySubscriptDefault.swift
+++ b/benchmark/single-source/DictionarySubscriptDefault.swift
@@ -84,8 +84,8 @@ class Box<T : Hashable> : Hashable, P {
     value = v
   }
 
-  var hashValue: Int {
-    return value.hashValue
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
   }
 
   static func ==(lhs: Box, rhs: Box) -> Bool {

--- a/benchmark/single-source/DictionarySwap.swift
+++ b/benchmark/single-source/DictionarySwap.swift
@@ -83,8 +83,8 @@ class Box<T : Hashable> : Hashable {
     value = v
   }
 
-  var hashValue: Int {
-    return value.hashValue
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
   }
 
   static func ==(lhs: Box, rhs: Box) -> Bool {

--- a/benchmark/single-source/Prims.swift
+++ b/benchmark/single-source/Prims.swift
@@ -181,10 +181,9 @@ func ==(lhs: Edge, rhs: Edge) -> Bool {
 }
 
 extension Edge : Hashable {
-  var hashValue: Int {
-    get {
-      return start.hashValue ^ end.hashValue
-    }
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(start)
+    hasher.combine(end)
   }
 }
 

--- a/benchmark/single-source/RGBHistogram.swift
+++ b/benchmark/single-source/RGBHistogram.swift
@@ -124,8 +124,8 @@ class Box<T : Hashable> : Hashable {
     value = v
   }
 
-  var hashValue: Int {
-    return value.hashValue
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
   }
 
   static func ==(lhs: Box, rhs: Box) -> Bool {

--- a/benchmark/single-source/SetTests.swift
+++ b/benchmark/single-source/SetTests.swift
@@ -122,8 +122,8 @@ class Box<T : Hashable> : Hashable {
     value = v
   }
 
-  var hashValue: Int {
-    return value.hashValue
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(value)
   }
 
   static func ==(lhs: Box, rhs: Box) -> Bool {

--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -111,8 +111,8 @@ extension BenchmarkInfo : Comparable {
 }
 
 extension BenchmarkInfo : Hashable {
-  public var hashValue: Int {
-    return name.hashValue
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(name)
   }
 }
 

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -50,6 +50,7 @@ import DictTest
 import DictTest2
 import DictTest3
 import DictTest4
+import DictTest4Legacy
 import DictionaryBridge
 import DictionaryCopy
 import DictionaryGroup
@@ -203,6 +204,7 @@ registerBenchmark(Dictionary)
 registerBenchmark(Dictionary2)
 registerBenchmark(Dictionary3)
 registerBenchmark(Dictionary4)
+registerBenchmark(Dictionary4Legacy)
 registerBenchmark(DictionaryBridge)
 registerBenchmark(DictionaryCopy)
 registerBenchmark(DictionaryGroup)


### PR DESCRIPTION
This gives us a better picture of expected hashing performance.

Add a new benchmark to track legacy hashValue performance.
