### PR TITLE
[AST] Flatten internal representation of SubstitutionMap. 

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -223,6 +223,17 @@ public:
       });
   }
 
+  /// Compute the number of conformance requirements in this signature.
+  unsigned getNumConformanceRequirements() const {
+    unsigned result = 0;
+    for (const auto &req : getRequirements()) {
+      if (req.getKind() == RequirementKind::Conformance)
+        ++result;
+    }
+
+    return result;
+  }
+
   /// Return the size of a SubstitutionList built from this signature.
   ///
   /// Don't add new calls of this -- the representation of SubstitutionList

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -12,30 +12,19 @@
 //
 // This file defines the SubstitutionMap class.
 //
-// This is a data structure type describing the mapping of abstract types to
-// replacement types, together with associated conformances to use for deriving
-// nested types.
-//
-// Depending on how the SubstitutionMap is constructed, the abstract types are
-// either archetypes or interface types. Care must be exercised to only look up
-// one or the other.
-//
-// SubstitutionMaps are constructed by calling the getSubstitutionMap() method
-// on a GenericSignature or GenericEnvironment.
-//
 //===----------------------------------------------------------------------===//
 
 #ifndef SWIFT_AST_SUBSTITUTION_MAP_H
 #define SWIFT_AST_SUBSTITUTION_MAP_H
 
