### PR TITLE
[AST] NFC: Avoid pointer indirection with ASTContext Impl storage

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -186,19 +186,24 @@ class SILLayout; // From SIL
 /// DispatchQueues. Summary: if you think you need a global or static variable,
 /// you probably need to put it here instead.
 
-class ASTContext {
+class ASTContext final {
   ASTContext(const ASTContext&) = delete;
   void operator=(const ASTContext&) = delete;
+
+  ASTContext(LangOptions &langOpts, SearchPathOptions &SearchPathOpts,
+             SourceManager &SourceMgr, DiagnosticEngine &Diags);
 
 public:
   // Members that should only be used by ASTContext.cpp.
   struct Implementation;
-  Implementation &Impl;
-  
+  Implementation &getImpl() const;
+
   friend ConstraintCheckerArenaRAII;
-public:
-  ASTContext(LangOptions &langOpts, SearchPathOptions &SearchPathOpts,
-             SourceManager &SourceMgr, DiagnosticEngine &Diags);
+
+  static ASTContext *get(LangOptions &langOpts,
+                         SearchPathOptions &SearchPathOpts,
+                         SourceManager &SourceMgr,
+                         DiagnosticEngine &Diags);
   ~ASTContext();
 
   /// \brief The language options used for translation.

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -416,14 +416,14 @@ ASTContext::Implementation::~Implementation() {
 
 ConstraintCheckerArenaRAII::
 ConstraintCheckerArenaRAII(ASTContext &self, llvm::BumpPtrAllocator &allocator)
-  : Self(self), Data(self.Impl.CurrentConstraintSolverArena.release())
+  : Self(self), Data(self.getImpl().CurrentConstraintSolverArena.release())
 {
-  Self.Impl.CurrentConstraintSolverArena.reset(
+  Self.getImpl().CurrentConstraintSolverArena.reset(
     new ASTContext::Implementation::ConstraintSolverArena(allocator));
 }
 
 ConstraintCheckerArenaRAII::~ConstraintCheckerArenaRAII() {
-  Self.Impl.CurrentConstraintSolverArena.reset(
+  Self.getImpl().CurrentConstraintSolverArena.reset(
     (ASTContext::Implementation::ConstraintSolverArena *)Data);
 }
 
@@ -434,10 +434,31 @@ static ModuleDecl *createBuiltinModule(ASTContext &ctx) {
   return M;
 }
 
+inline ASTContext::Implementation &ASTContext::getImpl() const {
+  auto end = reinterpret_cast<void*>(const_cast<ASTContext*>(this) + 1);
+  auto impl = llvm::alignAddr(end, alignof(Implementation));
+  return *reinterpret_cast<Implementation*>(impl);
+}
+
+ASTContext *ASTContext::get(LangOptions &langOpts,
+                            SearchPathOptions &SearchPathOpts,
+                            SourceManager &SourceMgr,
+                            DiagnosticEngine &Diags) {
+  // If more than two data structures are concatentated, then the aggregate
+  // size math needs to become more complicated due to per-struct alignment
+  // constraints.
+  auto align = std::max(alignof(ASTContext), alignof(Implementation));
+  auto size = llvm::alignTo(sizeof(ASTContext) + sizeof(Implementation), align);
+  auto mem = AlignedAlloc(size, align);
+  auto impl = reinterpret_cast<void*>((char*)mem + sizeof(ASTContext));
+  impl = reinterpret_cast<void*>(llvm::alignAddr(impl,alignof(Implementation)));
+  new (impl) Implementation();
+  return new (mem) ASTContext(langOpts, SearchPathOpts, SourceMgr, Diags);
+}
+
 ASTContext::ASTContext(LangOptions &langOpts, SearchPathOptions &SearchPathOpts,
                        SourceManager &SourceMgr, DiagnosticEngine &Diags)
-  : Impl(*new Implementation()),
-    LangOpts(langOpts),
+  : LangOpts(langOpts),
     SearchPathOpts(SearchPathOpts),
     SourceMgr(SourceMgr),
     Diags(Diags),
@@ -484,43 +505,43 @@ ASTContext::ASTContext(LangOptions &langOpts, SearchPathOptions &SearchPathOpts,
 
   // Record the initial set of search paths.
   for (StringRef path : SearchPathOpts.ImportSearchPaths)
-    Impl.SearchPathsSet[path] |= SearchPathKind::Import;
+    getImpl().SearchPathsSet[path] |= SearchPathKind::Import;
   for (const auto &framepath : SearchPathOpts.FrameworkSearchPaths)
-    Impl.SearchPathsSet[framepath.Path] |= SearchPathKind::Framework;
+    getImpl().SearchPathsSet[framepath.Path] |= SearchPathKind::Framework;
 }
 
 ASTContext::~ASTContext() {
-  delete &Impl;
+  getImpl().~Implementation();
 }
 
 llvm::BumpPtrAllocator &ASTContext::getAllocator(AllocationArena arena) const {
   switch (arena) {
   case AllocationArena::Permanent:
-    return Impl.Allocator;
+    return getImpl().Allocator;
 
   case AllocationArena::ConstraintSolver:
-    assert(Impl.CurrentConstraintSolverArena != nullptr);
-    return Impl.CurrentConstraintSolverArena->Allocator;
+    assert(getImpl().CurrentConstraintSolverArena != nullptr);
+    return getImpl().CurrentConstraintSolverArena->Allocator;
   }
   llvm_unreachable("bad AllocationArena");
 }
 
 syntax::SyntaxArena &ASTContext::getSyntaxArena() const {
-  return Impl.TheSyntaxArena;
+  return getImpl().TheSyntaxArena;
 }
 
 LazyResolver *ASTContext::getLazyResolver() const {
-  return Impl.Resolver;
+  return getImpl().Resolver;
 }
 
 /// Set the lazy resolver for this context.
 void ASTContext::setLazyResolver(LazyResolver *resolver) {
   if (resolver) {
-    assert(Impl.Resolver == nullptr && "already have a resolver");
-    Impl.Resolver = resolver;
+    assert(getImpl().Resolver == nullptr && "already have a resolver");
+    getImpl().Resolver = resolver;
   } else {
-    assert(Impl.Resolver != nullptr && "no resolver to remove");
-    Impl.Resolver = resolver;
+    assert(getImpl().Resolver != nullptr && "no resolver to remove");
+    getImpl().Resolver = resolver;
   }
 }
 
@@ -531,7 +552,7 @@ Identifier ASTContext::getIdentifier(StringRef Str) const {
   if (Str.data() == nullptr)
     return Identifier(nullptr);
 
-  auto I = Impl.IdentifierTable.insert(std::make_pair(Str, char())).first;
+  auto I = getImpl().IdentifierTable.insert(std::make_pair(Str, char())).first;
   return Identifier(I->getKeyData());
 }
 
@@ -567,8 +588,8 @@ static NominalTypeDecl *findStdlibType(const ASTContext &ctx, StringRef name,
 }
 
 FuncDecl *ASTContext::getPlusFunctionOnRangeReplaceableCollection() const {
-  if (Impl.PlusFunctionOnRangeReplaceableCollection) {
-    return Impl.PlusFunctionOnRangeReplaceableCollection;
+  if (getImpl().PlusFunctionOnRangeReplaceableCollection) {
+    return getImpl().PlusFunctionOnRangeReplaceableCollection;
   }
   // Find all of the declarations with this name in the Swift module.
   SmallVector<ValueDecl *, 1> Results;
@@ -581,17 +602,17 @@ FuncDecl *ASTContext::getPlusFunctionOnRangeReplaceableCollection() const {
         if (Req.getKind() == RequirementKind::Conformance &&
               Req.getSecondType()->getNominalOrBoundGenericNominal() ==
             getRangeReplaceableCollectionDecl()) {
-          Impl.PlusFunctionOnRangeReplaceableCollection = FD;
+          getImpl().PlusFunctionOnRangeReplaceableCollection = FD;
         }
       }
     }
   }
-  return Impl.PlusFunctionOnRangeReplaceableCollection;
+  return getImpl().PlusFunctionOnRangeReplaceableCollection;
 }
 
 FuncDecl *ASTContext::getPlusFunctionOnString() const {
-  if (Impl.PlusFunctionOnString) {
-    return Impl.PlusFunctionOnString;
+  if (getImpl().PlusFunctionOnString) {
+    return getImpl().PlusFunctionOnString;
   }
   // Find all of the declarations with this name in the Swift module.
   SmallVector<ValueDecl *, 1> Results;
@@ -612,20 +633,20 @@ FuncDecl *ASTContext::getPlusFunctionOnString() const {
       };
       if (CheckIfStringParam(ParamLists[1]->get(0)) &&
           CheckIfStringParam(ParamLists[1]->get(1))) {
-        Impl.PlusFunctionOnString = FD;
+        getImpl().PlusFunctionOnString = FD;
         break;
       }
     }
   }
-  return Impl.PlusFunctionOnString;
+  return getImpl().PlusFunctionOnString;
 }
 
 #define KNOWN_STDLIB_TYPE_DECL(NAME, DECL_CLASS, NUM_GENERIC_PARAMS) \
   DECL_CLASS *ASTContext::get##NAME##Decl() const { \
-    if (!Impl.NAME##Decl) \
-      Impl.NAME##Decl = dyn_cast_or_null<DECL_CLASS>( \
+    if (!getImpl().NAME##Decl) \
+      getImpl().NAME##Decl = dyn_cast_or_null<DECL_CLASS>( \
         findStdlibType(*this, #NAME, NUM_GENERIC_PARAMS)); \
-    return Impl.NAME##Decl; \
+    return getImpl().NAME##Decl; \
   }
 #include "swift/AST/KnownStdlibTypes.def"
 
@@ -643,15 +664,15 @@ ProtocolDecl *ASTContext::getErrorDecl() const {
 }
 
 EnumElementDecl *ASTContext::getOptionalSomeDecl() const {
-  if (!Impl.OptionalSomeDecl)
-    Impl.OptionalSomeDecl = getOptionalDecl()->getUniqueElement(/*hasVal*/true);
-  return Impl.OptionalSomeDecl;
+  if (!getImpl().OptionalSomeDecl)
+    getImpl().OptionalSomeDecl = getOptionalDecl()->getUniqueElement(/*hasVal*/true);
+  return getImpl().OptionalSomeDecl;
 }
 
 EnumElementDecl *ASTContext::getOptionalNoneDecl() const {
-  if (!Impl.OptionalNoneDecl)
-    Impl.OptionalNoneDecl =getOptionalDecl()->getUniqueElement(/*hasVal*/false);
-  return Impl.OptionalNoneDecl;
+  if (!getImpl().OptionalNoneDecl)
+    getImpl().OptionalNoneDecl =getOptionalDecl()->getUniqueElement(/*hasVal*/false);
+  return getImpl().OptionalNoneDecl;
 }
 
 static VarDecl *getPointeeProperty(VarDecl *&cache,
@@ -685,23 +706,23 @@ VarDecl *
 ASTContext::getPointerPointeePropertyDecl(PointerTypeKind ptrKind) const {
   switch (ptrKind) {
   case PTK_UnsafeMutableRawPointer:
-    return getPointeeProperty(Impl.UnsafeMutableRawPointerMemoryDecl,
+    return getPointeeProperty(getImpl().UnsafeMutableRawPointerMemoryDecl,
                              &ASTContext::getUnsafeMutableRawPointerDecl,
                              *this);
   case PTK_UnsafeRawPointer:
-    return getPointeeProperty(Impl.UnsafeRawPointerMemoryDecl,
+    return getPointeeProperty(getImpl().UnsafeRawPointerMemoryDecl,
                              &ASTContext::getUnsafeRawPointerDecl,
                              *this);
   case PTK_UnsafeMutablePointer:
-    return getPointeeProperty(Impl.UnsafeMutablePointerMemoryDecl,
+    return getPointeeProperty(getImpl().UnsafeMutablePointerMemoryDecl,
                              &ASTContext::getUnsafeMutablePointerDecl,
                              *this);
   case PTK_UnsafePointer:
-    return getPointeeProperty(Impl.UnsafePointerMemoryDecl,
+    return getPointeeProperty(getImpl().UnsafePointerMemoryDecl,
                              &ASTContext::getUnsafePointerDecl,
                              *this);
   case PTK_AutoreleasingUnsafeMutablePointer:
-    return getPointeeProperty(Impl.AutoreleasingUnsafeMutablePointerMemoryDecl,
+    return getPointeeProperty(getImpl().AutoreleasingUnsafeMutablePointerMemoryDecl,
                          &ASTContext::getAutoreleasingUnsafeMutablePointerDecl,
                              *this);
   }
@@ -709,14 +730,14 @@ ASTContext::getPointerPointeePropertyDecl(PointerTypeKind ptrKind) const {
 }
 
 CanType ASTContext::getAnyObjectType() const {
-  if (Impl.AnyObjectType) {
-    return Impl.AnyObjectType;
+  if (getImpl().AnyObjectType) {
+    return getImpl().AnyObjectType;
   }
 
-  Impl.AnyObjectType = CanType(
+  getImpl().AnyObjectType = CanType(
     ProtocolCompositionType::get(
       *this, {}, /*HasExplicitAnyObject=*/true));
-  return Impl.AnyObjectType;
+  return getImpl().AnyObjectType;
 }
 
 CanType ASTContext::getNeverType() const {
@@ -727,8 +748,8 @@ CanType ASTContext::getNeverType() const {
 }
 
 TypeAliasDecl *ASTContext::getVoidDecl() const {
-  if (Impl.VoidDecl) {
-    return Impl.VoidDecl;
+  if (getImpl().VoidDecl) {
+    return getImpl().VoidDecl;
   }
 
   // Go find 'Void' in the Swift module.
@@ -736,16 +757,16 @@ TypeAliasDecl *ASTContext::getVoidDecl() const {
   lookupInSwiftModule("Void", results);
   for (auto result : results) {
     if (auto typeAlias = dyn_cast<TypeAliasDecl>(result)) {
-      Impl.VoidDecl = typeAlias;
+      getImpl().VoidDecl = typeAlias;
       return typeAlias;
     }
   }
 
-  return Impl.VoidDecl;
+  return getImpl().VoidDecl;
 }
 
 StructDecl *ASTContext::getObjCBoolDecl() const {
-  if (!Impl.ObjCBoolDecl) {
+  if (!getImpl().ObjCBoolDecl) {
     SmallVector<ValueDecl *, 1> results;
     auto *Context = const_cast<ASTContext *>(this);
     if (ModuleDecl *M = Context->getModuleByName(Id_ObjectiveC.str())) {
@@ -754,7 +775,7 @@ StructDecl *ASTContext::getObjCBoolDecl() const {
       for (auto result : results) {
         if (auto structDecl = dyn_cast<StructDecl>(result)) {
           if (structDecl->getGenericParams() == nullptr) {
-            Impl.ObjCBoolDecl = structDecl;
+            getImpl().ObjCBoolDecl = structDecl;
             break;
           }
         }
@@ -762,12 +783,12 @@ StructDecl *ASTContext::getObjCBoolDecl() const {
     }
   }
 
-  return Impl.ObjCBoolDecl;
+  return getImpl().ObjCBoolDecl;
 }
 
 #define GET_FOUNDATION_DECL(NAME) \
 ClassDecl *ASTContext::get##NAME##Decl() const { \
-  if (!Impl.NAME##Decl) { \
+  if (!getImpl().NAME##Decl) { \
     if (ModuleDecl *M = getLoadedModule(Id_Foundation)) { \
       /* Note: use unqualified lookup so we find NSError regardless of */ \
       /* whether it's defined in the Foundation module or the Clang */ \
@@ -776,14 +797,14 @@ ClassDecl *ASTContext::get##NAME##Decl() const { \
       if (auto type = lookup.getSingleTypeResult()) { \
         if (auto classDecl = dyn_cast<ClassDecl>(type)) { \
           if (classDecl->getGenericParams() == nullptr) { \
-            Impl.NAME##Decl = classDecl; \
+            getImpl().NAME##Decl = classDecl; \
           } \
         } \
       } \
     } \
   } \
   \
-  return Impl.NAME##Decl; \
+  return getImpl().NAME##Decl; \
 }
 
 FOR_KNOWN_FOUNDATION_TYPES(GET_FOUNDATION_DECL)
@@ -794,8 +815,8 @@ ProtocolDecl *ASTContext::getProtocol(KnownProtocolKind kind) const {
   // Check whether we've already looked for and cached this protocol.
   unsigned index = (unsigned)kind;
   assert(index < NumKnownProtocols && "Number of known protocols is wrong");
-  if (Impl.KnownProtocols[index])
-    return Impl.KnownProtocols[index];
+  if (getImpl().KnownProtocols[index])
+    return getImpl().KnownProtocols[index];
 
   // Find all of the declarations with this name in the appropriate module.
   SmallVector<ValueDecl *, 1> results;
@@ -822,7 +843,7 @@ ProtocolDecl *ASTContext::getProtocol(KnownProtocolKind kind) const {
 
   for (auto result : results) {
     if (auto protocol = dyn_cast<ProtocolDecl>(result)) {
-      Impl.KnownProtocols[index] = protocol;
+      getImpl().KnownProtocols[index] = protocol;
       return protocol;
     }
   }
@@ -955,8 +976,8 @@ static FuncDecl *lookupLibraryIntrinsicFunc(const ASTContext &ctx,
 }
 
 FuncDecl *ASTContext::getEqualIntDecl() const {
-  if (Impl.EqualIntDecl)
-    return Impl.EqualIntDecl;
+  if (getImpl().EqualIntDecl)
+    return getImpl().EqualIntDecl;
 
   if (!getIntDecl() || !getBoolDecl())
     return nullptr;
@@ -974,13 +995,13 @@ FuncDecl *ASTContext::getEqualIntDecl() const {
   };
 
   auto decl = lookupOperatorFunc<32>(*this, "==", intType, callback);
-  Impl.EqualIntDecl = decl;
+  getImpl().EqualIntDecl = decl;
   return decl;
 }
 
 FuncDecl *ASTContext::getGetBoolDecl(LazyResolver *resolver) const {
-  if (Impl.GetBoolDecl)
-    return Impl.GetBoolDecl;
+  if (getImpl().GetBoolDecl)
+    return getImpl().GetBoolDecl;
 
   auto callback = [&](Type inputType, Type resultType) {
     // Look for the signature (Builtin.Int1) -> Bool
@@ -989,13 +1010,13 @@ FuncDecl *ASTContext::getGetBoolDecl(LazyResolver *resolver) const {
   };
 
   auto decl = lookupLibraryIntrinsicFunc(*this, "_getBool", resolver, callback);
-  Impl.GetBoolDecl = decl;
+  getImpl().GetBoolDecl = decl;
   return decl;
 }
 
 FuncDecl *ASTContext::getHashValueForDecl() const {
-  if (Impl.HashValueForDecl)
-    return Impl.HashValueForDecl;
+  if (getImpl().HashValueForDecl)
+    return getImpl().HashValueForDecl;
 
   SmallVector<ValueDecl *, 1> results;
   lookupInSwiftModule("_hashValue", results);
@@ -1012,15 +1033,15 @@ FuncDecl *ASTContext::getHashValueForDecl() const {
     auto genericParams = fd->getGenericParams();
     if (!genericParams || genericParams->size() != 1)
       continue;
-    Impl.HashValueForDecl = fd;
+    getImpl().HashValueForDecl = fd;
     return fd;
   }
   return nullptr;
 }
 
 FuncDecl *ASTContext::getArrayAppendElementDecl() const {
-  if (Impl.ArrayAppendElementDecl)
-    return Impl.ArrayAppendElementDecl;
+  if (getImpl().ArrayAppendElementDecl)
+    return getImpl().ArrayAppendElementDecl;
 
   auto AppendFunctions = getArrayDecl()->lookupDirect(getIdentifier("append"));
 
@@ -1059,7 +1080,7 @@ FuncDecl *ASTContext::getArrayAppendElementDecl() const {
       if (!FnDecl->getResultInterfaceType()->isVoid())
         return nullptr;
 
-      Impl.ArrayAppendElementDecl = FnDecl;
+      getImpl().ArrayAppendElementDecl = FnDecl;
       return FnDecl;
     }
   }
@@ -1067,8 +1088,8 @@ FuncDecl *ASTContext::getArrayAppendElementDecl() const {
 }
 
 FuncDecl *ASTContext::getArrayReserveCapacityDecl() const {
-  if (Impl.ArrayReserveCapacityDecl)
-    return Impl.ArrayReserveCapacityDecl;
+  if (getImpl().ArrayReserveCapacityDecl)
+    return getImpl().ArrayReserveCapacityDecl;
 
   auto ReserveFunctions = getArrayDecl()->lookupDirect(
                                    getIdentifier("reserveCapacityForAppend"));
@@ -1119,7 +1140,7 @@ FuncDecl *ASTContext::getArrayReserveCapacityDecl() const {
       if (!FnDecl->getResultInterfaceType()->isVoid())
         return nullptr;
 
-      Impl.ArrayReserveCapacityDecl = FnDecl;
+      getImpl().ArrayReserveCapacityDecl = FnDecl;
       return FnDecl;
     }
   }
@@ -1128,8 +1149,8 @@ FuncDecl *ASTContext::getArrayReserveCapacityDecl() const {
 
 FuncDecl *
 ASTContext::getUnimplementedInitializerDecl(LazyResolver *resolver) const {
-  if (Impl.UnimplementedInitializerDecl)
-    return Impl.UnimplementedInitializerDecl;
+  if (getImpl().UnimplementedInitializerDecl)
+    return getImpl().UnimplementedInitializerDecl;
 
   // Look for the function.
   Type input, output;
@@ -1141,14 +1162,14 @@ ASTContext::getUnimplementedInitializerDecl(LazyResolver *resolver) const {
 
   // FIXME: Check inputs and outputs.
 
-  Impl.UnimplementedInitializerDecl = decl;
+  getImpl().UnimplementedInitializerDecl = decl;
   return decl;
 }
 
 FuncDecl *
 ASTContext::getUndefinedDecl(LazyResolver *resolver) const {
-  if (Impl.UndefinedDecl)
-    return Impl.UndefinedDecl;
+  if (getImpl().UndefinedDecl)
+    return getImpl().UndefinedDecl;
 
   // Look for the function.
   CanType input, output;
@@ -1156,13 +1177,13 @@ ASTContext::getUndefinedDecl(LazyResolver *resolver) const {
   if (!decl)
     return nullptr;
 
-  Impl.UndefinedDecl = decl;
+  getImpl().UndefinedDecl = decl;
   return decl;
 }
 
 FuncDecl *ASTContext::getIsOSVersionAtLeastDecl(LazyResolver *resolver) const {
-  if (Impl.IsOSVersionAtLeastDecl)
-    return Impl.IsOSVersionAtLeastDecl;
+  if (getImpl().IsOSVersionAtLeastDecl)
+    return getImpl().IsOSVersionAtLeastDecl;
 
   // Look for the function.
   Type input, output;
@@ -1185,7 +1206,7 @@ FuncDecl *ASTContext::getIsOSVersionAtLeastDecl(LazyResolver *resolver) const {
   if (!isBuiltinInt1Type(output))
     return nullptr;
 
-  Impl.IsOSVersionAtLeastDecl = decl;
+  getImpl().IsOSVersionAtLeastDecl = decl;
   return decl;
 }
 
@@ -1271,10 +1292,10 @@ ASTContext::associateInfixOperators(PrecedenceGroupDecl *left,
   // then flip the result.
 
   if (uintptr_t(left) < uintptr_t(right)) {
-    return computeAssociativity(Impl.AssociativityCache, left, right);
+    return computeAssociativity(getImpl().AssociativityCache, left, right);
   }
 
-  switch (computeAssociativity(Impl.AssociativityCache, right, left)) {
+  switch (computeAssociativity(getImpl().AssociativityCache, right, left)) {
   case Associativity::Left: return Associativity::Right;
   case Associativity::Right: return Associativity::Left;
   case Associativity::None: return Associativity::None;
@@ -1294,7 +1315,7 @@ static FuncDecl *findLibraryFunction(const ASTContext &ctx, FuncDecl *&cache,
 
 #define FUNC_DECL(Name, Id)                                         \
 FuncDecl *ASTContext::get##Name(LazyResolver *resolver) const {     \
-  return findLibraryFunction(*this, Impl.Get##Name, Id, resolver);  \
+  return findLibraryFunction(*this, getImpl().Get##Name, Id, resolver);  \
 }
 #include "swift/AST/KnownDecls.def"
 
@@ -1339,7 +1360,7 @@ void ASTContext::addSynthesizedDecl(Decl *decl) {
 }
 
 void ASTContext::addCleanup(std::function<void(void)> cleanup) {
-  Impl.Cleanups.push_back(std::move(cleanup));
+  getImpl().Cleanups.push_back(std::move(cleanup));
 }
 
 bool ASTContext::hadError() const {
@@ -1355,7 +1376,7 @@ static AllocationArena getArena(RecursiveTypeProperties properties) {
 
 void ASTContext::addSearchPath(StringRef searchPath, bool isFramework,
                                bool isSystem) {
-  OptionSet<SearchPathKind> &loaded = Impl.SearchPathsSet[searchPath];
+  OptionSet<SearchPathKind> &loaded = getImpl().SearchPathsSet[searchPath];
   auto kind = isFramework ? SearchPathKind::Framework : SearchPathKind::Import;
   if (loaded.contains(kind))
     return;
@@ -1373,16 +1394,16 @@ void ASTContext::addSearchPath(StringRef searchPath, bool isFramework,
 void ASTContext::addModuleLoader(std::unique_ptr<ModuleLoader> loader,
                                  bool IsClang) {
   if (IsClang) {
-    assert(!Impl.TheClangModuleLoader && "Already have a Clang module loader");
-    Impl.TheClangModuleLoader =
+    assert(!getImpl().TheClangModuleLoader && "Already have a Clang module loader");
+    getImpl().TheClangModuleLoader =
       static_cast<ClangModuleLoader *>(loader.get());
   }
-  Impl.ModuleLoaders.push_back(std::move(loader));
+  getImpl().ModuleLoaders.push_back(std::move(loader));
 }
 
 void ASTContext::loadExtensions(NominalTypeDecl *nominal,
                                 unsigned previousGeneration) {
-  for (auto &loader : Impl.ModuleLoaders) {
+  for (auto &loader : getImpl().ModuleLoaders) {
     loader->loadExtensions(nominal, previousGeneration);
   }
 }
@@ -1393,7 +1414,7 @@ void ASTContext::loadObjCMethods(
        bool isInstanceMethod,
        unsigned previousGeneration,
        llvm::TinyPtrVector<AbstractFunctionDecl *> &methods) {
-  for (auto &loader : Impl.ModuleLoaders) {
+  for (auto &loader : getImpl().ModuleLoaders) {
     loader->loadObjCMethods(classDecl, selector, isInstanceMethod,
                             previousGeneration, methods);
   }
@@ -1402,7 +1423,7 @@ void ASTContext::loadObjCMethods(
 void ASTContext::verifyAllLoadedModules() const {
 #ifndef NDEBUG
   FrontendStatsTracer tracer(Stats, "verify-all-loaded-modules");
-  for (auto &loader : Impl.ModuleLoaders)
+  for (auto &loader : getImpl().ModuleLoaders)
     loader->verifyAllModules();
 
   for (auto &topLevelModulePair : LoadedModules) {
@@ -1413,7 +1434,7 @@ void ASTContext::verifyAllLoadedModules() const {
 }
 
 ClangModuleLoader *ASTContext::getClangModuleLoader() const {
-  return Impl.TheClangModuleLoader;
+  return getImpl().TheClangModuleLoader;
 }
 
 static void recordKnownProtocol(ModuleDecl *Stdlib, StringRef Name,
@@ -1458,14 +1479,14 @@ void ASTContext::registerGenericSignatureBuilder(
                                        GenericSignature *sig,
                                        GenericSignatureBuilder &&builder) {
   auto canSig = sig->getCanonicalSignature();
-  auto known = Impl.GenericSignatureBuilders.find(canSig);
-  if (known != Impl.GenericSignatureBuilders.end()) {
+  auto known = getImpl().GenericSignatureBuilders.find(canSig);
+  if (known != getImpl().GenericSignatureBuilders.end()) {
     ++NumRegisteredGenericSignatureBuildersAlready;
     return;
   }
 
   ++NumRegisteredGenericSignatureBuilders;
-  Impl.GenericSignatureBuilders[canSig] =
+  getImpl().GenericSignatureBuilders[canSig] =
     llvm::make_unique<GenericSignatureBuilder>(std::move(builder));
 }
 
@@ -1473,15 +1494,15 @@ GenericSignatureBuilder *ASTContext::getOrCreateGenericSignatureBuilder(
                                                       CanGenericSignature sig) {
   // Check whether we already have a generic signature builder for this
   // signature and module.
-  auto known = Impl.GenericSignatureBuilders.find(sig);
-  if (known != Impl.GenericSignatureBuilders.end())
+  auto known = getImpl().GenericSignatureBuilders.find(sig);
+  if (known != getImpl().GenericSignatureBuilders.end())
     return known->second.get();
 
   // Create a new generic signature builder with the given signature.
   auto builder = new GenericSignatureBuilder(*this);
 
   // Store this generic signature builder (no generic environment yet).
-  Impl.GenericSignatureBuilders[sig] =
+  getImpl().GenericSignatureBuilders[sig] =
     std::unique_ptr<GenericSignatureBuilder>(builder);
 
   builder->addGenericSignature(sig);
@@ -1552,12 +1573,12 @@ GenericSignatureBuilder *ASTContext::getOrCreateGenericSignatureBuilder(
 GenericEnvironment *ASTContext::getOrCreateCanonicalGenericEnvironment(
                                               GenericSignatureBuilder *builder,
                                               GenericSignature *sig) {
-  auto known = Impl.CanonicalGenericEnvironments.find(builder);
-  if (known != Impl.CanonicalGenericEnvironments.end())
+  auto known = getImpl().CanonicalGenericEnvironments.find(builder);
+  if (known != getImpl().CanonicalGenericEnvironments.end())
     return known->second;
 
   auto env = sig->createGenericEnvironment();
-  Impl.CanonicalGenericEnvironments[builder] = env;
+  getImpl().CanonicalGenericEnvironments[builder] = env;
   return env;
 }
 
@@ -1614,8 +1635,8 @@ ArrayRef<AssociatedTypeDecl *> AssociatedTypeDecl::getOverriddenDecls() const {
       return { };
 
     // Look up the overrides.
-    auto known = getASTContext().Impl.AssociatedTypeOverrides.find(this);
-    assert(known != getASTContext().Impl.AssociatedTypeOverrides.end());
+    auto known = getASTContext().getImpl().AssociatedTypeOverrides.find(this);
+    assert(known != getASTContext().getImpl().AssociatedTypeOverrides.end());
     return known->second;
   }
 
@@ -1679,7 +1700,7 @@ ArrayRef<AssociatedTypeDecl *> AssociatedTypeDecl::setOverriddenDecls(
   Bits.AssociatedTypeDecl.HasOverridden = true;
   auto overriddenCopy = ctx.AllocateCopy(overridden);
   auto inserted =
-    ctx.Impl.AssociatedTypeOverrides.insert({this, overriddenCopy}).second;
+    ctx.getImpl().AssociatedTypeOverrides.insert({this, overriddenCopy}).second;
   (void)inserted;
   assert(inserted && "Already recorded associated type overrides");
   return overriddenCopy;
@@ -1695,7 +1716,7 @@ bool ASTContext::canImportModule(std::pair<Identifier, SourceLoc> ModulePath) {
     return false;
 
   // Otherwise, ask the module loaders.
-  for (auto &importer : Impl.ModuleLoaders) {
+  for (auto &importer : getImpl().ModuleLoaders) {
     if (importer->canImportModule(ModulePath)) {
       return true;
     }
@@ -1713,7 +1734,7 @@ ASTContext::getModule(ArrayRef<std::pair<Identifier, SourceLoc>> ModulePath) {
     return M;
 
   auto moduleID = ModulePath[0];
-  for (auto &importer : Impl.ModuleLoaders) {
+  for (auto &importer : getImpl().ModuleLoaders) {
     if (ModuleDecl *M = importer->loadModule(moduleID.second, ModulePath)) {
       if (ModulePath.size() == 1 &&
           (ModulePath[0].first == StdlibModuleName ||
@@ -1752,32 +1773,32 @@ ModuleDecl *ASTContext::getStdlibModule(bool loadIfAbsent) {
 }
 
 Optional<RawComment> ASTContext::getRawComment(const Decl *D) {
-  auto Known = Impl.RawComments.find(D);
-  if (Known == Impl.RawComments.end())
+  auto Known = getImpl().RawComments.find(D);
+  if (Known == getImpl().RawComments.end())
     return None;
 
   return Known->second;
 }
 
 void ASTContext::setRawComment(const Decl *D, RawComment RC) {
-  Impl.RawComments[D] = RC;
+  getImpl().RawComments[D] = RC;
 }
 
 Optional<StringRef> ASTContext::getBriefComment(const Decl *D) {
-  auto Known = Impl.BriefComments.find(D);
-  if (Known == Impl.BriefComments.end())
+  auto Known = getImpl().BriefComments.find(D);
+  if (Known == getImpl().BriefComments.end())
     return None;
 
   return Known->second;
 }
 
 void ASTContext::setBriefComment(const Decl *D, StringRef Comment) {
-  Impl.BriefComments[D] = Comment;
+  getImpl().BriefComments[D] = Comment;
 }
 
 unsigned ValueDecl::getLocalDiscriminator() const {
   assert(getDeclContext()->isLocalContext());
-  auto &discriminators = getASTContext().Impl.LocalDiscriminators;
+  auto &discriminators = getASTContext().getImpl().LocalDiscriminators;
   auto it = discriminators.find(this);
   if (it == discriminators.end())
     return 0;
@@ -1787,10 +1808,10 @@ unsigned ValueDecl::getLocalDiscriminator() const {
 void ValueDecl::setLocalDiscriminator(unsigned index) {
   assert(getDeclContext()->isLocalContext());
   if (!index) {
-    assert(!getASTContext().Impl.LocalDiscriminators.count(this));
+    assert(!getASTContext().getImpl().LocalDiscriminators.count(this));
     return;
   }
-  getASTContext().Impl.LocalDiscriminators.insert({this, index});
+  getASTContext().getImpl().LocalDiscriminators.insert({this, index});
 }
 
 NormalProtocolConformance *
@@ -1827,7 +1848,7 @@ ASTContext::getConformance(Type conformingType,
   // Did we already record the normal conformance?
   void *insertPos;
   auto &normalConformances =
-    Impl.getArena(AllocationArena::Permanent).NormalConformances;
+    getImpl().getArena(AllocationArena::Permanent).NormalConformances;
   if (auto result = normalConformances.FindNodeOrInsertPos(id, insertPos))
     return result;
 
@@ -1887,7 +1908,7 @@ ASTContext::getSpecializedConformance(Type type,
 
   // Did we already record the specialized conformance?
   void *insertPos;
-  auto &specializedConformances = Impl.getArena(arena).SpecializedConformances;
+  auto &specializedConformances = getImpl().getArena(arena).SpecializedConformances;
   if (auto result = specializedConformances.FindNodeOrInsertPos(id, insertPos))
     return result;
 
@@ -1909,7 +1930,7 @@ ASTContext::getInheritedConformance(Type type, ProtocolConformance *inherited) {
 
   // Did we already record the normal protocol conformance?
   void *insertPos;
-  auto &inheritedConformances = Impl.getArena(arena).InheritedConformances;
+  auto &inheritedConformances = getImpl().getArena(arena).InheritedConformances;
   if (auto result
         = inheritedConformances.FindNodeOrInsertPos(id, insertPos))
     return result;
@@ -1923,8 +1944,8 @@ ASTContext::getInheritedConformance(Type type, ProtocolConformance *inherited) {
 LazyContextData *ASTContext::getOrCreateLazyContextData(
                                                 const DeclContext *dc,
                                                 LazyMemberLoader *lazyLoader) {
-  auto known = Impl.LazyContexts.find(dc);
-  if (known != Impl.LazyContexts.end()) {
+  auto known = getImpl().LazyContexts.find(dc);
+  if (known != getImpl().LazyContexts.end()) {
     // Make sure we didn't provide an incompatible lazy loader.
     assert(!lazyLoader || lazyLoader == known->second->loader);
     return known->second;
@@ -1935,14 +1956,14 @@ LazyContextData *ASTContext::getOrCreateLazyContextData(
   if (isa<NominalTypeDecl>(dc) || isa<ExtensionDecl>(dc)) {
     auto *contextData = Allocate<LazyIterableDeclContextData>();
     contextData->loader = lazyLoader;
-    Impl.LazyContexts[dc] = contextData;
+    getImpl().LazyContexts[dc] = contextData;
     return contextData;
   }
 
   // Create new lazy generic context data with the given loader.
   auto *contextData = Allocate<LazyGenericContextData>();
   contextData->loader = lazyLoader;
-  Impl.LazyContexts[dc] = contextData;
+  getImpl().LazyContexts[dc] = contextData;
   return contextData;
 }
 
@@ -1969,23 +1990,23 @@ LazyGenericContextData *ASTContext::getOrCreateLazyGenericContextData(
 void ASTContext::addDelayedConformanceDiag(
        NormalProtocolConformance *conformance,
        DelayedConformanceDiag fn) {
-  Impl.DelayedConformanceDiags[conformance].push_back(std::move(fn));
+  getImpl().DelayedConformanceDiags[conformance].push_back(std::move(fn));
 }
 
 void ASTContext::
 addDelayedMissingWitnesses(NormalProtocolConformance *conformance,
                            ArrayRef<ValueDecl*> witnesses) {
-  auto &bucket = Impl.DelayedMissingWitnesses[conformance];
+  auto &bucket = getImpl().DelayedMissingWitnesses[conformance];
   bucket.insert(bucket.end(), witnesses.begin(), witnesses.end());
 }
 
 std::vector<ValueDecl*> ASTContext::
 takeDelayedMissingWitnesses(NormalProtocolConformance *conformance) {
   std::vector<ValueDecl*> result;
-  auto known = Impl.DelayedMissingWitnesses.find(conformance);
-  if (known != Impl.DelayedMissingWitnesses.end()) {
+  auto known = getImpl().DelayedMissingWitnesses.find(conformance);
+  if (known != getImpl().DelayedMissingWitnesses.end()) {
     result = std::move(known->second);
-    Impl.DelayedMissingWitnesses.erase(known);
+    getImpl().DelayedMissingWitnesses.erase(known);
   }
   return result;
 }
@@ -1993,10 +2014,10 @@ takeDelayedMissingWitnesses(NormalProtocolConformance *conformance) {
 std::vector<ASTContext::DelayedConformanceDiag>
 ASTContext::takeDelayedConformanceDiags(NormalProtocolConformance *conformance){
   std::vector<ASTContext::DelayedConformanceDiag> result;
-  auto known = Impl.DelayedConformanceDiags.find(conformance);
-  if (known != Impl.DelayedConformanceDiags.end()) {
+  auto known = getImpl().DelayedConformanceDiags.find(conformance);
+  if (known != getImpl().DelayedConformanceDiags.end()) {
     result = std::move(known->second);
-    Impl.DelayedConformanceDiags.erase(known);
+    getImpl().DelayedConformanceDiags.erase(known);
   }
   return result;
 }
@@ -2007,25 +2028,25 @@ size_t ASTContext::getTotalMemory() const {
     // ExternalDefinitions ?
     llvm::capacity_in_bytes(CanonicalGenericTypeParamTypeNames) +
     // RemappedTypes ?
-    sizeof(Impl) +
-    Impl.Allocator.getTotalMemory() +
-    Impl.Cleanups.capacity() +
-    llvm::capacity_in_bytes(Impl.ModuleLoaders) +
-    llvm::capacity_in_bytes(Impl.RawComments) +
-    llvm::capacity_in_bytes(Impl.BriefComments) +
-    llvm::capacity_in_bytes(Impl.LocalDiscriminators) +
-    llvm::capacity_in_bytes(Impl.ModuleTypes) +
-    llvm::capacity_in_bytes(Impl.GenericParamTypes) +
-    // Impl.GenericFunctionTypes ?
-    // Impl.SILFunctionTypes ?
-    llvm::capacity_in_bytes(Impl.SILBlockStorageTypes) +
-    llvm::capacity_in_bytes(Impl.IntegerTypes) +
-    // Impl.ProtocolCompositionTypes ?
-    // Impl.BuiltinVectorTypes ?
-    // Impl.GenericSignatures ?
-    // Impl.CompoundNames ?
-    Impl.OpenedExistentialArchetypes.getMemorySize() +
-    Impl.Permanent.getTotalMemory();
+    sizeof(getImpl()) +
+    getImpl().Allocator.getTotalMemory() +
+    getImpl().Cleanups.capacity() +
+    llvm::capacity_in_bytes(getImpl().ModuleLoaders) +
+    llvm::capacity_in_bytes(getImpl().RawComments) +
+    llvm::capacity_in_bytes(getImpl().BriefComments) +
+    llvm::capacity_in_bytes(getImpl().LocalDiscriminators) +
+    llvm::capacity_in_bytes(getImpl().ModuleTypes) +
+    llvm::capacity_in_bytes(getImpl().GenericParamTypes) +
+    // getImpl().GenericFunctionTypes ?
+    // getImpl().SILFunctionTypes ?
+    llvm::capacity_in_bytes(getImpl().SILBlockStorageTypes) +
+    llvm::capacity_in_bytes(getImpl().IntegerTypes) +
+    // getImpl().ProtocolCompositionTypes ?
+    // getImpl().BuiltinVectorTypes ?
+    // getImpl().GenericSignatures ?
+    // getImpl().CompoundNames ?
+    getImpl().OpenedExistentialArchetypes.getMemorySize() +
+    getImpl().Permanent.getTotalMemory();
 
     Size += getSolverMemory();
 
@@ -2035,9 +2056,9 @@ size_t ASTContext::getTotalMemory() const {
 size_t ASTContext::getSolverMemory() const {
   size_t Size = 0;
   
-  if (Impl.CurrentConstraintSolverArena) {
-    Size += Impl.CurrentConstraintSolverArena->getTotalMemory();
-    Size += Impl.CurrentConstraintSolverArena->Allocator.getBytesAllocated();
+  if (getImpl().CurrentConstraintSolverArena) {
+    Size += getImpl().CurrentConstraintSolverArena->getTotalMemory();
+    Size += getImpl().CurrentConstraintSolverArena->Allocator.getBytesAllocated();
   }
   
   return Size;
@@ -2355,7 +2376,7 @@ void ASTContext::recordObjCMethod(AbstractFunctionDecl *func) {
   if (func->hasClangNode())
     return;
 
-  Impl.ObjCMethods.push_back(func);
+  getImpl().ObjCMethods.push_back(func);
 }
 
 /// Lookup for an Objective-C method with the given selector in the
@@ -2417,7 +2438,7 @@ static AbstractFunctionDecl *lookupObjCMethodInType(
 void AbstractFunctionDecl::setForeignErrorConvention(
                                          const ForeignErrorConvention &conv) {
   assert(hasThrows() && "setting error convention on non-throwing decl");
-  auto &conventionsMap = getASTContext().Impl.ForeignErrorConventions;
+  auto &conventionsMap = getASTContext().getImpl().ForeignErrorConventions;
   assert(!conventionsMap.count(this) && "error convention already set");
   conventionsMap.insert({this, conv});
 }
@@ -2428,7 +2449,7 @@ AbstractFunctionDecl::getForeignErrorConvention() const {
     return None;
   if (!hasThrows())
     return None;
-  auto &conventionsMap = getASTContext().Impl.ForeignErrorConventions;
+  auto &conventionsMap = getASTContext().getImpl().ForeignErrorConventions;
   auto it = conventionsMap.find(this);
   if (it == conventionsMap.end()) return None;
   return it->second;
@@ -2445,10 +2466,10 @@ bool ASTContext::diagnoseUnintendedObjCMethodOverrides(SourceFile &sf) {
 
     return false;
   };
-  Impl.ObjCMethods.erase(std::remove_if(Impl.ObjCMethods.begin(),
-                                        Impl.ObjCMethods.end(),
+  getImpl().ObjCMethods.erase(std::remove_if(getImpl().ObjCMethods.begin(),
+                                        getImpl().ObjCMethods.end(),
                                         captureMethodInSourceFile),
-                         Impl.ObjCMethods.end());
+                         getImpl().ObjCMethods.end());
 
   // If no Objective-C methods were defined in this file, we're done.
   if (methods.empty())
@@ -2540,7 +2561,7 @@ bool ASTContext::diagnoseUnintendedObjCMethodOverrides(SourceFile &sf) {
 void ASTContext::recordObjCMethodConflict(ClassDecl *classDecl,
                                           ObjCSelector selector,
                                           bool isInstance) {
-  Impl.ObjCMethodConflicts.push_back(std::make_tuple(classDecl, selector,
+  getImpl().ObjCMethodConflicts.push_back(std::make_tuple(classDecl, selector,
                                                      isInstance));
 }
 
@@ -2614,14 +2635,14 @@ static bool shouldAssociateConflictWithSourceFile(
 
 bool ASTContext::diagnoseObjCMethodConflicts(SourceFile &sf) {
   // If there were no conflicts, we're done.
-  if (Impl.ObjCMethodConflicts.empty())
+  if (getImpl().ObjCMethodConflicts.empty())
     return false;
 
   // Partition the set of conflicts to put the conflicts that involve
   // this source file at the end.
   auto firstLocalConflict
-    = std::partition(Impl.ObjCMethodConflicts.begin(),
-                     Impl.ObjCMethodConflicts.end(),
+    = std::partition(getImpl().ObjCMethodConflicts.begin(),
+                     getImpl().ObjCMethodConflicts.end(),
                      [&](const ObjCMethodConflict &conflict) -> bool {
                        auto decls = getObjCMethodConflictDecls(conflict);
                        if (shouldAssociateConflictWithSourceFile(sf, decls)) {
@@ -2640,7 +2661,7 @@ bool ASTContext::diagnoseObjCMethodConflicts(SourceFile &sf) {
 
   // If there were no local conflicts, we're done.
   unsigned numLocalConflicts
-    = Impl.ObjCMethodConflicts.end() - firstLocalConflict;
+    = getImpl().ObjCMethodConflicts.end() - firstLocalConflict;
   if (numLocalConflicts == 0)
     return false;
 
@@ -2709,15 +2730,15 @@ bool ASTContext::diagnoseObjCMethodConflicts(SourceFile &sf) {
   }
 
   // Erase the local conflicts from the list of conflicts.
-  Impl.ObjCMethodConflicts.erase(firstLocalConflict,
-                                 Impl.ObjCMethodConflicts.end());
+  getImpl().ObjCMethodConflicts.erase(firstLocalConflict,
+                                 getImpl().ObjCMethodConflicts.end());
 
   return anyConflicts;
 }
 
 void ASTContext::recordObjCUnsatisfiedOptReq(DeclContext *dc,
                                              AbstractFunctionDecl *req) {
-  Impl.ObjCUnsatisfiedOptReqs.push_back(ObjCUnsatisfiedOptReq(dc, req));
+  getImpl().ObjCUnsatisfiedOptReqs.push_back(ObjCUnsatisfiedOptReq(dc, req));
 }
 
 /// Retrieve the source location associated with this declaration
@@ -2731,21 +2752,21 @@ static SourceLoc getDeclContextLoc(DeclContext *dc) {
 
 bool ASTContext::diagnoseObjCUnsatisfiedOptReqConflicts(SourceFile &sf) {
   // If there are no unsatisfied, optional @objc requirements, we're done.
-  if (Impl.ObjCUnsatisfiedOptReqs.empty())
+  if (getImpl().ObjCUnsatisfiedOptReqs.empty())
     return false;
 
   // Partition the set of unsatisfied requirements to put the
   // conflicts that involve this source file at the end.
   auto firstLocalReq
-    = std::partition(Impl.ObjCUnsatisfiedOptReqs.begin(),
-                     Impl.ObjCUnsatisfiedOptReqs.end(),
+    = std::partition(getImpl().ObjCUnsatisfiedOptReqs.begin(),
+                     getImpl().ObjCUnsatisfiedOptReqs.end(),
                      [&](const ObjCUnsatisfiedOptReq &unsatisfied) -> bool {
                        return &sf != unsatisfied.first->getParentSourceFile();
                      });
 
   // If there were no local unsatisfied requirements, we're done.
   unsigned numLocalReqs
-    = Impl.ObjCUnsatisfiedOptReqs.end() - firstLocalReq;
+    = getImpl().ObjCUnsatisfiedOptReqs.end() - firstLocalReq;
   if (numLocalReqs == 0)
     return false;
 
@@ -2839,8 +2860,8 @@ bool ASTContext::diagnoseObjCUnsatisfiedOptReqConflicts(SourceFile &sf) {
   }
 
   // Erase the local unsatisfied requirements from the list.
-  Impl.ObjCUnsatisfiedOptReqs.erase(firstLocalReq,
-                                    Impl.ObjCUnsatisfiedOptReqs.end());
+  getImpl().ObjCUnsatisfiedOptReqs.erase(firstLocalReq,
+                                    getImpl().ObjCUnsatisfiedOptReqs.end());
 
   return anyDiagnosed;
 }
@@ -2923,7 +2944,7 @@ NameAliasType *NameAliasType::get(TypeAliasDecl *typealias, Type parent,
 
   // Did we already record this type?
   void *insertPos;
-  auto &types = ctx.Impl.getArena(arena).NameAliasTypes;
+  auto &types = ctx.getImpl().getArena(arena).NameAliasTypes;
   if (auto result = types.FindNodeOrInsertPos(id, insertPos))
     return result;
 
@@ -2963,7 +2984,7 @@ Type ErrorType::get(Type originalType) {
   auto arena = getArena(originalProperties);
 
   auto &ctx = originalType->getASTContext();
-  auto &entry = ctx.Impl.getArena(arena).ErrorTypesWithOriginal[originalType];
+  auto &entry = ctx.getImpl().getArena(arena).ErrorTypesWithOriginal[originalType];
   if (entry) return entry;
 
   void *mem = ctx.Allocate(sizeof(ErrorType) + sizeof(Type),
@@ -2976,7 +2997,7 @@ Type ErrorType::get(Type originalType) {
 
 BuiltinIntegerType *BuiltinIntegerType::get(BuiltinIntegerWidth BitWidth,
                                             const ASTContext &C) {
-  BuiltinIntegerType *&Result = C.Impl.IntegerTypes[BitWidth];
+  BuiltinIntegerType *&Result = C.getImpl().IntegerTypes[BitWidth];
   if (Result == nullptr)
     Result = new (C, AllocationArena::Permanent) BuiltinIntegerType(BitWidth,C);
   return Result;
@@ -2990,14 +3011,14 @@ BuiltinVectorType *BuiltinVectorType::get(const ASTContext &context,
 
   void *insertPos;
   if (BuiltinVectorType *vecType
-        = context.Impl.BuiltinVectorTypes.FindNodeOrInsertPos(id, insertPos))
+        = context.getImpl().BuiltinVectorTypes.FindNodeOrInsertPos(id, insertPos))
     return vecType;
 
   assert(elementType->isCanonical() && "Non-canonical builtin vector?");
   BuiltinVectorType *vecTy
     = new (context, AllocationArena::Permanent)
        BuiltinVectorType(context, elementType, numElements);
-  context.Impl.BuiltinVectorTypes.InsertNode(vecTy, insertPos);
+  context.getImpl().BuiltinVectorTypes.InsertNode(vecTy, insertPos);
   return vecTy;
 }
 
@@ -3011,7 +3032,7 @@ ParenType *ParenType::get(const ASTContext &C, Type underlying,
   auto properties = underlying->getRecursiveProperties();
   auto arena = getArena(properties);
   ParenType *&Result =
-      C.Impl.getArena(arena).ParenTypes[{underlying, fl.toRaw()}];
+      C.getImpl().getArena(arena).ParenTypes[{underlying, fl.toRaw()}];
   if (Result == nullptr) {
     Result = new (C, arena) ParenType(underlying,
                                       properties, fl);
@@ -3066,7 +3087,7 @@ Type TupleType::get(ArrayRef<TupleTypeElt> Fields, const ASTContext &C) {
   TupleType::Profile(ID, Fields);
 
   if (TupleType *TT
-        = C.Impl.getArena(arena).TupleTypes.FindNodeOrInsertPos(ID,InsertPos))
+        = C.getImpl().getArena(arena).TupleTypes.FindNodeOrInsertPos(ID,InsertPos))
     return TT;
 
   bool IsCanonical = true;   // All canonical elts means this is canonical.
@@ -3083,7 +3104,7 @@ Type TupleType::get(ArrayRef<TupleTypeElt> Fields, const ASTContext &C) {
                          alignof(TupleType), arena);
   auto New = new (mem) TupleType(Fields, IsCanonical ? &C : nullptr, properties,
                                  hasInOut);
-  C.Impl.getArena(arena).TupleTypes.InsertNode(New, InsertPos);
+  C.getImpl().getArena(arena).TupleTypes.InsertNode(New, InsertPos);
   return New;
 }
 
@@ -3208,13 +3229,13 @@ get(GenericTypeDecl *TheDecl, Type Parent, const ASTContext &C) {
   if (Parent) properties |= Parent->getRecursiveProperties();
   auto arena = getArena(properties);
 
-  if (auto unbound = C.Impl.getArena(arena).UnboundGenericTypes
+  if (auto unbound = C.getImpl().getArena(arena).UnboundGenericTypes
                         .FindNodeOrInsertPos(ID, InsertPos))
     return unbound;
 
   auto result = new (C, arena) UnboundGenericType(TheDecl, Parent, C,
                                                   properties);
-  C.Impl.getArena(arena).UnboundGenericTypes.InsertNode(result, InsertPos);
+  C.getImpl().getArena(arena).UnboundGenericTypes.InsertNode(result, InsertPos);
   return result;
 }
 
@@ -3265,7 +3286,7 @@ BoundGenericType *BoundGenericType::get(NominalTypeDecl *TheDecl,
 
   void *InsertPos = nullptr;
   if (BoundGenericType *BGT =
-        C.Impl.getArena(arena).BoundGenericTypes.FindNodeOrInsertPos(ID,
+        C.getImpl().getArena(arena).BoundGenericTypes.FindNodeOrInsertPos(ID,
                                                                      InsertPos))
     return BGT;
 
@@ -3298,7 +3319,7 @@ BoundGenericType *BoundGenericType::get(NominalTypeDecl *TheDecl,
   } else {
     llvm_unreachable("Unhandled NominalTypeDecl");
   }
-  C.Impl.getArena(arena).BoundGenericTypes.InsertNode(newType, InsertPos);
+  C.getImpl().getArena(arena).BoundGenericTypes.InsertNode(newType, InsertPos);
 
   return newType;
 }
@@ -3341,11 +3362,11 @@ EnumType *EnumType::get(EnumDecl *D, Type Parent, const ASTContext &C) {
 
   void *insertPos = nullptr;
   if (auto enumTy
-        = C.Impl.getArena(arena).EnumTypes.FindNodeOrInsertPos(id, insertPos))
+        = C.getImpl().getArena(arena).EnumTypes.FindNodeOrInsertPos(id, insertPos))
     return enumTy;
 
   auto enumTy = new (C, arena) EnumType(D, Parent, C, properties);
-  C.Impl.getArena(arena).EnumTypes.InsertNode(enumTy, insertPos);
+  C.getImpl().getArena(arena).EnumTypes.InsertNode(enumTy, insertPos);
   return enumTy;
 }
 
@@ -3368,11 +3389,11 @@ StructType *StructType::get(StructDecl *D, Type Parent, const ASTContext &C) {
 
   void *insertPos = nullptr;
   if (auto structTy
-        = C.Impl.getArena(arena).StructTypes.FindNodeOrInsertPos(id, insertPos))
+        = C.getImpl().getArena(arena).StructTypes.FindNodeOrInsertPos(id, insertPos))
     return structTy;
 
   auto structTy = new (C, arena) StructType(D, Parent, C, properties);
-  C.Impl.getArena(arena).StructTypes.InsertNode(structTy, insertPos);
+  C.getImpl().getArena(arena).StructTypes.InsertNode(structTy, insertPos);
   return structTy;
 }
 
@@ -3395,11 +3416,11 @@ ClassType *ClassType::get(ClassDecl *D, Type Parent, const ASTContext &C) {
 
   void *insertPos = nullptr;
   if (auto classTy
-        = C.Impl.getArena(arena).ClassTypes.FindNodeOrInsertPos(id, insertPos))
+        = C.getImpl().getArena(arena).ClassTypes.FindNodeOrInsertPos(id, insertPos))
     return classTy;
 
   auto classTy = new (C, arena) ClassType(D, Parent, C, properties);
-  C.Impl.getArena(arena).ClassTypes.InsertNode(classTy, insertPos);
+  C.getImpl().getArena(arena).ClassTypes.InsertNode(classTy, insertPos);
   return classTy;
 }
 
@@ -3428,7 +3449,7 @@ ProtocolCompositionType::build(const ASTContext &C, ArrayRef<Type> Members,
   auto arena = getArena(properties);
 
   if (auto compTy
-      = C.Impl.getArena(arena).ProtocolCompositionTypes
+      = C.getImpl().getArena(arena).ProtocolCompositionTypes
           .FindNodeOrInsertPos(ID, InsertPos))
     return compTy;
 
@@ -3439,7 +3460,7 @@ ProtocolCompositionType::build(const ASTContext &C, ArrayRef<Type> Members,
                                                   Members,
                                                   HasExplicitAnyObject,
                                                   properties);
-  C.Impl.getArena(arena).ProtocolCompositionTypes.InsertNode(compTy, InsertPos);
+  C.getImpl().getArena(arena).ProtocolCompositionTypes.InsertNode(compTy, InsertPos);
   return compTy;
 }
 
@@ -3453,7 +3474,7 @@ ReferenceStorageType *ReferenceStorageType::get(Type T,
   auto arena = getArena(properties);
 
   auto key = uintptr_t(T.getPointer()) | unsigned(ownership);
-  auto &entry = C.Impl.getArena(arena).ReferenceStorageTypes[key];
+  auto &entry = C.getImpl().getArena(arena).ReferenceStorageTypes[key];
   if (entry) return entry;
 
 
@@ -3498,7 +3519,7 @@ MetatypeType *MetatypeType::get(Type T, Optional<MetatypeRepresentation> Repr,
   else
     reprKey = 0;
 
-  MetatypeType *&Entry = Ctx.Impl.getArena(arena).MetatypeTypes[{T, reprKey}];
+  MetatypeType *&Entry = Ctx.getImpl().getArena(arena).MetatypeTypes[{T, reprKey}];
   if (Entry) return Entry;
 
   return Entry = new (Ctx, arena) MetatypeType(
@@ -3523,7 +3544,7 @@ ExistentialMetatypeType::get(Type T, Optional<MetatypeRepresentation> repr,
   else
     reprKey = 0;
 
-  auto &entry = ctx.Impl.getArena(arena).ExistentialMetatypeTypes[{T, reprKey}];
+  auto &entry = ctx.getImpl().getArena(arena).ExistentialMetatypeTypes[{T, reprKey}];
   if (entry) return entry;
 
   return entry = new (ctx, arena) ExistentialMetatypeType(
@@ -3546,7 +3567,7 @@ ExistentialMetatypeType::ExistentialMetatypeType(Type T,
 ModuleType *ModuleType::get(ModuleDecl *M) {
   ASTContext &C = M->getASTContext();
 
-  ModuleType *&Entry = C.Impl.ModuleTypes[M];
+  ModuleType *&Entry = C.getImpl().ModuleTypes[M];
   if (Entry) return Entry;
 
   return Entry = new (C, AllocationArena::Permanent) ModuleType(M, C);
@@ -3559,7 +3580,7 @@ DynamicSelfType *DynamicSelfType::get(Type selfType, const ASTContext &ctx) {
   auto properties = selfType->getRecursiveProperties();
   auto arena = getArena(properties);
 
-  auto &dynamicSelfTypes = ctx.Impl.getArena(arena).DynamicSelfTypes;
+  auto &dynamicSelfTypes = ctx.getImpl().getArena(arena).DynamicSelfTypes;
   auto known = dynamicSelfTypes.find(selfType);
   if (known != dynamicSelfTypes.end())
     return known->second;
@@ -3687,7 +3708,7 @@ FunctionType *FunctionType::get(Type input, Type result,
   const ASTContext &C = input->getASTContext();
 
   FunctionType *&Entry
-    = C.Impl.getArena(arena).FunctionTypes[{input, {result, attrKey} }];
+    = C.getImpl().getArena(arena).FunctionTypes[{input, {result, attrKey} }];
   if (Entry) return Entry;
   
   SmallVector<AnyFunctionType::Param, 4> params;
@@ -3760,7 +3781,7 @@ GenericFunctionType::get(GenericSignature *sig,
   // Do we already have this generic function type?
   void *insertPos;
   if (auto result
-        = ctx.Impl.GenericFunctionTypes.FindNodeOrInsertPos(id, insertPos)) {
+        = ctx.getImpl().GenericFunctionTypes.FindNodeOrInsertPos(id, insertPos)) {
     return result;
   }
 
@@ -3774,7 +3795,7 @@ GenericFunctionType::get(GenericSignature *sig,
     && sig->isCanonicalTypeInContext(output);
 
   if (auto result
-        = ctx.Impl.GenericFunctionTypes.FindNodeOrInsertPos(id, insertPos)) {
+        = ctx.getImpl().GenericFunctionTypes.FindNodeOrInsertPos(id, insertPos)) {
     return result;
   }
   
@@ -3789,7 +3810,7 @@ GenericFunctionType::get(GenericSignature *sig,
                                               isCanonical ? &ctx : nullptr,
                                               properties);
 
-  ctx.Impl.GenericFunctionTypes.InsertNode(result, insertPos);
+  ctx.getImpl().GenericFunctionTypes.InsertNode(result, insertPos);
   return result;
 }
 
@@ -3809,13 +3830,13 @@ GenericFunctionType::GenericFunctionType(
 
 GenericTypeParamType *GenericTypeParamType::get(unsigned depth, unsigned index,
                                                 const ASTContext &ctx) {
-  auto known = ctx.Impl.GenericParamTypes.find({ depth, index });
-  if (known != ctx.Impl.GenericParamTypes.end())
+  auto known = ctx.getImpl().GenericParamTypes.find({ depth, index });
+  if (known != ctx.getImpl().GenericParamTypes.end())
     return known->second;
 
   auto result = new (ctx, AllocationArena::Permanent)
                   GenericTypeParamType(depth, index, ctx);
-  ctx.Impl.GenericParamTypes[{depth, index}] = result;
+  ctx.getImpl().GenericParamTypes[{depth, index}] = result;
   return result;
 }
 
@@ -3964,15 +3985,15 @@ SILFunctionType::SILFunctionType(GenericSignature *genericSig, ExtInfo ext,
 
 CanSILBlockStorageType SILBlockStorageType::get(CanType captureType) {
   ASTContext &ctx = captureType->getASTContext();
-  auto found = ctx.Impl.SILBlockStorageTypes.find(captureType);
-  if (found != ctx.Impl.SILBlockStorageTypes.end())
+  auto found = ctx.getImpl().SILBlockStorageTypes.find(captureType);
+  if (found != ctx.getImpl().SILBlockStorageTypes.end())
     return CanSILBlockStorageType(found->second);
   
   void *mem = ctx.Allocate(sizeof(SILBlockStorageType),
                            alignof(SILBlockStorageType));
   
   SILBlockStorageType *storageTy = new (mem) SILBlockStorageType(captureType);
-  ctx.Impl.SILBlockStorageTypes.insert({captureType, storageTy});
+  ctx.getImpl().SILBlockStorageTypes.insert({captureType, storageTy});
   return CanSILBlockStorageType(storageTy);
 }
 
@@ -3996,7 +4017,7 @@ CanSILFunctionType SILFunctionType::get(GenericSignature *genericSig,
   // Do we already have this generic function type?
   void *insertPos;
   if (auto result
-        = ctx.Impl.SILFunctionTypes.FindNodeOrInsertPos(id, insertPos))
+        = ctx.getImpl().SILFunctionTypes.FindNodeOrInsertPos(id, insertPos))
     return CanSILFunctionType(result);
 
   // All SILFunctionTypes are canonical.
@@ -4033,7 +4054,7 @@ CanSILFunctionType SILFunctionType::get(GenericSignature *genericSig,
       new (mem) SILFunctionType(genericSig, ext, coroutineKind, callee,
                                 params, yields, normalResults, errorResult,
                                 ctx, properties, witnessMethodConformance);
-  ctx.Impl.SILFunctionTypes.InsertNode(fnType, insertPos);
+  ctx.getImpl().SILFunctionTypes.InsertNode(fnType, insertPos);
   return CanSILFunctionType(fnType);
 }
 
@@ -4044,7 +4065,7 @@ ArraySliceType *ArraySliceType::get(Type base) {
 
   const ASTContext &C = base->getASTContext();
 
-  ArraySliceType *&entry = C.Impl.getArena(arena).ArraySliceTypes[base];
+  ArraySliceType *&entry = C.getImpl().getArena(arena).ArraySliceTypes[base];
   if (entry) return entry;
 
   return entry = new (C, arena) ArraySliceType(C, base, properties);
@@ -4058,7 +4079,7 @@ DictionaryType *DictionaryType::get(Type keyType, Type valueType) {
   const ASTContext &C = keyType->getASTContext();
 
   DictionaryType *&entry
-    = C.Impl.getArena(arena).DictionaryTypes[{keyType, valueType}];
+    = C.getImpl().getArena(arena).DictionaryTypes[{keyType, valueType}];
   if (entry) return entry;
 
   return entry = new (C, arena) DictionaryType(C, keyType, valueType, 
@@ -4071,7 +4092,7 @@ OptionalType *OptionalType::get(Type base) {
 
   const ASTContext &C = base->getASTContext();
 
-  OptionalType *&entry = C.Impl.getArena(arena).OptionalTypes[base];
+  OptionalType *&entry = C.getImpl().getArena(arena).OptionalTypes[base];
   if (entry) return entry;
 
   return entry = new (C, arena) OptionalType(C, base, properties);
@@ -4088,11 +4109,11 @@ ProtocolType *ProtocolType::get(ProtocolDecl *D, Type Parent,
 
   void *insertPos = nullptr;
   if (auto protoTy
-        = C.Impl.getArena(arena).ProtocolTypes.FindNodeOrInsertPos(id, insertPos))
+        = C.getImpl().getArena(arena).ProtocolTypes.FindNodeOrInsertPos(id, insertPos))
     return protoTy;
 
   auto protoTy = new (C, arena) ProtocolType(D, Parent, C, properties);
-  C.Impl.getArena(arena).ProtocolTypes.InsertNode(protoTy, insertPos);
+  C.getImpl().getArena(arena).ProtocolTypes.InsertNode(protoTy, insertPos);
 
   return protoTy;
 }
@@ -4119,7 +4140,7 @@ LValueType *LValueType::get(Type objectTy) {
   auto arena = getArena(properties);
 
   auto &C = objectTy->getASTContext();
-  auto &entry = C.Impl.getArena(arena).LValueTypes[objectTy];
+  auto &entry = C.getImpl().getArena(arena).LValueTypes[objectTy];
   if (entry)
     return entry;
 
@@ -4138,7 +4159,7 @@ InOutType *InOutType::get(Type objectTy) {
   auto arena = getArena(properties);
 
   auto &C = objectTy->getASTContext();
-  auto &entry = C.Impl.getArena(arena).InOutTypes[objectTy];
+  auto &entry = C.getImpl().getArena(arena).InOutTypes[objectTy];
   if (entry)
     return entry;
 
@@ -4154,7 +4175,7 @@ DependentMemberType *DependentMemberType::get(Type base, Identifier name) {
 
   llvm::PointerUnion<Identifier, AssociatedTypeDecl *> stored(name);
   const ASTContext &ctx = base->getASTContext();
-  auto *&known = ctx.Impl.getArena(arena).DependentMemberTypes[
+  auto *&known = ctx.getImpl().getArena(arena).DependentMemberTypes[
                                             {base, stored.getOpaqueValue()}];
   if (!known) {
     const ASTContext *canonicalCtx = base->isCanonical() ? &ctx : nullptr;
@@ -4173,7 +4194,7 @@ DependentMemberType *DependentMemberType::get(Type base,
 
   llvm::PointerUnion<Identifier, AssociatedTypeDecl *> stored(assocType);
   const ASTContext &ctx = base->getASTContext();
-  auto *&known = ctx.Impl.getArena(arena).DependentMemberTypes[
+  auto *&known = ctx.getImpl().getArena(arena).DependentMemberTypes[
                                             {base, stored.getOpaqueValue()}];
   if (!known) {
     const ASTContext *canonicalCtx = base->isCanonical() ? &ctx : nullptr;
@@ -4186,7 +4207,7 @@ DependentMemberType *DependentMemberType::get(Type base,
 CanArchetypeType ArchetypeType::getOpened(Type existential,
                                           Optional<UUID> knownID) {
   auto &ctx = existential->getASTContext();
-  auto &openedExistentialArchetypes = ctx.Impl.OpenedExistentialArchetypes;
+  auto &openedExistentialArchetypes = ctx.getImpl().OpenedExistentialArchetypes;
   // If we know the ID already...
   if (knownID) {
     // ... and we already have an archetype for that ID, return it.
@@ -4339,7 +4360,7 @@ SubstitutionMap::Storage *SubstitutionMap::Storage::get(
   // Did we already record this substitution map?
   auto &ctx = genericSig->getASTContext();
   void *insertPos;
-  auto &substitutionMaps = ctx.Impl.getArena(arena).SubstitutionMaps;
+  auto &substitutionMaps = ctx.getImpl().getArena(arena).SubstitutionMaps;
   if (auto result = substitutionMaps.FindNodeOrInsertPos(id, insertPos))
     return result;
 
@@ -4399,7 +4420,7 @@ GenericSignature::get(TypeArrayView<GenericTypeParamType> params,
 
   auto &ctx = getASTContext(params, requirements);
   void *insertPos;
-  if (auto *sig = ctx.Impl.GenericSignatures.FindNodeOrInsertPos(ID,
+  if (auto *sig = ctx.getImpl().GenericSignatures.FindNodeOrInsertPos(ID,
                                                                  insertPos)) {
     if (isKnownCanonical)
       sig->CanonicalSignatureOrASTContext = &ctx;
@@ -4413,7 +4434,7 @@ GenericSignature::get(TypeArrayView<GenericTypeParamType> params,
   void *mem = ctx.Allocate(bytes, alignof(GenericSignature));
   auto newSig = new (mem) GenericSignature(params, requirements,
                                            isKnownCanonical);
-  ctx.Impl.GenericSignatures.InsertNode(newSig, insertPos);
+  ctx.getImpl().GenericSignatures.InsertNode(newSig, insertPos);
   return newSig;
 }
 
@@ -4450,7 +4471,7 @@ void DeclName::initialize(ASTContext &C, DeclBaseName baseName,
 
   void *insert = nullptr;
   if (CompoundDeclName *compoundName
-        = C.Impl.CompoundNames.FindNodeOrInsertPos(id, insert)) {
+        = C.getImpl().CompoundNames.FindNodeOrInsertPos(id, insert)) {
     SimpleOrCompound = compoundName;
     return;
   }
@@ -4462,7 +4483,7 @@ void DeclName::initialize(ASTContext &C, DeclBaseName baseName,
   std::uninitialized_copy(argumentNames.begin(), argumentNames.end(),
                           compoundName->getArgumentNames().begin());
   SimpleOrCompound = compoundName;
-  C.Impl.CompoundNames.InsertNode(compoundName, insert);
+  C.getImpl().CompoundNames.InsertNode(compoundName, insert);
 }
 
 /// Build a compound value name given a base name and a set of argument names
@@ -4540,11 +4561,11 @@ ASTContext::getForeignRepresentationInfo(NominalTypeDecl *nominal,
       auto info = ForeignRepresentationInfo::forTrivial();
       if (allowOptional)
         info = ForeignRepresentationInfo::forTrivialWithOptional();
-      Impl.ForeignRepresentableCache.insert({type, info});
+      getImpl().ForeignRepresentableCache.insert({type, info});
     }
   };
 
-  if (Impl.ForeignRepresentableCache.empty()) {
+  if (getImpl().ForeignRepresentableCache.empty()) {
     // Pre-populate the foreign-representable cache with known types.
     if (auto stdlib = getStdlibModule()) {
       addTrivial(getIdentifier("OpaquePointer"), stdlib, true);
@@ -4602,8 +4623,8 @@ ASTContext::getForeignRepresentationInfo(NominalTypeDecl *nominal,
   // Determine whether we know anything about this nominal type
   // yet. If we've never seen this nominal type before, or if we have
   // an out-of-date negative cached value, we'll have to go looking.
-  auto known = Impl.ForeignRepresentableCache.find(nominal);
-  bool wasNotFoundInCache = known == Impl.ForeignRepresentableCache.end();
+  auto known = getImpl().ForeignRepresentableCache.find(nominal);
+  bool wasNotFoundInCache = known == getImpl().ForeignRepresentableCache.end();
 
   // For the REPL. We might have initialized the cache above before CoreGraphics
   // was loaded.
@@ -4620,8 +4641,8 @@ ASTContext::getForeignRepresentationInfo(NominalTypeDecl *nominal,
     if (nominal->getName() == typeName && wasNotFoundInCache) {
       if (auto module = getLoadedModule(moduleName)) {
         addTrivial(typeName, module, allowOptional);
-        known = Impl.ForeignRepresentableCache.find(nominal);
-        wasNotFoundInCache = known == Impl.ForeignRepresentableCache.end();
+        known = getImpl().ForeignRepresentableCache.find(nominal);
+        wasNotFoundInCache = known == getImpl().ForeignRepresentableCache.end();
       }
     }
   };
@@ -4673,7 +4694,7 @@ ASTContext::getForeignRepresentationInfo(NominalTypeDecl *nominal,
       result = ForeignRepresentationInfo::forNone(CurrentGeneration);
     
     // Cache the result.
-    known = Impl.ForeignRepresentableCache.insert({ nominal, *result }).first;
+    known = getImpl().ForeignRepresentableCache.insert({ nominal, *result }).first;
   }
 
   // Map a cache entry to a result for this specific 
@@ -4837,20 +4858,20 @@ Type ASTContext::getBridgedToObjC(const DeclContext *dc, Type type,
 }
 
 CanGenericSignature ASTContext::getSingleGenericParameterSignature() const {
-  if (auto theSig = Impl.SingleGenericParameterSignature)
+  if (auto theSig = getImpl().SingleGenericParameterSignature)
     return theSig;
   
   auto param = GenericTypeParamType::get(0, 0, *this);
   auto sig = GenericSignature::get(param, { });
   auto canonicalSig = CanGenericSignature(sig);
-  Impl.SingleGenericParameterSignature = canonicalSig;
+  getImpl().SingleGenericParameterSignature = canonicalSig;
   return canonicalSig;
 }
 
 CanGenericSignature ASTContext::getExistentialSignature(CanType existential,
                                                         ModuleDecl *mod) {
-  auto found = Impl.ExistentialSignatures.find(existential);
-  if (found != Impl.ExistentialSignatures.end())
+  auto found = getImpl().ExistentialSignatures.find(existential);
+  if (found != getImpl().ExistentialSignatures.end())
     return found->second;
 
   assert(existential.isExistentialType());
@@ -4868,7 +4889,7 @@ CanGenericSignature ASTContext::getExistentialSignature(CanType existential,
 
   CanGenericSignature genericSig(std::move(builder).computeGenericSignature(SourceLoc()));
 
-  auto result = Impl.ExistentialSignatures.insert(
+  auto result = getImpl().ExistentialSignatures.insert(
     std::make_pair(existential, genericSig));
   assert(result.second);
   (void) result;
@@ -4885,7 +4906,7 @@ SILLayout *SILLayout::get(ASTContext &C,
   
   // Return an existing layout if there is one.
   void *insertPos;
-  auto &Layouts = C.Impl.SILLayouts;
+  auto &Layouts = C.getImpl().SILLayouts;
   
   if (auto existing = Layouts.FindNodeOrInsertPos(id, insertPos))
     return existing;
@@ -4907,7 +4928,7 @@ CanSILBoxType SILBoxType::get(ASTContext &C,
 
   // Return an existing layout if there is one.
   void *insertPos;
-  auto &SILBoxTypes = C.Impl.SILBoxTypes;
+  auto &SILBoxTypes = C.getImpl().SILBoxTypes;
   llvm::FoldingSetNodeID id;
   Profile(id, Layout, Substitutions);
   if (auto existing = SILBoxTypes.FindNodeOrInsertPos(id, insertPos))
@@ -4962,7 +4983,7 @@ LayoutConstraint LayoutConstraint::getLayoutConstraint(LayoutConstraintKind Kind
 
   void *InsertPos = nullptr;
   if (LayoutConstraintInfo *Layout =
-          C.Impl.getArena(AllocationArena::Permanent)
+          C.getImpl().getArena(AllocationArena::Permanent)
               .LayoutConstraints.FindNodeOrInsertPos(ID, InsertPos))
     return LayoutConstraint(Layout);
 
@@ -4971,7 +4992,7 @@ LayoutConstraint LayoutConstraint::getLayoutConstraint(LayoutConstraintKind Kind
           ? new (C, AllocationArena::Permanent)
                 LayoutConstraintInfo(Kind, SizeInBits, Alignment)
           : new (C, AllocationArena::Permanent) LayoutConstraintInfo(Kind);
-  C.Impl.getArena(AllocationArena::Permanent)
+  C.getImpl().getArena(AllocationArena::Permanent)
       .LayoutConstraints.InsertNode(New, InsertPos);
   return LayoutConstraint(New);
 }

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -149,9 +149,9 @@ bool CompilerInstance::setup(const CompilerInvocation &Invok) {
     Invocation.getLangOptions().AttachCommentsToDecls = true;
   }
 
-  Context.reset(new ASTContext(Invocation.getLangOptions(),
-                               Invocation.getSearchPathOptions(), SourceMgr,
-                               Diagnostics));
+  Context.reset(ASTContext::get(Invocation.getLangOptions(),
+                                Invocation.getSearchPathOptions(), SourceMgr,
+                                Diagnostics));
 
   if (setUpModuleLoaders())
     return true;

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -979,7 +979,7 @@ struct ParserUnit::Implementation {
   LangOptions LangOpts;
   SearchPathOptions SearchPathOpts;
   DiagnosticEngine Diags;
-  ASTContext Ctx;
+  ASTContext &Ctx;
   SourceFile *SF;
   std::unique_ptr<Parser> TheParser;
 
@@ -987,7 +987,7 @@ struct ParserUnit::Implementation {
                  const LangOptions &Opts, StringRef ModuleName)
     : LangOpts(Opts),
       Diags(SM),
-      Ctx(LangOpts, SearchPathOpts, SM, Diags),
+      Ctx(*ASTContext::get(LangOpts, SearchPathOpts, SM, Diags)),
       SF(new (Ctx) SourceFile(
             *ModuleDecl::create(Ctx.getIdentifier(ModuleName), Ctx),
             SourceFileKind::Main, BufferID,

--- a/tools/driver/modulewrap_main.cpp
+++ b/tools/driver/modulewrap_main.cpp
@@ -169,7 +169,8 @@ int modulewrap_main(ArrayRef<const char *> Args, const char *Argv0,
   SourceManager SrcMgr;
   LangOptions LangOpts;
   LangOpts.Target = Invocation.getTargetTriple();
-  ASTContext ASTCtx(LangOpts, SearchPathOpts, SrcMgr, Instance.getDiags());
+  ASTContext &ASTCtx = *ASTContext::get(LangOpts, SearchPathOpts, SrcMgr,
+                                        Instance.getDiags());
   ClangImporterOptions ClangImporterOpts;
   ASTCtx.addModuleLoader(ClangImporter::create(ASTCtx, ClangImporterOpts, ""),
                          true);

--- a/unittests/AST/TestContext.cpp
+++ b/unittests/AST/TestContext.cpp
@@ -33,7 +33,7 @@ static void declareOptionalType(ASTContext &ctx, SourceFile *fileForLookups,
 }
 
 TestContext::TestContext(ShouldDeclareOptionalTypes optionals)
-    : Ctx(LangOpts, SearchPathOpts, SourceMgr, Diags) {
+    : Ctx(*ASTContext::get(LangOpts, SearchPathOpts, SourceMgr, Diags)) {
   auto stdlibID = Ctx.getIdentifier(STDLIB_NAME);
   auto *module = ModuleDecl::create(stdlibID, Ctx);
   Ctx.LoadedModules[stdlibID] = module;

--- a/unittests/AST/TestContext.h
+++ b/unittests/AST/TestContext.h
@@ -46,7 +46,7 @@ class TestContext : public TestContextBase {
   SourceFile *FileForLookups;
 
 public:
-  ASTContext Ctx;
+  ASTContext &Ctx;
 
   TestContext(ShouldDeclareOptionalTypes optionals = DoNotDeclareOptionalTypes);
 


### PR DESCRIPTION
Most of this change is mechanical: `Impl` -> `getImpl()`.