### PR TITLE
[4.2] IRGen: Don't pass metadata of not ABI accessible to outlined copy/destroy operations

### DIFF
--- a/lib/IRGen/Outlining.cpp
+++ b/lib/IRGen/Outlining.cpp
@@ -36,7 +36,11 @@ void OutliningMetadataCollector::collectTypeMetadataForLayout(SILType type) {
   }
 
   CanType formalType = type.getSwiftRValueType();
-  if (isa<FixedTypeInfo>(IGF.IGM.getTypeInfoForLowered(formalType))) {
+  auto &ti = IGF.IGM.getTypeInfoForLowered(formalType);
+  // We don't need the metadata for fixed size types or types that are not ABI
+  // accessible. Outlining will call the value witness of the enclosing type of
+  // non ABI accessible field/element types.
+  if (isa<FixedTypeInfo>(ti) || !ti.isABIAccessible()) {
     return;
   }
 

--- a/test/IRGen/Inputs/ABIInaccessible.swift
+++ b/test/IRGen/Inputs/ABIInaccessible.swift
@@ -1,0 +1,13 @@
+private struct Private<T> {
+  init(_ t: T) {
+    p = t
+  }
+  var p : T
+}
+
+public struct Public<T> {
+  init(_ t: T) {
+    p = Private<T>(t)
+  }
+  private var p: Private<T>
+}

--- a/test/IRGen/TestABIInaccessible.swift
+++ b/test/IRGen/TestABIInaccessible.swift
@@ -8,7 +8,7 @@ public struct AnotherType<T> {
 }
 
 // Don't pass the metadata of Private<T> to AnotherType<T>'s outlined destroy.
-// CHECK-LABEL: define swiftcc void @"$S4main4copyyAA11AnotherTypeVyxGAElF"(%T4main11AnotherTypeV* noalias nocapture sret, %T4main11AnotherTypeV* noalias nocapture, %swift.type* %T)
+// CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @"$S4main4copyyAA11AnotherTypeVyxGAElF"(%T4main11AnotherTypeV* noalias nocapture sret, %T4main11AnotherTypeV* noalias nocapture, %swift.type* %T)
 // CHECK:  [[MD:%.*]] = call swiftcc %swift.metadata_response @"$S4main11AnotherTypeVMa"(i{{.*}} 0, %swift.type* %T) #9
 // CHECK:  [[MD1:%.*]] = extractvalue %swift.metadata_response %3, 0
 // CHECK:  [[MD2:%.*]] = call swiftcc %swift.metadata_response @"$S4main6PublicVMa"(i{{.*}} 0, %swift.type* %T)

--- a/test/IRGen/TestABIInaccessible.swift
+++ b/test/IRGen/TestABIInaccessible.swift
@@ -1,0 +1,20 @@
+// RUN: %target-swift-frontend -module-name main -I %t -emit-ir -primary-file %s %S/Inputs/ABIInaccessible.swift | %FileCheck %s
+
+public struct AnotherType<T> {
+  init(_ t: T) {
+    p = Public<T>(t)
+  }
+  public var p : Public<T>
+}
+
+// Don't pass the metadata of Private<T> to AnotherType<T>'s outlined destroy.
+// CHECK-LABEL: define swiftcc void @"$S4main4copyyAA11AnotherTypeVyxGAElF"(%T4main11AnotherTypeV* noalias nocapture sret, %T4main11AnotherTypeV* noalias nocapture, %swift.type* %T)
+// CHECK:  [[MD:%.*]] = call swiftcc %swift.metadata_response @"$S4main11AnotherTypeVMa"(i{{.*}} 0, %swift.type* %T) #9
+// CHECK:  [[MD1:%.*]] = extractvalue %swift.metadata_response %3, 0
+// CHECK:  [[MD2:%.*]] = call swiftcc %swift.metadata_response @"$S4main6PublicVMa"(i{{.*}} 0, %swift.type* %T)
+// CHECK:  [[MD3:%.*]] = extractvalue %swift.metadata_response %10, 0
+// CHECK:  call %T4main11AnotherTypeV* @"$S4main11AnotherTypeVyxGlWOc"(%T4main11AnotherTypeV* %1, %T4main11AnotherTypeV* {{.*}}, %swift.type* %T, %swift.type* [[MD3]], %swift.type* [[MD1]])
+public func copy<T>(_ a: AnotherType<T>) -> AnotherType<T> {
+  let copy = a
+  return copy
+}


### PR DESCRIPTION

Doing so will cause linkage errors and is not neccessary since we call
the witness of the enclosing type as soon as its fields are not ABI
accessible.

rdar://40868358
