### PR TITLE
Make URL.init(resolvingBookmarkData:…) non-failable

### DIFF
--- a/stdlib/public/SDK/Foundation/URL.swift
+++ b/stdlib/public/SDK/Foundation/URL.swift
@@ -586,7 +586,16 @@ public struct URL : ReferenceConvertible, Equatable {
     }
 
     /// Initializes a URL that refers to a location specified by resolving bookmark data.
+    @available(swift, obsoleted: 4.2)
     public init?(resolvingBookmarkData data: Data, options: BookmarkResolutionOptions = [], relativeTo url: URL? = nil, bookmarkDataIsStale: inout Bool) throws {
+        var stale : ObjCBool = false
+        _url = URL._converted(from: try NSURL(resolvingBookmarkData: data, options: options, relativeTo: url, bookmarkDataIsStale: &stale))
+        bookmarkDataIsStale = stale.boolValue
+    }
+
+    /// Initializes a URL that refers to a location specified by resolving bookmark data.
+    @available(swift, introduced: 4.2)
+    public init(resolvingBookmarkData data: Data, options: BookmarkResolutionOptions = [], relativeTo url: URL? = nil, bookmarkDataIsStale: inout Bool) throws {
         var stale : ObjCBool = false
         _url = URL._converted(from: try NSURL(resolvingBookmarkData: data, options: options, relativeTo: url, bookmarkDataIsStale: &stale))
         bookmarkDataIsStale = stale.boolValue


### PR DESCRIPTION
The NSURL method can't return `nil` unless it's throwing an error, so the Swift initializer shouldn't be failable.

Cherry-pick of #10435.

Resolves [SR-3705](https://bugs.swift.org/browse/SR-3705).
