### PR TITLE
[ClangImporter] Take isCompatibilityAlias() into account in interface printing

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2455,6 +2455,15 @@ void ClangModuleUnit::getTopLevelDecls(SmallVectorImpl<Decl*> &results) const {
         results.push_back(extension);
     }
 
+    auto findEnclosingExtension = [](Decl *importedDecl) -> ExtensionDecl * {
+      for (auto importedDC = importedDecl->getDeclContext();
+           !importedDC->isModuleContext();
+           importedDC = importedDC->getParent()) {
+        if (auto ext = dyn_cast<ExtensionDecl>(importedDC))
+          return ext;
+      }
+      return nullptr;
+    };
     // Retrieve all of the globals that will be mapped to members.
 
     // FIXME: Since we don't represent Clang submodules as Swift
@@ -2462,17 +2471,30 @@ void ClangModuleUnit::getTopLevelDecls(SmallVectorImpl<Decl*> &results) const {
     llvm::SmallPtrSet<ExtensionDecl *, 8> knownExtensions;
     for (auto entry : lookupTable->allGlobalsAsMembers()) {
       auto decl = entry.get<clang::NamedDecl *>();
-      auto importedDecl =
-          owner.importDecl(decl, owner.CurrentVersion);
+      auto importedDecl = owner.importDecl(decl, owner.CurrentVersion);
       if (!importedDecl) continue;
 
       // Find the enclosing extension, if there is one.
-      ExtensionDecl *ext = nullptr;
-      for (auto importedDC = importedDecl->getDeclContext();
-           !importedDC->isModuleContext();
-           importedDC = importedDC->getParent()) {
-        ext = dyn_cast<ExtensionDecl>(importedDC);
-        if (ext) break;
+      ExtensionDecl *ext = findEnclosingExtension(importedDecl);
+
+      if (!ext) {
+        // If this is compatibility typealias and it's not in extension, the
+        // canonical extension may exists in another extension.
+        if (auto alias = dyn_cast_or_null<TypeAliasDecl>(importedDecl)) {
+          if (alias->isCompatibilityAlias()) {
+            auto aliasedTy = alias->getUnderlyingTypeLoc().getType();
+            
+            // Note: We can't use getAnyGeneric() here because `aliasedTy`
+            // might be typealias.
+            if (auto Ty = dyn_cast<NameAliasType>(aliasedTy.getPointer()))
+              importedDecl = Ty->getDecl();
+            else if (auto Ty = dyn_cast<AnyGenericType>(aliasedTy.getPointer()))
+              importedDecl = Ty->getDecl();
+            if (!importedDecl) continue;
+
+            ext = findEnclosingExtension(importedDecl);
+          }
+        }
       }
       if (!ext) continue;
 

--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2479,8 +2479,8 @@ void ClangModuleUnit::getTopLevelDecls(SmallVectorImpl<Decl*> &results) const {
       if (ext && knownExtensions.insert(ext).second)
         results.push_back(ext);
 
-      // If this is a compatibility typealias, the canonical extension may
-      // exists in another extension.
+      // If this is a compatibility typealias, the canonical type declaration
+      // may exist in another extension.
       auto alias = dyn_cast<TypeAliasDecl>(importedDecl);
       if (!alias || !alias->isCompatibilityAlias()) continue;
 

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -386,35 +386,6 @@ static bool isNSDictionaryMethod(const clang::ObjCMethodDecl *MD,
   return true;
 }
 
-void ClangImporter::Implementation::forEachDistinctName(
-    const clang::NamedDecl *decl,
-    llvm::function_ref<bool(ImportedName, ImportNameVersion)> action) {
-  using ImportNameKey = std::pair<DeclName, EffectiveClangContext>;
-  SmallVector<ImportNameKey, 8> seenNames;
-
-  ImportedName newName = importFullName(decl, CurrentVersion);
-  ImportNameKey key(newName, newName.getEffectiveContext());
-  if (action(newName, CurrentVersion))
-    seenNames.push_back(key);
-
-  CurrentVersion.forEachOtherImportNameVersion(
-      [&](ImportNameVersion nameVersion) {
-    // Check to see if the name is different.
-    ImportedName newName = importFullName(decl, nameVersion);
-    ImportNameKey key(newName, newName.getEffectiveContext());
-    bool seen = llvm::any_of(seenNames,
-                             [&key](const ImportNameKey &existing) -> bool {
-      if (key.first != existing.first)
-        return false;
-      return key.second.equalsWithoutResolving(existing.second);
-    });
-    if (seen)
-      return;
-    if (action(newName, nameVersion))
-      seenNames.push_back(key);
-  });
-}
-
 // Build the init(rawValue:) initializer for an imported NS_ENUM.
 //   enum NSSomeEnum: RawType {
 //     init?(rawValue: RawType) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -2175,7 +2175,9 @@ namespace {
         if (canonicalVersion != getActiveSwiftVersion()) {
           auto activeName = Impl.importFullName(D, getActiveSwiftVersion());
           if (activeName &&
-              activeName.getDeclName() == canonicalName.getDeclName()) {
+              activeName.getDeclName() == canonicalName.getDeclName() &&
+              activeName.getEffectiveContext().equalsWithoutResolving(
+                  canonicalName.getEffectiveContext())) {
             return ImportedName();
           }
         }
@@ -2192,7 +2194,9 @@ namespace {
       if (!alternateName)
         return ImportedName();
 
-      if (alternateName.getDeclName() == canonicalName.getDeclName()) {
+      if (alternateName.getDeclName() == canonicalName.getDeclName() &&
+          alternateName.getEffectiveContext().equalsWithoutResolving(
+              canonicalName.getEffectiveContext())) {
         if (getVersion() == getActiveSwiftVersion()) {
           assert(canonicalVersion != getActiveSwiftVersion());
           return alternateName;

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -1779,6 +1779,40 @@ ImportedName NameImporter::importName(const clang::NamedDecl *decl,
   return res;
 }
 
+bool NameImporter::forEachDistinctImportName(
+    const clang::NamedDecl *decl, ImportNameVersion activeVersion,
+    llvm::function_ref<bool(ImportedName, ImportNameVersion)> action) {
+  using ImportNameKey = std::pair<DeclName, EffectiveClangContext>;
+  SmallVector<ImportNameKey, 8> seenNames;
+
+  ImportedName newName = importName(decl, activeVersion);
+  if (!newName)
+    return true;
+  ImportNameKey key(newName.getDeclName(), newName.getEffectiveContext());
+  if (action(newName, activeVersion))
+    seenNames.push_back(key);
+
+  activeVersion.forEachOtherImportNameVersion(
+      [&](ImportNameVersion nameVersion) {
+        // Check to see if the name is different.
+        ImportedName newName = importName(decl, nameVersion);
+        if (!newName)
+          return;
+        ImportNameKey key(newName.getDeclName(), newName.getEffectiveContext());
+
+        bool seen = llvm::any_of(
+            seenNames, [&key](const ImportNameKey &existing) -> bool {
+              return key.first == existing.first &&
+                     key.second.equalsWithoutResolving(existing.second);
+            });
+        if (seen)
+          return;
+        if (action(newName, nameVersion))
+          seenNames.push_back(key);
+      });
+  return false;
+}
+
 const InheritedNameSet *NameImporter::getAllPropertyNames(
                           clang::ObjCInterfaceDecl *classDecl,
                           bool forInstance) {
@@ -1846,4 +1880,3 @@ const InheritedNameSet *NameImporter::getAllPropertyNames(
 
   return known->second.get();
 }
-

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -334,6 +334,28 @@ public:
                           clang::DeclarationName preferredName =
                             clang::DeclarationName());
 
+  /// Attempts to import the name of \p decl with each possible
+  /// ImportNameVersion. \p action will be called with each unique name.
+  ///
+  /// In this case, "unique" means either the full name is distinct or the
+  /// effective context is distinct. This method does not attempt to handle
+  /// "unresolved" contexts in any special way---if one name references a
+  /// particular Clang declaration and the other has an unresolved context that
+  /// will eventually reference that declaration, the contexts will still be
+  /// considered distinct.
+  ///
+  /// If \p action returns false, the current name will \e not be added to the
+  /// set of seen names.
+  ///
+  /// The active name for \p activeVerion is always first, followed by the
+  /// other names in the order of
+  /// ImportNameVersion::forEachOtherImportNameVersion.
+  ///
+  /// Returns \c true if it fails to import name for the active version.
+  bool forEachDistinctImportName(
+      const clang::NamedDecl *decl, ImportNameVersion activeVersion,
+      llvm::function_ref<bool(ImportedName, ImportNameVersion)> action);
+
   /// Imports the name of the given Clang macro into Swift.
   Identifier importMacroName(const clang::IdentifierInfo *clangIdentifier,
                              const clang::MacroInfo *macro);

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1352,7 +1352,9 @@ public:
   void forEachDistinctName(
       const clang::NamedDecl *decl,
       llvm::function_ref<bool(importer::ImportedName,
-                              importer::ImportNameVersion)> action);
+                              importer::ImportNameVersion)> action) {
+    getNameImporter().forEachDistinctImportName(decl, CurrentVersion, action);
+  }
 
   /// Dump the Swift-specific name lookup tables we generate.
   void dumpSwiftLookupTables();

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1643,7 +1643,7 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
         if (version == currentVersion && importedName.isSubscriptAccessor()) {
           table.addEntry(DeclName(nameImporter.getContext(),
                                   DeclBaseName::createSubscript(),
-                                  ArrayRef<Identifier>()),
+                                  {Identifier()}),
                          named, importedName.getEffectiveContext());
         }
 

--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -1633,37 +1633,30 @@ void importer::addEntryToLookupTable(SwiftLookupTable &table,
   // If we have a name to import as, add this entry to the table.
   auto currentVersion =
       ImportNameVersion::fromOptions(nameImporter.getLangOpts());
-  if (auto importedName = nameImporter.importName(named, currentVersion)) {
-    SmallPtrSet<DeclName, 8> distinctNames;
-    distinctNames.insert(importedName.getDeclName());
-    table.addEntry(importedName.getDeclName(), named,
-                   importedName.getEffectiveContext());
+  auto failed = nameImporter.forEachDistinctImportName(
+      named, currentVersion,
+      [&](ImportedName importedName, ImportNameVersion version) {
+        table.addEntry(importedName.getDeclName(), named,
+                       importedName.getEffectiveContext());
 
-    // Also add the subscript entry, if needed.
-    if (importedName.isSubscriptAccessor())
-      table.addEntry(DeclName(nameImporter.getContext(),
-                              DeclBaseName::createSubscript(),
-                              ArrayRef<Identifier>()),
-                     named, importedName.getEffectiveContext());
+        // Also add the subscript entry, if needed.
+        if (version == currentVersion && importedName.isSubscriptAccessor()) {
+          table.addEntry(DeclName(nameImporter.getContext(),
+                                  DeclBaseName::createSubscript(),
+                                  ArrayRef<Identifier>()),
+                         named, importedName.getEffectiveContext());
+        }
 
-    currentVersion.forEachOtherImportNameVersion(
-        [&](ImportNameVersion alternateVersion) {
-      auto alternateName = nameImporter.importName(named, alternateVersion);
-      if (!alternateName)
+        return true;
+      });
+  if (failed) {
+    if (auto category = dyn_cast<clang::ObjCCategoryDecl>(named)) {
+      // If the category is invalid, don't add it.
+      if (category->isInvalidDecl())
         return;
-      // FIXME: What if the DeclNames are the same but the contexts are
-      // different?
-      if (distinctNames.insert(alternateName.getDeclName()).second) {
-        table.addEntry(alternateName.getDeclName(), named,
-                       alternateName.getEffectiveContext());
-      }
-    });
-  } else if (auto category = dyn_cast<clang::ObjCCategoryDecl>(named)) {
-    // If the category is invalid, don't add it.
-    if (category->isInvalidDecl())
-      return;
 
-    table.addCategory(category);
+      table.addCategory(category);
+    }
   }
 
   // Walk the members of any context that can have nested members.
@@ -1864,4 +1857,3 @@ SwiftNameLookupExtension::createExtensionReader(
   // Return the new reader.
   return std::move(tableReader);
 }
-

--- a/test/APINotes/Inputs/custom-modules/ObsoletedAPINotesTest.apinotes
+++ b/test/APINotes/Inputs/custom-modules/ObsoletedAPINotesTest.apinotes
@@ -2,9 +2,13 @@ Name: M
 Classes:
 - Name: FooID
   SwiftName: Foo_ID
+- Name: BarSub
+  SwiftName: BarContainerCanonical.Sub
 
 SwiftVersions:
 - Version: 4
   Classes:
   - Name: FooID
     SwiftName: FooID
+  - Name: BarSub
+    SwiftName: BarContainerOld.Sub

--- a/test/APINotes/Inputs/custom-modules/ObsoletedAPINotesTest.h
+++ b/test/APINotes/Inputs/custom-modules/ObsoletedAPINotesTest.h
@@ -1,3 +1,10 @@
 @import Foundation;
 @interface FooID: NSObject
 @end
+
+@interface BarContainerOld
+@end
+@interface BarContainerCanonical
+@end
+@interface BarSub
+@end

--- a/test/APINotes/obsoleted.swift
+++ b/test/APINotes/obsoleted.swift
@@ -6,3 +6,6 @@ import ObsoletedAPINotesTest
 
 let _: FooID // expected-error{{'FooID' has been renamed to 'Foo_ID'}}
 let _: Foo_ID
+
+let _: BarContainerOld.Sub // expected-error{{'Sub' has been renamed to 'BarContainerCanonical.Sub'}}
+let _: BarContainerCanonical.Sub

--- a/test/SourceKit/InterfaceGen/Inputs/mock-sdk/APINotesTests.framework/Headers/APINotesTests.apinotes
+++ b/test/SourceKit/InterfaceGen/Inputs/mock-sdk/APINotesTests.framework/Headers/APINotesTests.apinotes
@@ -5,14 +5,22 @@ Classes:
 - Name:      MemberToGlobal_Class_Payload
   SwiftName: MemberToGlobal_Class_Payload
 - Name:      MemberToMember_Class_Payload
-  SwiftName: MemberToMember_Class_Swift4.Payload
+  SwiftName: MemberToMember_Class_Swift4.PayloadFor4
+- Name:      MemberToMember_SameName_Class_Payload
+  SwiftName: MemberToMember_SameName_Class_Swift4.Payload
+- Name:      MemberToMember_SameContainer_Class_Payload
+  SwiftName: MemberToMember_SameContainer_Class_Container.PayloadFor4
 Typedefs:
 - Name:      GlobalToMember_Typedef_Payload
   SwiftName: GlobalToMember_Typedef_Container.Payload
 - Name:      MemberToGlobal_Typedef_Payload
   SwiftName: MemberToGlobal_Typedef_Payload
 - Name:      MemberToMember_Typedef_Payload
-  SwiftName: MemberToMember_Typedef_Swift4.Payload
+  SwiftName: MemberToMember_Typedef_Swift4.PayloadFor4
+- Name:      MemberToMember_SameName_Typedef_Payload
+  SwiftName: MemberToMember_SameName_Typedef_Swift4.Payload
+- Name:      MemberToMember_SameContainer_Typedef_Payload
+  SwiftName: MemberToMember_SameContainer_Typedef_Container.PayloadFor4
 SwiftVersions:
 - Version: 3
   Classes:
@@ -21,11 +29,19 @@ SwiftVersions:
   - Name:      MemberToGlobal_Class_Payload
     SwiftName: MemberToGlobal_Class_Container.Payload
   - Name:      MemberToMember_Class_Payload
-    SwiftName: MemberToMember_Class_Swift3.Payload
+    SwiftName: MemberToMember_Class_Swift3.PayloadFor3
+  - Name:      MemberToMember_SameContainer_Class_Payload
+    SwiftName: MemberToMember_SameContainer_Class_Container.PayloadFor3
+  - Name:      MemberToMember_SameName_Class_Payload
+    SwiftName: MemberToMember_SameName_Class_Swift3.Payload
   Typedefs:
   - Name:      GlobalToMember_Typedef_Payload
     SwiftName: GlobalToMember_Typedef_Payload
   - Name:      MemberToGlobal_Typedef_Payload
     SwiftName: MemberToGlobal_Typedef_Container.Payload
   - Name:      MemberToMember_Typedef_Payload
-    SwiftName: MemberToMember_Typedef_Swift3.Payload
+    SwiftName: MemberToMember_Typedef_Swift3.PayloadFor3
+  - Name:      MemberToMember_SameContainer_Typedef_Payload
+    SwiftName: MemberToMember_SameContainer_Typedef_Container.PayloadFor3
+  - Name:      MemberToMember_SameName_Typedef_Payload
+    SwiftName: MemberToMember_SameName_Typedef_Swift3.Payload

--- a/test/SourceKit/InterfaceGen/Inputs/mock-sdk/APINotesTests.framework/Headers/APINotesTests.apinotes
+++ b/test/SourceKit/InterfaceGen/Inputs/mock-sdk/APINotesTests.framework/Headers/APINotesTests.apinotes
@@ -1,0 +1,31 @@
+Name: APINotesTests
+Classes:
+- Name:      GlobalToMember_Class_Payload
+  SwiftName: GlobalToMember_Class_Container.Payload
+- Name:      MemberToGlobal_Class_Payload
+  SwiftName: MemberToGlobal_Class_Payload
+- Name:      MemberToMember_Class_Payload
+  SwiftName: MemberToMember_Class_Swift4.Payload
+Typedefs:
+- Name:      GlobalToMember_Typedef_Payload
+  SwiftName: GlobalToMember_Typedef_Container.Payload
+- Name:      MemberToGlobal_Typedef_Payload
+  SwiftName: MemberToGlobal_Typedef_Payload
+- Name:      MemberToMember_Typedef_Payload
+  SwiftName: MemberToMember_Typedef_Swift4.Payload
+SwiftVersions:
+- Version: 3
+  Classes:
+  - Name:      GlobalToMember_Class_Payload
+    SwiftName: GlobalToMember_Class_Payload
+  - Name:      MemberToGlobal_Class_Payload
+    SwiftName: MemberToGlobal_Class_Container.Payload
+  - Name:      MemberToMember_Class_Payload
+    SwiftName: MemberToMember_Class_Swift3.Payload
+  Typedefs:
+  - Name:      GlobalToMember_Typedef_Payload
+    SwiftName: GlobalToMember_Typedef_Payload
+  - Name:      MemberToGlobal_Typedef_Payload
+    SwiftName: MemberToGlobal_Typedef_Container.Payload
+  - Name:      MemberToMember_Typedef_Payload
+    SwiftName: MemberToMember_Typedef_Swift3.Payload

--- a/test/SourceKit/InterfaceGen/Inputs/mock-sdk/APINotesTests.framework/Headers/APINotesTests.h
+++ b/test/SourceKit/InterfaceGen/Inputs/mock-sdk/APINotesTests.framework/Headers/APINotesTests.h
@@ -1,0 +1,3 @@
+
+#import "Foo.h"
+#import "Decls.h"

--- a/test/SourceKit/InterfaceGen/Inputs/mock-sdk/APINotesTests.framework/Headers/Decls.h
+++ b/test/SourceKit/InterfaceGen/Inputs/mock-sdk/APINotesTests.framework/Headers/Decls.h
@@ -1,15 +1,25 @@
 @import Foundation;
 
+// ===-------------------------------------------------------------------------
+// class Payload
+// ===-------------------------------------------------------------------------
+
+// 3: Payload
+// 4: Namespace.Payload
 @interface GlobalToMember_Class_Container : NSObject
 @end
 @interface GlobalToMember_Class_Payload : NSObject
 @end
 
+// 3: Namespace.Payload
+// 4: Payload
 @interface MemberToGlobal_Class_Container : NSObject
 @end
 @interface MemberToGlobal_Class_Payload: NSObject
 @end
 
+// 3: Namespace_Swift3.PayloadFor3
+// 4: Namespace_Swift4.PayloadFor4
 @interface MemberToMember_Class_Swift3 : NSObject
 @end
 @interface MemberToMember_Class_Swift4 : NSObject
@@ -17,16 +27,56 @@
 @interface MemberToMember_Class_Payload : NSObject
 @end
 
+// 3: Namespace.PayloadFor3
+// 4: Namespace.PayloadFor4
+@interface MemberToMember_SameContainer_Class_Container : NSObject
+@end
+@interface MemberToMember_SameContainer_Class_Payload : NSObject
+@end
+
+// 3: Namespace_Swift3.Payload
+// 4: Namespace_Swift4.Payload
+@interface MemberToMember_SameName_Class_Swift3 : NSObject
+@end
+@interface MemberToMember_SameName_Class_Swift4 : NSObject
+@end
+@interface MemberToMember_SameName_Class_Payload : NSObject
+@end
+
+// ===-------------------------------------------------------------------------
+// typealias Payload
+// ===-------------------------------------------------------------------------
+
+// 3: Payload
+// 4: Namespace.Payload
 @interface GlobalToMember_Typedef_Container : NSObject
 @end
 typedef Foo* GlobalToMember_Typedef_Payload;
 
+// 3: Namespace.Payload
+// 4: Payload
 @interface MemberToGlobal_Typedef_Container : NSObject
 @end
 typedef Foo* MemberToGlobal_Typedef_Payload;
 
+// 3: Namespace_Swift3.PayloadFor3
+// 4: Namespace_Swift4.PayloadFor4
 @interface MemberToMember_Typedef_Swift3 : NSObject
 @end
 @interface MemberToMember_Typedef_Swift4 : NSObject
 @end
 typedef Foo* MemberToMember_Typedef_Payload;
+
+// 3: Namespace.PayloadFor3
+// 4: Namespace.PayloadFor4
+@interface MemberToMember_SameContainer_Typedef_Container : NSObject
+@end
+typedef Foo* MemberToMember_SameContainer_Typedef_Payload;
+
+// 3: Namespace_Swift3.Payload
+// 4: Namespace_Swift4.Payload
+@interface MemberToMember_SameName_Typedef_Swift3 : NSObject
+@end
+@interface MemberToMember_SameName_Typedef_Swift4 : NSObject
+@end
+typedef Foo* MemberToMember_SameName_Typedef_Payload;

--- a/test/SourceKit/InterfaceGen/Inputs/mock-sdk/APINotesTests.framework/Headers/Decls.h
+++ b/test/SourceKit/InterfaceGen/Inputs/mock-sdk/APINotesTests.framework/Headers/Decls.h
@@ -1,0 +1,32 @@
+@import Foundation;
+
+@interface GlobalToMember_Class_Container : NSObject
+@end
+@interface GlobalToMember_Class_Payload : NSObject
+@end
+
+@interface MemberToGlobal_Class_Container : NSObject
+@end
+@interface MemberToGlobal_Class_Payload: NSObject
+@end
+
+@interface MemberToMember_Class_Swift3 : NSObject
+@end
+@interface MemberToMember_Class_Swift4 : NSObject
+@end
+@interface MemberToMember_Class_Payload : NSObject
+@end
+
+@interface GlobalToMember_Typedef_Container : NSObject
+@end
+typedef Foo* GlobalToMember_Typedef_Payload;
+
+@interface MemberToGlobal_Typedef_Container : NSObject
+@end
+typedef Foo* MemberToGlobal_Typedef_Payload;
+
+@interface MemberToMember_Typedef_Swift3 : NSObject
+@end
+@interface MemberToMember_Typedef_Swift4 : NSObject
+@end
+typedef Foo* MemberToMember_Typedef_Payload;

--- a/test/SourceKit/InterfaceGen/Inputs/mock-sdk/APINotesTests.framework/Headers/Foo.h
+++ b/test/SourceKit/InterfaceGen/Inputs/mock-sdk/APINotesTests.framework/Headers/Foo.h
@@ -1,0 +1,4 @@
+@import Foundation;
+
+@interface Foo : NSObject
+@end

--- a/test/SourceKit/InterfaceGen/Inputs/mock-sdk/APINotesTests.framework/Modules/module.modulemap
+++ b/test/SourceKit/InterfaceGen/Inputs/mock-sdk/APINotesTests.framework/Modules/module.modulemap
@@ -1,0 +1,4 @@
+framework module APINotesTests {
+  umbrella header "APINotesTests.h"
+  export *
+}

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift
@@ -90,3 +90,10 @@ var x: FooClassBase
 // CHECK-IMPORT: 	  source.lang.swift.ref.module ()
 // CHECK-IMPORT-NEXT: FooHelper{{$}}
 // CHECK-IMPORT-NEXT: FooHelper{{$}}
+
+// RUN: %sourcekitd-test -req=interface-gen -module APINotesTests -- -swift-version 3 -F %S/Inputs/mock-sdk \
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource > %t.apinotes_swift3.response
+// RUN: diff -u %s.apinotes_swift3.response %t.apinotes_swift3.response
+// RUN: %sourcekitd-test -req=interface-gen -module APINotesTests -- -swift-version 4 -F %S/Inputs/mock-sdk \
+// RUN:         %mcp_opt -target %target-triple %clang-importer-sdk-nosource > %t.apinotes_swift4.response
+// RUN: diff -u %s.apinotes_swift4.response %t.apinotes_swift4.response

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift3.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift3.response
@@ -3,7 +3,12 @@ import Foundation
 
 open class Foo : NSObject {
 }
+// ===-------------------------------------------------------------------------
+// class Payload
+// ===-------------------------------------------------------------------------
 
+// 3: Payload
+// 4: Namespace.Payload
 open class GlobalToMember_Class_Container : NSObject {
 }
 public typealias GlobalToMember_Class_Payload = GlobalToMember_Class_Container.Payload
@@ -13,6 +18,8 @@ extension GlobalToMember_Class_Container {
     }
 }
 
+// 3: Namespace.Payload
+// 4: Payload
 open class MemberToGlobal_Class_Container : NSObject {
 }
 open class MemberToGlobal_Class_Payload : NSObject {
@@ -22,16 +29,51 @@ extension MemberToGlobal_Class_Container {
     public typealias Payload = MemberToGlobal_Class_Payload
 }
 
+// 3: Namespace_Swift3.PayloadFor3
+// 4: Namespace_Swift4.PayloadFor4
 open class MemberToMember_Class_Swift3 : NSObject {
 }
 open class MemberToMember_Class_Swift4 : NSObject {
 }
 extension MemberToMember_Class_Swift3 {
 
-    open class Payload : NSObject {
+    public typealias PayloadFor3 = MemberToMember_Class_Swift4.PayloadFor4
+}
+extension MemberToMember_Class_Swift4 {
+
+    open class PayloadFor4 : NSObject {
     }
 }
 
+// 3: Namespace.PayloadFor3
+// 4: Namespace.PayloadFor4
+open class MemberToMember_SameContainer_Class_Container : NSObject {
+}
+extension MemberToMember_SameContainer_Class_Container {
+
+    public typealias PayloadFor3 = MemberToMember_SameContainer_Class_Container.PayloadFor4
+
+    open class PayloadFor4 : NSObject {
+    }
+}
+
+// 3: Namespace_Swift3.Payload
+// 4: Namespace_Swift4.Payload
+open class MemberToMember_SameName_Class_Swift3 : NSObject {
+}
+open class MemberToMember_SameName_Class_Swift4 : NSObject {
+}
+extension MemberToMember_SameName_Class_Swift3 {
+
+    public typealias Payload = MemberToMember_SameName_Class_Swift4.Payload
+}
+
+// ===-------------------------------------------------------------------------
+// typealias Payload
+// ===-------------------------------------------------------------------------
+
+// 3: Payload
+// 4: Namespace.Payload
 open class GlobalToMember_Typedef_Container : NSObject {
 }
 public typealias GlobalToMember_Typedef_Payload = GlobalToMember_Typedef_Container.Payload
@@ -40,6 +82,8 @@ extension GlobalToMember_Typedef_Container {
     public typealias Payload = Foo
 }
 
+// 3: Namespace.Payload
+// 4: Payload
 open class MemberToGlobal_Typedef_Container : NSObject {
 }
 public typealias MemberToGlobal_Typedef_Payload = Foo
@@ -48,13 +92,41 @@ extension MemberToGlobal_Typedef_Container {
     public typealias Payload = MemberToGlobal_Typedef_Payload
 }
 
+// 3: Namespace_Swift3.PayloadFor3
+// 4: Namespace_Swift4.PayloadFor4
 open class MemberToMember_Typedef_Swift3 : NSObject {
 }
 open class MemberToMember_Typedef_Swift4 : NSObject {
 }
 extension MemberToMember_Typedef_Swift3 {
 
-    public typealias Payload = Foo
+    public typealias PayloadFor3 = MemberToMember_Typedef_Swift4.PayloadFor4
+}
+extension MemberToMember_Typedef_Swift4 {
+
+    public typealias PayloadFor4 = Foo
+}
+
+// 3: Namespace.PayloadFor3
+// 4: Namespace.PayloadFor4
+open class MemberToMember_SameContainer_Typedef_Container : NSObject {
+}
+extension MemberToMember_SameContainer_Typedef_Container {
+
+    public typealias PayloadFor3 = MemberToMember_SameContainer_Typedef_Container.PayloadFor4
+
+    public typealias PayloadFor4 = Foo
+}
+
+// 3: Namespace_Swift3.Payload
+// 4: Namespace_Swift4.Payload
+open class MemberToMember_SameName_Typedef_Swift3 : NSObject {
+}
+open class MemberToMember_SameName_Typedef_Swift4 : NSObject {
+}
+extension MemberToMember_SameName_Typedef_Swift3 {
+
+    public typealias Payload = MemberToMember_SameName_Typedef_Swift4.Payload
 }
 
 [
@@ -89,434 +161,934 @@ extension MemberToMember_Typedef_Swift3 {
     key.length: 8
   },
   {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 50,
+    key.length: 80
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 130,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 147,
+    key.length: 80
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 228,
+    key.length: 14
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 242,
+    key.length: 24
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 51,
+    key.offset: 266,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 56,
+    key.offset: 271,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 62,
+    key.offset: 277,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 95,
+    key.offset: 310,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 108,
+    key.offset: 323,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 115,
+    key.offset: 330,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 125,
+    key.offset: 340,
     key.length: 28
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 156,
+    key.offset: 371,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 187,
+    key.offset: 402,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 195,
+    key.offset: 410,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 205,
+    key.offset: 420,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 243,
+    key.offset: 458,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 248,
+    key.offset: 463,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 254,
+    key.offset: 469,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 264,
+    key.offset: 479,
     key.length: 8
   },
   {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 499,
+    key.length: 24
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 523,
+    key.length: 14
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 284,
+    key.offset: 537,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 289,
+    key.offset: 542,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 295,
+    key.offset: 548,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 328,
+    key.offset: 581,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 341,
+    key.offset: 594,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 346,
+    key.offset: 599,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 352,
+    key.offset: 605,
     key.length: 28
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 383,
+    key.offset: 636,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 396,
+    key.offset: 649,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 406,
+    key.offset: 659,
     key.length: 30
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 444,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 451,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 461,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 471,
-    key.length: 28
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 503,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 508,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 514,
-    key.length: 27
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 544,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 557,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 562,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 568,
-    key.length: 27
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 598,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 611,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 621,
-    key.length: 27
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 656,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 661,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 667,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 677,
-    key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 697,
-    key.length: 4
+    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 702,
-    key.length: 5
+    key.offset: 704,
+    key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 708,
-    key.length: 32
+    key.offset: 714,
+    key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 743,
-    key.length: 8
+    key.offset: 724,
+    key.length: 28
   },
   {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.kind: source.lang.swift.syntaxtype.comment,
     key.offset: 756,
-    key.length: 6
+    key.length: 35
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 763,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 773,
-    key.length: 30
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 806,
-    key.length: 32
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 839,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 847,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 857,
-    key.length: 32
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 791,
+    key.length: 35
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 897,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 904,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 914,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 924,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 931,
+    key.offset: 826,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 936,
+    key.offset: 831,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 942,
-    key.length: 32
+    key.offset: 837,
+    key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 977,
+    key.offset: 867,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 990,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 997,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1007,
-    key.length: 30
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1040,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1044,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1054,
-    key.length: 32
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1094,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1101,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1111,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1121,
-    key.length: 30
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1155,
+    key.offset: 880,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1160,
+    key.offset: 885,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1166,
-    key.length: 29
+    key.offset: 891,
+    key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 921,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 934,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 944,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 979,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 986,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 996,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1010,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1038,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1052,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1062,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1097,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1102,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1108,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1122,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 1142,
+    key.length: 28
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 1170,
+    key.length: 28
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 1198,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1211,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1216,
+    key.offset: 1203,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1222,
-    key.length: 29
+    key.offset: 1209,
+    key.length: 44
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1254,
+    key.offset: 1256,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1267,
+    key.offset: 1269,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1277,
-    key.length: 29
+    key.offset: 1279,
+    key.length: 44
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 1314,
+    key.offset: 1331,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1321,
+    key.offset: 1338,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1331,
+    key.offset: 1348,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1362,
+    key.length: 44
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1407,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1424,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1429,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1435,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1449,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 1469,
+    key.length: 31
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 1500,
+    key.length: 31
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1531,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1536,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1542,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1581,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1594,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1599,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1605,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1644,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1657,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1667,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1711,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1718,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1728,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1341,
+    key.offset: 1738,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1775,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 1786,
+    key.length: 80
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 1866,
+    key.length: 21
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 1887,
+    key.length: 80
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 1968,
+    key.length: 14
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 1982,
+    key.length: 24
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2006,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2011,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2017,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2052,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2065,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2072,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2082,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2115,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2148,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2156,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2166,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2206,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2213,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2223,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2233,
     key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 2240,
+    key.length: 24
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 2264,
+    key.length: 14
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2278,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2283,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2289,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2324,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2337,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2344,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2354,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2387,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2391,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2401,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2441,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2448,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2458,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2468,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 2502,
+    key.length: 35
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 2537,
+    key.length: 35
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2572,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2577,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2583,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2615,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2628,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2633,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2639,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2671,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2684,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2694,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2731,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2738,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2748,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2762,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2792,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2806,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2816,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2853,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2860,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2870,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2884,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 2891,
+    key.length: 28
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 2919,
+    key.length: 28
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2947,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2952,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2958,
+    key.length: 46
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3007,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3020,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3030,
+    key.length: 46
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 3084,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3091,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3101,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3115,
+    key.length: 46
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3162,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 3179,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3186,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3196,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3210,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 3217,
+    key.length: 31
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 3248,
+    key.length: 31
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 3279,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3284,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3290,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3331,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 3344,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3349,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3355,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3396,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3409,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3419,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 3465,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3472,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3482,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3492,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3531,
+    key.length: 7
   }
 ]
 [
@@ -534,144 +1106,281 @@ extension MemberToMember_Typedef_Swift3 {
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 95,
+    key.offset: 310,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 156,
+    key.offset: 371,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 187,
+    key.offset: 402,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 205,
+    key.offset: 420,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 264,
+    key.offset: 479,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 328,
+    key.offset: 581,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 383,
+    key.offset: 636,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 406,
+    key.offset: 659,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 471,
+    key.offset: 724,
     key.length: 28
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 544,
+    key.offset: 867,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 598,
+    key.offset: 921,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 621,
+    key.offset: 944,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 677,
+    key.offset: 1010,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1038,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1062,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1122,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 743,
+    key.offset: 1256,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 806,
-    key.length: 32
+    key.offset: 1279,
+    key.length: 44
   },
   {
-    key.kind: source.lang.swift.ref.typealias,
-    key.offset: 839,
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1362,
+    key.length: 44
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1407,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1449,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1581,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1644,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1667,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1738,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1775,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 857,
-    key.length: 32
-  },
-  {
-    key.kind: source.lang.swift.ref.class,
-    key.offset: 924,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.ref.class,
-    key.offset: 977,
+    key.offset: 2052,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1040,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.ref.class,
-    key.offset: 1054,
+    key.offset: 2115,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 1121,
+    key.offset: 2148,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 2166,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 2233,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 2324,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 2387,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 2401,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.ref.typealias,
+    key.offset: 2468,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1198,
+    key.offset: 2615,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1254,
+    key.offset: 2671,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1277,
+    key.offset: 2694,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 1341,
+    key.offset: 2762,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.ref.typealias,
+    key.offset: 2792,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 2816,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 2884,
     key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 3007,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 3030,
+    key.length: 46
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 3115,
+    key.length: 46
+  },
+  {
+    key.kind: source.lang.swift.ref.typealias,
+    key.offset: 3162,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 3210,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 3331,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 3396,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 3419,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 3492,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.ref.typealias,
+    key.offset: 3531,
+    key.length: 7
   }
 ]
 [
@@ -710,12 +1419,12 @@ extension MemberToMember_Typedef_Swift3 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "GlobalToMember_Class_Container",
-    key.offset: 56,
+    key.offset: 271,
     key.length: 51,
     key.runtime_name: "_TtC4main30GlobalToMember_Class_Container",
-    key.nameoffset: 62,
+    key.nameoffset: 277,
     key.namelength: 30,
-    key.bodyoffset: 105,
+    key.bodyoffset: 320,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -724,7 +1433,7 @@ extension MemberToMember_Typedef_Swift3 {
     ],
     key.attributes: [
       {
-        key.offset: 51,
+        key.offset: 266,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -732,7 +1441,7 @@ extension MemberToMember_Typedef_Swift3 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 95,
+        key.offset: 310,
         key.length: 8
       }
     ]
@@ -741,13 +1450,13 @@ extension MemberToMember_Typedef_Swift3 {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "GlobalToMember_Class_Payload",
-    key.offset: 115,
+    key.offset: 330,
     key.length: 79,
-    key.nameoffset: 125,
+    key.nameoffset: 340,
     key.namelength: 28,
     key.attributes: [
       {
-        key.offset: 108,
+        key.offset: 323,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -756,22 +1465,22 @@ extension MemberToMember_Typedef_Swift3 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "GlobalToMember_Class_Container",
-    key.offset: 195,
+    key.offset: 410,
     key.length: 87,
-    key.nameoffset: 205,
+    key.nameoffset: 420,
     key.namelength: 30,
-    key.bodyoffset: 237,
+    key.bodyoffset: 452,
     key.bodylength: 44,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "Payload",
-        key.offset: 248,
+        key.offset: 463,
         key.length: 32,
-        key.nameoffset: 254,
+        key.nameoffset: 469,
         key.namelength: 7,
-        key.bodyoffset: 274,
+        key.bodyoffset: 489,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -780,7 +1489,7 @@ extension MemberToMember_Typedef_Swift3 {
         ],
         key.attributes: [
           {
-            key.offset: 243,
+            key.offset: 458,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -788,7 +1497,7 @@ extension MemberToMember_Typedef_Swift3 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 264,
+            key.offset: 479,
             key.length: 8
           }
         ]
@@ -799,12 +1508,12 @@ extension MemberToMember_Typedef_Swift3 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Class_Container",
-    key.offset: 289,
+    key.offset: 542,
     key.length: 51,
     key.runtime_name: "_TtC4main30MemberToGlobal_Class_Container",
-    key.nameoffset: 295,
+    key.nameoffset: 548,
     key.namelength: 30,
-    key.bodyoffset: 338,
+    key.bodyoffset: 591,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -813,7 +1522,7 @@ extension MemberToMember_Typedef_Swift3 {
     ],
     key.attributes: [
       {
-        key.offset: 284,
+        key.offset: 537,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -821,7 +1530,7 @@ extension MemberToMember_Typedef_Swift3 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 328,
+        key.offset: 581,
         key.length: 8
       }
     ]
@@ -830,12 +1539,12 @@ extension MemberToMember_Typedef_Swift3 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Class_Payload",
-    key.offset: 346,
+    key.offset: 599,
     key.length: 49,
     key.runtime_name: "_TtC4main28MemberToGlobal_Class_Payload",
-    key.nameoffset: 352,
+    key.nameoffset: 605,
     key.namelength: 28,
-    key.bodyoffset: 393,
+    key.bodyoffset: 646,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -844,7 +1553,7 @@ extension MemberToMember_Typedef_Swift3 {
     ],
     key.attributes: [
       {
-        key.offset: 341,
+        key.offset: 594,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -852,7 +1561,7 @@ extension MemberToMember_Typedef_Swift3 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 383,
+        key.offset: 636,
         key.length: 8
       }
     ]
@@ -860,24 +1569,24 @@ extension MemberToMember_Typedef_Swift3 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToGlobal_Class_Container",
-    key.offset: 396,
+    key.offset: 649,
     key.length: 105,
-    key.nameoffset: 406,
+    key.nameoffset: 659,
     key.namelength: 30,
-    key.bodyoffset: 438,
+    key.bodyoffset: 691,
     key.bodylength: 62,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 451,
+        key.offset: 704,
         key.length: 48,
-        key.nameoffset: 461,
+        key.nameoffset: 714,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 444,
+            key.offset: 697,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -889,12 +1598,12 @@ extension MemberToMember_Typedef_Swift3 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Class_Swift3",
-    key.offset: 508,
+    key.offset: 831,
     key.length: 48,
     key.runtime_name: "_TtC4main27MemberToMember_Class_Swift3",
-    key.nameoffset: 514,
+    key.nameoffset: 837,
     key.namelength: 27,
-    key.bodyoffset: 554,
+    key.bodyoffset: 877,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -903,7 +1612,7 @@ extension MemberToMember_Typedef_Swift3 {
     ],
     key.attributes: [
       {
-        key.offset: 503,
+        key.offset: 826,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -911,7 +1620,7 @@ extension MemberToMember_Typedef_Swift3 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 544,
+        key.offset: 867,
         key.length: 8
       }
     ]
@@ -920,12 +1629,12 @@ extension MemberToMember_Typedef_Swift3 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Class_Swift4",
-    key.offset: 562,
+    key.offset: 885,
     key.length: 48,
     key.runtime_name: "_TtC4main27MemberToMember_Class_Swift4",
-    key.nameoffset: 568,
+    key.nameoffset: 891,
     key.namelength: 27,
-    key.bodyoffset: 608,
+    key.bodyoffset: 931,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -934,7 +1643,7 @@ extension MemberToMember_Typedef_Swift3 {
     ],
     key.attributes: [
       {
-        key.offset: 557,
+        key.offset: 880,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -942,7 +1651,7 @@ extension MemberToMember_Typedef_Swift3 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 598,
+        key.offset: 921,
         key.length: 8
       }
     ]
@@ -950,22 +1659,50 @@ extension MemberToMember_Typedef_Swift3 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Class_Swift3",
-    key.offset: 611,
-    key.length: 84,
-    key.nameoffset: 621,
+    key.offset: 934,
+    key.length: 117,
+    key.nameoffset: 944,
     key.namelength: 27,
-    key.bodyoffset: 650,
-    key.bodylength: 44,
+    key.bodyoffset: 973,
+    key.bodylength: 77,
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.typealias,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "PayloadFor3",
+        key.offset: 986,
+        key.length: 63,
+        key.nameoffset: 996,
+        key.namelength: 11,
+        key.attributes: [
+          {
+            key.offset: 979,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension,
+    key.name: "MemberToMember_Class_Swift4",
+    key.offset: 1052,
+    key.length: 88,
+    key.nameoffset: 1062,
+    key.namelength: 27,
+    key.bodyoffset: 1091,
+    key.bodylength: 48,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
-        key.name: "Payload",
-        key.offset: 661,
-        key.length: 32,
-        key.nameoffset: 667,
-        key.namelength: 7,
-        key.bodyoffset: 687,
+        key.name: "PayloadFor4",
+        key.offset: 1102,
+        key.length: 36,
+        key.nameoffset: 1108,
+        key.namelength: 11,
+        key.bodyoffset: 1132,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -974,7 +1711,7 @@ extension MemberToMember_Typedef_Swift3 {
         ],
         key.attributes: [
           {
-            key.offset: 656,
+            key.offset: 1097,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -982,7 +1719,7 @@ extension MemberToMember_Typedef_Swift3 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 677,
+            key.offset: 1122,
             key.length: 8
           }
         ]
@@ -992,13 +1729,13 @@ extension MemberToMember_Typedef_Swift3 {
   {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
-    key.name: "GlobalToMember_Typedef_Container",
-    key.offset: 702,
-    key.length: 53,
-    key.runtime_name: "_TtC4main32GlobalToMember_Typedef_Container",
-    key.nameoffset: 708,
-    key.namelength: 32,
-    key.bodyoffset: 753,
+    key.name: "MemberToMember_SameContainer_Class_Container",
+    key.offset: 1203,
+    key.length: 65,
+    key.runtime_name: "_TtC4main44MemberToMember_SameContainer_Class_Container",
+    key.nameoffset: 1209,
+    key.namelength: 44,
+    key.bodyoffset: 1266,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1007,7 +1744,7 @@ extension MemberToMember_Typedef_Swift3 {
     ],
     key.attributes: [
       {
-        key.offset: 697,
+        key.offset: 1198,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1015,7 +1752,186 @@ extension MemberToMember_Typedef_Swift3 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 743,
+        key.offset: 1256,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension,
+    key.name: "MemberToMember_SameContainer_Class_Container",
+    key.offset: 1269,
+    key.length: 198,
+    key.nameoffset: 1279,
+    key.namelength: 44,
+    key.bodyoffset: 1325,
+    key.bodylength: 141,
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.typealias,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "PayloadFor3",
+        key.offset: 1338,
+        key.length: 80,
+        key.nameoffset: 1348,
+        key.namelength: 11,
+        key.attributes: [
+          {
+            key.offset: 1331,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      },
+      {
+        key.kind: source.lang.swift.decl.class,
+        key.accessibility: source.lang.swift.accessibility.open,
+        key.name: "PayloadFor4",
+        key.offset: 1429,
+        key.length: 36,
+        key.nameoffset: 1435,
+        key.namelength: 11,
+        key.bodyoffset: 1459,
+        key.bodylength: 5,
+        key.inheritedtypes: [
+          {
+            key.name: "NSObject"
+          }
+        ],
+        key.attributes: [
+          {
+            key.offset: 1424,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ],
+        key.elements: [
+          {
+            key.kind: source.lang.swift.structure.elem.typeref,
+            key.offset: 1449,
+            key.length: 8
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToMember_SameName_Class_Swift3",
+    key.offset: 1536,
+    key.length: 57,
+    key.runtime_name: "_TtC4main36MemberToMember_SameName_Class_Swift3",
+    key.nameoffset: 1542,
+    key.namelength: 36,
+    key.bodyoffset: 1591,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 1531,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 1581,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToMember_SameName_Class_Swift4",
+    key.offset: 1599,
+    key.length: 57,
+    key.runtime_name: "_TtC4main36MemberToMember_SameName_Class_Swift4",
+    key.nameoffset: 1605,
+    key.namelength: 36,
+    key.bodyoffset: 1654,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 1594,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 1644,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension,
+    key.name: "MemberToMember_SameName_Class_Swift3",
+    key.offset: 1657,
+    key.length: 127,
+    key.nameoffset: 1667,
+    key.namelength: 36,
+    key.bodyoffset: 1705,
+    key.bodylength: 78,
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.typealias,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "Payload",
+        key.offset: 1718,
+        key.length: 64,
+        key.nameoffset: 1728,
+        key.namelength: 7,
+        key.attributes: [
+          {
+            key.offset: 1711,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "GlobalToMember_Typedef_Container",
+    key.offset: 2011,
+    key.length: 53,
+    key.runtime_name: "_TtC4main32GlobalToMember_Typedef_Container",
+    key.nameoffset: 2017,
+    key.namelength: 32,
+    key.bodyoffset: 2062,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 2006,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 2052,
         key.length: 8
       }
     ]
@@ -1024,13 +1940,13 @@ extension MemberToMember_Typedef_Swift3 {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "GlobalToMember_Typedef_Payload",
-    key.offset: 763,
+    key.offset: 2072,
     key.length: 83,
-    key.nameoffset: 773,
+    key.nameoffset: 2082,
     key.namelength: 30,
     key.attributes: [
       {
-        key.offset: 756,
+        key.offset: 2065,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -1039,24 +1955,24 @@ extension MemberToMember_Typedef_Swift3 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "GlobalToMember_Typedef_Container",
-    key.offset: 847,
+    key.offset: 2156,
     key.length: 82,
-    key.nameoffset: 857,
+    key.nameoffset: 2166,
     key.namelength: 32,
-    key.bodyoffset: 891,
+    key.bodyoffset: 2200,
     key.bodylength: 37,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 904,
+        key.offset: 2213,
         key.length: 23,
-        key.nameoffset: 914,
+        key.nameoffset: 2223,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 897,
+            key.offset: 2206,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1068,12 +1984,12 @@ extension MemberToMember_Typedef_Swift3 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Typedef_Container",
-    key.offset: 936,
+    key.offset: 2283,
     key.length: 53,
     key.runtime_name: "_TtC4main32MemberToGlobal_Typedef_Container",
-    key.nameoffset: 942,
+    key.nameoffset: 2289,
     key.namelength: 32,
-    key.bodyoffset: 987,
+    key.bodyoffset: 2334,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1082,7 +1998,7 @@ extension MemberToMember_Typedef_Swift3 {
     ],
     key.attributes: [
       {
-        key.offset: 931,
+        key.offset: 2278,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1090,7 +2006,7 @@ extension MemberToMember_Typedef_Swift3 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 977,
+        key.offset: 2324,
         key.length: 8
       }
     ]
@@ -1099,13 +2015,13 @@ extension MemberToMember_Typedef_Swift3 {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "MemberToGlobal_Typedef_Payload",
-    key.offset: 997,
+    key.offset: 2344,
     key.length: 46,
-    key.nameoffset: 1007,
+    key.nameoffset: 2354,
     key.namelength: 30,
     key.attributes: [
       {
-        key.offset: 990,
+        key.offset: 2337,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -1114,24 +2030,24 @@ extension MemberToMember_Typedef_Swift3 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToGlobal_Typedef_Container",
-    key.offset: 1044,
+    key.offset: 2391,
     key.length: 109,
-    key.nameoffset: 1054,
+    key.nameoffset: 2401,
     key.namelength: 32,
-    key.bodyoffset: 1088,
+    key.bodyoffset: 2435,
     key.bodylength: 64,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 1101,
+        key.offset: 2448,
         key.length: 50,
-        key.nameoffset: 1111,
+        key.nameoffset: 2458,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 1094,
+            key.offset: 2441,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1143,12 +2059,12 @@ extension MemberToMember_Typedef_Swift3 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Typedef_Swift3",
-    key.offset: 1160,
+    key.offset: 2577,
     key.length: 50,
     key.runtime_name: "_TtC4main29MemberToMember_Typedef_Swift3",
-    key.nameoffset: 1166,
+    key.nameoffset: 2583,
     key.namelength: 29,
-    key.bodyoffset: 1208,
+    key.bodyoffset: 2625,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1157,7 +2073,7 @@ extension MemberToMember_Typedef_Swift3 {
     ],
     key.attributes: [
       {
-        key.offset: 1155,
+        key.offset: 2572,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1165,7 +2081,7 @@ extension MemberToMember_Typedef_Swift3 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1198,
+        key.offset: 2615,
         key.length: 8
       }
     ]
@@ -1174,12 +2090,12 @@ extension MemberToMember_Typedef_Swift3 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Typedef_Swift4",
-    key.offset: 1216,
+    key.offset: 2633,
     key.length: 50,
     key.runtime_name: "_TtC4main29MemberToMember_Typedef_Swift4",
-    key.nameoffset: 1222,
+    key.nameoffset: 2639,
     key.namelength: 29,
-    key.bodyoffset: 1264,
+    key.bodyoffset: 2681,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1188,7 +2104,7 @@ extension MemberToMember_Typedef_Swift3 {
     ],
     key.attributes: [
       {
-        key.offset: 1211,
+        key.offset: 2628,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1196,7 +2112,7 @@ extension MemberToMember_Typedef_Swift3 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 1254,
+        key.offset: 2671,
         key.length: 8
       }
     ]
@@ -1204,24 +2120,217 @@ extension MemberToMember_Typedef_Swift3 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Typedef_Swift3",
-    key.offset: 1267,
-    key.length: 79,
-    key.nameoffset: 1277,
+    key.offset: 2684,
+    key.length: 121,
+    key.nameoffset: 2694,
     key.namelength: 29,
-    key.bodyoffset: 1308,
-    key.bodylength: 37,
+    key.bodyoffset: 2725,
+    key.bodylength: 79,
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.typealias,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "PayloadFor3",
+        key.offset: 2738,
+        key.length: 65,
+        key.nameoffset: 2748,
+        key.namelength: 11,
+        key.attributes: [
+          {
+            key.offset: 2731,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension,
+    key.name: "MemberToMember_Typedef_Swift4",
+    key.offset: 2806,
+    key.length: 83,
+    key.nameoffset: 2816,
+    key.namelength: 29,
+    key.bodyoffset: 2847,
+    key.bodylength: 41,
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.typealias,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "PayloadFor4",
+        key.offset: 2860,
+        key.length: 27,
+        key.nameoffset: 2870,
+        key.namelength: 11,
+        key.attributes: [
+          {
+            key.offset: 2853,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToMember_SameContainer_Typedef_Container",
+    key.offset: 2952,
+    key.length: 67,
+    key.runtime_name: "_TtC4main46MemberToMember_SameContainer_Typedef_Container",
+    key.nameoffset: 2958,
+    key.namelength: 46,
+    key.bodyoffset: 3017,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 2947,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 3007,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension,
+    key.name: "MemberToMember_SameContainer_Typedef_Container",
+    key.offset: 3020,
+    key.length: 195,
+    key.nameoffset: 3030,
+    key.namelength: 46,
+    key.bodyoffset: 3078,
+    key.bodylength: 136,
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.typealias,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "PayloadFor3",
+        key.offset: 3091,
+        key.length: 82,
+        key.nameoffset: 3101,
+        key.namelength: 11,
+        key.attributes: [
+          {
+            key.offset: 3084,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      },
+      {
+        key.kind: source.lang.swift.decl.typealias,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "PayloadFor4",
+        key.offset: 3186,
+        key.length: 27,
+        key.nameoffset: 3196,
+        key.namelength: 11,
+        key.attributes: [
+          {
+            key.offset: 3179,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToMember_SameName_Typedef_Swift3",
+    key.offset: 3284,
+    key.length: 59,
+    key.runtime_name: "_TtC4main38MemberToMember_SameName_Typedef_Swift3",
+    key.nameoffset: 3290,
+    key.namelength: 38,
+    key.bodyoffset: 3341,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 3279,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 3331,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToMember_SameName_Typedef_Swift4",
+    key.offset: 3349,
+    key.length: 59,
+    key.runtime_name: "_TtC4main38MemberToMember_SameName_Typedef_Swift4",
+    key.nameoffset: 3355,
+    key.namelength: 38,
+    key.bodyoffset: 3406,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 3344,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 3396,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension,
+    key.name: "MemberToMember_SameName_Typedef_Swift3",
+    key.offset: 3409,
+    key.length: 131,
+    key.nameoffset: 3419,
+    key.namelength: 38,
+    key.bodyoffset: 3459,
+    key.bodylength: 80,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 1321,
-        key.length: 23,
-        key.nameoffset: 1331,
+        key.offset: 3472,
+        key.length: 66,
+        key.nameoffset: 3482,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 1314,
+            key.offset: 3465,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift3.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift3.response
@@ -67,6 +67,11 @@ extension MemberToMember_SameName_Class_Swift3 {
 
     public typealias Payload = MemberToMember_SameName_Class_Swift4.Payload
 }
+extension MemberToMember_SameName_Class_Swift4 {
+
+    open class Payload : NSObject {
+    }
+}
 
 // ===-------------------------------------------------------------------------
 // typealias Payload
@@ -127,6 +132,10 @@ open class MemberToMember_SameName_Typedef_Swift4 : NSObject {
 extension MemberToMember_SameName_Typedef_Swift3 {
 
     public typealias Payload = MemberToMember_SameName_Typedef_Swift4.Payload
+}
+extension MemberToMember_SameName_Typedef_Swift4 {
+
+    public typealias Payload = Foo
 }
 
 [
@@ -626,469 +635,529 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     key.length: 7
   },
   {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1785,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1795,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1839,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1844,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1850,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1860,
+    key.length: 8
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1786,
+    key.offset: 1880,
     key.length: 80
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1866,
+    key.offset: 1960,
     key.length: 21
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1887,
+    key.offset: 1981,
     key.length: 80
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1968,
+    key.offset: 2062,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 1982,
+    key.offset: 2076,
     key.length: 24
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2006,
+    key.offset: 2100,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2011,
+    key.offset: 2105,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2017,
+    key.offset: 2111,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2052,
+    key.offset: 2146,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2065,
+    key.offset: 2159,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2072,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2082,
-    key.length: 30
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2115,
-    key.length: 32
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2148,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2156,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 2166,
-    key.length: 32
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2206,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2213,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2223,
+    key.offset: 2176,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2209,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2242,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2250,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2260,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2300,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2307,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2317,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2233,
+    key.offset: 2327,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2240,
+    key.offset: 2334,
     key.length: 24
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2264,
+    key.offset: 2358,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2278,
+    key.offset: 2372,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2283,
+    key.offset: 2377,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2289,
+    key.offset: 2383,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2324,
+    key.offset: 2418,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2337,
+    key.offset: 2431,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2344,
+    key.offset: 2438,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2354,
+    key.offset: 2448,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2387,
+    key.offset: 2481,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2391,
+    key.offset: 2485,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2401,
+    key.offset: 2495,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2441,
+    key.offset: 2535,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2448,
+    key.offset: 2542,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2458,
+    key.offset: 2552,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2468,
+    key.offset: 2562,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2502,
+    key.offset: 2596,
     key.length: 35
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2537,
+    key.offset: 2631,
     key.length: 35
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2572,
+    key.offset: 2666,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2577,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2583,
-    key.length: 29
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2615,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2628,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2633,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2639,
-    key.length: 29
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
     key.offset: 2671,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2677,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2709,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2722,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2727,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2733,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2765,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2684,
+    key.offset: 2778,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2694,
+    key.offset: 2788,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2731,
+    key.offset: 2825,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2738,
+    key.offset: 2832,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2748,
+    key.offset: 2842,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2762,
+    key.offset: 2856,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2792,
+    key.offset: 2886,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2806,
+    key.offset: 2900,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2816,
+    key.offset: 2910,
     key.length: 29
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 2853,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2860,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2870,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 2884,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2891,
-    key.length: 28
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 2919,
-    key.length: 28
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 2947,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 2952,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 2958,
-    key.length: 46
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3007,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3020,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3030,
-    key.length: 46
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3084,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3091,
+    key.offset: 2954,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3101,
+    key.offset: 2964,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3115,
-    key.length: 46
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3162,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3179,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3186,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3196,
-    key.length: 11
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3210,
+    key.offset: 2978,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 3217,
-    key.length: 31
+    key.offset: 2985,
+    key.length: 28
   },
   {
     key.kind: source.lang.swift.syntaxtype.comment,
-    key.offset: 3248,
-    key.length: 31
+    key.offset: 3013,
+    key.length: 28
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3279,
+    key.offset: 3041,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3284,
+    key.offset: 3046,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3290,
-    key.length: 38
+    key.offset: 3052,
+    key.length: 46
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3331,
-    key.length: 8
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3344,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3349,
-    key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3355,
-    key.length: 38
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3396,
+    key.offset: 3101,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3409,
+    key.offset: 3114,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3419,
-    key.length: 38
+    key.offset: 3124,
+    key.length: 46
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 3465,
+    key.offset: 3178,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 3472,
+    key.offset: 3185,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 3482,
-    key.length: 7
+    key.offset: 3195,
+    key.length: 11
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3492,
+    key.offset: 3209,
+    key.length: 46
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3256,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 3273,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3280,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3290,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3304,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 3311,
+    key.length: 31
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 3342,
+    key.length: 31
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 3373,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3378,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3384,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 3531,
+    key.offset: 3425,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 3438,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3443,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3449,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3490,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3503,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3513,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 3559,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3566,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3576,
     key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3586,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3625,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3635,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3645,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 3691,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 3698,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 3708,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 3718,
+    key.length: 3
   }
 ]
 [
@@ -1247,140 +1316,161 @@ extension MemberToMember_SameName_Typedef_Swift3 {
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2052,
+    key.offset: 1795,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1860,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2115,
+    key.offset: 2146,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 2209,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 2148,
+    key.offset: 2242,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2166,
+    key.offset: 2260,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2233,
+    key.offset: 2327,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2324,
+    key.offset: 2418,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2387,
+    key.offset: 2481,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2401,
+    key.offset: 2495,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 2468,
+    key.offset: 2562,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2615,
+    key.offset: 2709,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2671,
+    key.offset: 2765,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2694,
+    key.offset: 2788,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2762,
+    key.offset: 2856,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 2792,
+    key.offset: 2886,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2816,
+    key.offset: 2910,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 2884,
+    key.offset: 2978,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3007,
+    key.offset: 3101,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3030,
+    key.offset: 3124,
     key.length: 46
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3115,
+    key.offset: 3209,
     key.length: 46
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 3162,
+    key.offset: 3256,
     key.length: 11
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3210,
+    key.offset: 3304,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3331,
+    key.offset: 3425,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3396,
+    key.offset: 3490,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3419,
+    key.offset: 3513,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 3492,
+    key.offset: 3586,
     key.length: 38
   },
   {
     key.kind: source.lang.swift.ref.typealias,
-    key.offset: 3531,
+    key.offset: 3625,
     key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 3645,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 3718,
+    key.length: 3
   }
 ]
 [
@@ -1906,15 +1996,57 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     ]
   },
   {
+    key.kind: source.lang.swift.decl.extension,
+    key.name: "MemberToMember_SameName_Class_Swift4",
+    key.offset: 1785,
+    key.length: 93,
+    key.nameoffset: 1795,
+    key.namelength: 36,
+    key.bodyoffset: 1833,
+    key.bodylength: 44,
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.class,
+        key.accessibility: source.lang.swift.accessibility.open,
+        key.name: "Payload",
+        key.offset: 1844,
+        key.length: 32,
+        key.nameoffset: 1850,
+        key.namelength: 7,
+        key.bodyoffset: 1870,
+        key.bodylength: 5,
+        key.inheritedtypes: [
+          {
+            key.name: "NSObject"
+          }
+        ],
+        key.attributes: [
+          {
+            key.offset: 1839,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ],
+        key.elements: [
+          {
+            key.kind: source.lang.swift.structure.elem.typeref,
+            key.offset: 1860,
+            key.length: 8
+          }
+        ]
+      }
+    ]
+  },
+  {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "GlobalToMember_Typedef_Container",
-    key.offset: 2011,
+    key.offset: 2105,
     key.length: 53,
     key.runtime_name: "_TtC4main32GlobalToMember_Typedef_Container",
-    key.nameoffset: 2017,
+    key.nameoffset: 2111,
     key.namelength: 32,
-    key.bodyoffset: 2062,
+    key.bodyoffset: 2156,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1923,7 +2055,7 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     ],
     key.attributes: [
       {
-        key.offset: 2006,
+        key.offset: 2100,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -1931,7 +2063,7 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2052,
+        key.offset: 2146,
         key.length: 8
       }
     ]
@@ -1940,13 +2072,13 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "GlobalToMember_Typedef_Payload",
-    key.offset: 2072,
+    key.offset: 2166,
     key.length: 83,
-    key.nameoffset: 2082,
+    key.nameoffset: 2176,
     key.namelength: 30,
     key.attributes: [
       {
-        key.offset: 2065,
+        key.offset: 2159,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -1955,24 +2087,24 @@ extension MemberToMember_SameName_Typedef_Swift3 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "GlobalToMember_Typedef_Container",
-    key.offset: 2156,
+    key.offset: 2250,
     key.length: 82,
-    key.nameoffset: 2166,
+    key.nameoffset: 2260,
     key.namelength: 32,
-    key.bodyoffset: 2200,
+    key.bodyoffset: 2294,
     key.bodylength: 37,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 2213,
+        key.offset: 2307,
         key.length: 23,
-        key.nameoffset: 2223,
+        key.nameoffset: 2317,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 2206,
+            key.offset: 2300,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -1984,12 +2116,12 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Typedef_Container",
-    key.offset: 2283,
+    key.offset: 2377,
     key.length: 53,
     key.runtime_name: "_TtC4main32MemberToGlobal_Typedef_Container",
-    key.nameoffset: 2289,
+    key.nameoffset: 2383,
     key.namelength: 32,
-    key.bodyoffset: 2334,
+    key.bodyoffset: 2428,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -1998,7 +2130,7 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     ],
     key.attributes: [
       {
-        key.offset: 2278,
+        key.offset: 2372,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2006,7 +2138,7 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2324,
+        key.offset: 2418,
         key.length: 8
       }
     ]
@@ -2015,13 +2147,13 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "MemberToGlobal_Typedef_Payload",
-    key.offset: 2344,
+    key.offset: 2438,
     key.length: 46,
-    key.nameoffset: 2354,
+    key.nameoffset: 2448,
     key.namelength: 30,
     key.attributes: [
       {
-        key.offset: 2337,
+        key.offset: 2431,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -2030,24 +2162,24 @@ extension MemberToMember_SameName_Typedef_Swift3 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToGlobal_Typedef_Container",
-    key.offset: 2391,
+    key.offset: 2485,
     key.length: 109,
-    key.nameoffset: 2401,
+    key.nameoffset: 2495,
     key.namelength: 32,
-    key.bodyoffset: 2435,
+    key.bodyoffset: 2529,
     key.bodylength: 64,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 2448,
+        key.offset: 2542,
         key.length: 50,
-        key.nameoffset: 2458,
+        key.nameoffset: 2552,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 2441,
+            key.offset: 2535,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2059,12 +2191,12 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Typedef_Swift3",
-    key.offset: 2577,
+    key.offset: 2671,
     key.length: 50,
     key.runtime_name: "_TtC4main29MemberToMember_Typedef_Swift3",
-    key.nameoffset: 2583,
+    key.nameoffset: 2677,
     key.namelength: 29,
-    key.bodyoffset: 2625,
+    key.bodyoffset: 2719,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2073,7 +2205,7 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     ],
     key.attributes: [
       {
-        key.offset: 2572,
+        key.offset: 2666,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2081,7 +2213,7 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2615,
+        key.offset: 2709,
         key.length: 8
       }
     ]
@@ -2090,12 +2222,12 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Typedef_Swift4",
-    key.offset: 2633,
+    key.offset: 2727,
     key.length: 50,
     key.runtime_name: "_TtC4main29MemberToMember_Typedef_Swift4",
-    key.nameoffset: 2639,
+    key.nameoffset: 2733,
     key.namelength: 29,
-    key.bodyoffset: 2681,
+    key.bodyoffset: 2775,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2104,7 +2236,7 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     ],
     key.attributes: [
       {
-        key.offset: 2628,
+        key.offset: 2722,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2112,7 +2244,7 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 2671,
+        key.offset: 2765,
         key.length: 8
       }
     ]
@@ -2120,24 +2252,24 @@ extension MemberToMember_SameName_Typedef_Swift3 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Typedef_Swift3",
-    key.offset: 2684,
+    key.offset: 2778,
     key.length: 121,
-    key.nameoffset: 2694,
+    key.nameoffset: 2788,
     key.namelength: 29,
-    key.bodyoffset: 2725,
+    key.bodyoffset: 2819,
     key.bodylength: 79,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor3",
-        key.offset: 2738,
+        key.offset: 2832,
         key.length: 65,
-        key.nameoffset: 2748,
+        key.nameoffset: 2842,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 2731,
+            key.offset: 2825,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2148,24 +2280,24 @@ extension MemberToMember_SameName_Typedef_Swift3 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Typedef_Swift4",
-    key.offset: 2806,
+    key.offset: 2900,
     key.length: 83,
-    key.nameoffset: 2816,
+    key.nameoffset: 2910,
     key.namelength: 29,
-    key.bodyoffset: 2847,
+    key.bodyoffset: 2941,
     key.bodylength: 41,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor4",
-        key.offset: 2860,
+        key.offset: 2954,
         key.length: 27,
-        key.nameoffset: 2870,
+        key.nameoffset: 2964,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 2853,
+            key.offset: 2947,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2177,12 +2309,12 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameContainer_Typedef_Container",
-    key.offset: 2952,
+    key.offset: 3046,
     key.length: 67,
     key.runtime_name: "_TtC4main46MemberToMember_SameContainer_Typedef_Container",
-    key.nameoffset: 2958,
+    key.nameoffset: 3052,
     key.namelength: 46,
-    key.bodyoffset: 3017,
+    key.bodyoffset: 3111,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2191,7 +2323,7 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     ],
     key.attributes: [
       {
-        key.offset: 2947,
+        key.offset: 3041,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2199,7 +2331,7 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 3007,
+        key.offset: 3101,
         key.length: 8
       }
     ]
@@ -2207,24 +2339,24 @@ extension MemberToMember_SameName_Typedef_Swift3 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameContainer_Typedef_Container",
-    key.offset: 3020,
+    key.offset: 3114,
     key.length: 195,
-    key.nameoffset: 3030,
+    key.nameoffset: 3124,
     key.namelength: 46,
-    key.bodyoffset: 3078,
+    key.bodyoffset: 3172,
     key.bodylength: 136,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor3",
-        key.offset: 3091,
+        key.offset: 3185,
         key.length: 82,
-        key.nameoffset: 3101,
+        key.nameoffset: 3195,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 3084,
+            key.offset: 3178,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2234,13 +2366,13 @@ extension MemberToMember_SameName_Typedef_Swift3 {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "PayloadFor4",
-        key.offset: 3186,
+        key.offset: 3280,
         key.length: 27,
-        key.nameoffset: 3196,
+        key.nameoffset: 3290,
         key.namelength: 11,
         key.attributes: [
           {
-            key.offset: 3179,
+            key.offset: 3273,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -2252,12 +2384,12 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Typedef_Swift3",
-    key.offset: 3284,
+    key.offset: 3378,
     key.length: 59,
     key.runtime_name: "_TtC4main38MemberToMember_SameName_Typedef_Swift3",
-    key.nameoffset: 3290,
+    key.nameoffset: 3384,
     key.namelength: 38,
-    key.bodyoffset: 3341,
+    key.bodyoffset: 3435,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2266,7 +2398,7 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     ],
     key.attributes: [
       {
-        key.offset: 3279,
+        key.offset: 3373,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2274,7 +2406,7 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 3331,
+        key.offset: 3425,
         key.length: 8
       }
     ]
@@ -2283,12 +2415,12 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_SameName_Typedef_Swift4",
-    key.offset: 3349,
+    key.offset: 3443,
     key.length: 59,
     key.runtime_name: "_TtC4main38MemberToMember_SameName_Typedef_Swift4",
-    key.nameoffset: 3355,
+    key.nameoffset: 3449,
     key.namelength: 38,
-    key.bodyoffset: 3406,
+    key.bodyoffset: 3500,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -2297,7 +2429,7 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     ],
     key.attributes: [
       {
-        key.offset: 3344,
+        key.offset: 3438,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -2305,7 +2437,7 @@ extension MemberToMember_SameName_Typedef_Swift3 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 3396,
+        key.offset: 3490,
         key.length: 8
       }
     ]
@@ -2313,24 +2445,52 @@ extension MemberToMember_SameName_Typedef_Swift3 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_SameName_Typedef_Swift3",
-    key.offset: 3409,
+    key.offset: 3503,
     key.length: 131,
-    key.nameoffset: 3419,
+    key.nameoffset: 3513,
     key.namelength: 38,
-    key.bodyoffset: 3459,
+    key.bodyoffset: 3553,
     key.bodylength: 80,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 3472,
+        key.offset: 3566,
         key.length: 66,
-        key.nameoffset: 3482,
+        key.nameoffset: 3576,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 3465,
+            key.offset: 3559,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension,
+    key.name: "MemberToMember_SameName_Typedef_Swift4",
+    key.offset: 3635,
+    key.length: 88,
+    key.nameoffset: 3645,
+    key.namelength: 38,
+    key.bodyoffset: 3685,
+    key.bodylength: 37,
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.typealias,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "Payload",
+        key.offset: 3698,
+        key.length: 23,
+        key.nameoffset: 3708,
+        key.namelength: 7,
+        key.attributes: [
+          {
+            key.offset: 3691,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift3.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift3.response
@@ -1,0 +1,1232 @@
+import Foundation
+
+
+open class Foo : NSObject {
+}
+
+open class GlobalToMember_Class_Container : NSObject {
+}
+public typealias GlobalToMember_Class_Payload = GlobalToMember_Class_Container.Payload
+extension GlobalToMember_Class_Container {
+
+    open class Payload : NSObject {
+    }
+}
+
+open class MemberToGlobal_Class_Container : NSObject {
+}
+open class MemberToGlobal_Class_Payload : NSObject {
+}
+extension MemberToGlobal_Class_Container {
+
+    public typealias Payload = MemberToGlobal_Class_Payload
+}
+
+open class MemberToMember_Class_Swift3 : NSObject {
+}
+open class MemberToMember_Class_Swift4 : NSObject {
+}
+extension MemberToMember_Class_Swift3 {
+
+    open class Payload : NSObject {
+    }
+}
+
+open class GlobalToMember_Typedef_Container : NSObject {
+}
+public typealias GlobalToMember_Typedef_Payload = GlobalToMember_Typedef_Container.Payload
+extension GlobalToMember_Typedef_Container {
+
+    public typealias Payload = Foo
+}
+
+open class MemberToGlobal_Typedef_Container : NSObject {
+}
+public typealias MemberToGlobal_Typedef_Payload = Foo
+extension MemberToGlobal_Typedef_Container {
+
+    public typealias Payload = MemberToGlobal_Typedef_Payload
+}
+
+open class MemberToMember_Typedef_Swift3 : NSObject {
+}
+open class MemberToMember_Typedef_Swift4 : NSObject {
+}
+extension MemberToMember_Typedef_Swift3 {
+
+    public typealias Payload = Foo
+}
+
+[
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 0,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 7,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 20,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 25,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 31,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 37,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 51,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 56,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 62,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 95,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 108,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 115,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 125,
+    key.length: 28
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 156,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 187,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 195,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 205,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 243,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 248,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 254,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 264,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 284,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 289,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 295,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 328,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 341,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 346,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 352,
+    key.length: 28
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 383,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 396,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 406,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 444,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 451,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 461,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 471,
+    key.length: 28
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 503,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 508,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 514,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 544,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 557,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 562,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 568,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 598,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 611,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 621,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 656,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 661,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 667,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 677,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 697,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 702,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 708,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 743,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 756,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 763,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 773,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 806,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 839,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 847,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 857,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 897,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 904,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 914,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 924,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 931,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 936,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 942,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 977,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 990,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 997,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1007,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1040,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1044,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1054,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1094,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1101,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1111,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1121,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1155,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1160,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1166,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1198,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1211,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1216,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1222,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1254,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1267,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1277,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1314,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1321,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1331,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1341,
+    key.length: 3
+  }
+]
+[
+  {
+    key.kind: source.lang.swift.ref.module,
+    key.offset: 7,
+    key.length: 10,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 37,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 95,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 156,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 187,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 205,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 264,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 328,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 383,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 406,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 471,
+    key.length: 28
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 544,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 598,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 621,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 677,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 743,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 806,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.ref.typealias,
+    key.offset: 839,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 857,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 924,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 977,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1040,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1054,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.ref.typealias,
+    key.offset: 1121,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1198,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1254,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1277,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1341,
+    key.length: 3
+  }
+]
+[
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "Foo",
+    key.offset: 25,
+    key.length: 24,
+    key.runtime_name: "_TtC4main3Foo",
+    key.nameoffset: 31,
+    key.namelength: 3,
+    key.bodyoffset: 47,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 20,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 37,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "GlobalToMember_Class_Container",
+    key.offset: 56,
+    key.length: 51,
+    key.runtime_name: "_TtC4main30GlobalToMember_Class_Container",
+    key.nameoffset: 62,
+    key.namelength: 30,
+    key.bodyoffset: 105,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 51,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 95,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.typealias,
+    key.accessibility: source.lang.swift.accessibility.public,
+    key.name: "GlobalToMember_Class_Payload",
+    key.offset: 115,
+    key.length: 79,
+    key.nameoffset: 125,
+    key.namelength: 28,
+    key.attributes: [
+      {
+        key.offset: 108,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension,
+    key.name: "GlobalToMember_Class_Container",
+    key.offset: 195,
+    key.length: 87,
+    key.nameoffset: 205,
+    key.namelength: 30,
+    key.bodyoffset: 237,
+    key.bodylength: 44,
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.class,
+        key.accessibility: source.lang.swift.accessibility.open,
+        key.name: "Payload",
+        key.offset: 248,
+        key.length: 32,
+        key.nameoffset: 254,
+        key.namelength: 7,
+        key.bodyoffset: 274,
+        key.bodylength: 5,
+        key.inheritedtypes: [
+          {
+            key.name: "NSObject"
+          }
+        ],
+        key.attributes: [
+          {
+            key.offset: 243,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ],
+        key.elements: [
+          {
+            key.kind: source.lang.swift.structure.elem.typeref,
+            key.offset: 264,
+            key.length: 8
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToGlobal_Class_Container",
+    key.offset: 289,
+    key.length: 51,
+    key.runtime_name: "_TtC4main30MemberToGlobal_Class_Container",
+    key.nameoffset: 295,
+    key.namelength: 30,
+    key.bodyoffset: 338,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 284,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 328,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToGlobal_Class_Payload",
+    key.offset: 346,
+    key.length: 49,
+    key.runtime_name: "_TtC4main28MemberToGlobal_Class_Payload",
+    key.nameoffset: 352,
+    key.namelength: 28,
+    key.bodyoffset: 393,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 341,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 383,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension,
+    key.name: "MemberToGlobal_Class_Container",
+    key.offset: 396,
+    key.length: 105,
+    key.nameoffset: 406,
+    key.namelength: 30,
+    key.bodyoffset: 438,
+    key.bodylength: 62,
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.typealias,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "Payload",
+        key.offset: 451,
+        key.length: 48,
+        key.nameoffset: 461,
+        key.namelength: 7,
+        key.attributes: [
+          {
+            key.offset: 444,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToMember_Class_Swift3",
+    key.offset: 508,
+    key.length: 48,
+    key.runtime_name: "_TtC4main27MemberToMember_Class_Swift3",
+    key.nameoffset: 514,
+    key.namelength: 27,
+    key.bodyoffset: 554,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 503,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 544,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToMember_Class_Swift4",
+    key.offset: 562,
+    key.length: 48,
+    key.runtime_name: "_TtC4main27MemberToMember_Class_Swift4",
+    key.nameoffset: 568,
+    key.namelength: 27,
+    key.bodyoffset: 608,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 557,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 598,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension,
+    key.name: "MemberToMember_Class_Swift3",
+    key.offset: 611,
+    key.length: 84,
+    key.nameoffset: 621,
+    key.namelength: 27,
+    key.bodyoffset: 650,
+    key.bodylength: 44,
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.class,
+        key.accessibility: source.lang.swift.accessibility.open,
+        key.name: "Payload",
+        key.offset: 661,
+        key.length: 32,
+        key.nameoffset: 667,
+        key.namelength: 7,
+        key.bodyoffset: 687,
+        key.bodylength: 5,
+        key.inheritedtypes: [
+          {
+            key.name: "NSObject"
+          }
+        ],
+        key.attributes: [
+          {
+            key.offset: 656,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ],
+        key.elements: [
+          {
+            key.kind: source.lang.swift.structure.elem.typeref,
+            key.offset: 677,
+            key.length: 8
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "GlobalToMember_Typedef_Container",
+    key.offset: 702,
+    key.length: 53,
+    key.runtime_name: "_TtC4main32GlobalToMember_Typedef_Container",
+    key.nameoffset: 708,
+    key.namelength: 32,
+    key.bodyoffset: 753,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 697,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 743,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.typealias,
+    key.accessibility: source.lang.swift.accessibility.public,
+    key.name: "GlobalToMember_Typedef_Payload",
+    key.offset: 763,
+    key.length: 83,
+    key.nameoffset: 773,
+    key.namelength: 30,
+    key.attributes: [
+      {
+        key.offset: 756,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension,
+    key.name: "GlobalToMember_Typedef_Container",
+    key.offset: 847,
+    key.length: 82,
+    key.nameoffset: 857,
+    key.namelength: 32,
+    key.bodyoffset: 891,
+    key.bodylength: 37,
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.typealias,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "Payload",
+        key.offset: 904,
+        key.length: 23,
+        key.nameoffset: 914,
+        key.namelength: 7,
+        key.attributes: [
+          {
+            key.offset: 897,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToGlobal_Typedef_Container",
+    key.offset: 936,
+    key.length: 53,
+    key.runtime_name: "_TtC4main32MemberToGlobal_Typedef_Container",
+    key.nameoffset: 942,
+    key.namelength: 32,
+    key.bodyoffset: 987,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 931,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 977,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.typealias,
+    key.accessibility: source.lang.swift.accessibility.public,
+    key.name: "MemberToGlobal_Typedef_Payload",
+    key.offset: 997,
+    key.length: 46,
+    key.nameoffset: 1007,
+    key.namelength: 30,
+    key.attributes: [
+      {
+        key.offset: 990,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension,
+    key.name: "MemberToGlobal_Typedef_Container",
+    key.offset: 1044,
+    key.length: 109,
+    key.nameoffset: 1054,
+    key.namelength: 32,
+    key.bodyoffset: 1088,
+    key.bodylength: 64,
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.typealias,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "Payload",
+        key.offset: 1101,
+        key.length: 50,
+        key.nameoffset: 1111,
+        key.namelength: 7,
+        key.attributes: [
+          {
+            key.offset: 1094,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToMember_Typedef_Swift3",
+    key.offset: 1160,
+    key.length: 50,
+    key.runtime_name: "_TtC4main29MemberToMember_Typedef_Swift3",
+    key.nameoffset: 1166,
+    key.namelength: 29,
+    key.bodyoffset: 1208,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 1155,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 1198,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToMember_Typedef_Swift4",
+    key.offset: 1216,
+    key.length: 50,
+    key.runtime_name: "_TtC4main29MemberToMember_Typedef_Swift4",
+    key.nameoffset: 1222,
+    key.namelength: 29,
+    key.bodyoffset: 1264,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 1211,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 1254,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension,
+    key.name: "MemberToMember_Typedef_Swift3",
+    key.offset: 1267,
+    key.length: 79,
+    key.nameoffset: 1277,
+    key.namelength: 29,
+    key.bodyoffset: 1308,
+    key.bodylength: 37,
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.typealias,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "Payload",
+        key.offset: 1321,
+        key.length: 23,
+        key.nameoffset: 1331,
+        key.namelength: 7,
+        key.attributes: [
+          {
+            key.offset: 1314,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift4.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift4.response
@@ -1,0 +1,984 @@
+import Foundation
+
+
+open class Foo : NSObject {
+}
+
+open class GlobalToMember_Class_Container : NSObject {
+}
+extension GlobalToMember_Class_Container {
+
+    open class Payload : NSObject {
+    }
+}
+
+open class MemberToGlobal_Class_Container : NSObject {
+}
+open class MemberToGlobal_Class_Payload : NSObject {
+}
+
+open class MemberToMember_Class_Swift3 : NSObject {
+}
+open class MemberToMember_Class_Swift4 : NSObject {
+}
+extension MemberToMember_Class_Swift4 {
+
+    open class Payload : NSObject {
+    }
+}
+
+open class GlobalToMember_Typedef_Container : NSObject {
+}
+extension GlobalToMember_Typedef_Container {
+
+    public typealias Payload = Foo
+}
+
+open class MemberToGlobal_Typedef_Container : NSObject {
+}
+public typealias MemberToGlobal_Typedef_Payload = Foo
+
+open class MemberToMember_Typedef_Swift3 : NSObject {
+}
+open class MemberToMember_Typedef_Swift4 : NSObject {
+}
+extension MemberToMember_Typedef_Swift4 {
+
+    public typealias Payload = Foo
+}
+
+[
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 0,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 7,
+    key.length: 10
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 20,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 25,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 31,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 37,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 51,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 56,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 62,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 95,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 108,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 118,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 156,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 161,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 167,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 177,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 197,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 202,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 208,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 241,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 254,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 259,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 265,
+    key.length: 28
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 296,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 310,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 315,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 321,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 351,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 364,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 369,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 375,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 405,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 418,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 428,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 463,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 468,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 474,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 484,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 504,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 509,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 515,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 550,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 563,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 573,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 613,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 620,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 630,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 640,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 647,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 652,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 658,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 693,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 706,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 713,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 723,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 756,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 761,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 766,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 772,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 804,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 817,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 822,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 828,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 860,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 873,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 883,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 920,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 927,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 937,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 947,
+    key.length: 3
+  }
+]
+[
+  {
+    key.kind: source.lang.swift.ref.module,
+    key.offset: 7,
+    key.length: 10,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 37,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 95,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 118,
+    key.length: 30
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 177,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 241,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 296,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 351,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 405,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 428,
+    key.length: 27
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 484,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 550,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 573,
+    key.length: 32
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 640,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 693,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 756,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 804,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 860,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 883,
+    key.length: 29
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 947,
+    key.length: 3
+  }
+]
+[
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "Foo",
+    key.offset: 25,
+    key.length: 24,
+    key.runtime_name: "_TtC4main3Foo",
+    key.nameoffset: 31,
+    key.namelength: 3,
+    key.bodyoffset: 47,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 20,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 37,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "GlobalToMember_Class_Container",
+    key.offset: 56,
+    key.length: 51,
+    key.runtime_name: "_TtC4main30GlobalToMember_Class_Container",
+    key.nameoffset: 62,
+    key.namelength: 30,
+    key.bodyoffset: 105,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 51,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 95,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension,
+    key.name: "GlobalToMember_Class_Container",
+    key.offset: 108,
+    key.length: 87,
+    key.nameoffset: 118,
+    key.namelength: 30,
+    key.bodyoffset: 150,
+    key.bodylength: 44,
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.class,
+        key.accessibility: source.lang.swift.accessibility.open,
+        key.name: "Payload",
+        key.offset: 161,
+        key.length: 32,
+        key.nameoffset: 167,
+        key.namelength: 7,
+        key.bodyoffset: 187,
+        key.bodylength: 5,
+        key.inheritedtypes: [
+          {
+            key.name: "NSObject"
+          }
+        ],
+        key.attributes: [
+          {
+            key.offset: 156,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ],
+        key.elements: [
+          {
+            key.kind: source.lang.swift.structure.elem.typeref,
+            key.offset: 177,
+            key.length: 8
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToGlobal_Class_Container",
+    key.offset: 202,
+    key.length: 51,
+    key.runtime_name: "_TtC4main30MemberToGlobal_Class_Container",
+    key.nameoffset: 208,
+    key.namelength: 30,
+    key.bodyoffset: 251,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 197,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 241,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToGlobal_Class_Payload",
+    key.offset: 259,
+    key.length: 49,
+    key.runtime_name: "_TtC4main28MemberToGlobal_Class_Payload",
+    key.nameoffset: 265,
+    key.namelength: 28,
+    key.bodyoffset: 306,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 254,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 296,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToMember_Class_Swift3",
+    key.offset: 315,
+    key.length: 48,
+    key.runtime_name: "_TtC4main27MemberToMember_Class_Swift3",
+    key.nameoffset: 321,
+    key.namelength: 27,
+    key.bodyoffset: 361,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 310,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 351,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToMember_Class_Swift4",
+    key.offset: 369,
+    key.length: 48,
+    key.runtime_name: "_TtC4main27MemberToMember_Class_Swift4",
+    key.nameoffset: 375,
+    key.namelength: 27,
+    key.bodyoffset: 415,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 364,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 405,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension,
+    key.name: "MemberToMember_Class_Swift4",
+    key.offset: 418,
+    key.length: 84,
+    key.nameoffset: 428,
+    key.namelength: 27,
+    key.bodyoffset: 457,
+    key.bodylength: 44,
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.class,
+        key.accessibility: source.lang.swift.accessibility.open,
+        key.name: "Payload",
+        key.offset: 468,
+        key.length: 32,
+        key.nameoffset: 474,
+        key.namelength: 7,
+        key.bodyoffset: 494,
+        key.bodylength: 5,
+        key.inheritedtypes: [
+          {
+            key.name: "NSObject"
+          }
+        ],
+        key.attributes: [
+          {
+            key.offset: 463,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ],
+        key.elements: [
+          {
+            key.kind: source.lang.swift.structure.elem.typeref,
+            key.offset: 484,
+            key.length: 8
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "GlobalToMember_Typedef_Container",
+    key.offset: 509,
+    key.length: 53,
+    key.runtime_name: "_TtC4main32GlobalToMember_Typedef_Container",
+    key.nameoffset: 515,
+    key.namelength: 32,
+    key.bodyoffset: 560,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 504,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 550,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension,
+    key.name: "GlobalToMember_Typedef_Container",
+    key.offset: 563,
+    key.length: 82,
+    key.nameoffset: 573,
+    key.namelength: 32,
+    key.bodyoffset: 607,
+    key.bodylength: 37,
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.typealias,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "Payload",
+        key.offset: 620,
+        key.length: 23,
+        key.nameoffset: 630,
+        key.namelength: 7,
+        key.attributes: [
+          {
+            key.offset: 613,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToGlobal_Typedef_Container",
+    key.offset: 652,
+    key.length: 53,
+    key.runtime_name: "_TtC4main32MemberToGlobal_Typedef_Container",
+    key.nameoffset: 658,
+    key.namelength: 32,
+    key.bodyoffset: 703,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 647,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 693,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.typealias,
+    key.accessibility: source.lang.swift.accessibility.public,
+    key.name: "MemberToGlobal_Typedef_Payload",
+    key.offset: 713,
+    key.length: 46,
+    key.nameoffset: 723,
+    key.namelength: 30,
+    key.attributes: [
+      {
+        key.offset: 706,
+        key.length: 6,
+        key.attribute: source.decl.attribute.public
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToMember_Typedef_Swift3",
+    key.offset: 766,
+    key.length: 50,
+    key.runtime_name: "_TtC4main29MemberToMember_Typedef_Swift3",
+    key.nameoffset: 772,
+    key.namelength: 29,
+    key.bodyoffset: 814,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 761,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 804,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToMember_Typedef_Swift4",
+    key.offset: 822,
+    key.length: 50,
+    key.runtime_name: "_TtC4main29MemberToMember_Typedef_Swift4",
+    key.nameoffset: 828,
+    key.namelength: 29,
+    key.bodyoffset: 870,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 817,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 860,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension,
+    key.name: "MemberToMember_Typedef_Swift4",
+    key.offset: 873,
+    key.length: 79,
+    key.nameoffset: 883,
+    key.namelength: 29,
+    key.bodyoffset: 914,
+    key.bodylength: 37,
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.typealias,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "Payload",
+        key.offset: 927,
+        key.length: 23,
+        key.nameoffset: 937,
+        key.namelength: 7,
+        key.attributes: [
+          {
+            key.offset: 920,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift4.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.apinotes_swift4.response
@@ -3,7 +3,12 @@ import Foundation
 
 open class Foo : NSObject {
 }
+// ===-------------------------------------------------------------------------
+// class Payload
+// ===-------------------------------------------------------------------------
 
+// 3: Payload
+// 4: Namespace.Payload
 open class GlobalToMember_Class_Container : NSObject {
 }
 extension GlobalToMember_Class_Container {
@@ -12,21 +17,53 @@ extension GlobalToMember_Class_Container {
     }
 }
 
+// 3: Namespace.Payload
+// 4: Payload
 open class MemberToGlobal_Class_Container : NSObject {
 }
 open class MemberToGlobal_Class_Payload : NSObject {
 }
 
+// 3: Namespace_Swift3.PayloadFor3
+// 4: Namespace_Swift4.PayloadFor4
 open class MemberToMember_Class_Swift3 : NSObject {
 }
 open class MemberToMember_Class_Swift4 : NSObject {
 }
 extension MemberToMember_Class_Swift4 {
 
+    open class PayloadFor4 : NSObject {
+    }
+}
+
+// 3: Namespace.PayloadFor3
+// 4: Namespace.PayloadFor4
+open class MemberToMember_SameContainer_Class_Container : NSObject {
+}
+extension MemberToMember_SameContainer_Class_Container {
+
+    open class PayloadFor4 : NSObject {
+    }
+}
+
+// 3: Namespace_Swift3.Payload
+// 4: Namespace_Swift4.Payload
+open class MemberToMember_SameName_Class_Swift3 : NSObject {
+}
+open class MemberToMember_SameName_Class_Swift4 : NSObject {
+}
+extension MemberToMember_SameName_Class_Swift4 {
+
     open class Payload : NSObject {
     }
 }
 
+// ===-------------------------------------------------------------------------
+// typealias Payload
+// ===-------------------------------------------------------------------------
+
+// 3: Payload
+// 4: Namespace.Payload
 open class GlobalToMember_Typedef_Container : NSObject {
 }
 extension GlobalToMember_Typedef_Container {
@@ -34,15 +71,39 @@ extension GlobalToMember_Typedef_Container {
     public typealias Payload = Foo
 }
 
+// 3: Namespace.Payload
+// 4: Payload
 open class MemberToGlobal_Typedef_Container : NSObject {
 }
 public typealias MemberToGlobal_Typedef_Payload = Foo
 
+// 3: Namespace_Swift3.PayloadFor3
+// 4: Namespace_Swift4.PayloadFor4
 open class MemberToMember_Typedef_Swift3 : NSObject {
 }
 open class MemberToMember_Typedef_Swift4 : NSObject {
 }
 extension MemberToMember_Typedef_Swift4 {
+
+    public typealias PayloadFor4 = Foo
+}
+
+// 3: Namespace.PayloadFor3
+// 4: Namespace.PayloadFor4
+open class MemberToMember_SameContainer_Typedef_Container : NSObject {
+}
+extension MemberToMember_SameContainer_Typedef_Container {
+
+    public typealias PayloadFor4 = Foo
+}
+
+// 3: Namespace_Swift3.Payload
+// 4: Namespace_Swift4.Payload
+open class MemberToMember_SameName_Typedef_Swift3 : NSObject {
+}
+open class MemberToMember_SameName_Typedef_Swift4 : NSObject {
+}
+extension MemberToMember_SameName_Typedef_Swift4 {
 
     public typealias Payload = Foo
 }
@@ -79,323 +140,693 @@ extension MemberToMember_Typedef_Swift4 {
     key.length: 8
   },
   {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 50,
+    key.length: 80
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 130,
+    key.length: 17
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 147,
+    key.length: 80
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 228,
+    key.length: 14
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 242,
+    key.length: 24
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 51,
+    key.offset: 266,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 56,
+    key.offset: 271,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 62,
+    key.offset: 277,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 95,
+    key.offset: 310,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 108,
+    key.offset: 323,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 118,
+    key.offset: 333,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 156,
+    key.offset: 371,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 161,
+    key.offset: 376,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 167,
+    key.offset: 382,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 177,
+    key.offset: 392,
     key.length: 8
   },
   {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 412,
+    key.length: 24
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 436,
+    key.length: 14
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 197,
+    key.offset: 450,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 202,
+    key.offset: 455,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 208,
+    key.offset: 461,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 241,
+    key.offset: 494,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 254,
+    key.offset: 507,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 259,
+    key.offset: 512,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 265,
+    key.offset: 518,
     key.length: 28
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 296,
+    key.offset: 549,
     key.length: 8
   },
   {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 563,
+    key.length: 35
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 598,
+    key.length: 35
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 310,
+    key.offset: 633,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 315,
+    key.offset: 638,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 321,
+    key.offset: 644,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 351,
+    key.offset: 674,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 364,
+    key.offset: 687,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 369,
+    key.offset: 692,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 375,
+    key.offset: 698,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 405,
+    key.offset: 728,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 418,
+    key.offset: 741,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 428,
+    key.offset: 751,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 463,
+    key.offset: 786,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 468,
+    key.offset: 791,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 474,
+    key.offset: 797,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 811,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 831,
+    key.length: 28
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 859,
+    key.length: 28
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 887,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 892,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 898,
+    key.length: 44
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 945,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 958,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 968,
+    key.length: 44
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1020,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1025,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1031,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1045,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 1065,
+    key.length: 31
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 1096,
+    key.length: 31
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1127,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1132,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1138,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1177,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1190,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1195,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1201,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1240,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1253,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1263,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1307,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1312,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1318,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 484,
+    key.offset: 1328,
     key.length: 8
   },
   {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 1348,
+    key.length: 80
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 1428,
+    key.length: 21
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 1449,
+    key.length: 80
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 1530,
+    key.length: 14
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 1544,
+    key.length: 24
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 504,
+    key.offset: 1568,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 509,
+    key.offset: 1573,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 515,
+    key.offset: 1579,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 550,
+    key.offset: 1614,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 563,
+    key.offset: 1627,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 573,
+    key.offset: 1637,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 613,
+    key.offset: 1677,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 620,
+    key.offset: 1684,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 630,
+    key.offset: 1694,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 640,
+    key.offset: 1704,
     key.length: 3
   },
   {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 1711,
+    key.length: 24
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 1735,
+    key.length: 14
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 647,
+    key.offset: 1749,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 652,
+    key.offset: 1754,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 658,
+    key.offset: 1760,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 693,
+    key.offset: 1795,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 706,
+    key.offset: 1808,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 713,
+    key.offset: 1815,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 723,
+    key.offset: 1825,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 756,
+    key.offset: 1858,
     key.length: 3
   },
   {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 1863,
+    key.length: 35
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 1898,
+    key.length: 35
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 761,
+    key.offset: 1933,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 766,
+    key.offset: 1938,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 772,
+    key.offset: 1944,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 804,
+    key.offset: 1976,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 817,
+    key.offset: 1989,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 822,
+    key.offset: 1994,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 828,
+    key.offset: 2000,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 860,
+    key.offset: 2032,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 873,
+    key.offset: 2045,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 883,
+    key.offset: 2055,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 920,
+    key.offset: 2092,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 927,
+    key.offset: 2099,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 937,
+    key.offset: 2109,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2123,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 2130,
+    key.length: 28
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 2158,
+    key.length: 28
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2186,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2191,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2197,
+    key.length: 46
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2246,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2259,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2269,
+    key.length: 46
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2323,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2330,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2340,
+    key.length: 11
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2354,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 2361,
+    key.length: 31
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.comment,
+    key.offset: 2392,
+    key.length: 31
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2423,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2428,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2434,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2475,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2488,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2493,
+    key.length: 5
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2499,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2540,
+    key.length: 8
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2553,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 2563,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 2609,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 2616,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 2626,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 947,
+    key.offset: 2636,
     key.length: 3
   }
 ]
@@ -414,103 +845,181 @@ extension MemberToMember_Typedef_Swift4 {
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 95,
+    key.offset: 310,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 118,
+    key.offset: 333,
     key.length: 30
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 177,
+    key.offset: 392,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 241,
+    key.offset: 494,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 296,
+    key.offset: 549,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 351,
+    key.offset: 674,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 405,
+    key.offset: 728,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 428,
+    key.offset: 751,
     key.length: 27
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 484,
+    key.offset: 811,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 550,
+    key.offset: 945,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 573,
+    key.offset: 968,
+    key.length: 44
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1045,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1177,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1240,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1263,
+    key.length: 36
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1328,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1614,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 1637,
     key.length: 32
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 640,
+    key.offset: 1704,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 693,
+    key.offset: 1795,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 756,
+    key.offset: 1858,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 804,
+    key.offset: 1976,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 860,
+    key.offset: 2032,
     key.length: 8,
     key.is_system: 1
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 883,
+    key.offset: 2055,
     key.length: 29
   },
   {
     key.kind: source.lang.swift.ref.class,
-    key.offset: 947,
+    key.offset: 2123,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 2246,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 2269,
+    key.length: 46
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 2354,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 2475,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 2540,
+    key.length: 8,
+    key.is_system: 1
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 2563,
+    key.length: 38
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.offset: 2636,
     key.length: 3
   }
 ]
@@ -550,12 +1059,12 @@ extension MemberToMember_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "GlobalToMember_Class_Container",
-    key.offset: 56,
+    key.offset: 271,
     key.length: 51,
     key.runtime_name: "_TtC4main30GlobalToMember_Class_Container",
-    key.nameoffset: 62,
+    key.nameoffset: 277,
     key.namelength: 30,
-    key.bodyoffset: 105,
+    key.bodyoffset: 320,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -564,7 +1073,7 @@ extension MemberToMember_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 51,
+        key.offset: 266,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -572,7 +1081,7 @@ extension MemberToMember_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 95,
+        key.offset: 310,
         key.length: 8
       }
     ]
@@ -580,22 +1089,22 @@ extension MemberToMember_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "GlobalToMember_Class_Container",
-    key.offset: 108,
+    key.offset: 323,
     key.length: 87,
-    key.nameoffset: 118,
+    key.nameoffset: 333,
     key.namelength: 30,
-    key.bodyoffset: 150,
+    key.bodyoffset: 365,
     key.bodylength: 44,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
         key.name: "Payload",
-        key.offset: 161,
+        key.offset: 376,
         key.length: 32,
-        key.nameoffset: 167,
+        key.nameoffset: 382,
         key.namelength: 7,
-        key.bodyoffset: 187,
+        key.bodyoffset: 402,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -604,7 +1113,7 @@ extension MemberToMember_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 156,
+            key.offset: 371,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -612,7 +1121,7 @@ extension MemberToMember_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 177,
+            key.offset: 392,
             key.length: 8
           }
         ]
@@ -623,12 +1132,12 @@ extension MemberToMember_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Class_Container",
-    key.offset: 202,
+    key.offset: 455,
     key.length: 51,
     key.runtime_name: "_TtC4main30MemberToGlobal_Class_Container",
-    key.nameoffset: 208,
+    key.nameoffset: 461,
     key.namelength: 30,
-    key.bodyoffset: 251,
+    key.bodyoffset: 504,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -637,7 +1146,7 @@ extension MemberToMember_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 197,
+        key.offset: 450,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -645,7 +1154,7 @@ extension MemberToMember_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 241,
+        key.offset: 494,
         key.length: 8
       }
     ]
@@ -654,12 +1163,12 @@ extension MemberToMember_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Class_Payload",
-    key.offset: 259,
+    key.offset: 512,
     key.length: 49,
     key.runtime_name: "_TtC4main28MemberToGlobal_Class_Payload",
-    key.nameoffset: 265,
+    key.nameoffset: 518,
     key.namelength: 28,
-    key.bodyoffset: 306,
+    key.bodyoffset: 559,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -668,7 +1177,7 @@ extension MemberToMember_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 254,
+        key.offset: 507,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -676,7 +1185,7 @@ extension MemberToMember_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 296,
+        key.offset: 549,
         key.length: 8
       }
     ]
@@ -685,12 +1194,12 @@ extension MemberToMember_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Class_Swift3",
-    key.offset: 315,
+    key.offset: 638,
     key.length: 48,
     key.runtime_name: "_TtC4main27MemberToMember_Class_Swift3",
-    key.nameoffset: 321,
+    key.nameoffset: 644,
     key.namelength: 27,
-    key.bodyoffset: 361,
+    key.bodyoffset: 684,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -699,7 +1208,7 @@ extension MemberToMember_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 310,
+        key.offset: 633,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -707,7 +1216,7 @@ extension MemberToMember_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 351,
+        key.offset: 674,
         key.length: 8
       }
     ]
@@ -716,12 +1225,12 @@ extension MemberToMember_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Class_Swift4",
-    key.offset: 369,
+    key.offset: 692,
     key.length: 48,
     key.runtime_name: "_TtC4main27MemberToMember_Class_Swift4",
-    key.nameoffset: 375,
+    key.nameoffset: 698,
     key.namelength: 27,
-    key.bodyoffset: 415,
+    key.bodyoffset: 738,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -730,7 +1239,7 @@ extension MemberToMember_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 364,
+        key.offset: 687,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -738,7 +1247,7 @@ extension MemberToMember_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 405,
+        key.offset: 728,
         key.length: 8
       }
     ]
@@ -746,22 +1255,22 @@ extension MemberToMember_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Class_Swift4",
-    key.offset: 418,
-    key.length: 84,
-    key.nameoffset: 428,
+    key.offset: 741,
+    key.length: 88,
+    key.nameoffset: 751,
     key.namelength: 27,
-    key.bodyoffset: 457,
-    key.bodylength: 44,
+    key.bodyoffset: 780,
+    key.bodylength: 48,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.class,
         key.accessibility: source.lang.swift.accessibility.open,
-        key.name: "Payload",
-        key.offset: 468,
-        key.length: 32,
-        key.nameoffset: 474,
-        key.namelength: 7,
-        key.bodyoffset: 494,
+        key.name: "PayloadFor4",
+        key.offset: 791,
+        key.length: 36,
+        key.nameoffset: 797,
+        key.namelength: 11,
+        key.bodyoffset: 821,
         key.bodylength: 5,
         key.inheritedtypes: [
           {
@@ -770,7 +1279,7 @@ extension MemberToMember_Typedef_Swift4 {
         ],
         key.attributes: [
           {
-            key.offset: 463,
+            key.offset: 786,
             key.length: 4,
             key.attribute: source.decl.attribute.open
           }
@@ -778,7 +1287,184 @@ extension MemberToMember_Typedef_Swift4 {
         key.elements: [
           {
             key.kind: source.lang.swift.structure.elem.typeref,
-            key.offset: 484,
+            key.offset: 811,
+            key.length: 8
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToMember_SameContainer_Class_Container",
+    key.offset: 892,
+    key.length: 65,
+    key.runtime_name: "_TtC4main44MemberToMember_SameContainer_Class_Container",
+    key.nameoffset: 898,
+    key.namelength: 44,
+    key.bodyoffset: 955,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 887,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 945,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension,
+    key.name: "MemberToMember_SameContainer_Class_Container",
+    key.offset: 958,
+    key.length: 105,
+    key.nameoffset: 968,
+    key.namelength: 44,
+    key.bodyoffset: 1014,
+    key.bodylength: 48,
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.class,
+        key.accessibility: source.lang.swift.accessibility.open,
+        key.name: "PayloadFor4",
+        key.offset: 1025,
+        key.length: 36,
+        key.nameoffset: 1031,
+        key.namelength: 11,
+        key.bodyoffset: 1055,
+        key.bodylength: 5,
+        key.inheritedtypes: [
+          {
+            key.name: "NSObject"
+          }
+        ],
+        key.attributes: [
+          {
+            key.offset: 1020,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ],
+        key.elements: [
+          {
+            key.kind: source.lang.swift.structure.elem.typeref,
+            key.offset: 1045,
+            key.length: 8
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToMember_SameName_Class_Swift3",
+    key.offset: 1132,
+    key.length: 57,
+    key.runtime_name: "_TtC4main36MemberToMember_SameName_Class_Swift3",
+    key.nameoffset: 1138,
+    key.namelength: 36,
+    key.bodyoffset: 1187,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 1127,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 1177,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToMember_SameName_Class_Swift4",
+    key.offset: 1195,
+    key.length: 57,
+    key.runtime_name: "_TtC4main36MemberToMember_SameName_Class_Swift4",
+    key.nameoffset: 1201,
+    key.namelength: 36,
+    key.bodyoffset: 1250,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 1190,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 1240,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension,
+    key.name: "MemberToMember_SameName_Class_Swift4",
+    key.offset: 1253,
+    key.length: 93,
+    key.nameoffset: 1263,
+    key.namelength: 36,
+    key.bodyoffset: 1301,
+    key.bodylength: 44,
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.class,
+        key.accessibility: source.lang.swift.accessibility.open,
+        key.name: "Payload",
+        key.offset: 1312,
+        key.length: 32,
+        key.nameoffset: 1318,
+        key.namelength: 7,
+        key.bodyoffset: 1338,
+        key.bodylength: 5,
+        key.inheritedtypes: [
+          {
+            key.name: "NSObject"
+          }
+        ],
+        key.attributes: [
+          {
+            key.offset: 1307,
+            key.length: 4,
+            key.attribute: source.decl.attribute.open
+          }
+        ],
+        key.elements: [
+          {
+            key.kind: source.lang.swift.structure.elem.typeref,
+            key.offset: 1328,
             key.length: 8
           }
         ]
@@ -789,12 +1475,12 @@ extension MemberToMember_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "GlobalToMember_Typedef_Container",
-    key.offset: 509,
+    key.offset: 1573,
     key.length: 53,
     key.runtime_name: "_TtC4main32GlobalToMember_Typedef_Container",
-    key.nameoffset: 515,
+    key.nameoffset: 1579,
     key.namelength: 32,
-    key.bodyoffset: 560,
+    key.bodyoffset: 1624,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -803,7 +1489,7 @@ extension MemberToMember_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 504,
+        key.offset: 1568,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -811,7 +1497,7 @@ extension MemberToMember_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 550,
+        key.offset: 1614,
         key.length: 8
       }
     ]
@@ -819,24 +1505,24 @@ extension MemberToMember_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "GlobalToMember_Typedef_Container",
-    key.offset: 563,
+    key.offset: 1627,
     key.length: 82,
-    key.nameoffset: 573,
+    key.nameoffset: 1637,
     key.namelength: 32,
-    key.bodyoffset: 607,
+    key.bodyoffset: 1671,
     key.bodylength: 37,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 620,
+        key.offset: 1684,
         key.length: 23,
-        key.nameoffset: 630,
+        key.nameoffset: 1694,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 613,
+            key.offset: 1677,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }
@@ -848,12 +1534,12 @@ extension MemberToMember_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToGlobal_Typedef_Container",
-    key.offset: 652,
+    key.offset: 1754,
     key.length: 53,
     key.runtime_name: "_TtC4main32MemberToGlobal_Typedef_Container",
-    key.nameoffset: 658,
+    key.nameoffset: 1760,
     key.namelength: 32,
-    key.bodyoffset: 703,
+    key.bodyoffset: 1805,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -862,7 +1548,7 @@ extension MemberToMember_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 647,
+        key.offset: 1749,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -870,7 +1556,7 @@ extension MemberToMember_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 693,
+        key.offset: 1795,
         key.length: 8
       }
     ]
@@ -879,13 +1565,13 @@ extension MemberToMember_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.typealias,
     key.accessibility: source.lang.swift.accessibility.public,
     key.name: "MemberToGlobal_Typedef_Payload",
-    key.offset: 713,
+    key.offset: 1815,
     key.length: 46,
-    key.nameoffset: 723,
+    key.nameoffset: 1825,
     key.namelength: 30,
     key.attributes: [
       {
-        key.offset: 706,
+        key.offset: 1808,
         key.length: 6,
         key.attribute: source.decl.attribute.public
       }
@@ -895,12 +1581,12 @@ extension MemberToMember_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Typedef_Swift3",
-    key.offset: 766,
+    key.offset: 1938,
     key.length: 50,
     key.runtime_name: "_TtC4main29MemberToMember_Typedef_Swift3",
-    key.nameoffset: 772,
+    key.nameoffset: 1944,
     key.namelength: 29,
-    key.bodyoffset: 814,
+    key.bodyoffset: 1986,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -909,7 +1595,7 @@ extension MemberToMember_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 761,
+        key.offset: 1933,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -917,7 +1603,7 @@ extension MemberToMember_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 804,
+        key.offset: 1976,
         key.length: 8
       }
     ]
@@ -926,12 +1612,12 @@ extension MemberToMember_Typedef_Swift4 {
     key.kind: source.lang.swift.decl.class,
     key.accessibility: source.lang.swift.accessibility.open,
     key.name: "MemberToMember_Typedef_Swift4",
-    key.offset: 822,
+    key.offset: 1994,
     key.length: 50,
     key.runtime_name: "_TtC4main29MemberToMember_Typedef_Swift4",
-    key.nameoffset: 828,
+    key.nameoffset: 2000,
     key.namelength: 29,
-    key.bodyoffset: 870,
+    key.bodyoffset: 2042,
     key.bodylength: 1,
     key.inheritedtypes: [
       {
@@ -940,7 +1626,7 @@ extension MemberToMember_Typedef_Swift4 {
     ],
     key.attributes: [
       {
-        key.offset: 817,
+        key.offset: 1989,
         key.length: 4,
         key.attribute: source.decl.attribute.open
       }
@@ -948,7 +1634,7 @@ extension MemberToMember_Typedef_Swift4 {
     key.elements: [
       {
         key.kind: source.lang.swift.structure.elem.typeref,
-        key.offset: 860,
+        key.offset: 2032,
         key.length: 8
       }
     ]
@@ -956,24 +1642,173 @@ extension MemberToMember_Typedef_Swift4 {
   {
     key.kind: source.lang.swift.decl.extension,
     key.name: "MemberToMember_Typedef_Swift4",
-    key.offset: 873,
-    key.length: 79,
-    key.nameoffset: 883,
+    key.offset: 2045,
+    key.length: 83,
+    key.nameoffset: 2055,
     key.namelength: 29,
-    key.bodyoffset: 914,
+    key.bodyoffset: 2086,
+    key.bodylength: 41,
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.typealias,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "PayloadFor4",
+        key.offset: 2099,
+        key.length: 27,
+        key.nameoffset: 2109,
+        key.namelength: 11,
+        key.attributes: [
+          {
+            key.offset: 2092,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToMember_SameContainer_Typedef_Container",
+    key.offset: 2191,
+    key.length: 67,
+    key.runtime_name: "_TtC4main46MemberToMember_SameContainer_Typedef_Container",
+    key.nameoffset: 2197,
+    key.namelength: 46,
+    key.bodyoffset: 2256,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 2186,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 2246,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension,
+    key.name: "MemberToMember_SameContainer_Typedef_Container",
+    key.offset: 2259,
+    key.length: 100,
+    key.nameoffset: 2269,
+    key.namelength: 46,
+    key.bodyoffset: 2317,
+    key.bodylength: 41,
+    key.substructure: [
+      {
+        key.kind: source.lang.swift.decl.typealias,
+        key.accessibility: source.lang.swift.accessibility.public,
+        key.name: "PayloadFor4",
+        key.offset: 2330,
+        key.length: 27,
+        key.nameoffset: 2340,
+        key.namelength: 11,
+        key.attributes: [
+          {
+            key.offset: 2323,
+            key.length: 6,
+            key.attribute: source.decl.attribute.public
+          }
+        ]
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToMember_SameName_Typedef_Swift3",
+    key.offset: 2428,
+    key.length: 59,
+    key.runtime_name: "_TtC4main38MemberToMember_SameName_Typedef_Swift3",
+    key.nameoffset: 2434,
+    key.namelength: 38,
+    key.bodyoffset: 2485,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 2423,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 2475,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.class,
+    key.accessibility: source.lang.swift.accessibility.open,
+    key.name: "MemberToMember_SameName_Typedef_Swift4",
+    key.offset: 2493,
+    key.length: 59,
+    key.runtime_name: "_TtC4main38MemberToMember_SameName_Typedef_Swift4",
+    key.nameoffset: 2499,
+    key.namelength: 38,
+    key.bodyoffset: 2550,
+    key.bodylength: 1,
+    key.inheritedtypes: [
+      {
+        key.name: "NSObject"
+      }
+    ],
+    key.attributes: [
+      {
+        key.offset: 2488,
+        key.length: 4,
+        key.attribute: source.decl.attribute.open
+      }
+    ],
+    key.elements: [
+      {
+        key.kind: source.lang.swift.structure.elem.typeref,
+        key.offset: 2540,
+        key.length: 8
+      }
+    ]
+  },
+  {
+    key.kind: source.lang.swift.decl.extension,
+    key.name: "MemberToMember_SameName_Typedef_Swift4",
+    key.offset: 2553,
+    key.length: 88,
+    key.nameoffset: 2563,
+    key.namelength: 38,
+    key.bodyoffset: 2603,
     key.bodylength: 37,
     key.substructure: [
       {
         key.kind: source.lang.swift.decl.typealias,
         key.accessibility: source.lang.swift.accessibility.public,
         key.name: "Payload",
-        key.offset: 927,
+        key.offset: 2616,
         key.length: 23,
-        key.nameoffset: 937,
+        key.nameoffset: 2626,
         key.namelength: 7,
         key.attributes: [
           {
-            key.offset: 920,
+            key.offset: 2609,
             key.length: 6,
             key.attribute: source.decl.attribute.public
           }


### PR DESCRIPTION
If the Clang declarations are *types*, canonical declaration in Swift is imported for newest version of Swift. In interface generation, if the declaration is versioned and it's imported as a member, we might have to search the canonical imported decl in newest version of Swift.

rdar://problem/39295365