### PR TITLE
[func-sig-opts][+0->+1] Rename OwnershipChecker.h => OwnershipUtils.h

### DIFF
--- a/include/swift/SIL/OwnershipUtils.h
+++ b/include/swift/SIL/OwnershipUtils.h
@@ -1,8 +1,8 @@
-//===--- OwnershipChecker.h -------------------------------------*- C++ -*-===//
+//===--- OwnershipUtils.h ------------------------------------*- C++ -*----===//
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -10,11 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_SIL_OWNERSHIPCHECKER_H
-#define SWIFT_SIL_OWNERSHIPCHECKER_H
+#ifndef SWIFT_SIL_OWNERSHIPUTILS_H
+#define SWIFT_SIL_OWNERSHIPUTILS_H
 
-#include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
 
 namespace swift {
 
@@ -48,6 +48,6 @@ struct OwnershipChecker {
   bool checkValue(SILValue Value);
 };
 
-} // end swift namespace
+} // namespace swift
 
 #endif

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -26,7 +26,7 @@
 #include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SIL/Dominance.h"
 #include "swift/SIL/DynamicCasts.h"
-#include "swift/SIL/OwnershipChecker.h"
+#include "swift/SIL/OwnershipUtils.h"
 #include "swift/SIL/PrettyStackTrace.h"
 #include "swift/SIL/Projection.h"
 #include "swift/SIL/SILBuiltinVisitor.h"

--- a/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
+++ b/lib/SILOptimizer/Mandatory/SemanticARCOpts.cpp
@@ -11,10 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "sil-semantic-arc-opts"
-#include "swift/SIL/OwnershipChecker.h"
+#include "swift/SIL/BasicBlockUtils.h"
+#include "swift/SIL/OwnershipUtils.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILInstruction.h"
-#include "swift/SIL/BasicBlockUtils.h"
 #include "swift/SILOptimizer/Analysis/PostOrderAnalysis.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"


### PR DESCRIPTION
I am going to be expanding this to contain more general utilities so naming the
file OwnershipChecker.h really doesn't make sense.

rdar://38196046
