### PR TITLE
Eliminate most uses of SubstitutionList

### DIFF
--- a/include/swift/AST/GenericEnvironment.h
+++ b/include/swift/AST/GenericEnvironment.h
@@ -171,7 +171,6 @@ public:
   Type getSugaredType(Type type) const;
 
   SubstitutionMap getForwardingSubstitutionMap() const;
-  SubstitutionList getForwardingSubstitutions() const;
 
   void dump(raw_ostream &os) const;
 

--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -3057,10 +3057,6 @@ public:
                               
   /// Substitute the given generic arguments into this generic
   /// function type and return the resulting non-generic type.
-  FunctionType *substGenericArgs(SubstitutionList subs);
-
-  /// Substitute the given generic arguments into this generic
-  /// function type and return the resulting non-generic type.
   FunctionType *substGenericArgs(const SubstitutionMap &subs);
 
   /// Substitute the given generic arguments into this generic
@@ -4036,8 +4032,6 @@ public:
   ABICompatibilityCheckResult
   isABICompatibleWith(CanSILFunctionType other) const;
 
-  CanSILFunctionType substGenericArgs(SILModule &silModule,
-                                      SubstitutionList subs);
   CanSILFunctionType substGenericArgs(SILModule &silModule,
                                       const SubstitutionMap &subs);
   CanSILFunctionType substGenericArgs(SILModule &silModule,

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -121,9 +121,6 @@ private:
   /// Only set if this function is a specialization of another function.
   const GenericSpecializationInformation *SpecializationInfo;
 
-  /// The forwarding substitutions, lazily computed.
-  Optional<SubstitutionList> ForwardingSubs;
-
   /// The forwarding substitution map, lazily computed.
   SubstitutionMap ForwardingSubMap;
 
@@ -683,10 +680,6 @@ public:
 
   /// Converts the given function definition to a declaration.
   void convertToDeclaration();
-
-  /// Return the identity substitutions necessary to forward this call if it is
-  /// generic.
-  SubstitutionList getForwardingSubstitutions();
 
   /// Return the identity substitutions necessary to forward this call if it is
   /// generic.

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -1793,9 +1793,6 @@ public:
   }
 
   /// The substitutions used to bind the generic arguments of this function.
-  SubstitutionList getSubstitutions() const { return Substitutions.toList(); }
-
-  /// The substitutions used to bind the generic arguments of this function.
   SubstitutionMap getSubstitutionMap() const { return Substitutions; }
 
   /// Return the total number of operands of this instruction.
@@ -1892,7 +1889,6 @@ public:
   using super::getSubstCalleeType;
   using super::getSubstCalleeConv;
   using super::hasSubstitutions;
-  using super::getSubstitutions;
   using super::getNumArguments;
   using super::getArgument;
   using super::getArguments;
@@ -7701,23 +7697,8 @@ public:
   }
 
   /// The substitutions used to bind the generic arguments of this function.
-  SubstitutionList getSubstitutions() const {
-    FOREACH_IMPL_RETURN(getSubstitutions());
-  }
-
-  /// The substitutions used to bind the generic arguments of this function.
   SubstitutionMap getSubstitutionMap() const {
     FOREACH_IMPL_RETURN(getSubstitutionMap());
-  }
-
-  /// Return a begin iterator for the substitution array.
-  auto subs_begin() const -> decltype(getSubstitutions().begin()) {
-    return getSubstitutions().begin();
-  }
-
-  /// Return an end iterator for the substitution array.
-  auto subs_end() const -> decltype(getSubstitutions().end()) {
-    return getSubstitutions().end();
   }
 
   /// The arguments passed to this instruction.

--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -439,13 +439,6 @@ public:
   ///
   /// Only call this with function types!
   SILType substGenericArgs(SILModule &M,
-                           SubstitutionList Subs) const;
-
-  /// Transform the function type SILType by replacing all of its interface
-  /// generic args with the appropriate item from the substitution.
-  ///
-  /// Only call this with function types!
-  SILType substGenericArgs(SILModule &M,
                            const SubstitutionMap &SubMap) const;
 
   /// If the original type is generic, pass the signature as genericSig.

--- a/include/swift/SILOptimizer/Utils/Local.h
+++ b/include/swift/SILOptimizer/Utils/Local.h
@@ -124,10 +124,6 @@ ProjectBoxInst *getOrCreateProjectBox(AllocBoxInst *ABI, unsigned Index);
 /// if possible.
 void replaceDeadApply(ApplySite Old, ValueBase *New);
 
-/// \brief Return true if the substitution list contains replacement types
-/// that are dependent on the type parameters of the caller.
-bool hasArchetypes(SubstitutionList Subs);
-
 /// \brief Return true if any call inside the given function may bind dynamic
 /// 'Self' to a generic argument of the callee.
 bool mayBindDynamicSelf(SILFunction *F);

--- a/lib/AST/GenericEnvironment.cpp
+++ b/lib/AST/GenericEnvironment.cpp
@@ -225,15 +225,6 @@ SubstitutionMap GenericEnvironment::getForwardingSubstitutionMap() const {
     MakeAbstractConformanceForGenericType());
 }
 
