### PR TITLE
Remove no longer needed SDK Overlay EPOCH macro definitions.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -484,36 +484,6 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
       // Avoid including the iso646.h header because some headers from OS X
       // frameworks are broken by it.
       "-D_ISO646_H_", "-D__ISO646_H",
-
-      // Request new APIs from AppKit.
-      "-DSWIFT_SDK_OVERLAY_APPKIT_EPOCH=2",
-
-      // Request new APIs from Foundation.
-      "-DSWIFT_SDK_OVERLAY_FOUNDATION_EPOCH=8",
-
-      // Request new APIs from SceneKit.
-      "-DSWIFT_SDK_OVERLAY2_SCENEKIT_EPOCH=3",
-
-      // Request new APIs from GameplayKit.
-      "-DSWIFT_SDK_OVERLAY_GAMEPLAYKIT_EPOCH=1",
-
-      // Request new APIs from SpriteKit.
-      "-DSWIFT_SDK_OVERLAY_SPRITEKIT_EPOCH=1",
-
-      // Request new APIs from CoreImage.
-      "-DSWIFT_SDK_OVERLAY_COREIMAGE_EPOCH=2",
-
-      // Request new APIs from libdispatch.
-      "-DSWIFT_SDK_OVERLAY_DISPATCH_EPOCH=2",
-
-      // Request new APIs from libpthread
-      "-DSWIFT_SDK_OVERLAY_PTHREAD_EPOCH=1",
-
-      // Request new APIs from CoreGraphics.
-      "-DSWIFT_SDK_OVERLAY_COREGRAPHICS_EPOCH=0",
-
-      // Request new APIs from UIKit.
-      "-DSWIFT_SDK_OVERLAY_UIKIT_EPOCH=2",
     });
 
     // Get the version of this compiler and pass it to C/Objective-C


### PR DESCRIPTION
This removes the SDK overlay "EPOCH" macro definitions.

These were previously used to stage in SDK changes, but
they are no longer needed.