### PR TITLE
[String] Shrink and simplify String.Index

### DIFF
--- a/stdlib/public/SDK/Foundation/ExtraStringAPIs.swift
+++ b/stdlib/public/SDK/Foundation/ExtraStringAPIs.swift
@@ -16,7 +16,7 @@ extension String.UTF16View.Index {
   @available(swift, obsoleted: 4.0)
   public init(_ offset: Int) {
     _precondition(offset >= 0, "Negative UTF16 index offset not allowed")
-    self.init(_offset: offset)
+    self.init(encodedOffset: offset)
   }
 
   @available(swift, deprecated: 3.2)

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -221,18 +221,14 @@ extension String._CharacterView : BidirectionalCollection {
   /// this view's `_baseOffset`.
   @inlinable // FIXME(sil-serialize-all)
   internal func _toBaseIndex(_ index: Index) -> Index {
-    var ret = index
-    ret._codeUnitOffset -= _baseOffset
-    return ret
+    return String.Index(from: index, adjustingEncodedOffsetBy: -_baseOffset)
   }
 
   /// Translates an index in the underlying base string into a view index using
   /// this view's `_baseOffset`.
   @inlinable // FIXME(sil-serialize-all)
   internal func _toViewIndex(_ index: Index) -> Index {
-    var ret = index
-    ret._codeUnitOffset += _baseOffset
-    return ret
+    return String.Index(from: index, adjustingEncodedOffsetBy: _baseOffset)
   }
 
   /// The position of the first character in a nonempty character view.

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -221,18 +221,18 @@ extension String._CharacterView : BidirectionalCollection {
   /// this view's `_baseOffset`.
   @inlinable // FIXME(sil-serialize-all)
   internal func _toBaseIndex(_ index: Index) -> Index {
-    return Index(
-      encodedOffset: index.encodedOffset - _baseOffset,
-      index._cache)
+    var ret = index
+    ret._codeUnitOffset -= _baseOffset
+    return ret
   }
 
   /// Translates an index in the underlying base string into a view index using
   /// this view's `_baseOffset`.
   @inlinable // FIXME(sil-serialize-all)
   internal func _toViewIndex(_ index: Index) -> Index {
-    return Index(
-      encodedOffset: index.encodedOffset + _baseOffset,
-      index._cache)
+    var ret = index
+    ret._codeUnitOffset += _baseOffset
+    return ret
   }
 
   /// The position of the first character in a nonempty character view.

--- a/stdlib/public/core/StringComparable.swift
+++ b/stdlib/public/core/StringComparable.swift
@@ -27,6 +27,14 @@ extension _StringGuts {
     if left._bitwiseEqualTo(right) {
       return true
     }
+    if left._isSmall && right._isSmall {
+      // TODO: Ensure normality when adding UTF-8 support
+      _sanityCheck(left._isASCIIOrSmallASCII && right._isASCIIOrSmallASCII,
+        "Need to ensure normality")
+
+      // Equal small strings should be bitwise equal if ASCII
+      return false
+    }
     return compare(left, to: right) == 0
   }
 
@@ -50,6 +58,10 @@ extension _StringGuts {
     if left._bitwiseEqualTo(right) {
       return false
     }
+    if left._isSmall && right._isSmall {
+      // Small strings compare lexicographically if ASCII
+      return left._smallUTF8String._compare(right._smallUTF8String) == .less
+    }
     return compare(left, to: right) == -1
   }
 
@@ -72,14 +84,14 @@ extension _StringGuts {
   ) -> Int {
     defer { _fixLifetime(left) }
     defer { _fixLifetime(right) }
-    
+
     if left.isASCII && right.isASCII {
       let leftASCII = left._unmanagedASCIIView[leftRange]
       let rightASCII = right._unmanagedASCIIView[rightRange]
       let result = leftASCII.compareASCII(to: rightASCII)
       return result
     }
-    
+
     let leftBits = left.rawBits
     let rightBits = right.rawBits
 
@@ -92,14 +104,14 @@ extension _StringGuts {
   ) -> Int {
     defer { _fixLifetime(left) }
     defer { _fixLifetime(right) }
-    
+
     if left.isASCII && right.isASCII {
       let leftASCII = left._unmanagedASCIIView
       let rightASCII = right._unmanagedASCIIView
       let result = leftASCII.compareASCII(to: rightASCII)
       return result
     }
-    
+
     let leftBits = left.rawBits
     let rightBits = right.rawBits
 

--- a/stdlib/public/core/StringComparison.swift
+++ b/stdlib/public/core/StringComparison.swift
@@ -120,25 +120,19 @@ func _compareUnicode(
 // TODO: coalesce many of these into a protocol to simplify the code
 
 extension _SmallUTF8String {
+  @inlinable
   func _compare(_ other: _SmallUTF8String) -> _Ordering {
 #if arch(i386) || arch(arm)
     _conditionallyUnreachable()
 #else
-    if _fastPath(self.isASCII && other.isASCII) {
-      // TODO: fast in-register comparison
-      return self.withUnmanagedASCII { selfView in
-        return other.withUnmanagedASCII { otherView in
-          return _Ordering(signedNotation: selfView.compareASCII(to: otherView))
-        }
-      }
+    // TODO: Ensure normality when adding UTF-8 support
+    _sanityCheck(self.isASCII && other.isASCII, "Need to ensure normality")
+    if self._storage == other._storage { return .equal }
+    for i in 0..<Swift.min(self.count, other.count) {
+      if self[i] < other[i] { return .less }
+      if self[i] > other[i] { return .greater }
     }
-
-    // TODO: fast in-register comparison
-    return self.withUnmanagedUTF16 { selfView in
-      return other.withUnmanagedUTF16 { otherView in
-        return selfView._compare(otherView)
-      }
-    }
+    return self.count < other.count ? .less : .greater
 #endif // 64-bit
   }
   func _compare(_contiguous other: _StringGuts) -> _Ordering {

--- a/stdlib/public/core/StringGraphemeBreaking.swift
+++ b/stdlib/public/core/StringGraphemeBreaking.swift
@@ -18,29 +18,10 @@ internal var _CR: UInt8 { return 0x0d }
 @inlinable // FIXME(sil-serialize-all)
 internal var _LF: UInt8 { return 0x0a }
 
-extension String.Index {
-  @inlinable // FIXME(sil-serialize-all)
-  internal init(encodedOffset: Int, characterStride stride: Int) {
-    if _slowPath(stride == 0 || stride > UInt16.max) {
-      // Don't store a 0 stride for the endIndex
-      // or a truncated stride for an overlong grapheme cluster.
-      self.init(encodedOffset: encodedOffset)
-      return
-    }
-    self.init(
-      encodedOffset: encodedOffset,
-      .character(stride: UInt16(truncatingIfNeeded: stride)))
-  }
-}
-
 extension _StringVariant {
   @inlinable
   internal func _stride(at i: String.Index) -> Int {
-    if case .character(let stride) = i._cache {
-      // TODO: should _fastPath the case somehow
-      _sanityCheck(stride > 0)
-      return Int(stride)
-    }
+    if let stride = i.characterStride { return stride }
     return characterStride(atOffset: i.encodedOffset)
   }
 

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -18,14 +18,13 @@ extension String {
     @usableFromInline
     internal var _cache: _Cache
 
-    internal typealias _UTF8Buffer = _ValidUTF8Buffer<UInt64>
+    internal typealias _UTF8Buffer = UTF8.EncodedScalar
     @_frozen // FIXME(sil-serialize-all)
     @usableFromInline
     internal enum _Cache {
-    case utf16
+    case none
     case utf8(buffer: _UTF8Buffer)
     case character(stride: UInt16)
-    case unicodeScalar(value: Unicode.Scalar)
     }
   }
 }
@@ -33,20 +32,12 @@ extension String {
 /// Convenience accessors
 extension String.Index._Cache {
   @inlinable // FIXME(sil-serialize-all)
-  internal var utf16: Void? {
-    if case .utf16 = self { return () } else { return nil }
-  }
-  @inlinable // FIXME(sil-serialize-all)
   internal var utf8: String.Index._UTF8Buffer? {
     if case .utf8(let r) = self { return r } else { return nil }
   }
   @inlinable // FIXME(sil-serialize-all)
   internal var character: UInt16? {
     if case .character(let r) = self { return r } else { return nil }
-  }
-  @inlinable // FIXME(sil-serialize-all)
-  internal var unicodeScalar: UnicodeScalar? {
-    if case .unicodeScalar(let r) = self { return r } else { return nil }
   }
 }
 
@@ -85,7 +76,7 @@ extension String.Index {
   @inlinable // FIXME(sil-serialize-all)
   public init(encodedOffset offset: Int) {
     _compoundOffset = UInt64(offset << _Self._strideBits)
-    _cache = .utf16
+    _cache = .none
   }
 
   @inlinable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/StringRangeReplaceableCollection.swift
+++ b/stdlib/public/core/StringRangeReplaceableCollection.swift
@@ -455,11 +455,8 @@ extension String {
 
   @inlinable // FIXME(sil-serialize-all)
   internal func _stride(of i: Index) -> Int {
-    if case .character(let stride) = i._cache {
-      // TODO: should _fastPath the case somehow
-      _sanityCheck(stride > 0)
-      return Int(stride)
-    }
+    if let stride = i.characterStride { return stride }
+
     let offset = i.encodedOffset
     return _visitGuts(_guts, args: offset,
       ascii: { ascii, offset in

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -322,9 +322,9 @@ extension String {
     // there is no owner and elements are dropped from the end.
     let wholeString = String(utf16._guts)
     guard
-      let start = UTF16Index(_offset: utf16._offset)
+      let start = UTF16Index(encodedOffset: utf16._offset)
         .samePosition(in: wholeString),
-      let end = UTF16Index(_offset: utf16._offset + utf16._length)
+      let end = UTF16Index(encodedOffset: utf16._offset + utf16._length)
         .samePosition(in: wholeString)
       else
     {

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -392,7 +392,7 @@ extension String.UTF16View.Index {
   public init?(
     _ sourcePosition: String.Index, within target: String.UTF16View
   ) {
-    guard sourcePosition._transcodedOffset == 0 else { return nil }
+    guard sourcePosition.transcodedOffset == 0 else { return nil }
     self.init(encodedOffset: sourcePosition.encodedOffset)
   }
 

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -187,7 +187,7 @@ extension String {
           return UTF8View._fillBuffer(from: &i)}
       )
 
-      return Index(encodedOffset: n, .utf8(buffer: buffer))
+      return Index(encodedOffset: n, transcodedOffset: 0, buffer: buffer)
     }
 
     @inline(__always)
@@ -241,12 +241,12 @@ extension String {
       var j = i
 
       // Ensure j's cache is utf8
-      if _slowPath(j._cache.utf8 == nil) {
+      if _slowPath(j.utf8Buffer == nil) {
         j = _nonASCIIIndex(atEncodedOffset: j.encodedOffset)
         precondition(j != endIndex, "Index out of bounds")
       }
 
-      let buffer = j._cache.utf8._unsafelyUnwrappedUnchecked
+      let buffer = j.utf8Buffer._unsafelyUnwrappedUnchecked
 
       var scalarLength16 = 1
       let b0 = buffer.first._unsafelyUnwrappedUnchecked
@@ -258,13 +258,13 @@ extension String {
       }
       else {
         // Number of bytes consumed in this scalar
-        let n8 = j._transcodedOffset + 1
+        let n8 = j.transcodedOffset + 1
         // If we haven't reached a scalar boundary...
         if _fastPath(n8 < leading1s) {
           // Advance to the next position in this scalar
           return Index(
             encodedOffset: j.encodedOffset,
-            transcodedOffset: n8, .utf8(buffer: buffer))
+            transcodedOffset: n8, buffer: buffer)
         }
         // We reached a scalar boundary; compute the underlying utf16's width
         // based on the number of utf8 code units
@@ -275,7 +275,8 @@ extension String {
       if _fastPath(!nextBuffer.isEmpty) {
         return Index(
           encodedOffset: j.encodedOffset + scalarLength16,
-          .utf8(buffer: nextBuffer))
+          transcodedOffset: 0,
+          buffer: nextBuffer)
       }
       // If nothing left in the buffer, refill it.
       return _nonASCIIIndex(atEncodedOffset: j.encodedOffset + scalarLength16)
@@ -296,11 +297,12 @@ extension String {
     @usableFromInline
     internal func _nonASCIIIndex(before i: Index) -> Index {
       _sanityCheck(!_guts._isASCIIOrSmallASCII)
-      if i._transcodedOffset != 0 {
-        _sanityCheck(i._cache.utf8 != nil)
-        var r = i
-        r._compoundOffset = r._compoundOffset &- 1
-        return r
+      if i.transcodedOffset != 0 {
+        _sanityCheck(i.utf8Buffer != nil)
+        return Index(
+          encodedOffset: i.encodedOffset,
+          transcodedOffset: i.transcodedOffset &- 1,
+          buffer: i.utf8Buffer._unsafelyUnwrappedUnchecked)
       }
 
       // Handle the scalar boundary the same way as the not-a-utf8-index case.
@@ -312,8 +314,7 @@ extension String {
       return Index(
         encodedOffset: i.encodedOffset &- (u8.count < 4 ? 1 : 2),
         transcodedOffset: u8.count &- 1,
-        .utf8(buffer: String.Index._UTF8Buffer(u8))
-      )
+        buffer: String.Index._UTF8Buffer(u8))
     }
 
     @inlinable // FIXME(sil-serialize-all)
@@ -338,7 +339,7 @@ extension String {
         start = j
         end = i
       }
-      let countAbs = end._transcodedOffset - start._transcodedOffset
+      let countAbs = end.transcodedOffset - start.transcodedOffset
         + _gutsNonASCIIUTF8Count(start.encodedOffset..<end.encodedOffset)
       return forwards ? countAbs : -countAbs
     }
@@ -380,10 +381,10 @@ extension String {
       _sanityCheck(!_guts._isASCIIOrSmallASCII)
       var j = position
       while true {
-        if case .utf8(let buffer) = j._cache {
+        if let buffer = j.utf8Buffer {
           _onFastPath()
           return buffer[
-            buffer.index(buffer.startIndex, offsetBy: j._transcodedOffset)]
+            buffer.index(buffer.startIndex, offsetBy: j.transcodedOffset)]
         }
         j = _nonASCIIIndex(atEncodedOffset: j.encodedOffset)
         precondition(j < endIndex, "Index out of bounds")
@@ -473,8 +474,8 @@ extension String {
   @available(swift, obsoleted: 4.0,
     message: "Please use non-failable String.init(_:UTF8View) instead")
   public init?(_ utf8: UTF8View) {
-    if utf8.startIndex._transcodedOffset != 0
-      || utf8.endIndex._transcodedOffset != 0
+    if utf8.startIndex.transcodedOffset != 0
+      || utf8.endIndex.transcodedOffset != 0
       || utf8._legacyPartialCharacters.start
       || utf8._legacyPartialCharacters.end {
       return nil
@@ -627,10 +628,9 @@ internal func _utf8Count(_ utf16CU: UInt16, prev: UInt16) -> Int {
 }
 
 extension String.UTF8View {
-  @usableFromInline
-  internal static func _count<Source: Sequence>(fromUTF16 source: Source) -> Int
-  where Source.Element == Unicode.UTF16.CodeUnit
-  {
+  internal static func _count<Source: RandomAccessCollection>(
+    fromUTF16 source: Source
+  ) -> Int where Source.Element == Unicode.UTF16.CodeUnit {
     var result = 0
     var prev: Unicode.UTF16.CodeUnit = 0
     for u in source {
@@ -702,17 +702,14 @@ extension String.UTF8View.Index {
   ///   - sourcePosition: A position in a `String` or one of its views.
   ///   - target: The `UTF8View` in which to find the new position.
   @inlinable // FIXME(sil-serialize-all)
-  public init?(_ sourcePosition: String.Index, within target: String.UTF8View) {
-    switch sourcePosition._cache {
-    case .utf8:
-      self.init(encodedOffset: sourcePosition.encodedOffset,
-        transcodedOffset:sourcePosition._transcodedOffset, sourcePosition._cache)
-
-    default:
-      guard String.UnicodeScalarView(target._guts)._isOnUnicodeScalarBoundary(
-        sourcePosition) else { return nil }
-      self.init(encodedOffset: sourcePosition.encodedOffset)
+  public init?(_ idx: String.Index, within target: String.UTF8View) {
+    guard idx.isUTF8 ||
+          String.UnicodeScalarView(target._guts)._isOnUnicodeScalarBoundary(idx)
+    else {
+      return nil
     }
+
+    self = idx
   }
 }
 
@@ -794,23 +791,23 @@ extension String.UTF8View {
         r.upperBound.encodedOffset == _guts.count) ||
       r.upperBound.samePosition(in: wholeString) == nil)
 
-    if r.upperBound._transcodedOffset == 0 {
+    if r.upperBound.transcodedOffset == 0 {
       return String.UTF8View(
         _guts._extractSlice(
         r.lowerBound.encodedOffset..<r.upperBound.encodedOffset),
-        legacyOffsets: (r.lowerBound._transcodedOffset, 0),
+        legacyOffsets: (r.lowerBound.transcodedOffset, 0),
         legacyPartialCharacters: legacyPartialCharacters)
     }
 
-    let b0 = r.upperBound._cache.utf8!.first!
+    let b0 = r.upperBound.utf8Buffer!.first!
     let scalarLength8 = (~b0).leadingZeroBitCount
     let scalarLength16 = scalarLength8 == 4 ? 2 : 1
     let coreEnd = r.upperBound.encodedOffset + scalarLength16
     return String.UTF8View(
       _guts._extractSlice(r.lowerBound.encodedOffset..<coreEnd),
       legacyOffsets: (
-        r.lowerBound._transcodedOffset,
-        r.upperBound._transcodedOffset - scalarLength8),
+        r.lowerBound.transcodedOffset,
+        r.upperBound.transcodedOffset - scalarLength8),
       legacyPartialCharacters: legacyPartialCharacters)
   }
 

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -527,7 +527,7 @@ extension String.UnicodeScalarView {
     if i == startIndex || i == endIndex {
       return true
     }
-    if i._transcodedOffset != 0 { return false }
+    if i.transcodedOffset != 0 { return false }
     let i2 = _toCoreIndex(i)
     if _fastPath(!UTF16.isTrailSurrogate(_guts[i2])) { return true }
     return i2 == 0 || !UTF16.isLeadSurrogate(_guts[i2 &- 1])

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -370,7 +370,7 @@ extension Substring : LosslessStringConvertible {
 %   View = ViewPrefix + 'View'
 %   _View = '_CharacterView' if property == 'characters' else View
 %   _property = '_characters' if property == 'characters' else property
-% 
+%
 extension Substring {
   % if View == 'CharacterView':
   @available(swift, deprecated: 3.2, message:
@@ -386,7 +386,10 @@ extension Substring {
 }
 
 extension Substring.${_View} : BidirectionalCollection {
-  public typealias Index = String.Index
+  public typealias Index = String.${View}.Index
+  public typealias Indices = String.${View}.Indices
+  public typealias Element = String.${View}.Element
+  public typealias SubSequence = Substring.${_View}
 
   /// Creates an instance that slices `base` at `_bounds`.
   @inlinable // FIXME(sil-serialize-all)
@@ -407,22 +410,66 @@ extension Substring.${_View} : BidirectionalCollection {
     return startIndex.encodedOffset..<endIndex.encodedOffset
   }
 
+  //
+  // Plumb slice operations through
+  //
   @inlinable // FIXME(sil-serialize-all)
   public var startIndex: Index { return _slice.startIndex }
+
   @inlinable // FIXME(sil-serialize-all)
   public var endIndex: Index { return _slice.endIndex }
+
   @inlinable // FIXME(sil-serialize-all)
-  public func index(after i: Index) -> Index {
-    return _slice.index(after: i)
-  }
+  public subscript(index: Index) -> Element { return _slice[index] }
+
   @inlinable // FIXME(sil-serialize-all)
-  public func index(before i: Index) -> Index {
-    return _slice.index(before: i)
-  }
+  public var indices: Indices { return _slice.indices }
+
   @inlinable // FIXME(sil-serialize-all)
-  public subscript(i: Index) -> String.${View}.Element {
-    return _slice[i]
+  public func index(after i: Index) -> Index { return _slice.index(after: i) }
+
+  @inlinable // FIXME(sil-serialize-all)
+  public func formIndex(after i: inout Index) {
+    _slice.formIndex(after: &i)
   }
+
+  @inlinable // FIXME(sil-serialize-all)
+  public func index(_ i: Index, offsetBy n: Int) -> Index {
+    return _slice.index(i, offsetBy: n)
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  public func index(
+    _ i: Index, offsetBy n: Int, limitedBy limit: Index
+  ) -> Index? {
+    return _slice.index(i, offsetBy: n, limitedBy: limit)
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  public func distance(from start: Index, to end: Index) -> Int {
+    return _slice.distance(from: start, to: end)
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  public func _failEarlyRangeCheck(_ index: Index, bounds: Range<Index>) {
+    _slice._failEarlyRangeCheck(index, bounds: bounds)
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  public func _failEarlyRangeCheck(
+    _ range: Range<Index>, bounds: Range<Index>
+  ) {
+    _slice._failEarlyRangeCheck(range, bounds: bounds)
+  }
+
+  @inlinable // FIXME(sil-serialize-all)
+  public func index(before i: Index) -> Index { return _slice.index(before: i) }
+
+  @inlinable // FIXME(sil-serialize-all)
+  public func formIndex(before i: inout Index) {
+    _slice.formIndex(before: &i)
+  }
+
   @inlinable // FIXME(sil-serialize-all)
   % if property == 'characters':
   @available(swift, deprecated: 3.2, message:
@@ -528,7 +575,7 @@ extension Substring : RangeReplaceableCollection {
       self.init(String(elements))
     }
   }
-  
+
   @inlinable // FIXME(sil-serialize-all)
   public mutating func append<S : Sequence>(contentsOf elements: S)
   where S.Element == Character {
@@ -549,7 +596,7 @@ extension Substring {
   public func uppercased() -> String {
     return String(self).uppercased()
   }
-  
+
   @inlinable // FIXME(sil-serialize-all)
   public func filter(
     _ isIncluded: (Element) throws -> Bool

--- a/test/stdlib/StringIndex.swift
+++ b/test/stdlib/StringIndex.swift
@@ -5,43 +5,82 @@ import StdlibUnittest
 
 var StringIndexTests = TestSuite("StringIndexTests")
 
-let simpleStrings = [
-    "abcdefg", // Small ASCII
-    "abéÏ", // Small Unicode
-    "012345678901234567890", // Large ASCII
-    "abéÏ012345678901234567890", // Large Unicode
-]
-
-func validateViewCount<View: BidirectionalCollection>(
-  _ view: View, for string: String,
-  stackTrace: SourceLocStack = SourceLocStack(),
-  showFrame: Bool = true,
-  file: String = #file, line: UInt = #line) {
-
-  var stackTrace = stackTrace.pushIf(showFrame, file: file, line: line)
-
-  let count = view.count
-  func expect(_ i: Int,
-    file: String = #file, line: UInt = #line
-  ) {
-    expectEqual(count, i, "for String: \(string)",
-      stackTrace: stackTrace.pushIf(showFrame, file: file, line: line),
-      showFrame: false)
-  }
-
-
-  let reversedView = view.reversed()
-
-  expect(Array(view).count)
-  expect(view.indices.count)
-  expect(view.indices.reversed().count)
-  expect(reversedView.indices.count)
-  expect(view.distance(from: view.startIndex, to: view.endIndex))
-  expect(reversedView.distance(
-    from: reversedView.startIndex, to: reversedView.endIndex))
+enum SimpleString: String {
+  case smallASCII = "abcdefg"
+  case smallUnicode = "abéÏ𓀀"
+  case largeASCII = "012345678901234567890"
+  case largeUnicode = "abéÏ012345678901234567890𓀀"
+  case emoji = "😀😃🤢🤮👩🏿‍🎤🧛🏻‍♂️🧛🏻‍♂️👩‍👩‍👦‍👦"
 }
 
-StringIndexTests.test("views") {
+let simpleStrings: [String] = [
+    SimpleString.smallASCII.rawValue,
+    SimpleString.smallUnicode.rawValue,
+    SimpleString.largeASCII.rawValue,
+    SimpleString.largeUnicode.rawValue,
+    SimpleString.emoji.rawValue,
+]
+
+StringIndexTests.test("basic sanity checks") {
+  for s in simpleStrings {
+    let utf8 = Array(s.utf8)
+    let subUTF8 = Array(s[...].utf8)
+    let utf16 = Array(s.utf16)
+    let subUTF16 = Array(s[...].utf16)
+    let utf32 = Array(s.unicodeScalars.map { $0.value })
+    let subUTF32 = Array(s[...].unicodeScalars.map { $0.value })
+
+    expectEqual(s, String(decoding: utf8, as: UTF8.self))
+    expectEqual(s, String(decoding: subUTF8, as: UTF8.self))
+    expectEqual(s, String(decoding: utf16, as: UTF16.self))
+    expectEqual(s, String(decoding: subUTF16, as: UTF16.self))
+    expectEqual(s, String(decoding: utf32, as: UTF32.self))
+    expectEqual(s, String(decoding: subUTF32, as: UTF32.self))
+  }
+}
+
+StringIndexTests.test("view counts") {
+  func validateViewCount<View: BidirectionalCollection>(
+    _ view: View, for string: String,
+    stackTrace: SourceLocStack = SourceLocStack(),
+    showFrame: Bool = true,
+    file: String = #file, line: UInt = #line
+  ) where View.Element: Equatable, View.Index == String.Index {
+
+    var stackTrace = stackTrace.pushIf(showFrame, file: file, line: line)
+
+    let count = view.count
+    func expect(_ i: Int,
+      file: String = #file, line: UInt = #line
+    ) {
+      expectEqual(count, i, "for String: \(string)",
+        stackTrace: stackTrace.pushIf(showFrame, file: file, line: line),
+        showFrame: false)
+    }
+
+    let reversedView = view.reversed()
+
+    expect(Array(view).count)
+    expect(view.indices.count)
+    expect(view.indices.reversed().count)
+    expect(reversedView.indices.count)
+    expect(view.distance(from: view.startIndex, to: view.endIndex))
+    expect(reversedView.distance(
+      from: reversedView.startIndex, to: reversedView.endIndex))
+
+    // Access the elements from the indices
+    expectEqual(Array(view), view.indices.map { view[$0] })
+    expectEqual(
+      Array(reversedView), reversedView.indices.map { reversedView[$0] })
+
+    let indicesArray = Array<String.Index>(view.indices)
+    for i in 0..<indicesArray.count {
+      var idx = view.startIndex
+      idx = view.index(idx, offsetBy: i)
+      expectEqual(indicesArray[i], idx)
+    }
+  }
+
   for s in simpleStrings {
     validateViewCount(s, for: s)
     validateViewCount(s.utf8, for: s)
@@ -52,6 +91,43 @@ StringIndexTests.test("views") {
     validateViewCount(s[...].utf8, for: s)
     validateViewCount(s[...].utf16, for: s)
     validateViewCount(s[...].unicodeScalars, for: s)
+  }
+}
+
+StringIndexTests.test("interchange") {
+  // Basic index alignment
+
+  func validateIndices(_ s: String) {
+    let utf8Indices = s.utf8.indices
+    let utf16Indices = s.utf16.indices
+    let unicodeScalarIndices = s.unicodeScalars.indices
+    let characterIndices = s.indices
+
+    for idx in utf8Indices {
+      let char = s.utf8[idx]
+
+      // ASCII or leading code unit in the scalar
+      if char <= 0x7F || char >= 0b1100_0000 {
+        expectEqual(idx, idx.samePosition(in: s.unicodeScalars))
+        expectEqual(idx, idx.samePosition(in: s.utf16))
+
+        // ASCII
+        if char <= 0x7F {
+          expectEqual(UInt16(char), s.utf16[idx])
+          expectEqual(UInt32(char), s.unicodeScalars[idx].value)
+        }
+      } else {
+        // Continuation code unit
+        assert(char & 0b1100_0000 == 0b1000_0000)
+        expectNil(idx.samePosition(in: s))
+        expectNil(idx.samePosition(in: s.utf16))
+        expectNil(idx.samePosition(in: s.unicodeScalars))
+      }
+    }
+  }
+
+  for s in simpleStrings {
+    validateIndices(s)
   }
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->

Shrink String.Index to 2 words (and thus Substring goes from 8 to 6 words). At the same time, sink transcoded offsets into the `.utf8` variant, in preparation for a more resilient Index.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->