### PR TITLE
libSyntax: add a mechanism to synthesize syntax nodes in SyntaxParsingContext.

### DIFF
--- a/include/swift/Parse/SyntaxParsingContext.h
+++ b/include/swift/Parse/SyntaxParsingContext.h
@@ -255,6 +255,14 @@ public:
   /// the syntax tree before closing the root context.
   void finalizeRoot();
 
+  /// Make a missing node corresponding to the given token kind and text, and
+  /// push this node into the context. The synthesized node can help
+  /// the creation of valid syntax nodes.
+  void synthesize(tok Kind, StringRef Text = "");
+
+  /// Make a missing node corresponding to the given node kind, and
+  /// push this node into the context.
+  void synthesize(SyntaxKind Kind);
 };
 
 } // namespace swift

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -637,8 +637,11 @@ ParserResult<BraceStmt> Parser::parseBraceItemList(Diag<> ID) {
 
   ParserStatus Status = parseBraceItems(Entries, BraceItemListKind::Brace,
                                         BraceItemListKind::Brace);
-  parseMatchingToken(tok::r_brace, RBLoc,
-                     diag::expected_rbrace_in_brace_stmt, LBLoc);
+  if (parseMatchingToken(tok::r_brace, RBLoc,
+                         diag::expected_rbrace_in_brace_stmt, LBLoc)) {
+    // Synthesize a r-brace if the source doesn't have any.
+    LocalContext.synthesize(tok::r_brace);
+  }
 
   return makeParserResult(Status,
                           BraceStmt::create(Context, LBLoc, Entries, RBLoc));

--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -317,6 +317,20 @@ void SyntaxParsingContext::finalizeRoot() {
   getRootData().Storage.clear();
 }
 
+void SyntaxParsingContext::synthesize(tok Kind, StringRef Text) {
+  if (!Enabled)
+    return;
+  if (Text.empty())
+    Text = getTokenText(Kind);
+  Storage.push_back(RawSyntax::missing(Kind, Text));
+}
+
+void SyntaxParsingContext::synthesize(SyntaxKind Kind) {
+  if (!Enabled)
+    return;
+  Storage.push_back(RawSyntax::missing(Kind));
+}
+
 SyntaxParsingContext::~SyntaxParsingContext() {
   assert(isTopOfContextStack() && "destructed in wrong order");
 

--- a/test/Syntax/Outputs/round_trip_invalid.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_invalid.swift.withkinds
@@ -1,0 +1,14 @@
+<FunctionDecl>// RUN: rm -rf %t
+// RUN: %swift-syntax-test -input-source-filename %s -parse-gen > %t
+// RUN: diff -u %s %t
+// RUN: %swift-syntax-test -input-source-filename %s -parse-gen -print-node-kind > %t.withkinds
+// RUN: diff -u %S/Outputs/round_trip_invalid.swift.withkinds %t.withkinds
+// RUN: %swift-syntax-test -input-source-filename %s -eof > %t
+// RUN: diff -u %s %t
+// RUN: %swift-syntax-test -serialize-raw-tree -input-source-filename %s > %t.dump
+// RUN: %swift-syntax-test -deserialize-raw-tree -input-source-filename %t.dump -output-filename %t
+// RUN: diff -u %s %t
+
+// Function body without closing brace token.
+func foo<FunctionSignature><ParameterClause>() </ParameterClause></FunctionSignature><CodeBlock>{<VariableDecl>
+  var <PatternBinding><IdentifierPattern>a </IdentifierPattern><InitializerClause>= <IntegerLiteralExpr>2</IntegerLiteralExpr></InitializerClause></PatternBinding></VariableDecl></CodeBlock></FunctionDecl>

--- a/test/Syntax/round_trip_invalid.swift
+++ b/test/Syntax/round_trip_invalid.swift
@@ -1,0 +1,14 @@
+// RUN: rm -rf %t
+// RUN: %swift-syntax-test -input-source-filename %s -parse-gen > %t
+// RUN: diff -u %s %t
+// RUN: %swift-syntax-test -input-source-filename %s -parse-gen -print-node-kind > %t.withkinds
+// RUN: diff -u %S/Outputs/round_trip_invalid.swift.withkinds %t.withkinds
+// RUN: %swift-syntax-test -input-source-filename %s -eof > %t
+// RUN: diff -u %s %t
+// RUN: %swift-syntax-test -serialize-raw-tree -input-source-filename %s > %t.dump
+// RUN: %swift-syntax-test -deserialize-raw-tree -input-source-filename %t.dump -output-filename %t
+// RUN: diff -u %s %t
+
+// Function body without closing brace token.
+func foo() {
+  var a = 2


### PR DESCRIPTION
To enhance the error-recovery of syntax parsing, this patch allows the
parser to synthesize missing nodes to satisfy the requirement of a
syntax node under parsing. As proof-of-concept, we synthesize r-braces
for function body to avoid regressing a function decl to an unknown
decl.