### PR TITLE
[4.2 EARLY] Fixes for batch mode diagnostics in Xcode

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1495,7 +1495,7 @@ ERROR(witness_argument_name_mismatch,none,
       "%select{method|initializer}0 %1 has different argument labels from those "
       "required by protocol %2 (%3)", (bool, DeclName, Type, DeclName))
 ERROR(witness_initializer_not_required,none,
-      "initializer requirement %0 can only be satisfied by a `required` "
+      "initializer requirement %0 can only be satisfied by a 'required' "
       "initializer in%select{| the definition of}1 non-final class %2",
       (DeclName, bool, Type))
 ERROR(witness_initializer_failability,none,
@@ -1517,12 +1517,12 @@ NOTE(witness_self_weaken_same_type,none,
       "consider weakening the same-type requirement %0 == %1 to a superclass "
       "requirement", (Type, Type))
 ERROR(witness_requires_dynamic_self,none,
-      "method %0 in non-final class %1 must return `Self` to conform to "
+      "method %0 in non-final class %1 must return 'Self' to conform to "
       "protocol %2",
       (DeclName, Type, Type))
 ERROR(witness_requires_class_implementation,none,
       "method %0 in non-final class %1 cannot be implemented in a "
-      "protocol extension because it returns `Self` and has associated type "
+      "protocol extension because it returns 'Self' and has associated type "
       "requirements",
       (DeclName, Type))
 ERROR(witness_not_accessible_proto,none,
@@ -1550,6 +1550,9 @@ ERROR(type_witness_objc_generic_parameter,none,
       "type %0 involving Objective-C type parameter%select{| %1}2 cannot be "
       "used for associated type %3 of protocol %4",
       (Type, Type, bool, DeclName, DeclName))
+NOTE(witness_fix_access,none,
+     "mark the %0 as '%select{%error|fileprivate|internal|public|%error}1' to "
+     "satisfy the requirement", (DescriptiveDeclKind, AccessLevel))
 
 ERROR(protocol_refine_access,none,
       "%select{protocol must be declared %select{"
@@ -3377,10 +3380,10 @@ WARNING(objc_inference_swift3_objc_derived,none,
         "deprecated", ())
 
 NOTE(objc_inference_swift3_addobjc,none,
-     "add `@objc` to continue exposing an Objective-C entry point (Swift 3 "
+     "add '@objc' to continue exposing an Objective-C entry point (Swift 3 "
      "behavior)", ())
 NOTE(objc_inference_swift3_addnonobjc,none,
-     "add `@nonobjc` to suppress the Objective-C entry point (Swift 4 "
+     "add '@nonobjc' to suppress the Objective-C entry point (Swift 4 "
      "behavior)", ())
 
 ERROR(objc_for_generic_class,none,
@@ -3774,9 +3777,6 @@ ERROR(availability_protocol_requires_version,
 
 NOTE(availability_protocol_requirement_here, none,
      "protocol requirement here", ())
-
-NOTE(availability_conformance_introduced_here, none,
-     "conformance introduced here", ())
 
 // This doesn't display as an availability diagnostic, but it's
 // implemented there and fires when these subscripts are marked

--- a/include/swift/Frontend/FrontendInputsAndOutputs.h
+++ b/include/swift/Frontend/FrontendInputsAndOutputs.h
@@ -103,6 +103,10 @@ public:
   bool
   forEachPrimaryInput(llvm::function_ref<bool(const InputFile &)> fn) const;
 
+  /// If \p fn returns true, exit early and return true.
+  bool
+  forEachNonPrimaryInput(llvm::function_ref<bool(const InputFile &)> fn) const;
+
   unsigned primaryInputCount() const { return PrimaryInputsInOrder.size(); }
 
   // Primary count readers:

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2267,6 +2267,9 @@ bool swift::fixDeclarationName(InFlightDiagnostic &diag, ValueDecl *decl,
 bool swift::fixDeclarationObjCName(InFlightDiagnostic &diag, ValueDecl *decl,
                                    Optional<ObjCSelector> targetNameOpt,
                                    bool ignoreImpliedName) {
+  if (decl->isImplicit())
+    return false;
+
   // Subscripts cannot be renamed, so handle them directly.
   if (isa<SubscriptDecl>(decl)) {
     diag.fixItInsert(decl->getAttributeInsertionLoc(/*forModifier=*/false),

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -2095,6 +2095,9 @@ bool ValueDecl::canInferObjCFromRequirement(ValueDecl *requirement) {
 }
 
 SourceLoc ValueDecl::getAttributeInsertionLoc(bool forModifier) const {
+  if (isImplicit())
+    return SourceLoc();
+
   if (auto var = dyn_cast<VarDecl>(this)) {
     // [attrs] var ...
     // The attributes are part of the VarDecl, but the 'var' is part of the PBD.

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -528,6 +528,11 @@ namespace driver {
                               ReturnCode);
         }
 
+        // See how ContinueBuildingAfterErrors gets set up in Driver.cpp for
+        // more info.
+        assert((Comp.ContinueBuildingAfterErrors || !Comp.EnableBatchMode) &&
+               "batch mode diagnostics require ContinueBuildingAfterErrors");
+
         return Comp.ContinueBuildingAfterErrors ?
           TaskFinishedResponse::ContinueExecution :
           TaskFinishedResponse::StopExecution;

--- a/lib/Frontend/FrontendInputsAndOutputs.cpp
+++ b/lib/Frontend/FrontendInputsAndOutputs.cpp
@@ -97,6 +97,13 @@ bool FrontendInputsAndOutputs::forEachPrimaryInput(
   return false;
 }
 
+bool FrontendInputsAndOutputs::forEachNonPrimaryInput(
+    llvm::function_ref<bool(const InputFile &)> fn) const {
+  return forEachInput([&](const InputFile &f) -> bool {
+    return f.isPrimary() ? false : fn(f);
+  });
+}
+
 void FrontendInputsAndOutputs::assertMustNotBeMoreThanOnePrimaryInput() const {
   assert(!hasMultiplePrimaryInputs() &&
          "have not implemented >1 primary input yet");

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -948,9 +948,13 @@ static bool performCompile(CompilerInstance &Instance,
 
   // We've just been told to perform a typecheck, so we can return now.
   if (Action == FrontendOptions::ActionType::Typecheck) {
-    const bool hadPrintAsObjCError = printAsObjCIfNeeded(
-        Invocation.getObjCHeaderOutputPathForAtMostOnePrimary(),
-        Instance.getMainModule(), opts.ImplicitObjCHeaderPath, moduleIsPublic);
+    const bool hadPrintAsObjCError =
+        Invocation.getFrontendOptions()
+            .InputsAndOutputs.hasObjCHeaderOutputPath() &&
+        printAsObjCIfNeeded(
+            Invocation.getObjCHeaderOutputPathForAtMostOnePrimary(),
+            Instance.getMainModule(), opts.ImplicitObjCHeaderPath,
+            moduleIsPublic);
 
     const bool hadEmitIndexDataError = emitIndexData(Invocation, Instance);
 
@@ -1527,6 +1531,19 @@ createDispatchingDiagnosticConsumerIfNeeded(
       subConsumers.emplace_back(input.file(), std::move(subConsumer));
     return false;
   });
+  // For batch mode, the compiler must swallow diagnostics pertaining to
+  // non-primary files in order to avoid Xcode showing the same diagnostic
+  // multiple times. So, create a diagnostic "eater" for those non-primary
+  // files.
+  // To avoid introducing bugs into WMO or single-file modes, test for multiple
+  // primaries.
+  if (inputsAndOutputs.hasMultiplePrimaryInputs()) {
+    inputsAndOutputs.forEachNonPrimaryInput(
+        [&](const InputFile &input) -> bool {
+          subConsumers.emplace_back(input.file(), nullptr);
+          return false;
+        });
+  }
 
   if (subConsumers.empty())
     return nullptr;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2047,6 +2047,39 @@ void ConformanceChecker::recordInvalidWitness(ValueDecl *requirement) {
   Conformance->setWitness(requirement, Witness());
 }
 
+/// Returns the location we should use for a primary diagnostic (an error or
+/// warning) that concerns \p witness but arose as part of checking
+/// \p conformance.
+///
+/// Ideally we'd like to use the location of \p witness for this, but that
+/// could be confusing if the conformance is declared somewhere else. Moreover,
+/// if the witness and the conformance declaration are in different files, we
+/// could be issuing diagnostics in one file that wouldn't be present if we
+/// recompiled just that file. Therefore, we only use the witness's location if
+/// it's in the same type or extension that declares the conformance.
+static SourceLoc
+getLocForDiagnosingWitness(const NormalProtocolConformance *conformance,
+                           const ValueDecl *witness) {
+  if (witness && witness->getDeclContext() == conformance->getDeclContext()) {
+    SourceLoc witnessLoc = witness->getLoc();
+    if (witnessLoc.isValid())
+      return witnessLoc;
+  }
+  return conformance->getLoc();
+}
+
+/// Emits a "'foo' declared here" note unless \p mainDiagLoc is already the
+/// location of \p value.
+static void emitDeclaredHereIfNeeded(DiagnosticEngine &diags,
+                                     SourceLoc mainDiagLoc,
+                                     const ValueDecl *value) {
+  if (!value)
+    return;
+  if (mainDiagLoc == value->getLoc())
+    return;
+  diags.diagnose(value, diag::decl_declared_here, value->getFullName());
+}
+
 bool ConformanceChecker::checkObjCTypeErasedGenerics(
                                                  AssociatedTypeDecl *assocType,
                                                  Type type,
@@ -2079,17 +2112,11 @@ bool ConformanceChecker::checkObjCTypeErasedGenerics(
   });
 
   // Diagnose the problem.
-  auto &diags = assocType->getASTContext().Diags;
-  if (typeDecl) {
-    diags.diagnose(typeDecl, diag::type_witness_objc_generic_parameter,
-                   type, genericParam, !genericParam.isNull(),
-                   assocType->getFullName(), Proto->getFullName());
-  } else {
-    diags.diagnose(Conformance->getLoc(),
-                   diag::type_witness_objc_generic_parameter,
-                   type, genericParam,  !genericParam.isNull(),
-                   assocType->getFullName(), Proto->getFullName());
-  }
+  SourceLoc diagLoc = getLocForDiagnosingWitness(Conformance, typeDecl);
+  ctx.Diags.diagnose(diagLoc, diag::type_witness_objc_generic_parameter,
+                     type, genericParam, !genericParam.isNull(),
+                     assocType->getFullName(), Proto->getFullName());
+  emitDeclaredHereIfNeeded(ctx.Diags, diagLoc, typeDecl);
 
   return true;
 }
@@ -2134,12 +2161,16 @@ void ConformanceChecker::recordTypeWitness(AssociatedTypeDecl *assocType,
                           ? diag::type_witness_not_accessible_proto
                           : diag::type_witness_not_accessible_type;
         auto &diags = DC->getASTContext().Diags;
-        auto diag = diags.diagnose(typeDecl, diagKind,
-                                   typeDecl->getDescriptiveKind(),
-                                   typeDecl->getFullName(),
-                                   requiredAccess,
-                                   proto->getName());
-        fixItAccess(diag, typeDecl, requiredAccess);
+        diags.diagnose(getLocForDiagnosingWitness(conformance, typeDecl),
+                       diagKind,
+                       typeDecl->getDescriptiveKind(),
+                       typeDecl->getFullName(),
+                       requiredAccess,
+                       proto->getName());
+        auto fixItDiag = diags.diagnose(typeDecl, diag::witness_fix_access,
+                                        typeDecl->getDescriptiveKind(),
+                                        requiredAccess);
+        fixItAccess(fixItDiag, typeDecl, requiredAccess);
       });
     }
   } else {
@@ -2487,13 +2518,23 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
         [ctor, requirement](NormalProtocolConformance *conformance) {
           bool inExtension = isa<ExtensionDecl>(ctor->getDeclContext());
           auto &diags = ctor->getASTContext().Diags;
-          auto diag = diags.diagnose(ctor->getLoc(),
-                                     diag::witness_initializer_not_required,
-                                     requirement->getFullName(),
-                                     inExtension,
-                                     conformance->getType());
-          if (!ctor->isImplicit() && !inExtension)
-            diag.fixItInsert(ctor->getStartLoc(), "required ");
+          SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, ctor);
+          Optional<InFlightDiagnostic> fixItDiag =
+              diags.diagnose(diagLoc, diag::witness_initializer_not_required,
+                             requirement->getFullName(), inExtension,
+                             conformance->getType());
+          if (diagLoc != ctor->getLoc() && !ctor->isImplicit()) {
+            // If the main diagnostic is emitted on the conformance, we want to
+            // attach the fix-it to the note that shows where the initializer is
+            // defined.
+            fixItDiag.getValue().flush();
+            fixItDiag.emplace(diags.diagnose(ctor, diag::decl_declared_here,
+                                             ctor->getFullName()));
+          }
+          if (!inExtension) {
+            fixItDiag->fixItInsert(ctor->getAttributeInsertionLoc(true),
+                                   "required ");
+          }
         });
     }
   }
@@ -2512,9 +2553,11 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
       [witness, requirement](NormalProtocolConformance *conformance) {
         auto proto = conformance->getProtocol();
         auto &diags = proto->getASTContext().Diags;
-        diags.diagnose(witness->getLoc(), diag::witness_self_non_subtype,
+        SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, witness);
+        diags.diagnose(diagLoc, diag::witness_self_non_subtype,
                        proto->getDeclaredType(), requirement->getFullName(),
                        conformance->getType());
+        emitDeclaredHereIfNeeded(diags, diagLoc, witness);
       });
   } else if (selfKind.result) {
     // The reference to Self occurs in the result type. A non-final class
@@ -2528,11 +2571,13 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
           [witness, requirement](NormalProtocolConformance *conformance) {
             auto proto = conformance->getProtocol();
             auto &diags = proto->getASTContext().Diags;
-            diags.diagnose(witness->getLoc(),
+            SourceLoc diagLoc = getLocForDiagnosingWitness(conformance,witness);
+            diags.diagnose(diagLoc,
                            diag::witness_requires_dynamic_self,
                            requirement->getFullName(),
                            conformance->getType(),
                            proto->getDeclaredType());
+            emitDeclaredHereIfNeeded(diags, diagLoc, witness);
           });
       }
 
@@ -2543,10 +2588,12 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
         [witness, requirement](NormalProtocolConformance *conformance) {
           auto proto = conformance->getProtocol();
           auto &diags = proto->getASTContext().Diags;
-          diags.diagnose(witness->getLoc(), diag::witness_self_non_subtype,
+          SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, witness);
+          diags.diagnose(diagLoc, diag::witness_self_non_subtype,
                          proto->getDeclaredType(),
                          requirement->getFullName(),
                          conformance->getType());
+          emitDeclaredHereIfNeeded(diags, diagLoc, witness);
         });
     }
   } else if (selfKind.requirement) {
@@ -2555,14 +2602,15 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
       // A "Self ==" constraint works incorrectly with subclasses. Complain.
       auto proto = Conformance->getProtocol();
       auto &diags = proto->getASTContext().Diags;
-      diags.diagnose(witness->getLoc(),
-                     diag::witness_self_same_type,
+      SourceLoc diagLoc = getLocForDiagnosingWitness(Conformance, witness);
+      diags.diagnose(diagLoc, diag::witness_self_same_type,
                      witness->getDescriptiveKind(),
                      witness->getFullName(),
                      Conformance->getType(),
                      requirement->getDescriptiveKind(),
                      requirement->getFullName(),
                      proto->getDeclaredType());
+      emitDeclaredHereIfNeeded(diags, diagLoc, witness);
 
       if (auto requirementRepr = *constraint) {
         diags.diagnose(requirementRepr->getEqualLoc(),
@@ -2594,10 +2642,12 @@ void ConformanceChecker::checkNonFinalClassWitness(ValueDecl *requirement,
           [witness, requirement](NormalProtocolConformance *conformance) {
             auto proto = conformance->getProtocol();
             auto &diags = proto->getASTContext().Diags;
-            diags.diagnose(witness->getLoc(),
+            diags.diagnose(conformance->getLoc(),
                            diag::witness_requires_class_implementation,
                            requirement->getFullName(),
                            conformance->getType());
+            diags.diagnose(witness, diag::decl_declared_here,
+                           witness->getFullName());
           });
       }
     }
@@ -2671,13 +2721,20 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
           auto proto = conformance->getProtocol();
           auto &diags = proto->getASTContext().Diags;
           {
-            auto diag = diags.diagnose(witness,
+            SourceLoc diagLoc = getLocForDiagnosingWitness(conformance,witness);
+            auto diag = diags.diagnose(diagLoc,
                                        diag::witness_argument_name_mismatch,
                                        isa<ConstructorDecl>(witness),
                                        witness->getFullName(),
                                        proto->getDeclaredType(),
                                        requirement->getFullName());
-            fixDeclarationName(diag, witness, requirement->getFullName());
+            if (diagLoc == witness->getLoc()) {
+              fixDeclarationName(diag, witness, requirement->getFullName());
+            } else {
+              diag.flush();
+              diags.diagnose(witness, diag::decl_declared_here,
+                             witness->getFullName());
+            }
           }
 
           diags.diagnose(requirement, diag::protocol_requirement_here,
@@ -2713,15 +2770,18 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
         bool isSetter = (check.Kind == CheckKind::AccessOfSetter);
 
         auto &diags = DC->getASTContext().Diags;
-        auto diag = diags.diagnose(
-                             witness, diagKind,
-                             getRequirementKind(requirement),
-                             witness->getFullName(),
-                             isSetter,
-                             requiredAccess,
-                             protoAccessScope.accessLevelForDiagnostics(),
-                             proto->getName());
-        fixItAccess(diag, witness, requiredAccess, isSetter);
+        diags.diagnose(getLocForDiagnosingWitness(conformance, witness),
+                       diagKind,
+                       getRequirementKind(requirement),
+                       witness->getFullName(),
+                       isSetter,
+                       requiredAccess,
+                       protoAccessScope.accessLevelForDiagnostics(),
+                       proto->getName());
+        auto fixItDiag = diags.diagnose(witness, diag::witness_fix_access,
+                                        witness->getDescriptiveKind(),
+                                        requiredAccess);
+        fixItAccess(fixItDiag, witness, requiredAccess, isSetter);
       });
       break;
     }
@@ -2733,17 +2793,16 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
           // FIXME: The problem may not be the OS version.
           ASTContext &ctx = witness->getASTContext();
           auto &diags = ctx.Diags;
+          SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, witness);
           diags.diagnose(
-                  witness,
-                  diag::availability_protocol_requires_version,
-                  conformance->getProtocol()->getFullName(),
-                  witness->getFullName(),
-                  prettyPlatformString(targetPlatform(ctx.LangOpts)),
-                  check.RequiredAvailability.getOSVersion().getLowerEndpoint());
-          diags.diagnose(requirement, 
+              diagLoc, diag::availability_protocol_requires_version,
+              conformance->getProtocol()->getFullName(),
+              witness->getFullName(),
+              prettyPlatformString(targetPlatform(ctx.LangOpts)),
+              check.RequiredAvailability.getOSVersion().getLowerEndpoint());
+          emitDeclaredHereIfNeeded(diags, diagLoc, witness);
+          diags.diagnose(requirement,
                          diag::availability_protocol_requirement_here);
-          diags.diagnose(conformance->getLoc(),
-                         diag::availability_conformance_introduced_here);
         });
       break;
     }
