### PR TITLE
Infer imports for linking

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -783,7 +783,7 @@ private:
   /// This is the list of modules that are imported by this module.
   ///
   /// This is filled in by the Name Binding phase.
-  ArrayRef<std::pair<ModuleDecl::ImportedModule, ImportOptions>> Imports;
+  MutableArrayRef<std::pair<ModuleDecl::ImportedModule, ImportOptions>> Imports;
 
   /// A unique identifier representing this file; used to mark private decls
   /// within the file to keep them from conflicting with other files in the
@@ -888,6 +888,8 @@ public:
   addImports(ArrayRef<std::pair<ModuleDecl::ImportedModule, ImportOptions>> IM);
 
   bool hasTestableImport(const ModuleDecl *module) const;
+
+  void markUsableFromInlineImport(const ModuleDecl *module);
 
   void clearLookupCache();
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -351,7 +351,7 @@ public:
     // @_exported only.
     Public,
 
-    // Not @_exported only. Also includes @_usableFromInline.
+    // Neither @_usableFromInline nor @_exported.
     Private,
 
     // @_usableFromInline and @_exported only.
@@ -770,10 +770,6 @@ public:
     /// This source file has access to testable declarations in the imported
     /// module.
     Testable = 0x2,
-
-    /// Modules that depend on the module containing this source file will
-    /// autolink this dependency.
-    UsableFromInline = 0x4,
   };
 
   /// \see ImportFlags
@@ -786,7 +782,10 @@ private:
   /// This is the list of modules that are imported by this module.
   ///
   /// This is filled in by the Name Binding phase.
-  MutableArrayRef<std::pair<ModuleDecl::ImportedModule, ImportOptions>> Imports;
+  ArrayRef<std::pair<ModuleDecl::ImportedModule, ImportOptions>> Imports;
+
+  /// A list of modules where declarations were used in inline functions.
+  llvm::SetVector<ModuleDecl *> ModulesUsedFromInline;
 
   /// A unique identifier representing this file; used to mark private decls
   /// within the file to keep them from conflicting with other files in the
@@ -892,7 +891,10 @@ public:
 
   bool hasTestableImport(const ModuleDecl *module) const;
 
-  void markUsableFromInlineImport(const ModuleDecl *module);
+  void markUsableFromInline(ModuleDecl *module);
+  ArrayRef<ModuleDecl *> getUsableFromInlineModules() const {
+    return ModulesUsedFromInline.getArrayRef();
+  }
 
   void clearLookupCache();
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -373,8 +373,11 @@ public:
   void
   getImportedModulesForLookup(SmallVectorImpl<ImportedModule> &imports) const;
 
-  /// Extension of the above hack. Identical to getImportedModulesForLookup()
-  /// for imported modules, otherwise also includes @usableFromInline imports.
+  /// Looks up which modules are imported by this module, ignoring any that
+  /// definitely don't represent distinct libraries.
+  ///
+  /// This is a performance hack for the ClangImporter. Do not use for
+  /// anything but linking. May go away in the future.
   void
   getImportedModulesForLinking(SmallVectorImpl<ImportedModule> &imports) const;
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -975,13 +975,27 @@ SourceFile::getImportedModules(SmallVectorImpl<ModuleDecl::ImportedModule> &modu
         continue;
       break;
     case ModuleDecl::ImportFilter::ForLinking:
-      if (!importPair.second.contains(ImportFlags::UsableFromInline) &&
-          !importPair.second.contains(ImportFlags::Exported))
+      if (!importPair.second.contains(ImportFlags::Exported))
         continue;
       break;
     }
 
     modules.push_back(importPair.first);
+  }
+
+  switch (filter) {
+  case ModuleDecl::ImportFilter::Public:
+  case ModuleDecl::ImportFilter::Private:
+    break;
+
+  case ModuleDecl::ImportFilter::All:
+  case ModuleDecl::ImportFilter::ForLinking:
+    // Treat UsableAsInline modules like imports.
+    // This isn't strictly necessary because we would have already found them
+    // through one of the modules listed above, but it's better for testing.
+    for (ModuleDecl *module : getUsableFromInlineModules())
+      modules.emplace_back(ModuleDecl::AccessPathTy(), module);
+    break;
   }
 }
 
