### PR TITLE
Handle missing output file map gracefully swift 4.2 branch rdar://39660680

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -61,7 +61,7 @@ ERROR(error_cannot_specify__o_for_multiple_outputs,none,
       "cannot specify -o when generating multiple output files", ())
 
 ERROR(error_unable_to_load_output_file_map, none,
-      "unable to load output file map: %0", (StringRef))
+      "unable to load output file map '%1': %0", (StringRef, StringRef))
 
 ERROR(error_no_output_file_map_specified,none,
       "no output file map specified", ())

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1832,7 +1832,8 @@ Driver::buildOutputFileMap(const llvm::opt::DerivedArgList &Args,
       OutputFileMap::loadFromPath(A->getValue(), workingDirectory);
   if (auto Err = OFM.takeError()) {
     Diags.diagnose(SourceLoc(), diag::error_unable_to_load_output_file_map,
-                   llvm::toString(std::move(Err)));
+                   llvm::toString(std::move(Err)), A->getValue());
+    return None;
   }
   return *OFM;
 }

--- a/test/Driver/missing-ofm.swift
+++ b/test/Driver/missing-ofm.swift
@@ -1,0 +1,8 @@
+// Ensure that a bogus output-file-map path does not crash the driver,
+// but instead outputs a nice diagnostic.
+//
+// RUN: %empty-directory(%t)
+// RUN: not %swiftc_driver -c %S/../Inputs/empty.swift -output-file-map %t/something-which-should-not-exist.json 2>&1 | %FileCheck %s
+//
+// CHECK: error: unable to load output file map '{{.*}}/something-which-should-not-exist.json': No such file or directory
+// CHECK-NOT: Assertion failed


### PR DESCRIPTION
<!-- What's in this pull request? -->
When the driver tries to open the path for -output-file-map, it currently emits a diagnostic and then fails an assertion. Fix this so it exits instead (as it does for other fatal diagnostics). Also enhance the diagnostic to include the path that could not be opened.
rdar://39660680

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->