### PR TITLE
[Sema] Fix spurious use_local_before_declaration errors.

### DIFF
--- a/lib/Sema/TypeCheckNameLookup.cpp
+++ b/lib/Sema/TypeCheckNameLookup.cpp
@@ -47,6 +47,26 @@ void LookupResult::filter(
                 Results.end());
 }
 
+void LookupResult::shiftDownResults() {
+  // Remove inner results.
+  Results.erase(Results.begin(), Results.begin() + IndexOfFirstOuterResult);
+  IndexOfFirstOuterResult = 0;
+
+  if (Results.empty())
+    return;
+
+  // Compute IndexOfFirstOuterResult.
+  const DeclContext *dcInner = Results.front().getValueDecl()->getDeclContext();
+  for (auto &&result : Results) {
+    const DeclContext *dc = result.getValueDecl()->getDeclContext();
+    if (dc == dcInner ||
+        (dc->isModuleScopeContext() && dcInner->isModuleScopeContext()))
+      ++IndexOfFirstOuterResult;
+    else
+      break;
+  }
+}
+
 namespace {
   /// Builder that helps construct a lookup result from the raw lookup
   /// data.

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -149,6 +149,11 @@ public:
   /// Filter out any results that aren't accepted by the given predicate.
   void
   filter(llvm::function_ref<bool(LookupResultEntry, /*isOuter*/ bool)> pred);
+
+  /// Shift down results by dropping inner results while keeping outer
+  /// results (if any), the innermost of which are recogized as inner
+  /// results afterwards.
+  void shiftDownResults();
 };
 
 /// The result of name lookup for types.

--- a/test/NameBinding/name-binding.swift
+++ b/test/NameBinding/name-binding.swift
@@ -195,16 +195,16 @@ test+++
 //===----------------------------------------------------------------------===//
 
 func forwardReference() {
-  x = 0 // expected-error{{use of local variable 'x' before its declaration}}
-  var x: Float = 0.0 // expected-note{{'x' declared here}}
+  v = 0 // expected-error{{use of local variable 'v' before its declaration}}
+  var v: Float = 0.0 // expected-note{{'v' declared here}}
 }
 
 class ForwardReference {
   var x: Int = 0
 
   func test() {
-    x = 0 // expected-error{{use of local variable 'x' before its declaration}}
-    var x: Float = 0.0 // expected-note{{'x' declared here}}
+    x = 0
+    var x: Float = 0.0 // expected-warning{{variable 'x' was never used; consider replacing with '_' or removing it}}
   }
 }
 

--- a/test/Sema/diag_use_before_declaration.swift
+++ b/test/Sema/diag_use_before_declaration.swift
@@ -15,8 +15,97 @@ func sr5163() {
 var foo: Int?
 
 func test() {
-  guard let bar = foo else { // expected-error {{use of local variable 'foo' before its declaration}}
+  guard let bar = foo else {
     return
   }
-  let foo = String(bar) // expected-note {{'foo' declared here}}
+  let foo = String(bar)
+}
+
+// SR-7660
+class C {
+  var variable: Int?
+  func f() {
+    guard let _ = variable else { return }
+    let variable = 1 // expected-warning {{initialization of immutable value 'variable' was never used; consider replacing with assignment to '_' or removing it}}
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Nested scope
+//===----------------------------------------------------------------------===//
+
+func nested_scope_1() {
+  do {
+    do {
+      let _ = x // expected-error {{use of local variable 'x' before its declaration}}
+      let x = 111 // expected-note {{'x' declared here}}
+    }
+    let x = 11
+  }
+  let x = 1
+}
+
+func nested_scope_2() {
+  do {
+    let x = 11
+    do {
+      let _ = x
+      let x = 111 // expected-warning {{initialization of immutable value 'x' was never used; consider replacing with assignment to '_' or removing it}}
+    }
+  }
+  let x = 1  // expected-warning {{initialization of immutable value 'x' was never used; consider replacing with assignment to '_' or removing it}}
+}
+
+func nested_scope_3() {
+  let x = 1
+  do {
+    do {
+      let _ = x
+      let x = 111 // expected-warning {{initialization of immutable value 'x' was never used; consider replacing with assignment to '_' or removing it}}
+    }
+    let x = 11 // expected-warning {{initialization of immutable value 'x' was never used; consider replacing with assignment to '_' or removing it}}
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// Type scope
+//===----------------------------------------------------------------------===//
+
+class Ty {
+  var v : Int?
+
+  func fn() {
+    let _ = v
+    let v = 1 // expected-warning {{initialization of immutable value 'v' was never used; consider replacing with assignment to '_' or removing it}}
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// File scope
+//===----------------------------------------------------------------------===//
+
+let g = 0
+
+func file_scope_1() {
+  let _ = g
+  let g = 1 // expected-warning {{initialization of immutable value 'g' was never used; consider replacing with assignment to '_' or removing it}}
+}
+
+func file_scope_2() {
+  let _ = gg // expected-error {{use of local variable 'gg' before its declaration}}
+  let gg = 1 // expected-note {{'gg' declared here}}
+}
+
+//===----------------------------------------------------------------------===//
+// Module scope
+//===----------------------------------------------------------------------===//
+
+func module_scope_1() {
+  let _ = print // Legal use of func print declared in Swift Standard Library
+  let print = "something" // expected-warning {{initialization of immutable value 'print' was never used; consider replacing with assignment to '_' or removing it}}
+}
+
+func module_scope_2() {
+  let _ = another_print // expected-error {{use of local variable 'another_print' before its declaration}}
+  let another_print = "something" // expected-note {{'another_print' declared here}}
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
The current implementation of type checker is overly strict for use_local_before_declaration cases.
When performing name lookup for UnresolvedDeclRefExpr, if a local declaration after use is detected, an error is raised immediately, without checking outer results where legal candidates may occur. 

This PR adds relevant checking to see if we can find better matching candidates from outer results before raising a use_local_before_declaration error.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7660](https://bugs.swift.org/browse/SR-7660).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
