### PR TITLE
[Diagnostics|SR-5789] Fixits for applying subscripts by keyword

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -75,6 +75,12 @@ ERROR(could_not_find_type_member_corrected,none,
       "type %0 has no member %1; did you mean %2?",
       (Type, DeclName, DeclName))
 
+ERROR(could_not_find_subscript_member,none,
+      "type %0 has no member property or method named 'subscript'",
+      (Type))
+NOTE(did_you_mean_subscript_operator,none,
+      "did you mean to use the subscript operator?", ())
+
 ERROR(could_not_find_enum_case,none,
       "enum type %0 has no case %1; did you mean %2", (Type, DeclName, DeclName))
 

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -75,11 +75,12 @@ ERROR(could_not_find_type_member_corrected,none,
       "type %0 has no member %1; did you mean %2?",
       (Type, DeclName, DeclName))
 
-ERROR(could_not_find_subscript_member,none,
-      "type %0 has no member property or method named 'subscript'",
+ERROR(could_not_find_subscript_member_did_you_mean,none,
+      "value of type %0 has no property or method named 'subscript'; "
+      "did you mean to use the subscript operator?",
       (Type))
-NOTE(did_you_mean_subscript_operator,none,
-      "did you mean to use the subscript operator?", ())
+NOTE(subscript_declared_here,none,
+      "declared here", ())
 
 ERROR(could_not_find_enum_case,none,
       "enum type %0 has no case %1; did you mean %2", (Type, DeclName, DeclName))

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -5399,7 +5399,7 @@ bool FailureDiagnosis::diagnoseSubscriptMisuse(ApplyExpr *callExpr) {
   auto argExpr = typeCheckChildIndependently(callExpr->getArg(),
                                              Type(), CTP_CallArgument);
   if (!argExpr)
-    return false;
+    return CS.TC.Diags.hadAnyError();
 
   SmallVector<Identifier, 2> scratch;
   ArrayRef<Identifier> argLabels = callExpr->getArgumentLabels(scratch);

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -5510,14 +5510,19 @@ bool FailureDiagnosis::visitApplyExpr(ApplyExpr *callExpr) {
         if (candidates.closeness != CC_ExactMatch)
           return hadError();
 
-        diag.fixItReplace(SourceRange(argExpr->getStartLoc()), "[");
+        auto l_bracket = getTokenText(swift::tok::l_square);
+        auto r_bracket = getTokenText(swift::tok::r_square);
+        auto r_paren = getTokenText(swift::tok::r_paren);
+        auto lastArgSym =
+          Lexer::getCharSourceRangeFromSourceRange(CS.TC.Context.SourceMgr,
+                                                   argExpr->getEndLoc());
+        diag.fixItReplace(SourceRange(argExpr->getStartLoc()), l_bracket);
         diag.fixItRemove(nameLoc.getSourceRange());
         diag.fixItRemove(SourceRange(UDE->getDotLoc()));
-
-        if (CS.TC.Context.SourceMgr.extractText({argExpr->getEndLoc(), 1}) == ")")
-          diag.fixItReplace(SourceRange(argExpr->getEndLoc()), "]");
+        if (CS.TC.Context.SourceMgr.extractText(lastArgSym) == r_paren)
+          diag.fixItReplace(SourceRange(argExpr->getEndLoc()), r_bracket);
         else
-          diag.fixItInsertAfter(argExpr->getEndLoc(), "]");
+          diag.fixItInsertAfter(argExpr->getEndLoc(), r_bracket);
       }
       return hadError();
     }

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -838,7 +838,7 @@ CalleeCandidateInfo::CalleeCandidateInfo(Type baseType,
     // the uncurry level is 1 if self has already been applied.
     unsigned uncurryLevel = 0;
     if (decl->getDeclContext()->isTypeContext() &&
-        selfAlreadyApplied)
+        selfAlreadyApplied && !isa<SubscriptDecl>(decl))
       uncurryLevel = 1;
     
     candidates.push_back({ decl, uncurryLevel });

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -253,11 +253,20 @@ struct SubscriptTest1 {
 
 func testSubscript1(_ s1 : SubscriptTest1) {
   let _ : Int = s1["hello"]  // expected-error {{ambiguous subscript with base type 'SubscriptTest1' and index type 'String'}}
-  
+
   if s1["hello"] {}
-  
-  
-  let _ = s1["hello"]  // expected-error {{ambiguous use of 'subscript'}}
+
+  _ = s1.subscript("hello")
+  // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
+  // expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{27-28=]}}
+  _ = s1.subscript("hello"
+  // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
+  // expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{27-27=]}}
+  // expected-note@-3 {{to match this opening '('}}
+
+  let _ = s1["hello"]
+  // expected-error@-1 {{ambiguous use of 'subscript'}}
+  // expected-error@-2 {{expected ')' in expression list}}
 }
 
 struct SubscriptTest2 {
@@ -268,11 +277,13 @@ struct SubscriptTest2 {
 func testSubscript1(_ s2 : SubscriptTest2) {
   _ = s2["foo"] // expected-error {{cannot subscript a value of type 'SubscriptTest2' with an index of type 'String'}}
   // expected-note @-1 {{overloads for 'subscript' exist with these partially matching parameter lists: (String, Int), (String, String)}}
-  
+
   let a = s2["foo", 1.0] // expected-error {{cannot subscript a value of type 'SubscriptTest2' with an index of type '(String, Double)'}}
   // expected-note @-1 {{overloads for 'subscript' exist with these partially matching parameter lists: (String, Int), (String, String)}}
-  
-  
+
+  _ = s2.subscript("hello", 6)
+  // expected-error@-1 {{type 'SubscriptTest2' has no member property or method named 'subscript'}}
+  // expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{30-31=]}}
   let b = s2[1, "foo"] // expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
 
   // rdar://problem/27449208
@@ -318,4 +329,6 @@ struct SR2575 {
   }
 }
 
-SR2575().subscript() // expected-error{{type 'SR2575' has no member 'subscript'}}
+SR2575().subscript()
+// expected-error@-1 {{type 'SR2575' has no member property or method named 'subscript'}}
+// expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{20-21=]}}

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -255,24 +255,24 @@ class ClassConformingToProtocol: Protocol {}
 class ClassConformingToRefinedProtocol: RefinedProtocol {}
 
 struct GenSubscriptFixitTest {
-  subscript<T>(_ arg: T) -> Bool { return true }
+  subscript<T>(_ arg: T) -> Bool { return true } // expected-note {{declared here}}
 }
 
 func testGenSubscriptFixit(_ s0: GenSubscriptFixitTest) {
 
   _ = s0.subscript("hello")
-  // expected-error@-1 {{type 'GenSubscriptFixitTest' has no member property or method named 'subscript'}}
-  // expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{27-28=]}}
+  // expected-error@-1 {{value of type 'GenSubscriptFixitTest' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{27-28=]}}
 }
 
 struct SubscriptTest1 {
   subscript(keyword:String) -> Bool { return true }  // expected-note 2 {{found this candidate}}
   subscript(keyword:String) -> String? {return nil }  // expected-note 2 {{found this candidate}}
 
-  subscript(arg: SubClass) -> Bool { return true }
-  subscript(arg: Protocol) -> Bool { return true }
+  subscript(arg: SubClass) -> Bool { return true } // expected-note {{declared here}}
+  subscript(arg: Protocol) -> Bool { return true } // expected-note 2 {{declared here}}
 
   subscript(arg: (foo: Bool, bar: (Int, baz: SubClass)), arg2: String) -> Bool { return true }
+  // expected-note@-1 2 {{declared here}}
 }
 
 func testSubscript1(_ s1 : SubscriptTest1) {
@@ -281,36 +281,26 @@ func testSubscript1(_ s1 : SubscriptTest1) {
   if s1["hello"] {}
 
   _ = s1.subscript((true, (5, SubClass())), "hello")
-  // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
-  // expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{52-53=]}}
+  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{52-53=]}}
   _ = s1.subscript((true, (5, baz: SubSubClass())), "hello")
-  // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
-  // expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{60-61=]}}
+  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{60-61=]}}
   _ = s1.subscript((fo: true, (5, baz: SubClass())), "hello")
-  // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
-  // expected-note@-2 {{did you mean to use the subscript operator?}}
+  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}}
   _ = s1.subscript(SubSubClass())
-  // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
-  // expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{33-34=]}}
+  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{33-34=]}}
   _ = s1.subscript(ClassConformingToProtocol())
