### PR TITLE
Revert "[SIL] Replace more SubstitutionLists with SubstitutionMap"

### DIFF
--- a/include/swift/AST/Substitution.h
+++ b/include/swift/AST/Substitution.h
@@ -51,6 +51,10 @@ public:
   /// Checks whether the current substitution is canonical.
   bool isCanonical() const;
 
+  /// Get the canonicalized substitution. If wasCanonical is not nullptr,
+  /// store there whether the current substitution was canonical already.
+  Substitution getCanonicalSubstitution(bool *wasCanonical = nullptr) const;
+
   bool operator!=(const Substitution &other) const { return !(*this == other); }
   bool operator==(const Substitution &other) const;
   void print(llvm::raw_ostream &os,

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -415,7 +415,7 @@ public:
   }
 
   BuiltinInst *createBuiltin(SILLocation Loc, Identifier Name, SILType ResultTy,
-                             SubstitutionMap Subs,
+                             SubstitutionList Subs,
                              ArrayRef<SILValue> Args) {
     return insert(BuiltinInst::create(getSILDebugLocation(Loc), Name,
                                       ResultTy, Subs, Args, getModule()));
@@ -582,7 +582,7 @@ public:
   
   KeyPathInst *createKeyPath(SILLocation Loc,
                              KeyPathPattern *Pattern,
-                             SubstitutionMap Subs,
+                             SubstitutionList Subs,
                              ArrayRef<SILValue> Args,
                              SILType Ty) {
     return insert(KeyPathInst::create(getSILDebugLocation(Loc),
@@ -1446,7 +1446,7 @@ public:
   InitBlockStorageHeaderInst *
   createInitBlockStorageHeader(SILLocation Loc, SILValue BlockStorage,
                                SILValue InvokeFunction, SILType BlockType,
-                               SubstitutionMap Subs) {
+                               SubstitutionList Subs) {
     return insert(InitBlockStorageHeaderInst::create(getFunction(),
       getSILDebugLocation(Loc), BlockStorage, InvokeFunction, BlockType, Subs));
   }

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -114,15 +114,7 @@ protected:
     }
     return NewSubs;
   }
-
-  SubstitutionMap remapSubstitutionMap(SubstitutionMap Subs) {
-    return Subs;
-  }
-
-  SubstitutionMap getOpSubstitutionMap(SubstitutionMap Subs) {
-    return asImpl().remapSubstitutionMap(Subs);
-  }
-
+  
   SILType getTypeInClonedContext(SILType Ty) {
     auto objectTy = Ty.getSwiftRValueType();
     // Do not substitute opened existential types, if we do not have any.
@@ -569,7 +561,7 @@ SILCloner<ImplClass>::visitBuiltinInst(BuiltinInst *Inst) {
         getBuilder().createBuiltin(getOpLocation(Inst->getLoc()),
                                    Inst->getName(),
                                    getOpType(Inst->getType()),
-                                   getOpSubstitutionMap(Inst->getSubstitutions()),
+                                   getOpSubstitutions(Inst->getSubstitutions()),
                                    Args));
 }
 
@@ -2442,7 +2434,7 @@ void SILCloner<ImplClass>::visitInitBlockStorageHeaderInst(
                           getOpValue(Inst->getBlockStorage()),
                           getOpValue(Inst->getInvokeFunction()),
                           getOpType(Inst->getType()),
-                          getOpSubstitutionMap(Inst->getSubstitutions())));
+                          getOpSubstitutions(Inst->getSubstitutions())));
 }
 
 template <typename ImplClass>
@@ -2483,7 +2475,7 @@ void SILCloner<ImplClass>::visitKeyPathInst(KeyPathInst *Inst) {
   doPostProcess(Inst, getBuilder().createKeyPath(
                           getOpLocation(Inst->getLoc()),
                           Inst->getPattern(),
-                          getOpSubstitutionMap(Inst->getSubstitutions()),
+                          getOpSubstitutions(Inst->getSubstitutions()),
                           opValues,
                           getOpType(Inst->getType())));
 }

