### PR TITLE
[IRGen] NFC: Repack TypeInfo and FixedTypeInfo bits

### DIFF
--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -35,11 +35,6 @@ namespace irgen {
 /// implementing a type that has a statically known layout.
 class FixedTypeInfo : public TypeInfo {
 private:
-  /// The storage size of this type in bytes.  This may be zero even
-  /// for well-formed and complete types, such as a trivial enum or
-  /// tuple.
-  Size StorageSize;
-  
   /// The spare bit mask for this type. SpareBits[0] is the LSB of the first
   /// byte. This may be empty if the type has no spare bits.
   SpareBitVector SpareBits;
@@ -49,22 +44,26 @@ protected:
                 const SpareBitVector &spareBits,
                 Alignment align, IsPOD_t pod, IsBitwiseTakable_t bt,
                 IsFixedSize_t alwaysFixedSize,
-                SpecialTypeInfoKind stik = STIK_Fixed)
+                SpecialTypeInfoKind stik = SpecialTypeInfoKind::Fixed)
       : TypeInfo(type, align, pod, bt, alwaysFixedSize, stik),
-        StorageSize(size), SpareBits(spareBits) {
+        SpareBits(spareBits) {
     assert(SpareBits.size() == size.getValueInBits());
     assert(isFixedSize());
+    Bits.FixedTypeInfo.Size = size.getValue();
+    assert(Bits.FixedTypeInfo.Size == size.getValue() && "truncation");
   }
 
   FixedTypeInfo(llvm::Type *type, Size size,
                 SpareBitVector &&spareBits,
                 Alignment align, IsPOD_t pod, IsBitwiseTakable_t bt,
                 IsFixedSize_t alwaysFixedSize,
-                SpecialTypeInfoKind stik = STIK_Fixed)
+                SpecialTypeInfoKind stik = SpecialTypeInfoKind::Fixed)
       : TypeInfo(type, align, pod, bt, alwaysFixedSize, stik),
