### PR TITLE
 [SIL Cloner] Substitute for open existentials in substitution maps.

### DIFF
--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -168,21 +168,17 @@ protected:
 
   ProtocolConformanceRef getOpConformance(Type ty,
                                           ProtocolConformanceRef conformance) {
-    auto newConformance =
-      conformance.subst(ty,
-                        [&](SubstitutableType *t) -> Type {
-                          if (t->isOpenedExistential()) {
-                            auto found = OpenedExistentialSubs.find(
-                              t->castTo<ArchetypeType>());
-                            if (found != OpenedExistentialSubs.end())
-                              return found->second;
-                            return t;
-                          }
-                          return t;
-                        },
-                        MakeAbstractConformanceForGenericType());
+    // If we have open existentials to substitute, do so now.
+    if (ty->hasOpenedExistential() && !OpenedExistentialSubs.empty()) {
+      conformance =
+        conformance.subst(ty,
+                          QueryTypeSubstitutionMapOrIdentity{
+                                                        OpenedExistentialSubs},
+                          MakeAbstractConformanceForGenericType());
+    }
+
     return asImpl().remapConformance(getASTTypeInClonedContext(ty),
-                                     newConformance);
+                                     conformance);
   }
 
   ArrayRef<ProtocolConformanceRef>

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -120,6 +120,21 @@ protected:
   }
 
   SubstitutionMap getOpSubstitutionMap(SubstitutionMap Subs) {
+    // If we have open existentials to substitute, check whether that's
+    // relevant to this this particular substitution.
+    if (!OpenedExistentialSubs.empty()) {
+      for (auto ty : Subs.getReplacementTypes()) {
+        // If we found a type containing an opened existential, substitute
+        // open existentials throughout the substitution map.
+        if (ty->hasOpenedExistential()) {
+          Subs = Subs.subst(QueryTypeSubstitutionMapOrIdentity{
+                              OpenedExistentialSubs},
+                            MakeAbstractConformanceForGenericType());
+          break;
+        }
+      }
+    }
+
     return asImpl().remapSubstitutionMap(Subs).getCanonical();
   }
 


### PR DESCRIPTION
When introducing SIL cloner support for substitution maps, I failed
to account for the separate handling of substitutions for opened
existentials. Perform this substitution when needed.

Fixes rdar://problem/39976572.