### PR TITLE
[4.2] SILGen: Capture address-only `let`s with the in_guaranteed convention.

### DIFF
--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -879,9 +879,16 @@ lowerCaptureContextParameters(SILModule &M, AnyFunctionRef function,
     case CaptureKind::StorageAddress: {
       // Non-escaping lvalues are captured as the address of the value.
       SILType ty = loweredTy.getAddressType();
+      
+      ParameterConvention convention
+        = ParameterConvention::Indirect_InoutAliasable;
+      
+      if (auto var = dyn_cast<VarDecl>(VD))
+        if (var->isLet())
+          convention = ParameterConvention::Indirect_In_Guaranteed;
+      
       auto param =
-          SILParameterInfo(ty.getSwiftRValueType(),
-                           ParameterConvention::Indirect_InoutAliasable);
+          SILParameterInfo(ty.getSwiftRValueType(), convention);
       inputs.push_back(param);
       break;
     }

--- a/test/SILGen/generic_closures.swift
+++ b/test/SILGen/generic_closures.swift
@@ -144,9 +144,9 @@ class NestedGeneric<U> {
 
 // CHECK: sil hidden @$S16generic_closures018nested_closure_in_A0yxxlF : $@convention(thin) <T> (@in_guaranteed T) -> @out T
 // CHECK:   function_ref [[OUTER_CLOSURE:@\$S16generic_closures018nested_closure_in_A0yxxlFxyXEfU_]]
-// CHECK: sil private [[OUTER_CLOSURE]] : $@convention(thin) <T> (@inout_aliasable T) -> @out T
+// CHECK: sil private [[OUTER_CLOSURE]] : $@convention(thin) <T> (@in_guaranteed T) -> @out T
 // CHECK:   function_ref [[INNER_CLOSURE:@\$S16generic_closures018nested_closure_in_A0yxxlFxyXEfU_xyXEfU_]]
-// CHECK: sil private [[INNER_CLOSURE]] : $@convention(thin) <T> (@inout_aliasable T) -> @out T {
+// CHECK: sil private [[INNER_CLOSURE]] : $@convention(thin) <T> (@in_guaranteed T) -> @out T {
 func nested_closure_in_generic<T>(_ x:T) -> T {
   return { { x }() }()
 }

--- a/test/SILOptimizer/definite_init_address_only_let.swift
+++ b/test/SILOptimizer/definite_init_address_only_let.swift
@@ -1,0 +1,9 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+func foo<T>(a: Bool, t: T) {
+  let x: T
+  defer { print(x) }
+
+  x = t
+  return
+}


### PR DESCRIPTION
Fixes rdar://problem/40828667. If we capture a `let` as inout_aliasable, then definite initialization mistakes capture of the `let` from a defer closure as an inappropriate inout use.
