### PR TITLE
[UnitTests] 4.2 - Build unittests with the same compiler used to build the runtime library to ensure calling conventions match.

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -1,4 +1,31 @@
 
+if(SWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER)
+  if((NOT "${CMAKE_C_COMPILER_ID}" STREQUAL "Clang") AND
+     (NOT "${CMAKE_C_COMPILER_ID}" STREQUAL "AppleClang"))
+    message(FATAL_ERROR "Building the swift runtime is not supported with ${CMAKE_C_COMPILER_ID}. Use the just-built clang instead.")
+  else()
+    message(WARNING "Building the swift runtime using the host compiler, and not the just-built clang.")
+  endif()
+else()
+  # If we use Clang-cl or MSVC, CMake provides default compiler and linker flags that are incompatible
+  # with the frontend of Clang or Clang++.
+  if(SWIFT_COMPILER_IS_MSVC_LIKE)
+    set(CMAKE_CXX_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang-cl")
+    set(CMAKE_C_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang-cl")
+  else()
+    set(CMAKE_CXX_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang++")
+    set(CMAKE_C_COMPILER "${SWIFT_NATIVE_LLVM_TOOLS_PATH}/clang")
+  endif()
+  
+  set(CMAKE_CXX_COMPILER_ARG1 "")
+  set(CMAKE_C_COMPILER_ARG1 "")
+  # The sanitizers require using the same version of the compiler for
+  # everything and there are various places where we link runtime code with
+  # code built by the host compiler. Disable sanitizers for the runtime for
+  # now.
+  append("-fno-sanitize=all" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+endif()
+
 include(AddSwiftUnittests)
 
 if(SWIFT_INCLUDE_TOOLS)

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -19,11 +19,16 @@ else()
   
   set(CMAKE_CXX_COMPILER_ARG1 "")
   set(CMAKE_C_COMPILER_ARG1 "")
-  # The sanitizers require using the same version of the compiler for
-  # everything and there are various places where we link runtime code with
-  # code built by the host compiler. Disable sanitizers for the runtime for
-  # now.
-  append("-fno-sanitize=all" CMAKE_C_FLAGS CMAKE_CXX_FLAGS)
+endif()
+
+if(SWIFT_RUNTIME_USE_SANITIZERS)
+  # TODO: Refactor this
+  if("Thread" IN_LIST SWIFT_RUNTIME_USE_SANITIZERS)
+    list(APPEND SWIFT_RUNTIME_CXX_FLAGS "-fsanitize=thread")
+    list(APPEND SWIFT_RUNTIME_LINK_FLAGS "-fsanitize=thread")
+    list(APPEND SWIFT_RUNTIME_SWIFT_COMPILE_FLAGS "-sanitize=thread")
+    list(APPEND SWIFT_RUNTIME_SWIFT_LINK_FLAGS "-fsanitize=thread")
+  endif()
 endif()
 
 include(AddSwiftUnittests)


### PR DESCRIPTION
This cherry-picks #16508 into the 4.2 branch.

rdar://problem/40114415