### PR TITLE
[4.2][CSApply] Make sure that indexing into an r-value tuple produces r-value

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2876,11 +2876,22 @@ namespace {
 
       case OverloadChoiceKind::TupleIndex: {
         Type toType = simplifyType(cs.getType(expr));
-        
-        // If the result type is an rvalue and the base contains lvalues, need a full
-        // tuple coercion to properly load & set access kind on all underlying elements
-        // before taking a single element.
+
         auto baseTy = cs.getType(base);
+        // If the base type is not a tuple l-value, access to
+        // its elements supposed to be r-value as well.
+        //
+        // This is modeled in constraint system in a way
+        // that when member type is resolved by `resolveOverload`
+        // it would take r-value type of the element at
+        // specified index, but if it's a type variable it
+        // could still be bound to l-value later.
+        if (!baseTy->is<LValueType>())
+          toType = toType->getRValueType();
+
+        // If the result type is an rvalue and the base contains lvalues,
+        // need a full tuple coercion to properly load & set access kind
+        // on all underlying elements before taking a single element.
         if (!toType->hasLValueType() && baseTy->hasLValueType())
           base = coerceToType(base, baseTy->getRValueType(),
                               cs.getConstraintLocator(base));

--- a/test/Constraints/rdar39931475.swift
+++ b/test/Constraints/rdar39931475.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {
+  func b(i: @escaping (inout Int) -> Double)
+}
+
+func foo<T: P>(_ bar: T) {
+  _ = bar.b { a in Double((a, a += 1).0) }
+}


### PR DESCRIPTION
This is modeled in constraint system in a way
that when member type is resolved by `resolveOverload`
it would take r-value type of the element at
specified index, but if it's a type variable it
could still be bound to l-value later, so r-value
result has to be enforced by coercion if necessary.

Resolves: rdar://problem/39931475
(cherry picked from commit 58fb0ac6a72e610fdfab920777385771cdbc4fef)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
