### PR TITLE
[Diagnostics & Tests] SR-6052 Prevent nil capitalization

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -310,7 +310,7 @@ ERROR(cannot_convert_initializer_value,none,
 ERROR(cannot_convert_initializer_value_protocol,none,
       "value of type %0 does not conform to specified type %1", (Type,Type))
 ERROR(cannot_convert_initializer_value_nil,none,
-      "nil cannot initialize specified type %0", (Type))
+      "'nil' cannot initialize specified type %0", (Type))
 
 ERROR(cannot_convert_to_return_type,none,
       "cannot convert return expression of type %0 to return type %1",
@@ -318,7 +318,7 @@ ERROR(cannot_convert_to_return_type,none,
 ERROR(cannot_convert_to_return_type_protocol,none,
       "return expression of type %0 does not conform to %1", (Type,Type))
 ERROR(cannot_convert_to_return_type_nil,none,
-      "nil is incompatible with return type %0", (Type))
+      "'nil' is incompatible with return type %0", (Type))
 
 ERROR(cannot_convert_thrown_type,none,
       "thrown expression type %0 does not conform to 'Error'", (Type))
@@ -327,13 +327,13 @@ ERROR(cannot_throw_error_code,none,
       "instance", (Type, Type))
 
 ERROR(cannot_throw_nil,none,
-      "cannot infer concrete Error for thrown 'nil' value", ())
+      "cannot infer concrete Error for thrown 'nil value", ())
 
 
 ERROR(cannot_convert_raw_initializer_value,none,
       "cannot convert value of type %0 to raw type %1", (Type,Type))
 ERROR(cannot_convert_raw_initializer_value_nil,none,
-      "cannot convert nil to raw type %0", (Type))
+      "cannot convert 'nil' to raw type %0", (Type))
 
 ERROR(cannot_convert_default_arg_value,none,
       "default argument value of type %0 cannot be converted to type %1",
@@ -356,7 +356,7 @@ ERROR(cannot_convert_partial_argument_value_protocol,none,
       "in argument type %0, %1 does not conform to expected type %2", (Type, Type, Type))
 
 ERROR(cannot_convert_argument_value_nil,none,
-      "nil is not compatible with expected argument type %0", (Type))
+      "'nil' is not compatible with expected argument type %0", (Type))
 
 ERROR(cannot_convert_closure_result,none,
       "cannot convert value of type %0 to closure result type %1",
@@ -365,7 +365,7 @@ ERROR(cannot_convert_closure_result_protocol,none,
       "result value of type %0 does not conform to closure result type %1",
       (Type, Type))
 ERROR(cannot_convert_closure_result_nil,none,
-      "nil is not compatible with closure result type %0", (Type))
+      "'nil' is not compatible with closure result type %0", (Type))
 
 ERROR(destructor_not_accessible,none,
       "deinitializers cannot be accessed", ())
