### PR TITLE
Swift 4.x (x < 2) names are obsoleted in 4.2, not 5.

### DIFF
--- a/test/APINotes/Inputs/custom-modules/ObsoletedAPINotesTest.apinotes
+++ b/test/APINotes/Inputs/custom-modules/ObsoletedAPINotesTest.apinotes
@@ -1,0 +1,10 @@
+Name: M
+Classes:
+- Name: FooID
+  SwiftName: Foo_ID
+
+SwiftVersions:
+- Version: 4
+  Classes:
+  - Name: FooID
+    SwiftName: FooID

--- a/test/APINotes/Inputs/custom-modules/ObsoletedAPINotesTest.h
+++ b/test/APINotes/Inputs/custom-modules/ObsoletedAPINotesTest.h
@@ -1,0 +1,3 @@
+@import Foundation;
+@interface FooID: NSObject
+@end

--- a/test/APINotes/Inputs/custom-modules/module.modulemap
+++ b/test/APINotes/Inputs/custom-modules/module.modulemap
@@ -1,3 +1,6 @@
 module APINotesTest {
   header "APINotesTest.h"
 }
+module ObsoletedAPINotesTest {
+  header "ObsoletedAPINotesTest.h"
+}

--- a/test/APINotes/obsoleted.swift
+++ b/test/APINotes/obsoleted.swift
@@ -1,0 +1,7 @@
+// RUN: not %target-swift-frontend -typecheck -verify -I %S/Inputs/custom-modules -F %S/Inputs/custom-frameworks -swift-version 3 %s
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs/custom-modules -F %S/Inputs/custom-frameworks -swift-version 4.2 %s
+// RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs/custom-modules -F %S/Inputs/custom-frameworks -swift-version 5 %s
+import ObsoletedAPINotesTest
+
+let _: FooID // expected-error{{'FooID' has been renamed to 'Foo_ID'}}
+let _: Foo_ID

--- a/test/APINotes/obsoleted.swift
+++ b/test/APINotes/obsoleted.swift
@@ -1,6 +1,7 @@
 // RUN: not %target-swift-frontend -typecheck -verify -I %S/Inputs/custom-modules -F %S/Inputs/custom-frameworks -swift-version 3 %s
 // RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs/custom-modules -F %S/Inputs/custom-frameworks -swift-version 4.2 %s
 // RUN: %target-swift-frontend -typecheck -verify -I %S/Inputs/custom-modules -F %S/Inputs/custom-frameworks -swift-version 5 %s
+// REQUIRES: objc_interop
 import ObsoletedAPINotesTest
 
 let _: FooID // expected-error{{'FooID' has been renamed to 'Foo_ID'}}

--- a/test/APINotes/versioned-multi.swift
+++ b/test/APINotes/versioned-multi.swift
@@ -308,69 +308,69 @@
 
 
 // CHECK-SWIFT-5: var multiVersionedGlobal4: Int32
-// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal4")
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4.2, renamed: "multiVersionedGlobal4")
 // CHECK-SWIFT-5: var multiVersionedGlobal4_4: Int32
 // CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal4Notes_NEW")
 // CHECK-SWIFT-5: var multiVersionedGlobal4Notes: Int32
-// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal4Notes_NEW")
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4.2, renamed: "multiVersionedGlobal4Notes_NEW")
 // CHECK-SWIFT-5: var multiVersionedGlobal4Notes_4: Int32
 // CHECK-SWIFT-5: var multiVersionedGlobal4Notes_NEW: Int32
 // CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal4Header_NEW")
 // CHECK-SWIFT-5: var multiVersionedGlobal4Header: Int32
-// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal4Header_NEW")
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4.2, renamed: "multiVersionedGlobal4Header_NEW")
 // CHECK-SWIFT-5: var multiVersionedGlobal4Header_4: Int32
 // CHECK-SWIFT-5: var multiVersionedGlobal4Header_NEW: Int32
 // CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal4Both_NEW")
 // CHECK-SWIFT-5: var multiVersionedGlobal4Both: Int32
-// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal4Both_NEW")
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4.2, renamed: "multiVersionedGlobal4Both_NEW")
 // CHECK-SWIFT-5: var multiVersionedGlobal4Both_4: Int32
 // CHECK-SWIFT-5: var multiVersionedGlobal4Both_NEW: Int32
 
 // CHECK-SWIFT-5: var multiVersionedGlobal34: Int32
 // CHECK-SWIFT-5: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal34")
 // CHECK-SWIFT-5: var multiVersionedGlobal34_3: Int32
-// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal34")
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4.2, renamed: "multiVersionedGlobal34")
 // CHECK-SWIFT-5: var multiVersionedGlobal34_4: Int32
 // CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal34Notes_NEW")
 // CHECK-SWIFT-5: var multiVersionedGlobal34Notes: Int32
 // CHECK-SWIFT-5: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal34Notes_NEW")
 // CHECK-SWIFT-5: var multiVersionedGlobal34Notes_3: Int32
-// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal34Notes_NEW")
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4.2, renamed: "multiVersionedGlobal34Notes_NEW")
 // CHECK-SWIFT-5: var multiVersionedGlobal34Notes_4: Int32
 // CHECK-SWIFT-5: var multiVersionedGlobal34Notes_NEW: Int32
 // CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal34Header_NEW")
 // CHECK-SWIFT-5: var multiVersionedGlobal34Header: Int32
 // CHECK-SWIFT-5: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal34Header_NEW")
 // CHECK-SWIFT-5: var multiVersionedGlobal34Header_3: Int32
-// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal34Header_NEW")
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4.2, renamed: "multiVersionedGlobal34Header_NEW")
 // CHECK-SWIFT-5: var multiVersionedGlobal34Header_4: Int32
 // CHECK-SWIFT-5: var multiVersionedGlobal34Header_NEW: Int32
 // CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal34Both_NEW")
 // CHECK-SWIFT-5: var multiVersionedGlobal34Both: Int32
 // CHECK-SWIFT-5: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal34Both_NEW")
 // CHECK-SWIFT-5: var multiVersionedGlobal34Both_3: Int32
-// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal34Both_NEW")
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4.2, renamed: "multiVersionedGlobal34Both_NEW")
 // CHECK-SWIFT-5: var multiVersionedGlobal34Both_4: Int32
 // CHECK-SWIFT-5: var multiVersionedGlobal34Both_NEW: Int32
 
 // CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45_5")
 // CHECK-SWIFT-5: var multiVersionedGlobal45: Int32
-// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal45_5")
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4.2, renamed: "multiVersionedGlobal45_5")
 // CHECK-SWIFT-5: var multiVersionedGlobal45_4: Int32
 // CHECK-SWIFT-5: var multiVersionedGlobal45_5: Int32
 // CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45Notes_5")
 // CHECK-SWIFT-5: var multiVersionedGlobal45Notes: Int32
-// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal45Notes_5")
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4.2, renamed: "multiVersionedGlobal45Notes_5")
 // CHECK-SWIFT-5: var multiVersionedGlobal45Notes_4: Int32
 // CHECK-SWIFT-5: var multiVersionedGlobal45Notes_5: Int32
 // CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45Header_5")
 // CHECK-SWIFT-5: var multiVersionedGlobal45Header: Int32
-// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal45Header_5")
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4.2, renamed: "multiVersionedGlobal45Header_5")
 // CHECK-SWIFT-5: var multiVersionedGlobal45Header_4: Int32
 // CHECK-SWIFT-5: var multiVersionedGlobal45Header_5: Int32
 // CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal45Both_5")
 // CHECK-SWIFT-5: var multiVersionedGlobal45Both: Int32
-// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal45Both_5")
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4.2, renamed: "multiVersionedGlobal45Both_5")
 // CHECK-SWIFT-5: var multiVersionedGlobal45Both_4: Int32
 // CHECK-SWIFT-5: var multiVersionedGlobal45Both_5: Int32
 
@@ -378,28 +378,28 @@
 // CHECK-SWIFT-5: var multiVersionedGlobal345: Int32
 // CHECK-SWIFT-5: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal345_5")
 // CHECK-SWIFT-5: var multiVersionedGlobal345_3: Int32
-// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal345_5")
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4.2, renamed: "multiVersionedGlobal345_5")
 // CHECK-SWIFT-5: var multiVersionedGlobal345_4: Int32
 // CHECK-SWIFT-5: var multiVersionedGlobal345_5: Int32
 // CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345Notes_5")
 // CHECK-SWIFT-5: var multiVersionedGlobal345Notes: Int32
 // CHECK-SWIFT-5: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal345Notes_5")
 // CHECK-SWIFT-5: var multiVersionedGlobal345Notes_3: Int32
-// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal345Notes_5")
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4.2, renamed: "multiVersionedGlobal345Notes_5")
 // CHECK-SWIFT-5: var multiVersionedGlobal345Notes_4: Int32
 // CHECK-SWIFT-5: var multiVersionedGlobal345Notes_5: Int32
 // CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345Header_5")
 // CHECK-SWIFT-5: var multiVersionedGlobal345Header: Int32
 // CHECK-SWIFT-5: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal345Header_5")
 // CHECK-SWIFT-5: var multiVersionedGlobal345Header_3: Int32
-// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal345Header_5")
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4.2, renamed: "multiVersionedGlobal345Header_5")
 // CHECK-SWIFT-5: var multiVersionedGlobal345Header_4: Int32
 // CHECK-SWIFT-5: var multiVersionedGlobal345Header_5: Int32
 // CHECK-SWIFT-5: @available(swift, obsoleted: 3, renamed: "multiVersionedGlobal345Both_5")
 // CHECK-SWIFT-5: var multiVersionedGlobal345Both: Int32
 // CHECK-SWIFT-5: @available(swift, obsoleted: 4, renamed: "multiVersionedGlobal345Both_5")
 // CHECK-SWIFT-5: var multiVersionedGlobal345Both_3: Int32
-// CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal345Both_5")
+// CHECK-SWIFT-5: @available(swift, obsoleted: 4.2, renamed: "multiVersionedGlobal345Both_5")
 // CHECK-SWIFT-5: var multiVersionedGlobal345Both_4: Int32
 // CHECK-SWIFT-5: var multiVersionedGlobal345Both_5: Int32
 // CHECK-SWIFT-5: @available(swift, obsoleted: 5, renamed: "multiVersionedGlobal34_4_2")


### PR DESCRIPTION
Pulls in changes from #16468 into `swift-4.2-branch-04-30-2018`.