### PR TITLE
[IRGen] Do not use ObjC tagged-pointer logic on non-ObjC platforms

### DIFF
--- a/lib/IRGen/ExtraInhabitants.cpp
+++ b/lib/IRGen/ExtraInhabitants.cpp
@@ -24,6 +24,9 @@ using namespace swift;
 using namespace irgen;
 
 static unsigned getNumLowObjCReservedBits(IRGenModule &IGM) {
+  if (!IGM.ObjCInterop)
+    return 0;
+
   // Get the index of the first non-reserved bit.
   SpareBitVector ObjCMask = IGM.TargetInfo.ObjCPointerReservedBits;
   ObjCMask.flipAll();

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -1,5 +1,7 @@
-// Please put -enable-objc-interop tests in enum_objc.sil
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -gnone -emit-ir -disable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-runtime-%target-ptrsize
+// #if directives don't work with SIL keywords, therefore please put ObjC tests
+// in `enum_objc.sil`.
+
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -gnone -emit-ir -disable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 
@@ -1120,8 +1122,8 @@ enum SinglePayloadClass {
 // CHECK-64: entry:
 // CHECK-64:   switch i64 %0, label {{%.*}} [
 // CHECK-64:     i64 0, label {{%.*}}
-// CHECK-64:     i64 2, label {{%.*}}
-// CHECK-64:     i64 4, label {{%.*}}
+// CHECK-64:   i64 1, label {{%.*}}
+// CHECK-64:   i64 2, label {{%.*}}
 // CHECK-64:   ]
 // CHECK-64: ; <label>
 // CHECK-64:   inttoptr [[WORD]] %0 to %T4enum1CC*
@@ -1163,8 +1165,8 @@ enum SinglePayloadClassProtocol {
 // CHECK-64: define{{( dllexport)?}}{{( protected)?}} swiftcc void @single_payload_class_protocol_switch(i64, i64) {{.*}} {
 // CHECK-64:   switch i64 %0, label {{%.*}} [
 // CHECK-64:     i64 0, label {{%.*}}
+// CHECK-64:     i64 1, label {{%.*}}
 // CHECK-64:     i64 2, label {{%.*}}
-// CHECK-64:     i64 4, label {{%.*}}
 // CHECK-64:   ]
 
 // CHECK-64:   inttoptr i64 %0 to %swift.refcounted*
@@ -2437,7 +2439,7 @@ entry(%0 : $DynamicSingleton<NoPayloads>):
 // Check that payloads get properly masked in nested single-payload enums.
 // rdar://problem/18841262
 // CHECK-64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @optional_optional_class_protocol(i64, i64)
-// CHECK-64:         icmp eq i64 %0, 2
+// CHECK-64:       icmp eq i64 %0, 1
 // CHECK-32-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc i1 @optional_optional_class_protocol(i32, i32)
 // CHECK-32:         icmp eq i32 %0, 1
 enum Optionable<T> {
@@ -2458,7 +2460,7 @@ struct ContainsUnownedObjC {
   unowned let x: C
 }
 // CHECK-LABEL: define {{.*}} @optional_unowned() {{.*}} {
-// CHECK-64:   ret { [[WORD]], [[WORD]] } { [[WORD]] 0, [[WORD]] 2 }
+// CHECK-64: ret { [[WORD]], [[WORD]] } { [[WORD]] 0, [[WORD]] 1 }
 // CHECK-32:   ret { [[WORD]], [[WORD]] } { [[WORD]] 0, [[WORD]] 1 }
 sil @optional_unowned : $@convention(thin) () -> (Optionable<ContainsUnowned>, Optionable<Optionable<ContainsUnowned>>) {
 entry:
@@ -2468,7 +2470,7 @@ entry:
   return %t : $(Optionable<ContainsUnowned>, Optionable<Optionable<ContainsUnowned>>)
 }
 // CHECK-LABEL: define {{.*}} @optional_unowned_objc() {{.*}} {
-// CHECK-64:    ret { [[WORD]], [[WORD]] } { [[WORD]] 0, [[WORD]] 2 }
+// CHECK-64:  ret { [[WORD]], [[WORD]] } { [[WORD]] 0, [[WORD]] 1 }
 // CHECK-32:    ret { [[WORD]], [[WORD]] } { [[WORD]] 0, [[WORD]] 1 }
 sil @optional_unowned_objc : $@convention(thin) () -> (Optionable<ContainsUnownedObjC>, Optionable<Optionable<ContainsUnownedObjC>>) {
 entry:

--- a/test/IRGen/enum_objc.sil
+++ b/test/IRGen/enum_objc.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -gnone -emit-ir -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-%target-runtime-%target-ptrsize
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -gnone -emit-ir -disable-objc-attr-requires-foundation-module -enable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 // REQUIRES: CPU=i386 || CPU=x86_64
 

--- a/test/IRGen/enum_value_semantics.sil
+++ b/test/IRGen/enum_value_semantics.sil
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -gnone -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -gnone -emit-ir -enable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-objc --check-prefix=CHECK-objc-%target-ptrsize --check-prefix=CHECK-%target-os --check-prefix=CHECK-objc-%target-os
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -gnone -emit-ir -disable-objc-interop | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize --check-prefix=CHECK-native --check-prefix=CHECK-native-%target-ptrsize --check-prefix=CHECK-%target-os --check-prefix=CHECK-native-%target-os
 
 // REQUIRES: CPU=x86_64
 
@@ -134,9 +135,16 @@ enum GenericFixedLayout<T> {
 // --                         0x250007
 // CHECK:   i8* inttoptr (i64 2424839 to i8*),
 // CHECK:   i8* inttoptr (i64 8 to i8*),
-// --                         on Darwin, first 4GB are unmapped: 0x7ffffffc
-// --                         on Linux, only safe to assume first 4KB: 0x7fd
-// CHECK:   i8* inttoptr (i64 {{2045|2147483644}} to i8*)
+// -- On Darwin, the first 4 GiB are unmapped: 0x7ffffffc
+// -- Otherwise, one can only assume the first page (4 KiB) is unmapped: 0xffd
+// CHECK-ios:       i8* inttoptr (i64 2147483644 to i8*)
+// CHECK-macosx:    i8* inttoptr (i64 2147483644 to i8*)
+// CHECK-watchos:   i8* inttoptr (i64 2147483644 to i8*)
+// CHECK-darwin:    i8* inttoptr (i64 2147483644 to i8*)
+// CHECK-objc-linux-gnu:   i8* inttoptr (i64 2045 to i8*)
+// CHECK-native-linux-gnu: i8* inttoptr (i64 4093 to i8*)
+// CHECK-objc-windows:     i8* inttoptr (i64 2045 to i8*)
+// CHECK-native-windows:   i8* inttoptr (i64 4093 to i8*)
 // CHECK:   i8* bitcast (void (%swift.opaque*, i32, %swift.type*)* @"$S20enum_value_semantics23SinglePayloadNontrivialOwxs" to i8*)
 // CHECK:   i8* bitcast (i32 (%swift.opaque*, %swift.type*)* @"$S20enum_value_semantics23SinglePayloadNontrivialOwxg" to i8*)
 // CHECK:   i8* bitcast (i32 (%swift.opaque*, %swift.type*)* @"$S20enum_value_semantics23SinglePayloadNontrivialOwug" to i8*),
@@ -277,8 +285,10 @@ bb0(%0 : $SinglePayloadNontrivial):
 // CHECK-NEXT: [[PAYLOAD:%.*]] = load i64, i64* [[PAYLOAD_ADDR]], align 8
 // CHECK-NEXT: switch i64 %2, label %[[RELEASE_PAYLOAD:[0-9]+]] [
 // CHECK:        i64 0, label %[[DONE:[0-9]+]]
-// CHECK:        i64 2, label %[[DONE]]
-// CHECK:        i64 4, label %[[DONE]]
+// CHECK-native:      i64 1, label %[[DONE]]
+// CHECK-native:      i64 2, label %[[DONE]]
+// CHECK-objc:        i64 2, label %[[DONE]]
+// CHECK-objc:        i64 4, label %[[DONE]]
 // CHECK:      ]
 
 // CHECK:      ; <label>:[[RELEASE_PAYLOAD]]

--- a/test/IRGen/enum_value_semantics_special_cases.sil
+++ b/test/IRGen/enum_value_semantics_special_cases.sil
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-runtime
 
 // REQUIRES: CPU=x86_64
 
@@ -134,7 +134,8 @@ enum MultipleEmptyRefcounted {
 // CHECK:   %2 = load i64, i64* %1, align 8
 // CHECK:   switch i64 %2, label %3 [
 // CHECK:     i64 0, label %5
-// CHECK:     i64 2, label %5
+// CHECK-native:   i64 1, label %5
+// CHECK-objc:     i64 2, label %5
 // CHECK:   ]
 // CHECK: ; <label>:3:                                      ; preds = %entry
 // CHECK:   %4 = bitcast %T34enum_value_semantics_special_cases23MultipleEmptyRefcountedO* %0 to %swift.refcounted**


### PR DESCRIPTION
Something to squeeze in before the ABI freeze (I hope).