### PR TITLE
[build-script] Add build-script support for running benchmarks on Linux

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -194,6 +194,10 @@ set(BENCH_DRIVER_LIBRARY_MODULES
 # Build Configuration
 #===-----------------------------------------------------------------------===#
 
+if (SWIFT_BENCHMARK_BUILT_STANDALONE)
+  set (SWIFT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/..")
+endif()
+
 # You have to delete CMakeCache.txt in the swift build to force a
 # reconfiguration.
 set(SWIFT_EXTRA_BENCH_CONFIGS CACHE STRING

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -97,7 +97,7 @@ Using the Benchmark Driver
 ### Note
 As a shortcut, you can also refer to benchmarks by their ordinal numbers.
 The regular `--list` option does not provide these, but you can run:
-* `$ ./Benchmark_O --list --run-all | tail -n +2 | nl`
+* `$ ./Benchmark_O --list --skip-tags= | tail -n +2 | nl`
 You can use ordinal numbers instead of test names like this:
 * `$ ./Benchmark_O 1 42`
 * `$ ./Benchmark_Driver run 1 42`

--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -677,21 +677,21 @@ function(swift_benchmark_compile)
           POST_BUILD
           COMMAND
             "mv" ${platform_executables} "${swift-bin-dir}")
-
-      add_custom_target("run-${executable_target}"
-          COMMAND "${swift-bin-dir}/Benchmark_Driver" "run"
-                  "-o" "O" "--output-dir" "${CMAKE_CURRENT_BINARY_DIR}/logs"
-                  "--swift-repo" "${SWIFT_SOURCE_DIR}"
-                  "--iterations" "${SWIFT_BENCHMARK_NUM_O_ITERATIONS}"
-          COMMAND "${swift-bin-dir}/Benchmark_Driver" "run"
-                  "-o" "Onone" "--output-dir" "${CMAKE_CURRENT_BINARY_DIR}/logs"
-                  "--swift-repo" "${SWIFT_SOURCE_DIR}"
-                  "--iterations" "${SWIFT_BENCHMARK_NUM_ONONE_ITERATIONS}"
-          COMMAND "${swift-bin-dir}/Benchmark_Driver" "compare"
-                  "--log-dir" "${CMAKE_CURRENT_BINARY_DIR}/logs"
-                  "--swift-repo" "${SWIFT_SOURCE_DIR}"
-                  "--compare-script"
-                  "${SWIFT_SOURCE_DIR}/benchmark/scripts/compare_perf_tests.py")
     endif()
+
+    add_custom_target("run-${executable_target}"
+        COMMAND "${swift-bin-dir}/Benchmark_Driver" "run"
+                "-o" "O" "--output-dir" "${CMAKE_CURRENT_BINARY_DIR}/logs"
+                "--swift-repo" "${SWIFT_SOURCE_DIR}"
+                "--iterations" "${SWIFT_BENCHMARK_NUM_O_ITERATIONS}"
+        COMMAND "${swift-bin-dir}/Benchmark_Driver" "run"
+                "-o" "Onone" "--output-dir" "${CMAKE_CURRENT_BINARY_DIR}/logs"
+                "--swift-repo" "${SWIFT_SOURCE_DIR}"
+                "--iterations" "${SWIFT_BENCHMARK_NUM_ONONE_ITERATIONS}"
+        COMMAND "${swift-bin-dir}/Benchmark_Driver" "compare"
+                "--log-dir" "${CMAKE_CURRENT_BINARY_DIR}/logs"
+                "--swift-repo" "${SWIFT_SOURCE_DIR}"
+                "--compare-script"
+                "${SWIFT_SOURCE_DIR}/benchmark/scripts/compare_perf_tests.py")
   endforeach()
 endfunction()

--- a/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
+++ b/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake
@@ -678,7 +678,7 @@ function(swift_benchmark_compile)
           COMMAND
             "mv" ${platform_executables} "${swift-bin-dir}")
 
-      add_custom_target("check-${executable_target}"
+      add_custom_target("run-${executable_target}"
           COMMAND "${swift-bin-dir}/Benchmark_Driver" "run"
                   "-o" "O" "--output-dir" "${CMAKE_CURRENT_BINARY_DIR}/logs"
                   "--swift-repo" "${SWIFT_SOURCE_DIR}"

--- a/benchmark/scripts/Benchmark_Driver
+++ b/benchmark/scripts/Benchmark_Driver
@@ -18,6 +18,7 @@ import datetime
 import glob
 import json
 import os
+import platform
 import re
 import subprocess
 import sys
@@ -82,13 +83,21 @@ def submit_to_lnt(data, url):
 def instrument_test(driver_path, test, num_samples):
     """Run a test and instrument its peak memory use"""
     test_outputs = []
+    peak_memory_regex = None
+    time_flags = ['-p']
+
+    if platform.system() == "Darwin":
+        peak_memory_regex = re.compile('\s*(\d+)\s*maximum resident set size')
+        time_flags += ['-l']
     for _ in range(num_samples):
         test_output_raw = subprocess.check_output(
-            ['time', '-lp', driver_path, test],
+            ['time'] + time_flags + [driver_path, test],
             stderr=subprocess.STDOUT
         )
-        peak_memory = re.match('\s*(\d+)\s*maximum resident set size',
-                               test_output_raw.split('\n')[-15]).group(1)
+        peak_memory = "1"
+        if peak_memory_regex:
+            peak_memory_str = test_output_raw.split('\n')[-15]
+            peak_memory = peak_memory_regex.match(peak_memory_str).group(1)
         test_outputs.append(test_output_raw.split()[1].split(',') +
                             [peak_memory])
 
@@ -125,7 +134,7 @@ def get_tests(driver_path, args):
     """Return a list of available performance tests"""
     driver = ([driver_path, '--list'])
     if args.benchmarks or args.filters:
-        driver.append('--run-all')
+        driver.append('--skip-tags=')
     tests = []
     for l in subprocess.check_output(driver).split("\n")[1:]:
         m = BENCHMARK_OUTPUT_RE.match(l)

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -458,8 +458,10 @@ func runBenchmarks(_ c: TestConfig) {
 
   for t in c.tests {
     guard let results = runBench(t, c) else {
-      print("\(t.index)\(c.delim)\(t.name)\(c.delim)Unsupported")
-      fflush(stdout)
+      if c.verbose {
+        print("\(t.index)\(c.delim)\(t.name)\(c.delim)Unsupported")
+        fflush(stdout)
+      }
       continue
     }
     print("\(t.index)\(c.delim)\(t.name)\(c.delim)\(results.description)")

--- a/utils/build-script
+++ b/utils/build-script
@@ -22,6 +22,7 @@ from build_swift import defaults
 from build_swift import driver_arguments
 from build_swift import presets
 from build_swift.migration import migrate_swift_sdks
+import build_swift.postbuild_steps as postbuild_steps
 
 from swift_build_support.swift_build_support import (
     arguments,
@@ -1043,8 +1044,8 @@ def main_preset():
         return 0
 
     call_without_sleeping(build_script_args)
-    return 0
 
+    return 0
 
 # Main entry point for the normal mode.
 def main_normal():
@@ -1119,22 +1120,8 @@ def main_normal():
     # Execute the underlying build script implementation.
     invocation.execute()
 
-    if args.symbols_package:
-        print('--- Creating symbols package ---')
-        print('-- Package file: {} --'.format(args.symbols_package))
-
-        if platform.system() == 'Darwin':
-            prefix = targets.darwin_toolchain_prefix(args.install_prefix)
-        else:
-            prefix = args.install_prefix
-
-        # As a security measure, `tar` normally strips leading '/' from paths
-        # it is archiving. To stay safe, we change working directories, then
-        # run `tar` without the leading '/' (we remove it ourselves to keep
-        # `tar` from emitting a warning).
-        with shell.pushd(args.install_symroot):
-            tar.tar(source=prefix.lstrip('/'),
-                    destination=args.symbols_package)
+    # Run postbuild steps.
+    postbuild_steps.execute(invocation)
 
     return 0
 

--- a/utils/build-script
+++ b/utils/build-script
@@ -165,12 +165,13 @@ class HostSpecificConfiguration(object):
                 else:
                     self.swift_stdlib_build_targets.append(
                         "swift-test-stdlib-" + name)
+
             if build_benchmarks:
                 self.swift_benchmark_build_targets.append(
                     "swift-benchmark-" + name)
                 if args.benchmark:
                     self.swift_benchmark_run_targets.append(
-                        "check-swift-benchmark-" + name)
+                        "run-swift-benchmark-" + name)
 
             if build_external_benchmarks:
                 # Add support for the external benchmarks.
@@ -178,7 +179,8 @@ class HostSpecificConfiguration(object):
                     "swift-benchmark-{}-external".format(name))
                 if args.benchmark:
                     self.swift_benchmark_run_targets.append(
-                        "check-swift-benchmark-{}-external".format(name))
+                        "run-swift-benchmark-{}-external".format(name))
+
             if test:
                 if test_host_only:
                     suffix = "-non-executable"

--- a/utils/build-script
+++ b/utils/build-script
@@ -582,6 +582,12 @@ class BuildScriptInvocation(object):
             impl_args += [
                 "--install-symroot", os.path.abspath(args.install_symroot)
             ]
+        if args.install_destdir:
+            impl_args += [
+                "--install-destdir", os.path.abspath(args.install_destdir)
+            ]
+        if args.install_foundation:
+            impl_args += ["--install-foundation"]
 
         if args.skip_build:
             impl_args += ["--skip-build-cmark",

--- a/utils/build_swift/driver_arguments.py
+++ b/utils/build_swift/driver_arguments.py
@@ -317,6 +317,11 @@ def create_argument_parser():
                 '(like bin, lib, and include) will be installed.')
     option('--install-symroot', store_path,
            help='the path to install debug symbols into')
+    option('--install-destdir', store_path,
+           help='the root installation directory')
+    option('--install-foundation', toggle_true,
+           help='Should foundation be installed into the installation '
+                'directory')
 
     option(['-j', '--jobs'], store_int('build_jobs'),
            default=multiprocessing.cpu_count(),

--- a/utils/build_swift/postbuild_steps.py
+++ b/utils/build_swift/postbuild_steps.py
@@ -10,8 +10,18 @@
 #
 #===----------------------------------------------------------------------===#
 
+import os
+import platform
+import shutil
+
+import swift_build_support.swift_build_support.products as products
+import swift_build_support.swift_build_support.tar as tar
+import swift_build_support.swift_build_support.shell as shell
+from swift_build_support.swift_build_support.targets \
+    import StdlibDeploymentTarget
+
 def create_symbols_package(args):
-    assert(args.symbols_package)
+    assert args.symbols_package
     print('--- Creating symbols package ---')
     print('-- Package file: {} --'.format(args.symbols_package))
 
@@ -28,8 +38,78 @@ def create_symbols_package(args):
         tar.tar(source=prefix.lstrip('/'),
                 destination=args.symbols_package)
 
+def build_benchmarks_linux(invocation):
+    # Perform some sanity checking.
+    args = invocation.args
+
+    # For Linux, we need a full install root.
+    assert args.install_destdir, "Can only benchmark if we compile a dest root?!"
+    # We also need to have built and installed Foundation into the destdir.
+    assert args.install_foundation, "Must build/install foundation to do benchmarks."
+
+    install_destdir = os.path.join(args.install_destdir,
+                                   args.install_prefix.lstrip('/'))
+
+    workspace = invocation.workspace
+    llvm = products.LLVM
+    swift = products.Swift
+    host_target = StdlibDeploymentTarget.host_target().name
+
+    swift_src_dir = workspace.source_dir(swift.product_source_name())
+    benchmark_src_dir = os.path.join(swift_src_dir, 'benchmark')
+    llvm_build_dir = workspace.build_dir(host_target,
+                                         llvm.product_source_name())
+    benchmark_build_dir = workspace.build_dir(host_target, "swiftbench")
+
+    # Clean the directory. Since this is an external build, we will not get
+    # proper dependencies from swift's cmake.
+    if os.path.isdir(benchmark_build_dir):
+        shutil.rmtree(benchmark_build_dir)
+    os.makedirs(benchmark_build_dir)
+
+    cmake = invocation.toolchain.cmake
+    # We use the just built clang
+    clang = os.path.join(llvm_build_dir, 'bin', 'clang')
+
+    swift_exec = os.path.join(install_destdir, 'bin', 'swiftc')
+    swift_lib_path = os.path.join(install_destdir, 'lib', 'swift')
+    num_o_iters = args.benchmark_num_o_iterations
+    num_onone_iters = args.benchmark_num_onone_iterations
+    configureInvocation = [
+        cmake,
+        '-GNinja',
+        '-DSWIFT_EXEC={}'.format(swift_exec),
+        '-DCLANG_EXEC={}'.format(clang),
+        '-DSWIFT_LIBRARY_PATH={}'.format(swift_lib_path),
+        '-DSWIFT_BENCHMARK_NUM_O_ITERATIONS={}'.format(num_o_iters),
+        '-DSWIFT_BENCHMARK_NUM_ONONE_ITERATIONS={}'.format(num_onone_iters),
+        '{}'.format(benchmark_src_dir)
+    ]
+
+    buildInvocation = [
+        cmake, '--build', benchmark_build_dir, '--',
+        'swift-benchmark-{}'.format(host_target)
+    ]
+
+    runInvocation = [
+        cmake, '--build', benchmark_build_dir, '--',
+        'run-swift-benchmark-{}'.format(host_target)
+    ]
+
+    with shell.pushd(benchmark_build_dir):
+        shell.call(configureInvocation)
+        shell.call(buildInvocation)
+        shell.call(runInvocation)
+
 # This is the main entrypoint for post build actions.
 def execute(invocation):
     args = invocation.args
     if args.symbols_package:
         create_symbols_package(args)
+
+    # If we were asked to benchmark and we are on Linux, build the benchmark
+    # suite.
+    #
+    # TODO: Build Darwin the same way.
+    if args.benchmark and platform.system() == 'Linux':
+        build_benchmarks_linux(invocation)

--- a/utils/build_swift/postbuild_steps.py
+++ b/utils/build_swift/postbuild_steps.py
@@ -1,0 +1,35 @@
+#===--- postbuild.py -----------------------------------------------------===#
+#
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See https:#swift.org/LICENSE.txt for license information
+# See https:#swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+#
+#===----------------------------------------------------------------------===#
+
+def create_symbols_package(args):
+    assert(args.symbols_package)
+    print('--- Creating symbols package ---')
+    print('-- Package file: {} --'.format(args.symbols_package))
+
+    if platform.system() == 'Darwin':
+        prefix = targets.darwin_toolchain_prefix(args.install_prefix)
+    else:
+        prefix = args.install_prefix
+
+    # As a security measure, `tar` normally strips leading '/' from paths
+    # it is archiving. To stay safe, we change working directories, then
+    # run `tar` without the leading '/' (we remove it ourselves to keep
+    # `tar` from emitting a warning).
+    with shell.pushd(args.install_symroot):
+        tar.tar(source=prefix.lstrip('/'),
+                destination=args.symbols_package)
+
+# This is the main entrypoint for post build actions.
+def execute(invocation):
+    args = invocation.args
+    if args.symbols_package:
+        create_symbols_package(args)

--- a/utils/build_swift/tests/expected_options.py
+++ b/utils/build_swift/tests/expected_options.py
@@ -437,6 +437,7 @@ EXPECTED_OPTIONS = [
     EnableOption('--verbose-build'),
     EnableOption('--watchos'),
     EnableOption('--xctest', dest='build_xctest'),
+    EnableOption('--install-foundation'),
 
     DisableOption('--skip-build-android', dest='build_android'),
     DisableOption('--skip-build-benchmarks', dest='build_benchmarks'),
@@ -511,6 +512,7 @@ EXPECTED_OPTIONS = [
     PathOption('--host-lipo'),
     PathOption('--install-prefix'),
     PathOption('--install-symroot'),
+    PathOption('--install-destdir'),
     PathOption('--symbols-package'),
 
     IntOption('--benchmark-num-o-iterations'),


### PR DESCRIPTION
Now you can just do --benchmark on Linux. I did this relatively quickly so we can do ``@swift-ci`` benchmark jobs on Linux.