### PR TITLE
[Runtime] 4.2 - Include <vector> in Concurrent.h, since it uses std::vector.

### DIFF
--- a/include/swift/Runtime/Concurrent.h
+++ b/include/swift/Runtime/Concurrent.h
@@ -16,6 +16,7 @@
 #include <atomic>
 #include <functional>
 #include <stdint.h>
+#include <vector>
 #include "llvm/Support/Allocator.h"
 #include "Atomic.h"
 #include "Debug.h"


### PR DESCRIPTION
Cherry-pick #16658 back to 4.2.

rdar://problem/37173156