### PR TITLE
[benchmark] Improve the output format

### DIFF
--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -203,7 +203,7 @@ def run_benchmarks(driver, benchmarks=[], num_samples=10, verbose=False,
     output = []
     headings = ['#', 'TEST', 'SAMPLES', 'MIN(μs)', 'MAX(μs)', 'MEAN(μs)',
                 'SD(μs)', 'MEDIAN(μs)', 'MAX_RSS(B)']
-    line_format = '{:>3} {:<57} {:>7} {:>7} {:>7} {:>8} {:>6} {:>10} {:>10}'
+    line_format = '{:>3} {:<57} {:>7} {:>8} {:>8} {:>8} {:>6} {:>10} {:>10}'
     if verbose and log_directory:
         print(line_format.format(*headings))
     for test in benchmarks:

--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -203,7 +203,7 @@ def run_benchmarks(driver, benchmarks=[], num_samples=10, verbose=False,
     output = []
     headings = ['#', 'TEST', 'SAMPLES', 'MIN(μs)', 'MAX(μs)', 'MEAN(μs)',
                 'SD(μs)', 'MEDIAN(μs)', 'MAX_RSS(B)']
-    line_format = '{:>3} {:<25} {:>7} {:>7} {:>7} {:>8} {:>6} {:>10} {:>10}'
+    line_format = '{:>3} {:<57} {:>7} {:>7} {:>7} {:>8} {:>6} {:>10} {:>10}'
     if verbose and log_directory:
         print(line_format.format(*headings))
     for test in benchmarks:


### PR DESCRIPTION
This PR improves the output format of benchmark tests.

Currently, the output is something like below.

```
  # TEST                      SAMPLES MIN(μs) MAX(μs) MEAN(μs) SD(μs) MEDIAN(μs) MAX_RSS(B)
...
  1 ArrayOfGenericPOD2              1     152     152      152      0        152    9515008
  1 ArrayOfGenericRef               1    5823    5823     5823      0       5823   11206656
  1 ArrayOfPOD                      1     150     150      150      0        150    9465856
  1 ArrayOfRef                      1    5735    5735     5735      0       5735   10915840
  1 ArrayPlusEqualArrayOfInt        1     520     520      520      0        520    9879552
  1 ArrayPlusEqualFiveElementCollection       1   60463   60463    60463      0      60463   12324864
  1 ArrayPlusEqualSingleElementCollection       1    8306    8306     8306      0       8306   10444800
  1 ArrayPlusEqualThreeElements       1    3779    3779     3779      0       3779    7938048
  1 ArraySubscript                  1    2770    2770     2770      0       2770  111255552
  1 ArrayValueProp                  1       6       6        6      0          6    7823360
  1 ArrayValueProp2                 1       6       6        6      0          6    7823360
  1 ArrayValueProp3                 1       6       6        6      0          6    7819264
  1 ArrayValueProp4                 1       6       6        6      0          6    7835648
...
  1 CharIteration_punctuatedJapanese_unicodeScalars_Backwards       1    2805    2805     2805      0       2805    8085504
...
    Totals                        429 15326694 15326694 15326694      0          0          0
```

This is caused by the `line_format` with too short width in `benchmark/scripts/Benchmark_Driver` .

```python
line_format = '{:>3} {:<25} {:>7} {:>7} {:>7} {:>8} {:>6} {:>10} {:>10}'
```

This line was added at 0356ec8ec373e64b2100adb939f9a1dbfb9cd9bc . After that, various tests with a name longer than 25 characters were added and the format issue was caused.

The current longest name is `CharIteration_punctuatedJapanese_unicodeScalars_Backwards` whose length is 57. So this PR changes `{:<25}` to `{:<57}` by 99b0f0d8c84923b606d404852b6a8b0f16e36a7a .

The last "Totals" line also has format issues. Because "Totals" have much larger values than each test, its items are likely to have larger width. In my environment, `MAX` and `MIN` need width of 8 though they are formatted by `{:>7}`. However, it heavily depends on machine specs if they need width of 8. In addition, I was not sure if it was better that all lines had `MAX` and `MIN` with width of 8 than we gave up the format of the last "Totals" line. So I separated the modifications for them from 99b0f0d8c84923b606d404852b6a8b0f16e36a7a to bf2215667244bd69de47b31e896e908c4bdbc460 .

These 2 commits resulted outputs like the following ones.

```
  # TEST                                                      SAMPLES MIN(μs) MAX(μs) MEAN(μs) SD(μs) MEDIAN(μs) MAX_RSS(B)
...
  1 ArrayOfPOD                                                      1      146      146      146      0        146    9515008
  1 ArrayOfRef                                                      1     5783     5783     5783      0       5783   10686464
  1 ArrayPlusEqualArrayOfInt                                        1      450      450      450      0        450    9940992
  1 ArrayPlusEqualFiveElementCollection                             1    55240    55240    55240      0      55240   12337152
  1 ArrayPlusEqualSingleElementCollection                           1     7392     7392     7392      0       7392   10215424
  1 ArrayPlusEqualThreeElements                                     1     3756     3756     3756      0       3756    8003584
  1 ArraySubscript                                                  1     2713     2713     2713      0       2713  110686208
  1 ArrayValueProp                                                  1        6        6        6      0          6    7929856
  1 ArrayValueProp2                                                 1        6        6        6      0          6    7917568
  1 ArrayValueProp3                                                 1        6        6        6      0          6    7897088
  1 ArrayValueProp4                                                 1        6        6        6      0          6    7933952
...
  1 CharIndexing_punctuatedJapanese_unicodeScalars_Backwards        1     3251     3251     3251      0       3251    8032256
...
    Totals                                                        427 15678258 15678258 15678258      0          0          0
```

The header line still has some format issues. However they are caused by how Python 2 counts characters of unicode strings. For example, `len('μ')` is 2 in Python 2 while it is 1 in Python 3. Because they are resolved automatically when we migrate to Python3, I left them as it was.