### PR TITLE
[Serialization] Allow unbound generic types to cross-reference typealias decls

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -3943,7 +3943,9 @@ void Serializer::writeType(Type ty) {
 
     unsigned abbrCode = DeclTypeAbbrCodes[UnboundGenericTypeLayout::Code];
     UnboundGenericTypeLayout::emitRecord(Out, ScratchRecord, abbrCode,
-                                         addDeclRef(generic->getDecl()),
+                                         addDeclRef(generic->getDecl(),
+                                                    /*forceSerialization*/false,
+                                                    /*allowTypeAliasXRef*/true),
                                          addTypeRef(generic->getParent()));
     break;
   }

--- a/test/Serialization/Inputs/alias.swift
+++ b/test/Serialization/Inputs/alias.swift
@@ -36,3 +36,6 @@ public struct Outer { public typealias G<T> = T }
 public typealias GG = Outer.G
 
 public typealias GInt = Outer.G<Int>
+
+public struct UnboundStruct<T> {}
+public typealias UnboundAlias<T: Comparable> = UnboundStruct<T>

--- a/test/Serialization/typealias.swift
+++ b/test/Serialization/typealias.swift
@@ -1,5 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-build-swift -module-name alias -emit-module -o %t %S/Inputs/alias.swift
+// RUN: %target-build-swift -I %t %s -module-name typealias -emit-module-path %t/typealias.swiftmodule -o %t/typealias.o
 // RUN: llvm-bcanalyzer %t/alias.swiftmodule | %FileCheck %s
 // RUN: %target-build-swift -I %t %s -o %t/a.out
 // RUN: %target-run %t/a.out | %FileCheck -check-prefix=OUTPUT %s
@@ -53,3 +54,5 @@ func check(_: BaseAlias) {
 
 let x: GG<Int> = 0
 let x2: GInt = 1
+
+public typealias TestUnbound = UnboundAlias


### PR DESCRIPTION
Ideally `UnboundGenericType` should never be serialized but it is
currently allowed to make generic `typealias` declarations without
specifying generic parameters, so it should be allowed to cross
reference typealias decls in such types as well because `NameAliasType`
can't be used until generic parameters are resolved.

This is only a temporary fix and more comprehensive solution is still
pending here, most likely such declarations should not produce
`UnboundGenericType` but instead should copy generic parameters from
underlying type and produce proper `NameAliasType`.

Resolves: rdar://problem/37384120

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
