### PR TITLE
[AST] Remove dead declaration of DeclContext::getCommonParentContext

### DIFF
--- a/include/swift/AST/DeclContext.h
+++ b/include/swift/AST/DeclContext.h
@@ -408,10 +408,6 @@ public:
     return false;
   }
 
-  /// Compute a context C such that C is a parent context of A and B.
-  /// If no such context exists, return \c nullptr.
-  static DeclContext *getCommonParentContext(DeclContext *A, DeclContext *B);
-
   /// Returns the module context that contains this context.
   ModuleDecl *getParentModule() const;
 


### PR DESCRIPTION
Remove declaration for `DeclContext::getCommonParentContext` which no longer exist.
I removed the definition in #16836 , but forgot to remove the declaration.