### PR TITLE
[Sema] NFC: Switch to scoped enum for `accessControlErrorKind`

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1849,7 +1849,7 @@ static void checkGenericParamAccess(TypeChecker &TC,
     return;
 
   // This must stay in sync with diag::generic_param_access.
-  enum ACEK {
+  enum class ACEK {
     Parameter = 0,
     Requirement
   } accessControlErrorKind;
@@ -1934,7 +1934,7 @@ static void checkGenericParamAccess(TypeChecker &TC,
                           owner->getDescriptiveKind(), isExplicit,
                           contextAccess, minAccess,
                           isa<FileUnit>(owner->getDeclContext()),
-                          accessControlErrorKind);
+                          accessControlErrorKind == ACEK::Requirement);
   highlightOffendingType(TC, diag, complainRepr);
 }
 


### PR DESCRIPTION
Follow-up gardening for https://github.com/apple/swift/pull/16223
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
