### PR TITLE
Include source ranges for statements, declarations, and parameter lists in the AST dump

### DIFF
--- a/include/swift/AST/Stmt.h
+++ b/include/swift/AST/Stmt.h
@@ -128,7 +128,7 @@ public:
   LLVM_ATTRIBUTE_DEPRECATED(
       void dump() const LLVM_ATTRIBUTE_USED,
       "only for use within the debugger");
-  void print(raw_ostream &OS, unsigned Indent = 0) const;
+  void print(raw_ostream &OS, const ASTContext *Ctx = nullptr, unsigned Indent = 0) const;
 
   // Only allow allocation of Exprs using the allocator in ASTContext
   // or by doing a placement new.

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -425,7 +425,7 @@ namespace {
 
     void printRec(Decl *D) { D->dump(OS, Indent + 2); }
     void printRec(Expr *E) { E->print(OS, Indent + 2); }
-    void printRec(Stmt *S) { S->print(OS, Indent + 2); }
+    void printRec(Stmt *S, const ASTContext &Ctx) { S->print(OS, &Ctx, Indent + 2); }
     void printRec(TypeRepr *T);
     void printRec(const Pattern *P) {
       PrintPattern(OS, Indent+2).visit(const_cast<Pattern *>(P));
@@ -553,7 +553,7 @@ namespace {
     
     void printRec(Decl *D) { PrintDecl(OS, Indent + 2).visit(D); }
     void printRec(Expr *E) { E->print(OS, Indent+2); }
-    void printRec(Stmt *S) { S->print(OS, Indent+2); }
+    void printRec(Stmt *S, const ASTContext &Ctx) { S->print(OS, &Ctx, Indent+2); }
     void printRec(Pattern *P) { PrintPattern(OS, Indent+2).visit(P); }
     void printRec(TypeRepr *T);
 
@@ -1038,7 +1038,7 @@ namespace {
       }
       if (auto Body = D->getBody(/*canSynthesize=*/false)) {
         OS << '\n';
-        printRec(Body);
+        printRec(Body, D->getASTContext());
       }
     }
 
@@ -1085,12 +1085,12 @@ namespace {
       printCommon(TLCD, "top_level_code_decl");
       if (TLCD->getBody()) {
         OS << "\n";
-        printRec(TLCD->getBody());
+        printRec(TLCD->getBody(), static_cast<Decl *>(TLCD)->getASTContext());
       }
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
     
-    void printASTNodes(const ArrayRef<ASTNode> &Elements, StringRef Name) {
+    void printASTNodes(const ArrayRef<ASTNode> &Elements, const ASTContext &Ctx, StringRef Name) {
       OS.indent(Indent);
       PrintWithColorRAII(OS, ParenthesisColor) << "(";
       PrintWithColorRAII(OS, ASTNodeColor) << Name;
@@ -1099,7 +1099,7 @@ namespace {
         if (auto *SubExpr = Elt.dyn_cast<Expr*>())
           printRec(SubExpr);
         else if (auto *SubStmt = Elt.dyn_cast<Stmt*>())
-          printRec(SubStmt);
+          printRec(SubStmt, Ctx);
         else
           printRec(Elt.get<Decl*>());
       }
@@ -1122,7 +1122,7 @@ namespace {
 
         OS << '\n';
         Indent += 2;
-        printASTNodes(Clause.Elements, "elements");
+        printASTNodes(Clause.Elements, ICD->getASTContext(), "elements");
         Indent -= 2;
       }
 
@@ -1369,9 +1369,11 @@ namespace {
 class PrintStmt : public StmtVisitor<PrintStmt> {
 public:
   raw_ostream &OS;
+  const ASTContext *Ctx;
   unsigned Indent;
 
-  PrintStmt(raw_ostream &os, unsigned indent) : OS(os), Indent(indent) {
+  PrintStmt(raw_ostream &os, const ASTContext *ctx, unsigned indent)
+    : OS(os), Ctx(ctx), Indent(indent) {
   }
 
   void printRec(Stmt *S) {
@@ -1438,6 +1440,15 @@ public:
     if (S->isImplicit())
       OS << " implicit";
 
+    if (Ctx) {
+      auto R = S->getSourceRange();
+      if (R.isValid()) {
+        PrintWithColorRAII(OS, RangeColor) << " range=";
+        R.print(PrintWithColorRAII(OS, RangeColor).getOS(),
+                Ctx->SourceMgr, /*PrintText=*/false);
+      }
+    }
+
     if (S->TrailingSemiLoc.isValid())
       OS << " trailing_semi";
 
@@ -1445,13 +1456,12 @@ public:
   }
 
   void visitBraceStmt(BraceStmt *S) {
-    printASTNodes(S->getElements(), "brace_stmt");
+    printCommon(S, "brace_stmt");
+    printASTNodes(S->getElements());
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 
-  void printASTNodes(const ArrayRef<ASTNode> &Elements, StringRef Name) {
-    OS.indent(Indent);
-    PrintWithColorRAII(OS, ParenthesisColor) << "(";
-    PrintWithColorRAII(OS, ASTNodeColor) << Name;
+  void printASTNodes(const ArrayRef<ASTNode> &Elements) {
     for (auto Elt : Elements) {
       OS << '\n';
       if (auto *SubExpr = Elt.dyn_cast<Expr*>())
@@ -1461,7 +1471,6 @@ public:
       else
         printRec(Elt.get<Decl*>());
     }
-    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 
   void visitReturnStmt(ReturnStmt *S) {
@@ -1645,8 +1654,8 @@ void Stmt::dump() const {
   llvm::errs() << '\n';
 }
 
-void Stmt::print(raw_ostream &OS, unsigned Indent) const {
-  PrintStmt(OS, Indent).visit(const_cast<Stmt*>(this));
+void Stmt::print(raw_ostream &OS, const ASTContext *Ctx, unsigned Indent) const {
+  PrintStmt(OS, Ctx, Indent).visit(const_cast<Stmt*>(this));
 }
 
 //===----------------------------------------------------------------------===//
@@ -1691,7 +1700,7 @@ public:
   /// FIXME: This should use ExprWalker to print children.
 
   void printRec(Decl *D) { D->dump(OS, Indent + 2); }
-  void printRec(Stmt *S) { S->print(OS, Indent + 2); }
+  void printRec(Stmt *S, const ASTContext &Ctx) { S->print(OS, &Ctx, Indent + 2); }
   void printRec(const Pattern *P) {
     PrintPattern(OS, Indent+2).visit(const_cast<Pattern *>(P));
   }
@@ -2301,7 +2310,7 @@ public:
     if (E->hasSingleExpressionBody()) {
       printRec(E->getSingleExpressionBody());
     } else {
-      printRec(E->getBody());
+      printRec(E->getBody(), E->getASTContext());
     }
     PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -991,7 +991,7 @@ namespace {
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
     }
 
-    void printParameterList(const ParameterList *params) {
+    void printParameterList(const ParameterList *params, const ASTContext *ctx = nullptr) {
       OS.indent(Indent);
       PrintWithColorRAII(OS, ParenthesisColor) << '(';
       PrintWithColorRAII(OS, ParameterColor) << "parameter_list";
@@ -1000,6 +1000,19 @@ namespace {
         OS << '\n';
         printParameter(P);
       }
+
+      if (!ctx && params->size() != 0 && params->get(0))
+        ctx = &params->get(0)->getASTContext();
+
+      if (ctx) {
+        auto R = params->getSourceRange();
+        if (R.isValid()) {
+          PrintWithColorRAII(OS, RangeColor) << " range=";
+          R.print(PrintWithColorRAII(OS, RangeColor).getOS(),
+                  ctx->SourceMgr, /*PrintText=*/false);
+        }
+      }
+
       PrintWithColorRAII(OS, ParenthesisColor) << ')';
       Indent -= 2;
     }
@@ -1008,7 +1021,7 @@ namespace {
       for (auto pl : D->getParameterLists()) {
         OS << '\n';
         Indent += 2;
-        printParameterList(pl);
+        printParameterList(pl, &D->getASTContext());
         Indent -= 2;
      }
       if (auto FD = dyn_cast<FuncDecl>(D)) {
@@ -2281,7 +2294,7 @@ public:
 
     if (E->getParameters()) {
       OS << '\n';
-      PrintDecl(OS, Indent+2).printParameterList(E->getParameters());
+      PrintDecl(OS, Indent+2).printParameterList(E->getParameters(), &E->getASTContext());
     }
 
     OS << '\n';
@@ -2297,7 +2310,7 @@ public:
 
     if (E->getParameters()) {
       OS << '\n';
-      PrintDecl(OS, Indent+2).printParameterList(E->getParameters());
+      PrintDecl(OS, Indent+2).printParameterList(E->getParameters(), &E->getASTContext());
     }
 
     OS << '\n';

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -575,6 +575,13 @@ namespace {
       if (D->isImplicit())
         PrintWithColorRAII(OS, DeclModifierColor) << " implicit";
 
+      auto R = D->getSourceRange();
+      if (R.isValid()) {
+        PrintWithColorRAII(OS, RangeColor) << " range=";
+        R.print(PrintWithColorRAII(OS, RangeColor).getOS(),
+                D->getASTContext().SourceMgr, /*PrintText=*/false);
+      }
+
       if (D->TrailingSemiLoc.isValid())
         PrintWithColorRAII(OS, DeclModifierColor) << " trailing_semi";
     }

--- a/test/Driver/dump-parse.swift
+++ b/test/Driver/dump-parse.swift
@@ -1,8 +1,8 @@
 // RUN: not %target-swift-frontend -dump-parse %s 2>&1 | %FileCheck %s
 // RUN: not %target-swift-frontend -dump-ast %s 2>&1 | %FileCheck %s -check-prefix=CHECK-AST
 
-// CHECK-LABEL: (func_decl "foo(_:)"
-// CHECK-AST-LABEL: (func_decl "foo(_:)"
+// CHECK-LABEL: (func_decl{{.*}}"foo(_:)"
+// CHECK-AST-LABEL: (func_decl{{.*}}"foo(_:)"
 func foo(_ n: Int) -> Int {
   // CHECK:   (brace_stmt
   // CHECK:     (return_stmt
@@ -15,8 +15,8 @@ func foo(_ n: Int) -> Int {
 }
 
 // -dump-parse should print an AST even though this code is invalid.
-// CHECK-LABEL: (func_decl "bar()"
-// CHECK-AST-LABEL: (func_decl "bar()"
+// CHECK-LABEL: (func_decl{{.*}}"bar()"
+// CHECK-AST-LABEL: (func_decl{{.*}}"bar()"
 func bar() {
   // CHECK: (brace_stmt
   // CHECK-NEXT:   (unresolved_decl_ref_expr type='{{[^']+}}' name=foo
@@ -29,22 +29,22 @@ func bar() {
   foo foo foo
 }
 
-// CHECK-LABEL: (enum_decl trailing_semi "TrailingSemi"
+// CHECK-LABEL: (enum_decl{{.*}}trailing_semi "TrailingSemi"
 enum TrailingSemi {
 
-  // CHECK-LABEL: (enum_case_decl trailing_semi
+  // CHECK-LABEL: (enum_case_decl{{.*}}trailing_semi
   // CHECK-NOT:   (enum_element_decl{{.*}}trailing_semi
-  // CHECK:       (enum_element_decl "A")
-  // CHECK:       (enum_element_decl "B")
+  // CHECK:       (enum_element_decl{{.*}}"A")
+  // CHECK:       (enum_element_decl{{.*}}"B")
   case A,B;
 
-  // CHECK-LABEL: (subscript_decl trailing_semi
-  // CHECK-NOT:   (func_decl trailing_semi 'anonname={{.*}}' getter_for=subscript(_:)
-  // CHECK:       (accessor_decl 'anonname={{.*}}' getter_for=subscript(_:)
+  // CHECK-LABEL: (subscript_decl{{.*}}trailing_semi
+  // CHECK-NOT:   (func_decl{{.*}}trailing_semi 'anonname={{.*}}' getter_for=subscript(_:)
+  // CHECK:       (accessor_decl{{.*}}'anonname={{.*}}' getter_for=subscript(_:)
   subscript(x: Int) -> Int {
-    // CHECK-LABEL: (pattern_binding_decl trailing_semi
-    // CHECK-NOT:   (var_decl trailing_semi "y"
-    // CHECK:       (var_decl "y"
+    // CHECK-LABEL: (pattern_binding_decl{{.*}}trailing_semi
+    // CHECK-NOT:   (var_decl{{.*}}trailing_semi "y"
+    // CHECK:       (var_decl{{.*}}"y"
     var y = 1;
 
     // CHECK-LABEL: (sequence_expr {{.*}} trailing_semi
@@ -56,7 +56,7 @@ enum TrailingSemi {
 };
 
 // The substitution map for a declref should be relatively unobtrustive.
-// CHECK-AST-LABEL:   (func_decl "generic(_:)" <T : Hashable> interface type='<T where T : Hashable> (T) -> ()' access=internal captures=(<generic> )
+// CHECK-AST-LABEL:   (func_decl{{.*}}"generic(_:)" <T : Hashable> interface type='<T where T : Hashable> (T) -> ()' access=internal captures=(<generic> )
 func generic<T: Hashable>(_: T) {}
 // CHECK-AST:       (pattern_binding_decl
 // CHECK-AST:         (declref_expr type='(Int) -> ()' location={{.*}} range={{.*}} decl=main.(file).generic@{{.*}} [with (substitution_map generic_signature=<T where T : Hashable> (substitution T -> Int))] function_ref=unapplied))

--- a/test/Driver/dump-parse.swift
+++ b/test/Driver/dump-parse.swift
@@ -50,7 +50,7 @@ enum TrailingSemi {
     // CHECK-LABEL: (sequence_expr {{.*}} trailing_semi
     y += 1;
 
-    // CHECK-LABEL: (return_stmt trailing_semi
+    // CHECK-LABEL: (return_stmt{{.*}}trailing_semi
     return y;
   };
 };

--- a/test/NameBinding/import-resolution-overload.swift
+++ b/test/NameBinding/import-resolution-overload.swift
@@ -55,7 +55,7 @@ extension HasFooSub {
   var foo: Int { return 0 }
 }
 
-// CHECK-LABEL: func_decl "testHasFooSub(_:)"
+// CHECK-LABEL: func_decl{{.*}}"testHasFooSub(_:)"
 func testHasFooSub(_ hfs: HasFooSub) -> Int {
   // CHECK: return_stmt
   // CHECK-NOT: func_decl
@@ -67,7 +67,7 @@ extension HasBar {
   var bar: Int { return 0 }
 }
 
-// CHECK-LABEL: func_decl "testHasBar(_:)"
+// CHECK-LABEL: func_decl{{.*}}"testHasBar(_:)"
 func testHasBar(_ hb: HasBar) -> Int {
   // CHECK: return_stmt
   // CHECK-NOT: func_decl

--- a/test/Parse/if_expr.swift
+++ b/test/Parse/if_expr.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -dump-ast %s 2>&1 | %FileCheck %s
 
-// CHECK: (func_decl "r13756261(_:_:)"
+// CHECK: (func_decl{{.*}}"r13756261(_:_:)"
 func r13756261(_ x: Bool, _ y: Int) -> Int {
   // CHECK: (if_expr
   // CHECK:   (call_expr
@@ -15,7 +15,7 @@ func r13756261(_ x: Bool, _ y: Int) -> Int {
   return (x) ? y : (x) ? y : (x) ? y : y
 }
 
-// CHECK: (func_decl "r13756221(_:_:)"
+// CHECK: (func_decl{{.*}}"r13756221(_:_:)"
 func r13756221(_ x: Bool, _ y: Int) -> Int {
   // CHECK: (if_expr
   // CHECK:   (call_expr
@@ -33,7 +33,7 @@ func r13756221(_ x: Bool, _ y: Int) -> Int {
        : y
 }
 
-// CHECK: (func_decl "telescoping_if(_:_:)"
+// CHECK: (func_decl{{.*}}"telescoping_if(_:_:)"
 func telescoping_if(_ x: Bool, _ y: Int) -> Int {
   // CHECK: (if_expr
   // CHECK:   (call_expr
@@ -69,7 +69,7 @@ func +>> (x: Bool, y: Bool) -> Bool {}
 func +<< (x: Bool, y: Bool) -> Bool {}
 func +== (x: Bool, y: Bool) -> Bool {}
 
-// CHECK: (func_decl "prec_above(_:_:_:)"
+// CHECK: (func_decl{{.*}}"prec_above(_:_:_:)"
 func prec_above(_ x: Bool, _ y: Bool, _ z: Bool) -> Bool {
   // (x +>> y) ? (y +>> z) : ((x +>> y) ? (y +>> z) : (x +>> y))
   // CHECK: (if_expr
@@ -82,7 +82,7 @@ func prec_above(_ x: Bool, _ y: Bool, _ z: Bool) -> Bool {
   return x +>> y ? y +>> z : x +>> y ? y +>> z : x +>> y
 }
 
-// CHECK: (func_decl "prec_below(_:_:_:)"
+// CHECK: (func_decl{{.*}}"prec_below(_:_:_:)"
 func prec_below(_ x: Bool, _ y: Bool, _ z: Bool) -> Bool {
   // The middle arm of the ternary is max-munched, so this is:
   // ((x +<< (y ? (y +<< z) : x)) +<< (y ? (y +<< z) : x)) +<< y
@@ -102,7 +102,7 @@ func prec_below(_ x: Bool, _ y: Bool, _ z: Bool) -> Bool {
   return x +<< y ? y +<< z : x +<< y ? y +<< z : x +<< y
 }
 
-// CHECK: (func_decl "prec_equal(_:_:_:)"
+// CHECK: (func_decl{{.*}}"prec_equal(_:_:_:)"
 func prec_equal(_ x: Bool, _ y: Bool, _ z: Bool) -> Bool {
   // The middle arm of the ternary is max-munched, so this is:
   // x +== (y ? (y +== z) : (x +== (y ? (y +== z) : (x +== y))))

--- a/test/attr/attr_fixed_layout.swift
+++ b/test/attr/attr_fixed_layout.swift
@@ -7,14 +7,14 @@
 // Public types with @_fixed_layout are always fixed layout
 //
 
-// RESILIENCE-ON: struct_decl "Point" interface type='Point.Type' access=public non-resilient
-// RESILIENCE-OFF: struct_decl "Point" interface type='Point.Type' access=public non-resilient
+// RESILIENCE-ON: struct_decl{{.*}}"Point" interface type='Point.Type' access=public non-resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"Point" interface type='Point.Type' access=public non-resilient
 @_fixed_layout public struct Point {
   let x, y: Int
 }
 
-// RESILIENCE-ON: enum_decl "ChooseYourOwnAdventure" interface type='ChooseYourOwnAdventure.Type' access=public non-resilient
-// RESILIENCE-OFF: enum_decl "ChooseYourOwnAdventure" interface type='ChooseYourOwnAdventure.Type' access=public non-resilient
+// RESILIENCE-ON: enum_decl{{.*}}"ChooseYourOwnAdventure" interface type='ChooseYourOwnAdventure.Type' access=public non-resilient
+// RESILIENCE-OFF: enum_decl{{.*}}"ChooseYourOwnAdventure" interface type='ChooseYourOwnAdventure.Type' access=public non-resilient
 @_frozen public enum ChooseYourOwnAdventure {
   case JumpIntoRabbitHole
   case EatMushroom
@@ -24,14 +24,14 @@
 // Public types are resilient when -enable-resilience is on
 //
 
-// RESILIENCE-ON: struct_decl "Size" interface type='Size.Type' access=public resilient
-// RESILIENCE-OFF: struct_decl "Size" interface type='Size.Type' access=public non-resilient
+// RESILIENCE-ON: struct_decl{{.*}}"Size" interface type='Size.Type' access=public resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"Size" interface type='Size.Type' access=public non-resilient
 public struct Size {
   let w, h: Int
 }
 
-// RESILIENCE-ON: enum_decl "TaxCredit" interface type='TaxCredit.Type' access=public resilient
-// RESILIENCE-OFF: enum_decl "TaxCredit" interface type='TaxCredit.Type' access=public non-resilient
+// RESILIENCE-ON: enum_decl{{.*}}"TaxCredit" interface type='TaxCredit.Type' access=public resilient
+// RESILIENCE-OFF: enum_decl{{.*}}"TaxCredit" interface type='TaxCredit.Type' access=public non-resilient
 public enum TaxCredit {
   case EarnedIncome
   case MortgageDeduction
@@ -41,8 +41,8 @@ public enum TaxCredit {
 // Internal types are always fixed layout
 //
 
-// RESILIENCE-ON: struct_decl "Rectangle" interface type='Rectangle.Type' access=internal non-resilient
-// RESILIENCE-OFF: struct_decl "Rectangle" interface type='Rectangle.Type' access=internal non-resilient
+// RESILIENCE-ON: struct_decl{{.*}}"Rectangle" interface type='Rectangle.Type' access=internal non-resilient
+// RESILIENCE-OFF: struct_decl{{.*}}"Rectangle" interface type='Rectangle.Type' access=internal non-resilient
 struct Rectangle {
   let topLeft: Point
   let bottomRight: Size

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -2038,14 +2038,14 @@ class ClassThrows1 {
 }
 
 
-// CHECK-DUMP-LABEL: class_decl "ImplicitClassThrows1"
+// CHECK-DUMP-LABEL: class_decl{{.*}}"ImplicitClassThrows1"
 @objc class ImplicitClassThrows1 {
   // CHECK: @objc func methodReturnsVoid() throws
-  // CHECK-DUMP: func_decl "methodReturnsVoid()"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
+  // CHECK-DUMP: func_decl{{.*}}"methodReturnsVoid()"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
   func methodReturnsVoid() throws { }
 
   // CHECK: @objc func methodReturnsObjCClass() throws -> Class_ObjC1
-  // CHECK-DUMP: func_decl "methodReturnsObjCClass()" {{.*}}foreign_error=NilResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>
+  // CHECK-DUMP: func_decl{{.*}}"methodReturnsObjCClass()" {{.*}}foreign_error=NilResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>
   func methodReturnsObjCClass() throws -> Class_ObjC1 {
     return Class_ObjC1()
   }
@@ -2060,11 +2060,11 @@ class ClassThrows1 {
   func methodReturnsOptionalObjCClass() throws -> Class_ObjC1? { return nil }
 
   // CHECK: @objc func methodWithTrailingClosures(_ s: String, fn1: @escaping ((Int) -> Int), fn2: @escaping (Int) -> Int, fn3: @escaping (Int) -> Int)
-  // CHECK-DUMP: func_decl "methodWithTrailingClosures(_:fn1:fn2:fn3:)"{{.*}}foreign_error=ZeroResult,unowned,param=1,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
+  // CHECK-DUMP: func_decl{{.*}}"methodWithTrailingClosures(_:fn1:fn2:fn3:)"{{.*}}foreign_error=ZeroResult,unowned,param=1,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
   func methodWithTrailingClosures(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int, fn3: @escaping (Int) -> Int) throws { }
 
   // CHECK: @objc init(degrees: Double) throws
-  // CHECK-DUMP: constructor_decl "init(degrees:)"{{.*}}foreign_error=NilResult,unowned,param=1,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>
+  // CHECK-DUMP: constructor_decl{{.*}}"init(degrees:)"{{.*}}foreign_error=NilResult,unowned,param=1,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>
   init(degrees: Double) throws { }
 
   // CHECK: {{^}} func methodReturnsBridgedValueType() throws -> NSRange
@@ -2086,10 +2086,10 @@ class ClassThrows1 {
   }
 }
 
-// CHECK-DUMP-LABEL: class_decl "SubclassImplicitClassThrows1"
+// CHECK-DUMP-LABEL: class_decl{{.*}}"SubclassImplicitClassThrows1"
 @objc class SubclassImplicitClassThrows1 : ImplicitClassThrows1 {
   // CHECK: @objc override func methodWithTrailingClosures(_ s: String, fn1: @escaping ((Int) -> Int), fn2: @escaping ((Int) -> Int), fn3: @escaping ((Int) -> Int))
-  // CHECK-DUMP: func_decl "methodWithTrailingClosures(_:fn1:fn2:fn3:)"{{.*}}foreign_error=ZeroResult,unowned,param=1,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
+  // CHECK-DUMP: func_decl{{.*}}"methodWithTrailingClosures(_:fn1:fn2:fn3:)"{{.*}}foreign_error=ZeroResult,unowned,param=1,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
   override func methodWithTrailingClosures(_ s: String, fn1: (@escaping (Int) -> Int), fn2: (@escaping (Int) -> Int), fn3: (@escaping (Int) -> Int)) throws { }
 }
 
@@ -2122,20 +2122,20 @@ class ThrowsObjCName {
 
   @objc(method7) func method7(x: Int) throws { } // expected-error{{@objc' method name provides names for 0 arguments, but method has 2 parameters (including the error parameter)}}
 
-  // CHECK-DUMP: func_decl "method8(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=2,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
+  // CHECK-DUMP: func_decl{{.*}}"method8(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=2,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
   @objc(method8:fn1:error:fn2:)
   func method8(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 
-  // CHECK-DUMP: func_decl "method9(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
+  // CHECK-DUMP: func_decl{{.*}}"method9(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
   @objc(method9AndReturnError:s:fn1:fn2:)
   func method9(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 }
 
 class SubclassThrowsObjCName : ThrowsObjCName {
-  // CHECK-DUMP: func_decl "method8(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=2,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
+  // CHECK-DUMP: func_decl{{.*}}"method8(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=2,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
   override func method8(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 
-  // CHECK-DUMP: func_decl "method9(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
+  // CHECK-DUMP: func_decl{{.*}}"method9(_:fn1:fn2:)"{{.*}}foreign_error=ZeroResult,unowned,param=0,paramtype=Optional<AutoreleasingUnsafeMutablePointer<Optional<NSError>>>,resulttype=ObjCBool
   override func method9(_ s: String, fn1: (@escaping (Int) -> Int), fn2: @escaping (Int) -> Int) throws { }
 }
 

--- a/test/decl/protocol/associated_type_overrides.swift
+++ b/test/decl/protocol/associated_type_overrides.swift
@@ -4,8 +4,8 @@ protocol P1 {
   associatedtype A
 }
 
-// CHECK-LABEL: protocol "P2"
-// CHECK-NEXT: (associated_type_decl "A" {{.*}} overridden=P1))
+// CHECK-LABEL: (protocol{{.*}}"P2"
+// CHECK-NEXT: (associated_type_decl{{.*}}"A" {{.*}} overridden=P1))
 protocol P2 : P1 {
   associatedtype A
 }
@@ -14,14 +14,14 @@ protocol P3 {
   associatedtype A
 }
 
-// CHECK-LABEL: protocol "P4"
-// CHECK-NEXT: (associated_type_decl "A" {{.*}} overridden=P2, P3))
+// CHECK-LABEL: (protocol{{.*}}"P4"
+// CHECK-NEXT: (associated_type_decl{{.*}}"A" {{.*}} overridden=P2, P3))
 protocol P4 : P2, P3 {
   associatedtype A
 }
 
-// CHECK-LABEL: protocol "P5"
-// CHECK-NEXT: (associated_type_decl "A" {{.*}} overridden=P4))
+// CHECK-LABEL: (protocol{{.*}}"P5"
+// CHECK-NEXT: (associated_type_decl{{.*}}"A" {{.*}} overridden=P4))
 protocol P5 : P4, P2 {
   associatedtype A
 }

--- a/test/decl/protocol/conforms/nscoding.swift
+++ b/test/decl/protocol/conforms/nscoding.swift
@@ -12,7 +12,7 @@
 import Foundation
 
 // Top-level classes
-// CHECK-NOT: class_decl "CodingA"{{.*}}@_staticInitializeObjCMetadata
+// CHECK-NOT: class_decl{{.*}}"CodingA"{{.*}}@_staticInitializeObjCMetadata
 class CodingA : NSObject, NSCoding {
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
@@ -21,7 +21,7 @@ class CodingA : NSObject, NSCoding {
 
 // Nested classes
 extension CodingA {
-  // CHECK-NOT: class_decl "NestedA"{{.*}}@_staticInitializeObjCMetadata
+  // CHECK-NOT: class_decl{{.*}}"NestedA"{{.*}}@_staticInitializeObjCMetadata
   class NestedA : NSObject, NSCoding { // expected-error{{nested class 'CodingA.NestedA' has an unstable name when archiving via 'NSCoding'}}
     // expected-note@-1{{for compatibility with existing archives, use '@objc' to record the Swift 3 runtime name}}{{3-3=@objc(_TtCC8nscoding7CodingA7NestedA)}}
     // expected-note@-2{{for new classes, use '@objc' to specify a unique, prefixed Objective-C runtime name}}{{3-3=@objc(<#prefixed Objective-C class name#>)}}
@@ -36,14 +36,14 @@ extension CodingA {
     func encode(coder: NSCoder) { }
   }
 
-  // CHECK-NOT: class_decl "NestedC"{{.*}}@_staticInitializeObjCMetadata
+  // CHECK-NOT: class_decl{{.*}}"NestedC"{{.*}}@_staticInitializeObjCMetadata
   @objc(CodingA_NestedC)
   class NestedC : NSObject, NSCoding {
     required init(coder: NSCoder) { }
     func encode(coder: NSCoder) { }
   }
 
-  // CHECK-NOT: class_decl "NestedD"{{.*}}@_staticInitializeObjCMetadata
+  // CHECK-NOT: class_decl{{.*}}"NestedD"{{.*}}@_staticInitializeObjCMetadata
   @objc(CodingA_NestedD)
   class NestedD : NSObject {
     required init(coder: NSCoder) { }
@@ -58,7 +58,7 @@ extension CodingA.NestedD: NSCoding { // okay
 }
 
 // Generic classes
-// CHECK-NOT: class_decl "CodingB"{{.*}}@_staticInitializeObjCMetadata
+// CHECK-NOT: class_decl{{.*}}"CodingB"{{.*}}@_staticInitializeObjCMetadata
 class CodingB<T> : NSObject, NSCoding {
   required init(coder: NSCoder) { }
   func encode(coder: NSCoder) { }
@@ -72,7 +72,7 @@ extension CodingB {
 }
 
 // Fileprivate classes.
-// CHECK-NOT: class_decl "CodingC"{{.*}}@_staticInitializeObjCMetadata
+// CHECK-NOT: class_decl{{.*}}"CodingC"{{.*}}@_staticInitializeObjCMetadata
 fileprivate class CodingC : NSObject, NSCoding { // expected-error{{fileprivate class 'CodingC' has an unstable name when archiving via 'NSCoding'}}
   // expected-note@-1{{for compatibility with existing archives, use '@objc' to record the Swift 3 runtime name}}{{1-1=@objc(_TtC8nscodingP33_0B4E7641C0BD1F170280EEDD0D0C1F6C7CodingC)}}
   // expected-note@-2{{for new classes, use '@objc' to specify a unique, prefixed Objective-C runtime name}}{{1-1=@objc(<#prefixed Objective-C class name#>)}}
@@ -99,7 +99,7 @@ func someFunction() {
 }
 
 // Inherited conformances.
-// CHECK-NOT: class_decl "CodingE"{{.*}}@_staticInitializeObjCMetadata
+// CHECK-NOT: class_decl{{.*}}"CodingE"{{.*}}@_staticInitializeObjCMetadata
 class CodingE<T> : CodingB<T> {
   required init(coder: NSCoder) { super.init(coder: coder) }
   override func encode(coder: NSCoder) { }
@@ -119,24 +119,24 @@ private class CodingG : NSObject, NSCoding {
 }
 
 extension CodingB {
-  // CHECK-NOT: class_decl "GenericViaScope"{{.*}}@_staticInitializeObjCMetadata
+  // CHECK-NOT: class_decl{{.*}}"GenericViaScope"{{.*}}@_staticInitializeObjCMetadata
   @objc(GenericViaScope) // expected-error {{generic subclasses of '@objc' classes cannot have an explicit '@objc' because they are not directly visible from Objective-C}}
   class GenericViaScope : NSObject { }
 }
 
 // Inference of @_staticInitializeObjCMetadata.
-// CHECK-NOT: class_decl "SubclassOfCodingA"{{.*}}@_staticInitializeObjCMetadata
+// CHECK-NOT: class_decl{{.*}}"SubclassOfCodingA"{{.*}}@_staticInitializeObjCMetadata
 class SubclassOfCodingA : CodingA { }
 
-// CHECK: class_decl "SubclassOfCodingE"{{.*}}@_staticInitializeObjCMetadata
+// CHECK: class_decl{{.*}}"SubclassOfCodingE"{{.*}}@_staticInitializeObjCMetadata
 class SubclassOfCodingE : CodingE<Int> { }
 
 // Do not warn when simply inheriting from classes that conform to NSCoding.
 // The subclass may never be serialized. But do still infer static
 // initialization, just in case.
-// CHECK-NOT: class_decl "PrivateSubclassOfCodingA"{{.*}}@_staticInitializeObjCMetadata
+// CHECK-NOT: class_decl{{.*}}"PrivateSubclassOfCodingA"{{.*}}@_staticInitializeObjCMetadata
 private class PrivateSubclassOfCodingA : CodingA { }
-// CHECK: class_decl "PrivateSubclassOfCodingE"{{.*}}@_staticInitializeObjCMetadata
+// CHECK: class_decl{{.*}}"PrivateSubclassOfCodingE"{{.*}}@_staticInitializeObjCMetadata
 private class PrivateSubclassOfCodingE : CodingE<Int> { }
 
 // But do warn when inherited through a protocol.

--- a/test/decl/protocol/conforms/nscoding_availability_osx.swift
+++ b/test/decl/protocol/conforms/nscoding_availability_osx.swift
@@ -17,6 +17,6 @@ class CodingI : NSObject, NSCoding {
 
 @available(OSX 10.51, *)
 class OuterCodingJ {
-  // CHECK-NOT: class_decl "NestedJ"{{.*}}@_staticInitializeObjCMetadata
+  // CHECK-NOT: class_decl{{.*}}"NestedJ"{{.*}}@_staticInitializeObjCMetadata
   class NestedJ : CodingI { }
 }

--- a/test/expr/capture/dynamic_self.swift
+++ b/test/expr/capture/dynamic_self.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -dump-ast %s 2>&1 | %FileCheck %s
 
-// CHECK: func_decl "clone()" interface type='(Android) -> () -> Self'
+// CHECK: func_decl{{.*}}"clone()" interface type='(Android) -> () -> Self'
 
 class Android {
   func clone() -> Self {

--- a/test/expr/capture/generic_params.swift
+++ b/test/expr/capture/generic_params.swift
@@ -2,7 +2,7 @@
 
 func doSomething<T>(_ t: T) {}
 
-// CHECK: func_decl "outerGeneric(t:x:)" <T> interface type='<T> (t: T, x: AnyObject) -> ()'
+// CHECK: func_decl{{.*}}"outerGeneric(t:x:)" <T> interface type='<T> (t: T, x: AnyObject) -> ()'
 
 func outerGeneric<T>(t: T, x: AnyObject) {
   // Simple case -- closure captures outer generic parameter
@@ -20,14 +20,14 @@ func outerGeneric<T>(t: T, x: AnyObject) {
 
   // Nested generic functions always capture outer generic parameters, even if
   // they're not mentioned in the function body
-  // CHECK: func_decl "innerGeneric(u:)" <U> interface type='<T, U> (u: U) -> ()' {{.*}} captures=(<generic> )
+  // CHECK: func_decl{{.*}}"innerGeneric(u:)" <U> interface type='<T, U> (u: U) -> ()' {{.*}} captures=(<generic> )
   func innerGeneric<U>(u: U) {}
 
   // Make sure we look through typealiases
   typealias TT = (a: T, b: T)
 
   // FIXME: Losing some type sugar here.
-  // CHECK: func_decl "localFunction(tt:)" interface type='<T> (tt: (a: T, b: T)) -> ()' {{.*}} captures=(<generic> )
+  // CHECK: func_decl{{.*}}"localFunction(tt:)" interface type='<T> (tt: (a: T, b: T)) -> ()' {{.*}} captures=(<generic> )
   func localFunction(tt: TT) {}
 
   // CHECK: closure_expr type='((a: T, b: T)) -> ()' {{.*}} captures=(<generic> )

--- a/test/expr/capture/nested.swift
+++ b/test/expr/capture/nested.swift
@@ -1,6 +1,6 @@
 // RUN: %target-swift-frontend -dump-ast %s 2>&1 | %FileCheck %s
 
-// CHECK: func_decl "foo2(_:)"
+// CHECK: func_decl{{.*}}"foo2(_:)"
 func foo2(_ x: Int) -> (Int) -> (Int) -> Int {
   // CHECK: closure_expr type='(Int) -> (Int) -> Int' {{.*}} discriminator=0 captures=(x)
   return {(bar: Int) -> (Int) -> Int in

--- a/test/expr/capture/top-level-guard.swift
+++ b/test/expr/capture/top-level-guard.swift
@@ -15,7 +15,7 @@ guard let x = Optional(0) else { fatalError() }
 // CHECK: (top_level_code_decl
 _ = 0 // intervening code
 
-// CHECK-LABEL: (func_decl "function()" interface type='() -> ()' access=internal captures=(x<direct>)
+// CHECK-LABEL: (func_decl{{.*}}"function()" interface type='() -> ()' access=internal captures=(x<direct>)
 func function() {
   _ = x
 }
@@ -23,7 +23,7 @@ func function() {
 // CHECK-LABEL: (closure_expr
 // CHECK: location={{.*}}top-level-guard.swift:[[@LINE+3]]
 // CHECK: captures=(x<direct>)
-// CHECK: (var_decl "closure"
+// CHECK: (var_decl{{.*}}"closure"
 let closure: () -> Void = {
   _ = x
 }
@@ -33,13 +33,13 @@ let closure: () -> Void = {
 // CHECK: (closure_expr
 // CHECK: location={{.*}}top-level-guard.swift:[[@LINE+3]]
 // CHECK: captures=(x)
-// CHECK: (var_decl "closureCapture"
+// CHECK: (var_decl{{.*}}"closureCapture"
 let closureCapture: () -> Void = { [x] in
   _ = x
 }
 
 // CHECK-LABEL: (defer_stmt
-// CHECK-NEXT: (func_decl implicit "$defer()" interface type='() -> ()' access=fileprivate captures=(x<direct><noescape>)
+// CHECK-NEXT: (func_decl{{.*}}implicit "$defer()" interface type='() -> ()' access=fileprivate captures=(x<direct><noescape>)
 defer {
   _ = x
 }

--- a/test/expr/primary/literal/collection_upcast_opt.swift
+++ b/test/expr/primary/literal/collection_upcast_opt.swift
@@ -11,7 +11,7 @@ struct TakesArray<T> {
   init(_: [(T) -> Void]) { }
 }
 
-// CHECK-LABEL: func_decl "arrayUpcast(_:_:)"
+// CHECK-LABEL: func_decl{{.*}}"arrayUpcast(_:_:)"
 // CHECK: assign_expr
 // CHECK-NOT: collection_upcast_expr
 // CHECK: array_expr type='[(X) -> Void]'
@@ -27,7 +27,7 @@ struct TakesDictionary<T> {
   init(_: [Int : (T) -> Void]) { }
 }
 
-// CHECK-LABEL: func_decl "dictionaryUpcast(_:_:)"
+// CHECK-LABEL: func_decl{{.*}}"dictionaryUpcast(_:_:)"
 // CHECK: assign_expr
 // CHECK-NOT: collection_upcast_expr
 // CHECK: paren_expr type='([Int : (X) -> Void])'


### PR DESCRIPTION
Source ranges are currently missing from statements, declarations, and parameter lists in the AST dump. This PR addresses that.

For some background: we have a Swift-based domain-specific language that works by analyzing AST dumps and transforming them into new Swift code. In cases where the input doesn't match the constraints of our DSL, we emit errors that point to the problems in the original Swift source. The lack of source range information on these node types makes this difficult for certain types of errors.

This is #16473 rebased on master, with the necessary fixes made to tests.