### PR TITLE
Basic: inline TaskQueue serialization

### DIFF
--- a/lib/Basic/TaskQueue.cpp
+++ b/lib/Basic/TaskQueue.cpp
@@ -29,6 +29,22 @@ using namespace swift::sys;
 #include "Default/TaskQueue.inc"
 #endif
 
+namespace swift {
+namespace sys {
+void TaskProcessInformation::ResourceUsage::provideMapping(json::Output &out) {
+  out.mapRequired("utime", Utime);
+  out.mapRequired("stime", Stime);
+  out.mapRequired("maxrss", Maxrss);
+}
+
+void TaskProcessInformation::provideMapping(json::Output &out) {
+  out.mapRequired("real_pid", OSPid);
+  if (ProcessUsage.hasValue())
+    out.mapRequired("usage", ProcessUsage.getValue());
+}
+}
+}
+
 TaskQueue::TaskQueue(unsigned NumberOfParallelTasks,
                      UnifiedStatsReporter *USR)
   : NumberOfParallelTasks(NumberOfParallelTasks),

--- a/lib/Basic/Unix/TaskQueue.inc
+++ b/lib/Basic/Unix/TaskQueue.inc
@@ -49,18 +49,6 @@ extern "C" {
 namespace swift {
 namespace sys {
 
-void TaskProcessInformation::ResourceUsage::provideMapping(json::Output &out) {
-    out.mapRequired("utime", Utime);
-    out.mapRequired("stime", Stime);
-    out.mapRequired("maxrss", Maxrss);
-}
-
-void TaskProcessInformation::provideMapping(json::Output &out) {
-    out.mapRequired("real_pid", OSPid);
-    if (ProcessUsage.hasValue())
-    out.mapRequired("usage", ProcessUsage.getValue());
-}
-
 #if defined(HAVE_GETRUSAGE) && !defined(__HAIKU__)
 TaskProcessInformation::TaskProcessInformation(ProcessId Pid, struct rusage Usage)
     : TaskProcessInformation(Pid,


### PR DESCRIPTION
This inlines two methods in the TaskQueue class definition.  The
implementation is small and would need to be replicated into the default
implementation.  This repairs the Windows build of the compiler.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
