### PR TITLE
Implement benchmark testing on Linux

### DIFF
--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -2,40 +2,54 @@
 include(CMakeParseArguments)
 include(SwiftBenchmarkUtils)
 
-macro (configure_build)
+macro(configure_build)
   add_definitions(-DSWIFT_EXEC -DSWIFT_LIBRARY_PATH -DONLY_PLATFORMS
                   -DSWIFT_OPTIMIZATION_LEVELS -DSWIFT_BENCHMARK_EMIT_SIB)
 
   if(NOT ONLY_PLATFORMS)
-    set(ONLY_PLATFORMS "macosx" "iphoneos" "appletvos" "watchos")
+    set(ONLY_PLATFORMS "macosx" "iphoneos" "appletvos" "watchos" "linux")
   endif()
 
-  if(NOT SWIFT_EXEC)
-    runcmd(COMMAND "xcrun" "-f" "swiftc"
-           VARIABLE SWIFT_EXEC
-           ERROR "Unable to find Swift driver")
+  if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+    if(NOT SWIFT_EXEC)
+      runcmd(COMMAND "xcrun" "-f" "swiftc"
+        VARIABLE SWIFT_EXEC
+        ERROR "Unable to find Swift driver")
+    endif()
+
+    # If the CMAKE_C_COMPILER is already clang, don't find it again,
+    # thus allowing the --host-cc build-script argument to work here.
+    get_filename_component(c_compiler ${CMAKE_C_COMPILER} NAME)
+
+    if(${c_compiler} STREQUAL "clang")
+      set(CLANG_EXEC ${CMAKE_C_COMPILER})
+    else()
+      runcmd(COMMAND "xcrun" "-toolchain" "${SWIFT_DARWIN_XCRUN_TOOLCHAIN}" "-f" "clang"
+             VARIABLE CLANG_EXEC
+             ERROR "Unable to find Clang driver")
+    endif()
+  elseif("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+    # We always require SWIFT_EXEC and CLANG_EXEC to be specified explicitly
+    # when compiling for Linux.
+    #
+    # TODO: Investigate if we can eliminate CLANG_EXEC/SWIFT_EXEC and use more
+    # normal like cmake patterns.
+    precondition(SWIFT_EXEC)
+    precondition(CLANG_EXEC)
+  else()
+    message(FATAL_ERROR "Unsupported platform?!")
   endif()
 
+  # We always infer the SWIFT_LIBRARY_PATH from SWIFT_EXEC unless
+  # SWIFT_LIBRARY_PATH is specified explicitly.
   if(NOT SWIFT_LIBRARY_PATH)
     get_filename_component(tmp_dir "${SWIFT_EXEC}" DIRECTORY)
     get_filename_component(tmp_dir "${tmp_dir}" DIRECTORY)
     set(SWIFT_LIBRARY_PATH "${tmp_dir}/lib/swift")
   endif()
-
-  # If the CMAKE_C_COMPILER is already clang, don't find it again,
-  # thus allowing the --host-cc build-script argument to work here.
-  get_filename_component(c_compiler ${CMAKE_C_COMPILER} NAME)
-
-  if(${c_compiler} STREQUAL "clang")
-    set(CLANG_EXEC ${CMAKE_C_COMPILER})
-  else()
-    runcmd(COMMAND "xcrun" "-toolchain" "${SWIFT_DARWIN_XCRUN_TOOLCHAIN}" "-f" "clang"
-           VARIABLE CLANG_EXEC
-           ERROR "Unable to find Clang driver")
-  endif()
 endmacro()
 
-macro (configure_sdks)
+macro(configure_sdks_darwin)
   set(macosx_arch "x86_64")
   set(iphoneos_arch "arm64" "armv7")
   set(appletvos_arch "arm64")
@@ -54,6 +68,7 @@ macro (configure_sdks)
   set(sdks)
   set(platforms)
   foreach(platform ${ONLY_PLATFORMS})
+    set(${platform}_is_darwin TRUE)
     execute_process(
         COMMAND "xcrun" "--sdk" "${platform}" "--show-sdk-path"
         OUTPUT_VARIABLE ${platform}_sdk
@@ -64,6 +79,31 @@ macro (configure_sdks)
       list(APPEND platforms ${platform})
     endif()
   endforeach()
+endmacro()
+
+macro(configure_sdks_linux)
+  # TODO: Get the correct triple.
+  set(linux_arch "x86_64")
+  set(linux_ver "") # Linux doesn't use the ver field
+  set(linux_vendor "unknown")
+  set(linux_triple_platform "linux")
+  set(linux_sdk "") # Linux doesn't use sdks.
+  set(linux_is_darwin FALSE)
+
+  # This is not applicable on linux since on linux we do not use
+  # SDKs/frameworks when building our benchmarks.
+  set(sdks "N/A")
+  set(platforms "linux")
+endmacro()
+
+macro(configure_sdks)
+  if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+    configure_sdks_darwin()
+  elseif ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+    configure_sdks_linux()
+  else()
+    message(FATAL_ERROR "Unsupported system: ${CMAKE_SYSTEM_NAME}?!")
+  endif()
 endmacro()
 
 function (add_swift_benchmark_library objfile_out sibfile_out)
@@ -229,11 +269,13 @@ endfunction()
 
 function (swift_benchmark_compile_archopts)
   cmake_parse_arguments(BENCH_COMPILE_ARCHOPTS "" "PLATFORM;ARCH;OPT" "" ${ARGN})
+  set(is_darwin ${${BENCH_COMPILE_ARCHOPTS_PLATFORM}_is_darwin})
   set(sdk ${${BENCH_COMPILE_ARCHOPTS_PLATFORM}_sdk})
+  set(vendor ${${BENCH_COMPILE_ARCHOPTS_PLATFORM}_vendor})
   set(ver ${${BENCH_COMPILE_ARCHOPTS_PLATFORM}_ver})
   set(triple_platform ${${BENCH_COMPILE_ARCHOPTS_PLATFORM}_triple_platform})
 
-  set(target "${BENCH_COMPILE_ARCHOPTS_ARCH}-apple-${triple_platform}${ver}")
+  set(target "${BENCH_COMPILE_ARCHOPTS_ARCH}-${vendor}-${triple_platform}${ver}")
 
   set(objdir "${CMAKE_CURRENT_BINARY_DIR}/${BENCH_COMPILE_ARCHOPTS_OPT}-${target}")
   file(MAKE_DIRECTORY "${objdir}")
@@ -250,12 +292,16 @@ function (swift_benchmark_compile_archopts)
 
   set(common_options
       "-c"
-      "-sdk" "${sdk}"
       "-target" "${target}"
+      "-${BENCH_COMPILE_ARCHOPTS_OPT}")
+
+  if (is_darwin)
+    list(APPEND common_options
+      "-I" "${srcdir}/utils/ObjectiveCTests"
       "-F" "${sdk}/../../../Developer/Library/Frameworks"
-      "-${BENCH_COMPILE_ARCHOPTS_OPT}"
-      "-no-link-objc-runtime"
-      "-I" "${srcdir}/utils/ObjectiveCTests")
+      "-sdk" "${sdk}"
+      "-no-link-objc-runtime")
+  endif()
 
   set(opt_view_main_dir)
   if(SWIFT_BENCHMARK_GENERATE_OPT_VIEW AND LLVM_HAVE_OPT_VIEWER_MODULES)
@@ -274,12 +320,15 @@ function (swift_benchmark_compile_archopts)
 
   set(common_options_driver
       "-c"
-      "-sdk" "${sdk}"
       "-target" "${target}"
-      "-F" "${sdk}/../../../Developer/Library/Frameworks"
-      "-${driver_opt}"
-      "-no-link-objc-runtime")
+      "-${driver_opt}")
 
