### PR TITLE
Teach findAccessedStorage about global addressors.

### DIFF
--- a/include/swift/Parse/ParseSILSupport.h
+++ b/include/swift/Parse/ParseSILSupport.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_PARSER_PARSESILSUPPORT_H
 #define SWIFT_PARSER_PARSESILSUPPORT_H
 
+#include "swift/Parse/Parser.h"
 #include "llvm/Support/PrettyStackTrace.h"
 
 namespace swift {

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -350,15 +350,19 @@ namespace swift {
 /// If `sourceAddr` is produced by a begin_access, this returns a Nested
 /// AccessedStorage kind. This is useful for exclusivity checking to distinguish
 /// between a nested access vs. a conflict.
-AccessedStorage findAccessedStorage(SILValue sourceAddr);
+AccessedStorage findUnknownAccessedStorage(SILValue sourceAddr);
 
-/// Given an address accessed by an instruction that reads or modifies
-/// memory, return an AccessedStorage that identifies the formal access, looking
-/// through any Nested access to find the original storage.
+/// Given an address that is accessed with dynamic enforcement, return
+/// an AccessedStorage object that identifies the formal access.
 ///
-/// This is identical to findAccessedStorage(), but never returns Nested
-/// storage.
-AccessedStorage findAccessedStorageNonNested(SILValue sourceAddr);
+/// This has the same behavior findUnknownAccessedStorage except that dynamic
+/// access has stricter requirements. In particular, Unidentified access is only
+/// allowed for patterns that are recognized as local access. This should be
+/// used by any optimization pass that analyzes dynamic access and assumes that
+/// Global or Class access does not alias with Unidentified access.
+///
+/// The returned AccessedStorage will never be Nested.
+AccessedStorage findDynamicAccessedStorage(SILValue sourceAddr);
 
 /// Return true if the given address operand is used by a memory operation that
 /// initializes the memory at that address, implying that the previous value is

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -221,6 +221,7 @@ public:
     }
   }
 
