### PR TITLE
[func-sig-opts] Run DeadArgument elimination before ArgumentExplosion.

### DIFF
--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.h
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.h
@@ -47,6 +47,12 @@ struct ArgumentDescriptor {
   /// Was this parameter originally dead?
   bool IsEntirelyDead;
 
+  /// Was this argument completely removed already?
+  ///
+  /// TODO: Could we make ArgumentDescriptors just optional and once they have
+  /// been consumed no longer process them?
+  bool WasErased;
+
   /// Should the argument be exploded ?
   bool Explode;
 
@@ -79,10 +85,10 @@ struct ArgumentDescriptor {
   /// when optimizing.
   ArgumentDescriptor(SILFunctionArgument *A)
       : Arg(A), PInfo(A->getKnownParameterInfo()), Index(A->getIndex()),
-        Decl(A->getDecl()), IsEntirelyDead(false), Explode(false),
-        OwnedToGuaranteed(false), IsIndirectResult(A->isIndirectResult()),
-        CalleeRelease(), CalleeReleaseInThrowBlock(),
-        ProjTree(A->getModule(), A->getType()) {
+        Decl(A->getDecl()), IsEntirelyDead(false), WasErased(false),
+        Explode(false), OwnedToGuaranteed(false),
+        IsIndirectResult(A->isIndirectResult()), CalleeRelease(),
+        CalleeReleaseInThrowBlock(), ProjTree(A->getModule(), A->getType()) {
     if (!A->isIndirectResult()) {
       PInfo = Arg->getKnownParameterInfo();
     }

--- a/test/SILOptimizer/funcsig_deadarg_explode.sil
+++ b/test/SILOptimizer/funcsig_deadarg_explode.sil
@@ -1,0 +1,35 @@
+
+// This file makes sure that we do not explode dead parameters.
+
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -function-signature-opts %s | %FileCheck %s
+// REQUIRES: asserts
+
+sil_stage canonical
+
+class Klass {}
+struct S {
+  var k1: Klass
+  var k2: Klass
+}
+
+sil @klass_user : $@convention(thin) (@guaranteed Klass) -> ()
+
+sil @callee : $@convention(thin) (@guaranteed S, @guaranteed S, @guaranteed S) -> () {
+bb0(%0 : $S, %1 : $S, %2 : $S):
+  %3 = function_ref @klass_user : $@convention(thin) (@guaranteed Klass) -> ()
+  %4 = struct_extract %1 : $S, #S.k1
+  apply %3(%4) : $@convention(thin) (@guaranteed Klass) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+sil @caller : $@convention(thin) (@guaranteed S) -> () {
+bb0(%0 : $S):
+  %1 = function_ref @callee : $@convention(thin) (@guaranteed S, @guaranteed S, @guaranteed S) -> ()
+  apply %1(%0, %0, %0) : $@convention(thin) (@guaranteed S, @guaranteed S, @guaranteed S) -> ()
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil shared @$S6calleeTf4dxd_n : $@convention(thin) (@guaranteed Klass) -> () {
+// CHECK: bb0([[KLASS:%[0-9]+]] : $Klass):


### PR DESCRIPTION
This ensures that we perform analysis and transformation in the same order. This
is the last missing piece before I can split function signature opts (a task for
another time).

rdar://38196046
