### PR TITLE
[SIL]/[SILOpt] Thunks and specializations are never public.

### DIFF
--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -40,7 +40,12 @@ class SILProfiler;
 enum IsBare_t { IsNotBare, IsBare };
 enum IsTransparent_t { IsNotTransparent, IsTransparent };
 enum Inline_t { InlineDefault, NoInline, AlwaysInline };
-enum IsThunk_t { IsNotThunk, IsThunk, IsReabstractionThunk };
+enum IsThunk_t {
+  IsNotThunk,
+  IsThunk,
+  IsReabstractionThunk,
+  IsSignatureOptimizedThunk
+};
 
 class SILSpecializeAttr final {
   friend SILFunction;

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -229,6 +229,33 @@ private:
   /// serialization.
   bool WasDeserializedCanonical = false;
 
+  static void
+  validateSubclassScope(SubclassScope scope, IsThunk_t isThunk,
+                        const GenericSpecializationInformation *genericInfo) {
+#ifndef NDEBUG
+    // The _original_ function for a method can turn into a thunk through
+    // signature optimization, meaning it needs to retain its subclassScope, but
+    // other thunks and specializations are implementation details and so
+    // shouldn't be connected to their parent class.
+    bool thunkCanHaveSubclassScope;
+    switch (isThunk) {
+    case IsNotThunk:
+    case IsSignatureOptimizedThunk:
+      thunkCanHaveSubclassScope = true;
+      break;
+    case IsThunk:
+    case IsReabstractionThunk:
+      thunkCanHaveSubclassScope = false;
+      break;
+    }
+    auto allowsInterestingScopes = thunkCanHaveSubclassScope && !genericInfo;
+    assert(
+        allowsInterestingScopes ||
+        scope == SubclassScope::NotApplicable &&
+            "SubclassScope on specialization or non-signature-optimized thunk");
+#endif
+  }
+
   SILFunction(SILModule &module, SILLinkage linkage, StringRef mangledName,
               CanSILFunctionType loweredType, GenericEnvironment *genericEnv,
               Optional<SILLocation> loc, IsBare_t isBareSILFunction,
@@ -578,13 +605,20 @@ public:
 
   /// Get this function's thunk attribute.
   IsThunk_t isThunk() const { return IsThunk_t(Thunk); }
-  void setThunk(IsThunk_t isThunk) { Thunk = isThunk; }
+  void setThunk(IsThunk_t isThunk) {
+    validateSubclassScope(getClassSubclassScope(), isThunk, SpecializationInfo);
+    Thunk = isThunk;
+  }
 
   /// Get the class visibility (relevant for class methods).
   SubclassScope getClassSubclassScope() const {
     return SubclassScope(ClassSubclassScope);
   }
-    
+  void setClassSubclassScope(SubclassScope scope) {
+    validateSubclassScope(scope, isThunk(), SpecializationInfo);
+    ClassSubclassScope = static_cast<unsigned>(scope);
+  }
+
   /// Get this function's noinline attribute.
   Inline_t getInlineStrategy() const { return Inline_t(InlineStrategy); }
   void setInlineStrategy(Inline_t inStr) { InlineStrategy = inStr; }
@@ -660,6 +694,7 @@ public:
 
   void setSpecializationInfo(const GenericSpecializationInformation *Info) {
     assert(!isSpecialization());
+    validateSubclassScope(getClassSubclassScope(), isThunk(), Info);
     SpecializationInfo = Info;
   }
 

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -912,6 +912,8 @@ static bool parseDeclSILOptional(bool *isTransparent,
       *isCanonical = true;
     else if (isThunk && SP.P.Tok.getText() == "thunk")
       *isThunk = IsThunk;
+    else if (isThunk && SP.P.Tok.getText() == "signature_optimized_thunk")
+      *isThunk = IsSignatureOptimizedThunk;
     else if (isThunk && SP.P.Tok.getText() == "reabstraction_thunk")
       *isThunk = IsReabstractionThunk;
     else if (isGlobalInit && SP.P.Tok.getText() == "global_init")

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -771,6 +771,10 @@ SubclassScope SILDeclRef::getSubclassScope() const {
   if (context->isExtensionContext())
     return SubclassScope::NotApplicable;
 
+  // Various forms of thunks don't either.
+  if (isThunk() || isForeign)
+    return SubclassScope::NotApplicable;
+
   auto *classType = context->getAsClassOrClassExtensionContext();
   if (!classType || classType->isFinal())
     return SubclassScope::NotApplicable;

--- a/lib/SIL/SILFunction.cpp
+++ b/lib/SIL/SILFunction.cpp
@@ -102,6 +102,8 @@ SILFunction::SILFunction(SILModule &Module, SILLinkage Linkage, StringRef Name,
       HasCReferences(false), IsWeakLinked(false),
       OptMode(OptimizationMode::NotSet), EffectsKindAttr(E),
       EntryCount(entryCount) {
+  validateSubclassScope(classSubclassScope, isThunk, nullptr);
+
   if (InsertBefore)
     Module.functions.insert(SILModule::iterator(InsertBefore), this);
   else

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2326,6 +2326,9 @@ void SILFunction::print(SILPrintContext &PrintCtx) const {
   switch (isThunk()) {
   case IsNotThunk: break;
   case IsThunk: OS << "[thunk] "; break;
+  case IsSignatureOptimizedThunk:
+    OS << "[signature_optimized_thunk] ";
+    break;
   case IsReabstractionThunk: OS << "[reabstraction_thunk] "; break;
   }
 

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -529,7 +529,7 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
   }
 
   // Create the thunk body !
-  F->setThunk(IsThunk);
+  F->setThunk(IsSignatureOptimizedThunk);
   // The thunk now carries the information on how the signature is
   // optimized. If we inline the thunk, we will get the benefit of calling
   // the signature optimized function without additional setup on the

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -506,6 +506,10 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
     NewF->setUnqualifiedOwnership();
   }
 
+  if (F->isSpecialization()) {
+    NewF->setSpecializationInfo(F->getSpecializationInfo());
+  }
+
   // Then we transfer the body of F to NewF.
   NewF->spliceBody(F);
 

--- a/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
+++ b/lib/SILOptimizer/IPO/ClosureSpecializer.cpp
@@ -635,11 +635,15 @@ ClosureSpecCloner::initCloned(const CallSiteDescriptor &CallSiteDesc,
       // and not the original linkage.
       // Otherwise the new function could have an external linkage (in case the
       // original function was de-serialized) and would not be code-gen'd.
+      // It's also important to disconnect this specialized function from any
+      // classes (the classSubclassScope), because that may incorrectly
+      // influence the linkage.
       getSpecializedLinkage(ClosureUser, ClosureUser->getLinkage()), ClonedName,
       ClonedTy, ClosureUser->getGenericEnvironment(),
       ClosureUser->getLocation(), IsBare, ClosureUser->isTransparent(),
       CallSiteDesc.isSerialized(), ClosureUser->getEntryCount(),
-      ClosureUser->isThunk(), ClosureUser->getClassSubclassScope(),
+      ClosureUser->isThunk(),
+      /*classSubclassScope=*/SubclassScope::NotApplicable,
       ClosureUser->getInlineStrategy(), ClosureUser->getEffectsKind(),
       ClosureUser, ClosureUser->getDebugScope());
   if (!ClosureUser->hasQualifiedOwnership()) {

--- a/lib/SILOptimizer/Utils/Generics.cpp
+++ b/lib/SILOptimizer/Utils/Generics.cpp
@@ -1840,6 +1840,7 @@ SILFunction *GenericFuncSpecializer::tryCreateSpecialization() {
   auto *Caller = ReInfo.getApply() ? ReInfo.getApply().getFunction() : nullptr;
   SubstitutionMap Subs = Caller ? ReInfo.getApply().getSubstitutionMap()
                                 : ReInfo.getClonerParamSubstitutionMap();
+  SpecializedF->setClassSubclassScope(SubclassScope::NotApplicable);
   SpecializedF->setSpecializationInfo(
       GenericSpecializationInformation::create(Caller, GenericFunc, Subs));
   return SpecializedF;

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -286,7 +286,7 @@ namespace sil_block {
       BCRecordLayout<SIL_FUNCTION, SILLinkageField,
                      BCFixed<1>,  // transparent
                      BCFixed<2>,  // serialized
-                     BCFixed<2>,  // thunk/reabstraction_thunk
+                     BCFixed<2>,  // thunks: signature optimized/reabstraction
                      BCFixed<1>,  // global_init
                      BCFixed<2>,  // inlineStrategy
                      BCFixed<2>,  // optimizationMode

--- a/test/SILOptimizer/dead_partial_apply_arg.swift
+++ b/test/SILOptimizer/dead_partial_apply_arg.swift
@@ -8,7 +8,7 @@ extension Int32 {
 
 // This function has an unused metatype argument.
 
-// CHECK-LABEL: sil [thunk] [always_inline] @$Ss5Int32V4testE8lessthan3lhs3rhsSbAB_ABtFZ : $@convention(method) (Int32, Int32, @thin Int32.Type) -> Bool
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @$Ss5Int32V4testE8lessthan3lhs3rhsSbAB_ABtFZ : $@convention(method) (Int32, Int32, @thin Int32.Type) -> Bool
   public static func lessthan (lhs: Int32, rhs: Int32) -> Bool {
     return lhs < rhs
   }

--- a/test/SILOptimizer/deadargsignatureopt.sil
+++ b/test/SILOptimizer/deadargsignatureopt.sil
@@ -5,7 +5,7 @@ import Swift
 
 // Specialize to a function with removed dead argument.
 
-// CHECK-LABEL: sil [thunk] [always_inline] @one_arg_dead
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @one_arg_dead
 // CHECK: [[F:%[0-9]+]] = function_ref @$S12one_arg_deadTf4nnd_n
 // CHECK: [[A:%[0-9]+]] = apply [[F]](%0, %1)
 // CHECK: return [[A]]
@@ -18,7 +18,7 @@ bb0(%0 : $Int32, %1 : $Int32, %2 : $@thin Int32.Type):
   return %8 : $Bool
 }
 
-// CHECK-LABEL: sil [thunk] [always_inline] @always_inline_one_arg_dead
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @always_inline_one_arg_dead
 // CHECK: [[F:%[0-9]+]] = function_ref @$S26always_inline_one_arg_deadTf4nnd_n
 // CHECK: [[A:%[0-9]+]] = apply [[F]](%0, %1)
 // CHECK: return [[A]]
@@ -33,7 +33,7 @@ bb0(%0 : $Int32, %1 : $Int32, %2 : $@thin Int32.Type):
 
 // Still delete only one dead arg as only one arg is partially applied.
 
-// CHECK-LABEL: sil [thunk] [always_inline] @two_args_dead
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @two_args_dead
 // CHECK: [[F:%[0-9]+]] = function_ref @$S13two_args_deadTf4nnd_n
 // CHECK: [[A:%[0-9]+]] = apply [[F]](%0, %1)
 // CHECK: return [[A]]

--- a/test/SILOptimizer/funcsig_opaque.sil
+++ b/test/SILOptimizer/funcsig_opaque.sil
@@ -14,7 +14,7 @@ sil @testAggregateArgHelper : $@convention(thin) (@owned R<S>) -> ()
 
 // Test owned-to-guaranteed transformation of opaque arguments.
 //
-// CHECK-LABEL: sil [thunk] [always_inline] @testAggregateArg : $@convention(thin) (@in R<S>) -> @out () {
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @testAggregateArg : $@convention(thin) (@in R<S>) -> @out () {
 // CHECK: bb0(%0 : $R<S>):
 // CHECK:   [[F:%.*]] = function_ref @$S16testAggregateArgTf4g_n : $@convention(thin) (@in_guaranteed R<S>) -> @out ()
 // CHECK:   [[CALL:%.*]] = apply [[F]](%0) : $@convention(thin) (@in_guaranteed R<S>) -> @out ()

--- a/test/SILOptimizer/functionsigopts.sil
+++ b/test/SILOptimizer/functionsigopts.sil
@@ -79,7 +79,7 @@ bb0:
   return %4 : $()
 }
 
-// CHECK-LABEL: sil [thunk] [always_inline] @argument_with_incomplete_epilogue_release
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @argument_with_incomplete_epilogue_release
 // CHECK: [[IN2:%.*]] = struct_extract [[IN1:%.*]] : $goo, #goo.top
 // CHECK: function_ref @$S41argument_with_incomplete_epilogue_releaseTf4x_nTf4gn_n : $@convention(thin) (@guaranteed foo, @owned foo) -> ()
 // CHECK: release_value [[IN2]]
@@ -139,7 +139,7 @@ sil [serialized] @create_object : $@convention(thin) () -> Builtin.NativeObject
 // Make sure argument is exploded and the baz part is not passed in as argument, as its only use
 // is a release.
 //
-// CHECK-LABEL: sil [thunk] [always_inline] @dead_argument_due_to_only_release_user
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @dead_argument_due_to_only_release_user
 // CHECK: [[IN:%.*]] = function_ref @$S38dead_argument_due_to_only_release_userTf4gX_n
 // CHECK: [[IN2:%.*]] = struct_extract [[IN1:%.*]] : $boo, #boo.a
 // CHECK: apply [[IN]]([[IN2]])
@@ -178,7 +178,7 @@ bb0(%0 : $boo):
 
 // Make sure argument is exploded and the baz part is not passed in as argument, as its only use
 // is a release.
-// CHECK-LABEL: sil [thunk] [always_inline] @dead_argument_due_to_only_release_user_but__exploded
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @dead_argument_due_to_only_release_user_but__exploded
 // CHECK: [[FN1:%.*]] = function_ref @$S52dead_argument_due_to_only_release_user_but__explodedTf4gX_n
 // CHECK: [[IN1:%.*]] = struct_extract %0 : $lotsoffield, #lotsoffield.c
 // CHECK: [[IN2:%.*]] = struct_extract %0 : $lotsoffield, #lotsoffield.b
@@ -221,7 +221,7 @@ bb0(%0 : $lotsoffield):
 
 // Make sure argument is exploded and the baz part is not passed in as argument, as its only use
 // is a release.
-// CHECK-LABEL: sil [thunk] [always_inline] @dead_argument_due_to_more_than_release_user
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @dead_argument_due_to_more_than_release_user
 // CHECK: [[FN1:%.*]] = function_ref @$S43dead_argument_due_to_more_than_release_userTf4gX_n : $@convention(thin) (@guaranteed baz, Int) -> (Int, Int)
 sil @dead_argument_due_to_more_than_release_user : $@convention(thin) (@owned boo) -> (Int, Int) {
 bb0(%0 : $boo):
@@ -303,7 +303,7 @@ bb3:
 
 // Make sure %0 is a dead argument.
 //
-// CHECK-LABEL: sil [thunk] [always_inline] @exploded_release_to_dead_argument
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @exploded_release_to_dead_argument
 // CHECK: bb0([[INPUT_ARG0:%[0-9]+]] : $boo):
 // CHECK: [[IN1:%.*]] = function_ref @$S33exploded_release_to_dead_argumentTf4d_n
 // CHECK: apply [[IN1]]()
@@ -348,7 +348,7 @@ bb0(%0 : $boo):
 
 // Make sure %0 is not a dead argument, but gets converted to a guaranteed arg.
 //
-// CHECK-LABEL: sil [thunk] [always_inline] @exploded_release_to_guaranteed_param
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @exploded_release_to_guaranteed_param
 // CHECK: bb0([[INPUT_ARG0:%[0-9]+]] : $boo):
 // CHECK: [[IN1:%.*]] = function_ref @$S36exploded_release_to_guaranteed_paramTf4gX_n
 // CHECK: release_value [[INPUT_ARG0]]
@@ -390,7 +390,7 @@ bb0(%0 : $boo):
   return %6 : $()
 }
 
-// CHECK-LABEL: sil [thunk] [always_inline] @single_owned_return_value
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @single_owned_return_value
 // CHECK: bb0([[INPUT_ARG0:%[0-9]+]] : $boo):
 // CHECK: [[IN1:%.*]] = function_ref @$S25single_owned_return_valueTf4n_g
 // CHECK: [[IN2:%.*]] = apply [[IN1]]([[INPUT_ARG0]]
@@ -426,7 +426,7 @@ bb0(%0 : $boo):
 }
 
 
-// CHECK-LABEL: sil [thunk] [always_inline] @single_owned_return_value_with_self_recursion
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @single_owned_return_value_with_self_recursion
 // CHECK: function_ref @$S45single_owned_return_value_with_self_recursionTf4n_g
 // CHECK: [[RET:%.*]] = apply
 // CHECK: retain_value [[RET]]
@@ -468,7 +468,7 @@ bb3(%4 : $boo):
   return %4 : $boo
 }
 
-// CHECK-LABEL: sil [thunk] [always_inline] @single_owned_return_value_with_interfering_release
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @single_owned_return_value_with_interfering_release
 // CHECK: bb0([[INPUT_ARG0:%[0-9]+]] : $boo):
 // CHECK: [[IN1:%.*]] = function_ref @$S50single_owned_return_value_with_interfering_releaseTf4x_nTf4gnn_n
 // CHECK-NOT: retain_value
@@ -508,7 +508,7 @@ bb0(%0 : $boo):
 
 // Make sure we do not move the retain_value in the throw block.
 //
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] @owned_to_unowned_retval_with_error_result : $@convention(thin) (@owned boo) -> (@owned boo, @error Error) {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @owned_to_unowned_retval_with_error_result : $@convention(thin) (@owned boo) -> (@owned boo, @error Error) {
 // CHECK: function_ref @$S41owned_to_unowned_retval_with_error_resultTfq4n_g : $@convention(thin) (@owned boo) -> (boo, @error Error)
 // CHECK: bb1
 // CHECK-NOT: retain_value
@@ -550,7 +550,7 @@ bb2:
   throw undef : $Error
 }
 
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] @dead_arg_with_callsites : $@convention(thin) (Builtin.NativeObject, Builtin.NativeObject) -> () {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @dead_arg_with_callsites : $@convention(thin) (Builtin.NativeObject, Builtin.NativeObject) -> () {
 // CHECK: bb0
 // CHECK-NEXT: function_ref
 // CHECK-NEXT: function_ref @$S23dead_arg_with_callsitesTfq4dn_n : $@convention(thin) (Builtin.NativeObject) -> ()
@@ -818,7 +818,7 @@ bb0(%0 : $goo):
 //========================================
 // @owned => @guaranteed with error result
 
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] @owned_to_guaranteed_with_error_result : $@convention(thin) (@owned Builtin.NativeObject, Int) -> (Int, @error Error) {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @owned_to_guaranteed_with_error_result : $@convention(thin) (@owned Builtin.NativeObject, Int) -> (Int, @error Error) {
 // CHECK: [[FUNC_REF:%[0-9]+]] = function_ref @$S37owned_to_guaranteed_with_error_resultTfq4gn_n : $@convention(thin) (@guaranteed Builtin.NativeObject, Int)
 // CHECK: try_apply [[FUNC_REF]]({{.*}}, normal bb1, error bb2
 // CHECK: bb1([[NORMRET:%[0-9]+]] : $Int):
@@ -903,7 +903,7 @@ bb0(%0 : $Builtin.NativeObject, %1 : $Int):
 // @owned => @guaranteed
 
 // We should optimize this call.
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] @owned_to_guaranteed_simple_singlebb_callee : $@convention(thin) (@owned Builtin.NativeObject) -> () {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @owned_to_guaranteed_simple_singlebb_callee : $@convention(thin) (@owned Builtin.NativeObject) -> () {
 // CHECK: [[FUNC_REF:%[0-9]+]] = function_ref @$S42owned_to_guaranteed_simple_singlebb_calleeTfq4g_n : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
 // CHECK: apply [[FUNC_REF]]
 // CHECK-NOT: fix_lifetime
@@ -1052,7 +1052,7 @@ bb0(%0 : $Builtin.NativeObject):
 // We should be able to optimize this callee since the release is in the exit
 // BB. Additionally this test makes sure that we delete dead parameters before
 // invalidating the owned argument -> release map.
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] @owned_to_guaranteed_multibb_callee_with_release_in_exit : $@convention(thin) (Builtin.Int1, @owned Builtin.NativeObject) -> () {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @owned_to_guaranteed_multibb_callee_with_release_in_exit : $@convention(thin) (Builtin.Int1, @owned Builtin.NativeObject) -> () {
 // CHECK-NOT: fix_lifetime
 // CHECK: release_value %1 : $Builtin.NativeObject
 sil [serialized] @owned_to_guaranteed_multibb_callee_with_release_in_exit : $@convention(thin) (Builtin.Int1, @owned Builtin.NativeObject) -> () {
@@ -1135,7 +1135,7 @@ bb2:
   return %1 : $()
 }
 
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] @owned_to_guaranteed_simple_singlebb_multiple_arg_callee : $@convention(thin) (Builtin.Int1, @owned Builtin.NativeObject, Builtin.Int1) -> () {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @owned_to_guaranteed_simple_singlebb_multiple_arg_callee : $@convention(thin) (Builtin.Int1, @owned Builtin.NativeObject, Builtin.Int1) -> () {
 sil [serialized] @owned_to_guaranteed_simple_singlebb_multiple_arg_callee : $@convention(thin) (Builtin.Int1, @owned Builtin.NativeObject, Builtin.Int1) -> () {
 bb0(%0 : $Builtin.Int1, %1 : $Builtin.NativeObject, %2 : $Builtin.Int1):
   // make it a non-trivial function
@@ -1186,7 +1186,7 @@ bb3:
   return %3 : $()
 }
 
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] @owned_to_guaranteed_multibb_callee_with_release_in_exit_two_args_1 : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @owned_to_guaranteed_multibb_callee_with_release_in_exit_two_args_1 : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
 // CHECK: bb0([[INPUT_PTR1:%.*]] : $Builtin.NativeObject, [[INPUT_PTR2:%.*]] : $Builtin.NativeObject):
 // CHECK: release_value [[INPUT_PTR2]] : $Builtin.NativeObject
 // CHECK: release_value [[INPUT_PTR1]] : $Builtin.NativeObject
@@ -1231,7 +1231,7 @@ bb2:
   return %2 : $()
 }
 
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] @owned_to_guaranteed_multibb_callee_with_release_in_exit_two_args_2 : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @owned_to_guaranteed_multibb_callee_with_release_in_exit_two_args_2 : $@convention(thin) (@owned Builtin.NativeObject, @owned Builtin.NativeObject) -> () {
 // CHECK: bb0([[INPUT_PTR1:%.*]] : $Builtin.NativeObject, [[INPUT_PTR2:%.*]] : $Builtin.NativeObject):
 // CHECK: release_value [[INPUT_PTR2]] : $Builtin.NativeObject
 // CHECK: release_value [[INPUT_PTR1]] : $Builtin.NativeObject
@@ -1378,7 +1378,7 @@ bb0(%0 : $foo):
 
 // We should remove the array semantic from specialized calls.
 
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] [_semantics "array.foobar"] @array_semantic : $@convention(method) (@owned Builtin.NativeObject) -> () {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] [_semantics "array.foobar"] @array_semantic : $@convention(method) (@owned Builtin.NativeObject) -> () {
 // CHECK: [[FUNC_REF:%[0-9]+]] = function_ref @$S14array_semanticTfq4g_n : $@convention(thin) (@guaranteed Builtin.NativeObject) -> ()
 // CHECK: apply [[FUNC_REF]]
 // CHECK: release_value
@@ -1444,7 +1444,7 @@ bb0(%0 : $Builtin.Int32):
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] @s2 : $@convention(thin) (Builtin.Int32) -> () {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @s2 : $@convention(thin) (Builtin.Int32) -> () {
 sil [serialized] @s2 : $@convention(thin) (Builtin.Int32) -> () {
 bb0(%0 : $Builtin.Int32):
   // make it a non-trivial function
@@ -1481,7 +1481,7 @@ bb0(%0 : $Builtin.Int32):
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] @s1 : $@convention(thin) (Builtin.Int32) -> () {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @s1 : $@convention(thin) (Builtin.Int32) -> () {
 sil [serialized] @s1 : $@convention(thin) (Builtin.Int32) -> () {
 bb0(%0 : $Builtin.Int32):
   // make it a non-trivial function
@@ -1512,13 +1512,13 @@ bb0(%0 : $Builtin.Int32):
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil hidden [thunk] [always_inline] @generic_owned_to_guaranteed : $@convention(thin) <T where T : KlassFoo> (@owned T) -> Int64
+// CHECK-LABEL: sil hidden [signature_optimized_thunk] [always_inline] @generic_owned_to_guaranteed : $@convention(thin) <T where T : KlassFoo> (@owned T) -> Int64
 // CHECK: function_ref @$S27generic_owned_to_guaranteedTf4g_n 
 // CHECK: apply
 // CHECK: release_value
 // CHECK: end sil function 'generic_owned_to_guaranteed'
 
-// CHECK-LABEL: sil [thunk] [always_inline] @generic_owned_to_guaranteed_caller : $@convention(thin) <T where T : KlassFoo> (@owned T) -> Int64 
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @generic_owned_to_guaranteed_caller : $@convention(thin) <T where T : KlassFoo> (@owned T) -> Int64
 // CHECK: function_ref @$S34generic_owned_to_guaranteed_callerTf4g_n 
 // CHECK: apply
 // CHECK: release_value
@@ -1552,13 +1552,13 @@ bb0(%0 : $T):
   return %15 : $Int64
 }
 
-// CHECK-LABEL: sil hidden [thunk] [always_inline] @generic_in_to_guaranteed : $@convention(thin) <T where T : P> (@in T) -> Int64
+// CHECK-LABEL: sil hidden [signature_optimized_thunk] [always_inline] @generic_in_to_guaranteed : $@convention(thin) <T where T : P> (@in T) -> Int64
 // CHECK: function_ref @$S24generic_in_to_guaranteedTf4g_n 
 // CHECK: apply
 // CHECK: destroy_addr
 // CHECK: end sil function 'generic_in_to_guaranteed'
 
-// CHECK-LABEL: sil [thunk] [always_inline] @generic_in_to_guaranteed_caller : $@convention(thin) <T where T : P> (@in T) -> Int64 
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @generic_in_to_guaranteed_caller : $@convention(thin) <T where T : P> (@in T) -> Int64
 // CHECK: function_ref @$S31generic_in_to_guaranteed_callerTf4g_n 
 // CHECK: apply
 // CHECK: destroy_addr
@@ -1591,7 +1591,7 @@ bb0(%0 : $*T):
   return %15 : $Int64
 }
 
-// CHECK-LABEL: sil [thunk] [always_inline] @generic_func_with_dead_non_generic_arg : $@convention(thin) <T> (@owned foo, @in T) -> ()
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @generic_func_with_dead_non_generic_arg : $@convention(thin) <T> (@owned foo, @in T) -> ()
 // CHECK: function_ref @$S027generic_func_with_dead_non_A4_argTf4dd_n : $@convention(thin) () -> ()
 // Call the specialization which is not polymorphic.
 // CHECK: apply
@@ -1604,7 +1604,7 @@ bb0(%0 : $foo, %1 : $*T):
   return %r : $()
 }
 
-// CHECK-LABEL: sil [thunk] [always_inline] @generic_func_with_dead_generic_arg : $@convention(thin) <T> (Int64, @in T) -> Int64
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @generic_func_with_dead_generic_arg : $@convention(thin) <T> (Int64, @in T) -> Int64
 // CHECK: function_ref @$S023generic_func_with_dead_A4_argTf4nd_n : $@convention(thin) (Int64) -> Int64 
 // Call the specialization which is not polymorphic.
 // CHECK: apply
@@ -1616,7 +1616,7 @@ bb0(%0 : $Int64, %1 : $*T):
   return %0 : $Int64
 }
 
-// CHECK-LABEL: sil [thunk] [always_inline] @generic_func_with_unused_generic_param_and_non_generic_arg : $@convention(thin) <T> (Int64) -> Int64 
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @generic_func_with_unused_generic_param_and_non_generic_arg : $@convention(thin) <T> (Int64) -> Int64
 // CHECK: function_ref @$S025generic_func_with_unused_a15_param_and_non_A4_argTf4n_n : $@convention(thin) (Int64) -> Int64 
 // Call the specialization which is not polymorphic.
 // CHECK: apply
@@ -1633,7 +1633,7 @@ bb0(%0 : $Int64):
   return %r : $Int64
 }
 
-// CHECK-LABEL: sil [thunk] [always_inline] @generic_func_with_unused_generic_param_and_dead_non_generic_arg : $@convention(thin) <T> (Int64, Int64) -> Int64
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @generic_func_with_unused_generic_param_and_dead_non_generic_arg : $@convention(thin) <T> (Int64, Int64) -> Int64
 // CHECK: function_ref @$S025generic_func_with_unused_a20_param_and_dead_non_A4_argTf4nd_n : $@convention(thin) (Int64) -> Int64 
 // Call the specialization which is not polymorphic.
 // CHECK: apply
@@ -1650,7 +1650,7 @@ bb0(%0 : $Int64):
   return %r : $Int64
 }
 
-// CHECK-LABEL: sil [thunk] [always_inline] @generic_func_with_unused_generic_param_and_dead_generic_arg : $@convention(thin) <T> (@in_guaranteed T) -> ()
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @generic_func_with_unused_generic_param_and_dead_generic_arg : $@convention(thin) <T> (@in_guaranteed T) -> ()
 // CHECK: function_ref @$S025generic_func_with_unused_a16_param_and_dead_A4_argTf4d_n : $@convention(thin) () -> ()
 // Call the specialization which is not polymorphic.
 // CHECK: apply
@@ -1669,7 +1669,7 @@ bb0(%0 : $*T):
   return %r : $()
 }
 
-// CHECK-LABEL: sil [thunk] [always_inline] @generic_func_with_unused_generic_param_and_dead_owned_generic_arg : $@convention(thin) <T where T : KlassFoo> (@owned T) -> ()
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @generic_func_with_unused_generic_param_and_dead_owned_generic_arg : $@convention(thin) <T where T : KlassFoo> (@owned T) -> ()
 // CHECK: function_ref @$S025generic_func_with_unused_a22_param_and_dead_owned_A4_argTf4d_n : $@convention(thin) () -> ()
 // Call the specialization which is not polymorphic.
 // CHECK: apply
@@ -1690,7 +1690,7 @@ bb0(%0 : $T):
   return %r : $()
 }
 
-// CHECK-LABEL: sil [thunk] [always_inline] @generic_func_with_multple_generic_args_and_dead_generic_arg : $@convention(thin) <T, S> (@in T, @in S) -> ()
+// CHECK-LABEL: sil [signature_optimized_thunk] [always_inline] @generic_func_with_multple_generic_args_and_dead_generic_arg : $@convention(thin) <T, S> (@in T, @in S) -> ()
 // CHECK: function_ref @$S026generic_func_with_multple_a15_args_and_dead_A4_argTf4nd_n : $@convention(thin) <τ_0_0, τ_0_1> (@in τ_0_0) -> ()
 // Call the specialization which has only one function argument, because another one is dead
 // and was eliminated.

--- a/test/SILOptimizer/functionsigopts_sroa.sil
+++ b/test/SILOptimizer/functionsigopts_sroa.sil
@@ -136,7 +136,7 @@ struct SingleFieldLvl3 {
 
 /// This checks the case where we have a single level hierarchy and the root is
 /// dead.
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] @single_level_dead_root_callee : $@convention(thin) (S1) -> Builtin.Int32 {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @single_level_dead_root_callee : $@convention(thin) (S1) -> Builtin.Int32 {
 // CHECK: bb0([[INPUT:%[0-9]+]] : $S1):
 // CHECK: [[FN:%[0-9]+]] = function_ref @$S29single_level_dead_root_calleeTfq4x_n : $@convention(thin) (Builtin.Int32) -> Builtin.Int32
 // CHECK: [[ARG:%.*]] = struct_extract [[INPUT]] : $S1, #S1.f2
@@ -182,7 +182,7 @@ bb0(%0 : $S1):
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] @single_level_live_root_callee : $@convention(thin) (S1) -> Builtin.Int32 {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @single_level_live_root_callee : $@convention(thin) (S1) -> Builtin.Int32 {
 // CHECK: bb0([[INPUT:%[0-9]+]] : $S1):
 // CHECK: [[FN:%[0-9]+]] = function_ref @$S29single_level_live_root_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> Builtin.Int32
 // CHECK: [[ARG2:%.*]] = struct_extract [[INPUT]] : $S1, #S1.f2
@@ -234,7 +234,7 @@ bb0(%0 : $S1):
 // This test checks where we have a multiple level hierarchy, the root is dead,
 // but the root has all fields used. This means that we should extract
 // everything, but we should not "reform" the aggregate.
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] @multiple_level_all_root_fields_used_callee : $@convention(thin) (S2) -> (Builtin.Int16, Builtin.Int64) {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @multiple_level_all_root_fields_used_callee : $@convention(thin) (S2) -> (Builtin.Int16, Builtin.Int64) {
 // CHECK: bb0([[INPUT:%.*]] : $S2):
 // CHECK: [[FN:%.*]] = function_ref @$S42multiple_level_all_root_fields_used_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64)
 // CHECK: [[EXT1:%.*]] = struct_extract [[INPUT]] : $S2, #S2.f2
@@ -292,7 +292,7 @@ bb0(%0 : $S2):
 }
 
 /// This test checks a multiple level hierarchy where the root has no fields used.
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] @multiple_level_no_root_fields_have_direct_uses_callee : $@convention(thin) (S3) -> (Builtin.Int16, Builtin.Int64) {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @multiple_level_no_root_fields_have_direct_uses_callee : $@convention(thin) (S3) -> (Builtin.Int16, Builtin.Int64) {
 // CHECK: bb0([[IN:%.*]] : $S3):
 // CHECK: [[FN:%.*]] = function_ref @$S53multiple_level_no_root_fields_have_direct_uses_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64)
 // CHECK: [[EXT1:%.*]] = struct_extract [[IN]] : $S3, #S3.f2
@@ -355,7 +355,7 @@ bb0(%0 : $S3):
 
 // This test checks a multiple level hierarchy where the root has its own use
 // and needs to be reformed via a struct.
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] @multiple_level_root_must_be_reformed_callee : $@convention(thin) (S2) -> (Builtin.Int16, Builtin.Int64) {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @multiple_level_root_must_be_reformed_callee : $@convention(thin) (S2) -> (Builtin.Int16, Builtin.Int64) {
 // CHECK: bb0([[IN:%.*]] : $S2):
 // CHECK: [[FN:%.*]] = function_ref @$S43multiple_level_root_must_be_reformed_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int32, Builtin.Int64) -> (Builtin.Int16, Builtin.Int64)
 // CHECK: [[EXT1:%.*]] = struct_extract [[IN]] : $S2, #S2.f2
@@ -439,7 +439,7 @@ bb0(%0 : $S2):
 }
 
 // This test checks if we can handle @owned structs correctly
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] @owned_struct_1_callee : $@convention(thin) (@owned S5, @owned S5) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32) {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @owned_struct_1_callee : $@convention(thin) (@owned S5, @owned S5) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32) {
 // CHECK: bb0([[IN1:%.*]] : $S5, [[IN2:%.*]] : $S5):
 // CHECK: [[FN:%.*]] = function_ref @$S21owned_struct_1_calleeTfq4dgX_n : $@convention(thin) (@guaranteed S4, Builtin.Int16, Builtin.Int32) -> (Builtin.Int16, Builtin.Int32, Builtin.Int16, Builtin.Int32)
 // CHECK: [[EXT1:%.*]] = struct_extract [[IN2]] : $S5, #S5.f2
@@ -505,7 +505,7 @@ bb0(%0 : $S5):
 }
 
 // This test checks if we can properly insert arguments in between dead arguments.
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] @owned_struct_2_callee : $@convention(thin) (Builtin.Int256, Builtin.Int256, @owned S5, Builtin.Int128, Builtin.Int128) -> (Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128) {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @owned_struct_2_callee : $@convention(thin) (Builtin.Int256, Builtin.Int256, @owned S5, Builtin.Int128, Builtin.Int128) -> (Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128) {
 // CHECK: bb0([[IN1:%.*]] : $Builtin.Int256, [[IN2:%.*]] : $Builtin.Int256, [[IN3:%.*]] : $S5, [[IN4:%.*]] : $Builtin.Int128, [[IN5:%.*]] : $Builtin.Int128):
 // CHECK: [[FN:%.*]] = function_ref @$S21owned_struct_2_calleeTfq4ndgXdn_n : $@convention(thin) (Builtin.Int256, @guaranteed S4, Builtin.Int16, Builtin.Int32, Builtin.Int128) -> (Builtin.Int256, Builtin.Int16, Builtin.Int32, Builtin.Int128)
 // CHECK: [[EXT1:%.*]] = struct_extract [[IN3]] : $S5, #S5.f2
@@ -567,7 +567,7 @@ bb0(%0 : $Builtin.Int256, %1 : $S5, %2 : $Builtin.Int128):
 }
 
 /// This test makes sure that we ignore pointer arguments for now.
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] @ignore_ptrs_callee : $@convention(thin) (@in S1, S1, S1) -> (Builtin.Int16, Builtin.Int16) {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @ignore_ptrs_callee : $@convention(thin) (@in S1, S1, S1) -> (Builtin.Int16, Builtin.Int16) {
 // CHECK: bb0([[IN1:%.*]] : $*S1, [[IN2:%.*]] : $S1, [[IN3:%.*]] : $S1):
 // CHECK: [[FN:%.*]] = function_ref @$S18ignore_ptrs_calleeTfq4nxx_n : $@convention(thin) (@in S1, Builtin.Int16, Builtin.Int16) -> (Builtin.Int16, Builtin.Int16)
 // CHECK: [[EXT1:%.*]] = struct_extract [[IN2]] : $S1, #S1.f1
@@ -677,7 +677,7 @@ bb0(%0 : $FakeStaticString, %1 : $FakeString, %2 : $FakeStaticString):
 // This test makes sure that we handle cases where the callee has field uses
 // that are processed in a different order than the fields are layed out in the
 // structure.
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] @check_out_of_order_uses_callee : $@convention(thin) (S1) -> () {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @check_out_of_order_uses_callee : $@convention(thin) (S1) -> () {
 // CHECK: bb0([[IN:%.*]] : $S1):
 // CHECK: [[FN:%.*]] = function_ref @$S30check_out_of_order_uses_calleeTfq4x_n : $@convention(thin) (Builtin.Int16, Builtin.Int32) -> ()
 // CHECK: [[EXT1:%.*]] = struct_extract [[IN]] : $S1, #S1.f2
@@ -735,7 +735,7 @@ bb0(%0 : $S1):
 }
 
 // Make sure that we do not SROA classes.
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] @class_callee_1 : $@convention(thin) (@owned C1, Builtin.Int32) -> Builtin.Int32 {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @class_callee_1 : $@convention(thin) (@owned C1, Builtin.Int32) -> Builtin.Int32 {
 // CHECK: bb0([[IN1:%.*]] : $C1, [[IN2:%.*]] : $Builtin.Int32):
 // CHECK: [[FN:%.*]] = function_ref @$S14class_callee_1Tfq4gn_n : $@convention(thin) (@guaranteed C1, Builtin.Int32) -> Builtin.Int32
 // CHECK: apply [[FN]]([[IN1]], [[IN2]]) : $@convention(thin) (@guaranteed C1, Builtin.Int32) -> Builtin.Int32
@@ -774,7 +774,7 @@ bb0(%0 : $C1, %1 : $Builtin.Int32):
   return %1 : $Builtin.Int32
 }
 
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] @class_caller_1 : $@convention(thin) (@owned C1, Builtin.Int32) -> Builtin.Int32 {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @class_caller_1 : $@convention(thin) (@owned C1, Builtin.Int32) -> Builtin.Int32 {
 // CHECK: bb0([[IN1:%.*]] : $C1, [[IN2:%.*]] : $Builtin.Int32):
 // CHECK: [[FN:%.*]] = function_ref @$S14class_callee_1Tfq4gn_n : $@convention(thin) (@guaranteed C1, Builtin.Int32) -> Builtin.Int32
 // CHECK: apply [[FN]]([[IN1]], [[IN2]]) : $@convention(thin) (@guaranteed C1, Builtin.Int32) -> Builtin.Int32
@@ -856,7 +856,7 @@ bb0(%0 : $ThirtySixFieldStruct):
   return %9999 : $()
 }
 
-// CHECK-LABEL: sil [serialized] [thunk] [always_inline] @more_than_32_type_sized_callee : $@convention(thin) (ThirtySixFieldStruct) -> Builtin.Int32 {
+// CHECK-LABEL: sil [serialized] [signature_optimized_thunk] [always_inline] @more_than_32_type_sized_callee : $@convention(thin) (ThirtySixFieldStruct) -> Builtin.Int32 {
 sil [serialized] @more_than_32_type_sized_callee : $@convention(thin) (ThirtySixFieldStruct) -> Builtin.Int32 {
 bb0(%0 : $ThirtySixFieldStruct):
   // make it a non-trivial function

--- a/test/TBD/class_objc.swift.gyb
+++ b/test/TBD/class_objc.swift.gyb
@@ -1,9 +1,9 @@
 // RUN: %empty-directory(%t)
 // RUN: %gyb %s > %t/main.swift
 
-// RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -import-objc-header %S/Inputs/objc_class_header.h -validate-tbd-against-ir=all %t/main.swift -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -import-objc-header %S/Inputs/objc_class_header.h -validate-tbd-against-ir=missing %t/main.swift -disable-objc-attr-requires-foundation-module
 
-// RUN: %target-swift-frontend -enable-resilience -emit-ir -o- -parse-as-library -module-name test -import-objc-header %S/Inputs/objc_class_header.h -validate-tbd-against-ir=all %t/main.swift -disable-objc-attr-requires-foundation-module
+// RUN: %target-swift-frontend -enable-resilience -emit-ir -o- -parse-as-library -module-name test -import-objc-header %S/Inputs/objc_class_header.h -validate-tbd-against-ir=missing %t/main.swift -disable-objc-attr-requires-foundation-module
 
 // With -enable-testing:
 
@@ -15,29 +15,56 @@
 
 import Foundation
 
-% names = ["Public", "Internal", "Private"]
+
+%{
+names = ["Open", "Public", "Internal", "Private"]
+
+METHODS = "{access} {override} func method{name}() {{}}"
+OBJC_METHOD = "@objc {access} {override} func method{name}ObjC() {{}}"
+def classBody(i, override=False):
+    methods = []
+    for name in names[i:]:
+        is_private = name == "Private"
+        args = {"access": name.lower(), "name": name,
+                "override": "override" if override and not is_private else ""}
+        methods.append(METHODS.format(**args))
+        if not is_private:
+            methods.append(OBJC_METHOD.format(**args))
+
+    return "\n".join(methods)
+}%
 
 % for i, name in enumerate(names):
 % access = name.lower()
 
 // a class by itself
-${access} class ${name}Empty: NSObject {}
+${access} class ${name}Empty: NSObject {
+${classBody(i)}
+}
 
 // subclasses of that
 % for subname in names[i:]:
 % subaccess = subname.lower()
-${subaccess} class ${subname}Sub${name}Empty: ${name}Empty {}
+${subaccess} class ${subname}Sub${name}Empty: ${name}Empty {
+${classBody(i, override=True)}
+}
 %end
 
-${access} class ${name}InheritObjCProtocol: NSObject, ObjCProtocol {}
+${access} class ${name}InheritObjCProtocol: NSObject, ObjCProtocol {
+${classBody(i)}
+}
 
 // some bugs were revealed when there's @objc without inheriting from
 // NSObject.
-@objc ${access} class ${name}ObjCOnly {}
+@objc ${access} class ${name}ObjCOnly {
+${classBody(i)}
+}
 
 %end
 
 @usableFromInline
 @objc
-internal class InternalObjCOnlyUsableFromInline {}
+internal class InternalObjCOnlyUsableFromInline {
+${classBody(names.index("Internal"))}
+}
 

--- a/test/TBD/specialization.swift
+++ b/test/TBD/specialization.swift
@@ -1,0 +1,35 @@
+// Validate the the specializations actually exist (if they don't then we're not
+// validating that they end up with the correct linkages):
+// RUN: %target-swift-frontend -emit-sil -o- -O -validate-tbd-against-ir=none %s | %FileCheck %s
+
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -O -validate-tbd-against-ir=all %s
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -O -validate-tbd-against-ir=all -enable-resilience %s
+
+// With -enable-testing:
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -O -validate-tbd-against-ir=all -enable-testing %s
+// RUN: %target-swift-frontend -emit-ir -o/dev/null -O -validate-tbd-against-ir=all -enable-resilience -enable-testing %s
+
+// rdar://problem/40738913
+
+open class Foo {
+    @inline(never)
+    fileprivate func foo<T>(_: T.Type) {}
+}
+
+open class Bar<T> {
+    @inline(never)
+    fileprivate func bar() {}
+}
+
+
+public func f() {
+    Foo().foo(Int.self)
+    Bar<Int>().bar()
+}
+
+
+// CHECK-LABEL: // specialized Foo.foo<A>(_:)
+// CHECK-NEXT: sil private [noinline] @$S14specialization3FooC3foo33_A6E3E43DB6679655BDF5A878ABC489A0LLyyxmlFSi_Tg5Tf4dd_n : $@convention(thin) () -> ()
+
+// CHECK-LABEL: // specialized Bar.bar()
+// CHECK-NEXT: sil private [noinline] @$S14specialization3BarC3bar33_A6E3E43DB6679655BDF5A878ABC489A0LLyyFSi_Tg5Tf4d_n : $@convention(thin) () -> ()


### PR DESCRIPTION
The current behaviour of (some) open classes means private members are
forced to be public, but this only applies to the real members, not
thunks or specializations associated with them.

Fixes rdar://problem/40738913.

