### PR TITLE
Conditionalize warnings for IUO-to-Any coercion on Swift version.

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -1559,8 +1559,17 @@ static ValueDecl *getCalledValue(Expr *E) {
   if (auto *DRE = dyn_cast<DeclRefExpr>(E))
     return DRE->getDecl();
 
+  if (auto *OCRE = dyn_cast<OtherConstructorDeclRefExpr>(E))
+    return OCRE->getDecl();
+
+  // Look through SelfApplyExpr.
+  if (auto *SAE = dyn_cast<SelfApplyExpr>(E))
+    return SAE->getCalledValue();
+
   Expr *E2 = E->getValueProvidingExpr();
-  if (E != E2) return getCalledValue(E2);
+  if (E != E2)
+    return getCalledValue(E2);
+
   return nullptr;
 }
 

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -3728,6 +3728,13 @@ static void diagnoseUnintendedOptionalBehavior(TypeChecker &TC, const Expr *E,
         if (auto *call = dyn_cast<CallExpr>(E))
           E = call->getDirectCallee();
 
+        if (auto *subscript = dyn_cast<SubscriptExpr>(E)) {
+          if (subscript->hasDecl())
+            return subscript->getDecl().getDecl();
+
+          return nullptr;
+        }
+
         if (auto *memberRef = dyn_cast<MemberRefExpr>(E))
           return memberRef->getMember().getDecl();
         if (auto *declRef = dyn_cast<DeclRefExpr>(E))

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -407,22 +407,10 @@ func testPropertyAndMethodCollision(_ obj: PropertyAndMethodCollision,
   type(of: rev).classRef(rev, doSomething:#selector(getter: NSMenuItem.action))
 
   var value: Any
-  value = obj.protoProp() // expected-warning {{expression implicitly coerced from 'Any?' to 'Any'}}
-  // expected-note@-1 {{force-unwrap the value to avoid this warning}}
-  // expected-note@-2 {{provide a default value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
-  value = obj.protoPropRO() // expected-warning {{expression implicitly coerced from 'Any?' to 'Any'}}
-  // expected-note@-1 {{force-unwrap the value to avoid this warning}}
-  // expected-note@-2 {{provide a default value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
-  value = type(of: obj).protoClassProp() // expected-warning {{expression implicitly coerced from 'Any?' to 'Any'}}
-  // expected-note@-1 {{force-unwrap the value to avoid this warning}}
-  // expected-note@-2 {{provide a default value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
-  value = type(of: obj).protoClassPropRO() // expected-warning {{expression implicitly coerced from 'Any?' to 'Any'}}
-  // expected-note@-1 {{force-unwrap the value to avoid this warning}}
-  // expected-note@-2 {{provide a default value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
+  value = obj.protoProp()
+  value = obj.protoPropRO()
+  value = type(of: obj).protoClassProp()
+  value = type(of: obj).protoClassPropRO()
   _ = value
 }
 

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -247,27 +247,18 @@ func almostSubscriptableValueMismatch(_ as1: AlmostSubscriptable, a: A) {
 func almostSubscriptableKeyMismatch(_ bc: BadCollection, key: NSString) {
   // FIXME: We end up importing this as read-only due to the mismatch between
   // getter/setter element types.
-  var _ : Any = bc[key] // expected-warning {{expression implicitly coerced from 'Any?' to 'Any'}}
-  // expected-note@-1 {{force-unwrap the value to avoid this warning}}
-  // expected-note@-2 {{provide a default value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
+  var _ : Any = bc[key]
 }
 
 func almostSubscriptableKeyMismatchInherited(_ bc: BadCollectionChild,
                                              key: String) {
-  var value : Any = bc[key] // expected-warning {{expression implicitly coerced from 'Any?' to 'Any'}}
-  // expected-note@-1 {{force-unwrap the value to avoid this warning}}
-  // expected-note@-2 {{provide a default value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
+  var value : Any = bc[key]
   bc[key] = value // expected-error{{cannot assign through subscript: subscript is get-only}}
 }
 
 func almostSubscriptableKeyMismatchInherited(_ roc: ReadOnlyCollectionChild,
                                              key: String) {
-  var value : Any = roc[key] // expected-warning {{expression implicitly coerced from 'Any?' to 'Any'}}
-  // expected-note@-1 {{force-unwrap the value to avoid this warning}}
-  // expected-note@-2 {{provide a default value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
+  var value : Any = roc[key]
   roc[key] = value // expected-error{{cannot assign through subscript: subscript is get-only}}
 }
 

--- a/test/Constraints/casts_objc.swift
+++ b/test/Constraints/casts_objc.swift
@@ -34,12 +34,7 @@ func nsobject_as_class_cast<T>(_ x: NSObject, _: T) {
 func test(_ a : CFString!, b : CFString) {
   let dict = NSMutableDictionary()
   let object = NSObject()
-  dict[a] = object // expected-warning {{expression implicitly coerced from 'CFString?' to 'Any'}}
-  // expected-note@-1 {{force-unwrap the value to avoid this warning}}
-  // expected-note@-2 {{provide a default value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
-
-
+  dict[a] = object
   dict[b] = object
 }
 

--- a/test/Constraints/diag_ambiguities.swift
+++ b/test/Constraints/diag_ambiguities.swift
@@ -51,10 +51,7 @@ struct SR3715 {
   func take(_ a: [Any]) {}
 
   func test() {
-    take([overloaded]) // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
-  // expected-note@-1 {{force-unwrap the value to avoid this warning}}
-  // expected-note@-2 {{provide a default value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
+    take([overloaded])
   }
 }
 

--- a/test/Constraints/existential_metatypes.swift
+++ b/test/Constraints/existential_metatypes.swift
@@ -87,8 +87,5 @@ func testP3(_ p: P3, something: Something) {
 }
 
 func testIUOToAny(_ t: AnyObject.Type!) {
-  let _: Any = t // expected-warning {{expression implicitly coerced from 'AnyObject.Type?' to 'Any'}}
-  // expected-note@-1 {{force-unwrap the value to avoid this warning}}
-  // expected-note@-2 {{provide a default value to avoid this warning}}
-  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}
+  let _: Any = t
 }

--- a/test/Sema/diag_unintended_optional_behavior.swift
+++ b/test/Sema/diag_unintended_optional_behavior.swift
@@ -82,34 +82,33 @@ func warnNestedOptionalToOptionalAnyCoercion(_ a: Int?, _ b: Any??, _ c: Int???,
   takesOptionalAny(c as Any?, d as Any?)
 }
 
-func warnIUOToAnyCoercion(_ a: Int!, _ b: Any?!) {
-  _ = takeAny(a, b) // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
-  // expected-note@-1 {{provide a default value to avoid this warning}}{{16-16= ?? <#default value#>}}
-  // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{16-16=!}}
-  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{16-16= as Any}}
-  // expected-warning@-4 {{expression implicitly coerced from 'Any??' to 'Any'}}
-  // expected-note@-5 {{force-unwrap the value to avoid this warning}}{{19-19=!!}}
-  // expected-note@-6 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{19-19= as Any}}
+class C {
+  var a: Int!
+  var b: Any?!
+  func returningIUO() -> Int! { return a }
+  func returningAny() -> Any { return a }
+}
+
+func returningIUO() -> Int! { return 1 }
+
+// No warnings in Swift 3/4 for IUO-to-Any coercion.
+func nowarnIUOToAnyCoercion(_ a: Int!, _ b: Any?!) {
+  _ = takeAny(a, b)
+  _ = takeAny(returningIUO(), C().returningIUO())
+  _ = takeAny(C().a, C().b)
 
   _ = takeAny(a as Any, b as Any)
 }
 
-func warnIUOToOptionalAnyCoercion(_ a: Int!, _ b: Any?!, _ c: Int??!, _ d: Any???!) {
-  takesOptionalAny(a, b) // expected-warning {{expression implicitly coerced from 'Any??' to 'Any?'}}
-  // expected-note@-1 {{provide a default value to avoid this warning}}{{24-24= ?? <#default value#>}}
-  // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{24-24=!}}
-  // expected-note@-3 {{explicitly cast to 'Any?' with 'as Any?' to silence this warning}}{{24-24= as Any?}}
+// No warnings in Swift 3/4 for IUO-to-Any coercion.
+func nowarnIUOToOptionalAnyCoercion(_ a: Int!, _ b: Any?!, _ c: Int??!, _ d: Any???!) {
+  takesOptionalAny(a, b)
 
   takesOptionalAny(a, b ?? "")
   takesOptionalAny(a, b!)
   takesOptionalAny(a, b as Any?)
 
-  takesOptionalAny(c, d) // expected-warning {{expression implicitly coerced from 'Int???' to 'Any?'}}
-  // expected-note@-1 {{force-unwrap the value to avoid this warning}}{{21-21=!!}}
-  // expected-note@-2 {{explicitly cast to 'Any?' with 'as Any?' to silence this warning}}{{21-21= as Any?}}
-  // expected-warning@-3 {{expression implicitly coerced from 'Any????' to 'Any?'}}
-  // expected-note@-4 {{force-unwrap the value to avoid this warning}}{{24-24=!!!}}
-  // expected-note@-5 {{explicitly cast to 'Any?' with 'as Any?' to silence this warning}}{{24-24= as Any?}}
+  takesOptionalAny(c, d)
 
   takesOptionalAny(c!!, d!!!)
   takesOptionalAny(c as Any?, d as Any?)

--- a/test/Sema/diag_unintended_optional_behavior.swift
+++ b/test/Sema/diag_unintended_optional_behavior.swift
@@ -87,6 +87,13 @@ class C {
   var b: Any?!
   func returningIUO() -> Int! { return a }
   func returningAny() -> Any { return a }
+
+  subscript(i: Int) -> Int! { return 0 }
+  subscript(i: Float) -> Any! { return 0 }
+}
+
+class D {
+  init!() {}
 }
 
 func returningIUO() -> Int! { return 1 }
@@ -96,6 +103,8 @@ func nowarnIUOToAnyCoercion(_ a: Int!, _ b: Any?!) {
   _ = takeAny(a, b)
   _ = takeAny(returningIUO(), C().returningIUO())
   _ = takeAny(C().a, C().b)
+  _ = takeAny(C()[0], C()[1.0])
+  _ = takeAny(D(), D())
 
   _ = takeAny(a as Any, b as Any)
 }

--- a/test/Sema/diag_unintended_optional_behavior.swift
+++ b/test/Sema/diag_unintended_optional_behavior.swift
@@ -145,8 +145,20 @@ func warnCollectionOfOptionalToAnyCoercion(_ a: [Int?], _ d: [String : Int?]) {
   // expected-note@-1 {{explicitly cast to '[Any]' with 'as [Any]' to silence this warning}}{{25-25= as [Any]}}
   // expected-warning@-2 {{expression implicitly coerced from '[String : Int?]' to '[String : Any]'}}
   // expected-note@-3 {{explicitly cast to '[String : Any]' with 'as [String : Any]' to silence this warning}}{{28-28= as [String : Any]}}
+  takesCollectionOfAny([a[0]], ["test" : a[0]]) // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}{{29-29= ?? <#default value#>}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{29-29=!}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{29-29= as Any}}
+  // expected-warning@-4 {{expression implicitly coerced from 'Int?' to 'Any'}}
+  // expected-note@-5 {{provide a default value to avoid this warning}}{{46-46= ?? <#default value#>}}
+  // expected-note@-6 {{force-unwrap the value to avoid this warning}}{{46-46=!}}
+  // expected-note@-7 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{46-46= as Any}}
 
   takesCollectionOfAny(a as [Any], d as [String : Any])
+}
+
+func nowarnCollectionOfIUOToAnyCoercion(_ a: Int!) {
+  takesCollectionOfAny([a], ["test" : a])
 }
 
 func warnCollectionOfTripleOptionalToAnyCoercion(_ a: [Any???], _ d: [String: Any???]) {

--- a/test/Sema/diag_unintended_optional_behavior_swift_5.swift
+++ b/test/Sema/diag_unintended_optional_behavior_swift_5.swift
@@ -1,0 +1,69 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+
+// Additional warnings produced in Swift 5+ mode.
+
+func takeAny(_ left: Any, _ right: Any) -> Int? {
+  return left as? Int
+}
+
+func takesOptionalAny(_: Any?, _: Any?) {}
+
+class C {
+  var a: Int!
+  var b: Any?!
+  func returningIUO() -> Int! { return a }
+  func returningAny() -> Any { return a } // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}{{40-40= ?? <#default value#>}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{40-40=!}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{40-40= as Any}}
+}
+
+func returningIUO() -> Int! { return 1 }
+
+func warnIUOToAnyCoercion(_ a: Int!, _ b: Any?!) {
+  _ = takeAny(a, b) // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}{{16-16= ?? <#default value#>}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{16-16=!}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{16-16= as Any}}
+  // expected-warning@-4 {{expression implicitly coerced from 'Any??' to 'Any'}}
+  // expected-note@-5 {{force-unwrap the value to avoid this warning}}{{19-19=!!}}
+  // expected-note@-6 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{19-19= as Any}}
+  _ = takeAny(returningIUO(), C().returningIUO()) // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}{{29-29= ?? <#default value#>}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{29-29=!}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{29-29= as Any}}
+  // expected-warning@-4 {{expression implicitly coerced from 'Int?' to 'Any'}}
+  // expected-note@-5 {{provide a default value to avoid this warning}}{{49-49= ?? <#default value#>}}
+  // expected-note@-6 {{force-unwrap the value to avoid this warning}}{{49-49=!}}
+  // expected-note@-7 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{49-49= as Any}}
+  _ = takeAny(C().a, C().b) // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}{{20-20= ?? <#default value#>}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{20-20=!}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{20-20= as Any}}
+  // expected-warning@-4 {{expression implicitly coerced from 'Any??' to 'Any'}}
+  // expected-note@-5 {{force-unwrap the value to avoid this warning}}{{27-27=!!}}
+  // expected-note@-6 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{27-27= as Any}}
+
+  _ = takeAny(a as Any, b as Any)
+}
+
+func warnIUOToOptionalAnyCoercion(_ a: Int!, _ b: Any?!, _ c: Int??!, _ d: Any???!) {
+  takesOptionalAny(a, b) // expected-warning {{expression implicitly coerced from 'Any??' to 'Any?'}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}{{24-24= ?? <#default value#>}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{24-24=!}}
+  // expected-note@-3 {{explicitly cast to 'Any?' with 'as Any?' to silence this warning}}{{24-24= as Any?}}
+
+  takesOptionalAny(a, b ?? "")
+  takesOptionalAny(a, b!)
+  takesOptionalAny(a, b as Any?)
+
+  takesOptionalAny(c, d) // expected-warning {{expression implicitly coerced from 'Int???' to 'Any?'}}
+  // expected-note@-1 {{force-unwrap the value to avoid this warning}}{{21-21=!!}}
+  // expected-note@-2 {{explicitly cast to 'Any?' with 'as Any?' to silence this warning}}{{21-21= as Any?}}
+  // expected-warning@-3 {{expression implicitly coerced from 'Any????' to 'Any?'}}
+  // expected-note@-4 {{force-unwrap the value to avoid this warning}}{{24-24=!!!}}
+  // expected-note@-5 {{explicitly cast to 'Any?' with 'as Any?' to silence this warning}}{{24-24= as Any?}}
+
+  takesOptionalAny(c!!, d!!!)
+  takesOptionalAny(c as Any?, d as Any?)
+}

--- a/test/Sema/diag_unintended_optional_behavior_swift_5.swift
+++ b/test/Sema/diag_unintended_optional_behavior_swift_5.swift
@@ -67,3 +67,16 @@ func warnIUOToOptionalAnyCoercion(_ a: Int!, _ b: Any?!, _ c: Int??!, _ d: Any??
   takesOptionalAny(c!!, d!!!)
   takesOptionalAny(c as Any?, d as Any?)
 }
+
+func takesCollectionOfAny(_ a: [Any], _ d: [String : Any]) {}
+
+func warnCollectionOfIUOToAnyCoercion(_ a: Int!) {
+  takesCollectionOfAny([a], ["test" : a]) // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}{{26-26= ?? <#default value#>}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{26-26=!}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{26-26= as Any}}
+  // expected-warning@-4 {{expression implicitly coerced from 'Int?' to 'Any'}}
+  // expected-note@-5 {{provide a default value to avoid this warning}}{{40-40= ?? <#default value#>}}
+  // expected-note@-6 {{force-unwrap the value to avoid this warning}}{{40-40=!}}
+  // expected-note@-7 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{40-40= as Any}}
+}

--- a/test/Sema/diag_unintended_optional_behavior_swift_5.swift
+++ b/test/Sema/diag_unintended_optional_behavior_swift_5.swift
@@ -16,6 +16,13 @@ class C {
   // expected-note@-1 {{provide a default value to avoid this warning}}{{40-40= ?? <#default value#>}}
   // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{40-40=!}}
   // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{40-40= as Any}}
+
+  subscript(i: Int) -> Int! { return 0 }
+  subscript(i: Float) -> Any! { return 0 }
+}
+
+class D {
+  init!() {}
 }
 
 func returningIUO() -> Int! { return 1 }
@@ -43,6 +50,22 @@ func warnIUOToAnyCoercion(_ a: Int!, _ b: Any?!) {
   // expected-warning@-4 {{expression implicitly coerced from 'Any??' to 'Any'}}
   // expected-note@-5 {{force-unwrap the value to avoid this warning}}{{27-27=!!}}
   // expected-note@-6 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{27-27= as Any}}
+  _ = takeAny(C()[0], C()[1.0]) // expected-warning {{expression implicitly coerced from 'Int?' to 'Any'}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}{{21-21= ?? <#default value#>}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{21-21=!}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{21-21= as Any}}
+  // expected-warning@-4 {{expression implicitly coerced from 'Any?' to 'Any'}}
+  // expected-note@-5 {{provide a default value to avoid this warning}}{{31-31= ?? <#default value#>}}
+  // expected-note@-6 {{force-unwrap the value to avoid this warning}}{{31-31=!}}
+  // expected-note@-7 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{31-31= as Any}}
+  _ = takeAny(D(), D()) // expected-warning {{expression implicitly coerced from 'D?' to 'Any'}}
+  // expected-note@-1 {{provide a default value to avoid this warning}}{{18-18= ?? <#default value#>}}
+  // expected-note@-2 {{force-unwrap the value to avoid this warning}}{{18-18=!}}
+  // expected-note@-3 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{18-18= as Any}}
+  // expected-warning@-4 {{expression implicitly coerced from 'D?' to 'Any'}}
+  // expected-note@-5 {{provide a default value to avoid this warning}}{{23-23= ?? <#default value#>}}
+  // expected-note@-6 {{force-unwrap the value to avoid this warning}}{{23-23=!}}
+  // expected-note@-7 {{explicitly cast to 'Any' with 'as Any' to silence this warning}}{{23-23= as Any}}
 
   _ = takeAny(a as Any, b as Any)
 }


### PR DESCRIPTION
Conditionalize warnings for IUO-to-Any coercion on Swift version.
These warnings are turning out to be pretty noisy for code that
declares IUOs (e.g. for @IBOutlets) and then passes them to
Objective-C APIs with parameters declared as _Nonnull id.

Since we bridge non-nil values successfully in most cases, and
previuosly written and correctly executing code is either not seeing
nil values passed in or are handling the nil (which is bridged as
NSNull), it seems like a nuisance to warn about these for existing
Swift versions.

We'll conditionalize the warning, and then users can deal with these
when moving to the new language version.

Fixes: rdar://problem/39886178