### PR TITLE
Windows: further improve module maps

### DIFF
--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -99,9 +99,14 @@ module ucrt [system] {
     }
   }
 
-  module io {
-    header "corecrt_io.h"
+  module corecrt {
+    header "corecrt.h"
     export *
+
+    module io {
+      header "corecrt_io.h"
+      export *
+    }
   }
 }
 

--- a/stdlib/public/Platform/visualc.modulemap
+++ b/stdlib/public/Platform/visualc.modulemap
@@ -21,6 +21,11 @@ module visualc [system] {
     export *
   }
 
+  module vcruntime {
+    header "vcruntime.h"
+    export *
+  }
+
   module stdint {
     header "stdint.h"
     export *


### PR DESCRIPTION
Further enhance the modulemaps.  This is needed to support the use of
the ucrt for the builtins as used in the ClangImporter unit tests.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
