### PR TITLE
Autolink libraries referenced from default arguments and @inlinable bodies [4.2]

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -348,6 +348,10 @@ SIMPLE_DECL_ATTR(_weakLinked, WeakLinked,
 
 SIMPLE_DECL_ATTR(_frozen, Frozen, OnEnum | UserInaccessible, 76)
 
+SIMPLE_DECL_ATTR(_usableFromInline, UsableFromInlineImport,
+                 OnImport | UserInaccessible,
+                 77)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef CONTEXTUAL_DECL_ATTR_ALIAS

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1549,8 +1549,17 @@ public:
     return static_cast<ImportKind>(Bits.ImportDecl.ImportKind);
   }
 
+  // An exported import is visible to name lookup from other modules, and is
+  // autolinked when the containing module is autolinked.
   bool isExported() const {
     return getAttrs().hasAttribute<ExportedAttr>();
+  }
+
+  // A usable from inline import is autolinked but not visible to name lookup.
+  // This attribute is inferred when type checking inlinable and default
+  // argument bodies.
+  bool isUsableFromInline() const {
+    return getAttrs().hasAttribute<UsableFromInlineImportAttr>();
   }
 
   ModuleDecl *getModule() const { return Mod; }

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -732,13 +732,17 @@ public:
   };
 
   /// Possible attributes for imports in source files.
-  enum class ImportFlags {
+  enum class ImportFlags : uint8_t {
     /// The imported module is exposed to anyone who imports the parent module.
     Exported = 0x1,
 
     /// This source file has access to testable declarations in the imported
     /// module.
-    Testable = 0x2
+    Testable = 0x2,
+
+    /// Modules that depend on the module containing this source file will
+    /// autolink this dependency.
+    UsableFromInline = 0x4,
   };
 
   /// \see ImportFlags

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -400,45 +400,13 @@ public:
   ///
   /// \param topLevelAccessPath If present, include the top-level module in the
   ///        results, with the given access path.
-  /// \param includePrivateTopLevelImports If true, imports listed in all
-  ///        file units within this module are traversed. Otherwise (the
-  ///        default), only re-exported imports are traversed.
   /// \param fn A callback of type bool(ImportedModule) or void(ImportedModule).
   ///        Return \c false to abort iteration.
   ///
   /// \return True if the traversal ran to completion, false if it ended early
   ///         due to the callback.
   bool forAllVisibleModules(AccessPathTy topLevelAccessPath,
-                            bool includePrivateTopLevelImports,
                             llvm::function_ref<bool(ImportedModule)> fn);
-
-  bool forAllVisibleModules(AccessPathTy topLevelAccessPath,
-                            bool includePrivateTopLevelImports,
-                            llvm::function_ref<void(ImportedModule)> fn) {
-    return forAllVisibleModules(topLevelAccessPath,
-                                includePrivateTopLevelImports,
-                                [=](const ImportedModule &import) -> bool {
-      fn(import);
-      return true;
-    });
-  }
-
-  template <typename Fn>
-  bool forAllVisibleModules(AccessPathTy topLevelAccessPath,
-                            bool includePrivateTopLevelImports,
-                            Fn &&fn) {
-    using RetTy = typename std::result_of<Fn(ImportedModule)>::type;
-    llvm::function_ref<RetTy(ImportedModule)> wrapped{std::forward<Fn>(fn)};
-    return forAllVisibleModules(topLevelAccessPath,
-                                includePrivateTopLevelImports,
-                                wrapped);
-  }
-
-  template <typename Fn>
-  bool forAllVisibleModules(AccessPathTy topLevelAccessPath, Fn &&fn) {
-    return forAllVisibleModules(topLevelAccessPath, false,
-                                std::forward<Fn>(fn));
-  }
 
   /// @}
 
@@ -686,23 +654,6 @@ public:
   ///         due to the callback.
   bool
   forAllVisibleModules(llvm::function_ref<bool(ModuleDecl::ImportedModule)> fn);
-
-  bool
-  forAllVisibleModules(llvm::function_ref<void(ModuleDecl::ImportedModule)> fn) {
-    return forAllVisibleModules([=](ModuleDecl::ImportedModule import) -> bool {
-      fn(import);
-      return true;
-    });
-  }
-  
-  template <typename Fn>
-  bool forAllVisibleModules(Fn &&fn) {
-    using RetTy = typename std::result_of<Fn(ModuleDecl::ImportedModule)>::type;
-    llvm::function_ref<RetTy(ModuleDecl::ImportedModule)> wrapped{
-      std::forward<Fn>(fn)
-    };
-    return forAllVisibleModules(wrapped);
-  }
 
   /// @}
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -783,7 +783,7 @@ private:
   /// This is the list of modules that are imported by this module.
   ///
   /// This is filled in by the Name Binding phase.
-  ArrayRef<std::pair<ModuleDecl::ImportedModule, ImportOptions>> Imports;
+  MutableArrayRef<std::pair<ModuleDecl::ImportedModule, ImportOptions>> Imports;
 
   /// A unique identifier representing this file; used to mark private decls
   /// within the file to keep them from conflicting with other files in the
@@ -888,6 +888,8 @@ public:
   addImports(ArrayRef<std::pair<ModuleDecl::ImportedModule, ImportOptions>> IM);
 
   bool hasTestableImport(const ModuleDecl *module) const;
+
+  void markUsableFromInlineImport(const ModuleDecl *module);
 
   void clearLookupCache();
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -345,9 +345,17 @@ public:
 
   /// \sa getImportedModules
   enum class ImportFilter {
+    // Everything.
     All,
+
+    // @_exported only.
     Public,
-    Private
+
+    // Not @_exported only. Also includes @_usableFromInline.
+    Private,
+
+    // @_usableFromInline and @_exported only.
+    ForLinking
   };
 
   /// Looks up which modules are imported by this module.
@@ -360,10 +368,15 @@ public:
   /// Looks up which modules are imported by this module, ignoring any that
   /// won't contain top-level decls.
   ///
-  /// This is a performance hack. Do not use for anything but name lookup.
-  /// May go away in the future.
+  /// This is a performance hack for the ClangImporter. Do not use for
+  /// anything but name lookup. May go away in the future.
   void
   getImportedModulesForLookup(SmallVectorImpl<ImportedModule> &imports) const;
+
+  /// Extension of the above hack. Identical to getImportedModulesForLookup()
+  /// for imported modules, otherwise also includes @usableFromInline imports.
+  void
+  getImportedModulesForLinking(SmallVectorImpl<ImportedModule> &imports) const;
 
   /// Finds all top-level decls of this module.
   ///
@@ -402,11 +415,16 @@ public:
   ///        results, with the given access path.
   /// \param fn A callback of type bool(ImportedModule) or void(ImportedModule).
   ///        Return \c false to abort iteration.
+  /// \param includeLinkOnlyModules Include modules that are not visible to
+  ///        name lookup but must be linked in because inlinable code can
+  ///        reference their symbols.
   ///
   /// \return True if the traversal ran to completion, false if it ended early
   ///         due to the callback.
   bool forAllVisibleModules(AccessPathTy topLevelAccessPath,
-                            llvm::function_ref<bool(ImportedModule)> fn);
+                            llvm::function_ref<bool(ImportedModule)> fn,
+                            bool includeLinkOnlyModules = false);
+
 
   /// @}
 
