### PR TITLE
Adds a new line character to the message for parse position error

### DIFF
--- a/tools/swift-refactor/swift-refactor.cpp
+++ b/tools/swift-refactor/swift-refactor.cpp
@@ -279,7 +279,7 @@ int main(int argc, char *argv[]) {
 
   auto Start = getLocsByLabelOrPosition(options::LineColumnPair, Buffer);
   if (Start.empty()) {
-    llvm::errs() << "cannot parse position pair.";
+    llvm::errs() << "cannot parse position pair.\n";
     return 1;
   }
 


### PR DESCRIPTION
Adds a new line character to the message for parse position error when using the swift-refactor tool.