### PR TITLE
[AST] Store SubstitutionMaps in the AST rather than Substitution lists.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -740,30 +740,11 @@ public:
   /// \param generic The generic conformance.
   ///
   /// \param substitutions The set of substitutions required to produce the
-  /// specialized conformance from the generic conformance. This list is
-  /// copied so passing a temporary is permitted.
+  /// specialized conformance from the generic conformance.
   ProtocolConformance *
   getSpecializedConformance(Type type,
                             ProtocolConformance *generic,
-                            SubstitutionList substitutions,
-                            bool alreadyCheckedCollapsed = false);
-
-  /// \brief Produce a specialized conformance, which takes a generic
-  /// conformance and substitutions written in terms of the generic
-  /// conformance's signature.
-  ///
-  /// \param type The type for which we are retrieving the conformance.
-  ///
-  /// \param generic The generic conformance.
-  ///
-  /// \param substitutions The set of substitutions required to produce the
-  /// specialized conformance from the generic conformance. The keys must
-  /// be generic parameters, not archetypes, so for example passing in
-  /// TypeBase::getContextSubstitutionMap() is OK.
-  ProtocolConformance *
-  getSpecializedConformance(Type type,
-                            ProtocolConformance *generic,
-                            const SubstitutionMap &substitutions);
+                            SubstitutionMap substitutions);
 
   /// \brief Produce an inherited conformance, for subclasses of a type
   /// that already conforms to a protocol.

--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -170,6 +170,7 @@ public:
   /// generic parameter types by their sugared form.
   Type getSugaredType(Type type) const;
 
+  SubstitutionMap getForwardingSubstitutionMap() const;
   SubstitutionList getForwardingSubstitutions() const;
 
   void dump(raw_ostream &os) const;

--- a/include/swift/AST/ProtocolConformance.h
+++ b/include/swift/AST/ProtocolConformance.h
@@ -651,7 +651,7 @@ class SpecializedProtocolConformance : public ProtocolConformance,
 
   /// The substitutions applied to the generic conformance to produce this
   /// conformance.
-  SubstitutionList GenericSubstitutions;
+  SubstitutionMap GenericSubstitutions;
 
   /// The mapping from associated type requirements to their substitutions.
   ///
@@ -667,7 +667,7 @@ class SpecializedProtocolConformance : public ProtocolConformance,
 
   SpecializedProtocolConformance(Type conformingType,
                                  ProtocolConformance *genericConformance,
-                                 SubstitutionList substitutions);
+                                 SubstitutionMap substitutions);
 
 public:
   /// Get the generic conformance from which this conformance was derived,
@@ -676,15 +676,9 @@ public:
     return GenericConformance;
   }
 
-  /// Get the substitutions used to produce this specialized conformance from
-  /// the generic conformance.
-  SubstitutionList getGenericSubstitutions() const {
-    return GenericSubstitutions;
-  }
-
   /// Get the substitution map representing the substitutions used to produce
   /// this specialized conformance.
-  SubstitutionMap getSubstitutionMap() const;
+  SubstitutionMap getSubstitutionMap() const { return GenericSubstitutions; }
 
   /// Get any requirements that must be satisfied for this conformance to apply.
   ArrayRef<Requirement> getConditionalRequirements() const {
@@ -744,16 +738,15 @@ public:
   }
 
   void Profile(llvm::FoldingSetNodeID &ID) {
-    Profile(ID, getType(), getGenericConformance(),
-            getGenericSubstitutions());
+    Profile(ID, getType(), getGenericConformance(), getSubstitutionMap());
   }
 
   static void Profile(llvm::FoldingSetNodeID &ID, Type type,
                       ProtocolConformance *genericConformance,
-                      SubstitutionList subs) {
+                      SubstitutionMap subs) {
     ID.AddPointer(type.getPointer());
     ID.AddPointer(genericConformance);
-    profileSubstitutionList(ID, subs);
+    subs.profile(ID);
   }
 
   static bool classof(const ProtocolConformance *conformance) {

--- a/include/swift/AST/SubstitutionList.h
+++ b/include/swift/AST/SubstitutionList.h
@@ -34,19 +34,6 @@ using SubstitutionList = ArrayRef<Substitution>;
 
 void dump(SubstitutionList subs);
 
-/// Create a canonicalized substitution list from subs.
-/// subs is the substitution list to be canonicalized.
-/// canSubs is an out-parameter, which is used to store the results in case
-/// the list of substitutions was not canonical.
-/// The function returns a list of canonicalized substitutions.
-/// If the substitution list subs was canonical already, it will be returned and
-/// canSubs out-parameter will be empty.
-/// If something had to be canonicalized, then the canSubs out-parameter will be
-/// populated and the returned SubstitutionList would refer to canSubs storage.
-SubstitutionList
-getCanonicalSubstitutionList(SubstitutionList subs,
-                             SmallVectorImpl<Substitution> &canSubs);
-
 /// Profile the substitution list for use in a folding set.
 void profileSubstitutionList(llvm::FoldingSetNodeID &id, SubstitutionList subs);
 

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -155,7 +155,16 @@ private:
   /// signature nor any replacement types/conformances.
   Storage *storage = nullptr;
 
-  MutableArrayRef<Type> getReplacementTypes() {
+  /// Retrieve the array of replacement types, which line up with the
+  /// generic parameters.
+  ///
+  /// Note that the types may be null, for cases where the generic parameter
+  /// is concrete but hasn't been queried yet.
+  ArrayRef<Type> getReplacementTypesBuffer() const {
+    return storage ? storage->getReplacementTypes() : ArrayRef<Type>();
+  }
+
+  MutableArrayRef<Type> getReplacementTypesBuffer() {
     return storage ? storage->getReplacementTypes() : MutableArrayRef<Type>();
   }
 
@@ -223,12 +232,7 @@ public:
 
   /// Retrieve the array of replacement types, which line up with the
   /// generic parameters.
-  ///
-  /// Note that the types may be null, for cases where the generic parameter
-  /// is concrete but hasn't been queried yet.
-  ArrayRef<Type> getReplacementTypes() const {
-    return storage ? storage->getReplacementTypes() : ArrayRef<Type>();
-  }
+  ArrayRef<Type> getReplacementTypes() const;
 
   /// Query whether any replacement types in the map contain archetypes.
   bool hasArchetypes() const;

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -273,6 +273,14 @@ public:
                            GenericSignature *derivedSig,
                            Optional<SubstitutionMap> derivedSubs);
 
+  /// Produce a substitution list for the given substitution map.
+  ///
+  /// Note: we are moving away from using Substitutions, so this should only
+  /// be used at the edges where part of the compiler is still working
+  /// directly with Substitution/SubstitutionList and hasn't been converted
+  /// to SubstitutionMap.
+  SmallVector<Substitution, 4> toList() const;
+
   /// Combine two substitution maps as follows.
   ///
   /// The result is written in terms of the generic parameters of 'genericSig'.
@@ -322,6 +330,14 @@ public:
   static SubstitutionMap getTombstoneKey() {
     return SubstitutionMap(
                (Storage *)llvm::DenseMapInfo<void*>::getTombstoneKey());
+  }
+
+  friend bool operator ==(SubstitutionMap lhs, SubstitutionMap rhs) {
+    return lhs.storage == rhs.storage;
+  }
+
+  friend bool operator !=(SubstitutionMap lhs, SubstitutionMap rhs) {
+    return lhs.storage != rhs.storage;
   }
 
 private:

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -240,6 +240,12 @@ public:
   /// Query whether any replacement type sin the map contain dynamic Self.
   bool hasDynamicSelf() const;
 
+  /// Whether the replacement types are all canonical.
+  bool isCanonical() const;
+
+  /// Return the canonical form of this substitution map.
+  SubstitutionMap getCanonical() const;
+
   /// Apply a substitution to all replacement types in the map. Does not
   /// change keys.
   SubstitutionMap subst(const SubstitutionMap &subMap) const;

--- a/include/swift/AST/Witness.h
+++ b/include/swift/AST/Witness.h
@@ -93,7 +93,7 @@ class Witness {
     /// the witness declaration from the synthetic environment.
     ConcreteDeclRef declRef;
     GenericEnvironment *syntheticEnvironment;
-    SubstitutionList reqToSyntheticEnvSubs;
+    SubstitutionMap reqToSyntheticEnvSubs;
   };
 
   llvm::PointerUnion<ValueDecl *, StoredWitness *> storage;
@@ -130,9 +130,9 @@ public:
   /// \param reqToSyntheticEnvSubs The mapping from the interface types of the
   /// requirement into the interface types of the synthetic environment.
   Witness(ValueDecl *decl,
-          SubstitutionList substitutions,
+          SubstitutionMap substitutions,
           GenericEnvironment *syntheticEnv,
-          SubstitutionList reqToSyntheticEnvSubs);
+          SubstitutionMap reqToSyntheticEnvSubs);
 
   /// Retrieve the witness declaration reference, which includes the
   /// substitutions needed to use the witness from the synthetic environment
@@ -155,7 +155,7 @@ public:
   ///
   /// The substitutions are substitutions for the witness, providing interface
   /// types from the synthetic environment.
