### PR TITLE
[Serialization] Follow compatibility typealiases for non-generic types

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -4304,6 +4304,31 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
     if (!nominalOrError)
       return nominalOrError.takeError();
 
+    // Look through compatibility aliases.
+    if (auto *alias = dyn_cast<TypeAliasDecl>(nominalOrError.get())) {
+      // Reminder: TypeBase::getAs will look through sugar. But we don't want to
+      // do that here, so we do isa<> checks on the TypeBase itself instead of
+      // using the Type wrapper.
+      const TypeBase *underlyingTy = nullptr;
+      while (alias->isCompatibilityAlias()) {
+        underlyingTy = alias->getUnderlyingTypeLoc().getType().getPointer();
+
+        // If the underlying type is itself a typealias, it might be another
+        // compatibility alias, meaning we need to go around the loop again.
+        auto aliasTy = dyn_cast<NameAliasType>(underlyingTy);
+        if (!aliasTy)
+          break;
+        alias = aliasTy->getDecl();
+      }
+
+      // We only want to use the type we found if it's a simple non-generic
+      // nominal type.
+      if (auto simpleNominalTy = dyn_cast_or_null<NominalType>(underlyingTy)) {
+        nominalOrError = simpleNominalTy->getDecl();
+        (void)!nominalOrError; // "Check" the llvm::Expected<> value.
+      }
+    }
+
     auto nominal = dyn_cast<NominalTypeDecl>(nominalOrError.get());
     if (!nominal) {
       XRefTracePath tinyTrace{*nominalOrError.get()->getModuleContext()};

--- a/test/Serialization/Recovery/Inputs/custom-modules/RenameAcrossVersions.h
+++ b/test/Serialization/Recovery/Inputs/custom-modules/RenameAcrossVersions.h
@@ -1,0 +1,22 @@
+#if NEW
+# define NEW_NAME(x) __attribute__((swift_name(#x)))
+#else
+# define NEW_NAME(x)
+#endif
+
+struct BeforeStruct {
+  int value;
+} NEW_NAME(AfterStruct);
+
+typedef int BeforeTypedef NEW_NAME(AfterTypedef);
+typedef int BeforeWrappedTypedef __attribute__((swift_wrapper(struct))) NEW_NAME(AfterWrappedTypedef);
+
+#if NEW
+typedef struct DifferentStruct {
+  int value;
+} BeforeReplacedType NEW_NAME(AfterReplacedType);
+#else
+struct BeforeReplacedType {
+  float value;
+};
+#endif

--- a/test/Serialization/Recovery/Inputs/custom-modules/Types.apinotes
+++ b/test/Serialization/Recovery/Inputs/custom-modules/Types.apinotes
@@ -7,6 +7,8 @@ Classes:
 Typedefs:
 - Name: RenamedTypedef
   SwiftName: RenamedTypedef
+- Name: RenamedWrappedTypedef
+  SwiftName: RenamedWrappedTypedef
 Tags:
 - Name: RenamedStruct
   SwiftName: RenamedStruct
@@ -27,6 +29,8 @@ SwiftVersions:
     SwiftName: Swift3RenamedTypedef
   - Name: NewlyWrappedTypedef
     SwiftWrapper: none
+  - Name: RenamedWrappedTypedef
+    SwiftName: Swift3RenamedWrappedTypedef
   Tags:
   - Name: RenamedStruct
     SwiftName: Swift3RenamedStruct

--- a/test/Serialization/Recovery/Inputs/custom-modules/Types.h
+++ b/test/Serialization/Recovery/Inputs/custom-modules/Types.h
@@ -10,6 +10,7 @@
 
 typedef int RenamedTypedef;
 typedef int NewlyWrappedTypedef __attribute__((swift_wrapper(struct)));
+typedef int RenamedWrappedTypedef __attribute__((swift_wrapper(struct)));
 
 struct RenamedStruct {
   int value;

--- a/test/Serialization/Recovery/Inputs/custom-modules/module.modulemap
+++ b/test/Serialization/Recovery/Inputs/custom-modules/module.modulemap
@@ -1,5 +1,6 @@
 module Overrides { header "Overrides.h" }
 module ProtocolInheritance { header "ProtocolInheritance.h" }
+module RenameAcrossVersions { header "RenameAcrossVersions.h" }
 module Typedefs { header "Typedefs.h" }
 module TypeRemovalObjC { header "TypeRemovalObjC.h" }
 module Types { header "Types.h" }

--- a/test/Serialization/Recovery/rename-across-versions.swift
+++ b/test/Serialization/Recovery/rename-across-versions.swift
@@ -1,0 +1,38 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -o %t -module-name Lib -I %S/Inputs/custom-modules %s
+
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules | %FileCheck %s
+
+// RUN: %target-swift-ide-test -source-filename=x -print-module -module-to-print Lib -I %t -I %S/Inputs/custom-modules -Xcc -DNEW > %t/recovery.txt
+// RUN: %FileCheck -check-prefix CHECK-RECOVERY %s < %t/recovery.txt
+// RUN: %FileCheck -check-prefix NEGATIVE-RECOVERY %s < %t/recovery.txt
+
+import RenameAcrossVersions
+
+public func test(
+  a: BeforeStruct,
+  b: BeforeTypedef,
+  c: BeforeWrappedTypedef
+) {}
+
+// CHECK-LABEL: func test(
+// CHECK-SAME: a: BeforeStruct
+// CHECK-SAME: b: BeforeTypedef
+// CHECK-SAME: c: BeforeWrappedTypedef
+// CHECK-SAME: )
+
+// CHECK-RECOVERY-LABEL: func test(
+// CHECK-RECOVERY-SAME: a: AfterStruct
+// CHECK-RECOVERY-SAME: b: AfterTypedef
+// CHECK-RECOVERY-SAME: c: AfterWrappedTypedef
+// CHECK-RECOVERY-SAME: )
+
+// Test replacements that look like renames.
+
+// Please only include one parameter per function, so that we test that that one
+// parameter is enough to get the function dropped from the recovery interface.
+public func testReplacementA(_: BeforeReplacedType) {}
+
+// CHECK-LABEL: func testReplacementA(_: BeforeReplacedType)
+
+// NEGATIVE-RECOVERY-NOT: testReplacement

--- a/test/Serialization/Recovery/types-3-to-4.swift
+++ b/test/Serialization/Recovery/types-3-to-4.swift
@@ -32,7 +32,8 @@ public func A_renameAllTheThings(
   c: Swift3RenamedTypedef,
   d: Swift3RenamedStruct,
   e: Swift3RenamedEnum,
-  f: Swift3RenamedProtocol
+  f: Swift3RenamedProtocol,
+  g: Swift3RenamedWrappedTypedef
 ) {}
 
 // CHECK-4-LABEL: func A_renameAllTheThings(
@@ -42,6 +43,7 @@ public func A_renameAllTheThings(
 // CHECK-4-SAME: d: RenamedStruct
 // CHECK-4-SAME: e: RenamedEnum
 // CHECK-4-SAME: f: RenamedProtocol
+// CHECK-4-SAME: g: RenamedWrappedTypedef
 // CHECK-4-SAME: )
 
 
@@ -56,6 +58,7 @@ public func A_renameAllTheThings(
 // CHECK-3-SAME: d: Swift3RenamedStruct
 // CHECK-3-SAME: e: Swift3RenamedEnum
 // CHECK-3-SAME: f: Swift3RenamedProtocol
+// CHECK-3-SAME: g: Swift3RenamedWrappedTypedef
 // CHECK-3-SAME: )
 
 

--- a/test/Serialization/Recovery/types-4-to-3.swift
+++ b/test/Serialization/Recovery/types-4-to-3.swift
@@ -32,7 +32,8 @@ public func A_renameAllTheThings(
   c: RenamedTypedef,
   d: RenamedStruct,
   e: RenamedEnum,
-  f: RenamedProtocol
+  f: RenamedProtocol,
+  g: RenamedWrappedTypedef
 ) {}
 
 // CHECK-LABEL: func A_renameAllTheThings(
@@ -42,6 +43,7 @@ public func A_renameAllTheThings(
 // CHECK-SAME: d: RenamedStruct
 // CHECK-SAME: e: RenamedEnum
 // CHECK-SAME: f: RenamedProtocol
+// CHECK-SAME: g: RenamedWrappedTypedef
 // CHECK-SAME: )
 
 


### PR DESCRIPTION
Now that we use the C names of imported types in mangled names, it's safe to resolve a compatibility alias when a type gets an NS_SWIFT_NAME for the first time, rather than requiring the developer to recompile the imported library.

This doesn't include generic types, which only applies for Objective-C generics. There shouldn't be additional complications here but I want to be extra careful.

rdar://problem/39661212