### PR TITLE
[4.2][Sema] SpaceEngine: Improve handling of empty/non-reduced spaces in c…

### DIFF
--- a/test/Sema/rdar39710335.swift
+++ b/test/Sema/rdar39710335.swift
@@ -1,0 +1,61 @@
+// RUN: %target-typecheck-verify-swift
+
+enum E1 {
+  case a1
+  case b1
+  case c1
+  case d1
+  case e1
+  case f1
+}
+
+enum E2 {
+  case a2, b2, c2, d2
+}
+
+func foo(s: E1, style: E2) {
+  switch (s, style) {
+    case (.a1, .a2),
+         (.a1, .d2),
+         (.c1, .a2),
+         (.c1, .d2),
+         (.c1, .c2),
+         (.a1, .c2):
+      break
+
+    case (.a1, .b2),
+         (.b1, .b2),
+         (.c1, .b2):
+        break
+
+    case (.b1, .a2),
+         (.b1, .d2),
+         (.b1, .c2):
+      break
+
+    case (.e1, .a2),
+         (.e1, .d2),
+         (.e1, .c2):
+      break
+
+    case (.e1, .b2):
+        break
+
+    case (.d1, .a2),
+         (.d1, .d2):
+
+      break
+
+    case (.d1, .b2):
+      break
+
+    case (.d1, .c2):
+      break
+
+    case (.f1, .a2),
+         (.f1, .b2),
+         (.f1, .c2),
+         (.f1, .d2):
+      break
+  }
+}


### PR DESCRIPTION
…onstrutors/disjuncts

Eagerly remove empty (sub-)spaces from constructors and disjuncts
to minimize number of operations required to check space coverage.
Also return original constructor space while subtracting a pair of
constructors, instead of disjunct, if subtraction of one of its
sub-spaces produced the same space, this reduces the number of
disjuncts in the path.

Resolves: rdar://problem/39710335
(cherry picked from commit 3ea663571d377db3326504ee6ed46587abb277cc)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
