### PR TITLE
Generic type alias access level regression [4.2]

### DIFF
--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -821,6 +821,9 @@ IterableDeclContext::castDeclToIterableDeclContext(const Decl *D) {
 /// declaration or extension, the supplied context is returned.
 static const DeclContext *
 getPrivateDeclContext(const DeclContext *DC, const SourceFile *useSF) {
+  if (DC->getASTContext().isSwiftVersion3())
+    return DC;
+
   auto NTD = DC->getAsNominalTypeOrNominalTypeExtensionContext();
   if (!NTD)
     return DC;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1408,8 +1408,7 @@ class TypeAccessScopeChecker : private TypeWalker, AccessScopeChecker {
       return Action::Stop;
 
     if (!CanonicalizeParentTypes) {
-      return isa<NameAliasType>(T.getPointer()) ? Action::SkipChildren
-                                                     : Action::Continue;
+      return Action::Continue;
     }
     
     Type nominalParentTy;

--- a/test/Compatibility/accessibility_private.swift
+++ b/test/Compatibility/accessibility_private.swift
@@ -171,8 +171,10 @@ extension Container {
 extension Container {
   private struct VeryPrivateStruct { // expected-note * {{type declared here}}
     private typealias VeryPrivateType = Int // expected-note * {{type declared here}}
+    private struct VeryPrivateInnerStruct {}
     var privateVar: VeryPrivateType { fatalError() } // expected-warning {{property should be declared private because its type uses a private type}}
     var privateVar2 = VeryPrivateType() // expected-warning {{property should be declared private because its type 'Container.VeryPrivateStruct.VeryPrivateType' (aka 'Int') uses a private type}}
+    var privateVar3 = VeryPrivateInnerStruct() // expected-warning {{property should be declared private because its type 'Container.VeryPrivateStruct.VeryPrivateInnerStruct' uses a private type}}
     typealias PrivateAlias = VeryPrivateType // expected-warning {{type alias should be declared private because its underlying type uses a private type}}
     subscript(_: VeryPrivateType) -> Void { return () } // expected-warning {{subscript should be declared private because its index uses a private type}}
     func privateMethod(_: VeryPrivateType) -> Void {} // expected-warning {{method should be declared private because its parameter uses a private type}} {{none}}

--- a/test/Sema/accessibility_private.swift
+++ b/test/Sema/accessibility_private.swift
@@ -171,8 +171,10 @@ extension Container {
 extension Container {
   private struct VeryPrivateStruct { // expected-note * {{type declared here}}
     private typealias VeryPrivateType = Int // expected-note * {{type declared here}}
+    private struct VeryPrivateInnerStruct {}
     var privateVar: VeryPrivateType { fatalError() } // expected-error {{property must be declared private because its type uses a private type}}
     var privateVar2 = VeryPrivateType() // expected-error {{property must be declared private because its type 'Container.VeryPrivateStruct.VeryPrivateType' (aka 'Int') uses a private type}}
+    var privateVar3 = VeryPrivateInnerStruct() // expected-error {{property must be declared private because its type 'Container.VeryPrivateStruct.VeryPrivateInnerStruct' uses a private type}}
     typealias PrivateAlias = VeryPrivateType // expected-error {{type alias must be declared private because its underlying type uses a private type}}
     subscript(_: VeryPrivateType) -> Void { return () } // expected-error {{subscript must be declared private because its index uses a private type}}
     func privateMethod(_: VeryPrivateType) -> Void {} // expected-error {{method must be declared private because its parameter uses a private type}} {{none}}

--- a/test/Sema/accessibility_typealias.swift
+++ b/test/Sema/accessibility_typealias.swift
@@ -90,3 +90,13 @@ public var failNested2: (_ x: (main.ActuallyPrivate) -> Void) -> Void = { _ in }
 public func failTest(x: ActuallyPrivate) {} // expected-error {{cannot be declared public}}
 public func failTest2(x: main.ActuallyPrivate) {} // expected-error {{cannot be declared public}}
 
+// Property has an inferred type, public alias with
+// private generic parameter bound.
+public struct PublicGeneric<T> {}
+
+public typealias GenericAlias<T> = PublicGeneric<T>
+
+fileprivate func makeAValue() -> GenericAlias<ActuallyPrivate> { }
+
+public var cannotBePublic = makeAValue()
+// expected-error@-1 {{variable cannot be declared public because its type 'GenericAlias<ActuallyPrivate>' (aka 'PublicGeneric<ActuallyPrivate>') uses a private type}}


### PR DESCRIPTION
I noticed this while working on better checking of `@usableForInline` access control.

If a property had an inferred type that is a generic type alias, we weren't checking the access level of the generic arguments.

This used to work in 4.1 because we didn't have a sugared representation for generic type aliases, so we were checking the substituted underlying type here. But now that NameAliasType can store generic arguments, make sure we visit them here.

Fixes rdar://problem/40188409.