### PR TITLE
[Misc] NFC: Fix random build warnings

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -552,7 +552,6 @@ namespace {
 
     EquivalenceClassVizNode node;
     BaseIterator base;
-    BaseIterator baseEnd;
 
   public:
     using difference_type = ptrdiff_t;
@@ -563,7 +562,7 @@ namespace {
 
     EquivalenceClassVizIterator(EquivalenceClassVizNode node,
                                 BaseIterator base, BaseIterator baseEnd)
-        : node(node), base(base), baseEnd(baseEnd) {
+        : node(node), base(base) {
     }
 
     BaseIterator &getBase() { return base; }

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -133,7 +133,7 @@ OutputFilesComputer::OutputFilesComputer(
     const FrontendOptions::ActionType requestedAction,
     const llvm::opt::Arg *moduleNameArg, const StringRef suffix,
     const bool hasTextualOutput)
-    : Args(args), Diags(diags), InputsAndOutputs(inputsAndOutputs),
+    : Diags(diags), InputsAndOutputs(inputsAndOutputs),
       OutputFileArguments(outputFileArguments),
       OutputDirectoryArgument(outputDirectoryArgument), FirstInput(firstInput),
       RequestedAction(requestedAction), ModuleNameArg(moduleNameArg),

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.cpp
@@ -118,7 +118,7 @@ OutputFilesComputer::create(const llvm::opt::ArgList &args,
   }
 
   return OutputFilesComputer(
-      args, diags, inputsAndOutputs, std::move(outputFileArguments),
+      diags, inputsAndOutputs, std::move(outputFileArguments),
       outputDirectoryArgument, firstInput, requestedAction,
       args.getLastArg(options::OPT_module_name),
       FrontendOptions::suffixForPrincipalOutputFileForAction(requestedAction),
@@ -126,7 +126,7 @@ OutputFilesComputer::create(const llvm::opt::ArgList &args,
 }
 
 OutputFilesComputer::OutputFilesComputer(
-    const llvm::opt::ArgList &args, DiagnosticEngine &diags,
+    DiagnosticEngine &diags,
     const FrontendInputsAndOutputs &inputsAndOutputs,
     std::vector<std::string> outputFileArguments,
     const StringRef outputDirectoryArgument, const StringRef firstInput,

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.h
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.h
@@ -53,7 +53,6 @@ public:
 };
 
 class OutputFilesComputer {
-  const llvm::opt::ArgList &Args;
   DiagnosticEngine &Diags;
   const FrontendInputsAndOutputs &InputsAndOutputs;
   const std::vector<std::string> OutputFileArguments;

--- a/lib/Frontend/ArgsToFrontendOutputsConverter.h
+++ b/lib/Frontend/ArgsToFrontendOutputsConverter.h
@@ -63,7 +63,7 @@ class OutputFilesComputer {
   const StringRef Suffix;
   const bool HasTextualOutput;
 
-  OutputFilesComputer(const llvm::opt::ArgList &args, DiagnosticEngine &diags,
+  OutputFilesComputer(DiagnosticEngine &diags,
                       const FrontendInputsAndOutputs &inputsAndOutputs,
                       std::vector<std::string> outputFileArguments,
                       StringRef outputDirectoryArgument, StringRef firstInput,

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -128,21 +128,23 @@ static void *allocateDebugVarCarryingInst(SILModule &M,
 TailAllocatedDebugVariable::TailAllocatedDebugVariable(
     Optional<SILDebugVariable> Var, char *buf) {
   if (!Var) {
-    RawValue = 0;
+    Bits.RawValue = 0;
     return;
   }
 
-  Data.HasValue = true;
-  Data.Constant = Var->Constant;
-  Data.ArgNo = Var->ArgNo;
-  Data.NameLength = Var->Name.size();
-  assert(Data.ArgNo == Var->ArgNo && "Truncation");
-  assert(Data.NameLength == Var->Name.size() && "Truncation");
-  memcpy(buf, Var->Name.data(), Data.NameLength);
+  Bits.Data.HasValue = true;
+  Bits.Data.Constant = Var->Constant;
+  Bits.Data.ArgNo = Var->ArgNo;
+  Bits.Data.NameLength = Var->Name.size();
+  assert(Bits.Data.ArgNo == Var->ArgNo && "Truncation");
+  assert(Bits.Data.NameLength == Var->Name.size() && "Truncation");
+  memcpy(buf, Var->Name.data(), Bits.Data.NameLength);
 }
 
 StringRef TailAllocatedDebugVariable::getName(const char *buf) const {
-  return Data.NameLength ? StringRef(buf, Data.NameLength) : StringRef();
+  if (Bits.Data.NameLength)
+    return StringRef(buf, Bits.Data.NameLength);
+  return StringRef();
 }
 
 AllocStackInst::AllocStackInst(SILDebugLocation Loc, SILType elementType,

--- a/lib/SILOptimizer/Transforms/Outliner.cpp
+++ b/lib/SILOptimizer/Transforms/Outliner.cpp
@@ -218,7 +218,7 @@ class BridgedProperty : public OutlinePattern {
   SingleValueInstruction *FirstInst; // A load or class_method
   SILBasicBlock *StartBB;
   SwitchInfo switchInfo;
-  ObjCMethodInst *ObjCMethod;;
+  ObjCMethodInst *ObjCMethod;
   StrongReleaseInst *Release;
   ApplyInst *PropApply;
 

--- a/stdlib/public/runtime/SwiftDtoa.cpp
+++ b/stdlib/public/runtime/SwiftDtoa.cpp
@@ -99,6 +99,7 @@
 // ----------------------------------------------------------------------------
 
 #include <float.h>
+#include <inttypes.h>
 #include <math.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -1068,7 +1069,7 @@ size_t swift_format_double(double d, char *dest, size_t length)
             uint64_t payload = raw & ((1ull << (significandBitCount - 2)) - 1);
             char buff[32];
             if (payload != 0) {
-                snprintf(buff, sizeof(buff), "%s%snan(0x%llx)",
+                snprintf(buff, sizeof(buff), "%s%snan(0x%" PRIx64 ")",
                          sign, signaling, payload);
             } else {
                 snprintf(buff, sizeof(buff), "%s%snan",
@@ -1124,7 +1125,7 @@ size_t swift_format_float80(long double d, char *dest, size_t length)
             uint64_t payload = significandBitPattern & (((uint64_t)1 << 61) - 1);
             char buff[32];
             if (payload != 0) {
-                snprintf(buff, sizeof(buff), "%s%snan(0x%llx)",
+                snprintf(buff, sizeof(buff), "%s%snan(0x%" PRIx64 ")",
                          sign, signaling, payload);
             } else {
                 snprintf(buff, sizeof(buff), "%s%snan",

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -866,7 +866,6 @@ public:
   }
 
   bool isConformingTo(KnownProtocolKind Kind) const {
-    StringRef Usr;
     switch (Kind) {
 #define KNOWN_PROTOCOL(NAME)                                                  \
       case KnownProtocolKind::NAME:                                           \

--- a/tools/swift-reflection-test/swift-reflection-test.c
+++ b/tools/swift-reflection-test/swift-reflection-test.c
@@ -62,7 +62,7 @@ static void errnoAndExit(const char *message) {
 }
 
 static swift_reflection_section_t
-makeLocalSection(void *Buffer, RemoteSection Section,
+makeLocalSection(const void *Buffer, RemoteSection Section,
                  RemoteReflectionInfo Info) {
   if (Section.Size == 0) {
     swift_reflection_section_t LS = {NULL, NULL};
@@ -174,7 +174,8 @@ void PipeMemoryReader_collectBytesFromPipe(const PipeMemoryReader *Reader,
     else if (bytesRead == 0)
       errorAndExit("collectBytesFromPipe: Unexpected end of file");
     Size -= bytesRead;
-    Dest += bytesRead;
+    // Arithmetic on a void pointer is a GNU extension.
+    Dest = (char*)(Dest) + bytesRead;
   }
 }
 
@@ -204,8 +205,7 @@ static void PipeMemoryReader_freeBytes(void *reader_context, const void *bytes,
 
 static
 const void *PipeMemoryReader_readBytes(void *Context, swift_addr_t Address,
-                                       uint64_t Size,
-                                       void **outFreeContext) {
+                                       uint64_t Size, void **outFreeContext) {
   const PipeMemoryReader *Reader = (const PipeMemoryReader *)Context;
   uintptr_t TargetAddress = Address;
   size_t TargetSize = (size_t)Size;
@@ -342,13 +342,12 @@ PipeMemoryReader_receiveReflectionInfo(SwiftReflectionContextRef RC,
   for (size_t i = 0; i < NumReflectionInfos; ++i) {
     RemoteReflectionInfo RemoteInfo = RemoteInfos[i];
 
-    void *Buffer = malloc(RemoteInfo.TotalSize);
-
-    int Success = PipeMemoryReader_readBytes((void *)Reader,
-                                             RemoteInfo.StartAddress,
-                                             Buffer,
-                                             RemoteInfo.TotalSize);
-    if (!Success)
+    void *outFreeContext = NULL;
+    const void *Buffer = PipeMemoryReader_readBytes((void *)Reader,
+                                                    RemoteInfo.StartAddress,
+                                                    RemoteInfo.TotalSize,
+                                                    &outFreeContext);
+    if (!Buffer)
       errorAndExit("Couldn't read reflection information");
 
     swift_reflection_info_t Info = {

--- a/tools/swift-syntax-test/swift-syntax-test.cpp
+++ b/tools/swift-syntax-test/swift-syntax-test.cpp
@@ -272,7 +272,6 @@ int doDeserializeRawTree(const char *MainExecutablePath,
   auto os = llvm::make_unique<llvm::raw_fd_ostream>(
               OutputFileName, errorCode, llvm::sys::fs::F_None);
   swift::json::SyntaxDeserializer deserializer(llvm::MemoryBufferRef(*(Buffer.get())));
-  swift::SyntaxPrintOptions opt;
   deserializer.getSourceFileSyntax()->print(*os);
   return EXIT_SUCCESS;
 }
@@ -301,7 +300,6 @@ int dumpEOFSourceLoc(const char *MainExecutablePath,
   CompilerInstance Instance;
   SourceFile *SF = getSourceFile(Instance, InputFileName, MainExecutablePath);
   auto BufferId = *SF->getBufferID();
-  SyntaxPrintOptions Opts;
   auto Root = SF->getSyntaxRoot();
   auto AbPos = Root.getEOFToken().getAbsolutePosition();
 

--- a/unittests/Basic/BlotMapVectorTest.cpp
+++ b/unittests/Basic/BlotMapVectorTest.cpp
@@ -515,7 +515,14 @@ TYPED_TEST(BlotMapVectorTest, AssignmentTest) {
   EXPECT_EQ(this->getValue(), copyMap[this->getKey()]);
 
   // test self-assignment.
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-assign-overloaded"
   copyMap = copyMap;
+#pragma clang diagnostic pop
+#else
+  copyMap = copyMap;
+#endif
   EXPECT_EQ(1u, copyMap.size());
   EXPECT_EQ(this->getValue(), copyMap[this->getKey()]);
   this->NumExpectedLiveTesters = 2;

--- a/unittests/runtime/Enum.cpp
+++ b/unittests/runtime/Enum.cpp
@@ -57,7 +57,7 @@ OpaqueValue *asOpaque(void *v) {
   return reinterpret_cast<OpaqueValue*>(v);
 }
 
-unsigned test_getEnumCaseSinglePayload(std::initializer_list<uint8_t> repr,
+int test_getEnumCaseSinglePayload(std::initializer_list<uint8_t> repr,
                                        const FullOpaqueMetadata &metadata,
                                        unsigned numEmptyCases) {
   return swift_getEnumCaseSinglePayload(asOpaque(repr.begin()),

--- a/unittests/runtime/LongTests/LongRefcounting.cpp
+++ b/unittests/runtime/LongTests/LongRefcounting.cpp
@@ -25,8 +25,8 @@
 # define EXPECT_UNALLOCATED(p)  EXPECT_EQ(0u, malloc_size(p))
 #else
 // FIXME: heap assertion for other platforms?
-# define EXPECT_ALLOCATED(p) do {} while (0)
-# define EXPECT_UNALLOCATED(p) do {} while (0)
+# define EXPECT_ALLOCATED(p) (void)(p)
+# define EXPECT_UNALLOCATED(p) (void)(p)
 #endif
 
 using namespace swift;

--- a/unittests/runtime/Metadata.cpp
+++ b/unittests/runtime/Metadata.cpp
@@ -297,12 +297,12 @@ ProtocolDescriptor ProtocolNoWitnessTable{
 };
 
 TEST(MetadataTest, getExistentialMetadata) {
-  const ProtocolDescriptor *protoList1[] = {};
+  const ProtocolDescriptor *const proto = nullptr;
   RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
     [&]() -> const ExistentialTypeMetadata * {
       auto any = swift_getExistentialTypeMetadata(ProtocolClassConstraint::Any,
                                                   /*superclass=*/nullptr,
-                                                  0, protoList1);
+                                                  0, &proto);
       EXPECT_EQ(MetadataKind::Existential, any->getKind());
       EXPECT_EQ(0U, any->Flags.getNumWitnessTables());
       EXPECT_EQ(ProtocolClassConstraint::Any, any->Flags.getClassConstraint());

--- a/unittests/runtime/Metadata.cpp
+++ b/unittests/runtime/Metadata.cpp
@@ -297,12 +297,11 @@ ProtocolDescriptor ProtocolNoWitnessTable{
 };
 
 TEST(MetadataTest, getExistentialMetadata) {
-  const ProtocolDescriptor *const proto = nullptr;
   RaceTest_ExpectEqual<const ExistentialTypeMetadata *>(
     [&]() -> const ExistentialTypeMetadata * {
       auto any = swift_getExistentialTypeMetadata(ProtocolClassConstraint::Any,
                                                   /*superclass=*/nullptr,
-                                                  0, &proto);
+                                                  0, nullptr);
       EXPECT_EQ(MetadataKind::Existential, any->getKind());
       EXPECT_EQ(0U, any->Flags.getNumWitnessTables());
       EXPECT_EQ(ProtocolClassConstraint::Any, any->Flags.getClassConstraint());


### PR DESCRIPTION
Unused variables/methods, language extensions, extra semicolons, intentional self assignment, platform specific quirks, etc. Also downright horror shows. For example, I'm not sure that anybody verified that swift-reflection-test.c actually works.