### PR TITLE
Revert "[NFC] Remove unused/unnecessary variable."

### DIFF
--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -2617,6 +2617,8 @@ static void emitDiagnoseOfUnexpectedEnumCase(SILGenFunction &SGF,
   ManagedValue metatype = SGF.B.createValueMetatype(loc, metatypeType, value);
 
   Substitution sub{switchedValueSwiftType, /*Conformances*/None};
+  auto genericArgsMap =
+      diagnoseFailure->getGenericSignature()->getSubstitutionMap(sub);
 
   SGF.emitApplyOfLibraryIntrinsic(loc, diagnoseFailure, genericArgsMap,
                                   metatype,


### PR DESCRIPTION
This reverts commit 411609a4e340159ea93b022ab0904ffaffc030cc. We are using this variable now.