### PR TITLE
[4.2 04-30-2018] Allow synthesis of conformances in same-file extensions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2159,6 +2159,9 @@ NOTE(construct_raw_representable_from_unwrapped_value,none,
      "construct %0 from unwrapped %1 value", (Type, Type))
 
 // Derived conformances
+ERROR(swift3_cannot_synthesize_in_extension,none,
+      "implementation of %0 cannot be automatically synthesized in an extension "
+      "in Swift 3", (Type))
 ERROR(cannot_synthesize_init_in_extension_of_nonfinal,none,
       "implementation of %0 for non-final class cannot be automatically "
       "synthesized in extension because initializer requirement %1 can only be "

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2159,8 +2159,14 @@ NOTE(construct_raw_representable_from_unwrapped_value,none,
      "construct %0 from unwrapped %1 value", (Type, Type))
 
 // Derived conformances
-ERROR(cannot_synthesize_in_extension,none,
-      "implementation of %0 cannot be automatically synthesized in an extension", (Type))
+ERROR(cannot_synthesize_init_in_extension_of_nonfinal,none,
+      "implementation of %0 for non-final class cannot be automatically "
+      "synthesized in extension because initializer requirement %1 can only be "
+      "be satisfied by a 'required' initializer in the class definition",
+      (Type, DeclName))
+ERROR(cannot_synthesize_in_crossfile_extension,none,
+      "implementation of %0 cannot be automatically synthesized in an extension "
+      "in a different file to the type", (Type))
 
 ERROR(broken_case_iterable_requirement,none,
       "CaseIterable protocol is broken: unexpected requirement", ())

--- a/lib/Sema/DerivedConformanceCaseIterable.cpp
+++ b/lib/Sema/DerivedConformanceCaseIterable.cpp
@@ -42,7 +42,7 @@ static bool canDeriveConformance(NominalTypeDecl *type) {
 void deriveCaseIterable_enum_getter(AbstractFunctionDecl *funcDecl) {
   auto *parentDC = funcDecl->getDeclContext();
   auto *parentEnum = parentDC->getAsEnumOrEnumExtensionContext();
-  auto enumTy = parentEnum->getDeclaredTypeInContext();
+  auto enumTy = parentDC->getDeclaredTypeInContext();
   auto &C = parentDC->getASTContext();
 
   SmallVector<Expr *, 8> elExprs;

--- a/lib/Sema/DerivedConformanceCaseIterable.cpp
+++ b/lib/Sema/DerivedConformanceCaseIterable.cpp
@@ -79,14 +79,8 @@ static Type deriveCaseIterable_AllCases(DerivedConformance &derived) {
 
 ValueDecl *DerivedConformance::deriveCaseIterable(ValueDecl *requirement) {
   // Conformance can't be synthesized in an extension.
-  auto caseIterableProto =
-      TC.Context.getProtocol(KnownProtocolKind::CaseIterable);
-  auto caseIterableType = caseIterableProto->getDeclaredType();
-  if (Nominal != ConformanceDecl) {
-    TC.diagnose(ConformanceDecl->getLoc(), diag::cannot_synthesize_in_extension,
-                caseIterableType);
+  if (checkAndDiagnoseDisallowedContext())
     return nullptr;
-  }
 
   // Check that we can actually derive CaseIterable for this type.
   if (!canDeriveConformance(Nominal))
@@ -120,15 +114,8 @@ ValueDecl *DerivedConformance::deriveCaseIterable(ValueDecl *requirement) {
 }
 
 Type DerivedConformance::deriveCaseIterable(AssociatedTypeDecl *assocType) {
-  // Conformance can't be synthesized in an extension.
-  auto caseIterableProto =
-      TC.Context.getProtocol(KnownProtocolKind::CaseIterable);
-  auto caseIterableType = caseIterableProto->getDeclaredType();
-  if (Nominal != ConformanceDecl) {
-    TC.diagnose(ConformanceDecl->getLoc(), diag::cannot_synthesize_in_extension,
-                caseIterableType);
+  if (checkAndDiagnoseDisallowedContext())
     return nullptr;
-  }
 
   // We can only synthesize CaseIterable for enums.
   auto enumDecl = dyn_cast<EnumDecl>(Nominal);

--- a/lib/Sema/DerivedConformanceCaseIterable.cpp
+++ b/lib/Sema/DerivedConformanceCaseIterable.cpp
@@ -79,7 +79,7 @@ static Type deriveCaseIterable_AllCases(DerivedConformance &derived) {
 
 ValueDecl *DerivedConformance::deriveCaseIterable(ValueDecl *requirement) {
   // Conformance can't be synthesized in an extension.
-  if (checkAndDiagnoseDisallowedContext())
+  if (checkAndDiagnoseDisallowedContext(requirement))
     return nullptr;
 
   // Check that we can actually derive CaseIterable for this type.
@@ -114,7 +114,7 @@ ValueDecl *DerivedConformance::deriveCaseIterable(ValueDecl *requirement) {
 }
 
 Type DerivedConformance::deriveCaseIterable(AssociatedTypeDecl *assocType) {
-  if (checkAndDiagnoseDisallowedContext())
+  if (checkAndDiagnoseDisallowedContext(assocType))
     return nullptr;
 
   // We can only synthesize CaseIterable for enums.

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -1204,14 +1204,8 @@ ValueDecl *DerivedConformance::deriveEncodable(ValueDecl *requirement) {
     return nullptr;
   }
 
-  // Conformance can't be synthesized in an extension.
-  auto encodableProto = TC.Context.getProtocol(KnownProtocolKind::Encodable);
-  auto encodableType = encodableProto->getDeclaredType();
-  if (Nominal != ConformanceDecl) {
-    TC.diagnose(ConformanceDecl->getLoc(), diag::cannot_synthesize_in_extension,
-                encodableType);
+  if (checkAndDiagnoseDisallowedContext())
     return nullptr;
-  }
 
   // We're about to try to synthesize Encodable. If something goes wrong,
   // we'll have to output at least one error diagnostic because we returned
@@ -1230,9 +1224,10 @@ ValueDecl *DerivedConformance::deriveEncodable(ValueDecl *requirement) {
   // fake failures.
   auto diagnosticTransaction = DiagnosticTransaction(TC.Context.Diags);
   TC.diagnose(Nominal, diag::type_does_not_conform, Nominal->getDeclaredType(),
-              encodableType);
+              getProtocolType());
   TC.diagnose(requirement, diag::no_witnesses, diag::RequirementKind::Func,
-              requirement->getFullName(), encodableType, /*AddFixIt=*/false);
+              requirement->getFullName(), getProtocolType(),
+              /*AddFixIt=*/false);
 
   // Check other preconditions for synthesized conformance.
   // This synthesizes a CodingKeys enum if possible.
@@ -1255,14 +1250,8 @@ ValueDecl *DerivedConformance::deriveDecodable(ValueDecl *requirement) {
     return nullptr;
   }
 
-  // Conformance can't be synthesized in an extension.
-  auto decodableProto = TC.Context.getProtocol(KnownProtocolKind::Decodable);
-  auto decodableType = decodableProto->getDeclaredType();
-  if (Nominal != ConformanceDecl) {
-    TC.diagnose(ConformanceDecl->getLoc(), diag::cannot_synthesize_in_extension,
-                decodableType);
+  if (checkAndDiagnoseDisallowedContext())
     return nullptr;
-  }
 
   // We're about to try to synthesize Decodable. If something goes wrong,
   // we'll have to output at least one error diagnostic. We need to collate
@@ -1271,10 +1260,10 @@ ValueDecl *DerivedConformance::deriveDecodable(ValueDecl *requirement) {
   // background on this transaction.
   auto diagnosticTransaction = DiagnosticTransaction(TC.Context.Diags);
   TC.diagnose(Nominal, diag::type_does_not_conform, Nominal->getDeclaredType(),
-              decodableType);
+              getProtocolType());
   TC.diagnose(requirement, diag::no_witnesses,
               diag::RequirementKind::Constructor, requirement->getFullName(),
-              decodableType, /*AddFixIt=*/false);
+              getProtocolType(), /*AddFixIt=*/false);
 
   // Check other preconditions for synthesized conformance.
   // This synthesizes a CodingKeys enum if possible.

--- a/lib/Sema/DerivedConformanceCodable.cpp
+++ b/lib/Sema/DerivedConformanceCodable.cpp
@@ -1166,15 +1166,16 @@ static bool canSynthesize(DerivedConformance &derived, ValueDecl *requirement) {
       } else {
         auto *initializer =
           cast<ConstructorDecl>(result.front().getValueDecl());
+        auto conformanceDC = derived.getConformanceContext();
         if (!initializer->isDesignatedInit()) {
           // We must call a superclass's designated initializer.
           tc.diagnose(initializer,
                       diag::decodable_super_init_not_designated_here,
                       requirement->getFullName(), memberName);
           return false;
-        } else if (!initializer->isAccessibleFrom(classDecl)) {
+        } else if (!initializer->isAccessibleFrom(conformanceDC)) {
           // Cannot call an inaccessible method.
-          auto accessScope = initializer->getFormalAccessScope(classDecl);
+          auto accessScope = initializer->getFormalAccessScope(conformanceDC);
           tc.diagnose(initializer, diag::decodable_inaccessible_super_init_here,
                       requirement->getFullName(), memberName,
                       accessScope.accessLevelForDiagnostics());
@@ -1238,8 +1239,8 @@ ValueDecl *DerivedConformance::deriveEncodable(ValueDecl *requirement) {
   // synthesizing Encodable, we can cancel the transaction and get rid of the
   // fake failures.
   auto diagnosticTransaction = DiagnosticTransaction(TC.Context.Diags);
-  TC.diagnose(Nominal, diag::type_does_not_conform, Nominal->getDeclaredType(),
-              getProtocolType());
+  TC.diagnose(ConformanceDecl, diag::type_does_not_conform,
+              Nominal->getDeclaredType(), getProtocolType());
   TC.diagnose(requirement, diag::no_witnesses, diag::RequirementKind::Func,
               requirement->getFullName(), getProtocolType(),
               /*AddFixIt=*/false);
@@ -1274,8 +1275,8 @@ ValueDecl *DerivedConformance::deriveDecodable(ValueDecl *requirement) {
   // them in the right order -- see the comment in deriveEncodable for
   // background on this transaction.
   auto diagnosticTransaction = DiagnosticTransaction(TC.Context.Diags);
-  TC.diagnose(Nominal, diag::type_does_not_conform, Nominal->getDeclaredType(),
-              getProtocolType());
+  TC.diagnose(ConformanceDecl->getLoc(), diag::type_does_not_conform,
+              Nominal->getDeclaredType(), getProtocolType());
   TC.diagnose(requirement, diag::no_witnesses,
               diag::RequirementKind::Constructor, requirement->getFullName(),
               getProtocolType(), /*AddFixIt=*/false);

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -682,7 +682,7 @@ bool DerivedConformance::canDeriveEquatable(TypeChecker &tc,
 }
 
 ValueDecl *DerivedConformance::deriveEquatable(ValueDecl *requirement) {
-  if (checkAndDiagnoseDisallowedContext())
+  if (checkAndDiagnoseDisallowedContext(requirement))
     return nullptr;
 
   // Build the necessary decl.
@@ -1197,7 +1197,7 @@ ValueDecl *DerivedConformance::deriveHashable(ValueDecl *requirement) {
         return nullptr;
       }
 
-      if (checkAndDiagnoseDisallowedContext())
+      if (checkAndDiagnoseDisallowedContext(requirement))
         return nullptr;
 
       if (auto ED = dyn_cast<EnumDecl>(Nominal)) {

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -1043,16 +1043,15 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
   // ExpressibleByIntegerLiteral.
   if (!tc.conformsToProtocol(intType,
                              C.getProtocol(KnownProtocolKind::Hashable),
-                             derived.Nominal, None)) {
-    tc.diagnose(derived.Nominal->getLoc(),
-                diag::broken_int_hashable_conformance);
+                             parentDC, None)) {
+    tc.diagnose(derived.ConformanceDecl, diag::broken_int_hashable_conformance);
     return nullptr;
   }
 
   ProtocolDecl *intLiteralProto =
       C.getProtocol(KnownProtocolKind::ExpressibleByIntegerLiteral);
-  if (!tc.conformsToProtocol(intType, intLiteralProto, derived.Nominal, None)) {
-    tc.diagnose(derived.Nominal->getLoc(),
+  if (!tc.conformsToProtocol(intType, intLiteralProto, parentDC, None)) {
+    tc.diagnose(derived.ConformanceDecl,
                 diag::broken_int_integer_literal_convertible_conformance);
     return nullptr;
   }

--- a/lib/Sema/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformanceError.cpp
@@ -24,7 +24,6 @@
 #include "swift/AST/Types.h"
 
 using namespace swift;
-using namespace DerivedConformance;
 
 static void deriveBodyBridgedNSError_enum_nsErrorDomain(
               AbstractFunctionDecl *domainDecl) {
@@ -53,9 +52,8 @@ static void deriveBodyBridgedNSError_enum_nsErrorDomain(
   domainDecl->setBody(body);
 }
 
-static ValueDecl *deriveBridgedNSError_enum_nsErrorDomain(TypeChecker &tc,
-                                                          Decl *parentDecl,
-                                                          EnumDecl *enumDecl) {
+static ValueDecl *
+deriveBridgedNSError_enum_nsErrorDomain(DerivedConformance &derived) {
   // enum SomeEnum {
   //   @derived
   //   static var _nsErrorDomain: String {
@@ -65,25 +63,24 @@ static ValueDecl *deriveBridgedNSError_enum_nsErrorDomain(TypeChecker &tc,
 
   // Note that for @objc enums the format is assumed to be "MyModule.SomeEnum".
   // If this changes, please change PrintAsObjC as well.
-  
-  ASTContext &C = tc.Context;
-  
+
+  ASTContext &C = derived.TC.Context;
+
   auto stringTy = C.getStringDecl()->getDeclaredType();
 
   // Define the property.
   VarDecl *propDecl;
   PatternBindingDecl *pbDecl;
-  std::tie(propDecl, pbDecl)
-    = declareDerivedProperty(tc, parentDecl, enumDecl, C.Id_nsErrorDomain,
-                             stringTy, stringTy, /*isStatic=*/true,
-                             /*isFinal=*/true);
+  std::tie(propDecl, pbDecl) = derived.declareDerivedProperty(
+      C.Id_nsErrorDomain, stringTy, stringTy, /*isStatic=*/true,
+      /*isFinal=*/true);
 
   // Define the getter.
-  auto getterDecl =
-    addGetterToReadOnlyDerivedProperty(tc, propDecl, stringTy);
+  auto getterDecl = derived.addGetterToReadOnlyDerivedProperty(
+      derived.TC, propDecl, stringTy);
   getterDecl->setBodySynthesizer(&deriveBodyBridgedNSError_enum_nsErrorDomain);
 
-  auto dc = cast<IterableDeclContext>(parentDecl);
+  auto dc = cast<IterableDeclContext>(derived.ConformanceDecl);
   dc->addMember(getterDecl);
   dc->addMember(propDecl);
   dc->addMember(pbDecl);
@@ -91,19 +88,13 @@ static ValueDecl *deriveBridgedNSError_enum_nsErrorDomain(TypeChecker &tc,
   return propDecl;
 }
 
-ValueDecl *DerivedConformance::deriveBridgedNSError(TypeChecker &tc,
-                                                    Decl *parentDecl,
-                                                    NominalTypeDecl *type,
-                                                    ValueDecl *requirement) {
-  if (!isa<EnumDecl>(type))
+ValueDecl *DerivedConformance::deriveBridgedNSError(ValueDecl *requirement) {
+  if (!isa<EnumDecl>(Nominal))
     return nullptr;
 
-  auto enumType = cast<EnumDecl>(type);
+  if (requirement->getBaseName() == TC.Context.Id_nsErrorDomain)
+    return deriveBridgedNSError_enum_nsErrorDomain(*this);
 
-  if (requirement->getBaseName() == tc.Context.Id_nsErrorDomain)
-    return deriveBridgedNSError_enum_nsErrorDomain(tc, parentDecl, enumType);
-
-  tc.diagnose(requirement->getLoc(),
-              diag::broken_errortype_requirement);
+  TC.diagnose(requirement->getLoc(), diag::broken_errortype_requirement);
   return nullptr;
 }

--- a/lib/Sema/DerivedConformanceError.cpp
+++ b/lib/Sema/DerivedConformanceError.cpp
@@ -80,10 +80,7 @@ deriveBridgedNSError_enum_nsErrorDomain(DerivedConformance &derived) {
       derived.TC, propDecl, stringTy);
   getterDecl->setBodySynthesizer(&deriveBodyBridgedNSError_enum_nsErrorDomain);
 
-  auto dc = cast<IterableDeclContext>(derived.ConformanceDecl);
-  dc->addMember(getterDecl);
-  dc->addMember(propDecl);
-  dc->addMember(pbDecl);
+  derived.addMembersToConformanceContext({getterDecl, propDecl, pbDecl});
 
   return propDecl;
 }

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -383,6 +383,19 @@ bool DerivedConformance::checkAndDiagnoseDisallowedContext(
     allowCrossfileExtensions = ED && ED->hasOnlyCasesWithoutAssociatedValues();
   }
 
+  if (TC.Context.isSwiftVersion3()) {
+    // In Swift 3, a 'private' property can't be accessed in any extensions, so
+    // we can't synthesize anything that uses them. Thus, we stick to the old
+    // rule for synthesis, which is never in an extension except for the
+    // Equatable/Hashable cases mentioned above.
+    if (!allowCrossfileExtensions && Nominal != ConformanceDecl) {
+      TC.diagnose(ConformanceDecl->getLoc(),
+                  diag::swift3_cannot_synthesize_in_extension,
+                  getProtocolType());
+      return true;
+    }
+  }
+
   if (!allowCrossfileExtensions &&
       Nominal->getModuleScopeContext() !=
           getConformanceContext()->getModuleScopeContext()) {

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -27,8 +27,24 @@ DerivedConformance::DerivedConformance(TypeChecker &tc, Decl *conformanceDecl,
                                        ProtocolDecl *protocol)
     : TC(tc), ConformanceDecl(conformanceDecl), Nominal(nominal),
       Protocol(protocol) {
-  assert(cast<DeclContext>(conformanceDecl)
+  assert(getConformanceContext()
              ->getAsNominalTypeOrNominalTypeExtensionContext() == nominal);
+}
+
+DeclContext *DerivedConformance::getConformanceContext() const {
+  return cast<DeclContext>(ConformanceDecl);
+}
+
+void DerivedConformance::addMembersToConformanceContext(
+    ArrayRef<Decl *> children) {
+  auto IDC = cast<IterableDeclContext>(ConformanceDecl);
+  for (auto child : children) {
+    IDC->addMember(child);
+  }
+}
+
+Type DerivedConformance::getProtocolType() const {
+  return Protocol->getDeclaredType();
 }
 
 bool DerivedConformance::derivesProtocolConformance(TypeChecker &TC,

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -67,7 +67,7 @@ public:
   ///
   /// \return True if the type can implicitly derive a conformance for the
   /// given protocol.
-  static bool derivesProtocolConformance(TypeChecker &tc,
+  static bool derivesProtocolConformance(TypeChecker &tc, DeclContext *DC,
                                          NominalTypeDecl *nominal,
                                          ProtocolDecl *protocol);
 
@@ -120,7 +120,8 @@ public:
   /// associated values, and for structs with all-Equatable stored properties.
   ///
   /// \returns True if the requirement can be derived.
-  static bool canDeriveEquatable(TypeChecker &tc, NominalTypeDecl *type);
+  static bool canDeriveEquatable(TypeChecker &tc, DeclContext *DC,
+                                 NominalTypeDecl *type);
 
   /// Derive an Equatable requirement for a type.
   ///

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -21,194 +21,160 @@
 #include <utility>
 
 namespace swift {
-  class Decl;
-  class DeclRefExpr;
-  class AccessorDecl;
-  class NominalTypeDecl;
-  class PatternBindingDecl;
-  class Type;
-  class TypeChecker;
-  class ValueDecl;
-  class VarDecl;
-  
-namespace DerivedConformance {
+class Decl;
+class DeclRefExpr;
+class AccessorDecl;
+class NominalTypeDecl;
+class PatternBindingDecl;
+class Type;
+class TypeChecker;
+class ValueDecl;
+class VarDecl;
 
-/// True if the type can implicitly derive a conformance for the given protocol.
-///
-/// If true, explicit conformance checking will synthesize implicit declarations
-/// for requirements of the protocol that are not satisfied by the type's
-/// explicit members.
-///
-/// \param tc The type checker.
-///
-/// \param nominal The nominal type for which we are determining whether to
-/// derive a witness.
-///
-/// \param protocol The protocol whose requirements are being derived.
-///
-/// \return True if the type can implicitly derive a conformance for the given
-/// protocol.
-bool derivesProtocolConformance(TypeChecker &tc,
-                                NominalTypeDecl *nominal,
-                                ProtocolDecl *protocol);
+class DerivedConformance {
+public:
+  TypeChecker &TC;
+  Decl *ConformanceDecl;
+  NominalTypeDecl *Nominal;
+  ProtocolDecl *Protocol;
 
-/// Determine the derivable requirement that would satisfy the given
-/// requirement, if there is one.
-///
-/// \param tc The type checker.
-///
-/// \param nominal The nominal type for which we are determining whether to
-/// derive a witness.
-///
-/// \param requirement The requirement for which we are checking for a
-/// derivation. This requirement need not be within a derivable protocol,
-/// because derivable requirements can get restated in inherited unrelated or
-/// unrelated protocols.
-///
-/// \returns The requirement whose witness could be derived to potentially
-/// satisfy this given requirement, or NULL if there is no such requirement.
-ValueDecl *getDerivableRequirement(TypeChecker &tc,
-                                   NominalTypeDecl *nominal,
-                                   ValueDecl *requirement);
+  DerivedConformance(TypeChecker &tc, Decl *conformanceDecl,
+                     NominalTypeDecl *nominal, ProtocolDecl *protocol);
 
+  /// True if the type can implicitly derive a conformance for the given
+  /// protocol.
+  ///
+  /// If true, explicit conformance checking will synthesize implicit
+  /// declarations for requirements of the protocol that are not satisfied by
+  /// the type's explicit members.
+  ///
+  /// \param tc The type checker.
+  ///
+  /// \param nominal The nominal type for which we are determining whether to
+  /// derive a witness.
+  ///
+  /// \param protocol The protocol whose requirements are being derived.
+  ///
+  /// \return True if the type can implicitly derive a conformance for the
+  /// given protocol.
+  static bool derivesProtocolConformance(TypeChecker &tc,
+                                         NominalTypeDecl *nominal,
+                                         ProtocolDecl *protocol);
 
-/// Derive a CaseIterable requirement for an enum if it has no associated
-/// values for any of its cases.
-///
-/// \returns the derived member, which will also be added to the type.
-ValueDecl *deriveCaseIterable(TypeChecker &tc,
-                              Decl *parentDecl,
-                              NominalTypeDecl *type,
-                              ValueDecl *requirement);
+  /// Determine the derivable requirement that would satisfy the given
+  /// requirement, if there is one.
+  ///
+  /// \param tc The type checker.
+  ///
+  /// \param nominal The nominal type for which we are determining whether to
+  /// derive a witness.
+  ///
+  /// \param requirement The requirement for which we are checking for a
+  /// derivation. This requirement need not be within a derivable protocol,
+  /// because derivable requirements can get restated in inherited unrelated
+  /// or unrelated protocols.
+  ///
+  /// \returns The requirement whose witness could be derived to potentially
+  /// satisfy this given requirement, or NULL if there is no such requirement.
+  static ValueDecl *getDerivableRequirement(TypeChecker &tc,
+                                            NominalTypeDecl *nominal,
+                                            ValueDecl *requirement);
 
-/// Derive a CaseIterable type witness for an enum if it has no associated
-/// values for any of its cases.
-///
-/// \returns the derived member, which will also be added to the type.
-Type deriveCaseIterable(TypeChecker &tc,
-                        Decl *parentDecl,
-                        NominalTypeDecl *type,
-                        AssociatedTypeDecl *assocType);
+  /// Derive a CaseIterable requirement for an enum if it has no associated
+  /// values for any of its cases.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  ValueDecl *deriveCaseIterable(ValueDecl *requirement);
 
-/// Derive a RawRepresentable requirement for an enum, if it has a valid
-/// raw type and raw values for all of its cases.
-///
-/// \returns the derived member, which will also be added to the type.
-ValueDecl *deriveRawRepresentable(TypeChecker &tc,
-                                  Decl *parentDecl,
-                                  NominalTypeDecl *type,
-                                  ValueDecl *requirement);
+  /// Derive a CaseIterable type witness for an enum if it has no associated
+  /// values for any of its cases.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  Type deriveCaseIterable(AssociatedTypeDecl *assocType);
 
-/// Derive a RawRepresentable type witness for an enum, if it has a valid
-/// raw type and raw values for all of its cases.
-///
-/// \returns the derived member, which will also be added to the type.
-Type deriveRawRepresentable(TypeChecker &tc,
-                            Decl *parentDecl,
-                            NominalTypeDecl *type,
-                            AssociatedTypeDecl *assocType);
+  /// Derive a RawRepresentable requirement for an enum, if it has a valid
+  /// raw type and raw values for all of its cases.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  ValueDecl *deriveRawRepresentable(ValueDecl *requirement);
 
-/// Determine if an Equatable requirement can be derived for a type.
-///
-/// This is implemented for enums without associated values or all-Equatable
-/// associated values, and for structs with all-Equatable stored properties.
-///
-/// \returns True if the requirement can be derived.
-bool canDeriveEquatable(TypeChecker &tc,
-                        NominalTypeDecl *type,
-                        ValueDecl *requirement);
+  /// Derive a RawRepresentable type witness for an enum, if it has a valid
+  /// raw type and raw values for all of its cases.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  Type deriveRawRepresentable(AssociatedTypeDecl *assocType);
 
-/// Derive an Equatable requirement for a type.
-///
-/// This is implemented for enums without associated values or all-Equatable
-/// associated values, and for structs with all-Equatable stored properties.
-///
-/// \returns the derived member, which will also be added to the type.
-ValueDecl *deriveEquatable(TypeChecker &tc,
-                           Decl *parentDecl,
-                           NominalTypeDecl *type,
-                           ValueDecl *requirement);
+  /// Determine if an Equatable requirement can be derived for a type.
+  ///
+  /// This is implemented for enums without associated values or all-Equatable
+  /// associated values, and for structs with all-Equatable stored properties.
+  ///
+  /// \returns True if the requirement can be derived.
+  static bool canDeriveEquatable(TypeChecker &tc, NominalTypeDecl *type);
 
-/// Determine if a Hashable requirement can be derived for a type.
-///
-/// This is implemented for enums without associated values or all-Hashable
-/// associated values, and for structs with all-Hashable stored properties.
-///
-/// \returns True if the requirement can be derived.
-bool canDeriveHashable(TypeChecker &tc,
-                       NominalTypeDecl *type,
-                       ValueDecl *requirement);
-  
-/// Derive a Hashable requirement for a type.
-///
-/// This is implemented for enums without associated values or all-Hashable
-/// associated values, and for structs with all-Hashable stored properties.
-///
-/// \returns the derived member, which will also be added to the type.
-ValueDecl *deriveHashable(TypeChecker &tc,
-                          Decl *parentDecl,
-                          NominalTypeDecl *type,
-                          ValueDecl *requirement);
+  /// Derive an Equatable requirement for a type.
+  ///
+  /// This is implemented for enums without associated values or all-Equatable
+  /// associated values, and for structs with all-Equatable stored properties.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  ValueDecl *deriveEquatable(ValueDecl *requirement);
 
-/// Derive a _BridgedNSError requirement for an @objc enum type.
-///
-/// \returns the derived member, which will also be added to the type.
-ValueDecl *deriveBridgedNSError(TypeChecker &tc,
-                                Decl *parentDecl,
-                                NominalTypeDecl *type,
-                                ValueDecl *requirement);
+  /// Determine if a Hashable requirement can be derived for a type.
+  ///
+  /// This is implemented for enums without associated values or all-Hashable
+  /// associated values, and for structs with all-Hashable stored properties.
+  ///
+  /// \returns True if the requirement can be derived.
+  static bool canDeriveHashable(TypeChecker &tc, NominalTypeDecl *type);
 
-/// Derive a CodingKey requirement for an enum type.
-///
-/// \returns the derived member, which will also be added to the type.
-ValueDecl *deriveCodingKey(TypeChecker &tc,
-                           Decl *parentDecl,
-                           NominalTypeDecl *type,
-                           ValueDecl *requirement);
+  /// Derive a Hashable requirement for a type.
+  ///
+  /// This is implemented for enums without associated values or all-Hashable
+  /// associated values, and for structs with all-Hashable stored properties.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  ValueDecl *deriveHashable(ValueDecl *requirement);
 
-/// Derive an Encodable requirement for a struct type.
-///
-/// \returns the derived member, which will also be added to the type.
-ValueDecl *deriveEncodable(TypeChecker &tc,
-                           Decl *parentDecl,
-                           NominalTypeDecl *type,
-                           ValueDecl *requirement);
+  /// Derive a _BridgedNSError requirement for an @objc enum type.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  ValueDecl *deriveBridgedNSError(ValueDecl *requirement);
 
-/// Derive a Decodable requirement for a struct type.
-///
-/// \returns the derived member, which will also be added to the type.
-ValueDecl *deriveDecodable(TypeChecker &tc,
-                           Decl *parentDecl,
-                           NominalTypeDecl *type,
-                           ValueDecl *requirement);
+  /// Derive a CodingKey requirement for an enum type.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  ValueDecl *deriveCodingKey(ValueDecl *requirement);
 
-/// Declare a read-only property.
-std::pair<VarDecl *, PatternBindingDecl *>
-declareDerivedProperty(TypeChecker &tc,
-                       Decl *parentDecl,
-                       NominalTypeDecl *typeDecl,
-                       Identifier name,
-                       Type propertyInterfaceType,
-                       Type propertyContextType,
-                       bool isStatic,
-                       bool isFinal);
+  /// Derive an Encodable requirement for a struct type.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  ValueDecl *deriveEncodable(ValueDecl *requirement);
 
-/// Add a getter to a derived property.  The property becomes read-only.
-AccessorDecl *addGetterToReadOnlyDerivedProperty(TypeChecker &tc,
-                                                 VarDecl *property,
-                                                 Type propertyContextType);
+  /// Derive a Decodable requirement for a struct type.
+  ///
+  /// \returns the derived member, which will also be added to the type.
+  ValueDecl *deriveDecodable(ValueDecl *requirement);
 
-/// Declare a getter for a derived property.
-/// The getter will not be added to the property yet.
-AccessorDecl *declareDerivedPropertyGetter(TypeChecker &tc,
-                                           VarDecl *property,
-                                           Type propertyContextType);
+  /// Declare a read-only property.
+  std::pair<VarDecl *, PatternBindingDecl *>
+  declareDerivedProperty(Identifier name, Type propertyInterfaceType,
+                         Type propertyContextType, bool isStatic, bool isFinal);
 
-/// Build a reference to the 'self' decl of a derived function.
-DeclRefExpr *createSelfDeclRef(AbstractFunctionDecl *fn);
+  /// Add a getter to a derived property.  The property becomes read-only.
+  static AccessorDecl *
+  addGetterToReadOnlyDerivedProperty(TypeChecker &tc, VarDecl *property,
+                                     Type propertyContextType);
 
-}
-  
+  /// Declare a getter for a derived property.
+  /// The getter will not be added to the property yet.
+  static AccessorDecl *declareDerivedPropertyGetter(TypeChecker &tc,
+                                                    VarDecl *property,
+                                                    Type propertyContextType);
+
+  /// Build a reference to the 'self' decl of a derived function.
+  static DeclRefExpr *createSelfDeclRef(AbstractFunctionDecl *fn);
+};
 }
 
 #endif

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -184,6 +184,10 @@ public:
 
   /// Build a reference to the 'self' decl of a derived function.
   static DeclRefExpr *createSelfDeclRef(AbstractFunctionDecl *fn);
+
+  /// Returns true if this derivation is trying to use a context that isn't
+  /// appropriate for deriving.
+  bool checkAndDiagnoseDisallowedContext() const;
 };
 }
 

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -41,6 +41,16 @@ public:
   DerivedConformance(TypeChecker &tc, Decl *conformanceDecl,
                      NominalTypeDecl *nominal, ProtocolDecl *protocol);
 
+  /// Retrieve the context in which the conformance is declared (either the
+  /// nominal type, or an extension of it) as a \c DeclContext.
+  DeclContext *getConformanceContext() const;
+
+  /// Add \c children as members of the context that declares the conformance.
+  void addMembersToConformanceContext(ArrayRef<Decl *> children);
+
+  /// Get the declared type of the protocol that this is conformance is for.
+  Type getProtocolType() const;
+
   /// True if the type can implicitly derive a conformance for the given
   /// protocol.
   ///

--- a/lib/Sema/DerivedConformances.h
+++ b/lib/Sema/DerivedConformances.h
@@ -187,7 +187,9 @@ public:
 
   /// Returns true if this derivation is trying to use a context that isn't
   /// appropriate for deriving.
-  bool checkAndDiagnoseDisallowedContext() const;
+  ///
+  /// \param synthesizing The decl that is being synthesized.
+  bool checkAndDiagnoseDisallowedContext(ValueDecl *synthesizing) const;
 };
 }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4667,11 +4667,12 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
     // Special case: explain that 'RawRepresentable' conformance
     // is implied for enums which already declare a raw type.
     if (auto enumDecl = dyn_cast<EnumDecl>(existingDecl)) {
-      if (diag.Protocol->isSpecificProtocol(KnownProtocolKind::RawRepresentable)
-          && DerivedConformance::derivesProtocolConformance(*this, enumDecl,
-                                                            diag.Protocol)
-          && enumDecl->hasRawType()
-          && enumDecl->getInherited()[0].getSourceRange().isValid()) {
+      if (diag.Protocol->isSpecificProtocol(
+              KnownProtocolKind::RawRepresentable) &&
+          DerivedConformance::derivesProtocolConformance(*this, enumDecl,
+                                                         diag.Protocol) &&
+          enumDecl->hasRawType() &&
+          enumDecl->getInherited()[0].getSourceRange().isValid()) {
         diagnose(enumDecl->getInherited()[0].getSourceRange().Start,
                  diag::enum_declares_rawrep_with_raw_type,
                  dc->getDeclaredInterfaceType(), enumDecl->getRawType());
@@ -4978,35 +4979,32 @@ ValueDecl *TypeChecker::deriveProtocolRequirement(DeclContext *DC,
   if (Decl->isInvalid())
     return nullptr;
 
+  DerivedConformance derived(*this, Decl, TypeDecl, protocol);
+
   switch (*knownKind) {
   case KnownProtocolKind::RawRepresentable:
-    return DerivedConformance::deriveRawRepresentable(*this, Decl,
-                                                      TypeDecl, Requirement);
+    return derived.deriveRawRepresentable(Requirement);
 
   case KnownProtocolKind::CaseIterable:
-    return DerivedConformance::deriveCaseIterable(*this, Decl,
-                                                  TypeDecl, Requirement);
+    return derived.deriveCaseIterable(Requirement);
 
   case KnownProtocolKind::Equatable:
-    return DerivedConformance::deriveEquatable(*this, Decl, TypeDecl,
-                                               Requirement);
-  
+    return derived.deriveEquatable(Requirement);
+
   case KnownProtocolKind::Hashable:
-    return DerivedConformance::deriveHashable(*this, Decl, TypeDecl,
-                                              Requirement);
-    
+    return derived.deriveHashable(Requirement);
+
   case KnownProtocolKind::BridgedNSError:
-    return DerivedConformance::deriveBridgedNSError(*this, Decl, TypeDecl,
-                                                    Requirement);
+    return derived.deriveBridgedNSError(Requirement);
 
   case KnownProtocolKind::CodingKey:
-    return DerivedConformance::deriveCodingKey(*this, Decl, TypeDecl, Requirement);
+    return derived.deriveCodingKey(Requirement);
 
   case KnownProtocolKind::Encodable:
-    return DerivedConformance::deriveEncodable(*this, Decl, TypeDecl, Requirement);
+    return derived.deriveEncodable(Requirement);
 
   case KnownProtocolKind::Decodable:
-    return DerivedConformance::deriveDecodable(*this, Decl, TypeDecl, Requirement);
+    return derived.deriveDecodable(Requirement);
 
   default:
     return nullptr;
@@ -5025,13 +5023,12 @@ Type TypeChecker::deriveTypeWitness(DeclContext *DC,
 
   auto Decl = DC->getInnermostDeclarationDeclContext();
 
+  DerivedConformance derived(*this, Decl, TypeDecl, protocol);
   switch (*knownKind) {
   case KnownProtocolKind::RawRepresentable:
-    return DerivedConformance::deriveRawRepresentable(*this, Decl,
-                                                      TypeDecl, AssocType);
+    return derived.deriveRawRepresentable(AssocType);
   case KnownProtocolKind::CaseIterable:
-    return DerivedConformance::deriveCaseIterable(*this, Decl,
-                                                  TypeDecl, AssocType);
+    return derived.deriveCaseIterable(AssocType);
   default:
     return nullptr;
   }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2903,7 +2903,7 @@ ResolveWitnessResult ConformanceChecker::resolveWitnessViaDerivation(
   // Find the declaration that derives the protocol conformance.
   NominalTypeDecl *derivingTypeDecl = nullptr;
   auto *nominal = Adoptee->getAnyNominal();
-  if (DerivedConformance::derivesProtocolConformance(TC, nominal, Proto))
+  if (DerivedConformance::derivesProtocolConformance(TC, DC, nominal, Proto))
     derivingTypeDecl = nominal;
 
   if (!derivingTypeDecl) {
@@ -3579,7 +3579,8 @@ static void diagnoseConformanceFailure(TypeChecker &TC, Type T,
   // conformance to RawRepresentable was inferred.
   if (auto enumDecl = T->getEnumOrBoundGenericEnum()) {
     if (Proto->isSpecificProtocol(KnownProtocolKind::RawRepresentable) &&
-        DerivedConformance::derivesProtocolConformance(TC, enumDecl, Proto) &&
+        DerivedConformance::derivesProtocolConformance(TC, DC, enumDecl,
+                                                       Proto) &&
         enumDecl->hasRawType()) {
 
       auto rawType = enumDecl->getRawType();
@@ -4669,7 +4670,7 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
     if (auto enumDecl = dyn_cast<EnumDecl>(existingDecl)) {
       if (diag.Protocol->isSpecificProtocol(
               KnownProtocolKind::RawRepresentable) &&
-          DerivedConformance::derivesProtocolConformance(*this, enumDecl,
+          DerivedConformance::derivesProtocolConformance(*this, dc, enumDecl,
                                                          diag.Protocol) &&
           enumDecl->hasRawType() &&
           enumDecl->getInherited()[0].getSourceRange().isValid()) {

--- a/lib/Sema/TypeCheckProtocolInference.cpp
+++ b/lib/Sema/TypeCheckProtocolInference.cpp
@@ -877,7 +877,7 @@ Type AssociatedTypeInference::computeDerivedTypeWitness(
 
   // Can we derive conformances for this protocol and adoptee?
   NominalTypeDecl *derivingTypeDecl = adoptee->getAnyNominal();
-  if (!DerivedConformance::derivesProtocolConformance(tc, derivingTypeDecl,
+  if (!DerivedConformance::derivesProtocolConformance(tc, dc, derivingTypeDecl,
                                                       proto))
     return Type();
 

--- a/test/IRGen/synthesized_conformance.swift
+++ b/test/IRGen/synthesized_conformance.swift
@@ -1,0 +1,55 @@
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-ir %s -swift-version 4 | %FileCheck %s
+
+struct Struct<T> {
+    var x: T
+}
+
+extension Struct: Equatable where T: Equatable {}
+extension Struct: Hashable where T: Hashable {}
+extension Struct: Codable where T: Codable {}
+
+enum Enum<T> {
+    case a(T), b(T)
+}
+
+extension Enum: Equatable where T: Equatable {}
+extension Enum: Hashable where T: Hashable {}
+
+final class Final<T> {
+    var x: T
+    init(x: T) { self.x = x }
+}
+
+extension Final: Encodable where T: Encodable {}
+extension Final: Decodable where T: Decodable {}
+
+class Nonfinal<T> {
+    var x: T
+    init(x: T) { self.x = x }
+}
+extension Nonfinal: Encodable where T: Encodable {}
+
+func doEquality<T: Equatable>(_: T) {}
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S23synthesized_conformance8equalityyyF"()
+public func equality() {
+    // CHECK: [[Struct_Equatable:%.*]] = call i8** @"$S23synthesized_conformance6StructVySiGACyxGs9EquatableAAsAFRzlWl"()
+    // CHECK-NEXT: call swiftcc void @"$S23synthesized_conformance10doEqualityyyxs9EquatableRzlF"(%swift.opaque* noalias nocapture {{%.*}}, %swift.type* {{%.*}}, i8** [[Struct_Equatable]])
+    doEquality(Struct(x: 1))
+    // CHECK: [[Enum_Equatable:%.*]] = call i8** @"$S23synthesized_conformance4EnumOySiGACyxGs9EquatableAAsAFRzlWl"()
+    // CHECK-NEXT: call swiftcc void @"$S23synthesized_conformance10doEqualityyyxs9EquatableRzlF"(%swift.opaque* noalias nocapture {{%.*}}, %swift.type* {{%.*}}, i8** [[Enum_Equatable]])
+    doEquality(Enum.a(1))
+}
+
+func doEncodable<T: Encodable>(_: T) {}
+// CHECK-LABEL: define{{( protected)?}} swiftcc void @"$S23synthesized_conformance9encodableyyF"()
+public func encodable() {
+    // CHECK: [[Struct_Encodable:%.*]] = call i8** @"$S23synthesized_conformance6StructVySiGACyxGs9EncodableAAs9DecodableRzsAFRzlWl"()
+    // CHECK-NEXT: call swiftcc void @"$S23synthesized_conformance11doEncodableyyxs0D0RzlF"(%swift.opaque* noalias nocapture {{%.*}}, %swift.type* {{%.*}}, i8** [[Struct_Encodable]])
+    doEncodable(Struct(x: 1))
+    // CHECK: [[Final_Encodable:%.*]] = call i8** @"$S23synthesized_conformance5FinalCySiGACyxGs9EncodableAAsAFRzlWl"()
+    // CHECK-NEXT: call swiftcc void @"$S23synthesized_conformance11doEncodableyyxs0D0RzlF"(%swift.opaque* noalias nocapture {{%.*}}, %swift.type* {{%.*}}, i8** [[Final_Encodable]])
+    doEncodable(Final(x: 1))
+    // CHECK: [[Nonfinal_Encodable:%.*]] = call i8** @"$S23synthesized_conformance8NonfinalCySiGACyxGs9EncodableAAsAFRzlWl"()
+    // CHECK-NEXT: call swiftcc void @"$S23synthesized_conformance11doEncodableyyxs0D0RzlF"(%swift.opaque* noalias nocapture {{%.*}}, %swift.type* {{%.*}}, i8** [[Nonfinal_Encodable]])
+    doEncodable(Nonfinal(x: 1))
+}

--- a/test/Interpreter/synthesized_extension_conformances.swift
+++ b/test/Interpreter/synthesized_extension_conformances.swift
@@ -1,0 +1,279 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift %s -o %t/a.out -module-name main -swift-version 4
+// RUN: %target-run %t/a.out
+
+// REQUIRES: executable_test
+// REQUIRES: objc_interop
+
+import Foundation
+
+#if FOUNDATION_XCTEST
+import XCTest
+class TestSuper : XCTestCase { }
+#else
+import StdlibUnittest
+class TestSuper { }
+#endif
+
+struct SInt: Codable, Equatable, Hashable {
+    var x: Int
+}
+struct SFloat {
+    var y: Float
+}
+extension SFloat: Equatable {}
+extension SFloat: Hashable {}
+extension SFloat: Codable {}
+
+struct SGeneric<T, U> {
+    var t: T
+    var u: U
+}
+extension SGeneric: Equatable where T: Equatable, U: Equatable {}
+extension SGeneric: Hashable where T: Hashable, U: Hashable {}
+extension SGeneric: Codable where T: Codable, U: Codable {}
+
+enum EGeneric<T> {
+    case a(T), b(Int), c
+}
+extension EGeneric: Equatable where T: Equatable {}
+extension EGeneric: Hashable where T: Hashable {}
+
+enum NoValues {
+    case a, b, c
+}
+extension NoValues: CaseIterable {}
+
+// Cache some values, and make them all have the same width (within a type) for
+// formatting niceness.
+let SIOne = SInt(x: 1)
+let SITwo = SInt(x: 2)
+
+let SFOne = SFloat(y: 1.0)
+let SFTwo = SFloat(y: 2.0)
+let SFInf = SFloat(y: .infinity)
+let SFNan = SFloat(y: .nan)
+
+let SGOneOne = SGeneric(t: SIOne, u: SFOne)
+let SGTwoOne = SGeneric(t: SITwo, u: SFOne)
+let SGTwoTwo = SGeneric(t: SITwo, u: SFTwo)
+let SGOneInf = SGeneric(t: SIOne, u: SFInf)
+let SGOneNan = SGeneric(t: SIOne, u: SFNan)
+
+let EGaOne: EGeneric<SInt> = .a(SIOne)
+let EGaTwo: EGeneric<SInt> = .a(SITwo)
+let EGbOne: EGeneric<SInt> = .b(1)
+let EGbTwo: EGeneric<SInt> = .b(2)
+let EGc___: EGeneric<SInt> = .c
+
+
+func debugDescription<T>(_ value: T) -> String {
+    if let debugDescribable = value as? CustomDebugStringConvertible {
+        return debugDescribable.debugDescription
+    } else if let describable = value as? CustomStringConvertible {
+        return describable.description
+    } else {
+        return "\(value)"
+    }
+}
+
+func testEquatableHashable<T: Equatable & Hashable>(cases: [Int: (T, T, Bool, Bool)]) {
+    for (testLine, (lhs, rhs, equal, hashEqual)) in cases {
+        expectEqual(lhs == rhs, equal,
+                    "\(#file):\(testLine) LHS <\(debugDescription(lhs))> == RHS <\(debugDescription(rhs))> doesn't match <\(equal)>")
+
+        let lhsHash = lhs.hashValue
+        let rhsHash = rhs.hashValue
+        expectEqual(lhsHash == rhsHash, hashEqual,
+                    "\(#file):\(testLine) LHS <\(debugDescription(lhs)).hashValue> (\(lhsHash)) == RHS <\(debugDescription(rhs)).hashValue> (\(rhsHash)) doesn't match <\(hashEqual)>")
+    }
+}
+
+class TestEquatableHashable : TestSuper {
+    lazy var int: [Int: (SInt, SInt, Bool, Bool)] = [
+      #line : (SIOne, SIOne, true, true),
+      #line : (SIOne, SITwo, false, false),
+      #line : (SITwo, SIOne, false, false),
+      #line : (SITwo, SITwo, true, true),
+    ]
+
+    func test_SInt() {
+        testEquatableHashable(cases: int)
+    }
+
+    lazy var float: [Int: (SFloat, SFloat, Bool, Bool)] = [
+      #line : (SFOne, SFOne, true, true),
+      #line : (SFOne, SFTwo, false, false),
+      #line : (SFTwo, SFOne, false, false),
+      #line : (SFTwo, SFTwo, true, true),
+
+      #line : (SFInf, SFInf, true, true),
+      #line : (SFInf, SFOne, false, false),
+
+      // A bit-based hasher is likely to hash these to the same thing.
+      #line : (SFNan, SFNan, false, true),
+      #line : (SFNan, SFOne, false, false),
+    ]
+
+    func test_SFloat() {
+        testEquatableHashable(cases: float)
+    }
+
+    lazy var generic: [Int: (SGeneric<SInt, SFloat>, SGeneric<SInt, SFloat>, Bool, Bool)] = [
+      #line : (SGOneOne, SGOneOne, true, true),
+      #line : (SGOneOne, SGTwoOne, false, false),
+      #line : (SGOneOne, SGTwoTwo, false, false),
+
+      #line : (SGTwoOne, SGTwoOne, true, true),
+      #line : (SGTwoOne, SGTwoTwo, false, false),
+
+      #line : (SGTwoTwo, SGTwoTwo, true, true),
+
+      #line : (SGOneInf, SGOneInf, true, true),
+      #line : (SGOneInf, SGOneOne, false, false),
+      #line : (SGOneInf, SGTwoOne, false, false),
+      #line : (SGOneInf, SGTwoTwo, false, false),
+
+      // As above, a bit-based hasher is likely to hash these to the same thing
+      #line : (SGOneNan, SGOneNan, false, true),
+      #line : (SGOneNan, SGOneOne, false, false),
+      #line : (SGOneNan, SGTwoOne, false, false),
+      #line : (SGOneNan, SGTwoTwo, false, false),
+      #line : (SGOneNan, SGOneInf, false, false)
+    ]
+
+    func test_SGeneric() {
+        testEquatableHashable(cases: generic)
+    }
+
+    lazy var egeneric: [Int: (EGeneric<SInt>, EGeneric<SInt>, Bool, Bool)] = [
+      #line : (EGaOne, EGaOne, true, true),
+      #line : (EGaOne, EGaTwo, false, false),
+      #line : (EGaOne, EGbOne, false, false),
+      #line : (EGaOne, EGbTwo, false, false),
+      #line : (EGaOne, EGc___, false, false),
+
+      #line : (EGbOne, EGaOne, false, false),
+      #line : (EGbOne, EGaTwo, false, false),
+      #line : (EGbOne, EGbOne, true, true),
+      #line : (EGbOne, EGbTwo, false, false),
+      #line : (EGbOne, EGc___, false, false),
+
+      #line : (EGc___, EGaOne, false, false),
+      #line : (EGc___, EGaTwo, false, false),
+      #line : (EGc___, EGbOne, false, false),
+      #line : (EGc___, EGbTwo, false, false),
+      #line : (EGc___, EGc___, true, true),
+    ]
+
+    func test_EGeneric() {
+        testEquatableHashable(cases: egeneric)
+    }
+}
+
+
+func expectRoundTripEquality<T : Codable>(of value: T, lineNumber: Int) where T : Equatable {
+    let inf = "INF", negInf = "-INF", nan = "NaN"
+    let encoder = JSONEncoder()
+    encoder.nonConformingFloatEncodingStrategy = .convertToString(positiveInfinity: inf,
+                                                                  negativeInfinity: negInf,
+                                                                  nan: nan)
+    let data: Data
+    do {
+        data = try encoder.encode(value)
+    } catch {
+        fatalError("\(#file):\(lineNumber): Unable to encode \(T.self) <\(debugDescription(value))>: \(error)")
+    }
+
+    let decoder = JSONDecoder()
+    decoder.nonConformingFloatDecodingStrategy = .convertFromString(positiveInfinity: inf,
+                                                                    negativeInfinity: negInf,
+                                                                    nan: nan)
+    let decoded: T
+    do {
+        decoded = try decoder.decode(T.self, from: data)
+    } catch {
+        fatalError("\(#file):\(lineNumber): Unable to decode \(T.self) <\(debugDescription(value))>: \(error)")
+    }
+
+    expectEqual(value, decoded, "\(#file):\(lineNumber): Decoded \(T.self) <\(debugDescription(decoded))> not equal to original <\(debugDescription(value))>")
+}
+class TestCodable : TestSuper {
+    lazy var int: [Int: SInt] = [
+      #line : SIOne,
+      #line : SITwo,
+    ]
+
+    func test_SInt() {
+        for (testLine, value) in int {
+            expectRoundTripEquality(of: value, lineNumber: testLine)
+        }
+    }
+
+    lazy var float: [Int : SFloat] = [
+      #line : SFOne,
+      #line : SFTwo,
+      #line : SFInf,
+      // This won't compare equal to itself
+      // #line : SFNan
+    ]
+    func test_SFloat() {
+        for (testLine, value) in float {
+            expectRoundTripEquality(of: value, lineNumber: testLine)
+        }
+    }
+
+    lazy var generic : [Int : SGeneric<SInt, SFloat>] = [
+      #line : SGOneOne,
+      #line : SGTwoOne,
+      #line : SGTwoTwo,
+      #line : SGOneInf,
+      // As above, this won't compare equal to itself
+      // #line : SGOneNan,
+    ]
+    func test_SGeneric() {
+        for (testLine, value) in generic {
+            expectRoundTripEquality(of: value, lineNumber: testLine)
+        }
+    }
+}
+
+class TestCaseIterable : TestSuper {
+    func test_allCases() {
+        expectEqual(NoValues.allCases, [.a, .b, .c])
+    }
+}
+
+#if !FOUNDATION_XCTEST
+var equatableHashable = [
+  "TestEquatableHashable.test_SInt": TestEquatableHashable.test_SInt,
+  "TestEquatableHashable.test_SFloat": TestEquatableHashable.test_SFloat,
+  "TestEquatableHashable.test_SGeneric": TestEquatableHashable.test_SGeneric,
+  "TestEquatableHashable.test_EGeneric": TestEquatableHashable.test_EGeneric,
+]
+var EquatableHashableTests = TestSuite("TestEquatableHashable")
+for (name, test) in equatableHashable {
+    EquatableHashableTests.test(name) { test(TestEquatableHashable())() }
+}
+
+var codable = [
+  "TestCodable.test_SInt": TestCodable.test_SInt,
+  "TestCodable.test_SFloat": TestCodable.test_SFloat,
+  "TestCodable.test_SGeneric": TestCodable.test_SGeneric,
+]
+
+var CodableTests = TestSuite("TestCodable")
+for (name, test) in codable {
+    CodableTests.test(name) { test(TestCodable())() }
+}
+
+var caseIterable = [
+  "TestCaseIterable.test_allCases": TestCaseIterable.test_allCases,
+]
+
+var CaseIterableTests = TestSuite("TestCaseIterable")
+for (name, test) in caseIterable {
+    CaseIterableTests.test(name) { test(TestCaseIterable())() }
+}
+runAllTests()
+#endif

--- a/test/SILGen/synthesized_conformance_class.swift
+++ b/test/SILGen/synthesized_conformance_class.swift
@@ -1,0 +1,86 @@
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-silgen %s -swift-version 4 | %FileCheck %s
+
+final class Final<T> {
+    var x: T
+    init(x: T) { self.x = x }
+}
+// CHECK-LABEL: final class Final<T> {
+// CHECK:   @sil_stored final var x: T { get set }
+// CHECK:   init(x: T)
+// CHECK:   deinit
+// CHECK:   enum CodingKeys : CodingKey {
+// CHECK:     case x
+// CHECK:     var stringValue: String { get }
+// CHECK:     init?(stringValue: String)
+// CHECK:     var intValue: Int? { get }
+// CHECK:     init?(intValue: Int)
+// CHECK:     @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: Final<T>.CodingKeys, _ b: Final<T>.CodingKeys) -> Bool
+// CHECK:     var hashValue: Int { get }
+// CHECK:     func hash(into hasher: inout Hasher)
+// CHECK:   }
+// CHECK: }
+
+class Nonfinal<T> {
+    var x: T
+    init(x: T) { self.x = x }
+}
+// CHECK-LABEL: class Nonfinal<T> {
+// CHECK:   @sil_stored var x: T { get set }
+// CHECK:   init(x: T)
+// CHECK:   deinit
+// CHECK:   enum CodingKeys : CodingKey {
+// CHECK:     case x
+// CHECK:     var stringValue: String { get }
+// CHECK:     init?(stringValue: String)
+// CHECK:     var intValue: Int? { get }
+// CHECK:     init?(intValue: Int)
+// CHECK:     @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: Nonfinal<T>.CodingKeys, _ b: Nonfinal<T>.CodingKeys) -> Bool
+// CHECK:     var hashValue: Int { get }
+// CHECK:     func hash(into hasher: inout Hasher)
+// CHECK:   }
+// CHECK: }
+
+// CHECK-LABEL: extension Final : Encodable where T : Encodable {
+// CHECK:   func encode(to encoder: Encoder) throws
+// CHECK: }
+// CHECK-LABEL: extension Final : Decodable where T : Decodable {
+// CHECK:   init(from decoder: Decoder) throws
+// CHECK: }
+
+// CHECK-LABEL: extension Nonfinal : Encodable where T : Encodable {
+// CHECK:   func encode(to encoder: Encoder) throws
+// CHECK: }
+
+extension Final: Encodable where T: Encodable {}
+// CHECK-LABEL: // Final<A>.encode(to:)
+// CHECK-NEXT: sil hidden @$S29synthesized_conformance_class5FinalCAAs9EncodableRzlE6encode2toys7Encoder_p_tKF : $@convention(method) <T where T : Encodable> (@in_guaranteed Encoder, @guaranteed Final<T>) -> @error Error {
+
+extension Final: Decodable where T: Decodable {}
+// CHECK-LABEL: // Final<A>.init(from:)
+// CHECK-NEXT: sil hidden @$S29synthesized_conformance_class5FinalCAAs9DecodableRzlE4fromACyxGs7Decoder_p_tKcfC : $@convention(method) <T where T : Decodable> (@in Decoder, @thick Final<T>.Type) -> (@owned Final<T>, @error Error) {
+
+extension Nonfinal: Encodable where T: Encodable {}
+// CHECK-LABEL: // Nonfinal<A>.encode(to:)
+// CHECK-NEXT: sil hidden @$S29synthesized_conformance_class8NonfinalCAAs9EncodableRzlE6encode2toys7Encoder_p_tKF : $@convention(method) <T where T : Encodable> (@in_guaranteed Encoder, @guaranteed Nonfinal<T>) -> @error Error {
+
+// Witness tables for Final
+
+// CHECK-LABEL: sil_witness_table hidden <T where T : Encodable> Final<T>: Encodable module synthesized_conformance_class {
+// CHECK-NEXT:   method #Encodable.encode!1: <Self where Self : Encodable> (Self) -> (Encoder) throws -> () : @$S29synthesized_conformance_class5FinalCyxGs9EncodableAAsAERzlsAEP6encode2toys7Encoder_p_tKFTW	// protocol witness for Encodable.encode(to:) in conformance <A> Final<A>
+// CHECK-NEXT:   conditional_conformance (T: Encodable): dependent
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_witness_table hidden <T where T : Decodable> Final<T>: Decodable module synthesized_conformance_class {
+// CHECK-NEXT:   method #Decodable.init!allocator.1: <Self where Self : Decodable> (Self.Type) -> (Decoder) throws -> Self : @$S29synthesized_conformance_class5FinalCyxGs9DecodableAAsAERzlsAEP4fromxs7Decoder_p_tKcfCTW	// protocol witness for Decodable.init(from:) in conformance <A> Final<A>
+// CHECK-NEXT:   conditional_conformance (T: Decodable): dependent
+// CHECK-NEXT: }
+
+// Witness tables for Nonfinal
+
+// CHECK-LABEL: sil_witness_table hidden <T where T : Encodable> Nonfinal<T>: Encodable module synthesized_conformance_class {
+// CHECK-NEXT:   method #Encodable.encode!1: <Self where Self : Encodable> (Self) -> (Encoder) throws -> () : @$S29synthesized_conformance_class8NonfinalCyxGs9EncodableAAsAERzlsAEP6encode2toys7Encoder_p_tKFTW	// protocol witness for Encodable.encode(to:) in conformance <A> Nonfinal<A>
+// CHECK-NEXT:   conditional_conformance (T: Encodable): dependent
+// CHECK-NEXT: }
+
+
+

--- a/test/SILGen/synthesized_conformance_enum.swift
+++ b/test/SILGen/synthesized_conformance_enum.swift
@@ -1,0 +1,72 @@
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-silgen %s -swift-version 4 | %FileCheck %s
+
+enum Enum<T> {
+    case a(T), b(T)
+}
+// CHECK-LABEL: enum Enum<T> {
+// CHECK:   case a(T), b(T)
+// CHECK: }
+
+enum NoValues {
+    case a, b
+}
+// CHECK-LABEL: enum NoValues {
+// CHECK:   case a, b
+// CHECK:   @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: NoValues, _ b: NoValues) -> Bool
+// CHECK:   var hashValue: Int { get }
+// CHECK:   func hash(into hasher: inout Hasher)
+// CHECK: }
+
+// CHECK-LABEL: extension Enum : Equatable where T : Equatable {
+// CHECK:   @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: Enum<T>, _ b: Enum<T>) -> Bool
+// CHECK: }
+// CHECK-LABEL: extension Enum : Hashable where T : Hashable {
+// CHECK:   var hashValue: Int { get }
+// CHECK:   func hash(into hasher: inout Hasher)
+// CHECK: }
+
+// CHECK-LABEL: extension NoValues : CaseIterable {
+// CHECK:   typealias AllCases = [NoValues]
+// CHECK:   static var allCases: [NoValues] { get }
+// CHECK: }
+
+
+extension Enum: Equatable where T: Equatable {}
+// CHECK-LABEL: // static Enum<A>.__derived_enum_equals(_:_:)
+// CHECK-NEXT: sil hidden @$S28synthesized_conformance_enum4EnumOAAs9EquatableRzlE010__derived_C7_equalsySbACyxG_AFtFZ : $@convention(method) <T where T : Equatable> (@in_guaranteed Enum<T>, @in_guaranteed Enum<T>, @thin Enum<T>.Type) -> Bool {
+
+extension Enum: Hashable where T: Hashable {}
+// CHECK-LABEL: // Enum<A>.hashValue.getter
+// CHECK-NEXT: sil hidden @$S28synthesized_conformance_enum4EnumOAAs8HashableRzlE9hashValueSivg : $@convention(method) <T where T : Hashable> (@in_guaranteed Enum<T>) -> Int {
+
+// CHECK-LABEL: // Enum<A>.hash(into:)
+// CHECK-NEXT: sil hidden @$S28synthesized_conformance_enum4EnumOAAs8HashableRzlE4hash4intoys6HasherVz_tF : $@convention(method) <T where T : Hashable> (@inout Hasher, @in_guaranteed Enum<T>) -> () {
+
+extension NoValues: CaseIterable {}
+// CHECK-LABEL: // static NoValues.allCases.getter
+// CHECK-NEXT: sil hidden @$S28synthesized_conformance_enum8NoValuesO8allCasesSayACGvgZ : $@convention(method) (@thin NoValues.Type) -> @owned Array<NoValues> {
+
+
+// Witness tables for Enum
+
+// CHECK-LABEL: sil_witness_table hidden <T where T : Equatable> Enum<T>: Equatable module synthesized_conformance_enum {
+// CHECK-NEXT:   method #Equatable."=="!1: <Self where Self : Equatable> (Self.Type) -> (Self, Self) -> Bool : @$S28synthesized_conformance_enum4EnumOyxGs9EquatableAAsAERzlsAEP2eeoiySbx_xtFZTW	// protocol witness for static Equatable.== infix(_:_:) in conformance <A> Enum<A>
+// CHECK-NEXT:   conditional_conformance (T: Equatable): dependent
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_witness_table hidden <T where T : Hashable> Enum<T>: Hashable module synthesized_conformance_enum {
+// CHECK-NEXT:   base_protocol Equatable: <T where T : Equatable> Enum<T>: Equatable module synthesized_conformance_enum
+// CHECK-NEXT:   method #Hashable.hashValue!getter.1: <Self where Self : Hashable> (Self) -> () -> Int : @$S28synthesized_conformance_enum4EnumOyxGs8HashableAAsAERzlsAEP9hashValueSivgTW	// protocol witness for Hashable.hashValue.getter in conformance <A> Enum<A>
+// CHECK-NEXT:   method #Hashable.hash!1: <Self where Self : Hashable> (Self) -> (inout Hasher) -> () : @$S28synthesized_conformance_enum4EnumOyxGs8HashableAAsAERzlsAEP4hash4intoys6HasherVz_tFTW	// protocol witness for Hashable.hash(into:) in conformance <A> Enum<A>
+// CHECK-NEXT:   conditional_conformance (T: Hashable): dependent
+// CHECK-NEXT: }
+
+// Witness tables for NoValues
+
+// CHECK-LABEL: sil_witness_table hidden NoValues: CaseIterable module synthesized_conformance_enum {
+// CHECK-NEXT:   associated_type AllCases: Array<NoValues>
+// CHECK-NEXT:   associated_type_protocol (AllCases: Collection): [NoValues]: specialize <NoValues> (<Element> Array<Element>: Collection module Swift)
+// CHECK-NEXT:   method #CaseIterable.allCases!getter.1: <Self where Self : CaseIterable> (Self.Type) -> () -> Self.AllCases : @$S28synthesized_conformance_enum8NoValuesOs12CaseIterableAAsADP8allCases03AllI0QzvgZTW // protocol witness for static CaseIterable.allCases.getter in conformance NoValues
+// CHECK-NEXT: }
+
+

--- a/test/SILGen/synthesized_conformance_struct.swift
+++ b/test/SILGen/synthesized_conformance_struct.swift
@@ -1,0 +1,76 @@
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -emit-silgen %s -swift-version 4 | %FileCheck %s
+
+struct Struct<T> {
+    var x: T
+}
+
+// CHECK-LABEL: struct Struct<T> {
+// CHECK:   @sil_stored var x: T { get set }
+// CHECK:   init(x: T)
+// CHECK:   enum CodingKeys : CodingKey {
+// CHECK:     case x
+// CHECK:     var stringValue: String { get }
+// CHECK:     init?(stringValue: String)
+// CHECK:     var intValue: Int? { get }
+// CHECK:     init?(intValue: Int)
+// CHECK:     @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: Struct<T>.CodingKeys, _ b: Struct<T>.CodingKeys) -> Bool
+// CHECK:     var hashValue: Int { get }
+// CHECK:     func hash(into hasher: inout Hasher)
+// CHECK:   }
+// CHECK: }
+// CHECK-LABEL: extension Struct : Equatable where T : Equatable {
+// CHECK:   @_implements(Equatable, ==(_:_:)) static func __derived_struct_equals(_ a: Struct<T>, _ b: Struct<T>) -> Bool
+// CHECK: }
+// CHECK-LABEL: extension Struct : Hashable where T : Hashable {
+// CHECK:   var hashValue: Int { get }
+// CHECK:   func hash(into hasher: inout Hasher)
+// CHECK: }
+// CHECK-LABEL: extension Struct : Decodable & Encodable where T : Decodable, T : Encodable {
+// CHECK:   init(from decoder: Decoder) throws
+// CHECK:   func encode(to encoder: Encoder) throws
+// CHECK: }
+
+extension Struct: Equatable where T: Equatable {}
+// CHECK-LABEL: // static Struct<A>.__derived_struct_equals(_:_:)
+// CHECK-NEXT: sil hidden @$S30synthesized_conformance_struct6StructVAAs9EquatableRzlE010__derived_C7_equalsySbACyxG_AFtFZ : $@convention(method) <T where T : Equatable> (@in_guaranteed Struct<T>, @in_guaranteed Struct<T>, @thin Struct<T>.Type) -> Bool {
+
+extension Struct: Hashable where T: Hashable {}
+// CHECK-LABEL: // Struct<A>.hashValue.getter
+// CHECK-NEXT: sil hidden @$S30synthesized_conformance_struct6StructVAAs8HashableRzlE9hashValueSivg : $@convention(method) <T where T : Hashable> (@in_guaranteed Struct<T>) -> Int {
+
+// CHECK-LABEL: // Struct<A>.hash(into:)
+// CHECK-NEXT: sil hidden @$S30synthesized_conformance_struct6StructVAAs8HashableRzlE4hash4intoys6HasherVz_tF : $@convention(method) <T where T : Hashable> (@inout Hasher, @in_guaranteed Struct<T>) -> () {
+
+extension Struct: Codable where T: Codable {}
+// CHECK-LABEL: // Struct<A>.init(from:)
+// CHECK-NEXT: sil hidden @$S30synthesized_conformance_struct6StructVAAs9DecodableRzs9EncodableRzlE4fromACyxGs7Decoder_p_tKcfC : $@convention(method) <T where T : Decodable, T : Encodable> (@in Decoder, @thin Struct<T>.Type) -> (@out Struct<T>, @error Error)
+
+// CHECK-LABEL: // Struct<A>.encode(to:)
+// CHECK-NEXT: sil hidden @$S30synthesized_conformance_struct6StructVAAs9DecodableRzs9EncodableRzlE6encode2toys7Encoder_p_tKF : $@convention(method) <T where T : Decodable, T : Encodable> (@in_guaranteed Encoder, @in_guaranteed Struct<T>) -> @error Error {
+
+
+// Witness tables
+
+// CHECK-LABEL: sil_witness_table hidden <T where T : Equatable> Struct<T>: Equatable module synthesized_conformance_struct {
+// CHECK-NEXT:   method #Equatable."=="!1: <Self where Self : Equatable> (Self.Type) -> (Self, Self) -> Bool : @$S30synthesized_conformance_struct6StructVyxGs9EquatableAAsAERzlsAEP2eeoiySbx_xtFZTW	// protocol witness for static Equatable.== infix(_:_:) in conformance <A> Struct<A>
+// CHECK-NEXT:   conditional_conformance (T: Equatable): dependent
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_witness_table hidden <T where T : Hashable> Struct<T>: Hashable module synthesized_conformance_struct {
+// CHECK-NEXT:   base_protocol Equatable: <T where T : Equatable> Struct<T>: Equatable module synthesized_conformance_struct
+// CHECK-NEXT:   method #Hashable.hashValue!getter.1: <Self where Self : Hashable> (Self) -> () -> Int : @$S30synthesized_conformance_struct6StructVyxGs8HashableAAsAERzlsAEP9hashValueSivgTW	// protocol witness for Hashable.hashValue.getter in conformance <A> Struct<A>
+// CHECK-NEXT:   method #Hashable.hash!1: <Self where Self : Hashable> (Self) -> (inout Hasher) -> () : @$S30synthesized_conformance_struct6StructVyxGs8HashableAAsAERzlsAEP4hash4intoys6HasherVz_tFTW	// protocol witness for Hashable.hash(into:) in conformance <A> Struct<A>
+// CHECK-NEXT:   conditional_conformance (T: Hashable): dependent
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_witness_table hidden <T where T : Decodable, T : Encodable> Struct<T>: Decodable module synthesized_conformance_struct {
+// CHECK-NEXT:   method #Decodable.init!allocator.1: <Self where Self : Decodable> (Self.Type) -> (Decoder) throws -> Self : @$S30synthesized_conformance_struct6StructVyxGs9DecodableAAsAERzs9EncodableRzlsAEP4fromxs7Decoder_p_tKcfCTW	// protocol witness for Decodable.init(from:) in conformance <A> Struct<A>
+// CHECK-NEXT:   conditional_conformance (T: Decodable): dependent
+// CHECK-NEXT:   conditional_conformance (T: Encodable): dependent
+// CHECK-NEXT: }
+
+// CHECK-LABEL: sil_witness_table hidden <T where T : Decodable, T : Encodable> Struct<T>: Encodable module synthesized_conformance_struct {
+// CHECK-NEXT:   method #Encodable.encode!1: <Self where Self : Encodable> (Self) -> (Encoder) throws -> () : @$S30synthesized_conformance_struct6StructVyxGs9EncodableAAs9DecodableRzsAERzlsAEP6encode2toys7Encoder_p_tKFTW	// protocol witness for Encodable.encode(to:) in conformance <A> Struct<A>
+// CHECK-NEXT:   conditional_conformance (T: Decodable): dependent
+// CHECK-NEXT:   conditional_conformance (T: Encodable): dependent
+// CHECK-NEXT: }

--- a/test/Sema/Inputs/enum_conformance_synthesis_other.swift
+++ b/test/Sema/Inputs/enum_conformance_synthesis_other.swift
@@ -1,6 +1,7 @@
 // Note that for the test to be effective, each of these enums must only have
 // its Equatable or Hashable conformance referenced /once/ in the primary file.
 enum FromOtherFile : String {
+// expected-note@-1 {{type declared here}}
   case A = "a"
 }
 enum AlsoFromOtherFile : Int {
@@ -14,5 +15,6 @@ enum OtherFileNonconforming {
   case A(Int)
 }
 enum YetOtherFileNonconforming {
+// expected-note@-1 {{type declared here}}
   case A(Int)
 }

--- a/test/Sema/Inputs/enum_conformance_synthesis_other.swift
+++ b/test/Sema/Inputs/enum_conformance_synthesis_other.swift
@@ -18,3 +18,8 @@ enum YetOtherFileNonconforming {
 // expected-note@-1 {{type declared here}}
   case A(Int)
 }
+
+enum GenericOtherFileNonconforming<T> {
+// expected-note@-1 {{type declared here}}
+    case A(T)
+}

--- a/test/Sema/Inputs/struct_equatable_hashable_other.swift
+++ b/test/Sema/Inputs/struct_equatable_hashable_other.swift
@@ -17,3 +17,8 @@ struct YetOtherFileNonconforming {
 // expected-note@-1{{type declared here}}
   let v: String
 }
+
+struct GenericOtherFileNonconforming<T> {
+// expected-note@-1{{type declared here}}
+    let v: T
+}

--- a/test/Sema/Inputs/struct_equatable_hashable_other.swift
+++ b/test/Sema/Inputs/struct_equatable_hashable_other.swift
@@ -14,5 +14,6 @@ struct OtherFileNonconforming {
   let v: String
 }
 struct YetOtherFileNonconforming {
+// expected-note@-1{{type declared here}}
   let v: String
 }

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -178,6 +178,13 @@ enum Instrument {
 
 extension Instrument : Equatable {}
 
+extension Instrument : CaseIterable {}
+
+enum UnusedGeneric<T> {
+    case a, b, c
+}
+extension UnusedGeneric : CaseIterable {}
+
 // Explicit conformance should work too
 public enum Medicine {
   case Antibiotic

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-swift-frontend -typecheck -verify -primary-file %t/main.swift %S/Inputs/enum_conformance_synthesis_other.swift -verify-ignore-unknown
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %t/main.swift %S/Inputs/enum_conformance_synthesis_other.swift -verify-ignore-unknown -swift-version 4
 
 var hasher = Hasher()
 

--- a/test/Sema/enum_conformance_synthesis.swift
+++ b/test/Sema/enum_conformance_synthesis.swift
@@ -190,11 +190,10 @@ public func ==(lhs: Medicine, rhs: Medicine) -> Bool { // expected-note 3 {{non-
   return true
 }
 
-// No explicit conformance; it could be derived, but we don't support extensions
-// yet.
-extension Complex : Hashable {}  // expected-error 2 {{cannot be automatically synthesized in an extension}}
+// No explicit conformance; but it can be derived, for the same-file cases.
+extension Complex : Hashable {}
 extension Complex : CaseIterable {}  // expected-error {{type 'Complex' does not conform to protocol 'CaseIterable'}}
-extension FromOtherFile: CaseIterable {} // expected-error {{cannot be automatically synthesized in an extension}} expected-error {{does not conform to protocol 'CaseIterable'}}
+extension FromOtherFile: CaseIterable {} // expected-error {{cannot be automatically synthesized in an extension in a different file to the type}} expected-error {{does not conform to protocol 'CaseIterable'}}
 
 // No explicit conformance and it cannot be derived.
 enum NotExplicitlyHashableAndCannotDerive {
@@ -212,7 +211,7 @@ extension OtherFileNonconforming: Hashable {
   var hashValue: Int { return 0 }
 }
 // ...but synthesis in a type defined in another file doesn't work yet.
-extension YetOtherFileNonconforming: Equatable {} // expected-error {{cannot be automatically synthesized in an extension}}
+extension YetOtherFileNonconforming: Equatable {} // expected-error {{cannot be automatically synthesized in an extension in a different file to the type}}
 extension YetOtherFileNonconforming: CaseIterable {} // expected-error {{does not conform}}
 
 // Verify that an indirect enum doesn't emit any errors as long as its "leaves"

--- a/test/Sema/enum_equatable_conditional.swift
+++ b/test/Sema/enum_equatable_conditional.swift
@@ -20,7 +20,6 @@ enum WithArrayOfEquatables2<T> {
 case only([T])
 }
 
-// No: T is Equatable here, but cannot synthesize via an extension.
-// expected-error@+1{{type 'WithArrayOfEquatables2<T>' does not conform to protocol 'Equatable'}}
+// Okay: T is Equatable here too
 extension WithArrayOfEquatables2: Equatable where T: Equatable { }
 

--- a/test/Sema/enum_equatable_conditional.swift
+++ b/test/Sema/enum_equatable_conditional.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -swift-version 4
 
 struct NotEquatable { }
 

--- a/test/Sema/struct_equatable_hashable.swift
+++ b/test/Sema/struct_equatable_hashable.swift
@@ -1,6 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: cp %s %t/main.swift
-// RUN: %target-swift-frontend -typecheck -verify -primary-file %t/main.swift %S/Inputs/struct_equatable_hashable_other.swift -verify-ignore-unknown
+// RUN: %target-swift-frontend -typecheck -verify -primary-file %t/main.swift %S/Inputs/struct_equatable_hashable_other.swift -verify-ignore-unknown -swift-version 4
 
 var hasher = Hasher()
 

--- a/test/Sema/struct_equatable_hashable.swift
+++ b/test/Sema/struct_equatable_hashable.swift
@@ -147,13 +147,13 @@ let _: Int = gnh.hashValue // No error. hashValue is always synthesized, even if
 gnh.hash(into: &hasher) // expected-error {{value of type 'GenericNotHashable<String>' has no member 'hash'}}
 
 
-// Conformance cannot be synthesized in an extension.
+// Synthesis can be from an extension...
 struct StructConformsInExtension {
   let v: Int
 }
-extension StructConformsInExtension : Equatable {} // expected-error {{cannot be automatically synthesized in an extension}}
+extension StructConformsInExtension : Equatable {}
 
-// But explicit conformance in an extension should work.
+// and explicit conformance in an extension should also work.
 public struct StructConformsAndImplementsInExtension {
   let v: Int
 }
@@ -181,7 +181,7 @@ extension OtherFileNonconforming: Hashable {
   var hashValue: Int { return 0 }
 }
 // ...but synthesis in a type defined in another file doesn't work yet.
-extension YetOtherFileNonconforming: Equatable {} // expected-error {{cannot be automatically synthesized in an extension}}
+extension YetOtherFileNonconforming: Equatable {} // expected-error {{cannot be automatically synthesized in an extension in a different file to the type}}
 
 // Verify that we can add Hashable conformance in an extension by only
 // implementing hash(into:)

--- a/test/Sema/synthesized_conformance_swift_3.swift
+++ b/test/Sema/synthesized_conformance_swift_3.swift
@@ -1,0 +1,43 @@
+// RUN: %target-typecheck-verify-swift -swift-version 3
+// All of these cases should work in Swift 4, so do a normal without -verify should succeed:
+// RUN: %target-swift-frontend -typecheck %s -swift-version 4
+
+struct Struct {}
+
+extension Struct: Equatable {}
+// expected-error@-1{{implementation of 'Equatable' cannot be automatically synthesized in an extension in Swift 3}}
+extension Struct: Codable {}
+// expected-error@-1{{implementation of 'Encodable' cannot be automatically synthesized in an extension in Swift 3}}
+// expected-error@-2{{implementation of 'Decodable' cannot be automatically synthesized in an extension in Swift 3}}
+
+final class Final {}
+extension Final: Codable {}
+// expected-error@-1{{implementation of 'Encodable' cannot be automatically synthesized in an extension in Swift 3}}
+// expected-error@-2{{implementation of 'Decodable' cannot be automatically synthesized in an extension in Swift 3}}
+
+class Nonfinal {}
+extension Nonfinal: Encodable {}
+// expected-error@-1{{implementation of 'Encodable' cannot be automatically synthesized in an extension in Swift 3}}
+
+
+enum NoValues {
+    case a, b
+}
+
+// This case has been able to be synthesized since at least Swift 3, so it
+// should work in that mode.
+extension NoValues: Equatable {}
+extension NoValues: Hashable {}
+
+extension NoValues: CaseIterable {}
+// expected-error@-1{{implementation of 'CaseIterable' cannot be automatically synthesized in an extension in Swift 3}}
+// expected-error@-2{{type 'NoValues' does not conform to protocol 'CaseIterable'}}
+
+enum Values {
+    case a(Int), b
+}
+
+extension Values: Equatable {}
+// expected-error@-1{{implementation of 'Equatable' cannot be automatically synthesized in an extension in Swift 3}}
+extension Values: Hashable {}
+// expected-error@-1{{implementation of 'Hashable' cannot be automatically synthesized in an extension in Swift 3}}

--- a/test/decl/protocol/special/coding/class_codable_failure_diagnostics.swift
+++ b/test/decl/protocol/special/coding/class_codable_failure_diagnostics.swift
@@ -113,3 +113,20 @@ class C6 : Codable {
 class C7 {}
 extension C7 : Decodable {}
 // expected-error@-1 {{implementation of 'Decodable' for non-final class cannot be automatically synthesized in extension because initializer requirement 'init(from:)' can only be be satisfied by a 'required' initializer in the class definition}}
+
+// Check that the diagnostics from an extension end up on the extension
+class C8 {
+// expected-note@-1 {{cannot automatically synthesize 'init(from:)' because superclass does not have a callable 'init()'}}
+    private init?(from: Decoder) {}
+}
+final class C9: C8 {}
+extension C9: Codable {}
+// expected-error@-1 {{type 'C9' does not conform to protocol 'Decodable'}}
+
+struct NotEncodable {}
+class C10 {
+    var x: NotEncodable = NotEncodable()
+    // expected-note@-1 {{cannot automatically synthesize 'Encodable' because 'NotEncodable' does not conform to 'Encodable'}}
+}
+extension C10: Encodable {}
+// expected-error@-1 {{type 'C10' does not conform to protocol 'Encodable'}}

--- a/test/decl/protocol/special/coding/class_codable_failure_diagnostics.swift
+++ b/test/decl/protocol/special/coding/class_codable_failure_diagnostics.swift
@@ -109,8 +109,7 @@ class C6 : Codable {
   }
 }
 
-// Classes cannot yet synthesize Encodable or Decodable in extensions.
+// Non-final classes cannot synthesize Decodable in an extension.
 class C7 {}
-extension C7 : Codable {}
-// expected-error@-1 {{implementation of 'Decodable' cannot be automatically synthesized in an extension}}
-// expected-error@-2 {{implementation of 'Encodable' cannot be automatically synthesized in an extension}}
+extension C7 : Decodable {}
+// expected-error@-1 {{implementation of 'Decodable' for non-final class cannot be automatically synthesized in extension because initializer requirement 'init(from:)' can only be be satisfied by a 'required' initializer in the class definition}}

--- a/test/decl/protocol/special/coding/class_codable_simple_conditional.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_conditional.swift
@@ -1,0 +1,39 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+class Conditional<T> {
+  var x: T
+  var y: T?
+
+  init() {
+  // expected-note@-1 2 {{did you mean 'init'}}
+    fatalError()
+  }
+  func foo() {
+    // They should receive a synthesized CodingKeys enum.
+    let _ = Conditional.CodingKeys.self
+
+    // The enum should have a case for each of the vars.
+    let _ = Conditional.CodingKeys.x
+    let _ = Conditional.CodingKeys.y
+
+    // Static vars should not be part of the CodingKeys enum.
+    let _ = Conditional.CodingKeys.z // expected-error {{type 'Conditional<T>.CodingKeys' has no member 'z'}}
+  }
+}
+
+extension Conditional: Codable where T: Codable {
+    // expected-error@-1 2 {{implementation of 'Decodable' for non-final class cannot be automatically synthesized in extension because initializer requirement 'init(from:)' can only be be satisfied by a 'required' initializer in the class definition}}
+}
+
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = Conditional<Int>.init(from:) // expected-error {{type 'Conditional<Int>' has no member 'init(from:)'}}
+let _ = Conditional<Int>.encode(to:)
+
+// but only for Codable parameters.
+struct Nonconforming {}
+let _ = Conditional<Nonconforming>.init(from:) // expected-error {{type 'Conditional<Nonconforming>' has no member 'init(from:)'}}
+let _ = Conditional<Nonconforming>.encode(to:) // expected-error {{type 'Nonconforming' does not conform to protocol 'Decodable'}}
+
+// The synthesized CodingKeys type should not be accessible from outside the
+// struct.
+let _ = Conditional<Int>.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/class_codable_simple_conditional.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_conditional.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -swift-version 4
 
 class Conditional<T> {
   var x: T

--- a/test/decl/protocol/special/coding/class_codable_simple_conditional_final.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_conditional_final.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -swift-version 4
 
 final class Conditional<T> {
   var x: T

--- a/test/decl/protocol/special/coding/class_codable_simple_conditional_final.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_conditional_final.swift
@@ -1,0 +1,36 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+final class Conditional<T> {
+  var x: T
+  var y: T?
+
+  init() {
+    fatalError()
+  }
+  func foo() {
+    // They should receive a synthesized CodingKeys enum.
+    let _ = Conditional.CodingKeys.self
+
+    // The enum should have a case for each of the vars.
+    let _ = Conditional.CodingKeys.x
+    let _ = Conditional.CodingKeys.y
+
+    // Static vars should not be part of the CodingKeys enum.
+    let _ = Conditional.CodingKeys.z // expected-error {{type 'Conditional<T>.CodingKeys' has no member 'z'}}
+  }
+}
+
+extension Conditional: Codable where T: Codable {}
+
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = Conditional<Int>.init(from:)
+let _ = Conditional<Int>.encode(to:)
+
+// but only for Codable parameters.
+struct Nonconforming {}
+let _ = Conditional<Nonconforming>.init(from:) // expected-error {{type 'Nonconforming' does not conform to protocol 'Decodable'}}
+let _ = Conditional<Nonconforming>.encode(to:) // expected-error {{type 'Nonconforming' does not conform to protocol 'Decodable'}}
+
+// The synthesized CodingKeys type should not be accessible from outside the
+// struct.
+let _ = Conditional<Int>.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/class_codable_simple_conditional_final_separate.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_conditional_final_separate.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -swift-version 4
 
 final class Conditional<T> {
   var x: T

--- a/test/decl/protocol/special/coding/class_codable_simple_conditional_final_separate.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_conditional_final_separate.swift
@@ -1,0 +1,42 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+final class Conditional<T> {
+  var x: T
+  var y: T?
+
+  init() {
+    fatalError()
+  }
+  func foo() {
+    // They should receive a synthesized CodingKeys enum.
+    let _ = Conditional.CodingKeys.self
+
+    // The enum should have a case for each of the vars.
+    let _ = Conditional.CodingKeys.x
+    let _ = Conditional.CodingKeys.y
+
+    // Static vars should not be part of the CodingKeys enum.
+    let _ = Conditional.CodingKeys.z // expected-error {{type 'Conditional<T>.CodingKeys' has no member 'z'}}
+  }
+}
+
+extension Conditional: Encodable where T: Encodable {
+}
+
+extension Conditional: Decodable where T: Decodable {
+}
+
+struct OnlyEnc: Encodable {}
+struct OnlyDec: Decodable {}
+
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = Conditional<OnlyDec>.init(from:)
+let _ = Conditional<OnlyEnc>.encode(to:)
+
+// but only for the appropriately *codable parameters.
+let _ = Conditional<OnlyEnc>.init(from:) // expected-error {{type 'OnlyEnc' does not conform to protocol 'Decodable'}}
+let _ = Conditional<OnlyDec>.encode(to:) // expected-error {{type 'OnlyDec' does not conform to protocol 'Encodable'}}
+
+// The synthesized CodingKeys type should not be accessible from outside the
+// struct.
+let _ = Conditional<Int>.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/class_codable_simple_conditional_separate.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_conditional_separate.swift
@@ -1,0 +1,44 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+class Conditional<T> {
+  var x: T
+  var y: T?
+
+  init() {
+  // expected-note@-1 2 {{did you mean 'init'}}
+    fatalError()
+  }
+  func foo() {
+    // They should receive a synthesized CodingKeys enum.
+    let _ = Conditional.CodingKeys.self
+
+    // The enum should have a case for each of the vars.
+    let _ = Conditional.CodingKeys.x
+    let _ = Conditional.CodingKeys.y
+
+    // Static vars should not be part of the CodingKeys enum.
+    let _ = Conditional.CodingKeys.z // expected-error {{type 'Conditional<T>.CodingKeys' has no member 'z'}}
+  }
+}
+
+extension Conditional: Encodable where T: Encodable {
+}
+
+extension Conditional: Decodable where T: Decodable {
+    // expected-error@-1 2 {{implementation of 'Decodable' for non-final class cannot be automatically synthesized in extension because initializer requirement 'init(from:)' can only be be satisfied by a 'required' initializer in the class definition}}
+}
+
+struct OnlyEnc: Encodable {}
+struct OnlyDec: Decodable {}
+
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = Conditional<OnlyDec>.init(from:) // expected-error {{type 'Conditional<OnlyDec>' has no member 'init(from:)'}}
+let _ = Conditional<OnlyEnc>.encode(to:)
+
+// but only for the appropriately *codable parameters.
+let _ = Conditional<OnlyEnc>.init(from:) // expected-error {{type 'Conditional<OnlyEnc>' has no member 'init(from:)'}}
+let _ = Conditional<OnlyDec>.encode(to:) // expected-error {{type 'OnlyDec' does not conform to protocol 'Encodable'}}
+
+// The synthesized CodingKeys type should not be accessible from outside the
+// struct.
+let _ = Conditional<Int>.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/class_codable_simple_conditional_separate.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_conditional_separate.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -swift-version 4
 
 class Conditional<T> {
   var x: T

--- a/test/decl/protocol/special/coding/class_codable_simple_extension.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_extension.swift
@@ -1,29 +1,31 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
-// Simple classes where Codable conformance is added in extensions should not
-// derive conformance yet.
+// Non-final classes where Codable conformance is added in extensions should
+// only be able to derive conformance for Encodable.
 class SimpleClass { // expected-note {{did you mean 'init'?}}
   var x: Int = 1
   var y: Double = .pi
   static var z: String = "foo"
 
   func foo() {
-    // They should not get a CodingKeys type.
-    let _ = SimpleClass.CodingKeys.self // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
-    let _ = SimpleClass.CodingKeys.x // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
-    let _ = SimpleClass.CodingKeys.y // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
-    let _ = SimpleClass.CodingKeys.z // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
+    // They should receive a synthesized CodingKeys enum.
+    let _ = SimpleClass.CodingKeys.self
+
+    // The enum should have a case for each of the vars.
+    let _ = SimpleClass.CodingKeys.x
+    let _ = SimpleClass.CodingKeys.y
+
+    // Static vars should not be part of the CodingKeys enum.
+    let _ = SimpleClass.CodingKeys.z // expected-error {{type 'SimpleClass.CodingKeys' has no member 'z'}}
   }
 }
 
-extension SimpleClass : Codable {} // expected-error {{implementation of 'Decodable' cannot be automatically synthesized in an extension}}
-// expected-error@-1 {{implementation of 'Decodable' cannot be automatically synthesized in an extension}}
-// expected-error@-2 {{implementation of 'Encodable' cannot be automatically synthesized in an extension}}
-// expected-error@-3 {{implementation of 'Encodable' cannot be automatically synthesized in an extension}}
+extension SimpleClass : Codable {} // expected-error 2 {{implementation of 'Decodable' for non-final class cannot be automatically synthesized in extension because initializer requirement 'init(from:)' can only be be satisfied by a 'required' initializer in the class definition}}
 
-// They should not receive Codable methods.
+// They should not receive synthesized init(from:), but should receive an encode(to:).
 let _ = SimpleClass.init(from:) // expected-error {{type 'SimpleClass' has no member 'init(from:)'}}
-let _ = SimpleClass.encode(to:) // expected-error {{type 'SimpleClass' has no member 'encode(to:)'}}
+let _ = SimpleClass.encode(to:)
 
-// They should not get a CodingKeys type.
-let _ = SimpleClass.CodingKeys.self // expected-error {{type 'SimpleClass' has no member 'CodingKeys'}}
+// The synthesized CodingKeys type should not be accessible from outside the
+// struct.
+let _ = SimpleClass.CodingKeys.self  // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/class_codable_simple_extension.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_extension.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -swift-version 4
 
 // Non-final classes where Codable conformance is added in extensions should
 // only be able to derive conformance for Encodable.

--- a/test/decl/protocol/special/coding/class_codable_simple_extension_final.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_extension_final.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -swift-version 4
 
 // Simple final classes where Codable conformance is added in extensions should
 // be able to derive conformance for both Codable protocols.

--- a/test/decl/protocol/special/coding/class_codable_simple_extension_final.swift
+++ b/test/decl/protocol/special/coding/class_codable_simple_extension_final.swift
@@ -1,0 +1,31 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+// Simple final classes where Codable conformance is added in extensions should
+// be able to derive conformance for both Codable protocols.
+final class SimpleClass {
+  var x: Int = 1
+  var y: Double = .pi
+  static var z: String = "foo"
+
+  func foo() {
+    // They should receive a synthesized CodingKeys enum.
+    let _ = SimpleClass.CodingKeys.self
+
+    // The enum should have a case for each of the vars.
+    let _ = SimpleClass.CodingKeys.x
+    let _ = SimpleClass.CodingKeys.y
+
+    // Static vars should not be part of the CodingKeys enum.
+    let _ = SimpleClass.CodingKeys.z // expected-error {{type 'SimpleClass.CodingKeys' has no member 'z'}}
+  }
+}
+
+extension SimpleClass : Codable {}
+
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = SimpleClass.init(from:)
+let _ = SimpleClass.encode(to:)
+
+// The synthesized CodingKeys type should not be accessible from outside the
+// struct.
+let _ = SimpleClass.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/struct_codable_failure_diagnostics.swift
+++ b/test/decl/protocol/special/coding/struct_codable_failure_diagnostics.swift
@@ -89,9 +89,3 @@ struct S5 : Codable {
     case c
   }
 }
-
-// Structs cannot yet synthesize Encodable or Decodable in extensions.
-struct S6 {}
-extension S6 : Codable {}
-// expected-error@-1 {{implementation of 'Decodable' cannot be automatically synthesized in an extension}}
-// expected-error@-2 {{implementation of 'Encodable' cannot be automatically synthesized in an extension}}

--- a/test/decl/protocol/special/coding/struct_codable_failure_diagnostics.swift
+++ b/test/decl/protocol/special/coding/struct_codable_failure_diagnostics.swift
@@ -89,3 +89,13 @@ struct S5 : Codable {
     case c
   }
 }
+
+struct NotCodable {}
+struct S6 {
+    var x: NotCodable = NotCodable()
+    // expected-note@-1 {{cannot automatically synthesize 'Encodable' because 'NotCodable' does not conform to 'Encodable'}}
+    // expected-note@-2 {{cannot automatically synthesize 'Decodable' because 'NotCodable' does not conform to 'Decodable'}}
+}
+extension S6: Codable {}
+// expected-error@-1 {{type 'S6' does not conform to protocol 'Encodable'}}
+// expected-error@-2 {{type 'S6' does not conform to protocol 'Decodable'}}

--- a/test/decl/protocol/special/coding/struct_codable_simple_conditional.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple_conditional.swift
@@ -1,0 +1,33 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+struct Conditional<T> {
+  var x: T
+  var y: T?
+  func foo() {
+    // They should receive a synthesized CodingKeys enum.
+    let _ = Conditional.CodingKeys.self
+
+    // The enum should have a case for each of the vars.
+    let _ = Conditional.CodingKeys.x
+    let _ = Conditional.CodingKeys.y
+
+    // Static vars should not be part of the CodingKeys enum.
+    let _ = Conditional.CodingKeys.z // expected-error {{type 'Conditional<T>.CodingKeys' has no member 'z'}}
+  }
+}
+
+extension Conditional: Codable where T: Codable {
+}
+
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = Conditional<Int>.init(from:)
+let _ = Conditional<Int>.encode(to:)
+
+// but only for Codable parameters.
+struct Nonconforming {}
+let _ = Conditional<Nonconforming>.init(from:) // expected-error {{type 'Nonconforming' does not conform to protocol 'Decodable'}}
+let _ = Conditional<Nonconforming>.encode(to:) // expected-error {{type 'Nonconforming' does not conform to protocol 'Decodable'}}
+
+// The synthesized CodingKeys type should not be accessible from outside the
+// struct.
+let _ = Conditional<Int>.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/struct_codable_simple_conditional.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple_conditional.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -swift-version 4
 
 struct Conditional<T> {
   var x: T

--- a/test/decl/protocol/special/coding/struct_codable_simple_conditional_separate.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple_conditional_separate.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -swift-version 4
 
 struct Conditional<T> {
   var x: T

--- a/test/decl/protocol/special/coding/struct_codable_simple_conditional_separate.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple_conditional_separate.swift
@@ -1,0 +1,37 @@
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+
+struct Conditional<T> {
+  var x: T
+  var y: T?
+  func foo() {
+    // They should receive a synthesized CodingKeys enum.
+    let _ = Conditional.CodingKeys.self
+
+    // The enum should have a case for each of the vars.
+    let _ = Conditional.CodingKeys.x
+    let _ = Conditional.CodingKeys.y
+
+    // Static vars should not be part of the CodingKeys enum.
+    let _ = Conditional.CodingKeys.z // expected-error {{type 'Conditional<T>.CodingKeys' has no member 'z'}}
+  }
+}
+
+extension Conditional: Encodable where T: Encodable {
+}
+extension Conditional: Decodable where T: Decodable {
+}
+
+struct OnlyEnc: Encodable {}
+struct OnlyDec: Decodable {}
+
+// They should receive synthesized init(from:) and an encode(to:).
+let _ = Conditional<OnlyDec>.init(from:)
+let _ = Conditional<OnlyEnc>.encode(to:)
+
+// but only for the appropriately *codable parameters.
+let _ = Conditional<OnlyEnc>.init(from:) // expected-error {{type 'OnlyEnc' does not conform to protocol 'Decodable'}}
+let _ = Conditional<OnlyDec>.encode(to:) // expected-error {{type 'OnlyDec' does not conform to protocol 'Encodable'}}
+
+// The synthesized CodingKeys type should not be accessible from outside the
+// struct.
+let _ = Conditional<Int>.CodingKeys.self // expected-error {{'CodingKeys' is inaccessible due to 'private' protection level}}

--- a/test/decl/protocol/special/coding/struct_codable_simple_extension.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple_extension.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -swift-version 4
 
 // Simple structs where Codable conformance is added in extensions should derive
 // conformance.

--- a/test/decl/protocol/special/coding/struct_codable_simple_extension_flipped.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple_extension_flipped.swift
@@ -1,7 +1,10 @@
 // RUN: %target-typecheck-verify-swift -verify-ignore-unknown
 
 // Simple structs where Codable conformance is added in extensions should derive
-// conformance.
+// conformance, no matter which order the extension and type occur in.
+
+extension SimpleStruct : Codable {}
+
 struct SimpleStruct {
   var x: Int
   var y: Double
@@ -17,9 +20,6 @@ struct SimpleStruct {
     // Static vars should not be part of the CodingKeys enum.
     let _ = SimpleStruct.CodingKeys.z // expected-error {{type 'SimpleStruct.CodingKeys' has no member 'z'}}
   }
-}
-
-extension SimpleStruct : Codable {
 }
 
 // They should receive synthesized init(from:) and an encode(to:).

--- a/test/decl/protocol/special/coding/struct_codable_simple_extension_flipped.swift
+++ b/test/decl/protocol/special/coding/struct_codable_simple_extension_flipped.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -verify-ignore-unknown
+// RUN: %target-typecheck-verify-swift -verify-ignore-unknown -swift-version 4
 
 // Simple structs where Codable conformance is added in extensions should derive
 // conformance, no matter which order the extension and type occur in.


### PR DESCRIPTION
**Explanation**: Allow `Equatable`, `Hashable`, `Encodable`, `Decodable` (and thus `Codable`) and `CaseIterable` to have conformances synthesized in an extension in the same file as the type declaration, e.g. `struct Foo<T> { var x: T } extension Foo: Equatable where T: Equatable { /* creates an == that compares x */ }`.
**Scope**: Two major features of 4.1 were conditional conformances and synthesis of protocol conformances, but without being able to synthesize in extensions they didn't work together at all: the only way to get a conditional conformance is in an `extension`. Thus, this enables synthesis for many generic types.
**Radar/SR Issue**: https://bugs.swift.org/browse/SR-6803 rdar://problem/39199726
**Risk**: Low: most of the change is mechanical refactoring to enable the actual change to be simple and obvious. There's lots of testing, and a lot of the changes are no-ops for existing code that compiles (for those cases, `Nominal` and `ConformanceDecl` are equal, and so changing the references from one to the other don't do anything). Additionally, the diff is deceptively large: the non-test diff stat is more like +600,-700.
**Testing**: Significant additions (1069 additions, 66 deletions) to the test suite both for type checking, code generation and runtime behaviour.
**Reviewer**: @DougGregor 

https://github.com/apple/swift/pull/16439