### PR TITLE
[4.2] [ConstraintSystem] Honor -solver-memory-threshold if present.

### DIFF
--- a/test/Misc/prioritize_solver_memory_threshold.swift
+++ b/test/Misc/prioritize_solver_memory_threshold.swift
@@ -1,0 +1,3 @@
+// RUN: %target-typecheck-verify-swift -solver-memory-threshold 1
+
+func foo() { _ = 1 } // expected-error {{the compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions}}


### PR DESCRIPTION
If the user specifies a memory threshold on the command-line, try to
honor that value and consider expressions too complex if we end up
allocating more memory than they specify.

Fixes rdar://problem/40952582 (aka https://bugs.swift.org/browse/SR-7525).

(cherry picked from commit d135daae4495e268f600e57b156a1f226abb6380)
