### PR TITLE
[Parse] Minor fix for parsing SIL BuiltinInst.

### DIFF
--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -2583,7 +2583,7 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
         continue;
       if (P.consumeIf(tok::r_paren))
         break;
-      P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "(' or ',");
+      P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, ")' or ',");
       return true;
     }
     

--- a/test/SIL/Parser/errors.sil
+++ b/test/SIL/Parser/errors.sil
@@ -21,6 +21,10 @@ bb0:
   %2 = tuple (%199 : $())  // expected-error {{use of undefined value '%199'}}
 }
 
+sil @local_value_errors2 : $() -> () {
+bb0:
+  %0 = builtin "cmp_eq_Int1"(%0 : $() // expected-error @+1 {{expected ')' or ',' in SIL instruction}}
+} // expected-error {{extraneous '}' at top level}}
 
 sil @global_value_errors : $() -> () {
 bb0:


### PR DESCRIPTION
The expected token in the diagnostic should be `")"`, not `"("`.

Contributed during the [try! Swift San Jose 2018 event](https://www.tryswift.co/events/2018/sanjose/)!