### PR TITLE
Lazy: Put an initializer expression on Lazy::OnceToken.

### DIFF
--- a/include/swift/Basic/Lazy.h
+++ b/include/swift/Basic/Lazy.h
@@ -47,7 +47,7 @@ namespace swift {
 template <class T> class Lazy {
   alignas(T) char Value[sizeof(T)] = { 0 };
 
-  OnceToken_t OnceToken;
+  OnceToken_t OnceToken = {};
 
   static void defaultInitCallback(void *ValueAddr) {
     ::new (ValueAddr) T();


### PR DESCRIPTION
Recent builds of clang give C++ globals of a type global constructors if they have a mix of explicitly initialized and default-initialized fields, apparently.