### PR TITLE
[4.2 EARLY] Revert "'@available' without an OS is ignored on extensions" warning

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3751,10 +3751,6 @@ WARNING(availability_query_useless_enclosing_scope, none,
 NOTE(availability_query_useless_enclosing_scope_here, none,
      "enclosing scope here", ())
 
-WARNING(availability_extension_platform_agnostic, none,
-        "'@available' without an OS is ignored on extensions; "
-        "apply the attribute to each member instead", ())
-
 ERROR(availability_global_script_no_potential,
       none, "global variable cannot be marked potentially "
       "unavailable with '@available' in script mode", ())

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -70,6 +70,7 @@ public:
   bool visitDeclAttribute(DeclAttribute *A) = delete;
 
 #define IGNORED_ATTR(X) void visit##X##Attr(X##Attr *) {}
+  IGNORED_ATTR(Available)
   IGNORED_ATTR(CDecl)
   IGNORED_ATTR(ClangImporterSynthesizedType)
   IGNORED_ATTR(Convenience)
@@ -114,14 +115,6 @@ public:
   IGNORED_ATTR(UsableFromInline)
   IGNORED_ATTR(WeakLinked)
 #undef IGNORED_ATTR
-
-  void visitAvailableAttr(AvailableAttr *attr) {
-    if (!isa<ExtensionDecl>(D))
-      return;
-    if (attr->hasPlatform())
-      return;
-    diagnoseAndRemoveAttr(attr, diag::availability_extension_platform_agnostic);
-  }
 
   // @noreturn has been replaced with a 'Never' return type.
   void visitNoReturnAttr(NoReturnAttr *attr) {

--- a/test/attr/attr_availability.swift
+++ b/test/attr/attr_availability.swift
@@ -809,13 +809,6 @@ rdar32526620_3(a: 42, b: .bar, c: "question")
 // expected-error@-1 {{'rdar32526620_3(a:b:c:)' has been replaced by instance method 'E_32526620.set(a:c:)'}} {{1-15=E_32526620.bar.set}} {{23-32=}}
 
 
-@available(*, unavailable) // expected-warning {{'@available' without an OS is ignored on extensions; apply the attribute to each member instead}} {{1-28=}}
-extension DummyType {}
-
-@available(*, deprecated) // expected-warning {{'@available' without an OS is ignored on extensions; apply the attribute to each member instead}} {{1-27=}}
-extension DummyType {}
-
-
 var deprecatedGetter: Int {
   @available(*, deprecated) get { return 0 }
   set {}

--- a/test/attr/attr_availability_swift.swift
+++ b/test/attr/attr_availability_swift.swift
@@ -29,7 +29,7 @@ extension TestStruct {
   func doTheThing() {} // expected-note {{'doTheThing()' was introduced in Swift 400}}
 }
 
-@available(swift 400) // expected-warning {{'@available' without an OS is ignored on extensions; apply the attribute to each member instead}} {{1-23=}}
+@available(swift 400) // FIXME: This has no effect and should be complained about.
 extension TestStruct {
   func doAnotherThing() {}
 }
@@ -40,10 +40,10 @@ func testMemberAvailability() {
   TestStruct().doAnotherThing() // okay (for now)
 }
 
-@available(swift 400) // expected-warning {{'@available' without an OS is ignored on extensions; apply the attribute to each member instead}} {{1-23=}}
+@available(swift 400) // FIXME: This has no effect and should be complained about.
 @available(macOS 10.11, *)
 extension TestStruct {}
 
 @available(macOS 10.11, *)
-@available(swift 400) // expected-warning {{'@available' without an OS is ignored on extensions; apply the attribute to each member instead}} {{1-23=}}
+@available(swift 400) // FIXME: This has no effect and should be complained about.
 extension TestStruct {}


### PR DESCRIPTION
- **Explanation**: I added an overzealous warning. It turns out this feature still has some uses at the moment.
- **Scope**: Affects people using `@available` on extensions for useful purposes (permission to use other deprecated or unavailable things).
- **Issue**: [SR-7577](https://bugs.swift.org/browse/SR-7577) / rdar://problem/39867773
- **Risk**: None. Code is being removed, going back to the way it was before I added this.
- **Testing**: Compiler regression tests went back to not warning on this.
- **Reviewer**: @huonw 