### PR TITLE
[4.2] Ease cherry-picking by providing an impl of SILType::getASTType().

### DIFF
--- a/include/swift/SIL/SILType.h
+++ b/include/swift/SIL/SILType.h
@@ -158,6 +158,11 @@ public:
     return SILType(getSwiftRValueType(), SILValueCategory::Object);
   }
 
+  /// Returns the canonical AST type referenced by this SIL type.
+  CanType getASTType() const {
+    return getSwiftRValueType();
+  }
+
   /// Returns the Swift type referenced by this SIL type.
   CanType getSwiftRValueType() const {
     return CanType(value.getPointer());


### PR DESCRIPTION
SILType::getSwiftRValueType() was renamed to SILType::getASTType() on
master. This commit provides SILType::getASTType() and delegates to
getSwiftRValueType() to ease cherry-picking from master -> 4.2.

Otherwise, all of the times someone on master cherry-picks such code, we will
get a compilation error.
