### PR TITLE
std::function -> llvm::function_ref for some non-escaping params.

### DIFF
--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -459,13 +459,13 @@ public:
   /// Enumerate each immediate child expression of this node, invoking the
   /// specific functor on it.  This ignores statements and other non-expression
   /// children.
-  void forEachImmediateChildExpr(const std::function<Expr*(Expr*)> &callback);
+  void forEachImmediateChildExpr(llvm::function_ref<Expr *(Expr *)> callback);
 
   /// Enumerate each expr node within this expression subtree, invoking the
   /// specific functor on it.  This ignores statements and other non-expression
   /// children, and if there is a closure within the expression, this does not
   /// walk into the body of it (unless it is single-expression).
-  void forEachChildExpr(const std::function<Expr*(Expr*)> &callback);
+  void forEachChildExpr(llvm::function_ref<Expr *(Expr *)> callback);
 
   /// Determine whether this expression refers to a type by name.
   ///

--- a/include/swift/AST/Pattern.h
+++ b/include/swift/AST/Pattern.h
@@ -166,14 +166,14 @@ public:
 
   /// \brief apply the specified function to all variables referenced in this
   /// pattern.
-  void forEachVariable(const std::function<void(VarDecl*)> &f) const;
+  void forEachVariable(llvm::function_ref<void(VarDecl *)> f) const;
 
   /// \brief apply the specified function to all pattern nodes recursively in
   /// this pattern.  This is a pre-order traversal.
-  void forEachNode(const std::function<void(Pattern*)> &f);
+  void forEachNode(llvm::function_ref<void(Pattern *)> f);
 
-  void forEachNode(const std::function<void(const Pattern*)> &f) const {
-    const std::function<void(Pattern*)> &f2 = f;
+  void forEachNode(llvm::function_ref<void(const Pattern *)> f) const {
+    llvm::function_ref<void(Pattern *)> f2 = f;
     const_cast<Pattern *>(this)->forEachNode(f2);
   }
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -835,7 +835,7 @@ public:
   /// paramsAndResultMatch which determines in a client-specific way
   /// whether the parameters and result of the types match.
   bool matchesFunctionType(Type other, TypeMatchOptions matchOptions,
-                           std::function<bool()> paramsAndResultMatch);
+                           llvm::function_ref<bool()> paramsAndResultMatch);
 
   /// \brief Determines whether this type has a retainable pointer
   /// representation, i.e. whether it is representable as a single,

--- a/include/swift/Frontend/FrontendOptions.h
+++ b/include/swift/Frontend/FrontendOptions.h
@@ -38,7 +38,7 @@ public:
   InputFileKind InputKind = InputFileKind::IFK_Swift;
 
   void forAllOutputPaths(const InputFile &input,
-                         std::function<void(StringRef)> fn) const;
+                         llvm::function_ref<void(StringRef)> fn) const;
 
   bool isOutputFileDirectory() const;
 

--- a/include/swift/IDE/Utils.h
+++ b/include/swift/IDE/Utils.h
@@ -87,7 +87,7 @@ bool initInvocationByClangArguments(ArrayRef<const char *> ArgList,
 /// Visits all overridden declarations exhaustively from VD, including protocol
 /// conformances and clang declarations.
 void walkOverriddenDecls(const ValueDecl *VD,
-                         std::function<void(llvm::PointerUnion<
+                         llvm::function_ref<void(llvm::PointerUnion<
                              const ValueDecl*, const clang::NamedDecl*>)> Fn);
 
 void collectModuleNames(StringRef SDKPath, std::vector<std::string> &Modules);

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -675,7 +675,7 @@ public:
   ParserStatus parseList(tok RightK, SourceLoc LeftLoc, SourceLoc &RightLoc,
                          bool AllowSepAfterLast, Diag<> ErrorDiag,
                          syntax::SyntaxKind Kind,
-                         std::function<ParserStatus()> callback);
+                         llvm::function_ref<ParserStatus()> callback);
 
   void consumeTopLevelDecl(ParserPosition BeginParserPosition,
                            TopLevelCodeDecl *TLCD);

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -295,7 +295,7 @@ bool isPossibleFormalAccessBase(const AccessedStorage &storage, SILFunction *F);
 /// This only visits instructions that modify memory in some user-visible way,
 /// which could be considered part of a formal access.
 void visitAccessedAddress(SILInstruction *I,
-                          std::function<void(Operand *)> visitor);
+                          llvm::function_ref<void(Operand *)> visitor);
 
 } // end namespace swift
 

--- a/include/swift/SILOptimizer/Analysis/ClosureScope.h
+++ b/include/swift/SILOptimizer/Analysis/ClosureScope.h
@@ -177,7 +177,7 @@ public:
   // Visit all functions in a module, visiting each closure scope function
   // before
   // the closure function itself.
-  void visitFunctions(std::function<void(SILFunction *)> visitor);
+  void visitFunctions(llvm::function_ref<void(SILFunction *)> visitor);
 };
 
 } // end namespace swift

