### PR TITLE
@compilerEvaluable attribute and skeleton of checker

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -322,6 +322,9 @@ DECL_ATTR(differentiable, Differentiable,
           OnFunc | LongAttribute | NotSerialized,
           /* Not serialized */ 76)
 
+SIMPLE_DECL_ATTR(compilerEvaluable, CompilerEvaluable,
+                 OnFunc | OnConstructor, 77)
+
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS
 #undef SIMPLE_DECL_ATTR

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -323,7 +323,7 @@ DECL_ATTR(differentiable, Differentiable,
           /* Not serialized */ 76)
 
 SIMPLE_DECL_ATTR(compilerEvaluable, CompilerEvaluable,
-                 OnFunc | OnConstructor, 77)
+                 OnFunc | OnConstructor, /* Not serialized */ 77)
 
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2436,6 +2436,11 @@ ERROR(differentiable_attr_ambiguous_function_identifier,none,
 ERROR(differentiable_attr_forward_mode_unsupported,none,
       "forward-mode automatic differentiation is not supported yet", ())
 
+ERROR(compiler_evaluable_bad_context,none,
+      "@compilerEvaluable functions not allowed here", ())
+ERROR(compiler_evaluable_loop,none,
+      "loops not allowed in @compilerEvaluable functions", ())
+
 //------------------------------------------------------------------------------
 // Type Check Expressions
 //------------------------------------------------------------------------------

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -39,6 +39,8 @@ add_swift_library(swiftSema STATIC
   TypeCheckAvailability.cpp
   TypeCheckCaptures.cpp
   TypeCheckCircularity.cpp
+  # SWIFT_ENABLE_TENSORFLOW
+  TypeCheckCompilerEvaluable.cpp
   TypeCheckConstraints.cpp
   TypeCheckDecl.cpp
   TypeCheckError.cpp

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2582,17 +2582,14 @@ void AttributeChecker::visitCompilerEvaluableAttr(CompilerEvaluableAttr *attr) {
   // a struct instead").
   auto declContext = D->getDeclContext();
   switch (declContext->getContextKind()) {
+  case DeclContextKind::AbstractFunctionDecl:
+    // Nested functions are okay.
+    break;
   case DeclContextKind::FileUnit:
     // Top level functions are okay.
     break;
   case DeclContextKind::GenericTypeDecl:
     switch (cast<GenericTypeDecl>(declContext)->getKind()) {
-    case DeclKind::Constructor:
-    case DeclKind::Destructor:
-    case DeclKind::Func:
-    case DeclKind::Accessor:
-      // Functions are okay.
-      break;
     case DeclKind::Struct:
       // Structs are okay, if they are compiler-representable.
       // TODO(marcrasi): Check that it's compiler-representable.

--- a/lib/Sema/TypeCheckCompilerEvaluable.cpp
+++ b/lib/Sema/TypeCheckCompilerEvaluable.cpp
@@ -1,0 +1,70 @@
+//===--- TypeCheckCompilerEvaluable.cpp - Check compiler evaluability -----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// SWIFT_ENABLE_TENSORFLOW
+// Checks that function bodies follow rules for compiler evaluable functions.
+//
+//===----------------------------------------------------------------------===//
+
+#include "TypeChecker.h"
+#include "swift/AST/ASTWalker.h"
+#include "swift/AST/Attr.h"
+#include "swift/AST/Decl.h"
+
+#include "llvm/Support/Debug.h"
+
+using namespace swift;
+
+namespace {
+
+/// Checks that the body of a function is compiler evaluable.
+/// Currently a skeleton implementation that only rejects while loops.
+/// TODO(marcrasi): Fill in a real implementation.
+class CheckCompilerEvaluableBody : public ASTWalker {
+  TypeChecker &TC;
+  bool compilerEvaluable = true;
+
+ public:
+  CheckCompilerEvaluableBody(TypeChecker &TC) : TC(TC) {}
+
+  std::pair<bool, Stmt *> walkToStmtPre(Stmt *S) override {
+    if (S->getKind() == StmtKind::While) {
+      TC.diagnose(S->getStartLoc(), diag::compiler_evaluable_loop);
+      compilerEvaluable = false;
+      return {false, S};
+    }
+    return {true, S};
+  }
+
+  bool getCompilerEvaluable() const { return compilerEvaluable; }
+};
+
+}  // namespace
+
+/// If the function has a valid @compilerEvaluable attribute, checks that the
+/// function body follows all the rules for compiler evaluable functions.
+///
+/// The function body must already be type checked.
+void TypeChecker::checkFunctionBodyCompilerEvaluable(AbstractFunctionDecl *D) {
+  auto compilerEvaluableAttr =
+      D->getAttrs().getAttribute<CompilerEvaluableAttr>();
+  if (!compilerEvaluableAttr || !compilerEvaluableAttr->isValid()) return;
+
+  assert(D->getBodyKind() == AbstractFunctionDecl::BodyKind::TypeChecked &&
+         "cannot check @compilerEvaluable body that is not type checked");
+
+  CheckCompilerEvaluableBody Checker(*this);
+  D->getBody()->walk(Checker);
+  if (!Checker.getCompilerEvaluable()) {
+    compilerEvaluableAttr->setInvalid();
+  }
+}

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -6507,6 +6507,7 @@ public:
 
     // SWIFT_ENABLE_TENSORFLOW
     UNINTERESTING_ATTR(Differentiable)
+    UNINTERESTING_ATTR(CompilerEvaluable)
 
     // These can't appear on overridable declarations.
     UNINTERESTING_ATTR(Prefix)

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -538,6 +538,15 @@ static void typeCheckFunctionsAndExternalDecls(TypeChecker &TC) {
       TC.checkFunctionErrorHandling(fn);
     }
   }
+
+  // SWIFT_ENABLE_TENSORFLOW
+  // Check @compilerEvaluable function body correctness for all the functions
+  // defined in this file. We do this here, rather than in
+  // AttributeChecker::visitCompilerEvaluableAttr() because we need the function
+  // bodies to be type checked.
+  for (AbstractFunctionDecl *AFD : TC.definedFunctions) {
+    TC.checkFunctionBodyCompilerEvaluable(AFD);
+  }
 }
 
 void swift::typeCheckExternalDefinitions(SourceFile &SF) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2466,6 +2466,9 @@ public:
   void checkInitializerErrorHandling(Initializer *I, Expr *E);
   void checkEnumElementErrorHandling(EnumElementDecl *D);
 
+  // SWIFT_ENABLE_TENSORFLOW
+  void checkFunctionBodyCompilerEvaluable(AbstractFunctionDecl *D);
+
   void addExprForDiagnosis(Expr *E1, ExprAndConstraintSystem Result) {
     DiagnosedExprs[E1] = Result;
   }

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -88,7 +88,7 @@ struct S{}
 
 @#^KEYWORD_LAST^#
 
-// KEYWORD_LAST:                  Begin completions, 21 items
+// KEYWORD_LAST:                  Begin completions, 22 items
 // KEYWORD_LAST-NEXT:             Keyword/None:                       available[#Declaration Attribute#]; name=available{{$}}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       objc[#Declaration Attribute#]; name=objc{{$}}
 // SWIFT_ENABLE_TENSORFLOW
@@ -112,4 +112,5 @@ struct S{}
 // KEYWORD_LAST-NEXT:             Keyword/None:                       GKInspectable[#Declaration Attribute#]; name=GKInspectable{{$}}
 // SWIFT_ENABLE_TENSORFLOW
 // KEYWORD_LAST-NEXT:             Keyword/None:                       differentiable[#Declaration Attribute#]; name=differentiable
+// KEYWORD_LAST-NEXT:             Keyword/None:                       compilerEvaluable[#Declaration Attribute#]; name=compilerEvaluable
 // KEYWORD_LAST-NEXT:             End completions

--- a/test/IDE/complete_decl_attribute.swift
+++ b/test/IDE/complete_decl_attribute.swift
@@ -34,7 +34,7 @@
 func method(){}
 
 // SWIFT_ENABLE_TENSORFLOW
-// KEYWORD2:                  Begin completions, 10 items
+// KEYWORD2:                  Begin completions, 11 items
 // KEYWORD2-NEXT:             Keyword/None:                       available[#Func Attribute#]; name=available{{$}}
 // KEYWORD2-NEXT:             Keyword/None:                       objc[#Func Attribute#]; name=objc{{$}}
 // KEYWORD2-NEXT:             Keyword/None:                       noreturn[#Func Attribute#]; name=noreturn{{$}}
@@ -46,6 +46,7 @@ func method(){}
 // KEYWORD2-NEXT:             Keyword/None:                       discardableResult[#Func Attribute#]; name=discardableResult
 // SWIFT_ENABLE_TENSORFLOW
 // KEYWORD2-NEXT:             Keyword/None:                       differentiable[#Func Attribute#]; name=differentiable
+// KEYWORD2-NEXT:             Keyword/None:                       compilerEvaluable[#Func Attribute#]; name=compilerEvaluable
 // KEYWORD2-NEXT:             End completions
 
 @#^KEYWORD3^#

--- a/test/Sema/compiler_evaluable.swift
+++ b/test/Sema/compiler_evaluable.swift
@@ -1,0 +1,54 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol AProtocol {
+  @compilerEvaluable
+  func protocolFunc() // expected-error{{@compilerEvaluable functions not allowed here}}
+}
+
+extension AProtocol {
+  @compilerEvaluable
+  func extensionFunc() {} // expected-error{{@compilerEvaluable functions not allowed here}}
+}
+
+class AClass {
+  @compilerEvaluable
+  init() {} // expected-error{{@compilerEvaluable functions not allowed here}}
+
+  @compilerEvaluable
+  func classFunc() {} // expected-error{{@compilerEvaluable functions not allowed here}}
+}
+
+struct AStruct {
+  @compilerEvaluable
+  init() {}
+
+  @compilerEvaluable
+  func structFunc() {}
+
+  var structProperty: Int {
+    @compilerEvaluable
+    get {
+      return 42
+    }
+
+    @compilerEvaluable
+    set(prop) {}
+  }
+}
+
+func aFunction() {
+  @compilerEvaluable
+  func functionFunc() {}
+}
+
+@compilerEvaluable
+func funcTopLevel() {}
+
+@compilerEvaluable
+func funcWithLoop() -> Int {
+  var x = 1
+  while (x < 10) { // expected-error{{loops not allowed in @compilerEvaluable functions}}
+    x += 1
+  }
+  return x
+}


### PR DESCRIPTION
This adds a @compilerEvaluable attribute, and a skeleton of a checker (to keep
the change small and simple).

I plan to fill out the checker in future CLs.

It seems likely that we'll eventually change the name of @compilerEvaluable,
but it's unclear what the final name will be. @compilerEvaluable is unique
enough that it should be easy to change it with a global find-and-replace.

This has already been reviewed in Google's internal review tool, so I will just merge it once CI passes.