### PR TITLE
Fix regression with inout in enum and subscript signatures [4.2]

### DIFF
--- a/lib/Parse/ParsePattern.cpp
+++ b/lib/Parse/ParsePattern.cpp
@@ -437,7 +437,7 @@ mapParsedParameters(Parser &parser,
                          Identifier argName, SourceLoc argNameLoc,
                          Identifier paramName, SourceLoc paramNameLoc)
   -> ParamDecl * {
-    auto param = new (ctx) ParamDecl(paramInfo.SpecifierKind,
+    auto param = new (ctx) ParamDecl(VarDecl::Specifier::Default,
                                      paramInfo.SpecifierLoc,
                                      argNameLoc, argName,
                                      paramNameLoc, paramName, Type(),

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -2850,7 +2850,7 @@ Type TypeResolver::resolveTupleType(TupleTypeRepr *repr,
     // `FunctionInput` so that e.g. ((foo: Int)) -> Int is considered a
     // tuple argument rather than a labeled Int argument.
     if (isImmediateFunctionInput) {
-      elementOptions -= TypeResolutionFlags::ImmediateFunctionInput;
+      elementOptions = withoutContext(elementOptions, true);
       elementOptions |= TypeResolutionFlags::FunctionInput;
     }
   } else {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -581,6 +581,7 @@ withoutContext(TypeResolutionOptions options, bool preserveSIL = false) {
   options -= TypeResolutionFlags::FunctionInput;
   options -= TypeResolutionFlags::VariadicFunctionInput;
   options -= TypeResolutionFlags::EnumCase;
+  options -= TypeResolutionFlags::SubscriptParameters;
   options -= TypeResolutionFlags::ImmediateOptionalTypeArgument;
   options -= TypeResolutionFlags::AllowIUO;
   if (!preserveSIL) options -= TypeResolutionFlags::SILType;

--- a/test/decl/enum/enumtest.swift
+++ b/test/decl/enum/enumtest.swift
@@ -322,4 +322,7 @@ func useSynthesizedMember() {
 enum Lens<T> {
   case foo(inout T) // expected-error {{'inout' may only be used on parameters}}
   case bar(inout T, Int) // expected-error {{'inout' may only be used on parameters}}
+
+  case baz((inout T) -> ()) // ok
+  case quux((inout T, inout T) -> ()) // ok
 }

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -331,4 +331,8 @@ struct InOutSubscripts {
 
   subscript(x3: (inout Int) -> ()) -> Int { return 0 } // ok
   subscript(x4: (inout Int, inout Int) -> ()) -> Int { return 0 } // ok
+
+  subscript(inout x5: Int) -> Int { return 0 }
+  // expected-error@-1 {{'inout' before a parameter name is not allowed, place it before the parameter type instead}}
+  // expected-error@-2 {{'inout' must not be used on subscript parameters}}
 }

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -319,3 +319,16 @@ struct SR2575 {
 }
 
 SR2575().subscript() // expected-error{{type 'SR2575' has no member 'subscript'}}
+
+// SR-7890
+
+struct InOutSubscripts {
+  subscript(x1: inout Int) -> Int { return 0 }
+  // expected-error@-1 {{'inout' must not be used on subscript parameters}}
+
+  subscript(x2: inout Int, y2: inout Int) -> Int { return 0 }
+  // expected-error@-1 2{{'inout' must not be used on subscript parameters}}
+
+  subscript(x3: (inout Int) -> ()) -> Int { return 0 } // ok
+  subscript(x4: (inout Int, inout Int) -> ()) -> Int { return 0 } // ok
+}


### PR DESCRIPTION
Fixes https://bugs.swift.org/browse/SR-7890.