### PR TITLE
[Sema] Refactor member type matching from `checkOverrides` to make it reusable

### DIFF
--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -155,6 +155,9 @@ SubstitutionMap SubstitutionMap::get(GenericSignature *genericSig,
 }
 
 Type SubstitutionMap::lookupSubstitution(CanSubstitutableType type) const {
+  if (empty())
+    return Type();
+
   // If we have an archetype, map out of the context so we can compute a
   // conformance access path.
   if (auto archetype = dyn_cast<ArchetypeType>(type)) {

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3987,6 +3987,123 @@ static void finalizeAbstractStorageDecl(TypeChecker &TC,
   }
 }
 
+static void adjustFunctionTypeForOverride(Type &type) {
+  // Drop 'throws'.
+  // FIXME: Do we want to allow overriding a function returning a value
+  // with one returning Never?
+  auto fnType = type->castTo<AnyFunctionType>();
+  auto extInfo = fnType->getExtInfo();
+  extInfo = extInfo.withThrows(false);
+  if (fnType->getExtInfo() != extInfo)
+    type = fnType->withExtInfo(extInfo);
+}
+
+/// Drop the optionality of the result type of the given function type.
+static Type dropResultOptionality(Type type, unsigned uncurryLevel) {
+  // We've hit the result type.
+  if (uncurryLevel == 0) {
+    if (auto objectTy = type->getOptionalObjectType())
+      return objectTy;
+
+    return type;
+  }
+
+  // Determine the input and result types of this function.
+  auto fnType = type->castTo<AnyFunctionType>();
+  auto parameters = fnType->getParams();
+  Type resultType =
+      dropResultOptionality(fnType->getResult(), uncurryLevel - 1);
+
+  // Produce the resulting function type.
+  if (auto genericFn = dyn_cast<GenericFunctionType>(fnType)) {
+    return GenericFunctionType::get(genericFn->getGenericSignature(),
+                                    parameters, resultType,
+                                    fnType->getExtInfo());
+  }
+
+  return FunctionType::get(parameters, resultType, fnType->getExtInfo());
+}
+
+static Type getMemberTypeForComparison(ASTContext &ctx, ValueDecl *member,
+                                       ValueDecl *derivedDecl = nullptr,
+                                       bool stripLabels = true) {
+  auto *method = dyn_cast<AbstractFunctionDecl>(member);
+  ConstructorDecl *ctor = nullptr;
+  if (method)
+    ctor = dyn_cast<ConstructorDecl>(method);
+
+  auto abstractStorage = dyn_cast<AbstractStorageDecl>(member);
+  assert((method || abstractStorage) && "Not a method or abstractStorage?");
+  SubscriptDecl *subscript = nullptr;
+  if (abstractStorage)
+    subscript = dyn_cast<SubscriptDecl>(abstractStorage);
+
+  auto memberType = member->getInterfaceType();
+  if (derivedDecl) {
+    auto *dc = derivedDecl->getDeclContext();
+    auto owningType = dc->getDeclaredInterfaceType();
+    assert(owningType);
+
+    memberType = owningType->adjustSuperclassMemberDeclType(member, derivedDecl,
+                                                            memberType);
+    if (memberType->hasError())
+      return memberType;
+  }
+
+  if (stripLabels)
+    memberType = memberType->getUnlabeledType(ctx);
+
+  if (method) {
+    // For methods, strip off the 'Self' type.
+    memberType = memberType->castTo<AnyFunctionType>()->getResult();
+    adjustFunctionTypeForOverride(memberType);
+  } else if (subscript) {
+    // For subscripts, we don't have a 'Self' type, but turn it
+    // into a monomorphic function type.
+    auto funcTy = memberType->castTo<AnyFunctionType>();
+    memberType = FunctionType::get(funcTy->getParams(), funcTy->getResult(),
+                                   FunctionType::ExtInfo());
+  } else {
+    // For properties, strip off ownership.
+    memberType = memberType->getReferenceStorageReferent();
+  }
+
+  // Ignore the optionality of initializers when comparing types;
+  // we'll enforce this separately
+  if (ctor) {
+    memberType = dropResultOptionality(memberType, 1);
+  }
+
+  return memberType;
+}
+
+static bool isOverrideBasedOnType(ValueDecl *decl, Type declTy,
+                                  ValueDecl *parentDecl, Type parentDeclTy) {
+  auto *genericSig =
+      decl->getInnermostDeclContext()->getGenericSignatureOfContext();
+
+  auto canDeclTy = declTy->getCanonicalType(genericSig);
+  auto canParentDeclTy = parentDeclTy->getCanonicalType(genericSig);
+
+  auto declIUOAttr =
+      decl->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>();
+  auto parentDeclIUOAttr =
+      parentDecl->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>();
+
+  if (declIUOAttr != parentDeclIUOAttr)
+    return false;
+
+  // If this is a constructor, let's compare only parameter types.
+  if (isa<ConstructorDecl>(decl)) {
+    auto fnType1 = declTy->castTo<AnyFunctionType>();
+    auto fnType2 = parentDeclTy->castTo<AnyFunctionType>();
+    return AnyFunctionType::equalParams(fnType1->getParams(),
+                                        fnType2->getParams());
+  }
+
+  return canDeclTy == canParentDeclTy;
+}
+
 namespace {
 class DeclChecker : public DeclVisitor<DeclChecker> {
 public:
@@ -4801,32 +4918,6 @@ public:
     return true;
   }
 
-  /// Drop the optionality of the result type of the given function type.
-  static Type dropResultOptionality(Type type, unsigned uncurryLevel) {
-    // We've hit the result type.
-    if (uncurryLevel == 0) {
-      if (auto objectTy = type->getOptionalObjectType())
-        return objectTy;
-
-      return type;
-    }
-
-    // Determine the input and result types of this function.
-    auto fnType = type->castTo<AnyFunctionType>();
-    auto parameters = fnType->getParams();
-    Type resultType = dropResultOptionality(fnType->getResult(),
-                                            uncurryLevel - 1);
-
-    // Produce the resulting function type.
-    if (auto genericFn = dyn_cast<GenericFunctionType>(fnType)) {
-      return GenericFunctionType::get(genericFn->getGenericSignature(),
-                                      parameters, resultType,
-                                      fnType->getExtInfo());
-    }
-
-    return FunctionType::get(parameters, resultType, fnType->getExtInfo());
-  }
-
   static bool
   diagnoseMismatchedOptionals(TypeChecker &TC, const ValueDecl *member,
                               const ParameterList *params, TypeLoc resultTL,
@@ -4991,17 +5082,6 @@ public:
       if (auto setter = storage->getSetter())
         makeInvalidOverrideAttr(TC, setter);
     }
-  }
-
-  static void adjustFunctionTypeForOverride(Type &type) {
-    // Drop 'throws'.
-    // FIXME: Do we want to allow overriding a function returning a value
-    // with one returning Never?
-    auto fnType = type->castTo<AnyFunctionType>();
-    auto extInfo = fnType->getExtInfo();
-    extInfo = extInfo.withThrows(false);
-    if (fnType->getExtInfo() != extInfo)
-      type = fnType->withExtInfo(extInfo);
   }
 
   /// If the difference between the types of \p decl and \p base is something
@@ -5198,7 +5278,7 @@ public:
     // when their storage decl is processed.
     if (isa<AccessorDecl>(decl))
       return false;
-    
+
     auto method = dyn_cast<AbstractFunctionDecl>(decl);
     ConstructorDecl *ctor = nullptr;
     if (method)
@@ -5211,28 +5291,7 @@ public:
       subscript = dyn_cast<SubscriptDecl>(abstractStorage);
 
     // Figure out the type of the declaration that we're using for comparisons.
-    auto declTy = decl->getInterfaceType()->getUnlabeledType(TC.Context);
-    if (method) {
-      // For methods, strip off the 'Self' type.
-      declTy = declTy->castTo<AnyFunctionType>()->getResult();
-      adjustFunctionTypeForOverride(declTy);
-    } if (subscript) {
-      // For subscripts, we don't have a 'Self' type, but turn it
-      // into a monomorphic function type.
-      auto funcTy = declTy->castTo<AnyFunctionType>();
-      declTy = FunctionType::get(funcTy->getParams(),
-                                 funcTy->getResult(),
-                                 FunctionType::ExtInfo());
-    } else {
-      // For properties, strip off ownership.
-      declTy = declTy->getReferenceStorageReferent();
-    }
-
-    // Ignore the optionality of initializers when comparing types;
-    // we'll enforce this separately
-    if (ctor) {
-      declTy = dropResultOptionality(declTy, 1);
-    }
+    auto declTy = getMemberTypeForComparison(TC.Context, decl);
 
     // Look for members with the same name and matching types as this
     // one.
@@ -5327,45 +5386,20 @@ public:
           // checked by name.
         }
 
