### PR TITLE
<rdar://40182303> Fix typo in error message, on failure to write stats file.

### DIFF
--- a/lib/Basic/Statistic.cpp
+++ b/lib/Basic/Statistic.cpp
@@ -621,7 +621,7 @@ UnifiedStatsReporter::~UnifiedStatsReporter()
   raw_fd_ostream ostream(StatsFilename, EC, fs::F_Append | fs::F_Text);
   if (EC) {
     llvm::errs() << "Error opening -stats-output-dir file '"
-                 << TraceFilename << "' for writing\n";
+                 << StatsFilename << "' for writing\n";
     return;
   }
 


### PR DESCRIPTION
Trivial typo in error message discovered while reading output of a transient bug.

rdar://40182303