### PR TITLE
Make DWARF debug flag behavior match Clang.

### DIFF
--- a/include/swift/Driver/ToolChain.h
+++ b/include/swift/Driver/ToolChain.h
@@ -197,9 +197,11 @@ protected:
                                           const llvm::opt::ArgList &args,
                                           StringRef extraEntry = "") const;
 
-  /// Specific toolchains should override this to indicate whether the
-  /// compilation flags should be written into DWARF debug info.
-  virtual bool usesDWARFDebugFlags() const { return false; }
+  /// Specific toolchains should override this to provide additional conditions
+  /// under which the compiler invocation should be written into debug info. For
+  /// example, Darwin does this if the RC_DEBUG_OPTIONS environment variable is
+  /// set to match the behavior of Clang.
+  virtual bool shouldStoreInvocationInDebugInfo() const { return false; }
 
 public:
   virtual ~ToolChain() = default;

--- a/include/swift/Driver/ToolChain.h
+++ b/include/swift/Driver/ToolChain.h
@@ -197,6 +197,10 @@ protected:
                                           const llvm::opt::ArgList &args,
                                           StringRef extraEntry = "") const;
 
+  /// Specific toolchains should override this to indicate whether the
+  /// compilation flags should be written into DWARF debug info.
+  virtual bool usesDWARFDebugFlags() const { return false; }
+
 public:
   virtual ~ToolChain() = default;
 

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -486,4 +486,7 @@ def disable_verify_exclusivity : Flag<["-"], "disable-verify-exclusivity">,
 def enable_key_path_resilience : Flag<["-"], "enable-key-path-resilience">,
   HelpText<"Enable key path resilience.">;
 
+def use_dwarf_debug_flags : Flag<["-"], "use-dwarf-debug-flags">,
+  HelpText<"Write the compilation flags into the DWARF debug info.">;
+
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/include/swift/Option/FrontendOptions.td
+++ b/include/swift/Option/FrontendOptions.td
@@ -486,7 +486,4 @@ def disable_verify_exclusivity : Flag<["-"], "disable-verify-exclusivity">,
 def enable_key_path_resilience : Flag<["-"], "enable-key-path-resilience">,
   HelpText<"Enable key path resilience.">;
 
-def use_dwarf_debug_flags : Flag<["-"], "use-dwarf-debug-flags">,
-  HelpText<"Write the compilation flags into the DWARF debug info.">;
-
 } // end let Flags = [FrontendOption, NoDriverOption, HelpHidden]

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -473,6 +473,10 @@ def verify_debug_info : Flag<["-"], "verify-debug-info">,
   Flags<[NoInteractiveOption, DoesNotAffectIncrementalBuild]>,
   HelpText<"Verify the binary representation of debug output.">;
 
+def debug_info_store_invocation : Flag<["-"], "debug-info-store-invocation">,
+  Flags<[FrontendOption]>,
+  HelpText<"Emit the compiler invocation in the debug info.">;
+
 // Assert configuration identifiers.
 def AssertConfig : Separate<["-"], "assert-config">,
   Flags<[FrontendOption]>,

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -452,7 +452,7 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
   return II;
 }
 
