### PR TITLE
[CSSolver] Make sure generic requirements are checked for typealiases

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -1616,15 +1616,14 @@ class NameAliasType final
     return Bits.NameAliasType.HasSubstitutionMap ? 1 : 0;
   }
 
+public:
   /// Retrieve the generic signature used for substitutions.
   GenericSignature *getGenericSignature() const {
     return getSubstitutionMap().getGenericSignature();
   }
 
-public:
   static NameAliasType *get(TypeAliasDecl *typealias, Type parent,
-                                 SubstitutionMap substitutions,
-                                 Type underlying);
+                            SubstitutionMap substitutions, Type underlying);
 
   /// \brief Returns the declaration that declares this type.
   TypeAliasDecl *getDecl() const {

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2160,6 +2160,15 @@ public:
                    ConstraintLocatorBuilder locator,
                    OpenedTypeMap &replacements);
 
+  /// Given generic signature open its generic requirements,
+  /// using substitution function, and record them in the
+  /// constraint system for further processing.
+  void openGenericRequirements(DeclContext *outerDC,
+                               GenericSignature *signature,
+                               bool skipProtocolSelfConstraint,
+                               ConstraintLocatorBuilder locator,
+                               llvm::function_ref<Type(Type)> subst);
+
   /// Record the set of opened types for the given locator.
   void recordOpenedTypes(
          ConstraintLocatorBuilder locator,

--- a/test/Constraints/rdar39931339.swift
+++ b/test/Constraints/rdar39931339.swift
@@ -4,16 +4,38 @@ protocol P {}
 
 struct S<T> {}
 
-class A : P {}
+class C : P {}
 
 extension S where T : P {
   typealias A = Int
   typealias B<U> = S<U>
 }
 
-_ = S<A>.A()           // Ok
+extension S where T == Float {
+  typealias C = Int
+}
+
+class A<T, U> {}
+
+extension A where T == [U], U: P {
+  typealias S1 = Int
+}
+
+extension A where T == [U], U == Int {
+  typealias S2 = Int
+}
+
+class B<U> : A<[U], U> {}
+
+_ = B<C>.S1()          // Ok
+_ = B<Int>.S2()        // Ok
+_ = B<Float>.S1()      // expected-error {{type 'Float' does not conform to protocol 'P'}}
+_ = B<String>.S2()     // expected-error {{'B<String>.S2.Type' (aka 'Int.Type') requires the types '[String]' and '[Int]' be equivalent}}
+
+_ = S<C>.A()           // Ok
 _ = S<Int>.A()         // expected-error {{type 'Int' does not conform to protocol 'P'}}
 _ = S<String>.B<Int>() // expected-error {{type 'String' does not conform to protocol 'P'}}
+_ = S<Int>.C()         // expected-error {{'S<Int>.C.Type' (aka 'Int.Type') requires the types 'Int' and 'Float' be equivalent}}
 
 func foo<T>(_ s: S<T>.Type) {
   _ = s.A() // expected-error {{type 'T' does not conform to protocol 'P'}}

--- a/test/Constraints/rdar39931339.swift
+++ b/test/Constraints/rdar39931339.swift
@@ -1,0 +1,24 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {}
+
+struct S<T> {}
+
+class A : P {}
+
+extension S where T : P {
+  typealias A = Int
+  typealias B<U> = S<U>
+}
+
+_ = S<A>.A()           // Ok
+_ = S<Int>.A()         // expected-error {{type 'Int' does not conform to protocol 'P'}}
+_ = S<String>.B<Int>() // expected-error {{type 'String' does not conform to protocol 'P'}}
+
+func foo<T>(_ s: S<T>.Type) {
+  _ = s.A() // expected-error {{type 'T' does not conform to protocol 'P'}}
+}
+
+func bar<T: P>(_ s: S<T>.Type) {
+  _ = s.A() // Ok
+}


### PR DESCRIPTION
If solver encounters a typealias inside of constrainted extension
make sure to add its requirements to the constraint system, otherwise
it might produce invalid solutions.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
