### PR TITLE
[4.2] IRGen: Use `swift_getObjectType` to get the `type(of:)` mixed classes.

### DIFF
--- a/lib/IRGen/GenHeap.h
+++ b/lib/IRGen/GenHeap.h
@@ -152,7 +152,7 @@ llvm::Value *emitDynamicTypeOfHeapObject(IRGenFunction &IGF,
                                          llvm::Value *object,
                                          MetatypeRepresentation rep,
                                          SILType objectType,
-                                         bool suppressCast = false);
+                                         bool allowArtificialSubclasses = false);
 
 /// Given a non-tagged object pointer, load a pointer to its class object.
 llvm::Value *emitLoadOfObjCHeapMetadataRef(IRGenFunction &IGF,

--- a/lib/IRGen/GenProto.cpp
+++ b/lib/IRGen/GenProto.cpp
@@ -627,9 +627,10 @@ bindParameterSource(SILParameterInfo param, unsigned paramIndex,
     llvm::Value *instanceRef = getParameter(paramIndex);
     SILType instanceType = SILType::getPrimitiveObjectType(paramType);
     llvm::Value *metadata =
-    emitDynamicTypeOfHeapObject(IGF, instanceRef,
-                                MetatypeRepresentation::Thick,
-                                instanceType);
+      emitDynamicTypeOfHeapObject(IGF, instanceRef,
+                                  MetatypeRepresentation::Thick,
+                                  instanceType,
+                                  /*allow artificial subclasses*/ true);
     IGF.bindLocalTypeDataFromTypeMetadata(paramType, IsInexact, metadata,
                                           MetadataState::Complete);
     return;
@@ -690,7 +691,8 @@ void BindPolymorphicParameter::emit(Explosion &nativeParam, unsigned paramIndex)
   llvm::Value *metadata =
     emitDynamicTypeOfHeapObject(IGF, instanceRef,
                                 MetatypeRepresentation::Thick,
-                                instanceType);
+                                instanceType,
+                                /* allow artificial subclasses */ true);
   IGF.bindLocalTypeDataFromTypeMetadata(paramType, IsInexact, metadata,
                                         MetadataState::Complete);
 }

--- a/test/IRGen/objc_typeof.swift
+++ b/test/IRGen/objc_typeof.swift
@@ -1,0 +1,36 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir %s | %FileCheck %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+open class AllSwift {}
+
+open class Mixed: NSObject {}
+
+// CHECK-LABEL: define{{.*@.*}}14typeOfAllSwift
+public func typeOfAllSwift(_ x: AllSwift) -> AllSwift.Type {
+  // CHECK: [[ISA:%.*]] = load %swift.type*
+  // CHECK: ret %swift.type* [[ISA]]
+  return type(of: x)
+}
+
+// CHECK-LABEL: define{{.*@.*}}11typeOfMixed
+public func typeOfMixed(_ x: Mixed) -> Mixed.Type {
+  // CHECK: [[ISA:%.*]] = call %swift.type* @swift_getObjectType
+  // CHECK: ret %swift.type* [[ISA]]
+  return type(of: x)
+}
+
+// CHECK-LABEL: define{{.*@.*}}14typeOfNSObject
+public func typeOfNSObject(_ x: NSObject) -> NSObject.Type {
+  // CHECK: [[ISA:%.*]] = call %swift.type* @swift_getObjectType
+  // CHECK: ret %swift.type* [[ISA]]
+  return type(of: x)
+}
+
+// CHECK-LABEL: define{{.*@.*}}13typeOfUnknown
+public func typeOfUnknown(_ x: AnyObject) -> AnyObject.Type {
+  // CHECK: [[ISA:%.*]] = call %swift.type* @swift_getObjectType
+  // CHECK: ret %swift.type* [[ISA]]
+  return type(of: x)
+}


### PR DESCRIPTION
A Swift subclass of an ObjC class can be dynamically subclassed, but `type(of:)` shouldn't return the artificial subclass, since that's not what -class does for ObjC classes, and people expect `Bundle(for: type(of: c))` to work like `[NSBundle bundleForClass: [c class]]` would in ObjC. Fixes rdar://problem/37319860.