### PR TITLE
[runtime] Update `initializeHashingParameters()`

### DIFF
--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -17,10 +17,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "../SwiftShims/GlobalObjects.h"
+#include "../SwiftShims/LibcShims.h"
 #include "swift/Runtime/Metadata.h"
 #include "swift/Runtime/Debug.h"
 #include <stdlib.h>
-#include <random>
 
 namespace swift {
 // FIXME(ABI)#76 : does this declaration need SWIFT_RUNTIME_STDLIB_INTERFACE?
@@ -116,18 +116,10 @@ static swift::_SwiftHashingParameters initializeHashingParameters() {
   if (determinism && 0 == strcmp(determinism, "1")) {
     return { 0, 0, true };
   }
-#if defined(__APPLE__)
-  // Use arc4random if available.
   __swift_uint64_t seed0 = 0, seed1 = 0;
-  arc4random_buf(&seed0, sizeof(seed0));
-  arc4random_buf(&seed1, sizeof(seed1));
+  swift::_stdlib_random(&seed0, sizeof(seed0));
+  swift::_stdlib_random(&seed1, sizeof(seed1));
   return { seed0, seed1, false };
-#else
-  std::random_device randomDevice;
-  std::mt19937_64 engine(randomDevice());
-  std::uniform_int_distribution<__swift_uint64_t> distribution;
-  return { distribution(engine), distribution(engine), false };
-#endif
 }
 
 SWIFT_ALLOWED_RUNTIME_GLOBAL_CTOR_BEGIN


### PR DESCRIPTION
Using `swift::_stdlib_random` instead of `arc4random_buf` or `std::mt19937_64`, etc.