### PR TITLE
[Runtime] Add a comment to explain the previous change.

### DIFF
--- a/stdlib/public/runtime/MetadataImpl.h
+++ b/stdlib/public/runtime/MetadataImpl.h
@@ -411,6 +411,8 @@ struct BridgeObjectBox :
       
   static void *retain(void *obj) {
     (void)swift_bridgeObjectRetain(obj);
+    // The return value from swift_bridgeObjectRetain may not include the
+    // tag bits; return the input value instead.
     return obj;
   }
 


### PR DESCRIPTION
The reason for have BridgeObjectBox::retain() not return the value
from swift_bridgeObjectRetain is not obvious.