### PR TITLE
[4.2] Correct cast from IUO in Locale.localizedString(for:)

### DIFF
--- a/stdlib/public/SDK/Foundation/Locale.swift
+++ b/stdlib/public/SDK/Foundation/Locale.swift
@@ -109,7 +109,7 @@ public struct Locale : Hashable, Equatable, ReferenceConvertible {
     /// For example, in the "en" locale, the result for `.buddhist` is `"Buddhist Calendar"`.
     public func localizedString(for calendarIdentifier: Calendar.Identifier) -> String? {
         // NSLocale doesn't export a constant for this
-        let result = CFLocaleCopyDisplayNameForPropertyValue(unsafeBitCast(_wrapped, to: CFLocale.self), .calendarIdentifier, Calendar._toNSCalendarIdentifier(calendarIdentifier).rawValue as CFString) as String
+        let result = CFLocaleCopyDisplayNameForPropertyValue(unsafeBitCast(_wrapped, to: CFLocale.self), .calendarIdentifier, Calendar._toNSCalendarIdentifier(calendarIdentifier).rawValue as CFString) as String?
         return result
     }
 


### PR DESCRIPTION
**What's in this pull request?**
Cherry-picks #16393 to `swift-4.2-branch`.