### PR TITLE
[4.2] stdlib: make Sequence -> String inlinable

### DIFF
--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -451,10 +451,7 @@ extension _SmallUTF8String {
 
   // NOTE: This exists to facilitate _fromCodeUnits, which is awful for this use
   // case. Please don't call this from anywhere else.
-  @usableFromInline
-  @inline(never) // @outlined
-  // @_specialize(where Encoding == UTF16)
-  // @_specialize(where Encoding == UTF8)
+  @inlinable
   init?<S: Sequence, Encoding: Unicode.Encoding>(
     _fromCodeUnits codeUnits: S,
     utf16Length: Int,


### PR DESCRIPTION
As this function is generic, it makes a big difference when it can be specialized for concrete sequences, like arrays or unsafe buffers.
This fixes a performance regression of String(decoding:as:), e.g. when constructing a String from a byte buffer.
