### PR TITLE
[tools] Add a libfuzzer based swift demangler fuzzer.

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -2306,6 +2306,38 @@ function(add_swift_host_tool executable)
   endif()
 endfunction()
 
+macro(add_swift_fuzz_tool executable)
+  cmake_parse_arguments(
+      ADDSWIFTHOSTTOOL # prefix
+      "" # options
+      "" # single-value args
+      "SWIFT_COMPONENT" # multi-value args
+      ${ARGN})
+
+  # Create the executable rule.
+  add_swift_executable(${executable} ${ADDSWIFTHOSTTOOL_UNPARSED_ARGUMENTS})
+
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=fuzzer")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=fuzzer")
+  set(LINK_FLAGS "${LINK_FLAGS} -fsanitize=fuzzer")
+
+  # And then create the install rule if we are asked to.
+  if (ADDSWIFTHOSTTOOL_SWIFT_COMPONENT)
+    swift_install_in_component(${ADDSWIFTHOSTTOOL_SWIFT_COMPONENT}
+      TARGETS ${executable}
+      RUNTIME DESTINATION bin)
+
+    swift_is_installing_component(${ADDSWIFTHOSTTOOL_SWIFT_COMPONENT}
+      is_installing)
+
+    if(NOT is_installing)
+      set_property(GLOBAL APPEND PROPERTY SWIFT_BUILDTREE_EXPORTS ${executable})
+    else()
+      set_property(GLOBAL APPEND PROPERTY SWIFT_EXPORTS ${executable})
+    endif()
+  endif()
+endmacro()
+
 macro(add_swift_tool_symlink name dest component)
   add_llvm_tool_symlink(${name} ${dest} ALWAYS_GENERATE)
   llvm_install_symlink(${name} ${dest} ALWAYS_GENERATE COMPONENT ${component})

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -30,6 +30,10 @@ add_swift_tool_subdirectory(swift-api-digester)
 add_swift_tool_subdirectory(swift-syntax-test)
 add_swift_tool_subdirectory(swift-refactor)
 
+if(LLVM_USE_SANITIZE_COVERAGE)
+add_swift_tool_subdirectory(swift-demangle-fuzzer)
+endif()
+
 if(SWIFT_BUILD_STDLIB AND SWIFT_BUILD_SDK_OVERLAY)
   set(BUILD_FOUNDATION TRUE)
 else()

--- a/tools/swift-demangle-fuzzer/CMakeLists.txt
+++ b/tools/swift-demangle-fuzzer/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_swift_fuzz_tool(swift-demangle-fuzzer
+  swift-demangle-fuzzer.cpp
+  LINK_LIBRARIES swiftDemangling
+  LLVM_COMPONENT_DEPENDS support
+  SWIFT_COMPONENT compiler
+  )

--- a/tools/swift-demangle-fuzzer/swift-demangle-fuzzer.cpp
+++ b/tools/swift-demangle-fuzzer/swift-demangle-fuzzer.cpp
@@ -1,0 +1,34 @@
+//===--- swift-demangle-fuzzer.cpp - Swift fuzzer -------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This program tries to fuzz the demangler shipped as part of the swift
+// compiler.
+// For this to work you need to pass --enable-sanitizer-coverage to build-script
+// otherwise the fuzzer doesn't have coverage information to make progress
+// (making the whole fuzzing operation really ineffective).
+// It is recommended to use the tool together with another sanitizer to expose
+// more bugs (asan, lsan, etc...)
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Demangling/Demangle.h"
+#include "swift/Demangling/ManglingMacros.h"
+#include <stddef.h>
+#include <stdint.h>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+  swift::Demangle::Context DCtx;
+  swift::Demangle::DemangleOptions Opts;
+  std::string NullTermStr((const char *)Data, Size);
+  swift::Demangle::NodePointer pointer = DCtx.demangleSymbolAsNode(NullTermStr);
+  return 0; // Non-zero return values are reserved for future use.
+}


### PR DESCRIPTION
The debugger demangles names pretty often and we would like
to ensure it never crashes.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
