### PR TITLE
[4.2][Migrator] Use RewriteBuffer::InsertText() for applying insertion

### DIFF
--- a/lib/Migrator/FixitApplyDiagnosticConsumer.cpp
+++ b/lib/Migrator/FixitApplyDiagnosticConsumer.cpp
@@ -55,15 +55,27 @@ handleDiagnostic(SourceManager &SM, SourceLoc Loc,
     auto Offset = SM.getLocOffsetInBuffer(Fixit.getRange().getStart(),
                                           ThisBufferID);
     auto Length = Fixit.getRange().getByteLength();
+    auto Text = Fixit.getText();
 
-    Replacement R { Offset, Length, Fixit.getText() };
+    // Ignore meaningless Fix-its.
+    if (Length == 0 && Text.size() == 0)
+      return;
+
+    // Ignore pre-applied equivalents.
+    Replacement R { Offset, Length, Text };
     if (Replacements.count(R)) {
       return;
     } else {
       Replacements.insert(R);
     }
 
-    RewriteBuf.ReplaceText(Offset, Length, Fixit.getText());
+    if (Length == 0) {
+      RewriteBuf.InsertText(Offset, Text);
+    } else if (Text.size() == 0) {
+      RewriteBuf.RemoveText(Offset, Length);
+    } else {
+      RewriteBuf.ReplaceText(Offset, Length, Text);
+    }
     ++NumFixitsApplied;
   }
 }

--- a/test/Migrator/insert_replace_fixit.swift
+++ b/test/Migrator/insert_replace_fixit.swift
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -update-code -primary-file %s -F %S/mock-sdk -emit-migrated-file-path %t/result.swift
+// RUN: diff -u %s.expected %t/result.swift
+
+import TestMyTime
+
+let zero = kMyTimeZero
+
+let _ = MyTimeAdd(kMyTimeZero, kMyTimeZero)
+let _ = MyTimeAdd(
+  kMyTimeZero, kMyTimeZero)
+let _ = MyTimeAdd(
+  kMyTimeZero,
+  kMyTimeZero)

--- a/test/Migrator/insert_replace_fixit.swift.expected
+++ b/test/Migrator/insert_replace_fixit.swift.expected
@@ -1,0 +1,14 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -update-code -primary-file %s -F %S/mock-sdk -emit-migrated-file-path %t/result.swift
+// RUN: diff -u %s.expected %t/result.swift
+
+import TestMyTime
+
+let zero = MyTime.z
+
+let _ = MyTime.add(this: MyTime.z, that: MyTime.z)
+let _ = MyTime.add(
+  this: MyTime.z, that: MyTime.z)
+let _ = MyTime.add(
+  this: MyTime.z,
+  that: MyTime.z)

--- a/test/Migrator/mock-sdk/TestMyTime.framework/Headers/MyTime.h
+++ b/test/Migrator/mock-sdk/TestMyTime.framework/Headers/MyTime.h
@@ -1,0 +1,8 @@
+
+typedef struct {
+	int value;
+} MyTime;
+
+extern const MyTime kMyTimeZero;
+
+extern MyTime MyTimeAdd(MyTime lhs, MyTime rhs);

--- a/test/Migrator/mock-sdk/TestMyTime.framework/Headers/TestMyTime.apinotes
+++ b/test/Migrator/mock-sdk/TestMyTime.framework/Headers/TestMyTime.apinotes
@@ -1,0 +1,15 @@
+Name: TestMyTime
+Globals:
+- Name: kMyTimeZero
+  SwiftName: "MyTime.z"
+Functions:
+- Name: MyTimeAdd
+  SwiftName: "MyTime.add(this:that:)"
+SwiftVersions:
+- Version: 3
+  Globals:
+  - Name: kMyTimeZero
+    SwiftName: "kMyTimeZero"
+  Functions:
+  - Name: MyTimeAdd
+    SwiftName: "MyTimeAdd(_:_:)"

--- a/test/Migrator/mock-sdk/TestMyTime.framework/Headers/TestMyTime.h
+++ b/test/Migrator/mock-sdk/TestMyTime.framework/Headers/TestMyTime.h
@@ -1,0 +1,2 @@
+
+#include <TestMyTime/MyTime.h>

--- a/test/Migrator/mock-sdk/TestMyTime.framework/Modules/module.modulemap
+++ b/test/Migrator/mock-sdk/TestMyTime.framework/Modules/module.modulemap
@@ -1,0 +1,6 @@
+framework module TestMyTime {
+  umbrella header "TestMyTime.h"
+
+  export *
+  module * { export * }
+}


### PR DESCRIPTION
Cherry-pick of #16171 reviewed by @nkcsgexi 

Apparently, ReplaceText() on the same location replaces the replaced
text. Using InsertText() fixes the problem.
This problem used to cause a invalid migration. For example:
```swift
_ = FooBar(SomeThing)

// Renaming: FooBar(_:) → Foo.bar(someThing:)
_ = FooBar(someThing: SomeThing)

// Renaming: SomeValue → Some.val
_ = Foo.bar(Some.valg: SomeThing)
```

rdar://problem/39518867