### PR TITLE
Reject bad string interpolations

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1227,7 +1227,7 @@ ERROR(string_interpolation_extra,none,
       "extra tokens after interpolated string expression", ())
 
 // Interpolated value accidentally forms a tuple.
-ERROR(string_interpolation_multiple_exprs,none,
+ERROR(string_interpolation_single_expr,none,
       "interpolations should be a single expression", ())
 NOTE(string_interpolation_form_tuple,none,
       "insert parentheses to form a tuple", ())

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1226,6 +1226,14 @@ ERROR(expected_type_after_as,none,
 ERROR(string_interpolation_extra,none,
       "extra tokens after interpolated string expression", ())
 
+// Interpolated value accidentally forms a tuple.
+ERROR(string_interpolation_multiple_exprs,none,
+      "interpolations should be a single expression", ())
+NOTE(string_interpolation_form_tuple,none,
+      "insert parentheses to form a tuple", ())
+ERROR(string_interpolation_keyword_argument,PointsToFirstBadToken,
+      "interpolations cannot start with a keyword argument", ())
+
 // Keypath expressions.
 ERROR(expr_keypath_expected_lparen,PointsToFirstBadToken,
       "expected '(' following '#keyPath'", ())

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1231,6 +1231,8 @@ ERROR(string_interpolation_single_expr,none,
       "interpolations should be a single expression", ())
 NOTE(string_interpolation_form_tuple,none,
       "insert parentheses to form a tuple", ())
+NOTE(string_interpolation_delete_empty,none,
+      "delete empty interpolation", ())
 ERROR(string_interpolation_keyword_argument,PointsToFirstBadToken,
       "interpolations cannot start with a keyword argument", ())
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1945,6 +1945,19 @@ parseStringSegments(SmallVectorImpl<Lexer::StringSegment> &Segments,
             Exprs.back() =
               new (Context) ParenExpr(SourceLoc(), tuple, SourceLoc(), 
                                       /*hasTrailingClosure=*/false);
+          } else if (tuple->getNumElements() == 0) {
+            SourceLoc StartLoc = tuple->getStartLoc();
+            SourceLoc EndLoc = tuple->getEndLoc();
+            SourceLoc SlashLoc = StartLoc.getAdvancedLocOrInvalid(-1);
+            
+            diagnose(EndLoc, diag::string_interpolation_single_expr);
+            diagnose(SlashLoc, diag::string_interpolation_delete_empty)
+              .fixItRemoveChars(SlashLoc, EndLoc.getAdvancedLocOrInvalid(1));
+            
+            auto Error = new (Context) ErrorExpr(SourceRange(EndLoc, EndLoc));
+            Exprs.back() =
+              new (Context) ParenExpr(SourceLoc(), Error, SourceLoc(), 
+                                    /*hasTrailingClosure=*/false);
           } else if (tuple->getNumElements() == 1 && 
                    !tuple->getElementName(0).empty()) {
             SourceLoc NameStart = tuple->getElementNameLoc(0);

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1937,7 +1937,7 @@ parseStringSegments(SmallVectorImpl<Lexer::StringSegment> &Segments,
             SourceLoc SecondExprLoc = tuple->getElement(1)->getStartLoc();
             SourceLoc EndLoc = tuple->getEndLoc();
             
-            diagnose(SecondExprLoc, diag::string_interpolation_multiple_exprs);
+            diagnose(SecondExprLoc, diag::string_interpolation_single_expr);
             diagnose(StartLoc, diag::string_interpolation_form_tuple)
               .fixItInsert(StartLoc, "(")
               .fixItInsertAfter(EndLoc, ")");

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1945,19 +1945,6 @@ parseStringSegments(SmallVectorImpl<Lexer::StringSegment> &Segments,
             Exprs.back() =
               new (Context) ParenExpr(SourceLoc(), tuple, SourceLoc(), 
                                       /*hasTrailingClosure=*/false);
-          } else if (tuple->getNumElements() == 0) {
-            SourceLoc StartLoc = tuple->getStartLoc();
-            SourceLoc EndLoc = tuple->getEndLoc();
-            SourceLoc SlashLoc = StartLoc.getAdvancedLocOrInvalid(-1);
-            
-            diagnose(EndLoc, diag::string_interpolation_single_expr);
-            diagnose(SlashLoc, diag::string_interpolation_delete_empty)
-              .fixItRemoveChars(SlashLoc, EndLoc.getAdvancedLocOrInvalid(1));
-            
-            auto Error = new (Context) ErrorExpr(SourceRange(EndLoc, EndLoc));
-            Exprs.back() =
-              new (Context) ParenExpr(SourceLoc(), Error, SourceLoc(), 
-                                    /*hasTrailingClosure=*/false);
           } else if (tuple->getNumElements() == 1 && 
                    !tuple->getElementName(0).empty()) {
             SourceLoc NameStart = tuple->getElementNameLoc(0);
@@ -1969,7 +1956,20 @@ parseStringSegments(SmallVectorImpl<Lexer::StringSegment> &Segments,
             Exprs.back() =
               new (Context) ParenExpr(tuple->getLParenLoc(), tuple->getElement(0), 
                                       tuple->getRParenLoc(), /*hasTrailingClosure=*/false);
-          }
+          } else if (tuple->getNumElements() == 0 && !Status.isError()) {
+            SourceLoc StartLoc = tuple->getStartLoc();
+            SourceLoc EndLoc = tuple->getEndLoc();
+            SourceLoc SlashLoc = StartLoc.getAdvancedLocOrInvalid(-1);
+            
+            diagnose(EndLoc, diag::string_interpolation_single_expr);
+            diagnose(SlashLoc, diag::string_interpolation_delete_empty)
+            .fixItRemoveChars(SlashLoc, EndLoc.getAdvancedLocOrInvalid(1));
+            
+            auto Error = new (Context) ErrorExpr(SourceRange(EndLoc, EndLoc));
+            Exprs.back() =
+            new (Context) ParenExpr(SourceLoc(), Error, SourceLoc(), 
+                                    /*hasTrailingClosure=*/false);
+          } 
         }
 
         if (!Tok.is(tok::eof)) {

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1930,8 +1930,8 @@ parseStringSegments(SmallVectorImpl<Lexer::StringSegment> &Segments,
         
         if (auto tuple = dyn_cast<TupleExpr>(Exprs.back())) {
           // If parseExprList() returns a TupleExpr instead of a ParenExpr, 
-          // the interpolation must have had an argument label, or multiple
-          // elements, or both. Reject these.
+          // the interpolation must have had an argument label, or the wrong 
+          // number of elements, or both. Reject these.
           if (tuple->getNumElements() > 1) {
             SourceLoc StartLoc = tuple->getStartLoc();
             SourceLoc SecondExprLoc = tuple->getElement(1)->getStartLoc();

--- a/lib/Parse/Parser.cpp
+++ b/lib/Parse/Parser.cpp
@@ -902,6 +902,10 @@ ParserStatus
 Parser::parseList(tok RightK, SourceLoc LeftLoc, SourceLoc &RightLoc,
                   bool AllowSepAfterLast, Diag<> ErrorDiag, SyntaxKind Kind,
                   llvm::function_ref<ParserStatus()> callback) {
+  auto TokIsStringInterpolationEOF = [&]() -> bool {
+    return Tok.is(tok::eof) && Tok.getText() == ")" && RightK == tok::r_paren;
+  };
+  
   llvm::Optional<SyntaxParsingContext> ListContext;
   ListContext.emplace(SyntaxContext, Kind);
   if (Kind == SyntaxKind::Unknown)
@@ -912,6 +916,10 @@ Parser::parseList(tok RightK, SourceLoc LeftLoc, SourceLoc &RightLoc,
   if (Tok.is(RightK)) {
     ListContext.reset();
     RightLoc = consumeToken(RightK);
+    return makeParserSuccess();
+  }
+  if (TokIsStringInterpolationEOF()) {
+    RightLoc = Tok.getLoc();
     return makeParserSuccess();
   }
 
@@ -933,7 +941,7 @@ Parser::parseList(tok RightK, SourceLoc LeftLoc, SourceLoc &RightLoc,
     // If the lexer stopped with an EOF token whose spelling is ")", then this
     // is actually the tuple that is a string literal interpolation context.
     // Just accept the ")" and build the tuple as we usually do.
-    if (Tok.is(tok::eof) && Tok.getText() == ")" && RightK == tok::r_paren) {
+    if (TokIsStringInterpolationEOF()) {
       RightLoc = Tok.getLoc();
       return Status;
     }

--- a/test/Parse/interpolation_tuple_errors.swift
+++ b/test/Parse/interpolation_tuple_errors.swift
@@ -20,4 +20,7 @@ func babyBear() {
 // Test with an argument label
 func funkyBear() {
   _ = "\(describing: str)" // expected-error{{interpolations cannot start with a keyword argument}} {{10-22=}}
+  _ = "\(format: str)" // expected-error{{interpolations cannot start with a keyword argument}} {{10-18=}}
+  _ = "\(validatingUTF8: str)" // expected-error{{interpolations cannot start with a keyword argument}} {{10-26=}}
+  _ = "\(fnord: str)" // expected-error{{interpolations cannot start with a keyword argument}} {{10-17=}}
 }

--- a/test/Parse/interpolation_tuple_errors.swift
+++ b/test/Parse/interpolation_tuple_errors.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend -typecheck -verify %s
+// RUN: %target-typecheck-verify-swift
 
 let str = "a"
 

--- a/test/Parse/interpolation_tuple_errors.swift
+++ b/test/Parse/interpolation_tuple_errors.swift
@@ -1,0 +1,23 @@
+// RUN: not %target-swift-frontend -typecheck -verify %s
+
+let str = "a"
+
+// Test with too many interpolated values.
+func papaBear() {
+  _ = "\(str, str)" // expected-error{{interpolations should be a single expression}} expected-note {{insert parentheses to form a tuple}} {{9-9=(}} {{19-19=)}}
+}
+
+// Test with too few interpolated values.
+func mamaBear() {
+  _ = "\()" // expected-error{{expected expression in list of expressions}}
+}
+
+// Test with the correct number of interpolated values.
+func babyBear() {
+  _ = "\(str)"
+}
+
+// Test with an argument label
+func funkyBear() {
+  _ = "\(describing: str)" // expected-error{{interpolations cannot start with a keyword argument}} {{10-22=}}
+}

--- a/test/Parse/interpolation_tuple_errors.swift
+++ b/test/Parse/interpolation_tuple_errors.swift
@@ -9,7 +9,7 @@ func papaBear() {
 
 // Test with too few interpolated values.
 func mamaBear() {
-  _ = "\()" // expected-error{{expected expression in list of expressions}}
+  _ = "\()" // expected-error{{interpolations should be a single expression}} expected-note {{delete empty interpolation}} {{8-11=}}
 }
 
 // Test with the correct number of interpolated values.

--- a/validation-test/compiler_crashers_2_fixed/0160-sr7958.swift
+++ b/validation-test/compiler_crashers_2_fixed/0160-sr7958.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 
 func foo<U>(_ x: U?) {
   _ = "\(anyLabelHere: x)"


### PR DESCRIPTION
String interpolations with multiple comma-separated expressions or argument labels were being incorrectly accepted. This change makes both of them into errors, with appropriate fix-its.

The comma-separated-expressions error could be a warning if we wanted to preserve source compatibility, but as far as I can tell there are no examples of it in the source compatibility suite. The argument-label one can cause an error/crash in serialization if not diagnosed.

Resolves [SR-7937](https://bugs.swift.org/browse/SR-7937) and [SR-7958](https://bugs.swift.org/browse/SR-7958).