### PR TITLE
 [Syntax] Verify syntax tree only if we reached the real EOF

### DIFF
--- a/lib/Parse/SyntaxParsingContext.cpp
+++ b/lib/Parse/SyntaxParsingContext.cpp
@@ -297,8 +297,10 @@ void finalizeSourceFile(RootContextData &RootData,
   assert(newRaw);
   SF.setSyntaxRoot(make<SourceFileSyntax>(newRaw));
 
-  if (SF.getASTContext().LangOpts.VerifySyntaxTree) {
-    // Verify the added nodes if specified.
+  // Verify the tree if specified.
+  // Do this only when we see the real EOF token because parseIntoSourceFile()
+  // can get called multiple times for single source file.
+  if (EOFToken->isPresent() && SF.getASTContext().LangOpts.VerifySyntaxTree) {
     SyntaxVerifier Verifier(RootData);
     Verifier.verify(SF.getSyntaxRoot());
   }

--- a/test/Syntax/diagnostics_verify.swift
+++ b/test/Syntax/diagnostics_verify.swift
@@ -1,0 +1,15 @@
+// RUN: %target-typecheck-verify-swift -verify-syntax-tree
+// FIXME: Too many "unknown syntax" errors.
+
+if true {
+  try
+  // expected-error@-1 4 {{unknown expression syntax exists in the source}}
+  // expected-error@-2 2 {{unknown statement syntax exists in the source}}
+} // expected-error {{expected expression}} expected-error 2 {{unknown statement syntax exists in the source}}
+
+if false {
+  [.]
+  // expected-error@-1 {{expected identifier after '.' expression}}
+  // expected-error@-2 2 {{unknown expression syntax exists in the source}}
+  // expected-error@-3 {{unknown statement syntax exists in the source}}
+} // expected-error {{unknown statement syntax exists in the source}}

--- a/test/Syntax/diagnostics_verify.swift
+++ b/test/Syntax/diagnostics_verify.swift
@@ -3,9 +3,9 @@
 
 if true {
   try
-  // expected-error@-1 4 {{unknown expression syntax exists in the source}}
-  // expected-error@-2 2 {{unknown statement syntax exists in the source}}
-} // expected-error {{expected expression}} expected-error 2 {{unknown statement syntax exists in the source}}
+  // expected-error@-1 2 {{unknown expression syntax exists in the source}}
+  // expected-error@-2 {{unknown statement syntax exists in the source}}
+} // expected-error {{expected expression}} expected-error {{unknown statement syntax exists in the source}}
 
 if false {
   [.]


### PR DESCRIPTION
We used to verify the tree for every `parseIntoSourceFile()` invocation. That used to cause significant performance penalty if `-verify-syntax-tree` is passed and the source contains `TopLevelCodeDecl`s.