-SubstitutionList
-GenericEnvironment::getForwardingSubstitutions() const {
-  auto *genericSig = getGenericSignature();
-
-  SmallVector<Substitution, 4> result;
-  genericSig->getSubstitutions(getForwardingSubstitutionMap(), result);
-  return genericSig->getASTContext().AllocateCopy(result);
-}
-
 std::pair<Type, ProtocolConformanceRef>
 GenericEnvironment::mapConformanceRefIntoContext(GenericEnvironment *genericEnv,
                                            Type conformingType,

--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -2766,11 +2766,6 @@ bool AnyFunctionType::isCanonicalFunctionInputType(Type input) {
 }
 
 FunctionType *
-GenericFunctionType::substGenericArgs(SubstitutionList args) {
-  return substGenericArgs(getGenericSignature()->getSubstitutionMap(args));
-}
-
-FunctionType *
 GenericFunctionType::substGenericArgs(const SubstitutionMap &subs) {
   Type input = getInput().subst(subs);
   Type result = getResult().subst(subs);

--- a/lib/IRGen/CallEmission.h
+++ b/lib/IRGen/CallEmission.h
@@ -75,7 +75,7 @@ public:
 
   const Callee &getCallee() const { return CurCallee; }
 
-  SubstitutionList getSubstitutions() const {
+  SubstitutionMap getSubstitutions() const {
     return CurCallee.getSubstitutions();
   }
 

--- a/lib/IRGen/Callee.h
+++ b/lib/IRGen/Callee.h
@@ -41,13 +41,13 @@ namespace irgen {
 
     /// The archetype substitutions under which the function is being
     /// called.
-    std::vector<Substitution> Substitutions;
+    SubstitutionMap Substitutions;
 
     CalleeInfo(CanSILFunctionType origFnType,
                CanSILFunctionType substFnType,
-               SubstitutionList substitutions)
+               SubstitutionMap substitutions)
       : OrigFnType(origFnType), SubstFnType(substFnType),
-        Substitutions(substitutions.begin(), substitutions.end()) {
+        Substitutions(substitutions) {
     }
   };
 
@@ -159,8 +159,11 @@ namespace irgen {
       return Info.SubstFnType;
     }
 
-    bool hasSubstitutions() const { return !Info.Substitutions.empty(); }
-    SubstitutionList getSubstitutions() const { return Info.Substitutions; }
+    bool hasSubstitutions() const {
+      return Info.Substitutions.hasAnySubstitutableParams();
+    }
+    
+    SubstitutionMap getSubstitutions() const { return Info.Substitutions; }
 
     const FunctionPointer &getFunctionPointer() const { return Fn; }
 

--- a/lib/IRGen/GenKeyPath.cpp
+++ b/lib/IRGen/GenKeyPath.cpp
@@ -230,8 +230,7 @@ getAccessorForComputedComponent(IRGenModule &IGM,
     // Use the bound generic metadata to form a call to the original generic
     // accessor.
     WitnessMetadata ignoreWitnessMetadata;
-    auto forwardingSubs = genericEnv->getGenericSignature()->getSubstitutionMap(
-      genericEnv->getForwardingSubstitutions());
+    auto forwardingSubs = genericEnv->getForwardingSubstitutionMap();
     emitPolymorphicArguments(IGF, accessor->getLoweredFunctionType(),
                              forwardingSubs,
                              &ignoreWitnessMetadata,

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -482,18 +482,6 @@ void SILFunction::convertToDeclaration() {
   getBlocks().clear();
 }
 
-SubstitutionList SILFunction::getForwardingSubstitutions() {
-  if (ForwardingSubs)
-    return *ForwardingSubs;
-
-  auto *env = getGenericEnvironment();
-  if (!env)
-    return {};
-
-  ForwardingSubs = env->getForwardingSubstitutions();
-  return *ForwardingSubs;
-}
-
 SubstitutionMap SILFunction::getForwardingSubstitutionMap() {
   if (ForwardingSubMap)
     return ForwardingSubMap;

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -2456,23 +2456,6 @@ SILType SILType::subst(SILModule &silModule, const SubstitutionMap &subs) const{
 /// type, except using the original conventions.
 CanSILFunctionType
 SILFunctionType::substGenericArgs(SILModule &silModule,
-                                  SubstitutionList subs) {
-  if (subs.empty()) {
-    assert(
-        (!isPolymorphic() || getGenericSignature()->areAllParamsConcrete()) &&
-        "no args for non-concrete polymorphic substitution");
-    return CanSILFunctionType(this);
-  }
-
-  auto subMap = GenericSig->getSubstitutionMap(subs);
-  return substGenericArgs(silModule, subMap);
-}
-
-/// Apply a substitution to this polymorphic SILFunctionType so that
-/// it has the form of the normal SILFunctionType for the substituted
-/// type, except using the original conventions.
-CanSILFunctionType
-SILFunctionType::substGenericArgs(SILModule &silModule,
                                   const SubstitutionMap &subs) {
   if (!isPolymorphic()) {
     return CanSILFunctionType(this);

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -372,14 +372,14 @@ void SILDeclRef::dump() const {
 static void printGenericSpecializationInfo(
     raw_ostream &OS, StringRef Kind, StringRef Name,
     const GenericSpecializationInformation *SpecializationInfo,
-    SubstitutionList Subs = SubstitutionList()) {
+    SubstitutionMap Subs = { }) {
   if (!SpecializationInfo)
     return;
 
-  auto PrintSubstitutions = [&](SubstitutionList Subs) {
+  auto PrintSubstitutions = [&](SubstitutionMap Subs) {
     OS << '<';
-    interleave(Subs,
-               [&](const Substitution &s) { OS << s.getReplacement(); },
+    interleave(Subs.getReplacementTypes(),
+               [&](Type type) { OS << type; },
                [&] { OS << ", "; });
     OS << '>';
   };
@@ -396,7 +396,7 @@ static void printGenericSpecializationInfo(
     OS << "// Caller: " << SpecializationInfo->getCaller()->getName() << '\n';
     OS << "// Parent: " << SpecializationInfo->getParent()->getName() << '\n';
     OS << "// Substitutions: ";
-    PrintSubstitutions(SpecializationInfo->getSubstitutions().toList());
+    PrintSubstitutions(SpecializationInfo->getSubstitutions());
     OS << '\n';
     OS << "//\n";
     if (!SpecializationInfo->getCaller()->isSpecialization())
@@ -638,7 +638,7 @@ public:
           if (AI.getSpecializationInfo() && AI.getCalleeFunction())
             printGenericSpecializationInfo(
                 PrintState.OS, "call-site", AI.getCalleeFunction()->getName(),
-                AI.getSpecializationInfo(), AI.getSubstitutions());
+                AI.getSpecializationInfo(), AI.getSubstitutionMap());
       }
       print(&I);
     }

--- a/lib/SIL/SILType.cpp
+++ b/lib/SIL/SILType.cpp
@@ -179,13 +179,6 @@ bool SILType::isAddressOnly(SILModule &M) const {
 }
 
 SILType SILType::substGenericArgs(SILModule &M,
-                                  SubstitutionList Subs) const {
-  auto fnTy = castTo<SILFunctionType>();
-  auto canFnTy = CanSILFunctionType(fnTy->substGenericArgs(M, Subs));
-  return SILType::getPrimitiveObjectType(canFnTy);
-}
-
-SILType SILType::substGenericArgs(SILModule &M,
                                   const SubstitutionMap &SubMap) const {
   auto fnTy = castTo<SILFunctionType>();
   auto canFnTy = CanSILFunctionType(fnTy->substGenericArgs(M, SubMap));

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -2440,7 +2440,7 @@ public:
 
     // Map interface types to archetypes.
     if (auto *env = constantInfo.GenericEnv) {
-      auto subs = env->getForwardingSubstitutions();
+      auto subs = env->getForwardingSubstitutionMap();
       methodTy = methodTy->substGenericArgs(F.getModule(), subs);
     }
     assert(!methodTy->isPolymorphic());

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1081,8 +1081,8 @@ public:
     };
 
     // Search for opened archetypes and dynamic self.
-    for (auto &Sub : AS.getSubstitutions()) {
-      Sub.getReplacement()->getCanonicalType().visit(HandleType);
+    for (auto Replacement : AS.getSubstitutionMap().getReplacementTypes()) {
+      Replacement->getCanonicalType().visit(HandleType);
     }
     AS.getSubstCalleeType().visit(HandleType);
 

--- a/lib/SILGen/LValue.h
+++ b/lib/SILGen/LValue.h
@@ -431,7 +431,7 @@ public:
   /// Add a member component to the access path of this lvalue.
   void addMemberComponent(SILGenFunction &SGF, SILLocation loc,
                           AbstractStorageDecl *storage,
-                          SubstitutionList subs,
+                          SubstitutionMap subs,
                           LValueOptions options,
                           bool isSuper,
                           AccessKind accessKind,
@@ -442,7 +442,7 @@ public:
 
   void addMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
                              VarDecl *var,
-                             SubstitutionList subs,
+                             SubstitutionMap subs,
                              LValueOptions options,
                              bool isSuper,
                              AccessKind accessKind,
@@ -452,7 +452,7 @@ public:
 
   void addMemberSubscriptComponent(SILGenFunction &SGF, SILLocation loc,
                                    SubscriptDecl *subscript,
-                                   SubstitutionList subs,
+                                   SubstitutionMap subs,
                                    LValueOptions options,
                                    bool isSuper,
                                    AccessKind accessKind,

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1264,9 +1264,9 @@ void SILGenModule::tryEmitPropertyDescriptor(AbstractStorageDecl *decl) {
     return;
   }
   
-  SubstitutionList subs = {};
+  SubstitutionMap subs = {};
   if (genericEnv)
-    subs = genericEnv->getForwardingSubstitutions();
+    subs = genericEnv->getForwardingSubstitutionMap();
   
   if (auto sub = dyn_cast<SubscriptDecl>(decl)) {
     for (auto *index : *sub->getIndices()) {

--- a/lib/SILGen/SILGen.cpp
+++ b/lib/SILGen/SILGen.cpp
@@ -1383,14 +1383,6 @@ void SILGenModule::useConformance(ProtocolConformanceRef conformanceRef) {
   usedConformances.insert(root);
 }
 
-void
-SILGenModule::useConformancesFromSubstitutions(SubstitutionList subs) {
-  for (auto &sub : subs) {
-    for (auto conformance : sub.getConformances())
-      useConformance(conformance);
-  }
-}
-
 void SILGenModule::useConformancesFromSubstitutions(
                                                 const SubstitutionMap subs) {
   for (auto conf : subs.getConformances())

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -435,7 +435,7 @@ public:
 
   /// Get the substitutions necessary to invoke a non-member (global or local)
   /// property.
-  SubstitutionList
+  SubstitutionMap
   getNonMemberVarDeclSubstitutions(VarDecl *var);
 
   /// Emit a property descriptor for the given storage decl if it needs one.

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -426,9 +426,6 @@ public:
   void useConformance(ProtocolConformanceRef conformance);
 
   /// Mark protocol conformances from the given set of substitutions as used.
-  void useConformancesFromSubstitutions(SubstitutionList subs);
-
-  /// Mark protocol conformances from the given set of substitutions as used.
   void useConformancesFromSubstitutions(SubstitutionMap subs);
 
   /// Emit a `mark_function_escape` instruction for top-level code when a

--- a/lib/SILGen/SILGen.h
+++ b/lib/SILGen/SILGen.h
@@ -344,7 +344,7 @@ public:
                               GenericEnvironment *genericEnv,
                               unsigned &baseOperand,
                               bool &needsGenericContext,
-                              SubstitutionList subs,
+                              SubstitutionMap subs,
                               AbstractStorageDecl *storage,
                               ArrayRef<ProtocolConformanceRef> indexHashables,
                               CanType baseTy,

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4458,14 +4458,11 @@ SILGenFunction::emitApplyOfLibraryIntrinsic(SILLocation loc,
   llvm::SmallVector<ManagedValue, 8> finalArgs;
   convertOwnershipConventionsGivenParamInfos(*this, silConv.getParameters(), args, loc, finalArgs);
 
-  SmallVector<Substitution, 4> subs;
-  if (auto *genericSig = fn->getGenericSignature())
-    genericSig->getSubstitutions(subMap, subs);
-
   ResultPlanPtr resultPlan =
   ResultPlanBuilder::computeResultPlan(*this, calleeTypeInfo, loc, ctx);
   ArgumentScope argScope(*this, loc);
-  return emitApply(std::move(resultPlan), std::move(argScope), loc, mv, subs,
+  return emitApply(std::move(resultPlan), std::move(argScope), loc, mv,
+                   subMap.toList(),
                    finalArgs, calleeTypeInfo, ApplyOptions::None, ctx);
 }
 

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4797,24 +4797,19 @@ static Callee
 emitSpecializedAccessorFunctionRef(SILGenFunction &SGF,
                                    SILLocation loc,
                                    SILDeclRef constant,
-                                   SubstitutionList substitutions,
+                                   SubstitutionMap substitutions,
                                    ArgumentSource &selfValue,
                                    bool isSuper,
                                    bool isDirectUse)
 {
   // Convert the substitution list into a substitution map.
   auto origAccessType = SGF.SGM.Types.getConstantInfo(constant).FormalType;
-  SubstitutionMap subMap;
-  if (auto genericFnType = dyn_cast<GenericFunctionType>(origAccessType)) {
-    auto genericSig = genericFnType.getGenericSignature();
-    subMap = genericSig->getSubstitutionMap(substitutions);;
-  }
 
   // Get the accessor function. The type will be a polymorphic function if
   // the Self type is generic.
   Callee callee = getBaseAccessorFunctionRef(SGF, loc, constant, selfValue,
                                              isSuper, isDirectUse,
-                                             subMap);
+                                             substitutions);
   
   // Collect captures if the accessor has them.
   auto accessorFn = cast<AbstractFunctionDecl>(constant.getDecl());
@@ -5016,7 +5011,7 @@ SILDeclRef SILGenModule::getGetterDeclRef(AbstractStorageDecl *storage) {
 /// Emit a call to a getter.
 RValue SILGenFunction::
 emitGetAccessor(SILLocation loc, SILDeclRef get,
-                SubstitutionList substitutions,
+                SubstitutionMap substitutions,
                 ArgumentSource &&selfValue,
                 bool isSuper, bool isDirectUse,
                 RValue &&subscripts, SGFContext c) {
@@ -5053,7 +5048,7 @@ SILDeclRef SILGenModule::getSetterDeclRef(AbstractStorageDecl *storage) {
 }
 
 void SILGenFunction::emitSetAccessor(SILLocation loc, SILDeclRef set,
-                                     SubstitutionList substitutions,
+                                     SubstitutionMap substitutions,
                                      ArgumentSource &&selfValue,
                                      bool isSuper, bool isDirectUse,
                                      RValue &&subscripts,
@@ -5126,7 +5121,7 @@ SILGenModule::getMaterializeForSetDeclRef(AbstractStorageDecl *storage) {
 
 MaterializedLValue SILGenFunction::
 emitMaterializeForSetAccessor(SILLocation loc, SILDeclRef materializeForSet,
-                              SubstitutionList substitutions,
+                              SubstitutionMap substitutions,
                               ArgumentSource &&selfValue,
                               bool isSuper, bool isDirectUse,
                               RValue &&subscripts, SILValue buffer,
@@ -5211,7 +5206,7 @@ SILDeclRef SILGenModule::getAddressorDeclRef(AbstractStorageDecl *storage,
 /// pointer, if applicable.
 std::pair<ManagedValue, ManagedValue> SILGenFunction::
 emitAddressorAccessor(SILLocation loc, SILDeclRef addressor,
-                      SubstitutionList substitutions,
+                      SubstitutionMap substitutions,
                       ArgumentSource &&selfValue,
                       bool isSuper, bool isDirectUse,
                       RValue &&subscripts, SILType addressType) {

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4802,9 +4802,6 @@ emitSpecializedAccessorFunctionRef(SILGenFunction &SGF,
                                    bool isSuper,
                                    bool isDirectUse)
 {
-  // Convert the substitution list into a substitution map.
-  auto origAccessType = SGF.SGM.Types.getConstantInfo(constant).FormalType;
-
   // Get the accessor function. The type will be a polymorphic function if
   // the Self type is generic.
   Callee callee = getBaseAccessorFunctionRef(SGF, loc, constant, selfValue,

--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4469,18 +4469,6 @@ SILGenFunction::emitApplyOfLibraryIntrinsic(SILLocation loc,
                    finalArgs, calleeTypeInfo, ApplyOptions::None, ctx);
 }
 
-RValue
-SILGenFunction::emitApplyOfLibraryIntrinsic(SILLocation loc,
-                                            FuncDecl *fn,
-                                            const SubstitutionList &subs,
-                                            ArrayRef<ManagedValue> args,
-                                            SGFContext ctx) {
-  SubstitutionMap subMap;
-  if (auto genericSig = fn->getGenericSignature())
-    subMap = genericSig->getSubstitutionMap(subs);
-  return emitApplyOfLibraryIntrinsic(loc, fn, subMap, args, ctx);
-}
-
 static StringRef
 getMagicFunctionString(SILGenFunction &SGF) {
   assert(SGF.MagicFunctionName

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -1245,7 +1245,7 @@ static SILValue emitObjCUnconsumedArgument(SILGenFunction &SGF,
 }
 
 static CanAnyFunctionType substGenericArgs(CanAnyFunctionType fnType,
-                                           const SubstitutionList &subs) {
+                                           SubstitutionMap subs) {
   if (auto genericFnType = dyn_cast<GenericFunctionType>(fnType)) {
     return cast<FunctionType>(genericFnType->substGenericArgs(subs)
                                            ->getCanonicalType());
@@ -1264,7 +1264,7 @@ static SILFunctionType *emitObjCThunkArguments(SILGenFunction &SGF,
                                                CanType &bridgedFormalResultTy) {
   SILDeclRef native = thunk.asForeign(false);
 
-  auto subs = SGF.F.getForwardingSubstitutions();
+  auto subs = SGF.F.getForwardingSubstitutionMap();
 
   auto objcInfo = SGF.SGM.Types.getConstantInfo(thunk);
   auto objcFnTy = objcInfo.SILFnType->substGenericArgs(SGF.SGM.M, subs);
@@ -1550,7 +1550,6 @@ getThunkedForeignFunctionRef(SILGenFunction &SGF,
                              SILLocation loc,
                              SILDeclRef foreign,
                              ArrayRef<ManagedValue> args,
-                             SubstitutionList subs,
                              const SILConstantInfo &foreignCI) {
   assert(!foreign.isCurried
          && "should not thunk calling convention when curried");
@@ -1752,8 +1751,8 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
     maybeAddForeignErrorArg();
     
     // Call the original.
-    auto subs = getForwardingSubstitutions();
-    auto fn = getThunkedForeignFunctionRef(*this, fd, foreignDeclRef, args, subs,
+    auto subs = getForwardingSubstitutionMap();
+    auto fn = getThunkedForeignFunctionRef(*this, fd, foreignDeclRef, args,
                                            foreignCI);
 
     auto fnType = fn->getType().castTo<SILFunctionType>();
@@ -1781,8 +1780,8 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
     ArgumentScope argScope(*this, fd);
     ManagedValue resultMV =
         emitApply(std::move(resultPlan), std::move(argScope), fd,
-                  ManagedValue::forUnmanaged(fn), subs, args, calleeTypeInfo,
-                  ApplyOptions::None, context)
+                  ManagedValue::forUnmanaged(fn), subs.toList(), args,
+                  calleeTypeInfo, ApplyOptions::None, context)
             .getAsSingleValue(*this, fd);
 
     if (indirectResult) {

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -236,8 +236,7 @@ emitBridgeObjectiveCToNative(SILGenFunction &SGF,
   ArgumentScope argScope(SGF, loc);
   RValue result =
       SGF.emitApply(std::move(resultPlan), std::move(argScope), loc,
-                    ManagedValue::forUnmanaged(witnessRef),
-                    subs.toList(),
+                    ManagedValue::forUnmanaged(witnessRef), subs,
                     {objcValue, ManagedValue::forUnmanaged(metatypeValue)},
                     calleeTypeInfo, ApplyOptions::None, context);
   return std::move(result).getAsSingleValue(SGF, loc);
@@ -1780,7 +1779,7 @@ void SILGenFunction::emitForeignToNativeThunk(SILDeclRef thunk) {
     ArgumentScope argScope(*this, fd);
     ManagedValue resultMV =
         emitApply(std::move(resultPlan), std::move(argScope), fd,
-                  ManagedValue::forUnmanaged(fn), subs.toList(), args,
+                  ManagedValue::forUnmanaged(fn), subs, args,
                   calleeTypeInfo, ApplyOptions::None, context)
             .getAsSingleValue(*this, fd);
 

--- a/lib/SILGen/SILGenBuilder.cpp
+++ b/lib/SILGen/SILGenBuilder.cpp
@@ -77,8 +77,7 @@ MetatypeInst *SILGenBuilder::createMetatype(SILLocation loc, SILType metatype) {
       auto subMap = t->getContextSubstitutionMap(getSILGenModule().SwiftModule,
                                                  decl);
       SmallVector<Substitution, 4> subs;
-      genericSig->getSubstitutions(subMap, subs);
-      getSILGenModule().useConformancesFromSubstitutions(subs);
+      getSILGenModule().useConformancesFromSubstitutions(subMap);
       return false;
     });
 

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -951,7 +951,7 @@ void SILGenFunction::emitMemberInitializers(DeclContext *dc,
         // signature of the type, with replacement archetypes from the
         // constructor's context (which might be in an extension of
         // the type, which adds additional generic requirements).
-        SubstitutionList subs;
+        SubstitutionMap subs;
         auto *genericEnv = dc->getGenericEnvironmentOfContext();
         auto typeGenericSig = nominal->getGenericSignatureOfContext();
 
@@ -959,7 +959,7 @@ void SILGenFunction::emitMemberInitializers(DeclContext *dc,
           // Generate a set of substitutions for the initialization function,
           // whose generic signature is that of the type context, and whose
           // replacement types are the archetypes of the initializer itself.
-          auto subMap = typeGenericSig->getSubstitutionMap(
+          subs = typeGenericSig->getSubstitutionMap(
                        [&](SubstitutableType *type) {
                          if (auto gp = type->getAs<GenericTypeParamType>()) {
                            return genericEnv->mapTypeIntoContext(gp);
@@ -973,9 +973,6 @@ void SILGenFunction::emitMemberInitializers(DeclContext *dc,
                          return ProtocolConformanceRef(
                                   conformedProtocol->getDecl());
                        });
-          SmallVector<Substitution, 4> subsVec;
-          typeGenericSig->getSubstitutions(subMap, subsVec);
-          subs = SGM.getASTContext().AllocateCopy(subsVec);
         }
 
         // Get the type of the initialization result, in terms

--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -593,7 +593,7 @@ ManagedValue SILGenFunction::emitExistentialErasure(
           emitRValueForStorageLoad(
               loc, nativeError, concreteFormalType,
               /*super*/ false, nsErrorVar, RValue(),
-              nsErrorVarSubstitutions.toList(),
+              nsErrorVarSubstitutions,
               AccessSemantics::Ordinary, nsErrorType, SGFContext())
               .getAsSingleValue(*this, loc);
 

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -144,10 +144,6 @@ namespace {
   };
 } // end anonymous namespace
 
-SubstitutionList SILGenFunction::getForwardingSubstitutions() {
-  return F.getForwardingSubstitutions();
-}
-
 SubstitutionMap SILGenFunction::getForwardingSubstitutionMap() {
   return F.getForwardingSubstitutionMap();
 }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -2649,7 +2649,7 @@ SILGenFunction::emitApplyOfDefaultArgGenerator(SILLocation loc,
       ResultPlanBuilder::computeResultPlan(*this, calleeTypeInfo, loc, C);
   ArgumentScope argScope(*this, loc);
   return emitApply(std::move(resultPtr), std::move(argScope), loc, fnRef,
-                   subs.toList(), {}, calleeTypeInfo, ApplyOptions::None, C);
+                   subs, {}, calleeTypeInfo, ApplyOptions::None, C);
 }
 
 RValue SILGenFunction::emitApplyOfStoredPropertyInitializer(
@@ -2672,7 +2672,7 @@ RValue SILGenFunction::emitApplyOfStoredPropertyInitializer(
       ResultPlanBuilder::computeResultPlan(*this, calleeTypeInfo, loc, C);
   ArgumentScope argScope(*this, loc);
   return emitApply(std::move(resultPlan), std::move(argScope), loc, fnRef,
-                   subs.toList(), {}, calleeTypeInfo, ApplyOptions::None, C);
+                   subs, {}, calleeTypeInfo, ApplyOptions::None, C);
 }
 
 static void emitTupleShuffleExprInto(RValueEmitter &emitter,
@@ -3550,7 +3550,7 @@ getOrCreateKeyPathEqualsAndHash(SILGenModule &SGM,
         isEqual = subSGF
           .emitApply(std::move(equalsResultPlan), std::move(argScope),
                      loc, ManagedValue::forUnmanaged(equalsWitness),
-                     equatableSub.toList(),
+                     equatableSub,
                      {lhsArg, rhsArg, metatyValue},
                      equalsInfo, ApplyOptions::None, SGFContext())
           .getUnmanagedSingleValue(subSGF, loc);
@@ -3664,7 +3664,7 @@ getOrCreateKeyPathEqualsAndHash(SILGenModule &SGM,
       auto hashWitness = subSGF.B.createWitnessMethod(loc,
         formalTy, hashable,
         hashRef, hashTy);
-      
+
       auto hashSubstTy = hashTy.castTo<SILFunctionType>()
         ->substGenericArgs(SGM.M, hashableSubsMap);
       auto hashInfo = CalleeTypeInfo(hashSubstTy,
@@ -3690,7 +3690,7 @@ getOrCreateKeyPathEqualsAndHash(SILGenModule &SGM,
             subSGF
                 .emitApply(std::move(hashResultPlan), std::move(argScope), loc,
                            ManagedValue::forUnmanaged(hashWitness),
-                           hashableSubsMap.toList(),
+                           hashableSubsMap,
                            {arg}, hashInfo, ApplyOptions::None, SGFContext())
                 .getUnmanagedSingleValue(subSGF, loc);
       }

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1076,7 +1076,7 @@ emitRValueForDecl(SILLocation loc, ConcreteDeclRef declRef, Type ncRefType,
 
     bool isDirectAccessorUse = (semantics == AccessSemantics::DirectToAccessor);
     return emitGetAccessor(loc, getter,
-                           SGM.getNonMemberVarDeclSubstitutions(var).toList(),
+                           SGM.getNonMemberVarDeclSubstitutions(var),
                            std::move(selfSource),
                            /*isSuper=*/false, isDirectAccessorUse,
                            RValue(), C);
@@ -1148,7 +1148,7 @@ emitRValueWithAccessor(SILGenFunction &SGF, SILLocation loc,
   // The easy path here is if we don't need to use an addressor.
   case AccessStrategy::DirectToAccessor:
   case AccessStrategy::DispatchToAccessor: {
-    return SGF.emitGetAccessor(loc, accessor, substitutions.toList(),
+    return SGF.emitGetAccessor(loc, accessor, substitutions,
                                std::move(baseRV), isSuper, isDirectUse,
                                std::move(subscriptRV), C);
   }
@@ -1161,7 +1161,7 @@ emitRValueWithAccessor(SILGenFunction &SGF, SILLocation loc,
   SILType storageType = storageTL.getLoweredType().getAddressType();
 
   auto addressorResult =
-    SGF.emitAddressorAccessor(loc, accessor, substitutions.toList(),
+    SGF.emitAddressorAccessor(loc, accessor, substitutions,
                               std::move(baseRV), isSuper, isDirectUse,
                               std::move(subscriptRV), storageType);
 
@@ -3358,12 +3358,12 @@ SILFunction *getOrCreateKeyPathSetter(SILGenModule &SGM,
 
   LValueOptions lvOptions;
   if (auto var = dyn_cast<VarDecl>(property)) {
-    lv.addMemberVarComponent(subSGF, loc, var, subs.toList(), lvOptions,
+    lv.addMemberVarComponent(subSGF, loc, var, subs, lvOptions,
                              /*super*/ false, AccessKind::Write,
                              AccessSemantics::Ordinary, strategy, propertyType);
   } else {
     auto sub = cast<SubscriptDecl>(property);
-    lv.addMemberSubscriptComponent(subSGF, loc, sub, subs.toList(), lvOptions,
+    lv.addMemberSubscriptComponent(subSGF, loc, sub, subs, lvOptions,
                                    /*super*/ false, AccessKind::Write,
                                    AccessSemantics::Ordinary, strategy, propertyType,
                                    std::move(indexValue));

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -1076,7 +1076,7 @@ emitRValueForDecl(SILLocation loc, ConcreteDeclRef declRef, Type ncRefType,
 
     bool isDirectAccessorUse = (semantics == AccessSemantics::DirectToAccessor);
     return emitGetAccessor(loc, getter,
-                           SGM.getNonMemberVarDeclSubstitutions(var),
+                           SGM.getNonMemberVarDeclSubstitutions(var).toList(),
                            std::move(selfSource),
                            /*isSuper=*/false, isDirectAccessorUse,
                            RValue(), C);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1083,7 +1083,7 @@ public:
                                   CanType baseFormalType,
                                   bool isSuper, AbstractStorageDecl *storage,
                                   RValue indexes,
-                                  SubstitutionList substitutions,
+                                  SubstitutionMap substitutions,
                                   AccessSemantics semantics, Type propTy,
                                   SGFContext C,
                                   bool isBaseGuaranteed = false);
@@ -1312,7 +1312,7 @@ public:
   RValue emitApplyOfStoredPropertyInitializer(
       SILLocation loc,
       const PatternBindingEntry &entry,
-      SubstitutionList subs,
+      SubstitutionMap subs,
       CanType resultType,
       AbstractionPattern origResultType,
       SGFContext C);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1297,7 +1297,7 @@ public:
   /// result does need to be turned back into something matching a
   /// formal type.
   RValue emitApply(ResultPlanPtr &&resultPlan, ArgumentScope &&argScope,
-                   SILLocation loc, ManagedValue fn, SubstitutionList subs,
+                   SILLocation loc, ManagedValue fn, SubstitutionMap subs,
                    ArrayRef<ManagedValue> args,
                    const CalleeTypeInfo &calleeTypeInfo, ApplyOptions options,
                    SGFContext evalContext);

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1335,12 +1335,6 @@ public:
                                      ArrayRef<ManagedValue> args,
                                      SGFContext ctx);
 
-  RValue emitApplyOfLibraryIntrinsic(SILLocation loc,
-                                     FuncDecl *fn,
-                                     const SubstitutionList &subs,
-                                     ArrayRef<ManagedValue> args,
-                                     SGFContext ctx);
-
   SILValue emitApplyWithRethrow(SILLocation loc, SILValue fn,
                                 SILType substFnType,
                                 SubstitutionMap subs,

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1815,10 +1815,6 @@ public:
 
   /// Return forwarding substitutions for the archetypes in the current
   /// function.
-  SubstitutionList getForwardingSubstitutions();
-
-  /// Return forwarding substitutions for the archetypes in the current
-  /// function.
   SubstitutionMap getForwardingSubstitutionMap();
 
   /// Get the _Pointer protocol used for pointer argument operations.

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -1106,13 +1106,13 @@ public:
                                         SILDeclRef accessor);
 
   RValue emitGetAccessor(SILLocation loc, SILDeclRef getter,
-                         SubstitutionList substitutions,
+                         SubstitutionMap substitutions,
                          ArgumentSource &&optionalSelfValue,
                          bool isSuper, bool isDirectAccessorUse,
                          RValue &&optionalSubscripts, SGFContext C);
 
   void emitSetAccessor(SILLocation loc, SILDeclRef setter,
-                       SubstitutionList substitutions,
+                       SubstitutionMap substitutions,
                        ArgumentSource &&optionalSelfValue,
                        bool isSuper, bool isDirectAccessorUse,
                        RValue &&optionalSubscripts,
@@ -1120,7 +1120,7 @@ public:
 
   MaterializedLValue
   emitMaterializeForSetAccessor(SILLocation loc, SILDeclRef materializeForSet,
-                                SubstitutionList substitutions,
+                                SubstitutionMap substitutions,
                                 ArgumentSource &&optionalSelfValue,
                                 bool isSuper, bool isDirectAccessorUse,
                                 RValue &&optionalSubscripts,
@@ -1131,12 +1131,12 @@ public:
                                        GenericEnvironment *genericEnv,
                                        AccessorDecl *requirement,
                                        AccessorDecl *witness,
-                                       SubstitutionList witnessSubs);
+                                       SubstitutionMap witnessSubs);
   void emitMaterializeForSet(AccessorDecl *decl);
 
   std::pair<ManagedValue,ManagedValue>
   emitAddressorAccessor(SILLocation loc, SILDeclRef addressor,
-                        SubstitutionList substitutions,
+                        SubstitutionMap substitutions,
                         ArgumentSource &&optionalSelfValue,
                         bool isSuper, bool isDirectAccessorUse,
                         RValue &&optionalSubscripts,

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -997,7 +997,7 @@ namespace {
     AbstractStorageDecl *decl;
     bool IsSuper;
     bool IsDirectAccessorUse;
-    std::vector<Substitution> substitutions;
+    SubstitutionMap substitutions;
 
     /// The subscript index expression.  Useless
     Expr *subscriptIndexExpr;
@@ -1032,14 +1032,14 @@ namespace {
     AccessorBasedComponent(PathComponent::KindTy kind,
                            AbstractStorageDecl *decl,
                            bool isSuper, bool isDirectAccessorUse,
-                           SubstitutionList substitutions,
+                           SubstitutionMap substitutions,
                            CanType baseFormalType,
                            LValueTypeData typeData,
                            Expr *subscriptIndexExpr,
                            RValue *optSubscripts)
       : Base(typeData, kind), decl(decl),
         IsSuper(isSuper), IsDirectAccessorUse(isDirectAccessorUse),
-        substitutions(substitutions.begin(), substitutions.end()),
+        substitutions(substitutions),
         subscriptIndexExpr(subscriptIndexExpr),
         baseFormalType(baseFormalType)
     {
@@ -1091,7 +1091,7 @@ namespace {
 
      GetterSetterComponent(AbstractStorageDecl *decl,
                            bool isSuper, bool isDirectAccessorUse,
-                           SubstitutionList substitutions,
+                           SubstitutionMap substitutions,
                            CanType baseFormalType,
                            LValueTypeData typeData,
                            Expr *subscriptIndexExpr = nullptr,
@@ -1135,15 +1135,15 @@ namespace {
       dest.dropLastComponent(*this);
 
       return emitAssignWithSetter(SGF, loc, std::move(dest), baseFormalType,
-                                  isSuper, setter, isDirectAccessorUse, subs,
-                                  std::move(indices), std::move(value));
+                                  isSuper, setter, isDirectAccessorUse,
+                                  subs, std::move(indices), std::move(value));
     }
 
     static void emitAssignWithSetter(SILGenFunction &SGF, SILLocation loc,
                                      LValue &&baseLV, CanType baseFormalType,
                                      bool isSuper, SILDeclRef setter,
                                      bool isDirectAccessorUse,
-                                     SubstitutionList subs,
+                                     SubstitutionMap subs,
                                      RValue &&indices, ArgumentSource &&value) {
       ArgumentSource self = [&] {
         if (!baseLV.isValid()) {
@@ -1157,8 +1157,8 @@ namespace {
         }
       }();
 
-      return SGF.emitSetAccessor(loc, setter, subs, std::move(self), isSuper,
-                                 isDirectAccessorUse,
+      return SGF.emitSetAccessor(loc, setter, subs, std::move(self),
+                                 isSuper, isDirectAccessorUse,
                                  std::move(indices), std::move(value));
     }
 
@@ -1284,7 +1284,8 @@ namespace {
         auto args = std::move(*this).prepareAccessorArgs(SGF, loc, borrowedBase,
                                                          materializeForSet);
         materialized = SGF.emitMaterializeForSetAccessor(
-            loc, materializeForSet, substitutions, std::move(args.base),
+            loc, materializeForSet, substitutions,
+            std::move(args.base),
             IsSuper, IsDirectAccessorUse, std::move(args.subscripts), buffer,
             callbackStorage);
 
@@ -1411,15 +1412,9 @@ namespace {
                                        materialized.temporary.getValue(),
                                        rawPointerTy);
 
-        // Convert the substitution list into a substitution map.
-        SubstitutionMap subMap;
-        if (auto genericSig = origCallbackFnType->getGenericSignature()) {
-          subMap = genericSig->getSubstitutionMap(substitutions);;
-        }
-
         // Apply the callback.
         SGF.B.createApply(loc, callback,
-                          subMap, {
+                          substitutions, {
                             temporaryPointer,
                             materialized.callbackStorage,
                             baseAddress,
@@ -1578,7 +1573,7 @@ namespace {
   public:
      AddressorComponent(AbstractStorageDecl *decl,
                         bool isSuper, bool isDirectAccessorUse,
-                        SubstitutionList substitutions,
+                        SubstitutionMap substitutions,
                         CanType baseFormalType, LValueTypeData typeData,
                         SILType substFieldType,
                         Expr *subscriptIndexExpr = nullptr,
@@ -1609,7 +1604,8 @@ namespace {
         auto args =
             std::move(*this).prepareAccessorArgs(SGF, loc, base, addressor);
         result = SGF.emitAddressorAccessor(
-            loc, addressor, substitutions, std::move(args.base), IsSuper,
+            loc, addressor, substitutions, std::move(args.base),
+            IsSuper,
             IsDirectAccessorUse, std::move(args.subscripts), SubstFieldType);
       }
       switch (cast<AccessorDecl>(addressor.getDecl())->getAddressorKind()) {
@@ -2007,7 +2003,7 @@ LValue LValue::forAddress(ManagedValue address,
 
 void LValue::addMemberComponent(SILGenFunction &SGF, SILLocation loc,
                                 AbstractStorageDecl *storage,
-                                SubstitutionList subs,
+                                SubstitutionMap subs,
                                 LValueOptions options,
                                 bool isSuper,
                                 AccessKind accessKind,
@@ -2238,7 +2234,7 @@ addNonMemberVarDeclAddressorComponent(SILGenModule &SGM, VarDecl *var,
   auto typeData = getPhysicalStorageTypeData(SGM, var, formalRValueType);
   SILType storageType = SGM.Types.getLoweredType(var->getType()).getAddressType();
   lvalue.add<AddressorComponent>(var, /*isSuper=*/ false, /*direct*/ true,
-                             SGM.getNonMemberVarDeclSubstitutions(var).toList(),
+                             SGM.getNonMemberVarDeclSubstitutions(var),
                                  CanType(), typeData, storageType);
 }
 
@@ -2270,7 +2266,7 @@ static LValue emitLValueForNonMemberVarDecl(SILGenFunction &SGF,
   case AccessStrategy::DirectToAccessor: {
     auto typeData = getLogicalStorageTypeData(SGF.SGM, formalRValueType);
     lv.add<GetterSetterComponent>(var, /*isSuper=*/false, /*direct*/ true,
-                         SGF.SGM.getNonMemberVarDeclSubstitutions(var).toList(),
+                                  SGF.SGM.getNonMemberVarDeclSubstitutions(var),
                                   CanType(), typeData);
     break;
   }
@@ -2437,7 +2433,7 @@ LValue SILGenLValue::visitMemberRefExpr(MemberRefExpr *e,
 
   CanType substFormalRValueType = getSubstFormalRValueType(e);
   lv.addMemberVarComponent(SGF, e, var,
-                           e->getMember().getSubstitutions().toList(),
+                           e->getMember().getSubstitutions(),
                            options, e->isSuper(), accessKind,
                            e->getAccessSemantics(),
                            strategy, substFormalRValueType);
@@ -2446,7 +2442,7 @@ LValue SILGenLValue::visitMemberRefExpr(MemberRefExpr *e,
 
 void LValue::addMemberVarComponent(SILGenFunction &SGF, SILLocation loc,
                                    VarDecl *var,
-                                   SubstitutionList subs,
+                                   SubstitutionMap subs,
                                    LValueOptions options,
                                    bool isSuper,
                                    AccessKind accessKind,
@@ -2537,7 +2533,7 @@ LValue SILGenLValue::visitSubscriptExpr(SubscriptExpr *e,
 
   CanType formalRValueType = getSubstFormalRValueType(e);
   lv.addMemberSubscriptComponent(SGF, e, decl,
-                                 e->getDecl().getSubstitutions().toList(),
+                                 e->getDecl().getSubstitutions(),
                                  options, e->isSuper(), accessKind,
                                  accessSemantics, strategy,
                                  formalRValueType, std::move(index),
@@ -2590,7 +2586,7 @@ LValue SILGenLValue::visitKeyPathApplicationExpr(KeyPathApplicationExpr *e,
 
 void LValue::addMemberSubscriptComponent(SILGenFunction &SGF, SILLocation loc,
                                          SubscriptDecl *decl,
-                                         SubstitutionList subs,
+                                         SubstitutionMap subs,
                                          LValueOptions options,
                                          bool isSuper,
                                          AccessKind accessKind,
@@ -2732,10 +2728,6 @@ LValue SILGenFunction::emitPropertyLValue(SILLocation loc, ManagedValue base,
   auto subMap = baseType->getContextSubstitutionMap(
       SGM.M.getSwiftModule(), ivar->getDeclContext());
 
-  SmallVector<Substitution, 4> subs;
-  if (auto *genericSig = ivar->getDeclContext()->getGenericSignatureOfContext())
-    genericSig->getSubstitutions(subMap, subs);
-
   LValueTypeData baseTypeData = getValueTypeData(baseFormalType,
                                                  base.getValue());
 
@@ -2757,7 +2749,7 @@ LValue SILGenFunction::emitPropertyLValue(SILLocation loc, ManagedValue base,
     auto typeData = getLogicalStorageTypeData(SGM, substFormalType);
     lv.add<GetterSetterComponent>(ivar, /*super*/ false,
                                   strategy == AccessStrategy::DirectToAccessor,
-                                  subs, baseFormalType, typeData);
+                                  subMap, baseFormalType, typeData);
     return lv;
   }
 
@@ -2772,7 +2764,7 @@ LValue SILGenFunction::emitPropertyLValue(SILLocation loc, ManagedValue base,
 
   if (strategy == AccessStrategy::Addressor) {
     lv.add<AddressorComponent>(ivar, /*super*/ false, /*direct*/ true,
-                               subs, baseFormalType, typeData, varStorageType);
+                               subMap, baseFormalType, typeData, varStorageType);
   } else if (baseFormalType->hasReferenceSemantics()) {
     lv.add<RefElementComponent>(ivar, options, varStorageType, typeData);
   } else {

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -2588,10 +2588,24 @@ static void emitDiagnoseOfUnexpectedEnumCaseValue(SILGenFunction &SGF,
                                                       loweredRawType);
   auto materializedRawValue = rawValue.materialize(SGF, loc);
 
-  Substitution subs[] = {
-    {switchedValueSwiftType, /*Conformances*/None},
-    {enumDecl->getRawType(), /*Conformances*/None},
-  };
+  auto genericSig = diagnoseFailure->getGenericSignature();
+  auto subs = genericSig->getSubstitutionMap(
+      [&](SubstitutableType *type) -> Type {
+        auto genericParam = cast<GenericTypeParamType>(type);
+        assert(genericParam->getDepth() == 0);
+        assert(genericParam->getIndex() < 2);
+        switch (genericParam->getIndex()) {
+        case 0:
+          return switchedValueSwiftType;
+
+        case 1:
+          return enumDecl->getRawType();
+
+        default:
+          llvm_unreachable("wrong generic signature for expected case value");
+        }
+      },
+      LookUpConformanceInSignature(*genericSig));
 
   SGF.emitApplyOfLibraryIntrinsic(loc, diagnoseFailure, subs,
                                   {ManagedValue::forUnmanaged(metatype),

--- a/lib/SILGen/SILGenPattern.cpp
+++ b/lib/SILGen/SILGenPattern.cpp
@@ -2631,8 +2631,10 @@ static void emitDiagnoseOfUnexpectedEnumCase(SILGenFunction &SGF,
   ManagedValue metatype = SGF.B.createValueMetatype(loc, metatypeType, value);
 
   Substitution sub{switchedValueSwiftType, /*Conformances*/None};
-  auto genericArgsMap =
-      diagnoseFailure->getGenericSignature()->getSubstitutionMap(sub);
+  auto diagnoseSignature = diagnoseFailure->getGenericSignature();
+  auto genericArgsMap = diagnoseSignature->getSubstitutionMap(
+      [&](SubstitutableType *type) -> Type { return switchedValueSwiftType; },
+      LookUpConformanceInSignature(*diagnoseSignature));
 
   SGF.emitApplyOfLibraryIntrinsic(loc, diagnoseFailure, genericArgsMap,
                                   metatype,

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2655,8 +2655,7 @@ buildThunkSignature(SILGenFunction &SGF,
   if (openedExistential == nullptr) {
     auto genericSig = SGF.F.getLoweredFunctionType()->getGenericSignature();
     genericEnv = SGF.F.getGenericEnvironment();
-    auto subsArray = SGF.F.getForwardingSubstitutions();
-    interfaceSubs = genericSig->getSubstitutionMap(subsArray);
+    interfaceSubs = SGF.F.getForwardingSubstitutionMap();
     contextSubs = interfaceSubs;
     return genericSig;
   }
@@ -3015,7 +3014,7 @@ SILGenFunction::createWithoutActuallyEscapingClosure(
   }
 
   CanSILFunctionType substFnType = thunkType->substGenericArgs(
-      F.getModule(), thunk->getForwardingSubstitutions());
+      F.getModule(), thunk->getForwardingSubstitutionMap());
 
   // Create it in our current function.
   auto thunkValue = B.createFunctionRef(loc, thunk);

--- a/lib/SILGen/SILGenType.cpp
+++ b/lib/SILGen/SILGenType.cpp
@@ -696,7 +696,7 @@ SILFunction *SILGenModule::emitProtocolWitness(
       if (SGF.maybeEmitMaterializeForSetThunk(conformance, linkage,
                                               selfInterfaceType, selfType,
                                               genericEnv, reqFn, witnessFn,
-                                              witnessSubs.toList()))
+                                              witnessSubs))
         return f;
 
       // Proceed down the normal path.

--- a/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerApplyVisitors.cpp
@@ -805,8 +805,7 @@ SILCombiner::createApplyWithConcreteType(FullApplySite AI,
   // replaced by a concrete type.
   SubstitutionMap Substitutions;
   if (FnTy->isPolymorphic()) {
-    auto FnSubsMap =
-        FnTy->getGenericSignature()->getSubstitutionMap(AI.getSubstitutions());
+    auto FnSubsMap = AI.getSubstitutionMap();
     Substitutions = FnSubsMap.subst(
         [&](SubstitutableType *type) -> Type {
           if (type == OpenedArchetype)

--- a/lib/SILOptimizer/Transforms/CSE.cpp
+++ b/lib/SILOptimizer/Transforms/CSE.cpp
@@ -1043,7 +1043,8 @@ static bool tryToCSEOpenExtCall(OpenExistentialAddrInst *From,
          "Invalid number of arguments");
 
   // Don't handle any apply instructions that involve substitutions.
-  if (ToAI->getSubstitutions().size() != 1) return false;
+  if (ToAI->getSubstitutionMap().getReplacementTypes().size() != 1)
+    return false;
 
   // Prepare the Apply args.
   SmallVector<SILValue, 8> Args;

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -285,9 +285,9 @@ static bool usesGenerics(SILFunction *F,
       }
       // Scan all substitutions of apply instructions.
       if (auto AI = ApplySite::isa(&I)) {
-        auto Subs = AI.getSubstitutions();
-        for (auto Sub : Subs) {
-          Sub.getReplacement().visit(FindArchetypesAndGenericTypes);
+        auto Subs = AI.getSubstitutionMap();
+        for (auto Replacement : Subs.getReplacementTypes()) {
+          Replacement.visit(FindArchetypesAndGenericTypes);
         }
       }
       // Scan all substitutions of builtin instructions.

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -475,7 +475,7 @@ bool SILPerformanceInliner::isProfitableToInline(
 /// It returns None if the decision cannot be made without a more complex
 /// analysis.
 static Optional<bool> shouldInlineGeneric(FullApplySite AI) {
-  assert(!AI.getSubstitutions().empty() &&
+  assert(AI.hasSubstitutions() &&
          "Expected a generic apply");
 
   SILFunction *Callee = AI.getReferencedFunction();
@@ -516,7 +516,7 @@ bool SILPerformanceInliner::decideInWarmBlock(
     FullApplySite AI, Weight CallerWeight, ConstantTracker &callerTracker,
     int &NumCallerBlocks,
     const llvm::DenseMap<SILBasicBlock *, uint64_t> &BBToWeightMap) {
-  if (!AI.getSubstitutions().empty()) {
+  if (AI.hasSubstitutions()) {
     // Only inline generics if definitively clear that it should be done.
     auto ShouldInlineGeneric = shouldInlineGeneric(AI);
     if (ShouldInlineGeneric.hasValue())
@@ -540,7 +540,7 @@ bool SILPerformanceInliner::decideInWarmBlock(
 /// Return true if inlining this call site into a cold block is profitable.
 bool SILPerformanceInliner::decideInColdBlock(FullApplySite AI,
                                               SILFunction *Callee) {
-  if (!AI.getSubstitutions().empty()) {
+  if (AI.hasSubstitutions()) {
     // Only inline generics if definitively clear that it should be done.
     auto ShouldInlineGeneric = shouldInlineGeneric(AI);
     if (ShouldInlineGeneric.hasValue())

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -441,9 +441,7 @@ getSubstitutionsForCallee(SILModule &M,
         M.getSwiftModule(), baseClassDecl);
   }
 
-  SubstitutionMap origSubMap;
-  if (auto origCalleeSig = AI.getOrigCalleeType()->getGenericSignature())
-    origSubMap = origCalleeSig->getSubstitutionMap(AI.getSubstitutions());
+  SubstitutionMap origSubMap = AI.getSubstitutionMap();
 
   Type calleeSelfType = AI.getOrigCalleeType()->getSelfParameter().getType();
   if (auto metatypeType = calleeSelfType->getAs<MetatypeType>())

--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -765,7 +765,7 @@ swift::tryDevirtualizeClassMethod(FullApplySite AI, SILValue ClassInstance,
 /// \param conformanceRef The (possibly-specialized) conformance
 /// \param requirementSig The generic signature of the requirement
 /// \param witnessThunkSig The generic signature of the witness method
-/// \param origSubs The substitutions from the call instruction
+/// \param origSubMap The substitutions from the call instruction
 /// \param isDefaultWitness True if this is a default witness method
 /// \param classWitness The ClassDecl if this is a class witness method
 static SubstitutionMap
@@ -774,14 +774,12 @@ getWitnessMethodSubstitutions(
     ProtocolConformanceRef conformanceRef,
     GenericSignature *requirementSig,
     GenericSignature *witnessThunkSig,
-    SubstitutionList origSubs,
+    SubstitutionMap origSubMap,
     bool isDefaultWitness,
     ClassDecl *classWitness) {
 
   if (witnessThunkSig == nullptr)
     return SubstitutionMap();
-
-  auto origSubMap = requirementSig->getSubstitutionMap(origSubs);
 
   if (isDefaultWitness)
     return origSubMap;
@@ -841,7 +839,7 @@ getWitnessMethodSubstitutions(SILModule &Module, ApplySite AI, SILFunction *F,
   auto requirementSig = AI.getOrigCalleeType()->getGenericSignature();
   auto witnessThunkSig = witnessFnTy->getGenericSignature();
 
-  SubstitutionList origSubs = AI.getSubstitutions();
+  SubstitutionMap origSubs = AI.getSubstitutionMap();
 
   auto *mod = Module.getSwiftModule();
   bool isDefaultWitness =

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -290,9 +290,8 @@ static bool createsInfiniteSpecializationLoop(ApplySite Apply) {
                      << "Caller: " << Caller->getName() << "\n"
                      << "Callee: " << Callee->getName() << "\n";
         llvm::dbgs() << "Substitutions:\n";
-        for (auto Sub: Apply.getSubstitutions()) {
-          Sub.getReplacement()->dump();
-        });
+        Apply.getSubstitutionMap().dump(llvm::dbgs());
+        );
 
   auto *CurSpecializationInfo = Apply.getSpecializationInfo();
   if (CurSpecializationInfo) {

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -232,19 +232,21 @@ public:
 
 } // anonymous namespace
 
-/// Checks if a second substitution list is an expanded version of
-/// the first substitution list.
+/// Checks if a second substitution map is an expanded version of
+/// the first substitution map.
 /// This is the case if at least one of the substitution type in Subs2 is
 /// "bigger" than the corresponding substitution type in Subs1.
 /// Type T2 is "smaller" than type T1 if T2 is structurally contained in T1.
-static bool growingSubstitutions(SubstitutionList Subs1,
-                                 SubstitutionList Subs2) {
-  assert(Subs1.size() == Subs2.size());
+static bool growingSubstitutions(SubstitutionMap Subs1,
+                                 SubstitutionMap Subs2) {
+  auto Replacements1 = Subs1.getReplacementTypes();
+  auto Replacements2 = Subs2.getReplacementTypes();
+  assert(Replacements1.size() == Replacements2.size());
   TypeComparator TypeCmp;
   // Perform component-wise comparisions for substitutions.
-  for (unsigned idx = 0, e = Subs1.size(); idx < e; ++idx) {
-    auto Type1 = Subs1[idx].getReplacement()->getCanonicalType();
-    auto Type2 = Subs2[idx].getReplacement()->getCanonicalType();
+  for (unsigned idx : indices(Replacements1)) {
+    auto Type1 = Replacements1[idx]->getCanonicalType();
+    auto Type2 = Replacements2[idx]->getCanonicalType();
     // If types are the same, the substitution type does not grow.
     if (TypeCmp.isEqual(Type2, Type1))
       continue;
@@ -255,7 +257,7 @@ static bool growingSubstitutions(SubstitutionList Subs1,
     if (TypeCmp.isPartiallyContainedIn(Type1, Type2)) {
       DEBUG(llvm::dbgs() << "Type:\n"; Type1.dump();
             llvm::dbgs() << "is (partially) contained in type:\n"; Type2.dump();
-            llvm::dbgs() << "SubstitutionList[" << idx
+            llvm::dbgs() << "Replacements[" << idx
                          << "] has got bigger since last time.\n");
       return true;
     }
@@ -317,8 +319,8 @@ static bool createsInfiniteSpecializationLoop(ApplySite Apply) {
       DEBUG(llvm::dbgs() << "Found a call graph loop, checking substitutions\n");
       // Consider if components of the substitution list gets bigger compared to
       // the previously seen specialization of the same generic function.
-      if (growingSubstitutions(CurSpecializationInfo->getSubstitutions().toList(),
-                               Apply.getSubstitutions())) {
+      if (growingSubstitutions(CurSpecializationInfo->getSubstitutions(),
+                               Apply.getSubstitutionMap())) {
         DEBUG(llvm::dbgs() << "Found a generic specialization loop!\n");
         return true;
       }
@@ -346,11 +348,11 @@ static bool createsInfiniteSpecializationLoop(ApplySite Apply) {
 // =============================================================================
 
 static bool shouldNotSpecializeCallee(SILFunction *Callee,
-                                      SubstitutionList Subs = {}) {
+                                      SubstitutionMap Subs = {}) {
   if (Callee->hasSemanticsAttr("optimize.sil.specialize.generic.never"))
     return true;
 
-  if (!Subs.empty() &&
+  if (Subs.hasAnySubstitutableParams() &&
       Callee->hasSemanticsAttr("optimize.sil.specialize.generic.partial.never"))
     return true;
 
@@ -467,7 +469,7 @@ bool ReabstractionInfo::prepareAndCheck(ApplySite Apply, SILFunction *Callee,
       return false;
 
     // Bail if the callee should not be partially specialized.
-    if (shouldNotSpecializeCallee(Callee, ParamSubs.toList()))
+    if (shouldNotSpecializeCallee(Callee, ParamSubs))
       return false;
   }
 
@@ -978,7 +980,6 @@ static void collectRequirements(ArchetypeType *Archetype, GenericSignature *Sig,
 /// really used?
 static bool
 shouldBePartiallySpecialized(Type Replacement,
-                             ArrayRef<ProtocolConformanceRef> Conformances,
                              GenericSignature *Sig, GenericEnvironment *Env) {
   // If replacement is a concrete type, this substitution
   // should participate.
@@ -1024,8 +1025,8 @@ shouldBePartiallySpecialized(Type Replacement,
 
   if (OptimizeGenericSubstitutions) {
     // Is it an unconstrained generic parameter?
-    if (Conformances.empty()) {
-      if (Replacement->is<ArchetypeType>()) {
+    if (auto Archetype = Replacement->getAs<ArchetypeType>()) {
+      if (Archetype->getConformsTo().empty()) {
         // TODO: If Replacement add a new layout constraint, then
         // it may be still useful to perform the partial specialization.
         return false;
@@ -1128,7 +1129,7 @@ class FunctionSignaturePartialSpecializer {
   /// Take into account only those archetypes that occur in the
   /// substitutions of generic parameters which will be partially
   /// specialized. Ignore all others.
-  void collectUsedCallerArchetypes(SubstitutionList ParamSubs);
+  void collectUsedCallerArchetypes(SubstitutionMap ParamSubs);
 
   /// Create a new generic parameter.
   GenericTypeParamType *createGenericParam();
@@ -1139,15 +1140,14 @@ public:
                                       GenericEnvironment *CallerGenericEnv,
                                       GenericSignature *CalleeGenericSig,
                                       GenericEnvironment *CalleeGenericEnv,
-                                      SubstitutionList ParamSubs)
+                                      SubstitutionMap ParamSubs)
       : CallerGenericSig(CallerGenericSig), CallerGenericEnv(CallerGenericEnv),
         CalleeGenericSig(CalleeGenericSig), CalleeGenericEnv(CalleeGenericEnv),
         M(M), SM(M.getSwiftModule()), Ctx(M.getASTContext()),
         Builder(Ctx) {
     SpecializedGenericSig = nullptr;
     SpecializedGenericEnv = nullptr;
-    CalleeInterfaceToCallerArchetypeMap =
-      CalleeGenericSig->getSubstitutionMap(ParamSubs);
+    CalleeInterfaceToCallerArchetypeMap = ParamSubs;
   }
 
   /// This constructor is used by when processing @_specialize.
@@ -1194,7 +1194,7 @@ public:
     return SpecializedGenericEnv;
   }
 
-  void createSpecializedGenericSignature(SubstitutionList ParamSubs);
+  void createSpecializedGenericSignature(SubstitutionMap ParamSubs);
 
   void createSpecializedGenericSignatureWithNonGenericSubs();
 
@@ -1217,16 +1217,15 @@ FunctionSignaturePartialSpecializer::createGenericParam() {
 
 /// Collect all used caller's archetypes from all the substitutions.
 void FunctionSignaturePartialSpecializer::collectUsedCallerArchetypes(
-    SubstitutionList ParamSubs) {
-  for (auto Sub : ParamSubs) {
-    auto Replacement = Sub.getReplacement();
+    SubstitutionMap ParamSubs) {
+  for (auto Replacement : ParamSubs.getReplacementTypes()) {
     if (!Replacement->hasArchetype())
       continue;
 
     // If the substitution will not be performed in the specialized
     // function, there is no need to check for any archetypes inside
     // the replacement.
-    if (!shouldBePartiallySpecialized(Replacement, Sub.getConformances(),
+    if (!shouldBePartiallySpecialized(Replacement,
                                       CallerGenericSig, CallerGenericEnv))
       continue;
 
@@ -1350,7 +1349,7 @@ void FunctionSignaturePartialSpecializer::
     DEBUG(llvm::dbgs() << "Replacement found:\n"; Replacement->dump());
 
     bool ShouldSpecializeGP = shouldBePartiallySpecialized(
-        Replacement, {}, CallerGenericSig, CallerGenericEnv);
+        Replacement, CallerGenericSig, CallerGenericEnv);
 
     if (ShouldSpecializeGP) {
       DEBUG(llvm::dbgs() << "Should be partially specialized.\n");
@@ -1559,7 +1558,7 @@ void FunctionSignaturePartialSpecializer::
 }
 
 void FunctionSignaturePartialSpecializer::createSpecializedGenericSignature(
-    SubstitutionList ParamSubs) {
+    SubstitutionMap ParamSubs) {
   // Collect all used caller's archetypes from all the substitutions.
   collectUsedCallerArchetypes(ParamSubs);
 
@@ -1644,11 +1643,11 @@ void ReabstractionInfo::performPartialSpecializationPreparation(
   FunctionSignaturePartialSpecializer FSPS(M,
                                            CallerGenericSig, CallerGenericEnv,
                                            CalleeGenericSig, CalleeGenericEnv,
-                                           ParamSubs.toList());
+                                           ParamSubs);
 
   // Create the partially specialized generic signature and generic environment.
   if (SupportGenericSubstitutions)
-    FSPS.createSpecializedGenericSignature(ParamSubs.toList());
+    FSPS.createSpecializedGenericSignature(ParamSubs);
   else
     FSPS.createSpecializedGenericSignatureWithNonGenericSubs();
 

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -1066,7 +1066,7 @@ class FunctionSignaturePartialSpecializer {
   SubstitutionMap CallerInterfaceToSpecializedInterfaceMap;
 
   /// Maps callee's interface types to caller's contextual types.
-  /// It is computed from the original SubstitutionList.
+  /// It is computed from the original substitutions.
   SubstitutionMap CalleeInterfaceToCallerArchetypeMap;
 
   /// Maps callee's interface types to specialized functions interface types.

--- a/lib/SILOptimizer/Utils/Local.cpp
+++ b/lib/SILOptimizer/Utils/Local.cpp
@@ -322,13 +322,6 @@ void swift::replaceDeadApply(ApplySite Old, ValueBase *New) {
   recursivelyDeleteTriviallyDeadInstructions(OldApply, true);
 }
 
-bool swift::hasArchetypes(SubstitutionList Subs) {
-  // Check whether any of the substitutions are dependent.
-  return llvm::any_of(Subs, [](const Substitution &S) {
-    return S.getReplacement()->hasArchetype();
-  });
-}
-
 bool swift::mayBindDynamicSelf(SILFunction *F) {
   if (!F->hasSelfMetadataParam())
     return false;

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -560,12 +560,12 @@ static bool calleeHasPartialApplyWithOpenedExistentials(FullApplySite AI) {
     return false;
 
   SILFunction *Callee = AI.getReferencedFunction();
-  auto Subs = AI.getSubstitutions();
+  auto SubsMap = AI.getSubstitutionMap();
 
   // Bail if there are no open existentials in the list of substitutions.
   bool HasNoOpenedExistentials = true;
-  for (auto Sub : Subs) {
-    if (Sub.getReplacement()->hasOpenedExistential()) {
+  for (auto Replacement : SubsMap.getReplacementTypes()) {
+    if (Replacement->hasOpenedExistential()) {
       HasNoOpenedExistentials = false;
       break;
     }
@@ -573,9 +573,6 @@ static bool calleeHasPartialApplyWithOpenedExistentials(FullApplySite AI) {
 
   if (HasNoOpenedExistentials)
     return false;
-
-  auto SubsMap = Callee->getLoweredFunctionType()
-    ->getGenericSignature()->getSubstitutionMap(Subs);
 
   for (auto &BB : *Callee) {
     for (auto &I : BB) {
@@ -630,7 +627,7 @@ static bool isCallerAndCalleeLayoutConstraintsCompatible(FullApplySite AI) {
   SILFunction *Callee = AI.getReferencedFunction();
   auto CalleeSig = Callee->getLoweredFunctionType()->getGenericSignature();
   auto SubstParams = CalleeSig->getSubstitutableParams();
-  auto AISubs = AI.getSubstitutions();
+  auto AISubs = AI.getSubstitutionMap();
   for (auto idx : indices(SubstParams)) {
     auto Param = SubstParams[idx];
     // Map the parameter into context
@@ -643,7 +640,7 @@ static bool isCallerAndCalleeLayoutConstraintsCompatible(FullApplySite AI) {
       continue;
     // The generic parameter has a layout constraint.
     // Check that the substitution has the same constraint.
-    auto AIReplacement = AISubs[idx].getReplacement();
+    auto AIReplacement = Type(Param).subst(AISubs);
     auto AIArchetype = AIReplacement->getAs<ArchetypeType>();
     if (!AIArchetype)
       return false;

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -65,7 +65,7 @@ UncurriedCandidate::UncurriedCandidate(ValueDecl *decl, unsigned level)
     auto *DC = decl->getInnermostDeclContext();
     if (auto *GFT = entityType->getAs<GenericFunctionType>()) {
       auto subs = DC->getGenericEnvironmentOfContext()
-      ->getForwardingSubstitutions();
+      ->getForwardingSubstitutionMap();
       entityType = GFT->substGenericArgs(subs);
     } else {
       // FIXME: look through unforced IUOs here?


### PR DESCRIPTION
Switch most clients of `SubstitutionList` over to `SubstitutionMap`, including:

* All of SILGen's `LValue` infrastructure
* SILGen's key-path emission code
* Call emission in SILGen and IRGen
* Lots of helpers that trafficked in SubstitutionList but are no longer used.