### PR TITLE
[benchmark] Use SWIFT_EXEC instead of CLANG_EXEC to link together ben…

### DIFF
--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -479,7 +479,7 @@ function (swift_benchmark_compile_archopts)
         ${bench_library_objects} ${bench_driver_objects} ${SWIFT_BENCH_OBJFILES}
         "${objcfile}" ${opt_view_dirs}
       COMMAND
-        "${CLANG_EXEC}"
+        "${SWIFT_EXEC}"
         "-fno-stack-protector"
         "-fPIC"
         "-Werror=date-time"


### PR DESCRIPTION
…chmarks.

This ensures that the swift driver selects the flags to pass to the linker
instead of clang. Otherwise, I run into missing symbol problems when linking on
Linux.

rdar://40541972
