### PR TITLE
Adding Ubuntu 18.04

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -781,6 +781,9 @@ skip-test-libdispatch
 skip-test-playgroundsupport
 skip-test-libicu
 
+# Ubuntu 18.04 preset for backwards compat and future customizations.
+[preset: buildbot_linux_1804]
+mixin-preset=buildbot_linux
 
 # Ubuntu 16.10 preset for backwards compat and future customizations.
 [preset: buildbot_linux_1610]


### PR DESCRIPTION
The new swift community hosted CI repo requires presents to be present here. https://github.com/apple/swift-community-hosted-continuous-integration

<!-- What's in this pull request? -->
Add build preset for Ubuntu 18.04. Ubuntu 18.04 is the latest LTS release for Ubuntu. 

Currently, the latest version of Ubuntu that Swift supports is 16.10, which is an Ubuntu version that Ubuntu doesn't support any more. (For example, the `apt-get` repos have been removed for Ubuntu 16.10.)

Thanks!

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
