### PR TITLE
[SIL] NFC: Rename misleading getSwiftRValueType() to getASTType()

### DIFF
--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -457,14 +457,13 @@ public:
     assert(Args[0]->getType() == Args[1]->getType() &&
            "Binary operands must match");
     assert(Args[2]->getType().is<BuiltinIntegerType>() &&
-           Args[2]->getType().getSwiftRValueType()->isBuiltinIntegerType(1) &&
+           Args[2]->getType().getASTType()->isBuiltinIntegerType(1) &&
            "Must have a third Int1 operand");
 
     SILType OpdTy = Args[0]->getType();
     SILType Int1Ty = Args[2]->getType();
 
-    TupleTypeElt ResultElts[] = {OpdTy.getSwiftRValueType(),
-                                 Int1Ty.getSwiftRValueType()};
+    TupleTypeElt ResultElts[] = {OpdTy.getASTType(), Int1Ty.getASTType()};
     Type ResultTy = TupleType::get(ResultElts, getASTContext());
     SILType SILResultTy =
         SILType::getPrimitiveObjectType(ResultTy->getCanonicalType());
@@ -2044,7 +2043,7 @@ private:
 
   void appendOperandTypeName(SILType OpdTy, llvm::SmallString<16> &Name) {
     if (auto BuiltinIntTy =
-            dyn_cast<BuiltinIntegerType>(OpdTy.getSwiftRValueType())) {
+            dyn_cast<BuiltinIntegerType>(OpdTy.getASTType())) {
       if (BuiltinIntTy == BuiltinIntegerType::getWordType(getASTContext())) {
         Name += "_Word";
       } else {
@@ -2052,7 +2051,7 @@ private:
         Name += "_Int" + llvm::utostr(NumBits);
       }
     } else {
-      assert(OpdTy.getSwiftRValueType() == getASTContext().TheRawPointerType);
+      assert(OpdTy.getASTType() == getASTContext().TheRawPointerType);
       Name += "_RawPointer";
     }
   }

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -124,7 +124,7 @@ protected:
   }
 
   SILType getTypeInClonedContext(SILType Ty) {
-    auto objectTy = Ty.getSwiftRValueType();
+    auto objectTy = Ty.getASTType();
     // Do not substitute opened existential types, if we do not have any.
     if (!objectTy->hasOpenedExistential())
       return Ty;
@@ -614,9 +614,7 @@ SILCloner<ImplClass>::visitPartialApplyInst(PartialApplyInst *Inst) {
                     getOpLocation(Inst->getLoc()),
                     getOpValue(Inst->getCallee()),
                     getOpSubstitutions(Inst->getSubstitutions()), Args,
-                    Inst->getType()
-                        .getSwiftRValueType()
-                        ->getAs<SILFunctionType>()
+                    Inst->getType().getAs<SILFunctionType>()
                       ->getCalleeConvention(),
                     GenericSpecializationInformation::create(Inst,
                                                              getBuilder())));