-        StorageSize(size), SpareBits(std::move(spareBits)) {
+        SpareBits(std::move(spareBits)) {
     assert(SpareBits.size() == size.getValueInBits());
     assert(isFixedSize());
+    Bits.FixedTypeInfo.Size = size.getValue();
+    assert(Bits.FixedTypeInfo.Size == size.getValue() && "truncation");
   }
 
 public:
@@ -73,7 +72,7 @@ public:
 
   /// Whether this type is known to be empty.
   bool isKnownEmpty(ResilienceExpansion expansion) const {
-    return (isFixedSize(expansion) && StorageSize.isZero());
+    return (isFixedSize(expansion) && getFixedSize().isZero());
   }
 
   StackAddress allocateStack(IRGenFunction &IGF, SILType T,
@@ -99,7 +98,8 @@ public:
   llvm::Constant *getStaticStride(IRGenModule &IGM) const override;
 
   void completeFixed(Size size, Alignment alignment) {
-    StorageSize = size;
+    Bits.FixedTypeInfo.Size = size.getValue();
+    assert(Bits.FixedTypeInfo.Size == size.getValue() && "truncation");
     setStorageAlignment(alignment);
   }
 
@@ -110,7 +110,7 @@ public:
 
   /// Returns the known, fixed size required to store a value of this type.
   Size getFixedSize() const {
-    return StorageSize;
+    return Size(Bits.FixedTypeInfo.Size);
   }
 
   /// Returns the (assumed fixed) stride of the storage for this
@@ -120,7 +120,7 @@ public:
   /// The stride is at least one, even for zero-sized types, like the empty
   /// tuple.
   Size getFixedStride() const {
-    Size s = StorageSize.roundUpToAlignment(getFixedAlignment());
+    Size s = getFixedSize().roundUpToAlignment(getFixedAlignment());
     if (s.isZero())
       s = Size(1);
     return s;

--- a/lib/IRGen/LoadableTypeInfo.h
+++ b/lib/IRGen/LoadableTypeInfo.h
@@ -57,7 +57,7 @@ protected:
                    const SpareBitVector &spareBits,
                    Alignment align,
                    IsPOD_t pod, IsFixedSize_t alwaysFixedSize,
-                   SpecialTypeInfoKind stik = STIK_Loadable)
+                   SpecialTypeInfoKind stik = SpecialTypeInfoKind::Loadable)
       : FixedTypeInfo(type, size, spareBits, align, pod,
                       // All currently implemented loadable types are bitwise-takable.
                       IsBitwiseTakable, alwaysFixedSize, stik) {
@@ -68,7 +68,7 @@ protected:
                    SpareBitVector &&spareBits,
                    Alignment align,
                    IsPOD_t pod, IsFixedSize_t alwaysFixedSize,
-                   SpecialTypeInfoKind stik = STIK_Loadable)
+                   SpecialTypeInfoKind stik = SpecialTypeInfoKind::Loadable)
       : FixedTypeInfo(type, size, std::move(spareBits), align, pod,
                       // All currently implemented loadable types are bitwise-takable.
                       IsBitwiseTakable, alwaysFixedSize, stik) {

--- a/lib/IRGen/NonFixedTypeInfo.h
+++ b/lib/IRGen/NonFixedTypeInfo.h
@@ -53,7 +53,7 @@ protected:
 
   WitnessSizedTypeInfo(llvm::Type *type, Alignment align, IsPOD_t pod,
                        IsBitwiseTakable_t bt)
-    : super(type, align, pod, bt, IsNotFixedSize, TypeInfo::STIK_None) {}
+    : super(type, align, pod, bt, IsNotFixedSize, SpecialTypeInfoKind::None) {}
 
 private:
   /// Bit-cast the given pointer to the right type and assume it as an

--- a/lib/IRGen/ReferenceTypeInfo.h
+++ b/lib/IRGen/ReferenceTypeInfo.h
@@ -35,7 +35,7 @@ protected:
   ReferenceTypeInfo(llvm::Type *type, Size size, SpareBitVector spareBits,
                     Alignment align, IsPOD_t pod = IsNotPOD)
     : LoadableTypeInfo(type, size, spareBits, align, pod,
-                       IsFixedSize, STIK_Reference)
+                       IsFixedSize, SpecialTypeInfoKind::Reference)
   {}
 
 public:
@@ -102,7 +102,7 @@ public:
 
   static bool classof(const ReferenceTypeInfo *type) { return true; }
   static bool classof(const TypeInfo *type) {
-    return type->getSpecialTypeInfoKind() == STIK_Reference;
+    return type->getSpecialTypeInfoKind() == SpecialTypeInfoKind::Reference;
   }
 };
 

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -66,6 +66,24 @@ enum class FixedPacking {
   Dynamic
 };
 
