### PR TITLE
[Sema] Diagnostic: improve diagnostics for ApplyExpr.

### DIFF
--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -5672,7 +5672,8 @@ static bool isViableOverloadSet(const CalleeCandidateInfo &CCI,
   for (unsigned i = 0; i < CCI.size(); ++i) {
     auto &&cand = CCI[i];
     auto funcDecl = dyn_cast_or_null<AbstractFunctionDecl>(cand.getDecl());
-    if (!funcDecl) continue;
+    if (!funcDecl)
+      continue;
 
     auto params = cand.getParameters();
     bool hasVariadicParameter = false;
@@ -5684,7 +5685,8 @@ static bool isViableOverloadSet(const CalleeCandidateInfo &CCI,
     auto defaultMap = computeDefaultMap(params, funcDecl, cand.level);
     InputMatcher IM(params, defaultMap);
     auto result = IM.match(numArgs, pairMatcher);
-    if (result == InputMatcher::IM_Succeeded) return true;
+    if (result == InputMatcher::IM_Succeeded)
+      return true;
     if (result == InputMatcher::IM_HasUnclaimedInput && hasVariadicParameter)
       return true;
   }

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -606,8 +606,6 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
         auto funcTy2 = openedType2->castTo<FunctionType>();
         auto params1 = funcTy1->getParams();
         auto params2 = funcTy2->getParams();
-        llvm::SmallBitVector defaultMapType2 =
-          computeDefaultMap(params2, decl2, outerDC2->isTypeContext());
 
         unsigned numParams1 = params1.size();
         unsigned numParams2 = params2.size();
@@ -620,8 +618,6 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
               params1.back().getType()->is<AnyFunctionType>() &&
               params2.back().getType()->is<AnyFunctionType>()) {
             compareTrailingClosureParamsSeparately = true;
-            --numParams1;
-            --numParams2;
           }
         }
 
@@ -646,55 +642,31 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
           return true;
         };
 
-        for (unsigned param1 = 0, param2 = 0; param2 != numParams2; ++param2) {
-          // If there is a default for parameter in the second function
-          // while there are still some parameters left unclaimed in first,
-          // it could only mean that default parameters are intermixed e.g.
-          //
-          // ```swift
-          // func foo(a: Int) {}
-          // func foo(q: String = "", a: Int) {}
-          // ```
-          // or
-          // ```swift
-          // func foo(a: Int, c: Int) {}
-          // func foo(a: Int, b: Int = 0, c: Int) {}
-          // ```
-          // and we shouldn't claim parameter from the first function.
-          if (param1 < numParams1 && numParams1 != numParams2 &&
-              defaultMapType2[param2]) {
-            fewerEffectiveParameters = true;
-            continue;
-          }
-
-          // If we've claimed all of the parameters from first
-          // function, the rest of the parameters in second should
-          // be either default or variadic.
-          if (param1 >= numParams1) {
-            if (!defaultMapType2[param2] && !params2[param2].isVariadic())
-              return false;
-
-            fewerEffectiveParameters = true;
-            continue;
-          }
-
+        auto pairMatcher = [&](unsigned idx1, unsigned idx2) -> bool {
           // Emulate behavior from when IUO was a type, where IUOs
           // were considered subtypes of plain optionals, but not
           // vice-versa.  This wouldn't normally happen, but there are
           // cases where we can rename imported APIs so that we have a
           // name collision, and where the parameter type(s) are the
           // same except for details of the kind of optional declared.
-          auto param1IsIUO = paramIsIUO(decl1, param1);
-          auto param2IsIUO = paramIsIUO(decl2, param2);
+          auto param1IsIUO = paramIsIUO(decl1, idx1);
+          auto param2IsIUO = paramIsIUO(decl2, idx2);
           if (param2IsIUO && !param1IsIUO)
             return false;
 
-          if (!maybeAddSubtypeConstraint(params1[param1], params2[param2]))
+          if (!maybeAddSubtypeConstraint(params1[idx1], params2[idx2]))
             return false;
 
-          // claim the parameter as used.
-          ++param1;
-        }
+          return true;
+        };
+
+        InputMatcher IM(decl2, params2);
+        if (IM.solve(numParams1,
+                compareTrailingClosureParamsSeparately,
+                pairMatcher) != InputMatcher::IM_Succeeded)
+          return false;
+
+        fewerEffectiveParameters |= (IM.getNumSkippedParameters() != 0);
 
         if (compareTrailingClosureParamsSeparately)
           if (!maybeAddSubtypeConstraint(params1.back(), params2.back()))
