### PR TITLE
Better protocol conformance and substitution map printing

### DIFF
--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -218,8 +218,12 @@ public:
   /// Verify that this substitution map is valid.
   void verify() const;
 
+  /// Whether to dump the full substitution map, or just a minimal useful subset
+  /// (on a single line).
+  enum class DumpStyle { Minimal, Full };
   /// Dump the contents of this substitution map for debugging purposes.
-  void dump(llvm::raw_ostream &out, unsigned indent = 0) const;
+  void dump(llvm::raw_ostream &out, DumpStyle style = DumpStyle::Full,
+            unsigned indent = 0) const;
 
   LLVM_ATTRIBUTE_DEPRECATED(void dump() const, "only for use in the debugger");
 

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -219,7 +219,7 @@ public:
   void verify() const;
 
   /// Dump the contents of this substitution map for debugging purposes.
-  void dump(llvm::raw_ostream &out) const;
+  void dump(llvm::raw_ostream &out, unsigned indent = 0) const;
 
   LLVM_ATTRIBUTE_DEPRECATED(void dump() const, "only for use in the debugger");
 

--- a/include/swift/AST/SubstitutionMap.h
+++ b/include/swift/AST/SubstitutionMap.h
@@ -71,13 +71,17 @@ private:
   /// signature nor any replacement types/conformances.
   Storage *storage = nullptr;
 
+public:
   /// Retrieve the array of replacement types, which line up with the
   /// generic parameters.
   ///
   /// Note that the types may be null, for cases where the generic parameter
   /// is concrete but hasn't been queried yet.
+  ///
+  /// Prefer \c getReplacementTypes, this is public for printing purposes.
   ArrayRef<Type> getReplacementTypesBuffer() const;
 
+private:
   MutableArrayRef<Type> getReplacementTypesBuffer();
 
   /// Retrieve a mutable reference to the buffer of conformances.

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2857,7 +2857,7 @@ static void dumpProtocolConformanceRec(
             out.indent(indent + 2);
             PrintWithColorRAII(out, ParenthesisColor) << '(';
             out << "assoc_type req=" << req->getName() << " type=";
-            PrintWithColorRAII(out, TypeColor) << ty;
+            PrintWithColorRAII(out, TypeColor) << Type(ty->getDesugaredType());
             PrintWithColorRAII(out, ParenthesisColor) << ')';
             return false;
           });

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2810,7 +2810,6 @@ static void dumpProtocolConformanceRefRec(
     out.indent(indent) << "(abstract_conformance protocol="
                        << conformance.getAbstract()->getName();
     PrintWithColorRAII(out, ParenthesisColor) << ')';
-    out << '\n';
   }
 }
 
@@ -2923,7 +2922,10 @@ static void dumpProtocolConformanceRec(
   PrintWithColorRAII(out, ParenthesisColor) << ')';
 }
 
-void ProtocolConformanceRef::dump() const { dump(llvm::errs()); }
+void ProtocolConformanceRef::dump() const {
+  dump(llvm::errs());
+  llvm::errs() << '\n';
+}
 
 void ProtocolConformanceRef::dump(llvm::raw_ostream &out,
                                   unsigned indent) const {

--- a/lib/AST/ConcreteDeclRef.cpp
+++ b/lib/AST/ConcreteDeclRef.cpp
@@ -56,7 +56,7 @@ void ConcreteDeclRef::dump(raw_ostream &os) {
   // If specialized, dump the substitutions.
   if (isSpecialized()) {
     os << " [with ";
-    getSubstitutions().dump(os);
+    getSubstitutions().dump(os, SubstitutionMap::DumpStyle::Minimal);
     os << ']';
   }
 }

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -609,48 +609,6 @@ void SubstitutionMap::verify() const {
 #endif
 }
 
-void SubstitutionMap::dump(llvm::raw_ostream &out) const {
-  auto *genericSig = getGenericSignature();
-  if (genericSig == nullptr) {
-    out << "Empty substitution map\n";
-    return;
-  }
-  out << "Generic signature: ";
-  genericSig->print(out);
-  out << "\n";
-  out << "Substitutions:\n";
-  auto genericParams = genericSig->getGenericParams();
-  auto replacementTypes = getReplacementTypesBuffer();
-  for (unsigned i : indices(genericParams)) {
-    out.indent(2);
-    genericParams[i]->print(out);
-    out << " -> ";
-    if (replacementTypes[i])
-      replacementTypes[i]->print(out);
-    else
-      out << "<<unresolved concrete type>>";
-    out << "\n";
-  }
-
-  out << "\nConformance map:\n";
-  auto conformances = getConformances();
-  for (const auto &req : genericSig->getRequirements()) {
-    if (req.getKind() != RequirementKind::Conformance) continue;
-
-    out.indent(2);
-    req.getFirstType()->print(out);
-    out << " -> ";
-    conformances.front().dump(out);
-    out << "\n";
-
-    conformances = conformances.slice(1);
-  }
-}
-
-void SubstitutionMap::dump() const {
-  return dump(llvm::errs());
-}
-
 void SubstitutionMap::profile(llvm::FoldingSetNodeID &id) const {
   id.AddPointer(storage);
 }

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -4670,16 +4670,19 @@ void TypeChecker::checkConformancesInContext(DeclContext *dc,
         inferStaticInitializeObjCMetadata(*this, classDecl);
       }
     }