+  if (is_darwin)
+    list(APPEND common_options_driver
+      "-sdk" "${sdk}"
+      "-F" "${sdk}/../../../Developer/Library/Frameworks"
+      "-no-link-objc-runtime")
+  endif()
   set(bench_library_objects)
   set(bench_library_sibfiles)
   set(opt_view_dirs)
@@ -490,65 +539,97 @@ function (swift_benchmark_compile_archopts)
       "${source}")
   list(APPEND SWIFT_BENCH_OBJFILES "${objdir}/${module_name}.o")
 
-  if("${BENCH_COMPILE_ARCHOPTS_PLATFORM}" STREQUAL "macosx")
-    set(OUTPUT_EXEC "${benchmark-bin-dir}/Benchmark_${BENCH_COMPILE_ARCHOPTS_OPT}")
-  else()
-    set(OUTPUT_EXEC "${benchmark-bin-dir}/Benchmark_${BENCH_COMPILE_ARCHOPTS_OPT}-${target}")
+  set(objcfile)
+  if (is_darwin)
+    set(objcfile "${objdir}/ObjectiveCTests.o")
+    add_custom_command(
+        OUTPUT "${objcfile}"
+        DEPENDS "${srcdir}/utils/ObjectiveCTests/ObjectiveCTests.m"
+          "${srcdir}/utils/ObjectiveCTests/ObjectiveCTests.h"
+        COMMAND
+          "${CLANG_EXEC}"
+          "-fno-stack-protector"
+          "-fPIC"
+          "-Werror=date-time"
+          "-fcolor-diagnostics"
+          "-O3"
+          "-target" "${target}"
+          "-isysroot" "${sdk}"
+          "-fobjc-arc"
+          "-arch" "${BENCH_COMPILE_ARCHOPTS_ARCH}"
+          "-F" "${sdk}/../../../Developer/Library/Frameworks"
+          "-m${triple_platform}-version-min=${ver}"
+          "-I" "${srcdir}/utils/ObjectiveCTests"
+          "${srcdir}/utils/ObjectiveCTests/ObjectiveCTests.m"
+          "-c"
+          "-o" "${objcfile}")
   endif()
 
