### PR TITLE
[pred-memopt] Replace remaining occurances of prefix DI with PMO prefix.

### DIFF
--- a/lib/SILOptimizer/Mandatory/CMakeLists.txt
+++ b/lib/SILOptimizer/Mandatory/CMakeLists.txt
@@ -4,7 +4,6 @@ set(MANDATORY_SOURCES
   Mandatory/AddressLowering.cpp
   Mandatory/ConstantPropagation.cpp
   Mandatory/DefiniteInitialization.cpp
-  Mandatory/DIMemoryUseCollector.cpp
   Mandatory/DIMemoryUseCollectorOwnership.cpp
   Mandatory/DataflowDiagnostics.cpp
   Mandatory/DiagnoseInfiniteRecursion.cpp
@@ -14,6 +13,7 @@ set(MANDATORY_SOURCES
   Mandatory/IRGenPrepare.cpp
   Mandatory/MandatoryInlining.cpp
   Mandatory/PredictableMemOpt.cpp
+  Mandatory/PMOMemoryUseCollector.cpp
   Mandatory/SemanticARCOpts.cpp
   Mandatory/ClosureLifetimeFixup.cpp
   PARENT_SCOPE)

--- a/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.h
+++ b/lib/SILOptimizer/Mandatory/PMOMemoryUseCollector.h
@@ -1,4 +1,4 @@
-//===--- DIMemoryUseCollector.h - Memory use information for DI -*- C++ -*-===//
+//===- PMOMemoryUseCollector.h - Memory use information for PMO -*- C++ -*-===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -17,8 +17,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SWIFT_SILOPTIMIZER_MANDATORY_DIMEMORYUSECOLLECTOR_H
-#define SWIFT_SILOPTIMIZER_MANDATORY_DIMEMORYUSECOLLECTOR_H
+#ifndef SWIFT_SILOPTIMIZER_MANDATORY_PMOMEMORYUSECOLLECTOR_H
+#define SWIFT_SILOPTIMIZER_MANDATORY_PMOMEMORYUSECOLLECTOR_H
 
 #include "swift/Basic/LLVM.h"
 #include "swift/SIL/SILInstruction.h"
@@ -30,7 +30,7 @@ namespace swift {
 
 class SILBuilder;
 
-/// DIMemoryObjectInfo - This struct holds information about the memory object
+/// PMOMemoryObjectInfo - This struct holds information about the memory object
 /// being analyzed that is required to correctly break it down into elements.
 ///
 /// This includes a collection of utilities for reasoning about (potentially
@@ -47,7 +47,7 @@ class SILBuilder;
 ///
 /// Derived classes have an additional field at the end that models whether or
 /// not super.init() has been called or not.
-class DIMemoryObjectInfo {
+class PMOMemoryObjectInfo {
 public:
   /// This is the instruction that represents the memory.  It is either an
   /// allocation (alloc_box, alloc_stack) or a mark_uninitialized.
@@ -55,7 +55,7 @@ public:
 
   /// This is the base type of the memory allocation.
   SILType MemorySILType;
-  
+
   /// True if the memory object being analyzed represents a 'let', which is
   /// initialize-only (reassignments are not allowed).
   bool IsLet = false;
@@ -64,9 +64,9 @@ public:
   /// tuples, this is the flattened element count.  For 'self' members in init
   /// methods, this is the local field count (+1 for derive classes).
   unsigned NumElements;
-public:
 
-  DIMemoryObjectInfo(SingleValueInstruction *MemoryInst);
+public:
+  PMOMemoryObjectInfo(SingleValueInstruction *MemoryInst);
 
   SILLocation getLoc() const { return MemoryInst->getLoc(); }
   SILFunction &getFunction() const { return *MemoryInst->getFunction(); }
@@ -74,9 +74,7 @@ public:
   /// Return the first instruction of the function containing the memory object.
   SILInstruction *getFunctionEntryPoint() const;
 
-  CanType getType() const {
-    return MemorySILType.getASTType();
-  }
+  CanType getType() const { return MemorySILType.getASTType(); }
 
   SingleValueInstruction *getAddress() const {
     if (isa<AllocStackInst>(MemoryInst))
@@ -108,32 +106,31 @@ public:
   bool isElementLetProperty(unsigned Element) const;
 };
 
-
-enum DIUseKind {
+enum PMOUseKind {
   /// The instruction is a Load.
   Load,
-  
+
   /// The instruction is either an initialization or an assignment, we don't
   /// know which.  This classification only happens with values of trivial type
   /// where the different isn't significant.
   InitOrAssign,
-  
+
   /// The instruction is an initialization of the tuple element.
   Initialization,
-  
+
   /// The instruction is an assignment, overwriting an already initialized
   /// value.
   Assign,
-  
+
   /// The instruction is a store to a member of a larger struct value.
   PartialStore,
-  
+
   /// An indirect 'inout' parameter of an Apply instruction.
   InOutUse,
-  
+
   /// An indirect 'in' parameter of an Apply instruction.
   IndirectIn,
-  
+
   /// This instruction is a general escape of the value, e.g. a call to a
   /// closure that captures it.
   Escape,
@@ -148,51 +145,52 @@ enum DIUseKind {
 
 /// This struct represents a single classified access to the memory object
 /// being analyzed, along with classification information about the access.
-struct DIMemoryUse {
+struct PMOMemoryUse {
   /// This is the instruction accessing the memory.
   SILInstruction *Inst;
-  
+
   /// This is what kind of access it is, load, store, escape, etc.
-  DIUseKind Kind;
-  
+  PMOUseKind Kind;
+
   /// For memory objects of (potentially recursive) tuple type, this keeps
   /// track of which tuple elements are affected.
   unsigned short FirstElement, NumElements;
-  
-  DIMemoryUse(SILInstruction *Inst, DIUseKind Kind, unsigned FE, unsigned NE)
-  : Inst(Inst), Kind(Kind), FirstElement(FE), NumElements(NE) {
+
+  PMOMemoryUse(SILInstruction *Inst, PMOUseKind Kind, unsigned FE, unsigned NE)
+      : Inst(Inst), Kind(Kind), FirstElement(FE), NumElements(NE) {
     assert(FE == FirstElement && NumElements == NE &&
            "more than 64K elements not supported yet");
   }
-  
-  DIMemoryUse() : Inst(nullptr) {}
-  
+
+  PMOMemoryUse() : Inst(nullptr) {}
+
   bool isInvalid() const { return Inst == nullptr; }
   bool isValid() const { return Inst != nullptr; }
 
   bool usesElement(unsigned i) const {
-    return i >= FirstElement && i < static_cast<unsigned>(FirstElement+NumElements);
+    return i >= FirstElement &&
+           i < static_cast<unsigned>(FirstElement + NumElements);
   }
-  
+
   /// onlyTouchesTrivialElements - Return true if all of the accessed elements
   /// have trivial type.
-  bool onlyTouchesTrivialElements(const DIMemoryObjectInfo &MemoryInfo) const;
-  
+  bool onlyTouchesTrivialElements(const PMOMemoryObjectInfo &MemoryInfo) const;
+
   /// getElementBitmask - Return a bitmask with the touched tuple elements
   /// set.
   APInt getElementBitmask(unsigned NumMemoryTupleElements) const {
     return APInt::getBitsSet(NumMemoryTupleElements, FirstElement,
-                             FirstElement+NumElements);
+                             FirstElement + NumElements);
   }
 };
 
-/// collectDIElementUsesFrom - Analyze all uses of the specified allocation
+/// collectPMOElementUsesFrom - Analyze all uses of the specified allocation
 /// instruction (alloc_box, alloc_stack or mark_uninitialized), classifying them
 /// and storing the information found into the Uses and Releases lists.
 LLVM_NODISCARD bool
-collectDIElementUsesFrom(const DIMemoryObjectInfo &MemoryInfo,
-                         SmallVectorImpl<DIMemoryUse> &Uses,
-                         SmallVectorImpl<SILInstruction *> &Releases);
+collectPMOElementUsesFrom(const PMOMemoryObjectInfo &MemoryInfo,
+                          SmallVectorImpl<PMOMemoryUse> &Uses,
+                          SmallVectorImpl<SILInstruction *> &Releases);
 
 } // end namespace swift
 

--- a/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
+++ b/lib/SILOptimizer/Mandatory/PredictableMemOpt.cpp
@@ -12,7 +12,7 @@
 
 #define DEBUG_TYPE "predictable-memopt"
 
-#include "DIMemoryUseCollector.h"
+#include "PMOMemoryUseCollector.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SILOptimizer/PassManager/Passes.h"
 #include "swift/SILOptimizer/PassManager/Transforms.h"
@@ -163,7 +163,7 @@ struct AvailableValue {
   SetVector InsertionPoints;
 
   /// Just for updating.
-  SmallVectorImpl<DIMemoryUse> *Uses;
+  SmallVectorImpl<PMOMemoryUse> *Uses;
 
 public:
   AvailableValue() = default;
@@ -352,12 +352,12 @@ class AvailableValueAggregator {
   SILBuilderWithScope B;
   SILLocation Loc;
   MutableArrayRef<AvailableValue> AvailableValueList;
-  SmallVectorImpl<DIMemoryUse> &Uses;
+  SmallVectorImpl<PMOMemoryUse> &Uses;
 
 public:
   AvailableValueAggregator(SILInstruction *Inst,
                            MutableArrayRef<AvailableValue> AvailableValueList,
-                           SmallVectorImpl<DIMemoryUse> &Uses)
+                           SmallVectorImpl<PMOMemoryUse> &Uses)
       : M(Inst->getModule()), B(Inst), Loc(Inst->getLoc()),
         AvailableValueList(AvailableValueList), Uses(Uses) {}
 
@@ -508,8 +508,8 @@ SILValue AvailableValueAggregator::handlePrimitiveValue(SILType LoadTy,
   if (!Val) {
     auto *Load =
         B.createLoad(Loc, Address, LoadOwnershipQualifier::Unqualified);
-    Uses.push_back(DIMemoryUse(Load, DIUseKind::Load, FirstElt,
-                               getNumSubElements(Load->getType(), M)));
+    Uses.push_back(PMOMemoryUse(Load, PMOUseKind::Load, FirstElt,
+                                getNumSubElements(Load->getType(), M)));
     return Load;
   }
 
@@ -564,7 +564,7 @@ class AvailableValueDataflowContext {
   /// The set of uses that we are tracking. This is only here so we can update
   /// when exploding copy_addr. It would be great if we did not have to store
   /// this.
-  llvm::SmallVectorImpl<DIMemoryUse> &Uses;
+  llvm::SmallVectorImpl<PMOMemoryUse> &Uses;
 
   /// The set of blocks with local definitions.
   ///
@@ -583,7 +583,7 @@ class AvailableValueDataflowContext {
 public:
   AvailableValueDataflowContext(AllocationInst *TheMemory,
                                 unsigned NumMemorySubElements,
-                                llvm::SmallVectorImpl<DIMemoryUse> &Uses);
+                                llvm::SmallVectorImpl<PMOMemoryUse> &Uses);
 
   /// Try to compute available values for "TheMemory" at the instruction \p
   /// StartingFrom. We only compute the values for set bits in \p
@@ -623,7 +623,7 @@ private:
 
 AvailableValueDataflowContext::AvailableValueDataflowContext(
     AllocationInst *InputTheMemory, unsigned NumMemorySubElements,
-    SmallVectorImpl<DIMemoryUse> &InputUses)
+    SmallVectorImpl<PMOMemoryUse> &InputUses)
     : TheMemory(InputTheMemory), NumMemorySubElements(NumMemorySubElements),
       Uses(InputUses) {
   // The first step of processing an element is to collect information about the
@@ -633,13 +633,13 @@ AvailableValueDataflowContext::AvailableValueDataflowContext(
     assert(Use.Inst && "No instruction identified?");
 
     // Keep track of all the uses that aren't loads.
-    if (Use.Kind == DIUseKind::Load)
+    if (Use.Kind == PMOUseKind::Load)
       continue;
 
     NonLoadUses[Use.Inst] = ui;
     HasLocalDefinition.insert(Use.Inst->getParent());
-    
-    if (Use.Kind == DIUseKind::Escape) {
+
+    if (Use.Kind == PMOUseKind::Escape) {
       // Determine which blocks the value can escape from.  We aren't allowed to
       // promote loads in blocks reachable from an escape point.
       HasAnyEscape = true;
@@ -883,12 +883,12 @@ void AvailableValueDataflowContext::explodeCopyAddr(CopyAddrInst *CAI) {
   // Remove the copy_addr from Uses.  A single copy_addr can appear multiple
   // times if the source and dest are to elements within a single aggregate, but
   // we only want to pick up the CopyAddrKind from the store.
-  DIMemoryUse LoadUse, StoreUse;
+  PMOMemoryUse LoadUse, StoreUse;
   for (auto &Use : Uses) {
     if (Use.Inst != CAI)
       continue;
 
-    if (Use.Kind == DIUseKind::Load) {
+    if (Use.Kind == PMOUseKind::Load) {
       assert(LoadUse.isInvalid());
       LoadUse = Use;
     } else {
@@ -991,14 +991,14 @@ class AllocOptimize {
   /// value.
   unsigned NumMemorySubElements;
 
-  SmallVectorImpl<DIMemoryUse> &Uses;
+  SmallVectorImpl<PMOMemoryUse> &Uses;
   SmallVectorImpl<SILInstruction *> &Releases;
 
   /// A structure that we use to compute our available values.
   AvailableValueDataflowContext DataflowContext;
 
 public:
-  AllocOptimize(AllocationInst *TheMemory, SmallVectorImpl<DIMemoryUse> &Uses,
+  AllocOptimize(AllocationInst *TheMemory, SmallVectorImpl<PMOMemoryUse> &Uses,
                 SmallVectorImpl<SILInstruction *> &Releases);
 
   bool doIt();
@@ -1029,7 +1029,7 @@ static SILType getMemoryType(AllocationInst *TheMemory) {
 }
 
 AllocOptimize::AllocOptimize(AllocationInst *InputMemory,
-                             SmallVectorImpl<DIMemoryUse> &InputUses,
+                             SmallVectorImpl<PMOMemoryUse> &InputUses,
                              SmallVectorImpl<SILInstruction *> &InputReleases)
     : Module(InputMemory->getModule()), TheMemory(InputMemory),
       MemoryType(getMemoryType(TheMemory)),
@@ -1233,20 +1233,20 @@ bool AllocOptimize::tryToRemoveDeadAllocation() {
     return false;
 
   // Check the uses list to see if there are any non-store uses left over after
-  // load promotion and other things DI does.
+  // load promotion and other things PMO does.
   for (auto &U : Uses) {
     // Ignore removed instructions.
     if (U.Inst == nullptr) continue;
 
     switch (U.Kind) {
-    case DIUseKind::SelfInit:
-    case DIUseKind::SuperInit:
+    case PMOUseKind::SelfInit:
+    case PMOUseKind::SuperInit:
       llvm_unreachable("Can't happen on allocations");
-    case DIUseKind::Assign:
-    case DIUseKind::PartialStore:
-    case DIUseKind::InitOrAssign:
+    case PMOUseKind::Assign:
+    case PMOUseKind::PartialStore:
+    case PMOUseKind::InitOrAssign:
       break;    // These don't prevent removal.
-    case DIUseKind::Initialization:
+    case PMOUseKind::Initialization:
       if (!isa<ApplyInst>(U.Inst) &&
           // A copy_addr that is not a take affects the retain count
           // of the source.
@@ -1255,10 +1255,10 @@ bool AllocOptimize::tryToRemoveDeadAllocation() {
         break;
       // FALL THROUGH.
      LLVM_FALLTHROUGH;
-    case DIUseKind::Load:
-    case DIUseKind::IndirectIn:
-    case DIUseKind::InOutUse:
-    case DIUseKind::Escape:
+    case PMOUseKind::Load:
+    case PMOUseKind::IndirectIn:
+    case PMOUseKind::InOutUse:
+    case PMOUseKind::Escape:
       DEBUG(llvm::dbgs() << "*** Failed to remove autogenerated alloc: "
             "kept alive by: " << *U.Inst);
       return false;   // These do prevent removal.
@@ -1340,7 +1340,7 @@ bool AllocOptimize::doIt() {
   for (unsigned i = 0; i != Uses.size(); ++i) {
     auto &Use = Uses[i];
     // Ignore entries for instructions that got expanded along the way.
-    if (Use.Inst && Use.Kind == DIUseKind::Load) {
+    if (Use.Inst && Use.Kind == PMOUseKind::Load) {
       if (promoteLoad(Use.Inst)) {
         Uses[i].Inst = nullptr;  // remove entry if load got deleted.
         Changed = true;
@@ -1366,17 +1366,17 @@ static bool optimizeMemoryAllocations(SILFunction &Fn) {
       }
       auto Alloc = cast<AllocationInst>(Inst);
 
-      DEBUG(llvm::dbgs() << "*** DI Optimize looking at: " << *Alloc << "\n");
-      DIMemoryObjectInfo MemInfo(Alloc);
+      DEBUG(llvm::dbgs() << "*** PMO Optimize looking at: " << *Alloc << "\n");
+      PMOMemoryObjectInfo MemInfo(Alloc);
 
       // Set up the datastructure used to collect the uses of the allocation.
-      SmallVector<DIMemoryUse, 16> Uses;
+      SmallVector<PMOMemoryUse, 16> Uses;
       SmallVector<SILInstruction*, 4> Releases;
 
       // Walk the use list of the pointer, collecting them. If we are not able
       // to optimize, skip this value. *NOTE* We may still scalarize values
       // inside the value.
-      if (!collectDIElementUsesFrom(MemInfo, Uses, Releases)) {
+      if (!collectPMOElementUsesFrom(MemInfo, Uses, Releases)) {
         ++I;
         continue;
       }


### PR DESCRIPTION
I am going to DI and predictable mem opts have been split for a long time and
their subroutines aren't going to be joined in the future... so replace the DI
prefixes in pred-mem-opts impl with PMO and rename DIMemoryUseCollector =>
PMOUseCollector.

Been sitting on this for a long time... just happy to get it in.

----

@atrick this is a pretty straight forward conversion. Can you take a look and make sure I didn't miss anything? I think eventually we will want to re-unify some parts of the implementations (for instance I think we could unify DIMemoryInfo and PMOMemoryInfo).

I ran into this in my local git repo while looking at some other stuff... I just wanted to get it into GitHub. So there isn't a rush with this, but can you take a look sooner rather than later?