### PR TITLE
Emits a DW_OP_deref for global variables in a fixed size buffer.

### DIFF
--- a/lib/IRGen/GenDecl.h
+++ b/lib/IRGen/GenDecl.h
@@ -46,13 +46,11 @@ namespace irgen {
                                  OptimizationMode FuncOptMode =
                                    OptimizationMode::NotSet);
 
-  llvm::GlobalVariable *createVariable(IRGenModule &IGM,
-                                       LinkInfo &linkInfo,
-                                       llvm::Type *objectType,
-                                       Alignment alignment,
-                                       DebugTypeInfo DebugType=DebugTypeInfo(),
-                                       Optional<SILLocation> DebugLoc = None,
-                                       StringRef DebugName = StringRef());
+  llvm::GlobalVariable *
+  createVariable(IRGenModule &IGM, LinkInfo &linkInfo, llvm::Type *objectType,
+                 Alignment alignment, DebugTypeInfo DebugType = DebugTypeInfo(),
+                 Optional<SILLocation> DebugLoc = None,
+                 StringRef DebugName = StringRef(), bool heapAllocated = false);
 
   void disableAddressSanitizer(IRGenModule &IGM, llvm::GlobalVariable *var);
 }

--- a/lib/IRGen/GenInit.cpp
+++ b/lib/IRGen/GenInit.cpp
@@ -45,7 +45,8 @@ void IRGenModule::emitSILGlobalVariable(SILGlobalVariable *var) {
       auto DbgTy = DebugTypeInfo::getGlobal(var, Int8Ty, Size(0), Alignment(1));
       DebugInfo->emitGlobalVariableDeclaration(
           nullptr, var->getDecl()->getName().str(), "", DbgTy,
-          var->getLinkage() != SILLinkage::Public, SILLocation(var->getDecl()));
+          var->getLinkage() != SILLinkage::Public,
+          IRGenDebugInfo::NotHeapAllocated, SILLocation(var->getDecl()));
     }
     return;
   }

--- a/lib/IRGen/IRGenDebugInfo.h
+++ b/lib/IRGen/IRGenDebugInfo.h
@@ -136,11 +136,13 @@ public:
                         unsigned Line, unsigned Col, llvm::DILocalScope *Scope,
                         const SILDebugScope *DS);
 
+  enum { NotHeapAllocated = false };
+  
   /// Create debug metadata for a global variable.
   void emitGlobalVariableDeclaration(llvm::GlobalVariable *Storage,
                                      StringRef Name, StringRef LinkageName,
                                      DebugTypeInfo DebugType,
-                                     bool IsLocalToUnit,
+                                     bool IsLocalToUnit, bool InFixedBuffer,
                                      Optional<SILLocation> Loc);
 
   /// Emit debug metadata for type metadata (for generic types). So meta.

--- a/test/DebugInfo/resilience.swift
+++ b/test/DebugInfo/resilience.swift
@@ -13,9 +13,25 @@
 // RUN:    -enable-resilience-bypass | %FileCheck %s --check-prefix=CHECK-LLDB
 import resilient_struct
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S10resilience1fyyF"()
-// CHECK-LLDB-LABEL: define{{( protected)?}} swiftcc void @"$S10resilience1fyyF"()
-public func f() {
+let fixed = Point(x: 1, y: 2)
+let non_fixed = Size(w: 1, h: 2)
+let int = ResilientInt(i: 1)
+// CHECK: @"$S10resilience5fixed16resilient_struct5PointVvp" =
+// CHECK-SAME: !dbg ![[FIXED:[0-9]+]]
+// CHECK: @"$S10resilience9non_fixed16resilient_struct4SizeVvp" =
+// CHECK-SAME: !dbg ![[NON_FIXED:[0-9]+]]
+// CHECK: @"$S10resilience3int16resilient_struct12ResilientIntVvp" =
+// CHECK-SAME: !dbg ![[INT:[0-9]+]]
+// CHECK-LABEL: define{{.*}}main
+
+// CHECK-LABEL: define{{.*}} swiftcc void @"$S10resilience9takesSizeyy16resilient_struct0C0VF"(%swift.opaque* noalias nocapture)
+// CHECK-LLDB-LABEL: define{{.*}} swiftcc void @"$S10resilience9takesSizeyy16resilient_struct0C0VF"(%T16resilient_struct4SizeV* noalias nocapture dereferenceable({{8|16}}))
+public func takesSize(_ s: Size) {}
+
+
+// CHECK-LABEL: define{{.*}} swiftcc void @"$S10resilience1fyyF"()
+// CHECK-LLDB-LABEL: define{{.*}} swiftcc void @"$S10resilience1fyyF"()
+func f() {
   let s1 = Size(w: 1, h: 2)
   takesSize(s1)
   // CHECK: %[[ADDR:.*]] = alloca i8*
@@ -30,15 +46,21 @@ public func f() {
   // CHECK-LLDB-SAME:                        metadata ![[V1:[0-9]+]],
   // CHECK-LLDB-SAME:                        metadata !DIExpression())
 }
+f()
 
+// Note that these DW_OP_deref are not necessarily correct, but it's the best
+// approxmiation we have until LLDB can query the runtime for whether a relient
+// type's storage is inline or not.
+// CHECK: ![[FIXED]] = !DIGlobalVariableExpression(
+// CHECK-SAME:            expr: !DIExpression())
+// CHECK: ![[NON_FIXED]] = !DIGlobalVariableExpression(
+// CHECK-SAME:            expr: !DIExpression(DW_OP_deref))
+// CHECK: ![[TY:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Size",
+// CHECK: ![[INT]] = !DIGlobalVariableExpression(
+// CHECK-SAME:            expr: !DIExpression(DW_OP_deref))
 
-// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S10resilience9takesSizeyy16resilient_struct0C0VF"(%swift.opaque* noalias nocapture)
-// CHECK-LLDB-LABEL: define{{( protected)?}} swiftcc void @"$S10resilience9takesSizeyy16resilient_struct0C0VF"(%T16resilient_struct4SizeV* noalias nocapture dereferenceable({{8|16}}))
-public func takesSize(_ s: Size) {}
+// CHECK: ![[V1]] = !DILocalVariable(name: "s1", {{.*}}type: ![[TY]])
 
+// CHECK-LLDB: ![[TY:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Size",
+// CHECK-LLDB: ![[V1]] = !DILocalVariable(name: "s1", {{.*}}type: ![[TY]])
 
-// CHECK: ![[V1]] = !DILocalVariable(name: "s1", {{.*}}type: ![[TY:[0-9]+]])
-// CHECK: ![[TY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Size",
-
-// CHECK-LLDB: ![[V1]] = !DILocalVariable(name: "s1", {{.*}}type: ![[TY:[0-9]+]])
-// CHECK-LLDB: ![[TY]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Size",


### PR DESCRIPTION
Note that this is only correct unless the variable uses inline
storage. This makes the majority of resilient types in Foundation work
as global variables.  The correct solution would be for LLDB to poke
at the runtime to figure out whether the storage is inline or not, but
until then this is the next best thing.

rdar://problem/39722386
(cherry picked from commit 2c7a69852b3de3bc6b6862dcfb62d0d1b2a24e08)
