### PR TITLE
Revert "Temporarily disable an optimization to avoid some crashes."

### DIFF
--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -1144,8 +1144,7 @@ getAddrOfKnownValueWitnessTable(IRGenModule &IGM, CanType type) {
       witnessSurrogate = C.TheUnknownObjectType;
       break;
     case ReferenceCounting::Bridge:
-      // FIXME: Temporarily disable this optimization (rdar://problem/39697747)
-      // witnessSurrogate = C.TheBridgeObjectType;
+      witnessSurrogate = C.TheBridgeObjectType;
       break;
     case ReferenceCounting::Error:
       break;


### PR DESCRIPTION
Reverts apple/swift#16149

The runtime implementation is okay but was not getting rebuild and so it looked like the workaround was necessary when it was not.

rdar://problem/39697747