### PR TITLE
[SILGen] When emitting an apply, don't decode the dbgloc unconditionally

### DIFF
--- a/lib/SILGen/SILGenApply.cpp
+++ b/lib/SILGen/SILGenApply.cpp
@@ -4158,7 +4158,6 @@ RValue SILGenFunction::emitApply(ResultPlanPtr &&resultPlan,
   }
 
   // Emit the raw application.
-  loc.decodeDebugLoc(SGM.M.getASTContext().SourceMgr);
   SILValue rawDirectResult = emitRawApply(
       *this, loc, fn, subs, args, substFnType, options, indirectResultAddrs);
 


### PR DESCRIPTION
Turns out it's really expensive and not really needed. On my machine
the testcase reported in SR-7691 goes down from 24 seconds to 2 seconds
after this change.

<rdar://problem/40258978>