### PR TITLE
Start gutting ExprCleaner and friends

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -403,7 +403,7 @@ public:
   Type getType() const { return Ty; }
 
   /// setType - Sets the type of this expression.
-  void setType(Type T) { Ty = T; }
+  void setType(Type T);
 
   /// \brief Return the source range of the expression.
   SourceRange getSourceRange() const;

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -717,12 +717,19 @@ public:
 /// can help us preserve the context of the code completion position.
 class CodeCompletionExpr : public Expr {
   SourceRange Range;
+  bool Activated;
+
 public:
   CodeCompletionExpr(SourceRange Range, Type Ty = Type()) :
       Expr(ExprKind::CodeCompletion, /*Implicit=*/true, Ty),
-      Range(Range) {}
+      Range(Range) {
+    Activated = false;
+  }
 
   SourceRange getSourceRange() const { return Range; }
+
+  bool isActivated() const { return Activated; }
+  void setActivated() { Activated = true; }
 
   static bool classof(const Expr *E) {
     return E->getKind() == ExprKind::CodeCompletion;

--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -126,7 +126,10 @@ public:
 
   /// Set the type of this pattern, given that it was previously not
   /// type-checked.
-  void setType(Type ty) { Ty = ty; }
+  void setType(Type ty) {
+    assert(!ty || !ty->hasTypeVariable());
+    Ty = ty;
+  }
 
   /// Retrieve the delayed interface type of this pattern, if it has one.
   ///

--- a/include/swift/AST/TypeLoc.h
+++ b/include/swift/AST/TypeLoc.h
@@ -65,9 +65,7 @@ public:
   bool isNull() const { return getType().isNull() && TyR == nullptr; }
 
   void setInvalidType(ASTContext &C);
-  void setType(Type Ty, bool validated = false) {
-    TAndValidBit.setPointerAndInt(Ty, validated);
-  }
+  void setType(Type Ty, bool validated = false);
 
   TypeLoc clone(ASTContext &ctx) const;
 };

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -117,6 +117,11 @@ namespace {
   };
 } // end anonymous namespace
 
