### PR TITLE
[SILGen] Ensure type params in witness method conformances match the witness method signatures.

### DIFF
--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -613,6 +613,20 @@ SILFunction *SILGenModule::emitProtocolWitness(
   auto input = reqtOrigTy->getInput().subst(reqtSubMap)->getCanonicalType();
   auto result = reqtOrigTy->getResult().subst(reqtSubMap)->getCanonicalType();
 
+  // If there's something to map to for the witness thunk, the conformance
+  // should be phrased in the same terms. This particularly applies to classes
+  // where a thunk for a method in a conformance like `extension Class: P where
+  // T: Q` will go from its native signature of `<τ_0_0 where τ_0_0: Q>` (with T
+  // canonicalised to τ_0_0), to `<τ_0_0, τ_1_0 where τ_0_0: Class<τ_1_0>,
+  // τ_1_0: Q>` (with T now represented by τ_1_0). Find the right conformance by
+  // looking for the conformance of 'Self'.
+  if (reqtSubMap) {
+    auto requirement = conformance.getRequirement();
+    auto self = requirement->getProtocolSelfType()->getCanonicalType();
+
+    conformance = *reqtSubMap.lookupConformance(self, requirement);
+  }
+
   CanAnyFunctionType reqtSubstTy;
   if (genericEnv) {
     auto *genericSig = genericEnv->getGenericSignature();

--- a/test/IRGen/conditional_conformances_class_with_defaulted_method.swift
+++ b/test/IRGen/conditional_conformances_class_with_defaulted_method.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -emit-ir %s -module-name x | %FileCheck %s
+
+// rdar://problem/40078863 - witness signatures get adjusted and the
+// ProtocolConformances accompanying them did not, resulting in an extra witness
+// table parameter.
+
+protocol Foo {
+    func bar()
+}
+extension Foo {
+    func bar() {}
+}
+class Box<T> {}
+extension Box: Foo where T: Foo {}
+// CHECK-LABEL: define internal swiftcc void @"$S1x3BoxCyqd__GAA3FooA2aEP3baryyFTW"(%T1x3BoxC.0** noalias nocapture swiftself dereferenceable({{[48]}}), %swift.type* %Self, i8** %SelfWitnessTable)

--- a/test/SILGen/witnesses_class.swift
+++ b/test/SILGen/witnesses_class.swift
@@ -77,7 +77,7 @@ class UsesDefaults<X : Barable> : HasDefaults {}
 
 // Covariant Self:
 
-// CHECK-LABEL: sil private [transparent] [thunk] @$S15witnesses_class12UsesDefaultsCyxGAA03HasD0A2aEP10hasDefaultyyFTW : $@convention(witness_method: HasDefaults) <τ_0_0><τ_1_0 where τ_0_0 : UsesDefaults<τ_1_0>, τ_1_0 : Barable> (@in_guaranteed τ_0_0) -> ()
+// CHECK-LABEL: sil private [transparent] [thunk] @$S15witnesses_class12UsesDefaultsCyqd__GAA03HasD0A2aEP10hasDefaultyyFTW : $@convention(witness_method: HasDefaults) <τ_0_0><τ_1_0 where τ_0_0 : UsesDefaults<τ_1_0>, τ_1_0 : Barable> (@in_guaranteed τ_0_0) -> () {
 // CHECK: [[FN:%.*]] = function_ref @$S15witnesses_class11HasDefaultsPAAE10hasDefaultyyF : $@convention(method) <τ_0_0 where τ_0_0 : HasDefaults> (@in_guaranteed τ_0_0) -> ()
 // CHECK: apply [[FN]]<τ_0_0>(
 // CHECK: return
@@ -91,7 +91,7 @@ class UsesDefaults<X : Barable> : HasDefaults {}
 
 // Covariant Self:
 
-// CHECK-LABEL: sil private [transparent] [thunk] @$S15witnesses_class12UsesDefaultsCyxGAA03HasD0A2aEP17hasDefaultGenericyyqd__AA7FooableRd__lFTW : $@convention(witness_method: HasDefaults) <τ_0_0><τ_1_0 where τ_0_0 : UsesDefaults<τ_1_0>, τ_1_0 : Barable><τ_2_0 where τ_2_0 : Fooable> (@guaranteed τ_2_0, @in_guaranteed τ_0_0) -> ()
+// CHECK-LABEL: sil private [transparent] [thunk] @$S15witnesses_class12UsesDefaultsCyqd__GAA03HasD0A2aEP17hasDefaultGenericyyqd__AA7FooableRd__lFTW : $@convention(witness_method: HasDefaults) <τ_0_0><τ_1_0 where τ_0_0 : UsesDefaults<τ_1_0>, τ_1_0 : Barable><τ_2_0 where τ_2_0 : Fooable> (@guaranteed τ_2_0, @in_guaranteed τ_0_0) -> () {
 // CHECK: [[FN:%.*]] = function_ref @$S15witnesses_class11HasDefaultsPAAE17hasDefaultGenericyyqd__AA7FooableRd__lF : $@convention(method) <τ_0_0 where τ_0_0 : HasDefaults><τ_1_0 where τ_1_0 : Fooable> (@guaranteed τ_1_0, @in_guaranteed τ_0_0) -> ()
 // CHECK: apply [[FN]]<τ_0_0, τ_2_0>(
 // CHECK: return


### PR DESCRIPTION
A witness method of a class can have its generic parameters rephrased: a
parameters of the class, like τ_0_0, get pushed to the next depth, like τ_1_0,
to make way for a τ_0_0 parameter with a τ_0_0: Class<...> subclass
constraint. When this wasn't accounted for, IRGen would find that it couldn't
satisfy conditional requirements on the rewritten type parameters, and they'd
incorrectly be passed as additional arguments of a witness method thunk rather
than pulled out of the Self witness table's private area inside the thunk.

Fixes rdar://problem/40078863.
