### PR TITLE
[Gardening] Update alloc_stack documentation in SIL.rst

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -1886,10 +1886,6 @@ Allocates uninitialized memory that is sufficiently aligned on the stack
 to contain a value of type ``T``. The result of the instruction is the address
 of the allocated memory.
 
-If a type is runtime-sized, the compiler must emit code to potentially
-dynamically allocate memory. So there is no guarantee that the allocated
-memory is really located on the stack.
-
 ``alloc_stack`` marks the start of the lifetime of the value; the
 allocation must be balanced with a ``dealloc_stack`` instruction to
 mark the end of its lifetime. All ``alloc_stack`` allocations must be

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -1886,6 +1886,8 @@ Allocates uninitialized memory that is sufficiently aligned on the stack
 to contain a value of type ``T``. The result of the instruction is the address
 of the allocated memory.
 
+``alloc_stack`` always allocates memory on the stack even for runtime-sized type.
+
 ``alloc_stack`` marks the start of the lifetime of the value; the
 allocation must be balanced with a ``dealloc_stack`` instruction to
 mark the end of its lifetime. All ``alloc_stack`` allocations must be


### PR DESCRIPTION
As of Swift 4.0, `alloc_stack` always uses stack which means it's now guaranteed that the allocated memory is really located on the stack since this change below.
https://github.com/apple/swift/commit/cd1037b799402f4d68322011ef1b196f94281cea