### PR TITLE
 Add stronger SILVerifier support for formal access. 

### DIFF
--- a/include/swift/Parse/ParseSILSupport.h
+++ b/include/swift/Parse/ParseSILSupport.h
@@ -13,6 +13,7 @@
 #ifndef SWIFT_PARSER_PARSESILSUPPORT_H
 #define SWIFT_PARSER_PARSESILSUPPORT_H
 
+#include "swift/Parse/Parser.h"
 #include "llvm/Support/PrettyStackTrace.h"
 
 namespace swift {

--- a/include/swift/SIL/MemAccessUtils.h
+++ b/include/swift/SIL/MemAccessUtils.h
@@ -221,6 +221,7 @@ public:
     }
   }
 
+  /// Return true if the storage is guaranteed local.
   bool isLocal() const {
     switch (getKind()) {
     case Box:

--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -68,7 +68,8 @@ private:
   /// once (either in its declaration, or once later), making it immutable.
   unsigned IsLet : 1;
 
-  /// The VarDecl associated with this SILGlobalVariable. For debugger purpose.
+  /// The VarDecl associated with this SILGlobalVariable. Must by nonnull for
+  /// language-level global variables.
   VarDecl *VDecl;
 
   /// Whether or not this is a declaration.

--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -225,4 +225,38 @@ private:
 
 } // end llvm namespace
 
+//===----------------------------------------------------------------------===//
+// Utilities for verification and optimization.
+//===----------------------------------------------------------------------===//
+
+namespace swift {
+
+/// Given an addressor, AddrF, return the global variable being addressed, or
+/// return nullptr if the addressor isn't a recognized pattern.
+SILGlobalVariable *getVariableOfGlobalInit(SILFunction *AddrF);
+
+/// Return the callee of a once call.
+SILFunction *getCalleeOfOnceCall(BuiltinInst *BI);
+
+/// Helper for getVariableOfGlobalInit(), so GlobalOpts can deeply inspect and
+/// rewrite the initialization pattern.
+///
+/// Given an addressor, AddrF, find the call to the global initializer if
+/// present, otherwise return null. If an initializer is returned, then
+/// `CallsToOnce` is initialized to the corresponding builtin "once" call.
+SILFunction *findInitializer(SILModule *Module, SILFunction *AddrF,
+                             BuiltinInst *&CallToOnce);
+
+/// Helper for getVariableOfGlobalInit(), so GlobalOpts can deeply inspect and
+/// rewrite the initialization pattern.
+///
+/// Given a global initializer, InitFunc, return the GlobalVariable that it
+/// statically initializes or return nullptr if it isn't an obvious static
+/// initializer. If a global variable is returned, InitVal is initialized to the
+/// the instruction producing the global's initial value.
+SILGlobalVariable *getVariableOfStaticInitializer(
+  SILFunction *InitFunc, SingleValueInstruction *&InitVal);
+
+} // namespace swift
+
 #endif

--- a/include/swift/SIL/SILLinkage.h
+++ b/include/swift/SIL/SILLinkage.h
@@ -17,6 +17,8 @@
 
 namespace swift {
 
+class ValueDecl;
+
 /// Linkage for a SIL object.  This concept combines the notions
 /// of symbol linkage and visibility.
 ///
@@ -175,6 +177,8 @@ inline bool isPossiblyUsedExternally(SILLinkage linkage, bool wholeModule) {
   }
   return linkage <= SILLinkage::Hidden;
 }
+
+SILLinkage getDeclSILLinkage(const ValueDecl *decl);
 
 inline bool hasPublicVisibility(SILLinkage linkage) {
   switch (linkage) {

--- a/include/swift/SIL/SILModule.h
+++ b/include/swift/SIL/SILModule.h
@@ -474,6 +474,14 @@ public:
   void setOptRecordStream(std::unique_ptr<llvm::yaml::Output> &&Stream,
                           std::unique_ptr<llvm::raw_ostream> &&RawStream);
 
+  // This is currently limited to VarDecl because the visibility of global
+  // variables and class properties is straighforward, while the visibility of
+  // class methods (ValueDecls) depends on the subclass scope. "Visiblity" has
+  // a different meaning when vtable layout is at stake.
+  bool isVisibleExternally(const VarDecl *decl) {
+    return isPossiblyUsedExternally(getDeclSILLinkage(decl), isWholeModule());
+  }
+
   PropertyListType &getPropertyList() { return properties; }
   const PropertyListType &getPropertyList() const { return properties; }
   

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -17,9 +17,10 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/Timer.h"
+#include "swift/Demangling/Demangle.h"
 #include "swift/Parse/Lexer.h"
-#include "swift/Parse/Parser.h"
 #include "swift/Parse/ParseSILSupport.h"
+#include "swift/Parse/Parser.h"
 #include "swift/SIL/AbstractionPattern.h"
 #include "swift/SIL/InstructionUtils.h"
 #include "swift/SIL/SILArgument.h"
@@ -28,8 +29,8 @@
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILUndef.h"
 #include "swift/SIL/TypeLowering.h"
-#include "swift/Syntax/SyntaxKind.h"
 #include "swift/Subsystems.h"
+#include "swift/Syntax/SyntaxKind.h"
 #include "llvm/ADT/StringSwitch.h"
 #include "llvm/Support/SaveAndRestore.h"
 
@@ -5403,11 +5404,27 @@ bool SILParserTUState::parseSILGlobal(Parser &P) {
   if (!GlobalLinkage.hasValue())
     GlobalLinkage = SILLinkage::DefaultForDefinition;
 
-  // FIXME: check for existing global variable?
-  auto *GV = SILGlobalVariable::create(M, GlobalLinkage.getValue(),
-                                       isSerialized,
-                                       GlobalName.str(),GlobalType,
-                                       RegularLocation(NameLoc));
+  // Lookup the global variable declaration for this sil_global.
+  std::string GlobalDeclName = Demangle::demangleSymbolAsString(
+    GlobalName.str(), Demangle::DemangleOptions::SimplifiedUIDemangleOptions());
+  SmallVector<ValueDecl *, 4> CurModuleResults;
+  P.SF.getParentModule()->lookupValue(
+      {}, P.Context.getIdentifier(GlobalDeclName), NLKind::UnqualifiedLookup,
+      CurModuleResults);
+  // A variable declaration exists for all sil_global variables defined in
+  // Swift. If a Swift global is defined outside this module, it will be exposed
+  // via an addressor rather than as a sil_global. However, globals imported
+  // from clang *will* result in a sil_global *without* any corresponding
+  // variable declaration.
+  VarDecl *VD = nullptr;
+  if (!CurModuleResults.empty()) {
+    assert(CurModuleResults.size() == 1);
+    VD = cast<VarDecl>(CurModuleResults[0]);
+    assert(getDeclSILLinkage(VD) == GlobalLinkage);
+  }
+  auto *GV = SILGlobalVariable::create(
+      M, GlobalLinkage.getValue(), isSerialized, GlobalName.str(), GlobalType,
+      RegularLocation(NameLoc), VD);
 
   GV->setLet(isLet);
   // Parse static initializer if exists.

--- a/lib/SIL/SILGlobalVariable.cpp
+++ b/lib/SIL/SILGlobalVariable.cpp
@@ -10,7 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILGlobalVariable.h"
+#include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILLinkage.h"
 #include "swift/SIL/SILModule.h"
 
@@ -124,4 +126,133 @@ ClangNode SILGlobalVariable::getClangNode() const {
 }
 const clang::Decl *SILGlobalVariable::getClangDecl() const {
   return (VDecl ? VDecl->getClangDecl() : nullptr);
+}
+
+//===----------------------------------------------------------------------===//
+// Utilities for verification and optimization.
+//===----------------------------------------------------------------------===//
+
+static SILGlobalVariable *getStaticallyInitializedVariable(SILFunction *AddrF) {
+  if (AddrF->isExternalDeclaration())
+    return nullptr;
+
+  auto *RetInst = cast<ReturnInst>(AddrF->findReturnBB()->getTerminator());
+  auto *API = dyn_cast<AddressToPointerInst>(RetInst->getOperand());
+  if (!API)
+    return nullptr;
+  auto *GAI = dyn_cast<GlobalAddrInst>(API->getOperand());
+  if (!GAI)
+    return nullptr;
+
+  return GAI->getReferencedGlobal();
+}
+
+SILGlobalVariable *swift::getVariableOfGlobalInit(SILFunction *AddrF) {
+  if (!AddrF->isGlobalInit())
+    return nullptr;
+
+  if (auto *SILG = getStaticallyInitializedVariable(AddrF))
+    return SILG;
+
+  // If the addressor contains a single "once" call, it calls globalinit_func,
+  // and the globalinit_func is called by "once" from a single location,
+  // continue; otherwise bail.
+  BuiltinInst *CallToOnce;
+  auto *InitF = findInitializer(&AddrF->getModule(), AddrF, CallToOnce);
+
+  if (!InitF || !InitF->getName().startswith("globalinit_"))
+    return nullptr;
+
+  // If the globalinit_func is trivial, continue; otherwise bail.
+  SingleValueInstruction *dummyInitVal;
+  auto *SILG = getVariableOfStaticInitializer(InitF, dummyInitVal);
+
+  return SILG;
+}
+
+SILFunction *swift::getCalleeOfOnceCall(BuiltinInst *BI) {
+  assert(BI->getNumOperands() == 2 && "once call should have 2 operands.");
+
+  auto Callee = BI->getOperand(1);
+  assert(Callee->getType().castTo<SILFunctionType>()->getRepresentation()
+           == SILFunctionTypeRepresentation::CFunctionPointer &&
+         "Expected C function representation!");
+
+  if (auto *FR = dyn_cast<FunctionRefInst>(Callee))
+    return FR->getReferencedFunction();
+
+  return nullptr;
+}
+
+// Find the globalinit_func by analyzing the body of the addressor.
+SILFunction *swift::findInitializer(SILModule *Module, SILFunction *AddrF,
+                             BuiltinInst *&CallToOnce) {
+  // We only handle a single SILBasicBlock for now.
+  if (AddrF->size() != 1)
+    return nullptr;
+
+  CallToOnce = nullptr;
+  SILBasicBlock *BB = &AddrF->front();
+  for (auto &I : *BB) {
+    // Find the builtin "once" call.
+    if (auto *BI = dyn_cast<BuiltinInst>(&I)) {
+      const BuiltinInfo &Builtin =
+        BI->getModule().getBuiltinInfo(BI->getName());
+      if (Builtin.ID != BuiltinValueKind::Once)
+        continue;
+
+      // Bail if we have multiple "once" calls in the addressor.
+      if (CallToOnce)
+        return nullptr;
+
+      CallToOnce = BI;
+    }
+  }
+  if (!CallToOnce)
+    return nullptr;
+  return getCalleeOfOnceCall(CallToOnce);
+}
+
+SILGlobalVariable *
+swift::getVariableOfStaticInitializer(SILFunction *InitFunc,
+                                      SingleValueInstruction *&InitVal) {
+  InitVal = nullptr;
+  SILGlobalVariable *GVar = nullptr;
+  // We only handle a single SILBasicBlock for now.
+  if (InitFunc->size() != 1)
+    return nullptr;
+
+  SILBasicBlock *BB = &InitFunc->front();
+  GlobalAddrInst *SGA = nullptr;
+  bool HasStore = false;
+  for (auto &I : *BB) {
+    // Make sure we have a single GlobalAddrInst and a single StoreInst.
+    // And the StoreInst writes to the GlobalAddrInst.
+    if (isa<AllocGlobalInst>(&I) || isa<ReturnInst>(&I)
+        || isa<DebugValueInst>(&I)) {
+      continue;
+    } else if (auto *sga = dyn_cast<GlobalAddrInst>(&I)) {
+      if (SGA)
+        return nullptr;
+      SGA = sga;
+      GVar = SGA->getReferencedGlobal();
+    } else if (auto *SI = dyn_cast<StoreInst>(&I)) {
+      if (HasStore || SI->getDest() != SGA)
+        return nullptr;
+      HasStore = true;
+      SILValue value = SI->getSrc();
+
+      // We only handle StructInst and TupleInst being stored to a
+      // global variable for now.
+      if (!isa<StructInst>(value) && !isa<TupleInst>(value))
+        return nullptr;
+      InitVal = cast<SingleValueInstruction>(value);
+    } else if (!SILGlobalVariable::isValidStaticInitializerInst(&I,
+                                                             I.getModule())) {
+      return nullptr;
+    }
+  }
+  if (!InitVal)
+    return nullptr;
+  return GVar;
 }

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -855,3 +855,22 @@ SILProperty *SILProperty::create(SILModule &M,
   return prop;
 }
 
+// Definition from SILLinkage.h.
+SILLinkage swift::getDeclSILLinkage(const ValueDecl *decl) {
+  AccessLevel access = decl->getEffectiveAccess();
+  SILLinkage linkage;
+  switch (access) {
+  case AccessLevel::Private:
+  case AccessLevel::FilePrivate:
+    linkage = SILLinkage::Private;
+    break;
+  case AccessLevel::Internal:
+    linkage = SILLinkage::Hidden;
+    break;
+  case AccessLevel::Public:
+  case AccessLevel::Open:
+    linkage = SILLinkage::Public;
+    break;
+  }
+  return linkage;
+}

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1605,10 +1605,16 @@ public:
       break;
     }
 
-    // For dynamic Read/Modify access, AccessEnforcementWMO assumes a valid
-    // AccessedStorage and runs very late in the optimizer pipeline.
-    // TODO: eventually, make this true for any kind of access.
-    findAccessedStorage(sourceOper);
+    // Verify that all formal accesses patterns are recognized as part of a
+    // whitelist. The presence of an unknown pattern means that analysis will
+    // silently fail, and the compiler may be introducing undefined behavior
+    // with no other way to detect it.
+    //
+    // For example, AccessEnforcementWMO runs very late in the
+    // pipeline and assumes valid storage for all dynamic Read/Modify access. It
+    // also requires that Unidentified access fit a whitelist on known
+    // non-internal globals or class properties.
+    require(findAccessedStorage(sourceOper), "Unknown formal access pattern.");
   }
 
   void checkEndAccessInst(EndAccessInst *EAI) {

--- a/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
+++ b/lib/SILOptimizer/IPO/GlobalPropertyOpt.cpp
@@ -128,25 +128,6 @@ class GlobalPropertyOpt {
     return false;
   }
 
-  bool isVisibleExternally(VarDecl *decl) {
-    AccessLevel access = decl->getEffectiveAccess();
-    SILLinkage linkage;
-    switch (access) {
-      case AccessLevel::Private:
-      case AccessLevel::FilePrivate:
-        linkage = SILLinkage::Private;
-        break;
-      case AccessLevel::Internal:
-        linkage = SILLinkage::Hidden;
-        break;
-      case AccessLevel::Public:
-      case AccessLevel::Open:
-        linkage = SILLinkage::Public;
-        break;
-    }
-    return isPossiblyUsedExternally(linkage, M.isWholeModule());
-  }
-  
   static bool canAddressEscape(SILValue V, bool acceptStore);
 
   /// Gets the entry for a struct or class field.
@@ -154,7 +135,7 @@ class GlobalPropertyOpt {
     Entry * &entry = FieldEntries[Field];
     if (!entry) {
       entry = new (EntryAllocator.Allocate()) Entry(SILValue(), Field);
-      if (isVisibleExternally(Field))
+      if (M.isVisibleExternally(Field))
         setAddressEscapes(entry);
     }
     return entry;

--- a/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
+++ b/lib/SILOptimizer/IPO/LetPropertiesOpts.cpp
@@ -284,28 +284,7 @@ static bool isSameInitSequence(const InitSequence &LHS,
 
 /// Check if a given let property can be assigned externally.
 static bool isAssignableExternally(VarDecl *Property, SILModule *Module) {
-  AccessLevel access = Property->getEffectiveAccess();
-  SILLinkage linkage;
-  switch (access) {
-  case AccessLevel::Private:
-  case AccessLevel::FilePrivate:
-    linkage = SILLinkage::Private;
-    DEBUG(llvm::dbgs() << "Property " << *Property << " has private access\n");
-    break;
-  case AccessLevel::Internal:
-    linkage = SILLinkage::Hidden;
-    DEBUG(llvm::dbgs() << "Property " << *Property << " has internal access\n");
-    break;
-  case AccessLevel::Public:
-  case AccessLevel::Open:
-    linkage = SILLinkage::Public;
-    DEBUG(llvm::dbgs() << "Property " << *Property << " has public access\n");
-    break;
-  }
-
-  DEBUG(llvm::dbgs() << "Module of " << *Property << " WMO mode is: " << Module->isWholeModule() << "\n");
-
-  if (isPossiblyUsedExternally(linkage, Module->isWholeModule())) {
+  if (Module->isVisibleExternally(Property)) {
     // If at least one of the properties of the enclosing type cannot be
     // used externally, then no initializer can be implemented externally as
     // it wouldn't be able to initialize such a property.

--- a/test/SILOptimizer/accessed_storage_analysis.sil
+++ b/test/SILOptimizer/accessed_storage_analysis.sil
@@ -129,45 +129,207 @@ bb0(%0 : $Int):
   return %6 : $Int
 }
 
-sil_global @int_global : $Int
+public var defined_global: Int64
 
-// CHECK-LABEL: @readIdentifiedGlobal
-// CHECK: [read] Global // int_global
-// CHECK: sil_global @int_global : $Int
-sil @readIdentifiedGlobal : $@convention(thin) () -> Int {
+// defined_global definition and initializer.
+//
+// A global defined in the current module must have a Swift declaration.
+// The variable name is derived from the mangled SIL name.
+sil_global @$S25accessed_storage_analysis14defined_globalSivp : $Int64
+
+sil_global private @globalinit_33_45D320C25F1882286C6F155330EA3839_token0 : $Builtin.Word
+
+sil private @globalinit_33_45D320C25F1882286C6F155330EA3839_func0 : $@convention(c) () -> () {
 bb0:
-  %1 = global_addr @int_global : $*Int
-  %2 = begin_access [read] [dynamic] %1 : $*Int
-  %3 = load %2 : $*Int
-  end_access %2 : $*Int
-  return %3 : $Int
+  alloc_global @$S25accessed_storage_analysis14defined_globalSivp
+  %1 = global_addr @$S25accessed_storage_analysis14defined_globalSivp : $*Int64
+  %2 = integer_literal $Builtin.Int64, 0
+  %3 = struct $Int64 (%2 : $Builtin.Int64)
+  store %3 to %1 : $*Int64
+  %5 = tuple ()
+  return %5 : $()
 }
 
-// CHECK-LABEL: @writeIdentifiedGlobal
-// CHECK: [modify] Global // int_global
-// CHECK: sil_global @int_global : $Int
-sil @writeIdentifiedGlobal : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
-  %1 = global_addr @int_global : $*Int
-  %2 = begin_access [modify] [dynamic] %1 : $*Int
-  store %0 to %2 : $*Int
-  end_access %2 : $*Int
+// defined_global.unsafeMutableAddressor
+sil hidden [global_init] @$S25accessed_storage_analysis14defined_globalSivau : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = global_addr @globalinit_33_45D320C25F1882286C6F155330EA3839_token0 : $*Builtin.Word
+  %1 = address_to_pointer %0 : $*Builtin.Word to $Builtin.RawPointer
+  %2 = function_ref @globalinit_33_45D320C25F1882286C6F155330EA3839_func0 : $@convention(c) () -> ()
+  %3 = builtin "once"(%1 : $Builtin.RawPointer, %2 : $@convention(c) () -> ()) : $()
+  %4 = global_addr @$S25accessed_storage_analysis14defined_globalSivp : $*Int64
+  %5 = address_to_pointer %4 : $*Int64 to $Builtin.RawPointer
+  return %5 : $Builtin.RawPointer
+}
+
+// CHECK-LABEL: @readIdentifiedDefinedGlobal
+// CHECK: [read] Global // defined_global
+// CHECK: sil_global @$S25accessed_storage_analysis14defined_globalSivp : $Int64
+sil @readIdentifiedDefinedGlobal : $@convention(thin) () -> Int64 {
+bb0:
+  %1 = global_addr @$S25accessed_storage_analysis14defined_globalSivp : $*Int64
+  %2 = begin_access [read] [dynamic] %1 : $*Int64
+  %3 = load %2 : $*Int64
+  end_access %2 : $*Int64
+  return %3 : $Int64
+}
+
+// CHECK-LABEL: @writeIdentifiedDefinedGlobal
+// CHECK: [modify] Global // defined_global
+// CHECK: sil_global @$S25accessed_storage_analysis14defined_globalSivp : $Int64
+sil @writeIdentifiedDefinedGlobal : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  %1 = global_addr @$S25accessed_storage_analysis14defined_globalSivp : $*Int64
+  %2 = begin_access [modify] [dynamic] %1 : $*Int64
+  store %0 to %2 : $*Int64
+  end_access %2 : $*Int64
   %v = tuple ()
   return %v : $()
 }
 
-// CHECK-LABEL: @readWriteIdentifiedGlobal
-// CHECK: [modify] Global // int_global
-// CHECK: sil_global @int_global : $Int
-sil @readWriteIdentifiedGlobal : $@convention(thin) (Int) -> (Int) {
-bb0(%0 : $Int):
-  %1 = function_ref @writeIdentifiedGlobal : $@convention(thin) (Int) -> ()
-  %2 = apply %1(%0) : $@convention(thin) (Int) -> ()
-  %3 = global_addr @int_global : $*Int
-  %4 = begin_access [read] [dynamic] %3 : $*Int
-  %5 = load %4 : $*Int
-  end_access %4 : $*Int
-  return %5 : $Int
+// CHECK-LABEL: @readWriteIdentifiedDefinedGlobal
+// CHECK: [modify] Global // defined_global
+// CHECK: sil_global @$S25accessed_storage_analysis14defined_globalSivp : $Int64
+sil @readWriteIdentifiedDefinedGlobal : $@convention(thin) (Int64) -> (Int64) {
+bb0(%0 : $Int64):
+  %1 = function_ref @writeIdentifiedDefinedGlobal : $@convention(thin) (Int64) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (Int64) -> ()
+  %3 = global_addr @$S25accessed_storage_analysis14defined_globalSivp : $*Int64
+  %4 = begin_access [read] [dynamic] %3 : $*Int64
+  %5 = load %4 : $*Int64
+  end_access %4 : $*Int64
+  return %5 : $Int64
+}
+
+// CHECK-LABEL: @readIdentifiedAddressedGlobal
+// CHECK: [read] Global // defined_global
+// CHECK: sil_global @$S25accessed_storage_analysis14defined_globalSivp : $Int64
+sil @readIdentifiedAddressedGlobal : $@convention(thin) () -> Int64 {
+bb0:
+  // function_ref myGlobal.unsafeMutableAddressor
+  %0 = function_ref @$S25accessed_storage_analysis14defined_globalSivau : $@convention(thin) () -> Builtin.RawPointer
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Int64
+  %3 = begin_access [read] [dynamic] %2 : $*Int64
+  %4 = load %3 : $*Int64
+  end_access %3 : $*Int64
+  return %4 : $Int64
+}
+
+// CHECK-LABEL: @writeIdentifiedAddressedGlobal
+// CHECK: [modify] Global // defined_global
+// CHECK: sil_global @$S25accessed_storage_analysis14defined_globalSivp : $Int64
+sil @writeIdentifiedAddressedGlobal : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  // function_ref myGlobal.unsafeMutableAddressor
+  %1 = function_ref @$S25accessed_storage_analysis14defined_globalSivau : $@convention(thin) () -> Builtin.RawPointer
+  %2 = apply %1() : $@convention(thin) () -> Builtin.RawPointer
+  %3 = pointer_to_address %2 : $Builtin.RawPointer to [strict] $*Int64
+  %4 = begin_access [modify] [dynamic] %3 : $*Int64
+  store %0 to %4 : $*Int64
+  end_access %4 : $*Int64
+  %v = tuple ()
+  return %v : $()
+}
+
+// CHECK-LABEL: @readWriteIdentifiedAddressedGlobal
+// CHECK: [modify] Global // defined_global
+// CHECK: sil_global @$S25accessed_storage_analysis14defined_globalSivp : $Int64
+sil @readWriteIdentifiedAddressedGlobal : $@convention(thin) (Int64) -> (Int64) {
+bb0(%0 : $Int64):
+  %1 = function_ref @writeIdentifiedAddressedGlobal : $@convention(thin) (Int64) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (Int64) -> ()
+  // function_ref myGlobal.unsafeMutableAddressor
+  %3 = function_ref @$S25accessed_storage_analysis14defined_globalSivau : $@convention(thin) () -> Builtin.RawPointer
+  %4 = apply %3() : $@convention(thin) () -> Builtin.RawPointer
+  %5 = pointer_to_address %4 : $Builtin.RawPointer to [strict] $*Int64
+  %6 = begin_access [modify] [dynamic] %5 : $*Int64
+  %7 = load %6 : $*Int64
+  end_access %6 : $*Int64
+  return %7 : $Int64
+}
+
+public var static_global: Int64
+
+// static_global definition and static initializer.
+//
+// A global defined in the current module must have a Swift declaration.
+// The variable name is derived from the mangled SIL name.
+sil_global @$S25accessed_storage_analysis13static_globalSivp : $Int64 = {
+  %0 = integer_literal $Builtin.Int64, 0
+  %initval = struct $Int64 (%0 : $Builtin.Int64)
+}
+
+// static_global.unsafeMutableAddressor
+sil hidden [global_init] @$S25accessed_storage_analysis13static_globalSivau : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = global_addr @$S25accessed_storage_analysis14defined_globalSivp : $*Int64
+  %1 = address_to_pointer %0 : $*Int64 to $Builtin.RawPointer
+  return %1 : $Builtin.RawPointer
+}
+
+// A sil_global such as this without a corresponding Swift declaration must be
+// defined in another module. Such a global can only be identified when accessed
+// via global_addr instruction (as happens with C imports). Any access via an
+// addessor (as with Swift imports) will be Unidentified. For the purpose of
+// access analysis, a global is considered "external" based on the availabitiy
+// of a Swift declaraion. We only consider an global to be a disjoint access
+// location if its declaration is available.
+sil_global @external_global : $Int64
+
+sil hidden_external [global_init] @globalAddressor : $@convention(thin) () -> Builtin.RawPointer
+
+// CHECK-LABEL: @readIdentifiedExternalGlobal
+// CHECK: [read] Global // external_global
+// CHECK: sil_global @external_global : $Int64
+sil @readIdentifiedExternalGlobal : $@convention(thin) () -> Int64 {
+bb0:
+  %1 = global_addr @external_global : $*Int64
+  %2 = begin_access [read] [dynamic] %1 : $*Int64
+  %3 = load %2 : $*Int64
+  end_access %2 : $*Int64
+  return %3 : $Int64
+}
+
+// CHECK-LABEL: @writeIdentifiedExternalGlobal
+// CHECK: [modify] Global // external_global
+// CHECK: sil_global @external_global : $Int64
+sil @writeIdentifiedExternalGlobal : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  %1 = global_addr @external_global : $*Int64
+  %2 = begin_access [modify] [dynamic] %1 : $*Int64
+  store %0 to %2 : $*Int64
+  end_access %2 : $*Int64
+  %v = tuple ()
+  return %v : $()
+}
+
+// CHECK-LABEL: @readWriteIdentifiedExternalGlobal
+// CHECK: [modify] Global // external_global
+// CHECK: sil_global @external_global : $Int64
+sil @readWriteIdentifiedExternalGlobal : $@convention(thin) (Int64) -> (Int64) {
+bb0(%0 : $Int64):
+  %1 = function_ref @writeIdentifiedExternalGlobal : $@convention(thin) (Int64) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (Int64) -> ()
+  %3 = global_addr @external_global : $*Int64
+  %4 = begin_access [read] [dynamic] %3 : $*Int64
+  %5 = load %4 : $*Int64
+  end_access %4 : $*Int64
+  return %5 : $Int64
+}
+
+// CHECK-LABEL: @readUnidentifiedExternalGlobal
+// CHECK-NOT: Global
+// CHECK: unidentified accesses: modify
+sil @readUnidentifiedExternalGlobal : $@convention(thin) () -> Int64 {
+bb0:
+  %0 = function_ref @globalAddressor : $@convention(thin) () -> Builtin.RawPointer
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Int64
+  %3 = begin_access [read] [dynamic] %2 : $*Int64
+  %4 = load %3 : $*Int64
+  end_access %3 : $*Int64
+  return %4 : $Int64
 }
 
 class C {
@@ -262,42 +424,6 @@ bb0(%0 : $Int):
   return %7 : $Int
 }
 
-// CHECK-LABEL: @readUnidentified
-// CHECK: unidentified accesses: read
-sil @readUnidentified : $@convention(thin) (Builtin.RawPointer) -> Int {
-bb0(%0 : $Builtin.RawPointer):
-  %1 = pointer_to_address %0 : $Builtin.RawPointer to $*Int
-  %2 = begin_access [read] [dynamic] %1 : $*Int
-  %4 = load %2 : $*Int
-  end_access %2 : $*Int
-  return %4 : $Int
-}
-
-// CHECK-LABEL: @writeUnidentified
-// CHECK: unidentified accesses: modify
-sil @writeUnidentified : $@convention(thin) (Builtin.RawPointer, Int) -> () {
-bb0(%0 : $Builtin.RawPointer, %1 : $Int):
-  %2 = pointer_to_address %0 : $Builtin.RawPointer to $*Int
-  %3 = begin_access [modify] [dynamic] %2 : $*Int
-  store %1 to %3 : $*Int
-  end_access %3 : $*Int
-  %v = tuple ()
-  return %v : $()
-}
-
-// CHECK-LABEL: @readWriteUnidentified
-// CHECK: unidentified accesses: modify
-sil @readWriteUnidentified : $@convention(thin) (Builtin.RawPointer, Int) -> Int {
-bb0(%0 : $Builtin.RawPointer, %1 : $Int):
-  %2 = function_ref @writeUnidentified : $@convention(thin) (Builtin.RawPointer, Int) -> ()
-  %3 = apply %2(%0, %1) : $@convention(thin) (Builtin.RawPointer, Int) -> ()
-  %4 = pointer_to_address %0 : $Builtin.RawPointer to $*Int
-  %5 = begin_access [read] [dynamic] %4 : $*Int
-  %6 = load %5 : $*Int
-  end_access %5 : $*Int
-  return %6 : $Int
-}
-
 enum TreeB<T> {
   case Nil
   case Leaf(T)
@@ -360,13 +486,6 @@ class CP : P {
 // CHECK: unidentified accesses: read
 sil @readUnexpected : $@convention(thin) (@inout Int, @inout Int?, @inout Builtin.UnsafeValueBuffer) -> () {
 bb0(%inout : $*Int, %oi : $*Optional<Int>, %b : $*Builtin.UnsafeValueBuffer):
-  br bb1(%inout : $*Int)
-
-bb1(%phi : $*Int):
-  %phiAccess = begin_access [read] [dynamic] %phi : $*Int
-  %ld = load %phiAccess : $*Int
-  end_access %phiAccess : $*Int
-
   %ea = init_enum_data_addr %oi : $*Optional<Int>, #Optional.some!enumelt.1
   %eaAccess = begin_access [read] [dynamic] %ea : $*Int
   %eaload = load %eaAccess : $*Int


### PR DESCRIPTION
Ensure that all formal access follows recognizable patterns
at all points in the SIL pipeline.

This is important to run acccess enforcement optimization late in the pipeline.

This is a single-commit PR building on https://github.com/apple/swift/pull/16877