### PR TITLE
SIL Printer: Fix crash when @_specialize attribute applied to a declaration

### DIFF
--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -3017,9 +3017,12 @@ void SILSpecializeAttr::print(llvm::raw_ostream &OS) const {
     SILFunction *F = getFunction();
     assert(F);
     auto GenericEnv = F->getGenericEnvironment();
-    assert(GenericEnv);
     interleave(getRequirements(),
                [&](Requirement req) {
+                 if (!GenericEnv) {
+                   req.print(OS, SubPrinter);
+                   return;
+                 }
                  // Use GenericEnvironment to produce user-friendly
                  // names instead of something like t_0_0.
                  auto FirstTy = GenericEnv->getSugaredType(req.getFirstType());

--- a/test/Sema/fixed_ambiguities/rdar35623181.swift
+++ b/test/Sema/fixed_ambiguities/rdar35623181.swift
@@ -1,8 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
 
-// XFAIL: *
-// ^ SR-7673
-
 extension Sequence where Element == String {
   func record() -> String {
     // CHECK: function_ref @$Ss20LazySequenceProtocolPsE3mapys0a3MapB0Vy8ElementsQzqd__Gqd__7ElementQzclF : $@convention(method) <τ_0_0 where τ_0_0 : LazySequenceProtocol><τ_1_0> (@guaranteed @callee_guaranteed (@in_guaranteed τ_0_0.Element) -> @out τ_1_0, @in_guaranteed τ_0_0) -> @out LazyMapSequence<τ_0_0.Elements, τ_1_0

--- a/test/Serialization/serialize_attr.swift
+++ b/test/Serialization/serialize_attr.swift
@@ -11,7 +11,6 @@
 
 //CHECK-DAG: @_semantics("crazy") func foo()
 @inlinable
-@usableFromInline
 @_semantics("crazy") func foo() -> Int  { return 5}
 
 // @_optimize
@@ -19,19 +18,16 @@
 
 //CHECK-DAG: @_optimize(none) func test_onone()
 @inlinable
-@usableFromInline
 @_optimize(none)
 func test_onone() -> Int  { return 5}
 
 //CHECK-DAG: @_optimize(speed) func test_ospeed()
 @inlinable
-@usableFromInline
 @_optimize(speed)
 func test_ospeed() -> Int  { return 5}
  
 //CHECK-DAG: @_optimize(size) func test_osize()
 @inlinable
-@usableFromInline
 @_optimize(size)
 func test_osize() -> Int  { return 5}
 
@@ -42,9 +38,14 @@ func test_osize() -> Int  { return 5}
 // CHECK-DAG: @_specialize(exported: false, kind: full, where T == Int, U == Float)
 // CHECK-DAG: func specializeThis<T, U>(_ t: T, u: U)
 @inlinable
+@_specialize(where T == Int, U == Float)
+func specializeThis<T, U>(_ t: T, u: U) {
+  specializeThat(t, u: u)
+}
+
 @usableFromInline
 @_specialize(where T == Int, U == Float)
-func specializeThis<T, U>(_ t: T, u: U) {}
+func specializeThat<T, U>(_ t: T, u: U) {}
 
 public protocol PP {
   associatedtype PElt
@@ -71,7 +72,6 @@ public struct GG<T : PP> {}
 // CHECK-DAG: @inline(never) func foo<U>(_ u: U, g: GG<T>) -> (U, GG<T>) where U : QQ
 public class CC<T : PP> {
   @inlinable
-  @usableFromInline
   @inline(never)
   @_specialize(where T==RR, U==SS)
   func foo<U : QQ>(_ u: U, g: GG<T>) -> (U, GG<T>) {


### PR DESCRIPTION
We have no generic environment in this case, and just need to print
the canonical generic parameter types.

Fixes <https://bugs.swift.org/browse/SR-7673>.