### PR TITLE
[Testing Coverage] Enable (not REQUIRE) ObjC interop

### DIFF
--- a/test/IRGen/objc_factory_method.sil
+++ b/test/IRGen/objc_factory_method.sil
@@ -1,7 +1,6 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -emit-ir | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-ir %s | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
-// REQUIRES: objc_interop
 
 // CHECK: [[SWIFT_TYPE:%swift.type]] = type { i64 }
 sil_stage canonical

--- a/test/IRGen/objc_int_encoding.sil
+++ b/test/IRGen/objc_int_encoding.sil
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop %s -emit-ir | %FileCheck %s --check-prefix=CHECK --check-prefix=CHECK-%target-ptrsize
 
 // CHECK: [[SELECTOR:@.*]] = private global {{.*}} c"fooWithX:\00"
 

--- a/test/IRGen/objc_properties_imported.swift
+++ b/test/IRGen/objc_properties_imported.swift
@@ -1,7 +1,6 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-source-import -emit-ir -o - -primary-file %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -enable-source-import -emit-ir -o - -primary-file %s | %FileCheck %s
 
 // REQUIRES: CPU=x86_64
-// REQUIRES: objc_interop
 
 // FIXME: This test uses IRGen with -enable-source-import; it may fail with -g.
 

--- a/test/IRGen/objc_properties_jit.swift
+++ b/test/IRGen/objc_properties_jit.swift
@@ -1,6 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) %s -emit-ir -disable-objc-attr-requires-foundation-module -use-jit | %FileCheck %s
-
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop %s -emit-ir -disable-objc-attr-requires-foundation-module -use-jit | %FileCheck %s
 
 import Foundation
 

--- a/test/IRGen/type_layout_reference_storage_objc.swift
+++ b/test/IRGen/type_layout_reference_storage_objc.swift
@@ -1,5 +1,4 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-ir %s | %FileCheck %s
-// REQUIRES: objc_interop
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-ir %s | %FileCheck %s
 
 import Foundation
 


### PR DESCRIPTION
This improves coverage on Linux. With a little more work, more IRGen tests could use this approach.