@@ -2763,15 +2822,22 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
           auto &ctx = witness->getASTContext();
           auto &diags = ctx.Diags;
           {
+            SourceLoc diagLoc = getLocForDiagnosingWitness(conformance,witness);
             auto diag = diags.diagnose(
-                          witness,
-                          hasAnyError(adjustments)
-                            ? diag::err_protocol_witness_optionality
-                            : diag::warn_protocol_witness_optionality,
-                          classifyOptionalityIssues(adjustments, requirement),
-                          witness->getFullName(),
-                          proto->getFullName());
-            addOptionalityFixIts(adjustments, ctx, witness, diag);
+                diagLoc,
+                hasAnyError(adjustments)
+                  ? diag::err_protocol_witness_optionality
+                  : diag::warn_protocol_witness_optionality,
+                classifyOptionalityIssues(adjustments, requirement),
+                witness->getFullName(),
+                proto->getFullName());
+            if (diagLoc == witness->getLoc()) {
+              addOptionalityFixIts(adjustments, ctx, witness, diag);
+            } else {
+              diag.flush();
+              diags.diagnose(witness, diag::decl_declared_here,
+                             witness->getFullName());
+            }
           }
 
           diags.diagnose(requirement, diag::protocol_requirement_here,
@@ -2786,12 +2852,14 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
           auto ctor = cast<ConstructorDecl>(requirement);
           auto witnessCtor = cast<ConstructorDecl>(witness);
           auto &diags = witness->getASTContext().Diags;
-          diags.diagnose(witness,
+          SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, witness);
+          diags.diagnose(diagLoc,
                          diag::witness_initializer_failability,
                          ctor->getFullName(),
                          witnessCtor->getFailability()
                            == OTK_ImplicitlyUnwrappedOptional)
             .highlight(witnessCtor->getFailabilityLoc());
+          emitDeclaredHereIfNeeded(diags, diagLoc, witness);
         });
 
       break;
@@ -2802,12 +2870,14 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
         [witness, requirement, emitError](
                                     NormalProtocolConformance *conformance) {
           auto &diags = witness->getASTContext().Diags;
-          diags.diagnose(witness,
+          SourceLoc diagLoc = getLocForDiagnosingWitness(conformance, witness);
+          diags.diagnose(diagLoc,
                          emitError ? diag::witness_unavailable
                                    : diag::witness_unavailable_warn,
                          witness->getDescriptiveKind(),
                          witness->getFullName(),
                          conformance->getProtocol()->getFullName());
+          emitDeclaredHereIfNeeded(diags, diagLoc, witness);
           diags.diagnose(requirement, diag::protocol_requirement_here,
                          requirement->getFullName());
         });
