### PR TITLE
[String] Internalize and drop some inlinable annotations

### DIFF
--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -911,7 +911,6 @@ extension String {
 
   // TODO(SSO): Consider small-checking version
   @inlinable // FIXME(sil-serialize-all)
-  public
   init<CodeUnit>(_largeStorage storage: _SwiftStringStorage<CodeUnit>)
   where CodeUnit : FixedWidthInteger & UnsignedInteger {
     _guts = _StringGuts(_large: storage)

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -637,10 +637,9 @@ extension _StringGuts {
     return _copyToNativeStorage(of: CodeUnit.self, from: 0..<count)
   }
 
+  @inlinable
   @_specialize(where CodeUnit == UInt8)
   @_specialize(where CodeUnit == UInt16)
-  @_specialize(where CodeUnit == UTF16.CodeUnit)
-  @inlinable
   internal
   func _copyToNativeStorage<CodeUnit>(
     of codeUnit: CodeUnit.Type = CodeUnit.self,

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -101,7 +101,7 @@ extension _StringGuts {
   @inlinable
   @inline(__always)
   public // @testable
-  mutating func isUniqueNative() -> Bool {
+  mutating func _isUniqueNative() -> Bool {
     guard _isNative else { return false }
     // Note that the isUnique test must be in a separate statement;
     // `isNative && _isUnique` always evaluates to false in debug builds,
@@ -450,7 +450,7 @@ extension _StringGuts {
 
 #if _runtime(_ObjC)
 extension _StringGuts {
-  public // @testable
+  @usableFromInline
   var _underlyingCocoaString: _CocoaString? {
     if _object.isNative {
       return _object.nativeRawStorage
@@ -708,7 +708,7 @@ extension _StringGuts {
     }
     // We have enough space; check if it's unique and of the correct width.
     if _fastPath(_object.bitWidth == CodeUnit.bitWidth) {
-      if _fastPath(isUniqueNative()) {
+      if _fastPath(_isUniqueNative()) {
         return nil
       }
     }
@@ -862,7 +862,6 @@ extension _StringGuts {
 
   /// Get the UTF-16 code unit stored at the specified position in this string.
   @inlinable // FIXME(sil-serialize-all)
-  public // @testable
   func codeUnit(atCheckedOffset offset: Int) -> UTF16.CodeUnit {
     if _slowPath(_isOpaque) {
       return _opaqueCodeUnit(atCheckedOffset: offset)
@@ -931,7 +930,7 @@ extension _StringGuts {
     _ unusedCapacity: Int,
     ascii: Bool = false
   ) {
-    if _fastPath(isUniqueNative()) {
+    if _fastPath(_isUniqueNative()) {
       if _fastPath(
         ascii == (_object.bitWidth == 8) &&
         _object.nativeRawStorage.unusedCapacity >= unusedCapacity) {
@@ -960,7 +959,7 @@ extension _StringGuts {
   @inlinable
   public // TODO(StringGuts): for testing
   mutating func reserveCapacity(_ capacity: Int) {
-    if _fastPath(isUniqueNative()) {
+    if _fastPath(_isUniqueNative()) {
       if _fastPath(_object.nativeRawStorage.capacity >= capacity) {
         return
       }

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -709,7 +709,6 @@ extension _StringObject {
   }
 
   @inlinable
-  public // @testable
   var isSingleByte: Bool {
     @inline(__always)
     get {
@@ -729,7 +728,6 @@ extension _StringObject {
   }
 
   @inlinable
-  public // @testable
   var byteWidth: Int {
     @inline(__always)
     get { return isSingleByte ? 1 : 2 }
@@ -742,14 +740,12 @@ extension _StringObject {
   }
 
   @inlinable
-  public // @testable
   var isContiguousASCII: Bool {
     @inline(__always)
     get { return isContiguous && isSingleByte }
   }
 
   @inlinable
-  public // @testable
   var isContiguousUTF16: Bool {
     @inline(__always)
     get { return isContiguous && !isSingleByte }
@@ -770,7 +766,6 @@ extension _StringObject {
   }
 
   @inlinable
-  public // @testable
   var nativeRawStorage: _SwiftRawStringStorage {
     @inline(__always) get {
       _sanityCheck(isNative)

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -13,14 +13,14 @@
 import SwiftShims
 
 @_fixed_layout
-public
+@usableFromInline
 class _SwiftRawStringStorage : _SwiftNativeNSString {
   @nonobjc
-  public // @testable
+  @usableFromInline
   final var capacity: Int
 
   @nonobjc
-  public // @testable
+  @usableFromInline
   final var count: Int
 
   @nonobjc
@@ -36,7 +36,6 @@ class _SwiftRawStringStorage : _SwiftNativeNSString {
 
   @inlinable
   @nonobjc
-  public // @testable
   final var unusedCapacity: Int {
     _sanityCheck(capacity >= count)
     return capacity - count
@@ -47,7 +46,8 @@ internal typealias _ASCIIStringStorage = _SwiftStringStorage<UInt8>
 internal typealias _UTF16StringStorage = _SwiftStringStorage<UTF16.CodeUnit>
 
 @_fixed_layout
-public final class _SwiftStringStorage<CodeUnit>
+@usableFromInline
+final class _SwiftStringStorage<CodeUnit>
   : _SwiftRawStringStorage, _NSStringCore
 where CodeUnit : UnsignedInteger & FixedWidthInteger {
 
@@ -91,24 +91,28 @@ where CodeUnit : UnsignedInteger & FixedWidthInteger {
   // NSString API
 
   @objc(initWithCoder:)
-  public convenience init(coder aDecoder: AnyObject) {
+  @usableFromInline
+  convenience init(coder aDecoder: AnyObject) {
     _sanityCheckFailure("init(coder:) not implemented for _SwiftStringStorage")
   }
 
   @objc(length)
-  public var length: Int {
+  @usableFromInline
+  var length: Int {
     return count
   }
 
   @objc(characterAtIndex:)
-  public func character(at index: Int) -> UInt16 {
+  @usableFromInline
+  func character(at index: Int) -> UInt16 {
     defer { _fixLifetime(self) }
     precondition(index >= 0 && index < count, "Index out of bounds")
     return UInt16(start[index])
   }
 
   @objc(getCharacters:range:)
-  public func getCharacters(
+  @usableFromInline
+  func getCharacters(
     _ buffer: UnsafeMutablePointer<UInt16>,
     range aRange: _SwiftNSRange
   ) {
@@ -126,13 +130,15 @@ where CodeUnit : UnsignedInteger & FixedWidthInteger {
   }
 
   @objc(_fastCharacterContents)
-  public func _fastCharacterContents() -> UnsafePointer<UInt16>? {
+  @usableFromInline
+  func _fastCharacterContents() -> UnsafePointer<UInt16>? {
     guard CodeUnit.self == UInt16.self else { return nil }
     return UnsafePointer(rawStart.assumingMemoryBound(to: UInt16.self))
   }
 
   @objc(copyWithZone:)
-  public func copy(with zone: _SwiftNSZone?) -> AnyObject {
+  @usableFromInline
+  func copy(with zone: _SwiftNSZone?) -> AnyObject {
     // While _SwiftStringStorage instances aren't immutable in general,
     // mutations may only occur when instances are uniquely referenced.
     // Therefore, it is safe to return self here; any outstanding Objective-C

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -52,8 +52,10 @@ final class _SwiftStringStorage<CodeUnit>
 where CodeUnit : UnsignedInteger & FixedWidthInteger {
 
   /// Create uninitialized storage of at least the specified capacity.
-  @inlinable
+  @usableFromInline
   @nonobjc
+  @_specialize(where CodeUnit == UInt8)
+  @_specialize(where CodeUnit == UInt16)
   internal static func create(
     capacity: Int,
     count: Int = 0
@@ -191,7 +193,7 @@ extension _SwiftStringStorage {
 extension _SwiftStringStorage {
   // Append operations
 
-  @inlinable
+  @inlinable // TODO(inlinability): @usableFromInline - P3
   @nonobjc
   internal final func _appendInPlace<OtherCodeUnit>(
     _ other: _UnmanagedString<OtherCodeUnit>
@@ -203,7 +205,7 @@ extension _SwiftStringStorage {
     self.count += otherCount
   }
 
-  @inlinable
+  @inlinable // TODO(inlinability): @usableFromInline - P3
   @nonobjc
   internal final func _appendInPlace(_ other: _UnmanagedOpaqueString) {
     let otherCount = Int(other.count)
@@ -212,7 +214,7 @@ extension _SwiftStringStorage {
     self.count += otherCount
   }
 
-  @inlinable
+  @inlinable // TODO(inlinability): @usableFromInline - P3
   @nonobjc
   internal final func _appendInPlace<C: Collection>(contentsOf other: C)
   where C.Element == CodeUnit {
@@ -225,7 +227,7 @@ extension _SwiftStringStorage {
     count += otherCount
   }
 
-  @inlinable
+  @inlinable // TODO(inlinability): @usableFromInline - P3
   @_specialize(where C == Character._SmallUTF16, CodeUnit == UInt8)
   @nonobjc
   internal final func _appendInPlaceUTF16<C: Collection>(contentsOf other: C)

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -942,7 +942,7 @@ StringTests.test("stringGutsReserve")
     expectEqual(isSwiftNative(base), startedNative)
     
     let originalBuffer = base.bufferID
-    let isUnique = base._guts.isUniqueNative()
+    let isUnique = base._guts._isUniqueNative()
     let startedUnique =
       startedNative &&
       base._guts._objectIdentifier != nil &&


### PR DESCRIPTION
<!-- What's in this pull request? -->
Attempt to internalize and drop some `@inlinable` annotations. PR up to see effects.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
