### PR TITLE
[Sema] Fix a crash in rethrows checking.

### DIFF
--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -770,7 +770,7 @@ private:
 
     auto mapping = shuffle->getElementMapping();
     for (unsigned destIndex = 0; destIndex != mapping.size(); ++destIndex) {
-      auto srcIndex = shuffle->getElementMapping()[destIndex];
+      auto srcIndex = mapping[destIndex];
       if (srcIndex >= 0) {
         origSrcElts[srcIndex] = origParamTupleType->getElement(destIndex);
       } else if (srcIndex == TupleShuffleExpr::DefaultInitialize ||
@@ -785,9 +785,6 @@ private:
           origSrcElts[srcIndex] =
             origParamTupleType->getASTContext().TheRawPointerType;
         }
-
-        // We're done iterating these elements.
-        break;
       } else {
         llvm_unreachable("bad source-element mapping!");
       }

--- a/test/decl/func/rethrows.swift
+++ b/test/decl/func/rethrows.swift
@@ -545,3 +545,9 @@ func rethrowsWithCaptureList<R, T>(
     return try operation(array.count)
   }
 }
+
+// rdar://problem/40472018: Crash on rethrows function with variadic parameter and throwing function parameter.
+public func variadic_rethrows(_ values: Int..., body: (Int) throws -> ()) rethrows { }
+public func rdar40472018() {
+  variadic_rethrows(1, 2) { _ in }
+}


### PR DESCRIPTION
We were assuming that variadic parameters are at the end, so we didn't
fill in all the types of the tuple elements in the tuple type we were
constructing.

Fixes: rdar://problem/40472018