### PR TITLE
Add descriptions for SwiftSyntax errors

### DIFF
--- a/tools/SwiftSyntax/SwiftSyntax.swift
+++ b/tools/SwiftSyntax/SwiftSyntax.swift
@@ -22,9 +22,23 @@ import Glibc
 
 /// A list of possible errors that could be encountered while parsing a
 /// Syntax tree.
-public enum ParserError: Error {
+public enum ParserError: Error, CustomStringConvertible {
   case swiftcFailed(Int, String)
   case invalidFile
+
+  public var description: String {
+    switch self{
+    case let .swiftcFailed(exitCode, stderr):
+      let stderrLines = stderr.split(separator: "\n")
+      return """
+      swiftc returned with non-zero exit code \(exitCode)
+      stderr:
+        \(stderrLines.joined(separator: "\n  "))
+      """
+    case .invalidFile:
+      return "swiftc created an invalid syntax file"
+    }
+  }
 }
 
 extension Syntax {

--- a/tools/SwiftSyntax/SwiftcInvocation.swift
+++ b/tools/SwiftSyntax/SwiftcInvocation.swift
@@ -108,10 +108,18 @@ func findFirstObjectFile(for dsohandle: UnsafeRawPointer = #dsohandle) -> URL? {
   return URL(fileURLWithPath: path)
 }
 
-enum InvocationError: Error {
+enum InvocationError: Error, CustomStringConvertible {
   case couldNotFindSwiftc
   case couldNotFindSDK
-  case abort(code: Int)
+
+  var description: String {
+    switch self {
+    case .couldNotFindSwiftc:
+      return "could not locate swift compiler binary"
+    case .couldNotFindSDK:
+      return "could not locate macOS SDK"
+    }
+  }
 }
 
 struct SwiftcRunner {


### PR DESCRIPTION
This patch adds description strings for SwiftSyntax errors. It just makes SwiftSyntax tooling development a little nicer.