### PR TITLE
[Coverage] Test lowering of ill-formed SIL profiling intrinsics

### DIFF
--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -6212,11 +6212,12 @@ bool SILParserTUState::parseSILCoverageMap(Parser &P) {
     return true;
 
   // Parse the covered name.
-  Identifier FuncName;
-  SourceLoc FuncLoc;
-  if (State.parseSILIdentifier(FuncName, FuncLoc,
-                               diag::expected_sil_value_name))
+  if (!P.Tok.is(tok::string_literal)) {
+    P.diagnose(P.Tok, diag::sil_coverage_expected_quote);
     return true;
+  }
+  StringRef FuncName = P.Tok.getText().drop_front().drop_back();
+  P.consumeToken();
 
   // Parse the PGO func name.
   if (!P.Tok.is(tok::string_literal)) {
@@ -6225,12 +6226,6 @@ bool SILParserTUState::parseSILCoverageMap(Parser &P) {
   }
   StringRef PGOFuncName = P.Tok.getText().drop_front().drop_back();
   P.consumeToken();
-
-  SILFunction *Func = M.lookUpFunction(FuncName.str());
-  if (!Func) {
-    P.diagnose(FuncLoc, diag::sil_coverage_func_not_found, FuncName);
-    return true;
-  }
 
   uint64_t Hash;
   if (State.parseInteger(Hash, diag::sil_coverage_invalid_hash))

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2950,9 +2950,9 @@ void SILDefaultWitnessTable::dump() const {
 
 void SILCoverageMap::print(SILPrintContext &PrintCtx) const {
   llvm::raw_ostream &OS = PrintCtx.OS();
-  OS << "sil_coverage_map " << QuotedString(getFile()) << " " << getName()
-     << " " << QuotedString(getPGOFuncName()) << " " << getHash() << " {\t// "
-     << demangleSymbol(getName()) << "\n";
+  OS << "sil_coverage_map " << QuotedString(getFile()) << " "
+     << QuotedString(getName()) << " " << QuotedString(getPGOFuncName()) << " "
+     << getHash() << " {\t// " << demangleSymbol(getName()) << "\n";
   if (PrintCtx.sortSIL())
     std::sort(MappedRegions.begin(), MappedRegions.end(),
               [](const MappedRegion &LHS, const MappedRegion &RHS) {

--- a/test/Profiler/coverage_deinit.swift
+++ b/test/Profiler/coverage_deinit.swift
@@ -11,5 +11,5 @@ public class Derived: NSString {
   }
 }
 
-// CHECK-LABEL: sil_coverage_map "{{.*}}coverage_deinit.swift" $S15coverage_deinit7DerivedCfD
+// CHECK-LABEL: sil_coverage_map "{{.*}}coverage_deinit.swift" "$S15coverage_deinit7DerivedCfD"
 // CHECK-NEXT: [[@LINE-5]]:10 -> [[@LINE-4]]:4 : 0

--- a/test/Profiler/coverage_force_emission.swift
+++ b/test/Profiler/coverage_force_emission.swift
@@ -1,22 +1,22 @@
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_force_emission %s | %FileCheck %s -check-prefix=COVERAGE
-// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -emit-sorted-sil -emit-sil -module-name coverage_force_emission %s | %FileCheck %s -check-prefix=PGO
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sil -module-name coverage_force_emission %s | %FileCheck %s -check-prefix=COVERAGE
+// RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -emit-sil -module-name coverage_force_emission %s | %FileCheck %s -check-prefix=PGO
 
 final class VarInit {
-  // COVERAGE: sil_coverage_map {{.*}} $S23coverage_force_emission7VarInitC04lazydE033_7D375D72BA8B0C53C9AD7E4DBC7FF493LLSSvg
+  // COVERAGE: sil_coverage_map {{.*}} "$S23coverage_force_emission7VarInitC04lazydE033_7D375D72BA8B0C53C9AD7E4DBC7FF493LLSSvgSSyXEfU_"
   // PGO-LABEL: coverage_force_emission.VarInit.(lazyVarInit in _7D375D72BA8B0C53C9AD7E4DBC7FF493).getter : Swift.String
   // PGO: int_instrprof_increment
   private lazy var lazyVarInit: String = {
     return "Hello"
   }()
 
-  // CHECK: sil_coverage_map {{.*}} $S23coverage_force_emission7VarInitC05basicdE033_7D375D72BA8B0C53C9AD7E4DBC7FF493LLSSvpfiSSyXEfU_
+  // CHECK: sil_coverage_map {{.*}} "$S23coverage_force_emission7VarInitC05basicdE033_7D375D72BA8B0C53C9AD7E4DBC7FF493LLSSvpfiSSyXEfU_"
   // PGO-LABEL: closure #1 () -> Swift.String in variable initialization expression of coverage_force_emission.VarInit.(basicVarInit in _7D375D72BA8B0C53C9AD7E4DBC7FF493) : Swift.String
   // PGO: int_instrprof_increment
   private var basicVarInit: String = {
     return "Hello"
   }()
 
-  // CHECK: sil_coverage_map {{.*}} $S23coverage_force_emission7VarInitC06simpleD033_7D375D72BA8B0C53C9AD7E4DBC7FF493LLSSvg
+  // CHECK: sil_coverage_map {{.*}} "$S23coverage_force_emission7VarInitC06simpleD033_7D375D72BA8B0C53C9AD7E4DBC7FF493LLSSvg"
   // PGO-LABEL: coverage_force_emission.VarInit.(simpleVar in _7D375D72BA8B0C53C9AD7E4DBC7FF493).getter : Swift.String
   // PGO: int_instrprof_increment
   private var simpleVar: String {

--- a/test/Profiler/coverage_member_closure.swift
+++ b/test/Profiler/coverage_member_closure.swift
@@ -2,7 +2,7 @@
 
 class C {
   // Closures in members receive their own coverage mapping.
-  // CHECK: sil_coverage_map {{.*}} $S23coverage_member_closure1CC17completionHandleryySS_SaySSGtcvpfiySS_AEtcfU_
+  // CHECK: sil_coverage_map {{.*}} "$S23coverage_member_closure1CC17completionHandleryySS_SaySSGtcvpfiySS_AEtcfU_"
   // CHECK: [[@LINE+1]]:55 -> [[@LINE+1]]:79 : 0
   var completionHandler: (String, [String]) -> Void = { (foo, bar) in return }
 }

--- a/test/Profiler/coverage_var_init.swift
+++ b/test/Profiler/coverage_var_init.swift
@@ -1,19 +1,19 @@
 // RUN: %target-swift-frontend -Xllvm -sil-full-demangle -profile-generate -profile-coverage-mapping -emit-sorted-sil -emit-sil -module-name coverage_var_init %s | %FileCheck %s
 
 final class VarInit {
-  // CHECK: sil_coverage_map {{.*}} $S17coverage_var_init7VarInitC04lazydE033_49373CB2DFB47C8DC62FA963604688DFLLSSvgSSyXEfU_
+  // CHECK: sil_coverage_map {{.*}} "$S17coverage_var_init7VarInitC04lazydE033_49373CB2DFB47C8DC62FA963604688DFLLSSvgSSyXEfU_"
   // CHECK-NEXT: [[@LINE+1]]:42 -> [[@LINE+3]]:4 : 0
   private lazy var lazyVarInit: String = {
     return "lazyVarInit"
   }()
 
-  // CHECK: sil_coverage_map {{.*}} $S17coverage_var_init7VarInitC05basicdE033_49373CB2DFB47C8DC62FA963604688DFLLSSvpfiSSyXEfU_
+  // CHECK: sil_coverage_map {{.*}} "$S17coverage_var_init7VarInitC05basicdE033_49373CB2DFB47C8DC62FA963604688DFLLSSvpfiSSyXEfU_"
   // CHECK-NEXT: [[@LINE+1]]:38 -> [[@LINE+3]]:4 : 0
   private var basicVarInit: String = {
     return "Hello"
   }()
 
-  // CHECK: sil_coverage_map {{.*}} $S17coverage_var_init7VarInitC06simpleD033_49373CB2DFB47C8DC62FA963604688DFLLSSvg 
+  // CHECK: sil_coverage_map {{.*}} "$S17coverage_var_init7VarInitC06simpleD033_49373CB2DFB47C8DC62FA963604688DFLLSSvg"
   // CHECK-NEXT: [[@LINE+1]]:33 -> [[@LINE+3]]:4 : 0
   private var simpleVar: String {
     return "Hello"

--- a/test/Profiler/instrprof_symtab_valid.sil
+++ b/test/Profiler/instrprof_symtab_valid.sil
@@ -1,0 +1,30 @@
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -profile-generate -profile-coverage-mapping -emit-ir -o - -module-name=irgen | %FileCheck %s
+
+// CHECK-NOT: @__llvm_coverage_mapping
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+// main
+sil @main : $@convention(c) (Int32, UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>) -> Int32 {
+bb0(%0 : $Int32, %1 : $UnsafeMutablePointer<Optional<UnsafeMutablePointer<Int8>>>):
+  %2 = string_literal utf8 "<stdin>:__tlcd_line:1:1" // user: %6
+  %3 = integer_literal $Builtin.Int64, 0          // user: %6
+  %4 = integer_literal $Builtin.Int32, 2          // user: %6
+  %5 = integer_literal $Builtin.Int32, 0          // user: %6
+
+  // Pass an invalid SIL value to the int_instrprof_increment intrinsic
+  // to force IRGen to drop it.
+  %6 = builtin "int_instrprof_increment"(%3 : $Builtin.Int64, %3 : $Builtin.Int64, %4 : $Builtin.Int32, %5 : $Builtin.Int32) : $()
+
+  return %0 : $Int32                             // id: %33
+} // end sil function 'main'
+
+sil_coverage_map "<stdin>" "__tlcd_line:1:1" "<stdin>:__tlcd_line:1:1" 0 {	// __tlcd_line:1:1
+  1:19 -> 1:20 : 1
+  1:23 -> 1:24 : (0 - 1)
+  1:1 -> 1:24 : 0
+}

--- a/test/SIL/Parser/coverage_maps.sil
+++ b/test/SIL/Parser/coverage_maps.sil
@@ -6,12 +6,12 @@ bb0:
   return %0 : $()
 }
 
-// CHECK-LABEL: sil_coverage_map "coverage_maps.sil" someFunction "coverage_maps.sil:someFunction" 0 {
+// CHECK-LABEL: sil_coverage_map "coverage_maps.sil" "someFunction" "coverage_maps.sil:someFunction" 0 {
 // CHECK: }
-sil_coverage_map "coverage_maps.sil" someFunction "coverage_maps.sil:someFunction" 0 {
+sil_coverage_map "coverage_maps.sil" "someFunction" "coverage_maps.sil:someFunction" 0 {
 }
 
-// CHECK-LABEL: sil_coverage_map "/some/other/file.sil" someFunction "/some/other/file.sil:someFunction" 0 {
+// CHECK-LABEL: sil_coverage_map "/some/other/file.sil" "someFunction" "/some/other/file.sil:someFunction" 0 {
 // CHECK: 4:19 -> 31:1 : 0
 // CHECK: 7:9 -> 7:16 : (0 + 1)
 // CHECK: 7:18 -> 9:3 : zero


### PR DESCRIPTION
This adds a test case to exercise a path in IRGen which discards
ill-formed profiling intrinsics.

The reason that path exists is because SIL optimizations may rewrite profiling intrinsics in a way that IRGen can't understand. Essentially IRGen would need to undo the optimizations in order to gather information needed to emit the right LLVM IR.

Eventually I'd like to fix this by adding a SIL verifier check to make sure SIL optimizations don't touch profiling intrinsics (see: r://39146527), but we need to avoid generating incorrect binaries right away.

rdar://40133800