### PR TITLE
[4.2][migrator] Add -api-diff-data-dir option to override the default location for the migrator's platform + version specific api diff json files

### DIFF
--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -545,6 +545,13 @@ def api_diff_data_file: Separate<["-"], "api-diff-data-file">,
   HelpText<"API migration data is from <path>">,
   MetaVarName<"<path>">;
 
+def api_diff_data_dir: Separate<["-"], "api-diff-data-dir">,
+  Flags<[FrontendOption, NoInteractiveOption, DoesNotAffectIncrementalBuild,
+         ArgumentIsPath]>,
+  HelpText<"Load platform and version specific API migration data files from <path>. "
+      "Ignored if -api-diff-data-file is specified.">,
+  MetaVarName<"<path>">;
+
 def dump_usr: Flag<["-"], "dump-usr">,
   Flags<[FrontendOption, NoInteractiveOption]>,
   HelpText<"Dump USR for each declaration reference">;

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -267,6 +267,10 @@ ToolChain::constructInvocation(const CompileJobAction &job,
     Arguments.push_back("-api-diff-data-file");
     Arguments.push_back(DataPath->getValue());
   }
+  if (auto DataDir = context.Args.getLastArg(options::OPT_api_diff_data_dir)) {
+    Arguments.push_back("-api-diff-data-dir");
+    Arguments.push_back(DataDir->getValue());
+  }
   if (context.Args.hasArg(options::OPT_dump_usr)) {
     Arguments.push_back("-dump-usr");
   }

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -951,9 +951,16 @@ static bool ParseMigratorArgs(MigratorOptions &Opts,
     auto &Triple = LangOpts.Target;
     bool isSwiftVersion3 = LangOpts.isSwiftVersion3();
 
+    llvm::SmallString<128> basePath;
+    if (auto DataDir = Args.getLastArg(OPT_api_diff_data_dir)) {
+      basePath = DataDir->getValue();
+    } else {
+      basePath = ResourcePath;
+      llvm::sys::path::append(basePath, "migrator");
+    }
+
     bool Supported = true;
-    llvm::SmallString<128> dataPath(ResourcePath);
-    llvm::sys::path::append(dataPath, "migrator");
+    llvm::SmallString<128> dataPath(basePath);
 
     if (Triple.isMacOSX())
       llvm::sys::path::append(dataPath,
@@ -970,8 +977,7 @@ static bool ParseMigratorArgs(MigratorOptions &Opts,
     else
       Supported = false;
     if (Supported) {
-      llvm::SmallString<128> authoredDataPath(ResourcePath);
-      llvm::sys::path::append(authoredDataPath, "migrator");
+      llvm::SmallString<128> authoredDataPath(basePath);
       llvm::sys::path::append(authoredDataPath,
                               getScriptFileName("overlay", isSwiftVersion3));
       // Add authored list first to take higher priority.

--- a/test/Migrator/Inputs/api-diff-data-dir/ios3.json
+++ b/test/Migrator/Inputs/api-diff-data-dir/ios3.json
@@ -1,0 +1,13 @@
+[
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "Rename",
+    "ChildIndex": "0",
+    "LeftUsr": "c:objc(cs)BarForwardDeclaredClass(im)barInstanceFunc1:anotherValue:anotherValue1:anotherValue2:",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "barNewSwift3InstanceFunc1(newlabel1:newlabel2:newlabel3:newlabel4:)",
+    "ModuleName": "bar"
+  }
+]

--- a/test/Migrator/Inputs/api-diff-data-dir/ios4.json
+++ b/test/Migrator/Inputs/api-diff-data-dir/ios4.json
@@ -1,0 +1,13 @@
+[
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "Rename",
+    "ChildIndex": "0",
+    "LeftUsr": "c:objc(cs)BarForwardDeclaredClass(im)barInstanceFunc1:anotherValue:anotherValue1:anotherValue2:",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "barNewSwift4InstanceFunc1(newlabel1:newlabel2:newlabel3:newlabel4:)",
+    "ModuleName": "bar"
+  }
+]

--- a/test/Migrator/Inputs/api-diff-data-dir/macos3.json
+++ b/test/Migrator/Inputs/api-diff-data-dir/macos3.json
@@ -1,0 +1,13 @@
+[
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "Rename",
+    "ChildIndex": "0",
+    "LeftUsr": "c:objc(cs)BarForwardDeclaredClass(im)barInstanceFunc1:anotherValue:anotherValue1:anotherValue2:",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "barNewSwift3InstanceFunc1(newlabel1:newlabel2:newlabel3:newlabel4:)",
+    "ModuleName": "bar"
+  }
+]

--- a/test/Migrator/Inputs/api-diff-data-dir/macos4.json
+++ b/test/Migrator/Inputs/api-diff-data-dir/macos4.json
@@ -1,0 +1,13 @@
+[
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "Rename",
+    "ChildIndex": "0",
+    "LeftUsr": "c:objc(cs)BarForwardDeclaredClass(im)barInstanceFunc1:anotherValue:anotherValue1:anotherValue2:",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "barNewSwift4InstanceFunc1(newlabel1:newlabel2:newlabel3:newlabel4:)",
+    "ModuleName": "bar"
+  }
+]

