### PR TITLE
[SIL] Add `GraphOperationInst`.

### DIFF
--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -5336,16 +5336,16 @@ graph_op
 
   sil-instruction ::= 'graph_op' string-literal
                       '(' (sil-operand (',' sil-operand)*)? ')'
-                      '[' (sil-graph-op-attr (',' sil-graph-op-attr)*)? ']'
+                      ('{' (sil-graph-op-attr (',' sil-graph-op-attr)*)? '}')?
                       ':' sil-type (',' sil-type)*
-  sil-graph-op-attr ::= sil-identifier '=' sil-symbolic-value
+  sil-graph-op-attr ::= sil-identifier ':' sil-symbolic-value
   sil-symbolic-value ::= i[0-9]+ int-literal |
                          f(32|64) float-literal |
                          sil-type |
                          '[' (sil-symbolic-value (',' sil-symbolic-value)*)? ']'
 
   %add = graph_op "tf.Add"(%x : $Tensor<Float>, %y : $Tensor<Float>) \
-    [T = $Float] : $Tensor<Float>
+    {T: $Float} : $Tensor<Float>
 
 Represents a graph program operation.
 

--- a/docs/SIL.rst
+++ b/docs/SIL.rst
@@ -5314,7 +5314,7 @@ gradient
   sil-autodiff-preserving-result ::= '[' 'preserving_result' ']'
 
   %original = function_ref @original : $(Float, Float) -> Float
-  %original_grad = gradient [wrt 0, 1] [preserving_result]
+  %original_grad = gradient [wrt 0, 1] [preserving_result] \
     %original : $(Float, Float) -> Float
 
 Computes the gradient function of a value ``%original`` using reverse-mode
@@ -5324,6 +5324,37 @@ automatic differentiation.
 
 This instruction is only valid in raw SIL and is rewritten by the automatic
 differentiation pass.
+
+.. SWIFT_ENABLE_TENSORFLOW
+
+Graph Program Extraction
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+graph_op
+````````
+::
+
+  sil-instruction ::= 'graph_op' string-literal
+                      '(' (sil-operand (',' sil-operand)*)? ')'
+                      '[' (sil-graph-op-attr (',' sil-graph-op-attr)*)? ']'
+                      ':' sil-type (',' sil-type)*
+  sil-graph-op-attr ::= sil-identifier '=' sil-symbolic-value
+  sil-symbolic-value ::= i[0-9]+ int-literal |
+                         f(32|64) float-literal |
+                         sil-type |
+                         '[' (sil-symbolic-value (',' sil-symbolic-value)*)? ']'
+
+  %add = graph_op "tf.Add"(%x : $Tensor<Float>, %y : $Tensor<Float>) \
+    [T = $Float] : $Tensor<Float>
+
+Represents a graph program operation.
+
+``graph_op`` instructions have a name, zero or more operands, zero or more
+attributes (an identifier and SIL constant value), and one or more result
+types.
+
+This instruction is only valid in raw SIL and is rewritten and extracted by the
+graph program extraction passes (debastraction, partitioning, graph lowering).
 
 Assertion configuration
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1674,9 +1674,13 @@ ERROR(sil_graph_op_expected_rsquare,PointsToFirstBadToken,
       "expected ']' in 'graph_op' attribute list", ())
 
 ERROR(sil_const_expected_int_datatype,PointsToFirstBadToken,
-      "expected int datatype ('i[0-9]+', e.g. 'i32')", ())
+      "expected integer datatype ('i[0-9]+', e.g. 'i32')", ())
+ERROR(sil_const_expected_int_value,PointsToFirstBadToken,
+      "expected integer value in SIL constant value", ())
 ERROR(sil_const_expected_fp_datatype,PointsToFirstBadToken,
       "expected floating point datatype ('f32' or 'f64')", ())
+ERROR(sil_const_expected_fp_value,PointsToFirstBadToken,
+      "expected floating point value in SIL constant value", ())
 ERROR(sil_const_aggregate_expected_rsquare,PointsToFirstBadToken,
       "expected ']' at end of aggregate 'SymbolicValue'", ())
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1666,6 +1666,8 @@ ERROR(sil_expected_graph_op_attr_name,PointsToFirstBadToken,
       "expected graph_op attribute name", ())
 ERROR(sil_expected_graph_op_attr_value,PointsToFirstBadToken,
       "expected graph_op attribute value", ())
