### PR TITLE
swift-reflection-test: preprocess for windows build

### DIFF
--- a/tools/swift-reflection-test/overrides.c
+++ b/tools/swift-reflection-test/overrides.c
@@ -1,5 +1,6 @@
 #include "overrides.h"
 
+#if !defined(_WIN32)
 extern pid_t fork(void);
 extern int execv(const char *path, char * const *argv);
 
@@ -10,4 +11,5 @@ pid_t _fork(void) {
 int _execv(const char *path, char * const *argv) {
   return execv(path, argv);
 }
+#endif
 

--- a/tools/swift-reflection-test/overrides.h
+++ b/tools/swift-reflection-test/overrides.h
@@ -2,5 +2,8 @@
 
 #include <sys/types.h>
 
+#if !defined(_WIN32)
 pid_t _fork(void);
 int _execv(const char *path, char * const *argv);
+#endif
+

--- a/tools/swift-reflection-test/swift-reflection-test.c
+++ b/tools/swift-reflection-test/swift-reflection-test.c
@@ -27,7 +27,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 #include <unistd.h>
+#elif defined(_WIN32)
+#include <io.h>
+#include <fcntl.h>
+#endif
 
 typedef struct PipeMemoryReader {
   int to_child[2];
@@ -265,10 +270,17 @@ void PipeMemoryReader_sendDoneMessage(const PipeMemoryReader *Reader) {
 static
 PipeMemoryReader createPipeMemoryReader() {
   PipeMemoryReader Reader;
+#if defined(_WIN32)
+  if (pipe(Reader.to_child, 256, _O_BINARY))
+    errnoAndExit("Couldn't create pipes to child process");
+  if (pipe(Reader.from_child, 256, _O_BINARY))
+    errnoAndExit("Couldn't create pipes from child process");
+#else
   if (pipe(Reader.to_child))
     errnoAndExit("Couldn't create pipes to child process");
   if (pipe(Reader.from_child))
     errnoAndExit("Couldn't create pipes from child process");
+#endif
   return Reader;
 }
 
@@ -441,6 +453,8 @@ int reflectExistential(SwiftReflectionContextRef RC,
 int doDumpHeapInstance(const char *BinaryFilename) {
   PipeMemoryReader Pipe = createPipeMemoryReader();
 
+#if defined(_WIN32)
+#else
   pid_t pid = _fork();
   switch (pid) {
     case -1:
@@ -515,6 +529,7 @@ int doDumpHeapInstance(const char *BinaryFilename) {
       }
     }
   }
+#endif
   return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
Windows does not support fork/exec, so preprocess away the calls to
those APIs on Windows.  This allows for building more of the test
binaries.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
