### PR TITLE
[Runtime] 4.2 - Change MetadataLookup section vectors to use ConcurrentReadableArray.

### DIFF
--- a/include/swift/Runtime/Atomic.h
+++ b/include/swift/Runtime/Atomic.h
@@ -1,0 +1,31 @@
+//===--- Atomic.h - Utilities for atomic operations. ------------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Utilities for atomic operations, to use with std::atomic.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_RUNTIME_ATOMIC_H
+#define SWIFT_RUNTIME_ATOMIC_H
+
+// FIXME: Workaround for rdar://problem/18889711. 'Consume' does not require
+// a barrier on ARM64, but LLVM doesn't know that. Although 'relaxed'
+// is formally UB by C++11 language rules, we should be OK because neither
+// the processor model nor the optimizer can realistically reorder our uses
+// of 'consume'.
+#if __arm64__ || __arm__
+#  define SWIFT_MEMORY_ORDER_CONSUME (std::memory_order_relaxed)
+#else
+#  define SWIFT_MEMORY_ORDER_CONSUME (std::memory_order_consume)
+#endif
+
+#endif

--- a/include/swift/Runtime/Concurrent.h
+++ b/include/swift/Runtime/Concurrent.h
@@ -450,7 +450,37 @@ private:
   Mutex WriterLock;
   std::vector<Storage *> FreeList;
   
+  void incrementReaders() {
+    ReaderCount.fetch_add(1, std::memory_order_acquire);
+  }
+  
+  void decrementReaders() {
+    ReaderCount.fetch_sub(1, std::memory_order_release);
+  }
+  
 public:
+  struct Snapshot {
+    ConcurrentReadableArray *Array;
+    const ElemTy *Start;
+    size_t Count;
+    
+    Snapshot(ConcurrentReadableArray *array, const ElemTy *start, size_t count)
+      : Array(array), Start(start), Count(count) {}
+    
+    Snapshot(const Snapshot &other)
+      : Array(other.Array), Start(other.Start), Count(other.Count) {
+      Array->incrementReaders();
+    }
+    
+    ~Snapshot() {
+      Array->decrementReaders();
+    }
+    
+    const ElemTy *begin() { return Start; }
+    const ElemTy *end() { return Start + Count; }
+    size_t count() { return Count; }
+  };
+  
   // This type cannot be safely copied, moved, or deleted.
   ConcurrentReadableArray(const ConcurrentReadableArray &) = delete;
   ConcurrentReadableArray(ConcurrentReadableArray &&) = delete;
@@ -485,28 +515,16 @@ public:
         storage->deallocate();
   }
   
-  /// Read the contents of the array. The parameter `f` is called with
-  /// two parameters: a pointer to the elements in the array, and the
-  /// count. This represents a snapshot of the contents at the time
-  /// `read` was called. The pointer becomes invalid after `f` returns.
-  template <class F> auto read(F f) -> decltype(f(nullptr, 0)) {
-    ReaderCount.fetch_add(1, std::memory_order_acquire);
+  Snapshot snapshot() {
+    incrementReaders();
     auto *storage = Elements.load(SWIFT_MEMORY_ORDER_CONSUME);
+    if (storage == nullptr) {
+      return Snapshot(this, nullptr, 0);
+    }
+    
     auto count = storage->Count.load(std::memory_order_acquire);
     const auto *ptr = storage->data();
-    
-    decltype(f(nullptr, 0)) result = f(ptr, count);
-    
-    ReaderCount.fetch_sub(1, std::memory_order_release);
-    
-    return result;
-  }
-  
-  /// Get the current count. It's just a snapshot and may be obsolete immediately.
-  size_t count() {
-    return read([](const ElemTy *ptr, size_t count) -> size_t {
-      return count;
-    });
+    return Snapshot(this, ptr, count);
   }
 };
 

--- a/stdlib/public/SwiftShims/RefCount.h
+++ b/stdlib/public/SwiftShims/RefCount.h
@@ -35,19 +35,10 @@ typedef InlineRefCountsPlaceholder InlineRefCounts;
 
 #include "llvm/Support/Compiler.h"
 #include "swift/Basic/type_traits.h"
+#include "swift/Runtime/Atomic.h"
 #include "swift/Runtime/Config.h"
 #include "swift/Runtime/Debug.h"
 
