### PR TITLE
Better error message for 'class func/var' usage in protocols (part 2)

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -66,10 +66,10 @@ ERROR(super_not_in_class_method,none,
 
 ERROR(class_func_not_in_class,none,
       "class methods are only allowed within classes; "
-      "use 'static' to declare a%select{| requirement fulfilled by either a class or}0 static method", (bool))
+      "use 'static' to declare a %select{static|requirement fulfilled by either a static or class}0 method", (bool))
 ERROR(class_var_not_in_class,none,
       "class properties are only allowed within classes; "
-      "use 'static' to declare a%select{| requirement fulfilled by either a class or}0 static property", (bool))
+      "use 'static' to declare a %select{static|requirement fulfilled by either a static or class}0 property", (bool))
 
 // FIXME: Used by both the parser and the type-checker.
 ERROR(func_decl_without_brace,PointsToFirstBadToken,

--- a/test/decl/func/static_func.swift
+++ b/test/decl/func/static_func.swift
@@ -110,7 +110,7 @@ protocol P { // expected-note{{extended type declared here}}
   static func f2()
   static func f3() {} // expected-error {{protocol methods must not have bodies}}
   static final func f4() // expected-error {{only classes and class members may be marked with 'final'}}
-  class func f5() // expected-error {{class methods are only allowed within classes; use 'static' to declare a requirement fulfilled by either a class or static method}} {{3-8=static}}
+  class func f5() // expected-error {{class methods are only allowed within classes; use 'static' to declare a requirement fulfilled by either a static or class method}} {{3-8=static}}
 }
 
 extension P {

--- a/test/decl/var/static_var.swift
+++ b/test/decl/var/static_var.swift
@@ -174,11 +174,11 @@ extension C {
 protocol P {  // expected-note{{did you mean 'P'?}} expected-note{{extended type declared here}}
   // Both `static` and `class` property requirements are equivalent in protocols rdar://problem/17198298
   static var v1: Int { get }
-  class var v2: Int { get } // expected-error {{class properties are only allowed within classes; use 'static' to declare a requirement fulfilled by either a class or static property}} {{3-8=static}}
+  class var v2: Int { get } // expected-error {{class properties are only allowed within classes; use 'static' to declare a requirement fulfilled by either a static or class property}} {{3-8=static}}
   static final var v3: Int { get } // expected-error {{only classes and class members may be marked with 'final'}}
 
   static let l1: Int // expected-error {{immutable property requirement must be declared as 'var' with a '{ get }' specifier}}
-  class let l2: Int // expected-error {{class properties are only allowed within classes; use 'static' to declare a requirement fulfilled by either a class or static property}} {{3-8=static}} expected-error {{immutable property requirement must be declared as 'var' with a '{ get }' specifier}}
+  class let l2: Int // expected-error {{class properties are only allowed within classes; use 'static' to declare a requirement fulfilled by either a static or class property}} {{3-8=static}} expected-error {{immutable property requirement must be declared as 'var' with a '{ get }' specifier}}
 }
 
 extension P {


### PR DESCRIPTION
<!-- What's in this pull request? -->
As a continuation to https://github.com/apple/swift/pull/16965 flip static/class in the error message, to make the error even clearer about class methods / class properties

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
