### PR TITLE
[Sema] Diagnose misplaced InOutExpr in `preCheckExpression`

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1099,8 +1099,6 @@ ERROR(expected_operator_ref,none,
       "expected operator name in operator reference", ())
 ERROR(invalid_postfix_operator,none,
       "operator with postfix spacing cannot start a subexpression", ())
-ERROR(extraneous_amp_prefix,none,
-      "use of extraneous '&'", ())
 
 ERROR(expected_member_name,PointsToFirstBadToken,
       "expected member name following '.'", ())

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -1193,21 +1193,19 @@ public:
 
   //===--------------------------------------------------------------------===//
   // Expression Parsing
-  ParserResult<Expr> parseExpr(Diag<> ID, bool allowAmpPrefix = false) {
-    return parseExprImpl(ID, /*isExprBasic=*/false, allowAmpPrefix);
+  ParserResult<Expr> parseExpr(Diag<> ID) {
+    return parseExprImpl(ID, /*isExprBasic=*/false);
   }
   ParserResult<Expr> parseExprBasic(Diag<> ID) {
     return parseExprImpl(ID, /*isExprBasic=*/true);
   }
-  ParserResult<Expr> parseExprImpl(Diag<> ID, bool isExprBasic,
-                                   bool allowAmpPrefix = false);
+  ParserResult<Expr> parseExprImpl(Diag<> ID, bool isExprBasic);
   ParserResult<Expr> parseExprIs();
   ParserResult<Expr> parseExprAs();
   ParserResult<Expr> parseExprArrow();
   ParserResult<Expr> parseExprSequence(Diag<> ID,
                                        bool isExprBasic,
-                                       bool isForConditionalDirective = false,
-                                       bool allowAmpPrefix = false);
+                                       bool isForConditionalDirective = false);
   ParserResult<Expr> parseExprSequenceElement(Diag<> ID,
                                               bool isExprBasic);
   ParserResult<Expr> parseExprPostfixSuffix(ParserResult<Expr> inner,
@@ -1311,8 +1309,7 @@ public:
                              SmallVectorImpl<SourceLoc> &exprLabelLocs,
                              SourceLoc &rightLoc,
                              Expr *&trailingClosure,
-                             syntax::SyntaxKind Kind,
-                             bool allowAmpPrefix = false);
+                             syntax::SyntaxKind Kind);
 
   ParserResult<Expr> parseTrailingClosure(SourceRange calleeRange);
 

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -41,8 +41,7 @@ using namespace swift::syntax;
 ///
 /// \param isExprBasic Whether we're only parsing an expr-basic.
 ParserResult<Expr> Parser::parseExprImpl(Diag<> Message,
-                                         bool isExprBasic,
-                                         bool allowAmpPrefix) {
+                                         bool isExprBasic) {
   // Start a context for creating expression syntax.
   SyntaxParsingContext ExprParsingContext(SyntaxContext, SyntaxContextKind::Expr);
 
@@ -64,8 +63,7 @@ ParserResult<Expr> Parser::parseExprImpl(Diag<> Message,
   }
   
   auto expr = parseExprSequence(Message, isExprBasic,
-                                /*forConditionalDirective*/false,
-                                allowAmpPrefix);
+                                /*forConditionalDirective*/false);
   if (expr.hasCodeCompletion())
     return expr;
   if (expr.isNull())
