### PR TITLE
NFC: Some small refactoring in `buildCompilation`

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -700,7 +700,9 @@ computeWorkingDirectory(const llvm::opt::InputArgList *ArgList) {
     SmallString<128> workingDirectory;
     workingDirectory = A->getValue();
     llvm::sys::fs::make_absolute(workingDirectory);
-    return workingDirectory.str();
+    //  Create a new string that can outlive ArgList.
+    std::string result = workingDirectory.str().str();
+    return result;
   }
   return std::string();
 }

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -674,17 +674,14 @@ getDriverBatchCount(llvm::opt::InputArgList &ArgList,
 
 static bool computeIncremental(const llvm::opt::InputArgList *ArgList,
                                const bool ShowIncrementalBuildDecisions) {
-  {
-    const bool WasIncrementalRequested =
-    ArgList->hasArg(options::OPT_incremental);
-    if (!WasIncrementalRequested)
-      return false;
-  }
+  if (!ArgList->hasArg(options::OPT_incremental))
+    return false;
+
   const char *ReasonToDisable =
       ArgList->hasArg(options::OPT_whole_module_optimization)
           ? "is not compatible with whole module optimization."
           : ArgList->hasArg(options::OPT_embed_bitcode)
-                ? "is not currently compatible with embedding LLVM IR bitcode"
+                ? "is not currently compatible with embedding LLVM IR bitcode."
                 : nullptr;
 
   if (!ReasonToDisable)
@@ -709,9 +706,9 @@ computeWorkingDirectory(const llvm::opt::InputArgList *ArgList) {
 }
 
 static std::unique_ptr<UnifiedStatsReporter>
-computeStatsReporter(const llvm::opt::InputArgList *ArgList,
-                     const InputFileList &Inputs, const OutputInfo OI,
-                     StringRef DefaultTargetTriple) {
+createStatsReporter(const llvm::opt::InputArgList *ArgList,
+                    const InputFileList &Inputs, const OutputInfo OI,
+                    StringRef DefaultTargetTriple) {
   const Arg *A = ArgList->getLastArgNoClaim(options::OPT_stats_output_dir);
   if (!A)
     return nullptr;
@@ -886,7 +883,7 @@ Driver::buildCompilation(const ToolChain &TC,
     const bool ShowDriverTimeCompilation =
         ArgList->hasArg(options::OPT_driver_time_compilation);
     std::unique_ptr<UnifiedStatsReporter> StatsReporter =
-        computeStatsReporter(ArgList.get(), Inputs, OI, DefaultTargetTriple);
+        createStatsReporter(ArgList.get(), Inputs, OI, DefaultTargetTriple);
     
     C = llvm::make_unique<Compilation>(
         Diags, TC, OI, Level,

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -700,7 +700,7 @@ computeWorkingDirectory(const llvm::opt::InputArgList *ArgList) {
     SmallString<128> workingDirectory;
     workingDirectory = A->getValue();
     llvm::sys::fs::make_absolute(workingDirectory);
-    //  Create a new string that can outlive ArgList.
+    //  Create a new string that can outlive workingDirectory.
     std::string result = workingDirectory.str().str();
     return result;
   }

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -700,7 +700,6 @@ computeWorkingDirectory(const llvm::opt::InputArgList *ArgList) {
     SmallString<128> workingDirectory;
     workingDirectory = A->getValue();
     llvm::sys::fs::make_absolute(workingDirectory);
-    //  Create a new string that can outlive workingDirectory.
     std::string result = workingDirectory.str().str();
     return result;
   }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Minor refactoring of `buildCompilation` to try to get the function to be fewer lines, and also moving definitions closer to uses.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
