### PR TITLE
Merge pull request #17028 from shajrawi/loadable_tiny

### DIFF
--- a/lib/IRGen/LoadableByAddress.cpp
+++ b/lib/IRGen/LoadableByAddress.cpp
@@ -2649,7 +2649,7 @@ void LoadableByAddress::run() {
   for (auto &F : *getModule())
     runOnFunction(&F);
 
-  if (modFuncs.empty()) {
+  if (modFuncs.empty() && modApplies.empty()) {
     return;
   }
 

--- a/test/IRGen/big_types_corner_cases.swift
+++ b/test/IRGen/big_types_corner_cases.swift
@@ -254,3 +254,20 @@ class UseBigStructWithFunc {
     private func callMethod(ptr: ((BigStruct) -> Void)?) -> () {
     }
 }
+
+struct BiggerString {
+  var str: String
+  var double: Double
+}
+
+struct LoadableStructWithBiggerString {
+    public var a1: BiggerString
+    public var a2: [String]
+    public var a3: [String]
+}
+
+class ClassWithLoadableStructWithBiggerString {
+    public func f() -> LoadableStructWithBiggerString {
+        return LoadableStructWithBiggerString(a1: BiggerString(str:"", double:0.0), a2: [], a3: [])
+    }
+}

--- a/test/IRGen/big_types_corner_cases_tiny.swift
+++ b/test/IRGen/big_types_corner_cases_tiny.swift
@@ -1,0 +1,11 @@
+
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-large-loadable-types -primary-file %s %S/big_types_corner_cases.swift -emit-ir | %FileCheck %s --check-prefix=CHECK
+// REQUIRES: optimized_stdlib
+
+// DO NOT ADD ANY MORE CODE TO THIS FILE!
+
+// CHECK-LABEL: define internal void @globalinit
+// CHECK: [[ALLOC:%.*]] = alloca %T27big_types_corner_cases_tiny30LoadableStructWithBiggerStringV
+// CHECK: call swiftcc void {{.*}}(%T27big_types_corner_cases_tiny30LoadableStructWithBiggerStringV* noalias nocapture sret [[ALLOC]]
+let model = ClassWithLoadableStructWithBiggerString().f()
+


### PR DESCRIPTION
Assume we have a module with functions that keep their signatures as-is. And assume we have a method call callee for which we modified the return type to be indirect.
In that case we need to re-create the applies to said callee.

The large loadable types pass had a check that if we did not modify any function signatures, we can exit the module pass early to reduce compile time, that check breaks the situation described above.

This commit changes the early-exit check so that we can skip the rest of of the module pass if we did not change any function signatures AND we did not change any applies.

rdar://problem/40809999