### PR TITLE
[benchmark] When building the benchmark suite via subcmake specify CL…

### DIFF
--- a/cmake/modules/SwiftExternalBenchmarkBuild.cmake
+++ b/cmake/modules/SwiftExternalBenchmarkBuild.cmake
@@ -84,6 +84,7 @@ function (add_external_benchmark_suite)
       -DSWIFT_LIBRARY_PATH=${SWIFT_BINARY_DIR}/lib/swift
       -DCMAKE_C_COMPILER=${PATH_TO_CLANG_BUILD}/bin/clang
       -DCMAKE_CXX_COMPILER=${PATH_TO_CLANG_BUILD}/bin/clang++
+      -DCLANG_EXEC=${PATH_TO_CLANG_BUILD}/bin/clang
       -DSWIFT_BENCHMARK_SUBCMAKE_BUILD=TRUE
     PASSTHROUGH_PREFIXES SWIFT_BENCHMARK
     )


### PR DESCRIPTION
…ANG_EXEC.

Given that we already know the clang that we want the benchmark suite to use,
just specify it explicitly.

rdar://40541972
