### PR TITLE
[swift-4.2-branch-04-30-2018] migrator: ignore migration scripts with underscored new names. rdar://39877447

### DIFF
--- a/include/swift/IDE/APIDigesterData.h
+++ b/include/swift/IDE/APIDigesterData.h
@@ -147,6 +147,15 @@ public:
   APIDiffItemKind getKind() const override {
     return APIDiffItemKind::ADK_CommonDiffItem;
   }
+
+  bool rightCommentUnderscored() const {
+    DeclNameViewer Viewer(RightComment);
+    auto HasUnderScore =
+      [](StringRef S) { return S.find('_') != StringRef::npos; };
+    auto Args = Viewer.args();
+    return HasUnderScore(Viewer.base()) ||
+        std::any_of(Args.begin(), Args.end(), HasUnderScore);
+  }
 };
 
 

--- a/lib/IDE/APIDigesterData.cpp
+++ b/lib/IDE/APIDigesterData.cpp
@@ -482,6 +482,15 @@ struct swift::ide::api::APIDiffItemStore::Implementation {
 private:
   llvm::SmallVector<std::unique_ptr<llvm::MemoryBuffer>, 2> AllBuffer;
   llvm::BumpPtrAllocator Allocator;
+
+  static bool shouldInclude(APIDiffItem *Item) {
+    if (auto *CI = dyn_cast<CommonDiffItem>(Item)) {
+      if (CI->rightCommentUnderscored())
+        return false;
+    }
+    return true;
+  }
+
 public:
   llvm::StringMap<std::vector<APIDiffItem*>> Data;
   bool PrintUsr;
@@ -507,14 +516,13 @@ public:
         APIDiffItem *Item = serializeDiffItem(Allocator,
           cast<llvm::yaml::MappingNode>(&*It));
         auto &Bag = Data[Item->getKey()];
-        if (std::find_if(Bag.begin(), Bag.end(),
+        if (shouldInclude(Item) && std::find_if(Bag.begin(), Bag.end(),
             [&](APIDiffItem* I) { return *Item == *I; }) == Bag.end()) {
           Bag.push_back(Item);
           AllItems.push_back(Item);
         }
       }
     }
-
   }
 };
 

--- a/test/Migrator/Inputs/API.json
+++ b/test/Migrator/Inputs/API.json
@@ -19,6 +19,17 @@
   },
   {
     "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Var",
+    "NodeAnnotation": "Rename",
+    "ChildIndex": "0",
+    "LeftUsr": "c:@SA@SomeItemSet@FI@theSimpleOldNameNotToRename",
+    "LeftComment": "theSimpleOldNameNotToRename",
+    "RightUsr": "",
+    "RightComment": "__theSimpleNewName",
+    "ModuleName": "SomeModule"
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
     "NodeKind": "Function",
     "NodeAnnotation": "Rename",
     "ChildIndex": "0",

--- a/test/Migrator/member.swift
+++ b/test/Migrator/member.swift
@@ -6,5 +6,6 @@ import Bar
 
 func foo(_ b: BarForwardDeclaredClass, _ s: SomeItemSet) -> Int32 {
   let _ = s.theSimpleOldName
+  let _ = s.theSimpleOldNameNotToRename
   return barGlobalVariable
 }

--- a/test/Migrator/member.swift.expected
+++ b/test/Migrator/member.swift.expected
@@ -6,5 +6,6 @@ import Bar
 
 func foo(_ b: BarForwardDeclaredClass, _ s: SomeItemSet) -> Int32 {
   let _ = s.theSimpleNewName
+  let _ = s.theSimpleOldNameNotToRename
   return bar.memberVariable
 }

--- a/test/Migrator/mock-sdk/Bar.framework/Headers/Bar.h
+++ b/test/Migrator/mock-sdk/Bar.framework/Headers/Bar.h
@@ -36,6 +36,7 @@ enum BarForwardDeclaredEnum {
 typedef struct {
   int count;
   int theSimpleOldName;
+  int theSimpleOldNameNotToRename;
 } SomeItemSet;
 
 typedef SomeItemSet SomeEnvironment;

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -3979,12 +3979,7 @@ static int deserializeNameCorrection(APIDiffItemStore &Store,
       if (CI->DiffKind == NodeAnnotation::Rename) {
         auto NewName = CI->getNewName();
         auto Module = CI->ModuleName;
-        DeclNameViewer Viewer(NewName);
-        auto HasUnderScore =
-          [](StringRef S) { return S.find('_') != StringRef::npos; };
-        auto Args = Viewer.args();
-        if (HasUnderScore(Viewer.base()) ||
-            std::any_of(Args.begin(), Args.end(), HasUnderScore)) {
+        if (CI->rightCommentUnderscored()) {
           Result.insert(NameCorrectionInfo(NewName, NewName, Module));
         }
       }


### PR DESCRIPTION
Updating something to underscored names is hardly correct. This patch
disallows picking up such migration scripts.