### PR TITLE
[SR-7501] inlinable misspelling

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1321,6 +1321,8 @@ ERROR(attr_renamed, none,
       "'@%0' has been renamed to '@%1'", (StringRef, StringRef))
 WARNING(attr_renamed_warning, none,
         "'@%0' has been renamed to '@%1'", (StringRef, StringRef))
+ERROR(attr_name_close_match, none,
+      "No attribute named '@%0', did you mean '@%1'?", (StringRef, StringRef))
 
 // availability
 ERROR(attr_availability_platform,none,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1557,6 +1557,13 @@ bool Parser::parseDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc) {
   // the specific fallback path at some point.
   checkRenamedAttr("availability", "available", DAK_Available, false);
 
+  // Check if attr is inlineable, and suggest inlinable instead
+  if (DK == DAK_Count && Tok.getText() == "inlineable") {
+    DK = DAK_Inlinable;
+    diagnose(Tok, diag::attr_name_close_match, "inlineable", "inlinable")
+        .fixItReplace(Tok.getLoc(), "inlinable");
+  }
+
   // In Swift 5 and above, these become hard errors. Otherwise, emit a
   // warning for compatibility.
   if (!Context.isSwiftVersionAtLeast(5)) {

--- a/test/attr/attr_inlinable_close_match.swift
+++ b/test/attr/attr_inlinable_close_match.swift
@@ -1,0 +1,4 @@
+// RUN: %target-typecheck-verify-swift
+
+@inlineable public func misspelledInlinable() {}
+// expected-error@-1 {{No attribute named '@inlineable', did you mean '@inlinable'?}}{{2-12=inlinable}}


### PR DESCRIPTION
Adds a nice error for when `@inlinable` is misspelled as `@inlineable`, and suggests the correct spelling.

Resolves [SR-7501](https://bugs.swift.org/browse/SR-7501).
