### PR TITLE
Better error message for 'class func/var' usage in protocols

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -66,10 +66,10 @@ ERROR(super_not_in_class_method,none,
 
 ERROR(class_func_not_in_class,none,
       "class methods are only allowed within classes; "
-      "use 'static' to declare a static method", ())
+      "use 'static' to declare a%select{| requirement fulfilled by either a class or}0 static method", (bool))
 ERROR(class_var_not_in_class,none,
       "class properties are only allowed within classes; "
-      "use 'static' to declare a static property", ())
+      "use 'static' to declare a%select{| requirement fulfilled by either a class or}0 static property", (bool))
 
 // FIXME: Used by both the parser and the type-checker.
 ERROR(func_decl_without_brace,PointsToFirstBadToken,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4808,7 +4808,8 @@ Parser::parseDeclVar(ParseDeclOptions Flags,
     } else if (Flags.contains(PD_InStruct) || Flags.contains(PD_InEnum) ||
                Flags.contains(PD_InProtocol)) {
       if (StaticSpelling == StaticSpellingKind::KeywordClass)
-        diagnose(Tok, diag::class_var_not_in_class)
+        diagnose(Tok, diag::class_var_not_in_class, 
+                 Flags.contains(PD_InProtocol))
             .fixItReplace(StaticLoc, "static");
     }
   }
@@ -5194,7 +5195,8 @@ Parser::parseDeclFunc(SourceLoc StaticLoc, StaticSpellingKind StaticSpelling,
     } else if (Flags.contains(PD_InStruct) || Flags.contains(PD_InEnum) ||
                Flags.contains(PD_InProtocol)) {
       if (StaticSpelling == StaticSpellingKind::KeywordClass) {
-        diagnose(Tok, diag::class_func_not_in_class)
+        diagnose(Tok, diag::class_func_not_in_class,
+                 Flags.contains(PD_InProtocol))
             .fixItReplace(StaticLoc, "static");
 
         StaticSpelling = StaticSpellingKind::KeywordStatic;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1134,7 +1134,7 @@ static void validatePatternBindingEntry(TypeChecker &tc,
         ->getAsNominalTypeOrNominalTypeExtensionContext()) {
       if (!isa<ClassDecl>(NTD)) {
         if (StaticSpelling == StaticSpellingKind::KeywordClass) {
-          tc.diagnose(binding, diag::class_var_not_in_class)
+          tc.diagnose(binding, diag::class_var_not_in_class, false)
             .fixItReplace(binding->getStaticLoc(), "static");
           tc.diagnose(NTD, diag::extended_type_declared_here);
         }
@@ -7194,7 +7194,7 @@ void TypeChecker::validateDecl(ValueDecl *D) {
               ->getAsNominalTypeOrNominalTypeExtensionContext()) {
         if (!isa<ClassDecl>(NTD)) {
           if (StaticSpelling == StaticSpellingKind::KeywordClass) {
-            diagnose(FD, diag::class_func_not_in_class)
+            diagnose(FD, diag::class_func_not_in_class, false)
                 .fixItReplace(FD->getStaticLoc(), "static");
             diagnose(NTD, diag::extended_type_declared_here);
           }

--- a/test/decl/func/static_func.swift
+++ b/test/decl/func/static_func.swift
@@ -105,10 +105,15 @@ extension C_Derived {
   class override func ef5() {} // expected-error {{not supported}}
 }
 
-protocol P {
+protocol P { // expected-note{{extended type declared here}}
   static func f1()
   static func f2()
   static func f3() {} // expected-error {{protocol methods must not have bodies}}
   static final func f4() // expected-error {{only classes and class members may be marked with 'final'}}
+  class func f5() // expected-error {{class methods are only allowed within classes; use 'static' to declare a requirement fulfilled by either a class or static method}} {{3-8=static}}
+}
+
+extension P {
+  class func f6() {} // expected-error {{class methods are only allowed within classes; use 'static' to declare a static method}} {{3-8=static}}
 }
 

--- a/test/decl/var/static_var.swift
+++ b/test/decl/var/static_var.swift
@@ -171,14 +171,18 @@ extension C {
   static final let el4: Int = 0 // expected-error {{static declarations are already final}} {{10-16=}}
 }
 
-protocol P {  // expected-note{{did you mean 'P'?}}
+protocol P {  // expected-note{{did you mean 'P'?}} expected-note{{extended type declared here}}
   // Both `static` and `class` property requirements are equivalent in protocols rdar://problem/17198298
   static var v1: Int { get }
-  class var v2: Int { get } // expected-error {{class properties are only allowed within classes; use 'static' to declare a static property}} {{3-8=static}}
+  class var v2: Int { get } // expected-error {{class properties are only allowed within classes; use 'static' to declare a requirement fulfilled by either a class or static property}} {{3-8=static}}
   static final var v3: Int { get } // expected-error {{only classes and class members may be marked with 'final'}}
 
   static let l1: Int // expected-error {{immutable property requirement must be declared as 'var' with a '{ get }' specifier}}
-  class let l2: Int // expected-error {{class properties are only allowed within classes; use 'static' to declare a static property}} {{3-8=static}} expected-error {{immutable property requirement must be declared as 'var' with a '{ get }' specifier}}
+  class let l2: Int // expected-error {{class properties are only allowed within classes; use 'static' to declare a requirement fulfilled by either a class or static property}} {{3-8=static}} expected-error {{immutable property requirement must be declared as 'var' with a '{ get }' specifier}}
+}
+
+extension P {
+  class var v4: Int { return 0 } // expected-error {{class properties are only allowed within classes; use 'static' to declare a static property}} {{3-8=static}}
 }
 
 struct S1 {


### PR DESCRIPTION
<!-- What's in this pull request? -->
Clarify how to use protocols in relation to class funcs. This has been discussed in https://forums.swift.org/t/class-constrained-protocols-dont-allow-for-class-methods/13031

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
