### PR TITLE
[4.2] DocSupport: don't assume we've printed the first extension when merging several together. rdar://39887195

### DIFF
--- a/lib/IDE/ModuleInterfacePrinting.cpp
+++ b/lib/IDE/ModuleInterfacePrinting.cpp
@@ -622,10 +622,11 @@ void swift::ide::printSubmoduleInterface(
                              // For sub-decls, all extensions should be printed.
                   SynthesizedExtensionAnalyzer::MergeGroupKind::All,
               [&](ArrayRef<ExtensionInfo> Decls) {
+                // Whether we've started the extension merge group in printing.
+                bool Opened = false;
                 for (auto ET : Decls) {
-                  AdjustedOptions.BracketOptions = {
-                      ET.Ext, Decls.front().Ext == ET.Ext,
-                      Decls.back().Ext == ET.Ext, true};
+                  AdjustedOptions.BracketOptions = { ET.Ext, !Opened,
+                    Decls.back().Ext == ET.Ext, true};
                   if (AdjustedOptions.BracketOptions.shouldOpenExtension(
                           ET.Ext))
                     Printer << "\n";
@@ -636,7 +637,8 @@ void swift::ide::printSubmoduleInterface(
                     else
                       AdjustedOptions.initForSynthesizedExtension(NTD);
                   }
-                  ET.Ext->print(Printer, AdjustedOptions);
+                  // Set opened if we actually printed this extension.
+                  Opened |= ET.Ext->print(Printer, AdjustedOptions);
                   if (ET.IsSynthesized)
                     AdjustedOptions.clearSynthesizedExtension();
                   if (AdjustedOptions.BracketOptions.shouldCloseExtension(

--- a/test/SourceKit/DocSupport/doc_stdlib.swift
+++ b/test/SourceKit/DocSupport/doc_stdlib.swift
@@ -1,0 +1,2 @@
+// Make sure we're not crashing.
+// RUN: %sourcekitd-test -req=doc-info -module Swift

--- a/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftDocSupport.cpp
@@ -209,6 +209,7 @@ public:
     initDefaultMapToUse(D);
     // If D is declared in the extension, then the synthesized target is valid.
     TypeOrExtensionDecl SynthesizedTarget;
+    assert(D->getDeclContext()->isModuleScopeContext() == EntitiesStack.empty());
     if (D->getDeclContext() == SynthesizedExtensionInfo.first)
       SynthesizedTarget = SynthesizedExtensionInfo.second;
     EntitiesStack.emplace_back(D, SynthesizedTarget,


### PR DESCRIPTION
When printing the content of several extensions into a
synthesized one, we shouldn't assume the first extension in the
group always gets printed.
