### PR TITLE
put build-toolchain results in directory that it is called from

### DIFF
--- a/utils/build-toolchain
+++ b/utils/build-toolchain
@@ -28,8 +28,8 @@ function usage() {
   echo ""
 }
 
+RESULT_DIR=$PWD
 cd "$(dirname $0)/.." || exit
-SRC_DIR=$PWD
 
 # Set defaults
 DRY_RUN=
@@ -98,11 +98,11 @@ DISPLAY_NAME_SHORT="Local Swift Development Snapshot"
 DISPLAY_NAME="${DISPLAY_NAME_SHORT} ${YEAR}-${MONTH}-${DAY}"
 TOOLCHAIN_NAME="${TOOLCHAIN_VERSION}"
 
-SWIFT_INSTALLABLE_PACKAGE="${SRC_DIR}/${ARCHIVE}"
-SWIFT_INSTALL_DIR="${SRC_DIR}/swift-nightly-install"
-SWIFT_INSTALL_SYMROOT="${SRC_DIR}/swift-nightly-symroot"
+SWIFT_INSTALLABLE_PACKAGE="${RESULT_DIR}/${ARCHIVE}"
+SWIFT_INSTALL_DIR="${RESULT_DIR}/swift-nightly-install"
+SWIFT_INSTALL_SYMROOT="${RESULT_DIR}/swift-nightly-symroot"
 SWIFT_TOOLCHAIN_DIR="/Library/Developer/Toolchains/${TOOLCHAIN_NAME}.xctoolchain"
-SYMBOLS_PACKAGE="${SRC_DIR}/${SYM_ARCHIVE}"
+SYMBOLS_PACKAGE="${RESULT_DIR}/${SYM_ARCHIVE}"
 DRY_RUN="${DRY_RUN}"
 
 ./utils/build-script ${DRY_RUN} --preset="${SWIFT_PACKAGE}" \


### PR DESCRIPTION
This prevents the results from cluttering up the repo root directory (where the results used to go).

I decided to do this based on suggestions I received on: https://github.com/apple/swift/pull/16958