### PR TITLE
[4.2 04-30-2018] Add -emit-public-type-metadata-accessors to work around metadata linkage bug

### DIFF
--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -223,6 +223,9 @@ namespace swift {
     /// Enables key path resilience.
     bool EnableKeyPathResilience = false;
 
+    /// Enables public emission of private metadata accessors.
+    bool EmitPublicTypeMetadataAccessors = false;
+
     /// If set to true, the diagnosis engine can assume the emitted diagnostics
     /// will be used in editor. This usually leads to more aggressive fixit.
     bool DiagnosticsEditorMode = false;

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -355,6 +355,11 @@ def warn_swift3_objc_inference : Flag<["-"], "warn-swift3-objc-inference">,
   Alias<warn_swift3_objc_inference_complete>,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, HelpHidden]>;
 
+def emit_public_type_metadata_accessors :
+  Flag<["-"], "emit-public-type-metadata-accessors">,
+  Flags<[FrontendOption]>,
+  HelpText<"Emit all type metadata accessors as public">;
+
 def Rpass_EQ : Joined<["-"], "Rpass=">,
   Flags<[FrontendOption]>,
   HelpText<"Report performed transformations by optimization passes whose "

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -184,6 +184,8 @@ static void addCommonFrontendArgs(const ToolChain &TC,
                        options::OPT_warn_swift3_objc_inference_minimal,
                        options::OPT_warn_swift3_objc_inference_complete);
   inputArgs.AddLastArg(arguments, options::OPT_typo_correction_limit);
+  inputArgs.AddLastArg(arguments,
+                       options::OPT_emit_public_type_metadata_accessors);
   inputArgs.AddLastArg(arguments, options::OPT_enable_app_extension);
   inputArgs.AddLastArg(arguments, options::OPT_enable_testing);
   inputArgs.AddLastArg(arguments, options::OPT_g_Group);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -304,6 +304,9 @@ static bool ParseLangArgs(LangOptions &Opts, ArgList &Args,
     }
   }
 
+  Opts.EmitPublicTypeMetadataAccessors =
+    Args.hasArg(OPT_emit_public_type_metadata_accessors);
+
   Opts.EnableNSKeyedArchiverDiagnostics =
       Args.hasFlag(OPT_enable_nskeyedarchiver_diagnostics,
                    OPT_disable_nskeyedarchiver_diagnostics,

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -601,6 +601,17 @@ bool irgen::isTypeMetadataAccessTrivial(IRGenModule &IGM, CanType type) {
   return false;
 }
 
+/// Determine whether we should promote the type metadata access function
+/// for the given nominal type to "public".
+static bool promoteMetadataAccessFunctionToPublic(
+                                              const NominalTypeDecl *nominal) {
+  ASTContext &ctx = nominal->getASTContext();
+
+  // When -emit-public-type-metadata-accessors is provided, promote all
+  // of the metadata access functions to public.
+  return ctx.LangOpts.EmitPublicTypeMetadataAccessors;
+}
+
 /// Return the standard access strategy for getting a non-dependent
 /// type metadata object.
 MetadataAccessStrategy irgen::getTypeMetadataAccessStrategy(CanType type) {
@@ -633,8 +644,12 @@ MetadataAccessStrategy irgen::getTypeMetadataAccessStrategy(CanType type) {
     case FormalLinkage::PublicUnique:
       return MetadataAccessStrategy::PublicUniqueAccessor;
     case FormalLinkage::HiddenUnique:
+      if (promoteMetadataAccessFunctionToPublic(nominal))
+        return MetadataAccessStrategy::PublicUniqueAccessor;
       return MetadataAccessStrategy::HiddenUniqueAccessor;
     case FormalLinkage::Private:
+      if (promoteMetadataAccessFunctionToPublic(nominal))
+        return MetadataAccessStrategy::PublicUniqueAccessor;
       return MetadataAccessStrategy::PrivateAccessor;
 
     case FormalLinkage::PublicNonUnique:

--- a/test/IRGen/Inputs/emit_public_type_metadata_accessors_other.swift
+++ b/test/IRGen/Inputs/emit_public_type_metadata_accessors_other.swift
@@ -1,0 +1,3 @@
+func foo() -> Any {
+  return Wrapper()
+}

--- a/test/IRGen/emit_public_type_metadata_accessors.swift
+++ b/test/IRGen/emit_public_type_metadata_accessors.swift
@@ -1,0 +1,17 @@
+// RUN: %swift -module-name test -target x86_64-apple-macosx10.9  -emit-ir -parse-stdlib -emit-public-type-metadata-accessors -primary-file %s %S/Inputs/emit_public_type_metadata_accessors_other.swift | %FileCheck --check-prefix=CHECK-PUBLIC %s
+
+// RUN: %swift -module-name test -target x86_64-apple-macosx10.9  -emit-ir -parse-stdlib -primary-file %s %S/Inputs/emit_public_type_metadata_accessors_other.swift | %FileCheck --check-prefix=CHECK-NONPUBLIC %s
+
+private class C { }
+
+// CHECK-PUBLIC: define swiftcc %swift.metadata_response @"$S4test3Foo33_DEC9477CC6E8E6E7A9CE422B1DBE7EA4LLVMa"
+// CHECK-NONPUBLIC: define internal swiftcc %swift.metadata_response @"$S4test3Foo33_DEC9477CC6E8E6E7A9CE422B1DBE7EA4LLVMa"
+private struct Foo {
+  private let c: C = C()
+}
+
+public struct Wrapper {
+  private let foo: Foo = Foo()
+}
+
+


### PR DESCRIPTION
**Explanation**: Introduce a new flag `-emit-public-type-metadata-accessors` that works around problems where IR generation might emit code that references the type metadata accessor for a private or internal type that should not be accessible, e.g., because it's from another module or (in non-WMO mode) source file. Such problems manifest as assertions in the compiler (when enabled) or linker errors, and can be identified by linker errors mentioning the "type metadata accessor" (whose mangled name have the suffix "VMa").
**Scope**: Affects the linkage for type metadata accessors *only* when the command-line flag is provided, so the impact is limited to projects that specifically pass the flag.
**Radar/SR Issue**: [SR-7549](https://bugs.swift.org/browse/SR-7549) / rdar://problem/40229755
**Risk**: Very low risk; there is no change unless the newly-introduced command-line flag is used, and that change is very minimal and unlikely to break anything.
**Testing**: New tests for this functionality; compiler regression tests; tested the project attached to [SR-7549](https://bugs.swift.org/browse/SR-7549)
**Reviewer**: @slavapestov and @rjmccall  
