### PR TITLE
[sourcekit test] Split -sanitizer= test out and add REQUIRES

### DIFF
--- a/test/SourceKit/Misc/ignored-flags-sanitizers.swift
+++ b/test/SourceKit/Misc/ignored-flags-sanitizers.swift
@@ -1,0 +1,9 @@
+var s = 10
+s.
+
+// CHECK: littleEndian
+
+// REQUIRES: asan_runtime
+// REQUIRES: fuzzer_runtime
+
+// RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -sanitize=address,fuzzer -sanitize-coverage=func %s | %FileCheck %s

--- a/test/SourceKit/Misc/ignored-flags.swift
+++ b/test/SourceKit/Misc/ignored-flags.swift
@@ -15,7 +15,6 @@ s.
 // RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -use-ld=blah %s | %FileCheck %s
 // RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -incremental %s | %FileCheck %s
 // RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -driver-time-compilation %s | %FileCheck %s
-// RUN: %sourcekitd-test -req=complete -pos=2:3 %s -- -sanitize=address,fuzzer -sanitize-coverage=func %s | %FileCheck %s
 
 
 // Mode flags


### PR DESCRIPTION
This test requires the sanitizer runtime libraries, so split it out and
add the requisite REQUIRES lines.