-  // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
-  // expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{47-48=]}}
+  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{47-48=]}}
   _ = s1.subscript(ClassConformingToRefinedProtocol())
-  // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
-  // expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{54-55=]}}
+  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{54-55=]}}
   _ = s1.subscript(true)
-  // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
-  // expected-note@-2 {{did you mean to use the subscript operator?}}
+  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}}
   _ = s1.subscript(SuperClass())
-  // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
-  // expected-note@-2 {{did you mean to use the subscript operator?}}
+  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}}
   _ = s1.subscript("hello")
-  // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
-  // expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{27-28=]}}
+  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{27-28=]}}
   _ = s1.subscript("hello"
-  // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
-  // expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{27-27=]}}
-  // expected-note@-3 {{to match this opening '('}}
+  // expected-error@-1 {{value of type 'SubscriptTest1' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{27-27=]}}
+  // expected-note@-2 {{to match this opening '('}}
 
   let _ = s1["hello"]
   // expected-error@-1 {{ambiguous use of 'subscript'}}
@@ -319,6 +309,7 @@ func testSubscript1(_ s1 : SubscriptTest1) {
 
 struct SubscriptTest2 {
   subscript(a : String, b : Int) -> Int { return 0 }
+  // expected-note@-1 {{declared here}}
   subscript(a : String, b : String) -> Int { return 0 }
 }
 
@@ -330,8 +321,7 @@ func testSubscript1(_ s2 : SubscriptTest2) {
   // expected-note @-1 {{overloads for 'subscript' exist with these partially matching parameter lists: (String, Int), (String, String)}}
 
   _ = s2.subscript("hello", 6)
-  // expected-error@-1 {{type 'SubscriptTest2' has no member property or method named 'subscript'}}
-  // expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{30-31=]}}
+  // expected-error@-1 {{value of type 'SubscriptTest2' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{30-31=]}}
   let b = s2[1, "foo"] // expected-error {{cannot convert value of type 'Int' to expected argument type 'String'}}
 
   // rdar://problem/27449208
@@ -372,11 +362,10 @@ struct S4 {
 
 // SR-2575
 struct SR2575 {
-  subscript() -> Int {
+  subscript() -> Int { // expected-note {{declared here}}
     return 1
   }
 }
 
 SR2575().subscript()
-// expected-error@-1 {{type 'SR2575' has no member property or method named 'subscript'}}
-// expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{20-21=]}}
+// expected-error@-1 {{value of type 'SR2575' has no property or method named 'subscript'; did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{20-21=]}}

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -246,9 +246,33 @@ struct MutableSubscriptInGetter {
   }
 }
 
+protocol Protocol {}
+protocol RefinedProtocol: Protocol {}
+class SuperClass {}
+class SubClass: SuperClass {}
+class SubSubClass: SubClass {}
+class ClassConformingToProtocol: Protocol {}
+class ClassConformingToRefinedProtocol: RefinedProtocol {}
+
+struct GenSubscriptFixitTest {
+  subscript<T>(_ arg: T) -> Bool { return true }
+}
+
+func testGenSubscriptFixit(_ s0: GenSubscriptFixitTest) {
+
+  _ = s0.subscript("hello")
+  // expected-error@-1 {{type 'GenSubscriptFixitTest' has no member property or method named 'subscript'}}
+  // expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{27-28=]}}
+}
+
 struct SubscriptTest1 {
   subscript(keyword:String) -> Bool { return true }  // expected-note 2 {{found this candidate}}
   subscript(keyword:String) -> String? {return nil }  // expected-note 2 {{found this candidate}}
+
+  subscript(arg: SubClass) -> Bool { return true }
+  subscript(arg: Protocol) -> Bool { return true }
+
+  subscript(arg: (foo: Bool, bar: (Int, baz: Int))) -> Bool { return true }
 }
 
 func testSubscript1(_ s1 : SubscriptTest1) {
@@ -256,6 +280,24 @@ func testSubscript1(_ s1 : SubscriptTest1) {
 
   if s1["hello"] {}
 
+  _ = s1.subscript((true, (5, 6)))
+  // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
+  // expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{34-35=]}}
+  _ = s1.subscript(SubSubClass())
+  // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
+  // expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{33-34=]}}
+  _ = s1.subscript(ClassConformingToProtocol())
+  // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
+  // expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{47-48=]}}
+  _ = s1.subscript(ClassConformingToRefinedProtocol())
+  // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
+  // expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{54-55=]}}
+  _ = s1.subscript(true)
+  // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
+  // expected-note@-2 {{did you mean to use the subscript operator?}}
+  _ = s1.subscript(SuperClass())
+  // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
+  // expected-note@-2 {{did you mean to use the subscript operator?}}
   _ = s1.subscript("hello")
   // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
   // expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{27-28=]}}

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -272,7 +272,7 @@ struct SubscriptTest1 {
   subscript(arg: SubClass) -> Bool { return true }
   subscript(arg: Protocol) -> Bool { return true }
 
-  subscript(arg: (foo: Bool, bar: (Int, baz: Int))) -> Bool { return true }
+  subscript(arg: (foo: Bool, bar: (Int, baz: SubClass)), arg2: String) -> Bool { return true }
 }
 
 func testSubscript1(_ s1 : SubscriptTest1) {
@@ -280,9 +280,15 @@ func testSubscript1(_ s1 : SubscriptTest1) {
 
   if s1["hello"] {}
 
-  _ = s1.subscript((true, (5, 6)))
+  _ = s1.subscript((true, (5, SubClass())), "hello")
   // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
-  // expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{34-35=]}}
+  // expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{52-53=]}}
+  _ = s1.subscript((true, (5, baz: SubSubClass())), "hello")
+  // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
+  // expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{60-61=]}}
+  _ = s1.subscript((fo: true, (5, baz: SubClass())), "hello")
+  // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
+  // expected-note@-2 {{did you mean to use the subscript operator?}}
   _ = s1.subscript(SubSubClass())
   // expected-error@-1 {{type 'SubscriptTest1' has no member property or method named 'subscript'}}
   // expected-note@-2 {{did you mean to use the subscript operator?}} {{9-10=}} {{10-19=}} {{19-20=[}} {{33-34=]}}


### PR DESCRIPTION
If there is a subscript member, the error message changes to 
`type %0 has no member property or method named 'subscript'`.
The fix-it replaces parentheses with brackets, removes '.subscript'.
If the apply expression is incomplete, e.g. subscript(..., the fix-it adds a bracket at the end.

Resolves [SR-5789](https://bugs.swift.org/browse/SR-5789).

I am not entirely happy with where this is diagnosed. (See the last sentence in this [comment](https://bugs.swift.org/browse/SR-7617?focusedCommentId=35355&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-35355) for the reason)