### PR TITLE
[SR-7501] corrected the error message to be lowercase

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1322,7 +1322,7 @@ ERROR(attr_renamed, none,
 WARNING(attr_renamed_warning, none,
         "'@%0' has been renamed to '@%1'", (StringRef, StringRef))
 ERROR(attr_name_close_match, none,
-      "No attribute named '@%0', did you mean '@%1'?", (StringRef, StringRef))
+      "no attribute named '@%0'; did you mean '@%1'?", (StringRef, StringRef))
 
 // availability
 ERROR(attr_availability_platform,none,

--- a/test/attr/attr_inlinable_close_match.swift
+++ b/test/attr/attr_inlinable_close_match.swift
@@ -1,4 +1,4 @@
 // RUN: %target-typecheck-verify-swift
 
 @inlineable public func misspelledInlinable() {}
-// expected-error@-1 {{No attribute named '@inlineable', did you mean '@inlinable'?}}{{2-12=inlinable}}
+// expected-error@-1 {{no attribute named '@inlineable'; did you mean '@inlinable'?}}{{2-12=inlinable}}


### PR DESCRIPTION
Corrects the inlinable misspelling error message to be all lowercase.

Resolves [SR-7501](https://bugs.swift.org/browse/SR-7501).
