### PR TITLE
[benchmark] Add the ability for a benchmark to specify that it does n…

### DIFF
--- a/benchmark/utils/TestsUtils.swift
+++ b/benchmark/utils/TestsUtils.swift
@@ -70,34 +70,91 @@ public enum BenchmarkCategory : String {
   case skip
 }
 
+public struct BenchmarkPlatformSet : OptionSet {
+  public let rawValue: Int
+
+  public init(rawValue: Int) {
+    self.rawValue = rawValue
+  }
+
+  public static let darwin = BenchmarkPlatformSet(rawValue: 1 << 0)
+  public static let linux = BenchmarkPlatformSet(rawValue: 1 << 1)
+
+  public static var currentPlatform: BenchmarkPlatformSet {
+    #if os(Linux)
+      return .linux
+    #else
+      return .darwin
+    #endif
+  }
+
+  public static var allPlatforms: BenchmarkPlatformSet {
+    return [.darwin, .linux]
+  }
+}
+
 public struct BenchmarkInfo {
   /// The name of the benchmark that should be displayed by the harness.
   public var name: String
 
+  /// Shadow static variable for runFunction.
+  private var _runFunction: (Int) -> ()
+
   /// A function that invokes the specific benchmark routine.
-  public var runFunction: (Int) -> ()
+  public var runFunction: ((Int) -> ())? {
+    if !shouldRun {
+      return nil
+    }
+    return _runFunction
+  }
 
   /// A set of category tags that describe this benchmark. This is used by the
   /// harness to allow for easy slicing of the set of benchmarks along tag
   /// boundaries, e.x.: run all string benchmarks or ref count benchmarks, etc.
   public var tags: [BenchmarkCategory]
 
+  /// The platforms that this benchmark supports. This is an OptionSet.
+  private var unsupportedPlatforms: BenchmarkPlatformSet
+
+  /// Shadow variable for setUpFunction.
+  private var _setUpFunction: (() -> ())?
+
   /// An optional function that if non-null is run before benchmark samples
   /// are timed.
-  public var setUpFunction: (() -> ())?
+  public var setUpFunction : (() -> ())? {
+    if !shouldRun {
+      return nil
+    }
+    return _setUpFunction
+  }
+
+  /// Shadow static variable for computed property tearDownFunction.
+  private var _tearDownFunction: (() -> ())?
 
   /// An optional function that if non-null is run immediately after a sample is
   /// taken.
-  public var tearDownFunction: (() -> ())?
+  public var tearDownFunction: (() -> ())? {
+    if !shouldRun {
+      return nil
+    }
+    return _tearDownFunction
+  }
 
   public init(name: String, runFunction: @escaping (Int) -> (), tags: [BenchmarkCategory],
               setUpFunction: (() -> ())? = nil,
-              tearDownFunction: (() -> ())? = nil) {
+              tearDownFunction: (() -> ())? = nil,
+              unsupportedPlatforms: BenchmarkPlatformSet = []) {
     self.name = name
-    self.runFunction = runFunction
+    self._runFunction = runFunction
     self.tags = tags
-    self.setUpFunction = setUpFunction
-    self.tearDownFunction = tearDownFunction
+    self._setUpFunction = setUpFunction
+    self._tearDownFunction = tearDownFunction
+    self.unsupportedPlatforms = unsupportedPlatforms
+  }
+
+  /// Returns true if this benchmark should be run on the current platform.
+  var shouldRun: Bool {
+    return !unsupportedPlatforms.contains(.currentPlatform)
   }
 }
 


### PR DESCRIPTION
…ot run on specific platforms.

Today, one can not completely disable a benchmark depending on the platform
without changing the source of main.swift. We would like to be able to disable
benchmarks locally in a benchmark's file without needing to modify the rest of
the infrastructure. The closest that one can get to such behavior is to just
conditionally compile out the file locally. But one still will have the test
run.

This commit adds support for not-running the benchmark on specific
platforms. This in combination with conditional compilation of benchmark bodies,
allows us to not have to comment out module's in main.swift or have to
conditionally compile testinfo.

rdar://40541972
