### PR TITLE
[Testing] Add missing --check-prefix and mark as XFAIL

### DIFF
--- a/test/IRGen/type_layout_reference_storage_objc.swift
+++ b/test/IRGen/type_layout_reference_storage_objc.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -enable-objc-interop -emit-ir %s | %FileCheck %s --check-prefix=CHECK-%target-ptrsize
+// XFAIL: *
 
 import Foundation
 


### PR DESCRIPTION
The CHECK-64 extra inhabitant tests are broken and will be fixed as a part of #16237.