### PR TITLE
[NFC] SILGlobalVariable utilities.

### DIFF
--- a/include/swift/Parse/ParseSILSupport.h
+++ b/include/swift/Parse/ParseSILSupport.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_PARSER_PARSESILSUPPORT_H
 #define SWIFT_PARSER_PARSESILSUPPORT_H
 
+#include "swift/Parse/Parser.h"
 #include "llvm/Support/PrettyStackTrace.h"
 
 namespace swift {

--- a/include/swift/Parse/ParseSILSupport.h
+++ b/include/swift/Parse/ParseSILSupport.h
@@ -13,7 +13,6 @@
 #ifndef SWIFT_PARSER_PARSESILSUPPORT_H
 #define SWIFT_PARSER_PARSESILSUPPORT_H
 
-#include "swift/Parse/Parser.h"
 #include "llvm/Support/PrettyStackTrace.h"
 
 namespace swift {
@@ -44,11 +43,7 @@ namespace swift {
     Parser &P;
   public:
     explicit PrettyStackTraceParser(Parser &P) : P(P) {}
-    void print(llvm::raw_ostream &out) const override {
-      out << "With parser at source location: ";
-      P.Tok.getLoc().print(out, P.Context.SourceMgr);
-      out << '\n';
-    }
+    void print(llvm::raw_ostream &out) const override;
   };
 } // end namespace swift
 

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -221,6 +221,7 @@ public:
     }
   }
 
