### PR TITLE
[stdlib] Improvements to `Random` and some doc fixes

### DIFF
--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -94,7 +94,7 @@ public struct Bool {
   /// method to generate a random Boolean value when you are using a custom
   /// random number generator.
   ///
-  ///     let flippedHeads = Boolean.random(using: &myGenerator)
+  ///     let flippedHeads = Bool.random(using: &myGenerator)
   ///     if flippedHeads {
   ///         print("Heads, you win!")
   ///     } else {
@@ -116,7 +116,7 @@ public struct Bool {
   ///
   /// This method returns `true` and `false` with equal probability.
   ///
-  ///     let flippedHeads = Boolean.random()
+  ///     let flippedHeads = Bool.random()
   ///     if flippedHeads {
   ///         print("Heads, you win!")
   ///     } else {

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2577,7 +2577,11 @@ extension ${Range}
     // Compute delta, the distance between the lower and upper bounds. This
     // value may not representable by the type Bound if Bound is signed, but
     // is always representable as Bound.Magnitude.
+%   if 'Closed' in Range:
     var delta = Bound.Magnitude(truncatingIfNeeded: upperBound &- lowerBound)
+%   else:
+    let delta = Bound.Magnitude(truncatingIfNeeded: upperBound &- lowerBound)
+%   end
 %   if 'Closed' in Range:
     // Subtle edge case: if the range is the whole set of representable values,
     // then adding one to delta to account for a closed range will overflow.
@@ -4046,6 +4050,7 @@ public func _assumeNonNegative(_ x: ${Self}) -> ${Self} {
 % end
 
 extension ${Self} {
+  @inlinable
   public static func _random<R: RandomNumberGenerator>(
     using generator: inout R
   ) -> ${Self} {

--- a/stdlib/public/core/Random.swift
+++ b/stdlib/public/core/Random.swift
@@ -32,7 +32,7 @@ import SwiftShims
 ///         }
 ///
 ///         static func random() -> Weekday {
-///             return Weekday.randomWeekday(using: &Random.default)
+///             return Weekday.random(using: &Random.default)
 ///         }
 ///     }
 ///
@@ -60,6 +60,7 @@ public protocol RandomNumberGenerator {
 }
 
 extension RandomNumberGenerator {
+  @inlinable
   public mutating func _fill(bytes buffer: UnsafeMutableRawBufferPointer) {
     // FIXME: Optimize
     var chunk: UInt64 = 0
@@ -132,25 +133,29 @@ extension RandomNumberGenerator {
 /// - Apple platforms use `arc4random_buf(3)`.
 /// - Linux platforms use `getrandom(2)` when available; otherwise, they read
 ///   from `/dev/urandom`.
+@_fixed_layout
 public struct Random : RandomNumberGenerator {
   /// The default instance of the `Random` random number generator.
+  @inlinable
   public static var `default`: Random {
     get { return Random() }
     set { /* Discard */ }
   }
 
-  private init() {}
+  @inlinable
+  internal init() {}
 
   /// Returns a value from a uniform, independent distribution of binary data.
   ///
   /// - Returns: An unsigned 64-bit random value.
-  @effects(releasenone)
+  @inlinable
   public mutating func next() -> UInt64 {
     var random: UInt64 = 0
     _stdlib_random(&random, MemoryLayout<UInt64>.size)
     return random
   }
 
+  @inlinable
   public mutating func _fill(bytes buffer: UnsafeMutableRawBufferPointer) {
     if !buffer.isEmpty {
       _stdlib_random(buffer.baseAddress!, buffer.count)


### PR DESCRIPTION
- Some docs fixes for `Bool` and `RandomNumberGenerator`
cc: @natecook1000 

- Adds `@inlinable` and `@_fixed_layout` to some places in `Random`
cc: @lorentey 

- Removes a warning in `[Closed]Range.randomElement(using:)`

Also, should I add `@inlinable` to the `_fill(bytes:)` methods and `FixedWidthInteger._random()` methods?
@milseman pointed out that we could probably fast path the `FixedWidthInteger._random()` method, is this something we could also tackle in this PR as well?