-// FIXME: Workaround for rdar://problem/18889711. 'Consume' does not require
-// a barrier on ARM64, but LLVM doesn't know that. Although 'relaxed'
-// is formally UB by C++11 language rules, we should be OK because neither
-// the processor model nor the optimizer can realistically reorder our uses
-// of 'consume'.
-#if __arm64__ || __arm__
-#  define SWIFT_MEMORY_ORDER_CONSUME (std::memory_order_relaxed)
-#else
-#  define SWIFT_MEMORY_ORDER_CONSUME (std::memory_order_consume)
-#endif
 
 /*
   An object conceptually has three refcounts. These refcounts 

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -23,7 +23,6 @@
 #include "swift/Runtime/Concurrent.h"
 #include "swift/Runtime/HeapObject.h"
 #include "swift/Runtime/Metadata.h"
-#include "swift/Runtime/Mutex.h"
 #include "swift/Strings.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Optional.h"
@@ -106,11 +105,9 @@ namespace {
 
 struct TypeMetadataPrivateState {
   ConcurrentMap<NominalTypeDescriptorCacheEntry> NominalCache;
-  std::vector<TypeMetadataSection> SectionsToScan;
-  Mutex SectionsToScanLock;
+  ConcurrentReadableArray<TypeMetadataSection> SectionsToScan;
 
   TypeMetadataPrivateState() {
-    SectionsToScan.reserve(16);
     initializeTypeMetadataRecordLookup();
   }
 
@@ -122,7 +119,6 @@ static void
 _registerTypeMetadataRecords(TypeMetadataPrivateState &T,
                              const TypeMetadataRecord *begin,
                              const TypeMetadataRecord *end) {
-  ScopedLock guard(T.SectionsToScanLock);
   T.SectionsToScan.push_back(TypeMetadataSection{begin, end});
 }
 
@@ -296,12 +292,9 @@ swift::_contextDescriptorMatchesMangling(const ContextDescriptor *context,
 
 // returns the nominal type descriptor for the type named by typeName
 static const TypeContextDescriptor *
-_searchTypeMetadataRecords(const TypeMetadataPrivateState &T,
+_searchTypeMetadataRecords(TypeMetadataPrivateState &T,
                            Demangle::NodePointer node) {
-  unsigned sectionIdx = 0;
-  unsigned endSectionIdx = T.SectionsToScan.size();
-  for (; sectionIdx < endSectionIdx; ++sectionIdx) {
-    auto &section = T.SectionsToScan[sectionIdx];
+  for (auto &section : T.SectionsToScan.snapshot()) {
     for (const auto &record : section) {
       if (auto ntd = record.getTypeContextDescriptor()) {
         if (_contextDescriptorMatchesMangling(ntd, node)) {
@@ -342,9 +335,7 @@ _findNominalTypeDescriptor(Demangle::NodePointer node,
     return Value->getDescription();
 
   // Check type metadata records
-  T.SectionsToScanLock.withLock([&] {
-    foundNominal = _searchTypeMetadataRecords(T, node);
-  });
+  foundNominal = _searchTypeMetadataRecords(T, node);
 
   // Check protocol conformances table. Note that this has no support for
   // resolving generic types yet.
@@ -395,11 +386,9 @@ namespace {
 
   struct ProtocolMetadataPrivateState {
     ConcurrentMap<ProtocolDescriptorCacheEntry> ProtocolCache;
-    std::vector<ProtocolSection> SectionsToScan;
-    Mutex SectionsToScanLock;
+    ConcurrentReadableArray<ProtocolSection> SectionsToScan;
 
     ProtocolMetadataPrivateState() {
-      SectionsToScan.reserve(16);
       initializeProtocolLookup();
     }
   };
@@ -411,7 +400,6 @@ static void
 _registerProtocols(ProtocolMetadataPrivateState &C,
                    const ProtocolRecord *begin,
                    const ProtocolRecord *end) {
-  ScopedLock guard(C.SectionsToScanLock);
   C.SectionsToScan.push_back(ProtocolSection{begin, end});
 }
 
@@ -439,12 +427,9 @@ void swift::swift_registerProtocols(const ProtocolRecord *begin,
 }
 
 static const ProtocolDescriptor *
-_searchProtocolRecords(const ProtocolMetadataPrivateState &C,
+_searchProtocolRecords(ProtocolMetadataPrivateState &C,
                        const llvm::StringRef protocolName){
-  unsigned sectionIdx = 0;
-  unsigned endSectionIdx = C.SectionsToScan.size();
-  for (; sectionIdx < endSectionIdx; ++sectionIdx) {
-    auto &section = C.SectionsToScan[sectionIdx];
+  for (auto &section : C.SectionsToScan.snapshot()) {
     for (const auto &record : section) {
       if (auto protocol = record.Protocol.getPointer()) {
         // Drop the "S$" prefix from the protocol record. It's not used in
@@ -472,9 +457,7 @@ _findProtocolDescriptor(llvm::StringRef mangledName) {
     return Value->getDescription();
 
   // Check type metadata records
-  T.SectionsToScanLock.withLock([&] {
-    foundProtocol = _searchProtocolRecords(T, mangledName);
-  });
+  foundProtocol = _searchProtocolRecords(T, mangledName);
 
   if (foundProtocol) {
     T.ProtocolCache.getOrInsert(mangledName, foundProtocol);
@@ -534,7 +517,7 @@ public:
   DynamicFieldSection(const FieldDescriptor **fields, size_t size)
       : Begin(fields), End(fields + size) {}
 
-  const FieldDescriptor **begin() { return Begin; }
+  const FieldDescriptor **begin() const { return Begin; }
 
   const FieldDescriptor **end() const { return End; }
 };
@@ -542,13 +525,10 @@ public:
 struct FieldCacheState {
   ConcurrentMap<FieldDescriptorCacheEntry> FieldCache;
 
-  Mutex SectionsLock;
-  std::vector<StaticFieldSection> StaticSections;
-  std::vector<DynamicFieldSection> DynamicSections;
+  ConcurrentReadableArray<StaticFieldSection> StaticSections;
+  ConcurrentReadableArray<DynamicFieldSection> DynamicSections;
 
   FieldCacheState() {
-    StaticSections.reserve(16);
-    DynamicSections.reserve(8);
     initializeTypeFieldLookup();
   }
 };
@@ -559,7 +539,6 @@ static Lazy<FieldCacheState> FieldCache;
 void swift::swift_registerFieldDescriptors(const FieldDescriptor **records,
                                            size_t size) {
   auto &cache = FieldCache.get();
-  ScopedLock guard(cache.SectionsLock);
   cache.DynamicSections.push_back({records, size});
 }
 
@@ -570,7 +549,6 @@ void swift::addImageTypeFieldDescriptorBlockCallback(const void *recordsBegin,
 
   // Field cache should always be sufficiently initialized by this point.
   auto &cache = FieldCache.unsafeGetAlreadyInitialized();
-  ScopedLock guard(cache.SectionsLock);
   cache.StaticSections.push_back({recordsBegin, recordsEnd});
 }
 
@@ -1216,16 +1194,15 @@ void swift::swift_getFieldAt(
     return;
   }
 
-  ScopedLock guard(cache.SectionsLock);
   // Otherwise let's try to find it in one of the sections.
-  for (auto &section : cache.DynamicSections) {
+  for (auto &section : cache.DynamicSections.snapshot()) {
     for (const auto *descriptor : section) {
       if (isRequestedDescriptor(*descriptor))
         return;
     }
   }
 
-  for (const auto &section : cache.StaticSections) {
+  for (const auto &section : cache.StaticSections.snapshot()) {
     for (auto &descriptor : section) {
       if (isRequestedDescriptor(descriptor))
         return;

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -326,7 +326,7 @@ void ConformanceState::verify() const {
   // Iterate over all of the sections and verify all of the protocol
   // descriptors.
   auto &Self = const_cast<ConformanceState &>(*this);
-  Self.SectionsToScan.read([](ConformanceSection *ptr, size_t count) -> char {
+  Self.SectionsToScan.read([](const ConformanceSection *ptr, size_t count) -> char {
     for (size_t i = 0; i < count; i++) {
       for (const auto &Record : ptr[i]) {
         Record.get()->verify();
@@ -548,7 +548,7 @@ swift_conformsToProtocolImpl(const Metadata * const type,
   // Prepare to scan conformance records.
   size_t scannedCount;
   auto returnNull = C.SectionsToScan
-    .read([&](ConformanceSection *ptr, size_t count) -> bool {
+    .read([&](const ConformanceSection *ptr, size_t count) -> bool {
     scannedCount = count;
     // Scan only sections that were not scanned yet.
     // If we found an out-of-date negative cache entry,
@@ -658,7 +658,7 @@ swift::_searchConformancesByMangledTypeName(Demangle::NodePointer node) {
   auto &C = Conformances.get();
 
   return C.SectionsToScan
-    .read([&](ConformanceSection *ptr, size_t count) -> const TypeContextDescriptor * {
+    .read([&](const ConformanceSection *ptr, size_t count) -> const TypeContextDescriptor * {
     for (size_t i = 0; i < count; i++) {
       auto &section = ptr[i];
       for (const auto &record : section) {

--- a/stdlib/public/runtime/ProtocolConformance.cpp
+++ b/stdlib/public/runtime/ProtocolConformance.cpp
@@ -21,7 +21,6 @@
 #include "swift/Runtime/Concurrent.h"
 #include "swift/Runtime/HeapObject.h"
 #include "swift/Runtime/Metadata.h"
-#include "swift/Runtime/Mutex.h"
 #include "swift/Runtime/Unreachable.h"
 #include "CompatibilityOverride.h"
 #include "ImageInspection.h"
@@ -228,12 +227,12 @@ namespace {
     const void *Type; 
     const ProtocolDescriptor *Proto;
     std::atomic<const WitnessTable *> Table;
-    std::atomic<uintptr_t> FailureGeneration;
+    std::atomic<size_t> FailureGeneration;
 
   public:
     ConformanceCacheEntry(ConformanceCacheKey key,
                           const WitnessTable *table,
-                          uintptr_t failureGeneration)
+                          size_t failureGeneration)
       : Type(key.Type), Proto(key.Proto), Table(table),
         FailureGeneration(failureGeneration) {
     }
@@ -261,7 +260,7 @@ namespace {
       Table.store(table, std::memory_order_release);
     }
 
-    void updateFailureGeneration(uintptr_t failureGeneration) {
+    void updateFailureGeneration(size_t failureGeneration) {
       assert(!isSuccessful());
       FailureGeneration.store(failureGeneration, std::memory_order_relaxed);
     }
@@ -272,8 +271,8 @@ namespace {
       return Table.load(std::memory_order_acquire);
     }
     
-    /// Get the generation number under which this lookup failed.
-    unsigned getFailureGeneration() const {
+    /// Get the generation in which this lookup failed.
+    size_t getFailureGeneration() const {
       assert(!isSuccessful());
       return FailureGeneration.load(std::memory_order_relaxed);
     }
@@ -283,18 +282,16 @@ namespace {
 // Conformance Cache.
 struct ConformanceState {
   ConcurrentMap<ConformanceCacheEntry> Cache;
-  std::vector<ConformanceSection> SectionsToScan;
-  Mutex SectionsToScanLock;
+  ConcurrentReadableArray<ConformanceSection> SectionsToScan;
   
   ConformanceState() {
-    SectionsToScan.reserve(16);
     initializeProtocolConformanceLookup();
   }
 
   void cacheSuccess(const void *type, const ProtocolDescriptor *proto,
                     const WitnessTable *witness) {
     auto result = Cache.getOrInsert(ConformanceCacheKey(type, proto),
-                                    witness, uintptr_t(0));
+                                    witness, 0);
 
     // If the entry was already present, we may need to update it.
     if (!result.second) {
@@ -302,8 +299,8 @@ struct ConformanceState {
     }
   }
 
-  void cacheFailure(const void *type, const ProtocolDescriptor *proto) {
-    uintptr_t failureGeneration = SectionsToScan.size();
+  void cacheFailure(const void *type, const ProtocolDescriptor *proto,
+                    size_t failureGeneration) {
     auto result = Cache.getOrInsert(ConformanceCacheKey(type, proto),
                                     (const WitnessTable *) nullptr,
                                     failureGeneration);
@@ -329,13 +326,14 @@ void ConformanceState::verify() const {
   // Iterate over all of the sections and verify all of the protocol
   // descriptors.
   auto &Self = const_cast<ConformanceState &>(*this);
-  ScopedLock guard(Self.SectionsToScanLock);
-
-  for (const auto &Section : SectionsToScan) {
-    for (const auto &Record : Section) {
-      Record.get()->verify();
+  Self.SectionsToScan.read([](ConformanceSection *ptr, size_t count) -> char {
+    for (size_t i = 0; i < count; i++) {
+      for (const auto &Record : ptr[i]) {
+        Record.get()->verify();
+      }
     }
-  }
+    return 0;
+  });
 }
 #endif
 
@@ -345,7 +343,6 @@ static void
 _registerProtocolConformances(ConformanceState &C,
                               const ProtocolConformanceRecord *begin,
                               const ProtocolConformanceRecord *end) {
-  ScopedLock guard(C.SectionsToScanLock);
   C.SectionsToScan.push_back(ConformanceSection{begin, end});
 }
 
@@ -448,9 +445,7 @@ recur:
       }
 
       // Check if the negative cache entry is up-to-date.
-      // FIXME: Using SectionsToScan.size() outside SectionsToScanLock
-      // is undefined.
-      if (Value->getFailureGeneration() == C.SectionsToScan.size()) {
+      if (Value->getFailureGeneration() == C.SectionsToScan.count()) {
         // Negative cache entry is up-to-date. Return failure along with
         // the original query type's own cache entry, if we found one.
         // (That entry may be out of date but the caller still has use for it.)
@@ -543,8 +538,6 @@ swift_conformsToProtocolImpl(const Metadata * const type,
 
   // See if we have a cached conformance. The ConcurrentMap data structure
   // allows us to insert and search the map concurrently without locking.
-  // We do lock the slow path because the SectionsToScan data structure is not
-  // concurrent.
   auto FoundConformance = searchInConformanceCache(type, protocol);
   // If the result (positive or negative) is authoritative, return it.
   if (FoundConformance.isAuthoritative)
@@ -552,133 +545,102 @@ swift_conformsToProtocolImpl(const Metadata * const type,
 
   auto failureEntry = FoundConformance.failureEntry;
 
-  // No up-to-date cache entry found.
-  // Acquire the lock so we can scan conformance records.
-  ScopedLock guard(C.SectionsToScanLock);
-
-  // The world may have changed while we waited for the lock.
-  // If we found an out-of-date negative cache entry before
-  // acquiring the lock, make sure the entry is still negative and out of date.
-  // If we found no entry before acquiring the lock, search the cache again.
-  if (failureEntry) {
-    if (failureEntry->isSuccessful()) {
-      // Somebody else found a conformance.
-      return failureEntry->getWitnessTable();
-    }
-    if (failureEntry->getFailureGeneration() == C.SectionsToScan.size()) {
-      // Somebody else brought the negative cache entry up to date.
-      return nullptr;
-    }
-  }
-  else {
-    FoundConformance = searchInConformanceCache(type, protocol);
-    if (FoundConformance.isAuthoritative) {
-      // Somebody else found a conformance or cached an up-to-date failure.
-      return FoundConformance.witnessTable;
-    }
-    failureEntry = FoundConformance.failureEntry;
-  }
-
-  // We are now caught up after acquiring the lock.
   // Prepare to scan conformance records.
-
-  // Scan only sections that were not scanned yet.
-  // If we found an out-of-date negative cache entry,
-  // we need not to re-scan the sections that it covers.
-  unsigned startSectionIdx =
-    failureEntry ? failureEntry->getFailureGeneration() : 0;
-
-  unsigned endSectionIdx = C.SectionsToScan.size();
-
-  // If there are no unscanned sections outstanding
-  // then we can cache failure and give up now.
-  if (startSectionIdx == endSectionIdx) {
-    C.cacheFailure(type, protocol);
-    return nullptr;
-  }
-
-  /// Local function to retrieve the witness table and record the result.
-  auto recordWitnessTable = [&](const ProtocolConformanceDescriptor &descriptor,
-                                const Metadata *type) {
-    switch (descriptor.getConformanceKind()) {
-    case ConformanceFlags::ConformanceKind::WitnessTable:
-      // If the record provides a nondependent witness table for all
-      // instances of a generic type, cache it for the generic pattern.
-      C.cacheSuccess(type, protocol, descriptor.getStaticWitnessTable());
-      return;
-
-    case ConformanceFlags::ConformanceKind::WitnessTableAccessor:
-      // If the record provides a dependent witness table accessor,
-      // cache the result for the instantiated type metadata.
-      C.cacheSuccess(type, protocol, descriptor.getWitnessTable(type));
-      return;
-
-    case ConformanceFlags::ConformanceKind::ConditionalWitnessTableAccessor: {
-      // Note: we might end up doing more scanning for other conformances
-      // when checking the conditional requirements, so do a gross unlock/lock.
-      // FIXME: Don't do this :)
-      C.SectionsToScanLock.unlock();
-      auto witnessTable = descriptor.getWitnessTable(type);
-      C.SectionsToScanLock.lock();
-      if (witnessTable)
-        C.cacheSuccess(type, protocol, witnessTable);
-      else
-        C.cacheFailure(type, protocol);
-      return;
-    }
+  size_t scannedCount;
+  auto returnNull = C.SectionsToScan
+    .read([&](ConformanceSection *ptr, size_t count) -> bool {
+    scannedCount = count;
+    // Scan only sections that were not scanned yet.
+    // If we found an out-of-date negative cache entry,
+    // we need not to re-scan the sections that it covers.
+    auto startIndex = failureEntry ? failureEntry->getFailureGeneration() : 0;
+    auto endIndex = count;
+  
+    // If there are no unscanned sections outstanding
+    // then we can cache failure and give up now.
+    if (startIndex == endIndex) {
+      C.cacheFailure(type, protocol, count);
+      return true;
     }
 
-    // Always fail, because we cannot interpret a future conformance
-    // kind.
-    C.cacheFailure(type, protocol);
-  };
+    /// Local function to retrieve the witness table and record the result.
+    auto recordWitnessTable = [&](const ProtocolConformanceDescriptor &descriptor,
+                                  const Metadata *type) {
+      switch (descriptor.getConformanceKind()) {
+      case ConformanceFlags::ConformanceKind::WitnessTable:
+        // If the record provides a nondependent witness table for all
+        // instances of a generic type, cache it for the generic pattern.
+        C.cacheSuccess(type, protocol, descriptor.getStaticWitnessTable());
+        return;
 
-  // Really scan conformance records.
+      case ConformanceFlags::ConformanceKind::WitnessTableAccessor:
+        // If the record provides a dependent witness table accessor,
+        // cache the result for the instantiated type metadata.
+        C.cacheSuccess(type, protocol, descriptor.getWitnessTable(type));
+        return;
 
-  for (unsigned sectionIdx = startSectionIdx;
-       sectionIdx < endSectionIdx;
-       ++sectionIdx) {
-    auto &section = C.SectionsToScan[sectionIdx];
-    // Eagerly pull records for nondependent witnesses into our cache.
-    for (const auto &record : section) {
-      auto &descriptor = *record.get();
+      case ConformanceFlags::ConformanceKind::ConditionalWitnessTableAccessor: {
+        auto witnessTable = descriptor.getWitnessTable(type);
+        if (witnessTable)
+          C.cacheSuccess(type, protocol, witnessTable);
+        else
+          C.cacheFailure(type, protocol, count);
+        return;
+      }
+      }
 
-      // If the record applies to a specific type, cache it.
-      if (auto metadata = descriptor.getCanonicalTypeMetadata()) {
-        auto P = descriptor.getProtocol();
+      // Always fail, because we cannot interpret a future conformance
+      // kind.
+      C.cacheFailure(type, protocol, count);
+    };
 
-        // Look for an exact match.
-        if (protocol != P)
-          continue;
+    // Really scan conformance records.
+    for (size_t i = startIndex; i < endIndex; i++) {
+      auto &section = ptr[i];
+      // Eagerly pull records for nondependent witnesses into our cache.
+      for (const auto &record : section) {
+        auto &descriptor = *record.get();
 
-        if (!isRelatedType(type, metadata, /*candidateIsMetadata=*/true))
-          continue;
+        // If the record applies to a specific type, cache it.
+        if (auto metadata = descriptor.getCanonicalTypeMetadata()) {
+          auto P = descriptor.getProtocol();
 
-        // Record the witness table.
-        recordWitnessTable(descriptor, metadata);
+          // Look for an exact match.
+          if (protocol != P)
+            continue;
 
-      // TODO: "Nondependent witness table" probably deserves its own flag.
-      // An accessor function might still be necessary even if the witness table
-      // can be shared.
-      } else if (descriptor.getTypeKind()
-                   == TypeMetadataRecordKind::DirectNominalTypeDescriptor ||
-                 descriptor.getTypeKind()
-                  == TypeMetadataRecordKind::IndirectNominalTypeDescriptor) {
-        auto R = descriptor.getTypeContextDescriptor();
-        auto P = descriptor.getProtocol();
+          if (!isRelatedType(type, metadata, /*candidateIsMetadata=*/true))
+            continue;
 
-        // Look for an exact match.
-        if (protocol != P)
-          continue;
+          // Record the witness table.
+          recordWitnessTable(descriptor, metadata);
 
-        if (!isRelatedType(type, R, /*candidateIsMetadata=*/false))
-          continue;
+        // TODO: "Nondependent witness table" probably deserves its own flag.
+        // An accessor function might still be necessary even if the witness table
+        // can be shared.
+        } else if (descriptor.getTypeKind()
+                     == TypeMetadataRecordKind::DirectNominalTypeDescriptor ||
+                   descriptor.getTypeKind()
+                    == TypeMetadataRecordKind::IndirectNominalTypeDescriptor) {
+          auto R = descriptor.getTypeContextDescriptor();
+          auto P = descriptor.getProtocol();
 
-        recordWitnessTable(descriptor, type);
+          // Look for an exact match.
+          if (protocol != P)
+            continue;
+
+          if (!isRelatedType(type, R, /*candidateIsMetadata=*/false))
+            continue;
+
+          recordWitnessTable(descriptor, type);
+        }
       }
     }