+ERROR(sil_unhandled_graph_op_attr_value,PointsToFirstBadToken,
+      "unhandled graph_op attribute value", ())
 
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1658,6 +1658,15 @@ ERROR(expr_expected_function_to_differentiate,none,
 ERROR(gradient_expr_expected_parameter,none,
       "expected a parameter, which can be the index of a function parameter with a leading dot (e.g. '.0'), or 'self'", ())
 
+// SWIFT_ENABLE_TENSORFLOW
+//------------------------------------------------------------------------------
+// Graph operation related parsing diagnostics
+//------------------------------------------------------------------------------
+ERROR(sil_expected_graph_op_attr_name,PointsToFirstBadToken,
+      "expected graph_op attribute name", ())
+ERROR(sil_expected_graph_op_attr_value,PointsToFirstBadToken,
+      "expected graph_op attribute value", ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1662,12 +1662,19 @@ ERROR(gradient_expr_expected_parameter,none,
 //------------------------------------------------------------------------------
 // Graph operation related parsing diagnostics
 //------------------------------------------------------------------------------
-ERROR(sil_expected_graph_op_attr_name,PointsToFirstBadToken,
-      "expected graph_op attribute name", ())
-ERROR(sil_expected_graph_op_attr_value,PointsToFirstBadToken,
-      "expected graph_op attribute value", ())
-ERROR(sil_unhandled_graph_op_attr_value,PointsToFirstBadToken,
-      "unhandled graph_op attribute value", ())
+ERROR(sil_graph_op_expected_attr_name,PointsToFirstBadToken,
+      "expected 'graph_op' attribute name", ())
+ERROR(sil_graph_op_expected_attr_value,PointsToFirstBadToken,
+      "expected 'graph_op' attribute value", ())
+ERROR(sil_graph_op_unhandled_attr_value,PointsToFirstBadToken,
+      "unhandled 'graph_op' attribute value", ())
+ERROR(sil_graph_op_expected_rparen,PointsToFirstBadToken,
+      "expected ')' in 'graph_op' argument list", ())
+ERROR(sil_graph_op_expected_rsquare,PointsToFirstBadToken,
+      "expected ']' in 'graph_op' attribute list", ())
+
+ERROR(sil_const_aggregate_expected_rsquare,PointsToFirstBadToken,
+      "expected ']' at end of aggregate 'SymbolicValue'", ())
 
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1673,6 +1673,10 @@ ERROR(sil_graph_op_expected_rparen,PointsToFirstBadToken,
 ERROR(sil_graph_op_expected_rsquare,PointsToFirstBadToken,
       "expected ']' in 'graph_op' attribute list", ())
 
+ERROR(sil_const_expected_int_datatype,PointsToFirstBadToken,
+      "expected int datatype ('i[0-9]+', e.g. 'i32')", ())
+ERROR(sil_const_expected_fp_datatype,PointsToFirstBadToken,
+      "expected floating point datatype ('f32' or 'f64')", ())
 ERROR(sil_const_aggregate_expected_rsquare,PointsToFirstBadToken,
       "expected ']' at end of aggregate 'SymbolicValue'", ())
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1670,8 +1670,12 @@ ERROR(sil_graph_op_unhandled_attr_value,PointsToFirstBadToken,
       "unhandled 'graph_op' attribute value", ())
 ERROR(sil_graph_op_expected_rparen,PointsToFirstBadToken,
       "expected ')' in 'graph_op' argument list", ())
-ERROR(sil_graph_op_expected_rsquare,PointsToFirstBadToken,
-      "expected ']' in 'graph_op' attribute list", ())
+ERROR(sil_graph_op_expected_rbrace,PointsToFirstBadToken,
+      "expected '}' in 'graph_op' attribute list", ())
+ERROR(sil_graph_op_expected_colon_after_attr_name,PointsToFirstBadToken,
+      "expected ':' after 'graph_op' attribute name", ())
+ERROR(sil_graph_op_expected_colon_before_result_types,PointsToFirstBadToken,
+      "expected ':' before 'graph_op' result types", ())
 
 ERROR(sil_const_expected_int_datatype,PointsToFirstBadToken,
       "expected integer datatype ('i[0-9]+', e.g. 'i32')", ())

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1278,6 +1278,15 @@ public:
       SILLocation Loc, SILValue Operand,
       llvm::SmallVectorImpl<SILValue> &Result);
 
+  GraphOperationInst *createGraphOperation(SILLocation loc, Identifier name,
+                                           ArrayRef<SILValue> operands,
+                                        ArrayRef<GraphOperationAttribute> attrs,
+                                           ArrayRef<SILType> resultTypes) {
+    return insert(GraphOperationInst::create(
+        getModule(), getSILDebugLocation(loc), name, operands, attrs,
+        resultTypes));
+  }
+
   ClassMethodInst *createClassMethod(SILLocation Loc, SILValue Operand,
                                      SILDeclRef Member, SILType MethodTy) {
     return insert(new (getModule()) ClassMethodInst(

--- a/include/swift/SIL/SILBuilder.h
+++ b/include/swift/SIL/SILBuilder.h
@@ -1278,10 +1278,9 @@ public:
       SILLocation Loc, SILValue Operand,
       llvm::SmallVectorImpl<SILValue> &Result);
 
-  GraphOperationInst *createGraphOperation(SILLocation loc, Identifier name,
-                                           ArrayRef<SILValue> operands,
-                                        ArrayRef<GraphOperationAttribute> attrs,
-                                           ArrayRef<SILType> resultTypes) {
+  GraphOperationInst *createGraphOperation(
+      SILLocation loc, Identifier name, ArrayRef<SILValue> operands,
+      ArrayRef<GraphOperationAttribute> attrs, ArrayRef<SILType> resultTypes) {
     return insert(GraphOperationInst::create(
         getModule(), getSILDebugLocation(loc), name, operands, attrs,
         resultTypes));

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1605,6 +1605,21 @@ void SILCloner<ImplClass>::visitDestructureTupleInst(
 }
 
 template <typename ImplClass>
+void SILCloner<ImplClass>::visitGraphOperationInst(GraphOperationInst *Inst) {
+  getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
+  auto arguments =
+    getOpValueArray<4>(OperandValueArrayRef(Inst->getArguments()));
+  auto attributes = Inst->getAttributes();
+  SmallVector<SILType, 4> resultTypes;
+  for (auto result : Inst->getResults())
+    resultTypes.push_back(result->getType());
+  doPostProcess(Inst,
+      getBuilder().createGraphOperation(getOpLocation(Inst->getLoc()),
+                                        Inst->getName(), arguments,
+                                        Inst->getAttributes(), resultTypes));
+}
+
+template <typename ImplClass>
 void SILCloner<ImplClass>::visitClassMethodInst(ClassMethodInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   doPostProcess(Inst,

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1604,6 +1604,7 @@ void SILCloner<ImplClass>::visitDestructureTupleInst(
                                           getOpValue(Inst->getOperand())));
 }
 
+// SWIFT_ENABLE_TENSORFLOW
 template <typename ImplClass>
 void SILCloner<ImplClass>::visitGraphOperationInst(GraphOperationInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));

--- a/include/swift/SIL/SILCloner.h
+++ b/include/swift/SIL/SILCloner.h
@@ -1610,7 +1610,6 @@ void SILCloner<ImplClass>::visitGraphOperationInst(GraphOperationInst *Inst) {
   getBuilder().setCurrentDebugScope(getOpScope(Inst->getDebugScope()));
   auto arguments =
     getOpValueArray<4>(OperandValueArrayRef(Inst->getArguments()));
-  auto attributes = Inst->getAttributes();
   SmallVector<SILType, 4> resultTypes;
   for (auto result : Inst->getResults())
     resultTypes.push_back(result->getType());

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8038,11 +8038,9 @@ class GraphOperationInst final
                                             resultOwnerships),
     Name(name), NumOperands(arguments.size()), NumAttributes(attrs.size()) {
       auto allOperands = getAllOperands();
-      for (unsigned i : indices(arguments)) {
+      for (unsigned i : indices(arguments))
         new (&allOperands[i]) Operand(this, arguments[i]);
-      }
-      memcpy(getAttributes().data(), attrs.begin(),
-             sizeof(attrs[0]) * attrs.size());
+      std::copy(attrs.begin(), attrs.end(), getAttributes().data());
     }
 
 public:

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8088,9 +8088,9 @@ public:
     return { getTrailingObjects<GraphOperationAttribute>(), NumAttributes };
   }
 
-  Optional<GraphOperationAttribute> getAttribute(Identifier name) {
+  Optional<GraphOperationAttribute> getAttribute(StringRef name) {
     for (auto attr : getAttributes())
-      if (attr.name == name)
+      if (attr.name.is(name))
         return attr;
     return None;
   };
@@ -8100,7 +8100,7 @@ public:
   }
 };
 
-/// SWIFT_ENABLE_TENSORFLOW
+// SWIFT_ENABLE_TENSORFLOW
 // Out of line to work around forward declaration issues.
 inline GraphOperationInst *GraphOperationResult::getParent() {
   auto *Parent = MultipleValueInstructionResult::getParent();

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8003,7 +8003,7 @@ public:
 };
 
 /// SWIFT_ENABLE_TENSORFLOW
-/// An graph operation attribute. Attributes have a name and a constant value.
+/// A graph operation attribute. Attributes have a name and a constant value.
 struct GraphOperationAttribute {
   Identifier name;
   SymbolicValue value;

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -29,6 +29,8 @@
 #include "swift/Basic/Range.h"
 #include "swift/SIL/Consumption.h"
 #include "swift/SIL/SILAllocated.h"
+// SWIFT_ENABLE_TENSORFLOW
+#include "swift/SIL/SILConstants.h"
 #include "swift/SIL/SILDeclRef.h"
 #include "swift/SIL/SILFunctionConventions.h"
 #include "swift/SIL/SILLocation.h"
@@ -51,6 +53,8 @@ class MultipleValueInstruction;
 class MultipleValueInstructionResult;
 class DestructureTupleInst;
 class DestructureStructInst;
+// SWIFT_ENABLE_TENSORFLOW
+class GraphOperationInst;
 class NonValueInstruction;
 class SILBasicBlock;
 class SILBuilder;
@@ -7976,6 +7980,130 @@ public:
 inline DestructureTupleInst *DestructureTupleResult::getParent() {
   auto *Parent = MultipleValueInstructionResult::getParent();
   return cast<DestructureTupleInst>(Parent);
+}
+
+/// A result for the graph_op instruction. See documentation for
+/// graph_op for more information.
+class GraphOperationResult final : public MultipleValueInstructionResult {
+public:
+  GraphOperationResult(unsigned Index, SILType Type,
+                       ValueOwnershipKind OwnershipKind)
+  : MultipleValueInstructionResult(ValueKind::GraphOperationResult, Index,
+                                   Type, OwnershipKind) {}
+
+  static bool classof(const SILNode *N) {
+    return N->getKind() == SILNodeKind::GraphOperationResult;
+  }
+
+  GraphOperationInst *getParent();
+  const GraphOperationInst *getParent() const {
+    return const_cast<GraphOperationResult *>(this)->getParent();
+  }
+};
+
+/// SWIFT_ENABLE_TENSORFLOW
+/// An graph operation attribute. Attributes have a name and a constant value.
+struct GraphOperationAttribute {
+  Identifier name;
+  SymbolicValue value;
+};
+
+/// SWIFT_ENABLE_TENSORFLOW
+/// A graph operation. This instruction will be extracted to a graph program
+/// via graph program extraction passes.
+class GraphOperationInst final
+  : public InstructionBase<
+               SILInstructionKind::GraphOperationInst,
+               MultipleValueInstruction>,
+    public MultipleValueInstructionTrailingObjects<
+               GraphOperationInst, GraphOperationResult,
+               InitialTrailingObjects<>,
+               FinalTrailingObjects<Operand, GraphOperationAttribute>> {
+  friend TrailingObjects;
+
+  /// The name of the graph operation.
+  Identifier Name;
+  /// The number of operands.
+  unsigned NumOperands;
+  /// The number of attributes.
+  unsigned NumAttributes;
+
+  GraphOperationInst(SILModule &M, SILDebugLocation loc, Identifier name,
+                     ArrayRef<SILValue> arguments,
+                     ArrayRef<GraphOperationAttribute> attrs,
+                     ArrayRef<SILType> resultTypes,
+                     ArrayRef<ValueOwnershipKind> resultOwnerships) :
+    InstructionBase(loc),
+    MultipleValueInstructionTrailingObjects(this, resultTypes,
+                                            resultOwnerships),
+    Name(name), NumOperands(arguments.size()), NumAttributes(attrs.size()) {
+      auto allOperands = getAllOperands();
+      for (unsigned i : indices(arguments)) {
+        new (&allOperands[i]) Operand(this, arguments[i]);
+      }
+      memcpy(getAttributes().data(), attrs.begin(),
+             sizeof(attrs[0]) * attrs.size());
+    }
+
+public:
+  using MultipleValueInstructionTrailingObjects::numTrailingObjects;
+  using MultipleValueInstructionTrailingObjects::totalSizeToAlloc;
+
+  ~GraphOperationInst() {
+    for (auto &operand : getAllOperands())
+      operand.~Operand();
+  }
+
+  static GraphOperationInst *create(SILModule &M, SILDebugLocation loc,
+                                    Identifier name,
+                                    ArrayRef<SILValue> arguments,
+                                    ArrayRef<GraphOperationAttribute> attrs,
+                                    ArrayRef<SILType> resultTypes);
+
+  Identifier getName() const { return Name; }
+  unsigned getNumOperands() const { return NumOperands; }
+  unsigned getNumAttributes() const { return NumAttributes; }
+
+  unsigned numTrailingObjects(OverloadToken<Operand>) const {
+    return NumOperands;
+  }
+
+  ArrayRef<Operand> getAllOperands() const {
+    return { getTrailingObjects<Operand>(), NumOperands };
+  }
+
+  MutableArrayRef<Operand> getAllOperands() {
+    return { getTrailingObjects<Operand>(), NumOperands };
+  }
+
+  OperandValueArrayRef getArguments() const {
+    return OperandValueArrayRef(getAllOperands());
+  }
+
+  ArrayRef<GraphOperationAttribute> getAttributes() const {
+    return { getTrailingObjects<GraphOperationAttribute>(), NumAttributes };
+  }
+
+  MutableArrayRef<GraphOperationAttribute> getAttributes() {
+    return { getTrailingObjects<GraphOperationAttribute>(), NumAttributes };
+  }
+
+  Optional<GraphOperationAttribute> getAttribute(Identifier name) {
+    for (auto attr : getAttributes())
+      if (attr.name == name)
+        return attr;
+    return None;
+  };
+
+  static bool classof(const SILNode *N) {
+    return N->getKind() == SILNodeKind::GraphOperationInst;
+  }
+};
+
+// Out of line to work around forward declaration issues.
+inline GraphOperationInst *GraphOperationResult::getParent() {
+  auto *Parent = MultipleValueInstructionResult::getParent();
+  return cast<GraphOperationInst>(Parent);
 }
 
 inline SILType *AllocRefInstBase::getTypeStorage() {

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7996,7 +7996,11 @@ public:
     return N->getKind() == SILNodeKind::GraphOperationResult;
   }
 
-  GraphOperationInst *getParent();
+  GraphOperationInst *getParent() {
+    auto *Parent = MultipleValueInstructionResult::getParent();
+    return cast<GraphOperationInst>(Parent);
+  };
+
   const GraphOperationInst *getParent() const {
     return const_cast<GraphOperationResult *>(this)->getParent();
   }
@@ -8099,13 +8103,6 @@ public:
     return N->getKind() == SILNodeKind::GraphOperationInst;
   }
 };
-
-// SWIFT_ENABLE_TENSORFLOW
-// Out of line to work around forward declaration issues.
-inline GraphOperationInst *GraphOperationResult::getParent() {
-  auto *Parent = MultipleValueInstructionResult::getParent();
-  return cast<GraphOperationInst>(Parent);
-}
 
 inline SILType *AllocRefInstBase::getTypeStorage() {
   // If the size of the subclasses are equal, then all of this compiles away.

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8003,8 +8003,7 @@ public:
 };
 
 /// SWIFT_ENABLE_TENSORFLOW
-/// An graph operation attribute.
-/// Currently, attributes have a name and a constant value.
+/// An graph operation attribute. Attributes have a name and a constant value.
 struct GraphOperationAttribute {
   Identifier name;
   SymbolicValue value;
@@ -8042,7 +8041,8 @@ class GraphOperationInst final
       auto allOperands = getAllOperands();
       for (unsigned i : indices(arguments))
         new (&allOperands[i]) Operand(this, arguments[i]);
-      std::copy(attrs.begin(), attrs.end(), getAttributes().data());
+      std::uninitialized_copy(attrs.begin(), attrs.end(),
+                              getAttributes().data());
     }
 
 public:

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -7982,6 +7982,7 @@ inline DestructureTupleInst *DestructureTupleResult::getParent() {
   return cast<DestructureTupleInst>(Parent);
 }
 
+/// SWIFT_ENABLE_TENSORFLOW
 /// A result for the graph_op instruction. See documentation for
 /// graph_op for more information.
 class GraphOperationResult final : public MultipleValueInstructionResult {
@@ -8002,7 +8003,8 @@ public:
 };
 
 /// SWIFT_ENABLE_TENSORFLOW
-/// An graph operation attribute. Attributes have a name and a constant value.
+/// An graph operation attribute.
+/// Currently, attributes have a name and a constant value.
 struct GraphOperationAttribute {
   Identifier name;
   SymbolicValue value;
@@ -8098,6 +8100,7 @@ public:
   }
 };
 
+/// SWIFT_ENABLE_TENSORFLOW
 // Out of line to work around forward declaration issues.
 inline GraphOperationInst *GraphOperationResult::getParent() {
   auto *Parent = MultipleValueInstructionResult::getParent();

--- a/include/swift/SIL/SILNodes.def
+++ b/include/swift/SIL/SILNodes.def
@@ -218,7 +218,9 @@ ABSTRACT_VALUE(MultipleValueInstructionResult, ValueBase)
   MULTIPLE_VALUE_INST_RESULT(BeginApplyResult, MultipleValueInstructionResult)
   MULTIPLE_VALUE_INST_RESULT(DestructureStructResult, MultipleValueInstructionResult)
   MULTIPLE_VALUE_INST_RESULT(DestructureTupleResult, MultipleValueInstructionResult)
-  VALUE_RANGE(MultipleValueInstructionResult, BeginApplyResult, DestructureTupleResult)
+  // SWIFT_ENABLE_TENSORFLOW
+  MULTIPLE_VALUE_INST_RESULT(GraphOperationResult, MultipleValueInstructionResult)
+  VALUE_RANGE(MultipleValueInstructionResult, BeginApplyResult, GraphOperationResult)
 
 VALUE(SILUndef, ValueBase)
 
@@ -666,10 +668,13 @@ MULTIPLE_VALUE_INST(DestructureStructInst, destructure_struct,
                     SILInstruction, None, DoesNotRelease)
 MULTIPLE_VALUE_INST(DestructureTupleInst, destructure_tuple,
                     SILInstruction, None, DoesNotRelease)
-INST_RANGE(MultipleValueInstruction, BeginApplyInst, DestructureTupleInst)
+// SWIFT_ENABLE_TENSORFLOW
+MULTIPLE_VALUE_INST(GraphOperationInst, graph_op,
+                    SILInstruction, None, DoesNotRelease)
+INST_RANGE(MultipleValueInstruction, BeginApplyInst, GraphOperationInst)
 
-NODE_RANGE(SILInstruction, AllocStackInst, DestructureTupleInst)
-NODE_RANGE(SILNode, SILPHIArgument, DestructureTupleInst)
+NODE_RANGE(SILInstruction, AllocStackInst, GraphOperationInst)
+NODE_RANGE(SILNode, SILPHIArgument, GraphOperationInst)
 
 #undef SINGLE_VALUE_INST_RANGE
 #undef INST_RANGE

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 404; // SWIFT_ENABLE_TENSORFLOW: gradient.
+const uint16_t VERSION_MINOR = 405; // SWIFT_ENABLE_TENSORFLOW: graph_op.
 
 using DeclIDField = BCFixed<31>;
 

--- a/lib/IRGen/IRGenSIL.cpp
+++ b/lib/IRGen/IRGenSIL.cpp
@@ -885,6 +885,11 @@ public:
     llvm_unreachable("gradient is not valid in canonical SIL");
   }
 
+  // SWIFT_ENABLE_TENSORFLOW
+  void visitGraphOperationInst(GraphOperationInst *i) {
+    llvm_unreachable("graph_op is not valid in canonical SIL");
+  }
+
   void visitFunctionRefInst(FunctionRefInst *i);
   void visitAllocGlobalInst(AllocGlobalInst *i);
   void visitGlobalAddrInst(GlobalAddrInst *i);

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -963,7 +963,6 @@ static bool parseSymbolicValue(SymbolicValue &value, SILParser &SP,
         }
       }
       // Handle decimal case.
-      double tmpValue;
       bool negative = false;
       if (P.Tok.isAnyOperator() && P.Tok.getText() == "-") {
         negative = true;
@@ -973,6 +972,7 @@ static bool parseSymbolicValue(SymbolicValue &value, SILParser &SP,
         P.diagnose(P.Tok, diag::sil_const_expected_fp_value);
         return true;
       }
+      double tmpValue;
       P.Tok.getText().getAsDouble(tmpValue);
       P.consumeToken(tok::floating_literal);
 

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -891,10 +891,10 @@ void SILParser::convertRequirements(SILFunction *F,
 /// Parse a SIL constant value (one of the following categories):
 /// - An integer datatype and literal (i32 42).
 /// - A floating point datatype and literal (f64 3.14).
-///   - The literal value may be in either decimal or the hexadecimal format
-///     used by the 'float_literal' instruction.
+///   - The literal value may be in either decimal format or the hexadecimal
+///     format used by the 'float_literal' instruction.
 /// - A metatype (the instance type is parsed) ($Float).
-/// - An aggregate ([i32 1, i64 2, f32 3]).
+/// - An aggregate ([i32 1, i64 2, f32 3.0]).
 /// Returns true on error.
 static bool parseSymbolicValue(SymbolicValue &value, SILParser &SP,
                                SILBuilder &B) {

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -2957,23 +2957,23 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
 
     // Parse optional graph operation attributes.
     SmallVector<GraphOperationAttribute, 4> attributes;
-    SourceLoc lSquareLoc;
-    if (P.consumeIf(tok::l_square, lSquareLoc)) {
-      SourceLoc rSquareLoc;
+    SourceLoc lBraceLoc;
+    if (P.consumeIf(tok::l_brace, lBraceLoc)) {
+      SourceLoc rBraceLoc;
       ParserStatus status =
-        P.parseList(tok::r_square, lSquareLoc, rSquareLoc,
+        P.parseList(tok::r_brace, lBraceLoc, rBraceLoc,
                     /*AllowSepAfterLast*/ false,
-                    diag::sil_graph_op_expected_rsquare,
+                    diag::sil_graph_op_expected_rbrace,
                     SyntaxKind::Unknown,
                     [&]() -> ParserStatus {
         // Parse an attribute.
         Identifier attrName;
-        if (parseSILIdentifier(attrName, lSquareLoc,
+        if (parseSILIdentifier(attrName, lBraceLoc,
                                diag::sil_graph_op_expected_attr_name))
           return makeParserError();
         SymbolicValue attrValue;
-        if (!P.consumeIf(tok::equal)) {
-          P.diagnose(P.Tok, diag::expected_equal_in_sil_instr);
+        if (!P.consumeIf(tok::colon)) {
+          P.diagnose(P.Tok, diag::sil_graph_op_expected_colon_after_attr_name);
           return makeParserError();
         }
         if (parseSymbolicValue(attrValue, *this, B))
@@ -2986,7 +2986,8 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     }
 
     // Parse graph operation result types.
-    if (P.parseToken(tok::colon, diag::expected_tok_in_sil_instr, ":"))
+    if (P.parseToken(tok::colon,
+                     diag::sil_graph_op_expected_colon_before_result_types))
       return true;
     SmallVector<SILType, 4> resultTypes;
     SILType temp;

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -920,7 +920,7 @@ static bool parseSymbolicValue(SymbolicValue &value, SILParser &SP,
     // StringRef rawString = P.Tok.getText().drop_front().drop_back();
     // value = SymbolicValue::getStringValue(rawString, allocator);
     // return false;
-    llvm_unreachable("`SymbolicValue.getStringValue` is unimplemented");
+    P.diagnose(P.Tok, diag::sil_unhandled_graph_op_attr_value);
   }
   // Handle metatypes (the instance type is parsed).
   if (P.Tok.is(tok::sil_dollar)) {
@@ -2840,7 +2840,7 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
   // SWIFT_ENABLE_TENSORFLOW
   case SILInstructionKind::GraphOperationInst: {
     // Parse graph operation name.
-    if (P.Tok.getKind() != tok::string_literal) {
+    if (P.Tok.isNot(tok::string_literal)) {
       P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "graph_op name");
       return true;
     }
@@ -2849,7 +2849,7 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     P.consumeToken(tok::string_literal);
 
     // Parse graph operation arguments.
-    if (P.Tok.getKind() != tok::l_paren) {
+    if (P.Tok.isNot(tok::l_paren)) {
       P.diagnose(P.Tok, diag::expected_tok_in_sil_instr, "(");
       return true;
     }
@@ -2904,9 +2904,8 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
       if (parseSILType(temp))
         return true;
       resultTypes.push_back(temp);
-      if (!P.Tok.is(tok::comma))
+      if (!P.consumeIf(tok::comma))
         break;
-      P.consumeToken(tok::comma);
     }
 
     if (parseSILDebugLocation(InstLoc, B))

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -921,6 +921,7 @@ static bool parseSymbolicValue(SymbolicValue &value, SILParser &SP,
     // value = SymbolicValue::getStringValue(rawString, allocator);
     // return false;
     P.diagnose(P.Tok, diag::sil_unhandled_graph_op_attr_value);
+    return true;
   }
   // Handle metatypes (the instance type is parsed).
   if (P.Tok.is(tok::sil_dollar)) {

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -892,7 +892,7 @@ void SILParser::convertRequirements(SILFunction *F,
 /// - An integer datatype and literal (i32 42).
 /// - A floating point datatype and literal (f64 3.14).
 /// - A metatype (the instance type is parsed) ($Float).
-/// - An aggregate ([1, 2, 3]).
+/// - An aggregate ([i32 1, i64 2, f32 3]).
 /// Returns true on error.
 static bool parseSymbolicValue(SymbolicValue &value, SILParser &SP,
                                SILBuilder &B) {
@@ -982,7 +982,6 @@ static bool parseSymbolicValue(SymbolicValue &value, SILParser &SP,
       P.parseList(tok::r_square, lSquareLoc, rSquareLoc,
                   /*AllowSepAfterLast*/ false,
                   diag::sil_const_aggregate_expected_rsquare,
-                  // SyntaxKind::TuplePatternElementList,
                   SyntaxKind::Unknown,
                   [&]() -> ParserStatus {
       SymbolicValue element;

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -895,6 +895,7 @@ void SILParser::convertRequirements(SILFunction *F,
 ///     format used by the 'float_literal' instruction.
 /// - A metatype (the instance type is parsed) ($Float).
 /// - An aggregate ([i32 1, i64 2, f32 3.0]).
+///   - Aggregates values represent constant arrays/structs/tuples.
 /// Returns true on error.
 static bool parseSymbolicValue(SymbolicValue &value, SILParser &SP,
                                SILBuilder &B) {

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -2463,3 +2463,25 @@ DestructureTupleInst *DestructureTupleInst::create(SILModule &M,
   return ::new (Buffer)
       DestructureTupleInst(M, Loc, Operand, Types, OwnershipKinds);
 }
+
+// SWIFT_ENABLE_TENSORFLOW
+GraphOperationInst *GraphOperationInst::create(
+    SILModule &M, SILDebugLocation loc, Identifier name,
+    ArrayRef<SILValue> arguments, ArrayRef<GraphOperationAttribute> attributes,
+    ArrayRef<SILType> resultTypes) {
+  llvm::SmallVector<ValueOwnershipKind, 4> resultOwnerships;
+  for (auto resultType : resultTypes) {
+    if (resultType.isTrivial(M)) {
+      resultOwnerships.push_back(ValueOwnershipKind::Trivial);
+      continue;
+    }
+    resultOwnerships.push_back(ValueOwnershipKind::Owned);
+  }
+
+  unsigned size =
+    totalSizeToAlloc<MultipleValueInstruction *, GraphOperationResult, Operand, GraphOperationAttribute>(
+      1, resultTypes.size(), arguments.size(), attributes.size());
+  void *buffer = M.allocateInst(size, alignof(GraphOperationInst));
+  return ::new (buffer) GraphOperationInst(M, loc, name, arguments, attributes,
+                                           resultTypes, resultOwnerships);
+}

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -2471,15 +2471,14 @@ GraphOperationInst *GraphOperationInst::create(
     ArrayRef<SILType> resultTypes) {
   llvm::SmallVector<ValueOwnershipKind, 4> resultOwnerships;
   for (auto resultType : resultTypes) {
-    if (resultType.isTrivial(M)) {
-      resultOwnerships.push_back(ValueOwnershipKind::Trivial);
-      continue;
-    }
-    resultOwnerships.push_back(ValueOwnershipKind::Owned);
+    auto ownership = resultType.isTrivial(M)
+      ? ValueOwnershipKind::Trivial : ValueOwnershipKind::Owned;
+    resultOwnerships.push_back(ownership);
   }
 
   unsigned size =
-    totalSizeToAlloc<MultipleValueInstruction *, GraphOperationResult, Operand, GraphOperationAttribute>(
+    totalSizeToAlloc<MultipleValueInstruction *, GraphOperationResult, Operand,
+                     GraphOperationAttribute>(
       1, resultTypes.size(), arguments.size(), attributes.size());
   void *buffer = M.allocateInst(size, alignof(GraphOperationInst));
   return ::new (buffer) GraphOperationInst(M, loc, name, arguments, attributes,

--- a/lib/SIL/SILOwnershipVerifier.cpp
+++ b/lib/SIL/SILOwnershipVerifier.cpp
@@ -198,6 +198,7 @@ static bool isOwnershipForwardingValueKind(SILNodeKind K) {
   case SILNodeKind::DestructureTupleInst:
   // SWIFT_ENABLE_TENSORFLOW
   case SILNodeKind::GradientInst:
+  case SILNodeKind::GraphOperationInst:
     return true;
   default:
     return false;
@@ -687,6 +688,7 @@ FORWARD_ANY_OWNERSHIP_INST(DestructureStruct)
 FORWARD_ANY_OWNERSHIP_INST(DestructureTuple)
 // SWIFT_ENABLE_TENSORFLOW
 FORWARD_ANY_OWNERSHIP_INST(Gradient)
+FORWARD_ANY_OWNERSHIP_INST(GraphOperation)
 #undef FORWARD_ANY_OWNERSHIP_INST
 
 // An instruction that forwards a constant ownership or trivial ownership.

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1186,10 +1186,16 @@ public:
       return;
     }
     case SymbolicValue::Float: {
-      SmallString<12> decimal;
       APFloat floatValue = v.getFloatValue();
+      *this << "f" << APFloat::getSizeInBits(floatValue.getSemantics()) << " ";
+
+      APInt bits = floatValue.bitcastToAPInt();
+      *this << "0x" << bits.toString(16, /*Signed*/ false);
+      *this << " ";
+
+      SmallString<12> decimal;
       floatValue.toString(decimal);
-      *this << "f" << APFloat::getSizeInBits(floatValue.getSemantics()) << " " << decimal;
+      *this << "/* " << decimal << " */";
       return;
     }
     case SymbolicValue::String:

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1180,40 +1180,40 @@ public:
   // SWIFT_ENABLE_TENSORFLOW
   void visitSymbolicValue(SymbolicValue v) {
     switch (v.getKind()) {
-      case swift::SymbolicValue::Integer:
-        *this << v.getIntegerValue();
-        return;
-      case swift::SymbolicValue::Float: {
-        SmallString<12> decimal;
-        v.getFloatValue().toString(decimal);
-        *this << decimal;
-        return;
-      }
-      case swift::SymbolicValue::String:
-        // TODO: Uncomment when `getStringValue` is implemented.
-        // *this << v.getStringValue();
-        llvm_unreachable("`SymbolicValue.getStringValue` is unimplemented");
-        break;
-      case swift::SymbolicValue::Metatype: {
-        auto metatype = cast<AnyMetatypeType>(v.getMetatypeValue());
-        *this << SILType::getPrimitiveObjectType(metatype.getInstanceType());
-        break;
-      }
-      case swift::SymbolicValue::Aggregate:
-        *this << "[";
-        interleave(v.getAggregateValue(), [&](SymbolicValue element) {
-          visitSymbolicValue(element);
-        }, [&] {
-          *this << ", ";
-        });
-        *this << "]";
-        break;
-      case swift::SymbolicValue::Function:
-      case swift::SymbolicValue::Address:
-      case swift::SymbolicValue::UninitMemory:
-      case swift::SymbolicValue::Unknown:
-        llvm_unreachable("Unimplemented SymbolicValue case");
-        break;
+    case swift::SymbolicValue::Integer:
+      *this << v.getIntegerValue();
+      return;
+    case swift::SymbolicValue::Float: {
+      SmallString<12> decimal;
+      v.getFloatValue().toString(decimal);
+      *this << decimal;
+      return;
+    }
+    case swift::SymbolicValue::String:
+      // TODO: Uncomment when `getStringValue` is implemented.
+      // *this << v.getStringValue();
+      llvm_unreachable("`SymbolicValue.getStringValue` is unimplemented");
+      break;
+    case swift::SymbolicValue::Metatype: {
+      auto metatype = cast<AnyMetatypeType>(v.getMetatypeValue());
+      *this << SILType::getPrimitiveObjectType(metatype.getInstanceType());
+      break;
+    }
+    case swift::SymbolicValue::Aggregate:
+      *this << "[";
+      interleave(v.getAggregateValue(), [&](SymbolicValue element) {
+        visitSymbolicValue(element);
+      }, [&] {
+        *this << ", ";
+      });
+      *this << "]";
+      break;
+    case swift::SymbolicValue::Function:
+    case swift::SymbolicValue::Address:
+    case swift::SymbolicValue::UninitMemory:
+    case swift::SymbolicValue::Unknown:
+      llvm_unreachable("Unimplemented SymbolicValue case");
+      break;
     }
   }
 

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1180,26 +1180,26 @@ public:
   // SWIFT_ENABLE_TENSORFLOW
   void visitSymbolicValue(SymbolicValue v) {
     switch (v.getKind()) {
-    case swift::SymbolicValue::Integer:
+    case SymbolicValue::Integer:
       *this << v.getIntegerValue();
       return;
-    case swift::SymbolicValue::Float: {
+    case SymbolicValue::Float: {
       SmallString<12> decimal;
       v.getFloatValue().toString(decimal);
       *this << decimal;
       return;
     }
-    case swift::SymbolicValue::String:
+    case SymbolicValue::String:
       // TODO: Uncomment when `getStringValue` is implemented.
       // *this << v.getStringValue();
       llvm_unreachable("`SymbolicValue.getStringValue` is unimplemented");
       break;
-    case swift::SymbolicValue::Metatype: {
+    case SymbolicValue::Metatype: {
       auto metatype = cast<AnyMetatypeType>(v.getMetatypeValue());
       *this << SILType::getPrimitiveObjectType(metatype.getInstanceType());
       break;
     }
-    case swift::SymbolicValue::Aggregate:
+    case SymbolicValue::Aggregate:
       *this << "[";
       interleave(v.getAggregateValue(), [&](SymbolicValue element) {
         visitSymbolicValue(element);
@@ -1208,10 +1208,10 @@ public:
       });
       *this << "]";
       break;
-    case swift::SymbolicValue::Function:
-    case swift::SymbolicValue::Address:
-    case swift::SymbolicValue::UninitMemory:
-    case swift::SymbolicValue::Unknown:
+    case SymbolicValue::Function:
+    case SymbolicValue::Address:
+    case SymbolicValue::UninitMemory:
+    case SymbolicValue::Unknown:
       llvm_unreachable("Unimplemented SymbolicValue case");
       break;
     }

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1180,13 +1180,16 @@ public:
   // SWIFT_ENABLE_TENSORFLOW
   void visitSymbolicValue(SymbolicValue v) {
     switch (v.getKind()) {
-    case SymbolicValue::Integer:
-      *this << v.getIntegerValue();
+    case SymbolicValue::Integer: {
+      APInt intValue = v.getIntegerValue();
+      *this << "i" << intValue.getBitWidth() << " " << intValue;
       return;
+    }
     case SymbolicValue::Float: {
       SmallString<12> decimal;
-      v.getFloatValue().toString(decimal);
-      *this << decimal;
+      APFloat floatValue = v.getFloatValue();
+      floatValue.toString(decimal);
+      *this << "f" << APFloat::getSizeInBits(floatValue.getSemantics()) << " " << decimal;
       return;
     }
     case SymbolicValue::String:
@@ -1233,7 +1236,7 @@ public:
       *this << " [";
       interleave(GI->getAttributes(), [&](GraphOperationAttribute attr) {
         *this << attr.name.str();
-        *this << " ";
+        *this << " = ";
         visitSymbolicValue(attr.value);
       }, [&] {
         *this << ", ";

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1239,15 +1239,15 @@ public:
     *this << ")";
 
     if (GI->getNumAttributes()) {
-      *this << " [";
+      *this << " {";
       interleave(GI->getAttributes(), [&](GraphOperationAttribute attr) {
         *this << attr.name.str();
-        *this << " = ";
+        *this << ": ";
         visitSymbolicValue(attr.value);
       }, [&] {
         *this << ", ";
       });
-      *this << "]";
+      *this << "}";
     }
 
     *this << " : ";

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1187,9 +1187,8 @@ public:
   }
 
   void checkGraphOperationInst(GraphOperationInst *GI) {
-    for (auto attr : GI->getAttributes()) {
+    for (auto attr : GI->getAttributes())
       require(attr.value.isConstant(), "Invalid graph operation attribute");
-    }
   }
 
   void checkFunctionRefInst(FunctionRefInst *FRI) {

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1185,7 +1185,12 @@ public:
     if (isAutoDiffBuiltinInst(BI))
       checkAutoDiffBuiltinInst(BI);
   }
-  
+
+  void checkGraphOperationInst(GraphOperationInst *GI) {
+    // FIXME
+    GI->getResults();
+  }
+
   void checkFunctionRefInst(FunctionRefInst *FRI) {
     auto fnType = requireObjectType(SILFunctionType, FRI,
                                     "result of function_ref");

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1186,6 +1186,7 @@ public:
       checkAutoDiffBuiltinInst(BI);
   }
 
+  // SWIFT_ENABLE_TENSORFLOW
   void checkGraphOperationInst(GraphOperationInst *GI) {
     for (auto attr : GI->getAttributes())
       require(attr.value.isConstant(), "Invalid graph operation attribute");

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1187,8 +1187,9 @@ public:
   }
 
   void checkGraphOperationInst(GraphOperationInst *GI) {
-    // FIXME
-    GI->getResults();
+    for (auto attr : GI->getAttributes()) {
+      require(attr.value.isConstant(), "Invalid graph operation attribute");
+    }
   }
 
   void checkFunctionRefInst(FunctionRefInst *FRI) {

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1188,8 +1188,12 @@ public:
 
   // SWIFT_ENABLE_TENSORFLOW
   void checkGraphOperationInst(GraphOperationInst *GI) {
-    for (auto attr : GI->getAttributes())
+    llvm::DenseSet<Identifier> attributeNames;
+    for (auto attr : GI->getAttributes()) {
+      require(attributeNames.insert(attr.name).second,
+              "Duplicate attribute name '" + attr.name.str() + "'");
       require(attr.value.isConstant(), "Invalid graph operation attribute");
+    }
   }
 
   void checkFunctionRefInst(FunctionRefInst *FRI) {

--- a/lib/SIL/ValueOwnershipKindClassifier.cpp
+++ b/lib/SIL/ValueOwnershipKindClassifier.cpp
@@ -280,6 +280,11 @@ ValueOwnershipKind ValueOwnershipKindClassifier::visitDestructureStructResult(
   return Result->getOwnershipKind();
 }
 
+ValueOwnershipKind ValueOwnershipKindClassifier::visitGraphOperationResult(
+    GraphOperationResult *Result) {
+  return Result->getOwnershipKind();
+}
+
 ValueOwnershipKind ValueOwnershipKindClassifier::visitDestructureTupleResult(
     DestructureTupleResult *Result) {
   return Result->getOwnershipKind();

--- a/lib/SIL/ValueOwnershipKindClassifier.cpp
+++ b/lib/SIL/ValueOwnershipKindClassifier.cpp
@@ -280,13 +280,14 @@ ValueOwnershipKind ValueOwnershipKindClassifier::visitDestructureStructResult(
   return Result->getOwnershipKind();
 }
 
-ValueOwnershipKind ValueOwnershipKindClassifier::visitGraphOperationResult(
-    GraphOperationResult *Result) {
+ValueOwnershipKind ValueOwnershipKindClassifier::visitDestructureTupleResult(
+    DestructureTupleResult *Result) {
   return Result->getOwnershipKind();
 }
 
-ValueOwnershipKind ValueOwnershipKindClassifier::visitDestructureTupleResult(
-    DestructureTupleResult *Result) {
+// SWIFT_ENABLE_TENSORFLOW
+ValueOwnershipKind ValueOwnershipKindClassifier::visitGraphOperationResult(
+    GraphOperationResult *Result) {
   return Result->getOwnershipKind();
 }
 

--- a/lib/SILOptimizer/Utils/SILInliner.cpp
+++ b/lib/SILOptimizer/Utils/SILInliner.cpp
@@ -485,6 +485,8 @@ InlineCost swift::instructionInlineCost(SILInstruction &I) {
   case SILInstructionKind::SelectValueInst:
   case SILInstructionKind::KeyPathInst:
   case SILInstructionKind::GlobalValueInst:
+  // SWIFT_ENABLE_TENSORFLOW
+  case SILInstructionKind::GraphOperationInst:
     return InlineCost::Expensive;
 
   case SILInstructionKind::BuiltinInst: {

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -1350,6 +1350,10 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
                                       Args);
     break;
   }
+  // SWIFT_ENABLE_TENSORFLOW
+  case SILInstructionKind::GraphOperationInst: {
+    llvm_unreachable("Unimplemented");
+  }
   case SILInstructionKind::AllocGlobalInst: {
     // Format: Name and type. Use SILOneOperandLayout.
     Identifier Name = MF->getIdentifier(ValID);

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -912,6 +912,10 @@ void SILSerializer::writeSILInstruction(const SILInstruction &SI) {
     S.writeSubstitutions(BI->getSubstitutions(), SILAbbrCodes);
     break;
   }
+  // SWIFT_ENABLE_TENSORFLOW
+  case SILInstructionKind::GraphOperationInst: {
+    llvm_unreachable("Unimplemented");
+  }
   case SILInstructionKind::ApplyInst: {
     // Format: attributes such as transparent and number of substitutions,
     // the callee's substituted and unsubstituted types, a value for

--- a/test/TensorFlow/graph_op_inst.sil
+++ b/test/TensorFlow/graph_op_inst.sil
@@ -10,52 +10,52 @@ struct Tensor<Scalar> {}
 
 sil @attribute_test : $@convention(thin) () -> Tensor<Float> {
 bb0:
-  %0 = graph_op "tf.Dummy"() [int 1, float 3.14, metatype $Float, array [[1, 2], [3, 4]]] : $Tensor<Float>
+  %0 = graph_op "tf.Dummy"() [int = i64 48, float = f32 3.14, metatype = $Float, array = [[i32 1, i32 2], [i32 3, i32 4]]] : $Tensor<Float>
   return %0 : $Tensor<Float>
 }
 
 // CHECK-LABEL: sil @attribute_test : $@convention(thin) () -> Tensor<Float> {
 // CHECK: bb0:
-// CHECK-NEXT:   %0 = graph_op "tf.Dummy"() [int 1, float 3.14{{[0-9]*}}, metatype $Float, array {{\[\[}}1, 2], [3, 4]]] : $Tensor<Float>
+// CHECK-NEXT:   %0 = graph_op "tf.Dummy"() [int = i64 48, float = f32 3.14{{[0-9]*}}, metatype = $Float, array = {{\[\[}}i32 1, i32 2], [i32 3, i32 4]]] : $Tensor<Float>
 // CHECK-NEXT:   return %0 : $Tensor<Float>
 // CHECK-NEXT: }
 
 sil @chained_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> {
 bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
-  %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T $Float] : $Tensor<Float>
-  %3 = graph_op "tf.Mul"(%2 : $Tensor<Float>, %2 : $Tensor<Float>) [T $Float] : $Tensor<Float>
+  %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T = $Float] : $Tensor<Float>
+  %3 = graph_op "tf.Mul"(%2 : $Tensor<Float>, %2 : $Tensor<Float>) [T = $Float] : $Tensor<Float>
   return %3 : $Tensor<Float>
 }
 
 // CHECK-LABEL: sil @chained_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> {
 // CHECK: bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
-// CHECK-NEXT:   %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T $Float] : $Tensor<Float>
-// CHECK-NEXT:   %3 = graph_op "tf.Mul"(%2 : $Tensor<Float>, %2 : $Tensor<Float>) [T $Float] : $Tensor<Float>
+// CHECK-NEXT:   %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T = $Float] : $Tensor<Float>
+// CHECK-NEXT:   %3 = graph_op "tf.Mul"(%2 : $Tensor<Float>, %2 : $Tensor<Float>) [T = $Float] : $Tensor<Float>
 // CHECK-NEXT:   return %3 : $Tensor<Float>
 // CHECK-NEXT: }
 
 sil @single_result_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> {
 bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
-  %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T $Float] : $Tensor<Float>
+  %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T = $Float] : $Tensor<Float>
   return %2 : $Tensor<Float>
 }
 
 // CHECK-LABEL: sil @single_result_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> {
 // CHECK: bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
-// CHECK-NEXT:   %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T $Float] : $Tensor<Float>
+// CHECK-NEXT:   %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T = $Float] : $Tensor<Float>
 // CHECK-NEXT:   return %2 : $Tensor<Float>
 // CHECK-NEXT: }
 
 sil @multiple_result_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> (Tensor<Float>, Tensor<Float>) {
 bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
-  (%2, %3) = graph_op "tf.Dummy"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T $Float] : $Tensor<Float>, $Tensor<Float>
+  (%2, %3) = graph_op "tf.Dummy"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T = $Float] : $Tensor<Float>, $Tensor<Float>
   %4 = tuple (%2 : $Tensor<Float>, %3 : $Tensor<Float>)
   return %4 : $(Tensor<Float>, Tensor<Float>)
 }
 
 // CHECK-LABEL: sil @multiple_result_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> (Tensor<Float>, Tensor<Float>) {
 // CHECK: bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
-// CHECK-NEXT:   (%2, %3) = graph_op "tf.Dummy"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T $Float] : $Tensor<Float>, $Tensor<Float>
+// CHECK-NEXT:   (%2, %3) = graph_op "tf.Dummy"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T = $Float] : $Tensor<Float>, $Tensor<Float>
 // CHECK-NEXT:   %4 = tuple (%2 : $Tensor<Float>, %3 : $Tensor<Float>)
 // CHECK-NEXT:   return %4 : $(Tensor<Float>, Tensor<Float>)
 // CHECK-NEXT: }

--- a/test/TensorFlow/graph_op_inst.sil
+++ b/test/TensorFlow/graph_op_inst.sil
@@ -10,60 +10,60 @@ struct Tensor<Scalar> {}
 
 sil @attribute_test : $@convention(thin) () -> Tensor<Float> {
 bb0:
-  %0 = graph_op "tf.Dummy"() [int1 = i32 -3, int2 = i8 4, int3 = i64 42] : $Tensor<Float>
-  %1 = graph_op "tf.Dummy"() [hex1 = f64 0x40091EB851EB851F, hex2 = f32 0x4048F5C3] : $Tensor<Float>
-  %3 = graph_op "tf.Dummy"() [float1 = f64 3.14, float2 = f32 -3.14] : $Tensor<Float>
-  %4 = graph_op "tf.Dummy"() [metatype1 = $Float, metatype2 = $Tensor<Float>] : $Tensor<Float>
-  %5 = graph_op "tf.Dummy"() [array = [[i8 1, i32 -2], [f32 -1.0, $Float]]] : $Tensor<Float>
+  %0 = graph_op "tf.Dummy"() {int1: i32 -3, int2: i8 4, int3: i64 42} : $Tensor<Float>
+  %1 = graph_op "tf.Dummy"() {hex1: f64 0x40091EB851EB851F, hex2: f32 0x4048F5C3} : $Tensor<Float>
+  %3 = graph_op "tf.Dummy"() {float1: f64 3.14, float2: f32 -3.14} : $Tensor<Float>
+  %4 = graph_op "tf.Dummy"() {metatype1: $Float, metatype2: $Tensor<Float>} : $Tensor<Float>
+  %5 = graph_op "tf.Dummy"() {array: [[i8 1, i32 -2], [f32 -1.0, $Float]]} : $Tensor<Float>
   return %0 : $Tensor<Float>
 }
 
 // CHECK-LABEL: sil @attribute_test : $@convention(thin) () -> Tensor<Float> {
 // CHECK: bb0:
-// CHECK-NEXT:   %0 = graph_op "tf.Dummy"() [int1 = i32 -3, int2 = i8 4, int3 = i64 42] : $Tensor<Float> // user: %5
-// CHECK-NEXT:   %1 = graph_op "tf.Dummy"() [hex1 = f64 0x40091EB851EB851F /* 3.1400000000000001 */, hex2 = f32 0x4048F5C3 /* 3.1400001 */] : $Tensor<Float>
-// CHECK-NEXT:   %2 = graph_op "tf.Dummy"() [float1 = f64 0x40091EB851EB851F /* 3.1400000000000001 */, float2 = f32 0xC048F5C3 /* -3.1400001 */] : $Tensor<Float>
-// CHECK-NEXT:   %3 = graph_op "tf.Dummy"() [metatype1 = $Float, metatype2 = $Tensor<Float>] : $Tensor<Float>
-// CHECK-NEXT:   %4 = graph_op "tf.Dummy"() [array = {{\[\[}}i8 1, i32 -2], [f32 0xBF800000 /* -1 */, $Float]]] : $Tensor<Float>
+// CHECK-NEXT:   %0 = graph_op "tf.Dummy"() {int1: i32 -3, int2: i8 4, int3: i64 42} : $Tensor<Float> // user: %5
+// CHECK-NEXT:   %1 = graph_op "tf.Dummy"() {hex1: f64 0x40091EB851EB851F /* 3.1400000000000001 */, hex2: f32 0x4048F5C3 /* 3.1400001 */} : $Tensor<Float>
+// CHECK-NEXT:   %2 = graph_op "tf.Dummy"() {float1: f64 0x40091EB851EB851F /* 3.1400000000000001 */, float2: f32 0xC048F5C3 /* -3.1400001 */} : $Tensor<Float>
+// CHECK-NEXT:   %3 = graph_op "tf.Dummy"() {metatype1: $Float, metatype2: $Tensor<Float>} : $Tensor<Float>
+// CHECK-NEXT:   %4 = graph_op "tf.Dummy"() {array: {{\[\[}}i8 1, i32 -2], [f32 0xBF800000 /* -1 */, $Float]]} : $Tensor<Float>
 // CHECK-NEXT:   return %0 : $Tensor<Float>
 // CHECK-NEXT: }
 
 sil @chained_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> {
 bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
-  %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T = $Float] : $Tensor<Float>
-  %3 = graph_op "tf.Mul"(%2 : $Tensor<Float>, %2 : $Tensor<Float>) [T = $Float] : $Tensor<Float>
+  %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) {T: $Float} : $Tensor<Float>
+  %3 = graph_op "tf.Mul"(%2 : $Tensor<Float>, %2 : $Tensor<Float>) {T: $Float} : $Tensor<Float>
   return %3 : $Tensor<Float>
 }
 
 // CHECK-LABEL: sil @chained_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> {
 // CHECK: bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
-// CHECK-NEXT:   %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T = $Float] : $Tensor<Float>
-// CHECK-NEXT:   %3 = graph_op "tf.Mul"(%2 : $Tensor<Float>, %2 : $Tensor<Float>) [T = $Float] : $Tensor<Float>
+// CHECK-NEXT:   %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) {T: $Float} : $Tensor<Float>
+// CHECK-NEXT:   %3 = graph_op "tf.Mul"(%2 : $Tensor<Float>, %2 : $Tensor<Float>) {T: $Float} : $Tensor<Float>
 // CHECK-NEXT:   return %3 : $Tensor<Float>
 // CHECK-NEXT: }
 
 sil @single_result_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> {
 bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
-  %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T = $Float] : $Tensor<Float>
+  %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) {T: $Float} : $Tensor<Float>
   return %2 : $Tensor<Float>
 }
 
 // CHECK-LABEL: sil @single_result_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> {
 // CHECK: bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
-// CHECK-NEXT:   %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T = $Float] : $Tensor<Float>
+// CHECK-NEXT:   %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) {T: $Float} : $Tensor<Float>
 // CHECK-NEXT:   return %2 : $Tensor<Float>
 // CHECK-NEXT: }
 
 sil @multiple_result_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> (Tensor<Float>, Tensor<Float>) {
 bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
-  (%2, %3) = graph_op "tf.Dummy"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T = $Float] : $Tensor<Float>, $Tensor<Float>
+  (%2, %3) = graph_op "tf.Dummy"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) {T: $Float} : $Tensor<Float>, $Tensor<Float>
   %4 = tuple (%2 : $Tensor<Float>, %3 : $Tensor<Float>)
   return %4 : $(Tensor<Float>, Tensor<Float>)
 }
 
 // CHECK-LABEL: sil @multiple_result_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> (Tensor<Float>, Tensor<Float>) {
 // CHECK: bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
-// CHECK-NEXT:   (%2, %3) = graph_op "tf.Dummy"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T = $Float] : $Tensor<Float>, $Tensor<Float>
+// CHECK-NEXT:   (%2, %3) = graph_op "tf.Dummy"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) {T: $Float} : $Tensor<Float>, $Tensor<Float>
 // CHECK-NEXT:   %4 = tuple (%2 : $Tensor<Float>, %3 : $Tensor<Float>)
 // CHECK-NEXT:   return %4 : $(Tensor<Float>, Tensor<Float>)
 // CHECK-NEXT: }

--- a/test/TensorFlow/graph_op_inst.sil
+++ b/test/TensorFlow/graph_op_inst.sil
@@ -10,13 +10,21 @@ struct Tensor<Scalar> {}
 
 sil @attribute_test : $@convention(thin) () -> Tensor<Float> {
 bb0:
-  %0 = graph_op "tf.Dummy"() [int = i64 48, hex_float = f64 0x40091EB851EB851F, dec_float = f32 3.14, metatype = $Float, array = [[i32 1, i32 2], [i32 3, i32 4]]] : $Tensor<Float>
+  %0 = graph_op "tf.Dummy"() [int1 = i32 -3, int2 = i8 4, int3 = i64 42] : $Tensor<Float>
+  %1 = graph_op "tf.Dummy"() [hex1 = f64 0x40091EB851EB851F, hex2 = f32 0x4048F5C3] : $Tensor<Float>
+  %3 = graph_op "tf.Dummy"() [float1 = f64 3.14, float2 = f32 -3.14] : $Tensor<Float>
+  %4 = graph_op "tf.Dummy"() [metatype1 = $Float, metatype2 = $Tensor<Float>] : $Tensor<Float>
+  %5 = graph_op "tf.Dummy"() [array = [[i8 1, i32 -2], [f32 -1.0, $Float]]] : $Tensor<Float>
   return %0 : $Tensor<Float>
 }
 
 // CHECK-LABEL: sil @attribute_test : $@convention(thin) () -> Tensor<Float> {
 // CHECK: bb0:
-// CHECK-NEXT:   %0 = graph_op "tf.Dummy"() [int = i64 48, hex_float = f64 0x40091EB851EB851F /* 3.1400000000000001 */, dec_float = f32 0x4048F5C3 /* 3.1400001 */, metatype = $Float, array = {{\[\[}}i32 1, i32 2], [i32 3, i32 4]]] : $Tensor<Float>
+// CHECK-NEXT:   %0 = graph_op "tf.Dummy"() [int1 = i32 -3, int2 = i8 4, int3 = i64 42] : $Tensor<Float> // user: %5
+// CHECK-NEXT:   %1 = graph_op "tf.Dummy"() [hex1 = f64 0x40091EB851EB851F /* 3.1400000000000001 */, hex2 = f32 0x4048F5C3 /* 3.1400001 */] : $Tensor<Float>
+// CHECK-NEXT:   %2 = graph_op "tf.Dummy"() [float1 = f64 0x40091EB851EB851F /* 3.1400000000000001 */, float2 = f32 0xC048F5C3 /* -3.1400001 */] : $Tensor<Float>
+// CHECK-NEXT:   %3 = graph_op "tf.Dummy"() [metatype1 = $Float, metatype2 = $Tensor<Float>] : $Tensor<Float>
+// CHECK-NEXT:   %4 = graph_op "tf.Dummy"() [array = {{\[\[}}i8 1, i32 -2], [f32 0xBF800000 /* -1 */, $Float]]] : $Tensor<Float>
 // CHECK-NEXT:   return %0 : $Tensor<Float>
 // CHECK-NEXT: }
 

--- a/test/TensorFlow/graph_op_inst.sil
+++ b/test/TensorFlow/graph_op_inst.sil
@@ -16,7 +16,6 @@ bb0:
 
 // CHECK-LABEL: sil @attribute_test : $@convention(thin) () -> Tensor<Float> {
 // CHECK: bb0:
-//    %0 = graph_op "tf.Dummy" () [int 1, float 3.14{{[0-9]*}}, metatype $Float, array {{\[\[}}1, 2], [3, 4]]] : $Tensor<Float>
 // CHECK-NEXT:   %0 = graph_op "tf.Dummy"() [int 1, float 3.14{{[0-9]*}}, metatype $Float, array {{\[\[}}1, 2], [3, 4]]] : $Tensor<Float>
 // CHECK-NEXT:   return %0 : $Tensor<Float>
 // CHECK-NEXT: }

--- a/test/TensorFlow/graph_op_inst.sil
+++ b/test/TensorFlow/graph_op_inst.sil
@@ -10,13 +10,13 @@ struct Tensor<Scalar> {}
 
 sil @attribute_test : $@convention(thin) () -> Tensor<Float> {
 bb0:
-  %0 = graph_op "tf.Dummy"() [int = i64 48, float = f32 3.14, metatype = $Float, array = [[i32 1, i32 2], [i32 3, i32 4]]] : $Tensor<Float>
+  %0 = graph_op "tf.Dummy"() [int = i64 48, hex_float = f64 0x40091EB851EB851F, dec_float = f32 3.14, metatype = $Float, array = [[i32 1, i32 2], [i32 3, i32 4]]] : $Tensor<Float>
   return %0 : $Tensor<Float>
 }
 
 // CHECK-LABEL: sil @attribute_test : $@convention(thin) () -> Tensor<Float> {
 // CHECK: bb0:
-// CHECK-NEXT:   %0 = graph_op "tf.Dummy"() [int = i64 48, float = f32 3.14{{[0-9]*}}, metatype = $Float, array = {{\[\[}}i32 1, i32 2], [i32 3, i32 4]]] : $Tensor<Float>
+// CHECK-NEXT:   %0 = graph_op "tf.Dummy"() [int = i64 48, hex_float = f64 0x40091EB851EB851F /* 3.1400000000000001 */, dec_float = f32 0x4048F5C3 /* 3.1400001 */, metatype = $Float, array = {{\[\[}}i32 1, i32 2], [i32 3, i32 4]]] : $Tensor<Float>
 // CHECK-NEXT:   return %0 : $Tensor<Float>
 // CHECK-NEXT: }
 

--- a/test/TensorFlow/graph_op_inst.sil
+++ b/test/TensorFlow/graph_op_inst.sil
@@ -1,0 +1,62 @@
+// RUN: %target-sil-opt -sil-print-all %s | %FileCheck %s
+
+sil_stage raw
+
+import Builtin
+import Swift
+
+// Dummy struct mimicking the real `Tensor` type.
+struct Tensor<Scalar> {}
+
+sil @attribute_test : $@convention(thin) () -> Tensor<Float> {
+bb0:
+  %0 = graph_op "tf.Dummy"() [int 1, float 3.14, metatype $Float, array [[1, 2], [3, 4]]] : $Tensor<Float>
+  return %0 : $Tensor<Float>
+}
+
+// CHECK-LABEL: sil @attribute_test : $@convention(thin) () -> Tensor<Float> {
+// CHECK: bb0:
+//    %0 = graph_op "tf.Dummy" () [int 1, float 3.14{{[0-9]*}}, metatype $Float, array {{\[\[}}1, 2], [3, 4]]] : $Tensor<Float>
+// CHECK-NEXT:   %0 = graph_op "tf.Dummy"() [int 1, float 3.14{{[0-9]*}}, metatype $Float, array {{\[\[}}1, 2], [3, 4]]] : $Tensor<Float>
+// CHECK-NEXT:   return %0 : $Tensor<Float>
+// CHECK-NEXT: }
+
+sil @chained_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> {
+bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
+  %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T $Float] : $Tensor<Float>
+  %3 = graph_op "tf.Mul"(%2 : $Tensor<Float>, %2 : $Tensor<Float>) [T $Float] : $Tensor<Float>
+  return %3 : $Tensor<Float>
+}
+
+// CHECK-LABEL: sil @chained_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> {
+// CHECK: bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
+// CHECK-NEXT:   %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T $Float] : $Tensor<Float>
+// CHECK-NEXT:   %3 = graph_op "tf.Mul"(%2 : $Tensor<Float>, %2 : $Tensor<Float>) [T $Float] : $Tensor<Float>
+// CHECK-NEXT:   return %3 : $Tensor<Float>
+// CHECK-NEXT: }
+
+sil @single_result_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> {
+bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
+  %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T $Float] : $Tensor<Float>
+  return %2 : $Tensor<Float>
+}
+
+// CHECK-LABEL: sil @single_result_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float> {
+// CHECK: bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
+// CHECK-NEXT:   %2 = graph_op "tf.Add"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T $Float] : $Tensor<Float>
+// CHECK-NEXT:   return %2 : $Tensor<Float>
+// CHECK-NEXT: }
+
+sil @multiple_result_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> (Tensor<Float>, Tensor<Float>) {
+bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
+  (%2, %3) = graph_op "tf.Dummy"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T $Float] : $Tensor<Float>, $Tensor<Float>
+  %4 = tuple (%2 : $Tensor<Float>, %3 : $Tensor<Float>)
+  return %4 : $(Tensor<Float>, Tensor<Float>)
+}
+
+// CHECK-LABEL: sil @multiple_result_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> (Tensor<Float>, Tensor<Float>) {
+// CHECK: bb0(%0 : $Tensor<Float>, %1 : $Tensor<Float>):
+// CHECK-NEXT:   (%2, %3) = graph_op "tf.Dummy"(%0 : $Tensor<Float>, %1 : $Tensor<Float>) [T $Float] : $Tensor<Float>, $Tensor<Float>
+// CHECK-NEXT:   %4 = tuple (%2 : $Tensor<Float>, %3 : $Tensor<Float>)
+// CHECK-NEXT:   return %4 : $(Tensor<Float>, Tensor<Float>)
+// CHECK-NEXT: }


### PR DESCRIPTION
Add `GraphOperationInst` to represent graph operations.

A graph operation may have:
- Zero or more SILValue operands
- Zero or more attributes (consisting of a name and a `SymbolicValue` constant value)
- One or more result types

`GraphOperationInst` will replace `BuiltinInst` as the representation for
TensorFlow operations in the TFDeabstraction/TFPartition passes.

Todos:
 - @lattner: Edit deabstraction/partitioning to use `GraphOperationInst`.
 - Low priority: Implement SIL serialization/deserialization for `GraphOperationInst`.