### PR TITLE
☣️ Experiment: Disable auto-lookup into NSString on String instances.

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -3118,7 +3118,7 @@ performMemberLookup(ConstraintKind constraintKind, DeclName memberName,
   // If the instance type is String bridged to NSString, compute
   // the type we'll look in for bridging.
   Type bridgedType;
-  if (baseObjTy->getAnyNominal() == TC.Context.getStringDecl()) {
+  if (false && baseObjTy->getAnyNominal() == TC.Context.getStringDecl()) {
     if (Type classType = TC.Context.getBridgedToObjC(DC, instanceTy)) {
       bridgedType = classType;
     }

--- a/test/ClangImporter/objc_bridge_categories.swift
+++ b/test/ClangImporter/objc_bridge_categories.swift
@@ -8,9 +8,9 @@ import Foundation
 import AppKit
 
 func testStringBridge(_ str: String) {
-  var str2 = str.nsStringMethod()!
+  var str2 = (str as NSString).nsStringMethod()!
   var int = NSString.nsStringClassMethod()
-  var str3 = str.nsStringProperty!
+  var str3 = (str as NSString).nsStringProperty!
 
   // Make sure the types worked out as expected
   var str: String = str2

--- a/test/Interpreter/SDK/objc_extensions.swift
+++ b/test/Interpreter/SDK/objc_extensions.swift
@@ -56,4 +56,4 @@ o.blackHoleWithHawkingRadiation = NSObject()
 // Use of extensions via bridging 
 let str = "Hello, world"
 // CHECK: I've been frobbed!
-str.frob()
+(str as NSString).frob()

--- a/test/SILGen/objc_bridging_nsstring.swift
+++ b/test/SILGen/objc_bridging_nsstring.swift
@@ -14,4 +14,4 @@ extension NSString {
 var str: String = "hello world"
 
 // Crash when NSString member is accessed on a String with an lvalue base
-_ = str.x
+_ = (str as NSString).x


### PR DESCRIPTION
An experiment to see what the impact of removing lookup into NSString on String instances would be on the projects in the source compatibility suite.