### PR TITLE
[4.2 EARLY] Just autolink everything

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1214,13 +1214,15 @@ void ModuleDecl::collectLinkLibraries(LinkLibraryCallback callback) {
 
 void
 SourceFile::collectLinkLibraries(ModuleDecl::LinkLibraryCallback callback) const {
-
-  const_cast<SourceFile *>(this)->forAllVisibleModules([&](swift::ModuleDecl::ImportedModule import) {
+  forAllImportedModules<false>(getParentModule(), /*thisPath*/{},
+                               /*includePrivateTopLevelImports*/false,
+                               [=](ModuleDecl::ImportedModule import) -> bool {
     swift::ModuleDecl *next = import.second;
     if (next->getName() == getParentModule()->getName())
-      return;
+      return true;
 
     next->collectLinkLibraries(callback);
+    return true;
   });
 }
 

--- a/test/ClangImporter/autolinking.swift
+++ b/test/ClangImporter/autolinking.swift
@@ -7,8 +7,9 @@
 // RUN: %FileCheck %s < %t/with-adapter.ll
 // RUN: %FileCheck --check-prefix=CHECK-WITH-SWIFT %s < %t/with-adapter.ll
 
-// RUN: %target-swift-frontend %s -sdk %S/Inputs -I %S/Inputs/custom-modules -emit-ir -disable-autolink-framework LinkFramework -o %t/with-disabled.ll
-// RUN: %FileCheck --check-prefix=CHECK-WITH-DISABLED %s < %t/with-disabled.ll
+// RUN: %target-swift-frontend %s -sdk %S/Inputs -I %S/Inputs/custom-modules -emit-ir -disable-autolink-framework LinkFramework -o - > %t/with-disabled.ll
+// RUN: %FileCheck -check-prefix CHECK-WITH-DISABLED %s < %t/with-disabled.ll
+// RUN: %FileCheck -check-prefix NEGATIVE-WITH-DISABLED %s < %t/with-disabled.ll
 
 // Linux uses a different autolinking mechanism, based on
 // swift-autolink-extract. This file tests the Darwin mechanism.
@@ -38,6 +39,6 @@ UsesSubmodule.useSomethingFromSubmodule()
 
 // CHECK-WITH-SWIFT: !{{[0-9]+}} = !{!"-lSwiftAdapter"}
 
-// CHECK-WITH-DISABLED: !{!"-framework", !"Barrel"}
-// CHECK-WITH-DISABLED-NOT: !{!"-framework", !"LinkFramework"}
-// CHECK-WITH-DISABLED: !{!"-framework", !"Indirect"}
+// CHECK-WITH-DISABLED-DAG: !{!"-framework", !"Barrel"}
+// CHECK-WITH-DISABLED-DAG: !{!"-framework", !"Indirect"}
+// NEGATIVE-WITH-DISABLED-NOT: !"LinkFramework"

--- a/test/IRGen/clang_inline.swift
+++ b/test/IRGen/clang_inline.swift
@@ -1,12 +1,13 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs -primary-file %s -O -disable-sil-perf-optzns -disable-llvm-optzns -emit-ir | %FileCheck %s
+// RUN: %build-irgen-test-overlays
+// RUN: %target-swift-frontend -enable-objc-interop -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs -primary-file %s -O -disable-sil-perf-optzns -disable-llvm-optzns -emit-ir -Xcc -fstack-protector -I %t | %FileCheck %s
 
 // RUN: %empty-directory(%t/Empty.framework/Modules/Empty.swiftmodule)
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-module-path %t/Empty.framework/Modules/Empty.swiftmodule/%target-swiftmodule-name %S/../Inputs/empty.swift -module-name Empty
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs -primary-file %s -F %t -DIMPORT_EMPTY -O -disable-sil-perf-optzns -disable-llvm-optzns -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-module-path %t/Empty.framework/Modules/Empty.swiftmodule/%target-swiftmodule-name %S/../Inputs/empty.swift -module-name Empty -I %t
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs -primary-file %s -I %t -F %t -DIMPORT_EMPTY -O -disable-sil-perf-optzns -disable-llvm-optzns -emit-ir -Xcc -fstack-protector -enable-objc-interop | %FileCheck %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
-// XFAIL: linux
+// REQUIRES: objc_interop
 
 #if IMPORT_EMPTY
   import Empty

--- a/test/IRGen/clang_inline_reverse.swift
+++ b/test/IRGen/clang_inline_reverse.swift
@@ -1,9 +1,11 @@
 // Same test as clang_inline.swift, but with the order swapped.
 
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs -primary-file %s -emit-ir -module-name clang_inline | %FileCheck %s
+// RUN: %empty-directory(%t)
+// RUN: %build-irgen-test-overlays
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -sdk %S/Inputs -primary-file %s -enable-objc-interop -emit-ir -module-name clang_inline -I %t | %FileCheck %s
 
 // REQUIRES: CPU=i386 || CPU=x86_64
-// XFAIL: linux
+// REQUIRES: objc_interop
 
 import gizmo
 

--- a/test/IRGen/objc_block_storage.sil
+++ b/test/IRGen/objc_block_storage.sil
@@ -1,4 +1,6 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -gnone -sdk %S/Inputs %s -emit-ir | %FileCheck %s
+// RUN: %empty-directory(%t)
+// RUN: %build-irgen-test-overlays
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -gnone -enable-objc-interop -sdk %S/Inputs -I %t %s -emit-ir | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
 // REQUIRES: objc_interop

--- a/test/Serialization/Inputs/autolinking_indirect.swift
+++ b/test/Serialization/Inputs/autolinking_indirect.swift
@@ -1,0 +1,1 @@
+@_exported import autolinking_other2

--- a/test/Serialization/Inputs/autolinking_module_inferred.swift
+++ b/test/Serialization/Inputs/autolinking_module_inferred.swift
@@ -1,0 +1,8 @@
+@_exported import autolinking_public
+import autolinking_other
+import autolinking_indirect
+import autolinking_private
+
+public func bfunc(x: Int = afunc(), y: Int = afunc2()) {
+  cfunc()
+}

--- a/test/Serialization/Inputs/autolinking_other.swift
+++ b/test/Serialization/Inputs/autolinking_other.swift
@@ -1,0 +1,1 @@
+public func afunc() -> Int { return 0 }

--- a/test/Serialization/Inputs/autolinking_other2.swift
+++ b/test/Serialization/Inputs/autolinking_other2.swift
@@ -1,0 +1,1 @@
+public func afunc2() -> Int { return 0 }

--- a/test/Serialization/Inputs/autolinking_private.swift
+++ b/test/Serialization/Inputs/autolinking_private.swift
@@ -1,0 +1,1 @@
+public func cfunc() {}

--- a/test/Serialization/Inputs/autolinking_public.swift
+++ b/test/Serialization/Inputs/autolinking_public.swift
@@ -1,0 +1,1 @@
+// Empty module

--- a/test/Serialization/autolinking-inlinable-inferred.swift
+++ b/test/Serialization/autolinking-inlinable-inferred.swift
@@ -1,0 +1,36 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_public.swift -emit-module-path %t/autolinking_public.swiftmodule -module-link-name autolinking_public -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_other.swift -emit-module-path %t/autolinking_other.swiftmodule -module-link-name autolinking_other -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_private.swift -emit-module-path %t/autolinking_private.swiftmodule -module-link-name autolinking_private -I %t -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_other2.swift -emit-module-path %t/autolinking_other2.swiftmodule -module-link-name autolinking_other2 -swift-version 4
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_indirect.swift -emit-module-path %t/autolinking_indirect.swiftmodule -module-link-name autolinking_indirect -I %t -swift-version 4
+
+// RUN: %target-swift-frontend -emit-module %S/Inputs/autolinking_module_inferred.swift -emit-module-path %t/autolinking_module_inferred.swiftmodule -module-link-name autolinking_module_inferred -I %t -swift-version 4
+// RUN: %target-swift-frontend -emit-ir %s -I %t -swift-version 4 | %FileCheck %s
+
+// Linux uses a different autolinking mechanism, based on
+// swift-autolink-extract. This file tests the Darwin mechanism.
+// UNSUPPORTED: OS=linux-gnu
+// UNSUPPORTED: OS=linux-gnueabihf
+// UNSUPPORTED: OS=freebsd
+// UNSUPPORTED: OS=linux-androideabi
+
+import autolinking_module_inferred
+
+bfunc()
+
+// CHECK: !llvm.linker.options = !{[[MODULE:![0-9]+]], [[PUBLIC:![0-9]+]], [[SWIFTONONESUPPORT:![0-9]+]], [[SWIFTCORE:![0-9]+]], [[PRIVATE:![0-9]+]], [[OTHER:![0-9]+]], [[INDIRECT:![0-9]+]], [[OTHER2:![0-9]+]], [[OBJC:![0-9]+]]}
+
+// CHECK-DAG: [[SWIFTCORE]] = !{!"-lswiftCore"}
+// CHECK-DAG: [[SWIFTONONESUPPORT]] = !{!"-lswiftSwiftOnoneSupport"}
+// CHECK-DAG: [[MODULE]] = !{!"-lautolinking_module_inferred"}
+// CHECK-DAG: [[PUBLIC]] = !{!"-lautolinking_public"}
+// CHECK-DAG: [[OTHER]] = !{!"-lautolinking_other"}
+// CHECK-DAG: [[OTHER2]] = !{!"-lautolinking_other2"}
+// CHECK-DAG: [[OBJC]] = !{!"-lobjc"}
+
+// We don't actually care about these two. As long as we autolink the libraries
+// that get used, we're okay.
+// CHECK-DAG: [[PRIVATE]] = !{!"-lautolinking_private"}
+// CHECK-DAG: [[INDIRECT]] = !{!"-lautolinking_indirect"}


### PR DESCRIPTION
- **Explanation**: If module A uses some inlinable code from module B (including function default arguments), and that code uses a symbol in module C, but module A doesn't itself import module C, we'll get a link error. This change conservatively autolinks *any* modules that are transitively imported, even if they aren't re-exported by their intervening modules.
- **Scope**: As described in the explanation. We've seen this on at least one Apple-internal project.
- **Issue**: rdar://problem/39338239
- **Risk**: Medium-low. There's basically no way that this could result in *fewer* things being linked, so the main risk is whether *more* things will get linked than before, or if this drastically slows down compilation or linking. That seems unlikely (and hasn't been observed).
- **Testing**: Added compiler regression tests.
- **Reviewed by**: @graydon and @DougGregor 
