### PR TITLE
SwiftSourceKit: add API to generate a syntax tree from a given source buffer.

### DIFF
--- a/test/SwiftSyntax/ParseFile.swift
+++ b/test/SwiftSyntax/ParseFile.swift
@@ -37,4 +37,13 @@ ParseFile.test("ParseSingleFile") {
   })
 }
 
+ParseFile.test("ParseBuffer") {
+  expectDoesNotThrow({
+    let content = "func foo() {}"
+    let parsed = try SourceFileSyntax.decodeSourceFileSyntax(try
+      SwiftLang.parse(content))
+    expectEqual("\(parsed)", content)
+  })
+}
+
 runAllTests()

--- a/tools/SourceKit/tools/swift-lang/SwiftLang.swift
+++ b/tools/SourceKit/tools/swift-lang/SwiftLang.swift
@@ -14,22 +14,64 @@
 
 import Foundation
 
+enum SourceKitdError: Error, CustomStringConvertible {
+  case EditorOpenError(message: String)
+  case EditorCloseError(message: String)
+
+  var description: String {
+    switch self {
+    case .EditorOpenError(let message):
+      return "cannot open document: \(message)"
+    case .EditorCloseError(let message):
+      return "cannot close document: \(message)"
+    }
+  }
+}
+
 public class SwiftLang {
 
-  /// Parses the Swift file at the provided URL into a `Syntax` tree in Json
-  /// serialization format by querying SourceKitd service.
-  /// - Parameter url: The URL you wish to parse.
-  /// - Returns: The syntax tree in Json format string.
-  public static func parse(_ url: URL) throws -> String {
+  fileprivate static func parse(content: String, name: String, isURL: Bool) throws -> String {
     let Service = SourceKitdService()
     let Request = SourceKitdRequest(uid: .request_EditorOpen)
-    let Path = url.path
-    Request.addParameter(.key_SourceFile, value: Path)
-    Request.addParameter(.key_Name, value: Path)
+    if isURL {
+      Request.addParameter(.key_SourceFile, value: content)
+    } else {
+      Request.addParameter(.key_SourceText, value: content)
+    }
+    Request.addParameter(.key_Name, value: name)
     Request.addParameter(.key_EnableSyntaxTree, value: 1)
+    Request.addParameter(.key_SyntacticOnly, value: 1)
 
     // FIXME: SourceKitd error handling.
     let Resp = Service.sendSyn(request: Request)
+    if Resp.isError {
+      throw SourceKitdError.EditorOpenError(message: Resp.description)
+    }
+
+    let CloseReq = SourceKitdRequest(uid: .request_EditorClose)
+    CloseReq.addParameter(.key_Name, value: name)
+    let CloseResp = Service.sendSyn(request: CloseReq)
+    if CloseResp.isError {
+      throw SourceKitdError.EditorCloseError(message: CloseResp.description)
+    }
     return Resp.value.getString(.key_SerializedSyntaxTree)
+  }
+
+  /// Parses the Swift file at the provided URL into a `Syntax` tree in Json
+  /// serialization format by querying SourceKitd service. This function isn't
+  /// thread safe.
+  /// - Parameter url: The URL you wish to parse.
+  /// - Returns: The syntax tree in Json format string.
+  public static func parse(_ url: URL) throws -> String {
+    let Path = url.path
+    return try parse(content: Path, name: Path, isURL: true)
+  }
+
+  /// Parses a given source buffer into a `Syntax` tree in Json serialization
+  /// format by querying SourceKitd service. This function isn't thread safe.
+  /// - Parameter source: The source buffer you wish to parse.
+  /// - Returns: The syntax tree in Json format string.
+  public static func parse(_ source: String) throws -> String {
+    return try parse(content: source, name: "foo", isURL: false)
   }
 }


### PR DESCRIPTION
We used to only have a parse API for a given source file URL. This patch starts to support parsing a source buffer without a file on disk.