@@ -1384,4 +1356,62 @@ SolutionDiff::SolutionDiff(ArrayRef<Solution> solutions) {
       break;
     }
   }
+}
+
+InputMatcher::InputMatcher(const ValueDecl *funcDecl,
+    const ArrayRef<AnyFunctionType::Param> params) :
+    NumSkippedParameters(0), Params(params) {
+  DefaultValueMap = computeDefaultMap(params, funcDecl,
+      funcDecl->getDeclContext()->isTypeContext());
+}
+
+InputMatcher::Result InputMatcher::solve(int numInputs,
+    bool ignoreLastPair,
+    std::function<bool(unsigned, unsigned)> pairMatcher) {
+
+  int inputIdx = 0;
+  int numParams = Params.size();
+
+  if (ignoreLastPair) {
+    --numInputs;
+    --numParams;
+  }
+
+  for (int i = 0; i < numParams; ++i) {
+    // If we've claimed all of the inputs, he rest of the parameters should
+    // be either default or variadic.
+    if (inputIdx == numInputs) {
+      if (!DefaultValueMap[i] && !Params[i].isVariadic())
+        return IM_HasUnmatchedParam;
+      ++NumSkippedParameters;
+      continue;
+    }
+
+    // If there is a default for parameter, while there are still some
+    // input left unclaimed, it could only mean that default parameters
+    // are intermixed e.g.
+    //
+    // inputs: (a: Int)
+    // params: (q: String = "", a: Int)
+    //
+    // or
+    // inputs: (a: Int, c: Int)
+    // params: (a: Int, b: Int = 0, c: Int)
+    //
+    // and we shouldn't claim parameter from the inputs.
+    if ((numInputs - inputIdx) < (numParams - i) && DefaultValueMap[i]) {
+      ++NumSkippedParameters;
+      continue;
+    }
+
+    // Call customized function to match the input-parameter pair.
+    if (!pairMatcher(inputIdx, i)) return IM_CustomPairMatcherFailed;
+
+    // claim the input as used.
+    ++inputIdx;
+  }
+
+  if (inputIdx < numInputs) return IM_HasUnclaimedInput;
+
+  return IM_Succeeded;
 }

--- a/lib/Sema/CSRanking.cpp
+++ b/lib/Sema/CSRanking.cpp
@@ -660,8 +660,8 @@ static bool isDeclAsSpecializedAs(TypeChecker &tc, DeclContext *dc,
           return true;
         };
 
-        auto defaultMap = computeDefaultMap(params2, decl2,
-            decl2->getDeclContext()->isTypeContext());
+        auto defaultMap = computeDefaultMap(
+            params2, decl2, decl2->getDeclContext()->isTypeContext());
         auto params2ForMatching = params2;
         if (compareTrailingClosureParamsSeparately) {
           --numParams1;
@@ -1365,12 +1365,13 @@ SolutionDiff::SolutionDiff(ArrayRef<Solution> solutions) {
 }
 
 InputMatcher::InputMatcher(const ArrayRef<AnyFunctionType::Param> params,
-    const llvm::SmallBitVector &defaultValueMap) :
-    NumSkippedParameters(0), DefaultValueMap(defaultValueMap), Params(params) {
-}
+                           const llvm::SmallBitVector &defaultValueMap)
+    : NumSkippedParameters(0), DefaultValueMap(defaultValueMap),
+      Params(params) {}
 
-InputMatcher::Result InputMatcher::match(int numInputs,
-    std::function<bool(unsigned, unsigned)> pairMatcher) {
+InputMatcher::Result
+InputMatcher::match(int numInputs,
+                    std::function<bool(unsigned, unsigned)> pairMatcher) {
 
   int inputIdx = 0;
   int numParams = Params.size();
@@ -1402,13 +1403,15 @@ InputMatcher::Result InputMatcher::match(int numInputs,
     }
 
     // Call custom function to match the input-parameter pair.
-    if (!pairMatcher(inputIdx, i)) return IM_CustomPairMatcherFailed;
+    if (!pairMatcher(inputIdx, i))
+      return IM_CustomPairMatcherFailed;
 
     // claim the input as used.
     ++inputIdx;
   }
 
-  if (inputIdx < numInputs) return IM_HasUnclaimedInput;
+  if (inputIdx < numInputs)
+    return IM_HasUnclaimedInput;
 
   return IM_Succeeded;
 }

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -880,7 +880,6 @@ CalleeCandidateInfo::CalleeCandidateInfo(Type baseType,
     declName = candidates[0].getDecl()->getBaseName().userFacingName();
 }
 
