### PR TITLE
Revert "[Runtime] Assert that metadata mangled names successfully roundtrip."

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -4389,12 +4389,6 @@ void swift_getFieldAt(
     const Metadata *type, unsigned index,
     std::function<void(llvm::StringRef name, FieldType type)> callback);
 
-#if !NDEBUG
-/// Verify that the given metadata pointer correctly roundtrips its
-/// mangled name through the demangler.
-void verifyMangledNameRoundtrip(const Metadata *metadata);
-#endif
-
 } // end namespace swift
 
 #pragma clang diagnostic pop

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3914,28 +3914,3 @@ bool Metadata::satisfiesClassConstraint() const {
   // or it's a class.
   return isAnyClass();
 }
-
-#if !NDEBUG
-void swift::verifyMangledNameRoundtrip(const Metadata *metadata) {
-  // Disable verification when a special environment variable is set.
-  // Some metatypes crash when going through the mangler or demangler. A
-  // lot of tests currently trigger those crashes, resulting in failing
-  // tests which are still usefully testing something else. Tests are
-  // run with this variable set to avoid a ton of new test failures.
-  // When the tests are fixed, remove this.
-  bool verificationDisabled =
-    SWIFT_LAZY_CONSTANT((bool)getenv("SWIFT_DISABLE_MANGLED_NAME_VERIFICATION"));
-  
-  if (verificationDisabled) return;
-  
-  Demangle::Demangler Dem;
-  auto node = _swift_buildDemanglingForMetadata(metadata, Dem);
-  auto mangledName = Demangle::mangleNode(node);
-  auto result = _getTypeByMangledName(mangledName,
-                                      [](unsigned, unsigned){ return nullptr; });
-  if (metadata != result)
-    swift::warning(RuntimeErrorFlagNone,
-                   "Metadata mangled name failed to roundtrip: %p -> %s -> %p",
-                   metadata, mangledName.c_str(), (const Metadata *)result);
-}
-#endif

--- a/stdlib/public/runtime/MetadataCache.h
+++ b/stdlib/public/runtime/MetadataCache.h
@@ -925,10 +925,6 @@ private:
       awaitSatisfyingState(concurrency, request, curTrackingInfo);
     }
 
-#if !NDEBUG
-    verifyMangledNameRoundtrip(value);
-#endif
-
     return { value, curTrackingInfo.getAccomplishedRequestState() };
   }
 

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1157,10 +1157,6 @@ if config.lldb_build_root != "":
 # variable.
 config.environment[TARGET_ENV_PREFIX + 'SWIFT_DETERMINISTIC_HASHING'] = '1'
 
-# Disable mangled name roundtrip verification to avoid a ton of
-# not-very-useful test failures. Take this out once the bugs are fixed.
-config.environment[TARGET_ENV_PREFIX + 'SWIFT_DISABLE_MANGLED_NAME_VERIFICATION'] = '1'
-
 # Run lsb_release on the target to be tested and return the results.
 def linux_get_lsb_release():
     lsb_release_path = '/usr/bin/lsb_release'

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1702,10 +1702,7 @@ function set_swiftpm_bootstrap_command() {
         echo "Error: Cannot build swiftpm without llbuild (swift-build-tool)."
         exit 1
     fi
-    # Disable mangled name verification when bootstrapping swiftpm, as
-    # it triggers some failures. Remove the setting of
-    # SWIFT_DISABLE_MANGLED_NAME_VERIFICATION=1 once the bugs are fixed.
-    swiftpm_bootstrap_command=("env" "SWIFT_DISABLE_MANGLED_NAME_VERIFICATION=1" "${SWIFTPM_SOURCE_DIR}/Utilities/bootstrap" "${swiftpm_bootstrap_options[@]}")
+    swiftpm_bootstrap_command=("${SWIFTPM_SOURCE_DIR}/Utilities/bootstrap" "${swiftpm_bootstrap_options[@]}")
     # Add --release if we have to build in release mode.
     if [[ "${SWIFTPM_BUILD_TYPE}" ==  "Release" ]] ; then
         swiftpm_bootstrap_command+=(--release)
@@ -2999,11 +2996,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 SWIFT_DYLIB_PATH=$(build_directory ${host} swift)/lib/swift/macosx/
                 PLAYGROUNDLOGGER_FRAMEWORK_PATH=$(build_directory ${host} ${product})/DerivedData/Build/Products/${PLAYGROUNDSUPPORT_BUILD_TYPE}
                 pushd "${PLAYGROUNDLOGGER_FRAMEWORK_PATH}"
-                # Disable mangled name verification when running the
-                # test driver, as it triggers some failures. Remove the
-                # setting of SWIFT_DISABLE_MANGLED_NAME_VERIFICATION=1
-                # once the bugs are fixed.
-                SWIFT_DISABLE_MANGLED_NAME_VERIFICATION=1 DYLD_LIBRARY_PATH=$SWIFT_DYLIB_PATH DYLD_FRAMEWORK_PATH=$PLAYGROUNDLOGGER_FRAMEWORK_PATH ./PlaygroundLogger_TestDriver
+                DYLD_LIBRARY_PATH=$SWIFT_DYLIB_PATH DYLD_FRAMEWORK_PATH=$PLAYGROUNDLOGGER_FRAMEWORK_PATH ./PlaygroundLogger_TestDriver
                 popd
                 { set +x; } 2>/dev/null
                 continue


### PR DESCRIPTION
Reverts apple/swift#16188

The source compat bot is broken (well, probably the demangler but ...)