### PR TITLE
[AST] Add XFAIL test for extra inhabitant logic for reference storage types

### DIFF
--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2147,7 +2147,13 @@ void TypeChecker::checkReferenceOwnershipAttr(VarDecl *var,
   case ReferenceOwnership::Strong:
     llvm_unreachable("Cannot specify 'strong' in an ownership attribute");
   case ReferenceOwnership::Unowned:
+    break;
   case ReferenceOwnership::Unmanaged:
+    // The Clang importer can create optional Unmanaged. Otherwise this is not
+    // allowed. Allow optionalness under SIL for testing and debugging.
+    if (auto sourceFile = var->getDeclContext()->getParentSourceFile())
+      if (sourceFile->Kind == SourceFileKind::SIL)
+        allowOptional = true;
     break;
   case ReferenceOwnership::Weak:
     allowOptional = true;

--- a/test/IRGen/reference_storage_extra_inhabitants.sil
+++ b/test/IRGen/reference_storage_extra_inhabitants.sil
@@ -1,0 +1,34 @@
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -disable-objc-interop -emit-ir -primary-file %s | %FileCheck %s
+// XFAIL: *
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+class C { }
+sil_vtable C { }
+
+struct S {
+  @sil_stored unowned(unsafe) var uu: @sil_unmanaged C? { get set }
+}
+
+func example(_ os: S?)
+
+// CHECK-LABEL: define hidden swiftcc void @"$S35reference_storage_extra_inhabitants7exampleyyAA1SVSgF"(i64) #0
+// CHECK-NEXT:  entry:
+// CHECK-NEXT:    %1 = icmp eq i64 %0, 1
+sil hidden @$S35reference_storage_extra_inhabitants7exampleyyAA1SVSgF : $@convention(thin) (Optional<S>) -> () {
+bb0(%0 : $Optional<S>):
+  switch_enum %0 : $Optional<S>, case #Optional.some!enumelt.1: bb2, case #Optional.none!enumelt: bb1 // id: %2
+
+bb1:                                              // Preds: bb0
+  br bb4                                          // id: %3
+
+bb2(%4 : $S):                                     // Preds: bb0
+  br bb4                                          // id: %9
+
+bb4:                                              // Preds: bb3 bb1
+  %10 = tuple ()                                  // user: %11
+  return %10 : $()                                // id: %11
+}


### PR DESCRIPTION
Optional reference storage types have broken extra inhabitant logic. Right now, this problem is limited to optional unmanaged nodes created by the clang importer because the formal language does not allow optional unowned/unmanaged.

Please note that GitHub pull request #16237 contains a general solution to this problem, but without changing the formal user facing policy.