### PR TITLE
[SR-7562] inheriting discardableResult attribute for constructors.

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2026,6 +2026,12 @@ static void configureDesignatedInitAttributes(TypeChecker &tc,
     }
   }
 
+  // Inherit the @discardableResult attribute.
+  if (superclassCtor->getAttrs().hasAttribute<DiscardableResultAttr>()) {
+    auto *clonedAttr = new (ctx) DiscardableResultAttr(/*implicit=*/true);
+    ctor->getAttrs().add(clonedAttr);
+  }
+
   // Make sure the constructor is only as available as its superclass's
   // constructor.
   AvailabilityInference::applyInferredAvailableAttrs(ctor, superclassCtor, ctx);

--- a/test/attr/attr_discardableResult.swift
+++ b/test/attr/attr_discardableResult.swift
@@ -185,3 +185,12 @@ func testOptionalChaining(c1: C1?, s1: S1?) {
   return closure
 }
 SR2948({}) // okay
+
+class SR7562_A {
+    @discardableResult required init(input: Int) { }
+}
+
+class SR7562_B : SR7562_A {}
+
+SR7562_A(input: 10) // okay
+SR7562_B(input: 10) // okay


### PR DESCRIPTION
Checking if the supperclass ctor has been marked
with attribute `@discardableResult`. If so, set the
attribute for the ctor as well.

Resolves [SR-7562](https://bugs.swift.org/browse/SR-7562).