### PR TITLE
[SourceKit] Force print '!' for optional method call in code completion.

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1232,6 +1232,7 @@ void CodeCompletionString::getName(raw_ostream &OS) const {
       case ChunkKind::TypeAnnotation:
       case ChunkKind::CallParameterClosureType:
       case ChunkKind::DeclAttrParamColon:
+      case ChunkKind::OptionalMethodCallTail:
         continue;
       case ChunkKind::ThrowsKeyword:
       case ChunkKind::RethrowsKeyword:

--- a/lib/IDE/CodeCompletionResultBuilder.h
+++ b/lib/IDE/CodeCompletionResultBuilder.h
@@ -426,8 +426,7 @@ public:
 
   void addOptionalMethodCallTail() {
     addChunkWithTextNoCopy(
-        CodeCompletionString::Chunk::ChunkKind::OptionalMethodCallTail, "!");
-    getLastChunk().setIsAnnotation();
+        CodeCompletionString::Chunk::ChunkKind::OptionalMethodCallTail, "?");
   }
 
   void addTypeAnnotation(StringRef Type) {

--- a/test/IDE/complete_members_optional.swift
+++ b/test/IDE/complete_members_optional.swift
@@ -29,7 +29,7 @@ func optionalMembers1(_ a: HasOptionalMembers1) {
   a.#^OPTIONAL_MEMBERS_1^#
 }
 // OPTIONAL_MEMBERS_1: Begin completions, 3 items
-// OPTIONAL_MEMBERS_1-DAG: Decl[InstanceMethod]/CurrNominal:   optionalInstanceFunc!()[#Int#]{{; name=.+$}}
+// OPTIONAL_MEMBERS_1-DAG: Decl[InstanceMethod]/CurrNominal:   optionalInstanceFunc?()[#Int#]{{; name=.+$}}
 // OPTIONAL_MEMBERS_1-DAG: Decl[InstanceVar]/CurrNominal:      optionalInstanceProperty[#Int?#]{{; name=.+$}}
 // OPTIONAL_MEMBERS_1-DAG: Keyword[self]/CurrNominal: self[#HasOptionalMembers1#]; name=self
 // OPTIONAL_MEMBERS_1: End completions
@@ -38,8 +38,8 @@ func optionalMembers2<T : HasOptionalMembers1>(_ a: T) {
   T.#^OPTIONAL_MEMBERS_2^#
 }
 // OPTIONAL_MEMBERS_2: Begin completions, 4 items
-// OPTIONAL_MEMBERS_2-DAG: Decl[InstanceMethod]/Super:         optionalInstanceFunc!({#self: HasOptionalMembers1#})[#() -> Int#]{{; name=.+$}}
-// OPTIONAL_MEMBERS_2-DAG: Decl[StaticMethod]/Super:           optionalClassFunc!()[#Int#]{{; name=.+$}}
+// OPTIONAL_MEMBERS_2-DAG: Decl[InstanceMethod]/Super:         optionalInstanceFunc?({#self: HasOptionalMembers1#})[#() -> Int#]{{; name=.+$}}
+// OPTIONAL_MEMBERS_2-DAG: Decl[StaticMethod]/Super:           optionalClassFunc?()[#Int#]{{; name=.+$}}
 // OPTIONAL_MEMBERS_2-DAG: Decl[StaticVar]/Super:              optionalClassProperty[#Int?#]{{; name=.+$}}
 // OPTIONAL_MEMBERS_2-DAG: Keyword[self]/CurrNominal: self[#T.Type#]; name=self
 // OPTIONAL_MEMBERS_2: End completions

--- a/test/SourceKit/CodeComplete/complete_optionalmethod.swift
+++ b/test/SourceKit/CodeComplete/complete_optionalmethod.swift
@@ -1,0 +1,11 @@
+@objc protocol Proto {
+  @objc optional func optionalMethod() -> Int
+}
+
+func test<T : Proto>(obj: T) {
+  let _ = obj.
+}
+
+// RUN: %sourcekitd-test -req=complete -pos=6:15 %s -- %s > %t.response
+// RUN: diff -u %s.response %t.response
+// REQUIRES: objc_interop

--- a/test/SourceKit/CodeComplete/complete_optionalmethod.swift.response
+++ b/test/SourceKit/CodeComplete/complete_optionalmethod.swift.response
@@ -1,0 +1,24 @@
+{
+  key.results: [
+    {
+      key.kind: source.lang.swift.decl.function.method.instance,
+      key.name: "optionalMethod()",
+      key.sourcetext: "optionalMethod?()",
+      key.description: "optionalMethod?()",
+      key.typename: "Int",
+      key.context: source.codecompletion.context.superclass,
+      key.num_bytes_to_erase: 0,
+      key.associated_usrs: "c:@M@complete_optionalmethod@objc(pl)Proto(im)optionalMethod",
+      key.modulename: "complete_optionalmethod"
+    },
+    {
+      key.kind: source.lang.swift.keyword,
+      key.name: "self",
+      key.sourcetext: "self",
+      key.description: "self",
+      key.typename: "T",
+      key.context: source.codecompletion.context.thisclass,
+      key.num_bytes_to_erase: 0
+    }
+  ]
+}

--- a/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
+++ b/tools/SourceKit/lib/SwiftLang/CodeCompletionOrganizer.cpp
@@ -1212,6 +1212,7 @@ void CompletionBuilder::getFilterName(CodeCompletionString *str,
       case ChunkKind::Whitespace:
       case ChunkKind::Ellipsis:
       case ChunkKind::Ampersand:
+      case ChunkKind::OptionalMethodCallTail:
         continue;
       case ChunkKind::CallParameterColon:
         // Since we don't add the type, also don't add the space after ':'.


### PR DESCRIPTION
Calling `@objc optional func` requires `?` or `!` after its name. When completing method calls for them, `key.sourcetext` should have `!` whereas `key.name` shouldn't.

Previously,
```swift
@objc protocol Foo {
    @objc optional func bar()
}

func foo(_ foo: Foo) {
    foo.<HERE>
}
```
completing at `<HERE>` used to complete `bar()`(without `!`).

rdar://problem/37904574