### PR TITLE
[CodeCompletion][SR-7670] Duplicate generic param completions

### DIFF
--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -877,8 +877,8 @@ void swift::lookupVisibleDecls(VisibleDeclConsumer &Consumer,
       LS = LS.withOnMetatype();
     }
 
-    // Look for generic parameters in the current context. Those in parent
-    // contexts will be looked up anyways via `lookupVisibleMemberDecls`.
+    // We don't look for generic parameters if we are in the context of a
+    // nominal type: they will be looked up anyways via `lookupVisibleMemberDecls`.
     if (DC && !isa<NominalTypeDecl>(DC)) {
       if (auto *decl = DC->getAsDeclOrDeclExtensionContext()) {
         if (auto GC = decl->getAsGenericContext()) {

--- a/test/IDE/complete_type.swift
+++ b/test/IDE/complete_type.swift
@@ -45,6 +45,14 @@
 // RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
 // RUN: %FileCheck %s -check-prefix=GLOBAL_NEGATIVE < %t.types.txt
 
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_RETURN_GEN_PARAM_NO_DUP > %t.types.txt
+// RUN: %FileCheck %s -check-prefix=TYPE_IN_RETURN_GEN_PARAM_NO_DUP < %t.types.txt
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IVAR_GEN_PARAM_NO_DUP > %t.types.txt
+// RUN: %FileCheck %s -check-prefix=TYPE_IVAR_GEN_PARAM_NO_DUP < %t.types.txt
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_SUBSCR_GEN_PARAM_NO_DUP > %t.types.txt
+// RUN: %FileCheck %s -check-prefix=TYPE_IN_SUBSCR_GEN_PARAM_NO_DUP < %t.types.txt
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=TYPE_IN_LOCAL_VAR_IN_FREE_FUNC_1 > %t.types.txt
 // RUN: %FileCheck %s -check-prefix=WITH_GLOBAL_TYPES < %t.types.txt
@@ -572,6 +580,34 @@ struct TestTypeInConstructorParamGeneric3<
 // TYPE_IN_CONSTRUCTOR_PARAM_GENERIC_3: End completions
 
 // No tests for destructors: destructors don't have parameters.
+
+//===---
+//===--- Test that we don't duplicate generic parameters.
+//===---
+
+struct GenericStruct<T> {
+	func foo() -> #^TYPE_IN_RETURN_GEN_PARAM_NO_DUP^#
+}
+class A<T> {
+	var foo: #^TYPE_IVAR_GEN_PARAM_NO_DUP^#
+
+	subscript(_ arg: Int) -> #^TYPE_IN_SUBSCR_GEN_PARAM_NO_DUP^#
+}
+
+// TYPE_IN_RETURN_GEN_PARAM_NO_DUP: Begin completions
+// TYPE_IN_RETURN_GEN_PARAM_NO_DUP-DAG: Decl[GenericTypeParam]/CurrNominal: T[#T#]; name=T
+// TYPE_IN_RETURN_GEN_PARAM_NO_DUP-NOT: Decl[GenericTypeParam]/Local:       T[#T#]; name=T
+// TYPE_IN_RETURN_GEN_PARAM_NO_DUP: End completions
+
+// TYPE_IVAR_GEN_PARAM_NO_DUP: Begin completions
+// TYPE_IVAR_GEN_PARAM_NO_DUP-DAG: Decl[GenericTypeParam]/CurrNominal: T[#T#]; name=T
+// TYPE_IVAR_GEN_PARAM_NO_DUP-NOT: Decl[GenericTypeParam]/Local:       T[#T#]; name=T
+// TYPE_IVAR_GEN_PARAM_NO_DUP: End completions
+
+// TYPE_IN_SUBSCR_GEN_PARAM_NO_DUP: Begin completions
+// TYPE_IN_SUBSCR_GEN_PARAM_NO_DUP-DAG: Decl[GenericTypeParam]/CurrNominal: T[#T#]; name=T
+// TYPE_IN_SUBSCR_GEN_PARAM_NO_DUP-NOT: Decl[GenericTypeParam]/Local:       T[#T#]; name=T
+// TYPE_IN_SUBSCR_GEN_PARAM_NO_DUP: End completions
 
 //===---
 //===--- Test that we can complete types in variable declarations.

--- a/test/IDE/complete_type_subscript.swift
+++ b/test/IDE/complete_type_subscript.swift
@@ -37,7 +37,7 @@ struct G0<T> {
   subscript(x: T) -> #^GEN_RETURN_0^# { return 0 }
 }
 // GEN_TOP_LEVEL_0: Keyword/None:                       Any[#Any#];
-// GEN_TOP_LEVEL_0: Decl[GenericTypeParam]/Local:       T[#T#];
+// GEN_TOP_LEVEL_0: Decl[GenericTypeParam]/OutNominal:  T[#T#]; name=T
 // GEN_TOP_LEVEL_0: Decl[Struct]/CurrModule:            S0[#S0#];
 // GEN_TOP_LEVEL_0: Decl[Struct]/OtherModule[Swift]:    Int[#Int#];
 

--- a/test/IDE/complete_type_subscript.swift
+++ b/test/IDE/complete_type_subscript.swift
@@ -37,7 +37,7 @@ struct G0<T> {
   subscript(x: T) -> #^GEN_RETURN_0^# { return 0 }
 }
 // GEN_TOP_LEVEL_0: Keyword/None:                       Any[#Any#];
-// GEN_TOP_LEVEL_0: Decl[GenericTypeParam]/OutNominal:  T[#T#]; name=T
+// GEN_TOP_LEVEL_0: Decl[GenericTypeParam]/CurrNominal: T[#T#]; name=T
 // GEN_TOP_LEVEL_0: Decl[Struct]/CurrModule:            S0[#S0#];
 // GEN_TOP_LEVEL_0: Decl[Struct]/OtherModule[Swift]:    Int[#Int#];
 

--- a/test/IDE/complete_where_clause.swift
+++ b/test/IDE/complete_where_clause.swift
@@ -17,13 +17,13 @@
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=INIT_2 | %FileCheck %s -check-prefix=GEN_T_DOT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ALIAS_1 | %FileCheck %s -check-prefix=GEN_T
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ALIAS_2 | %FileCheck %s -check-prefix=GEN_T_DOT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STRUCT_1 | %FileCheck %s -check-prefix=GEN_T
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STRUCT_1 | %FileCheck %s -check-prefix=GEN_T_NOMINAL
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STRUCT_2 | %FileCheck %s -check-prefix=GEN_T_DOT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STRUCT_3 | %FileCheck %s -check-prefix=GEN_T
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STRUCT_3 | %FileCheck %s -check-prefix=GEN_T_NOMINAL
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STRUCT_4 | %FileCheck %s -check-prefix=GEN_T_DOT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CLASS_1 | %FileCheck %s -check-prefix=GEN_T
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CLASS_1 | %FileCheck %s -check-prefix=GEN_T_NOMINAL
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CLASS_2 | %FileCheck %s -check-prefix=GEN_T_DOT
-// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ENUM_1 | %FileCheck %s -check-prefix=GEN_T
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ENUM_1 | %FileCheck %s -check-prefix=GEN_T_NOMINAL
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ENUM_2 | %FileCheck %s -check-prefix=GEN_T_DOT
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ASSOC_1 | %FileCheck %s -check-prefix=P2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ASSOC_2 | %FileCheck %s -check-prefix=U_DOT
@@ -68,7 +68,7 @@ protocol Assoc {
 }
 
 func f1<T>(_: T) where #^FUNC_1^# {}
-// GEN_T: Decl[GenericTypeParam]/Local:       T[#T#]; name=T
+// GEN_T: Decl[GenericTypeParam]/Local: T[#T#]; name=T
 func f2<T>(_: T) where T.#^FUNC_2^# {}
 // GEN_T_DOT: Begin completions
 // GEN_T_DOT-DAG: Keyword/None:                       Type[#T.Type#];
@@ -101,6 +101,7 @@ class C1<T> where #^CLASS_1^# {}
 class C2<T> where T.#^CLASS_2^# {}
 enum E1<T> where #^ENUM_1^# {}
 enum E2<T> where T.#^ENUM_2^# {}
+// GEN_T_NOMINAL: Decl[GenericTypeParam]/CurrNominal: T[#T#]; name=T
 
 protocol P2 {
   associatedtype T where #^ASSOC_1^#

--- a/test/IDE/complete_where_clause.swift
+++ b/test/IDE/complete_where_clause.swift
@@ -68,7 +68,7 @@ protocol Assoc {
 }
 
 func f1<T>(_: T) where #^FUNC_1^# {}
-// GEN_T: Decl[GenericTypeParam]/Local:       T[#T#];
+// GEN_T: Decl[GenericTypeParam]/Local:       T[#T#]; name=T
 func f2<T>(_: T) where T.#^FUNC_2^# {}
 // GEN_T_DOT: Begin completions
 // GEN_T_DOT-DAG: Keyword/None:                       Type[#T.Type#];


### PR DESCRIPTION
Fixed duplicate completions for generic parameters in non-generic members.
This also fixed the `SemanticContextKind` for some related tests.

Resolves [SR-7670](https://bugs.swift.org/browse/SR-7670).


