### PR TITLE
[SIL] Relax isTypeMetadataAccessible() for debugger-produced modules.

### DIFF
--- a/lib/SIL/SIL.cpp
+++ b/lib/SIL/SIL.cpp
@@ -107,6 +107,11 @@ swift::getLinkageForProtocolConformance(const NormalProtocolConformance *C,
 }
 
 bool SILModule::isTypeMetadataAccessible(CanType type) {
+  // SILModules built for the debugger have special powers to access metadata
+  // for types in other files/modules.
+  if (getASTContext().LangOpts.DebuggerSupport)
+    return true;
+
   assert(type->isLegalFormalType());
 
   return !type.findIf([&](CanType type) {


### PR DESCRIPTION
SILModules built for the debugger have special powers to access
metadata for types in other files/modules. Thanks to John McCall for
suggesting the fix. This should fix a verifier failure in the lldb
testsuite. The reason why it wasn't caught during PR testing is that
this test wasn't run as part of the standard swift-pr cycle. I'm
going to submit another PR in lldb next to make sure it runs (and,
therefore, we can catch other regressions).

<rdar://problem/40336275>