### PR TITLE
[libSyntax] Verify the syntax tree generated by compiling the stdlib

### DIFF
--- a/stdlib/public/CMakeLists.txt
+++ b/stdlib/public/CMakeLists.txt
@@ -13,6 +13,8 @@ if(SWIFT_RUNTIME_USE_SANITIZERS)
   endif()
 endif()
 
+list(APPEND SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS "-Xfrontend" "-verify-syntax-tree")
+
 # Build the runtime with -Wall to catch, e.g., uninitialized variables
 # warnings.
 list(APPEND SWIFT_RUNTIME_CXX_FLAGS "-Wall")

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -139,7 +139,7 @@ DECL_NODES = [
                        'lazy', 'optional', 'override', 'postfix', 'prefix',
                        'required', 'static', 'unowned', 'weak', 'private',
                        'fileprivate', 'internal', 'public', 'open',
-                       'mutating', 'nonmutating', 'indirect',
+                       'mutating', 'nonmutating', 'indirect', '__consuming'
                    ]),
              Child('DetailLeftParen', kind='LeftParenToken', is_optional=True),
              Child('Detail', kind='IdentifierToken', is_optional=True),


### PR DESCRIPTION
In order to verify that libSyntax is able to parse about every Swift code, we would like to generate the libSyntax tree while building the standard library and verify that it contains no unknown nodes.