### PR TITLE
Allowing forming WritableKeyPath to read-only value in Swift 3/4.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -4036,8 +4036,19 @@ ConstraintSystem::simplifyKeyPathConstraint(Type keyPathTy,
       // get any special power from being formed in certain contexts, such
       // as the ability to assign to `let`s in initialization contexts, so
       // we pass null for the DC to `isSettable` here.)
-      if (!storage->isSettable(nullptr)
-          || !storage->isSetterAccessibleFrom(DC)) {
+      if (!getASTContext().isSwiftVersionAtLeast(5)) {
+        // As a source-compatibility measure, continue to allow
+        // WritableKeyPaths to be formed in the same conditions we did
+        // in previous releases even if we should not be able to set
+        // the value in this context.
+        if (!storage->isSettable(DC)) {
+          // A non-settable component makes the key path read-only, unless
+          // a reference-writable component shows up later.
+          capability = ReadOnly;
+          continue;
+        }
+      } else if (!storage->isSettable(nullptr)
+                 || !storage->isSetterAccessibleFrom(DC)) {
         // A non-settable component makes the key path read-only, unless
         // a reference-writable component shows up later.
         capability = ReadOnly;

--- a/test/Constraints/Inputs/keypath.swift
+++ b/test/Constraints/Inputs/keypath.swift
@@ -1,0 +1,3 @@
+class C {
+  fileprivate(set) var i = 0
+}

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift %S/Inputs/keypath.swift -primary-file %s
+
+struct S {
+  let i: Int
+
+  init() {
+    let _: WritableKeyPath<S, Int> = \.i // no error for Swift 3/4
+  }
+}
+
+func test() {
+  let _: WritableKeyPath<C, Int> = \.i // no error for Swift 3/4
+}

--- a/test/Constraints/keypath_swift_5.swift
+++ b/test/Constraints/keypath_swift_5.swift
@@ -1,0 +1,13 @@
+// RUN: %target-typecheck-verify-swift %S/Inputs/keypath.swift -primary-file %s -swift-version 5
+
+struct S {
+  let i: Int
+
+  init() {
+    let _: WritableKeyPath<S, Int> = \.i // expected-error {{type of expression is ambiguous without more context}}
+  }
+}
+
+func test() {
+  let _: WritableKeyPath<C, Int> = \.i // expected-error {{type of expression is ambiguous without more context}}
+}

--- a/test/expr/unary/keypath/keypath.swift
+++ b/test/expr/unary/keypath/keypath.swift
@@ -514,8 +514,9 @@ struct VisibilityTesting {
       toHaveType: Exactly<WritableKeyPath<VisibilityTesting, Int>>.self)
     expect(&yRef,
       toHaveType: Exactly<WritableKeyPath<VisibilityTesting, Int>>.self)
+    // Allow WritableKeyPath for Swift 3/4 only.
     expect(&zRef,
-      toHaveType: Exactly<KeyPath<VisibilityTesting, Int>>.self)
+      toHaveType: Exactly<WritableKeyPath<VisibilityTesting, Int>>.self)
   }
 
   func inPrivateContext() {
@@ -536,8 +537,9 @@ struct VisibilityTesting2 {
     var xRef = \VisibilityTesting.x
     var yRef = \VisibilityTesting.y
     var zRef = \VisibilityTesting.z
+    // Allow WritableKeyPath for Swift 3/4 only.
     expect(&xRef,
-      toHaveType: Exactly<KeyPath<VisibilityTesting, Int>>.self)
+      toHaveType: Exactly<WritableKeyPath<VisibilityTesting, Int>>.self)
     expect(&yRef,
       toHaveType: Exactly<WritableKeyPath<VisibilityTesting, Int>>.self)
     expect(&zRef,


### PR DESCRIPTION
We inadvertantly allowed this in the past, so continue to do so when
compiling in Swift 3/4 mode to avoid suddenly breaking existing code.

The diagnostic here is pretty bad, and I've opened issues for that as
well as providing some kind of deprecation warning for this so that
even under Swift 3/4 mode we alert users that this is unsupported.

rdar://problem/39802797
