### PR TITLE
[4.2] SILCombine: Can't replace a alloc_ref_dynamic with an alloc_ref…

### DIFF
--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -1399,6 +1399,8 @@ visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI) {
   if (auto *MI = dyn_cast<MetatypeInst>(MDVal)) {
     auto &Mod = ARDI->getModule();
     auto SILInstanceTy = MI->getType().getMetatypeInstanceType(Mod);
+    if (!SILInstanceTy.getClassOrBoundGenericClass())
+      return nullptr;
 
     NewInst = Builder.createAllocRef(ARDI->getLoc(), SILInstanceTy,
                                      ARDI->isObjC(), false,
@@ -1420,6 +1422,8 @@ visitAllocRefDynamicInst(AllocRefDynamicInst *ARDI) {
     if (CCBI && CCBI->isExact() && ARDI->getParent() == CCBI->getSuccessBB()) {
       auto &Mod = ARDI->getModule();
       auto SILInstanceTy = CCBI->getCastType().getMetatypeInstanceType(Mod);
+      if (!SILInstanceTy.getClassOrBoundGenericClass())
+        return nullptr;
       NewInst = Builder.createAllocRef(ARDI->getLoc(), SILInstanceTy,
                                        ARDI->isObjC(), false,
                                        ARDI->getTailAllocatedTypes(),

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -2431,6 +2431,20 @@ sil @alloc_ref_dynamic_with_metatype : $() -> () {
   return %4 : $()
 }
 
+// CHECK: sil @alloc_ref_dynamic_with_metatype_genneric
+// CHECK: metatype
+// CHECK: upcast
+// CHECK: alloc_ref_dynamic
+// CHECK: return
+sil @alloc_ref_dynamic_with_metatype_genneric : $<T where T : B>() -> () {
+  %1 = metatype $@thick T.Type
+  %2 = upcast %1 : $@thick T.Type to $@thick B.Type
+  %3 = alloc_ref_dynamic %2 : $@thick B.Type, $B
+  strong_release %3 : $B
+  %4 = tuple()
+  return %4 : $()
+}
+
 // CHECK-LABEL: sil @alloc_ref_dynamic_with_upcast_metatype
 // CHECK: bb0
 // CHECK-NOT: alloc_ref_dynamic


### PR DESCRIPTION
… if the metatype is generic

rdar://40853265
SR-7896