-
-    // When requested, print out information about this conformance.
-    if (Context.LangOpts.DebugGenericSignatures) {
-      dc->dumpContext();
-      conformance->dump();
-    }
   }
 
   // Check all conformances.
   groupChecker.checkAllConformances();
+
+  if (Context.LangOpts.DebugGenericSignatures) {
+    // Now that they're filled out, print out information about the conformances
+    // here, when requested.
+    for (auto conformance : conformances) {
+      dc->dumpContext();
+      conformance->dump();
+    }
+  }
 
   // Catalog all of members of this declaration context that satisfy
   // requirements of conformances in this context.

--- a/test/Driver/debug-generic-signatures.swift
+++ b/test/Driver/debug-generic-signatures.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -typecheck -debug-generic-signatures %s 2>&1 | %FileCheck %s
+
+// CHECK: Generic signature: <Self where Self : P1>
+// CHECK-NEXT: Canonical generic signature: <τ_0_0 where τ_0_0 : P1>
+// CHECK-LABEL: main.(file).P1@
+// CHECK: Requirement signature: <Self>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0>
+protocol P1 {
+    associatedtype A
+    func f() -> A
+}
+
+// CHECK-LABEL: StructDecl name=Basic
+// CHECK: (normal_conformance type=Basic protocol=P1
+// CHECK-NEXT: (assoc_type req=A type=Basic.A)
+// CHECK-NEXT: (value req=f() witness=main.(file).Basic.f()@{{.*}}))
+struct Basic: P1 {
+    typealias A = Int
+    func f() -> Int { fatalError() }
+}

--- a/test/Driver/debug-generic-signatures.swift
+++ b/test/Driver/debug-generic-signatures.swift
@@ -10,6 +10,17 @@ protocol P1 {
     func f() -> A
 }
 
+// Recursion, and where clauses.
+// CHECK: Generic signature: <Self where Self : P2>
+// CHECK-NEXT: Canonical generic signature: <τ_0_0 where τ_0_0 : P2>
+// CHECK-LABEL: main.(file).P2@
+// CHECK: Requirement signature: <Self where Self.A : P2, Self.B : P2, Self.A.A == Self.B.A>
+// CHECK-NEXT: Canonical requirement signature: <τ_0_0 where τ_0_0.A : P2, τ_0_0.B : P2, τ_0_0.A.A == τ_0_0.B.A>
+protocol P2 {
+    associatedtype A: P2
+    associatedtype B: P2 where Self.A.A == Self.B.A
+}
+
 // CHECK-LABEL: StructDecl name=Basic
 // CHECK: (normal_conformance type=Basic protocol=P1
 // CHECK-NEXT: (assoc_type req=A type=Basic.A)
@@ -18,3 +29,83 @@ struct Basic: P1 {
     typealias A = Int
     func f() -> Int { fatalError() }
 }
