### PR TITLE
[SIL] Avoid std::function in transform-iterators

### DIFF
--- a/include/swift/SIL/SILBasicBlock.h
+++ b/include/swift/SIL/SILBasicBlock.h
@@ -163,10 +163,10 @@ public:
 
   ArrayRef<SILArgument *> getArguments() const { return ArgumentList; }
   using PHIArgumentArrayRefTy =
-      TransformArrayRef<std::function<SILPHIArgument *(SILArgument *)>>;
+      TransformArrayRef<SILPHIArgument *(*)(SILArgument *)>;
   PHIArgumentArrayRefTy getPHIArguments() const;
   using FunctionArgumentArrayRefTy =
-      TransformArrayRef<std::function<SILFunctionArgument *(SILArgument *)>>;
+      TransformArrayRef<SILFunctionArgument *(*)(SILArgument *)>;
   FunctionArgumentArrayRefTy getFunctionArguments() const;
 
   unsigned getNumArguments() const { return ArgumentList.size(); }

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -197,18 +197,6 @@ private:
   /// Please do not use this outside of this class. It is only meant to speedup
   /// MultipleValueInstruction::getIndexOfResult(SILValue).
   const ValueBase *back() const;
-
-  /// Return the offset 1 past the end of the array or None if we are not
-  /// actually storing anything.
-  Optional<unsigned> getStartOffset() const {
-    return empty() ? None : Optional<unsigned>(0);
-  }
-
-  /// Return the offset 1 past the end of the array or None if we are not
-  /// actually storing anything.
-  Optional<unsigned> getEndOffset() const {
-    return empty() ? None : Optional<unsigned>(size());
-  }
 };
 
 class SILInstructionResultArray::iterator {
@@ -220,7 +208,7 @@ class SILInstructionResultArray::iterator {
   SILInstructionResultArray Parent;
 
   /// The index into the parent array.
-  Optional<unsigned> Index;
+  unsigned Index;
 
 public:
   using difference_type = int;
@@ -230,34 +218,31 @@ public:
   using iterator_category = std::bidirectional_iterator_tag;
 
   iterator() = default;
-  iterator(const SILInstructionResultArray &Parent,
-           Optional<unsigned> Index = 0)
+  iterator(const SILInstructionResultArray &Parent, unsigned Index = 0)
       : Parent(Parent), Index(Index) {}
 
-  SILValue operator*() const { return Parent[Index.getValue()]; }
-  SILValue operator*() { return Parent[Index.getValue()]; }
+  SILValue operator*() const { return Parent[Index]; }
   SILValue operator->() const { return operator*(); }
-  SILValue operator->() { return operator*(); }
 
   iterator &operator++() {
-    ++Index.getValue();
+    ++Index;
     return *this;
   }
 
   iterator operator++(int) {
     iterator copy = *this;
-    ++Index.getValue();
+    ++Index;
     return copy;
   }
 
   iterator &operator--() {
-    --Index.getValue();
+    --Index;
     return *this;
   }
 
   iterator operator--(int) {
     iterator copy = *this;
-    --Index.getValue();
+    --Index;
     return copy;
   }
 

--- a/lib/SIL/SILBasicBlock.cpp
+++ b/lib/SIL/SILBasicBlock.cpp
@@ -336,20 +336,18 @@ bool SILBasicBlock::isEntry() const {
 }
 
 SILBasicBlock::PHIArgumentArrayRefTy SILBasicBlock::getPHIArguments() const {
-  using FuncTy = std::function<SILPHIArgument *(SILArgument *)>;
-  FuncTy F = [](SILArgument *A) -> SILPHIArgument * {
+  return PHIArgumentArrayRefTy(getArguments(),
+                               [](SILArgument *A) -> SILPHIArgument * {
     return cast<SILPHIArgument>(A);
-  };
-  return makeTransformArrayRef(getArguments(), F);
+  });
 }
 
 SILBasicBlock::FunctionArgumentArrayRefTy
 SILBasicBlock::getFunctionArguments() const {
-  using FuncTy = std::function<SILFunctionArgument *(SILArgument *)>;
-  FuncTy F = [](SILArgument *A) -> SILFunctionArgument * {
+  return FunctionArgumentArrayRefTy(getArguments(),
+                                    [](SILArgument *A) -> SILFunctionArgument* {
     return cast<SILFunctionArgument>(A);
-  };
-  return makeTransformArrayRef(getArguments(), F);
+  });
 }
 
 /// Returns true if this block ends in an unreachable or an apply of a

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -1361,11 +1361,11 @@ SILInstructionResultArray::getTypes() const {
 }
 
 SILInstructionResultArray::iterator SILInstructionResultArray::begin() const {
-  return iterator(*this, getStartOffset());
+  return iterator(*this, 0);
 }
 
 SILInstructionResultArray::iterator SILInstructionResultArray::end() const {
-  return iterator(*this, getEndOffset());
+  return iterator(*this, size());
 }
 
 SILInstructionResultArray::reverse_iterator

--- a/lib/SIL/SILInstruction.cpp
+++ b/lib/SIL/SILInstruction.cpp
@@ -1354,7 +1354,7 @@ operator==(const SILInstructionResultArray &other) {
 
 SILInstructionResultArray::type_range
 SILInstructionResultArray::getTypes() const {
-  std::function<SILType(SILValue)> F = [](SILValue V) -> SILType {
+  SILType (*F)(SILValue) = [](SILValue V) -> SILType {
     return V->getType();
   };
   return {llvm::map_iterator(begin(), F), llvm::map_iterator(end(), F)};


### PR DESCRIPTION
In a non-rigorous test, this change shaves off 20% of the time spent in SIL optimizations for the standard library (Swift.o) in a +Asserts build. (Admittedly the wins for a no-asserts build will be much lower because SILInstructionResultArray has a bunch of assertions in its constructor.)

Also simplify SILInstructionResultArray::iterator, because why make things more complicated than they need to be?