### PR TITLE
[SR-953] Implement Bundle(for: class): Expose SPI to get type descriptor.

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -4377,6 +4377,14 @@ void swift_getFieldAt(
 void verifyMangledNameRoundtrip(const Metadata *metadata);
 #endif
 
+#if !SWIFT_OBJC_INTEROP
+
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_SPI // SPI for swift-corelibs-foundation
+ConstTargetMetadataPointer<swift::InProcess, TargetTypeContextDescriptor>
+_swift_getTypeContextDescriptor(const Metadata *type);
+
+#endif // !SWIFT_OBJC_INTEROP
+
 } // end namespace swift
 
 #pragma clang diagnostic pop

--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -4379,9 +4379,8 @@ void verifyMangledNameRoundtrip(const Metadata *metadata);
 
 #if !SWIFT_OBJC_INTEROP
 
-SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_SPI // SPI for swift-corelibs-foundation
-ConstTargetMetadataPointer<swift::InProcess, TargetTypeContextDescriptor>
-_swift_getTypeContextDescriptor(const Metadata *type);
+SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
+const TypeContextDescriptor *swift_getTypeContextDescriptor(const Metadata *type);
 
 #endif // !SWIFT_OBJC_INTEROP
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3940,3 +3940,13 @@ void swift::verifyMangledNameRoundtrip(const Metadata *metadata) {
                    metadata, mangledName.c_str(), (const Metadata *)result);
 }
 #endif
+
+#if !SWIFT_OBJC_INTEROP
+
+// SPI for swift-corelibs-foundation
+ConstTargetMetadataPointer<swift::InProcess, TargetTypeContextDescriptor>
+swift::_swift_getTypeContextDescriptor(const Metadata *type) {
+    return type->getTypeContextDescriptor();
+}
+
+#endif // !SWIFT_OBJC_INTEROP

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3943,9 +3943,7 @@ void swift::verifyMangledNameRoundtrip(const Metadata *metadata) {
 
 #if !SWIFT_OBJC_INTEROP
 
-// SPI for swift-corelibs-foundation
-ConstTargetMetadataPointer<swift::InProcess, TargetTypeContextDescriptor>
-swift::_swift_getTypeContextDescriptor(const Metadata *type) {
+const TypeContextDescriptor *swift::swift_getTypeContextDescriptor(const Metadata *type) {
     return type->getTypeContextDescriptor();
 }
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
Per discussion with @jckarter — we would like to have a way, given a class, to get a symbol that originates in the same image (library/shared object/executable etc.) so we can implement `Bundle(for class: AnyClass)` in terms of `dladdr()`. The type descriptor apparently satisfies this condition for all classes that were compiled AOT.

This exposes a C SPI for swift-corelibs-foundation use to obtain the type descriptor given a type.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-953](https://bugs.swift.org/browse/SR-953) alongside the patch at https://github.com/apple/swift-corelibs-foundation/pull/1573.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->