### PR TITLE
[Runtime] Disable mangled name verification unless specifically enabled with an environment variable.

### DIFF
--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3917,16 +3917,17 @@ bool Metadata::satisfiesClassConstraint() const {
 
 #if !NDEBUG
 void swift::verifyMangledNameRoundtrip(const Metadata *metadata) {
-  // Disable verification when a special environment variable is set.
+  // Enable verification when a special environment variable is set.
   // Some metatypes crash when going through the mangler or demangler. A
   // lot of tests currently trigger those crashes, resulting in failing
-  // tests which are still usefully testing something else. Tests are
-  // run with this variable set to avoid a ton of new test failures.
-  // When the tests are fixed, remove this.
-  bool verificationDisabled =
-    SWIFT_LAZY_CONSTANT((bool)getenv("SWIFT_DISABLE_MANGLED_NAME_VERIFICATION"));
+  // tests which are still usefully testing something else. This
+  // variable lets us easily turn on verification to find and fix these
+  // bugs. Remove this and leave it permanently on once everything works
+  // with it enabled.
+  bool verificationEnabled =
+    SWIFT_LAZY_CONSTANT((bool)getenv("SWIFT_ENABLE_MANGLED_NAME_VERIFICATION"));
   
-  if (verificationDisabled) return;
+  if (!verificationEnabled) return;
   
   Demangle::Demangler Dem;
   auto node = _swift_buildDemanglingForMetadata(metadata, Dem);

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -1157,10 +1157,6 @@ if config.lldb_build_root != "":
 # variable.
 config.environment[TARGET_ENV_PREFIX + 'SWIFT_DETERMINISTIC_HASHING'] = '1'
 
-# Disable mangled name roundtrip verification to avoid a ton of
-# not-very-useful test failures. Take this out once the bugs are fixed.
-config.environment[TARGET_ENV_PREFIX + 'SWIFT_DISABLE_MANGLED_NAME_VERIFICATION'] = '1'
-
 # Run lsb_release on the target to be tested and return the results.
 def linux_get_lsb_release():
     lsb_release_path = '/usr/bin/lsb_release'

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1702,10 +1702,7 @@ function set_swiftpm_bootstrap_command() {
         echo "Error: Cannot build swiftpm without llbuild (swift-build-tool)."
         exit 1
     fi
-    # Disable mangled name verification when bootstrapping swiftpm, as
-    # it triggers some failures. Remove the setting of
-    # SWIFT_DISABLE_MANGLED_NAME_VERIFICATION=1 once the bugs are fixed.
-    swiftpm_bootstrap_command=("env" "SWIFT_DISABLE_MANGLED_NAME_VERIFICATION=1" "${SWIFTPM_SOURCE_DIR}/Utilities/bootstrap" "${swiftpm_bootstrap_options[@]}")
+    swiftpm_bootstrap_command=("${SWIFTPM_SOURCE_DIR}/Utilities/bootstrap" "${swiftpm_bootstrap_options[@]}")
     # Add --release if we have to build in release mode.
     if [[ "${SWIFTPM_BUILD_TYPE}" ==  "Release" ]] ; then
         swiftpm_bootstrap_command+=(--release)
@@ -2999,11 +2996,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 SWIFT_DYLIB_PATH=$(build_directory ${host} swift)/lib/swift/macosx/
                 PLAYGROUNDLOGGER_FRAMEWORK_PATH=$(build_directory ${host} ${product})/DerivedData/Build/Products/${PLAYGROUNDSUPPORT_BUILD_TYPE}
                 pushd "${PLAYGROUNDLOGGER_FRAMEWORK_PATH}"
-                # Disable mangled name verification when running the
-                # test driver, as it triggers some failures. Remove the
-                # setting of SWIFT_DISABLE_MANGLED_NAME_VERIFICATION=1
-                # once the bugs are fixed.
-                SWIFT_DISABLE_MANGLED_NAME_VERIFICATION=1 DYLD_LIBRARY_PATH=$SWIFT_DYLIB_PATH DYLD_FRAMEWORK_PATH=$PLAYGROUNDLOGGER_FRAMEWORK_PATH ./PlaygroundLogger_TestDriver
+                DYLD_LIBRARY_PATH=$SWIFT_DYLIB_PATH DYLD_FRAMEWORK_PATH=$PLAYGROUNDLOGGER_FRAMEWORK_PATH ./PlaygroundLogger_TestDriver
                 popd
                 { set +x; } 2>/dev/null
                 continue


### PR DESCRIPTION
Finding all the things that mangled name verification broke and disabling verification for those cases has turned into a game of whack-a-mole. Instead, disable it by default. Developers hunting down bugs can enable it for bug-hunting. Once the bugs have been vanquished, we can turn it on for everything.

rdar://problem/39821779 rdar://problem/39821761 rdar://problem/39821758