### PR TITLE
AST: TypeWalker should not walk the desugared type of a NameAliasType

### DIFF
--- a/lib/AST/TypeWalker.cpp
+++ b/lib/AST/TypeWalker.cpp
@@ -39,9 +39,6 @@ class Traversal : public TypeVisitor<Traversal, bool>
     if (auto parent = ty->getParent())
       if (doIt(parent)) return true;
 
-    if (doIt(ty->getSinglyDesugaredType()))
-      return true;
-
     for (auto arg : ty->getInnermostGenericArgs())
       if (doIt(arg))
         return true;


### PR DESCRIPTION
Other sugared types only walk their structural components, and not
their desugaring.