### PR TITLE
[README] Up the warning about disk space usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ well. For more, see the [Code of Conduct](https://swift.org/community/#code-of-c
 ## Getting Started
 
 These instructions give the most direct path to a working Swift development
-environment. To build from source you will need 2 GB of disk space for the
-source code and over 20 GB of disk space for the build artifacts. A clean
-build can take multiple hours, but incremental builds will finish much faster.
+environment. To build from source you will need about 2 GB of disk space for the
+source code and up to 70 GB of disk space for the build artifacts with full
+debugging. Depending on your machine, a clean build can take a few minutes to
+several hours. Naturally, incremental builds are much faster.
 
 
 ### System Requirements


### PR DESCRIPTION
On my Linux box, I need upwards of 70 GiB for a Debug+Assert build.