### PR TITLE
[TypeChecker] Return error type to attempt to resolve not-yet-validat…

### DIFF
--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -710,6 +710,15 @@ static Type resolveTypeDecl(TypeChecker &TC, TypeDecl *typeDecl, SourceLoc loc,
     }
   }
 
+  // Sometimes code completion would request type check of the
+  // individual generic type parameters, because of the cursor
+  // position. Let's just return ErrorType in this case, if such
+  // type hasn't been validated yet.
+  if (auto *GTPD = dyn_cast<GenericTypeParamDecl>(typeDecl)) {
+    if (GTPD->getDepth() == GenericTypeParamDecl::InvalidDepth)
+      return ErrorType::get(TC.Context);
+  }
+
   // Resolve the type declaration to a specific type. How this occurs
   // depends on the current context and where the type was found.
   Type type =

--- a/validation-test/IDE/crashers_2_fixed/0019-rdar39909829.swift
+++ b/validation-test/IDE/crashers_2_fixed/0019-rdar39909829.swift
@@ -1,0 +1,3 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=COMPLETE -source-filename=%s
+
+public typealias CustomGetter<T> = (Int) -> T #^COMPLETE^#


### PR DESCRIPTION
…ed generic type parameter

Sometimes code completion would request type-check of the
individual generic type parameters, because of the cursor
position. Let's just return ErrorType in this case, if such
type hasn't been validated yet, which could only be done if
it's resolved/type-checked in the context of other declaration.

Resolves: rdar://problem/39909829

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