+
+// Recursive conformances should have finite output.
+
+// CHECK-LABEL: StructDecl name=Recur
+// CHECK-NEXT: (normal_conformance type=Recur protocol=P2
+// CHECK-NEXT:   (assoc_type req=A type=Recur.A)
+// CHECK-NEXT:   (assoc_type req=B type=Recur.B)
+// CHECK-NEXT:   (normal_conformance type=Recur protocol=P2 (details printed above))
+// CHECK-NEXT:   (normal_conformance type=Recur protocol=P2 (details printed above)))
+struct Recur: P2 {
+    typealias A = Recur
+    typealias B = Recur
+}
+
+// The full information about a conformance doesn't need to be printed twice.
+
+// CHECK-LABEL: StructDecl name=NonRecur
+// CHECK-NEXT: (normal_conformance type=NonRecur protocol=P2
+// CHECK-NEXT:   (assoc_type req=A type=NonRecur.A)
+// CHECK-NEXT:   (assoc_type req=B type=NonRecur.B)
+// CHECK-NEXT:   (normal_conformance type=Recur protocol=P2
+// CHECK-NEXT:     (assoc_type req=A type=Recur.A)
+// CHECK-NEXT:     (assoc_type req=B type=Recur.B)
+// CHECK-NEXT:     (normal_conformance type=Recur protocol=P2 (details printed above))
+// CHECK-NEXT:     (normal_conformance type=Recur protocol=P2 (details printed above)))
+// CHECK-NEXT:   (normal_conformance type=Recur protocol=P2 (details printed above)))
+struct NonRecur: P2 {
+    typealias A = Recur
+    typealias B = Recur
+}
+
+// Conditional conformance.
+
+struct Generic<T> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=Generic<T>
+// CHECK-NEXT: (normal_conformance type=Generic<T> protocol=P1
+// CHECK-NEXT:   (assoc_type req=A type=Generic<T>.A)
+// CHECK-NEXT:   (value req=f() witness=main.(file).Generic.f()@{{.*}})
+// CHECK-NEXT:   conforms_to: T P1)
+extension Generic: P1 where T: P1 {
+    typealias A = T
+    func f() -> T { fatalError() }
+}
+
+
+// Satisfying associated types with requirements with generic params
+class Super<T> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=Super<T>
+// CHECK-NEXT: (normal_conformance type=Super<T> protocol=P2
+// CHECK-NEXT:   (assoc_type req=A type=Super<T>.A)
+// CHECK-NEXT:   (assoc_type req=B type=Super<T>.B)
+// CHECK-NEXT:   (abstract_conformance protocol=P2)
+// CHECK:        (abstract_conformance protocol=P2)
+// CHECK:        conforms_to: T P2)
+extension Super: P2 where T: P2 {
+    typealias A = T
+    typealias B = T
+}
+
+// Inherited/specialized conformances.
+// CHECK-LABEL: ClassDecl name=Sub
+// CHECK-NEXT: (inherited_conformance type=Sub protocol=P2
+// CHECK-NEXT:   (specialized_conformance type=Super<Recur> protocol=P2
+// CHECK-NEXT: Generic signature: <T where T : P2>
+// CHECK-NEXT: Substitutions:
+// CHECK-NEXT:   T -> Recur
+// CHECK:      Conformance map:
+// CHECK-NEXT:   T -> (normal_conformance type=Recur protocol=P2
+// CHECK-NEXT:   (assoc_type req=A type=Recur.A)
+// CHECK-NEXT:   (assoc_type req=B type=Recur.B)
+// CHECK-NEXT:   (normal_conformance type=Recur protocol=P2 (details printed above))
+// CHECK-NEXT:   (normal_conformance type=Recur protocol=P2 (details printed above)))
+// CHECK-NEXT:     conforms_to: Recur P2
+// CHECK-NEXT:     (normal_conformance type=Super<T> protocol=P2
+// CHECK-NEXT:       (assoc_type req=A type=Super<T>.A)
+// CHECK-NEXT:       (assoc_type req=B type=Super<T>.B)
+// CHECK-NEXT:       (abstract_conformance protocol=P2)
+// CHECK:            (abstract_conformance protocol=P2)
+// CHECK:            conforms_to: T P2)))
+class Sub: Super<Recur> {}

