### PR TITLE
Split SymbolicValue out to being defined at the SIL level

### DIFF
--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -20,9 +20,6 @@
 
 #include "swift/SIL/SILValue.h"
 
-namespace llvm {
-  //class BumpPtrAllocator;
-}
 namespace swift {
 class SingleValueInstruction;
 class SILValue;

--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -1,0 +1,277 @@
+//===--- SILConstants.h - SIL constant representation -----------*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This defines an interface to represent SIL level structured constants in an
+// memory efficient way.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_SIL_CONSTANTS_H
+#define SWIFT_SIL_CONSTANTS_H
+
+#include "swift/SIL/SILValue.h"
+
+namespace llvm {
+  //class BumpPtrAllocator;
+}
+namespace swift {
+class SingleValueInstruction;
+class SILValue;
+class SILBuilder;
+class SerializedSILLoader;
+
+struct APIntSymbolicValue;
+struct APFloatSymbolicValue;
+struct AddressSymbolicValue;
+struct AggregateSymbolicValue;
+
+/// When we fail to constant fold a value, this captures a reason why,
+/// allowing the caller to produce a specific diagnostic.  The "Unknown"
+/// SymbolicValue representation also includes a pointer to the SILNode in
+/// question that was problematic.
+enum class UnknownReason {
+  // TODO: Eliminate the default code, by making classifications for each
+  // failure mode.
+  Default,
+
+  /// The constant expression was too big.  This is reported on a random
+  /// instruction within the constexpr that triggered the issue.
+  TooManyInstructions,
+};
+
+
+/// This is the symbolic value tracked for each SILValue in a scope.  We
+/// support multiple representational forms for the constant node in order to
+/// avoid pointless memory bloat + copying.  This is intended to be a
+/// light-weight POD type we can put in hash tables and pass around by-value.
+///
+/// Internally, this value has multiple ways to represent the same sorts of
+/// symbolic values (e.g. to save memory).  It provides a simpler public
+/// interface though.
+class SymbolicValue {
+  enum RepresentationKind {
+    /// This value is an alloc stack that is has not (yet) been initialized
+    /// by flow-sensitive analysis.
+    RK_UninitMemory,
+
+    /// This symbolic value cannot be determined, carries multiple values
+    /// (i.e., varies dynamically at the top level), or is of some type that
+    /// we cannot analyze and propagate (e.g. NSObject).
+    ///
+    RK_Unknown,
+
+    /// This value is known to be a metatype reference.  The type is stored
+    /// in the "metatype" member.
+    RK_Metatype,
+
+    /// This value is known to be a function reference, e.g. through
+    /// function_ref directly, or a devirtualized method reference.
+    RK_Function,
+
+    /// This value is a constant, and tracked by the "inst" member of the
+    /// value union.  This could be an integer, floating point, string, or
+    /// metatype value.
+    RK_Inst,
+
+    /// This value is represented with a bump pointer allocated APInt.
+    /// TODO: We could store small integers into the union inline to avoid
+    /// allocations if it ever matters.
+    RK_Integer,
+
+    /// This value is represented with a bump pointer allocated APFloat.
+    /// TODO: We could store small floats into the union inline to avoid
+    /// allocations if it ever matters.
+    RK_Float,
+
+    /// This value is a pointer to a tracked memory location, along with zero
+    /// or more indices (tuple indices, struct field indices, etc) into the
+    /// value if it is an aggregate.
+    ///
+    RK_Address,
+
+    /// This value is an array, struct, or tuple of constants.  This is
+    /// tracked by the "aggregate" member of the value union.  Note that we
+    /// cheat and represent single-element structs as the value of their
+    /// element (since they are so common).
+    RK_Aggregate,
+  };
+
+  RepresentationKind representationKind : 8;
+
+  union {
+    UnknownReason unknown_reason;
+    //unsigned integer_bitwidth;
+    // ...
+  } aux;
+
+  union {
+    /// When the value is Unknown, this contains the value that was the
+    /// unfoldable part of the computation.
+    ///
+    /// TODO: make this a more rich representation.
+    SILNode *unknown;
+
+    /// This is always a SILType with an object category.  This is the value
+    /// of the underlying instance type, not the MetatypeType.
+    TypeBase *metatype;
+
+    SILFunction *function;
+
+    /// When this SymbolicValue is of "Inst" kind, this contains a
+    /// pointer to the instruction whose value this holds.  This is known to
+    /// be one of a closed set of constant instructions:
+    ///    IntegerLiteralInst, FloatLiteralInst, StringLiteralInst
+    SingleValueInstruction *inst;
+
+    /// When this SymbolicValue is of "Integer" kind, this pointer stores
+    /// information about the APInt value it holds.
+    APIntSymbolicValue *integer;
+
+    /// When this SymbolicValue is of "Float" kind, this pointer stores
+    /// information about the APFloat value it holds.
+    APFloatSymbolicValue *float_;
+
+    /// When this SymbolicValue is of "Address" kind, this pointer stores
+    /// info about the base and the indices for the address.
+    AddressSymbolicValue *address;
+
+    /// When this SymbolicValue is of "Aggregate" kind, this pointer stores
+    /// information about the array elements, count, and element type.
+    AggregateSymbolicValue *aggregate;
+  } value;
+
+public:
+
+  /// This enum is used to indicate the sort of value held by a SymbolicValue
+  /// independent of its concrete representation.  This is the public
+  /// interface to SymbolicValue.
+  enum Kind {
+    Unknown, Metatype, Function, Integer, Float, String, Aggregate,
+
+    // These values are generally only seen internally to the system, external
+    // clients shouldn't have to deal with them.
+    Address, UninitMemory
+  };
+
+  /// For constant values, return the type classification of this value.
+  Kind getKind() const;
+
+  /// Return true if this represents a constant value.
+  bool isConstant() const {
+    auto kind = getKind();
+    return kind != Unknown && kind != UninitMemory;
+  }
+
+  static SymbolicValue getUnknown(SILNode *node, UnknownReason reason) {
+    assert(node && "node must be present");
+    SymbolicValue result;
+    result.representationKind = RK_Unknown;
+    result.value.unknown = node;
+    result.aux.unknown_reason = reason;
+    return result;
+  }
+
+  /// Return information about an unknown result, including the SIL node that
+  /// is a problem, and the reason it is an issue.
+  std::pair<SILNode *, UnknownReason> getUnknownValue() const {
+    assert(representationKind == RK_Unknown);
+    return { value.unknown, aux.unknown_reason };
+  }
+
+  static SymbolicValue getUninitMemory() {
+    SymbolicValue result;
+    result.representationKind = RK_UninitMemory;
+    return result;
+  }
+
+  static SymbolicValue getMetatype(CanType type) {
+    SymbolicValue result;
+    result.representationKind = RK_Metatype;
+    result.value.metatype = type.getPointer();
+    return result;
+  }
+
+  CanType getMetatypeValue() const {
+    assert(representationKind == RK_Metatype);
+    return CanType(value.metatype);
+  }
+
+  static SymbolicValue getFunction(SILFunction *fn) {
+    assert(fn && "Function cannot be null");
+    SymbolicValue result;
+    result.representationKind = RK_Function;
+    result.value.function = fn;
+    return result;
+  }
+
+  SILFunction *getFunctionValue() const {
+    assert(getKind() == Function);
+    return value.function;
+  }
+
+  static SymbolicValue getConstantInst(SingleValueInstruction *inst) {
+    assert(inst && "inst value must be present");
+    SymbolicValue result;
+    result.representationKind = RK_Inst;
+    result.value.inst = inst;
+    return result;
+  }
+
+  // TODO: Remove this, it is just needed because deabstraction has no SIL
+  // instruction of its own.
+  SingleValueInstruction *getConstantInstIfPresent() const {
+    return representationKind == RK_Inst ? value.inst : nullptr;
+  }
+
+  static SymbolicValue getInteger(const APInt &value,
+                                  llvm::BumpPtrAllocator &allocator);
+
+  APInt getIntegerValue() const;
+
+  static SymbolicValue getFloat(const APFloat &value,
+                                llvm::BumpPtrAllocator &allocator);
+
+  APFloat getFloatValue() const;
+
+  /// Get a SymbolicValue corresponding to a memory object with an optional
+  /// list of indices into it.  This is used by (e.g.) a struct_element_addr
+  /// of a stack_alloc.
+  static SymbolicValue getAddress(SILValue base,
+                                  ArrayRef<unsigned> indices,
+                                  llvm::BumpPtrAllocator &allocator);
+
+  /// Accessors for Address SymbolicValue's.
+  bool isAddress() const {
+    return getKind() == Address;
+  }
+
+  SILValue getAddressBase() const;
+  ArrayRef<unsigned> getAddressIndices() const;
+
+
+  /// This returns an aggregate value with the specified elements in it.  This
+  /// copies the elements into the specified allocator.
+  static SymbolicValue getAggregate(ArrayRef<SymbolicValue> elements,
+                                    llvm::BumpPtrAllocator &allocator);
+
+  ArrayRef<SymbolicValue> getAggregateValue() const;
+
+
+  // TODO: getStringValue.
+
+  void print(llvm::raw_ostream &os, unsigned indent = 0) const;
+  void dump() const;
+};
+
+} // end namespace swift
+
+#endif

--- a/lib/SIL/CMakeLists.txt
+++ b/lib/SIL/CMakeLists.txt
@@ -14,6 +14,7 @@ add_swift_library(swiftSIL STATIC
   SILArgument.cpp
   SILBasicBlock.cpp
   SILBuilder.cpp
+  SILConstants.cpp
   SILCoverageMap.cpp
   SILDebugScope.cpp
   SILDeclRef.cpp

--- a/lib/SIL/SILConstants.cpp
+++ b/lib/SIL/SILConstants.cpp
@@ -1,0 +1,385 @@
+//===--- SILConstants.cpp - SIL constant representation -------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// SWIFT_ENABLE_TENSORFLOW
+
+#include "swift/SIL/SILConstants.h"
+#include "swift/SIL/SILBuilder.h"
+#include "swift/Demangling/Demangle.h"
+#include "llvm/Support/TrailingObjects.h"
+using namespace swift;
+
+//===----------------------------------------------------------------------===//
+// SymbolicValue implementation
+//===----------------------------------------------------------------------===//
+
+void SymbolicValue::print(llvm::raw_ostream &os, unsigned indent) const {
+  os.indent(indent);
+  switch (representationKind) {
+  case RK_UninitMemory: os << "uninit\n"; return;
+  case RK_Unknown: {
+    std::pair<SILNode *, UnknownReason> unknown = getUnknownValue();
+    switch (unknown.second) {
+    case UnknownReason::Default: os << "unknown: "; break;
+    case UnknownReason::TooManyInstructions: os << "unknown(toobig): "; break;
+    }
+    unknown.first->dump();
+    return;
+  }
+  case RK_Metatype:
+    os << "metatype: ";
+    getMetatypeValue()->print(os);
+    os << "\n";
+    return;
+  case RK_Function:
+    os << "fn: " << getFunctionValue()->getName() << ": ";
+    os << Demangle::demangleSymbolAsString(getFunctionValue()->getName());
+    os << "\n";
+    return;
+  case RK_Inst:
+    os << "inst: ";
+    value.inst->dump();
+    return;
+  case RK_Integer:
+    os << "int: " << getIntegerValue() << "\n";
+    return;
+  case RK_Float:
+    os << "float: ";
+    getFloatValue().print(os);
+    os << "\n";
+    return;
+  case RK_Address: {
+    os << "address indices = [";
+    interleave(getAddressIndices(), [&](unsigned idx) { os << idx; },
+               [&]() { os << ", "; });
+    os << "]:  " << getAddressBase();
+    return;
+  }
+  case RK_Aggregate: {
+    ArrayRef<SymbolicValue> elements = getAggregateValue();
+    os << "agg: " << elements.size() << " element" << "s"[elements.size() == 1]
+       << " [\n";
+    for (auto elt : elements)
+      elt.print(os, indent+2);
+    os.indent(indent) << "]\n";
+    return;
+  }
+  }
+}
+
+void SymbolicValue::dump() const {
+  print(llvm::errs());
+}
+
+/// For constant values, return the classification of this value.  We have
+/// multiple forms for efficiency, but provide a simpler interface to clients.
+SymbolicValue::Kind SymbolicValue::getKind() const {
+  switch (representationKind) {
+  case RK_UninitMemory: return UninitMemory;
+  case RK_Unknown:      return Unknown;
+  case RK_Metatype:     return Metatype;
+  case RK_Function:     return Function;
+  case RK_Address:      return Address;
+  case RK_Aggregate:    return Aggregate;
+  case RK_Integer:      return Integer;
+  case RK_Float:        return Float;
+  case RK_Inst:
+    auto *inst = value.inst;
+    if (isa<IntegerLiteralInst>(inst))
+      return Integer;
+    if (isa<FloatLiteralInst>(inst))
+      return Float;
+    assert(isa<StringLiteralInst>(inst) && "Unknown ConstantInst kind");
+    return String;
+  }
+}
+
+
+//===----------------------------------------------------------------------===//
+// Integers
+//===----------------------------------------------------------------------===//
+
+namespace swift {
+/// This is a representation of an integer value, stored as a trailing array
+/// of words.  Elements of this value are bump pointer allocated.
+struct alignas(uint64_t) APIntSymbolicValue final
+  : private llvm::TrailingObjects<APIntSymbolicValue, uint64_t> {
+    friend class llvm::TrailingObjects<APIntSymbolicValue, uint64_t>;
+
+  /// The number of words in the trailing array and # bits of the value.
+  const unsigned numWords, numBits;
+
+  static APIntSymbolicValue *create(unsigned numBits,
+                                    ArrayRef<uint64_t> elements,
+                                    llvm::BumpPtrAllocator &allocator) {
+    auto byteSize =
+      APIntSymbolicValue::totalSizeToAlloc<uint64_t>(elements.size());
+    auto rawMem = allocator.Allocate(byteSize, alignof(APIntSymbolicValue));
+
+    //  Placement initialize the APIntSymbolicValue.
+    auto ilv = ::new (rawMem) APIntSymbolicValue(numBits, elements.size());
+    std::uninitialized_copy(elements.begin(), elements.end(),
+                            ilv->getTrailingObjects<uint64_t>());
+    return ilv;
+  }
+
+  APInt getValue() const {
+    return APInt(numBits, { getTrailingObjects<uint64_t>(), numWords });
+  }
+
+  // This is used by the llvm::TrailingObjects base class.
+  size_t numTrailingObjects(OverloadToken<uint64_t>) const {
+    return numWords;
+  }
+private:
+  APIntSymbolicValue() = delete;
+  APIntSymbolicValue(const APIntSymbolicValue &) = delete;
+  APIntSymbolicValue(unsigned numBits, unsigned numWords)
+    : numWords(numWords), numBits(numBits) {}
+};
+} // end namespace swift
+
+
+SymbolicValue SymbolicValue::getInteger(const APInt &value,
+                                        llvm::BumpPtrAllocator &allocator) {
+  // TODO: Could store these inline in the union in the common case.
+  auto intValue =
+    APIntSymbolicValue::create(value.getBitWidth(),
+                               { value.getRawData(), value.getNumWords()},
+                               allocator);
+  assert(intValue && "aggregate value must be present");
+  SymbolicValue result;
+  result.representationKind = RK_Integer;
+  result.value.integer = intValue;
+  return result;
+}
+
+APInt SymbolicValue::getIntegerValue() const {
+  assert(getKind() == Integer);
+  if (representationKind == RK_Integer)
+    return value.integer->getValue();
+
+  assert(representationKind == RK_Inst);
+  // TODO: Will eventually support the bump-pointer allocated folded int value.
+  return cast<IntegerLiteralInst>(value.inst)->getValue();
+}
+
+//===----------------------------------------------------------------------===//
+// Floats
+//===----------------------------------------------------------------------===//
+
+namespace swift {
+/// This is a representation of an integer value, stored as a trailing array
+/// of words.  Elements of this value are bump pointer allocated.
+struct alignas(uint64_t) APFloatSymbolicValue final
+  : private llvm::TrailingObjects<APFloatSymbolicValue, uint64_t> {
+    friend class llvm::TrailingObjects<APFloatSymbolicValue, uint64_t>;
+
+  const llvm::fltSemantics &semantics;
+
+  static APFloatSymbolicValue *create(const llvm::fltSemantics &semantics,
+                                     ArrayRef<uint64_t> elements,
+                                     llvm::BumpPtrAllocator &allocator) {
+    assert((APFloat::getSizeInBits(semantics)+63)/64 == elements.size());
+
+    auto byteSize =
+      APFloatSymbolicValue::totalSizeToAlloc<uint64_t>(elements.size());
+    auto rawMem = allocator.Allocate(byteSize, alignof(APFloatSymbolicValue));
+
+    //  Placement initialize the APFloatSymbolicValue.
+    auto ilv = ::new (rawMem) APFloatSymbolicValue(semantics);
+    std::uninitialized_copy(elements.begin(), elements.end(),
+                            ilv->getTrailingObjects<uint64_t>());
+    return ilv;
+  }
+
+  APFloat getValue() const {
+    auto val = APInt(APFloat::getSizeInBits(semantics),
+                     { getTrailingObjects<uint64_t>(),
+                       numTrailingObjects(OverloadToken<uint64_t>())
+                     });
+    return APFloat(semantics, val);
+  }
+
+  // This is used by the llvm::TrailingObjects base class.
+  size_t numTrailingObjects(OverloadToken<uint64_t>) const {
+    return (APFloat::getSizeInBits(semantics)+63)/64;
+  }
+private:
+  APFloatSymbolicValue() = delete;
+  APFloatSymbolicValue(const APFloatSymbolicValue &) = delete;
+  APFloatSymbolicValue(const llvm::fltSemantics &semantics)
+    : semantics(semantics) {}
+};
+} // end namespace swift
+
+
+SymbolicValue SymbolicValue::getFloat(const APFloat &value,
+                                      llvm::BumpPtrAllocator &allocator) {
+  APInt val = value.bitcastToAPInt();
+
+  // TODO: Could store these inline in the union in the common case.
+  auto fpValue =
+    APFloatSymbolicValue::create(value.getSemantics(),
+                                 { val.getRawData(), val.getNumWords()},
+                                 allocator);
+  assert(fpValue && "aggregate value must be present");
+  SymbolicValue result;
+  result.representationKind = RK_Float;
+  result.value.float_ = fpValue;
+  return result;
+}
+
+
+APFloat SymbolicValue::getFloatValue() const {
+  assert(getKind() == Float);
+
+  if (representationKind == RK_Float)
+    return value.float_->getValue();
+
+  assert(representationKind == RK_Inst);
+  return cast<FloatLiteralInst>(value.inst)->getValue();
+}
+
+//===----------------------------------------------------------------------===//
+// Addresses
+//===----------------------------------------------------------------------===//
+
+namespace swift {
+/// This is a representation of an address value, stored as a base pointer plus
+/// trailing array of indices.  Elements of this value are bump pointer
+/// allocated.
+struct alignas(SILValue) AddressSymbolicValue final
+  : private llvm::TrailingObjects<AddressSymbolicValue, unsigned> {
+    friend class llvm::TrailingObjects<AddressSymbolicValue, unsigned>;
+
+  /// The number of words in the trailing array and # bits of the value.
+  const SILValue base;
+  const unsigned numIndices;
+
+  static AddressSymbolicValue *create(SILValue base, ArrayRef<unsigned> indices,
+                                      llvm::BumpPtrAllocator &allocator) {
+    auto byteSize =
+      AddressSymbolicValue::totalSizeToAlloc<unsigned>(indices.size());
+    auto rawMem = allocator.Allocate(byteSize, alignof(AddressSymbolicValue));
+
+    //  Placement initialize the AddressSymbolicValue.
+    auto alv = ::new (rawMem) AddressSymbolicValue(base, indices.size());
+    std::uninitialized_copy(indices.begin(), indices.end(),
+                            alv->getTrailingObjects<unsigned>());
+    return alv;
+  }
+
+  ArrayRef<unsigned> getIndices() const {
+    return { getTrailingObjects<unsigned>(), numIndices };
+  }
+
+  // This is used by the llvm::TrailingObjects base class.
+  size_t numTrailingObjects(OverloadToken<unsigned>) const {
+    return numIndices;
+  }
+private:
+  AddressSymbolicValue() = delete;
+  AddressSymbolicValue(const AddressSymbolicValue &) = delete;
+  AddressSymbolicValue(SILValue base, unsigned numIndices)
+    : base(base), numIndices(numIndices) {}
+};
+} // end namespace swift
+
+
+SymbolicValue
+SymbolicValue::getAddress(SILValue base, ArrayRef<unsigned> indices,
+                          llvm::BumpPtrAllocator &allocator) {
+  auto alv = AddressSymbolicValue::create(base, indices, allocator);
+  assert(alv && "aggregate value must be present");
+  SymbolicValue result;
+  result.representationKind = RK_Address;
+  result.value.address = alv;
+  return result;
+}
+
+SILValue SymbolicValue::getAddressBase() const {
+  assert(representationKind == RK_Address);
+  return value.address->base;
+}
+
+ArrayRef<unsigned> SymbolicValue::getAddressIndices() const {
+  assert(representationKind == RK_Address);
+  return value.address->getIndices();
+}
+
+
+//===----------------------------------------------------------------------===//
+// Aggregates
+//===----------------------------------------------------------------------===//
+
+namespace swift {
+
+/// This is the representation of a constant aggregate value.  It maintains
+/// the elements as a trailing array of SymbolicValue's.  Note that single
+/// element structs do not use this (as a performance optimization to reduce
+/// allocations).
+struct alignas(SymbolicValue) AggregateSymbolicValue final
+: private llvm::TrailingObjects<AggregateSymbolicValue, SymbolicValue> {
+  friend class llvm::TrailingObjects<AggregateSymbolicValue, SymbolicValue>;
+
+  /// This is the number of elements in the aggregate.
+  const unsigned numElements;
+
+  static AggregateSymbolicValue *create(ArrayRef<SymbolicValue> elements,
+                                       llvm::BumpPtrAllocator &allocator) {
+    auto byteSize =
+      AggregateSymbolicValue::totalSizeToAlloc<SymbolicValue>(elements.size());
+    auto rawMem = allocator.Allocate(byteSize, alignof(AggregateSymbolicValue));
+
+    //  Placement initialize the AggregateSymbolicValue.
+    auto alv = ::new (rawMem) AggregateSymbolicValue(elements.size());
+    std::uninitialized_copy(elements.begin(), elements.end(),
+                            alv->getTrailingObjects<SymbolicValue>());
+    return alv;
+  }
+
+  /// Return the element constants for this aggregate constant.  These are
+  /// known to all be constants.
+  ArrayRef<SymbolicValue> getElements() const {
+    return { getTrailingObjects<SymbolicValue>(), numElements };
+  }
+
+  // This is used by the llvm::TrailingObjects base class.
+  size_t numTrailingObjects(OverloadToken<SymbolicValue>) const {
+    return numElements;
+  }
+private:
+  AggregateSymbolicValue() = delete;
+  AggregateSymbolicValue(const AggregateSymbolicValue &) = delete;
+  AggregateSymbolicValue(unsigned numElements) : numElements(numElements) {}
+};
+} // end namespace swift
+
+
+/// This returns a constant Symbolic value with the specified elements in it.
+/// This assumes that the elements lifetime has been managed for this.
+SymbolicValue SymbolicValue::getAggregate(ArrayRef<SymbolicValue> elements,
+                                          llvm::BumpPtrAllocator &allocator) {
+  auto aggregate = AggregateSymbolicValue::create(elements, allocator);
+  assert(aggregate && "aggregate value must be present");
+  SymbolicValue result;
+  result.representationKind = RK_Aggregate;
+  result.value.aggregate = aggregate;
+  return result;
+}
+
+ArrayRef<SymbolicValue> SymbolicValue::getAggregateValue() const {
+  assert(getKind() == Aggregate);
+  return value.aggregate->getElements();
+}
+

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
@@ -17,9 +17,7 @@
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SubstitutionMap.h"
 #include "swift/Basic/Defer.h"
-#include "swift/Demangling/Demangle.h"
 #include "llvm/Support/CommandLine.h"
-#include "llvm/Support/TrailingObjects.h"
 
 using namespace swift;
 using namespace tf;
@@ -35,378 +33,6 @@ evaluateAndCacheCall(SILFunction &fn, SubstitutionList substitutions,
                      SmallVectorImpl<SymbolicValue> &results,
                      unsigned &numInstEvaluated,
                      ConstExprEvaluator &evaluator);
-
-//===----------------------------------------------------------------------===//
-// SymbolicValue implementation
-//===----------------------------------------------------------------------===//
-
-void SymbolicValue::print(llvm::raw_ostream &os, unsigned indent) const {
-  os.indent(indent);
-  switch (representationKind) {
-  case RK_UninitMemory: os << "uninit\n"; return;
-  case RK_Unknown: {
-    std::pair<SILNode *, UnknownReason> unknown = getUnknownValue();
-    switch (unknown.second) {
-    case UnknownReason::Default: os << "unknown: "; break;
-    case UnknownReason::TooManyInstructions: os << "unknown(toobig): "; break;
-    }
-    unknown.first->dump();
-    return;
-  }
-  case RK_Metatype:
-    os << "metatype: ";
-    getMetatypeValue()->print(os);
-    os << "\n";
-    return;
-  case RK_Function:
-    os << "fn: " << getFunctionValue()->getName() << ": ";
-    os << Demangle::demangleSymbolAsString(getFunctionValue()->getName());
-    os << "\n";
-    return;
-  case RK_Inst:
-    os << "inst: ";
-    value.inst->dump();
-    return;
-  case RK_Integer:
-    os << "int: " << getIntegerValue() << "\n";
-    return;
-  case RK_Float:
-    os << "float: ";
-    getFloatValue().print(os);
-    os << "\n";
-    return;
-  case RK_Address: {
-    os << "address indices = [";
-    interleave(getAddressIndices(), [&](unsigned idx) { os << idx; },
-               [&]() { os << ", "; });
-    os << "]:  " << getAddressBase();
-    return;
-  }
-  case RK_Aggregate: {
-    ArrayRef<SymbolicValue> elements = getAggregateValue();
-    os << "agg: " << elements.size() << " element" << "s"[elements.size() == 1]
-       << " [\n";
-    for (auto elt : elements)
-      elt.print(os, indent+2);
-    os.indent(indent) << "]\n";
-    return;
-  }
-  }
-}
-
-void SymbolicValue::dump() const {
-  print(llvm::errs());
-}
-
-/// For constant values, return the classification of this value.  We have
-/// multiple forms for efficiency, but provide a simpler interface to clients.
-SymbolicValue::Kind SymbolicValue::getKind() const {
-  switch (representationKind) {
-  case RK_UninitMemory: return UninitMemory;
-  case RK_Unknown:      return Unknown;
-  case RK_Metatype:     return Metatype;
-  case RK_Function:     return Function;
-  case RK_Address:      return Address;
-  case RK_Aggregate:    return Aggregate;
-  case RK_Integer:      return Integer;
-  case RK_Float:        return Float;
-  case RK_Inst:
-    auto *inst = value.inst;
-    if (isa<IntegerLiteralInst>(inst))
-      return Integer;
-    if (isa<FloatLiteralInst>(inst))
-      return Float;
-    assert(isa<StringLiteralInst>(inst) && "Unknown ConstantInst kind");
-    return String;
-  }
-}
-
-
-//===----------------------------------------------------------------------===//
-// Integers
-//===----------------------------------------------------------------------===//
-
-namespace swift {
-namespace tf {
-/// This is a representation of an integer value, stored as a trailing array
-/// of words.  Elements of this value are bump pointer allocated.
-struct alignas(uint64_t) APIntSymbolicValue final
-  : private llvm::TrailingObjects<APIntSymbolicValue, uint64_t> {
-    friend class llvm::TrailingObjects<APIntSymbolicValue, uint64_t>;
-
-  /// The number of words in the trailing array and # bits of the value.
-  const unsigned numWords, numBits;
-
-  static APIntSymbolicValue *create(unsigned numBits,
-                                    ArrayRef<uint64_t> elements,
-                                    llvm::BumpPtrAllocator &allocator) {
-    auto byteSize =
-      APIntSymbolicValue::totalSizeToAlloc<uint64_t>(elements.size());
-    auto rawMem = allocator.Allocate(byteSize, alignof(APIntSymbolicValue));
-
-    //  Placement initialize the APIntSymbolicValue.
-    auto ilv = ::new (rawMem) APIntSymbolicValue(numBits, elements.size());
-    std::uninitialized_copy(elements.begin(), elements.end(),
-                            ilv->getTrailingObjects<uint64_t>());
-    return ilv;
-  }
-
-  APInt getValue() const {
-    return APInt(numBits, { getTrailingObjects<uint64_t>(), numWords });
-  }
-
-  // This is used by the llvm::TrailingObjects base class.
-  size_t numTrailingObjects(OverloadToken<uint64_t>) const {
-    return numWords;
-  }
-private:
-  APIntSymbolicValue() = delete;
-  APIntSymbolicValue(const APIntSymbolicValue &) = delete;
-  APIntSymbolicValue(unsigned numBits, unsigned numWords)
-    : numWords(numWords), numBits(numBits) {}
-};
-} // end namespace tf
-} // end namespace swift
-
-
-SymbolicValue SymbolicValue::getInteger(const APInt &value,
-                                        llvm::BumpPtrAllocator &allocator) {
-  // TODO: Could store these inline in the union in the common case.
-  auto intValue =
-    APIntSymbolicValue::create(value.getBitWidth(),
-                               { value.getRawData(), value.getNumWords()},
-                               allocator);
-  assert(intValue && "aggregate value must be present");
-  SymbolicValue result;
-  result.representationKind = RK_Integer;
-  result.value.integer = intValue;
-  return result;
-}
-
-APInt SymbolicValue::getIntegerValue() const {
-  assert(getKind() == Integer);
-  if (representationKind == RK_Integer)
-    return value.integer->getValue();
-
-  assert(representationKind == RK_Inst);
-  // TODO: Will eventually support the bump-pointer allocated folded int value.
-  return cast<IntegerLiteralInst>(value.inst)->getValue();
-}
-
-//===----------------------------------------------------------------------===//
-// Floats
-//===----------------------------------------------------------------------===//
-
-namespace swift {
-namespace tf {
-/// This is a representation of an integer value, stored as a trailing array
-/// of words.  Elements of this value are bump pointer allocated.
-struct alignas(uint64_t) APFloatSymbolicValue final
-  : private llvm::TrailingObjects<APFloatSymbolicValue, uint64_t> {
-    friend class llvm::TrailingObjects<APFloatSymbolicValue, uint64_t>;
-
-  const llvm::fltSemantics &semantics;
-
-  static APFloatSymbolicValue *create(const llvm::fltSemantics &semantics,
-                                     ArrayRef<uint64_t> elements,
-                                     llvm::BumpPtrAllocator &allocator) {
-    assert((APFloat::getSizeInBits(semantics)+63)/64 == elements.size());
-
-    auto byteSize =
-      APFloatSymbolicValue::totalSizeToAlloc<uint64_t>(elements.size());
-    auto rawMem = allocator.Allocate(byteSize, alignof(APFloatSymbolicValue));
-
-    //  Placement initialize the APFloatSymbolicValue.
-    auto ilv = ::new (rawMem) APFloatSymbolicValue(semantics);
-    std::uninitialized_copy(elements.begin(), elements.end(),
-                            ilv->getTrailingObjects<uint64_t>());
-    return ilv;
-  }
-
-  APFloat getValue() const {
-    auto val = APInt(APFloat::getSizeInBits(semantics),
-                     { getTrailingObjects<uint64_t>(),
-                       numTrailingObjects(OverloadToken<uint64_t>())
-                     });
-    return APFloat(semantics, val);
-  }
-
-  // This is used by the llvm::TrailingObjects base class.
-  size_t numTrailingObjects(OverloadToken<uint64_t>) const {
-    return (APFloat::getSizeInBits(semantics)+63)/64;
-  }
-private:
-  APFloatSymbolicValue() = delete;
-  APFloatSymbolicValue(const APFloatSymbolicValue &) = delete;
-  APFloatSymbolicValue(const llvm::fltSemantics &semantics)
-    : semantics(semantics) {}
-};
-} // end namespace tf
-} // end namespace swift
-
-
-SymbolicValue SymbolicValue::getFloat(const APFloat &value,
-                                      llvm::BumpPtrAllocator &allocator) {
-  APInt val = value.bitcastToAPInt();
-
-  // TODO: Could store these inline in the union in the common case.
-  auto fpValue =
-    APFloatSymbolicValue::create(value.getSemantics(),
-                                 { val.getRawData(), val.getNumWords()},
-                                 allocator);
-  assert(fpValue && "aggregate value must be present");
-  SymbolicValue result;
-  result.representationKind = RK_Float;
-  result.value.float_ = fpValue;
-  return result;
-}
-
-
-APFloat SymbolicValue::getFloatValue() const {
-  assert(getKind() == Float);
-
-  if (representationKind == RK_Float)
-    return value.float_->getValue();
-
-  assert(representationKind == RK_Inst);
-  return cast<FloatLiteralInst>(value.inst)->getValue();
-}
-
-//===----------------------------------------------------------------------===//
-// Addresses
-//===----------------------------------------------------------------------===//
-
-namespace swift {
-namespace tf {
-/// This is a representation of an address value, stored as a base pointer plus
-/// trailing array of indices.  Elements of this value are bump pointer
-/// allocated.
-struct alignas(SILValue) AddressSymbolicValue final
-  : private llvm::TrailingObjects<AddressSymbolicValue, unsigned> {
-    friend class llvm::TrailingObjects<AddressSymbolicValue, unsigned>;
-
-  /// The number of words in the trailing array and # bits of the value.
-  const SILValue base;
-  const unsigned numIndices;
-
-  static AddressSymbolicValue *create(SILValue base, ArrayRef<unsigned> indices,
-                                      llvm::BumpPtrAllocator &allocator) {
-    auto byteSize =
-      AddressSymbolicValue::totalSizeToAlloc<unsigned>(indices.size());
-    auto rawMem = allocator.Allocate(byteSize, alignof(AddressSymbolicValue));
-
-    //  Placement initialize the AddressSymbolicValue.
-    auto alv = ::new (rawMem) AddressSymbolicValue(base, indices.size());
-    std::uninitialized_copy(indices.begin(), indices.end(),
-                            alv->getTrailingObjects<unsigned>());
-    return alv;
-  }
-
-  ArrayRef<unsigned> getIndices() const {
-    return { getTrailingObjects<unsigned>(), numIndices };
-  }
-
-  // This is used by the llvm::TrailingObjects base class.
-  size_t numTrailingObjects(OverloadToken<unsigned>) const {
-    return numIndices;
-  }
-private:
-  AddressSymbolicValue() = delete;
-  AddressSymbolicValue(const AddressSymbolicValue &) = delete;
-  AddressSymbolicValue(SILValue base, unsigned numIndices)
-    : base(base), numIndices(numIndices) {}
-};
-} // end namespace tf
-} // end namespace swift
-
-
-SymbolicValue
-SymbolicValue::getAddress(SILValue base, ArrayRef<unsigned> indices,
-                          llvm::BumpPtrAllocator &allocator) {
-  auto alv = AddressSymbolicValue::create(base, indices, allocator);
-  assert(alv && "aggregate value must be present");
-  SymbolicValue result;
-  result.representationKind = RK_Address;
-  result.value.address = alv;
-  return result;
-}
-
-SILValue SymbolicValue::getAddressBase() const {
-  assert(representationKind == RK_Address);
-  return value.address->base;
-}
-
-ArrayRef<unsigned> SymbolicValue::getAddressIndices() const {
-  assert(representationKind == RK_Address);
-  return value.address->getIndices();
-}
-
-
-//===----------------------------------------------------------------------===//
-// Aggregates
-//===----------------------------------------------------------------------===//
-
-namespace swift {
-namespace tf {
-/// This is the representation of a constant aggregate value.  It maintains
-/// the elements as a trailing array of SymbolicValue's.  Note that single
-/// element structs do not use this (as a performance optimization to reduce
-/// allocations).
-struct alignas(SymbolicValue) AggregateSymbolicValue final
-: private llvm::TrailingObjects<AggregateSymbolicValue, SymbolicValue> {
-  friend class llvm::TrailingObjects<AggregateSymbolicValue, SymbolicValue>;
-
-  /// This is the number of elements in the aggregate.
-  const unsigned numElements;
-
-  static AggregateSymbolicValue *create(ArrayRef<SymbolicValue> elements,
-                                       llvm::BumpPtrAllocator &allocator) {
-    auto byteSize =
-      AggregateSymbolicValue::totalSizeToAlloc<SymbolicValue>(elements.size());
-    auto rawMem = allocator.Allocate(byteSize, alignof(AggregateSymbolicValue));
-
-    //  Placement initialize the AggregateSymbolicValue.
-    auto alv = ::new (rawMem) AggregateSymbolicValue(elements.size());
-    std::uninitialized_copy(elements.begin(), elements.end(),
-                            alv->getTrailingObjects<SymbolicValue>());
-    return alv;
-  }
-
-  /// Return the element constants for this aggregate constant.  These are
-  /// known to all be constants.
-  ArrayRef<SymbolicValue> getElements() const {
-    return { getTrailingObjects<SymbolicValue>(), numElements };
-  }
-
-  // This is used by the llvm::TrailingObjects base class.
-  size_t numTrailingObjects(OverloadToken<SymbolicValue>) const {
-    return numElements;
-  }
-private:
-  AggregateSymbolicValue() = delete;
-  AggregateSymbolicValue(const AggregateSymbolicValue &) = delete;
-  AggregateSymbolicValue(unsigned numElements) : numElements(numElements) {}
-};
-} // end namespace tf
-} // end namespace swift
-
-
-/// This returns a constant Symbolic value with the specified elements in it.
-/// This assumes that the elements lifetime has been managed for this.
-SymbolicValue SymbolicValue::getAggregate(ArrayRef<SymbolicValue> elements,
-                                          llvm::BumpPtrAllocator &allocator) {
-  auto aggregate = AggregateSymbolicValue::create(elements, allocator);
-  assert(aggregate && "aggregate value must be present");
-  SymbolicValue result;
-  result.representationKind = RK_Aggregate;
-  result.value.aggregate = aggregate;
-  return result;
-}
-
-ArrayRef<SymbolicValue> SymbolicValue::getAggregateValue() const {
-  assert(getKind() == Aggregate);
-  return value.aggregate->getElements();
-}
 
 
 
@@ -485,20 +111,31 @@ Type ConstExprFunctionCache::simplifyType(Type ty) {
   return substitutionMap.empty() ? ty : ty.subst(substitutionMap);
 }
 
+/// Lazily initialize the specified SIL Loader.
+static SerializedSILLoader &
+initLoader(std::unique_ptr<SerializedSILLoader> &silLoader, SILModule &module) {
+  if (!silLoader)
+    silLoader = SerializedSILLoader::create(module.getASTContext(),
+                                            &module, nullptr);
+  return *silLoader;
+}
+
+
 // TODO: refactor this out somewhere sharable between autodiff and this code.
 static SILWitnessTable *
-lookupOrLinkWitnessTable(ProtocolConformanceRef confRef,
-                         SILModule &module,
-                         SerializedSILLoader &silLoader) {
+lookupOrLinkWitnessTable(ProtocolConformanceRef confRef, SILModule &module,
+                         std::unique_ptr<SerializedSILLoader> &silLoader) {
   auto *conf = confRef.getConcrete();
   auto wtable = module.lookUpWitnessTable(conf);
   if (wtable) return wtable;
+
+
 
   auto *decl =
     conf->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
   auto linkage = getSILLinkage(getDeclLinkage(decl), NotForDefinition);
   auto *newTable = module.createWitnessTableDeclaration(conf, linkage);
-  newTable = silLoader.lookupWitnessTable(newTable);
+  newTable = initLoader(silLoader, module).lookupWitnessTable(newTable);
   // Update linkage for witness methods.
   // FIXME: Figure out why witnesses have shared linkage by default.
   for (auto &entry : newTable->getEntries())
@@ -950,7 +587,8 @@ ConstExprFunctionCache::computeCallResult(ApplyInst *apply) {
   // sure to pull it in so we can see its body.  If that fails, then we can't
   // analyze the function.
   if (callee->isExternalDeclaration()) {
-    callee = evaluator.getSILLoader().lookupSILFunction(callee);
+    callee = initLoader(evaluator.getSILLoader(),
+                        callee->getModule()).lookupSILFunction(callee);
     if (!callee || callee->isExternalDeclaration()) {
       DEBUG(llvm::errs() << "ConstExpr Opaque Callee: "
                          << *calleeLV.getFunctionValue() << "\n");
@@ -1356,8 +994,7 @@ evaluateAndCacheCall(SILFunction &fn, SubstitutionList substitutions,
 // ConstExprEvaluator implementation.
 //===----------------------------------------------------------------------===//
 
-ConstExprEvaluator::ConstExprEvaluator(SILModule &m)
-  : silLoader(SerializedSILLoader::create(m.getASTContext(), &m, nullptr)) {
+ConstExprEvaluator::ConstExprEvaluator(SILModule &m) {
 }
 
 ConstExprEvaluator::~ConstExprEvaluator() {

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.h
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.h
@@ -24,8 +24,8 @@
 #ifndef SWIFT_SILOPTIMIZER_TF_CONSTEXPR_H
 #define SWIFT_SILOPTIMIZER_TF_CONSTEXPR_H
 
+#include "swift/SIL/SILConstants.h"
 #include "llvm/Support/Allocator.h"
-#include "swift/SIL/SILValue.h"
 
 namespace swift {
   class SingleValueInstruction;
@@ -34,279 +34,37 @@ namespace swift {
   class SerializedSILLoader;
 
 namespace tf {
-  struct APIntSymbolicValue;
-  struct APFloatSymbolicValue;
-  struct AddressSymbolicValue;
-  struct AggregateSymbolicValue;
 
-  /// When we fail to constant fold a value, this captures a reason why,
-  /// allowing the caller to produce a specific diagnostic.  The "Unknown"
-  /// SymbolicValue representation also includes a pointer to the SILNode in
-  /// question that was problematic.
-  enum class UnknownReason {
-    // TODO: Eliminate the default code, by making classifications for each
-    // failure mode.
-    Default,
+/// This class is the main entrypoint for evaluating constant expressions.  It
+/// also handles caching of previously computed constexpr results.
+class ConstExprEvaluator {
+  /// This is a long-lived bump pointer allocator that holds the arguments and
+  /// result values for the cached constexpr calls we have already analyzed.
+  llvm::BumpPtrAllocator allocator;
 
-    /// The constant expression was too big.  This is reported on a random
-    /// instruction within the constexpr that triggered the issue.
-    TooManyInstructions,
-  };
+  /// This is a handle to a loader for serialized code.
+  std::unique_ptr<SerializedSILLoader> silLoader;
 
+  ConstExprEvaluator(const ConstExprEvaluator &) = delete;
+  void operator=(const ConstExprEvaluator &) = delete;
+public:
+  explicit ConstExprEvaluator(SILModule &m);
+  ~ConstExprEvaluator();
 
-  /// This is the symbolic value tracked for each SILValue in a scope.  We
-  /// support multiple representational forms for the constant node in order to
-  /// avoid pointless memory bloat + copying.  This is intended to be a
-  /// light-weight POD type we can put in hash tables and pass around by-value.
+  llvm::BumpPtrAllocator &getAllocator() { return allocator; }
+  std::unique_ptr<SerializedSILLoader> &getSILLoader() { return silLoader; }
+
+  /// Analyze the specified values to determine if they are constant values.
+  /// This is done in code that is not necessarily itself a constexpr
+  /// function.  The results are added to the results list which is a parallel
+  /// structure to the input values.
   ///
-  /// Internally, this value has multiple ways to represent the same sorts of
-  /// symbolic values (e.g. to save memory).  It provides a simpler public
-  /// interface though.
-  class SymbolicValue {
-    enum RepresentationKind {
-      /// This value is an alloc stack that is has not (yet) been initialized
-      /// by flow-sensitive analysis.
-      RK_UninitMemory,
-
-      /// This symbolic value cannot be determined, carries multiple values
-      /// (i.e., varies dynamically at the top level), or is of some type that
-      /// we cannot analyze and propagate (e.g. NSObject).
-      ///
-      RK_Unknown,
-
-      /// This value is known to be a metatype reference.  The type is stored
-      /// in the "metatype" member.
-      RK_Metatype,
-
-      /// This value is known to be a function reference, e.g. through
-      /// function_ref directly, or a devirtualized method reference.
-      RK_Function,
-
-      /// This value is a constant, and tracked by the "inst" member of the
-      /// value union.  This could be an integer, floating point, string, or
-      /// metatype value.
-      RK_Inst,
-
-      /// This value is represented with a bump pointer allocated APInt.
-      /// TODO: We could store small integers into the union inline to avoid
-      /// allocations if it ever matters.
-      RK_Integer,
-
-      /// This value is represented with a bump pointer allocated APFloat.
-      /// TODO: We could store small floats into the union inline to avoid
-      /// allocations if it ever matters.
-      RK_Float,
-
-      /// This value is a pointer to a tracked memory location, along with zero
-      /// or more indices (tuple indices, struct field indices, etc) into the
-      /// value if it is an aggregate.
-      ///
-      RK_Address,
-
-      /// This value is an array, struct, or tuple of constants.  This is
-      /// tracked by the "aggregate" member of the value union.  Note that we
-      /// cheat and represent single-element structs as the value of their
-      /// element (since they are so common).
-      RK_Aggregate,
-    };
-
-    RepresentationKind representationKind : 8;
-
-    union {
-      UnknownReason unknown_reason;
-      //unsigned integer_bitwidth;
-      // ...
-    } aux;
-
-    union {
-      /// When the value is Unknown, this contains the value that was the
-      /// unfoldable part of the computation.
-      ///
-      /// TODO: make this a more rich representation.
-      SILNode *unknown;
-
-      /// This is always a SILType with an object category.  This is the value
-      /// of the underlying instance type, not the MetatypeType.
-      TypeBase *metatype;
-
-      SILFunction *function;
-
-      /// When this SymbolicValue is of "Inst" kind, this contains a
-      /// pointer to the instruction whose value this holds.  This is known to
-      /// be one of a closed set of constant instructions:
-      ///    IntegerLiteralInst, FloatLiteralInst, StringLiteralInst
-      SingleValueInstruction *inst;
-
-      /// When this SymbolicValue is of "Integer" kind, this pointer stores
-      /// information about the APInt value it holds.
-      APIntSymbolicValue *integer;
-
-      /// When this SymbolicValue is of "Float" kind, this pointer stores
-      /// information about the APFloat value it holds.
-      APFloatSymbolicValue *float_;
-
-      /// When this SymbolicValue is of "Address" kind, this pointer stores
-      /// info about the base and the indices for the address.
-      AddressSymbolicValue *address;
-
-      /// When this SymbolicValue is of "Aggregate" kind, this pointer stores
-      /// information about the array elements, count, and element type.
-      AggregateSymbolicValue *aggregate;
-    } value;
-
-  public:
-
-    /// This enum is used to indicate the sort of value held by a SymbolicValue
-    /// independent of its concrete representation.  This is the public
-    /// interface to SymbolicValue.
-    enum Kind {
-      Unknown, Metatype, Function, Integer, Float, String, Aggregate,
-
-      // These values are generally only seen internally to the system, external
-      // clients shouldn't have to deal with them.
-      Address, UninitMemory
-    };
-
-    /// For constant values, return the type classification of this value.
-    Kind getKind() const;
-
-    /// Return true if this represents a constant value.
-    bool isConstant() const {
-      auto kind = getKind();
-      return kind != Unknown && kind != UninitMemory;
-    }
-
-    static SymbolicValue getUnknown(SILNode *node, UnknownReason reason) {
-      assert(node && "node must be present");
-      SymbolicValue result;
-      result.representationKind = RK_Unknown;
-      result.value.unknown = node;
-      result.aux.unknown_reason = reason;
-      return result;
-    }
-
-    /// Return information about an unknown result, including the SIL node that
-    /// is a problem, and the reason it is an issue.
-    std::pair<SILNode *, UnknownReason> getUnknownValue() const {
-      assert(representationKind == RK_Unknown);
-      return { value.unknown, aux.unknown_reason };
-    }
-
-    static SymbolicValue getUninitMemory() {
-      SymbolicValue result;
-      result.representationKind = RK_UninitMemory;
-      return result;
-    }
-
-    static SymbolicValue getMetatype(CanType type) {
-      SymbolicValue result;
-      result.representationKind = RK_Metatype;
-      result.value.metatype = type.getPointer();
-      return result;
-    }
-
-    CanType getMetatypeValue() const {
-      assert(representationKind == RK_Metatype);
-      return CanType(value.metatype);
-    }
-
-    static SymbolicValue getFunction(SILFunction *fn) {
-      assert(fn && "Function cannot be null");
-      SymbolicValue result;
-      result.representationKind = RK_Function;
-      result.value.function = fn;
-      return result;
-    }
-
-    SILFunction *getFunctionValue() const {
-      assert(getKind() == Function);
-      return value.function;
-    }
-
-    static SymbolicValue getConstantInst(SingleValueInstruction *inst) {
-      assert(inst && "inst value must be present");
-      SymbolicValue result;
-      result.representationKind = RK_Inst;
-      result.value.inst = inst;
-      return result;
-    }
-
-    // TODO: Remove this, it is just needed because deabstraction has no SIL
-    // instruction of its own.
-    SingleValueInstruction *getConstantInstIfPresent() const {
-      return representationKind == RK_Inst ? value.inst : nullptr;
-    }
-
-    static SymbolicValue getInteger(const APInt &value,
-                                    llvm::BumpPtrAllocator &allocator);
-
-    APInt getIntegerValue() const;
-
-    static SymbolicValue getFloat(const APFloat &value,
-                                  llvm::BumpPtrAllocator &allocator);
-
-    APFloat getFloatValue() const;
-
-    /// Get a SymbolicValue corresponding to a memory object with an optional
-    /// list of indices into it.  This is used by (e.g.) a struct_element_addr
-    /// of a stack_alloc.
-    static SymbolicValue getAddress(SILValue base,
-                                    ArrayRef<unsigned> indices,
-                                    llvm::BumpPtrAllocator &allocator);
-
-    /// Accessors for Address SymbolicValue's.
-    bool isAddress() const {
-      return getKind() == Address;
-    }
-
-    SILValue getAddressBase() const;
-    ArrayRef<unsigned> getAddressIndices() const;
-
-
-    /// This returns an aggregate value with the specified elements in it.  This
-    /// copies the elements into the specified allocator.
-    static SymbolicValue getAggregate(ArrayRef<SymbolicValue> elements,
-                                      llvm::BumpPtrAllocator &allocator);
-
-    ArrayRef<SymbolicValue> getAggregateValue() const;
-
-
-    // TODO: getStringValue.
-
-    void print(llvm::raw_ostream &os, unsigned indent = 0) const;
-    void dump() const;
-  };
-
-  /// This class is the main entrypoint for evaluating constant expressions.  It
-  /// also handles caching of previously computed constexpr results.
-  class ConstExprEvaluator {
-    /// This is a long-lived bump pointer allocator that holds the arguments and
-    /// result values for the cached constexpr calls we have already analyzed.
-    llvm::BumpPtrAllocator allocator;
-
-    /// This is a handle to a loader for serialized code.
-    const std::unique_ptr<SerializedSILLoader> silLoader;
-
-    ConstExprEvaluator(const ConstExprEvaluator &) = delete;
-    void operator=(const ConstExprEvaluator &) = delete;
-  public:
-    explicit ConstExprEvaluator(SILModule &m);
-    ~ConstExprEvaluator();
-
-    llvm::BumpPtrAllocator &getAllocator() { return allocator; }
-    SerializedSILLoader &getSILLoader() const { return *silLoader; }
-
-    /// Analyze the specified values to determine if they are constant values.
-    /// This is done in code that is not necessarily itself a constexpr
-    /// function.  The results are added to the results list which is a parallel
-    /// structure to the input values.
-    ///
-    /// TODO: Return information about which callees were found to be
-    /// constexprs, which would allow the caller to delete dead calls to them
-    /// that occur after after folding them.
-    void computeConstantValues(ArrayRef<SILValue> values,
-                               SmallVectorImpl<SymbolicValue> &results);
-  };
+  /// TODO: Return information about which callees were found to be
+  /// constexprs, which would allow the caller to delete dead calls to them
+  /// that occur after after folding them.
+  void computeConstantValues(ArrayRef<SILValue> values,
+                             SmallVectorImpl<SymbolicValue> &results);
+};
 
 } // end namespace tf
 } // end namespace swift


### PR DESCRIPTION
This is in prep for Dan's GraphOperationInst.  Also, make the SerializedSILLoader be lazily
allocated on first use, since it is expensive to create.  NFC.