### PR TITLE
[Testing] pipe_round_robin.swift.gyb is scheduling sensitive

### DIFF
--- a/test/Driver/pipe_round_robin.swift.gyb
+++ b/test/Driver/pipe_round_robin.swift.gyb
@@ -17,12 +17,12 @@
 // RUN: %gyb -D N=4 %s -o %t/manyfuncs/file4.swift
 //
 // We calculate the ratio of poll() calls to read() calls; these should be
-// nearly equal (we test abs(read/poll) < 2.0) if we're doing interleaved
+// nearly equal (we test abs(read/poll) < 3.0) if we're doing interleaved
 // reading. If we're doing non-interleaved reading, they become radically
 // different (eg. thousands of reads per poll).
 //
 // RUN: %target-build-swift -j 4 -module-name manyfuncs -typecheck -stats-output-dir %t/stats -Xfrontend -debug-time-function-bodies %t/manyfuncs/*.swift
-// RUN: %utils/process-stats-dir.py --evaluate 'abs(float(NumDriverPipeReads) / float(NumDriverPipePolls)) < 2.0' %t/stats
+// RUN: %utils/process-stats-dir.py --evaluate 'abs(float(NumDriverPipeReads) / float(NumDriverPipePolls)) < 3.0' %t/stats
 
 % for i in range(1,1000):
 func process_${N}_function_${i}(_ x: Int) -> Int {


### PR DESCRIPTION
If a background compile job is running on my Linux box, this test will sometimes fail. Also, let's up the buffer size while we're in here. One kilobyte is needlessly tiny.