### PR TITLE
[WIP][String] Use interior C string pointer if available

### DIFF
--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -262,6 +262,21 @@ internal func _memcpy(
     /*volatile:*/ false._value)
 }
 
+@inlinable
+internal func _memset(
+  dest destination: UnsafeMutableRawPointer,
+  value: UInt8,
+  size: UInt
+) {
+  let dest = destination._rawValue
+  let value = value._value
+  let size = UInt64(size)._value
+  Builtin.int_memset_RawPointer_Int64(
+    dest, value, size,
+    /*alignment:*/ Int32()._value,
+    /*volatile:*/ false._value)
+}
+
 /// Copy `count` bytes of memory from `src` into `dest`.
 ///
 /// The memory regions `source..<source + count` and
@@ -280,3 +295,5 @@ internal func _memmove(
     /*alignment:*/ Int32()._value,
     /*volatile:*/ false._value)
 }
+
+

--- a/stdlib/public/core/LifetimeManager.swift
+++ b/stdlib/public/core/LifetimeManager.swift
@@ -63,6 +63,13 @@ extension String {
   public func withCString<Result>(
     _ body: (UnsafePointer<Int8>) throws -> Result
   ) rethrows -> Result {
+    if self._guts._isContiguousNulTerminatedUTF8 {
+      defer { _fixLifetime(self) }
+      return try body(
+        UnsafeRawPointer(
+          self._guts._unmanagedASCIIView.start
+        ).assumingMemoryBound(to: Int8.self))
+    }
     return try self.utf8CString.withUnsafeBufferPointer {
       try body($0.baseAddress!)
     }

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -1414,6 +1414,12 @@ extension _StringGuts {
     return _object.isContiguousASCII
   }
 
+  @inlinable
+  var _isContiguousNulTerminatedUTF8: Bool {
+    return self.isASCII && self._isNative &&
+      _object.nativeStorage(of: UInt8.self)._isNulTerminated
+  }
+
   @available(*, deprecated)
   public // SPI(Foundation)
   var _isContiguousUTF16: Bool {


### PR DESCRIPTION
<!-- What's in this pull request? -->

This is work in progress to guarantee more frequent nul-termination for String's storage, and take advantage of it when available for `withCString`.

Still TODO is handling literals.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->