### PR TITLE
[Clang importer] Honor swift_bridged_typedef attribute.

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2529,7 +2529,7 @@ namespace {
         clang::QualType ClangType = Decl->getUnderlyingType();
         SwiftType = Impl.importTypeIgnoreIUO(
             ClangType, ImportTypeKind::Typedef, isInSystemModule(DC),
-            getTypedefBridgeability(ClangType), OTK_Optional);
+            getTypedefBridgeability(Decl, ClangType), OTK_Optional);
       }
 
       if (!SwiftType)

--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -663,12 +663,11 @@ namespace {
         auto underlyingType = type->desugar();
 
         // Figure out the bridgeability we would normally use for this typedef.
-        auto typedefBridgeability = getTypedefBridgeability(underlyingType);
+        auto typedefBridgeability =
+          getTypedefBridgeability(type->getDecl(), underlyingType);
 
         // Figure out the typedef we should actually use.
-        auto underlyingBridgeability =
-          (Bridging == Bridgeability::Full
-             ? typedefBridgeability : Bridgeability::None);
+        auto underlyingBridgeability = Bridging;
         SwiftTypeConverter innerConverter(Impl, AllowNSUIntegerAsInt,
                                           underlyingBridgeability);
         auto underlyingResult = innerConverter.Visit(underlyingType);
@@ -685,7 +684,8 @@ namespace {
 #ifndef NDEBUG
         switch (underlyingResult.Hint) {
         case ImportHint::Block:
-          // Blocks change in all sorts of ways, due to bridging.
+        case ImportHint::ObjCBridged:
+          // Bridging is fine for Objective-C and blocks.
           break;
         case ImportHint::NSUInteger:
           // NSUInteger might be imported as Int rather than UInt depending
@@ -1088,7 +1088,6 @@ namespace {
 static bool canBridgeTypes(ImportTypeKind importKind) {
   switch (importKind) {
   case ImportTypeKind::Abstract:
-  case ImportTypeKind::Typedef:
   case ImportTypeKind::Value:
   case ImportTypeKind::Variable:
   case ImportTypeKind::AuditedVariable:
@@ -1104,6 +1103,7 @@ static bool canBridgeTypes(ImportTypeKind importKind) {
   case ImportTypeKind::Property:
   case ImportTypeKind::PropertyWithReferenceSemantics:
   case ImportTypeKind::BridgedValue:
+  case ImportTypeKind::Typedef:
     return true;
   }
 
@@ -1286,7 +1286,7 @@ static ImportedType adjustTypeForConcreteImport(
   // In a bridgeable context, or in the direct structure of a typedef,
   // we would prefer to instead use the default Swift convention.
   if (hint == ImportHint::Block) {
-    if (canBridgeTypes(importKind) || importKind == ImportTypeKind::Typedef) {
+    if (canBridgeTypes(importKind)) {
       auto fTy = importedType->castTo<FunctionType>();
       FunctionType::ExtInfo einfo = fTy->getExtInfo();
       if (einfo.getRepresentation() != FunctionTypeRepresentation::Swift) {
@@ -1330,13 +1330,18 @@ static ImportedType adjustTypeForConcreteImport(
   // bridge, do so.
   if (hint == ImportHint::ObjCBridged &&
       canBridgeTypes(importKind) &&
-      importKind != ImportTypeKind::PropertyWithReferenceSemantics) {
+      importKind != ImportTypeKind::PropertyWithReferenceSemantics &&
+      !(importKind == ImportTypeKind::Typedef &&
+        bridging == Bridgeability::None)) {
     // id and Any can be bridged without Foundation. There would be
     // bootstrapping issues with the ObjectiveC module otherwise.
     if (hint.BridgedType->isAny()
         || impl.tryLoadFoundationModule()
         || impl.ImportForwardDeclarations) {
-      importedType = hint.BridgedType;
+
+      // Set the bridged type if it wasn't done already.
+      if (!importedType->isEqual(hint.BridgedType))
+        importedType = hint.BridgedType;
     }
   }
 
@@ -2484,7 +2489,7 @@ Type ClangImporter::Implementation::getSugaredTypeReference(TypeDecl *type) {
     }
 
     return NameAliasType::get(typealias, parentType, SubstitutionMap(),
-                                   typealias->getUnderlyingTypeLoc().getType());
+                              typealias->getUnderlyingTypeLoc().getType());
   }
 
   return type->getDeclaredInterfaceType();

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -196,8 +196,14 @@ enum class Bridgeability {
 ///
 /// In either case we end up losing sugar at some uses sites, so this is more
 /// about what the right default is.
-static inline Bridgeability getTypedefBridgeability(clang::QualType type) {
-  return type->isBlockPointerType() ? Bridgeability::Full : Bridgeability::None;
+static inline Bridgeability getTypedefBridgeability(
+                                          const clang::TypedefNameDecl *decl,
+                                          clang::QualType type) {
+    return decl->hasAttr<clang::SwiftBridgedTypedefAttr>()
+      ? Bridgeability::Full
+        : type->isBlockPointerType()
+        ? Bridgeability::Full
+          : Bridgeability::None;
 }
 
 /// \brief Describes the kind of the C type that can be mapped to a stdlib

--- a/test/IDE/print_clang_decls.swift
+++ b/test/IDE/print_clang_decls.swift
@@ -22,6 +22,9 @@
 // RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -print-module -source-filename %s -module-to-print=nullability -function-definitions=false -prefer-type-repr=true > %t.printed.txt
 // RUN: %FileCheck %s -check-prefix=CHECK-NULLABILITY -strict-whitespace < %t.printed.txt
 
+// RUN: %target-swift-ide-test(mock-sdk: -sdk %S/../Inputs/clang-importer-sdk -I %t) -print-module -source-filename %s -module-to-print=bridged_typedef -function-definitions=false -prefer-type-repr=true > %t.printed.txt
+// RUN: %FileCheck %s -check-prefix=CHECK-BRIDGED-TYPEDEF -strict-whitespace < %t.printed.txt
+
 // TAG_DECLS_AND_TYPEDEFS: {{^}}struct FooStruct1 {{{$}}
 // TAG_DECLS_AND_TYPEDEFS: {{^}}  var x: Int32{{$}}
 // TAG_DECLS_AND_TYPEDEFS: {{^}}  var y: Double{{$}}
@@ -153,3 +156,8 @@
 // CHECK-NULLABILITY:   func optArrayMethod() -> [Any]?
 // CHECK-NULLABILITY: }
 // CHECK-NULLABILITY: func compare_classes(_ sc1: SomeClass, _ sc2: SomeClass, _ sc3: SomeClass!)
+
+// CHECK-BRIDGED-TYPEDEF: typealias NSMyAmazingStringAlias = String
+// CHECK-BRIDGED-TYPEDEF: func acceptNSMyAmazingStringAlias(_ param: NSMyAmazingStringAlias?)
+// CHECK-BRIDGED-TYPEDEF: func acceptNSMyAmazingStringAliasArray(_ param: [NSMyAmazingStringAlias])
+// CHECK-BRIDGED-TYPEDEF: func acceptIndirectedAmazingAlias(_ param: AutoreleasingUnsafeMutablePointer<NSString>?)

--- a/test/Inputs/clang-importer-sdk/usr/include/bridged_typedef.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/bridged_typedef.h
@@ -1,0 +1,13 @@
+#ifndef BRIDGED_TYPEDEF_H
+#define BRIDGED_TYPEDEF_H
+
+@import Foundation;
+
+
+typedef NSString *NSMyAmazingStringAlias __attribute__((swift_bridged_typedef));
+
+void acceptNSMyAmazingStringAlias(NSMyAmazingStringAlias _Nullable param);
+void acceptNSMyAmazingStringAliasArray(NSArray<NSMyAmazingStringAlias> * _Nonnull param);
+void acceptIndirectedAmazingAlias(NSMyAmazingStringAlias _Nonnull * _Nullable param);
+
+#endif

--- a/test/Inputs/clang-importer-sdk/usr/include/module.map
+++ b/test/Inputs/clang-importer-sdk/usr/include/module.map
@@ -126,3 +126,8 @@ module OtherSubscripts {
   header "OtherSubscripts.h"
   export *
 }
+
+module bridged_typedef {
+  header "bridged_typedef.h"
+  export *
+}


### PR DESCRIPTION
When the `swift_bridged_typedef` attribute is present on a typedef,
import the underlying type as bridged (e.g., String) rather than as
its unbridged type (e.g., NSString).

Fixes rdar://problem/39497900.
