### PR TITLE
Allow Copyable Types To Elide Ownership Conventions

### DIFF
--- a/include/swift/AST/Types.h
+++ b/include/swift/AST/Types.h
@@ -2652,6 +2652,10 @@ public:
     /// Whether the parameter is marked 'owned'
     bool isOwned() const { return Flags.isOwned(); }
 
+    ValueOwnership getValueOwnership() const {
+      return Flags.getValueOwnership();
+    }
+
     bool operator==(Param const &b) const {
       return Label == b.Label && getType()->isEqual(b.getType()) &&
              Flags == b.Flags;

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -396,10 +396,6 @@ swift::matchWitness(
     // Check that the mutating bit is ok.
     if (checkMutating(funcReq, funcWitness, funcWitness))
       return RequirementMatch(witness, MatchKind::MutatingConflict);
-    if (funcWitness->isNonMutating() && funcReq->isConsuming())
-      return RequirementMatch(witness, MatchKind::NonMutatingConflict);
-    if (funcWitness->isConsuming() && !funcReq->isConsuming())
-      return RequirementMatch(witness, MatchKind::ConsumingConflict);
 
     // If the requirement is rethrows, the witness must either be
     // rethrows or be non-throwing.
@@ -534,9 +530,6 @@ swift::matchWitness(
       // Variadic bits must match.
       // FIXME: Specialize the match failure kind
       if (reqParams[i].isVariadic() != witnessParams[i].isVariadic())
-        return RequirementMatch(witness, MatchKind::TypeConflict, witnessType);
-
-      if (reqParams[i].isShared() != witnessParams[i].isShared())
         return RequirementMatch(witness, MatchKind::TypeConflict, witnessType);
 
       if (reqParams[i].isInOut() != witnessParams[i].isInOut())

--- a/test/SILGen/value_ownership.swift
+++ b/test/SILGen/value_ownership.swift
@@ -1,0 +1,44 @@
+// RUN: %target-swift-emit-silgen -enable-sil-ownership -emit-verbose-sil %s | %FileCheck %s
+
+// REQUIRES: plus_zero_runtime
+
+protocol OwnershipProto {
+  __consuming func elided(_ default: String, _ shared: __shared String, _ owned: __owned String)
+
+  __consuming func explicit(_ default: String, _ shared: __shared String, _ owned: __owned String)
+}
+
+struct Witness: OwnershipProto {
+  func elided(_ default: String, _ shared: String, _ owned: String) { }
+
+  __consuming func explicit(_ default: String, _ toShared: __shared String, _ toOwned: __owned String) { }
+}
+
+// Check the conventions of the witnesses
+
+// CHECK-LABEL: sil hidden @$S15value_ownership7WitnessV6elidedyySS_S2StF : $@convention(method) (@guaranteed String, @guaranteed String, @guaranteed String, Witness) -> () {
+// CHECK:       } // end sil function '$S15value_ownership7WitnessV6elidedyySS_S2StF'
+
+// CHECK-LABEL: sil hidden @$S15value_ownership7WitnessV8explicityySS_SShSSntF : $@convention(method) (@guaranteed String, @guaranteed String, @owned String, Witness) -> () {
+// CHECK:       } // end sil function '$S15value_ownership7WitnessV8explicityySS_SShSSntF'
+
+// Check the elided witness' thunk has the right conventions and borrows where necessary
+
+// CHECK-LABEL: @$S15value_ownership7WitnessVAA14OwnershipProtoA2aDP6elidedyySS_SShSSntFTW : $@convention(witness_method: OwnershipProto) (@guaranteed String, @guaranteed String, @owned String, @in_guaranteed Witness) -> ()
+// CHECK:       bb0([[DEFAULT2DEFAULT:%.*]] : @guaranteed $String, [[SHARED2DEFAULT:%.*]] : @guaranteed $String, [[OWNED2DEFAULT:%.*]] : @owned $String, [[WITNESS_VALUE:%.*]] : @trivial $*Witness):
+// CHECK:         [[LOAD_WITNESS:%.*]] = load [trivial] [[WITNESS_VALUE]] : $*Witness
+// CHECK:         [[WITNESS_FUNC:%.*]] = function_ref @$S15value_ownership7WitnessV6elidedyySS_S2StF
+// CHECK:         [[BORROWOWNED2DEFAULT:%.*]] = begin_borrow [[OWNED2DEFAULT]] : $String
+// CHECK:         apply [[WITNESS_FUNC]]([[DEFAULT2DEFAULT]], [[SHARED2DEFAULT]], [[BORROWOWNED2DEFAULT]], [[LOAD_WITNESS]])
+// CHECK:         end_borrow [[BORROWOWNED2DEFAULT]] from [[OWNED2DEFAULT]] : $String, $String
+// CHECK:       } // end sil function '$S15value_ownership7WitnessVAA14OwnershipProtoA2aDP6elidedyySS_SShSSntFTW'
+
+// Check that the explicit witness' thunk doesn't copy or borrow
+
+// CHECK-LABEL: @$S15value_ownership7WitnessVAA14OwnershipProtoA2aDP8explicityySS_SShSSntFTW : $@convention(witness_method: OwnershipProto) (@guaranteed String, @guaranteed String, @owned String, @in_guaranteed Witness) -> () {
+// CHECK:       bb0([[ARG0:%.*]] : @guaranteed $String, [[ARG1:%.*]] : @guaranteed $String, [[ARG2:%.*]] : @owned $String, [[WITNESS_VALUE:%.*]] : @trivial $*Witness):
+// CHECK-NEXT:    [[LOAD_WITNESS:%.*]] = load [trivial] [[WITNESS_VALUE]] : $*Witness
+// CHECK-NEXT:    // function_ref Witness.explicit(_:_:_:)
+// CHECK-NEXT:    [[WITNESS_FUNC:%.*]] = function_ref @$S15value_ownership7WitnessV8explicityySS_SShSSntF
+// CHECK-NEXT:    apply [[WITNESS_FUNC]]([[ARG0]], [[ARG1]], [[ARG2]], [[LOAD_WITNESS]])
+// CHECK:       } // end sil function '$S15value_ownership7WitnessVAA14OwnershipProtoA2aDP8explicityySS_SShSSntFTW'

--- a/test/Sema/immutability.swift
+++ b/test/Sema/immutability.swift
@@ -246,9 +246,9 @@ protocol MutatingTestProto {
   mutating
   func mutatingfunc()
   
-  func nonmutatingfunc()  // expected-note 2 {{protocol requires}}
+  func nonmutatingfunc() // expected-note {{protocol requires}}
   __consuming
-  func consuming_nonmutating_func()  // expected-note 2 {{protocol requires}}
+  func consuming_nonmutating_func() // expected-note {{protocol requires}}
 }
 
 class TestClass : MutatingTestProto {
@@ -281,18 +281,18 @@ struct TestStruct3 : MutatingTestProto {   // expected-error {{type 'TestStruct3
   func consuming_nonmutating_func() {} // expected-note {{candidate is marked 'mutating' but protocol does not allow it}}
 }
 
-struct TestStruct4 : MutatingTestProto { // expected-error {{type 'TestStruct4' does not conform to protocol 'MutatingTestProto'}}
+struct TestStruct4 : MutatingTestProto {
   mutating
   func mutatingfunc() {}  // Ok, can be mutating.
   func nonmutatingfunc() {}
-  nonmutating func consuming_nonmutating_func() {}  // expected-note {{candidate is marked 'nonmutating' but protocol does not allow it}}
+  nonmutating func consuming_nonmutating_func() {}
 }
 
-struct TestStruct5 : MutatingTestProto { // expected-error {{type 'TestStruct5' does not conform to protocol 'MutatingTestProto'}}
+struct TestStruct5 : MutatingTestProto {
   mutating
   func mutatingfunc() {}  // Ok, can be mutating.
   __consuming
-  func nonmutatingfunc() {} // expected-note {{candidate is marked '__consuming' but protocol does not allow it}}
+  func nonmutatingfunc() {}
   __consuming func consuming_nonmutating_func() {}
 }
 

--- a/test/decl/protocol/req/func.swift
+++ b/test/decl/protocol/req/func.swift
@@ -196,16 +196,26 @@ struct X6 : P6 { // expected-error{{type 'X6' does not conform to protocol 'P6'}
 }
 
 protocol P6Ownership {
-  func foo(_ x: __shared Int) // expected-note{{protocol requires function 'foo' with type '(__shared Int) -> ()'}}
-  func foo2(_ x: Int) // expected-note{{protocol requires function 'foo2' with type '(Int) -> ()'}}
-  func bar(x: Int)
-  func bar2(x: __owned Int)
+  func thunk__shared(_ x: __shared Int)
+  func mismatch__shared(_ x: Int)
+  func mismatch__owned(x: Int)
+  func thunk__owned__owned(x: __owned Int)
+
+  __consuming func inherits__consuming(x: Int)
+  func mismatch__consuming(x: Int)
+  __consuming func mismatch__consuming_mutating(x: Int) // expected-note {{protocol requires function 'mismatch__consuming_mutating(x:)' with type '(Int) -> ()'}}
+  mutating func mismatch__mutating_consuming(x: Int)
 }
 struct X6Ownership : P6Ownership { // expected-error{{type 'X6Ownership' does not conform to protocol 'P6Ownership'}}
-  func foo(_ x: Int) { } // expected-note{{candidate has non-matching type '(Int) -> ()'}}
-  func foo2(_ x: __shared Int) { } // expected-note{{candidate has non-matching type '(__shared Int) -> ()'}}
-  func bar(x: __owned Int) { } // no diagnostic
-  func bar2(x: Int) { } // no diagnostic
+  func thunk__shared(_ x: Int) { } // OK
+  func mismatch__shared(_ x: __shared Int) { } // OK
+  func mismatch__owned(x: __owned Int) { } // OK
+  func thunk__owned__owned(x: Int) { } // OK
+
+  func inherits__consuming(x: Int) { } // OK
+  __consuming func mismatch__consuming(x: Int) { } // OK
+  mutating func mismatch__consuming_mutating(x: Int) { } // expected-note {{candidate is marked 'mutating' but protocol does not allow it}}
+  __consuming func mismatch__mutating_consuming(x: Int) { } // OK - '__consuming' acts as a counterpart to 'nonmutating'
 }
 
 protocol P7 {


### PR DESCRIPTION
Allow witnesses to protocols in a copyable context to elide explicit
ownership conventions.  This allows clients like the standard library to
standardize on one ownership convention without an ABI or API breaking
change in 3rd party code. 

In the future, moveonly contexts must disallow this default behavior
else the witness thunks could silently transfer ownership.

rdar://40774922

```swift
protocol P {
  __consuming func implicit(x: __shared String)
  __consuming func explicit(x: __owned String)
  __consuming func mismatch(x: __shared String)
}

class C : P {
  // C.implicit(x:) takes self and x '@guaranteed' thru the witness thunk
  func implicit(x: String) {}
  // C.explicit(x:) takes self and x @owned with no convention changes
  __consuming func explicit(x: __owned String) {}
  // Would inherit __consuming, but x has been spelled __owned so the requirement match fails.
  func mismatch(x: __owned String) {}
}
```