@@ -3379,43 +3449,70 @@ void ConformanceChecker::checkConformance(MissingWitnessDiagnosisKind Kind) {
         if (!witness->isObjC()) {
           bool isOptional =
             requirement->getAttrs().hasAttribute<OptionalAttr>();
+          SourceLoc diagLoc = getLocForDiagnosingWitness(Conformance, witness);
           if (auto witnessFunc = dyn_cast<AbstractFunctionDecl>(witness)) {
             auto diagInfo = getObjCMethodDiagInfo(witnessFunc);
-            auto diag = TC.diagnose(witness,
-                                    isOptional ? diag::witness_non_objc_optional
-                                               : diag::witness_non_objc,
-                                    diagInfo.first, diagInfo.second,
-                                    Proto->getFullName());
+            Optional<InFlightDiagnostic> fixItDiag =
+                TC.diagnose(diagLoc,
+                            isOptional ? diag::witness_non_objc_optional
+                                       : diag::witness_non_objc,
+                            diagInfo.first, diagInfo.second,
+                            Proto->getFullName());
+            if (diagLoc != witness->getLoc()) {
+              // If the main diagnostic is emitted on the conformance, we want
+              // to attach the fix-it to the note that shows where the
+              // witness is defined.
+              fixItDiag.getValue().flush();
+              fixItDiag.emplace(TC.diagnose(witness, diag::make_decl_objc,
+                                            witness->getDescriptiveKind()));
+            }
             if (!witness->canInferObjCFromRequirement(requirement)) {
               fixDeclarationObjCName(
-                diag, witness,
-                cast<AbstractFunctionDecl>(requirement)->getObjCSelector());
+                  fixItDiag.getValue(), witness,
+                  cast<AbstractFunctionDecl>(requirement)->getObjCSelector());
             }
           } else if (isa<VarDecl>(witness)) {
-            auto diag = TC.diagnose(witness,
-                                    isOptional
-                                      ? diag::witness_non_objc_storage_optional
-                                      : diag::witness_non_objc_storage,
-                                    /*isSubscript=*/false,
-                                    witness->getFullName(),
-                                    Proto->getFullName());
+            Optional<InFlightDiagnostic> fixItDiag =
+                TC.diagnose(diagLoc,
+                            isOptional ? diag::witness_non_objc_storage_optional
+                                       : diag::witness_non_objc_storage,
+                            /*isSubscript=*/false,
+                            witness->getFullName(),
+                            Proto->getFullName());
+            if (diagLoc != witness->getLoc()) {
+              // If the main diagnostic is emitted on the conformance, we want
+              // to attach the fix-it to the note that shows where the
+              // witness is defined.
+              fixItDiag.getValue().flush();
+              fixItDiag.emplace(TC.diagnose(witness, diag::make_decl_objc,
+                                            witness->getDescriptiveKind()));
+            }
             if (!witness->canInferObjCFromRequirement(requirement)) {
               fixDeclarationObjCName(
-                 diag, witness,
+                 fixItDiag.getValue(), witness,
                  ObjCSelector(requirement->getASTContext(), 0,
                               cast<VarDecl>(requirement)
                                 ->getObjCPropertyName()));
             }
           } else if (isa<SubscriptDecl>(witness)) {
-            TC.diagnose(witness,
-                        isOptional
-                          ? diag::witness_non_objc_storage_optional
-                          : diag::witness_non_objc_storage,
-                        /*isSubscript=*/true,
-                        witness->getFullName(),
-                        Proto->getFullName())
-              .fixItInsert(witness->getAttributeInsertionLoc(false),
-                           "@objc ");
+            Optional<InFlightDiagnostic> fixItDiag =
+                TC.diagnose(diagLoc,
+                            isOptional
+                              ? diag::witness_non_objc_storage_optional
+                              : diag::witness_non_objc_storage,
+                            /*isSubscript=*/true,
+                            witness->getFullName(),
+                            Proto->getFullName());
+            if (diagLoc != witness->getLoc()) {
+              // If the main diagnostic is emitted on the conformance, we want
+              // to attach the fix-it to the note that shows where the
+              // witness is defined.
+              fixItDiag.getValue().flush();
+              fixItDiag.emplace(TC.diagnose(witness, diag::make_decl_objc,
+                                            witness->getDescriptiveKind()));
+            }
+            fixItDiag->fixItInsert(witness->getAttributeInsertionLoc(false),
+                                   "@objc ");
           }
 
           // If the requirement is optional, @nonobjc suppresses the

--- a/test/ClangImporter/objc_generics_conformance.swift
+++ b/test/ClangImporter/objc_generics_conformance.swift
@@ -24,6 +24,16 @@ extension GenericClass : WithAssocOther {
   typealias Other = [T] // expected-error{{type 'GenericClass<T>.Other' involving Objective-C type parameter 'T' cannot be used for associated type 'Other' of protocol 'WithAssocOther'}}
 }
 
+protocol WithAssocSeparate {
+  associatedtype Separate
+}
+
+extension GenericClass {
+  typealias Separate = T // expected-note {{'Separate' declared here}}
+}
+extension GenericClass : WithAssocSeparate { // expected-error {{type 'GenericClass<T>.Separate' involving Objective-C type parameter 'T' cannot be used for associated type 'Separate' of protocol 'WithAssocSeparate'}}
+}
+
 protocol WithAssocElement {
   associatedtype Element
 }

--- a/test/Compatibility/accessibility.swift
+++ b/test/Compatibility/accessibility.swift
@@ -19,40 +19,40 @@ private protocol PrivateProto {
 }
 
 public struct PublicStruct: PublicProto, InternalProto, FilePrivateProto, PrivateProto {
-  private func publicReq() {} // expected-error {{method 'publicReq()' must be declared public because it matches a requirement in public protocol 'PublicProto'}} {{3-10=public}}
-  private func internalReq() {} // expected-error {{method 'internalReq()' must be declared internal because it matches a requirement in internal protocol 'InternalProto'}} {{3-10=internal}}
-  private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{3-10=fileprivate}}
-  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in private protocol 'PrivateProto'}} {{3-10=fileprivate}}
+  private func publicReq() {} // expected-error {{method 'publicReq()' must be declared public because it matches a requirement in public protocol 'PublicProto'}} {{none}} expected-note {{mark the instance method as 'public' to satisfy the requirement}} {{3-10=public}}
+  private func internalReq() {} // expected-error {{method 'internalReq()' must be declared internal because it matches a requirement in internal protocol 'InternalProto'}} {{none}} expected-note {{mark the instance method as 'internal' to satisfy the requirement}} {{3-10=internal}}
+  private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
+  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in private protocol 'PrivateProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
 
   public var publicVar = 0
 }
 
 // expected-note@+1 * {{type declared here}}
 internal struct InternalStruct: PublicProto, InternalProto, FilePrivateProto, PrivateProto {
-  private func publicReq() {} // expected-error {{method 'publicReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicProto'}} {{3-10=internal}}
-  private func internalReq() {} // expected-error {{method 'internalReq()' must be declared internal because it matches a requirement in internal protocol 'InternalProto'}} {{3-10=internal}}
-  private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{3-10=fileprivate}}
-  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in private protocol 'PrivateProto'}} {{3-10=fileprivate}}
+  private func publicReq() {} // expected-error {{method 'publicReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicProto'}} {{none}} expected-note {{mark the instance method as 'internal' to satisfy the requirement}} {{3-10=internal}}
+  private func internalReq() {} // expected-error {{method 'internalReq()' must be declared internal because it matches a requirement in internal protocol 'InternalProto'}} {{none}} expected-note {{mark the instance method as 'internal' to satisfy the requirement}} {{3-10=internal}}
+  private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
+  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in private protocol 'PrivateProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
 
   public var publicVar = 0
 }
 
 // expected-note@+1 * {{type declared here}}
 fileprivate struct FilePrivateStruct: PublicProto, InternalProto, FilePrivateProto, PrivateProto {
-  private func publicReq() {} // expected-error {{method 'publicReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicProto'}} {{3-10=fileprivate}}
-  private func internalReq() {} // expected-error {{method 'internalReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'InternalProto'}} {{3-10=fileprivate}}
-  private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{3-10=fileprivate}}
-  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in private protocol 'PrivateProto'}} {{3-10=fileprivate}}
+  private func publicReq() {} // expected-error {{method 'publicReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
+  private func internalReq() {} // expected-error {{method 'internalReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'InternalProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
+  private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
+  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in private protocol 'PrivateProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
 
   public var publicVar = 0
 }
 
 // expected-note@+1 * {{type declared here}}
 private struct PrivateStruct: PublicProto, InternalProto, FilePrivateProto, PrivateProto {
-  private func publicReq() {} // expected-error {{method 'publicReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicProto'}} {{3-10=fileprivate}}
-  private func internalReq() {} // expected-error {{method 'internalReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'InternalProto'}} {{3-10=fileprivate}}
-  private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{3-10=fileprivate}}
-  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in private protocol 'PrivateProto'}} {{3-10=fileprivate}}
+  private func publicReq() {} // expected-error {{method 'publicReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
+  private func internalReq() {} // expected-error {{method 'internalReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'InternalProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
+  private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
+  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in private protocol 'PrivateProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
 
   public var publicVar = 0
 }
