### PR TITLE
[benchmarks] Move StringComparison Workload initialization out of the…

### DIFF
--- a/benchmark/single-source/StringComparison.swift
+++ b/benchmark/single-source/StringComparison.swift
@@ -34,167 +34,275 @@ public let StringComparison = [
   BenchmarkInfo(
     name: "StringComparison_ascii",
     runFunction: run_StringComparison_ascii,
-    tags: [.validation, .api, .String]),    
+    tags: [.validation, .api, .String],
+    setUpFunction: setup_StringComparison_ascii),
   BenchmarkInfo(
     name: "StringComparison_latin1",
     runFunction: run_StringComparison_latin1,
-    tags: [.validation, .api, .String]),    
+    tags: [.validation, .api, .String],
+    setUpFunction: setup_StringComparison_latin1),
   BenchmarkInfo(
     name: "StringComparison_fastPrenormal",
     runFunction: run_StringComparison_fastPrenormal,
-    tags: [.validation, .api, .String]),    
+    tags: [.validation, .api, .String],
+    setUpFunction: setup_StringComparison_fastPrenormal),
   BenchmarkInfo(
     name: "StringComparison_slowerPrenormal",
     runFunction: run_StringComparison_slowerPrenormal,
-    tags: [.validation, .api, .String]),    
+    tags: [.validation, .api, .String],
+    setUpFunction: setup_StringComparison_slowerPrenormal),
   BenchmarkInfo(
     name: "StringComparison_nonBMPSlowestPrenormal",
     runFunction: run_StringComparison_nonBMPSlowestPrenormal,
-    tags: [.validation, .api, .String]),    
+    tags: [.validation, .api, .String],
+    setUpFunction: setup_StringComparison_nonBMPSlowestPrenormal),
   BenchmarkInfo(
     name: "StringComparison_emoji",
     runFunction: run_StringComparison_emoji,
-    tags: [.validation, .api, .String]),    
+    tags: [.validation, .api, .String],
+    setUpFunction: setup_StringComparison_emoji),
   BenchmarkInfo(
     name: "StringComparison_abnormal",
     runFunction: run_StringComparison_abnormal,
-    tags: [.validation, .api, .String]),    
+    tags: [.validation, .api, .String],
+    setUpFunction: setup_StringComparison_abnormal),
   BenchmarkInfo(
     name: "StringComparison_zalgo",
     runFunction: run_StringComparison_zalgo,
-    tags: [.validation, .api, .String]),    
+    tags: [.validation, .api, .String],
+    setUpFunction: setup_StringComparison_zalgo),
   BenchmarkInfo(
     name: "StringComparison_longSharedPrefix",
     runFunction: run_StringComparison_longSharedPrefix,
-    tags: [.validation, .api, .String]),    
+    tags: [.validation, .api, .String],
+    setUpFunction: setup_StringComparison_longSharedPrefix),
 ]