@@ -378,7 +378,7 @@ ERROR(cannot_convert_array_element_protocol,none,
       "value of type %0 does not conform to expected element type %1",
       (Type, Type))
 ERROR(cannot_convert_array_element_nil,none,
-      "nil is not compatible with expected element type %0", (Type))
+      "'nil' is not compatible with expected element type %0", (Type))
 
 // Dictionary Key
 ERROR(cannot_convert_dict_key,none,
@@ -388,7 +388,7 @@ ERROR(cannot_convert_dict_key_protocol,none,
       "value of type %0 does not conform to expected dictionary key type %1",
       (Type, Type))
 ERROR(cannot_convert_dict_key_nil,none,
-      "nil is not compatible with expected dictionary key type %0", (Type))
+      "'nil' is not compatible with expected dictionary key type %0", (Type))
 
 // Dictionary Value
 ERROR(cannot_convert_dict_value,none,
@@ -398,7 +398,7 @@ ERROR(cannot_convert_dict_value_protocol,none,
       "value of type %0 does not conform to expected dictionary value type %1",
       (Type, Type))
 ERROR(cannot_convert_dict_value_nil,none,
-      "nil is not compatible with expected dictionary value type %0", (Type))
+      "'nil' is not compatible with expected dictionary value type %0", (Type))
 
 // Coerce Expr
 ERROR(cannot_convert_coerce,none,
@@ -408,7 +408,7 @@ ERROR(cannot_convert_coerce_protocol,none,
       "value of type %0 does not conform to %1 in coercion",
       (Type, Type))
 ERROR(cannot_convert_coerce_nil,none,
-      "nil is not compatible with type %0 in coercion", (Type))
+      "'nil' is not compatible with type %0 in coercion", (Type))
 
 // Assign Expr
 ERROR(cannot_convert_assign,none,
@@ -418,7 +418,7 @@ ERROR(cannot_convert_assign_protocol,none,
       "value of type %0 does not conform to %1 in assignment",
       (Type, Type))
 ERROR(cannot_convert_assign_nil,none,
-      "nil cannot be assigned to type %0", (Type))
+      "'nil' cannot be assigned to type %0", (Type))
 
 
 ERROR(throws_functiontype_mismatch,none,
@@ -847,7 +847,7 @@ WARNING(conditional_downcast_same_type,none,
         (Type, Type, unsigned))
 WARNING(is_expr_same_type,none,
         "checking a value with optional type %0 against dynamic type %1 "
-        "succeeds whenever the value is non-'nil'; did you mean to use "
+        "succeeds whenever the value is non-nil; did you mean to use "
         "'!= nil'?", (Type, Type))
 WARNING(downcast_to_unrelated,none,
         "cast from %0 to unrelated type %1 always fails", (Type, Type))
@@ -1396,7 +1396,7 @@ NOTE(objc_generic_extension_using_type_parameter_try_objc,none,
 ERROR(type_does_not_conform,none,
       "type %0 does not conform to protocol %1", (Type, Type))
 ERROR(cannot_use_nil_with_this_type,none,
-      "nil cannot be used in context expecting type %0", (Type))
+      "'nil' cannot be used in context expecting type %0", (Type))
 
 ERROR(use_of_equal_instead_of_equality,none,
       "use of '=' in a boolean context, did you mean '=='?", ())
@@ -2575,7 +2575,7 @@ ERROR(missing_protocol,none,
 ERROR(nil_literal_broken_proto,none,
       "protocol 'ExpressibleByNilLiteral' is broken", ())
 ERROR(array_protocol_broken,none,
-      "ExpressibleByArrayLiteral protocol definition is broken", ())
+      "protocol 'ExpressibleByArrayLiteral' is broken", ())
 ERROR(builtin_integer_literal_broken_proto,none,
       "protocol '_ExpressibleByBuiltinIntegerLiteral' is broken", ())
 ERROR(integer_literal_broken_proto,none,
@@ -2794,7 +2794,7 @@ WARNING(use_of_qq_on_non_optional_value,none,
         "left side of nil coalescing operator '?""?' has non-optional type %0, "
         "so the right side is never used", (Type))
 WARNING(nonoptional_compare_to_nil,none,
-        "comparing non-optional value of type %0 to nil always returns"
+        "comparing non-optional value of type %0 to 'nil' always returns"
         " %select{false|true}1", (Type, bool))
 WARNING(optional_check_nonoptional,none,
         "non-optional expression of type %0 used in a check for optionals",

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -327,7 +327,7 @@ ERROR(cannot_throw_error_code,none,
       "instance", (Type, Type))
 
 ERROR(cannot_throw_nil,none,
-      "cannot infer concrete Error for thrown 'nil value", ())
+      "cannot infer concrete Error for thrown 'nil' value", ())
 
 
 ERROR(cannot_convert_raw_initializer_value,none,

--- a/test/ClangImporter/cfuncs_parse.swift
+++ b/test/ClangImporter/cfuncs_parse.swift
@@ -153,7 +153,7 @@ func test_decay() {
 func test_nested_pointers() {
   nested_pointer(nil)
   nested_pointer_audited(nil)
-  nested_pointer_audited2(nil) // expected-error {{nil is not compatible with expected argument type 'UnsafePointer<UnsafePointer<Int32>?>'}}
+  nested_pointer_audited2(nil) // expected-error {{'nil' is not compatible with expected argument type 'UnsafePointer<UnsafePointer<Int32>?>'}}
 
   nested_pointer(0) // expected-error {{expected argument type 'UnsafePointer<UnsafePointer<Int32>?>?'}}
   nested_pointer_audited(0) // expected-error {{expected argument type 'UnsafePointer<UnsafePointer<Int32>>?'}}

--- a/test/ClangImporter/ctypes_parse.swift
+++ b/test/ClangImporter/ctypes_parse.swift
@@ -217,9 +217,9 @@ func testStructDefaultInit() {
 
 func testArrays() {
   nonnullArrayParameters([], [], [])
-  nonnullArrayParameters(nil, [], []) // expected-error {{nil is not compatible with expected argument type 'UnsafePointer<Int8>'}}
-  nonnullArrayParameters([], nil, []) // expected-error {{nil is not compatible with expected argument type 'UnsafePointer<UnsafeMutableRawPointer?>'}}
-  nonnullArrayParameters([], [], nil) // expected-error {{nil is not compatible with expected argument type 'UnsafePointer<Int32>'}}
+  nonnullArrayParameters(nil, [], []) // expected-error {{'nil' is not compatible with expected argument type 'UnsafePointer<Int8>'}}
+  nonnullArrayParameters([], nil, []) // expected-error {{'nil' is not compatible with expected argument type 'UnsafePointer<UnsafeMutableRawPointer?>'}}
+  nonnullArrayParameters([], [], nil) // expected-error {{'nil' is not compatible with expected argument type 'UnsafePointer<Int32>'}}
 
   nullableArrayParameters([], [], [])
   nullableArrayParameters(nil, nil, nil)
@@ -234,7 +234,7 @@ func testVaList() {
   withVaList([]) {
     hasVaList($0) // okay
   }
-  hasVaList(nil) // expected-error {{nil is not compatible with expected argument type 'CVaListPointer'}}
+  hasVaList(nil) // expected-error {{'nil' is not compatible with expected argument type 'CVaListPointer'}}
 }
 
 func testNestedForwardDeclaredStructs() {

--- a/test/ClangImporter/ctypes_parse_swift4.swift
+++ b/test/ClangImporter/ctypes_parse_swift4.swift
@@ -6,5 +6,5 @@ func testArrays() {
   // It would also be nice to warn here about the arrays being too short, but
   // that's probably beyond us for a while.
   staticBoundsArray([])
-  staticBoundsArray(nil) // expected-error {{nil is not compatible with expected argument type 'UnsafePointer<Int8>'}}
+  staticBoundsArray(nil) // expected-error {{'nil' is not compatible with expected argument type 'UnsafePointer<Int8>'}}
 }

--- a/test/ClangImporter/nullability.swift
+++ b/test/ClangImporter/nullability.swift
@@ -7,11 +7,11 @@ import CoreCooling
 func testSomeClass(_ sc: SomeClass, osc: SomeClass?) {
   let ao1: Any = sc.methodA(osc)
   _ = ao1
-  if sc.methodA(osc) == nil { } // expected-warning {{comparing non-optional value of type 'Any' to nil always returns false}}
+  if sc.methodA(osc) == nil { } // expected-warning {{comparing non-optional value of type 'Any' to 'nil' always returns false}}
 
   let ao2: Any = sc.methodB(nil)
   _ = ao2
-  if sc.methodA(osc) == nil { }// expected-warning {{comparing non-optional value of type 'Any' to nil always returns false}}
+  if sc.methodA(osc) == nil { }// expected-warning {{comparing non-optional value of type 'Any' to 'nil' always returns false}}
 
   let ao3: Any? = sc.property.flatMap { .some($0) }
   _ = ao3
@@ -20,7 +20,7 @@ func testSomeClass(_ sc: SomeClass, osc: SomeClass?) {
 
   let ao4: Any = sc.methodD()
   _ = ao4
-  if sc.methodD() == nil { } // expected-warning {{comparing non-optional value of type 'Any' to nil always returns false}}
+  if sc.methodD() == nil { } // expected-warning {{comparing non-optional value of type 'Any' to 'nil' always returns false}}
 
   sc.methodE(sc)
   sc.methodE(osc) // expected-error{{value of optional type 'SomeClass?' not unwrapped; did you mean to use '!' or '?'?}} {{17-17=!}}
@@ -37,7 +37,7 @@ func testSomeClass(_ sc: SomeClass, osc: SomeClass?) {
   let sc2 = SomeClass(int: ci)
   let sc2a: SomeClass = sc2
   _ = sc2a
-  if sc2 == nil { } // expected-warning {{comparing non-optional value of type 'SomeClass' to nil always returns false}}
+  if sc2 == nil { } // expected-warning {{comparing non-optional value of type 'SomeClass' to 'nil' always returns false}}
 
   let sc3 = SomeClass(double: 1.5)
   if sc3 == nil { } // okay
@@ -47,13 +47,13 @@ func testSomeClass(_ sc: SomeClass, osc: SomeClass?) {
   let sc4 = sc.returnMe()
   let sc4a: SomeClass = sc4
   _ = sc4a
-  if sc4 == nil { } // expected-warning {{comparing non-optional value of type 'SomeClass' to nil always returns false}}
+  if sc4 == nil { } // expected-warning {{comparing non-optional value of type 'SomeClass' to 'nil' always returns false}}
 }
 
 // Nullability with CF types.
 func testCF(_ fridge: CCRefrigerator) {
   CCRefrigeratorOpenDoSomething(fridge) // okay
-  CCRefrigeratorOpenDoSomething(nil) // expected-error{{nil is not compatible with expected argument type 'CCRefrigerator'}}
+  CCRefrigeratorOpenDoSomething(nil) // expected-error{{'nil' is not compatible with expected argument type 'CCRefrigerator'}}
 
   CCRefrigeratorOpenMaybeDoSomething(fridge) // okay
   CCRefrigeratorOpenMaybeDoSomething(nil) // okay

--- a/test/Constraints/array_literal.swift
+++ b/test/Constraints/array_literal.swift
@@ -44,7 +44,7 @@ func useDict<K,V>(_ d: Dict<K,V>) {}
 
 useIntList([1,2,3])
 useIntList([1.0,2,3]) // expected-error{{cannot convert value of type 'Double' to expected element type 'Int'}}
-useIntList([nil])  // expected-error {{nil is not compatible with expected element type 'Int'}}
+useIntList([nil])  // expected-error {{'nil' is not compatible with expected element type 'Int'}}
 
 useDoubleList([1.0,2,3])
 useDoubleList([1.0,2.0,3.0])

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -210,7 +210,7 @@ class r20201968C {
 // <rdar://problem/21459429> QoI: Poor compilation error calling assert
 func r21459429(_ a : Int) {
   assert(a != nil, "ASSERT COMPILATION ERROR")
-  // expected-warning @-1 {{comparing non-optional value of type 'Int' to nil always returns true}}
+  // expected-warning @-1 {{comparing non-optional value of type 'Int' to 'nil' always returns true}}
 }
 
 
@@ -486,12 +486,44 @@ class B {
   static func f1(_ a : AOpts) {}
 }
 
+class GenClass<T> {}
+struct GenStruct<T> {}
+enum GenEnum<T> {}
 
 func test(_ a : B) {
-  B.f1(nil)    // expected-error {{nil is not compatible with expected argument type 'AOpts'}}
-  a.function(42, a: nil) //expected-error {{nil is not compatible with expected argument type 'AOpts'}}
-  a.function(42, nil) //expected-error {{missing argument label 'a:' in call}}
-  a.f2(nil)  // expected-error {{nil is not compatible with expected argument type 'AOpts'}}
+  B.f1(nil)              // expected-error {{'nil' is not compatible with expected argument type 'AOpts'}}
+  a.function(42, a: nil) // expected-error {{'nil' is not compatible with expected argument type 'AOpts'}}
+  a.function(42, nil)    // expected-error {{missing argument label 'a:' in call}}
+  a.f2(nil)              // expected-error {{'nil' is not compatible with expected argument type 'AOpts'}}
+
+  func foo1(_ arg: Bool) -> Int {return nil}
+  func foo2<T>(_ arg: T) -> GenClass<T> {return nil}
+  func foo3<T>(_ arg: T) -> GenStruct<T> {return nil}
+  func foo4<T>(_ arg: T) -> GenEnum<T> {return nil}
+  // expected-error@-4 {{'nil' is incompatible with return type 'Int'}}
+  // expected-error@-4 {{'nil' is incompatible with return type 'GenClass<T>'}}
+  // expected-error@-4 {{'nil' is incompatible with return type 'GenStruct<T>'}}
+  // expected-error@-4 {{'nil' is incompatible with return type 'GenEnum<T>'}}
+
+  let clsr1: () -> Int = {return nil}
+  let clsr2: () -> GenClass<Bool> = {return nil}
+  let clsr3: () -> GenStruct<String> = {return nil}
+  let clsr4: () -> GenEnum<Double?> = {return nil}
+  // expected-error@-4 {{'nil' is not compatible with closure result type 'Int'}}
+  // expected-error@-4 {{'nil' is not compatible with closure result type 'GenClass<Bool>'}}
+  // expected-error@-4 {{'nil' is not compatible with closure result type 'GenStruct<String>'}}
+  // expected-error@-4 {{'nil' is not compatible with closure result type 'GenEnum<Double?>'}}
+
+  var number = 0
+  var genClassBool = GenClass<Bool>()
+  var funcFoo1 = foo1
+
+  number = nil
+  genClassBool = nil
+  funcFoo1 = nil
+  // expected-error@-3 {{'nil' cannot be assigned to type 'Int'}}
+  // expected-error@-3 {{'nil' cannot be assigned to type 'GenClass<Bool>'}}
+  // expected-error@-3 {{'nil' cannot be assigned to type '(Bool) -> Int'}}
 }
 
 // <rdar://problem/21684487> QoI: invalid operator use inside a closure reported as a problem with the closure
@@ -507,7 +539,7 @@ func r21684487() {
 func r18397777(_ d : r21447318?) {
   let c = r21447318()
 
-  if c != nil { // expected-warning {{comparing non-optional value of type 'r21447318' to nil always returns true}}
+  if c != nil { // expected-warning {{comparing non-optional value of type 'r21447318' to 'nil' always returns true}}
   }
   
   if d {  // expected-error {{optional type 'r21447318?' cannot be used as a boolean; test for '!= nil' instead}} {{6-6=(}} {{7-7= != nil)}}
@@ -687,18 +719,18 @@ class SR1594 {
   func sr1594(bytes : UnsafeMutablePointer<Int>, _ i : Int?) {
     _ = (i === nil) // expected-error {{value of type 'Int?' cannot be compared by reference; did you mean to compare by value?}} {{12-15===}}
     _ = (bytes === nil) // expected-error {{type 'UnsafeMutablePointer<Int>' is not optional, value can never be nil}}
-    _ = (self === nil) // expected-warning {{comparing non-optional value of type 'AnyObject' to nil always returns false}}
+    _ = (self === nil) // expected-warning {{comparing non-optional value of type 'AnyObject' to 'nil' always returns false}}
     _ = (i !== nil) // expected-error {{value of type 'Int?' cannot be compared by reference; did you mean to compare by value?}} {{12-15=!=}}
     _ = (bytes !== nil) // expected-error {{type 'UnsafeMutablePointer<Int>' is not optional, value can never be nil}}
-    _ = (self !== nil) // expected-warning {{comparing non-optional value of type 'AnyObject' to nil always returns true}}
+    _ = (self !== nil) // expected-warning {{comparing non-optional value of type 'AnyObject' to 'nil' always returns true}}
   }
 }
 
 func nilComparison(i: Int, o: AnyObject) {
-  _ = i == nil // expected-warning {{comparing non-optional value of type 'Int' to nil always returns false}}
-  _ = nil == i // expected-warning {{comparing non-optional value of type 'Int' to nil always returns false}}
-  _ = i != nil // expected-warning {{comparing non-optional value of type 'Int' to nil always returns true}}
-  _ = nil != i // expected-warning {{comparing non-optional value of type 'Int' to nil always returns true}}
+  _ = i == nil // expected-warning {{comparing non-optional value of type 'Int' to 'nil' always returns false}}
+  _ = nil == i // expected-warning {{comparing non-optional value of type 'Int' to 'nil' always returns false}}
+  _ = i != nil // expected-warning {{comparing non-optional value of type 'Int' to 'nil' always returns true}}
+  _ = nil != i // expected-warning {{comparing non-optional value of type 'Int' to 'nil' always returns true}}
   
   // FIXME(integers): uncomment these tests once the < is no longer ambiguous
   // _ = i < nil  // _xpected-error {{type 'Int' is not optional, value can never be nil}}
@@ -710,8 +742,8 @@ func nilComparison(i: Int, o: AnyObject) {
   // _ = i >= nil // _xpected-error {{type 'Int' is not optional, value can never be nil}}
   // _ = nil >= i // _xpected-error {{type 'Int' is not optional, value can never be nil}}
 
-  _ = o === nil // expected-warning {{comparing non-optional value of type 'AnyObject' to nil always returns false}}
-  _ = o !== nil // expected-warning {{comparing non-optional value of type 'AnyObject' to nil always returns true}}
+  _ = o === nil // expected-warning {{comparing non-optional value of type 'AnyObject' to 'nil' always returns false}}
+  _ = o !== nil // expected-warning {{comparing non-optional value of type 'AnyObject' to 'nil' always returns true}}
 }
 
 func secondArgumentNotLabeled(a: Int, _ b: Int) { }

--- a/test/Constraints/dictionary_literal.swift
+++ b/test/Constraints/dictionary_literal.swift
@@ -18,11 +18,20 @@ func useDict<K, V>(_ d: Dictionary<K,V>) {}
 // Concrete dictionary literals.
 useDictStringInt(["Hello" : 1])
 useDictStringInt(["Hello" : 1, "World" : 2])
-useDictStringInt(["Hello" : 1, "World" : 2.5]) // expected-error{{cannot convert value of type 'Double' to expected dictionary value type 'Int'}}
-useDictStringInt([4.5 : 2]) // expected-error{{cannot convert value of type 'Double' to expected dictionary key type 'String'}}
-useDictStringInt([nil : 2]) // expected-error{{nil is not compatible with expected dictionary key type 'String'}}
+useDictStringInt(["Hello" : 1, "World" : 2.5])
+// expected-error@-1 {{cannot convert value of type 'Double' to expected dictionary value type 'Int'}}
+useDictStringInt([4.5 : 2])
+// expected-error@-1 {{cannot convert value of type 'Double' to expected dictionary key type 'String'}}
+useDictStringInt([nil : 2])
+// expected-error@-1 {{'nil' is not compatible with expected dictionary key type 'String'}}
+useDictStringInt([7 : 1, "World" : 2])
+// expected-error@-1 {{cannot convert value of type 'Int' to expected dictionary key type 'String'}}
+useDictStringInt(["Hello" : nil])
+// expected-error@-1 {{'nil' is not compatible with expected dictionary value type 'Int'}}
 
-useDictStringInt([7 : 1, "World" : 2]) // expected-error{{cannot convert value of type 'Int' to expected dictionary key type 'String'}}
+typealias FuncBoolToInt = (Bool) -> Int
+let dict1: Dictionary<String, FuncBoolToInt> = ["Hello": nil]
+// expected-error@-1 {{'nil' is not compatible with expected dictionary value type '(Bool) -> Int'}}
 
 // Generic dictionary literals.
 useDict(["Hello" : 1])

--- a/test/Parse/enum.swift
+++ b/test/Parse/enum.swift
@@ -437,7 +437,7 @@ enum RawValueBTest: Double, RawValueB {
 }
 
 enum foo : String { // expected-error {{'foo' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized}}
-  case bar = nil // expected-error {{cannot convert nil to raw type 'String'}}
+  case bar = nil // expected-error {{cannot convert 'nil' to raw type 'String'}}
 }
 
 // Static member lookup from instance methods

--- a/test/Parse/pointer_conversion.swift.gyb
+++ b/test/Parse/pointer_conversion.swift.gyb
@@ -40,7 +40,7 @@ func mutablePointerArguments(_ p: UnsafeMutablePointer<Int>,
                              cp: UnsafePointer<Int>) {
   takesMutablePointer(nil)
 % if not suffix:
-  // expected-error@-2 {{nil is not compatible with expected argument type}}
+  // expected-error@-2 {{'nil' is not compatible with expected argument type}}
 % end
 
   takesMutablePointer(p)
@@ -72,7 +72,7 @@ func mutableVoidPointerArguments(_ p: UnsafeMutablePointer<Int>,
                                  fp: UnsafeMutablePointer<Float>) {
   takesMutableVoidPointer(nil)
 % if not suffix:
-  // expected-error@-2 {{nil is not compatible with expected argument type}}
+  // expected-error@-2 {{'nil' is not compatible with expected argument type}}
 % end
 
   takesMutableVoidPointer(p)
@@ -106,7 +106,7 @@ func mutableRawPointerArguments(_ p: UnsafeMutablePointer<Int>,
                                 rp: UnsafeRawPointer) {
   takesMutableRawPointer(nil)
 % if not suffix:
-  // expected-error@-2 {{nil is not compatible with expected argument type}}
+  // expected-error@-2 {{'nil' is not compatible with expected argument type}}
 % end
 
   takesMutableRawPointer(p)
@@ -139,7 +139,7 @@ func constPointerArguments(_ p: UnsafeMutablePointer<Int>,
                            cp: UnsafePointer<Int>) {
   takesConstPointer(nil)
 % if not suffix:
-  // expected-error@-2 {{nil is not compatible with expected argument type}}
+  // expected-error@-2 {{'nil' is not compatible with expected argument type}}
 % end
 
   takesConstPointer(p)
@@ -171,7 +171,7 @@ func constVoidPointerArguments(_ p: UnsafeMutablePointer<Int>,
                                cfp: UnsafePointer<Float>) {
   takesConstVoidPointer(nil)
 % if not suffix:
-  // expected-error@-2 {{nil is not compatible with expected argument type}}
+  // expected-error@-2 {{'nil' is not compatible with expected argument type}}
 % end
 
   takesConstVoidPointer(p)
@@ -210,7 +210,7 @@ func constRawPointerArguments(_ p: UnsafeMutablePointer<Int>,
                                mrp: UnsafeMutableRawPointer) {
   takesConstRawPointer(nil)
 % if not suffix:
-  // expected-error@-2 {{nil is not compatible with expected argument type}}
+  // expected-error@-2 {{'nil' is not compatible with expected argument type}}
 % end
 
   takesConstRawPointer(p)

--- a/test/Parse/pointer_conversion_objc.swift.gyb
+++ b/test/Parse/pointer_conversion_objc.swift.gyb
@@ -52,7 +52,7 @@ func autoreleasingPointerArguments(p: UnsafeMutablePointer<Int>,
                                    ap: AutoreleasingUnsafeMutablePointer<C>) {
   takesAutoreleasingPointer(nil)
 % if not suffix:
-  // expected-error@-2 {{nil is not compatible with expected argument type}}
+  // expected-error@-2 {{'nil' is not compatible with expected argument type}}
 % end
 
   takesAutoreleasingPointer(p) // expected-error{{cannot convert value of type 'UnsafeMutablePointer<Int>' to expected argument type 'AutoreleasingUnsafeMutablePointer<C>${diag_suffix}'}}

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -50,10 +50,10 @@ let _ = wrapped // expected-error {{use of unresolved identifier 'wrapped'}}
 let _ = unwrapped // okay
 
 _ = usesWrapped(nil) // expected-error {{use of unresolved identifier 'usesWrapped'}}
-_ = usesUnwrapped(nil) // expected-error {{nil is not compatible with expected argument type 'Int32'}}
+_ = usesUnwrapped(nil) // expected-error {{'nil' is not compatible with expected argument type 'Int32'}}
 
 let _: WrappedAlias = nil // expected-error {{use of undeclared type 'WrappedAlias'}}
-let _: UnwrappedAlias = nil // expected-error {{nil cannot initialize specified type 'UnwrappedAlias' (aka 'Int32')}} expected-note {{add '?'}}
+let _: UnwrappedAlias = nil // expected-error {{'nil' cannot initialize specified type 'UnwrappedAlias' (aka 'Int32')}} expected-note {{add '?'}}
 
 let _: ConstrainedWrapped<Int> = nil // expected-error {{use of undeclared type 'ConstrainedWrapped'}}
 let _: ConstrainedUnwrapped<Int> = nil // expected-error {{type 'Int' does not conform to protocol 'HasAssoc'}}

--- a/test/decl/init/nil.swift
+++ b/test/decl/init/nil.swift
@@ -1,29 +1,29 @@
 // RUN: %target-typecheck-verify-swift
 
 var a: Int = nil
-// expected-error@-1 {{nil cannot initialize specified type 'Int'}} 
+// expected-error@-1 {{'nil' cannot initialize specified type 'Int'}}
 // expected-note@-2 {{add '?' to form the optional type 'Int?'}} {{11-11=?}}
 
 var b: () -> Void = nil
-// expected-error@-1 {{nil cannot initialize specified type '() -> Void'}} 
+// expected-error@-1 {{'nil' cannot initialize specified type '() -> Void'}}
 // expected-note@-2 {{add '?' to form the optional type '(() -> Void)?'}} {{8-8=(}} {{18-18=)?}}
 
 var c, d: Int = nil
 // expected-error@-1 {{type annotation missing in pattern}}
-// expected-error@-2 {{nil cannot initialize specified type 'Int'}} 
+// expected-error@-2 {{'nil' cannot initialize specified type 'Int'}}
 // expected-note@-3 {{add '?' to form the optional type 'Int?'}} {{14-14=?}}
 
 var (e, f): (Int, Int) = nil
-// expected-error@-1 {{nil cannot initialize specified type '(Int, Int)'}} 
+// expected-error@-1 {{'nil' cannot initialize specified type '(Int, Int)'}}
 
 var g: Int = nil, h: Int = nil
-// expected-error@-1 {{nil cannot initialize specified type 'Int'}} 
+// expected-error@-1 {{'nil' cannot initialize specified type 'Int'}}
 // expected-note@-2 {{add '?' to form the optional type 'Int?'}} {{11-11=?}}
-// expected-error@-3 {{nil cannot initialize specified type 'Int'}} 
+// expected-error@-3 {{'nil' cannot initialize specified type 'Int'}}
 // expected-note@-4 {{add '?' to form the optional type 'Int?'}} {{25-25=?}}
 
 var _: Int = nil
-// expected-error@-1 {{nil cannot initialize specified type 'Int'}} 
+// expected-error@-1 {{'nil' cannot initialize specified type 'Int'}}
 // expected-note@-2 {{add '?' to form the optional type 'Int?'}} {{11-11=?}}
 
 // 'nil' can initialize the specified type, if its generic parameters are bound

--- a/test/expr/cast/bridged.swift
+++ b/test/expr/cast/bridged.swift
@@ -85,8 +85,8 @@ func testBridgeDowncastExact(_ obj: BridgedClass, objOpt: BridgedClass?,
   _ = objImplicitOpt as! BridgedStruct // expected-warning{{forced cast from 'BridgedClass?' to 'BridgedStruct' only unwraps and bridges; did you mean to use '!' with 'as'?}}{{21-21=!}}{{22-25=as}}
 
   _ = obj is BridgedStruct // expected-warning{{'is' test is always true}}
-  _ = objOpt is BridgedStruct // expected-warning{{checking a value with optional type 'BridgedClass?' against dynamic type 'BridgedStruct' succeeds whenever the value is non-'nil'; did you mean to use '!= nil'?}}{{14-30=!= nil}}
-  _ = objImplicitOpt is BridgedStruct // expected-warning{{checking a value with optional type 'BridgedClass?' against dynamic type 'BridgedStruct' succeeds whenever the value is non-'nil'; did you mean to use '!= nil'?}}{{22-38=!= nil}}
+  _ = objOpt is BridgedStruct // expected-warning{{checking a value with optional type 'BridgedClass?' against dynamic type 'BridgedStruct' succeeds whenever the value is non-nil; did you mean to use '!= nil'?}}{{14-30=!= nil}}
+  _ = objImplicitOpt is BridgedStruct // expected-warning{{checking a value with optional type 'BridgedClass?' against dynamic type 'BridgedStruct' succeeds whenever the value is non-nil; did you mean to use '!= nil'?}}{{22-38=!= nil}}
 }
 
 func testExplicitBridging(_ object: BridgedClass, value: BridgedStruct) {

--- a/test/expr/cast/nil_value_to_optional.swift
+++ b/test/expr/cast/nil_value_to_optional.swift
@@ -5,8 +5,8 @@ var f = false
 
 func markUsed<T>(_ t: T) {}
 
-markUsed(t != nil) // expected-warning {{comparing non-optional value of type 'Bool' to nil always returns true}}
-markUsed(f != nil) // expected-warning {{comparing non-optional value of type 'Bool' to nil always returns true}}
+markUsed(t != nil) // expected-warning {{comparing non-optional value of type 'Bool' to 'nil' always returns true}}
+markUsed(f != nil) // expected-warning {{comparing non-optional value of type 'Bool' to 'nil' always returns true}}
 
 class C : Equatable {}
 
@@ -15,7 +15,7 @@ func == (lhs: C, rhs: C) -> Bool {
 }
 
 func test(_ c: C) {
-  if c == nil {}  // expected-warning {{comparing non-optional value of type 'C' to nil always returns false}}
+  if c == nil {}  // expected-warning {{comparing non-optional value of type 'C' to 'nil' always returns false}}
 }
 
 class D {}

--- a/test/expr/cast/optional.swift
+++ b/test/expr/cast/optional.swift
@@ -26,8 +26,8 @@ func f1(i: Int?, ii: Int??, a: [Base]?, d: [Base : Base]?, de: Derived?) {
   _ = de as? Base // expected-warning{{conditional downcast from 'Derived?' to 'Base' is equivalent to an implicit conversion to an optional 'Base'}}{{9-18=}}
 
   // "is" checks
-  _ = i is Int // expected-warning{{checking a value with optional type 'Int?' against dynamic type 'Int' succeeds whenever the value is non-'nil'; did you mean to use '!= nil'?}}{{9-15=!= nil}}
-  _ = i..<1 is Int // expected-warning{{checking a value with optional type 'Int?' against dynamic type 'Int' succeeds whenever the value is non-'nil'; did you mean to use '!= nil'?}}{{7-7=(}}{{12-12=)}}{{13-19=!= nil}}
+  _ = i is Int // expected-warning{{checking a value with optional type 'Int?' against dynamic type 'Int' succeeds whenever the value is non-nil; did you mean to use '!= nil'?}}{{9-15=!= nil}}
+  _ = i..<1 is Int // expected-warning{{checking a value with optional type 'Int?' against dynamic type 'Int' succeeds whenever the value is non-nil; did you mean to use '!= nil'?}}{{7-7=(}}{{12-12=)}}{{13-19=!= nil}}
   _ = ii is Int
 
   _ = i..<1 is Bool // expected-warning{{cast from 'Int?' to unrelated type 'Bool' always fails}}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -743,10 +743,10 @@ func invalidDictionaryLiteral() {
 //===----------------------------------------------------------------------===//
 // nil/metatype comparisons
 //===----------------------------------------------------------------------===//
-_ = Int.self == nil  // expected-warning {{comparing non-optional value of type 'Any.Type' to nil always returns false}}
-_ = nil == Int.self  // expected-warning {{comparing non-optional value of type 'Any.Type' to nil always returns false}}
-_ = Int.self != nil  // expected-warning {{comparing non-optional value of type 'Any.Type' to nil always returns true}}
-_ = nil != Int.self  // expected-warning {{comparing non-optional value of type 'Any.Type' to nil always returns true}}
+_ = Int.self == nil  // expected-warning {{comparing non-optional value of type 'Any.Type' to 'nil' always returns false}}
+_ = nil == Int.self  // expected-warning {{comparing non-optional value of type 'Any.Type' to 'nil' always returns false}}
+_ = Int.self != nil  // expected-warning {{comparing non-optional value of type 'Any.Type' to 'nil' always returns true}}
+_ = nil != Int.self  // expected-warning {{comparing non-optional value of type 'Any.Type' to 'nil' always returns true}}
 
 // <rdar://problem/19032294> Disallow postfix ? when not chaining
 func testOptionalChaining(_ a : Int?, b : Int!, c : Int??) {


### PR DESCRIPTION
Apart from preventing capitalization in Xcode, this provides better semantic background by surrounding 'nil' in ticks when it is referred to as a literal.
Also added missing tests for certain cases involving nil capitalization.

Resolves [SR-6052](https://bugs.swift.org/browse/SR-6052).