@@ -638,6 +656,12 @@ public:
     return getImportedModules(imports, ModuleDecl::ImportFilter::Public);
   }
 
+  /// \see ModuleDecl::getImportedModulesForLinking
+  virtual void getImportedModulesForLinking(
+      SmallVectorImpl<ModuleDecl::ImportedModule> &imports) const {
+    return getImportedModules(imports, ModuleDecl::ImportFilter::ForLinking);
+  }
+
   /// Generates the list of libraries needed to link this file, based on its
   /// imports.
   virtual void
@@ -649,11 +673,15 @@ public:
   ///
   /// \param fn A callback of type bool(ImportedModule) or void(ImportedModule).
   ///           Return \c false to abort iteration.
+  /// \param includeLinkOnlyModules Include modules that are not visible to
+  ///        name lookup but must be linked in because inlinable code can
+  ///        reference their symbols.
   ///
   /// \return True if the traversal ran to completion, false if it ended early
   ///         due to the callback.
   bool
-  forAllVisibleModules(llvm::function_ref<bool(ModuleDecl::ImportedModule)> fn);
+  forAllVisibleModules(llvm::function_ref<bool(ModuleDecl::ImportedModule)> fn,
+                       bool includeLinkOnlyModules = false);
 
   /// @}
 

--- a/include/swift/ClangImporter/ClangModule.h
+++ b/include/swift/ClangImporter/ClangModule.h
@@ -97,6 +97,12 @@ public:
   virtual void getImportedModulesForLookup(
       SmallVectorImpl<ModuleDecl::ImportedModule> &imports) const override;
 
+  virtual void getImportedModulesForLinking(
+      SmallVectorImpl<ModuleDecl::ImportedModule> &imports) const override {
+    // In C, anything that's linkable is visible to the source language.
+    return getImportedModulesForLookup(imports);
+  }
+
   virtual void
   collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const override;
 

--- a/include/swift/IRGen/IRGenPublic.h
+++ b/include/swift/IRGen/IRGenPublic.h
@@ -36,20 +36,6 @@ createIRGenModule(SILModule *SILMod, StringRef OutputFilename,
 /// Delete the IRGenModule and IRGenerator obtained by the above call.
 void deleteIRGenModule(std::pair<IRGenerator *, IRGenModule *> &Module);
 
-/// Collect the set of libraries to autolink against by mining the
-/// external definitions stored in an AST context.
-///
-/// This entire thing is a hack that we shouldn't need, but it reflects the
-/// fact that we can end up referencing something via an external definition
-/// (e.g., an imported Clang declaration) indirectly via the Clang importer
-/// that would not be visible directly. In such cases, we would fail to
-/// link against the shared library that defines the entity or an overlay that
-/// is needed as part of its import from Clang (e.g., the Foundation overlay
-/// is needed when bridging NSString, even if there is no other mention of
-/// an entity from the Foundation overlay).
-llvm::SmallVector<LinkLibrary, 4> collectLinkLibrariesFromExternals(
-                                                           ASTContext &ctx);
-
 } // end namespace irgen
 } // end namespace swift
 

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -156,8 +156,6 @@ public:
     bool isHeader() const { return IsHeader; }
     bool isScoped() const { return IsScoped; }
 
-    void forceExported() { IsExported = true; }
-
     std::string getPrettyPrintedPath() const;
   };
 
@@ -398,12 +396,6 @@ private:
 
     /// Whether this module file comes from a framework.
     unsigned IsFramework : 1;
-
-    /// THIS SETTING IS OBSOLETE BUT IS STILL USED BY OLDER MODULES.
-    ///
-    /// Whether this module has a shadowed module that's part of its public
-    /// interface.
-    unsigned HasUnderlyingModule : 1;
 
     /// Whether or not ImportDecls is valid.
     unsigned ComputedImportDecls : 1;

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -132,20 +132,32 @@ public:
     const StringRef RawPath;
 
   private:
