### PR TITLE
Eliminate GenericSignature::enumeratePairedRequirements()

### DIFF
--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -209,12 +209,7 @@ public:
 
   /// Check if the generic signature makes all generic parameters
   /// concrete.
-  bool areAllParamsConcrete() const {
-    return !enumeratePairedRequirements(
-      [](Type, ArrayRef<Requirement>) -> bool {
-        return true;
-      });
-  }
+  bool areAllParamsConcrete() const { return getSubstitutableParams().empty(); }
 
   /// Compute the number of conformance requirements in this signature.
   unsigned getNumConformanceRequirements() const {
@@ -224,20 +219,6 @@ public:
         ++result;
     }
 
-    return result;
-  }
-
-  /// Return the size of a SubstitutionList built from this signature.
-  ///
-  /// Don't add new calls of this -- the representation of SubstitutionList
-  /// will be changing soon.
-  unsigned getSubstitutionListSize() const {
-    unsigned result = 0;
-    enumeratePairedRequirements(
-      [&](Type, ArrayRef<Requirement>) -> bool {
-        result++;
-        return false;
-      });
     return result;
   }
 

--- a/include/swift/AST/GenericSignature.h
+++ b/include/swift/AST/GenericSignature.h
@@ -191,25 +191,13 @@ public:
   Optional<ProtocolConformanceRef>
   lookupConformance(CanType depTy, ProtocolDecl *proto) const;
 
-  /// Enumerate all of the dependent types in the type signature that will
-  /// occur in substitution lists (in order), along with the set of
-  /// conformance requirements placed on that dependent type.
-  ///
-  /// \param fn Callback function that will receive each (type, requirements)
-  /// pair, in the order they occur within a list of substitutions. If this
-  /// returns \c true, the enumeration will be aborted.
-  ///
-  /// \returns true if any call to \c fn returned \c true, otherwise \c false.
-  bool enumeratePairedRequirements(
-         llvm::function_ref<bool(Type, ArrayRef<Requirement>)> fn) const;
-
   /// Return a vector of all generic parameters that are not subject to
   /// a concrete same-type constraint.
   SmallVector<GenericTypeParamType *, 2> getSubstitutableParams() const;
 
   /// Check if the generic signature makes all generic parameters
   /// concrete.
