### PR TITLE
[Typos] Fix some comment typos in Sema

### DIFF
--- a/lib/Sema/NameBinding.cpp
+++ b/lib/Sema/NameBinding.cpp
@@ -347,9 +347,10 @@ static void insertPrecedenceGroupDecl(NameBinder &binder, SourceFile &SF,
 /// performNameBinding - Once parsing is complete, this walks the AST to
 /// resolve names and do other top-level validation.
 ///
-/// At this parsing has been performed, but we still have UnresolvedDeclRefExpr
-/// nodes for unresolved value names, and we may have unresolved type names as
-/// well.  This handles import directives and forward references.
+/// At this point parsing has been performed, but we still have
+/// UnresolvedDeclRefExpr nodes for unresolved value names, and we may have
+/// unresolved type names as well. This handles import directives and forward
+/// references.
 void swift::performNameBinding(SourceFile &SF, unsigned StartElem) {
   SharedTimer timer("Name binding");
   // Make sure we skip adding the standard library imports if the

--- a/lib/Sema/TypeChecker.cpp
+++ b/lib/Sema/TypeChecker.cpp
@@ -585,7 +585,7 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
 
   // Make sure we have a type checker.
   //
-  // FIXME: We should never have a type checker here, but currently do when
+  // FIXME: We should never have a type checker here, but currently we do when
   // we're using immediate together with -enable-source-import.
   //
   // This possibility should be eliminated, since it results in duplicated
@@ -596,7 +596,7 @@ void swift::performTypeChecking(SourceFile &SF, TopLevelContext &TLC,
 
   // Make sure that name binding has been completed before doing any type
   // checking.
-    performNameBinding(SF, StartElem);
+  performNameBinding(SF, StartElem);
 
   {
     // NOTE: The type checker is scoped to be torn down before AST


### PR DESCRIPTION
While I was working on something, I came across some typos in some comments. I also found a function call indented too much. cc: @natecook1000 