### PR TITLE
[SR-7629] Fix wrong fixit when the type doesn't conform to a public protocol

### DIFF
--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2773,6 +2773,12 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
                        requiredAccess,
                        protoAccessScope.accessLevelForDiagnostics(),
                        proto->getName());
+        if (auto *decl = dyn_cast<AbstractFunctionDecl>(witness)) {
+          auto isMemberwiseInitializer = decl->getBodyKind() == AbstractFunctionDecl::BodyKind::MemberwiseInitializer;
+          if (isMemberwiseInitializer) {
+            return;
+          }
+        }
         auto fixItDiag = diags.diagnose(witness, diag::witness_fix_access,
                                         witness->getDescriptiveKind(),
                                         requiredAccess);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -2774,7 +2774,9 @@ ConformanceChecker::resolveWitnessViaLookup(ValueDecl *requirement) {
                        protoAccessScope.accessLevelForDiagnostics(),
                        proto->getName());
         if (auto *decl = dyn_cast<AbstractFunctionDecl>(witness)) {
-          auto isMemberwiseInitializer = decl->getBodyKind() == AbstractFunctionDecl::BodyKind::MemberwiseInitializer;
+          auto isMemberwiseInitializer =
+              decl->getBodyKind() ==
+              AbstractFunctionDecl::BodyKind::MemberwiseInitializer;
           if (isMemberwiseInitializer) {
             return;
           }

--- a/test/attr/accessibility.swift
+++ b/test/attr/accessibility.swift
@@ -260,8 +260,8 @@ public protocol PublicInitProto {
 public struct NonPublicInitStruct: PublicInitProto {
   public var value: Int
   init(value: Int) {
-// expected-error@-1 {{initializer 'init(value:)' must be declared public because it matches a requirement in public protocol 'PublicInitProto'}}
-// expected-note@-2 {{mark the initializer as 'public' to satisfy the requirement}}
+  // expected-error@-1 {{initializer 'init(value:)' must be declared public because it matches a requirement in public protocol 'PublicInitProto'}}
+  // expected-note@-2 {{mark the initializer as 'public' to satisfy the requirement}}
     self.value = value
   }
 }

--- a/test/attr/accessibility.swift
+++ b/test/attr/accessibility.swift
@@ -252,3 +252,20 @@ public struct AdoptViaCombinedProtocol : ProtoWithReqs, ReqProvider2 {
   // expected-error@-1 {{method 'foo()' must be declared public because it matches a requirement in public protocol 'ProtoWithReqs'}} {{none}}
   public typealias Assoc = Int
 }
+
+public protocol PublicInitProto {
+  var value: Int { get }
+  init(value: Int)
+}
+public struct NonPublicInitStruct: PublicInitProto {
+  public var value: Int
+  init(value: Int) {
+// expected-error@-1 {{initializer 'init(value:)' must be declared public because it matches a requirement in public protocol 'PublicInitProto'}}
+// expected-note@-2 {{mark the initializer as 'public' to satisfy the requirement}}
+    self.value = value
+  }
+}
+public struct NonPublicMemberwiseInitStruct: PublicInitProto {
+// expected-error@-1 {{initializer 'init(value:)' must be declared public because it matches a requirement in public protocol 'PublicInitProto'}}
+  public var value: Int
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
Wrong fixit occurred when initializer is memberwiseInitializer. So I disabled fixit only in that case.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7629](https://bugs.swift.org/browse/SR-7629).
