### PR TITLE
[4.2-04-30] [migrator] Handle simple renames for TypeDecl

### DIFF
--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -295,7 +295,8 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
 
     // Simple rename.
     if (auto CI = dyn_cast<CommonDiffItem>(Item)) {
-      if (CI->NodeKind == SDKNodeKind::DeclVar && CI->isRename()) {
+      if (CI->isRename() && (CI->NodeKind == SDKNodeKind::DeclVar ||
+                             CI->NodeKind == SDKNodeKind::DeclType)) {
         Text = CI->getNewName();
         return true;
       }

--- a/test/Migrator/Inputs/API.json
+++ b/test/Migrator/Inputs/API.json
@@ -498,5 +498,16 @@
     "NewTypeName": "example",
     "SelfIndex": 0,
     "RemovedIndex": 1
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "TypeDecl",
+    "NodeAnnotation": "Rename",
+    "ChildIndex": "0",
+    "LeftUsr": "c:objc(cs)BarBaseNested",
+    "LeftComment": "BarBaseNested",
+    "RightUsr": "",
+    "RightComment": "BarBase.Nested",
+    "ModuleName": "bar"
   }
 ]

--- a/test/Migrator/mock-sdk/Bar.framework/Headers/Bar.h
+++ b/test/Migrator/mock-sdk/Bar.framework/Headers/Bar.h
@@ -53,3 +53,8 @@ typedef NS_ENUM(long, FooComparisonResult) {
   FooOrderedSame,
   FooOrderedDescending
 };
+
+@interface BarBase
+@end
+@interface BarBaseNested
+@end

--- a/test/Migrator/rename.swift
+++ b/test/Migrator/rename.swift
@@ -17,6 +17,7 @@ func foo(_ b: BarForwardDeclaredClass) {
   barGlobalFuncOldName(2)
   _ = barGlobalVariableOldEnumElement
   _ = PropertyUserInterface.methodPlus()
+  let _: BarBaseNested
 }
 
 func foo1(_ b: BarForwardDeclaredClass) {

--- a/test/Migrator/rename.swift.expected
+++ b/test/Migrator/rename.swift.expected
@@ -17,6 +17,7 @@ func foo(_ b: BarForwardDeclaredClass) {
   barGlobalFuncNewName(newlabel: 2)
   _ = NewEnum.enumElement
   _ = PropertyUserInterface.newMethodPlus()
+  let _: BarBase.Nested
 }
 
 func foo1(_ b: BarForwardDeclaredClass) {


### PR DESCRIPTION
Cherry-pick #16460 to swift-4.2-branch-04-30-2018

---

Previously we only handle VarDecl, but it ought to work for types as
well.

rdar://problem/40073478