### PR TITLE
Sema: Don't set 'validation started' bit on ParamDecls from validateDecl()

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -748,7 +748,7 @@ Type TypeChecker::getUnopenedTypeOfReference(VarDecl *value, Type baseType,
                                              const DeclRefExpr *base,
                                              bool wantInterfaceType) {
   validateDecl(value);
-  if (value->isInvalid())
+  if (!value->hasValidSignature() || value->isInvalid())
     return ErrorType::get(Context);
 
   Type requestedType = (wantInterfaceType

--- a/validation-test/IDE/crashers_2_fixed/0018-rdar38189778.swift
+++ b/validation-test/IDE/crashers_2_fixed/0018-rdar38189778.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=A -source-filename=%s
+
+struct Horse {
+    init(saddle: @escaping (_ height: Float) -> Float) {}
+}
+
+func myHorse() -> Horse {
+    return Horse(
+        saddle: { (height) -> Float in
+            let stirrups: #^A^#Float = 30
+            return height - stirrups
+    })
+}


### PR DESCRIPTION
Otherwise, when the horrible ExprCleanser comes along, it will set
the interface type of the ParamDecl to nullptr. However there is
no way to clear the 'validation started' bit, so the next time
validateDecl() is called on this ParamDecl we will just return,
causing crashes downstream when callers expect it to already have
an interface type set.

Fixes <rdar://problem/38189778> and possibly some instances of
<rdar://problem/36434823>.