### PR TITLE
[4.2] Mirror: Treat fields with type names we fail to demangle as empty.

### DIFF
--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1150,8 +1150,10 @@ void swift::swift_getFieldAt(
       }
     }
 
+    auto typeName = field.getMangledTypeName(0);
+
     auto typeInfo = _getTypeByMangledName(
-        field.getMangledTypeName(0),
+        typeName,
         [&](unsigned depth, unsigned index) -> const Metadata * {
           if (depth >= descriptorPath.size())
             return nullptr;
@@ -1174,6 +1176,16 @@ void swift::swift_getFieldAt(
 
           return base->getGenericArgs()[flatIndex];
         });
+
+    // If demangling the type failed, pretend it's an empty type instead with
+    // a log message.
+    if (typeInfo == nullptr) {
+      typeInfo = TypeInfo(&METADATA_SYM(EMPTY_TUPLE_MANGLING), {});
+      warning(0, "SWIFT RUNTIME BUG: unable to demangle type of field '%*s'. "
+                 "mangled type name is '%*s'",
+                 (int)name.size(), name.data(),
+                 (int)typeName.size(), typeName.data());
+    }
 
     callback(name, FieldType()
                        .withType(typeInfo)

--- a/stdlib/public/runtime/Private.h
+++ b/stdlib/public/runtime/Private.h
@@ -60,7 +60,7 @@ public:
 /// itself related info has to be bundled with it.
 class TypeInfo {
   const Metadata *Type;
-  const TypeReferenceOwnership ReferenceOwnership;
+  TypeReferenceOwnership ReferenceOwnership;
 
 public:
   TypeInfo() : Type(nullptr), ReferenceOwnership() {}


### PR DESCRIPTION
And log a warning message that we're doing so.
