### PR TITLE
[migrator] Apply the flatMap -> compactMap fixit

### DIFF
--- a/include/swift/Migrator/FixitFilter.h
+++ b/include/swift/Migrator/FixitFilter.h
@@ -117,6 +117,16 @@ struct FixitFilter {
     if (Kind == DiagnosticKind::Error)
       return true;
 
+    if (Info.ID == diag::note_deprecated_rename.ID) {
+      // deprecated_rename FixIts may not always be equivalent, so filter down
+      // to those we want to apply.
+      for (auto FixIt: Info.FixIts) {
+        // flatMap -> compactMap
+        if (FixIt.getText().contains("compactMap"))
+          return true;
+      }
+    }
+
     // Fixits from warnings/notes that should be applied.
     if (Info.ID == diag::forced_downcast_coercion.ID ||
         Info.ID == diag::forced_downcast_noop.ID ||

--- a/test/Migrator/fixit_flatMap.swift
+++ b/test/Migrator/fixit_flatMap.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -typecheck %s -swift-version 4
+// RUN: %target-swift-frontend -typecheck -update-code -primary-file %s -emit-migrated-file-path %t.result -swift-version 4
+// RUN: diff -u %s.expected %t.result
+// RUN: %target-swift-frontend -typecheck %s.expected
+
+_ = [1,2,3].flatMap { $0 < 2 ? nil : $0 }
+func foo(x: UnsafeMutablePointer<Int>) {
+  x.initialize(to: 2, count: 2)
+}

--- a/test/Migrator/fixit_flatMap.swift.expected
+++ b/test/Migrator/fixit_flatMap.swift.expected
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -typecheck %s -swift-version 4
+// RUN: %target-swift-frontend -typecheck -update-code -primary-file %s -emit-migrated-file-path %t.result -swift-version 4
+// RUN: diff -u %s.expected %t.result
+// RUN: %target-swift-frontend -typecheck %s.expected
+
+_ = [1,2,3].compactMap { $0 < 2 ? nil : $0 }
+func foo(x: UnsafeMutablePointer<Int>) {
+  x.initialize(to: 2, count: 2)
+}


### PR DESCRIPTION
The deprecation warning shows up fairly commonly post-migration and its fixit is safe to apply automatically.

Resolves rdar://problem/40172217