### PR TITLE
Remove __consuming from Code Completion

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -226,6 +226,7 @@ SIMPLE_DECL_ATTR(objcMembers, ObjCMembers,
 CONTEXTUAL_SIMPLE_DECL_ATTR(__consuming, Consuming,
   OnFunc | OnAccessor |
   DeclModifier |
+  UserInaccessible |
   NotSerialized, 40)
 CONTEXTUAL_SIMPLE_DECL_ATTR(mutating, Mutating,
   OnFunc | OnAccessor |

--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -4845,6 +4845,11 @@ static void addDeclKeywords(CodeCompletionResultSink &Sink) {
       // Treat keywords that could be the start of a pattern specially.
       return;
     }
+    // FIXME: __consuming should not appear in CodeCompletion until it is
+    // finalized in a language proposal.
+    if (Name == "__consuming")
+      return;
+
     CodeCompletionResultBuilder Builder(
         Sink, CodeCompletionResult::ResultKind::Keyword,
         SemanticContextKind::None, {});

--- a/test/SourceKit/CodeComplete/complete_override.swift.response
+++ b/test/SourceKit/CodeComplete/complete_override.swift.response
@@ -2,15 +2,6 @@
   key.results: [
     {
       key.kind: source.lang.swift.keyword,
-      key.name: "__consuming",
-      key.sourcetext: "__consuming",
-      key.description: "__consuming",
-      key.typename: "",
-      key.context: source.codecompletion.context.none,
-      key.num_bytes_to_erase: 0
-    },
-    {
-      key.kind: source.lang.swift.keyword,
       key.name: "associatedtype",
       key.sourcetext: "associatedtype",
       key.description: "associatedtype",


### PR DESCRIPTION
Set the UserInaccessible bit and remove __consuming from code
completion until we commit to a real keyword.

rdar://40828289

