### PR TITLE
 [Refactoring] Disallow several kinds of decl to move to extension

### DIFF
--- a/lib/AST/DeclContext.cpp
+++ b/lib/AST/DeclContext.cpp
@@ -296,23 +296,6 @@ DeclContext *DeclContext::getParentForLookup() const {
   return getParent();
 }
 
-DeclContext *DeclContext::getCommonParentContext(DeclContext *A,
-                                                 DeclContext *B) {
-  if (A == B)
-    return A;
-
-  if (A->isChildContextOf(B))
-    return B;
-
-  // Peel away layers of A until we reach a common parent
-  for (DeclContext *CurDC = A; CurDC; CurDC = CurDC->getParent()) {
-    if (B->isChildContextOf(CurDC))
-      return CurDC;
-  }
-
-  return nullptr;
-}
-
 ModuleDecl *DeclContext::getParentModule() const {
   const DeclContext *DC = this;
   while (!DC->isModuleContext())

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -1521,36 +1521,24 @@ bool RefactoringActionExtractRepeatedExpr::performChange() {
                                           EditConsumer).performChange();
 }
 
-// Compute a decl context that is the parent context for all decls in
-// \c DeclaredDecls. Return \c nullptr if no such context exists.
-DeclContext *getCommonDeclContext(ArrayRef<DeclaredDecl> DeclaredDecls) {
-  if (DeclaredDecls.empty())
-    return nullptr;
-
-  DeclContext *CommonDC = DeclaredDecls.front().VD->getDeclContext();
-  for (auto DD : DeclaredDecls) {
-    auto OtherDC = DD.VD->getDeclContext();
-    CommonDC = DeclContext::getCommonParentContext(CommonDC, OtherDC);
-  }
-  return CommonDC;
-}
 
 bool RefactoringActionMoveMembersToExtension::isApplicable(
     ResolvedRangeInfo Info, DiagnosticEngine &Diag) {
   switch (Info.Kind) {
   case RangeKind::SingleDecl:
   case RangeKind::MultiTypeMemberDecl: {
-    DeclContext *CommonDC = getCommonDeclContext(Info.DeclaredDecls);
+    DeclContext *DC = Info.RangeContext;
 
     // The the common decl context is not a nomial type, we cannot create an
     // extension for it
-    if (!CommonDC || !CommonDC->getInnermostDeclarationDeclContext() ||
-        !isa<NominalTypeDecl>(CommonDC->getInnermostDeclarationDeclContext()))
+    if (!DC || !DC->getInnermostDeclarationDeclContext() ||
+        !isa<NominalTypeDecl>(DC->getInnermostDeclarationDeclContext()))
       return false;
+
 
     // Members of types not declared at top file level cannot be extracted
     // to an extension at top file level
-    if (CommonDC->getParent()->getContextKind() != DeclContextKind::FileUnit)
+    if (DC->getParent()->getContextKind() != DeclContextKind::FileUnit)
       return false;
 
     // Check if contained nodes are all allowed decls.
@@ -1570,7 +1558,7 @@ bool RefactoringActionMoveMembersToExtension::isApplicable(
       if (auto ASD = dyn_cast<AbstractStorageDecl>(DD.VD)) {
         // Only disallow storages in the common decl context, allow them in
         // any subtypes
-        if (ASD->hasStorage() && ASD->getDeclContext() == CommonDC) {
+        if (ASD->hasStorage() && ASD->getDeclContext() == DC) {
           return false;
         }
       }
@@ -1588,10 +1576,10 @@ bool RefactoringActionMoveMembersToExtension::isApplicable(
 }
 
 bool RefactoringActionMoveMembersToExtension::performChange() {
-  DeclContext *CommonDC = getCommonDeclContext(RangeInfo.DeclaredDecls);
+  DeclContext *DC = RangeInfo.RangeContext;
 
   auto CommonTypeDecl =
-      dyn_cast<NominalTypeDecl>(CommonDC->getInnermostDeclarationDeclContext());
+      dyn_cast<NominalTypeDecl>(DC->getInnermostDeclarationDeclContext());
   assert(CommonTypeDecl && "Not applicable if common parent is no nomial type");
 
   SmallString<64> Buffer;

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -1553,6 +1553,17 @@ bool RefactoringActionMoveMembersToExtension::isApplicable(
     if (CommonDC->getParent()->getContextKind() != DeclContextKind::FileUnit)
       return false;
 
+    // Check if contained nodes are all allowed decls.
+    for (auto Node : Info.ContainedNodes) {
+      Decl *D = Node.dyn_cast<Decl*>();
+      if (!D)
+        return false;
+
+      if (isa<AccessorDecl>(D) || isa<DestructorDecl>(D) ||
+          isa<EnumCaseDecl>(D) || isa<EnumElementDecl>(D))
+        return false;
+    }
+
     // We should not move instance variables with storage into the extension
     // because they are not allowed to be declared there
     for (auto DD : Info.DeclaredDecls) {

--- a/test/refactoring/MoveMembersToExtension/Outputs/L2-5.swift.expected
+++ b/test/refactoring/MoveMembersToExtension/Outputs/L2-5.swift.expected
@@ -28,5 +28,17 @@ class OtherClass {
   var computedVariable: Int {
     return 0
   }
+
+  var computedVariable2: Int {
+    get { return 0 }
+    set { }
+  }
+
+  deinit { print("deinit") }
+}
+
+enum MyEnum {
+  case foo, bar
+  case baz
 }
 

--- a/test/refactoring/MoveMembersToExtension/Outputs/L24-27.swift.expected
+++ b/test/refactoring/MoveMembersToExtension/Outputs/L24-27.swift.expected
@@ -22,11 +22,23 @@ class OtherClass {
   }
 
   
+
+  var computedVariable2: Int {
+    get { return 0 }
+    set { }
+  }
+
+  deinit { print("deinit") }
 }
 
 extension OtherClass {
 var computedVariable: Int {
     return 0
   }
+}
+
+enum MyEnum {
+  case foo, bar
+  case baz
 }
 

--- a/test/refactoring/MoveMembersToExtension/Outputs/L3-13.swift.expected
+++ b/test/refactoring/MoveMembersToExtension/Outputs/L3-13.swift.expected
@@ -28,5 +28,17 @@ class OtherClass {
   var computedVariable: Int {
     return 0
   }
+
+  var computedVariable2: Int {
+    get { return 0 }
+    set { }
+  }
+
+  deinit { print("deinit") }
+}
+
+enum MyEnum {
+  case foo, bar
+  case baz
 }
 

--- a/test/refactoring/MoveMembersToExtension/Outputs/L3-5.swift.expected
+++ b/test/refactoring/MoveMembersToExtension/Outputs/L3-5.swift.expected
@@ -28,5 +28,17 @@ class OtherClass {
   var computedVariable: Int {
     return 0
   }
+
+  var computedVariable2: Int {
+    get { return 0 }
+    set { }
+  }
+
+  deinit { print("deinit") }
+}
+
+enum MyEnum {
+  case foo, bar
+  case baz
 }
 

--- a/test/refactoring/MoveMembersToExtension/Outputs/L6-8.swift.expected
+++ b/test/refactoring/MoveMembersToExtension/Outputs/L6-8.swift.expected
@@ -28,5 +28,17 @@ class OtherClass {
   var computedVariable: Int {
     return 0
   }
+
+  var computedVariable2: Int {
+    get { return 0 }
+    set { }
+  }
+
+  deinit { print("deinit") }
+}
+
+enum MyEnum {
+  case foo, bar
+  case baz
 }
 

--- a/test/refactoring/MoveMembersToExtension/basic.swift
+++ b/test/refactoring/MoveMembersToExtension/basic.swift
@@ -24,6 +24,18 @@ class OtherClass {
   var computedVariable: Int {
     return 0
   }
+
+  var computedVariable2: Int {
+    get { return 0 }
+    set { }
+  }
+
+  deinit { print("deinit") }
+}
+
+enum MyEnum {
+  case foo, bar
+  case baz
 }
 
 // RUN: %empty-directory(%t.result)
@@ -46,3 +58,9 @@ class OtherClass {
 // RUN: not %refactor -move-to-extension -source-filename %s -pos=1:1 -end-pos=14:1
 // RUN: not %refactor -move-to-extension -source-filename %s -pos=14:1 -end-pos=15:1
 // RUN: not %refactor -move-to-extension -source-filename %s -pos=15:1 -end-pos=23:1
+// RUN: not %refactor -move-to-extension -source-filename %s -pos=24:29 -end-pos=27:1
+// RUN: not %refactor -move-to-extension -source-filename %s -pos=29:1 -end-pos=30:1
+// RUN: not %refactor -move-to-extension -source-filename %s -pos=30:1 -end-pos=31:1
+// RUN: not %refactor -move-to-extension -source-filename %s -pos=33:1 -end-pos=34:1
+// RUN: not %refactor -move-to-extension -source-filename %s -pos=37:1 -end-pos=37:1
+// RUN: not %refactor -move-to-extension -source-filename %s -pos=37:8 -end-pos=37:16


### PR DESCRIPTION
* `AccessorDecl` and `EnumElementDecl` aren't independent decls
* `DestructorDecl` and `EnumCaseDecl` can't be put in extension

rdar://problem/40274500

Also, simplified the implementation.