### PR TITLE
gitignore artifacts from utils/build-toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,10 @@ compile_commands.json
 SortedCFDatabase.def
 htmlcov
 .coverage
+
+#==============================================================================#
+# Ignore artifacts from ./utils/build-toolchain
+#==============================================================================#
+/swift-nightly-install/
+/swift-nightly-symroot/
+/swift-LOCAL-*.tar.gz


### PR DESCRIPTION
utils/build-toolchain puts a few things in the source directory. Could we gitignore them?
