### PR TITLE
[4.2] Fix call to llvm::opt::OptionTable::PrintHelp

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2798,7 +2798,8 @@ void Driver::printHelp(bool ShowHidden) const {
     ExcludedFlagsBitmask |= HelpHidden;
 
   getOpts().PrintHelp(llvm::outs(), Name.c_str(), "Swift compiler",
-                      IncludedFlagsBitmask, ExcludedFlagsBitmask);
+                      IncludedFlagsBitmask, ExcludedFlagsBitmask,
+                      /*ShowAllAliases*/false);
 }
 
 bool OutputInfo::mightHaveExplicitPrimaryInputs(

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1696,7 +1696,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
     std::unique_ptr<llvm::opt::OptTable> Options(createSwiftOptTable());
     Options->PrintHelp(llvm::outs(), displayName(MainExecutablePath).c_str(),
                        "Swift frontend", IncludedFlagsBitmask,
-                       ExcludedFlagsBitmask);
+                       ExcludedFlagsBitmask, /*ShowAllAliases*/false);
     return finishDiagProcessing(0);
   }
 

--- a/test/Driver/help.swift
+++ b/test/Driver/help.swift
@@ -1,0 +1,23 @@
+// Check that options printed with -help respect whether the driver is invoked
+// as 'swift' or as 'swiftc'.
+
+// RUN: %swiftc_driver -help | %FileCheck -check-prefix CHECK -check-prefix CHECK-SWIFTC %s
+// RUN: %swiftc_driver -help | %FileCheck -check-prefix NEGATIVE -check-prefix NEGATIVE-SWIFTC %s
+
+// RUN: %swift_driver -help | %FileCheck -check-prefix CHECK -check-prefix CHECK-SWIFT %s
+// RUN: %swift_driver -help | %FileCheck -check-prefix NEGATIVE -check-prefix NEGATIVE-SWIFT %s
+
+// Options that work with both 'swiftc' and 'swift':
+// CHECK-DAG: -swift-version
+
+// swiftc-only options:
+// CHECK-SWIFTC-DAG: -typecheck
+// NEGATIVE-SWIFT-NOT: -typecheck
+
+// There are currently no interpreter-only options.
+
+// Frontend options should not show up here.
+// NEGATIVE-NOT: -merge-modules
+
+// Options marked "help-hidden" should not show up here.
+// NEGATIVE-NOT: -parse-stdlib

--- a/tools/driver/autolink_extract_main.cpp
+++ b/tools/driver/autolink_extract_main.cpp
@@ -84,7 +84,7 @@ public:
       std::string ExecutableName = llvm::sys::path::stem(MainExecutablePath);
       Table->PrintHelp(llvm::outs(), ExecutableName.c_str(),
                        "Swift Autolink Extract", options::AutolinkExtractOption,
-                       0);
+                       0, /*ShowAllAliases*/false);
       return 1;
     }
 

--- a/tools/driver/modulewrap_main.cpp
+++ b/tools/driver/modulewrap_main.cpp
@@ -91,7 +91,8 @@ public:
     if (ParsedArgs.getLastArg(OPT_help)) {
       std::string ExecutableName = llvm::sys::path::stem(MainExecutablePath);
       Table->PrintHelp(llvm::outs(), ExecutableName.c_str(),
-                       "Swift Module Wrapper", options::ModuleWrapOption, 0);
+                       "Swift Module Wrapper", options::ModuleWrapOption, 0,
+                       /*ShowAllAliases*/false);
       return 1;
     }
 

--- a/tools/driver/swift_format_main.cpp
+++ b/tools/driver/swift_format_main.cpp
@@ -152,7 +152,8 @@ public:
     if (ParsedArgs.getLastArg(OPT_help)) {
       std::string ExecutableName = llvm::sys::path::stem(MainExecutablePath);
       Table->PrintHelp(llvm::outs(), ExecutableName.c_str(),
-                       "Swift Format Tool", options::SwiftFormatOption, 0);
+                       "Swift Format Tool", options::SwiftFormatOption, 0,
+                       /*ShowAllAliases*/false);
       return 1;
     }
 


### PR DESCRIPTION
Cherry-pick of #16269 to the 4.2 branch. Reviewed by @graydon and @davidungar.