### PR TITLE
[Runtime] Redo the ErrorObject/dlsym interface to use a struct containing all the bridging points.

### DIFF
--- a/stdlib/public/SDK/Foundation/CMakeLists.txt
+++ b/stdlib/public/SDK/Foundation/CMakeLists.txt
@@ -26,6 +26,7 @@ add_swift_library(swiftFoundation ${SWIFT_SDK_OVERLAY_LIBRARY_BUILD_TYPES} IS_SD
   NSCoder.swift
   NSDate.swift
   NSDictionary.swift
+  NSError.mm
   NSError.swift
   NSExpression.swift
   NSFastEnumeration.swift

--- a/stdlib/public/SDK/Foundation/NSError.h
+++ b/stdlib/public/SDK/Foundation/NSError.h
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_FOUNDATION_NSERROR_H
+#define SWIFT_FOUNDATION_NSERROR_H
+
+#include "swift/Runtime/Metadata.h"
+#include "../../runtime/SwiftHashableSupport.h"
+#include <Foundation/Foundation.h>
+
+namespace swift {
+
+/// The name of the symbol that ErrorObject.mm will look up using dlsym. It uses
+/// this to locate various items related to Error bridging to NS/CFError.
+#define ERROR_BRIDGING_SYMBOL_NAME swift_errorBridgingInfo
+#define ERROR_BRIDGING_SYMBOL_NAME_STRING "swift_errorBridgingInfo"
+
+/// The items that ErrorObject.mm needs for bridging. The
+/// ERROR_BRIDGING_SYMBOL_NAME symbol will contain an instance of this struct.
+struct ErrorBridgingInfo {
+  const SWIFT_CC(swift) WitnessTable *(*GetCFErrorErrorConformance)();
+  
+  const SWIFT_CC(swift) hashable_support::HashableWitnessTable *
+    (*GetNSObjectHashableConformance)();
+  
+  SWIFT_CC(swift) NSDictionary *(*GetErrorDefaultUserInfo)(const OpaqueValue *error,
+                                                           const Metadata *T,
+                                                           const WitnessTable *Error);
+  
+  SWIFT_CC(swift) bool (*BridgeErrorToNSError)(NSError *, OpaqueValue*, const Metadata *,
+                                               const WitnessTable *);
+  
+  const ProtocolDescriptor *ObjectiveCBridgeableError;
+};
+
+}
+
+#endif // SWIFT_FOUNDATION_NSERROR_H

--- a/stdlib/public/SDK/Foundation/NSError.mm
+++ b/stdlib/public/SDK/Foundation/NSError.mm
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "NSError.h"
+
+#include "swift/Demangling/ManglingMacros.h"
+
+using namespace swift;
+
+// Declare the mangled Swift symbols that we'll be putting in the bridging info.
+extern "C" const SWIFT_CC(swift) WitnessTable *
+  MANGLE_SYM(So10CFErrorRefas5Error10FoundationWa)();
+
+extern "C" const SWIFT_CC(swift) hashable_support::HashableWitnessTable *
+  MANGLE_SYM(So8NSObjectCs8Hashable10ObjectiveCWa)();
+
+extern "C" SWIFT_CC(swift)
+  NSDictionary *MANGLE_SYM(10Foundation24_getErrorDefaultUserInfoyyXlSgxs0C0RzlF)(
+    const OpaqueValue *error, const Metadata *T, const WitnessTable *Error);
+
+extern "C" SWIFT_CC(swift) bool
+  MANGLE_SYM(10Foundation21_bridgeNSErrorToError_3outSbSo0C0C_SpyxGtAA021_ObjectiveCBridgeableE0RzlF)(
+    NSError *, OpaqueValue*, const Metadata *, const WitnessTable *);
+
+extern "C" const ProtocolDescriptor
+  MANGLE_SYM(10Foundation26_ObjectiveCBridgeableErrorMp);
+
+// Define the bridging info struct.
+extern "C" ErrorBridgingInfo ERROR_BRIDGING_SYMBOL_NAME = {
+  MANGLE_SYM(So10CFErrorRefas5Error10FoundationWa),
+  MANGLE_SYM(So8NSObjectCs8Hashable10ObjectiveCWa),
+  MANGLE_SYM(10Foundation24_getErrorDefaultUserInfoyyXlSgxs0C0RzlF),
+  MANGLE_SYM(10Foundation21_bridgeNSErrorToError_3outSbSo0C0C_SpyxGtAA021_ObjectiveCBridgeableE0RzlF),
+  &MANGLE_SYM(10Foundation26_ObjectiveCBridgeableErrorMp)
+};
+
+// This directive ensures that the symbol is preserved even when statically
+// linked into an executable and stripped, so that the dlsym lookup from
+// ErrorObject.mm still works.
+asm(".desc _" ERROR_BRIDGING_SYMBOL_NAME_STRING ", 0x10");

--- a/stdlib/public/runtime/ErrorObject.mm
+++ b/stdlib/public/runtime/ErrorObject.mm
@@ -37,6 +37,7 @@
 #include <objc/message.h>
 #include <objc/objc.h>
 #include <Foundation/Foundation.h>
+#include "../SDK/Foundation/NSError.h"
 
 using namespace swift;
 using namespace swift::hashable_support;
@@ -220,31 +221,40 @@ swift::swift_deallocError(SwiftError *error, const Metadata *type) {
   object_dispose((id)error);
 }
 
+/// Get the error bridging info from the Foundation overlay. If it can't
+/// be loaded, return all NULLs.
+static ErrorBridgingInfo getErrorBridgingInfo() {
+  auto *info = SWIFT_LAZY_CONSTANT(
+    reinterpret_cast<ErrorBridgingInfo *>(
+      dlsym(RTLD_DEFAULT, ERROR_BRIDGING_SYMBOL_NAME_STRING)));
+  if (!info) {
+    ErrorBridgingInfo nulls = {};
+    return nulls;
+  }
+  return *info;
+}
+
 static const WitnessTable *getNSErrorConformanceToError() {
   // CFError and NSError are toll-free-bridged, so we can use either type's
   // witness table interchangeably. CFError's is potentially slightly more
   // efficient since it doesn't need to dispatch for an unsubclassed NSCFError.
-  // The witness table lives in the Foundation overlay, but it should be safe
-  // to assume that that's been linked in if a user is using NSError in their
-  // Swift source.
+  // The error bridging info lives in the Foundation overlay, but it should be
+  // safe to assume that that's been linked in if a user is using NSError in
+  // their Swift source.
 
-  auto TheWitnessTable = SWIFT_LAZY_CONSTANT(dlsym(RTLD_DEFAULT,
-      MANGLE_AS_STRING(MANGLE_SYM(So10CFErrorRefas5Error10FoundationWa))));
-  assert(TheWitnessTable &&
+  auto getter = getErrorBridgingInfo().GetCFErrorErrorConformance;
+  assert(getter &&
          "Foundation overlay not loaded, or 'CFError : Error' conformance "
          "not available");
-
-  return reinterpret_cast<const SWIFT_CC(swift) WitnessTable *(*)()>(TheWitnessTable)();
+  return getter();
 }
 
 static const HashableWitnessTable *getNSErrorConformanceToHashable() {
-  auto TheWitnessTable = SWIFT_LAZY_CONSTANT(dlsym(RTLD_DEFAULT,
-           MANGLE_AS_STRING(MANGLE_SYM(So8NSObjectCs8Hashable10ObjectiveCWa))));
-  assert(TheWitnessTable &&
+  auto getter = getErrorBridgingInfo().GetNSObjectHashableConformance;
+  assert(getter &&
          "ObjectiveC overlay not loaded, or 'NSObject : Hashable' conformance "
          "not available");
-
-  return reinterpret_cast<const SWIFT_CC(swift) HashableWitnessTable *(*)()>(TheWitnessTable)();
+  return getter();
 }
 
 bool SwiftError::isPureNSError() const {
@@ -371,16 +381,9 @@ SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_INTERNAL
 NSDictionary *_swift_stdlib_getErrorDefaultUserInfo(OpaqueValue *error,
                                                     const Metadata *T,
                                                     const WitnessTable *Error) {
-  typedef SWIFT_CC(swift)
-    NSDictionary *GetDefaultFn(const OpaqueValue *error,
-                               const Metadata *T,
-                               const WitnessTable *Error);
-
   // public func Foundation._getErrorDefaultUserInfo<T: Error>(_ error: T)
   //   -> AnyObject?
-  auto foundationGetDefaultUserInfo = SWIFT_LAZY_CONSTANT(
-    reinterpret_cast<GetDefaultFn*> (dlsym(RTLD_DEFAULT,
-    MANGLE_AS_STRING(MANGLE_SYM(10Foundation24_getErrorDefaultUserInfoyyXlSgxs0C0RzlF)))));
+  auto foundationGetDefaultUserInfo = getErrorBridgingInfo().GetErrorDefaultUserInfo;
   if (!foundationGetDefaultUserInfo) {
     SWIFT_CC_PLUSONE_GUARD(T->vw_destroy(error));
     return nullptr;
@@ -505,16 +508,9 @@ swift::tryDynamicCastNSErrorToValue(OpaqueValue *dest,
   // public func Foundation._bridgeNSErrorToError<
   //   T : _ObjectiveCBridgeableError
   // >(error: NSError, out: UnsafeMutablePointer<T>) -> Bool {
-  typedef SWIFT_CC(swift)
-    bool BridgeFn(NSError *, OpaqueValue*, const Metadata *,
-                  const WitnessTable *);
-  auto bridgeNSErrorToError = SWIFT_LAZY_CONSTANT(
-    reinterpret_cast<BridgeFn*>(dlsym(RTLD_DEFAULT,
-    MANGLE_AS_STRING(MANGLE_SYM(10Foundation21_bridgeNSErrorToError_3outSbSo0C0C_SpyxGtAA021_ObjectiveCBridgeableE0RzlF)))));
+  auto bridgeNSErrorToError = getErrorBridgingInfo().BridgeErrorToNSError;
   // protocol _ObjectiveCBridgeableError
-  auto TheObjectiveCBridgeableError = SWIFT_LAZY_CONSTANT(
-    reinterpret_cast<const ProtocolDescriptor *>(dlsym(RTLD_DEFAULT,
-    MANGLE_AS_STRING(MANGLE_SYM(10Foundation26_ObjectiveCBridgeableErrorMp)))));
+  auto TheObjectiveCBridgeableError = getErrorBridgingInfo().ObjectiveCBridgeableError;
 
   // If the Foundation overlay isn't loaded, then arbitrary NSErrors can't be
   // bridged.

--- a/test/stdlib/ErrorBridgedStatic.swift
+++ b/test/stdlib/ErrorBridgedStatic.swift
@@ -14,6 +14,10 @@ class Bar: Foo {
   override func foo(_ x: Int32) throws {
     try super.foo(5)
   }
+  
+  override func foothrows(_ x: Int32) throws {
+    try super.foothrows(5)
+  }
 }
 
 var ErrorBridgingStaticTests = TestSuite("ErrorBridging with static libs")
@@ -22,6 +26,16 @@ ErrorBridgingStaticTests.test("round-trip Swift override of ObjC method") {
   do {
     try (Bar() as Foo).foo(5)
   } catch { }
+}
+
+ErrorBridgingStaticTests.test("round-trip Swift override of throwing ObjC method") {
+  do {
+    try (Bar() as Foo).foothrows(5)
+  } catch {
+    print(error)
+    expectEqual(error._domain, "abcd")
+    expectEqual(error._code, 1234)
+  }
 }
 
 runAllTests()

--- a/test/stdlib/Inputs/ErrorBridgedStaticImpl.h
+++ b/test/stdlib/Inputs/ErrorBridgedStaticImpl.h
@@ -3,5 +3,6 @@
 @interface Foo: NSObject
 
 - (BOOL)foo:(int)x error:(NSError**)error;
+- (BOOL)foothrows:(int)x error:(NSError**)error;
 
 @end

--- a/test/stdlib/Inputs/ErrorBridgedStaticImpl.m
+++ b/test/stdlib/Inputs/ErrorBridgedStaticImpl.m
@@ -7,5 +7,10 @@
   return NO;
 }
 
+- (BOOL)foothrows:(int)x error:(NSError**)error {
+  *error = [NSError errorWithDomain: @"abcd" code: 1234 userInfo: nil];
+  return NO;
+}
+
 @end
 


### PR DESCRIPTION
This allows for better static typing and reduces the amount of dynamic symbol lookups.

rdar://problem/39810532