### PR TITLE
Remove some usages of InOutType

### DIFF
--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2255,15 +2255,15 @@ public:
 
       // Variables must have materializable type, unless they are parameters,
       // in which case they must either have l-value type or be anonymous.
-      if (!var->getInterfaceType()->isMaterializable() || var->isInOut()) {
+      if (!var->getInterfaceType()->isMaterializable()) {
         if (!isa<ParamDecl>(var)) {
-          Out << "Non-parameter VarDecl has non-materializable type: ";
+          Out << "VarDecl has non-materializable type: ";
           var->getType().print(Out);
           Out << "\n";
           abort();
         }
 
-        if (!var->getInterfaceType()->is<InOutType>() && var->hasName()) {
+        if (!var->isInOut() && var->hasName()) {
           Out << "ParamDecl may only have non-materializable tuple type "
                  "when it is anonymous: ";
           var->getType().print(Out);
@@ -2340,8 +2340,7 @@ public:
 
       if (var->getAttrs().hasAttribute<ImplicitlyUnwrappedOptionalAttr>()) {
         auto varTy = var->getInterfaceType()
-                         ->getReferenceStorageReferent()
-                         ->getWithoutSpecifierType();
+                         ->getReferenceStorageReferent();
 
         // FIXME: Update to look for plain Optional once
         // ImplicitlyUnwrappedOptional is removed
@@ -2906,13 +2905,13 @@ public:
           abort();
         }
         const ParamDecl *selfParam = FD->getImplicitSelfDecl();
-        if (!selfParam->getInterfaceType()->is<InOutType>()) {
+        if (!selfParam->isInOut()) {
           Out << "mutating function does not have inout 'self'\n";
           abort();
         }
       } else {
         const ParamDecl *selfParam = FD->getImplicitSelfDecl();
-        if (selfParam && selfParam->getInterfaceType()->is<InOutType>()) {
+        if (selfParam && selfParam->isInOut()) {
           Out << "non-mutating function has inout 'self'\n";
           abort();
         }
@@ -2925,7 +2924,7 @@ public:
           abort();
         }
 
-        auto resultTy = FD->getResultInterfaceType()->getWithoutSpecifierType();
+        auto resultTy = FD->getResultInterfaceType();
 
         // FIXME: Update to look for plain Optional once
         // ImplicitlyUnwrappedOptional is removed

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1960,14 +1960,7 @@ bool ValueDecl::hasInterfaceType() const {
 
 Type ValueDecl::getInterfaceType() const {
   assert(hasInterfaceType() && "No interface type was set");
-  auto ty = TypeAndAccess.getPointer();
-  // FIXME(Remove InOutType): This grossness will go away when Sema is weaned
-  // off of InOutType.  Until then we should respect our parameter flags and
-  // return the type it expects.
-  if (auto *VD = dyn_cast<ParamDecl>(this)) {
-    ty = VD->isInOut() ? InOutType::get(ty) : ty;
-  }
-  return ty;
+  return TypeAndAccess.getPointer();
 }
 
 void ValueDecl::setInterfaceType(Type type) {
@@ -4072,13 +4065,9 @@ Type VarDecl::getType() const {
   if (!typeInContext) {
     const_cast<VarDecl *>(this)->typeInContext =
       getDeclContext()->mapTypeIntoContext(
-        getInterfaceType())->getInOutObjectType();
+        getInterfaceType());
   }
 
-  // FIXME(Remove InOutType): This grossness will go away when Sema is weaned
-  // off of InOutType.  Until then we should respect our parameter flags and
-  // return the type it expects.
-  if (isInOut()) return InOutType::get(typeInContext);
   return typeInContext;
 }
 
@@ -4380,7 +4369,7 @@ ParamDecl::ParamDecl(ParamDecl *PD, bool withTypes)
   : VarDecl(DeclKind::Param, /*IsStatic*/false, PD->getSpecifier(),
             /*IsCaptureList*/false, PD->getNameLoc(), PD->getName(),
             PD->hasType() && withTypes
-              ? PD->getType()->getInOutObjectType()
+              ? PD->getType()
               : Type(),
             PD->getDeclContext()),
     ArgumentName(PD->getArgumentName()),

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -439,7 +439,7 @@ makeEnumRawValueConstructor(ClangImporter::Implementation &Impl,
     return ctorDecl;
   
   auto selfRef = new (C) DeclRefExpr(selfDecl, DeclNameLoc(), /*implicit*/true);
-  selfRef->setType(LValueType::get(selfDecl->getType()->getInOutObjectType()));
+  selfRef->setType(LValueType::get(selfDecl->getType()));
   selfRef->propagateLValueAccessKind(AccessKind::Write);
 
   auto paramRef = new (C) DeclRefExpr(param, DeclNameLoc(),
@@ -1308,7 +1308,7 @@ createValueConstructor(ClangImporter::Implementation &Impl,
         // Construct left-hand side.
         Expr *lhs = new (context) DeclRefExpr(selfDecl, DeclNameLoc(),
                                               /*Implicit=*/true);
-        lhs->setType(LValueType::get(selfDecl->getType()->getInOutObjectType()));
+        lhs->setType(LValueType::get(selfDecl->getType()));
 
         auto semantics = (var->hasStorage()
                           ? AccessSemantics::DirectToStorage
@@ -1460,7 +1460,7 @@ static ConstructorDecl *createRawValueBridgingConstructor(
     // Construct left-hand side.
     Expr *lhs = new (ctx) DeclRefExpr(selfDecl, DeclNameLoc(),
                                       /*Implicit=*/true);
-    lhs->setType(LValueType::get(selfDecl->getType()->getInOutObjectType()));
+    lhs->setType(LValueType::get(selfDecl->getType()));
 
     lhs = new (ctx) MemberRefExpr(lhs, SourceLoc(), storedRawValue,
                                   DeclNameLoc(), /*Implicit=*/true,
@@ -5663,7 +5663,7 @@ Decl *SwiftDeclConverter::importGlobalAsInitializer(
   Type selfType = selfParam->getType();
   Type initType = FunctionType::get(selfType, fnType);
   result->setInitializerInterfaceType(initType);
-  Type selfMetaType = MetatypeType::get(selfType->getInOutObjectType());
+  Type selfMetaType = MetatypeType::get(selfType);
   Type allocType = FunctionType::get(selfMetaType, fnType);
   result->setInterfaceType(allocType);
   Impl.recordImplicitUnwrapForDecl(result,

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -2104,10 +2104,10 @@ public:
     setClangDeclKeywords(VD, Pairs, Builder);
     // Add a type annotation.
     Type VarType = getTypeOfMember(VD);
-    if (VD->getName() == Ctx.Id_self) {
-      // Strip inout from 'self'.  It is useful to show inout for function
-      // parameters.  But for 'self' it is just noise.
-      VarType = VarType->getInOutObjectType();
+    if (VD->getName() != Ctx.Id_self && VD->isInOut()) {
+      // It is useful to show inout for function parameters.
+      // But for 'self' it is just noise.
+      VarType = InOutType::get(VarType);
     }
     auto DynamicOrOptional =
         IsDynamicLookup || VD->getAttrs().hasAttribute<OptionalAttr>();

--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -72,6 +72,7 @@ DebugTypeInfo DebugTypeInfo::getLocalVariable(DeclContext *DC,
   if (Unwrap) {
     DeclType = DeclType->getInOutObjectType();
     RealType = RealType->getInOutObjectType();
+    // FIXME FIXME FIXME
   }
 
   // DynamicSelfType is also sugar as far as debug info is concerned.

--- a/lib/IRGen/DebugTypeInfo.cpp
+++ b/lib/IRGen/DebugTypeInfo.cpp
@@ -63,17 +63,11 @@ DebugTypeInfo DebugTypeInfo::getFromTypeInfo(DeclContext *DC,
 DebugTypeInfo DebugTypeInfo::getLocalVariable(DeclContext *DC,
                                               GenericEnvironment *GE,
                                               VarDecl *Decl, swift::Type Ty,
-                                              const TypeInfo &Info,
-                                              bool Unwrap) {
+                                              const TypeInfo &Info) {
 
   auto DeclType =
       Decl->hasInterfaceType() ? Decl->getInterfaceType() : Decl->getType();
   auto RealType = Ty;
-  if (Unwrap) {
-    DeclType = DeclType->getInOutObjectType();
-    RealType = RealType->getInOutObjectType();
-    // FIXME FIXME FIXME
-  }
 
   // DynamicSelfType is also sugar as far as debug info is concerned.
   auto Sugared = DeclType;

--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -62,8 +62,7 @@ public:
   /// Create type for a local variable.
   static DebugTypeInfo getLocalVariable(DeclContext *DeclCtx,
                                         GenericEnvironment *GE, VarDecl *Decl,
-                                        swift::Type Ty, const TypeInfo &Info,
-                                        bool Unwrap);
+                                        swift::Type Ty, const TypeInfo &Info);
   /// Create type for an artificial metadata variable.
   static DebugTypeInfo getMetadata(swift::Type Ty, llvm::Type *StorageTy,
                                    Size size, Alignment align);

--- a/lib/IRGen/DebugTypeInfo.h
+++ b/lib/IRGen/DebugTypeInfo.h
@@ -84,10 +84,6 @@ public:
   DeclContext *getDeclContext() const { return DeclCtx; }
   GenericEnvironment *getGenericEnvironment() const { return GenericEnv; }
 
-  void unwrapLValueOrInOutType() {
-    Type = Type->getWithoutSpecifierType().getPointer();
-  }
-
   // Determine whether this type is an Archetype itself.
   bool isArchetype() const {
     return Type->getWithoutSpecifierType()->is<ArchetypeType>();

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -3671,7 +3671,7 @@ void IRGenSILFunction::visitDebugValueInst(DebugValueInst *i) {
   if (VarDecl *Decl = i->getDecl()) {
     DbgTy = DebugTypeInfo::getLocalVariable(
         CurSILFn->getDeclContext(), CurSILFn->getGenericEnvironment(), Decl,
-        RealTy, getTypeInfo(SILVal->getType()), /*Unwrap=*/false);
+        RealTy, getTypeInfo(SILVal->getType()));
   } else if (i->getFunction()->isBare() &&
              !SILTy.hasArchetype() && !Name.empty()) {
     // Preliminary support for .sil debug information.
@@ -3713,16 +3713,10 @@ void IRGenSILFunction::visitDebugValueAddrInst(DebugValueAddrInst *i) {
   auto Addr = getLoweredAddress(SILVal).getAddress();
   SILType SILTy = SILVal->getType();
   auto RealType = SILTy.getASTType();
-  // Unwrap implicitly indirect types and types that are passed by
-  // reference only at the SIL level and below.
-  //
-  // FIXME: Should this check if the lowered SILType is address only
-  // instead? Otherwise optionals of archetypes etc will still have
-  // 'Unwrap' set to false.
-  bool Unwrap = VarInfo->Constant || SILTy.is<ArchetypeType>();
+
   auto DbgTy = DebugTypeInfo::getLocalVariable(
       CurSILFn->getDeclContext(), CurSILFn->getGenericEnvironment(), Decl,
-      RealType, getTypeInfo(SILVal->getType()), Unwrap);
+      RealType, getTypeInfo(SILVal->getType()));
   bindArchetypes(DbgTy.getType());
   if (!IGM.DebugInfo)
     return;
@@ -4011,7 +4005,7 @@ void IRGenSILFunction::emitDebugInfoForAllocStack(AllocStackInst *i,
   auto RealType = SILTy.getASTType();
   auto DbgTy = DebugTypeInfo::getLocalVariable(
       CurSILFn->getDeclContext(), CurSILFn->getGenericEnvironment(), Decl,
-      RealType, type, false);
+      RealType, type);
 
   // FIXME: This is working around the inverse special case in LLDB.
   if (DbgTy.isImplicitlyIndirect())
@@ -4208,7 +4202,7 @@ void IRGenSILFunction::visitAllocBoxInst(swift::AllocBoxInst *i) {
   auto RealType = SILTy.getASTType();
   auto DbgTy = DebugTypeInfo::getLocalVariable(
       CurSILFn->getDeclContext(), CurSILFn->getGenericEnvironment(), Decl,
-      RealType, type, /*Unwrap=*/false);
+      RealType, type);
 
   if (isInlinedGeneric(Decl, i->getDebugScope()))
     return;

--- a/lib/IRGen/MetadataRequest.cpp
+++ b/lib/IRGen/MetadataRequest.cpp
@@ -891,9 +891,7 @@ namespace {
     }
 
     llvm::Value *getFunctionParameterRef(AnyFunctionType::CanParam &param) {
-      auto type = param.getType();
-      if (param.getParameterFlags().isInOut())
-        type = type->getInOutObjectType()->getCanonicalType();
+      auto type = param.getPlainType()->getCanonicalType();
       return IGF.emitAbstractTypeMetadataRef(type);
     }
 

--- a/lib/SIL/AbstractionPattern.cpp
+++ b/lib/SIL/AbstractionPattern.cpp
@@ -73,7 +73,6 @@ AbstractionPattern TypeConverter::getAbstractionPattern(VarDecl *var) {
     genericSig = sig->getCanonicalSignature();
 
   CanType swiftType = var->getInterfaceType()
-                         ->getInOutObjectType()
                          ->getCanonicalType();
 
   if (auto clangDecl = var->getClangDecl()) {

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -686,10 +686,16 @@ private:
 
     unsigned origParamIndex = NextOrigParamIndex++;
 
+    bool isInout = false;
+    if (auto inoutType = dyn_cast<InOutType>(substType)) {
+      isInout = true;
+      substType = inoutType.getObjectType();
+      origType = origType.getWithoutSpecifierType();
+    }
+
     auto &substTL = M.Types.getTypeLowering(origType, substType);
     ParameterConvention convention;
-    if (isa<InOutType>(substType)) {
-      assert(origType.isTypeParameter() || origType.getAs<InOutType>());
+    if (isInout) {
       convention = ParameterConvention::Indirect_Inout;
     } else if (isFormallyPassedIndirectly(origType, substType, substTL)) {
       if (forSelf && rep == SILFunctionTypeRepresentation::WitnessMethod)

--- a/lib/SILGen/RValue.h
+++ b/lib/SILGen/RValue.h
@@ -205,11 +205,6 @@ public:
   /// True if this rvalue was emitted into context.
   bool isInContext() const & { return elementsToBeAdded == InContext; }
   
-  /// True if this represents an lvalue.
-  bool isLValue() const & {
-    return isa<InOutType>(type);
-  }
-  
   /// Add an element to the rvalue. The rvalue must not yet be complete.
   void addElement(RValue &&element) &;
   

--- a/lib/SILGen/SILGenConstructor.cpp
+++ b/lib/SILGen/SILGenConstructor.cpp
@@ -85,8 +85,8 @@ static void emitImplicitValueConstructor(SILGenFunction &SGF,
   // FIXME: Handle 'self' along with the other arguments.
   auto *paramList = ctor->getParameterList(1);
   auto *selfDecl = ctor->getImplicitSelfDecl();
-  auto selfTyCan = selfDecl->getType()->getInOutObjectType();
-  auto selfIfaceTyCan = selfDecl->getInterfaceType()->getInOutObjectType();
+  auto selfTyCan = selfDecl->getType();
+  auto selfIfaceTyCan = selfDecl->getInterfaceType();
   SILType selfTy = SGF.getLoweredType(selfTyCan);
 
   // Emit the indirect return argument, if any.
@@ -199,7 +199,7 @@ void SILGenFunction::emitValueConstructor(ConstructorDecl *ctor) {
 
   // Get the 'self' decl and type.
   VarDecl *selfDecl = ctor->getImplicitSelfDecl();
-  auto &lowering = getTypeLowering(selfDecl->getType()->getInOutObjectType());
+  auto &lowering = getTypeLowering(selfDecl->getType());
   SILType selfTy = lowering.getLoweredType();
   (void)selfTy;
   assert(!selfTy.getClassOrBoundGenericClass()
@@ -782,8 +782,7 @@ void SILGenFunction::emitClassConstructorInitializer(ConstructorDecl *ctor) {
 
 static ManagedValue emitSelfForMemberInit(SILGenFunction &SGF, SILLocation loc,
                                           VarDecl *selfDecl) {
-  CanType selfFormalType = selfDecl->getType()
-      ->getInOutObjectType()->getCanonicalType();
+  CanType selfFormalType = selfDecl->getType()->getCanonicalType();
   if (selfFormalType->hasReferenceSemantics())
     return SGF.emitRValueForDecl(loc, selfDecl, selfDecl->getType(),
                                  AccessSemantics::DirectToStorage,
@@ -799,8 +798,7 @@ static ManagedValue emitSelfForMemberInit(SILGenFunction &SGF, SILLocation loc,
 static LValue emitLValueForMemberInit(SILGenFunction &SGF, SILLocation loc,
                                       VarDecl *selfDecl,
                                       VarDecl *property) {
-  CanType selfFormalType = selfDecl->getType()
-    ->getInOutObjectType()->getCanonicalType();
+  CanType selfFormalType = selfDecl->getType()->getCanonicalType();
   auto self = emitSelfForMemberInit(SGF, loc, selfDecl);
   return SGF.emitPropertyLValue(loc, self, selfFormalType, property,
                                 LValueOptions(), AccessKind::Write,

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -358,9 +358,8 @@ ManagedValue Transform::transform(ManagedValue v,
                                   CanType outputSubstType,
                                   SGFContext ctxt) {
   // Look through inout types.
-  if (isa<InOutType>(inputSubstType))
-    inputSubstType = CanType(inputSubstType->getInOutObjectType());
-  
+  inputSubstType = inputSubstType->getInOutObjectType()->getCanonicalType();
+
   // Load if the result isn't address-only.  All the translation routines
   // expect this.
   if (v.getType().isAddress()) {

--- a/lib/SILGen/SILGenProlog.cpp
+++ b/lib/SILGen/SILGenProlog.cpp
@@ -225,7 +225,7 @@ struct ArgumentInitHelper {
     if (vd->isInOut()) {
       SILValue address = argrv.getUnmanagedValue();
 
-      CanType objectType = vd->getType()->getInOutObjectType()->getCanonicalType();
+      CanType objectType = vd->getType()->getCanonicalType();
 
       // As a special case, don't introduce a local variable for
       // Builtin.UnsafeValueBuffer, which is not copyable.
@@ -265,6 +265,8 @@ struct ArgumentInitHelper {
 
   void emitParam(ParamDecl *PD) {
     auto type = PD->getType();
+    if (PD->isInOut())
+      type = InOutType::get(type); // FIXME remove InOutType
 
     ++ArgNo;
     if (PD->hasName()) {
@@ -331,6 +333,8 @@ void SILGenFunction::bindParametersForForwarding(const ParameterList *params,
     Type type = (param->hasType()
                  ? param->getType()
                  : F.mapTypeIntoContext(param->getInterfaceType()));
+    if (param->isInOut())
+      type = InOutType::get(type); // FIXME remove InOutType
     makeArgument(type->eraseDynamicSelfType(), param, parameters, *this);
   }
 }

--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -146,47 +146,47 @@ void SILGenFunction::emitCurryThunk(SILDeclRef thunk) {
     (void) fd;
   }
 
+  SILLocation loc(vd);
   Scope S(*this, vd);
 
-  auto selfTy = vd->getInterfaceType()->castTo<AnyFunctionType>()
-    ->getInput();
-  selfTy = vd->getInnermostDeclContext()->mapTypeIntoContext(selfTy);
-  ManagedValue selfArg =
-    B.createInputFunctionArgument(getLoweredType(selfTy), SILLocation(vd));
+  auto thunkFnTy = SGM.Types.getConstantInfo(thunk).SILFnType;
+  SILFunctionConventions fromConv(thunkFnTy, SGM.M);
+
+  auto selfTy = fromConv.getSILType(thunkFnTy->getSelfParameter());
+  selfTy = F.mapTypeIntoContext(selfTy);
+  ManagedValue selfArg = B.createInputFunctionArgument(selfTy, loc);
 
   // Forward substitutions.
   auto subs = F.getForwardingSubstitutionMap();
 
-  ManagedValue toFn = getNextUncurryLevelRef(*this, vd, thunk, selfArg, subs);
+  ManagedValue toFn = getNextUncurryLevelRef(*this, loc, thunk, selfArg, subs);
 
   // FIXME: Using the type from the ConstantInfo instead of looking at
   // getConstantOverrideInfo() for methods looks suspect in the presence
   // of covariant overrides and multiple vtable entries.
-  SILFunctionConventions fromConv(
-      SGM.Types.getConstantInfo(thunk).SILFnType, SGM.M);
   SILType resultTy = fromConv.getSingleSILResultType();
   resultTy = F.mapTypeIntoContext(resultTy);
   auto substTy = toFn.getType().substGenericArgs(SGM.M, subs);
 
   // Partially apply the next uncurry level and return the result closure.
-  selfArg = selfArg.ensurePlusOne(*this, vd);
+  selfArg = selfArg.ensurePlusOne(*this, loc);
   auto calleeConvention = ParameterConvention::Direct_Guaranteed;
   auto closureTy = SILGenBuilder::getPartialApplyResultType(
       toFn.getType(), /*appliedParams=*/1, SGM.M, subs, calleeConvention);
   ManagedValue toClosure =
-      B.createPartialApply(vd, toFn, substTy, subs, {selfArg}, closureTy);
+      B.createPartialApply(loc, toFn, substTy, subs, {selfArg}, closureTy);
   if (resultTy != closureTy) {
     CanSILFunctionType resultFnTy = resultTy.castTo<SILFunctionType>();
     CanSILFunctionType closureFnTy = closureTy.castTo<SILFunctionType>();
     if (resultFnTy->isABICompatibleWith(closureFnTy).isCompatible()) {
-      toClosure = B.createConvertFunction(vd, toClosure, resultTy);
+      toClosure = B.createConvertFunction(loc, toClosure, resultTy);
     } else {
       toClosure =
-          emitCanonicalFunctionThunk(vd, toClosure, closureFnTy, resultFnTy);
+          emitCanonicalFunctionThunk(loc, toClosure, closureFnTy, resultFnTy);
     }
   }
   toClosure = S.popPreservingValue(toClosure);
-  B.createReturn(ImplicitReturnLocation::getImplicitReturnLoc(vd), toClosure);
+  B.createReturn(ImplicitReturnLocation::getImplicitReturnLoc(loc), toClosure);
 }
 
 void SILGenModule::emitCurryThunk(SILDeclRef constant) {

--- a/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
+++ b/lib/SILOptimizer/Mandatory/DefiniteInitialization.cpp
@@ -999,7 +999,7 @@ void LifetimeChecker::handleStoreUse(unsigned UseID) {
     Type selfTy;
     SILLocation fnLoc = TheMemory.getFunction().getLocation();
     if (auto *ctor = fnLoc.getAsASTNode<ConstructorDecl>())
-      selfTy = ctor->getImplicitSelfDecl()->getType()->getInOutObjectType();
+      selfTy = ctor->getImplicitSelfDecl()->getType();
     else
       selfTy = TheMemory.getType();
 

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -5779,7 +5779,7 @@ Expr *ExprRewriter::coerceCallArguments(
     
       for (size_t i = 0; i < params.size(); i++) {
         if (auto dotExpr = dyn_cast<DotSyntaxCallExpr>(argElts[i])) {
-          auto paramTy = params[i].getType()->getWithoutSpecifierType();
+          auto paramTy = params[i].getType();
           auto argTy = cs.getType(dotExpr)->getWithoutSpecifierType();
           if (!paramTy->isEqual(argTy)) {
             allParamsMatch = false;

--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -2151,10 +2151,8 @@ bool DisjunctionChoice::isSymmetricOperator() const {
   if (paramList->size() != 2)
     return true;
 
-  auto firstType =
-      paramList->get(0)->getInterfaceType()->getWithoutSpecifierType();
-  auto secondType =
-      paramList->get(1)->getInterfaceType()->getWithoutSpecifierType();
+  auto firstType = paramList->get(0)->getInterfaceType();
+  auto secondType = paramList->get(1)->getInterfaceType();
   return firstType->isEqual(secondType);
 }
 

--- a/test/SILGen/initializers.swift
+++ b/test/SILGen/initializers.swift
@@ -1121,3 +1121,9 @@ struct DynamicTypeStruct {
     self.init()
   }
 }
+
+class InOutInitializer {
+// CHECK-LABEL: sil hidden @$S21failable_initializers16InOutInitializerC1xACSiz_tcfC : $@convention(method) (@inout Int, @thick InOutInitializer.Type) -> @owned InOutInitializer {
+// CHECK: bb0(%0 : @trivial $*Int, %1 : @trivial $@thick InOutInitializer.Type):
+  init(x: inout Int) {}
+}

--- a/test/api-digester/Outputs/cake.json
+++ b/test/api-digester/Outputs/cake.json
@@ -583,8 +583,9 @@
             },
             {
               "kind": "TypeNominal",
-              "name": "InOut",
-              "printedName": "inout Hasher"
+              "name": "Hasher",
+              "printedName": "Hasher",
+              "usr": "s:s6HasherV"
             }
           ]
         },


### PR DESCRIPTION
Most callers did not want the InOutType here, and checked
the ParamDecl's flags instead.