-
 CalleeCandidateInfo &CalleeCandidateInfo::
 operator=(const CalleeCandidateInfo &CCI) {
   if (this != &CCI) {

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -884,7 +884,7 @@ CalleeCandidateInfo::CalleeCandidateInfo(Type baseType,
 CalleeCandidateInfo &CalleeCandidateInfo::
 operator=(const CalleeCandidateInfo &CCI) {
   if (this != &CCI) {
-    // If the reference member (i.e., CS) is identical, just copy the rest
+    // If the reference member (i.e., CS) is identical, just copy remaining
     // members; otherwise, reconstruct the object.
     if (&CS == &CCI.CS) {
       declName = CCI.declName;

--- a/lib/Sema/CalleeCandidateInfo.cpp
+++ b/lib/Sema/CalleeCandidateInfo.cpp
@@ -880,6 +880,26 @@ CalleeCandidateInfo::CalleeCandidateInfo(Type baseType,
     declName = candidates[0].getDecl()->getBaseName().userFacingName();
 }
 
+
+CalleeCandidateInfo &CalleeCandidateInfo::
+operator=(const CalleeCandidateInfo &CCI) {
+  if (this != &CCI) {
+    // If the reference member (i.e., CS) is identical, just copy the rest
+    // members; otherwise, reconstruct the object.
+    if (&CS == &CCI.CS) {
+      declName = CCI.declName;
+      hasTrailingClosure = CCI.hasTrailingClosure;
+      candidates = CCI.candidates;
+      closeness = CCI.closeness;
+      failedArgument = CCI.failedArgument;
+    } else {
+      this->~CalleeCandidateInfo();
+      new (this) CalleeCandidateInfo(CCI);
+    }
+  }
+  return *this;
+}
+
 /// Given a set of parameter lists from an overload group, and a list of
 /// arguments, emit a diagnostic indicating any partially matching overloads.
 void CalleeCandidateInfo::

--- a/lib/Sema/CalleeCandidateInfo.h
+++ b/lib/Sema/CalleeCandidateInfo.h
@@ -188,6 +188,12 @@ namespace swift {
                         bool hasTrailingClosure, ConstraintSystem &CS,
                         bool selfAlreadyApplied = true);
 
+    ~CalleeCandidateInfo() = default;
+    CalleeCandidateInfo(const CalleeCandidateInfo &CCI) = default;
+    CalleeCandidateInfo &operator=(const CalleeCandidateInfo &CCI);
+    CalleeCandidateInfo(CalleeCandidateInfo &&CCI) = delete;
+    CalleeCandidateInfo &operator=(CalleeCandidateInfo &&CCI) = delete;
+
     using ClosenessResultTy = std::pair<CandidateCloseness, FailedArgumentInfo>;
     using ClosenessPredicate =
         const std::function<ClosenessResultTy(UncurriedCandidate)> &;

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3486,6 +3486,52 @@ public:
     return { true, expr };
   }
 };
+
+
+/// \brief Matching an array of input to an array of parameter.
+///
+/// Input can be anything suitable (e.g., parameter, argument).
+/// It claims inputs sequentially and tries to pair between an input
+/// and the next appropriate parameter. The detailed matching behavior
+/// of each pair is specified by a custom function (i.e., pairMatcher).
+/// It considers variadic and defaulted arguments when forming proper
+/// input-parameter pairs; however, other information like label and
+/// type information is not directly used here. It can be implemented
+/// in the custom function when necessary.
+class InputMatcher {
+  size_t NumSkippedParameters;
+  llvm::SmallBitVector DefaultValueMap;
+  ArrayRef<AnyFunctionType::Param> Params;
+
+public:
+  enum Result {
+    /// The specified inputs are successfully matched.
+    IM_Succeeded,
+    /// There are input(s) left unclaimed while all parameters are matched.
+    IM_HasUnclaimedInput,
+    /// There are parateter(s) left unmatched while all inputs are claimed.
+    IM_HasUnmatchedParam,
+    /// Custom pair matcher function failure.
+    IM_CustomPairMatcherFailed,
+  };
+
+  InputMatcher(const ValueDecl *funcDecl,
+      const ArrayRef<AnyFunctionType::Param> params);
+
+  /// Matching a given array of inputs.
+  ///
+  /// \param numInputs The number of inputs.
+  /// \param ignoreLastPair Skip the last parameter and input. This may happen,
+  ///        for example, when we want to match trailing closures separately.
+  /// \param pairMatcher Custom matching behavior of an input-parameter pair.
+  /// \return the matching result.
+  Result solve(int numInputs, bool ignoreLastPair,
+      std::function<bool(unsigned inputIdx, unsigned paramIdx)> pairMatcher);
+
+  size_t getNumSkippedParameters() const {
+    return NumSkippedParameters;
+  }
+};
 } // end namespace swift
 
 #endif // LLVM_SWIFT_SEMA_CONSTRAINT_SYSTEM_H

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3487,7 +3487,6 @@ public:
   }
 };
 
-
 /// \brief Matches array of function parameters to candidate inputs,
 /// which can be anything suitable (e.g., parameters, arguments).
 ///
@@ -3516,19 +3515,18 @@ public:
   };
 
   InputMatcher(const ArrayRef<AnyFunctionType::Param> params,
-      const llvm::SmallBitVector &defaultValueMap);
+               const llvm::SmallBitVector &defaultValueMap);
 
   /// Matching a given array of inputs.
   ///
   /// \param numInputs The number of inputs.
   /// \param pairMatcher Custom matching behavior of an input-parameter pair.
   /// \return the matching result.
