### PR TITLE
Rename @effects to @_effects

### DIFF
--- a/docs/HighLevelSILOptimizations.rst
+++ b/docs/HighLevelSILOptimizations.rst
@@ -313,19 +313,19 @@ Dictionary
 ~~~~~~~~~~
 TBD.
 
-@effects attribute
+@_effects attribute
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The @effects attribute describes how a function affects "the state of the world".
+The @_effects attribute describes how a function affects "the state of the world".
 More practically how the optimizer can modify the program based on information
 that is provided by the attribute.
 
 Usage:
 
-  @effects(readonly) func foo() { .. }
+  @_effects(readonly) func foo() { .. }
 
 
-The @effects attribute supports the following tags:
+The @_effects attribute supports the following tags:
 
 readnone
 
@@ -363,13 +363,13 @@ releasenone
       }
     }
 
-    @effects(releasenone)
+    @_effects(releasenone)
     func validReleaseNoneFunction(x: Int) -> Int {
       global.x = 5
       return x + 2
     }
 
-    @effects(releasenone)
+    @_effects(releasenone)
     func validReleaseNoneFunction(x: Int) -> Int {
       var notExternallyVisibleObject = SomeObject()
       return x +  notExternallyVisibleObject.x

--- a/docs/proposals/OptimizerEffects.rst
+++ b/docs/proposals/OptimizerEffects.rst
@@ -96,7 +96,7 @@ don't have a more general term for "release", which refers to any
 release_value operation.
 
 When referring to unspecified state, I will use the syntax
-``@effects(no<effectname>)``. When referring to state reachable via an
+``@_effects(no<effectname>)``. When referring to state reachable via an
 argument, ``@no<effectname> arg``.
 
 Naturally, we also need a syntax for associating effects with
@@ -110,7 +110,7 @@ effects at a call site. For now, we assume the predicate only applies
 to unspecified state and that the bridged object is always self. That
 way we can denote predicated effects as @nonbridged_effects.
 
-In examples, @effects(argonly) means that there are no effects on
+In examples, @_effects(argonly) means that there are no effects on
 unspecified state.
 
 CoW Optimization Requirements
@@ -167,7 +167,7 @@ state.
 
   Note: In terms of low-level SIL attributes such a method will be marked:::
 
-    @effects(argonly)
+    @_effects(argonly)
     @selfeffects(make_unique)
     func makeUnique() {}
 
@@ -230,7 +230,7 @@ state.
 
   Note: In terms of low-level SIL attributes such a method will be marked:::
 
-    @effects(argonly)
+    @_effects(argonly)
     @selfeffects(preserve_unique, nowrite, nocapture, norelease,
                  projects_subobject)
     func getElement(_ index: Int) -> T {}
@@ -297,7 +297,7 @@ state.
 
   Note: In terms of low-level SIL attributes such a method will be marked:::
 
-    @effects(argonly)
+    @_effects(argonly)
     @selfeffects(preserve_unique, nowrite, nocapture, norelease,
                  projects_subobject_addr)
     func getElementAddr(_ index: Int) -> T {}
@@ -320,7 +320,7 @@ state.
 
   Note: In terms of low-level SIL attributes such a method will be marked:::
 
-    @effects(argonly)
+    @_effects(argonly)
     @selfeffects(preserve_unique, nocapture, norelease)
     func appendElementAssumingUnique(@norelease @nowrite elt: T) {}
 
@@ -356,7 +356,7 @@ state.
 
   Note: In terms of low-level SIL attributes such a method will be marked:::
 
-    @effects(argonly, T.release)
+    @_effects(argonly, T.release)
     @selfeffects(preserve_unique, nocapture)
     func setElement(@nowrite e: T, index: Int) {
     }
@@ -536,15 +536,15 @@ Mostly TBD.
 
 The optimizer can only take advantage of user-specified effects before
 they have been inlined. Consequently, the optimizer initially preserves
-calls to annotated @effects() functions. After optimizing for effects
+calls to annotated @_effects() functions. After optimizing for effects
 these functions can be inlined, dropping the effects information.
 
 Without special syntax, specifying a pure function would require::
 
-  @effects(argonly)
+  @_effects(argonly)
   func foo(@noread @nowrite arg)
 
-A shorthand, such as @effects(none) could easily be
+A shorthand, such as @_effects(none) could easily be
 introduced. Typically, this shouldn't be needed because the purity of
 a function can probably be deduced from its argument types given that
 it has no effect on unspecified state. i.e. If the function does not
@@ -576,7 +576,7 @@ example. But there are two situations to be concerned about:
 Solving this requires a system for polymorphic effects. Language
 support for polymorphic effects might look something like this::
 
-  @effects(T.release)
+  @_effects(T.release)
   func foo<T>(t: T) { ... }
 
 This would mean that foo's unspecified effects are bounded by the

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -269,7 +269,7 @@ CONTEXTUAL_DECL_ATTR(weak, ReferenceOwnership,
   DeclModifier |
   NotSerialized, 49)
 CONTEXTUAL_DECL_ATTR_ALIAS(unowned, ReferenceOwnership)
-DECL_ATTR(effects, Effects,
+DECL_ATTR(_effects, Effects,
   OnAbstractFunction |
   UserInaccessible,
   50)

--- a/include/swift/AST/AttrKind.h
+++ b/include/swift/AST/AttrKind.h
@@ -72,7 +72,7 @@ enum class InlineKind : uint8_t {
 enum : unsigned { NumInlineKindBits =
   countBitsUsed(static_cast<unsigned>(InlineKind::Last_InlineKind)) };
 
-/// This enum represents the possible values of the @effects attribute.
+/// This enum represents the possible values of the @_effects attribute.
 /// These values are ordered from the strongest guarantee to the weakest,
 /// so please do not reorder existing values.
 enum class EffectsKind : uint8_t {

--- a/include/swift/SIL/SILFunction.h
+++ b/include/swift/SIL/SILFunction.h
@@ -587,7 +587,7 @@ public:
   /// \return the function side effects information.
   EffectsKind getEffectsKind() const { return EffectsKindAttr; }
 
-  /// \return True if the function is annotated with the @effects attribute.
+  /// \return True if the function is annotated with the @_effects attribute.
   bool hasEffectsKind() const {
     return EffectsKindAttr != EffectsKind::Unspecified;
   }

--- a/include/swift/SILOptimizer/Analysis/SideEffectAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/SideEffectAnalysis.h
@@ -406,8 +406,8 @@ public:
   }
 
 protected:
-  /// Set the side-effects of a function, which has an @effects attribute.
-  /// Returns true if \a F has an @effects attribute which could be handled.
+  /// Set the side-effects of a function, which has an @_effects attribute.
+  /// Returns true if \a F has an @_effects attribute which could be handled.
   bool setDefinedEffects(SILFunction *F);
 
   /// Set the side-effects of a semantic call.

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2222,7 +2222,7 @@ Address IRGenModule::getAddrOfSILGlobalVariable(SILGlobalVariable *var,
 }
 
 /// Return True if the function \p f is a 'readonly' function. Checking
-/// for the SIL @effects(readonly) attribute is not enough because this
+/// for the SIL @_effects(readonly) attribute is not enough because this
 /// definition does not match the definition of the LLVM readonly function
 /// attribute. In this function we do the actual check.
 static bool isReadOnlyFunction(SILFunction *f) {
@@ -2235,11 +2235,11 @@ static bool isReadOnlyFunction(SILFunction *f) {
   auto Eff = f->getEffectsKind();
 
   // Swift's readonly does not automatically match LLVM's readonly.
-  // Swift SIL optimizer relies on @effects(readonly) to remove e.g.
+  // Swift SIL optimizer relies on @_effects(readonly) to remove e.g.
   // dead code remaining from initializers of strings or dictionaries
   // of variables that are not used. But those initializers are often
   // not really readonly in terms of LLVM IR. For example, the
-  // Dictionary.init() is marked as @effects(readonly) in Swift, but
+  // Dictionary.init() is marked as @_effects(readonly) in Swift, but
   // it does invoke reference-counting operations.
   if (Eff == EffectsKind::ReadOnly || Eff == EffectsKind::ReadNone) {
     // TODO: Analyze the body of function f and return true if it is

--- a/lib/SILOptimizer/Analysis/SideEffectAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/SideEffectAnalysis.cpp
@@ -334,7 +334,7 @@ bool FunctionSideEffects::setDefinedEffects(SILFunction *F) {
     case EffectsKind::ReadNone:
       return true;
     case EffectsKind::ReadOnly:
-      // @effects(readonly) is worthless if we have owned parameters, because
+      // @_effects(readonly) is worthless if we have owned parameters, because
       // the release inside the callee may call a deinit, which itself can do
       // anything.
       if (!F->hasOwnedParameters()) {
@@ -356,7 +356,7 @@ bool FunctionSideEffects::summarizeFunction(SILFunction *F) {
   if (!F->empty())
     ParamEffects.resize(F->getArguments().size());
 
-  // Handle @effects attributes
+  // Handle @_effects attributes
   if (setDefinedEffects(F)) {
     DEBUG(llvm::dbgs() << "  -- has defined effects " << F->getName() << '\n');
     return true;
@@ -463,7 +463,7 @@ bool FunctionSideEffects::summarizeCall(FullApplySite fullApply) {
   }
 
   if (SILFunction *SingleCallee = fullApply.getReferencedFunction()) {
-    // Does the function have any @effects?
+    // Does the function have any @_effects?
     if (setDefinedEffects(SingleCallee))
       return true;
   }

--- a/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
+++ b/lib/SILOptimizer/Transforms/PerformanceInliner.cpp
@@ -924,7 +924,7 @@ public:
 } // end anonymous namespace
 
 /// Create an inliner pass that does not inline functions that are marked with
-/// the @_semantics, @effects or global_init attributes.
+/// the @_semantics, @_effects or global_init attributes.
 SILTransform *swift::createEarlyInliner() {
   return new SILPerformanceInlinerPass(
     InlineSelection::NoSemanticsAndGlobalInit, "Early");
@@ -937,7 +937,7 @@ SILTransform *swift::createPerfInliner() {
 }
 
 /// Create an inliner pass that inlines all functions that are marked with
-/// the @_semantics, @effects or global_init attributes.
+/// the @_semantics, @_effects or global_init attributes.
 SILTransform *swift::createLateInliner() {
   return new SILPerformanceInlinerPass(InlineSelection::Everything, "Late");
 }

--- a/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
+++ b/lib/SILOptimizer/Utils/PerformanceInlinerUtils.cpp
@@ -669,7 +669,7 @@ SILFunction *swift::getEligibleFunction(FullApplySite AI,
   auto ModuleName = Callee->getModule().getSwiftModule()->getName().str();
   bool IsInStdlib = (ModuleName == STDLIB_NAME || ModuleName == SWIFT_ONONE_SUPPORT);
 
-  // Don't inline functions that are marked with the @_semantics or @effects
+  // Don't inline functions that are marked with the @_semantics or @_effects
   // attribute if the inliner is asked not to inline them.
   if (Callee->hasSemanticsAttrs() || Callee->hasEffectsKind()) {
     if (WhatToInline == InlineSelection::NoSemanticsAndGlobalInit) {

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -130,7 +130,7 @@ extension Character
   }
 
   @inlinable // FIXME(sil-serialize-all)
-  @effects(readonly)
+  @_effects(readonly)
   public init(_builtinUnicodeScalarLiteral value: Builtin.Int32) {
     self.init(Unicode.Scalar(_builtinUnicodeScalarLiteral: value))
   }
@@ -139,7 +139,7 @@ extension Character
   // integer constant in case of small character literals.
   @inlinable // FIXME(sil-serialize-all)
   @inline(__always)
-  @effects(readonly)
+  @_effects(readonly)
   public init(
     _builtinExtendedGraphemeClusterLiteral start: Builtin.RawPointer,
     utf8CodeUnitCount: Builtin.Word,
@@ -194,7 +194,7 @@ extension Character
   // integer constant in case of small character literals.
   @inlinable // FIXME(sil-serialize-all)
   @inline(__always)
-  @effects(readonly)
+  @_effects(readonly)
   public init(
     _builtinExtendedGraphemeClusterLiteral start: Builtin.RawPointer,
     utf16CodeUnitCount: Builtin.Word
@@ -483,7 +483,7 @@ extension Character: Hashable {
   ///
   /// - Parameter hasher: The hasher to use when combining the components
   ///   of this instance.
-  @effects(releasenone)
+  @_effects(releasenone)
   public func hash(into hasher: inout Hasher) {
     // FIXME(performance): constructing a temporary string is extremely
     // wasteful and inefficient.

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -798,7 +798,7 @@ extension Dictionary: ExpressibleByDictionaryLiteral {
   /// - Parameter elements: The key-value pairs that will make up the new
   ///   dictionary. Each key in `elements` must be unique.
   @inlinable // FIXME(sil-serialize-all)
-  @effects(readonly)
+  @_effects(readonly)
   public init(dictionaryLiteral elements: (Key, Value)...) {
     self.init(_nativeBuffer: _NativeDictionaryBuffer.fromArray(elements))
   }

--- a/stdlib/public/core/Hasher.swift
+++ b/stdlib/public/core/Hasher.swift
@@ -281,14 +281,14 @@ public struct Hasher {
 
   /// Initialize a new hasher.  The hasher uses a per-execution seed value that
   /// is set during process startup, usually from a high-quality random source.
-  @effects(releasenone)
+  @_effects(releasenone)
   public init() {
     self._core = Core(seed: Hasher._seed)
   }
 
   /// Initialize a new hasher using the specified seed value.
   @usableFromInline
-  @effects(releasenone)
+  @_effects(releasenone)
   internal init(_seed seed: (UInt64, UInt64)) {
     self._core = Core(seed: seed)
   }
@@ -331,37 +331,37 @@ public struct Hasher {
     value.hash(into: &self)
   }
 
-  @effects(releasenone)
+  @_effects(releasenone)
   @usableFromInline
   internal mutating func _combine(_ value: UInt) {
     _core.combine(value)
   }
 
-  @effects(releasenone)
+  @_effects(releasenone)
   @usableFromInline
   internal mutating func _combine(_ value: UInt64) {
     _core.combine(value)
   }
 
-  @effects(releasenone)
+  @_effects(releasenone)
   @usableFromInline
   internal mutating func _combine(_ value: UInt32) {
     _core.combine(value)
   }
 
-  @effects(releasenone)
+  @_effects(releasenone)
   @usableFromInline
   internal mutating func _combine(_ value: UInt16) {
     _core.combine(value)
   }
 
-  @effects(releasenone)
+  @_effects(releasenone)
   @usableFromInline
   internal mutating func _combine(_ value: UInt8) {
     _core.combine(value)
   }
 
-  @effects(releasenone)
+  @_effects(releasenone)
   @usableFromInline
   internal mutating func _combine(bytes value: UInt64, count: Int) {
     _core.combine(bytes: value, count: count)
@@ -369,7 +369,7 @@ public struct Hasher {
 
   /// Feed the contents of `buffer` into this hasher, mixing it into the hasher
   /// state.
-  @effects(releasenone)
+  @_effects(releasenone)
   public mutating func combine(bytes: UnsafeRawBufferPointer) {
     _core.combine(bytes: bytes)
   }
@@ -377,7 +377,7 @@ public struct Hasher {
   /// Finalize the hasher state and return the hash value.
   /// Finalizing invalidates the hasher; additional bits cannot be combined
   /// into it, and it cannot be finalized again.
-  @effects(releasenone)
+  @_effects(releasenone)
   @usableFromInline
   internal mutating func _finalize() -> Int {
     return Int(truncatingIfNeeded: _core.finalize())
@@ -391,7 +391,7 @@ public struct Hasher {
   ///
   /// Hash values are not guaranteed to be equal across different executions of
   /// your program. Do not save hash values to use during a future execution.
-  @effects(releasenone)
+  @_effects(releasenone)
   public __consuming func finalize() -> Int {
     var core = _core
     return Int(truncatingIfNeeded: core.finalize())
@@ -399,13 +399,13 @@ public struct Hasher {
 
   // Generate a seed value from the current state of this hasher.
   // FIXME(hasher): Remove
-  @effects(readnone)
+  @_effects(readnone)
   @usableFromInline
   internal func _generateSeed() -> (UInt64, UInt64) {
     return _core._generateSeed()
   }
 
-  @effects(readnone)
+  @_effects(readnone)
   @usableFromInline
   internal static func _hash(seed: (UInt64, UInt64), _ value: UInt64) -> Int {
     var core = RawCore(seed: seed)
@@ -414,7 +414,7 @@ public struct Hasher {
     return Int(truncatingIfNeeded: core.finalize(tailAndByteCount: tbc.value))
   }
 
-  @effects(readnone)
+  @_effects(readnone)
   @usableFromInline
   internal static func _hash(seed: (UInt64, UInt64), _ value: UInt) -> Int {
     var core = RawCore(seed: seed)
@@ -431,7 +431,7 @@ public struct Hasher {
     return Int(truncatingIfNeeded: core.finalize(tailAndByteCount: tbc.value))
   }
 
-  @effects(readnone)
+  @_effects(readnone)
   @usableFromInline
   internal static func _hash(
     seed: (UInt64, UInt64),
@@ -442,7 +442,7 @@ public struct Hasher {
     return Int(truncatingIfNeeded: core.finalize(tailAndByteCount: tbc.value))
   }
 
-  @effects(readnone)
+  @_effects(readnone)
   @usableFromInline
   internal static func _hash(
     seed: (UInt64, UInt64),

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -57,7 +57,7 @@ public class AnyKeyPath: Hashable, _AppendKeyPath {
   ///
   /// - Parameter hasher: The hasher to use when combining the components
   ///   of this instance.
-  @effects(releasenone)
+  @_effects(releasenone)
   final public func hash(into hasher: inout Hasher) {
     return withBuffer {
       var buffer = $0
@@ -594,7 +594,7 @@ internal enum KeyPathComponent: Hashable {
     }
   }
 
-  @effects(releasenone)
+  @_effects(releasenone)
   internal func hash(into hasher: inout Hasher) {
     var hasher = hasher
     func appendHashFromArgument(

--- a/stdlib/public/core/OutputStream.swift
+++ b/stdlib/public/core/OutputStream.swift
@@ -415,7 +415,7 @@ internal func _print_unlocked<T, TargetStream : TextOutputStream>(
 ///
 /// This function is forbidden from being inlined because when building the
 /// standard library inlining makes us drop the special semantics.
-@inline(never) @effects(readonly)
+@inline(never) @_effects(readonly)
 @usableFromInline
 internal func _toStringReadOnlyStreamable<
   T : TextOutputStreamable
@@ -425,7 +425,7 @@ internal func _toStringReadOnlyStreamable<
   return result
 }
 
-@inline(never) @effects(readonly)
+@inline(never) @_effects(readonly)
 @usableFromInline
 internal func _toStringReadOnlyPrintable<
   T : CustomStringConvertible

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -129,7 +129,7 @@ extension _SmallUTF8String {
 
   @inline(__always)
   @inlinable
-  @effects(readonly)
+  @_effects(readonly)
   public // @testable
   init?(_ codeUnits: UnsafeBufferPointer<UInt8>) {
 #if arch(i386) || arch(arm)

--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -196,7 +196,7 @@ public struct StaticString
   }
 
   @inlinable // FIXME(sil-serialize-all)
-  @effects(readonly)
+  @_effects(readonly)
   @_transparent
   public init(_builtinUnicodeScalarLiteral value: Builtin.Int32) {
     self = StaticString(unicodeScalar: value)
@@ -207,14 +207,14 @@ public struct StaticString
   /// Do not call this initializer directly. It may be used by the compiler
   /// when you initialize a static string with a Unicode scalar.
   @inlinable // FIXME(sil-serialize-all)
-  @effects(readonly)
+  @_effects(readonly)
   @_transparent
   public init(unicodeScalarLiteral value: StaticString) {
     self = value
   }
 
   @inlinable // FIXME(sil-serialize-all)
-  @effects(readonly)
+  @_effects(readonly)
   @_transparent
   public init(
     _builtinExtendedGraphemeClusterLiteral start: Builtin.RawPointer,
@@ -234,14 +234,14 @@ public struct StaticString
   /// Do not call this initializer directly. It may be used by the compiler
   /// when you initialize a static string using an extended grapheme cluster.
   @inlinable // FIXME(sil-serialize-all)
-  @effects(readonly)
+  @_effects(readonly)
   @_transparent
   public init(extendedGraphemeClusterLiteral value: StaticString) {
     self = value
   }
 
   @inlinable // FIXME(sil-serialize-all)
-  @effects(readonly)
+  @_effects(readonly)
   @_transparent
   public init(
     _builtinStringLiteral start: Builtin.RawPointer,
@@ -259,7 +259,7 @@ public struct StaticString
   /// Do not call this initializer directly. It may be used by the compiler
   /// when you initialize a static string using a string literal.
   @inlinable // FIXME(sil-serialize-all)
-  @effects(readonly)
+  @_effects(readonly)
   @_transparent
   public init(stringLiteral value: StaticString) {
     self = value

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -668,7 +668,7 @@ extension String {
 
 extension String : _ExpressibleByBuiltinUnicodeScalarLiteral {
   @inlinable // FIXME(sil-serialize-all)
-  @effects(readonly)
+  @_effects(readonly)
   public // @testable
   init(_builtinUnicodeScalarLiteral value: Builtin.Int32) {
     self.init(Unicode.Scalar(_value: UInt32(value)))
@@ -699,7 +699,7 @@ extension String : _ExpressibleByBuiltinUnicodeScalarLiteral {
 
 extension String : _ExpressibleByBuiltinExtendedGraphemeClusterLiteral {
   @inlinable
-  @effects(readonly)
+  @_effects(readonly)
   @_semantics("string.makeUTF8")
   public init(
     _builtinExtendedGraphemeClusterLiteral start: Builtin.RawPointer,
@@ -715,7 +715,7 @@ extension String : _ExpressibleByBuiltinExtendedGraphemeClusterLiteral {
 
 extension String : _ExpressibleByBuiltinUTF16StringLiteral {
   @inlinable
-  @effects(readonly)
+  @_effects(readonly)
   @_semantics("string.makeUTF16")
   public init(
     _builtinUTF16StringLiteral start: Builtin.RawPointer,
@@ -736,7 +736,7 @@ extension String : _ExpressibleByBuiltinUTF16StringLiteral {
 extension String : _ExpressibleByBuiltinStringLiteral {
   @inline(__always)
   @inlinable
-  @effects(readonly)
+  @_effects(readonly)
   @_semantics("string.makeUTF8")
   public init(
     _builtinStringLiteral start: Builtin.RawPointer,
@@ -922,7 +922,7 @@ extension String {
 
 extension String {
   @inlinable // FIXME(sil-serialize-all)
-  @effects(readonly)
+  @_effects(readonly)
   @_semantics("string.concat")
   public static func + (lhs: String, rhs: String) -> String {
     var lhs = lhs

--- a/stdlib/public/core/StringBridge.swift
+++ b/stdlib/public/core/StringBridge.swift
@@ -30,7 +30,7 @@ func _stdlib_binary_CFStringCreateCopy(
 }
 
 @inlinable // FIXME(sil-serialize-all)
-@effects(readonly)
+@_effects(readonly)
 public // @testable
 func _stdlib_binary_CFStringGetLength(
   _ source: _CocoaString

--- a/stdlib/public/core/StringComparison.swift
+++ b/stdlib/public/core/StringComparison.swift
@@ -33,7 +33,7 @@ extension _StringGuts {
 // HACK: This gets rid of some retains/releases that was slowing down the
 // memcmp fast path for comparing ascii strings. rdar://problem/37473470
 @inline(never) // @outlined
-@effects(readonly)
+@_effects(readonly)
 @usableFromInline // @opaque
 internal
 func _compareUnicode(
@@ -70,7 +70,7 @@ func _compareUnicode(
 }
 
 @inline(never) // @outlined
-@effects(readonly)
+@_effects(readonly)
 @usableFromInline // @opaque
 internal
 func _compareUnicode(

--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -228,7 +228,7 @@ extension _StringGuts {
   // FIXME(TODO: JIRA): HACK HACK HACK: Work around for ARC :-(
   //
   @usableFromInline
-  @effects(readonly)
+  @_effects(readonly)
   internal static func getCocoaLength(_unsafeBitPattern: UInt) -> Int {
     return _stdlib_binary_CFStringGetLength(
       Builtin.reinterpretCast(_unsafeBitPattern))
@@ -399,7 +399,7 @@ extension _StringGuts {
   @inlinable
   internal
   var _unmanagedASCIIView: _UnmanagedString<UInt8> {
-    @effects(readonly)
+    @_effects(readonly)
     get {
       _sanityCheck(_object.isContiguousASCII)
       if _object.isUnmanaged {
@@ -420,7 +420,7 @@ extension _StringGuts {
   @inlinable
   internal
   var _unmanagedUTF16View: _UnmanagedString<UTF16.CodeUnit> {
-    @effects(readonly)
+    @_effects(readonly)
     get {
       _sanityCheck(_object.isContiguousUTF16)
       if _object.isUnmanaged {
@@ -807,7 +807,7 @@ extension _StringGuts {
   @usableFromInline
   internal
   var _nonStoredCount: Int {
-    @effects(readonly)
+    @_effects(readonly)
     get {
       if _object.isSmall {
         return _object.smallUTF8Count

--- a/stdlib/public/core/StringGutsVisitor.swift
+++ b/stdlib/public/core/StringGutsVisitor.swift
@@ -54,7 +54,7 @@ extension String {
   }
 
   @usableFromInline
-  @effects(readonly)
+  @_effects(readonly)
   @inline(never) // @_outlined
   func _visitOpaque<Result>(
     range: (Range<Int>, performBoundsCheck: Bool)? = nil,
@@ -141,7 +141,7 @@ extension String {
   }
 
   @usableFromInline // @opaque
-  @effects(readonly)
+  @_effects(readonly)
   @inline(never)
   func _visitOpaque<T, Result>(
     range: (Range<Int>, performBoundsCheck: Bool)?,

--- a/stdlib/public/core/StringHashable.swift
+++ b/stdlib/public/core/StringHashable.swift
@@ -107,7 +107,7 @@ extension _SmallUTF8String {
 }
 
 extension _StringGuts {
-  @effects(releasenone) // FIXME: Is this valid in the opaque case?
+  @_effects(releasenone) // FIXME: Is this valid in the opaque case?
   @usableFromInline
   internal func hash(into hasher: inout Hasher) {
     if _isSmall {
@@ -127,7 +127,7 @@ extension _StringGuts {
     _unmanagedUTF16View.hash(into: &hasher)
   }
 
-  @effects(releasenone) // FIXME: Is this valid in the opaque case?
+  @_effects(releasenone) // FIXME: Is this valid in the opaque case?
   @usableFromInline
   internal func hash(_ range: Range<Int>, into hasher: inout Hasher) {
     if _isSmall {
@@ -147,7 +147,7 @@ extension _StringGuts {
     _unmanagedUTF16View[range].hash(into: &hasher)
   }
 
-  @effects(releasenone) // FIXME: Is this valid in the opaque case?
+  @_effects(releasenone) // FIXME: Is this valid in the opaque case?
   @usableFromInline
   internal func _rawHashValue(seed: (UInt64, UInt64)) -> Int {
     if _isSmall {
@@ -164,7 +164,7 @@ extension _StringGuts {
     return _unmanagedUTF16View._rawHashValue(seed: seed)
   }
 
-  @effects(releasenone) // FIXME: Is this valid in the opaque case?
+  @_effects(releasenone) // FIXME: Is this valid in the opaque case?
   @usableFromInline
   internal func _rawHashValue(
     _ range: Range<Int>,

--- a/stdlib/public/core/StringInterpolation.swift
+++ b/stdlib/public/core/StringInterpolation.swift
@@ -26,7 +26,7 @@ extension String : _ExpressibleByStringInterpolation {
   ///     print(message)
   ///     // Prints "If one cookie costs 2 dollars, 3 cookies cost 6 dollars."
   @inlinable
-  @effects(readonly)
+  @_effects(readonly)
   public init(stringInterpolation strings: String...) {
     self.init()
     for str in strings {

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -168,7 +168,7 @@ extension String {
     }
 
     @inline(never)
-    @effects(releasenone)
+    @_effects(releasenone)
     @usableFromInline
     internal func _nonASCIIIndex(atEncodedOffset n: Int) -> Index {
       _sanityCheck(!_guts._isASCIIOrSmallASCII)
@@ -233,7 +233,7 @@ extension String {
     }
 
     @inline(never)
-    @effects(releasenone)
+    @_effects(releasenone)
     @usableFromInline
     internal func _nonASCIIIndex(after i: Index) -> Index {
       _sanityCheck(!_guts._isASCIIOrSmallASCII)
@@ -293,7 +293,7 @@ extension String {
     }
 
     @inline(never)
-    @effects(releasenone)
+    @_effects(releasenone)
     @usableFromInline
     internal func _nonASCIIIndex(before i: Index) -> Index {
       _sanityCheck(!_guts._isASCIIOrSmallASCII)
@@ -326,7 +326,7 @@ extension String {
     }
 
     @inline(never)
-    @effects(releasenone)
+    @_effects(releasenone)
     @usableFromInline
     internal func _nonASCIIDistance(from i: Index, to j: Index) -> Int {
       let forwards = j >= i
@@ -375,7 +375,7 @@ extension String {
     }
 
     @inline(never)
-    @effects(releasenone)
+    @_effects(releasenone)
     @usableFromInline
     internal func _nonASCIISubscript(position: Index) -> UTF8.CodeUnit {
       _sanityCheck(!_guts._isASCIIOrSmallASCII)
@@ -648,7 +648,7 @@ extension String.UTF8View {
   }
 
   @inline(never)
-  @effects(releasenone)
+  @_effects(releasenone)
   @usableFromInline
   internal func _gutsNonASCIIUTF8Count(
     _ range: Range<Int>

--- a/test/SILGen/effectsattr.swift
+++ b/test/SILGen/effectsattr.swift
@@ -2,13 +2,13 @@
 
 
 //CHECK: [readonly] @func1
-@effects(readonly) @_silgen_name("func1") func func1() { }
+@_effects(readonly) @_silgen_name("func1") func func1() { }
 
 //CHECK: [readnone] @func2
-@effects(readnone) @_silgen_name("func2") func func2() { }
+@_effects(readnone) @_silgen_name("func2") func func2() { }
 
 //CHECK: [readwrite] @func3
-@effects(readwrite) @_silgen_name("func3") func func3() { }
+@_effects(readwrite) @_silgen_name("func3") func func3() { }
 
 //CHECK: [releasenone] @func4
-@effects(releasenone) @_silgen_name("func4") func func4() { }
+@_effects(releasenone) @_silgen_name("func4") func func4() { }

--- a/test/SILOptimizer/inline_semantics.sil
+++ b/test/SILOptimizer/inline_semantics.sil
@@ -89,7 +89,7 @@ bb0:
   return %1 : $Int32
 }
 
-// A function annotated with the @effects(readonly) attribute.
+// A function annotated with the @_effects(readonly) attribute.
 sil [readonly] @callee_func2 : $@convention(thin) () -> Int32 {
 bb0:
   %0 = integer_literal $Builtin.Int32, 3

--- a/test/SourceKit/InterfaceGen/gen_stdlib.swift
+++ b/test/SourceKit/InterfaceGen/gen_stdlib.swift
@@ -22,7 +22,7 @@ var x: Int
 
 // CHECK-MUTATING-ATTR: mutating func
 
-// CHECK-HIDE-ATTR-NOT: @effects
+// CHECK-HIDE-ATTR-NOT: @_effects
 // CHECK-HIDE-ATTR-NOT: @semantics
 // CHECK-HIDE-ATTR-NOT: @inline
 

--- a/test/stdlib/DictionaryUnchecked.swift
+++ b/test/stdlib/DictionaryUnchecked.swift
@@ -15,7 +15,7 @@ DictionaryUnchecked.test("noCseOnInit") {
   func createDict() -> Dictionary<Int, Bool> {
     // CSE should not be able to combine both Dictionary.init() calls.
     // This did happen and resulted in a crash because Dictionary.init()
-    // was defined with @effects(readnone).
+    // was defined with @_effects(readnone).
     // But this was wrong because it actually reads the array buffer (from
     // the literal).
     var Dict: Dictionary<Int, Bool> = [:]


### PR DESCRIPTION
`@effects` is too low a level, and not meant for general usage outside
the standard library. Therefore it deserves to be underscored like
other such attributes.