### PR TITLE
[TypeReconstruction] Add support for generic typealiases.

### DIFF
--- a/test/DebugInfo/DumpDeclFromMangledName.swift
+++ b/test/DebugInfo/DumpDeclFromMangledName.swift
@@ -39,3 +39,19 @@ func patatino() -> Int {
 }
 
 patatino()
+
+class Foo<T> {
+  var x : T
+  init(_ x : T) {
+    self.x = x
+  }
+}
+
+typealias Patatino<T> = Foo<T>
+
+func main() -> Int {
+  var p : Patatino<Int> = Patatino(23);
+  return 0
+}
+
+let _ = main()

--- a/test/DebugInfo/DumpTypeFromMangledName.swift
+++ b/test/DebugInfo/DumpTypeFromMangledName.swift
@@ -12,10 +12,6 @@
 // RUN: diff %t.check %t.output
 
 // REQUIRES: executable_test
-func main() {
-  struct Patatino {}
-}
-
 extension Collection where Element: Equatable {
   func split<C: Collection>(separatedBy separator: C) -> [SubSequence]
     where C.Element == Element {
@@ -23,3 +19,20 @@ extension Collection where Element: Equatable {
       return results
   }
 }
+
+class Foo<T> {
+  var x : T
+  init(_ x : T) {
+    self.x = x
+  }
+}
+
+typealias Patatino<T> = Foo<T>
+
+func main() -> Int {
+  struct patatino {}
+  var p : Patatino<Int> = Patatino(23);
+  return 0
+}
+
+let _ = main()

--- a/test/DebugInfo/Inputs/decl-reconstr-names.txt
+++ b/test/DebugInfo/Inputs/decl-reconstr-names.txt
@@ -1,2 +1,3 @@
 $S12DeclReconstr8patatinoSiyF ---> func patatino() -> Int
 $S12DeclReconstr1SVACycfC ---> init()
+$S12DeclReconstr8PatatinoaySiGD ---> typealias Patatino<T> = Foo<T>

--- a/test/DebugInfo/Inputs/type-reconstr-names.txt
+++ b/test/DebugInfo/Inputs/type-reconstr-names.txt
@@ -4,3 +4,4 @@ $Ss5Int32VD ---> Int32
 $S4blah4mainyyF8PatatinoL_VMa ---> Can't resolve type of $S4blah4mainyyF8PatatinoL_VMa
 $Ss10CollectionP7Element ---> Can't resolve type of $Ss10CollectionP7Element
 $Ss15ContiguousArrayV9formIndex5afterySiz_tFSS_Tg5 ---> (inout Int) -> ()
+$S12TypeReconstr8PatatinoaySiGD ---> Patatino<Int>


### PR DESCRIPTION
This fixes the compiler side of the problem.
An lldb test will be added to make sure this doesn't regress
in the future (or, if it does, at least we know).

<rdar://problem/40261592>.