--- a/test/Migrator/Inputs/api-diff-data-dir/overlay3.json
+++ b/test/Migrator/Inputs/api-diff-data-dir/overlay3.json
@@ -1,0 +1,13 @@
+[
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "Rename",
+    "ChildIndex": "0",
+    "LeftUsr": "c:@F@barGlobalFuncOldName",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "barGlobalFuncNewSwift3OverlayName(newlabel:)",
+    "ModuleName": "bar"
+  }
+]

--- a/test/Migrator/Inputs/api-diff-data-dir/overlay4.json
+++ b/test/Migrator/Inputs/api-diff-data-dir/overlay4.json
@@ -1,0 +1,13 @@
+[
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "Rename",
+    "ChildIndex": "0",
+    "LeftUsr": "c:@F@barGlobalFuncOldName",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "barGlobalFuncNewSwift4OverlayName(newlabel:)",
+    "ModuleName": "bar"
+  }
+]

--- a/test/Migrator/Inputs/api-diff-data-dir/tvos3.json
+++ b/test/Migrator/Inputs/api-diff-data-dir/tvos3.json
@@ -1,0 +1,13 @@
+[
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "Rename",
+    "ChildIndex": "0",
+    "LeftUsr": "c:objc(cs)BarForwardDeclaredClass(im)barInstanceFunc1:anotherValue:anotherValue1:anotherValue2:",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "barNewSwift3InstanceFunc1(newlabel1:newlabel2:newlabel3:newlabel4:)",
+    "ModuleName": "bar"
+  }
+]

--- a/test/Migrator/Inputs/api-diff-data-dir/tvos4.json
+++ b/test/Migrator/Inputs/api-diff-data-dir/tvos4.json
@@ -1,0 +1,13 @@
+[
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "Rename",
+    "ChildIndex": "0",
+    "LeftUsr": "c:objc(cs)BarForwardDeclaredClass(im)barInstanceFunc1:anotherValue:anotherValue1:anotherValue2:",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "barNewSwift4InstanceFunc1(newlabel1:newlabel2:newlabel3:newlabel4:)",
+    "ModuleName": "bar"
+  }
+]

--- a/test/Migrator/Inputs/api-diff-data-dir/watchos3.json
+++ b/test/Migrator/Inputs/api-diff-data-dir/watchos3.json
@@ -1,0 +1,13 @@
+[
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "Rename",
+    "ChildIndex": "0",
+    "LeftUsr": "c:objc(cs)BarForwardDeclaredClass(im)barInstanceFunc1:anotherValue:anotherValue1:anotherValue2:",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "barNewSwift3InstanceFunc1(newlabel1:newlabel2:newlabel3:newlabel4:)",
+    "ModuleName": "bar"
+  }
+]

--- a/test/Migrator/Inputs/api-diff-data-dir/watchos4.json
+++ b/test/Migrator/Inputs/api-diff-data-dir/watchos4.json
@@ -1,0 +1,13 @@
+[
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "Function",
+    "NodeAnnotation": "Rename",
+    "ChildIndex": "0",
+    "LeftUsr": "c:objc(cs)BarForwardDeclaredClass(im)barInstanceFunc1:anotherValue:anotherValue1:anotherValue2:",
+    "LeftComment": "",
+    "RightUsr": "",
+    "RightComment": "barNewSwift4InstanceFunc1(newlabel1:newlabel2:newlabel3:newlabel4:)",
+    "ModuleName": "bar"
+  }
+]

--- a/test/Migrator/api-diff-data-dir.swift
+++ b/test/Migrator/api-diff-data-dir.swift
@@ -1,0 +1,16 @@
+// REQUIRES: objc_interop
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -swift-version 3 -primary-file %s -F %S/mock-sdk -api-diff-data-dir %S/Inputs/api-diff-data-dir -emit-migrated-file-path %t/api-diff-data-dir.swift.result -emit-remap-file-path %t/api-diff-data-dir.swift.remap -o /dev/null
+// RUN: %FileCheck %s -input-file %t/api-diff-data-dir.swift.result -match-full-lines -check-prefix=SWIFT3
+// RUN: %empty-directory(%t) && %target-swift-frontend -c -update-code -swift-version 4 -primary-file %s -F %S/mock-sdk -api-diff-data-dir %S/Inputs/api-diff-data-dir -emit-migrated-file-path %t/api-diff-data-dir.swift.result -emit-remap-file-path %t/api-diff-data-dir.swift.remap -o /dev/null
+// RUN: %FileCheck %s -input-file %t/api-diff-data-dir.swift.result -match-full-lines -check-prefix=SWIFT4
+
+import Bar
+
+func foo(_ b: BarForwardDeclaredClass) {
+  b.barInstanceFunc1(0, anotherValue: 1, anotherValue1: 2, anotherValue2: 3)
+  // SWIFT3:  b.barNewSwift3InstanceFunc1(newlabel1: 0, newlabel2: 1, newlabel3: 2, newlabel4: 3)
+  // SWIFT4:  b.barNewSwift4InstanceFunc1(newlabel1: 0, newlabel2: 1, newlabel3: 2, newlabel4: 3)
+  barGlobalFuncOldName(2)
+  // SWIFT3:  barGlobalFuncNewSwift3OverlayName(newlabel: 2)
+  // SWIFT4:  barGlobalFuncNewSwift4OverlayName(newlabel: 2)
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift/pull/16920
<!-- What's in this pull request? -->
This is useful for testing the migrator with different versions of the api diff data.
The new option is ignored if `-api-diff-data-file`, that expects a single JSON file, is also passed.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
