### PR TITLE
[func-sig-opts] Add a regression benchmark that shows overhead from +…

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -45,6 +45,7 @@ set(SWIFT_BENCH_MODULES
     single-source/BitCount
     single-source/ByteSwap
     single-source/COWTree
+    single-source/COWArrayGuaranteedParameterOverhead
     single-source/CString
     single-source/CSVParsing
     single-source/Calculator

--- a/benchmark/single-source/COWArrayGuaranteedParameterOverhead.swift
+++ b/benchmark/single-source/COWArrayGuaranteedParameterOverhead.swift
@@ -1,0 +1,42 @@
+//===--- COWArrayGuaranteedParameterOverhead.swift ------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import TestsUtils
+
+// This test makes sure that even though we have +0 arguments by default that we
+// can properly convert +0 -> +1 to avoid extra COW copies.
+
+public let COWArrayGuaranteedParameterOverhead = BenchmarkInfo(
+  name: "COWArrayGuaranteedParameterOverhead",
+  runFunction: run_COWArrayGuaranteedParameterOverhead,
+  tags: [.regression, .abstraction, .refcount])
+
+@inline(never)
+func caller() {
+  let x = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
+  blackHole(callee(x))
+}
+
+@inline(never)
+func callee(_ x: [Int]) -> [Int] {
+  var y = x
+  // This should not copy.
+  y[2] = 27
+  return y
+}
+
+@inline(never)
+public func run_COWArrayGuaranteedParameterOverhead(_ N: Int) {
+  for _ in 0..<N*20000 {
+    caller()
+  }
+}

--- a/benchmark/utils/main.swift
+++ b/benchmark/utils/main.swift
@@ -32,6 +32,7 @@ import BinaryFloatingPointProperties
 import BitCount
 import ByteSwap
 import COWTree
+import COWArrayGuaranteedParameterOverhead
 import CString
 import CSVParsing
 import Calculator
@@ -184,6 +185,7 @@ registerBenchmark(BinaryFloatingPointPropertiesUlp)
 registerBenchmark(BitCount)
 registerBenchmark(ByteSwap)
 registerBenchmark(COWTree)
+registerBenchmark(COWArrayGuaranteedParameterOverhead)
 registerBenchmark(CString)
 registerBenchmark(CSVParsing)
 registerBenchmark(CSVParsingAlt)


### PR DESCRIPTION
…1->+0 without a corresponding +0->+1 optimization.

rdar://38196046
