### PR TITLE
[SR-7844] Fix error message for a subscript without accessors

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -248,7 +248,7 @@ ERROR(static_var_decl_global_scope,none,
       "%select{%error|static properties|class properties}0 may only be declared on a type",
       (StaticSpellingKind))
 ERROR(computed_property_no_accessors, none,
-      "computed property must have accessors specified", ())
+      "%select{computed property|subscript}0 must have accessors specified", (bool))
 ERROR(expected_getset_in_protocol,none,
       "expected get or set in a protocol property", ())
 ERROR(computed_property_missing_type,none,

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -4158,7 +4158,7 @@ bool Parser::parseGetSetImpl(ParseDeclOptions Flags,
     // Give syntax node an empty statement list.
     SyntaxParsingContext StmtListContext(SyntaxContext,
                                          SyntaxKind::CodeBlockItemList);
-    diagnose(Tok, diag::computed_property_no_accessors);
+    diagnose(Tok, diag::computed_property_no_accessors, /*subscript*/Indices != nullptr);
     return true;
   }
 

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -172,7 +172,7 @@ struct RetOverloadedSubscript {
 
 struct MissingGetterSubscript1 {
   subscript (i : Int) -> Int {
-  } // expected-error {{computed property must have accessors specified}}
+  } // expected-error {{subscript must have accessors specified}}
 }
 struct MissingGetterSubscript2 {
   subscript (i : Int, j : Int) -> Int { // expected-error{{subscript declarations must have a getter}}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Fix error message for a subscript without accessors says "computed property".

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7844](https://bugs.swift.org/browse/SR-7844).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
