### PR TITLE
DI: Remove unnecessary assertion [4.2]

### DIFF
--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -2176,9 +2176,6 @@ SILValue LifetimeChecker::handleConditionalInitAssign() {
       continue;
     }
 
-    assert(!TheMemory.isDelegatingInit() &&
-           "re-assignment of self in delegating init?");
-
     // If this ambiguous store is only of trivial types, then we don't need to
     // do anything special.  We don't even need keep the init bit for the
     // element precise.

--- a/test/SILOptimizer/definite_init_value_types.swift
+++ b/test/SILOptimizer/definite_init_value_types.swift
@@ -1,21 +1,16 @@
-// RUN: %target-swift-frontend -emit-sil -enable-sil-ownership %s -o /dev/null -verify
+// RUN: %target-swift-frontend -emit-sil -enable-sil-ownership %s | %FileCheck %s
 
-struct EmptyStruct {}
+enum ValueEnum {
+  case a(String)
+  case b
+  case c
 
-struct ValueStruct {
-  var ivar: EmptyStruct // expected-note {{'self.ivar' not initialized}}
-
-  init() { ivar = EmptyStruct() }
-
+  init() { self = .b }
 
   init(a: Double) {
     self.init()
-    _ = ivar // okay: ivar has been initialized by the delegation above
-  }
-
-  init(a: Int) {
-    _ = ivar // expected-error {{'self' used before 'self.init' call or assignment to 'self'}}
-    self.init()
+    _ = self // okay: self has been initialized by the delegation above
+    self = .c
   }
 
   init(a: Float) {
@@ -23,20 +18,91 @@ struct ValueStruct {
     self.init() // this is now OK
   }
 
-  init(c: Bool) {
-    if c {
-      return
+  init(e: Bool) {
+    if e {
+      self = ValueEnum()
+    } else {
+      self.init()
     }
+  }
 
+  // CHECK-LABEL: sil hidden @$S25definite_init_value_types9ValueEnumO1xACSb_tcfC : $@convention(method) (Bool, @thin ValueEnum.Type) -> @owned ValueEnum
+  // CHECK:      bb0(%0 : $Bool, %1 : $@thin ValueEnum.Type):
+  // CHECK-NEXT:   [[STATE:%.*]] = alloc_stack $Builtin.Int1
+  // CHECK-NEXT:   [[SELF_BOX:%.*]] = alloc_stack $ValueEnum
+  // CHECK-NEXT:   [[INIT_STATE:%.*]] = integer_literal $Builtin.Int1, 0
+  // CHECK-NEXT:   store [[INIT_STATE]] to [[STATE]]
+  // CHECK:        [[BOOL:%.*]] = struct_extract %0 : $Bool, #Bool._value
+  // CHECK-NEXT:   cond_br [[BOOL]], bb1, bb2
+  // CHECK:      bb1:
+  // CHECK-NEXT:   [[METATYPE:%.*]] = metatype $@thin ValueEnum.Type
+  // CHECK-NEXT:   [[NEW_SELF:%.*]] = enum $ValueEnum, #ValueEnum.b!enumelt
+  // CHECK-NEXT:   [[SELF_ACCESS:%.*]] = begin_access [modify] [static] [[SELF_BOX]]
+  // CHECK-NEXT:   [[NEW_STATE:%.*]] = integer_literal $Builtin.Int1, -1
+  // CHECK-NEXT:   store [[NEW_STATE]] to [[STATE]]
+  // CHECK-NEXT:   store [[NEW_SELF]] to [[SELF_ACCESS]]
+  // CHECK-NEXT:   end_access [[SELF_ACCESS]]
+  // CHECK-NEXT:   br bb2
+  // CHECK:      bb2:
+  // CHECK-NEXT:   [[METATYPE:%.*]] = metatype $@thin ValueEnum.Type
+  // CHECK-NEXT:   [[NEW_SELF:%.*]] = enum $ValueEnum, #ValueEnum.c!enumelt
+  // CHECK-NEXT:   [[SELF_ACCESS:%.*]] = begin_access [modify] [static] [[SELF_BOX]]
+  // CHECK-NEXT:   [[STATE_VALUE:%.*]] = load [[STATE]]
+  // CHECK-NEXT:   cond_br [[STATE_VALUE]], bb3, bb4
+  // CHECK:      bb3:
+  // CHECK-NEXT:   destroy_addr [[SELF_BOX]]
+  // CHECK-NEXT:   br bb4
+  // CHECK:      bb4:
+  // CHECK-NEXT:   [[NEW_STATE:%.*]] = integer_literal $Builtin.Int1, -1
+  // CHECK-NEXT:   store [[NEW_STATE]] to [[STATE]]
+  // CHECK-NEXT:   store [[NEW_SELF]] to [[SELF_ACCESS]]
+  // CHECK-NEXT:   end_access [[SELF_ACCESS]]
+  // CHECK-NEXT:   retain_value [[NEW_SELF]]
+  // CHECK-NEXT:   destroy_addr [[SELF_BOX]]
+  // CHECK-NEXT:   dealloc_stack [[SELF_BOX]]
+  // CHECK-NEXT:   dealloc_stack [[STATE]]
+  // CHECK-NEXT:   return [[NEW_SELF]]
+  init(x: Bool) {
+    if x {
+      self = .b
+    }
+    self = .c
+  }
+}
+
+enum AddressEnum {
+  case a(Any)
+  case b
+  case c
+
+  init() { self = .b }
+
+  init(e: Bool) {
+    if e {
+      self = AddressEnum()
+    } else {
+      self.init()
+    }
+  }
+
+  init(x: Bool) {
+    if x {
+      self = .b
+    }
+    self = .c
+  }
+}
+
+struct EmptyStruct {}
+
+struct ValueStruct {
+  var ivar: EmptyStruct
+
+  init() { ivar = EmptyStruct() }
+
+  init(a: Float) {
     self.init()
-  } // expected-error {{'self.init' isn't called on all paths before returning from initializer}}
-
-  init(d: Bool) {
-    if d {
-      return // expected-error {{return from initializer without initializing all stored properties}}
-    }
-
-    self = ValueStruct()
+    self.init()
   }
 
   init(e: Bool) {
@@ -48,73 +114,11 @@ struct ValueStruct {
   }
 }
 
-enum ValueEnum {
-  case Dinosaur, Train, Truck
-
-  init() { self = .Train }
-
-  init(a: Double) {
-    self.init()
-    _ = self // okay: self has been initialized by the delegation above
-    self = .Dinosaur
-  }
-
-  init(a: Int) {
-    _ = self // expected-error {{'self' used before 'self.init' call or assignment to 'self'}}
-    self.init()
-  }
-
-  init(a: Float) {
-    self.init()
-    self.init() // this is now OK
-  }
-
-  init(c: Bool) {
-    if c {
-      return
-    }
-
-    self.init()
-  } // expected-error {{'self.init' isn't called on all paths before returning from initializer}}
-
-  init(d: Bool) {
-    if d {
-      return
-    }
-
-    self = ValueEnum()
-  } // expected-error {{'self.init' isn't called on all paths before returning from initializer}}
-
-  init(e: Bool) {
-    if e {
-      self = ValueEnum()
-    } else {
-      self.init()
-    }
-  }
-}
-
 struct AddressStruct {
   var ivar: EmptyStruct // expected-note {{'self.ivar' not initialized}}
   var any: Any?
 
   init() { ivar = EmptyStruct(); any = nil }
-
-  init(c: Bool) {
-    if c {
-      return
-    }
-
-    self.init()
-  } // expected-error {{'self.init' isn't called on all paths before returning from initializer}}
-
-  init(d: Bool) {
-    if d {
-      return
-    }
-
-    self = AddressStruct()
-  } // expected-error {{return from initializer without initializing all stored properties}}
 
   init(e: Bool) {
     if e {

--- a/test/SILOptimizer/definite_init_value_types_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_value_types_diagnostics.swift
@@ -1,0 +1,80 @@
+// RUN: %target-swift-frontend -emit-sil -enable-sil-ownership %s -o /dev/null -verify
+
+struct EmptyStruct {}
+
+struct ValueStruct {
+  var ivar: EmptyStruct // expected-note {{'self.ivar' not initialized}}
+
+  init() { ivar = EmptyStruct() }
+
+  init(a: Int) {
+    _ = ivar // expected-error {{'self' used before 'self.init' call or assignment to 'self'}}
+    self.init()
+  }
+
+  init(c: Bool) {
+    if c {
+      return
+    }
+
+    self.init()
+  } // expected-error {{'self.init' isn't called on all paths before returning from initializer}}
+
+  init(d: Bool) {
+    if d {
+      return // expected-error {{return from initializer without initializing all stored properties}}
+    }
+
+    self = ValueStruct()
+  }
+}
+
+enum ValueEnum {
+  case Dinosaur, Train, Truck
+
+  init() { self = .Train }
+
+  init(a: Int) {
+    _ = self // expected-error {{'self' used before 'self.init' call or assignment to 'self'}}
+    self.init()
+  }
+
+  init(c: Bool) {
+    if c {
+      return
+    }
+
+    self.init()
+  } // expected-error {{'self.init' isn't called on all paths before returning from initializer}}
+
+  init(d: Bool) {
+    if d {
+      return
+    }
+
+    self = ValueEnum()
+  } // expected-error {{'self.init' isn't called on all paths before returning from initializer}}
+}
+
+struct AddressStruct {
+  var ivar: EmptyStruct // expected-note {{'self.ivar' not initialized}}
+  var any: Any?
+
+  init() { ivar = EmptyStruct(); any = nil }
+
+  init(c: Bool) {
+    if c {
+      return
+    }
+
+    self.init()
+  } // expected-error {{'self.init' isn't called on all paths before returning from initializer}}
+
+  init(d: Bool) {
+    if d {
+      return
+    }
+
+    self = AddressStruct()
+  } // expected-error {{return from initializer without initializing all stored properties}}
+}


### PR DESCRIPTION
It's totally fine to have a conditional destroy of 'self' because
we now uniformly treat assignment to self and self.init delegation,
both of which can appear multiple times in a value type
initializer.

This change removes the assertion and adds some tFileCheck tests to
ensure that DI was already capable of inserting the correct memory
management operations in this scenario.

Fixes <rdar://problem/40417944>, <https://bugs.swift.org/browse/SR-7727>.