### PR TITLE
Fix some oversights in AST dumping

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1906,7 +1906,7 @@ public:
       OS << '\n';
       printRec(E->getArgument());
     }
-    OS << "')";
+    OS << ")";
   }
   void visitDotSelfExpr(DotSelfExpr *E) {
     printCommon(E, "dot_self_expr");

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1960,6 +1960,7 @@ public:
     if (auto semaE = E->getSemanticExpr()) {
       OS << '\n';
       printRec(semaE);
+      PrintWithColorRAII(OS, ParenthesisColor) << ')';
       return;
     }
     for (auto elt : E->getElements()) {


### PR DESCRIPTION
This addresses two mistakes in AST dumping that make consuming AST dumps<sup>1</sup> more challenging than necessary:
1. `dictionary_expr` has a missing closing paren when it has a semantic expression.
2. `unresolved_member_expr` contains an unmatched single quote.

---

<sub>1: I understand that the AST dump format is unstable and isn't intended to be consumed, but it's the best option we've found for what we're trying to do.</sub>