-  set(objcfile "${objdir}/ObjectiveCTests.o")
-  add_custom_command(
-      OUTPUT "${objcfile}"
-      DEPENDS "${srcdir}/utils/ObjectiveCTests/ObjectiveCTests.m"
-        "${srcdir}/utils/ObjectiveCTests/ObjectiveCTests.h"
-      COMMAND
-        "${CLANG_EXEC}"
-        "-fno-stack-protector"
-        "-fPIC"
-        "-Werror=date-time"
-        "-fcolor-diagnostics"
-        "-O3"
-        "-target" "${target}"
-        "-isysroot" "${sdk}"
-        "-fobjc-arc"
-        "-arch" "${BENCH_COMPILE_ARCHOPTS_ARCH}"
-        "-F" "${sdk}/../../../Developer/Library/Frameworks"
-        "-m${triple_platform}-version-min=${ver}"
-        "-I" "${srcdir}/utils/ObjectiveCTests"
-        "${srcdir}/utils/ObjectiveCTests/ObjectiveCTests.m"
-        "-c"
-        "-o" "${objcfile}")
+  if(is_darwin)
+    # If host == target.
+    if("${BENCH_COMPILE_ARCHOPTS_PLATFORM}" STREQUAL "macosx")
+      set(OUTPUT_EXEC "${benchmark-bin-dir}/Benchmark_${BENCH_COMPILE_ARCHOPTS_OPT}")
+    else()
+      set(OUTPUT_EXEC "${benchmark-bin-dir}/Benchmark_${BENCH_COMPILE_ARCHOPTS_OPT}-${target}")
+    endif()
+  else()
+    # If we are on Linux, we do not support cross compiling.
+    set(OUTPUT_EXEC "${benchmark-bin-dir}/Benchmark_${BENCH_COMPILE_ARCHOPTS_OPT}")
+  endif()
 