-  }
-
+    return false;
+  });
+  
+  if (returnNull) return nullptr;
+  
   // Conformance scan is complete.
   // Search the cache once more, and this time update the cache if necessary.
 
@@ -686,7 +648,7 @@ swift_conformsToProtocolImpl(const Metadata * const type,
   if (FoundConformance.isAuthoritative) {
     return FoundConformance.witnessTable;
   } else {
-    C.cacheFailure(type, protocol);
+    C.cacheFailure(type, protocol, scannedCount);
     return nullptr;
   }
 }
@@ -695,22 +657,19 @@ const TypeContextDescriptor *
 swift::_searchConformancesByMangledTypeName(Demangle::NodePointer node) {
   auto &C = Conformances.get();
 
-  ScopedLock guard(C.SectionsToScanLock);
-
-  unsigned sectionIdx = 0;
-  unsigned endSectionIdx = C.SectionsToScan.size();
-
-  for (; sectionIdx < endSectionIdx; ++sectionIdx) {
-    auto &section = C.SectionsToScan[sectionIdx];
-    for (const auto &record : section) {
-      if (auto ntd = record->getTypeContextDescriptor()) {
-        if (_contextDescriptorMatchesMangling(ntd, node))
-          return ntd;
+  return C.SectionsToScan
+    .read([&](ConformanceSection *ptr, size_t count) -> const TypeContextDescriptor * {
+    for (size_t i = 0; i < count; i++) {
+      auto &section = ptr[i];
+      for (const auto &record : section) {
+        if (auto ntd = record->getTypeContextDescriptor()) {
+          if (_contextDescriptorMatchesMangling(ntd, node))
+            return ntd;
+        }
       }
     }
-  }
-
-  return nullptr;
+    return nullptr;
+  });
 }
 
 /// Resolve a reference to a generic parameter to type metadata.

--- a/unittests/runtime/CMakeLists.txt
+++ b/unittests/runtime/CMakeLists.txt
@@ -34,6 +34,7 @@ if(("${SWIFT_HOST_VARIANT_SDK}" STREQUAL "${SWIFT_PRIMARY_VARIANT_SDK}") AND
   add_swift_unittest(SwiftRuntimeTests
     Array.cpp
     CompatibilityOverride.cpp
+    Concurrent.cpp
     Exclusivity.cpp
     Metadata.cpp
     Mutex.cpp

--- a/unittests/runtime/Concurrent.cpp
+++ b/unittests/runtime/Concurrent.cpp
@@ -1,0 +1,44 @@
+//===--- Concurrent.cpp - Concurrent data structure tests -----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#include "swift/Runtime/Concurrent.h"
+#include "gtest/gtest.h"
+
+using namespace swift;
+
+TEST(ConcurrentReadableArrayTest, SingleThreaded) {
+  ConcurrentReadableArray<size_t> array;
+  
+  auto add = [&](size_t limit) {
+    for (size_t i = array.snapshot().count(); i < limit; i++)
+      array.push_back(i);
+  };
+  auto check = [&]{
+    size_t i = 0;
+    for (auto element : array.snapshot()) {
+      ASSERT_EQ(element, i);
+      i++;
+    }
+  };
+  
+  check();
+  add(1);
+  check();
+  add(16);
+  check();
+  add(100);
+  check();
+  add(1000);
+  check();
+  add(1000000);
+  check();
+}


### PR DESCRIPTION
Cherry-pick #16753 into 4.2.

This fixes a potential deadlock due to dyld calling Swift with a lock held and vice versa.

rdar://problem/40230581