### PR TITLE
[sourcekit] Send compile notifications when argument parsing files

### DIFF
--- a/test/SourceKit/CompileNotifications/arg-parsing.swift
+++ b/test/SourceKit/CompileNotifications/arg-parsing.swift
@@ -1,4 +1,6 @@
 // RUN: not %sourcekitd-test -req=track-compiles == -req=complete %s -offset=0 -- %s -no-such-arg | %FileCheck %s -check-prefix=ARG_PARSE_1
+// RUN: %sourcekitd-test -req=track-compiles == -req=sema %s -print-raw-response -- %s -no-such-arg | %FileCheck %s -check-prefix=ARG_PARSE_1
+// RUN: %sourcekitd-test -req=track-compiles == -req=cursor -offset=0 %s -- %s -no-such-arg | %FileCheck %s -check-prefix=ARG_PARSE_1
 // ARG_PARSE_1: {
 // ARG_PARSE_1:  key.notification: source.notification.compile-will-start
 // ARG_PARSE_1:  key.compileid: [[CID1:".*"]]
@@ -17,3 +19,23 @@
 // ARG_PARSE_1: }
 // ARG_PARSE_1-NOT: compile-will-start
 // ARG_PARSE_1-NOT: compile-did-finish
+
+// RUN: not %sourcekitd-test -req=track-compiles == -req=complete %s -offset=0 | %FileCheck %s -check-prefix=ARG_PARSE_2
+// RUN: %sourcekitd-test -req=track-compiles == -req=sema %s -print-raw-response | %FileCheck %s -check-prefix=ARG_PARSE_2
+// ARG_PARSE_2: {
+// ARG_PARSE_2:  key.notification: source.notification.compile-will-start
+// ARG_PARSE_2:  key.compileid: [[CID1:".*"]]
+// ARG_PARSE_2: }
+// ARG_PARSE_2: {
+// ARG_PARSE_2:   key.notification: source.notification.compile-did-finish
+// ARG_PARSE_2:   key.diagnostics: [
+// ARG_PARSE_2:     {
+// ARG_PARSE_2:       key.filepath: "<unknown>",
+// ARG_PARSE_2:       key.severity: source.diagnostic.severity.error,
+// ARG_PARSE_2:       key.description: "no input files"
+// ARG_PARSE_2:     }
+// ARG_PARSE_2:   ]
+// ARG_PARSE_2:   key.compileid: [[CID1]]
+// ARG_PARSE_2: }
+// ARG_PARSE_2-NOT: compile-will-start
+// ARG_PARSE_2-NOT: compile-did-finish

--- a/test/SourceKit/CompileNotifications/arg-parsing.swift
+++ b/test/SourceKit/CompileNotifications/arg-parsing.swift
@@ -7,8 +7,12 @@
 // ARG_PARSE_1: {
 // ARG_PARSE_1:   key.notification: source.notification.compile-did-finish
 // ARG_PARSE_1:   key.diagnostics: [
-// FIXME: we should pass through the error from parsing the arguments
-// ARG_PARSE_1-NEXT: ]
+// ARG_PARSE_1:     {
+// ARG_PARSE_1:       key.filepath: "<unknown>",
+// ARG_PARSE_1:       key.severity: source.diagnostic.severity.error,
+// ARG_PARSE_1:       key.description: "unknown argument: '-no-such-arg'"
+// ARG_PARSE_1:     }
+// ARG_PARSE_1:   ]
 // ARG_PARSE_1:   key.compileid: [[CID1]]
 // ARG_PARSE_1: }
 // ARG_PARSE_1-NOT: compile-will-start

