### PR TITLE
Plumb through support for 'usable from inline' imports

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -372,6 +372,9 @@ SIMPLE_DECL_ATTR(_frozen, Frozen,
   OnEnum |
   UserInaccessible,
   76)
+SIMPLE_DECL_ATTR(_usableFromInline, UsableFromInlineImport,
+  OnImport | UserInaccessible,
+  77)
 
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1549,8 +1549,17 @@ public:
     return static_cast<ImportKind>(Bits.ImportDecl.ImportKind);
   }
 
+  // An exported import is visible to name lookup from other modules, and is
+  // autolinked when the containing module is autolinked.
   bool isExported() const {
     return getAttrs().hasAttribute<ExportedAttr>();
+  }
+
+  // A usable from inline import is autolinked but not visible to name lookup.
+  // This attribute is inferred when type checking inlinable and default
+  // argument bodies.
+  bool isUsableFromInline() const {
+    return getAttrs().hasAttribute<UsableFromInlineImportAttr>();
   }
 
   ModuleDecl *getModule() const { return Mod; }

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -732,13 +732,17 @@ public:
   };
 
   /// Possible attributes for imports in source files.
-  enum class ImportFlags {
+  enum class ImportFlags : uint8_t {
     /// The imported module is exposed to anyone who imports the parent module.
     Exported = 0x1,
 
     /// This source file has access to testable declarations in the imported
     /// module.
-    Testable = 0x2
+    Testable = 0x2,
+
+    /// Modules that depend on the module containing this source file will
+    /// autolink this dependency.
+    UsableFromInline = 0x4,
   };
 
   /// \see ImportFlags

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -345,9 +345,17 @@ public:
 
   /// \sa getImportedModules
   enum class ImportFilter {
+    // Everything.
     All,
+
+    // @_exported only.
     Public,
-    Private
+
+    // Not @_exported only. Also includes @_usableFromInline.
+    Private,
+
+    // @_usableFromInline and @_exported only.
+    ForLinking
   };
 
   /// Looks up which modules are imported by this module.
@@ -360,10 +368,15 @@ public:
   /// Looks up which modules are imported by this module, ignoring any that
   /// won't contain top-level decls.
   ///
-  /// This is a performance hack. Do not use for anything but name lookup.
-  /// May go away in the future.
+  /// This is a performance hack for the ClangImporter. Do not use for
+  /// anything but name lookup. May go away in the future.
   void
   getImportedModulesForLookup(SmallVectorImpl<ImportedModule> &imports) const;
+
+  /// Extension of the above hack. Identical to getImportedModulesForLookup()
+  /// for imported modules, otherwise also includes @usableFromInline imports.
+  void
+  getImportedModulesForLinking(SmallVectorImpl<ImportedModule> &imports) const;
 
   /// Finds all top-level decls of this module.
   ///
@@ -402,11 +415,16 @@ public:
   ///        results, with the given access path.
   /// \param fn A callback of type bool(ImportedModule) or void(ImportedModule).
   ///        Return \c false to abort iteration.
+  /// \param includeLinkOnlyModules Include modules that are not visible to
+  ///        name lookup but must be linked in because inlinable code can
+  ///        reference their symbols.
   ///
   /// \return True if the traversal ran to completion, false if it ended early
   ///         due to the callback.
   bool forAllVisibleModules(AccessPathTy topLevelAccessPath,
-                            llvm::function_ref<bool(ImportedModule)> fn);
+                            llvm::function_ref<bool(ImportedModule)> fn,
+                            bool includeLinkOnlyModules = false);
+
 
   /// @}
 
@@ -638,6 +656,12 @@ public:
     return getImportedModules(imports, ModuleDecl::ImportFilter::Public);
   }
 
+  /// \see ModuleDecl::getImportedModulesForLinking
+  virtual void getImportedModulesForLinking(
+      SmallVectorImpl<ModuleDecl::ImportedModule> &imports) const {
+    return getImportedModules(imports, ModuleDecl::ImportFilter::ForLinking);
+  }
+
   /// Generates the list of libraries needed to link this file, based on its
   /// imports.
   virtual void
@@ -649,11 +673,15 @@ public:
   ///
   /// \param fn A callback of type bool(ImportedModule) or void(ImportedModule).
   ///           Return \c false to abort iteration.
+  /// \param includeLinkOnlyModules Include modules that are not visible to
+  ///        name lookup but must be linked in because inlinable code can
+  ///        reference their symbols.
   ///
   /// \return True if the traversal ran to completion, false if it ended early
   ///         due to the callback.
   bool
