### PR TITLE
IRGen: Fix enum lowering with -enable-resilience-bypass [4.2-04-30-2018]

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -4067,8 +4067,10 @@ IRGenModule::getAddrOfGlobalUTF16ConstantString(StringRef utf8) {
 /// - For classes, the superclass might change the size or number
 ///   of stored properties
 bool IRGenModule::isResilient(NominalTypeDecl *D, ResilienceExpansion expansion) {
-  if (Types.isCompletelyFragile())
+  if (expansion == ResilienceExpansion::Maximal &&
+      Types.isCompletelyFragile()) {
     return false;
+  }
   return D->isResilient(getSwiftModule(), expansion);
 }
 

--- a/test/IRGen/Inputs/resilience_bypass/first.swift
+++ b/test/IRGen/Inputs/resilience_bypass/first.swift
@@ -1,0 +1,9 @@
+public class C {}
+
+public struct S {
+  public let c: C
+
+  public init() {
+    self.c = C()
+  }
+}

--- a/test/IRGen/Inputs/resilience_bypass/second.swift
+++ b/test/IRGen/Inputs/resilience_bypass/second.swift
@@ -1,0 +1,6 @@
+import first
+
+public enum E {
+  case a(S)
+  case b(S)
+}

--- a/test/IRGen/resilience_bypass.swift
+++ b/test/IRGen/resilience_bypass.swift
@@ -1,0 +1,16 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/first.swiftmodule -module-name=first %S/Inputs/resilience_bypass/first.swift
+// RUN: %target-swift-frontend -emit-module -emit-module-path=%t/second.swiftmodule -module-name=second %S/Inputs/resilience_bypass/second.swift -I %t
+// RUN: %target-swift-frontend -emit-ir -enable-resilience-bypass %s -I %t | %FileCheck %s -DINT=i%target-ptrsize
+
+import second
+
+// CHECK:       define{{( protected)?}} swiftcc [[INT]] @"$S17resilience_bypass7getSizeSiyF"() {{.*}} {
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    ret [[INT]] {{5|9}}
+// CHECK-NEXT:  }
+
+public func getSize() -> Int {
+  return MemoryLayout<E>.size
+}


### PR DESCRIPTION
* Description: lldb does not (yet) support resilient value types, so it uses a special frontend flag where resilience is bypassed and exact type layouts are computed from the swiftmodule file. However in one corner case, resilient and non-resilient enums could actually get different layouts if the resilient case was able to make use of spare bits because the payload types had known layouts from inside the module. This patch fixes the resilience bypass to compute the correct enum layout in this case.

* Origination: Introduced when resilience was enabled by default for the stdlib and overlays, making some value types defined in overlays resilient.

* Scope of the issue: Manifests as a runtime crash when manipulating multi-payload enums from lldb, Swift REPL or Playgrounds.

* Risk: Low, this changes a code path that is only hit in the above cases.

* Reviewed by: @jrose-apple reviewed the change on swift-4.2-branch already.

* Tested: New test case added.

* Radar: rdar://problem/40034143