-        // Check whether the types are identical.
-        auto parentDeclTy = owningTy->adjustSuperclassMemberDeclType(
-            parentDecl, decl, parentDecl->getInterfaceType());
-        if (parentDeclTy->hasError()) continue;
-        parentDeclTy = parentDeclTy->getUnlabeledType(TC.Context);
-        if (method) {
-          // For methods, strip off the 'Self' type.
-          parentDeclTy = parentDeclTy->castTo<FunctionType>()->getResult();
-          adjustFunctionTypeForOverride(parentDeclTy);
-        } else {
-          // For properties, strip off ownership.
-          parentDeclTy = parentDeclTy->getReferenceStorageReferent();
-        }
-
-        // Ignore the optionality of initializers when comparing types;
-        // we'll enforce this separately
         if (ctor) {
-          parentDeclTy = dropResultOptionality(parentDeclTy, 1);
-
           // Factory methods cannot be overridden.
           auto parentCtor = cast<ConstructorDecl>(parentDecl);
           if (parentCtor->isFactoryInit())
             continue;
         }
 
-        // Canonicalize with respect to the override's generic signature, if any.
-        auto *genericSig = decl->getInnermostDeclContext()
-          ->getGenericSignatureOfContext();
+        // Check whether the types are identical.
+        auto parentDeclTy =
+            getMemberTypeForComparison(TC.Context, parentDecl, decl);
+        if (parentDeclTy->hasError())
+          continue;
 