+#include "swift/AST/GenericSignature.h"
 #include "swift/AST/ProtocolConformanceRef.h"
 #include "swift/AST/SubstitutionList.h"
 #include "swift/AST/Type.h"
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Optional.h"
-#include "llvm/ADT/SmallPtrSet.h"
-#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/TrailingObjects.h"
+#include <memory>
 
 namespace llvm {
   class FoldingSetNodeID;
@@ -43,7 +32,6 @@ namespace llvm {
 
 namespace swift {
 
-class GenericSignature;
 class GenericEnvironment;
 class SubstitutableType;
 typedef CanTypeWrapper<GenericTypeParamType> CanGenericTypeParamType;
@@ -56,41 +44,130 @@ enum class CombineSubstitutionMaps {
   AtIndex
 };
 
+/// SubstitutionMap is a data structure type that describes the mapping of
+/// abstract types to replacement types, together with associated conformances
+/// to use for deriving nested types and conformances.
+///
+/// Depending on how the SubstitutionMap is constructed, the abstract types are
+/// either archetypes or interface types. Care must be exercised to only look
+/// up one or the other.
+///
+/// SubstitutionMaps are constructed by calling the getSubstitutionMap() method
+/// on a GenericSignature or (equivalently) by calling one of the static
+/// \c SubstitutionMap::get() methods.
 class SubstitutionMap {
-  /// The generic signature for which we are performing substitutions.
-  GenericSignature *genericSig;
+  /// Stored data for a substitution map, which uses tail allocation for the
+  /// replacement types and conformances.
+  class Storage final
+    : llvm::TrailingObjects<Storage, Type, ProtocolConformanceRef>
+  {
+    friend TrailingObjects;
 
-  /// The replacement types for the generic type parameters.
-  std::unique_ptr<Type[]> replacementTypes;
+    /// The generic signature for which we are performing substitutions.
+    GenericSignature * const genericSig;
 
-  // FIXME: Switch to a more efficient representation that corresponds to
-  // the conformance requirements in the GenericSignature.
-  llvm::DenseMap<CanType, SmallVector<ProtocolConformanceRef, 1>>
-    conformanceMap;
+    /// The number of conformance requirements, cached to avoid constantly
+    /// recomputing it on conformance-buffer access.
+    const unsigned numConformanceRequirements;
+
+    Storage() = delete;
+
+    Storage(GenericSignature *genericSig,
+            ArrayRef<Type> replacementTypes,
+            ArrayRef<ProtocolConformanceRef> conformances);
+
+  private:
+    unsigned getNumReplacementTypes() const {
+      return genericSig->getGenericParams().size();
+    }
+
+    size_t numTrailingObjects(OverloadToken<Type>) const {
+      return getNumReplacementTypes();
+    }
+
+    size_t numTrailingObjects(OverloadToken<ProtocolConformanceRef>) const {
+      return numConformanceRequirements;
+    }
+
+  public:
+    /// Form storage for the given generic signature and its replacement
+    /// types and conformances.
+    static Storage *get(GenericSignature *genericSig,
+                        ArrayRef<Type> replacementTypes,
+                        ArrayRef<ProtocolConformanceRef> conformances);
+
+    /// Retrieve the generic signature that describes the shape of this
+    /// storage.
+    GenericSignature *getGenericSignature() const { return genericSig; }
+
+    /// Retrieve the array of replacement types, which line up with the
+    /// generic parameters.
+    ///
+    /// Note that the types may be null, for cases where the generic parameter
+    /// is concrete but hasn't been queried yet.
+    ArrayRef<Type> getReplacementTypes() const {
+      return llvm::makeArrayRef(getTrailingObjects<Type>(),
+                                getNumReplacementTypes());
+    }
+
+    MutableArrayRef<Type> getReplacementTypes() {
+      return MutableArrayRef<Type>(getTrailingObjects<Type>(),
+                                   getNumReplacementTypes());
+    }
+
+    /// Retrieve the array of protocol conformances, which line up with the
+    /// requirements of the generic signature.
+    ArrayRef<ProtocolConformanceRef> getConformances() const {
+      return llvm::makeArrayRef(getTrailingObjects<ProtocolConformanceRef>(),
+                                numConformanceRequirements);
+    }
+    MutableArrayRef<ProtocolConformanceRef> getConformances() {
+      return MutableArrayRef<ProtocolConformanceRef>(
+                                getTrailingObjects<ProtocolConformanceRef>(),
+                                numConformanceRequirements);
+    }
+  };
+
+  /// The storage needed to describe the set of substitutions.
+  ///
+  /// When null, this substitution map is empty, having neither a generic
+  /// signature nor any replacement types/conformances.
+  std::shared_ptr<Storage> storage;
 
   /// Retrieve the array of replacement types, which line up with the
   /// generic parameters.
   ///
   /// Note that the types may be null, for cases where the generic parameter
   /// is concrete but hasn't been queried yet.
-  ArrayRef<Type> getReplacementTypes() const;
+  ArrayRef<Type> getReplacementTypes() const {
+    return storage ? storage->getReplacementTypes() : ArrayRef<Type>();
+  }
 
-  MutableArrayRef<Type> getReplacementTypes();
+  MutableArrayRef<Type> getReplacementTypes() {
+    return storage ? storage->getReplacementTypes() : MutableArrayRef<Type>();
+  }
 
-  SubstitutionMap(GenericSignature *genericSig);
+  /// Retrieve the array of protocol conformances, which line up with the
+  /// requirements of the generic signature.
+  ArrayRef<ProtocolConformanceRef> getConformances() const {
+    return storage ? storage->getConformances()
+                   : ArrayRef<ProtocolConformanceRef>();
+  }
+  MutableArrayRef<ProtocolConformanceRef> getConformances() {
+    return storage ? storage->getConformances()
+                   : MutableArrayRef<ProtocolConformanceRef>();
+  }
+
+  /// Form a substitution map for the given generic signature with the
+  /// specified replacement types and conformances.
+  SubstitutionMap(GenericSignature *genericSig,
+                  ArrayRef<Type> replacementTypes,
+                  ArrayRef<ProtocolConformanceRef> conformances)
+    : storage(Storage::get(genericSig, replacementTypes, conformances)) { }
 
 public:
-  SubstitutionMap()
-    : SubstitutionMap(static_cast<GenericSignature *>(nullptr)) { }
-
-  SubstitutionMap(SubstitutionMap &&other) = default;
-  SubstitutionMap &operator=(SubstitutionMap &&other) = default;
-
-  SubstitutionMap(const SubstitutionMap &other);
-
-  SubstitutionMap &operator=(const SubstitutionMap &other);
-
-  ~SubstitutionMap();
+  /// Build an empty substitution map.
+  SubstitutionMap() { }
 
   /// Build an interface type substitution map for the given generic
   /// signature and a vector of Substitutions that correspond to the
@@ -106,8 +183,11 @@ public:
 
   /// Retrieve the generic signature describing the environment in which
   /// substitutions occur.
-  GenericSignature *getGenericSignature() const { return genericSig; }
+  GenericSignature *getGenericSignature() const {
+    return storage ? storage->getGenericSignature() : nullptr;
+  }
 
+  /// Look up a conformance for the given type to the given protocol.
   Optional<ProtocolConformanceRef>
   lookupConformance(CanType type, ProtocolDecl *proto) const;
 
@@ -202,13 +282,6 @@ private:
   /// stored inside the map. In most cases, you should call Type::subst()
   /// instead, since that will resolve member types also.
   Type lookupSubstitution(CanSubstitutableType type) const;
-
-  // You should not need to call these directly to build SubstitutionMaps;
-  // instead, use GenericSignature::getSubstitutionMap() or
-  // GenericEnvironment::getSubstitutionMap().
-
-  void addSubstitution(CanGenericTypeParamType type, Type replacement);
-  void addConformance(CanType type, ProtocolConformanceRef conformance);
 };
 
 } // end namespace swift

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -29,6 +29,7 @@
 #define SWIFT_AST_SUBSTITUTION_MAP_H
 
 #include "swift/AST/ProtocolConformanceRef.h"
+#include "swift/AST/SubstitutionList.h"
 #include "swift/AST/Type.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/DenseMap.h"
@@ -76,13 +77,11 @@ class SubstitutionMap {
 
   MutableArrayRef<Type> getReplacementTypes();
 
+  SubstitutionMap(GenericSignature *genericSig);
+
 public:
   SubstitutionMap()
     : SubstitutionMap(static_cast<GenericSignature *>(nullptr)) { }
-
-  SubstitutionMap(GenericSignature *genericSig);
-
-  SubstitutionMap(GenericEnvironment *genericEnv);
 
   SubstitutionMap(SubstitutionMap &&other) = default;
   SubstitutionMap &operator=(SubstitutionMap &&other) = default;
@@ -92,6 +91,18 @@ public:
   SubstitutionMap &operator=(const SubstitutionMap &other);
 
   ~SubstitutionMap();
+
+  /// Build an interface type substitution map for the given generic
+  /// signature and a vector of Substitutions that correspond to the
+  /// requirements of this generic signature.
+  static SubstitutionMap get(GenericSignature *genericSig,
+                             SubstitutionList substitutions);
+
+  /// Build an interface type substitution map for the given generic signature
+  /// from a type substitution function and conformance lookup function.
+  static SubstitutionMap get(GenericSignature *genericSig,
+                             TypeSubstitutionFn subs,
+                             LookupConformanceFn lookupConformance);
 
   /// Retrieve the generic signature describing the environment in which
   /// substitutions occur.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -309,6 +309,9 @@ FOR_KNOWN_FOUNDATION_TYPES(CACHE_FOUNDATION_DECL)
     /// The set of inherited protocol conformances.
     llvm::FoldingSet<InheritedProtocolConformance> InheritedConformances;
 
+    /// The set of substitution maps (uniqued by their storage).
+    llvm::FoldingSet<SubstitutionMap::Storage> SubstitutionMaps;
+
     ~Arena() {
       for (auto &conformance : SpecializedConformances)
         conformance.~SpecializedProtocolConformance();
@@ -2907,11 +2910,9 @@ NameAliasType::NameAliasType(TypeAliasDecl *typealias, Type parent,
   }
 }
 
-NameAliasType *NameAliasType::get(
-                                        TypeAliasDecl *typealias,
-                                        Type parent,
-                                        const SubstitutionMap &substitutions,
-                                        Type underlying) {
+NameAliasType *NameAliasType::get(TypeAliasDecl *typealias, Type parent,
+                                  const SubstitutionMap &substitutions,
+                                  Type underlying) {
   // Compute the recursive properties.
   //
   auto properties = underlying->getRecursiveProperties();
@@ -4291,6 +4292,64 @@ CapturingTypeCheckerDebugConsumer::CapturingTypeCheckerDebugConsumer()
 
 CapturingTypeCheckerDebugConsumer::~CapturingTypeCheckerDebugConsumer() {
   delete Log;
+}
+
+void SubstitutionMap::Storage::Profile(
+                               llvm::FoldingSetNodeID &id,
+                               GenericSignature *genericSig,
+                               ArrayRef<Type> replacementTypes,
+                               ArrayRef<ProtocolConformanceRef> conformances) {
+  id.AddPointer(genericSig);
+  id.AddInteger(replacementTypes.size());
+  for (auto type : replacementTypes)
+    id.AddPointer(type.getPointer());
+  id.AddInteger(conformances.size());
+  for (auto conformance : conformances)
+    id.AddPointer(conformance.getOpaqueValue());
+}
+
+SubstitutionMap::Storage *SubstitutionMap::Storage::get(
+                            GenericSignature *genericSig,
+                            ArrayRef<Type> replacementTypes,
+                            ArrayRef<ProtocolConformanceRef> conformances) {
+  // If there is no generic signature, we need no storage.
+  if (!genericSig) {
+    assert(replacementTypes.empty());
+    assert(conformances.empty());
+    return nullptr;
+  }
+
+  // Figure out which arena this should go in.
+  RecursiveTypeProperties properties;
+  for (auto type : replacementTypes) {
+    if (type)
+      properties |= type->getRecursiveProperties();
+  }
+
+  // Profile the substitution map.
+  llvm::FoldingSetNodeID id;
+  SubstitutionMap::Storage::Profile(id, genericSig, replacementTypes,
+                                    conformances);
+
+  auto arena = getArena(properties);
+
+  // Did we already record this substitution map?
+  auto &ctx = genericSig->getASTContext();
+  void *insertPos;
+  auto &substitutionMaps = ctx.Impl.getArena(arena).SubstitutionMaps;
+  if (auto result = substitutionMaps.FindNodeOrInsertPos(id, insertPos))
+    return result;
+
+  // Allocate the appropriate amount of storage for the signature and its
+  // replacement types and conformances.
+  auto size = Storage::totalSizeToAlloc<Type, ProtocolConformanceRef>(
+                                                      replacementTypes.size(),
+                                                      conformances.size());
+  auto mem = ctx.Allocate(size, alignof(Storage), arena);
+
+  auto result = new (mem) Storage(genericSig, replacementTypes, conformances);
+  substitutionMaps.InsertNode(result, insertPos);
+  return result;
 }
 
 void GenericSignature::Profile(llvm::FoldingSetNodeID &ID,

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -467,68 +467,15 @@ bool GenericSignature::enumeratePairedRequirements(
 
 SubstitutionMap
 GenericSignature::getSubstitutionMap(SubstitutionList subs) const {
-  SubstitutionMap result(const_cast<GenericSignature *>(this));
-
-  enumeratePairedRequirements(
-    [&](Type depTy, ArrayRef<Requirement> reqts) -> bool {
-      auto sub = subs.front();
-      subs = subs.slice(1);
-
-      auto canTy = depTy->getCanonicalType();
-      if (auto paramTy = dyn_cast<GenericTypeParamType>(canTy))
-        result.addSubstitution(paramTy,
-                               sub.getReplacement());
-
-      auto conformances = sub.getConformances();
-      assert(reqts.size() == conformances.size());
-
-      for (unsigned i = 0, e = conformances.size(); i < e; i++) {
-        assert(reqts[i].getSecondType()->getAnyNominal() ==
-               conformances[i].getRequirement());
-        result.addConformance(canTy, conformances[i]);
-      }
-
-      return false;
-    });
-
-  assert(subs.empty() && "did not use all substitutions?!");
-  result.verify();
-  return result;
+  return SubstitutionMap::get(const_cast<GenericSignature *>(this), subs);
 }
 
 SubstitutionMap
 GenericSignature::
 getSubstitutionMap(TypeSubstitutionFn subs,
                    LookupConformanceFn lookupConformance) const {
-  SubstitutionMap subMap(const_cast<GenericSignature *>(this));
-
-  // Enumerate all of the requirements that require substitution.
-  enumeratePairedRequirements([&](Type depTy, ArrayRef<Requirement> reqs) {
-    auto canTy = depTy->getCanonicalType();
-
-    // Compute the replacement type.
-    Type currentReplacement = depTy.subst(subs, lookupConformance,
-                                          SubstFlags::UseErrorType);
-    if (auto paramTy = dyn_cast<GenericTypeParamType>(canTy))
-      if (!currentReplacement->hasError())
-        subMap.addSubstitution(paramTy, currentReplacement);
-
-    // Collect the conformances.
-    for (auto req: reqs) {
-      assert(req.getKind() == RequirementKind::Conformance);
-      auto protoType = req.getSecondType()->castTo<ProtocolType>();
-      if (auto conformance = lookupConformance(canTy,
-                                               currentReplacement,
-                                               protoType)) {
-        subMap.addConformance(canTy, *conformance);
-      }
-    }
-
-    return false;
-  });
-
-  subMap.verify();
-  return subMap;
+  return SubstitutionMap::get(const_cast<GenericSignature *>(this),
+                              subs, lookupConformance);
 }
 
 void GenericSignature::

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -119,7 +119,7 @@ SubstitutionMap SubstitutionMap::get(GenericSignature *genericSig,
       auto conformances = sub.getConformances();
       assert(reqts.size() == conformances.size());
 
-      for (unsigned i = 0, e = conformances.size(); i < e; i++) {
+      for (auto i : indices(conformances)) {
         assert(reqts[i].getSecondType()->getAnyNominal() ==
                conformances[i].getRequirement());
         storedConformances.push_back(conformances[i]);
@@ -599,14 +599,8 @@ void SubstitutionMap::profile(llvm::FoldingSetNodeID &id) const {
   }
 
   // Conformance requirements.
-  for (const auto &req : genericSig->getRequirements()) {
-    if (req.getKind() != RequirementKind::Conformance)
-      continue;
-
-    auto conformance =
-      lookupConformance(req.getFirstType()->getCanonicalType(),
-                        req.getSecondType()->castTo<ProtocolType>()->getDecl());
-    id.AddPointer(conformance ? conformance->getOpaqueValue() : nullptr);
+  for (const auto conformance : getConformances()) {
+    id.AddPointer(conformance.getOpaqueValue());
   }
 }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -719,7 +719,7 @@ RequirementMatch swift::matchWitness(TypeChecker &tc,
 
       // If substitution failed, skip the requirement. This only occurs in
       // invalid code.
-      if (!replacedInReq)
+      if (!replacedInReq || replacedInReq->hasError())
         continue;
 
       if (reqGenericEnv) {


### PR DESCRIPTION
Collapse the out-of-line array of replacement types and the `DenseMap` used
for conformances into a single field that references out-of-line,
tail-allocated storage for all of the contents of a `SubstitutionMap`.
The conformances are now represented as a flat array whose indices
line up with the indices of the conformance requirements in the
underlying generic signtature.

Unique and `ASTContext`-allocate `SubstitutionMap` instances, making them
cheap to copy and opening the door for them to be stored directly in AST nodes.