### PR TITLE
[TypeReconstruction] Handle InOutType when reconstructing elements.

### DIFF
--- a/test/DebugInfo/Inputs/type-reconstr-names.txt
+++ b/test/DebugInfo/Inputs/type-reconstr-names.txt
@@ -3,3 +3,4 @@ $SytD ---> ()
 $Ss5Int32VD ---> Int32
 $S4blah4mainyyF8PatatinoL_VMa ---> Can't resolve type of $S4blah4mainyyF8PatatinoL_VMa
 $Ss10CollectionP7Element ---> Can't resolve type of $Ss10CollectionP7Element
+$Ss15ContiguousArrayV9formIndex5afterySiz_tFSS_Tg5 ---> (inout Int) -> ()


### PR DESCRIPTION
Before, we were just ignoring it, and this resulted in the type being reconstructed incorrectly when assertion were disabled, and in an assertion firing otherwise (AST invariants being broken).

<rdar://problem/39248252>