### PR TITLE
🛑[WIP][stdlib] Disable hashing for small dictionaries

### DIFF
--- a/stdlib/public/SwiftShims/GlobalObjects.h
+++ b/stdlib/public/SwiftShims/GlobalObjects.h
@@ -51,6 +51,8 @@ struct _SwiftDictionaryBodyStorage {
   struct _SwiftUnsafeBitMap initializedEntries;
   void *keys;
   void *values;
+  __swift_uint64_t seed0;
+  __swift_uint64_t seed1;
 };
 
 struct _SwiftSetBodyStorage {
@@ -58,6 +60,8 @@ struct _SwiftSetBodyStorage {
   __swift_intptr_t count;
   struct _SwiftUnsafeBitMap initializedEntries;
   void *keys;
+  __swift_uint64_t seed0;
+  __swift_uint64_t seed1;
 };
 
 struct _SwiftEmptyDictionaryStorage {

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -3439,6 +3439,7 @@ internal enum _VariantDictionaryBuffer<Key: Hashable, Value>: _HashBuffer {
 
 #if _runtime(_ObjC)
   @usableFromInline // blacklisted
+  @effects(releasenone)
   internal mutating func ensureUniqueNativeBufferCocoa(
     withBucketCount desiredBucketCount: Int
   ) -> (reallocated: Bool, rehashed: Bool) {

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1801,6 +1801,7 @@ internal class _RawNativeDictionaryStorage
   internal final var values: UnsafeMutableRawPointer
 
   @usableFromInline // FIXME(sil-serialize-all)
+  @nonobjc
   internal final var seed: (UInt64, UInt64)
 
   // This API is unsafe and needs a `_fixLifetime` in the caller.

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -4074,7 +4074,7 @@ internal enum _VariantDictionaryBuffer<Key: Hashable, Value>: _HashBuffer {
   @inlinable // FIXME(sil-serialize-all)
   internal mutating func _nativeLargeRemoveObject(forKey key: Key) -> Value? {
     var idealBucket = asNative._bucket(key)
-    var (index, found) = asNative._find(key)
+    var (index, found) = asNative._find(key, startBucket: idealBucket)
 
     // Fast path: if the key is not present, we will not mutate the set,
     // so don't force unique buffer.

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -2443,13 +2443,13 @@ extension _NativeDictionaryBuffer where Key: Hashable
   }
 
   @inlinable // FIXME(sil-serialize-all)
-  internal func _index(after bucket: Int) -> Int {
+  internal func _bucket(after bucket: Int) -> Int {
     // Bucket is within 0 and bucketCount. Therefore adding 1 does not overflow.
     return (bucket &+ 1) & _bucketMask
   }
 
   @inlinable // FIXME(sil-serialize-all)
-  internal func _prev(_ bucket: Int) -> Int {
+  internal func _bucket(before bucket: Int) -> Int {
     // Bucket is not negative. Therefore subtracting 1 does not overflow.
     return (bucket &- 1) & _bucketMask
   }
@@ -2475,7 +2475,7 @@ extension _NativeDictionaryBuffer where Key: Hashable
       if self.key(at: bucket) == key {
         return (Index(offset: bucket), true)
       }
-      bucket = _index(after: bucket)
+      bucket = _bucket(after: bucket)
     }
   }
 
@@ -3811,15 +3811,15 @@ internal enum _VariantDictionaryBuffer<Key: Hashable, Value>: _HashBuffer {
     // Find the first bucket in the contiguous chain
     var start = idealBucket
     while nativeBuffer.isInitializedEntry(at: nativeBuffer._prev(start)) {
-      start = nativeBuffer._prev(start)
+      start = nativeBuffer._bucket(before: start)
     }
 
     // Find the last bucket in the contiguous chain
     var lastInChain = hole
-    var b = nativeBuffer._index(after: lastInChain)
+    var b = nativeBuffer._bucket(after: lastInChain)
     while nativeBuffer.isInitializedEntry(at: b) {
       lastInChain = b
-      b = nativeBuffer._index(after: b)
+      b = nativeBuffer._bucket(after: b)
     }
 
     // Relocate out-of-place elements in the chain, repeating until
@@ -3839,7 +3839,7 @@ internal enum _VariantDictionaryBuffer<Key: Hashable, Value>: _HashBuffer {
         if start <= hole ? (c0 && c1) : (c0 || c1) {
           break // Found it
         }
-        b = nativeBuffer._prev(b)
+        b = nativeBuffer._bucket(before: b)
       }
 
       if b == hole { // No out-of-place elements found; we're done adjusting

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -2175,8 +2175,10 @@ internal struct _NativeDictionaryBuffer<Key, Value> {
 
   @usableFromInline
   internal var capacity: Int {
-    @inline(never) // blacklisted
+    @inline(__always)
     get {
+      // FIXME: This should be stored in _storage, initialized at its creation.
+      // (Capacity calculation should not be inlinable.)
       if isSmall {
         return bucketCount
       }
@@ -2187,7 +2189,12 @@ internal struct _NativeDictionaryBuffer<Key, Value> {
 
   @inlinable // FIXME(sil-serialize-all)
   internal var isSmall: Bool {
-    return bucketCount <= _smallHashTableLimit
+    @inline(__always)
+    get {
+      // FIXME: This should be a flag in _storage, initialized at its creation.
+      // (This logic should not be inlinable.)
+      return bucketCount <= _smallHashTableLimit
+    }
   }
 
   @inlinable // FIXME(sil-serialize-all)
@@ -2568,7 +2575,10 @@ extension _NativeDictionaryBuffer where Key: Hashable
   /// Find an empty bucket for the specified key, which must not already be in
   /// the Dictionary.
   @inline(__always)
-  @usableFromInline // blacklisted
+  // FIXME: Temporarily disabled
+  // @effects(readonly)
+  // @usableFromInline // blacklisted
+  @inlinable
   internal func _findNew(_ key: Key) -> Int {
     if isSmall {
       _sanityCheck(count < bucketCount)

--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -19,7 +19,7 @@ internal var _smallHashTableLimit: Int {
   @inline(__always) get {
     // Note that this must be a power of two, or it will get rounded up,
     // breaking assumptions made elsewhere in the code.
-    return 1 << 4
+    return 1 << 6
   }
 }
 

--- a/stdlib/public/core/Hashing.swift
+++ b/stdlib/public/core/Hashing.swift
@@ -14,6 +14,15 @@
 // This file implements helpers for hashing collections.
 //
 
+@usableFromInline
+internal var _smallHashTableLimit: Int {
+  @inline(__always) get {
+    // Note that this must be a power of two, or it will get rounded up,
+    // breaking assumptions made elsewhere in the code.
+    return 1 << 4
+  }
+}
+
 /// This protocol is only used for compile-time checks that
 /// every buffer type implements all required operations.
 internal protocol _HashBuffer {

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1470,6 +1470,7 @@ internal class _RawNativeSetStorage:
   internal final var keys: UnsafeMutableRawPointer
 
   @usableFromInline // FIXME(sil-serialize-all)
+  @nonobjc
   internal final var seed: (UInt64, UInt64)
 
   // This API is unsafe and needs a `_fixLifetime` in the caller.

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -2043,13 +2043,13 @@ extension _NativeSetBuffer where Element: Hashable
   }
 
   @inlinable // FIXME(sil-serialize-all)
-  internal func _index(after bucket: Int) -> Int {
+  internal func _bucket(after bucket: Int) -> Int {
     // Bucket is within 0 and bucketCount. Therefore adding 1 does not overflow.
     return (bucket &+ 1) & _bucketMask
   }
 
   @inlinable // FIXME(sil-serialize-all)
-  internal func _prev(_ bucket: Int) -> Int {
+  internal func _bucket(before bucket: Int) -> Int {
     // Bucket is not negative. Therefore subtracting 1 does not overflow.
     return (bucket &- 1) & _bucketMask
   }
@@ -2075,7 +2075,7 @@ extension _NativeSetBuffer where Element: Hashable
       if self.key(at: bucket) == key {
         return (Index(offset: bucket), true)
       }
-      bucket = _index(after: bucket)
+      bucket = _bucket(after: bucket)
     }
   }
 
@@ -3122,16 +3122,18 @@ internal enum _VariantSetBuffer<Element: Hashable>: _HashBuffer {
 
     // Find the first bucket in the contiguous chain
     var start = idealBucket
-    while nativeBuffer.isInitializedEntry(at: nativeBuffer._prev(start)) {
-      start = nativeBuffer._prev(start)
+    while nativeBuffer.isInitializedEntry(
+      at: nativeBuffer._bucket(before: start)
+    ) {
+      start = nativeBuffer._bucket(before: start)
     }
 
     // Find the last bucket in the contiguous chain
     var lastInChain = hole
-    var b = nativeBuffer._index(after: lastInChain)
+    var b = nativeBuffer._bucket(after: lastInChain)
     while nativeBuffer.isInitializedEntry(at: b) {
       lastInChain = b
-      b = nativeBuffer._index(after: b)
+      b = nativeBuffer._bucket(after: b)
     }
 
     // Relocate out-of-place elements in the chain, repeating until
@@ -3151,7 +3153,7 @@ internal enum _VariantSetBuffer<Element: Hashable>: _HashBuffer {
         if start <= hole ? (c0 && c1) : (c0 || c1) {
           break // Found it
         }
-        b = nativeBuffer._prev(b)
+        b = nativeBuffer._bucket(before: b)
       }
 
       if b == hole { // No out-of-place elements found; we're done adjusting

--- a/stdlib/public/core/StringComparable.swift
+++ b/stdlib/public/core/StringComparable.swift
@@ -160,3 +160,26 @@ extension String : Comparable {
 }
 
 extension Substring : Equatable {}
+
+extension String {
+  //@usableFromInline
+  @effects(readonly)
+  public func _find(in haystack: UnsafeBufferPointer<String>) -> Int? {
+    defer { _fixLifetime(self) }
+    if _fastPath(_guts._isSmall) {
+      defer { _fixLifetime(self) }
+      if _guts._smallUTF8String.isASCII {
+        for i in 0 ..< haystack.count {
+          if _guts.rawBits == haystack[i]._guts.rawBits { return i }
+          if !haystack[i]._guts._isSmall, self == haystack[i] { return i }
+        }
+        return nil
+      }
+    }
+    // Slow path
+    for i in 0 ..< haystack.count {
+      if self == haystack[i] { return i }
+    }
+    return nil
+  }
+}

--- a/stdlib/public/stubs/GlobalObjects.cpp
+++ b/stdlib/public/stubs/GlobalObjects.cpp
@@ -73,7 +73,9 @@ swift::_SwiftEmptyDictionaryStorage swift::_swiftEmptyDictionaryStorage = {
     },
     
     (void*)1, // void* keys; (non-null garbage)
-    (void*)1  // void* values; (non-null garbage)
+    (void*)1, // void* values; (non-null garbage)
+
+    0, 0 // seed
   },
 
   0 // int entries; (zero'd bits)
@@ -86,11 +88,11 @@ swift::_SwiftEmptySetStorage swift::_swiftEmptySetStorage = {
     &swift::CLASS_METADATA_SYM(s20_RawNativeSetStorage), // isa pointer
   },
   
-  // _SwiftDictionaryBodyStorage body;
+  // _SwiftSetBodyStorage body;
   {
     // We set the capacity to 1 so that there's an empty hole to search.
     // Any insertion will lead to a real storage being allocated, because 
-    // Dictionary guarantees there's always another empty hole after insertion.
+    // Set guarantees there's always another empty hole after insertion.
     1, // int capacity;                                    
     0, // int count;
     
@@ -100,7 +102,9 @@ swift::_SwiftEmptySetStorage swift::_swiftEmptySetStorage = {
       1 // int bitCount; (1 so there's something for iterators to read)
     },
     
-    (void*)1 // void* keys; (non-null garbage)
+    (void*)1, // void* keys; (non-null garbage)
+
+    0, 0 // seed
   },
 
   0 // int entries; (zero'd bits)


### PR DESCRIPTION
For dictionaries with a small number of entries, calculating the hash is more expensive than just dumping the elements in an unsorted buffer and linear searching through it.

rdar://problem/40070877