### PR TITLE
[4.2 2018-04-30] [sourcekit] Pass -resource-dir when parsing driver arguments

### DIFF
--- a/test/SourceKit/Misc/ignored-flags.swift
+++ b/test/SourceKit/Misc/ignored-flags.swift
@@ -15,6 +15,7 @@ s.
 // RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -use-ld=blah %s | %FileCheck %s
 // RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -incremental %s | %FileCheck %s
 // RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -driver-time-compilation %s | %FileCheck %s
+// RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -sanitize=address,fuzzer -sanitize-coverage=func %s | %FileCheck %s
 
 
 // Mode flags

--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -414,10 +414,14 @@ resolveSymbolicLinksInInputs(FrontendInputsAndOutputs &inputsAndOutputs,
 }
 
 bool SwiftASTManager::initCompilerInvocation(CompilerInvocation &Invocation,
-                                             ArrayRef<const char *> Args,
+                                             ArrayRef<const char *> OrigArgs,
                                              DiagnosticEngine &Diags,
                                              StringRef UnresolvedPrimaryFile,
                                              std::string &Error) {
+  SmallVector<const char *, 16> Args(OrigArgs.begin(), OrigArgs.end());
+  Args.push_back("-resource-dir");
+  Args.push_back(Impl.RuntimeResourcePath.c_str());
+
   if (auto driverInvocation = driver::createCompilerInvocation(Args, Diags)) {
     Invocation = *driverInvocation;
   } else {
@@ -425,8 +429,6 @@ bool SwiftASTManager::initCompilerInvocation(CompilerInvocation &Invocation,
     Error = "error when parsing the compiler arguments";
     return true;
   }
-
-  Invocation.setRuntimeResourcePath(Impl.RuntimeResourcePath);
 
   Invocation.getFrontendOptions().InputsAndOutputs =
       resolveSymbolicLinksInInputs(


### PR DESCRIPTION
Cherry-pick #16547 to swift-4.2 04-30

---

... instead of overriding it after the driver is done. This improves
the fidelity of anything that looks at the resource directory inside the
driver or frontend argument parsing.  In particular, it fixes an issue
where sourcekit requests would fail if they included the -sanitize=
option because the driver would fail to find the runtime libraries.

Even though this should be *more correct* for all uses, in the
interests of understanding all possible immediate effects of this
change, I manually audited all the code that looks at the resource
directory in between when it is parsed as and argument and when
createCompilerInvocation returns. I claim that the only changes are:
1. The sanitizer library check that we wanted to change
2. The DWARFDebugFlags, which are for IRGen so don't affect SourceKit
3. The Migrator data paths, which also don't affect SourceKit

For now, I put the -resource-dir option at the end of the arguments so
that it overrides any existing option, which mimics how it behaved
before.  We might want to move it to the beginning so that we honour a
user-provided resource directory, but that should be a separate change.

rdar://40147839