### PR TITLE
[Preset] Add linux crosscompile android preset

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -781,9 +781,26 @@ skip-test-libdispatch
 skip-test-playgroundsupport
 skip-test-libicu
 
+[preset: buildbot_linux_crosscompile_android,tools=RA,stdlib=RD,build]
+mixin-preset=buildbot_linux
+
+release
+assertions
+
+dash-dash
+
+android
+android-ndk=%(ndk_path)s
+android-api-level=21
+android-icu-uc=%(arm_dir)s/libicuucswift.so
+android-icu-uc-include=%(arm_dir)s/icu/source/common
+android-icu-i18n=%(arm_dir)s/libicui18nswift.so
+android-icu-i18n-include=%(arm_dir)s/icu/source/i18n
+
 # Ubuntu 18.04 preset for backwards compat and future customizations.
 [preset: buildbot_linux_1804]
 mixin-preset=buildbot_linux
+
 
 # Ubuntu 16.10 preset for backwards compat and future customizations.
 [preset: buildbot_linux_1610]

--- a/utils/build_swift/tests/test_presets.py
+++ b/utils/build_swift/tests/test_presets.py
@@ -40,6 +40,8 @@ PRESET_DEFAULTS = {
     'installable_package': '/tmp/install/pkg',
     'swift_install_destdir': '/tmp/install/swift',
     'symbols_package': '/path/to/symbols/package',
+    'ndk_path': '/path/to/ndk',
+    'arm_dir': '/path/to/arm',
 }
 
 SAMPLE_PRESET = """


### PR DESCRIPTION
The preset needs to include all of the following options passed to build-script:

```
    -R \                                       # Build in ReleaseAssert mode.
    --android \                                # Build for Android.
    --android-ndk $NDK_PATH \   # Path to an Android NDK.
    --android-api-level 21 \                   # The Android API level to target. Swift only supports 21 or greater.
    --android-icu-uc ${ARM_DIR}/libicuucswift.so \
    --android-icu-uc-include ${ARM_DIR}/icu/source/common \
    --android-icu-i18 ${ARM_DIR}/libicui18nswift.so \
    --android-icu-i18n-include ${ARM_DIR}/icu/source/i18n
```

I couldn't find other examples of presets that cross compile, @shahmishal is there a simple way to add this?