### PR TITLE
[WIP] Delay rendering error strings in the runtime

### DIFF
--- a/include/swift/Basic/Compiler.h
+++ b/include/swift/Basic/Compiler.h
@@ -49,4 +49,23 @@
 #define SWIFT_CONSTRUCTOR
 #endif
 
+#if __has_attribute(format)
+#define SWIFT_ATTRIBUTE_PRINTF_LIKE(index, firstToCheck) \
+  __attribute__((format(printf, index, firstToCheck)))
+#else
+#define SWIFT_ATTRIBUTE_PRINTF_LIKE(index, firstToCheck)
+#endif
+
+#if __has_attribute(optnone)
+
+/// Prevent the optimizer from doing any inlining or IPO on a function body.
+#define SWIFT_ATTRIBUTE_OPTNONE __attribute__((optnone))
+
+#else
+
+/// Prevent the optimizer from doing any inlining or IPO on a function body.
+#define SWIFT_ATTRIBUTE_OPTNONE
+
+#endif
+
 #endif // SWIFT_BASIC_COMPILER_H

--- a/include/swift/Runtime/Debug.h
+++ b/include/swift/Runtime/Debug.h
@@ -22,6 +22,7 @@
 #include <cstdio>
 #include <stdint.h>
 #include "swift/Runtime/Config.h"
+#include "swift/Basic/Compiler.h"
 #include "swift/Runtime/Unreachable.h"
 
 #ifdef SWIFT_HAVE_CRASHREPORTERCLIENT
@@ -55,6 +56,8 @@ static inline const char *CRGetCrashLogMessage() {
   return reinterpret_cast<const char *>(gCRAnnotations.message);
 }
 
+
+
 #else
 
 LLVM_ATTRIBUTE_ALWAYS_INLINE
