### PR TITLE
Swift 4.2 branch update data inlines

### DIFF
--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -1585,7 +1585,6 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         }
     }
     
-    @inlinable
     public mutating func replaceSubrange(_ subrange: Range<Index>, with bytes: UnsafeRawPointer, count cnt: Int) {
         _validateRange(subrange)
         let nsRange = NSRange(location: subrange.lowerBound, length: subrange.upperBound - subrange.lowerBound)
@@ -1601,7 +1600,6 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     /// Return a new copy of the data in a specified range.
     ///
     /// - parameter range: The range to copy.
-    @inlinable
     public func subdata(in range: Range<Index>) -> Data {
         _validateRange(range)
         if isEmpty {
@@ -1651,7 +1649,6 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
         return hashValue
     }
     
-    @inlinable
     public func advanced(by amount: Int) -> Data {
         _validateIndex(startIndex + amount)
         let length = count - amount

--- a/stdlib/public/SDK/Foundation/Data.swift
+++ b/stdlib/public/SDK/Foundation/Data.swift
@@ -1668,12 +1668,10 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     
     /// Sets or returns the byte at the specified index.
     public subscript(index: Index) -> UInt8 {
-        @inlinable
         get {
             _validateIndex(index)
             return _backing.get(index)
         }
-        @inlinable
         set {
             _validateIndex(index)
             if !isKnownUniquelyReferenced(&_backing) {
@@ -1684,12 +1682,10 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     }
     
     public subscript(bounds: Range<Index>) -> Data {
-        @inlinable
         get {
             _validateRange(bounds)
             return Data(backing: _backing, range: bounds)
         }
-        @inlinable
         set {
             replaceSubrange(bounds, with: newValue)
         }
@@ -1697,7 +1693,6 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     
     public subscript<R: RangeExpression>(_ rangeExpression: R) -> Data
         where R.Bound: FixedWidthInteger, R.Bound.Stride : SignedInteger {
-        @inlinable
         get {
             let lower = R.Bound(_sliceRange.lowerBound)
             let upper = R.Bound(_sliceRange.upperBound)
@@ -1708,7 +1703,6 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
             _validateRange(r)
             return Data(backing: _backing, range: r)
         }
-        @inlinable
         set {
             let lower = R.Bound(_sliceRange.lowerBound)
             let upper = R.Bound(_sliceRange.upperBound)
@@ -1724,7 +1718,6 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     
     /// The start `Index` in the data.
     public var startIndex: Index {
-        @inlinable
         get {
             return _sliceRange.lowerBound
         }
@@ -1734,24 +1727,20 @@ public struct Data : ReferenceConvertible, Equatable, Hashable, RandomAccessColl
     ///
     /// This is the "one-past-the-end" position, and will always be equal to the `count`.
     public var endIndex: Index {
-        @inlinable
         get {
             return _sliceRange.upperBound
         }
     }
     
-    @inlinable
     public func index(before i: Index) -> Index {
         return i - 1
     }
     
-    @inlinable
     public func index(after i: Index) -> Index {
         return i + 1
     }
     
     public var indices: Range<Int> {
-        @inlinable
         get {
             return startIndex..<endIndex
         }


### PR DESCRIPTION
<!-- What's in this pull request? -->
This prepares Data to be ABI stable. Primarily we are now letting the compiler do the work of any public inline accessors. Our internal structure is defined to have certain paths marked as usable from inline and specific internal methods to be inlined, the reset of the public interface will defer to the wisdom of the compiler itself to understand which methods can and cannot be inlined. In most cases this results in a performance gain due to the conversion to private/internal types. However there is one known regression when appending a Sequence that is not an Array or Data or UnsafeBufferPointer etc. One particular case that is a known regression is Repeating<UInt8>. We plan on addressing this in a followup change that will add better inlines for this type of case (perhaps even boiling down to memset). 

Resolves <rdar://problem/33678210>


