### PR TITLE
test: use %empty-directory more aggressively

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -694,14 +694,14 @@ if run_vendor == 'apple':
             config.target_run_simple_swift = (
                 "%s %%s" % (target_run_base))
             config.target_run_simple_swiftgyb = (
-                'rm -rf %%t && mkdir -p %%t && '
+                '%%empty-directory(%%t) && '
                 '%%gyb %%s -o %%t/main.swift && '
                 '%%line-directive %%t/main.swift -- %s %%t/main.swift'
                 % (target_run_base))
             config.target_run_stdlib_swift = (
                 "%s %%s" % (target_run_stdlib))
             config.target_run_stdlib_swiftgyb = (
-                'rm -rf %%t && mkdir -p %%t && '
+                '%%empty-directory(%%t) && '
                 '%%gyb %%s -o %%t/main.swift && '
                 '%%line-directive %%t/main.swift -- %s %%t/main.swift'
                 % (target_run_stdlib))
@@ -811,14 +811,14 @@ elif run_os in ['linux-gnu', 'linux-gnueabihf', 'freebsd', 'windows-cygnus', 'wi
         config.target_run_simple_swift = (
             '%s %%s' % (target_run_base))
         config.target_run_simple_swiftgyb = (
-            'rm -rf %%t && mkdir -p %%t && '
+            '%%empty-directory(%%t) && '
             '%%gyb %%s -o %%t/main.swift && '
             '%%line-directive %%t/main.swift -- %s %%t/main.swift'
             % (target_run_base))
         config.target_run_stdlib_swift = (
             '%s %%s' % (target_run_stdlib))
         config.target_run_stdlib_swiftgyb = (
-            'rm -rf %%t && mkdir -p %%t && '
+            '%%empty-directory(%%t) && '
             '%%gyb %%s -o %%t/main.swift && '
             '%%line-directive %%t/main.swift -- %s %%t/main.swift'
             % (target_run_stdlib))
@@ -967,18 +967,18 @@ check_runtime_libs(runtime_libs)
 
 if not getattr(config, 'target_run_simple_swift', None):
     config.target_run_simple_swift = (
-        'rm -rf %%t && mkdir -p %%t && '
+        '%%empty-directory(%%t) && '
         '%s %s %%s -o %%t/a.out -module-name main && '
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, config.target_run))
     config.target_run_stdlib_swift = (
-        'rm -rf %%t && mkdir -p %%t && '
+        '%%empty-directory(%%t) && '
         '%s %s %%s -o %%t/a.out -module-name main '
         '-Xfrontend -disable-access-control && '
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, config.target_run))
     config.target_run_simple_swiftgyb = (
-        'rm -rf %%t && mkdir -p %%t && '
+        '%%empty-directory(%%t) && '
         '%%gyb %%s -o %%t/main.swift && '
         '%%line-directive %%t/main.swift -- '
         '%s %s %%t/main.swift -o %%t/a.out -module-name main && '
@@ -986,7 +986,7 @@ if not getattr(config, 'target_run_simple_swift', None):
         '%s %%t/a.out'
         % (config.target_build_swift, mcp_opt, config.target_run))
     config.target_run_stdlib_swiftgyb = (
-        'rm -rf %%t && mkdir -p %%t && '
+        '%%empty-directory(%%t) && '
         '%%gyb %%s -o %%t/main.swift && '
         '%%line-directive %%t/main.swift -- '
         '%s %s %%t/main.swift -o %%t/a.out -module-name main '


### PR DESCRIPTION
Convert the last embedded cases of `rm -rf && mkdir -p` to the
empty-directory lit substitution.  NFC.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