--- a/test/Driver/debug-generic-signatures.swift
+++ b/test/Driver/debug-generic-signatures.swift
@@ -75,15 +75,16 @@ extension Generic: P1 where T: P1 {
 
 
 // Satisfying associated types with requirements with generic params
-class Super<T> {}
-// CHECK-LABEL: ExtensionDecl line={{.*}} base=Super<T>
-// CHECK-NEXT: (normal_conformance type=Super<T> protocol=P2
-// CHECK-NEXT:   (assoc_type req=A type=Super<T>.A)
-// CHECK-NEXT:   (assoc_type req=B type=Super<T>.B)
+class Super<T, U> {}
+// CHECK-LABEL: ExtensionDecl line={{.*}} base=Super<T, U>
+// CHECK-NEXT: (normal_conformance type=Super<T, U> protocol=P2
+// CHECK-NEXT:   (assoc_type req=A type=Super<T, U>.A)
+// CHECK-NEXT:   (assoc_type req=B type=Super<T, U>.B)
 // CHECK-NEXT:   (abstract_conformance protocol=P2)
 // CHECK:        (abstract_conformance protocol=P2)
-// CHECK:        conforms_to: T P2)
-extension Super: P2 where T: P2 {
+// CHECK:        conforms_to: T P2
+// CHECK:        conforms_to: U P2)
+extension Super: P2 where T: P2, U: P2 {
     typealias A = T
     typealias B = T
 }
@@ -91,21 +92,29 @@ extension Super: P2 where T: P2 {
 // Inherited/specialized conformances.
 // CHECK-LABEL: ClassDecl name=Sub
 // CHECK-NEXT: (inherited_conformance type=Sub protocol=P2
-// CHECK-NEXT:   (specialized_conformance type=Super<Recur> protocol=P2
-// CHECK-NEXT: Generic signature: <T where T : P2>
-// CHECK-NEXT: Substitutions:
-// CHECK-NEXT:   T -> Recur
-// CHECK:      Conformance map:
-// CHECK-NEXT:   T -> (normal_conformance type=Recur protocol=P2
-// CHECK-NEXT:   (assoc_type req=A type=Recur.A)
-// CHECK-NEXT:   (assoc_type req=B type=Recur.B)
-// CHECK-NEXT:   (normal_conformance type=Recur protocol=P2 (details printed above))
-// CHECK-NEXT:   (normal_conformance type=Recur protocol=P2 (details printed above)))
+// CHECK-NEXT:   (specialized_conformance type=Super<NonRecur, Recur> protocol=P2
+// CHECK-NEXT:      (substitution_map generic_signature=<T, U where T : P2, U : P2>
+// CHECK-NEXT:         (substitution T -> NonRecur)
+// CHECK-NEXT:         (substitution U -> Recur)
+// CHECK-NEXT:         (conformance type=T
+// CHECK-NEXT:            (normal_conformance type=NonRecur protocol=P2
+// CHECK-NEXT:              (assoc_type req=A type=NonRecur.A)
+// CHECK-NEXT:              (assoc_type req=B type=NonRecur.B)
+// CHECK-NEXT:              (normal_conformance type=Recur protocol=P2
+// CHECK-NEXT:                (assoc_type req=A type=Recur.A)
+// CHECK-NEXT:                (assoc_type req=B type=Recur.B)
+// CHECK-NEXT:                (normal_conformance type=Recur protocol=P2 (details printed above))
+// CHECK-NEXT:                (normal_conformance type=Recur protocol=P2 (details printed above)))
+// CHECK-NEXT:              (normal_conformance type=Recur protocol=P2 (details printed above))))
+// CHECK-NEXT:         (conformance type=U
+// CHECK-NEXT:            (normal_conformance type=Recur protocol=P2 (details printed above))))
+// CHECK-NEXT:     conforms_to: NonRecur P2
 // CHECK-NEXT:     conforms_to: Recur P2
-// CHECK-NEXT:     (normal_conformance type=Super<T> protocol=P2
-// CHECK-NEXT:       (assoc_type req=A type=Super<T>.A)
-// CHECK-NEXT:       (assoc_type req=B type=Super<T>.B)
+// CHECK-NEXT:     (normal_conformance type=Super<T, U> protocol=P2
+// CHECK-NEXT:       (assoc_type req=A type=Super<T, U>.A)
+// CHECK-NEXT:       (assoc_type req=B type=Super<T, U>.B)
 // CHECK-NEXT:       (abstract_conformance protocol=P2)
 // CHECK:            (abstract_conformance protocol=P2)
-// CHECK:            conforms_to: T P2)))
-class Sub: Super<Recur> {}
+// CHECK:            conforms_to: T P2
+// CHECK:            conforms_to: U P2)))
+class Sub: Super<NonRecur, Recur> {}

--- a/test/Driver/debug-generic-signatures.swift
+++ b/test/Driver/debug-generic-signatures.swift
@@ -33,7 +33,7 @@ protocol P3 {
 
 // CHECK-LABEL: StructDecl name=Basic
 // CHECK: (normal_conformance type=Basic protocol=P1
-// CHECK-NEXT: (assoc_type req=A type=Basic.A)
+// CHECK-NEXT: (assoc_type req=A type=Int)
 // CHECK-NEXT: (value req=f() witness=main.(file).Basic.f()@{{.*}}))
 struct Basic: P1 {
     typealias A = Int
@@ -44,8 +44,8 @@ struct Basic: P1 {
 
 // CHECK-LABEL: StructDecl name=Recur
 // CHECK-NEXT: (normal_conformance type=Recur protocol=P2
-// CHECK-NEXT:   (assoc_type req=A type=Recur.A)
-// CHECK-NEXT:   (assoc_type req=B type=Recur.B)
+// CHECK-NEXT:   (assoc_type req=A type=Recur)
+// CHECK-NEXT:   (assoc_type req=B type=Recur)
 // CHECK-NEXT:   (normal_conformance type=Recur protocol=P2 (details printed above))
 // CHECK-NEXT:   (normal_conformance type=Recur protocol=P2 (details printed above)))
 struct Recur: P2 {
@@ -57,11 +57,11 @@ struct Recur: P2 {
 
 // CHECK-LABEL: StructDecl name=NonRecur
 // CHECK-NEXT: (normal_conformance type=NonRecur protocol=P2
-// CHECK-NEXT:   (assoc_type req=A type=NonRecur.A)
-// CHECK-NEXT:   (assoc_type req=B type=NonRecur.B)
+// CHECK-NEXT:   (assoc_type req=A type=Recur)
+// CHECK-NEXT:   (assoc_type req=B type=Recur)
 // CHECK-NEXT:   (normal_conformance type=Recur protocol=P2
-// CHECK-NEXT:     (assoc_type req=A type=Recur.A)
-// CHECK-NEXT:     (assoc_type req=B type=Recur.B)
+// CHECK-NEXT:     (assoc_type req=A type=Recur)
+// CHECK-NEXT:     (assoc_type req=B type=Recur)
 // CHECK-NEXT:     (normal_conformance type=Recur protocol=P2 (details printed above))
 // CHECK-NEXT:     (normal_conformance type=Recur protocol=P2 (details printed above)))
 // CHECK-NEXT:   (normal_conformance type=Recur protocol=P2 (details printed above)))
@@ -75,7 +75,7 @@ struct NonRecur: P2 {
 struct Generic<T> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Generic<T>
 // CHECK-NEXT: (normal_conformance type=Generic<T> protocol=P1
-// CHECK-NEXT:   (assoc_type req=A type=Generic<T>.A)
+// CHECK-NEXT:   (assoc_type req=A type=T)
 // CHECK-NEXT:   (value req=f() witness=main.(file).Generic.f()@{{.*}})
 // CHECK-NEXT:   conforms_to: T P1)
 extension Generic: P1 where T: P1 {
@@ -88,8 +88,8 @@ extension Generic: P1 where T: P1 {
 class Super<T, U> {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=Super<T, U>
 // CHECK-NEXT: (normal_conformance type=Super<T, U> protocol=P2
-// CHECK-NEXT:   (assoc_type req=A type=Super<T, U>.A)
-// CHECK-NEXT:   (assoc_type req=B type=Super<T, U>.B)
+// CHECK-NEXT:   (assoc_type req=A type=T)
+// CHECK-NEXT:   (assoc_type req=B type=T)
 // CHECK-NEXT:   (abstract_conformance protocol=P2)
 // CHECK-NEXT:   (abstract_conformance protocol=P2)
 // CHECK-NEXT:   conforms_to: T P2
@@ -108,11 +108,11 @@ extension Super: P2 where T: P2, U: P2 {
 // CHECK-NEXT:         (substitution U -> Recur)
 // CHECK-NEXT:         (conformance type=T
 // CHECK-NEXT:            (normal_conformance type=NonRecur protocol=P2
-// CHECK-NEXT:              (assoc_type req=A type=NonRecur.A)
-// CHECK-NEXT:              (assoc_type req=B type=NonRecur.B)
+// CHECK-NEXT:              (assoc_type req=A type=Recur)
+// CHECK-NEXT:              (assoc_type req=B type=Recur)
 // CHECK-NEXT:              (normal_conformance type=Recur protocol=P2
-// CHECK-NEXT:                (assoc_type req=A type=Recur.A)
-// CHECK-NEXT:                (assoc_type req=B type=Recur.B)
+// CHECK-NEXT:                (assoc_type req=A type=Recur)
+// CHECK-NEXT:                (assoc_type req=B type=Recur)
 // CHECK-NEXT:                (normal_conformance type=Recur protocol=P2 (details printed above))
 // CHECK-NEXT:                (normal_conformance type=Recur protocol=P2 (details printed above)))
 // CHECK-NEXT:              (normal_conformance type=Recur protocol=P2 (details printed above))))
@@ -121,8 +121,8 @@ extension Super: P2 where T: P2, U: P2 {
 // CHECK-NEXT:     conforms_to: NonRecur P2
 // CHECK-NEXT:     conforms_to: Recur P2
 // CHECK-NEXT:     (normal_conformance type=Super<T, U> protocol=P2
-// CHECK-NEXT:       (assoc_type req=A type=Super<T, U>.A)
-// CHECK-NEXT:       (assoc_type req=B type=Super<T, U>.B)
+// CHECK-NEXT:       (assoc_type req=A type=T)
+// CHECK-NEXT:       (assoc_type req=B type=T)
 // CHECK-NEXT:       (abstract_conformance protocol=P2)
 // CHECK-NEXT:       (abstract_conformance protocol=P2)
 // CHECK-NEXT:       conforms_to: T P2
@@ -134,7 +134,7 @@ class Sub: Super<NonRecur, Recur> {}
 
 // CHECK-LABEL: StructDecl name=RecurGeneric
 // CHECK-NEXT: (normal_conformance type=RecurGeneric<T> protocol=P3
-// CHECK-NEXT:   (assoc_type req=A type=RecurGeneric<T>.A)
+// CHECK-NEXT:   (assoc_type req=A type=RecurGeneric<T>)
 // CHECK-NEXT:   (normal_conformance type=RecurGeneric<T> protocol=P3 (details printed above)))
 struct RecurGeneric<T: P3>: P3 {
     typealias A = RecurGeneric<T>
@@ -142,14 +142,14 @@ struct RecurGeneric<T: P3>: P3 {
 
 // CHECK-LABEL: StructDecl name=Specialize
 // CHECK-NEXT: (normal_conformance type=Specialize protocol=P3
-// CHECK-NEXT:   (assoc_type req=A type=Specialize.A)
+// CHECK-NEXT:   (assoc_type req=A type=RecurGeneric<Specialize>)
 // CHECK-NEXT:   (specialized_conformance type=Specialize.A protocol=P3
 // CHECK-NEXT:     (substitution_map generic_signature=<T where T : P3>
 // CHECK-NEXT:       (substitution T -> Specialize)
 // CHECK-NEXT:       (conformance type=T
 // CHECK-NEXT:         (normal_conformance type=Specialize protocol=P3 (details printed above))))
 // CHECK-NEXT:     (normal_conformance type=RecurGeneric<T> protocol=P3
-// CHECK-NEXT:       (assoc_type req=A type=RecurGeneric<T>.A)
+// CHECK-NEXT:       (assoc_type req=A type=RecurGeneric<T>)
 // CHECK-NEXT:       (normal_conformance type=RecurGeneric<T> protocol=P3 (details printed above)))))
 struct Specialize: P3 {
     typealias A = RecurGeneric<Specialize>

--- a/test/Driver/debug-generic-signatures.swift
+++ b/test/Driver/debug-generic-signatures.swift
@@ -81,9 +81,9 @@ class Super<T, U> {}
 // CHECK-NEXT:   (assoc_type req=A type=Super<T, U>.A)
 // CHECK-NEXT:   (assoc_type req=B type=Super<T, U>.B)
 // CHECK-NEXT:   (abstract_conformance protocol=P2)
-// CHECK:        (abstract_conformance protocol=P2)
-// CHECK:        conforms_to: T P2
-// CHECK:        conforms_to: U P2)
+// CHECK-NEXT:   (abstract_conformance protocol=P2)
+// CHECK-NEXT:   conforms_to: T P2
+// CHECK-NEXT:   conforms_to: U P2)
 extension Super: P2 where T: P2, U: P2 {
     typealias A = T
     typealias B = T
@@ -114,7 +114,7 @@ extension Super: P2 where T: P2, U: P2 {
 // CHECK-NEXT:       (assoc_type req=A type=Super<T, U>.A)
 // CHECK-NEXT:       (assoc_type req=B type=Super<T, U>.B)
 // CHECK-NEXT:       (abstract_conformance protocol=P2)
-// CHECK:            (abstract_conformance protocol=P2)
-// CHECK:            conforms_to: T P2
-// CHECK:            conforms_to: U P2)))
+// CHECK-NEXT:       (abstract_conformance protocol=P2)
+// CHECK-NEXT:       conforms_to: T P2
+// CHECK-NEXT:       conforms_to: U P2)))
 class Sub: Super<NonRecur, Recur> {}

--- a/test/Driver/dump-parse.swift
+++ b/test/Driver/dump-parse.swift
@@ -54,3 +54,10 @@ enum TrailingSemi {
     return y;
   };
 };
+
+// The substitution map for a declref should be relatively unobtrustive.
+// CHECK-AST-LABEL:   (func_decl "generic(_:)" <T : Hashable> interface type='<T where T : Hashable> (T) -> ()' access=internal captures=(<generic> )
+func generic<T: Hashable>(_: T) {}
+// CHECK-AST:       (pattern_binding_decl
+// CHECK-AST:         (declref_expr type='(Int) -> ()' location={{.*}} range={{.*}} decl=main.(file).generic@{{.*}} [with (substitution_map generic_signature=<T where T : Hashable> (substitution T -> Int))] function_ref=unapplied))
+let _: (Int) -> () = generic

--- a/test/Generics/conditional_conformances.swift
+++ b/test/Generics/conditional_conformances.swift
@@ -217,6 +217,8 @@ struct InheritEqual<T> {}
 extension InheritEqual: P2 where T: P1 {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritEqual<T>
 // CHECK-NEXT:  (normal_conformance type=InheritEqual<T> protocol=P5
+// CHECK-NEXT:    (normal_conformance type=InheritEqual<T> protocol=P2
+// CHECK-NEXT:      conforms_to: T P1)
 // CHECK-NEXT:    conforms_to: T P1)
 extension InheritEqual: P5 where T: P1 {}
 func inheritequal_good<U: P1>(_: U) {
@@ -249,6 +251,8 @@ struct InheritMore<T> {}
 extension InheritMore: P2 where T: P1 {}
 // CHECK-LABEL: ExtensionDecl line={{.*}} base=InheritMore<T>
 // CHECK-NEXT:  (normal_conformance type=InheritMore<T> protocol=P5
+// CHECK-NEXT:    (normal_conformance type=InheritMore<T> protocol=P2
+// CHECK-NEXT:      conforms_to: T P1)
 // CHECK-NEXT:    conforms_to: T P4)
 extension InheritMore: P5 where T: P4 {}
 func inheritequal_good_good<U: P4>(_: U) {


### PR DESCRIPTION
This stops recursive conformances from printing forever, and replaces them with something like:

```swift
protocol P { associatedtype A: P }
struct X: P { typealias A = X }
/*
(normal_conformance type=X protocol=P
  (assoc_type req=A type=X)
  (normal_conformance type=X protocol=P (details printed above)))
*/
```

(Also, notice that the above says `(assoc_type req=A type=X)` with the `type` desugared to `X`, whereas previously it would print the sugared version `X.A` because of the `typealias`.)

This also makes substitution map printed lisp-style and indent-awarely... nice for specialised conformances:

```swift
protocol P {}
struct X: P {}
class Super<T: P>: P {}
class Sub: Super<X> {}
/*
(inherited_conformance type=Sub protocol=P
  (specialized_conformance type=Super<X> protocol=P
    (substitution_map generic_signature=<T where T : P>
      (substitution T -> X)
      (conformance type=T
        (normal_conformance type=X protocol=P)))
    (normal_conformance type=Super<T> protocol=P)))
*/
```

And, lastly, minimises the size of substitution maps inside expressions (which occur on decl refs pointing to something generic):

```swift
func generic<T: Hashable>(_: T) {}
let _: (Int) -> () = generic
/*
...
(declref_expr type='(Int) -> ()' ... [with (substitution_map generic_signature=<T where T : Hashable> (substitution T -> Int))] function_ref=unapplied))
*/
```


Fixes rdar://problem/40074968.