### PR TITLE
[gardening] Standardize indentation/whitespace around ++/--, prefer pre-, and use for-each loops.

### DIFF
--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -1260,7 +1260,7 @@ void FunctionSignatureTransform::ArgumentExplosionFinalizeOptimizedFunction() {
     // Simply continue if do not explode.
     if (!AD.Explode) {
       TransformDescriptor.AIM[TotalArgIndex] = AD.Index;
-      TotalArgIndex ++;
+      ++TotalArgIndex;
       continue;
     }
 
@@ -1279,11 +1279,12 @@ void FunctionSignatureTransform::ArgumentExplosionFinalizeOptimizedFunction() {
 
     for (auto *Node : LeafNodes) {
       auto OwnershipKind = *AD.getTransformedOwnershipKind(Node->getType());
-      LeafValues.push_back(BB->insertFunctionArgument(
-          ArgOffset++, Node->getType(), OwnershipKind,
-          BB->getArgument(OldArgIndex)->getDecl()));
+      LeafValues.push_back(
+          BB->insertFunctionArgument(ArgOffset, Node->getType(), OwnershipKind,
+                                     BB->getArgument(OldArgIndex)->getDecl()));
       TransformDescriptor.AIM[TotalArgIndex - 1] = AD.Index;
-      TotalArgIndex ++;
+      ++ArgOffset;
+      ++TotalArgIndex;
     }
 
     // Then go through the projection tree constructing aggregates and replacing
@@ -1305,7 +1306,7 @@ void FunctionSignatureTransform::ArgumentExplosionFinalizeOptimizedFunction() {
     // Now erase the old argument since it does not have any uses. We also
     // decrement ArgOffset since we have one less argument now.
     BB->eraseArgument(OldArgIndex);
-    TotalArgIndex --;
+    --TotalArgIndex;
   }
 }
 

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -909,7 +909,7 @@ bool FunctionSignatureTransform::DeadArgumentAnalyzeParameters() {
   auto OrigShouldModifySelfArgument =
       TransformDescriptor.shouldModifySelfArgument;
   // Analyze the argument information.
-  for (unsigned i = 0, e = Args.size(); i != e; ++i) {
+  for (unsigned i : indices(Args)) {
     ArgumentDescriptor &A = TransformDescriptor.ArgumentDescList[i];
     if (!A.PInfo.hasValue()) {
       // It is not an argument. It could be an indirect result. 
@@ -1002,7 +1002,7 @@ bool FunctionSignatureTransform::OwnedToGuaranteedAnalyzeParameters() {
   bool SignatureOptimize = false;
 
   // Analyze the argument information.
-  for (unsigned i = 0, e = Args.size(); i != e; ++i) {
+  for (unsigned i : indices(Args)) {
     ArgumentDescriptor &A = TransformDescriptor.ArgumentDescList[i];
     if (!A.canOptimizeLiveArg()) {
       continue;
@@ -1214,7 +1214,7 @@ bool FunctionSignatureTransform::ArgumentExplosionAnalyzeParameters() {
     RCIA->get(F), F, {SILArgumentConvention::Direct_Owned});
 
   // Analyze the argument information.
-  for (unsigned i = 0, e = Args.size(); i != e; ++i) {
+  for (unsigned i : indices(Args)) {
     ArgumentDescriptor &A = TransformDescriptor.ArgumentDescList[i];
     // If the argument is dead, there is no point in trying to explode it. The
     // dead argument pass will get it.
@@ -1378,7 +1378,7 @@ public:
     /// index.
     llvm::SmallDenseMap<int, int> AIM;
     int asize = F->begin()->getArguments().size();
-    for (auto i = 0; i < asize; ++i) {
+    for (unsigned i : range(asize)) {
       AIM[i] = i;
     }
 
@@ -1386,7 +1386,7 @@ public:
     llvm::SmallVector<ArgumentDescriptor, 4> ArgumentDescList;
     llvm::SmallVector<ResultDescriptor, 4> ResultDescList;
     auto Args = F->begin()->getFunctionArguments();
-    for (unsigned i = 0, e = Args.size(); i != e; ++i) {
+    for (unsigned i : indices(Args)) {
       ArgumentDescList.emplace_back(Args[i]);
     }
     for (SILResultInfo IR : F->getLoweredFunctionType()->getResults()) {


### PR DESCRIPTION
This PR contains two different changes in Function Signature Optimization.

1. We now standardize on using for-each loops.
2. Whitespace in between a variable and ++/-- has been eliminated.
3. All post-{in,de}crement have been converted to their pre variant.