### PR TITLE
Minor @inlinable improvements [4.2]

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -894,8 +894,8 @@ public:
   /// This is usually the check you want; for example, when introducing
   /// a new language feature which is only visible in Swift 5, you would
   /// check for isSwiftVersionAtLeast(5).
-  bool isSwiftVersionAtLeast(unsigned major) const {
-    return LangOpts.isSwiftVersionAtLeast(major);
+  bool isSwiftVersionAtLeast(unsigned major, unsigned minor = 0) const {
+    return LangOpts.isSwiftVersionAtLeast(major, minor);
   }
 
 private:

--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -295,7 +295,7 @@ DECL_ATTR(_cdecl, CDecl,
 
 SIMPLE_DECL_ATTR(usableFromInline, UsableFromInline,
                  OnFunc | OnVar | OnSubscript | OnConstructor |
-                 OnDestructor | OnStruct | OnEnum | OnClass |
+                 OnDestructor | OnStruct | OnEnum | OnClass | OnTypeAlias |
                  OnProtocol | LongAttribute | UserInaccessible,
                  64)
 

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -340,8 +340,8 @@ namespace swift {
     /// This is usually the check you want; for example, when introducing
     /// a new language feature which is only visible in Swift 5, you would
     /// check for isSwiftVersionAtLeast(5).
-    bool isSwiftVersionAtLeast(unsigned major) const {
-      return EffectiveLanguageVersion.isVersionAtLeast(major);
+    bool isSwiftVersionAtLeast(unsigned major, unsigned minor = 0) const {
+      return EffectiveLanguageVersion.isVersionAtLeast(major, minor);
     }
 
     /// Returns true if the given platform condition argument represents

--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -112,8 +112,17 @@ public:
 
   /// Whether this version is greater than or equal to the given major version
   /// number.
-  bool isVersionAtLeast(unsigned major) const {
-    return !empty() && Components[0] >= major;
+  bool isVersionAtLeast(unsigned major, unsigned minor = 0) const {
+    switch (size()) {
+    case 0:
+      return false;
+    case 1:
+      return ((Components[0] == major && 0 == minor) ||
+              (Components[0] > major));
+    default:
+      return ((Components[0] == major && Components[1] >= minor) ||
+              (Components[0] > major));
+    }
   }
 
   /// Return this Version struct with minor and sub-minor components stripped

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1466,15 +1466,17 @@ bool Parser::parseDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc) {
   // over to the alternate parsing path.
   DeclAttrKind DK = DeclAttribute::getAttrKindFromString(Tok.getText());
   
-  auto checkInvalidAttrName = [&](StringRef invalidName, StringRef correctName,
-                              DeclAttrKind kind, Diag<StringRef, StringRef> diag) {
+  auto checkInvalidAttrName = [&](StringRef invalidName,
+                                  StringRef correctName,
+                                  DeclAttrKind kind,
+                                  Optional<Diag<StringRef, StringRef>> diag = None) {
     if (DK == DAK_Count && Tok.getText() == invalidName) {
-      // We renamed @availability to @available, so if we see the former,
-      // treat it as the latter and emit a Fix-It.
       DK = kind;
-      
-      diagnose(Tok, diag, invalidName, correctName)
+
+      if (diag) {
+        diagnose(Tok, *diag, invalidName, correctName)
             .fixItReplace(Tok.getLoc(), correctName);
+      }
     }
   };
 
@@ -1485,14 +1487,17 @@ bool Parser::parseDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc) {
   // Check if attr is inlineable, and suggest inlinable instead
   checkInvalidAttrName("inlineable", "inlinable", DAK_Inlinable, diag::attr_name_close_match);
 
-  // In Swift 5 and above, these become hard errors. Otherwise, emit a
-  // warning for compatibility.
-  if (!Context.isSwiftVersionAtLeast(5)) {
+  // In Swift 5 and above, these become hard errors. In Swift 4.2, emit a
+  // warning for compatibility. Otherwise, don't diagnose at all.
+  if (Context.isSwiftVersionAtLeast(5)) {
+    checkInvalidAttrName("_versioned", "usableFromInline", DAK_UsableFromInline, diag::attr_renamed);
+    checkInvalidAttrName("_inlineable", "inlinable", DAK_Inlinable, diag::attr_renamed);
+  } else if (Context.isSwiftVersionAtLeast(4, 2)) {
     checkInvalidAttrName("_versioned", "usableFromInline", DAK_UsableFromInline, diag::attr_renamed_warning);
     checkInvalidAttrName("_inlineable", "inlinable", DAK_Inlinable, diag::attr_renamed_warning);
   } else {
-    checkInvalidAttrName("_versioned", "usableFromInline", DAK_UsableFromInline, diag::attr_renamed);
-    checkInvalidAttrName("_inlineable", "inlinable", DAK_Inlinable, diag::attr_renamed);
+    checkInvalidAttrName("_versioned", "usableFromInline", DAK_UsableFromInline);
+    checkInvalidAttrName("_inlineable", "inlinable", DAK_Inlinable);
   }
 
   if (DK == DAK_Count && Tok.getText() == "warn_unused_result") {

--- a/test/Compatibility/attr_inlinable_old_spelling_4.swift
+++ b/test/Compatibility/attr_inlinable_old_spelling_4.swift
@@ -1,0 +1,7 @@
+// RUN: %target-typecheck-verify-swift -swift-version 3
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+// In -swift-version 4 mode, the old spelling is silently parsed as the new spelling.
+
+@_inlineable public func oldInlinableFunction() {}
+@_versioned func oldVersionedFunction() {}

--- a/test/Compatibility/attr_inlinable_old_spelling_42.swift
+++ b/test/Compatibility/attr_inlinable_old_spelling_42.swift
@@ -1,8 +1,6 @@
-// RUN: %target-typecheck-verify-swift -swift-version 3
-// RUN: %target-typecheck-verify-swift -swift-version 4
 // RUN: %target-typecheck-verify-swift -swift-version 4.2
 
-// Until -swift-version 5 mode, the old spelling only produces a warning.
+// In -swift-version 4.2 mode, the old spelling produces a warning.
 
 @_inlineable public func oldInlinableFunction() {}
 // expected-warning@-1 {{'@_inlineable' has been renamed to '@inlinable'}}{{2-13=inlinable}}

--- a/test/attr/attr_inlinable_typealias.swift
+++ b/test/attr/attr_inlinable_typealias.swift
@@ -1,0 +1,22 @@
+// RUN: %target-typecheck-verify-swift
+
+// None of this is enforced for now, but make sure we don't crash or
+// do anything stupid when a typealias is annotated with @usableFromInline.
+
+private typealias PrivateAlias = Int
+
+internal typealias InternalAlias = Int
+
+@usableFromInline typealias UsableFromInlineAlias = Int
+
+public typealias PublicAlias = Int
+
+@inlinable public func f() {
+  _ = PrivateAlias.self
+
+  _ = InternalAlias.self
+
+  _ = UsableFromInlineAlias.self
+
+  _ = PublicAlias.self
+}


### PR DESCRIPTION
- Allow `@usableFromInline` on typealias declarations, but don't enforce it yet. Enforcement is coming in https://github.com/apple/swift/pull/16586
- Don't produce a warning for the old spelling of `@_inlineable` and `@_versioned` except in -swift-version 4.2 mode (in -swift-version 5 it is still an error). This was an ask from the SwiftNIO team who want to build without warnings on both 4.1 and 4.2 for the time being.