### PR TITLE
Platform: MSVCRT provides POSIX.fcntl

### DIFF
--- a/stdlib/public/Platform/ucrt.modulemap
+++ b/stdlib/public/Platform/ucrt.modulemap
@@ -78,6 +78,11 @@ module ucrt [system] {
     }
 
     module POSIX {
+      module fcntl {
+        header "fcntl.h"
+        export *
+      }
+
       module sys {
         export *
 


### PR DESCRIPTION
Add the missing module declaration for the POSIX interfaces.  This is
needed to access the permission mode macros.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
