### PR TITLE
[simplify-cfg] The name for the pass does not have a - at the beginning.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -256,7 +256,7 @@ PASS(SROABBArgs, "sroa-bb-args",
      "Scalar Replacement of Aggregate SIL Block Arguments")
 PASS(SimplifyBBArgs, "simplify-bb-args",
      "SIL Block Argument Simplification")
-PASS(SimplifyCFG, "-simplify-cfg",
+PASS(SimplifyCFG, "simplify-cfg",
      "SIL CFG Simplification")
 PASS(SpeculativeDevirtualization, "specdevirt",
      "Speculative Devirtualization via Guarded Calls")

--- a/test/SILOptimizer/simplify_cfg_simple.sil
+++ b/test/SILOptimizer/simplify_cfg_simple.sil
@@ -1,0 +1,29 @@
+// RUN: %target-sil-opt -assume-parsing-unqualified-ownership-sil -enable-sil-verify-all -simplify-cfg %s | %FileCheck %s
+//
+// Make sure that we can succesfully call simplify-cfg with that name via sil-opt.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+
+// CHECK-LABEL: sil @simple_test : $@convention(thin) () -> () {
+// CHECK: bb0:
+// CHECK-NEXT: tuple
+// CHECK-NEXT: return
+// CHECK: } // end sil function 'simple_test'
+sil @simple_test : $@convention(thin) () -> () {
+bb0:
+  %0 = integer_literal $Builtin.Int1, -1
+  cond_br %0, bb1, bb2
+
+bb1:
+  br bb3
+
+bb2:
+  br bb3
+
+bb3:
+  %9999 = tuple ()
+  return %9999 : $()
+}


### PR DESCRIPTION
I added a test that makes sure we can invoke this correctly. I found this when
trying to get the bug_reducer tests working again.
