### PR TITLE
Fix validateDeclForNameLookup() to use the right flags when resolving type alias underlying type

### DIFF
--- a/lib/Sema/ITCDecl.cpp
+++ b/lib/Sema/ITCDecl.cpp
@@ -341,7 +341,7 @@ void IterativeTypeChecker::processResolveTypeDecl(
     if (typeAliasDecl->getDeclContext()->isModuleScopeContext() &&
         typeAliasDecl->getGenericParams() == nullptr) {
       TypeResolutionOptions options =
-                                   TypeResolutionFlags::TypeAliasUnderlyingType;
+        TypeResolutionFlags::TypeAliasUnderlyingType;
       if (!typeAliasDecl->getDeclContext()->isCascadingContextForLookup(
             /*functionsAreNonCascading*/true)) {
         options |= TypeResolutionFlags::KnownNonCascadingDependency;

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -3815,9 +3815,6 @@ void TypeChecker::resolveIsObjC(ValueDecl *VD) {
   auto dc = VD->getDeclContext();
   if (dc->getAsClassOrClassExtensionContext()) {
     // Members of classes can be @objc.
-
-    // FIXME: We
-    validateDeclForNameLookup(VD);
   }
   else if (isa<ClassDecl>(VD)) {
     // Classes can be @objc.

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7987,8 +7987,10 @@ void TypeChecker::validateDeclForNameLookup(ValueDecl *D) {
         validateAccessControl(typealias);
 
         ProtocolRequirementTypeResolver resolver;
+        TypeResolutionOptions options =
+          TypeResolutionFlags::TypeAliasUnderlyingType;
         if (validateType(typealias->getUnderlyingTypeLoc(),
-                         typealias, TypeResolutionOptions(), &resolver)) {
+                         typealias, options, &resolver)) {
           typealias->setInvalid();
           typealias->getUnderlyingTypeLoc().setInvalidType(Context);
         }

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -290,3 +290,12 @@ struct Y11: P11 { }
 extension P11 {
   func foo(_: X11<Self.A>) { }
 }
+
+// Ordering issue
+struct SomeConformingType : UnboundGenericAliasProto {
+  func f(_: G<Int>) {}
+}
+
+protocol UnboundGenericAliasProto {
+  typealias G = X
+}


### PR DESCRIPTION
Fixes bug reported here: https://forums.swift.org/t/am-i-hitting-a-compiler-bug/13372