### PR TITLE
[4.2][4/30][String] Define _copyContents for UTF8View

### DIFF
--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -474,6 +474,11 @@ extension String.UTF8View.Iterator : IteratorProtocol {
     self._endOffset = utf8._guts.count
   }
 
+  internal mutating func _clear() {
+    self._nextOffset = self._endOffset
+    self._buffer = _OutputBuffer()
+  }
+
   @inlinable // FIXME(sil-serialize-all)
   public mutating func next() -> Unicode.UTF8.CodeUnit? {
     if _slowPath(_nextOffset == _endOffset) {
@@ -729,5 +734,44 @@ extension String.UTF8View {
   @available(swift, obsoleted: 4)
   public subscript(bounds: ClosedRange<Index>) -> String.UTF8View {
     return self[bounds.relative(to: self)]
+  }
+}
+
+extension String.UTF8View {
+  /// Copies `self` into the supplied buffer.
+  ///
+  /// - Precondition: The memory in `self` is uninitialized. The buffer must
+  ///   contain sufficient uninitialized memory to accommodate `source.underestimatedCount`.
+  ///
+  /// - Postcondition: The `Pointee`s at `buffer[startIndex..<returned index]` are
+  ///   initialized.
+  public func _copyContents(
+    initializing buffer: UnsafeMutableBufferPointer<Iterator.Element>
+  ) -> (Iterator,UnsafeMutableBufferPointer<Iterator.Element>.Index) {
+    guard var ptr = buffer.baseAddress else {
+        _preconditionFailure(
+          "Attempt to copy string contents into nil buffer pointer")
+    }
+    var it = self.makeIterator()
+
+    if _guts.isASCII {
+      defer { _fixLifetime(_guts) }
+      let asciiView = _guts._unmanagedASCIIView
+      _precondition(asciiView.count <= buffer.count,
+        "Insufficient space allocated to copy string contents")
+      ptr.initialize(from: asciiView.start, count: asciiView.count)
+      it._clear()
+      return (it, buffer.index(buffer.startIndex, offsetBy: asciiView.count))
+    }
+    else {
+      for idx in buffer.startIndex..<buffer.count {
+        guard let x = it.next() else {
+          return (it, idx)
+        }
+        ptr.initialize(to: x)
+        ptr += 1
+      }
+      return (it,buffer.endIndex)
+    }
   }
 }


### PR DESCRIPTION
Define _copyContents on String.UTF8View, which allows it to
efficiently memcpy bytes when the String is already in UTF-8 (or
ASCII).

<!-- What's in this pull request? -->
<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->

4/30 cherry-pick of https://github.com/apple/swift/pull/16313