### PR TITLE
[ConstraintSystem] Honor -solver-memory-threshold if present.

### DIFF
--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3096,6 +3096,15 @@ public:
   /// \brief Determine if we've already explored too many paths in an
   /// attempt to solve this expression.
   bool getExpressionTooComplex(SmallVectorImpl<Solution> const &solutions) {
+    auto used = TC.Context.getSolverMemory();
+    for (auto const& s : solutions) {
+      used += s.getTotalMemory();
+    }
+    MaxMemory = std::max(used, MaxMemory);
+    auto threshold = TC.Context.LangOpts.SolverMemoryThreshold;
+    if (MaxMemory > threshold)
+      return true;
+
     auto timeoutThresholdInMillis = TC.getExpressionTimeoutThresholdInSeconds();
     if (Timer && Timer->isExpired(timeoutThresholdInMillis)) {
       // Disable warnings about expressions that go over the warning
@@ -3119,18 +3128,12 @@ public:
         return true;
 
       // Bail out once we've looked at a really large number of
-      // choices, even if we haven't used a huge amount of memory.
+      // choices.
       if (CountScopes > TC.Context.LangOpts.SolverBindingThreshold)
         return true;
     }
 
-    auto used = TC.Context.getSolverMemory();
-    for (auto const& s : solutions) {
-      used += s.getTotalMemory();
-    }
-    MaxMemory = std::max(used, MaxMemory);
-    auto threshold = TC.Context.LangOpts.SolverMemoryThreshold;
-    return MaxMemory > threshold;
+    return false;
   }
   
   LLVM_ATTRIBUTE_DEPRECATED(

--- a/test/Misc/prioritize_solver_memory_threshold.swift
+++ b/test/Misc/prioritize_solver_memory_threshold.swift
@@ -1,0 +1,3 @@
+// RUN: %target-typecheck-verify-swift -solver-memory-threshold 1
+
+func foo() { _ = 1 } // expected-error {{the compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions}}


### PR DESCRIPTION
If the user specifies a memory threshold on the command-line, try to
honor that value and consider expressions too complex if we end up
allocating more memory than they specify.

Fixes rdar://problem/40952582 (aka https://bugs.swift.org/browse/SR-7525).
