### PR TITLE
[GSB] Don't try to infer requirements from error types.

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -5437,6 +5437,9 @@ public:
   }
 
   Action walkToTypePost(Type ty) override {
+    if (ty->hasError())
+      return Action::Continue;
+
     // Infer from generic typealiases.
     if (auto NameAlias = dyn_cast<NameAliasType>(ty.getPointer())) {
       auto decl = NameAlias->getDecl();

--- a/validation-test/compiler_crashers_2_fixed/0158-rdar39548143.swift
+++ b/validation-test/compiler_crashers_2_fixed/0158-rdar39548143.swift
@@ -1,0 +1,8 @@
+// RUN: %target-typecheck-verify-swift
+enum a<b> {}
+struct X {}
+extension a where b == X {
+    typealias c = d
+    // expected-error@-1{{use of undeclared type 'd'}}
+    func e<f>() -> c {}
+}


### PR DESCRIPTION
Fixes rdar://problem/39548143.
