### PR TITLE
Move note generation out of TFDeabstraction into SILConstants and adopt it in #assert

### DIFF
--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -262,8 +262,12 @@ public:
 
   ArrayRef<SymbolicValue> getAggregateValue() const;
 
-
   // TODO: getStringValue.
+
+
+  /// Given that this is an 'Unknown' value, emit diagnostic notes providing
+  /// context about what the problem is.
+  void emitUnknownDiagnosticNotes();
 
   void print(llvm::raw_ostream &os, unsigned indent = 0) const;
   void dump() const;

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
@@ -13,6 +13,7 @@
 #define DEBUG_TYPE "TFConstExpr"
 #include "TFConstExpr.h"
 #include "swift/SIL/SILBuilder.h"
+#include "swift/SIL/SILConstants.h"
 #include "swift/Serialization/SerializedSILLoader.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/SubstitutionMap.h"
@@ -128,8 +129,6 @@ lookupOrLinkWitnessTable(ProtocolConformanceRef confRef, SILModule &module,
   auto *conf = confRef.getConcrete();
   auto wtable = module.lookUpWitnessTable(conf);
   if (wtable) return wtable;
-
-
 
   auto *decl =
     conf->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
@@ -607,7 +606,7 @@ ConstExprFunctionCache::computeCallResult(ApplyInst *apply) {
     // call.
     auto cst = getConstantValue(apply->getOperand(applyParamBaseIndex+i));
     if (!cst.isConstant())
-      return failure(UnknownReason::Default);
+      return cst;
 
     paramConstants.push_back(cst);
   }

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.h
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.h
@@ -24,14 +24,16 @@
 #ifndef SWIFT_SILOPTIMIZER_TF_CONSTEXPR_H
 #define SWIFT_SILOPTIMIZER_TF_CONSTEXPR_H
 
-#include "swift/SIL/SILConstants.h"
 #include "llvm/Support/Allocator.h"
+#include "swift/Basic/LLVM.h"
 
 namespace swift {
   class SingleValueInstruction;
-  class SILValue;
   class SILBuilder;
+  class SILModule;
+  class SILValue;
   class SerializedSILLoader;
+  class SymbolicValue;
 
 namespace tf {
 

--- a/test/SILOptimizer/pound_assert.swift
+++ b/test/SILOptimizer/pound_assert.swift
@@ -18,3 +18,16 @@ func nonConstant() {
   #assert(isOne(Int(readLine()!)!)) // expected-error{{#assert condition not constant}}
   #assert(isOne(Int(readLine()!)!), "input is not 1") // expected-error{{#assert condition not constant}}
 }
+
+
+
+func recursive(a: Int) -> Int {
+  if a == 0 { return 0 }     // expected-note {{expression is too large to evaluate at compile-time}}
+  return recursive(a: a-1)
+}
+
+func recursion() {
+  // expected-error @+1 {{#assert condition not constant}}
+  #assert(recursive(a: 20000) > 42)
+}
+

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -2,18 +2,6 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -Xllvm -tf-strict-deabstraction -verify %s | %FileCheck %s
 import TensorFlow
 
-// TODO: move this to a #assert test.
-func recursive(a: Int) -> Int {
-  if a == 0 { return 0 }     // expected-note {{expression is too large to evaluate at compile-time}}
-  return recursive(a: a-1)
-}
-public func recursion(a: Tensor<Float>, idx: Tensor<Int32>) -> Tensor<Float> {
-  // expected-error @+1 {{attribute 'axis' requires a constant argument}}
-  return Tensor<Float>(oneHotAtIndices: idx.toDevice(), depth: 0, axis: recursive(a: 20000))
-}
-
-
-
 
 public func trivialAdd(a: Tensor<Float>) -> Tensor<Float> {
   let b = a.toDevice()

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -48,7 +48,6 @@ public func tensorShape() -> Tensor<Float> {
   let shape : TensorShape = [2]
   // expected-error @+1 {{attribute 'value' requires a constant argument}}
   return Tensor(handle: #tfop("Const", dtype: Float.self, value$tensor: [1.0, 2.0], value$shape: shape))
-  // expected-note @-1 {{could not fold operation}}
 }
 
 // b/75407624


### PR DESCRIPTION
Move note generation out of TFDeabstraction into SILConstants and adopt it in #assert
generation.  Add a #assert testcase that generates notes.

This also changes constexpr calls to complain about their operands which regresses
a testcase slightly.  There will be a fix for that later.
