### PR TITLE
[SR-7015] Fix CoreFoundation conditional downcast diagnostic

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2506,7 +2506,8 @@ NOTE(silence_inject_forced_downcast,none,
      "add parentheses around the cast to silence this warning", ())
 
 ERROR(conditional_downcast_foreign,none,
-      "conditional downcast to CoreFoundation type %0 will always succeed",
+      "conditional downcast to CoreFoundation type %0 cannot be resolved; "
+      "compare each CFTypeIDs to check cast",
       (Type))
 
 ERROR(optional_used_as_boolean,none,

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -3380,9 +3380,17 @@ namespace {
               if (SuppressDiagnostics)
                 return nullptr;
 
+              auto startLoc = static_cast<const char *>(cast->getStartLoc().getOpaquePointerValue());
+              auto asLoc = static_cast<const char *>(cast->getLoc().getOpaquePointerValue());
+              auto fromType = std::string(startLoc).substr(0, asLoc-startLoc);
+              auto toType = resultType->getOptionalObjectType().getString();
+              auto replacement = "(CFGetTypeID(" + fromType + "as AnyObject) == " + toType + "GetTypeID()) ? (" + fromType + "as! " + toType + ") : nil";
+              
               auto &tc = cs.getTypeChecker();
               tc.diagnose(cast->getLoc(), diag::conditional_downcast_foreign,
-                          destValueType);
+                          destValueType)
+              .highlight(cast->getAsLoc())
+              .fixItReplace(cast->getSourceRange(), replacement);
             }
           }
         }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fix CoreFoundation conditional downcast diagnostic.

---

Fix message and add fix-it to fix error.
For example, this fix-it replace

```swift
_ = 10 as? CFString
```

with
 
```swift
_ = (CFGetTypeID(10 as AnyObject) == CFStringGetTypeID()) ? (10 as! CFString) : nil
```

This replacement also works well in case of `if let _ = 10 as? CFString { ... }`.

---

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7015](https://bugs.swift.org/browse/SR-7015).
