### PR TITLE
[CodeCompletion] Remove 'self' from type identifier completions

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4151,7 +4151,6 @@ public:
                              CurrDeclContext, TypeResolver.get(),
                              IncludeInstanceMembers);
     addKeyword("Type", MetaBase);
-    addKeyword("self", BaseType, SemanticContextKind::CurrentNominal);
   }
 
   static bool canUseAttributeOnDecl(DeclAttrKind DAK, bool IsInSil,

--- a/test/IDE/complete_associated_types.swift
+++ b/test/IDE/complete_associated_types.swift
@@ -177,7 +177,7 @@ func testStruct2() {
 func testStruct3(a: StructWithAssociatedTypes) {
   a.#^STRUCT_INSTANCE^#
 }
-// STRUCT_TYPE_COUNT: Begin completions, 26 items
+// STRUCT_TYPE_COUNT: Begin completions, 25 items
 
 // STRUCT_INSTANCE: Begin completions, 15 items
 // STRUCT_INSTANCE-DAG: Decl[InstanceMethod]/CurrNominal:   deduceCommonA()[#Int#]

--- a/test/IDE/complete_type.swift
+++ b/test/IDE/complete_type.swift
@@ -1024,7 +1024,7 @@ func testTypeIdentifierGeneric3<
 
 // TYPE_IDENTIFIER_GENERIC_3: Begin completions
 // TYPE_IDENTIFIER_GENERIC_3-NEXT: Keyword/None:          Type[#GenericFoo.Type#]
-// TYPE_IDENTIFIER_GENERIC_3-NEXT: Keyword/CurrNominal:          self[#GenericFoo#]
+// TYPE_IDENTIFIER_GENERIC_3-NOT: Keyword/CurrNominal:    self[#GenericFoo#]
 // TYPE_IDENTIFIER_GENERIC_3-NEXT: End completions
 
 func testTypeIdentifierIrrelevant1() {

--- a/test/IDE/complete_type_subscript.swift
+++ b/test/IDE/complete_type_subscript.swift
@@ -17,7 +17,6 @@ struct S1 {
   subscript(x: MyStruct) -> MyStruct#^RETURN_1^# { }
 }
 // MYSTRUCT_0: Keyword/None:                       .Type[#S1.MyStruct.Type#];
-// MYSTRUCT_0: Keyword/CurrNominal:                .self[#S1.MyStruct#];
 
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PARAM_2 | %FileCheck %s -check-prefix=MYSTRUCT_1
@@ -28,7 +27,7 @@ struct S2 {
   subscript(x: MyStruct) -> MyStruct.#^RETURN_2^# { }
 }
 // MYSTRUCT_1: Keyword/None:                       Type[#S2.MyStruct.Type#];
-// MYSTRUCT_1: Keyword/CurrNominal:                self[#S2.MyStruct#];
+// MYSTRUCT_1-NOT: Keyword/CurrNominal:            self[#S2.MyStruct#];
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GEN_PARAM_0 | %FileCheck %s -check-prefix=GEN_TOP_LEVEL_0
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GEN_RETURN_0 | %FileCheck %s -check-prefix=GEN_TOP_LEVEL_0
@@ -48,7 +47,6 @@ struct G1<T> {
   subscript(x: T) -> T#^GEN_RETURN_1^# { return 0 }
 }
 // GEN_PARAM_1: Keyword/None:                       .Type[#T.Type#];
-// GEN_PARAM_1: Keyword/CurrNominal:                .self[#T#];
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GEN_PARAM_2 | %FileCheck %s -check-prefix=GEN_PARAM_2
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GEN_RETURN_2 | %FileCheck %s -check-prefix=GEN_PARAM_2
@@ -57,7 +55,6 @@ struct G2<T> {
   subscript(x: T) -> T.#^GEN_RETURN_2^# { return 0 }
 }
 // GEN_PARAM_2: Keyword/None:                       Type[#T.Type#];
-// GEN_PARAM_2: Keyword/CurrNominal:                self[#T#];
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GEN_PARAM_3 | %FileCheck %s -check-prefix=GEN_TOP_LEVEL_1
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GEN_RETURN_3 | %FileCheck %s -check-prefix=GEN_TOP_LEVEL_1
@@ -77,7 +74,6 @@ struct G4 {
   subscript<T>(x: T) -> T#^GEN_RETURN_4^# { return 0 }
 }
 // GEN_PARAM_4: Keyword/None:                       .Type[#T.Type#];
-// GEN_PARAM_4: Keyword/CurrNominal:                .self[#T#];
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GEN_PARAM_5 | %FileCheck %s -check-prefix=GEN_PARAM_5
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GEN_RETURN_5 | %FileCheck %s -check-prefix=GEN_PARAM_5
@@ -86,4 +82,4 @@ struct G5 {
   subscript<T>(x: T) -> T.#^GEN_RETURN_5^# { return 0 }
 }
 // GEN_PARAM_5: Keyword/None:                       Type[#T.Type#];
-// GEN_PARAM_5: Keyword/CurrNominal:                self[#T#];
+// GEN_PARAM_5-NOT: Keyword/CurrNominal:            self[#T#];

--- a/test/IDE/complete_where_clause.swift
+++ b/test/IDE/complete_where_clause.swift
@@ -72,13 +72,13 @@ func f1<T>(_: T) where #^FUNC_1^# {}
 func f2<T>(_: T) where T.#^FUNC_2^# {}
 // GEN_T_DOT: Begin completions
 // GEN_T_DOT-DAG: Keyword/None:                       Type[#T.Type#];
-// GEN_T_DOT-DAG: Keyword/CurrNominal:                self[#T#];
+// GEN_T_DOT-NOT: Keyword/CurrNominal:                self[#T#];
 // GEN_T_DOT: End completions
 func f2b<T: Assoc>(_: T) where T.#^FUNC_2_ASSOC^# {}
 // GEN_T_ASSOC_DOT: Begin completions
 // GEN_T_ASSOC_DOT-DAG: Decl[AssociatedType]/Super:         Q;
 // GEN_T_ASSOC_DOT-DAG: Keyword/None:                       Type[#T.Type#];
-// GEN_T_ASSOC_DOT-DAG: Keyword/CurrNominal:                self[#T#];
+// GEN_T_ASSOC_DOT-NOT: Keyword/CurrNominal:                self[#T#];
 // GEN_T_ASSOC_DOT: End completions
 func f3<T>(_: T) where T == #^FUNC_3^# {}
 func f3<T>(_: T) where T == T.#^FUNC_4^# {}
@@ -117,5 +117,4 @@ protocol P2 {
 // U_DOT: Begin completions
 // FIXME: Should complete Q from Assoc.
 // U_DOT-DAG: Keyword/None:                       Type[#Self.U.Type#];
-// U_DOT-DAG: Keyword/CurrNominal:                self[#Self.U#];
 // U_DOT: End completions


### PR DESCRIPTION
Resolves [SR-7856](https://bugs.swift.org/browse/SR-7856).
