### PR TITLE
[4.2] Perform value operations opaquely on ABI-inaccessible types

### DIFF
--- a/include/swift/AST/Type.h
+++ b/include/swift/AST/Type.h
@@ -419,6 +419,12 @@ public:
       });
   }
 
+  bool findIf(llvm::function_ref<bool (CanType)> fn) const {
+    return Type::findIf([&fn](Type t) {
+      return fn(CanType(t));
+    });
+  }
+
   // Provide a few optimized accessors that are really type-class queries.
 
   /// Do values of this type have reference semantics?

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -634,6 +634,14 @@ public:
     PGOReader = std::move(IPR);
   }
 
+  /// Can value operations (copies and destroys) on the given lowered type
+  /// be performed in this module?
+  bool isTypeABIAccessible(SILType type);
+
+  /// Can type metadata for the given formal type be fetched in
+  /// the given module?
+  bool isTypeMetadataAccessible(CanType type);
+
   /// \brief Run the SIL verifier to make sure that all Functions follow
   /// invariants.
   void verify() const;

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -96,35 +96,120 @@ enum IsDependent_t : unsigned {
   IsNotDependent = false,
   IsDependent = true
 };
-  
+
+/// Is a lowered SIL type trivial?  That is, are copies ultimately just
+/// bit-copies, and it takes no work to destroy a value?
+enum IsTrivial_t : bool {
+  IsNotTrivial = false,
+  IsTrivial = true
+};
+
+/// Is a lowered SIL type fixed-ABI?  That is, can the current context
+/// assign it a fixed size and alignment and perform value operations on it
+/// (such as copies, destroys, constructions, and projections) without
+/// metadata?
+///
+/// Note that a fully concrete type can be non-fixed-ABI without being
+/// itself resilient if it contains a subobject which is not fixed-ABI.
+///
+/// Also note that we're only concerned with the external value ABI here:
+/// resilient class types are still fixed-ABI, indirect enum cases do not
+/// affect the fixed-ABI-ness of the enum, and so on.
+enum IsFixedABI_t : bool {
+  IsNotFixedABI = false,
+  IsFixedABI = true
+};
+
+/// Is a lowered SIL type address-only?  That is, is the current context
+/// required to keep the value in memory for some reason?
+///
+/// A type might be address-only because:
+///
+///   - it is not fixed-size (e.g. because it is a resilient type) and
+///     therefore cannot be loaded into a statically-boundable set of
+///     registers; or
+///
+///   - it is semantically bound to memory, either because its storage
+///     address is used by the language runtime to implement its semantics
+///     (as with a weak reference) or because its representation is somehow
+///     address-dependent (as with something like a relative pointer).
+///
+/// An address-only type can be fixed-layout and/or trivial.
+/// A non-fixed-layout type is always address-only.
+enum IsAddressOnly_t : bool {
+  IsNotAddressOnly = false,
+  IsAddressOnly = true
+};
+
+/// Is this type somewhat like a reference-counted type?
+enum IsReferenceCounted_t : bool {
+  IsNotReferenceCounted = false,
+  IsReferenceCounted = true
+};
+
 /// Extended type information used by SIL.
 class TypeLowering {
 public:
-  enum IsTrivial_t : bool { IsNotTrivial, IsTrivial };
-  enum IsAddressOnly_t : bool { IsNotAddressOnly, IsAddressOnly };
-  enum IsReferenceCounted_t : bool {
-    IsNotReferenceCounted,
-    IsReferenceCounted
+  class RecursiveProperties {
+    // These are chosen so that bitwise-or merges the flags properly.
+    enum : unsigned {
+      NonTrivialFlag     = 1 << 0,
+      NonFixedABIFlag    = 1 << 1,
+      AddressOnlyFlag    = 1 << 2,
+    };
+
+    uint8_t Flags;
+  public:
+    /// Construct a default RecursiveProperties, which corresponds to
+    /// a trivial, loadable, fixed-layout type.
+    constexpr RecursiveProperties() : Flags(0) {}
+
+    constexpr RecursiveProperties(IsTrivial_t isTrivial,
+                                  IsFixedABI_t isFixedABI,
+                                  IsAddressOnly_t isAddressOnly)
+      : Flags((isTrivial ? 0U : NonTrivialFlag) | 
+              (isAddressOnly ? AddressOnlyFlag : 0U) |
+              (isFixedABI ? 0U : NonFixedABIFlag)) {}
+
+    static constexpr RecursiveProperties forReference() {
+      return {IsNotTrivial, IsFixedABI, IsNotAddressOnly};
+    }
+
+    static constexpr RecursiveProperties forOpaque() {
+      return {IsNotTrivial, IsNotFixedABI, IsAddressOnly};
+    }
+
+    void addSubobject(RecursiveProperties other) {
+      Flags |= other.Flags;
+    }
+
+    IsTrivial_t isTrivial() const {
+      return IsTrivial_t((Flags & NonTrivialFlag) == 0);
+    }
+    IsFixedABI_t isFixedABI() const {
+      return IsFixedABI_t((Flags & NonFixedABIFlag) == 0);
+    }
+    IsAddressOnly_t isAddressOnly() const {
+      return IsAddressOnly_t((Flags & AddressOnlyFlag) != 0);
+    }
+
+    void setNonTrivial() { Flags |= NonTrivialFlag; }
+    void setNonFixedABI() { Flags |= NonFixedABIFlag; }
+    void setAddressOnly() { Flags |= AddressOnlyFlag; }
   };
 
 private:
   /// The SIL type of values with this Swift type.
   SILType LoweredType;
 
-  enum : unsigned {
-    IsTrivialFlag     = 0x1,
-    IsAddressOnlyFlag = 0x2,
-    IsReferenceCountedFlag = 0x4,
-  };
-  unsigned Flags;
+  RecursiveProperties Properties;
+  unsigned ReferenceCounted : 1;
 
 protected:  
-  TypeLowering(SILType type, IsTrivial_t isTrivial,
-               IsAddressOnly_t isAddressOnly,
+  TypeLowering(SILType type, RecursiveProperties properties,
                IsReferenceCounted_t isRefCounted)
-    : LoweredType(type), Flags((isTrivial ? IsTrivialFlag : 0U) | 
-                               (isAddressOnly ? IsAddressOnlyFlag : 0U) |
-                               (isRefCounted ? IsReferenceCountedFlag : 0U)) {}
+    : LoweredType(type), Properties(properties),
+      ReferenceCounted(isRefCounted) {}
 
 public:
   TypeLowering(const TypeLowering &) = delete;
@@ -143,12 +228,16 @@ public:
   /// This is independent of whether the SIL result is address type.
   bool isFormallyReturnedIndirectly() const { return isAddressOnly(); }
 
+  RecursiveProperties getRecursiveProperties() const {
+    return Properties;
+  }
+
   /// isAddressOnly - Returns true if the type is an address-only type. A type
   /// is address-only if it is a resilient value type, or if it is a fragile
   /// value type with a resilient member. In either case, the full layout of
   /// values of the type is unavailable to the compiler.
   bool isAddressOnly() const {
-    return Flags & IsAddressOnlyFlag;
+    return Properties.isAddressOnly();
   }
   /// isLoadable - Returns true if the type is loadable, in other words, its
   /// full layout is available to the compiler. This is the inverse of
@@ -156,17 +245,24 @@ public:
   bool isLoadable() const {
     return !isAddressOnly();
   }
+
+  /// isFixedABI - Returns true if the type has a known fixed layout.
+  /// If this is true, value operations on the type can be performed even if
+  /// the type is inaccessible.
+  bool isFixedABI() const {
+    return Properties.isFixedABI();
+  }
   
   /// Returns true if the type is trivial, meaning it is a loadable
   /// value type with no reference type members that require releasing.
   bool isTrivial() const {
-    return Flags & IsTrivialFlag;
+    return Properties.isTrivial();
   }
   
   /// Returns true if the type is a scalar reference-counted reference, which
   /// can be retained and released.
   bool isReferenceCounted() const {
-    return Flags & IsReferenceCountedFlag;
+    return ReferenceCounted;
   }
 
   /// getLoweredType - Get the type used to represent values of the Swift type

--- a/lib/IRGen/FixedTypeInfo.h
+++ b/lib/IRGen/FixedTypeInfo.h
@@ -50,8 +50,7 @@ protected:
                 Alignment align, IsPOD_t pod, IsBitwiseTakable_t bt,
                 IsFixedSize_t alwaysFixedSize,
                 SpecialTypeInfoKind stik = STIK_Fixed)
-      : TypeInfo(type, align, pod, bt, alwaysFixedSize, stik),
-        StorageSize(size), SpareBits(spareBits) {
+      : TypeInfo(type, align, pod, bt, alwaysFixedSize, IsABIAccessible, stik),        StorageSize(size), SpareBits(spareBits) {
     assert(SpareBits.size() == size.getValueInBits());
     assert(isFixedSize());
   }
@@ -61,7 +60,7 @@ protected:
                 Alignment align, IsPOD_t pod, IsBitwiseTakable_t bt,
                 IsFixedSize_t alwaysFixedSize,
                 SpecialTypeInfoKind stik = STIK_Fixed)
-      : TypeInfo(type, align, pod, bt, alwaysFixedSize, stik),
+      : TypeInfo(type, align, pod, bt, alwaysFixedSize, IsABIAccessible, stik),
         StorageSize(size), SpareBits(std::move(spareBits)) {
     assert(SpareBits.size() == size.getValueInBits());
     assert(isFixedSize());
@@ -70,6 +69,7 @@ protected:
 public:
   // This is useful for metaprogramming.
   static bool isFixed() { return true; }
+  static IsABIAccessible_t isABIAccessible() { return IsABIAccessible; }
 
   /// Whether this type is known to be empty.
   bool isKnownEmpty(ResilienceExpansion expansion) const {

--- a/lib/IRGen/GenArchetype.cpp
+++ b/lib/IRGen/GenArchetype.cpp
@@ -89,7 +89,8 @@ namespace {
 class OpaqueArchetypeTypeInfo
   : public ResilientTypeInfo<OpaqueArchetypeTypeInfo>
 {
-  OpaqueArchetypeTypeInfo(llvm::Type *type) : ResilientTypeInfo(type) {}
+  OpaqueArchetypeTypeInfo(llvm::Type *type)
+    : ResilientTypeInfo(type, IsABIAccessible) {}
 
 public:
   static const OpaqueArchetypeTypeInfo *create(llvm::Type *type) {

--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -142,7 +142,8 @@ static llvm::Constant *emitEnumLayoutFlags(IRGenModule &IGM, bool isVWTMutable){
   return IGM.getSize(Size(uintptr_t(flags)));
 }
 
-SpareBitVector getBitVectorFromAPInt(const APInt &bits, unsigned startBit = 0) {
+static SpareBitVector
+getBitVectorFromAPInt(const APInt &bits, unsigned startBit = 0) {
   if (startBit == 0) {
     return SpareBitVector::fromAPInt(bits);
   }
@@ -150,6 +151,28 @@ SpareBitVector getBitVectorFromAPInt(const APInt &bits, unsigned startBit = 0) {
   result.appendClearBits(startBit);
   result.append(SpareBitVector::fromAPInt(bits));
   return result;
+}
+
+static IsABIAccessible_t
+areElementsABIAccessible(ArrayRef<EnumImplStrategy::Element> elts) {
+  for (auto &elt : elts) {
+    if (!elt.ti->isABIAccessible())
+      return IsNotABIAccessible;
+  }
+  return IsABIAccessible;
+}
+
+EnumImplStrategy::EnumImplStrategy(IRGenModule &IGM,
+                                   TypeInfoKind tik,
+                                   IsFixedSize_t alwaysFixedSize,
+                                   unsigned NumElements,
+                                   std::vector<Element> &&eltsWithPayload,
+                                   std::vector<Element> &&eltsWithNoPayload)
+  : ElementsWithPayload(std::move(eltsWithPayload)),
+    ElementsWithNoPayload(std::move(eltsWithNoPayload)),
+    IGM(IGM), TIK(tik), AlwaysFixedSize(alwaysFixedSize),
+    ElementsAreABIAccessible(areElementsABIAccessible(ElementsWithPayload)),
+    NumElements(NumElements) {
 }
 
 void irgen::EnumImplStrategy::initializeFromParams(IRGenFunction &IGF,
@@ -465,7 +488,9 @@ namespace {
     void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
                         SILType T, bool isOutlined) const override {
       if (!getSingleton()) return;
-      if (isOutlined || T.hasOpenedExistential()) {
+      if (!ElementsAreABIAccessible) {
+        emitAssignWithCopyCall(IGF, T, dest, src);
+      } else if (isOutlined || T.hasOpenedExistential()) {
         dest = getSingletonAddress(IGF, dest);
         src = getSingletonAddress(IGF, src);
         getSingleton()->assignWithCopy(
@@ -478,7 +503,9 @@ namespace {
     void assignWithTake(IRGenFunction &IGF, Address dest, Address src,
                         SILType T, bool isOutlined) const override {
       if (!getSingleton()) return;
-      if (isOutlined || T.hasOpenedExistential()) {
+      if (!ElementsAreABIAccessible) {
+        emitAssignWithTakeCall(IGF, T, dest, src);
+      } else if (isOutlined || T.hasOpenedExistential()) {
         dest = getSingletonAddress(IGF, dest);
         src = getSingletonAddress(IGF, src);
         getSingleton()->assignWithTake(
@@ -498,7 +525,9 @@ namespace {
     void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
                             SILType T, bool isOutlined) const override {
       if (!getSingleton()) return;
-      if (isOutlined || T.hasOpenedExistential()) {
+      if (!ElementsAreABIAccessible) {
+        emitInitializeWithCopyCall(IGF, T, dest, src);
+      } else if (isOutlined || T.hasOpenedExistential()) {
         dest = getSingletonAddress(IGF, dest);
         src = getSingletonAddress(IGF, src);
         getSingleton()->initializeWithCopy(
@@ -511,7 +540,9 @@ namespace {
     void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
                             SILType T, bool isOutlined) const override {
       if (!getSingleton()) return;
-      if (isOutlined || T.hasOpenedExistential()) {
+      if (!ElementsAreABIAccessible) {
+        emitInitializeWithTakeCall(IGF, T, dest, src);
+      } else if (isOutlined || T.hasOpenedExistential()) {
         dest = getSingletonAddress(IGF, dest);
         src = getSingletonAddress(IGF, src);
         getSingleton()->initializeWithTake(
@@ -555,7 +586,9 @@ namespace {
                  bool isOutlined) const override {
       if (getSingleton() &&
           !getSingleton()->isPOD(ResilienceExpansion::Maximal)) {
-        if (isOutlined || T.hasOpenedExistential()) {
+        if (!ElementsAreABIAccessible) {
+          emitDestroyCall(IGF, T, addr);
+        } else if (isOutlined || T.hasOpenedExistential()) {
           getSingleton()->destroy(IGF, getSingletonAddress(IGF, addr),
                                   getSingletonType(IGF.IGM, T), isOutlined);
         } else {
@@ -1478,6 +1511,8 @@ namespace {
       Normal,
       /// The payload is POD, so copying is bitwise, and destruction is a noop.
       POD,
+      /// The payload type is ABI-inaccessible, so we can't recurse.
+      ABIInaccessible,
       /// The payload is a single reference-counted value, and we have
       /// a single no-payload case which uses the null extra inhabitant, so
       /// copy and destroy can pass through to retain and release entry
@@ -1595,7 +1630,9 @@ namespace {
 
       // If the payload is POD, then we can use POD value semantics.
       auto &payloadTI = *ElementsWithPayload[0].ti;
-      if (payloadTI.isPOD(ResilienceExpansion::Maximal)) {
+      if (!payloadTI.isABIAccessible()) {
+        CopyDestroyKind = ABIInaccessible;
+      } else if (payloadTI.isPOD(ResilienceExpansion::Maximal)) {
         CopyDestroyKind = POD;
       // If the payload is a single refcounted pointer and we have a single
       // empty case, then the layout will be a nullable pointer, and we can
@@ -2217,6 +2254,7 @@ namespace {
         return IGM.getReferenceType(Refcounting);
       case POD:
       case Normal:
+      case ABIInaccessible:
         llvm_unreachable("not a refcounted payload");
       }
 
@@ -2231,6 +2269,7 @@ namespace {
         return;
       case POD:
       case Normal:
+      case ABIInaccessible:
         llvm_unreachable("not a refcounted payload");
       }
     }
@@ -2243,6 +2282,7 @@ namespace {
         return;
       case POD:
       case Normal:
+      case ABIInaccessible:
         llvm_unreachable("not a refcounted payload");
       }
     }
@@ -2255,6 +2295,7 @@ namespace {
         return;
       case POD:
       case Normal:
+      case ABIInaccessible:
         llvm_unreachable("not a refcounted payload");
       }
     }
@@ -2280,6 +2321,9 @@ namespace {
       case POD:
         reexplode(IGF, src, dest);
         return;
+
+      case ABIInaccessible:
+        llvm_unreachable("ABI-inaccessible type cannot be loadable");
 
       case Normal: {
         if (!copyEnumFunction)
@@ -2315,6 +2359,9 @@ namespace {
         (void)src.claim(getExplosionSize());
         return;
 
+      case ABIInaccessible:
+        llvm_unreachable("ABI-inaccessible type cannot be loadable");
+
       case Normal: {
         if (!consumeEnumFunction)
           consumeEnumFunction = emitConsumeEnumFunction(IGF.IGM, loweredType);
@@ -2344,6 +2391,9 @@ namespace {
       case POD:
         (void)src.claim(getExplosionSize());
         return;
+
+      case ABIInaccessible:
+        llvm_unreachable("ABI-inaccessible type cannot be loadable");
 
       case Normal: {
         // Check that we have a payload.
@@ -2385,10 +2435,15 @@ namespace {
       if (CopyDestroyKind == POD) {
         return;
       }
-      if (isOutlined || T.hasOpenedExistential()) {
+      if (!ElementsAreABIAccessible) {
+        return emitDestroyCall(IGF, T, addr);
+      } else if (isOutlined || T.hasOpenedExistential()) {
         switch (CopyDestroyKind) {
         case POD:
           return;
+
+        case ABIInaccessible:
+          llvm_unreachable("should already have been handled");
 
         case Normal: {
           // Check that there is a payload at the address.
@@ -2474,6 +2529,9 @@ namespace {
       switch (CopyDestroyKind) {
       case POD:
         return emitPrimitiveCopy(IGF, dest, src, T);
+
+      case ABIInaccessible:
+        llvm_unreachable("shouldn't get here");
 
       case Normal: {
         llvm::BasicBlock *endBB = llvm::BasicBlock::Create(C);
@@ -2582,6 +2640,9 @@ namespace {
       case POD:
         return emitPrimitiveCopy(IGF, dest, src, T);
 
+      case ABIInaccessible:
+        llvm_unreachable("shouldn't get here");
+
       case Normal: {
         llvm::BasicBlock *endBB = llvm::BasicBlock::Create(C);
 
@@ -2638,7 +2699,9 @@ namespace {
   public:
     void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
                         SILType T, bool isOutlined) const override {
-      if (isOutlined || T.hasOpenedExistential()) {
+      if (!ElementsAreABIAccessible) {
+        emitAssignWithCopyCall(IGF, T, dest, src);
+      } else if (isOutlined || T.hasOpenedExistential()) {
         emitIndirectAssign(IGF, dest, src, T, IsNotTake, isOutlined);
       } else {
         callOutlinedCopy(IGF, dest, src, T, IsNotInitialization, IsNotTake);
@@ -2647,7 +2710,9 @@ namespace {
 
     void assignWithTake(IRGenFunction &IGF, Address dest, Address src,
                         SILType T, bool isOutlined) const override {
-      if (isOutlined || T.hasOpenedExistential()) {
+      if (!ElementsAreABIAccessible) {
+        emitAssignWithTakeCall(IGF, T, dest, src);
+      } else if (isOutlined || T.hasOpenedExistential()) {
         emitIndirectAssign(IGF, dest, src, T, IsTake, isOutlined);
       } else {
         callOutlinedCopy(IGF, dest, src, T, IsNotInitialization, IsTake);
@@ -2656,7 +2721,9 @@ namespace {
 
     void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
                             SILType T, bool isOutlined) const override {
-      if (isOutlined || T.hasOpenedExistential()) {
+      if (!ElementsAreABIAccessible) {
+        emitInitializeWithCopyCall(IGF, T, dest, src);
+      } else if (isOutlined || T.hasOpenedExistential()) {
         emitIndirectInitialize(IGF, dest, src, T, IsNotTake, isOutlined);
       } else {
         callOutlinedCopy(IGF, dest, src, T, IsInitialization, IsNotTake);
@@ -2665,7 +2732,9 @@ namespace {
 
     void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
                             SILType T, bool isOutlined) const override {
-      if (isOutlined || T.hasOpenedExistential()) {
+      if (!ElementsAreABIAccessible) {
+        emitInitializeWithTakeCall(IGF, T, dest, src);
+      } else if (isOutlined || T.hasOpenedExistential()) {
         emitIndirectInitialize(IGF, dest, src, T, IsTake, isOutlined);
       } else {
         callOutlinedCopy(IGF, dest, src, T, IsInitialization, IsTake);
@@ -2932,6 +3001,8 @@ namespace {
       /// The payloads are all POD, so copying is bitwise, and destruction is a
       /// noop.
       POD,
+      /// One or more of the payloads is ABI-inaccessible, so we cannot recurse.
+      ABIInaccessible,
       /// The payloads are all bitwise-takable, but have no other special
       /// shared layout.
       BitwiseTakable,
@@ -3073,7 +3144,9 @@ namespace {
         }
       }
 
-      if (allPOD) {
+      if (!ElementsAreABIAccessible) {
+        CopyDestroyKind = ABIInaccessible;
+      } else if (allPOD) {
         assert(!allSingleRefcount && "pod *and* refcounted?!");
         CopyDestroyKind = POD;
       // FIXME: Memory corruption issues arise when enabling this for mixed
@@ -3168,6 +3241,7 @@ namespace {
       case POD:
       case BitwiseTakable:
       case Normal:
+      case ABIInaccessible:
         llvm_unreachable("not a refcounted payload");
       }
 
@@ -3183,6 +3257,7 @@ namespace {
       case POD:
       case BitwiseTakable:
       case Normal:
+      case ABIInaccessible:
         llvm_unreachable("not a refcounted payload");
       }
     }
@@ -3196,6 +3271,7 @@ namespace {
       case POD:
       case BitwiseTakable:
       case Normal:
+      case ABIInaccessible:
         llvm_unreachable("not a refcounted payload");
       }
     }
@@ -3209,6 +3285,7 @@ namespace {
       case POD:
       case BitwiseTakable:
       case Normal:
+      case ABIInaccessible:
         llvm_unreachable("not a refcounted payload");
       }
     }
@@ -3989,6 +4066,9 @@ namespace {
         reexplode(IGF, src, dest);
         return;
 
+      case ABIInaccessible:
+        llvm_unreachable("ABI-accessible type cannot be loadable");
+
       case BitwiseTakable:
       case Normal: {
         if (!copyEnumFunction)
@@ -4031,6 +4111,9 @@ namespace {
         (void)src.claim(getExplosionSize());
         return;
 
+      case ABIInaccessible:
+        llvm_unreachable("ABI-accessible type cannot be loadable");
+
       case BitwiseTakable:
       case Normal: {
         if (!consumeEnumFunction)
@@ -4063,6 +4146,9 @@ namespace {
       case POD:
         (void)src.claim(getExplosionSize());
         return;
+
+      case ABIInaccessible:
+        llvm_unreachable("ABI-accessible type cannot be loadable");
 
       case BitwiseTakable:
       case Normal: {
@@ -4102,6 +4188,9 @@ namespace {
       switch (CopyDestroyKind) {
       case POD:
         return emitPrimitiveCopy(IGF, dest, src, T);
+
+      case ABIInaccessible:
+        llvm_unreachable("shouldn't get here");
 
       case BitwiseTakable:
       case TaggedRefcounted:
@@ -4152,6 +4241,9 @@ namespace {
       switch (CopyDestroyKind) {
       case POD:
         return emitPrimitiveCopy(IGF, dest, src, T);
+
+      case ABIInaccessible:
+        llvm_unreachable("shouldn't get here");
 
       case BitwiseTakable:
       case TaggedRefcounted:
@@ -4277,7 +4369,9 @@ namespace {
   public:
     void assignWithCopy(IRGenFunction &IGF, Address dest, Address src,
                         SILType T, bool isOutlined) const override {
-      if (isOutlined || T.hasOpenedExistential()) {
+      if (!ElementsAreABIAccessible) {
+        emitAssignWithCopyCall(IGF, T, dest, src);
+      } else if (isOutlined || T.hasOpenedExistential()) {
         emitIndirectAssign(IGF, dest, src, T, IsNotTake, isOutlined);
       } else {
         callOutlinedCopy(IGF, dest, src, T, IsNotInitialization, IsNotTake);
@@ -4286,7 +4380,9 @@ namespace {
 
     void assignWithTake(IRGenFunction &IGF, Address dest, Address src,
                         SILType T, bool isOutlined) const override {
-      if (isOutlined || T.hasOpenedExistential()) {
+      if (!ElementsAreABIAccessible) {
+        emitAssignWithTakeCall(IGF, T, dest, src);
+      } else if (isOutlined || T.hasOpenedExistential()) {
         emitIndirectAssign(IGF, dest, src, T, IsTake, isOutlined);
       } else {
         callOutlinedCopy(IGF, dest, src, T, IsNotInitialization, IsTake);
@@ -4295,7 +4391,9 @@ namespace {
 
     void initializeWithCopy(IRGenFunction &IGF, Address dest, Address src,
                             SILType T, bool isOutlined) const override {
-      if (isOutlined || T.hasOpenedExistential()) {
+      if (!ElementsAreABIAccessible) {
+        emitInitializeWithCopyCall(IGF, T, dest, src);
+      } else if (isOutlined || T.hasOpenedExistential()) {
         emitIndirectInitialize(IGF, dest, src, T, IsNotTake, isOutlined);
       } else {
         callOutlinedCopy(IGF, dest, src, T, IsInitialization, IsNotTake);
@@ -4304,7 +4402,9 @@ namespace {
 
     void initializeWithTake(IRGenFunction &IGF, Address dest, Address src,
                             SILType T, bool isOutlined) const override {
-      if (isOutlined || T.hasOpenedExistential()) {
+      if (!ElementsAreABIAccessible) {
+        emitInitializeWithTakeCall(IGF, T, dest, src);
+      } else if (isOutlined || T.hasOpenedExistential()) {
         emitIndirectInitialize(IGF, dest, src, T, IsTake, isOutlined);
       } else {
         callOutlinedCopy(IGF, dest, src, T, IsInitialization, IsTake);
@@ -4332,10 +4432,15 @@ namespace {
       if (CopyDestroyKind == POD) {
         return;
       }
-      if (isOutlined || T.hasOpenedExistential()) {
+      if (!ElementsAreABIAccessible) {
+        emitDestroyCall(IGF, T, addr);
+      } else if (isOutlined || T.hasOpenedExistential()) {
         switch (CopyDestroyKind) {
         case POD:
           return;
+
+        case ABIInaccessible:
+          llvm_unreachable("shouldn't get here");
 
         case BitwiseTakable:
         case Normal:
@@ -5395,8 +5500,9 @@ namespace {
                          llvm::Type *irTy,
                          Alignment align,
                          IsPOD_t pod,
-                         IsBitwiseTakable_t bt)
-      : EnumTypeInfoBase(strategy, irTy, align, pod, bt) {}
+                         IsBitwiseTakable_t bt,
+                         IsABIAccessible_t abiAccessible)
+      : EnumTypeInfoBase(strategy, irTy, align, pod, bt, abiAccessible) {}
   };
 
   /// TypeInfo for dynamically-sized enum types.
@@ -5405,8 +5511,8 @@ namespace {
   {
   public:
     ResilientEnumTypeInfo(EnumImplStrategy &strategy,
-                          llvm::Type *irTy)
-      : EnumTypeInfoBase(strategy, irTy) {}
+                          llvm::Type *irTy, IsABIAccessible_t abiAccessible)
+      : EnumTypeInfoBase(strategy, irTy, abiAccessible) {}
   };
 } // end anonymous namespace
 
@@ -5479,10 +5585,13 @@ SingletonEnumImplStrategy::completeEnumTypeLayout(TypeConverter &TC,
       auto alignment = eltTI.getBestKnownAlignment();
       applyLayoutAttributes(TC.IGM, Type.getSwiftRValueType(), /*fixed*/false,
                             alignment);
+      auto enumAccessible =
+        IsABIAccessible_t(TC.IGM.getSILModule().isTypeABIAccessible(Type));
       return registerEnumTypeInfo(new NonFixedEnumTypeInfo(*this, enumTy,
                              alignment,
                              eltTI.isPOD(ResilienceExpansion::Maximal),
-                             eltTI.isBitwiseTakable(ResilienceExpansion::Maximal)));
+                             eltTI.isBitwiseTakable(ResilienceExpansion::Maximal),
+                             enumAccessible));
     } else {
       auto &fixedEltTI = cast<FixedTypeInfo>(eltTI);
       auto alignment = fixedEltTI.getFixedAlignment();
@@ -5668,10 +5777,14 @@ TypeInfo *SinglePayloadEnumImplStrategy::completeDynamicLayout(
   applyLayoutAttributes(TC.IGM, Type.getSwiftRValueType(), /*fixed*/false,
                         alignment);
   
+  auto enumAccessible =
+    IsABIAccessible_t(TC.IGM.getSILModule().isTypeABIAccessible(Type));
+
   return registerEnumTypeInfo(new NonFixedEnumTypeInfo(*this, enumTy,
          alignment,
          payloadTI.isPOD(ResilienceExpansion::Maximal),
-         payloadTI.isBitwiseTakable(ResilienceExpansion::Maximal)));
+         payloadTI.isBitwiseTakable(ResilienceExpansion::Maximal),
+         enumAccessible));
 }
 
 TypeInfo *
@@ -5866,9 +5979,13 @@ TypeInfo *MultiPayloadEnumImplStrategy::completeDynamicLayout(
   
   applyLayoutAttributes(TC.IGM, Type.getSwiftRValueType(), /*fixed*/false,
                         alignment);
+
+  auto enumAccessible =
+    IsABIAccessible_t(TC.IGM.getSILModule().isTypeABIAccessible(Type));
   
   return registerEnumTypeInfo(new NonFixedEnumTypeInfo(*this, enumTy,
-                                                       alignment, pod, bt));
+                                                       alignment, pod, bt,
+                                                       enumAccessible));
 }
 
 TypeInfo *
@@ -5887,7 +6004,10 @@ ResilientEnumImplStrategy::completeEnumTypeLayout(TypeConverter &TC,
                                                   SILType Type,
                                                   EnumDecl *theEnum,
                                                   llvm::StructType *enumTy) {
-  return registerEnumTypeInfo(new ResilientEnumTypeInfo(*this, enumTy));
+  auto abiAccessible =
+    IsABIAccessible_t(TC.IGM.getSILModule().isTypeABIAccessible(Type));
+  return registerEnumTypeInfo(
+                       new ResilientEnumTypeInfo(*this, enumTy, abiAccessible));
 }
 
 const TypeInfo *TypeConverter::convertEnumType(TypeBase *key, CanType type,

--- a/lib/IRGen/GenEnum.h
+++ b/lib/IRGen/GenEnum.h
@@ -138,6 +138,7 @@ protected:
   const TypeInfo *TI = nullptr;
   TypeInfoKind TIK;
   IsFixedSize_t AlwaysFixedSize;
+  IsABIAccessible_t ElementsAreABIAccessible;
   unsigned NumElements;
   
   EnumImplStrategy(IRGenModule &IGM,
@@ -145,12 +146,7 @@ protected:
                    IsFixedSize_t alwaysFixedSize,
                    unsigned NumElements,
                    std::vector<Element> &&ElementsWithPayload,
-                   std::vector<Element> &&ElementsWithNoPayload)
-  : ElementsWithPayload(std::move(ElementsWithPayload)),
-    ElementsWithNoPayload(std::move(ElementsWithNoPayload)),
-    IGM(IGM), TIK(tik), AlwaysFixedSize(alwaysFixedSize),
-    NumElements(NumElements)
-  {}
+                   std::vector<Element> &&ElementsWithNoPayload);
   
   /// Save the TypeInfo created for the enum.
   TypeInfo *registerEnumTypeInfo(TypeInfo *mutableTI) {

--- a/lib/IRGen/GenOpaque.cpp
+++ b/lib/IRGen/GenOpaque.cpp
@@ -388,6 +388,11 @@ IRGenFunction::emitValueWitnessFunctionRef(SILType type,
   return witness;
 }
 
+static llvm::Value *emitCastToOpaquePtr(IRGenFunction &IGF,
+                                        Address object) {
+  return IGF.Builder.CreateBitCast(object.getAddress(), IGF.IGM.OpaquePtrTy);
+}
+
 llvm::Value *irgen::emitInitializeBufferWithCopyOfBufferCall(IRGenFunction &IGF,
                                                      SILType T,
                                                      Address destBuffer,
@@ -529,10 +534,8 @@ void irgen::emitInitializeArrayWithCopyCall(IRGenFunction &IGF,
                                             Address srcObject,
                                             llvm::Value *count) {
   auto metadata = IGF.emitTypeMetadataRefForLayout(T);
-  auto dest =
-      IGF.Builder.CreateBitCast(destObject.getAddress(), IGF.IGM.OpaquePtrTy);
-  auto src =
-      IGF.Builder.CreateBitCast(srcObject.getAddress(), IGF.IGM.OpaquePtrTy);
+  auto dest = emitCastToOpaquePtr(IGF, destObject);
+  auto src = emitCastToOpaquePtr(IGF, srcObject);
   IGF.Builder.CreateCall(IGF.IGM.getArrayInitWithCopyFn(),
                          {dest, src, count, metadata});
 }
@@ -544,10 +547,8 @@ void irgen::emitInitializeArrayWithTakeNoAliasCall(IRGenFunction &IGF,
                                                    Address srcObject,
                                                    llvm::Value *count) {
   auto metadata = IGF.emitTypeMetadataRefForLayout(T);
-  auto dest =
-      IGF.Builder.CreateBitCast(destObject.getAddress(), IGF.IGM.OpaquePtrTy);
-  auto src =
-      IGF.Builder.CreateBitCast(srcObject.getAddress(), IGF.IGM.OpaquePtrTy);
+  auto dest = emitCastToOpaquePtr(IGF, destObject);
+  auto src = emitCastToOpaquePtr(IGF, srcObject);
   IGF.Builder.CreateCall(IGF.IGM.getArrayInitWithTakeNoAliasFn(),
                          {dest, src, count, metadata});
 }
@@ -559,10 +560,8 @@ void irgen::emitInitializeArrayWithTakeFrontToBackCall(IRGenFunction &IGF,
                                             Address srcObject,
                                             llvm::Value *count) {
   auto metadata = IGF.emitTypeMetadataRefForLayout(T);
-  auto dest =
-      IGF.Builder.CreateBitCast(destObject.getAddress(), IGF.IGM.OpaquePtrTy);
-  auto src =
-      IGF.Builder.CreateBitCast(srcObject.getAddress(), IGF.IGM.OpaquePtrTy);
+  auto dest = emitCastToOpaquePtr(IGF, destObject);
+  auto src = emitCastToOpaquePtr(IGF, srcObject);
   IGF.Builder.CreateCall(IGF.IGM.getArrayInitWithTakeFrontToBackFn(),
                          {dest, src, count, metadata});
 }
@@ -574,10 +573,8 @@ void irgen::emitInitializeArrayWithTakeBackToFrontCall(IRGenFunction &IGF,
                                             Address srcObject,
                                             llvm::Value *count) {
   auto metadata = IGF.emitTypeMetadataRefForLayout(T);
-  auto dest =
-      IGF.Builder.CreateBitCast(destObject.getAddress(), IGF.IGM.OpaquePtrTy);
-  auto src =
-      IGF.Builder.CreateBitCast(srcObject.getAddress(), IGF.IGM.OpaquePtrTy);
+  auto dest = emitCastToOpaquePtr(IGF, destObject);
+  auto src = emitCastToOpaquePtr(IGF, srcObject);
   IGF.Builder.CreateCall(IGF.IGM.getArrayInitWithTakeBackToFrontFn(),
                          {dest, src, count, metadata});
 }
@@ -590,8 +587,9 @@ void irgen::emitAssignWithCopyCall(IRGenFunction &IGF,
   llvm::Value *metadata;
   auto copyFn = IGF.emitValueWitnessFunctionRef(T, metadata,
                                                 ValueWitness::AssignWithCopy);
-  IGF.Builder.CreateCall(copyFn,
-      {destObject.getAddress(), srcObject.getAddress(), metadata});
+  auto dest = emitCastToOpaquePtr(IGF, destObject);
+  auto src = emitCastToOpaquePtr(IGF, srcObject);
+  IGF.Builder.CreateCall(copyFn, {dest, src, metadata});
 }
 
 /// Emit a call to do an 'assignWithCopy' operation.
@@ -601,8 +599,9 @@ void irgen::emitAssignWithCopyCall(IRGenFunction &IGF,
                                    Address srcObject) {
   auto copyFn = emitLoadOfValueWitnessFunctionFromMetadata(IGF, metadata,
                                          ValueWitness::AssignWithCopy);
-  IGF.Builder.CreateCall(copyFn,
-      {destObject.getAddress(), srcObject.getAddress(), metadata});
+  auto dest = emitCastToOpaquePtr(IGF, destObject);
+  auto src = emitCastToOpaquePtr(IGF, srcObject);
+  IGF.Builder.CreateCall(copyFn, {dest, src, metadata});
 }
 
 /// Emit a call to do an 'arrayAssignWithCopyNoAlias' operation.
@@ -610,10 +609,8 @@ void irgen::emitAssignArrayWithCopyNoAliasCall(IRGenFunction &IGF, SILType T,
                                           Address destObject, Address srcObject,
                                           llvm::Value *count) {
   auto metadata = IGF.emitTypeMetadataRefForLayout(T);
-  auto dest =
-      IGF.Builder.CreateBitCast(destObject.getAddress(), IGF.IGM.OpaquePtrTy);
-  auto src =
-      IGF.Builder.CreateBitCast(srcObject.getAddress(), IGF.IGM.OpaquePtrTy);
+  auto dest = emitCastToOpaquePtr(IGF, destObject);
+  auto src = emitCastToOpaquePtr(IGF, srcObject);
   IGF.Builder.CreateCall(IGF.IGM.getArrayAssignWithCopyNoAliasFn(),
                          {dest, src, count, metadata});
 }
@@ -625,10 +622,8 @@ void irgen::emitAssignArrayWithCopyFrontToBackCall(IRGenFunction &IGF,
                                                    Address srcObject,
                                                    llvm::Value *count) {
   auto metadata = IGF.emitTypeMetadataRefForLayout(T);
-  auto dest =
-      IGF.Builder.CreateBitCast(destObject.getAddress(), IGF.IGM.OpaquePtrTy);
-  auto src =
-      IGF.Builder.CreateBitCast(srcObject.getAddress(), IGF.IGM.OpaquePtrTy);
+  auto dest = emitCastToOpaquePtr(IGF, destObject);
+  auto src = emitCastToOpaquePtr(IGF, srcObject);
   IGF.Builder.CreateCall(IGF.IGM.getArrayAssignWithCopyFrontToBackFn(),
                          {dest, src, count, metadata});
 }
@@ -640,10 +635,8 @@ void irgen::emitAssignArrayWithCopyBackToFrontCall(IRGenFunction &IGF,
                                                    Address srcObject,
                                                    llvm::Value *count) {
   auto metadata = IGF.emitTypeMetadataRefForLayout(T);
-  auto dest =
-      IGF.Builder.CreateBitCast(destObject.getAddress(), IGF.IGM.OpaquePtrTy);
-  auto src =
-      IGF.Builder.CreateBitCast(srcObject.getAddress(), IGF.IGM.OpaquePtrTy);
+  auto dest = emitCastToOpaquePtr(IGF, destObject);
+  auto src = emitCastToOpaquePtr(IGF, srcObject);
   IGF.Builder.CreateCall(IGF.IGM.getArrayAssignWithCopyBackToFrontFn(),
                          {dest, src, count, metadata});
 }
@@ -656,8 +649,9 @@ void irgen::emitAssignWithTakeCall(IRGenFunction &IGF,
   llvm::Value *metadata;
   auto copyFn = IGF.emitValueWitnessFunctionRef(T, metadata,
                                                 ValueWitness::AssignWithTake);
-  IGF.Builder.CreateCall(copyFn,
-      {destObject.getAddress(), srcObject.getAddress(), metadata});
+  auto dest = emitCastToOpaquePtr(IGF, destObject);
+  auto src = emitCastToOpaquePtr(IGF, srcObject);
+  IGF.Builder.CreateCall(copyFn, {dest, src, metadata});
 }
 
 /// Emit a call to do an 'arrayAssignWithTake' operation.
@@ -665,10 +659,8 @@ void irgen::emitAssignArrayWithTakeCall(IRGenFunction &IGF, SILType T,
                                         Address destObject, Address srcObject,
                                         llvm::Value *count) {
   auto metadata = IGF.emitTypeMetadataRefForLayout(T);
-  auto dest =
-      IGF.Builder.CreateBitCast(destObject.getAddress(), IGF.IGM.OpaquePtrTy);
-  auto src =
-      IGF.Builder.CreateBitCast(srcObject.getAddress(), IGF.IGM.OpaquePtrTy);
+  auto dest = emitCastToOpaquePtr(IGF, destObject);
+  auto src = emitCastToOpaquePtr(IGF, srcObject);
   IGF.Builder.CreateCall(IGF.IGM.getArrayAssignWithTakeFn(),
                          {dest, src, count, metadata});
 }
@@ -683,8 +675,7 @@ void irgen::emitDestroyArrayCall(IRGenFunction &IGF,
     return;
 
   auto metadata = IGF.emitTypeMetadataRefForLayout(T);
-  auto obj =
-      IGF.Builder.CreateBitCast(object.getAddress(), IGF.IGM.OpaquePtrTy);
+  auto obj = emitCastToOpaquePtr(IGF, object);
   IGF.Builder.CreateCall(IGF.IGM.getArrayDestroyFn(), {obj, count, metadata});
 }
 
@@ -696,9 +687,10 @@ llvm::Value *irgen::emitGetExtraInhabitantIndexCall(IRGenFunction &IGF,
   llvm::Value *metadata;
   auto fn = IGF.emitValueWitnessFunctionRef(T, metadata,
                                        ValueWitness::GetExtraInhabitantIndex);
-  
+
+  auto src = emitCastToOpaquePtr(IGF, srcObject);
   llvm::CallInst *call =
-    IGF.Builder.CreateCall(fn, {srcObject.getAddress(), metadata});
+    IGF.Builder.CreateCall(fn, {src, metadata});
   return call;
 }
 
@@ -711,8 +703,9 @@ llvm::Value *irgen::emitStoreExtraInhabitantCall(IRGenFunction &IGF,
   llvm::Value *metadata;
   auto fn = IGF.emitValueWitnessFunctionRef(T, metadata,
                                           ValueWitness::StoreExtraInhabitant);
+  auto dest = emitCastToOpaquePtr(IGF, destObject);
   llvm::CallInst *call =
-    IGF.Builder.CreateCall(fn, {destObject.getAddress(), index, metadata});
+    IGF.Builder.CreateCall(fn, {dest, index, metadata});
   return call;
 }
 
@@ -783,16 +776,15 @@ llvm::Value *irgen::emitGetEnumTagSinglePayloadCall(IRGenFunction &IGF,
     llvm::Value *metadata;
     auto fn = IGF.emitValueWitnessFunctionRef(
         T, metadata, ValueWitness::GetEnumTagSinglePayload);
+    auto dest = emitCastToOpaquePtr(IGF, destObject);
     llvm::CallInst *call = IGF.Builder.CreateCall(
-        fn, {destObject.getAddress(), numEmptyCases, metadata});
+        fn, {dest, numEmptyCases, metadata});
     return call;
   }
   auto *metadata = IGF.emitTypeMetadataRefForLayout(T);
   auto *func = getGetEnumTagSinglePayloadTrampolineFn(IGF.IGM);
-  auto *result = IGF.Builder.CreateCall(
-      func,
-      {IGF.Builder.CreateBitCast(destObject.getAddress(), IGF.IGM.OpaquePtrTy),
-       numEmptyCases, metadata});
+  auto dest = emitCastToOpaquePtr(IGF, destObject);
+  auto *result = IGF.Builder.CreateCall(func, {dest, numEmptyCases, metadata});
   return result;
 }
 
@@ -803,17 +795,17 @@ llvm::Value *irgen::emitStoreEnumTagSinglePayloadCall(
     llvm::Value *metadata;
     auto fn = IGF.emitValueWitnessFunctionRef(
         T, metadata, ValueWitness::StoreEnumTagSinglePayload);
+    auto dest = emitCastToOpaquePtr(IGF, destObject);
     llvm::CallInst *call = IGF.Builder.CreateCall(
-        fn, {destObject.getAddress(), whichCase, numEmptyCases, metadata});
+        fn, {dest, whichCase, numEmptyCases, metadata});
     return call;
   }
 
   auto *metadata = IGF.emitTypeMetadataRefForLayout(T);
   auto *func = getStoreEnumTagSinglePayloadTrampolineFn(IGF.IGM);
-  auto *result = IGF.Builder.CreateCall(
-      func,
-      {IGF.Builder.CreateBitCast(destObject.getAddress(), IGF.IGM.OpaquePtrTy),
-       whichCase, numEmptyCases, metadata});
+  auto dest = emitCastToOpaquePtr(IGF, destObject);
+  auto *result = IGF.Builder.CreateCall(func,
+                                    {dest, whichCase, numEmptyCases, metadata});
   return result;
 }
 
@@ -825,8 +817,9 @@ llvm::Value *irgen::emitGetEnumTagCall(IRGenFunction &IGF,
   auto fn = IGF.emitValueWitnessFunctionRef(T, metadata,
                                             ValueWitness::GetEnumTag);
 
+  auto src = emitCastToOpaquePtr(IGF, srcObject);
   llvm::CallInst *call =
-    IGF.Builder.CreateCall(fn, {srcObject.getAddress(), metadata});
+    IGF.Builder.CreateCall(fn, {src, metadata});
   return call;
 }
 
@@ -838,7 +831,8 @@ void irgen::emitDestructiveProjectEnumDataCall(IRGenFunction &IGF,
   llvm::Value *metadata;
   auto fn = IGF.emitValueWitnessFunctionRef(T, metadata,
                                     ValueWitness::DestructiveProjectEnumData);
-  IGF.Builder.CreateCall(fn, {srcObject.getAddress(), metadata});
+  auto src = emitCastToOpaquePtr(IGF, srcObject);
+  IGF.Builder.CreateCall(fn, {src, metadata});
 }
 
 /// Emit a call to the 'destructiveInjectEnumTag' operation.
@@ -850,7 +844,8 @@ void irgen::emitDestructiveInjectEnumTagCall(IRGenFunction &IGF,
   llvm::Value *metadata;
   auto fn = IGF.emitValueWitnessFunctionRef(T, metadata,
                                       ValueWitness::DestructiveInjectEnumTag);
-  IGF.Builder.CreateCall(fn, {srcObject.getAddress(), tagValue, metadata});
+  auto src = emitCastToOpaquePtr(IGF, srcObject);
+  IGF.Builder.CreateCall(fn, {src, tagValue, metadata});
 }
 
 /// Load the 'size' value witness from the given table as a size_t.
@@ -950,7 +945,9 @@ void irgen::emitInitializeWithCopyCall(IRGenFunction &IGF,
   llvm::Value *metadata;
   auto fn = IGF.emitValueWitnessFunctionRef(T, metadata,
                                             ValueWitness::InitializeWithCopy);
-  IGF.Builder.CreateCall(fn, {dest.getAddress(), src.getAddress(), metadata});
+  auto destPtr = emitCastToOpaquePtr(IGF, dest);
+  auto srcPtr = emitCastToOpaquePtr(IGF, src);
+  IGF.Builder.CreateCall(fn, {destPtr, srcPtr, metadata});
 }
 
 llvm::Value *irgen::emitInitializeWithCopyCall(IRGenFunction &IGF,
@@ -958,8 +955,10 @@ llvm::Value *irgen::emitInitializeWithCopyCall(IRGenFunction &IGF,
                                                Address dest, Address src) {
   auto copyFn = emitLoadOfValueWitnessFunctionFromMetadata(
       IGF, metadata, ValueWitness::InitializeWithCopy);
+  auto destPtr = emitCastToOpaquePtr(IGF, dest);
+  auto srcPtr = emitCastToOpaquePtr(IGF, src);
   llvm::CallInst *call = IGF.Builder.CreateCall(
-      copyFn, {dest.getAddress(), src.getAddress(), metadata});
+      copyFn, {destPtr, srcPtr, metadata});
 
   return call;
 }
@@ -972,7 +971,9 @@ void irgen::emitInitializeWithTakeCall(IRGenFunction &IGF,
   llvm::Value *metadata;
   auto fn = IGF.emitValueWitnessFunctionRef(T, metadata,
                                             ValueWitness::InitializeWithTake);
-  IGF.Builder.CreateCall(fn, {dest.getAddress(), src.getAddress(), metadata});
+  auto destPtr = emitCastToOpaquePtr(IGF, dest);
+  auto srcPtr = emitCastToOpaquePtr(IGF, src);
+  IGF.Builder.CreateCall(fn, {destPtr, srcPtr, metadata});
 }
 
 llvm::Value *irgen::emitInitializeWithTakeCall(IRGenFunction &IGF,
@@ -980,8 +981,10 @@ llvm::Value *irgen::emitInitializeWithTakeCall(IRGenFunction &IGF,
                                                Address dest, Address src) {
   auto copyFn = emitLoadOfValueWitnessFunctionFromMetadata(
       IGF, metadata, ValueWitness::InitializeWithTake);
-  llvm::CallInst *call = IGF.Builder.CreateCall(
-      copyFn, {dest.getAddress(), src.getAddress(), metadata});
+  auto destPtr = emitCastToOpaquePtr(IGF, dest);
+  auto srcPtr = emitCastToOpaquePtr(IGF, src);
+  llvm::CallInst *call =
+    IGF.Builder.CreateCall(copyFn, {destPtr, srcPtr, metadata});
 
   return call;
 }
@@ -996,14 +999,16 @@ void irgen::emitDestroyCall(IRGenFunction &IGF,
   llvm::Value *metadata;
   auto fn = IGF.emitValueWitnessFunctionRef(T, metadata,
                                             ValueWitness::Destroy);
-  IGF.Builder.CreateCall(fn, {object.getAddress(), metadata});
+  auto objectPtr = emitCastToOpaquePtr(IGF, object);
+  IGF.Builder.CreateCall(fn, {objectPtr, metadata});
 }
 
 void irgen::emitDestroyCall(IRGenFunction &IGF, llvm::Value *metadata,
                             Address object) {
   auto fn = emitLoadOfValueWitnessFunctionFromMetadata(IGF, metadata,
                                                        ValueWitness::Destroy);
-  IGF.Builder.CreateCall(fn, {object.getAddress(), metadata});
+  auto objectPtr = emitCastToOpaquePtr(IGF, object);
+  IGF.Builder.CreateCall(fn, {objectPtr, metadata});
 }
 
 static llvm::Constant *getAllocateValueBufferFunction(IRGenModule &IGM) {

--- a/lib/IRGen/GenRecord.h
+++ b/lib/IRGen/GenRecord.h
@@ -22,6 +22,7 @@
 #include "IRGenModule.h"
 #include "Explosion.h"
 #include "GenEnum.h"
+#include "GenOpaque.h"
 #include "LoadableTypeInfo.h"
 #include "Outlining.h"
 #include "TypeInfo.h"
@@ -69,6 +70,10 @@ public:
     return Layout.isPOD();
   }
 
+  IsABIAccessible_t isABIAccessible() const {
+    return Layout.getTypeForLayout().isABIAccessible();
+  }
+
   Address projectAddress(IRGenFunction &IGF, Address seq,
                          NonFixedOffsets offsets) const {
     return Layout.project(IGF, seq, offsets, "." + asImpl()->getFieldName());
@@ -93,6 +98,11 @@ public:
   }
 };
 
+enum FieldsAreABIAccessible_t : bool {
+  FieldsAreNotABIAccessible = false,
+  FieldsAreABIAccessible = true,
+};
+
 /// A metaprogrammed TypeInfo implementation for record types.
 template <class Impl, class Base, class FieldImpl_,
           bool IsLoadable = std::is_base_of<LoadableTypeInfo, Base>::value>
@@ -105,13 +115,18 @@ public:
 
 private:
   const unsigned NumFields;
+  const unsigned AreFieldsABIAccessible : 1;
 
 protected:
   const Impl &asImpl() const { return *static_cast<const Impl*>(this); }
 
   template <class... As> 
-  RecordTypeInfoImpl(ArrayRef<FieldImpl> fields, As&&...args)
-      : Base(std::forward<As>(args)...), NumFields(fields.size()) {
+  RecordTypeInfoImpl(ArrayRef<FieldImpl> fields,
+                     FieldsAreABIAccessible_t fieldsABIAccessible,
+                     As&&...args)
+      : Base(std::forward<As>(args)...),
+        NumFields(fields.size()),
+        AreFieldsABIAccessible(fieldsABIAccessible) {
     std::uninitialized_copy(fields.begin(), fields.end(),
                             this->template getTrailingObjects<FieldImpl>());
   }
@@ -138,6 +153,11 @@ public:
 
   void assignWithCopy(IRGenFunction &IGF, Address dest, Address src, SILType T,
                       bool isOutlined) const override {
+    // If the fields are not ABI-accessible, use the value witness table.
+    if (!AreFieldsABIAccessible) {
+      return emitAssignWithCopyCall(IGF, T, dest, src);
+    }
+
     if (isOutlined || T.hasOpenedExistential()) {
       auto offsets = asImpl().getNonFixedOffsets(IGF, T);
       for (auto &field : getFields()) {
@@ -156,6 +176,11 @@ public:
 
   void assignWithTake(IRGenFunction &IGF, Address dest, Address src, SILType T,
                       bool isOutlined) const override {
+    // If the fields are not ABI-accessible, use the value witness table.
+    if (!AreFieldsABIAccessible) {
+      return emitAssignWithTakeCall(IGF, T, dest, src);
+    }
+
     if (isOutlined || T.hasOpenedExistential()) {
       auto offsets = asImpl().getNonFixedOffsets(IGF, T);
       for (auto &field : getFields()) {
@@ -179,6 +204,11 @@ public:
         isa<LoadableTypeInfo>(this)) {
       return cast<LoadableTypeInfo>(this)->LoadableTypeInfo::initializeWithCopy(
           IGF, dest, src, T, isOutlined);
+    }
+
+    // If the fields are not ABI-accessible, use the value witness table.
+    if (!AreFieldsABIAccessible) {
+      return emitInitializeWithCopyCall(IGF, T, dest, src);
     }
 
     if (isOutlined || T.hasOpenedExistential()) {
@@ -207,6 +237,11 @@ public:
       return;
     }
 
+    // If the fields are not ABI-accessible, use the value witness table.
+    if (!AreFieldsABIAccessible) {
+      return emitInitializeWithTakeCall(IGF, T, dest, src);
+    }
+
     if (isOutlined || T.hasOpenedExistential()) {
       auto offsets = asImpl().getNonFixedOffsets(IGF, T);
       for (auto &field : getFields()) {
@@ -225,6 +260,11 @@ public:
 
   void destroy(IRGenFunction &IGF, Address addr, SILType T,
                bool isOutlined) const override {
+    // If the fields are not ABI-accessible, use the value witness table.
+    if (!AreFieldsABIAccessible) {
+      return emitDestroyCall(IGF, T, addr);
+    }
+
     if (isOutlined || T.hasOpenedExistential()) {
       auto offsets = asImpl().getNonFixedOffsets(IGF, T);
       for (auto &field : getFields()) {
@@ -323,6 +363,9 @@ private:
       // Ignore empty fields.
       if (field.isEmpty()) continue;
 
+      // If the field is not ABI-accessible, suppress this.
+      if (!field.isABIAccessible()) continue;
+
       // If we've already found an index, then there isn't a
       // unique non-empty field.
       if (result) return 0;
@@ -351,7 +394,8 @@ class RecordTypeInfo<Impl, Base, FieldImpl,
 
 protected:
   template <class... As> 
-  RecordTypeInfo(As&&...args) : super(std::forward<As>(args)...) {}
+  RecordTypeInfo(ArrayRef<FieldImpl> fields, As &&...args)
+    : super(fields, FieldsAreABIAccessible, std::forward<As>(args)...) {}
 };
 
 /// An implementation of RecordTypeInfo for loadable types. 
@@ -367,9 +411,10 @@ protected:
   using super::asImpl;
 
   template <class... As> 
-  RecordTypeInfo(ArrayRef<FieldImpl> fields, unsigned explosionSize,
+  RecordTypeInfo(ArrayRef<FieldImpl> fields,
+                 unsigned explosionSize,
                  As &&...args)
-    : super(fields, std::forward<As>(args)...),
+    : super(fields, FieldsAreABIAccessible, std::forward<As>(args)...),
       ExplosionSize(explosionSize) {}
 
 private:
@@ -518,6 +563,7 @@ public:
     fieldTypesForLayout.reserve(astFields.size());
 
     bool loadable = true;
+    auto fieldsABIAccessible = FieldsAreABIAccessible;
 
     unsigned explosionSize = 0;
     for (unsigned i : indices(astFields)) {
@@ -526,6 +572,9 @@ public:
       auto &fieldTI = IGM.getTypeInfo(asImpl()->getType(astField));
       assert(fieldTI.isComplete());
       fieldTypesForLayout.push_back(&fieldTI);
+
+      if (!fieldTI.isABIAccessible())
+        fieldsABIAccessible = FieldsAreNotABIAccessible;
 
       fields.push_back(FieldImpl(asImpl()->getFieldInfo(i, astField, fieldTI)));
 
@@ -550,11 +599,14 @@ public:
     // Create the type info.
     if (loadable) {
       assert(layout.isFixedLayout());
+      assert(fieldsABIAccessible);
       return asImpl()->createLoadable(fields, std::move(layout), explosionSize);
     } else if (layout.isFixedLayout()) {
+      assert(fieldsABIAccessible);
       return asImpl()->createFixed(fields, std::move(layout));
     } else {
-      return asImpl()->createNonFixed(fields, std::move(layout));
+      return asImpl()->createNonFixed(fields, fieldsABIAccessible,
+                                      std::move(layout));
     }
   }  
 };

--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -494,11 +494,15 @@ namespace {
                                   WitnessSizedTypeInfo<NonFixedStructTypeInfo>>
   {
   public:
-    NonFixedStructTypeInfo(ArrayRef<StructFieldInfo> fields, llvm::Type *T,
+    NonFixedStructTypeInfo(ArrayRef<StructFieldInfo> fields,
+                           FieldsAreABIAccessible_t fieldsAccessible,
+                           llvm::Type *T,
                            Alignment align,
-                           IsPOD_t isPOD, IsBitwiseTakable_t isBT)
+                           IsPOD_t isPOD, IsBitwiseTakable_t isBT,
+                           IsABIAccessible_t structAccessible)
       : StructTypeInfoBase(StructTypeInfoKind::NonFixedStructTypeInfo,
-                           fields, T, align, isPOD, isBT) {
+                           fields, fieldsAccessible,
+                           T, align, isPOD, isBT, structAccessible) {
     }
 
     // We have an indirect schema.
@@ -556,11 +560,16 @@ namespace {
     }
 
     NonFixedStructTypeInfo *createNonFixed(ArrayRef<StructFieldInfo> fields,
+                                     FieldsAreABIAccessible_t fieldsAccessible,
                                            StructLayout &&layout) {
-      return NonFixedStructTypeInfo::create(fields, layout.getType(),
+      auto structAccessible = IsABIAccessible_t(
+        IGM.getSILModule().isTypeMetadataAccessible(TheStruct));
+      return NonFixedStructTypeInfo::create(fields, fieldsAccessible,
+                                            layout.getType(),
                                             layout.getAlignment(),
                                             layout.isPOD(),
-                                            layout.isBitwiseTakable());
+                                            layout.isBitwiseTakable(),
+                                            structAccessible);
     }
 
     StructFieldInfo getFieldInfo(unsigned index,
@@ -871,24 +880,29 @@ namespace {
       : public ResilientTypeInfo<ResilientStructTypeInfo>
   {
   public:
-    ResilientStructTypeInfo(llvm::Type *T)
-      : ResilientTypeInfo(T) {
+    ResilientStructTypeInfo(llvm::Type *T, IsABIAccessible_t abiAccessible)
+      : ResilientTypeInfo(T, abiAccessible) {
       setSubclassKind((unsigned) StructTypeInfoKind::ResilientStructTypeInfo);
     }
   };
 } // end anonymous namespace
 
-const TypeInfo *TypeConverter::convertResilientStruct() {
+const TypeInfo *
+TypeConverter::convertResilientStruct(IsABIAccessible_t abiAccessible) {
   llvm::Type *storageType = IGM.OpaquePtrTy->getElementType();
-  return new ResilientStructTypeInfo(storageType);
+  return new ResilientStructTypeInfo(storageType, abiAccessible);
 }
 
 const TypeInfo *TypeConverter::convertStructType(TypeBase *key, CanType type,
                                                  StructDecl *D) {
   // All resilient structs have the same opaque lowering, since they are
-  // indistinguishable as values.
-  if (IGM.isResilient(D, ResilienceExpansion::Maximal))
-    return &getResilientStructTypeInfo();
+  // indistinguishable as values --- except that we have to track
+  // ABI-accessibility.
+  if (IGM.isResilient(D, ResilienceExpansion::Maximal)) {
+    auto structAccessible =
+      IsABIAccessible_t(IGM.getSILModule().isTypeMetadataAccessible(type));
+    return &getResilientStructTypeInfo(structAccessible);
+  }
 
   // Create the struct type.
   auto ty = IGM.createNominalType(type);

--- a/lib/IRGen/GenType.cpp
+++ b/lib/IRGen/GenType.cpp
@@ -1243,12 +1243,15 @@ const LoadableTypeInfo &TypeConverter::getEmptyTypeInfo() {
   return *EmptyTI;
 }
 
-const TypeInfo &TypeConverter::getResilientStructTypeInfo() {
-  if (ResilientStructTI) return *ResilientStructTI;
-  ResilientStructTI = convertResilientStruct();
-  ResilientStructTI->NextConverted = FirstType;
-  FirstType = ResilientStructTI;
-  return *ResilientStructTI;
+const TypeInfo &
+TypeConverter::getResilientStructTypeInfo(IsABIAccessible_t isAccessible) {
+  auto &cache = isAccessible ? AccessibleResilientStructTI
+                             : InaccessibleResilientStructTI;
+  if (cache) return *cache;
+  cache = convertResilientStruct(isAccessible);
+  cache->NextConverted = FirstType;
+  FirstType = cache;
+  return *cache;
 }
 
 /// Get the fragile type information for the given type, which may not

--- a/lib/IRGen/GenType.h
+++ b/lib/IRGen/GenType.h
@@ -82,7 +82,8 @@ private:
   const LoadableTypeInfo *ObjCClassPtrTI = nullptr;
   const LoadableTypeInfo *EmptyTI = nullptr;
 
-  const TypeInfo *ResilientStructTI = nullptr;
+  const TypeInfo *AccessibleResilientStructTI = nullptr;
+  const TypeInfo *InaccessibleResilientStructTI = nullptr;
   
   llvm::DenseMap<std::pair<unsigned, unsigned>, const LoadableTypeInfo *>
     OpaqueStorageTypes;
@@ -123,7 +124,7 @@ private:
   const LoadableTypeInfo *convertBuiltinNativeObject();
   const LoadableTypeInfo *convertBuiltinUnknownObject();
   const LoadableTypeInfo *convertBuiltinBridgeObject();
-  const TypeInfo *convertResilientStruct();
+  const TypeInfo *convertResilientStruct(IsABIAccessible_t abiAccessible);
   const TypeInfo *convertUnmanagedStorageType(UnmanagedStorageType *T);
   const TypeInfo *convertUnownedStorageType(UnownedStorageType *T);
   const TypeInfo *convertWeakStorageType(WeakStorageType *T);
@@ -147,7 +148,7 @@ public:
   const LoadableTypeInfo &getObjCClassPtrTypeInfo();
   const LoadableTypeInfo &getWitnessTablePtrTypeInfo();
   const LoadableTypeInfo &getEmptyTypeInfo();
-  const TypeInfo &getResilientStructTypeInfo();
+  const TypeInfo &getResilientStructTypeInfo(IsABIAccessible_t abiAccessible);
   const ProtocolInfo &getProtocolInfo(ProtocolDecl *P);
   const LoadableTypeInfo &getOpaqueStorageTypeInfo(Size storageSize,
                                                    Alignment storageAlign);

--- a/lib/IRGen/IRGen.h
+++ b/lib/IRGen/IRGen.h
@@ -33,7 +33,7 @@ namespace swift {
   class CanType;
   class ClusteredBitVector;
   enum ForDefinition_t : bool;
-  
+
 namespace irgen {
   using Lowering::AbstractionPattern;
   using clang::CodeGen::ConstantInitFuture;
@@ -76,6 +76,11 @@ inline IsBitwiseTakable_t operator&(IsBitwiseTakable_t l, IsBitwiseTakable_t r) 
 inline IsBitwiseTakable_t &operator&=(IsBitwiseTakable_t &l, IsBitwiseTakable_t r) {
   return (l = (l & r));
 }
+
+enum IsABIAccessible_t : bool {
+  IsNotABIAccessible = false,
+  IsABIAccessible = true  
+};
 
 /// The kind of reference counting implementation a heap object uses.
 enum class ReferenceCounting : uint8_t {

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -1923,6 +1923,9 @@ namespace {
   /// not to cache the result as if it were the metadata for a formal type
   /// unless the type actually cannot possibly be a formal type, e.g. because
   /// it is one of the special lowered type kinds like SILFunctionType.
+  ///
+  /// NOTE: If you modify the special cases in this, you should update
+  /// isTypeMetadataForLayoutAccessible in SIL.cpp.
   class EmitTypeMetadataRefForLayout
     : public CanTypeVisitor<EmitTypeMetadataRefForLayout, llvm::Value *,
                             DynamicMetadataRequest> {

--- a/lib/IRGen/NonFixedTypeInfo.h
+++ b/lib/IRGen/NonFixedTypeInfo.h
@@ -52,8 +52,8 @@ protected:
   const Impl &asImpl() const { return static_cast<const Impl &>(*this); }
 
   WitnessSizedTypeInfo(llvm::Type *type, Alignment align, IsPOD_t pod,
-                       IsBitwiseTakable_t bt)
-    : super(type, align, pod, bt, IsNotFixedSize, TypeInfo::STIK_None) {}
+                       IsBitwiseTakable_t bt, IsABIAccessible_t abi)
+    : super(type, align, pod, bt, IsNotFixedSize, abi, TypeInfo::STIK_None) {}
 
 private:
   /// Bit-cast the given pointer to the right type and assume it as an

--- a/lib/IRGen/ResilientTypeInfo.h
+++ b/lib/IRGen/ResilientTypeInfo.h
@@ -42,9 +42,10 @@ namespace irgen {
 template <class Impl>
 class ResilientTypeInfo : public WitnessSizedTypeInfo<Impl> {
 protected:
-  ResilientTypeInfo(llvm::Type *type)
+  ResilientTypeInfo(llvm::Type *type, IsABIAccessible_t abiAccessible)
     : WitnessSizedTypeInfo<Impl>(type, Alignment(1),
-                                 IsNotPOD, IsNotBitwiseTakable) {}
+                                 IsNotPOD, IsNotBitwiseTakable,
+                                 abiAccessible) {}
 
 public:
   void assignWithCopy(IRGenFunction &IGF, Address dest, Address src, SILType T,

--- a/lib/IRGen/TypeInfo.h
+++ b/lib/IRGen/TypeInfo.h
@@ -93,10 +93,12 @@ protected:
   TypeInfo(llvm::Type *Type, Alignment A, IsPOD_t pod,
            IsBitwiseTakable_t bitwiseTakable,
            IsFixedSize_t alwaysFixedSize,
+           IsABIAccessible_t abiAccessible,
            SpecialTypeInfoKind stik)
     : NextConverted(0), StorageType(Type), nativeReturnSchema(nullptr),
       nativeParameterSchema(nullptr), StorageAlignment(A),
       POD(pod), BitwiseTakable(bitwiseTakable),
+      ABIAccessible(abiAccessible),
       AlwaysFixedSize(alwaysFixedSize), STIK(stik),
       SubclassKind(InvalidSubclassKind) {
     assert(STIK >= STIK_Fixed || !AlwaysFixedSize);
@@ -134,6 +136,9 @@ private:
   /// Whether this type is known to be bitwise-takable.
   unsigned BitwiseTakable : 1;
 
+  /// Whether this type is ABI-accessible from this SILModule.
+  unsigned ABIAccessible : 1;
+
   /// Whether this type can be assumed to have a fixed size from all
   /// resilience domains.
   unsigned AlwaysFixedSize : 1;
@@ -160,6 +165,17 @@ public:
 
   /// Whether this type is known to be empty.
   bool isKnownEmpty(ResilienceExpansion expansion) const;
+
+  /// Whether this type is known to be ABI-accessible, i.e. whether it's
+  /// actually possible to do ABI operations on it from this current SILModule.
+  /// See SILModule::isTypeABIAccessible.
+  ///
+  /// All fixed-size types are currently ABI-accessible, although this would
+  /// not be difficult to change (e.g. if we had an archetype size constraint
+  /// that didn't say anything about triviality).
+  IsABIAccessible_t isABIAccessible() const {
+    return IsABIAccessible_t(ABIAccessible);
+  }
 
   /// Whether this type is known to be POD, i.e. to not require any
   /// particular action on copy or destroy.

--- a/lib/SIL/SIL.cpp
+++ b/lib/SIL/SIL.cpp
@@ -105,3 +105,101 @@ swift::getLinkageForProtocolConformance(const NormalProtocolConformance *C,
       return (definition ? SILLinkage::Public : SILLinkage::PublicExternal);
   }
 }
+
+bool SILModule::isTypeMetadataAccessible(CanType type) {
+  assert(type->isLegalFormalType());
+
+  return !type.findIf([&](CanType type) {
+    // Note that this function returns true if the type is *illegal* to use.
+
+    // Ignore non-nominal types.
+    auto decl = type.getNominalOrBoundGenericNominal();
+    if (!decl)
+      return false;
+
+    // Check whether the declaration is inaccessible from the current context.
+    switch (getDeclLinkage(decl)) {
+
+    // Public declarations are accessible from everywhere.
+    case FormalLinkage::PublicUnique:
+    case FormalLinkage::PublicNonUnique:
+      return false;
+
+    // Hidden declarations are inaccessible from different modules.
+    case FormalLinkage::HiddenUnique:
+      return (decl->getModuleContext() != getSwiftModule());
+
+    // Private declarations are inaccessible from different files unless
+    // this is WMO and we're in the same module.
+    case FormalLinkage::Private: {
+      // The only time we don't have an associated DC is in the
+      // integrated REPL, where we also don't have a concept of other
+      // source files within the current module.
+      if (!AssociatedDeclContext)
+        return (decl->getModuleContext() != getSwiftModule());
+
+      // The associated DC should be either a SourceFile or, in WMO mode,
+      // a ModuleDecl.  In the WMO modes, IRGen will ensure that private
+      // declarations are usable throughout the module.  Therefore, in
+      // either case we just need to make sure that the declaration comes
+      // from within the associated DC.
+      auto declDC = decl->getDeclContext();
+      return !(declDC == AssociatedDeclContext ||
+               declDC->isChildContextOf(AssociatedDeclContext));
+    }
+    }
+    llvm_unreachable("bad linkage");
+  });
+}
+
+/// Answer whether IRGen's emitTypeMetadataForLayout can fetch metadata for
+/// a type, which is the necessary condition for being able to do value
+/// operations on the type using dynamic metadata.
+static bool isTypeMetadataForLayoutAccessible(SILModule &M, SILType type) {
+  // Look through types that aren't necessarily legal formal types:
+
+  //   - tuples
+  if (auto tupleType = type.getAs<TupleType>()) {
+    for (auto index : indices(tupleType.getElementTypes())) {
+      if (!isTypeMetadataForLayoutAccessible(M, type.getTupleElementType(index)))
+        return false;
+    }
+    return true;
+  }
+
+  //   - optionals
+  if (auto objType = type.getOptionalObjectType()) {
+    return isTypeMetadataForLayoutAccessible(M, objType);
+  }
+
+  //   - function types
+  if (type.is<SILFunctionType>())
+    return true;
+
+  //   - metatypes
+  if (type.is<AnyMetatypeType>())
+    return true;
+
+  // Otherwise, check that we can fetch the type metadata.
+  return M.isTypeMetadataAccessible(type.getSwiftRValueType());
+
+}
+
+/// Can we perform value operations on the given type?  We have no way
+/// of doing value operations on resilient-layout types from other modules
+/// that are ABI-private to their defining module.  But if the type is not
+/// ABI-private, we can always at least fetch its metadata and use the
+/// value witness table stored there.
+bool SILModule::isTypeABIAccessible(SILType type) {
+  // Fixed-ABI types can have value operations done without metadata.
+  if (Types.getTypeLowering(type).isFixedABI())
+    return true;
+
+  assert(!type.is<ReferenceStorageType>() &&
+         !type.is<SILFunctionType>() &&
+         !type.is<AnyMetatypeType>() &&
+         "unexpected SIL lowered-only type with non-fixed layout");
+
+  // Otherwise, we need to be able to fetch layout-metadata for the type.
+  return isTypeMetadataForLayoutAccessible(*this, type);
+}

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1819,6 +1819,8 @@ public:
             "Dest address should be lvalue");
     require(SI->getDest()->getType() == SI->getSrc()->getType(),
             "Store operand type and dest type mismatch");
+    require(F.getModule().isTypeABIAccessible(SI->getDest()->getType()),
+            "cannot directly copy type with inaccessible ABI");
   }
 
   void checkRetainValueInst(RetainValueInst *I) {
@@ -2241,6 +2243,8 @@ public:
   void checkDestroyAddrInst(DestroyAddrInst *DI) {
     require(DI->getOperand()->getType().isAddress(),
             "Operand of destroy_addr must be address");
+    require(F.getModule().isTypeABIAccessible(DI->getOperand()->getType()),
+            "cannot directly destroy type with inaccessible ABI");
   }
 
   void checkBindMemoryInst(BindMemoryInst *BI) {

--- a/test/IRGen/Inputs/OtherModule.swift
+++ b/test/IRGen/Inputs/OtherModule.swift
@@ -1,0 +1,24 @@
+import resilient_struct
+
+public struct First {}
+public struct Second {
+    public let resilientData: Size
+}
+
+private enum PrivateEnum {
+  case first(First?)
+  case second(Second?)
+}
+
+public struct Foo {
+    private var _property = PrivateEnum.first(nil)
+}
+
+internal enum InternalEnum {
+  case first(First?)
+  case second(Second?)
+}
+
+public struct Bar {
+    private var _property = InternalEnum.first(nil)
+}

--- a/test/IRGen/multi_file_resilience.swift
+++ b/test/IRGen/multi_file_resilience.swift
@@ -1,0 +1,41 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+
+// RUN: %target-swift-frontend -emit-module -enable-resilience \
+// RUN:   -emit-module-path=%t/resilient_struct.swiftmodule \
+// RUN:   -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
+
+// RUN: %target-swift-frontend -module-name main -I %t -emit-ir -primary-file %s %S/Inputs/OtherModule.swift | %FileCheck %s -DINT=i%target-ptrsize
+
+// This is a single-module version of the test case in
+// multi_module_resilience.
+// rdar://39763787
+
+// CHECK-LABEL: define {{(protected )?}}swiftcc void @"$S4main7copyFoo3fooAA0C0VAE_tF"
+// CHECK: [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S4main3FooVMa"([[INT]] 0)
+// CHECK: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK: [[VWT:%.*]] = load i8**,
+//   Allocate 'copy'.
+// CHECK: [[T0:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 9
+// CHECK: [[T1:%.*]] = load i8*, i8** [[T0]],
+// CHECK: [[SIZE:%.*]] = ptrtoint i8* [[T1]] to [[INT]]
+// CHECK: [[ALLOCA:%.*]] = alloca i8, [[INT]] [[SIZE]],
+// CHECK: [[COPY:%.*]] = bitcast i8* [[ALLOCA]] to [[FOO:%T4main3FooV]]*
+//   Perform 'initializeWithCopy' via the VWT instead of trying to inline it.
+// CHECK: [[T0:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 2
+// CHECK: [[T1:%.*]] = load i8*, i8** [[T0]],
+// CHECK: [[COPYFN:%.*]] = bitcast i8* [[T1]] to %swift.opaque* (%swift.opaque*, %swift.opaque*, %swift.type*)*
+// CHECK: [[DEST:%.*]] = bitcast [[FOO]]* [[COPY]] to %swift.opaque*
+// CHECK: [[SRC:%.*]] = bitcast [[FOO]]* %1 to %swift.opaque*
+// CHECK: call %swift.opaque* [[COPYFN]](%swift.opaque* noalias [[DEST]], %swift.opaque* noalias [[SRC]], %swift.type* [[METADATA]])
+//   Perform 'initializeWithTake' via the VWT.
+// CHECK: [[T0:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 4
+// CHECK: [[T1:%.*]] = load i8*, i8** [[T0]],
+// CHECK: [[TAKEFN:%.*]] = bitcast i8* [[T1]] to %swift.opaque* (%swift.opaque*, %swift.opaque*, %swift.type*)*
+// CHECK: [[DEST:%.*]] = bitcast [[FOO]]* %0 to %swift.opaque*
+// CHECK: [[SRC:%.*]] = bitcast [[FOO]]* [[COPY]] to %swift.opaque*
+// CHECK: call %swift.opaque* [[TAKEFN]](%swift.opaque* noalias [[DEST]], %swift.opaque* noalias [[SRC]], %swift.type* [[METADATA]])
+public func copyFoo(foo: Foo) -> Foo {
+  let copy = foo
+  return copy
+}

--- a/test/IRGen/multi_module_resilience.swift
+++ b/test/IRGen/multi_module_resilience.swift
@@ -1,0 +1,74 @@
+// RUN: rm -rf %t
+// RUN: mkdir %t
+
+// RUN: %target-swift-frontend -emit-module -enable-resilience \
+// RUN:   -emit-module-path=%t/resilient_struct.swiftmodule \
+// RUN:   -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
+
+// RUN: %target-swift-frontend -emit-module -I %t \
+// RUN:   -emit-module-path=%t/OtherModule.swiftmodule \
+// RUN:   -module-name=OtherModule %S/Inputs/OtherModule.swift
+
+// RUN: %target-swift-frontend -module-name main -I %t -emit-ir %s | %FileCheck %s -DINT=i%target-ptrsize
+
+// rdar://39763787
+
+import OtherModule
+
+// CHECK-LABEL: define {{(protected )?}}swiftcc void @"$S4main7copyFoo3foo11OtherModule0C0VAF_tF"
+// CHECK: [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S11OtherModule3FooVMa"([[INT]] 0)
+// CHECK: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK: [[VWT:%.*]] = load i8**,
+//   Allocate 'copy'.
+// CHECK: [[T0:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 9
+// CHECK: [[T1:%.*]] = load i8*, i8** [[T0]],
+// CHECK: [[SIZE:%.*]] = ptrtoint i8* [[T1]] to [[INT]]
+// CHECK: [[ALLOCA:%.*]] = alloca i8, [[INT]] [[SIZE]],
+// CHECK: [[COPY:%.*]] = bitcast i8* [[ALLOCA]] to [[FOO:%T11OtherModule3FooV]]*
+//   Perform 'initializeWithCopy' via the VWT instead of trying to inline it.
+// CHECK: [[T0:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 2
+// CHECK: [[T1:%.*]] = load i8*, i8** [[T0]],
+// CHECK: [[COPYFN:%.*]] = bitcast i8* [[T1]] to %swift.opaque* (%swift.opaque*, %swift.opaque*, %swift.type*)*
+// CHECK: [[DEST:%.*]] = bitcast [[FOO]]* [[COPY]] to %swift.opaque*
+// CHECK: [[SRC:%.*]] = bitcast [[FOO]]* %1 to %swift.opaque*
+// CHECK: call %swift.opaque* [[COPYFN]](%swift.opaque* noalias [[DEST]], %swift.opaque* noalias [[SRC]], %swift.type* [[METADATA]])
+//   Perform 'initializeWithTake' via the VWT.
+// CHECK: [[T0:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 4
+// CHECK: [[T1:%.*]] = load i8*, i8** [[T0]],
+// CHECK: [[TAKEFN:%.*]] = bitcast i8* [[T1]] to %swift.opaque* (%swift.opaque*, %swift.opaque*, %swift.type*)*
+// CHECK: [[DEST:%.*]] = bitcast [[FOO]]* %0 to %swift.opaque*
+// CHECK: [[SRC:%.*]] = bitcast [[FOO]]* [[COPY]] to %swift.opaque*
+// CHECK: call %swift.opaque* [[TAKEFN]](%swift.opaque* noalias [[DEST]], %swift.opaque* noalias [[SRC]], %swift.type* [[METADATA]])
+public func copyFoo(foo: Foo) -> Foo {
+  let copy = foo
+  return copy
+}
+
+// CHECK-LABEL: define {{(protected )?}}swiftcc void @"$S4main7copyBar3bar11OtherModule0C0VAF_tF"
+// CHECK: [[T0:%.*]] = call swiftcc %swift.metadata_response @"$S11OtherModule3BarVMa"([[INT]] 0)
+// CHECK: [[METADATA:%.*]] = extractvalue %swift.metadata_response [[T0]], 0
+// CHECK: [[VWT:%.*]] = load i8**,
+//   Allocate 'copy'.
+// CHECK: [[T0:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 9
+// CHECK: [[T1:%.*]] = load i8*, i8** [[T0]],
+// CHECK: [[SIZE:%.*]] = ptrtoint i8* [[T1]] to [[INT]]
+// CHECK: [[ALLOCA:%.*]] = alloca i8, [[INT]] [[SIZE]],
+// CHECK: [[COPY:%.*]] = bitcast i8* [[ALLOCA]] to [[BAR:%T11OtherModule3BarV]]*
+//   Perform 'initializeWithCopy' via the VWT instead of trying to inline it.
+// CHECK: [[T0:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 2
+// CHECK: [[T1:%.*]] = load i8*, i8** [[T0]],
+// CHECK: [[COPYFN:%.*]] = bitcast i8* [[T1]] to %swift.opaque* (%swift.opaque*, %swift.opaque*, %swift.type*)*
+// CHECK: [[DEST:%.*]] = bitcast [[BAR]]* [[COPY]] to %swift.opaque*
+// CHECK: [[SRC:%.*]] = bitcast [[BAR]]* %1 to %swift.opaque*
+// CHECK: call %swift.opaque* [[COPYFN]](%swift.opaque* noalias [[DEST]], %swift.opaque* noalias [[SRC]], %swift.type* [[METADATA]])
+//   Perform 'initializeWithTake' via the VWT.
+// CHECK: [[T0:%.*]] = getelementptr inbounds i8*, i8** [[VWT]], i32 4
+// CHECK: [[T1:%.*]] = load i8*, i8** [[T0]],
+// CHECK: [[TAKEFN:%.*]] = bitcast i8* [[T1]] to %swift.opaque* (%swift.opaque*, %swift.opaque*, %swift.type*)*
+// CHECK: [[DEST:%.*]] = bitcast [[BAR]]* %0 to %swift.opaque*
+// CHECK: [[SRC:%.*]] = bitcast [[BAR]]* [[COPY]] to %swift.opaque*
+// CHECK: call %swift.opaque* [[TAKEFN]](%swift.opaque* noalias [[DEST]], %swift.opaque* noalias [[SRC]], %swift.type* [[METADATA]])
+public func copyBar(bar: Bar) -> Bar {
+  let copy = bar
+  return copy
+}


### PR DESCRIPTION
This is the swift-4.2-branch version of #16615.

Track whether types are fixed-ABI and ABI-accessible at the SIL level.
    
*Fixed ABI* means that we can do value operations on the type without any metadata: value-allocations, copies, and destroys.  It's currently equivalent to being fixed-size, but (1) being fixed-size isn't useful by itself at the SIL level and (2) you can imagine resilience or generics micro-optimizations where there's like an attribute that tells us the size of a type without actually telling us how to copy it.  All types are fixed-ABI except:

- layout-unconstrained generic types,
- resilient value types, and
- value types which contain a subobject of such a type (except within indirect enum cases).
    
*ABI-accessible* means that it's legal to perform value operations on the type.  We cannot perform value operations on a type `T` if it's not fixed-ABI and we can't construct metadata for it in the current file.  The latter will be true if `T` is private to a different file (in non-WMO builds) or internal to a different module because the metadata-accessor symbol will be private or hidden, respectively.  Importantly, in these cases, it always illegal to use `T` directly in the current file, which means that SIL generated from that source code won't contain any direct value operations on `T`.  However, we may be able use some type `C` that's itself permitted to use `T` and which *is* accessible to the current file.  If `C` contains subobjects of type `T`, value operations on `C` must perform value operations on `T` recursively.  This is okay as long as we don't either:

- inline code that contains value operations on `T` or
- naively attempt to recursively expand a value operation on `C` into value operations on its subobjects.

(Note that we cannot simply treat `C` as an opaque type because we may need to perform operations on it that would not be legal on a totally opaque type, such as directly accessing a known-stored property.  It is tempting to try to define that away by saying that we never use direct property access on such types and instead go through property accessors.  However, this would require us to *guarantee* the emission of property accessors for properties, which we'd like to avoid.  Also, it's not actually possible to define this problem completely, because the current file might define a type `C2` which contains `C` as a subobject.  The same recursive trouble applies to `C2` as would apply to `C`, but we must be able to directly access the properties of `C2` in order to define its constructors and accessors.  Any model which can support directly accessing the properties of `C2` can equally support it for `C` as well.)

The SIL optimizer currently never tries to expand value operations on objects in memory.  (It does sometimes expand value operations on scalars, and this may be a problem for the opaque-values effort.)  However, IRGen currently recursively expands value operations on non-resilient types.  That is fixed as the final commit in this PR.
    
The SIL verification that I've added here is definitely incomplete.

Fixes rdar://39763787 / [SR-7549](https://bugs.swift.org/browse/SR-7549).