### PR TITLE
[Reflection] Remove DEPENDENT_TEMPLATE2 macro

### DIFF
--- a/include/swift/Reflection/TypeRef.h
+++ b/include/swift/Reflection/TypeRef.h
@@ -40,33 +40,20 @@ enum class TypeRefKind {
 
 // MSVC reports an error if we use "template"
 // Clang reports an error if we don't use "template"
-#if defined(__APPLE_CC__)
+#if defined(__clang__) || defined(__GNUC__)
 #  define DEPENDENT_TEMPLATE template
-#  if __APPLE_CC__ >= 7000
-#    define DEPENDENT_TEMPLATE2
-#  else
-#    define DEPENDENT_TEMPLATE2 template
-#  endif
-#elif defined(__clang__) || defined(__GNUC__)
-#  define DEPENDENT_TEMPLATE template
-#  if __clang_major__ >= 7
-#    define DEPENDENT_TEMPLATE2
-#  else
-#    define DEPENDENT_TEMPLATE2 template
-#  endif
 #else
-#  define DEPENDENT_TEMPLATE template
-#  define DEPENDENT_TEMPLATE2
+#  define DEPENDENT_TEMPLATE
 #endif
 
 #define FIND_OR_CREATE_TYPEREF(Allocator, TypeRefTy, ...)                      \
   auto ID = Profile(__VA_ARGS__);                                              \
-  const auto Entry = Allocator.DEPENDENT_TEMPLATE2 TypeRefTy##s.find(ID);      \
-  if (Entry != Allocator.DEPENDENT_TEMPLATE2 TypeRefTy##s.end())               \
+  const auto Entry = Allocator.TypeRefTy##s.find(ID);      \
+  if (Entry != Allocator.TypeRefTy##s.end())               \
     return Entry->second;                                                      \
   const auto TR =                                                              \
       Allocator.DEPENDENT_TEMPLATE makeTypeRef<TypeRefTy>(__VA_ARGS__);        \
-  Allocator.DEPENDENT_TEMPLATE2 TypeRefTy##s.insert({ID, TR});                 \
+  Allocator.TypeRefTy##s.insert({ID, TR});                 \
   return TR;
 
 /// An identifier containing the unique bit pattern made up of all of the


### PR DESCRIPTION
The Clang version checks introduced in #16212 and #16221 do not work well.
The __clang_major__ macro is defined differently for Apple builds of Clang,
and the __APPLE_CC__ macro is obsolete and not useful. The good news is that
those checks appear to be unnecessary. The version of Clang used with
Swift 4.2 (based on LLVM 6.0) accepts the code without the template keyword
in the places where the DEPENDENT_TEMPLATE2 macro was being used.

This also corrects a mistake in #16221 where the non-Clang/GCC definition
of DEPENDENT_TEMPLATE was changed to use the template keyword.