+  /// Return true if the storage is guaranteed local.
   bool isLocal() const {
     switch (getKind()) {
     case Box:

--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -225,4 +225,38 @@ private:
 
 } // end llvm namespace
 
+//===----------------------------------------------------------------------===//
+// Utilities for verification and optimization.
+//===----------------------------------------------------------------------===//
+
+namespace swift {
+
+/// Given an addressor, AddrF, return the global variable being addressed, or
+/// return nullptr if the addressor isn't a recognized pattern.
+SILGlobalVariable *getVariableOfGlobalInit(SILFunction *AddrF);
+
+/// Return the callee of a once call.
+SILFunction *getCalleeOfOnceCall(BuiltinInst *BI);
+
+/// Helper for getVariableOfGlobalInit(), so GlobalOpts can deeply inspect and
+/// rewrite the initialization pattern.
+///
+/// Given an addressor, AddrF, find the call to the global initializer if
+/// present, otherwise return null. If an initializer is returned, then
+/// `CallsToOnce` is initialized to the corresponding builtin "once" call.
+SILFunction *findInitializer(SILModule *Module, SILFunction *AddrF,
+                             BuiltinInst *&CallToOnce);
+
+/// Helper for getVariableOfGlobalInit(), so GlobalOpts can deeply inspect and
+/// rewrite the initialization pattern.
+///
+/// Given a global initializer, InitFunc, return the GlobalVariable that it
+/// statically initializes or return nullptr if it isn't an obvious static
+/// initializer. If a global variable is returned, InitVal is initialized to the
+/// the instruction producing the global's initial value.
+SILGlobalVariable *getVariableOfStaticInitializer(
+  SILFunction *InitFunc, SingleValueInstruction *&InitVal);
+
+} // namespace swift
+
 #endif

--- a/include/swift/SIL/SILLinkage.h
+++ b/include/swift/SIL/SILLinkage.h
@@ -17,6 +17,8 @@
 
 namespace swift {
 
+class ValueDecl;
+
 /// Linkage for a SIL object.  This concept combines the notions
 /// of symbol linkage and visibility.
 ///
@@ -175,6 +177,8 @@ inline bool isPossiblyUsedExternally(SILLinkage linkage, bool wholeModule) {
   }
   return linkage <= SILLinkage::Hidden;
 }
+
+SILLinkage getDeclSILLinkage(const ValueDecl *decl);
 
 inline bool hasPublicVisibility(SILLinkage linkage) {
   switch (linkage) {

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -474,6 +474,14 @@ public:
   void setOptRecordStream(std::unique_ptr<llvm::yaml::Output> &&Stream,
                           std::unique_ptr<llvm::raw_ostream> &&RawStream);
 
+  // This is currently limited to VarDecl because the visibility of global
+  // variables and class properties is straighforward, while the visibility of
+  // class methods (ValueDecls) depends on the subclass scope. "Visiblity" has
+  // a different meaning when vtable layout is at stake.
+  bool isVisibleExternally(const VarDecl *decl) {
+    return isPossiblyUsedExternally(getDeclSILLinkage(decl), isWholeModule());
+  }
+
   PropertyListType &getPropertyList() { return properties; }
   const PropertyListType &getPropertyList() const { return properties; }
   

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -475,7 +475,7 @@ public:
                           std::unique_ptr<llvm::raw_ostream> &&RawStream);
 
   // This is currently limited to VarDecl because the visibility of global
-  // variables and class properties is straighforward, while the visibility of
+  // variables and class properties is straightforward, while the visibility of
   // class methods (ValueDecls) depends on the subclass scope. "Visiblity" has
   // a different meaning when vtable layout is at stake.
   bool isVisibleExternally(const VarDecl *decl) {

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -5394,9 +5394,15 @@ bool SILParserTUState::parseDeclSILStage(Parser &P) {
 static Optional<VarDecl *> lookupGlobalDecl(Identifier GlobalName,
                                             SILLinkage GlobalLinkage,
                                             SILType GlobalType, Parser &P) {
+  // Create a set of DemangleOptions to produce the global variable's
+  // identifier, which is used as a search key in the declaration context.
+  Demangle::DemangleOptions demangleOpts;
+  demangleOpts.QualifyEntities = false;
+  demangleOpts.ShowPrivateDiscriminators = false;
+  demangleOpts.DisplayEntityTypes = false;
   std::string GlobalDeclName = Demangle::demangleSymbolAsString(
-      GlobalName.str(),
-      Demangle::DemangleOptions::SimplifiedUIDemangleOptions());
+    GlobalName.str(), demangleOpts);
+
   SmallVector<ValueDecl *, 4> CurModuleResults;
   P.SF.getParentModule()->lookupValue(
       {}, P.Context.getIdentifier(GlobalDeclName), NLKind::UnqualifiedLookup,

--- a/lib/SIL/SILGlobalVariable.cpp
+++ b/lib/SIL/SILGlobalVariable.cpp
@@ -10,7 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILGlobalVariable.h"
+#include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILLinkage.h"
 #include "swift/SIL/SILModule.h"
 
@@ -136,4 +138,133 @@ ClangNode SILGlobalVariable::getClangNode() const {
 }
 const clang::Decl *SILGlobalVariable::getClangDecl() const {
   return (VDecl ? VDecl->getClangDecl() : nullptr);
+}
+
+//===----------------------------------------------------------------------===//
+// Utilities for verification and optimization.
+//===----------------------------------------------------------------------===//
+
+static SILGlobalVariable *getStaticallyInitializedVariable(SILFunction *AddrF) {
+  if (AddrF->isExternalDeclaration())
+    return nullptr;
+
+  auto *RetInst = cast<ReturnInst>(AddrF->findReturnBB()->getTerminator());
+  auto *API = dyn_cast<AddressToPointerInst>(RetInst->getOperand());
+  if (!API)
+    return nullptr;
+  auto *GAI = dyn_cast<GlobalAddrInst>(API->getOperand());
+  if (!GAI)
+    return nullptr;
+
+  return GAI->getReferencedGlobal();
+}
+
+SILGlobalVariable *swift::getVariableOfGlobalInit(SILFunction *AddrF) {
+  if (!AddrF->isGlobalInit())
+    return nullptr;
+
+  if (auto *SILG = getStaticallyInitializedVariable(AddrF))
+    return SILG;
+
+  // If the addressor contains a single "once" call, it calls globalinit_func,
+  // and the globalinit_func is called by "once" from a single location,
+  // continue; otherwise bail.
+  BuiltinInst *CallToOnce;
+  auto *InitF = findInitializer(&AddrF->getModule(), AddrF, CallToOnce);
+
+  if (!InitF || !InitF->getName().startswith("globalinit_"))
+    return nullptr;
+
+  // If the globalinit_func is trivial, continue; otherwise bail.
+  SingleValueInstruction *dummyInitVal;
+  auto *SILG = getVariableOfStaticInitializer(InitF, dummyInitVal);
+
+  return SILG;
+}
+
+SILFunction *swift::getCalleeOfOnceCall(BuiltinInst *BI) {
+  assert(BI->getNumOperands() == 2 && "once call should have 2 operands.");
+
+  auto Callee = BI->getOperand(1);
+  assert(Callee->getType().castTo<SILFunctionType>()->getRepresentation()
+           == SILFunctionTypeRepresentation::CFunctionPointer &&
+         "Expected C function representation!");
+
+  if (auto *FR = dyn_cast<FunctionRefInst>(Callee))
+    return FR->getReferencedFunction();
+
+  return nullptr;
+}
+
+// Find the globalinit_func by analyzing the body of the addressor.
+SILFunction *swift::findInitializer(SILModule *Module, SILFunction *AddrF,
+                             BuiltinInst *&CallToOnce) {
+  // We only handle a single SILBasicBlock for now.
+  if (AddrF->size() != 1)
+    return nullptr;
+
+  CallToOnce = nullptr;
+  SILBasicBlock *BB = &AddrF->front();
+  for (auto &I : *BB) {
+    // Find the builtin "once" call.
+    if (auto *BI = dyn_cast<BuiltinInst>(&I)) {
+      const BuiltinInfo &Builtin =
+        BI->getModule().getBuiltinInfo(BI->getName());
+      if (Builtin.ID != BuiltinValueKind::Once)
+        continue;
+
+      // Bail if we have multiple "once" calls in the addressor.
+      if (CallToOnce)
+        return nullptr;
+
+      CallToOnce = BI;
+    }
+  }
+  if (!CallToOnce)
+    return nullptr;
+  return getCalleeOfOnceCall(CallToOnce);
+}
+
+SILGlobalVariable *
+swift::getVariableOfStaticInitializer(SILFunction *InitFunc,
+                                      SingleValueInstruction *&InitVal) {
+  InitVal = nullptr;
+  SILGlobalVariable *GVar = nullptr;
+  // We only handle a single SILBasicBlock for now.
+  if (InitFunc->size() != 1)
+    return nullptr;
+
+  SILBasicBlock *BB = &InitFunc->front();
+  GlobalAddrInst *SGA = nullptr;
+  bool HasStore = false;
+  for (auto &I : *BB) {
+    // Make sure we have a single GlobalAddrInst and a single StoreInst.
+    // And the StoreInst writes to the GlobalAddrInst.
+    if (isa<AllocGlobalInst>(&I) || isa<ReturnInst>(&I)
+        || isa<DebugValueInst>(&I)) {
+      continue;
+    } else if (auto *sga = dyn_cast<GlobalAddrInst>(&I)) {
+      if (SGA)
+        return nullptr;
+      SGA = sga;
+      GVar = SGA->getReferencedGlobal();
+    } else if (auto *SI = dyn_cast<StoreInst>(&I)) {
+      if (HasStore || SI->getDest() != SGA)
+        return nullptr;
+      HasStore = true;
+      SILValue value = SI->getSrc();
+
+      // We only handle StructInst and TupleInst being stored to a
+      // global variable for now.
+      if (!isa<StructInst>(value) && !isa<TupleInst>(value))
+        return nullptr;
+      InitVal = cast<SingleValueInstruction>(value);
+    } else if (!SILGlobalVariable::isValidStaticInitializerInst(&I,
+                                                             I.getModule())) {
+      return nullptr;
+    }
+  }
+  if (!InitVal)
+    return nullptr;
+  return GVar;
 }

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -855,3 +855,22 @@ SILProperty *SILProperty::create(SILModule &M,
   return prop;
 }
 
+// Definition from SILLinkage.h.
+SILLinkage swift::getDeclSILLinkage(const ValueDecl *decl) {
+  AccessLevel access = decl->getEffectiveAccess();
+  SILLinkage linkage;
+  switch (access) {
+  case AccessLevel::Private:
+  case AccessLevel::FilePrivate:
+    linkage = SILLinkage::Private;
+    break;
+  case AccessLevel::Internal:
+    linkage = SILLinkage::Hidden;
+    break;
+  case AccessLevel::Public:
+  case AccessLevel::Open:
+    linkage = SILLinkage::Public;
+    break;
+  }
+  return linkage;
+}

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -371,6 +371,13 @@ protected:
   }
 
   /// Retrieve the visibility information from the AST.
+  ///
+  /// This differs from SILModule::isVisibleExternally(VarDecl *) because of
+  /// it's handling of class methods. It returns true for methods whose
+  /// declarations are not directly visible externally, but have been imported
+  /// from another module. This ensures that entries aren't deleted from vtables
+  /// imported from the stdlib.
+  /// FIXME: Passes should not embed special logic for handling linkage.
   bool isVisibleExternally(const ValueDecl *decl) {
     AccessLevel access = decl->getEffectiveAccess();
     SILLinkage linkage;
@@ -390,9 +397,7 @@ protected:
     if (isPossiblyUsedExternally(linkage, Module->isWholeModule()))
       return true;
 
-    // If a vtable or witness table (method) is only visible in another module
-    // it can be accessed inside that module and we don't see this access.
-    // We hit this case e.g. if a table is imported from the stdlib.
+    // Special case for vtable visibility.
     if (decl->getDeclContext()->getParentModule() != Module->getSwiftModule())
       return true;
 

--- a/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
@@ -128,25 +128,6 @@ class GlobalPropertyOpt {
     return false;
   }
 
-  bool isVisibleExternally(VarDecl *decl) {
-    AccessLevel access = decl->getEffectiveAccess();
-    SILLinkage linkage;
-    switch (access) {
-      case AccessLevel::Private:
-      case AccessLevel::FilePrivate:
-        linkage = SILLinkage::Private;
-        break;
-      case AccessLevel::Internal:
-        linkage = SILLinkage::Hidden;
-        break;
-      case AccessLevel::Public:
-      case AccessLevel::Open:
-        linkage = SILLinkage::Public;
-        break;
-    }
-    return isPossiblyUsedExternally(linkage, M.isWholeModule());
-  }
-  
   static bool canAddressEscape(SILValue V, bool acceptStore);
 
   /// Gets the entry for a struct or class field.
@@ -154,7 +135,7 @@ class GlobalPropertyOpt {
     Entry * &entry = FieldEntries[Field];
     if (!entry) {
       entry = new (EntryAllocator.Allocate()) Entry(SILValue(), Field);
-      if (isVisibleExternally(Field))
+      if (M.isVisibleExternally(Field))
         setAddressEscapes(entry);
     }
     return entry;

--- a/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
+++ b/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
@@ -284,28 +284,7 @@ static bool isSameInitSequence(const InitSequence &LHS,
 
 /// Check if a given let property can be assigned externally.
 static bool isAssignableExternally(VarDecl *Property, SILModule *Module) {
-  AccessLevel access = Property->getEffectiveAccess();
-  SILLinkage linkage;
-  switch (access) {
-  case AccessLevel::Private:
-  case AccessLevel::FilePrivate:
-    linkage = SILLinkage::Private;
-    DEBUG(llvm::dbgs() << "Property " << *Property << " has private access\n");
-    break;
-  case AccessLevel::Internal:
-    linkage = SILLinkage::Hidden;
-    DEBUG(llvm::dbgs() << "Property " << *Property << " has internal access\n");
-    break;
-  case AccessLevel::Public:
-  case AccessLevel::Open:
-    linkage = SILLinkage::Public;
-    DEBUG(llvm::dbgs() << "Property " << *Property << " has public access\n");
-    break;
-  }
-
-  DEBUG(llvm::dbgs() << "Module of " << *Property << " WMO mode is: " << Module->isWholeModule() << "\n");
-
-  if (isPossiblyUsedExternally(linkage, Module->isWholeModule())) {
+  if (Module->isVisibleExternally(Property)) {
     // If at least one of the properties of the enclosing type cannot be
     // used externally, then no initializer can be implemented externally as
     // it wouldn't be able to initialize such a property.

--- a/test/SIL/Parser/global_decl.sil
+++ b/test/SIL/Parser/global_decl.sil
@@ -1,0 +1,54 @@
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all %s
+
+// Check that sil_globals and their corresponding decls are
+// parsed. There is no direct way to verify that the declarations are
+// properly associated with the sil_globals, so just make sure it succeeds.
+//
+// FIXME: Add support for name collisions across private/fileprivate globals.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+struct S {
+  init()
+}
+
+class C {
+  init()
+  deinit
+}
+
+enum E {
+  case a
+  @_implements(Equatable, ==(_:_:)) static func __derived_enum_equals(_ a: E, _ b: E) -> Bool
+  var hashValue: Int { get }
+  func hash(into hasher: inout Hasher)
+}
+
+private var global1: S
+
+fileprivate var global2: C
+
+var global3: E
+
+public var global4: Int
+
+weak var global5: @sil_weak C?
+
+// CHECK: sil_global private @$S11global_decl7global133_EB6670D548223EDC99AF0D8F02575BC4LLAA1SVvp : $S
+sil_global private @$S11global_decl7global133_EB6670D548223EDC99AF0D8F02575BC4LLAA1SVvp : $S
+
+// CHECK: sil_global private @$S11global_decl7global233_EB6670D548223EDC99AF0D8F02575BC4LLAA1CCvp : $C
+sil_global private @$S11global_decl7global233_EB6670D548223EDC99AF0D8F02575BC4LLAA1CCvp : $C
+
+// CHECK: sil_global hidden @$S11global_decl7global3AA1EOvp : $E
+sil_global hidden @$S11global_decl7global3AA1EOvp : $E
+
+// CHECK: sil_global @$S11global_decl7global4Sivp : $Int
+sil_global @$S11global_decl7global4Sivp : $Int
+
+// CHECK: sil_global hidden @$S11global_decl7global5AA1CCSgXwvp : $@sil_weak Optional<C>
+sil_global hidden @$S11global_decl7global5AA1CCSgXwvp : $@sil_weak Optional<C>


### PR DESCRIPTION
Ignore the first two commits, which are from https://github.com/apple/swift/pull/16834.

The third commit just moves some code to a place it belongs: Move the utilities that are required for recognizing SILGlobalVariable access into SILGlobalVariable.[h|cpp].

Should be a trivial review. I'm not making a serious attempt to rework the interfaces:
@eeckstein, @gottesmm, @shajrawi ?