### PR TITLE
master-next: Stop using ilist_default_traits

### DIFF
--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -438,7 +438,7 @@ namespace llvm {
 
 template <>
 struct ilist_traits<::swift::SILBasicBlock>
-  : ilist_default_traits<::swift::SILBasicBlock> {
+  : ilist_node_traits<::swift::SILBasicBlock> {
   using SelfTy = ilist_traits<::swift::SILBasicBlock>;
   using SILBasicBlock = ::swift::SILBasicBlock;
   using SILFunction = ::swift::SILFunction;

--- a/include/swift/SIL/SILCoverageMap.h
+++ b/include/swift/SIL/SILCoverageMap.h
@@ -144,7 +144,7 @@ namespace llvm {
 
 template <>
 struct ilist_traits<::swift::SILCoverageMap>
-    : public ilist_default_traits<::swift::SILCoverageMap> {
+    : public ilist_node_traits<::swift::SILCoverageMap> {
   using SILCoverageMap = ::swift::SILCoverageMap;
 
 public:

--- a/include/swift/SIL/SILDefaultWitnessTable.h
+++ b/include/swift/SIL/SILDefaultWitnessTable.h
@@ -173,7 +173,7 @@ namespace llvm {
   
 template <>
 struct ilist_traits<::swift::SILDefaultWitnessTable> :
-public ilist_default_traits<::swift::SILDefaultWitnessTable> {
+public ilist_node_traits<::swift::SILDefaultWitnessTable> {
   using SILDefaultWitnessTable = ::swift::SILDefaultWitnessTable;
 
 public:

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -880,7 +880,7 @@ namespace llvm {
 
 template <>
 struct ilist_traits<::swift::SILFunction> :
-public ilist_default_traits<::swift::SILFunction> {
+public ilist_node_traits<::swift::SILFunction> {
   using SILFunction = ::swift::SILFunction;
 
 public:

--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -213,7 +213,7 @@ namespace llvm {
 
 template <>
 struct ilist_traits<::swift::SILGlobalVariable> :
-public ilist_default_traits<::swift::SILGlobalVariable> {
+public ilist_node_traits<::swift::SILGlobalVariable> {
   using SILGlobalVariable = ::swift::SILGlobalVariable;
 
 public:

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8077,7 +8077,7 @@ namespace llvm {
 
 template <>
 struct ilist_traits<::swift::SILInstruction> :
-  public ilist_default_traits<::swift::SILInstruction> {
+  public ilist_node_traits<::swift::SILInstruction> {
   using SILInstruction = ::swift::SILInstruction;
 
 private:

--- a/include/swift/SIL/SILProperty.h
+++ b/include/swift/SIL/SILProperty.h
@@ -78,7 +78,7 @@ namespace llvm {
 
 template <>
 struct ilist_traits<::swift::SILProperty>
-    : public ilist_default_traits<::swift::SILProperty> {
+    : public ilist_node_traits<::swift::SILProperty> {
   using SILProperty = ::swift::SILProperty;
 
 public:

--- a/include/swift/SIL/SILVTable.h
+++ b/include/swift/SIL/SILVTable.h
@@ -173,7 +173,7 @@ namespace llvm {
 
 template <>
 struct ilist_traits<::swift::SILVTable> :
-public ilist_default_traits<::swift::SILVTable> {
+public ilist_node_traits<::swift::SILVTable> {
   using SILVTable = ::swift::SILVTable;
 
   static void deleteNode(SILVTable *VT) { VT->~SILVTable(); }

--- a/include/swift/SIL/SILWitnessTable.h
+++ b/include/swift/SIL/SILWitnessTable.h
@@ -317,7 +317,7 @@ namespace llvm {
   
 template <>
 struct ilist_traits<::swift::SILWitnessTable> :
-public ilist_default_traits<::swift::SILWitnessTable> {
+public ilist_node_traits<::swift::SILWitnessTable> {
   using SILWitnessTable = ::swift::SILWitnessTable;
 
 public:

--- a/lib/Sema/Constraint.h
+++ b/lib/Sema/Constraint.h
@@ -710,7 +710,7 @@ namespace llvm {
 /// Specialization of \c ilist_traits for constraints.
 template<>
 struct ilist_traits<swift::constraints::Constraint>
-         : public ilist_default_traits<swift::constraints::Constraint> {
+         : public ilist_node_traits<swift::constraints::Constraint> {
   using Element = swift::constraints::Constraint;
 
   static Element *createNode(const Element &V) = delete;


### PR DESCRIPTION
LLVM r330736 removed ilist_default_traits. Apparently it is not needed
and ilist_node_traits works just as well.