### PR TITLE
Narrow exclusivity duration for existential methods, and emit default arg generators late

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1693,13 +1693,7 @@ public:
     /// This is a true inout argument.
     InOut,
 
-    /// This is a borrowed direct argument.
-    BorrowDirect,
-
-    /// This is a borrowed indirect argument.
-    BorrowIndirect,
-
-    LastLVKindWithoutExtra = BorrowIndirect,
+    LastLVKindWithoutExtra = InOut,
 
     /// The l-value needs to be converted to a pointer type.
     LValueToPointer,
@@ -1832,10 +1826,6 @@ public:
     switch (Kind) {
     case InOut:
       return emitInOut(SGF);
-    case BorrowDirect:
-      return emitBorrowDirect(SGF);
-    case BorrowIndirect:
-      return emitBorrowIndirect(SGF);
     case LValueToPointer:
     case LValueArrayToPointer:
     case RValueArrayToPointer:
@@ -1917,8 +1907,6 @@ private:
 
     switch (Kind) {
     case InOut:
-    case BorrowDirect:
-    case BorrowIndirect:
       llvm_unreachable("no original expr to finish in these cases");
 
     case LValueToPointer:

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -1894,16 +1894,19 @@ private:
     CanType resultType;
     AbstractionPattern origResultType;
     ClaimedParamsRef paramsToEmit;
+    SILFunctionTypeRepresentation functionRepresentation;
     
     DefaultArgumentStorage(SILLocation loc,
                            ConcreteDeclRef defaultArgsOwner,
                            unsigned destIndex,
                            CanType resultType,
                            AbstractionPattern origResultType,
-                           ClaimedParamsRef paramsToEmit)
+                           ClaimedParamsRef paramsToEmit,
+                           SILFunctionTypeRepresentation functionRepresentation)
       : loc(loc), defaultArgsOwner(defaultArgsOwner), destIndex(destIndex),
         resultType(resultType), origResultType(origResultType),
-        paramsToEmit(paramsToEmit)
+        paramsToEmit(paramsToEmit),
+        functionRepresentation(functionRepresentation)
     {}
   };
 
@@ -1989,12 +1992,14 @@ public:
                   unsigned destIndex,
                   CanType resultType,
                   AbstractionPattern origResultType,
-                  ClaimedParamsRef params)
+                  ClaimedParamsRef params,
+                  SILFunctionTypeRepresentation functionTypeRepresentation)
     : Kind(DefaultArgument) {
     Value.emplace<DefaultArgumentStorage>(Kind, loc, defaultArgsOwner,
                                           destIndex,
                                           resultType,
-                                          origResultType, params);
+                                          origResultType, params,
+                                          functionTypeRepresentation);
   }
 
   DelayedArgument(DelayedArgument &&other)
