### PR TITLE
[GSB] Use a larger set for checking for visited requirements in 'isRecursive'.

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -1775,7 +1775,7 @@ FloatingRequirementSource FloatingRequirementSource::asInferred(
 bool FloatingRequirementSource::isRecursive(
                                     Type rootType,
                                     GenericSignatureBuilder &builder) const {
-  llvm::SmallSet<std::pair<CanType, ProtocolDecl *>, 4> visitedAssocReqs;
+  llvm::SmallSet<std::pair<CanType, ProtocolDecl *>, 32> visitedAssocReqs;
   for (auto storedSource = storage.dyn_cast<const RequirementSource *>();
        storedSource; storedSource = storedSource->parent) {
     // FIXME: isRecursive() is completely misnamed


### PR DESCRIPTION
This claws back some of the regression of
2feb830b58456ab6c22d8a191d15f69fe56a458a on certain generics heavy code.

rdar://problem/40005262 (no-opt) goes from 7.83 -> 5.75 and
rdar://problem/40010847 (opt) goes from 90.7 -> 66.6 (both -27%).