### PR TITLE
[Amendments][#16431] Note emitting amendment & use generic note

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -84,8 +84,6 @@ ERROR(could_not_find_subscript_member_did_you_mean,none,
       "value of type %0 has no property or method named 'subscript'; "
       "did you mean to use the subscript operator?",
       (Type))
-NOTE(subscript_declared_here,none,
-      "declared here", ())
 
 ERROR(could_not_find_enum_case,none,
       "enum type %0 has no case %1; did you mean %2", (Type, DeclName, DeclName))

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -5546,9 +5546,16 @@ bool FailureDiagnosis::diagnoseSubscriptMisuse(ApplyExpr *callExpr) {
                        baseType);
   diag.highlight(memberRange).highlight(nameLoc.getSourceRange());
 
-  if (candidateInfo.closeness != CC_ExactMatch)
+  auto showNote = [&]() {
+    diag.flush();
+    if (candidateInfo.size() == 1)
+      diagnose(candidateInfo.candidates.front().getDecl(),
+               diag::kind_declared_here, DescriptiveDeclKind::Subscript);
+  };
+  if (candidateInfo.closeness != CC_ExactMatch) {
+    showNote();
     return true;
-
+  }
   auto toCharSourceRange = Lexer::getCharSourceRangeFromSourceRange;
   auto lastArgSymbol = toCharSourceRange(CS.TC.Context.SourceMgr,
                                          argExpr->getEndLoc());
@@ -5564,11 +5571,7 @@ bool FailureDiagnosis::diagnoseSubscriptMisuse(ApplyExpr *callExpr) {
   else
     diag.fixItInsertAfter(argExpr->getEndLoc(),
                           getTokenText(tok::r_square));
-  diag.flush();
-
-  if (candidateInfo.size() == 1)
-    diagnose(candidateInfo.candidates.front().getDecl(),
-             diag::subscript_declared_here);
+  showNote();
 
   return true;
 }


### PR DESCRIPTION
Show the note always if there is a single candidate.
Switch to using the generic `declared here` note [#16766](https://github.com/apple/swift/pull/16766)

/cc @xedin 