-    unsigned IsExported : 1;
     const unsigned IsHeader : 1;
+    const unsigned IsExported : 1;
+    const unsigned IsUsableFromInline : 1;
     const unsigned IsScoped : 1;
 
-    Dependency(StringRef path, bool isHeader, bool exported, bool isScoped)
-      : RawPath(path), IsExported(exported), IsHeader(isHeader),
-        IsScoped(isScoped) {}
+    Dependency(bool isHeader,
+               StringRef path, bool exported,
+               bool isUsableFromInline, bool isScoped)
+      : RawPath(path),
+        IsHeader(isHeader),
+        IsExported(exported),
+        IsUsableFromInline(isUsableFromInline),
+        IsScoped(isScoped) {
+      assert(!(IsExported && IsUsableFromInline));
+      assert(!(IsHeader && IsScoped));
+    }
 
   public:
-    Dependency(StringRef path, bool exported, bool isScoped)
-      : Dependency(path, false, exported, isScoped) {}
+    Dependency(StringRef path, bool exported, bool isUsableFromInline,
+               bool isScoped)
+      : Dependency(false, path, exported, isUsableFromInline, isScoped) {}
 
     static Dependency forHeader(StringRef headerPath, bool exported) {
-      return Dependency(headerPath, true, exported, false);
+      return Dependency(true, headerPath, exported,
+                        /*isUsableFromInline=*/false,
+                        /*isScoped=*/false);
     }
 
     bool isLoaded() const {
@@ -153,6 +165,7 @@ public:
     }
 
     bool isExported() const { return IsExported; }
+    bool isUsableFromInline() const { return IsUsableFromInline; }
     bool isHeader() const { return IsHeader; }
     bool isScoped() const { return IsScoped; }
 

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 409; // Last change: standalone requirement subs
+const uint16_t VERSION_MINOR = 410; // Last change: @usableFromInline import
 
 using DeclIDField = BCFixed<31>;
 
