### PR TITLE
test: explicitly invoke python for process-stats-dir

### DIFF
--- a/test/Driver/pipe_round_robin.swift.gyb
+++ b/test/Driver/pipe_round_robin.swift.gyb
@@ -22,7 +22,7 @@
 // different (eg. thousands of reads per poll).
 //
 // RUN: %target-build-swift -j 4 -module-name manyfuncs -typecheck -stats-output-dir %t/stats -Xfrontend -debug-time-function-bodies %t/manyfuncs/*.swift
-// RUN: %utils/process-stats-dir.py --evaluate 'abs(float(NumDriverPipeReads) / float(NumDriverPipePolls)) < 3.0' %t/stats
+// RUN: %{python} %utils/process-stats-dir.py --evaluate 'abs(float(NumDriverPipeReads) / float(NumDriverPipePolls)) < 3.0' %t/stats
 
 % for i in range(1,1000):
 func process_${N}_function_${i}(_ x: Int) -> Int {

--- a/test/Misc/stats_dir.swift
+++ b/test/Misc/stats_dir.swift
@@ -1,27 +1,27 @@
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -c -o %t/out.o -stats-output-dir %t %s
-// RUN: %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv %t
+// RUN: %{python} %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv %t
 // RUN: %FileCheck -input-file %t/frontend.csv %s
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -c -o %t/out.o -stats-output-dir %t %s
-// RUN: %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv --exclude-timers %t
+// RUN: %{python} %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv --exclude-timers %t
 // RUN: %FileCheck -input-file %t/frontend.csv --implicit-check-not '{{time.swift}}' %s
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -c -o %t/out.o -stats-output-dir %t %s
-// RUN: %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv --select-stat NumSourceLines --select-stat NumIRFunctions --select-stat NumLLVMBytesOutput %t
+// RUN: %{python} %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv --select-stat NumSourceLines --select-stat NumIRFunctions --select-stat NumLLVMBytesOutput %t
 // RUN: %FileCheck -input-file %t/frontend.csv %s
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -c -wmo -num-threads 4 -o %t/out.o -stats-output-dir %t %s
-// RUN: %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv %t
+// RUN: %{python} %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv %t
 // RUN: %FileCheck -input-file %t/frontend.csv %s
 // RUN: echo '9000000000	"LLVM.NumLLVMBytesOutput"	1' >>%t/frontend.csv
-// RUN: not %utils/process-stats-dir.py --compare-to-csv-baseline %t/frontend.csv %t
+// RUN: not %{python} %utils/process-stats-dir.py --compare-to-csv-baseline %t/frontend.csv %t
 
 // RUN: %empty-directory(%t)
 // RUN: %target-swiftc_driver -c -o %t/out.o -stats-output-dir %t %s
-// RUN: %utils/process-stats-dir.py --set-csv-baseline %t/driver.csv %t
+// RUN: %{python} %utils/process-stats-dir.py --set-csv-baseline %t/driver.csv %t
 // RUN: %FileCheck -input-file %t/driver.csv %s
-// RUN: %utils/process-stats-dir.py --compare-to-csv-baseline %t/driver.csv %t
+// RUN: %{python} %utils/process-stats-dir.py --compare-to-csv-baseline %t/driver.csv %t
 
 // RUN: %target-swiftc_driver -c -o %t/out.o -stats-output-dir %t/this/is/not/a/directory %s 2>&1 | %FileCheck -check-prefix=CHECK-NODIR %s
 

--- a/test/Misc/stats_dir_failure_count.swift
+++ b/test/Misc/stats_dir_failure_count.swift
@@ -2,7 +2,7 @@
 // RUN: %empty-directory(%t)
 // RUN: echo zzz >%t/other.swift
 // RUN: not %target-swiftc_driver -continue-building-after-errors -D BROKEN -j 2 -typecheck -stats-output-dir %t %s %t/other.swift
-// RUN: %utils/process-stats-dir.py --set-csv-baseline %t/stats.csv %t
+// RUN: %{python} %utils/process-stats-dir.py --set-csv-baseline %t/stats.csv %t
 // RUN: %FileCheck -input-file %t/stats.csv -check-prefix=FAILURE %s
 // FAILURE: {{"Driver.NumProcessFailures"	1$}}
 // FAILURE: {{"Frontend.NumProcessFailures"	2$}}
@@ -11,7 +11,7 @@
 // RUN: %empty-directory(%t)
 // RUN: echo 'let x : Int = 1' >%t/other.swift
 // RUN: %target-swiftc_driver -j 2 -typecheck -stats-output-dir %t %s %t/other.swift
-// RUN: %utils/process-stats-dir.py --set-csv-baseline %t/stats.csv %t
+// RUN: %{python} %utils/process-stats-dir.py --set-csv-baseline %t/stats.csv %t
 // RUN: %FileCheck -input-file %t/stats.csv -check-prefix=SUCCESS %s
 // SUCCESS-NOT: {{"Driver.NumProcessFailures"	[1-9]+}}
 // SUCCESS-NOT: {{"Frontend.NumProcessFailures"	[1-9]+}}

--- a/test/Misc/stats_dir_long_path_name.swift
+++ b/test/Misc/stats_dir_long_path_name.swift
@@ -4,7 +4,7 @@
 // RUN: cp %s %t/very-long-directory-name-that-contains-over-128-characters-which-is-not-enough-to-be-illegal-on-its-own-but-presents/a-problem-when-combined-with-other-long-path-elements-and-filenames-to-exceed-256-characters-combined-because-yay-arbitrary-limits-amirite.swift
 // RUN: touch %t/main.swift
 // RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t %t/main.swift %t/very-long-directory-name-that-contains-over-128-characters-which-is-not-enough-to-be-illegal-on-its-own-but-presents/a-problem-when-combined-with-other-long-path-elements-and-filenames-to-exceed-256-characters-combined-because-yay-arbitrary-limits-amirite.swift
-// RUN: %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv %t
+// RUN: %{python} %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv %t
 // RUN: %FileCheck -input-file %t/frontend.csv %s
 
 // CHECK: {{"AST.NumSourceLines"	[1-9][0-9]*$}}

--- a/test/Misc/stats_dir_plausible_maxrss.swift
+++ b/test/Misc/stats_dir_plausible_maxrss.swift
@@ -1,7 +1,7 @@
 // RUN: %empty-directory(%t)
 // RUN: touch %t/main.swift
 // RUN: %target-swiftc_driver -o %t/main -module-name main -stats-output-dir %t %t/main.swift
-// RUN: %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv %t
+// RUN: %{python} %utils/process-stats-dir.py --set-csv-baseline %t/frontend.csv %t
 // RUN: %FileCheck -input-file %t/frontend.csv %s
 
 // This test checks that we're reporting some number that's "at least 10MB" and

--- a/test/NameBinding/named_lazy_member_loading_objc_category.swift
+++ b/test/NameBinding/named_lazy_member_loading_objc_category.swift
@@ -8,7 +8,7 @@
 // Check that named-lazy-member-loading reduces the number of Decls deserialized
 // RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -disable-named-lazy-member-loading -stats-output-dir %t/stats-pre %s
 // RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -stats-output-dir %t/stats-post %s
-// RUN: %utils/process-stats-dir.py --evaluate-delta 'NumTotalClangImportedEntities < -10' %t/stats-pre %t/stats-post
+// RUN: %{python} %utils/process-stats-dir.py --evaluate-delta 'NumTotalClangImportedEntities < -10' %t/stats-pre %t/stats-post
 
 import NamedLazyMembers
 

--- a/test/NameBinding/named_lazy_member_loading_objc_interface.swift
+++ b/test/NameBinding/named_lazy_member_loading_objc_interface.swift
@@ -8,7 +8,7 @@
 // Check that named-lazy-member-loading reduces the number of Decls deserialized
 // RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -disable-named-lazy-member-loading -stats-output-dir %t/stats-pre -primary-file %s %S/Inputs/NamedLazyMembers/NamedLazyMembersExt.swift
 // RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -stats-output-dir %t/stats-post -primary-file %s %S/Inputs/NamedLazyMembers/NamedLazyMembersExt.swift
-// RUN: %utils/process-stats-dir.py --evaluate-delta 'NumTotalClangImportedEntities < -10' %t/stats-pre %t/stats-post
+// RUN: %{python} %utils/process-stats-dir.py --evaluate-delta 'NumTotalClangImportedEntities < -10' %t/stats-pre %t/stats-post
 
 import NamedLazyMembers
 

--- a/test/NameBinding/named_lazy_member_loading_objc_protocol.swift
+++ b/test/NameBinding/named_lazy_member_loading_objc_protocol.swift
@@ -8,7 +8,7 @@
 // Check that named-lazy-member-loading reduces the number of Decls deserialized
 // RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -disable-named-lazy-member-loading -stats-output-dir %t/stats-pre %s
 // RUN: %target-swift-frontend -typecheck -I %S/Inputs/NamedLazyMembers -stats-output-dir %t/stats-post %s
-// RUN: %utils/process-stats-dir.py --evaluate-delta 'NumTotalClangImportedEntities < -9' %t/stats-pre %t/stats-post
+// RUN: %{python} %utils/process-stats-dir.py --evaluate-delta 'NumTotalClangImportedEntities < -9' %t/stats-pre %t/stats-post
 
 import NamedLazyMembers
 

--- a/test/NameBinding/named_lazy_member_loading_swift_class.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_class.swift
@@ -6,7 +6,7 @@
 // Check that named-lazy-member-loading reduces the number of Decls deserialized
 // RUN: %target-swift-frontend -typecheck -I %t -disable-named-lazy-member-loading -typecheck -stats-output-dir %t/stats-pre %s
 // RUN: %target-swift-frontend -typecheck -I %t -stats-output-dir %t/stats-post %s
-// RUN: %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -10' %t/stats-pre %t/stats-post
+// RUN: %{python} %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -10' %t/stats-pre %t/stats-post
 
 import NamedLazyMembers
 

--- a/test/NameBinding/named_lazy_member_loading_swift_class_type.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_class_type.swift
@@ -6,7 +6,7 @@
 // Check that named-lazy-member-loading reduces the number of Decls deserialized
 // RUN: %target-swift-frontend -typecheck -I %t -disable-named-lazy-member-loading -typecheck -stats-output-dir %t/stats-pre %s
 // RUN: %target-swift-frontend -typecheck -I %t -stats-output-dir %t/stats-post %s
-// RUN: %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -10' %t/stats-pre %t/stats-post
+// RUN: %{python} %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -10' %t/stats-pre %t/stats-post
 
 import NamedLazyMembers
 

--- a/test/NameBinding/named_lazy_member_loading_swift_derived_class.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_derived_class.swift
@@ -6,7 +6,7 @@
 // Check that named-lazy-member-loading reduces the number of Decls deserialized
 // RUN: %target-swift-frontend -typecheck -I %t -disable-named-lazy-member-loading -typecheck -stats-output-dir %t/stats-pre %s
 // RUN: %target-swift-frontend -typecheck -I %t -stats-output-dir %t/stats-post %s
-// RUN: %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -10' %t/stats-pre %t/stats-post
+// RUN: %{python} %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -10' %t/stats-pre %t/stats-post
 
 import NamedLazyMembers
 

--- a/test/NameBinding/named_lazy_member_loading_swift_derived_class_type.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_derived_class_type.swift
@@ -6,7 +6,7 @@
 // Check that named-lazy-member-loading reduces the number of Decls deserialized
 // RUN: %target-swift-frontend -typecheck -I %t -disable-named-lazy-member-loading -typecheck -stats-output-dir %t/stats-pre %s
 // RUN: %target-swift-frontend -typecheck -I %t -stats-output-dir %t/stats-post %s
-// RUN: %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -10' %t/stats-pre %t/stats-post
+// RUN: %{python} %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -10' %t/stats-pre %t/stats-post
 
 import NamedLazyMembers
 

--- a/test/NameBinding/named_lazy_member_loading_swift_enum.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_enum.swift
@@ -6,7 +6,7 @@
 // Check that named-lazy-member-loading reduces the number of Decls deserialized
 // RUN: %target-swift-frontend -typecheck -I %t -disable-named-lazy-member-loading -typecheck -stats-output-dir %t/stats-pre %s
 // RUN: %target-swift-frontend -typecheck -I %t -stats-output-dir %t/stats-post %s
-// RUN: %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -5' %t/stats-pre %t/stats-post
+// RUN: %{python} %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -5' %t/stats-pre %t/stats-post
 
 import NamedLazyMembers
 

--- a/test/NameBinding/named_lazy_member_loading_swift_proto.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_proto.swift
@@ -6,7 +6,7 @@
 // Check that named-lazy-member-loading reduces the number of Decls deserialized
 // RUN: %target-swift-frontend -typecheck -I %t -disable-named-lazy-member-loading -typecheck -stats-output-dir %t/stats-pre %s
 // RUN: %target-swift-frontend -typecheck -I %t -stats-output-dir %t/stats-post %s
-// RUN: %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -3' %t/stats-pre %t/stats-post
+// RUN: %{python} %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -3' %t/stats-pre %t/stats-post
 
 import NamedLazyMembers
 

--- a/test/NameBinding/named_lazy_member_loading_swift_struct.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_struct.swift
@@ -6,7 +6,7 @@
 // Check that named-lazy-member-loading reduces the number of Decls deserialized
 // RUN: %target-swift-frontend -typecheck -I %t -disable-named-lazy-member-loading -typecheck -stats-output-dir %t/stats-pre %s
 // RUN: %target-swift-frontend -typecheck -I %t -stats-output-dir %t/stats-post %s
-// RUN: %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -4' %t/stats-pre %t/stats-post
+// RUN: %{python} %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -4' %t/stats-pre %t/stats-post
 
 import NamedLazyMembers
 

--- a/test/NameBinding/named_lazy_member_loading_swift_struct_ext.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_struct_ext.swift
@@ -6,7 +6,7 @@
 // Check that named-lazy-member-loading reduces the number of Decls deserialized
 // RUN: %target-swift-frontend -typecheck -I %t -disable-named-lazy-member-loading -typecheck -stats-output-dir %t/stats-pre %s
 // RUN: %target-swift-frontend -typecheck -I %t -stats-output-dir %t/stats-post %s
-// RUN: %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -5' %t/stats-pre %t/stats-post
+// RUN: %{python} %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -5' %t/stats-pre %t/stats-post
 
 import NamedLazyMembers
 

--- a/test/NameBinding/named_lazy_member_loading_swift_struct_ext_mem.swift
+++ b/test/NameBinding/named_lazy_member_loading_swift_struct_ext_mem.swift
@@ -6,7 +6,7 @@
 // Check that named-lazy-member-loading reduces the number of Decls deserialized
 // RUN: %target-swift-frontend -typecheck -I %t -disable-named-lazy-member-loading -typecheck -stats-output-dir %t/stats-pre %s
 // RUN: %target-swift-frontend -typecheck -I %t -stats-output-dir %t/stats-post %s
-// RUN: %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -5' %t/stats-pre %t/stats-post
+// RUN: %{python} %utils/process-stats-dir.py --evaluate-delta 'NumDeclsDeserialized < -5' %t/stats-pre %t/stats-post
 
 import NamedLazyMembers
 

--- a/test/SILOptimizer/hello-world.swift
+++ b/test/SILOptimizer/hello-world.swift
@@ -1,6 +1,6 @@
 // RUN: rm -rf %t && mkdir -p %t/stats
 // RUN: %target-swift-frontend -emit-sil -stats-output-dir %t/stats %s -o /dev/null
-// RUN: %utils/process-stats-dir.py --evaluate 'NumSILGenFunctions < 10' %t/stats
-// RUN: %utils/process-stats-dir.py --evaluate 'NumSILOptFunctions < 10' %t/stats
+// RUN: %{python} %utils/process-stats-dir.py --evaluate 'NumSILGenFunctions < 10' %t/stats
+// RUN: %{python} %utils/process-stats-dir.py --evaluate 'NumSILOptFunctions < 10' %t/stats
 
 print("Hello world")


### PR DESCRIPTION
Explicitly mark the interpreter for the tool as windows does not
implicitly treat shebangs as the interpreter.  This allows for the
proper invocation of the tool on Windows.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
