### PR TITLE
[build-script] SKIP_TEST_BENCHMARK => SKIP_TEST_BENCHMARKS

### DIFF
--- a/utils/build-script
+++ b/utils/build-script
@@ -168,17 +168,17 @@ class HostSpecificConfiguration(object):
             if build_benchmarks:
                 self.swift_benchmark_build_targets.append(
                     "swift-benchmark-" + name)
-                # FIXME: This probably should respect `args.benchmark`, but
-                # a typo in build-script-impl meant we always would do this.
-                self.swift_benchmark_run_targets.append(
-                    "check-swift-benchmark-" + name)
+                if args.benchmark:
+                    self.swift_benchmark_run_targets.append(
+                        "check-swift-benchmark-" + name)
 
             if build_external_benchmarks:
                 # Add support for the external benchmarks.
                 self.swift_benchmark_build_targets.append(
                     "swift-benchmark-{}-external".format(name))
-                self.swift_benchmark_run_targets.append(
-                    "check-swift-benchmark-{}-external".format(name))
+                if args.benchmark:
+                    self.swift_benchmark_run_targets.append(
+                        "check-swift-benchmark-{}-external".format(name))
             if test:
                 if test_host_only:
                     suffix = "-non-executable"

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1389,7 +1389,7 @@ function calculate_targets_for_host() {
         fi
         if [[ "${build_benchmark_this_target}" ]] && [[ "${is_in_build_list}" ]]; then
             SWIFT_BENCHMARK_TARGETS+=("swift-benchmark-${stdlib_deployment_target}")
-            if [[ $(not ${SKIP_TEST_BENCHMARK}) ]] ; then
+            if [[ $(not ${SKIP_TEST_BENCHMARKS}) ]] ; then
               SWIFT_RUN_BENCHMARK_TARGETS+=("check-swift-benchmark-${stdlib_deployment_target}")
             fi
         fi
@@ -1398,7 +1398,7 @@ function calculate_targets_for_host() {
            [[ "${build_external_benchmark_this_target}" ]] &&
            [[ "${is_in_build_list}" ]] ; then
             SWIFT_BENCHMARK_TARGETS+=("swift-benchmark-${stdlib_deployment_target}-external")
-            if [[ $(not ${SKIP_TEST_BENCHMARK}) ]] ; then
+            if [[ $(not ${SKIP_TEST_BENCHMARKS}) ]] ; then
                 SWIFT_RUN_BENCHMARK_TARGETS+=("check-swift-benchmark-${stdlib_deployment_target}-external")
             fi
         fi
@@ -1811,8 +1811,7 @@ for host in "${ALL_HOSTS[@]}"; do
             echo "Running Swift tests for: ${SWIFT_TEST_TARGETS[@]}"
         fi
         if ! [[ "${SKIP_TEST_BENCHMARKS}" ]] &&
-                [[ "${SWIFT_RUN_BENCHMARK_TARGETS[@]}" ]] &&
-                ! [[ "${SKIP_TEST_BENCHMARK}" ]]; then
+             [[ "${SWIFT_RUN_BENCHMARK_TARGETS[@]}" ]]; then
             echo "Running Swift benchmarks for: ${SWIFT_RUN_BENCHMARK_TARGETS[@]}"
         fi
     fi


### PR DESCRIPTION
I looked for --skip-test-benchmark (notice no s) and SKIP_TEST_BENCHMARK. It
seems like it is dead, especially since we have --skip-test-benchmarks.
