### PR TITLE
[SIL] Perf: Cache basic block during SILSuccessor iteration

### DIFF
--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8094,6 +8094,15 @@ inline EnumElementDecl **SelectEnumInstBase::getEnumElementDeclStorage() {
   llvm_unreachable("Unhandled SelectEnumInstBase subclass");
 }
 
+inline void SILSuccessor::pred_iterator::cacheBasicBlock() {
+  if (Cur != nullptr) {
+    Block = Cur->ContainingInst->getParent();
+    assert(Block != nullptr);
+  } else {
+    Block = nullptr;
+  }
+}
+
 } // end swift namespace
 
 //===----------------------------------------------------------------------===//

--- a/lib/SIL/SILSuccessor.cpp
+++ b/lib/SIL/SILSuccessor.cpp
@@ -37,15 +37,3 @@ void SILSuccessor::operator=(SILBasicBlock *BB) {
   
   SuccessorBlock = BB;
 }
-
-// Dereferencing the pred_iterator returns the predecessor's SILBasicBlock.
-SILBasicBlock *SILSuccessor::pred_iterator::operator*() {
-  assert(Cur && "Can't deference end (or default constructed) iterator");
-  return Cur->ContainingInst->getParent();
-}
-
-// Dereferencing the pred_iterator returns the predecessor's SILBasicBlock.
-const SILBasicBlock *SILSuccessor::pred_iterator::operator*() const {
-  assert(Cur && "Can't deference end (or default constructed) iterator");
-  return Cur->ContainingInst->getParent();
-}


### PR DESCRIPTION
'operator*' in this patch becomes a hot spot in some scenarios. For example: an enum with an unusually large number of cases.