### PR TITLE
[4.2] IRGen: don't emit metadata lazily in JIT mode.

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -79,6 +79,8 @@ bool IRGenerator::tryEnableLazyTypeMetadata(NominalTypeDecl *Nominal) {
   // is not used by the program itself.
   if (!Opts.shouldOptimize())
     return false;
+  if (Opts.UseJIT)
+    return false;
 
   switch (Nominal->getKind()) {
     case DeclKind::Enum:

--- a/test/Interpreter/unused-type.swift
+++ b/test/Interpreter/unused-type.swift
@@ -1,0 +1,17 @@
+// RUN: %target-jit-run -O %s | %FileCheck %s
+// REQUIRES: executable_test
+// REQUIRES: swift_interpreter
+
+// Check that when running the jit with -O we don't crash with an unresolved
+// metadata symbol.
+
+protocol Foo {
+    func foo() -> Int
+}
+
+struct Dummy: Foo {
+    func foo() -> Int { return 42 }
+}
+
+// CHECK: ok
+print("ok")


### PR DESCRIPTION
We already do this for witness tables, but the check was missing for metadata.
This problem caused unresolved symbols when interpreting with -O.

rdar://problem/40128897
