### PR TITLE
[4.2] IRGen: Fix multipayload enums with indirect cases

### DIFF
--- a/lib/IRGen/GenEnum.cpp
+++ b/lib/IRGen/GenEnum.cpp
@@ -3129,15 +3129,12 @@ namespace {
                                                &refcounting)) {
           allSingleRefcount = false;
         } else if (haveRefcounting) {
-          // Different payloads have different reference counting styles.
-          if (refcounting != Refcounting) {
-            // Fall back to unknown entry points if the Objective-C runtime is
-            // available.
-            Refcounting = ReferenceCounting::Unknown;
-            // Otherwise, use value witnesses.
-            if (!IGM.ObjCInterop)
-              allSingleRefcount = false;
-          }
+          // Only support a single style of reference counting for now.
+          // swift_unknowRetain does not support the heap buffer of indirect
+          // enums. And I am not convinced that unknowRetain supports
+          // bridgedObjectRetain.
+          if (refcounting != Refcounting)
+            allSingleRefcount = false;
         } else {
           Refcounting = refcounting;
           haveRefcounting = true;

--- a/test/IRGen/enum_value_semantics_special_cases_objc.sil
+++ b/test/IRGen/enum_value_semantics_special_cases_objc.sil
@@ -36,10 +36,10 @@ enum AllMixedRefcounted {
 // CHECK:   %0 = bitcast %swift.opaque* %object to %T39enum_value_semantics_special_cases_objc18AllMixedRefcountedO*
 // CHECK:   %1 = bitcast %T39enum_value_semantics_special_cases_objc18AllMixedRefcountedO* %0 to i64*
 // CHECK:   %2 = load i64, i64* %1, align 8
-// --                         0x3fffffffffffffff
-// CHECK:   %3 = and i64 %2, 4611686018427387903
-// CHECK:   %4 = inttoptr i64 %3 to %objc_object*
-// CHECK:   call void @swift_unknownRelease(%objc_object* %4) {{#[0-9]+}}
+// CHECK:   %3 = lshr i64 %2, 62
+// CHECK:   %4 = trunc i64 %3 to i8
+// CHECK:   %5 = and i8 %4, 3
+// CHECK:   call void @"$S39enum_value_semantics_special_cases_objc18AllMixedRefcountedOWOe"(i64 %2)
 // CHECK:   ret void
 // CHECK: }
 
@@ -53,3 +53,51 @@ enum AllMixedRefcountedTwoSimple {
 
 // CHECK-LABEL: define linkonce_odr hidden void @"$S39enum_value_semantics_special_cases_objc27AllMixedRefcountedTwoSimpleOwxx"
 // CHECK:   call void @"$S39enum_value_semantics_special_cases_objc27AllMixedRefcountedTwoSimpleOWOy"
+
+struct Val {
+}
+
+// Currently, swift_unknownRelease does not support the indirect heap object.
+
+enum MixedRefcountedWithIndirect {
+  indirect case Indirect(Builtin.Int64)
+  case Ref(Builtin.UnknownObject)
+  case None
+}
+
+// CHECK-LABEL: define linkonce_odr hidden void @"$S39enum_value_semantics_special_cases_objc27MixedRefcountedWithIndirectOwxx"(%swift.opaque* noalias %object, %swift.type* %MixedRefcountedWithIndirect)
+// CHECK: entry:
+// CHECK:   %0 = bitcast %swift.opaque* %object to %T39enum_value_semantics_special_cases_objc27MixedRefcountedWithIndirectO*
+// CHECK:   %1 = bitcast %T39enum_value_semantics_special_cases_objc27MixedRefcountedWithIndirectO* %0 to i64*
+// CHECK:   %2 = load i64, i64* %1, align 8
+// CHECK:   %3 = lshr i64 %2, 62
+// CHECK:   %4 = trunc i64 %3 to i8
+// CHECK:   %5 = and i8 %4, 3
+// CHECK:   call void @"$S39enum_value_semantics_special_cases_objc27MixedRefcountedWithIndirectOWOe"(i64 %2)
+// CHECK:   ret void
+// CHECK: }
+
+
+// CHECK-LABEL: define linkonce_odr hidden void @"$S39enum_value_semantics_special_cases_objc27MixedRefcountedWithIndirectOWOe"(i64)
+// CHECK: entry:
+// CHECK:   %1 = lshr i64 %0, 62
+// CHECK:   %2 = trunc i64 %1 to i8
+// CHECK:   %3 = and i8 %2, 3
+// CHECK:   switch i8 %3, label %9 [
+// CHECK:     i8 0, label %4
+// CHECK:     i8 1, label %6
+// CHECK:   ]
+
+// CHECK: ; <label>:4:
+// CHECK:   %5 = inttoptr i64 %0 to %swift.refcounted*
+// CHECK:   call void @swift_release(%swift.refcounted* %5) #1
+// CHECK:   br label %9
+
+// CHECK: ; <label>:6:
+// CHECK:   %7 = and i64 %0, 4611686018427387903
+// CHECK:   %8 = inttoptr i64 %7 to %objc_object*
+// CHECK:   call void @swift_unknownRelease(%objc_object* %8) #1
+// CHECK:   br label %9
+
+// CHECK: ; <label>:9:
+// CHECK:   ret void

--- a/test/Interpreter/enum.swift
+++ b/test/Interpreter/enum.swift
@@ -667,3 +667,33 @@ public func testCase(_ closure: @escaping (Int) -> ()) -> Indirect<(Int) -> ()> 
 
 // CHECK: payload((Function), other: (Function))
 print(testCase({ _ in }))
+
+
+enum MultiIndirectRef {
+  case empty
+  indirect case ind(Int)
+  case collection([Int])
+}
+
+struct Container {
+  var storage : MultiIndirectRef = .empty
+
+  mutating func adoptStyle(_ s: Int) {
+    storage = .ind(s)
+  }
+}
+
+func copyStorage(_ s: Int, _ x : Container) -> Container {
+  var c = x
+  c.adoptStyle(s)
+  return c
+}
+
+func testCase() {
+  let l = Container()
+  let c = copyStorage(5, l)
+  print(c)
+}
+
+// CHECK: Container(storage: a.MultiIndirectRef.ind(5))
+testCase()


### PR DESCRIPTION
swift_unknownRetain does not work on indirect enum heap buffers.

The existing logic would say: oh one case is
ReferenceCounting::BridgeObject (which on its own probably would not
work with swift_unknownRetain), oh and another second case is NativeObject (for
the indirect buffer), let's use unknowRetain.

Pair the logic down to only use a single style of reference count
operation if all cases are of the same ReferenceCounting type.

rdar://40525268
