### PR TITLE
[SR-7492] Project over-parenthesized patterns properly

### DIFF
--- a/lib/Sema/TypeCheckSwitchStmt.cpp
+++ b/lib/Sema/TypeCheckSwitchStmt.cpp
@@ -1737,8 +1737,7 @@ namespace {
           //
           // FIXME: SE-0155 makes this case unreachable.
           if (SP->getKind() == PatternKind::Named
-              || SP->getKind() == PatternKind::Any
-              || SP->getKind() == PatternKind::Tuple) {
+              || SP->getKind() == PatternKind::Any) {
             if (auto *TTy = SP->getType()->getAs<TupleType>()) {
               for (auto ty : TTy->getElements()) {
                 conArgSpace.push_back(Space::forType(ty.getType(),
@@ -1748,6 +1747,13 @@ namespace {
               conArgSpace.push_back(projectPattern(TC, SP,
                                                    sawDowngradablePattern));
             }
+          } else if (SP->getKind() == PatternKind::Tuple) {
+            Space argTupleSpace = projectPattern(TC, SP,
+                                                 sawDowngradablePattern);
+            assert(argTupleSpace.getKind() == SpaceKind::Constructor);
+            conArgSpace.insert(conArgSpace.end(),
+                               argTupleSpace.getSpaces().begin(),
+                               argTupleSpace.getSpaces().end());
           } else {
             conArgSpace.push_back(projectPattern(TC, SP,
                                                  sawDowngradablePattern));

--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -48,6 +48,19 @@ enum Result<T> {
   }
 }
 
+func overParenthesized() {
+  // SR-7492: Space projection needs to treat extra paren-patterns explicitly.
+  let x: Result<(Result<Int>, String)> = .Ok((.Ok(1), "World"))
+  switch x {
+  case let .Error(e):
+    print(e)
+  case let .Ok((.Error(e), b)):
+    print(e, b)
+  case let .Ok((.Ok(a), b)): // No warning here.
+    print(a, b)
+  }
+}
+
 enum Foo {
   case A(Int)
   case B(Int)


### PR DESCRIPTION
Projection assumed if it ever hit a case where an argument pattern
contained extra parentheses that the user was trying to create
a var pattern to bind the entire argument tuple.

```swift
enum Foo {
  case bar(Int, String, Float)
}

switch fooVal {
  case bar(let x): ...
}
```

This breaks in the presence of tuple patterns with extra parentheses.
Treat these patterns explicitly when projecting them.

Resolves [SR-7492](https://bugs.swift.org/browse/SR-7492).
