### PR TITLE
NFC, [Incremental Compilation] Refactor ReferenceDependencies

### DIFF
--- a/docs/DependencyAnalysis.rst
+++ b/docs/DependencyAnalysis.rst
@@ -92,7 +92,7 @@ External Dependencies
 
 External dependencies, including imported Swift module files and Clang headers,
 are tracked using a special ``depends-external`` set. These dependencies refer
-to definitions that are external to the module. The Swift driver
+to files that are external to the module. The Swift driver
 interprets this set specially and decides whether or not the cross-module
 dependencies have changed.
 

--- a/docs/DependencyAnalysis.rst
+++ b/docs/DependencyAnalysis.rst
@@ -91,7 +91,8 @@ External Dependencies
 =====================
 
 External dependencies, including imported Swift module files and Clang headers,
-are tracked using a special ``depends-external`` set. The Swift driver
+are tracked using a special ``depends-external`` set. These dependencies refer
+to definitions that are external to the module. The Swift driver
 interprets this set specially and decides whether or not the cross-module
 dependencies have changed.
 

--- a/include/swift/AST/Module.h
+++ b/include/swift/AST/Module.h
@@ -977,6 +977,10 @@ public:
   ReferencedNameTracker *getReferencedNameTracker() {
     return ReferencedNames ? ReferencedNames.getPointer() : nullptr;
   }
+  const ReferencedNameTracker *getReferencedNameTracker() const {
+    return ReferencedNames ? ReferencedNames.getPointer() : nullptr;
+  }
+
   void createReferencedNameTracker();
 
   /// \brief The buffer ID for the file that was imported, or None if there

--- a/include/swift/Driver/DependencyGraph.h
+++ b/include/swift/Driver/DependencyGraph.h
@@ -127,8 +127,7 @@ private:
   /// dependency graph. Each member of the set is the name of a file which is
   /// not in the module. These files' contents may (or may not) have affected
   /// the module's compilation. This list may even include the paths of
-  /// non-existent files whose absence is significant in the same way as
-  /// Makefile .d dependencies.
+  /// non-existent files whose absence is significant.
   ///
   /// Furthermore, this set might not exhaustive. It only includes dependencies
   /// that will be checked by the driver's incremental mode.

--- a/include/swift/Driver/DependencyGraph.h
+++ b/include/swift/Driver/DependencyGraph.h
@@ -123,9 +123,17 @@ private:
   /// The set of marked nodes.
   llvm::SmallPtrSet<const void *, 16> Marked;
 
-  /// A list of all external dependencies that cannot be resolved
-  /// just from this dependency graph. They must be resolved from definitions
-  /// in files that do not belong to this module.
+  /// A list of all external dependencies that cannot be resolved from just this
+  /// dependency graph. Each member of the set is the name of a file which is
+  /// not in the module. These files' contents may (or may not) have affected
+  /// the module's compilation. This list may even include the paths of
+  /// non-existent files whose absence is significant in the same way as
+  /// Makefile .d dependencies.
+  ///
+  /// Furthermore, this set might not exhaustive. It only includes dependencies
+  /// that will be checked by the driver's incremental mode.
+  /// For example, it might excludes headers in the SDK if the cost
+  /// of `stat`ing them were to outweigh the likelihood that they would change.
   llvm::StringSet<> ExternalDependencies;
 
   /// The interface hash for each node. This determines if the interface of

--- a/include/swift/Driver/DependencyGraph.h
+++ b/include/swift/Driver/DependencyGraph.h
@@ -123,8 +123,9 @@ private:
   /// The set of marked nodes.
   llvm::SmallPtrSet<const void *, 16> Marked;
 
-  /// A list of all "external" dependencies that cannot be resolved just from
-  /// this dependency graph.
+  /// A list of all external dependencies that cannot be resolved
+  /// just from this dependency graph. They must be resolved from definitions
+  /// outside of this module.
   llvm::StringSet<> ExternalDependencies;
 
   /// The interface hash for each node. This determines if the interface of

--- a/include/swift/Driver/DependencyGraph.h
+++ b/include/swift/Driver/DependencyGraph.h
@@ -125,7 +125,7 @@ private:
 
   /// A list of all external dependencies that cannot be resolved
   /// just from this dependency graph. They must be resolved from definitions
-  /// outside of this module.
+  /// in files that do not belong to this module.
   llvm::StringSet<> ExternalDependencies;
 
   /// The interface hash for each node. This determines if the interface of

