### PR TITLE
[4.2] Revert "Temporarily disable an optimization to avoid some crash…

### DIFF
--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -1144,8 +1144,7 @@ getAddrOfKnownValueWitnessTable(IRGenModule &IGM, CanType type) {
       witnessSurrogate = C.TheUnknownObjectType;
       break;
     case ReferenceCounting::Bridge:
-      // FIXME: Temporarily disable this optimization (rdar://problem/39697747)
-      // witnessSurrogate = C.TheBridgeObjectType;
+      witnessSurrogate = C.TheBridgeObjectType;
       break;
     case ReferenceCounting::Error:
       break;


### PR DESCRIPTION
…es."

This was not necessary.

This reverts commit ef3c77417c73b18c8227b5d41c01112f43ed5a1f.

The fix from #16115 is sufficient.

rdar://39697747
