### PR TITLE
[4.2 04-30] Fix IRGen test affected by clang change

### DIFF
--- a/test/IRGen/ordering_x86.sil
+++ b/test/IRGen/ordering_x86.sil
@@ -41,4 +41,4 @@ bb0:
 // the order of features differs.
 
 // X86_64: define{{( protected)?}} swiftcc void @baz{{.*}}#0
-// X86_64: #0 = {{.*}}"target-features"="+cx16,+fxsr,+mmx,+sse,+sse2,+sse3,+ssse3,+x87"
+// X86_64: #0 = {{.*}}"target-features"="+cx16,+fxsr,+mmx,+sahf,+sse,+sse2,+sse3,+ssse3,+x87"


### PR DESCRIPTION
r325446 added the 'sahf' target feature.

rdar://40333809