@@ -2890,14 +2895,16 @@ void DelayedArgument::emitDefaultArgument(SILGenFunction &SGF,
   
   SmallVector<ManagedValue, 4> loweredArgs;
   SmallVector<DelayedArgument, 4> delayedArgs;
-  auto emitter = ArgEmitter(SGF, SILFunctionTypeRepresentation::Thin,
+  Optional<ForeignErrorConvention> errorConvention = None;
+  auto emitter = ArgEmitter(SGF, info.functionRepresentation,
                             info.paramsToEmit,
                             loweredArgs, delayedArgs,
-                            None, ImportAsMemberStatus());
+                            errorConvention, ImportAsMemberStatus());
   
   emitter.emitTopLevel(ArgumentSource(info.loc, std::move(value)),
                        info.origResultType);
   assert(delayedArgs.empty());
+  assert(!errorConvention);
   
   // Splice the emitted default argument into the argument list.
   if (loweredArgs.size() == 1) {
@@ -3206,7 +3213,8 @@ void TupleShuffleArgEmitter::emitDefaultArgsAndFinalize(ArgEmitter &parent) {
                                               ImportAsMemberStatus());
       parent.DelayedArguments.emplace_back(outer, defaultArgsOwner,
                                          outerIndex, eltType, origType,
-                                         parent.ParamInfos.slice(0, numParams));
+                                         parent.ParamInfos.slice(0, numParams),
+                                         parent.Rep);
       parent.ParamInfos = parent.ParamInfos.slice(numParams);
       parent.Args.push_back(ManagedValue());
       continue;

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -5389,34 +5389,15 @@ RValue RValueEmitter::emitForceValue(ForceValueExpr *loc, Expr *E,
 void SILGenFunction::emitOpenExistentialExprImpl(
        OpenExistentialExpr *E,
        llvm::function_ref<void(Expr *)> emitSubExpr) {
+  Optional<FormalEvaluationScope> writebackScope;
+
   // Emit the existential value.
   if (E->getExistentialValue()->getType()->is<LValueType>()) {
-    // Open the existential container right away. We need the dynamic type
-    // to be opened in order to evaluate the subexpression.
-    AccessKind accessKind;
-    if (E->hasLValueAccessKind())
-      accessKind = E->getLValueAccessKind();
-    else
-      accessKind = E->getExistentialValue()->getLValueAccessKind();
-    auto lv = emitLValue(E->getExistentialValue(), accessKind);
-    auto formalOpenedType = E->getOpaqueValue()->getType()
-                                    ->getWithoutSpecifierType()
-                                    ->getCanonicalType();
-    lv = emitOpenExistentialLValue(E, std::move(lv),
-                                   CanArchetypeType(E->getOpenedArchetype()),
-                                   formalOpenedType,
-                                   accessKind);
-    
-    auto addr = emitAddressOfLValue(E, std::move(lv), accessKind);
-    bool inserted = OpaqueLValues.insert({E->getOpaqueValue(),
-                                          {addr.getValue(), formalOpenedType}})
-      .second;
+    bool inserted = OpaqueValueExprs.insert({E->getOpaqueValue(), E}).second;
     (void)inserted;
     assert(inserted && "already have this opened existential?");
 
     emitSubExpr(E->getSubExpr());
-    assert(OpaqueLValues.count(E->getOpaqueValue()) == 0
-           && "opened existential not removed?");
     return;
   }
 
@@ -5443,12 +5424,6 @@ RValue RValueEmitter::visitOpenExistentialExpr(OpenExistentialExpr *E,
     return RValue(SGF, E, *result);
   }
 
-  Optional<FormalEvaluationScope> scope;
-  // Begin an evaluation scope for an lvalue existential opened into an
-  // rvalue expression.
-  if (E->getExistentialValue()->getType()->is<LValueType>())
-    scope.emplace(SGF);
-  
   return SGF.emitOpenExistentialExpr<RValue>(E,
                                              [&](Expr *subExpr) -> RValue {
                                                return visit(subExpr, C);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2623,11 +2623,11 @@ RValue RValueEmitter::visitTupleElementExpr(TupleElementExpr *E,
 
 RValue
 SILGenFunction::emitApplyOfDefaultArgGenerator(SILLocation loc,
-                                               ConcreteDeclRef defaultArgsOwner,
-                                               unsigned destIndex,
-                                               CanType resultType,
+                                             ConcreteDeclRef defaultArgsOwner,
+                                             unsigned destIndex,
+                                             CanType resultType,
                                              AbstractionPattern origResultType,
-                                               SGFContext C) {
+                                             SGFContext C) {
   SILDeclRef generator 
     = SILDeclRef::getDefaultArgGenerator(defaultArgsOwner.getDecl(),
                                          destIndex);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1397,10 +1397,10 @@ public:
   llvm::SmallDenseMap<OpaqueValueExpr *, OpaqueValueState>
     OpaqueValues;
 
-  /// A mapping from opaque value lvalue expressions to the address of the
-  /// opened value in memory.
-  llvm::SmallDenseMap<OpaqueValueExpr *, std::pair<SILValue, CanType>>
-    OpaqueLValues;
+  /// A mapping from opaque value expressions to the open-existential
+  /// expression that determines them, used while lowering lvalues.
+  llvm::SmallDenseMap<OpaqueValueExpr *, OpenExistentialExpr *>
+    OpaqueValueExprs;
 
   /// RAII object that introduces a temporary binding for an opaque value.
   ///

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1059,18 +1059,21 @@ namespace {
         subscripts(copied.subscripts.copy(SGF, loc)) ,
         baseFormalType(copied.baseFormalType) {}
 
-    virtual SILDeclRef getAccessor(SILGenFunction &SGF,
-                                   AccessKind kind) const  = 0;
+    virtual bool doesAccessMutateSelf(SILGenFunction &SGF,
+                                      AccessKind kind) const = 0;
 
+    bool doesAccessorMutateSelf(SILGenFunction &SGF,
+                                SILDeclRef accessor) const {
+      auto accessorSelf = SGF.SGM.Types.getConstantSelfParameter(accessor);
+      return accessorSelf.getType() && accessorSelf.isIndirectMutating();
+    }
+    
     AccessKind getBaseAccessKind(SILGenFunction &SGF,
                                  AccessKind kind) const override {
-      SILDeclRef accessor = getAccessor(SGF, kind);
-      auto accessorSelf = SGF.SGM.Types.getConstantSelfParameter(accessor);
-      if (accessorSelf.getType() && accessorSelf.isIndirectMutating()) {
+      if (doesAccessMutateSelf(SGF, kind))
         return AccessKind::ReadWrite;
-      } else {
+      else
         return AccessKind::Read;
-      }
     }
 
     void printBase(raw_ostream &OS, unsigned indent, StringRef name) const {
@@ -1110,13 +1113,25 @@ namespace {
     {
     }
 
-    SILDeclRef getAccessor(SILGenFunction &SGF,
-                           AccessKind accessKind) const override {
-      if (accessKind == AccessKind::Read) {
-        return SGF.SGM.getGetterDeclRef(decl);
-      } else {
-        return SGF.SGM.getSetterDeclRef(decl);
+    bool doesAccessMutateSelf(SILGenFunction &SGF,
+                              AccessKind accessKind) const override {
+      switch (accessKind) {
+      case AccessKind::Read: {
+        auto getter = SGF.SGM.getGetterDeclRef(decl);
+        return doesAccessorMutateSelf(SGF, getter);
       }
+      case AccessKind::Write: {
+        auto setter = SGF.SGM.getSetterDeclRef(decl);
+        return doesAccessorMutateSelf(SGF, setter);
+      }
+      case AccessKind::ReadWrite: {
+        auto getter = SGF.SGM.getGetterDeclRef(decl);
+        auto setter = SGF.SGM.getSetterDeclRef(decl);
+        return doesAccessorMutateSelf(SGF, getter)
+            || doesAccessorMutateSelf(SGF, setter);
+      }
+      }
+      llvm_unreachable("unknown access kind");
     }
 
     void emitAssignWithSetter(SILGenFunction &SGF, SILLocation loc,
@@ -1586,9 +1601,10 @@ namespace {
     {
     }
 
-    SILDeclRef getAccessor(SILGenFunction &SGF,
-                           AccessKind accessKind) const override {
-      return SGF.SGM.getAddressorDeclRef(decl, accessKind);
+    bool doesAccessMutateSelf(SILGenFunction &SGF,
+                              AccessKind kind) const override {
+      auto addressor = SGF.SGM.getAddressorDeclRef(decl, kind);
+      return doesAccessorMutateSelf(SGF, addressor);
     }
 
     ManagedValue offset(SILGenFunction &SGF, SILLocation loc, ManagedValue base,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2350,18 +2350,20 @@ LValue SILGenLValue::visitOpaqueValueExpr(OpaqueValueExpr *e,
                                           AccessKind accessKind,
                                           LValueOptions options) {
   // Handle an opaque lvalue that refers to an opened existential.
-  auto known = SGF.OpaqueLValues.find(e);
-  if (known != SGF.OpaqueLValues.end()) {
-    // Dig the opened address out of the list.
-    SILValue opened = known->second.first;
-    CanType openedType = known->second.second;
-    SGF.OpaqueLValues.erase(known);
+  auto known = SGF.OpaqueValueExprs.find(e);
+  if (known != SGF.OpaqueValueExprs.end()) {
+    // Dig the open-existential expression out of the list.
+    OpenExistentialExpr *opened = known->second;
+    SGF.OpaqueValueExprs.erase(known);
 
-    // Continue formal evaluation of the lvalue from this address.
-    return LValue::forAddress(ManagedValue::forLValue(opened),
-                              None,
-                              AbstractionPattern(openedType),
-                              openedType);
+    // Do formal evaluation of the underlying existential lvalue.
+    auto lv = visitRec(opened->getExistentialValue(), accessKind, options);
+    lv = SGF.emitOpenExistentialLValue(
+        opened, std::move(lv),
+        CanArchetypeType(opened->getOpenedArchetype()),
+        e->getType()->getWithoutSpecifierType()->getCanonicalType(),
+        accessKind);
+    return lv;
   }
 
   assert(SGF.OpaqueValues.count(e) && "Didn't bind OpaqueValueExpr");
@@ -2655,12 +2657,29 @@ LValue SILGenLValue::visitTupleElementExpr(TupleElementExpr *e,
 LValue SILGenLValue::visitOpenExistentialExpr(OpenExistentialExpr *e,
                                               AccessKind accessKind,
                                               LValueOptions options) {
-  return SGF.emitOpenExistentialExpr<LValue>(e,
-                                             [&](Expr *subExpr) -> LValue {
-                                               return visitRec(subExpr,
-                                                               accessKind,
-                                                               options);
-                                             });
+  // If the opaque value is not an lvalue, open the existential immediately.
+  if (!e->getOpaqueValue()->getType()->is<LValueType>()) {
+    return SGF.emitOpenExistentialExpr<LValue>(e,
+                                               [&](Expr *subExpr) -> LValue {
+                                                 return visitRec(subExpr,
+                                                                 accessKind,
+                                                                 options);
+                                               });
+  }
+
+  // Record the fact that we're opening this existential. The actual
+  // opening operation will occur when we see the OpaqueValueExpr.
+  bool inserted = SGF.OpaqueValueExprs.insert({e->getOpaqueValue(), e}).second;
+  (void)inserted;
+  assert(inserted && "already have this opened existential?");
+
+  // Visit the subexpression.
+  LValue lv = visitRec(e->getSubExpr(), accessKind, options);
+
+  // Sanity check that we did see the OpaqueValueExpr.
+  assert(SGF.OpaqueValueExprs.count(e->getOpaqueValue()) == 0 &&
+         "opened existential not removed?");
+  return lv;
 }
 
 static LValueTypeData

--- a/test/SILGen/assignment.swift
+++ b/test/SILGen/assignment.swift
@@ -43,11 +43,11 @@ protocol P {
 // CHECK-LABEL: sil hidden @$S10assignment15copyRightToLeft1pyAA1P_pz_tF : $@convention(thin) (@inout P) -> () {
 func copyRightToLeft(p: inout P) {
   // CHECK: bb0(%0 : @trivial $*P):
-  // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] %0 : $*P
-  // CHECK:   [[WRITE_OPEN:%.*]] = open_existential_addr mutable_access [[WRITE]]
   // CHECK:   [[READ:%.*]] = begin_access [read] [unknown] %0 : $*P
   // CHECK:   [[READ_OPEN:%.*]] = open_existential_addr immutable_access [[READ]]
   // CHECK:   end_access [[READ]] : $*P
+  // CHECK:   [[WRITE:%.*]] = begin_access [modify] [unknown] %0 : $*P
+  // CHECK:   [[WRITE_OPEN:%.*]] = open_existential_addr mutable_access [[WRITE]]
   // CHECK:   end_access [[WRITE]] : $*P
   p.left = p.right
 }

--- a/test/SILGen/class_bound_protocols.swift
+++ b/test/SILGen/class_bound_protocols.swift
@@ -176,7 +176,7 @@ func takesInheritsMutatingMethod(x: inout InheritsMutatingMethod,
   // CHECK-NEXT: [[X_PAYLOAD:%.*]] = open_existential_ref [[X_VALUE]] : $InheritsMutatingMethod to $@opened("{{.*}}") InheritsMutatingMethod
   // CHECK-NEXT: [[TEMPORARY:%.*]] = alloc_stack $@opened("{{.*}}") InheritsMutatingMethod
   // CHECK-NEXT: store [[X_PAYLOAD]] to [init] [[TEMPORARY]] : $*@opened("{{.*}}") InheritsMutatingMethod
-  // CHECK-NEXT: [[X_PAYLOAD_RELOADED:%.*]] = load_borrow [[TEMPORARY]]
+  // CHECK-NEXT: [[X_PAYLOAD_RELOADED:%.*]] = load [take] [[TEMPORARY]]
   //
   // ** *NOTE* This extra copy is here since RValue invariants enforce that all
   // ** loadable objects are actually loaded. So we form the RValue and
@@ -184,15 +184,14 @@ func takesInheritsMutatingMethod(x: inout InheritsMutatingMethod,
   // ** pass to an in_guaranteed method. PredictableMemOpts is able to handle this
   // ** type of temporary codegen successfully.
   // CHECK-NEXT: [[TEMPORARY_2:%.*]] = alloc_stack $@opened("{{.*}}") InheritsMutatingMethod
-  // CHECK-NEXT: store_borrow [[X_PAYLOAD_RELOADED:%.*]] to [[TEMPORARY_2]]
+  // CHECK-NEXT: store [[X_PAYLOAD_RELOADED:%.*]] to [init] [[TEMPORARY_2]]
   // 
   // CHECK-NEXT: [[METHOD:%.*]] = witness_method $@opened("{{.*}}") InheritsMutatingMethod, #HasMutatingMethod.mutatingCounter!getter.1 : <Self where Self : HasMutatingMethod> (Self) -> () -> Value, [[X_PAYLOAD]] : $@opened("{{.*}}") InheritsMutatingMethod : $@convention(witness_method: HasMutatingMethod) <τ_0_0 where τ_0_0 : HasMutatingMethod> (@in_guaranteed τ_0_0) -> Value
   // CHECK-NEXT: [[RESULT_VALUE:%.*]] = apply [[METHOD]]<@opened("{{.*}}") InheritsMutatingMethod>([[TEMPORARY_2]]) : $@convention(witness_method: HasMutatingMethod) <τ_0_0 where τ_0_0 : HasMutatingMethod> (@in_guaranteed τ_0_0) -> Value
+  // CHECK-NEXT: destroy_addr [[TEMPORARY_2]] : $*@opened("{{.*}}") InheritsMutatingMethod
   // CHECK-NEXT: dealloc_stack  [[TEMPORARY_2]]
-  // CHECK-NEXT: end_borrow [[X_PAYLOAD_RELOADED]]
+  // CHECK-NEXT: end_access [[X_ADDR]] : $*InheritsMutatingMethod
   // CHECK-NEXT: assign [[RESULT_VALUE]] to [[RESULT]] : $*Value
-  // CHECK-NEXT: destroy_addr [[TEMPORARY]]
-  // CHECK-NEXT: end_access [[X_ADDR]]
   // CHECK-NEXT: dealloc_stack [[TEMPORARY]] : $*@opened("{{.*}}") InheritsMutatingMethod
   // CHECK-NEXT: dealloc_stack [[RESULT_BOX]] : $*Value
   _ = x.mutatingCounter

--- a/test/SILGen/properties.swift
+++ b/test/SILGen/properties.swift
@@ -1215,12 +1215,12 @@ protocol NonmutatingProtocol {
 // CHECK-NEXT:   [[C_FIELD_PAYLOAD:%.*]] = open_existential_addr immutable_access [[C_FIELD_BOX]] : $*NonmutatingProtocol to $*@opened("{{.*}}") NonmutatingProtocol
 // CHECK-NEXT:   [[C_FIELD_COPY:%.*]] = alloc_stack $@opened("{{.*}}") NonmutatingProtocol
 // CHECK-NEXT:   copy_addr [[C_FIELD_PAYLOAD]] to [initialization] [[C_FIELD_COPY]] : $*@opened("{{.*}}") NonmutatingProtocol
+// CHECK-NEXT:   destroy_addr [[C_FIELD_BOX]] : $*NonmutatingProtocol
+// CHECK-NEXT:   destroy_value [[C]] : $ReferenceType
 // CHECK-NEXT:   [[GETTER:%.*]] = witness_method $@opened("{{.*}}") NonmutatingProtocol, #NonmutatingProtocol.x!getter.1 : <Self where Self : NonmutatingProtocol> (Self) -> () -> Int, [[C_FIELD_PAYLOAD]] : $*@opened("{{.*}}") NonmutatingProtocol : $@convention(witness_method: NonmutatingProtocol) <τ_0_0 where τ_0_0 : NonmutatingProtocol> (@in_guaranteed τ_0_0) -> Int
 // CHECK-NEXT:   [[RESULT_VALUE:%.*]] = apply [[GETTER]]<@opened("{{.*}}") NonmutatingProtocol>([[C_FIELD_COPY]]) : $@convention(witness_method: NonmutatingProtocol) <τ_0_0 where τ_0_0 : NonmutatingProtocol> (@in_guaranteed τ_0_0) -> Int
 // CHECK-NEXT:   assign [[RESULT_VALUE]] to [[UNINIT]] : $*Int
 // CHECK-NEXT:   destroy_addr [[C_FIELD_COPY]] : $*@opened("{{.*}}") NonmutatingProtocol
-// CHECK-NEXT:   destroy_addr [[C_FIELD_BOX]] : $*NonmutatingProtocol
-// CHECK-NEXT:   destroy_value [[C]] : $ReferenceType
 // CHECK-NEXT:   dealloc_stack [[C_FIELD_COPY]] : $*@opened("{{.*}}") NonmutatingProtocol
 // CHECK-NEXT:   dealloc_stack [[C_FIELD_BOX]] : $*NonmutatingProtocol
 // CHECK-NEXT:   dealloc_stack [[RESULT]] : $*Int

--- a/test/SILGen/protocol-extension-default-arg-existential-objc.swift
+++ b/test/SILGen/protocol-extension-default-arg-existential-objc.swift
@@ -1,0 +1,12 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+class Foo: NSObject {
+  dynamic func bridged(x: String = "foo") {}
+}
+
+func invokeMethodsWithDefaultArgs(x: Foo) {
+  x.bridged()
+}

--- a/test/SILGen/protocol-extension-default-arg-existential.swift
+++ b/test/SILGen/protocol-extension-default-arg-existential.swift
@@ -1,0 +1,39 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+//
+// Make sure neither rdar://problem/37031037 (default arguments on protocol extension methods
+// depend on Self and normally get evaluated before an existential self value
+// gets opened) nor rdar://problem/39524104 (if you open the existential self
+// earlier in an attempt to fix this, then you get undesirable exclusivity
+// conflicts on constructs like `existential.x = existential.y`) regress.
+//
+
+protocol MethodWithDefaultArgGenerator {
+  var a: Int { get set }
+  var b: Int { get nonmutating set }
+
+  mutating func mutate(_ x: inout Int)
+}
+
+protocol P { static var value: Self { get } }
+extension Int: P { static var value: Int { return 0 } }
+
+extension MethodWithDefaultArgGenerator {
+  mutating func foo(_ x: Int = 0) {}
+
+  mutating func reabstracted<T>(_ x: T.Type = T.self) -> T { fatalError() }
+  mutating func indirected<T: P>(_ x: T = T.value) -> T { fatalError() }
+
+  mutating func exploded(x y: (Int, String) = (0, "foo")) {}
+}
+func invokeMethodsWithDefaultArgs(x: inout MethodWithDefaultArgGenerator) {
+  x.foo()
+  _ = x.reabstracted() as Int
+  _ = x.indirected() as Int
+  x.exploded()
+}
+func checkAgainstExclusivityViolations(x: inout MethodWithDefaultArgGenerator) {
+  x.a = x.a
+  x.mutate(&x.b)
+}
+

--- a/test/SILGen/protocols.swift
+++ b/test/SILGen/protocols.swift
@@ -27,10 +27,10 @@ func use_subscript_rvalue_get(_ i : Int) -> Int {
 // CHECK: [[PROJ:%[0-9]+]] = open_existential_addr immutable_access [[READ]] : $*SubscriptableGet to $*[[OPENED:@opened(.*) SubscriptableGet]]
 // CHECK: [[ALLOCSTACK:%[0-9]+]] = alloc_stack $[[OPENED]]
 // CHECK: copy_addr [[PROJ]] to [initialization] [[ALLOCSTACK]] : $*[[OPENED]]
+// CHECK-NEXT: end_access [[READ]] : $*SubscriptableGet
 // CHECK-NEXT: [[METH:%[0-9]+]] = witness_method $[[OPENED]], #SubscriptableGet.subscript!getter.1
 // CHECK-NEXT: [[RESULT:%[0-9]+]] = apply [[METH]]<[[OPENED]]>(%0, [[ALLOCSTACK]])
 // CHECK-NEXT: destroy_addr [[ALLOCSTACK]]
-// CHECK-NEXT: end_access [[READ]] : $*SubscriptableGet
 // CHECK-NEXT: dealloc_stack [[ALLOCSTACK]] : $*[[OPENED]]
 // CHECK-NEXT: return [[RESULT]]
 
@@ -134,9 +134,9 @@ func use_property_rvalue_get() -> Int {
 // CHECK: [[PROJ:%[0-9]+]] = open_existential_addr immutable_access [[READ]] : $*PropertyWithGetter to $*[[OPENED:@opened(.*) PropertyWithGetter]]
 // CHECK: [[COPY:%.*]] = alloc_stack $[[OPENED]]
 // CHECK-NEXT: copy_addr [[PROJ]] to [initialization] [[COPY]] : $*[[OPENED]]
+// CHECK-NEXT: end_access [[READ]] : $*PropertyWithGetter
 // CHECK-NEXT: [[METH:%[0-9]+]] = witness_method $[[OPENED]], #PropertyWithGetter.a!getter.1
 // CHECK-NEXT: apply [[METH]]<[[OPENED]]>([[COPY]])
-// CHECK: end_access [[READ]] : $*PropertyWithGetter
 
 func use_property_lvalue_get() -> Int {
   return propertyGetSet.b
@@ -458,15 +458,3 @@ public func test(_ p: Proto) {
 // CHECK-LABEL: sil_witness_table hidden StructWithStoredClassProperty: PropertyWithGetter module protocols {
 // CHECK-NEXT:  method #PropertyWithGetter.a!getter.1: {{.*}} : @$S9protocols29StructWithStoredClassPropertyVAA0fC6GetterA2aDP1aSivgTW
 // CHECK-NEXT: }
-
-//
-// rdar://problem/37031037
-//
-
-protocol MethodWithDefaultArgGenerator {}
-extension MethodWithDefaultArgGenerator {
-  mutating func foo(_ x: Int = 0) {}
-}
-func invokeMethodWithDefaultArg(x: inout MethodWithDefaultArgGenerator) {
-  x.foo()
-}

--- a/test/SILGen/scalar_to_tuple_args.swift
+++ b/test/SILGen/scalar_to_tuple_args.swift
@@ -14,9 +14,9 @@ func variadicSecond(_ x: Int, _ y: Int...) {}
 
 var x = 0
 // CHECK: [[X_ADDR:%.*]] = global_addr @$S20scalar_to_tuple_args1xSivp : $*Int
+// CHECK: [[WRITE:%.*]] = begin_access [modify] [dynamic] [[X_ADDR]] : $*Int
 // CHECK: [[DEFAULT_Y:%.*]] = apply {{.*}} : $@convention(thin) () -> Int
 // CHECK: [[DEFAULT_Z:%.*]] = apply {{.*}} : $@convention(thin) () -> Int
-// CHECK: [[WRITE:%.*]] = begin_access [modify] [dynamic] [[X_ADDR]] : $*Int
 // CHECK: [[INOUT_WITH_DEFAULTS:%.*]] = function_ref @$S20scalar_to_tuple_args17inoutWithDefaults_1y1zySiz_S2itF
 // CHECK: apply [[INOUT_WITH_DEFAULTS]]([[WRITE]], [[DEFAULT_Y]], [[DEFAULT_Z]])
 inoutWithDefaults(&x)

--- a/test/SILOptimizer/access_marker_verify.swift
+++ b/test/SILOptimizer/access_marker_verify.swift
@@ -970,12 +970,12 @@ struct StructWithLayout {
 // CHECK: [[PROJ:%.*]] = project_box %{{.*}} : ${ var StructWithLayout }, 0
 // CHECK: [[PA:%.*]] = partial_apply [callee_guaranteed] %{{.*}}([[PROJ]]) : $@convention(thin) (@inout_aliasable StructWithLayout) -> Bool
 // CHECK: [[CLOSURE:%.*]] = convert_escape_to_noescape [not_guaranteed] [[PA]] : $@callee_guaranteed () -> Bool to $@noescape @callee_guaranteed () -> Bool
-// call default argument
-// CHECK: apply %{{.*}}() : $@convention(thin) () -> StaticString
 // call StaticString.init
 // CHECK: apply
 // call UInt.init(_builtinIntegerLiteral:)
 // CHECK: apply
+// call default argument
+// CHECK: apply %{{.*}}() : $@convention(thin) () -> StaticString
 // call _sanityCheck(_:_:file:line:)
 // CHECK: apply %{{.*}}([[CLOSURE]], {{.*}})
 // CHECK: load [trivial] [[PROJ]] : $*StructWithLayout

--- a/test/SILOptimizer/exclusivity_static_diagnostics_inlined.swift
+++ b/test/SILOptimizer/exclusivity_static_diagnostics_inlined.swift
@@ -2,8 +2,7 @@
 // RUN: %target-swift-frontend -enforce-exclusivity=none -emit-sil -Onone %s -o %t/Onone.sil
 // RUN: %target-sil-opt %t/Onone.sil -inline -assume-parsing-unqualified-ownership-sil -o %t/inlined.sil
 // RUN: %FileCheck %s --check-prefix=INLINE < %t/inlined.sil
-// RUN: not %target-sil-opt -enable-sil-verify-all %t/inlined.sil -enforce-exclusivity=unchecked -diagnose-static-exclusivity -assume-parsing-unqualified-ownership-sil -o /dev/null 2> %t/err.txt
-// RUN: %FileCheck %s --check-prefix=DIAGNOSE < %t/err.txt
+// RUN: %target-sil-opt -enable-sil-verify-all %t/inlined.sil -enforce-exclusivity=unchecked -diagnose-static-exclusivity -assume-parsing-unqualified-ownership-sil -o /dev/null
 
 public protocol SomeP {
   var someV: Int { get set }
@@ -23,15 +22,10 @@ struct Some : SomeP {
 //
 // INLINE-LABEL: $S5Onone16testNestedAccessyyF
 // INLINE: [[OUTER:%.*]] = begin_access [modify] [static] %0 : $*SomeP
+// INLINE: [[INNERREAD:%.*]] = begin_access [read] [static] [[OUTER]] : $*SomeP
 // INLINE: [[INNERMOD:%.*]] = begin_access [modify] [static] [[OUTER]] : $*SomeP
 // INLINE: %{{.*}} = open_existential_addr mutable_access [[INNERMOD]] : $*SomeP to $*@opened("{{.*}}") SomeP
-// INLINE: [[INNERREAD:%.*]] = begin_access [read] [static] [[OUTER]] : $*SomeP
 //
-// DIAGNOSE: error: overlapping accesses, but modification requires exclusive access; consider copying to a local variable
-// DIAGNOSE: %{{.*}} = begin_access [modify] [static] %0 : $*SomeP
-// DIAGNOSE: %{{.*}} = begin_access [read] [static] %0 : $*SomeP
-// DIAGNOSE: %{{.*}} = begin_access [modify] [static] %{{.*}} : $*SomeP
-// DIAGNOSE: %{{.*}} = begin_access [read] [static] %{{.*}} : $*SomeP
 public func testNestedAccess() {
   var s: SomeP = Some()
   assignNonConflict(&s)


### PR DESCRIPTION
Another attempt to cover the conflicting needs of narrowing exclusive access to existentials during a method invocation (so that, e.g. `x.foo(&x.bar)` or `x.foo = x.bar` work) while also having access to the opened existential in order to invoke default argument generators dependent on the `Self` type in protocol extensions. rdar://problem/39524104