### PR TITLE
Fix crash-on-invalid when calling non-required init on a metatype

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -359,16 +359,6 @@ diagnoseInvalidDynamicConstructorReferences(ConstraintSystem &cs,
         return cs.getType(expr);
       });
 
-  // 'super.' is always OK
-  if (isa<SuperRefExpr>(base))
-    return true;
-
-  // 'self.' reference with concrete type is OK
-  if (isa<DeclRefExpr>(base) &&
-      cast<DeclRefExpr>(base)->getDecl()->getBaseName() == tc.Context.Id_self &&
-      !baseTy->is<ArchetypeType>())
-    return true;
-
   // FIXME: The "hasClangNode" check here is a complete hack.
   if (isNonFinalClass(instanceTy) &&
       !isStaticallyDerived &&
@@ -2697,12 +2687,6 @@ namespace {
 
       auto *ctor = cast<ConstructorDecl>(choice.getDecl());
 
-      // If the member is a constructor, verify that it can be legally
-      // referenced from this base.
-      if (!diagnoseInvalidDynamicConstructorReferences(cs, base, nameLoc,
-                                                       ctor, SuppressDiagnostics))
-        return nullptr;
-
       // If the subexpression is a metatype, build a direct reference to the
       // constructor.
       if (cs.getType(base)->is<AnyMetatypeType>()) {
@@ -2724,6 +2708,17 @@ namespace {
           if (dre->getDecl()->getFullName() == cs.getASTContext().Id_self) {
             // We have a reference to 'self'.
             diagnoseBadInitRef = false;
+
+            // Special case -- in a protocol extension initializer with a class
+            // constrainted Self type, 'self' has archetype type, and only
+            // required initializers can be called.
+            if (cs.getType(dre)->getRValueType()->is<ArchetypeType>()) {
+              if (!diagnoseInvalidDynamicConstructorReferences(cs, base,
+                                                               nameLoc,
+                                                               ctor,
+                                                               SuppressDiagnostics))
+                return nullptr;
+            }
 
             // Make sure the reference to 'self' occurs within an initializer.
             if (!dyn_cast_or_null<ConstructorDecl>(

--- a/test/expr/postfix/call/construction.swift
+++ b/test/expr/postfix/call/construction.swift
@@ -21,12 +21,39 @@ enum E {
 }
 
 class C {
-  init(i: Int) { } // expected-note{{selected non-required initializer 'init(i:)'}}
+  init(i: Int) { } // expected-note 3{{selected non-required initializer 'init(i:)'}}
 
   required init(d: Double) { }
 
   class Inner {
     init(i: Int) { }
+  }
+
+  static func makeCBad() -> C {
+    return self.init(i: 0)
+    // expected-error@-1 {{constructing an object of class type 'C' with a metatype value must use a 'required' initializer}}
+  }
+
+  static func makeCGood() -> C {
+    return self.init(d: 0)
+  }
+
+  static func makeSelfBad() -> Self {
+    return self.init(i: 0)
+    // expected-error@-1 {{constructing an object of class type 'Self' with a metatype value must use a 'required' initializer}}
+  }
+
+  static func makeSelfGood() -> Self {
+    return self.init(d: 0)
+  }
+
+  static func makeSelfImplicitBaseBad() -> Self {
+    return .init(i: 0)
+    // FIXME
+  }
+
+  static func makeSelfImplicitBaseGood() -> Self {
+    return .init(d: 0)
   }
 }
 

--- a/test/expr/postfix/call/construction.swift
+++ b/test/expr/postfix/call/construction.swift
@@ -21,7 +21,7 @@ enum E {
 }
 
 class C {
-  init(i: Int) { } // expected-note 3{{selected non-required initializer 'init(i:)'}}
+  init(i: Int) { } // expected-note 4{{selected non-required initializer 'init(i:)'}}
 
   required init(d: Double) { }
 
@@ -49,7 +49,7 @@ class C {
 
   static func makeSelfImplicitBaseBad() -> Self {
     return .init(i: 0)
-    // FIXME
+    // expected-error@-1 {{constructing an object of class type 'Self' with a metatype value must use a 'required' initializer}}
   }
 
   static func makeSelfImplicitBaseGood() -> Self {


### PR DESCRIPTION
We were missing some checks. Reported by a user on Twitter.