### PR TITLE
ClangImporter: improve ObjC-interop and enable tests

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -464,6 +464,19 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
     if (!triple.isOSDarwin())
       invocationArgStrs.insert(invocationArgStrs.end(),
                                {"-fobjc-runtime=ios-7.0"});
+
+    // Define macros that Swift bridging headers use.
+    invocationArgStrs.insert(invocationArgStrs.end(), {
+          "-DSWIFT_CLASS_EXTRA=__attribute__((__annotate__("
+          "\"" SWIFT_NATIVE_ANNOTATION_STRING "\")))",
+          "-DSWIFT_PROTOCOL_EXTRA=__attribute__((__annotate__("
+          "\"" SWIFT_NATIVE_ANNOTATION_STRING "\")))",
+          "-DSWIFT_EXTENSION_EXTRA=__attribute__((__annotate__("
+          "\"" SWIFT_NATIVE_ANNOTATION_STRING "\")))",
+          "-DSWIFT_ENUM_EXTRA=__attribute__((__annotate__("
+          "\"" SWIFT_NATIVE_ANNOTATION_STRING "\")))",
+      });
+
   } else {
     invocationArgStrs.insert(invocationArgStrs.end(), {"-x", "c", "-std=gnu11"});
   }
@@ -471,16 +484,6 @@ getNormalInvocationArguments(std::vector<std::string> &invocationArgStrs,
   // Set C language options.
   if (triple.isOSDarwin()) {
     invocationArgStrs.insert(invocationArgStrs.end(), {
-      // Define macros that Swift bridging headers use.
-      "-DSWIFT_CLASS_EXTRA=__attribute__((annotate(\""
-        SWIFT_NATIVE_ANNOTATION_STRING "\")))",
-      "-DSWIFT_PROTOCOL_EXTRA=__attribute__((annotate(\""
-        SWIFT_NATIVE_ANNOTATION_STRING "\")))",
-      "-DSWIFT_EXTENSION_EXTRA=__attribute__((annotate(\""
-        SWIFT_NATIVE_ANNOTATION_STRING "\")))",
-      "-DSWIFT_ENUM_EXTRA=__attribute__((annotate(\""
-        SWIFT_NATIVE_ANNOTATION_STRING "\")))",
-
       // Avoid including the iso646.h header because some headers from OS X
       // frameworks are broken by it.
       "-D_ISO646_H_", "-D__ISO646_H",

--- a/test/ClangImporter/CoreMIDI_test.swift
+++ b/test/ClangImporter/CoreMIDI_test.swift
@@ -1,6 +1,4 @@
-// RUN: %target-typecheck-verify-swift %clang-importer-sdk
-
-// REQUIRES: objc_interop
+// RUN: %target-typecheck-verify-swift %clang-importer-sdk -enable-objc-interop
 
 import CoreMIDI
 

--- a/test/ClangImporter/MixedSource/Xcc_include.swift
+++ b/test/ClangImporter/MixedSource/Xcc_include.swift
@@ -1,12 +1,7 @@
 // RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xcc -include -Xcc %S/Inputs/Xcc_include.h -typecheck %s 2>&1 | %FileCheck -check-prefix=CHECK-INCLUDE-ONLY %s
-
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xcc -include -Xcc %S/Inputs/Xcc_include.h -import-objc-header %S/../../Inputs/empty.swift -typecheck %s 2>&1 | %FileCheck -check-prefix=CHECK-INCLUDE-PLUS-BRIDGING %s
-
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xcc -include -Xcc %S/Inputs/Xcc_include.h -F %S/Inputs/mixed-target/ -module-name Mixed -import-underlying-module -typecheck %s -disable-objc-attr-requires-foundation-module 2>&1 | %FileCheck -check-prefix=CHECK-INCLUDE-FRAMEWORK %s
-
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xcc -include -Xcc %S/Inputs/Xcc_include.h -enable-objc-interop -import-objc-header %S/../../Inputs/empty.swift -typecheck %s 2>&1 | %FileCheck -check-prefix=CHECK-INCLUDE-PLUS-BRIDGING %s
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xcc -include -Xcc %S/Inputs/Xcc_include.h -F %S/Inputs/mixed-target/ -module-name Mixed -import-underlying-module -typecheck %s -enable-objc-interop -disable-objc-attr-requires-foundation-module 2>&1 | %FileCheck -check-prefix=CHECK-INCLUDE-FRAMEWORK %s
 // RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -Xcc -include -Xcc %S/Inputs/this_header_does_not_exist.h -typecheck %s 2>&1 | %FileCheck -check-prefix=CHECK-INCLUDE-MISSING %s
-
-// REQUIRES: objc_interop
 
 // CHECK-INCLUDE-MISSING: error: '{{.*}}this_header_does_not_exist.h' file not found
 

--- a/test/ClangImporter/MixedSource/broken-bridging-header.swift
+++ b/test/ClangImporter/MixedSource/broken-bridging-header.swift
@@ -1,14 +1,14 @@
 // RUN: %empty-directory(%t)
-// RUN: not %target-swift-frontend -typecheck %S/../../Inputs/empty.swift -import-objc-header %t/fake.h 2>&1 | %FileCheck -check-prefix=MISSING-HEADER %s
+// RUN: not %target-swift-frontend -typecheck %S/../../Inputs/empty.swift -enable-objc-interop -import-objc-header %t/fake.h 2>&1 | %FileCheck -check-prefix=MISSING-HEADER %s
 
 // RUN: cp %S/Inputs/error-on-define.h %t
-// RUN: not %target-swift-frontend -typecheck %S/../../Inputs/empty.swift -import-objc-header %t/error-on-define.h 2>&1 | %FileCheck -check-prefix=MISSING-OTHER-HEADER %s
+// RUN: not %target-swift-frontend -typecheck %S/../../Inputs/empty.swift -enable-objc-interop -import-objc-header %t/error-on-define.h 2>&1 | %FileCheck -check-prefix=MISSING-OTHER-HEADER %s
 
 // RUN: cp %S/Inputs/error-on-define-impl.h %t
-// RUN: not %target-swift-frontend -typecheck %S/../../Inputs/empty.swift -import-objc-header %t/error-on-define.h -Xcc -DERROR 2>&1 | %FileCheck -check-prefix=HEADER-ERROR %s
+// RUN: not %target-swift-frontend -typecheck %S/../../Inputs/empty.swift -enable-objc-interop -import-objc-header %t/error-on-define.h -Xcc -DERROR 2>&1 | %FileCheck -check-prefix=HEADER-ERROR %s
 
 
-// RUN: %target-swift-frontend -emit-module -o %t -module-name HasBridgingHeader %S/../../Inputs/empty.swift -import-objc-header %t/error-on-define.h
+// RUN: %target-swift-frontend -emit-module -o %t -module-name HasBridgingHeader %S/../../Inputs/empty.swift -enable-objc-interop -import-objc-header %t/error-on-define.h
 
 // RUN: %target-swift-frontend -typecheck %s -I %t -Xcc -DERROR -verify -show-diagnostics-after-fatal
 // RUN: not %target-swift-frontend -typecheck %s -I %t -Xcc -DERROR 2>&1 | %FileCheck -check-prefix=HEADER-ERROR %s
@@ -16,8 +16,6 @@
 // RUN: rm %t/error-on-define-impl.h
 // RUN: %target-swift-frontend -typecheck %s -I %t -verify -show-diagnostics-after-fatal
 // RUN: not %target-swift-frontend -typecheck %s -I %t 2>&1 | %FileCheck -check-prefix=MISSING-OTHER-HEADER %s
-
-// REQUIRES: objc_interop
 
 import HasBridgingHeader // expected-error {{failed to import bridging header}} expected-error {{failed to load module 'HasBridgingHeader'}}
 

--- a/test/ClangImporter/MixedSource/broken-modules.swift
+++ b/test/ClangImporter/MixedSource/broken-modules.swift
@@ -1,13 +1,9 @@
 // RUN: %empty-directory(%t)
-// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/broken-modules/ -enable-source-import -show-diagnostics-after-fatal 2> %t/err.txt
-// RUN: %FileCheck -check-prefix CHECK -check-prefix CLANG-CHECK %s < %t/err.txt
+// RUN: not %target-swift-frontend -enable-objc-interop -typecheck %s -I %S/Inputs/broken-modules/ -enable-source-import -show-diagnostics-after-fatal -o /dev/null 2>&1 | %FileCheck -check-prefix CHECK -check-prefix CLANG-CHECK %s
 
-// RUN: not %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/broken-modules/BrokenClangModule.h -enable-source-import 2> %t/err.bridging-header.txt 
-// RUN: %FileCheck -check-prefix CHECK-BRIDGING-HEADER -check-prefix CLANG-CHECK %s < %t/err.bridging-header.txt
+// RUN: not %target-swift-frontend -typecheck %s -enable-objc-interop -import-objc-header %S/Inputs/broken-modules/BrokenClangModule.h -enable-source-import -o /dev/null 2>&1 | %FileCheck -check-prefix CHECK-BRIDGING-HEADER -check-prefix CLANG-CHECK %s 
 
-// RUN: not %target-swift-frontend -typecheck %s -import-objc-header %S/../../Inputs/empty.swift 2>&1 | %FileCheck -check-prefix=EMPTY-HEADER %s
-
-// REQUIRES: objc_interop
+// RUN: not %target-swift-frontend -typecheck %s -enable-objc-interop -import-objc-header %S/../../Inputs/empty.swift 2>&1 | %FileCheck -check-prefix=EMPTY-HEADER %s
 
 // EMPTY-HEADER-NOT: header
 

--- a/test/ClangImporter/MixedSource/can_import_objc_idempotent.swift
+++ b/test/ClangImporter/MixedSource/can_import_objc_idempotent.swift
@@ -2,11 +2,11 @@
 // RUN: cp -R %S/Inputs/mixed-target %t
 
 // FIXME: BEGIN -enable-source-import hackaround
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
 // FIXME: END -enable-source-import hackaround
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -import-objc-header %t/mixed-target/header.h -emit-module-path %t/MixedWithHeader.swiftmodule %S/Inputs/mixed-with-header.swift %S/../../Inputs/empty.swift -module-name MixedWithHeader -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -enable-objc-interop -import-objc-header %t/mixed-target/header.h -emit-module-path %t/MixedWithHeader.swiftmodule %S/Inputs/mixed-with-header.swift %S/../../Inputs/empty.swift -module-name MixedWithHeader -disable-objc-attr-requires-foundation-module
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -typecheck %s -verify
 
 // RUN: rm -rf %t/mixed-target/

--- a/test/ClangImporter/MixedSource/defer-supermodule-import.swift
+++ b/test/ClangImporter/MixedSource/defer-supermodule-import.swift
@@ -1,7 +1,6 @@
-// RUN: not %target-swift-frontend -F %S/Inputs/defer-supermodule-import -import-objc-header %S/Inputs/defer-supermodule-import/Some-Bridging-Header.h -typecheck %s 2>&1 | %FileCheck -check-prefix=HEADER-ERROR %s
+// RUN: not %target-swift-frontend -F %S/Inputs/defer-supermodule-import -enable-objc-interop -import-objc-header %S/Inputs/defer-supermodule-import/Some-Bridging-Header.h -typecheck %s 2>&1 | %FileCheck -check-prefix=HEADER-ERROR %s
 // HEADER-ERROR: Some-Bridging-Header.h:4:13: error: expected a type
 // HEADER-ERROR: Some-Bridging-Header.h:7:10: error: declaration of 'TYPE' must be imported from module 'Some' before it is required
-// REQUIRES: objc_interop
 
 // The bug we're testing here is that:
 //

--- a/test/ClangImporter/MixedSource/import-mixed-framework-with-forward.swift
+++ b/test/ClangImporter/MixedSource/import-mixed-framework-with-forward.swift
@@ -1,16 +1,14 @@
 // RUN: %empty-directory(%t)
 // RUN: cp -r %S/Inputs/mixed-framework/Mixed.framework %t
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t/Mixed.framework/Modules/Mixed.swiftmodule/%target-swiftmodule-name %S/Inputs/mixed-framework/Mixed.swift -import-underlying-module -F %t -module-name Mixed -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t/Mixed.framework/Modules/Mixed.swiftmodule/%target-swiftmodule-name %S/Inputs/mixed-framework/Mixed.swift -import-underlying-module -F %t -module-name Mixed -enable-objc-interop -disable-objc-attr-requires-foundation-module
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %t -import-objc-header %S/Inputs/import-mixed-framework-with-forward.h %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %t -enable-objc-interop -import-objc-header %S/Inputs/import-mixed-framework-with-forward.h %s -verify
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-pch -F %t %S/Inputs/import-mixed-framework-with-forward.h -o %t/bridge.pch
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %t -import-objc-header %t/bridge.pch %s -verify
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %t -import-objc-header %S/Inputs/import-mixed-framework-with-forward.h -pch-output-dir %t/pch %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-pch -F %t %S/Inputs/import-mixed-framework-with-forward.h -o %t/bridge.pch
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %t -enable-objc-interop -import-objc-header %t/bridge.pch %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %t -enable-objc-interop -import-objc-header %S/Inputs/import-mixed-framework-with-forward.h -pch-output-dir %t/pch %s -verify
 
-
-// REQUIRES: objc_interop
 
 import Mixed
 

--- a/test/ClangImporter/MixedSource/import-mixed-framework.swift
+++ b/test/ClangImporter/MixedSource/import-mixed-framework.swift
@@ -4,10 +4,8 @@
 // Don't crash if a generated header is present but the swiftmodule is missing.
 // RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %t -typecheck %s
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t/Mixed.framework/Modules/Mixed.swiftmodule/%target-swiftmodule-name %S/Inputs/mixed-framework/Mixed.swift -import-underlying-module -F %t -module-name Mixed -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %t -typecheck %s -verify
-
-// XFAIL: linux
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module -o %t/Mixed.framework/Modules/Mixed.swiftmodule/%target-swiftmodule-name %S/Inputs/mixed-framework/Mixed.swift -import-underlying-module -F %t -module-name Mixed -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -F %t -typecheck %s -verify
 
 import Mixed
 

--- a/test/ClangImporter/MixedSource/import-mixed-with-header-twice.swift
+++ b/test/ClangImporter/MixedSource/import-mixed-with-header-twice.swift
@@ -1,14 +1,12 @@
 // RUN: %empty-directory(%t)
 // RUN: cp -R %S/Inputs/mixed-target %t
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../Inputs/custom-modules -import-objc-header %t/mixed-target/header.h -emit-module-path %t/MixedWithHeader.swiftmodule %S/Inputs/mixed-with-header.swift %S/../../Inputs/empty.swift -module-name MixedWithHeader -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -I %S/../Inputs/custom-modules -import-objc-header %t/mixed-target/header-again.h -emit-module-path %t/MixedWithHeaderAgain.swiftmodule %S/Inputs/mixed-with-header-again.swift %S/../../Inputs/empty.swift -module-name MixedWithHeaderAgain -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../Inputs/custom-modules -I %t -typecheck %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../Inputs/custom-modules -enable-objc-interop -import-objc-header %t/mixed-target/header.h -emit-module-path %t/MixedWithHeader.swiftmodule %S/Inputs/mixed-with-header.swift %S/../../Inputs/empty.swift -module-name MixedWithHeader -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -I %S/../Inputs/custom-modules -enable-objc-interop -import-objc-header %t/mixed-target/header-again.h -emit-module-path %t/MixedWithHeaderAgain.swiftmodule %S/Inputs/mixed-with-header-again.swift %S/../../Inputs/empty.swift -module-name MixedWithHeaderAgain -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../Inputs/custom-modules -I %t -enable-objc-interop -typecheck %s -verify
 
 // RUN: rm %t/mixed-target/header.h
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -I %S/../Inputs/custom-modules -typecheck %s 2>&1 | %FileCheck %s -check-prefix=USE-SERIALIZED-HEADER
-
-// XFAIL: linux
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %t -I %S/../Inputs/custom-modules -enable-objc-interop -typecheck %s 2>&1 | %FileCheck %s -check-prefix=USE-SERIALIZED-HEADER
 
 // USE-SERIALIZED-HEADER: redefinition of 'Point2D'
 // USE-SERIALIZED-HEADER: previous definition is here

--- a/test/ClangImporter/MixedSource/import-mixed-with-header.swift
+++ b/test/ClangImporter/MixedSource/import-mixed-with-header.swift
@@ -2,15 +2,15 @@
 // RUN: cp -R %S/Inputs/mixed-target %t
 
 // FIXME: BEGIN -enable-source-import hackaround
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift
 // FIXME: END -enable-source-import hackaround
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -import-objc-header %t/mixed-target/header.h -emit-module-path %t/MixedWithHeader.swiftmodule %S/Inputs/mixed-with-header.swift %S/../../Inputs/empty.swift -module-name MixedWithHeader -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -typecheck %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -import-objc-header %t/mixed-target/header.h -emit-module-path %t/MixedWithHeader.swiftmodule %S/Inputs/mixed-with-header.swift %S/../../Inputs/empty.swift -module-name MixedWithHeader -enable-objc-interop -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -enable-objc-interop -typecheck %s -verify
 
 // RUN: rm -rf %t/mixed-target/
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -typecheck %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -I %S/../Inputs/custom-modules -enable-objc-interop -typecheck %s -verify
 
 // XFAIL: linux
 

--- a/test/ClangImporter/MixedSource/mixed-target-using-header-swift4.swift
+++ b/test/ClangImporter/MixedSource/mixed-target-using-header-swift4.swift
@@ -1,4 +1,3 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../Inputs/custom-modules -import-objc-header %S/Inputs/mixed-target/header.h -typecheck -primary-file %S/mixed-target-using-header.swift %S/Inputs/mixed-target/other-file.swift -disable-objc-attr-requires-foundation-module -verify -swift-version 4
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../Inputs/custom-modules -import-objc-header %S/Inputs/mixed-target/header.h -emit-sil -primary-file %S/mixed-target-using-header.swift %S/Inputs/mixed-target/other-file.swift -disable-objc-attr-requires-foundation-module -o /dev/null -D SILGEN -swift-version 4
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../Inputs/custom-modules -enable-objc-interop -import-objc-header %S/Inputs/mixed-target/header.h -typecheck -primary-file %S/mixed-target-using-header.swift %S/Inputs/mixed-target/other-file.swift -disable-objc-attr-requires-foundation-module -verify -swift-version 4
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../Inputs/custom-modules -enable-objc-interop -import-objc-header %S/Inputs/mixed-target/header.h -emit-sil -primary-file %S/mixed-target-using-header.swift %S/Inputs/mixed-target/other-file.swift -disable-objc-attr-requires-foundation-module -o /dev/null -D SILGEN -swift-version 4
 
-// REQUIRES: objc_interop

--- a/test/ClangImporter/MixedSource/mixed-target-using-header.swift
+++ b/test/ClangImporter/MixedSource/mixed-target-using-header.swift
@@ -1,7 +1,5 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../Inputs/custom-modules -import-objc-header %S/Inputs/mixed-target/header.h -typecheck -primary-file %s %S/Inputs/mixed-target/other-file.swift -disable-objc-attr-requires-foundation-module -verify
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../Inputs/custom-modules -import-objc-header %S/Inputs/mixed-target/header.h -emit-sil -primary-file %s %S/Inputs/mixed-target/other-file.swift -disable-objc-attr-requires-foundation-module -o /dev/null -D SILGEN
-
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../Inputs/custom-modules -enable-objc-interop -import-objc-header %S/Inputs/mixed-target/header.h -typecheck -primary-file %s %S/Inputs/mixed-target/other-file.swift -disable-objc-attr-requires-foundation-module -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/../Inputs/custom-modules -enable-objc-interop -import-objc-header %S/Inputs/mixed-target/header.h -emit-sil -primary-file %s %S/Inputs/mixed-target/other-file.swift -disable-objc-attr-requires-foundation-module -o /dev/null -D SILGEN
 
 func test(_ foo : FooProto) {
   _ = foo.bar as CInt

--- a/test/ClangImporter/MixedSource/mixed-target-using-module.swift
+++ b/test/ClangImporter/MixedSource/mixed-target-using-module.swift
@@ -1,8 +1,6 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %S/Inputs/mixed-target/ -module-name Mixed -import-underlying-module -typecheck %s -verify -disable-objc-attr-requires-foundation-module
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %S/Inputs/mixed-target/ -module-name Mixed -import-underlying-module -emit-ir %S/../../Inputs/empty.swift - | %FileCheck -check-prefix=CHECK-AUTOLINK %s
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %S/Inputs/mixed-target/ -module-name WrongName -import-underlying-module -typecheck %s  -disable-objc-attr-requires-foundation-module 2>&1 | %FileCheck -check-prefix=CHECK-WRONG-NAME %s
-
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %S/Inputs/mixed-target/ -module-name Mixed -import-underlying-module -typecheck %s -verify -enable-objc-interop -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %S/Inputs/mixed-target/ -module-name Mixed -import-underlying-module -enable-objc-interop -emit-ir %S/../../Inputs/empty.swift - | %FileCheck -check-prefix=CHECK-AUTOLINK %s
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -F %S/Inputs/mixed-target/ -module-name WrongName -import-underlying-module -typecheck %s  -enable-objc-interop -disable-objc-attr-requires-foundation-module 2>&1 | %FileCheck -check-prefix=CHECK-WRONG-NAME %s
 
 // CHECK-AUTOLINK: !llvm.linker.options = !{
 // CHECK-AUTOLINK-NOT: metadata !"-framework", metadata !"Mixed"

--- a/test/ClangImporter/MixedSource/resolve-cross-language.swift
+++ b/test/ClangImporter/MixedSource/resolve-cross-language.swift
@@ -1,10 +1,8 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -emit-module -emit-objc-header -o %t %S/Inputs/resolve-cross-language/Base.swift -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -emit-module -enable-objc-interop -emit-objc-header -o %t %S/Inputs/resolve-cross-language/Base.swift -disable-objc-attr-requires-foundation-module
 // RUN: cp %S/Inputs/resolve-cross-language/Base-module.map %t/module.map
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -typecheck -I %t -F %S/Inputs/resolve-cross-language %s -verify
-
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource) -enable-objc-interop -typecheck -I %t -F %S/Inputs/resolve-cross-language %s -verify
 
 import Base
 import BaseUser

--- a/test/ClangImporter/attr-objc_subclassing_restricted.swift
+++ b/test/ClangImporter/attr-objc_subclassing_restricted.swift
@@ -1,9 +1,7 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -import-objc-header %S/Inputs/attr-objc_subclassing_restricted.h %s -swift-version 5 -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -enable-objc-interop -import-objc-header %S/Inputs/attr-objc_subclassing_restricted.h %s -swift-version 5 -verify
 
 // No errors in Swift 3 and 4 modes.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -import-objc-header %S/Inputs/attr-objc_subclassing_restricted.h %s -swift-version 4
-
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -enable-objc-interop -import-objc-header %S/Inputs/attr-objc_subclassing_restricted.h %s -swift-version 4
 
 class Sub: Restricted { // expected-error {{cannot inherit from non-open class 'Restricted' outside of its defining module}}
 }

--- a/test/ClangImporter/attr-swift_name_renaming-objc.swift
+++ b/test/ClangImporter/attr-swift_name_renaming-objc.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -Xcc -w -typecheck -verify %s
-
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -I %S/Inputs/custom-modules -Xcc -w -typecheck -verify %s
 
 import SwiftName
 

--- a/test/ClangImporter/autolinking.swift
+++ b/test/ClangImporter/autolinking.swift
@@ -1,14 +1,13 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend %s -sdk %S/Inputs -I %S/Inputs/custom-modules -emit-ir -o %t/without-adapter.ll
-// RUN: %FileCheck %s < %t/without-adapter.ll
+// RUN: %target-swift-frontend %s -sdk %S/Inputs -I %S/Inputs/custom-modules -emit-ir -o - | %FileCheck %s
 
 // RUN: %target-swift-frontend -emit-module %S/Inputs/adapter.swift -sdk %S/Inputs -module-link-name SwiftAdapter -module-name ClangModuleWithAdapter -I %S/Inputs/custom-modules -o %t
+
 // RUN: %target-swift-frontend %s -sdk %S/Inputs -I %S/Inputs/custom-modules -I %t -emit-ir -o %t/with-adapter.ll
 // RUN: %FileCheck %s < %t/with-adapter.ll
-// RUN: %FileCheck --check-prefix=CHECK-WITH-SWIFT %s < %t/with-adapter.ll
+// RUN: %FileCheck -check-prefix CHECK-WITH-SWIFT %s < %t/with-adapter.ll
 
-// RUN: %target-swift-frontend %s -sdk %S/Inputs -I %S/Inputs/custom-modules -emit-ir -disable-autolink-framework LinkFramework -o %t/with-disabled.ll
-// RUN: %FileCheck --check-prefix=CHECK-WITH-DISABLED %s < %t/with-disabled.ll
+// RUN: %target-swift-frontend %s -sdk %S/Inputs -I %S/Inputs/custom-modules -emit-ir -disable-autolink-framework LinkFramework -o - | %FileCheck -check-prefix CHECK-WITH-DISABLED %s
 
 // Linux uses a different autolinking mechanism, based on
 // swift-autolink-extract. This file tests the Darwin mechanism.

--- a/test/ClangImporter/availability_returns_twice.swift
+++ b/test/ClangImporter/availability_returns_twice.swift
@@ -3,8 +3,11 @@
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
   import Darwin
   typealias JumpBuffer = Int32
-#else
+#elseif os(Android) || os(Cygwin) || os(FreeBSD) || os(Linux)
   import Glibc
+  typealias JumpBuffer = jmp_buf
+#elseif os(Windows)
+  import MSVCRT
   typealias JumpBuffer = jmp_buf
 #endif
 

--- a/test/ClangImporter/bad-ns-extensible-string-enum.swift
+++ b/test/ClangImporter/bad-ns-extensible-string-enum.swift
@@ -1,4 +1,3 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -import-objc-header %S/Inputs/bad-ns-extensible-string-enum.h -verify
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -enable-objc-interop -import-objc-header %S/Inputs/bad-ns-extensible-string-enum.h -verify
 
 let string = MyString.MyStringOne // expected-error {{use of unresolved identifier 'MyString'}}

--- a/test/ClangImporter/broken-modules.swift
+++ b/test/ClangImporter/broken-modules.swift
@@ -1,18 +1,8 @@
-// RUN: %empty-directory(%t)
+// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules/ -enable-objc-interop -show-diagnostics-after-fatal -D MISSING_FROM_MODULE -o /dev/null 2>&1 | %FileCheck -check-prefix CHECK-MODULE-MAP %s
+// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules/ -enable-objc-interop -show-diagnostics-after-fatal -o /dev/null 2>&1 | %FileCheck -check-prefix CHECK -check-prefix CHECK-DIRECT %s
+// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules/ -enable-objc-interop -show-diagnostics-after-fatal -D INDIRECT -o /dev/null 2>&1 | %FileCheck -check-prefix CHECK -check-prefix CHECK-INDIRECT %s
 
-// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules/ -show-diagnostics-after-fatal -D MISSING_FROM_MODULE 2> %t/err.txt
-// RUN: %FileCheck -check-prefix CHECK-MODULE-MAP %s < %t/err.txt
-
-// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules/ -show-diagnostics-after-fatal 2> %t/err.txt
-// RUN: %FileCheck -check-prefix CHECK -check-prefix CHECK-DIRECT %s < %t/err.txt
-
-// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules/ -show-diagnostics-after-fatal -D INDIRECT 2> %t/err.txt
-// RUN: %FileCheck -check-prefix CHECK -check-prefix CHECK-INDIRECT %s < %t/err.txt
-
-// FIXME: not every test here depends on Objective-C syntax, this test can be
-// split.
-//
-// REQUIRES: objc_interop
+// FIXME: not every test here depends on Objective-C syntax, this test can be split.
 
 #if MISSING_FROM_MODULE
 import MissingHeader

--- a/test/ClangImporter/c_inside_objc.swift
+++ b/test/ClangImporter/c_inside_objc.swift
@@ -1,12 +1,10 @@
-// RUN: %target-swift-ide-test -print-module -module-to-print CInsideObjC -I %S/Inputs/custom-modules -source-filename %s -Xcc -DCLASS | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -module-to-print CInsideObjC -I %S/Inputs/custom-modules -source-filename %s -Xcc -DCATEGORY | %FileCheck %s
-// RUN: %target-swift-ide-test -print-module -module-to-print CInsideObjC -I %S/Inputs/custom-modules -source-filename %s -Xcc -DPROTOCOL | %FileCheck %s
+// RUN: %target-swift-ide-test -enable-objc-interop -print-module -module-to-print CInsideObjC -I %S/Inputs/custom-modules -source-filename %s -Xcc -DCLASS | %FileCheck %s
+// RUN: %target-swift-ide-test -enable-objc-interop -print-module -module-to-print CInsideObjC -I %S/Inputs/custom-modules -source-filename %s -Xcc -DCATEGORY | %FileCheck %s
+// RUN: %target-swift-ide-test -enable-objc-interop -print-module -module-to-print CInsideObjC -I %S/Inputs/custom-modules -source-filename %s -Xcc -DPROTOCOL | %FileCheck %s
 
-// RUN: %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules -verify -Xcc -DCLASS
-// RUN: %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules -verify -Xcc -DCATEGORY
-// RUN: %target-swift-frontend -typecheck %s -I %S/Inputs/custom-modules -verify -Xcc -DPROTOCOL
-
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend -enable-objc-interop -typecheck %s -I %S/Inputs/custom-modules -verify -Xcc -DCLASS
+// RUN: %target-swift-frontend -enable-objc-interop -typecheck %s -I %S/Inputs/custom-modules -verify -Xcc -DCATEGORY
+// RUN: %target-swift-frontend -enable-objc-interop -typecheck %s -I %S/Inputs/custom-modules -verify -Xcc -DPROTOCOL
 
 // CHECK-LABEL: struct AlreadyDeclaredStruct {
 

--- a/test/ClangImporter/can_import_missing_requirement.swift
+++ b/test/ClangImporter/can_import_missing_requirement.swift
@@ -1,7 +1,5 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/missing-requirement %s -verify
 
-// REQUIRES: objc_interop
-
 class Unique {}
 
 #if canImport(MissingRequirement)

--- a/test/ClangImporter/clang_builtins.swift
+++ b/test/ClangImporter/clang_builtins.swift
@@ -5,8 +5,10 @@
 
 #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
   import Darwin
-#else
+#elseif os(Android) || os(Cygwin) || os(FreeBSD) || os(Linux)
   import Glibc
+#elseif os(Windows)
+  import MSVCRT
 #endif
 
 func test() {

--- a/test/ClangImporter/const_and_pure.swift
+++ b/test/ClangImporter/const_and_pure.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil %s -import-objc-header %S/Inputs/const_and_pure.h | %FileCheck %s
+// RUN: %target-swift-frontend -emit-sil %s -enable-objc-interop -import-objc-header %S/Inputs/const_and_pure.h | %FileCheck %s
 
 func testit() {
 	const_function()

--- a/test/ClangImporter/ctypes_parse_objc.swift
+++ b/test/ClangImporter/ctypes_parse_objc.swift
@@ -1,6 +1,4 @@
-// RUN: %target-typecheck-verify-swift %clang-importer-sdk
-
-// REQUIRES: objc_interop
+// RUN: %target-typecheck-verify-swift %clang-importer-sdk -enable-objc-interop
 
 import ctypes
 import CoreGraphics

--- a/test/ClangImporter/diags-with-many-imports.swift
+++ b/test/ClangImporter/diags-with-many-imports.swift
@@ -1,7 +1,7 @@
-// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/many-imports -import-objc-header %S/Inputs/many-imports/obsoleted.h 2>&1 | %FileCheck %s
-// RUN: %target-swift-frontend -emit-pch %S/Inputs/many-imports/obsoleted.h -o %t.pch
-// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/many-imports -import-objc-header %t.pch 2>&1 | %FileCheck %s
-// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/many-imports -import-objc-header %S/Inputs/many-imports/obsoleted.h -pch-output-dir %t/pch 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/many-imports -enable-objc-interop -import-objc-header %S/Inputs/many-imports/obsoleted.h 2>&1 | %FileCheck %s
+// RUN: %target-swift-frontend -enable-objc-interop -emit-pch %S/Inputs/many-imports/obsoleted.h -o %t.pch
+// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/many-imports -enable-objc-interop -import-objc-header %t.pch 2>&1 | %FileCheck %s
+// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/many-imports -enable-objc-interop -import-objc-header %S/Inputs/many-imports/obsoleted.h -pch-output-dir %t/pch 2>&1 | %FileCheck %s
 
 import Module1
 import Module2

--- a/test/ClangImporter/diags_from_header.swift
+++ b/test/ClangImporter/diags_from_header.swift
@@ -1,6 +1,6 @@
-// RUN: not %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/diags_from_header.h 2>&1 | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-WARN
+// RUN: not %target-swift-frontend -typecheck %s -enable-objc-interop -import-objc-header %S/Inputs/diags_from_header.h 2>&1 | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-WARN
 
-// RUN: not %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/diags_from_header.h -Xcc -Wno-#warnings 2>&1 | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-NO-WARN
+// RUN: not %target-swift-frontend -typecheck %s -enable-objc-interop -import-objc-header %S/Inputs/diags_from_header.h -Xcc -Wno-#warnings 2>&1 | %FileCheck %s -check-prefix=CHECK -check-prefix=CHECK-NO-WARN
 
 // CHECK-WARN: diags_from_header.h:{{.*}}:2: warning: "here is some warning about something"
 // CHECK-NO-WARN-NOT: warning about something

--- a/test/ClangImporter/diags_from_module.swift
+++ b/test/ClangImporter/diags_from_module.swift
@@ -1,13 +1,11 @@
-// RUN: not %target-swift-frontend -typecheck %s -F %S/Inputs/frameworks -Xcc -D -Xcc FOO 2> %t.err.txt
-// RUN: %FileCheck -input-file=%t.err.txt %s
+// RUN: %empty-directory(%t)
+// RUN: not %target-swift-frontend -module-cache-path %t -enable-objc-interop -typecheck %s -F %S/Inputs/frameworks -Xcc -D -Xcc FOO -o /dev/null 2>&1 | %FileCheck %s
 
-// RUN: %target-swift-frontend -typecheck %s -F %S/Inputs/frameworks 2> %t.warn.txt
-// RUN: %FileCheck -input-file=%t.warn.txt %s -check-prefix=CHECK-WARN
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -module-cache-path %t -enable-objc-interop -typecheck %s -F %S/Inputs/frameworks -o /dev/null 2>&1 | %FileCheck %s -check-prefix CHECK-WARN
 
-// RUN: %target-swift-frontend -typecheck %s -F %S/Inputs/frameworks -Xcc -Wno-#warnings 2> %t.nowarn.txt
-// RUN: %FileCheck -input-file=%t.nowarn.txt %s -check-prefix=CHECK-NO-WARN -allow-empty
-
-// XFAIL: linux
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -module-cache-path %t -enable-objc-interop -typecheck %s -F %S/Inputs/frameworks -Xcc -Wno-#warnings -o /dev/null 2>&1 | %FileCheck -check-prefix CHECK-NO-WARN -allow-empty %s
 
 import Module
 
@@ -16,6 +14,7 @@ import Module
 // CHECK: diags_from_module.swift:[[@LINE-4]]:8: error: could not build Objective-C module 'Module'
 
 // CHECK-WARN: Sub2.h:7:2: warning: here is some warning about something
-// FIXME: show the clang warning: <module-includes>:1:1: warning: umbrella header for module 'Module' does not include header 'NotInModule.h' [-Wincomplete-umbrella]
+// CHECK-WARN: <module-includes>:1:1: warning: umbrella header for module 'Module' does not include header 'NotInModule.h'
+// FIXME: show [-Wincomplete-umbrella]
 
 // CHECK-NO-WARN-NOT: warning about something

--- a/test/ClangImporter/enum-anon.swift
+++ b/test/ClangImporter/enum-anon.swift
@@ -1,5 +1,5 @@
-// RUN: %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/enum-anon.h -DDIAGS -verify
-// RUN: %target-swift-frontend -emit-ir %s -import-objc-header %S/Inputs/enum-anon.h | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-%target-runtime %s
+// RUN: %target-swift-frontend -typecheck %s -enable-objc-interop -import-objc-header %S/Inputs/enum-anon.h -DDIAGS -verify
+// RUN: %target-swift-frontend -emit-ir %s -enable-objc-interop -import-objc-header %S/Inputs/enum-anon.h | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-%target-runtime %s
 
 #if DIAGS
 func testDiags() {

--- a/test/ClangImporter/enum-dataflow.swift
+++ b/test/ClangImporter/enum-dataflow.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify
-
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify -enable-objc-interop
 
 import Foundation
 import user_objc

--- a/test/ClangImporter/enum-inferred-exhaustivity.swift
+++ b/test/ClangImporter/enum-inferred-exhaustivity.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -typecheck %s -import-objc-header %S/Inputs/enum-inferred-exhaustivity.h -verify -enable-nonfrozen-enum-exhaustivity-diagnostics -warnings-as-errors
+// RUN: %target-swift-frontend -typecheck %s -enable-objc-interop -import-objc-header %S/Inputs/enum-inferred-exhaustivity.h -verify -enable-nonfrozen-enum-exhaustivity-diagnostics -warnings-as-errors
 
 // This is testing what happens with a CF_ENUM definition that doesn't include
 // any enum_extensibility attributes. As such, the test deliberately avoids

--- a/test/ClangImporter/enum-objc.swift
+++ b/test/ClangImporter/enum-objc.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-sil %s -import-objc-header %S/Inputs/enum-objc.h -verify -enable-nonfrozen-enum-exhaustivity-diagnostics
+// RUN: %target-swift-frontend -emit-sil %s -enable-objc-interop -import-objc-header %S/Inputs/enum-objc.h -verify -enable-nonfrozen-enum-exhaustivity-diagnostics
 
 // REQUIRES: objc_interop
 

--- a/test/ClangImporter/import-as-member-objc.swift
+++ b/test/ClangImporter/import-as-member-objc.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/../IDE/Inputs/custom-modules %s -verify
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/../IDE/Inputs/custom-modules %s -verify -enable-objc-interop
 
 import ImportAsMember.Class
 

--- a/test/ClangImporter/import-as-member.swift
+++ b/test/ClangImporter/import-as-member.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -I %S/Inputs/custom-modules %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -F %S/Inputs/frameworks -I %S/Inputs/custom-modules %s -verify
 
 import ImportAsMember
 import ImportAsMemberSubmodules

--- a/test/ClangImporter/inherited-protocols-sil.swift
+++ b/test/ClangImporter/inherited-protocols-sil.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-frontend -sdk "" -emit-sil %s -import-objc-header %S/Inputs/inherited-protocols-sil.h -O
-
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend -sdk "" -emit-sil %s -enable-objc-interop -import-objc-header %S/Inputs/inherited-protocols-sil.h -O
 
 // <rdar://problem/24547884> Protocol Extensions May Crash Swift Compiler when Whole-Module Optimization is Enabled
 

--- a/test/ClangImporter/invalid_bridging_header.swift
+++ b/test/ClangImporter/invalid_bridging_header.swift
@@ -1,7 +1,4 @@
-// RUN: not %target-swift-frontend -typecheck -import-objc-header %S/Inputs/invalid_bridging_header.h %s > %t.out 2>&1 
-// RUN: %FileCheck %s < %t.out
-
-// REQUIRES: objc_interop
+// RUN: not %target-swift-frontend -typecheck -enable-objc-interop -import-objc-header %S/Inputs/invalid_bridging_header.h %s -o - 2>&1 | %FileCheck %s
 
 // CHECK: 1:12: error: cannot find interface declaration for 'UndeclaredError'
 // CHECK: error: failed to import bridging header

--- a/test/ClangImporter/macros_redef.swift
+++ b/test/ClangImporter/macros_redef.swift
@@ -1,6 +1,5 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -import-objc-header %S/Inputs/macros_redef.h -emit-silgen %s | %FileCheck -check-prefix=NEGATIVE %s
-
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -import-objc-header %S/Inputs/macros_redef.h -DCONFLICT -typecheck -verify %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -enable-objc-interop -import-objc-header %S/Inputs/macros_redef.h -emit-silgen %s | %FileCheck -check-prefix=NEGATIVE %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -I %S/Inputs/custom-modules -enable-objc-interop -import-objc-header %S/Inputs/macros_redef.h -DCONFLICT -typecheck -verify %s
 
 // NEGATIVE-NOT: OLDTAG
 

--- a/test/ClangImporter/mirror_import_overrides.swift
+++ b/test/ClangImporter/mirror_import_overrides.swift
@@ -1,7 +1,5 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/mirror_import_overrides_1.h -typecheck -verify %s
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/mirror_import_overrides_2.h -typecheck -verify %s
-
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -import-objc-header %S/Inputs/mirror_import_overrides_1.h -typecheck -verify %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -import-objc-header %S/Inputs/mirror_import_overrides_2.h -typecheck -verify %s
 
 // rdar://31471034
 

--- a/test/ClangImporter/no-import-objc.swift
+++ b/test/ClangImporter/no-import-objc.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/no-import-objc %s -verify
-
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -enable-objc-interop -I %S/Inputs/no-import-objc %s -verify
 
 // Note that we don't import ObjectiveC.
 import People

--- a/test/ClangImporter/non-modular-include.swift
+++ b/test/ClangImporter/non-modular-include.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: not %target-swift-frontend -typecheck %s -I %S/Inputs/non-modular -F %S/Inputs/non-modular 2>&1 | %FileCheck --check-prefix=CHECK --check-prefix=CHECK-%target-runtime %s
+// RUN: not %target-swift-frontend -enable-objc-interop -typecheck %s -I %S/Inputs/non-modular -F %S/Inputs/non-modular 2>&1 | %FileCheck --check-prefix=CHECK -check-prefix CHECK-objc %s
+// RUN: not %target-swift-frontend -disable-objc-interop -typecheck %s -I %S/Inputs/non-modular -F %S/Inputs/non-modular 2>&1 | %FileCheck --check-prefix=CHECK -check-prefix CHECK-native %s
 
 // CHECK: {{.+}}/non-modular/Foo.framework/Headers/Foo.h:1:9: error: include of non-modular header inside framework module 'Foo'
 // CHECK-objc: error: could not build Objective-C module 'Foo'

--- a/test/ClangImporter/nullability.swift
+++ b/test/ClangImporter/nullability.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -import-underlying-module -verify
-
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -I %S/Inputs/custom-modules %s -import-underlying-module -verify
 
 import CoreCooling
 

--- a/test/ClangImporter/objc_curried_method.swift
+++ b/test/ClangImporter/objc_curried_method.swift
@@ -1,7 +1,5 @@
-// RUN: %target-swift-frontend -swift-version 3 -typecheck %s -import-objc-header %S/Inputs/objc_curried_method.h
-// RUN: %target-swift-frontend -swift-version 4 -typecheck %s -import-objc-header %S/Inputs/objc_curried_method.h
-
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend -swift-version 3 -typecheck %s -enable-objc-interop -import-objc-header %S/Inputs/objc_curried_method.h
+// RUN: %target-swift-frontend -swift-version 4 -typecheck %s -enable-objc-interop -import-objc-header %S/Inputs/objc_curried_method.h
 
 // rdar://problem/32588152
 

--- a/test/ClangImporter/objc_diags.swift
+++ b/test/ClangImporter/objc_diags.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify
-
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck %s -verify
 
 import ObjectiveC
 

--- a/test/ClangImporter/objc_missing_designated_init.swift
+++ b/test/ClangImporter/objc_missing_designated_init.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules %s -swift-version 4 -verify
-
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -I %S/Inputs/custom-modules %s -swift-version 4 -verify
 
 import UnimportableMembers
 import UnimportableMembersUser

--- a/test/ClangImporter/objc_parse_verifier.swift
+++ b/test/ClangImporter/objc_parse_verifier.swift
@@ -1,6 +1,5 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-sil -I %S/Inputs/custom-modules %s -verify > /dev/null
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-sil -I %S/Inputs/custom-modules %s -verify > /dev/null
 
-// REQUIRES: objc_interop
 // expected-no-diagnostics
 
 // This file tests the AST verifier, which performs extra checks when there are

--- a/test/ClangImporter/objc_redeclared_properties.swift
+++ b/test/ClangImporter/objc_redeclared_properties.swift
@@ -1,8 +1,6 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -D ONE_MODULE %s -verify
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -D SUB_MODULE %s -verify
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -I %S/Inputs/custom-modules -D TWO_MODULES %s -verify
-
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -I %S/Inputs/custom-modules -D ONE_MODULE %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -I %S/Inputs/custom-modules -D SUB_MODULE %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -I %S/Inputs/custom-modules -D TWO_MODULES %s -verify
 
 #if ONE_MODULE
 import RedeclaredProperties

--- a/test/ClangImporter/objc_redeclared_properties_incompatible.swift
+++ b/test/ClangImporter/objc_redeclared_properties_incompatible.swift
@@ -1,13 +1,11 @@
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks %s 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PUBLIC %s
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -typecheck -F %S/Inputs/frameworks %s 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PUBLIC %s
 
 // RUN: echo '#import <PrivatelyReadwrite/Private.h>' > %t.h
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -import-objc-header %t.h %s 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PRIVATE %s
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -enable-objc-interop -import-objc-header %t.h %s 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PRIVATE %s
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-pch -F %S/Inputs/frameworks -o %t.pch %t.h
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -import-objc-header %t.pch %s 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PRIVATE %s
-// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -import-objc-header %t.h -pch-output-dir %t/pch %s 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PRIVATE %s
-
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-pch -F %S/Inputs/frameworks -o %t.pch %t.h
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -enable-objc-interop -import-objc-header %t.pch %s 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PRIVATE %s
+// RUN: not %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -F %S/Inputs/frameworks -enable-objc-interop -import-objc-header %t.h -pch-output-dir %t/pch %s 2>&1 | %FileCheck -check-prefix=CHECK -check-prefix=CHECK-PRIVATE %s
 
 import PrivatelyReadwrite
 

--- a/test/ClangImporter/objc_runtime_visible.swift
+++ b/test/ClangImporter/objc_runtime_visible.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-frontend -typecheck -disable-objc-attr-requires-foundation-module -I %S/../Inputs/custom-modules %s -verify
-
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend -typecheck -enable-objc-interop -disable-objc-attr-requires-foundation-module -I %S/../Inputs/custom-modules %s -verify
 
 import ObjCRuntimeVisible
 

--- a/test/ClangImporter/overlay_with_submodule.swift
+++ b/test/ClangImporter/overlay_with_submodule.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-frontend -emit-module %s -sdk %S/Inputs -module-name HasSubmodule  -I %S/Inputs/custom-modules -o %t
-
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend -enable-objc-interop -emit-module %s -sdk %S/Inputs -module-name HasSubmodule -I %S/Inputs/custom-modules -o %t
 
 @_exported import HasSubmodule
 @_exported import HasSubmodule.Submodule

--- a/test/ClangImporter/pch-bridging-header-deps.swift
+++ b/test/ClangImporter/pch-bridging-header-deps.swift
@@ -1,4 +1,3 @@
-// REQUIRES: objc_interop
 // RUN: rm -f %t.*
 //
 // Generate a bridging PCH, use it in a swift file, and check that the swift file's .swiftdeps

--- a/test/ClangImporter/pch-bridging-header-vs-modular-interface-defn.swift
+++ b/test/ClangImporter/pch-bridging-header-vs-modular-interface-defn.swift
@@ -77,8 +77,7 @@
 // RUN: rm -rf %t
 // RUN: mkdir -p %t/Headers/Simple
 // RUN: ln -s %S/Inputs/frameworks/Simple.framework/Headers/Simple.h %t/Headers/Simple/Simple.h
-// RUN: %target-build-swift -emit-module -module-name test -Xfrontend -disable-deserialization-recovery -v -F %S/Inputs/frameworks -Xcc "-I%t/Headers" -module-cache-path %t/clang-module-cache -import-objc-header %S/Inputs/pch-bridging-header-with-non-modular-import.h %S/Inputs/other.swift %s
-// REQUIRES: objc_interop
+// RUN: %target-build-swift -emit-module -module-name test -Xfrontend -enable-objc-interop -Xfrontend -disable-deserialization-recovery -v -F %S/Inputs/frameworks -Xcc "-I%t/Headers" -module-cache-path %t/clang-module-cache -import-objc-header %S/Inputs/pch-bridging-header-with-non-modular-import.h %S/Inputs/other.swift %s
 
 import Simple
 class Foo: SimpleProtocol {

--- a/test/ClangImporter/protocol-conformance-in-extension.swift
+++ b/test/ClangImporter/protocol-conformance-in-extension.swift
@@ -1,8 +1,6 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t/a~partial.swiftmodule -I %S/Inputs/custom-modules -module-name TEST -primary-file %s
-// RUN: %target-swift-frontend -emit-module -o %t/test.swiftmodule -I %S/Inputs/custom-modules -module-name TEST %t/a~partial.swiftmodule
-
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend -enable-objc-interop -emit-module -o %t/a~partial.swiftmodule -I %S/Inputs/custom-modules -module-name TEST -primary-file %s
+// RUN: %target-swift-frontend -enable-objc-interop -emit-module -o %t/test.swiftmodule -I %S/Inputs/custom-modules -module-name TEST %t/a~partial.swiftmodule
 
 import TestProtocols
 

--- a/test/ClangImporter/static_inline.swift
+++ b/test/ClangImporter/static_inline.swift
@@ -2,9 +2,9 @@
 
 // Check if SIL printing+parsing of a clang imported function works.
 
-// RUN: %target-swift-frontend -parse-as-library -module-name=static_inline -emit-sil %S/Inputs/static_inline.swift -import-objc-header %S/Inputs/static_inline.h -o %t/static_inline.sil
+// RUN: %target-swift-frontend -parse-as-library -module-name=static_inline -emit-sil %S/Inputs/static_inline.swift -enable-objc-interop -import-objc-header %S/Inputs/static_inline.h -o %t/static_inline.sil
 // RUN: %FileCheck < %t/static_inline.sil %s
-// RUN: %target-swift-frontend -parse-as-library -module-name=static_inline -O -emit-ir %t/static_inline.sil -import-objc-header %S/Inputs/static_inline.h | %FileCheck --check-prefix=CHECK-IR %s
+// RUN: %target-swift-frontend -parse-as-library -module-name=static_inline -O -emit-ir %t/static_inline.sil -enable-objc-interop -import-objc-header %S/Inputs/static_inline.h | %FileCheck --check-prefix=CHECK-IR %s
 
 // CHECK: sil shared [serializable] [clang c_inline_func] @c_inline_func : $@convention(c) (Int32) -> Int32
 

--- a/test/ClangImporter/static_inline_serialize.swift
+++ b/test/ClangImporter/static_inline_serialize.swift
@@ -2,9 +2,9 @@
 
 // Try serialization of clang-generated functions.
 
-// RUN: %target-swift-frontend -parse-as-library -module-name=static_inline -emit-module %S/Inputs/static_inline.swift -import-objc-header %S/Inputs/static_inline.h -o %t/static_inline.swiftmodule
-// RUN: %target-swift-frontend -module-name test -O -emit-sil %s -I %t | %FileCheck %s
-// RUN: %target-swift-frontend -module-name test -O -emit-ir %s -I %t | %FileCheck --check-prefix=CHECK-IR %s
+// RUN: %target-swift-frontend -parse-as-library -module-name=static_inline -emit-module %S/Inputs/static_inline.swift -enable-objc-interop -import-objc-header %S/Inputs/static_inline.h -o %t/static_inline.swiftmodule
+// RUN: %target-swift-frontend -module-name test -O -emit-sil %s -I %t -enable-objc-interop | %FileCheck %s
+// RUN: %target-swift-frontend -module-name test -O -emit-ir %s -I %t -enable-objc-interop | %FileCheck --check-prefix=CHECK-IR %s
 
 // CHECK: sil shared_external [clang c_inline_func] @c_inline_func : $@convention(c) (Int32) -> Int32
 

--- a/test/ClangImporter/submodules-bridging-header.swift
+++ b/test/ClangImporter/submodules-bridging-header.swift
@@ -1,8 +1,8 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules/ -import-objc-header %S/Inputs/submodules-bridging-header.h %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules/ -enable-objc-interop -import-objc-header %S/Inputs/submodules-bridging-header.h %s
 
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-pch -o %t/submodules-bridging-header.pch %S/Inputs/submodules-bridging-header.h
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules/ -import-objc-header %t/submodules-bridging-header.pch %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-pch -o %t/submodules-bridging-header.pch %S/Inputs/submodules-bridging-header.h
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck -verify -I %S/Inputs/custom-modules/ -enable-objc-interop -import-objc-header %t/submodules-bridging-header.pch %s
 
 // From ctypes.bits submodule
 public var x : DWORD = MY_INT

--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -374,11 +374,10 @@ config.clang_include_dir = make_path(config.swift, '..', '..', 'include')
 config.substitutions.append( ('%clang-include-dir', config.clang_include_dir) )
 
 # Use this to build the basic set of Objective-C overlays.
-config.substitutions.append(
-    ('%build-clang-importer-objc-overlays',
-  '%target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %clang-importer-sdk-path/swift-modules/ObjectiveC.swift && '
-  '%target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift && '
-  '%target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift'))
+config.substitutions.append(('%build-clang-importer-objc-overlays',
+                             '%target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/ObjectiveC.swift && '
+                             '%target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/CoreGraphics.swift && '
+                             '%target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -enable-objc-interop -emit-module -o %t %clang-importer-sdk-path/swift-modules/Foundation.swift'))
 
 # FIXME: BEGIN -enable-source-import hackaround
 config.substitutions.append(('%clang-importer-sdk-path',


### PR DESCRIPTION
This enables additional tests for the ClangImporter.  This found a
missing piece in the `-enable-objc-interop` work that was done
previously.  Address that and enable the tests.  There are now two
failing tests on Linux:
  * sdk - depends on Foundation (not hermetic, see SR-7572)
  * import-mixed-with-header-twice - requires apple/swift PR#16022

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
