### PR TITLE
[4.2] migrator: emit error messages when migration scripts are missing.

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -161,6 +161,9 @@ WARNING(warn_emit_public_type_metadata_accessors_deprecated, none,
 
 REMARK(remark_using_batch_mode,none, "using batch mode", ())
 
+ERROR(cannot_find_migration_script, none,
+      "missing migration script from path '%0'", (StringRef))
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/include/swift/IDE/APIDigesterData.h
+++ b/include/swift/IDE/APIDigesterData.h
@@ -22,6 +22,8 @@
 #include "llvm/Support/raw_ostream.h"
 
 namespace swift {
+class DiagnosticEngine;
+
 namespace ide {
 namespace api {
 
@@ -370,7 +372,7 @@ struct APIDiffItemStore {
   static void serialize(llvm::raw_ostream &os, ArrayRef<APIDiffItem*> Items);
   static void serialize(llvm::raw_ostream &os, ArrayRef<NameCorrectionInfo> Items);
   APIDiffItemStore(const APIDiffItemStore& that) = delete;
-  APIDiffItemStore();
+  APIDiffItemStore(DiagnosticEngine &Diags);
   ~APIDiffItemStore();
   ArrayRef<APIDiffItem*> getDiffItems(StringRef Key) const;
   ArrayRef<APIDiffItem*> getAllDiffItems() const;

--- a/include/swift/Migrator/ASTMigratorPass.h
+++ b/include/swift/Migrator/ASTMigratorPass.h
@@ -24,6 +24,7 @@
 namespace swift {
 class SourceManager;
 struct MigratorOptions;
+class DiagnosticEngine;
 
 namespace migrator {
 class ASTMigratorPass {
@@ -34,12 +35,13 @@ protected:
   const StringRef Filename;
   const unsigned BufferID;
   SourceManager &SM;
+  DiagnosticEngine &Diags;
 
   ASTMigratorPass(EditorAdapter &Editor, SourceFile *SF,
                   const MigratorOptions &Opts)
     : Editor(Editor), SF(SF), Opts(Opts), Filename(SF->getFilename()),
       BufferID(SF->getBufferID().getValue()),
-      SM(SF->getASTContext().SourceMgr) {}
+      SM(SF->getASTContext().SourceMgr), Diags(SF->getASTContext().Diags) {}
 };
 
 /// Run a general pass to migrate code based on SDK differences in the previous

--- a/lib/Migrator/APIDiffMigratorPass.cpp
+++ b/lib/Migrator/APIDiffMigratorPass.cpp
@@ -332,7 +332,7 @@ struct APIDiffMigratorPass : public ASTMigratorPass, public SourceEntityWalker {
   SourceLoc FileEndLoc;
   APIDiffMigratorPass(EditorAdapter &Editor, SourceFile *SF,
                       const MigratorOptions &Opts):
-    ASTMigratorPass(Editor, SF, Opts),
+    ASTMigratorPass(Editor, SF, Opts), DiffStore(Diags),
     FileEndLoc(SM.getRangeForBuffer(BufferID).getEnd()) {
       SmallVector<Decl*, 16> TopDecls;
       SF->getTopLevelDecls(TopDecls);

--- a/test/Migrator/missing_script.swift
+++ b/test/Migrator/missing_script.swift
@@ -1,0 +1,3 @@
+// RUN: %empty-directory(%t) && not %target-swift-frontend -c -update-code -primary-file %s -F %S/mock-sdk -api-diff-data-file %S/Inputs/NoSuchFile.json -emit-migrated-file-path %t/missing_script.swift.result -emit-remap-file-path %t/missing_script.swift.remap -o /dev/null &> %t.diag
+// RUN: %FileCheck %s < %t.diag
+// CHECK: missing migration script from path

--- a/tools/swift-api-digester/swift-api-digester.cpp
+++ b/tools/swift-api-digester/swift-api-digester.cpp
@@ -4105,8 +4105,8 @@ static void readIgnoredUsrs(llvm::StringSet<> &IgnoredUsrs) {
   readFileLineByLine(Path, IgnoredUsrs);
 }
 
-static int deserializeDiffItems(StringRef DiffPath, StringRef OutputPath) {
-  APIDiffItemStore Store;
+static int deserializeDiffItems(APIDiffItemStore &Store, StringRef DiffPath,
+    StringRef OutputPath) {
   Store.addStorePath(DiffPath);
   std::error_code EC;
   llvm::raw_fd_ostream FS(OutputPath, EC, llvm::sys::fs::F_None);
@@ -4223,13 +4223,18 @@ int main(int argc, char *argv[]) {
       llvm::cl::PrintHelpMessage();
       return 1;
     }
-    if (options::Action == ActionType::DeserializeDiffItems)
-      return deserializeDiffItems(options::SDKJsonPaths[0], options::OutputFile);
-    else
+    if (options::Action == ActionType::DeserializeDiffItems) {
+      CompilerInstance CI;
+      APIDiffItemStore Store(CI.getDiags());
+      return deserializeDiffItems(Store, options::SDKJsonPaths[0],
+        options::OutputFile);
+    } else {
       return deserializeSDKDump(options::SDKJsonPaths[0], options::OutputFile);
+    }
   }
   case ActionType::GenerateNameCorrectionTemplate: {
-    APIDiffItemStore Store;
+    CompilerInstance CI;
+    APIDiffItemStore Store(CI.getDiags());
     auto &Paths = options::SDKJsonPaths;
     for (unsigned I = 0; I < Paths.size(); I ++)
       Store.addStorePath(Paths[I]);


### PR DESCRIPTION
We used to assert migration scripts exist. This patch further
decouples these scripts and the compiler by treating missing scripts
as a regular compiler error.

Related: rdar://40538097