-  forAllVisibleModules(llvm::function_ref<bool(ModuleDecl::ImportedModule)> fn);
+  forAllVisibleModules(llvm::function_ref<bool(ModuleDecl::ImportedModule)> fn,
+                       bool includeLinkOnlyModules = false);
 
   /// @}
 

--- a/include/swift/ClangImporter/ClangModule.h
+++ b/include/swift/ClangImporter/ClangModule.h
@@ -97,6 +97,12 @@ public:
   virtual void getImportedModulesForLookup(
       SmallVectorImpl<ModuleDecl::ImportedModule> &imports) const override;
 
+  virtual void getImportedModulesForLinking(
+      SmallVectorImpl<ModuleDecl::ImportedModule> &imports) const override {
+    // In C, anything that's linkable is visible to the source language.
+    return getImportedModulesForLookup(imports);
+  }
+
   virtual void
   collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const override;
 

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -132,20 +132,32 @@ public:
     const StringRef RawPath;
 
   private:
-    unsigned IsExported : 1;
     const unsigned IsHeader : 1;
+    const unsigned IsExported : 1;
+    const unsigned IsUsableFromInline : 1;
     const unsigned IsScoped : 1;
 
-    Dependency(StringRef path, bool isHeader, bool exported, bool isScoped)
-      : RawPath(path), IsExported(exported), IsHeader(isHeader),
-        IsScoped(isScoped) {}
+    Dependency(bool isHeader,
+               StringRef path, bool exported,
+               bool isUsableFromInline, bool isScoped)
+      : RawPath(path),
+        IsHeader(isHeader),
+        IsExported(exported),
+        IsUsableFromInline(isUsableFromInline),
+        IsScoped(isScoped) {
+      assert(!(IsExported && IsUsableFromInline));
+      assert(!(IsHeader && IsScoped));
+    }
 
   public:
-    Dependency(StringRef path, bool exported, bool isScoped)
-      : Dependency(path, false, exported, isScoped) {}
+    Dependency(StringRef path, bool exported, bool isUsableFromInline,
+               bool isScoped)
+      : Dependency(false, path, exported, isUsableFromInline, isScoped) {}
 
     static Dependency forHeader(StringRef headerPath, bool exported) {
-      return Dependency(headerPath, true, exported, false);
+      return Dependency(true, headerPath, exported,
+                        /*isUsableFromInline=*/false,
+                        /*isScoped=*/false);
     }
 
     bool isLoaded() const {
@@ -153,6 +165,7 @@ public:
     }
 
     bool isExported() const { return IsExported; }
+    bool isUsableFromInline() const { return IsUsableFromInline; }
     bool isHeader() const { return IsHeader; }
     bool isScoped() const { return IsScoped; }
 

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 411; // Last change: copy_block_without_escaping
+const uint16_t VERSION_MINOR = 412; // Last change: @usableFromInline import
 
 using DeclIDField = BCFixed<31>;
 
