### PR TITLE
[Driver] Use case-insensitive manner to check duplicate filenames of inputs.

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1121,9 +1121,12 @@ void Driver::buildInputs(const ToolChain &TC,
 
       if (Ty == file_types::TY_Swift) {
         StringRef Basename = llvm::sys::path::filename(Value);
-        if (!SourceFileNames.insert({Basename, Value}).second) {
+        // We check duplicate filenames case-insensitively, because
+        // the filesystem used may be case-insensitive.
+        StringRef Key = Basename.lower();
+        if (!SourceFileNames.insert({Key, Value}).second) {
           Diags.diagnose(SourceLoc(), diag::error_two_files_same_name,
-                         Basename, SourceFileNames[Basename], Value);
+                         Basename, SourceFileNames[Key], Value);
           Diags.diagnose(SourceLoc(), diag::note_explain_two_files_same_name);
         }
       }

--- a/test/Driver/driver-compile.swift
+++ b/test/Driver/driver-compile.swift
@@ -34,6 +34,8 @@
 // RUN: not %swiftc_driver -driver-print-jobs -c -target x86_64-apple-macosx10.9 %s %s 2>&1 | %FileCheck -check-prefix DUPLICATE-NAME %s
 // RUN: cp %s %t
 // RUN: not %swiftc_driver -driver-print-jobs -c -target x86_64-apple-macosx10.9 %s %t/driver-compile.swift 2>&1 | %FileCheck -check-prefix DUPLICATE-NAME %s
+// RUN: mv %t/driver-compile.swift %t/Driver-compile.swift
+// RUN: not %swiftc_driver -driver-print-jobs -c -target x86_64-apple-macosx10.9 %s %t/Driver-compile.swift 2>&1 | %FileCheck -check-prefix DUPLICATE-NAME %s
 
 // RUN: %swiftc_driver -driver-print-jobs -c -target x86_64-apple-macosx10.9 %s %S/../Inputs/empty.swift -module-name main -driver-filelist-threshold=0 2>&1 | %FileCheck -check-prefix=FILELIST %s
 
@@ -98,7 +100,7 @@
 // OBJ: -c{{ }}
 // OBJ: -o {{[^-]}}
 
-// DUPLICATE-NAME: error: filename "driver-compile.swift" used twice: '{{.*}}test/Driver/driver-compile.swift' and '{{.*}}driver-compile.swift'
+// DUPLICATE-NAME: error: filename "{{[Dd]}}river-compile.swift" used twice: '{{.*}}test/Driver/driver-compile.swift' and '{{.*[Dd]}}river-compile.swift'
 // DUPLICATE-NAME: note: filenames are used to distinguish private declarations with the same name
 
 // FILELIST: bin/swift


### PR DESCRIPTION
<!-- What's in this pull request? -->
This PR fixes a crash related to case sensitivity of filename checking.

When it comes to case-insensitive filesystems, e.g., Mac OS
Extended (Journaled), case-sensitive filename comparison is not
sufficient. Inputs with case-insensitively matched base filenames
cannot produce individual outputs under the same path. This patch
makes it more conservative by checking base filenames
case-insensitively.

A better solution would be checking the case sensitivity of the
output path (which may include system tmp) first, and then
deciding case-sensitive/-insensitive filename matching. However,
I am not aware of any C++ API providing such filesystem path
checking. Any ideas?

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7887](https://bugs.swift.org/browse/SR-7887).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