-  bool areAllParamsConcrete() const { return getSubstitutableParams().empty(); }
+  bool areAllParamsConcrete() const;
 
   /// Compute the number of conformance requirements in this signature.
   unsigned getNumConformanceRequirements() const {

--- a/lib/AST/GenericSignature.cpp
+++ b/lib/AST/GenericSignature.cpp
@@ -138,6 +138,19 @@ GenericSignature::getSubstitutableParams() const {
   return result;
 }
 
+bool GenericSignature::areAllParamsConcrete() const {
+  unsigned numConcreteGenericParams = 0;
+  for (const auto &req : getRequirements()) {
+    if (req.getKind() != RequirementKind::SameType) continue;
+    if (!req.getFirstType()->is<GenericTypeParamType>()) continue;
+    if (req.getSecondType()->isTypeParameter()) continue;
+
+    ++numConcreteGenericParams;
+  }
+
+  return numConcreteGenericParams == getGenericParams().size();
+}
+
 ASTContext &GenericSignature::getASTContext(
                                     TypeArrayView<GenericTypeParamType> params,
                                     ArrayRef<swift::Requirement> requirements) {
@@ -360,136 +373,6 @@ GenericSignature::lookupConformance(CanType type, ProtocolDecl *proto) const {
     return ProtocolConformanceRef(proto);
 
   return M->lookupConformance(type, proto);
-}
-
-bool GenericSignature::enumeratePairedRequirements(
-               llvm::function_ref<bool(Type, ArrayRef<Requirement>)> fn) const {
-  // We'll be walking through the list of requirements.
-  ArrayRef<Requirement> reqs = getRequirements();
-  unsigned curReqIdx = 0, numReqs = reqs.size();
-
-  // ... and walking through the list of generic parameters.
-  auto genericParams = getGenericParams();
-  unsigned curGenericParamIdx = 0, numGenericParams = genericParams.size();
-
-  // Figure out which generic parameters are concrete or same-typed to another
-  // generic parameter.
-  auto genericParamsAreNonCanonical =
-    SmallVector<bool, 4>(genericParams.size(), false);
-  for (auto req : reqs) {
-    if (req.getKind() != RequirementKind::SameType) continue;
-    
-    GenericTypeParamType *gp;
-    if (auto secondGP = req.getSecondType()->getAs<GenericTypeParamType>()) {
-      // If two generic parameters are same-typed, then the left-hand one
-      // is canonical.
-      gp = secondGP;
-    } else {
-      // If an associated type is same-typed, it doesn't constrain the generic
-      // parameter itself.
-      if (req.getSecondType()->isTypeParameter()) continue;
-      
-      // Otherwise, the generic parameter is concrete.
-      gp = req.getFirstType()->getAs<GenericTypeParamType>();
-      if (!gp) continue;
-    }
-
-    unsigned index = GenericParamKey(gp).findIndexIn(genericParams);
-    genericParamsAreNonCanonical[index] = true;
-  }
-
-  /// Local function to 'catch up' to the next dependent type we're going to
-  /// visit, calling the function for each of the generic parameters in the
-  /// generic parameter list prior to this parameter.
-  auto enumerateGenericParamsUpToDependentType = [&](CanType depTy) -> bool {
-    // Figure out where we should stop when enumerating generic parameters.
-    unsigned stopDepth, stopIndex;
-    if (auto gp = dyn_cast_or_null<GenericTypeParamType>(depTy)) {
-      stopDepth = gp->getDepth();
-      stopIndex = gp->getIndex();
-    } else {
-      stopDepth = genericParams.back()->getDepth() + 1;
-      stopIndex = 0;
-    }
-
-    // Enumerate generic parameters up to the stopping point, calling the
-    // callback function for each one
-    while (curGenericParamIdx != numGenericParams) {
-      auto curGenericParam = genericParams[curGenericParamIdx];
-
-      // If the current generic parameter is before our stopping point, call
-      // the function.
-      if (curGenericParam->getDepth() < stopDepth ||
-          (curGenericParam->getDepth() == stopDepth &&
-           curGenericParam->getIndex() < stopIndex)) {
-        if (!genericParamsAreNonCanonical[curGenericParamIdx] &&
-            fn(curGenericParam, { }))
-          return true;
-
-        ++curGenericParamIdx;
-        continue;
-      }
-
-      // If the current generic parameter is at our stopping point, we're
-      // done.
-      if (curGenericParam->getDepth() == stopDepth &&
-          curGenericParam->getIndex() == stopIndex) {
-        ++curGenericParamIdx;
-        return false;
-      }
-
-      // Otherwise, there's nothing to do.
-      break;
-    }
-
-    return false;
-  };
-
-  // Walk over all of the requirements.
-  while (curReqIdx != numReqs) {
-    // "Catch up" by enumerating generic parameters up to this dependent type.
-    CanType depTy = reqs[curReqIdx].getFirstType()->getCanonicalType();
-    if (enumerateGenericParamsUpToDependentType(depTy)) return true;
-
-    // Utility to skip over non-conformance constraints that apply to this
-    // type.
-    auto skipNonConformanceConstraints = [&] {
-      while (curReqIdx != numReqs &&
-             reqs[curReqIdx].getKind() != RequirementKind::Conformance &&
-             reqs[curReqIdx].getFirstType()->getCanonicalType() == depTy) {
-        ++curReqIdx;
-      }
-    };
-
-    // First, skip past any non-conformance constraints on this type.
-    skipNonConformanceConstraints();
-
-    // Collect all of the conformance constraints for this dependent type.
-    unsigned startIdx = curReqIdx;
-    unsigned endIdx = curReqIdx;
-    while (curReqIdx != numReqs &&
-           reqs[curReqIdx].getKind() == RequirementKind::Conformance &&
-           reqs[curReqIdx].getFirstType()->getCanonicalType() == depTy) {
-      ++curReqIdx;
-      endIdx = curReqIdx;
-    }
-
-    // Skip any trailing non-conformance constraints.
-    skipNonConformanceConstraints();
-
-    // If there were any conformance constraints, or we have a generic
-    // parameter we can't skip, invoke the callback.
-    if ((startIdx != endIdx ||
-         (isa<GenericTypeParamType>(depTy) &&
-          !genericParamsAreNonCanonical[
-            GenericParamKey(cast<GenericTypeParamType>(depTy))
-              .findIndexIn(genericParams)])) &&
-        fn(depTy, reqs.slice(startIdx, endIdx-startIdx)))
-      return true;
-  }
-
-  // Catch up on any remaining generic parameters.
-  return enumerateGenericParamsUpToDependentType(CanType());
 }
 
 SubstitutionMap

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -49,6 +49,7 @@ SubstitutionMap::Storage::Storage(
             getReplacementTypes().data());
   std::copy(conformances.begin(), conformances.end(),
             getConformances().data());
+  populatedAllReplacements = false;
 }
 
 SubstitutionMap::SubstitutionMap(
@@ -82,7 +83,7 @@ ArrayRef<Type> SubstitutionMap::getReplacementTypes() const {
   // Make sure we've filled in all of the replacement types.
   if (!storage->populatedAllReplacements) {
     for (auto gp : getGenericSignature()->getGenericParams()) {
-      (void)Type(gp).subst(*this);
+      (void)lookupSubstitution(cast<SubstitutableType>(gp->getCanonicalType()));
     }
 
     storage->populatedAllReplacements = true;

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -192,37 +192,31 @@ SubstitutionMap SubstitutionMap::get(GenericSignature *genericSig,
     return SubstitutionMap();
   }
 
-  SmallVector<Type, 4> replacementTypes(genericSig->getGenericParams().size(),
-                                        Type());
-  SmallVector<ProtocolConformanceRef, 4> storedConformances;
+  // Form the replacement types.
+  SmallVector<Type, 4> replacementTypes;
+  replacementTypes.reserve(genericSig->getGenericParams().size());
+  for (auto gp : genericSig->getGenericParams()) {
+    Type replacement = Type(gp).subst(subs, lookupConformance,
+                                      SubstFlags::UseErrorType);
+    replacementTypes.push_back(replacement);
+  }
 
-  // Enumerate all of the requirements that require substitution.
-  genericSig->enumeratePairedRequirements(
-    [&](Type depTy, ArrayRef<Requirement> reqs) {
-      auto canTy = depTy->getCanonicalType();
+  // Form the stored conformances.
+  SmallVector<ProtocolConformanceRef, 4> conformances;
+  for (const auto &req : genericSig->getRequirements()) {
+    if (req.getKind() != RequirementKind::Conformance) continue;
 
-      // Compute the replacement type.
-      Type currentReplacement = depTy.subst(subs, lookupConformance,
-                                            SubstFlags::UseErrorType);
-      if (auto paramTy = dyn_cast<GenericTypeParamType>(canTy)) {
-        replacementTypes[genericSig->getGenericParamOrdinal(paramTy)] =
-          currentReplacement;
-      }
+    CanType depTy = req.getFirstType()->getCanonicalType();
+    auto replacement = depTy.subst(subs, lookupConformance,
+                                   SubstFlags::UseErrorType);
+    auto protoType = req.getSecondType()->castTo<ProtocolType>();
+    auto proto = protoType->getDecl();
+    auto conformance = lookupConformance(depTy, replacement, protoType)
+                         .getValueOr(ProtocolConformanceRef(proto));
+    conformances.push_back(conformance);
+  }
 
-      // Collect the conformances.
-      for (auto req: reqs) {
-        assert(req.getKind() == RequirementKind::Conformance);
-        auto protoType = req.getSecondType()->castTo<ProtocolType>();
-        auto conformance =
-          lookupConformance(canTy, currentReplacement, protoType)
-            .getValueOr(ProtocolConformanceRef(protoType->getDecl()));
-        storedConformances.push_back(conformance);
-      }
-
-      return false;
-    });
-
-  return SubstitutionMap(genericSig, replacementTypes, storedConformances);
+  return SubstitutionMap(genericSig, replacementTypes, conformances);
 }
 
 Type SubstitutionMap::lookupSubstitution(CanSubstitutableType type) const {

--- a/lib/AST/SubstitutionMapStorage.h
+++ b/lib/AST/SubstitutionMapStorage.h
@@ -35,7 +35,10 @@ class SubstitutionMap::Storage final
 
   /// The number of conformance requirements, cached to avoid constantly
   /// recomputing it on conformance-buffer access.
-  const unsigned numConformanceRequirements;
+  const unsigned numConformanceRequirements : 31;
+
+  /// Whether we've populated all replacement types already.
+  bool populatedAllReplacements = false;
 
   Storage() = delete;
 

--- a/lib/AST/SubstitutionMapStorage.h
+++ b/lib/AST/SubstitutionMapStorage.h
@@ -38,7 +38,7 @@ class SubstitutionMap::Storage final
   const unsigned numConformanceRequirements : 31;
 
   /// Whether we've populated all replacement types already.
-  bool populatedAllReplacements = false;
+  unsigned populatedAllReplacements : 1;
 
   Storage() = delete;
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3053,12 +3053,10 @@ CheckTypeWitnessResult swift::checkTypeWitness(TypeChecker &tc, DeclContext *dc,
           dc->getParentModule(),
           decl,
           decl->getGenericEnvironmentOfContext());
-      auto result = decl->getGenericSignature()->enumeratePairedRequirements(
-        [&](Type t, ArrayRef<Requirement> reqt) -> bool {
-          return t.subst(subMap, SubstFlags::UseErrorType)->hasError();
-        });
-      if (result)
-        return CheckTypeWitnessResult(reqProto->getDeclaredType());
+      for (auto replacement : subMap.getReplacementTypes()) {
+        if (replacement->hasError())
+          return CheckTypeWitnessResult(reqProto->getDeclaredType());
+      }
     }
   }
 

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2297,7 +2297,7 @@ Type TypeResolver::resolveSILBoxType(SILBoxTypeRepr *repr,
 
     auto params = genericSig->getGenericParams();
     if (repr->getGenericArguments().size()
-          != genericSig->getSubstitutionListSize()) {
+          != genericSig->getGenericParams().size()) {
       TC.diagnose(repr->getLoc(), diag::sil_box_arg_mismatch);
       return ErrorType::get(Context);
     }

--- a/test/Serialization/sil_box_types.sil
+++ b/test/Serialization/sil_box_types.sil
@@ -18,9 +18,9 @@ entry(%0 : $<τ_0_0> { var τ_0_0 } <Builtin.Int32>, %1 : $<τ_0_0> { var τ_0_0
 }
 
 // CHECK-LABEL: sil @boxes_extra_reqs : $@convention(thin) <T where T : Q, T.AT : P> (@owned <τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T>) -> () {
-sil @boxes_extra_reqs : $@convention(thin) <T where T : Q, T.AT : P> (@owned <τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T, T.AT>) -> () {
+sil @boxes_extra_reqs : $@convention(thin) <T where T : Q, T.AT : P> (@owned <τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T>) -> () {
 // CHECK: bb0(%0 : $<τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T>)
-bb0(%0 : $<τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T, T.AT>):
-  %1 = project_box %0 : $<τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T, T.AT>, 0
+bb0(%0 : $<τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T>):
+  %1 = project_box %0 : $<τ_0_0 where τ_0_0 : Q, τ_0_0.AT : P> { var τ_0_0 } <T>, 0
   return undef : $()
 }


### PR DESCRIPTION
This method's primary use was to form `SubstitutionList`s. Those are gone now, so migrate all of the callers away and eliminate this complicated code.