### PR TITLE
[4.2-04-30-2018] [SILGen] Ensure type params in witness method conformances match the witness method signatures.

### DIFF
--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -614,6 +614,20 @@ SILFunction *SILGenModule::emitProtocolWitness(
   auto input = reqtOrigTy->getInput().subst(reqtSubMap)->getCanonicalType();
   auto result = reqtOrigTy->getResult().subst(reqtSubMap)->getCanonicalType();
 
+  // If there's something to map to for the witness thunk, the conformance
+  // should be phrased in the same terms. This particularly applies to classes
+  // where a thunk for a method in a conformance like `extension Class: P where
+  // T: Q` will go from its native signature of `<τ_0_0 where τ_0_0: Q>` (with T
+  // canonicalised to τ_0_0), to `<τ_0_0, τ_1_0 where τ_0_0: Class<τ_1_0>,
+  // τ_1_0: Q>` (with T now represented by τ_1_0). Find the right conformance by
+  // looking for the conformance of 'Self'.
+  if (!reqtSubMap.empty()) {
+    auto requirement = conformance.getRequirement();
+    auto self = requirement->getProtocolSelfType()->getCanonicalType();
+
+    conformance = *reqtSubMap.lookupConformance(self, requirement);
+  }
+
   CanAnyFunctionType reqtSubstTy;
   if (genericEnv) {
     auto *genericSig = genericEnv->getGenericSignature();

--- a/test/IRGen/conditional_conformances_class_with_defaulted_method.swift
+++ b/test/IRGen/conditional_conformances_class_with_defaulted_method.swift
@@ -1,0 +1,15 @@
+// RUN: %target-swift-frontend -emit-ir %s -module-name x | %FileCheck %s
+
+// rdar://problem/40078863 - witness signatures get adjusted and the
+// ProtocolConformances accompanying them did not, resulting in an extra witness
+// table parameter.
+
+protocol Foo {
+    func bar()
+}
+extension Foo {
+    func bar() {}
+}
+class Box<T> {}
+extension Box: Foo where T: Foo {}
+// CHECK-LABEL: define internal swiftcc void @"$S1x3BoxCyqd__GAA3FooA2aEP3baryyFTW"(%T1x3BoxC.0** noalias nocapture swiftself dereferenceable({{[48]}}), %swift.type* %Self, i8** %SelfWitnessTable)

--- a/test/SILGen/witnesses_class.swift
+++ b/test/SILGen/witnesses_class.swift
@@ -77,7 +77,7 @@ class UsesDefaults<X : Barable> : HasDefaults {}
 
 // Covariant Self:
 
-// CHECK-LABEL: sil private [transparent] [thunk] @$S15witnesses_class12UsesDefaultsCyxGAA03HasD0A2aEP10hasDefaultyyFTW : $@convention(witness_method: HasDefaults) <τ_0_0><τ_1_0 where τ_0_0 : UsesDefaults<τ_1_0>, τ_1_0 : Barable> (@in_guaranteed τ_0_0) -> ()
+// CHECK-LABEL: sil private [transparent] [thunk] @$S15witnesses_class12UsesDefaultsCyqd__GAA03HasD0A2aEP10hasDefaultyyFTW : $@convention(witness_method: HasDefaults) <τ_0_0><τ_1_0 where τ_0_0 : UsesDefaults<τ_1_0>, τ_1_0 : Barable> (@in_guaranteed τ_0_0) -> () {
 // CHECK: [[FN:%.*]] = function_ref @$S15witnesses_class11HasDefaultsPAAE10hasDefaultyyF : $@convention(method) <τ_0_0 where τ_0_0 : HasDefaults> (@in_guaranteed τ_0_0) -> ()
 // CHECK: apply [[FN]]<τ_0_0>(
 // CHECK: return
@@ -91,7 +91,7 @@ class UsesDefaults<X : Barable> : HasDefaults {}
 
 // Covariant Self:
 
-// CHECK-LABEL: sil private [transparent] [thunk] @$S15witnesses_class12UsesDefaultsCyxGAA03HasD0A2aEP17hasDefaultGenericyyqd__AA7FooableRd__lFTW : $@convention(witness_method: HasDefaults) <τ_0_0><τ_1_0 where τ_0_0 : UsesDefaults<τ_1_0>, τ_1_0 : Barable><τ_2_0 where τ_2_0 : Fooable> (@guaranteed τ_2_0, @in_guaranteed τ_0_0) -> ()
+// CHECK-LABEL: sil private [transparent] [thunk] @$S15witnesses_class12UsesDefaultsCyqd__GAA03HasD0A2aEP17hasDefaultGenericyyqd__AA7FooableRd__lFTW : $@convention(witness_method: HasDefaults) <τ_0_0><τ_1_0 where τ_0_0 : UsesDefaults<τ_1_0>, τ_1_0 : Barable><τ_2_0 where τ_2_0 : Fooable> (@guaranteed τ_2_0, @in_guaranteed τ_0_0) -> () {
 // CHECK: [[FN:%.*]] = function_ref @$S15witnesses_class11HasDefaultsPAAE17hasDefaultGenericyyqd__AA7FooableRd__lF : $@convention(method) <τ_0_0 where τ_0_0 : HasDefaults><τ_1_0 where τ_1_0 : Fooable> (@guaranteed τ_1_0, @in_guaranteed τ_0_0) -> ()
 // CHECK: apply [[FN]]<τ_0_0, τ_2_0>(
 // CHECK: return


### PR DESCRIPTION
**Explanation**: A class conditionally conforming to a protocol and using a default method for one of the requirements, would result in an incorrect signature (at the LLVM/asm level) for the thunk for the witness for that requirement. These are called dynamically, and so would result in crashes/undefined behaviour at runtime if things from the conditional requirements were used (e.g. calling a method on a `T` in `extension Class: P where T: Q`).
**Scope**: Any class conforming to a protocol as above is at high risk of this. 
**Radar**: rdar://problem/40078863.
**Risk**: Low: this is, essentially, just changing a type parameter from the incorrect default to the correct one, without modifying anything around it.
**Testing**: Test suite plus source compatibility suite
**Reviewer**: @DougGregor

https://github.com/apple/swift/pull/16493 https://github.com/apple/swift/pull/16514