### PR TITLE
DI: Consider capture of `let`s to be a read-only use.

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -2203,6 +2203,7 @@ public:
                           ValueDecl *decl,
                           FunctionRefKind functionRefKind,
                           ConstraintLocatorBuilder locator,
+                          DeclContext *useDC,
                           const DeclRefExpr *base = nullptr);
 
   /// \brief Retrieve the type of a reference to the given value declaration,

--- a/test/SILGen/closures.swift
+++ b/test/SILGen/closures.swift
@@ -380,13 +380,11 @@ func closeOverLetLValue() {
 // CHECK:   [[TMP_CLASS_ADDR:%.*]] = alloc_stack $ClassWithIntProperty, let, name "a", argno 1
 // CHECK:   [[COPY_ARG:%.*]] = copy_value [[ARG]]
 // CHECK:   store [[COPY_ARG]] to [init] [[TMP_CLASS_ADDR]] : $*ClassWithIntProperty
-// CHECK:   [[LOADED_CLASS:%.*]] = load [copy] [[TMP_CLASS_ADDR]] : $*ClassWithIntProperty
-// CHECK:   [[BORROWED_LOADED_CLASS:%.*]] = begin_borrow [[LOADED_CLASS]]
+// CHECK:   [[BORROWED_LOADED_CLASS:%.*]] = load_borrow [[TMP_CLASS_ADDR]] : $*ClassWithIntProperty
 // CHECK:   [[INT_IN_CLASS_ADDR:%.*]] = ref_element_addr [[BORROWED_LOADED_CLASS]] : $ClassWithIntProperty, #ClassWithIntProperty.x
 // CHECK:   [[ACCESS:%.*]] = begin_access [read] [dynamic] [[INT_IN_CLASS_ADDR]] : $*Int
 // CHECK:   [[INT_IN_CLASS:%.*]] = load [trivial] [[ACCESS]] : $*Int
-// CHECK:   end_borrow [[BORROWED_LOADED_CLASS]] from [[LOADED_CLASS]]
-// CHECK:   destroy_value [[LOADED_CLASS]]
+// CHECK:   end_borrow [[BORROWED_LOADED_CLASS]] from [[TMP_CLASS_ADDR]]
 // CHECK:   destroy_addr [[TMP_CLASS_ADDR]] : $*ClassWithIntProperty
 // CHECK:   dealloc_stack %1 : $*ClassWithIntProperty
 // CHECK:   return [[INT_IN_CLASS]]
@@ -397,10 +395,8 @@ func closeOverLetLValue() {
 // GUARANTEED:   [[TMP:%.*]] = alloc_stack $ClassWithIntProperty
 // GUARANTEED:   [[COPY:%.*]] = copy_value %0 : $ClassWithIntProperty
 // GUARANTEED:   store [[COPY]] to [init] [[TMP]] : $*ClassWithIntProperty
-// GUARANTEED:   [[LOADED_COPY:%.*]] = load [copy] [[TMP]]
-// GUARANTEED:   [[BORROWED:%.*]] = begin_borrow [[LOADED_COPY]]
-// GUARANTEED:   end_borrow [[BORROWED]] from [[LOADED_COPY]]
-// GUARANTEED:   destroy_value [[LOADED_COPY]]
+// GUARANTEED:   [[BORROWED:%.*]] = load_borrow [[TMP]]
+// GUARANTEED:   end_borrow [[BORROWED]] from [[TMP]]
 // GUARANTEED:   destroy_addr [[TMP]]
 // GUARANTEED: } // end sil function '$S8closures18closeOverLetLValueyyFSiyXEfU_'
 

--- a/test/SILOptimizer/definite_init_address_only_let.swift
+++ b/test/SILOptimizer/definite_init_address_only_let.swift
@@ -1,0 +1,31 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s
+
+func foo<T>(a: Bool, t: T) {
+  let x: T
+  defer { print(x) }
+
+  x = t
+  return
+}
+
+func bar<T>(a: Bool, t: T) {
+  let x: T // expected-note {{defined here}}
+  defer { print(x) } //expected-error{{constant 'x' used before being initialized}}
+
+  if a {
+    x = t
+    return
+  }
+}
+
+func bas<T>(a: Bool, t: T) {
+  let x: T 
+  defer { print(x) }
+
+  if a {
+    x = t
+    return
+  }
+
+  x = t
+}

--- a/test/SILOptimizer/definite_init_diagnostics.swift
+++ b/test/SILOptimizer/definite_init_diagnostics.swift
@@ -83,11 +83,6 @@ func test2() {
   }
   b4 = 7
   
-  let b5: Any
-  b5 = "x"   
-  { takes_inout_any(&b5) }()   // expected-error {{immutable value 'b5' must not be passed inout}}
-  ({ takes_inout_any(&b5) })()   // expected-error {{immutable value 'b5' must not be passed inout}}
-
   // Structs
   var s1 : SomeStruct
   s1 = SomeStruct()   // ok

--- a/test/expr/closure/let.swift
+++ b/test/expr/closure/let.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+func frob(x: inout Int) {}
+
+func foo() {
+  let x: Int // expected-note* {{}}
+
+  x = 0
+
+  _ = { frob(x: x) }() // expected-error{{'x' is a 'let'}}
+  _ = { x = 0 }() // expected-error{{'x' is a 'let'}}
+  _ = { frob(x: x); x = 0 }() // expected-error 2 {{'x' is a 'let'}}
+}


### PR DESCRIPTION
SILGen emits capture of an address-only `let` property as @inout_aliasable, but Sema enforces that the closure is not really allowed to modify the property, so DI can consider the capture to be a read. Fixes rdar://problem/40828667.

A more principled solution would be to treat `let` captures as @in_guaranteed (see #17047), but that unfortunately leads to breakage elsewhere in the optimizer.