### PR TITLE
Improve Dictionary.Keys.contains(_:)

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -67,6 +67,7 @@ set(SWIFT_BENCH_MODULES
     single-source/DictionaryBridge
     single-source/DictionaryCopy
     single-source/DictionaryGroup
+    single-source/DictionaryKeysContains
     single-source/DictionaryLiteral
     single-source/DictionaryRemove
     single-source/DictionarySubscriptDefault

--- a/benchmark/single-source/DictionaryKeysContains.swift
+++ b/benchmark/single-source/DictionaryKeysContains.swift
@@ -1,4 +1,4 @@
-//===--- DictionaryKeysContains.swift -------------------------------------------===//
+//===--- DictionaryKeysContains.swift -------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -44,27 +44,33 @@ public let DictionaryKeysContains = [
 private var dictionary: [NSString: NSString]!
 
 private func setup_DictionaryKeysContainsNative() {
-    let keyValuePairs = (1...1_000_000).map { ("\($0)" as NSString, "\($0)" as NSString) }
-    dictionary = [NSString: NSString](uniqueKeysWithValues: keyValuePairs)
+  let keyValuePairs = (1...1_000_000).map {
+    ("\($0)" as NSString, "\($0)" as NSString)
+  }
+  dictionary = [NSString: NSString](uniqueKeysWithValues: keyValuePairs)
 }
 
 #if _runtime(_ObjC)
 private func setup_DictionaryKeysContainsCocoa() {
-    let keyValuePairs = (1...1_000_000).map { ("\($0)" as NSString, "\($0)" as NSString) }
-    let nativeDictionary = [NSString: NSString](uniqueKeysWithValues: keyValuePairs)
-    dictionary = (NSDictionary(dictionary: nativeDictionary) as! [NSString: NSString])
+  let keyValuePairs = (1...1_000_000).map {
+    ("\($0)" as NSString, "\($0)" as NSString)
+  }
+  let nativeDictionary = [NSString: NSString](
+    uniqueKeysWithValues: keyValuePairs)
+  dictionary = (NSDictionary(dictionary: nativeDictionary)
+    as! [NSString: NSString])
 }
 #endif
 
 private func teardown_DictionaryKeysContains() {
-    dictionary = nil
+  dictionary = nil
 }
 
 @inline(never)
 public func run_DictionaryKeysContains(_ N: Int) {
-    for _ in 0..<(N * 100) {
-        CheckResults(dictionary.keys.contains("42"))
-        CheckResults(!dictionary.keys.contains("-1"))
-    }
+  for _ in 0..<(N * 100) {
+    CheckResults(dictionary.keys.contains("42"))
+    CheckResults(!dictionary.keys.contains("-1"))
+  }
 }
 

--- a/benchmark/single-source/DictionaryKeysContains.swift
+++ b/benchmark/single-source/DictionaryKeysContains.swift
@@ -1,0 +1,70 @@
+//===--- DictionaryKeysContains.swift -------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// This benchmark checks if keys.contains(key) is executed in O(1)
+// even when wrapping a NSDictionary
+import TestsUtils
+import Foundation
+
+#if _runtime(_ObjC)
+public let DictionaryKeysContains = [
+  BenchmarkInfo(
+    name: "DictionaryKeysContainsNative",
+    runFunction: run_DictionaryKeysContains,
+    tags: [.validation, .api, .Dictionary],
+    setUpFunction: setup_DictionaryKeysContainsNative,
+    tearDownFunction: teardown_DictionaryKeysContains),
+  BenchmarkInfo(
+    name: "DictionaryKeysContainsCocoa",
+    runFunction: run_DictionaryKeysContains,
+    tags: [.validation, .api, .Dictionary],
+    setUpFunction: setup_DictionaryKeysContainsCocoa,
+    tearDownFunction: teardown_DictionaryKeysContains),
+]
+#else
+public let DictionaryKeysContains = [
+  BenchmarkInfo(
+    name: "DictionaryKeysContainsNative",
+    runFunction: run_DictionaryKeysContains,
+    tags: [.validation, .api, .Dictionary],
+    setUpFunction: setup_DictionaryKeysContainsNative,
+    tearDownFunction: teardown_DictionaryKeysContains),
+]
+#endif
+
+private var dictionary: [NSString: NSString]!
+
+private func setup_DictionaryKeysContainsNative() {
+    let keyValuePairs = (1...1_000_000).map { ("\($0)" as NSString, "\($0)" as NSString) }
+    dictionary = [NSString: NSString](uniqueKeysWithValues: keyValuePairs)
+}
+
+#if _runtime(_ObjC)
+private func setup_DictionaryKeysContainsCocoa() {
+    let keyValuePairs = (1...1_000_000).map { ("\($0)" as NSString, "\($0)" as NSString) }
+    let nativeDictionary = [NSString: NSString](uniqueKeysWithValues: keyValuePairs)
+    dictionary = (NSDictionary(dictionary: nativeDictionary) as! [NSString: NSString])
+}
+#endif
+
+private func teardown_DictionaryKeysContains() {
+    dictionary = nil
+}
+
+@inline(never)
+public func run_DictionaryKeysContains(_ N: Int) {
+    for _ in 0..<(N * 100) {
+        CheckResults(dictionary.keys.contains("42"))
+        CheckResults(!dictionary.keys.contains("-1"))
+    }
+}
+

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -54,6 +54,7 @@ import DictTest4Legacy
 import DictionaryBridge
 import DictionaryCopy
 import DictionaryGroup
+import DictionaryKeysContains
 import DictionaryLiteral
 import DictionaryRemove
 import DictionarySubscriptDefault
@@ -208,6 +209,7 @@ registerBenchmark(Dictionary4Legacy)
 registerBenchmark(DictionaryBridge)
 registerBenchmark(DictionaryCopy)
 registerBenchmark(DictionaryGroup)
+registerBenchmark(DictionaryKeysContains)
 registerBenchmark(DictionaryLiteral)
 registerBenchmark(DictionaryRemove)
 registerBenchmark(DictionarySubscriptDefault)

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1254,7 +1254,7 @@ extension Dictionary {
 
     @inlinable // FIXME(sil-serialize-all)
     public func _customContainsEquatableElement(_ element: Element) -> Bool? {
-      return _variantBuffer.index(forKey: element) != nil
+      return _variantBuffer.containsKey(element)
     }
 
     @inlinable // FIXME(sil-serialize-all)
@@ -3415,6 +3415,23 @@ internal enum _VariantDictionaryBuffer<Key: Hashable, Value>: _HashBuffer {
         return ._cocoa(cocoaIndex)
       }
       return nil
+#endif
+    }
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  @inline(__always)
+  internal func containsKey(_ key: Key) -> Bool {
+    if _fastPath(guaranteedNative) {
+      return asNative.index(forKey: key) != nil
+    }
+
+    switch self {
+    case .native:
+      return asNative.index(forKey: key) != nil
+#if _runtime(_ObjC)
+    case .cocoa(let cocoaBuffer):
+      return SelfType.maybeGetFromCocoaBuffer(cocoaBuffer, forKey: key) != nil
 #endif
     }
   }


### PR DESCRIPTION
`Dictionary.Keys.contains(_:)` takes O(1) for native dictionaries. However it takes O(n) when dictionaries wrap a `NSDictionary`. This PR makes it to take just O(1) even when wrapping a `NSDictionary`.

## Benchmark results

### Before

```
  # TEST                      SAMPLES MIN(μs) MAX(μs) MEAN(μs) SD(μs) MEDIAN(μs) MAX_RSS(B)
  1 DictionaryKeysContainsCocoa       1 1442133 1442133  1442133      0    1442133  314028032
  1 DictionaryKeysContainsNative       1      29      29       29      0         29   57896960
```

### After

```
  # TEST                      SAMPLES MIN(μs) MAX(μs) MEAN(μs) SD(μs) MEDIAN(μs) MAX_RSS(B)
  1 DictionaryKeysContainsCocoa       1      36      36       36      0         36  314073088
  1 DictionaryKeysContainsNative       1      30      30       30      0         30   57925632
```