-  Result match(int numInputs,
-      std::function<bool(unsigned inputIdx, unsigned paramIdx)> pairMatcher);
+  Result
+  match(int numInputs,
+        std::function<bool(unsigned inputIdx, unsigned paramIdx)> pairMatcher);
 
-  size_t getNumSkippedParameters() const {
-    return NumSkippedParameters;
-  }
+  size_t getNumSkippedParameters() const { return NumSkippedParameters; }
 };
 } // end namespace swift
 

--- a/lib/Sema/ConstraintSystem.h
+++ b/lib/Sema/ConstraintSystem.h
@@ -3488,9 +3488,9 @@ public:
 };
 
 
-/// \brief Matching an array of input to an array of parameter.
+/// \brief Matches array of function parameters to candidate inputs,
+/// which can be anything suitable (e.g., parameters, arguments).
 ///
-/// Input can be anything suitable (e.g., parameter, argument).
 /// It claims inputs sequentially and tries to pair between an input
 /// and the next appropriate parameter. The detailed matching behavior
 /// of each pair is specified by a custom function (i.e., pairMatcher).
@@ -3500,8 +3500,8 @@ public:
 /// in the custom function when necessary.
 class InputMatcher {
   size_t NumSkippedParameters;
-  llvm::SmallBitVector DefaultValueMap;
-  ArrayRef<AnyFunctionType::Param> Params;
+  const llvm::SmallBitVector DefaultValueMap;
+  const ArrayRef<AnyFunctionType::Param> Params;
 
 public:
   enum Result {
@@ -3515,17 +3515,15 @@ public:
     IM_CustomPairMatcherFailed,
   };
 
-  InputMatcher(const ValueDecl *funcDecl,
-      const ArrayRef<AnyFunctionType::Param> params);
+  InputMatcher(const ArrayRef<AnyFunctionType::Param> params,
+      const llvm::SmallBitVector &defaultValueMap);
 
   /// Matching a given array of inputs.
   ///
   /// \param numInputs The number of inputs.
-  /// \param ignoreLastPair Skip the last parameter and input. This may happen,
-  ///        for example, when we want to match trailing closures separately.
   /// \param pairMatcher Custom matching behavior of an input-parameter pair.
   /// \return the matching result.
-  Result solve(int numInputs, bool ignoreLastPair,
+  Result match(int numInputs,
       std::function<bool(unsigned inputIdx, unsigned paramIdx)> pairMatcher);
 
   size_t getNumSkippedParameters() const {

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -376,7 +376,7 @@ CurriedClass.method3(c)(32, b: 1)
 _ = CurriedClass.method3(c)
 _ = CurriedClass.method3(c)(1, 2)        // expected-error {{missing argument label 'b:' in call}} {{32-32=b: }}
 _ = CurriedClass.method3(c)(1, b: 2)(32) // expected-error {{cannot call value of non-function type '()'}}
-_ = CurriedClass.method3(1, 2)           // expected-error {{missing argument label 'b:' in call}}
+_ = CurriedClass.method3(1, 2)           // expected-error {{instance member 'method3' cannot be used on type 'CurriedClass'; did you mean to use a value of this type instead?}}
 CurriedClass.method3(c)(1.0, b: 1)       // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 CurriedClass.method3(c)(1)               // expected-error {{missing argument for parameter 'b' in call}}
 

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -376,7 +376,7 @@ CurriedClass.method3(c)(32, b: 1)
 _ = CurriedClass.method3(c)
 _ = CurriedClass.method3(c)(1, 2)        // expected-error {{missing argument label 'b:' in call}} {{32-32=b: }}
 _ = CurriedClass.method3(c)(1, b: 2)(32) // expected-error {{cannot call value of non-function type '()'}}
-_ = CurriedClass.method3(1, 2)           // expected-error {{instance member 'method3' cannot be used on type 'CurriedClass'; did you mean to use a value of this type instead?}}
+_ = CurriedClass.method3(1, 2)           // expected-error {{missing argument label 'b:' in call}}
 CurriedClass.method3(c)(1.0, b: 1)       // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
 CurriedClass.method3(c)(1)               // expected-error {{missing argument for parameter 'b' in call}}
 

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -40,6 +40,22 @@ struct S {
   }
 }
 
+
+class DefaultValue {
+  static func foo(_ a: Int) {}
+  static func foo(_ a: Int, _ b: Int = 1) {}
+  static func foo(_ a: Int, _ b: Int = 1, _ c: Int = 2) {}
+}
+DefaultValue.foo(1.0, 1) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
+
+
+class Variadic {
+  static func foo(_ a: Int) {}
+  static func foo(_ a: Int, _ b: Double...) {}
+}
+Variadic.foo(1.0, 2.0, 3.0) // expected-error {{cannot convert value of type 'Double' to expected argument type 'Int'}}
+
+
 //=-------------- SR-7918 --------------=/
 class sr7918_Suit {
   static func foo<T: Any>(_ :inout T) {}

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift
+// RUN: %target-typecheck-verify-swift -swift-version 4
 
 enum E : String {
   case foo = "foo"
@@ -19,19 +19,17 @@ func fg<T>(_ f: (T) -> T) -> Void {} // expected-note {{in call to function 'fg'
 fg({x in x}) // expected-error {{generic parameter 'T' could not be inferred}}
 
 
-// FIXME: Both f & g should complain about ambiguity of arg1, but in both cases the generic member
-// never gets into the list of candidates in the first place.
 struct S {
   func f<T>(_ i: (T) -> T, _ j: Int) -> Void {}
   func f(_ d: (Double) -> Double) -> Void {}
   func test() -> Void {
-    f({x in x}, 2) // expected-error {{extra argument in call}}
+    f({x in x}, 2) // expected-error {{generic parameter 'T' could not be inferred}}
   }
   
   func g<T>(_ a: T, _ b: Int) -> Void {}
   func g(_ a: String) -> Void {}
   func test2() -> Void {
-    g(.notAThing, 7) // expected-error {{extra argument in call}}
+    g(.notAThing, 7) // expected-error {{reference to member 'notAThing' cannot be resolved without a contextual type}}
   }
   
   func h(_ a: Int, _ b: Int) -> Void {}
@@ -40,5 +38,77 @@ struct S {
     h(.notAThing, 3) // expected-error {{type 'Int' has no member 'notAThing'}}
     h(.notAThing) // expected-error {{type 'String' has no member 'notAThing'}}
   }
+}
+
+//=-------------- SR-7918 --------------=/
+class sr7918_Suit {
+  static func foo<T: Any>(_ :inout T) {}
+  static func foo() {}
+}
+
+class sr7918_RandomNumberGenerator {}
+
+let myRNG = sr7918_RandomNumberGenerator() // expected-note {{change 'let' to 'var' to make it mutable}}
+_ = sr7918_Suit.foo(&myRNG) // expected-error {{cannot pass immutable value as inout argument: 'myRNG' is a 'let' constant}}
+
+
+//=-------------- SR-7786 --------------=/
+struct sr7786 {
+  func foo() -> UInt { return 0 }
+  func foo<T: UnsignedInteger>(bar: T) -> T {
+    return bar
+  }
+}
+
+let s = sr7786()
+let a = s.foo()
+let b = s.foo(bar: 123) // expected-error {{argument type 'Int' does not conform to expected type 'UnsignedInteger'}}
+let c: UInt = s.foo(bar: 123)
+let d = s.foo(bar: 123 as UInt)
+
+
+//=-------------- SR-7440 --------------=/
+struct sr7440_ITunesGenre {
+  let genre: Int // expected-note {{'genre' declared here}}
+  let name: String
+}
+class sr7440_Genre {
+  static func fetch<B: BinaryInteger>(genreID: B, name: String) {}
+  static func fetch(_ iTunesGenre: sr7440_ITunesGenre) -> sr7440_Genre {
+    return sr7440_Genre.fetch(genreID: iTunesGenre.genreID, name: iTunesGenre.name)
+// expected-error@-1 {{value of type 'sr7440_ITunesGenre' has no member 'genreID'; did you mean 'genre'?}}
+  }
+}
+
+
+//=-------------- SR-7295 --------------=/
+class sr7295 {
+  func doSomething(a: (() -> Void)? = nil, completion: @escaping ((String, Error?) -> Void)) {}
+  func doSomething(b: @escaping ((String, Error?, Bool) -> Void)) {}
+  func a() {
+    doSomething(a: nil, completion: { _ in })
+// expected-error@-1 {{contextual closure type '(String, Error?) -> Void' expects 2 arguments, but 1 was used in closure body}}
+  }
+}
+
+
+//=-------------- SR-5154 --------------=/
+protocol sr5154_Scheduler {
+  func inBackground(run task: @escaping () -> Void)
+}
+
+extension sr5154_Scheduler {
+  func inBackground(run task: @escaping () -> [Count], completedBy resultHandler: @escaping ([Count]) -> Void) {}
+}
+
+struct Count { // expected-note {{'init(title:)' declared here}}
+  let title: String
+}
+
+func getCounts(_ scheduler: sr5154_Scheduler, _ handler: @escaping ([Count]) -> Void) {
+  scheduler.inBackground(run: {
+    return [Count()] // expected-error {{missing argument for parameter 'title' in call}}
+  }, completedBy: {
+  })
 }
 

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4
+// RUN: %target-typecheck-verify-swift
 
 enum E : String {
   case foo = "foo"
@@ -93,17 +93,6 @@ class sr7440_Genre {
   static func fetch(_ iTunesGenre: sr7440_ITunesGenre) -> sr7440_Genre {
     return sr7440_Genre.fetch(genreID: iTunesGenre.genreID, name: iTunesGenre.name)
 // expected-error@-1 {{value of type 'sr7440_ITunesGenre' has no member 'genreID'; did you mean 'genre'?}}
-  }
-}
-
-
-//=-------------- SR-7295 --------------=/
-class sr7295 {
-  func doSomething(a: (() -> Void)? = nil, completion: @escaping ((String, Error?) -> Void)) {}
-  func doSomething(b: @escaping ((String, Error?, Bool) -> Void)) {}
-  func a() {
-    doSomething(a: nil, completion: { _ in })
-// expected-error@-1 {{contextual closure type '(String, Error?) -> Void' expects 2 arguments, but 1 was used in closure body}}
   }
 }
 

--- a/test/Sema/diag_ambiguous_overloads_swift4.swift
+++ b/test/Sema/diag_ambiguous_overloads_swift4.swift
@@ -1,0 +1,11 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+//=-------------- SR-7295 --------------=/
+class sr7295 {
+  func doSomething(a: (() -> Void)? = nil, completion: @escaping ((String, Error?) -> Void)) {}
+  func doSomething(b: @escaping ((String, Error?, Bool) -> Void)) {}
+  func a() {
+    doSomething(a: nil, completion: { _ in })
+// expected-error@-1 {{contextual closure type '(String, Error?) -> Void' expects 2 arguments, but 1 was used in closure body}}
+  }
+}


### PR DESCRIPTION
<!-- What's in this pull request? -->
When diagnosing ApplyExpr, the existing implementation tries to resolve the function subexpression independently in the first place, without considering the argument information. As a result, such resolved function type may not produce the best diagnostic message.

This PR adds consideration of the number of arguments to decide the better function subexpression for diagnostic purpose.

It also improves a primary test case by proving better diagnostic to fix a [FIXME](https://github.com/dingobye/swift/commit/5342cd4ccf7bdb4b2c7f06aa51b9788865031773#diff-9b28b2b1d74ac4f21e0f460a1bc3374aL22).


<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7918](https://bugs.swift.org/browse/SR-7918), [SR-7786](https://bugs.swift.org/browse/SR-7786), [SR-7440](https://bugs.swift.org/browse/SR-7440), [SR-7295](https://bugs.swift.org/browse/SR-7295), [SR-5154](https://bugs.swift.org/browse/SR-5154).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
