### PR TITLE
Adjust access level of inaccessible protocol members in diagnostics.

### DIFF
--- a/lib/Sema/TypeCheckConstraints.cpp
+++ b/lib/Sema/TypeCheckConstraints.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -489,8 +489,9 @@ resolveDeclRefExpr(UnresolvedDeclRefExpr *UDRE, DeclContext *DC) {
     if (inaccessibleResults) {
       // FIXME: What if the unviable candidates have different levels of access?
       const ValueDecl *first = inaccessibleResults.front().getValueDecl();
-      diagnose(Loc, diag::candidate_inaccessible,
-               Name, first->getFormalAccess());
+      diagnose(Loc, diag::candidate_inaccessible, Name,
+               first->adjustAccessLevelForProtocolExtension(
+                   first->getFormalAccess()));
 
       // FIXME: If any of the candidates (usually just one) are in the same
       // module we could offer a fix-it.

--- a/test/NameBinding/Inputs/has_accessibility.swift
+++ b/test/NameBinding/Inputs/has_accessibility.swift
@@ -40,3 +40,12 @@ extension HasDefaultImplementation {
   internal func foo() {}
 }
 internal class InternalBase {}
+
+open class ImplementsInternalProtocol {}
+
+protocol InternalProtocol {}
+extension InternalProtocol {
+  public var i: Int { return 1 }
+}
+
+extension ImplementsInternalProtocol : InternalProtocol {}

--- a/test/NameBinding/accessibility.swift
+++ b/test/NameBinding/accessibility.swift
@@ -169,3 +169,7 @@ public class TestablePublicSub: InternalBase {} // expected-error {{undeclared t
 // <unknown>:0: error: unexpected note produced: 'method()' declared here
 // <unknown>:0: error: unexpected note produced: 'method' declared here
 // <unknown>:0: error: unexpected note produced: 'method' declared here
+
+class AccessMemberOfInternalProtocol : ImplementsInternalProtocol {
+  func testProperty() { let _ = i } // expected-error {{'i' is inaccessible due to 'internal' protection level}}
+}


### PR DESCRIPTION
Otherwise we hit one of the "%error" cases in the diagnostic text,
which results in an assert.

Fixes rdar://problem/40111079.