--- a/include/swift/SILOptimizer/Utils/Local.h
+++ b/include/swift/SILOptimizer/Utils/Local.h
@@ -63,7 +63,7 @@ NullablePtr<SILInstruction> createDecrementBefore(SILValue Ptr,
 void
 recursivelyDeleteTriviallyDeadInstructions(
   ArrayRef<SILInstruction*> I, bool Force = false,
-  std::function<void(SILInstruction *)> C = [](SILInstruction *){});
+  llvm::function_ref<void(SILInstruction *)> C = [](SILInstruction *){});
 
 /// \brief If the given instruction is dead, delete it along with its dead
 /// operands.
@@ -76,7 +76,7 @@ void
 recursivelyDeleteTriviallyDeadInstructions(
   SILInstruction *I,
   bool Force = false,
-  std::function<void(SILInstruction *)> C = [](SILInstruction *){});
+  llvm::function_ref<void(SILInstruction *)> C = [](SILInstruction *){});
 
 /// \brief Perform a fast local check to see if the instruction is dead.
 ///
@@ -96,7 +96,7 @@ collectUsesOfValue(SILValue V, llvm::SmallPtrSetImpl<SILInstruction *> &Insts);
 /// instruction itself)
 void eraseUsesOfInstruction(
     SILInstruction *Inst,
-    std::function<void(SILInstruction *)> C = [](SILInstruction *){});
+    llvm::function_ref<void(SILInstruction *)> C = [](SILInstruction *){});
 
 /// \brief Recursively erase all of the uses of the value (but not the
 /// value itself)

--- a/include/swift/Syntax/AtomicCache.h
+++ b/include/swift/Syntax/AtomicCache.h
@@ -15,6 +15,7 @@
 
 #include <functional>
 #include "swift/Syntax/References.h"
