### PR TITLE
[4.2] Optimize string constants

### DIFF
--- a/include/swift/AST/Builtins.def
+++ b/include/swift/AST/Builtins.def
@@ -475,6 +475,11 @@ BUILTIN_MISC_OPERATION(StaticReport, "staticReport", "", Special)
 BUILTIN_MISC_OPERATION(AssertConf, "assert_configuration", "n", Special)
 
 /// StringObjectOr has type (T,T) -> T.
+/// Sets bits in a string object. The first operand is bit-cast string literal
+/// pointer to an integer. The second operand is the bit mask to be or'd into
+/// the high bits of the pointer.
+/// It is required that the or'd bits are all 0 in the first operand. So this
+/// or-operation is actually equivalent to an addition.
 BUILTIN_MISC_OPERATION(StringObjectOr,     "stringObjectOr",      "n", Integer)
 
 /// Special truncation builtins that check for sign and overflow errors. These

--- a/lib/SIL/SILGlobalVariable.cpp
+++ b/lib/SIL/SILGlobalVariable.cpp
@@ -86,6 +86,17 @@ bool SILGlobalVariable::isValidStaticInitializerInst(const SILInstruction *I,
           if (isa<LiteralInst>(bi->getArguments()[0]))
             return true;
           break;
+        case BuiltinValueKind::StringObjectOr:
+          // The first operand can be a string literal (i.e. a pointer), but the
+          // second operand must be a constant. This enables creating a
+          // a pointer+offset relocation.
+          // Note that StringObjectOr requires the or'd bits in the first
+          // operand to be 0, so the operation is equivalent to an addition.
+          if (isa<IntegerLiteralInst>(bi->getArguments()[1]))
+            return true;
+          break;
+        case BuiltinValueKind::ZExtOrBitCast:
+          return true;
         default:
           break;
       }
