### PR TITLE
[4.2] ClosureLifetimeFixup: Fix closure insertion point in deallocati…

### DIFF
--- a/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
+++ b/lib/SILOptimizer/Mandatory/ClosureLifetimeFixup.cpp
@@ -66,6 +66,27 @@ static SILBasicBlock *getOptionalDiamondSuccessor(SwitchEnumInst *SEI) {
    return nullptr;
 }
 
+/// Find a safe insertion point for closure destruction. We might create a
+/// closure that captures self in deinit of self. In this situation it is not
+/// safe to destroy the closure after we called super deinit. We have to place
+/// the closure destruction before that call.
+///
+///  %deinit = objc_super_method %0 : $C, #A.deinit!deallocator.foreign
+///  %super = upcast %0 : $C to $A
+///  apply %deinit(%super) : $@convention(objc_method) (A) -> ()
+///  end_lifetime %super : $A
+static SILInstruction *getDeinitSafeClosureDestructionPoint(TermInst *Term) {
+  for (auto It = Term->getParent()->rbegin(), E = Term->getParent()->rend();
+       It != E; ++It) {
+    if (auto *EndLifetime = dyn_cast<EndLifetimeInst>(&*It)) {
+      auto *SuperInstance = EndLifetime->getOperand()->getDefiningInstruction();
+      assert(SuperInstance && "Expected an instruction");
+      return SuperInstance;
+    }
+  }
+  return Term;
+}
+
 /// Extend the lifetime of the convert_escape_to_noescape's operand to the end
 /// of the function.
 static void extendLifetimeToEndOfFunction(SILFunction &Fn,
@@ -111,10 +132,11 @@ static void extendLifetimeToEndOfFunction(SILFunction &Fn,
   Fn.findExitingBlocks(ExitingBlocks);
   for (auto *Exit : ExitingBlocks) {
     auto *Term = Exit->getTerminator();
-    SILBuilderWithScope B(Term);
-    B.setInsertionPoint(Term);
+    auto *SafeClosureDestructionPt = getDeinitSafeClosureDestructionPoint(Term);
+    SILBuilderWithScope B(SafeClosureDestructionPt);
     B.createDestroyAddr(loc, Slot);
-    B.createDeallocStack(loc, Slot);
+    SILBuilderWithScope B2(Term);
+    B2.createDeallocStack(loc, Slot);
   }
 }
 


### PR DESCRIPTION
…ng deinits

We must not capture self beyond the call to super.deinit

rdar://40660799