### PR TITLE
[Demangle to metadata] Support simple extension contexts.

### DIFF
--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -29,7 +29,7 @@ namespace Demangle {
 
 /// Strip generic arguments from the "spine" of a context node, producing a
 /// bare context to be used in (e.g.) forming nominal type descriptors.
-NodePointer stripGenericArgsFromContextNode(const NodePointer &node,
+NodePointer stripGenericArgsFromContextNode(NodePointer node,
                                             NodeFactory &factory);
 
 /// Describe a function parameter, parameterized on the type
@@ -482,7 +482,7 @@ private:
       if (node->getNumChildren() < 2)
         return false;
 
-      auto moduleOrParentType = node->getChild(0);
+      auto parentContext = node->getChild(0);
 
       // Nested types are handled a bit funny here because a
       // nominal typeref always stores its full mangled name,
@@ -490,14 +490,22 @@ private:
       // mangled name already includes the module and parent
       // types, if any.
       nominalNode = node;
-      if (moduleOrParentType->getKind() != NodeKind::Module) {
-        parent = decodeMangledType(moduleOrParentType);
-        if (!parent) return false;
-
+      switch (parentContext->getKind()) {
+      case Node::Kind::Module:
+        break;
+      case Node::Kind::Extension:
+        // Decode the type being extended.
+        if (parentContext->getNumChildren() < 2)
+          return false;
+        parentContext = parentContext->getChild(1);
+        LLVM_FALLTHROUGH;
+      default:
+        parent = decodeMangledType(parentContext);
         // Remove any generic arguments from the context node, producing a
-        // node that reference the nominal type declaration.
+        // node that references the nominal type declaration.
         nominalNode =
           stripGenericArgsFromContextNode(node, Builder.getNodeFactory());
+        break;
       }
     }
     typeDecl = Builder.createNominalTypeDecl(nominalNode);
@@ -507,7 +515,7 @@ private:
   }
 
   BuiltProtocolDecl decodeMangledProtocolType(
-                                           const Demangle::NodePointer &node) {
+                                            const Demangle::NodePointer &node) {
     if (node->getKind() == NodeKind::Type)
       return decodeMangledProtocolType(node->getChild(0));
 

--- a/lib/Demangling/Demangler.cpp
+++ b/lib/Demangling/Demangler.cpp
@@ -264,8 +264,8 @@ bool swift::Demangle::isStruct(llvm::StringRef mangledName) {
   return isStructNode(Dem.demangleType(mangledName));
 }
 
-namespace swift {
-namespace Demangle {
+using namespace swift;
+using namespace Demangle;
 
 //////////////////////////////////
 // Node member functions        //
@@ -2695,6 +2695,3 @@ NodePointer Demangler::demangleObjCTypeName() {
 
   return Global;
 }
-
-} // namespace Demangle
-} // namespace swift

--- a/lib/Demangling/TypeDecoder.cpp
+++ b/lib/Demangling/TypeDecoder.cpp
@@ -18,7 +18,7 @@
 using namespace swift;
 using namespace Demangle;
 
-NodePointer Demangle::stripGenericArgsFromContextNode(const NodePointer &node,
+NodePointer Demangle::stripGenericArgsFromContextNode(NodePointer node,
                                                       NodeFactory &factory) {
   switch (node->getKind()) {
   case Demangle::Node::Kind::BoundGenericClass:
@@ -51,6 +51,23 @@ NodePointer Demangle::stripGenericArgsFromContextNode(const NodePointer &node,
     newNode->addChild(newContext, factory);
     for (unsigned i = 1, n = node->getNumChildren(); i != n; ++i)
       newNode->addChild(node->getChild(i), factory);
+    return newNode;
+  }
+      
+  case Demangle::Node::Kind::Extension: {
+    // Strip generic arguments from the extended type.
+    if (node->getNumChildren() < 2)
+      return node;
+    
+    auto newExtended = stripGenericArgsFromContextNode(node->getChild(1),
+                                                       factory);
+    if (newExtended == node->getChild(1)) return node;
+    
+    auto newNode = factory.createNode(Node::Kind::Extension);
+    newNode->addChild(node->getChild(0), factory);
+    newNode->addChild(newExtended, factory);
+    if (node->getNumChildren() == 3)
+      newNode->addChild(node->getChild(2), factory);
     return newNode;
   }
 

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -153,13 +153,17 @@ swift::swift_registerTypeMetadataRecords(const TypeMetadataRecord *begin,
   _registerTypeMetadataRecords(T, begin, end);
 }
 
+static const TypeContextDescriptor *
+_findNominalTypeDescriptor(Demangle::NodePointer node,
+                           Demangle::Demangler &Dem);
+
 bool
 swift::_contextDescriptorMatchesMangling(const ContextDescriptor *context,
                                          Demangle::NodePointer node) {
-  if (node->getKind() == Demangle::Node::Kind::Type)
-    node = node->getChild(0);
-
   while (context) {
+    if (node->getKind() == Demangle::Node::Kind::Type)
+      node = node->getChild(0);
+    
     // We can directly match symbolic references to the current context.
     if (node && node->getKind() == Demangle::Node::Kind::SymbolicReference) {
       if (equalContexts(context, reinterpret_cast<const ContextDescriptor *>(
@@ -182,8 +186,56 @@ swift::_contextDescriptorMatchesMangling(const ContextDescriptor *context,
     }
     
     case ContextDescriptorKind::Extension: {
-      // TODO: Check whether the extension context constraints match.
-      return false;
+      auto extension = cast<ExtensionContextDescriptor>(context);
+      
+      // Check whether the extension context matches the mangled context.
+      if (node->getKind() != Demangle::Node::Kind::Extension)
+        return false;
+      if (node->getNumChildren() < 2)
+        return false;
+      
+      // Check that the context being extended matches as well.
+      auto extendedContextNode = node->getChild(1);
+      auto extendedContextMangledName = extension->getMangledExtendedContext();
+      auto demangler = getDemanglerForRuntimeTypeResolution();
+      auto extendedContextDemangled =
+         demangler.demangleType(extendedContextMangledName);
+      if (!extendedContextDemangled)
+        return false;
+      if (extendedContextDemangled->getKind() == Node::Kind::Type) {
+        if (extendedContextDemangled->getNumChildren() < 1)
+          return false;
+        extendedContextDemangled = extendedContextDemangled->getChild(0);
+      }
+      extendedContextDemangled =
+        stripGenericArgsFromContextNode(extendedContextDemangled, demangler);
+      
+      auto extendedDescriptorFromNode =
+        _findNominalTypeDescriptor(extendedContextNode, demangler);
+      auto extendedDescriptorFromDemangled =
+        _findNominalTypeDescriptor(extendedContextDemangled, demangler);
+      
+      if (!extendedDescriptorFromNode || !extendedDescriptorFromDemangled ||
+          !equalContexts(extendedDescriptorFromNode,
+                         extendedDescriptorFromDemangled))
+        return false;
+      
+      // Check whether the generic signature of the extension matches the
+      // mangled constraints, if any.
+
+      if (node->getNumChildren() >= 3) {
+        // NB: If we ever support extensions with independent generic arguments
+        // like `extension <T> Array where Element == Optional<T>`, we'd need
+        // to look at the mangled context name to match up generic arguments.
+        // That would probably need a new extension mangling form, though.
+        
+        // TODO
+      }
+      
+      // The parent context of the extension should match in the mangling and
+      // context descriptor.
+      node = node->getChild(0);
+      break;
     }
     
     default:

--- a/test/Runtime/demangleToMetadata.swift
+++ b/test/Runtime/demangleToMetadata.swift
@@ -333,5 +333,93 @@ DemangleToMetadataTests.test("superclass requirements") {
   expectNil(_typeByMangledName("4main4SG10VyAA2C3CG"))
 }
 
+//
+// Extensions of external types, and constrained extensions
+//
+
+struct SG11<T> {}
+
+extension Dictionary {
+  struct Inner<V: P1> {}
+}
+
+extension SG11 where T: P1 {
+  struct InnerTConformsToP1<U: P2> { }
+}
+
+extension SG11.InnerTConformsToP1 where U: P3 {
+  struct InnermostUConformsToP3<V: P4> { }
+}
+
+struct ConformsToP2AndP3: P2, P3 { }
+
+DemangleToMetadataTests.test("Nested types in extensions") {
+  expectEqual(
+    Dictionary<String, Int>.Inner<ConformsToP1>.self,
+    _typeByMangledName("s10DictionaryV4mainE5InnerVySSSi_AC12ConformsToP1VG")!)
+  expectEqual(
+    SG11<ConformsToP1>.InnerTConformsToP1<ConformsToP2>.self,
+    _typeByMangledName("4main4SG11VA2A2P1RzlE016InnerTConformsToC0VyAA08ConformsfC0V_AA0gF2P2VG")!)
+  expectEqual(
+    SG11<ConformsToP1>.InnerTConformsToP1<ConformsToP2AndP3>
+                      .InnermostUConformsToP3<ConformsToP4a>.self,
+    _typeByMangledName("4main4SG11VA2A2P1RzlE016InnerTConformsToC0VA2A2P3Rd__rlE018InnermostUConformsfG0VyAA08ConformsfC0V_AA0jf5P2AndG0V_AA0jF3P4aVG")!)
+
+  // Failure case: Dictionary's outer `Key: Hashable` constraint not sastified
+  // TODO: expectNil(_typeByMangledName("s10DictionaryV4mainE5InnerVyAC12ConformsToP1VSi_AC12ConformsToP1VG"))
+  // Failure case: Dictionary's inner `V: P1` constraint not satisfied
+  expectNil(_typeByMangledName("s10DictionaryV4mainE5InnerVySSSi_AC12ConformsToP2VG"))
+
+  // Failure case: SG11's outer `T: P1` constraint not satisfied
+  expectNil(_typeByMangledName("4main4SG11VA2A2P1RzlE016InnerTConformsToC0VyAA08ConformsF2P2V_AHGMa"))
+  // Failure case: SG11's inner `U: P2` constraint not satisfied
+  expectNil(_typeByMangledName("4main4SG11VA2A2P1RzlE016InnerTConformsToC0VyAA08ConformsfC0V_AHGMa"))
+
+  // TODO: Failure case: InnermostUConformsToP3's 'U: P3' constraint not satisfied
+  
+}
+
+//
+// Nested types in same-type-constrained extensions
+//
+
+/* TODO
+
+struct SG12<T: P1, U: P2> {}
+
+struct ConformsToP1AndP2 : P1, P2 { }
+
+extension SG12 where U == T {
+  struct InnerTEqualsU<V: P3> { }
+}
+
+extension SG12 where T == ConformsToP1 {
+  struct InnerTEqualsConformsToP1<V: P3> { }
+}
+
+extension SG12 where U == ConformsToP2 {
+  struct InnerUEqualsConformsToP2<V: P3> { }
+}
+
+DemangleToMetadataTests.test("Nested types in same-type-constrained extensions") {
+  expectEqual(
+    SG12<ConformsToP1AndP2, ConformsToP1AndP2>.InnerTEqualsU<ConformsToP3>.self,
+    _typeByMangledName("4main4SG12VA2A2P2Rzq_RszrlE13InnerTEqualsUVyAA015ConformsToP1AndC0VAH_AA0fG2P3VG")!)
+  expectEqual(
+    SG12<ConformsToP1, ConformsToP2>.InnerTEqualsConformsToP1<ConformsToP3>.self,
+    _typeByMangledName("4main4SG12VA2A12ConformsToP1VRszrlE012InnerTEqualscdE0VyAeA0cD2P2V_AA0cD2P3VG")!)
+  expectEqual(
+    SG12<ConformsToP1, ConformsToP2>.InnerUEqualsConformsToP2<ConformsToP3>.self,
+    _typeByMangledName("4main4SG12VA2A12ConformsToP2VRs_rlE012InnerUEqualscdE0VyAA0cD2P1VAE_AA0cD2P3VG")!)
+
+  // TODO: Cases where mangled name doesn't match constraints
+  // T != U in InnerTEqualsU
+  // V !: P3 in InnerTEqualsU
+  // T != ConformsToP1 in InnerTEqualsConformsToP1
+  // V !: P3 in InnerTEqualsConformsToP1
+}
+
+ */
+
 runAllTests()
 


### PR DESCRIPTION
Support demangling for types nested within some simple extension contexts.
Still does not support nested types within constrained extensions that
involve same-type constraints among generic parameters, nor
deeply-nested types in extensions. However, it fixes
rdar://problem/40071688.

This an updated version of https://github.com/apple/swift/pull/16287/.