### PR TITLE
Building macOS SDK is also required for cross compiling

### DIFF
--- a/docs/WindowsCrossCompile.md
+++ b/docs/WindowsCrossCompile.md
@@ -38,7 +38,7 @@ Additionally, the ICU headers and libraries need to be provided for the build.
 --extra-cmake-options=-DSWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER=FALSE,\
 -DCMAKE_AR=<path to llvm-ar>,\
 -DCMAKE_RANLIB=<path to llvm-ranlib>,\
--DSWIFT_SDKS=WINDOWS,\
+-DSWIFT_SDKS='OSX;WINDOWS',\
 -DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=<path to ICU i18n includes>,\
 -DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=<path to ICU UC includes>,\
 -DSWIFT_WINDOWS_x86_64_ICU_I18N=<path to ICU i18n lib>,\
@@ -47,19 +47,8 @@ Additionally, the ICU headers and libraries need to be provided for the build.
 
 #### Linux
 
-For Linux, you will also need to build the Linux SDK with the cmake options
-below.
-
-```bash
---extra-cmake-options=-DSWIFT_BUILD_RUNTIME_WITH_HOST_COMPILER=FALSE,\
--DCMAKE_AR=<path to llvm-ar>,\
--DCMAKE_RANLIB=<path to llvm-ranlib>,\
--DSWIFT_SDKS='LINUX;WINDOWS',\
--DSWIFT_WINDOWS_x86_64_ICU_I18N_INCLUDE=<path to ICU i18n includes>,\
--DSWIFT_WINDOWS_x86_64_ICU_UC_INCLUDE=<path to ICU UC includes>,\
--DSWIFT_WINDOWS_x86_64_ICU_I18N=<path to ICU i18n lib>,\
--DSWIFT_WINDOWS_x86_64_ICU_UC=<path to ICU UC lib>
-```
+For Linux, you will need to build the Linux SDK instead of the macOS SDK by
+replacing the cmake option with `-DSWIFT_SDKS='LINUX;WINDOWS'`.
 
 ## 4. Build the Swift runtime and standard library with `ninja`
 From the build directory, you can build the Swift runtime and standard library


### PR DESCRIPTION
<!-- What's in this pull request? -->
It turns out that building the macOS SDK is required for cross compiling with Windows. These cmake options have been tested on both Linux and macOS.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
