### PR TITLE
[stdlib] Undeprecate Countable*Range

### DIFF
--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -495,6 +495,5 @@ extension ClosedRange {
 @available(*, deprecated, renamed: "ClosedRange.Index")
 public typealias ClosedRangeIndex<T> = ClosedRange<T>.Index where T: Strideable, T.Stride: SignedInteger
 
-@available(*, deprecated: 4.2, renamed: "ClosedRange")
 public typealias CountableClosedRange<Bound: Strideable> = ClosedRange<Bound>
   where Bound.Stride : SignedInteger

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -905,10 +905,8 @@ extension Range {
   }
 }
 
-@available(*, deprecated, renamed: "Range")
 public typealias CountableRange<Bound: Strideable> = Range<Bound>
   where Bound.Stride : SignedInteger
 
-@available(*, deprecated: 4.2, renamed: "PartialRangeFrom")
 public typealias CountablePartialRangeFrom<Bound: Strideable> = PartialRangeFrom<Bound>
   where Bound.Stride : SignedInteger

--- a/test/Compatibility/stdlib_generic_typealiases.swift
+++ b/test/Compatibility/stdlib_generic_typealiases.swift
@@ -2,8 +2,7 @@
 
 struct RequiresStrideable<T: Strideable> { }
 
-extension CountableRange { // expected-warning{{'CountableRange' is deprecated: renamed to 'Range'}}
-  // expected-note@-1{{use 'Range' instead}}{{11-25=Range}}
+extension CountableRange {
   func testStrideable() {
     _ = RequiresStrideable<Bound>()
   }
@@ -24,7 +23,5 @@ extension DictionaryIndex {
 }
 
 extension CountableRange where Element == Int {
-  // expected-warning@-1{{'CountableRange' is deprecated: renamed to 'Range'}}
-  // expected-note@-2{{use 'Range' instead}}
   func getLowerBoundAsInt() -> Int { return lowerBound }
 }


### PR DESCRIPTION
Now that `Range` is conditionally a `Sequence`, `CountableRange` is redundant and implemented as a generic typealias for source compatibility.

However, it's still useful shorthand for a `Range` that is countable. This change removes the deprecation on the typealias, for now, pending feedback.