### PR TITLE
[projection] Add a small note that we should eliminate the allocator …

### DIFF
--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -838,6 +838,9 @@ class ProjectionTree {
   SILModule &Mod;
 
   /// The allocator we use to allocate ProjectionTreeNodes in the tree.
+  ///
+  /// FIXME: This should be a reference to an outside allocator. We shouldn't
+  /// have each ProjectionTree have its own allocator.
   llvm::SpecificBumpPtrAllocator<ProjectionTreeNode> Allocator;
 
   // A common pattern is a 3 field struct.


### PR DESCRIPTION
…from ProjectionTree.

----

Slicing off commits from a larger FSO commit real quick.