### PR TITLE
[Python] Throw error when numeric operation fails.

### DIFF
--- a/stdlib/public/Python/Python.swift
+++ b/stdlib/public/Python/Python.swift
@@ -1052,6 +1052,8 @@ private func performBinaryOp(
   _ op: PythonBinaryOp, lhs: PythonObject, rhs: PythonObject
 ) -> PythonObject {
   let result = op(lhs.ownedPyObject, rhs.ownedPyObject)
+  // If binary operation fails (e.g. due to `TypeError`), throw an exception.
+  try! throwPythonErrorIfPresent()
   return PythonObject(owning: result!)
 }
 


### PR DESCRIPTION
Numeric operations now fail with more descriptive errors:

```swift
let a: PythonObject = 1
let b: PythonObject = "string"
print(a + b) // exception: unsupported operand type(s) for +: 'int' and 'str'
```

I couldn't add a test because there's no throwing version of the operators yet.
TODO: Redesign `ThrowingPythonObject` to enable throwing operator calls.