+void Expr::setType(Type T) {
+  assert(!T || !T->hasTypeVariable());
+  Ty = T;
+}
+
 template <class T> static SourceRange getSourceRangeImpl(const T *E) {
   static_assert(isOverriddenFromExpr(&T::getSourceRange) ||
                 (isOverriddenFromExpr(&T::getStartLoc) &&

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -66,6 +66,11 @@ Type QuerySubstitutionMap::operator()(SubstitutableType *type) const {
   return subMap.lookupSubstitution(key);
 }
 
+void TypeLoc::setType(Type Ty, bool validated) {
+  assert(!Ty || !Ty->hasTypeVariable());
+  TAndValidBit.setPointerAndInt(Ty, validated);
+}
+
 bool TypeLoc::isError() const {
   assert(wasValidated() && "Type not yet validated");
   return getType()->hasError();

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -1912,6 +1912,8 @@ namespace {
 
     Expr *visitCodeCompletionExpr(CodeCompletionExpr *expr) {
       // Do nothing with code completion expressions.
+      auto toType = simplifyType(cs.getType(expr));
+      cs.setType(expr, toType);
       return expr;
     }
 

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1164,8 +1164,11 @@ namespace {
     }
 
     virtual Type visitCodeCompletionExpr(CodeCompletionExpr *E) {
-      // If the expression has already been assigned a type; just use that type.
-      return E->getType();
+      if (!E->isActivated())
+        return Type();
+
+      return CS.createTypeVariable(CS.getConstraintLocator(E),
+                                   TVO_CanBindToLValue);
     }
 
     Type visitLiteralExpr(LiteralExpr *expr) {

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -3556,7 +3556,7 @@ bool swift::typeCheckUnresolvedExpr(DeclContext &DC,
   auto *TC = static_cast<TypeChecker*>(DC.getASTContext().getLazyResolver());
   ConstraintSystem CS(*TC, &DC, Options);
   Parent = Parent->walk(SanitizeExpr(CS));
-  CleanupIllFormedExpressionRAII cleanup(TC->Context, Parent);
+  CleanupIllFormedExpressionRAII cleanup(Parent);
   InferUnresolvedMemberConstraintGenerator MCG(E, CS);
   ConstraintWalker cw(MCG);
   Parent->walk(cw);

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1173,7 +1173,7 @@ namespace {
 
     Type visitLiteralExpr(LiteralExpr *expr) {
       // If the expression has already been assigned a type; just use that type.
-      if (expr->getType() && !expr->getType()->hasTypeVariable())
+      if (expr->getType())
         return expr->getType();
 
       auto protocol = CS.getTypeChecker().getLiteralProtocol(expr);
@@ -1237,7 +1237,7 @@ namespace {
 
     Type visitObjectLiteralExpr(ObjectLiteralExpr *expr) {
       // If the expression has already been assigned a type; just use that type.
-      if (expr->getType() && !expr->getType()->hasTypeVariable())
+      if (expr->getType())
         return expr->getType();
 
       auto &tc = CS.getTypeChecker();

--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -461,13 +461,13 @@ Type ConstraintSystem::openUnboundGenericType(UnboundGenericType *unbound,
   }
         
   // Map the generic parameters to their corresponding type variables.
-  llvm::SmallVector<TypeLoc, 4> arguments;
+  llvm::SmallVector<Type, 2> arguments;
   for (auto gp : unboundDecl->getInnermostGenericParamTypes()) {
     auto found = replacements.find(
       cast<GenericTypeParamType>(gp->getCanonicalType()));
     assert(found != replacements.end() &&
            "Missing generic parameter?");
-    arguments.push_back(TypeLoc::withoutLoc(found->second));
+    arguments.push_back(found->second);
   }
 
   // FIXME: For some reason we can end up with unbound->getDecl()
@@ -477,7 +477,6 @@ Type ConstraintSystem::openUnboundGenericType(UnboundGenericType *unbound,
   return TC.applyUnboundGenericArguments(
       unbound, unboundDecl,
       SourceLoc(), DC, arguments,
-      /*options*/TypeResolutionOptions(),
       /*resolver*/nullptr,
       /*unsatisfiedDependency*/nullptr);
 }

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2089,9 +2089,7 @@ bool TypeChecker::typeCheckCompletionSequence(Expr *&expr, DeclContext *DC) {
   assert(exprAsBinOp == expr && "found wrong expr?");
 
   // Add type variable for the code-completion expression.
-  auto tvRHS =
-      CS.createTypeVariable(CS.getConstraintLocator(CCE), TVO_CanBindToLValue);
-  CCE->setType(tvRHS);
+  CCE->setActivated();
 
   if (auto generated = CS.generateConstraints(expr)) {
     expr = generated;

--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -1649,31 +1649,9 @@ void PreCheckExpression::resolveKeyPathExpr(KeyPathExpr *KPE) {
 
 /// \brief Clean up the given ill-formed expression, removing any references
 /// to type variables and setting error types on erroneous expression nodes.
-void CleanupIllFormedExpressionRAII::doIt(Expr *expr, ASTContext &Context) {
+void CleanupIllFormedExpressionRAII::doIt(Expr *expr) {
   class CleanupIllFormedExpression : public ASTWalker {
-    ASTContext &context;
-    
   public:
-    CleanupIllFormedExpression(ASTContext &context) : context(context) { }
-    
-    std::pair<bool, Expr *> walkToExprPre(Expr *expr) override {
-      // If the type of this expression has a type variable or is invalid,
-      // overwrite it with ErrorType.
-      Type type = expr->getType();
-      if (type && type->hasTypeVariable())
-        expr->setType(ErrorType::get(context));
-
-      return { true, expr };
-    }
-
-    // If we find a TypeLoc (e.g. in an as? expr) with a type variable, rewrite
-    // it.
-    bool walkToTypeLocPre(TypeLoc &TL) override {
-      if (TL.getType() && TL.getType()->hasTypeVariable())
-        TL.setType(Type(), /*was validated*/false);
-      return true;
-    }
-
     bool walkToDeclPre(Decl *D) override {
       // This handles parameter decls in ClosureExprs.
       if (auto VD = dyn_cast<VarDecl>(D)) {
@@ -1692,13 +1670,13 @@ void CleanupIllFormedExpressionRAII::doIt(Expr *expr, ASTContext &Context) {
   };
   
   if (expr)
-    expr->walk(CleanupIllFormedExpression(Context));
+    expr->walk(CleanupIllFormedExpression());
 }
 
 
 CleanupIllFormedExpressionRAII::~CleanupIllFormedExpressionRAII() {
   if (expr)
-    CleanupIllFormedExpressionRAII::doIt(*expr, Context);
+    CleanupIllFormedExpressionRAII::doIt(*expr);
 }
 
 /// Pre-check the expression, validating any types that occur in the
@@ -1825,7 +1803,7 @@ Type TypeChecker::typeCheckExpression(Expr *&expr, DeclContext *dc,
     csOptions |= ConstraintSystemFlags::PreferForceUnwrapToOptional;
   ConstraintSystem cs(*this, dc, csOptions);
   cs.baseCS = baseCS;
-  CleanupIllFormedExpressionRAII cleanup(Context, expr);
+  CleanupIllFormedExpressionRAII cleanup(expr);
   ExprCleaner cleanup2(expr);
 
   // Verify that a purpose was specified if a convertType was.  Note that it is
@@ -1940,7 +1918,7 @@ getTypeOfExpressionWithoutApplying(Expr *&expr, DeclContext *dc,
 
   // Construct a constraint system from this expression.
   ConstraintSystem cs(*this, dc, ConstraintSystemFlags::AllowFixes);
-  CleanupIllFormedExpressionRAII cleanup(Context, expr);
+  CleanupIllFormedExpressionRAII cleanup(expr);
 
   // Attempt to solve the constraint system.
   SmallVector<Solution, 4> viable;
@@ -2035,7 +2013,7 @@ void TypeChecker::getPossibleTypesOfExpressionWithoutApplying(
   // If the previous checking gives the expr error type,
   // clear the result and re-check.
   {
-    CleanupIllFormedExpressionRAII cleanup(Context, expr);
+    CleanupIllFormedExpressionRAII cleanup(expr);
 
     const Type originalType = expr->getType();
     if (originalType && originalType->hasError())
@@ -2058,7 +2036,7 @@ bool TypeChecker::typeCheckCompletionSequence(Expr *&expr, DeclContext *DC) {
 
   // Construct a constraint system from this expression.
   ConstraintSystem CS(*this, DC, ConstraintSystemFlags::AllowFixes);
-  CleanupIllFormedExpressionRAII cleanup(Context, expr);
+  CleanupIllFormedExpressionRAII cleanup(expr);
 
   auto *SE = cast<SequenceExpr>(expr);
   assert(SE->getNumElements() >= 3);
@@ -2135,7 +2113,7 @@ bool TypeChecker::typeCheckExpressionShallow(Expr *&expr, DeclContext *dc) {
 
   // Construct a constraint system from this expression.
   ConstraintSystem cs(*this, dc, ConstraintSystemFlags::AllowFixes);
-  CleanupIllFormedExpressionRAII cleanup(Context, expr);
+  CleanupIllFormedExpressionRAII cleanup(expr);
   if (auto generatedExpr = cs.generateConstraintsShallow(expr))
     expr = generatedExpr;
   else
@@ -3001,7 +2979,7 @@ bool TypeChecker::convertToType(Expr *&expr, Type type, DeclContext *dc,
   // TODO: need to add kind arg?
   // Construct a constraint system from this expression.
   ConstraintSystem cs(*this, dc, ConstraintSystemFlags::AllowFixes);
-  CleanupIllFormedExpressionRAII cleanup(Context, expr);
+  CleanupIllFormedExpressionRAII cleanup(expr);
 
   // If there is a type that we're expected to convert to, add the conversion
   // constraint.

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -339,6 +339,18 @@ Type TypeChecker::resolveTypeInContext(
                                  selfType);
 }
 
+static TypeResolutionOptions
+adjustOptionsForGenericArgs(TypeResolutionOptions options) {
+  options -= TypeResolutionFlags::SILType;
+  options -= TypeResolutionFlags::ImmediateFunctionInput;
+  options -= TypeResolutionFlags::FunctionInput;
+  options -= TypeResolutionFlags::TypeAliasUnderlyingType;
+  options -= TypeResolutionFlags::AllowUnavailableProtocol;
+  options -= TypeResolutionFlags::AllowIUO;
+
+  return options;
+}
+
 /// This function checks if a bound generic type is UnsafePointer<Void> or
 /// UnsafeMutablePointer<Void>. For these two type representations, we should
 /// warn users that they are deprecated and replace them with more handy
@@ -462,15 +474,35 @@ Type TypeChecker::applyGenericArguments(Type type, TypeDecl *decl,
     return ErrorType::get(Context);
   }
 
-  SmallVector<TypeLoc, 8> args;
-  for (auto tyR : genericArgs)
-    args.push_back(tyR);
+  // Resolve the types of the generic arguments.
+  assert(!options.contains(TypeResolutionFlags::ResolveStructure) &&
+         "should not touch generic arguments when resolving structure");
+  options = adjustOptionsForGenericArgs(options);
+
+  SmallVector<Type, 2> args;
+  for (auto tyR : genericArgs) {
+    // Propagate failure.
+    TypeLoc genericArg = tyR;
+    if (validateType(genericArg, dc, options, resolver,
+                     unsatisfiedDependency))
+      return ErrorType::get(Context);
+
+    auto substTy = genericArg.getType();
+
+    // Unsatisfied dependency case.
+    if (!substTy)
+      return nullptr;
+
+    args.push_back(substTy);
+  }
 
   auto result = applyUnboundGenericArguments(unboundType, genericDecl, loc,
-                                             dc, args, options,
-                                             resolver, unsatisfiedDependency);
+                                             dc, args, resolver,
+                                             unsatisfiedDependency);
   if (!result)
     return result;
+
+  // Migration hack.
   bool isMutablePointer;
   if (isPointerToVoid(dc->getASTContext(), result, isMutablePointer)) {
     if (isMutablePointer)
@@ -487,19 +519,9 @@ Type TypeChecker::applyGenericArguments(Type type, TypeDecl *decl,
 Type TypeChecker::applyUnboundGenericArguments(
     UnboundGenericType *unboundType, GenericTypeDecl *decl,
     SourceLoc loc, DeclContext *dc,
-    MutableArrayRef<TypeLoc> genericArgs,
-    TypeResolutionOptions options,
+    ArrayRef<Type> genericArgs,
     GenericTypeResolver *resolver,
     UnsatisfiedDependency *unsatisfiedDependency) {
-  assert(!options.contains(TypeResolutionFlags::ResolveStructure) &&
-         "should not touch generic arguments when resolving structure");
-  options -= TypeResolutionFlags::SILType;
-  options -= TypeResolutionFlags::ImmediateFunctionInput;
-  options -= TypeResolutionFlags::FunctionInput;
-  options -= TypeResolutionFlags::TypeAliasUnderlyingType;
-  options -= TypeResolutionFlags::AllowUnavailableProtocol;
-  options -= TypeResolutionFlags::AllowIUO;
-
   assert(genericArgs.size() == decl->getGenericParams()->size() &&
          "invalid arguments, use applyGenericArguments for diagnostic emitting");
 
@@ -527,23 +549,7 @@ Type TypeChecker::applyUnboundGenericArguments(
       // If we're working with a nominal type declaration, just construct
       // a bound generic type without checking the generic arguments.
       if (auto *nominalDecl = dyn_cast<NominalTypeDecl>(decl)) {
-        SmallVector<Type, 2> args;
-        for (auto &genericArg : genericArgs) {
-          // Propagate failure.
-          if (validateType(genericArg, dc, options, resolver,
-                           unsatisfiedDependency))
-            return ErrorType::get(Context);
-
-          auto substTy = genericArg.getType();
-
-          // Unsatisfied dependency case.
-          if (!substTy)
-            return nullptr;
-
-          args.push_back(substTy);
-        }
-
-        return BoundGenericType::get(nominalDecl, parentType, args);
+        return BoundGenericType::get(nominalDecl, parentType, genericArgs);
       }
 
       assert(!resultType->hasTypeParameter());
@@ -563,18 +569,8 @@ Type TypeChecker::applyUnboundGenericArguments(
   // Realize the types of the generic arguments and add them to the
   // substitution map.
   for (unsigned i = 0, e = genericArgs.size(); i < e; i++) {
-    auto &genericArg = genericArgs[i];
-
-    // Propagate failure.
-    if (validateType(genericArg, dc, options, resolver, unsatisfiedDependency))
-      return ErrorType::get(Context);
-
     auto origTy = genericSig->getInnermostGenericParams()[i];
-    auto substTy = genericArg.getType();
-
-    // Unsatisfied dependency case.
-    if (!substTy)
-      return nullptr;
+    auto substTy = genericArgs[i];
 
     // Enter a substitution.
     subs[origTy->getCanonicalType()->castTo<GenericTypeParamType>()] =
@@ -2734,6 +2730,8 @@ Type TypeResolver::resolveArrayType(ArrayTypeRepr *repr,
 
 Type TypeResolver::resolveDictionaryType(DictionaryTypeRepr *repr,
                                          TypeResolutionOptions options) {
+  options = adjustOptionsForGenericArgs(options);
+
   // FIXME: diagnose non-materializability of key/value type?
   Type keyTy = resolveType(repr->getKey(), withoutContext(options));
   if (!keyTy || keyTy->hasError()) return keyTy;
@@ -2749,12 +2747,10 @@ Type TypeResolver::resolveDictionaryType(DictionaryTypeRepr *repr,
     auto unboundTy = dictDecl->getDeclaredType()->castTo<UnboundGenericType>();
 
     if (!options.contains(TypeResolutionFlags::ResolveStructure)) {
-      TypeLoc args[2] = {TypeLoc(repr->getKey()), TypeLoc(repr->getValue())};
-      args[0].setType(keyTy, true);
-      args[1].setType(valueTy, true);
+      Type args[] = {keyTy, valueTy};
 
       if (!TC.applyUnboundGenericArguments(
-              unboundTy, dictDecl, repr->getStartLoc(), DC, args, options,
+              unboundTy, dictDecl, repr->getStartLoc(), DC, args,
               Resolver, UnsatisfiedDependency)) {
         return nullptr;
       }

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2522,16 +2522,15 @@ public:
 /// \brief RAII object that cleans up the given expression if not explicitly
 /// disabled.
 class CleanupIllFormedExpressionRAII {
-  ASTContext &Context;
   Expr **expr;
 
 public:
-  CleanupIllFormedExpressionRAII(ASTContext &Context, Expr *&expr)
-    : Context(Context), expr(&expr) { }
+  CleanupIllFormedExpressionRAII(Expr *&expr)
+    : expr(&expr) { }
 
   ~CleanupIllFormedExpressionRAII();
 
-  static void doIt(Expr *expr, ASTContext &Context);
+  static void doIt(Expr *expr);
 
   /// \brief Disable the cleanup of this expression; it doesn't need it.
   void disable() {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1186,7 +1186,6 @@ public:
   /// \param loc The source location for diagnostic reporting.
   /// \param dc The context where the arguments are applied.
   /// \param genericArgs The list of generic arguments to apply to the type.
-  /// \param options The type resolution context.
   /// \param resolver The generic type resolver.
   ///
   /// \returns A BoundGenericType bound to the given arguments, or null on
@@ -1196,8 +1195,7 @@ public:
   Type applyUnboundGenericArguments(UnboundGenericType *unboundType,
                                     GenericTypeDecl *decl,
                                     SourceLoc loc, DeclContext *dc,
-                                    MutableArrayRef<TypeLoc> genericArgs,
-                                    TypeResolutionOptions options,
+                                    ArrayRef<Type> genericArgs,
                                     GenericTypeResolver *resolver,
                                     UnsatisfiedDependency *unsatisfiedDependency);
 


### PR DESCRIPTION
Thanks to @rudkx's work on the constraint system type map, we can actually enforce that Exprs don't get type variables stored into them.