### PR TITLE
[4.2] Discriminate local variables

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -2150,6 +2150,7 @@ class ValueDecl : public Decl {
   DeclName Name;
   SourceLoc NameLoc;
   llvm::PointerIntPair<Type, 3, OptionalEnum<AccessLevel>> TypeAndAccess;
+  unsigned LocalDiscriminator = 0;
 
 private:
     bool isUsableFromInline() const;

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -763,6 +763,7 @@ public:
   ParserStatus parseLineDirective(bool isLine = false);
 
   void setLocalDiscriminator(ValueDecl *D);
+  void setLocalDiscriminatorToParamList(ParameterList *PL);
 
   /// Parse the optional attributes before a declaration.
   bool parseDeclAttributeList(DeclAttributes &Attributes,

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 412; // Last change: add begin_access [builtin].
+const uint16_t VERSION_MINOR = 413; // Last change: Remove discriminator from LocalDeclTableInfo.
 
 using DeclIDField = BCFixed<31>;
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -223,10 +223,6 @@ FOR_KNOWN_FOUNDATION_TYPES(CACHE_FOUNDATION_DECL)
   /// \brief Map from Swift declarations to brief comments.
   llvm::DenseMap<const Decl *, StringRef> BriefComments;
 
-  /// \brief Map from local declarations to their discriminators.
-  /// Missing entries implicitly have value 0.
-  llvm::DenseMap<const ValueDecl *, unsigned> LocalDiscriminators;
-
   /// \brief Map from declarations to foreign error conventions.
   /// This applies to both actual imported functions and to @objc functions.
   llvm::DenseMap<const AbstractFunctionDecl *,
@@ -1769,24 +1765,6 @@ void ASTContext::setBriefComment(const Decl *D, StringRef Comment) {
   Impl.BriefComments[D] = Comment;
 }
 
-unsigned ValueDecl::getLocalDiscriminator() const {
-  assert(getDeclContext()->isLocalContext());
-  auto &discriminators = getASTContext().Impl.LocalDiscriminators;
-  auto it = discriminators.find(this);
-  if (it == discriminators.end())
-    return 0;
-  return it->second;
-}
-
-void ValueDecl::setLocalDiscriminator(unsigned index) {
-  assert(getDeclContext()->isLocalContext());
-  if (!index) {
-    assert(!getASTContext().Impl.LocalDiscriminators.count(this));
-    return;
-  }
-  getASTContext().Impl.LocalDiscriminators.insert({this, index});
-}
-
 NormalProtocolConformance *
 ASTContext::getBehaviorConformance(Type conformingType,
                                    ProtocolDecl *protocol,
@@ -2031,7 +2009,6 @@ size_t ASTContext::getTotalMemory() const {
     llvm::capacity_in_bytes(Impl.ModuleLoaders) +
     llvm::capacity_in_bytes(Impl.RawComments) +
     llvm::capacity_in_bytes(Impl.BriefComments) +
-    llvm::capacity_in_bytes(Impl.LocalDiscriminators) +
     llvm::capacity_in_bytes(Impl.ModuleTypes) +
     llvm::capacity_in_bytes(Impl.GenericParamTypes) +
     // Impl.GenericFunctionTypes ?

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1680,6 +1680,16 @@ bool ValueDecl::needsCapture() const {
   return !isa<TypeDecl>(this);
 }
 
+unsigned ValueDecl::getLocalDiscriminator() const {
+  return LocalDiscriminator;
+}
+
+void ValueDecl::setLocalDiscriminator(unsigned index) {
+  assert(getDeclContext()->isLocalContext());
+  assert(LocalDiscriminator == 0 && "LocalDiscriminator is set multiple times");
+  LocalDiscriminator = index;
+}
+
 ValueDecl *ValueDecl::getOverriddenDecl() const {
   if (auto fd = dyn_cast<FuncDecl>(this))
     return fd->getOverriddenDecl();

--- a/lib/IDE/SwiftSourceDocInfo.cpp
+++ b/lib/IDE/SwiftSourceDocInfo.cpp
@@ -581,7 +581,7 @@ std::pair<bool, Pattern*> NameMatcher::walkToPatternPre(Pattern *P) {
   if (isDone() || shouldSkip(P->getSourceRange()))
     return std::make_pair(false, P);
 
-  tryResolve(ASTWalker::ParentTy(P), P->getLoc());
+  tryResolve(ASTWalker::ParentTy(P), P->getStartLoc());
   return std::make_pair(!isDone(), P);
 }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4384,8 +4384,6 @@ VarDecl *Parser::parseDeclVarGetSet(Pattern *pattern,
   if (!PrimaryVar || !primaryVarIsWellFormed) {
     diagnose(pattern->getLoc(), diag::getset_nontrivial_pattern);
     Invalid = true;
-  } else {
-    setLocalDiscriminator(PrimaryVar);
   }
 
   TypeLoc TyLoc;
@@ -4795,6 +4793,7 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
     pattern->forEachVariable([&](VarDecl *VD) {
       VD->setStatic(StaticLoc.isValid());
       VD->getAttrs() = Attributes;
+      setLocalDiscriminator(VD);
       Decls.push_back(VD);
     });
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2727,6 +2727,7 @@ ParserResult<Expr> Parser::parseExprClosure() {
   if (params) {
     // Add the parameters into scope.
     addParametersToScope(params);
+    setLocalDiscriminatorToParamList(params);
   } else {
     // There are no parameters; allow anonymous closure variables.
     // FIXME: We could do this all the time, and then provide Fix-Its

--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -972,6 +972,7 @@ static void parseGuardedPattern(Parser &P, GuardedPattern &result,
     // represents tuples and var patterns as tupleexprs and
     // unresolved_pattern_expr nodes, instead of as proper pattern nodes.
     patternResult.get()->forEachVariable([&](VarDecl *VD) {
+      P.setLocalDiscriminator(VD);
       if (VD->hasName()) P.addToScope(VD);
       boundDecls.push_back(VD);
     });
@@ -993,6 +994,8 @@ static void parseGuardedPattern(Parser &P, GuardedPattern &result,
       for (auto previous : boundDecls) {
         if (previous->hasName() && previous->getName() == VD->getName()) {
           found = true;
+          // Use the same local discriminator.
+          VD->setLocalDiscriminator(previous->getLocalDiscriminator());
           break;
         }
       }
@@ -1390,6 +1393,7 @@ Parser::parseStmtConditionElement(SmallVectorImpl<StmtConditionElement> &result,
   // Add variable bindings from the pattern to our current scope and mark
   // them as being having a non-pattern-binding initializer.
   ThePattern.get()->forEachVariable([&](VarDecl *VD) {
+    setLocalDiscriminator(VD);
     if (VD->hasName())
       addToScope(VD);
     VD->setHasNonPatternBindingInit();

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -2018,7 +2018,8 @@ ModuleFile::getLocalTypeDecls(SmallVectorImpl<TypeDecl *> &results) {
   for (auto entry : LocalTypeDecls->data()) {
     auto DeclID = entry.first;
     auto TD = cast<TypeDecl>(getDecl(DeclID));
-    TD->setLocalDiscriminator(entry.second);
+    assert(entry.second == TD->getLocalDiscriminator());
+//    TD->setLocalDiscriminator(entry.second);
     results.push_back(TD);
   }
 }

--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -429,7 +429,7 @@ class ModuleFile::LocalDeclTableInfo {
 public:
   using internal_key_type = StringRef;
   using external_key_type = internal_key_type;
-  using data_type = std::pair<DeclID, unsigned>; // ID, local discriminator
+  using data_type = DeclID;
   using hash_value_type = uint32_t;
   using offset_type = unsigned;
 
@@ -447,7 +447,7 @@ public:
 
   static std::pair<unsigned, unsigned> ReadKeyDataLength(const uint8_t *&data) {
     unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
-    return { keyLength, sizeof(uint32_t) + sizeof(unsigned) };
+    return { keyLength, sizeof(uint32_t) };
   }
 
   static internal_key_type ReadKey(const uint8_t *data, unsigned length) {
@@ -456,9 +456,7 @@ public:
 
   static data_type ReadData(internal_key_type key, const uint8_t *data,
                             unsigned length) {
-    auto declID = endian::readNext<uint32_t, little, unaligned>(data);
-    auto discriminator = endian::readNext<unsigned, little, unaligned>(data);
-    return { declID, discriminator };
+    return endian::readNext<uint32_t, little, unaligned>(data);
   }
 };
 
@@ -1527,7 +1525,7 @@ TypeDecl *ModuleFile::lookupLocalType(StringRef MangledName) {
   if (iter == LocalTypeDecls->end())
     return nullptr;
 
-  return cast<TypeDecl>(getDecl((*iter).first));
+  return cast<TypeDecl>(getDecl(*iter));
 }
 
 TypeDecl *ModuleFile::lookupNestedType(Identifier name,
@@ -2015,11 +2013,8 @@ ModuleFile::getLocalTypeDecls(SmallVectorImpl<TypeDecl *> &results) {
   if (!LocalTypeDecls)
     return;
 
-  for (auto entry : LocalTypeDecls->data()) {
-    auto DeclID = entry.first;
+  for (auto DeclID : LocalTypeDecls->data()) {
     auto TD = cast<TypeDecl>(getDecl(DeclID));
-    assert(entry.second == TD->getLocalDiscriminator());
-//    TD->setLocalDiscriminator(entry.second);
     results.push_back(TD);
   }
 }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -228,7 +228,7 @@ namespace {
   public:
     using key_type = std::string;
     using key_type_ref = StringRef;
-    using data_type = std::pair<DeclID, unsigned>; // ID, local discriminator
+    using data_type = DeclID;
     using data_type_ref = const data_type &;
     using hash_value_type = uint32_t;
     using offset_type = unsigned;
@@ -242,7 +242,7 @@ namespace {
                                                     key_type_ref key,
                                                     data_type_ref data) {
       uint32_t keyLength = key.size();
-      uint32_t dataLength = sizeof(uint32_t) + sizeof(unsigned);
+      uint32_t dataLength = sizeof(uint32_t);
       endian::Writer<little> writer(out);
       writer.write<uint16_t>(keyLength);
       return { keyLength, dataLength };
@@ -256,8 +256,7 @@ namespace {
                   unsigned len) {
       static_assert(declIDFitsIn32Bits(), "DeclID too large");
       endian::Writer<little> writer(out);
-      writer.write<uint32_t>(data.first);
-      writer.write<unsigned>(data.second);
+      writer.write<uint32_t>(data);
     }
   };
 
@@ -4913,9 +4912,7 @@ void Serializer::writeAST(ModuleOrSourceFile DC,
       Mangle::ASTMangler Mangler;
       std::string MangledName = Mangler.mangleDeclAsUSR(TD, /*USRPrefix*/"");
       assert(!MangledName.empty() && "Mangled type came back empty!");
-      localTypeGenerator.insert(MangledName, {
-        addDeclRef(TD), TD->getLocalDiscriminator()
-      });
+      localTypeGenerator.insert(MangledName, addDeclRef(TD));
 
       if (auto IDC = dyn_cast<IterableDeclContext>(TD)) {
         collectInterestingNestedDeclarations(*this, IDC->getMembers(),

--- a/test/refactoring/rename/Outputs/local/casebind_1.swift.expected
+++ b/test/refactoring/rename/Outputs/local/casebind_1.swift.expected
@@ -1,0 +1,46 @@
+func test1() {
+  if true {
+    let x = 1
+    print(x)
+  } else {
+    let x = 2
+    print(x)
+  }
+}
+
+func test2(arg1: Int?, arg2: (Int, String)?) {
+  if let x = arg1 {
+    print(x)
+  } else if let (x, y) = arg2 {
+    print(x, y)
+  }
+}
+
+func test3(arg: Int?) {
+  switch arg {
+  case let .some(xRenamed) where xRenamed == 0:
+    print(xRenamed)
+  case let .some(x) where x == 1,
+       let .some(x) where x == 2: // FIXME: This 'x' in '.some(x)' isn't properly renamed in 'casebind_2' case.
+    print(x)
+  default:
+    break
+  }
+}
+
+struct Err1 : Error { }
+func test4(arg: () throws -> Void) {
+  do {
+    try arg()
+  } catch let x as Err1 {
+    print(x)
+  } catch let x {
+    print(x)
+  }
+}
+
+
+
+
+
+

--- a/test/refactoring/rename/Outputs/local/casebind_1.swift.expected
+++ b/test/refactoring/rename/Outputs/local/casebind_1.swift.expected
@@ -39,8 +39,8 @@ func test4(arg: () throws -> Void) {
   }
 }
 
-
-
-
-
+func test5(_ x: Int) {
+  let x = x 
+  print(x)
+}
 

--- a/test/refactoring/rename/Outputs/local/casebind_2.swift.expected
+++ b/test/refactoring/rename/Outputs/local/casebind_2.swift.expected
@@ -1,0 +1,46 @@
+func test1() {
+  if true {
+    let x = 1
+    print(x)
+  } else {
+    let x = 2
+    print(x)
+  }
+}
+
+func test2(arg1: Int?, arg2: (Int, String)?) {
+  if let x = arg1 {
+    print(x)
+  } else if let (x, y) = arg2 {
+    print(x, y)
+  }
+}
+
+func test3(arg: Int?) {
+  switch arg {
+  case let .some(x) where x == 0:
+    print(x)
+  case let .some(xRenamed) where xRenamed == 1,
+       let .some(x) where xRenamed == 2: // FIXME: This 'x' in '.some(x)' isn't properly renamed in 'casebind_2' case.
+    print(xRenamed)
+  default:
+    break
+  }
+}
+
+struct Err1 : Error { }
+func test4(arg: () throws -> Void) {
+  do {
+    try arg()
+  } catch let x as Err1 {
+    print(x)
+  } catch let x {
+    print(x)
+  }
+}
+
+
+
+
+
+

--- a/test/refactoring/rename/Outputs/local/casebind_2.swift.expected
+++ b/test/refactoring/rename/Outputs/local/casebind_2.swift.expected
@@ -39,8 +39,8 @@ func test4(arg: () throws -> Void) {
   }
 }
 
-
-
-
-
+func test5(_ x: Int) {
+  let x = x 
+  print(x)
+}
 

--- a/test/refactoring/rename/Outputs/local/catch_1.swift.expected
+++ b/test/refactoring/rename/Outputs/local/catch_1.swift.expected
@@ -1,0 +1,46 @@
+func test1() {
+  if true {
+    let x = 1
+    print(x)
+  } else {
+    let x = 2
+    print(x)
+  }
+}
+
+func test2(arg1: Int?, arg2: (Int, String)?) {
+  if let x = arg1 {
+    print(x)
+  } else if let (x, y) = arg2 {
+    print(x, y)
+  }
+}
+
+func test3(arg: Int?) {
+  switch arg {
+  case let .some(x) where x == 0:
+    print(x)
+  case let .some(x) where x == 1,
+       let .some(x) where x == 2: // FIXME: This 'x' in '.some(x)' isn't properly renamed in 'casebind_2' case.
+    print(x)
+  default:
+    break
+  }
+}
+
+struct Err1 : Error { }
+func test4(arg: () throws -> Void) {
+  do {
+    try arg()
+  } catch let x as Err1 {
+    print(xRenamed)
+  } catch let x {
+    print(x)
+  }
+}
+
+
+
+
+
+

--- a/test/refactoring/rename/Outputs/local/catch_1.swift.expected
+++ b/test/refactoring/rename/Outputs/local/catch_1.swift.expected
@@ -32,7 +32,7 @@ struct Err1 : Error { }
 func test4(arg: () throws -> Void) {
   do {
     try arg()
-  } catch let x as Err1 {
+  } catch let xRenamed as Err1 {
     print(xRenamed)
   } catch let x {
     print(x)

--- a/test/refactoring/rename/Outputs/local/catch_2.swift.expected
+++ b/test/refactoring/rename/Outputs/local/catch_2.swift.expected
@@ -1,0 +1,46 @@
+func test1() {
+  if true {
+    let x = 1
+    print(x)
+  } else {
+    let x = 2
+    print(x)
+  }
+}
+
+func test2(arg1: Int?, arg2: (Int, String)?) {
+  if let x = arg1 {
+    print(x)
+  } else if let (x, y) = arg2 {
+    print(x, y)
+  }
+}
+
+func test3(arg: Int?) {
+  switch arg {
+  case let .some(x) where x == 0:
+    print(x)
+  case let .some(x) where x == 1,
+       let .some(x) where x == 2: // FIXME: This 'x' in '.some(x)' isn't properly renamed in 'casebind_2' case.
+    print(x)
+  default:
+    break
+  }
+}
+
+struct Err1 : Error { }
+func test4(arg: () throws -> Void) {
+  do {
+    try arg()
+  } catch let x as Err1 {
+    print(x)
+  } catch let xRenamed {
+    print(xRenamed)
+  }
+}
+
+
+
+
+
+

--- a/test/refactoring/rename/Outputs/local/catch_2.swift.expected
+++ b/test/refactoring/rename/Outputs/local/catch_2.swift.expected
@@ -39,8 +39,8 @@ func test4(arg: () throws -> Void) {
   }
 }
 
-
-
-
-
+func test5(_ x: Int) {
+  let x = x 
+  print(x)
+}
 

--- a/test/refactoring/rename/Outputs/local/ifbind_1.swift.expected
+++ b/test/refactoring/rename/Outputs/local/ifbind_1.swift.expected
@@ -1,0 +1,46 @@
+func test1() {
+  if true {
+    let x = 1
+    print(x)
+  } else {
+    let x = 2
+    print(x)
+  }
+}
+
+func test2(arg1: Int?, arg2: (Int, String)?) {
+  if let xRenamed = arg1 {
+    print(xRenamed)
+  } else if let (x, y) = arg2 {
+    print(x, y)
+  }
+}
+
+func test3(arg: Int?) {
+  switch arg {
+  case let .some(x) where x == 0:
+    print(x)
+  case let .some(x) where x == 1,
+       let .some(x) where x == 2: // FIXME: This 'x' in '.some(x)' isn't properly renamed in 'casebind_2' case.
+    print(x)
+  default:
+    break
+  }
+}
+
+struct Err1 : Error { }
+func test4(arg: () throws -> Void) {
+  do {
+    try arg()
+  } catch let x as Err1 {
+    print(x)
+  } catch let x {
+    print(x)
+  }
+}
+
+
+
+
+
+

--- a/test/refactoring/rename/Outputs/local/ifbind_1.swift.expected
+++ b/test/refactoring/rename/Outputs/local/ifbind_1.swift.expected
@@ -39,8 +39,8 @@ func test4(arg: () throws -> Void) {
   }
 }
 
-
-
-
-
+func test5(_ x: Int) {
+  let x = x 
+  print(x)
+}
 

--- a/test/refactoring/rename/Outputs/local/ifbind_2.swift.expected
+++ b/test/refactoring/rename/Outputs/local/ifbind_2.swift.expected
@@ -1,0 +1,46 @@
+func test1() {
+  if true {
+    let x = 1
+    print(x)
+  } else {
+    let x = 2
+    print(x)
+  }
+}
+
+func test2(arg1: Int?, arg2: (Int, String)?) {
+  if let x = arg1 {
+    print(x)
+  } else if let (xRenamed, y) = arg2 {
+    print(xRenamed, y)
+  }
+}
+
+func test3(arg: Int?) {
+  switch arg {
+  case let .some(x) where x == 0:
+    print(x)
+  case let .some(x) where x == 1,
+       let .some(x) where x == 2: // FIXME: This 'x' in '.some(x)' isn't properly renamed in 'casebind_2' case.
+    print(x)
+  default:
+    break
+  }
+}
+
+struct Err1 : Error { }
+func test4(arg: () throws -> Void) {
+  do {
+    try arg()
+  } catch let x as Err1 {
+    print(x)
+  } catch let x {
+    print(x)
+  }
+}
+
+
+
+
+
+

--- a/test/refactoring/rename/Outputs/local/ifbind_2.swift.expected
+++ b/test/refactoring/rename/Outputs/local/ifbind_2.swift.expected
@@ -39,8 +39,8 @@ func test4(arg: () throws -> Void) {
   }
 }
 
-
-
-
-
+func test5(_ x: Int) {
+  let x = x 
+  print(x)
+}
 

--- a/test/refactoring/rename/Outputs/local/localvar_1.swift.expected
+++ b/test/refactoring/rename/Outputs/local/localvar_1.swift.expected
@@ -1,0 +1,46 @@
+func test1() {
+  if true {
+    let xRenamed = 1
+    print(xRenamed)
+  } else {
+    let x = 2
+    print(x)
+  }
+}
+
+func test2(arg1: Int?, arg2: (Int, String)?) {
+  if let x = arg1 {
+    print(x)
+  } else if let (x, y) = arg2 {
+    print(x, y)
+  }
+}
+
+func test3(arg: Int?) {
+  switch arg {
+  case let .some(x) where x == 0:
+    print(x)
+  case let .some(x) where x == 1,
+       let .some(x) where x == 2: // FIXME: This 'x' in '.some(x)' isn't properly renamed in 'casebind_2' case.
+    print(x)
+  default:
+    break
+  }
+}
+
+struct Err1 : Error { }
+func test4(arg: () throws -> Void) {
+  do {
+    try arg()
+  } catch let x as Err1 {
+    print(x)
+  } catch let x {
+    print(x)
+  }
+}
+
+
+
+
+
+

--- a/test/refactoring/rename/Outputs/local/localvar_1.swift.expected
+++ b/test/refactoring/rename/Outputs/local/localvar_1.swift.expected
@@ -39,8 +39,8 @@ func test4(arg: () throws -> Void) {
   }
 }
 
-
-
-
-
+func test5(_ x: Int) {
+  let x = x 
+  print(x)
+}
 

--- a/test/refactoring/rename/Outputs/local/localvar_2.swift.expected
+++ b/test/refactoring/rename/Outputs/local/localvar_2.swift.expected
@@ -1,0 +1,46 @@
+func test1() {
+  if true {
+    let x = 1
+    print(x)
+  } else {
+    let xRenamed = 2
+    print(xRenamed)
+  }
+}
+
+func test2(arg1: Int?, arg2: (Int, String)?) {
+  if let x = arg1 {
+    print(x)
+  } else if let (x, y) = arg2 {
+    print(x, y)
+  }
+}
+
+func test3(arg: Int?) {
+  switch arg {
+  case let .some(x) where x == 0:
+    print(x)
+  case let .some(x) where x == 1,
+       let .some(x) where x == 2: // FIXME: This 'x' in '.some(x)' isn't properly renamed in 'casebind_2' case.
+    print(x)
+  default:
+    break
+  }
+}
+
+struct Err1 : Error { }
+func test4(arg: () throws -> Void) {
+  do {
+    try arg()
+  } catch let x as Err1 {
+    print(x)
+  } catch let x {
+    print(x)
+  }
+}
+
+
+
+
+
+

--- a/test/refactoring/rename/Outputs/local/localvar_2.swift.expected
+++ b/test/refactoring/rename/Outputs/local/localvar_2.swift.expected
@@ -39,8 +39,8 @@ func test4(arg: () throws -> Void) {
   }
 }
 
-
-
-
-
+func test5(_ x: Int) {
+  let x = x 
+  print(x)
+}
 

--- a/test/refactoring/rename/Outputs/local/param_1.swift.expected
+++ b/test/refactoring/rename/Outputs/local/param_1.swift.expected
@@ -32,15 +32,15 @@ struct Err1 : Error { }
 func test4(arg: () throws -> Void) {
   do {
     try arg()
-  } catch let xRenamed as Err1 {
-    print(xRenamed)
+  } catch let x as Err1 {
+    print(x)
   } catch let x {
     print(x)
   }
 }
 
-func test5(_ x: Int) {
-  let x = x 
+func test5(_ xRenamed: Int) {
+  let x = xRenamed 
   print(x)
 }
 

--- a/test/refactoring/rename/Outputs/local/param_2.swift.expected
+++ b/test/refactoring/rename/Outputs/local/param_2.swift.expected
@@ -32,15 +32,15 @@ struct Err1 : Error { }
 func test4(arg: () throws -> Void) {
   do {
     try arg()
-  } catch let xRenamed as Err1 {
-    print(xRenamed)
+  } catch let x as Err1 {
+    print(x)
   } catch let x {
     print(x)
   }
 }
 
 func test5(_ x: Int) {
-  let x = x 
-  print(x)
+  let xRenamed = x 
+  print(xRenamed)
 }
 

--- a/test/refactoring/rename/local.swift
+++ b/test/refactoring/rename/local.swift
@@ -39,25 +39,29 @@ func test4(arg: () throws -> Void) {
   }
 }
 
-
+func test5(_ x: Int) {
+  let x = x 
+  print(x)
+}
 
 // RUN: %empty-directory(%t.result)
 // RUN: %refactor -rename -source-filename %s -pos=3:9 -new-name="xRenamed" >> %t.result/localvar_1.swift
 // RUN: %refactor -rename -source-filename %s -pos=7:11 -new-name="xRenamed" >> %t.result/localvar_2.swift
 // RUN: diff -u %S/Outputs/local/localvar_1.swift.expected %t.result/localvar_1.swift
 // RUN: diff -u %S/Outputs/local/localvar_2.swift.expected %t.result/localvar_2.swift
-
 // RUN: %refactor -rename -source-filename %s -pos=12:10 -new-name="xRenamed" >> %t.result/ifbind_1.swift
 // RUN: %refactor -rename -source-filename %s -pos=15:11 -new-name="xRenamed" >> %t.result/ifbind_2.swift
 // RUN: diff -u %S/Outputs/local/ifbind_1.swift.expected %t.result/ifbind_1.swift
 // RUN: diff -u %S/Outputs/local/ifbind_2.swift.expected %t.result/ifbind_2.swift
-
 // RUN: %refactor -rename -source-filename %s -pos=21:18 -new-name="xRenamed" >> %t.result/casebind_1.swift
 // RUN: %refactor -rename -source-filename %s -pos=25:11 -new-name="xRenamed" >> %t.result/casebind_2.swift
 // RUN: diff -u %S/Outputs/local/casebind_1.swift.expected %t.result/casebind_1.swift
 // RUN: diff -u %S/Outputs/local/casebind_2.swift.expected %t.result/casebind_2.swift
-
 // RUN: %refactor -rename -source-filename %s -pos=35:15 -new-name="xRenamed" >> %t.result/catch_1.swift
 // RUN: %refactor -rename -source-filename %s -pos=38:11 -new-name="xRenamed" >> %t.result/catch_2.swift
 // RUN: diff -u %S/Outputs/local/catch_1.swift.expected %t.result/catch_1.swift
 // RUN: diff -u %S/Outputs/local/catch_2.swift.expected %t.result/catch_2.swift
+// RUN: %refactor -rename -source-filename %s -pos=42:14 -new-name="xRenamed" >> %t.result/param_1.swift
+// RUN: %refactor -rename -source-filename %s -pos=44:9 -new-name="xRenamed" >> %t.result/param_2.swift
+// RUN: diff -u %S/Outputs/local/param_1.swift.expected %t.result/param_1.swift
+// RUN: diff -u %S/Outputs/local/param_2.swift.expected %t.result/param_2.swift

--- a/test/refactoring/rename/local.swift
+++ b/test/refactoring/rename/local.swift
@@ -1,0 +1,63 @@
+func test1() {
+  if true {
+    let x = 1
+    print(x)
+  } else {
+    let x = 2
+    print(x)
+  }
+}
+
+func test2(arg1: Int?, arg2: (Int, String)?) {
+  if let x = arg1 {
+    print(x)
+  } else if let (x, y) = arg2 {
+    print(x, y)
+  }
+}
+
+func test3(arg: Int?) {
+  switch arg {
+  case let .some(x) where x == 0:
+    print(x)
+  case let .some(x) where x == 1,
+       let .some(x) where x == 2: // FIXME: This 'x' in '.some(x)' isn't properly renamed in 'casebind_2' case.
+    print(x)
+  default:
+    break
+  }
+}
+
+struct Err1 : Error { }
+func test4(arg: () throws -> Void) {
+  do {
+    try arg()
+  } catch let x as Err1 {
+    print(x)
+  } catch let x {
+    print(x)
+  }
+}
+
+
+
+// RUN: %empty-directory(%t.result)
+// RUN: %refactor -rename -source-filename %s -pos=3:9 -new-name="xRenamed" >> %t.result/localvar_1.swift
+// RUN: %refactor -rename -source-filename %s -pos=7:11 -new-name="xRenamed" >> %t.result/localvar_2.swift
+// RUN: diff -u %S/Outputs/local/localvar_1.swift.expected %t.result/localvar_1.swift
+// RUN: diff -u %S/Outputs/local/localvar_2.swift.expected %t.result/localvar_2.swift
+
+// RUN: %refactor -rename -source-filename %s -pos=12:10 -new-name="xRenamed" >> %t.result/ifbind_1.swift
+// RUN: %refactor -rename -source-filename %s -pos=15:11 -new-name="xRenamed" >> %t.result/ifbind_2.swift
+// RUN: diff -u %S/Outputs/local/ifbind_1.swift.expected %t.result/ifbind_1.swift
+// RUN: diff -u %S/Outputs/local/ifbind_2.swift.expected %t.result/ifbind_2.swift
+
+// RUN: %refactor -rename -source-filename %s -pos=21:18 -new-name="xRenamed" >> %t.result/casebind_1.swift
+// RUN: %refactor -rename -source-filename %s -pos=25:11 -new-name="xRenamed" >> %t.result/casebind_2.swift
+// RUN: diff -u %S/Outputs/local/casebind_1.swift.expected %t.result/casebind_1.swift
+// RUN: diff -u %S/Outputs/local/casebind_2.swift.expected %t.result/casebind_2.swift
+
+// RUN: %refactor -rename -source-filename %s -pos=35:15 -new-name="xRenamed" >> %t.result/catch_1.swift
+// RUN: %refactor -rename -source-filename %s -pos=38:11 -new-name="xRenamed" >> %t.result/catch_2.swift
+// RUN: diff -u %S/Outputs/local/catch_1.swift.expected %t.result/catch_1.swift
+// RUN: diff -u %S/Outputs/local/catch_2.swift.expected %t.result/catch_2.swift


### PR DESCRIPTION
Cherry-pick of #16130 reviewed by @rjmccall

Set local discriminator for all local `VarDecl`s (including `ParamDecl`s). Otherwise, they cannot
be discriminated with USRs. This change is needed for rename refactoring which uses USR for discrimiating variable names.

https://bugs.swift.org/browse/SR-7205,
rdar://problem/34701880