### PR TITLE
[CMake] Add explicit Glibc dependencies to account for "autolinking"

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/CMakeLists.txt
+++ b/stdlib/private/StdlibCollectionUnittest/CMakeLists.txt
@@ -20,6 +20,10 @@ add_swift_library(swiftStdlibCollectionUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYP
   ../../public/core/WriteBackMutableSlice.swift
 
   SWIFT_MODULE_DEPENDS StdlibUnittest
+  SWIFT_MODULE_DEPENDS_LINUX Glibc
+  SWIFT_MODULE_DEPENDS_FREEBSD Glibc
+  SWIFT_MODULE_DEPENDS_CYGWIN Glibc
+  SWIFT_MODULE_DEPENDS_HAIKU Glibc
   SWIFT_COMPILE_FLAGS ${swift_stdlib_unittest_compile_flags}
   TARGET_SDKS ALL_POSIX_PLATFORMS
   INSTALL_IN_COMPONENT stdlib-experimental)

--- a/stdlib/private/StdlibUnicodeUnittest/CMakeLists.txt
+++ b/stdlib/private/StdlibUnicodeUnittest/CMakeLists.txt
@@ -9,6 +9,10 @@ add_swift_library(swiftStdlibUnicodeUnittest ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES}
   Collation.swift
 
   SWIFT_MODULE_DEPENDS StdlibUnittest
+  SWIFT_MODULE_DEPENDS_LINUX Glibc
+  SWIFT_MODULE_DEPENDS_FREEBSD Glibc
+  SWIFT_MODULE_DEPENDS_CYGWIN Glibc
+  SWIFT_MODULE_DEPENDS_HAIKU Glibc
   SWIFT_COMPILE_FLAGS ${swift_stdlib_unittest_compile_flags}
   TARGET_SDKS ALL_POSIX_PLATFORMS
   INSTALL_IN_COMPONENT stdlib-experimental)


### PR DESCRIPTION
#16349 made the compiler autolink libraries more eagerly than before. This normally wouldn't affect the products we build with CMake, but when an overlay is autolinked the compiler also puts in a dummy symbol to make sure it gets linked. So now we have to link to the overlay directly.

rdar://problem/39338239