### PR TITLE
Add a compact() shorthand for Sequence.compactMap (SE-0187)

### DIFF
--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -749,6 +749,15 @@ extension Sequence {
     return try _compactMap(transform)
   }
 
+  /// Returns an array containing the non-`nil` elements of this sequence.
+  ///
+  /// This is just a shorthand for `compactMap { $0 }`.
+  @inlinable
+  public func compact<T>(
+  ) -> [T] where Element == Optional<T> {
+    return _compactMap { $0 }
+  }
+
   /// Returns an array containing the non-`nil` results of calling the given
   /// transformation with each element of this sequence.
   ///


### PR DESCRIPTION
The accepted and implemented [SE-0187](https://github.com/apple/swift-evolution/blob/master/proposals/0187-introduce-filtermap.md) says “…we will add Sequence.compact() when it is possible to do so.” It seems to be possible now, and the shorter syntax for a common operation (filtering `nil`s out of a collection) is a nice addition.