### PR TITLE
IRGen: adjust the module hash section for COFF

### DIFF
--- a/lib/IRGen/IRGenModule.cpp
+++ b/lib/IRGen/IRGenModule.cpp
@@ -1047,8 +1047,10 @@ bool IRGenModule::finalize() {
       ModuleHash->setSection("__LLVM,__swift_modhash");
       break;
     case llvm::Triple::ELF:
-    case llvm::Triple::COFF:
       ModuleHash->setSection(".swift_modhash");
+      break;
+    case llvm::Triple::COFF:
+      ModuleHash->setSection(".sw5hash");
       break;
     default:
       llvm_unreachable("Don't know how to emit the module hash for the selected"


### PR DESCRIPTION
COFF uses 8-character section names.  Adjust the section name for the
module hash from `.swift_modhash` to `.sw5hash` to fit this restriction.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
