### PR TITLE
[ClangImporter] <rdar://39801675> Treat fake-buffer locs as invalid, avoid nulls in diags.

### DIFF
--- a/test/ClangImporter/Inputs/custom-modules/ConditionallyFoo.h
+++ b/test/ClangImporter/Inputs/custom-modules/ConditionallyFoo.h
@@ -1,0 +1,3 @@
+#ifdef WANT_FOO
+int foo();
+#endif

--- a/test/ClangImporter/Inputs/custom-modules/module.map
+++ b/test/ClangImporter/Inputs/custom-modules/module.map
@@ -212,3 +212,8 @@ module Warnings6 { header "Warnings6.h" }
 module Warnings7 { header "Warnings7.h" }
 module Warnings8 { header "Warnings8.h" }
 module Warnings9 { header "Warnings9.h" }
+
+module ConditionallyFoo {
+  header "ConditionallyFoo.h"
+  config_macros [exhaustive] WANT_FOO
+}

--- a/test/ClangImporter/Inputs/no-fake-source-buffer-excerpts.h
+++ b/test/ClangImporter/Inputs/no-fake-source-buffer-excerpts.h
@@ -1,0 +1,2 @@
+#define WANT_FOO
+@import ConditionallyFoo;

--- a/test/ClangImporter/no-fake-source-buffer-excerpts.swift
+++ b/test/ClangImporter/no-fake-source-buffer-excerpts.swift
@@ -1,0 +1,11 @@
+// REQUIRES: OS=macosx
+//
+// This triggers a warning about ignored configuration macros; the warning then
+// attempts to emit an excerpt from one of the clang importer's fake buffers
+// (<swift-imported-modules>) which is full of 250kb of nulls. We want to check
+// that we do not emit a gigantic block of nulls to stderr.
+//
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -typecheck -I %S/Inputs/custom-modules -import-objc-header %S/Inputs/no-fake-source-buffer-excerpts.h %s 2>%t/errors
+// RUN: od -a < %t/errors | %FileCheck %s
+// CHECK-NOT: nul nul nul nul


### PR DESCRIPTION
We were emitting chunks of the fake ClangImporter buffers when certain warnings bubbled up from clang. Let's not do that!

rdar://39801675