### PR TITLE
[libSyntax] Add support for parsing #sourceLocation directives

### DIFF
--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -538,4 +538,10 @@ struct S <TypeInheritanceClause>: <InheritedType><SimpleTypeIdentifier>Q</Simple
   fileprivate(set) </DeclModifier>var <PatternBinding><IdentifierPattern>x</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>String</SimpleTypeIdentifier></TypeAnnotation></PatternBinding></VariableDecl></MemberDeclListItem>
 }</MemberDeclBlock></StructDecl><StructDecl><Attribute>
 
-@_alignment(16) </Attribute><DeclModifier>public </DeclModifier>struct float3 <MemberDeclBlock>{ <MemberDeclListItem><VariableDecl><DeclModifier>public </DeclModifier>var <PatternBinding><IdentifierPattern>x</IdentifierPattern>, </PatternBinding><PatternBinding><IdentifierPattern>y</IdentifierPattern>, </PatternBinding><PatternBinding><IdentifierPattern>z</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Float </SimpleTypeIdentifier></TypeAnnotation></PatternBinding></VariableDecl></MemberDeclListItem>}</MemberDeclBlock></StructDecl>
+@_alignment(16) </Attribute><DeclModifier>public </DeclModifier>struct float3 <MemberDeclBlock>{ <MemberDeclListItem><VariableDecl><DeclModifier>public </DeclModifier>var <PatternBinding><IdentifierPattern>x</IdentifierPattern>, </PatternBinding><PatternBinding><IdentifierPattern>y</IdentifierPattern>, </PatternBinding><PatternBinding><IdentifierPattern>z</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Float </SimpleTypeIdentifier></TypeAnnotation></PatternBinding></VariableDecl></MemberDeclListItem>}</MemberDeclBlock></StructDecl><PoundSourceLocation>
+
+#sourceLocation(<PoundSourceLocationArgs>file: "otherFile.swift", line: 5</PoundSourceLocationArgs>)</PoundSourceLocation><FunctionDecl>
+
+func foo<FunctionSignature><ParameterClause>() </ParameterClause></FunctionSignature><CodeBlock>{}</CodeBlock></FunctionDecl><PoundSourceLocation>
+
+#sourceLocation()</PoundSourceLocation>

--- a/test/Syntax/round_trip_parse_gen.swift
+++ b/test/Syntax/round_trip_parse_gen.swift
@@ -539,3 +539,9 @@ struct S : Q, Equatable {
 }
 
 @_alignment(16) public struct float3 { public var x, y, z: Float }
+
+#sourceLocation(file: "otherFile.swift", line: 5)
+
+func foo() {}
+
+#sourceLocation()

--- a/utils/gyb_syntax_support/DeclNodes.py
+++ b/utils/gyb_syntax_support/DeclNodes.py
@@ -131,6 +131,28 @@ DECL_NODES = [
              Child('RightParen', kind='RightParenToken')
          ]),
 
+    Node('PoundSourceLocation', kind='Decl', 
+         traits=['Parenthesized'],
+         children=[
+             Child('PoundSourceLocation', kind='PoundSourceLocationToken'),
+             Child('LeftParen', kind='LeftParenToken'),
+             Child('Args', kind='PoundSourceLocationArgs', is_optional=True),
+             Child('RightParen', kind='RightParenToken')
+         ]),
+
+    Node('PoundSourceLocationArgs', kind='Syntax',
+         children=[
+             Child('FileArgLabel', kind='IdentifierToken', 
+                   text_choices=['file']),
+             Child('FileArgColon', kind='ColonToken'),
+             Child('FileName', kind='StringLiteralToken'),
+             Child('Comma', kind='CommaToken'),
+             Child('LineArgLabel', kind='IdentifierToken', 
+                   text_choices=['line']),
+             Child('LineArgColon', kind='ColonToken'),
+             Child('LineNumber', kind='IntegerLiteralToken'),
+         ]),
+
     Node('DeclModifier', kind='Syntax',
          children=[
              Child('Name', kind='Token',


### PR DESCRIPTION
Add support for parsing `#sourceLocation` directives in libSyntax.