--- a/include/swift/SIL/SILNode.h
+++ b/include/swift/SIL/SILNode.h
@@ -162,6 +162,11 @@ protected:
   // Ensure that TupleInst bitfield does not overflow.
   IBWTO_BITFIELD_EMPTY(TupleInst, SingleValueInstruction);
 
+  IBWTO_BITFIELD(BuiltinInst, SingleValueInstruction,
+                             32-NumSingleValueInstructionBits,
+    NumSubstitutions : 32-NumSingleValueInstructionBits
+  );
+
   IBWTO_BITFIELD(ObjectInst, SingleValueInstruction,
                              32-NumSingleValueInstructionBits,
     NumBaseElements : 32-NumSingleValueInstructionBits

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -188,10 +188,6 @@ protected:
                       LookUpConformanceInSubstitutionMap(SubsMap));
   }
 
-  SubstitutionMap remapSubstitutionMap(SubstitutionMap Subs) {
-    return Subs.subst(SubsMap);
-  }
-
   void visitApplyInst(ApplyInst *Inst) {
     ApplySiteCloningHelper Helper(ApplySite(Inst), *this);
     ApplyInst *N =

--- a/lib/AST/CMakeLists.txt
+++ b/lib/AST/CMakeLists.txt
@@ -49,6 +49,7 @@ add_swift_library(swiftAST STATIC
   SILLayout.cpp
   Stmt.cpp
   Substitution.cpp
+  SubstitutionList.cpp
   SubstitutionMap.cpp
   SwiftNameTranslation.cpp
   Type.cpp

--- a/lib/AST/SubstitutionList.cpp
+++ b/lib/AST/SubstitutionList.cpp
@@ -1,4 +1,4 @@
-//===--- SubstitutionList.h - Compact SubstitutionMap -----------*- C++ -*-===//
+//===--- SubstitutionList.cpp - Compact SubstitutionMap -------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -16,27 +16,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_AST_SUBSTITUTION_LIST_H
-#define SWIFT_AST_SUBSTITUTION_LIST_H
-
-#include "swift/AST/Substitution.h"
-#include "llvm/ADT/ArrayRef.h"
+#include "swift/AST/SubstitutionList.h"
+#include "swift/AST/ProtocolConformanceRef.h"
 #include "llvm/ADT/FoldingSet.h"
 
-namespace llvm {
-class FoldingSetNodeID;
-} // end namespace llvm
+using namespace swift;
 
-namespace swift {
-
-// FIXME: Soon this will change.
-using SubstitutionList = ArrayRef<Substitution>;
-
-void dump(SubstitutionList subs);
-
-/// Profile the substitution list for use in a folding set.
-void profileSubstitutionList(llvm::FoldingSetNodeID &id, SubstitutionList subs);
-
-} // end namespace swift
-
-#endif
+void swift::profileSubstitutionList(llvm::FoldingSetNodeID &id,
+                                    SubstitutionList subs) {
+  id.AddInteger(subs.size());
+  for (auto &sub : subs) {
+    id.AddPointer(sub.getReplacement().getPointer());
+    for (auto conformance : sub.getConformances())
+      id.AddPointer(conformance.getOpaqueValue());
+  }
+}

--- a/lib/IRGen/GenBuiltin.h
+++ b/lib/IRGen/GenBuiltin.h
@@ -18,7 +18,7 @@
 #ifndef SWIFT_IRGEN_GENBUILTIN_H
 #define SWIFT_IRGEN_GENBUILTIN_H
 
-#include "swift/AST/SubstitutionMap.h"
+#include "swift/AST/SubstitutionList.h"
 #include "swift/Basic/LLVM.h"
 
 namespace swift {
@@ -34,7 +34,7 @@ namespace irgen {
   void emitBuiltinCall(IRGenFunction &IGF, const BuiltinInfo &builtin,
                        Identifier fnId, SILType resultType,
                        Explosion &args, Explosion &result,
-                       SubstitutionMap substitutions);
+                       SubstitutionList substitutions);
 
 } // end namespace irgen
 } // end namespace swift

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -753,7 +753,8 @@ emitKeyPathComponent(IRGenModule &IGM,
     SmallVector<llvm::Constant*, 4> descriptorArgs;
     auto componentSig = component.getExternalDecl()->getInnermostDeclContext()
       ->getGenericSignatureOfContext();
-    auto subs = component.getExternalSubstitutions();
+    auto subs = componentSig->getSubstitutionMap(
+                                        component.getExternalSubstitutions());
     enumerateGenericSignatureRequirements(
       componentSig->getCanonicalSignature(),
       [&](GenericRequirement reqt) {

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -4985,7 +4985,9 @@ void IRGenSILFunction::visitKeyPathInst(swift::KeyPathInst *I) {
   llvm::Value *args;
   if (!I->getSubstitutions().empty() || !I->getAllOperands().empty()) {
     auto sig = I->getPattern()->getGenericSignature();
-    SubstitutionMap subs = I->getSubstitutions();
+    SubstitutionMap subs;
+    if (sig)
+      subs = sig->getSubstitutionMap(I->getSubstitutions());
 
     SmallVector<GenericRequirement, 4> requirements;
     enumerateGenericSignatureRequirements(sig,

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1065,18 +1065,6 @@ public:
     printDebugVar(ABI->getVarInfo());
   }
 
-  void printSubstitutions(SubstitutionMap Subs) {
-    if (Subs.empty())
-      return;
-
-    *this << '<';
-    interleave(Subs.getReplacementTypes(),
-               [&](Type type) { *this << type; },
-               [&] { *this << ", "; });
-    *this << '>';
-
-  }
-
   void printSubstitutions(SubstitutionList Subs) {
     if (Subs.empty())
       return;

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -123,10 +123,14 @@ void verifyKeyPathComponent(SILModule &M,
                             const KeyPathPatternComponent &component,
                             ArrayRef<Operand> operands,
                             CanGenericSignature patternSig,
-                            SubstitutionMap patternSubs,
+                            SubstitutionList patternSubList,
                             bool forPropertyDescriptor,
                             bool hasIndices) {
   auto &C = M.getASTContext();
+  
+  SubstitutionMap patternSubs;
+  if (patternSig)
+    patternSubs  = patternSig->getSubstitutionMap(patternSubList);
   
   auto loweredBaseTy =
     M.Types.getLoweredType(AbstractionPattern::getOpaque(), baseTy);
@@ -145,7 +149,7 @@ void verifyKeyPathComponent(SILModule &M,
                         "operator");
         
         auto substEqualsType = equals->getLoweredFunctionType()
-          ->substGenericArgs(M, patternSubs);
+          ->substGenericArgs(M, patternSubList);
         
         require(substEqualsType->getParameters().size() == 2,
                 "must have two arguments");
@@ -177,7 +181,7 @@ void verifyKeyPathComponent(SILModule &M,
                       "operator");
         
         auto substHashType = hash->getLoweredFunctionType()
-          ->substGenericArgs(M, patternSubs);
+          ->substGenericArgs(M, patternSubList);
         
         require(substHashType->getParameters().size() == 1,
                 "must have two arguments");
@@ -258,7 +262,7 @@ void verifyKeyPathComponent(SILModule &M,
     {
       auto getter = component.getComputedPropertyGetter();
       auto substGetterType = getter->getLoweredFunctionType()
-        ->substGenericArgs(M, patternSubs);
+        ->substGenericArgs(M, patternSubList);
       require(substGetterType->getRepresentation() ==
                 SILFunctionTypeRepresentation::Thin,
               "getter should be a thin function");
@@ -297,7 +301,7 @@ void verifyKeyPathComponent(SILModule &M,
       
       auto setter = component.getComputedPropertySetter();
       auto substSetterType = setter->getLoweredFunctionType()
-        ->substGenericArgs(M, patternSubs);
+        ->substGenericArgs(M, patternSubList);
       
       require(substSetterType->getRepresentation() ==
                 SILFunctionTypeRepresentation::Thin,
@@ -365,7 +369,7 @@ void verifyKeyPathComponent(SILModule &M,
     CanGenericSignature canSig = nullptr;
     if (sig) {
       canSig = sig->getCanonicalSignature();
-      subs = component.getExternalSubstitutions();
+      subs = sig->getSubstitutionMap(component.getExternalSubstitutions());
     }
     auto substType = component.getExternalDecl()->getStorageInterfaceType()
       .subst(subs);
@@ -4046,7 +4050,7 @@ public:
             invokeTy->getExtInfo().isPseudogeneric(),
             "invoke function must not take reified generic parameters");
     
-    invokeTy = checkApplySubstitutions(IBSHI->getSubstitutions().toList(),
+    invokeTy = checkApplySubstitutions(IBSHI->getSubstitutions(),
                                     SILType::getPrimitiveObjectType(invokeTy));
     
     auto storageParam = invokeTy->getParameters()[0];
@@ -4132,7 +4136,10 @@ public:
     
     auto baseTy = CanType(kpBGT->getGenericArgs()[0]);
     auto pattern = KPI->getPattern();
-    SubstitutionMap patternSubs = KPI->getSubstitutions();
+    SubstitutionMap patternSubs;
+    if (pattern->getGenericSignature())
+      patternSubs = pattern->getGenericSignature()
+                           ->getSubstitutionMap(KPI->getSubstitutions());
     require(baseTy == pattern->getRootType().subst(patternSubs)->getCanonicalType(),
             "keypath root type should match root type of keypath pattern");
 
@@ -4776,10 +4783,10 @@ void SILProperty::verify(const SILModule &M) const {
                   ->getCanonicalType(sig);
   auto leafTy = decl->getStorageInterfaceType()->getReferenceStorageReferent()
                     ->getCanonicalType(sig);
-  SubstitutionMap subs;
+  SubstitutionList subs;
   if (sig) {
     auto env = dc->getGenericEnvironmentOfContext();
-    subs = env->getForwardingSubstitutionMap();
+    subs = env->getForwardingSubstitutions();
     baseTy = env->mapTypeIntoContext(baseTy)->getCanonicalType();
     leafTy = env->mapTypeIntoContext(leafTy)->getCanonicalType();
   }

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1391,12 +1391,6 @@ SILGenModule::useConformancesFromSubstitutions(SubstitutionList subs) {
   }
 }
 
-void SILGenModule::useConformancesFromSubstitutions(
-                                                const SubstitutionMap subs) {
-  for (auto conf : subs.getConformances())
-    useConformance(conf);
-}
-
 namespace {
 
 /// An RAII class to scope source file codegen.

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -428,9 +428,6 @@ public:
   /// Mark protocol conformances from the given set of substitutions as used.
   void useConformancesFromSubstitutions(SubstitutionList subs);
 
-  /// Mark protocol conformances from the given set of substitutions as used.
-  void useConformancesFromSubstitutions(SubstitutionMap subs);
-
   /// Emit a `mark_function_escape` instruction for top-level code when a
   /// function or closure at top level refers to script globals.
   void emitMarkFunctionEscapeForTopLevelCodeGlobals(SILLocation loc,

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -3869,7 +3869,7 @@ CallEmission::applySpecializedEmitter(SpecializedEmitter &specializedEmitter,
     // always still expressions.
     Expr *argument = std::move(uncurriedSites[0]).forward().asKnownExpr();
     ManagedValue resultMV =
-        emitter(SGF, uncurriedLoc, callee.getSubstitutions(),
+        emitter(SGF, uncurriedLoc, callee.getSubstitutions().toList(),
                 argument, uncurriedContext);
     firstLevelResult.value =
         RValue(SGF, uncurriedLoc, formalResultType, resultMV);
@@ -3889,7 +3889,7 @@ CallEmission::applySpecializedEmitter(SpecializedEmitter &specializedEmitter,
   if (specializedEmitter.isLateEmitter()) {
     auto emitter = specializedEmitter.getLateEmitter();
     ManagedValue mv = emitter(SGF, *uncurriedLoc,
-                              callee.getSubstitutions(),
+                              callee.getSubstitutions().toList(),
                               uncurriedArgs, uncurriedContext);
     firstLevelResult.value =
         RValue(SGF, *uncurriedLoc, formalApplyType.getResult(), mv);
@@ -3908,7 +3908,7 @@ CallEmission::applySpecializedEmitter(SpecializedEmitter &specializedEmitter,
   SILFunctionConventions substConv(substFnType, SGF.SGM.M);
   auto resultVal = SGF.B.createBuiltin(uncurriedLoc.getValue(), builtinName,
                                        substConv.getSILResultType(),
-                                       callee.getSubstitutions(),
+                                       callee.getSubstitutions().toList(),
                                        consumedArgs);
   firstLevelResult.value =
       RValue(SGF, *uncurriedLoc, formalApplyType.getResult(),

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -552,12 +552,12 @@ ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
 
   CanGenericSignature genericSig;
   GenericEnvironment *genericEnv = nullptr;
-  SubstitutionMap subs;
+  SubstitutionList subs;
   if (funcType->hasArchetype() || blockType->hasArchetype()) {
     genericSig = F.getLoweredFunctionType()->getGenericSignature();
     genericEnv = F.getGenericEnvironment();
 
-    subs = F.getForwardingSubstitutionMap();
+    subs = F.getForwardingSubstitutions();
 
     // The block invoke function must be pseudogeneric. This should be OK for now
     // since a bridgeable function's parameters and returns should all be

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -118,7 +118,7 @@ SILGenBuilder::createPartialApply(SILLocation loc, SILValue fn,
 
 BuiltinInst *SILGenBuilder::createBuiltin(SILLocation loc, Identifier name,
                                           SILType resultTy,
-                                          SubstitutionMap subs,
+                                          SubstitutionList subs,
                                           ArrayRef<SILValue> args) {
   getSILGenModule().useConformancesFromSubstitutions(subs);
   return SILBuilder::createBuiltin(loc, name, resultTy, subs, args);

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -101,7 +101,7 @@ public:
   }
 
   BuiltinInst *createBuiltin(SILLocation loc, Identifier name, SILType resultTy,
-                             SubstitutionMap subs, ArrayRef<SILValue> args);
+                             SubstitutionList subs, ArrayRef<SILValue> args);
 
   // Existential containers use the conformances needed by the existential
   // box.

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -4025,7 +4025,8 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
                  indexEquals, indexHash);
       }
       return KeyPathPatternComponent::forExternal(
-        decl, subMap, SGF.getASTContext().AllocateCopy(indices),
+        decl, SGF.getASTContext().AllocateCopy(subMap.toList()),
+        SGF.getASTContext().AllocateCopy(indices),
         indexEquals, indexHash,
         ty->getCanonicalType());
     };
@@ -4107,8 +4108,8 @@ RValue RValueEmitter::visitKeyPathExpr(KeyPathExpr *E, SGFContext C) {
                                      objcString);
   auto keyPath = SGF.B.createKeyPath(SILLocation(E), pattern,
                                      needsGenericContext
-                                       ? SGF.F.getForwardingSubstitutionMap()
-                                       : SubstitutionMap(),
+                                       ? SGF.F.getForwardingSubstitutions()
+                                       : SubstitutionList(),
                                      operands,
                                      loweredTy);
   auto value = SGF.emitManagedRValueWithCleanup(keyPath);

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -2617,8 +2617,6 @@ static void emitDiagnoseOfUnexpectedEnumCase(SILGenFunction &SGF,
   ManagedValue metatype = SGF.B.createValueMetatype(loc, metatypeType, value);
 
   Substitution sub{switchedValueSwiftType, /*Conformances*/None};
-  auto genericArgsMap =
-      diagnoseFailure->getGenericSignature()->getSubstitutionMap(sub);
 
   SGF.emitApplyOfLibraryIntrinsic(loc, diagnoseFailure, genericArgsMap,
                                   metatype,

--- a/lib/SILGen/SpecializedEmitter.h
+++ b/lib/SILGen/SpecializedEmitter.h
@@ -41,7 +41,7 @@ public:
   /// have already been emitted.
   using EarlyEmitter = ManagedValue (SILGenFunction &,
                                      SILLocation,
-                                     SubstitutionMap,
+                                     SubstitutionList,
                                      Expr *argument,
                                      SGFContext);
 
@@ -49,7 +49,7 @@ public:
   /// have already been emitted.
   using LateEmitter = ManagedValue (SILGenFunction &,
                                     SILLocation,
-                                    SubstitutionMap,
+                                    SubstitutionList,
                                     ArrayRef<ManagedValue>,
                                     SGFContext);
 

--- a/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
@@ -84,10 +84,10 @@ SILInstruction *SILCombiner::optimizeBuiltinCanBeObjCClass(BuiltinInst *BI) {
   assert(BI->hasSubstitutions() && "Expected substitutions for canBeClass");
 
   auto const &Subs = BI->getSubstitutions();
-  assert((Subs.getReplacementTypes().size() == 1) &&
+  assert((Subs.size() == 1) &&
          "Expected one substitution in call to canBeClass");
 
-  auto Ty = Subs.getReplacementTypes()[0]->getCanonicalType();
+  auto Ty = Subs[0].getReplacement()->getCanonicalType();
   switch (Ty->canBeClass()) {
   case TypeTraitResult::IsNot:
     return Builder.createIntegerLiteral(BI->getLoc(), BI->getType(),
@@ -514,10 +514,11 @@ SILInstruction *SILCombiner::visitBuiltinInst(BuiltinInst *I) {
       [](const APInt &i) -> bool { return false; }           /* isZero */,
       Builder, this);
   case BuiltinValueKind::DestroyArray: {
-    SubstitutionMap Substs = I->getSubstitutions();
+    SubstitutionList Substs = I->getSubstitutions();
     // Check if the element type is a trivial type.
-    if (Substs.getReplacementTypes().size() == 1) {
-      Type ElemType = Substs.getReplacementTypes()[0];
+    if (Substs.size() == 1) {
+      Substitution Subst = Substs[0];
+      Type ElemType = Subst.getReplacement();
       auto &SILElemTy = I->getModule().Types.getTypeLowering(ElemType);
       // Destroying an array of trivial types is a no-op.
       if (SILElemTy.isTrivial())

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -343,8 +343,8 @@ static bool usesGenerics(SILFunction *F,
       // Scan all substitutions of builtin instructions.
       if (auto *BI = dyn_cast<BuiltinInst>(&I)) {
         auto Subs = BI->getSubstitutions();
-        for (auto Ty : Subs.getReplacementTypes()) {
-          Ty.visit(FindArchetypesAndGenericTypes);
+        for (auto Sub : Subs) {
+          Sub.getReplacement().visit(FindArchetypesAndGenericTypes);
         }
       }
 


### PR DESCRIPTION
Reverts apple/swift#16334. It broke something in the source compatibility suite, as well as the `parse_stdlib` long test.