### PR TITLE
Support synthesis of protocol conformances (including conditional ones) in extensions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2162,8 +2162,14 @@ NOTE(construct_raw_representable_from_unwrapped_value,none,
      "construct %0 from unwrapped %1 value", (Type, Type))
 
 // Derived conformances
-ERROR(cannot_synthesize_in_extension,none,
-      "implementation of %0 cannot be automatically synthesized in an extension", (Type))
+ERROR(cannot_synthesize_init_in_extension_of_nonfinal,none,
+      "implementation of %0 for non-final class cannot be automatically "
+      "synthesized in extension because initializer requirement %1 can only be "
+      "be satisfied by a 'required' initializer in the class definition",
+      (Type, DeclName))
+ERROR(cannot_synthesize_in_crossfile_extension,none,
+      "implementation of %0 cannot be automatically synthesized in an extension "
+      "in a different file to the type", (Type))
 
 ERROR(broken_case_iterable_requirement,none,
       "CaseIterable protocol is broken: unexpected requirement", ())

--- a/lib/Sema/DerivedConformanceCaseIterable.cpp
+++ b/lib/Sema/DerivedConformanceCaseIterable.cpp
@@ -79,14 +79,8 @@ static Type deriveCaseIterable_AllCases(DerivedConformance &derived) {
 
 ValueDecl *DerivedConformance::deriveCaseIterable(ValueDecl *requirement) {
   // Conformance can't be synthesized in an extension.
-  auto caseIterableProto =
-      TC.Context.getProtocol(KnownProtocolKind::CaseIterable);
-  auto caseIterableType = caseIterableProto->getDeclaredType();
-  if (Nominal != ConformanceDecl) {
-    TC.diagnose(ConformanceDecl->getLoc(), diag::cannot_synthesize_in_extension,
-                caseIterableType);
+  if (checkAndDiagnoseDisallowedContext())
     return nullptr;
-  }
 
   // Check that we can actually derive CaseIterable for this type.
   if (!canDeriveConformance(Nominal))
@@ -120,15 +114,8 @@ ValueDecl *DerivedConformance::deriveCaseIterable(ValueDecl *requirement) {
 }
 
 Type DerivedConformance::deriveCaseIterable(AssociatedTypeDecl *assocType) {
-  // Conformance can't be synthesized in an extension.
-  auto caseIterableProto =
-      TC.Context.getProtocol(KnownProtocolKind::CaseIterable);
-  auto caseIterableType = caseIterableProto->getDeclaredType();
-  if (Nominal != ConformanceDecl) {
-    TC.diagnose(ConformanceDecl->getLoc(), diag::cannot_synthesize_in_extension,
-                caseIterableType);
+  if (checkAndDiagnoseDisallowedContext())
     return nullptr;
-  }
 
   // Check that we can actually derive CaseIterable for this type.
   if (!canDeriveConformance(Nominal))

--- a/lib/Sema/DerivedConformanceCaseIterable.cpp
+++ b/lib/Sema/DerivedConformanceCaseIterable.cpp
@@ -79,7 +79,7 @@ static Type deriveCaseIterable_AllCases(DerivedConformance &derived) {
 
 ValueDecl *DerivedConformance::deriveCaseIterable(ValueDecl *requirement) {
   // Conformance can't be synthesized in an extension.
-  if (checkAndDiagnoseDisallowedContext())
+  if (checkAndDiagnoseDisallowedContext(requirement))
     return nullptr;
 
   // Check that we can actually derive CaseIterable for this type.
@@ -114,7 +114,7 @@ ValueDecl *DerivedConformance::deriveCaseIterable(ValueDecl *requirement) {
 }
 
 Type DerivedConformance::deriveCaseIterable(AssociatedTypeDecl *assocType) {
-  if (checkAndDiagnoseDisallowedContext())
+  if (checkAndDiagnoseDisallowedContext(assocType))
     return nullptr;
 
   // Check that we can actually derive CaseIterable for this type.

--- a/lib/Sema/DerivedConformanceCaseIterable.cpp
+++ b/lib/Sema/DerivedConformanceCaseIterable.cpp
@@ -22,7 +22,6 @@
 #include "DerivedConformances.h"
 
 using namespace swift;
-using namespace DerivedConformance;
 
 /// Common preconditions for CaseIterable.
 static bool canDeriveConformance(NominalTypeDecl *type) {
@@ -79,51 +78,44 @@ static Type deriveCaseIterable_AllCases(TypeChecker &tc, Decl *parentDecl,
   return cast<DeclContext>(parentDecl)->mapTypeIntoContext(rawInterfaceType);
 }
 
-ValueDecl *DerivedConformance::deriveCaseIterable(TypeChecker &tc,
-                                                  Decl *parentDecl,
-                                                  NominalTypeDecl *targetDecl,
-                                                  ValueDecl *requirement) {
+ValueDecl *DerivedConformance::deriveCaseIterable(ValueDecl *requirement) {
   // Conformance can't be synthesized in an extension.
-  auto caseIterableProto
-      = tc.Context.getProtocol(KnownProtocolKind::CaseIterable);
+  auto caseIterableProto =
+      TC.Context.getProtocol(KnownProtocolKind::CaseIterable);
   auto caseIterableType = caseIterableProto->getDeclaredType();
-  if (targetDecl != parentDecl) {
-    tc.diagnose(parentDecl->getLoc(), diag::cannot_synthesize_in_extension,
+  if (Nominal != ConformanceDecl) {
+    TC.diagnose(ConformanceDecl->getLoc(), diag::cannot_synthesize_in_extension,
                 caseIterableType);
     return nullptr;
   }
 
   // Check that we can actually derive CaseIterable for this type.
-  if (!canDeriveConformance(targetDecl))
+  if (!canDeriveConformance(Nominal))
     return nullptr;
 
   // Build the necessary decl.
-  if (requirement->getBaseName() != tc.Context.Id_allCases) {
-    tc.diagnose(requirement->getLoc(),
-                diag::broken_case_iterable_requirement);
+  if (requirement->getBaseName() != TC.Context.Id_allCases) {
+    TC.diagnose(requirement->getLoc(), diag::broken_case_iterable_requirement);
     return nullptr;
   }
 
-  auto enumDecl = cast<EnumDecl>(targetDecl);
-  ASTContext &C = tc.Context;
-  
+  ASTContext &C = TC.Context;
 
   // Define the property.
-  auto *returnTy = computeAllCasesType(targetDecl);
+  auto *returnTy = computeAllCasesType(Nominal);
 
   VarDecl *propDecl;
   PatternBindingDecl *pbDecl;
-  std::tie(propDecl, pbDecl)
-    = declareDerivedProperty(tc, parentDecl, enumDecl, C.Id_allCases,
-                             returnTy, returnTy,
+  std::tie(propDecl, pbDecl) =
+      declareDerivedProperty(C.Id_allCases, returnTy, returnTy,
                              /*isStatic=*/true, /*isFinal=*/true);
 
   // Define the getter.
-  auto *getterDecl = addGetterToReadOnlyDerivedProperty(tc, propDecl, returnTy);
+  auto *getterDecl = addGetterToReadOnlyDerivedProperty(TC, propDecl, returnTy);
 
   getterDecl->setBodySynthesizer(&deriveCaseIterable_enum_getter);
 
-  auto dc = cast<IterableDeclContext>(parentDecl);
+  auto dc = cast<IterableDeclContext>(ConformanceDecl);
   dc->addMember(getterDecl);
   dc->addMember(propDecl);
   dc->addMember(pbDecl);
@@ -131,30 +123,27 @@ ValueDecl *DerivedConformance::deriveCaseIterable(TypeChecker &tc,
   return propDecl;
 }
 
-Type DerivedConformance::deriveCaseIterable(TypeChecker &tc, Decl *parentDecl,
-                                            NominalTypeDecl *targetDecl,
-                                            AssociatedTypeDecl *assocType) {
+Type DerivedConformance::deriveCaseIterable(AssociatedTypeDecl *assocType) {
   // Conformance can't be synthesized in an extension.
-  auto caseIterableProto
-      = tc.Context.getProtocol(KnownProtocolKind::CaseIterable);
+  auto caseIterableProto =
+      TC.Context.getProtocol(KnownProtocolKind::CaseIterable);
   auto caseIterableType = caseIterableProto->getDeclaredType();
-  if (targetDecl != parentDecl) {
-    tc.diagnose(parentDecl->getLoc(), diag::cannot_synthesize_in_extension,
+  if (Nominal != ConformanceDecl) {
+    TC.diagnose(ConformanceDecl->getLoc(), diag::cannot_synthesize_in_extension,
                 caseIterableType);
     return nullptr;
   }
 
   // Check that we can actually derive CaseIterable for this type.
-  if (!canDeriveConformance(targetDecl))
+  if (!canDeriveConformance(Nominal))
     return nullptr;
 
-  if (assocType->getName() == tc.Context.Id_AllCases) {
-    auto enumDecl = cast<EnumDecl>(targetDecl);
-    return deriveCaseIterable_AllCases(tc, parentDecl, enumDecl);
+  if (assocType->getName() == TC.Context.Id_AllCases) {
+    auto enumDecl = cast<EnumDecl>(Nominal);
+    return deriveCaseIterable_AllCases(TC, ConformanceDecl, enumDecl);
   }
 
-  tc.diagnose(assocType->getLoc(),
-              diag::broken_case_iterable_requirement);
+  TC.diagnose(assocType->getLoc(), diag::broken_case_iterable_requirement);
   return nullptr;
 }
 

--- a/lib/Sema/DerivedConformanceCaseIterable.cpp
+++ b/lib/Sema/DerivedConformanceCaseIterable.cpp
@@ -42,7 +42,7 @@ static bool canDeriveConformance(NominalTypeDecl *type) {
 void deriveCaseIterable_enum_getter(AbstractFunctionDecl *funcDecl) {
   auto *parentDC = funcDecl->getDeclContext();
   auto *parentEnum = parentDC->getAsEnumOrEnumExtensionContext();
-  auto enumTy = parentEnum->getDeclaredTypeInContext();
+  auto enumTy = parentDC->getDeclaredTypeInContext();
   auto &C = parentDC->getASTContext();
 
   SmallVector<Expr *, 8> elExprs;

--- a/lib/Sema/DerivedConformanceCaseIterable.cpp
+++ b/lib/Sema/DerivedConformanceCaseIterable.cpp
@@ -68,14 +68,13 @@ static ArraySliceType *computeAllCasesType(NominalTypeDecl *enumType) {
   return ArraySliceType::get(metaTy->getRValueInstanceType());
 }
 
-static Type deriveCaseIterable_AllCases(TypeChecker &tc, Decl *parentDecl,
-                                        EnumDecl *enumDecl) {
+static Type deriveCaseIterable_AllCases(DerivedConformance &derived) {
   // enum SomeEnum : CaseIterable {
   //   @derived
   //   typealias AllCases = [SomeEnum]
   // }
-  auto *rawInterfaceType = computeAllCasesType(enumDecl);
-  return cast<DeclContext>(parentDecl)->mapTypeIntoContext(rawInterfaceType);
+  auto *rawInterfaceType = computeAllCasesType(cast<EnumDecl>(derived.Nominal));
+  return derived.getConformanceContext()->mapTypeIntoContext(rawInterfaceType);
 }
 
 ValueDecl *DerivedConformance::deriveCaseIterable(ValueDecl *requirement) {
@@ -115,10 +114,7 @@ ValueDecl *DerivedConformance::deriveCaseIterable(ValueDecl *requirement) {
 
   getterDecl->setBodySynthesizer(&deriveCaseIterable_enum_getter);
 
-  auto dc = cast<IterableDeclContext>(ConformanceDecl);
-  dc->addMember(getterDecl);
-  dc->addMember(propDecl);
-  dc->addMember(pbDecl);
+  addMembersToConformanceContext({getterDecl, propDecl, pbDecl});
 
   return propDecl;
 }
@@ -139,8 +135,7 @@ Type DerivedConformance::deriveCaseIterable(AssociatedTypeDecl *assocType) {
     return nullptr;
 
   if (assocType->getName() == TC.Context.Id_AllCases) {
-    auto enumDecl = cast<EnumDecl>(Nominal);
-    return deriveCaseIterable_AllCases(TC, ConformanceDecl, enumDecl);
+    return deriveCaseIterable_AllCases(*this);
   }
 
   TC.diagnose(assocType->getLoc(), diag::broken_case_iterable_requirement);

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -1204,14 +1204,8 @@ ValueDecl *DerivedConformance::deriveEncodable(ValueDecl *requirement) {
     return nullptr;
   }
 
-  // Conformance can't be synthesized in an extension.
-  auto encodableProto = TC.Context.getProtocol(KnownProtocolKind::Encodable);
-  auto encodableType = encodableProto->getDeclaredType();
-  if (Nominal != ConformanceDecl) {
-    TC.diagnose(ConformanceDecl->getLoc(), diag::cannot_synthesize_in_extension,
-                encodableType);
+  if (checkAndDiagnoseDisallowedContext())
     return nullptr;
-  }
 
   // We're about to try to synthesize Encodable. If something goes wrong,
   // we'll have to output at least one error diagnostic because we returned
@@ -1230,9 +1224,10 @@ ValueDecl *DerivedConformance::deriveEncodable(ValueDecl *requirement) {
   // fake failures.
   auto diagnosticTransaction = DiagnosticTransaction(TC.Context.Diags);
   TC.diagnose(Nominal, diag::type_does_not_conform, Nominal->getDeclaredType(),
-              encodableType);
+              getProtocolType());
   TC.diagnose(requirement, diag::no_witnesses, diag::RequirementKind::Func,
-              requirement->getFullName(), encodableType, /*AddFixIt=*/false);
+              requirement->getFullName(), getProtocolType(),
+              /*AddFixIt=*/false);
 
   // Check other preconditions for synthesized conformance.
   // This synthesizes a CodingKeys enum if possible.
@@ -1255,14 +1250,8 @@ ValueDecl *DerivedConformance::deriveDecodable(ValueDecl *requirement) {
     return nullptr;
   }
 
-  // Conformance can't be synthesized in an extension.
-  auto decodableProto = TC.Context.getProtocol(KnownProtocolKind::Decodable);
-  auto decodableType = decodableProto->getDeclaredType();
-  if (Nominal != ConformanceDecl) {
-    TC.diagnose(ConformanceDecl->getLoc(), diag::cannot_synthesize_in_extension,
-                decodableType);
+  if (checkAndDiagnoseDisallowedContext())
     return nullptr;
-  }
 
   // We're about to try to synthesize Decodable. If something goes wrong,
   // we'll have to output at least one error diagnostic. We need to collate
@@ -1271,10 +1260,10 @@ ValueDecl *DerivedConformance::deriveDecodable(ValueDecl *requirement) {
   // background on this transaction.
   auto diagnosticTransaction = DiagnosticTransaction(TC.Context.Diags);
   TC.diagnose(Nominal, diag::type_does_not_conform, Nominal->getDeclaredType(),
-              decodableType);
+              getProtocolType());
   TC.diagnose(requirement, diag::no_witnesses,
               diag::RequirementKind::Constructor, requirement->getFullName(),
-              decodableType, /*AddFixIt=*/false);
+              getProtocolType(), /*AddFixIt=*/false);
 
   // Check other preconditions for synthesized conformance.
   // This synthesizes a CodingKeys enum if possible.

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -682,7 +682,7 @@ bool DerivedConformance::canDeriveEquatable(TypeChecker &tc,
 }
 
 ValueDecl *DerivedConformance::deriveEquatable(ValueDecl *requirement) {
-  if (checkAndDiagnoseDisallowedContext())
+  if (checkAndDiagnoseDisallowedContext(requirement))
     return nullptr;
 
   // Build the necessary decl.
@@ -1197,7 +1197,7 @@ ValueDecl *DerivedConformance::deriveHashable(ValueDecl *requirement) {
         return nullptr;
       }
 
-      if (checkAndDiagnoseDisallowedContext())
+      if (checkAndDiagnoseDisallowedContext(requirement))
         return nullptr;
 
       if (auto ED = dyn_cast<EnumDecl>(Nominal)) {

--- a/lib/Sema/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformanceError.cpp
@@ -24,7 +24,6 @@
 #include "swift/AST/Types.h"
 
 using namespace swift;
-using namespace DerivedConformance;
 
 static void deriveBodyBridgedNSError_enum_nsErrorDomain(
               AbstractFunctionDecl *domainDecl) {
@@ -53,9 +52,8 @@ static void deriveBodyBridgedNSError_enum_nsErrorDomain(
   domainDecl->setBody(body);
 }
 
-static ValueDecl *deriveBridgedNSError_enum_nsErrorDomain(TypeChecker &tc,
-                                                          Decl *parentDecl,
-                                                          EnumDecl *enumDecl) {
+static ValueDecl *
+deriveBridgedNSError_enum_nsErrorDomain(DerivedConformance &derived) {
   // enum SomeEnum {
   //   @derived
   //   static var _nsErrorDomain: String {
@@ -65,25 +63,24 @@ static ValueDecl *deriveBridgedNSError_enum_nsErrorDomain(TypeChecker &tc,
 
   // Note that for @objc enums the format is assumed to be "MyModule.SomeEnum".
   // If this changes, please change PrintAsObjC as well.
-  
-  ASTContext &C = tc.Context;
-  
+
+  ASTContext &C = derived.TC.Context;
+
   auto stringTy = C.getStringDecl()->getDeclaredType();
 
   // Define the property.
   VarDecl *propDecl;
   PatternBindingDecl *pbDecl;
-  std::tie(propDecl, pbDecl)
-    = declareDerivedProperty(tc, parentDecl, enumDecl, C.Id_nsErrorDomain,
-                             stringTy, stringTy, /*isStatic=*/true,
-                             /*isFinal=*/true);
+  std::tie(propDecl, pbDecl) = derived.declareDerivedProperty(
+      C.Id_nsErrorDomain, stringTy, stringTy, /*isStatic=*/true,
+      /*isFinal=*/true);
 
   // Define the getter.
-  auto getterDecl =
-    addGetterToReadOnlyDerivedProperty(tc, propDecl, stringTy);
+  auto getterDecl = derived.addGetterToReadOnlyDerivedProperty(
+      derived.TC, propDecl, stringTy);
   getterDecl->setBodySynthesizer(&deriveBodyBridgedNSError_enum_nsErrorDomain);
 
-  auto dc = cast<IterableDeclContext>(parentDecl);
+  auto dc = cast<IterableDeclContext>(derived.ConformanceDecl);
   dc->addMember(getterDecl);
   dc->addMember(propDecl);
   dc->addMember(pbDecl);
@@ -91,19 +88,13 @@ static ValueDecl *deriveBridgedNSError_enum_nsErrorDomain(TypeChecker &tc,
   return propDecl;
 }
 
-ValueDecl *DerivedConformance::deriveBridgedNSError(TypeChecker &tc,
-                                                    Decl *parentDecl,
-                                                    NominalTypeDecl *type,
-                                                    ValueDecl *requirement) {
-  if (!isa<EnumDecl>(type))
+ValueDecl *DerivedConformance::deriveBridgedNSError(ValueDecl *requirement) {
+  if (!isa<EnumDecl>(Nominal))
     return nullptr;
 
-  auto enumType = cast<EnumDecl>(type);
+  if (requirement->getBaseName() == TC.Context.Id_nsErrorDomain)
+    return deriveBridgedNSError_enum_nsErrorDomain(*this);
 
-  if (requirement->getBaseName() == tc.Context.Id_nsErrorDomain)
-    return deriveBridgedNSError_enum_nsErrorDomain(tc, parentDecl, enumType);
-
-  tc.diagnose(requirement->getLoc(),
-              diag::broken_errortype_requirement);
+  TC.diagnose(requirement->getLoc(), diag::broken_errortype_requirement);
   return nullptr;
 }

--- a/lib/Sema/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformanceError.cpp
@@ -80,10 +80,7 @@ deriveBridgedNSError_enum_nsErrorDomain(DerivedConformance &derived) {
       derived.TC, propDecl, stringTy);
   getterDecl->setBodySynthesizer(&deriveBodyBridgedNSError_enum_nsErrorDomain);
 
-  auto dc = cast<IterableDeclContext>(derived.ConformanceDecl);
-  dc->addMember(getterDecl);
-  dc->addMember(propDecl);
-  dc->addMember(pbDecl);
+  derived.addMembersToConformanceContext({getterDecl, propDecl, pbDecl});
 
   return propDecl;
 }

--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -26,7 +26,6 @@
 #include "DerivedConformances.h"
 
 using namespace swift;
-using namespace DerivedConformance;
 
 static LiteralExpr *cloneRawLiteralExpr(ASTContext &C, LiteralExpr *expr) {
   LiteralExpr *clone;
@@ -114,7 +113,7 @@ static void deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl) {
                                      SourceLoc(), body));
   }
 
-  auto selfRef = createSelfDeclRef(toRawDecl);
+  auto selfRef = DerivedConformance::createSelfDeclRef(toRawDecl);
   auto switchStmt = SwitchStmt::create(LabeledStmtInfo(), SourceLoc(), selfRef,
                                        SourceLoc(), cases, SourceLoc(), C);
   auto body = BraceStmt::create(C, SourceLoc(),
@@ -123,26 +122,24 @@ static void deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl) {
   toRawDecl->setBody(body);
 }
 
-static VarDecl *deriveRawRepresentable_raw(TypeChecker &tc,
-                                           Decl *parentDecl,
+static VarDecl *deriveRawRepresentable_raw(DerivedConformance &derived,
                                            EnumDecl *enumDecl) {
-  ASTContext &C = tc.Context;
-  
-  auto parentDC = cast<DeclContext>(parentDecl);
+  ASTContext &C = derived.TC.Context;
+
+  auto parentDC = cast<DeclContext>(derived.ConformanceDecl);
   auto rawInterfaceType = enumDecl->getRawType();
   auto rawType = parentDC->mapTypeIntoContext(rawInterfaceType);
 
   // Define the property.
   VarDecl *propDecl;
   PatternBindingDecl *pbDecl;
-  std::tie(propDecl, pbDecl)
-    = declareDerivedProperty(tc, parentDecl, enumDecl, C.Id_rawValue,
-                             rawInterfaceType, rawType, /*isStatic=*/false,
-                             /*isFinal=*/false);
+  std::tie(propDecl, pbDecl) = derived.declareDerivedProperty(
+      C.Id_rawValue, rawInterfaceType, rawType, /*isStatic=*/false,
+      /*isFinal=*/false);
 
   // Define the getter.
-  auto getterDecl =
-    addGetterToReadOnlyDerivedProperty(tc, propDecl, rawType);
+  auto getterDecl = DerivedConformance::addGetterToReadOnlyDerivedProperty(
+      derived.TC, propDecl, rawType);
   getterDecl->setBodySynthesizer(&deriveBodyRawRepresentable_raw);
 
   // If the containing module is not resilient, make sure clients can get at
@@ -156,7 +153,7 @@ static VarDecl *deriveRawRepresentable_raw(TypeChecker &tc,
       getterDecl->getAttrs().add(new (C) InlinableAttr(/*implicit*/false));
   }
 
-  auto dc = cast<IterableDeclContext>(parentDecl);
+  auto dc = cast<IterableDeclContext>(derived.ConformanceDecl);
   dc->addMember(getterDecl);
   dc->addMember(propDecl);
   dc->addMember(pbDecl);
@@ -416,50 +413,43 @@ static bool canSynthesizeRawRepresentable(TypeChecker &tc, Decl *parentDecl,
   return true;
 }
 
-ValueDecl *DerivedConformance::deriveRawRepresentable(TypeChecker &tc,
-                                                      Decl *parentDecl,
-                                                      NominalTypeDecl *type,
-                                                      ValueDecl *requirement) {
+ValueDecl *DerivedConformance::deriveRawRepresentable(ValueDecl *requirement) {
 
   // We can only synthesize RawRepresentable for enums.
-  auto enumDecl = dyn_cast<EnumDecl>(type);
+  auto enumDecl = dyn_cast<EnumDecl>(Nominal);
   if (!enumDecl)
     return nullptr;
 
   // Check other preconditions for synthesized conformance.
-  if (!canSynthesizeRawRepresentable(tc, parentDecl, enumDecl))
+  if (!canSynthesizeRawRepresentable(TC, ConformanceDecl, enumDecl))
     return nullptr;
 
-  if (requirement->getBaseName() == tc.Context.Id_rawValue)
-    return deriveRawRepresentable_raw(tc, parentDecl, enumDecl);
+  if (requirement->getBaseName() == TC.Context.Id_rawValue)
+    return deriveRawRepresentable_raw(*this, enumDecl);
 
   if (requirement->getBaseName() == DeclBaseName::createConstructor())
-    return deriveRawRepresentable_init(tc, parentDecl, enumDecl);
-  
-  tc.diagnose(requirement->getLoc(),
+    return deriveRawRepresentable_init(TC, ConformanceDecl, enumDecl);
+
+  TC.diagnose(requirement->getLoc(),
               diag::broken_raw_representable_requirement);
   return nullptr;
 }
 
-Type DerivedConformance::deriveRawRepresentable(TypeChecker &tc,
-                                                Decl *parentDecl,
-                                                NominalTypeDecl *type,
-                                                AssociatedTypeDecl *assocType) {
+Type DerivedConformance::deriveRawRepresentable(AssociatedTypeDecl *assocType) {
 
   // We can only synthesize RawRepresentable for enums.
-  auto enumDecl = dyn_cast<EnumDecl>(type);
+  auto enumDecl = dyn_cast<EnumDecl>(Nominal);
   if (!enumDecl)
     return nullptr;
 
   // Check other preconditions for synthesized conformance.
-  if (!canSynthesizeRawRepresentable(tc, parentDecl, enumDecl))
+  if (!canSynthesizeRawRepresentable(TC, ConformanceDecl, enumDecl))
     return nullptr;
 
-  if (assocType->getName() == tc.Context.Id_RawValue) {
-    return deriveRawRepresentable_Raw(tc, parentDecl, enumDecl);
+  if (assocType->getName() == TC.Context.Id_RawValue) {
+    return deriveRawRepresentable_Raw(TC, ConformanceDecl, enumDecl);
   }
-  
-  tc.diagnose(assocType->getLoc(),
-              diag::broken_raw_representable_requirement);
+
+  TC.diagnose(assocType->getLoc(), diag::broken_raw_representable_requirement);
   return nullptr;
 }

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -27,8 +27,24 @@ DerivedConformance::DerivedConformance(TypeChecker &tc, Decl *conformanceDecl,
                                        ProtocolDecl *protocol)
     : TC(tc), ConformanceDecl(conformanceDecl), Nominal(nominal),
       Protocol(protocol) {
-  assert(cast<DeclContext>(conformanceDecl)
+  assert(getConformanceContext()
              ->getAsNominalTypeOrNominalTypeExtensionContext() == nominal);
+}
+
+DeclContext *DerivedConformance::getConformanceContext() const {
+  return cast<DeclContext>(ConformanceDecl);
+}
+
+void DerivedConformance::addMembersToConformanceContext(
+    ArrayRef<Decl *> children) {
+  auto IDC = cast<IterableDeclContext>(ConformanceDecl);
+  for (auto child : children) {
+    IDC->addMember(child);
+  }
+}
+
+Type DerivedConformance::getProtocolType() const {
+  return Protocol->getDeclaredType();
 }
 
 bool DerivedConformance::derivesProtocolConformance(TypeChecker &TC,

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -67,7 +67,7 @@ public:
   ///
   /// \return True if the type can implicitly derive a conformance for the
   /// given protocol.
-  static bool derivesProtocolConformance(TypeChecker &tc,
+  static bool derivesProtocolConformance(TypeChecker &tc, DeclContext *DC,
                                          NominalTypeDecl *nominal,
                                          ProtocolDecl *protocol);
 
@@ -120,7 +120,8 @@ public:
   /// associated values, and for structs with all-Equatable stored properties.
   ///
   /// \returns True if the requirement can be derived.
-  static bool canDeriveEquatable(TypeChecker &tc, NominalTypeDecl *type);
+  static bool canDeriveEquatable(TypeChecker &tc, DeclContext *DC,
+                                 NominalTypeDecl *type);
 
   /// Derive an Equatable requirement for a type.
   ///

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -21,194 +21,160 @@
 #include <utility>
 
 namespace swift {
-  class Decl;
-  class DeclRefExpr;
-  class AccessorDecl;
-  class NominalTypeDecl;
-  class PatternBindingDecl;
-  class Type;
-  class TypeChecker;
-  class ValueDecl;
-  class VarDecl;
-  
-namespace DerivedConformance {
+class Decl;
+class DeclRefExpr;
+class AccessorDecl;
+class NominalTypeDecl;
+class PatternBindingDecl;
+class Type;
+class TypeChecker;
+class ValueDecl;
+class VarDecl;
 
-/// True if the type can implicitly derive a conformance for the given protocol.
-///
-/// If true, explicit conformance checking will synthesize implicit declarations
-/// for requirements of the protocol that are not satisfied by the type's
-/// explicit members.
-///
-/// \param tc The type checker.
-///
-/// \param nominal The nominal type for which we are determining whether to
-/// derive a witness.
-///
-/// \param protocol The protocol whose requirements are being derived.
-///
-/// \return True if the type can implicitly derive a conformance for the given
-/// protocol.
-bool derivesProtocolConformance(TypeChecker &tc,
-                                NominalTypeDecl *nominal,
-                                ProtocolDecl *protocol);
+class DerivedConformance {
+public:
+  TypeChecker &TC;
+  Decl *ConformanceDecl;
+  NominalTypeDecl *Nominal;
+  ProtocolDecl *Protocol;
 
-/// Determine the derivable requirement that would satisfy the given
-/// requirement, if there is one.
-///
-/// \param tc The type checker.
-///
-/// \param nominal The nominal type for which we are determining whether to
-/// derive a witness.
-///
-/// \param requirement The requirement for which we are checking for a
-/// derivation. This requirement need not be within a derivable protocol,
-/// because derivable requirements can get restated in inherited unrelated or
-/// unrelated protocols.
-///
-/// \returns The requirement whose witness could be derived to potentially
-/// satisfy this given requirement, or NULL if there is no such requirement.
-ValueDecl *getDerivableRequirement(TypeChecker &tc,
-                                   NominalTypeDecl *nominal,
-                                   ValueDecl *requirement);
+  DerivedConformance(TypeChecker &tc, Decl *conformanceDecl,
+                     NominalTypeDecl *nominal, ProtocolDecl *protocol);
 
+  /// True if the type can implicitly derive a conformance for the given
+  /// protocol.
+  ///
+  /// If true, explicit conformance checking will synthesize implicit
+  /// declarations for requirements of the protocol that are not satisfied by
+  /// the type's explicit members.
+  ///
+  /// \param tc The type checker.
+  ///
+  /// \param nominal The nominal type for which we are determining whether to
+  /// derive a witness.
+  ///
+  /// \param protocol The protocol whose requirements are being derived.
+  ///
+  /// \return True if the type can implicitly derive a conformance for the
+  /// given protocol.
+  static bool derivesProtocolConformance(TypeChecker &tc,
+                                         NominalTypeDecl *nominal,
+                                         ProtocolDecl *protocol);
 
-/// Derive a CaseIterable requirement for an enum if it has no associated
-/// values for any of its cases.
-///
-/// \returns the derived member, which will also be added to the type.
-ValueDecl *deriveCaseIterable(TypeChecker &tc,
-                              Decl *parentDecl,
-                              NominalTypeDecl *type,
-                              ValueDecl *requirement);
+  /// Determine the derivable requirement that would satisfy the given
+  /// requirement, if there is one.
+  ///
+  /// \param tc The type checker.
+  ///
+  /// \param nominal The nominal type for which we are determining whether to
+  /// derive a witness.
+  ///
+  /// \param requirement The requirement for which we are checking for a
+  /// derivation. This requirement need not be within a derivable protocol,
+  /// because derivable requirements can get restated in inherited unrelated
+  /// or unrelated protocols.
+  ///
+  /// \returns The requirement whose witness could be derived to potentially
+  /// satisfy this given requirement, or NULL if there is no such requirement.
+  static ValueDecl *getDerivableRequirement(TypeChecker &tc,
+                                            NominalTypeDecl *nominal,
+                                            ValueDecl *requirement);
 
-/// Derive a CaseIterable type witness for an enum if it has no associated
-/// values for any of its cases.
-///
-/// \returns the derived member, which will also be added to the type.
-Type deriveCaseIterable(TypeChecker &tc,
-                        Decl *parentDecl,
-                        NominalTypeDecl *type,
-                        AssociatedTypeDecl *assocType);
+  /// Derive a CaseIterable requirement for an enum if it has no associated
+  /// values for any of its cases.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  ValueDecl *deriveCaseIterable(ValueDecl *requirement);
 
-/// Derive a RawRepresentable requirement for an enum, if it has a valid
-/// raw type and raw values for all of its cases.
-///
-/// \returns the derived member, which will also be added to the type.
-ValueDecl *deriveRawRepresentable(TypeChecker &tc,
-                                  Decl *parentDecl,
-                                  NominalTypeDecl *type,
-                                  ValueDecl *requirement);
+  /// Derive a CaseIterable type witness for an enum if it has no associated
+  /// values for any of its cases.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  Type deriveCaseIterable(AssociatedTypeDecl *assocType);
 
-/// Derive a RawRepresentable type witness for an enum, if it has a valid
-/// raw type and raw values for all of its cases.
-///
-/// \returns the derived member, which will also be added to the type.
-Type deriveRawRepresentable(TypeChecker &tc,
-                            Decl *parentDecl,
-                            NominalTypeDecl *type,
-                            AssociatedTypeDecl *assocType);
+  /// Derive a RawRepresentable requirement for an enum, if it has a valid
+  /// raw type and raw values for all of its cases.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  ValueDecl *deriveRawRepresentable(ValueDecl *requirement);
 
-/// Determine if an Equatable requirement can be derived for a type.
-///
-/// This is implemented for enums without associated values or all-Equatable
-/// associated values, and for structs with all-Equatable stored properties.
-///
-/// \returns True if the requirement can be derived.
-bool canDeriveEquatable(TypeChecker &tc,
-                        NominalTypeDecl *type,
-                        ValueDecl *requirement);
+  /// Derive a RawRepresentable type witness for an enum, if it has a valid
+  /// raw type and raw values for all of its cases.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  Type deriveRawRepresentable(AssociatedTypeDecl *assocType);
 
-/// Derive an Equatable requirement for a type.
-///
-/// This is implemented for enums without associated values or all-Equatable
-/// associated values, and for structs with all-Equatable stored properties.
-///
-/// \returns the derived member, which will also be added to the type.
-ValueDecl *deriveEquatable(TypeChecker &tc,
-                           Decl *parentDecl,
-                           NominalTypeDecl *type,
-                           ValueDecl *requirement);
+  /// Determine if an Equatable requirement can be derived for a type.
+  ///
+  /// This is implemented for enums without associated values or all-Equatable
+  /// associated values, and for structs with all-Equatable stored properties.
+  ///
+  /// \returns True if the requirement can be derived.
+  static bool canDeriveEquatable(TypeChecker &tc, NominalTypeDecl *type);
 
-/// Determine if a Hashable requirement can be derived for a type.
-///
-/// This is implemented for enums without associated values or all-Hashable
-/// associated values, and for structs with all-Hashable stored properties.
-///
-/// \returns True if the requirement can be derived.
-bool canDeriveHashable(TypeChecker &tc,
-                       NominalTypeDecl *type,
-                       ValueDecl *requirement);
-  
-/// Derive a Hashable requirement for a type.
-///
-/// This is implemented for enums without associated values or all-Hashable
-/// associated values, and for structs with all-Hashable stored properties.
-///
-/// \returns the derived member, which will also be added to the type.
-ValueDecl *deriveHashable(TypeChecker &tc,
-                          Decl *parentDecl,
-                          NominalTypeDecl *type,
-                          ValueDecl *requirement);
+  /// Derive an Equatable requirement for a type.
+  ///
+  /// This is implemented for enums without associated values or all-Equatable
+  /// associated values, and for structs with all-Equatable stored properties.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  ValueDecl *deriveEquatable(ValueDecl *requirement);
 
-/// Derive a _BridgedNSError requirement for an @objc enum type.
-///
-/// \returns the derived member, which will also be added to the type.
-ValueDecl *deriveBridgedNSError(TypeChecker &tc,
-                                Decl *parentDecl,
-                                NominalTypeDecl *type,
-                                ValueDecl *requirement);
+  /// Determine if a Hashable requirement can be derived for a type.
+  ///
+  /// This is implemented for enums without associated values or all-Hashable
+  /// associated values, and for structs with all-Hashable stored properties.
+  ///
+  /// \returns True if the requirement can be derived.
+  static bool canDeriveHashable(TypeChecker &tc, NominalTypeDecl *type);
 
-/// Derive a CodingKey requirement for an enum type.
-///
-/// \returns the derived member, which will also be added to the type.
-ValueDecl *deriveCodingKey(TypeChecker &tc,
-                           Decl *parentDecl,
-                           NominalTypeDecl *type,
-                           ValueDecl *requirement);
+  /// Derive a Hashable requirement for a type.
+  ///
+  /// This is implemented for enums without associated values or all-Hashable
+  /// associated values, and for structs with all-Hashable stored properties.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  ValueDecl *deriveHashable(ValueDecl *requirement);
 
-/// Derive an Encodable requirement for a struct type.
-///
-/// \returns the derived member, which will also be added to the type.
-ValueDecl *deriveEncodable(TypeChecker &tc,
-                           Decl *parentDecl,
-                           NominalTypeDecl *type,
-                           ValueDecl *requirement);
+  /// Derive a _BridgedNSError requirement for an @objc enum type.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  ValueDecl *deriveBridgedNSError(ValueDecl *requirement);
 
-/// Derive a Decodable requirement for a struct type.
-///
-/// \returns the derived member, which will also be added to the type.
-ValueDecl *deriveDecodable(TypeChecker &tc,
-                           Decl *parentDecl,
-                           NominalTypeDecl *type,
-                           ValueDecl *requirement);
+  /// Derive a CodingKey requirement for an enum type.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  ValueDecl *deriveCodingKey(ValueDecl *requirement);
 
-/// Declare a read-only property.
-std::pair<VarDecl *, PatternBindingDecl *>
-declareDerivedProperty(TypeChecker &tc,
-                       Decl *parentDecl,
-                       NominalTypeDecl *typeDecl,
-                       Identifier name,
-                       Type propertyInterfaceType,
-                       Type propertyContextType,
-                       bool isStatic,
-                       bool isFinal);
+  /// Derive an Encodable requirement for a struct type.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  ValueDecl *deriveEncodable(ValueDecl *requirement);
 
-/// Add a getter to a derived property.  The property becomes read-only.
-AccessorDecl *addGetterToReadOnlyDerivedProperty(TypeChecker &tc,
-                                                 VarDecl *property,
-                                                 Type propertyContextType);
+  /// Derive a Decodable requirement for a struct type.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  ValueDecl *deriveDecodable(ValueDecl *requirement);
 
-/// Declare a getter for a derived property.
-/// The getter will not be added to the property yet.
-AccessorDecl *declareDerivedPropertyGetter(TypeChecker &tc,
-                                           VarDecl *property,
-                                           Type propertyContextType);
+  /// Declare a read-only property.
+  std::pair<VarDecl *, PatternBindingDecl *>
+  declareDerivedProperty(Identifier name, Type propertyInterfaceType,
+                         Type propertyContextType, bool isStatic, bool isFinal);
 
-/// Build a reference to the 'self' decl of a derived function.
-DeclRefExpr *createSelfDeclRef(AbstractFunctionDecl *fn);
+  /// Add a getter to a derived property.  The property becomes read-only.
+  static AccessorDecl *
+  addGetterToReadOnlyDerivedProperty(TypeChecker &tc, VarDecl *property,
+                                     Type propertyContextType);
 
-}
-  
+  /// Declare a getter for a derived property.
+  /// The getter will not be added to the property yet.
+  static AccessorDecl *declareDerivedPropertyGetter(TypeChecker &tc,
+                                                    VarDecl *property,
+                                                    Type propertyContextType);
+
+  /// Build a reference to the 'self' decl of a derived function.
+  static DeclRefExpr *createSelfDeclRef(AbstractFunctionDecl *fn);
+};
 }
 
 #endif

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -184,6 +184,10 @@ public:
 
   /// Build a reference to the 'self' decl of a derived function.
   static DeclRefExpr *createSelfDeclRef(AbstractFunctionDecl *fn);
+
+  /// Returns true if this derivation is trying to use a context that isn't
+  /// appropriate for deriving.
+  bool checkAndDiagnoseDisallowedContext() const;
 };
 }
 

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -41,6 +41,16 @@ public:
   DerivedConformance(TypeChecker &tc, Decl *conformanceDecl,
                      NominalTypeDecl *nominal, ProtocolDecl *protocol);
 
+  /// Retrieve the context in which the conformance is declared (either the
+  /// nominal type, or an extension of it) as a \c DeclContext.
+  DeclContext *getConformanceContext() const;
+
+  /// Add \c children as members of the context that declares the conformance.
+  void addMembersToConformanceContext(ArrayRef<Decl *> children);
+
+  /// Get the declared type of the protocol that this is conformance is for.
+  Type getProtocolType() const;
+
   /// True if the type can implicitly derive a conformance for the given
   /// protocol.
   ///

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -187,7 +187,9 @@ public:
 
   /// Returns true if this derivation is trying to use a context that isn't
   /// appropriate for deriving.
-  bool checkAndDiagnoseDisallowedContext() const;
+  ///
+  /// \param synthesizing The decl that is being synthesized.
+  bool checkAndDiagnoseDisallowedContext(ValueDecl *synthesizing) const;
 };
 }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4662,11 +4662,12 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
     // Special case: explain that 'RawRepresentable' conformance
     // is implied for enums which already declare a raw type.
     if (auto enumDecl = dyn_cast<EnumDecl>(existingDecl)) {
-      if (diag.Protocol->isSpecificProtocol(KnownProtocolKind::RawRepresentable)
-          && DerivedConformance::derivesProtocolConformance(*this, enumDecl,
-                                                            diag.Protocol)
-          && enumDecl->hasRawType()
-          && enumDecl->getInherited()[0].getSourceRange().isValid()) {
+      if (diag.Protocol->isSpecificProtocol(
+              KnownProtocolKind::RawRepresentable) &&
+          DerivedConformance::derivesProtocolConformance(*this, enumDecl,
+                                                         diag.Protocol) &&
+          enumDecl->hasRawType() &&
+          enumDecl->getInherited()[0].getSourceRange().isValid()) {
         diagnose(enumDecl->getInherited()[0].getSourceRange().Start,
                  diag::enum_declares_rawrep_with_raw_type,
                  dc->getDeclaredInterfaceType(), enumDecl->getRawType());
@@ -4973,35 +4974,32 @@ ValueDecl *TypeChecker::deriveProtocolRequirement(DeclContext *DC,
   if (Decl->isInvalid())
     return nullptr;
 
+  DerivedConformance derived(*this, Decl, TypeDecl, protocol);
+
   switch (*knownKind) {
   case KnownProtocolKind::RawRepresentable:
-    return DerivedConformance::deriveRawRepresentable(*this, Decl,
-                                                      TypeDecl, Requirement);
+    return derived.deriveRawRepresentable(Requirement);
 
   case KnownProtocolKind::CaseIterable:
-    return DerivedConformance::deriveCaseIterable(*this, Decl,
-                                                  TypeDecl, Requirement);
+    return derived.deriveCaseIterable(Requirement);
 
   case KnownProtocolKind::Equatable:
-    return DerivedConformance::deriveEquatable(*this, Decl, TypeDecl,
-                                               Requirement);
-  
+    return derived.deriveEquatable(Requirement);
+
   case KnownProtocolKind::Hashable:
-    return DerivedConformance::deriveHashable(*this, Decl, TypeDecl,
-                                              Requirement);
-    
+    return derived.deriveHashable(Requirement);
+
   case KnownProtocolKind::BridgedNSError:
-    return DerivedConformance::deriveBridgedNSError(*this, Decl, TypeDecl,
-                                                    Requirement);
+    return derived.deriveBridgedNSError(Requirement);
 
   case KnownProtocolKind::CodingKey:
-    return DerivedConformance::deriveCodingKey(*this, Decl, TypeDecl, Requirement);
+    return derived.deriveCodingKey(Requirement);
 
   case KnownProtocolKind::Encodable:
-    return DerivedConformance::deriveEncodable(*this, Decl, TypeDecl, Requirement);
+    return derived.deriveEncodable(Requirement);
 
   case KnownProtocolKind::Decodable:
-    return DerivedConformance::deriveDecodable(*this, Decl, TypeDecl, Requirement);
+    return derived.deriveDecodable(Requirement);
 
   default:
     return nullptr;
@@ -5020,13 +5018,12 @@ Type TypeChecker::deriveTypeWitness(DeclContext *DC,
 
   auto Decl = DC->getInnermostDeclarationDeclContext();
 
+  DerivedConformance derived(*this, Decl, TypeDecl, protocol);
   switch (*knownKind) {
   case KnownProtocolKind::RawRepresentable:
-    return DerivedConformance::deriveRawRepresentable(*this, Decl,
-                                                      TypeDecl, AssocType);
+    return derived.deriveRawRepresentable(AssocType);
   case KnownProtocolKind::CaseIterable:
-    return DerivedConformance::deriveCaseIterable(*this, Decl,
-                                                  TypeDecl, AssocType);
+    return derived.deriveCaseIterable(AssocType);
   default:
     return nullptr;
   }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2898,7 +2898,7 @@ ResolveWitnessResult ConformanceChecker::resolveWitnessViaDerivation(
   // Find the declaration that derives the protocol conformance.
   NominalTypeDecl *derivingTypeDecl = nullptr;
   auto *nominal = Adoptee->getAnyNominal();
-  if (DerivedConformance::derivesProtocolConformance(TC, nominal, Proto))
+  if (DerivedConformance::derivesProtocolConformance(TC, DC, nominal, Proto))
     derivingTypeDecl = nominal;
 
   if (!derivingTypeDecl) {
@@ -3574,7 +3574,8 @@ static void diagnoseConformanceFailure(TypeChecker &TC, Type T,
   // conformance to RawRepresentable was inferred.
   if (auto enumDecl = T->getEnumOrBoundGenericEnum()) {
     if (Proto->isSpecificProtocol(KnownProtocolKind::RawRepresentable) &&
-        DerivedConformance::derivesProtocolConformance(TC, enumDecl, Proto) &&
+        DerivedConformance::derivesProtocolConformance(TC, DC, enumDecl,
+                                                       Proto) &&
         enumDecl->hasRawType()) {
 
       auto rawType = enumDecl->getRawType();
@@ -4664,7 +4665,7 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
     if (auto enumDecl = dyn_cast<EnumDecl>(existingDecl)) {
       if (diag.Protocol->isSpecificProtocol(
               KnownProtocolKind::RawRepresentable) &&
-          DerivedConformance::derivesProtocolConformance(*this, enumDecl,
+          DerivedConformance::derivesProtocolConformance(*this, dc, enumDecl,
                                                          diag.Protocol) &&
           enumDecl->hasRawType() &&
           enumDecl->getInherited()[0].getSourceRange().isValid()) {

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -877,7 +877,7 @@ Type AssociatedTypeInference::computeDerivedTypeWitness(
 
   // Can we derive conformances for this protocol and adoptee?
   NominalTypeDecl *derivingTypeDecl = adoptee->getAnyNominal();
-  if (!DerivedConformance::derivesProtocolConformance(tc, derivingTypeDecl,
+  if (!DerivedConformance::derivesProtocolConformance(tc, dc, derivingTypeDecl,
                                                       proto))
     return Type();
 

--- a/test/Sema/Inputs/enum_conformance_synthesis_other.swift
+++ b/test/Sema/Inputs/enum_conformance_synthesis_other.swift
@@ -1,6 +1,7 @@
 // Note that for the test to be effective, each of these enums must only have
 // its Equatable or Hashable conformance referenced /once/ in the primary file.
 enum FromOtherFile : String {
+// expected-note@-1 {{type declared here}}
   case A = "a"
 }
 enum AlsoFromOtherFile : Int {
@@ -14,5 +15,6 @@ enum OtherFileNonconforming {
   case A(Int)
 }
 enum YetOtherFileNonconforming {
+// expected-note@-1 {{type declared here}}
   case A(Int)
 }

--- a/test/Sema/Inputs/enum_conformance_synthesis_other.swift
+++ b/test/Sema/Inputs/enum_conformance_synthesis_other.swift
@@ -18,3 +18,8 @@ enum YetOtherFileNonconforming {
 // expected-note@-1 {{type declared here}}
   case A(Int)
 }
+
+enum GenericOtherFileNonconforming<T> {
+// expected-note@-1 {{type declared here}}
+    case A(T)
+}

--- a/test/Sema/Inputs/struct_equatable_hashable_other.swift
+++ b/test/Sema/Inputs/struct_equatable_hashable_other.swift
@@ -17,3 +17,8 @@ struct YetOtherFileNonconforming {
 // expected-note@-1{{type declared here}}
   let v: String
 }
+
+struct GenericOtherFileNonconforming<T> {
+// expected-note@-1{{type declared here}}
+    let v: T
+}

--- a/test/Sema/Inputs/struct_equatable_hashable_other.swift
+++ b/test/Sema/Inputs/struct_equatable_hashable_other.swift
@@ -14,5 +14,6 @@ struct OtherFileNonconforming {
   let v: String
 }
 struct YetOtherFileNonconforming {
+// expected-note@-1{{type declared here}}
   let v: String
 }

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -178,6 +178,13 @@ enum Instrument {
 
 extension Instrument : Equatable {}
 
+extension Instrument : CaseIterable {}
+
+enum UnusedGeneric<T> {
+    case a, b, c
+}
+extension UnusedGeneric : CaseIterable {}
+
 // Explicit conformance should work too
 public enum Medicine {
   case Antibiotic

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -190,11 +190,10 @@ public func ==(lhs: Medicine, rhs: Medicine) -> Bool { // expected-note 3 {{non-
   return true
 }
 
-// No explicit conformance; it could be derived, but we don't support extensions
-// yet.
-extension Complex : Hashable {}  // expected-error 2 {{cannot be automatically synthesized in an extension}}
+// No explicit conformance; but it can be derived, for the same-file cases.
+extension Complex : Hashable {}
 extension Complex : CaseIterable {}  // expected-error {{type 'Complex' does not conform to protocol 'CaseIterable'}}
-extension FromOtherFile: CaseIterable {} // expected-error {{cannot be automatically synthesized in an extension}} expected-error {{does not conform to protocol 'CaseIterable'}}
+extension FromOtherFile: CaseIterable {} // expected-error {{cannot be automatically synthesized in an extension in a different file to the type}} expected-error {{does not conform to protocol 'CaseIterable'}}
 
 // No explicit conformance and it cannot be derived.
 enum NotExplicitlyHashableAndCannotDerive {
@@ -212,7 +211,7 @@ extension OtherFileNonconforming: Hashable {
   var hashValue: Int { return 0 }
 }
 // ...but synthesis in a type defined in another file doesn't work yet.
-extension YetOtherFileNonconforming: Equatable {} // expected-error {{cannot be automatically synthesized in an extension}}
+extension YetOtherFileNonconforming: Equatable {} // expected-error {{cannot be automatically synthesized in an extension in a different file to the type}}
 extension YetOtherFileNonconforming: CaseIterable {} // expected-error {{does not conform}}
 
 // Verify that an indirect enum doesn't emit any errors as long as its "leaves"

--- a/test/Sema/enum_equatable_conditional.swift
+++ b/test/Sema/enum_equatable_conditional.swift
@@ -20,7 +20,6 @@ enum WithArrayOfEquatables2<T> {
 case only([T])
 }
 
-// No: T is Equatable here, but cannot synthesize via an extension.
-// expected-error@+1{{type 'WithArrayOfEquatables2<T>' does not conform to protocol 'Equatable'}}
+// Okay: T is Equatable here too
 extension WithArrayOfEquatables2: Equatable where T: Equatable { }
 

--- a/test/Sema/struct_equatable_hashable.swift
+++ b/test/Sema/struct_equatable_hashable.swift
@@ -147,13 +147,13 @@ let _: Int = gnh.hashValue // No error. hashValue is always synthesized, even if
 gnh.hash(into: &hasher) // expected-error {{value of type 'GenericNotHashable<String>' has no member 'hash'}}
 
 
-// Conformance cannot be synthesized in an extension.
+// Synthesis can be from an extension...
 struct StructConformsInExtension {
   let v: Int
 }
-extension StructConformsInExtension : Equatable {} // expected-error {{cannot be automatically synthesized in an extension}}
+extension StructConformsInExtension : Equatable {}
 
-// But explicit conformance in an extension should work.
+// and explicit conformance in an extension should also work.
 public struct StructConformsAndImplementsInExtension {
   let v: Int
 }
@@ -181,7 +181,7 @@ extension OtherFileNonconforming: Hashable {
   var hashValue: Int { return 0 }
 }
 // ...but synthesis in a type defined in another file doesn't work yet.
-extension YetOtherFileNonconforming: Equatable {} // expected-error {{cannot be automatically synthesized in an extension}}
+extension YetOtherFileNonconforming: Equatable {} // expected-error {{cannot be automatically synthesized in an extension in a different file to the type}}
 
 // Verify that we can add Hashable conformance in an extension by only
 // implementing hash(into:)

--- a/test/decl/protocol/special/coding/class_codable_failure_diagnostics.swift
+++ b/test/decl/protocol/special/coding/class_codable_failure_diagnostics.swift
@@ -109,8 +109,7 @@ class C6 : Codable {
   }
 }
 
-// Classes cannot yet synthesize Encodable or Decodable in extensions.
+// Non-final classes cannot synthesize Decodable in an extension.
 class C7 {}
-extension C7 : Codable {}
-// expected-error@-1 {{implementation of 'Decodable' cannot be automatically synthesized in an extension}}
-// expected-error@-2 {{implementation of 'Encodable' cannot be automatically synthesized in an extension}}
+extension C7 : Decodable {}
+// expected-error@-1 {{implementation of 'Decodable' for non-final class cannot be automatically synthesized in extension because initializer requirement 'init(from:)' can only be be satisfied by a 'required' initializer in the class definition}}

--- a/test/decl/protocol/special/coding/class_codable_simple_conditional.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_conditional.swift
@@ -1,0 +1,39 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+class Conditional<T> {
+  var x: T
+  var y: T?
+
+  init() {
+  // expected-note@-1 2 {{did you mean 'init'}}
+    fatalError()
+  }
+  func foo() {
+    // They should receive a synthesized CodingKeys enum.
+    let _ = Conditional.CodingKeys.self
+
+    // The enum should have a case for each of the vars.
+    let _ = Conditional.CodingKeys.x
+    let _ = Conditional.CodingKeys.y
+
+    // Static vars should not be part of the CodingKeys enum.
+    let _ = Conditional.CodingKeys.z // expected-error {{type 'Conditional<T>.CodingKeys' has no member 'z'}}
+  }
+}
+
+extension Conditional: Codable where T: Codable {
+    // expected-error@-1 2 {{implementation of 'Decodable' for non-final class cannot be automatically synthesized in extension because initializer requirement 'init(from:)' can only be be satisfied by a 'required' initializer in the class definition}}
+}
+
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = Conditional<Int>.init(from:) // expected-error {{type 'Conditional<Int>' has no member 'init(from:)'}}
+let _ = Conditional<Int>.encode(to:)
+
+// but only for Codable parameters.
+struct Nonconforming {}
+let _ = Conditional<Nonconforming>.init(from:) // expected-error {{type 'Conditional<Nonconforming>' has no member 'init(from:)'}}
+let _ = Conditional<Nonconforming>.encode(to:) // expected-error {{type 'Nonconforming' does not conform to protocol 'Decodable'}}
+
+// The synthesized CodingKeys type should not be accessible from outside the
+// struct.
+let _ = Conditional<Int>.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/class_codable_simple_conditional_final.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_conditional_final.swift
@@ -1,0 +1,36 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+final class Conditional<T> {
+  var x: T
+  var y: T?
+
+  init() {
+    fatalError()
+  }
+  func foo() {
+    // They should receive a synthesized CodingKeys enum.
+    let _ = Conditional.CodingKeys.self
+
+    // The enum should have a case for each of the vars.
+    let _ = Conditional.CodingKeys.x
+    let _ = Conditional.CodingKeys.y
+
+    // Static vars should not be part of the CodingKeys enum.
+    let _ = Conditional.CodingKeys.z // expected-error {{type 'Conditional<T>.CodingKeys' has no member 'z'}}
+  }
+}
+
+extension Conditional: Codable where T: Codable {}
+
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = Conditional<Int>.init(from:)
+let _ = Conditional<Int>.encode(to:)
+
+// but only for Codable parameters.
+struct Nonconforming {}
+let _ = Conditional<Nonconforming>.init(from:) // expected-error {{type 'Nonconforming' does not conform to protocol 'Decodable'}}
+let _ = Conditional<Nonconforming>.encode(to:) // expected-error {{type 'Nonconforming' does not conform to protocol 'Decodable'}}
+
+// The synthesized CodingKeys type should not be accessible from outside the
+// struct.
+let _ = Conditional<Int>.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/class_codable_simple_conditional_final_separate.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_conditional_final_separate.swift
@@ -1,0 +1,42 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+final class Conditional<T> {
+  var x: T
+  var y: T?
+
+  init() {
+    fatalError()
+  }
+  func foo() {
+    // They should receive a synthesized CodingKeys enum.
+    let _ = Conditional.CodingKeys.self
+
+    // The enum should have a case for each of the vars.
+    let _ = Conditional.CodingKeys.x
+    let _ = Conditional.CodingKeys.y
+
+    // Static vars should not be part of the CodingKeys enum.
+    let _ = Conditional.CodingKeys.z // expected-error {{type 'Conditional<T>.CodingKeys' has no member 'z'}}
+  }
+}
+
+extension Conditional: Encodable where T: Encodable {
+}
+
+extension Conditional: Decodable where T: Decodable {
+}
+
+struct OnlyEnc: Encodable {}
+struct OnlyDec: Decodable {}
+
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = Conditional<OnlyDec>.init(from:)
+let _ = Conditional<OnlyEnc>.encode(to:)
+
+// but only for the appropriately *codable parameters.
+let _ = Conditional<OnlyEnc>.init(from:) // expected-error {{type 'OnlyEnc' does not conform to protocol 'Decodable'}}
+let _ = Conditional<OnlyDec>.encode(to:) // expected-error {{type 'OnlyDec' does not conform to protocol 'Encodable'}}
+
+// The synthesized CodingKeys type should not be accessible from outside the
+// struct.
+let _ = Conditional<Int>.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/class_codable_simple_conditional_separate.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_conditional_separate.swift
@@ -1,0 +1,44 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+class Conditional<T> {
+  var x: T
+  var y: T?
+
+  init() {
+  // expected-note@-1 2 {{did you mean 'init'}}
+    fatalError()
+  }
+  func foo() {
+    // They should receive a synthesized CodingKeys enum.
+    let _ = Conditional.CodingKeys.self
+
+    // The enum should have a case for each of the vars.
+    let _ = Conditional.CodingKeys.x
+    let _ = Conditional.CodingKeys.y
+
+    // Static vars should not be part of the CodingKeys enum.
+    let _ = Conditional.CodingKeys.z // expected-error {{type 'Conditional<T>.CodingKeys' has no member 'z'}}
+  }
+}
+
+extension Conditional: Encodable where T: Encodable {
+}
+
+extension Conditional: Decodable where T: Decodable {
+    // expected-error@-1 2 {{implementation of 'Decodable' for non-final class cannot be automatically synthesized in extension because initializer requirement 'init(from:)' can only be be satisfied by a 'required' initializer in the class definition}}
+}
+
+struct OnlyEnc: Encodable {}
+struct OnlyDec: Decodable {}
+
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = Conditional<OnlyDec>.init(from:) // expected-error {{type 'Conditional<OnlyDec>' has no member 'init(from:)'}}
+let _ = Conditional<OnlyEnc>.encode(to:)
+
+// but only for the appropriately *codable parameters.
+let _ = Conditional<OnlyEnc>.init(from:) // expected-error {{type 'Conditional<OnlyEnc>' has no member 'init(from:)'}}
+let _ = Conditional<OnlyDec>.encode(to:) // expected-error {{type 'OnlyDec' does not conform to protocol 'Encodable'}}
+
+// The synthesized CodingKeys type should not be accessible from outside the
+// struct.
+let _ = Conditional<Int>.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/class_codable_simple_extension.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_extension.swift
@@ -1,29 +1,31 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
-// Simple classes where Codable conformance is added in extensions should not
-// derive conformance yet.
+// Non-final classes where Codable conformance is added in extensions should
+// only be able to derive conformance for Encodable.
 class SimpleClass { // expected-note {{did you mean 'init'?}}
   var x: Int = 1
   var y: Double = .pi
   static var z: String = "foo"
 
   func foo() {
-    // They should not get a CodingKeys type.
-    let _ = SimpleClass.CodingKeys.self // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
-    let _ = SimpleClass.CodingKeys.x // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
-    let _ = SimpleClass.CodingKeys.y // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
-    let _ = SimpleClass.CodingKeys.z // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
+    // They should receive a synthesized CodingKeys enum.
+    let _ = SimpleClass.CodingKeys.self
+
+    // The enum should have a case for each of the vars.
+    let _ = SimpleClass.CodingKeys.x
+    let _ = SimpleClass.CodingKeys.y
+
+    // Static vars should not be part of the CodingKeys enum.
+    let _ = SimpleClass.CodingKeys.z // expected-error {{type 'SimpleClass.CodingKeys' has no member 'z'}}
   }
 }
 
-extension SimpleClass : Codable {} // expected-error {{implementation of 'Decodable' cannot be automatically synthesized in an extension}}
-// expected-error@-1 {{implementation of 'Decodable' cannot be automatically synthesized in an extension}}
-// expected-error@-2 {{implementation of 'Encodable' cannot be automatically synthesized in an extension}}
-// expected-error@-3 {{implementation of 'Encodable' cannot be automatically synthesized in an extension}}
+extension SimpleClass : Codable {} // expected-error 2 {{implementation of 'Decodable' for non-final class cannot be automatically synthesized in extension because initializer requirement 'init(from:)' can only be be satisfied by a 'required' initializer in the class definition}}
 
-// They should not receive Codable methods.
+// They should not receive synthesized init(from:), but should receive an encode(to:).
 let _ = SimpleClass.init(from:) // expected-error {{type 'SimpleClass' has no member 'init(from:)'}}
-let _ = SimpleClass.encode(to:) // expected-error {{type 'SimpleClass' has no member 'encode(to:)'}}
+let _ = SimpleClass.encode(to:)
 
-// They should not get a CodingKeys type.
-let _ = SimpleClass.CodingKeys.self // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
+// The synthesized CodingKeys type should not be accessible from outside the
+// struct.
+let _ = SimpleClass.CodingKeys.self  // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/class_codable_simple_extension_final.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_extension_final.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+// Simple final classes where Codable conformance is added in extensions should
+// be able to derive conformance for both Codable protocols.
+final class SimpleClass {
+  var x: Int = 1
+  var y: Double = .pi
+  static var z: String = "foo"
+
+  func foo() {
+    // They should receive a synthesized CodingKeys enum.
+    let _ = SimpleClass.CodingKeys.self
+
+    // The enum should have a case for each of the vars.
+    let _ = SimpleClass.CodingKeys.x
+    let _ = SimpleClass.CodingKeys.y
+
+    // Static vars should not be part of the CodingKeys enum.
+    let _ = SimpleClass.CodingKeys.z // expected-error {{type 'SimpleClass.CodingKeys' has no member 'z'}}
+  }
+}
+
+extension SimpleClass : Codable {}
+
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = SimpleClass.init(from:)
+let _ = SimpleClass.encode(to:)
+
+// The synthesized CodingKeys type should not be accessible from outside the
+// struct.
+let _ = SimpleClass.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/struct_codable_failure_diagnostics.swift
+++ b/test/decl/protocol/special/coding/struct_codable_failure_diagnostics.swift
@@ -89,9 +89,3 @@ struct S5 : Codable {
     case c
   }
 }
-
-// Structs cannot yet synthesize Encodable or Decodable in extensions.
-struct S6 {}
-extension S6 : Codable {}
-// expected-error@-1 {{implementation of 'Decodable' cannot be automatically synthesized in an extension}}
-// expected-error@-2 {{implementation of 'Encodable' cannot be automatically synthesized in an extension}}

--- a/test/decl/protocol/special/coding/struct_codable_simple_conditional.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple_conditional.swift
@@ -1,0 +1,33 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+struct Conditional<T> {
+  var x: T
+  var y: T?
+  func foo() {
+    // They should receive a synthesized CodingKeys enum.
+    let _ = Conditional.CodingKeys.self
+
+    // The enum should have a case for each of the vars.
+    let _ = Conditional.CodingKeys.x
+    let _ = Conditional.CodingKeys.y
+
+    // Static vars should not be part of the CodingKeys enum.
+    let _ = Conditional.CodingKeys.z // expected-error {{type 'Conditional<T>.CodingKeys' has no member 'z'}}
+  }
+}
+
+extension Conditional: Codable where T: Codable {
+}
+
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = Conditional<Int>.init(from:)
+let _ = Conditional<Int>.encode(to:)
+
+// but only for Codable parameters.
+struct Nonconforming {}
+let _ = Conditional<Nonconforming>.init(from:) // expected-error {{type 'Nonconforming' does not conform to protocol 'Decodable'}}
+let _ = Conditional<Nonconforming>.encode(to:) // expected-error {{type 'Nonconforming' does not conform to protocol 'Decodable'}}
+
+// The synthesized CodingKeys type should not be accessible from outside the
+// struct.
+let _ = Conditional<Int>.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/struct_codable_simple_conditional_separate.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple_conditional_separate.swift
@@ -1,0 +1,37 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+struct Conditional<T> {
+  var x: T
+  var y: T?
+  func foo() {
+    // They should receive a synthesized CodingKeys enum.
+    let _ = Conditional.CodingKeys.self
+
+    // The enum should have a case for each of the vars.
+    let _ = Conditional.CodingKeys.x
+    let _ = Conditional.CodingKeys.y
+
+    // Static vars should not be part of the CodingKeys enum.
+    let _ = Conditional.CodingKeys.z // expected-error {{type 'Conditional<T>.CodingKeys' has no member 'z'}}
+  }
+}
+
+extension Conditional: Encodable where T: Encodable {
+}
+extension Conditional: Decodable where T: Decodable {
+}
+
+struct OnlyEnc: Encodable {}
+struct OnlyDec: Decodable {}
+
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = Conditional<OnlyDec>.init(from:)
+let _ = Conditional<OnlyEnc>.encode(to:)
+
+// but only for the appropriately *codable parameters.
+let _ = Conditional<OnlyEnc>.init(from:) // expected-error {{type 'OnlyEnc' does not conform to protocol 'Decodable'}}
+let _ = Conditional<OnlyDec>.encode(to:) // expected-error {{type 'OnlyDec' does not conform to protocol 'Encodable'}}
+
+// The synthesized CodingKeys type should not be accessible from outside the
+// struct.
+let _ = Conditional<Int>.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/struct_codable_simple_extension_flipped.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple_extension_flipped.swift
@@ -1,7 +1,10 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
 // Simple structs where Codable conformance is added in extensions should derive
-// conformance.
+// conformance, no matter which order the extension and type occur in.
+
+extension SimpleStruct : Codable {}
+
 struct SimpleStruct {
   var x: Int
   var y: Double
@@ -17,9 +20,6 @@ struct SimpleStruct {
     // Static vars should not be part of the CodingKeys enum.
     let _ = SimpleStruct.CodingKeys.z // expected-error {{type 'SimpleStruct.CodingKeys' has no member 'z'}}
   }
-}
-
-extension SimpleStruct : Codable {
 }
 
 // They should receive synthesized init(from:) and an encode(to:).


### PR DESCRIPTION
This works for `Equatable`, `Hashable`, `Encodable`, `Decodable` (and thus `Codable`), and `CaseIterable`. For instance,

```swift
struct Foo<T> {
    var x: T 
}
extension Foo: Equatable where T: Equatable {}
```

Fixes rdar://problem/39199726 and https://bugs.swift.org/browse/SR-6803