### PR TITLE
[SR-7554] Re-project cast subpatterns

### DIFF
--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -327,6 +327,7 @@ func switcheroo(a: XX, b: XX) -> Int {
 enum PatternCasts {
   case one(Any)
   case two
+  case three(String)
 }
 
 func checkPatternCasts() {
@@ -336,6 +337,7 @@ func checkPatternCasts() {
   case .one(let s as String): print(s)
   case .one: break
   case .two: break
+  case .three: break
   }
 
   // But should warn here.
@@ -343,6 +345,14 @@ func checkPatternCasts() {
   case .one(_): print(s)
   case .one: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
   case .two: break
+  case .three: break
+  }
+
+  // And not here
+  switch x {
+  case .one: break
+  case .two: break
+  case .three(let s as String?): print(s as Any)
   }
 }
 


### PR DESCRIPTION
A corner-case left over from an earlier fix that made the exhaustiveness
checker aware of irrefutable coercions.  If the coercion occured as part
of a sub-pattern, that pattern would be projected with the wrong type
and would fail the intersection test.  Project the pattern with the type
of the scrutinee instead.

Resolves [SR-7554](https://bugs.swift.org/browse/SR-7554).

Would be a little QoI change, but Lyft reports they're having trouble with this in the 4.2 toolchain, so I'll cherry-pick again.