### PR TITLE
libSyntax: add getAbsoluteEndPosition() method to syntax nodes.

### DIFF
--- a/include/swift/Syntax/Syntax.h
+++ b/include/swift/Syntax/Syntax.h
@@ -194,6 +194,11 @@ public:
     return Data->getAbsolutePosition();
   }
 
+  /// Get the absolute end position (exclusively) of this raw syntax: its offset,
+  /// line, and column.
+  AbsolutePosition getAbsoluteEndPosition() const {
+    return Data->getAbsoluteEndPosition();
+  }
   // TODO: hasSameStructureAs ?
 };
 

--- a/include/swift/Syntax/SyntaxData.h
+++ b/include/swift/Syntax/SyntaxData.h
@@ -136,6 +136,10 @@ class SyntaxData final
   /// find such node.
   RC<SyntaxData> getPreviousNode() const;
 
+  /// Get the node immediately after this current node. Return 0 if we cannot
+  /// find such node.
+  RC<SyntaxData> getNextNode() const;
+
   /// Get the absolute position without skipping the leading trivia of this node.
   AbsolutePosition getAbsolutePositionWithLeadingTrivia() const;
 
@@ -248,6 +252,10 @@ public:
   /// Calculate the absolute position of this node, use cache if the cache
   /// is populated.
   AbsolutePosition getAbsolutePosition() const;
+
+  /// Calculate the absolute end position of this node, use cache of the immediate
+  /// next node if populated.
+  AbsolutePosition getAbsoluteEndPosition() const;
 
   /// Returns true if the data node represents type syntax.
   bool isType() const;

--- a/lib/Syntax/SyntaxData.cpp
+++ b/lib/Syntax/SyntaxData.cpp
@@ -66,6 +66,18 @@ RC<SyntaxData> SyntaxData::getPreviousNode() const {
   return hasParent() ? Parent->getPreviousNode() : nullptr;
 }
 
+RC<SyntaxData> SyntaxData::getNextNode() const {
+  if (hasParent()) {
+    for (size_t I = getIndexInParent() + 1, N = Parent->getNumChildren();
+         I != N; I++) {
+      if (auto C = getParent()->getChild(I))
+        return C;
+    }
+    return Parent->getNextNode();
+  }
+  return nullptr;
+}
+
 AbsolutePosition SyntaxData::getAbsolutePositionWithLeadingTrivia() const {
   if (PositionCache.hasValue())
     return *PositionCache;
@@ -84,4 +96,14 @@ AbsolutePosition SyntaxData::getAbsolutePosition() const {
   auto Result = getAbsolutePositionWithLeadingTrivia();
   getRaw()->accumulateLeadingTrivia(Result);
   return Result;
+}
+
+AbsolutePosition SyntaxData::getAbsoluteEndPosition() const {
+  if (auto N = getNextNode()) {
+    return N->getAbsolutePositionWithLeadingTrivia();
+  } else {
+    auto Result = getAbsolutePositionWithLeadingTrivia();
+    getRaw()->accumulateAbsolutePosition(Result);
+    return Result;
+  }
 }

--- a/unittests/Syntax/AbsolutePositionTests.cpp
+++ b/unittests/Syntax/AbsolutePositionTests.cpp
@@ -1,0 +1,37 @@
+#include "swift/Syntax/SyntaxFactory.h"
+#include "swift/Syntax/SyntaxNodes.h"
+#include "swift/Syntax/SyntaxBuilders.h"
+#include "llvm/ADT/SmallString.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+using namespace swift::syntax;
+
+TEST(PositionTests, AbsolutePosition1) {
+  Trivia Leading;
+  Leading.Pieces = {TriviaPiece::newlines(2), TriviaPiece::carriageReturns(2),
+    TriviaPiece::carriageReturnLineFeeds(2)};
+  auto Token = SyntaxFactory::makeIdentifier("aaa", Leading, {});
+  AbsolutePosition Pos = Token.getAbsolutePosition();
+  ASSERT_EQ(7u, Pos.getLine());
+  ASSERT_EQ(1u, Pos.getColumn());
+  ASSERT_EQ(8u, Pos.getOffset());
+  AbsolutePosition EndPos = Token.getAbsoluteEndPosition();
+  ASSERT_EQ(7u, EndPos.getLine());
+  ASSERT_EQ(4u, EndPos.getColumn());
+  ASSERT_EQ(11u, EndPos.getOffset());
+}
+
+TEST(PositionTests, AbsolutePosition2) {
+  Trivia Leading;
+  Leading.Pieces = { TriviaPiece::blockComment("/* \n\r\r\n */") };
+  auto Token = SyntaxFactory::makeIdentifier("aaa", Leading, {});
+  AbsolutePosition Pos = Token.getAbsolutePosition();
+  ASSERT_EQ(4u, Pos.getLine());
+  ASSERT_EQ(4u, Pos.getColumn());
+  ASSERT_EQ(10u, Pos.getOffset());
+  AbsolutePosition EndPos = Token.getAbsoluteEndPosition();
+  ASSERT_EQ(4u, EndPos.getLine());
+  ASSERT_EQ(7u, EndPos.getColumn());
+  ASSERT_EQ(13u, EndPos.getOffset());
+}

--- a/unittests/Syntax/CMakeLists.txt
+++ b/unittests/Syntax/CMakeLists.txt
@@ -9,6 +9,7 @@ add_swift_unittest(SwiftSyntaxTests
   TriviaTests.cpp
   TypeSyntaxTests.cpp
   UnknownSyntaxTests.cpp
+  AbsolutePositionTests.cpp
   )
 
 target_link_libraries(SwiftSyntaxTests


### PR DESCRIPTION
This implementation uses sibling's absolute start position to help
populate caches while getting the end position.