-  add_custom_command(
-      OUTPUT "${OUTPUT_EXEC}"
-      DEPENDS
-        ${bench_library_objects} ${bench_driver_objects} ${SWIFT_BENCH_OBJFILES}
-        "${objcfile}" ${opt_view_dirs}
-      COMMAND
-        "${CLANG_EXEC}"
-        "-fno-stack-protector"
-        "-fPIC"
-        "-Werror=date-time"
-        "-fcolor-diagnostics"
-        "-O3"
-        "-Wl,-search_paths_first"
-        "-Wl,-headerpad_max_install_names"
-        "-target" "${target}"
-        "-isysroot" "${sdk}"
-        "-arch" "${BENCH_COMPILE_ARCHOPTS_ARCH}"
-        "-F" "${sdk}/../../../Developer/Library/Frameworks"
-        "-m${triple_platform}-version-min=${ver}"
-        "-lobjc"
-        "-L${SWIFT_LIBRARY_PATH}/${BENCH_COMPILE_ARCHOPTS_PLATFORM}"
-        "-Xlinker" "-rpath"
-        "-Xlinker" "@executable_path/../lib/swift/${BENCH_COMPILE_ARCHOPTS_PLATFORM}"
-        ${bench_library_objects}
-        ${bench_driver_objects}
-        ${SWIFT_BENCH_OBJFILES}
-        ${objcfile}
-        "-o" "${OUTPUT_EXEC}"
-      COMMAND
+  # TODO: Unify the linux and darwin builds here.
+  #
+  # We are avoiding this for now until it is investigated if swiftc and clang
+  # both do exactly the same thing with both sets of arguments. It also lets us
+  # avoid issues around code-signing.
+  if (is_darwin)
+    add_custom_command(
+        OUTPUT "${OUTPUT_EXEC}"
+        DEPENDS
+          ${bench_library_objects} ${bench_driver_objects} ${SWIFT_BENCH_OBJFILES}
+          "${objcfile}" ${opt_view_dirs}
+        COMMAND
+          "${CLANG_EXEC}"
+          "-fno-stack-protector"
+          "-fPIC"
+          "-Werror=date-time"
+          "-fcolor-diagnostics"
+          "-O3"
+          "-Wl,-search_paths_first"
+          "-Wl,-headerpad_max_install_names"
+          "-target" "${target}"
+          "-isysroot" "${sdk}"
+          "-arch" "${BENCH_COMPILE_ARCHOPTS_ARCH}"
+          "-F" "${sdk}/../../../Developer/Library/Frameworks"
+          "-m${triple_platform}-version-min=${ver}"
+          "-lobjc"
+          "-L${SWIFT_LIBRARY_PATH}/${BENCH_COMPILE_ARCHOPTS_PLATFORM}"
+          "-Xlinker" "-rpath"
+          "-Xlinker" "@executable_path/../lib/swift/${BENCH_COMPILE_ARCHOPTS_PLATFORM}"
+          ${bench_library_objects}
+          ${bench_driver_objects}
+          ${SWIFT_BENCH_OBJFILES}
+          ${objcfile}
+          "-o" "${OUTPUT_EXEC}"
+        COMMAND
         "codesign" "-f" "-s" "-" "${OUTPUT_EXEC}")
+  else()
+    # TODO: rpath.
+    add_custom_command(
+        OUTPUT "${OUTPUT_EXEC}"
+        DEPENDS
+          ${bench_library_objects} ${bench_driver_objects} ${SWIFT_BENCH_OBJFILES}
+          "${objcfile}" ${opt_view_dirs}
+        COMMAND
+          "${SWIFT_EXEC}"
+          "-O"
+          "-target" "${target}"
+          "-L${SWIFT_LIBRARY_PATH}/${BENCH_COMPILE_ARCHOPTS_PLATFORM}"
+          ${bench_library_objects}
+          ${bench_driver_objects}
+          ${SWIFT_BENCH_OBJFILES}
+          "-o" "${OUTPUT_EXEC}")
+  endif()
   set(new_output_exec "${OUTPUT_EXEC}" PARENT_SCOPE)
 endfunction()
 

--- a/benchmark/scripts/build_linux.py
+++ b/benchmark/scripts/build_linux.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+import argparse
+import os
+import subprocess
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('cmake_path', help='The cmake binary to use')
+    p.add_argument('swift_src_dir', help='The swift source directory')
+    p.add_argument('clang', help='The path to the clang binary to use')
+    p.add_argument('swift_root_dir',
+                   help='A path to a swift root produced by installing '
+                        'Swift and Foundation together. We infer swiftc '
+                        'from here')
+    p.add_argument('destdir', help='The directory to perform the actual '
+                                   'build in')
+    p.add_argument('--clean', action='store_true',
+                   help='Delete destdir before performing a build.')
+    args = p.parse_args()
+
+    if args.clean:
+        print("Asked to clean... Cleaning!")
+        subprocess.check_output(['/bin/rm', '-rfv', args.destdir])
+    subprocess.check_call(['/bin/mkdir', '-p', args.destdir])
+    os.chdir(args.destdir)
+    configureInvocation = [
+        args.cmake_path, '-GNinja',
+        '-DSWIFT_EXEC={}/bin/swiftc'.format(args.swift_root_dir),
+        '-DCLANG_EXEC={}'.format(args.clang),
+        '-DSWIFT_LIBRARY_PATH={}/lib/swift'.format(args.swift_root_dir),
+        '{}/benchmark'.format(args.swift_src_dir)
+    ]
+    print('COMMAND: {}'.format(' '.join(configureInvocation)))
+    subprocess.check_call(configureInvocation)
+
+    buildInvocation = [
+        args.cmake_path, '--build', args.destdir, '--',
+        'swift-benchmark-linux-x86_64'
+    ]
+    print('COMMAND: {}'.format(' '.join(buildInvocation)))
+    subprocess.check_call(buildInvocation)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/single-source/DataBenchmarks.swift
+++ b/benchmark/single-source/DataBenchmarks.swift
@@ -96,7 +96,11 @@ import Glibc
 @inline(__always)
 func getRandomBuf(_ arg: UnsafeMutableBufferPointer<UInt8>) {
 #if os(Linux)
-    getrandom(arg.baseAddress, arg.count, 0)
+    let fd = open("/dev/urandom", O_RDONLY)
+    defer { if (fd >= 0) { close(fd) } }
+    if fd >= 0 {
+         read(fd, arg.baseAddress, arg.count)
+    }
 #else
     arc4random_buf(arg.baseAddress, arg.count)
 #endif
@@ -105,7 +109,11 @@ func getRandomBuf(_ arg: UnsafeMutableBufferPointer<UInt8>) {
 @inline(__always)
 func getRandomBuf(baseAddress: UnsafeMutablePointer<UInt8>, count: Int) {
 #if os(Linux)
-    getrandom(arg.baseAddress, arg.count, 0)
+    let fd = open("/dev/urandom", O_RDONLY)
+    defer { if (fd >= 0) { close(fd) } }
+    if fd >= 0 {
+         read(fd, baseAddress, count)
+    }
 #else
     arc4random_buf(baseAddress, count)
 #endif

--- a/benchmark/single-source/DictionaryKeysContains.swift
+++ b/benchmark/single-source/DictionaryKeysContains.swift
@@ -37,17 +37,22 @@ public let DictionaryKeysContains = [
     runFunction: run_DictionaryKeysContains,
     tags: [.validation, .api, .Dictionary],
     setUpFunction: setup_DictionaryKeysContainsNative,
-    tearDownFunction: teardown_DictionaryKeysContains),
+    tearDownFunction: teardown_DictionaryKeysContains,
+    unsupportedPlatforms: [.linux]),
 ]
 #endif
 
 private var dictionary: [NSString: NSString]!
 
 private func setup_DictionaryKeysContainsNative() {
+#if os(Linux)
+  fatalError("Unsupported benchmark")
+#else
   let keyValuePairs = (1...1_000_000).map {
     ("\($0)" as NSString, "\($0)" as NSString)
   }
   dictionary = [NSString: NSString](uniqueKeysWithValues: keyValuePairs)
+#endif
 }
 
 #if _runtime(_ObjC)
@@ -68,9 +73,13 @@ private func teardown_DictionaryKeysContains() {
 
 @inline(never)
 public func run_DictionaryKeysContains(_ N: Int) {
+#if os(Linux)
+  fatalError("Unsupported benchmark")
+#else
   for _ in 0..<(N * 100) {
     CheckResults(dictionary.keys.contains("42"))
     CheckResults(!dictionary.keys.contains("-1"))
   }
+#endif
 }
 


### PR DESCRIPTION
Some notes:

1. I had to disable the Data benchmarks and a Dictionary benchmark on Linux due to some sort of compilation error. But everything else seems to work.
2. The linux build can only be done via the out of tree build. It was done to simplify the problem by just having the user specify all of the parameters.
3. I added a small argparse based script in the benchmarks that should make it easy to do out of tree without needing to know the variable names.

rdar://40541972