### PR TITLE
[4.2][string] Only bridge tagged NSStrings to small string form.

### DIFF
--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -203,22 +203,6 @@ func _makeCocoaStringGuts(_ cocoaString: _CocoaString) -> _StringGuts {
 
   let length = _StringGuts.getCocoaLength(
     _unsafeBitPattern: Builtin.reinterpretCast(immutableCopy))
-
-  // TODO(SSO): And also for UTF-16 strings and non-contiguous strings
-  if let ptr = start, !isUTF16 && length <= _SmallUTF8String.capacity {
-    if let small = _SmallUTF8String(
-      UnsafeBufferPointer(
-        start: ptr.assumingMemoryBound(to: UInt8.self), count: length)
-    ) {
-      return _StringGuts(small)
-    } else {
-#if arch(i386) || arch(arm)
-#else
-      _sanityCheckFailure("Couldn't fit 15-char ASCII small string?")
-#endif
-    }
-  }
-
   return _StringGuts(
     _largeNonTaggedCocoaObject: immutableCopy,
     count: length,

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -62,8 +62,10 @@ where CodeUnit : UnsignedInteger & FixedWidthInteger {
 
 #if arch(i386) || arch(arm)
 #else
-    _sanityCheck((CodeUnit.self != UInt8.self || capacity > 15),
-      "Should prefer a small representation")
+    // TODO(SR-7594): Restore below invariant
+    // _sanityCheck(
+    //   CodeUnit.self != UInt8.self || capacity > _SmallUTF8String.capacity,
+    //   "Should prefer a small representation")
 #endif // 64-bit
 
     let storage = Builtin.allocWithTailElems_1(

--- a/test/stdlib/StringBridge.swift
+++ b/test/stdlib/StringBridge.swift
@@ -1,0 +1,72 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+
+// REQUIRES: objc_interop
+
+import Foundation
+import StdlibUnittest
+
+var StringBridgeTests = TestSuite("StringBridgeTests")
+
+extension String {
+  init(fromCocoa s: String) {
+    self = (s as NSString) as String
+  }
+
+
+}
+
+func expectSmall(_ str: String,
+  stackTrace: SourceLocStack = SourceLocStack(),
+  showFrame: Bool = true,
+  file: String = #file, line: UInt = #line
+ ) {
+  expectTrue(str._guts._isSmall,
+    stackTrace: stackTrace, showFrame: showFrame, file: file, line: line)
+}
+func expectCocoa(_ str: String,
+  stackTrace: SourceLocStack = SourceLocStack(),
+  showFrame: Bool = true,
+  file: String = #file, line: UInt = #line
+ ) {
+  expectTrue(str._guts._isCocoa,
+    stackTrace: stackTrace, showFrame: showFrame, file: file, line: line)
+}
+
+StringBridgeTests.test("Tagged NSString") {
+#if arch(i386) || arch(arm)
+#else
+  // Bridge tagged strings as small
+  expectSmall((("0123456" as NSString) as String))
+  expectSmall((("012345678" as NSString) as String))
+  expectSmall((("aaaaaaaaaaa" as NSString) as String))
+  expectSmall((("bbbbbbbbb" as NSString) as String))
+
+  // Bridge non-tagged as non-small even if they fit, for fear of losing
+  // associated information
+  let bigAs = ("aaaaaaaaaaaa" as NSString) as String
+  let bigBs = ("bbbbbbbbbb" as NSString) as String
+  let bigQs = ("????????" as NSString) as String
+  expectCocoa(bigAs)
+  expectCocoa(bigBs)
+  expectCocoa(bigQs)
+
+#if false // TODO(SR-7594): re-enable
+  let littleAsNSString = ("aa" as NSString)
+  var littleAs = littleAsNSString as String
+
+  // But become small when appended to
+  expectSmall(bigAs + "c")
+  expectSmall(bigBs + "c")
+  expectSmall("a\(bigAs)")
+  expectSmall("a\(bigBs)")
+  expectSmall(littleAs + bigQs)
+  expectSmall(bigQs + littleAs)
+  expectSmall("\(littleAs)bigQs\(littleAs)")
+#endif // false
+
+#endif // not 32bit
+}
+
+runAllTests()
+


### PR DESCRIPTION
Non-tagged NSStrings carry identity separate from their
value. Continue to bridge them lazily, even if they could fit in small
form, to respect this and avoid potential information loss.

<!-- What's in this pull request? -->

4.2 cherry pick of https://github.com/apple/swift/pull/16320

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
