### PR TITLE
[Sema] Diagnose redundant conditional conformances more specifically.

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1697,9 +1697,18 @@ ERROR(witness_unavailable,none,
 
 ERROR(redundant_conformance,none,
       "redundant conformance of %0 to protocol %1", (Type, DeclName))
+ERROR(redundant_conformance_conditional,none,
+      "conflicting conformance of %0 to protocol %1; there cannot be more "
+      "than one conformance, even with different conditional bounds",
+      (Type, DeclName))
 WARNING(redundant_conformance_adhoc,none,
         "conformance of %0 to protocol %1 was already stated in "
         "%select{the protocol's|the type's}2 module %3",
+        (Type, DeclName, bool, Identifier))
+WARNING(redundant_conformance_adhoc_conditional,none,
+        "conformance of %0 to protocol %1 conflicts with that stated in "
+        "%select{the protocol's|the type's}2 module %3 and will be ignored; "
+        "there cannot be more than one conformance, even with different conditional bounds",
         (Type, DeclName, bool, Identifier))
 NOTE(redundant_conformance_witness_ignored,none,
      "%0 %1 will not be used to satisfy the conformance to %2",

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -322,13 +322,13 @@ struct TwoConformances<T> {}
 extension TwoConformances: P2 where T: P1 {}
 // expected-note@-1{{'TwoConformances<T>' declares conformance to protocol 'P2' here}}
 extension TwoConformances: P2 where T: P3 {}
-// expected-error@-1{{redundant conformance of 'TwoConformances<T>' to protocol 'P2'}}
+// expected-error@-1{{conflicting conformance of 'TwoConformances<T>' to protocol 'P2'; there cannot be more than one conformance, even with different conditional bounds}}
 
 struct TwoDisjointConformances<T> {}
 extension TwoDisjointConformances: P2 where T == Int {}
 // expected-note@-1{{'TwoDisjointConformances<T>' declares conformance to protocol 'P2' here}}
 extension TwoDisjointConformances: P2 where T == String {}
-// expected-error@-1{{redundant conformance of 'TwoDisjointConformances<T>' to protocol 'P2'}}
+// expected-error@-1{{conflicting conformance of 'TwoDisjointConformances<T>' to protocol 'P2'; there cannot be more than one conformance, even with different conditional bounds}}
 
 
 // FIXME: these cases should be equivalent (and both with the same output as the

--- a/test/decl/protocol/conforms/Inputs/redundant_conformance_A.swift
+++ b/test/decl/protocol/conforms/Inputs/redundant_conformance_A.swift
@@ -12,3 +12,22 @@ public struct OtherConformsToP {
   public func f() -> Int { return 0 }
 }
 
+// The downstream conformance is conditional
+public struct GenericConformsToP<T> : P1 {
+    public func f() -> Int { return 0 }
+}
+
+public struct OtherGenericConformsToP<T> {
+    public func f() -> Int { return 0 }
+}
+
+// The upstream conformance is conditional
+public struct GenericConditionalConformsToP<T> {}
+extension GenericConditionalConformsToP: P1 where T == Int {
+    public typealias A = Int
+    public func f() -> Int { return 0 }
+}
+
+public struct OtherGenericConditionalConformsToP<T> {
+    public func f() -> Int { return 0 }
+}

--- a/test/decl/protocol/conforms/Inputs/redundant_conformance_B.swift
+++ b/test/decl/protocol/conforms/Inputs/redundant_conformance_B.swift
@@ -8,7 +8,16 @@ public protocol P2 {
 
 extension OtherConformsToP: P1 {
 }
+extension OtherGenericConformsToP: P1 {}
+extension OtherGenericConditionalConformsToP: P1 where T: P2 {}
 
 extension ConformsToP: P2 {
   public func f() -> Int { return 0 }
+}
+
+extension GenericConformsToP: P2 {
+    public func f() -> Int { return 0 }
+}
+extension GenericConditionalConformsToP: P2 where T: P1 {
+    public func f() -> Int { return 0 }
 }

--- a/test/decl/protocol/conforms/redundant_conformance.swift
+++ b/test/decl/protocol/conforms/redundant_conformance.swift
@@ -2,7 +2,7 @@
 
 // RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/redundant_conformance_A.swift
 // RUN: %target-swift-frontend -emit-module -o %t -I %t %S/Inputs/redundant_conformance_B.swift
-// RUN: %target-typecheck-verify-swift -I %t %s
+// RUN: %target-typecheck-verify-swift -I %t
 
 import redundant_conformance_A
 import redundant_conformance_B
@@ -28,4 +28,40 @@ func testConformsToP(cp1: ConformsToP, ocp1: OtherConformsToP) {
   let _ = cp1.f()  // expected-error{{ambiguous use of 'f()'}}
 
   let _ = ocp1.f() // okay: picks "our" OtherConformsToP.f()
+}
+
+// slightly different error messages for conditional conformances:
+
+extension GenericConformsToP: P1 where T: P1 {
+// expected-warning@-1{{conformance of 'GenericConformsToP<T>' to protocol 'P1' conflicts with that stated in the type's module 'redundant_conformance_A' and will be ignored; there cannot be more than one conformance, even with different conditional bounds}}
+    typealias A = Double
+    // expected-note@-1{{type alias 'A' will not be used to satisfy the conformance to 'P1'}}
+    func f() -> Double { return 0.0 }
+    // expected-note@-1{{instance method 'f()' will not be used to satisfy the conformance to 'P1'}}
+}
+extension GenericConformsToP: P2 where T: P1 {
+    // expected-warning@-1{{conformance of 'GenericConformsToP<T>' to protocol 'P2' conflicts with that stated in the protocol's module 'redundant_conformance_B' and will be ignored; there cannot be more than one conformance, even with different conditional bounds}}
+}
+
+extension OtherGenericConformsToP: P1 where T: P1 {
+// expected-error@-1{{conflicting conformance of 'OtherGenericConformsToP<T>' to protocol 'P1'; there cannot be more than one conformance, even with different conditional bounds}}
+    typealias A = Double
+    func f() -> Double { return 0.0 }
+}
+
+extension GenericConditionalConformsToP: P1 {
+// expected-warning@-1{{conformance of 'GenericConditionalConformsToP<T>' to protocol 'P1' conflicts with that stated in the type's module 'redundant_conformance_A' and will be ignored; there cannot be more than one conformance, even with different conditional bounds}}
+    typealias A = Double
+    // expected-note@-1{{type alias 'A' will not be used to satisfy the conformance to 'P1'}}
+    func f() -> Double { return 0.0 }
+    // expected-note@-1{{instance method 'f()' will not be used to satisfy the conformance to 'P1'}}
+}
+extension GenericConditionalConformsToP: P2 {
+    // expected-warning@-1{{conformance of 'GenericConditionalConformsToP<T>' to protocol 'P2' conflicts with that stated in the protocol's module 'redundant_conformance_B' and will be ignored; there cannot be more than one conformance, even with different conditional bounds}}
+}
+
+extension OtherGenericConditionalConformsToP: P1 {
+// expected-error@-1{{conflicting conformance of 'OtherGenericConditionalConformsToP<T>' to protocol 'P1'; there cannot be more than one conformance, even with different conditional bounds}}
+    typealias A = Double
+    func f() -> Double { return 0.0 }
 }

--- a/test/decl/protocol/conforms/redundant_conformance_same_conditions.swift
+++ b/test/decl/protocol/conforms/redundant_conformance_same_conditions.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/redundant_conformance_A.swift
+// RUN: %target-swift-frontend -emit-module -o %t -I %t %S/Inputs/redundant_conformance_B.swift
+// RUN: %target-typecheck-verify-swift -I %t
+
+import redundant_conformance_A
+import redundant_conformance_B
+
+// These have identical requirements to the original conformances
+
+extension GenericConditionalConformsToP: P1 where T == Int {
+    // expected-warning@-1{{conformance of 'GenericConditionalConformsToP<T>' to protocol 'P1' was already stated in the type's module 'redundant_conformance_A'}}
+    func f() -> Int { return 0 }
+    // expected-note@-1{{instance method 'f()' will not be used to satisfy the conformance to 'P1'}}
+}
+extension GenericConditionalConformsToP: P2 where T: P1 {
+    // expected-warning@-1{{conformance of 'GenericConditionalConformsToP<T>' to protocol 'P2' was already stated in the protocol's module 'redundant_conformance_B'}}
+    func f() -> Int { return 0 }
+    // expected-note@-1{{instance method 'f()' will not be used to satisfy the conformance to 'P2'}}
+}
+extension OtherGenericConditionalConformsToP: P1 where T: P2 {
+    // expected-error@-1{{redundant conformance of 'OtherGenericConditionalConformsToP<T>' to protocol 'P1'}}
+    func f() -> Int { return 0 }
+}


### PR DESCRIPTION
We don't allow things like

    extension Type: P where Param: P {}
    extension Type: P where Param: Q {}

or

    extension Type: P where Param == Int {}
    extension Type: P where Param == Float {}

or

    extension Type: P where Param: P {}
    extension Type: P where Param == SomethingThatIsntP {}

and the default error message "redundant conformance" message doesn't convey
this very well.

Fixes rdar://problem/36262409.
