### PR TITLE
[SIL] Teach *ApplyInst to traffic in SubstitutionMap.

### DIFF
--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -133,7 +133,12 @@ public:
   lookupConformance(CanType type, ProtocolDecl *proto) const;
 
   /// Whether the substitution map is empty.
-  bool empty() const { return getGenericSignature() == nullptr; }
+  bool empty() const;
+
+  /// Whether the substitution has any substitutable parameters, i.e.,
+  /// it is non-empty and at least one of the type parameters can be
+  /// substituted (i.e., is not mapped to a concrete type).
+  bool hasAnySubstitutableParams() const;
 
   /// Whether the substitution map is non-empty.
   explicit operator bool() const { return !empty(); }

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -247,7 +247,7 @@ public:
 
   static SILType getPartialApplyResultType(SILType Ty, unsigned ArgCount,
                                          SILModule &M,
-                                         SubstitutionList subs,
+                                         SubstitutionMap subs,
                                          ParameterConvention calleeConvention);
 
   //===--------------------------------------------------------------------===//
@@ -357,7 +357,7 @@ public:
   }
 
   ApplyInst *createApply(
-      SILLocation Loc, SILValue Fn, SubstitutionList Subs,
+      SILLocation Loc, SILValue Fn, SubstitutionMap Subs,
       ArrayRef<SILValue> Args, bool isNonThrowing,
       const GenericSpecializationInformation *SpecializationInfo = nullptr) {
     return insert(ApplyInst::create(getSILDebugLocation(Loc), Fn, Subs, Args,
@@ -370,12 +370,12 @@ public:
       const GenericSpecializationInformation *SpecializationInfo = nullptr) {
     SILFunctionConventions conventions(Fn->getType().castTo<SILFunctionType>(),
                                        getModule());
-    return createApply(Loc, Fn, SubstitutionList(), Args, isNonThrowing,
+    return createApply(Loc, Fn, SubstitutionMap(), Args, isNonThrowing,
                        SpecializationInfo);
   }
 
   TryApplyInst *createTryApply(
-      SILLocation Loc, SILValue fn, SubstitutionList subs,
+      SILLocation Loc, SILValue fn, SubstitutionMap subs,
       ArrayRef<SILValue> args, SILBasicBlock *normalBB, SILBasicBlock *errorBB,
       const GenericSpecializationInformation *SpecializationInfo = nullptr) {
     return insertTerminator(TryApplyInst::create(getSILDebugLocation(Loc),
@@ -386,7 +386,7 @@ public:
   }
 
   PartialApplyInst *createPartialApply(
-      SILLocation Loc, SILValue Fn, SubstitutionList Subs,
+      SILLocation Loc, SILValue Fn, SubstitutionMap Subs,
       ArrayRef<SILValue> Args, ParameterConvention CalleeConvention,
       const GenericSpecializationInformation *SpecializationInfo = nullptr) {
     return insert(PartialApplyInst::create(getSILDebugLocation(Loc), Fn,
@@ -396,7 +396,7 @@ public:
   }
 
   BeginApplyInst *createBeginApply(
-      SILLocation Loc, SILValue Fn, SubstitutionList Subs,
+      SILLocation Loc, SILValue Fn, SubstitutionMap Subs,
       ArrayRef<SILValue> Args, bool isNonThrowing,
       const GenericSpecializationInformation *SpecializationInfo = nullptr) {
     return insert(BeginApplyInst::create(getSILDebugLocation(Loc), Fn, Subs,

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -107,13 +107,6 @@ protected:
   const SILDebugScope *getOpScope(const SILDebugScope *DS) {
     return asImpl().remapScope(DS);
   }
-  SmallVector<Substitution, 4> getOpSubstitutions(SubstitutionList Subs) {
-    SmallVector<Substitution, 4> NewSubs;
-    for (auto Sub : Subs) {
-      NewSubs.push_back(getOpSubstitution(Sub));
-    }
-    return NewSubs;
-  }
 
   SubstitutionMap remapSubstitutionMap(SubstitutionMap Subs) {
     return Subs;
@@ -205,14 +198,6 @@ protected:
     return ty->getASTContext().AllocateCopy(newConformances);
   }
   
-  Substitution getOpSubstitution(Substitution sub) {
-    CanType newReplacement =
-      getOpASTType(sub.getReplacement()->getCanonicalType());
-    auto conformances = getOpConformances(sub.getReplacement(),
-                                          sub.getConformances());
-    return Substitution(newReplacement, conformances);
-  }
-
   SILValue getOpValue(SILValue Value) {
     return asImpl().remapValue(Value);
   }
@@ -592,7 +577,7 @@ SILCloner<ImplClass>::visitApplyInst(ApplyInst *Inst) {
   doPostProcess(Inst,
     getBuilder().createApply(getOpLocation(Inst->getLoc()),
                              getOpValue(Inst->getCallee()),
-                             getOpSubstitutions(Inst->getSubstitutions()),
+                             getOpSubstitutionMap(Inst->getSubstitutionMap()),
                              Args,
                              Inst->isNonThrowing(),
                              GenericSpecializationInformation::create(
@@ -607,7 +592,8 @@ SILCloner<ImplClass>::visitTryApplyInst(TryApplyInst *Inst) {
   doPostProcess(Inst,
     getBuilder().createTryApply(getOpLocation(Inst->getLoc()),
                                 getOpValue(Inst->getCallee()),
-                                getOpSubstitutions(Inst->getSubstitutions()),
+                                getOpSubstitutionMap(
+                                                  Inst->getSubstitutionMap()),
                                 Args,
                                 getOpBasicBlock(Inst->getNormalBB()),
                                 getOpBasicBlock(Inst->getErrorBB()),
@@ -624,7 +610,7 @@ SILCloner<ImplClass>::visitPartialApplyInst(PartialApplyInst *Inst) {
                 getBuilder().createPartialApply(
                     getOpLocation(Inst->getLoc()),
                     getOpValue(Inst->getCallee()),
-                    getOpSubstitutions(Inst->getSubstitutions()), Args,
+                    getOpSubstitutionMap(Inst->getSubstitutionMap()), Args,
                     Inst->getType().getAs<SILFunctionType>()
                       ->getCalleeConvention(),
                     GenericSpecializationInformation::create(Inst,
@@ -639,7 +625,8 @@ SILCloner<ImplClass>::visitBeginApplyInst(BeginApplyInst *Inst) {
   doPostProcess(Inst,
     getBuilder().createBeginApply(getOpLocation(Inst->getLoc()),
                                   getOpValue(Inst->getCallee()),
-                                  getOpSubstitutions(Inst->getSubstitutions()),
+                                  getOpSubstitutionMap(
+                                                    Inst->getSubstitutionMap()),
                                   Args,
                                   Inst->isNonThrowing(),
                                   GenericSpecializationInformation::create(

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1788,7 +1788,9 @@ public:
   }
 
   /// True if this application has generic substitutions.
-  bool hasSubstitutions() const { return !Substitutions.empty(); }
+  bool hasSubstitutions() const {
+    return Substitutions.hasAnySubstitutableParams();
+  }
 
   /// The substitutions used to bind the generic arguments of this function.
   SubstitutionList getSubstitutions() const { return Substitutions.toList(); }
@@ -2769,7 +2771,7 @@ public:
   /// True if this builtin application has substitutions, which represent type
   /// parameters to the builtin.
   bool hasSubstitutions() const {
-    return !Substitutions.empty();
+    return Substitutions.hasAnySubstitutableParams();
   }
 
   /// Return the type parameters to the builtin.

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1688,7 +1688,7 @@ class ApplyInstBase<Impl, Base, false> : public Base {
 protected:
   template <class... As>
   ApplyInstBase(SILInstructionKind kind, SILDebugLocation DebugLoc, SILValue callee,
-                SILType substCalleeType, SubstitutionList subs,
+                SILType substCalleeType, SubstitutionMap subs,
                 ArrayRef<SILValue> args,
                 ArrayRef<SILValue> typeDependentOperands,
                 const GenericSpecializationInformation *specializationInfo,
@@ -1696,7 +1696,8 @@ protected:
       : Base(kind, DebugLoc, baseArgs...), SubstCalleeType(substCalleeType),
         SpecializationInfo(specializationInfo),
         NonThrowing(false), NumCallArguments(args.size()),
-        NumTypeDependentOperands(typeDependentOperands.size()) {
+        NumTypeDependentOperands(typeDependentOperands.size()),
+        Substitutions(subs) {
 
     // Initialize the operands.
     auto allOperands = getAllOperands();
@@ -1707,13 +1708,6 @@ protected:
     for (size_t i : indices(typeDependentOperands)) {
       new (&allOperands[NumStaticOperands + args.size() + i])
         Operand(this, typeDependentOperands[i]);
-    }
-
-    // Initialize the substitutions.
-    if (!subs.empty()) {
-      if (auto genericSig = getOrigCalleeType()->getGenericSignature()) {
-        Substitutions = genericSig->getSubstitutionMap(subs);
-      }
     }
   }
 
@@ -1996,7 +1990,7 @@ class ApplyInst final
 
   ApplyInst(SILDebugLocation DebugLoc, SILValue Callee,
             SILType SubstCalleeType, SILType ReturnType,
-            SubstitutionList Substitutions,
+            SubstitutionMap Substitutions,
             ArrayRef<SILValue> Args,
             ArrayRef<SILValue> TypeDependentOperands,
             bool isNonThrowing,
@@ -2004,7 +1998,7 @@ class ApplyInst final
 
   static ApplyInst *
   create(SILDebugLocation DebugLoc, SILValue Callee,
-         SubstitutionList Substitutions, ArrayRef<SILValue> Args,
+         SubstitutionMap Substitutions, ArrayRef<SILValue> Args,
          bool isNonThrowing, Optional<SILModuleConventions> ModuleConventions,
          SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes,
          const GenericSpecializationInformation *SpecializationInfo);
@@ -2028,7 +2022,7 @@ class PartialApplyInst final
 
   PartialApplyInst(SILDebugLocation DebugLoc, SILValue Callee,
                    SILType SubstCalleeType,
-                   SubstitutionList Substitutions,
+                   SubstitutionMap Substitutions,
                    ArrayRef<SILValue> Args,
                    ArrayRef<SILValue> TypeDependentOperands,
                    SILType ClosureType,
@@ -2036,7 +2030,7 @@ class PartialApplyInst final
 
   static PartialApplyInst *
   create(SILDebugLocation DebugLoc, SILValue Callee, ArrayRef<SILValue> Args,
-         SubstitutionList Substitutions, ParameterConvention CalleeConvention,
+         SubstitutionMap Substitutions, ParameterConvention CalleeConvention,
          SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes,
          const GenericSpecializationInformation *SpecializationInfo);
 
@@ -2097,7 +2091,7 @@ class BeginApplyInst final
                  SILType substCalleeType,
                  ArrayRef<SILType> allResultTypes,
                  ArrayRef<ValueOwnershipKind> allResultOwnerships,
-                 SubstitutionList substitutions,
+                 SubstitutionMap substitutions,
                  ArrayRef<SILValue> args,
                  ArrayRef<SILValue> typeDependentOperands,
                  bool isNonThrowing,
@@ -2105,7 +2099,7 @@ class BeginApplyInst final
 
   static BeginApplyInst *
   create(SILDebugLocation debugLoc, SILValue Callee,
-         SubstitutionList substitutions, ArrayRef<SILValue> args,
+         SubstitutionMap substitutions, ArrayRef<SILValue> args,
          bool isNonThrowing, Optional<SILModuleConventions> moduleConventions,
          SILFunction &F, SILOpenedArchetypesState &openedArchetypes,
          const GenericSpecializationInformation *specializationInfo);
@@ -7556,7 +7550,7 @@ class TryApplyInst final
   friend SILBuilder;
 
   TryApplyInst(SILDebugLocation DebugLoc, SILValue callee,
-               SILType substCalleeType, SubstitutionList substitutions,
+               SILType substCalleeType, SubstitutionMap substitutions,
                ArrayRef<SILValue> args,
                ArrayRef<SILValue> TypeDependentOperands,
                SILBasicBlock *normalBB, SILBasicBlock *errorBB,
@@ -7564,7 +7558,7 @@ class TryApplyInst final
 
   static TryApplyInst *
   create(SILDebugLocation DebugLoc, SILValue callee,
-         SubstitutionList substitutions, ArrayRef<SILValue> args,
+         SubstitutionMap substitutions, ArrayRef<SILValue> args,
          SILBasicBlock *normalBB, SILBasicBlock *errorBB, SILFunction &F,
          SILOpenedArchetypesState &OpenedArchetypes,
          const GenericSpecializationInformation *SpecializationInfo);

--- a/include/swift/SIL/TypeSubstCloner.h
+++ b/include/swift/SIL/TypeSubstCloner.h
@@ -40,13 +40,6 @@ class TypeSubstCloner : public SILClonerWithScopes<ImplClass> {
     llvm_unreachable("Clients need to explicitly call a base class impl!");
   }
 
-  void computeSubsMap() {
-    if (auto genericSig = Original.getLoweredFunctionType()
-          ->getGenericSignature()) {
-      SubsMap = genericSig->getSubstitutionMap(ApplySubs);
-    }
-  }
-
   // A helper class for cloning different kinds of apply instructions.
   // Supports cloning of self-recursive functions.
   class ApplySiteCloningHelper {
@@ -141,27 +134,25 @@ public:
 
   TypeSubstCloner(SILFunction &To,
                   SILFunction &From,
-                  SubstitutionList ApplySubs,
+                  SubstitutionMap ApplySubs,
                   SILOpenedArchetypesTracker &OpenedArchetypesTracker,
                   bool Inlining = false)
     : SILClonerWithScopes<ImplClass>(To, OpenedArchetypesTracker, Inlining),
       SwiftMod(From.getModule().getSwiftModule()),
+      SubsMap(ApplySubs),
       Original(From),
-      ApplySubs(ApplySubs),
       Inlining(Inlining) {
-    computeSubsMap();
   }
 
   TypeSubstCloner(SILFunction &To,
                   SILFunction &From,
-                  SubstitutionList ApplySubs,
+                  SubstitutionMap ApplySubs,
                   bool Inlining = false)
     : SILClonerWithScopes<ImplClass>(To, Inlining),
       SwiftMod(From.getModule().getSwiftModule()),
+      SubsMap(ApplySubs),
       Original(From),
-      ApplySubs(ApplySubs),
       Inlining(Inlining) {
-    computeSubsMap();
   }
 
 
@@ -295,8 +286,6 @@ protected:
   llvm::DenseMap<SILType, SILType> TypeCache;
   /// The original function to specialize.
   SILFunction &Original;
-  /// The substitutions used at the call site.
-  SubstitutionList ApplySubs;
   /// True, if used for inlining.
   bool Inlining;
 };

--- a/include/swift/SILOptimizer/Analysis/ArraySemantic.h
+++ b/include/swift/SILOptimizer/Analysis/ArraySemantic.h
@@ -155,7 +155,7 @@ public:
   bool replaceByAppendingValues(SILModule &M, SILFunction *AppendFn,
                                 SILFunction *ReserveFn,
                                 const llvm::SmallVectorImpl<SILValue> &Vals,
-                                ArrayRef<Substitution> Subs);
+                                SubstitutionMap Subs);
 
   /// Hoist the call to the insert point.
   void hoist(SILInstruction *InsertBefore, DominanceInfo *DT) {

--- a/include/swift/SILOptimizer/Utils/GenericCloner.h
+++ b/include/swift/SILOptimizer/Utils/GenericCloner.h
@@ -41,7 +41,7 @@ public:
   GenericCloner(SILFunction *F,
                 IsSerialized_t Serialized,
                 const ReabstractionInfo &ReInfo,
-                SubstitutionList ParamSubs,
+                SubstitutionMap ParamSubs,
                 StringRef NewName,
                 CloneCollector::CallbackType Callback)
   : TypeSubstCloner(*initCloned(F, Serialized, ReInfo, NewName), *F,
@@ -55,7 +55,7 @@ public:
   cloneFunction(SILFunction *F,
                 IsSerialized_t Serialized,
                 const ReabstractionInfo &ReInfo,
-                SubstitutionList ParamSubs,
+                SubstitutionMap ParamSubs,
                 StringRef NewName,
                 CloneCollector::CallbackType Callback =nullptr) {
     // Clone and specialize the function.

--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -119,13 +119,13 @@ class ReabstractionInfo {
 
   void createSubstitutedAndSpecializedTypes();
   bool prepareAndCheck(ApplySite Apply, SILFunction *Callee,
-                       SubstitutionList ParamSubs,
+                       SubstitutionMap ParamSubs,
                        OptRemark::Emitter *ORE = nullptr);
   void performFullSpecializationPreparation(SILFunction *Callee,
-                                            SubstitutionList ParamSubs);
+                                            SubstitutionMap ParamSubs);
   void performPartialSpecializationPreparation(SILFunction *Caller,
                                                SILFunction *Callee,
-                                               SubstitutionList ParamSubs);
+                                               SubstitutionMap ParamSubs);
   void finishPartialSpecializationPreparation(
       FunctionSignaturePartialSpecializer &FSPS);
 
@@ -136,7 +136,7 @@ public:
   /// If specialization is not possible getSpecializedType() will return an
   /// invalid type.
   ReabstractionInfo(ApplySite Apply, SILFunction *Callee,
-                    SubstitutionList ParamSubs,
+                    SubstitutionMap ParamSubs,
                     bool ConvertIndirectToDirect = true,
                     OptRemark::Emitter *ORE = nullptr);
 
@@ -256,7 +256,7 @@ public:
 
   /// Returns true if a given apply can be specialized.
   static bool canBeSpecialized(ApplySite Apply, SILFunction *Callee,
-                               SubstitutionList ParamSubs);
+                               SubstitutionMap ParamSubs);
 
   /// Returns the apply site for the current generic specialization.
   ApplySite getApply() const {
@@ -271,7 +271,7 @@ public:
 class GenericFuncSpecializer {
   SILModule &M;
   SILFunction *GenericFunc;
-  SubstitutionList ParamSubs;
+  SubstitutionMap ParamSubs;
   IsSerialized_t Serialized;
   const ReabstractionInfo &ReInfo;
 
@@ -280,7 +280,7 @@ class GenericFuncSpecializer {
 
 public:
   GenericFuncSpecializer(SILFunction *GenericFunc,
-                         SubstitutionList ParamSubs,
+                         SubstitutionMap ParamSubs,
                          IsSerialized_t Serialized,
                          const ReabstractionInfo &ReInfo);
 

--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -82,23 +82,17 @@ class ReabstractionInfo {
   // any transformations performed by the generic specializer.
   //
   // Maps callee's generic parameters to caller's archetypes.
-  SubstitutionList CalleeParamSubs;
+  SubstitutionMap CalleeParamSubMap;
 
   // Set of substitutions to be used to invoke a specialized function.
   //
   // Maps generic parameters of the specialized callee function to caller's
   // archetypes.
-  SubstitutionList CallerParamSubs;
+  SubstitutionMap CallerParamSubMap;
 
   // Replaces archetypes of the original callee with archetypes
   // or concrete types, if they were made concrete) of the specialized
   // callee.
-  //
-  // Maps original callee's generic parameters to specialized
-  // callee archetypes.
-  SubstitutionList ClonerParamSubs;
-
-  /// Substitution map form of ClonerParamSubs.
   SubstitutionMap ClonerParamSubMap;
 
   // Reference to the original generic non-specialized callee function.
@@ -213,11 +207,15 @@ public:
   }
 
   SubstitutionList getCallerParamSubstitutions() const {
-    return CallerParamSubs;
+    return CallerParamSubMap.toList();
+  }
+
+  SubstitutionMap getCallerParamSubstitutionMap() const {
+    return CallerParamSubMap;
   }
 
   SubstitutionList getClonerParamSubstitutions() const {
-    return ClonerParamSubs;
+    return ClonerParamSubMap.toList();
   }
 
   SubstitutionMap getClonerParamSubstitutionMap() const {
@@ -225,7 +223,11 @@ public:
   }
 
   SubstitutionList getCalleeParamSubstitutions() const {
-    return CalleeParamSubs;
+    return CalleeParamSubMap.toList();
+  }
+
+  SubstitutionMap getCalleeParamSubstitutionMap() const {
+    return CalleeParamSubMap;
   }
 
   /// Create a specialized function type for a specific substituted type \p

--- a/include/swift/SILOptimizer/Utils/Generics.h
+++ b/include/swift/SILOptimizer/Utils/Generics.h
@@ -206,24 +206,12 @@ public:
     return SpecializedGenericSig;
   }
 
-  SubstitutionList getCallerParamSubstitutions() const {
-    return CallerParamSubMap.toList();
-  }
-
   SubstitutionMap getCallerParamSubstitutionMap() const {
     return CallerParamSubMap;
   }
 
-  SubstitutionList getClonerParamSubstitutions() const {
-    return ClonerParamSubMap.toList();
-  }
-
   SubstitutionMap getClonerParamSubstitutionMap() const {
     return ClonerParamSubMap;
-  }
-
-  SubstitutionList getCalleeParamSubstitutions() const {
-    return CalleeParamSubMap.toList();
   }
 
   SubstitutionMap getCalleeParamSubstitutionMap() const {

--- a/include/swift/SILOptimizer/Utils/SILInliner.h
+++ b/include/swift/SILOptimizer/Utils/SILInliner.h
@@ -61,7 +61,7 @@ private:
 
 public:
   SILInliner(SILFunction &To, SILFunction &From, InlineKind IKind,
-             SubstitutionList ApplySubs,
+             SubstitutionMap ApplySubs,
              SILOpenedArchetypesTracker &OpenedArchetypesTracker,
              CloneCollector::CallbackType Callback = nullptr)
       : TypeSubstCloner<SILInliner>(To, From, ApplySubs,

--- a/include/swift/SILOptimizer/Utils/SpecializationMangler.h
+++ b/include/swift/SILOptimizer/Utils/SpecializationMangler.h
@@ -65,17 +65,17 @@ protected:
 // The mangler for specialized generic functions.
 class GenericSpecializationMangler : public SpecializationMangler {
 
-  SubstitutionList Subs;
+  SubstitutionMap SubMap;
   bool isReAbstracted;
 
 public:
 
   GenericSpecializationMangler(SILFunction *F,
-                               SubstitutionList Subs,
+                               SubstitutionMap SubMap,
                                IsSerialized_t Serialized,
                                bool isReAbstracted)
     : SpecializationMangler(SpecializationPass::GenericSpecializer, Serialized, F),
-      Subs(Subs), isReAbstracted(isReAbstracted) {}
+      SubMap(SubMap), isReAbstracted(isReAbstracted) {}
 
   std::string mangle();
 };

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -4157,8 +4157,8 @@ void ProtocolConformance::printName(llvm::raw_ostream &os,
   case ProtocolConformanceKind::Specialized: {
     auto spec = cast<SpecializedProtocolConformance>(this);
     os << "specialize <";
-    interleave(spec->getSubstitutionMap().toList(),
-               [&](const Substitution &s) { s.print(os, PO); },
+    interleave(spec->getSubstitutionMap().getReplacementTypes(),
+               [&](Type type) { type.print(os, PO); },
                [&] { os << ", "; });
 
     os << "> (";

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -91,6 +91,17 @@ GenericSignature *SubstitutionMap::getGenericSignature() const {
   return storage ? storage->getGenericSignature() : nullptr;
 }
 
+bool SubstitutionMap::empty() const {
+  return getGenericSignature() == nullptr;
+}
+
+bool SubstitutionMap::hasAnySubstitutableParams() const {
+  auto genericSig = getGenericSignature();
+  if (!genericSig) return false;
+
+  return !genericSig->areAllParamsConcrete();
+}
+
 bool SubstitutionMap::hasArchetypes() const {
   for (Type replacementTy : getReplacementTypes()) {
     if (replacementTy && replacementTy->hasArchetype())

--- a/lib/IRGen/GenFunc.h
+++ b/lib/IRGen/GenFunc.h
@@ -50,7 +50,7 @@ namespace irgen {
   void emitFunctionPartialApplication(
       IRGenFunction &IGF, SILFunction &SILFn, const FunctionPointer &fnPtr,
       llvm::Value *fnContext, Explosion &args,
-      ArrayRef<SILParameterInfo> argTypes, SubstitutionList subs,
+      ArrayRef<SILParameterInfo> argTypes, SubstitutionMap subs,
       CanSILFunctionType origType, CanSILFunctionType substType,
       CanSILFunctionType outType, Explosion &out, bool isOutlined);
 

--- a/lib/IRGen/GenReflection.cpp
+++ b/lib/IRGen/GenReflection.cpp
@@ -558,14 +558,14 @@ class CaptureDescriptorBuilder : public ReflectionMetadataBuilder {
   swift::reflection::MetadataSourceBuilder SourceBuilder;
   CanSILFunctionType OrigCalleeType;
   CanSILFunctionType SubstCalleeType;
-  SubstitutionList Subs;
+  SubstitutionMap Subs;
   const HeapLayout &Layout;
 
 public:
   CaptureDescriptorBuilder(IRGenModule &IGM,
                            CanSILFunctionType OrigCalleeType,
                            CanSILFunctionType SubstCalleeType,
-                           SubstitutionList Subs,
+                           SubstitutionMap Subs,
                            const HeapLayout &Layout)
     : ReflectionMetadataBuilder(IGM),
       OrigCalleeType(OrigCalleeType),
@@ -656,9 +656,6 @@ public:
     // Check if any requirements were fulfilled by metadata stored inside a
     // captured value.
 
-    auto SubstMap =
-      OrigCalleeType->getGenericSignature()->getSubstitutionMap(Subs);
-
     enumerateGenericParamFulfillments(IGM, OrigCalleeType,
         [&](CanType GenericParam,
             const irgen::MetadataSource &Source,
@@ -690,7 +687,7 @@ public:
       // parameters.
       auto Src = Path.getMetadataSource(SourceBuilder, Root);
 
-      auto SubstType = GenericParam.subst(SubstMap);
+      auto SubstType = GenericParam.subst(Subs);
       auto InterfaceType = SubstType->mapTypeOutOfContext();
       SourceMap.push_back({InterfaceType->getCanonicalType(), Src});
     });
@@ -845,7 +842,7 @@ llvm::Constant *
 IRGenModule::getAddrOfCaptureDescriptor(SILFunction &Caller,
                                         CanSILFunctionType OrigCalleeType,
                                         CanSILFunctionType SubstCalleeType,
-                                        SubstitutionList Subs,
+                                        SubstitutionMap Subs,
                                         const HeapLayout &Layout) {
   if (!IRGen.Opts.EnableReflectionMetadata)
     return llvm::Constant::getNullValue(CaptureDescriptorPtrTy);

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -979,7 +979,7 @@ public:
   llvm::Constant *getAddrOfCaptureDescriptor(SILFunction &caller,
                                              CanSILFunctionType origCalleeType,
                                              CanSILFunctionType substCalleeType,
-                                             SubstitutionList subs,
+                                             SubstitutionMap subs,
                                              const HeapLayout &layout);
   llvm::Constant *getAddrOfBoxDescriptor(CanType boxedType);
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -2316,9 +2316,7 @@ void IRGenSILFunction::visitFullApplySite(FullApplySite site) {
 
   // Pass the generic arguments.
   if (hasPolymorphicParameters(origCalleeType)) {
-    SubstitutionMap subMap;
-    if (auto genericSig = origCalleeType->getGenericSignature())
-      subMap = genericSig->getSubstitutionMap(site.getSubstitutions());
+    SubstitutionMap subMap = site.getSubstitutionMap();
     emitPolymorphicArguments(*this, origCalleeType,
                              subMap, &witnessMetadata, llArgs);
   }
@@ -2518,7 +2516,7 @@ void IRGenSILFunction::visitPartialApplyInst(swift::PartialApplyInst *i) {
   Explosion function;
   emitFunctionPartialApplication(
       *this, *CurSILFn, calleeFn, innerContext, llArgs, params,
-      i->getSubstitutions(), origCalleeTy, i->getSubstCalleeType(),
+      i->getSubstitutionMap(), origCalleeTy, i->getSubstCalleeType(),
       i->getType().castTo<SILFunctionType>(), function, false);
   setLoweredExplosion(v, function);
 }

--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -2375,7 +2375,7 @@ void LoadableByAddress::recreateSingleApply(SILInstruction *applyInst) {
     auto *castedApply = cast<ApplyInst>(applyInst);
     SILValue newApply =
       applyBuilder.createApply(castedApply->getLoc(), callee,
-                               applySite.getSubstitutions(),
+                               applySite.getSubstitutionMap(),
                                callArgs, castedApply->isNonThrowing());
     castedApply->replaceAllUsesWith(newApply);
     break;
@@ -2384,7 +2384,7 @@ void LoadableByAddress::recreateSingleApply(SILInstruction *applyInst) {
     auto *castedApply = cast<TryApplyInst>(applyInst);
     applyBuilder.createTryApply(
         castedApply->getLoc(), callee,
-        applySite.getSubstitutions(), callArgs,
+        applySite.getSubstitutionMap(), callArgs,
         castedApply->getNormalBB(), castedApply->getErrorBB());
     break;
   }
@@ -2392,7 +2392,7 @@ void LoadableByAddress::recreateSingleApply(SILInstruction *applyInst) {
     auto oldApply = cast<BeginApplyInst>(applyInst);
     auto newApply =
       applyBuilder.createBeginApply(oldApply->getLoc(), callee,
-                                    applySite.getSubstitutions(), callArgs,
+                                    applySite.getSubstitutionMap(), callArgs,
                                     oldApply->isNonThrowing());
 
     // Use the new token result.
@@ -2438,7 +2438,7 @@ void LoadableByAddress::recreateSingleApply(SILInstruction *applyInst) {
 
     auto newApply =
       applyBuilder.createPartialApply(castedApply->getLoc(), callee,
-                                      applySite.getSubstitutions(), callArgs,
+                                      applySite.getSubstitutionMap(), callArgs,
                                       partialApplyConvention);
     castedApply->replaceAllUsesWith(newApply);
     break;

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -4943,14 +4943,16 @@ bool SILParser::parseCallInstruction(SILLocation InstLoc,
     return true;
   }
 
-  SmallVector<Substitution, 4> subs;
+  SubstitutionMap subs;
   if (!parsedSubs.empty()) {
     if (!GenericEnv) {
       P.diagnose(TypeLoc, diag::sil_substitutions_on_non_polymorphic_type);
       return true;
     }
-    if (getApplySubstitutionsFromParsed(*this, GenericEnv, parsedSubs, subs))
+    SmallVector<Substitution, 4> subsVec;
+    if (getApplySubstitutionsFromParsed(*this, GenericEnv, parsedSubs, subsVec))
       return true;
+    subs = GenericEnv->getGenericSignature()->getSubstitutionMap(subsVec);
   }
 
   SILValue FnVal = getLocalValue(FnName, Ty, InstLoc, B);

--- a/lib/SIL/Linker.cpp
+++ b/lib/SIL/Linker.cpp
@@ -156,21 +156,21 @@ void SILLinkerVisitor::linkInVTable(ClassDecl *D) {
 void SILLinkerVisitor::visitApplyInst(ApplyInst *AI) {
   if (auto sig = AI->getCallee()->getType().castTo<SILFunctionType>()
                    ->getGenericSignature()) {
-    visitApplySubstitutions(sig->getSubstitutionMap(AI->getSubstitutions()));
+    visitApplySubstitutions(AI->getSubstitutionMap());
   }
 }
 
 void SILLinkerVisitor::visitTryApplyInst(TryApplyInst *TAI) {
   if (auto sig = TAI->getCallee()->getType().castTo<SILFunctionType>()
                    ->getGenericSignature()) {
-    visitApplySubstitutions(sig->getSubstitutionMap(TAI->getSubstitutions()));
+    visitApplySubstitutions(TAI->getSubstitutionMap());
   }
 }
 
 void SILLinkerVisitor::visitPartialApplyInst(PartialApplyInst *PAI) {
   if (auto sig = PAI->getCallee()->getType().castTo<SILFunctionType>()
                     ->getGenericSignature()) {
-    visitApplySubstitutions(sig->getSubstitutionMap(PAI->getSubstitutions()));
+    visitApplySubstitutions(PAI->getSubstitutionMap());
   }
 }
 

--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -50,7 +50,7 @@ TupleInst *SILBuilder::createTuple(SILLocation loc, ArrayRef<SILValue> elts) {
 
 SILType SILBuilder::getPartialApplyResultType(SILType origTy, unsigned argCount,
                                         SILModule &M,
-                                        SubstitutionList subs,
+                                        SubstitutionMap subs,
                                         ParameterConvention calleeConvention) {
   CanSILFunctionType FTI = origTy.castTo<SILFunctionType>();
   if (!subs.empty())

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -609,7 +609,7 @@ namespace {
 
     bool visitApplyInst(ApplyInst *RHS) {
       auto *X = cast<ApplyInst>(LHS);
-      return X->getSubstitutions() == RHS->getSubstitutions();
+      return X->getSubstitutionMap() == RHS->getSubstitutionMap();
     }
 
     bool visitBuiltinInst(BuiltinInst *RHS) {

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -399,8 +399,9 @@ InitBlockStorageHeaderInst::create(SILFunction &F,
 
 ApplyInst::ApplyInst(SILDebugLocation Loc, SILValue Callee,
                      SILType SubstCalleeTy, SILType Result,
-                     SubstitutionList Subs,
-                     ArrayRef<SILValue> Args, ArrayRef<SILValue> TypeDependentOperands,
+                     SubstitutionMap Subs,
+                     ArrayRef<SILValue> Args,
+                     ArrayRef<SILValue> TypeDependentOperands,
                      bool isNonThrowing,
                      const GenericSpecializationInformation *SpecializationInfo)
     : InstructionBase(Loc, Callee, SubstCalleeTy, Subs, Args,
@@ -410,7 +411,7 @@ ApplyInst::ApplyInst(SILDebugLocation Loc, SILValue Callee,
 }
 
 ApplyInst *
-ApplyInst::create(SILDebugLocation Loc, SILValue Callee, SubstitutionList Subs,
+ApplyInst::create(SILDebugLocation Loc, SILValue Callee, SubstitutionMap Subs,
                   ArrayRef<SILValue> Args, bool isNonThrowing,
                   Optional<SILModuleConventions> ModuleConventions,
                   SILFunction &F, SILOpenedArchetypesState &OpenedArchetypes,
@@ -426,7 +427,7 @@ ApplyInst::create(SILDebugLocation Loc, SILValue Callee, SubstitutionList Subs,
 
   SmallVector<SILValue, 32> TypeDependentOperands;
   collectTypeDependentOperands(TypeDependentOperands, OpenedArchetypes, F,
-                               SubstCalleeSILTy.getASTType(), Subs);
+                               SubstCalleeSILTy.getASTType(), Subs.toList());
   void *Buffer =
     allocateTrailingInst<ApplyInst, Operand>(
       F, getNumAllOperands(Args, TypeDependentOperands));
@@ -440,7 +441,7 @@ BeginApplyInst::BeginApplyInst(SILDebugLocation loc, SILValue callee,
                                SILType substCalleeTy,
                                ArrayRef<SILType> allResultTypes,
                                ArrayRef<ValueOwnershipKind> allResultOwnerships,
-                               SubstitutionList subs,
+                               SubstitutionMap subs,
                                ArrayRef<SILValue> args,
                                ArrayRef<SILValue> typeDependentOperands,
                                bool isNonThrowing,
@@ -455,7 +456,7 @@ BeginApplyInst::BeginApplyInst(SILDebugLocation loc, SILValue callee,
 
 BeginApplyInst *
 BeginApplyInst::create(SILDebugLocation loc, SILValue callee,
-                       SubstitutionList subs, ArrayRef<SILValue> args,
+                       SubstitutionMap subs, ArrayRef<SILValue> args,
                        bool isNonThrowing,
                        Optional<SILModuleConventions> moduleConventions,
                        SILFunction &F,
@@ -486,7 +487,7 @@ BeginApplyInst::create(SILDebugLocation loc, SILValue callee,
 
   SmallVector<SILValue, 32> typeDependentOperands;
   collectTypeDependentOperands(typeDependentOperands, openedArchetypes, F,
-                               substCalleeType, subs);
+                               substCalleeType, subs.toList());
   void *buffer =
     allocateTrailingInst<BeginApplyInst, Operand,
                          MultipleValueInstruction*, BeginApplyResult>(
@@ -507,7 +508,7 @@ bool swift::doesApplyCalleeHaveSemantics(SILValue callee, StringRef semantics) {
 
 PartialApplyInst::PartialApplyInst(
     SILDebugLocation Loc, SILValue Callee, SILType SubstCalleeTy,
-    SubstitutionList Subs, ArrayRef<SILValue> Args,
+    SubstitutionMap Subs, ArrayRef<SILValue> Args,
     ArrayRef<SILValue> TypeDependentOperands, SILType ClosureType,
     const GenericSpecializationInformation *SpecializationInfo)
     // FIXME: the callee should have a lowered SIL function type, and
@@ -520,7 +521,7 @@ PartialApplyInst::PartialApplyInst(
 
 PartialApplyInst *PartialApplyInst::create(
     SILDebugLocation Loc, SILValue Callee, ArrayRef<SILValue> Args,
-    SubstitutionList Subs, ParameterConvention CalleeConvention, SILFunction &F,
+    SubstitutionMap Subs, ParameterConvention CalleeConvention, SILFunction &F,
     SILOpenedArchetypesState &OpenedArchetypes,
     const GenericSpecializationInformation *SpecializationInfo) {
   SILType SubstCalleeTy =
@@ -530,7 +531,7 @@ PartialApplyInst *PartialApplyInst::create(
 
   SmallVector<SILValue, 32> TypeDependentOperands;
   collectTypeDependentOperands(TypeDependentOperands, OpenedArchetypes, F,
-                               SubstCalleeTy.getASTType(), Subs);
+                               SubstCalleeTy.getASTType(), Subs.toList());
   void *Buffer =
     allocateTrailingInst<PartialApplyInst, Operand>(
       F, getNumAllOperands(Args, TypeDependentOperands));
@@ -548,7 +549,7 @@ TryApplyInstBase::TryApplyInstBase(SILInstructionKind kind,
 
 TryApplyInst::TryApplyInst(
     SILDebugLocation Loc, SILValue callee, SILType substCalleeTy,
-    SubstitutionList subs, ArrayRef<SILValue> args,
+    SubstitutionMap subs, ArrayRef<SILValue> args,
     ArrayRef<SILValue> TypeDependentOperands, SILBasicBlock *normalBB,
     SILBasicBlock *errorBB,
     const GenericSpecializationInformation *SpecializationInfo)
@@ -557,7 +558,7 @@ TryApplyInst::TryApplyInst(
                       errorBB) {}
 
 TryApplyInst *TryApplyInst::create(
-    SILDebugLocation loc, SILValue callee, SubstitutionList subs,
+    SILDebugLocation loc, SILValue callee, SubstitutionMap subs,
     ArrayRef<SILValue> args, SILBasicBlock *normalBB, SILBasicBlock *errorBB,
     SILFunction &F, SILOpenedArchetypesState &openedArchetypes,
     const GenericSpecializationInformation *specializationInfo) {
@@ -566,7 +567,8 @@ TryApplyInst *TryApplyInst::create(
 
   SmallVector<SILValue, 32> typeDependentOperands;
   collectTypeDependentOperands(typeDependentOperands, openedArchetypes, F,
-                               substCalleeTy.getASTType(), subs);
+                               substCalleeTy.getASTType(),
+                               subs.toList());
   void *buffer =
     allocateTrailingInst<TryApplyInst, Operand>(
       F, getNumAllOperands(args, typeDependentOperands));

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1083,7 +1083,7 @@ public:
   template <class Inst>
   void visitApplyInstBase(Inst *AI) {
     *this << Ctx.getID(AI->getCallee());
-    printSubstitutions(AI->getSubstitutions());
+    printSubstitutions(AI->getSubstitutionMap());
     *this << '(';
     interleave(AI->getArguments(),
                [&](const SILValue &arg) { *this << Ctx.getID(arg); },

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1019,12 +1019,12 @@ public:
   }
 
   /// Check the substitutions passed to an apply or partial_apply.
-  CanSILFunctionType checkApplySubstitutions(SubstitutionList subs,
+  CanSILFunctionType checkApplySubstitutions(SubstitutionMap subs,
                                              SILType calleeTy) {
     auto fnTy = requireObjectType(SILFunctionType, calleeTy, "callee operand");
 
     // If there are substitutions, verify them and apply them to the callee.
-    if (subs.empty()) {
+    if (!subs.hasAnySubstitutableParams()) {
       require(!fnTy->isPolymorphic(),
               "callee of apply without substitutions must not be polymorphic");
       return fnTy;
@@ -1034,8 +1034,8 @@ public:
 
     // Each archetype occurring in the substitutions list should belong to the
     // current function.
-    for (auto sub : subs) {
-      sub.getReplacement()->getCanonicalType().visit([&](CanType t) {
+    for (auto replacementType : subs.getReplacementTypes()) {
+      replacementType->getCanonicalType().visit([&](CanType t) {
         auto A = dyn_cast<ArchetypeType>(t);
         if (!A)
           return;
@@ -1118,7 +1118,7 @@ public:
 
     // Then make sure that we have a type that can be substituted for the
     // callee.
-    auto substTy = checkApplySubstitutions(site.getSubstitutions(),
+    auto substTy = checkApplySubstitutions(site.getSubstitutionMap(),
                                            site.getCallee()->getType());
     require(site.getOrigCalleeType()->getRepresentation() ==
             site.getSubstCalleeType()->getRepresentation(),
@@ -1274,7 +1274,7 @@ public:
 
     checkApplyTypeDependentArguments(PAI);
 
-    auto substTy = checkApplySubstitutions(PAI->getSubstitutions(),
+    auto substTy = checkApplySubstitutions(PAI->getSubstitutionMap(),
                                         PAI->getCallee()->getType());
 
     require(!PAI->getSubstCalleeType()->isPolymorphic(),
@@ -4043,7 +4043,7 @@ public:
             invokeTy->getExtInfo().isPseudogeneric(),
             "invoke function must not take reified generic parameters");
     
-    invokeTy = checkApplySubstitutions(IBSHI->getSubstitutions().toList(),
+    invokeTy = checkApplySubstitutions(IBSHI->getSubstitutions(),
                                     SILType::getPrimitiveObjectType(invokeTy));
     
     auto storageParam = invokeTy->getParameters()[0];

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -91,7 +91,7 @@ MetatypeInst *SILGenBuilder::createMetatype(SILLocation loc, SILType metatype) {
 
 ApplyInst *SILGenBuilder::createApply(SILLocation loc, SILValue fn,
                                       SILType substFnTy, SILType result,
-                                      SubstitutionList subs,
+                                      SubstitutionMap subs,
                                       ArrayRef<SILValue> args) {
   getSILGenModule().useConformancesFromSubstitutions(subs);
   return SILBuilder::createApply(loc, fn, subs, args, false);
@@ -99,7 +99,7 @@ ApplyInst *SILGenBuilder::createApply(SILLocation loc, SILValue fn,
 
 TryApplyInst *
 SILGenBuilder::createTryApply(SILLocation loc, SILValue fn, SILType substFnTy,
-                              SubstitutionList subs, ArrayRef<SILValue> args,
+                              SubstitutionMap subs, ArrayRef<SILValue> args,
                               SILBasicBlock *normalBB, SILBasicBlock *errorBB) {
   getSILGenModule().useConformancesFromSubstitutions(subs);
   return SILBuilder::createTryApply(loc, fn, subs, args, normalBB, errorBB);
@@ -107,7 +107,7 @@ SILGenBuilder::createTryApply(SILLocation loc, SILValue fn, SILType substFnTy,
 
 PartialApplyInst *
 SILGenBuilder::createPartialApply(SILLocation loc, SILValue fn,
-                                  SILType substFnTy, SubstitutionList subs,
+                                  SILType substFnTy, SubstitutionMap subs,
                                   ArrayRef<SILValue> args, SILType closureTy) {
   getSILGenModule().useConformancesFromSubstitutions(subs);
   return SILBuilder::createPartialApply(
@@ -185,7 +185,7 @@ AllocExistentialBoxInst *SILGenBuilder::createAllocExistentialBox(
 
 ManagedValue SILGenBuilder::createPartialApply(SILLocation loc, SILValue fn,
                                                SILType substFnTy,
-                                               SubstitutionList subs,
+                                               SubstitutionMap subs,
                                                ArrayRef<ManagedValue> args,
                                                SILType closureTy) {
   llvm::SmallVector<SILValue, 8> values;

--- a/lib/SILGen/SILGenBuilder.h
+++ b/lib/SILGen/SILGenBuilder.h
@@ -76,24 +76,24 @@ public:
   using SILBuilder::createApply;
 
   ApplyInst *createApply(SILLocation loc, SILValue fn, SILType SubstFnTy,
-                         SILType result, SubstitutionList subs,
+                         SILType result, SubstitutionMap subs,
                          ArrayRef<SILValue> args);
 
   TryApplyInst *createTryApply(SILLocation loc, SILValue fn, SILType substFnTy,
-                               SubstitutionList subs,
+                               SubstitutionMap subs,
                                ArrayRef<SILValue> args, SILBasicBlock *normalBB,
                                SILBasicBlock *errorBB);
 
   PartialApplyInst *createPartialApply(SILLocation loc, SILValue fn,
-                                       SILType substFnTy, SubstitutionList subs,
+                                       SILType substFnTy, SubstitutionMap subs,
                                        ArrayRef<SILValue> args,
                                        SILType closureTy);
   ManagedValue createPartialApply(SILLocation loc, SILValue fn,
-                                  SILType substFnTy, SubstitutionList subs,
+                                  SILType substFnTy, SubstitutionMap subs,
                                   ArrayRef<ManagedValue> args,
                                   SILType closureTy);
   ManagedValue createPartialApply(SILLocation loc, ManagedValue fn,
-                                  SILType substFnTy, SubstitutionList subs,
+                                  SILType substFnTy, SubstitutionMap subs,
                                   ArrayRef<ManagedValue> args,
                                   SILType closureTy) {
     return createPartialApply(loc, fn.getValue(), substFnTy, subs, args,

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -516,7 +516,6 @@ void SILGenFunction::emitClassConstructorAllocator(ConstructorDecl *ctor) {
 
   // Call the initializer.
   SubstitutionMap subMap;
-  SmallVector<Substitution, 4> subs;
   if (auto *genericEnv = ctor->getGenericEnvironmentOfContext()) {
     auto *genericSig = genericEnv->getGenericSignature();
     subMap = genericSig->getSubstitutionMap(
@@ -525,14 +524,13 @@ void SILGenFunction::emitClassConstructorAllocator(ConstructorDecl *ctor) {
           t->castTo<GenericTypeParamType>());
       },
       MakeAbstractConformanceForGenericType());
-    genericSig->getSubstitutions(subMap, subs);
   }
 
   std::tie(initVal, initTy)
     = emitSiblingMethodRef(Loc, selfValue, initConstant, subMap);
 
   SILValue initedSelfValue = emitApplyWithRethrow(Loc, initVal.forward(*this),
-                                                  initTy, subs, args);
+                                                  initTy, subMap, args);
 
   emitProfilerIncrement(ctor->getBody());
 

--- a/lib/SILGen/SILGenDestructor.cpp
+++ b/lib/SILGen/SILGenDestructor.cpp
@@ -68,11 +68,8 @@ void SILGenFunction::emitDestroyingDestructor(DestructorDecl *dd) {
     std::tie(dtorValue, dtorTy)
       = emitSiblingMethodRef(cleanupLoc, baseSelf, dtorConstant, subMap);
 
-    SmallVector<Substitution, 4> subs;
-    if (auto *genericSig = superclass->getGenericSignature())
-      genericSig->getSubstitutions(subMap, subs);
     resultSelfValue = B.createApply(cleanupLoc, dtorValue.forward(*this),
-                                    dtorTy, objectPtrTy, subs, baseSelf);
+                                    dtorTy, objectPtrTy, subMap, baseSelf);
   } else {
     resultSelfValue = selfValue;
   }
@@ -126,10 +123,6 @@ void SILGenFunction::emitDeallocatingDestructor(DestructorDecl *dd) {
   std::tie(dtorValue, dtorTy)
     = emitSiblingMethodRef(loc, initialSelfValue, dtorConstant, subMap);
 
-  SmallVector<Substitution, 4> subs;
-  if (auto *genericSig = classDecl->getGenericSignature())
-    genericSig->getSubstitutions(subMap, subs);
-
   // Call the destroying destructor.
   SILValue selfForDealloc;
   {
@@ -137,7 +130,7 @@ void SILGenFunction::emitDeallocatingDestructor(DestructorDecl *dd) {
     ManagedValue borrowedSelf = emitManagedBeginBorrow(loc, initialSelfValue);
     SILType objectPtrTy = SILType::getNativeObjectType(F.getASTContext());
     selfForDealloc = B.createApply(loc, dtorValue.forward(*this),
-                                   dtorTy, objectPtrTy, subs,
+                                   dtorTy, objectPtrTy, subMap,
                                    borrowedSelf.getUnmanagedValue());
   }
 
@@ -262,12 +255,8 @@ void SILGenFunction::emitObjCDestructor(SILDeclRef dtor) {
              ParameterConvention::Direct_Unowned &&
          "Objective C deinitializing destructor takes self as unowned");
 
-  SmallVector<Substitution, 4> subs;
-    if (auto *genericSig = superclass->getGenericSignature())
-      genericSig->getSubstitutions(subMap, subs);
-
   B.createApply(cleanupLoc, superclassDtorValue, substDtorType,
-                dtorConv.getSILResultType(), subs, superSelf);
+                dtorConv.getSILResultType(), subMap, superSelf);
 
   // We know that the givne value came in at +1, but we pass the relevant value
   // as unowned to the destructor. Create a fake balance for the verifier to be

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1092,7 +1092,7 @@ emitRValueForDecl(SILLocation loc, ConcreteDeclRef declRef, Type ncRefType,
   }
 
   ManagedValue result = emitClosureValue(loc, silDeclRef, refType,
-                                         declRef.getSubstitutions().toList());
+                                         declRef.getSubstitutions());
   return RValue(*this, loc, refType, result);
 }
 
@@ -2923,9 +2923,9 @@ RValue RValueEmitter::visitAbstractClosureExpr(AbstractClosureExpr *e,
   // Emit the closure body.
   SGF.SGM.emitClosure(e);
 
-  SubstitutionList subs;
+  SubstitutionMap subs;
   if (e->getCaptureInfo().hasGenericParamCaptures())
-    subs = SGF.getForwardingSubstitutions();
+    subs = SGF.getForwardingSubstitutionMap();
 
   // Generate the closure value (if any) for the closure expr's function
   // reference.

--- a/lib/SILGen/SILGenFunction.cpp
+++ b/lib/SILGen/SILGenFunction.cpp
@@ -303,7 +303,7 @@ void SILGenFunction::emitCaptures(SILLocation loc,
 ManagedValue
 SILGenFunction::emitClosureValue(SILLocation loc, SILDeclRef constant,
                                  CanType expectedType,
-                                 SubstitutionList subs) {
+                                 SubstitutionMap subs) {
   auto closure = *constant.getAnyFunctionRef();
   auto captureInfo = closure.getCaptureInfo();
   auto loweredCaptureInfo = SGM.Types.getLoweredLocalCaptures(closure);
@@ -326,7 +326,7 @@ SILGenFunction::emitClosureValue(SILLocation loc, SILDeclRef constant,
     // If we have a closure expression in generic context, Sema won't give
     // us substitutions, so we just use the forwarding substitutions from
     // context.
-    subs = getForwardingSubstitutions();
+    subs = getForwardingSubstitutionMap();
   }
 
   bool wasSpecialized = false;

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -550,7 +550,7 @@ public:
                            CanAnyFunctionType reqtSubstTy,
                            SILDeclRef requirement,
                            SILDeclRef witness,
-                           SubstitutionList witnessSubs,
+                           SubstitutionMap witnessSubs,
                            IsFreeFunctionWitness_t isFree);
   
   /// Convert a block to a native function with a thunk.
@@ -1099,7 +1099,7 @@ public:
   ManagedValue emitClosureValue(SILLocation loc,
                                 SILDeclRef function,
                                 CanType expectedType,
-                                SubstitutionList subs);
+                                SubstitutionMap subs);
   
   ArgumentSource prepareAccessorBaseArg(SILLocation loc, ManagedValue base,
                                         CanType baseFormalType,
@@ -1343,7 +1343,7 @@ public:
 
   SILValue emitApplyWithRethrow(SILLocation loc, SILValue fn,
                                 SILType substFnType,
-                                SubstitutionList subs,
+                                SubstitutionMap subs,
                                 ArrayRef<SILValue> args);
 
   /// Emit a literal that applies the various initializers.

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -1411,9 +1411,15 @@ namespace {
                                        materialized.temporary.getValue(),
                                        rawPointerTy);
 
+        // Convert the substitution list into a substitution map.
+        SubstitutionMap subMap;
+        if (auto genericSig = origCallbackFnType->getGenericSignature()) {
+          subMap = genericSig->getSubstitutionMap(substitutions);;
+        }
+
         // Apply the callback.
         SGF.B.createApply(loc, callback,
-                          substitutions, {
+                          subMap, {
                             temporaryPointer,
                             materialized.callbackStorage,
                             baseAddress,

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2912,9 +2912,7 @@ static ManagedValue createThunk(SILGenFunction &SGF,
 
   CanSILFunctionType substFnType = thunkType;
 
-  SmallVector<Substitution, 4> subs;
   if (auto genericSig = thunkType->getGenericSignature()) {
-    genericSig->getSubstitutions(interfaceSubs, subs);
     substFnType = thunkType->substGenericArgs(SGF.F.getModule(),
                                               interfaceSubs);
   }
@@ -2924,7 +2922,7 @@ static ManagedValue createThunk(SILGenFunction &SGF,
   ManagedValue thunkedFn =
     SGF.B.createPartialApply(loc, thunkValue,
                              SILType::getPrimitiveObjectType(substFnType),
-                             subs, fn.ensurePlusOne(SGF, loc),
+                             interfaceSubs, fn.ensurePlusOne(SGF, loc),
                              SILType::getPrimitiveObjectType(toType));
 
   if (!expectedType->isNoEscape()) {
@@ -3026,7 +3024,7 @@ SILGenFunction::createWithoutActuallyEscapingClosure(
   SingleValueInstruction *thunkedFn = B.createPartialApply(
       loc, thunkValue,
       SILType::getPrimitiveObjectType(substFnType),
-      thunk->getForwardingSubstitutions(),
+      thunk->getForwardingSubstitutionMap(),
       noEscapeValue,
       SILType::getPrimitiveObjectType(escapingFnTy));
   // We need to ensure the 'lifetime' of the trivial values context captures. As
@@ -3251,10 +3249,10 @@ SILGenFunction::emitVTableThunk(SILDeclRef derived,
 
   auto fTy = implFn->getLoweredFunctionType();
   
-  SubstitutionList subs;
+  SubstitutionMap subs;
   if (auto *genericEnv = fd->getGenericEnvironment()) {
     F.setGenericEnvironment(genericEnv);
-    subs = getForwardingSubstitutions();
+    subs = getForwardingSubstitutionMap();
     fTy = fTy->substGenericArgs(SGM.M, subs);
 
     inputSubstType = cast<FunctionType>(
@@ -3400,7 +3398,7 @@ void SILGenFunction::emitProtocolWitness(AbstractionPattern reqtOrigTy,
                                          CanAnyFunctionType reqtSubstTy,
                                          SILDeclRef requirement,
                                          SILDeclRef witness,
-                                         SubstitutionList witnessSubs,
+                                         SubstitutionMap witnessSubs,
                                          IsFreeFunctionWitness_t isFree) {
   // FIXME: Disable checks that the protocol witness carries debug info.
   // Should we carry debug info for witnesses?
@@ -3419,11 +3417,10 @@ void SILGenFunction::emitProtocolWitness(AbstractionPattern reqtOrigTy,
   // Get the type of the witness.
   auto witnessInfo = getConstantInfo(witness);
   CanAnyFunctionType witnessSubstTy = witnessInfo.LoweredType;
-  if (!witnessSubs.empty()) {
-    witnessSubstTy = cast<FunctionType>(
-      cast<GenericFunctionType>(witnessSubstTy)
-        ->substGenericArgs(witnessSubs)
-        ->getCanonicalType());
+  if (auto genericFnType = dyn_cast<GenericFunctionType>(witnessSubstTy)) {
+    witnessSubstTy = cast<FunctionType>(genericFnType
+                                          ->substGenericArgs(witnessSubs)
+                                          ->getCanonicalType());
   }
   CanType reqtSubstInputTy = F.mapTypeIntoContext(reqtSubstTy.getInput())
       ->getCanonicalType();
@@ -3613,16 +3610,15 @@ SILGenFunction::emitCanonicalFunctionThunk(SILLocation loc, ManagedValue fn,
 
   CanSILFunctionType substFnTy = thunkTy;
 
-  SmallVector<Substitution, 4> subs;
   if (auto genericSig = thunkTy->getGenericSignature()) {
-    genericSig->getSubstitutions(interfaceSubs, subs);
     substFnTy = thunkTy->substGenericArgs(F.getModule(), interfaceSubs);
   }
 
   // Create it in the current function.
   auto thunkValue = B.createFunctionRef(loc, thunk);
   ManagedValue thunkedFn = B.createPartialApply(
-      loc, thunkValue, SILType::getPrimitiveObjectType(substFnTy), subs, {fn},
+      loc, thunkValue, SILType::getPrimitiveObjectType(substFnTy),
+      interfaceSubs, {fn},
       SILType::getPrimitiveObjectType(canonicalTy));
   if (canonicalTy->isNoEscape()) {
     auto &funcTL = getTypeLowering(canonicalTy);

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -705,7 +705,7 @@ SILFunction *SILGenModule::emitProtocolWitness(
 
   SGF.emitProtocolWitness(AbstractionPattern(reqtOrigTy), reqtSubstTy,
                           requirement, witnessRef,
-                          witnessSubs.toList(), isFree);
+                          witnessSubs, isFree);
 
   return f;
 }

--- a/lib/SILOptimizer/Analysis/ArraySemantic.cpp
+++ b/lib/SILOptimizer/Analysis/ArraySemantic.cpp
@@ -717,7 +717,7 @@ bool swift::ArraySemanticsCall::replaceByValue(SILValue V) {
 
 bool swift::ArraySemanticsCall::replaceByAppendingValues(
     SILModule &M, SILFunction *AppendFn, SILFunction *ReserveFn,
-    const SmallVectorImpl<SILValue> &Vals, ArrayRef<Substitution> Subs) {
+    const SmallVectorImpl<SILValue> &Vals, SubstitutionMap Subs) {
   assert(getKind() == ArrayCallKind::kAppendContentsOf &&
          "Must be an append_contentsOf call");
   assert(AppendFn && "Must provide an append SILFunction");

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -1261,7 +1261,7 @@ processPartialApplyInst(PartialApplyInst *PAI, IndicesSet &PromotableIndices,
 
   // Create a new partial apply with the new arguments.
   auto *NewPAI = B.createPartialApply(
-      PAI->getLoc(), FnVal, PAI->getSubstitutions(), Args,
+      PAI->getLoc(), FnVal, PAI->getSubstitutionMap(), Args,
       PAI->getType().getAs<SILFunctionType>()->getCalleeConvention());
   PAI->replaceAllUsesWith(NewPAI);
   PAI->eraseFromParent();

--- a/lib/SILOptimizer/IPO/CapturePromotion.cpp
+++ b/lib/SILOptimizer/IPO/CapturePromotion.cpp
@@ -1221,7 +1221,7 @@ processPartialApplyInst(PartialApplyInst *PAI, IndicesSet &PromotableIndices,
   auto SubstCalleeFunctionTy = CalleeFunctionTy;
   if (PAI->hasSubstitutions())
     SubstCalleeFunctionTy =
-        CalleeFunctionTy->substGenericArgs(M, PAI->getSubstitutions());
+        CalleeFunctionTy->substGenericArgs(M, PAI->getSubstitutionMap());
   SILFunctionConventions calleeConv(SubstCalleeFunctionTy, M);
   auto CalleePInfo = SubstCalleeFunctionTy->getParameters();
   SILFunctionConventions paConv(PAI->getType().castTo<SILFunctionType>(), M);

--- a/lib/SILOptimizer/IPO/CapturePropagation.cpp
+++ b/lib/SILOptimizer/IPO/CapturePropagation.cpp
@@ -218,7 +218,8 @@ CanSILFunctionType getPartialApplyInterfaceResultType(PartialApplyInst *PAI) {
   // expressed as literals. So its callee signature will be the same as its
   // return signature.
   auto FTy = PAI->getType().castTo<SILFunctionType>();
-  assert(!PAI->hasSubstitutions() || !hasArchetypes(PAI->getSubstitutions()));
+  assert(!PAI->hasSubstitutions() ||
+         !PAI->getSubstitutionMap().hasArchetypes());
   FTy = cast<SILFunctionType>(
     FTy->mapTypeOutOfContext()->getCanonicalType());
   auto NewFTy = FTy;
@@ -434,7 +435,7 @@ bool CapturePropagation::optimizePartialApply(PartialApplyInst *PAI) {
   if (SubstF->isExternalDeclaration())
     return false;
 
-  if (PAI->hasSubstitutions() && hasArchetypes(PAI->getSubstitutions())) {
+  if (PAI->hasSubstitutions() && PAI->getSubstitutionMap().hasArchetypes()) {
     DEBUG(llvm::dbgs()
               << "CapturePropagation: cannot handle partial specialization "
                  "of partial_apply:\n";

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -405,7 +405,7 @@ static void rewriteApplyInst(const CallSiteDescriptor &CSDesc,
   FullApplySite NewAI;
   if (auto *TAI = dyn_cast<TryApplyInst>(AI)) {
     NewAI = Builder.createTryApply(AI.getLoc(), FRI,
-                                   SubstitutionList(), NewArgs,
+                                   SubstitutionMap(), NewArgs,
                                    TAI->getNormalBB(), TAI->getErrorBB());
     // If we passed in the original closure as @owned, then insert a release
     // right after NewAI. This is to balance the +1 from being an @owned
@@ -420,7 +420,7 @@ static void rewriteApplyInst(const CallSiteDescriptor &CSDesc,
   } else {
     auto oldApply = cast<ApplyInst>(AI);
     auto newApply = Builder.createApply(oldApply->getLoc(), FRI,
-                                        SubstitutionList(),
+                                        SubstitutionMap(),
                                         NewArgs, oldApply->isNonThrowing());
     // If we passed in the original closure as @owned, then insert a release
     // right after NewAI. This is to balance the +1 from being an @owned

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -623,7 +623,7 @@ emitArgumentConversion(SmallVectorImpl<SILValue> &CallArgs) {
   auto CalleeSubstFnTy = CanSILFuncTy;
   if (CanSILFuncTy->isPolymorphic()) {
     CalleeSubstFnTy = CanSILFuncTy->substGenericArgs(
-        Builder.getModule(), ReInfo.getCallerParamSubstitutions());
+        Builder.getModule(), ReInfo.getCallerParamSubstitutionMap());
     assert(!CalleeSubstFnTy->isPolymorphic() &&
            "Substituted callee type should not be polymorphic");
     assert(!CalleeSubstFnTy->hasTypeParameter() &&
@@ -718,7 +718,7 @@ static SILFunction *eagerSpecialize(SILFunction *GenericFunc,
     Serialized = IsSerializable;
 
   GenericFuncSpecializer
-        FuncSpecializer(GenericFunc, ReInfo.getClonerParamSubstitutions(),
+        FuncSpecializer(GenericFunc, ReInfo.getClonerParamSubstitutionMap(),
                         Serialized, ReInfo);
 
   SILFunction *NewFunc = FuncSpecializer.trySpecialization();

--- a/lib/SILOptimizer/IPO/EagerSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/EagerSpecializer.cpp
@@ -153,7 +153,7 @@ emitApplyWithRethrow(SILBuilder &Builder,
                      SILLocation Loc,
                      SILValue FuncRef,
                      CanSILFunctionType CanSILFuncTy,
-                     SubstitutionList Subs,
+                     SubstitutionMap Subs,
                      ArrayRef<SILValue> CallArgs,
                      void (*EmitCleanup)(SILBuilder&, SILLocation)) {
 
@@ -203,7 +203,7 @@ emitInvocation(SILBuilder &Builder,
   auto *FuncRefInst = Builder.createFunctionRef(Loc, CalleeFunc);
   auto CanSILFuncTy = CalleeFunc->getLoweredFunctionType();
   auto CalleeSubstFnTy = CanSILFuncTy;
-  SubstitutionList Subs;
+  SubstitutionMap Subs;
   if (CanSILFuncTy->isPolymorphic()) {
     // Create a substituted callee type.
     assert(CanSILFuncTy == ReInfo.getSpecializedType() &&
@@ -228,9 +228,9 @@ emitInvocation(SILBuilder &Builder,
     // where <TS: _Trivial(64)> introduces a new archetype with the given
     // constraints.
     if (ReInfo.getSpecializedType()->isPolymorphic()) {
-      Subs = ReInfo.getCallerParamSubstitutions();
+      Subs = ReInfo.getCallerParamSubstitutionMap();
       CalleeSubstFnTy = CanSILFuncTy->substGenericArgs(
-          Builder.getModule(), ReInfo.getCallerParamSubstitutions());
+          Builder.getModule(), ReInfo.getCallerParamSubstitutionMap());
       assert(!CalleeSubstFnTy->isPolymorphic() &&
              "Substituted callee type should not be polymorphic");
       assert(!CalleeSubstFnTy->hasTypeParameter() &&
@@ -569,7 +569,7 @@ void EagerDispatch::emitRefCountedObjectCheck(SILBasicBlock *FailedTypeCheckBB,
   Builder.emitBlock(IsClassCheckBB);
 
   auto *FRI = Builder.createFunctionRef(Loc, IsClassF);
-  auto IsClassRuntimeCheck = Builder.createApply(Loc, FRI, SubMap.toList(),
+  auto IsClassRuntimeCheck = Builder.createApply(Loc, FRI, SubMap,
                                                  {GenericMT},
                                                  /* isNonThrowing */ false);
   // Extract the i1 from the Bool struct.

--- a/lib/SILOptimizer/IPO/UsePrespecialized.cpp
+++ b/lib/SILOptimizer/IPO/UsePrespecialized.cpp
@@ -77,15 +77,15 @@ bool UsePrespecialized::replaceByPrespecialized(SILFunction &F) {
     // If this is the case, check if there is a specialization
     // available for it already and use this specialization
     // instead of the generic version.
-
-    SubstitutionList Subs = AI.getSubstitutions();
-    if (Subs.empty())
+    if (!AI.hasSubstitutions())
       continue;
+
+    SubstitutionMap Subs = AI.getSubstitutionMap();
 
     // Bail if any generic type parameters are unbound.
     // TODO: Remove this limitation once public partial specializations
     // are supported and can be provided by other modules.
-    if (hasArchetypes(Subs))
+    if (Subs.hasArchetypes())
       continue;
 
     ReabstractionInfo ReInfo(AI, ReferencedF, Subs);

--- a/lib/SILOptimizer/Mandatory/AddressLowering.cpp
+++ b/lib/SILOptimizer/Mandatory/AddressLowering.cpp
@@ -981,7 +981,7 @@ void ApplyRewriter::convertApplyWithIndirectResults() {
   switch (origCallInst->getKind()) {
   case SILInstructionKind::ApplyInst:
     newCallInst = callBuilder.createApply(
-        loc, apply.getCallee(), apply.getSubstitutions(), newCallArgs,
+        loc, apply.getCallee(), apply.getSubstitutionMap(), newCallArgs,
         cast<ApplyInst>(origCallInst)->isNonThrowing(), nullptr);
     break;
   case SILInstructionKind::TryApplyInst:

--- a/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
+++ b/lib/SILOptimizer/Mandatory/MandatoryInlining.cpp
@@ -535,8 +535,8 @@ runOnFunctionRecursively(SILFunction *F, FullApplySite AI,
 
       // Get our list of substitutions.
       auto Subs = (PAI
-                   ? PAI->getSubstitutions()
-                   : InnerAI.getSubstitutions());
+                   ? PAI->getSubstitutionMap()
+                   : InnerAI.getSubstitutionMap());
 
       SILOpenedArchetypesTracker OpenedArchetypesTracker(F);
       F->getModule().registerDeleteNotificationHandler(

--- a/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
+++ b/lib/SILOptimizer/Transforms/AllocBoxToStack.cpp
@@ -871,7 +871,7 @@ specializePartialApply(PartialApplyInst *PartialApply,
   SILValue FunctionRef = Builder.createFunctionRef(PartialApply->getLoc(),
                                                    ClonedFn);
   return Builder.createPartialApply(
-      PartialApply->getLoc(), FunctionRef, PartialApply->getSubstitutions(),
+      PartialApply->getLoc(), FunctionRef, PartialApply->getSubstitutionMap(),
       Args,
       PartialApply->getType().getAs<SILFunctionType>()->getCalleeConvention());
 }

--- a/lib/SILOptimizer/Transforms/ArrayElementValuePropagation.cpp
+++ b/lib/SILOptimizer/Transforms/ArrayElementValuePropagation.cpp
@@ -335,13 +335,9 @@ public:
       SubstitutionMap ArraySubMap = ArrayType.getASTType()
         ->getContextSubstitutionMap(M.getSwiftModule(), NTD);
       
-      GenericSignature *Sig = NTD->getGenericSignature();
-      assert(Sig && "Array type must have generic signature");
-      SmallVector<Substitution, 4> Subs;
-      Sig->getSubstitutions(ArraySubMap, Subs);
-      
       AppendContentsOf.replaceByAppendingValues(M, AppendFn, ReserveFn,
-                                                Repl.ReplacementValues, Subs);
+                                                Repl.ReplacementValues,
+                                                ArraySubMap);
     }
     return true;
   }

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -1052,7 +1052,7 @@ static bool tryToCSEOpenExtCall(OpenExistentialAddrInst *From,
   }
 
   ApplyInst *NAI = Builder.createApply(ToAI->getLoc(), ToWMI,
-                                       ToAI->getSubstitutions(), Args,
+                                       ToAI->getSubstitutionMap(), Args,
                                        ToAI->isNonThrowing());
   FromAI->replaceAllUsesWith(NAI);
   FromAI->eraseFromParent();

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -601,12 +601,12 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
   SILType ResultType = NewF->getConventions().getSILResultType();
   auto GenCalleeType = NewF->getLoweredFunctionType();
   auto SubstCalleeSILType = LoweredType;
-  ArrayRef<Substitution> Subs;
+  SubstitutionMap Subs;
   // Handle generic functions.
   if (GenCalleeType->isPolymorphic()) {
     // Produce a substitutions list and a set of substituted SIL types
     // required for creating a new SIL function.
-    Subs = F->getForwardingSubstitutions();
+    Subs = F->getForwardingSubstitutionMap();
     auto SubstCalleeType =
         GenCalleeType->substGenericArgs(M, Subs);
     SubstCalleeSILType = SILType::getPrimitiveObjectType(SubstCalleeType);

--- a/lib/SILOptimizer/Transforms/ObjectOutliner.cpp
+++ b/lib/SILOptimizer/Transforms/ObjectOutliner.cpp
@@ -473,7 +473,7 @@ void ObjectOutliner::replaceFindStringCall(ApplyInst *FindStringCall) {
   FunctionRefInst *FRI = B.createFunctionRef(FindStringCall->getLoc(),
                                              replacementFunc);
   ApplyInst *NewCall = B.createApply(FindStringCall->getLoc(), FRI,
-                                     FindStringCall->getSubstitutions(),
+                                     FindStringCall->getSubstitutionMap(),
                                      { FindStringCall->getArgument(0),
                                        FindStringCall->getArgument(1),
                                        CacheAddr },

--- a/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/ReleaseDevirtualizer.cpp
@@ -163,11 +163,7 @@ bool ReleaseDevirtualizer::createDeallocCall(SILType AllocType,
   // argument.
   auto *MI = B.createFunctionRef(ReleaseInst->getLoc(), Dealloc);
 
-  SmallVector<Substitution, 4> AllocSubsts;
-  if (auto *Sig = NTD->getGenericSignature())
-    Sig->getSubstitutions(AllocSubMap, AllocSubsts);
-
-  B.createApply(ReleaseInst->getLoc(), MI, AllocSubsts, {object}, false);
+  B.createApply(ReleaseInst->getLoc(), MI, AllocSubMap, {object}, false);
 
   NumReleasesDevirtualized++;
   ReleaseInst->eraseFromParent();

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -2085,14 +2085,14 @@ bool SimplifyCFG::simplifyTryApplyBlock(TryApplyInst *TAI) {
     auto TargetFnTy = CalleeFnTy;
     if (TargetFnTy->isPolymorphic()) {
       TargetFnTy = TargetFnTy->substGenericArgs(TAI->getModule(),
-                                                TAI->getSubstitutions());
+                                                TAI->getSubstitutionMap());
     }
     SILFunctionConventions targetConv(TargetFnTy, TAI->getModule());
 
     auto OrigFnTy = TAI->getCallee()->getType().getAs<SILFunctionType>();
     if (OrigFnTy->isPolymorphic()) {
       OrigFnTy = OrigFnTy->substGenericArgs(TAI->getModule(),
-                                            TAI->getSubstitutions());
+                                            TAI->getSubstitutionMap());
     }
     SILFunctionConventions origConv(OrigFnTy, TAI->getModule());
 

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -2112,7 +2112,7 @@ bool SimplifyCFG::simplifyTryApplyBlock(TryApplyInst *TAI) {
 
     DEBUG(llvm::dbgs() << "replace with apply: " << *TAI);
     ApplyInst *NewAI = Builder.createApply(TAI->getLoc(), Callee,
-                                           TAI->getSubstitutions(),
+                                           TAI->getSubstitutionMap(),
                                            Args, CalleeFnTy->hasErrorResult());
 
     auto Loc = TAI->getLoc();

--- a/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
+++ b/lib/SILOptimizer/Transforms/SpeculativeDevirtualizer.cpp
@@ -62,17 +62,17 @@ static FullApplySite CloneApply(FullApplySite AI, SILBuilder &Builder) {
   switch (AI.getInstruction()->getKind()) {
   case SILInstructionKind::ApplyInst:
     NAI = Builder.createApply(AI.getLoc(), AI.getCallee(),
-                                   AI.getSubstitutions(),
-                                   Ret,
-                                   cast<ApplyInst>(AI)->isNonThrowing());
+                              AI.getSubstitutionMap(),
+                              Ret,
+                              cast<ApplyInst>(AI)->isNonThrowing());
     break;
   case SILInstructionKind::TryApplyInst: {
     auto *TryApplyI = cast<TryApplyInst>(AI.getInstruction());
     NAI = Builder.createTryApply(AI.getLoc(), AI.getCallee(),
-                                      AI.getSubstitutions(),
-                                      Ret,
-                                      TryApplyI->getNormalBB(),
-                                      TryApplyI->getErrorBB());
+                                 AI.getSubstitutionMap(),
+                                 Ret,
+                                 TryApplyI->getNormalBB(),
+                                 TryApplyI->getErrorBB());
     }
     break;
   default:
@@ -209,7 +209,7 @@ static FullApplySite speculateMonomorphicTarget(FullApplySite AI,
       Args.push_back(Arg);
     }
     FullApplySite NewVirtAI = Builder.createTryApply(VirtAI.getLoc(), VirtAI.getCallee(),
-        VirtAI.getSubstitutions(),
+        VirtAI.getSubstitutionMap(),
         Args, NormalBB, ErrorBB);
     VirtAI.getInstruction()->eraseFromParent();
     VirtAI = NewVirtAI;

--- a/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
+++ b/lib/SILOptimizer/UtilityPasses/BugReducerTester.cpp
@@ -148,7 +148,7 @@ class BugReducerTester : public SILFunctionTransform {
         RuntimeCrasherFunc->dump();
         SILBuilder B(Apply->getIterator());
         B.createApply(Loc, B.createFunctionRef(Loc, RuntimeCrasherFunc),
-                      SubstitutionList(),
+                      SubstitutionMap(),
                       ArrayRef<SILValue>(), false /*NoThrow*/);
 
         Apply->replaceAllUsesWith(SILUndef::get(Apply->getType(), M));

--- a/lib/SILOptimizer/Utils/CFG.cpp
+++ b/lib/SILOptimizer/Utils/CFG.cpp
@@ -300,7 +300,7 @@ void swift::changeBranchTarget(TermInst *T, unsigned EdgeIdx,
     for (auto &Op : TAI->getArgumentOperands())
       Arguments.push_back(Op.get());
 
-    B.createTryApply(TAI->getLoc(), TAI->getCallee(), TAI->getSubstitutions(),
+    B.createTryApply(TAI->getLoc(), TAI->getCallee(), TAI->getSubstitutionMap(),
                      Arguments, NormalBB, ErrorBB);
 
     TAI->eraseFromParent();

--- a/lib/SILOptimizer/Utils/CastOptimizer.cpp
+++ b/lib/SILOptimizer/Utils/CastOptimizer.cpp
@@ -234,10 +234,7 @@ SILInstruction *CastOptimizer::optimizeBridgedObjCToSwiftCast(
   Args.push_back(SrcOp);
   Args.push_back(MetaTyVal);
 
-  SmallVector<Substitution, 4> Subs;
-  Conf.getRequirement()->getGenericSignature()->getSubstitutions(SubMap, Subs);
-
-  auto *AI = Builder.createApply(Loc, FuncRef, Subs, Args, false);
+  auto *AI = Builder.createApply(Loc, FuncRef, SubMap, Args, false);
 
   // If we have guaranteed normal arguments, insert the destroy.
   //
@@ -516,12 +513,8 @@ SILInstruction *CastOptimizer::optimizeBridgedSwiftToObjCCast(
     }
   }
 
-  SmallVector<Substitution, 4> Subs;
-  if (auto *Sig = Source->getAnyNominal()->getGenericSignature())
-    Sig->getSubstitutions(SubMap, Subs);
-
   // Generate a code to invoke the bridging function.
-  auto *NewAI = Builder.createApply(Loc, FnRef, Subs, Src, false);
+  auto *NewAI = Builder.createApply(Loc, FnRef, SubMap, Src, false);
 
   auto releaseSrc = [&](SILBuilder &Builder) {
     if (AddressOnlyType) {

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -557,15 +557,12 @@ ReabstractionInfo::ReabstractionInfo(ApplySite Apply, SILFunction *Callee,
     if (SpecializedSubstFnTy != SpecializedCalleeSubstFnTy) {
       llvm::dbgs() << "SpecializedFnTy:\n" << SpecializedFnTy << "\n";
       llvm::dbgs() << "SpecializedSubstFnTy:\n" << SpecializedSubstFnTy << "\n";
-      for (auto Sub : getCallerParamSubstitutions()) {
-        llvm::dbgs() << "Sub:\n";
-        Sub.dump();
-      }
+      getCallerParamSubstitutionMap().getCanonical().dump(llvm::dbgs());
       llvm::dbgs() << "\n\n";
 
       llvm::dbgs() << "CalleeFnTy:\n" << CalleeFnTy << "\n";
       llvm::dbgs() << "SpecializedCalleeSubstFnTy:\n" << SpecializedCalleeSubstFnTy << "\n";
-      ParamSubs.dump(llvm::dbgs());
+      ParamSubs.getCanonical().dump(llvm::dbgs());
       llvm::dbgs() << "\n\n";
       assert(SpecializedSubstFnTy == SpecializedCalleeSubstFnTy &&
              "Substituted function types should be the same");
@@ -595,20 +592,13 @@ ReabstractionInfo::ReabstractionInfo(ApplySite Apply, SILFunction *Callee,
           llvm::dbgs() << "Callee generic function type:\n"
                        << Callee->getLoweredFunctionType() << "\n\n";
           llvm::dbgs() << "Callee's call substitution:\n";
-          for (auto Sub : getCalleeParamSubstitutions()) {
-            llvm::dbgs() << "Sub:\n";
-            Sub.dump();
-            llvm::dbgs() << "\n";
-          }
+          getCalleeParamSubstitutionMap().getCanonical().dump(llvm::dbgs());
 
           llvm::dbgs() << "Partially specialized generic function type:\n"
                        << getSpecializedType() << "\n\n";
           llvm::dbgs() << "\nSpecialization call substitution:\n";
-          for (auto Sub : getCallerParamSubstitutions()) {
-            llvm::dbgs() << "Sub:\n";
-            Sub.dump();
-            llvm::dbgs() << "\n";
-          });
+          getCallerParamSubstitutionMap().getCanonical().dump(llvm::dbgs());
+          );
   }
 }
 

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -854,7 +854,7 @@ SingleValueInstruction *StringConcatenationOptimizer::optimize() {
   Arguments.push_back(FuncResultType);
 
   return Builder.createApply(AI->getLoc(), FRIConvertFromBuiltin,
-                             SubstitutionList(), Arguments,
+                             SubstitutionMap(), Arguments,
                              false);
 }
 

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -580,14 +580,12 @@ static bool calleeHasPartialApplyWithOpenedExistentials(FullApplySite AI) {
   for (auto &BB : *Callee) {
     for (auto &I : BB) {
       if (auto PAI = dyn_cast<PartialApplyInst>(&I)) {
-        auto PAISubs = PAI->getSubstitutions();
-        if (PAISubs.empty())
+        if (!PAI->hasSubstitutions())
           continue;
 
         // Check if any of substitutions would contain open existentials
         // after inlining.
-        auto PAISubMap = PAI->getOrigCalleeType()
-          ->getGenericSignature()->getSubstitutionMap(PAISubs);
+        auto PAISubMap = PAI->getSubstitutionMap();
         PAISubMap = PAISubMap.subst(SubsMap);
         if (PAISubMap.hasOpenedExistential())
           return true;

--- a/lib/SILOptimizer/Utils/SpecializationMangler.cpp
+++ b/lib/SILOptimizer/Utils/SpecializationMangler.cpp
@@ -80,7 +80,6 @@ std::string GenericSpecializationMangler::mangle() {
   SILFunctionType *FTy = Function->getLoweredFunctionType();
   CanGenericSignature Sig = FTy->getGenericSignature();
 
-  auto SubMap = Sig->getSubstitutionMap(Subs);
   bool First = true;
   for (auto ParamType : Sig->getSubstitutableParams()) {
     appendType(Type(ParamType).subst(SubMap)->getCanonicalType());

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1265,11 +1265,11 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
 
     if (OpCode == SILInstructionKind::ApplyInst) {
       ResultVal = Builder.createApply(Loc, getLocalValue(ValID, FnTy),
-                                      Substitutions.toList(), Args,
+                                      Substitutions, Args,
                                       IsNonThrowingApply != 0);
     } else {
       ResultVal = Builder.createBeginApply(Loc, getLocalValue(ValID, FnTy),
-                                           Substitutions.toList(), Args,
+                                           Substitutions, Args,
                                            IsNonThrowingApply != 0);
     }
     break;
@@ -1300,7 +1300,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
     SubstitutionMap Substitutions = MF->getSubstitutionMap(NumSubs);
 
     ResultVal = Builder.createTryApply(Loc, getLocalValue(ValID, FnTy),
-                                       Substitutions.toList(), Args, normalBB,
+                                       Substitutions, Args, normalBB,
                                        errorBB);
     break;
   }
@@ -1331,7 +1331,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
 
     // FIXME: Why the arbitrary order difference in IRBuilder type argument?
     ResultVal = Builder.createPartialApply(
-        Loc, FnVal, Substitutions.toList(), Args,
+        Loc, FnVal, Substitutions, Args,
         closureTy.castTo<SILFunctionType>()->getCalleeConvention());
     break;
   }

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -384,7 +384,7 @@ sil hidden_external @complex_generic_function : $@convention(thin) <T where T : 
 sil @partial_apply_complex_generic_function : $@convention(thin) <T where T : P2, T.Y : P2> (Int) -> () {
 bb0(%0 : $Int):
   %fn = function_ref @complex_generic_function : $@convention(thin) <T where T : P2, T.Y : P2> (Int) -> ()
-  %pa = partial_apply %fn <T, T.Y>(%0) : $@convention(thin) <T where T : P2, T.Y : P1, T.Y : P2> (Int) -> ()
+  %pa = partial_apply %fn <T>(%0) : $@convention(thin) <T where T : P2, T.Y : P1, T.Y : P2> (Int) -> ()
   %result = tuple ()
   return %result : $()
 }

--- a/test/SILGen/newtype.swift
+++ b/test/SILGen/newtype.swift
@@ -70,14 +70,14 @@ func bridgeToNewtype() -> MyString {
 // CHECK-RAW: [[TO_MY:%.*]] = function_ref @$Ss20_SwiftNewtypeWrapperPss21_ObjectiveCBridgeable8RawValueRpzrlE026_unconditionallyBridgeFromD1CyxAD_01_D5CTypeQZSgFZ : $@convention(method) <τ_0_0 where τ_0_0 : _SwiftNewtypeWrapper, τ_0_0.RawValue : _ObjectiveCBridgeable> (@guaranteed Optional<τ_0_0.RawValue._ObjectiveCType>, @thick τ_0_0.Type)
 // CHECK-RAW: [[OPTNS:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[NS]]
 // CHECK-RAW: [[META:%.*]] = metatype $@thick MyString.Type
-// CHECK-RAW: apply [[TO_MY]]<MyString, String>({{.*}}, [[OPTNS]], [[META]])
+// CHECK-RAW: apply [[TO_MY]]<MyString>({{.*}}, [[OPTNS]], [[META]])
   return "foo" as NSString as MyString
 }
 
 // CHECK-RAW-LABEL: sil hidden @$S7newtype17bridgeFromNewtype6stringSSSo8MyStringa_tF
 func bridgeFromNewtype(string: MyString) -> String {
 // CHECK-RAW: [[FROM_MY:%.*]] = function_ref @$Ss20_SwiftNewtypeWrapperPss21_ObjectiveCBridgeable8RawValueRpzrlE09_bridgeToD1CAD_01_D5CTypeQZyF : $@convention(method) <τ_0_0 where τ_0_0 : _SwiftNewtypeWrapper, τ_0_0.RawValue : _ObjectiveCBridgeable> (@in_guaranteed τ_0_0) -> @owned τ_0_0.RawValue._ObjectiveCType
-// CHECK-RAW: [[NS:%.*]] = apply [[FROM_MY]]<MyString, String>(
+// CHECK-RAW: [[NS:%.*]] = apply [[FROM_MY]]<MyString>(
 // CHECK-RAW: [[FROM_NS:%.*]] = function_ref @$SSS10FoundationE36_unconditionallyBridgeFromObjectiveCySSSo8NSStringCSgFZ
 // CHECK-RAW: [[OPTNS:%.*]] = enum $Optional<NSString>, #Optional.some!enumelt.1, [[NS]]
 // CHECK-RAW: [[META:%.*]] = metatype $@thin String.Type

--- a/test/SILGen/opaque_ownership.swift
+++ b/test/SILGen/opaque_ownership.swift
@@ -153,7 +153,7 @@ public struct Int64 : ExpressibleByIntegerLiteral, _ExpressibleByBuiltinIntegerL
 // CHECK-LABEL: sil shared [transparent] [serialized] [thunk] @$Ss17FloatingPointSignOs9EquatablessACP2eeoiySbx_xtFZTW : $@convention(witness_method: Equatable) (@in_guaranteed FloatingPointSign, @in_guaranteed FloatingPointSign, @thick FloatingPointSign.Type) -> Bool {
 // CHECK: bb0(%0 : @trivial $FloatingPointSign, %1 : @trivial $FloatingPointSign, %2 : @trivial $@thick FloatingPointSign.Type):
 // CHECK:   %3 = function_ref @$Ss2eeoiySbx_xts16RawRepresentableRzs9Equatable0B5ValueRpzlF : $@convention(thin) <τ_0_0 where τ_0_0 : RawRepresentable, τ_0_0.RawValue : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> Bool
-// CHECK:   %4 = apply %3<FloatingPointSign, Int64>(%0, %1) : $@convention(thin) <τ_0_0 where τ_0_0 : RawRepresentable, τ_0_0.RawValue : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> Bool
+// CHECK:   %4 = apply %3<FloatingPointSign>(%0, %1) : $@convention(thin) <τ_0_0 where τ_0_0 : RawRepresentable, τ_0_0.RawValue : Equatable> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> Bool
 // CHECK:   return %4 : $Bool
 // CHECK-LABEL: } // end sil function '$Ss17FloatingPointSignOs9EquatablessACP2eeoiySbx_xtFZTW'
 public enum FloatingPointSign: Int64 {

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -638,7 +638,7 @@ bb0(%0 : $*T, %1 : $*S):
 // CHECK:   %15 = unchecked_addr_cast %1 : $*S to $*S
 // function_ref specialized checkExplicitPartialSpecialization<A, B> (A, B) -> ()
 // CHECK:   %16 = function_ref @$S16eager_specialize34checkExplicitPartialSpecializationyyx_q_tr0_lFs5Int64Vq_ADRszr0_lIetyi_Tp5 : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 == Int64> (Int64, @in τ_0_1) -> ()
-// CHECK:   %17 = apply %16<S>(%14, %15) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 == Int64> (Int64, @in τ_0_1) -> ()
+// CHECK:   %17 = apply %16<Int64, S>(%14, %15) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_0 == Int64> (Int64, @in τ_0_1) -> ()
 // CHECK:   %18 = tuple ()
 // CHECK:   %19 = unchecked_trivial_bit_cast %18 : $() to $()
 // CHECK:   br bb2

--- a/test/SILOptimizer/specialize.sil
+++ b/test/SILOptimizer/specialize.sil
@@ -644,7 +644,7 @@ bb0:
 // CHECK-LABEL: sil @selfReferringGenericClosure : $@convention(thin) <R, S> (@in_guaranteed R, @in_guaranteed S, Builtin.Int64) -> ()
 // Refer to the specialized version of the function
 // CHECK: [[SPECIALIZED_FN:%[0-9]+]] = function_ref @$S27selfReferringGenericClosurexBi64_Bi64_Bi64_Rs_r0_lIetnyy_Tp5
-// CHECK: partial_apply [[SPECIALIZED_FN]]<R>({{.*}}) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_1 == Builtin.Int64> (@in_guaranteed τ_0_0, Builtin.Int64, Builtin.Int64) -> ()
+// CHECK: partial_apply [[SPECIALIZED_FN]]<R, Builtin.Int64>({{.*}}) : $@convention(thin) <τ_0_0, τ_0_1 where τ_0_1 == Builtin.Int64> (@in_guaranteed τ_0_0, Builtin.Int64, Builtin.Int64) -> ()
 sil @selfReferringGenericClosure : $@convention(thin) <R, S> (@in_guaranteed R, @in_guaranteed S, Builtin.Int64) -> () {
 bb0(%0 : $*R, %1 : $*S, %2 : $Builtin.Int64):
   %4 = integer_literal $Builtin.Int64, 100


### PR DESCRIPTION
Push SubstitutionMaps through most of SILGen, the SIL optimizers, and much of IRGen
that involve the various *ApplyInsts. Overall this eliminates ~100 more explicit uses of `SubstitutionList`, and plumbs substitution maps through most of the infrastructure.