### PR TITLE
[build-script] NFC: Update a comment regarding LLD for Apple platforms

### DIFF
--- a/cmake/modules/AddSwift.cmake
+++ b/cmake/modules/AddSwift.cmake
@@ -430,8 +430,8 @@ function(_add_variant_link_flags)
   endif()
 
   if(NOT SWIFT_COMPILER_IS_MSVC_LIKE)
+    # FIXME: On Apple platforms, find_program needs to look for "ld64.lld"
     find_program(LDLLD_PATH "ld.lld")
-    # Strangely, macOS finds lld and then can't find it when using -fuse-ld=
     if((SWIFT_ENABLE_LLD_LINKER AND LDLLD_PATH AND NOT APPLE) OR
        ("${LFLAGS_SDK}" STREQUAL "WINDOWS" AND
         NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "WINDOWS"))


### PR DESCRIPTION
PR #14306 fixed the problem in https://bugs.swift.org/browse/SR-6878 but
included a comment about mysterious behavior on macOS. I did some
investigation and found that Clang assumes that Darwin platforms use
a different name for LLD. My impression is that LLD is not yet ready for
prime time on Darwin, so leaving it disabled for Apple platforms seems
like the right thing for now. This just updates the comments to explain
what will need to change whenever someone wants to reenable it.

rdar://problem/37053028