@@ -1287,12 +1301,10 @@ bool SourceFile::hasTestableImport(const swift::ModuleDecl *module) const {
   });
 }
 
-void SourceFile::markUsableFromInlineImport(const ModuleDecl *module) {
-  for (auto &Import : Imports) {
-    if (Import.first.second == module) {
-      Import.second |= ImportFlags::UsableFromInline;
-    }
-  }
+void SourceFile::markUsableFromInline(ModuleDecl *module) {
+  if (module == getParentModule())
+    return;
+  ModulesUsedFromInline.insert(module);
 }
 
 void SourceFile::clearLookupCache() {

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1287,6 +1287,14 @@ bool SourceFile::hasTestableImport(const swift::ModuleDecl *module) const {
   });
 }
 
+void SourceFile::markUsableFromInlineImport(const ModuleDecl *module) {
+  for (auto &Import : Imports) {
+    if (Import.first.second == module) {
+      Import.second |= ImportFlags::UsableFromInline;
+    }
+  }
+}
+
 void SourceFile::clearLookupCache() {
   if (!Cache)
     return;

--- a/lib/Sema/NameBinding.cpp
+++ b/lib/Sema/NameBinding.cpp
@@ -235,14 +235,18 @@ void NameBinder::addImport(
   ImportOptions options;
   if (ID->isExported())
     options |= SourceFile::ImportFlags::Exported;
-  if (ID->isUsableFromInline())
-    options |= SourceFile::ImportFlags::UsableFromInline;
   if (testableAttr)
     options |= SourceFile::ImportFlags::Testable;
   imports.push_back({ { ID->getDeclPath(), M }, options });
 
   if (topLevelModule != M)
     imports.push_back({ { ID->getDeclPath(), topLevelModule }, options });
+
+  if (ID->isUsableFromInline()) {
+    // This is a bit unfortunate; everywhere else in this function, we're not
+    // actually modifying the SourceFile yet, just building a list for later.
+    SF.markUsableFromInline(topLevelModule);
+  }
 
   if (ID->getImportKind() != ImportKind::Module) {
     // If we're importing a specific decl, validate the import kind.

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2509,11 +2509,18 @@ bool AvailabilityWalker::diagAvailability(const ValueDecl *D, SourceRange R,
       return true;
   }
 
-  if (FragileKind)
-    if (R.isValid())
+  if (FragileKind) {
+    if (R.isValid()) {
       if (TC.diagnoseInlinableDeclRef(R.Start, D, DC, *FragileKind,
                                       TreatUsableFromInlineAsPublic))
         return true;
+
+      auto *SF = cast<SourceFile>(DC->getModuleScopeContext());
+      auto *M = D->getDeclContext()->getParentModule();
+      if (SF->getParentModule() != M)
+        SF->markUsableFromInlineImport(M);
+    }
+  }
 
   if (TC.diagnoseExplicitUnavailability(D, R, DC, call))
     return true;

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2516,9 +2516,7 @@ bool AvailabilityWalker::diagAvailability(const ValueDecl *D, SourceRange R,
         return true;
 
       auto *SF = cast<SourceFile>(DC->getModuleScopeContext());
-      auto *M = D->getDeclContext()->getParentModule();
-      if (SF->getParentModule() != M)
-        SF->markUsableFromInlineImport(M);
+      SF->markUsableFromInline(D->getModuleContext());
     }
   }
 

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1588,8 +1588,8 @@ void ModuleFile::getImportedModules(
       break;
 
     case ModuleDecl::ImportFilter::Private:
-      // Skip @_exported imports.
-      if (dep.isExported())
+      // Skip otherwise-labeled imports.
+      if (dep.isExported() || dep.isUsableFromInline())
         continue;
 
       break;

--- a/test/Serialization/Inputs/autolinking_module_inferred.swift
+++ b/test/Serialization/Inputs/autolinking_module_inferred.swift
@@ -1,0 +1,7 @@
+@_exported import autolinking_public
+import autolinking_other // inferred as @_usableFromInline
+import autolinking_private
+
+public func bfunc(x: Int = afunc()) {
+  cfunc()
+}

--- a/test/Serialization/Inputs/autolinking_module_inferred.swift
+++ b/test/Serialization/Inputs/autolinking_module_inferred.swift
@@ -1,7 +1,8 @@
 @_exported import autolinking_public
 import autolinking_other // inferred as @_usableFromInline
+import autolinking_other2
 import autolinking_private
 
-public func bfunc(x: Int = afunc()) {
+public func bfunc(x: Int = afunc(), y: Int = afunc2()) {
   cfunc()
 }

--- a/test/Serialization/Inputs/autolinking_other2.swift
+++ b/test/Serialization/Inputs/autolinking_other2.swift
@@ -1,0 +1,1 @@
+@_exported import autolinking_other3

--- a/test/Serialization/Inputs/autolinking_other3.swift
+++ b/test/Serialization/Inputs/autolinking_other3.swift
@@ -1,0 +1,1 @@
+public func afunc2() -> Int { return 0 }

--- a/test/Serialization/autolinking-inlinable-inferred.swift
+++ b/test/Serialization/autolinking-inlinable-inferred.swift
@@ -1,7 +1,9 @@
 // RUN: %empty-directory(%t)
 
-// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_public.swift -emit-module-path %t/autolinking_public.swiftmodule -module-link-name autolinking_public -swift-version 4
-// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_other.swift -emit-module-path %t/autolinking_other.swiftmodule -module-link-name autolinking_other -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_public.swift -emit-module-path %t/autolinking_public.swiftmodule -module-link-name autolinking_public -I %t -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_other3.swift -emit-module-path %t/autolinking_other3.swiftmodule -module-link-name autolinking_other3 -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_other2.swift -emit-module-path %t/autolinking_other2.swiftmodule -module-link-name autolinking_other2 -I %t -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_other.swift -emit-module-path %t/autolinking_other.swiftmodule -module-link-name autolinking_other -I %t -swift-version 4
 // RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_private.swift -emit-module-path %t/autolinking_private.swiftmodule -module-link-name autolinking_private -I %t -swift-version 4
 // RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_module_inferred.swift -emit-module-path %t/autolinking_module_inferred.swiftmodule -module-link-name autolinking_module_inferred -I %t -swift-version 4
 // RUN: %target-swift-frontend -emit-ir %s -I %t -swift-version 4 | %FileCheck %s
@@ -22,11 +24,12 @@ bfunc()
 
 // Note: we don't autolink autolinking_private even though autolinking_module imports it also.
 
-// CHECK: !llvm.linker.options = !{[[SWIFTCORE:![0-9]+]], [[SWIFTONONESUPPORT:![0-9]+]], [[MODULE:![0-9]+]], [[PUBLIC:![0-9]+]], [[OTHER:![0-9]+]], [[OBJC:![0-9]+]]}
+// CHECK: !llvm.linker.options = !{[[SWIFTCORE:![0-9]+]], [[SWIFTONONESUPPORT:![0-9]+]], [[MODULE:![0-9]+]], [[PUBLIC:![0-9]+]], [[OTHER3:![0-9]+]], [[OTHER:![0-9]+]], [[OBJC:![0-9]+]]}
 
 // CHECK: [[SWIFTCORE]] = !{!"-lswiftCore"}
 // CHECK: [[SWIFTONONESUPPORT]] = !{!"-lswiftSwiftOnoneSupport"}
 // CHECK: [[MODULE]] = !{!"-lautolinking_module_inferred"}
 // CHECK: [[PUBLIC]] = !{!"-lautolinking_public"}
+// CHECK: [[OTHER3]] = !{!"-lautolinking_other3"}
 // CHECK: [[OTHER]] = !{!"-lautolinking_other"}
 // CHECK: [[OBJC]] = !{!"-lobjc"}

--- a/test/Serialization/autolinking-inlinable-inferred.swift
+++ b/test/Serialization/autolinking-inlinable-inferred.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_public.swift -emit-module-path %t/autolinking_public.swiftmodule -module-link-name autolinking_public -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_other.swift -emit-module-path %t/autolinking_other.swiftmodule -module-link-name autolinking_other -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_private.swift -emit-module-path %t/autolinking_private.swiftmodule -module-link-name autolinking_private -I %t -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_module_inferred.swift -emit-module-path %t/autolinking_module_inferred.swiftmodule -module-link-name autolinking_module_inferred -I %t -swift-version 4
+// RUN: %target-swift-frontend -emit-ir %s -I %t -swift-version 4 | %FileCheck %s
+
+// This test is identical to autolinking-inlinable, except we also rely on the
+// '@_usableFromInline' attribute getting inferred correctly on the import.
+
+// Linux uses a different autolinking mechanism, based on
+// swift-autolink-extract. This file tests the Darwin mechanism.
+// UNSUPPORTED: OS=linux-gnu
+// UNSUPPORTED: OS=linux-gnueabihf
+// UNSUPPORTED: OS=freebsd
+// UNSUPPORTED: OS=linux-androideabi
+
+import autolinking_module_inferred
+
+bfunc()
+
+// Note: we don't autolink autolinking_private even though autolinking_module imports it also.
+
+// CHECK: !llvm.linker.options = !{[[SWIFTCORE:![0-9]+]], [[SWIFTONONESUPPORT:![0-9]+]], [[MODULE:![0-9]+]], [[PUBLIC:![0-9]+]], [[OTHER:![0-9]+]], [[OBJC:![0-9]+]]}
+
+// CHECK: [[SWIFTCORE]] = !{!"-lswiftCore"}
+// CHECK: [[SWIFTONONESUPPORT]] = !{!"-lswiftSwiftOnoneSupport"}
+// CHECK: [[MODULE]] = !{!"-lautolinking_module_inferred"}
+// CHECK: [[PUBLIC]] = !{!"-lautolinking_public"}
+// CHECK: [[OTHER]] = !{!"-lautolinking_other"}
+// CHECK: [[OBJC]] = !{!"-lobjc"}

--- a/test/Serialization/autolinking-inlinable.swift
+++ b/test/Serialization/autolinking-inlinable.swift
@@ -1,7 +1,9 @@
 // RUN: %empty-directory(%t)
 
 // RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_public.swift -emit-module-path %t/autolinking_public.swiftmodule -module-link-name autolinking_public -swift-version 4
-// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_other.swift -emit-module-path %t/autolinking_other.swiftmodule -module-link-name autolinking_other -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_other3.swift -emit-module-path %t/autolinking_other3.swiftmodule -module-link-name autolinking_other3 -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_other2.swift -emit-module-path %t/autolinking_other2.swiftmodule -module-link-name autolinking_other2 -I %t -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_other.swift -emit-module-path %t/autolinking_other.swiftmodule -module-link-name autolinking_other -I %t -swift-version 4
 // RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_private.swift -emit-module-path %t/autolinking_private.swiftmodule -module-link-name autolinking_private -I %t -swift-version 4
 // RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_module.swift -emit-module-path %t/autolinking_module.swiftmodule -module-link-name autolinking_module -I %t -swift-version 4
 // RUN: %target-swift-frontend -emit-ir %s -I %t -swift-version 4 | %FileCheck %s


### PR DESCRIPTION
Alternate version of #16299. Checks what modules are being used in inlinable code, and adds them to the "usable from inline" list for autolinking purposes.

This isn't quite as clean as the version Slava had, but that one started affecting name lookup, and so I went for a more heavy-handed version.

rdar://problem/39338239