+  /// Return true if the storage is guaranteed local.
   bool isLocal() const {
     switch (getKind()) {
     case Box:

--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -68,7 +68,8 @@ private:
   /// once (either in its declaration, or once later), making it immutable.
   unsigned IsLet : 1;
 
-  /// The VarDecl associated with this SILGlobalVariable. For debugger purpose.
+  /// The VarDecl associated with this SILGlobalVariable. Must by nonnull for
+  /// language-level global variables.
   VarDecl *VDecl;
 
   /// Whether or not this is a declaration.

--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -225,4 +225,38 @@ private:
 
 } // end llvm namespace
 
+//===----------------------------------------------------------------------===//
+// Utilities for verification and optimization.
+//===----------------------------------------------------------------------===//
+
+namespace swift {
+
+/// Given an addressor, AddrF, return the global variable being addressed, or
+/// return nullptr if the addressor isn't a recognized pattern.
+SILGlobalVariable *getVariableOfGlobalInit(SILFunction *AddrF);
+
+/// Return the callee of a once call.
+SILFunction *getCalleeOfOnceCall(BuiltinInst *BI);
+
+/// Helper for getVariableOfGlobalInit(), so GlobalOpts can deeply inspect and
+/// rewrite the initialization pattern.
+///
+/// Given an addressor, AddrF, find the call to the global initializer if
+/// present, otherwise return null. If an initializer is returned, then
+/// `CallsToOnce` is initialized to the corresponding builtin "once" call.
+SILFunction *findInitializer(SILModule *Module, SILFunction *AddrF,
+                             BuiltinInst *&CallToOnce);
+
+/// Helper for getVariableOfGlobalInit(), so GlobalOpts can deeply inspect and
+/// rewrite the initialization pattern.
+///
+/// Given a global initializer, InitFunc, return the GlobalVariable that it
+/// statically initializes or return nullptr if it isn't an obvious static
+/// initializer. If a global variable is returned, InitVal is initialized to the
+/// the instruction producing the global's initial value.
+SILGlobalVariable *getVariableOfStaticInitializer(
+  SILFunction *InitFunc, SingleValueInstruction *&InitVal);
+
+} // namespace swift
+
 #endif

--- a/include/swift/SIL/SILLinkage.h
+++ b/include/swift/SIL/SILLinkage.h
@@ -17,6 +17,8 @@
 
 namespace swift {
 
+class ValueDecl;
+
 /// Linkage for a SIL object.  This concept combines the notions
 /// of symbol linkage and visibility.
 ///
@@ -175,6 +177,8 @@ inline bool isPossiblyUsedExternally(SILLinkage linkage, bool wholeModule) {
   }
   return linkage <= SILLinkage::Hidden;
 }
+
+SILLinkage getDeclSILLinkage(const ValueDecl *decl);
 
 inline bool hasPublicVisibility(SILLinkage linkage) {
   switch (linkage) {

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -474,6 +474,14 @@ public:
   void setOptRecordStream(std::unique_ptr<llvm::yaml::Output> &&Stream,
                           std::unique_ptr<llvm::raw_ostream> &&RawStream);
 
+  // This is currently limited to VarDecl because the visibility of global
+  // variables and class properties is straighforward, while the visibility of
+  // class methods (ValueDecls) depends on the subclass scope. "Visiblity" has
+  // a different meaning when vtable layout is at stake.
+  bool isVisibleExternally(const VarDecl *decl) {
+    return isPossiblyUsedExternally(getDeclSILLinkage(decl), isWholeModule());
+  }
+
   PropertyListType &getPropertyList() { return properties; }
   const PropertyListType &getPropertyList() const { return properties; }
   

--- a/lib/SIL/SILGlobalVariable.cpp
+++ b/lib/SIL/SILGlobalVariable.cpp
@@ -10,7 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILGlobalVariable.h"
+#include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILLinkage.h"
 #include "swift/SIL/SILModule.h"
 
@@ -124,4 +126,133 @@ ClangNode SILGlobalVariable::getClangNode() const {
 }
 const clang::Decl *SILGlobalVariable::getClangDecl() const {
   return (VDecl ? VDecl->getClangDecl() : nullptr);
+}
+
+//===----------------------------------------------------------------------===//
+// Utilities for verification and optimization.
+//===----------------------------------------------------------------------===//
+
+static SILGlobalVariable *getStaticallyInitializedVariable(SILFunction *AddrF) {
+  if (AddrF->isExternalDeclaration())
+    return nullptr;
+
+  auto *RetInst = cast<ReturnInst>(AddrF->findReturnBB()->getTerminator());
+  auto *API = dyn_cast<AddressToPointerInst>(RetInst->getOperand());
+  if (!API)
+    return nullptr;
+  auto *GAI = dyn_cast<GlobalAddrInst>(API->getOperand());
+  if (!GAI)
+    return nullptr;
+
+  return GAI->getReferencedGlobal();
+}
+
+SILGlobalVariable *swift::getVariableOfGlobalInit(SILFunction *AddrF) {
+  if (!AddrF->isGlobalInit())
+    return nullptr;
+
+  if (auto *SILG = getStaticallyInitializedVariable(AddrF))
+    return SILG;
+
+  // If the addressor contains a single "once" call, it calls globalinit_func,
+  // and the globalinit_func is called by "once" from a single location,
+  // continue; otherwise bail.
+  BuiltinInst *CallToOnce;
+  auto *InitF = findInitializer(&AddrF->getModule(), AddrF, CallToOnce);
+
+  if (!InitF || !InitF->getName().startswith("globalinit_"))
+    return nullptr;
+
+  // If the globalinit_func is trivial, continue; otherwise bail.
+  SingleValueInstruction *dummyInitVal;
+  auto *SILG = getVariableOfStaticInitializer(InitF, dummyInitVal);
+
+  return SILG;
+}
+
+SILFunction *swift::getCalleeOfOnceCall(BuiltinInst *BI) {
+  assert(BI->getNumOperands() == 2 && "once call should have 2 operands.");
+
+  auto Callee = BI->getOperand(1);
+  assert(Callee->getType().castTo<SILFunctionType>()->getRepresentation()
+           == SILFunctionTypeRepresentation::CFunctionPointer &&
+         "Expected C function representation!");
+
+  if (auto *FR = dyn_cast<FunctionRefInst>(Callee))
+    return FR->getReferencedFunction();
+
+  return nullptr;
+}
+
+// Find the globalinit_func by analyzing the body of the addressor.
+SILFunction *swift::findInitializer(SILModule *Module, SILFunction *AddrF,
+                             BuiltinInst *&CallToOnce) {
+  // We only handle a single SILBasicBlock for now.
+  if (AddrF->size() != 1)
+    return nullptr;
+
+  CallToOnce = nullptr;
+  SILBasicBlock *BB = &AddrF->front();
+  for (auto &I : *BB) {
+    // Find the builtin "once" call.
+    if (auto *BI = dyn_cast<BuiltinInst>(&I)) {
+      const BuiltinInfo &Builtin =
+        BI->getModule().getBuiltinInfo(BI->getName());
+      if (Builtin.ID != BuiltinValueKind::Once)
+        continue;
+
+      // Bail if we have multiple "once" calls in the addressor.
+      if (CallToOnce)
+        return nullptr;
+
+      CallToOnce = BI;
+    }
+  }
+  if (!CallToOnce)
+    return nullptr;
+  return getCalleeOfOnceCall(CallToOnce);
+}
+
+SILGlobalVariable *
+swift::getVariableOfStaticInitializer(SILFunction *InitFunc,
+                                      SingleValueInstruction *&InitVal) {
+  InitVal = nullptr;
+  SILGlobalVariable *GVar = nullptr;
+  // We only handle a single SILBasicBlock for now.
+  if (InitFunc->size() != 1)
+    return nullptr;
+
+  SILBasicBlock *BB = &InitFunc->front();
+  GlobalAddrInst *SGA = nullptr;
+  bool HasStore = false;
+  for (auto &I : *BB) {
+    // Make sure we have a single GlobalAddrInst and a single StoreInst.
+    // And the StoreInst writes to the GlobalAddrInst.
+    if (isa<AllocGlobalInst>(&I) || isa<ReturnInst>(&I)
+        || isa<DebugValueInst>(&I)) {
+      continue;
+    } else if (auto *sga = dyn_cast<GlobalAddrInst>(&I)) {
+      if (SGA)
+        return nullptr;
+      SGA = sga;
+      GVar = SGA->getReferencedGlobal();
+    } else if (auto *SI = dyn_cast<StoreInst>(&I)) {
+      if (HasStore || SI->getDest() != SGA)
+        return nullptr;
+      HasStore = true;
+      SILValue value = SI->getSrc();
+
+      // We only handle StructInst and TupleInst being stored to a
+      // global variable for now.
+      if (!isa<StructInst>(value) && !isa<TupleInst>(value))
+        return nullptr;
+      InitVal = cast<SingleValueInstruction>(value);
+    } else if (!SILGlobalVariable::isValidStaticInitializerInst(&I,
+                                                             I.getModule())) {
+      return nullptr;
+    }
+  }
+  if (!InitVal)
+    return nullptr;
+  return GVar;
 }

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -855,3 +855,22 @@ SILProperty *SILProperty::create(SILModule &M,
   return prop;
 }
 
+// Definition from SILLinkage.h.
+SILLinkage swift::getDeclSILLinkage(const ValueDecl *decl) {
+  AccessLevel access = decl->getEffectiveAccess();
+  SILLinkage linkage;
+  switch (access) {
+  case AccessLevel::Private:
+  case AccessLevel::FilePrivate:
+    linkage = SILLinkage::Private;
+    break;
+  case AccessLevel::Internal:
+    linkage = SILLinkage::Hidden;
+    break;
+  case AccessLevel::Public:
+  case AccessLevel::Open:
+    linkage = SILLinkage::Public;
+    break;
+  }
+  return linkage;
+}

--- a/lib/SILGen/SILGenLValue.cpp
+++ b/lib/SILGen/SILGenLValue.cpp
@@ -500,7 +500,7 @@ SILValue UnenforcedAccess::beginAccess(SILGenFunction &SGF, SILLocation loc,
   if (!SGF.getOptions().VerifyExclusivity)
     return address;
 
-  const AccessedStorage &storage = findAccessedStorage(address);
+  const AccessedStorage &storage = findUnknownAccessedStorage(address);
   if (!storage) {
     llvm::dbgs() << "Bad memory access source: " << address;
     llvm_unreachable("Unexpected access source.");

--- a/lib/SILOptimizer/Analysis/AccessedStorageAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessedStorageAnalysis.cpp
@@ -272,7 +272,7 @@ transformCalleeStorage(const StorageAccessInfo &storage,
     SILValue argVal = getCallerArg(fullApply, storage.getParamIndex());
     if (argVal) {
       // Remap the argument source value and inherit the old storage info.
-      return StorageAccessInfo(findAccessedStorageNonNested(argVal), storage);
+      return StorageAccessInfo(findDynamicAccessedStorage(argVal), storage);
     }
     // If the argument can't be transformed, demote it to an unidentified
     // access.
@@ -304,7 +304,7 @@ void FunctionAccessedStorage::visitBeginAccess(B *beginAccess) {
     return;
 
   const AccessedStorage &storage =
-      findAccessedStorageNonNested(beginAccess->getSource());
+      findDynamicAccessedStorage(beginAccess->getSource());
 
   if (storage.getKind() == AccessedStorage::Unidentified) {
     // This also catches invalid storage.

--- a/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
@@ -128,25 +128,6 @@ class GlobalPropertyOpt {
     return false;
   }
 
-  bool isVisibleExternally(VarDecl *decl) {
-    AccessLevel access = decl->getEffectiveAccess();
-    SILLinkage linkage;
-    switch (access) {
-      case AccessLevel::Private:
-      case AccessLevel::FilePrivate:
-        linkage = SILLinkage::Private;
-        break;
-      case AccessLevel::Internal:
-        linkage = SILLinkage::Hidden;
-        break;
-      case AccessLevel::Public:
-      case AccessLevel::Open:
-        linkage = SILLinkage::Public;
-        break;
-    }
-    return isPossiblyUsedExternally(linkage, M.isWholeModule());
-  }
-  
   static bool canAddressEscape(SILValue V, bool acceptStore);
 
   /// Gets the entry for a struct or class field.
@@ -154,7 +135,7 @@ class GlobalPropertyOpt {
     Entry * &entry = FieldEntries[Field];
     if (!entry) {
       entry = new (EntryAllocator.Allocate()) Entry(SILValue(), Field);
-      if (isVisibleExternally(Field))
+      if (M.isVisibleExternally(Field))
         setAddressEscapes(entry);
     }
     return entry;

--- a/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
+++ b/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
@@ -284,28 +284,7 @@ static bool isSameInitSequence(const InitSequence &LHS,
 
 /// Check if a given let property can be assigned externally.
 static bool isAssignableExternally(VarDecl *Property, SILModule *Module) {
-  AccessLevel access = Property->getEffectiveAccess();
-  SILLinkage linkage;
-  switch (access) {
-  case AccessLevel::Private:
-  case AccessLevel::FilePrivate:
-    linkage = SILLinkage::Private;
-    DEBUG(llvm::dbgs() << "Property " << *Property << " has private access\n");
-    break;
-  case AccessLevel::Internal:
-    linkage = SILLinkage::Hidden;
-    DEBUG(llvm::dbgs() << "Property " << *Property << " has internal access\n");
-    break;
-  case AccessLevel::Public:
-  case AccessLevel::Open:
-    linkage = SILLinkage::Public;
-    DEBUG(llvm::dbgs() << "Property " << *Property << " has public access\n");
-    break;
-  }
-
-  DEBUG(llvm::dbgs() << "Module of " << *Property << " WMO mode is: " << Module->isWholeModule() << "\n");
-
-  if (isPossiblyUsedExternally(linkage, Module->isWholeModule())) {
+  if (Module->isVisibleExternally(Property)) {
     // If at least one of the properties of the enclosing type cannot be
     // used externally, then no initializer can be implemented externally as
     // it wouldn't be able to initialize such a property.

--- a/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
@@ -37,13 +37,11 @@
 using namespace swift;
 
 // This temporary option allows markers during optimization passes. Enabling
-// this flag causes this pass to preserve only dynamic checks when dynamic
-// checking is enabled. Otherwise, this pass removes all checks.
-//
-// This is currently unsupported because tail duplication results in
-// address-type block arguments.
+// this flag causes this pass to preserve static checks (as well as dynamic
+// checks) when dynamic checking is enabled. Otherwise, this pass removes all
+// static checks.
 llvm::cl::opt<bool> EnableOptimizedAccessMarkers(
-    "sil-optimized-access-markers", llvm::cl::init(true),
+    "sil-optimized-access-markers", llvm::cl::init(false),
     llvm::cl::desc("Enable memory access markers during optimization passes."));
 
 namespace {
@@ -80,13 +78,10 @@ struct AccessMarkerElimination {
 
 bool AccessMarkerElimination::shouldPreserveAccess(
     SILAccessEnforcement enforcement) {
-  if (!EnableOptimizedAccessMarkers)
-    return false;
-
   switch (enforcement) {
   case SILAccessEnforcement::Static:
   case SILAccessEnforcement::Unsafe:
-    return false;
+    return EnableOptimizedAccessMarkers;
   case SILAccessEnforcement::Unknown:
   case SILAccessEnforcement::Dynamic:
     return Mod->getOptions().EnforceExclusivityDynamic;

--- a/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
+++ b/lib/SILOptimizer/Mandatory/DiagnoseStaticExclusivity.cpp
@@ -589,7 +589,7 @@ static void diagnoseExclusivityViolation(const ConflictingAccess &Violation,
 
 /// Look through a value to find the underlying storage accessed.
 static AccessedStorage findValidAccessedStorage(SILValue Source) {
-  const AccessedStorage &Storage = findAccessedStorage(Source);
+  const AccessedStorage &Storage = findUnknownAccessedStorage(Source);
   if (!Storage) {
     llvm::dbgs() << "Bad memory access source: " << Source;
     llvm_unreachable("Unexpected access source.");
@@ -1058,13 +1058,12 @@ static void checkAccessedAddress(Operand *memOper, StorageMap &Accesses) {
   }
 
   // Strip off address projections, but not ref_element_addr.
-  const AccessedStorage &storage = findAccessedStorage(address);
-  // findAccessedStorage may return an invalid storage object if the address
-  // producer is not recognized by its whitelist. For the purpose of
-  // verification, we assume that this can only happen for local
-  // initialization, not a formal memory access. The strength of
-  // verification rests on the completeness of the opcode list inside
-  // findAccessedStorage.
+  const AccessedStorage &storage = findUnknownAccessedStorage(address);
+  // findUnknownAccessedStorage may return an invalid storage object if the
+  // address producer is not recognized by its whitelist. For the purpose of
+  // verification, we assume that this can only happen for local initialization,
+  // not a formal memory access. The strength of verification rests on the
+  // completeness of the opcode list inside findUnknownAccessedStorage.
   if (!storage || !isPossibleFormalAccessBase(storage, memInst->getFunction()))
     return;
 

--- a/test/SILOptimizer/accessed_storage_analysis.sil
+++ b/test/SILOptimizer/accessed_storage_analysis.sil
@@ -129,45 +129,207 @@ bb0(%0 : $Int):
   return %6 : $Int
 }
 
-sil_global @int_global : $Int
+public var defined_global: Int64
 
-// CHECK-LABEL: @readIdentifiedGlobal
-// CHECK: [read] Global // int_global
-// CHECK: sil_global @int_global : $Int
-sil @readIdentifiedGlobal : $@convention(thin) () -> Int {
+// defined_global definition and initializer.
+//
+// A global defined in the current module must have a Swift declaration.
+// The variable name is derived from the mangled SIL name.
+sil_global @$S25accessed_storage_analysis14defined_globalSivp : $Int64
+
+sil_global private @globalinit_33_45D320C25F1882286C6F155330EA3839_token0 : $Builtin.Word
+
+sil private @globalinit_33_45D320C25F1882286C6F155330EA3839_func0 : $@convention(c) () -> () {
 bb0:
-  %1 = global_addr @int_global : $*Int
-  %2 = begin_access [read] [dynamic] %1 : $*Int
-  %3 = load %2 : $*Int
-  end_access %2 : $*Int
-  return %3 : $Int
+  alloc_global @$S25accessed_storage_analysis14defined_globalSivp
+  %1 = global_addr @$S25accessed_storage_analysis14defined_globalSivp : $*Int64
+  %2 = integer_literal $Builtin.Int64, 0
+  %3 = struct $Int64 (%2 : $Builtin.Int64)
+  store %3 to %1 : $*Int64
+  %5 = tuple ()
+  return %5 : $()
 }
 
-// CHECK-LABEL: @writeIdentifiedGlobal
-// CHECK: [modify] Global // int_global
-// CHECK: sil_global @int_global : $Int
-sil @writeIdentifiedGlobal : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
-  %1 = global_addr @int_global : $*Int
-  %2 = begin_access [modify] [dynamic] %1 : $*Int
-  store %0 to %2 : $*Int
-  end_access %2 : $*Int
+// defined_global.unsafeMutableAddressor
+sil hidden [global_init] @$S25accessed_storage_analysis14defined_globalSivau : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = global_addr @globalinit_33_45D320C25F1882286C6F155330EA3839_token0 : $*Builtin.Word
+  %1 = address_to_pointer %0 : $*Builtin.Word to $Builtin.RawPointer
+  %2 = function_ref @globalinit_33_45D320C25F1882286C6F155330EA3839_func0 : $@convention(c) () -> ()
+  %3 = builtin "once"(%1 : $Builtin.RawPointer, %2 : $@convention(c) () -> ()) : $()
+  %4 = global_addr @$S25accessed_storage_analysis14defined_globalSivp : $*Int64
+  %5 = address_to_pointer %4 : $*Int64 to $Builtin.RawPointer
+  return %5 : $Builtin.RawPointer
+}
+
+// CHECK-LABEL: @readIdentifiedDefinedGlobal
+// CHECK: [read] Global // defined_global
+// CHECK: sil_global @$S25accessed_storage_analysis14defined_globalSivp : $Int64
+sil @readIdentifiedDefinedGlobal : $@convention(thin) () -> Int64 {
+bb0:
+  %1 = global_addr @$S25accessed_storage_analysis14defined_globalSivp : $*Int64
+  %2 = begin_access [read] [dynamic] %1 : $*Int64
+  %3 = load %2 : $*Int64
+  end_access %2 : $*Int64
+  return %3 : $Int64
+}
+
+// CHECK-LABEL: @writeIdentifiedDefinedGlobal
+// CHECK: [modify] Global // defined_global
+// CHECK: sil_global @$S25accessed_storage_analysis14defined_globalSivp : $Int64
+sil @writeIdentifiedDefinedGlobal : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  %1 = global_addr @$S25accessed_storage_analysis14defined_globalSivp : $*Int64
+  %2 = begin_access [modify] [dynamic] %1 : $*Int64
+  store %0 to %2 : $*Int64
+  end_access %2 : $*Int64
   %v = tuple ()
   return %v : $()
 }
 
-// CHECK-LABEL: @readWriteIdentifiedGlobal
-// CHECK: [modify] Global // int_global
-// CHECK: sil_global @int_global : $Int
-sil @readWriteIdentifiedGlobal : $@convention(thin) (Int) -> (Int) {
-bb0(%0 : $Int):
-  %1 = function_ref @writeIdentifiedGlobal : $@convention(thin) (Int) -> ()
-  %2 = apply %1(%0) : $@convention(thin) (Int) -> ()
-  %3 = global_addr @int_global : $*Int
-  %4 = begin_access [read] [dynamic] %3 : $*Int
-  %5 = load %4 : $*Int
-  end_access %4 : $*Int
-  return %5 : $Int
+// CHECK-LABEL: @readWriteIdentifiedDefinedGlobal
+// CHECK: [modify] Global // defined_global
+// CHECK: sil_global @$S25accessed_storage_analysis14defined_globalSivp : $Int64
+sil @readWriteIdentifiedDefinedGlobal : $@convention(thin) (Int64) -> (Int64) {
+bb0(%0 : $Int64):
+  %1 = function_ref @writeIdentifiedDefinedGlobal : $@convention(thin) (Int64) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (Int64) -> ()
+  %3 = global_addr @$S25accessed_storage_analysis14defined_globalSivp : $*Int64
+  %4 = begin_access [read] [dynamic] %3 : $*Int64
+  %5 = load %4 : $*Int64
+  end_access %4 : $*Int64
+  return %5 : $Int64
+}
+
+// CHECK-LABEL: @readIdentifiedAddressedGlobal
+// CHECK: [read] Global // defined_global
+// CHECK: sil_global @$S25accessed_storage_analysis14defined_globalSivp : $Int64
+sil @readIdentifiedAddressedGlobal : $@convention(thin) () -> Int64 {
+bb0:
+  // function_ref myGlobal.unsafeMutableAddressor
+  %0 = function_ref @$S25accessed_storage_analysis14defined_globalSivau : $@convention(thin) () -> Builtin.RawPointer
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Int64
+  %3 = begin_access [read] [dynamic] %2 : $*Int64
+  %4 = load %3 : $*Int64
+  end_access %3 : $*Int64
+  return %4 : $Int64
+}
+
+// CHECK-LABEL: @writeIdentifiedAddressedGlobal
+// CHECK: [modify] Global // defined_global
+// CHECK: sil_global @$S25accessed_storage_analysis14defined_globalSivp : $Int64
+sil @writeIdentifiedAddressedGlobal : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  // function_ref myGlobal.unsafeMutableAddressor
+  %1 = function_ref @$S25accessed_storage_analysis14defined_globalSivau : $@convention(thin) () -> Builtin.RawPointer
+  %2 = apply %1() : $@convention(thin) () -> Builtin.RawPointer
+  %3 = pointer_to_address %2 : $Builtin.RawPointer to [strict] $*Int64
+  %4 = begin_access [modify] [dynamic] %3 : $*Int64
+  store %0 to %4 : $*Int64
+  end_access %4 : $*Int64
+  %v = tuple ()
+  return %v : $()
+}
+
+// CHECK-LABEL: @readWriteIdentifiedAddressedGlobal
+// CHECK: [modify] Global // defined_global
+// CHECK: sil_global @$S25accessed_storage_analysis14defined_globalSivp : $Int64
+sil @readWriteIdentifiedAddressedGlobal : $@convention(thin) (Int64) -> (Int64) {
+bb0(%0 : $Int64):
+  %1 = function_ref @writeIdentifiedAddressedGlobal : $@convention(thin) (Int64) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (Int64) -> ()
+  // function_ref myGlobal.unsafeMutableAddressor
+  %3 = function_ref @$S25accessed_storage_analysis14defined_globalSivau : $@convention(thin) () -> Builtin.RawPointer
+  %4 = apply %3() : $@convention(thin) () -> Builtin.RawPointer
+  %5 = pointer_to_address %4 : $Builtin.RawPointer to [strict] $*Int64
+  %6 = begin_access [modify] [dynamic] %5 : $*Int64
+  %7 = load %6 : $*Int64
+  end_access %6 : $*Int64
+  return %7 : $Int64
+}
+
+public var static_global: Int64
+
+// static_global definition and static initializer.
+//
+// A global defined in the current module must have a Swift declaration.
+// The variable name is derived from the mangled SIL name.
+sil_global @$S25accessed_storage_analysis13static_globalSivp : $Int64 = {
+  %0 = integer_literal $Builtin.Int64, 0
+  %initval = struct $Int64 (%0 : $Builtin.Int64)
+}
+
+// static_global.unsafeMutableAddressor
+sil hidden [global_init] @$S25accessed_storage_analysis13static_globalSivau : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = global_addr @$S25accessed_storage_analysis14defined_globalSivp : $*Int64
+  %1 = address_to_pointer %0 : $*Int64 to $Builtin.RawPointer
+  return %1 : $Builtin.RawPointer
+}
+
+// A sil_global such as this without a corresponding Swift declaration must be
+// defined in another module. Such a global can only be identified when accessed
+// via global_addr instruction (as happens with C imports). Any access via an
+// addessor (as with Swift imports) will be Unidentified. For the purpose of
+// access analysis, a global is considered "external" based on the availabitiy
+// of a Swift declaraion. We only consider an global to be a disjoint access
+// location if its declaration is available.
+sil_global @external_global : $Int64
+
+sil hidden_external [global_init] @globalAddressor : $@convention(thin) () -> Builtin.RawPointer
+
+// CHECK-LABEL: @readIdentifiedExternalGlobal
+// CHECK: [read] Global // external_global
+// CHECK: sil_global @external_global : $Int64
+sil @readIdentifiedExternalGlobal : $@convention(thin) () -> Int64 {
+bb0:
+  %1 = global_addr @external_global : $*Int64
+  %2 = begin_access [read] [dynamic] %1 : $*Int64
+  %3 = load %2 : $*Int64
+  end_access %2 : $*Int64
+  return %3 : $Int64
+}
+
+// CHECK-LABEL: @writeIdentifiedExternalGlobal
+// CHECK: [modify] Global // external_global
+// CHECK: sil_global @external_global : $Int64
+sil @writeIdentifiedExternalGlobal : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  %1 = global_addr @external_global : $*Int64
+  %2 = begin_access [modify] [dynamic] %1 : $*Int64
+  store %0 to %2 : $*Int64
+  end_access %2 : $*Int64
+  %v = tuple ()
+  return %v : $()
+}
+
+// CHECK-LABEL: @readWriteIdentifiedExternalGlobal
+// CHECK: [modify] Global // external_global
+// CHECK: sil_global @external_global : $Int64
+sil @readWriteIdentifiedExternalGlobal : $@convention(thin) (Int64) -> (Int64) {
+bb0(%0 : $Int64):
+  %1 = function_ref @writeIdentifiedExternalGlobal : $@convention(thin) (Int64) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (Int64) -> ()
+  %3 = global_addr @external_global : $*Int64
+  %4 = begin_access [read] [dynamic] %3 : $*Int64
+  %5 = load %4 : $*Int64
+  end_access %4 : $*Int64
+  return %5 : $Int64
+}
+
+// CHECK-LABEL: @readUnidentifiedExternalGlobal
+// CHECK-NOT: Global
+// CHECK: unidentified accesses: modify
+sil @readUnidentifiedExternalGlobal : $@convention(thin) () -> Int64 {
+bb0:
+  %0 = function_ref @globalAddressor : $@convention(thin) () -> Builtin.RawPointer
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Int64
+  %3 = begin_access [read] [dynamic] %2 : $*Int64
+  %4 = load %3 : $*Int64
+  end_access %3 : $*Int64
+  return %4 : $Int64
 }
 
 class C {
@@ -216,88 +378,6 @@ bb0(%0 : $Int):
   return %6 : $Int
 }
 
-// CHECK-LABEL: @readIdentifiedNestedClass
-// CHECK: [read] Class %0 = argument of bb0 : $C
-// CHECK: Field: @sil_stored var property: Int
-sil @readIdentifiedNestedClass : $@convention(thin) (@guaranteed C) -> Int {
-bb0(%0 : $C):
-  %1 = ref_element_addr %0 : $C, #C.property
-  %2 = begin_access [read] [dynamic] %1 : $*Int
-  %3 = begin_access [read] [dynamic] %2 : $*Int
-  %4 = load %3 : $*Int
-  end_access %2 : $*Int
-  end_access %3 : $*Int
-  return %4 : $Int
-}
-
-// CHECK-LABEL: @writeIdentifiedNestedClass
-// CHECK: [modify] Class %0 = argument of bb0 : $C
-// CHECK: Field: @sil_stored var property: Int
-sil @writeIdentifiedNestedClass : $@convention(thin) (@guaranteed C, Int) -> () {
-bb0(%0 : $C, %1 : $Int):
-  %2 = ref_element_addr %0 : $C, #C.property
-  %3 = begin_access [read] [dynamic] %2 : $*Int
-  %4 = begin_access [modify] [dynamic] %3 : $*Int
-  store %1 to %4 : $*Int
-  end_access %4 : $*Int
-  end_access %3 : $*Int
-  %v = tuple ()
-  return %v : $()
-}
-
-// CHECK-LABEL: @readWriteIdentifiedNestedClass
-// CHECK: [modify] Class   %1 = alloc_ref $C
-// CHECK: Field: @sil_stored var property: Int
-sil @readWriteIdentifiedNestedClass : $@convention(thin) (Int) -> (Int) {
-bb0(%0 : $Int):
-  %1 = alloc_ref $C
-  %2 = function_ref @writeIdentifiedNestedClass : $@convention(thin) (@guaranteed C, Int) -> ()
-  %3 = apply %2(%1, %0) : $@convention(thin) (@guaranteed C, Int) -> ()
-  %4 = ref_element_addr %1 : $C, #C.property
-  %5 = begin_access [read] [dynamic] %4 : $*Int
-  %6 = begin_access [read] [dynamic] %5 : $*Int
-  %7 = load %6 : $*Int
-  end_access %5 : $*Int
-  end_access %6 : $*Int
-  return %7 : $Int
-}
-
-// CHECK-LABEL: @readUnidentified
-// CHECK: unidentified accesses: read
-sil @readUnidentified : $@convention(thin) (Builtin.RawPointer) -> Int {
-bb0(%0 : $Builtin.RawPointer):
-  %1 = pointer_to_address %0 : $Builtin.RawPointer to $*Int
-  %2 = begin_access [read] [dynamic] %1 : $*Int
-  %4 = load %2 : $*Int
-  end_access %2 : $*Int
-  return %4 : $Int
-}
-
-// CHECK-LABEL: @writeUnidentified
-// CHECK: unidentified accesses: modify
-sil @writeUnidentified : $@convention(thin) (Builtin.RawPointer, Int) -> () {
-bb0(%0 : $Builtin.RawPointer, %1 : $Int):
-  %2 = pointer_to_address %0 : $Builtin.RawPointer to $*Int
-  %3 = begin_access [modify] [dynamic] %2 : $*Int
-  store %1 to %3 : $*Int
-  end_access %3 : $*Int
-  %v = tuple ()
-  return %v : $()
-}
-
-// CHECK-LABEL: @readWriteUnidentified
-// CHECK: unidentified accesses: modify
-sil @readWriteUnidentified : $@convention(thin) (Builtin.RawPointer, Int) -> Int {
-bb0(%0 : $Builtin.RawPointer, %1 : $Int):
-  %2 = function_ref @writeUnidentified : $@convention(thin) (Builtin.RawPointer, Int) -> ()
-  %3 = apply %2(%0, %1) : $@convention(thin) (Builtin.RawPointer, Int) -> ()
-  %4 = pointer_to_address %0 : $Builtin.RawPointer to $*Int
-  %5 = begin_access [read] [dynamic] %4 : $*Int
-  %6 = load %5 : $*Int
-  end_access %5 : $*Int
-  return %6 : $Int
-}
-
 enum TreeB<T> {
   case Nil
   case Leaf(T)
@@ -321,70 +401,12 @@ bb0(%0 : $*TreeB<T>, %1 : $*TreeB<T>):
 
 struct SomeError: Error {}
 
-// CHECK-LABEL: @writeIdentifiedArgReadUnidentifiedVarious
-// CHECK: [modify] Argument index: 0
-// CHECK: unidentified accesses: read
-sil @writeIdentifiedArgReadUnidentifiedVarious : $@convention(thin) (Int, Error) -> (@out Int) {
-bb0(%out : $*Int, %i : $Int, %e : $Error):
-  %argAccess = begin_access [modify] [dynamic] %out : $*Int
-  store %i to %argAccess : $*Int
-  end_access %argAccess : $*Int
-
-  %peb = project_existential_box $SomeError in %e : $Error
-  %pebAccess = begin_access [read] [dynamic] %peb : $*SomeError
-  %eload = load %pebAccess : $*SomeError
-  end_access %pebAccess : $*SomeError
-
-  %oeb = open_existential_box %e : $Error to $*@opened("01234567-89AB-CDEF-0123-333333333333") Error
-  %oebAccess = begin_access [read] [dynamic] %oeb : $*@opened("01234567-89AB-CDEF-0123-333333333333") Error
-  end_access %oebAccess : $*@opened("01234567-89AB-CDEF-0123-333333333333") Error
-
-  %v = tuple ()
-  return %v : $()
-}
-
 protocol P {}
 
 class CP : P {
   var property: Int
   init()
   deinit
-}
-
-// None of these address producers are normally used for formal
-// access. i.e. They should not feed into a begin_access
-// operand. Eventually, we may want to verify that SIL passes never
-// result in such patterns. Until then we gracefully treat them as
-// unidentified access.
-// CHECK-LABEL: @readUnexpected
-// CHECK: unidentified accesses: read
-sil @readUnexpected : $@convention(thin) (@inout Int, @inout Int?, @inout Builtin.UnsafeValueBuffer) -> () {
-bb0(%inout : $*Int, %oi : $*Optional<Int>, %b : $*Builtin.UnsafeValueBuffer):
-  br bb1(%inout : $*Int)
-
-bb1(%phi : $*Int):
-  %phiAccess = begin_access [read] [dynamic] %phi : $*Int
-  %ld = load %phiAccess : $*Int
-  end_access %phiAccess : $*Int
-
-  %ea = init_enum_data_addr %oi : $*Optional<Int>, #Optional.some!enumelt.1
-  %eaAccess = begin_access [read] [dynamic] %ea : $*Int
-  %eaload = load %eaAccess : $*Int
-  end_access %eaAccess : $*Int
-
-  %pvb = project_value_buffer $Int in %b : $*Builtin.UnsafeValueBuffer
-  %pvbAccess = begin_access [read] [dynamic] %pvb : $*Int
-  %bload = load %pvbAccess : $*Int
-  end_access %pvbAccess : $*Int
-
-  %p = alloc_stack $P
-  %iea = init_existential_addr %p : $*P, $CP
-  %propAccess = begin_access [read] [dynamic] %iea : $*CP
-  end_access %propAccess : $*CP
-  dealloc_stack %p : $*P
-
-  %v = tuple ()
-  return %v : $()
 }
 
 // CHECK-LABEL: @testDirectlyAppliedNoEscape
@@ -506,4 +528,120 @@ bb2(%7 : ${ var Int }):
 
 bb3(%result : $Int):
   return %result : $Int
+}
+
+// None of these address producers are normally used for formal
+// access. i.e. They should not feed into a begin_access operand. Eventually, we
+// may want to verify that SIL passes never result in such patterns. For now,
+// SILVerifier will assert only when the access is dynamic, which means
+// AccessedStorageAnalysis cannot see them.
+//
+// For now, we test that SILVerifier does *not* assert when the access is static.
+sil @readUnexpected : $@convention(thin) (@inout Int, @inout Int?, @inout Builtin.UnsafeValueBuffer) -> () {
+bb0(%inout : $*Int, %oi : $*Optional<Int>, %b : $*Builtin.UnsafeValueBuffer):
+  %ea = init_enum_data_addr %oi : $*Optional<Int>, #Optional.some!enumelt.1
+  %eaAccess = begin_access [read] [static] %ea : $*Int
+  %eaload = load %eaAccess : $*Int
+  end_access %eaAccess : $*Int
+
+  %pvb = project_value_buffer $Int in %b : $*Builtin.UnsafeValueBuffer
+  %pvbAccess = begin_access [read] [static] %pvb : $*Int
+  %bload = load %pvbAccess : $*Int
+  end_access %pvbAccess : $*Int
+
+  %p = alloc_stack $P
+  %iea = init_existential_addr %p : $*P, $CP
+  %propAccess = begin_access [read] [static] %iea : $*CP
+  end_access %propAccess : $*CP
+  dealloc_stack %p : $*P
+
+  %v = tuple ()
+  return %v : $()
+}
+
+// Nested access will assert unless it is static.
+sil @readIdentifiedNestedClass : $@convention(thin) (@guaranteed C) -> Int {
+bb0(%0 : $C):
+  %1 = ref_element_addr %0 : $C, #C.property
+  %2 = begin_access [read] [static] %1 : $*Int
+  %3 = begin_access [read] [static] %2 : $*Int
+  %4 = load %3 : $*Int
+  end_access %2 : $*Int
+  end_access %3 : $*Int
+  return %4 : $Int
+}
+
+// Nested access will assert unless it is static.
+sil @writeIdentifiedNestedClass : $@convention(thin) (@guaranteed C, Int) -> () {
+bb0(%0 : $C, %1 : $Int):
+  %2 = ref_element_addr %0 : $C, #C.property
+  %3 = begin_access [read] [static] %2 : $*Int
+  %4 = begin_access [modify] [static] %3 : $*Int
+  store %1 to %4 : $*Int
+  end_access %4 : $*Int
+  end_access %3 : $*Int
+  %v = tuple ()
+  return %v : $()
+}
+
+// Nested access will assert unless it is static.
+sil @readWriteIdentifiedNestedClass : $@convention(thin) (Int) -> (Int) {
+bb0(%0 : $Int):
+  %1 = alloc_ref $C
+  %2 = function_ref @writeIdentifiedNestedClass : $@convention(thin) (@guaranteed C, Int) -> ()
+  %3 = apply %2(%1, %0) : $@convention(thin) (@guaranteed C, Int) -> ()
+  %4 = ref_element_addr %1 : $C, #C.property
+  %5 = begin_access [read] [static] %4 : $*Int
+  %6 = begin_access [read] [static] %5 : $*Int
+  %7 = load %6 : $*Int
+  end_access %5 : $*Int
+  end_access %6 : $*Int
+  return %7 : $Int
+}
+
+// The SILVerifier allows these static access patterns, but will assert if they are dynamic.
+sil @writeIdentifiedArgReadUnidentifiedVarious : $@convention(thin) (Int, Error) -> (@out Int) {
+bb0(%out : $*Int, %i : $Int, %e : $Error):
+  %argAccess = begin_access [modify] [static] %out : $*Int
+  store %i to %argAccess : $*Int
+  end_access %argAccess : $*Int
+
+  %peb = project_existential_box $SomeError in %e : $Error
+  %pebAccess = begin_access [read] [static] %peb : $*SomeError
+  %eload = load %pebAccess : $*SomeError
+  end_access %pebAccess : $*SomeError
+
+  %oeb = open_existential_box %e : $Error to $*@opened("01234567-89AB-CDEF-0123-333333333333") Error
+  %oebAccess = begin_access [read] [static] %oeb : $*@opened("01234567-89AB-CDEF-0123-333333333333") Error
+  end_access %oebAccess : $*@opened("01234567-89AB-CDEF-0123-333333333333") Error
+
+  %v = tuple ()
+  return %v : $()
+}
+
+// UnsafePointer.pointee may be statically accessed as follows. The SILVerifier
+// will assert on dynamic access to it.
+sil @readUnsafePointer : $@convention(thin) (UnsafeMutablePointer<Int32>) -> Int32 {
+bb0(%0 : $UnsafeMutablePointer<Int32>):
+  %ptr = struct_extract %0 : $UnsafeMutablePointer<Int32>, #UnsafeMutablePointer._rawValue
+  %adr = pointer_to_address %ptr : $Builtin.RawPointer to [strict] $*Int32
+  %access = begin_access [read] [static] %adr : $*Int32
+  %val = load %access : $*Int32
+  end_access %access : $*Int32
+  return %val : $Int32
+}
+
+// Helper for @readMaterializeForSet.
+sil @readMaterializeForSetHelper : $@convention(thin) () -> (Builtin.RawPointer, Optional<Builtin.RawPointer>)
+
+sil @readMaterializeForSet : $@convention(thin) () -> Int32 {
+bb0:
+  %f = function_ref @readMaterializeForSetHelper : $@convention(thin) () -> (Builtin.RawPointer, Optional<Builtin.RawPointer>)
+  %call = apply %f() : $@convention(thin) () -> (Builtin.RawPointer, Optional<Builtin.RawPointer>)
+  %ptr = tuple_extract %call : $(Builtin.RawPointer, Optional<Builtin.RawPointer>), 0
+  %adr = pointer_to_address %ptr : $Builtin.RawPointer to [strict] $*Int32
+  %access = begin_access [read] [static] %adr : $*Int32
+  %val = load %access : $*Int32
+  end_access %access : $*Int32
+  return %val : $Int32
 }


### PR DESCRIPTION
All but the last commit are covered by: https://github.com/apple/swift/pull/16870.

The only new change here is to enable strict verification of formal access on global variables and add unit tests.

AccessedStorage now properly represents access to global variables, even if they
haven't been fully optimized down to global_addr instructions.

This is essential for optimizing dynamic exclusivity checks. As a verified SIL property, all access to globals and class properties needs to be identifiable.