### PR TITLE
Sema: Infer '@_usableFromInline' imports by looking at references from inlinable functions

### DIFF
--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -783,7 +783,7 @@ private:
   /// This is the list of modules that are imported by this module.
   ///
   /// This is filled in by the Name Binding phase.
-  ArrayRef<std::pair<ModuleDecl::ImportedModule, ImportOptions>> Imports;
+  MutableArrayRef<std::pair<ModuleDecl::ImportedModule, ImportOptions>> Imports;
 
   /// A unique identifier representing this file; used to mark private decls
   /// within the file to keep them from conflicting with other files in the
@@ -888,6 +888,8 @@ public:
   addImports(ArrayRef<std::pair<ModuleDecl::ImportedModule, ImportOptions>> IM);
 
   bool hasTestableImport(const ModuleDecl *module) const;
+
+  void markUsableFromInlineImport(const ModuleDecl *module);
 
   void clearLookupCache();
 

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1287,6 +1287,14 @@ bool SourceFile::hasTestableImport(const swift::ModuleDecl *module) const {
   });
 }
 
+void SourceFile::markUsableFromInlineImport(const ModuleDecl *module) {
+  for (auto &Import : Imports) {
+    if (Import.first.second == module) {
+      Import.second |= ImportFlags::UsableFromInline;
+    }
+  }
+}
+
 void SourceFile::clearLookupCache() {
   if (!Cache)
     return;

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -2509,11 +2509,18 @@ bool AvailabilityWalker::diagAvailability(const ValueDecl *D, SourceRange R,
       return true;
   }
 
-  if (FragileKind)
-    if (R.isValid())
+  if (FragileKind) {
+    if (R.isValid()) {
       if (TC.diagnoseInlinableDeclRef(R.Start, D, DC, *FragileKind,
                                       TreatUsableFromInlineAsPublic))
         return true;
+
+      auto *SF = cast<SourceFile>(DC->getModuleScopeContext());
+      auto *M = D->getDeclContext()->getParentModule();
+      if (SF->getParentModule() != M)
+        SF->markUsableFromInlineImport(M);
+    }
+  }
 
   if (TC.diagnoseExplicitUnavailability(D, R, DC, call))
     return true;

--- a/test/Serialization/Inputs/autolinking_module_inferred.swift
+++ b/test/Serialization/Inputs/autolinking_module_inferred.swift
@@ -1,0 +1,7 @@
+@_exported import autolinking_public
+import autolinking_other // inferred as @_usableFromInline
+import autolinking_private
+
+public func bfunc(x: Int = afunc()) {
+  cfunc()
+}

--- a/test/Serialization/autolinking-inlinable-inferred.swift
+++ b/test/Serialization/autolinking-inlinable-inferred.swift
@@ -1,0 +1,32 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_public.swift -emit-module-path %t/autolinking_public.swiftmodule -module-link-name autolinking_public -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_other.swift -emit-module-path %t/autolinking_other.swiftmodule -module-link-name autolinking_other -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_private.swift -emit-module-path %t/autolinking_private.swiftmodule -module-link-name autolinking_private -I %t -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_module_inferred.swift -emit-module-path %t/autolinking_module_inferred.swiftmodule -module-link-name autolinking_module_inferred -I %t -swift-version 4
+// RUN: %target-swift-frontend -emit-ir %s -I %t -swift-version 4 | %FileCheck %s
+
+// This test is identical to autolinking-inlinable, except we also rely on the
+// '@_usableFromInline' attribute getting inferred correctly on the import.
+
+// Linux uses a different autolinking mechanism, based on
+// swift-autolink-extract. This file tests the Darwin mechanism.
+// UNSUPPORTED: OS=linux-gnu
+// UNSUPPORTED: OS=linux-gnueabihf
+// UNSUPPORTED: OS=freebsd
+// UNSUPPORTED: OS=linux-androideabi
+
+import autolinking_module_inferred
+
+bfunc()
+
+// Note: we don't autolink autolinking_private even though autolinking_module imports it also.
+
+// CHECK: !llvm.linker.options = !{[[SWIFTCORE:![0-9]+]], [[SWIFTONONESUPPORT:![0-9]+]], [[MODULE:![0-9]+]], [[PUBLIC:![0-9]+]], [[OTHER:![0-9]+]], [[OBJC:![0-9]+]]}
+
+// CHECK: [[SWIFTCORE]] = !{!"-lswiftCore"}
+// CHECK: [[SWIFTONONESUPPORT]] = !{!"-lswiftSwiftOnoneSupport"}
+// CHECK: [[MODULE]] = !{!"-lautolinking_module_inferred"}
+// CHECK: [[PUBLIC]] = !{!"-lautolinking_public"}
+// CHECK: [[OTHER]] = !{!"-lautolinking_other"}
+// CHECK: [[OBJC]] = !{!"-lobjc"}


### PR DESCRIPTION
Since #16299 and #16317 are turning out to be tricky, let's get the incomplete fix in to at least cut down the number of people affected by this. Hopefully the rest of the fix will come soon.

rdar://problem/39338239