@@ -107,6 +118,7 @@ bool SILGlobalVariable::isValidStaticInitializerInst(const SILInstruction *I,
     case SILInstructionKind::IntegerLiteralInst:
     case SILInstructionKind::FloatLiteralInst:
     case SILInstructionKind::ObjectInst:
+    case SILInstructionKind::ValueToBridgeObjectInst:
       return true;
     default:
       return false;

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -383,6 +383,12 @@ static void addClosureSpecializePassPipeline(SILPassPipelinePlan &P) {
   P.addDeadFunctionElimination();
   P.addDeadObjectElimination();
 
+  // These few passes are needed to cleanup between loop unrolling and GlobalOpt.
+  P.addSimplifyCFG();
+  P.addSILCombine();
+  P.addPerformanceConstantPropagation();
+  P.addSimplifyCFG();
+
   // Hoist globals out of loops.
   // Global-init functions should not be inlined GlobalOpt is done.
   P.addGlobalOpt();

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -198,6 +198,7 @@ public:
   SILInstruction *visitPartialApplyInst(PartialApplyInst *AI);
   SILInstruction *visitApplyInst(ApplyInst *AI);
   SILInstruction *visitTryApplyInst(TryApplyInst *AI);
+  SILInstruction *optimizeStringObject(BuiltinInst *BI);
   SILInstruction *visitBuiltinInst(BuiltinInst *BI);
   SILInstruction *visitCondFailInst(CondFailInst *CFI);
   SILInstruction *visitStrongRetainInst(StrongRetainInst *SRI);

--- a/lib/SILOptimizer/SILCombiner/SILCombiner.h
+++ b/lib/SILOptimizer/SILCombiner/SILCombiner.h
@@ -203,7 +203,9 @@ public:
   SILInstruction *visitStrongRetainInst(StrongRetainInst *SRI);
   SILInstruction *visitRefToRawPointerInst(RefToRawPointerInst *RRPI);
   SILInstruction *visitUpcastInst(UpcastInst *UCI);
+  SILInstruction *optimizeLoadFromStringLiteral(LoadInst *LI);
   SILInstruction *visitLoadInst(LoadInst *LI);
+  SILInstruction *visitIndexAddrInst(IndexAddrInst *IA);
   SILInstruction *visitAllocStackInst(AllocStackInst *AS);
   SILInstruction *visitAllocRefInst(AllocRefInst *AR);
   SILInstruction *visitSwitchEnumAddrInst(SwitchEnumAddrInst *SEAI);

--- a/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerBuiltinVisitors.cpp
@@ -430,6 +430,87 @@ SILInstruction *optimizeBitOp(BuiltinInst *BI,
   return nullptr;
 }
 
+/// Returns a 64-bit integer constant if \p op is an integer_literal instruction
+/// with a value which fits into 64 bits.
+static Optional<uint64_t> getIntConst(SILValue op) {
+  if (auto *ILI = dyn_cast<IntegerLiteralInst>(op)) {
+    if (ILI->getValue().getActiveBits() <= 64)
+      return ILI->getValue().getZExtValue();
+  }
+  return None;
+}
+
+/// Optimize the bit extract of a string object. Example in SIL pseudo-code,
+/// omitting the type-conversion instructions:
+///
+///    %0 = string_literal
+///    %1 = integer_literal 0x8000000000000000
+///    %2 = builtin "stringObjectOr_Int64" (%0, %1)
+///    %3 = integer_literal 0x4000000000000000
+///    %4 = builtin "and_Int64" (%2, %3)
+///
+/// optimizes to an integer_literal of 0.
+SILInstruction *SILCombiner::optimizeStringObject(BuiltinInst *BI) {
+  assert(BI->getBuiltinInfo().ID == BuiltinValueKind::And);
+  auto AndOp = getIntConst(BI->getArguments()[1]);
+  if (!AndOp)
+    return nullptr;
+
+  uint64_t andBits = AndOp.getValue();
+
+  // TODO: It's bad that we have to hardcode the payload bit mask here.
+  // Instead we should introduce builtins (or instructions) to extract the
+  // payload and extra bits, respectively.
+  const uint64_t payloadBits = 0x00ffffffffffffffll;
+  if ((andBits & payloadBits) != 0)
+    return nullptr;
+
+  uint64_t setBits = 0;
+  SILValue val = BI->getArguments()[0];
+  while (val->getKind() != ValueKind::StringLiteralInst) {
+    switch (val->getKind()) {
+      // Look through all the type conversion and projection instructions.
+      case ValueKind::StructExtractInst:
+      case ValueKind::UncheckedTrivialBitCastInst:
+      case ValueKind::ValueToBridgeObjectInst:
+        val = cast<SingleValueInstruction>(val)->getOperand(0);
+        break;
+      case ValueKind::StructInst: {
+        auto *SI = cast<StructInst>(val);
+        if (SI->getNumOperands() != 1)
+          return nullptr;
+        val = SI->getOperand(0);
+        break;
+      }
+      case ValueKind::BuiltinInst: {
+        auto *B = cast<BuiltinInst>(val);
+        switch (B->getBuiltinInfo().ID) {
+          case BuiltinValueKind::StringObjectOr:
+            // Note that it is a requirement that the or'd bits of the left
+            // operand are initially zero.
+            if (auto opVal = getIntConst(B->getArguments()[1])) {
+              setBits |= opVal.getValue();
+            } else {
+              return nullptr;
+            }
+            LLVM_FALLTHROUGH;
+          case BuiltinValueKind::ZExtOrBitCast:
+          case BuiltinValueKind::PtrToInt:
+            val = B->getArguments()[0];
+            break;
+          default:
+            return nullptr;
+        }
+        break;
+      }
+      default:
+        return nullptr;
+    }
+  }
+  return Builder.createIntegerLiteral(BI->getLoc(), BI->getType(),
+                                      setBits & andBits);
+}
+
 SILInstruction *SILCombiner::visitBuiltinInst(BuiltinInst *I) {
   if (I->getBuiltinInfo().ID == BuiltinValueKind::CanBeObjCClass)
     return optimizeBuiltinCanBeObjCClass(I);
@@ -496,6 +577,9 @@ SILInstruction *SILCombiner::visitBuiltinInst(BuiltinInst *I) {
     break;
   }
   case BuiltinValueKind::And:
+    if (SILInstruction *optimized = optimizeStringObject(I))
+      return optimized;
+
     return optimizeBitOp(I,
       [](APInt &left, const APInt &right) { left &= right; }    /* combine */,
       [](const APInt &i) -> bool { return i.isAllOnesValue(); } /* isNeutral */,

--- a/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
+++ b/lib/SILOptimizer/SILCombiner/SILCombinerMiscVisitors.cpp
@@ -465,6 +465,58 @@ SILInstruction *SILCombiner::visitAllocRefInst(AllocRefInst *AR) {
   return nullptr;
 }
 
+/// Returns the base address if \p val is an index_addr with constant index.
+static SILValue isConstIndexAddr(SILValue val, unsigned &index) {
+  auto *IA = dyn_cast<IndexAddrInst>(val);
+  if (!IA)
+    return nullptr;
+  auto *Index = dyn_cast<IntegerLiteralInst>(IA->getIndex());
+
+  // Limiting to 32 bits is more than enough. The reason why not limiting to 64
+  // bits is to let room for overflow when we add two indices.
+  if (!Index || Index->getValue().getActiveBits() > 32)
+    return nullptr;
+
+  index = Index->getValue().getZExtValue();
+  return IA->getBase();
+}
+
+/// Optimize loading bytes from a string literal.
+/// Example in SIL pseudo code:
+///     %0 = string_literal "abc"
+///     %1 = integer_literal 2
+///     %2 = index_addr %0, %2
+///     %3 = load %2
+/// ->
+///     %3 = integer_literal 'c'
+SILInstruction *SILCombiner::optimizeLoadFromStringLiteral(LoadInst *LI) {
+  auto *SEA = dyn_cast<StructElementAddrInst>(LI->getOperand());
+  if (!SEA)
+    return nullptr;
+
+  SILValue addr = SEA->getOperand();
+  unsigned index = 0;
+  if (SILValue iaBase = isConstIndexAddr(addr, index))
+    addr = iaBase;
+
+  auto *PTA = dyn_cast<PointerToAddressInst>(addr);
+  if (!PTA)
+    return nullptr;
+  auto *Literal = dyn_cast<StringLiteralInst>(PTA->getOperand());
+  if (!Literal || Literal->getEncoding() != StringLiteralInst::Encoding::UTF8)
+    return nullptr;
+
+  BuiltinIntegerType *BIType = LI->getType().getAs<BuiltinIntegerType>();
+  if (!BIType || !BIType->isFixedWidth(8))
+    return nullptr;
+
+  StringRef str = Literal->getValue();
+  if (index >= str.size())
+    return nullptr;
+
+  return Builder.createIntegerLiteral(LI->getLoc(), LI->getType(), str[index]);
+}
+
 SILInstruction *SILCombiner::visitLoadInst(LoadInst *LI) {
   // (load (upcast-ptr %x)) -> (upcast-ref (load %x))
   Builder.setCurrentDebugScope(LI->getDebugScope());
@@ -473,6 +525,9 @@ SILInstruction *SILCombiner::visitLoadInst(LoadInst *LI) {
                                     LoadOwnershipQualifier::Unqualified);
     return Builder.createUpcast(LI->getLoc(), NewLI, LI->getType());
   }
+
+  if (SILInstruction *I = optimizeLoadFromStringLiteral(LI))
+    return I;
 
   // Given a load with multiple struct_extracts/tuple_extracts and no other
   // uses, canonicalize the load into several (struct_element_addr (load))
@@ -533,6 +588,28 @@ SILInstruction *SILCombiner::visitLoadInst(LoadInst *LI) {
 
   // Erase the old load.
   return eraseInstFromFunction(*LI);
+}
+
+/// Optimize nested index_addr instructions:
+/// Example in SIL pseudo code:
+///    %1 = index_addr %ptr, x
+///    %2 = index_addr %1, y
+/// ->
+///    %2 = index_addr %ptr, x+y
+SILInstruction *SILCombiner::visitIndexAddrInst(IndexAddrInst *IA) {
+  unsigned index = 0;
+  SILValue base = isConstIndexAddr(IA, index);
+  if (!base)
+    return nullptr;
+
+  unsigned index2 = 0;
+  SILValue base2 = isConstIndexAddr(base, index2);
+  if (!base2)
+    return nullptr;
+
+  auto *newIndex = Builder.createIntegerLiteral(IA->getLoc(),
+                                    IA->getIndex()->getType(), index + index2);
+  return Builder.createIndexAddr(IA->getLoc(), base2, newIndex);
 }
 
 SILInstruction *SILCombiner::visitReleaseValueInst(ReleaseValueInst *RVI) {

--- a/stdlib/public/core/StringObject.swift
+++ b/stdlib/public/core/StringObject.swift
@@ -247,8 +247,7 @@ extension _StringObject {
   internal
   static var _variantMask: UInt {
     @inline(__always)
-    get { return UInt(Builtin.stringObjectOr_Int64(
-      _isValueBit._value, _subVariantBit._value)) }
+    get { return _isValueBit | _subVariantBit }
   }
 
   @inlinable
@@ -861,7 +860,7 @@ extension _StringObject {
     self.init(.strong(Builtin.reinterpretCast(_payloadBits)), bits)
 #else
     _sanityCheck(_payloadBits & ~_StringObject._payloadMask == 0)
-    var rawBits = _payloadBits & _StringObject._payloadMask
+    var rawBits = _payloadBits
     if isValue {
       var rawBitsBuiltin = Builtin.stringObjectOr_Int64(
         rawBits._value, _StringObject._isValueBit._value)

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -3579,3 +3579,61 @@ bb0(%0 : $Builtin.Int64):
   strong_retain %2 : $Builtin.BridgeObject
   return %2 : $Builtin.BridgeObject
 }
+
+// CHECK-LABEL: sil @optimize_stringObject_bit_operations
+// CHECK:      bb0:
+// CHECK-NEXT:   %0 = integer_literal $Builtin.Int64, 4611686018427387904
+// CHECK-NEXT:   return %0
+sil @optimize_stringObject_bit_operations : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  %2 = string_literal utf8 "thequickbrownfoxjumpsoverthelazydogusingasmanycharacteraspossible123456789"
+  %5 = builtin "ptrtoint_Word"(%2 : $Builtin.RawPointer) : $Builtin.Word
+  %6 = builtin "zextOrBitCast_Word_Int64"(%5 : $Builtin.Word) : $Builtin.Int64
+  %9 = integer_literal $Builtin.Int64, 13835058055282163712
+  %10 = builtin "stringObjectOr_Int64"(%6 : $Builtin.Int64, %9 : $Builtin.Int64) : $Builtin.Int64
+  %11 = struct $UInt64 (%10 : $Builtin.Int64)
+  %12 = value_to_bridge_object %11 : $UInt64
+  %33 = unchecked_trivial_bit_cast %12 : $Builtin.BridgeObject to $UInt64
+  %34 = integer_literal $Builtin.Int64, 6917529027641081856
+  %35 = struct_extract %33 : $UInt64, #UInt64._value
+  %36 = builtin "and_Int64"(%35 : $Builtin.Int64, %34 : $Builtin.Int64) : $Builtin.Int64
+  return %36 : $Builtin.Int64
+}
+
+// CHECK-LABEL: sil @dont_optimize_stringObject_bit_operations1
+// CHECK:   builtin "stringObjectOr_Int64"
+// CHECK:   builtin "and_Int64"
+sil @dont_optimize_stringObject_bit_operations1 : $@convention(thin) (Builtin.RawPointer) -> Builtin.Int64 {
+bb0(%2 : $Builtin.RawPointer):
+  %5 = builtin "ptrtoint_Word"(%2 : $Builtin.RawPointer) : $Builtin.Word
+  %6 = builtin "zextOrBitCast_Word_Int64"(%5 : $Builtin.Word) : $Builtin.Int64
+  %9 = integer_literal $Builtin.Int64, -9223372036854775808
+  %10 = builtin "stringObjectOr_Int64"(%6 : $Builtin.Int64, %9 : $Builtin.Int64) : $Builtin.Int64
+  %11 = struct $UInt64 (%10 : $Builtin.Int64)
+  %12 = value_to_bridge_object %11 : $UInt64
+  %33 = unchecked_trivial_bit_cast %12 : $Builtin.BridgeObject to $UInt64
+  %34 = integer_literal $Builtin.Int64, 4611686018427387904
+  %35 = struct_extract %33 : $UInt64, #UInt64._value
+  %36 = builtin "and_Int64"(%35 : $Builtin.Int64, %34 : $Builtin.Int64) : $Builtin.Int64
+  return %36 : $Builtin.Int64
+}
+
+// CHECK-LABEL: sil @dont_optimize_stringObject_bit_operations2
+// CHECK:   builtin "stringObjectOr_Int64"
+// CHECK:   builtin "and_Int64"
+sil @dont_optimize_stringObject_bit_operations2 : $@convention(thin) () -> Builtin.Int64 {
+bb0:
+  %2 = string_literal utf8 "thequickbrownfoxjumpsoverthelazydogusingasmanycharacteraspossible123456789"
+  %5 = builtin "ptrtoint_Word"(%2 : $Builtin.RawPointer) : $Builtin.Word
+  %6 = builtin "zextOrBitCast_Word_Int64"(%5 : $Builtin.Word) : $Builtin.Int64
+  %9 = integer_literal $Builtin.Int64, 13835058055282163712
+  %10 = builtin "stringObjectOr_Int64"(%6 : $Builtin.Int64, %9 : $Builtin.Int64) : $Builtin.Int64
+  %11 = struct $UInt64 (%10 : $Builtin.Int64)
+  %12 = value_to_bridge_object %11 : $UInt64
+  %33 = unchecked_trivial_bit_cast %12 : $Builtin.BridgeObject to $UInt64
+  %34 = integer_literal $Builtin.Int64, 1152921504606846975
+  %35 = struct_extract %33 : $UInt64, #UInt64._value
+  %36 = builtin "and_Int64"(%35 : $Builtin.Int64, %34 : $Builtin.Int64) : $Builtin.Int64
+  return %36 : $Builtin.Int64
+}
+

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -360,6 +360,53 @@ bb0(%0 : $*(Builtin.Int8, Builtin.Int8)):
   return %6 : $((Builtin.Int8, Builtin.Int8), Builtin.Int8)
 }
 
+// CHECK-LABEL: sil @optimize_load_first_char_from_string_literal
+// CHECK:      bb0:
+// CHECK-NEXT:   %0 = integer_literal $Builtin.Int8, 97
+// CHECK-NEXT:   return %0
+sil @optimize_load_first_char_from_string_literal : $@convention(thin) () -> Builtin.Int8 {
+bb0:
+  %0 = string_literal utf8 "abc123a"
+  %1 = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*UInt8
+  %2 = struct_element_addr %1 : $*UInt8, #UInt8._value
+  %3 = load %2 : $*Builtin.Int8
+  return %3 : $Builtin.Int8
+}
+
+// CHECK-LABEL: sil @optimize_load_from_string_literal
+// CHECK:      bb0:
+// CHECK-NEXT:   %0 = integer_literal $Builtin.Int8, 49
+// CHECK-NEXT:   return %0
+sil @optimize_load_from_string_literal : $@convention(thin) () -> Builtin.Int8 {
+bb0:
+  %0 = string_literal utf8 "abc123a"
+  %1 = integer_literal $Builtin.Word, 3
+  %2 = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*UInt8
+  %3 = index_addr %2 : $*UInt8, %1 : $Builtin.Word
+  %4 = struct_element_addr %3 : $*UInt8, #UInt8._value
+  %5 = load %4 : $*Builtin.Int8
+  return %5 : $Builtin.Int8
+}
+
+// CHECK-LABEL: sil @optimize_nested_index_addr
+// CHECK:      bb0(%0 : $Builtin.RawPointer):
+// CHECK-NEXT:   %1 = pointer_to_address %0
+// CHECK-NEXT:   %2 = integer_literal $Builtin.Word, 10
+// CHECK-NEXT:   %3 = index_addr %1 : $*UInt8, %2
+// CHECK-NEXT:   %4 = address_to_pointer %3
+// CHECK-NEXT:   return %4
+sil @optimize_nested_index_addr : $@convention(thin) (Builtin.RawPointer) -> Builtin.RawPointer {
+bb0(%0 : $Builtin.RawPointer):
+  %1 = integer_literal $Builtin.Word, 3
+  %2 = integer_literal $Builtin.Word, 7
+  %3 = pointer_to_address %0 : $Builtin.RawPointer to [strict] $*UInt8
+  %4 = index_addr %3 : $*UInt8, %1 : $Builtin.Word
+  %5 = index_addr %4 : $*UInt8, %2 : $Builtin.Word
+  %6 = address_to_pointer %5 : $*UInt8 to $Builtin.RawPointer
+  return %6 : $Builtin.RawPointer
+}
+
+
 // CHECK-LABEL: sil @release_value_test
 // CHECK: bb0({{%[0-9]+}} : $Builtin.Int8, [[RELEASE_TARGET:%[0-9]+]] : $Builtin.NativeObject):
 // CHECK-NEXT: strong_release [[RELEASE_TARGET]] : $Builtin.NativeObject

--- a/test/SILOptimizer/static_strings.swift
+++ b/test/SILOptimizer/static_strings.swift
@@ -1,0 +1,107 @@
+// RUN: %target-swift-frontend -O -emit-ir  %s | %FileCheck %s
+// RUN: %target-swift-frontend -Osize -emit-ir  %s | %FileCheck %s
+
+// RUN: %empty-directory(%t) 
+// RUN: %target-build-swift -O -module-name=test %s -o %t/a.out
+// RUN: %target-run %t/a.out | %FileCheck %s -check-prefix=CHECK-OUTPUT
+
+// REQUIRES: executable_test,swift_stdlib_no_asserts,optimized_stdlib
+// REQUIRES: CPU=arm64 || CPU=x86_64
+
+// This is an end-to-end test to ensure that the optimizer generates
+// optimal code for static String variables.
+
+public struct S {
+  // CHECK: {{^@"}}[[SMALL:.*smallstr.*pZ]]" ={{.*}} global {{.*}} inttoptr
+  public static let smallstr = "abc123a"
+  // CHECK: {{^@"}}[[LARGE:.*largestr.*pZ]]" ={{.*}} global {{.*}} inttoptr {{.*}} add
+  public static let largestr = "abc123asd3sdj3basfasdf"
+  // CHECK: {{^@"}}[[UNICODE:.*unicodestr.*pZ]]" ={{.*}} global {{.*}} inttoptr {{.*}} add
+  public static let unicodestr = "❄️gastroperiodyni"
+}
+
+// unsafeMutableAddressor for S.smallstr
+// CHECK: define {{.*smallstr.*}}u"
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   ret {{.*}} @"[[SMALL]]"
+// CHECK-NEXT: }
+
+// getter for S.smallstr
+// CHECK: define {{.*smallstr.*}}gZ"
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   ret {{.*}}
+// CHECK-NEXT: }
+
+// unsafeMutableAddressor for S.largestr
+// CHECK: define {{.*largestr.*}}u"
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   ret {{.*}} @"[[LARGE]]"
+// CHECK-NEXT: }
+
+// getter for S.largestr
+// CHECK: define {{.*largestr.*}}gZ"
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   ret {{.*}}
+// CHECK-NEXT: }
+
+// unsafeMutableAddressor for S.unicodestr
+// CHECK: define {{.*unicodestr.*}}u"
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   ret {{.*}} @"[[UNICODE]]"
+// CHECK-NEXT: }
+
+// getter for S.unicodestr
+// CHECK: define {{.*unicodestr.*}}gZ"
+// CHECK-NEXT: entry:
+// CHECK-NEXT:   ret {{.*}}
+// CHECK-NEXT: }
+
+// CHECK-LABEL: define {{.*}}get_smallstr
+// CHECK:      entry:
+// CHECK-NEXT:   ret {{.*}}
+// CHECK-NEXT: }
+@inline(never)
+public func get_smallstr() -> String {
+  return S.smallstr
+}
+
+// CHECK-LABEL: define {{.*}}get_largestr
+// CHECK:      entry:
+// CHECK-NEXT:   ret {{.*}}
+// CHECK-NEXT: }
+@inline(never)
+public func get_largestr() -> String {
+  return S.largestr
+}
+
+// CHECK-LABEL: define {{.*}}get_unicodestr
+// CHECK:      entry:
+// CHECK-NEXT:   ret {{.*}}
+// CHECK-NEXT: }
+@inline(never)
+public func get_unicodestr() -> String {
+  return S.unicodestr
+}
+
+// Also check if the generated code is correct.
+
+// CHECK-OUTPUT: abc123a
+// CHECK-OUTPUT: abc123asd3sdj3basfasdf
+// CHECK-OUTPUT: ❄️gastroperiodyni
+print(get_smallstr())
+print(get_largestr())
+print(get_unicodestr())
+
+// Really load the globals from their addresses.
+@_optimize(none)
+func print_strings_from_addressors() {
+  print(S.smallstr)
+  print(S.largestr)
+  print(S.unicodestr)
+}
+
+// CHECK-OUTPUT: abc123a
+// CHECK-OUTPUT: abc123asd3sdj3basfasdf
+// CHECK-OUTPUT: ❄️gastroperiodyni
+print_strings_from_addressors()
+


### PR DESCRIPTION
Some optimizations to generate optimal code for static String constants.
For example:
```
struct S {
  static let str = "abc"
}
```

This reduces code size for static String constants a lot.
For details see the commit list.

rdar://problem/34715367