### PR TITLE
[CodeCompletion] Disable completion for declaration name position

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -2673,10 +2673,8 @@ Parser::parseDecl(ParseDeclOptions Flags,
     return makeParserErrorResult<Decl>();
   }
 
-  if (DeclResult.isParseError() && MayNeedOverrideCompletion &&
-      Tok.is(tok::code_complete)) {
-    DeclResult = makeParserCodeCompletionStatus();
-    if (CodeCompletion) {
+  if (DeclResult.isParseError() && Tok.is(tok::code_complete)) {
+    if (MayNeedOverrideCompletion && CodeCompletion) {
       // If we need to complete an override, collect the keywords already
       // specified so that we do not duplicate them in code completion
       // strings.
@@ -2698,6 +2696,9 @@ Parser::parseDecl(ParseDeclOptions Flags,
       }
       CodeCompletion->completeNominalMemberBeginning(Keywords);
     }
+
+    DeclResult = makeParserCodeCompletionStatus();
+    consumeToken(tok::code_complete);
   }
 
   if (auto SF = CurDeclContext->getParentSourceFile()) {

--- a/test/IDE/complete_declname.swift
+++ b/test/IDE/complete_declname.swift
@@ -1,0 +1,44 @@
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=CLASSNAME | %FileCheck %s --check-prefix=NO_COMPLETIONS
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=STRUCTNAME | %FileCheck %s --check-prefix=NO_COMPLETIONS
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=ENUMNAME | %FileCheck %s --check-prefix=NO_COMPLETIONS
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PROTOCOLNAME | %FileCheck %s --check-prefix=NO_COMPLETIONS
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PRECEDENCEGROUPNAME | %FileCheck %s --check-prefix=NO_COMPLETIONS
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=OPERATORNAME | %FileCheck %s --check-prefix=NO_COMPLETIONS
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-keywords=false -code-completion-token=METHODNAME | %FileCheck %s --check-prefix=NO_COMPLETIONS
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-keywords=false -code-completion-token=METHODNAME_OVERRIDE | %FileCheck %s --check-prefix=METHODNAME_OVERRIDE
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-keywords=false -code-completion-token=METHODNAME_PROTOCOL | %FileCheck %s --check-prefix=NO_COMPLETIONS
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-keywords=false -code-completion-token=METHODNAME_CONFORMANCE | %FileCheck %s --check-prefix=METHODNAME_CONFORMANCE
+
+// NO_COMPLETIONS-NOT: Begin completions
+
+class #^CLASSNAME^# {}
+struct #^STRUCTNAME^#
+enum #^ENUMNAME^#
+protocol #^PROTOCOLNAME^# {}
+precedencegroup #^PRECEDENCEGROUPNAME^#
+infix operator #^OPERATORNAME^#
+
+class MyCls {
+  func foo() {}
+  func #^METHODNAME^#
+}
+
+class MySub : MyCls {
+  func #^METHODNAME_OVERRIDE^#
+// METHODNAME_OVERRIDE: Begin completions, 1 items
+// METHODNAME_OVERRIDE-NEXT: Decl[InstanceMethod]/Super: foo() {|}; name=foo()
+// METHODNAME_OVERRIDE-NEXT: End completions
+}
+
+protocol P {
+  func foo() {}
+  func #^METHODNAME_PROTOCOL^#
+}
+
+struct MyStruct : P {
+  func #^METHODNAME_CONFORMANCE^#
+// METHODNAME_CONFORMANCE: Begin completions, 1 items
+// METHODNAME_CONFORMANCE-NEXT: Decl[InstanceMethod]/Super: foo() {|}; name=foo()
+// METHODNAME_CONFORMANCE-NEXT: End completions
+}


### PR DESCRIPTION
Code completion should not suggest anything when declaring a new name. e.g.

```swift
public class <HERE>
```

rdar://problem/29392238