### PR TITLE
[Diagnostics] SR-7445 Improve diagnostics for assignment failures

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2907,6 +2907,10 @@ WARNING(expression_unused_literal,none,
 
 ERROR(assignment_lhs_not_lvalue,none,
       "cannot assign to immutable expression of type %0", (Type))
+ERROR(assignment_lhs_is_apply_expression,none,
+      "expression is not assignable: %0", (StringRef))
+ERROR(assignment_lhs_is_method,none,
+      "cannot assign to member: %0", (StringRef))
 ERROR(assignment_lhs_is_immutable_variable,none,
       "cannot assign to value: %0", (StringRef))
 ERROR(assignment_lhs_is_immutable_property,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2909,8 +2909,6 @@ ERROR(assignment_lhs_not_lvalue,none,
       "cannot assign to immutable expression of type %0", (Type))
 ERROR(assignment_lhs_is_apply_expression,none,
       "expression is not assignable: %0", (StringRef))
-ERROR(assignment_lhs_is_method,none,
-      "cannot assign to member: %0", (StringRef))
 ERROR(assignment_lhs_is_immutable_variable,none,
       "cannot assign to value: %0", (StringRef))
 ERROR(assignment_lhs_is_immutable_property,none,

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -738,7 +738,7 @@ static void diagnoseSubElementFailure(Expr *destExpr,
         argsTuple->getNumElements() == 1 &&
         isa<LiteralExpr>(argsTuple->getElement(0)->getSemanticsProvidingExpr())) {
       TC.diagnose(loc, diag::assignment_lhs_is_immutable_variable,
-                      "literals are not mutable");
+                  "literals are not mutable");
       return;
     }
 

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -738,7 +738,8 @@ static void diagnoseSubElementFailure(Expr *destExpr,
         argsTuple->getNumElements() == 1 &&
         isa<LiteralExpr>(argsTuple->getElement(0)->
                          getSemanticsProvidingExpr())) {
-      TC.diagnose(loc, diagID, "literals are not mutable");
+          TC.diagnose(loc, diag::assignment_lhs_is_immutable_variable,
+                      "literals are not mutable");
       return;
     }
 
@@ -3131,12 +3132,6 @@ bool FailureDiagnosis::diagnoseContextualConversionError(
 void ConstraintSystem::diagnoseAssignmentFailure(Expr *dest, Type destTy,
                                                  SourceLoc equalLoc) {
   auto &TC = getTypeChecker();
-
-  // Diagnose obvious assignments to literals.
-  if (isa<LiteralExpr>(dest->getValueProvidingExpr())) {
-    TC.diagnose(equalLoc, diag::cannot_assign_to_literal);
-    return;
-  }
 
   // Diagnose assignments to let-properties in delegating initializers.
   if (auto *member = dyn_cast<UnresolvedDotExpr>(dest)) {

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -736,9 +736,8 @@ static void diagnoseSubElementFailure(Expr *destExpr,
       dyn_cast<TupleExpr>(AE->getArg()->getSemanticsProvidingExpr());
     if (isa<CallExpr>(AE) && AE->isImplicit() && argsTuple &&
         argsTuple->getNumElements() == 1 &&
-        isa<LiteralExpr>(argsTuple->getElement(0)->
-                         getSemanticsProvidingExpr())) {
-          TC.diagnose(loc, diag::assignment_lhs_is_immutable_variable,
+        isa<LiteralExpr>(argsTuple->getElement(0)->getSemanticsProvidingExpr())) {
+      TC.diagnose(loc, diag::assignment_lhs_is_immutable_variable,
                       "literals are not mutable");
       return;
     }

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -3166,9 +3166,9 @@ void ConstraintSystem::diagnoseAssignmentFailure(Expr *dest, Type destTy,
     diagID = diag::assignment_lhs_is_immutable_variable;
   else if (isa<ForceValueExpr>(dest))
     diagID = diag::assignment_bang_has_immutable_subcomponent;
-  else if (isa<UnresolvedDotExpr>(dest) || isa<MemberRefExpr>(dest)) {
+  else if (isa<UnresolvedDotExpr>(dest) || isa<MemberRefExpr>(dest))
     diagID = diag::assignment_lhs_is_immutable_property;
-  } else if (auto sub = dyn_cast<SubscriptExpr>(dest)) {
+  else if (auto sub = dyn_cast<SubscriptExpr>(dest)) {
     diagID = diag::assignment_subscript_has_immutable_base;
 
     // If the destination is a subscript with a 'dynamicLookup:' label and if

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -657,7 +657,7 @@ static void diagnoseSubElementFailure(Expr *destExpr,
                                       Diag<StringRef> diagID,
                                       Diag<Type> unknownDiagID) {
   auto &TC = CS.getTypeChecker();
-  
+
   // Walk through the destination expression, resolving what the problem is.  If
   // we find a node in the lvalue path that is problematic, this returns it.
   auto immInfo = resolveImmutableBase(destExpr, CS);
@@ -706,7 +706,7 @@ static void diagnoseSubElementFailure(Expr *destExpr,
       .highlight(immInfo.first->getSourceRange());
     return;
   }
-  
+
   // If we're trying to set an unapplied method, say that.
   if (auto *VD = immInfo.second) {
     std::string message = "'";
@@ -716,13 +716,13 @@ static void diagnoseSubElementFailure(Expr *destExpr,
     if (auto *AFD = dyn_cast<AbstractFunctionDecl>(VD)) {
       if (AFD->getImplicitSelfDecl()) {
         message += " is a method";
-        diagID = diag::assignment_lhs_is_method;
+        diagID = diag::assignment_lhs_is_immutable_variable;
       } else {
         message += " is a function";
       }
     } else
       message += " is not settable";
-    
+
     TC.diagnose(loc, diagID, message)
       .highlight(immInfo.first->getSourceRange());
     return;
@@ -761,7 +761,7 @@ static void diagnoseSubElementFailure(Expr *destExpr,
       .highlight(AE->getSourceRange());
     return;
   }
-  
+
   if (auto *ICE = dyn_cast<ImplicitConversionExpr>(immInfo.first))
     if (isa<LoadExpr>(ICE->getSubExpr())) {
       TC.diagnose(loc, diagID,

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -121,7 +121,7 @@ func properties(_ b: B) {
   // An informal property cannot be made formal in a subclass. The
   // formal property is simply ignored.
   b.informalMadeFormal()
-  b.informalMadeFormal = i // expected-error{{cannot assign to property: 'informalMadeFormal' is a method}}
+  b.informalMadeFormal = i // expected-error{{cannot assign to member: 'informalMadeFormal' is a method}}
   b.setInformalMadeFormal(5)
 
   b.overriddenProp = 17

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -121,7 +121,7 @@ func properties(_ b: B) {
   // An informal property cannot be made formal in a subclass. The
   // formal property is simply ignored.
   b.informalMadeFormal()
-  b.informalMadeFormal = i // expected-error{{cannot assign to member: 'informalMadeFormal' is a method}}
+  b.informalMadeFormal = i // expected-error{{cannot assign to value: 'informalMadeFormal' is a method}}
   b.setInformalMadeFormal(5)
 
   b.overriddenProp = 17

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -600,7 +600,6 @@ func testConditional(b : Bool) {
 
 
 
-
 func f(a : FooClass, b : LetStructMembers) {
   a.baz = 1 // expected-error {{cannot assign to member: 'baz' is a method}}
   b.f = 42     // expected-error {{cannot assign to member: 'f' is a method}}

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -600,10 +600,10 @@ func testConditional(b : Bool) {
 
 
 
-// <rdar://problem/27384685> QoI: Poor diagnostic when assigning a value to a method
+
 func f(a : FooClass, b : LetStructMembers) {
-  a.baz = 1 // expected-error {{cannot assign to property: 'baz' is a method}}
-  b.f = 42     // expected-error {{cannot assign to property: 'f' is a method}}
+  a.baz = 1 // expected-error {{cannot assign to member: 'baz' is a method}}
+  b.f = 42     // expected-error {{cannot assign to member: 'f' is a method}}
 }
 
 // SR-2354: Reject subscript declarations with mutable parameters.

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -433,17 +433,17 @@ func QoI() {
 func func1() -> Int { return 7 }
 
 func func2() {
-    func func3() {}
+  func func3() {}
 
-    func3() = 0 // expected-error {{expression is not assignable: 'func3' returns immutable value}}
+  func3() = 0 // expected-error {{expression is not assignable: 'func3' returns immutable value}}
 }
 
 func assignmentsToFuncs() {
 
-  LetClassMembers(arg: 7).f() = 5 // expected-error {{expression is not assignable: function call returns immutable value}}
+  LetClassMembers(arg: 7).f() = 5  // expected-error {{expression is not assignable: function call returns immutable value}}
   LetStructMembers(arg: 7).f() = 5 // expected-error {{expression is not assignable: function call returns immutable value}}
 
-  func1() = 9 // expected-error {{expression is not assignable: 'func1' returns immutable value}}
+  func1() = 9     // expected-error {{expression is not assignable: 'func1' returns immutable value}}
   func2() = "rrr" // expected-error {{expression is not assignable: 'func2' returns immutable value}}
 
   var x = 0

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -619,8 +619,8 @@ func testConditional(b : Bool) {
 
 
 func f(a : FooClass, b : LetStructMembers) {
-  a.baz = 1 // expected-error {{cannot assign to member: 'baz' is a method}}
-  b.f = 42     // expected-error {{cannot assign to member: 'f' is a method}}
+  a.baz = 1   // expected-error {{cannot assign to value: 'baz' is a method}}
+  b.f = 42    // expected-error {{cannot assign to value: 'f' is a method}}
 }
 
 // SR-2354: Reject subscript declarations with mutable parameters.

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -430,7 +430,25 @@ func QoI() {
   get_only = 92            // expected-error {{cannot assign to value: 'get_only' is a get-only property}}
 }
 
+func func1() -> Int { return 7 }
 
+func func2() {
+    func func3() {}
+
+    func3() = 0 // expected-error {{expression is not assignable: 'func3' returns immutable value}}
+}
+
+func assignmentsToFuncs() {
+
+  LetClassMembers(arg: 7).f() = 5 // expected-error {{expression is not assignable: function call returns immutable value}}
+  LetStructMembers(arg: 7).f() = 5 // expected-error {{expression is not assignable: function call returns immutable value}}
+
+  func1() = 9 // expected-error {{expression is not assignable: 'func1' returns immutable value}}
+  func2() = "rrr" // expected-error {{expression is not assignable: 'func2' returns immutable value}}
+
+  var x = 0
+  (x, func1() = 0) = (4, 5) // expected-error {{expression is not assignable: 'func1' returns immutable value}}
+}
 
 // <rdar://problem/17051675> Structure initializers in an extension cannot assign to constant properties
 struct rdar17051675_S {

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -352,6 +352,6 @@ class C6 {
   static func == (lhs: C6, rhs: C6) -> Bool { return false }
 
   func test1(x: C6) {
-    if x == x && x = x { } // expected-error{{cannot assign to value: '&&' returns immutable value}}
+    if x == x && x = x { } // expected-error{{expression is not assignable: '&&' returns immutable value}}
   }
 }

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -885,7 +885,7 @@ var y = 1
 let _ = (x, x + 1).0
 let _ = (x, 3).1
 (x,y) = (2,3)
-(x,4) = (1,2) // expected-error {{cannot assign to value: literals are not mutable}}
+(x,4) = (1,2) // expected-error {{expression is not assignable: literals are not mutable}}
 (x,y).1 = 7 // expected-error {{cannot assign to immutable expression of type 'Int'}}
 x = (x,(3,y)).1.1
 

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -42,7 +42,7 @@ func funcdecl5(_ a: Int, y: Int) {
   1 = x        // expected-error {{cannot assign to a literal value}}
   (1) = x      // expected-error {{cannot assign to a literal value}}
   "string" = "other"    // expected-error {{cannot assign to a literal value}}
-  [1, 1, 1, 1] = [1, 1] // expected-error {{cannot assign to a literal value}}
+  [1, 1, 1, 1] = [1, 1] // expected-error {{cannot assign to immutable expression of type '[Int]}}
   1.0 = x               // expected-error {{cannot assign to a literal value}}
   nil = 1               // expected-error {{cannot assign to a literal value}}
 

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -41,6 +41,11 @@ func funcdecl5(_ a: Int, y: Int) {
 
   1 = x        // expected-error {{cannot assign to a literal value}}
   (1) = x      // expected-error {{cannot assign to a literal value}}
+  "string" = "other"    // expected-error {{cannot assign to a literal value}}
+  [1, 1, 1, 1] = [1, 1] // expected-error {{cannot assign to a literal value}}
+  1.0 = x               // expected-error {{cannot assign to a literal value}}
+  nil = 1               // expected-error {{cannot assign to a literal value}}
+
   (x:1).x = 1 // expected-error {{cannot assign to immutable expression of type 'Int'}}
   var tup : (x:Int, y:Int)
   tup.x = 1


### PR DESCRIPTION
Attempt to resolve [SR-7445](https://bugs.swift.org/browse/SR-7445).
modified messages for assignments to function calls,
modified messages for assignments to methods.
removed comment for resolved radar.

Suggestions appreciated.

Implementation proposals (`CSDiag.cpp`):
The `diagnoseSubElementFailure` function has no substantial reason to be separated from it's caller, 
`diagnoseAssignmentFailure`. Right now this separation prevents from creating a single diagnostic 
`cannot assign to %select{member|property|value}0: %1` (it is currently split into 3) and only accepts `Diag<StringRef>` (There are other diagnostics types like the aforementioned that are reasonable to be accepted. Furthermore, the current state of these two functions results in unnecessary logic separation – passing a generic diagnostic that is yet uncertain to `diagnoseSubElementFailure` can meet a need to be mutated. I propose to merge `diagnoseSubElementFailure` into `diagnoseAssignmentFailure` and tidy things up.

