### PR TITLE
[master-next] Fix struct_resilience.swift test for 32-bit targets

### DIFF
--- a/test/IRGen/struct_resilience.swift
+++ b/test/IRGen/struct_resilience.swift
@@ -98,7 +98,7 @@ public func functionWithMyResilientTypesSize(_ s: __owned MySize, f: (__owned My
 // CHECK: llvm.lifetime.start
 // CHECK: [[COPY:%.*]] = bitcast %T17struct_resilience6MySizeV* %4 to i8*
 // CHECK: [[ARG:%.*]] = bitcast %T17struct_resilience6MySizeV* %1 to i8*
-// CHECK: call void @llvm.memcpy{{.*}}(i8* align 8 [[COPY]], i8* align 8 [[ARG]], i64 16, i1 false)
+// CHECK: call void @llvm.memcpy{{.*}}(i8* align {{4|8}} [[COPY]], i8* align {{4|8}} [[ARG]], {{i32 8|i64 16}}, i1 false)
 // CHECK: [[FN:%.*]] = bitcast i8* %2
 // CHECK: call swiftcc void [[FN]](%T17struct_resilience6MySizeV* {{.*}} %0, {{.*}} [[TEMP]], %swift.refcounted* swiftself %{{.*}})
 // CHECK: ret void

--- a/test/IRGen/struct_resilience.swift
+++ b/test/IRGen/struct_resilience.swift
@@ -8,9 +8,6 @@
 import resilient_struct
 import resilient_enum
 
-// rdar://39116363
-// REQUIRES: OS=macosx
-
 // CHECK: %TSi = type <{ [[INT:i32|i64]] }>
 
 // CHECK-LABEL: @"$S17struct_resilience26StructWithResilientStorageVMf" = internal global


### PR DESCRIPTION
The previous change to this test for master-next (adbc4103d5c) made it work only for 64-bit targets. This changes it back to match the IR for both 32-bit and 64-bit targets. rdar://problem/39116363