### PR TITLE
[Runtime] Fix warnings for inconsistent nullability annotation on _stdlib_getEnviron.

### DIFF
--- a/stdlib/public/SwiftShims/LibcShims.h
+++ b/stdlib/public/SwiftShims/LibcShims.h
@@ -130,7 +130,7 @@ int _stdlib_ioctlPtr(int fd, unsigned long int request, void* ptr);
 // Environment
 #if defined(__APPLE__) || defined(__FreeBSD__)
 SWIFT_RUNTIME_STDLIB_INTERNAL
-char * _Nullable *_stdlib_getEnviron();
+char * _Nullable * _Null_unspecified _stdlib_getEnviron();
 #endif
 
 // System error numbers <errno.h>

--- a/stdlib/public/stubs/LibcShims.cpp
+++ b/stdlib/public/stubs/LibcShims.cpp
@@ -171,7 +171,7 @@ int swift::_stdlib_ioctlPtr(int fd, unsigned long int request, void* ptr) {
 
 #if defined(__FreeBSD__)
 SWIFT_RUNTIME_STDLIB_INTERNAL
-char * _Nullable *swift::_stdlib_getEnviron() {
+char * _Nullable * _Null_unspecified swift::_stdlib_getEnviron() {
   extern char **environ;
   return environ;
 }


### PR DESCRIPTION
rdar://problem/39739801