### PR TITLE
[4.2] stdlib: replace an obsolete initialize function in UnsafeBufferPointe…

### DIFF
--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -361,7 +361,7 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     let pj = (_position! + j)
     let tmp = pi.move()
     pi.moveInitialize(from: pj, count: 1)
-    pj.initialize(to: tmp, count: 1)
+    pj.initialize(to: tmp)
   }
 % end # mutable
 }


### PR DESCRIPTION
…r.swapAt with the new one. (#16270)