--- a/test/SourceKit/CompileNotifications/arg-parsing.swift
+++ b/test/SourceKit/CompileNotifications/arg-parsing.swift
@@ -1,0 +1,15 @@
+// RUN: not %sourcekitd-test -req=track-compiles == -req=complete %s -offset=0 -- %s -no-such-arg | %FileCheck %s -check-prefix=ARG_PARSE_1
+// ARG_PARSE_1: {
+// ARG_PARSE_1:  key.notification: source.notification.compile-will-start
+// ARG_PARSE_1:  key.compileid: [[CID1:".*"]]
+// ARG_PARSE_1:  key.compilerargs-string: "{{.*}}.swift -no-such-arg"
+// ARG_PARSE_1: }
+// ARG_PARSE_1: {
+// ARG_PARSE_1:   key.notification: source.notification.compile-did-finish
+// ARG_PARSE_1:   key.diagnostics: [
+// FIXME: we should pass through the error from parsing the arguments
+// ARG_PARSE_1-NEXT: ]
+// ARG_PARSE_1:   key.compileid: [[CID1]]
+// ARG_PARSE_1: }
+// ARG_PARSE_1-NOT: compile-will-start
+// ARG_PARSE_1-NOT: compile-did-finish

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -136,6 +136,10 @@ static bool swiftCodeCompleteImpl(SwiftLangSupport &Lang,
     CI.addDiagnosticConsumer(&TraceDiags);
     trace::SwiftInvocation SwiftArgs;
     trace::initTraceInfo(SwiftArgs, InputFile->getBufferIdentifier(), Args);
+    TracedOp.setDiagnosticProvider(
+        [&TraceDiags](SmallVectorImpl<DiagnosticEntryInfo> &diags) {
+          TraceDiags.getAllDiagnostics(diags);
+        });
     TracedOp.start(SwiftArgs,
                    {std::make_pair("OriginalOffset", std::to_string(Offset)),
                     std::make_pair("Offset",
@@ -190,12 +194,6 @@ static bool swiftCodeCompleteImpl(SwiftLangSupport &Lang,
                            &CompletionContext);
   CI.performSema();
   SwiftConsumer.clearContext();
-
-  if (TracedOp.enabled()) {
-    SmallVector<DiagnosticEntryInfo, 8> Diagnostics;
-    TraceDiags.getAllDiagnostics(Diagnostics);
-    TracedOp.finish(Diagnostics);
-  }
 
   return true;
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftCompletion.cpp
@@ -119,6 +119,12 @@ static bool swiftCodeCompleteImpl(SwiftLangSupport &Lang,
       UnresolvedInputFile->getBuffer(),
       Lang.resolvePathSymlinks(UnresolvedInputFile->getBufferIdentifier()));
 
+  auto origBuffSize = InputFile->getBufferSize();
+  unsigned CodeCompletionOffset = Offset;
+  if (CodeCompletionOffset > origBuffSize) {
+    CodeCompletionOffset = origBuffSize;
+  }
+
   CompilerInstance CI;
   // Display diagnostics to stderr.
   PrintingDiagnosticConsumer PrintDiags;
@@ -128,6 +134,12 @@ static bool swiftCodeCompleteImpl(SwiftLangSupport &Lang,
   trace::TracedOperation TracedOp(trace::OperationKind::CodeCompletion);
   if (TracedOp.enabled()) {
     CI.addDiagnosticConsumer(&TraceDiags);
+    trace::SwiftInvocation SwiftArgs;
+    trace::initTraceInfo(SwiftArgs, InputFile->getBufferIdentifier(), Args);
+    TracedOp.start(SwiftArgs,
+                   {std::make_pair("OriginalOffset", std::to_string(Offset)),
+                    std::make_pair("Offset",
+                      std::to_string(CodeCompletionOffset))});
   }
 
   CompilerInvocation Invocation;
@@ -139,12 +151,6 @@ static bool swiftCodeCompleteImpl(SwiftLangSupport &Lang,
   if (!Invocation.getFrontendOptions().InputsAndOutputs.hasInputs()) {
     Error = "no input filenames specified";
     return false;
-  }
-
-  auto origBuffSize = InputFile->getBufferSize();
-  unsigned CodeCompletionOffset = Offset;
-  if (CodeCompletionOffset > origBuffSize) {
-    CodeCompletionOffset = origBuffSize;
   }
 
   const char *Position = InputFile->getBufferStart() + CodeCompletionOffset;
@@ -176,15 +182,6 @@ static bool swiftCodeCompleteImpl(SwiftLangSupport &Lang,
   if (CI.setup(Invocation)) {
     // FIXME: error?
     return true;
-  }
-
-  if (TracedOp.enabled()) {
-    trace::SwiftInvocation SwiftArgs;
-    trace::initTraceInfo(SwiftArgs, InputFile->getBufferIdentifier(), Args);
-    TracedOp.start(SwiftArgs,
-                   {std::make_pair("OriginalOffset", std::to_string(Offset)),
-                    std::make_pair("Offset",
-                      std::to_string(CodeCompletionOffset))});
   }
 
   CloseClangModuleFiles scopedCloseFiles(


### PR DESCRIPTION
When swift command-line argument parsing fails in sourcekit, make sure we can still send a compile notification including the diagnostic about the incorrect arguments.

rdar://39225180