### PR TITLE
build: add Bcrypt.h to Windows SDK overlay

### DIFF
--- a/utils/WindowsSDKVFSOverlay.yaml.in
+++ b/utils/WindowsSDKVFSOverlay.yaml.in
@@ -5,6 +5,9 @@ roots:
   - name: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/shared"
     type: directory
     contents:
+      - name: Bcrypt.h
+        type: file
+        external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/shared/bcrypt.h"
       - name: DriverSpecs.h
         type: file
         external-contents: "@UniversalCRTSdkDir@/Include/@UCRTVersion@/shared/driverspecs.h"


### PR DESCRIPTION
This is used in the stdlib shims, but has a case mismatch.  Add an entry
for the spelling as provided on MSDN and the case that is used in the
WinSDK distribution.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
