### PR TITLE
[SILGen] When emitting an apply, don't decode the dbgloc unconditiona…

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4159,7 +4159,6 @@ RValue SILGenFunction::emitApply(ResultPlanPtr &&resultPlan,
   }
 
   // Emit the raw application.
-  loc.decodeDebugLoc(SGM.M.getASTContext().SourceMgr);
   auto genericSig =
     fn.getType().castTo<SILFunctionType>()->getGenericSignature();
   if (genericSig != subs.getGenericSignature()) {


### PR DESCRIPTION
…lly.

Turns out it's really expensive and not really needed (apparently, all the tests
pass without this). On my machine the testcase reported in #50231 goes down 
from 24 seconds to 2 seconds
after this change.

Resolves #50231
<rdar://problem/40258978>