### PR TITLE
[4.2] IRGen: Collect the current type metadata of singleton enums

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -527,6 +527,7 @@ namespace {
         return;
       getSingleton()->collectMetadataForOutlining(collector,
                                         getSingletonType(collector.IGF.IGM, T));
+      collector.collectTypeMetadataForLayout(T);
     }
 
     void reexplode(IRGenFunction &IGF, Explosion &src, Explosion &dest)

--- a/test/IRGen/outlined_copy_addr.swift
+++ b/test/IRGen/outlined_copy_addr.swift
@@ -18,8 +18,8 @@ public struct StructWithBaseStruct<T: BaseProt> {
     var elem2: BaseStruct<Element>
 }
 
-// CHECK-LABEL: define hidden swiftcc void @"$S11outcopyaddr010StructWithbc4BaseB0V4elemAA0bcdB0VyxGvg"(%T11outcopyaddr014StructWithBaseB0V.4* noalias nocapture sret, %swift.type* %"StructWithStructWithBaseStruct<T>", %T11outcopyaddr010StructWithbc4BaseB0V* noalias nocapture swiftself)
-// CHECK: call %T11outcopyaddr014StructWithBaseB0V.4* @"$S11outcopyaddr014StructWithBaseB0VyxGAA9ChildProtRzlWOc"
+// CHECK-LABEL: define hidden swiftcc void @"$S11outcopyaddr010StructWithbc4BaseB0V4elemAA0bcdB0VyxGvg"(%T11outcopyaddr014StructWithBaseB0V.5* noalias nocapture sret, %swift.type* %"StructWithStructWithBaseStruct<T>", %T11outcopyaddr010StructWithbc4BaseB0V* noalias nocapture swiftself)
+// CHECK: call %T11outcopyaddr014StructWithBaseB0V.5* @"$S11outcopyaddr014StructWithBaseB0VyxGAA9ChildProtRzlWOc"
 public struct StructWithStructWithBaseStruct<T: ChildProt> {
     public typealias Element = T
     let elem: StructWithBaseStruct<Element>
@@ -48,3 +48,13 @@ extension P {
   }
 }
 
+enum GenericError<T: BaseProt> {
+  case payload(T)
+}
+
+func testIt<P: BaseProt>(_ f: GenericError<P>?) {
+}
+
+func dontCrash<P: BaseProt>(_ f: GenericError<P>) {
+  testIt(f)
+}


### PR DESCRIPTION
We have missed the singleton enum case.

Outlined value operations like copy/destroy, init need to have the
metadata of dependent types available. The single enum case missed an
instance. Causing a compiler crash.

Scope: Regression somewhere along the line with the introduction of outlined copy_addr,
destroy_addr instructions.

Risk: Low. Single line change that adds passing a metadata parameter.

Testing: CI test added

rdar://39923978