### PR TITLE
[4.2] [ConstraintSystem] Attempt to select disjunctions that split constraint systems.

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1802,15 +1802,89 @@ static bool shouldSkipDisjunctionChoice(ConstraintSystem &cs,
   return false;
 }
 
+// Attempt to find a disjunction of bind constraints where all options
+// in the disjunction are binding the same type variable, and where
+// that type variable appears as the right hand side of a conversion
+// constraint.
+//
+// Trying these bindings early can make it possible to split the
+// constraint system into multiple ones.
+static Constraint *selectDisjunctionBindingConversionResultType(
+    ConstraintSystem &cs, SmallVectorImpl<Constraint *> &disjunctions) {
+
+  // Collect any disjunctions that simply attempt bindings for a
+  // type variable.
+  SmallVector<Constraint *, 8> bindingDisjunctions;
+  for (auto *disjunction : disjunctions) {
+    llvm::Optional<TypeVariableType *> commonTypeVariable;
+    if (llvm::all_of(
+            disjunction->getNestedConstraints(),
+            [&](Constraint *bindingConstraint) {
+              if (bindingConstraint->getKind() != ConstraintKind::Bind)
+                return false;
+
+              auto *tv =
+                  bindingConstraint->getFirstType()->getAs<TypeVariableType>();
+              // Only do this for simple type variable bindings, not for
+              // bindings like: ($T1) -> $T2 bind String -> Int
+              if (!tv)
+                return false;
+
+              if (!commonTypeVariable.hasValue())
+                commonTypeVariable = tv;
+
+              if (commonTypeVariable.getValue() != tv)
+                return false;
+
+              return true;
+            })) {
+      bindingDisjunctions.push_back(disjunction);
+    }
+  }
+
+  for (auto *disjunction : bindingDisjunctions) {
+    auto nested = disjunction->getNestedConstraints();
+    assert(!nested.empty());
+    auto *tv = cs.simplifyType(nested[0]->getFirstType())
+                   ->getRValueType()
+                   ->getAs<TypeVariableType>();
+    assert(tv);
+
+    SmallVector<Constraint *, 8> constraints;
+    cs.getConstraintGraph().gatherConstraints(
+        tv, constraints, ConstraintGraph::GatheringKind::EquivalenceClass);
+
+    for (auto *constraint : constraints) {
+      if (constraint->getKind() != ConstraintKind::Conversion)
+        continue;
+
+      auto toType =
+          cs.simplifyType(constraint->getSecondType())->getRValueType();
+      auto *toTV = toType->getAs<TypeVariableType>();
+      if (tv != toTV)
+        continue;
+
+      return disjunction;
+    }
+  }
+
+  return nullptr;
+}
+
 Constraint *ConstraintSystem::selectDisjunction(
     SmallVectorImpl<Constraint *> &disjunctions) {
   if (disjunctions.empty())
     return nullptr;
 
+  auto *disjunction =
+      selectDisjunctionBindingConversionResultType(*this, disjunctions);
+  if (disjunction)
+    return disjunction;
+
   // Pick the smallest disjunction.
   // FIXME: This heuristic isn't great, but it helped somewhat for
   // overload sets.
-  auto disjunction = disjunctions[0];
+  disjunction = disjunctions[0];
   auto bestSize = disjunction->countActiveNestedConstraints();
   if (bestSize > 2) {
     for (auto contender : llvm::makeArrayRef(disjunctions).slice(1)) {

--- a/validation-test/Sema/type_checker_perf/fast/rdar40344044.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/fast/rdar40344044.swift.gyb
@@ -1,4 +1,4 @@
-// RUN: %scale-test --invert-result --begin 3 --end 8  --step 1 --select incrementScopeCounter %s
+// RUN: %scale-test --begin 3 --end 20  --step 1 --select incrementScopeCounter %s
 // REQUIRES: OS=macosx
 // REQUIRES: asserts
 

--- a/validation-test/Sema/type_checker_perf/slow/rdar40344044.swift.gyb
+++ b/validation-test/Sema/type_checker_perf/slow/rdar40344044.swift.gyb
@@ -1,0 +1,23 @@
+// RUN: %scale-test --invert-result --begin 3 --end 8  --step 1 --select incrementScopeCounter %s
+// REQUIRES: OS=macosx
+// REQUIRES: asserts
+
+protocol P {}
+class C : P {}
+class D : P {}
+
+class Test {
+  let c: C! = C()
+  let d: D! = D()
+  var a: [P]! = []
+
+  func test() {
+    a = [
+      c,
+%for i in range(0, N):
+      c,
+%end
+      d
+    ]
+  }
+}


### PR DESCRIPTION
When selecting the next disjunction to attempt, try to find one that
is a disjunction of bindings where the type being bound is the
converted-to type in a conversion constraint. Attempting these early
makes it possible to split constraint systems, eliminating exponential
behavior.

Fixes: rdar://problem/40344044
(cherry picked from commit b92649a)