### PR TITLE
Clarify ownership of dependency tracker.

### DIFF
--- a/include/swift/Frontend/Frontend.h
+++ b/include/swift/Frontend/Frontend.h
@@ -336,7 +336,8 @@ class CompilerInstance {
   std::unique_ptr<ASTContext> Context;
   std::unique_ptr<SILModule> TheSILModule;
 
-  DependencyTracker *DepTracker = nullptr;
+  /// Null if no tracker.
+  std::unique_ptr<DependencyTracker> DepTracker;
 
   ModuleDecl *MainModule = nullptr;
   SerializedModuleLoader *SML = nullptr;
@@ -408,13 +409,11 @@ public:
     Diagnostics.addConsumer(*DC);
   }
 
-  void setDependencyTracker(DependencyTracker *DT) {
+  void createDependencyTracker() {
     assert(!Context && "must be called before setup()");
-    DepTracker = DT;
+    DepTracker = llvm::make_unique<DependencyTracker>();
   }
-  DependencyTracker *getDependencyTracker() {
-    return DepTracker;
-  }
+  DependencyTracker *getDependencyTracker() { return DepTracker.get(); }
 
   /// Set the SIL module for this compilation instance.
   ///

--- a/lib/Frontend/Frontend.cpp
+++ b/lib/Frontend/Frontend.cpp
@@ -197,10 +197,10 @@ bool CompilerInstance::setUpModuleLoaders() {
     Context->addModuleLoader(SourceLoader::create(*Context,
                                                   !immediate,
                                                   enableResilience,
-                                                  DepTracker));
+                                                  getDependencyTracker()));
   }
   {
-    auto SML = SerializedModuleLoader::create(*Context, DepTracker);
+    auto SML = SerializedModuleLoader::create(*Context, getDependencyTracker());
     this->SML = SML.get();
     Context->addModuleLoader(std::move(SML));
   }
@@ -210,7 +210,7 @@ bool CompilerInstance::setUpModuleLoaders() {
     // knowledge.
     auto clangImporter =
         ClangImporter::create(*Context, Invocation.getClangImporterOptions(),
-                              Invocation.getPCHHash(), DepTracker);
+                              Invocation.getPCHHash(), getDependencyTracker());
     if (!clangImporter) {
       Diagnostics.diagnose(SourceLoc(), diag::error_clang_importer_create_fail);
       return true;

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1756,6 +1756,8 @@ int swift::performFrontend(ArrayRef<const char *> Args,
     enableDiagnosticVerifier(Instance->getSourceMgr());
   }
 
+  // Do not move into the following block. Even though it appears to not be
+  // referenced, depTracker must live as long as this activation record.
   DependencyTracker depTracker;
   {
     const FrontendInputsAndOutputs &io =

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1756,17 +1756,10 @@ int swift::performFrontend(ArrayRef<const char *> Args,
     enableDiagnosticVerifier(Instance->getSourceMgr());
   }
 
-  // Do not move into the following block. Even though it appears to not be
-  // referenced, depTracker must live as long as this activation record.
-  DependencyTracker depTracker;
-  {
-    const FrontendInputsAndOutputs &io =
-        Invocation.getFrontendOptions().InputsAndOutputs;
-    if (io.hasDependencyTrackerPath() ||
-        !Invocation.getFrontendOptions().IndexStorePath.empty()) {
-      Instance->setDependencyTracker(&depTracker);
-    }
-  }
+  if (Invocation.getFrontendOptions()
+          .InputsAndOutputs.hasDependencyTrackerPath() ||
+      !Invocation.getFrontendOptions().IndexStorePath.empty())
+    Instance->createDependencyTracker();
 
   if (Instance->setup(Invocation)) {
     return finishDiagProcessing(1);


### PR DESCRIPTION
<!-- What's in this pull request? -->
The dependency tracker is allocated as a local in `performFrontend` and at first glance, it appears that it could be moved into the following block. But it can't. It needs to last as long as the CompilerInstance. So, move its ownership into the CompilerInstance.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->