### PR TITLE
[upstream-update] Remove usage of removed method clang::VersionTuple:…

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7494,11 +7494,6 @@ void ClangImporter::Implementation::importAttributes(
       clang::VersionTuple obsoleted = avail->getObsoleted();
       clang::VersionTuple introduced = avail->getIntroduced();
 
-      // Swift only allows "." separators.
-      obsoleted.UseDotAsSeparator();
-      introduced.UseDotAsSeparator();
-      deprecated.UseDotAsSeparator();
-
       const auto &replacement = avail->getReplacement();
 
       StringRef swiftReplacement = "";


### PR DESCRIPTION
…:UseDotAsSeparator().

As of r332598, clang::VersionTuple only stores '.' as delimiters. On input any
'_' are converted to the '.' representation. So by the time it gets to swift, we
are guaranteed to have a '.' representation. So we can just drop any reference
to the flag and carry on.

rdar://36765072
