### PR TITLE
[Migrator] Apply fixit coercing IUO to Any

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2842,6 +2842,9 @@ NOTE(force_optional_to_any,none,
 NOTE(silence_optional_to_any,none,
      "explicitly cast to %0 with '%1' to silence this warning",
      (Type, StringRef))
+NOTE(silence_implicitly_unwrapped_optional_to_any,none,
+     "explicitly cast to %0 with '%1' to silence this warning",
+     (Type, StringRef))
 WARNING(optional_in_string_interpolation_segment,none,
         "string interpolation produces a debug description for an optional "
         "value; did you mean to make this explicit?",

--- a/include/swift/Migrator/FixitFilter.h
+++ b/include/swift/Migrator/FixitFilter.h
@@ -133,7 +133,8 @@ struct FixitFilter {
         Info.ID == diag::missing_unknown_case.ID ||
         Info.ID == diag::paren_void_probably_void.ID ||
         Info.ID == diag::make_decl_objc.ID ||
-        Info.ID == diag::optional_req_nonobjc_near_match_add_objc.ID)
+        Info.ID == diag::optional_req_nonobjc_near_match_add_objc.ID ||
+        Info.ID == diag::silence_implicitly_unwrapped_optional_to_any.ID)
       return true;
 
     return false;

--- a/test/Migrator/iuo_any_coercion.swift
+++ b/test/Migrator/iuo_any_coercion.swift
@@ -1,0 +1,9 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -api-diff-data-file %S/Inputs/API.json -emit-migrated-file-path %t/iuo_any_coercion.swift.result -emit-remap-file-path %t/iuo_any_coercion.swift.remap -o /dev/null
+// RUN: diff -u %S/iuo_any_coercion.swift.expected %t/iuo_any_coercion.swift.result
+
+let x: Int! = 1
+let _: Any = x
+
+let y: Int? = 1
+let _: Any = y

--- a/test/Migrator/iuo_any_coercion.swift.expected
+++ b/test/Migrator/iuo_any_coercion.swift.expected
@@ -1,0 +1,9 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -api-diff-data-file %S/Inputs/API.json -emit-migrated-file-path %t/iuo_any_coercion.swift.result -emit-remap-file-path %t/iuo_any_coercion.swift.remap -o /dev/null
+// RUN: diff -u %S/iuo_any_coercion.swift.expected %t/iuo_any_coercion.swift.result
+
+let x: Int! = 1
+let _: Any = x as Any
+
+let y: Int? = 1
+let _: Any = y


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR makes the migrator automatically add `as Any` coercions when the base type is an implicitly unwrapped optional.

Fixes rdar://40050875