### PR TITLE
[Parse] Parse label in tuple type as tok::identifier

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -466,6 +466,16 @@ public:
     return consumeToken();
   }
 
+  SourceLoc consumeArgumentLabel(Identifier &Result) {
+    assert(Tok.canBeArgumentLabel());
+    assert(Result.empty());
+    if (!Tok.is(tok::kw__)) {
+      Tok.setKind(tok::identifier);
+      Result = Context.getIdentifier(Tok.getText());
+    }
+    return consumeToken();
+  }
+
   /// \brief Retrieve the location just past the end of the previous
   /// source location.
   SourceLoc getEndOfPreviousLoc();

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -2023,12 +2023,7 @@ void Parser::parseOptionalArgumentLabel(Identifier &name, SourceLoc &loc) {
           .fixItRemoveChars(end.getAdvancedLoc(-1), end);
     }
 
-    auto unescapedUnderscore = underscore && !escaped;
-    if (!unescapedUnderscore)
-      name = Context.getIdentifier(text);
-    if (!underscore)
-      Tok.setKind(tok::identifier);
-    loc = consumeToken();
+    loc = consumeArgumentLabel(name);
     consumeToken(tok::colon);
   }
 }

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -240,23 +240,11 @@ Parser::parseParameterClause(SourceLoc &leftParenLoc,
 
     if (startsParameterName(*this, isClosure)) {
       // identifier-or-none for the first name
-      if (Tok.is(tok::kw__)) {
-        param.FirstNameLoc = consumeToken();
-      } else {
-        assert(Tok.canBeArgumentLabel() && "startsParameterName() lied");
-        Tok.setKind(tok::identifier);
-        param.FirstName = Context.getIdentifier(Tok.getText());
-        param.FirstNameLoc = consumeToken();
-      }
+      param.FirstNameLoc = consumeArgumentLabel(param.FirstName);
 
       // identifier-or-none? for the second name
-      if (Tok.canBeArgumentLabel()) {
-        if (!Tok.is(tok::kw__)) {
-          param.SecondName = Context.getIdentifier(Tok.getText());
-          Tok.setKind(tok::identifier);
-        }
-        param.SecondNameLoc = consumeToken();
-      }
+      if (Tok.canBeArgumentLabel())
+        param.SecondNameLoc = consumeArgumentLabel(param.SecondName);
 
       // Operators, closures, and enum elements cannot have API names.
       if ((paramContext == ParameterContextKind::Operator ||

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -878,16 +878,11 @@ ParserResult<TupleTypeRepr> Parser::parseTypeTupleBody() {
         Backtracking->cancelBacktrack();
 
       // Consume a name.
-      if (!Tok.is(tok::kw__))
-        element.Name = Context.getIdentifier(Tok.getText());
-      element.NameLoc = consumeToken();
+      element.NameLoc = consumeArgumentLabel(element.Name);
 
       // If there is a second name, consume it as well.
-      if (Tok.canBeArgumentLabel()) {
-        if (!Tok.is(tok::kw__))
-          element.SecondName = Context.getIdentifier(Tok.getText());
-        element.SecondNameLoc = consumeToken();
-      }
+      if (Tok.canBeArgumentLabel())
+        element.SecondNameLoc = consumeArgumentLabel(element.SecondName);
 
       // Consume the ':'.
       if (!consumeIf(tok::colon, element.ColonLoc))

--- a/test/SourceKit/SyntaxMapData/Inputs/syntaxmap.swift
+++ b/test/SourceKit/SyntaxMapData/Inputs/syntaxmap.swift
@@ -49,3 +49,8 @@ func bar() {}
 // unknownprotocol://awesomeguy.com
 
 _ = -123
+
+func testArgumentLabels(in class: Int, _ case: (_ default: Int) -> Void) -> (in: Int, String) {
+  let result: (in: Int, String) = (0, "test")
+  return something ? result : (in: 2, "foo")
+}

--- a/test/SourceKit/SyntaxMapData/syntaxmap.swift.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap.swift.response
@@ -474,7 +474,7 @@
       key.length: 1
     },
     {
-      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.kind: source.lang.swift.syntaxtype.identifier,
       key.offset: 910,
       key.length: 7
     },
@@ -489,7 +489,7 @@
       key.length: 4
     },
     {
-      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.kind: source.lang.swift.syntaxtype.identifier,
       key.offset: 937,
       key.length: 2
     },
@@ -514,7 +514,7 @@
       key.length: 6
     },
     {
-      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.kind: source.lang.swift.syntaxtype.identifier,
       key.offset: 971,
       key.length: 2
     },

--- a/test/SourceKit/SyntaxMapData/syntaxmap.swift.response
+++ b/test/SourceKit/SyntaxMapData/syntaxmap.swift.response
@@ -1,6 +1,6 @@
 {
   key.offset: 0,
-  key.length: 859,
+  key.length: 1049,
   key.diagnostic_stage: source.diagnostic.stage.swift.parse,
   key.syntaxmap: [
     {
@@ -432,6 +432,141 @@
       key.kind: source.lang.swift.syntaxtype.number,
       key.offset: 854,
       key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 860,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 865,
+      key.length: 18
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 884,
+      key.length: 2
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 887,
+      key.length: 5
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 894,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 899,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 901,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 908,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 910,
+      key.length: 7
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 919,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 927,
+      key.length: 4
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 937,
+      key.length: 2
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 941,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 946,
+      key.length: 6
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 958,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 962,
+      key.length: 6
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 971,
+      key.length: 2
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 975,
+      key.length: 3
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.typeidentifier,
+      key.offset: 980,
+      key.length: 6
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.number,
+      key.offset: 991,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.string,
+      key.offset: 994,
+      key.length: 6
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.keyword,
+      key.offset: 1004,
+      key.length: 6
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 1011,
+      key.length: 9
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 1023,
+      key.length: 6
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.identifier,
+      key.offset: 1033,
+      key.length: 2
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.number,
+      key.offset: 1037,
+      key.length: 1
+    },
+    {
+      key.kind: source.lang.swift.syntaxtype.string,
+      key.offset: 1040,
+      key.length: 5
     }
   ]
 }


### PR DESCRIPTION
Make an utility method `Parser::consumeArgumentLabel`, and use it for:
* Labels in tuple type
* Labels in tuple expression
* Argument and parameter names in parameter clause

Fixes: [SR-7731](https://bugs.swift.org/browse/SR-7731)