### PR TITLE
[TypeReconstruction] Fix reconstruction for VarDecls.

### DIFF
--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -668,9 +668,10 @@ static DeclKind GetKindAsDeclKind(Demangle::Node::Kind node_kind) {
     return DeclKind::Enum;
   case Demangle::Node::Kind::Protocol:
     return DeclKind::Protocol;
+  case Demangle::Node::Kind::Variable:
+    return DeclKind::Var;
   default:
     llvm_unreachable("Missing alias");
-    // FIXME: can we 'log' getNodeKindString(node_kind))
   }
 }
 

--- a/test/DebugInfo/Inputs/type-reconstr-names.txt
+++ b/test/DebugInfo/Inputs/type-reconstr-names.txt
@@ -4,3 +4,4 @@ $Ss5Int32VD ---> Int32
 $S4blah4mainyyF8PatatinoL_VMa ---> Can't resolve type of $S4blah4mainyyF8PatatinoL_VMa
 $Ss10CollectionP7Element ---> Can't resolve type of $Ss10CollectionP7Element
 $Ss15ContiguousArrayV9formIndex5afterySiz_tFSS_Tg5 ---> (inout Int) -> ()
+$S13EyeCandySwift21_previousUniqueNumber33_ADC08935D64EA4F796440E7335798735LLs6UInt64Vvp -> UInt64


### PR DESCRIPTION
We were previously asserting on the following tree:
kind=Global
  kind=Variable
    kind=Module, text="EyeCandySwift"
    kind=PrivateDeclName
      kind=Identifier, text="_ADC08935D64EA4F796440E7335798735"
      kind=Identifier, text="_previousUniqueNumber"
    kind=Type
      kind=Structure
        kind=Module, text="Swift"
        kind=Identifier, text="UInt64"

<rdar://problem/39283527>