### PR TITLE
[SourceKit] Make the NameLength of EnumElements take argument labels into account

### DIFF
--- a/lib/IDE/SyntaxModel.cpp
+++ b/lib/IDE/SyntaxModel.cpp
@@ -16,6 +16,7 @@
 #include "swift/AST/Decl.h"
 #include "swift/AST/Expr.h"
 #include "swift/AST/Pattern.h"
+#include "swift/AST/ParameterList.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/Stmt.h"
 #include "swift/AST/TypeRepr.h"
@@ -870,8 +871,15 @@ bool ModelASTWalker::walkToDeclPre(Decl *D) {
         SN.Kind = SyntaxStructureKind::EnumElement;
         SN.Range = charSourceRangeFromSourceRange(SM,
                                                   EnumElemD->getSourceRange());
-        SN.NameRange = CharSourceRange(EnumElemD->getNameLoc(),
-                                       EnumElemD->getName().getLength());
+        if (auto ParamList = EnumElemD->getParameterList()) {
+          SourceRange NameRange = SourceRange(EnumElemD->getNameLoc(),
+                                              ParamList->getSourceRange().End);
+          SN.NameRange = charSourceRangeFromSourceRange(SM, NameRange);
+        } else {
+          SN.NameRange = CharSourceRange(EnumElemD->getNameLoc(),
+                                         EnumElemD->getName().getLength());
+        }
+
         if (auto *E = EnumElemD->getRawValueExpr()) {
           SourceRange ElemRange = E->getSourceRange();
           SN.Elements.emplace_back(SyntaxStructureElementKind::InitExpr,

--- a/test/IDE/structure.swift
+++ b/test/IDE/structure.swift
@@ -142,7 +142,7 @@ func test1() {
 // CHECK: <enum>enum <name>SomeEnum</name> {
 // CHECK:   <enum-case>case <enum-elem><name>North</name></enum-elem></enum-case>
 // CHECK:   <enum-case>case <enum-elem><name>South</name></enum-elem>, <enum-elem><name>East</name></enum-elem></enum-case>
-// CHECK:   <enum-case>case <enum-elem><name>QRCode</name>(<param><type>String</type></param>)</enum-elem></enum-case>
+// CHECK:   <enum-case>case <enum-elem><name>QRCode(<param><type>String</type></param>)</name></enum-elem></enum-case>
 // CHECK:   <enum-case>case</enum-case>
 // CHECK: }</enum>
 enum SomeEnum {

--- a/test/SourceKit/DocumentStructure/Inputs/main.swift
+++ b/test/SourceKit/DocumentStructure/Inputs/main.swift
@@ -118,3 +118,12 @@ class C {
 var // comment
   `$` = 1
 func /* comment */`foo`(x: Int) {}
+
+// rdar://40085232
+enum MyEnum {
+  case Bar(arg: Int)
+}
+
+enum MySecondEnum {
+  case One = 1
+}

--- a/test/SourceKit/DocumentStructure/structure.swift.response
+++ b/test/SourceKit/DocumentStructure/structure.swift.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 1970,
+  key.length: 2065,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.substructure: [
     {
@@ -1206,6 +1206,84 @@
           key.typename: "Int",
           key.nameoffset: 1959,
           key.namelength: 1
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.enum,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "MyEnum",
+      key.offset: 1990,
+      key.length: 36,
+      key.nameoffset: 1995,
+      key.namelength: 6,
+      key.bodyoffset: 2003,
+      key.bodylength: 22,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.enumcase,
+          key.offset: 2006,
+          key.length: 18,
+          key.nameoffset: 0,
+          key.namelength: 0,
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.enumelement,
+              key.accessibility: source.lang.swift.accessibility.internal,
+              key.name: "Bar(arg:)",
+              key.offset: 2011,
+              key.length: 13,
+              key.nameoffset: 2011,
+              key.namelength: 13
+            }
+          ]
+        },
+        {
+          key.kind: source.lang.swift.decl.var.parameter,
+          key.name: "arg",
+          key.offset: 2015,
+          key.length: 8,
+          key.typename: "Int",
+          key.nameoffset: 2015,
+          key.namelength: 3
+        }
+      ]
+    },
+    {
+      key.kind: source.lang.swift.decl.enum,
+      key.accessibility: source.lang.swift.accessibility.internal,
+      key.name: "MySecondEnum",
+      key.offset: 2028,
+      key.length: 36,
+      key.nameoffset: 2033,
+      key.namelength: 12,
+      key.bodyoffset: 2047,
+      key.bodylength: 16,
+      key.substructure: [
+        {
+          key.kind: source.lang.swift.decl.enumcase,
+          key.offset: 2050,
+          key.length: 12,
+          key.nameoffset: 0,
+          key.namelength: 0,
+          key.substructure: [
+            {
+              key.kind: source.lang.swift.decl.enumelement,
+              key.accessibility: source.lang.swift.accessibility.internal,
+              key.name: "One",
+              key.offset: 2055,
+              key.length: 7,
+              key.nameoffset: 2055,
+              key.namelength: 3,
+              key.elements: [
+                {
+                  key.kind: source.lang.swift.structure.elem.init_expr,
+                  key.offset: 2061,
+                  key.length: 1
+                }
+              ]
+            }
+          ]
         }
       ]
     }


### PR DESCRIPTION
This fixes an inconsistency where the argument labels of enum elements were included in the element's `DisplayName` because of #15562 but not taken into account for its `NameLength`.

Fixes rdar://40085232