### PR TITLE
[WIP] SILGen: Capture address-only `let`s with the in_guaranteed convention.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1925,8 +1925,12 @@ void IRGenDebugInfoImpl::emitVariableDeclaration(
 
     // There are variables without storage, such as "struct { func foo() {}
     // }". Emit them as constant 0.
-    if (isa<llvm::UndefValue>(Piece))
-      Piece = llvm::ConstantInt::get(IGM.Int64Ty, 0);
+    if (isa<llvm::UndefValue>(Piece)) {
+      auto undefSize = IGM.DataLayout.getTypeSizeInBits(Piece->getType());
+      
+      Piece = llvm::ConstantInt::get(
+         llvm::IntegerType::get(IGM.getLLVMContext(), undefSize), 0);
+    }
 
     if (IsPiece) {
       // Advance the offset and align it for the next piece.

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -881,9 +881,16 @@ lowerCaptureContextParameters(SILModule &M, AnyFunctionRef function,
     case CaptureKind::StorageAddress: {
       // Non-escaping lvalues are captured as the address of the value.
       SILType ty = loweredTy.getAddressType();
+      
+      ParameterConvention convention
+        = ParameterConvention::Indirect_InoutAliasable;
+      
+      if (auto var = dyn_cast<VarDecl>(VD))
+        if (var->isLet())
+          convention = ParameterConvention::Indirect_In_Guaranteed;
+      
       auto param =
-          SILParameterInfo(ty.getASTType(),
-                           ParameterConvention::Indirect_InoutAliasable);
+          SILParameterInfo(ty.getASTType(), convention);
       inputs.push_back(param);
       break;
     }

--- a/test/SILGen/generic_closures.swift
+++ b/test/SILGen/generic_closures.swift
@@ -144,9 +144,9 @@ class NestedGeneric<U> {
 
 // CHECK: sil hidden @$S16generic_closures018nested_closure_in_A0yxxlF : $@convention(thin) <T> (@in_guaranteed T) -> @out T
 // CHECK:   function_ref [[OUTER_CLOSURE:@\$S16generic_closures018nested_closure_in_A0yxxlFxyXEfU_]]
-// CHECK: sil private [[OUTER_CLOSURE]] : $@convention(thin) <T> (@inout_aliasable T) -> @out T
+// CHECK: sil private [[OUTER_CLOSURE]] : $@convention(thin) <T> (@in_guaranteed T) -> @out T
 // CHECK:   function_ref [[INNER_CLOSURE:@\$S16generic_closures018nested_closure_in_A0yxxlFxyXEfU_xyXEfU_]]
-// CHECK: sil private [[INNER_CLOSURE]] : $@convention(thin) <T> (@inout_aliasable T) -> @out T {
+// CHECK: sil private [[INNER_CLOSURE]] : $@convention(thin) <T> (@in_guaranteed T) -> @out T {
 func nested_closure_in_generic<T>(_ x:T) -> T {
   return { { x }() }()
 }

--- a/test/SILOptimizer/definite_init_address_only_let.swift
+++ b/test/SILOptimizer/definite_init_address_only_let.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+func foo<T>(a: Bool, t: T) {
+  let x: T
+  defer { print(x) }
+
+  x = t
+  return
+}
+
+func bar<T>(a: Bool, t: T) {
+  let x: T // expected-note {{defined here}}
+  defer { print(x) } //expected-error{{constant 'x' used before being initialized}}
+
+  if a {
+    x = t
+    return
+  }
+}
+
+func bas<T>(a: Bool, t: T) {
+  let x: T 
+  defer { print(x) }
+
+  if a {
+    x = t
+    return
+  }
+
+  x = t
+}
+


### PR DESCRIPTION
Fixes rdar://problem/40828667. If we capture a `let` as inout_aliasable, then definite initialization mistakes capture of the `let` from a defer closure as an inappropriate inout use.