### PR TITLE
[Reflection] Fix a member function so that it actually compiles.

### DIFF
--- a/include/swift/Reflection/ReflectionContext.h
+++ b/include/swift/Reflection/ReflectionContext.h
@@ -108,7 +108,7 @@ public:
   }
 
   void dumpAllSections(std::ostream &OS) {
-    getBuilder().dumpAllSections();
+    getBuilder().dumpAllSections(OS);
   }
 
 #if defined(__APPLE__) && defined(__MACH__)


### PR DESCRIPTION
Nobody's using it, so nobody noticed. I plan to use this in the
debugger.
