### PR TITLE
SILGen: Fix invalid SIL emitted when protocol requirement witnessed by base class convenience init

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3345,10 +3345,19 @@ static WitnessDispatchKind getWitnessDispatchKind(SILDeclRef witness) {
   // A natively ObjC method witness referenced this way will end up going
   // through its native thunk, which will redispatch the method after doing
   // bridging just like we want.
-  if (isFinal || isExtension || witness.isForeignToNativeThunk()
-      // Hack--We emit a static thunk for ObjC allocating constructors.
-      || (decl->hasClangNode() && witness.kind == SILDeclRef::Kind::Allocator))
+  if (isFinal || isExtension || witness.isForeignToNativeThunk())
     return WitnessDispatchKind::Static;
+
+  if (witness.kind == SILDeclRef::Kind::Allocator) {
+    // Non-required initializers can witness a protocol requirement if the class
+    // is final, so we can statically dispatch to them.
+    if (!cast<ConstructorDecl>(decl)->isRequired())
+      return WitnessDispatchKind::Static;
+
+    // We emit a static thunk for ObjC allocating constructors.
+    if (decl->hasClangNode())
+      return WitnessDispatchKind::Static;
+  }
 
   // Otherwise emit a class method.
   return WitnessDispatchKind::Class;

--- a/test/SILGen/witness-init-requirement-with-base-class-init.swift
+++ b/test/SILGen/witness-init-requirement-with-base-class-init.swift
@@ -20,3 +20,32 @@ class Dog: Animal, BestFriend {}
 // CHECK-LABEL: sil private [transparent] [thunk] @$S4main3DogCAA10BestFriendA2aDP6createxyFZTW
 // CHECK:         [[SELF:%.*]] = apply
 // CHECK:         unchecked_ref_cast [[SELF]] : $Animal to $Dog
+
+class Base {
+  init() {}
+
+  convenience init(x: Int) {
+    self.init()
+  }
+}
+
+protocol Initable {
+  init(x: Int)
+}
+
+final class Derived : Base, Initable {}
+
+// CHECK-LABEL: sil hidden @$S4main4BaseC1xACSi_tcfC : $@convention(method) (Int, @thick Base.Type) -> @owned Base
+// CHECK:         [[SELF:%.*]] = alloc_ref_dynamic %1 : $@thick Base.Type, $Base
+// CHECK:         [[METHOD:%.*]] = function_ref @$S4main4BaseC1xACSi_tcfc
+// CHECK-NEXT:    [[RESULT:%.*]] = apply [[METHOD]](%0, [[SELF]])
+// CHECK-NEXT:    return [[RESULT]]
+
+// CHECK-LABEL: sil private [transparent] [thunk] @$S4main7DerivedCAA8InitableA2aDP1xxSi_tcfCTW : $@convention(witness_method: Initable) (Int, @thick Derived.Type) -> @out Derived
+// CHECK:         [[SELF:%.*]] = upcast %2 : $@thick Derived.Type to $@thick Base.Type
+// CHECK:         [[METHOD:%.*]] = function_ref @$S4main4BaseC1xACSi_tcfC
+// CHECK-NEXT:    [[RESULT:%.*]] = apply [[METHOD]](%1, [[SELF]])
+// CHECK-NEXT:    [[NEW_SELF:%.*]] = unchecked_ref_cast [[RESULT]] : $Base to $Derived
+// CHECK-NEXT:    store [[NEW_SELF]] to [init] %0 : $*Derived
+// CHECK-NEXT:    [[TUPLE:%.*]] = tuple ()
+// CHECK-NEXT:    return [[TUPLE]]


### PR DESCRIPTION
If the derived class is final and the base class is not, the
protocol requirement can be witnessed by a non-required
initializer. Non-required initializers have initializing
but not allocating entry points in the vtable.

The fix here statically dispatches to the allocating
initializer instead. The test verifies that the allocating
entry point uses alloc_ref_dynamic, so you will get an
instance of the correct subclass.

This fix does not handle the resilient case where the
conformance is defined in a different module, and the original
module adds an override of the convenience init later.
I filed <rdar://problem/40639124> to track the resilient case.

Fixes <rdar://problem/40003840>.