### PR TITLE
[GSB][SE][WIP] Reconsider typealias usage in protocols and prot ext

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1850,6 +1850,22 @@ WARNING(typealias_override_associated_type,none,
 WARNING(associated_type_override_typealias,none,
         "associated type %0 is redundant with type %0 declared in inherited "
         "%1 %2", (DeclName, DescriptiveDeclKind, Type))
+WARNING(swift4_typealias_in_protocol_warn,none,
+        "typealias should not be declared within a protocol; "
+        "move to an extension or use 'associatedtype' to define an associated "
+        "type requirement", ())
+ERROR(swift5_typealias_in_protocol_error,none,
+      "typealias must not be declared within a protocol; "
+      "move to an extension or use 'associatedtype' to define an associated "
+      "type requirement", ())
+ERROR(swift5_typealias_in_protocol_short,none,
+      "typealias must not be declared within a protocol", ())
+NOTE(swift5_typealias_to_associated_type_fixit,none,
+     "use 'associatedtype' to specify a default value for %0 from protocol %1",
+     (DeclName, Type))
+NOTE(swift5_typealias_to_same_type_constr_fixit,none,
+     "use a same-type constraint on the protocol", ())
+
 
 ERROR(associated_type_objc,none,
       "associated type %0 cannot be declared inside '@objc' protocol %1",

--- a/test/Generics/protocol_type_aliases_swift4.swift
+++ b/test/Generics/protocol_type_aliases_swift4.swift
@@ -1,0 +1,25 @@
+// RUN: %target-typecheck-verify-swift -typecheck %s -verify -swift-version 4
+
+protocol P1 {
+  typealias A = Int
+  // expected-warning@-1 {{typealias should not be declared within a protocol; move to an extension or use 'associatedtype' to define an associated type requirement}} {{3-12=associatedtype}}
+}
+protocol P2 : P1 {
+  associatedtype A
+}
+
+protocol P3 {
+  associatedtype A // expected-note 2 {{'A' declared here}}
+}
+
+// We leave the current warning intact when we 'override' an associatedtype in Swift 4
+protocol P4: P3 {
+  typealias A = Int
+  // expected-warning@-1 {{typealias overriding associated type 'A' from protocol 'P3' is better expressed as same-type constraint on the protocol}} {{16-16= where A == Int}} {{3-20=}}
+}
+
+// Nothing changes here
+protocol P5: P3 {
+  associatedtype A: P1
+  // expected-warning@-1 {{redeclaration of associated type 'A' from protocol 'P3' is better expressed as a 'where' clause on the protocol}} {{16-16= where A: P1}} {{3-23=}}
+}

--- a/test/Generics/protocol_type_aliases_swift5.swift
+++ b/test/Generics/protocol_type_aliases_swift5.swift
@@ -1,0 +1,32 @@
+// RUN: %target-typecheck-verify-swift -typecheck %s -verify -swift-version 5
+
+protocol P1 {
+  typealias A = Int
+  // expected-error@-1 {{typealias must not be declared within a protocol; move to an extension or use 'associatedtype' to define an associated type requirement}} {{3-12=associatedtype}}
+}
+protocol P2 : P1 {
+  associatedtype A
+}
+
+protocol P3 {
+  associatedtype A // expected-note 3 {{'A' declared here}}
+  associatedtype B
+}
+
+// Complain and since we have 'A' from 'P3', provide some options the user might have had in mind
+protocol P4: P3 {
+  typealias A = Int // expected-error {{typealias must not be declared within a protocol}}
+  // expected-note@-1 {{use 'associatedtype' to specify a default value for 'A' from protocol 'P3'}} {{3-12=associatedtype}}
+  // expected-note@-2 {{use a same-type constraint on the protocol}} {{16-16= where A == Int}} {{3-21=}}
+}
+protocol P5: P3 where B == Int {
+  typealias A = Bool // expected-error {{typealias must not be declared within a protocol}}
+  // expected-note@-1 {{use 'associatedtype' to specify a default value for 'A' from protocol 'P3'}} {{3-12=associatedtype}}
+  // expected-note@-2 {{use a same-type constraint on the protocol}} {{31-31=, A == Bool}} {{3-22=}}
+}
+
+// Nothing changes here
+protocol P6: P3 {
+  associatedtype A: P1
+  // expected-warning@-1 {{redeclaration of associated type 'A' from protocol 'P3' is better expressed as a 'where' clause on the protocol}}
+}


### PR DESCRIPTION
SE PR – https://github.com/apple/swift-evolution/pull/857

I've not done it before, but this should go to 4.2 and 5 as well, I suppose. 

These changes don't touch yet cases like 
```swift
protocol P {
  associatedtype A
  func foo() -> A
}
extension P {typealias A = Int}
```
The preferred option is to allow type aliases to act as defaults for associated types.