### PR TITLE
Reenable Runtime/linux-fatal-backtrace.swift test

### DIFF
--- a/test/Runtime/linux-fatal-backtrace.swift
+++ b/test/Runtime/linux-fatal-backtrace.swift
@@ -4,7 +4,6 @@
 // REQUIRES: executable_test
 // REQUIRES: OS=linux-gnu
 // REQUIRES: lldb
-// REQUIRES: rdar38181372
 
 // Backtraces are not emitted when optimizations are enabled. This test can not
 // run when optimizations are enabled.

--- a/utils/symbolicate-linux-fatal
+++ b/utils/symbolicate-linux-fatal
@@ -55,8 +55,7 @@ def process_ldd(lddoutput):
 
 def create_lldb_target(binary, memmap):
     lldb_debugger = lldb.SBDebugger.Create()
-    lldb_target = lldb_debugger.CreateTargetWithFileAndArch(
-        binary, lldb.LLDB_ARCH_DEFAULT)
+    lldb_target = lldb_debugger.CreateTarget(binary)
     module = lldb_target.GetModuleAtIndex(0)
     for dynlib_path in memmap:
         module = lldb_target.AddModule(


### PR DESCRIPTION
This test broke when we switched to the swift-4.2-branch of Clang/LLVM.
It seems to be a problem with LLDB's CreateTargetWithFileAndArch() API
(rdar://problem/39960149). In the meantime, since this script does not
really need to specify the architecture, we can work around the problem
by using CreateTarget(). That's simpler anyway.

rdar://problem/38181372