### PR TITLE
[master-next] update some IRGen tests with memcpy calls

### DIFF
--- a/test/IRGen/existentials_objc.sil
+++ b/test/IRGen/existentials_objc.sil
@@ -45,7 +45,7 @@ bb0(%0 : $*Any, %1 : $*Any):
 // CHECK-DAG:   define linkonce_odr hidden %Any* @"$SypWOb"(%Any*, %Any*)
 // CHECK:       %2 = bitcast %Any* %1 to i8*
 // CHECK-NEXT:  %3 = bitcast %Any* %0 to i8*
-// CHECK-NEXT:  call void @llvm.memcpy.p0i8.p0i8.i64(i8* %2, i8* %3, i64 32, i32 8, i1 false)
+// CHECK-NEXT:  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 8 %2, i8* align 8 %3, i64 32, i1 false)
 // CHECK-NEXT:  ret %Any* %1
 
 // rdar://problem/19035529

--- a/test/IRGen/existentials_opaque_boxed.sil
+++ b/test/IRGen/existentials_opaque_boxed.sil
@@ -446,7 +446,7 @@ bb0(%0 : $*Existential):
 // CHECK-LABEL: define linkonce_odr hidden %T25existentials_opaque_boxed11ExistentialP* @"$S25existentials_opaque_boxed11Existential_pWOb"(%T25existentials_opaque_boxed11ExistentialP*, %T25existentials_opaque_boxed11ExistentialP*)
 // CHECK:  %2 = bitcast %T25existentials_opaque_boxed11ExistentialP* %1 to i8*
 // CHECK:  %3 = bitcast %T25existentials_opaque_boxed11ExistentialP* %0 to i8*
-// CHECK:  call void @llvm.memcpy.p0i8.p0i8.{{(i64|i32)}}(i8* %2, i8* %3, {{(i64 40|i32 20)}}, {{(i32 8|i32 4)}}, i1 false)
+// CHECK:  call void @llvm.memcpy.p0i8.p0i8.{{(i64|i32)}}(i8* align {{(8|4)}} %2, i8* align {{(8|4)}} %3, {{(i64 40|i32 20)}}, i1 false)
 // CHECK:  ret %T25existentials_opaque_boxed11ExistentialP* %1
 
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc void @test_initWithTake_existential_addr(%T25existentials_opaque_boxed11ExistentialP*


### PR DESCRIPTION
Arnold's change for SR-343 (6267860a7ed) added some IRGen tests that use
the old memcpy style where the alignment is specified as a separate argument.
More recent versions of LLVM specify the alignment as part of the source
and destination arguments. Update the tests for master-next to expect the
new style of memcpy calls.