### PR TITLE
[4.2-04-30-2018] TypeDecoder: Be more forgiving of extra child nodes in demangled nominal types.

### DIFF
--- a/include/swift/Demangling/TypeDecoder.h
+++ b/include/swift/Demangling/TypeDecoder.h
@@ -127,7 +127,7 @@ class TypeDecoder {
     case NodeKind::BoundGenericEnum:
     case NodeKind::BoundGenericStructure:
     case NodeKind::BoundGenericOtherNominalType: {
-      if (Node->getNumChildren() != 2)
+      if (Node->getNumChildren() < 2)
         return BuiltType();
 
       BuiltNominalTypeDecl typeDecl = BuiltNominalTypeDecl();
@@ -161,7 +161,7 @@ class TypeDecoder {
       // Handle lowered metatypes in a hackish way. If the representation
       // was not thin, force the resulting typeref to have a non-empty
       // representation.
-      if (Node->getNumChildren() == 2) {
+      if (Node->getNumChildren() >= 2) {
         auto repr = Node->getChild(i++);
         if (repr->getKind() != NodeKind::MetatypeRepresentation ||
             !repr->hasText())

--- a/test/stdlib/Inputs/RuntimeRetroactiveConformance/A.swift
+++ b/test/stdlib/Inputs/RuntimeRetroactiveConformance/A.swift
@@ -1,0 +1,1 @@
+public struct AType {}

--- a/test/stdlib/Inputs/RuntimeRetroactiveConformance/B.swift
+++ b/test/stdlib/Inputs/RuntimeRetroactiveConformance/B.swift
@@ -1,0 +1,1 @@
+public protocol BProto {}

--- a/test/stdlib/RuntimeRetroactiveConformance.swift
+++ b/test/stdlib/RuntimeRetroactiveConformance.swift
@@ -1,0 +1,24 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -c -force-single-frontend-invocation -parse-as-library -emit-module -emit-module-path %t/A.swiftmodule -o %t/A.o -module-name A %S/Inputs/RuntimeRetroactiveConformance/A.swift 
+// RUN: %target-build-swift -c -force-single-frontend-invocation -parse-as-library -emit-module -emit-module-path %t/B.swiftmodule -o %t/B.o -module-name B %S/Inputs/RuntimeRetroactiveConformance/B.swift 
+// RUN: %target-build-swift %s %t/A.o %t/B.o -I %t -o %t/a.out
+// RUN: %target-run %t/a.out
+
+// REQUIRES: executable_test
+
+import A
+import B
+
+extension AType: BProto {}
+
+struct Foo<T: BProto> {}
+
+struct Bar {
+  var foo: Foo<AType> = Foo()
+}
+
+let mirror = Mirror(reflecting: Bar())
+
+_ = mirror.children.first!
+
+print("I survived") // CHECK: I survived


### PR DESCRIPTION
Scope: Using `Mirror` on types with fields of generic type parameterized on retroactive conformances would crash because code in `getTypeByMangledName` was not updated to expect the new demangling forms.

Risk: Low, small bug fix.

Testing: Swift CI test added

Reviewed by: Doug Gregor

rdar://problem/40375014