### PR TITLE
[+0-all-args] Change _swift_stdlib_bridgeErrorToNSError to take its p…

### DIFF
--- a/stdlib/public/core/ErrorType.swift
+++ b/stdlib/public/core/ErrorType.swift
@@ -174,7 +174,7 @@ internal func _getErrorDefaultUserInfo<T: Error>(_ error: T) -> AnyObject?
 /// Provided by the ErrorObject implementation.
 /// Called by the casting machinery and by the Foundation overlay.
 @_silgen_name("_swift_stdlib_bridgeErrorToNSError")
-public func _bridgeErrorToNSError(_ error: Error) -> AnyObject
+public func _bridgeErrorToNSError(_ error: __owned Error) -> AnyObject
 #endif
 
 /// Invoked by the compiler when the subexpression of a `try!` expression

--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -1975,10 +1975,7 @@ static id dynamicCastValueToNSError(OpaqueValue *src,
   BoxPair errorBox = swift_allocError(srcType, srcErrorWitness, src,
                             /*isTake*/ flags & DynamicCastFlags::TakeOnSuccess);
   auto *error = (SwiftError *)errorBox.object;
-  id result =  _swift_stdlib_bridgeErrorToNSError(error);
-  // Now that we have bridged the error to nserror, release the error.
-  SWIFT_CC_PLUSZERO_GUARD(swift_errorRelease(error));
-  return result;
+  return _swift_stdlib_bridgeErrorToNSError(error);
 }
 
 #endif

--- a/stdlib/public/runtime/ErrorObject.h
+++ b/stdlib/public/runtime/ErrorObject.h
@@ -218,6 +218,8 @@ void swift_unexpectedError(SwiftError *object);
 #if SWIFT_OBJC_INTEROP
 
 /// Initialize an Error box to make it usable as an NSError instance.
+///
+/// errorObject is assumed to be passed at +1 and consumed in this function.
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_SPI
 id _swift_stdlib_bridgeErrorToNSError(SwiftError *errorObject);
 

--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -392,7 +392,8 @@ NSDictionary *_swift_stdlib_getErrorDefaultUserInfo(OpaqueValue *error,
   return foundationGetDefaultUserInfo(error, T, Error);
 }
 
-/// Take an Error box and turn it into a valid NSError instance.
+/// Take an Error box and turn it into a valid NSError instance. Error is passed
+/// at +1.
 id
 swift::_swift_stdlib_bridgeErrorToNSError(SwiftError *errorObject) {
   auto ns = reinterpret_cast<NSError *>(errorObject);
@@ -410,7 +411,6 @@ swift::_swift_stdlib_bridgeErrorToNSError(SwiftError *errorObject) {
   // that the domain can be used alone as a flag for the initialization of the
   // object.
   if (errorObject->domain.load(std::memory_order_acquire)) {
-    SWIFT_CC_PLUSZERO_GUARD([ns retain]);
     return ns;
   }
 
@@ -453,7 +453,6 @@ swift::_swift_stdlib_bridgeErrorToNSError(SwiftError *errorObject) {
                                                    std::memory_order_acq_rel))
     objc_release(domain);
 
-  SWIFT_CC_PLUSZERO_GUARD([ns retain]);
   return ns;
 }
 


### PR DESCRIPTION
…arameter at +1.

This is truly a consuming operation. This can be seen since we always would need
to retain the argument here. This makes guaranteed -> owned less transformation
effective. Instead represent it taking a +1 argument so that the retain happens
outside the builtin instead of inside the builtin.

This also allows me to remove an extra copy from dynamicCastValueToNSError

rdar://38771331