-  SubstitutionList getSubstitutions() const {
+  SubstitutionMap getSubstitutions() const {
     return getDeclRef().getSubstitutions();
   }
 
@@ -168,7 +168,7 @@ public:
 
   /// Retrieve the substitution map that maps the interface types of the
   /// requirement to the interface types of the synthetic environment.
-  SubstitutionList getRequirementToSyntheticSubs() const {
+  SubstitutionMap getRequirementToSyntheticSubs() const {
     if (auto *storedWitness = storage.dyn_cast<StoredWitness *>())
       return storedWitness->reqToSyntheticEnvSubs;
     return {};

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -124,6 +124,9 @@ private:
   /// The forwarding substitutions, lazily computed.
   Optional<SubstitutionList> ForwardingSubs;
 
+  /// The forwarding substitution map, lazily computed.
+  SubstitutionMap ForwardingSubMap;
+
   /// The collection of all BasicBlocks in the SILFunction. Empty for external
   /// function references.
   BlockListType BlockList;
@@ -684,6 +687,10 @@ public:
   /// Return the identity substitutions necessary to forward this call if it is
   /// generic.
   SubstitutionList getForwardingSubstitutions();
+
+  /// Return the identity substitutions necessary to forward this call if it is
+  /// generic.
+  SubstitutionMap getForwardingSubstitutionMap();
 
   //===--------------------------------------------------------------------===//
   // Block List Access

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 412; // Last change: @usableFromInline import
+const uint16_t VERSION_MINOR = 413; // Last change: specialized conformance
 
 using DeclIDField = BCFixed<31>;
 
@@ -1287,9 +1287,9 @@ namespace decls_block {
 
   using SpecializedProtocolConformanceLayout = BCRecordLayout<
     SPECIALIZED_PROTOCOL_CONFORMANCE,
-    TypeIDField,         // conforming type
-    BCVBR<5>             // # of substitutions for the conformance
-    // followed by substitution records for the conformance
+    TypeIDField,           // conforming type
+    SubstitutionMapIDField // substitution map
+    // trailed by the underlying conformance
   >;
 
   using InheritedProtocolConformanceLayout = BCRecordLayout<

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 413; // Last change: specialized conformance
+const uint16_t VERSION_MINOR = 414; // Last change: SIL box type substitutions
 
 using DeclIDField = BCFixed<31>;
 
@@ -800,8 +800,8 @@ namespace decls_block {
 
   using SILBoxTypeLayout = BCRecordLayout<
     SIL_BOX_TYPE,
-    SILLayoutIDField     // layout
-                         // trailing substitutions
+    SILLayoutIDField,     // layout
+    SubstitutionMapIDField // substitutions
   >;
 
   template <unsigned Code>

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -4881,25 +4881,20 @@ SILLayout *SILLayout::get(ASTContext &C,
 
 CanSILBoxType SILBoxType::get(ASTContext &C,
                               SILLayout *Layout,
-                              SubstitutionList Args) {
-  llvm::FoldingSetNodeID id;
-
+                              SubstitutionMap Substitutions) {
   // Canonicalize substitutions.
-  SmallVector<Substitution, 4> CanArgs;
-  Args = getCanonicalSubstitutionList(Args, CanArgs);
-
-  Profile(id, Layout, Args);
+  Substitutions = Substitutions.getCanonical();
 
   // Return an existing layout if there is one.
   void *insertPos;
   auto &SILBoxTypes = C.Impl.SILBoxTypes;
-
+  llvm::FoldingSetNodeID id;
+  Profile(id, Layout, Substitutions);
   if (auto existing = SILBoxTypes.FindNodeOrInsertPos(id, insertPos))
     return CanSILBoxType(existing);
 
-  void *memory = C.Allocate(totalSizeToAlloc<Substitution>(Args.size()),
-                            alignof(SILBoxType));
-  auto newBox = ::new (memory) SILBoxType(C, Layout, Args);
+  auto newBox = new (C, AllocationArena::Permanent) SILBoxType(C, Layout,
+                                                               Substitutions);
   SILBoxTypes.InsertNode(newBox, insertPos);
   return CanSILBoxType(newBox);
 }
@@ -4909,12 +4904,20 @@ CanSILBoxType SILBoxType::get(ASTContext &C,
 CanSILBoxType SILBoxType::get(CanType boxedType) {
   auto &ctx = boxedType->getASTContext();
   auto singleGenericParamSignature = ctx.getSingleGenericParameterSignature();
+  auto genericParam = singleGenericParamSignature->getGenericParams()[0];
   auto layout = SILLayout::get(ctx, singleGenericParamSignature,
-                               SILField(CanType(singleGenericParamSignature
-                                  ->getGenericParams()[0]),
-                               /*mutable*/ true));
+                               SILField(CanType(genericParam),
+                                        /*mutable*/ true));
 
-  return get(boxedType->getASTContext(), layout, Substitution(boxedType, {}));
+  SubstitutionMap subMap =
+    singleGenericParamSignature->getSubstitutionMap(
+      [&](SubstitutableType *type) -> Type {
+        if (type->isEqual(genericParam)) return boxedType;
+
+        return nullptr;
+      },
+      MakeAbstractConformanceForGenericType());
+  return get(boxedType->getASTContext(), layout, subMap);
 }
 
 LayoutConstraint

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2904,10 +2904,7 @@ void ProtocolConformance::dump(llvm::raw_ostream &out, unsigned indent) const {
     auto conf = cast<SpecializedProtocolConformance>(this);
     printCommon("specialized");
     out << '\n';
-    for (auto sub : conf->getGenericSubstitutions()) {
-      sub.dump(out, indent + 2);
-      out << '\n';
-    }
+    conf->getSubstitutionMap().dump(out);
     for (auto subReq : conf->getConditionalRequirements()) {
       out.indent(indent + 2);
       subReq.dump(out);

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2051,7 +2051,6 @@ public:
     if (auto defaultArgsOwner = E->getDefaultArgsOwner()) {
       OS << " default_args_owner=";
       defaultArgsOwner.dump(OS);
-      dump(defaultArgsOwner.getSubstitutions());
     }
 
     OS << "\n";

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -986,8 +986,8 @@ void ASTMangler::appendType(Type type) {
 
       if (auto sig = layout->getGenericSignature()) {
         fieldsList.clear();
-        for (auto &arg : box->getGenericArgs()) {
-          fieldsList.push_back(TupleTypeElt(arg.getReplacement()));
+        for (Type type : box->getSubstitutions().getReplacementTypes()) {
+          fieldsList.push_back(TupleTypeElt(type));
         }
         appendTypeList(TupleType::get(fieldsList, tybase->getASTContext())
                          ->getCanonicalType());

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4157,9 +4157,16 @@ void ProtocolConformance::printName(llvm::raw_ostream &os,
   case ProtocolConformanceKind::Specialized: {
     auto spec = cast<SpecializedProtocolConformance>(this);
     os << "specialize <";
-    interleave(spec->getGenericSubstitutions(),
-               [&](const Substitution &s) { s.print(os, PO); },
+    auto subMap = spec->getSubstitutionMap();
+    auto genericParams =
+      spec->getGenericConformance()->getGenericSignature()->getGenericParams();
+    interleave(genericParams,
+               [&](Type type) {
+                 type.subst(subMap).print(os, PO);
+
+               },
                [&] { os << ", "; });
+
     os << "> (";
     spec->getGenericConformance()->printName(os, PO);
     os << ")";

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -3714,11 +3714,11 @@ public:
     }
 
     // The arguments to the layout, if any, do come from the outer environment.
-    if (!T->getGenericArgs().empty()) {
+    if (auto subMap = T->getSubstitutions()) {
       Printer << " <";
-      interleave(T->getGenericArgs(),
-                 [&](const Substitution &arg) {
-                   visit(arg.getReplacement());
+      interleave(subMap.getReplacementTypes(),
+                 [&](Type type) {
+                   visit(type);
                  }, [&]{
                    Printer << ", ";
                  });

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2416,6 +2416,10 @@ public:
       }
     }
 
+    void verifyChecked(SubstitutionMap substitutions){
+      // FIXME: Check replacement types without forcing anything.
+    }
+
     /// Check the given explicit protocol conformance.
     void verifyConformance(Decl *decl, ProtocolConformance *conformance) {
       PrettyStackTraceDecl debugStack("verifying protocol conformance", decl);
@@ -2525,11 +2529,8 @@ public:
           if (auto *genericEnv = witness.getSyntheticEnvironment())
             GenericEnv.push_back({genericEnv});
 
-          for (const auto &sub : witness.getRequirementToSyntheticSubs())
-            verifyChecked(sub.getReplacement());
-
-          for (const auto &sub : witness.getSubstitutions())
-            verifyChecked(sub.getReplacement());
+          verifyChecked(witness.getRequirementToSyntheticSubs());
+          verifyChecked(witness.getSubstitutions());
 
           if (auto *genericEnv = witness.getSyntheticEnvironment()) {
             assert(GenericEnv.back().storage.dyn_cast<GenericEnvironment *>()

--- a/lib/AST/ConcreteDeclRef.cpp
+++ b/lib/AST/ConcreteDeclRef.cpp
@@ -25,16 +25,7 @@
 #include "llvm/Support/raw_ostream.h"
 using namespace swift;
 
-ConcreteDeclRef::SpecializedDeclRef *
-ConcreteDeclRef::SpecializedDeclRef::create(
-                                       ASTContext &ctx, ValueDecl *decl,
-                                       SubstitutionMap substitutions) {
-  return new (ctx.getAllocator()) SpecializedDeclRef(decl,
-                                                     substitutions);
-}
-
-ConcreteDeclRef
-ConcreteDeclRef::getOverriddenDecl(ASTContext &ctx) const {
+ConcreteDeclRef ConcreteDeclRef::getOverriddenDecl() const {
   auto *derivedDecl = getDecl();
   auto *baseDecl = derivedDecl->getOverriddenDecl();
 
@@ -51,7 +42,7 @@ ConcreteDeclRef::getOverriddenDecl(ASTContext &ctx) const {
     subs = SubstitutionMap::getOverrideSubstitutions(baseDecl, derivedDecl,
                                                      derivedSubMap);
   }
-  return ConcreteDeclRef(ctx, baseDecl, subs);
+  return ConcreteDeclRef(baseDecl, subs);
 }
 
 void ConcreteDeclRef::dump(raw_ostream &os) {

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -218,16 +218,19 @@ Type GenericEnvironment::getSugaredType(Type type) const {
   });
 }
 
+SubstitutionMap GenericEnvironment::getForwardingSubstitutionMap() const {
+  auto *genericSig = getGenericSignature();
+  return genericSig->getSubstitutionMap(
+    QueryInterfaceTypeSubstitutions(this),
+    MakeAbstractConformanceForGenericType());
+}
+
 SubstitutionList
 GenericEnvironment::getForwardingSubstitutions() const {
   auto *genericSig = getGenericSignature();
 
-  SubstitutionMap subMap = genericSig->getSubstitutionMap(
-    QueryInterfaceTypeSubstitutions(this),
-    MakeAbstractConformanceForGenericType());
-
   SmallVector<Substitution, 4> result;
-  genericSig->getSubstitutions(subMap, result);
+  genericSig->getSubstitutions(getForwardingSubstitutionMap(), result);
   return genericSig->getASTContext().AllocateCopy(result);
 }
 

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -1295,27 +1295,6 @@ Substitution Substitution::getCanonicalSubstitution(bool *wasCanonical) const {
   return *this;
 }
 
-SubstitutionList
-swift::getCanonicalSubstitutionList(SubstitutionList subs,
-                                    SmallVectorImpl<Substitution> &canSubs) {
-  bool subListWasCanonical = true;
-  for (auto &sub : subs) {
-    bool subWasCanonical = false;
-    auto canSub = sub.getCanonicalSubstitution(&subWasCanonical);
-    if (!subWasCanonical)
-      subListWasCanonical = false;
-    canSubs.push_back(canSub);
-  }
-
-  if (subListWasCanonical) {
-    canSubs.clear();
-    return subs;
-  }
-
-  subs = canSubs;
-  return subs;
-}
-
 /// Check of all types used by the conformance are canonical.
 ProtocolConformance *ProtocolConformance::getCanonicalConformance() {
   if (isCanonical())

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -48,7 +48,7 @@ Witness::Witness(ValueDecl *decl, SubstitutionMap substitutions,
   }
 
   auto &ctx = decl->getASTContext();
-  auto declRef = ConcreteDeclRef(ctx, decl, substitutions);
+  auto declRef = ConcreteDeclRef(decl, substitutions);
   auto storedMem = ctx.Allocate(sizeof(StoredWitness), alignof(StoredWitness));
   auto stored = new (storedMem) StoredWitness{declRef, syntheticEnv,
                                               reqToSynthesizedEnvSubs};
@@ -906,8 +906,7 @@ SpecializedProtocolConformance::getWitnessDeclRef(
   if (combinedMap == baseWitness.getSubstitutions())
     return baseWitness;
 
-  return ConcreteDeclRef(witnessDecl->getASTContext(), witnessDecl,
-                         combinedMap);
+  return ConcreteDeclRef(witnessDecl, combinedMap);
 }
 
 ProtocolConformanceRef

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -50,6 +50,17 @@ SubstitutionMap::Storage::Storage(
             getConformances().data());
 }
 
+ArrayRef<Type> SubstitutionMap::getReplacementTypes() const {
+  if (empty()) return { };
+
+  // Make sure we've filled in all of the replacement types.
+  for (auto gp : getGenericSignature()->getGenericParams()) {
+    (void)Type(gp).subst(*this);
+  }
+
+  return getReplacementTypesBuffer();
+}
+
 bool SubstitutionMap::hasArchetypes() const {
   for (Type replacementTy : getReplacementTypes()) {
     if (replacementTy && replacementTy->hasArchetype())
@@ -75,6 +86,10 @@ bool SubstitutionMap::hasDynamicSelf() const {
 }
 
 bool SubstitutionMap::isCanonical() const {
+  if (empty()) return true;
+
+  if (!getGenericSignature()->isCanonical()) return false;
+
   for (Type replacementTy : getReplacementTypes()) {
     if (replacementTy && !replacementTy->isCanonical())
       return false;
@@ -91,6 +106,7 @@ bool SubstitutionMap::isCanonical() const {
 SubstitutionMap SubstitutionMap::getCanonical() const {
   if (empty()) return *this;
 
+  auto canonicalSig = getGenericSignature()->getCanonicalSignature();
   SmallVector<Type, 4> replacementTypes;
   for (Type replacementType : getReplacementTypes()) {
     if (replacementType)
@@ -104,7 +120,7 @@ SubstitutionMap SubstitutionMap::getCanonical() const {
     conformances.push_back(conf.getCanonicalConformanceRef());
   }
 
-  return SubstitutionMap::get(getGenericSignature(),
+  return SubstitutionMap::get(canonicalSig,
                               ArrayRef<Type>(replacementTypes),
                               ArrayRef<ProtocolConformanceRef>(conformances));
 }
@@ -206,7 +222,7 @@ Type SubstitutionMap::lookupSubstitution(CanSubstitutableType type) const {
   // have.
   auto genericParam = cast<GenericTypeParamType>(type);
   auto mutableThis = const_cast<SubstitutionMap *>(this);
-  auto replacementTypes = mutableThis->getReplacementTypes();
+  auto replacementTypes = mutableThis->getReplacementTypesBuffer();
   auto genericSig = getGenericSignature();
   assert(genericSig);
   auto genericParams = genericSig->getGenericParams();
@@ -571,7 +587,7 @@ void SubstitutionMap::dump(llvm::raw_ostream &out) const {
   out << "\n";
   out << "Substitutions:\n";
   auto genericParams = genericSig->getGenericParams();
-  auto replacementTypes = getReplacementTypes();
+  auto replacementTypes = getReplacementTypesBuffer();
   for (unsigned i : indices(genericParams)) {
     out.indent(2);
     genericParams[i]->print(out);

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -570,3 +570,11 @@ void SubstitutionMap::profile(llvm::FoldingSetNodeID &id) const {
   id.AddPointer(storage);
 }
 
+SmallVector<Substitution, 4> SubstitutionMap::toList() const {
+  SmallVector<Substitution, 4> subs;
+  if (empty()) return subs;
+
+  getGenericSignature()->getSubstitutions(*this, subs);
+  return subs;
+}
+

--- a/lib/AST/TypeWalker.cpp
+++ b/lib/AST/TypeWalker.cpp
@@ -180,8 +180,8 @@ class Traversal : public TypeVisitor<Traversal, bool>
   }
 
   bool visitSILBoxType(SILBoxType *ty) {
-    for (auto &arg : ty->getGenericArgs()) {
-      if (doIt(arg.getReplacement()))
+    for (Type type : ty->getSubstitutions().getReplacementTypes()) {
+      if (type && doIt(type))
         return true;
     }
     return false;

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -481,7 +481,7 @@ makeEnumRawValueConstructor(ClangImporter::Implementation &Impl,
   SubstitutionMap subMap =
     SubstitutionMap::get(reinterpretCast->getGenericSignature(),
                          { rawTy, enumTy }, { });
-  ConcreteDeclRef concreteDeclRef(C, reinterpretCast, subMap);
+  ConcreteDeclRef concreteDeclRef(reinterpretCast, subMap);
   auto reinterpretCastRef
     = new (C) DeclRefExpr(concreteDeclRef, DeclNameLoc(), /*implicit*/ true);
   reinterpretCastRef->setType(FunctionType::get({rawTy}, enumTy));
@@ -570,7 +570,7 @@ static AccessorDecl *makeEnumRawValueGetter(ClangImporter::Implementation &Impl,
   SubstitutionMap subMap =
     SubstitutionMap::get(reinterpretCast->getGenericSignature(),
                          { enumTy, rawTy }, { });
-  ConcreteDeclRef concreteDeclRef(C, reinterpretCast, subMap);
+  ConcreteDeclRef concreteDeclRef(reinterpretCast, subMap);
 
   auto reinterpretCastRef
     = new (C) DeclRefExpr(concreteDeclRef, DeclNameLoc(), /*implicit*/ true);
@@ -1217,7 +1217,7 @@ createDefaultConstructor(ClangImporter::Implementation &Impl,
   SubstitutionMap subMap =
     SubstitutionMap::get(zeroInitializerFunc->getGenericSignature(),
                          llvm::makeArrayRef(selfType), { });
-  ConcreteDeclRef concreteDeclRef(context, zeroInitializerFunc, subMap);
+  ConcreteDeclRef concreteDeclRef(zeroInitializerFunc, subMap);
   auto zeroInitializerRef =
     new (context) DeclRefExpr(concreteDeclRef, DeclNameLoc(),
                               /*implicit*/ true);

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -476,10 +476,12 @@ makeEnumRawValueConstructor(ClangImporter::Implementation &Impl,
   paramRef->setType(param->getType());
 
   auto reinterpretCast
-    = getBuiltinValueDecl(C, C.getIdentifier("reinterpretCast"));
-  ConcreteDeclRef concreteDeclRef(C, reinterpretCast,
-                                  { Substitution(rawTy, {}),
-                                    Substitution(enumTy, {}) });
+    = cast<FuncDecl>(
+        getBuiltinValueDecl(C, C.getIdentifier("reinterpretCast")));
+  SubstitutionMap subMap =
+    SubstitutionMap::get(reinterpretCast->getGenericSignature(),
+                         { rawTy, enumTy }, { });
+  ConcreteDeclRef concreteDeclRef(C, reinterpretCast, subMap);
   auto reinterpretCastRef
     = new (C) DeclRefExpr(concreteDeclRef, DeclNameLoc(), /*implicit*/ true);
   reinterpretCastRef->setType(FunctionType::get({rawTy}, enumTy));
@@ -563,10 +565,13 @@ static AccessorDecl *makeEnumRawValueGetter(ClangImporter::Implementation &Impl,
   selfRef->setType(selfDecl->getType());
 
   auto reinterpretCast
-    = getBuiltinValueDecl(C, C.getIdentifier("reinterpretCast"));
-  ConcreteDeclRef concreteDeclRef(C, reinterpretCast,
-                                  { Substitution(enumTy, {}),
-                                    Substitution(rawTy, {}) });
+    = cast<FuncDecl>(
+        getBuiltinValueDecl(C, C.getIdentifier("reinterpretCast")));
+  SubstitutionMap subMap =
+    SubstitutionMap::get(reinterpretCast->getGenericSignature(),
+                         { enumTy, rawTy }, { });
+  ConcreteDeclRef concreteDeclRef(C, reinterpretCast, subMap);
+
   auto reinterpretCastRef
     = new (C) DeclRefExpr(concreteDeclRef, DeclNameLoc(), /*implicit*/ true);
   reinterpretCastRef->setType(FunctionType::get({enumTy}, rawTy));
@@ -1207,9 +1212,12 @@ createDefaultConstructor(ClangImporter::Implementation &Impl,
 
   // Construct the right-hand call to Builtin.zeroInitializer.
   Identifier zeroInitID = context.getIdentifier("zeroInitializer");
-  auto zeroInitializerFunc = getBuiltinValueDecl(context, zeroInitID);
-  ConcreteDeclRef concreteDeclRef(context, zeroInitializerFunc,
-                                  { Substitution(selfType, {}) });
+  auto zeroInitializerFunc =
+    cast<FuncDecl>(getBuiltinValueDecl(context, zeroInitID));
+  SubstitutionMap subMap =
+    SubstitutionMap::get(zeroInitializerFunc->getGenericSignature(),
+                         llvm::makeArrayRef(selfType), { });
+  ConcreteDeclRef concreteDeclRef(context, zeroInitializerFunc, subMap);
   auto zeroInitializerRef =
     new (context) DeclRefExpr(concreteDeclRef, DeclNameLoc(),
                               /*implicit*/ true);

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -5785,8 +5785,10 @@ ProtocolConformance *SILParser::parseProtocolConformanceHelper(
                                         subs))
       return nullptr;
 
+    auto subMap =
+      genericConform->getGenericSignature()->getSubstitutionMap(subs);
     auto result = P.Context.getSpecializedConformance(
-      ConformingTy, genericConform, subs);
+      ConformingTy, genericConform, subMap);
     return result;
   }
 

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -494,6 +494,16 @@ SubstitutionList SILFunction::getForwardingSubstitutions() {
   return *ForwardingSubs;
 }
 
+SubstitutionMap SILFunction::getForwardingSubstitutionMap() {
+  if (ForwardingSubMap)
+    return ForwardingSubMap;
+
+  if (auto *env = getGenericEnvironment())
+    ForwardingSubMap = env->getForwardingSubstitutionMap();
+
+  return ForwardingSubMap;
+}
+
 bool SILFunction::shouldVerifyOwnership() const {
   return !hasSemanticsAttr("verify.ownership.sil.never");
 }

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -582,13 +582,12 @@ SILBoxType::getFieldLoweredType(SILModule &M, unsigned index) const {
   auto fieldTy = getLayout()->getFields()[index].getLoweredType();
   
   // Apply generic arguments if the layout is generic.
-  if (!getGenericArgs().empty()) {
+  if (auto subMap = getSubstitutions()) {
     auto sig = getLayout()->getGenericSignature();
-    auto subs = sig->getSubstitutionMap(getGenericArgs());
     return SILType::getPrimitiveObjectType(fieldTy)
       .subst(M,
-             QuerySubstitutionMap{subs},
-             LookUpConformanceInSubstitutionMap(subs),
+             QuerySubstitutionMap{subMap},
+             LookUpConformanceInSubstitutionMap(subMap),
              sig)
       .getSwiftRValueType();
   }

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -2472,10 +2472,8 @@ TypeConverter::getInterfaceBoxTypeForCapture(ValueDecl *captured,
     -> ProtocolConformanceRef {
       return ProtocolConformanceRef(conformedTy->getDecl());
     });
-  SmallVector<Substitution, 4> genericArgs;
-  signature->getSubstitutions(subMap, genericArgs);
 
-  auto boxTy = SILBoxType::get(C, layout, genericArgs);
+  auto boxTy = SILBoxType::get(C, layout, subMap);
 #ifndef NDEBUG
   // FIXME: Map the box type out of context when asserting the field so
   // we don't need to push a GenericContextScope (which really ought to die).
@@ -2554,10 +2552,8 @@ CanSILBoxType TypeConverter::getBoxTypeForEnumElement(SILType enumType,
   // Instantiate the layout with enum's substitution list.
   auto subMap = boundEnum->getContextSubstitutionMap(
       M.getSwiftModule(), enumDecl, enumDecl->getGenericEnvironment());
-  SmallVector<Substitution, 4> genericArgs;
-  boxSignature->getSubstitutions(subMap, genericArgs);
 
-  auto boxTy = SILBoxType::get(C, layout, genericArgs);
+  auto boxTy = SILBoxType::get(C, layout, subMap);
   return boxTy;
 }
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -289,7 +289,7 @@ private:
 
   /// The substitutions applied to OrigFormalInterfaceType to produce
   /// SubstFormalInterfaceType.
-  SubstitutionList Substitutions;
+  SubstitutionMap Substitutions;
 
   /// The list of values captured by our callee.
   Optional<SmallVector<ManagedValue, 2>> Captures;
@@ -299,7 +299,7 @@ private:
 
   static CanFunctionType
   getSubstFormalInterfaceType(CanAnyFunctionType substFormalType,
-                              SubstitutionList subs) {
+                              SubstitutionMap subs) {
     if (auto *gft = substFormalType->getAs<GenericFunctionType>()) {
       return cast<FunctionType>(
         gft->substGenericArgs(subs)
@@ -325,7 +325,7 @@ private:
   Callee(SILGenFunction &SGF, SILDeclRef standaloneFunction,
          AbstractionPattern origFormalType,
          CanAnyFunctionType substFormalType,
-         SubstitutionList subs, SILLocation l)
+         SubstitutionMap subs, SILLocation l)
     : kind(Kind::StandaloneFunction), Constant(standaloneFunction),
       OrigFormalInterfaceType(origFormalType),
       SubstFormalInterfaceType(getSubstFormalInterfaceType(substFormalType,
@@ -339,7 +339,7 @@ private:
   /// forIndirect.
   Callee(Kind methodKind, SILGenFunction &SGF, SILDeclRef methodName,
          AbstractionPattern origFormalType, CanAnyFunctionType substFormalType,
-         SubstitutionList subs, SILLocation l)
+         SubstitutionMap subs, SILLocation l)
       : kind(methodKind), Constant(methodName),
         OrigFormalInterfaceType(origFormalType),
         SubstFormalInterfaceType(
@@ -355,13 +355,13 @@ public:
     return Callee(indirectValue, origFormalType, substFormalType, l);
   }
   static Callee forDirect(SILGenFunction &SGF, SILDeclRef c,
-                          SubstitutionList subs,
+                          SubstitutionMap subs,
                           SILLocation l) {
     auto &ci = SGF.getConstantInfo(c);
     return Callee(SGF, c, ci.FormalPattern, ci.FormalType, subs, l);
   }
   static Callee forEnumElement(SILGenFunction &SGF, SILDeclRef c,
-                               SubstitutionList subs,
+                               SubstitutionMap subs,
                                SILLocation l) {
     assert(isa<EnumElementDecl>(c.getDecl()));
     auto &ci = SGF.getConstantInfo(c);
@@ -369,7 +369,7 @@ public:
                   ci.FormalType, subs, l);
   }
   static Callee forClassMethod(SILGenFunction &SGF,
-                               SILDeclRef c, SubstitutionList subs,
+                               SILDeclRef c, SubstitutionMap subs,
                                SILLocation l) {
     auto base = c.getOverriddenVTableEntry();
     auto &baseCI = SGF.getConstantInfo(base);
@@ -378,7 +378,7 @@ public:
                   baseCI.FormalPattern, derivedCI.FormalType, subs, l);
   }
   static Callee forSuperMethod(SILGenFunction &SGF,
-                               SILDeclRef c, SubstitutionList subs,
+                               SILDeclRef c, SubstitutionMap subs,
                                SILLocation l) {
     auto &ci = SGF.getConstantInfo(c);
     return Callee(Kind::SuperMethod, SGF, c,
@@ -387,16 +387,16 @@ public:
   static Callee forWitnessMethod(SILGenFunction &SGF,
                                  CanType protocolSelfType,
                                  SILDeclRef c,
-                                 SubstitutionList subs,
+                                 SubstitutionMap subs,
                                  SILLocation l) {
     auto &ci = SGF.getConstantInfo(c);
     return Callee(Kind::WitnessMethod, SGF, c, ci.FormalPattern,
                   ci.FormalType, subs, l);
   }
   static Callee forDynamic(SILGenFunction &SGF,
-                           SILDeclRef c, const SubstitutionList &constantSubs,
+                           SILDeclRef c, SubstitutionMap constantSubs,
                            CanAnyFunctionType substFormalType,
-                           SubstitutionList subs, SILLocation l) {
+                           SubstitutionMap subs, SILLocation l) {
     auto &ci = SGF.getConstantInfo(c);
     AbstractionPattern origFormalType = ci.FormalPattern;
 
@@ -593,12 +593,9 @@ public:
       auto constantInfo = SGF.getConstantInfo(*constant);
 
       auto proto = cast<ProtocolDecl>(Constant.getDecl()->getDeclContext());
-      auto genericSig = cast<AbstractFunctionDecl>(Constant.getDecl())
-        ->getGenericSignature();
-      auto subMap = genericSig->getSubstitutionMap(Substitutions);
       auto selfType = proto->getSelfInterfaceType()->getCanonicalType();
-      auto lookupType = selfType.subst(subMap)->getCanonicalType();
-      auto conformance = *subMap.lookupConformance(selfType, proto);
+      auto lookupType = selfType.subst(Substitutions)->getCanonicalType();
+      auto conformance = *Substitutions.lookupConformance(selfType, proto);
 
       SILValue fn;
 
@@ -675,7 +672,7 @@ public:
     }
   }
 
-  SubstitutionList getSubstitutions() const {
+  SubstitutionMap getSubstitutions() const {
     return Substitutions;
   }
 
@@ -859,7 +856,7 @@ public:
 
     ArgumentSource selfValue = thisCallSite->getArg();
 
-    SubstitutionList subs = e->getDeclRef().getSubstitutions();
+    auto subs = e->getDeclRef().getSubstitutions();
 
     SILDeclRef::Kind kind = SILDeclRef::Kind::Func;
     if (isa<ConstructorDecl>(afd)) {
@@ -965,7 +962,7 @@ public:
   // Known callees.
   //
   void visitDeclRefExpr(DeclRefExpr *e) {
-    SubstitutionList subs = e->getDeclRef().getSubstitutions();
+    auto subs = e->getDeclRef().getSubstitutions();
 
     // If this is a direct reference to a vardecl, just emit its value directly.
     // Recursive references to callable declarations are allowed.
@@ -1003,7 +1000,7 @@ public:
     auto captureInfo = SGF.SGM.Types.getLoweredLocalCaptures(afd);
     if (afd->getDeclContext()->isLocalContext() &&
         !captureInfo.hasGenericParamCaptures())
-      subs = SubstitutionList();
+      subs = SubstitutionMap();
 
     setCallee(Callee::forDirect(SGF, constant, subs, e));
     
@@ -1031,9 +1028,9 @@ public:
     // really producing a closure object.
     SILDeclRef constant(e);
 
-    SubstitutionList subs;
+    SubstitutionMap subs;
     if (e->getCaptureInfo().hasGenericParamCaptures())
-      subs = SGF.getForwardingSubstitutions();
+      subs = SGF.getForwardingSubstitutionMap();
 
     setCallee(Callee::forDirect(SGF, constant, subs, e));
     
@@ -1054,7 +1051,8 @@ public:
     // constructors imported from Clang (which won't have a direct entry point)
     // or to delegate to a designated initializer.
     setCallee(Callee::forDirect(SGF,
-                SILDeclRef(e->getDecl(), SILDeclRef::Kind::Initializer), subs, e));
+                SILDeclRef(e->getDecl(), SILDeclRef::Kind::Initializer),
+                           subs, e));
   }
 
   void visitDotSyntaxBaseIgnoredExpr(DotSyntaxBaseIgnoredExpr *e) {
@@ -1094,7 +1092,7 @@ public:
 
     // The callee for a super call has to be either a method or constructor.
     Expr *fn = apply->getFn();
-    SubstitutionList substitutions;
+    SubstitutionMap substitutions;
     SILDeclRef constant;
     if (auto *ctorRef = dyn_cast<OtherConstructorDeclRefExpr>(fn)) {
       constant = SILDeclRef(ctorRef->getDecl(), SILDeclRef::Kind::Initializer)
@@ -1318,8 +1316,7 @@ public:
           SGF, constant, subs, fn));
     } else {
       // Directly call the peer constructor.
-      setCallee(
-        Callee::forDirect(SGF, constant, subs, fn));
+      setCallee(Callee::forDirect(SGF, constant, subs, fn));
     }
 
     setSelfParam(std::move(selfArgSource), expr);
@@ -1414,7 +1411,8 @@ public:
         dynamicMemberRef->getBase()->getType()->getCanonicalType(),
         substFormalType, AnyFunctionType::ExtInfo());
 
-      setCallee(Callee::forDynamic(SGF, member, memberRef.getSubstitutions(),
+      setCallee(Callee::forDynamic(SGF, member,
+                                   memberRef.getSubstitutions(),
                                    substFormalType, {}, e));
       setSelfParam(std::move(baseArgSource), dynamicMemberRef);
     };
@@ -1538,7 +1536,7 @@ static RValue emitStringLiteral(SILGenFunction &SGF, Expr *E, StringRef Str,
 static SILValue emitRawApply(SILGenFunction &SGF,
                              SILLocation loc,
                              ManagedValue fn,
-                             SubstitutionList subs,
+                             SubstitutionMap subs,
                              ArrayRef<ManagedValue> args,
                              CanSILFunctionType substFnType,
                              ApplyOptions options,
@@ -1594,7 +1592,7 @@ static SILValue emitRawApply(SILGenFunction &SGF,
   SILValue result;
   if (!substFnType->hasErrorResult()) {
     result = SGF.B.createApply(loc, fnValue, calleeType,
-                               resultType, subs, argValues);
+                               resultType, subs.toList(), argValues);
 
   // Otherwise, we need to create a try_apply.
   } else {
@@ -1605,7 +1603,7 @@ static SILValue emitRawApply(SILGenFunction &SGF,
       SGF.getTryApplyErrorDest(loc, substFnType->getErrorResult(),
                                options & ApplyOptions::DoesNotThrow);
 
-    SGF.B.createTryApply(loc, fnValue, calleeType, subs, argValues,
+    SGF.B.createTryApply(loc, fnValue, calleeType, subs.toList(), argValues,
                          normalBB, errorBB);
     SGF.B.emitBlock(normalBB);
   }
@@ -3709,7 +3707,7 @@ CallEmission::applyNormalCall(SGFContext C) {
   // Emit the uncurried call.
   firstLevelResult.value = SGF.emitApply(
       std::move(resultPlan), std::move(argScope), uncurriedLoc.getValue(), mv,
-      callee.getSubstitutions(), uncurriedArgs, calleeTypeInfo, options,
+      callee.getSubstitutions().toList(), uncurriedArgs, calleeTypeInfo, options,
       uncurriedContext);
   firstLevelResult.foreignSelf = calleeTypeInfo.foreignSelf;
   return firstLevelResult;
@@ -3818,7 +3816,7 @@ CallEmission::applyPartiallyAppliedSuperMethod(SGFContext C) {
   }
   auto calleeConvention = ParameterConvention::Direct_Guaranteed;
   auto closureTy = SILGenBuilder::getPartialApplyResultType(
-      constantInfo.getSILType(), 1, SGF.B.getModule(), subs, calleeConvention);
+      constantInfo.getSILType(), 1, SGF.B.getModule(), subs.toList(), calleeConvention);
 
   auto &module = SGF.getFunction().getModule();
 
@@ -3827,7 +3825,8 @@ CallEmission::applyPartiallyAppliedSuperMethod(SGFContext C) {
     partialApplyTy = partialApplyTy.substGenericArgs(module, subs);
 
   ManagedValue pa = SGF.B.createPartialApply(loc, superMethod, partialApplyTy,
-                                             subs, {upcastedSelf}, closureTy);
+                                             subs.toList(), {upcastedSelf},
+                                             closureTy);
   assert(!closureTy.castTo<SILFunctionType>()->isNoEscape());
   firstLevelResult.value = RValue(SGF, loc, formalApplyType.getResult(), pa);
   return firstLevelResult;
@@ -3870,8 +3869,8 @@ CallEmission::applySpecializedEmitter(SpecializedEmitter &specializedEmitter,
     // always still expressions.
     Expr *argument = std::move(uncurriedSites[0]).forward().asKnownExpr();
     ManagedValue resultMV =
-        emitter(SGF, uncurriedLoc, callee.getSubstitutions(), argument,
-                uncurriedContext);
+        emitter(SGF, uncurriedLoc, callee.getSubstitutions().toList(),
+                argument, uncurriedContext);
     firstLevelResult.value =
         RValue(SGF, uncurriedLoc, formalResultType, resultMV);
     return firstLevelResult;
@@ -3889,7 +3888,8 @@ CallEmission::applySpecializedEmitter(SpecializedEmitter &specializedEmitter,
   // If we have a late emitter, just delegate to that emitter and return.
   if (specializedEmitter.isLateEmitter()) {
     auto emitter = specializedEmitter.getLateEmitter();
-    ManagedValue mv = emitter(SGF, *uncurriedLoc, callee.getSubstitutions(),
+    ManagedValue mv = emitter(SGF, *uncurriedLoc,
+                              callee.getSubstitutions().toList(),
                               uncurriedArgs, uncurriedContext);
     firstLevelResult.value =
         RValue(SGF, *uncurriedLoc, formalApplyType.getResult(), mv);
@@ -3908,7 +3908,8 @@ CallEmission::applySpecializedEmitter(SpecializedEmitter &specializedEmitter,
   SILFunctionConventions substConv(substFnType, SGF.SGM.M);
   auto resultVal = SGF.B.createBuiltin(uncurriedLoc.getValue(), builtinName,
                                        substConv.getSILResultType(),
-                                       callee.getSubstitutions(), consumedArgs);
+                                       callee.getSubstitutions().toList(),
+                                       consumedArgs);
   firstLevelResult.value =
       RValue(SGF, *uncurriedLoc, formalApplyType.getResult(),
              SGF.emitManagedRValueWithCleanup(resultVal));
@@ -4159,8 +4160,11 @@ RValue SILGenFunction::emitApply(ResultPlanPtr &&resultPlan,
 
   // Emit the raw application.
   loc.decodeDebugLoc(SGM.M.getASTContext().SourceMgr);
+  auto genericSig =
+    fn.getType().castTo<SILFunctionType>()->getGenericSignature();
+  auto subMap = genericSig->getSubstitutionMap(subs);
   SILValue rawDirectResult = emitRawApply(
-      *this, loc, fn, subs, args, substFnType, options, indirectResultAddrs);
+      *this, loc, fn, subMap, args, substFnType, options, indirectResultAddrs);
 
   // Pop the argument scope.
   argScope.pop();
@@ -4429,20 +4433,7 @@ SILGenFunction::emitApplyOfLibraryIntrinsic(SILLocation loc,
                                             const SubstitutionMap &subMap,
                                             ArrayRef<ManagedValue> args,
                                             SGFContext ctx) {
-  SmallVector<Substitution, 4> subs;
-  if (auto *genericSig = fn->getGenericSignature())
-    genericSig->getSubstitutions(subMap, subs);
-
-  return emitApplyOfLibraryIntrinsic(loc, fn, subs, args, ctx);
-}
-
-RValue
-SILGenFunction::emitApplyOfLibraryIntrinsic(SILLocation loc,
-                                            FuncDecl *fn,
-                                            const SubstitutionList &subs,
-                                            ArrayRef<ManagedValue> args,
-                                            SGFContext ctx) {
-  auto callee = Callee::forDirect(*this, SILDeclRef(fn), subs, loc);
+  auto callee = Callee::forDirect(*this, SILDeclRef(fn), subMap, loc);
 
   auto origFormalType = callee.getOrigFormalType();
   auto substFormalType = callee.getSubstFormalType();
@@ -4467,11 +4458,27 @@ SILGenFunction::emitApplyOfLibraryIntrinsic(SILLocation loc,
   llvm::SmallVector<ManagedValue, 8> finalArgs;
   convertOwnershipConventionsGivenParamInfos(*this, silConv.getParameters(), args, loc, finalArgs);
 
+  SmallVector<Substitution, 4> subs;
+  if (auto *genericSig = fn->getGenericSignature())
+    genericSig->getSubstitutions(subMap, subs);
+
   ResultPlanPtr resultPlan =
-      ResultPlanBuilder::computeResultPlan(*this, calleeTypeInfo, loc, ctx);
+  ResultPlanBuilder::computeResultPlan(*this, calleeTypeInfo, loc, ctx);
   ArgumentScope argScope(*this, loc);
   return emitApply(std::move(resultPlan), std::move(argScope), loc, mv, subs,
                    finalArgs, calleeTypeInfo, ApplyOptions::None, ctx);
+}
+
+RValue
+SILGenFunction::emitApplyOfLibraryIntrinsic(SILLocation loc,
+                                            FuncDecl *fn,
+                                            const SubstitutionList &subs,
+                                            ArrayRef<ManagedValue> args,
+                                            SGFContext ctx) {
+  SubstitutionMap subMap;
+  if (auto genericSig = fn->getGenericSignature())
+    subMap = genericSig->getSubstitutionMap(subs);
+  return emitApplyOfLibraryIntrinsic(loc, fn, subMap, args, ctx);
 }
 
 static StringRef
@@ -4747,7 +4754,7 @@ static Callee getBaseAccessorFunctionRef(SILGenFunction &SGF,
                                          ArgumentSource &selfValue,
                                          bool isSuper,
                                          bool isDirectUse,
-                                         SubstitutionList subs) {
+                                         SubstitutionMap subs) {
   auto *decl = cast<AbstractFunctionDecl>(constant.getDecl());
 
   // The accessor might be a local function that does not capture any
@@ -4756,7 +4763,7 @@ static Callee getBaseAccessorFunctionRef(SILGenFunction &SGF,
   auto captureInfo = SGF.SGM.Types.getLoweredLocalCaptures(decl);
   if (decl->getDeclContext()->isLocalContext() &&
       !captureInfo.hasGenericParamCaptures()) {
-    subs = SubstitutionList();
+    subs = SubstitutionMap();
   }
 
   // If this is a method in a protocol, generate it as a protocol call.
@@ -4807,11 +4814,19 @@ emitSpecializedAccessorFunctionRef(SILGenFunction &SGF,
                                    bool isSuper,
                                    bool isDirectUse)
 {
+  // Convert the substitution list into a substitution map.
+  auto origAccessType = SGF.SGM.Types.getConstantInfo(constant).FormalType;
+  SubstitutionMap subMap;
+  if (auto genericFnType = dyn_cast<GenericFunctionType>(origAccessType)) {
+    auto genericSig = genericFnType.getGenericSignature();
+    subMap = genericSig->getSubstitutionMap(substitutions);;
+  }
+
   // Get the accessor function. The type will be a polymorphic function if
   // the Self type is generic.
   Callee callee = getBaseAccessorFunctionRef(SGF, loc, constant, selfValue,
                                              isSuper, isDirectUse,
-                                             substitutions);
+                                             subMap);
   
   // Collect captures if the accessor has them.
   auto accessorFn = cast<AbstractFunctionDecl>(constant.getDecl());

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -206,9 +206,7 @@ emitBridgeObjectiveCToNative(SILGenFunction &SGF,
 
   CanType swiftValueType = conformance->getType()->getCanonicalType();
   auto genericSig = witnessFnTy->getGenericSignature();
-  SubstitutionMap typeSubMap;
-  if (genericSig)
-    typeSubMap = genericSig->getSubstitutionMap(witness.getSubstitutions());
+  SubstitutionMap typeSubMap = witness.getSubstitutions();
 
   // Substitute into the witness function type.
   witnessFnTy = witnessFnTy->substGenericArgs(SGF.SGM.M, typeSubMap);
@@ -243,7 +241,8 @@ emitBridgeObjectiveCToNative(SILGenFunction &SGF,
   ArgumentScope argScope(SGF, loc);
   RValue result =
       SGF.emitApply(std::move(resultPlan), std::move(argScope), loc,
-                    ManagedValue::forUnmanaged(witnessRef), subs,
+                    ManagedValue::forUnmanaged(witnessRef),
+                    subs.toList(),
                     {objcValue, ManagedValue::forUnmanaged(metatypeValue)},
                     calleeTypeInfo, ApplyOptions::None, context);
   return std::move(result).getAsSingleValue(SGF, loc);

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -1021,7 +1021,8 @@ void SILGenFunction::emitMemberInitializers(DeclContext *dc,
       auto self = emitSelfForMemberInit(*this, var, selfDecl);
       
       auto mark = B.createMarkUninitializedBehavior(var,
-               initFn, init.getSubstitutions(), storageAddr.getValue(),
+               initFn, init.getSubstitutions().toList(),
+               storageAddr.getValue(),
                setterFn, getForwardingSubstitutions(), self.getValue(),
                getLoweredType(var->getType()).getAddressType());
       

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -572,7 +572,7 @@ ManagedValue SILGenFunction::emitExistentialErasure(
       auto nsErrorVar = SGM.getNSErrorRequirement(loc);
       if (!nsErrorVar) return emitUndef(loc, existentialTL.getLoweredType());
 
-      SubstitutionList nsErrorVarSubstitutions;
+      SubstitutionMap nsErrorVarSubstitutions;
 
       // Devirtualize.  Maybe this should be done implicitly by
       // emitPropertyLValue?
@@ -592,7 +592,8 @@ ManagedValue SILGenFunction::emitExistentialErasure(
       ManagedValue nsError =
           emitRValueForStorageLoad(
               loc, nativeError, concreteFormalType,
-              /*super*/ false, nsErrorVar, RValue(), nsErrorVarSubstitutions,
+              /*super*/ false, nsErrorVar, RValue(),
+              nsErrorVarSubstitutions.toList(),
               AccessSemantics::Ordinary, nsErrorType, SGFContext())
               .getAsSingleValue(*this, loc);
 

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -148,6 +148,10 @@ SubstitutionList SILGenFunction::getForwardingSubstitutions() {
   return F.getForwardingSubstitutions();
 }
 
+SubstitutionMap SILGenFunction::getForwardingSubstitutionMap() {
+  return F.getForwardingSubstitutionMap();
+}
+
 void SILGenFunction::visitFuncDecl(FuncDecl *fd) {
   // Generate the local function body.
   SGM.emitFunction(fd);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1822,7 +1822,11 @@ public:
   /// Return forwarding substitutions for the archetypes in the current
   /// function.
   SubstitutionList getForwardingSubstitutions();
-  
+
+  /// Return forwarding substitutions for the archetypes in the current
+  /// function.
+  SubstitutionMap getForwardingSubstitutionMap();
+
   /// Get the _Pointer protocol used for pointer argument operations.
   ProtocolDecl *getPointerProtocol();
 };

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -2427,7 +2427,8 @@ LValue SILGenLValue::visitMemberRefExpr(MemberRefExpr *e,
   assert(lv.isValid());
 
   CanType substFormalRValueType = getSubstFormalRValueType(e);
-  lv.addMemberVarComponent(SGF, e, var, e->getMember().getSubstitutions(),
+  lv.addMemberVarComponent(SGF, e, var,
+                           e->getMember().getSubstitutions().toList(),
                            options, e->isSuper(), accessKind,
                            e->getAccessSemantics(),
                            strategy, substFormalRValueType);
@@ -2526,7 +2527,8 @@ LValue SILGenLValue::visitSubscriptExpr(SubscriptExpr *e,
   RValue index = SGF.emitRValue(indexExpr);
 
   CanType formalRValueType = getSubstFormalRValueType(e);
-  lv.addMemberSubscriptComponent(SGF, e, decl, e->getDecl().getSubstitutions(),
+  lv.addMemberSubscriptComponent(SGF, e, decl,
+                                 e->getDecl().getSubstitutions().toList(),
                                  options, e->isSuper(), accessKind,
                                  accessSemantics, strategy,
                                  formalRValueType, std::move(index),

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -2620,7 +2620,7 @@ static void emitDiagnoseOfUnexpectedEnumCase(SILGenFunction &SGF,
   auto genericArgsMap =
       diagnoseFailure->getGenericSignature()->getSubstitutionMap(sub);
 
-  SGF.emitApplyOfLibraryIntrinsic(loc, diagnoseFailure, sub,
+  SGF.emitApplyOfLibraryIntrinsic(loc, diagnoseFailure, genericArgsMap,
                                   metatype,
                                   SGFContext());
 }

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -604,8 +604,7 @@ SILFunction *SILGenModule::emitProtocolWitness(
 
   // Mapping from the requirement's generic signature to the witness
   // thunk's generic signature.
-  auto reqtSubs = witness.getRequirementToSyntheticSubs();
-  auto reqtSubMap = reqtOrigTy->getGenericSignature()->getSubstitutionMap(reqtSubs);
+  auto reqtSubMap = witness.getRequirementToSyntheticSubs();
 
   // The generic environment for the witness thunk.
   auto *genericEnv = witness.getSyntheticEnvironment();
@@ -683,7 +682,7 @@ SILFunction *SILGenModule::emitProtocolWitness(
       if (SGF.maybeEmitMaterializeForSetThunk(conformance, linkage,
                                               selfInterfaceType, selfType,
                                               genericEnv, reqFn, witnessFn,
-                                              witnessSubs))
+                                              witnessSubs.toList()))
         return f;
 
       // Proceed down the normal path.
@@ -692,7 +691,7 @@ SILFunction *SILGenModule::emitProtocolWitness(
 
   SGF.emitProtocolWitness(AbstractionPattern(reqtOrigTy), reqtSubstTy,
                           requirement, witnessRef,
-                          witnessSubs, isFree);
+                          witnessSubs.toList(), isFree);
 
   return f;
 }

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -689,7 +689,7 @@ namespace {
       }
 
       auto declRefExpr =
-        new (ctx) DeclRefExpr(ConcreteDeclRef(ctx, decl, substitutions),
+        new (ctx) DeclRefExpr(ConcreteDeclRef(decl, substitutions),
                               loc, implicit, semantics, type);
       cs.cacheType(declRefExpr);
       declRefExpr->setFunctionRefKind(functionRefKind);
@@ -969,7 +969,7 @@ namespace {
         solution.computeSubstitutions(
             member->getInnermostDeclContext()->getGenericSignatureOfContext(),
             memberLocator);
-      auto memberRef = ConcreteDeclRef(context, member, substitutions);
+      auto memberRef = ConcreteDeclRef(member, substitutions);
 
       cs.TC.requestMemberLayout(member);
 
@@ -1644,7 +1644,7 @@ namespace {
         solution.computeSubstitutions(
           subscript->getInnermostDeclContext()->getGenericSignatureOfContext(),
           locator.withPathElement(locatorKind));
-      ConcreteDeclRef subscriptRef(tc.Context, subscript, substitutions);
+      ConcreteDeclRef subscriptRef(subscript, substitutions);
 
       // Handle dynamic lookup.
       if (choice.getKind() == OverloadChoiceKind::DeclViaDynamic ||
@@ -1699,7 +1699,7 @@ namespace {
       SubstitutionMap substitutions =
         solution.computeSubstitutions(ctor->getGenericSignature(), locator);
 
-      auto ref = ConcreteDeclRef(ctx, ctor, substitutions);
+      auto ref = ConcreteDeclRef(ctor, substitutions);
 
       // The constructor was opened with the allocating type, not the
       // initializer type. Map the former into the latter.
@@ -1842,7 +1842,7 @@ namespace {
           return *bridgedToObjectiveCConformance;
         });
 
-      ConcreteDeclRef fnSpecRef(tc.Context, fn, subMap);
+      ConcreteDeclRef fnSpecRef(fn, subMap);
 
       auto resultType = OptionalType::get(valueType);
 
@@ -1998,7 +1998,7 @@ namespace {
         SubstitutionMap subs =
           SubstitutionMap::get(genericSig, llvm::makeArrayRef(objectType),
                                { });
-        ConcreteDeclRef concreteDeclRef(tc.Context, nilDecl, subs);
+        ConcreteDeclRef concreteDeclRef(nilDecl, subs);
 
         auto nilType = FunctionType::get(
             {MetatypeType::get(type)}, type);
@@ -4448,7 +4448,7 @@ namespace {
           auto resolvedTy = foundDecl->openedType;
           resolvedTy = simplifyType(resolvedTy);
           
-          auto ref = ConcreteDeclRef(cs.getASTContext(), property, subs);
+          auto ref = ConcreteDeclRef(property, subs);
 
           component = KeyPathExpr::Component::forProperty(ref,
                                                        resolvedTy,
@@ -4518,7 +4518,7 @@ namespace {
           
           resolvedTy = simplifyType(resolvedTy);
           
-          auto ref = ConcreteDeclRef(cs.getASTContext(), subscript, subs);
+          auto ref = ConcreteDeclRef(subscript, subs);
           
           // Coerce the indices to the type the subscript expects.
           auto indexExpr = coerceToType(origComponent.getIndexExpr(),
@@ -4923,7 +4923,7 @@ ConcreteDeclRef Solution::resolveLocatorToDecl(
                   decl->getInnermostDeclContext()
                       ->getGenericSignatureOfContext(),
                 locator);
-              return ConcreteDeclRef(cs.getASTContext(), decl, subs);
+              return ConcreteDeclRef(decl, subs);
             })) {
     return resolved;
   }
@@ -5034,7 +5034,7 @@ getCallerDefaultArg(ConstraintSystem &cs, DeclContext *dc,
 
   case DefaultArgumentKind::Inherited:
     // Update the owner to reflect inheritance here.
-    owner = owner.getOverriddenDecl(tc.Context);
+    owner = owner.getOverriddenDecl();
     return getCallerDefaultArg(cs, dc, loc, owner, index);
 
   case DefaultArgumentKind::Column:

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1185,7 +1185,7 @@ void TypeChecker::completePropertyBehaviorStorage(VarDecl *VD,
   // Initialize the storage immediately, if we can.
   Expr *InitStorageExpr = nullptr;
   auto Method = DefaultInitStorage ? DefaultInitStorage : ParamInitStorage;
-  auto SpecializeInitStorage = ConcreteDeclRef(Context, Method, contextMap);
+  auto SpecializeInitStorage = ConcreteDeclRef(Method, contextMap);
 
   if (DefaultInitStorage ||
       (ParamInitStorage && VD->getParentInitializer())) {
@@ -1487,7 +1487,7 @@ void TypeChecker::completePropertyBehaviorAccessors(VarDecl *VD,
 
     Expr *selfExpr = makeSelfExpr(getter, ValueImpl->getGetter());
     
-    auto implRef = ConcreteDeclRef(Context, ValueImpl, SelfContextSubs);
+    auto implRef = ConcreteDeclRef(ValueImpl, SelfContextSubs);
     auto implMemberExpr = new (Context) MemberRefExpr(selfExpr,
                                                       SourceLoc(),
                                                       implRef,
@@ -1518,7 +1518,7 @@ void TypeChecker::completePropertyBehaviorAccessors(VarDecl *VD,
   
   if (auto setter = VD->getSetter()) {
     Expr *selfExpr = makeSelfExpr(setter, ValueImpl->getSetter());
-    auto implRef = ConcreteDeclRef(Context, ValueImpl, SelfContextSubs);
+    auto implRef = ConcreteDeclRef(ValueImpl, SelfContextSubs);
     auto implMemberExpr = new (Context) MemberRefExpr(selfExpr,
                                                       SourceLoc(),
                                                       implRef,

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1147,19 +1147,15 @@ void TypeChecker::completePropertyBehaviorStorage(VarDecl *VD,
                                Type SelfTy,
                                Type StorageTy,
                                NormalProtocolConformance *BehaviorConformance,
-                               SubstitutionList SelfInterfaceSubs,
-                               SubstitutionList SelfContextSubs) {
+                               SubstitutionMap interfaceMap,
+                               SubstitutionMap contextMap) {
   assert(BehaviorStorage);
   assert((bool)DefaultInitStorage != (bool)ParamInitStorage);
 
   // Substitute the storage type into the conforming context.
-  auto sig = BehaviorConformance->getProtocol()->getGenericSignatureOfContext();
-
-  auto interfaceMap = sig->getSubstitutionMap(SelfInterfaceSubs);
   auto SubstStorageInterfaceTy = StorageTy.subst(interfaceMap);
   assert(SubstStorageInterfaceTy && "storage type substitution failed?!");
 
-  auto contextMap = sig->getSubstitutionMap(SelfContextSubs);
   auto SubstStorageContextTy = StorageTy.subst(contextMap);
   assert(SubstStorageContextTy && "storage type substitution failed?!");
 
@@ -1189,8 +1185,7 @@ void TypeChecker::completePropertyBehaviorStorage(VarDecl *VD,
   // Initialize the storage immediately, if we can.
   Expr *InitStorageExpr = nullptr;
   auto Method = DefaultInitStorage ? DefaultInitStorage : ParamInitStorage;
-  auto SpecializeInitStorage = ConcreteDeclRef(Context, Method,
-                                               SelfContextSubs);
+  auto SpecializeInitStorage = ConcreteDeclRef(Context, Method, contextMap);
 
   if (DefaultInitStorage ||
       (ParamInitStorage && VD->getParentInitializer())) {
@@ -1231,8 +1226,11 @@ void TypeChecker::completePropertyBehaviorStorage(VarDecl *VD,
       InitValue->walk(RecontextualizeClosures(DC));
       
       // Coerce to the property type.
+      auto PropertyType =
+        Type(contextMap.getGenericSignature()->getGenericParams()[1])
+          .subst(contextMap);
       InitValue = new (Context) CoerceExpr(InitValue, SourceLoc(),
-                      TypeLoc::withoutLoc(SelfContextSubs[1].getReplacement()));
+                      TypeLoc::withoutLoc(PropertyType));
       // Type-check the expression.
       typeCheckExpression(InitValue, DC);
 
@@ -1289,8 +1287,8 @@ void TypeChecker::completePropertyBehaviorStorage(VarDecl *VD,
 void TypeChecker::completePropertyBehaviorParameter(VarDecl *VD,
                                  FuncDecl *BehaviorParameter,
                                  NormalProtocolConformance *BehaviorConformance,
-                                 SubstitutionList SelfInterfaceSubs,
-                                 SubstitutionList SelfContextSubs) {
+                                 SubstitutionMap interfaceMap,
+                                 SubstitutionMap contextMap) {
   // Create a method to witness the requirement.
   auto DC = VD->getDeclContext();
   SmallString<64> NameBuf = VD->getName().str();
@@ -1298,7 +1296,6 @@ void TypeChecker::completePropertyBehaviorParameter(VarDecl *VD,
   auto ParameterBaseName = Context.getIdentifier(NameBuf);
 
   // Substitute the requirement type into the conforming context.
-  auto sig = BehaviorConformance->getProtocol()->getGenericSignatureOfContext();
   auto ParameterTy = BehaviorParameter->getInterfaceType()
     ->castTo<AnyFunctionType>()
     ->getResult();
@@ -1306,12 +1303,9 @@ void TypeChecker::completePropertyBehaviorParameter(VarDecl *VD,
   GenericSignature *genericSig = nullptr;
   GenericEnvironment *genericEnv = nullptr;
 
-  auto interfaceMap = sig->getSubstitutionMap(SelfInterfaceSubs);
   auto SubstInterfaceTy = ParameterTy.subst(interfaceMap);
   assert(SubstInterfaceTy && "storage type substitution failed?!");
   
-  auto contextMap = sig->getSubstitutionMap(SelfContextSubs);
-
   auto SubstBodyResultTy = SubstInterfaceTy->castTo<AnyFunctionType>()
     ->getResult();
   
@@ -1423,10 +1417,11 @@ void TypeChecker::completePropertyBehaviorParameter(VarDecl *VD,
 void TypeChecker::completePropertyBehaviorAccessors(VarDecl *VD,
                                        VarDecl *ValueImpl,
                                        Type valueTy,
-                                       SubstitutionList SelfInterfaceSubs,
-                                       SubstitutionList SelfContextSubs) {
-  auto selfTy = SelfContextSubs[0].getReplacement();
-  auto selfIfaceTy = SelfInterfaceSubs[0].getReplacement();
+                                       SubstitutionMap SelfInterfaceSubs,
+                                       SubstitutionMap SelfContextSubs) {
+  auto selfGenericParamTy = Type(GenericTypeParamType::get(0, 0, Context));
+  auto selfTy = selfGenericParamTy.subst(SelfContextSubs);
+  auto selfIfaceTy = selfGenericParamTy.subst(SelfInterfaceSubs);
 
   SmallVector<ASTNode, 3> bodyStmts;
   

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -673,17 +673,8 @@ public:
   ///
   /// \param locator The locator that describes where the substitutions came
   /// from.
-  ///
-  /// \param substitutions Will be populated with the set of substitutions
-  /// to be applied to the generic function type.
-  void computeSubstitutions(GenericSignature *sig,
-                            ConstraintLocator *locator,
-                            SmallVectorImpl<Substitution> &substitutions) const;
-
-  /// Same as above but with a lazily-constructed locator.
-  void computeSubstitutions(GenericSignature *sig,
-                            ConstraintLocatorBuilder locator,
-                            SmallVectorImpl<Substitution> &substitutions) const;
+  SubstitutionMap computeSubstitutions(GenericSignature *sig,
+                                       ConstraintLocatorBuilder locator) const;
 
   /// Return the disjunction choice for the given constraint location.
   unsigned getDisjunctionChoice(ConstraintLocator *locator) const {

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -965,16 +965,19 @@ static void diagSyntacticUseRestrictions(TypeChecker &TC, const Expr *E,
       if (DRE->getDecl() != TC.Context.getUnsafeBitCast(&TC))
         return;
       
-      if (DRE->getDeclRef().getSubstitutions().size() != 2)
+      if (DRE->getDeclRef().getSubstitutions().empty())
         return;
       
       // Don't check the same use of unsafeBitCast twice.
       if (!AlreadyDiagnosedBitCasts.insert(DRE).second)
         return;
-      
-      auto fromTy = DRE->getDeclRef().getSubstitutions()[0].getReplacement();
-      auto toTy = DRE->getDeclRef().getSubstitutions()[1].getReplacement();
-    
+
+      auto subMap = DRE->getDeclRef().getSubstitutions();
+      auto fromTy =
+        Type(GenericTypeParamType::get(0, 0, TC.Context)).subst(subMap);
+      auto toTy =
+        Type(GenericTypeParamType::get(0, 1, TC.Context)).subst(subMap);
+
       // Warn about `unsafeBitCast` formulations that are undefined behavior
       // or have better-defined alternative APIs that can be used instead.
       

--- a/lib/Sema/TypeCheckCaptures.cpp
+++ b/lib/Sema/TypeCheckCaptures.cpp
@@ -234,8 +234,13 @@ public:
     // parameter references transitively.
     if (!D->getDeclContext()->isLocalContext()) {
       if (!AFR.isObjC() || !D->isObjC() || isa<ConstructorDecl>(D)) {
-        for (auto sub : DRE->getDeclRef().getSubstitutions()) {
-          checkType(sub.getReplacement(), DRE->getLoc());
+        if (auto subMap = DRE->getDeclRef().getSubstitutions()) {
+          auto genericSig = subMap.getGenericSignature();
+          for (auto gp : genericSig->getGenericParams()) {
+            if (auto type = Type(gp).subst(subMap)) {
+              checkType(type, DRE->getLoc());
+            }
+          }
         }
       }
     }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3313,7 +3313,6 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
   conformance->setState(ProtocolConformanceState::CheckingTypeWitnesses);
   
   // First, satisfy any associated type requirements.
-  Substitution valueSub;
   AssociatedTypeDecl *valueReqt = nullptr;
   for (auto assocTy : behaviorProto->getAssociatedTypeMembers()) {
   
@@ -3329,7 +3328,6 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
     // TODO: Handle secondary 'where' constraints on the associated types.
     // TODO: Handle non-protocol constraints ('class', base class)
     auto propTy = decl->getType();
-    SmallVector<ProtocolConformanceRef, 4> valueConformances;
     for (auto proto : assocTy->getConformingProtocols()) {
       auto valueConformance = TC.conformsToProtocol(propTy, proto, dc,
                                                     ConformanceCheckFlags::Used,
@@ -3342,12 +3340,9 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
                     behaviorProto->getName());
         goto next_requirement;
       }
-      valueConformances.push_back(*valueConformance);
     }
     
     {
-      auto conformancesCopy = TC.Context.AllocateCopy(valueConformances);
-      valueSub = Substitution(propTy, conformancesCopy);
       // FIXME: Maybe we should synthesize an implicit TypeAliasDecl? We
       // really don't want the behavior conformances to show up in the
       // enclosing namespace though.
@@ -3362,27 +3357,44 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
     return;
   }
 
-  // Build a Substitution vector from the conformance.
-  auto conformanceMem =
-    TC.Context.AllocateUninitialized<ProtocolConformanceRef>(1);
-  auto selfConformance = new ((void*)conformanceMem.data())
-    ProtocolConformanceRef(conformance);
-  Substitution allInterfaceSubs[] = {
-    Substitution(behaviorInterfaceSelf, *selfConformance),
-    Substitution(decl->getInterfaceType(), valueSub.getConformances()),
-  };
-  Substitution allContextSubs[] = {
-    Substitution(behaviorSelf, *selfConformance),
-    Substitution(decl->getType(), valueSub.getConformances()),
-  };
+  // Build interface and context substitution maps.
+  auto protoSelfType = behaviorProto->getProtocolSelfType();
+  auto sig = behaviorProto->getGenericSignatureOfContext();
+  auto interfaceSubsMap =
+    sig->getSubstitutionMap(
+      [&](SubstitutableType *depType) {
+        if (depType->isEqual(protoSelfType))
+          return behaviorInterfaceSelf;
 
-  SubstitutionList interfaceSubs = allInterfaceSubs;
-  if (interfaceSubs.back().getConformances().empty())
-    interfaceSubs = interfaceSubs.drop_back();
+        return Type();
+      },
+      [&](CanType dependentType, Type replacementType,
+          ProtocolType *conformedProtocol)
+            ->Optional<ProtocolConformanceRef> {
+        if (dependentType->isEqual(protoSelfType) &&
+            conformedProtocol->getDecl() == behaviorProto)
+          return ProtocolConformanceRef(conformance);
 
-  SubstitutionList contextSubs = allContextSubs;
-  if (contextSubs.back().getConformances().empty())
-    contextSubs = contextSubs.drop_back();
+        return None;
+      });
+
+  auto contextSubsMap =
+    sig->getSubstitutionMap(
+      [&](SubstitutableType *depType) {
+        if (depType->isEqual(protoSelfType))
+          return behaviorSelf;
+
+        return Type();
+      },
+      [&](CanType dependentType, Type replacementType,
+          ProtocolType *conformedProtocol)
+            ->Optional<ProtocolConformanceRef> {
+        if (dependentType->isEqual(protoSelfType) &&
+            conformedProtocol->getDecl() == behaviorProto)
+          return ProtocolConformanceRef(conformance);
+
+        return None;
+      });
 
   // Now that type witnesses are done, satisfy property and method requirements.
   conformance->setState(ProtocolConformanceState::Checking);
@@ -3491,8 +3503,8 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
                                            behaviorSelf,
                                            storageTy,
                                            conformance,
-                                           interfaceSubs,
-                                           contextSubs);
+                                           interfaceSubsMap,
+                                           contextSubsMap);
         continue;
       }
     } else if (auto func = dyn_cast<FuncDecl>(requirement)) {
@@ -3541,8 +3553,8 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
         // Build the parameter witness method.
         TC.completePropertyBehaviorParameter(decl, func,
                                              conformance,
-                                             interfaceSubs,
-                                             contextSubs);
+                                             interfaceSubsMap,
+                                             contextSubsMap);
         continue;
       }
     }
@@ -3578,9 +3590,8 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
 
   // Check that the 'value' property from the protocol matches the
   // declared property type in context.
-  auto sig = behaviorProto->getGenericSignatureOfContext();
-  auto map = sig->getSubstitutionMap(interfaceSubs);
-  auto substValueTy = behavior->ValueDecl->getInterfaceType().subst(map);
+  auto substValueTy =
+    behavior->ValueDecl->getInterfaceType().subst(interfaceSubsMap);
   
   if (!substValueTy->isEqual(decl->getInterfaceType())) {
     TC.diagnose(behavior->getLoc(),
@@ -3599,7 +3610,7 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
   // 'value' implementation.
   TC.completePropertyBehaviorAccessors(decl, behavior->ValueDecl,
                                        decl->getType(),
-                                       interfaceSubs, contextSubs);
+                                       interfaceSubsMap, contextSubsMap);
   
   return;
 }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3358,43 +3358,17 @@ static void checkVarBehavior(VarDecl *decl, TypeChecker &TC) {
   }
 
   // Build interface and context substitution maps.
-  auto protoSelfType = behaviorProto->getProtocolSelfType();
-  auto sig = behaviorProto->getGenericSignatureOfContext();
   auto interfaceSubsMap =
-    sig->getSubstitutionMap(
-      [&](SubstitutableType *depType) {
-        if (depType->isEqual(protoSelfType))
-          return behaviorInterfaceSelf;
-
-        return Type();
-      },
-      [&](CanType dependentType, Type replacementType,
-          ProtocolType *conformedProtocol)
-            ->Optional<ProtocolConformanceRef> {
-        if (dependentType->isEqual(protoSelfType) &&
-            conformedProtocol->getDecl() == behaviorProto)
-          return ProtocolConformanceRef(conformance);
-
-        return None;
-      });
+    SubstitutionMap::getProtocolSubstitutions(
+                                behaviorProto,
+                                behaviorInterfaceSelf,
+                                ProtocolConformanceRef(conformance));
 
   auto contextSubsMap =
-    sig->getSubstitutionMap(
-      [&](SubstitutableType *depType) {
-        if (depType->isEqual(protoSelfType))
-          return behaviorSelf;
-
-        return Type();
-      },
-      [&](CanType dependentType, Type replacementType,
-          ProtocolType *conformedProtocol)
-            ->Optional<ProtocolConformanceRef> {
-        if (dependentType->isEqual(protoSelfType) &&
-            conformedProtocol->getDecl() == behaviorProto)
-          return ProtocolConformanceRef(conformance);
-
-        return None;
-      });
+    SubstitutionMap::getProtocolSubstitutions(
+                                  behaviorProto,
+                                  behaviorSelf,
+                                  ProtocolConformanceRef(conformance));
 
   // Now that type witnesses are done, satisfy property and method requirements.
   conformance->setState(ProtocolConformanceState::Checking);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -91,15 +91,10 @@ struct swift::RequirementCheck {
 };
 
 swift::Witness RequirementMatch::getWitness(ASTContext &ctx) const {
-  SmallVector<Substitution, 2> syntheticSubs;
   auto syntheticEnv = ReqEnv->getSyntheticEnvironment();
-  ReqEnv->getRequirementSignature()->getSubstitutions(
-      ReqEnv->getRequirementToSyntheticMap(),
-      syntheticSubs);
   return swift::Witness(this->Witness, WitnessSubstitutions,
-                        syntheticEnv, syntheticSubs);
+                        syntheticEnv, ReqEnv->getRequirementToSyntheticMap());
 }
-
 
 AssociatedTypeDecl *
 swift::getReferencedAssocTypeOfProtocol(Type type, ProtocolDecl *proto) {
@@ -787,10 +782,10 @@ RequirementMatch swift::matchWitness(TypeChecker &tc,
                             optionalAdjustments);
 
     // Compute the set of substitutions we'll need for the witness.
-    solution->computeSubstitutions(
-      witness->getInnermostDeclContext()->getGenericSignatureOfContext(),
-      witnessLocator,
-      result.WitnessSubstitutions);
+    auto witnessSig =
+      witness->getInnermostDeclContext()->getGenericSignatureOfContext();
+    result.WitnessSubstitutions =
+      solution->computeSubstitutions(witnessSig, witnessLocator);
     
     return result;
   };

--- a/lib/Sema/TypeCheckProtocol.h
+++ b/lib/Sema/TypeCheckProtocol.h
@@ -368,7 +368,7 @@ struct RequirementMatch {
 
   /// Substitutions mapping the type of the witness to the requirement
   /// environment.
-  SmallVector<Substitution, 2> WitnessSubstitutions;
+  SubstitutionMap WitnessSubstitutions;
 
   /// \brief Determine whether this match is viable.
   bool isViable() const {

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2291,7 +2291,7 @@ Type TypeResolver::resolveSILBoxType(SILBoxTypeRepr *repr,
   
   // Resolve the generic arguments.
   // Start by building a TypeSubstitutionMap.
-  SmallVector<Substitution, 4> genericArgs;
+  SubstitutionMap subMap;
   if (genericSig) {
     TypeSubstitutionMap genericArgMap;
 
@@ -2308,7 +2308,7 @@ Type TypeResolver::resolveSILBoxType(SILBoxTypeRepr *repr,
     }
     
     bool ok = true;
-    auto subMap = genericSig->getSubstitutionMap(
+    subMap = genericSig->getSubstitutionMap(
       QueryTypeSubstitutionMap{genericArgMap},
       [&](CanType depTy, Type replacement, ProtocolType *proto)
       -> ProtocolConformanceRef {
@@ -2322,14 +2322,13 @@ Type TypeResolver::resolveSILBoxType(SILBoxTypeRepr *repr,
         
         return *result;
       });
-    genericSig->getSubstitutions(subMap, genericArgs);
 
     if (!ok)
       return ErrorType::get(Context);
   }
   
   auto layout = SILLayout::get(Context, genericSig, fields);
-  return SILBoxType::get(Context, layout, genericArgs);
+  return SILBoxType::get(Context, layout, subMap);
 }
 
 Type TypeResolver::resolveSILFunctionType(FunctionTypeRepr *repr,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -1590,24 +1590,24 @@ public:
                                Type SelfTy,
                                Type StorageTy,
                                NormalProtocolConformance *BehaviorConformance,
-                               SubstitutionList SelfInterfaceSubs,
-                               SubstitutionList SelfContextSubs);
+                               SubstitutionMap interfaceMap,
+                               SubstitutionMap contextMap);
   
   /// Instantiate the parameter implementation for a behavior-backed
   /// property.
   void completePropertyBehaviorParameter(VarDecl *VD,
                                FuncDecl *BehaviorParameter,
                                NormalProtocolConformance *BehaviorConformance,
-                               SubstitutionList SelfInterfaceSubs,
-                               SubstitutionList SelfContextSubs);
+                               SubstitutionMap interfaceMap,
+                               SubstitutionMap contextMap);
   
   /// Instantiate the accessor implementations for a behavior-backed
   /// property.
   void completePropertyBehaviorAccessors(VarDecl *VD,
                                      VarDecl *ValueImpl,
                                      Type valueTy,
-                                     SubstitutionList SelfInterfaceSubs,
-                                     SubstitutionList SelfContextSubs);
+                                     SubstitutionMap interfaceMap,
+                                     SubstitutionMap contextMap);
 
   /// Pre-check the expression, validating any types that occur in the
   /// expression and folding sequence expressions.

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -489,9 +489,9 @@ ProtocolConformanceRef ModuleFile::readConformance(
 
   case SPECIALIZED_PROTOCOL_CONFORMANCE: {
     TypeID conformingTypeID;
-    unsigned numSubstitutions;
+    SubstitutionMapID substitutionMapID;
     SpecializedProtocolConformanceLayout::readRecord(scratch, conformingTypeID,
-                                                     numSubstitutions);
+                                                     substitutionMapID);
 
     ASTContext &ctx = getContext();
     Type conformingType = getType(conformingTypeID);
@@ -503,13 +503,7 @@ ProtocolConformanceRef ModuleFile::readConformance(
                                "reading specialized conformance for",
                                conformingType);
 
-    // Read the substitutions.
-    SmallVector<Substitution, 4> substitutions;
-    while (numSubstitutions--) {
-      auto sub = maybeReadSubstitution(Cursor, genericEnv);
-      assert(sub.hasValue() && "Missing substitution?");
-      substitutions.push_back(*sub);
-    }
+    auto subMap = getSubstitutionMap(substitutionMapID);
 
     ProtocolConformanceRef genericConformance =
       readConformance(Cursor, genericEnv);
@@ -519,7 +513,7 @@ ProtocolConformanceRef ModuleFile::readConformance(
     auto conformance =
            ctx.getSpecializedConformance(conformingType,
                                          genericConformance.getConcrete(),
-                                         substitutions);
+                                         subMap);
     return ProtocolConformanceRef(conformance);
   }
 

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -5368,28 +5368,16 @@ void ModuleFile::finishNormalConformance(NormalProtocolConformance *conformance,
     };
 
     // Requirement -> synthetic map.
-    SmallVector<Substitution, 4> reqToSyntheticSubs;
     if (auto syntheticSig = getGenericSignature(*rawIDIter++)) {
       // Create the synthetic environment.
       syntheticEnv = syntheticSig->createGenericEnvironment();
     }
 
     // Requirement -> synthetic substitutions.
-    if (unsigned numReqSubstitutions = *rawIDIter++) {
-      while (numReqSubstitutions--) {
-        auto sub = maybeReadSubstitution(DeclTypeCursor, nullptr);
-        reqToSyntheticSubs.push_back(*sub);
-      }
-    }
+    SubstitutionMap reqToSyntheticSubs = getSubstitutionMap(*rawIDIter++);
 
     // Witness substitutions.
-    SmallVector<Substitution, 4> witnessSubstitutions;
-    if (unsigned numWitnessSubstitutions = *rawIDIter++) {
-      while (numWitnessSubstitutions--) {
-        auto sub = maybeReadSubstitution(DeclTypeCursor, syntheticEnv);
-        witnessSubstitutions.push_back(*sub);
-      }
-    }
+    SubstitutionMap witnessSubstitutions = getSubstitutionMap(*rawIDIter++);
 
     // Handle opaque witnesses that couldn't be deserialized.
     if (isOpaque) {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1659,16 +1659,15 @@ Serializer::writeConformance(ProtocolConformanceRef conformanceRef,
 
   case ProtocolConformanceKind::Specialized: {
     auto conf = cast<SpecializedProtocolConformance>(conformance);
-    auto substitutions = conf->getGenericSubstitutions();
     unsigned abbrCode = abbrCodes[SpecializedProtocolConformanceLayout::Code];
     auto type = conf->getType();
     if (genericEnv && type->hasArchetype())
       type = type->mapTypeOutOfContext();
-    SpecializedProtocolConformanceLayout::emitRecord(Out, ScratchRecord,
-                                                     abbrCode,
-                                                     addTypeRef(type),
-                                                     substitutions.size());
-    writeSubstitutions(substitutions, abbrCodes, genericEnv);
+    SpecializedProtocolConformanceLayout::emitRecord(
+                           Out, ScratchRecord,
+                           abbrCode,
+                           addTypeRef(type),
+                           addSubstitutionMapRef(conf->getSubstitutionMap()));
 
     writeConformance(conf->getGenericConformance(), abbrCodes, genericEnv);
     break;

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1588,10 +1588,10 @@ void Serializer::writeNormalConformance(
         data.push_back(/*null generic signature*/0);
       }
 
-      auto reqToSyntheticSubs = witness.getRequirementToSyntheticSubs();
-
-      data.push_back(reqToSyntheticSubs.size());
-      data.push_back(witness.getSubstitutions().size());
+      data.push_back(
+        addSubstitutionMapRef(witness.getRequirementToSyntheticSubs()));
+      data.push_back(
+        addSubstitutionMapRef(witness.getSubstitutions()));
   });
 
   unsigned numSignatureConformances =
@@ -1610,21 +1610,6 @@ void Serializer::writeNormalConformance(
   // Write requirement signature conformances.
   for (auto reqConformance : conformance->getSignatureConformances())
     writeConformance(reqConformance, DeclTypeAbbrCodes);
-  
-  conformance->forEachValueWitness(nullptr,
-                                   [&](ValueDecl *req, Witness witness) {
-   // Bail out early for simple witnesses.
-   if (!witness.getDecl()) return;
-
-   // Write requirement-to-synthetic substitutions.
-   writeSubstitutions(witness.getRequirementToSyntheticSubs(),
-                      DeclTypeAbbrCodes, nullptr);
-
-   // Write the witness substitutions.
-   writeSubstitutions(witness.getSubstitutions(),
-                      DeclTypeAbbrCodes,
-                      witness.getSyntheticEnvironment());
-  });
 }
 
 void

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3847,17 +3847,8 @@ void Serializer::writeType(Type ty) {
     unsigned abbrCode = DeclTypeAbbrCodes[SILBoxTypeLayout::Code];
     SILLayoutID layoutRef = addSILLayoutRef(boxTy->getLayout());
 
-#ifndef NDEBUG
-    if (auto sig = boxTy->getLayout()->getGenericSignature()) {
-      assert(sig->getSubstitutionListSize()
-               == boxTy->getGenericArgs().size());
-    }
-#endif
-
-    SILBoxTypeLayout::emitRecord(Out, ScratchRecord, abbrCode, layoutRef);
-
-    // Write the set of substitutions.
-    writeSubstitutions(boxTy->getGenericArgs(), DeclTypeAbbrCodes);
+    SILBoxTypeLayout::emitRecord(Out, ScratchRecord, abbrCode, layoutRef,
+                          addSubstitutionMapRef(boxTy->getSubstitutions()));
     break;
   }
       

--- a/test/Serialization/sil_box_types.sil
+++ b/test/Serialization/sil_box_types.sil
@@ -17,9 +17,9 @@ entry(%0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>, %1 : $<τ_0_0> { var τ_0_0
   return undef : $()
 }
 
-// CHECK-LABEL: @boxes_extra_reqs : $@convention(thin) <T where T : Q, T.AT : P> (@owned <τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T, T.AT>) -> ()
+// CHECK-LABEL: sil @boxes_extra_reqs : $@convention(thin) <T where T : Q, T.AT : P> (@owned <τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T>) -> () {
 sil @boxes_extra_reqs : $@convention(thin) <T where T : Q, T.AT : P> (@owned <τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T, T.AT>) -> () {
-// CHECK: bb0(%0 : $<τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T, T.AT>)
+// CHECK: bb0(%0 : $<τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T>)
 bb0(%0 : $<τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T, T.AT>):
   %1 = project_box %0 : $<τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T, T.AT>, 0
   return undef : $()

--- a/validation-test/compiler_crashers_fixed/28829-replacement-ismaterializable-cannot-substitute-with-a-non-materializable-type.swift
+++ b/validation-test/compiler_crashers_fixed/28829-replacement-ismaterializable-cannot-substitute-with-a-non-materializable-type.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+
+// RUN: not %target-swift-frontend %s -emit-ir
 &_==nil


### PR DESCRIPTION
Consistently store `SubstitutionMap` within various parts of the AST rather than `Substitution` lists, and deal with the fallout. Specific changes:

* `ConcreteDeclRef` now uses `SubstitutionMap` and has been simplified.
* `Witness` now uses `SubstitutionMap`
* `SpecializedProtocolConformance` now uses `SubstitutionMap`
* `SILBoxType` now uses `SubstitutionMap`.

Overall, removes ~90 explicit uses of `SubstitutionList` (of ~410).
