### PR TITLE
[WIP][SILGen] handle generic override curry thunks

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3499,6 +3499,12 @@ static void translateParametersForCanonicalFunctionThunk(
     SILParameterInfo newParamInfo;
     std::tie(origParam, newParamInfo) = T;
 
+    if (newParamInfo.isIndirectInGuaranteed()) {
+      origParam = origParam.materialize(SGF, loc);
+      newParams.emplace_back(origParam);
+      continue;
+    }
+
     if (origParam.getType().isTrivial(SGF.getModule())) {
       newParams.emplace_back(origParam);
       continue;

--- a/test/SILGen/curry_thunk_abi.swift
+++ b/test/SILGen/curry_thunk_abi.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle %s
+
+class GenericParent<T> {
+  func doesThing(_ x: T) { print(x) }
+}
+
+class SpecializedChild : GenericParent<Int> {
+  override func doesThing(_ x: Int) { print(x) }
+}
+
+let a = SpecializedChild().doesThing
+
+a(4)

--- a/test/SILGen/curry_thunk_abi_convert_tuple.swift
+++ b/test/SILGen/curry_thunk_abi_convert_tuple.swift
@@ -1,0 +1,16 @@
+// RUN: %target-swift-emit-silgen -Xllvm -sil-full-demangle %s
+// XFAIL: *
+
+class C<T> {
+  func f(t: T) { print(t) }
+}
+
+class B : C<(Int, Float)> {
+  override func f(t: (Int, Float)) {
+  	print(t)
+  }
+}
+
+let fn2: (B) -> ((Int, Float)) -> () = B.f
+
+fn2(B())((100, 200.0))


### PR DESCRIPTION
This makes it so SILGenFunction::emitCurryThunk  emits the correct
thunk type, even in the presence of overrides.

Resolves [SR-4425](https://bugs.swift.org/browse/SR-4425)

@slavapestov Can you take a look? This is my first foray into SILGen, so I'm not super familiar with the inner workings. So if you think there's a better/safer way, I'm all ears.
