### PR TITLE
[Runtime] Have swift_dynamicCast unwrap multiple levels of optionals in the source.

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -1866,7 +1866,7 @@ checkDynamicCastFromOptional(OpaqueValue *dest,
   // .Some
   // Single payload enums are guaranteed layout compatible with their
   // payload. Only the source's payload needs to be taken or destroyed.
-  return {false, payloadType};
+  return checkDynamicCastFromOptional(dest, src, payloadType, targetType, flags);
 }
 
 /******************************************************************************/

--- a/test/stdlib/Casts.swift
+++ b/test/stdlib/Casts.swift
@@ -50,6 +50,26 @@ CastsTests.test("No overrelease of existential boxes in failed casts") {
 
 extension Int : P {}
 
+// Test for SR-7664: Inconsistent optional casting behaviour with generics
+// Runtime failed to unwrap multiple levels of Optional when casting.
+CastsTests.test("Multi-level optionals can be casted") {
+  func testSuccess<From, To>(_ x: From, from: From.Type, to: To.Type) {
+    expectNotNil(x as? To)
+  }
+  func testFailure<From, To>(_ x: From, from: From.Type, to: To.Type) {
+    expectNil(x as? To)
+  }
+  testSuccess(42, from: Int?.self, to: Int.self)
+  testSuccess(42, from: Int??.self, to: Int.self)
+  testSuccess(42, from: Int???.self, to: Int.self)
+  testSuccess(42, from: Int???.self, to: Int?.self)
+  testSuccess(42, from: Int???.self, to: Int??.self)
+  testSuccess(42, from: Int???.self, to: Int???.self)
+  testFailure(42, from: Int?.self, to: String.self)
+  testFailure(42, from: Int??.self, to: String.self)
+  testFailure(42, from: Int???.self, to: String.self)
+}
+
 #if _runtime(_ObjC)
 extension CFBitVector : P {
   static func makeImmutable(from values: Array<UInt8>) -> CFBitVector {


### PR DESCRIPTION
The real work is done in `checkDynamicCastFromOptional`. This code tried to unwrap the source and returned the payload on success. It only did this once, so a type like `Optional<Optional<Int>>` would come out as `Optional<Int>` and then a cast to Int would fail.

This change makes `checkDynamicCastFromOptional` recursive, which makes it unwrap as many levels of `Optional` as it encounters.

Fixes rdar://problem/40171034 and SR-7664.