### PR TITLE
[RemoteMirrors][4.2] Put a cache in front of getFieldTypeInfo to avoid repetitive scanning of the target's reflection infos.

### DIFF
--- a/include/swift/Reflection/TypeRefBuilder.h
+++ b/include/swift/Reflection/TypeRefBuilder.h
@@ -178,6 +178,11 @@ private:
   std::unordered_map<TypeRefID, const TypeRef *,
                      TypeRefID::Hash, TypeRefID::Equal> AssociatedTypeCache;
 
+  /// Cache for field info lookups.
+  std::unordered_map<std::string,
+                     std::pair<const FieldDescriptor *, const ReflectionInfo *>>
+                     FieldTypeInfoCache;
+
   TypeConverter TC;
   MetadataSourceBuilder MSB;
 

--- a/stdlib/public/Reflection/TypeRefBuilder.cpp
+++ b/stdlib/public/Reflection/TypeRefBuilder.cpp
@@ -50,20 +50,25 @@ TypeRefBuilder::getRemoteAddrOfTypeRefPointer(const void *pointer) {
 
 TypeRefBuilder::TypeRefBuilder() : TC(*this) {}
 
-/// Determine whether the given reflection protocol name matches.
-static bool reflectionNameMatches(Demangler &dem,
-                                  StringRef reflectionName,
-                                  StringRef searchName) {
+/// Normalize a mangled name so it can be matched with string equality.
+static std::string normalizeReflectionName(Demangler &dem, StringRef reflectionName) {
   reflectionName = dropSwiftManglingPrefix(reflectionName);
   
   // Remangle the reflection name to resolve symbolic references.
   if (auto node = dem.demangleType(reflectionName)) {
-    auto remangled = mangleNode(node);
-    return remangled == searchName;
+    return mangleNode(node);
   }
-  
-  // Fall back to string matching.
-  return reflectionName.equals(searchName);
+
+  // Fall back to the raw string.
+  return reflectionName;
+}
+
+/// Determine whether the given reflection protocol name matches.
+static bool reflectionNameMatches(Demangler &dem,
+                                  StringRef reflectionName,
+                                  StringRef searchName) {
+  auto normalized = normalizeReflectionName(dem, reflectionName);
+  return searchName.equals(normalized);
 }
 
 const TypeRef * TypeRefBuilder::
@@ -139,6 +144,12 @@ TypeRefBuilder::getFieldTypeInfo(const TypeRef *TR) {
   else
     return {};
 
+  // Try the cache.
+  auto Found = FieldTypeInfoCache.find(MangledName);
+  if (Found != FieldTypeInfoCache.end())
+    return Found->second;
+
+  // On failure, fill out the cache with everything we know about.
   std::vector<std::pair<std::string, const TypeRef *>> Fields;
   for (auto &Info : ReflectionInfos) {
     uintptr_t TypeRefOffset = Info.Field.SectionOffset
@@ -147,11 +158,15 @@ TypeRefBuilder::getFieldTypeInfo(const TypeRef *TR) {
       if (!FD.hasMangledTypeName())
         continue;
       auto CandidateMangledName = FD.getMangledTypeName(TypeRefOffset);
-      if (!reflectionNameMatches(Dem, CandidateMangledName, MangledName))
-        continue;
-      return {&FD, &Info};
+      auto NormalizedName = normalizeReflectionName(Dem, CandidateMangledName);
+      FieldTypeInfoCache[NormalizedName] = {&FD, &Info};
     }
   }
+
+  // We've filled the cache with everything we know about now. Try the cache again.
+  Found = FieldTypeInfoCache.find(MangledName);
+  if (Found != FieldTypeInfoCache.end())
+    return Found->second;
 
   return {nullptr, 0};
 }


### PR DESCRIPTION
Cherry pick #16996 onto 4.2 branch.

rdar://problem/40705238