### PR TITLE
[migrator] Revert "migrator: avoid inserting base name while renaming if users' member access doesn't specify the base name. rdar://40373279"

### DIFF
--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -260,21 +260,6 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
       SF->getASTContext().SourceMgr, Range).str() == "nil";
   }
 
-  bool isDotMember(CharSourceRange Range) {
-    auto S = Range.str();
-    return S.startswith(".") && S.substr(1).find(".") == StringRef::npos;
-  }
-
-  bool isDotMember(SourceRange Range) {
-    return isDotMember(Lexer::getCharSourceRangeFromSourceRange(
-      SF->getASTContext().SourceMgr, Range));
-  }
-
-  bool isDotMember(Expr *E) {
-    auto Range = E->getSourceRange();
-    return Range.isValid() && isDotMember(Range);
-  }
-
   std::vector<APIDiffItem*> getRelatedDiffItems(ValueDecl *VD) {
     std::vector<APIDiffItem*> results;
     auto addDiffItems = [&](ValueDecl *VD) {
@@ -323,11 +308,11 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
   }
 
 
-  bool isSimpleReplacement(APIDiffItem *Item, bool isDotMember, std::string &Text) {
+  bool isSimpleReplacement(APIDiffItem *Item, std::string &Text) {
     if (auto *MD = dyn_cast<TypeMemberDiffItem>(Item)) {
       if (MD->Subkind == TypeMemberDiffItemSubKind::SimpleReplacement) {
-        Text = (llvm::Twine(isDotMember ? "" : MD->newTypeName) + "." +
-          MD->getNewName().base()).str();
+        Text = (llvm::Twine(MD->newTypeName) + "." + MD->getNewName().base()).
+          str();
         return true;
       }
     }
@@ -390,7 +375,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
                           Type T, ReferenceMetaData Data) override {
     for (auto *Item: getRelatedDiffItems(CtorTyRef ? CtorTyRef: D)) {
       std::string RepText;
-      if (isSimpleReplacement(Item, isDotMember(Range), RepText)) {
+      if (isSimpleReplacement(Item, RepText)) {
         Editor.replace(Range, RepText);
         return true;
       }
@@ -465,9 +450,8 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
       for (auto *I: getRelatedDiffItems(VD)) {
         if (auto *Item = dyn_cast<TypeMemberDiffItem>(I)) {
           if (Item->Subkind == TypeMemberDiffItemSubKind::QualifiedReplacement) {
-            Editor.replace(ToReplace,
-              (llvm::Twine(isDotMember(ToReplace) ? "" : Item->newTypeName) + "." +
-               Item->getNewName().base()).str());
+            Editor.replace(ToReplace, (llvm::Twine(Item->newTypeName) + "." +
+              Item->getNewName().base()).str());
             return true;
           }
         }
@@ -741,7 +725,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
     StringRef LeftComment;
     StringRef RightComment;
     for (auto *Item: getRelatedDiffItems(RD)) {
-      if (isSimpleReplacement(Item, isDotMember(Reference), Rename)) {
+      if (isSimpleReplacement(Item, Rename)) {
       } else if (auto *CI = dyn_cast<CommonDiffItem>(Item)) {
         if (CI->isStringRepresentableChange() &&
             CI->NodeKind == SDKNodeKind::DeclVar) {

--- a/test/Migrator/qualified-replacement.swift
+++ b/test/Migrator/qualified-replacement.swift
@@ -14,8 +14,6 @@ func foo() {
   _ = Cities.CityKind.Town
   _ = ToplevelType()
   _ = ToplevelType(recordName: "")
-  bar(.orderedSame)
 }
 
 func foo(_: ToplevelType) {}
-func bar(_ : FooComparisonResult) {}

--- a/test/Migrator/qualified-replacement.swift.expected
+++ b/test/Migrator/qualified-replacement.swift.expected
@@ -10,12 +10,10 @@ func foo() {
   _ = NewPropertyUserInterface.newFieldPlus
   NewPropertyUserInterface.newMethodPlus(1)
   _ = NewFooComparisonResult.NewFooOrderedSame
-  let _ : FooComparisonResult = .NewFooOrderedSame
+  let _ : FooComparisonResult = NewFooComparisonResult.NewFooOrderedSame
   _ = NewCityKind.NewTown
   _ = ToplevelWrapper.internalType()
   _ = ToplevelWrapper.internalType(recordName: "")
-  bar(.NewFooOrderedSame)
 }
 
 func foo(_: ToplevelWrapper.internalType) {}
-func bar(_ : FooComparisonResult) {}


### PR DESCRIPTION
We've seen cases where using dot member names cause build errors. Thus, we revert this QOL fix.

rdar://40458118