### PR TITLE
Sema: Fix availability of inherited designated initializers [4.2]

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -2037,9 +2037,12 @@ static void configureDesignatedInitAttributes(TypeChecker &tc,
     ctor->getAttrs().add(clonedAttr);
   }
 
-  // Make sure the constructor is only as available as its superclass's
-  // constructor.
-  AvailabilityInference::applyInferredAvailableAttrs(ctor, superclassCtor, ctx);
+  // If the superclass has its own availability, make sure the synthesized
+  // constructor is only as available as its superclass's constructor.
+  if (superclassCtor->getAttrs().hasAttribute<AvailableAttr>()) {
+    AvailabilityInference::applyInferredAvailableAttrs(
+        ctor, {classDecl, superclassCtor}, ctx);
+  }
 
   if (superclassCtor->isObjC()) {
     // Inherit the @objc name from the superclass initializer, if it

--- a/test/Sema/availability_versions.swift
+++ b/test/Sema/availability_versions.swift
@@ -985,6 +985,19 @@ func useUnavailableExtension() {
       // expected-note@-1 {{add 'if #available' version check}}
 }
 
+// Availability of synthesized designated initializers.
+
+@available(OSX, introduced: 10.51)
+class WidelyAvailableBase {
+  init() {}
+
+  @available(OSX, introduced: 10.52)
+  init(thing: ()) {}
+}
+
+@available(OSX, introduced: 10.53)
+class EsotericSmallBatchHipsterThing : WidelyAvailableBase {}
+
 // Useless #available(...) checks
 
 func functionWithDefaultAvailabilityAndUselessCheck(_ p: Bool) {


### PR DESCRIPTION
Inherited designated initializers got the same availability
as the corresponding initialier in the superclass.

However if the superclass was more available than the subclass,
we would generate a diagnostic that a member cannot be more
available than its containing type.

This diagnostic had an unknown source location, since the
location was for a synthesized declaration, causing confusion.

Fixes <https://bugs.swift.org/browse/SR-7881> aka
<rdar://problem/40853731>.