### PR TITLE
[IRGen] Zero-init stack shadow copies of values at -Onone.

### DIFF
--- a/test/DebugInfo/returnlocation.swift
+++ b/test/DebugInfo/returnlocation.swift
@@ -12,8 +12,7 @@ import Foundation
 // CHECK_NONE: define{{( protected)?}} {{.*}}void {{.*}}none
 public func none(_ a: inout Int64) {
   // CHECK_NONE: call void @llvm.dbg{{.*}}, !dbg
-  // CHECK_NONE: store{{.*}}, !dbg
-  // CHECK_NONE: !dbg ![[NONE_INIT:.*]]
+  // CHECK_NONE: store i64{{.*}}, !dbg ![[NONE_INIT:.*]]
   a -= 2
   // CHECK_NONE: ret {{.*}}, !dbg ![[NONE_RET:.*]]
   // CHECK_NONE: ![[NONE_INIT]] = !DILocation(line: [[@LINE-2]], column:

--- a/test/DebugInfo/shadowcopy-linetable.swift
+++ b/test/DebugInfo/shadowcopy-linetable.swift
@@ -8,6 +8,8 @@ func foo(_ x: inout Int64) {
   // not.
   // CHECK: %[[X:.*]] = alloca %Ts5Int64V*, align {{(4|8)}}
   // CHECK-NEXT: call void @llvm.dbg.declare
+  // CHECK-NEXT: [[ZEROED:%[0-9]+]] = bitcast %Ts5Int64V** %[[X]] to %swift.opaque**
+  // CHECK-NEXT: store %swift.opaque* null, %swift.opaque** [[ZEROED]], align {{(4|8)}}
   // CHECK: store %Ts5Int64V* %0, %Ts5Int64V** %[[X]], align {{(4|8)}}
   // CHECK-SAME: !dbg ![[LOC0:.*]]
   // CHECK-NEXT: getelementptr inbounds %Ts5Int64V, %Ts5Int64V* %0, i32 0, i32 0,

--- a/test/DebugInfo/uninitialized.swift
+++ b/test/DebugInfo/uninitialized.swift
@@ -8,8 +8,8 @@ public func f() {
   var object: MyClass
   // CHECK: %[[OBJ:.*]] = alloca %[[T1:.*]]*, align
   // CHECK: call void @llvm.dbg.declare(metadata %[[T1]]** %[[OBJ]],
-  // CHECK: %[[BC1:.*]] = bitcast %[[T1]]** %[[OBJ]] to %swift.opaque**, !dbg
-  // CHECK: store %swift.opaque* null, %swift.opaque** %[[BC1]], align {{.*}}, !dbg
+  // CHECK: %[[BC1:.*]] = bitcast %[[T1]]** %[[OBJ]] to %swift.opaque**
+  // CHECK: store %swift.opaque* null, %swift.opaque** %[[BC1]], align {{.*}}
   // OPT-NOT: store
   // OPT: ret
 }
@@ -20,8 +20,8 @@ public func g() {
   var dict: Dictionary<Int64, Int64>
   // CHECK: %[[DICT:.*]] = alloca %[[T2:.*]], align
   // CHECK: call void @llvm.dbg.declare(metadata %[[T2]]* %[[DICT]],
-  // CHECK: %[[BC2:.*]] = bitcast %[[T2]]* %[[DICT]] to %swift.opaque**, !dbg
-  // CHECK: store %swift.opaque* null, %swift.opaque** %[[BC2]], align {{.*}}, !dbg
+  // CHECK: %[[BC2:.*]] = bitcast %[[T2]]* %[[DICT]] to %swift.opaque**
+  // CHECK: store %swift.opaque* null, %swift.opaque** %[[BC2]], align {{.*}}
   // OPT-NOT: store
   // OPT: ret
 }


### PR DESCRIPTION
We already zero init AllocStack, and here's the same.
The debugger's variable view shows up variables on the line
where they're declared (before they've been initialized).
In some cases, we just print garbage. In some others, it's
dangerous (imagine an array which we believe has 2^32 elements
because we ended up reusing a stack slot). This way it's always
consistent, as lldb uses the first word to understand whether
an object is initialized or not here.

Fixes <rdar://problem/39883298>
