### PR TITLE
[silgen] When transforming values into an existential box representat…

### DIFF
--- a/lib/SILGen/SILGenConvert.cpp
+++ b/lib/SILGen/SILGenConvert.cpp
@@ -727,7 +727,7 @@ ManagedValue SILGenFunction::emitExistentialErasure(
                                    ExistentialRepresentation::Boxed, *this);
     ManagedValue mv = F(SGFContext(&init));
     if (!mv.isInContext()) {
-      mv.forwardInto(*this, loc, init.getAddress());
+      mv.ensurePlusOne(*this, loc).forwardInto(*this, loc, init.getAddress());
       init.finishInitialization(*this);
     }
     

--- a/test/SILGen/function_conversion.swift
+++ b/test/SILGen/function_conversion.swift
@@ -641,3 +641,27 @@ func rdar35702810_anyhashable() {
   // CHECK: convert_escape_to_noescape [not_guaranteed] [[PA]] : $@callee_guaranteed (@guaranteed Set<B>) -> () to $@noescape @callee_guaranteed (@guaranteed Set<B>) -> ()
   bar_set(type: B.self, fn_set)
 }
+
+// ==== Function conversion with parameter substToOrig reabstraction.
+
+struct FunctionConversionParameterSubstToOrigReabstractionTest {
+  typealias SelfTy = FunctionConversionParameterSubstToOrigReabstractionTest
+
+  class Klass: Error {}
+
+  struct Foo<T> {
+    static func enum1Func(_ : (T) -> Foo<Error>) -> Foo<Error> {
+      // Just to make it compile.
+      return Optional<Foo<Error>>.none!
+    }
+  }
+
+  static func bar<T>(t: T) -> Foo<T> {
+    // Just to make it compile.
+    return Optional<Foo<T>>.none!
+  }
+
+  static func testFunc() -> Foo<Error> {
+    return Foo<Klass>.enum1Func(SelfTy.bar)
+  }
+}


### PR DESCRIPTION
…ion, do it at +1.

In general, SILGen assumes that only +1 values are "forwarded" into memory. This
is because we want any value that is stored in memory to not be dependent on
other values and for the forwarded object to be able to maintain its own
liveness. So this assert was correct to fire.

The specific test case that exposed this issue is:

What happened here is that we needed to reabstract a loadable value into an
existential and tried to maximally abstract it and thus store it into
memory. The That code was never updated to make sure the value was at +1. So we
would store a guaranteed value into memory and hope that whereever we stored it
doesn't escape the current function. In this case, I believe that we would be
safe... but past returns are not indicators of future results.

rdar://40773543
SR-7858
