### PR TITLE
stdlib: remove some @inlineables from String API functions.

### DIFF
--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -1028,7 +1028,6 @@ extension _StringGuts {
     self.append(other._wholeString._guts, range: other._encodedOffsetRange)
   }
 
-  @inlinable
   public // TODO(StringGuts): for testing only
   mutating func append(_ other: _StringGuts) {
     // FIXME(TODO: JIRA): shouldn't _isEmptySingleton be sufficient?

--- a/stdlib/public/core/StringIndexConversions.swift
+++ b/stdlib/public/core/StringIndexConversions.swift
@@ -49,7 +49,6 @@ extension String.Index {
   ///     `sourcePosition` must be a valid index of at least one of the views
   ///     of `target`.
   ///   - target: The string referenced by the resulting index.
-  @inlinable // FIXME(sil-serialize-all)
   public init?(
     _ sourcePosition: String.Index,
     within target: String

--- a/stdlib/public/core/StringLegacy.swift
+++ b/stdlib/public/core/StringLegacy.swift
@@ -160,7 +160,6 @@ extension StringProtocol {
 }
 
 extension String {
-  @inlinable // FIXME(sil-serialize-all)
   public func hasPrefix(_ prefix: String) -> Bool {
     let prefixCount = prefix._guts.count
     if prefixCount == 0 { return true }
@@ -208,7 +207,6 @@ extension String {
     return self.starts(with: prefix)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   public func hasSuffix(_ suffix: String) -> Bool {
     let suffixCount = suffix._guts.count
     if suffixCount == 0 { return true }

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift
@@ -89,6 +89,11 @@ extension String : StringProtocol, RangeReplaceableCollection {
   @inlinable // FIXME(sil-serialize-all)
   public var endIndex: Index { return Index(encodedOffset: _guts.count) }
 
+  /// The number of characters in a string.
+  public var count: Int {
+    return distance(from: startIndex, to: endIndex)
+  }
+
   @inlinable
   @inline(__always)
   internal func _boundsCheck(_ index: Index) {
@@ -114,7 +119,6 @@ extension String : StringProtocol, RangeReplaceableCollection {
       "String index range is out of bounds")
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   internal func _index(atEncodedOffset offset: Int) -> Index {
     return _visitGuts(_guts, args: offset,
       ascii: { ascii, offset in return ascii.characterIndex(atOffset: offset) },
@@ -128,7 +132,6 @@ extension String : StringProtocol, RangeReplaceableCollection {
   /// - Parameter i: A valid index of the collection. `i` must be less than
   ///   `endIndex`.
   /// - Returns: The index value immediately after `i`.
-  @inlinable // FIXME(sil-serialize-all)
   public func index(after i: Index) -> Index {
     return _visitGuts(_guts, args: i,
       ascii: { ascii, i in ascii.characterIndex(after: i) },
@@ -141,7 +144,6 @@ extension String : StringProtocol, RangeReplaceableCollection {
   /// - Parameter i: A valid index of the collection. `i` must be greater than
   ///   `startIndex`.
   /// - Returns: The index value immediately before `i`.
-  @inlinable // FIXME(sil-serialize-all)
   public func index(before i: Index) -> Index {
     return _visitGuts(_guts, args: i,
       ascii: { ascii, i in ascii.characterIndex(before: i) },
@@ -171,7 +173,6 @@ extension String : StringProtocol, RangeReplaceableCollection {
   ///   to `index(before:)`.
   ///
   /// - Complexity: O(*n*), where *n* is the absolute value of `n`.
-  @inlinable // FIXME(sil-serialize-all)
   public func index(_ i: Index, offsetBy n: IndexDistance) -> Index {
     return _visitGuts(_guts, args: (i, n),
       ascii: { ascii, args in let (i, n) = args
@@ -219,7 +220,6 @@ extension String : StringProtocol, RangeReplaceableCollection {
   ///   the method returns `nil`.
   ///
   /// - Complexity: O(*n*), where *n* is the absolute value of `n`.
-  @inlinable // FIXME(sil-serialize-all)
   public func index(
     _ i: Index, offsetBy n: IndexDistance, limitedBy limit: Index
   ) -> Index? {
@@ -241,7 +241,6 @@ extension String : StringProtocol, RangeReplaceableCollection {
   /// - Returns: The distance between `start` and `end`.
   ///
   /// - Complexity: O(*n*), where *n* is the resulting distance.
-  @inlinable // FIXME(sil-serialize-all)
   public func distance(from start: Index, to end: Index) -> IndexDistance {
     return _visitGuts(_guts, args: (start, end),
       ascii: { ascii, args in let (start, end) = args
@@ -267,7 +266,6 @@ extension String : StringProtocol, RangeReplaceableCollection {
   ///
   /// - Parameter i: A valid index of the string. `i` must be less than the
   ///   string's end index.
-  @inlinable // FIXME(sil-serialize-all)
   public subscript(i: Index) -> Character {
     return _visitGuts(_guts, args: i,
       ascii: { ascii, i in return ascii.character(at: i) },

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -161,7 +161,8 @@ func rdar20142523() {
 // <rdar://problem/21080030> Bad diagnostic for invalid method call in boolean expression: (_, ExpressibleByIntegerLiteral)' is not convertible to 'ExpressibleByIntegerLiteral
 func rdar21080030() {
   var s = "Hello"
-  if s.count() == 0 {} // expected-error{{cannot call value of non-function type 'Int'}}{{13-15=}}
+  // SR-7599: This should be `cannot_call_non_function_value`
+  if s.count() == 0 {} // expected-error{{cannot invoke 'count' with no arguments}}
 }
 
 // <rdar://problem/21248136> QoI: problem with return type inference mis-diagnosed as invalid arguments


### PR DESCRIPTION
Beside the general goal to remove inlinable functions, this reduces code size and also improves performance for several benchmarks.
The performance problem was that by inlining top-level String API functions into client code (like String.count) it ended up calling non-inlinable internal String functions eventually.
This is much slower than to make a single call at the top-level API boundary into the library. Inside the library all the internal String functions can be specialized and inlined.

rdar://problem/39921548
