### PR TITLE
[gardening] Rename ProjectionTree::getLeafTypes() => getLiveLeafTypes().

### DIFF
--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -926,8 +926,7 @@ public:
     return false;
   }
 
-
-  void getLeafTypes(llvm::SmallVectorImpl<SILType> &OutArray) const {
+  void getLiveLeafTypes(llvm::SmallVectorImpl<SILType> &OutArray) const {
     for (unsigned LeafIndex : LiveLeafIndices) {
       const ProjectionTreeNode *Node = getNode(LeafIndex);
       assert(Node->IsLive && "We are only interested in leafs that are live");
@@ -935,8 +934,8 @@ public:
     }
   }
 
-  void
-  getLeafNodes(llvm::SmallVectorImpl<const ProjectionTreeNode *> &Out) const {
+  void getLiveLeafNodes(
+      llvm::SmallVectorImpl<const ProjectionTreeNode *> &Out) const {
     for (unsigned LeafIndex : LiveLeafIndices) {
       const ProjectionTreeNode *Node = getNode(LeafIndex);
       assert(Node->IsLive && "We are only interested in leafs that are live");
@@ -945,9 +944,7 @@ public:
   }
 
   /// Return the number of live leafs in the projection.
-  size_t liveLeafCount() const {
-    return LiveLeafIndices.size();
-  }
+  unsigned getLiveLeafCount() const { return LiveLeafIndices.size(); }
 
   void createTreeFromValue(SILBuilder &B, SILLocation Loc, SILValue NewBase,
                            llvm::SmallVectorImpl<SILValue> &Leafs) const;

--- a/lib/SIL/Projection.cpp
+++ b/lib/SIL/Projection.cpp
@@ -1244,7 +1244,7 @@ computeUsesAndLiveness(SILValue Base) {
 #ifndef NDEBUG
   DEBUG(llvm::dbgs() << "Final Leafs: \n");
   llvm::SmallVector<SILType, 8> LeafTypes;
-  getLeafTypes(LeafTypes);
+  getLiveLeafTypes(LeafTypes);
   for (SILType Leafs : LeafTypes) {
     DEBUG(llvm::dbgs() << "    " << Leafs << "\n");
   }

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.cpp
@@ -465,7 +465,7 @@ void FunctionSignatureTransformDescriptor::computeOptimizedArgInterface(
   if (AD.Explode) {
     ++NumSROAArguments;
     llvm::SmallVector<const ProjectionTreeNode *, 8> LeafNodes;
-    AD.ProjTree.getLeafNodes(LeafNodes);
+    AD.ProjTree.getLiveLeafNodes(LeafNodes);
     for (auto Node : LeafNodes) {
       SILType Ty = Node->getType();
       DEBUG(llvm::dbgs() << "                " << Ty << "\n");
@@ -1130,7 +1130,7 @@ void FunctionSignatureTransform::ArgumentExplosionFinalizeOptimizedFunction() {
     // We do this in the same order as leaf types since ProjTree expects that the
     // order of leaf values matches the order of leaf types.
     llvm::SmallVector<const ProjectionTreeNode*, 8> LeafNodes;
-    AD.ProjTree.getLeafNodes(LeafNodes);
+    AD.ProjTree.getLiveLeafNodes(LeafNodes);
 
     for (auto *Node : LeafNodes) {
       auto OwnershipKind = *AD.getTransformedOwnershipKind(Node->getType());

--- a/lib/SILOptimizer/Transforms/FunctionSignatureOpts.h
+++ b/lib/SILOptimizer/Transforms/FunctionSignatureOpts.h
@@ -149,7 +149,7 @@ struct ArgumentDescriptor {
         ERM.hasSomeReleasesForArgument(Arg))
       return true;
 
-    size_t explosionSize = ProjTree.liveLeafCount();
+    unsigned explosionSize = ProjTree.getLiveLeafCount();
     return explosionSize >= 1 && explosionSize <= 3;
   }
 


### PR DESCRIPTION
This is a more appropriate name. Otherwise, a reader could think that it returns
/all/ leaf types including dead leaf types.

----

Just slicing off some improvements from my fix to func sig opts.