### PR TITLE
Documentation: improve instructions for Windows cross compiling

### DIFF
--- a/docs/WindowsCrossCompile.md
+++ b/docs/WindowsCrossCompile.md
@@ -17,11 +17,11 @@ export VCToolsInstallDir=".../Microsoft Visual Studio/2017/Community"
 ```
 
 ## 2. Set up the `visualc` and `ucrt` modules
-The `visualc.modulemap` located at
-`swift/stdlib/public/Platform/visualc.modulemap` needs to be copied into
-`${VCToolsInstallDir}/include`. The `ucrt.modulemap` located at
+The `ucrt.modulemap` located at
 `swift/stdlib/public/Platform/ucrt.modulemap` needs to be copied into
-`${UniversalCRTSdkDir}/Include/${UCRTVersion}/ucrt`.
+`${UniversalCRTSdkDir}/Include/${UCRTVersion}/ucrt`. The `visualc.modulemap`
+located at `swift/stdlib/public/Platform/visualc.modulemap` needs to be copied
+into `${VCToolsInstallDir}/include`.
 
 ## 3. Configure the runtime to be built with the just built `clang`
 Ensure that we use the tools from the just built LLVM and `clang` tools to 

--- a/docs/WindowsCrossCompile.md
+++ b/docs/WindowsCrossCompile.md
@@ -39,10 +39,10 @@ Additionally, the ICU headers and libraries need to be provided for the build.
 -DCMAKE_AR=<path to llvm-ar>,\
 -DCMAKE_RANLIB=<path to llvm-ranlib>,\
 -DSWIFT_SDKS=WINDOWS,\
--DSWIFT_WINDOWS_ICU_I18N_INCLUDE=<path to ICU i18n includes>,\
--DSWIFT_WINDOWS_ICU_UC_INCLUDE=<path to ICU UC includes>,\
--DSWIFT_WINDOWS_ICU_I18N=<path to ICU i18n lib>,\
--DSWIFT_WINDOWS_ICU_UC=<path to ICU UC lib>
+-DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=<path to ICU i18n includes>,\
+-DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=<path to ICU UC includes>,\
+-DSWIFT_WINDOWS_x86_64_ICU_I18N=<path to ICU i18n lib>,\
+-DSWIFT_WINDOWS_x86_64_ICU_UC=<path to ICU UC lib>
 ```
 
 #### Linux

--- a/docs/WindowsCrossCompile.md
+++ b/docs/WindowsCrossCompile.md
@@ -32,13 +32,34 @@ build the static libraries. Note that cross-compiling will require the use of
 `lld`. Ensure that `lld-link.exe` is available to clang via your path.
 Additionally, the ICU headers and libraries need to be provided for the build.
 
+#### macOS
+
 ```bash
---extra-cmake-options=-DSWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER=FALSE, \
-  -DCMAKE_AR=<path to llvm-ar>, \
-  -DCMAKE_RANLIB=<path to llvm-ranlib>, \
-  -DSWIFT_SDKS=WINDOWS, \
-  -DSWIFT_WINDOWS_ICU_I18N_INCLUDE=<path to ICU i18n includes>, \
-  -DSWIFT_WINDOWS_ICU_UC_INCLUDE=<path to ICU UC includes>, \
-  -DSWIFT_WINDOWS_ICU_I18N=<path to ICU i18n lib>, \
-  -DSWIFT_WINDOWS_ICU_UC=<path to ICU UC lib>
+--extra-cmake-options=-DSWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER=FALSE,\
+-DCMAKE_AR=<path to llvm-ar>,\
+-DCMAKE_RANLIB=<path to llvm-ranlib>,\
+-DSWIFT_SDKS=WINDOWS,\
+-DSWIFT_WINDOWS_ICU_I18N_INCLUDE=<path to ICU i18n includes>,\
+-DSWIFT_WINDOWS_ICU_UC_INCLUDE=<path to ICU UC includes>,\
+-DSWIFT_WINDOWS_ICU_I18N=<path to ICU i18n lib>,\
+-DSWIFT_WINDOWS_ICU_UC=<path to ICU UC lib>
 ```
+
+#### Linux
+
+For Linux, there are a few issues that require slightly different cmake options.
+
+```bash
+--extra-cmake-options=-DSWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER=FALSE,\
+-DCMAKE_AR=<path to llvm-ar>,\
+-DCMAKE_RANLIB=<path to llvm-ranlib>,\
+-DSWIFT_SDKS='LINUX;WINDOWS',\
+-DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=<path to ICU i18n includes>,\
+-DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=<path to ICU UC includes>,\
+-DSWIFT_WINDOWS_x86_64_ICU_I18N=<path to ICU i18n lib>,\
+-DSWIFT_WINDOWS_x86_64_ICU_UC=<path to ICU UC lib>
+```
+
+## 4. Build the Swift runtime and standard library with `ninja`
+From the build directory, you can build the Swift runtime and standard library
+for Windows using `ninja swiftCore-windows-x86_64`.

--- a/docs/WindowsCrossCompile.md
+++ b/docs/WindowsCrossCompile.md
@@ -47,7 +47,8 @@ Additionally, the ICU headers and libraries need to be provided for the build.
 
 #### Linux
 
-For Linux, there are a few issues that require slightly different cmake options.
+For Linux, you will also need to build the Linux SDK with the cmake options
+below.
 
 ```bash
 --extra-cmake-options=-DSWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER=FALSE,\


### PR DESCRIPTION
<!-- What's in this pull request? -->
I wanted to help clarify and improve the instructions for cross compiling for windows. On Linux, the cmake options were not correct so I added the correct options. Also, the cmake options should be comma separated with no spaces between options.
