### PR TITLE
[migrator] Filter out diag::wrong_argument_labels for the fixit pass

### DIFF
--- a/include/swift/Migrator/FixitFilter.h
+++ b/include/swift/Migrator/FixitFilter.h
@@ -61,6 +61,18 @@ struct FixitFilter {
         Info.ID == diag::invalid_ibinspectable.ID ||
         Info.ID == diag::invalid_ibaction_decl.ID)
       return false;
+
+    // The Migrator only applies changes from the APIDiffMigratorPass in the
+    // primary file, so if a nominal type was renamed, for example, any members
+    // users have added in an extension in a separate file may not be visible,
+    // due to the extension rename not having been applied. The below diag(s)
+    // can provide undesireable fixits that rename references of these
+    // no-longer-visible members to similar still-visible ones.
+    // Note: missing_argument_lables and extra_argument_labels are filtered out
+    // elsewhere
+    if (Info.ID == diag::wrong_argument_labels.ID)
+      return false;
+
     // Adding type(of:) interacts poorly with the swift migrator by
     // invalidating some inits with type errors.
     if (Info.ID == diag::init_not_instance_member.ID)

--- a/test/Migrator/Inputs/API.json
+++ b/test/Migrator/Inputs/API.json
@@ -528,5 +528,16 @@
     "RightUsr": "",
     "RightComment": "Int",
     "ModuleName": "Cities"
+  },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "TypeDecl",
+    "NodeAnnotation": "Rename",
+    "ChildIndex": "0",
+    "LeftUsr": "s:6Cities10FontWeightO",
+    "LeftComment": "FontWeight",
+    "RightUsr": "",
+    "RightComment": "FontWeighting",
+    "ModuleName": "Cities"
   }
 ]

--- a/test/Migrator/Inputs/Cities.swift
+++ b/test/Migrator/Inputs/Cities.swift
@@ -62,3 +62,15 @@ open class ToplevelType {
 }
 
 public var GlobalAttribute: String = ""
+
+public enum FontWeighting: Int {
+  case Light = 0
+  case Regular
+  case Bold
+}
+
+public enum FontWeight: Int {
+  case Light = 0
+  case Regular
+  case Bold
+}

--- a/test/Migrator/Inputs/rename_cross_file_2.swift
+++ b/test/Migrator/Inputs/rename_cross_file_2.swift
@@ -1,0 +1,7 @@
+import Cities
+
+extension FontWeight {
+  init(string: String) { fatalError() }
+  init(x: Int, y: Int, z: Int) { fatalError() }
+  init(x: Int, _ y: Int) { fatalError() }
+}

--- a/test/Migrator/rename_cross_file.swift
+++ b/test/Migrator/rename_cross_file.swift
@@ -1,0 +1,18 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t.mod) && %target-swift-frontend -emit-module -o %t.mod/Cities.swiftmodule %S/Inputs/Cities.swift -module-name Cities -parse-as-library
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s %S/Inputs/rename_cross_file_2.swift -F %S/mock-sdk -I %t.mod -api-diff-data-file %S/Inputs/API.json -emit-migrated-file-path %t/rename_cross_file.swift.result -emit-remap-file-path %t/rename_cross_file.swift.remap -o /dev/null
+// RUN: diff -u %S/rename_cross_file.swift.expected %t/rename_cross_file.swift.result
+
+import Cities
+
+extension FontWeight {
+  init(x: Int, y: Int) { fatalError() }
+  init(x: Int, y: Int, _ z: Int) { fatalError() }
+}
+
+func foo() {
+  _ = FontWeight(rawValue: 1)
+  _ = FontWeight(string: "light")
+  _ = FontWeight(x: 2, y: 2, z: 2)
+  _ = FontWeight(x: 2, 2)
+}

--- a/test/Migrator/rename_cross_file.swift.expected
+++ b/test/Migrator/rename_cross_file.swift.expected
@@ -1,0 +1,18 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t.mod) && %target-swift-frontend -emit-module -o %t.mod/Cities.swiftmodule %S/Inputs/Cities.swift -module-name Cities -parse-as-library
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -primary-file %s %S/Inputs/rename_cross_file_2.swift -F %S/mock-sdk -I %t.mod -api-diff-data-file %S/Inputs/API.json -emit-migrated-file-path %t/rename_cross_file.swift.result -emit-remap-file-path %t/rename_cross_file.swift.remap -o /dev/null
+// RUN: diff -u %S/rename_cross_file.swift.expected %t/rename_cross_file.swift.result
+
+import Cities
+
+extension FontWeighting {
+  init(x: Int, y: Int) { fatalError() }
+  init(x: Int, y: Int, _ z: Int) { fatalError() }
+}
+
+func foo() {
+  _ = FontWeighting(rawValue: 1)
+  _ = FontWeighting(string: "light")
+  _ = FontWeighting(x: 2, y: 2, z: 2)
+  _ = FontWeighting(x: 2, 2)
+}


### PR DESCRIPTION
The migrator only applies changes from the `APIDiffMigratorPass` in the primary file. This means that if a nominal type was renamed, for example, any members users have added in an extension in a separate file won't be visible, because the extension would still have the old name. This can result in 'wrong/extraneous/missing argument label' errors with fixits to change the argument labels that, when applied by the fixit pass, change which function was being called and cause post-migration errors.

This patch updates the fixit pass to ignore fixits from `diag::wrong_argument_labels`. `diag::extra_argument_labels` and `diag::missing_argument_labels` were already filtered out for other reasons.

Resolves rdar://problem/40170377

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
