### PR TITLE
[NFC] Never synthesize @lvalue in typing judgements

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -2299,11 +2299,13 @@ ConstraintSystem::matchTypes(Type type1, Type type2, ConstraintKind kind,
 
   if (concrete && kind >= ConstraintKind::OperatorArgumentConversion) {
     // If the RHS is an inout type, the LHS must be an @lvalue type.
-    if (auto *iot = type2->getAs<InOutType>()) {
-      return matchTypes(type1, LValueType::get(iot->getObjectType()),
-                        kind, subflags,
-                        locator.withPathElement(
-                                ConstraintLocator::LValueConversion));
+    if (auto *lvt = type1->getAs<LValueType>()) {
+      if (auto *iot = type2->getAs<InOutType>()) {
+        return matchTypes(lvt->getObjectType(), iot->getObjectType(),
+                          kind, subflags,
+                          locator.withPathElement(
+                                  ConstraintLocator::LValueConversion));
+      }
     }
   }
 


### PR DESCRIPTION
When in a checking context, there is no need (and no sense) in synthesizing `@lvalue` instead of checking the underlying object type.

<strike>The locators for this typing rule and the other parameter binding one below it are still lying, but probably because there's really no good way to indicate that you're an argument to a function/operator without also lying about the index of the argument - which matchTypes has no way of knowing.</strike>