### PR TITLE
Fix crash-on-invalid when calling non-required init on a metatype [4.2]

### DIFF
--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -634,15 +634,24 @@ bool Expr::isTypeReference(
 
 bool Expr::isStaticallyDerivedMetatype(
     llvm::function_ref<Type(const Expr *)> getType) const {
-  // The type must first be a type reference.
+  // The expression must first be a type reference.
   if (!isTypeReference(getType))
     return false;
 
+  auto type = getType(this)
+    ->castTo<AnyMetatypeType>()
+    ->getInstanceType();
+
   // Archetypes are never statically derived.
-  return !getType(this)
-              ->getAs<AnyMetatypeType>()
-              ->getInstanceType()
-              ->is<ArchetypeType>();
+  if (type->is<ArchetypeType>())
+    return false;
+
+  // Dynamic Self is never statically derived.
+  if (type->is<DynamicSelfType>())
+    return false;
+
+  // Everything else is statically derived.
+  return true;
 }
 
 bool Expr::isSuperExpr() const {

--- a/test/expr/postfix/call/construction.swift
+++ b/test/expr/postfix/call/construction.swift
@@ -21,12 +21,39 @@ enum E {
 }
 
 class C {
-  init(i: Int) { } // expected-note{{selected non-required initializer 'init(i:)'}}
+  init(i: Int) { } // expected-note 3{{selected non-required initializer 'init(i:)'}}
 
   required init(d: Double) { }
 
   class Inner {
     init(i: Int) { }
+  }
+
+  static func makeCBad() -> C {
+    return self.init(i: 0)
+    // expected-error@-1 {{constructing an object of class type 'C' with a metatype value must use a 'required' initializer}}
+  }
+
+  static func makeCGood() -> C {
+    return self.init(d: 0)
+  }
+
+  static func makeSelfBad() -> Self {
+    return self.init(i: 0)
+    // expected-error@-1 {{constructing an object of class type 'Self' with a metatype value must use a 'required' initializer}}
+  }
+
+  static func makeSelfGood() -> Self {
+    return self.init(d: 0)
+  }
+
+  static func makeSelfImplicitBaseBad() -> Self {
+    return .init(i: 0)
+    // FIXME
+  }
+
+  static func makeSelfImplicitBaseGood() -> Self {
+    return .init(d: 0)
   }
 }
 

--- a/test/expr/postfix/call/construction.swift
+++ b/test/expr/postfix/call/construction.swift
@@ -21,7 +21,7 @@ enum E {
 }
 
 class C {
-  init(i: Int) { } // expected-note 3{{selected non-required initializer 'init(i:)'}}
+  init(i: Int) { } // expected-note 4{{selected non-required initializer 'init(i:)'}}
 
   required init(d: Double) { }
 
@@ -49,7 +49,7 @@ class C {
 
   static func makeSelfImplicitBaseBad() -> Self {
     return .init(i: 0)
-    // FIXME
+    // expected-error@-1 {{constructing an object of class type 'Self' with a metatype value must use a 'required' initializer}}
   }
 
   static func makeSelfImplicitBaseGood() -> Self {


### PR DESCRIPTION
We were missing some checks. Reported by a user on Twitter.