### PR TITLE
[4.2] [Parser] Don't lose outer "disabled" variables when checking a guard's "else"

### DIFF
--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -1605,7 +1605,7 @@ ParserResult<Stmt> Parser::parseStmtGuard() {
   for (auto &elt : Condition)
     if (auto pattern = elt.getPatternOrNull())
       pattern->collectVariables(Vars);
-
+  Vars.append(DisabledVars.begin(), DisabledVars.end());
   llvm::SaveAndRestore<decltype(DisabledVars)>
   RestoreCurVars(DisabledVars, Vars);
 

--- a/test/stmt/statements.swift
+++ b/test/stmt/statements.swift
@@ -378,6 +378,13 @@ func test_guard(_ x : Int, y : Int??, cond : Bool) {
 
 
   guard case _ = x else {}  // expected-warning {{'guard' condition is always true, body is unreachable}}
+
+  // SR-7567
+  guard let outer = y else {
+    guard true else {
+      print(outer) // expected-error {{variable declared in 'guard' condition is not usable in its body}}
+    }
+  }
 }
 
 func test_is_as_patterns() {


### PR DESCRIPTION
When checking for uses of "disabled" variables within the "else"
statement of a "guard", keep track of the disabled variables from
outer scopes. This is a pattern used everywhere else in the parser,
but got missed here. Fixes SR-7567 / rdar://problem/39868144.
