### PR TITLE
Configure the swiftImageInspectionShared to generate arch & sdk speci…

### DIFF
--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -251,7 +251,7 @@ endif()
 
 set(shared_only_libs)
 if(SWIFT_BUILD_STATIC_STDLIB AND "${SWIFT_HOST_VARIANT_SDK}" STREQUAL "LINUX")
-   list(APPEND shared_only_libs swiftImageInspectionShared)
+   list(APPEND swift_core_private_link_libraries swiftImageInspectionShared)
 endif()
 
 add_swift_library(swiftCore ${SWIFT_STDLIB_LIBRARY_BUILD_TYPES} IS_STDLIB IS_STDLIB_CORE

--- a/stdlib/public/runtime/CMakeLists.txt
+++ b/stdlib/public/runtime/CMakeLists.txt
@@ -103,16 +103,39 @@ if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
   string(TOLOWER "${sdk}" lowercase_sdk)
 
   # These two libraries are only used with the static swiftcore
-  add_swift_library(swiftImageInspectionShared STATIC
+  add_swift_library(swiftImageInspectionShared TARGET_LIBRARY STATIC
     ImageInspectionELF.cpp
     C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
-    LINK_FLAGS ${swift_runtime_linker_flags})
-  set_target_properties(swiftImageInspectionShared PROPERTIES
-    ARCHIVE_OUTPUT_DIRECTORY "${SWIFTSTATICLIB_DIR}/${lowercase_sdk}")
+    LINK_FLAGS ${swift_runtime_linker_flags}
+    INSTALL_IN_COMPONENT stdlib)
 
-  swift_install_in_component(stdlib
-    TARGETS swiftImageInspectionShared
-    DESTINATION "lib/swift_static/${lowercase_sdk}")
+  foreach(arch IN LISTS SWIFT_SDK_${sdk}_ARCHITECTURES)
+    set(FragileSupportLibrary swiftImageInspectionShared-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${arch})
+    set(LibraryLocation ${SWIFTSTATICLIB_DIR}/${lowercase_sdk}/${arch})
+    add_custom_command_target(swift_image_inspection_${arch}_static
+      COMMAND
+        "${CMAKE_COMMAND}" -E copy $<TARGET_FILE:${FragileSupportLibrary}> ${LibraryLocation}
+      OUTPUT
+        "${LibraryLocation}/${CMAKE_STATIC_LIBRARY_PREFIX}swiftImageInspectionShared${CMAKE_STATIC_LIBRARY_SUFFIX}"
+      DEPENDS
+         ${FragileSupportLibrary})
+    swift_install_in_component(stdlib
+      FILES $<TARGET_FILE:${FragileSupportLibrary}>
+      DESTINATION "lib/swift_static/${lowercase_sdk}/${arch}")
+  endforeach()
+
+  set(FragileSupportLibraryPrimary swiftImageInspectionShared-${SWIFT_SDK_${sdk}_LIB_SUBDIR}-${SWIFT_PRIMARY_VARIANT_ARCH})
+  set(LibraryLocationPrimary ${SWIFTSTATICLIB_DIR}/${lowercase_sdk})
+  add_custom_command_target(swift_image_inspection_static_primary_arch
+      COMMAND
+         "${CMAKE_COMMAND}" -E copy $<TARGET_FILE:${FragileSupportLibraryPrimary}> ${LibraryLocationPrimary}
+      OUTPUT
+      "${LibraryLocationPrimary}/${CMAKE_STATIC_LIBRARY_PREFIX}swiftImageInspectionShared${CMAKE_STATIC_LIBRARY_SUFFIX}"
+      DEPENDS
+         ${FragileSupportLibraryPrimary})
+    swift_install_in_component(stdlib
+      FILES $<TARGET_FILE:${FragileSupportLibraryPrimary}>
+      DESTINATION "lib/swift_static/${lowercase_sdk}")
 
   # Generate the static-executable-args.lnk file used for ELF systems (eg linux)
   set(linkfile "${lowercase_sdk}/static-executable-args.lnk")
@@ -131,8 +154,12 @@ if(SWIFT_BUILD_STATIC_STDLIB AND "${sdk}" STREQUAL "LINUX")
     FILES "${SWIFTSTATICLIB_DIR}/${linkfile}"
     DESTINATION "lib/swift_static/${lowercase_sdk}")
   add_custom_target(static_binary_magic ALL DEPENDS ${static_binary_lnk_file_list})
+  foreach(arch IN LISTS SWIFT_SDK_LINUX_ARCHITECTURES)
+    add_dependencies(static_binary_magic ${swift_image_inspection_${arch}_static})
+  endforeach()
+  add_dependencies(static_binary_magic ${swift_image_inspection_static_primary_arch})
 
-  add_swift_library(swiftImageInspectionShared OBJECT_LIBRARY TARGET_LIBRARY
+  add_swift_library(swiftImageInspectionSharedObject OBJECT_LIBRARY TARGET_LIBRARY
     ImageInspectionELF.cpp
     C_COMPILE_FLAGS ${swift_runtime_library_compile_flags}
     LINK_FLAGS ${swift_runtime_linker_flags}

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -3,7 +3,8 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
 
   set(swift_runtime_test_extra_libraries)
   if(SWIFT_BUILD_STATIC_STDLIB AND "${SWIFT_HOST_VARIANT_SDK}" STREQUAL "LINUX")
-    list(APPEND swift_runtime_test_extra_libraries swiftImageInspectionShared)
+    list(APPEND swift_runtime_test_extra_libraries 
+      $<TARGET_FILE:swiftImageInspectionShared-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH}>)
   endif()
 
   add_subdirectory(LongTests)


### PR DESCRIPTION
Previously, swiftImageInspectionShared generated one specific library at
lib/libswiftImageInspectionShared.a for only the main arch and sdk.
Generic cross compilation and various changes to the build system to get
cross compilation to work will require swiftImageInspectionShared to
generate libraries at the proper subdirectory. Change the outputs to
agree with paths such as lib/swift/linux/x86_64

Some ugly workarounds had to be used due to add_swift_library being invoked with IS_STDLIB causing circular shared object dependencies with SwiftImageInspectionShared. Thus the libraries had to be manually copied to`swift_static.

The copy/pasting from lib/swift/linux/libswiftImageInspectionShared.a to ../swift_static/..` will be removed in an upcoming PR as it will no longer be needed.