-        auto canDeclTy = declTy->getCanonicalType(genericSig);
-        auto canParentDeclTy = parentDeclTy->getCanonicalType(genericSig);
-
-        auto declIUOAttr =
-            decl->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>();
-        auto parentDeclIUOAttr =
-            parentDecl->getAttrs()
-                .hasAttribute<ImplicitlyUnwrappedOptionalAttr>();
-
-        if (declIUOAttr == parentDeclIUOAttr && canDeclTy == canParentDeclTy) {
+        if (isOverrideBasedOnType(decl, declTy, parentDecl, parentDeclTy)) {
           matches.push_back({parentDecl, true, parentDeclTy});
           hadExactMatch = true;
           continue;
@@ -8728,21 +8762,6 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
   if (decl->isInvalid())
     return;
 
-  // Local function that produces the canonical parameter type of the given
-  // initializer.
-  // FIXME: Doesn't work properly for generics.
-  auto getInitializerParamType = [](ConstructorDecl *ctor) -> CanType {
-    auto interfaceTy = ctor->getInterfaceType();
-
-    // Skip the 'self' parameter.
-    auto uncurriedInitTy = interfaceTy->castTo<AnyFunctionType>()->getResult();
-
-    // Grab the parameter type;
-    auto paramTy = uncurriedInitTy->castTo<AnyFunctionType>()->getInput();
-
-    return paramTy->getCanonicalType();
-  };
-
   // Bail out if we're validating one of our constructors already; we'll
   // revisit the issue later.
   if (isa<ClassDecl>(decl)) {
@@ -8764,7 +8783,7 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
   bool SuppressMemberwiseInitializer = false;
   bool FoundDesignatedInit = false;
 
-  SmallPtrSet<CanType, 4> initializerParamTypes;
+  SmallVector<std::pair<ValueDecl *, Type>, 4> declaredInitializers;
   llvm::SmallPtrSet<ConstructorDecl *, 4> overriddenInits;
   if (decl->hasClangNode() && isa<ClassDecl>(decl)) {
     // Objective-C classes may have interesting initializers in extensions.
@@ -8793,8 +8812,11 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
         if (isa<StructDecl>(decl))
           continue;
 
-        if (!ctor->isInvalid())
-          initializerParamTypes.insert(getInitializerParamType(ctor));
+        if (!ctor->isInvalid()) {
+          auto type = getMemberTypeForComparison(Context, ctor, nullptr,
+                                                 /*stripLabels*/ false);
+          declaredInitializers.push_back({ctor, type});
+        }
 
         if (auto overridden = ctor->getOverriddenDecl())
           overriddenInits.insert(overridden);
@@ -8949,10 +8971,22 @@ void TypeChecker::addImplicitConstructors(NominalTypeDecl *decl) {
 
       // A designated or required initializer has not been overridden.
 
+      bool alreadyDeclared = false;
+      for (const auto &ctorAndType : declaredInitializers) {
+        auto *ctor = ctorAndType.first;
+        auto type = ctorAndType.second;
+        auto parentType = getMemberTypeForComparison(
+            Context, superclassCtor, ctor, /*stripLabels*/ false);
+
+        if (isOverrideBasedOnType(ctor, type, superclassCtor, parentType)) {
+          alreadyDeclared = true;
+          break;
+        }
+      }
+
       // If we have already introduced an initializer with this parameter type,
       // don't add one now.
-      if (!initializerParamTypes.insert(
-             getInitializerParamType(superclassCtor)).second)
+      if (alreadyDeclared)
         continue;
 
       // If we're inheriting initializers, create an override delegating

--- a/test/Constraints/super_constructor.swift
+++ b/test/Constraints/super_constructor.swift
@@ -64,3 +64,11 @@ class Impl_2484 : SR_2484 {
     super.init() // expected-error {{'init' is inaccessible due to 'private' protection level}}
   }
 }
+
+class A_Priv<T> {
+  private init(_ foo: T) {}
+}
+
+class B_Override<U> : A_Priv<[U]> {
+  init(_ foo: [U]) { fatalError() } // Ok, because effectively overrides init from parent which is invisible
+}

--- a/validation-test/compiler_crashers_fixed/28839-genericsig.swift
+++ b/validation-test/compiler_crashers_fixed/28839-genericsig.swift
@@ -5,8 +5,8 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+
+// RUN: not %target-swift-frontend %s -emit-ir
 class a{
 class a<a:A
 protocol A:a{typealias wh:Self.a


### PR DESCRIPTION
These changes make it possible to use the same type matching logic
for both `checkOverrides` and `addImplicitConstructors` which removes
one of the last usages of `AnyFunctionType::getInput` and correctly
handles generic types.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
