### PR TITLE
[SR-7554][4.2] Re-project cast subpatterns

### DIFF
--- a/test/Sema/exhaustive_switch.swift
+++ b/test/Sema/exhaustive_switch.swift
@@ -314,6 +314,7 @@ func switcheroo(a: XX, b: XX) -> Int {
 enum PatternCasts {
   case one(Any)
   case two
+  case three(String)
 }
 
 func checkPatternCasts() {
@@ -323,6 +324,7 @@ func checkPatternCasts() {
   case .one(let s as String): print(s)
   case .one: break
   case .two: break
+  case .three: break
   }
 
   // But should warn here.
@@ -330,6 +332,14 @@ func checkPatternCasts() {
   case .one(_): print(s)
   case .one: break // expected-warning {{case is already handled by previous patterns; consider removing it}}
   case .two: break
+  case .three: break
+  }
+
+  // And not here
+  switch x {
+  case .one: break
+  case .two: break
+  case .three(let s as String?): print(s as Any)
   }
 }
 


### PR DESCRIPTION
Cherry-picked from #16199 

Original Rationale:

A corner-case left over from an earlier fix that made exhaustiveness
checker aware of irrefutable coercions.  If the coercion occured as part
of a sub-pattern, that pattern would be projected with the wrong type
and would fail the intersection test.  Project the pattern with the type
of the scrutinee instead.
