### PR TITLE
ClosureLifetimeFixup: We need to insert a None on the backedge of a loop after we destroyed the value

### DIFF
--- a/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
@@ -416,10 +416,10 @@ static bool fixupCopyBlockWithoutEscaping(CopyBlockWithoutEscapingInst *CB) {
   auto &Context = NewCB->getModule().getASTContext();
   auto OptionalEscapingClosureTy =
       SILType::getOptionalType(SentinelClosure->getType());
+  auto *NoneDecl = Context.getOptionalNoneDecl();
   {
     SILBuilderWithScope B(Fn.getEntryBlock()->begin());
     Slot = B.createAllocStack(generatedLoc, OptionalEscapingClosureTy);
-    auto *NoneDecl = Context.getOptionalNoneDecl();
     // Store None to it.
     B.createStore(generatedLoc,
                   B.createEnum(generatedLoc, SILValue(), NoneDecl,
@@ -445,6 +445,11 @@ static bool fixupCopyBlockWithoutEscaping(CopyBlockWithoutEscapingInst *CB) {
                                   IsEscapingClosureInst::ObjCEscaping);
     B.createCondFail(Loc, IsEscaping);
     B.createDestroyAddr(generatedLoc, Slot);
+    // Store None to it.
+    B.createStore(generatedLoc,
+                  B.createEnum(generatedLoc, SILValue(), NoneDecl,
+                               OptionalEscapingClosureTy),
+                  Slot, StoreOwnershipQualifier::Init);
   }
 
   // Insert the dealloc_stack in all exiting blocks.

--- a/test/Interpreter/withoutActuallyEscapingBlocks.swift
+++ b/test/Interpreter/withoutActuallyEscapingBlocks.swift
@@ -5,6 +5,7 @@
 
 import StdlibUnittest
 import Foundation
+import Dispatch
 
 var WithoutEscapingSuite = TestSuite("WithoutActuallyEscapingBlock")
 
@@ -31,6 +32,13 @@ WithoutEscapingSuite.test("ExpectNoCrash") {
   var shouldBeTrue = false
   dontReallyEscape(f: { shouldBeTrue=true })
   expectTrue(shouldBeTrue)
+}
+
+WithoutEscapingSuite.test("ExpectNoCrash2") {
+  for _ in 1...10 {
+    let queue = DispatchQueue(label: "Foo")
+    queue.sync { }
+  }
 }
 
 runAllTests()

--- a/test/SILOptimizer/closure_lifetime_fixup_objc.swift
+++ b/test/SILOptimizer/closure_lifetime_fixup_objc.swift
@@ -65,3 +65,17 @@ public protocol DangerousEscaper {
 public func couldActuallyEscape(_ closure: @escaping () -> (), _ villian: DangerousEscaper) {
   villian.malicious(closure)
 }
+
+// We need to store nil on the back-edge.
+// CHECK  sil {{.*}}dontCrash
+// CHECK:  is_escaping_closure [objc]
+// CHECK:  cond_fail
+// CHECK:  destroy_addr %0
+// CHECK:  [[NONE:%.*]] = enum $Optional<@callee_guaranteed () -> ()>, #Optional.none!enumelt
+// CHECK:  store [[NONE]] to %0 : $*Optional<@callee_guaranteed () -> ()>
+public func dontCrash() {
+  for i in 0 ..< 2 {
+    let queue = DispatchQueue(label: "Foo")
+    queue.sync { }
+  }
+}


### PR DESCRIPTION


rdar://40221767


