### PR TITLE
[Tests][4.2] Fix an unused function warning for PipeMemoryReader_receiveReflectionInfo in swift-reflection-test.c.

### DIFF
--- a/tools/swift-reflection-test/swift-reflection-test.c
+++ b/tools/swift-reflection-test/swift-reflection-test.c
@@ -308,7 +308,8 @@ PipeMemoryReader_receiveImages(SwiftReflectionContextRef RC,
   
   free(Images);
 }
-#endif
+
+#else
 
 static void
 PipeMemoryReader_receiveReflectionInfo(SwiftReflectionContextRef RC,
@@ -366,6 +367,7 @@ PipeMemoryReader_receiveReflectionInfo(SwiftReflectionContextRef RC,
 
   free(RemoteInfos);
 }
+#endif
 
 uint64_t PipeMemoryReader_getStringLength(void *Context, swift_addr_t Address) {
   const PipeMemoryReader *Reader = (const PipeMemoryReader *)Context;


### PR DESCRIPTION
rdar://problem/40626086