### PR TITLE
[NFC] Drop mutability from parameter context changes

### DIFF
--- a/include/swift/AST/Initializer.h
+++ b/include/swift/AST/Initializer.h
@@ -162,7 +162,7 @@ public:
   /// Change the parent of this context.  This is necessary because
   /// the function signature is parsed before the function
   /// declaration/expression itself is built.
-  void changeFunction(DeclContext *parent, MutableArrayRef<ParameterList *> paramLists);
+  void changeFunction(DeclContext *parent, ArrayRef<ParameterList *> paramLists);
 
   static bool classof(const DeclContext *DC) {
     if (auto init = dyn_cast<Initializer>(DC))

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1025,7 +1025,7 @@ public:
 
     /// Set the parsed context for all the initializers to the given
     /// function.
-    void setFunctionContext(DeclContext *DC, MutableArrayRef<ParameterList *> paramList);
+    void setFunctionContext(DeclContext *DC, ArrayRef<ParameterList *> paramList);
     
     DefaultArgumentInfo(bool inTypeContext) {
       NextIndex = inTypeContext ? 1 : 0;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -4554,7 +4554,7 @@ void ParamDecl::setDefaultArgumentInitContext(Initializer *initContext) {
 }
 
 void DefaultArgumentInitializer::changeFunction(
-    DeclContext *parent, MutableArrayRef<ParameterList *> paramLists) {
+    DeclContext *parent, ArrayRef<ParameterList *> paramLists) {
   if (parent->isLocalContext()) {
     setParent(parent);
   }

--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -57,7 +57,7 @@ static DefaultArgumentKind getDefaultArgKind(Expr *init) {
 }
 
 void Parser::DefaultArgumentInfo::setFunctionContext(
-    DeclContext *DC, MutableArrayRef<ParameterList *> paramList){
+    DeclContext *DC, ArrayRef<ParameterList *> paramList){
   for (auto context : ParsedContexts) {
     context->changeFunction(DC, paramList);
   }


### PR DESCRIPTION
Refactoring in this area means we no longer mutate the array, just call non-const members on the elements.

Noticed this while cleaning up #15418.