### PR TITLE
[CSApply] Make sure that indexing into an r-value tuple produces r-value

### DIFF
--- a/test/Constraints/rdar39931475.swift
+++ b/test/Constraints/rdar39931475.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {
+  func b(i: @escaping (inout Int) -> Double)
+}
+
+func foo<T: P>(_ bar: T) {
+  _ = bar.b { a in Double((a, a += 1).0) }
+}


### PR DESCRIPTION
This is modeled in constraint system in a way
that when member type is resolved by `resolveOverload`
it would take r-value type of the element at
specified index, but if it's a type variable it
could still be bound to l-value later, so r-value
result has to be enforced by coercion if necessary.

Resolves: rdar://problem/39931475

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
