### PR TITLE
[4.2][SE-0206][stdlib] hash(into:)/hashValue cleanup

### DIFF
--- a/stdlib/public/core/Arrays.swift.gyb
+++ b/stdlib/public/core/Arrays.swift.gyb
@@ -2264,11 +2264,6 @@ extension ${Self} : Equatable where Element : Equatable {
 
 extension ${Self}: Hashable where Element: Hashable {
   @inlinable // FIXME(sil-serialize-all)
-  public var hashValue: Int {
-    return _hashValue(for: self)
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
   public func hash(into hasher: inout Hasher) {
     hasher.combine(count) // discriminator
     for element in self {

--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -145,18 +145,6 @@ public // COMPILER_INTRINSIC
 func _getBool(_ v: Builtin.Int1) -> Bool { return Bool(v) }
 
 extension Bool : Equatable, Hashable {
-  /// The hash value for the Boolean value.
-  ///
-  /// Two values that are equal always have equal hash values.
-  ///
-  /// - Note: The hash value is not guaranteed to be stable across different
-  ///   invocations of the same program. Do not persist the hash value across
-  ///   program runs.
-  @inlinable // FIXME(sil-serialize-all)
-  public var hashValue: Int {
-    return _hashValue(for: self)
-  }
-
   @inlinable // FIXME(sil-serialize-all)
   public func hash(into hasher: inout Hasher) {
     hasher.combine((self ? 1 : 0) as UInt8)

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -174,16 +174,6 @@ extension OpaquePointer: Equatable {
 }
 
 extension OpaquePointer: Hashable {
-  /// The pointer's hash value.
-  ///
-  /// The hash value is not guaranteed to be stable across different
-  /// invocations of the same program.  Do not persist the hash value across
-  /// program runs.
-  @inlinable // FIXME(sil-serialize-all)
-  public var hashValue: Int {
-    return _hashValue(for: self)
-  }
-
   @inlinable // FIXME(sil-serialize-all)
   public func hash(into hasher: inout Hasher) {
     hasher.combine(Int(Builtin.ptrtoint_Word(_rawValue)))

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -487,4 +487,10 @@ extension Character: Hashable {
     // wasteful and inefficient.
     return String(self).hashValue
   }
+
+  public func hash(into hasher: inout Hasher) {
+    // FIXME(performance): constructing a temporary string is extremely
+    // wasteful and inefficient.
+    hasher.combine(String(self))
+  }
 }

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -477,6 +477,8 @@ extension Character : Comparable {
 }
 
 extension Character: Hashable {
+  // not @inlinable (performance)
+  @effects(releasenone)
   public func hash(into hasher: inout Hasher) {
     // FIXME(performance): constructing a temporary string is extremely
     // wasteful and inefficient.

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -477,17 +477,6 @@ extension Character : Comparable {
 }
 
 extension Character: Hashable {
-  /// The character's hash value.
-  ///
-  /// Hash values are not guaranteed to be equal across different executions of
-  /// your program. Do not save hash values to use during a future execution.
-  @inlinable // FIXME(sil-serialize-all)
-  public var hashValue: Int {
-    // FIXME(performance): constructing a temporary string is extremely
-    // wasteful and inefficient.
-    return String(self).hashValue
-  }
-
   public func hash(into hasher: inout Hasher) {
     // FIXME(performance): constructing a temporary string is extremely
     // wasteful and inefficient.

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -169,11 +169,6 @@ extension ClosedRange.Index : Comparable {
 extension ClosedRange.Index: Hashable
 where Bound: Strideable, Bound.Stride: SignedInteger, Bound: Hashable {
   @inlinable // FIXME(sil-serialize-all)
-  public var hashValue: Int {
-    return _hashValue(for: self)
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
   public func hash(into hasher: inout Hasher) {
     switch self {
     case .inRange(let value):
@@ -395,11 +390,6 @@ extension ClosedRange: Equatable {
 }
 
 extension ClosedRange: Hashable where Bound: Hashable {
-  @inlinable // FIXME(sil-serialize-all)
-  public var hashValue: Int {
-    return _hashValue(for: self)
-  }
-
   @inlinable // FIXME(sil-serialize-all)
   public func hash(into hasher: inout Hasher) {
     hasher.combine(lowerBound)

--- a/stdlib/public/core/Codable.swift.gyb
+++ b/stdlib/public/core/Codable.swift.gyb
@@ -1094,6 +1094,11 @@ public struct CodingUserInfoKey : RawRepresentable, Equatable, Hashable {
   public var hashValue: Int {
     return self.rawValue.hashValue
   }
+
+  @inlinable // FIXME(sil-serialize-all)
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(self.rawValue)
+  }
 }
 
 //===----------------------------------------------------------------------===//

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -4334,18 +4334,28 @@ extension Dictionary.Index {
 
   @inlinable // FIXME(sil-serialize-all)
   public var hashValue: Int {
-    if _fastPath(_guaranteedNative) {
-      return _nativeIndex.offset
-    }
+    return _hashValue(for: self)
+  }
 
+  @inlinable // FIXME(sil-serialize-all)
+  public func hash(into hasher: inout Hasher) {
+  #if _runtime(_ObjC)
+    if _fastPath(_guaranteedNative) {
+      hasher.combine(0 as UInt8)
+      hasher.combine(_nativeIndex.offset)
+      return
+    }
     switch _value {
     case ._native(let nativeIndex):
-      return nativeIndex.offset
-  #if _runtime(_ObjC)
+      hasher.combine(0 as UInt8)
+      hasher.combine(nativeIndex.offset)
     case ._cocoa(let cocoaIndex):
-      return cocoaIndex.currentKeyIndex
-  #endif
+      hasher.combine(1 as UInt8)
+      hasher.combine(cocoaIndex.currentKeyIndex)
     }
+  #else
+    hasher.combine(_nativeIndex.offset)
+  #endif
   }
 }
 

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1450,11 +1450,6 @@ extension Dictionary: Equatable where Value: Equatable {
 
 extension Dictionary: Hashable where Value: Hashable {
   @inlinable // FIXME(sil-serialize-all)
-  public var hashValue: Int {
-    return _hashValue(for: self)
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
   public func hash(into hasher: inout Hasher) {
     var commutativeHash = 0
     for (k, v) in self {

--- a/stdlib/public/core/Flatten.swift
+++ b/stdlib/public/core/Flatten.swift
@@ -230,11 +230,6 @@ extension FlattenCollection.Index : Comparable {
 extension FlattenCollection.Index : Hashable
   where Base.Index : Hashable, Base.Element.Index : Hashable {
   @inlinable // FIXME(sil-serialize-all)
-  public var hashValue: Int {
-    return _hashValue(for: self)
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
   public func hash(into hasher: inout Hasher) {
     hasher.combine(_outer)
     hasher.combine(_inner)

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1521,15 +1521,6 @@ extension ${Self} : _ExpressibleByBuiltinFloatLiteral {
 % end
 
 extension ${Self} : Hashable {
-  /// The number's hash value.
-  ///
-  /// Hash values are not guaranteed to be equal across different executions of
-  /// your program. Do not save hash values to use during a future execution.
-  @inlinable // FIXME(sil-serialize-all)
-  public var hashValue: Int {
-    return _hashValue(for: self)
-  }
-
   @inlinable // FIXME(sil-serialize-all)
   public func hash(into hasher: inout Hasher) {
     var v = self

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -3694,19 +3694,6 @@ ${assignmentOperatorComment(x.operator, True)}
 %# end of concrete type: ${Self}
 
 extension ${Self} : Hashable {
-  /// The integer's hash value.
-  ///
-  /// The hash value is not guaranteed to be stable across different
-  /// invocations of the same program. Do not persist the hash value across
-  /// program runs.
-  @inlinable // FIXME(sil-serialize-all)
-  public var hashValue: Int {
-    @inline(__always)
-    get {
-      return _hashValue(for: self)
-    }
-  }
-
   @inlinable // FIXME(sil-serialize-all)
   public func hash(into hasher: inout Hasher) {
     // FIXME(hasher): To correctly bridge `Set`s/`Dictionary`s containing

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -441,11 +441,6 @@ internal struct ComputedPropertyID: Hashable {
   }
 
   @inlinable // FIXME(sil-serialize-all)
-  internal var hashValue: Int {
-    return _hashValue(for: self)
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
   internal func hash(into hasher: inout Hasher) {
     hasher.combine(value)
     hasher.combine(isStoredProperty)
@@ -573,11 +568,6 @@ internal enum KeyPathComponent: Hashable {
     }
   }
   
-  @inlinable // FIXME(sil-serialize-all)
-  internal var hashValue: Int {
-    return _hashValue(for: self)
-  }
-
   @inlinable // FIXME(sil-serialize-all)
   internal func hash(into hasher: inout Hasher) {
     var hasher = hasher

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -52,7 +52,7 @@ public class AnyKeyPath: Hashable, _AppendKeyPath {
   }
 
   @inlinable // FIXME(sil-serialize-all)
-  public func hash(into hasher: inout Hasher) {
+  final public func hash(into hasher: inout Hasher) {
     return withBuffer {
       var buffer = $0
       while true {
@@ -446,7 +446,7 @@ internal struct ComputedPropertyID: Hashable {
   }
 
   @inlinable // FIXME(sil-serialize-all)
-  public func hash(into hasher: inout Hasher) {
+  internal func hash(into hasher: inout Hasher) {
     hasher.combine(value)
     hasher.combine(isStoredProperty)
     hasher.combine(isTableOffset)

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -84,17 +84,6 @@ extension ObjectIdentifier: Comparable {
 }
 
 extension ObjectIdentifier: Hashable {
-  // FIXME: Better hashing algorithm
-  /// The identifier's hash value.
-  ///
-  /// The hash value is not guaranteed to be stable across different
-  /// invocations of the same program.  Do not persist the hash value across
-  /// program runs.
-  @inlinable // FIXME(sil-serialize-all)
-  public var hashValue: Int {
-    return Int(Builtin.ptrtoint_Word(_value))
-  }
-
   @inlinable // FIXME(sil-serialize-all)
   public func hash(into hasher: inout Hasher) {
     hasher.combine(Int(Builtin.ptrtoint_Word(_value)))

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -94,6 +94,11 @@ extension ObjectIdentifier: Hashable {
   public var hashValue: Int {
     return Int(Builtin.ptrtoint_Word(_value))
   }
+
+  @inlinable // FIXME(sil-serialize-all)
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(Int(Builtin.ptrtoint_Word(_value)))
+  }
 }
 
 extension UInt {

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -410,17 +410,6 @@ extension Optional : Equatable where Wrapped : Equatable {
 }
 
 extension Optional: Hashable where Wrapped: Hashable {
-  /// The hash value for the optional instance.
-  ///
-  /// Two optionals that are equal will always have equal hash values.
-  ///
-  /// Hash values are not guaranteed to be equal across different executions of
-  /// your program. Do not save hash values to use during a future execution.
-  @inlinable // FIXME(sil-serialize-all)
-  public var hashValue: Int {
-    return _hashValue(for: self)
-  }
-
   @inlinable // FIXME(sil-serialize-all)
   public func hash(into hasher: inout Hasher) {
     switch self {

--- a/stdlib/public/core/PrefixWhile.swift
+++ b/stdlib/public/core/PrefixWhile.swift
@@ -203,11 +203,6 @@ extension LazyPrefixWhileCollection.Index: Comparable {
 
 extension LazyPrefixWhileCollection.Index: Hashable where Base.Index: Hashable {
   @inlinable // FIXME(sil-serialize-all)
-  public var hashValue: Int {
-    return _hashValue(for: self)
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
   public func hash(into hasher: inout Hasher) {
     switch _value {
     case .index(let value):

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -406,11 +406,6 @@ extension Range: Equatable {
 
 extension Range: Hashable where Bound: Hashable {
   @inlinable // FIXME(sil-serialize-all)
-  public var hashValue: Int {
-    return _hashValue(for: self)
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
   public func hash(into hasher: inout Hasher) {
     hasher.combine(lowerBound)
     hasher.combine(upperBound)

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -192,11 +192,6 @@ extension ReversedCollection.Index: Comparable {
 
 extension ReversedCollection.Index: Hashable where Base.Index: Hashable {
   @inlinable // FIXME(sil-serialize-all)
-  public var hashValue: Int {
-    return base.hashValue
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
   public func hash(into hasher: inout Hasher) {
     hasher.combine(base)
   }

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -3662,18 +3662,28 @@ extension Set.Index {
 
   @inlinable // FIXME(sil-serialize-all)
   public var hashValue: Int {
-    if _fastPath(_guaranteedNative) {
-      return _nativeIndex.offset
-    }
+    return _hashValue(for: self)
+  }
 
+  @inlinable // FIXME(sil-serialize-all)
+  public func hash(into hasher: inout Hasher) {
+  #if _runtime(_ObjC)
+    if _fastPath(_guaranteedNative) {
+      hasher.combine(0 as UInt8)
+      hasher.combine(_nativeIndex.offset)
+      return
+    }
     switch _value {
     case ._native(let nativeIndex):
-      return nativeIndex.offset
-  #if _runtime(_ObjC)
+      hasher.combine(0 as UInt8)
+      hasher.combine(nativeIndex.offset)
     case ._cocoa(let cocoaIndex):
-      return cocoaIndex.currentKeyIndex
-  #endif
+      hasher.combine(1 as UInt8)
+      hasher.combine(cocoaIndex.currentKeyIndex)
     }
+  #else
+    hasher.combine(_nativeIndex.offset)
+  #endif
   }
 }
 

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -484,20 +484,9 @@ extension Set: Equatable {
 }
 
 extension Set: Hashable {
-  /// The hash value for the set.
-  ///
-  /// Two sets that are equal will always have equal hash values.
-  ///
-  /// Hash values are not guaranteed to be equal across different executions of
-  /// your program. Do not save hash values to use during a future execution.
-  @inlinable // FIXME(sil-serialize-all)
-  public var hashValue: Int {
-    // FIXME(ABI)#177: <rdar://problem/18915294> Cache Set<T> hashValue
-    return _hashValue(for: self)
-  }
-
   @inlinable // FIXME(sil-serialize-all)
   public func hash(into hasher: inout Hasher) {
+    // FIXME(ABI)#177: <rdar://problem/18915294> Cache Set<T> hashValue
     var hash = 0
     for member in self {
       hash ^= _hashValue(for: member)

--- a/stdlib/public/core/StringHashable.swift
+++ b/stdlib/public/core/StringHashable.swift
@@ -122,15 +122,6 @@ extension _StringGuts {
 }
 
 extension String : Hashable {
-  /// The string's hash value.
-  ///
-  /// Hash values are not guaranteed to be equal across different executions of
-  /// your program. Do not save hash values to use during a future execution.
-  @inlinable
-  public var hashValue: Int {
-    return _hashValue(for: self)
-  }
-
   @inlinable
   public func hash(into hasher: inout Hasher) {
     _guts.hash(into: &hasher)
@@ -138,11 +129,6 @@ extension String : Hashable {
 }
 
 extension StringProtocol {
-  @inlinable
-  public var hashValue : Int {
-    return _hashValue(for: self)
-  }
-
   @inlinable
   public func hash(into hasher: inout Hasher) {
     _wholeString._guts.hash(_encodedOffsetRange, into: &hasher)

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -66,11 +66,6 @@ extension String.Index : Comparable {
 
 extension String.Index : Hashable {
   @inlinable // FIXME(sil-serialize-all)
-  public var hashValue: Int {
-    return _compoundOffset.hashValue
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
   public func hash(into hasher: inout Hasher) {
     hasher.combine(_compoundOffset)
   }

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -69,6 +69,11 @@ extension String.Index : Hashable {
   public var hashValue: Int {
     return _compoundOffset.hashValue
   }
+
+  @inlinable // FIXME(sil-serialize-all)
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(_compoundOffset)
+  }
 }
 
 extension String.Index {

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -319,6 +319,11 @@ extension Unicode.Scalar : Hashable {
   public var hashValue: Int {
     return Int(self.value)
   }
+
+  @inlinable // FIXME(sil-serialize-all)
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(self.value)
+  }
 }
 
 extension Unicode.Scalar {

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -311,15 +311,6 @@ extension Unicode.Scalar : LosslessStringConvertible {
 }
 
 extension Unicode.Scalar : Hashable {
-  /// The Unicode scalar's hash value.
-  ///
-  /// Hash values are not guaranteed to be equal across different executions of
-  /// your program. Do not save hash values to use during a future execution.
-  @inlinable // FIXME(sil-serialize-all)
-  public var hashValue: Int {
-    return Int(self.value)
-  }
-
   @inlinable // FIXME(sil-serialize-all)
   public func hash(into hasher: inout Hasher) {
     hasher.combine(self.value)

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -897,16 +897,6 @@ extension ${Self}: Comparable {
   }
 }
 extension ${Self}: Hashable {
-  /// The pointer's hash value.
-  ///
-  /// The hash value is not guaranteed to be stable across different
-  /// invocations of the same program.  Do not persist the hash value across
-  /// program runs.
-  @inlinable
-  public var hashValue: Int {
-    return _hashValue(for: self)
-  }
-
   @inlinable // FIXME(sil-serialize-all)
   public func hash(into hasher: inout Hasher) {
     hasher.combine(Int(bitPattern: self))

--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -974,6 +974,11 @@ extension ${Self}: Hashable {
   public var hashValue: Int {
     return Int(bitPattern: self)
   }
+
+  @inlinable // FIXME(sil-serialize-all)
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(Int(bitPattern: self))
+  }
 }
 
 extension Unsafe${Mutable}RawPointer : CustomDebugStringConvertible {

--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -965,16 +965,6 @@ extension ${Self}: Comparable {
 }
 
 extension ${Self}: Hashable {
-  /// The pointer's hash value.
-  ///
-  /// The hash value is not guaranteed to be stable across different
-  /// invocations of the same program.  Do not persist the hash value across
-  /// program runs.
-  @inlinable
-  public var hashValue: Int {
-    return Int(bitPattern: self)
-  }
-
   @inlinable // FIXME(sil-serialize-all)
   public func hash(into hasher: inout Hasher) {
     hasher.combine(Int(bitPattern: self))


### PR DESCRIPTION
Add hash(into:) implementations for stdlib types that currently lack them, and remove hashValue implementations that can be generated by the compiler.

Cherry-picked from #16154