@@ -85,10 +88,12 @@ static inline void crash(const char *message) {
 // swift::fatalError() halts with a crash log message, 
 // but makes no attempt to preserve register state.
 LLVM_ATTRIBUTE_NORETURN
+SWIFT_ATTRIBUTE_PRINTF_LIKE(2, 3)
 extern void
 fatalError(uint32_t flags, const char *format, ...);
 
 /// swift::warning() emits a warning from the runtime.
+SWIFT_ATTRIBUTE_PRINTF_LIKE(2, 3)
 extern void
 warning(uint32_t flags, const char *format, ...);
 
@@ -109,7 +114,8 @@ swift_dynamicCastFailure(const void *sourceType, const char *sourceName,
                          const char *message = nullptr);
 
 SWIFT_RUNTIME_EXPORT
-void swift_reportError(uint32_t flags, const char *message);
+SWIFT_ATTRIBUTE_PRINTF_LIKE(2, 3)
+void swift_reportError(uint32_t flags, const char *message, ...);
 
 // Halt due to an overflow in swift_retain().
 LLVM_ATTRIBUTE_NORETURN LLVM_ATTRIBUTE_NOINLINE
@@ -210,9 +216,10 @@ enum: uintptr_t {
 
 /// Debugger hook. Calling this stops the debugger with a message and details
 /// about the issues. Called by overlays.
-SWIFT_RUNTIME_STDLIB_SPI
-void _swift_reportToDebugger(uintptr_t flags, const char *message,
-                             RuntimeErrorDetails *details = nullptr);
+SWIFT_RUNTIME_STDLIB_SPI SWIFT_ATTRIBUTE_PRINTF_LIKE(3, 4)
+void _swift_reportToDebugger(uintptr_t flags,
+                             RuntimeErrorDetails *details,
+                             const char *message, ...);
 
 SWIFT_RUNTIME_STDLIB_SPI
 bool _swift_reportFatalErrorsToDebugger;

--- a/stdlib/public/SDK/Foundation/CheckClass.mm
+++ b/stdlib/public/SDK/Foundation/CheckClass.mm
@@ -208,8 +208,8 @@ static StringRefLite findBaseName(StringRefLite demangledName) {
       errorInfo.notes = notes;
       errorInfo.numNotes = arrayLength(notes);
 
-      _swift_reportToDebugger(RuntimeErrorFlagNone, [primaryMessage UTF8String],
-                              &errorInfo);
+      _swift_reportToDebugger(RuntimeErrorFlagNone,
+                              &errorInfo, "%s",  [primaryMessage UTF8String]);
 
       [primaryMessage release];
       [generatedNote release];
@@ -226,6 +226,9 @@ static StringRefLite findBaseName(StringRefLite demangledName) {
     NSString *demangledString = demangledName.newNSStringNoCopy();
     NSString *mangledString = NSStringFromClass(objcClass);
 
+    // TODO: Instead of pre-formatting the messages here, we should do the
+    // formatting inside NSLog/_swift_reportToDebugger so that the static
+    // strings in the message get preserved in production crash reports.
     NSString *primaryMessage;
     switch (operation) {
     case 1:
@@ -278,8 +281,8 @@ static StringRefLite findBaseName(StringRefLite demangledName) {
     errorInfo.notes = notes;
     errorInfo.numNotes = arrayLength(notes);
 
-    _swift_reportToDebugger(RuntimeErrorFlagNone, [primaryMessage UTF8String],
-                            &errorInfo);
+    _swift_reportToDebugger(RuntimeErrorFlagNone,
+                            &errorInfo, "%s",  [primaryMessage UTF8String]);
 
     [primaryMessage release];
     [firstNote release];

--- a/stdlib/public/SDK/os/thunks.mm
+++ b/stdlib/public/SDK/os/thunks.mm
@@ -16,5 +16,5 @@
 extern "C" void
 _swift_os_log_reportError(uint32_t flags, const char *message)
 {
-	swift::swift_reportError(flags, message);
+	swift::swift_reportError(flags, "%s", message);
 }

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -39,6 +39,7 @@
 #include "swift/Runtime/Debug.h"
 #include "swift/Runtime/Mutex.h"
 #include "swift/Demangling/Demangle.h"
+#include "swift/Basic/Compiler.h"
 #include "swift/Basic/LLVM.h"
 #include "llvm/ADT/StringRef.h"
 
@@ -199,9 +200,18 @@ void swift::printCurrentBacktrace(unsigned framesToSkip) {
   fprintf(stderr, "<backtrace unavailable>\n");
 #endif
 }
-
 #ifdef SWIFT_HAVE_CRASHREPORTERCLIENT
 #include <malloc/malloc.h>
+
+__API_AVAILABLE(macos(10.12), ios(10.0), tvos(10.0), watchos(3.0))
+bool _dyld_is_memory_immutable(const void *addr, size_t len);
+
+static bool isStringImmutable(const char *c) {
+  if (__builtin_available(macOS 10.12, iOS 10.0, tvOS 10.0, watchOS 3.0, *))
+    return _dyld_is_memory_immutable(c, strlen(c)+1);
+  else
+    return false;
+}
 
 // Instead of linking to CrashReporterClient.a (because it complicates the
 // build system), define the only symbol from that static archive ourselves.
@@ -217,8 +227,16 @@ __attribute__((__section__("__DATA," CRASHREPORTER_ANNOTATIONS_SECTION))) = {
 
 // Report a message to any forthcoming crash log.
 static void
-reportOnCrash(uint32_t flags, const char *message)
+reportOnCrash(uint32_t flags, const char *message, va_list args)
 {
+  // Render the message if it contains format sequences.
+  bool isFormatted = strchr(message, '%');
+  char *renderedMessage;
+  if (isFormatted)
+    asprintf(&renderedMessage, message, args);
+  else
+    renderedMessage = const_cast<char*>(message);
+
   // We must use an "unsafe" mutex in this pathway since the normal "safe"
   // mutex calls fatalError when an error is detected and fatalError ends up
   // calling us. In other words we could get infinite recursion if the
@@ -227,13 +245,20 @@ reportOnCrash(uint32_t flags, const char *message)
 
   crashlogLock.lock();
 
-  char *oldMessage = (char *)CRGetCrashLogMessage();
+  char *oldMessage = const_cast<char *>(CRGetCrashLogMessage());
   char *newMessage;
   if (oldMessage) {
-    asprintf(&newMessage, "%s%s", oldMessage, message);
-    if (malloc_size(oldMessage)) free(oldMessage);
+    asprintf(&newMessage, "%s%s", oldMessage, renderedMessage);
+    if (isFormatted)
+      free(renderedMessage);
+    if (malloc_size(oldMessage))
+      free(oldMessage);
+  // Avoid duplicating the string if it's immutable, since static strings from
+  // a binary won't be redacted in production crash logs.
+  } else if (isFormatted || isStringImmutable(renderedMessage)) {
+    newMessage = renderedMessage;
   } else {
-    newMessage = strdup(message);
+    newMessage = strdup(renderedMessage);
   }
   
   CRSetCrashLogMessage(newMessage);
@@ -244,7 +269,7 @@ reportOnCrash(uint32_t flags, const char *message)
 #else
 
 static void
-reportOnCrash(uint32_t flags, const char *message)
+reportOnCrash(uint32_t flags, const char *message, va_list args)
 {
   // empty
 }
@@ -253,18 +278,18 @@ reportOnCrash(uint32_t flags, const char *message)
 
 // Report a message to system console and stderr.
 static void
-reportNow(uint32_t flags, const char *message)
+reportNow(uint32_t flags, const char *message, va_list args)
 {
 #if defined(_WIN32)
 #define STDERR_FILENO 2
   _write(STDERR_FILENO, message, strlen(message));
 #else
-  write(STDERR_FILENO, message, strlen(message));
+  vdprintf(STDERR_FILENO, message, args);
 #endif
 #if defined(__APPLE__)
-  asl_log(nullptr, nullptr, ASL_LEVEL_ERR, "%s", message);
+  asl_vlog(nullptr, nullptr, ASL_LEVEL_ERR, message, args);
 #elif defined(__ANDROID__)
-  __android_log_print(ANDROID_LOG_FATAL, "SwiftRuntime", "%s", message);
+  __android_log_vprint(ANDROID_LOG_FATAL, "SwiftRuntime", message, args);
 #endif
 #if SWIFT_SUPPORTS_BACKTRACE_REPORTING
   if (flags & FatalErrorFlags::ReportBacktrace) {
@@ -274,39 +299,20 @@ reportNow(uint32_t flags, const char *message)
 #endif
 }
 
-LLVM_ATTRIBUTE_NOINLINE SWIFT_RUNTIME_EXPORT
+SWIFT_ATTRIBUTE_OPTNONE LLVM_ATTRIBUTE_NOINLINE SWIFT_RUNTIME_EXPORT
 void _swift_runtime_on_report(uintptr_t flags, const char *message,
                               RuntimeErrorDetails *details) {
   // Do nothing. This function is meant to be used by the debugger.
 
-  // The following is necessary to avoid calls from being optimized out.
+  // The following is necessary to avoid calls to this function or
+  // the formation of its arguments from being optimized out in
+  // compilers that don't understand or don't correctly honor the
+  // optnone attribute.
   asm volatile("" // Do nothing.
                : // Output list, empty.
                : "r" (flags), "r" (message), "r" (details) // Input list.
                : // Clobber list, empty.
                );
-}
-
-void swift::_swift_reportToDebugger(uintptr_t flags, const char *message,
-                                    RuntimeErrorDetails *details) {
-  _swift_runtime_on_report(flags, message, details);
-}
-
-bool swift::_swift_reportFatalErrorsToDebugger = true;
-
-bool swift::_swift_shouldReportFatalErrorsToDebugger() {
-  return _swift_reportFatalErrorsToDebugger;
-}
-
-/// Report a fatal error to system console, stderr, and crash logs.
-/// Does not crash by itself.
-void swift::swift_reportError(uint32_t flags,
-                              const char *message) {
-#if defined(__APPLE__) && NDEBUG
-  flags &= ~FatalErrorFlags::ReportBacktrace;
-#endif
-  reportNow(flags, message);
-  reportOnCrash(flags, message);
 }
 
 static int swift_vasprintf(char **strp, const char *fmt, va_list ap) {
@@ -329,6 +335,51 @@ static int swift_vasprintf(char **strp, const char *fmt, va_list ap) {
 #endif
 }
 
+void swift::_swift_reportToDebugger(uintptr_t flags,
+                                    RuntimeErrorDetails *details,
+                                    const char *message,
+                                    ...) {
+  // Render the string so that the debugger can collect the message with a
+  // breakpoint on _swift_runtime_on_report.
+  //
+  // In an alternate universe, _swift_runtime_on_report would also take an
+  // unrendered format string and va_list, so we don't need to prerender a
+  // string that's going to go unused when a debugger is not attached…
+  va_list args;
+  va_start(args, message);
+  
+  char *formatted;
+  swift_vasprintf(&formatted, message, args);
+  
+  _swift_runtime_on_report(flags, formatted, details);
+  
+  free(formatted);
+}
+
+bool swift::_swift_reportFatalErrorsToDebugger = true;
+
+bool swift::_swift_shouldReportFatalErrorsToDebugger() {
+  return _swift_reportFatalErrorsToDebugger;
+}
+
+static void reportErrorV(uint32_t flags, const char *message, va_list args) {
+#if defined(__APPLE__) && NDEBUG
+  flags &= ~FatalErrorFlags::ReportBacktrace;
+#endif
+
+  reportNow(flags, message, args);
+  reportOnCrash(flags, message, args);
+}
+
+/// Report a fatal error to system console, stderr, and crash logs.
+/// Does not crash by itself.
+void swift::swift_reportError(uint32_t flags,
+                              const char *message, ...) {
+  va_list args;
+  va_start(args, message);
+  reportErrorV(flags, message, args);
+}
+
 // Report a fatal error to system console, stderr, and crash logs, then abort.
 LLVM_ATTRIBUTE_NORETURN
 void
@@ -337,13 +388,7 @@ swift::fatalError(uint32_t flags, const char *format, ...)
   va_list args;
   va_start(args, format);
 
-  char *log;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuninitialized"
-  swift_vasprintf(&log, format, args);
-#pragma GCC diagnostic pop
-
-  swift_reportError(flags, log);
+  reportErrorV(flags, format, args);
   abort();
 }
 
@@ -354,15 +399,7 @@ swift::warning(uint32_t flags, const char *format, ...)
   va_list args;
   va_start(args, format);
 
-  char *log;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuninitialized"
-  swift_vasprintf(&log, format, args);
-#pragma GCC diagnostic pop
-
-  reportNow(flags, log);
-
-  free(log);
+  reportNow(flags, format, args);
 }
 
 // Crash when a deleted method is called by accident.

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3743,6 +3743,8 @@ static void diagnoseMetadataDependencyCycle(const Metadata *start,
                                             ArrayRef<MetadataDependency> links){
   assert(start == links.back().Value);
 
+  // TODO: Find some way to log this with format strings so that some part of
+  // the message can be preserved in redacted crash logs.
   std::string diagnostic =
     "runtime error: unresolvable type metadata dependency cycle detected\n  ";
   diagnostic += nameForMetadata(start);
@@ -3789,11 +3791,11 @@ static void diagnoseMetadataDependencyCycle(const Metadata *start,
     };
 #pragma GCC diagnostic pop
 
-    _swift_reportToDebugger(RuntimeErrorFlagFatal, diagnostic.c_str(),
-                            &details);
+    _swift_reportToDebugger(RuntimeErrorFlagFatal,
+                            &details, "%s", diagnostic.c_str());
   }
 
-  fatalError(0, diagnostic.c_str());
+  fatalError(0, "%s", diagnostic.c_str());
 }
 
 /// Check whether the given metadata dependency is satisfied, and if not,

--- a/stdlib/public/stubs/Assert.cpp
+++ b/stdlib/public/stubs/Assert.cpp
@@ -28,15 +28,14 @@ static void logPrefixAndMessageToDebugger(
   if (!_swift_shouldReportFatalErrorsToDebugger())
     return;
 
-  char *debuggerMessage;
   if (messageLength) {
-    swift_asprintf(&debuggerMessage, "%.*s: %.*s", prefixLength, prefix,
-        messageLength, message);
+    _swift_reportToDebugger(RuntimeErrorFlagFatal, nullptr,
+                            "%.*s: %.*s", prefixLength, prefix,
+                            messageLength, message);
   } else {
-    swift_asprintf(&debuggerMessage, "%.*s", prefixLength, prefix);
+    _swift_reportToDebugger(RuntimeErrorFlagFatal, nullptr,
+                            "%.*s", prefixLength, prefix);
   }
-  _swift_reportToDebugger(RuntimeErrorFlagFatal, debuggerMessage);
-  free(debuggerMessage);
 }
 
 void swift::_swift_stdlib_reportFatalErrorInFile(
@@ -48,17 +47,12 @@ void swift::_swift_stdlib_reportFatalErrorInFile(
 ) {
   logPrefixAndMessageToDebugger(prefix, prefixLength, message, messageLength);
 
-  char *log;
-  swift_asprintf(
-      &log, "%.*s: %.*s%sfile %.*s, line %" PRIu32 "\n",
-      prefixLength, prefix,
-      messageLength, message,
-      (messageLength ? ": " : ""),
-      fileLength, file,
-      line);
-
-  swift_reportError(flags, log);
-  free(log);
+  swift_reportError(flags, "%.*s: %.*s%sfile %.*s, line %" PRIu32 "\n",
+                    prefixLength, prefix,
+                    messageLength, message,
+                    (messageLength ? ": " : ""),
+                    fileLength, file,
+                    line);
 }
 
 void swift::_swift_stdlib_reportFatalError(
@@ -68,14 +62,9 @@ void swift::_swift_stdlib_reportFatalError(
 ) {
   logPrefixAndMessageToDebugger(prefix, prefixLength, message, messageLength);
 
-  char *log;
-  swift_asprintf(
-      &log, "%.*s: %.*s\n",
-      prefixLength, prefix,
-      messageLength, message);
-
-  swift_reportError(flags, log);
-  free(log);
+  swift_reportError(flags, "%.*s: %.*s\n",
+                    prefixLength, prefix,
+                    messageLength, message);
 }
 
 void swift::_swift_stdlib_reportUnimplementedInitializerInFile(
@@ -85,18 +74,13 @@ void swift::_swift_stdlib_reportUnimplementedInitializerInFile(
     uint32_t line, uint32_t column,
     uint32_t flags
 ) {
-  char *log;
-  swift_asprintf(
-      &log,
-      "%.*s: %" PRIu32 ": %" PRIu32 ": Fatal error: Use of unimplemented "
-      "initializer '%.*s' for class '%.*s'\n",
-      fileLength, file,
-      line, column,
-      initNameLength, initName,
-      classNameLength, className);
-
-  swift_reportError(flags, log);
-  free(log);
+  swift_reportError(flags,
+            "%.*s: %" PRIu32 ": %" PRIu32 ": Fatal error: Use of unimplemented "
+            "initializer '%.*s' for class '%.*s'\n",
+            fileLength, file,
+            line, column,
+            initNameLength, initName,
+            classNameLength, className);
 }
 
 void swift::_swift_stdlib_reportUnimplementedInitializer(
@@ -104,15 +88,10 @@ void swift::_swift_stdlib_reportUnimplementedInitializer(
     const unsigned char *initName, int initNameLength,
     uint32_t flags
 ) {
-  char *log;
-  swift_asprintf(
-      &log,
-      "Fatal error: Use of unimplemented "
-      "initializer '%.*s' for class '%.*s'\n",
-      initNameLength, initName,
-      classNameLength, className);
-
-  swift_reportError(flags, log);
-  free(log);
+  swift_reportError(flags,
+                    "Fatal error: Use of unimplemented "
+                    "initializer '%.*s' for class '%.*s'\n",
+                    initNameLength, initName,
+                    classNameLength, className);
 }
 


### PR DESCRIPTION
This avoids allocating temporary strings with `asprintf` just to call low-level APIs that accept format strings, and should produce better-quality logging on Apple platforms, where production crash logs get dynamic strings redacted for user privacy reasons.