### PR TITLE
ConstExpr: Significant progress to supporting more complicated cases

### DIFF
--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -43,6 +43,9 @@ enum class UnknownReason {
   /// The constant expression was too big.  This is reported on a random
   /// instruction within the constexpr that triggered the issue.
   TooManyInstructions,
+
+  /// A control flow loop was found.
+  Loop
 };
 
 
@@ -152,7 +155,14 @@ public:
   /// independent of its concrete representation.  This is the public
   /// interface to SymbolicValue.
   enum Kind {
-    Unknown, Metatype, Function, Integer, Float, String, Aggregate,
+    Unknown, Metatype, Function, Integer, Float,
+
+    // String values may have SIL type of Builtin.RawPointer or Builtin.Word
+    // type.
+    String,
+
+    // This can be an array, struct, tuple, etc.
+    Aggregate,
 
     // These values are generally only seen internally to the system, external
     // clients shouldn't have to deal with them.
@@ -266,8 +276,9 @@ public:
 
 
   /// Given that this is an 'Unknown' value, emit diagnostic notes providing
-  /// context about what the problem is.
-  void emitUnknownDiagnosticNotes();
+  /// context about what the problem is.  If there is no location for some
+  /// reason, we fall back to using the specified location.
+  void emitUnknownDiagnosticNotes(SILLocation fallbackLoc);
 
   void print(llvm::raw_ostream &os, unsigned indent = 0) const;
   void dump() const;

--- a/lib/SIL/SILConstants.cpp
+++ b/lib/SIL/SILConstants.cpp
@@ -74,6 +74,14 @@ void SymbolicValue::print(llvm::raw_ostream &os, unsigned indent) const {
   }
   case RK_Aggregate: {
     ArrayRef<SymbolicValue> elements = getAggregateValue();
+    if (elements.empty()) {
+      os << "agg: 0 elements []\n";
+      return;
+    } else if (elements.size() == 1) {
+      os << "agg: 1 elt: ";
+      elements[0].print(os, indent+2);
+      return;
+    }
     os << "agg: " << elements.size() << " element" << "s"[elements.size() == 1]
        << " [\n";
     for (auto elt : elements)

--- a/lib/SIL/SILConstants.cpp
+++ b/lib/SIL/SILConstants.cpp
@@ -38,6 +38,7 @@ void SymbolicValue::print(llvm::raw_ostream &os, unsigned indent) const {
     switch (unknown.second) {
     case UnknownReason::Default: os << "unknown: "; break;
     case UnknownReason::TooManyInstructions: os << "unknown(toobig): "; break;
+    case UnknownReason::Loop: os << "unknown(loop): "; break;
     }
     unknown.first->dump();
     return;
@@ -426,7 +427,7 @@ static SILDebugLocation skipInternalLocations(SILDebugLocation loc) {
 
 /// Given that this is an 'Unknown' value, emit diagnostic notes providing
 /// context about what the problem is.
-void SymbolicValue::emitUnknownDiagnosticNotes() {
+void SymbolicValue::emitUnknownDiagnosticNotes(SILLocation fallbackLoc) {
   std::pair<SILNode *, UnknownReason> unknown = getUnknownValue();
   auto badInst = dyn_cast<SILInstruction>(unknown.first);
   if (!badInst) return;
@@ -440,12 +441,20 @@ void SymbolicValue::emitUnknownDiagnosticNotes() {
     // TODO: Should pop up a level of the stack trace.
     error = "expression is too large to evaluate at compile-time";
     break;
+  case UnknownReason::Loop:
+    error = "control flow loop found";
+    break;
   }
 
   auto &module = badInst->getModule();
 
   auto loc = skipInternalLocations(badInst->getDebugLocation()).getLocation();
-  if (loc.isNull()) return;
+  if (loc.isNull()) {
+    // If we have important clarifying information, make sure to emit it.
+    if (unknown.second != UnknownReason::Default)
+      return;
+    loc = fallbackLoc;
+  }
 
   diagnose(module.getASTContext(), loc.getSourceLoc(),
            diag::tf_op_misuse_note, error)

--- a/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
+++ b/lib/SILOptimizer/Mandatory/DataflowDiagnostics.cpp
@@ -142,7 +142,7 @@ static void diagnosePoundAssert(const SILInstruction *I, SILModule &M) {
     // If we have more specific information about what went wrong, emit
     // notes.
     if (value.getKind() == SymbolicValue::Unknown)
-      value.emitUnknownDiagnosticNotes();
+      value.emitUnknownDiagnosticNotes(builtinInst->getLoc());
     return;
   }
   assert(value.getKind() == SymbolicValue::Integer &&

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -1918,7 +1918,7 @@ void TFDeabstraction::checkAndCanonicalizeAttributes() {
           // If we have more specific information about what went wrong, emit
           // notes.
           if (it->second.getKind() == SymbolicValue::Unknown)
-            it->second.emitUnknownDiagnosticNotes();
+            it->second.emitUnknownDiagnosticNotes(opInfo->inst->getLoc());
           break;
         }
 

--- a/test/TensorFlow/deabstraction_finished.swift
+++ b/test/TensorFlow/deabstraction_finished.swift
@@ -36,6 +36,7 @@ public func tensorShape() -> Tensor<Float> {
   let shape : TensorShape = [2]
   // expected-error @+1 {{attribute 'value' requires a constant argument}}
   return Tensor(handle: #tfop("Const", dtype: Float.self, value$tensor: [1.0, 2.0], value$shape: shape))
+  // expected-note @-1 {{could not fold operation}}
 }
 
 // b/75407624


### PR DESCRIPTION
 - Add a specific diagnostic for loops, which we don't support yet (intentionally).
 - Implement support for copy_addr, begin_access, end_access, destroy_addr.
 - Add support for ptrtoint of strings to word size, and llvm.expect.
 - Fix updateIndexedElement to be (a) correct, and (b) handle overwriting
   subelements of uninit memory, which happens with piecewise initialization
   of constant values.

Many of these cases are exercised by SignedInteger<>.init<A>(_:) which is
incredibly complicated.

Unfortunately, this isn't enough to make either testcase work, because I still
have a bug dealing with some witness table applications.  This isn't a
regression, but will need further work before those tests light up.
