### PR TITLE
[4.2] RecoverableError's resultHandler needs @escaping 

### DIFF
--- a/stdlib/public/SDK/Foundation/NSError.swift
+++ b/stdlib/public/SDK/Foundation/NSError.swift
@@ -109,7 +109,7 @@ public protocol RecoverableError : Error {
   /// "document" granularity, that do not affect the entire
   /// application.
   func attemptRecovery(optionIndex recoveryOptionIndex: Int,
-                       resultHandler handler: (_ recovered: Bool) -> Void)
+                       resultHandler handler: @escaping (_ recovered: Bool) -> Void)
 
   /// Attempt to recover from this error when the user selected the
   /// option at the given index. Returns true to indicate
@@ -127,7 +127,7 @@ public extension RecoverableError {
   /// mechanism (``attemptRecovery(optionIndex:)``) to implement
   /// document-modal recovery.
   func attemptRecovery(optionIndex recoveryOptionIndex: Int,
-                       resultHandler handler: (_ recovered: Bool) -> Void) {
+                       resultHandler handler: @escaping (_ recovered: Bool) -> Void) {
     handler(attemptRecovery(optionIndex: recoveryOptionIndex))
   }
 }


### PR DESCRIPTION
**What's in this pull request?**
Cherry-picks #16182 to `swift-4.2-branch`.