### PR TITLE
<rdar://40069856> Make-deterministic and re-enable Misc/stats_dir_fai…

### DIFF
--- a/test/Misc/stats_dir_failure_count.swift
+++ b/test/Misc/stats_dir_failure_count.swift
@@ -1,8 +1,7 @@
 // Check that a failed process-tree emits nonzero failure counters
-// REQUIRES: rdar40069856
 // RUN: %empty-directory(%t)
 // RUN: echo zzz >%t/other.swift
-// RUN: not %target-swiftc_driver -D BROKEN -j 2 -typecheck -stats-output-dir %t %s %t/other.swift
+// RUN: not %target-swiftc_driver -continue-building-after-errors -D BROKEN -j 2 -typecheck -stats-output-dir %t %s %t/other.swift
 // RUN: %utils/process-stats-dir.py --set-csv-baseline %t/stats.csv %t
 // RUN: %FileCheck -input-file %t/stats.csv -check-prefix=FAILURE %s
 // FAILURE: {{"Driver.NumProcessFailures"	1$}}


### PR DESCRIPTION
This test checks that two subprocesses both fail. Unfortunately if one fails quickly the driver exits before the second gets a chance to fail, making it nondeterministic. Adding `-continue-building-after-errors` fixes this.

rdar://40069856
