### PR TITLE
[update-checkout] Require --scheme for --match-timestamp.

### DIFF
--- a/utils/update_checkout.py
+++ b/utils/update_checkout.py
@@ -102,9 +102,6 @@ def update_single_repository(args):
                     checkout_target = find_rev_by_timestamp(timestamp,
                                                             repo_name,
                                                             checkout_target)
-            elif timestamp:
-                checkout_target = find_rev_by_timestamp(timestamp, repo_name,
-                                                        "HEAD")
 
             # The clean option restores a repository to pristine condition.
             if should_clean:
@@ -435,10 +432,17 @@ By default, updates your checkouts of Swift, SourceKit, LLDB, and SwiftPM.""")
         dest="n_processes")
     args = parser.parse_args()
 
-    if args.reset_to_remote and not args.scheme:
-        print("update-checkout usage error: --reset-to-remote must specify "
-              "--scheme=foo")
-        sys.exit(1)
+    if not args.scheme:
+        if args.reset_to_remote:
+            print("update-checkout usage error: --reset-to-remote must "
+                  "specify --scheme=foo")
+            sys.exit(1)
+        if args.match_timestamp:
+            # without a scheme, we won't be able match timestamps forward in
+            # time, which is an annoying footgun for bisection etc.
+            print("update-checkout usage error: --match-timestamp must "
+                  "specify --scheme=foo")
+            sys.exit(1)
 
     clone = args.clone
     clone_with_ssh = args.clone_with_ssh


### PR DESCRIPTION
Without a --scheme, --match-timestamp would only look back in time from the HEAD
of each sibling repository which means those repositories will never go forward
in time when the swift repo does. This is probably not what one wants when, for
instance, bisecting and generally trying to do historical builds. Finding the
--scheme behaviour in the first place is slightly non-obvious, passing that flag
is easy to forget, and the non---scheme behaviour is probably not particularly
useful, so let's just force --scheme to be passed.

Fixes https://bugs.swift.org/browse/SR-7468 and rdar://problem/39520842