@@ -140,7 +140,7 @@ private extension PrivateStruct {
 
 
 public struct PublicStructDefaultMethods: PublicProto, InternalProto, PrivateProto {
-  func publicReq() {} // expected-error {{method 'publicReq()' must be declared public because it matches a requirement in public protocol 'PublicProto'}} {{3-3=public }}
+  func publicReq() {} // expected-error {{method 'publicReq()' must be declared public because it matches a requirement in public protocol 'PublicProto'}} {{none}} expected-note {{mark the instance method as 'public' to satisfy the requirement}} {{3-3=public }}
   func internalReq() {}
   func privateReq() {}
 }
@@ -502,8 +502,8 @@ internal protocol InternalMutationOperations {
 }
 
 public struct AccessorsControl : InternalMutationOperations {
-  private var size = 0 // expected-error {{property 'size' must be declared internal because it matches a requirement in internal protocol 'InternalMutationOperations'}} {{3-10=internal}}
-  private subscript (_: Int) -> Int { // expected-error {{subscript must be declared internal because it matches a requirement in internal protocol 'InternalMutationOperations'}} {{3-10=internal}}
+  private var size = 0 // expected-error {{property 'size' must be declared internal because it matches a requirement in internal protocol 'InternalMutationOperations'}} {{none}} expected-note {{mark the var as 'internal' to satisfy the requirement}} {{3-10=internal}}
+  private subscript (_: Int) -> Int { // expected-error {{subscript must be declared internal because it matches a requirement in internal protocol 'InternalMutationOperations'}} {{none}} expected-note {{mark the subscript as 'internal' to satisfy the requirement}} {{3-10=internal}}
     get { return 42 }
     set {}
   }
@@ -511,8 +511,8 @@ public struct AccessorsControl : InternalMutationOperations {
 
 public struct PrivateSettersPublic : InternalMutationOperations {
   // Please don't change the formatting here; it's a precise fix-it test.
-  public private(set) var size = 0 // expected-error {{setter for property 'size' must be declared internal because it matches a requirement in internal protocol 'InternalMutationOperations'}} {{10-17=internal}}
-  public private(set) subscript (_: Int) -> Int { // expected-error {{subscript setter must be declared internal because it matches a requirement in internal protocol 'InternalMutationOperations'}} {{10-17=internal}}
+  public private(set) var size = 0 // expected-error {{setter for property 'size' must be declared internal because it matches a requirement in internal protocol 'InternalMutationOperations'}} {{none}} expected-note {{mark the var as 'internal' to satisfy the requirement}} {{10-17=internal}}
+  public private(set) subscript (_: Int) -> Int { // expected-error {{subscript setter must be declared internal because it matches a requirement in internal protocol 'InternalMutationOperations'}} {{none}} expected-note {{mark the subscript as 'internal' to satisfy the requirement}} {{10-17=internal}}
     get { return 42 }
     set {}
   }
@@ -520,9 +520,9 @@ public struct PrivateSettersPublic : InternalMutationOperations {
 
 internal struct PrivateSettersInternal : PublicMutationOperations {
   // Please don't change the formatting here; it's a precise fix-it test.
-  private(set)var size = 0 // expected-error {{setter for property 'size' must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicMutationOperations'}} {{3-15=}}
+  private(set)var size = 0 // expected-error {{setter for property 'size' must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicMutationOperations'}} {{none}} expected-note {{mark the var as 'internal' to satisfy the requirement}} {{3-15=}}
 
-  internal private(set)subscript (_: Int) -> Int { // expected-error {{subscript setter must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicMutationOperations'}} {{12-24=}}
+  internal private(set)subscript (_: Int) -> Int { // expected-error {{subscript setter must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicMutationOperations'}} {{none}} expected-note {{mark the subscript as 'internal' to satisfy the requirement}} {{12-24=}}
     get { return 42 }
     set {}
   }
@@ -543,7 +543,7 @@ internal struct PrivateSettersForReadOnlyInternal : PublicReadOnlyOperations {
 
 public struct PrivateSettersForReadOnlyPublic : PublicReadOnlyOperations {
   public private(set) var size = 0 // no-warning
-  internal private(set) subscript (_: Int) -> Int { // expected-error {{subscript must be declared public because it matches a requirement in public protocol 'PublicReadOnlyOperations'}} {{3-11=public}}
+  internal private(set) subscript (_: Int) -> Int { // expected-error {{subscript must be declared public because it matches a requirement in public protocol 'PublicReadOnlyOperations'}} {{none}} expected-note {{mark the subscript as 'public' to satisfy the requirement}} {{3-11=public}}
     get { return 42 }
     set {}
   }
@@ -567,10 +567,11 @@ private protocol PrivateOperatorProto {
 }
 
 public struct PublicOperatorAdopter : PublicOperatorProto {
+  // expected-error@-1 {{method '!' must be declared public because it matches a requirement in public protocol 'PublicOperatorProto'}} {{none}}
   fileprivate struct Inner : PublicOperatorProto {
   }
 }
-private prefix func !(input: PublicOperatorAdopter) -> PublicOperatorAdopter { // expected-error {{method '!' must be declared public because it matches a requirement in public protocol 'PublicOperatorProto'}} {{1-8=public}}
+private prefix func !(input: PublicOperatorAdopter) -> PublicOperatorAdopter { // expected-note {{mark the operator function as 'public' to satisfy the requirement}} {{1-8=public}}
   return input
 }
 private prefix func !(input: PublicOperatorAdopter.Inner) -> PublicOperatorAdopter.Inner {
@@ -578,10 +579,11 @@ private prefix func !(input: PublicOperatorAdopter.Inner) -> PublicOperatorAdopt
 }
 
 public struct InternalOperatorAdopter : InternalOperatorProto {
+  // expected-error@-1 {{method '!' must be declared internal because it matches a requirement in internal protocol 'InternalOperatorProto'}} {{none}}
   fileprivate struct Inner : InternalOperatorProto {
   }
 }
-private prefix func !(input: InternalOperatorAdopter) -> InternalOperatorAdopter { // expected-error {{method '!' must be declared internal because it matches a requirement in internal protocol 'InternalOperatorProto'}} {{1-8=internal}}
+private prefix func !(input: InternalOperatorAdopter) -> InternalOperatorAdopter { // expected-note {{mark the operator function as 'internal' to satisfy the requirement}} {{1-8=internal}}
   return input
 }
 private prefix func !(input: InternalOperatorAdopter.Inner) -> InternalOperatorAdopter.Inner {
@@ -636,17 +638,20 @@ fileprivate struct EquatablishOuterProblem {
 
 internal struct EquatablishOuterProblem2 {
   public struct Inner : Equatablish {
-    fileprivate static func ==(lhs: Inner, rhs: Inner) {} // expected-error {{method '==' must be as accessible as its enclosing type because it matches a requirement in protocol 'Equatablish'}} {{5-16=internal}}
-    // expected-note@-1 {{candidate has non-matching type}}
+    fileprivate static func ==(lhs: Inner, rhs: Inner) {} // expected-error {{method '==' must be as accessible as its enclosing type because it matches a requirement in protocol 'Equatablish'}} {{none}}
+    // expected-note@-1 {{mark the operator function as 'internal' to satisfy the requirement}} {{5-16=internal}}
+    // expected-note@-2 {{candidate has non-matching type}}
   }
 }
 
 internal struct EquatablishOuterProblem3 {
   public struct Inner : Equatablish {
+     // expected-error@-1 {{method '==' must be as accessible as its enclosing type because it matches a requirement in protocol 'Equatablish'}} {{none}}
   }
 }
-private func ==(lhs: EquatablishOuterProblem3.Inner, rhs: EquatablishOuterProblem3.Inner) {} // expected-error {{method '==' must be as accessible as its enclosing type because it matches a requirement in protocol 'Equatablish'}} {{1-8=internal}}
-// expected-note@-1 {{candidate has non-matching type}}
+private func ==(lhs: EquatablishOuterProblem3.Inner, rhs: EquatablishOuterProblem3.Inner) {}
+// expected-note@-1 {{mark the operator function as 'internal' to satisfy the requirement}} {{1-8=internal}}
+// expected-note@-2 {{candidate has non-matching type}}
 
 
 public protocol AssocTypeProto {
@@ -661,13 +666,13 @@ fileprivate struct AssocTypeOuter {
 
 fileprivate struct AssocTypeOuterProblem {
   internal struct Inner : AssocTypeProto {
-    private typealias Assoc = Int // expected-error {{type alias 'Assoc' must be as accessible as its enclosing type because it matches a requirement in protocol 'AssocTypeProto'}} {{5-12=fileprivate}}
+    private typealias Assoc = Int // expected-error {{type alias 'Assoc' must be as accessible as its enclosing type because it matches a requirement in protocol 'AssocTypeProto'}} {{none}} expected-note {{mark the type alias as 'fileprivate' to satisfy the requirement}} {{5-12=fileprivate}}
   }
 }
 
 internal struct AssocTypeOuterProblem2 {
   public struct Inner : AssocTypeProto {
-    fileprivate typealias Assoc = Int // expected-error {{type alias 'Assoc' must be as accessible as its enclosing type because it matches a requirement in protocol 'AssocTypeProto'}} {{5-16=internal}}
+    fileprivate typealias Assoc = Int // expected-error {{type alias 'Assoc' must be as accessible as its enclosing type because it matches a requirement in protocol 'AssocTypeProto'}} {{none}} expected-note {{mark the type alias as 'internal' to satisfy the requirement}} {{5-16=internal}}
   }
 }
 

--- a/test/Compatibility/accessibility_private.swift
+++ b/test/Compatibility/accessibility_private.swift
@@ -118,18 +118,21 @@ protocol VeryImportantProto {
 }
 
 private struct VIPPrivateType : VeryImportantProto {
-  private typealias Assoc = Int // expected-error {{type alias 'Assoc' must be as accessible as its enclosing type because it matches a requirement in protocol 'VeryImportantProto'}}
+  private typealias Assoc = Int // expected-error {{type alias 'Assoc' must be as accessible as its enclosing type because it matches a requirement in protocol 'VeryImportantProto'}} {{none}}
+  // expected-note@-1 {{mark the type alias as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
   var value: Int
 }
 
 private struct VIPPrivateProp : VeryImportantProto {
   typealias Assoc = Int
-  private var value: Int // expected-error {{property 'value' must be as accessible as its enclosing type because it matches a requirement in protocol 'VeryImportantProto'}} {{3-10=fileprivate}}
+  private var value: Int // expected-error {{property 'value' must be as accessible as its enclosing type because it matches a requirement in protocol 'VeryImportantProto'}} {{none}}
+  // expected-note@-1 {{mark the var as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
 }
 
 private struct VIPPrivateSetProp : VeryImportantProto {
   typealias Assoc = Int
-  private(set) var value: Int // expected-error {{setter for property 'value' must be as accessible as its enclosing type because it matches a requirement in protocol 'VeryImportantProto'}} {{3-10=fileprivate}}
+  private(set) var value: Int // expected-error {{setter for property 'value' must be as accessible as its enclosing type because it matches a requirement in protocol 'VeryImportantProto'}} {{none}}
+  // expected-note@-1 {{mark the var as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
 }
 
 private class VIPPrivateSetBase {
@@ -140,9 +143,11 @@ private class VIPPrivateSetSub : VIPPrivateSetBase, VeryImportantProto { // expe
 }
 
 private class VIPPrivateSetPropBase {
-  private(set) var value: Int = 0 // expected-error {{setter for property 'value' must be as accessible as its enclosing type because it matches a requirement in protocol 'VeryImportantProto'}} {{3-10=fileprivate}}
+  private(set) var value: Int = 0
+  // expected-note@-1 {{mark the var as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
 }
 private class VIPPrivateSetPropSub : VIPPrivateSetPropBase, VeryImportantProto {
+  // expected-error@-1 {{setter for property 'value' must be as accessible as its enclosing type because it matches a requirement in protocol 'VeryImportantProto'}} {{none}}
   typealias Assoc = Int
 }
 

--- a/test/Driver/continue-building-after-errors.swift
+++ b/test/Driver/continue-building-after-errors.swift
@@ -1,10 +1,16 @@
 // RUN: not %target-build-swift %S/Inputs/error.swift %s 2>&1 | %FileCheck %s
 // RUN: not %target-build-swift -continue-building-after-errors %S/Inputs/error.swift %s 2>&1 | %FileCheck -check-prefix=CHECK-CONTINUE %s
 
+// Check that batch mode implies -continue-building-after-errors.
+// RUN: touch %t.empty.swift
+// RUN: not %target-build-swift -enable-batch-mode -j2 %S/Inputs/error.swift %S/../Inputs/empty.swift %s %t.empty.swift 2>&1 | %FileCheck -check-prefix=CHECK-BATCH %s
+
 // CHECK: self.bar = self.bar
 // CHECK-NOT: self.baz = self.baz
 // CHECK-CONTINUE: self.bar = self.bar
 // CHECK-CONTINUE: self.baz = self.baz
+// CHECK-BATCH-DAG: self.bar = self.bar
+// CHECK-BATCH-DAG: self.baz = self.baz
 struct Bar {
   let baz: Int
   init() {

--- a/test/Misc/Inputs/serialized-diagnostics-batch-mode-suppression-helper.swift
+++ b/test/Misc/Inputs/serialized-diagnostics-batch-mode-suppression-helper.swift
@@ -1,0 +1,1 @@
+typealias SomeType = NonExistentType

--- a/test/Misc/serialized-diagnostics-batch-mode-nonprimary-suppression.swift
+++ b/test/Misc/serialized-diagnostics-batch-mode-nonprimary-suppression.swift
@@ -1,0 +1,26 @@
+// To avoid redundant diagnostics showing up in Xcode, batch-mode must suppress diagnostics in
+// non-primary files.
+//
+// RUN: rm -f %t.*
+
+// RUN: not %target-swift-frontend -typecheck  -primary-file %s  -serialize-diagnostics-path %t.main.dia -primary-file %S/../Inputs/empty.swift  -serialize-diagnostics-path %t.empty.dia %S/Inputs/serialized-diagnostics-batch-mode-suppression-helper.swift    2> %t.stderr.txt
+// RUN: c-index-test -read-diagnostics %t.main.dia 2> %t.main.txt
+// RUN: c-index-test -read-diagnostics %t.empty.dia 2> %t.empty.txt
+
+// Ensure there was an error:
+
+// RUN: %FileCheck -check-prefix=ERROR %s <%t.stderr.txt
+// ERROR: error:
+
+// Ensure the error is not in the serialized diagnostics:
+
+// RUN: %FileCheck -check-prefix=NO-DIAGNOSTICS %s <%t.main.txt
+// RUN: %FileCheck -check-prefix=NO-DIAGNOSTICS %s <%t.empty.txt
+// NO-DIAGNOSTICS: Number of diagnostics: 0
+
+// RUN: %FileCheck -check-prefix=NO-ERROR %s <%t.main.txt
+// RUN: %FileCheck -check-prefix=NO-ERROR %s <%t.empty.txt
+// NO-ERROR-NOT: error:
+
+func test(x: SomeType) {
+}

--- a/test/NameBinding/accessibility.swift
+++ b/test/NameBinding/accessibility.swift
@@ -132,11 +132,13 @@ func privateInOtherFile() {}
 
 #if !ACCESS_DISABLED
 struct ConformerByTypeAlias : TypeProto {
-  private typealias TheType = Int // expected-error {{type alias 'TheType' must be declared internal because it matches a requirement in internal protocol 'TypeProto'}} {{3-10=internal}}
+  private typealias TheType = Int // expected-error {{type alias 'TheType' must be declared internal because it matches a requirement in internal protocol 'TypeProto'}} {{none}}
+  // expected-note@-1 {{mark the type alias as 'internal' to satisfy the requirement}} {{3-10=internal}}
 }
 
 struct ConformerByLocalType : TypeProto {
-  private struct TheType {} // expected-error {{struct 'TheType' must be declared internal because it matches a requirement in internal protocol 'TypeProto'}} {{3-10=internal}}
+  private struct TheType {} // expected-error {{struct 'TheType' must be declared internal because it matches a requirement in internal protocol 'TypeProto'}} {{none}}
+  // expected-note@-1 {{mark the struct as 'internal' to satisfy the requirement}} {{3-10=internal}}
 }
 
 private struct PrivateConformerByLocalType : TypeProto {
@@ -144,7 +146,8 @@ private struct PrivateConformerByLocalType : TypeProto {
 }
 
 private struct PrivateConformerByLocalTypeBad : TypeProto {
-  private struct TheType {} // expected-error {{struct 'TheType' must be as accessible as its enclosing type because it matches a requirement in protocol 'TypeProto'}} {{3-10=fileprivate}}
+  private struct TheType {} // expected-error {{struct 'TheType' must be as accessible as its enclosing type because it matches a requirement in protocol 'TypeProto'}} {{none}}
+  // expected-note@-1 {{mark the struct as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
 }
 #endif
 

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -19,40 +19,40 @@ private protocol PrivateProto {
 }
 
 public struct PublicStruct: PublicProto, InternalProto, FilePrivateProto, PrivateProto {
-  private func publicReq() {} // expected-error {{method 'publicReq()' must be declared public because it matches a requirement in public protocol 'PublicProto'}} {{3-10=public}}
-  private func internalReq() {} // expected-error {{method 'internalReq()' must be declared internal because it matches a requirement in internal protocol 'InternalProto'}} {{3-10=internal}}
-  private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{3-10=fileprivate}}
-  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in private protocol 'PrivateProto'}} {{3-10=fileprivate}}
+  private func publicReq() {} // expected-error {{method 'publicReq()' must be declared public because it matches a requirement in public protocol 'PublicProto'}} {{none}} expected-note {{mark the instance method as 'public' to satisfy the requirement}} {{3-10=public}}
+  private func internalReq() {} // expected-error {{method 'internalReq()' must be declared internal because it matches a requirement in internal protocol 'InternalProto'}} {{none}} expected-note {{mark the instance method as 'internal' to satisfy the requirement}} {{3-10=internal}}
+  private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
+  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in private protocol 'PrivateProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
 
   public var publicVar = 0
 }
 
 // expected-note@+1 * {{type declared here}}
 internal struct InternalStruct: PublicProto, InternalProto, FilePrivateProto, PrivateProto {
-  private func publicReq() {} // expected-error {{method 'publicReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicProto'}} {{3-10=internal}}
-  private func internalReq() {} // expected-error {{method 'internalReq()' must be declared internal because it matches a requirement in internal protocol 'InternalProto'}} {{3-10=internal}}
-  private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{3-10=fileprivate}}
-  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in private protocol 'PrivateProto'}} {{3-10=fileprivate}}
+  private func publicReq() {} // expected-error {{method 'publicReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicProto'}} {{none}} expected-note {{mark the instance method as 'internal' to satisfy the requirement}} {{3-10=internal}}
+  private func internalReq() {} // expected-error {{method 'internalReq()' must be declared internal because it matches a requirement in internal protocol 'InternalProto'}} {{none}} expected-note {{mark the instance method as 'internal' to satisfy the requirement}} {{3-10=internal}}
+  private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
+  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in private protocol 'PrivateProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
 
   public var publicVar = 0
 }
 
 // expected-note@+1 * {{type declared here}}
 fileprivate struct FilePrivateStruct: PublicProto, InternalProto, FilePrivateProto, PrivateProto {
-  private func publicReq() {} // expected-error {{method 'publicReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicProto'}} {{3-10=fileprivate}}
-  private func internalReq() {} // expected-error {{method 'internalReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'InternalProto'}} {{3-10=fileprivate}}
-  private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{3-10=fileprivate}}
-  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in private protocol 'PrivateProto'}} {{3-10=fileprivate}}
+  private func publicReq() {} // expected-error {{method 'publicReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
+  private func internalReq() {} // expected-error {{method 'internalReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'InternalProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
+  private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
+  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in private protocol 'PrivateProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
 
   public var publicVar = 0
 }
 
 // expected-note@+1 * {{type declared here}}
 private struct PrivateStruct: PublicProto, InternalProto, FilePrivateProto, PrivateProto {
-  private func publicReq() {} // expected-error {{method 'publicReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicProto'}} {{3-10=fileprivate}}
-  private func internalReq() {} // expected-error {{method 'internalReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'InternalProto'}} {{3-10=fileprivate}}
-  private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{3-10=fileprivate}}
-  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in private protocol 'PrivateProto'}} {{3-10=fileprivate}}
+  private func publicReq() {} // expected-error {{method 'publicReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
+  private func internalReq() {} // expected-error {{method 'internalReq()' must be as accessible as its enclosing type because it matches a requirement in protocol 'InternalProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
+  private func filePrivateReq() {} // expected-error {{method 'filePrivateReq()' must be declared fileprivate because it matches a requirement in fileprivate protocol 'FilePrivateProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
+  private func privateReq() {} // expected-error {{method 'privateReq()' must be declared fileprivate because it matches a requirement in private protocol 'PrivateProto'}} {{none}} expected-note {{mark the instance method as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
 
   public var publicVar = 0
 }
@@ -140,7 +140,7 @@ private extension PrivateStruct {
 
 
 public struct PublicStructDefaultMethods: PublicProto, InternalProto, PrivateProto {
-  func publicReq() {} // expected-error {{method 'publicReq()' must be declared public because it matches a requirement in public protocol 'PublicProto'}} {{3-3=public }}
+  func publicReq() {} // expected-error {{method 'publicReq()' must be declared public because it matches a requirement in public protocol 'PublicProto'}} {{none}} expected-note {{mark the instance method as 'public' to satisfy the requirement}} {{3-3=public }}
   func internalReq() {}
   func privateReq() {}
 }
@@ -502,8 +502,8 @@ internal protocol InternalMutationOperations {
 }
 
 public struct AccessorsControl : InternalMutationOperations {
-  private var size = 0 // expected-error {{property 'size' must be declared internal because it matches a requirement in internal protocol 'InternalMutationOperations'}} {{3-10=internal}}
-  private subscript (_: Int) -> Int { // expected-error {{subscript must be declared internal because it matches a requirement in internal protocol 'InternalMutationOperations'}} {{3-10=internal}}
+  private var size = 0 // expected-error {{property 'size' must be declared internal because it matches a requirement in internal protocol 'InternalMutationOperations'}} {{none}} expected-note {{mark the var as 'internal' to satisfy the requirement}} {{3-10=internal}}
+  private subscript (_: Int) -> Int { // expected-error {{subscript must be declared internal because it matches a requirement in internal protocol 'InternalMutationOperations'}} {{none}} expected-note {{mark the subscript as 'internal' to satisfy the requirement}} {{3-10=internal}}
     get { return 42 }
     set {}
   }
@@ -511,8 +511,8 @@ public struct AccessorsControl : InternalMutationOperations {
 
 public struct PrivateSettersPublic : InternalMutationOperations {
   // Please don't change the formatting here; it's a precise fix-it test.
-  public private(set) var size = 0 // expected-error {{setter for property 'size' must be declared internal because it matches a requirement in internal protocol 'InternalMutationOperations'}} {{10-17=internal}}
-  public private(set) subscript (_: Int) -> Int { // expected-error {{subscript setter must be declared internal because it matches a requirement in internal protocol 'InternalMutationOperations'}} {{10-17=internal}}
+  public private(set) var size = 0 // expected-error {{setter for property 'size' must be declared internal because it matches a requirement in internal protocol 'InternalMutationOperations'}} {{none}} expected-note {{mark the var as 'internal' to satisfy the requirement}} {{10-17=internal}}
+  public private(set) subscript (_: Int) -> Int { // expected-error {{subscript setter must be declared internal because it matches a requirement in internal protocol 'InternalMutationOperations'}} {{none}} expected-note {{mark the subscript as 'internal' to satisfy the requirement}} {{10-17=internal}}
     get { return 42 }
     set {}
   }
@@ -520,9 +520,9 @@ public struct PrivateSettersPublic : InternalMutationOperations {
 
 internal struct PrivateSettersInternal : PublicMutationOperations {
   // Please don't change the formatting here; it's a precise fix-it test.
-  private(set)var size = 0 // expected-error {{setter for property 'size' must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicMutationOperations'}} {{3-15=}}
+  private(set)var size = 0 // expected-error {{setter for property 'size' must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicMutationOperations'}} {{none}} expected-note {{mark the var as 'internal' to satisfy the requirement}} {{3-15=}}
 
-  internal private(set)subscript (_: Int) -> Int { // expected-error {{subscript setter must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicMutationOperations'}} {{12-24=}}
+  internal private(set)subscript (_: Int) -> Int { // expected-error {{subscript setter must be as accessible as its enclosing type because it matches a requirement in protocol 'PublicMutationOperations'}} {{none}} expected-note {{mark the subscript as 'internal' to satisfy the requirement}} {{12-24=}}
     get { return 42 }
     set {}
   }
@@ -543,7 +543,7 @@ internal struct PrivateSettersForReadOnlyInternal : PublicReadOnlyOperations {
 
 public struct PrivateSettersForReadOnlyPublic : PublicReadOnlyOperations {
   public private(set) var size = 0 // no-warning
-  internal private(set) subscript (_: Int) -> Int { // expected-error {{subscript must be declared public because it matches a requirement in public protocol 'PublicReadOnlyOperations'}} {{3-11=public}}
+  internal private(set) subscript (_: Int) -> Int { // expected-error {{subscript must be declared public because it matches a requirement in public protocol 'PublicReadOnlyOperations'}} {{none}} expected-note {{mark the subscript as 'public' to satisfy the requirement}} {{3-11=public}}
     get { return 42 }
     set {}
   }
@@ -567,10 +567,11 @@ private protocol PrivateOperatorProto {
 }
 
 public struct PublicOperatorAdopter : PublicOperatorProto {
+  // expected-error@-1 {{method '!' must be declared public because it matches a requirement in public protocol 'PublicOperatorProto'}}
   fileprivate struct Inner : PublicOperatorProto {
   }
 }
-private prefix func !(input: PublicOperatorAdopter) -> PublicOperatorAdopter { // expected-error {{method '!' must be declared public because it matches a requirement in public protocol 'PublicOperatorProto'}} {{1-8=public}}
+private prefix func !(input: PublicOperatorAdopter) -> PublicOperatorAdopter { // expected-note {{mark the operator function as 'public' to satisfy the requirement}} {{1-8=public}}
   return input
 }
 private prefix func !(input: PublicOperatorAdopter.Inner) -> PublicOperatorAdopter.Inner {
@@ -578,10 +579,11 @@ private prefix func !(input: PublicOperatorAdopter.Inner) -> PublicOperatorAdopt
 }
 
 public struct InternalOperatorAdopter : InternalOperatorProto {
+  // expected-error@-1 {{method '!' must be declared internal because it matches a requirement in internal protocol 'InternalOperatorProto'}}
   fileprivate struct Inner : InternalOperatorProto {
   }
 }
-private prefix func !(input: InternalOperatorAdopter) -> InternalOperatorAdopter { // expected-error {{method '!' must be declared internal because it matches a requirement in internal protocol 'InternalOperatorProto'}} {{1-8=internal}}
+private prefix func !(input: InternalOperatorAdopter) -> InternalOperatorAdopter { // expected-note {{mark the operator function as 'internal' to satisfy the requirement}} {{1-8=internal}}
   return input
 }
 private prefix func !(input: InternalOperatorAdopter.Inner) -> InternalOperatorAdopter.Inner {
@@ -636,17 +638,19 @@ fileprivate struct EquatablishOuterProblem {
 
 internal struct EquatablishOuterProblem2 {
   public struct Inner : Equatablish {
-    fileprivate static func ==(lhs: Inner, rhs: Inner) {} // expected-error {{method '==' must be as accessible as its enclosing type because it matches a requirement in protocol 'Equatablish'}} {{5-16=internal}}
-    // expected-note@-1 {{candidate has non-matching type}}
+    fileprivate static func ==(lhs: Inner, rhs: Inner) {} // expected-error {{method '==' must be as accessible as its enclosing type because it matches a requirement in protocol 'Equatablish'}} {{none}}
+    // expected-note@-1 {{mark the operator function as 'internal' to satisfy the requirement}} {{5-16=internal}}
+    // expected-note@-2 {{candidate has non-matching type}}
   }
 }
 
 internal struct EquatablishOuterProblem3 {
-  public struct Inner : Equatablish {
+  public struct Inner : Equatablish { // expected-error {{method '==' must be as accessible as its enclosing type because it matches a requirement in protocol 'Equatablish'}} {{none}}
   }
 }
-private func ==(lhs: EquatablishOuterProblem3.Inner, rhs: EquatablishOuterProblem3.Inner) {} // expected-error {{method '==' must be as accessible as its enclosing type because it matches a requirement in protocol 'Equatablish'}} {{1-8=internal}}
-// expected-note@-1 {{candidate has non-matching type}}
+private func ==(lhs: EquatablishOuterProblem3.Inner, rhs: EquatablishOuterProblem3.Inner) {}
+// expected-note@-1 {{mark the operator function as 'internal' to satisfy the requirement}} {{1-8=internal}}
+// expected-note@-2 {{candidate has non-matching type}}
 
 
 public protocol AssocTypeProto {
@@ -661,13 +665,13 @@ fileprivate struct AssocTypeOuter {
 
 fileprivate struct AssocTypeOuterProblem {
   internal struct Inner : AssocTypeProto {
-    private typealias Assoc = Int // expected-error {{type alias 'Assoc' must be as accessible as its enclosing type because it matches a requirement in protocol 'AssocTypeProto'}} {{5-12=fileprivate}}
+    private typealias Assoc = Int // expected-error {{type alias 'Assoc' must be as accessible as its enclosing type because it matches a requirement in protocol 'AssocTypeProto'}} {{none}} expected-note {{mark the type alias as 'fileprivate' to satisfy the requirement}} {{5-12=fileprivate}}
   }
 }
 
 internal struct AssocTypeOuterProblem2 {
   public struct Inner : AssocTypeProto {
-    fileprivate typealias Assoc = Int // expected-error {{type alias 'Assoc' must be as accessible as its enclosing type because it matches a requirement in protocol 'AssocTypeProto'}} {{5-16=internal}}
+    fileprivate typealias Assoc = Int // expected-error {{type alias 'Assoc' must be as accessible as its enclosing type because it matches a requirement in protocol 'AssocTypeProto'}} {{none}} expected-note {{mark the type alias as 'internal' to satisfy the requirement}} {{5-16=internal}}
   }
 }
 

--- a/test/Sema/accessibility_private.swift
+++ b/test/Sema/accessibility_private.swift
@@ -118,18 +118,21 @@ protocol VeryImportantProto {
 }
 
 private struct VIPPrivateType : VeryImportantProto {
-  private typealias Assoc = Int // expected-error {{type alias 'Assoc' must be as accessible as its enclosing type because it matches a requirement in protocol 'VeryImportantProto'}}
+  private typealias Assoc = Int // expected-error {{type alias 'Assoc' must be as accessible as its enclosing type because it matches a requirement in protocol 'VeryImportantProto'}} {{none}}
+  // expected-note@-1 {{mark the type alias as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
   var value: Int
 }
 
 private struct VIPPrivateProp : VeryImportantProto {
   typealias Assoc = Int
-  private var value: Int // expected-error {{property 'value' must be as accessible as its enclosing type because it matches a requirement in protocol 'VeryImportantProto'}} {{3-10=fileprivate}}
+  private var value: Int // expected-error {{property 'value' must be as accessible as its enclosing type because it matches a requirement in protocol 'VeryImportantProto'}} {{none}}
+  // expected-note@-1 {{mark the var as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
 }
 
 private struct VIPPrivateSetProp : VeryImportantProto {
   typealias Assoc = Int
-  private(set) var value: Int // expected-error {{setter for property 'value' must be as accessible as its enclosing type because it matches a requirement in protocol 'VeryImportantProto'}} {{3-10=fileprivate}}
+  private(set) var value: Int // expected-error {{setter for property 'value' must be as accessible as its enclosing type because it matches a requirement in protocol 'VeryImportantProto'}}
+  // expected-note@-1 {{mark the var as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
 }
 
 private class VIPPrivateSetBase {
@@ -140,9 +143,11 @@ private class VIPPrivateSetSub : VIPPrivateSetBase, VeryImportantProto { // expe
 }
 
 private class VIPPrivateSetPropBase {
-  private(set) var value: Int = 0 // expected-error {{setter for property 'value' must be as accessible as its enclosing type because it matches a requirement in protocol 'VeryImportantProto'}} {{3-10=fileprivate}}
+  private(set) var value: Int = 0
+  // expected-note@-1 {{mark the var as 'fileprivate' to satisfy the requirement}} {{3-10=fileprivate}}
 }
 private class VIPPrivateSetPropSub : VIPPrivateSetPropBase, VeryImportantProto {
+  // expected-error@-1 {{setter for property 'value' must be as accessible as its enclosing type because it matches a requirement in protocol 'VeryImportantProto'}} {{none}}
   typealias Assoc = Int
 }
 

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -1362,7 +1362,7 @@ protocol HasMethodF {
   func f(_ p: T) // expected-note 5{{protocol requirement here}}
 }
 
-class TriesToConformWithFunctionIntroducedOn10_51 : HasMethodF { // expected-note {{conformance introduced here}}
+class TriesToConformWithFunctionIntroducedOn10_51 : HasMethodF {
   @available(OSX, introduced: 10.51)
   func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on OS X 10.50.0 and newer}}
 }
@@ -1377,10 +1377,10 @@ class ConformsWithFunctionIntroducedOnMinimumDeploymentTarget : HasMethodF {
 
 class SuperHasMethodF {
   @available(OSX, introduced: 10.51)
-    func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on OS X 10.50.0 and newer}}
+    func f(_ p: Int) { } // expected-note {{'f' declared here}}
 }
 
-class TriesToConformWithUnavailableFunctionInSuperClass : SuperHasMethodF, HasMethodF { // expected-note {{conformance introduced here}}
+class TriesToConformWithUnavailableFunctionInSuperClass : SuperHasMethodF, HasMethodF { // expected-error {{protocol 'HasMethodF' requires 'f' to be available on OS X 10.50.0 and newer}}
   // The conformance here is generating an error on f in the super class.
 }
 
@@ -1402,14 +1402,14 @@ class ConformsByOverridingFunctionInSuperClass : SuperHasMethodF, HasMethodF {
 // Attempt to conform in protocol extension with unavailable witness
 // in extension
 class HasNoMethodF1 { }
-extension HasNoMethodF1 : HasMethodF { // expected-note {{conformance introduced here}}
+extension HasNoMethodF1 : HasMethodF {
   @available(OSX, introduced: 10.51)
   func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on OS X 10.50.0 and newer}}
 }
 
 class HasNoMethodF2 { }
 @available(OSX, introduced: 10.51)
-extension HasNoMethodF2 : HasMethodF { // expected-note {{conformance introduced here}}
+extension HasNoMethodF2 : HasMethodF {
   func f(_ p: Int) { } // expected-error {{protocol 'HasMethodF' requires 'f' to be available on OS X 10.50.0 and newer}}
 }
 
@@ -1435,7 +1435,7 @@ class ConformsToUnavailableProtocolWithUnavailableWitness : HasMethodFOn10_51 {
 @available(OSX, introduced: 10.51)
 class HasNoMethodF4 { }
 @available(OSX, introduced: 10.52)
-extension HasNoMethodF4 : HasMethodFOn10_51 { // expected-note {{conformance introduced here}}
+extension HasNoMethodF4 : HasMethodFOn10_51 {
   func f(_ p: Int) { } // expected-error {{protocol 'HasMethodFOn10_51' requires 'f' to be available on OS X 10.51 and newer}}
 }
 
@@ -1444,7 +1444,7 @@ protocol HasTakesClassAvailableOn10_51 {
   func takesClassAvailableOn10_51(_ o: ClassAvailableOn10_51) // expected-note 2{{protocol requirement here}}
 }
 
-class AttemptsToConformToHasTakesClassAvailableOn10_51 : HasTakesClassAvailableOn10_51 { // expected-note {{conformance introduced here}}
+class AttemptsToConformToHasTakesClassAvailableOn10_51 : HasTakesClassAvailableOn10_51 {
   @available(OSX, introduced: 10.52)
   func takesClassAvailableOn10_51(_ o: ClassAvailableOn10_51) { // expected-error {{protocol 'HasTakesClassAvailableOn10_51' requires 'takesClassAvailableOn10_51' to be available on OS X 10.51 and newer}}
   }
@@ -1457,7 +1457,7 @@ class ConformsToHasTakesClassAvailableOn10_51 : HasTakesClassAvailableOn10_51 {
 }
 
 class TakesClassAvailableOn10_51_A { }
-extension TakesClassAvailableOn10_51_A : HasTakesClassAvailableOn10_51 { // expected-note {{conformance introduced here}}
+extension TakesClassAvailableOn10_51_A : HasTakesClassAvailableOn10_51 {
   @available(OSX, introduced: 10.52)
   func takesClassAvailableOn10_51(_ o: ClassAvailableOn10_51) { // expected-error {{protocol 'HasTakesClassAvailableOn10_51' requires 'takesClassAvailableOn10_51' to be available on OS X 10.51 and newer}}
   }
@@ -1475,7 +1475,7 @@ extension TakesClassAvailableOn10_51_B : HasTakesClassAvailableOn10_51 {
 // protocol requirement. Rather, the witness should be chosen, regardless of its
 // potential unavailability, and then it should be diagnosed if it is less available
 // than the protocol requires.
-class TestAvailabilityDoesNotAffectWitnessCandidacy : HasMethodF { // expected-note {{conformance introduced here}}
+class TestAvailabilityDoesNotAffectWitnessCandidacy : HasMethodF {
   // Test that we choose the more specialized witness even though it is
   // less available than the protocol requires and there is a less specialized
   // witness that has suitable availability.

--- a/test/Sema/diag_invalid_synthesized_init_proto_conformance.swift
+++ b/test/Sema/diag_invalid_synthesized_init_proto_conformance.swift
@@ -4,7 +4,7 @@ protocol P {
     init()
 }
 
-class A : P { } // expected-error{{initializer requirement 'init()' can only be satisfied by a `required` initializer in non-final class 'A'}} 
+class A : P { } // expected-error{{initializer requirement 'init()' can only be satisfied by a 'required' initializer in non-final class 'A'}}
 // No further errors
 
 class B : A {

--- a/test/attr/accessibility.swift
+++ b/test/attr/accessibility.swift
@@ -214,29 +214,41 @@ public protocol ProtoWithReqs {
 }
 
 public struct Adopter<T> : ProtoWithReqs {}
+// expected-error@-1 {{method 'foo()' must be declared public because it matches a requirement in public protocol 'ProtoWithReqs'}} {{none}}
+// expected-error@-2 {{type alias 'Assoc' must be declared public because it matches a requirement in public protocol 'ProtoWithReqs'}} {{none}}
 extension Adopter {
-  typealias Assoc = Int // expected-error {{type alias 'Assoc' must be declared public because it matches a requirement in public protocol 'ProtoWithReqs'}} {{3-3=public }}
-  func foo() {} // expected-error {{method 'foo()' must be declared public because it matches a requirement in public protocol 'ProtoWithReqs'}} {{3-3=public }}
+  typealias Assoc = Int
+  // expected-note@-1 {{mark the type alias as 'public' to satisfy the requirement}} {{3-3=public }}
+  func foo() {}
+  // expected-note@-1 {{mark the instance method as 'public' to satisfy the requirement}} {{3-3=public }}
 }
 
 public class AnotherAdopterBase {
-  typealias Assoc = Int // expected-error {{type alias 'Assoc' must be declared public because it matches a requirement in public protocol 'ProtoWithReqs'}} {{3-3=public }}
-  func foo() {} // expected-error {{method 'foo()' must be declared public because it matches a requirement in public protocol 'ProtoWithReqs'}} {{3-3=public }}
+  typealias Assoc = Int
+  // expected-note@-1 {{mark the type alias as 'public' to satisfy the requirement}} {{3-3=public }}
+  func foo() {}
+  // expected-note@-1 {{mark the instance method as 'public' to satisfy the requirement}} {{3-3=public }}
 }
 public class AnotherAdopterSub : AnotherAdopterBase, ProtoWithReqs {}
+// expected-error@-1 {{method 'foo()' must be declared public because it matches a requirement in public protocol 'ProtoWithReqs'}} {{none}}
+// expected-error@-2 {{type alias 'Assoc' must be declared public because it matches a requirement in public protocol 'ProtoWithReqs'}} {{none}}
 
 public protocol ReqProvider {}
 extension ReqProvider {
-  func foo() {} // expected-error {{method 'foo()' must be declared public because it matches a requirement in public protocol 'ProtoWithReqs'}} {{3-3=public }}
+  func foo() {}
+  // expected-note@-1 {{mark the instance method as 'public' to satisfy the requirement}} {{3-3=public }}
 }
 public struct AdoptViaProtocol : ProtoWithReqs, ReqProvider {
+  // expected-error@-1 {{method 'foo()' must be declared public because it matches a requirement in public protocol 'ProtoWithReqs'}} {{none}}
   public typealias Assoc = Int
 }
 
 public protocol ReqProvider2 {}
 extension ProtoWithReqs where Self : ReqProvider2 {
-  func foo() {} // expected-error {{method 'foo()' must be declared public because it matches a requirement in public protocol 'ProtoWithReqs'}} {{3-3=public }}
+  func foo() {}
+  // expected-note@-1 {{mark the instance method as 'public' to satisfy the requirement}} {{3-3=public }}
 }
 public struct AdoptViaCombinedProtocol : ProtoWithReqs, ReqProvider2 {
+  // expected-error@-1 {{method 'foo()' must be declared public because it matches a requirement in public protocol 'ProtoWithReqs'}} {{none}}
   public typealias Assoc = Int
 }

--- a/test/attr/attr_objc_swift3_deprecated.swift
+++ b/test/attr/attr_objc_swift3_deprecated.swift
@@ -5,12 +5,12 @@ import Foundation
 
 class ObjCSubclass : NSObject {
   func foo() { } // expected-warning{{inference of '@objc' for members of Objective-C-derived classes is deprecated}}
-    // expected-note@-1{{add `@objc` to continue exposing an Objective-C entry point (Swift 3 behavior)}}{{3-3=@objc }}
-    // expected-note@-2{{add `@nonobjc` to suppress the Objective-C entry point (Swift 4 behavior)}}{{3-3=@nonobjc }}
+    // expected-note@-1{{add '@objc' to continue exposing an Objective-C entry point (Swift 3 behavior)}}{{3-3=@objc }}
+    // expected-note@-2{{add '@nonobjc' to suppress the Objective-C entry point (Swift 4 behavior)}}{{3-3=@nonobjc }}
 
   var bar: NSObject? = nil // expected-warning{{inference of '@objc' for members of Objective-C-derived classes is deprecated}}
-    // expected-note@-1{{add `@objc` to continue exposing an Objective-C entry point (Swift 3 behavior)}}{{3-3=@objc }}
-    // expected-note@-2{{add `@nonobjc` to suppress the Objective-C entry point (Swift 4 behavior)}}{{3-3=@nonobjc }}
+    // expected-note@-1{{add '@objc' to continue exposing an Objective-C entry point (Swift 3 behavior)}}{{3-3=@objc }}
+    // expected-note@-2{{add '@nonobjc' to suppress the Objective-C entry point (Swift 4 behavior)}}{{3-3=@nonobjc }}
 }
 
 class DynamicMembers {
@@ -23,15 +23,15 @@ class GenericClass<T>: NSObject {}
 
 class SubclassOfGeneric: GenericClass<Int> {
   func foo() { } // expected-warning{{inference of '@objc' for members of Objective-C-derived classes is deprecated}}
-    // expected-note@-1{{add `@objc` to continue exposing an Objective-C entry point (Swift 3 behavior)}}{{3-3=@objc }}
-    // expected-note@-2{{add `@nonobjc` to suppress the Objective-C entry point (Swift 4 behavior)}}{{3-3=@nonobjc }}
+    // expected-note@-1{{add '@objc' to continue exposing an Objective-C entry point (Swift 3 behavior)}}{{3-3=@objc }}
+    // expected-note@-2{{add '@nonobjc' to suppress the Objective-C entry point (Swift 4 behavior)}}{{3-3=@nonobjc }}
 }
 
 @objc(SubclassOfGenericCustom)
 class SubclassOfGenericCustomName: GenericClass<Int> {
   func foo() { } // expected-warning{{inference of '@objc' for members of Objective-C-derived classes is deprecated}}
-    // expected-note@-1{{add `@objc` to continue exposing an Objective-C entry point (Swift 3 behavior)}}{{3-3=@objc }}
-    // expected-note@-2{{add `@nonobjc` to suppress the Objective-C entry point (Swift 4 behavior)}}{{3-3=@nonobjc }}
+    // expected-note@-1{{add '@objc' to continue exposing an Objective-C entry point (Swift 3 behavior)}}{{3-3=@objc }}
+    // expected-note@-2{{add '@nonobjc' to suppress the Objective-C entry point (Swift 4 behavior)}}{{3-3=@nonobjc }}
 }
 
 // Suppress diagnostices about references to inferred @objc declarations

--- a/test/decl/init/failable.swift
+++ b/test/decl/init/failable.swift
@@ -230,6 +230,11 @@ class C1b_objc : P1_objc {
   @objc required init!(string: String) { } // expected-error{{non-failable initializer requirement 'init(string:)' in Objective-C protocol cannot be satisfied by a failable initializer ('init!')}}
 }
 
+class C1c {
+  required init?(string: String) { } // expected-note {{'init(string:)' declared here}}
+}
+extension C1c: P1 {} // expected-error{{non-failable initializer requirement 'init(string:)' cannot be satisfied by a failable initializer ('init?')}}
+
 class C2a : P2 {
   required init(fail: String) { } // okay to remove failability
 }

--- a/test/decl/protocol/conforms/access_corner_case.swift
+++ b/test/decl/protocol/conforms/access_corner_case.swift
@@ -55,7 +55,7 @@ protocol Q2 : P2 {}
 extension Q2 {
   // note: not public
   func publicRequirement() {}
-  // expected-error@-1 {{method 'publicRequirement()' must be declared public because it matches a requirement in public protocol 'P2'}}
+  // expected-note@-1 {{mark the instance method as 'public' to satisfy the requirement}} {{3-3=public }}
 }
 
-public struct T2 : Q2 {}
+public struct T2 : Q2 {} // expected-error {{method 'publicRequirement()' must be declared public because it matches a requirement in public protocol 'P2'}}

--- a/test/decl/protocol/conforms/inherited.swift
+++ b/test/decl/protocol/conforms/inherited.swift
@@ -7,7 +7,10 @@ protocol P1 {
 
 // Never inheritable: property with 'Self' in its signature.
 protocol P2 {
-  var prop2: Self { get }
+  var prop2: Self { get set }
+}
+protocol P2a {
+  var prop2a: Self { get set }
 }
 
 // Never inheritable: subscript with 'Self' in its result type.
@@ -23,6 +26,9 @@ protocol P4 {
 // Potentially inheritable: method returning Self
 protocol P5 {
   func f5() -> Self
+}
+protocol P5a {
+  func f5a() -> Self
 }
 
 // Inheritable: method returning Self
@@ -49,6 +55,9 @@ protocol P9 {
 // Never inheritable: method with 'Self' in a non-contravariant position.
 protocol P10 {
   func f10(_ arr: [Self])
+}
+protocol P10a {
+  func f10a(_ arr: [Self])
 }
 
 // Never inheritable: method with 'Self' in curried position.
@@ -86,7 +95,14 @@ class A : P1, P2, P3, P4, P5, P6, P7, P8, P9, P10 {
 
   // P2
   var prop2: A { // expected-error{{protocol 'P2' requirement 'prop2' cannot be satisfied by a non-final class ('A') because it uses 'Self' in a non-parameter, non-result type position}}
-    return self
+    get { return self }
+    set {}
+  }
+
+  // P2a
+  var prop2a: A { // expected-note {{'prop2a' declared here}}
+    get { return self }
+    set {}
   }
 
   // P3
@@ -104,7 +120,10 @@ class A : P1, P2, P3, P4, P5, P6, P7, P8, P9, P10 {
   }
 
   // P5
-  func f5() -> A { return self } // expected-error{{method 'f5()' in non-final class 'A' must return `Self` to conform to protocol 'P5'}}
+  func f5() -> A { return self } // expected-error{{method 'f5()' in non-final class 'A' must return 'Self' to conform to protocol 'P5'}}
+
+  // P5a
+  func f5a() -> A { return self } // expected-note {{'f5a()' declared here}}
 
   // P6
   func f6() -> Self { return self }
@@ -118,9 +137,17 @@ class A : P1, P2, P3, P4, P5, P6, P7, P8, P9, P10 {
   // P10
   func f10(_ arr: [A]) { } // expected-error{{protocol 'P10' requirement 'f10' cannot be satisfied by a non-final class ('A') because it uses 'Self' in a non-parameter, non-result type position}}
 
+  // P10a
+  func f10a(_ arr: [A]) { } // expected-note {{'f10a' declared here}}
+
   // P11
   func f11() -> (_ x: A) -> Int { return { x in 5 } }
 }
+
+extension A: P2a, P5a, P10a {}
+// expected-error@-1 {{protocol 'P2a' requirement 'prop2a' cannot be satisfied by a non-final class ('A') because it uses 'Self' in a non-parameter, non-result type position}}
+// expected-error@-2 {{method 'f5a()' in non-final class 'A' must return 'Self' to conform to protocol 'P5a'}}
+// expected-error@-3 {{protocol 'P10a' requirement 'f10a' cannot be satisfied by a non-final class ('A') because it uses 'Self' in a non-parameter, non-result type position}}
 
 // P9
 func ==(x: A, y: A) -> Bool { return true }
@@ -173,7 +200,8 @@ final class A9 : P1, P2, P3, P4, P5, P6, P7, P8, P9, P10 {
 
   // P2
   var prop2: A9 {
-    return self
+    get { return self }
+    set {}
   }
 
   // P3

--- a/test/decl/protocol/conforms/init.swift
+++ b/test/decl/protocol/conforms/init.swift
@@ -26,7 +26,7 @@ final class C1b : P1 {
 }
 
 class C1c : P1 {
-  init() { } // expected-error{{initializer requirement 'init()' can only be satisfied by a `required` initializer in non-final class 'C1c'}}{{3-3=required }}
+  init() { } // expected-error{{initializer requirement 'init()' can only be satisfied by a 'required' initializer in non-final class 'C1c'}}{{3-3=required }}
 }
 
 struct S2 : P1 { } // okay
@@ -35,15 +35,24 @@ enum E2 : P1 { } // expected-error{{type 'E2' does not conform to protocol 'P1'}
 
 final class C2a : P1 { } // okay
 
-class C2b : P1 { } // expected-error{{initializer requirement 'init()' can only be satisfied by a `required` initializer in non-final class 'C2b'}}
+class C2b : P1 { } // expected-error{{initializer requirement 'init()' can only be satisfied by a 'required' initializer in non-final class 'C2b'}}
 
 class C2c { 
   init(x: Int) { }
 }
 
 extension C2c : P1 {
-  convenience init() { self.init(x: 0) } // expected-error{{initializer requirement 'init()' can only be satisfied by a `required` initializer in the definition of non-final class 'C2c'}}
+  convenience init() { self.init(x: 0) } // expected-error{{initializer requirement 'init()' can only be satisfied by a 'required' initializer in the definition of non-final class 'C2c'}}
 }
+
+class C2d { 
+  init(x: Int) { }
+  convenience init() { self.init(x: 0) } // expected-note {{'init()' declared here}} {{3-3=required }}
+}
+
+extension C2d : P1 { // expected-error{{initializer requirement 'init()' can only be satisfied by a 'required' initializer in non-final class 'C2d'}}
+}
+
 
 // rdar://problem/24575507
 protocol P2 {

--- a/test/decl/protocol/conforms/self.swift
+++ b/test/decl/protocol/conforms/self.swift
@@ -18,13 +18,13 @@ extension P {
 
   func hasDefaultTakesT(_: T) {}
 
-  func returnsSelfTakesT(_: T) -> Self { // expected-error {{method 'returnsSelfTakesT' in non-final class 'Class' cannot be implemented in a protocol extension because it returns `Self` and has associated type requirements}}
+  func returnsSelfTakesT(_: T) -> Self { // expected-note {{'returnsSelfTakesT' declared here}}
     return self
   }
 }
 
 // This fails
-class Class : P {}
+class Class : P {} // expected-error {{method 'returnsSelfTakesT' in non-final class 'Class' cannot be implemented in a protocol extension because it returns 'Self' and has associated type requirements}}
 
 // This succeeds, because the class is final
 final class FinalClass : P {}

--- a/test/decl/protocol/conforms/self_same_type.swift
+++ b/test/decl/protocol/conforms/self_same_type.swift
@@ -13,6 +13,12 @@ class C1: Q {
     // expected-note@-1{{consider weakening the same-type requirement 'T.T' == 'C1' to a superclass requirement}}{{41-43=:}}
 }
 
+class C1a {
+  func foo<T: P>(_: T, _: C1a) where T.T == C1a {} // expected-note {{'foo' declared here}}
+    // expected-note@-1{{consider weakening the same-type requirement 'T.T' == 'C1a' to a superclass requirement}}{{42-44=:}}
+}
+extension C1a: Q {} // expected-error{{instance method 'foo' in non-final class 'C1a' cannot be used to satisfy requirement instance method 'foo' (in protocol 'Q') due to same-type requirement involving 'Self'}}}}
+
 final class C2: Q {
   func foo<T: P>(_: T, _: C2) where T.T == C2 {}
 }

--- a/test/decl/protocol/req/dynamic_self.swift
+++ b/test/decl/protocol/req/dynamic_self.swift
@@ -28,7 +28,7 @@ class Z : Y, P { }
 
 // Erro: Z2 conforms, but subclass would not
 class Z2 : P {
-  func f() -> Z2 { return self } // expected-error{{method 'f()' in non-final class 'Z2' must return `Self` to conform to protocol 'P'}}
+  func f() -> Z2 { return self } // expected-error{{method 'f()' in non-final class 'Z2' must return 'Self' to conform to protocol 'P'}}
 }
 
 // Okay: struct conforms by returning itself

--- a/test/decl/protocol/req/name_mismatch.swift
+++ b/test/decl/protocol/req/name_mismatch.swift
@@ -1,7 +1,7 @@
 // RUN: %target-typecheck-verify-swift
 
 protocol P {
-  func foo(_ i: Int, x: Float) // expected-note 4{{requirement 'foo(_:x:)' declared here}}
+  func foo(_ i: Int, x: Float) // expected-note 5 {{requirement 'foo(_:x:)' declared here}}
 }
 
 struct S1 : P {
@@ -23,6 +23,11 @@ struct S4 : P {
 struct S5 : P {
   func foo(_ i: Int, z x: Float) { } // expected-error{{method 'foo(_:z:)' has different argument labels from those required by protocol 'P' ('foo(_:x:)')}}{{22-24=}}
 }
+
+struct S5a {
+  func foo(_ i: Int, z x: Float) { } // expected-note {{'foo(_:z:)' declared here}} {{none}}
+}
+extension S5a: P {} // expected-error{{method 'foo(_:z:)' has different argument labels from those required by protocol 'P' ('foo(_:x:)')}} {{none}}
 
 struct Loadable { }
 

--- a/test/decl/protocol/req/optionality.swift
+++ b/test/decl/protocol/req/optionality.swift
@@ -46,7 +46,7 @@
 // Parameters of non-optional type.
 // ------------------------------------------------------------------------
 @objc protocol ParameterNonOpt1 {
-  @objc optional func f0(_ x: C1) // expected-note 2{{declared here}}
+  @objc optional func f0(_ x: C1) // expected-note 3 {{declared here}}
 }
 
 @objc class ParameterNonOpt1a : ParameterNonOpt1 {
@@ -60,6 +60,11 @@
 @objc class ParameterNonOpt1c : ParameterNonOpt1 {
   func f0(_ x: C1?) { } // expected-warning{{parameter of 'f0' has different optionality than expected by protocol 'ParameterNonOpt1'}}{{18-19=}}
 }
+
+@objc class ParameterNonOpt1d {
+  func f0(_ x: C1?) { } // expected-note {{'f0' declared here}} {{none}}
+}
+extension ParameterNonOpt1d : ParameterNonOpt1 {} // expected-warning{{parameter of 'f0' has different optionality than expected by protocol 'ParameterNonOpt1'}} {{none}}
 
 // ------------------------------------------------------------------------
 // Result of IUO type.

--- a/test/decl/protocol/req/unavailable.swift
+++ b/test/decl/protocol/req/unavailable.swift
@@ -26,10 +26,17 @@ class Bar : NonObjCProto { // expected-error {{type 'Bar' does not conform to pr
 
 // Complain about unavailable witnesses (error in Swift 4, warning in Swift 3)
 protocol P {
-  func foo(bar: Foo) // expected-note{{requirement 'foo(bar:)' declared here}}
+  func foo(bar: Foo) // expected-note 2 {{requirement 'foo(bar:)' declared here}}
 }
 
 struct ConformsToP : P { // expected-error{{type 'ConformsToP' does not conform to protocol 'P'}}
   @available(*, unavailable)
   func foo(bar: Foo) { } // expected-error{{unavailable instance method 'foo(bar:)' was used to satisfy a requirement of protocol 'P'}}
 }
+
+struct ConformsToP2 {
+  @available(*, unavailable)
+  func foo(bar: Foo) { } // expected-note {{'foo(bar:)' declared here}}
+}
+extension ConformsToP2: P {} // expected-error{{type 'ConformsToP2' does not conform to protocol 'P'}}
+// expected-error@-1 {{unavailable instance method 'foo(bar:)' was used to satisfy a requirement of protocol 'P'}}

--- a/test/stdlib/BinaryIntegerRequirements.swift
+++ b/test/stdlib/BinaryIntegerRequirements.swift
@@ -1,6 +1,9 @@
-// RUN: %swift -swift-version 4 -typecheck -verify %s
+// RUN: %target-typecheck-verify-swift -swift-version 4
 
 struct MyInt: FixedWidthInteger { // expected-error {{type 'MyInt' does not conform to protocol 'BinaryInteger'}}
+  // expected-error@-1 {{unavailable operator function '&=' was used to satisfy a requirement of protocol 'BinaryInteger'}}
+  // expected-error@-2 {{unavailable operator function '|=' was used to satisfy a requirement of protocol 'BinaryInteger'}}
+  // expected-error@-3 {{unavailable operator function '^=' was used to satisfy a requirement of protocol 'BinaryInteger'}}
   typealias IntegerLiteralType = Int
   static let isSigned = false
   init(integerLiteral value: Int) { fatalError() }


### PR DESCRIPTION
- **Explanation**: This is fallout from #14900, which was the first attempt to deal with batch mode being different from single-file mode in terms of what diagnostics get produced and where. There was a hole in that scheme, however: if processing B.swift results in a diagnostic being emitted in A.swift (and B.swift and A.swift are in different batches), that diagnostic would appear in *every file in the same batch as B.swift.* This (1) looks bad in Xcode's Log Editor, and (2) could result in a diagnostic that *never goes away.* (How? Fix the problem in A.swift, and A.swift and B.swift will get rebuilt…but not necessarily other files in B.swift's original batch.)

    These changes do three things:

    1. Change Sema diagnostics so that every diagnostic emitted in file A.swift while processing a different file B.swift would be emitted if we processed A.swift on its own.

    2. Implicitly turn on `-continue-building-after-errors` when using batch mode to make sure we actually do process A.swift on its own in the same build. (A.swift might still not be processed if we're doing an incremental build, but that doesn't harm the model.)

    3. Stop emitting diagnostics located in A.swift altogether if A.swift isn't in the current batch.

- **Scope**: Affects batch mode. (Also benignly tweaks some existing diagnostics in all modes.)

- **Issue**: rdar://problem/40032762

- **Risk**: Medium-*high*. We're choosing not to report some diagnostics in batch mode because we expect them to be reported elsewhere; if those assumptions are violated, users will not see these diagnostics at all, and will have to use either single-file or WMO instead.

- **Testing**: Built a toy project and a real Apple project with the new compiler and observed the behavior of the Report Navigator for both warnings and errors.

- **Reviewed by**: Me and @graydon (for @davidungar's change), @huonw and @DougGregor (for part of my changes), @davidungar (for the other part of my changes).