### PR TITLE
[llvm-arc-opts] If we are missing "swift.{refcounted,bridge}", create…

### DIFF
--- a/test/LLVMPasses/missing_runtime_declarations.ll
+++ b/test/LLVMPasses/missing_runtime_declarations.ll
@@ -1,0 +1,23 @@
+; RUN: %swift-llvm-opt -swift-arc-contract %s | %FileCheck %s
+
+target datalayout = "e-p:64:64:64-S128-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f16:16:16-f32:32:32-f64:64:64-f128:128:128-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64"
+target triple = "x86_64-apple-macosx10.9"
+
+; CHECK: %a = type opaque
+; CHECK: %swift.bridge = type opaque
+; CHECK: declare void @swift_bridgeObjectRelease(%a* nocapture)
+
+%a = type opaque
+declare void @swift_bridgeObjectRelease(%a* nocapture)
+
+; CHECK-LABEL: define void @testcase(%a*) {
+; CHECK: entry:
+; CHECK-NEXT: [[CAST:%.*]] = bitcast %a* %0 to %swift.bridge*
+; CHECK-NEXT: call void @swift_bridgeObjectRelease_n(%swift.bridge* [[CAST]], i32 2)
+; CHECK-NEXT: ret void
+define void @testcase(%a*) {
+entry:
+  call void @swift_bridgeObjectRelease(%a* %0)
+  call void @swift_bridgeObjectRelease(%a* %0)
+  ret void
+}


### PR DESCRIPTION
… it as an opaque structure and don't assert.

Sometimes when running ARCContract on LLVM-IR certain required declarations will
be deleted. This triggers an assert that makes it difficult to work on running
test cases through the pass.

Instead, if we can not find by name the runtime function we are looking for,
recreate the named type as an opaque struct. Since we can not find the function
by name, we can assume that either this is a runtime function that we are the
only passes that create them or that the declarations were dead. Thus, there is
no earlier data, so we can just create a new opaque struct type and use pointers
to that struct_type. If we later need to merge this with another module that did
not delete that type definition, LLVM IR will set the type's body. Since we are
just using pointers to the type, there will be no codegen differences.

rdar://40491584
