### PR TITLE
IRGen: Silence clang warning

### DIFF
--- a/lib/IRGen/GenStruct.cpp
+++ b/lib/IRGen/GenStruct.cpp
@@ -287,19 +287,17 @@ namespace {
             VarDecl *FieldToFind;
             Size FieldOffset = Size::invalid();
 
-            using super = StructMetadataScanner<FindOffsetOfFieldOffsetVector>;
+            FindOffsetOfFieldOffsetVector(IRGenModule &IGM, VarDecl *Field)
+                : StructMetadataScanner<FindOffsetOfFieldOffsetVector>(
+                      IGM, cast<StructDecl>(Field->getDeclContext())),
+                  FieldToFind(Field) {}
 
-            FindOffsetOfFieldOffsetVector(IRGenModule &IGM,
-                                          VarDecl *Field)
-              : super(IGM, cast<StructDecl>(Field->getDeclContext())),
-                FieldToFind(Field)
-            {}
-              
             void addFieldOffset(VarDecl *Field) {
               if (Field == FieldToFind) {
                 FieldOffset = this->NextOffset;
               }
-              super::addFieldOffset(Field);
+              StructMetadataScanner<
+                  FindOffsetOfFieldOffsetVector>::addFieldOffset(Field);
             }
           };
           


### PR DESCRIPTION
I believe the warning is erroneous and filed a bug against clang.

GenStruct.cpp:290:19: warning: unused type alias 'super' [-Wunused-local-typedef]

rdar://40626108
