### PR TITLE
[4.2 2018-04-30] [Serialization] Handle XREFs to generic subscripts

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -1659,8 +1659,11 @@ giveUpFastPath:
         }
       } else if (auto alias = dyn_cast<TypeAliasDecl>(base)) {
         paramList = alias->getGenericParams();
-      } else if (auto fn = dyn_cast<AbstractFunctionDecl>(base))
+      } else if (auto fn = dyn_cast<AbstractFunctionDecl>(base)) {
         paramList = fn->getGenericParams();
+      } else if (auto subscript = dyn_cast<SubscriptDecl>(base)) {
+        paramList = subscript->getGenericParams();
+      }
 
       if (!paramList) {
         return llvm::make_error<XRefError>(

--- a/test/Serialization/Inputs/has_generic_subscript.swift
+++ b/test/Serialization/Inputs/has_generic_subscript.swift
@@ -8,6 +8,7 @@ public struct GenericSubscript {
     set { }
   }
 }
+extension GenericSubscript: GenericSubscriptProto {}
 
 public struct Outer<T> {
   public struct Inner<U> {

--- a/test/Serialization/Inputs/has_generic_subscript_proto.swift
+++ b/test/Serialization/Inputs/has_generic_subscript_proto.swift
@@ -1,0 +1,3 @@
+public protocol GenericSubscriptProto {
+  subscript<K, V>(k: K) -> V { get set }
+}

--- a/test/Serialization/generic_subscript.swift
+++ b/test/Serialization/generic_subscript.swift
@@ -1,5 +1,5 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -emit-module -o %t %S/Inputs/has_generic_subscript.swift
+// RUN: %target-build-swift -emit-module -o %t %S/Inputs/has_generic_subscript.swift %S/Inputs/has_generic_subscript_proto.swift -module-name has_generic_subscript
 // RUN: llvm-bcanalyzer %t/has_generic_subscript.swiftmodule | %FileCheck %s
 // RUN: %target-swift-frontend -emit-ir -I %t %s -o /dev/null
 
@@ -8,4 +8,5 @@
 import has_generic_subscript
 
 var sillyDict = GenericSubscript()
+_ = sillyDict as GenericSubscriptProto
 var value: Int = sillyDict["beer"]


### PR DESCRIPTION
* Description: Fixes a crash when deserializing a reference to a generic parameter within a generic subscript.

* Scope of the issue: Affects some projects that use generic subscripts across modules.

* Risk: Effectively zero; it's a small change to handle a case that would previously cause an immediate crash.

* Tested: New test added.

* Reviewed by: @jrose-apple 

* Radar: rdar://problem/40161885