### PR TITLE
Fix argument name in ArgsToFrontendOptionsConverter::setUnsignedIntegerArgument.

### DIFF
--- a/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.cpp
@@ -212,10 +212,10 @@ void ArgsToFrontendOptionsConverter::computeTBDOptions() {
 }
 
 void ArgsToFrontendOptionsConverter::setUnsignedIntegerArgument(
-    options::ID optionID, unsigned max, unsigned &valueToSet) {
+    options::ID optionID, unsigned radix, unsigned &valueToSet) {
   if (const Arg *A = Args.getLastArg(optionID)) {
     unsigned attempt;
-    if (StringRef(A->getValue()).getAsInteger(max, attempt)) {
+    if (StringRef(A->getValue()).getAsInteger(radix, attempt)) {
       Diags.diagnose(SourceLoc(), diag::error_invalid_arg_value,
                      A->getAsString(Args), A->getValue());
     } else {

--- a/lib/Frontend/ArgsToFrontendOptionsConverter.h
+++ b/lib/Frontend/ArgsToFrontendOptionsConverter.h
@@ -47,7 +47,7 @@ private:
   void computePrintStatsOptions();
   void computeTBDOptions();
 
-  void setUnsignedIntegerArgument(options::ID optionID, unsigned max,
+  void setUnsignedIntegerArgument(options::ID optionID, unsigned radix,
                                   unsigned &valueToSet);
 
   bool setUpForSILOrLLVM();


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fix argument name, which was wrong.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
