### PR TITLE
Delete Dead Code from DI

### DIFF
--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.cpp
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.cpp
@@ -62,19 +62,9 @@ static unsigned getElementCountRec(SILModule &Module, SILType T,
 }
 
 static std::pair<SILType, bool>
-computeMemorySILType(SILInstruction *MemoryInst) {
+computeMemorySILType(MarkUninitializedInst *MemoryInst) {
   // Compute the type of the memory object.
-  if (auto *ABI = dyn_cast<AllocBoxInst>(MemoryInst)) {
-    assert(ABI->getBoxType()->getLayout()->getFields().size() == 1 &&
-           "analyzing multi-field boxes not implemented");
-    return {ABI->getBoxType()->getFieldType(MemoryInst->getModule(), 0), false};
-  }
-
-  if (auto *ASI = dyn_cast<AllocStackInst>(MemoryInst)) {
-    return {ASI->getElementType(), false};
-  }
-
-  auto *MUI = cast<MarkUninitializedInst>(MemoryInst);
+  auto *MUI = MemoryInst;
   SILType MemorySILType = MUI->getType().getObjectType();
 
   // If this is a let variable we're initializing, remember this so we don't
@@ -89,7 +79,7 @@ computeMemorySILType(SILInstruction *MemoryInst) {
   return {MemorySILType, VDecl->isLet()};
 }
 
-DIMemoryObjectInfo::DIMemoryObjectInfo(SingleValueInstruction *MI)
+DIMemoryObjectInfo::DIMemoryObjectInfo(MarkUninitializedInst *MI)
     : MemoryInst(MI) {
   auto &Module = MI->getModule();
 
@@ -352,9 +342,8 @@ DIMemoryObjectInfo::getPathStringToElement(unsigned Element,
 
   // If we are analyzing a variable, we can generally get the decl associated
   // with it.
-  if (auto *MUI = dyn_cast<MarkUninitializedInst>(MemoryInst))
-    if (MUI->isVar())
-      return MUI->getLoc().getAsASTNode<VarDecl>();
+  if (MemoryInst->isVar())
+    return MemoryInst->getLoc().getAsASTNode<VarDecl>();
 
   // Otherwise, we can't.
   return nullptr;
@@ -521,11 +510,7 @@ public:
       return;
     }
 
-    if (auto *ABI = TheMemory.getContainer()) {
-      collectContainerUses(ABI);
-    } else {
-      collectUses(TheMemory.getAddress(), 0);
-    }
+    collectUses(TheMemory.MemoryInst, 0);
   }
 
   void trackUse(DIMemoryUse Use) { UseInfo.trackUse(Use); }
@@ -538,7 +523,6 @@ public:
 
 private:
   void collectUses(SILValue Pointer, unsigned BaseEltNo);
-  void collectContainerUses(AllocBoxInst *ABI);
   void collectClassSelfUses();
   void collectClassSelfUses(SILValue ClassPointer, SILType MemorySILType,
                             llvm::SmallDenseMap<VarDecl *, unsigned> &EN);
@@ -648,29 +632,6 @@ void ElementUseCollector::collectStructElementUses(StructElementAddrInst *SEAI,
   }
 
   collectUses(SEAI, BaseEltNo);
-}
-
-void ElementUseCollector::collectContainerUses(AllocBoxInst *ABI) {
-  for (auto *Op : ABI->getUses()) {
-    auto *User = Op->getUser();
-
-    // Deallocations and retain/release don't affect the value directly.
-    if (isa<DeallocBoxInst>(User) || isa<StrongRetainInst>(User) ||
-        isa<StrongReleaseInst>(User) || isa<DestroyValueInst>(User))
-      continue;
-
-    if (auto *PBI = dyn_cast<ProjectBoxInst>(User)) {
-      collectUses(PBI, PBI->getFieldIndex());
-      continue;
-    }
-
-    // Other uses of the container are considered escapes of the values.
-    for (unsigned Field : indices(ABI->getBoxType()->getLayout()->getFields())) {
-      addElementUses(Field,
-                     ABI->getBoxType()->getFieldType(ABI->getModule(), Field),
-                     User, DIUseKind::Escape);
-    }
-  }
 }
 
 /// Return the underlying accessed pointer value. This peeks through
@@ -1072,10 +1033,9 @@ void ElementUseCollector::collectClassSelfUses() {
 
   // If we are looking at the init method for a root class, just walk the
   // MUI use-def chain directly to find our uses.
-  auto *MUI = cast<MarkUninitializedInst>(TheMemory.MemoryInst);
-  if (MUI->getKind() == MarkUninitializedInst::RootSelf) {
-    collectClassSelfUses(TheMemory.getAddress(), TheMemory.MemorySILType,
-                         EltNumbering);
+  auto *MemoryInst = TheMemory.MemoryInst;
+  if (MemoryInst->getKind() == MarkUninitializedInst::RootSelf) {
+    collectClassSelfUses(MemoryInst, TheMemory.MemorySILType, EltNumbering);
     return;
   }
 
@@ -1092,7 +1052,7 @@ void ElementUseCollector::collectClassSelfUses() {
   //   4) Potential escapes after super.init, if self is closed over.
   //
   // Handle each of these in turn.
-  SmallVector<Operand *, 8> Uses(MUI->getUses());
+  SmallVector<Operand *, 8> Uses(MemoryInst->getUses());
   while (!Uses.empty()) {
     Operand *Op = Uses.pop_back_val();
     SILInstruction *User = Op->getUser();
@@ -1103,7 +1063,7 @@ void ElementUseCollector::collectClassSelfUses() {
         // The initial store of 'self' into the box at the start of the
         // function. Ignore it.
         if (auto *Arg = dyn_cast<SILArgument>(SI->getSrc())) {
-          if (Arg->getParent() == MUI->getParent()) {
+          if (Arg->getParent() == MemoryInst->getParent()) {
             StoresOfArgumentToSelf++;
             continue;
           }
@@ -1118,7 +1078,7 @@ void ElementUseCollector::collectClassSelfUses() {
           src = conversion->getConverted();
         
         if (auto *LI = dyn_cast<LoadInst>(src))
-          if (LI->getOperand() == MUI)
+          if (LI->getOperand() == MemoryInst)
             continue;
 
         // Any other store needs to be recorded.
@@ -1528,7 +1488,7 @@ void DelegatingClassInitElementUseCollector::collectClassInitSelfUses() {
   // all.  Just treat all members of self as uses of the single
   // non-field-sensitive value.
   assert(TheMemory.NumElements == 1 && "delegating inits only have 1 bit");
-  auto *MUI = cast<MarkUninitializedInst>(TheMemory.MemoryInst);
+  auto *MUI = TheMemory.MemoryInst;
 
   // The number of stores of the initial 'self' argument into the self box
   // that we saw.
@@ -1772,8 +1732,8 @@ void swift::ownership::collectDIElementUsesFrom(
     // at all. Just treat all members of self as uses of the single
     // non-field-sensitive value.
     assert(MemoryInfo.NumElements == 1 && "delegating inits only have 1 bit");
-    auto *MUI = cast<MarkUninitializedInst>(MemoryInfo.MemoryInst);
-    collectValueTypeDelegatingInitUses(MemoryInfo, UseInfo, MUI);
+    collectValueTypeDelegatingInitUses(MemoryInfo, UseInfo,
+                                       MemoryInfo.MemoryInst);
     return;
   }
 

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.h
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.h
@@ -218,8 +218,6 @@ public:
 
   /// If the specified value is a 'let' property in an initializer, return true.
   bool isElementLetProperty(unsigned Element) const;
-
-  void collectRetainCountInfo(DIElementUseInfo &OutVar) const;
 };
 
 enum DIUseKind {

--- a/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.h
+++ b/lib/SILOptimizer/Mandatory/DIMemoryUseCollectorOwnership.h
@@ -53,9 +53,8 @@ struct DIElementUseInfo;
 /// not super.init() has been called or not.
 class DIMemoryObjectInfo {
 public:
-  /// This is the instruction that represents the memory.  It is either an
-  /// allocation (alloc_box, alloc_stack) or a mark_uninitialized.
-  SingleValueInstruction *MemoryInst;
+  /// The uninitialized memory that we are analyzing.
+  MarkUninitializedInst *MemoryInst;
 
   /// This is the base type of the memory allocation.
   SILType MemorySILType;
@@ -74,7 +73,7 @@ public:
   bool HasDummyElement = false;
 
 public:
-  DIMemoryObjectInfo(SingleValueInstruction *MemoryInst);
+  DIMemoryObjectInfo(MarkUninitializedInst *MemoryInst);
 
   SILLocation getLoc() const { return MemoryInst->getLoc(); }
   SILFunction &getFunction() const { return *MemoryInst->getFunction(); }
@@ -84,17 +83,7 @@ public:
 
   CanType getType() const { return MemorySILType.getASTType(); }
 
-  SingleValueInstruction *getAddress() const {
-    if (isa<MarkUninitializedInst>(MemoryInst) ||
-        isa<AllocStackInst>(MemoryInst))
-      return MemoryInst;
-    assert(false);
-    return nullptr;
-  }
-
-  AllocBoxInst *getContainer() const {
-    return dyn_cast<AllocBoxInst>(MemoryInst);
-  }
+  SingleValueInstruction *getAddress() const { return MemoryInst; }
 
   /// getNumMemoryElements - Return the number of elements, without the extra
   /// "super.init" tracker in initializers of derived classes.
@@ -103,99 +92,82 @@ public:
   }
 
   /// isAnyInitSelf - Return true if this is 'self' in any kind of initializer.
-  bool isAnyInitSelf() const {
-    if (auto *MUI = dyn_cast<MarkUninitializedInst>(MemoryInst))
-      return !MUI->isVar();
-    return false;
-  }
+  bool isAnyInitSelf() const { return !MemoryInst->isVar(); }
 
   /// True if the memory object is the 'self' argument of a struct initializer.
   bool isStructInitSelf() const {
-    if (auto *MUI = dyn_cast<MarkUninitializedInst>(MemoryInst))
-      if (MUI->isRootSelf() || MUI->isCrossModuleRootSelf())
-        if (auto decl = getType()->getAnyNominal())
-          if (isa<StructDecl>(decl))
-            return true;
+    if (MemoryInst->isRootSelf() || MemoryInst->isCrossModuleRootSelf()) {
+      if (auto decl = getType()->getAnyNominal()) {
+        if (isa<StructDecl>(decl)) {
+          return true;
+        }
+      }
+    }
     return false;
   }
 
   /// True if the memory object is the 'self' argument of a non-delegating
   /// cross-module struct initializer.
   bool isCrossModuleStructInitSelf() const {
-    if (auto *MUI = dyn_cast<MarkUninitializedInst>(MemoryInst)) {
-      if (MUI->isCrossModuleRootSelf()) {
-        assert(isStructInitSelf());
-        return true;
-      }
+    if (MemoryInst->isCrossModuleRootSelf()) {
+      assert(isStructInitSelf());
+      return true;
     }
     return false;
   }
 
   /// True if the memory object is the 'self' argument of a class initializer.
   bool isClassInitSelf() const {
-    if (auto *MUI = dyn_cast<MarkUninitializedInst>(MemoryInst))
-      if (!MUI->isVar())
-        if (auto decl = getType()->getAnyNominal())
-          if (isa<ClassDecl>(decl))
-            return true;
+    if (!MemoryInst->isVar()) {
+      if (auto decl = getType()->getAnyNominal()) {
+        if (isa<ClassDecl>(decl)) {
+          return true;
+        }
+      }
+    }
     return false;
   }
 
   /// True if this memory object is the 'self' of a derived class initializer.
-  bool isDerivedClassSelf() const {
-    if (auto MUI = dyn_cast<MarkUninitializedInst>(MemoryInst))
-      return MUI->isDerivedClassSelf();
-    return false;
-  }
+  bool isDerivedClassSelf() const { return MemoryInst->isDerivedClassSelf(); }
 
   /// True if this memory object is the 'self' of a derived class initializer for
   /// which we can assume that all ivars have been initialized.
   bool isDerivedClassSelfOnly() const {
-    if (auto MUI = dyn_cast<MarkUninitializedInst>(MemoryInst))
-      return MUI->isDerivedClassSelfOnly();
-    return false;
+    return MemoryInst->isDerivedClassSelfOnly();
   }
 
   /// True if this memory object is the 'self' of a derived class init method,
   /// regardless of whether we're tracking ivar initializations or not.
   bool isAnyDerivedClassSelf() const {
-    if (auto MUI = dyn_cast<MarkUninitializedInst>(MemoryInst))
-      return MUI->isDerivedClassSelf() || MUI->isDerivedClassSelfOnly();
-    return false;
+    return MemoryInst->isDerivedClassSelf() ||
+           MemoryInst->isDerivedClassSelfOnly();
   }
 
   /// True if this memory object is the 'self' of a non-root class init method.
   bool isNonRootClassSelf() const {
-    if (isClassInitSelf())
-      if (auto MUI = dyn_cast<MarkUninitializedInst>(MemoryInst))
-        return !MUI->isRootSelf();
-
-    return false;
+    return isClassInitSelf() && !MemoryInst->isRootSelf();
   }
 
   /// isDelegatingInit - True if this is a delegating initializer, one that
   /// calls 'self.init'.
   bool isDelegatingInit() const {
-    if (auto MUI = dyn_cast<MarkUninitializedInst>(MemoryInst))
-      return MUI->isDelegatingSelf();
-    return false;
+    return MemoryInst->isDelegatingSelf();
   }
 
   /// isNonDelegatingInit - True if this is an initializer that initializes
   /// stored properties.
   bool isNonDelegatingInit() const {
-    if (auto *MUI = dyn_cast<MarkUninitializedInst>(MemoryInst)) {
-      switch (MUI->getKind()) {
-      case MarkUninitializedInst::Var:
-        return false;
-      case MarkUninitializedInst::RootSelf:
-      case MarkUninitializedInst::CrossModuleRootSelf:
-      case MarkUninitializedInst::DerivedSelf:
-      case MarkUninitializedInst::DerivedSelfOnly:
-        return true;
-      case MarkUninitializedInst::DelegatingSelf:
-        return false;
-      }
+    switch (MemoryInst->getKind()) {
+    case MarkUninitializedInst::Var:
+      return false;
+    case MarkUninitializedInst::RootSelf:
+    case MarkUninitializedInst::CrossModuleRootSelf:
+    case MarkUninitializedInst::DerivedSelf:
+    case MarkUninitializedInst::DerivedSelfOnly:
+      return true;
+    case MarkUninitializedInst::DelegatingSelf:
+      return false;
     }
     return false;
   }

--- a/test/SILOptimizer/definite_init_markuninitialized_var.sil
+++ b/test/SILOptimizer/definite_init_markuninitialized_var.sil
@@ -1,4 +1,4 @@
-// RUN: %target-sil-opt -enable-sil-ownership -enable-sil-verify-all %s -definite-init -raw-sil-inst-lowering -verify | %FileCheck %s
+// RUN: %target-sil-opt -enable-sil-ownership -enable-sil-verify-all %s -definite-init -verify | %FileCheck %s
 
 // This file contains tests that test diagnostics emitted for var initialization
 // by DI.
@@ -362,7 +362,7 @@ bb0(%0 : @trivial $*ContainsNativeObject):
 
 // CHECK-LABEL: sil @non_box_assign_trivial
 // CHECK-NOT: load
-// CHECK: store
+// CHECK: assign
 // CHECK: return
 sil @non_box_assign_trivial : $@convention(thin) (@inout Bool, Bool) -> () {
 bb0(%0 : @trivial $*Bool, %1 : @trivial $Bool):
@@ -372,8 +372,8 @@ bb0(%0 : @trivial $*Bool, %1 : @trivial $Bool):
 }
 
 // CHECK-LABEL: sil @non_box_assign
-// CHECK: load
-// CHECK: store
+// CHECK-NOT: load
+// CHECK: assign
 // CHECK: return
 sil @non_box_assign : $@convention(thin) (@inout SomeClass, @owned SomeClass) -> () {
 bb0(%0 : @trivial $*SomeClass, %1 : @owned $SomeClass):
@@ -390,7 +390,6 @@ sil_global @int_global : $Int
 sil @test_tlc : $() -> () {
   %0 = global_addr @int_global : $*Int
   %1 = mark_uninitialized [var] %0 : $*Int
-
   %9 = tuple ()
   return %9 : $()
 }

--- a/test/SILOptimizer/raw_sil_inst_lowering.sil
+++ b/test/SILOptimizer/raw_sil_inst_lowering.sil
@@ -1,0 +1,30 @@
+// RUN: %target-sil-opt -enable-sil-ownership -enable-sil-verify-all %s -raw-sil-inst-lowering | %FileCheck %s
+
+sil_stage raw
+
+import Builtin
+import Swift
+
+class SomeClass {}
+
+// CHECK-LABEL: sil @non_box_assign_trivial
+// CHECK-NOT: load
+// CHECK: store
+// CHECK: return
+sil @non_box_assign_trivial : $@convention(thin) (@inout Bool, Bool) -> () {
+bb0(%0 : @trivial $*Bool, %1 : @trivial $Bool):
+  assign %1 to %0 : $*Bool
+  %9 = tuple ()
+  return %9 : $()
+}
+
+// CHECK-LABEL: sil @non_box_assign
+// CHECK: load
+// CHECK: store
+// CHECK: return
+sil @non_box_assign : $@convention(thin) (@inout SomeClass, @owned SomeClass) -> () {
+bb0(%0 : @trivial $*SomeClass, %1 : @owned $SomeClass):
+  assign %1 to %0 : $*SomeClass
+  %9 = tuple ()
+  return %9 : $()
+}


### PR DESCRIPTION
Just deleting dead code. DefiniteInitialization has the property that MemoryInst is always a MarkUninitializedInst. So anything that will never run if MemoryInst is a MarkUninitializedInst is trivially dead.