### PR TITLE
[WIP] Build SwiftPM with the llbuild Swift bindings

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1685,6 +1685,7 @@ function cmake_config_opt() {
 function set_swiftpm_bootstrap_command() {
     SWIFTC_BIN="$(build_directory_bin ${LOCAL_HOST} swift)/swiftc"
     LLBUILD_BIN="$(build_directory_bin ${LOCAL_HOST} llbuild)/swift-build-tool"
+    LLBUILD_BUILD_DIR="$(build_directory ${host} llbuild)"
     if [[ ! "${SKIP_BUILD_FOUNDATION}" ]] ; then
         FOUNDATION_BUILD_DIR=$(build_directory ${host} foundation)
         if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
@@ -1716,7 +1717,9 @@ function set_swiftpm_bootstrap_command() {
     swiftpm_bootstrap_command+=(
         --swiftc="${SWIFTC_BIN}"
         --sbt="${LLBUILD_BIN}"
-        --build="${build_dir}")
+        --build="${build_dir}"
+        --llbuild-source-dir=${LLBUILD_SOURCE_DIR}
+        --llbuild-build-dir=${LLBUILD_BUILD_DIR})
     if [[ ! "${SKIP_BUILD_FOUNDATION}" ]] ; then
         swiftpm_bootstrap_command+=(
             --foundation="${FOUNDATION_BUILD_DIR}/Foundation")


### PR DESCRIPTION
This modifies the build script to provide SwiftPM with the build and source location of llbuild so it can statically link with the llbuild Swift bindings.

This will fail CI until https://github.com/apple/swift-package-manager/pull/1537 is merged.