### PR TITLE
Add reduced crasher for SR-7958

### DIFF
--- a/validation-test/compiler_crashers_2/0160-sr7958.swift
+++ b/validation-test/compiler_crashers_2/0160-sr7958.swift
@@ -1,4 +1,4 @@
-// RUN: %target-swift-frontend -emit-silgen %s
+// RUN: not --crash %target-swift-frontend %s -emit-ir
 
 func foo<U>(_ x: U?) {
   _ = "\(anyLabelHere: x)"

--- a/validation-test/compiler_crashers_2/0160-sr7958.swift
+++ b/validation-test/compiler_crashers_2/0160-sr7958.swift
@@ -1,0 +1,10 @@
+// RUN: %target-swift-frontend -emit-silgen %s
+
+func foo<U>(_ x: U?) {
+  _ = "\(anyLabelHere: x)"
+}
+
+// This one also crashes in a slightly different place
+func bar(_ x: Int?) {
+  _ = "\(anyLabelHere: x)"
+}


### PR DESCRIPTION
Trying to use an argument label in an interpolation can cause various crashes. In swiftlang-1000.0.16.7, these are usually in SILGen; in master at 8f6028d, they’re in CSApply.

The file includes two samples. In swiftlang-1000.0.16.7, the first crashes in exactly the same place as the code snippet in [SR-7958](https://bugs.swift.org/browse/SR-7958), while the second crashes elsewhere in SILGen. In master at 8f6028d, they both seem to crash in the same place.