### PR TITLE
IRGen: Use `swift_getObjectType` to get the `type(of:)` mixed classes.

### DIFF
--- a/lib/IRGen/GenHeap.cpp
+++ b/lib/IRGen/GenHeap.cpp
@@ -1967,16 +1967,30 @@ llvm::Value *irgen::emitDynamicTypeOfHeapObject(IRGenFunction &IGF,
                                                 llvm::Value *object,
                                                 MetatypeRepresentation repr,
                                                 SILType objectType,
-                                                bool suppressCast) {
-  // If it is known to have swift metadata, just load. A swift class is both
-  // heap metadata and type metadata.
-  if (hasKnownSwiftMetadata(IGF.IGM, objectType.getASTType())) {
-    return emitLoadOfHeapMetadataRef(IGF, object,
-                getIsaEncodingForType(IGF.IGM, objectType.getASTType()),
-                suppressCast);
+                                                bool allowArtificialSubclasses){
+  switch (auto isaEncoding =
+            getIsaEncodingForType(IGF.IGM, objectType.getASTType())) {
+  case IsaEncoding::Pointer:
+    // Directly load the isa pointer from a pure Swift class.
+    return emitLoadOfHeapMetadataRef(IGF, object, isaEncoding,
+                                     /*suppressCast*/ false);
+  case IsaEncoding::ObjC:
+    // A class defined in Swift that inherits from an Objective-C class may
+    // end up dynamically subclassed by ObjC runtime hackery. The artificial
+    // subclass isn't a formal Swift type, so isn't appropriate as the result
+    // of `type(of:)`, but is still a physical subtype of the real class object,
+    // so can be used for some purposes like satisfying type parameters in
+    // generic signatures.
+    if (allowArtificialSubclasses
+        && hasKnownSwiftMetadata(IGF.IGM, objectType.getASTType()))
+      return emitLoadOfHeapMetadataRef(IGF, object, isaEncoding,
+                                       /*suppressCast*/ false);
+   
+    // Ask the Swift runtime to find the dynamic type. This will look through
+    // dynamic subclasses of Swift classes, and use the -class message for
+    // ObjC classes.
+    return emitDynamicTypeOfOpaqueHeapObject(IGF, object, repr);
   }
-
-  return emitDynamicTypeOfOpaqueHeapObject(IGF, object, repr);
 }
 
 static ClassDecl *getRootClass(ClassDecl *theClass) {
@@ -2001,6 +2015,11 @@ IsaEncoding irgen::getIsaEncodingForType(IRGenModule &IGM,
     // For ObjC or mixed classes, we need to use object_getClass.
     return IsaEncoding::ObjC;
   }
+  
+  // Existentials use the encoding of the enclosed dynamic type.
+  if (type->isAnyExistentialType()) {
+    return getIsaEncodingForType(IGM, ArchetypeType::getOpened(type));
+  }
 
   if (auto archetype = dyn_cast<ArchetypeType>(type)) {
     // If we have a concrete superclass constraint, just recurse.
@@ -2012,9 +2031,6 @@ IsaEncoding irgen::getIsaEncodingForType(IRGenModule &IGM,
     // conservative answer.
     return IsaEncoding::ObjC;
   }
-
-  // We should never be working with an unopened existential type here.
-  assert(!type->isAnyExistentialType());
 
   // Non-class heap objects should be pure Swift, so we can access their isas
   // directly.

--- a/lib/IRGen/GenHeap.h
+++ b/lib/IRGen/GenHeap.h
@@ -152,7 +152,7 @@ llvm::Value *emitDynamicTypeOfHeapObject(IRGenFunction &IGF,
                                          llvm::Value *object,
                                          MetatypeRepresentation rep,
                                          SILType objectType,
-                                         bool suppressCast = false);
+                                         bool allowArtificialSubclasses = false);
 
 /// Given a non-tagged object pointer, load a pointer to its class object.
 llvm::Value *emitLoadOfObjCHeapMetadataRef(IRGenFunction &IGF,

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -627,9 +627,10 @@ bindParameterSource(SILParameterInfo param, unsigned paramIndex,
     llvm::Value *instanceRef = getParameter(paramIndex);
     SILType instanceType = SILType::getPrimitiveObjectType(paramType);
     llvm::Value *metadata =
-    emitDynamicTypeOfHeapObject(IGF, instanceRef,
-                                MetatypeRepresentation::Thick,
-                                instanceType);
+      emitDynamicTypeOfHeapObject(IGF, instanceRef,
+                                  MetatypeRepresentation::Thick,
+                                  instanceType,
+                                  /*allow artificial subclasses*/ true);
     IGF.bindLocalTypeDataFromTypeMetadata(paramType, IsInexact, metadata,
                                           MetadataState::Complete);
     return;
@@ -690,7 +691,8 @@ void BindPolymorphicParameter::emit(Explosion &nativeParam, unsigned paramIndex)
   llvm::Value *metadata =
     emitDynamicTypeOfHeapObject(IGF, instanceRef,
                                 MetatypeRepresentation::Thick,
-                                instanceType);
+                                instanceType,
+                                /* allow artificial subclasses */ true);
   IGF.bindLocalTypeDataFromTypeMetadata(paramType, IsInexact, metadata,
                                         MetadataState::Complete);
 }

--- a/test/IRGen/objc_typeof.swift
+++ b/test/IRGen/objc_typeof.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir %s | %FileCheck %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+open class AllSwift {}
+
+open class Mixed: NSObject {}
+
+// CHECK-LABEL: define{{.*@.*}}14typeOfAllSwift
+public func typeOfAllSwift(_ x: AllSwift) -> AllSwift.Type {
+  // CHECK: [[ISA:%.*]] = load %swift.type*
+  // CHECK: ret %swift.type* [[ISA]]
+  return type(of: x)
+}
+
+// CHECK-LABEL: define{{.*@.*}}11typeOfMixed
+public func typeOfMixed(_ x: Mixed) -> Mixed.Type {
+  // CHECK: [[ISA:%.*]] = call %swift.type* @swift_getObjectType
+  // CHECK: ret %swift.type* [[ISA]]
+  return type(of: x)
+}
+
+// CHECK-LABEL: define{{.*@.*}}14typeOfNSObject
+public func typeOfNSObject(_ x: NSObject) -> NSObject.Type {
+  // CHECK: [[ISA:%.*]] = call %swift.type* @swift_getObjectType
+  // CHECK: ret %swift.type* [[ISA]]
+  return type(of: x)
+}
+
+// CHECK-LABEL: define{{.*@.*}}13typeOfUnknown
+public func typeOfUnknown(_ x: AnyObject) -> AnyObject.Type {
+  // CHECK: [[ISA:%.*]] = call %swift.type* @swift_getObjectType
+  // CHECK: ret %swift.type* [[ISA]]
+  return type(of: x)
+}


### PR DESCRIPTION
A Swift subclass of an ObjC class can be dynamically subclassed, but `type(of:)` shouldn't return the artificial subclass, since that's not what -class does for ObjC classes, and people expect `Bundle(for: type(of: c))` to work like `[NSBundle bundleForClass: [c class]]` would in ObjC. Fixes rdar://problem/37319860.