### PR TITLE
Minor @inlinable improvements

### DIFF
--- a/docs/HighLevelSILOptimizations.rst
+++ b/docs/HighLevelSILOptimizations.rst
@@ -117,13 +117,13 @@ Cloning code from the standard library
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Swift compiler can copy code from the standard library into the
-application for functions marked @_inlineable. This allows the optimizer to
+application for functions marked @inlinable. This allows the optimizer to
 inline calls from the stdlib and improve the performance of code that uses
 common operators such as '+=' or basic containers such as Array. However,
 importing code from the standard library can increase the binary size.
 
 To prevent copying of functions from the standard library into the user
-program, make sure the function in question is not marked @_inlineable.
+program, make sure the function in question is not marked @inlinable.
 
 Array
 ~~~~~

--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -880,8 +880,8 @@ public:
   /// This is usually the check you want; for example, when introducing
   /// a new language feature which is only visible in Swift 5, you would
   /// check for isSwiftVersionAtLeast(5).
-  bool isSwiftVersionAtLeast(unsigned major) const {
-    return LangOpts.isSwiftVersionAtLeast(major);
+  bool isSwiftVersionAtLeast(unsigned major, unsigned minor = 0) const {
+    return LangOpts.isSwiftVersionAtLeast(major, minor);
   }
 
 private:

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -320,7 +320,7 @@ DECL_ATTR(_cdecl, CDecl,
   LongAttribute | UserInaccessible,
   63)
 SIMPLE_DECL_ATTR(usableFromInline, UsableFromInline,
-  OnAbstractFunction | OnVar | OnSubscript | OnNominalType |
+  OnAbstractFunction | OnVar | OnSubscript | OnNominalType | OnTypeAlias |
   LongAttribute,
   64)
 SIMPLE_DECL_ATTR(discardableResult, DiscardableResult,

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -342,8 +342,8 @@ namespace swift {
     /// This is usually the check you want; for example, when introducing
     /// a new language feature which is only visible in Swift 5, you would
     /// check for isSwiftVersionAtLeast(5).
-    bool isSwiftVersionAtLeast(unsigned major) const {
-      return EffectiveLanguageVersion.isVersionAtLeast(major);
+    bool isSwiftVersionAtLeast(unsigned major, unsigned minor = 0) const {
+      return EffectiveLanguageVersion.isVersionAtLeast(major, minor);
     }
 
     /// Returns true if the given platform condition argument represents

--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -112,8 +112,17 @@ public:
 
   /// Whether this version is greater than or equal to the given major version
   /// number.
-  bool isVersionAtLeast(unsigned major) const {
-    return !empty() && Components[0] >= major;
+  bool isVersionAtLeast(unsigned major, unsigned minor = 0) const {
+    switch (size()) {
+    case 0:
+      return false;
+    case 1:
+      return ((Components[0] == major && 0 == minor) ||
+              (Components[0] > major));
+    default:
+      return ((Components[0] == major && Components[1] >= minor) ||
+              (Components[0] > major));
+    }
   }
 
   /// Return this Version struct with minor and sub-minor components stripped

--- a/stdlib/public/SwiftShims/Visibility.h
+++ b/stdlib/public/SwiftShims/Visibility.h
@@ -118,7 +118,7 @@
 /// Note that @_silgen_name implementations must also be marked SWIFT_CC(swift).
 ///
 /// SWIFT_RUNTIME_STDLIB_API functions are called by compiler-generated code
-/// or by @_inlineable Swift code.
+/// or by @inlinable Swift code.
 /// Such functions must be exported and must be supported forever as API.
 /// The function name should be prefixed with `swift_`.
 ///
@@ -130,7 +130,7 @@
 /// SWIFT_RUNTIME_STDLIB_INTERNAL functions are called only by the stdlib.
 /// Such functions are internal and are not exported.
 /// FIXME(sil-serialize-all): _INTERNAL functions are also exported for now
-/// until the tide of @_inlineable is rolled back.
+/// until the tide of @inlinable is rolled back.
 /// They really should be LLVM_LIBRARY_VISIBILITY, not SWIFT_RUNTIME_EXPORT.
 #define SWIFT_RUNTIME_STDLIB_API       SWIFT_RUNTIME_EXPORT
 #define SWIFT_RUNTIME_STDLIB_SPI       SWIFT_RUNTIME_EXPORT

--- a/stdlib/public/core/BridgeObjectiveC.swift
+++ b/stdlib/public/core/BridgeObjectiveC.swift
@@ -649,7 +649,7 @@ public func _getObjCTypeEncoding<T>(_ type: T.Type) -> UnsafePointer<Int8> {
 /// Convert `x` from its Objective-C representation to its Swift
 /// representation.
 /// COMPILER_INTRINSIC
-@_inlineable // FIXME(sil-serialize-all)
+@inlinable // FIXME(sil-serialize-all)
 public func _forceBridgeFromObjectiveC_bridgeable<T:_ObjectiveCBridgeable> (
   _ x: T._ObjectiveCType,
   _: T.Type
@@ -662,7 +662,7 @@ public func _forceBridgeFromObjectiveC_bridgeable<T:_ObjectiveCBridgeable> (
 /// Attempt to convert `x` from its Objective-C representation to its Swift
 /// representation.
 /// COMPILER_INTRINSIC
-@_inlineable // FIXME(sil-serialize-all)
+@inlinable // FIXME(sil-serialize-all)
 public func _conditionallyBridgeFromObjectiveC_bridgeable<T:_ObjectiveCBridgeable>(
   _ x: T._ObjectiveCType,
   _: T.Type

--- a/test/ClangImporter/Inputs/ImportAsMemberSwiftVersioned_a.swift
+++ b/test/ClangImporter/Inputs/ImportAsMemberSwiftVersioned_a.swift
@@ -1,6 +1,6 @@
 import Foundation
 import ImportAsMember.Class
 
-@_versioned
+@usableFromInline
 internal func foo(_ x: IncompleteImportTargetName) -> Any { return x }
 

--- a/test/Compatibility/attr_inlinable_old_spelling_4.swift
+++ b/test/Compatibility/attr_inlinable_old_spelling_4.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift -swift-version 3
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+// In -swift-version 4 mode, the old spelling is silently parsed as the new spelling.
+
+@_inlineable public func oldInlinableFunction() {}
+@_versioned func oldVersionedFunction() {}

--- a/test/Compatibility/attr_inlinable_old_spelling_42.swift
+++ b/test/Compatibility/attr_inlinable_old_spelling_42.swift
@@ -1,8 +1,6 @@
-// RUN: %target-typecheck-verify-swift -swift-version 3
-// RUN: %target-typecheck-verify-swift -swift-version 4
 // RUN: %target-typecheck-verify-swift -swift-version 4.2
 
-// Until -swift-version 5 mode, the old spelling only produces a warning.
+// In -swift-version 4.2 mode, the old spelling produces a warning.
 
 @_inlineable public func oldInlinableFunction() {}
 // expected-warning@-1 {{'@_inlineable' has been renamed to '@inlinable'}}{{2-13=inlinable}}

--- a/test/attr/attr_inlinable_typealias.swift
+++ b/test/attr/attr_inlinable_typealias.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift
+
+// None of this is enforced for now, but make sure we don't crash or
+// do anything stupid when a typealias is annotated with @usableFromInline.
+
+private typealias PrivateAlias = Int
+
+internal typealias InternalAlias = Int
+
+@usableFromInline typealias UsableFromInlineAlias = Int
+
+public typealias PublicAlias = Int
+
+@inlinable public func f() {
+  _ = PrivateAlias.self
+
+  _ = InternalAlias.self
+
+  _ = UsableFromInlineAlias.self
+
+  _ = PublicAlias.self
+}


### PR DESCRIPTION
- Allow `@usableFromInline` on typealias declarations, but don't enforce it yet. Enforcement is coming in https://github.com/apple/swift/pull/16586
- Don't produce a warning for the old spelling of `@_inlineable` and `@_versioned` except in -swift-version 4.2 mode (in -swift-version 5 it is still an error). This was an ask from the SwiftNIO team who want to build without warnings on both 4.1 and 4.2 for the time being.