### PR TITLE
[4.2][Parser] Set decl context to be typealias when completing its underly…

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3466,10 +3466,16 @@ parseDeclTypeAlias(Parser::ParseDeclOptions Flags, DeclAttributes &Attributes) {
     return parseDeclAssociatedType(Flags, Attributes);
   }
   TmpCtxt.reset();
-  
+
+  auto *TAD = new (Context) TypeAliasDecl(TypeAliasLoc, EqualLoc, Id, IdLoc,
+                                          /*genericParams*/nullptr,
+                                          CurDeclContext);
+
   ParserResult<TypeRepr> UnderlyingTy;
 
   if (Tok.is(tok::colon) || Tok.is(tok::equal)) {
+    ContextChange CC(*this, TAD);
+
     SyntaxParsingContext InitCtx(SyntaxContext,
                                  SyntaxKind::TypeInitializerClause);
     if (Tok.is(tok::colon)) {
@@ -3477,20 +3483,15 @@ parseDeclTypeAlias(Parser::ParseDeclOptions Flags, DeclAttributes &Attributes) {
       // Recognize this and produce a fixit.
       diagnose(Tok, diag::expected_equal_in_typealias)
           .fixItReplace(Tok.getLoc(), " = ");
-      consumeToken(tok::colon);
+      EqualLoc = consumeToken(tok::colon);
     } else {
       EqualLoc = consumeToken(tok::equal);
     }
 
     UnderlyingTy = parseType(diag::expected_type_in_typealias);
     Status |= UnderlyingTy;
-    if (UnderlyingTy.isNull())
-      return Status;
   }
 
-  auto *TAD = new (Context) TypeAliasDecl(TypeAliasLoc, EqualLoc, Id, IdLoc,
-                                          /*genericParams*/nullptr,
-                                          CurDeclContext);
   TAD->getUnderlyingTypeLoc() = UnderlyingTy.getPtrOrNull();
   TAD->getAttrs() = Attributes;
 
@@ -3504,8 +3505,13 @@ parseDeclTypeAlias(Parser::ParseDeclOptions Flags, DeclAttributes &Attributes) {
   TAD->setGenericParams(genericParams);
 
   if (UnderlyingTy.isNull()) {
-    diagnose(Tok, diag::expected_equal_in_typealias);
-    Status.setIsParseError();
+    // If there is an attempt to do code completion
+    // inside of typealias type, let's just return
+    // because we've seen required '=' token.
+    if (EqualLoc.isInvalid()) {
+      diagnose(Tok, diag::expected_equal_in_typealias);
+      Status.setIsParseError();
+    }
     return Status;
   }
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6445,6 +6445,15 @@ static void validateTypealiasType(TypeChecker &tc, TypeAliasDecl *typeAlias) {
      options |= TypeResolutionFlags::KnownNonCascadingDependency;
   }
 
+  // This can happen when code completion is attempted inside
+  // of typealias underlying type e.g. `typealias F = () -> Int#^TOK^#`
+  auto underlyingType = typeAlias->getUnderlyingTypeLoc();
+  if (underlyingType.isNull()) {
+    typeAlias->setInterfaceType(ErrorType::get(tc.Context));
+    typeAlias->setInvalid();
+    return;
+  }
+
   if (typeAlias->getDeclContext()->isModuleScopeContext() &&
       typeAlias->getGenericParams() == nullptr) {
     IterativeTypeChecker ITC(tc);

--- a/test/IDE/complete_member_decls_from_parent_decl_context.swift
+++ b/test/IDE/complete_member_decls_from_parent_decl_context.swift
@@ -281,10 +281,10 @@ struct NestedOuter1 {
 
       typealias ATestTypealias = #^NESTED_NOMINAL_DECL_A_3^#
 // NESTED_NOMINAL_DECL_A_3: Begin completions
-// NESTED_NOMINAL_DECL_A_3-DAG: Decl[Struct]/CurrNominal:    NestedInnerAStruct[#NestedInnerA.NestedInnerAStruct#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_A_3-DAG: Decl[Class]/CurrNominal:     NestedInnerAClass[#NestedInnerA.NestedInnerAClass#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_A_3-DAG: Decl[Enum]/CurrNominal:      NestedInnerAEnum[#NestedInnerA.NestedInnerAEnum#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_A_3-DAG: Decl[TypeAlias]/CurrNominal: NestedInnerATypealias[#Int#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_A_3-DAG: Decl[Struct]/OutNominal:    NestedInnerAStruct[#NestedInnerA.NestedInnerAStruct#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_A_3-DAG: Decl[Class]/OutNominal:     NestedInnerAClass[#NestedInnerA.NestedInnerAClass#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_A_3-DAG: Decl[Enum]/OutNominal:      NestedInnerAEnum[#NestedInnerA.NestedInnerAEnum#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_A_3-DAG: Decl[TypeAlias]/OutNominal: NestedInnerATypealias[#Int#]{{; name=.+$}}
 // FIXME: should this really come as Local?
 // NESTED_NOMINAL_DECL_A_3-DAG: Decl[Struct]/Local:          NestedInnerA[#NestedInnerA#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_A_3-DAG: Decl[TypeAlias]/OutNominal:  OuterTypealias[#Int#]{{; name=.+$}}
@@ -388,10 +388,10 @@ struct NestedOuter1 {
 
       typealias BTestTypealias = #^NESTED_NOMINAL_DECL_B_3^#
 // NESTED_NOMINAL_DECL_B_3: Begin completions
-// NESTED_NOMINAL_DECL_B_3-DAG: Decl[Struct]/CurrNominal:    NestedInnerBStruct[#NestedInnerB.NestedInnerBStruct#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_B_3-DAG: Decl[Class]/CurrNominal:     NestedInnerBClass[#NestedInnerB.NestedInnerBClass#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_B_3-DAG: Decl[Enum]/CurrNominal:      NestedInnerBEnum[#NestedInnerB.NestedInnerBEnum#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_B_3-DAG: Decl[TypeAlias]/CurrNominal: NestedInnerBTypealias[#Int#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_B_3-DAG: Decl[Struct]/OutNominal:    NestedInnerBStruct[#NestedInnerB.NestedInnerBStruct#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_B_3-DAG: Decl[Class]/OutNominal:     NestedInnerBClass[#NestedInnerB.NestedInnerBClass#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_B_3-DAG: Decl[Enum]/OutNominal:      NestedInnerBEnum[#NestedInnerB.NestedInnerBEnum#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_B_3-DAG: Decl[TypeAlias]/OutNominal: NestedInnerBTypealias[#Int#]{{; name=.+$}}
 // FIXME: should this really come as Local?
 // NESTED_NOMINAL_DECL_B_3-DAG: Decl[Struct]/Local:          NestedInnerB[#NestedInnerB#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_B_3-DAG: Decl[TypeAlias]/OutNominal:  OuterTypealias[#Int#]{{; name=.+$}}
@@ -489,10 +489,10 @@ func testOuterC() {
 
     typealias CTestTypealias = #^NESTED_NOMINAL_DECL_C_3^#
 // NESTED_NOMINAL_DECL_C_3: Begin completions
-// NESTED_NOMINAL_DECL_C_3-DAG: Decl[Struct]/CurrNominal:    NestedInnerCStruct[#NestedInnerC.NestedInnerCStruct#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_C_3-DAG: Decl[Class]/CurrNominal:     NestedInnerCClass[#NestedInnerC.NestedInnerCClass#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_C_3-DAG: Decl[Enum]/CurrNominal:      NestedInnerCEnum[#NestedInnerC.NestedInnerCEnum#]{{; name=.+$}}
-// NESTED_NOMINAL_DECL_C_3-DAG: Decl[TypeAlias]/CurrNominal: NestedInnerCTypealias[#Int#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_C_3-DAG: Decl[Struct]/OutNominal:    NestedInnerCStruct[#NestedInnerC.NestedInnerCStruct#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_C_3-DAG: Decl[Class]/OutNominal:     NestedInnerCClass[#NestedInnerC.NestedInnerCClass#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_C_3-DAG: Decl[Enum]/OutNominal:      NestedInnerCEnum[#NestedInnerC.NestedInnerCEnum#]{{; name=.+$}}
+// NESTED_NOMINAL_DECL_C_3-DAG: Decl[TypeAlias]/OutNominal: NestedInnerCTypealias[#Int#]{{; name=.+$}}
 // FIXME: should this really come as Local?
 // NESTED_NOMINAL_DECL_C_3-DAG: Decl[Struct]/Local:          NestedInnerC[#NestedInnerC#]{{; name=.+$}}
 // NESTED_NOMINAL_DECL_C_3: End completions

--- a/validation-test/IDE/crashers_2_fixed/0019-rdar39909829.swift
+++ b/validation-test/IDE/crashers_2_fixed/0019-rdar39909829.swift
@@ -1,0 +1,3 @@
+// RUN: %target-swift-ide-test -code-completion -code-completion-token=COMPLETE -source-filename=%s
+
+public typealias CustomGetter<T> = (Int) -> T #^COMPLETE^#


### PR DESCRIPTION
…ing type

Parser didn't capture correct context when code completion
was attempted on typealias' right-hand side which, if there are
generic parameters present, would result in a crash. These
changes make it so completion gets a correct declaration
context in aforementioned case and typealias declaration is marked
invalid because it doesn't have a proper type.

Resolves: rdar://problem/39909829
(cherry picked from commit f49aad16b70d08a1aa96de752ad258013545127b)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
