### PR TITLE
Outliner: fix a crash during pattern matching in case a SIL instruction is not the expected enum instruction.

### DIFF
--- a/lib/SILOptimizer/Transforms/Outliner.cpp
+++ b/lib/SILOptimizer/Transforms/Outliner.cpp
@@ -453,9 +453,10 @@ static bool matchSwitch(SwitchInfo &SI, SILInstruction *Inst,
   // %38 = enum $Optional<NSString>, #Optional.some!enumelt.1, %36 : $NSString
   ADVANCE_ITERATOR_OR_RETURN_FALSE(It);
   auto *SomeEnum = dyn_cast<EnumInst>(It);
+  if (!SomeEnum || !SomeEnum->hasOperand() || SomeEnum->getOperand() != SomeBBArg)
+    return false;
   size_t numSomeEnumUses = std::distance(SomeEnum->use_begin(), SomeEnum->use_end());
-  if (!SomeEnum || !SomeEnum->hasOperand() || SomeEnum->getOperand() != SomeBBArg
-      || numSomeEnumUses > 2)
+  if (numSomeEnumUses > 2)
     return false;
 
   // %39 = metatype $@thin String.Type

--- a/test/SILOptimizer/outliner.swift
+++ b/test/SILOptimizer/outliner.swift
@@ -165,3 +165,12 @@ func dontCrash3() -> String? {
   return bundle.path(forResource: resource, ofType: "png")
       ?? bundle.path(forResource: resource, ofType: "apng")
 }
+
+extension Operation {
+  func dontCrash4() {
+    if completionBlock != nil {
+      completionBlock = { }
+    }
+  }
+}
+


### PR DESCRIPTION
SR-7870
rdar://problem/40810341