@@ -590,6 +590,7 @@ namespace input_block {
   using ImportedModuleLayout = BCRecordLayout<
     IMPORTED_MODULE,
     BCFixed<1>, // exported?
+    BCFixed<1>, // usable from inlinable functions?
     BCFixed<1>, // scoped?
     BCBlob // module name, with submodule path pieces separated by \0s.
            // If the 'scoped' flag is set, the final path piece is an access

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -583,7 +583,7 @@ namespace input_block {
     LINK_LIBRARY,
     IMPORTED_HEADER,
     IMPORTED_HEADER_CONTENTS,
-    MODULE_FLAGS,
+    MODULE_FLAGS, // [unused]
     SEARCH_PATH
   };
 
@@ -614,11 +614,6 @@ namespace input_block {
   using ImportedHeaderContentsLayout = BCRecordLayout<
     IMPORTED_HEADER_CONTENTS,
     BCBlob
-  >;
-
-  using ModuleFlagsLayout = BCRecordLayout<
-    MODULE_FLAGS,
-    BCFixed<1> // has underlying module? [[UNUSED]]
   >;
 
   using SearchPathLayout = BCRecordLayout<

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2348,6 +2348,7 @@ void ASTContext::diagnoseAttrsRequiringFoundation(SourceFile &SF) {
   SF.forAllVisibleModules([&](ModuleDecl::ImportedModule import) {
     if (import.second->getName() == Id_Foundation)
       ImportsFoundationModule = true;
+    return true;
   });
 
   if (ImportsFoundationModule)

--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -387,6 +387,7 @@ static void doDynamicLookup(VisibleDeclConsumer &Consumer,
   CurrDC->getParentSourceFile()->forAllVisibleModules(
       [&](ModuleDecl::ImportedModule Import) {
         Import.second->lookupClassMembers(Import.first, ConsumerWrapper);
+        return true;
       });
 }
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1127,18 +1127,15 @@ bool ModuleDecl::isSystemModule() const {
   return false;
 }
 
-static bool forAllImportedModules(ModuleDecl *topLevel,
-                                  ModuleDecl::AccessPathTy thisPath,
-                                  llvm::function_ref<bool(ModuleDecl::ImportedModule)> fn) {
-  using ImportedModule = ModuleDecl::ImportedModule;
-  
+bool ModuleDecl::forAllVisibleModules(AccessPathTy thisPath,
+                                  llvm::function_ref<bool(ImportedModule)> fn) {
   llvm::SmallSet<ImportedModule, 32, ModuleDecl::OrderImportedModules> visited;
   SmallVector<ImportedModule, 32> stack;
 
-  topLevel->getImportedModules(stack, ModuleDecl::ImportFilter::Public);
+  getImportedModules(stack, ModuleDecl::ImportFilter::Public);
 
   // Make sure the top-level module is first; we want pre-order-ish traversal.
-  stack.push_back(ImportedModule(thisPath, topLevel));
+  stack.push_back(ImportedModule(thisPath, this));
 
   while (!stack.empty()) {
     auto next = stack.pop_back_val();
@@ -1165,11 +1162,6 @@ static bool forAllImportedModules(ModuleDecl *topLevel,
   }
 
   return true;
-}
-
-bool ModuleDecl::forAllVisibleModules(AccessPathTy thisPath,
-                                  llvm::function_ref<bool(ImportedModule)> fn) {
-  return forAllImportedModules(this, thisPath, fn);
 }
 
 bool FileUnit::forAllVisibleModules(

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1287,6 +1287,14 @@ bool SourceFile::hasTestableImport(const swift::ModuleDecl *module) const {
   });
 }
 
+void SourceFile::markUsableFromInlineImport(const ModuleDecl *module) {
+  for (auto &Import : Imports) {
+    if (Import.first.second == module) {
+      Import.second |= ImportFlags::UsableFromInline;
+    }
+  }
+}
+
 void SourceFile::clearLookupCache() {
   if (!Cache)
     return;

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1127,40 +1127,28 @@ bool ModuleDecl::isSystemModule() const {
   return false;
 }
 
-template<bool respectVisibility, typename Callback>
 static bool forAllImportedModules(ModuleDecl *topLevel,
                                   ModuleDecl::AccessPathTy thisPath,
-                                  bool includePrivateTopLevelImports,
-                                  const Callback &fn) {
+                                  llvm::function_ref<bool(ModuleDecl::ImportedModule)> fn) {
   using ImportedModule = ModuleDecl::ImportedModule;
-  using AccessPathTy = ModuleDecl::AccessPathTy;
   
   llvm::SmallSet<ImportedModule, 32, ModuleDecl::OrderImportedModules> visited;
   SmallVector<ImportedModule, 32> stack;
 
-  // Even if we're processing the top-level module like any other, we may
-  // still want to include non-exported modules.
-  ModuleDecl::ImportFilter filter = respectVisibility ? ModuleDecl::ImportFilter::Public
-                                                      : ModuleDecl::ImportFilter::All;
-  ModuleDecl::ImportFilter topLevelFilter =
-    includePrivateTopLevelImports ? ModuleDecl::ImportFilter::All : filter;
-  topLevel->getImportedModules(stack, topLevelFilter);
+  topLevel->getImportedModules(stack, ModuleDecl::ImportFilter::Public);
 
   // Make sure the top-level module is first; we want pre-order-ish traversal.
-  AccessPathTy overridingPath;
-  if (respectVisibility)
-    overridingPath = thisPath;
-  stack.push_back(ImportedModule(overridingPath, topLevel));
+  stack.push_back(ImportedModule(thisPath, topLevel));
 
   while (!stack.empty()) {
     auto next = stack.pop_back_val();
 
     // Filter any whole-module imports, and skip specific-decl imports if the
     // import path doesn't match exactly.
-    if (next.first.empty() || !respectVisibility)
-      next.first = overridingPath;
-    else if (!overridingPath.empty() &&
-             !ModuleDecl::isSameAccessPath(next.first, overridingPath)) {
+    if (next.first.empty())
+      next.first = thisPath;
+    else if (!thisPath.empty() &&
+             !ModuleDecl::isSameAccessPath(next.first, thisPath)) {
       // If we ever allow importing non-top-level decls, it's possible the rule
       // above isn't what we want.
       assert(next.first.size() == 1 && "import of non-top-level decl");
@@ -1173,20 +1161,15 @@ static bool forAllImportedModules(ModuleDecl *topLevel,
     if (!fn(next))
       return false;
 
-    if (respectVisibility)
-      next.second->getImportedModulesForLookup(stack);
-    else
-      next.second->getImportedModules(stack, filter);
+    next.second->getImportedModulesForLookup(stack);
   }
 
   return true;
 }
 
 bool ModuleDecl::forAllVisibleModules(AccessPathTy thisPath,
-                                      bool includePrivateTopLevelImports,
                                   llvm::function_ref<bool(ImportedModule)> fn) {
-  return forAllImportedModules<true>(this, thisPath,
-                                     includePrivateTopLevelImports, fn);
+  return forAllImportedModules(this, thisPath, fn);
 }
 
 bool FileUnit::forAllVisibleModules(
@@ -1215,13 +1198,15 @@ void ModuleDecl::collectLinkLibraries(LinkLibraryCallback callback) {
 void
 SourceFile::collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const {
 
-  const_cast<SourceFile *>(this)->forAllVisibleModules([&](swift::ModuleDecl::ImportedModule import) {
-    swift::ModuleDecl *next = import.second;
-    if (next->getName() == getParentModule()->getName())
-      return;
+  const_cast<SourceFile *>(this)->forAllVisibleModules(
+    [&](swift::ModuleDecl::ImportedModule import) {
+      swift::ModuleDecl *next = import.second;
+      if (next->getName() == getParentModule()->getName())
+        return true;
 
-    next->collectLinkLibraries(callback);
-  });
+      next->collectLinkLibraries(callback);
+      return true;
+    });
 }
 
 bool ModuleDecl::walk(ASTWalker &Walker) {

--- a/lib/AST/NameLookup.cpp
+++ b/lib/AST/NameLookup.cpp
@@ -1865,6 +1865,7 @@ bool DeclContext::lookupQualified(Type type,
     SmallVector<ValueDecl *, 4> allDecls;
     forAllVisibleModules(this, [&](ModuleDecl::ImportedModule import) {
       import.second->lookupClassMember(import.first, member, allDecls);
+      return true;
     });
 
     // For each declaration whose context is not something we've
@@ -1927,6 +1928,7 @@ void DeclContext::lookupAllObjCMethods(
   // Collect all of the methods with this selector.
   forAllVisibleModules(this, [&](ModuleDecl::ImportedModule import) {
     import.second->lookupObjCMethods(selector, results);
+    return true;
   });
 
   // Filter out duplicates.

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -1576,7 +1576,9 @@ ModuleDecl *ClangImporter::Implementation::finishLoadingClangModule(
       // FIXME: This forces the creation of wrapper modules for all imports as
       // well, and may do unnecessary work.
       cacheEntry.setInt(true);
-      result->forAllVisibleModules({}, [&](ModuleDecl::ImportedModule import) {});
+      result->forAllVisibleModules({}, [&](ModuleDecl::ImportedModule import) {
+          return true;
+        });
     }
   } else {
     // Build the representation of the Clang module in Swift.
@@ -1595,7 +1597,9 @@ ModuleDecl *ClangImporter::Implementation::finishLoadingClangModule(
     // Force load adapter modules for all imported modules.
     // FIXME: This forces the creation of wrapper modules for all imports as
     // well, and may do unnecessary work.
-    result->forAllVisibleModules({}, [](ModuleDecl::ImportedModule import) {});
+    result->forAllVisibleModules({}, [](ModuleDecl::ImportedModule import) {
+        return true;
+      });
   }
 
   if (clangModule->isSubModule()) {

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3043,43 +3043,70 @@ ModuleDecl *ClangModuleUnit::getAdapterModule() const {
 void ClangModuleUnit::getImportedModules(
     SmallVectorImpl<ModuleDecl::ImportedModule> &imports,
     ModuleDecl::ImportFilter filter) const {
-  if (filter != ModuleDecl::ImportFilter::Public)
+  switch (filter) {
+  case ModuleDecl::ImportFilter::All:
+  case ModuleDecl::ImportFilter::Private:
     imports.push_back({ModuleDecl::AccessPathTy(), owner.getStdlibModule()});
+    break;
+  case ModuleDecl::ImportFilter::Public:
+    break;
+  }
 
   SmallVector<clang::Module *, 8> imported;
   if (!clangModule) {
     // This is the special "imported headers" module.
-    if (filter != ModuleDecl::ImportFilter::Private) {
+    switch (filter) {
+    case ModuleDecl::ImportFilter::All:
+    case ModuleDecl::ImportFilter::Public:
       imported.append(owner.ImportedHeaderExports.begin(),
                       owner.ImportedHeaderExports.end());
+      break;
+
+    case ModuleDecl::ImportFilter::Private:
+      break;
     }
 
   } else {
     clangModule->getExportedModules(imported);
-    if (filter != ModuleDecl::ImportFilter::Public) {
-      if (filter == ModuleDecl::ImportFilter::All) {
-        llvm::SmallPtrSet<clang::Module *, 8> knownModules;
-        imported.append(clangModule->Imports.begin(), clangModule->Imports.end());
-        imported.erase(std::remove_if(imported.begin(), imported.end(),
-                                      [&](clang::Module *mod) -> bool {
-                                        return !knownModules.insert(mod).second;
-                                      }),
-                       imported.end());
-      } else {
-        llvm::SmallPtrSet<clang::Module *, 8> knownModules(imported.begin(),
-                                                           imported.end());
-        SmallVector<clang::Module *, 8> privateImports;
-        std::copy_if(clangModule->Imports.begin(), clangModule->Imports.end(),
-                     std::back_inserter(privateImports), [&](clang::Module *mod) {
-                       return knownModules.count(mod) == 0;
-        });
-        imported.swap(privateImports);
-      }
+
+    switch (filter) {
+    case ModuleDecl::ImportFilter::All: {
+      llvm::SmallPtrSet<clang::Module *, 8> knownModules;
+      imported.append(clangModule->Imports.begin(), clangModule->Imports.end());
+      imported.erase(std::remove_if(imported.begin(), imported.end(),
+                                    [&](clang::Module *mod) -> bool {
+                                      return !knownModules.insert(mod).second;
+                                    }),
+                     imported.end());
 
       // FIXME: The parent module isn't exactly a private import, but it is
       // needed for link dependencies.
       if (clangModule->Parent)
         imported.push_back(clangModule->Parent);
+
+      break;
+    }
+
+    case ModuleDecl::ImportFilter::Private: {
+      llvm::SmallPtrSet<clang::Module *, 8> knownModules(imported.begin(),
+                                                         imported.end());
+      SmallVector<clang::Module *, 8> privateImports;
+      std::copy_if(clangModule->Imports.begin(), clangModule->Imports.end(),
+                   std::back_inserter(privateImports), [&](clang::Module *mod) {
+                     return knownModules.count(mod) == 0;
+                   });
+      imported.swap(privateImports);
+
+      // FIXME: The parent module isn't exactly a private import, but it is
+      // needed for link dependencies.
+      if (clangModule->Parent)
+        imported.push_back(clangModule->Parent);
+
+      break;
+    }
+
+    case ModuleDecl::ImportFilter::Public:
+      break;
     }
   }
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -3049,6 +3049,7 @@ void ClangModuleUnit::getImportedModules(
     imports.push_back({ModuleDecl::AccessPathTy(), owner.getStdlibModule()});
     break;
   case ModuleDecl::ImportFilter::Public:
+  case ModuleDecl::ImportFilter::ForLinking:
     break;
   }
 
@@ -3058,6 +3059,7 @@ void ClangModuleUnit::getImportedModules(
     switch (filter) {
     case ModuleDecl::ImportFilter::All:
     case ModuleDecl::ImportFilter::Public:
+    case ModuleDecl::ImportFilter::ForLinking:
       imported.append(owner.ImportedHeaderExports.begin(),
                       owner.ImportedHeaderExports.end());
       break;
@@ -3106,6 +3108,7 @@ void ClangModuleUnit::getImportedModules(
     }
 
     case ModuleDecl::ImportFilter::Public:
+    case ModuleDecl::ImportFilter::ForLinking:
       break;
     }
   }

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -3334,6 +3334,8 @@ public:
           break;
         }
       }
+
+      return true;
     });
     return results;
   }
@@ -5607,7 +5609,11 @@ void CodeCompletionCallbacksImpl::doneParsing() {
 
       // FIXME: actually check imports.
       const_cast<ModuleDecl*>(Request.TheModule)
-          ->forAllVisibleModules({}, handleImport);
+          ->forAllVisibleModules({},
+                                 [&](ModuleDecl::ImportedModule Import) {
+                                   handleImport(Import);
+                                   return true;
+                                 });
     } else {
       // Add results from current module.
       Lookup.getToplevelCompletions(Request.OnlyTypes);
@@ -5621,7 +5627,11 @@ void CodeCompletionCallbacksImpl::doneParsing() {
       for (auto Imported : Imports) {
         ModuleDecl *TheModule = Imported.second;
         ModuleDecl::AccessPathTy AccessPath = Imported.first;
-        TheModule->forAllVisibleModules(AccessPath, handleImport);
+        TheModule->forAllVisibleModules(AccessPath,
+                                        [&](ModuleDecl::ImportedModule Import) {
+                                          handleImport(Import);
+                                          return true;
+                                        });
       }
     }
     Lookup.RequestedCachedResults.reset();

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -219,10 +219,7 @@ bool swift::immediate::IRGenImportedModules(
     AllLinkLibraries.push_back(linkLib);
   };
 
-  M->forAllVisibleModules({}, /*includePrivateTopLevelImports=*/true,
-                          [&](ModuleDecl::ImportedModule import) {
-    import.second->collectLinkLibraries(addLinkLibrary);
-  });
+  M->collectLinkLibraries(addLinkLibrary);
 
   tryLoadLibraries(AllLinkLibraries, CI.getASTContext().SearchPathOpts,
                    CI.getDiags());

--- a/lib/Immediate/Immediate.cpp
+++ b/lib/Immediate/Immediate.cpp
@@ -224,12 +224,6 @@ bool swift::immediate::IRGenImportedModules(
     import.second->collectLinkLibraries(addLinkLibrary);
   });
 
-  // Hack to handle thunks eagerly synthesized by the Clang importer.
-  for (const auto &linkLib :
-          irgen::collectLinkLibrariesFromExternals(CI.getASTContext())) {
-    addLinkLibrary(linkLib);
-  }
-
   tryLoadLibraries(AllLinkLibraries, CI.getASTContext().SearchPathOpts,
                    CI.getDiags());
 

--- a/lib/Sema/NameBinding.cpp
+++ b/lib/Sema/NameBinding.cpp
@@ -235,6 +235,8 @@ void NameBinder::addImport(
   ImportOptions options;
   if (ID->isExported())
     options |= SourceFile::ImportFlags::Exported;
+  if (ID->isUsableFromInline())
+    options |= SourceFile::ImportFlags::UsableFromInline;
   if (testableAttr)
     options |= SourceFile::ImportFlags::Testable;
   imports.push_back({ { ID->getDeclPath(), M }, options });

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -112,6 +112,7 @@ public:
   IGNORED_ATTR(UIApplicationMain)
   IGNORED_ATTR(UnsafeNoObjCTaggedPointer)
   IGNORED_ATTR(UsableFromInline)
+  IGNORED_ATTR(UsableFromInlineImport)
   IGNORED_ATTR(WeakLinked)
 #undef IGNORED_ATTR
 
@@ -844,6 +845,7 @@ public:
     IGNORED_ATTR(SynthesizedProtocol)
     IGNORED_ATTR(Testable)
     IGNORED_ATTR(Transparent)
+    IGNORED_ATTR(UsableFromInlineImport)
     IGNORED_ATTR(WarnUnqualifiedAccess)
     IGNORED_ATTR(WeakLinked)
 #undef IGNORED_ATTR

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2501,11 +2501,18 @@ bool AvailabilityWalker::diagAvailability(const ValueDecl *D, SourceRange R,
       return true;
   }
 
-  if (FragileKind)
-    if (R.isValid())
+  if (FragileKind) {
+    if (R.isValid()) {
       if (TC.diagnoseInlinableDeclRef(R.Start, D, DC, *FragileKind,
                                       TreatUsableFromInlineAsPublic))
         return true;
+
+      auto *SF = cast<SourceFile>(DC->getModuleScopeContext());
+      auto *M = D->getDeclContext()->getParentModule();
+      if (SF->getParentModule() != M)
+        SF->markUsableFromInlineImport(M);
+    }
+  }
 
   if (TC.diagnoseExplicitUnavailability(D, R, DC, call))
     return true;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5779,6 +5779,8 @@ public:
     UNINTERESTING_ATTR(ClangImporterSynthesizedType)
     UNINTERESTING_ATTR(WeakLinked)
     UNINTERESTING_ATTR(Frozen)
+    UNINTERESTING_ATTR(UsableFromInlineImport)
+
 #undef UNINTERESTING_ATTR
 
     void visitAvailableAttr(AvailableAttr *attr) {

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -650,6 +650,8 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
             bindExtensionDecl(ED, TC);
         }
       }
+
+      return true;
     });
 
     // Type check the top-level elements of the source file.

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1594,6 +1594,13 @@ void ModuleFile::getImportedModules(
         continue;
 
       break;
+
+    case ModuleDecl::ImportFilter::ForLinking:
+      // FIXME
+      if (!dep.isExported())
+        continue;
+
+      break;
     }
 
     assert(dep.isLoaded());

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1591,9 +1591,26 @@ void ModuleFile::getImportedModules(
   PrettyStackTraceModuleFile stackEntry(*this);
 
   for (auto &dep : Dependencies) {
-    if (filter != ModuleDecl::ImportFilter::All &&
-        (filter == ModuleDecl::ImportFilter::Public) ^ dep.isExported())
-      continue;
+    switch (filter) {
+    case ModuleDecl::ImportFilter::All:
+      // We're including all imports.
+      break;
+
+    case ModuleDecl::ImportFilter::Private:
+      // Skip @_exported imports.
+      if (dep.isExported())
+        continue;
+
+      break;
+
+    case ModuleDecl::ImportFilter::Public:
+      // Only include @_exported imports.
+      if (!dep.isExported())
+        continue;
+
+      break;
+    }
+
     assert(dep.isLoaded());
     results.push_back(dep.Import);
   }

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1128,7 +1128,6 @@ ModuleFile::ModuleFile(
       }
 
       cursor.EnterSubBlock(INPUT_BLOCK_ID);
-      bool seenFlags = false;
 
       auto next = cursor.advance();
       while (next.Kind == llvm::BitstreamEntry::Record) {
@@ -1167,15 +1166,6 @@ ModuleFile::ModuleFile(
           assert(importedHeaderInfo.contents.empty() &&
                  "contents seen already");
           importedHeaderInfo.contents = blobData;
-          break;
-        }
-        case input_block::MODULE_FLAGS: {
-          assert(!seenFlags && "only one flags record allowed");
-          seenFlags = true;
-          bool hasUnderlyingModule;
-          input_block::ModuleFlagsLayout::readRecord(scratch,
-                                                     hasUnderlyingModule);
-          Bits.HasUnderlyingModule = hasUnderlyingModule;
           break;
         }
         case input_block::SEARCH_PATH: {
@@ -1432,11 +1422,6 @@ Status ModuleFile::associateWithFileContext(FileUnit *file,
       missingDependency = true;
       continue;
     }
-
-    // This is for backwards-compatibility with modules that still rely on the
-    // "HasUnderlyingModule" flag.
-    if (Bits.HasUnderlyingModule && module == ShadowedModule)
-      dependency.forceExported();
 
     if (scopePath.empty()) {
       dependency.Import = { {}, module };

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1043,7 +1043,6 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
   input_block::LinkLibraryLayout LinkLibrary(Out);
   input_block::ImportedHeaderLayout ImportedHeader(Out);
   input_block::ImportedHeaderContentsLayout ImportedHeaderContents(Out);
-  input_block::ModuleFlagsLayout ModuleFlags(Out);
   input_block::SearchPathLayout SearchPath(Out);
 
   if (options.SerializeOptionsForDebugging) {

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1059,15 +1059,21 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
   // FIXME: Having to deal with private imports as a superset of public imports
   // is inefficient.
   SmallVector<ModuleDecl::ImportedModule, 8> publicImports;
+  SmallVector<ModuleDecl::ImportedModule, 8> linkImports;
   SmallVector<ModuleDecl::ImportedModule, 8> allImports;
   for (auto file : M->getFiles()) {
     file->getImportedModules(publicImports, ModuleDecl::ImportFilter::Public);
+    file->getImportedModules(linkImports, ModuleDecl::ImportFilter::ForLinking);
     file->getImportedModules(allImports, ModuleDecl::ImportFilter::All);
   }
 
   llvm::SmallSet<ModuleDecl::ImportedModule, 8, ModuleDecl::OrderImportedModules>
     publicImportSet;
   publicImportSet.insert(publicImports.begin(), publicImports.end());
+
+  llvm::SmallSet<ModuleDecl::ImportedModule, 8, ModuleDecl::OrderImportedModules>
+    linkImportSet;
+  linkImportSet.insert(linkImports.begin(), linkImports.end());
 
   removeDuplicateImports(allImports);
   auto clangImporter =
@@ -1097,7 +1103,10 @@ void Serializer::writeInputBlock(const SerializationOptions &options) {
 
     ImportPathBlob importPath;
     flattenImportPath(import, importPath);
-    ImportedModule.emit(ScratchRecord, publicImportSet.count(import),
+    ImportedModule.emit(ScratchRecord,
+                        publicImportSet.count(import),
+                        (linkImportSet.count(import) &&
+                         !publicImportSet.count(import)),
                         !import.first.empty(), importPath);
   }
 

--- a/test/IDE/Inputs/HasInlinableImport.swift
+++ b/test/IDE/Inputs/HasInlinableImport.swift
@@ -1,0 +1,2 @@
+@_usableFromInline import InlinableImport
+

--- a/test/IDE/Inputs/InlinableImport.swift
+++ b/test/IDE/Inputs/InlinableImport.swift
@@ -1,0 +1,1 @@
+// Empty module

--- a/test/IDE/print_swift_module_with_inlinable_import.swift
+++ b/test/IDE/print_swift_module_with_inlinable_import.swift
@@ -1,0 +1,13 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -o %t/InlinableImport.swiftmodule %S/Inputs/InlinableImport.swift
+// RUN: %target-swift-frontend -I %t -emit-module -o %t/HasInlinableImport.swiftmodule %S/Inputs/HasInlinableImport.swift
+// RUN: %target-swift-ide-test -I %t -print-module -source-filename %s -module-to-print=HasInlinableImport -function-definitions=false | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import HasInlinableImport
+
+// For now, don't print anything special for inlinable imports.
+
+// CHECK: {{^}}import InlinableImport

--- a/test/Serialization/Inputs/autolinking_module.swift
+++ b/test/Serialization/Inputs/autolinking_module.swift
@@ -1,0 +1,7 @@
+@_exported import autolinking_public
+@_usableFromInline import autolinking_other
+import autolinking_private
+
+public func bfunc(x: Int = afunc()) {
+  cfunc()
+}

--- a/test/Serialization/Inputs/autolinking_module_inferred.swift
+++ b/test/Serialization/Inputs/autolinking_module_inferred.swift
@@ -1,0 +1,7 @@
+@_exported import autolinking_public
+import autolinking_other // inferred as @_usableFromInline
+import autolinking_private
+
+public func bfunc(x: Int = afunc()) {
+  cfunc()
+}

--- a/test/Serialization/Inputs/autolinking_other.swift
+++ b/test/Serialization/Inputs/autolinking_other.swift
@@ -1,0 +1,1 @@
+public func afunc() -> Int { return 0 }

--- a/test/Serialization/Inputs/autolinking_private.swift
+++ b/test/Serialization/Inputs/autolinking_private.swift
@@ -1,0 +1,1 @@
+public func cfunc() {}

--- a/test/Serialization/Inputs/autolinking_public.swift
+++ b/test/Serialization/Inputs/autolinking_public.swift
@@ -1,0 +1,1 @@
+// Empty module

--- a/test/Serialization/autolinking-inlinable-inferred.swift
+++ b/test/Serialization/autolinking-inlinable-inferred.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_public.swift -emit-module-path %t/autolinking_public.swiftmodule -module-link-name autolinking_public -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_other.swift -emit-module-path %t/autolinking_other.swiftmodule -module-link-name autolinking_other -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_private.swift -emit-module-path %t/autolinking_private.swiftmodule -module-link-name autolinking_private -I %t -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_module_inferred.swift -emit-module-path %t/autolinking_module_inferred.swiftmodule -module-link-name autolinking_module_inferred -I %t -swift-version 4
+// RUN: %target-swift-frontend -emit-ir %s -I %t -swift-version 4 | %FileCheck %s
+
+// This test is identical to autolinking-inlinable, except we also rely on the
+// '@_usableFromInline' attribute getting inferred correctly on the import.
+
+// Linux uses a different autolinking mechanism, based on
+// swift-autolink-extract. This file tests the Darwin mechanism.
+// UNSUPPORTED: OS=linux-gnu
+// UNSUPPORTED: OS=linux-gnueabihf
+// UNSUPPORTED: OS=freebsd
+// UNSUPPORTED: OS=linux-androideabi
+
+import autolinking_module_inferred
+
+bfunc()
+
+// Note: we don't autolink autolinking_private even though autolinking_module imports it also.
+
+// CHECK: !llvm.linker.options = !{[[SWIFTCORE:![0-9]+]], [[SWIFTONONESUPPORT:![0-9]+]], [[MODULE:![0-9]+]], [[PUBLIC:![0-9]+]], [[OTHER:![0-9]+]], [[OBJC:![0-9]+]]}
+
+// CHECK: [[SWIFTCORE]] = !{!"-lswiftCore"}
+// CHECK: [[SWIFTONONESUPPORT]] = !{!"-lswiftSwiftOnoneSupport"}
+// CHECK: [[MODULE]] = !{!"-lautolinking_module_inferred"}
+// CHECK: [[PUBLIC]] = !{!"-lautolinking_public"}
+// CHECK: [[OTHER]] = !{!"-lautolinking_other"}
+// CHECK: [[OBJC]] = !{!"-lobjc"}

--- a/test/Serialization/autolinking-inlinable.swift
+++ b/test/Serialization/autolinking-inlinable.swift
@@ -1,0 +1,29 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_public.swift -emit-module-path %t/autolinking_public.swiftmodule -module-link-name autolinking_public -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_other.swift -emit-module-path %t/autolinking_other.swiftmodule -module-link-name autolinking_other -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_private.swift -emit-module-path %t/autolinking_private.swiftmodule -module-link-name autolinking_private -I %t -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_module.swift -emit-module-path %t/autolinking_module.swiftmodule -module-link-name autolinking_module -I %t -swift-version 4
+// RUN: %target-swift-frontend -emit-ir %s -I %t -swift-version 4 | %FileCheck %s
+
+// Linux uses a different autolinking mechanism, based on
+// swift-autolink-extract. This file tests the Darwin mechanism.
+// UNSUPPORTED: OS=linux-gnu
+// UNSUPPORTED: OS=linux-gnueabihf
+// UNSUPPORTED: OS=freebsd
+// UNSUPPORTED: OS=linux-androideabi
+
+import autolinking_module
+
+bfunc()
+
+// Note: we don't autolink autolinking_private even though autolinking_module imports it also.
+
+// CHECK: !llvm.linker.options = !{[[SWIFTCORE:![0-9]+]], [[SWIFTONONESUPPORT:![0-9]+]], [[MODULE:![0-9]+]], [[PUBLIC:![0-9]+]], [[OTHER:![0-9]+]], [[OBJC:![0-9]+]]}
+
+// CHECK: [[SWIFTCORE]] = !{!"-lswiftCore"}
+// CHECK: [[SWIFTONONESUPPORT]] = !{!"-lswiftSwiftOnoneSupport"}
+// CHECK: [[MODULE]] = !{!"-lautolinking_module"}
+// CHECK: [[PUBLIC]] = !{!"-lautolinking_public"}
+// CHECK: [[OTHER]] = !{!"-lautolinking_other"}
+// CHECK: [[OBJC]] = !{!"-lobjc"}

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2449,6 +2449,8 @@ static int doPrintModuleImports(const CompilerInvocation &InitInvok,
           llvm::outs() << " (Clang)";
         llvm::outs() << "\n";
       }
+
+      return true;
     });
   }
 


### PR DESCRIPTION
Cherry-picking #16147, #16206, #16211 and #16299 to swift-4.2-branch.  

Fixes <rdar://problem/39338239>.