-bool toolchains::Darwin::usesDWARFDebugFlags() const {
+bool toolchains::Darwin::shouldStoreInvocationInDebugInfo() const {
   // This matches the behavior in Clang (see
   // clang/lib/driver/ToolChains/Darwin.cpp).
   if (const char *S = ::getenv("RC_DEBUG_OPTIONS"))

--- a/lib/Driver/DarwinToolChains.cpp
+++ b/lib/Driver/DarwinToolChains.cpp
@@ -451,3 +451,11 @@ toolchains::Darwin::constructInvocation(const LinkJobAction &job,
 
   return II;
 }
+
+bool toolchains::Darwin::usesDWARFDebugFlags() const {
+  // This matches the behavior in Clang (see
+  // clang/lib/driver/ToolChains/Darwin.cpp).
+  if (const char *S = ::getenv("RC_DEBUG_OPTIONS"))
+    return S[0] != '\0';
+  return false;
+}

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -360,9 +360,9 @@ ToolChain::constructInvocation(const CompileJobAction &job,
       Arguments.push_back("-index-system-modules");
   }
 
-  // Request whether the compilation flags should be written into DWARF info.
-  if (usesDWARFDebugFlags()) {
-    Arguments.push_back("-use-dwarf-debug-flags");
+  if (context.Args.hasArg(options::OPT_debug_info_store_invocation) ||
+      shouldStoreInvocationInDebugInfo()) {
+    Arguments.push_back("-debug-info-store-invocation");
   }
 
   return II;

--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -360,6 +360,11 @@ ToolChain::constructInvocation(const CompileJobAction &job,
       Arguments.push_back("-index-system-modules");
   }
 
+  // Request whether the compilation flags should be written into DWARF info.
+  if (usesDWARFDebugFlags()) {
+    Arguments.push_back("-use-dwarf-debug-flags");
+  }
+
   return II;
 }
 

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -30,6 +30,8 @@ protected:
 
   std::string findProgramRelativeToSwiftImpl(StringRef name) const override;
 
+  bool usesDWARFDebugFlags() const override;
+
 public:
   Darwin(const Driver &D, const llvm::Triple &Triple) : ToolChain(D, Triple) {}
   ~Darwin() = default;

--- a/lib/Driver/ToolChains.h
+++ b/lib/Driver/ToolChains.h
@@ -30,7 +30,7 @@ protected:
 
   std::string findProgramRelativeToSwiftImpl(StringRef name) const override;
 
-  bool usesDWARFDebugFlags() const override;
+  bool shouldStoreInvocationInDebugInfo() const override;
 
 public:
   Darwin(const Driver &D, const llvm::Triple &Triple) : ToolChain(D, Triple) {}

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -769,7 +769,7 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
              "unknown -g<kind> option");
 
     if (Opts.DebugInfoKind > IRGenDebugInfoKind::LineTables) {
-      if (Args.hasArg(options::OPT_use_dwarf_debug_flags)) {
+      if (Args.hasArg(options::OPT_debug_info_store_invocation)) {
         ArgStringList RenderedArgs;
         for (auto A : Args)
           A->render(Args, RenderedArgs);

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -769,12 +769,14 @@ static bool ParseIRGenArgs(IRGenOptions &Opts, ArgList &Args,
              "unknown -g<kind> option");
 
     if (Opts.DebugInfoKind > IRGenDebugInfoKind::LineTables) {
-      ArgStringList RenderedArgs;
-      for (auto A : Args)
-        A->render(Args, RenderedArgs);
-      CompilerInvocation::buildDWARFDebugFlags(Opts.DWARFDebugFlags,
-                                               RenderedArgs, SDKPath,
-                                               ResourceDir);
+      if (Args.hasArg(options::OPT_use_dwarf_debug_flags)) {
+        ArgStringList RenderedArgs;
+        for (auto A : Args)
+          A->render(Args, RenderedArgs);
+        CompilerInvocation::buildDWARFDebugFlags(Opts.DWARFDebugFlags,
+                                                 RenderedArgs, SDKPath,
+                                                 ResourceDir);
+      }
       // TODO: Should we support -fdebug-compilation-dir?
       llvm::SmallString<256> cwd;
       llvm::sys::fs::current_path(cwd);

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1074,8 +1074,10 @@ static void setPrivateDiscriminatorIfNeeded(IRGenOptions &IRGenOpts,
       !MSF.is<SourceFile *>())
     return;
   Identifier PD = MSF.get<SourceFile *>()->getPrivateDiscriminator();
-  if (!PD.empty())
-    IRGenOpts.DWARFDebugFlags += (" -private-discriminator " + PD.str()).str();
+  if (!PD.empty()) {
+    if (!IRGenOpts.DWARFDebugFlags.empty()) IRGenOpts.DWARFDebugFlags += " ";
+    IRGenOpts.DWARFDebugFlags += ("-private-discriminator " + PD.str()).str();
+  }
 }
 
 static bool serializeSIB(SILModule *SM, const PrimarySpecificPaths &PSPs,

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1075,7 +1075,8 @@ static void setPrivateDiscriminatorIfNeeded(IRGenOptions &IRGenOpts,
     return;
   Identifier PD = MSF.get<SourceFile *>()->getPrivateDiscriminator();
   if (!PD.empty()) {
-    if (!IRGenOpts.DWARFDebugFlags.empty()) IRGenOpts.DWARFDebugFlags += " ";
+    if (!IRGenOpts.DWARFDebugFlags.empty())
+      IRGenOpts.DWARFDebugFlags += " ";
     IRGenOpts.DWARFDebugFlags += ("-private-discriminator " + PD.str()).str();
   }
 }

--- a/test/DebugInfo/basic.swift
+++ b/test/DebugInfo/basic.swift
@@ -64,7 +64,7 @@ func foo(_ a: Int64, _ b: Int64) -> Int64 {
 
 // CHECK-DAG: ![[FILE_CWD:[0-9]+]] = !DIFile(filename: "{{.*}}DebugInfo/basic.swift", directory: "{{.*}}")
 // CHECK-DAG: ![[MAINFILE:[0-9]+]] = !DIFile(filename: "basic.swift", directory: "{{.*}}DebugInfo")
-// CHECK-DAG: !DICompileUnit(language: DW_LANG_Swift, file: ![[FILE_CWD]],{{.*}} producer: "{{.*}}Swift version{{.*}},{{.*}} flags: "{{[^"]*}}-emit-ir
+// CHECK-DAG: !DICompileUnit(language: DW_LANG_Swift, file: ![[FILE_CWD]],{{.*}} producer: "{{.*}}Swift version{{.*}},{{.*}}
 // CHECK-DAG: !DISubprogram(name: "main", {{.*}}file: ![[MAINFILE]],
 
 // Function type for foo.

--- a/test/DebugInfo/compiler-flags-macosx.swift
+++ b/test/DebugInfo/compiler-flags-macosx.swift
@@ -1,0 +1,11 @@
+// Check that the sdk and resource dirs end up in the debug info if we build for
+// a Darwin target and set the RC_DEBUG_OPTIONS environment variable. This
+// matches the behavior found in Clang.
+// RUN: %target-swiftc_driver %s -emit-ir -g -target x86_64-apple-macosx10.10 -o - | %FileCheck %s
+// RUN: RC_DEBUG_OPTIONS=1 %target-swiftc_driver %s -emit-ir -g -target x86_64-apple-macosx10.10 -o - | %FileCheck --check-prefix CHECK-VAR-SET %s
+// CHECK:               !DICompileUnit({{.*}} producer: "{{(Apple )?Swift version [^"]+}}"
+// CHECK-NOT:                          flags: "
+// CHECK-VAR-SET:       !DICompileUnit({{.*}}producer: "{{(Apple )?Swift version [^"]+}}"
+// CHECK-VAR-SET-SAME:                 flags: "
+// CHECK-VAR-SET-NOT:                  "
+// CHECK-VAR-SET-SAME:                 -resource-dir 

--- a/test/DebugInfo/compiler-flags-macosx.swift
+++ b/test/DebugInfo/compiler-flags-macosx.swift
@@ -1,8 +1,8 @@
 // Check that the sdk and resource dirs end up in the debug info if we build for
 // a Darwin target and set the RC_DEBUG_OPTIONS environment variable. This
 // matches the behavior found in Clang.
-// RUN: %target-swiftc_driver %s -emit-ir -g -target x86_64-apple-macosx10.10 -o - | %FileCheck %s
-// RUN: RC_DEBUG_OPTIONS=1 %target-swiftc_driver %s -emit-ir -g -target x86_64-apple-macosx10.10 -o - | %FileCheck --check-prefix CHECK-VAR-SET %s
+// RUN: %swiftc_driver %s -emit-ir -g -target x86_64-apple-macosx10.10 -o - | %FileCheck %s
+// RUN: RC_DEBUG_OPTIONS=1 %swiftc_driver %s -emit-ir -g -target x86_64-apple-macosx10.10 -o - | %FileCheck --check-prefix CHECK-VAR-SET %s
 // CHECK:               !DICompileUnit({{.*}} producer: "{{(Apple )?Swift version [^"]+}}"
 // CHECK-NOT:                          flags: "
 // CHECK-VAR-SET:       !DICompileUnit({{.*}}producer: "{{(Apple )?Swift version [^"]+}}"

--- a/test/DebugInfo/compiler-flags-macosx.swift
+++ b/test/DebugInfo/compiler-flags-macosx.swift
@@ -1,8 +1,8 @@
 // Check that the sdk and resource dirs end up in the debug info if we build for
 // a Darwin target and set the RC_DEBUG_OPTIONS environment variable. This
 // matches the behavior found in Clang.
-// RUN: %swiftc_driver %s -emit-ir -g -target x86_64-apple-macosx10.10 -o - | %FileCheck %s
-// RUN: RC_DEBUG_OPTIONS=1 %swiftc_driver %s -emit-ir -g -target x86_64-apple-macosx10.10 -o - | %FileCheck --check-prefix CHECK-VAR-SET %s
+// RUN: %swiftc_driver %s -emit-ir -g -target x86_64-apple-macosx10.10 -parse-stdlib -module-name scratch -o - | %FileCheck %s
+// RUN: RC_DEBUG_OPTIONS=1 %swiftc_driver %s -emit-ir -g -target x86_64-apple-macosx10.10 -parse-stdlib -module-name scratch -o - | %FileCheck --check-prefix CHECK-VAR-SET %s
 // CHECK:               !DICompileUnit({{.*}} producer: "{{(Apple )?Swift version [^"]+}}"
 // CHECK-NOT:                          flags: "
 // CHECK-VAR-SET:       !DICompileUnit({{.*}}producer: "{{(Apple )?Swift version [^"]+}}"

--- a/test/DebugInfo/compiler-flags.swift
+++ b/test/DebugInfo/compiler-flags.swift
@@ -1,8 +1,8 @@
 // Check that the sdk and resource dirs end up in the debug info if we pass the
 // frontend flag. This tests the general functionality; we test the macosx
 // specific toolchain logic in compiler-flags-macosx.swift.
-// RUN: %target-swiftc_driver %s -emit-ir -Xfrontend -use-dwarf-debug-flags -g -o - | %FileCheck %s
-// RUN: %target-swiftc_driver %s -emit-ir -Xfrontend -use-dwarf-debug-flags -sdk "/Weird Location/SDK" -g -o - | %FileCheck --check-prefix CHECK-EXPLICIT %s
+// RUN: %target-swiftc_driver %s -emit-ir -debug-info-store-invocation -g -o - | %FileCheck %s
+// RUN: %target-swiftc_driver %s -emit-ir -debug-info-store-invocation -sdk "/Weird Location/SDK" -g -o - | %FileCheck --check-prefix CHECK-EXPLICIT %s
 // CHECK:          !DICompileUnit({{.*}}producer: "{{(Apple )?Swift version [^"]+}}"
 // CHECK-SAME:                    flags: "
 // CHECK-NOT:                     "
@@ -15,6 +15,6 @@
 // CHECK-EXPLICIT-SAME:           -resource-dir 
 
 // Check that we don't write temporary file names in the debug info
-// RUN: TMPDIR=abc/def %target-swift-frontend %s -I abc/def/xyz -g -emit-ir -use-dwarf-debug-flags -o - | %FileCheck --check-prefix CHECK-TEMP %s
+// RUN: TMPDIR=abc/def %target-swift-frontend %s -I abc/def/xyz -g -emit-ir -debug-info-store-invocation -o - | %FileCheck --check-prefix CHECK-TEMP %s
 // CHECK-TEMP: !DICompileUnit({{.*}} flags: "{{.*}} -I <temporary-file>
 

--- a/test/DebugInfo/compiler-flags.swift
+++ b/test/DebugInfo/compiler-flags.swift
@@ -1,6 +1,8 @@
-// Check that the sdk and resource dirs end up in the debug info.
-// RUN: %target-swiftc_driver %s -emit-ir -g -o - | %FileCheck %s
-// RUN: %target-swiftc_driver %s -emit-ir -sdk "/Weird Location/SDK" -g -o - | %FileCheck --check-prefix CHECK-EXPLICIT %s
+// Check that the sdk and resource dirs end up in the debug info if we pass the
+// frontend flag. This tests the general functionality; we test the macosx
+// specific toolchain logic in compiler-flags-macosx.swift.
+// RUN: %target-swiftc_driver %s -emit-ir -Xfrontend -use-dwarf-debug-flags -g -o - | %FileCheck %s
+// RUN: %target-swiftc_driver %s -emit-ir -Xfrontend -use-dwarf-debug-flags -sdk "/Weird Location/SDK" -g -o - | %FileCheck --check-prefix CHECK-EXPLICIT %s
 // CHECK:          !DICompileUnit({{.*}}producer: "{{(Apple )?Swift version [^"]+}}"
 // CHECK-SAME:                    flags: "
 // CHECK-NOT:                     "
@@ -13,6 +15,6 @@
 // CHECK-EXPLICIT-SAME:           -resource-dir 
 
 // Check that we don't write temporary file names in the debug info
-// RUN: TMPDIR=abc/def %target-swift-frontend %s -I abc/def/xyz -g -emit-ir -o - | %FileCheck --check-prefix CHECK-TEMP %s
+// RUN: TMPDIR=abc/def %target-swift-frontend %s -I abc/def/xyz -g -emit-ir -use-dwarf-debug-flags -o - | %FileCheck --check-prefix CHECK-TEMP %s
 // CHECK-TEMP: !DICompileUnit({{.*}} flags: "{{.*}} -I <temporary-file>
 


### PR DESCRIPTION
Only write the compilation flags to debug info for Mach-O targets, and only
if the RC_DEBUG_OPTIONS environment variable is set.

This change improves hermeticity/reproducibility of Swift binaries/dSYMs by not encoding command line flags that might contain file system paths, since LLDB no longer needs them (except for `-private-discriminator`, which I've left in; it's invariant because it's computed only from the basename anyway).

@adrian-prantl 