--- a/include/swift/Frontend/ReferenceDependencyKeys.h
+++ b/include/swift/Frontend/ReferenceDependencyKeys.h
@@ -17,6 +17,8 @@
 #include "llvm/ADT/StringRef.h"
 
 namespace swift {
+  /// Define these string constants for reference dependencies (a.k.a. swiftdeps)
+  /// in one place to ensure consistency.
   namespace reference_dependency_keys {
   static constexpr StringLiteral providesTopLevel("provides-top-level");
   static constexpr StringLiteral providesNominal("provides-nominal");

--- a/include/swift/Frontend/ReferenceDependencyKeys.h
+++ b/include/swift/Frontend/ReferenceDependencyKeys.h
@@ -1,0 +1,38 @@
+//===--- ReferenceDependencyKeys.h - Keys for swiftdeps files ---*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_FRONTENDTOOL_REFERENCEDEPENDENCYKEYS_H
+#define SWIFT_FRONTENDTOOL_REFERENCEDEPENDENCYKEYS_H
+
+#include "swift/Basic/LLVM.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace swift {
+  namespace reference_dependency_keys {
+  static constexpr StringLiteral providesTopLevel("provides-top-level");
+  static constexpr StringLiteral providesNominal("provides-nominal");
+  static constexpr StringLiteral providesMember("provides-member");
+  static constexpr StringLiteral
+      providesDynamicLookup("provides-dynamic-lookup");
+
+  static constexpr StringLiteral dependsTopLevel("depends-top-level");
+  static constexpr StringLiteral dependsMember("depends-member");
+  static constexpr StringLiteral dependsNominal("depends-nominal");
+  static constexpr StringLiteral dependsDynamicLookup("depends-dynamic-lookup");
+  static constexpr StringLiteral dependsExternal("depends-external");
+
+  static constexpr StringLiteral interfaceHash("interface-hash");
+  } // end namespace reference_dependency_keys
+} // end namespace swift
+
+#endif
+

--- a/include/swift/Frontend/ReferenceDependencyKeys.h
+++ b/include/swift/Frontend/ReferenceDependencyKeys.h
@@ -17,24 +17,22 @@
 #include "llvm/ADT/StringRef.h"
 
 namespace swift {
-  /// Define these string constants for reference dependencies (a.k.a. swiftdeps)
-  /// in one place to ensure consistency.
-  namespace reference_dependency_keys {
-  static constexpr StringLiteral providesTopLevel("provides-top-level");
-  static constexpr StringLiteral providesNominal("provides-nominal");
-  static constexpr StringLiteral providesMember("provides-member");
-  static constexpr StringLiteral
-      providesDynamicLookup("provides-dynamic-lookup");
+/// Define these string constants for reference dependencies (a.k.a. swiftdeps)
+/// in one place to ensure consistency.
+namespace reference_dependency_keys {
+static constexpr StringLiteral providesTopLevel("provides-top-level");
+static constexpr StringLiteral providesNominal("provides-nominal");
+static constexpr StringLiteral providesMember("provides-member");
+static constexpr StringLiteral providesDynamicLookup("provides-dynamic-lookup");
 
-  static constexpr StringLiteral dependsTopLevel("depends-top-level");
-  static constexpr StringLiteral dependsMember("depends-member");
-  static constexpr StringLiteral dependsNominal("depends-nominal");
-  static constexpr StringLiteral dependsDynamicLookup("depends-dynamic-lookup");
-  static constexpr StringLiteral dependsExternal("depends-external");
+static constexpr StringLiteral dependsTopLevel("depends-top-level");
+static constexpr StringLiteral dependsMember("depends-member");
+static constexpr StringLiteral dependsNominal("depends-nominal");
+static constexpr StringLiteral dependsDynamicLookup("depends-dynamic-lookup");
+static constexpr StringLiteral dependsExternal("depends-external");
 
-  static constexpr StringLiteral interfaceHash("interface-hash");
-  } // end namespace reference_dependency_keys
+static constexpr StringLiteral interfaceHash("interface-hash");
+} // end namespace reference_dependency_keys
 } // end namespace swift
 
 #endif
-

--- a/lib/Driver/DependencyGraph.cpp
+++ b/lib/Driver/DependencyGraph.cpp
@@ -99,7 +99,7 @@ parseDependencyFile(llvm::MemoryBuffer &buffer,
     if (!key)
       return LoadResult::HadError;
     StringRef keyString = key->getValue(scratch);
-      
+
     using namespace reference_dependency_keys;
 
     if (keyString == interfaceHash) {

--- a/lib/Driver/DependencyGraph.cpp
+++ b/lib/Driver/DependencyGraph.cpp
@@ -13,6 +13,7 @@
 #include "swift/Basic/Statistic.h"
 #include "swift/Driver/DependencyGraph.h"
 #include "swift/Demangling/Demangle.h"
+#include "swift/Frontend/ReferenceDependencyKeys.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringSwitch.h"
@@ -98,8 +99,10 @@ parseDependencyFile(llvm::MemoryBuffer &buffer,
     if (!key)
       return LoadResult::HadError;
     StringRef keyString = key->getValue(scratch);
+      
+    using namespace reference_dependency_keys;
 
-    if (keyString == "interface-hash") {
+    if (keyString == interfaceHash) {
       auto *value = dyn_cast<yaml::ScalarNode>(i->getValue());
       if (!value)
         return LoadResult::HadError;
@@ -115,31 +118,31 @@ parseDependencyFile(llvm::MemoryBuffer &buffer,
       using KindPair = std::pair<DependencyKind, DependencyDirection>;
 
       KindPair dirAndKind = llvm::StringSwitch<KindPair>(key->getValue(scratch))
-        .Case("depends-top-level",
+        .Case(dependsTopLevel,
               std::make_pair(DependencyKind::TopLevelName,
                              DependencyDirection::Depends))
-        .Case("depends-nominal",
+        .Case(dependsNominal,
               std::make_pair(DependencyKind::NominalType,
                              DependencyDirection::Depends))
-        .Case("depends-member",
+        .Case(dependsMember,
               std::make_pair(DependencyKind::NominalTypeMember,
                              DependencyDirection::Depends))
-        .Case("depends-dynamic-lookup",
+        .Case(dependsDynamicLookup,
               std::make_pair(DependencyKind::DynamicLookupName,
                              DependencyDirection::Depends))
-        .Case("depends-external",
+        .Case(dependsExternal,
               std::make_pair(DependencyKind::ExternalFile,
                              DependencyDirection::Depends))
-        .Case("provides-top-level",
+        .Case(providesTopLevel,
               std::make_pair(DependencyKind::TopLevelName,
                              DependencyDirection::Provides))
-        .Case("provides-nominal",
+        .Case(providesNominal,
               std::make_pair(DependencyKind::NominalType,
                              DependencyDirection::Provides))
-        .Case("provides-member",
+        .Case(providesMember,
               std::make_pair(DependencyKind::NominalTypeMember,
                              DependencyDirection::Provides))
-        .Case("provides-dynamic-lookup",
+        .Case(providesDynamicLookup,
               std::make_pair(DependencyKind::DynamicLookupName,
                              DependencyDirection::Provides))
         .Default(std::make_pair(DependencyKind(),

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -193,8 +193,6 @@ bool swift::emitReferenceDependencies(DiagnosticEngine &diags,
 }
 
 void ProvidesEmitter::emit() const {
-  out << "provides-top-level" << ":\n";
-
   CollectedProvidedDeclarations cpd = emitTopLevelNames();
   emitNominalTypes(cpd.extendedNominals);
   emitMembers(cpd);
@@ -220,7 +218,9 @@ void ReferenceDependenciesEmitter::emitInterfaceHash() const {
 }
 
 ProvidesEmitter::CollectedProvidedDeclarations ProvidesEmitter::emitTopLevelNames() const {
-    CollectedProvidedDeclarations cpd;
+  out << "provides-top-level" << ":\n";
+  
+  CollectedProvidedDeclarations cpd;
   for (const Decl *D : SF->Decls)
     emitTopLevelDecl(D, cpd);
   for (auto *operatorFunction : cpd.memberOperatorDecls)

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -115,30 +115,6 @@ private:
 };
 } // end anon namespace
 
-void ProvidesEmitter::CollectedProvidedDeclarations::findNominalsAndOperators(DeclRange members) {
-  for (const Decl *D : members) {
-    auto *VD = dyn_cast<ValueDecl>(D);
-    if (!VD)
-      continue;
-
-    if (VD->hasAccess() &&
-        VD->getFormalAccess() <= AccessLevel::FilePrivate) {
-      continue;
-    }
-
-    if (VD->getFullName().isOperator()) {
-      memberOperatorDecls.push_back(cast<FuncDecl>(VD));
-      continue;
-    }
-
-    auto nominal = dyn_cast<NominalTypeDecl>(D);
-    if (!nominal)
-      continue;
-    extendedNominals[nominal] |= true;
-    findNominalsAndOperators(nominal->getMembers());
-  }
-}
-
 static bool declIsPrivate(const Decl *member) {
   auto *VD = dyn_cast<ValueDecl>(member);
   if (!VD) {
@@ -206,6 +182,17 @@ static std::string escape(DeclBaseName name) {
   return llvm::yaml::escape(name.userFacingName());
 }
 
+static SmallVector<std::pair<DeclBaseName, bool>, 16>
+sortedByName(const llvm::DenseMap<DeclBaseName, bool> map) {
+  SmallVector<std::pair<DeclBaseName, bool>, 16> pairs{map.begin(), map.end()};
+  llvm::array_pod_sort(pairs.begin(), pairs.end(),
+                       [](const std::pair<DeclBaseName, bool> *first,
+                          const std::pair<DeclBaseName, bool> *second) -> int {
+                         return first->first.compare(second->first);
+                       });
+  return pairs;
+}
+
 std::unique_ptr<llvm::raw_fd_ostream>ReferenceDependenciesEmitter::openFile(DiagnosticEngine &diags, StringRef outputPath) {
   // Before writing to the dependencies file path, preserve any previous file
   // that may have been there. No error handling -- this is just a nicety, it
@@ -271,6 +258,16 @@ void ProvidesEmitter::emit(const SourceFile *SF, llvm::raw_ostream &out) {
 
 void ReferenceDependenciesEmitter::emitProvides() {
   ProvidesEmitter::emit(SF, out);
+}
+
+void ReferenceDependenciesEmitter::emitDepends() {
+  DependsEmitter::emit(SF, depTracker, out);
+}
+
+void ReferenceDependenciesEmitter::emitInterfaceHash() {
+  llvm::SmallString<32> interfaceHash;
+  SF->getInterfaceHash(interfaceHash);
+  out << "interface-hash: \"" << interfaceHash << "\"\n";
 }
 
 ProvidesEmitter::CollectedProvidedDeclarations ProvidesEmitter::emitTopLevelNames() {
@@ -381,6 +378,30 @@ void ProvidesEmitter::emitNominalTypeDecl(
   cpd.findNominalsAndOperators(NTD->getMembers());
 }
 
+void ProvidesEmitter::CollectedProvidedDeclarations::findNominalsAndOperators(DeclRange members) {
+  for (const Decl *D : members) {
+    auto *VD = dyn_cast<ValueDecl>(D);
+    if (!VD)
+      continue;
+    
+    if (VD->hasAccess() &&
+        VD->getFormalAccess() <= AccessLevel::FilePrivate) {
+      continue;
+    }
+    
+    if (VD->getFullName().isOperator()) {
+      memberOperatorDecls.push_back(cast<FuncDecl>(VD));
+      continue;
+    }
+    
+    auto nominal = dyn_cast<NominalTypeDecl>(D);
+    if (!nominal)
+      continue;
+    extendedNominals[nominal] |= true;
+    findNominalsAndOperators(nominal->getMembers());
+  }
+}
+
 void ProvidesEmitter::emitValueDecl(const ValueDecl *const VD) {
   if (!VD->hasName())
     return;
@@ -459,21 +480,6 @@ void ProvidesEmitter::emitDynamicLookupMembers() {
       out << "- \"" << escape(name) << "\"\n";
     }
   }
-}
-
-static SmallVector<std::pair<DeclBaseName, bool>, 16>
-sortedByName(const llvm::DenseMap<DeclBaseName, bool> map) {
-  SmallVector<std::pair<DeclBaseName, bool>, 16> pairs{map.begin(), map.end()};
-  llvm::array_pod_sort(pairs.begin(), pairs.end(),
-                       [](const std::pair<DeclBaseName, bool> *first,
-                          const std::pair<DeclBaseName, bool> *second) -> int {
-                         return first->first.compare(second->first);
-                       });
-  return pairs;
-}
-
-void ReferenceDependenciesEmitter::emitDepends() {
-  DependsEmitter::emit(SF, depTracker, out);
 }
 
 void DependsEmitter::emit(const SourceFile *SF, const DependencyTracker &depTracker,
@@ -586,10 +592,4 @@ void DependsEmitter::emitExternal(const DependencyTracker &depTracker) const {
   for (auto &entry : reversePathSortedFilenames(depTracker.getDependencies())) {
     out << "- \"" << llvm::yaml::escape(entry) << "\"\n";
   }
-}
-
-void ReferenceDependenciesEmitter::emitInterfaceHash() {
-  llvm::SmallString<32> interfaceHash;
-  SF->getInterfaceHash(interfaceHash);
-  out << "interface-hash: \"" << interfaceHash << "\"\n";
 }

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -76,7 +76,7 @@ private:
     llvm::SmallVector<const FuncDecl *, 8> memberOperatorDecls;
     llvm::SmallVector<const ExtensionDecl *, 8> extensionsWithJustMembers;
     
-    void findNominalsAndOperators(DeclRange members);
+    void findNominalsAndOperators(const DeclRange members);
   };
   
   void emit() const;
@@ -329,7 +329,7 @@ void ProvidesEmitter::emitNominalTypeDecl(
   cpd.findNominalsAndOperators(NTD->getMembers());
 }
 
-void ProvidesEmitter::CollectedProvidedDeclarations::findNominalsAndOperators(DeclRange members) {
+void ProvidesEmitter::CollectedProvidedDeclarations::findNominalsAndOperators(const DeclRange members) {
   for (const Decl *D : members) {
     auto *VD = dyn_cast<ValueDecl>(D);
     if (!VD)

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -54,8 +54,9 @@ public:
   /// \param diags Where problems opening the file are emitted
   /// \param SF The SourceFile containing the code with the dependences
   /// \param depTracker The entities depended-upon
-  /// \param outputPath The path of the file where the dependencies are written
-  /// to \return true on error
+  /// \param outputPath Where the dependencies are written
+  ///
+  /// \return true on error
   static bool emit(DiagnosticEngine &diags, SourceFile *SF,
                    const DependencyTracker &depTracker, StringRef outputPath);
 
@@ -86,11 +87,6 @@ class ProvidesEmitter {
       : SF(SF), out(out) {}
 
 public:
-  /// Emit declarations
-  ///
-  /// \param SF Contains the declarations to emit
-  ///
-  /// \param out Where the declarations are emitted
   static void emit(const SourceFile *SF, llvm::raw_ostream &out);
 
 private:
@@ -163,8 +159,8 @@ private:
   void emit() const;
 
   void emitTopLevelNames(const ReferencedNameTracker *const tracker) const;
-  void emitMember(const ArrayRef<MemberTableEntryTy> sortedMembers) const;
-  void emitNominal(const ArrayRef<MemberTableEntryTy> sortedMembers) const;
+  void emitMembers(const ArrayRef<MemberTableEntryTy> sortedMembers) const;
+  void emitNominalTypes(const ArrayRef<MemberTableEntryTy> sortedMembers) const;
   void emitDynamicLookup(const ReferencedNameTracker *const tracker) const;
   void emitExternal(const DependencyTracker &depTracker) const;
 
@@ -566,8 +562,8 @@ void DependsEmitter::emit() const {
     return lhsMangledName.compare(rhsMangledName);
   });
 
-  emitMember(sortedMembers);
-  emitNominal(sortedMembers);
+  emitMembers(sortedMembers);
+  emitNominalTypes(sortedMembers);
   emitDynamicLookup(tracker);
   emitExternal(depTracker);
 }
@@ -584,7 +580,7 @@ void DependsEmitter::emitTopLevelNames(
   }
 }
 
-void DependsEmitter::emitMember(
+void DependsEmitter::emitMembers(
     ArrayRef<MemberTableEntryTy> sortedMembers) const {
   out << dependsMember << ":\n";
   for (auto &entry : sortedMembers) {
@@ -605,7 +601,7 @@ void DependsEmitter::emitMember(
   }
 }
 
-void DependsEmitter::emitNominal(
+void DependsEmitter::emitNominalTypes(
     ArrayRef<MemberTableEntryTy> sortedMembers) const {
   out << dependsNominal << ":\n";
   for (auto i = sortedMembers.begin(), e = sortedMembers.end(); i != e; ++i) {

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -151,22 +151,32 @@ static std::unique_ptr<llvm::raw_fd_ostream>openFile(DiagnosticEngine &diags, St
   return out;
 }
 
+static void emitReferenceDependencies(SourceFile *const SF,
+                                      const DependencyTracker &depTracker,
+                                      llvm::raw_ostream &out);
+
 bool swift::emitReferenceDependencies(DiagnosticEngine &diags,
                                       SourceFile *const SF,
                                       const DependencyTracker &depTracker,
                                       StringRef outputPath) {
-  assert(SF && "Cannot emit reference dependencies without a SourceFile");
   std::unique_ptr<llvm::raw_ostream> out = openFile(diags, outputPath);
   if (!out.get())
     return true;
-  
-  *out << "### Swift dependencies file v0 ###\n";
-  
-  emitProvides(SF, *out);
-  emitDepends(SF, depTracker, *out);
-  emitInterfaceHash(SF, *out);
+  ::emitReferenceDependencies( SF, depTracker, *out);
   
   return false;
+}
+
+static void emitReferenceDependencies(SourceFile *const SF,
+                                      const DependencyTracker &depTracker,
+                                      llvm::raw_ostream &out) {
+  assert(SF && "Cannot emit reference dependencies without a SourceFile");
+
+  out << "### Swift dependencies file v0 ###\n";
+  
+  emitProvides(SF, out);
+  emitDepends(SF, depTracker, out);
+  emitInterfaceHash(SF, out);
 }
 
 static void emitProvidesTopLevelNames(

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -468,11 +468,11 @@ namespace {
     
   private:
     void emit() const;
-    void emitDependsTopLevelNames(const ReferencedNameTracker *const tracker) const;
-    void emitDependsMember(const ArrayRef<TableEntryTy> sortedMembers) const;
-    void emitDependsNominal(const ArrayRef<TableEntryTy> sortedMembers) const;
-    void emitDependsDynamicLookup(const ReferencedNameTracker *const tracker) const;
-    void emitDependsExternal(const DependencyTracker &depTracker) const;
+    void emitTopLevelNames(const ReferencedNameTracker *const tracker) const;
+    void emitMember(const ArrayRef<TableEntryTy> sortedMembers) const;
+    void emitNominal(const ArrayRef<TableEntryTy> sortedMembers) const;
+    void emitDynamicLookup(const ReferencedNameTracker *const tracker) const;
+    void emitExternal(const DependencyTracker &depTracker) const;
   };
 } // end anon namespace
 
@@ -489,7 +489,7 @@ void DependsEmitter::emit() const {
   const ReferencedNameTracker *const tracker = SF->getReferencedNameTracker();
   assert(tracker && "Cannot emit reference dependencies without a tracker");
 
-  emitDependsTopLevelNames(tracker);
+  emitTopLevelNames(tracker);
 
   auto &memberLookupTable = tracker->getUsedMembers();
   std::vector<TableEntryTy> sortedMembers{
@@ -515,13 +515,13 @@ void DependsEmitter::emit() const {
     return lhsMangledName.compare(rhsMangledName);
   });
 
-  emitDependsMember(sortedMembers);
-  emitDependsNominal(sortedMembers);
-  emitDependsDynamicLookup(tracker);
-  emitDependsExternal(depTracker);
+  emitMember(sortedMembers);
+  emitNominal(sortedMembers);
+  emitDynamicLookup(tracker);
+  emitExternal(depTracker);
 }
 
-void DependsEmitter::emitDependsTopLevelNames(const ReferencedNameTracker *const tracker) const {
+void DependsEmitter::emitTopLevelNames(const ReferencedNameTracker *const tracker) const {
   out << "depends-top-level:\n";
   for (auto &entry : sortedByName(tracker->getTopLevelNames())) {
     assert(!entry.first.empty());
@@ -532,7 +532,7 @@ void DependsEmitter::emitDependsTopLevelNames(const ReferencedNameTracker *const
   }
 }
 
-void DependsEmitter::emitDependsMember(ArrayRef<TableEntryTy> sortedMembers) const {
+void DependsEmitter::emitMember(ArrayRef<TableEntryTy> sortedMembers) const {
   out << "depends-member:\n";
   for (auto &entry : sortedMembers) {
     assert(entry.first.first != nullptr);
@@ -552,7 +552,7 @@ void DependsEmitter::emitDependsMember(ArrayRef<TableEntryTy> sortedMembers) con
   }
 }
 
-void DependsEmitter::emitDependsNominal(ArrayRef<TableEntryTy> sortedMembers) const {
+void DependsEmitter::emitNominal(ArrayRef<TableEntryTy> sortedMembers) const {
   out << "depends-nominal:\n";
   for (auto i = sortedMembers.begin(), e = sortedMembers.end(); i != e; ++i) {
     bool isCascading = i->second;
@@ -574,7 +574,7 @@ void DependsEmitter::emitDependsNominal(ArrayRef<TableEntryTy> sortedMembers) co
   }
 }
 
-void DependsEmitter::emitDependsDynamicLookup(const ReferencedNameTracker *const tracker) const {
+void DependsEmitter::emitDynamicLookup(const ReferencedNameTracker *const tracker) const {
   out << "depends-dynamic-lookup:\n";
   for (auto &entry : sortedByName(tracker->getDynamicLookupNames())) {
     assert(!entry.first.empty());
@@ -585,7 +585,7 @@ void DependsEmitter::emitDependsDynamicLookup(const ReferencedNameTracker *const
   }
 }
 
-void DependsEmitter::emitDependsExternal(const DependencyTracker &depTracker) const {
+void DependsEmitter::emitExternal(const DependencyTracker &depTracker) const {
   out << "depends-external:\n";
   for (auto &entry : reversePathSortedFilenames(depTracker.getDependencies())) {
     out << "- \"" << llvm::yaml::escape(entry) << "\"\n";

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -450,29 +450,46 @@ sortedByName(const llvm::DenseMap<DeclBaseName, bool> map) {
   return pairs;
 }
 
-static void emitDependsTopLevelNames(const ReferencedNameTracker *tracker,
-                                     llvm::raw_ostream &out);
-
-using TableEntryTy = std::pair<ReferencedNameTracker::MemberPair, bool>;
-
-static void emitDependsMember(ArrayRef<TableEntryTy> sortedMembers,
-                              llvm::raw_ostream &out);
-
-static void emitDependsNominal(ArrayRef<TableEntryTy> sortedMembers,
-                               llvm::raw_ostream &out);
-
-static void emitDependsDynamicLookup(const ReferencedNameTracker *tracker,
-                                     llvm::raw_ostream &out);
-
-static void emitDependsExternal(const DependencyTracker &depTracker,
-                                llvm::raw_ostream &out);
+namespace {
+  class DependsEmitter {
+    const SourceFile *SF;
+    const DependencyTracker &depTracker;
+    llvm::raw_ostream &out;
+    
+    DependsEmitter(const SourceFile *SF, const DependencyTracker &depTracker,
+                   llvm::raw_ostream &out)
+    : SF(SF), depTracker(depTracker), out(out) {}
+    
+  public:
+    using TableEntryTy = std::pair<ReferencedNameTracker::MemberPair, bool>;
+    
+    static void emit(const SourceFile *SF, const DependencyTracker &depTracker,
+                     llvm::raw_ostream &out);
+    
+  private:
+    void emit() const;
+    void emitDependsTopLevelNames(const ReferencedNameTracker *const tracker) const;
+    void emitDependsMember(const ArrayRef<TableEntryTy> sortedMembers) const;
+    void emitDependsNominal(const ArrayRef<TableEntryTy> sortedMembers) const;
+    void emitDependsDynamicLookup(const ReferencedNameTracker *const tracker) const;
+    void emitDependsExternal(const DependencyTracker &depTracker) const;
+  };
+} // end anon namespace
 
 void ReferenceDependenciesEmitter::emitDepends() {
+  DependsEmitter::emit(SF, depTracker, out);
+}
 
+void DependsEmitter::emit(const SourceFile *SF, const DependencyTracker &depTracker,
+                          llvm::raw_ostream &out) {
+  DependsEmitter(SF, depTracker, out).emit();
+}
+
+void DependsEmitter::emit() const {
   const ReferencedNameTracker *const tracker = SF->getReferencedNameTracker();
   assert(tracker && "Cannot emit reference dependencies without a tracker");
 
-  emitDependsTopLevelNames(tracker, out);
+  emitDependsTopLevelNames(tracker);
 
   auto &memberLookupTable = tracker->getUsedMembers();
   std::vector<TableEntryTy> sortedMembers{
@@ -498,14 +515,13 @@ void ReferenceDependenciesEmitter::emitDepends() {
     return lhsMangledName.compare(rhsMangledName);
   });
 
-  emitDependsMember(sortedMembers, out);
-  emitDependsNominal(sortedMembers, out);
-  emitDependsDynamicLookup(tracker, out);
-  emitDependsExternal(depTracker, out);
+  emitDependsMember(sortedMembers);
+  emitDependsNominal(sortedMembers);
+  emitDependsDynamicLookup(tracker);
+  emitDependsExternal(depTracker);
 }
 
-static void emitDependsTopLevelNames(const ReferencedNameTracker *const tracker,
-                                     llvm::raw_ostream &out) {
+void DependsEmitter::emitDependsTopLevelNames(const ReferencedNameTracker *const tracker) const {
   out << "depends-top-level:\n";
   for (auto &entry : sortedByName(tracker->getTopLevelNames())) {
     assert(!entry.first.empty());
@@ -516,8 +532,7 @@ static void emitDependsTopLevelNames(const ReferencedNameTracker *const tracker,
   }
 }
 
-static void emitDependsMember(ArrayRef<TableEntryTy> sortedMembers,
-                              llvm::raw_ostream &out) {
+void DependsEmitter::emitDependsMember(ArrayRef<TableEntryTy> sortedMembers) const {
   out << "depends-member:\n";
   for (auto &entry : sortedMembers) {
     assert(entry.first.first != nullptr);
@@ -537,8 +552,7 @@ static void emitDependsMember(ArrayRef<TableEntryTy> sortedMembers,
   }
 }
 
-static void emitDependsNominal(ArrayRef<TableEntryTy> sortedMembers,
-                               llvm::raw_ostream &out) {
+void DependsEmitter::emitDependsNominal(ArrayRef<TableEntryTy> sortedMembers) const {
   out << "depends-nominal:\n";
   for (auto i = sortedMembers.begin(), e = sortedMembers.end(); i != e; ++i) {
     bool isCascading = i->second;
@@ -560,8 +574,7 @@ static void emitDependsNominal(ArrayRef<TableEntryTy> sortedMembers,
   }
 }
 
-static void emitDependsDynamicLookup(const ReferencedNameTracker *const tracker,
-                                     llvm::raw_ostream &out) {
+void DependsEmitter::emitDependsDynamicLookup(const ReferencedNameTracker *const tracker) const {
   out << "depends-dynamic-lookup:\n";
   for (auto &entry : sortedByName(tracker->getDynamicLookupNames())) {
     assert(!entry.first.empty());
@@ -572,8 +585,7 @@ static void emitDependsDynamicLookup(const ReferencedNameTracker *const tracker,
   }
 }
 
-static void emitDependsExternal(const DependencyTracker &depTracker,
-                                llvm::raw_ostream &out) {
+void DependsEmitter::emitDependsExternal(const DependencyTracker &depTracker) const {
   out << "depends-external:\n";
   for (auto &entry : reversePathSortedFilenames(depTracker.getDependencies())) {
     out << "- \"" << llvm::yaml::escape(entry) << "\"\n";

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -43,7 +43,7 @@ class ReferenceDependenciesEmitter {
   
 public:
   /// \return true on error
-  static bool emit(DiagnosticEngine &diags, SourceFile *const SF,
+  static bool emit(DiagnosticEngine &diags, SourceFile *SF,
                    const DependencyTracker &depTracker,
                    StringRef outputPath);
   static void emit(SourceFile *const SF, const DependencyTracker &depTracker, llvm::raw_ostream &out);
@@ -164,7 +164,7 @@ bool ReferenceDependenciesEmitter::emit(DiagnosticEngine &diags,
                                         SourceFile *const SF,
                                         const DependencyTracker &depTracker,
                                         StringRef outputPath) {
-  std::unique_ptr<llvm::raw_ostream> out = openFile(diags, outputPath);
+  const std::unique_ptr<llvm::raw_ostream> out = openFile(diags, outputPath);
   if (!out.get())
     return true;
   ReferenceDependenciesEmitter::emit(SF, depTracker, *out);

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -123,8 +123,19 @@ swift::reversePathSortedFilenames(const ArrayRef<std::string> elts) {
   return tmp;
 }
 
-bool swift::emitReferenceDependencies(DiagnosticEngine &diags, SourceFile *SF,
-                                      DependencyTracker &depTracker,
+static std::string escape(DeclBaseName name) {
+  return llvm::yaml::escape(name.userFacingName());
+}
+
+static void emitProvides(const SourceFile *SF, llvm::raw_fd_ostream &out);
+static void emitDepends(const SourceFile *SF,
+                        const DependencyTracker &depTracker,
+                        llvm::raw_fd_ostream &out);
+static void emitInterfaceHash(SourceFile *SF, llvm::raw_fd_ostream &out);
+
+bool swift::emitReferenceDependencies(DiagnosticEngine &diags,
+                                      SourceFile *const SF,
+                                      const DependencyTracker &depTracker,
                                       StringRef outputPath) {
   assert(SF && "Cannot emit reference dependencies without a SourceFile");
   
@@ -143,11 +154,17 @@ bool swift::emitReferenceDependencies(DiagnosticEngine &diags, SourceFile *SF,
     return true;
   }
 
-  auto escape = [](DeclBaseName name) -> std::string {
-    return llvm::yaml::escape(name.userFacingName());
-  };
-
   out << "### Swift dependencies file v0 ###\n";
+
+  emitProvides(SF, out);
+  emitDepends(SF, depTracker, out);
+  emitInterfaceHash(SF, out);
+
+  return false;
+}
+
+static void emitProvides(const SourceFile *const SF,
+                         llvm::raw_fd_ostream &out) {
 
   llvm::MapVector<const NominalTypeDecl *, bool> extendedNominals;
   llvm::SmallVector<const FuncDecl *, 8> memberOperatorDecls;
@@ -320,6 +337,11 @@ bool swift::emitReferenceDependencies(DiagnosticEngine &diags, SourceFile *SF,
       out << "- \"" << escape(name) << "\"\n";
     }
   }
+}
+
+static void emitDepends(const SourceFile *const SF,
+                        const DependencyTracker &depTracker,
+                        llvm::raw_fd_ostream &out) {
 
   auto sortedByName =
       [](const llvm::DenseMap<DeclBaseName, bool> map) ->
@@ -421,10 +443,10 @@ bool swift::emitReferenceDependencies(DiagnosticEngine &diags, SourceFile *SF,
   for (auto &entry : reversePathSortedFilenames(depTracker.getDependencies())) {
     out << "- \"" << llvm::yaml::escape(entry) << "\"\n";
   }
+}
 
+static void emitInterfaceHash(SourceFile *const SF, llvm::raw_fd_ostream &out) {
   llvm::SmallString<32> interfaceHash;
   SF->getInterfaceHash(interfaceHash);
   out << "interface-hash: \"" << interfaceHash << "\"\n";
-
-  return false;
 }

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -214,18 +214,19 @@ static void emitProvidesTopLevelNames(
     out << "- \"" << escape(operatorFunction->getName()) << "\"\n";
 }
 
-static void emitProvidesExtensionDecl(const ExtensionDecl *ED,
-                                      llvm::raw_fd_ostream &out,
-                                      llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
-                                      llvm::SmallVectorImpl<const FuncDecl *> &memberOperatorDecls,
-                                      llvm::SmallVectorImpl<const ExtensionDecl *> &extensionsWithJustMembers);
+static void emitProvidesExtensionDecl(
+    const ExtensionDecl *ED, llvm::raw_fd_ostream &out,
+    llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
+    llvm::SmallVectorImpl<const FuncDecl *> &memberOperatorDecls,
+    llvm::SmallVectorImpl<const ExtensionDecl *> &extensionsWithJustMembers);
 
-static void emitProvidesNominalTypeDecl(const NominalTypeDecl *NTD,
-                                        llvm::raw_fd_ostream &out,
-                                        llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
-                                        llvm::SmallVectorImpl<const FuncDecl *> &memberOperatorDecls);
+static void emitProvidesNominalTypeDecl(
+    const NominalTypeDecl *NTD, llvm::raw_fd_ostream &out,
+    llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
+    llvm::SmallVectorImpl<const FuncDecl *> &memberOperatorDecls);
 
-static void emitProvidesValueDecl(const ValueDecl *VD, llvm::raw_fd_ostream &out);
+static void emitProvidesValueDecl(const ValueDecl *VD,
+                                  llvm::raw_fd_ostream &out);
 
 static void emitProvidesTopLevelDecl(
     const Decl *const D, llvm::raw_fd_ostream &out,
@@ -241,7 +242,8 @@ static void emitProvidesTopLevelDecl(
     break;
 
   case DeclKind::Extension:
-    emitProvidesExtensionDecl(cast<ExtensionDecl>(D), out, extendedNominals, memberOperatorDecls, extensionsWithJustMembers);
+    emitProvidesExtensionDecl(cast<ExtensionDecl>(D), out, extendedNominals,
+                              memberOperatorDecls, extensionsWithJustMembers);
     break;
 
   case DeclKind::InfixOperator:
@@ -258,15 +260,16 @@ static void emitProvidesTopLevelDecl(
   case DeclKind::Struct:
   case DeclKind::Class:
   case DeclKind::Protocol:
-      emitProvidesNominalTypeDecl(cast<NominalTypeDecl>(D), out, extendedNominals, memberOperatorDecls);
-      break;
+    emitProvidesNominalTypeDecl(cast<NominalTypeDecl>(D), out, extendedNominals,
+                                memberOperatorDecls);
+    break;
 
   case DeclKind::TypeAlias:
   case DeclKind::Var:
   case DeclKind::Func:
   case DeclKind::Accessor:
-      emitProvidesValueDecl(cast<ValueDecl>(D), out);
-      break;
+    emitProvidesValueDecl(cast<ValueDecl>(D), out);
+    break;
 
   case DeclKind::PatternBinding:
   case DeclKind::TopLevelCode:
@@ -289,24 +292,23 @@ static void emitProvidesTopLevelDecl(
   }
 }
 
-static void emitProvidesExtensionDecl(const ExtensionDecl *const ED,
-                                      llvm::raw_fd_ostream &out,
-                                      llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
-                                      llvm::SmallVectorImpl<const FuncDecl *> &memberOperatorDecls,
-                                      llvm::SmallVectorImpl<const ExtensionDecl *> &extensionsWithJustMembers) {
+static void emitProvidesExtensionDecl(
+    const ExtensionDecl *const ED, llvm::raw_fd_ostream &out,
+    llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
+    llvm::SmallVectorImpl<const FuncDecl *> &memberOperatorDecls,
+    llvm::SmallVectorImpl<const ExtensionDecl *> &extensionsWithJustMembers) {
   auto *NTD = ED->getExtendedType()->getAnyNominal();
   if (!NTD)
     return;
-  if (NTD->hasAccess() &&
-      NTD->getFormalAccess() <= AccessLevel::FilePrivate) {
+  if (NTD->hasAccess() && NTD->getFormalAccess() <= AccessLevel::FilePrivate) {
     return;
   }
-  
+
   // Check if the extension is just adding members, or if it is
   // introducing a conformance to a public protocol.
   bool justMembers =
-  std::all_of(ED->getInherited().begin(), ED->getInherited().end(),
-              extendedTypeIsPrivate);
+      std::all_of(ED->getInherited().begin(), ED->getInherited().end(),
+                  extendedTypeIsPrivate);
   if (justMembers) {
     if (std::all_of(ED->getMembers().begin(), ED->getMembers().end(),
                     declIsPrivate)) {
@@ -319,14 +321,13 @@ static void emitProvidesExtensionDecl(const ExtensionDecl *const ED,
                            ED->getMembers());
 }
 
-static void emitProvidesNominalTypeDecl(const NominalTypeDecl *const NTD,
-                                        llvm::raw_fd_ostream &out,
-                                        llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
-                                        llvm::SmallVectorImpl<const FuncDecl *> &memberOperatorDecls) {
+static void emitProvidesNominalTypeDecl(
+    const NominalTypeDecl *const NTD, llvm::raw_fd_ostream &out,
+    llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
+    llvm::SmallVectorImpl<const FuncDecl *> &memberOperatorDecls) {
   if (!NTD->hasName())
     return;
-  if (NTD->hasAccess() &&
-      NTD->getFormalAccess() <= AccessLevel::FilePrivate) {
+  if (NTD->hasAccess() && NTD->getFormalAccess() <= AccessLevel::FilePrivate) {
     return;
   }
   out << "- \"" << escape(NTD->getName()) << "\"\n";
@@ -335,7 +336,8 @@ static void emitProvidesNominalTypeDecl(const NominalTypeDecl *const NTD,
                            NTD->getMembers());
 }
 
-static void emitProvidesValueDecl(const ValueDecl *const VD, llvm::raw_fd_ostream &out) {
+static void emitProvidesValueDecl(const ValueDecl *const VD,
+                                  llvm::raw_fd_ostream &out) {
   if (!VD->hasName())
     return;
   if (VD->hasAccess() && VD->getFormalAccess() <= AccessLevel::FilePrivate) {
@@ -344,10 +346,9 @@ static void emitProvidesValueDecl(const ValueDecl *const VD, llvm::raw_fd_ostrea
   out << "- \"" << escape(VD->getBaseName()) << "\"\n";
 }
 
-
 static void emitProvidesNominalTypes(
-                                     const llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
-                                     llvm::raw_fd_ostream &out) {
+    const llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
+    llvm::raw_fd_ostream &out) {
   out << "provides-nominal:\n";
   for (auto entry : extendedNominals) {
     if (!entry.second)
@@ -359,22 +360,22 @@ static void emitProvidesNominalTypes(
 }
 
 static void emitProvidesMembers(
-                                const llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
-                                const llvm::SmallVectorImpl<const ExtensionDecl *>
-                                &extensionsWithJustMembers,
-                                llvm::raw_fd_ostream &out) {
+    const llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
+    const llvm::SmallVectorImpl<const ExtensionDecl *>
+        &extensionsWithJustMembers,
+    llvm::raw_fd_ostream &out) {
   out << "provides-member:\n";
   for (auto entry : extendedNominals) {
     out << "- [\"";
     out << mangleTypeAsContext(entry.first);
     out << "\", \"\"]\n";
   }
-  
+
   // This is also part of "provides-member".
   for (auto *ED : extensionsWithJustMembers) {
     auto mangledName =
-    mangleTypeAsContext(ED->getExtendedType()->getAnyNominal());
-    
+        mangleTypeAsContext(ED->getExtendedType()->getAnyNominal());
+
     for (auto *member : ED->getMembers()) {
       auto *VD = dyn_cast<ValueDecl>(member);
       if (!VD || !VD->hasName() ||
@@ -382,7 +383,7 @@ static void emitProvidesMembers(
         continue;
       }
       out << "- [\"" << mangledName << "\", \"" << escape(VD->getBaseName())
-      << "\"]\n";
+          << "\"]\n";
     }
   }
 }
@@ -398,17 +399,17 @@ static void emitProvidesDynamicLookupMembers(const SourceFile *const SF,
     class NameCollector : public VisibleDeclConsumer {
     private:
       SmallVector<DeclBaseName, 16> names;
-      
+
     public:
       void foundDecl(ValueDecl *VD, DeclVisibilityKind Reason) override {
         names.push_back(VD->getBaseName());
       }
       ArrayRef<DeclBaseName> getNames() {
         llvm::array_pod_sort(
-                             names.begin(), names.end(),
-                             [](const DeclBaseName *lhs, const DeclBaseName *rhs) {
-                               return lhs->compare(*rhs);
-                             });
+            names.begin(), names.end(),
+            [](const DeclBaseName *lhs, const DeclBaseName *rhs) {
+              return lhs->compare(*rhs);
+            });
         names.erase(std::unique(names.begin(), names.end()), names.end());
         return names;
       }

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -461,7 +461,7 @@ namespace {
     : SF(SF), depTracker(depTracker), out(out) {}
     
   public:
-    using TableEntryTy = std::pair<ReferencedNameTracker::MemberPair, bool>;
+    using MemberTableEntryTy = std::pair<ReferencedNameTracker::MemberPair, bool>;
     
     static void emit(const SourceFile *SF, const DependencyTracker &depTracker,
                      llvm::raw_ostream &out);
@@ -469,8 +469,8 @@ namespace {
   private:
     void emit() const;
     void emitTopLevelNames(const ReferencedNameTracker *const tracker) const;
-    void emitMember(const ArrayRef<TableEntryTy> sortedMembers) const;
-    void emitNominal(const ArrayRef<TableEntryTy> sortedMembers) const;
+    void emitMember(const ArrayRef<MemberTableEntryTy> sortedMembers) const;
+    void emitNominal(const ArrayRef<MemberTableEntryTy> sortedMembers) const;
     void emitDynamicLookup(const ReferencedNameTracker *const tracker) const;
     void emitExternal(const DependencyTracker &depTracker) const;
   };
@@ -492,12 +492,12 @@ void DependsEmitter::emit() const {
   emitTopLevelNames(tracker);
 
   auto &memberLookupTable = tracker->getUsedMembers();
-  std::vector<TableEntryTy> sortedMembers{
+  std::vector<MemberTableEntryTy> sortedMembers{
     memberLookupTable.begin(), memberLookupTable.end()
   };
   llvm::array_pod_sort(sortedMembers.begin(), sortedMembers.end(),
-                       [](const TableEntryTy *lhs,
-                          const TableEntryTy *rhs) -> int {
+                       [](const MemberTableEntryTy *lhs,
+                          const MemberTableEntryTy *rhs) -> int {
     if (auto cmp = lhs->first.first->getName().compare(rhs->first.first->getName()))
       return cmp;
 
@@ -532,7 +532,7 @@ void DependsEmitter::emitTopLevelNames(const ReferencedNameTracker *const tracke
   }
 }
 
-void DependsEmitter::emitMember(ArrayRef<TableEntryTy> sortedMembers) const {
+void DependsEmitter::emitMember(ArrayRef<MemberTableEntryTy> sortedMembers) const {
   out << "depends-member:\n";
   for (auto &entry : sortedMembers) {
     assert(entry.first.first != nullptr);
@@ -552,7 +552,7 @@ void DependsEmitter::emitMember(ArrayRef<TableEntryTy> sortedMembers) const {
   }
 }
 
-void DependsEmitter::emitNominal(ArrayRef<TableEntryTy> sortedMembers) const {
+void DependsEmitter::emitNominal(ArrayRef<MemberTableEntryTy> sortedMembers) const {
   out << "depends-nominal:\n";
   for (auto i = sortedMembers.begin(), e = sortedMembers.end(); i != e; ++i) {
     bool isCascading = i->second;

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -193,7 +193,7 @@ bool swift::emitReferenceDependencies(DiagnosticEngine &diags,
 }
 
 void ProvidesEmitter::emit() const {
-  out << "provides-top-level:\n";
+  out << "provides-top-level" << ":\n";
 
   CollectedProvidedDeclarations cpd = emitTopLevelNames();
   emitNominalTypes(cpd.extendedNominals);
@@ -216,7 +216,7 @@ void ReferenceDependenciesEmitter::emitDepends() const {
 void ReferenceDependenciesEmitter::emitInterfaceHash() const {
   llvm::SmallString<32> interfaceHash;
   SF->getInterfaceHash(interfaceHash);
-  out << "interface-hash: \"" << interfaceHash << "\"\n";
+  out << "interface-hash" << ": \"" << interfaceHash << "\"\n";
 }
 
 ProvidesEmitter::CollectedProvidedDeclarations ProvidesEmitter::emitTopLevelNames() const {
@@ -362,7 +362,7 @@ void ProvidesEmitter::emitValueDecl(const ValueDecl *const VD) const {
 
 void ProvidesEmitter::emitNominalTypes(
     const llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals) const {
-  out << "provides-nominal:\n";
+  out << "provides-nominal" << ":\n";
   for (auto entry : extendedNominals) {
     if (!entry.second)
       continue;
@@ -374,7 +374,7 @@ void ProvidesEmitter::emitNominalTypes(
 
 void ProvidesEmitter::emitMembers(
     const CollectedProvidedDeclarations &cpd) const {
-  out << "provides-member:\n";
+  out << "provides-member" << ":\n";
   for (auto entry : cpd.extendedNominals) {
     out << "- [\"";
     out << mangleTypeAsContext(entry.first);
@@ -404,7 +404,7 @@ void ProvidesEmitter::emitDynamicLookupMembers() const {
     // We should (a) see if there's a cheaper way to keep it up to date,
     // and/or (b) see if we can fast-path cases where there's no ObjC
     // involved.
-    out << "provides-dynamic-lookup:\n";
+    out << "provides-dynamic-lookup" << ":\n";
     class NameCollector : public VisibleDeclConsumer {
     private:
       SmallVector<DeclBaseName, 16> names;
@@ -520,7 +520,7 @@ void DependsEmitter::emit() const {
 }
 
 void DependsEmitter::emitTopLevelNames(const ReferencedNameTracker *const tracker) const {
-  out << "depends-top-level:\n";
+  out << "depends-top-level" << ":\n";
   for (auto &entry : sortedByName(tracker->getTopLevelNames())) {
     assert(!entry.first.empty());
     out << "- ";
@@ -531,7 +531,7 @@ void DependsEmitter::emitTopLevelNames(const ReferencedNameTracker *const tracke
 }
 
 void DependsEmitter::emitMember(ArrayRef<MemberTableEntryTy> sortedMembers) const {
-  out << "depends-member:\n";
+  out << "depends-member" << ":\n";
   for (auto &entry : sortedMembers) {
     assert(entry.first.first != nullptr);
     if (entry.first.first->hasAccess() &&
@@ -551,7 +551,7 @@ void DependsEmitter::emitMember(ArrayRef<MemberTableEntryTy> sortedMembers) cons
 }
 
 void DependsEmitter::emitNominal(ArrayRef<MemberTableEntryTy> sortedMembers) const {
-  out << "depends-nominal:\n";
+  out << "depends-nominal" << ":\n";
   for (auto i = sortedMembers.begin(), e = sortedMembers.end(); i != e; ++i) {
     bool isCascading = i->second;
     while (i+1 != e && i[0].first.first == i[1].first.first) {
@@ -573,7 +573,7 @@ void DependsEmitter::emitNominal(ArrayRef<MemberTableEntryTy> sortedMembers) con
 }
 
 void DependsEmitter::emitDynamicLookup(const ReferencedNameTracker *const tracker) const {
-  out << "depends-dynamic-lookup:\n";
+  out << "depends-dynamic-lookup" << ":\n";
   for (auto &entry : sortedByName(tracker->getDynamicLookupNames())) {
     assert(!entry.first.empty());
     out << "- ";
@@ -584,7 +584,7 @@ void DependsEmitter::emitDynamicLookup(const ReferencedNameTracker *const tracke
 }
 
 void DependsEmitter::emitExternal(const DependencyTracker &depTracker) const {
-  out << "depends-external:\n";
+  out << "depends-external" << ":\n";
   for (auto &entry : reversePathSortedFilenames(depTracker.getDependencies())) {
     out << "- \"" << llvm::yaml::escape(entry) << "\"\n";
   }

--- a/lib/FrontendTool/ReferenceDependencies.cpp
+++ b/lib/FrontendTool/ReferenceDependencies.cpp
@@ -127,11 +127,11 @@ static std::string escape(DeclBaseName name) {
   return llvm::yaml::escape(name.userFacingName());
 }
 
-static void emitProvides(const SourceFile *SF, llvm::raw_fd_ostream &out);
+static void emitProvides(const SourceFile *SF, llvm::raw_ostream &out);
 static void emitDepends(const SourceFile *SF,
                         const DependencyTracker &depTracker,
-                        llvm::raw_fd_ostream &out);
-static void emitInterfaceHash(SourceFile *SF, llvm::raw_fd_ostream &out);
+                        llvm::raw_ostream &out);
+static void emitInterfaceHash(SourceFile *SF, llvm::raw_ostream &out);
 
 bool swift::emitReferenceDependencies(DiagnosticEngine &diags,
                                       SourceFile *const SF,
@@ -164,25 +164,25 @@ bool swift::emitReferenceDependencies(DiagnosticEngine &diags,
 }
 
 static void emitProvidesTopLevelNames(
-    const SourceFile *SF, llvm::raw_fd_ostream &out,
+    const SourceFile *SF, llvm::raw_ostream &out,
     llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
     llvm::SmallVectorImpl<const ExtensionDecl *> &extensionsWithJustMembers);
 
 static void emitProvidesNominalTypes(
     const llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
-    llvm::raw_fd_ostream &out);
+    llvm::raw_ostream &out);
 
 static void emitProvidesMembers(
     const llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
     const llvm::SmallVectorImpl<const ExtensionDecl *>
         &extensionsWithJustMembers,
-    llvm::raw_fd_ostream &out);
+    llvm::raw_ostream &out);
 
 static void emitProvidesDynamicLookupMembers(const SourceFile *SF,
-                                             llvm::raw_fd_ostream &out);
+                                             llvm::raw_ostream &out);
 
 static void emitProvides(const SourceFile *const SF,
-                         llvm::raw_fd_ostream &out) {
+                         llvm::raw_ostream &out) {
   llvm::MapVector<const NominalTypeDecl *, bool> extendedNominals;
   llvm::SmallVector<const ExtensionDecl *, 8> extensionsWithJustMembers;
 
@@ -196,13 +196,13 @@ static void emitProvides(const SourceFile *const SF,
 }
 
 static void emitProvidesTopLevelDecl(
-    const Decl *const D, llvm::raw_fd_ostream &out,
+    const Decl *const D, llvm::raw_ostream &out,
     llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
     llvm::SmallVectorImpl<const FuncDecl *> &memberOperatorDecls,
     llvm::SmallVectorImpl<const ExtensionDecl *> &extensionsWithJustMembers);
 
 static void emitProvidesTopLevelNames(
-    const SourceFile *const SF, llvm::raw_fd_ostream &out,
+    const SourceFile *const SF, llvm::raw_ostream &out,
     llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
     llvm::SmallVectorImpl<const ExtensionDecl *> &extensionsWithJustMembers) {
   llvm::SmallVector<const FuncDecl *, 8> memberOperatorDecls;
@@ -215,21 +215,21 @@ static void emitProvidesTopLevelNames(
 }
 
 static void emitProvidesExtensionDecl(
-    const ExtensionDecl *ED, llvm::raw_fd_ostream &out,
+    const ExtensionDecl *ED, llvm::raw_ostream &out,
     llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
     llvm::SmallVectorImpl<const FuncDecl *> &memberOperatorDecls,
     llvm::SmallVectorImpl<const ExtensionDecl *> &extensionsWithJustMembers);
 
 static void emitProvidesNominalTypeDecl(
-    const NominalTypeDecl *NTD, llvm::raw_fd_ostream &out,
+    const NominalTypeDecl *NTD, llvm::raw_ostream &out,
     llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
     llvm::SmallVectorImpl<const FuncDecl *> &memberOperatorDecls);
 
 static void emitProvidesValueDecl(const ValueDecl *VD,
-                                  llvm::raw_fd_ostream &out);
+                                  llvm::raw_ostream &out);
 
 static void emitProvidesTopLevelDecl(
-    const Decl *const D, llvm::raw_fd_ostream &out,
+    const Decl *const D, llvm::raw_ostream &out,
     llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
     llvm::SmallVectorImpl<const FuncDecl *> &memberOperatorDecls,
     llvm::SmallVectorImpl<const ExtensionDecl *> &extensionsWithJustMembers) {
@@ -293,7 +293,7 @@ static void emitProvidesTopLevelDecl(
 }
 
 static void emitProvidesExtensionDecl(
-    const ExtensionDecl *const ED, llvm::raw_fd_ostream &out,
+    const ExtensionDecl *const ED, llvm::raw_ostream &out,
     llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
     llvm::SmallVectorImpl<const FuncDecl *> &memberOperatorDecls,
     llvm::SmallVectorImpl<const ExtensionDecl *> &extensionsWithJustMembers) {
@@ -322,7 +322,7 @@ static void emitProvidesExtensionDecl(
 }
 
 static void emitProvidesNominalTypeDecl(
-    const NominalTypeDecl *const NTD, llvm::raw_fd_ostream &out,
+    const NominalTypeDecl *const NTD, llvm::raw_ostream &out,
     llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
     llvm::SmallVectorImpl<const FuncDecl *> &memberOperatorDecls) {
   if (!NTD->hasName())
@@ -337,7 +337,7 @@ static void emitProvidesNominalTypeDecl(
 }
 
 static void emitProvidesValueDecl(const ValueDecl *const VD,
-                                  llvm::raw_fd_ostream &out) {
+                                  llvm::raw_ostream &out) {
   if (!VD->hasName())
     return;
   if (VD->hasAccess() && VD->getFormalAccess() <= AccessLevel::FilePrivate) {
@@ -348,7 +348,7 @@ static void emitProvidesValueDecl(const ValueDecl *const VD,
 
 static void emitProvidesNominalTypes(
     const llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
-    llvm::raw_fd_ostream &out) {
+    llvm::raw_ostream &out) {
   out << "provides-nominal:\n";
   for (auto entry : extendedNominals) {
     if (!entry.second)
@@ -363,7 +363,7 @@ static void emitProvidesMembers(
     const llvm::MapVector<const NominalTypeDecl *, bool> &extendedNominals,
     const llvm::SmallVectorImpl<const ExtensionDecl *>
         &extensionsWithJustMembers,
-    llvm::raw_fd_ostream &out) {
+    llvm::raw_ostream &out) {
   out << "provides-member:\n";
   for (auto entry : extendedNominals) {
     out << "- [\"";
@@ -389,7 +389,7 @@ static void emitProvidesMembers(
 }
 
 static void emitProvidesDynamicLookupMembers(const SourceFile *const SF,
-                                             llvm::raw_fd_ostream &out) {
+                                             llvm::raw_ostream &out) {
   if (SF->getASTContext().LangOpts.EnableObjCInterop) {
     // FIXME: This requires a traversal of the whole file to compute.
     // We should (a) see if there's a cheaper way to keep it up to date,
@@ -434,25 +434,25 @@ sortedByName(const llvm::DenseMap<DeclBaseName, bool> map) {
 }
 
 static void emitDependsTopLevelNames(const ReferencedNameTracker *tracker,
-                                     llvm::raw_fd_ostream &out);
+                                     llvm::raw_ostream &out);
 
 using TableEntryTy = std::pair<ReferencedNameTracker::MemberPair, bool>;
 
 static void emitDependsMember(ArrayRef<TableEntryTy> sortedMembers,
-                              llvm::raw_fd_ostream &out);
+                              llvm::raw_ostream &out);
 
 static void emitDependsNominal(ArrayRef<TableEntryTy> sortedMembers,
-                               llvm::raw_fd_ostream &out);
+                               llvm::raw_ostream &out);
 
 static void emitDependsDynamicLookup(const ReferencedNameTracker *tracker,
-                                     llvm::raw_fd_ostream &out);
+                                     llvm::raw_ostream &out);
 
 static void emitDependsExternal(const DependencyTracker &depTracker,
-                                llvm::raw_fd_ostream &out);
+                                llvm::raw_ostream &out);
 
 static void emitDepends(const SourceFile *const SF,
                         const DependencyTracker &depTracker,
-                        llvm::raw_fd_ostream &out) {
+                        llvm::raw_ostream &out) {
 
   const ReferencedNameTracker *const tracker = SF->getReferencedNameTracker();
   assert(tracker && "Cannot emit reference dependencies without a tracker");
@@ -490,7 +490,7 @@ static void emitDepends(const SourceFile *const SF,
 }
 
 static void emitDependsTopLevelNames(const ReferencedNameTracker *const tracker,
-                                     llvm::raw_fd_ostream &out) {
+                                     llvm::raw_ostream &out) {
   out << "depends-top-level:\n";
   for (auto &entry : sortedByName(tracker->getTopLevelNames())) {
     assert(!entry.first.empty());
@@ -502,7 +502,7 @@ static void emitDependsTopLevelNames(const ReferencedNameTracker *const tracker,
 }
 
 static void emitDependsMember(ArrayRef<TableEntryTy> sortedMembers,
-                              llvm::raw_fd_ostream &out) {
+                              llvm::raw_ostream &out) {
   out << "depends-member:\n";
   for (auto &entry : sortedMembers) {
     assert(entry.first.first != nullptr);
@@ -523,7 +523,7 @@ static void emitDependsMember(ArrayRef<TableEntryTy> sortedMembers,
 }
 
 static void emitDependsNominal(ArrayRef<TableEntryTy> sortedMembers,
-                               llvm::raw_fd_ostream &out) {
+                               llvm::raw_ostream &out) {
   out << "depends-nominal:\n";
   for (auto i = sortedMembers.begin(), e = sortedMembers.end(); i != e; ++i) {
     bool isCascading = i->second;
@@ -546,7 +546,7 @@ static void emitDependsNominal(ArrayRef<TableEntryTy> sortedMembers,
 }
 
 static void emitDependsDynamicLookup(const ReferencedNameTracker *const tracker,
-                                     llvm::raw_fd_ostream &out) {
+                                     llvm::raw_ostream &out) {
   out << "depends-dynamic-lookup:\n";
   for (auto &entry : sortedByName(tracker->getDynamicLookupNames())) {
     assert(!entry.first.empty());
@@ -558,14 +558,14 @@ static void emitDependsDynamicLookup(const ReferencedNameTracker *const tracker,
 }
 
 static void emitDependsExternal(const DependencyTracker &depTracker,
-                                llvm::raw_fd_ostream &out) {
+                                llvm::raw_ostream &out) {
   out << "depends-external:\n";
   for (auto &entry : reversePathSortedFilenames(depTracker.getDependencies())) {
     out << "- \"" << llvm::yaml::escape(entry) << "\"\n";
   }
 }
 
-static void emitInterfaceHash(SourceFile *const SF, llvm::raw_fd_ostream &out) {
+static void emitInterfaceHash(SourceFile *const SF, llvm::raw_ostream &out) {
   llvm::SmallString<32> interfaceHash;
   SF->getInterfaceHash(interfaceHash);
   out << "interface-hash: \"" << interfaceHash << "\"\n";

--- a/lib/FrontendTool/ReferenceDependencies.h
+++ b/lib/FrontendTool/ReferenceDependencies.h
@@ -33,7 +33,7 @@ reversePathSortedFilenames(const llvm::ArrayRef<std::string> paths);
 
 /// Emit a Swift-style dependencies file for \p SF.
 bool emitReferenceDependencies(DiagnosticEngine &diags, SourceFile *SF,
-                               DependencyTracker &depTracker,
+                               const DependencyTracker &depTracker,
                                StringRef outputPath);
 } // end namespace swift
 

--- a/unittests/Driver/DependencyGraphTests.cpp
+++ b/unittests/Driver/DependencyGraphTests.cpp
@@ -55,28 +55,28 @@ TEST(DependencyGraph, BasicLoad) {
             LoadResult::UpToDate);
 
   EXPECT_EQ(loadFromString(graph, i++,
-                                  providesNominal, "a, b",
-                                  providesTopLevel, "b, c",
-                                  dependsNominal, "c, d",
-                                  dependsTopLevel, "d, a"),
+                           providesNominal, "a, b",
+                           providesTopLevel, "b, c",
+                           dependsNominal, "c, d",
+                           dependsTopLevel, "d, a"),
             LoadResult::UpToDate);
 }
 
 TEST(DependencyGraph, IndependentNodes) {
   DependencyGraph<uintptr_t> graph;
-    
+
   EXPECT_EQ(loadFromString(graph, 0,
-                                  dependsTopLevel, "a",
-                                  providesTopLevel, "a0"),
-            LoadResult::UpToDate);
+                           dependsTopLevel, "a",
+                           providesTopLevel, "a0"),
+      LoadResult::UpToDate);
   EXPECT_EQ(loadFromString(graph, 1,
-                                  dependsTopLevel, "b",
-                                  providesTopLevel, "b0"),
-            LoadResult::UpToDate);
+                           dependsTopLevel, "b",
+                           providesTopLevel, "b0"),
+      LoadResult::UpToDate);
   EXPECT_EQ(loadFromString(graph, 2,
-                                  dependsTopLevel, "c",
-                                  providesTopLevel, "c0"),
-            LoadResult::UpToDate);
+                           dependsTopLevel, "c",
+                           providesTopLevel, "c0"),
+      LoadResult::UpToDate);
 
   SmallVector<uintptr_t, 4> marked;
 
@@ -110,13 +110,13 @@ TEST(DependencyGraph, IndependentDepKinds) {
   DependencyGraph<uintptr_t> graph;
 
   EXPECT_EQ(loadFromString(graph, 0,
-                                  dependsNominal, "a",
-                                  providesNominal, "b"),
+                           dependsNominal, "a",
+                           providesNominal, "b"),
             LoadResult::UpToDate);
   EXPECT_EQ(loadFromString(graph, 1,
-                                  dependsTopLevel, "b",
-                                  providesTopLevel, "a"),
-            LoadResult::UpToDate);
+                           dependsTopLevel, "b",
+                           providesTopLevel, "a"),
+      LoadResult::UpToDate);
 
   SmallVector<uintptr_t, 4> marked;
 
@@ -130,13 +130,13 @@ TEST(DependencyGraph, IndependentDepKinds2) {
   DependencyGraph<uintptr_t> graph;
 
   EXPECT_EQ(loadFromString(graph, 0,
-                                  dependsNominal, "a",
-                                  providesNominal, "b"),
+                           dependsNominal, "a",
+                           providesNominal, "b"),
             LoadResult::UpToDate);
   EXPECT_EQ(loadFromString(graph, 1,
-                                  dependsTopLevel, "b",
-                                  providesTopLevel, "a"),
-            LoadResult::UpToDate);
+                           dependsTopLevel, "b",
+                           providesTopLevel, "a"),
+      LoadResult::UpToDate);
 
   SmallVector<uintptr_t, 4> marked;
 
@@ -244,9 +244,9 @@ TEST(DependencyGraph, SimpleDependent3) {
   DependencyGraph<uintptr_t> graph;
 
   EXPECT_EQ(loadFromString(graph, 0,
-                                  providesNominal, "a",
-                                  providesTopLevel, "a"),
-            LoadResult::UpToDate);
+                           providesNominal, "a",
+                           providesTopLevel, "a"),
+      LoadResult::UpToDate);
   EXPECT_EQ(loadFromString(graph, 1, dependsNominal, "a"),
             LoadResult::UpToDate);
 
@@ -271,8 +271,8 @@ TEST(DependencyGraph, SimpleDependent4) {
   EXPECT_EQ(loadFromString(graph, 0, providesNominal, "a"),
             LoadResult::UpToDate);
   EXPECT_EQ(loadFromString(graph, 1,
-                                  dependsNominal, "a",
-                                  dependsTopLevel, "a"),
+                           dependsNominal, "a",
+                           dependsTopLevel, "a"),
             LoadResult::UpToDate);
 
   SmallVector<uintptr_t, 4> marked;
@@ -294,12 +294,12 @@ TEST(DependencyGraph, SimpleDependent5) {
   DependencyGraph<uintptr_t> graph;
 
   EXPECT_EQ(loadFromString(graph, 0,
-                                  providesNominal, "a",
-                                  providesTopLevel, "a"),
-            LoadResult::UpToDate);
+                           providesNominal, "a",
+                           providesTopLevel, "a"),
+      LoadResult::UpToDate);
   EXPECT_EQ(loadFromString(graph, 1,
-                                  dependsNominal, "a",
-                                  dependsTopLevel, "a"),
+                           dependsNominal, "a",
+                           dependsTopLevel, "a"),
             LoadResult::UpToDate);
 
   SmallVector<uintptr_t, 4> marked;
@@ -345,10 +345,10 @@ TEST(DependencyGraph, SimpleDependentMember) {
   DependencyGraph<uintptr_t> graph;
 
   EXPECT_EQ(loadFromString(graph, 0,
-                                  providesMember, "[a,aa], [b,bb], [c,cc]"),
-      LoadResult::UpToDate);
+                           providesMember, "[a,aa], [b,bb], [c,cc]"),
+            LoadResult::UpToDate);
   EXPECT_EQ(loadFromString(graph, 1,
-                                  dependsMember, "[x, xx], [b,bb], [z,zz]"),
+                           dependsMember, "[x, xx], [b,bb], [z,zz]"),
             LoadResult::UpToDate);
 
   SmallVector<uintptr_t, 4> marked;
@@ -434,9 +434,9 @@ TEST(DependencyGraph, ChainedDependents) {
   EXPECT_EQ(loadFromString(graph, 0, providesNominal, "a, b, c"),
             LoadResult::UpToDate);
   EXPECT_EQ(loadFromString(graph, 1,
-                                  dependsNominal, "x, b",
-                                  providesNominal, "z"),
-            LoadResult::UpToDate);
+                           dependsNominal, "x, b",
+                           providesNominal, "z"),
+      LoadResult::UpToDate);
   EXPECT_EQ(loadFromString(graph, 2, dependsNominal, "z"),
             LoadResult::UpToDate);
 
@@ -464,21 +464,21 @@ TEST(DependencyGraph, MarkTwoNodes) {
   EXPECT_EQ(loadFromString(graph, 0, providesNominal, "a, b"),
             LoadResult::UpToDate);
   EXPECT_EQ(loadFromString(graph, 1,
-                                  dependsNominal, "a",
-                                  providesNominal, "z"),
+                           dependsNominal, "a",
+                           providesNominal, "z"),
             LoadResult::UpToDate);
   EXPECT_EQ(loadFromString(graph, 2, dependsNominal, "z"),
             LoadResult::UpToDate);
   EXPECT_EQ(loadFromString(graph, 10,
-                                  providesNominal, "y, z",
-                                  dependsNominal, "q"),
-            LoadResult::UpToDate);
+                           providesNominal, "y, z",
+                           dependsNominal, "q"),
+      LoadResult::UpToDate);
   EXPECT_EQ(loadFromString(graph, 11, dependsNominal, "y"),
             LoadResult::UpToDate);
   EXPECT_EQ(loadFromString(graph, 12,
-                                  dependsNominal, "q",
-                                  providesNominal, "q"),
-            LoadResult::UpToDate);
+                           dependsNominal, "q",
+                           providesNominal, "q"),
+      LoadResult::UpToDate);
 
   SmallVector<uintptr_t, 4> marked;
 
@@ -589,8 +589,8 @@ TEST(DependencyGraph, NotTransitiveOnceMarked) {
 
   // Reload 1.
   EXPECT_EQ(loadFromString(graph, 1,
-                                  dependsNominal, "a",
-                                  providesNominal, "b"),
+                           dependsNominal, "a",
+                           providesNominal, "b"),
             LoadResult::UpToDate);
   marked.clear();
 
@@ -613,12 +613,13 @@ TEST(DependencyGraph, DependencyLoops) {
   DependencyGraph<uintptr_t> graph;
 
   EXPECT_EQ(loadFromString(graph, 0,
-                                  providesTopLevel, "a, b, c",
-                                  dependsTopLevel, "a"),
+                           providesTopLevel, "a, b, c",
+                           dependsTopLevel, "a"),
             LoadResult::UpToDate);
   EXPECT_EQ(loadFromString(graph, 1,
-                                  providesTopLevel, "x",
-                                  dependsTopLevel, "x, b, z"),
+                           providesTopLevel, "x",
+                           dependsTopLevel,
+                           "x, b, z"),
             LoadResult::UpToDate);
   EXPECT_EQ(loadFromString(graph, 2, dependsTopLevel, "x"),
             LoadResult::UpToDate);
@@ -740,13 +741,13 @@ TEST(DependencyGraph, ChainedExternal) {
   DependencyGraph<uintptr_t> graph;
 
   EXPECT_EQ(loadFromString(graph, 0,
-                                  dependsExternal, "/foo",
-                                  providesTopLevel, "a"),
-            LoadResult::UpToDate);
+                           dependsExternal, "/foo",
+                           providesTopLevel, "a"),
+      LoadResult::UpToDate);
   EXPECT_EQ(loadFromString(graph, 1,
-                                  dependsExternal, "/bar",
-                                  dependsTopLevel, "a"),
-            LoadResult::UpToDate);
+                           dependsExternal, "/bar",
+                           dependsTopLevel, "a"),
+      LoadResult::UpToDate);
 
   EXPECT_TRUE(contains(graph.getExternalDependencies(), "/foo"));
   EXPECT_TRUE(contains(graph.getExternalDependencies(), "/bar"));
@@ -768,13 +769,13 @@ TEST(DependencyGraph, ChainedExternalReverse) {
   DependencyGraph<uintptr_t> graph;
 
   EXPECT_EQ(loadFromString(graph, 0,
-                                  dependsExternal, "/foo",
-                                  providesTopLevel, "a"),
-            LoadResult::UpToDate);
+                           dependsExternal, "/foo",
+                           providesTopLevel, "a"),
+      LoadResult::UpToDate);
   EXPECT_EQ(loadFromString(graph, 1,
-                                  dependsExternal, "/bar",
-                                  dependsTopLevel, "a"),
-            LoadResult::UpToDate);
+                           dependsExternal, "/bar",
+                           dependsTopLevel, "a"),
+      LoadResult::UpToDate);
 
   SmallVector<uintptr_t, 4> marked;
   graph.markExternal(marked, "/bar");
@@ -801,13 +802,13 @@ TEST(DependencyGraph, ChainedExternalPreMarked) {
   DependencyGraph<uintptr_t> graph;
 
   EXPECT_EQ(loadFromString(graph, 0,
-                                  dependsExternal, "/foo",
-                                  providesTopLevel, "a"),
-            LoadResult::UpToDate);
+                           dependsExternal, "/foo",
+                           providesTopLevel, "a"),
+      LoadResult::UpToDate);
   EXPECT_EQ(loadFromString(graph, 1,
-                                  dependsExternal, "/bar",
-                                  dependsTopLevel, "a"),
-            LoadResult::UpToDate);
+                           dependsExternal, "/bar",
+                           dependsTopLevel, "a"),
+      LoadResult::UpToDate);
 
   graph.markIntransitive(0);
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
To faciliate work on incremental compilation, carve up a long routine that outputs reference dependencies into smaller pieces to make the structure more accessible.
Also centralize label strings so that the driver and frontend don't have separate copies.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->