### PR TITLE
[libSyntax] Fix SwiftSyntax CodeBlockItemList test

### DIFF
--- a/test/SwiftSyntax/Inputs/nested-blocks.swift
+++ b/test/SwiftSyntax/Inputs/nested-blocks.swift
@@ -1,4 +1,4 @@
-struct {
+struct Foo {
   func foo() {
     print("hello")
     func bar() {

--- a/test/SwiftSyntax/VisitorTest.swift
+++ b/test/SwiftSyntax/VisitorTest.swift
@@ -83,6 +83,7 @@ VisitorTests.test("SyntaxRewriter.visitCollection") {
 
     override func visit(_ items: CodeBlockItemListSyntax) {
       numberOfCodeBlockItems += items.count
+      super.visit(items)
     }
   }
 
@@ -92,7 +93,7 @@ VisitorTests.test("SyntaxRewriter.visitCollection") {
     )
     let visitor = VisitCollections()
     visitor.visit(parsed)
-    expectEqual(3, visitor.numberOfCodeBlockItems)
+    expectEqual(4, visitor.numberOfCodeBlockItems)
   })
 }
 


### PR DESCRIPTION
The test had multiple issues that happened to cancel each other out:
- The declared struct had no name
- The visitor did not call super for `CodeBlockItemLists`
- The total number of CodeBlockItems in `nested-blocks.swift` is 4 (`struct Foo`, `print("hello")`, `func bar`, and `print("goodbye")`