### PR TITLE
[rcid] Add new method getRCUses() and reimplement getRCUsers() on top…

### DIFF
--- a/include/swift/SILOptimizer/Analysis/RCIdentityAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/RCIdentityAnalysis.h
@@ -50,9 +50,19 @@ public:
   SILValue getRCIdentityRoot(SILValue V);
 
   /// Return all recursive users of V, looking through users which propagate
-  /// RCIdentity. *NOTE* This ignores obvious ARC escapes where the a potential
+  /// RCIdentity.
+  ///
+  /// *NOTE* This ignores obvious ARC escapes where the a potential
   /// user of the RC is not managed by ARC. For instance
   /// unchecked_trivial_bit_cast.
+  void getRCUses(SILValue V, llvm::SmallVectorImpl<Operand *> &Uses);
+
+  /// A helper method that calls getRCUses and then maps each operand to the
+  /// operands user and then uniques the list.
+  ///
+  /// *NOTE* The routine asserts that the passed in Users array is empty for
+  /// simplicity. If needed this can be changed, but it is not necessary given
+  /// current uses.
   void getRCUsers(SILValue V, llvm::SmallVectorImpl<SILInstruction *> &Users);
 
   void handleDeleteNotification(SILNode *node) {


### PR DESCRIPTION
… of it.

The actual algorithm used here has not changed at all so this is basically a NFC
commit. What this PR does is change the underlying algorithm to return the
operands that it computes internally rather than transforming the operand list
into the user list internally. This enables the callers of the optimization to
find the operand number related to the uses. This makes working with
instructions with multiple operands much easier since one does not need to mess
around with rederiving the operand number from the user instruction/SILValue
pair.

getRCUsers() works now by running getRCUses() internally and then maps the
operand list to the user list.

rdar://38196046
