### PR TITLE
IRGen: Opaque existentials are now bitwise takable

### DIFF
--- a/lib/IRGen/GenExistential.cpp
+++ b/lib/IRGen/GenExistential.cpp
@@ -280,7 +280,7 @@ class OpaqueExistentialTypeInfo final :
                             llvm::Type *ty, Size size, Alignment align)
     : super(protocols, ty, size,
             SpareBitVector::getConstant(size.getValueInBits(), false), align,
-            IsNotPOD, IsNotBitwiseTakable, IsFixedSize) {}
+            IsNotPOD, IsBitwiseTakable, IsFixedSize) {}
 
 public:
   OpaqueExistentialLayout getLayout() const {

--- a/stdlib/public/runtime/ExistentialMetadataImpl.h
+++ b/stdlib/public/runtime/ExistentialMetadataImpl.h
@@ -327,7 +327,7 @@ struct LLVM_LIBRARY_VISIBILITY OpaqueExistentialBox
   static constexpr size_t alignment = alignof(Container);
   static constexpr size_t stride = sizeof(Container);
   static constexpr size_t isPOD = false;
-  static constexpr bool isBitwiseTakable = false;
+  static constexpr bool isBitwiseTakable = true;
   static constexpr unsigned numExtraInhabitants = 0;
 };
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -2526,7 +2526,7 @@ OpaqueExistentialValueWitnessTableCacheEntry(unsigned numWitnessTables) {
   Data.flags = ValueWitnessFlags()
     .withAlignment(Box::Container::getAlignment(numWitnessTables))
     .withPOD(false)
-    .withBitwiseTakable(false)
+    .withBitwiseTakable(true)
     .withInlineStorage(false)
     .withExtraInhabitants(false);
   Data.stride = Box::Container::getStride(numWitnessTables);

--- a/test/IRGen/existentials.sil
+++ b/test/IRGen/existentials.sil
@@ -5,6 +5,14 @@
 sil_stage canonical
 
 import Swift
+protocol P {}
+
+// NonBitwiseTakableBit = 0x00100000. This struct is bitwise takable because
+// 0x30007 = 196615.
+// CHECK: @"$S12existentials14BitwiseTakableVWV" = internal constant [11 x i8*] {{.*}} i8* inttoptr (i64 196615 to i8*)
+struct BitwiseTakable {
+  var p: P
+}
 
 protocol CP: class {}
 

--- a/unittests/runtime/Metadata.cpp
+++ b/unittests/runtime/Metadata.cpp
@@ -507,7 +507,7 @@ TEST(MetadataTest, getExistentialTypeMetadata_opaque) {
       EXPECT_EQ(5 * sizeof(void*), ex1->getValueWitnesses()->getSize());
       EXPECT_EQ(alignof(void*), ex1->getValueWitnesses()->getAlignment());
       EXPECT_FALSE(ex1->getValueWitnesses()->isPOD());
-      EXPECT_FALSE(ex1->getValueWitnesses()->isBitwiseTakable());
+      EXPECT_TRUE(ex1->getValueWitnesses()->isBitwiseTakable());
       EXPECT_EQ(nullptr,
                 ex1->getSuperclassConstraint());
       return ex1;
@@ -525,7 +525,7 @@ TEST(MetadataTest, getExistentialTypeMetadata_opaque) {
       EXPECT_EQ(6 * sizeof(void*), ex2->getValueWitnesses()->getSize());
       EXPECT_EQ(alignof(void*), ex2->getValueWitnesses()->getAlignment());
       EXPECT_FALSE(ex2->getValueWitnesses()->isPOD());
-      EXPECT_FALSE(ex2->getValueWitnesses()->isBitwiseTakable());
+      EXPECT_TRUE(ex2->getValueWitnesses()->isBitwiseTakable());
       EXPECT_EQ(nullptr,
                 ex2->getSuperclassConstraint());
       return ex2;
@@ -543,7 +543,7 @@ TEST(MetadataTest, getExistentialTypeMetadata_opaque) {
       EXPECT_EQ(7 * sizeof(void*), ex3->getValueWitnesses()->getSize());
       EXPECT_EQ(alignof(void*), ex3->getValueWitnesses()->getAlignment());
       EXPECT_FALSE(ex3->getValueWitnesses()->isPOD());
-      EXPECT_FALSE(ex3->getValueWitnesses()->isBitwiseTakable());
+      EXPECT_TRUE(ex3->getValueWitnesses()->isBitwiseTakable());
       EXPECT_EQ(nullptr,
                 ex3->getSuperclassConstraint());
       return ex3;


### PR DESCRIPTION
Now that the existential inline buffer is bitwise takable so are opaque
existentials.