### PR TITLE
[SILVerifier] UnmanagedToRef and RefToUnmanaged must be loadable

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -4901,6 +4901,9 @@ public:
     }
   }
 
+  /// Is this storage type known to be loadable in the given resilience scope?
+  bool isLoadable(ResilienceExpansion resilience) const;
+
   // Implement isa/cast/dyncast/etc.
   static bool classof(const TypeBase *T) {
     return T->getKind() >= TypeKind::First_ReferenceStorageType &&
@@ -4928,10 +4931,6 @@ public:
     return static_cast<UnownedStorageType *>(
         ReferenceStorageType::get(referent, ReferenceOwnership::Unowned, C));
   }
-
-  /// Is this unowned storage type known to be loadable within the given
-  /// resilience scope?
-  bool isLoadable(ResilienceExpansion resilience) const;
 
   // Implement isa/cast/dyncast/etc.
   static bool classof(const TypeBase *T) {

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -4023,7 +4023,7 @@ bool Type::isPrivateStdlibType(bool treatNonBuiltinProtocolsAsPublic) const {
   return false;
 }
 
-bool UnownedStorageType::isLoadable(ResilienceExpansion resilience) const {
+bool ReferenceStorageType::isLoadable(ResilienceExpansion resilience) const {
   return getReferentType()->usesNativeReferenceCounting(resilience);
 }
 

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -3325,6 +3325,8 @@ public:
     auto operandType = I->getOperand()->getType().getSwiftRValueType();
     auto resultType = requireObjectType(UnmanagedStorageType, I,
                                         "Result of ref_to_unmanaged");
+    require(resultType->isLoadable(ResilienceExpansion::Maximal),
+            "ref_to_unmanaged requires unowned type to be loadable");
     require(resultType.getReferentType() == operandType,
             "Result of ref_to_unmanaged does not have the "
             "operand's type as its referent type");
@@ -3334,6 +3336,8 @@ public:
     auto operandType = requireObjectType(UnmanagedStorageType,
                                          I->getOperand(),
                                          "Operand of unmanaged_to_ref");
+    require(operandType->isLoadable(ResilienceExpansion::Maximal),
+            "unmanaged_to_ref requires unowned type to be loadable");
     requireReferenceStorageCapableValue(I, "Result of unmanaged_to_ref");
     auto resultType = I->getType().getSwiftRValueType();
     require(operandType.getReferentType() == resultType,


### PR DESCRIPTION
In #16237, @rjmccall wrote: "Unmanaged is never not loadable. It's possible that we're messing that up somewhere."

Let's add a SIL verifier and sort this out.