### PR TITLE
[Batch mode] <rdar://40225790> Merge pull request #16583 from davidungar/batch-remark

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -37,6 +37,10 @@
   DIAG(NOTE,ID,Options,Text,Signature)
 #endif
 
+#ifndef REMARK
+#  define REMARK(ID,Options,Text,Signature) \
+DIAG(REMARK,ID,Options,Text,Signature)
+#endif
 
 WARNING(warning_parallel_execution_not_supported,none,
         "parallel execution not supported; falling back to serial execution",
@@ -150,6 +154,8 @@ WARNING(warn_ignoring_batch_mode,none,
 WARNING(warn_use_filelists_deprecated, none,
         "the option '-driver-use-filelists' is deprecated; use "
         "'-driver-filelist-threshold=0' instead", ())
+
+REMARK(remark_using_batch_mode,none, "using batch mode", ())
 
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -716,6 +716,11 @@ Driver::buildCompilation(const ToolChain &TC,
   const bool ContinueBuildingAfterErrors =
       BatchMode || ArgList->hasArg(options::OPT_continue_building_after_errors);
 
+  // Issue a remark to facilitate recognizing the use of batch mode in the build
+  // log.
+  if (BatchMode)
+    Diags.diagnose(SourceLoc(), diag::remark_using_batch_mode);
+
   if (Diags.hadAnyError())
     return nullptr;
 

--- a/test/Driver/batch_mode_force_one_batch_repartition.swift
+++ b/test/Driver/batch_mode_force_one_batch_repartition.swift
@@ -2,10 +2,8 @@
 // RUN: touch %t/file-01.swift %t/file-02.swift %t/file-03.swift
 // RUN: echo 'public func main() {}' >%t/main.swift
 //
-// RUN: %swiftc_driver -enable-batch-mode -c -emit-module -module-name main -j 2 -driver-force-one-batch-repartition %t/file-01.swift %t/file-02.swift %t/file-03.swift %t/main.swift  -###  2>%t/shouldBeEmpty2 | %FileCheck %s  -check-prefix=CHECK-COMBINED
-// RUN: test -z "`cat %t/shouldBeEmpty1`"
-// RUN: test -z "`cat %t/shouldBeEmpty2`"
-//
+// RUN: %swiftc_driver -enable-batch-mode -c -emit-module -module-name main -j 2 -driver-force-one-batch-repartition %t/file-01.swift %t/file-02.swift %t/file-03.swift %t/main.swift  -###  2>%t/stderr | %FileCheck %s  -check-prefix=CHECK-COMBINED
+
 // CHECK-COMBINED: -primary-file {{.*}}/file-01.swift
 // CHECK-COMBINED-NEXT: -primary-file {{.*}}/file-02.swift
 // CHECK-COMBINED-NEXT: -primary-file {{.*}}/file-03.swift

--- a/test/Driver/batch_mode_print_jobs.swift
+++ b/test/Driver/batch_mode_print_jobs.swift
@@ -10,9 +10,10 @@
 // RUN: touch %t/file-01.swift %t/file-02.swift %t/file-03.swift
 // RUN: echo 'public func main() {}' >%t/main.swift
 //
-// RUN: %swiftc_driver -enable-batch-mode -c -emit-module -module-name main -j 2 %t/file-01.swift %t/file-02.swift %t/file-03.swift %t/main.swift  -driver-print-jobs 2>%t/shouldBeEmpty1 | %FileCheck %s -check-prefix=CHECK-COMBINED
-// RUN: %swiftc_driver -enable-batch-mode -c -emit-module -module-name main -j 2 %t/file-01.swift %t/file-02.swift %t/file-03.swift %t/main.swift  -###  2>%t/shouldBeEmpty2 | %FileCheck %s  -check-prefix=CHECK-COMBINED
-// RUN: test -z "`cat %t/shouldBeEmpty1`"
-// RUN: test -z "`cat %t/shouldBeEmpty2`"
+// RUN: %swiftc_driver -enable-batch-mode -c -emit-module -module-name main -j 2 %t/file-01.swift %t/file-02.swift %t/file-03.swift %t/main.swift  -driver-print-jobs 2>%t/stderr1 | %FileCheck %s -check-prefix=CHECK-COMBINED
+// RUN: %swiftc_driver -enable-batch-mode -c -emit-module -module-name main -j 2 %t/file-01.swift %t/file-02.swift %t/file-03.swift %t/main.swift  -###  2>%t/stderr2 | %FileCheck %s  -check-prefix=CHECK-COMBINED
+// RUN: %FileCheck %s -check-prefix=NEGATIVE-CHECK-COMBINED <%t/stderr1
+// RUN: %FileCheck %s -check-prefix=NEGATIVE-CHECK-COMBINED <%t/stderr2
 //
 // CHECK-COMBINED: -primary-file {{.*}}/file-01.swift -primary-file {{.*}}/file-02.swift {{.*}}/file-03.swift {{.*}}/main.swift
+// NEGATIVE-CHECK-COMBINED-NOT: -primary-file {{.*}}/file-01.swift -primary-file {{.*}}/file-02.swift {{.*}}/file-03.swift {{.*}}/main.swift

--- a/test/Driver/batch_mode_remark.swift
+++ b/test/Driver/batch_mode_remark.swift
@@ -1,0 +1,12 @@
+// Ensure that driver issues a remark iff in batch mode.
+//
+// RUN: %swiftc_driver -whole-module-optimization -enable-batch-mode   %S/../Inputs/empty.swift -### 2>&1 >/dev/null | %FileCheck %s
+// RUN: %swiftc_driver                                                 %S/../Inputs/empty.swift -### 2>&1 >/dev/null | %FileCheck -allow-empty %s
+// RUN: %swiftc_driver -enable-batch-mode        -disable-batch-mode   %S/../Inputs/empty.swift -### 2>&1 >/dev/null | %FileCheck -allow-empty %s
+//
+// CHECK-NOT: remark: using batch mode
+//
+//
+// RUN: %swiftc_driver -enable-batch-mode  %S/../Inputs/empty.swift -### 2>&1 | %FileCheck %s -check-prefix USING-BATCH-MODE
+//
+// USING-BATCH-MODE: remark: using batch mode


### PR DESCRIPTION
[Batch Mode] Output a remark from the driver when in batch mode

<!-- What's in this pull request? -->
Explanation: Output a remark when using batch mode, so user can tell.
Scope of issue: Alleviates confusion when trying batch mode.
Origination: Batch mode + quasi-pid fix (https://github.com/apple/swift/pull/16546)
Risk: Minimal. Xcode ignores driver output in stderr.
Reviewed by: Jordan Rose
Testing: Normal regression tests.
Radar: rdar://40225790

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
