### PR TITLE
[Sema] Ensure that NameAliasTypes record the right substitutions.

### DIFF
--- a/lib/Sema/TypeCheckGeneric.cpp
+++ b/lib/Sema/TypeCheckGeneric.cpp
@@ -193,6 +193,16 @@ Type CompleteGenericTypeResolver::resolveDependentMemberType(
   // base type into it.
   auto concrete = ref->getBoundDecl();
   tc.validateDeclForNameLookup(concrete);
+
+  if (auto typeAlias = dyn_cast<TypeAliasDecl>(concrete)) {
+    if (auto protocol = dyn_cast<ProtocolDecl>(typeAlias->getDeclContext())) {
+      // We need to make sure the generic environment of a surrounding protocol
+      // propagates to the typealias, since the former may not have existed when
+      // the typealiases type was first computed.
+      // FIXME: See the comment in the ProtocolDecl case of validateDecl().
+      tc.validateDecl(protocol);
+    }
+  }
   if (!concrete->hasInterfaceType())
     return ErrorType::get(tc.Context);
   if (baseTy->isTypeParameter()) {

--- a/validation-test/compiler_crashers_2_fixed/0156-rdar39636312.swift
+++ b/validation-test/compiler_crashers_2_fixed/0156-rdar39636312.swift
@@ -1,0 +1,11 @@
+// RUN: %target-swift-frontend %s -emit-module
+
+protocol P2 {
+    func f1<T : P1>(_: T) -> T.T1
+}
+
+public struct S1<U> {}
+
+protocol P1 {
+    typealias T1 = S1<Self>
+}


### PR DESCRIPTION
If a typealias is inside a protocol, and things are defined in a certain order,
the NameAliasType for that typealias can be constructed before the parent
protocol has been validated (i.e. before its generic environment exists), in
which case it is missing the necessary substitutions.

Fixes rdar://problem/39636312.
