### PR TITLE
[NFC] Expose the TaskQueue as a Compilation Parameter

### DIFF
--- a/include/swift/Driver/Compilation.h
+++ b/include/swift/Driver/Compilation.h
@@ -149,13 +149,6 @@ private:
   /// If unknown, this will be some time in the past.
   llvm::sys::TimePoint<> LastBuildTime = llvm::sys::TimePoint<>::min();
 
-  /// Indicates whether this Compilation should use skip execution of
-  /// subtasks during performJobs() by using a dummy TaskQueue.
-  ///
-  /// \note For testing purposes only; similar user-facing features should be
-  /// implemented separately, as the dummy TaskQueue may provide faked output.
-  const bool SkipTaskExecution;
-
   /// Indicates whether this Compilation should continue execution of subtasks
   /// even if they returned an error status.
   bool ContinueBuildingAfterErrors = false;
@@ -236,7 +229,6 @@ public:
               bool EnableBatchMode = false,
               unsigned BatchSeed = 0,
               bool ForceOneBatchRepartition = false,
-              bool SkipTaskExecution = false,
               bool SaveTemps = false,
               bool ShowDriverTimeCompilation = false,
               std::unique_ptr<UnifiedStatsReporter> Stats = nullptr);
@@ -295,10 +287,6 @@ public:
   }
 
   bool getForceOneBatchRepartition() const { return ForceOneBatchRepartition; }
