### PR TITLE
[4.2][migrator] Treat the top-level argument parens of function types as an index level in the ChildIndexFinder

### DIFF
--- a/test/Migrator/Inputs/API.json
+++ b/test/Migrator/Inputs/API.json
@@ -518,4 +518,15 @@
     "NewPrintedName": "newName(is:at:for:)",
     "NewTypeName": "AwesomeWrapper"
   },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "TypeRewritten",
+    "ChildIndex": "1:1:0:0:0",
+    "LeftUsr": "s:6Cities12ToplevelTypeC6memberyyySayypGSgcF",
+    "LeftComment": "Any",
+    "RightUsr": "",
+    "RightComment": "Int",
+    "ModuleName": "Cities"
+  }
 ]

--- a/test/Migrator/Inputs/Cities.swift
+++ b/test/Migrator/Inputs/Cities.swift
@@ -55,9 +55,10 @@ public class Container {
   public func getOptionalSingleAttr() -> String? { return nil }
 }
 
-public class ToplevelType {
+open class ToplevelType {
   public init() {}
   public init(recordName: String) {}
+  open func member(_ x: @escaping ([Any]?) -> Void) {}
 }
 
 public var GlobalAttribute: String = ""

--- a/test/Migrator/rename-func-decl.swift
+++ b/test/Migrator/rename-func-decl.swift
@@ -10,3 +10,11 @@ class MyCities : MoreCities {
   func setZooLocation(x ix: Int, y iy: Int, z iz: Int) {}
   func addZooAt(_ x: Int, y: Int, z: Int) {}
 }
+
+class MySubTopLevelType: ToplevelType {
+  override func member(_ x: @escaping ([Any]?) -> Void) {}
+}
+
+class MySubTopLevelType2: ToplevelType {
+  override func member(_ x: @escaping (((([(Any)])?))) -> Void) {}
+}

--- a/test/Migrator/rename-func-decl.swift.expected
+++ b/test/Migrator/rename-func-decl.swift.expected
@@ -10,3 +10,11 @@ class MyCities : MoreCities {
   func setZooLocationNew(newX ix: Int, newY iy: Int, newZ iz: Int) {}
   func addNewZooAt(_ x: Int, newY y: Int, newZ z: Int) {}
 }
+
+class MySubTopLevelType: ToplevelType {
+  override func member(_ x: @escaping ([Int]?) -> Void) {}
+}
+
+class MySubTopLevelType2: ToplevelType {
+  override func member(_ x: @escaping (((([(Int)])?))) -> Void) {}
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/16637

The `APIDiffMigratorPass` was ignoring parens in all cases, but function type argument parens are significant and the API differ includes them as an index level in the generated JSON. This was causing a segmentation fault when trying to migrate anything inside a function type argument. E.g given the function below:
```
func member(_ x: ([Any]?) -> Void) {}
```
to migrate `Any` to a new type, the API differ provides `Any`'s index in the signature, `1:1:0:0:0`, and the new type. The APIDiffMigratorPass was interpreting this incorrectly, however:

| Index | API Differ | Migrator |
|--|--|--|
| 1 | The first parameter's type:<br>`([Any]?) -> Void` | Same |
| 1 | The function's argument type:<br>`([Any]?)` | Parens not an index level, so seen as: <br>`[Any]?` |
| 0 | The paren type's first child:<br>`[Any]?` | The optional type's first child:<br>`[Any]` |
| 0 | The optional type's first child:<br>`[Any]` | The array type's first child:<br>`Any` |
| 0 | The array type's first child:<br>`Any` | The first child of `Any`:<br>*crashes* |


Resolves rdar://problem/40225476.
