### PR TITLE
[4.2-04-30-2018] IRGen: Make sure we compare equal units in type size…

### DIFF
--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -4017,7 +4017,7 @@ void IRGenSILFunction::visitAllocStackInst(swift::AllocStackInst *i) {
       return;
 
     auto &DL = IGM.DataLayout;
-    if (DL.getTypeSizeInBits(AI->getAllocatedType()) < DL.getPointerSize())
+    if (DL.getTypeSizeInBits(AI->getAllocatedType()) < DL.getPointerSizeInBits())
       return;
 
     auto *BC = Builder.CreateBitCast(AI, IGM.OpaquePtrTy->getPointerTo());

--- a/test/IRGen/alloc_stack.swift
+++ b/test/IRGen/alloc_stack.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -primary-file %s -emit-ir | %FileCheck %s
+
+// REQUIRES: CPU=x86_64
+
+class Foobar {
+  init() {
+    var a : Bool = true
+  }
+}
+
+// Make sure we are mis-initializing the alloca.
+// CHECK-LABEL: define {{.*}}swiftcc %T11alloc_stack6FoobarC* @"$S11alloc_stack6FoobarCACycfc"(%T11alloc_stack6FoobarC* swiftself)
+// CHECK-NOT: store{{.*}}opaque
+// CHECK:  ret {{.*}}%0
+// CHECK:}
+


### PR DESCRIPTION
… comparison

This is in some code to initialize variables for the debugger.

From the original commit
"Zero-initialize uninitialized Dictionary variables for the debugger.

To avoid the debugger displaying garbage or having expressions crash
when inspecting an uninitialized dictionary variable, zero-initialize
the first word of the alloca at -Onone.
"

Unfortunately, we are comparing different quantities in that code.

rdar://40043512