-
-  bool wantsDummyQueue() const {
-    return SkipTaskExecution;
-  }
 
   bool getContinueBuildingAfterErrors() const {
     return ContinueBuildingAfterErrors;

--- a/include/swift/Driver/Driver.h
+++ b/include/swift/Driver/Driver.h
@@ -43,6 +43,9 @@ namespace opt {
 }
 
 namespace swift {
+  namespace sys {
+    class TaskQueue;
+  }
   class DiagnosticEngine;
 namespace driver {
   class Action;
@@ -212,6 +215,13 @@ public:
   /// because ToolChain has virtual methods.
   std::unique_ptr<ToolChain>
   buildToolChain(const llvm::opt::InputArgList &ArgList);
+
+  /// Compute the task queue for this compilation and command line argument
+  /// vector.
+  ///
+  /// \return A TaskQueue, or nullptr if an invalid number of parallel jobs is
+  /// specified.  This condition is signalled by a diagnostic.
+  std::unique_ptr<sys::TaskQueue> buildTaskQueue(const Compilation &C);
 
   /// Construct a compilation object for a given ToolChain and command line
   /// argument vector.

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -108,7 +108,6 @@ Compilation::Compilation(DiagnosticEngine &Diags,
                          llvm::sys::TimePoint<> StartTime,
                          llvm::sys::TimePoint<> LastBuildTime,
                          size_t FilelistThreshold,
-                         unsigned NumberOfParallelCommands,
                          bool EnableIncrementalBuild,
                          bool EnableBatchMode,
                          unsigned BatchSeed,
@@ -127,7 +126,6 @@ Compilation::Compilation(DiagnosticEngine &Diags,
     ArgsHash(ArgsHash),
     BuildStartTime(StartTime),
     LastBuildTime(LastBuildTime),
-    NumberOfParallelCommands(NumberOfParallelCommands),
     SkipTaskExecution(SkipTaskExecution),
     EnableIncrementalBuild(EnableIncrementalBuild),
     OutputCompilationRecordForModuleOnlyBuild(
@@ -619,14 +617,9 @@ namespace driver {
     }
 
   public:
-    PerformJobsState(Compilation &Comp)
-      : Comp(Comp),
-        ActualIncrementalTracer(Comp.Stats.get()) {
-      if (Comp.SkipTaskExecution)
-        TQ.reset(new DummyTaskQueue(Comp.NumberOfParallelCommands));
-      else
-        TQ.reset(new TaskQueue(Comp.NumberOfParallelCommands,
-                               Comp.Stats.get()));
+    PerformJobsState(Compilation &Comp, std::unique_ptr<TaskQueue> &&TaskQueue)
+      : Comp(Comp), ActualIncrementalTracer(Comp.Stats.get()),
+        TQ(std::move(TaskQueue)) {
       if (Comp.ShowIncrementalBuildDecisions || Comp.Stats)
         IncrementalTracer = &ActualIncrementalTracer;
     }
@@ -889,7 +882,7 @@ namespace driver {
         return;
       }
 
-      size_t NumPartitions = Comp.NumberOfParallelCommands;
+      size_t NumPartitions = TQ->getNumberOfParallelTasks();
       CommandSetVector Batchable, NonBatchable;
       std::vector<const Job *> Batches;
       bool PretendTheCommandLineIsTooLongOnce =
@@ -1220,8 +1213,9 @@ static bool writeFilelistIfNecessary(const Job *job, const ArgList &args,
   return ok;
 }
 
-int Compilation::performJobsImpl(bool &abnormalExit) {
-  PerformJobsState State(*this);
+int Compilation::performJobsImpl(bool &abnormalExit,
+                                 std::unique_ptr<TaskQueue> &&TQ) {
+  PerformJobsState State(*this, std::move(TQ));
 
   State.scheduleInitialJobs();
   State.scheduleAdditionalJobs();
@@ -1320,7 +1314,7 @@ static bool writeAllSourcesFile(DiagnosticEngine &diags, StringRef path,
   return true;
 }
 
-int Compilation::performJobs() {
+int Compilation::performJobs(std::unique_ptr<TaskQueue> &&TQ) {
   if (AllSourceFilesPath)
     if (!writeAllSourcesFile(Diags, AllSourceFilesPath, getInputFiles()))
       return EXIT_FAILURE;
@@ -1334,12 +1328,12 @@ int Compilation::performJobs() {
     return performSingleCommand(Jobs.front().get());
   }
 
-  if (!TaskQueue::supportsParallelExecution() && NumberOfParallelCommands > 1) {
+  if (!TaskQueue::supportsParallelExecution() && TQ->getNumberOfParallelTasks() > 1) {
     Diags.diagnose(SourceLoc(), diag::warning_parallel_execution_not_supported);
   }
 
   bool abnormalExit;
-  int result = performJobsImpl(abnormalExit);
+  int result = performJobsImpl(abnormalExit, std::move(TQ));
 
   if (!SaveTemps) {
     for (const auto &pathPair : TempFilePaths) {

--- a/lib/Driver/Compilation.cpp
+++ b/lib/Driver/Compilation.cpp
@@ -112,7 +112,6 @@ Compilation::Compilation(DiagnosticEngine &Diags,
                          bool EnableBatchMode,
                          unsigned BatchSeed,
                          bool ForceOneBatchRepartition,
-                         bool SkipTaskExecution,
                          bool SaveTemps,
                          bool ShowDriverTimeCompilation,
                          std::unique_ptr<UnifiedStatsReporter> StatsReporter)
@@ -126,7 +125,6 @@ Compilation::Compilation(DiagnosticEngine &Diags,
     ArgsHash(ArgsHash),
     BuildStartTime(StartTime),
     LastBuildTime(LastBuildTime),
-    SkipTaskExecution(SkipTaskExecution),
     EnableIncrementalBuild(EnableIncrementalBuild),
     OutputCompilationRecordForModuleOnlyBuild(
         OutputCompilationRecordForModuleOnlyBuild),
@@ -1223,7 +1221,7 @@ int Compilation::performJobsImpl(bool &abnormalExit,
   State.runTaskQueueToCompletion();
   State.checkUnfinishedJobs();
 
-  if (!CompilationRecordPath.empty() && !SkipTaskExecution) {
+  if (!CompilationRecordPath.empty()) {
     InputInfoMap InputInfo;
     State.populateInputInfoMap(InputInfo);
     checkForOutOfDateInputs(Diags, InputInfo);

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -296,7 +296,10 @@ std::unique_ptr<sys::TaskQueue> Driver::buildTaskQueue(const Compilation &C) {
     }
   }
 
-  if (C.wantsDummyQueue()) {
+  const bool DriverSkipExecution =
+    ArgList.hasArg(options::OPT_driver_skip_execution,
+                   options::OPT_driver_print_jobs);
+  if (DriverSkipExecution) {
     return llvm::make_unique<sys::DummyTaskQueue>(NumberOfParallelCommands);
   } else {
     return llvm::make_unique<sys::TaskQueue>(NumberOfParallelCommands,
@@ -656,9 +659,6 @@ Driver::buildCompilation(const ToolChain &TC,
   bool DriverPrintDerivedOutputFileMap =
     ArgList->hasArg(options::OPT_driver_print_derived_output_file_map);
   DriverPrintBindings = ArgList->hasArg(options::OPT_driver_print_bindings);
-  bool DriverSkipExecution =
-    ArgList->hasArg(options::OPT_driver_skip_execution,
-                    options::OPT_driver_print_jobs);
   bool ShowIncrementalBuildDecisions =
     ArgList->hasArg(options::OPT_driver_show_incremental);
   bool ShowJobLifecycle =
@@ -843,7 +843,6 @@ Driver::buildCompilation(const ToolChain &TC,
                       BatchMode,
                       DriverBatchSeed,
                       DriverForceOneBatchRepartition,
-                      DriverSkipExecution,
                       SaveTemps,
                       ShowDriverTimeCompilation,
                       std::move(StatsReporter)));

--- a/tools/driver/driver.cpp
+++ b/tools/driver/driver.cpp
@@ -17,6 +17,7 @@
 #include "swift/AST/DiagnosticEngine.h"
 #include "swift/Basic/LLVMInitialize.h"
 #include "swift/Basic/Program.h"
+#include "swift/Basic/TaskQueue.h"
 #include "swift/Basic/SourceManager.h"
 #include "swift/Driver/Compilation.h"
 #include "swift/Driver/Driver.h"
@@ -219,11 +220,13 @@ int main(int argc_, const char **argv_) {
 
   std::unique_ptr<Compilation> C =
       TheDriver.buildCompilation(*TC, std::move(ArgList));
+
   if (Diags.hadAnyError())
     return 1;
 
   if (C) {
-    return C->performJobs();
+    std::unique_ptr<sys::TaskQueue> TQ = TheDriver.buildTaskQueue(*C);
+    return C->performJobs(std::move(TQ));
   }
 
   return 0;


### PR DESCRIPTION
In preparation for a future where a driver can specify its own TaskQueue, lift the responsibility for its creation to the driver and provide a convenient builder function to handle the argument parsing.

The second commit softens a condition that used to use `SkipTaskExecution` to avoid writing compilation records when the DummyTaskQueue is around.  In my tests it didn't make a difference. Nevertheless, the second commit is revertible if I'm wrong about that.