### PR TITLE
[AST] Indicate which closures are escaping in AST dumps

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2301,6 +2301,11 @@ public:
       OS << " ";
       E->getCaptureInfo().print(PrintWithColorRAII(OS, CapturesColor).getOS());
     }
+    // Printing a function type doesn't indicate whether it's escaping because it doesn't 
+    // matter in 99% of contexts. AbstractClosureExpr nodes are one of the only exceptions.
+    if (auto Ty = GetTypeOfExpr(E))
+      if (!Ty->getAs<AnyFunctionType>()->getExtInfo().isNoEscape())
+        PrintWithColorRAII(OS, ClosureModifierColor) << " escaping";
 
     return OS;
   }

--- a/test/Driver/dump-parse.swift
+++ b/test/Driver/dump-parse.swift
@@ -61,3 +61,16 @@ func generic<T: Hashable>(_: T) {}
 // CHECK-AST:       (pattern_binding_decl
 // CHECK-AST:         (declref_expr type='(Int) -> ()' location={{.*}} range={{.*}} decl=main.(file).generic@{{.*}} [with (substitution_map generic_signature=<T where T : Hashable> (substitution T -> Int))] function_ref=unapplied))
 let _: (Int) -> () = generic
+
+// Closures should be marked as escaping or not.
+func escaping(_: @escaping (Int) -> Int) {}
+escaping({ $0 })
+// CHECK-AST:        (declref_expr type='(@escaping (Int) -> Int) -> ()'
+// CHECK-AST-NEXT:        (paren_expr
+// CHECK-AST-NEXT:          (closure_expr type='(Int) -> Int' {{.*}} discriminator=0 escaping single-expression
+
+func nonescaping(_: (Int) -> Int) {}
+nonescaping({ $0 })
+// CHECK-AST:        (declref_expr type='((Int) -> Int) -> ()'
+// CHECK-AST-NEXT:        (paren_expr
+// CHECK-AST-NEXT:          (closure_expr type='(Int) -> Int' {{.*}} discriminator=1 single-expression

--- a/test/expr/capture/generic_params.swift
+++ b/test/expr/capture/generic_params.swift
@@ -6,11 +6,11 @@ func doSomething<T>(_ t: T) {}
 
 func outerGeneric<T>(t: T, x: AnyObject) {
   // Simple case -- closure captures outer generic parameter
-  // CHECK: closure_expr type='() -> ()' {{.*}} discriminator=0 captures=(<generic> t) single-expression
+  // CHECK: closure_expr type='() -> ()' {{.*}} discriminator=0 captures=(<generic> t) escaping  single-expression
   _ = { doSomething(t) }
 
   // Special case -- closure does not capture outer generic parameters
-  // CHECK: closure_expr type='() -> ()' {{.*}} discriminator=1 captures=(x) single-expression
+  // CHECK: closure_expr type='() -> ()' {{.*}} discriminator=1 captures=(x) escaping single-expression
   _ = { doSomething(x) }
 
   // Special case -- closure captures outer generic parameter, but it does not


### PR DESCRIPTION
This change adds an "escaping" flag to AST dumps of closures with `@escaping` types. This helps when working on issues involving escaping vs. non-escaping closures.

My first attempt to do this added `@escaping` to function types in `ASTPrinter`, but this broke 239 tests, most having nothing to do with closures. I took this as a sign that adding escaping information to all function type dumps was overbroad.