### PR TITLE
stdlib: replace an obsolete initialize function in UnsafeBufferPointer.swapAt with the new one

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -361,7 +361,7 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     let pj = (_position! + j)
     let tmp = pi.move()
     pi.moveInitialize(from: pj, count: 1)
-    pj.initialize(to: tmp, count: 1)
+    pj.initialize(to: tmp)
   }
 % end # mutable
 }


### PR DESCRIPTION
This brings back performance on stdlib sort because the obsoleted function in UnsafePointer is not inlinable.
