### PR TITLE
[Type checking] A declaration in an overlay can shadow an imported declaration.

### DIFF
--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -75,19 +75,37 @@ namespace {
         Options |= NameLookupFlags::IgnoreAccessControl;
     }
 
+    /// Determine whether we should filter out the results by removing
+    /// overridden and shadowed declarations.
+    /// FIXME: We should *always* do this, but there are weird assumptions
+    /// about the results of unqualified name lookup, e.g., that a local
+    /// variable not having a type indicates that it hasn't been seen yet.
+    bool shouldFilterResults() const {
+      // Member lookups always filter results.
+      if (IsMemberLookup) return true;
+
+      bool allAreInOtherModules = true;
+      auto currentModule = DC->getParentModule();
+      for (const auto &found : Result) {
+        // We found a member, so we need to filter.
+        if (found.getBaseDecl() != nullptr)
+          return true;
+
+        // We found something in our own module.
+        if (found.getValueDecl()->getDeclContext()->getParentModule() ==
+              currentModule)
+          allAreInOtherModules = false;
+      }
+
+      // FIXME: Only perform shadowing if we found things from other modules.
+      // This prevents us from introducing additional type-checking work
+      // during name lookup.
+      return allAreInOtherModules;
+    }
+
     ~LookupResultBuilder() {
-      // If any of the results have a base, we need to remove
-      // overridden and shadowed declarations.
-      // FIXME: We should *always* remove overridden and shadowed declarations,
-      // but there are weird assumptions about the results of unqualified
-      // name lookup, e.g., that a local variable not having a type indicates
-      // that it hasn't been seen yet.
-      if (!IsMemberLookup &&
-          std::find_if(Result.begin(), Result.end(),
-                       [](const LookupResultEntry &found) {
-                         return found.getBaseDecl() != nullptr;
-                       }) == Result.end())
-        return;
+      // Check whether we should do this filtering aat all.
+      if (!shouldFilterResults()) return;
 
       // Remove any overridden declarations from the found-declarations set.
       removeOverriddenDecls(FoundDecls);

--- a/test/ClangImporter/Inputs/privateframeworks/bridging-somekit.h
+++ b/test/ClangImporter/Inputs/privateframeworks/bridging-somekit.h
@@ -1,0 +1,1 @@
+#import <SomeKit/SKWidget.h>

--- a/test/ClangImporter/Inputs/privateframeworks/bridging-somekitcore.h
+++ b/test/ClangImporter/Inputs/privateframeworks/bridging-somekitcore.h
@@ -1,0 +1,1 @@
+#import <SomeKitCore/SKWidget.h>

--- a/test/ClangImporter/Inputs/privateframeworks/overlay/SomeKit.swift
+++ b/test/ClangImporter/Inputs/privateframeworks/overlay/SomeKit.swift
@@ -47,3 +47,10 @@ public func inlineWidgetOperations(_ widget: SKWidget) {
   someKitGlobalFunc()
   hao.anObject = widget
 }
+
+@available(swift, deprecated: 4.2)
+public func someKitOtherGlobalFunc() { }
+
+extension SKWidget {
+  public var name: String { return "blah" }
+}

--- a/test/ClangImporter/Inputs/privateframeworks/withoutprivate/SomeKit.framework/Headers/SKWidget.h
+++ b/test/ClangImporter/Inputs/privateframeworks/withoutprivate/SomeKit.framework/Headers/SKWidget.h
@@ -24,3 +24,8 @@ typedef enum __attribute__((ns_error_domain(SKWidgetErrorDomain))) __attribute__
 @end
 
 extern void someKitGlobalFunc(void);
+
+static inline void someKitOtherGlobalFunc(void) { }
+
+extern NSString * _Nonnull someKitGetWidgetName(SKWidget * _Nonnull)
+  __attribute__((swift_name("getter:SKWidget.name(self:)")));

--- a/test/ClangImporter/Inputs/privateframeworks/withoutprivate/SomeKit.framework/Headers/SomeKit.apinotes
+++ b/test/ClangImporter/Inputs/privateframeworks/withoutprivate/SomeKit.framework/Headers/SomeKit.apinotes
@@ -1,0 +1,10 @@
+---
+Name: SomeKit
+Functions:
+- Name: someKitOtherGlobalFunc
+  SwiftPrivate: true
+SwiftVersions:
+- Version: 4
+  Functions:
+  - Name: someKitOtherGlobalFunc
+    SwiftPrivate: false

--- a/test/ClangImporter/Inputs/privateframeworks/withprivate/SomeKit.framework/Headers/SomeKit.apinotes
+++ b/test/ClangImporter/Inputs/privateframeworks/withprivate/SomeKit.framework/Headers/SomeKit.apinotes
@@ -1,0 +1,7 @@
+---
+Name: SomeKit
+SwiftVersions:
+- Version: 4
+  Functions:
+  - Name: someKitOtherGlobalFunc
+    SwiftPrivate: false

--- a/test/ClangImporter/Inputs/privateframeworks/withprivate/SomeKitCore.framework/Headers/SKWidget.h
+++ b/test/ClangImporter/Inputs/privateframeworks/withprivate/SomeKitCore.framework/Headers/SKWidget.h
@@ -25,3 +25,8 @@ typedef enum __attribute__((ns_error_domain(SKWidgetErrorDomain))) __attribute__
 @end
 
 extern void someKitGlobalFunc(void);
+
+static inline void someKitOtherGlobalFunc(void) { }
+
+extern NSString * _Nonnull someKitGetWidgetName(SKWidget * _Nonnull)
+  __attribute__((swift_name("getter:SKWidget.name(self:)")));

--- a/test/ClangImporter/Inputs/privateframeworks/withprivate/SomeKitCore.framework/Headers/SomeKitCore.apinotes
+++ b/test/ClangImporter/Inputs/privateframeworks/withprivate/SomeKitCore.framework/Headers/SomeKitCore.apinotes
@@ -1,0 +1,10 @@
+---
+Name: SomeKitCore
+Functions:
+- Name: someKitOtherGlobalFunc
+  SwiftPrivate: true
+SwiftVersions:
+- Version: 4
+  Functions:
+  - Name: someKitOtherGlobalFunc
+    SwiftPrivate: false

--- a/test/ClangImporter/private_frameworks.swift
+++ b/test/ClangImporter/private_frameworks.swift
@@ -9,19 +9,19 @@
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -F %S/Inputs/privateframeworks/withprivate -o %t %S/Inputs/privateframeworks/overlay/SomeKit.swift
 
 // Use the overlay with private frameworks.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withprivate %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withprivate -swift-version 4 %s -import-objc-header %S/Inputs/privateframeworks/bridging-somekitcore.h -verify
 
 // Use the overlay without private frameworks.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withoutprivate -I %t %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withoutprivate -I %t -swift-version 4 -import-objc-header %S/Inputs/privateframeworks/bridging-somekit.h %s
 
 // Build the overlay with public frameworks.
 // RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-module -F %S/Inputs/privateframeworks/withoutprivate -o %t %S/Inputs/privateframeworks/overlay/SomeKit.swift
 
 // Use the overlay with private frameworks.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withprivate %s -verify
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withprivate -swift-version 4 %s -import-objc-header %S/Inputs/privateframeworks/bridging-somekitcore.h -verify
 
 // Use the overlay without private frameworks.
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withoutprivate -I %t %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk-nosource -I %t) -emit-sil -o /dev/null -F %S/Inputs/privateframeworks/withoutprivate -I %t -swift-version 4 %s -import-objc-header %S/Inputs/privateframeworks/bridging-somekit.h 
 
 // REQUIRES: objc_interop
 
@@ -36,6 +36,8 @@ func testWidget(widget: SKWidget) {
 
   widget.doSomethingElse(widget)
   inlineWidgetOperations(widget)
+
+  let _ = widget.name
 }
 
 func testError(widget: SKWidget) {
@@ -43,3 +45,8 @@ func testError(widget: SKWidget) {
   if c.isBoom { }
 }
 
+func testGlobals() {
+  someKitGlobalFunc()
+  SomeKit.someKitOtherGlobalFunc()
+  someKitOtherGlobalFunc()
+}


### PR DESCRIPTION
If a declaration provided in a Swift overlay has the same signature as
a declaration imported from the Clang module it overlays, or some
private framework that re-exports its interface through that Clang
module, the declaration provided in the Swift overlay shadows the one
imported from Clang.

To make this work for unqualified lookup, allow the shadowing rules to
kick in there as well. Make this a very narrow fix, because the
underlying problems that prevented us from doing this shadowing still
persist.

Fixes rdar://problem/35691030 and its several dupes.
