### PR TITLE
[4.2][4/30][migrator] Only enable Swift 3 ObjC inference warnings when migrating from Swift 3

### DIFF
--- a/lib/Migrator/Migrator.cpp
+++ b/lib/Migrator/Migrator.cpp
@@ -133,20 +133,22 @@ Migrator::performAFixItMigration(version::Version SwiftLanguageVersion) {
     LLVMArgs.erase(aarch64_use_tbi);
   }
 
-  // SE-0160: When migrating, always use the Swift 3 @objc inference rules,
-  // which drives warnings with the "@objc" Fix-Its.
-  Invocation.getLangOptions().EnableSwift3ObjCInference = true;
+  if (StartInvocation.getLangOptions().EffectiveLanguageVersion.isVersion3()) {
+    // SE-0160: When migrating, always use the Swift 3 @objc inference rules,
+    // which drives warnings with the "@objc" Fix-Its.
+    Invocation.getLangOptions().EnableSwift3ObjCInference = true;
 
-  // The default behavior of the migrator, referred to as "minimal" migration
-  // in SE-0160, only adds @objc Fix-Its to those cases where the Objective-C
-  // entry point is explicitly used somewhere in the source code. The user
-  // may also select a workflow that adds @objc for every declaration that
-  // would infer @objc under the Swift 3 rules but would no longer infer
-  // @objc in Swift 4.
-  Invocation.getLangOptions().WarnSwift3ObjCInference =
-    getMigratorOptions().KeepObjcVisibility
-      ? Swift3ObjCInferenceWarnings::Complete
-      : Swift3ObjCInferenceWarnings::Minimal;
+    // The default behavior of the migrator, referred to as "minimal" migration
+    // in SE-0160, only adds @objc Fix-Its to those cases where the Objective-C
+    // entry point is explicitly used somewhere in the source code. The user
+    // may also select a workflow that adds @objc for every declaration that
+    // would infer @objc under the Swift 3 rules but would no longer infer
+    // @objc in Swift 4.
+    Invocation.getLangOptions().WarnSwift3ObjCInference =
+      getMigratorOptions().KeepObjcVisibility
+        ? Swift3ObjCInferenceWarnings::Complete
+        : Swift3ObjCInferenceWarnings::Minimal;
+  }
 
   const auto &OrigFrontendOpts = StartInvocation.getFrontendOptions();
 

--- a/test/Migrator/complete_objc_inference.swift
+++ b/test/Migrator/complete_objc_inference.swift
@@ -1,5 +1,5 @@
 // REQUIRES: objc_interop
 // RUN: %target-swift-frontend -typecheck -swift-version 3 -enable-swift3-objc-inference %s
-// RUN: %empty-directory(%t) && %target-swift-frontend -c -primary-file %S/Inputs/objc_inference.swift -emit-migrated-file-path %t/complete_objc_inference.swift.result -emit-remap-file-path %t/complete_objc_inference.swift.remap -migrate-keep-objc-visibility -o /dev/null
-// RUN: diff -u %S/complete_objc_inference.swift.expected %t/complete_objc_inference.swift.result 
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -primary-file %S/Inputs/objc_inference.swift -swift-version 3 -emit-migrated-file-path %t/complete_objc_inference.swift.result -emit-remap-file-path %t/complete_objc_inference.swift.remap -migrate-keep-objc-visibility -o /dev/null
+// RUN: diff -u %S/complete_objc_inference.swift.expected %t/complete_objc_inference.swift.result
 // RUN: %target-swift-frontend -typecheck -swift-version 4 -enable-swift3-objc-inference %t/complete_objc_inference.swift.result

--- a/test/Migrator/minimal_objc_inference.swift
+++ b/test/Migrator/minimal_objc_inference.swift
@@ -1,5 +1,5 @@
 // REQUIRES: objc_interop
 // RUN: %target-swift-frontend -typecheck -swift-version 3 %s
-// RUN: %empty-directory(%t) && %target-swift-frontend -c -primary-file %S/Inputs/objc_inference.swift -emit-migrated-file-path %t/minimal_objc_inference.swift.result -emit-remap-file-path %t/minimal_objc_inference.swift.remap -o /dev/null
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -primary-file %S/Inputs/objc_inference.swift -swift-version 3 -emit-migrated-file-path %t/minimal_objc_inference.swift.result -emit-remap-file-path %t/minimal_objc_inference.swift.remap -o /dev/null
 // RUN: diff -u %S/minimal_objc_inference.swift.expected %t/minimal_objc_inference.swift.result
 // RUN: %target-swift-frontend -typecheck -swift-version 4 %t/minimal_objc_inference.swift.result

--- a/test/Migrator/objc_inference_noop.swift
+++ b/test/Migrator/objc_inference_noop.swift
@@ -1,0 +1,10 @@
+// REQUIRES: objc_interop
+// RUN: %target-swift-frontend -typecheck -swift-version 4 %s
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -primary-file %s -swift-version 4 -emit-migrated-file-path %t/objc_inference_noop.swift.result -emit-remap-file-path %t/objc_inference_noop.swift.remap -migrate-keep-objc-visibility -o /dev/null
+// RUN: diff -u %s %t/objc_inference_noop.swift.result
+
+import Foundation
+
+@objc class Foo : NSObject {
+  var foo: Int = 10
+}


### PR DESCRIPTION
They were always enabled, meaning migrating from Swift 4 -> 4.2 would pick up
the associated fixits and add `@objc` unnecessarily in many places.

Cherry-pick of https://github.com/apple/swift/pull/16353
Resolves rdar://problem/39951671

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
