### PR TITLE
Sema: Fix validateDeclForNameLookup() to use the right flags when resolving type alias underlying type [4.2]

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -7924,8 +7924,10 @@ void TypeChecker::validateDeclForNameLookup(ValueDecl *D) {
         validateAccessControl(typealias);
 
         ProtocolRequirementTypeResolver resolver;
+        TypeResolutionOptions options =
+          TypeResolutionFlags::TypeAliasUnderlyingType;
         if (validateType(typealias->getUnderlyingTypeLoc(),
-                         typealias, TypeResolutionOptions(), &resolver)) {
+                         typealias, options, &resolver)) {
           typealias->setInvalid();
           typealias->getUnderlyingTypeLoc().setInvalidType(Context);
         }

--- a/test/decl/typealias/protocol.swift
+++ b/test/decl/typealias/protocol.swift
@@ -290,3 +290,12 @@ struct Y11: P11 { }
 extension P11 {
   func foo(_: X11<Self.A>) { }
 }
+
+// Ordering issue
+struct SomeConformingType : UnboundGenericAliasProto {
+  func f(_: G<Int>) {}
+}
+
+protocol UnboundGenericAliasProto {
+  typealias G = X
+}


### PR DESCRIPTION
Otherwise, we would in some cases reject this idiom, which looks odd
at first glance but we do support and users rely on:

```
struct Generic<T> {}

protocol P {
  typealias X = Generic
  // Equivalent to 'typealias X<T> = Generic<T>'
}
```