### PR TITLE
benchmarks: fix the handling of the --help command line option

### DIFF
--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -147,7 +147,7 @@ struct TestConfig {
 
     filters = benchArgs.positionalArgs
 
-    if benchArgs.optionalArgsMap["--help"] == nil {
+    if benchArgs.optionalArgsMap["--help"] != nil {
       return .help(validOptions)
     }
 


### PR DESCRIPTION
It displayed the help if the option was _not_ specified.
