### PR TITLE
[4.2][Parser] Detect non-breaking space (U+00A0) and offer a fix-it

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -121,6 +121,8 @@ ERROR(lex_invalid_curly_quote,none,
 NOTE(lex_confusable_character,none,
       "unicode character '%0' looks similar to '%1'; did you mean to use '%1'?",
       (StringRef, StringRef))
+WARNING(lex_nonbreaking_space,none,
+        "non-breaking space (U+00A0) used instead of regular space", ())
 
 ERROR(lex_unterminated_block_comment,none,
       "unterminated '/*' comment", ())

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1906,6 +1906,12 @@ bool Lexer::lexUnknown(bool EmitDiagnosticsIfToken) {
         .fixItReplaceChars(getSourceLoc(CurPtr - 1), getSourceLoc(Tmp), " ");
     CurPtr = Tmp;
     return false; // Skip presumed whitespace.
+  } else if (Codepoint == 0x000000A0) {
+      // Non-breaking whitespace (U+00A0)
+      diagnose(CurPtr - 1, diag::lex_nonbreaking_space)
+      .fixItReplaceChars(getSourceLoc(CurPtr - 1), getSourceLoc(Tmp), " ");
+      CurPtr = Tmp;
+      return false;
   } else if (Codepoint == 0x0000201D) {
     // If this is an end curly quote, just diagnose it with a fixit hint.
     if (EmitDiagnosticsIfToken) {
@@ -2438,18 +2444,6 @@ Restart:
       break;
     }
     break;
-  case '\302':
-    if (CurPtr[0] == '\240') {
-      // Non-breaking whitespace (U+00A0)
-      diagnose(TriviaStart, diag::lex_nonbreaking_space)
-        .fixItReplaceChars(getSourceLoc(CurPtr - 1), getSourceLoc(CurPtr + 1), " ");
-      ++CurPtr;
-      size_t Length = CurPtr - TriviaStart;
-      Pieces.push_back(TriviaPiece::garbageText({TriviaStart, Length}));
-      goto Restart;
-    } else {
-      break;
-    }
   // Start character of tokens.
   case -1: case -2:
   case '@': case '{': case '[': case '(': case '}': case ']': case ')':

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -682,8 +682,8 @@ static bool isLeftBound(const char *tokBegin, const char *bufferBegin) {
     else
       return true;
 
-  case '\240':
-    if (tokBegin - 1 != bufferBegin && tokBegin[-2] == '\302')
+  case '\xA0':
+    if (tokBegin - 1 != bufferBegin && tokBegin[-2] == '\xC2')
       return false; // Non-breaking whitespace (U+00A0)
     else
       return true;
@@ -722,8 +722,8 @@ static bool isRightBound(const char *tokEnd, bool isLeftBound,
     else
       return true;
 
-  case '\302':
-    if (tokEnd[1] == '\240')
+  case '\xC2':
+    if (tokEnd[1] == '\xA0')
       return false; // Non-breaking whitespace (U+00A0)
     else
       return true;
@@ -1909,7 +1909,7 @@ bool Lexer::lexUnknown(bool EmitDiagnosticsIfToken) {
   } else if (Codepoint == 0x000000A0) {
       // Non-breaking whitespace (U+00A0)
       diagnose(CurPtr - 1, diag::lex_nonbreaking_space)
-      .fixItReplaceChars(getSourceLoc(CurPtr - 1), getSourceLoc(Tmp), " ");
+          .fixItReplaceChars(getSourceLoc(CurPtr - 1), getSourceLoc(Tmp), " ");
       CurPtr = Tmp;
       return false;
   } else if (Codepoint == 0x0000201D) {

--- a/lib/Parse/Lexer.cpp
+++ b/lib/Parse/Lexer.cpp
@@ -1908,8 +1908,13 @@ bool Lexer::lexUnknown(bool EmitDiagnosticsIfToken) {
     return false; // Skip presumed whitespace.
   } else if (Codepoint == 0x000000A0) {
       // Non-breaking whitespace (U+00A0)
+      while (Tmp[0] == '\xC2' && Tmp[1] == '\xA0')
+        Tmp += 2;
+      SmallString<8> Spaces;
+      Spaces.assign((Tmp - CurPtr + 1) / 2, ' ');
       diagnose(CurPtr - 1, diag::lex_nonbreaking_space)
-          .fixItReplaceChars(getSourceLoc(CurPtr - 1), getSourceLoc(Tmp), " ");
+          .fixItReplaceChars(getSourceLoc(CurPtr - 1), getSourceLoc(Tmp),
+                             Spaces);
       CurPtr = Tmp;
       return false;
   } else if (Codepoint == 0x0000201D) {

--- a/test/Parse/nonbreaking_space.swift
+++ b/test/Parse/nonbreaking_space.swift
@@ -4,3 +4,6 @@ let nonBreakingSpace1 = 3 // expected-warning {{non-breaking space (U+00A0) use
 
 let nonBreakingSpace2 = 3 // expected-warning {{non-breaking space (U+00A0) used instead of regular space}} {{24-26= }}
 
+func foo() {
+    _ = 42 // expected-warning {{non-breaking space (U+00A0) used instead of regular space}} {{1-9=    }}
+}

--- a/test/Parse/nonbreaking_space.swift
+++ b/test/Parse/nonbreaking_space.swift
@@ -1,0 +1,6 @@
+// RUN: %target-typecheck-verify-swift
+
+let nonBreakingSpace1 = 3 // expected-warning {{non-breaking space (U+00A0) used instead of regular space}} {{22-24= }}
+
+let nonBreakingSpace2 = 3 // expected-warning {{non-breaking space (U+00A0) used instead of regular space}} {{24-26= }}
+

--- a/test/Syntax/tokens_nonbreaking_space.swift
+++ b/test/Syntax/tokens_nonbreaking_space.swift
@@ -2,10 +2,15 @@
 // RUN: cp -f %t.tmp %t
 // RUN: %swift-syntax-test -input-source-filename %t -dump-full-tokens 2>&1 | %FileCheck %t
 let a =Z3Z // nbsp(Z)
-func b() {}
+let bZ= 3Z
+let cZ=Z3
 
 // CHECK: 4:8: warning: non-breaking space (U+00A0) used instead of regular space
 // CHECK: 4:11: warning: non-breaking space (U+00A0) used instead of regular space
+// CHECK: 5:6: warning: non-breaking space (U+00A0) used instead of regular space
+// CHECK: 5:11: warning: non-breaking space (U+00A0) used instead of regular space
+// CHECK: 6:6: warning: non-breaking space (U+00A0) used instead of regular space
+// CHECK: 6:9: warning: non-breaking space (U+00A0) used instead of regular space
 
 // CHECK-LABEL: 4:7
 // CHECK-NEXT:(Token equal
@@ -18,9 +23,22 @@ func b() {}
 // CHECK-NEXT: (trivia garbageText \302\240)
 // CHECK-NEXT: (trivia space 1))
 
-// CHECK-LABEL: 5:1
-// CHECK-NEXT:(Token kw_func
-// CHECK-NEXT: (trivia lineComment // nbsp(\302\240))
-// CHECK-NEXT: (trivia newline 1)
-// CHECK-NEXT: (text="func")
-// CHECK-NEXT: (trivia space 1))
+// CHECK-LABEL: 5:5
+// CHECK-NEXT:(Token identifier
+// CHECK-NEXT: (text="b")
+// CHECK-NEXT: (trivia garbageText \302\240))
+
+// CHECK-LABEL: 5:10
+// CHECK-NEXT:(Token integer_literal
+// CHECK-NEXT: (text="3")
+// CHECK-NEXT: (trivia garbageText \302\240)
+
+// CHECK-LABEL: 6:5
+// CHECK-NEXT:(Token identifier
+// CHECK-NEXT: (text="c")
+// CHECK-NEXT: (trivia garbageText \302\240))
+
+// CHECK-LABEL: 6:8
+// CHECK-NEXT:(Token equal
+// CHECK-NEXT: (text="=")
+// CHECK-NEXT: (trivia garbageText \302\240))

--- a/test/Syntax/tokens_nonbreaking_space.swift
+++ b/test/Syntax/tokens_nonbreaking_space.swift
@@ -1,0 +1,26 @@
+// RUN: cat %s | sed -e 's/'$(echo -ne "\x5a")'/'$(echo -ne "\xc2\xa0")'/g' > %t.tmp
+// RUN: cp -f %t.tmp %t
+// RUN: %swift-syntax-test -input-source-filename %t -dump-full-tokens 2>&1 | %FileCheck %t
+let a =Z3Z // nbsp(Z)
+func b() {}
+
+// CHECK: 4:8: warning: non-breaking space (U+00A0) used instead of regular space
+// CHECK: 4:11: warning: non-breaking space (U+00A0) used instead of regular space
+
+// CHECK-LABEL: 4:7
+// CHECK-NEXT:(Token equal
+// CHECK-NEXT: (text="=")
+// CHECK-NEXT: (trivia garbageText \302\240))
+
+// CHECK-LABEL: 4:10
+// CHECK-NEXT:(Token integer_literal
+// CHECK-NEXT: (text="3")
+// CHECK-NEXT: (trivia garbageText \302\240)
+// CHECK-NEXT: (trivia space 1))
+
+// CHECK-LABEL: 5:1
+// CHECK-NEXT:(Token kw_func
+// CHECK-NEXT: (trivia lineComment // nbsp(\302\240))
+// CHECK-NEXT: (trivia newline 1)
+// CHECK-NEXT: (text="func")
+// CHECK-NEXT: (trivia space 1))


### PR DESCRIPTION
Cherry-pick of #16090 and #16280 
rdar://problem/20982969

#16090 authored by @hashemi, reviewed by me.
> Detect Unicode non-breaking space character (U+00A0) in the lexer, diagnose it, and offer a fix-it turning it into a regular space. Also treat the non-breaking space as whitespace when considering whether an operator is left/right bound.

 #16280 authored by me, reviewed by @jrose-apple 

> Diagnose and fix-it consecutive 'U+00A0's at once