### PR TITLE
SwiftSyntax: Allow absolute position access for dangling nodes.

### DIFF
--- a/test/SwiftSyntax/AbsolutePosition.swift
+++ b/test/SwiftSyntax/AbsolutePosition.swift
@@ -144,4 +144,16 @@ PositionTests.test("Implicit") {
   })
 }
 
+PositionTests.test("WithoutSourceFileRoot") {
+  expectDoesNotThrow({
+    let item = SyntaxFactory.makeCodeBlockItem(
+      item: SyntaxFactory.makeReturnStmt(
+        returnKeyword: SyntaxFactory.makeToken(.returnKeyword, presence: .present)
+          .withLeadingTrivia(.newlines(1)).withTrailingTrivia(.newlines(1)),
+            expression: nil), semicolon: nil)
+     expectEqual(0, item.position.utf8Offset)
+     expectEqual(1, item.positionAfterSkippingLeadingTrivia.utf8Offset)
+  })
+}
+
 runAllTests()

--- a/tools/SwiftSyntax/RawSyntax.swift
+++ b/tools/SwiftSyntax/RawSyntax.swift
@@ -257,13 +257,4 @@ extension RawSyntax {
       piece.accumulateAbsolutePosition(pos)
     }
   }
-
-  var isSourceFile: Bool {
-    switch self {
-    case .node(let kind, _, _):
-      return kind == SyntaxKind.sourceFile
-    default:
-      return false
-    }
-  }
 }

--- a/tools/SwiftSyntax/SyntaxData.swift
+++ b/tools/SwiftSyntax/SyntaxData.swift
@@ -43,7 +43,6 @@ final class SyntaxData: Equatable {
   fileprivate func calculatePosition(_ initPos: AbsolutePosition) ->
       AbsolutePosition {
     guard let parent = parent else {
-      assert(raw.isSourceFile, "cannot find SourceFileSyntax as root")
       // If this node is SourceFileSyntax, its location is the start of the file.
       return initPos
     }
@@ -78,7 +77,6 @@ final class SyntaxData: Equatable {
     // If this node is root, the position of the next sibling is the end of
     // this node.
     guard let parent = parent else {
-      assert(raw.isSourceFile, "cannot find SourceFileSyntax as root")
       let result = self.position.copy()
       raw.accumulateAbsolutePosition(result)
       return result


### PR DESCRIPTION
Since absolute position is defined by accumulating proceeding nodes,
we should allow its access for nodes without SourceFileSyntax as root.
