### PR TITLE
[Diagnostics] Better lazy ownership error

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2412,6 +2412,8 @@ ERROR(lazy_must_be_property,none,
       "lazy is only valid for members of a struct or class", ())
 ERROR(lazy_not_observable,none,
       "lazy properties must not have observers", ())
+ERROR(lazy_not_strong,none,
+      "lazy properties must not have reference attributes", ())
 
 // Debugger function attribute.
 ERROR(attr_for_debugger_support_only,none,

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2413,7 +2413,7 @@ ERROR(lazy_must_be_property,none,
 ERROR(lazy_not_observable,none,
       "lazy properties must not have observers", ())
 ERROR(lazy_not_strong,none,
-      "lazy properties must not have reference attributes", ())
+      "lazy properties cannot be %0", (ReferenceOwnership))
 
 // Debugger function attribute.
 ERROR(attr_for_debugger_support_only,none,

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -597,9 +597,12 @@ void AttributeEarlyChecker::visitLazyAttr(LazyAttr *attr) {
   if (VD->isLet())
     diagnoseAndRemoveAttr(attr, diag::lazy_not_on_let);
 
+  auto attrs = VD->getAttrs();
   // 'lazy' is not allowed to have reference attributes
-  if (VD->getAttrs().hasAttribute<ReferenceOwnershipAttr>())
-    diagnoseAndRemoveAttr(attr, diag::lazy_not_strong);
+  if (attrs.hasAttribute<ReferenceOwnershipAttr>()) {
+    auto *refAttr = attrs.getAttribute<ReferenceOwnershipAttr>();
+    diagnoseAndRemoveAttr(attr, diag::lazy_not_strong, refAttr->get());
+  }
 
   // lazy is not allowed on a protocol requirement.
   auto varDC = VD->getDeclContext();

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -597,6 +597,10 @@ void AttributeEarlyChecker::visitLazyAttr(LazyAttr *attr) {
   if (VD->isLet())
     diagnoseAndRemoveAttr(attr, diag::lazy_not_on_let);
 
+  // 'lazy' is not allowed to have reference attributes
+  if (VD->getAttrs().hasAttribute<ReferenceOwnershipAttr>())
+    diagnoseAndRemoveAttr(attr, diag::lazy_not_strong);
+
   // lazy is not allowed on a protocol requirement.
   auto varDC = VD->getDeclContext();
   if (isa<ProtocolDecl>(varDC))

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -599,10 +599,8 @@ void AttributeEarlyChecker::visitLazyAttr(LazyAttr *attr) {
 
   auto attrs = VD->getAttrs();
   // 'lazy' is not allowed to have reference attributes
-  if (attrs.hasAttribute<ReferenceOwnershipAttr>()) {
-    auto *refAttr = attrs.getAttribute<ReferenceOwnershipAttr>();
+  if (auto *refAttr = attrs.getAttribute<ReferenceOwnershipAttr>())
     diagnoseAndRemoveAttr(attr, diag::lazy_not_strong, refAttr->get());
-  }
 
   // lazy is not allowed on a protocol requirement.
   auto varDC = VD->getDeclContext();

--- a/test/Sema/diag_ownership_lazy.swift
+++ b/test/Sema/diag_ownership_lazy.swift
@@ -1,19 +1,12 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
-
-// -verify-ignore-unknown is for:
-// <unknown>:0: error: unexpected note produced: 'self' declared here
+// RUN: %target-typecheck-verify-swift
 
 class LazyReferenceClass {
-  // expected-note@-1 {{type declared here}}
-  // expected-note@-2 {{type declared here}}
   lazy unowned(unsafe) var unsafeSelf = { self }()
   // expected-error@-1 {{lazy properties cannot be 'unowned(unsafe)'}}
 
-  lazy weak var weakSelf = self
+  lazy weak var weakValue = LazyReferenceClass()
   // expected-error@-1 {{lazy properties cannot be 'weak'}}
-  // expected-error@-2 {{class declaration cannot close over value 'self' defined in outer scope}}
 
-  unowned lazy var unownedSelf = self
+  unowned lazy var unownedValue = LazyReferenceClass()
   // expected-error@-1 {{lazy properties cannot be 'unowned'}}
-  // expected-error@-2 {{class declaration cannot close over value 'self' defined in outer scope}}
 }

--- a/test/Sema/diag_ownership_lazy.swift
+++ b/test/Sema/diag_ownership_lazy.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift
+
+class LazyReferenceClass {
+  lazy unowned(unsafe) var unsafeSelf = { self }() // expected-error{{lazy properties must not have reference attributes}}
+  lazy weak var weakSelf = self // expected-error{{lazy properties must not have reference attributes}}
+  lazy unowned var unownedSelf = self // expected-error{{lazy properties must not have reference attributes}}
+}

--- a/test/Sema/diag_ownership_lazy.swift
+++ b/test/Sema/diag_ownership_lazy.swift
@@ -1,7 +1,19 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+// -verify-ignore-unknown is for:
+// <unknown>:0: error: unexpected note produced: 'self' declared here
 
 class LazyReferenceClass {
-  lazy unowned(unsafe) var unsafeSelf = { self }() // expected-error{{lazy properties must not have reference attributes}}
-  lazy weak var weakSelf = self // expected-error{{lazy properties must not have reference attributes}}
-  lazy unowned var unownedSelf = self // expected-error{{lazy properties must not have reference attributes}}
+  // expected-note@-1 {{type declared here}}
+  // expected-note@-2 {{type declared here}}
+  lazy unowned(unsafe) var unsafeSelf = { self }()
+  // expected-error@-1 {{lazy properties cannot be 'unowned(unsafe)'}}
+
+  lazy weak var weakSelf = self
+  // expected-error@-1 {{lazy properties cannot be 'weak'}}
+  // expected-error@-2 {{class declaration cannot close over value 'self' defined in outer scope}}
+
+  unowned lazy var unownedSelf = self
+  // expected-error@-1 {{lazy properties cannot be 'unowned'}}
+  // expected-error@-2 {{class declaration cannot close over value 'self' defined in outer scope}}
 }


### PR DESCRIPTION
Intead of just spitting out some non-sensical error,
properly tell the user that lazy properties shouldn't
have ownership attributes.

@jrose-apple @DougGregor Could one of you provide some input into this? I don't think we currently support this kind of behavior, and currently this kind of decl will spit out a default "cannot convert value of type `A` to expected type `A`" error, which isn't very helpful.

I may need to fixup that test as well.