@@ -595,6 +595,7 @@ namespace input_block {
   using ImportedModuleLayout = BCRecordLayout<
     IMPORTED_MODULE,
     BCFixed<1>, // exported?
+    BCFixed<1>, // usable from inlinable functions?
     BCFixed<1>, // scoped?
     BCBlob // module name, with submodule path pieces separated by \0s.
            // If the 'scoped' flag is set, the final path piece is an access

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3049,6 +3049,7 @@ void ClangModuleUnit::getImportedModules(
     imports.push_back({ModuleDecl::AccessPathTy(), owner.getStdlibModule()});
     break;
   case ModuleDecl::ImportFilter::Public:
+  case ModuleDecl::ImportFilter::ForLinking:
     break;
   }
 
@@ -3058,6 +3059,7 @@ void ClangModuleUnit::getImportedModules(
     switch (filter) {
     case ModuleDecl::ImportFilter::All:
     case ModuleDecl::ImportFilter::Public:
+    case ModuleDecl::ImportFilter::ForLinking:
       imported.append(owner.ImportedHeaderExports.begin(),
                       owner.ImportedHeaderExports.end());
       break;
@@ -3106,6 +3108,7 @@ void ClangModuleUnit::getImportedModules(
     }
 
     case ModuleDecl::ImportFilter::Public:
+    case ModuleDecl::ImportFilter::ForLinking:
       break;
     }
   }

--- a/lib/Sema/NameBinding.cpp
+++ b/lib/Sema/NameBinding.cpp
@@ -235,6 +235,8 @@ void NameBinder::addImport(
   ImportOptions options;
   if (ID->isExported())
     options |= SourceFile::ImportFlags::Exported;
+  if (ID->isUsableFromInline())
+    options |= SourceFile::ImportFlags::UsableFromInline;
   if (testableAttr)
     options |= SourceFile::ImportFlags::Testable;
   imports.push_back({ { ID->getDeclPath(), M }, options });

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -112,6 +112,7 @@ public:
   IGNORED_ATTR(UIApplicationMain)
   IGNORED_ATTR(UnsafeNoObjCTaggedPointer)
   IGNORED_ATTR(UsableFromInline)
+  IGNORED_ATTR(UsableFromInlineImport)
   IGNORED_ATTR(WeakLinked)
 #undef IGNORED_ATTR
 
@@ -840,6 +841,7 @@ public:
     IGNORED_ATTR(SynthesizedProtocol)
     IGNORED_ATTR(Testable)
     IGNORED_ATTR(Transparent)
+    IGNORED_ATTR(UsableFromInlineImport)
     IGNORED_ATTR(WarnUnqualifiedAccess)
     IGNORED_ATTR(WeakLinked)
 #undef IGNORED_ATTR

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5775,6 +5775,8 @@ public:
     UNINTERESTING_ATTR(ClangImporterSynthesizedType)
     UNINTERESTING_ATTR(WeakLinked)
     UNINTERESTING_ATTR(Frozen)
+    UNINTERESTING_ATTR(UsableFromInlineImport)
+
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1598,6 +1598,13 @@ void ModuleFile::getImportedModules(
         continue;
 
       break;
+
+    case ModuleDecl::ImportFilter::ForLinking:
+      // FIXME
+      if (!dep.isExported())
+        continue;
+
+      break;
     }
 
     assert(dep.isLoaded());

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1140,10 +1140,12 @@ ModuleFile::ModuleFile(
         unsigned kind = cursor.readRecord(next.ID, scratch, &blobData);
         switch (kind) {
         case input_block::IMPORTED_MODULE: {
-          bool exported, scoped;
+          bool exported, usableFromInline, scoped;
           input_block::ImportedModuleLayout::readRecord(scratch,
-                                                        exported, scoped);
-          Dependencies.push_back({blobData, exported, scoped});
+                                                        exported,
+                                                        usableFromInline,
+                                                        scoped);
+          Dependencies.push_back({blobData, exported, usableFromInline, scoped});
           break;
         }
         case input_block::LINK_LIBRARY: {
@@ -1600,8 +1602,8 @@ void ModuleFile::getImportedModules(
       break;
 
     case ModuleDecl::ImportFilter::ForLinking:
-      // FIXME
-      if (!dep.isExported())
+      // Only include @_exported and @usableFromInline imports.
+      if (!dep.isExported() && !dep.isUsableFromInline())
         continue;
 
       break;
@@ -1673,6 +1675,9 @@ void ModuleFile::getImportDecls(SmallVectorImpl<Decl *> &Results) {
       if (Dep.isExported())
         ID->getAttrs().add(
             new (Ctx) ExportedAttr(/*IsImplicit=*/false));
+      if (Dep.isUsableFromInline())
+        ID->getAttrs().add(
+            new (Ctx) UsableFromInlineImportAttr(/*IsImplicit=*/true));
       ImportDecls.push_back(ID);
     }
     Bits.ComputedImportDecls = true;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1073,15 +1073,21 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
   // FIXME: Having to deal with private imports as a superset of public imports
   // is inefficient.
   SmallVector<ModuleDecl::ImportedModule, 8> publicImports;
+  SmallVector<ModuleDecl::ImportedModule, 8> linkImports;
   SmallVector<ModuleDecl::ImportedModule, 8> allImports;
   for (auto file : M->getFiles()) {
     file->getImportedModules(publicImports, ModuleDecl::ImportFilter::Public);
+    file->getImportedModules(linkImports, ModuleDecl::ImportFilter::ForLinking);
     file->getImportedModules(allImports, ModuleDecl::ImportFilter::All);
   }
 
   llvm::SmallSet<ModuleDecl::ImportedModule, 8, ModuleDecl::OrderImportedModules>
     publicImportSet;
   publicImportSet.insert(publicImports.begin(), publicImports.end());
+
+  llvm::SmallSet<ModuleDecl::ImportedModule, 8, ModuleDecl::OrderImportedModules>
+    linkImportSet;
+  linkImportSet.insert(linkImports.begin(), linkImports.end());
 
   removeDuplicateImports(allImports);
   auto clangImporter =
@@ -1111,7 +1117,10 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
 
     ImportPathBlob importPath;
     flattenImportPath(import, importPath);
-    ImportedModule.emit(ScratchRecord, publicImportSet.count(import),
+    ImportedModule.emit(ScratchRecord,
+                        publicImportSet.count(import),
+                        (linkImportSet.count(import) &&
+                         !publicImportSet.count(import)),
                         !import.first.empty(), importPath);
   }
 

--- a/test/IDE/Inputs/HasInlinableImport.swift
+++ b/test/IDE/Inputs/HasInlinableImport.swift
@@ -1,0 +1,2 @@
+@_usableFromInline import InlinableImport
+

--- a/test/IDE/Inputs/InlinableImport.swift
+++ b/test/IDE/Inputs/InlinableImport.swift
@@ -1,0 +1,1 @@
+// Empty module

--- a/test/IDE/print_swift_module_with_inlinable_import.swift
+++ b/test/IDE/print_swift_module_with_inlinable_import.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -o %t/InlinableImport.swiftmodule %S/Inputs/InlinableImport.swift
+// RUN: %target-swift-frontend -I %t -emit-module -o %t/HasInlinableImport.swiftmodule %S/Inputs/HasInlinableImport.swift
+// RUN: %target-swift-ide-test -I %t -print-module -source-filename %s -module-to-print=HasInlinableImport -function-definitions=false | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import HasInlinableImport
+
+// For now, don't print anything special for inlinable imports.
+
+// CHECK: {{^}}import InlinableImport

--- a/test/Serialization/Inputs/autolinking_module.swift
+++ b/test/Serialization/Inputs/autolinking_module.swift
@@ -1,0 +1,7 @@
+@_exported import autolinking_public
+@_usableFromInline import autolinking_other
+import autolinking_private
+
+public func bfunc(x: Int = afunc()) {
+  cfunc()
+}

--- a/test/Serialization/Inputs/autolinking_other.swift
+++ b/test/Serialization/Inputs/autolinking_other.swift
@@ -1,0 +1,1 @@
+public func afunc() -> Int { return 0 }

--- a/test/Serialization/Inputs/autolinking_private.swift
+++ b/test/Serialization/Inputs/autolinking_private.swift
@@ -1,0 +1,1 @@
+public func cfunc() {}

--- a/test/Serialization/Inputs/autolinking_public.swift
+++ b/test/Serialization/Inputs/autolinking_public.swift
@@ -1,0 +1,1 @@
+// Empty module

--- a/test/Serialization/autolinking-inlinable.swift
+++ b/test/Serialization/autolinking-inlinable.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_public.swift -emit-module-path %t/autolinking_public.swiftmodule -module-link-name autolinking_public -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_other.swift -emit-module-path %t/autolinking_other.swiftmodule -module-link-name autolinking_other -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_private.swift -emit-module-path %t/autolinking_private.swiftmodule -module-link-name autolinking_private -I %t -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_module.swift -emit-module-path %t/autolinking_module.swiftmodule -module-link-name autolinking_module -I %t -swift-version 4
+// RUN: %target-swift-frontend -emit-ir %s -I %t -swift-version 4 | %FileCheck %s
+
+// Linux uses a different autolinking mechanism, based on
+// swift-autolink-extract. This file tests the Darwin mechanism.
+// UNSUPPORTED: OS=linux-gnu
+// UNSUPPORTED: OS=linux-gnueabihf
+// UNSUPPORTED: OS=freebsd
+// UNSUPPORTED: OS=linux-androideabi
+
+import autolinking_module
+
+bfunc()
+
+// Note: we don't autolink autolinking_private even though autolinking_module imports it also.
+
+// CHECK: !llvm.linker.options = !{[[SWIFTCORE:![0-9]+]], [[SWIFTONONESUPPORT:![0-9]+]], [[MODULE:![0-9]+]], [[PUBLIC:![0-9]+]], [[OTHER:![0-9]+]], [[OBJC:![0-9]+]]}
+
+// CHECK: [[SWIFTCORE]] = !{!"-lswiftCore"}
+// CHECK: [[SWIFTONONESUPPORT]] = !{!"-lswiftSwiftOnoneSupport"}
+// CHECK: [[MODULE]] = !{!"-lautolinking_module"}
+// CHECK: [[PUBLIC]] = !{!"-lautolinking_public"}
+// CHECK: [[OTHER]] = !{!"-lautolinking_other"}
+// CHECK: [[OBJC]] = !{!"-lobjc"}


### PR DESCRIPTION
Progress on <rdar://problem/39338239>; we still need to infer this attribute though.