### PR TITLE
IRGen: Fix enum lowering with -enable-resilience-bypass

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -4067,8 +4067,10 @@ IRGenModule::getAddrOfGlobalUTF16ConstantString(StringRef utf8) {
 /// - For classes, the superclass might change the size or number
 ///   of stored properties
 bool IRGenModule::isResilient(NominalTypeDecl *D, ResilienceExpansion expansion) {
-  if (Types.isCompletelyFragile())
+  if (expansion == ResilienceExpansion::Maximal &&
+      Types.isCompletelyFragile()) {
     return false;
+  }
   return D->isResilient(getSwiftModule(), expansion);
 }
 

--- a/test/IRGen/Inputs/resilience_bypass/first.swift
+++ b/test/IRGen/Inputs/resilience_bypass/first.swift
@@ -1,0 +1,9 @@
+public class C {}
+
+public struct S {
+  public let c: C
+
+  public init() {
+    self.c = C()
+  }
+}

--- a/test/IRGen/Inputs/resilience_bypass/second.swift
+++ b/test/IRGen/Inputs/resilience_bypass/second.swift
@@ -1,0 +1,6 @@
+import first
+
+public enum E {
+  case a(S)
+  case b(S)
+}

--- a/test/IRGen/resilience_bypass.swift
+++ b/test/IRGen/resilience_bypass.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/first.swiftmodule -module-name=first %S/Inputs/resilience_bypass/first.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path=%t/second.swiftmodule -module-name=second %S/Inputs/resilience_bypass/second.swift -I %t
+// RUN: %target-swift-frontend -emit-ir -enable-resilience-bypass %s -I %t | %FileCheck %s -DINT=i%target-ptrsize
+
+import second
+
+// CHECK:       define{{( protected)?}} swiftcc [[INT]] @"$S17resilience_bypass7getSizeSiyF"() {{.*}} {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    ret [[INT]] {{5|9}}
+// CHECK-NEXT:  }
+
+public func getSize() -> Int {
+  return MemoryLayout<E>.size
+}


### PR DESCRIPTION
The layout of an enum type will only use spare bits if the
payload types have a fixed size in all resilience domains
where they are visible. In practice, this means that:

- If the enum is internal or resilient, we can use spare bits
  if the payload types are fixed size from inside the current
  module.

- If the enum is public and not resilient, we can use spare bits
  if the payload types are fixed size from all resilience
  domains.

The bug was that the 'fixed size in all resilience domains'
check was returning true for resilient types when the
-enable-resilience-bypass flag was on. This is wrong, because
this meant that building a module with and without
-enable-resilience-bypass could produce different lowerings
for enum types.

Fixes <rdar://problem/40034143>.