### PR TITLE
[Sema] Correctly reject throwing apply expressions in lazy property initializers

### DIFF
--- a/lib/Sema/TypeCheckError.cpp
+++ b/lib/Sema/TypeCheckError.cpp
@@ -1411,7 +1411,8 @@ private:
 
     // HACK: functions can get queued multiple times in
     // definedFunctions, so be sure to be idempotent.
-    if (!E->isThrowsSet()) {
+    if (!E->isThrowsSet() &&
+        classification.getResult() != ThrowingKind::Invalid) {
       E->setThrows(classification.getResult() == ThrowingKind::RethrowingOnly ||
                    classification.getResult() == ThrowingKind::Throws);
     }
@@ -1485,6 +1486,9 @@ private:
       Flags.set(ContextFlags::HasAnyThrowSite);
       if (requiresTry) Flags.set(ContextFlags::HasTryThrowSite);
 
+      // We set the throwing bit of an apply expr after performing this
+      // analysis, so ensure we don't emit duplicate diagnostics for functions
+      // that have been queued multiple times.
       if (auto expr = E.dyn_cast<Expr*>())
         if (auto apply = dyn_cast<ApplyExpr>(expr))
           if (apply->isThrowsSet())

--- a/test/Parse/errors.swift
+++ b/test/Parse/errors.swift
@@ -86,20 +86,6 @@ func testAutoclosures() throws {
   takesThrowingAutoclosure(genNoError())
 }
 
-struct IllegalContext {
-  var x: Int = genError() // expected-error {{call can throw, but errors cannot be thrown out of a property initializer}}
-
-  func foo(_ x: Int = genError()) {} // expected-error {{call can throw, but errors cannot be thrown out of a default argument}}
-
-  func catcher() throws {
-    do {
-      _ = try genError()
-    } catch MSV.CarriesInt(genError()) { // expected-error {{call can throw, but errors cannot be thrown out of a catch pattern}}
-    } catch MSV.CarriesInt(let i) where i == genError() { // expected-error {{call can throw, but errors cannot be thrown out of a catch guard expression}}
-    }
-  }
-}
-
 func illformed() throws {
     do {
       _ = try genError()

--- a/test/decl/func/throwing_functions.swift
+++ b/test/decl/func/throwing_functions.swift
@@ -162,7 +162,91 @@ enum MSV : Error {
 func genError() throws -> Int { throw MSV.Foo }
 
 struct IllegalContext {
-  var x: Int = genError() // expected-error {{call can throw, but errors cannot be thrown out of a property initializer}}
+  var x1: Int = genError() // expected-error {{call can throw, but errors cannot be thrown out of a property initializer}}
+
+  let x2 = genError() // expected-error {{call can throw, but errors cannot be thrown out of a property initializer}}
+
+  var x3 = try genError() // expected-error {{call can throw, but errors cannot be thrown out of a property initializer}}
+
+  let x4: Int = try genError() // expected-error {{call can throw, but errors cannot be thrown out of a property initializer}}
+
+  var x5 = B() // expected-error {{call can throw, but errors cannot be thrown out of a property initializer}}
+
+  var x6 = try B() // expected-error {{call can throw, but errors cannot be thrown out of a property initializer}}
+
+  var x7 = { // expected-error {{call can throw, but errors cannot be thrown out of a property initializer}}
+    return try genError()
+  }()
+
+  var x8: Int = {
+    do {
+      return genError() // expected-error {{call can throw but is not marked with 'try'}}
+      // expected-note@-1 {{did you mean to use 'try'?}}
+      // expected-note@-2 {{did you mean to handle error as optional value?}}
+      // expected-note@-3 {{did you mean to disable error propagation?}}
+    } catch {
+      return 0
+    }
+  }()
+
+  var x9: Int = {
+    do {
+      return try genError()
+    } catch {
+      return 0
+    }
+  }()
+
+  var x10: B = {
+    do {
+      return try B()
+    } catch {
+      return B(foo: 0)
+    }
+  }()
+
+  lazy var y1: Int = genError() // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}}
+
+  lazy var y2 = genError() // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}}
+
+  lazy var y3 = try genError() // expected-error {{errors thrown from here are not handled}}
+
+  lazy var y4: Int = try genError() // expected-error {{errors thrown from here are not handled}}
+
+  lazy var y5 = B() // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}}
+
+  lazy var y6 = try B() // expected-error {{errors thrown from here are not handled}}
+
+  lazy var y7 = { // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}}
+    return try genError()
+  }()
+
+  lazy var y8: Int = {
+    do {
+      return genError() // expected-error {{call can throw but is not marked with 'try'}}
+      // expected-note@-1 {{did you mean to use 'try'?}}
+      // expected-note@-2 {{did you mean to handle error as optional value?}}
+      // expected-note@-3 {{did you mean to disable error propagation?}}
+    } catch {
+      return 0
+    }
+  }()
+
+  lazy var y9: Int = {
+    do {
+      return try genError()
+    } catch {
+      return 0
+    }
+  }()
+
+  lazy var y10: B = {
+    do {
+      return try B()
+    } catch {
+      return B(foo: 0)
+    }
+  }()
 
   func foo(_ x: Int = genError()) {} // expected-error {{call can throw, but errors cannot be thrown out of a default argument}}
 

--- a/test/decl/func/throwing_functions.swift
+++ b/test/decl/func/throwing_functions.swift
@@ -205,19 +205,19 @@ struct IllegalContext {
     }
   }()
 
-  lazy var y1: Int = genError() // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}}
+  lazy var y1: Int = genError() // expected-error {{call can throw, but errors cannot be thrown out of a property initializer}}
 
-  lazy var y2 = genError() // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}}
+  lazy var y2 = genError() // expected-error {{call can throw, but errors cannot be thrown out of a property initializer}}
 
-  lazy var y3 = try genError() // expected-error {{errors thrown from here are not handled}}
+  lazy var y3 = try genError() // expected-error {{call can throw, but errors cannot be thrown out of a property initializer}}
 
-  lazy var y4: Int = try genError() // expected-error {{errors thrown from here are not handled}}
+  lazy var y4: Int = try genError() // expected-error {{call can throw, but errors cannot be thrown out of a property initializer}}
 
-  lazy var y5 = B() // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}}
+  lazy var y5 = B() // expected-error {{call can throw, but errors cannot be thrown out of a property initializer}}
 
-  lazy var y6 = try B() // expected-error {{errors thrown from here are not handled}}
+  lazy var y6 = try B() // expected-error {{call can throw, but errors cannot be thrown out of a property initializer}}
 
-  lazy var y7 = { // expected-error {{call can throw, but it is not marked with 'try' and the error is not handled}}
+  lazy var y7 = { // expected-error {{call can throw, but errors cannot be thrown out of a property initializer}}
     return try genError()
   }()
 


### PR DESCRIPTION
Currently we set the 'throws' bit of an `ApplyExpr` to `false` if we cannot determine whether or not it throws (such as when it hasn't been type checked yet). This led to us doing so within lazy property initialisers, which don't have a solution applied to them until they are transplanted into the synthesised getter – therefore leading to us accepting invalid code that throws within within the initialiser.

This PR changes the logic to not set the 'throws' bit if we cannot determine whether or not an `ApplyExpr` throws (therefore resulting in us correctly setting it within the synthesised getter for a lazy property).

In addition, this PR adds a small hack to the error handling analysis in order to treat the synthesised getter of a lazy property as being a property initialiser context in order to produce better diagnostics. The only time we should be diagnosing in the getter should be in the initialiser expression, so I think it's okay – but ideally we should handle it some other way (I just don't know what that way would be). We can't apply a solution to the initialiser while it's still a part of the var's original pattern binding decl (and then apply the analysis on that), as that caused issues with double type checking that were resolved in d8234bace67a7af46e1b897fff1c2d5a7b32d1c5.

Resolves [SR-7862](https://bugs.swift.org/browse/SR-7862).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
