### PR TITLE
Fix unallocated memory read in Markup parser

### DIFF
--- a/lib/Markup/LineList.cpp
+++ b/lib/Markup/LineList.cpp
@@ -25,7 +25,7 @@ std::string LineList::str() const {
     return "";
 
   auto FirstLine = Lines.begin();
-  while (FirstLine->Text.empty() && FirstLine != Lines.end())
+  while (FirstLine != Lines.end() && FirstLine->Text.empty())
     ++FirstLine;
 
   if (FirstLine == Lines.end())


### PR DESCRIPTION
<!-- What's in this pull request? -->
Small memory read error found whilst fuzzing another application that uses the Swift Markup parser.