@@ -1678,8 +1676,7 @@ template<typename ImplClass>
 void
 SILCloner<ImplClass>::visitOpenExistentialAddrInst(OpenExistentialAddrInst *Inst) {
   // Create a new archetype for this opened existential type.
-  auto archetypeTy
-    = Inst->getType().getSwiftRValueType()->castTo<ArchetypeType>();
+  auto archetypeTy = Inst->getType().castTo<ArchetypeType>();
   registerOpenedExistentialRemapping(
       archetypeTy,
       ArchetypeType::getOpened(archetypeTy->getOpenedExistentialType()));
@@ -1696,8 +1693,7 @@ template <typename ImplClass>
 void SILCloner<ImplClass>::visitOpenExistentialValueInst(
     OpenExistentialValueInst *Inst) {
   // Create a new archetype for this opened existential type.
-  auto archetypeTy =
-      Inst->getType().getSwiftRValueType()->castTo<ArchetypeType>();
+  auto archetypeTy = Inst->getType().castTo<ArchetypeType>();
   registerOpenedExistentialRemapping(
       archetypeTy,
       ArchetypeType::getOpened(archetypeTy->getOpenedExistentialType()));
@@ -1714,8 +1710,8 @@ void
 SILCloner<ImplClass>::
 visitOpenExistentialMetatypeInst(OpenExistentialMetatypeInst *Inst) {
   // Create a new archetype for this opened existential type.
-  CanType openedType = Inst->getType().getSwiftRValueType();
-  CanType exType = Inst->getOperand()->getType().getSwiftRValueType();
+  auto openedType = Inst->getType().getASTType();
+  auto exType = Inst->getOperand()->getType().getASTType();
   while (auto exMetatype = dyn_cast<ExistentialMetatypeType>(exType)) {
     exType = exMetatype.getInstanceType();
     openedType = cast<MetatypeType>(openedType).getInstanceType();
@@ -1747,8 +1743,7 @@ void
 SILCloner<ImplClass>::
 visitOpenExistentialRefInst(OpenExistentialRefInst *Inst) {
   // Create a new archetype for this opened existential type.
-  auto archetypeTy
-    = Inst->getType().getSwiftRValueType()->castTo<ArchetypeType>();
+  auto archetypeTy = Inst->getType().castTo<ArchetypeType>();
   registerOpenedExistentialRemapping(
       archetypeTy,
       ArchetypeType::getOpened(archetypeTy->getOpenedExistentialType()));
@@ -1765,8 +1760,7 @@ void
 SILCloner<ImplClass>::
 visitOpenExistentialBoxInst(OpenExistentialBoxInst *Inst) {
   // Create a new archetype for this opened existential type.
-  auto archetypeTy
-    = Inst->getType().getSwiftRValueType()->castTo<ArchetypeType>();
+  auto archetypeTy = Inst->getType().castTo<ArchetypeType>();
   registerOpenedExistentialRemapping(
       archetypeTy,
       ArchetypeType::getOpened(archetypeTy->getOpenedExistentialType()));
@@ -1783,8 +1777,7 @@ void
 SILCloner<ImplClass>::
 visitOpenExistentialBoxValueInst(OpenExistentialBoxValueInst *Inst) {
   // Create a new archetype for this opened existential type.
-  auto archetypeTy
-    = Inst->getType().getSwiftRValueType()->castTo<ArchetypeType>();
+  auto archetypeTy = Inst->getType().castTo<ArchetypeType>();
   registerOpenedExistentialRemapping(
       archetypeTy,
       ArchetypeType::getOpened(archetypeTy->getOpenedExistentialType()));

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -3739,7 +3739,7 @@ class LoadReferenceInstBase
     : public UnaryInstructionBase<K, SingleValueInstruction> {
   static SILType getResultType(SILType operandTy) {
     assert(operandTy.isAddress() && "loading from non-address operand?");
-    auto refType = cast<ReferenceStorageType>(operandTy.getSwiftRValueType());
+    auto refType = cast<ReferenceStorageType>(operandTy.getASTType());
     return SILType::getPrimitiveObjectType(refType.getReferentType());
   }
 
@@ -4488,13 +4488,13 @@ public:
   /// Returns the formal type of the source value.
   CanType getSourceType() const {
     // This instruction is only used with types that allow this.
-    return getOperand()->getType().getSwiftRValueType();
+    return getOperand()->getType().getASTType();
   }
 
   /// Returns the formal target type.
   CanType getTargetType() const {
     // This instruction is only used with types that allow this.
-    return getType().getSwiftRValueType();
+    return getType().getASTType();
   }
 };
 
@@ -4941,7 +4941,7 @@ public:
   }
 
   TupleType *getTupleType() const {
-    return getType().getSwiftRValueType()->castTo<TupleType>();
+    return getType().castTo<TupleType>();
   }
 
   /// Search the operands of this tuple for a unique non-trivial elt. If we find
@@ -5420,7 +5420,7 @@ public:
   }
 
   TupleType *getTupleType() const {
-    return getOperand()->getType().getSwiftRValueType()->castTo<TupleType>();
+    return getOperand()->getType().castTo<TupleType>();
   }
 
   unsigned getNumTupleElts() const {
@@ -5453,7 +5453,7 @@ public:
 
 
   TupleType *getTupleType() const {
-    return getOperand()->getType().getSwiftRValueType()->castTo<TupleType>();
+    return getOperand()->getType().castTo<TupleType>();
   }
 };
 
@@ -5958,8 +5958,8 @@ public:
   /// instruction erases Decoder<T>.Type.Type to Printable.Type.Type,
   /// this method returns Decoder<T>.
   CanType getFormalErasedObjectType() const {
-    CanType exType = getType().getSwiftRValueType();
-    CanType concreteType = getOperand()->getType().getSwiftRValueType();
+    auto exType = getType().getASTType();
+    auto concreteType = getOperand()->getType().getASTType();
     while (auto exMetatype = dyn_cast<ExistentialMetatypeType>(exType)) {
       exType = exMetatype.getInstanceType();
       concreteType = cast<MetatypeType>(concreteType).getInstanceType();
@@ -7352,13 +7352,13 @@ public:
   /// Returns the formal type of the source value.
   CanType getSourceType() const {
     // This instruction is only used with types that allow this.
-    return getOperand()->getType().getSwiftRValueType();
+    return getOperand()->getType().getASTType();
   }
 
   /// Returns the formal target type.
   CanType getTargetType() const {
     // This instruction is only used with types that allow this.
-    return getCastType().getSwiftRValueType();
+    return getCastType().getASTType();
   }
 
   SILType getCastType() const { return DestTy; }
@@ -7407,13 +7407,13 @@ public:
   /// Returns the formal type of the source value.
   CanType getSourceType() const {
     // This instruction is only used with types that allow this.
-    return getOperand()->getType().getSwiftRValueType();
+    return getOperand()->getType().getASTType();
   }
 
   /// Returns the formal target type.
   CanType getTargetType() const {
     // This instruction is only used with types that allow this.
-    return getCastType().getSwiftRValueType();
+    return getCastType().getASTType();
   }
 
   SILType getCastType() const { return DestTy; }

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -138,7 +138,7 @@ public:
 
   /// Returns the \p Category variant of this type.
   SILType getCategoryType(SILValueCategory Category) const {
-    return SILType(getSwiftRValueType(), Category);
+    return SILType(getASTType(), Category);
   }
 
   /// Returns the variant of this type that matches \p Ty.getCategory()
@@ -149,20 +149,26 @@ public:
   /// Returns the address variant of this type.  Instructions which
   /// manipulate memory will generally work with object addresses.
   SILType getAddressType() const {
-    return SILType(getSwiftRValueType(), SILValueCategory::Address);
+    return SILType(getASTType(), SILValueCategory::Address);
   }
 
   /// Returns the object variant of this type.  Note that address-only
   /// types are not legal to manipulate directly as objects in SIL.
   SILType getObjectType() const {
-    return SILType(getSwiftRValueType(), SILValueCategory::Object);
+    return SILType(getASTType(), SILValueCategory::Object);
   }
 
-  /// Returns the Swift type referenced by this SIL type.
-  CanType getSwiftRValueType() const {
+  /// Returns the canonical AST type referenced by this SIL type.
+  CanType getASTType() const {
     return CanType(value.getPointer());
   }
   
+  // FIXME -- Temporary until LLDB adopts getASTType()
+  LLVM_ATTRIBUTE_DEPRECATED(CanType getSwiftRValueType() const,
+                            "Please use getASTType()") {
+    return getASTType();
+  }
+
   /// Returns the AbstractCC of a function type.
   /// The SILType must refer to a function type.
   SILFunctionTypeRepresentation getFunctionRepresentation() const {
@@ -173,18 +179,18 @@ public:
   /// cast fails.
   template<typename TYPE>
   typename CanTypeWrapperTraits<TYPE>::type
-  getAs() const { return dyn_cast<TYPE>(getSwiftRValueType()); }
+  getAs() const { return dyn_cast<TYPE>(getASTType()); }
 
   /// Cast the Swift type referenced by this SIL type, which must be of the
   /// specified subtype.
   template<typename TYPE>
   typename CanTypeWrapperTraits<TYPE>::type
-  castTo() const { return cast<TYPE>(getSwiftRValueType()); }
+  castTo() const { return cast<TYPE>(getASTType()); }
 
   /// Returns true if the Swift type referenced by this SIL type is of the
   /// specified subtype.
   template<typename TYPE>
-  bool is() const { return isa<TYPE>(getSwiftRValueType()); }
+  bool is() const { return isa<TYPE>(getASTType()); }
 
   bool isVoid() const {
     return value.getPointer()->isVoid();
@@ -193,22 +199,22 @@ public:
   /// Retrieve the ClassDecl for a type that maps to a Swift class or
   /// bound generic class type.
   ClassDecl *getClassOrBoundGenericClass() const {
-    return getSwiftRValueType().getClassOrBoundGenericClass();
+    return getASTType().getClassOrBoundGenericClass();
   }
   /// Retrieve the StructDecl for a type that maps to a Swift struct or
   /// bound generic struct type.
   StructDecl *getStructOrBoundGenericStruct() const {
-    return getSwiftRValueType().getStructOrBoundGenericStruct();
+    return getASTType().getStructOrBoundGenericStruct();
   }
   /// Retrieve the EnumDecl for a type that maps to a Swift enum or
   /// bound generic enum type.
   EnumDecl *getEnumOrBoundGenericEnum() const {
-    return getSwiftRValueType().getEnumOrBoundGenericEnum();
+    return getASTType().getEnumOrBoundGenericEnum();
   }
   /// Retrieve the NominalTypeDecl for a type that maps to a Swift
   /// nominal or bound generic nominal type.
   NominalTypeDecl *getNominalOrBoundGenericNominal() const {
-    return getSwiftRValueType().getNominalOrBoundGenericNominal();
+    return getASTType().getNominalOrBoundGenericNominal();
   }
   
   /// True if the type is an address type.
@@ -274,43 +280,43 @@ public:
 
   /// Returns true if the referenced type has reference semantics.
   bool hasReferenceSemantics() const {
-    return getSwiftRValueType().hasReferenceSemantics();
+    return getASTType().hasReferenceSemantics();
   }
 
   /// Returns true if the referenced type is any sort of class-reference type,
   /// meaning anything with reference semantics that is not a function type.
   bool isAnyClassReferenceType() const {
-    return getSwiftRValueType().isAnyClassReferenceType();
+    return getASTType().isAnyClassReferenceType();
   }
   
   /// Returns true if the referenced type is guaranteed to have a
   /// single-retainable-pointer representation.
   bool hasRetainablePointerRepresentation() const {
-    return getSwiftRValueType()->hasRetainablePointerRepresentation();
+    return getASTType()->hasRetainablePointerRepresentation();
   }
   /// Returns true if the referenced type is an existential type.
   bool isExistentialType() const {
-    return getSwiftRValueType().isExistentialType();
+    return getASTType().isExistentialType();
   }
   /// Returns true if the referenced type is any kind of existential type.
   bool isAnyExistentialType() const {
-    return getSwiftRValueType().isAnyExistentialType();
+    return getASTType().isAnyExistentialType();
   }
   /// Returns true if the referenced type is a class existential type.
   bool isClassExistentialType() const {
-    return getSwiftRValueType()->isClassExistentialType();
+    return getASTType()->isClassExistentialType();
   }
 
   /// Returns true if the referenced type is an opened existential type
   /// (which is actually a kind of archetype).
   bool isOpenedExistential() const {
-    return getSwiftRValueType()->isOpenedExistential();
+    return getASTType()->isOpenedExistential();
   }
 
   /// Returns true if the referenced type is expressed in terms of one
   /// or more opened existential types.
   bool hasOpenedExistential() const {
-    return getSwiftRValueType()->hasOpenedExistential();
+    return getASTType()->hasOpenedExistential();
   }
   
   /// Returns the representation used by an existential type. If the concrete
@@ -332,12 +338,12 @@ public:
   
   /// True if the type contains a type parameter.
   bool hasTypeParameter() const {
-    return getSwiftRValueType()->hasTypeParameter();
+    return getASTType()->hasTypeParameter();
   }
   
   /// True if the type is bridgeable to an ObjC object pointer type.
   bool isBridgeableObjectType() const {
-    return getSwiftRValueType()->isBridgeableObjectType();
+    return getASTType()->isBridgeableObjectType();
   }
 
   static bool isClassOrClassMetatype(Type t) {
@@ -350,17 +356,17 @@ public:
 
   /// True if the type is a class type or class metatype type.
   bool isClassOrClassMetatype() {
-    return isObject() && isClassOrClassMetatype(getSwiftRValueType());
+    return isObject() && isClassOrClassMetatype(getASTType());
   }
 
   /// True if the type involves any archetypes.
   bool hasArchetype() const {
-    return getSwiftRValueType()->hasArchetype();
+    return getASTType()->hasArchetype();
   }
   
   /// Returns the ASTContext for the referenced Swift type.
   const ASTContext &getASTContext() const {
-    return getSwiftRValueType()->getASTContext();
+    return getASTType()->getASTContext();
   }
 
   /// True if the given type has at least the size and alignment of a native
@@ -417,28 +423,26 @@ public:
   /// Return the immediate superclass type of this type, or null if
   /// it's the most-derived type.
   SILType getSuperclass() const {
-    auto superclass = getSwiftRValueType()->getSuperclass();
+    auto superclass = getASTType()->getSuperclass();
     if (!superclass) return SILType();
     return SILType::getPrimitiveObjectType(superclass->getCanonicalType());
   }
 
   /// Return true if Ty is a subtype of this exact SILType, or false otherwise.
   bool isExactSuperclassOf(SILType Ty) const {
-    return getSwiftRValueType()->isExactSuperclassOf(Ty.getSwiftRValueType());
+    return getASTType()->isExactSuperclassOf(Ty.getASTType());
   }
 
   /// Return true if Ty is a subtype of this SILType, or if this SILType
   /// contains archetypes that can be found to form a supertype of Ty, or false
   /// otherwise.
   bool isBindableToSuperclassOf(SILType Ty) const {
-    return getSwiftRValueType()->isBindableToSuperclassOf(
-                                                        Ty.getSwiftRValueType());
+    return getASTType()->isBindableToSuperclassOf(Ty.getASTType());
   }
 
   /// Look through reference-storage types on this type.
   SILType getReferenceStorageReferentType() const {
-    return SILType(getSwiftRValueType().getReferenceStorageReferent(),
-                   getCategory());
+    return SILType(getASTType().getReferenceStorageReferent(), getCategory());
   }
 
   /// Transform the function type SILType by replacing all of its interface
@@ -493,7 +497,7 @@ public:
   SILType unwrapOptionalType() const;
 
   /// Returns true if this is the AnyObject SILType;
-  bool isAnyObject() const { return getSwiftRValueType()->isAnyObject(); }
+  bool isAnyObject() const { return getASTType()->isAnyObject(); }
 
   /// Returns the underlying referent SILType of an @sil_unowned or @sil_weak
   /// Type.

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -187,7 +187,7 @@ public:
   /// return on a variable of this type.
   SILType getSemanticType() const {
     // If you change this, change getSemanticTypeLowering() too.
-    auto storageType = getLoweredType().getSwiftRValueType();
+    auto storageType = getLoweredType().getASTType();
     if (auto refType = dyn_cast<ReferenceStorageType>(storageType))
       return SILType::getPrimitiveType(refType.getReferentType(),
                                        SILValueCategory::Object);
@@ -639,7 +639,7 @@ public:
   }
   
   static bool isIndirectPlusZeroSelfParameter(SILType T) {
-    return isIndirectPlusZeroSelfParameter(T.getSwiftRValueType());
+    return isIndirectPlusZeroSelfParameter(T.getASTType());
   }
   
   /// Lowers a Swift type to a SILType, and returns the SIL TypeLowering
@@ -907,7 +907,7 @@ private:
 inline const TypeLowering &
 TypeLowering::getSemanticTypeLowering(TypeConverter &TC) const {
   // If you change this, change getSemanticType() too.
-  auto storageType = getLoweredType().getSwiftRValueType();
+  auto storageType = getLoweredType().getASTType();
   if (auto refType = dyn_cast<ReferenceStorageType>(storageType))
     return TC.getTypeLowering(refType.getReferentType());
   return *this;

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -98,8 +98,7 @@ class TypeSubstCloner : public SILClonerWithScopes<ImplClass> {
           // convention for parameters. E.g. some of former indirect parameters
           // may become direct. Some of indirect return values may become
           // direct. Do not replace the callee in that case.
-          if (SubstCalleeSILType.getSwiftRValueType() ==
-              RecursiveSubstCalleeSILType) {
+          if (SubstCalleeSILType.getASTType() == RecursiveSubstCalleeSILType) {
             Subs = RecursiveSubsList;
             Callee = Builder.createFunctionRef(
                 Cloner.getOpLocation(AI.getLoc()), &Builder.getFunction());

--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -103,7 +103,7 @@ DebugTypeInfo DebugTypeInfo::getGlobal(SILGlobalVariable *GV,
   // the type hasn't been mucked with by an optimization pass.
   DeclContext *DC = nullptr;
   GenericEnvironment *GE = nullptr;
-  auto LowTy = GV->getLoweredType().getSwiftRValueType();
+  auto LowTy = GV->getLoweredType().getASTType();
   auto *Type = LowTy.getPointer();
   if (auto *Decl = GV->getDecl()) {
     DC = Decl->getDeclContext();

--- a/lib/IRGen/GenCall.cpp
+++ b/lib/IRGen/GenCall.cpp
@@ -1637,10 +1637,8 @@ void CallEmission::emitToMemory(Address addr,
   // result that's actually being passed indirectly.
   //
   // TODO: SIL address lowering should be able to handle such cases earlier.
-  CanType origResultType =
-      origFnType->getDirectFormalResultsType().getSwiftRValueType();
-  CanType substResultType =
-      substFnType->getDirectFormalResultsType().getSwiftRValueType();
+  auto origResultType = origFnType->getDirectFormalResultsType().getASTType();
+  auto substResultType = substFnType->getDirectFormalResultsType().getASTType();
 
   if (origResultType->hasTypeParameter())
     origResultType = IGF.IGM.getGenericEnvironment()

--- a/lib/IRGen/GenClangType.cpp
+++ b/lib/IRGen/GenClangType.cpp
@@ -441,7 +441,7 @@ GenClangType::visitBoundGenericType(CanBoundGenericType type) {
           SILType::getPrimitiveObjectType(type).getOptionalObjectType()) {
     // The underlying type could be a bridged type, which makes any
     // sort of casual assertion here difficult.
-    return Converter.convert(IGM, underlyingTy.getSwiftRValueType());
+    return Converter.convert(IGM, underlyingTy.getASTType());
   }
 
   auto swiftStructDecl = type->getDecl();
@@ -466,7 +466,7 @@ GenClangType::visitBoundGenericType(CanBoundGenericType type) {
   auto args = type.getGenericArgs();
   assert(args.size() == 1 &&
          "should have a single generic argument!");
-  auto loweredArgTy = IGM.getLoweredType(args[0]).getSwiftRValueType();
+  auto loweredArgTy = IGM.getLoweredType(args[0]).getASTType();
 
   switch (kind) {
   case StructKind::Invalid:
@@ -756,7 +756,7 @@ clang::CanQualType IRGenModule::getClangType(CanType type) {
 }
 
 clang::CanQualType IRGenModule::getClangType(SILType type) {
-  return getClangType(type.getSwiftRValueType());
+  return getClangType(type.getASTType());
 }
 
 clang::CanQualType IRGenModule::getClangType(SILParameterInfo params) {

--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -1660,7 +1660,7 @@ OwnedAddress irgen::emitBoxedExistentialContainerAllocation(IRGenFunction &IGF,
   auto box = IGF.Builder.CreateExtractValue(result, 0);
   auto addr = IGF.Builder.CreateExtractValue(result, 1);
 
-  auto archetype = ArchetypeType::getOpened(destType.getSwiftRValueType());
+  auto archetype = ArchetypeType::getOpened(destType.getASTType());
   auto &srcTI = IGF.getTypeInfoForUnlowered(AbstractionPattern(archetype),
                                             formalSrcType);
   addr = IGF.Builder.CreateBitCast(addr,
@@ -1695,8 +1695,8 @@ void irgen::emitClassExistentialContainer(IRGenFunction &IGF,
                                ArrayRef<ProtocolConformanceRef> conformances) {
   // As a special case, an Error existential can be represented as a
   // reference to an already existing NSError or CFError instance.
-  if (outType.getSwiftRValueType().isExistentialType()) {
-    auto layout = outType.getSwiftRValueType().getExistentialLayout();
+  if (outType.isExistentialType()) {
+    auto layout = outType.getASTType().getExistentialLayout();
     if (layout.isErrorExistential()) {
       // Bitcast the incoming class reference to Error.
       out.add(IGF.Builder.CreateBitCast(instance, IGF.IGM.ErrorPtrTy));
@@ -1717,7 +1717,7 @@ void irgen::emitClassExistentialContainer(IRGenFunction &IGF,
   // Emit the witness table pointers.
   llvm::Value *instanceMetadata = nullptr;
   forEachProtocolWitnessTable(IGF, instanceFormalType, &instanceMetadata,
-                              outType.getSwiftRValueType(),
+                              outType.getASTType(),
                               destTI.getStoredProtocols(),
                               conformances,
                               [&](unsigned i, llvm::Value *ptable) {
@@ -1747,7 +1747,7 @@ Address irgen::emitOpaqueExistentialContainerInit(IRGenFunction &IGF,
 
   // Next, write the protocol witness tables.
   forEachProtocolWitnessTable(IGF, formalSrcType, &metadata,
-                              destType.getSwiftRValueType(),
+                              destType.getASTType(),
                               destTI.getStoredProtocols(), conformances,
                               [&](unsigned i, llvm::Value *ptable) {
     Address ptableSlot = destLayout.projectWitnessTable(IGF, dest, i);

--- a/lib/IRGen/GenFunc.cpp
+++ b/lib/IRGen/GenFunc.cpp
@@ -717,8 +717,7 @@ static bool isABIIgnoredParameterWithoutStorage(IRGenModule &IGM,
                                                 unsigned paramIdx) {
   auto param = substType->getParameters()[paramIdx];
   SILType argType = IGM.silConv.getSILType(param);
-  auto argLoweringTy =
-    getArgumentLoweringType(argType.getSwiftRValueType(), param);
+  auto argLoweringTy = getArgumentLoweringType(argType.getASTType(), param);
   auto &ti = IGF.getTypeInfoForLowered(argLoweringTy);
   // Empty values don't matter.
   return ti.getSchema().empty() && !param.isFormalIndirect();
@@ -1369,8 +1368,7 @@ void irgen::emitFunctionPartialApplication(
   for (auto param : params) {
     SILType argType = IGF.IGM.silConv.getSILType(param);
 
-    auto argLoweringTy =
-        getArgumentLoweringType(argType.getSwiftRValueType(), param);
+    auto argLoweringTy = getArgumentLoweringType(argType.getASTType(), param);
 
     auto &ti = IGF.getTypeInfoForLowered(argLoweringTy);
 

--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -1556,13 +1556,13 @@ public:
     auto boxedInterfaceType = boxedType;
     if (env) {
       boxedInterfaceType = SILType::getPrimitiveType(
-        boxedType.getSwiftRValueType()->mapTypeOutOfContext()
+        boxedType.getASTType()->mapTypeOutOfContext()
            ->getCanonicalType(),
          boxedType.getCategory());
     }
 
     auto boxDescriptor = IGF.IGM.getAddrOfBoxDescriptor(
-        boxedInterfaceType.getSwiftRValueType());
+        boxedInterfaceType.getASTType());
     llvm::Value *allocation = IGF.emitUnmanagedAlloc(layout, name,
                                                      boxDescriptor);
     Address rawAddr = project(IGF, allocation, boxedType);
@@ -1717,7 +1717,7 @@ Address irgen::emitAllocateExistentialBoxInBuffer(
     IRGenFunction &IGF, SILType boxedType, Address destBuffer,
     GenericEnvironment *env, const llvm::Twine &name, bool isOutlined) {
   // Get a box for the boxed value.
-  auto boxType = SILBoxType::get(boxedType.getSwiftRValueType());
+  auto boxType = SILBoxType::get(boxedType.getASTType());
   auto &boxTI = IGF.getTypeInfoForLowered(boxType).as<BoxTypeInfo>();
   OwnedAddress owned = boxTI.allocate(IGF, boxedType, env, name);
   Explosion box;
@@ -1912,7 +1912,7 @@ llvm::Value *irgen::emitHeapMetadataRefForHeapObject(IRGenFunction &IGF,
                                                      SILType objectType,
                                                      bool suppressCast) {
   return emitHeapMetadataRefForHeapObject(IGF, object,
-                                          objectType.getSwiftRValueType(),
+                                          objectType.getASTType(),
                                           suppressCast);
 }
 
@@ -1967,9 +1967,9 @@ llvm::Value *irgen::emitDynamicTypeOfHeapObject(IRGenFunction &IGF,
                                                 bool suppressCast) {
   // If it is known to have swift metadata, just load. A swift class is both
   // heap metadata and type metadata.
-  if (hasKnownSwiftMetadata(IGF.IGM, objectType.getSwiftRValueType())) {
+  if (hasKnownSwiftMetadata(IGF.IGM, objectType.getASTType())) {
     return emitLoadOfHeapMetadataRef(IGF, object,
-                getIsaEncodingForType(IGF.IGM, objectType.getSwiftRValueType()),
+                getIsaEncodingForType(IGF.IGM, objectType.getASTType()),
                 suppressCast);
   }
 

--- a/lib/IRGen/GenObjC.cpp
+++ b/lib/IRGen/GenObjC.cpp
@@ -687,7 +687,7 @@ Callee irgen::getObjCMethodCallee(IRGenFunction &IGF,
   if (auto searchType = methodInfo.getSearchType()) {
     receiverValue =
       emitSuperArgument(IGF, isInstanceMethod, selfValue,
-                        searchType.getSwiftRValueType());
+                        searchType.getASTType());
   } else {
     receiverValue = selfValue;
   }
@@ -1064,7 +1064,7 @@ static clang::CanQualType getObjCPropertyType(IRGenModule &IGM,
   assert(getter);
   CanSILFunctionType methodTy = getObjCMethodType(IGM, getter);
   return IGM.getClangType(
-      methodTy->getFormalCSemanticResult().getSwiftRValueType());
+      methodTy->getFormalCSemanticResult().getASTType());
 }
 
 void irgen::getObjCEncodingForPropertyType(IRGenModule &IGM,
@@ -1096,7 +1096,7 @@ static llvm::Constant *getObjCEncodingForTypes(IRGenModule &IGM,
 
   // Return type.
   {
-    auto clangType = IGM.getClangType(resultType.getSwiftRValueType());
+    auto clangType = IGM.getClangType(resultType.getASTType());
     if (clangType.isNull())
       return llvm::ConstantPointerNull::get(IGM.Int8PtrTy);
     HelperGetObjCEncodingForType(clangASTContext, clangType, encodingString,

--- a/lib/IRGen/GenPoly.cpp
+++ b/lib/IRGen/GenPoly.cpp
@@ -43,8 +43,7 @@ static SILType applyContextArchetypes(IRGenFunction &IGF,
   }
 
   auto substType =
-    IGF.IGM.getGenericEnvironment()->mapTypeIntoContext(
-        type.getSwiftRValueType())
+    IGF.IGM.getGenericEnvironment()->mapTypeIntoContext(type.getASTType())
       ->getCanonicalType();
   return SILType::getPrimitiveType(substType, type.getCategory());
 }

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -610,7 +610,7 @@ public:
     auto ElementTypes = Layout.getElementTypes().slice(
         Layout.hasBindings() ? 1 : 0);
     for (auto ElementType : ElementTypes) {
-      auto SwiftType = ElementType.getSwiftRValueType();
+      auto SwiftType = ElementType.getASTType();
       if (SwiftType->hasOpenedExistential())
         return true;
     }
@@ -704,7 +704,7 @@ public:
     std::vector<CanType> CaptureTypes;
 
     for (auto ElementType : getElementTypes()) {
-      auto SwiftType = ElementType.getSwiftRValueType();
+      auto SwiftType = ElementType.getASTType();
 
       // Erase pseudogeneric captures down to AnyObject.
       if (OrigCalleeType->isPseudogeneric()) {

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1298,7 +1298,7 @@ SILType IRGenModule::getLoweredType(Type subst) {
 /// unlike fetching the type info and asking it for the storage type,
 /// this operation will succeed for forward-declarations.
 llvm::PointerType *IRGenModule::getStoragePointerType(SILType T) {
-  return getStoragePointerTypeForLowered(T.getSwiftRValueType());
+  return getStoragePointerTypeForLowered(T.getASTType());
 }
 llvm::PointerType *IRGenModule::getStoragePointerTypeForUnlowered(Type T) {
   return getStorageTypeForUnlowered(T)->getPointerTo();
@@ -1312,7 +1312,7 @@ llvm::Type *IRGenModule::getStorageTypeForUnlowered(Type subst) {
 }
 
 llvm::Type *IRGenModule::getStorageType(SILType T) {
-  return getStorageTypeForLowered(T.getSwiftRValueType());
+  return getStorageTypeForLowered(T.getASTType());
 }
 
 /// Get the storage type for the given type.  Note that, unlike
@@ -1353,7 +1353,7 @@ IRGenModule::getTypeInfoForUnlowered(AbstractionPattern orig, CanType subst) {
 /// to have undergone SIL type lowering (or be one of the types for
 /// which that lowering is the identity function).
 const TypeInfo &IRGenModule::getTypeInfo(SILType T) {
-  return getTypeInfoForLowered(T.getSwiftRValueType());
+  return getTypeInfoForLowered(T.getASTType());
 }
 
 /// Get the fragile type information for the given type.
@@ -1449,8 +1449,7 @@ TypeCacheEntry TypeConverter::getTypeEntry(CanType canonicalTy) {
     // The type we got should be lowered, so lower it like a SILType.
     contextTy = getGenericEnvironment()->mapTypeIntoContext(
                   IGM.getSILModule(),
-                  SILType::getPrimitiveAddressType(contextTy))
-      .getSwiftRValueType();
+                  SILType::getPrimitiveAddressType(contextTy)).getASTType();
   }
   
   // Fold archetypes to unique exemplars. Any archetype with the same

--- a/lib/IRGen/GenValueWitness.cpp
+++ b/lib/IRGen/GenValueWitness.cpp
@@ -1491,6 +1491,6 @@ void TypeInfo::assignArrayWithTake(IRGenFunction &IGF, Address dest,
 
 void TypeInfo::collectMetadataForOutlining(OutliningMetadataCollector &c,
                                            SILType T) const {
-  auto canType = T.getSwiftRValueType();
+  auto canType = T.getASTType();
   assert(!canType->is<ArchetypeType>() && "Did not expect an ArchetypeType");
 }

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -468,7 +468,7 @@ private:
   void createParameterType(llvm::SmallVectorImpl<llvm::Metadata *> &Parameters,
                            SILType type, DeclContext *DeclCtx,
                            GenericEnvironment *GE) {
-    auto RealType = type.getSwiftRValueType();
+    auto RealType = type.getASTType();
     if (type.isAddress())
       RealType = CanInOutType::get(RealType);
     auto DbgTy = DebugTypeInfo::getFromTypeInfo(DeclCtx, GE, RealType,
@@ -1182,7 +1182,7 @@ private:
       SmallVector<llvm::Metadata *, 4> Protocols;
       for (auto *ProtocolDecl : Archetype->getConformsTo()) {
         auto PTy = IGM.getLoweredType(ProtocolDecl->getInterfaceType())
-                       .getSwiftRValueType();
+                       .getASTType();
         auto PDbgTy = DebugTypeInfo::getFromTypeInfo(
             DbgTy.getDeclContext(), DbgTy.getGenericEnvironment(),
             ProtocolDecl->getInterfaceType(), IGM.getTypeInfoForLowered(PTy));

--- a/lib/IRGen/LocalTypeData.cpp
+++ b/lib/IRGen/LocalTypeData.cpp
@@ -150,7 +150,7 @@ bool LocalTypeDataCache::AbstractCacheEntry::immediatelySatisfies(
 MetadataResponse
 IRGenFunction::tryGetLocalTypeMetadataForLayout(SILType layoutType,
                                                 DynamicMetadataRequest request){
-  auto type = layoutType.getSwiftRValueType();
+  auto type = layoutType.getASTType();
 
   // Check under the formal type first.
   if (type->isLegalFormalType()) {
@@ -192,7 +192,7 @@ IRGenFunction::tryGetConcreteLocalTypeData(LocalTypeDataKey key,
 
 llvm::Value *IRGenFunction::tryGetLocalTypeDataForLayout(SILType type,
                                                        LocalTypeDataKind kind) {
-  return tryGetLocalTypeData(LocalTypeDataKey(type.getSwiftRValueType(), kind));
+  return tryGetLocalTypeData(LocalTypeDataKey(type.getASTType(), kind));
 }
 
 llvm::Value *IRGenFunction::tryGetLocalTypeData(CanType type,
@@ -346,7 +346,7 @@ static void maybeEmitDebugInfoForLocalTypeData(IRGenFunction &IGF,
 void
 IRGenFunction::setScopedLocalTypeMetadataForLayout(SILType type,
                                                    MetadataResponse response) {
-  auto key = LocalTypeDataKey(type.getSwiftRValueType(),
+  auto key = LocalTypeDataKey(type.getASTType(),
                          LocalTypeDataKind::forRepresentationTypeMetadata());
   setScopedLocalTypeData(key, response);
 }
@@ -369,7 +369,7 @@ void IRGenFunction::setScopedLocalTypeDataForLayout(SILType type,
                                                     LocalTypeDataKind kind,
                                                     llvm::Value *data) {
   assert(!kind.isAnyTypeMetadata());
-  setScopedLocalTypeData(LocalTypeDataKey(type.getSwiftRValueType(), kind),
+  setScopedLocalTypeData(LocalTypeDataKey(type.getASTType(), kind),
                          MetadataResponse::forComplete(data));
 }
 

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -2046,7 +2046,7 @@ llvm::Value *
 IRGenFunction::emitTypeMetadataRefForLayout(SILType type,
                                             DynamicMetadataRequest request) {
   assert(request.canResponseStatusBeIgnored());
-  return EmitTypeMetadataRefForLayout(*this).visit(type.getSwiftRValueType(),
+  return EmitTypeMetadataRefForLayout(*this).visit(type.getASTType(),
                                                    request);
 }
 
@@ -2145,7 +2145,7 @@ namespace {
       // to the aggregate's.
       if (SILType singletonFieldTy = getSingletonAggregateFieldType(IGF.IGM,
                                              silTy, ResilienceExpansion::Maximal))
-        return visit(singletonFieldTy.getSwiftRValueType(), request);
+        return visit(singletonFieldTy.getASTType(), request);
 
       // If the type is fixed-layout, emit a copy of its layout.
       if (auto fixed = dyn_cast<FixedTypeInfo>(&ti))
@@ -2327,7 +2327,7 @@ llvm::Value *irgen::emitTypeLayoutRef(IRGenFunction &IGF, SILType type,
     DynamicMetadataRequest::getNonBlocking(MetadataState::LayoutComplete,
                                            collector);
   assert(request.canResponseStatusBeIgnored());
-  return EmitTypeLayoutRef(IGF).visit(type.getSwiftRValueType(), request);
+  return EmitTypeLayoutRef(IGF).visit(type.getASTType(), request);
 }
 
 /// Given a class metatype, produce the necessary heap metadata

--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -35,7 +35,7 @@ void OutliningMetadataCollector::collectTypeMetadataForLayout(SILType type) {
     return;
   }
 
-  CanType formalType = type.getSwiftRValueType();
+  auto formalType = type.getASTType();
   if (isa<FixedTypeInfo>(IGF.IGM.getTypeInfoForLowered(formalType))) {
     return;
   }
@@ -47,7 +47,7 @@ void OutliningMetadataCollector::collectTypeMetadataForLayout(SILType type) {
     return collectFormalTypeMetadata(formalType);
   }
 
-  auto key = LocalTypeDataKey(type.getSwiftRValueType(),
+  auto key = LocalTypeDataKey(type.getASTType(),
                             LocalTypeDataKind::forRepresentationTypeMetadata());
   if (Values.count(key)) return;
 
@@ -100,7 +100,7 @@ void OutliningMetadataCollector::bindMetadataParameters(IRGenFunction &IGF,
 
 std::pair<CanType, CanGenericSignature>
 irgen::getTypeAndGenericSignatureForManglingOutlineFunction(SILType type) {
-  auto loweredType = type.getSwiftRValueType();
+  auto loweredType = type.getASTType();
   if (loweredType->hasArchetype()) {
     GenericEnvironment *env = nullptr;
     loweredType.findIf([&env](Type t) -> bool {

--- a/lib/SIL/DynamicCasts.cpp
+++ b/lib/SIL/DynamicCasts.cpp
@@ -285,10 +285,10 @@ CanType swift::getNSBridgedClassOfCFClass(ModuleDecl *M, CanType type) {
 
 static bool isCFBridgingConversion(ModuleDecl *M, SILType sourceType,
                                    SILType targetType) {
-  return (sourceType.getSwiftRValueType() ==
-            getNSBridgedClassOfCFClass(M, targetType.getSwiftRValueType()) ||
-          targetType.getSwiftRValueType() ==
-            getNSBridgedClassOfCFClass(M, sourceType.getSwiftRValueType()));
+  return (sourceType.getASTType() ==
+            getNSBridgedClassOfCFClass(M, targetType.getASTType()) ||
+          targetType.getASTType() ==
+            getNSBridgedClassOfCFClass(M, sourceType.getASTType()));
 }
 
 /// Try to classify the dynamic-cast relationship between two types.

--- a/lib/SIL/MemAccessUtils.cpp
+++ b/lib/SIL/MemAccessUtils.cpp
@@ -287,8 +287,7 @@ static bool isLetAccess(const AccessedStorage &storage, SILFunction *F) {
 
 static bool isScratchBuffer(SILValue value) {
   // Special case unsafe value buffer access.
-  return isa<BuiltinUnsafeValueBufferType>(
-    value->getType().getSwiftRValueType());
+  return value->getType().is<BuiltinUnsafeValueBufferType>();
 }
 
 bool swift::memInstMustInitialize(Operand *memOper) {

--- a/lib/SIL/Projection.cpp
+++ b/lib/SIL/Projection.cpp
@@ -91,7 +91,7 @@ Projection::Projection(SingleValueInstruction *I) : Value() {
   }
   case SILInstructionKind::RefTailAddrInst: {
     auto *RTAI = cast<RefTailAddrInst>(I);
-    auto *Ty = RTAI->getTailType().getSwiftRValueType().getPointer();
+    auto *Ty = RTAI->getTailType().getASTType().getPointer();
     Value = ValueTy(ProjectionKind::TailElems, Ty);
     assert(getKind() == ProjectionKind::TailElems);
     break;
@@ -148,14 +148,14 @@ Projection::Projection(SingleValueInstruction *I) : Value() {
     break;
   }
   case SILInstructionKind::UpcastInst: {
-    auto *Ty = I->getType().getSwiftRValueType().getPointer();
+    auto *Ty = I->getType().getASTType().getPointer();
     assert(Ty->isCanonical());
     Value = ValueTy(ProjectionKind::Upcast, Ty);
     assert(getKind() == ProjectionKind::Upcast);
     break;
   }
   case SILInstructionKind::UncheckedRefCastInst: {
-    auto *Ty = I->getType().getSwiftRValueType().getPointer();
+    auto *Ty = I->getType().getASTType().getPointer();
     assert(Ty->isCanonical());
     Value = ValueTy(ProjectionKind::RefCast, Ty);
     assert(getKind() == ProjectionKind::RefCast);
@@ -163,7 +163,7 @@ Projection::Projection(SingleValueInstruction *I) : Value() {
   }
   case SILInstructionKind::UncheckedBitwiseCastInst:
   case SILInstructionKind::UncheckedAddrCastInst: {
-    auto *Ty = I->getType().getSwiftRValueType().getPointer();
+    auto *Ty = I->getType().getASTType().getPointer();
     assert(Ty->isCanonical());
     Value = ValueTy(ProjectionKind::BitwiseCast, Ty);
     assert(getKind() == ProjectionKind::BitwiseCast);

--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -41,7 +41,7 @@ TupleInst *SILBuilder::createTuple(SILLocation loc, ArrayRef<SILValue> elts) {
   // Derive the tuple type from the elements.
   SmallVector<TupleTypeElt, 4> eltTypes;
   for (auto elt : elts)
-    eltTypes.push_back(elt->getType().getSwiftRValueType());
+    eltTypes.push_back(elt->getType().getASTType());
   auto tupleType = SILType::getPrimitiveObjectType(
       CanType(TupleType::get(eltTypes, getASTContext())));
 

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -424,7 +424,7 @@ bool SILFunction::hasSelfMetadataParam() const {
   if (!silTy.isObject())
     return false;
 
-  auto selfTy = silTy.getSwiftRValueType();
+  auto selfTy = silTy.getASTType();
 
   if (auto metaTy = dyn_cast<MetatypeType>(selfTy)) {
     selfTy = metaTy.getInstanceType();

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -359,7 +359,7 @@ public:
       }
     }
 
-    SILResultInfo result(substResultTL.getLoweredType().getSwiftRValueType(),
+    SILResultInfo result(substResultTL.getLoweredType().getASTType(),
                          convention);
     Results.push_back(result);
   }
@@ -706,7 +706,7 @@ private:
                                    substTL);
       assert(!isIndirectFormalParameter(convention));
     }
-    auto loweredType = substTL.getLoweredType().getSwiftRValueType();
+    auto loweredType = substTL.getLoweredType().getASTType();
 
     Inputs.push_back(SILParameterInfo(loweredType, convention));
 
@@ -731,7 +731,7 @@ private:
       M.Types.getLoweredType(Foreign.Error->getErrorParameterType());
 
     // Assume the error parameter doesn't have interesting lowering.
-    Inputs.push_back(SILParameterInfo(foreignErrorTy.getSwiftRValueType(),
+    Inputs.push_back(SILParameterInfo(foreignErrorTy.getASTType(),
                                       ParameterConvention::Direct_Unowned));
     NextOrigParamIndex++;
     return true;
@@ -864,14 +864,14 @@ lowerCaptureContextParameters(SILModule &M, AnyFunctionRef function,
       } else {
         convention = ParameterConvention::Direct_Guaranteed;
       }
-      SILParameterInfo param(loweredTy.getSwiftRValueType(), convention);
+      SILParameterInfo param(loweredTy.getASTType(), convention);
       inputs.push_back(param);
       break;
     }
     case CaptureKind::Box: {
       // Lvalues are captured as a box that owns the captured value.
       auto boxTy = Types.getInterfaceBoxTypeForCapture(
-          VD, loweredTy.getSwiftRValueType(),
+          VD, loweredTy.getASTType(),
           /*mutable*/ true);
       auto convention = ParameterConvention::Direct_Guaranteed;
       auto param = SILParameterInfo(boxTy, convention);
@@ -882,7 +882,7 @@ lowerCaptureContextParameters(SILModule &M, AnyFunctionRef function,
       // Non-escaping lvalues are captured as the address of the value.
       SILType ty = loweredTy.getAddressType();
       auto param =
-          SILParameterInfo(ty.getSwiftRValueType(),
+          SILParameterInfo(ty.getASTType(),
                            ParameterConvention::Indirect_InoutAliasable);
       inputs.push_back(param);
       break;
@@ -960,7 +960,7 @@ static CanSILFunctionType getSILFunctionType(
            "using native Swift error convention for foreign type!");
     SILType exnType = SILType::getExceptionType(M.getASTContext());
     assert(exnType.isObject());
-    errorResult = SILResultInfo(exnType.getSwiftRValueType(),
+    errorResult = SILResultInfo(exnType.getASTType(),
                                 ResultConvention::Owned);
   }
 
@@ -1839,7 +1839,7 @@ public:
       break;
     }
 
-    auto type = tl.getLoweredType().getSwiftRValueType();
+    auto type = tl.getLoweredType().getASTType();
     if (type->hasRetainablePointerRepresentation()
         || (type->getSwiftNewtypeUnderlyingType() && !tl.isTrivial()))
       return ResultConvention::Autoreleased;
@@ -2360,7 +2360,7 @@ public:
   }
 
   SILType subst(SILType type) {
-    return SILType::getPrimitiveType(visit(type.getSwiftRValueType()),
+    return SILType::getPrimitiveType(visit(type.getASTType()),
                                      type.getCategory());
   }
 
@@ -2425,7 +2425,7 @@ public:
 
     AbstractionPattern abstraction(Sig, origType);
     return TheSILModule.Types.getLoweredType(abstraction, substType)
-             .getSwiftRValueType();
+             .getASTType();
   }
 };
 
@@ -2744,13 +2744,13 @@ static bool areABICompatibleParamsOrReturns(SILType a, SILType b) {
     auto types = tup.getElementTypes();
     aElements.append(types.begin(), types.end());
   } else {
-    aElements.push_back(a.getSwiftRValueType());
+    aElements.push_back(a.getASTType());
   }
   if (auto tup = b.getAs<TupleType>()) {
     auto types = tup.getElementTypes();
     bElements.append(types.begin(), types.end());
   } else {
-    bElements.push_back(b.getSwiftRValueType());
+    bElements.push_back(b.getASTType());
   }
 
   if (aElements.size() != bElements.size())

--- a/lib/SIL/SILOpenedArchetypesTracker.cpp
+++ b/lib/SIL/SILOpenedArchetypesTracker.cpp
@@ -152,7 +152,7 @@ CanArchetypeType swift::getOpenedArchetypeOf(const SILInstruction *I) {
       isa<OpenExistentialBoxInst>(I) || isa<OpenExistentialBoxValueInst>(I) ||
       isa<OpenExistentialMetatypeInst>(I) || isa<OpenExistentialValueInst>(I)) {
     auto SVI = cast<SingleValueInstruction>(I);
-    auto Ty = getOpenedArchetypeOf(SVI->getType().getSwiftRValueType());
+    auto Ty = getOpenedArchetypeOf(SVI->getType().getASTType());
     assert(Ty && Ty->isOpenedExistential() &&
            "Type should be an opened archetype");
     return Ty;

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -436,7 +436,7 @@ void SILType::print(raw_ostream &OS) const {
   
   // Print other types as their Swift representation.
   PrintOptions SubPrinter = PrintOptions::printSIL();
-  getSwiftRValueType().print(OS, SubPrinter);
+  getASTType().print(OS, SubPrinter);
 }
 
 void SILType::dump() const {
@@ -496,7 +496,7 @@ class SILPrinter : public SILInstructionVisitor<SILPrinter> {
   
   SILPrinter &operator<<(SILType t) {
     printSILTypeColorAndSigil(PrintState.OS, t);
-    t.getSwiftRValueType().print(PrintState.OS, PrintState.ASTOptions);
+    t.getASTType().print(PrintState.OS, PrintState.ASTOptions);
     return *this;
   }
   

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -268,7 +268,7 @@ void verifyKeyPathComponent(SILModule &M,
       auto baseParam = substGetterType->getParameters()[0];
       require(baseParam.getConvention() == normalArgConvention,
               "getter base parameter should have normal arg convention");
-      require(baseParam.getType() == loweredBaseTy.getSwiftRValueType(),
+      require(baseParam.getType() == loweredBaseTy.getASTType(),
               "getter base parameter should match base of component");
       
       if (hasIndices) {
@@ -286,7 +286,7 @@ void verifyKeyPathComponent(SILModule &M,
       auto result = substGetterType->getResults()[0];
       require(result.getConvention() == ResultConvention::Indirect,
               "getter result should be @out");
-      require(result.getType() == loweredComponentTy.getSwiftRValueType(),
+      require(result.getType() == loweredComponentTy.getASTType(),
               "getter result should match the maximal abstraction of the "
               "formal component type");
     }
@@ -330,7 +330,7 @@ void verifyKeyPathComponent(SILModule &M,
       }
 
       require(newValueParam.getType() ==
-                loweredComponentTy.getSwiftRValueType(),
+                loweredComponentTy.getASTType(),
               "setter value should match the maximal abstraction of the "
               "formal component type");
       
@@ -897,7 +897,7 @@ public:
 
   /// Check that the given type is a legal SIL value type.
   void checkLegalType(SILFunction *F, SILType type, SILInstruction *I) {
-    checkLegalSILType(F, type.getSwiftRValueType(), I);
+    checkLegalSILType(F, type.getASTType(), I);
   }
 
   /// Check that the given type is a legal SIL value type.
@@ -970,7 +970,7 @@ public:
     require(AI->getType().isAddress(),
             "result of alloc_stack must be an address type");
 
-    verifyOpenedArchetype(AI, AI->getElementType().getSwiftRValueType());
+    verifyOpenedArchetype(AI, AI->getElementType().getASTType());
 
     // There used to be a check if all uses of ASI are inside the alloc-dealloc
     // range. But apparently it can be the case that ASI has uses after the
@@ -981,7 +981,7 @@ public:
 
   void checkAllocRefBase(AllocRefInstBase *ARI) {
     requireReferenceValue(ARI, "Result of alloc_ref");
-    verifyOpenedArchetype(ARI, ARI->getType().getSwiftRValueType());
+    verifyOpenedArchetype(ARI, ARI->getType().getASTType());
     auto Types = ARI->getTailAllocatedTypes();
     auto Counts = ARI->getTailAllocatedCounts();
     unsigned NumTypes = Types.size();
@@ -989,7 +989,7 @@ public:
     require(NumTypes == 0 || !ARI->isObjC(),
             "Can't tail allocate with ObjC class");
     for (unsigned Idx = 0; Idx < NumTypes; ++Idx) {
-      verifyOpenedArchetype(ARI, Types[Idx].getSwiftRValueType());
+      verifyOpenedArchetype(ARI, Types[Idx].getASTType());
       require(Counts[Idx].get()->getType().is<BuiltinIntegerType>(),
               "count needs integer type");
     }
@@ -1386,7 +1386,7 @@ public:
       auto isSwiftRefcounted = [](SILType t) -> bool {
         if (t.is<SILBoxType>())
           return true;
-        if (t.getSwiftRValueType() == t.getASTContext().TheNativeObjectType)
+        if (t.getASTType() == t.getASTContext().TheNativeObjectType)
           return true;
         if (auto clas = t.getClassOrBoundGenericClass())
           // Must be a class defined in Swift.
@@ -1659,12 +1659,12 @@ public:
   void checkLoadUnownedInst(LoadUnownedInst *LUI) {
     require(LUI->getType().isObject(), "Result of load must be an object");
     auto PointerType = LUI->getOperand()->getType();
-    auto PointerRVType = PointerType.getSwiftRValueType();
+    auto PointerRVType = PointerType.getASTType();
     require(PointerType.isAddress() &&
             PointerRVType->is<UnownedStorageType>(),
             "load_unowned operand must be an unowned address");
     require(PointerRVType->getReferenceStorageReferent()->getCanonicalType() ==
-            LUI->getType().getSwiftRValueType(),
+            LUI->getType().getASTType(),
             "Load operand type and result type mismatch");
   }
 
@@ -1672,12 +1672,12 @@ public:
     require(SUI->getSrc()->getType().isObject(),
             "Can't store from an address source");
     auto PointerType = SUI->getDest()->getType();
-    auto PointerRVType = PointerType.getSwiftRValueType();
+    auto PointerRVType = PointerType.getASTType();
     require(PointerType.isAddress() &&
             PointerRVType->is<UnownedStorageType>(),
             "store_unowned address operand must be an unowned address");
     require(PointerRVType->getReferenceStorageReferent()->getCanonicalType() ==
-            SUI->getSrc()->getType().getSwiftRValueType(),
+            SUI->getSrc()->getType().getASTType(),
             "Store operand type and dest type mismatch");
   }
 
@@ -1686,12 +1686,12 @@ public:
     require(LWI->getType().getOptionalObjectType(),
             "Result of weak load must be an optional");
     auto PointerType = LWI->getOperand()->getType();
-    auto PointerRVType = PointerType.getSwiftRValueType();
+    auto PointerRVType = PointerType.getASTType();
     require(PointerType.isAddress() &&
             PointerRVType->is<WeakStorageType>(),
             "load_weak operand must be a weak address");
     require(PointerRVType->getReferenceStorageReferent()->getCanonicalType() ==
-            LWI->getType().getSwiftRValueType(),
+            LWI->getType().getASTType(),
             "Load operand type and result type mismatch");
   }
 
@@ -1701,12 +1701,12 @@ public:
     require(SWI->getSrc()->getType().getOptionalObjectType(),
             "store_weak must be of an optional value");
     auto PointerType = SWI->getDest()->getType();
-    auto PointerRVType = PointerType.getSwiftRValueType();
+    auto PointerRVType = PointerType.getASTType();
     require(PointerType.isAddress() &&
             PointerRVType->is<WeakStorageType>(),
             "store_weak address operand must be a weak address");
     require(PointerRVType->getReferenceStorageReferent()->getCanonicalType() ==
-            SWI->getSrc()->getType().getSwiftRValueType(),
+            SWI->getSrc()->getType().getASTType(),
             "Store operand type and dest type mismatch");
   }
 
@@ -1715,9 +1715,7 @@ public:
     require(MU->getModule().getStage() == SILStage::Raw,
             "mark_uninitialized instruction can only exist in raw SIL");
     require(Src->getType().isAddress() ||
-                Src->getType()
-                    .getSwiftRValueType()
-                    ->getClassOrBoundGenericClass() ||
+                Src->getType().getClassOrBoundGenericClass() ||
                 Src->getType().getAs<SILBoxType>(),
             "mark_uninitialized must be an address, class, or box type");
     require(Src->getType() == MU->getType(),"operand and result type mismatch");
@@ -1878,7 +1876,7 @@ public:
             "Operand value should be an address");
     require(I->getOperand()->getType().is<BuiltinUnsafeValueBufferType>(),
             "Operand value should be a Builtin.UnsafeValueBuffer");
-    verifyOpenedArchetype(I, I->getValueType().getSwiftRValueType());
+    verifyOpenedArchetype(I, I->getValueType().getASTType());
   }
 
   void checkProjectValueBufferInst(ProjectValueBufferInst *I) {
@@ -1924,7 +1922,7 @@ public:
     if (auto *AEBI = dyn_cast<AllocExistentialBoxInst>(PEBI->getOperand())) {
       // The lowered type must be the properly-abstracted form of the AST type.
       SILType exType = AEBI->getExistentialType();
-      auto archetype = ArchetypeType::getOpened(exType.getSwiftRValueType());
+      auto archetype = ArchetypeType::getOpened(exType.getASTType());
 
       auto loweredTy = F.getModule().Types.getLoweredType(
                                       Lowering::AbstractionPattern(archetype),
@@ -2077,7 +2075,7 @@ public:
 
     if (TI->getModule().getStage() != SILStage::Lowered) {
       for (size_t i = 0, size = TI->getElements().size(); i < size; ++i) {
-        require(TI->getElement(i)->getType().getSwiftRValueType() ==
+        require(TI->getElement(i)->getType().getASTType() ==
                     ResTy.getElementType(i),
                 "Tuple element arguments do not match tuple type!");
       }
@@ -2260,7 +2258,7 @@ public:
     require(EI->getFieldNo() < operandTy->getNumElements(),
             "invalid field index for tuple_extract instruction");
     if (EI->getModule().getStage() != SILStage::Lowered) {
-      require(EI->getType().getSwiftRValueType() ==
+      require(EI->getType().getASTType() ==
                   operandTy.getElementType(EI->getFieldNo()),
               "type of tuple_extract does not match type of element");
     }
@@ -2303,7 +2301,7 @@ public:
     require(EI->getFieldNo() < fields.size(),
             "invalid field index for element_addr instruction");
     if (EI->getModule().getStage() != SILStage::Lowered) {
-      require(EI->getType().getSwiftRValueType() ==
+      require(EI->getType().getASTType() ==
                   CanType(fields[EI->getFieldNo()].getType()),
               "type of tuple_element_addr does not match type of element");
     }
@@ -2451,7 +2449,7 @@ public:
     auto params = methodTy->getParameters();
     SmallVector<SILParameterInfo, 4>
       dynParams(params.begin(), params.end() - 1);
-    dynParams.push_back(SILParameterInfo(selfType.getSwiftRValueType(),
+    dynParams.push_back(SILParameterInfo(selfType.getASTType(),
                                          params.back().getConvention()));
 
     auto results = methodTy->getResults();
@@ -2550,7 +2548,7 @@ public:
             "wrong function type representation");
 
     auto operandType = OMI->getOperand()->getType();
-    auto operandInstanceType = operandType.getSwiftRValueType();
+    auto operandInstanceType = operandType.getASTType();
     if (auto metatypeType = dyn_cast<MetatypeType>(operandInstanceType))
       operandInstanceType = metatypeType.getInstanceType();
 
@@ -2563,7 +2561,7 @@ public:
       require(isa<ArchetypeType>(operandInstanceType) ||
               operandInstanceType->isObjCExistentialType(),
               "operand type must be an archetype or self-conforming existential");
-      verifyOpenedArchetype(OMI, OMI->getType().getSwiftRValueType());
+      verifyOpenedArchetype(OMI, OMI->getType().getASTType());
     }
 
     // TODO: We should enforce that ObjC methods are dispatched on ObjC
@@ -2617,7 +2615,7 @@ public:
     require(OEI->getType().isAddress(),
             "open_existential_addr result must be an address");
 
-    auto archetype = getOpenedArchetypeOf(OEI->getType().getSwiftRValueType());
+    auto archetype = getOpenedArchetypeOf(OEI->getType().getASTType());
     require(archetype,
         "open_existential_addr result must be an opened existential archetype");
     require(OpenedArchetypes.getOpenedArchetypeDef(archetype) == OEI,
@@ -2757,7 +2755,7 @@ public:
                                               ExistentialRepresentation::Class),
             "open_existential_ref operand must be class existential");
 
-    CanType resultInstanceTy = OEI->getType().getSwiftRValueType();
+    CanType resultInstanceTy = OEI->getType().getASTType();
 
     require(OEI->getType().isObject(),
             "open_existential_ref result must be an address");
@@ -2779,7 +2777,7 @@ public:
                                               ExistentialRepresentation::Boxed),
             "open_existential_box operand must be boxed existential");
 
-    CanType resultInstanceTy = OEI->getType().getSwiftRValueType();
+    CanType resultInstanceTy = OEI->getType().getASTType();
 
     require(OEI->getType().isAddress(),
             "open_existential_box result must be an address");
@@ -2801,7 +2799,7 @@ public:
                                               ExistentialRepresentation::Boxed),
             "open_existential_box operand must be boxed existential");
 
-    CanType resultInstanceTy = OEI->getType().getSwiftRValueType();
+    CanType resultInstanceTy = OEI->getType().getASTType();
 
     require(!OEI->getType().isAddress(),
             "open_existential_box_value result must not be an address");
@@ -2871,7 +2869,7 @@ public:
     require(!OEI->getType().isAddress(),
             "open_existential_value result must not be an address");
 
-    auto archetype = getOpenedArchetypeOf(OEI->getType().getSwiftRValueType());
+    auto archetype = getOpenedArchetypeOf(OEI->getType().getASTType());
     require(archetype, "open_existential_value result must be an opened "
                        "existential archetype");
     require(OpenedArchetypes.getOpenedArchetypeDef(archetype) == OEI,
@@ -2906,7 +2904,7 @@ public:
             "existential type");
     
     // The lowered type must be the properly-abstracted form of the AST type.
-    auto archetype = ArchetypeType::getOpened(exType.getSwiftRValueType());
+    auto archetype = ArchetypeType::getOpened(exType.getASTType());
     
     auto loweredTy = F.getModule().Types.getLoweredType(
                                 Lowering::AbstractionPattern(archetype),
@@ -2936,7 +2934,7 @@ public:
             "init_existential_value result must not be an address");
     // The operand must be at the right abstraction level for the existential.
     SILType exType = IEI->getType();
-    auto archetype = ArchetypeType::getOpened(exType.getSwiftRValueType());
+    auto archetype = ArchetypeType::getOpened(exType.getASTType());
     auto loweredTy = F.getModule().Types.getLoweredType(
         Lowering::AbstractionPattern(archetype), IEI->getFormalConcreteType());
     requireSameType(
@@ -2957,7 +2955,7 @@ public:
 
   void checkInitExistentialRefInst(InitExistentialRefInst *IEI) {
     SILType concreteType = IEI->getOperand()->getType();
-    require(concreteType.getSwiftRValueType()->isBridgeableObjectType(),
+    require(concreteType.getASTType()->isBridgeableObjectType(),
             "init_existential_ref operand must be a class instance");
     require(IEI->getType().canUseExistentialRepresentation(F.getModule(),
                                      ExistentialRepresentation::Class,
@@ -2968,7 +2966,7 @@ public:
     
     // The operand must be at the right abstraction level for the existential.
     SILType exType = IEI->getType();
-    auto archetype = ArchetypeType::getOpened(exType.getSwiftRValueType());
+    auto archetype = ArchetypeType::getOpened(exType.getASTType());
     auto loweredTy = F.getModule().Types.getLoweredType(
                                        Lowering::AbstractionPattern(archetype),
                                        IEI->getFormalConcreteType());
@@ -3044,7 +3042,7 @@ public:
     }
 
     checkExistentialProtocolConformances(resultType,
-                                         operandType.getSwiftRValueType(),
+                                         operandType.getASTType(),
                                          I->getConformances());
     verifyOpenedArchetype(I, MetaTy.getInstanceType());
   }
@@ -3052,7 +3050,7 @@ public:
   void checkExistentialProtocolConformances(SILType resultType,
                                             CanType concreteType,
                                 ArrayRef<ProtocolConformanceRef> conformances) {
-    auto layout = resultType.getSwiftRValueType().getExistentialLayout();
+    auto layout = resultType.getASTType().getExistentialLayout();
     auto protocols = layout.getProtocols();
 
     require(conformances.size() == protocols.size(),
@@ -3091,8 +3089,8 @@ public:
     require(fromTy.isObject() && toTy.isObject(),
             "value checked cast src and dest must be objects");
 
-    auto fromCanTy = fromTy.getSwiftRValueType();
-    auto toCanTy = toTy.getSwiftRValueType();
+    auto fromCanTy = fromTy.getASTType();
+    auto toCanTy = toTy.getASTType();
 
     require(isOpaque || canUseScalarCheckedCastInstructions(F.getModule(),
                                                             fromCanTy, toCanTy),
@@ -3138,14 +3136,14 @@ public:
     verifyCheckedCast(/*exact*/ false,
                       CI->getOperand()->getType(),
                       CI->getType());
-    verifyOpenedArchetype(CI, CI->getType().getSwiftRValueType());
+    verifyOpenedArchetype(CI, CI->getType().getASTType());
   }
 
   void checkUnconditionalCheckedCastValueInst(
       UnconditionalCheckedCastValueInst *CI) {
     verifyCheckedCast(/*exact*/ false, CI->getOperand()->getType(),
                       CI->getType(), true);
-    verifyOpenedArchetype(CI, CI->getType().getSwiftRValueType());
+    verifyOpenedArchetype(CI, CI->getType().getASTType());
   }
 
   /// Verify if a given type is or contains an opened archetype or dynamic self.
@@ -3185,7 +3183,7 @@ public:
     verifyCheckedCast(CBI->isExact(),
                       CBI->getOperand()->getType(),
                       CBI->getCastType());
-    verifyOpenedArchetype(CBI, CBI->getCastType().getSwiftRValueType());
+    verifyOpenedArchetype(CBI, CBI->getCastType().getASTType());
 
     require(CBI->getSuccessBB()->args_size() == 1,
             "success dest of checked_cast_br must take one argument");
@@ -3212,7 +3210,7 @@ public:
   void checkCheckedCastValueBranchInst(CheckedCastValueBranchInst *CBI) {
     verifyCheckedCast(false, CBI->getOperand()->getType(), CBI->getCastType(),
                       true);
-    verifyOpenedArchetype(CBI, CBI->getCastType().getSwiftRValueType());
+    verifyOpenedArchetype(CBI, CBI->getCastType().getASTType());
 
     require(CBI->getSuccessBB()->args_size() == 1,
             "success dest of checked_cast_value_br must take one argument");
@@ -3302,7 +3300,7 @@ public:
   void checkRefToUnownedInst(RefToUnownedInst *I) {
     requireReferenceStorageCapableValue(I->getOperand(),
                                         "Operand of ref_to_unowned");
-    auto operandType = I->getOperand()->getType().getSwiftRValueType();
+    auto operandType = I->getOperand()->getType().getASTType();
     auto resultType = requireObjectType(UnownedStorageType, I,
                                         "Result of ref_to_unowned");
     require(resultType->isLoadable(ResilienceExpansion::Maximal),
@@ -3319,7 +3317,7 @@ public:
     require(operandType->isLoadable(ResilienceExpansion::Maximal),
             "unowned_to_ref requires unowned type to be loadable");
     requireReferenceStorageCapableValue(I, "Result of unowned_to_ref");
-    auto resultType = I->getType().getSwiftRValueType();
+    auto resultType = I->getType().getASTType();
     require(operandType.getReferentType() == resultType,
             "Operand of unowned_to_ref does not have the "
             "operand's type as its referent type");
@@ -3328,7 +3326,7 @@ public:
   void checkRefToUnmanagedInst(RefToUnmanagedInst *I) {
     requireReferenceStorageCapableValue(I->getOperand(),
                                         "Operand of ref_to_unmanaged");
-    auto operandType = I->getOperand()->getType().getSwiftRValueType();
+    auto operandType = I->getOperand()->getType().getASTType();
     auto resultType = requireObjectType(UnmanagedStorageType, I,
                                         "Result of ref_to_unmanaged");
     require(resultType.getReferentType() == operandType,
@@ -3341,7 +3339,7 @@ public:
                                          I->getOperand(),
                                          "Operand of unmanaged_to_ref");
     requireReferenceStorageCapableValue(I, "Result of unmanaged_to_ref");
-    auto resultType = I->getType().getSwiftRValueType();
+    auto resultType = I->getType().getASTType();
     require(operandType.getReferentType() == resultType,
             "Operand of unmanaged_to_ref does not have the "
             "operand's type as its referent type");
@@ -3382,12 +3380,12 @@ public:
 
     // Upcast from Optional<B> to Optional<A> is legal as long as B is a
     // subclass of A.
-    if (ToTy.getSwiftRValueType().getOptionalObjectType() &&
-        FromTy.getSwiftRValueType().getOptionalObjectType()) {
+    if (ToTy.getASTType().getOptionalObjectType() &&
+        FromTy.getASTType().getOptionalObjectType()) {
       ToTy = SILType::getPrimitiveObjectType(
-          ToTy.getSwiftRValueType().getOptionalObjectType());
+          ToTy.getASTType().getOptionalObjectType());
       FromTy = SILType::getPrimitiveObjectType(
-          FromTy.getSwiftRValueType().getOptionalObjectType());
+          FromTy.getASTType().getOptionalObjectType());
     }
 
     auto ToClass = ToTy.getClassOrBoundGenericClass();
@@ -3395,7 +3393,7 @@ public:
             "upcast must convert a class instance to a class type");
       if (ToClass->usesObjCGenericsModel()) {
         require(ToClass->getDeclaredTypeInContext()
-                  ->isBindableToSuperclassOf(FromTy.getSwiftRValueType()),
+                  ->isBindableToSuperclassOf(FromTy.getASTType()),
                 "upcast must cast to a superclass or an existential metatype");
       } else {
         require(ToTy.isExactSuperclassOf(FromTy),
@@ -3406,13 +3404,13 @@ public:
   void checkAddressToPointerInst(AddressToPointerInst *AI) {
     require(AI->getOperand()->getType().isAddress(),
             "address-to-pointer operand must be an address");
-    require(AI->getType().getSwiftRValueType()->isEqual(
+    require(AI->getType().getASTType()->isEqual(
                               AI->getType().getASTContext().TheRawPointerType),
             "address-to-pointer result type must be RawPointer");
   }
   
   void checkUncheckedRefCastInst(UncheckedRefCastInst *AI) {
-    verifyOpenedArchetype(AI, AI->getType().getSwiftRValueType());
+    verifyOpenedArchetype(AI, AI->getType().getASTType());
     require(AI->getOperand()->getType().isObject(),
             "unchecked_ref_cast operand must be a value");
     require(AI->getType().isObject(),
@@ -3436,7 +3434,7 @@ public:
   }
   
   void checkUncheckedAddrCastInst(UncheckedAddrCastInst *AI) {
-    verifyOpenedArchetype(AI, AI->getType().getSwiftRValueType());
+    verifyOpenedArchetype(AI, AI->getType().getASTType());
 
     require(AI->getOperand()->getType().isAddress(),
             "unchecked_addr_cast operand must be an address");
@@ -3445,7 +3443,7 @@ public:
   }
   
   void checkUncheckedTrivialBitCastInst(UncheckedTrivialBitCastInst *BI) {
-    verifyOpenedArchetype(BI, BI->getType().getSwiftRValueType());
+    verifyOpenedArchetype(BI, BI->getType().getASTType());
     require(BI->getOperand()->getType().isObject(),
             "unchecked_trivial_bit_cast must operate on a value");
     require(BI->getType().isObject(),
@@ -3455,7 +3453,7 @@ public:
   }
 
   void checkUncheckedBitwiseCastInst(UncheckedBitwiseCastInst *BI) {
-    verifyOpenedArchetype(BI, BI->getType().getSwiftRValueType());
+    verifyOpenedArchetype(BI, BI->getType().getASTType());
     require(BI->getOperand()->getType().isObject(),
             "unchecked_bitwise_cast must operate on a value");
     require(BI->getType().isObject(),
@@ -3463,23 +3461,22 @@ public:
   }
 
   void checkRefToRawPointerInst(RefToRawPointerInst *AI) {
-    require(AI->getOperand()->getType().getSwiftRValueType()
-              ->isAnyClassReferenceType(),
+    require(AI->getOperand()->getType().isAnyClassReferenceType(),
             "ref-to-raw-pointer operand must be a class reference or"
             " NativeObject");
-    require(AI->getType().getSwiftRValueType()->isEqual(
+    require(AI->getType().getASTType()->isEqual(
                             AI->getType().getASTContext().TheRawPointerType),
             "ref-to-raw-pointer result must be RawPointer");
   }
 
   void checkRawPointerToRefInst(RawPointerToRefInst *AI) {
-    verifyOpenedArchetype(AI, AI->getType().getSwiftRValueType());
+    verifyOpenedArchetype(AI, AI->getType().getASTType());
     require(AI->getType()
-              .getSwiftRValueType()->isBridgeableObjectType()
-            || AI->getType().getSwiftRValueType()->isEqual(
+              .getASTType()->isBridgeableObjectType()
+            || AI->getType().getASTType()->isEqual(
                              AI->getType().getASTContext().TheNativeObjectType),
         "raw-pointer-to-ref result must be a class reference or NativeObject");
-    require(AI->getOperand()->getType().getSwiftRValueType()->isEqual(
+    require(AI->getOperand()->getType().getASTType()->isEqual(
                             AI->getType().getASTContext().TheRawPointerType),
             "raw-pointer-to-ref operand must be NativeObject");
   }
@@ -3487,7 +3484,7 @@ public:
   void checkRefToBridgeObjectInst(RefToBridgeObjectInst *RI) {
     require(RI->getConverted()->getType().isObject(),
             "ref_to_bridge_object must convert from a value");
-    require(RI->getConverted()->getType().getSwiftRValueType()
+    require(RI->getConverted()->getType().getASTType()
               ->isBridgeableObjectType(),
             "ref_to_bridge_object must convert from a heap object ref");
     require(RI->getBitsOperand()->getType()
@@ -3498,13 +3495,13 @@ public:
   }
   
   void checkBridgeObjectToRefInst(BridgeObjectToRefInst *RI) {
-    verifyOpenedArchetype(RI, RI->getType().getSwiftRValueType());
+    verifyOpenedArchetype(RI, RI->getType().getASTType());
     require(RI->getConverted()->getType()
                == SILType::getBridgeObjectType(F.getASTContext()),
             "bridge_object_to_ref must take a BridgeObject");
     require(RI->getType().isObject(),
             "bridge_object_to_ref must produce a value");
-    require(RI->getType().getSwiftRValueType()->isBridgeableObjectType(),
+    require(RI->getType().getASTType()->isBridgeableObjectType(),
             "bridge_object_to_ref must produce a heap object reference");
   }
   void checkBridgeObjectToWordInst(BridgeObjectToWordInst *RI) {
@@ -3972,9 +3969,9 @@ public:
 
     require(DMBI->getMember().getDecl()->isObjC(), "method must be @objc");
     if (!DMBI->getMember().getDecl()->isInstanceMember()) {
-      require(operandType.getSwiftRValueType()->is<MetatypeType>(),
+      require(operandType.is<MetatypeType>(),
               "operand must have metatype type");
-      require(operandType.getSwiftRValueType()->castTo<MetatypeType>()
+      require(operandType.castTo<MetatypeType>()
                 ->getInstanceType()->mayHaveSuperclass(),
               "operand must have metatype of class or class-bound type");
     }
@@ -3985,8 +3982,8 @@ public:
 
     auto bbArgTy = DMBI->getHasMethodBB()->args_begin()[0]->getType();
     require(getDynamicMethodType(operandType, DMBI->getMember())
-              .getSwiftRValueType()
-              ->isBindableTo(bbArgTy.getSwiftRValueType()),
+              .getASTType()
+              ->isBindableTo(bbArgTy.getASTType()),
             "bb argument for dynamic_method_br must be of the method's type");
   }
 
@@ -3998,7 +3995,7 @@ public:
     
     require(PBSI->getType().isAddress(),
             "result must be an address");
-    auto captureTy = PBSI->getType().getSwiftRValueType();
+    auto captureTy = PBSI->getType().getASTType();
     require(storageTy->getCaptureType() == captureTy,
             "result must be the capture type of the @block_storage type");
   }
@@ -4098,7 +4095,7 @@ public:
             "objc_metatype_to_object must take an @objc metatype value");
     require(OMOI->getType().isObject(),
             "objc_metatype_to_object must produce a value");
-    require(OMOI->getType().getSwiftRValueType()->isAnyObject(),
+    require(OMOI->getType().getASTType()->isAnyObject(),
             "objc_metatype_to_object must produce an AnyObject value");
   }
 
@@ -4113,7 +4110,7 @@ public:
             "objc_metatype_to_object must take an @objc existential metatype value");
     require(OMOI->getType().isObject(),
             "objc_metatype_to_object must produce a value");
-    require(OMOI->getType().getSwiftRValueType()->isAnyObject(),
+    require(OMOI->getType().getASTType()->isAnyObject(),
             "objc_metatype_to_object must produce an AnyObject value");
   }
   

--- a/lib/SIL/TypeLowering.cpp
+++ b/lib/SIL/TypeLowering.cpp
@@ -1378,7 +1378,7 @@ TypeConverter::~TypeConverter() {
     // Destroy only the unique entries.
     CanType srcType = ti.first.OrigType;
     if (!srcType) continue;
-    CanType mappedType = ti.second->getLoweredType().getSwiftRValueType();
+    CanType mappedType = ti.second->getLoweredType().getASTType();
     if (srcType == mappedType || isa<InOutType>(srcType))
       ti.second->~TypeLowering();
   }
@@ -1454,7 +1454,7 @@ static CanTupleType getLoweredTupleType(TypeConverter &tc,
     // the original type of the element --- the actual archetype
     // doesn't matter, just the abstraction pattern.
     SILType silType = tc.getLoweredType(origEltType, substEltType);
-    CanType loweredSubstEltType = silType.getSwiftRValueType();
+    CanType loweredSubstEltType = silType.getASTType();
 
     changed = (changed || substEltType != loweredSubstEltType);
 
@@ -1477,7 +1477,7 @@ static CanType getLoweredOptionalType(TypeConverter &tc,
 
   CanType loweredObjectType =
       tc.getLoweredType(origType.getOptionalObjectType(), substObjectType)
-          .getSwiftRValueType();
+          .getASTType();
 
   // If the object type didn't change, we don't have to rebuild anything.
   if (loweredObjectType == substObjectType) {
@@ -1494,7 +1494,7 @@ static CanType getLoweredReferenceStorageType(TypeConverter &tc,
   CanType loweredReferentType =
     tc.getLoweredType(origType.getReferenceStorageReferentType(),
                       substType.getReferentType())
-      .getSwiftRValueType();
+      .getASTType();
 
   if (loweredReferentType == substType.getReferentType())
     return substType;
@@ -1664,7 +1664,7 @@ CanType TypeConverter::getLoweredRValueType(AbstractionPattern origType,
 }
 
 const TypeLowering &TypeConverter::getTypeLowering(SILType type) {
-  auto loweredType = type.getSwiftRValueType();
+  auto loweredType = type.getASTType();
   auto key = getTypeKey(AbstractionPattern(getCurGenericContext(), loweredType),
                         loweredType);
 
@@ -2000,7 +2000,7 @@ SILType TypeConverter::getSubstitutedStorageType(AbstractStorageDecl *value,
   }
 
   SILType silSubstType = getLoweredType(origType, substType).getAddressType();
-  substType = silSubstType.getSwiftRValueType();
+  substType = silSubstType.getASTType();
 
   // Type substitution preserves structural type structure, and the
   // type-of-reference is only different in the outermost structural
@@ -2044,7 +2044,7 @@ void TypeConverter::popGenericContext(CanGenericSignature sig) {
     // Destroy only the unique entries.
     CanType srcType = ti.first.OrigType;
     if (!srcType) continue;
-    CanType mappedType = ti.second->getLoweredType().getSwiftRValueType();
+    CanType mappedType = ti.second->getLoweredType().getASTType();
     if (srcType == mappedType)
       ti.second->~TypeLowering();
   }
@@ -2085,7 +2085,7 @@ CanSILFunctionType TypeConverter::getMaterializeForSetCallbackType(
     // selfMetatypeType.
     if (auto metatype = canSelfType->getAs<MetatypeType>()) {
       if (!metatype->hasRepresentation())
-        canSelfType = getLoweredType(metatype).getSwiftRValueType();
+        canSelfType = getLoweredType(metatype).getASTType();
     }
   }
 
@@ -2294,8 +2294,8 @@ TypeConverter::checkForABIDifferences(SILType type1, SILType type2,
   // Classes, class-constrained archetypes, and pure-ObjC existential types
   // all have single retainable pointer representation; optionality change
   // is allowed.
-  if (type1.getSwiftRValueType()->satisfiesClassConstraint() &&
-      type2.getSwiftRValueType()->satisfiesClassConstraint())
+  if (type1.getASTType()->satisfiesClassConstraint() &&
+      type2.getASTType()->satisfiesClassConstraint())
     return ABIDifference::Trivial;
 
   // Function parameters are ABI compatible if their differences are
@@ -2488,7 +2488,7 @@ TypeConverter::getInterfaceBoxTypeForCapture(ValueDecl *captured,
          ->getCanonicalType());
   }
   assert(contextBoxTy->getLayout()->getFields().size() == 1
-         && contextBoxTy->getFieldType(M, 0).getSwiftRValueType()
+         && contextBoxTy->getFieldType(M, 0).getASTType()
              == loweredContextType
          && "box field type doesn't match capture!");
 #endif
@@ -2534,19 +2534,19 @@ CanSILBoxType TypeConverter::getBoxTypeForEnumElement(SILType enumType,
 
   if (boxSignature == CanGenericSignature()) {
     auto eltIntfTy = elt->getArgumentInterfaceType();
-    auto boxVarTy = getLoweredType(eltIntfTy).getSwiftRValueType();
+    auto boxVarTy = getLoweredType(eltIntfTy).getASTType();
     auto layout = SILLayout::get(C, nullptr, SILField(boxVarTy, true));
     return SILBoxType::get(C, layout, {});
   }
 
   // Use the enum's signature for the box type.
-  auto boundEnum = enumType.getSwiftRValueType();
+  auto boundEnum = enumType.getASTType();
 
   // Lower the enum element's argument in the box's context.
   auto eltIntfTy = elt->getArgumentInterfaceType();
   GenericContextScope scope(*this, boxSignature);
   auto boxVarTy = getLoweredType(getAbstractionPattern(elt), eltIntfTy)
-                      .getSwiftRValueType();
+                      .getASTType();
   auto layout = SILLayout::get(C, boxSignature, SILField(boxVarTy, true));
 
   // Instantiate the layout with enum's substitution list.

--- a/lib/SILGen/ArgumentSource.cpp
+++ b/lib/SILGen/ArgumentSource.cpp
@@ -356,7 +356,7 @@ void ArgumentSource::forwardInto(SILGenFunction &SGF,
   // RValue about the formal type (by using the lowered type) because
   // we're emitting into an abstracted value, which RValue doesn't
   // really handle.
-  auto substLoweredType = destTL.getLoweredType().getSwiftRValueType();
+  auto substLoweredType = destTL.getLoweredType().getASTType();
   RValue(SGF, loc, substLoweredType, outputValue).forwardInto(SGF, loc, dest);
 }
 

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1120,7 +1120,7 @@ ManagedValue SILGenFunction::emitBridgedToNativeValue(SILLocation loc,
 ManagedValue SILGenFunction::emitBridgedToNativeError(SILLocation loc,
                                                   ManagedValue bridgedError) {
   // If the incoming error is non-optional, just do an existential erasure.
-  CanType bridgedErrorTy = bridgedError.getType().getSwiftRValueType();
+  auto bridgedErrorTy = bridgedError.getType().getASTType();
   if (!bridgedErrorTy.getOptionalObjectType()) {
     auto nativeErrorTy = SILType::getExceptionType(getASTContext());
 

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -668,7 +668,7 @@ ManagedValue SILGenBuilder::createOptionalSome(SILLocation loc,
   }
 
   SILValue tempResult = SGF.emitTemporaryAllocation(loc, optionalType);
-  RValue rvalue(SGF, loc, arg.getType().getSwiftRValueType(), arg);
+  RValue rvalue(SGF, loc, arg.getType().getASTType(), arg);
   ArgumentSource argValue(loc, std::move(rvalue));
   SGF.emitInjectOptionalValueInto(
       loc, std::move(argValue), tempResult,

--- a/lib/SILGen/SILGenBuiltin.cpp
+++ b/lib/SILGen/SILGenBuiltin.cpp
@@ -364,7 +364,7 @@ static ManagedValue emitBuiltinCastToNativeObject(SILGenFunction &SGF,
                                          SubstitutionMap substitutions,
                                          ArrayRef<ManagedValue> args,
                                          SGFContext C) {
-  CanType ty = args[0].getType().getSwiftRValueType();
+  auto ty = args[0].getType().getASTType();
   (void)ty;
   assert(ty->usesNativeReferenceCounting(ResilienceExpansion::Maximal) &&
          "Can only cast types that use native reference counting to native "

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -886,10 +886,10 @@ static SILValue getBehaviorInitStorageFn(SILGenFunction &SGF,
     
     auto initConstantTy = initFn->getLoweredType().castTo<SILFunctionType>();
     
-    auto param = SILParameterInfo(initTy.getSwiftRValueType(),
+    auto param = SILParameterInfo(initTy.getASTType(),
                         initTy.isAddress() ? ParameterConvention::Indirect_In
                                            : ParameterConvention::Direct_Owned);
-    auto result = SILResultInfo(storageTy.getSwiftRValueType(),
+    auto result = SILResultInfo(storageTy.getASTType(),
                               storageTy.isAddress() ? ResultConvention::Indirect
                                                     : ResultConvention::Owned);
     

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -126,7 +126,7 @@ getOptionalSomeValue(SILLocation loc, ManagedValue value,
   assert((optTL.isLoadable() || !silConv.useLoweredAddresses()) &&
          "Address-only optionals cannot use this");
   SILType optType = optTL.getLoweredType();
-  CanType formalOptType = optType.getSwiftRValueType();
+  auto formalOptType = optType.getASTType();
   (void)formalOptType;
 
   assert(formalOptType.getOptionalObjectType());
@@ -435,7 +435,7 @@ SILGenFunction::emitOptionalToOptional(SILLocation loc,
           return scope.exitAndBranch(loc, some);
         }
 
-        RValue R(*this, loc, noOptResultTy.getSwiftRValueType(), result);
+        RValue R(*this, loc, noOptResultTy.getASTType(), result);
         ArgumentSource resultValueRV(loc, std::move(R));
         emitInjectOptionalValueInto(loc, std::move(resultValueRV),
                                     finalResult.getValue(), resultTL);

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -398,7 +398,7 @@ public:
 
     auto boxType = SGF.SGM.Types
       .getContextBoxTypeForCapture(decl,
-                     SGF.getLoweredType(decl->getType()).getSwiftRValueType(),
+                     SGF.getLoweredType(decl->getType()).getASTType(),
                      SGF.F.getGenericEnvironment(),
                      /*mutable*/ true);
 
@@ -865,7 +865,7 @@ void EnumElementPatternInitialization::emitEnumMatch(
         // Reabstract to the substituted type, if needed.
         CanType substEltTy =
             value.getType()
-                .getSwiftRValueType()
+                .getASTType()
                 ->getTypeOfMember(SGF.SGM.M.getSwiftModule(), eltDecl,
                                   eltDecl->getArgumentInterfaceType())
                 ->getCanonicalType();

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -117,10 +117,10 @@ void SILGenFunction::emitDeallocatingDestructor(DestructorDecl *dd) {
   // Form a reference to the destroying destructor.
   SILDeclRef dtorConstant(dd, SILDeclRef::Kind::Destroyer);
   auto classTy = initialSelfValue->getType();
-  auto classDecl = classTy.getSwiftRValueType()->getAnyNominal();
+  auto classDecl = classTy.getASTType()->getAnyNominal();
   ManagedValue dtorValue;
   SILType dtorTy;
-  auto subMap = classTy.getSwiftRValueType()
+  auto subMap = classTy.getASTType()
     ->getContextSubstitutionMap(SGM.M.getSwiftModule(),
                                 classDecl);
   std::tie(dtorValue, dtorTy)

--- a/lib/SILGen/SILGenEpilog.cpp
+++ b/lib/SILGen/SILGenEpilog.cpp
@@ -61,7 +61,7 @@ static SILValue buildReturnValue(SILGenFunction &SGF, SILLocation loc,
 
   SmallVector<TupleTypeElt, 4> eltTypes;
   for (auto elt : directResults)
-    eltTypes.push_back(elt->getType().getSwiftRValueType());
+    eltTypes.push_back(elt->getType().getASTType());
   auto resultType = SILType::getPrimitiveObjectType(
     CanType(TupleType::get(eltTypes, SGF.getASTContext())));
   return SGF.B.createTuple(loc, resultType, directResults);

--- a/lib/SILGen/SILGenForeignError.cpp
+++ b/lib/SILGen/SILGenForeignError.cpp
@@ -74,8 +74,7 @@ static void emitStoreToForeignErrorSlot(SILGenFunction &SGF,
 
   // Okay, break down the components of SomePointer<SomeError?>.
   // TODO: this should really be an unlowered AST type?
-  CanType bridgedErrorPtrType =
-    foreignErrorSlot->getType().getSwiftRValueType();
+  auto bridgedErrorPtrType = foreignErrorSlot->getType().getASTType();
 
   PointerTypeKind ptrKind;
   CanType bridgedErrorProto =
@@ -132,7 +131,7 @@ namespace {
 
     SILValue emitBridged(SILGenFunction &SGF, SILLocation loc,
                          CanType bridgedErrorProto) const override {
-      auto nativeErrorType = NativeError->getType().getSwiftRValueType();
+      auto nativeErrorType = NativeError->getType().getASTType();
       assert(nativeErrorType == SGF.SGM.getASTContext().getExceptionType());
 
       SILValue bridgedError = SGF.emitNativeToBridgedError(loc,
@@ -314,7 +313,7 @@ emitResultIsZeroErrorCheck(SILGenFunction &SGF, SILLocation loc,
 
   SILValue resultValue =
     emitUnwrapIntegerResult(SGF, loc, result.getUnmanagedValue());
-  CanType resultType = resultValue->getType().getSwiftRValueType();
+  auto resultType = resultValue->getType().getASTType();
 
   if (!resultType->isBuiltinIntegerType(1)) {
     SILValue zero =

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -273,7 +273,7 @@ void SILGenFunction::emitCaptures(SILLocation loc,
         // in-place.
         // TODO: Use immutable box for immutable captures.
         auto boxTy = SGM.Types.getContextBoxTypeForCapture(vd,
-                                       vl.value->getType().getSwiftRValueType(),
+                                       vl.value->getType().getASTType(),
                                        F.getGenericEnvironment(),
                                        /*mutable*/ true);
         
@@ -506,7 +506,7 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
     auto argvTy = fnConv.getSILArgumentType(1);
 
     SILType unwrappedTy = argvTy;
-    if (Type innerTy = argvTy.getSwiftRValueType()->getOptionalObjectType()) {
+    if (Type innerTy = argvTy.getASTType()->getOptionalObjectType()) {
       auto canInnerTy = innerTy->getCanonicalType();
       unwrappedTy = SILType::getPrimitiveObjectType(canInnerTy);
     }
@@ -516,8 +516,8 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
     if (unwrappedTy != argv->getType()) {
       auto converted =
           emitPointerToPointer(mainClass, managedArgv,
-                               argv->getType().getSwiftRValueType(),
-                               unwrappedTy.getSwiftRValueType());
+                               argv->getType().getASTType(),
+                               unwrappedTy.getASTType());
       managedArgv = std::move(converted).getAsSingleValue(*this, mainClass);
     }
 
@@ -550,9 +550,9 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
     // return NSApplicationMain(C_ARGC, C_ARGV);
 
     SILParameterInfo argTypes[] = {
-      SILParameterInfo(argc->getType().getSwiftRValueType(),
+      SILParameterInfo(argc->getType().getASTType(),
                        ParameterConvention::Direct_Unowned),
-      SILParameterInfo(argv->getType().getSwiftRValueType(),
+      SILParameterInfo(argv->getType().getASTType(),
                        ParameterConvention::Direct_Unowned),
     };
     auto NSApplicationMainType = SILFunctionType::get(nullptr,
@@ -564,7 +564,7 @@ void SILGenFunction::emitArtificialTopLevel(ClassDecl *mainClass) {
                   ParameterConvention::Direct_Unowned,
                   argTypes,
                   /*yields*/ {},
-                  SILResultInfo(argc->getType().getSwiftRValueType(),
+                  SILResultInfo(argc->getType().getASTType(),
                                 ResultConvention::Unowned),
                   /*error result*/ None,
                   getASTContext());

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -229,7 +229,7 @@ ManagedValue LogicalPathComponent::materializeIntoTemporary(
   // If the RValue type has an openedExistential, then the RValue must be
   // materialized before allocating a temporary for the RValue type. In that
   // case, the RValue cannot be emitted directly into the temporary.
-  if (getTypeOfRValue().getSwiftRValueType()->hasOpenedExistential()) {
+  if (getTypeOfRValue().hasOpenedExistential()) {
     // Emit a 'get'.
     rvalue = std::move(*this).get(SGF, loc, base, SGFContext());
 
@@ -2719,7 +2719,7 @@ LValue SILGenFunction::emitPropertyLValue(SILLocation loc, ManagedValue base,
   SILGenLValue sgl(*this);
   LValue lv;
 
-  auto baseType = base.getType().getSwiftRValueType();
+  auto baseType = base.getType().getASTType();
   auto subMap = baseType->getContextSubstitutionMap(
       SGM.M.getSwiftModule(), ivar->getDeclContext());
 
@@ -3444,8 +3444,8 @@ void SILGenFunction::emitCopyLValueInto(SILLocation loc, LValue &&src,
   if (!dest->canPerformInPlaceInitialization())
     return skipPeephole();
   auto destAddr = dest->getAddressForInPlaceInitialization(*this, loc);
-  assert(src.getTypeOfRValue().getSwiftRValueType()
-           == destAddr->getType().getSwiftRValueType());
+  assert(src.getTypeOfRValue().getASTType()
+           == destAddr->getType().getASTType());
 
   auto srcAddr = emitAddressOfLValue(loc, std::move(src), AccessKind::Read)
                    .getUnmanagedValue();

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -1451,7 +1451,7 @@ emitReabstractedSubobject(SILGenFunction &SGF, SILLocation loc,
                           CanType substFormalType) {
   // Return if there's no abstraction.  (The first condition is just
   // a fast path.)
-  if (value.getType().getSwiftRValueType() == substFormalType ||
+  if (value.getType().getASTType() == substFormalType ||
       value.getType() == SGF.getLoweredType(substFormalType))
     return value;
 
@@ -1865,7 +1865,7 @@ void PatternMatchEmission::emitEnumElementDispatchWithOwnership(
     bool hasElt = false;
     if (elt->hasAssociatedValues()) {
       eltTy = src.getType().getEnumElementType(elt, SGF.SGM.M);
-      hasElt = !eltTy.getSwiftRValueType()->isVoid();
+      hasElt = !eltTy.getASTType()->isVoid();
     }
 
     ConsumableManagedValue eltCMV, origCMV;
@@ -2026,7 +2026,7 @@ void PatternMatchEmission::emitEnumElementDispatch(
     bool hasElt = false;
     if (elt->hasAssociatedValues()) {
       eltTy = src.getType().getEnumElementType(elt, SGF.SGM.M);
-      hasElt = !eltTy.getSwiftRValueType()->isVoid();
+      hasElt = !eltTy.getASTType()->isVoid();
     }
 
     ConsumableManagedValue eltCMV, origCMV;
@@ -2573,7 +2573,7 @@ static void emitDiagnoseOfUnexpectedEnumCaseValue(SILGenFunction &SGF,
   assert(value.getType().isTrivial(SGF.getModule()));
 
   // Get the enum type as an Any.Type value.
-  CanType switchedValueSwiftType = value.getType().getSwiftRValueType();
+  CanType switchedValueSwiftType = value.getType().getASTType();
   SILType metatypeType = SGF.getLoweredType(
       CanMetatypeType::get(switchedValueSwiftType,
                            MetatypeRepresentation::Thick));
@@ -2610,7 +2610,7 @@ static void emitDiagnoseOfUnexpectedEnumCase(SILGenFunction &SGF,
   }
 
   // Get the switched-upon value's type.
-  CanType switchedValueSwiftType = value.getType().getSwiftRValueType();
+  CanType switchedValueSwiftType = value.getType().getASTType();
   SILType metatypeType = SGF.getLoweredType(
       CanMetatypeType::get(switchedValueSwiftType,
                            MetatypeRepresentation::Thick));

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2077,7 +2077,7 @@ ResultPlanner::planTupleIntoDirectResult(AbstractionPattern innerOrigType,
       auto someDecl = SGF.getASTContext().getOptionalSomeDecl();
       SILType outerObjectType =
           SGF.getSILType(outerResult).getOptionalObjectType();
-      SILResultInfo outerObjectResult(outerObjectType.getSwiftRValueType(),
+      SILResultInfo outerObjectResult(outerObjectType.getASTType(),
                                       outerResult.getConvention());
 
       // Plan to leave the tuple elements as a single direct outer result.
@@ -2121,7 +2121,7 @@ ResultPlanner::planTupleIntoDirectResult(AbstractionPattern innerOrigType,
   for (auto eltIndex : indices(innerSubstType.getElementTypes())) {
     auto outerEltType =
         SGF.getSILType(outerResult).getTupleElementType(eltIndex);
-    SILResultInfo outerEltResult(outerEltType.getSwiftRValueType(),
+    SILResultInfo outerEltResult(outerEltType.getASTType(),
                                  outerResult.getConvention());
 
     planIntoDirectResult(innerOrigType.getTupleElementType(eltIndex),
@@ -2185,7 +2185,7 @@ ResultPlanner::planScalarIntoIndirectResult(AbstractionPattern innerOrigType,
   assert(!outerOrigType.isTuple());
 
   bool hasAbstractionDifference =
-    (innerResult.getType() != outerResultAddr->getType().getSwiftRValueType());
+    (innerResult.getType() != outerResultAddr->getType().getASTType());
 
   // If the inner result is indirect, we need some memory to emit it into.
   if (SGF.silConv.isSILIndirect(innerResult)) {
@@ -2322,7 +2322,7 @@ ResultPlanner::planScalarFromIndirectResult(AbstractionPattern innerOrigType,
   assert(SGF.silConv.isSILIndirect(outerResult) == bool(optOuterResultAddr));
 
   bool hasAbstractionDifference =
-    (innerResultAddr->getType().getSwiftRValueType() != outerResult.getType());
+    (innerResultAddr->getType().getASTType() != outerResult.getType());
 
   // The outer result can be indirect, and it doesn't necessarily have an
   // abstraction difference.  Note that we should only end up in this path

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -397,7 +397,7 @@ static void emitCaptureArguments(SILGenFunction &SGF,
     // the captured value.
     auto type = getVarTypeInCaptureContext();
     auto boxTy = SGF.SGM.Types.getContextBoxTypeForCapture(VD,
-                               SGF.getLoweredType(type).getSwiftRValueType(),
+                               SGF.getLoweredType(type).getASTType(),
                                SGF.F.getGenericEnvironment(), /*mutable*/ true);
     SILValue box = SGF.F.begin()->createFunctionArgument(
         SILType::getPrimitiveObjectType(boxTy), VD);

--- a/lib/SILGen/Scope.cpp
+++ b/lib/SILGen/Scope.cpp
@@ -56,7 +56,7 @@ static void lifetimeExtendAddressOnlyRValueSubValues(
     assert(v->getType().isAddressOnly(SGF.getModule()) &&
            "RValue invariants imply that all RValue subtypes that are "
            "addresses must be address only.");
-    auto boxTy = SILBoxType::get(v->getType().getSwiftRValueType());
+    auto boxTy = SILBoxType::get(v->getType().getASTType());
     SILValue box = SGF.B.createAllocBox(loc, boxTy);
     SILValue addr = SGF.B.createProjectBox(loc, box, 0);
     SGF.B.createCopyAddr(loc, v, addr, IsTake, IsInitialization);

--- a/lib/SILOptimizer/Analysis/DestructorAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/DestructorAnalysis.cpp
@@ -27,10 +27,10 @@ using namespace swift;
 ///  * is a value type that implements the _DestructorSafeContainer protocol and
 ///    whose type parameters are safe types T1...Tn.
 bool DestructorAnalysis::mayStoreToMemoryOnDestruction(SILType T) {
-  bool IsSafe = isSafeType(T.getSwiftRValueType());
+  bool IsSafe = isSafeType(T.getASTType());
   DEBUG(llvm::dbgs() << " DestructorAnalysis::mayStoreToMemoryOnDestruction is"
                      << (IsSafe ? " false: " : " true: "));
-  DEBUG(T.getSwiftRValueType()->print(llvm::errs()));
+  DEBUG(T.getASTType()->print(llvm::errs()));
   DEBUG(llvm::errs() << "\n");
   return !IsSafe;
 }

--- a/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/EscapeAnalysis.cpp
@@ -1035,7 +1035,7 @@ static bool mayContainReference(SILType Ty, SILModule *Mod) {
   if (Ty.hasReferenceSemantics())
     return true;
 
-  if (Ty.getSwiftRValueType() == Mod->getASTContext().TheRawPointerType)
+  if (Ty.getASTType() == Mod->getASTContext().TheRawPointerType)
     return true;
 
   if (auto *Str = Ty.getStructOrBoundGenericStruct()) {

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -371,7 +371,7 @@ computeNewArgInterfaceTypes(SILFunction *F,
       convention = param.isGuaranteed() ? ParameterConvention::Direct_Guaranteed
                                         : ParameterConvention::Direct_Owned;
     }
-    OutTys.push_back(SILParameterInfo(paramBoxedTy.getSwiftRValueType(),
+    OutTys.push_back(SILParameterInfo(paramBoxedTy.getASTType(),
                                       convention));
   }
 }

--- a/lib/SILOptimizer/IPO/GlobalOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalOpt.cpp
@@ -261,7 +261,7 @@ static SILFunction *getGlobalGetterFunction(SILModule &M,
   auto refType = M.Types.getLoweredType(varDecl->getInterfaceType());
 
   // Function takes no arguments and returns refType
-  SILResultInfo Results[] = { SILResultInfo(refType.getSwiftRValueType(),
+  SILResultInfo Results[] = { SILResultInfo(refType.getASTType(),
                                             ResultConvention::Owned) };
   SILFunctionType::ExtInfo EInfo;
   EInfo = EInfo.withRepresentation(SILFunctionType::Representation::Thin);

--- a/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
@@ -346,7 +346,7 @@ void GlobalPropertyOpt::scanInstruction(swift::SILInstruction *Inst) {
       return;
     }
   } else if (auto *TI = dyn_cast<TupleInst>(Inst)) {
-    if (isTupleWithArray(TI->getType().getSwiftRValueType())) {
+    if (isTupleWithArray(TI->getType().getASTType())) {
       // Add dependencies from array elements to the tuple itself.
       for (Operand &Op : TI->getAllOperands()) {
         SILValue V = Op.get();
@@ -379,7 +379,7 @@ void GlobalPropertyOpt::scanInstruction(swift::SILInstruction *Inst) {
   // the instruction value to false.
   for (auto result : Inst->getResults()) {
     SILType Type = result->getType();
-    if (isArrayType(Type) || isTupleWithArray(Type.getSwiftRValueType())) {
+    if (isArrayType(Type) || isTupleWithArray(Type.getASTType())) {
       DEBUG(llvm::dbgs() << "      value could be non-native array: "
                          << *result);
       setNotNative(getValueEntry(result));
@@ -400,7 +400,7 @@ void GlobalPropertyOpt::scanInstructions() {
       for (auto *BBArg : BB.getArguments()) {
         bool hasPreds = false;
         SILType Type = BBArg->getType();
-        if (isArrayType(Type) || isTupleWithArray(Type.getSwiftRValueType())) {
+        if (isArrayType(Type) || isTupleWithArray(Type.getASTType())) {
           for (auto *Pred : BB.getPredecessorBlocks()) {
             hasPreds = true;
             auto *Term = Pred->getTerminator();

--- a/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
+++ b/lib/SILOptimizer/LoopTransforms/COWArrayOpt.cpp
@@ -1394,11 +1394,11 @@ bool COWArrayOpt::hasLoopOnlyDestructorSafeArrayOperations() {
         // Checking
         // that all types are the same make guarantees that this cannot happen.
         if (SameTy.isNull()) {
-          SameTy = Sem.getSelf()->getType().getSwiftRValueType();
+          SameTy = Sem.getSelf()->getType().getASTType();
           continue;
         }
         
-        if (Sem.getSelf()->getType().getSwiftRValueType() != SameTy) {
+        if (Sem.getSelf()->getType().getASTType() != SameTy) {
           DEBUG(llvm::dbgs() << "    (NO) mismatching array types\n");
           return ReturnWithCleanup(false);
         }

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -463,7 +463,7 @@ unsigned OpaqueStorageAllocation::insertIndirectReturnArgs() {
         ParamDecl(VarDecl::Specifier::InOut, SourceLoc(), SourceLoc(),
                   ctx.getIdentifier("$return_value"), SourceLoc(),
                   ctx.getIdentifier("$return_value"),
-                  bodyResultTy.getSwiftRValueType(), pass.F->getDeclContext());
+                  bodyResultTy.getASTType(), pass.F->getDeclContext());
 
     pass.F->begin()->insertFunctionArgument(argIdx,
                                             bodyResultTy.getAddressType(),

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollector.h
@@ -73,7 +73,7 @@ public:
   SILInstruction *getFunctionEntryPoint() const;
 
   CanType getType() const {
-    return MemorySILType.getSwiftRValueType();
+    return MemorySILType.getASTType();
   }
 
   SingleValueInstruction *getAddress() const {

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.h
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.h
@@ -82,7 +82,7 @@ public:
   /// Return the first instruction of the function containing the memory object.
   SILInstruction *getFunctionEntryPoint() const;
 
-  CanType getType() const { return MemorySILType.getSwiftRValueType(); }
+  CanType getType() const { return MemorySILType.getASTType(); }
 
   SingleValueInstruction *getAddress() const {
     if (isa<MarkUninitializedInst>(MemoryInst) ||

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -105,7 +105,7 @@ static void LowerAssignInstruction(SILBuilderWithScope &B, AssignInst *Inst,
     B.createStore(Loc, Src, Inst->getDest(), StoreOwnershipQualifier::Init);
 
     auto MetatypeTy = CanMetatypeType::get(
-        Inst->getDest()->getType().getSwiftRValueType(),
+        Inst->getDest()->getType().getASTType(),
         MetatypeRepresentation::Thick);
     auto SILMetatypeTy = SILType::getPrimitiveObjectType(MetatypeTy);
     SILValue Metatype = B.createValueMetatype(Loc, SILMetatypeTy, Pointer);
@@ -1962,7 +1962,7 @@ void LifetimeChecker::processUninitializedRelease(SILInstruction *Release,
         Pointer = B.createLoad(Loc, Pointer, LoadOwnershipQualifier::Take);
 
       auto MetatypeTy = CanMetatypeType::get(
-          TheMemory.MemorySILType.getSwiftRValueType(),
+          TheMemory.MemorySILType.getASTType(),
           MetatypeRepresentation::Thick);
       auto SILMetatypeTy = SILType::getPrimitiveObjectType(MetatypeTy);
       SILValue Metatype;

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1496,7 +1496,7 @@ visitClassifyBridgeObjectInst(ClassifyBridgeObjectInst *CBOI) {
   if (!URC)
     return nullptr;
 
-  auto type = URC->getOperand()->getType().getSwiftRValueType();
+  auto type = URC->getOperand()->getType().getASTType();
   if (ClassDecl *cd = type->getClassOrBoundGenericClass()) {
     if (!cd->isObjC()) {
       auto int1Ty = SILType::getBuiltinIntegerType(1, Builder.getASTContext());

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -642,7 +642,7 @@ SILFunction *PromotedParamCloner::initCloned(SILFunction *Orig,
                                             OrigFTI->getGenericSignature());
         paramTy = boxTy->getFieldType(Orig->getModule(), 0);
       }
-      auto promotedParam = SILParameterInfo(paramTy.getSwiftRValueType(),
+      auto promotedParam = SILParameterInfo(paramTy.getASTType(),
                                   ParameterConvention::Indirect_InoutAliasable);
       ClonedInterfaceArgTys.push_back(promotedParam);
     } else {

--- a/lib/SILOptimizer/Transforms/ArrayElementValuePropagation.cpp
+++ b/lib/SILOptimizer/Transforms/ArrayElementValuePropagation.cpp
@@ -324,15 +324,15 @@ public:
       assert(AppendContentsOf && "Must be AppendContentsOf call");
 
       NominalTypeDecl *AppendSelfArray = AppendContentsOf.getSelf()->getType().
-        getSwiftRValueType()->getAnyNominal();
+        getASTType()->getAnyNominal();
 
       // In case if it's not an Array, but e.g. an ContiguousArray
       if (AppendSelfArray != Ctx.getArrayDecl())
         continue;
 
       SILType ArrayType = Repl.Array->getType();
-      auto *NTD = ArrayType.getSwiftRValueType()->getAnyNominal();
-      SubstitutionMap ArraySubMap = ArrayType.getSwiftRValueType()
+      auto *NTD = ArrayType.getASTType()->getAnyNominal();
+      SubstitutionMap ArraySubMap = ArrayType.getASTType()
         ->getContextSubstitutionMap(M.getSwiftModule(), NTD);
       
       GenericSignature *Sig = NTD->getGenericSignature();

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -741,7 +741,7 @@ bool CSE::processOpenExistentialRef(OpenExistentialRefInst *Inst, ValueBase *V,
 
       // Check if the result type depends on this specific opened existential.
       auto ResultDependsOnOldOpenedArchetype =
-          CandidateResult->getType().getSwiftRValueType().findIf(
+          CandidateResult->getType().getASTType().findIf(
               [&OldOpenedArchetype](Type t) -> bool {
                 return (CanType(t) == OldOpenedArchetype);
               });

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -324,14 +324,14 @@ static bool usesGenerics(SILFunction *F,
         if (&BB != &*F->begin()) {
           // Scan types of all BB arguments. Ignore the entry BB, because
           // it is handled in a special way.
-           Arg->getType().getSwiftRValueType().visit(FindArchetypesAndGenericTypes);
+           Arg->getType().getASTType().visit(FindArchetypesAndGenericTypes);
            if (UsesGenerics)
              return UsesGenerics;
         }
       }
       // Scan types of all operands.
       for (auto &Op : I.getAllOperands()) {
-        Op.get()->getType().getSwiftRValueType().visit(FindArchetypesAndGenericTypes);
+        Op.get()->getType().getASTType().visit(FindArchetypesAndGenericTypes);
       }
       // Scan all substitutions of apply instructions.
       if (auto AI = ApplySite::isa(&I)) {
@@ -350,7 +350,7 @@ static bool usesGenerics(SILFunction *F,
 
       // Scan the result type of the instruction.
       for (auto V : I.getResults()) {
-        V->getType().getSwiftRValueType().visit(FindArchetypesAndGenericTypes);
+        V->getType().getASTType().visit(FindArchetypesAndGenericTypes);
       }
 
       if (UsesGenerics)
@@ -521,7 +521,7 @@ void FunctionSignatureTransformDescriptor::computeOptimizedArgInterface(
       DEBUG(llvm::dbgs() << "                " << Ty << "\n");
       // If Ty is trivial, just pass it directly.
       if (Ty.isTrivial(AD.Arg->getModule())) {
-        SILParameterInfo NewInfo(Ty.getSwiftRValueType(),
+        SILParameterInfo NewInfo(Ty.getASTType(),
                                  ParameterConvention::Direct_Unowned);
         Out.push_back(NewInfo);
         continue;
@@ -538,7 +538,7 @@ void FunctionSignatureTransformDescriptor::computeOptimizedArgInterface(
           llvm_unreachable("Unknown parameter convention transformation");
         }
       }
-      SILParameterInfo NewInfo(Ty.getSwiftRValueType(), ParameterConvention);
+      SILParameterInfo NewInfo(Ty.getASTType(), ParameterConvention);
       Out.push_back(NewInfo);
     }
     return;
@@ -936,7 +936,7 @@ bool FunctionSignatureTransform::DeadArgumentAnalyzeParameters() {
     bool HasNonTypeDeadArguments = false;
     for (auto &AD : TransformDescriptor.ArgumentDescList) {
       if (AD.IsEntirelyDead &&
-          !isa<AnyMetatypeType>(AD.Arg->getType().getSwiftRValueType())) {
+          !isa<AnyMetatypeType>(AD.Arg->getType().getASTType())) {
         HasNonTypeDeadArguments = true;
         break;
       }
@@ -1228,7 +1228,7 @@ bool FunctionSignatureTransform::ArgumentExplosionAnalyzeParameters() {
     }
 
     // Explosion of generic parameters is not supported yet.
-    if (A.Arg->getType().getSwiftRValueType()->hasArchetype())
+    if (A.Arg->getType().hasArchetype())
       continue;
 
     A.ProjTree.computeUsesAndLiveness(A.Arg);

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.h
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.h
@@ -108,7 +108,7 @@ struct ArgumentDescriptor {
     if (Arg->getType().isObject())
       return true;
     // @in arguments of generic types can be processed.
-    if (Arg->getType().getSwiftRValueType()->hasArchetype() &&
+    if (Arg->getType().hasArchetype() &&
         Arg->getType().isAddress() &&
         (Arg->hasConvention(SILArgumentConvention::Indirect_In) ||
          Arg->hasConvention(SILArgumentConvention::Indirect_In_Guaranteed)))

--- a/lib/SILOptimizer/Transforms/Outliner.cpp
+++ b/lib/SILOptimizer/Transforms/Outliner.cpp
@@ -278,18 +278,18 @@ CanSILFunctionType BridgedProperty::getOutlinedFunctionType(SILModule &M) {
   SmallVector<SILParameterInfo, 4> Parameters;
   if (auto *Load = dyn_cast<LoadInst>(FirstInst))
     Parameters.push_back(
-      SILParameterInfo(Load->getType().getSwiftRValueType(),
+      SILParameterInfo(Load->getType().getASTType(),
                        ParameterConvention::Indirect_In_Guaranteed));
   else
     Parameters.push_back(SILParameterInfo(cast<ObjCMethodInst>(FirstInst)
                                               ->getOperand()
                                               ->getType()
-                                              .getSwiftRValueType(),
+                                              .getASTType(),
                                           ParameterConvention::Direct_Unowned));
   SmallVector<SILResultInfo, 4> Results;
 
   Results.push_back(SILResultInfo(
-                      switchInfo.Br->getArg(0)->getType().getSwiftRValueType(),
+                      switchInfo.Br->getArg(0)->getType().getASTType(),
                       ResultConvention::Owned));
   auto ExtInfo =
       SILFunctionType::ExtInfo(SILFunctionType::Representation::Thin,
@@ -477,7 +477,7 @@ static bool matchSwitch(SwitchInfo &SI, SILInstruction *Inst,
     return false;
 
   // Check that we call the _unconditionallyBridgeFromObjectiveC witness.
-  auto NativeType = Apply->getType().getSwiftRValueType();
+  auto NativeType = Apply->getType().getASTType();
   auto *BridgeFun = FunRef->getReferencedFunction();
   auto *SwiftModule = BridgeFun->getModule().getSwiftModule();
   auto bridgeWitness = getBridgeFromObjectiveC(NativeType, SwiftModule);
@@ -763,7 +763,7 @@ BridgedArgument BridgedArgument::match(unsigned ArgIdx, SILValue Arg,
   }
 
   // Make sure we are calling the actual bridge witness.
-  auto NativeType = BridgedValue->getType().getSwiftRValueType();
+  auto NativeType = BridgedValue->getType().getASTType();
   auto *BridgeFun = FunRef->getReferencedFunction();
   auto *SwiftModule = BridgeFun->getModule().getSwiftModule();
   auto bridgeWitness = getBridgeToObjectiveC(NativeType, SwiftModule);
@@ -803,7 +803,7 @@ public:
   operator bool() { return switchInfo.SomeBB != nullptr; }
 
   CanType getReturnType() {
-    return switchInfo.Br->getArg(0)->getType().getSwiftRValueType();
+    return switchInfo.Br->getArg(0)->getType().getASTType();
   }
 
   /// Outline the return value bridging blocks.
@@ -1092,7 +1092,7 @@ CanSILFunctionType ObjCMethodCall::getOutlinedFunctionType(SILModule &M) {
       Parameters.push_back(SILParameterInfo(BridgedArguments[BridgedArgIdx]
                                                 .bridgedValue()
                                                 ->getType()
-                                                .getSwiftRValueType(),
+                                                .getASTType(),
                                             ParameterConvention::Direct_Owned));
       ++BridgedArgIdx;
     } else {

--- a/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
@@ -144,8 +144,8 @@ bool ReleaseDevirtualizer::createDeallocCall(SILType AllocType,
     return false;
 
   CanSILFunctionType DeallocType = Dealloc->getLoweredFunctionType();
-  auto *NTD = AllocType.getSwiftRValueType()->getAnyNominal();
-  auto AllocSubMap = AllocType.getSwiftRValueType()
+  auto *NTD = AllocType.getASTType()->getAnyNominal();
+  auto AllocSubMap = AllocType.getASTType()
     ->getContextSubstitutionMap(M.getSwiftModule(), NTD);
 
   DeallocType = DeallocType->substGenericArgs(M, AllocSubMap);

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -93,7 +93,7 @@ static FullApplySite speculateMonomorphicTarget(FullApplySite AI,
   if (!canDevirtualizeClassMethod(AI, SubType))
     return FullApplySite();
 
-  if (SubType.getSwiftRValueType()->hasDynamicSelfType())
+  if (SubType.getASTType()->hasDynamicSelfType())
     return FullApplySite();
 
   // Create a diamond shaped control flow and a checked_cast_branch
@@ -467,7 +467,7 @@ static bool tryToSpeculateTarget(FullApplySite AI, ClassHierarchyAnalysis *CHA,
 
     auto ClassOrMetatypeType = ClassType;
     if (auto EMT = SubType.getAs<AnyMetatypeType>()) {
-      auto InstTy = ClassType.getSwiftRValueType();
+      auto InstTy = ClassType.getASTType();
       auto *MetaTy = MetatypeType::get(InstTy, EMT->getRepresentation());
       auto CanMetaTy = CanMetatypeType(MetaTy);
       ClassOrMetatypeType = SILType::getPrimitiveObjectType(CanMetaTy);

--- a/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
+++ b/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
@@ -77,7 +77,7 @@ class BugReducerTester : public SILFunctionTransform {
     auto EmptyTupleCanType = getFunction()
                                  ->getModule()
                                  .Types.getEmptyTupleType()
-                                 .getSwiftRValueType();
+                                 .getASTType();
     ResultInfoArray.push_back(
         SILResultInfo(EmptyTupleCanType, ResultConvention::Unowned));
     auto FuncType = SILFunctionType::get(

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -207,7 +207,7 @@ SILInstruction *CastOptimizer::optimizeBridgedObjCToSwiftCast(
   SILValue InOutOptionalParam;
   if (isConditional) {
     // Create a temporary
-    OptionalTy = OptionalType::get(Dest->getType().getSwiftRValueType())
+    OptionalTy = OptionalType::get(Dest->getType().getASTType())
                      ->getImplementationType()
                      ->getCanonicalType();
     Tmp = Builder.createAllocStack(Loc,
@@ -314,14 +314,14 @@ static bool canOptimizeCast(const swift::Type &BridgedTargetTy,
     return true;
   }
   // check if it is a bridgeable CF type
-  if (ConvTy.getSwiftRValueType() ==
+  if (ConvTy.getASTType() ==
       getNSBridgedClassOfCFClass(M.getSwiftModule(),
-                                 DestTy.getSwiftRValueType())) {
+                                 DestTy.getASTType())) {
     return true;
   }
-  if (DestTy.getSwiftRValueType() ==
+  if (DestTy.getASTType() ==
       getNSBridgedClassOfCFClass(M.getSwiftModule(),
-                                 ConvTy.getSwiftRValueType())) {
+                                 ConvTy.getASTType())) {
     return true;
   }
   // All else failed - can't optimize this case
@@ -588,12 +588,12 @@ SILInstruction *CastOptimizer::optimizeBridgedSwiftToObjCCast(
         CastedValue = SILValue(
             Builder.createUnconditionalCheckedCast(Loc, NewAI, DestTy));
       }
-    } else if (ConvTy.getSwiftRValueType() ==
+    } else if (ConvTy.getASTType() ==
                    getNSBridgedClassOfCFClass(M.getSwiftModule(),
-                                              DestTy.getSwiftRValueType()) ||
-               DestTy.getSwiftRValueType() ==
+                                              DestTy.getASTType()) ||
+               DestTy.getASTType() ==
                    getNSBridgedClassOfCFClass(M.getSwiftModule(),
-                                              ConvTy.getSwiftRValueType())) {
+                                              ConvTy.getASTType())) {
       // Handle NS <-> CF toll-free bridging here.
       CastedValue =
           SILValue(Builder.createUncheckedRefCast(Loc, NewAI, DestTy));
@@ -1064,7 +1064,7 @@ SILInstruction *CastOptimizer::optimizeCheckedCastAddrBranchInst(
       if (MI) {
         if (SuccessBB->getSinglePredecessorBlock() &&
             canUseScalarCheckedCastInstructions(
-                Inst->getModule(), MI->getType().getSwiftRValueType(),
+                Inst->getModule(), MI->getType().getASTType(),
                 Inst->getTargetType())) {
           SILBuilderWithScope B(Inst);
           auto NewI = B.createCheckedCastBranch(
@@ -1174,7 +1174,7 @@ CastOptimizer::optimizeCheckedCastBranchInst(CheckedCastBranchInst *Inst) {
           return nullptr;
         // Get the metatype of this type.
         auto EMT = EmiTy.castTo<AnyMetatypeType>();
-        auto *MetaTy = MetatypeType::get(LoweredConcreteTy.getSwiftRValueType(),
+        auto *MetaTy = MetatypeType::get(LoweredConcreteTy.getASTType(),
                                          EMT->getRepresentation());
         auto CanMetaTy = CanTypeWrapper<MetatypeType>(MetaTy);
         auto SILMetaTy = SILType::getPrimitiveObjectType(CanMetaTy);
@@ -1300,8 +1300,8 @@ ValueBase *CastOptimizer::optimizeUnconditionalCheckedCastInst(
   SILBuilderWithScope Builder(Inst);
 
   // Try to apply the bridged casts optimizations
-  auto SourceType = LoweredSourceType.getSwiftRValueType();
-  auto TargetType = LoweredTargetType.getSwiftRValueType();
+  auto SourceType = LoweredSourceType.getASTType();
+  auto TargetType = LoweredTargetType.getASTType();
   auto Src = Inst->getOperand();
   auto NewI = optimizeBridgedCasts(Inst, CastConsumptionKind::CopyOnSuccess,
                                    false, Src, SILValue(), SourceType,
@@ -1328,8 +1328,8 @@ ValueBase *CastOptimizer::optimizeUnconditionalCheckedCastInst(
 
   auto Result = emitSuccessfulScalarUnconditionalCast(
       Builder, Mod.getSwiftModule(), Loc, Op, LoweredTargetType,
-      LoweredSourceType.getSwiftRValueType(),
-      LoweredTargetType.getSwiftRValueType(), Inst);
+      LoweredSourceType.getASTType(),
+      LoweredTargetType.getASTType(), Inst);
 
   if (!Result) {
     // No optimization was possible.

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -226,7 +226,7 @@ SILValue swift::getInstanceWithExactDynamicType(SILValue S, SILModule &M,
     S = stripCasts(S);
 
     if (isa<AllocRefInst>(S) || isa<MetatypeInst>(S)) {
-      if (S->getType().getSwiftRValueType()->hasDynamicSelfType())
+      if (S->getType().getASTType()->hasDynamicSelfType())
         return SILValue();
       return S;
     }
@@ -570,7 +570,7 @@ DevirtualizationResult swift::devirtualizeClassMethod(FullApplySite AI,
 
   SmallVector<Substitution, 4> Subs;
   getSubstitutionsForCallee(Mod, GenCalleeType,
-                            ClassOrMetatypeType.getSwiftRValueType(),
+                            ClassOrMetatypeType.getASTType(),
                             AI, Subs);
   CanSILFunctionType SubstCalleeType = GenCalleeType;
   if (GenCalleeType->isPolymorphic())
@@ -922,9 +922,7 @@ devirtualizeWitnessMethod(ApplySite AI, SILFunction *F,
     SAI = Builder.createTryApply(Loc, FRI, NewSubs, Arguments,
                                  TAI->getNormalBB(), TAI->getErrorBB());
   if (auto *PAI = dyn_cast<PartialApplyInst>(AI)) {
-    auto PartialApplyConvention = PAI->getType()
-                                      .getSwiftRValueType()
-                                      ->getAs<SILFunctionType>()
+    auto PartialApplyConvention = PAI->getType().getAs<SILFunctionType>()
                                       ->getCalleeConvention();
     auto *NewPAI = Builder.createPartialApply(
         Loc, FRI, NewSubs, Arguments, PartialApplyConvention);

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -552,7 +552,7 @@ SILValue swift::castValueToABICompatibleType(SILBuilder *B, SILLocation Loc,
 
   // Src is not optional, but dest is optional.
   if (!OptionalSrcTy && OptionalDestTy) {
-    auto OptionalSrcCanTy = OptionalType::get(SrcTy.getSwiftRValueType())
+    auto OptionalSrcCanTy = OptionalType::get(SrcTy.getASTType())
       ->getCanonicalType();
     auto LoweredOptionalSrcType = SILType::getPrimitiveObjectType(
       OptionalSrcCanTy);

--- a/lib/SILOptimizer/Utils/SpecializationMangler.cpp
+++ b/lib/SILOptimizer/Utils/SpecializationMangler.cpp
@@ -256,7 +256,7 @@ FunctionSignatureSpecializationMangler::mangleClosureProp(SILInstruction *Inst) 
   // specializing.
   for (auto &Op : PAI->getArgumentOperands()) {
     SILType Ty = Op.get()->getType();
-    appendType(Ty.getSwiftRValueType());
+    appendType(Ty.getASTType());
   }
 }
 

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -355,7 +355,7 @@ void SILSerializer::writeSILFunction(const SILFunction &F, bool DeclOnly) {
   FuncTable[Ctx.getIdentifier(F.getName())] = NextFuncID++;
   Funcs.push_back(Out.GetCurrentBitNo());
   unsigned abbrCode = SILAbbrCodes[SILFunctionLayout::Code];
-  TypeID FnID = S.addTypeRef(F.getLoweredType().getSwiftRValueType());
+  TypeID FnID = S.addTypeRef(F.getLoweredType().getASTType());
   DEBUG(llvm::dbgs() << "SILFunction " << F.getName() << " @ BitNo "
                      << Out.GetCurrentBitNo() << " abbrCode " << abbrCode
                      << " FnID " << FnID << "\n");
@@ -445,7 +445,7 @@ void SILSerializer::writeSILBasicBlock(const SILBasicBlock &BB) {
   SmallVector<DeclID, 4> Args;
   for (auto I = BB.args_begin(), E = BB.args_end(); I != E; ++I) {
     SILArgument *SA = *I;
-    DeclID tId = S.addTypeRef(SA->getType().getSwiftRValueType());
+    DeclID tId = S.addTypeRef(SA->getType().getASTType());
     DeclID vId = addValueRef(static_cast<const ValueBase*>(SA));
     Args.push_back(tId);
 
@@ -503,7 +503,7 @@ void SILSerializer::handleMethodInst(const MethodInst *MI,
                                      SmallVectorImpl<ValueID> &ListOfValues) {
   handleSILDeclRef(S, MI->getMember(), ListOfValues);
   ListOfValues.push_back(
-      S.addTypeRef(operand->getType().getSwiftRValueType()));
+      S.addTypeRef(operand->getType().getASTType()));
   ListOfValues.push_back((unsigned)operand->getType().getCategory());
   ListOfValues.push_back(addValueRef(operand));
 }
@@ -513,7 +513,7 @@ void SILSerializer::writeOneTypeLayout(SILInstructionKind valueKind,
   unsigned abbrCode = SILAbbrCodes[SILOneTypeLayout::Code];
   SILOneTypeLayout::emitRecord(Out, ScratchRecord, abbrCode,
         (unsigned) valueKind,
-        S.addTypeRef(type.getSwiftRValueType()),
+        S.addTypeRef(type.getASTType()),
         (unsigned)type.getCategory());
 }
 
@@ -522,7 +522,7 @@ void SILSerializer::writeOneOperandLayout(SILInstructionKind valueKind,
                                           SILValue operand) {
 
   auto operandType = operand->getType();
-  auto operandTypeRef = S.addTypeRef(operandType.getSwiftRValueType());
+  auto operandTypeRef = S.addTypeRef(operandType.getASTType());
   auto operandRef = addValueRef(operand);
 
   SILOneOperandLayout::emitRecord(Out, ScratchRecord,
@@ -538,7 +538,7 @@ writeOneOperandExtraAttributeLayout(SILInstructionKind valueKind,
                                     SILValue operand) {
 
   auto operandType = operand->getType();
-  auto operandTypeRef = S.addTypeRef(operandType.getSwiftRValueType());
+  auto operandTypeRef = S.addTypeRef(operandType.getASTType());
   auto operandRef = addValueRef(operand);
 
   SILOneOperandExtraAttributeLayout::emitRecord(
@@ -551,9 +551,9 @@ void SILSerializer::writeOneTypeOneOperandLayout(SILInstructionKind valueKind,
                                                  unsigned attrs,
                                                  SILType type,
                                                  SILValue operand) {
-  auto typeRef = S.addTypeRef(type.getSwiftRValueType());
+  auto typeRef = S.addTypeRef(type.getASTType());
   auto operandType = operand->getType();
-  auto operandTypeRef = S.addTypeRef(operandType.getSwiftRValueType());
+  auto operandTypeRef = S.addTypeRef(operandType.getASTType());
   auto operandRef = addValueRef(operand);
 
   SILOneTypeOneOperandLayout::emitRecord(Out, ScratchRecord,
@@ -569,7 +569,7 @@ void SILSerializer::writeOneTypeOneOperandLayout(SILInstructionKind valueKind,
                                                  SILValue operand) {
   auto typeRef = S.addTypeRef(type);
   auto operandType = operand->getType();
-  auto operandTypeRef = S.addTypeRef(operandType.getSwiftRValueType());
+  auto operandTypeRef = S.addTypeRef(operandType.getASTType());
   auto operandRef = addValueRef(operand);
 
   SILOneTypeOneOperandLayout::emitRecord(Out, ScratchRecord,
@@ -627,7 +627,7 @@ SILSerializer::writeKeyPathPatternComponent(
         ListOfValues.push_back(index.Operand);
         ListOfValues.push_back(S.addTypeRef(index.FormalType));
         ListOfValues.push_back(
-          S.addTypeRef(index.LoweredType.getSwiftRValueType()));
+          S.addTypeRef(index.LoweredType.getASTType()));
         ListOfValues.push_back((unsigned)index.LoweredType.getCategory());
         serializeAfter.push_back(index.Hashable);
       }
@@ -756,7 +756,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILValueCategory operandCategory = SILValueCategory::Object;
     ValueID operandID = 0;
     if (operand) {
-      operandType = S.addTypeRef(operand->getType().getSwiftRValueType());
+      operandType = S.addTypeRef(operand->getType().getASTType());
       operandCategory = operand->getType().getCategory();
       operandID = addValueRef(operand);
     }
@@ -764,7 +764,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     unsigned abbrCode = SILAbbrCodes[SILInitExistentialLayout::Code];
     SILInitExistentialLayout::emitRecord(Out, ScratchRecord, abbrCode,
        (unsigned)SI.getKind(),
-       S.addTypeRef(Ty.getSwiftRValueType()),
+       S.addTypeRef(Ty.getASTType()),
        (unsigned)Ty.getCategory(),
        operandType,
        (unsigned)operandCategory,
@@ -840,18 +840,18 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     for (unsigned Idx = 0; Idx < NumOpsToWrite; ++Idx) {
       if (Idx < NumTailAllocs) {
         assert(TailTypes[Idx].isObject());
-        Args.push_back(S.addTypeRef(TailTypes[Idx].getSwiftRValueType()));
+        Args.push_back(S.addTypeRef(TailTypes[Idx].getASTType()));
       }
       SILValue OpVal = AllOps[Idx].get();
       Args.push_back(addValueRef(OpVal));
       SILType OpType = OpVal->getType();
       assert(OpType.isObject());
-      Args.push_back(S.addTypeRef(OpType.getSwiftRValueType()));
+      Args.push_back(S.addTypeRef(OpType.getASTType()));
     }
     SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord, abbrCode,
                                        (unsigned)SI.getKind(),
                                        S.addTypeRef(
-                                         ARI->getType().getSwiftRValueType()),
+                                         ARI->getType().getASTType()),
                                        (unsigned)ARI->getType().getCategory(),
                                        Args);
     break;
@@ -875,7 +875,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     auto boxOperand = PBI->getOperand();
     auto boxRef = addValueRef(boxOperand);
     auto boxType = boxOperand->getType();
-    auto boxTypeRef = S.addTypeRef(boxType.getSwiftRValueType());
+    auto boxTypeRef = S.addTypeRef(boxType.getASTType());
     
     SILOneTypeOneOperandLayout::emitRecord(Out, ScratchRecord,
           SILAbbrCodes[SILOneTypeOneOperandLayout::Code],
@@ -902,14 +902,14 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SmallVector<ValueID, 4> Args;
     for (auto Arg : BI->getArguments()) {
       Args.push_back(addValueRef(Arg));
-      Args.push_back(S.addTypeRef(Arg->getType().getSwiftRValueType()));
+      Args.push_back(S.addTypeRef(Arg->getType().getASTType()));
       Args.push_back((unsigned)Arg->getType().getCategory());
     }
     SILInstApplyLayout::emitRecord(Out, ScratchRecord,
                              SILAbbrCodes[SILInstApplyLayout::Code],
                              SIL_BUILTIN,
                              S.addSubstitutionMapRef(BI->getSubstitutions()),
-                             S.addTypeRef(BI->getType().getSwiftRValueType()),
+                             S.addTypeRef(BI->getType().getASTType()),
                              (unsigned)BI->getType().getCategory(),
                              S.addDeclBaseNameRef(BI->getName()),
                              Args);
@@ -930,7 +930,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
         SILAbbrCodes[SILInstApplyLayout::Code],
         AI->isNonThrowing() ? SIL_NON_THROWING_APPLY : SIL_APPLY,
         S.addSubstitutionMapRef(AI->getSubstitutionMap()),
-        S.addTypeRef(AI->getCallee()->getType().getSwiftRValueType()),
+        S.addTypeRef(AI->getCallee()->getType().getASTType()),
         S.addTypeRef(AI->getSubstCalleeType()),
         addValueRef(AI->getCallee()),
         Args);
@@ -951,7 +951,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
         SILAbbrCodes[SILInstApplyLayout::Code],
         AI->isNonThrowing() ? SIL_NON_THROWING_BEGIN_APPLY : SIL_BEGIN_APPLY,
         S.addSubstitutionMapRef(AI->getSubstitutionMap()),
-        S.addTypeRef(AI->getCallee()->getType().getSwiftRValueType()),
+        S.addTypeRef(AI->getCallee()->getType().getASTType()),
         S.addTypeRef(AI->getSubstCalleeType()),
         addValueRef(AI->getCallee()),
         Args);
@@ -974,7 +974,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILInstApplyLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[SILInstApplyLayout::Code], SIL_TRY_APPLY,
         S.addSubstitutionMapRef(AI->getSubstitutionMap()),
-        S.addTypeRef(AI->getCallee()->getType().getSwiftRValueType()),
+        S.addTypeRef(AI->getCallee()->getType().getASTType()),
         S.addTypeRef(AI->getSubstCalleeType()),
         addValueRef(AI->getCallee()),
         Args);
@@ -989,8 +989,8 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILInstApplyLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[SILInstApplyLayout::Code], SIL_PARTIAL_APPLY,
         S.addSubstitutionMapRef(PAI->getSubstitutionMap()),
-        S.addTypeRef(PAI->getCallee()->getType().getSwiftRValueType()),
-        S.addTypeRef(PAI->getType().getSwiftRValueType()),
+        S.addTypeRef(PAI->getCallee()->getType().getASTType()),
+        S.addTypeRef(PAI->getType().getASTType()),
         addValueRef(PAI->getCallee()),
         Args);
     break;
@@ -1012,7 +1012,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILOneOperandLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[SILOneOperandLayout::Code],
         (unsigned)SI.getKind(), 0,
-        S.addTypeRef(GI->getType().getSwiftRValueType()),
+        S.addTypeRef(GI->getType().getASTType()),
         (unsigned)GI->getType().getCategory(),
         S.addDeclBaseNameRef(
             Ctx.getIdentifier(GI->getReferencedGlobal()->getName())));
@@ -1024,7 +1024,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     const BranchInst *BrI = cast<BranchInst>(&SI);
     SmallVector<ValueID, 4> ListOfValues;
     for (auto Elt : BrI->getArgs()) {
-      ListOfValues.push_back(S.addTypeRef(Elt->getType().getSwiftRValueType()));
+      ListOfValues.push_back(S.addTypeRef(Elt->getType().getASTType()));
       ListOfValues.push_back((unsigned)Elt->getType().getCategory());
       ListOfValues.push_back(addValueRef(Elt));
     }
@@ -1048,12 +1048,12 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     ListOfValues.push_back(BasicBlockMap[CBI->getFalseBB()]);
     ListOfValues.push_back(CBI->getTrueArgs().size());
     for (auto Elt : CBI->getTrueArgs()) {
-      ListOfValues.push_back(S.addTypeRef(Elt->getType().getSwiftRValueType()));
+      ListOfValues.push_back(S.addTypeRef(Elt->getType().getASTType()));
       ListOfValues.push_back((unsigned)Elt->getType().getCategory());
       ListOfValues.push_back(addValueRef(Elt));
     }
     for (auto Elt : CBI->getFalseArgs()) {
-      ListOfValues.push_back(S.addTypeRef(Elt->getType().getSwiftRValueType()));
+      ListOfValues.push_back(S.addTypeRef(Elt->getType().getASTType()));
       ListOfValues.push_back((unsigned)Elt->getType().getCategory());
       ListOfValues.push_back(addValueRef(Elt));
     }
@@ -1061,7 +1061,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[SILOneTypeValuesLayout::Code],
         (unsigned)SI.getKind(),
-        S.addTypeRef(CBI->getCondition()->getType().getSwiftRValueType()),
+        S.addTypeRef(CBI->getCondition()->getType().getASTType()),
         (unsigned)CBI->getCondition()->getType().getCategory(),
         ListOfValues);
     break;
@@ -1091,7 +1091,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[SILOneTypeValuesLayout::Code],
         (unsigned)SI.getKind(),
-        S.addTypeRef(SOI->getOperand()->getType().getSwiftRValueType()),
+        S.addTypeRef(SOI->getOperand()->getType().getASTType()),
         (unsigned)SOI->getOperand()->getType().getCategory(),
         ListOfValues);
     break;
@@ -1106,7 +1106,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     const SelectEnumInstBase *SOI = cast<SelectEnumInstBase>(&SI);
     SmallVector<ValueID, 4> ListOfValues;
     ListOfValues.push_back(addValueRef(SOI->getEnumOperand()));
-    ListOfValues.push_back(S.addTypeRef(SOI->getType().getSwiftRValueType()));
+    ListOfValues.push_back(S.addTypeRef(SOI->getType().getASTType()));
     ListOfValues.push_back((unsigned)SOI->getType().getCategory());
     ListOfValues.push_back((unsigned)SOI->hasDefault());
     if (SOI->hasDefault()) {
@@ -1124,7 +1124,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[SILOneTypeValuesLayout::Code],
         (unsigned)SI.getKind(),
-        S.addTypeRef(SOI->getEnumOperand()->getType().getSwiftRValueType()),
+        S.addTypeRef(SOI->getEnumOperand()->getType().getASTType()),
         (unsigned)SOI->getEnumOperand()->getType().getCategory(),
         ListOfValues);
     break;
@@ -1153,7 +1153,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[SILOneTypeValuesLayout::Code],
         (unsigned)SI.getKind(),
-        S.addTypeRef(SII->getOperand()->getType().getSwiftRValueType()),
+        S.addTypeRef(SII->getOperand()->getType().getASTType()),
         (unsigned)SII->getOperand()->getType().getCategory(),
         ListOfValues);
     break;
@@ -1167,7 +1167,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     const SelectValueInst *SVI = cast<SelectValueInst>(&SI);
     SmallVector<ValueID, 4> ListOfValues;
     ListOfValues.push_back(addValueRef(SVI->getOperand()));
-    ListOfValues.push_back(S.addTypeRef(SVI->getType().getSwiftRValueType()));
+    ListOfValues.push_back(S.addTypeRef(SVI->getType().getASTType()));
     ListOfValues.push_back((unsigned)SVI->getType().getCategory());
     ListOfValues.push_back((unsigned)SVI->hasDefault());
     if (SVI->hasDefault()) {
@@ -1185,7 +1185,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[SILOneTypeValuesLayout::Code],
         (unsigned)SI.getKind(),
-        S.addTypeRef(SVI->getOperand()->getType().getSwiftRValueType()),
+        S.addTypeRef(SVI->getOperand()->getType().getASTType()),
         (unsigned)SVI->getOperand()->getType().getCategory(),
         ListOfValues);
     break;
@@ -1266,7 +1266,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     auto YI = cast<YieldInst>(&SI);
     SmallVector<ValueID, 4> args;
     for (auto arg: YI->getYieldedValues()) {
-      args.push_back(S.addTypeRef(arg->getType().getSwiftRValueType()));
+      args.push_back(S.addTypeRef(arg->getType().getASTType()));
       args.push_back((unsigned)arg->getType().getCategory());
       args.push_back(addValueRef(arg));
     }
@@ -1285,7 +1285,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     unsigned abbrCode = SILAbbrCodes[SILOneOperandLayout::Code];
     SILOneOperandLayout::emitRecord(Out, ScratchRecord, abbrCode,
         (unsigned)SI.getKind(), 0,
-        S.addTypeRef(FRI->getType().getSwiftRValueType()),
+        S.addTypeRef(FRI->getType().getASTType()),
         (unsigned)FRI->getType().getCategory(),
         addSILFunctionRef(ReferencedFunction));
 
@@ -1322,10 +1322,10 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILTwoOperandsLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[SILTwoOperandsLayout::Code],
         (unsigned)SI.getKind(), Attr,
-        S.addTypeRef(operand->getType().getSwiftRValueType()),
+        S.addTypeRef(operand->getType().getASTType()),
         (unsigned)operand->getType().getCategory(),
         addValueRef(operand),
-        S.addTypeRef(operand2->getType().getSwiftRValueType()),
+        S.addTypeRef(operand2->getType().getASTType()),
         (unsigned)operand2->getType().getCategory(),
         addValueRef(operand2));
     break;
@@ -1335,11 +1335,11 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILTailAddrLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[SILTailAddrLayout::Code],
         (unsigned)SI.getKind(),
-        S.addTypeRef(TAI->getBase()->getType().getSwiftRValueType()),
+        S.addTypeRef(TAI->getBase()->getType().getASTType()),
         addValueRef(TAI->getBase()),
-        S.addTypeRef(TAI->getIndex()->getType().getSwiftRValueType()),
+        S.addTypeRef(TAI->getIndex()->getType().getASTType()),
         addValueRef(TAI->getIndex()),
-        S.addTypeRef(TAI->getTailType().getSwiftRValueType()));
+        S.addTypeRef(TAI->getTailType().getASTType()));
     break;
   }
   case SILInstructionKind::StringLiteralInst: {
@@ -1382,7 +1382,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     unsigned abbrCode = SILAbbrCodes[SILOneOperandLayout::Code];
     SILOneOperandLayout::emitRecord(Out, ScratchRecord, abbrCode,
         (unsigned)SI.getKind(), 0,
-        S.addTypeRef(Ty.getSwiftRValueType()),
+        S.addTypeRef(Ty.getASTType()),
         (unsigned)Ty.getCategory(),
         S.addDeclBaseNameRef(Ctx.getIdentifier(Str)));
     break;
@@ -1393,7 +1393,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     const MarkFunctionEscapeInst *MFE = cast<MarkFunctionEscapeInst>(&SI);
     SmallVector<ValueID, 4> ListOfValues;
     for (auto Elt : MFE->getElements()) {
-      ListOfValues.push_back(S.addTypeRef(Elt->getType().getSwiftRValueType()));
+      ListOfValues.push_back(S.addTypeRef(Elt->getType().getASTType()));
       ListOfValues.push_back((unsigned)Elt->getType().getCategory());
       ListOfValues.push_back(addValueRef(Elt));
     }
@@ -1413,7 +1413,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     unsigned abbrCode = SILAbbrCodes[SILOneOperandLayout::Code];
     SILOneOperandLayout::emitRecord(Out, ScratchRecord, abbrCode,
                               (unsigned)SI.getKind(), 0,
-                              S.addTypeRef(PI->getType().getSwiftRValueType()),
+                              S.addTypeRef(PI->getType().getASTType()),
                               (unsigned)PI->getType().getCategory(),
                               S.addDeclRef(PI->getProtocol()));
     break;
@@ -1481,10 +1481,10 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILTwoOperandsLayout::emitRecord(Out, ScratchRecord,
            SILAbbrCodes[SILTwoOperandsLayout::Code], (unsigned)SI.getKind(),
            /*attr*/ 0,
-           S.addTypeRef(RI->getConverted()->getType().getSwiftRValueType()),
+           S.addTypeRef(RI->getConverted()->getType().getASTType()),
            (unsigned)RI->getConverted()->getType().getCategory(),
            addValueRef(RI->getConverted()),
-           S.addTypeRef(RI->getBitsOperand()->getType().getSwiftRValueType()),
+           S.addTypeRef(RI->getBitsOperand()->getType().getASTType()),
            (unsigned)RI->getBitsOperand()->getType().getCategory(),
            addValueRef(RI->getBitsOperand()));
     break;
@@ -1495,9 +1495,9 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILInstCastLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[SILInstCastLayout::Code],
         (unsigned)SI.getKind(), /*attr*/ 0,
-        S.addTypeRef(CI->getType().getSwiftRValueType()),
+        S.addTypeRef(CI->getType().getASTType()),
         (unsigned)CI->getType().getCategory(),
-        S.addTypeRef(CI->getOperand()->getType().getSwiftRValueType()),
+        S.addTypeRef(CI->getOperand()->getType().getASTType()),
         (unsigned)CI->getOperand()->getType().getCategory(),
         addValueRef(CI->getOperand()));
     break;
@@ -1507,14 +1507,14 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     ValueID listOfValues[] = {
       S.addTypeRef(CI->getSourceType()),
       addValueRef(CI->getSrc()),
-      S.addTypeRef(CI->getSrc()->getType().getSwiftRValueType()),
+      S.addTypeRef(CI->getSrc()->getType().getASTType()),
       (unsigned)CI->getSrc()->getType().getCategory(),
       S.addTypeRef(CI->getTargetType()),
       addValueRef(CI->getDest())
     };
     SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
              SILAbbrCodes[SILOneTypeValuesLayout::Code], (unsigned)SI.getKind(),
-             S.addTypeRef(CI->getDest()->getType().getSwiftRValueType()),
+             S.addTypeRef(CI->getDest()->getType().getASTType()),
              (unsigned)CI->getDest()->getType().getCategory(),
              llvm::makeArrayRef(listOfValues));
     break;
@@ -1525,9 +1525,9 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
         Out, ScratchRecord, SILAbbrCodes[SILInstCastLayout::Code],
         (unsigned)SI.getKind(),
         /*attr*/ 0,
-        S.addTypeRef(CI->getType().getSwiftRValueType()),
+        S.addTypeRef(CI->getType().getASTType()),
         (unsigned)CI->getType().getCategory(),
-        S.addTypeRef(CI->getOperand()->getType().getSwiftRValueType()),
+        S.addTypeRef(CI->getOperand()->getType().getASTType()),
         (unsigned)CI->getOperand()->getType().getCategory(),
         addValueRef(CI->getOperand()));
     break;
@@ -1537,14 +1537,14 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     ValueID listOfValues[] = {
       S.addTypeRef(CI->getSourceType()),
       addValueRef(CI->getSrc()),
-      S.addTypeRef(CI->getSrc()->getType().getSwiftRValueType()),
+      S.addTypeRef(CI->getSrc()->getType().getASTType()),
       (unsigned)CI->getSrc()->getType().getCategory(),
       S.addTypeRef(CI->getTargetType()),
       addValueRef(CI->getDest())
     };
     SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
              SILAbbrCodes[SILOneTypeValuesLayout::Code], (unsigned)SI.getKind(),
-             S.addTypeRef(CI->getDest()->getType().getSwiftRValueType()),
+             S.addTypeRef(CI->getDest()->getType().getASTType()),
              (unsigned)CI->getDest()->getType().getCategory(),
              llvm::makeArrayRef(listOfValues));
     break;
@@ -1559,10 +1559,10 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
 
     SILTwoOperandsLayout::emitRecord(
         Out, ScratchRecord, abbrCode, (unsigned)SI.getKind(), Attr,
-        S.addTypeRef(BorrowedValue->getType().getSwiftRValueType()),
+        S.addTypeRef(BorrowedValue->getType().getASTType()),
         (unsigned)BorrowedValue->getType().getCategory(),
         addValueRef(BorrowedValue),
-        S.addTypeRef(OriginalValue->getType().getSwiftRValueType()),
+        S.addTypeRef(OriginalValue->getType().getASTType()),
         (unsigned)OriginalValue->getType().getCategory(),
         addValueRef(OriginalValue));
     break;
@@ -1578,7 +1578,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
 
     SILOneOperandExtraAttributeLayout::emitRecord(
         Out, ScratchRecord, abbrCode, (unsigned)SI.getKind(), attr,
-        S.addTypeRef(operand->getType().getSwiftRValueType()),
+        S.addTypeRef(operand->getType().getASTType()),
         (unsigned)operand->getType().getCategory(),
         addValueRef(operand));
     break;
@@ -1592,7 +1592,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
 
     SILOneOperandLayout::emitRecord(
         Out, ScratchRecord, abbrCode, (unsigned)SI.getKind(), attr,
-        S.addTypeRef(operand->getType().getSwiftRValueType()),
+        S.addTypeRef(operand->getType().getASTType()),
         (unsigned)operand->getType().getCategory(),
         addValueRef(operand));
     break;
@@ -1609,10 +1609,10 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
 
     SILTwoOperandsExtraAttributeLayout::emitRecord(
         Out, ScratchRecord, abbrCode, (unsigned)SI.getKind(), attr,
-        S.addTypeRef(source->getType().getSwiftRValueType()),
+        S.addTypeRef(source->getType().getASTType()),
         (unsigned)source->getType().getCategory(),
         addValueRef(source),
-        S.addTypeRef(buffer->getType().getSwiftRValueType()),
+        S.addTypeRef(buffer->getType().getASTType()),
         (unsigned)buffer->getType().getCategory(),
         addValueRef(buffer));
     break;
@@ -1627,7 +1627,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
 
     SILOneOperandExtraAttributeLayout::emitRecord(
         Out, ScratchRecord, abbrCode, (unsigned)SI.getKind(), attr,
-        S.addTypeRef(operand->getType().getSwiftRValueType()),
+        S.addTypeRef(operand->getType().getASTType()),
         (unsigned)operand->getType().getCategory(),
         addValueRef(operand));
     break;
@@ -1671,7 +1671,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     unsigned abbrCode = SILAbbrCodes[SILOneValueOneOperandLayout::Code];
     SILOneValueOneOperandLayout::emitRecord(Out, ScratchRecord, abbrCode,
                   (unsigned)SI.getKind(), Attr, addValueRef(value),
-                  S.addTypeRef(operand->getType().getSwiftRValueType()),
+                  S.addTypeRef(operand->getType().getASTType()),
                   (unsigned)operand->getType().getCategory(),
                   addValueRef(operand));
     break;
@@ -1683,11 +1683,11 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILType boundType = BI->getBoundType();
     SmallVector<ValueID, 6> ListOfValues;
     ListOfValues.push_back(S.addTypeRef(
-                             baseOperand->getType().getSwiftRValueType()));
+                             baseOperand->getType().getASTType()));
     ListOfValues.push_back((unsigned)baseOperand->getType().getCategory());
     ListOfValues.push_back(addValueRef(baseOperand));
     ListOfValues.push_back(S.addTypeRef(
-                             indexOperand->getType().getSwiftRValueType()));
+                             indexOperand->getType().getASTType()));
     ListOfValues.push_back((unsigned)indexOperand->getType().getCategory());
     ListOfValues.push_back(addValueRef(indexOperand));
 
@@ -1696,7 +1696,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       ScratchRecord,
       SILAbbrCodes[SILOneTypeValuesLayout::Code],
       (unsigned)SI.getKind(),
-      S.addTypeRef(boundType.getSwiftRValueType()),
+      S.addTypeRef(boundType.getASTType()),
       (unsigned)boundType.getCategory(),
       ListOfValues);
     break;
@@ -1746,7 +1746,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILOneValueOneOperandLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[SILOneValueOneOperandLayout::Code],
         (unsigned)SI.getKind(), 0, S.addDeclRef(tDecl),
-        S.addTypeRef(operand->getType().getSwiftRValueType()),
+        S.addTypeRef(operand->getType().getASTType()),
         (unsigned)operand->getType().getCategory(),
         addValueRef(operand));
     break;
@@ -1764,7 +1764,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     const StructInst *StrI = cast<StructInst>(&SI);
     SmallVector<ValueID, 4> ListOfValues;
     for (auto Elt : StrI->getElements()) {
-      ListOfValues.push_back(S.addTypeRef(Elt->getType().getSwiftRValueType()));
+      ListOfValues.push_back(S.addTypeRef(Elt->getType().getASTType()));
       ListOfValues.push_back((unsigned)Elt->getType().getCategory());
       ListOfValues.push_back(addValueRef(Elt));
     }
@@ -1772,7 +1772,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[SILOneTypeValuesLayout::Code],
         (unsigned)SI.getKind(),
-        S.addTypeRef(StrI->getType().getSwiftRValueType()),
+        S.addTypeRef(StrI->getType().getASTType()),
         (unsigned)StrI->getType().getCategory(), ListOfValues);
     break;
   }
@@ -1797,7 +1797,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
         SILAbbrCodes[SILOneTypeOneOperandLayout::Code],
         (unsigned)SI.getKind(), 0,
         FieldNo, 0,
-        S.addTypeRef(operand->getType().getSwiftRValueType()),
+        S.addTypeRef(operand->getType().getASTType()),
         (unsigned)operand->getType().getCategory(),
         addValueRef(operand));
     break;
@@ -1814,7 +1814,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     unsigned abbrCode = SILAbbrCodes[SILOneTypeValuesLayout::Code];
     SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord, abbrCode,
         (unsigned)SI.getKind(),
-        S.addTypeRef(TI->getType().getSwiftRValueType()),
+        S.addTypeRef(TI->getType().getASTType()),
         (unsigned)TI->getType().getCategory(),
         ListOfValues);
     break;
@@ -1824,13 +1824,13 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     // (DeclID + hasOperand), and an operand.
     const EnumInst *UI = cast<EnumInst>(&SI);
     TypeID OperandTy = UI->hasOperand() ?
-      S.addTypeRef(UI->getOperand()->getType().getSwiftRValueType()) : TypeID();
+      S.addTypeRef(UI->getOperand()->getType().getASTType()) : TypeID();
     unsigned OperandTyCategory = UI->hasOperand() ?
         (unsigned)UI->getOperand()->getType().getCategory() : 0;
     SILTwoOperandsLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[SILTwoOperandsLayout::Code], (unsigned)SI.getKind(),
         UI->hasOperand(),
-        S.addTypeRef(UI->getType().getSwiftRValueType()),
+        S.addTypeRef(UI->getType().getASTType()),
         (unsigned)UI->getType().getCategory(),
         S.addDeclRef(UI->getElement()),
         OperandTy, OperandTyCategory,
@@ -1856,7 +1856,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILInstWitnessMethodLayout::emitRecord(
         Out, ScratchRecord, SILAbbrCodes[SILInstWitnessMethodLayout::Code],
         S.addTypeRef(Ty), 0, 0,
-        S.addTypeRef(Ty2.getSwiftRValueType()), (unsigned)Ty2.getCategory(),
+        S.addTypeRef(Ty2.getASTType()), (unsigned)Ty2.getCategory(),
         OperandTy, OperandTyCategory, OperandValueId, ListOfValues);
 
     S.writeConformance(WMI->getConformance(), SILAbbrCodes);
@@ -1874,7 +1874,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
 
     SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[SILOneTypeValuesLayout::Code], (unsigned)SI.getKind(),
-        S.addTypeRef(Ty.getSwiftRValueType()),
+        S.addTypeRef(Ty.getASTType()),
         (unsigned)Ty.getCategory(), ListOfValues);
     break;
   }
@@ -1889,7 +1889,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
 
     SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[SILOneTypeValuesLayout::Code], (unsigned)SI.getKind(),
-        S.addTypeRef(Ty.getSwiftRValueType()),
+        S.addTypeRef(Ty.getASTType()),
         (unsigned)Ty.getCategory(), ListOfValues);
     break;
   }
@@ -1904,7 +1904,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
 
     SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[SILOneTypeValuesLayout::Code], (unsigned)SI.getKind(),
-        S.addTypeRef(Ty.getSwiftRValueType()),
+        S.addTypeRef(Ty.getASTType()),
         (unsigned)Ty.getCategory(), ListOfValues);
     break;
   }
@@ -1919,7 +1919,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
 
     SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[SILOneTypeValuesLayout::Code], (unsigned)SI.getKind(),
-        S.addTypeRef(Ty.getSwiftRValueType()),
+        S.addTypeRef(Ty.getASTType()),
         (unsigned)Ty.getCategory(), ListOfValues);
     break;
   }
@@ -1935,7 +1935,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
 
     SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
         SILAbbrCodes[SILOneTypeValuesLayout::Code], (unsigned)SI.getKind(),
-        S.addTypeRef(DMB->getOperand()->getType().getSwiftRValueType()),
+        S.addTypeRef(DMB->getOperand()->getType().getASTType()),
         (unsigned)DMB->getOperand()->getType().getCategory(), ListOfValues);
     break;
   }
@@ -1947,14 +1947,14 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     ListOfValues.push_back(CBI->isExact()),
     ListOfValues.push_back(addValueRef(CBI->getOperand()));
     ListOfValues.push_back(
-               S.addTypeRef(CBI->getOperand()->getType().getSwiftRValueType()));
+               S.addTypeRef(CBI->getOperand()->getType().getASTType()));
     ListOfValues.push_back((unsigned)CBI->getOperand()->getType().getCategory());
     ListOfValues.push_back(BasicBlockMap[CBI->getSuccessBB()]);
     ListOfValues.push_back(BasicBlockMap[CBI->getFailureBB()]);
 
     SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
              SILAbbrCodes[SILOneTypeValuesLayout::Code], (unsigned)SI.getKind(),
-             S.addTypeRef(CBI->getCastType().getSwiftRValueType()),
+             S.addTypeRef(CBI->getCastType().getASTType()),
              (unsigned)CBI->getCastType().getCategory(),
              ListOfValues);
     break;
@@ -1967,7 +1967,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SmallVector<ValueID, 8> ListOfValues;
     ListOfValues.push_back(addValueRef(CBI->getOperand()));
     ListOfValues.push_back(
-        S.addTypeRef(CBI->getOperand()->getType().getSwiftRValueType()));
+        S.addTypeRef(CBI->getOperand()->getType().getASTType()));
     ListOfValues.push_back(
         (unsigned)CBI->getOperand()->getType().getCategory());
     ListOfValues.push_back(BasicBlockMap[CBI->getSuccessBB()]);
@@ -1976,7 +1976,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SILOneTypeValuesLayout::emitRecord(
         Out, ScratchRecord, SILAbbrCodes[SILOneTypeValuesLayout::Code],
         (unsigned)SI.getKind(),
-        S.addTypeRef(CBI->getCastType().getSwiftRValueType()),
+        S.addTypeRef(CBI->getCastType().getASTType()),
         (unsigned)CBI->getCastType().getCategory(), ListOfValues);
     break;
   }
@@ -1989,7 +1989,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
       toStableCastConsumptionKind(CBI->getConsumptionKind()),
       S.addTypeRef(CBI->getSourceType()),
       addValueRef(CBI->getSrc()),
-      S.addTypeRef(CBI->getSrc()->getType().getSwiftRValueType()),
+      S.addTypeRef(CBI->getSrc()->getType().getASTType()),
       (unsigned)CBI->getSrc()->getType().getCategory(),
       S.addTypeRef(CBI->getTargetType()),
       addValueRef(CBI->getDest()),
@@ -1998,7 +1998,7 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     };
     SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
              SILAbbrCodes[SILOneTypeValuesLayout::Code], (unsigned)SI.getKind(),
-             S.addTypeRef(CBI->getDest()->getType().getSwiftRValueType()),
+             S.addTypeRef(CBI->getDest()->getType().getASTType()),
              (unsigned)CBI->getDest()->getType().getCategory(),
              llvm::makeArrayRef(listOfValues));
     break;
@@ -2008,18 +2008,18 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     SmallVector<ValueID, 6> ListOfValues;
     ListOfValues.push_back(addValueRef(IBSHI->getBlockStorage()));
     ListOfValues.push_back(
-         S.addTypeRef(IBSHI->getBlockStorage()->getType().getSwiftRValueType()));
+         S.addTypeRef(IBSHI->getBlockStorage()->getType().getASTType()));
     // Always an address, don't need to save category
     
     ListOfValues.push_back(addValueRef(IBSHI->getInvokeFunction()));
     ListOfValues.push_back(
-       S.addTypeRef(IBSHI->getInvokeFunction()->getType().getSwiftRValueType()));
+       S.addTypeRef(IBSHI->getInvokeFunction()->getType().getASTType()));
     // Always a value, don't need to save category
     ListOfValues.push_back(S.addSubstitutionMapRef(IBSHI->getSubstitutions()));
     
     SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
              SILAbbrCodes[SILOneTypeValuesLayout::Code], (unsigned)SI.getKind(),
-             S.addTypeRef(IBSHI->getType().getSwiftRValueType()),
+             S.addTypeRef(IBSHI->getType().getASTType()),
              (unsigned)IBSHI->getType().getCategory(),
              ListOfValues);
 
@@ -2059,13 +2059,13 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     for (auto &operand : KPI->getAllOperands()) {
       auto value = operand.get();
       ListOfValues.push_back(addValueRef(value));
-      ListOfValues.push_back(S.addTypeRef(value->getType().getSwiftRValueType()));
+      ListOfValues.push_back(S.addTypeRef(value->getType().getASTType()));
       ListOfValues.push_back((unsigned)value->getType().getCategory());
     }
     
     SILOneTypeValuesLayout::emitRecord(Out, ScratchRecord,
          SILAbbrCodes[SILOneTypeValuesLayout::Code], (unsigned)SI.getKind(),
-         S.addTypeRef(KPI->getType().getSwiftRValueType()),
+         S.addTypeRef(KPI->getType().getASTType()),
          (unsigned)KPI->getType().getCategory(),
          ListOfValues);
     for (const auto conf : serializeAfter) {
@@ -2160,7 +2160,7 @@ void SILSerializer::writeIndexTables() {
 void SILSerializer::writeSILGlobalVar(const SILGlobalVariable &g) {
   GlobalVarList[Ctx.getIdentifier(g.getName())] = NextGlobalVarID++;
   GlobalVarOffset.push_back(Out.GetCurrentBitNo());
-  TypeID TyID = S.addTypeRef(g.getLoweredType().getSwiftRValueType());
+  TypeID TyID = S.addTypeRef(g.getLoweredType().getASTType());
   DeclID dID = S.addDeclRef(g.getDecl());
   SILGlobalVarLayout::emitRecord(Out, ScratchRecord,
                                  SILAbbrCodes[SILGlobalVarLayout::Code],


### PR DESCRIPTION
In practice, `getSwiftRValueType()` is really just `getCanonicalType()`. This matters in the context of reference storage types, which are not RValues.