+#include "llvm/ADT/STLExtras.h"
 
 namespace swift {
 
@@ -38,7 +39,7 @@ public:
 
   /// Gets the value inside the cache, or creates it atomically using the
   /// provided lambda if it doesn't already exist.
-  RC<T> getOrCreate(std::function<RC<T> ()> Create) const {
+  RC<T> getOrCreate(llvm::function_ref<RC<T>()> Create) const {
     auto &Ptr = *reinterpret_cast<std::atomic<uintptr_t> *>(&Storage);
 
     // If an atomic load gets an initialized value, then return Storage.

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -624,7 +624,7 @@ private:
                          bool Curried, bool ArgNameIsAPIByDefault);
 
   void printParameterList(ParameterList *PL, Type paramListTy, bool isCurried,
-                          std::function<bool()> isAPINameByDefault);
+                          llvm::function_ref<bool()> isAPINameByDefault);
 
   /// \brief Print the function parameters in curried or selector style,
   /// to match the original function declaration.
@@ -2310,7 +2310,7 @@ void PrintAST::printOneParameter(const ParamDecl *param,
 
 void PrintAST::printParameterList(ParameterList *PL, Type paramListTy,
                                   bool isCurried,
-                                  std::function<bool()> isAPINameByDefault) {
+                                  llvm::function_ref<bool()> isAPINameByDefault) {
   SmallVector<ParameterTypeFlags, 4> paramFlags;
   if (paramListTy && !paramListTy->hasError()) {
     if (auto parenTy = dyn_cast<ParenType>(paramListTy.getPointer())) {

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -3414,9 +3414,8 @@ public:
 
     /// \brief Verify that the given source ranges is contained within the
     /// parent's source range.
-    void checkSourceRanges(SourceRange Current,
-                           ASTWalker::ParentTy Parent,
-                           std::function<void()> printEntity) {
+    void checkSourceRanges(SourceRange Current, ASTWalker::ParentTy Parent,
+                           llvm::function_ref<void()> printEntity) {
       SourceRange Enclosing;
       if (Parent.isNull())
           return;

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -540,12 +540,12 @@ ConcreteDeclRef Expr::getReferencedDecl() const {
 /// specific functor on it.  This ignores statements and other non-expression
 /// children.
 void Expr::
-forEachImmediateChildExpr(const std::function<Expr*(Expr*)> &callback) {
+forEachImmediateChildExpr(llvm::function_ref<Expr *(Expr *)> callback) {
   struct ChildWalker : ASTWalker {
-    const std::function<Expr*(Expr*)> &callback;
+    llvm::function_ref<Expr *(Expr *)> callback;
     Expr *ThisNode;
     
-    ChildWalker(const std::function<Expr*(Expr*)> &callback, Expr *ThisNode)
+    ChildWalker(llvm::function_ref<Expr *(Expr *)> callback, Expr *ThisNode)
       : callback(callback), ThisNode(ThisNode) {}
     
     std::pair<bool, Expr *> walkToExprPre(Expr *E) override {
@@ -576,11 +576,11 @@ forEachImmediateChildExpr(const std::function<Expr*(Expr*)> &callback) {
 /// Enumerate each immediate child expression of this node, invoking the
 /// specific functor on it.  This ignores statements and other non-expression
 /// children.
-void Expr::forEachChildExpr(const std::function<Expr*(Expr*)> &callback) {
+void Expr::forEachChildExpr(llvm::function_ref<Expr *(Expr *)> callback) {
   struct ChildWalker : ASTWalker {
-    const std::function<Expr*(Expr*)> &callback;
+    llvm::function_ref<Expr *(Expr *)> callback;
 
-    ChildWalker(const std::function<Expr*(Expr*)> &callback)
+    ChildWalker(llvm::function_ref<Expr *(Expr *)> callback)
     : callback(callback) {}
 
     std::pair<bool, Expr *> walkToExprPre(Expr *E) override {

--- a/lib/AST/Pattern.cpp
+++ b/lib/AST/Pattern.cpp
@@ -190,7 +190,7 @@ namespace {
 
 /// \brief apply the specified function to all variables referenced in this
 /// pattern.
-void Pattern::forEachVariable(const std::function<void(VarDecl*)> &fn) const {
+void Pattern::forEachVariable(llvm::function_ref<void(VarDecl *)> fn) const {
   switch (getKind()) {
   case PatternKind::Any:
   case PatternKind::Bool:
@@ -235,7 +235,7 @@ void Pattern::forEachVariable(const std::function<void(VarDecl*)> &fn) const {
 
 /// \brief apply the specified function to all pattern nodes recursively in
 /// this pattern.  This is a pre-order traversal.
-void Pattern::forEachNode(const std::function<void(Pattern*)> &f) {
+void Pattern::forEachNode(llvm::function_ref<void(Pattern*)> f) {
   f(this);
 
   switch (getKind()) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2226,7 +2226,7 @@ namespace {
 static bool matchesFunctionType(CanAnyFunctionType fn1, CanAnyFunctionType fn2,
                                 TypeMatchOptions matchMode,
                                 OptionalUnwrapping insideOptional,
-                                std::function<bool()> paramsAndResultMatch) {
+                                llvm::function_ref<bool()> paramsAndResultMatch) {
   // FIXME: Handle generic functions in non-ABI matches.
   if (!matchMode.contains(TypeMatchFlags::AllowABICompatible)) {
     if (!isa<FunctionType>(fn1) || !isa<FunctionType>(fn2))
@@ -2335,7 +2335,7 @@ static bool matches(CanType t1, CanType t2, TypeMatchOptions matchMode,
     if (!fn1)
       return false;
 
-    std::function<bool()> paramsAndResultMatch = [=]() {
+    auto paramsAndResultMatch = [&]() {
       // Inputs are contravariant, results are covariant.
       return (matches(fn2.getInput(), fn1.getInput(), matchMode,
                       ParameterPosition::Parameter, OptionalUnwrapping::None) &&
@@ -2371,7 +2371,7 @@ bool TypeBase::matchesParameter(Type other, TypeMatchOptions matchMode) {
 }
 
 bool TypeBase::matchesFunctionType(Type other, TypeMatchOptions matchMode,
-                                   std::function<bool()> paramsAndResultMatch) {
+                                   llvm::function_ref<bool()> paramsAndResultMatch) {
   auto thisFnTy = dyn_cast<AnyFunctionType>(getCanonicalType());
   auto otherFnTy = dyn_cast<AnyFunctionType>(other->getCanonicalType());
 

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -871,7 +871,7 @@ static Arg *makeInputArg(const DerivedArgList &Args, OptTable &Opts,
   return A;
 }
 
-using RemainingArgsHandler = std::function<void(InputArgList &, unsigned)>;
+using RemainingArgsHandler = llvm::function_ref<void(InputArgList &, unsigned)>;
 
 std::unique_ptr<InputArgList>
 parseArgsUntil(const llvm::opt::OptTable& Opts,

--- a/lib/Frontend/FrontendOptions.cpp
+++ b/lib/Frontend/FrontendOptions.cpp
@@ -108,7 +108,7 @@ bool FrontendOptions::shouldActionOnlyParse(ActionType action) {
 }
 
 void FrontendOptions::forAllOutputPaths(
-    const InputFile &input, std::function<void(StringRef)> fn) const {
+    const InputFile &input, llvm::function_ref<void(StringRef)> fn) const {
   if (RequestedAction != FrontendOptions::ActionType::EmitModuleOnly &&
       RequestedAction != FrontendOptions::ActionType::MergeModules) {
     if (InputsAndOutputs.isWholeModule())

--- a/lib/IDE/Utils.cpp
+++ b/lib/IDE/Utils.cpp
@@ -375,7 +375,7 @@ static void walkOverriddenClangDecls(const clang::NamedDecl *D, const FnTy &Fn){
 
 void
 ide::walkOverriddenDecls(const ValueDecl *VD,
-                         std::function<void(llvm::PointerUnion<
+                         llvm::function_ref<void(llvm::PointerUnion<
                              const ValueDecl*, const clang::NamedDecl*>)> Fn) {
   for (auto CurrOver = VD; CurrOver; CurrOver = CurrOver->getOverriddenDecl()) {
     if (CurrOver != VD)

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -3895,7 +3895,7 @@ namespace {
     }
 
     void forNontrivialPayloads(IRGenFunction &IGF, llvm::Value *tag,
-               std::function<void (unsigned, EnumImplStrategy::Element)> f)
+               llvm::function_ref<void(unsigned, EnumImplStrategy::Element)> f)
     const {
       auto *endBB = llvm::BasicBlock::Create(IGF.IGM.getLLVMContext());
 

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -1545,12 +1545,11 @@ TypeConverter::convertExistentialMetatypeType(ExistentialMetatypeType *T) {
 
 /// Emit protocol witness table pointers for the given protocol conformances,
 /// passing each emitted witness table index into the given function body.
-static void forEachProtocolWitnessTable(IRGenFunction &IGF,
-                          CanType srcType, llvm::Value **srcMetadataCache,
-                          CanType destType,
-                          ArrayRef<ProtocolEntry> protocols,
-                          ArrayRef<ProtocolConformanceRef> conformances,
-                          std::function<void (unsigned, llvm::Value*)> body) {
+static void forEachProtocolWitnessTable(
+    IRGenFunction &IGF, CanType srcType, llvm::Value **srcMetadataCache,
+    CanType destType, ArrayRef<ProtocolEntry> protocols,
+    ArrayRef<ProtocolConformanceRef> conformances,
+    llvm::function_ref<void(unsigned, llvm::Value *)> body) {
   // Collect the conformances that need witness tables.
   auto layout = destType.getExistentialLayout();
   auto destProtocols = layout.getProtocols();

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -884,7 +884,7 @@ static SyntaxKind getListElementKind(SyntaxKind ListKind) {
 ParserStatus
 Parser::parseList(tok RightK, SourceLoc LeftLoc, SourceLoc &RightLoc,
                   bool AllowSepAfterLast, Diag<> ErrorDiag, SyntaxKind Kind,
-                  std::function<ParserStatus()> callback) {
+                  llvm::function_ref<ParserStatus()> callback) {
   llvm::Optional<SyntaxParsingContext> ListContext;
   ListContext.emplace(SyntaxContext, Kind);
   if (Kind == SyntaxKind::Unknown)

--- a/lib/PrintAsObjC/PrintAsObjC.cpp
+++ b/lib/PrintAsObjC/PrintAsObjC.cpp
@@ -2158,7 +2158,7 @@ public:
   }
 
   void forwardDeclare(const NominalTypeDecl *NTD,
-                      std::function<void (void)> Printer) {
+                      llvm::function_ref<void(void)> Printer) {
     if (NTD->getModuleContext()->isStdlibModule())
       return;
     auto &state = seenTypes[NTD];

--- a/lib/SIL/MemAccessUtils.cpp
+++ b/lib/SIL/MemAccessUtils.cpp
@@ -331,7 +331,7 @@ bool swift::isPossibleFormalAccessBase(const AccessedStorage &storage,
 /// including arguments to @noescape functions that are passed as closures to
 /// the current call.
 static void visitApplyAccesses(ApplySite apply,
-                               std::function<void(Operand *)> visitor) {
+                               llvm::function_ref<void(Operand *)> visitor) {
   for (Operand &oper : apply.getArgumentOperands()) {
     // Consider any address-type operand an access. Whether it is read or modify
     // depends on the argument convention.
@@ -355,7 +355,7 @@ static void visitApplyAccesses(ApplySite apply,
 }
 
 static void visitBuiltinAddress(BuiltinInst *builtin,
-                                std::function<void(Operand *)> visitor) {
+                                llvm::function_ref<void(Operand *)> visitor) {
   if (auto kind = builtin->getBuiltinKind()) {
     switch (kind.getValue()) {
     default:
@@ -430,7 +430,7 @@ static void visitBuiltinAddress(BuiltinInst *builtin,
 }
 
 void swift::visitAccessedAddress(SILInstruction *I,
-                                 std::function<void(Operand *)> visitor) {
+                                 llvm::function_ref<void(Operand *)> visitor) {
   assert(I->mayReadOrWriteMemory());
 
   // Reference counting instructions do not access user visible memory.

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -431,9 +431,10 @@ ManagedValue SILGenBuilder::createFormalAccessCopyAddr(
   return SGF.emitFormalAccessManagedBufferWithCleanup(loc, newAddr);
 }
 
-ManagedValue SILGenBuilder::bufferForExpr(
-    SILLocation loc, SILType ty, const TypeLowering &lowering,
-    SGFContext context, std::function<void (SILValue)> rvalueEmitter) {
+ManagedValue
+SILGenBuilder::bufferForExpr(SILLocation loc, SILType ty,
+                             const TypeLowering &lowering, SGFContext context,
+                             llvm::function_ref<void(SILValue)> rvalueEmitter) {
   // If we have a single-buffer "emit into" initialization, use that for the
   // result.
   SILValue address = context.getAddressForInPlaceInitialization(SGF, loc);
@@ -459,10 +460,9 @@ ManagedValue SILGenBuilder::bufferForExpr(
   return SGF.emitManagedBufferWithCleanup(address);
 }
 
-
 ManagedValue SILGenBuilder::formalAccessBufferForExpr(
     SILLocation loc, SILType ty, const TypeLowering &lowering,
-    SGFContext context, std::function<void(SILValue)> rvalueEmitter) {
+    SGFContext context, llvm::function_ref<void(SILValue)> rvalueEmitter) {
   // If we have a single-buffer "emit into" initialization, use that for the
   // result.
   SILValue address = context.getAddressForInPlaceInitialization(SGF, loc);

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -236,9 +236,8 @@ public:
   ///
   /// \return an empty value if the buffer was taken from the context.
   ManagedValue bufferForExpr(SILLocation loc, SILType ty,
-                             const TypeLowering &lowering,
-                             SGFContext context,
-                             std::function<void(SILValue)> rvalueEmitter);
+                             const TypeLowering &lowering, SGFContext context,
+                             llvm::function_ref<void(SILValue)> rvalueEmitter);
 
   using SILBuilder::createUncheckedEnumData;
   ManagedValue createUncheckedEnumData(SILLocation loc, ManagedValue operand,
@@ -276,9 +275,10 @@ public:
 
   ManagedValue createSemanticLoadBorrow(SILLocation loc, ManagedValue addr);
 
-  ManagedValue formalAccessBufferForExpr(
-      SILLocation loc, SILType ty, const TypeLowering &lowering,
-      SGFContext context, std::function<void(SILValue)> rvalueEmitter);
+  ManagedValue
+  formalAccessBufferForExpr(SILLocation loc, SILType ty,
+                            const TypeLowering &lowering, SGFContext context,
+                            llvm::function_ref<void(SILValue)> rvalueEmitter);
 
   using SILBuilder::createUnconditionalCheckedCastValue;
   ManagedValue

--- a/lib/SILGen/SILGenDynamicCast.cpp
+++ b/lib/SILGen/SILGenDynamicCast.cpp
@@ -116,8 +116,8 @@ namespace {
     /// Emit a conditional cast.
     void emitConditional(
         ManagedValue operand, CastConsumptionKind consumption, SGFContext ctx,
-        const std::function<void(ManagedValue)> &handleTrue,
-        const std::function<void(Optional<ManagedValue>)> &handleFalse,
+        llvm::function_ref<void(ManagedValue)> handleTrue,
+        llvm::function_ref<void(Optional<ManagedValue>)> handleFalse,
         ProfileCounter TrueCount = ProfileCounter(),
         ProfileCounter FalseCount = ProfileCounter()) {
       // The cast instructions don't know how to work with anything
@@ -286,8 +286,8 @@ namespace {
 
 void SILGenFunction::emitCheckedCastBranch(
     SILLocation loc, Expr *source, Type targetType, SGFContext ctx,
-    std::function<void(ManagedValue)> handleTrue,
-    std::function<void(Optional<ManagedValue>)> handleFalse,
+    llvm::function_ref<void(ManagedValue)> handleTrue,
+    llvm::function_ref<void(Optional<ManagedValue>)> handleFalse,
     ProfileCounter TrueCount, ProfileCounter FalseCount) {
   CheckedCastEmitter emitter(*this, loc, source->getType(), targetType);
   ManagedValue operand = emitter.emitOperand(source);
@@ -298,8 +298,8 @@ void SILGenFunction::emitCheckedCastBranch(
 void SILGenFunction::emitCheckedCastBranch(
     SILLocation loc, ConsumableManagedValue src, Type sourceType,
     CanType targetType, SGFContext ctx,
-    std::function<void(ManagedValue)> handleTrue,
-    std::function<void(Optional<ManagedValue>)> handleFalse,
+    llvm::function_ref<void(ManagedValue)> handleTrue,
+    llvm::function_ref<void(Optional<ManagedValue>)> handleFalse,
     ProfileCounter TrueCount, ProfileCounter FalseCount) {
   CheckedCastEmitter emitter(*this, loc, sourceType, targetType);
   emitter.emitConditional(src.getFinalManagedValue(), src.getFinalConsumption(),
@@ -397,8 +397,8 @@ namespace {
     /// Emit a conditional cast.
     void emitConditional(ManagedValue operand, CastConsumptionKind consumption,
                          SGFContext ctx,
-                         const std::function<void(ManagedValue)> &handleTrue,
-                         const std::function<void()> &handleFalse,
+                         llvm::function_ref<void(ManagedValue)> handleTrue,
+                         llvm::function_ref<void()> handleFalse,
                          ProfileCounter TrueCount = ProfileCounter(),
                          ProfileCounter FalseCount = ProfileCounter()) {
       // The cast instructions don't know how to work with anything
@@ -544,8 +544,8 @@ namespace {
 
 void SILGenFunction::emitCheckedCastBranchOld(
     SILLocation loc, Expr *source, Type targetType, SGFContext ctx,
-    std::function<void(ManagedValue)> handleTrue,
-    std::function<void()> handleFalse, ProfileCounter TrueCount,
+    llvm::function_ref<void(ManagedValue)> handleTrue,
+    llvm::function_ref<void()> handleFalse, ProfileCounter TrueCount,
     ProfileCounter FalseCount) {
   CheckedCastEmitterOld emitter(*this, loc, source->getType(), targetType);
   ManagedValue operand = emitter.emitOperand(source);
@@ -556,8 +556,8 @@ void SILGenFunction::emitCheckedCastBranchOld(
 void SILGenFunction::emitCheckedCastBranchOld(
     SILLocation loc, ConsumableManagedValue src, Type sourceType,
     CanType targetType, SGFContext ctx,
-    std::function<void(ManagedValue)> handleTrue,
-    std::function<void()> handleFalse, ProfileCounter TrueCount,
+    llvm::function_ref<void(ManagedValue)> handleTrue,
+    llvm::function_ref<void()> handleFalse, ProfileCounter TrueCount,
     ProfileCounter FalseCount) {
   CheckedCastEmitterOld emitter(*this, loc, sourceType, targetType);
   emitter.emitConditional(src.getFinalManagedValue(), src.getFinalConsumption(),

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1446,13 +1446,13 @@ public:
   ///                     terminated.
   /// \param handleFalse  A callback to invoke in the failure path.  The
   ///                     current BB should be terminated.
-  void
-  emitCheckedCastBranch(SILLocation loc, ConsumableManagedValue src,
-                        Type sourceType, CanType targetType, SGFContext C,
-                        std::function<void(ManagedValue)> handleTrue,
-                        std::function<void(Optional<ManagedValue>)> handleFalse,
-                        ProfileCounter TrueCount = ProfileCounter(),
-                        ProfileCounter FalseCount = ProfileCounter());
+  void emitCheckedCastBranch(
+      SILLocation loc, ConsumableManagedValue src, Type sourceType,
+      CanType targetType, SGFContext C,
+      llvm::function_ref<void(ManagedValue)> handleTrue,
+      llvm::function_ref<void(Optional<ManagedValue>)> handleFalse,
+      ProfileCounter TrueCount = ProfileCounter(),
+      ProfileCounter FalseCount = ProfileCounter());
 
   /// A form of checked cast branch that uses the old non-ownership preserving
   /// semantics.
@@ -1460,12 +1460,13 @@ public:
   /// The main difference is that this code does not pass the old argument as a
   /// block argument in the failure case. This causes values to be double
   /// consumed.
-  void emitCheckedCastBranchOld(SILLocation loc, Expr *source, Type targetType,
-                                SGFContext ctx,
-                                std::function<void(ManagedValue)> handleTrue,
-                                std::function<void()> handleFalse,
-                                ProfileCounter TrueCount = ProfileCounter(),
-                                ProfileCounter FalseCount = ProfileCounter());
+  void
+  emitCheckedCastBranchOld(SILLocation loc, Expr *source, Type targetType,
+                           SGFContext ctx,
+                           llvm::function_ref<void(ManagedValue)> handleTrue,
+                           llvm::function_ref<void()> handleFalse,
+                           ProfileCounter TrueCount = ProfileCounter(),
+                           ProfileCounter FalseCount = ProfileCounter());
 
   /// \brief Emit a conditional checked cast branch, starting from an
   /// expression.  Terminates the current BB.
@@ -1479,13 +1480,12 @@ public:
   ///                     terminated.
   /// \param handleFalse  A callback to invoke in the failure path.  The
   ///                     current BB should be terminated.
-  void
-  emitCheckedCastBranch(SILLocation loc, Expr *src, Type targetType,
-                        SGFContext C,
-                        std::function<void(ManagedValue)> handleTrue,
-                        std::function<void(Optional<ManagedValue>)> handleFalse,
-                        ProfileCounter TrueCount = ProfileCounter(),
-                        ProfileCounter FalseCount = ProfileCounter());
+  void emitCheckedCastBranch(
+      SILLocation loc, Expr *src, Type targetType, SGFContext C,
+      llvm::function_ref<void(ManagedValue)> handleTrue,
+      llvm::function_ref<void(Optional<ManagedValue>)> handleFalse,
+      ProfileCounter TrueCount = ProfileCounter(),
+      ProfileCounter FalseCount = ProfileCounter());
 
   /// A form of checked cast branch that uses the old non-ownership preserving
   /// semantics.
@@ -1493,13 +1493,13 @@ public:
   /// The main difference is that this code does not pass the old argument as a
   /// block argument in the failure case. This causes values to be double
   /// consumed.
-  void emitCheckedCastBranchOld(SILLocation loc, ConsumableManagedValue src,
-                                Type sourceType, CanType targetType,
-                                SGFContext ctx,
-                                std::function<void(ManagedValue)> handleTrue,
-                                std::function<void()> handleFalse,
-                                ProfileCounter TrueCount = ProfileCounter(),
-                                ProfileCounter FalseCount = ProfileCounter());
+  void
+  emitCheckedCastBranchOld(SILLocation loc, ConsumableManagedValue src,
+                           Type sourceType, CanType targetType, SGFContext ctx,
+                           llvm::function_ref<void(ManagedValue)> handleTrue,
+                           llvm::function_ref<void()> handleFalse,
+                           ProfileCounter TrueCount = ProfileCounter(),
+                           ProfileCounter FalseCount = ProfileCounter());
 
   /// Emit the control flow for an optional 'bind' operation, branching to the
   /// active failure destination if the optional value addressed by optionalAddr

--- a/lib/SILOptimizer/Analysis/ClosureScope.cpp
+++ b/lib/SILOptimizer/Analysis/ClosureScope.cpp
@@ -167,7 +167,7 @@ SILAnalysis *createClosureScopeAnalysis(SILModule *M) {
 }
 
 void TopDownClosureFunctionOrder::visitFunctions(
-    std::function<void(SILFunction *)> visitor) {
+    llvm::function_ref<void(SILFunction *)> visitor) {
   auto markVisited = [&](SILFunction *F) {
     bool visitOnce = visited.insert(F).second;
     assert(visitOnce);

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -169,7 +169,7 @@ bool swift::isIntermediateRelease(SILInstruction *I,
 }
 
 namespace {
-  using CallbackTy = std::function<void(SILInstruction *)>;
+  using CallbackTy = llvm::function_ref<void(SILInstruction *)>;
 } // end anonymous namespace
 
 void swift::

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -4782,14 +4782,13 @@ namespace {
 ///
 /// \returns the decl to which the locator resolved.
 ///
-static ConcreteDeclRef
-resolveLocatorToDecl(ConstraintSystem &cs, ConstraintLocator *locator,
-   std::function<Optional<SelectedOverload>(ConstraintLocator *)> findOvlChoice,
-   std::function<ConcreteDeclRef (ValueDecl *decl,
-                                  Type openedType,
-                                  ConstraintLocator *declLocator)>
-     getConcreteDeclRef)
-{
+static ConcreteDeclRef resolveLocatorToDecl(
+    ConstraintSystem &cs, ConstraintLocator *locator,
+    llvm::function_ref<Optional<SelectedOverload>(ConstraintLocator *)>
+        findOvlChoice,
+    llvm::function_ref<ConcreteDeclRef(ValueDecl *decl, Type openedType,
+                                       ConstraintLocator *declLocator)>
+        getConcreteDeclRef) {
   assert(locator && "Null locator");
   if (!locator->getAnchor())
     return ConcreteDeclRef();

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -993,8 +993,9 @@ private:
 
   bool diagnoseTrailingClosureErrors(ApplyExpr *expr);
 
-  bool diagnoseClosureExpr(ClosureExpr *closureExpr, Type contextualType,
-                           std::function<bool(Type, Type)> resultTypeProcessor);
+  bool
+  diagnoseClosureExpr(ClosureExpr *closureExpr, Type contextualType,
+                      llvm::function_ref<bool(Type, Type)> resultTypeProcessor);
 
   bool diagnoseSubscriptErrors(SubscriptExpr *SE, bool performingSet);
 
@@ -6283,7 +6284,7 @@ bool FailureDiagnosis::visitClosureExpr(ClosureExpr *CE) {
 
 bool FailureDiagnosis::diagnoseClosureExpr(
     ClosureExpr *CE, Type contextualType,
-    std::function<bool(Type, Type)> resultTypeProcessor) {
+    llvm::function_ref<bool(Type, Type)> resultTypeProcessor) {
   // Look through IUO because it doesn't influence
   // neither parameter nor return type diagnostics itself,
   // but if we have function type inside, that might

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -562,7 +562,7 @@ namespace {
   /// overloads which inhibit any overload from being favored.
   void favorCallOverloads(ApplyExpr *expr,
                           ConstraintSystem &CS,
-                          std::function<bool(ValueDecl *)> isFavored,
+                          llvm::function_ref<bool(ValueDecl *)> isFavored,
                           std::function<bool(ValueDecl *)>
                               mustConsider = nullptr) {
     // Find the type variable associated with the function, if any.

--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1475,7 +1475,7 @@ ConstraintSystem::TypeMatchResult
 ConstraintSystem::matchTypesBindTypeVar(
     TypeVariableType *typeVar, Type type, ConstraintKind kind,
     TypeMatchOptions flags, ConstraintLocatorBuilder locator,
-    std::function<TypeMatchResult()> formUnsolvedResult) {
+    llvm::function_ref<TypeMatchResult()> formUnsolvedResult) {
   assert(typeVar->is<TypeVariableType>() && "Expected a type variable!");
   // FIXME: Due to some SE-0110 related code farther up we can end
   // up with type variables wrapped in parens that will trip this

--- a/lib/Sema/ConstraintGraph.cpp
+++ b/lib/Sema/ConstraintGraph.cpp
@@ -145,7 +145,7 @@ ConstraintGraphNode::getAdjacency(TypeVariableType *typeVar) {
 
 void ConstraintGraphNode::modifyAdjacency(
        TypeVariableType *typeVar,
-       std::function<void(Adjacency& adj)> modify) {
+       llvm::function_ref<void(Adjacency& adj)> modify) {
    // Find the adjacency information.
   auto pos = AdjacencyInfo.find(typeVar);
   assert(pos != AdjacencyInfo.end() && "Type variables not adjacent");

--- a/lib/Sema/ConstraintGraph.h
+++ b/lib/Sema/ConstraintGraph.h
@@ -104,7 +104,7 @@ private:
   /// directly. If the adjacency becomes empty afterward, it will be
   /// removed.
   void modifyAdjacency(TypeVariableType *typeVar,
-                       std::function<void(Adjacency& adj)> modify);
+                       llvm::function_ref<void(Adjacency &adj)> modify);
 
   /// Add an adjacency to the list of adjacencies.
   void addAdjacency(TypeVariableType *typeVar);

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -1183,7 +1183,7 @@ private:
     ///
     /// \param processor The processor function to be applied to each of
     /// the constraints retrieved.
-    void forEachRetired(std::function<void(Constraint &)> processor) {
+    void forEachRetired(llvm::function_ref<void(Constraint &)> processor) {
       for (auto &constraint : retiredConstraints)
         processor(constraint);
     }
@@ -2347,11 +2347,10 @@ public:
 
   /// \brief Subroutine of \c matchTypes(), used to bind a type to a
   /// type variable.
-  TypeMatchResult
-  matchTypesBindTypeVar(TypeVariableType *typeVar, Type type,
-                        ConstraintKind kind, TypeMatchOptions flags,
-                        ConstraintLocatorBuilder locator,
-                        std::function<TypeMatchResult()> formUnsolvedResult);
+  TypeMatchResult matchTypesBindTypeVar(
+      TypeVariableType *typeVar, Type type, ConstraintKind kind,
+      TypeMatchOptions flags, ConstraintLocatorBuilder locator,
+      llvm::function_ref<TypeMatchResult()> formUnsolvedResult);
 
 public: // FIXME: public due to statics in CSSimplify.cpp
   /// \brief Attempt to match up types \c type1 and \c type2, which in effect

--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -27,7 +27,7 @@
 using namespace swift;
 
 void LookupResult::filter(
-    const std::function<bool(LookupResultEntry, bool)> &pred) {
+    llvm::function_ref<bool(LookupResultEntry, bool)> pred) {
   size_t index = 0;
   size_t originalFirstOuter = IndexOfFirstOuterResult;
   Results.erase(std::remove_if(Results.begin(), Results.end(),

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -351,14 +351,14 @@ RequirementMatch
 swift::matchWitness(
              TypeChecker &tc,
              DeclContext *dc, ValueDecl *req, ValueDecl *witness,
-             const std::function<
+             llvm::function_ref<
                      std::tuple<Optional<RequirementMatch>, Type, Type>(void)> 
-               &setup,
-             const std::function<Optional<RequirementMatch>(Type, Type)> 
-               &matchTypes,
-             const std::function<
+               setup,
+             llvm::function_ref<Optional<RequirementMatch>(Type, Type)>
+               matchTypes,
+             llvm::function_ref<
                      RequirementMatch(bool, ArrayRef<OptionalAdjustment>)
-                   > &finalize) {
+                   > finalize) {
   assert(!req->isInvalid() && "Cannot have an invalid requirement here");
 
   /// Make sure the witness is of the same kind as the requirement.

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -830,14 +830,14 @@ public:
 RequirementMatch matchWitness(
              TypeChecker &tc,
              DeclContext *dc, ValueDecl *req, ValueDecl *witness,
-             const std::function<
+             llvm::function_ref<
                      std::tuple<Optional<RequirementMatch>, Type, Type>(void)>
-               &setup,
-             const std::function<Optional<RequirementMatch>(Type, Type)>
-               &matchTypes,
-             const std::function<
+               setup,
+             llvm::function_ref<Optional<RequirementMatch>(Type, Type)>
+               matchTypes,
+             llvm::function_ref<
                      RequirementMatch(bool, ArrayRef<OptionalAdjustment>)
-                   > &finalize);
+                   > finalize);
 
 RequirementMatch matchWitness(TypeChecker &tc,
                               ProtocolDecl *proto,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -148,7 +148,7 @@ public:
 
   /// Filter out any results that aren't accepted by the given predicate.
   void
-  filter(const std::function<bool(LookupResultEntry, /*isOuter*/ bool)> &pred);
+  filter(llvm::function_ref<bool(LookupResultEntry, /*isOuter*/ bool)> pred);
 };
 
 /// The result of name lookup for types.


### PR DESCRIPTION
`std::function` may need to allocate, which is totally unnecessary for non-escaping functions. `llvm::function_ref` covers this perfectly.