### PR TITLE
[GSB] Error types end up as unresolved equivalence classes.

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -3944,6 +3944,12 @@ ResolvedType GenericSignatureBuilder::maybeResolveEquivalenceClass(
                                     Type type,
                                     ArchetypeResolutionKind resolutionKind,
                                     bool wantExactPotentialArchetype) {
+  // An error type is best modeled as an unresolved potential archetype, since
+  // there's no way to be sure what it is actually meant to be.
+  if (type->is<ErrorType>()) {
+    return ResolvedType::forUnresolved(nullptr);
+  }
+
   // The equivalence class of a generic type is known directly.
   if (auto genericParam = type->getAs<GenericTypeParamType>()) {
     unsigned index = GenericParamKey(genericParam).findIndexIn(

--- a/test/IDE/print_ast_tc_decls_errors.swift
+++ b/test/IDE/print_ast_tc_decls_errors.swift
@@ -194,7 +194,7 @@ protocol AssociatedType1 {
 // TYREPR: {{^}}  associatedtype AssociatedTypeDecl4 : FooNonExistentProtocol, BarNonExistentProtocol{{$}}
 
   associatedtype AssociatedTypeDecl5 : FooClass
-// CHECK: {{^}}  associatedtype AssociatedTypeDecl5{{$}}
+// CHECK: {{^}}  associatedtype AssociatedTypeDecl5 : FooClass{{$}}
 }
 
 //===---

--- a/validation-test/compiler_crashers_2_fixed/0159-rdar40009245.swift
+++ b/validation-test/compiler_crashers_2_fixed/0159-rdar40009245.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {
+    associatedtype A : P where A.X == Self
+    associatedtype X : P where P.A == Self
+    // expected-error@-1{{associated type 'A' can only be used with a concrete type or generic parameter base}}
+}


### PR DESCRIPTION
We need to make sure they don't end up as "concrete" equivalence
classes, because they behave more like unresolved ones.

Fixes rdar://problem/40009245.