-    
-  @inline(never)
-  public func run_StringComparison_ascii(_ N: Int) {
-    let workload = Workload.ascii
-    let tripCount = workload.tripCount
-    let payload = workload.payload
-    for _ in 1...tripCount*N {
-      for s1 in payload {
-        for s2 in payload {
-          blackHole(s1 < s2)
-        }
+
+
+var Workload_ascii: Workload? = nil
+
+@inline(never)
+public func setup_StringComparison_ascii() {
+  if Workload_ascii != nil {
+    return
+  }
+  Workload_ascii = Workload.ascii
+}
+
+@inline(never)
+public func run_StringComparison_ascii(_ N: Int) {
+  let workload = Workload_ascii._unsafelyUnwrappedUnchecked
+  let tripCount = workload.tripCount
+  let payload = workload.payload
+  for _ in 1...tripCount*N {
+    for s1 in payload {
+      for s2 in payload {
+        blackHole(s1 < s2)
       }
     }
   }
-    
-  @inline(never)
-  public func run_StringComparison_latin1(_ N: Int) {
-    let workload = Workload.latin1
-    let tripCount = workload.tripCount
-    let payload = workload.payload
-    for _ in 1...tripCount*N {
-      for s1 in payload {
-        for s2 in payload {
-          blackHole(s1 < s2)
-        }
+}
+
+
+var Workload_latin1: Workload? = nil
+
+@inline(never)
+public func setup_StringComparison_latin1() {
+  if Workload_latin1 != nil {
+    return
+  }
+  Workload_latin1 = Workload.latin1
+}
+
+@inline(never)
+public func run_StringComparison_latin1(_ N: Int) {
+  let workload = Workload_latin1._unsafelyUnwrappedUnchecked
+  let tripCount = workload.tripCount
+  let payload = workload.payload
+  for _ in 1...tripCount*N {
+    for s1 in payload {
+      for s2 in payload {
+        blackHole(s1 < s2)
       }
     }
   }
-    
-  @inline(never)
-  public func run_StringComparison_fastPrenormal(_ N: Int) {
-    let workload = Workload.fastPrenormal
-    let tripCount = workload.tripCount
-    let payload = workload.payload
-    for _ in 1...tripCount*N {
-      for s1 in payload {
-        for s2 in payload {
-          blackHole(s1 < s2)
-        }
+}
+
+
+var Workload_fastPrenormal: Workload? = nil
+
+@inline(never)
+public func setup_StringComparison_fastPrenormal() {
+  if Workload_fastPrenormal != nil {
+    return
+  }
+  Workload_fastPrenormal = Workload.fastPrenormal
+}
+
+@inline(never)
+public func run_StringComparison_fastPrenormal(_ N: Int) {
+  let workload = Workload_fastPrenormal._unsafelyUnwrappedUnchecked
+  let tripCount = workload.tripCount
+  let payload = workload.payload
+  for _ in 1...tripCount*N {
+    for s1 in payload {
+      for s2 in payload {
+        blackHole(s1 < s2)
       }
     }
   }
-    
-  @inline(never)
-  public func run_StringComparison_slowerPrenormal(_ N: Int) {
-    let workload = Workload.slowerPrenormal
-    let tripCount = workload.tripCount
-    let payload = workload.payload
-    for _ in 1...tripCount*N {
-      for s1 in payload {
-        for s2 in payload {
-          blackHole(s1 < s2)
-        }
+}
+
+
+var Workload_slowerPrenormal: Workload? = nil
+
+@inline(never)
+public func setup_StringComparison_slowerPrenormal() {
+  if Workload_slowerPrenormal != nil {
+    return
+  }
+  Workload_slowerPrenormal = Workload.slowerPrenormal
+}
+
+@inline(never)
+public func run_StringComparison_slowerPrenormal(_ N: Int) {
+  let workload = Workload_slowerPrenormal._unsafelyUnwrappedUnchecked
+  let tripCount = workload.tripCount
+  let payload = workload.payload
+  for _ in 1...tripCount*N {
+    for s1 in payload {
+      for s2 in payload {
+        blackHole(s1 < s2)
       }
     }
   }
-    
-  @inline(never)
-  public func run_StringComparison_nonBMPSlowestPrenormal(_ N: Int) {
-    let workload = Workload.nonBMPSlowestPrenormal
-    let tripCount = workload.tripCount
-    let payload = workload.payload
-    for _ in 1...tripCount*N {
-      for s1 in payload {
-        for s2 in payload {
-          blackHole(s1 < s2)
-        }
+}
+
+
+var Workload_nonBMPSlowestPrenormal: Workload? = nil
+
+@inline(never)
+public func setup_StringComparison_nonBMPSlowestPrenormal() {
+  if Workload_nonBMPSlowestPrenormal != nil {
+    return
+  }
+  Workload_nonBMPSlowestPrenormal = Workload.nonBMPSlowestPrenormal
+}
+
+@inline(never)
+public func run_StringComparison_nonBMPSlowestPrenormal(_ N: Int) {
+  let workload = Workload_nonBMPSlowestPrenormal._unsafelyUnwrappedUnchecked
+  let tripCount = workload.tripCount
+  let payload = workload.payload
+  for _ in 1...tripCount*N {
+    for s1 in payload {
+      for s2 in payload {
+        blackHole(s1 < s2)
       }
     }
   }
-    
-  @inline(never)
-  public func run_StringComparison_emoji(_ N: Int) {
-    let workload = Workload.emoji
-    let tripCount = workload.tripCount
-    let payload = workload.payload
-    for _ in 1...tripCount*N {
-      for s1 in payload {
-        for s2 in payload {
-          blackHole(s1 < s2)
-        }
+}
+
+
+var Workload_emoji: Workload? = nil
+
+@inline(never)
+public func setup_StringComparison_emoji() {
+  if Workload_emoji != nil {
+    return
+  }
+  Workload_emoji = Workload.emoji
+}
+
+@inline(never)
+public func run_StringComparison_emoji(_ N: Int) {
+  let workload = Workload_emoji._unsafelyUnwrappedUnchecked
+  let tripCount = workload.tripCount
+  let payload = workload.payload
+  for _ in 1...tripCount*N {
+    for s1 in payload {
+      for s2 in payload {
+        blackHole(s1 < s2)
       }
     }
   }
-    
-  @inline(never)
-  public func run_StringComparison_abnormal(_ N: Int) {
-    let workload = Workload.abnormal
-    let tripCount = workload.tripCount
-    let payload = workload.payload
-    for _ in 1...tripCount*N {
-      for s1 in payload {
-        for s2 in payload {
-          blackHole(s1 < s2)
-        }
+}
+
+
+var Workload_abnormal: Workload? = nil
+
+@inline(never)
+public func setup_StringComparison_abnormal() {
+  if Workload_abnormal != nil {
+    return
+  }
+  Workload_abnormal = Workload.abnormal
+}
+
+@inline(never)
+public func run_StringComparison_abnormal(_ N: Int) {
+  let workload = Workload_abnormal._unsafelyUnwrappedUnchecked
+  let tripCount = workload.tripCount
+  let payload = workload.payload
+  for _ in 1...tripCount*N {
+    for s1 in payload {
+      for s2 in payload {
+        blackHole(s1 < s2)
       }
     }
   }
-    
-  @inline(never)
-  public func run_StringComparison_zalgo(_ N: Int) {
-    let workload = Workload.zalgo
-    let tripCount = workload.tripCount
-    let payload = workload.payload
-    for _ in 1...tripCount*N {
-      for s1 in payload {
-        for s2 in payload {
-          blackHole(s1 < s2)
-        }
+}
+
+
+var Workload_zalgo: Workload? = nil
+
+@inline(never)
+public func setup_StringComparison_zalgo() {
+  if Workload_zalgo != nil {
+    return
+  }
+  Workload_zalgo = Workload.zalgo
+}
+
+@inline(never)
+public func run_StringComparison_zalgo(_ N: Int) {
+  let workload = Workload_zalgo._unsafelyUnwrappedUnchecked
+  let tripCount = workload.tripCount
+  let payload = workload.payload
+  for _ in 1...tripCount*N {
+    for s1 in payload {
+      for s2 in payload {
+        blackHole(s1 < s2)
       }
     }
   }
-    
-  @inline(never)
-  public func run_StringComparison_longSharedPrefix(_ N: Int) {
-    let workload = Workload.longSharedPrefix
-    let tripCount = workload.tripCount
-    let payload = workload.payload
-    for _ in 1...tripCount*N {
-      for s1 in payload {
-        for s2 in payload {
-          blackHole(s1 < s2)
-        }
+}
+
+
+var Workload_longSharedPrefix: Workload? = nil
+
+@inline(never)
+public func setup_StringComparison_longSharedPrefix() {
+  if Workload_longSharedPrefix != nil {
+    return
+  }
+  Workload_longSharedPrefix = Workload.longSharedPrefix
+}
+
+@inline(never)
+public func run_StringComparison_longSharedPrefix(_ N: Int) {
+  let workload = Workload_longSharedPrefix._unsafelyUnwrappedUnchecked
+  let tripCount = workload.tripCount
+  let payload = workload.payload
+  for _ in 1...tripCount*N {
+    for s1 in payload {
+      for s2 in payload {
+        blackHole(s1 < s2)
       }
     }
   }
-    
+}
+
 
 struct Workload {
   static let N = 100

--- a/benchmark/single-source/StringComparison.swift.gyb
+++ b/benchmark/single-source/StringComparison.swift.gyb
@@ -37,25 +37,37 @@ public let StringComparison = [
   BenchmarkInfo(
     name: "StringComparison_${Name}",
     runFunction: run_StringComparison_${Name},
-    tags: [.validation, .api, .String]),    
+    tags: [.validation, .api, .String],
+    setUpFunction: setup_StringComparison_${Name}),
 % end # Names
 ]
-    
+
 % for Name in Names:
-  @inline(never)
-  public func run_StringComparison_${Name}(_ N: Int) {
-    let workload = Workload.${Name}
-    let tripCount = workload.tripCount
-    let payload = workload.payload
-    for _ in 1...tripCount*N {
-      for s1 in payload {
-        for s2 in payload {
-          blackHole(s1 < s2)
-        }
+
+var Workload_${Name}: Workload? = nil
+
+@inline(never)
+public func setup_StringComparison_${Name}() {
+  if Workload_${Name} != nil {
+    return
+  }
+  Workload_${Name} = Workload.${Name}
+}
+
+@inline(never)
+public func run_StringComparison_${Name}(_ N: Int) {
+  let workload = Workload_${Name}._unsafelyUnwrappedUnchecked
+  let tripCount = workload.tripCount
+  let payload = workload.payload
+  for _ in 1...tripCount*N {
+    for s1 in payload {
+      for s2 in payload {
+        blackHole(s1 < s2)
       }
     }
   }
-    
+}
+
 % end # Names
 
 struct Workload {


### PR DESCRIPTION
… timing loop.

I want to create some larger/more expensive workloads for this. So move all
StringComparison initialization out of the loop just to be standard.

rdar://40371840
