### PR TITLE
DO NOT MERGE [stdlib] SR 7266 avoid nesting reversed lazy

### DIFF
--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -299,6 +299,16 @@ extension LazyCollectionProtocol
   Self: BidirectionalCollection,
   Elements: BidirectionalCollection {
 
+  /// Reversing a lazy reversed array returns a lazy representation of the original array.
+  ///
+  /// - Complexity: O(1)
+  @inlinable
+  @available(swift, introduced: 4.2)
+  public func reversed<T>() -> LazyCollection<T>
+    where Elements == ReversedCollection<T> {
+      return elements._base.lazy
+  }
+
   /// Returns the elements of the collection in reverse order.
   ///
   /// - Complexity: O(1)

--- a/test/stdlib/ReverseCompatibility.swift
+++ b/test/stdlib/ReverseCompatibility.swift
@@ -33,4 +33,25 @@ tests.test("Double reverse type/Collection/\(swiftVersion)") {
   backwardCompatible(Array(0..<10))
 }
 
+tests.test("Double reverse type/LazyCollection/\(swiftVersion)") {
+  func reverse<C : BidirectionalCollection>(_ xs: C) {
+    var result = xs.lazy.reversed().reversed()
+    #if swift(>=4.2)
+    expectType(LazyCollection<C>.self, &result)
+    #else
+    expectType(
+    LazyCollection<ReversedCollection<ReversedCollection<C>>>.self,
+    &result)
+    #endif
+  }
+  reverse(Array(0..<10).lazy)
+
+  func backwardCompatible<C : BidirectionalCollection>(_ xs: C) {
+    typealias ExpectedType =
+      LazyCollection<ReversedCollection<ReversedCollection<C>>>
+    var result: ExpectedType = xs.lazy.reversed().reversed()
+    expectType(ExpectedType.self, &result)
+  }
+  backwardCompatible(Array(0..<10).lazy)
+}
 runAllTests()

--- a/test/stdlib/ReverseCompatibility.swift
+++ b/test/stdlib/ReverseCompatibility.swift
@@ -34,15 +34,17 @@ tests.test("Double reverse type/Collection/\(swiftVersion)") {
 }
 
 tests.test("Double reverse type/LazyCollection/\(swiftVersion)") {
-  func reverse<C : BidirectionalCollection>(_ xs: C) {
-    var result = xs.lazy.reversed().reversed()
-    #if swift(>=4.2)
+  func reverse<C : BidirectionalCollection>(_ xs: LazyCollection<C>) {
+    var singleReverse = xs.reversed()
+    expectType(LazyCollection<ReversedCollection<C>>.self, &singleReverse)
+#if swift(>=4.2)
+    var result: LazyCollection<C> = singleReverse.reversed()
     expectType(LazyCollection<C>.self, &result)
-    #else
+#else
+    var result = singleReverse.reversed()
     expectType(
-    LazyCollection<ReversedCollection<ReversedCollection<C>>>.self,
-    &result)
-    #endif
+    LazyCollection<ReversedCollection<ReversedCollection<C>>>.self, &result)
+#endif
   }
   reverse(Array(0..<10).lazy)
 
@@ -52,6 +54,6 @@ tests.test("Double reverse type/LazyCollection/\(swiftVersion)") {
     var result: ExpectedType = xs.lazy.reversed().reversed()
     expectType(ExpectedType.self, &result)
   }
-  backwardCompatible(Array(0..<10).lazy)
+  backwardCompatible(Array(0..<10))
 }
 runAllTests()


### PR DESCRIPTION
<!-- What's in this pull request? -->
This is continuation of https://github.com/apple/swift/pull/15815 where double reversal of regular (non-lazy) collection is fixed to produce the original collection.

This PR is similar fix for the lazy case. Which is non-trivial:

1) A straightforward solution would be to introduce ReversedCollectionProtocol, to target the extension to this specific situation (see https://gist.github.com/Moximillian/b7643abc7d460e1673981d3f41bb9b40). However, new protocols do not seem to be desirable.

2) Workaround the issue by using function generics. However, this solution is suboptimal as generic reverse() is not used when there are concrete alternatives. Thus this solution only works if receiving type specifically asks for it (see the tests).

3) In the future, potentially solution might be able to use _Parameterized extensions_, which are currently not available to swift. See  https://github.com/apple/swift/blob/master/docs/GenericsManifesto.md#parameterized-extensions
`
extension<T> LazyCollectionProtocol
  where Self: BidirectionalCollection, T: BidirectionalCollection, Elements == ReversedCollection<T> { ... }
`

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7266](https://bugs.swift.org/browse/SR-7266).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
