### PR TITLE
[4.2][CSSimplify] When trying to simplify `bind` with error type fail gracefully

### DIFF
--- a/lib/Sema/CSSimplify.cpp
+++ b/lib/Sema/CSSimplify.cpp
@@ -1488,6 +1488,16 @@ ConstraintSystem::matchTypesBindTypeVar(
   if (!isBindable(typeVar, type))
     return formUnsolvedResult();
 
+  // Since member lookup doesn't check requirements
+  // it might sometimes return types which are not
+  // visible in the current context e.g. typealias
+  // defined in constrained extension, substitution
+  // of which might produce error type for base, so
+  // assignement should thead lightly and just fail
+  // if it encounters such types.
+  if (type->hasError())
+    return getTypeMatchFailure(locator);
+
   // Equal constraints allow mixed LValue/RValue bindings, but
   // if we bind a type to a type variable that can bind to
   // LValues as part of simplifying the Equal constraint we may

--- a/validation-test/compiler_crashers_2_fixed/0130-sr5013.swift
+++ b/validation-test/compiler_crashers_2_fixed/0130-sr5013.swift
@@ -1,5 +1,5 @@
-// RUN: not --crash %target-swift-frontend -typecheck %s
-// REQUIRES: asserts
+// RUN: not %target-swift-frontend -typecheck %s
+
 
 protocol A {
     associatedtype B

--- a/validation-test/compiler_crashers_2_fixed/0159-rdar39931339.swift
+++ b/validation-test/compiler_crashers_2_fixed/0159-rdar39931339.swift
@@ -1,0 +1,39 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P0 {
+    associatedtype A
+}
+
+protocol P1 {
+  associatedtype B : P3 = S0<S2>
+  associatedtype C = ()
+}
+
+protocol P2 {
+  associatedtype D : P1
+  associatedtype E : P3 = S0<S2>
+}
+
+protocol P3 : P0 where A : P2 {}
+
+struct S0<T> : P0 {
+    typealias A = T
+}
+
+extension S0 : P3 where T : P2 {}
+
+struct S2 : P2 {
+  struct D : P1 {
+    let value: S2
+  }
+}
+
+extension P1 where C : P2 {
+  typealias B = C.E
+}
+
+extension P3 {
+  func foo() {
+    _ = A.D.B.self
+  }
+}

--- a/validation-test/compiler_crashers_fixed/28826-type-haserror-should-not-be-assigning-a-type-involving-errortype.swift
+++ b/validation-test/compiler_crashers_fixed/28826-type-haserror-should-not-be-assigning-a-type-involving-errortype.swift
@@ -5,6 +5,6 @@
 // See https://swift.org/LICENSE.txt for license information
 // See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-// REQUIRES: asserts
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+
+// RUN: not %target-swift-frontend %s -emit-ir
 protocol A{{}protocol a{extension{class a<a{let d=a(class a<P


### PR DESCRIPTION
Since member lookup doesn't check requirements
it might sometimes return types which are not
visible in the current context e.g. typealias
defined in constrained extension, substitution
of which might produce error type for base, so
assignement should thead lightly and just fail
if it encounters such types.

Resolves: rdar://problem/39931339
Resolves: [SR-5013](https://bugs.swift.org/browse/SR-5013)
(cherry picked from commit 11ba7e0f4289869ac3d0fa9e19e52fd027a29462)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
