### PR TITLE
[Testing] Fix over-eager regex in IDE/complete_expr_postfix_begin.swift

### DIFF
--- a/test/IDE/complete_expr_postfix_begin.swift
+++ b/test/IDE/complete_expr_postfix_begin.swift
@@ -123,8 +123,7 @@ typealias FooTypealias = Int
 // COMMON-DAG: Keyword[#column]/None: #column[#Int#]{{; name=.+$}}
 // COMMON: End completions
 
-// NO_SELF-NOT: Self
-// NO_SELF-NOT: self
+// NO_SELF-NOT: {{[[:<:]][Ss]elf[[:>:]]}}
 
 //===--- Test that we can code complete at the beginning of expr-postfix.
 


### PR DESCRIPTION
Don't trip over a keyword just because '[sS]elf' is within the name.