+enum class SpecialTypeInfoKind : uint8_t {
+  Unimplemented,
+
+  None,
+
+  /// Everything after this is statically fixed-size.
+  Fixed,
+  Weak,
+
+  /// Everything after this is loadable.
+  Loadable,
+  Reference,
+
+  Last_Kind = Reference
+};
+enum : unsigned { NumSpecialTypeInfoKindBits =
+  countBitsUsed(static_cast<unsigned>(SpecialTypeInfoKind::Last_Kind)) };
+
 /// Information about the IR representation and generation of the
 /// given type.
 class TypeInfo {
@@ -73,39 +91,93 @@ class TypeInfo {
   TypeInfo &operator=(const TypeInfo &) = delete;
 
   friend class TypeConverter;
-  mutable const TypeInfo *NextConverted;
+
+  enum : unsigned { InvalidAlignmentShift = 63 };
 
 protected:
-  enum SpecialTypeInfoKind {
-    STIK_Unimplemented,
-    
-    STIK_None,
+  union {
+    uint64_t OpaqueBits;
 
-    /// Everything after this is statically fixed-size.
-    STIK_Fixed,
-    STIK_Weak,
+    SWIFT_INLINE_BITFIELD_BASE(TypeInfo,
+                               bitmax(NumSpecialTypeInfoKindBits,8)+6+1+1+3+1,
+      /// The kind of supplemental API this type has, if any.
+      Kind : bitmax(NumSpecialTypeInfoKindBits,8),
 
-    /// Everything after this is loadable.
-    STIK_Loadable,
-    STIK_Reference,
-  };
+      /// The storage alignment of this type in log2 bytes.
+      AlignmentShift : 6,
+
+      /// Whether this type is known to be POD.
+      POD : 1,
+
+      /// Whether this type is known to be bitwise-takable.
+      BitwiseTakable : 1,
+
+      /// An arbitrary discriminator for the subclass.  This is useful for e.g.
+      /// distinguishing between different TypeInfos that all implement the same
+      /// kind of type.
+      /// FIXME -- Create TypeInfoNodes.def and get rid of this field.
+      SubclassKind : 3,
+
+      /// Whether this type can be assumed to have a fixed size from all
+      /// resilience domains.
+      AlwaysFixedSize : 1
+    );
+
+    /// FixedTypeInfo will use the remaining bits for the size.
+    ///
+    /// NOTE: Until one can define statically sized inline arrays in the
+    /// language, defining an extremely large object is quite impractical.
+    /// For now: "4 GiB should be more than good enough."
+    SWIFT_INLINE_BITFIELD_FULL(FixedTypeInfo, TypeInfo, 32,
+      : NumPadBits,
+
+      /// The storage size of this type in bytes.  This may be zero even
+      /// for well-formed and complete types, such as a trivial enum or
+      /// tuple.
+      Size : 32
+    );
+  } Bits;
+  enum { InvalidSubclassKind = 0x7 };
 
   TypeInfo(llvm::Type *Type, Alignment A, IsPOD_t pod,
            IsBitwiseTakable_t bitwiseTakable,
            IsFixedSize_t alwaysFixedSize,
-           SpecialTypeInfoKind stik)
-    : NextConverted(0), StorageType(Type), nativeReturnSchema(nullptr),
-      nativeParameterSchema(nullptr), StorageAlignment(A),
-      POD(pod), BitwiseTakable(bitwiseTakable),
-      AlwaysFixedSize(alwaysFixedSize), STIK(stik),
-      SubclassKind(InvalidSubclassKind) {
-    assert(STIK >= STIK_Fixed || !AlwaysFixedSize);
+           SpecialTypeInfoKind stik) : StorageType(Type) {
+    assert(stik >= SpecialTypeInfoKind::Fixed || !alwaysFixedSize);
+    Bits.OpaqueBits = 0;
+    Bits.TypeInfo.Kind = unsigned(stik);
+    Bits.TypeInfo.AlignmentShift = A.isZero() ? InvalidAlignmentShift
+                                              : llvm::Log2_32(A.getValue());
+    Bits.TypeInfo.POD = pod;
+    Bits.TypeInfo.BitwiseTakable = bitwiseTakable;
+    Bits.TypeInfo.SubclassKind = InvalidSubclassKind;
+    Bits.TypeInfo.AlwaysFixedSize = alwaysFixedSize;
   }
 
   /// Change the minimum alignment of a stored value of this type.
   void setStorageAlignment(Alignment alignment) {
-    StorageAlignment = alignment;
+    auto Prev = Bits.TypeInfo.AlignmentShift;
+    auto Next = llvm::Log2_32(alignment.getValue());
+    assert(Next >= Prev && "Alignment can only increase");
+    (void)Prev;
+    Bits.TypeInfo.AlignmentShift = Next;
   }
+
+  void setSubclassKind(unsigned kind) {
+    assert(kind != InvalidSubclassKind);
+    Bits.TypeInfo.SubclassKind = kind;
+    assert(Bits.TypeInfo.SubclassKind == kind && "kind was truncated?");
+  }
+
+private:
+  mutable const TypeInfo *NextConverted = nullptr;
+
+  /// The LLVM representation of a stored value of this type.  For
+  /// non-fixed types, this is really useful only for forming pointers to it.
+  llvm::Type *StorageType;
+
+  mutable NativeConventionSchema *nativeReturnSchema = nullptr;
+  mutable NativeConventionSchema *nativeParameterSchema = nullptr;
 
 public:
   virtual ~TypeInfo();
@@ -116,59 +188,24 @@ public:
     return static_cast<const T &>(*this);
   }
 
-private:
-  /// The LLVM representation of a stored value of this type.  For
-  /// non-fixed types, this is really useful only for forming pointers to it.
-  llvm::Type *StorageType;
-
-  mutable NativeConventionSchema *nativeReturnSchema;
-  mutable NativeConventionSchema *nativeParameterSchema;
-
-  /// The storage alignment of this type in bytes.  This is never zero
-  /// for a completely-converted type.
-  Alignment StorageAlignment;
-
-  /// Whether this type is known to be POD.
-  unsigned POD : 1;
-  
-  /// Whether this type is known to be bitwise-takable.
-  unsigned BitwiseTakable : 1;
-
-  /// Whether this type can be assumed to have a fixed size from all
-  /// resilience domains.
-  unsigned AlwaysFixedSize : 1;
-
-  /// The kind of supplemental API this type has, if any.
-  unsigned STIK : 3;
-
-  /// An arbitrary discriminator for the subclass.  This is useful for
-  /// e.g. distinguishing between different TypeInfos that all
-  /// implement the same kind of type.
-  unsigned SubclassKind : 3;
-  enum { InvalidSubclassKind = 0x7 };
-
-protected:
-  void setSubclassKind(unsigned kind) {
-    assert(kind != InvalidSubclassKind);
-    SubclassKind = kind;
-    assert(SubclassKind == kind && "kind was truncated?");
-  }
-
-public:
   /// Whether this type info has been completely converted.
-  bool isComplete() const { return !StorageAlignment.isZero(); }
+  bool isComplete() const {
+    return Bits.TypeInfo.AlignmentShift != InvalidAlignmentShift;
+  }
 
   /// Whether this type is known to be empty.
   bool isKnownEmpty(ResilienceExpansion expansion) const;
 
   /// Whether this type is known to be POD, i.e. to not require any
   /// particular action on copy or destroy.
-  IsPOD_t isPOD(ResilienceExpansion expansion) const { return IsPOD_t(POD); }
+  IsPOD_t isPOD(ResilienceExpansion expansion) const {
+    return IsPOD_t(Bits.TypeInfo.POD);
+  }
   
   /// Whether this type is known to be bitwise-takable, i.e. "initializeWithTake"
   /// is equivalent to a memcpy.
   IsBitwiseTakable_t isBitwiseTakable(ResilienceExpansion expansion) const {
-    return IsBitwiseTakable_t(BitwiseTakable);
+    return IsBitwiseTakable_t(Bits.TypeInfo.BitwiseTakable);
   }
   
   /// Returns the type of special interface followed by this TypeInfo.
@@ -178,7 +215,7 @@ public:
   /// properties on their parameter types, but then the program
   /// can rely on them.
   SpecialTypeInfoKind getSpecialTypeInfoKind() const {
-    return SpecialTypeInfoKind(STIK);
+    return SpecialTypeInfoKind(Bits.TypeInfo.Kind);
   }
 
   /// Returns whatever arbitrary data has been stash in the subclass
@@ -186,16 +223,16 @@ public:
   /// distinguishing between TypeInfos, which is useful when multiple
   /// TypeInfo subclasses are used to implement the same kind of type.
   unsigned getSubclassKind() const {
-    assert(SubclassKind != InvalidSubclassKind &&
+    assert(Bits.TypeInfo.SubclassKind != InvalidSubclassKind &&
            "subclass kind has not been initialized!");
-    return SubclassKind;
+    return Bits.TypeInfo.SubclassKind;
   }
 
   /// Whether this type is known to be fixed-size in the local
   /// resilience domain.  If true, this TypeInfo can be cast to
   /// FixedTypeInfo.
   IsFixedSize_t isFixedSize() const {
-    return IsFixedSize_t(STIK >= STIK_Fixed);
+    return IsFixedSize_t(getSpecialTypeInfoKind() >= SpecialTypeInfoKind::Fixed);
   }
 
   /// Whether this type is known to be fixed-size in the given
@@ -207,9 +244,9 @@ public:
     case ResilienceExpansion::Minimal:
       // We can't be universally fixed size if we're not locally
       // fixed size.
-      assert((isFixedSize() || AlwaysFixedSize == IsNotFixedSize) &&
+      assert((isFixedSize() || Bits.TypeInfo.AlwaysFixedSize == IsNotFixedSize) &&
              "IsFixedSize vs IsAlwaysFixedSize mismatch");
-      return IsFixedSize_t(AlwaysFixedSize);
+      return IsFixedSize_t(Bits.TypeInfo.AlwaysFixedSize);
     }
 
     llvm_unreachable("Not a valid ResilienceExpansion.");
@@ -219,13 +256,15 @@ public:
   /// resilience domain.  If true, this TypeInfo can be cast to
   /// LoadableTypeInfo.
   IsLoadable_t isLoadable() const {
-    return IsLoadable_t(STIK >= STIK_Loadable);
+    return IsLoadable_t(getSpecialTypeInfoKind() >= SpecialTypeInfoKind::Loadable);
   }
 
   llvm::Type *getStorageType() const { return StorageType; }
 
   Alignment getBestKnownAlignment() const {
-    return StorageAlignment;
+    auto Shift = Bits.TypeInfo.AlignmentShift;
+    assert(Shift != InvalidAlignmentShift);
+    return Alignment(1ull << Shift);
   }
 
   /// Given a generic pointer to this type, produce an Address for it.

--- a/lib/IRGen/WeakTypeInfo.h
+++ b/lib/IRGen/WeakTypeInfo.h
@@ -30,12 +30,14 @@ protected:
   WeakTypeInfo(llvm::Type *type, Size size, Alignment align,
                const SpareBitVector &spareBits)
     : FixedTypeInfo(type, size, spareBits, align, IsNotPOD,
-                    IsNotBitwiseTakable, IsFixedSize, STIK_Weak) {}
+                    IsNotBitwiseTakable, IsFixedSize,
+                    SpecialTypeInfoKind::Weak) {}
 
   WeakTypeInfo(llvm::Type *type, Size size, Alignment align,
                SpareBitVector &&spareBits)
     : FixedTypeInfo(type, size, std::move(spareBits), align, IsNotPOD,
-                    IsNotBitwiseTakable, IsFixedSize, STIK_Weak) {}
+                    IsNotBitwiseTakable, IsFixedSize,
+                    SpecialTypeInfoKind::Weak) {}
 
 public:
   virtual void weakLoadStrong(IRGenFunction &IGF, Address addr,
@@ -49,7 +51,7 @@ public:
 
   static bool classof(const WeakTypeInfo *type) { return true; }
   static bool classof(const TypeInfo *type) {
-    return type->getSpecialTypeInfoKind() == STIK_Weak;
+    return type->getSpecialTypeInfoKind() == SpecialTypeInfoKind::Weak;
   }
 };
 


### PR DESCRIPTION
This saves eight bytes per FixedTypeInfo node.

@rjmccall and @slavapestov – Can you please confirm that it is difficult to impossible to statically define extremely large objects in Swift? I suppose that one could define a multi-gigabyte sized object in C and then try to use it in Swift, but that feels impractical and unrealistic for various reasons. In any case, I can change this pull request to use all of the available bits (~48) if anybody is feeling paranoid.