### PR TITLE
[Runtime] Fix double-frees in ConcurrentReadableArray.

### DIFF
--- a/include/swift/Runtime/Concurrent.h
+++ b/include/swift/Runtime/Concurrent.h
@@ -451,7 +451,37 @@ private:
   Mutex WriterLock;
   std::vector<Storage *> FreeList;
   
+  void incrementReaders() {
+    ReaderCount.fetch_add(1, std::memory_order_acquire);
+  }
+  
+  void decrementReaders() {
+    ReaderCount.fetch_sub(1, std::memory_order_release);
+  }
+  
 public:
+  struct Snapshot {
+    ConcurrentReadableArray *Array;
+    const ElemTy *Start;
+    size_t Count;
+    
+    Snapshot(ConcurrentReadableArray *array, const ElemTy *start, size_t count)
+      : Array(array), Start(start), Count(count) {}
+    
+    Snapshot(const Snapshot &other)
+      : Array(other.Array), Start(other.Start), Count(other.Count) {
+      Array->incrementReaders();
+    }
+    
+    ~Snapshot() {
+      Array->decrementReaders();
+    }
+    
+    const ElemTy *begin() { return Start; }
+    const ElemTy *end() { return Start + Count; }
+    size_t count() { return Count; }
+  };
+  
   // This type cannot be safely copied, moved, or deleted.
   ConcurrentReadableArray(const ConcurrentReadableArray &) = delete;
   ConcurrentReadableArray(ConcurrentReadableArray &&) = delete;
@@ -486,28 +516,16 @@ public:
         storage->deallocate();
   }
   
-  /// Read the contents of the array. The parameter `f` is called with
-  /// two parameters: a pointer to the elements in the array, and the
-  /// count. This represents a snapshot of the contents at the time
-  /// `read` was called. The pointer becomes invalid after `f` returns.
-  template <class F> auto read(F f) -> decltype(f(nullptr, 0)) {
-    ReaderCount.fetch_add(1, std::memory_order_acquire);
+  Snapshot snapshot() {
+    incrementReaders();
     auto *storage = Elements.load(SWIFT_MEMORY_ORDER_CONSUME);
+    if (storage == nullptr) {
+      return Snapshot(this, nullptr, 0);
+    }
+    
     auto count = storage->Count.load(std::memory_order_acquire);
     const auto *ptr = storage->data();
-    
-    decltype(f(nullptr, 0)) result = f(ptr, count);
-    
-    ReaderCount.fetch_sub(1, std::memory_order_release);
-    
-    return result;
-  }
-  
-  /// Get the current count. It's just a snapshot and may be obsolete immediately.
-  size_t count() {
-    return read([](const ElemTy *ptr, size_t count) -> size_t {
-      return count;
-    });
+    return Snapshot(this, ptr, count);
   }
 };
 

--- a/include/swift/Runtime/Concurrent.h
+++ b/include/swift/Runtime/Concurrent.h
@@ -459,6 +459,13 @@ private:
     ReaderCount.fetch_sub(1, std::memory_order_release);
   }
   
+  void deallocateFreeList() {
+    for (Storage *storage : FreeList)
+      storage->deallocate();
+    FreeList.clear();
+    FreeList.shrink_to_fit();
+  }
+  
 public:
   struct Snapshot {
     ConcurrentReadableArray *Array;
@@ -489,6 +496,12 @@ public:
   
   ConcurrentReadableArray() : Capacity(0), ReaderCount(0), Elements(nullptr) {}
   
+  ~ConcurrentReadableArray() {
+    assert(ReaderCount.load(std::memory_order_acquire) == 0 &&
+           "deallocating ConcurrentReadableArray with outstanding snapshots");
+    deallocateFreeList();
+  }
+  
   void push_back(const ElemTy &elem) {
     ScopedLock guard(WriterLock);
     
@@ -512,8 +525,7 @@ public:
     storage->Count.store(count + 1, std::memory_order_release);
     
     if (ReaderCount.load(std::memory_order_acquire) == 0)
-      for (Storage *storage : FreeList)
-        storage->deallocate();
+      deallocateFreeList();
   }
   
   Snapshot snapshot() {

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -35,6 +35,7 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
   add_swift_unittest(SwiftRuntimeTests
     Array.cpp
     CompatibilityOverride.cpp
+    Concurrent.cpp
     Exclusivity.cpp
     Metadata.cpp
     Mutex.cpp

--- a/unittests/runtime/Concurrent.cpp
+++ b/unittests/runtime/Concurrent.cpp
@@ -1,0 +1,44 @@
+//===--- Concurrent.cpp - Concurrent data structure tests -----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/Concurrent.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+
+TEST(ConcurrentReadableArrayTest, SingleThreaded) {
+  ConcurrentReadableArray<size_t> array;
+  
+  auto add = [&](size_t limit) {
+    for (size_t i = array.snapshot().count(); i < limit; i++)
+      array.push_back(i);
+  };
+  auto check = [&]{
+    size_t i = 0;
+    for (auto element : array.snapshot()) {
+      ASSERT_EQ(element, i);
+      i++;
+    }
+  };
+  
+  check();
+  add(1);
+  check();
+  add(16);
+  check();
+  add(100);
+  check();
+  add(1000);
+  check();
+  add(1000000);
+  check();
+}


### PR DESCRIPTION
I sort of forgot to clear out `FreeList` after destroying all the stuff inside it. The result is that the second time through, the same storage blocks would be destroyed *again*, resulting in a crash or worse.

This clears `FreeList` after destroying the stuff inside. It also adds a destructor so the thing doesn't leak when used as a non-global, and a basic test to verify that adding a non-trivial number of elements actually works.

Thanks to @gwynne for finding this.

rdar://problem/40484362