### PR TITLE
Improve -enable-verify-exclusivity.

### DIFF
--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -276,6 +276,11 @@ AccessedStorage findAccessedStorage(SILValue sourceAddr);
 /// storage.
 AccessedStorage findAccessedStorageOrigin(SILValue sourceAddr);
 
+/// Return true if the given address operand is used by a memory operation that
+/// initializes the memory at that address, implying that the previous value is
+/// uninitialized.
+bool memInstMustInitialize(Operand *memOper);
+
 /// Return true if the given address producer may be the source of a formal
 /// access (a read or write of a potentially aliased, user visible variable).
 ///

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -889,6 +889,11 @@ static void checkAccessedAddress(Operand *memOper, StorageMap &Accesses) {
     abort();
   };
 
+  // If the memory instruction is only used for initialization, it doesn't need
+  // an access marker.
+  if (memInstMustInitialize(memOper))
+    return;
+
   if (auto apply = ApplySite::isa(memInst)) {
     SILArgumentConvention conv =
         apply.getArgumentConvention(apply.getCalleeArgIndex(*memOper));
@@ -922,8 +927,9 @@ static void checkAccessedAddress(Operand *memOper, StorageMap &Accesses) {
   if (!storage || !isPossibleFormalAccessBase(storage, memInst->getFunction()))
     return;
 
-  // Skip local non-lvalue accesses. There are many local initialization
-  // patterns that don't require access markers.
+  // A box or stack variable may represent lvalues, but they can only conflict
+  // with call sites in the same scope. Some initialization patters (stores to
+  // the local value) aren't protected by markers, so we need this check.
   if (!isa<ApplySite>(memInst)
       && (storage.getKind() == AccessedStorage::Box
           || storage.getKind() == AccessedStorage::Stack)) {


### PR DESCRIPTION
Cleanup the memory access utilities to for more robust detection of local
initialization patterns that don't use access markers.

Moving this to 4.2 so we can run verification on that branch.