@@ -170,8 +168,7 @@ ParserResult<Expr> Parser::parseExprArrow() {
 /// apply to everything to its right.
 ParserResult<Expr> Parser::parseExprSequence(Diag<> Message,
                                              bool isExprBasic,
-                                             bool isForConditionalDirective,
-                                             bool allowAmpPrefix) {
+                                             bool isForConditionalDirective) {
   SyntaxParsingContext ExprSequnceContext(SyntaxContext, SyntaxContextKind::Expr);
 
   SmallVector<Expr*, 8> SequencedExprs;
@@ -182,36 +179,10 @@ ParserResult<Expr> Parser::parseExprSequence(Diag<> Message,
   while (true) {
     if (isForConditionalDirective && Tok.isAtStartOfLine())
       break;
-    
-    ParserResult<Expr> Primary;
 
-    SourceLoc AmpPrefix;
-    if (Tok.is(tok::amp_prefix)) {
-      SyntaxParsingContext AmpCtx(SyntaxContext, SyntaxKind::InOutExpr);
-      AmpPrefix = consumeToken(tok::amp_prefix);
-
-      auto SubExpr = parseExprUnary(Message, isExprBasic);
-      auto allowNextAmpPrefix = Tok.isBinaryOperator();
-      if (SubExpr.hasCodeCompletion()) {
-        Primary = makeParserCodeCompletionResult<Expr>();
-      } else if (SubExpr.isNull()) {
-        Primary = nullptr;
-      } else if (allowAmpPrefix || allowNextAmpPrefix) {
-        Primary = makeParserResult(
-            new (Context) InOutExpr(AmpPrefix, SubExpr.get(), Type()));
-      } else {
-        diagnose(AmpPrefix, diag::extraneous_amp_prefix);
-        // In the long run, we should assign SubExpr to Primary to improve
-        // single-pass diagnostic completeness, but for now, doing so exposes
-        // diagnostic bugs in Sema where '&' is wrongly suggested as a fix.
-        Primary = makeParserErrorResult(new (Context) ErrorExpr(
-            {AmpPrefix, SubExpr.get()->getSourceRange().End}));
-      }
-      allowAmpPrefix = allowNextAmpPrefix;
-    } else {
-      // Parse a unary expression.
-      Primary = parseExprSequenceElement(Message, isExprBasic);
-    }
+    // Parse a unary expression.
+    ParserResult<Expr> Primary =
+      parseExprSequenceElement(Message, isExprBasic);
 
     HasCodeCompletion |= Primary.hasCodeCompletion();
     if (Primary.isNull()) {
@@ -256,8 +227,7 @@ parse_operator:
                                            SyntaxKind::BinaryOperatorExpr);
       Expr *Operator = parseExprOperator();
       SequencedExprs.push_back(Operator);
-      allowAmpPrefix = true;
-      
+
       // The message is only valid for the first subexpr.
       Message = diag::expected_expr_after_operator;
       break;
@@ -507,6 +477,19 @@ ParserResult<Expr> Parser::parseExprUnary(Diag<> Message, bool isExprBasic) {
   default:
     // If the next token is not an operator, just parse this as expr-postfix.
     return parseExprPostfix(Message, isExprBasic);
+
+  case tok::amp_prefix: {
+    SyntaxParsingContext AmpCtx(SyntaxContext, SyntaxKind::InOutExpr);
+    SourceLoc Loc = consumeToken(tok::amp_prefix);
+
+    ParserResult<Expr> SubExpr = parseExprUnary(Message, isExprBasic);
+    if (SubExpr.hasCodeCompletion())
+      return makeParserCodeCompletionResult<Expr>();
+    if (SubExpr.isNull())
+      return nullptr;
+    return makeParserResult(
+        new (Context) InOutExpr(Loc, SubExpr.get(), Type()));
+  }
 
   case tok::backslash:
     return parseExprKeyPath();
@@ -923,8 +906,7 @@ ParserResult<Expr> Parser::parseExprSuper(bool isExprBasic) {
                                         indexArgLabelLocs,
                                         rSquareLoc,
                                         trailingClosure,
-                                        SyntaxKind::FunctionCallArgumentList,
-                                        /*allowAmpPrefix*/true);
+                                        SyntaxKind::FunctionCallArgumentList);
     if (status.hasCodeCompletion())
       return makeParserCodeCompletionResult<Expr>();
     if (status.isError())
@@ -1272,8 +1254,7 @@ Parser::parseExprPostfixSuffix(ParserResult<Expr> Result, bool isExprBasic,
           tok::l_square, tok::r_square,
           /*isPostfix=*/true, isExprBasic, lSquareLoc, indexArgs,
           indexArgLabels, indexArgLabelLocs, rSquareLoc, trailingClosure,
-          SyntaxKind::FunctionCallArgumentList,
-          /*allowAmpPrefix*/true);
+          SyntaxKind::FunctionCallArgumentList);
       if (status.hasCodeCompletion())
         return makeParserCodeCompletionResult<Expr>();
       if (status.isError() || Result.isNull())
@@ -1709,8 +1690,7 @@ ParserResult<Expr> Parser::parseExprPrimary(Diag<> ID, bool isExprBasic) {
                                           argLabelLocs,
                                           rParenLoc,
                                           trailingClosure,
-                                          SyntaxKind::FunctionCallArgumentList,
-                                          /*allowAmpPrefix*/true);
+                                          SyntaxKind::FunctionCallArgumentList);
       if (status.isError())
         return nullptr;
 
@@ -2954,8 +2934,7 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
                                    SmallVectorImpl<SourceLoc> &exprLabelLocs,
                                    SourceLoc &rightLoc,
                                    Expr *&trailingClosure,
-                                   SyntaxKind Kind,
-                                   bool allowAmpPrefix) {
+                                   SyntaxKind Kind) {
   trailingClosure = nullptr;
 
   StructureMarkerRAII ParsingExprList(*this, Tok);
@@ -2992,8 +2971,7 @@ ParserStatus Parser::parseExprList(tok leftTok, tok rightTok,
                                                    DeclRefKind::Ordinary,
                                                    DeclNameLoc(Loc));
     } else {
-      auto ParsedSubExpr = parseExpr(diag::expected_expr_in_expr_list,
-                                     /*allowAmpPrefix*/allowAmpPrefix);
+      auto ParsedSubExpr = parseExpr(diag::expected_expr_in_expr_list);
       SubExpr = ParsedSubExpr.getPtrOrNull();
       Status = ParsedSubExpr;
     }
@@ -3237,8 +3215,7 @@ Parser::parseExprCallSuffix(ParserResult<Expr> fn, bool isExprBasic) {
                                       argLabelLocs,
                                       rParenLoc,
                                       trailingClosure,
-                                      SyntaxKind::FunctionCallArgumentList,
-                                      /*allowAmpPrefix*/true);
+                                      SyntaxKind::FunctionCallArgumentList);
 
   // Form the call.
   auto Result = makeParserResult(status | fn, 

--- a/test/Constraints/rdar40945329.swift
+++ b/test/Constraints/rdar40945329.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift
+
+class A {
+  static var a: Int = 0
+  static var b: Int = 42
+
+  func foo(_ ptr: UnsafeMutableRawPointer?) {
+    switch ptr {
+      case (&A.a)?: break
+      case (&A.b)?: break
+      default: break
+    }
+  }
+
+  func bar(_ ptr: UnsafeRawPointer) {
+    switch ptr {
+      case &A.a: break
+      case &A.b: break
+      default: break
+    }
+  }
+}

--- a/test/expr/expressions.swift
+++ b/test/expr/expressions.swift
@@ -814,8 +814,8 @@ public struct TestPropMethodOverloadGroup {
 // <rdar://problem/18496742> Passing ternary operator expression as inout crashes Swift compiler
 func inoutTests(_ arr: inout Int) {
   var x = 1, y = 2
-  (true ? &x : &y) // expected-error 2 {{use of extraneous '&'}}
-  let a = (true ? &x : &y) // expected-error 2 {{use of extraneous '&'}}
+  (true ? &x : &y) // expected-error {{use of extraneous '&'}}
+  let a = (true ? &x : &y) // expected-error {{use of extraneous '&'}}
 
   inoutTests(true ? &x : &y) // expected-error {{use of extraneous '&'}}
 
@@ -827,7 +827,7 @@ func inoutTests(_ arr: inout Int) {
   inoutTests(&x)
   
   // <rdar://problem/17489894> inout not rejected as operand to assignment operator
-  &x += y  // expected-error {{'&' can only appear immediately in a call argument list}}}
+  &x += y  // expected-error {{'&' can only appear immediately in a call argument list}}
 
   // <rdar://problem/23249098>
   func takeAny(_ x: Any) {}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Since there are cases where use of `&` is still allowed e.g. case statement patterns, let's move
diagnostics of extraneous use of `InOutExpr` to `preCheckExpression` where it's much
easier to do so comparing to doing that in parsing, where we'd have to thread a flag through
most of the `parseExpr*` calls to support that case.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves: rdar://problem/40945329
Resolves [SR-7877](https://bugs.swift.org/browse/SR-7877).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
