### PR TITLE
Preserve availability on ObjC subscript getters and setters

### DIFF
--- a/test/ClangImporter/Inputs/custom-modules/AvailabilityExtras.h
+++ b/test/ClangImporter/Inputs/custom-modules/AvailabilityExtras.h
@@ -97,6 +97,10 @@ typedef NS_ENUM(NSInteger, NSEnumAddedCasesIn2017) {
 @interface AccessorDeprecations: NSObject
 @property int fullyDeprecated __attribute__((deprecated));
 
+@property NSInteger fullyDeprecatedOnAccessors;
+- (NSInteger)fullyDeprecatedOnAccessors __attribute__((deprecated));
+- (void)setFullyDeprecatedOnAccessors:(NSInteger)fullyDeprecatedOnAccessors __attribute__((deprecated));
+
 @property int getterDeprecated;
 - (int)getterDeprecated __attribute__((deprecated));
 @property (class) int getterDeprecatedClass;
@@ -112,6 +116,10 @@ typedef NS_ENUM(NSInteger, NSEnumAddedCasesIn2017) {
 @interface UnavailableAccessors: NSObject
 @property NSInteger fullyUnavailable __attribute__((unavailable));
 
+@property NSInteger fullyUnavailableOnAccessors;
+- (NSInteger)fullyUnavailableOnAccessors __attribute__((unavailable));
+- (void)setFullyUnavailableOnAccessors:(NSInteger)fullyUnavailableOnAccessors __attribute__((unavailable));
+
 @property NSInteger getterUnavailable;
 - (NSInteger)getterUnavailable __attribute__((unavailable));
 @property (class) NSInteger getterUnavailableClass;
@@ -121,4 +129,43 @@ typedef NS_ENUM(NSInteger, NSEnumAddedCasesIn2017) {
 - (void)setSetterUnavailable:(NSInteger)setterUnavailable __attribute__((unavailable));
 @property (class) NSInteger setterUnavailableClass;
 + (void)setSetterUnavailableClass:(NSInteger)setterUnavailable __attribute__((unavailable));
+@end
+
+
+@interface UnavailableSubscript: NSObject
+- (nonnull NSString *)objectAtIndexedSubscript:(NSInteger)i __attribute__((unavailable("bad subscript getter")));
+- (void)setObject:(nonnull NSString *)obj atIndexedSubscript:(NSInteger)i __attribute__((unavailable("bad subscript setter")));
+@end
+
+@interface UnavailableGetterSubscript: NSObject
+- (nonnull NSString *)objectAtIndexedSubscript:(NSInteger)i __attribute__((unavailable("bad subscript getter")));
+- (void)setObject:(nonnull NSString *)obj atIndexedSubscript:(NSInteger)i;
+@end
+
+@interface UnavailableSetterSubscript: NSObject
+- (nonnull NSString *)objectAtIndexedSubscript:(NSInteger)i;
+- (void)setObject:(nonnull NSString *)obj atIndexedSubscript:(NSInteger)i __attribute__((unavailable("bad subscript setter")));
+@end
+
+@interface UnavailableReadOnlySubscript: NSObject
+- (nonnull NSString *)objectAtIndexedSubscript:(NSInteger)i __attribute__((unavailable));
+@end
+
+@interface DeprecatedSubscript: NSObject
+- (nonnull NSString *)objectAtIndexedSubscript:(NSInteger)i __attribute__((deprecated("bad subscript getter")));
+- (void)setObject:(nonnull NSString *)obj atIndexedSubscript:(NSInteger)i __attribute__((deprecated("bad subscript setter")));
+@end
+
+@interface DeprecatedGetterSubscript: NSObject
+- (nonnull NSString *)objectAtIndexedSubscript:(NSInteger)i __attribute__((deprecated("bad subscript getter")));
+- (void)setObject:(nonnull NSString *)obj atIndexedSubscript:(NSInteger)i;
+@end
+
+@interface DeprecatedSetterSubscript: NSObject
+- (nonnull NSString *)objectAtIndexedSubscript:(NSInteger)i;
+- (void)setObject:(nonnull NSString *)obj atIndexedSubscript:(NSInteger)i __attribute__((deprecated("bad subscript setter")));
+@end
+
+@interface DeprecatedReadOnlySubscript: NSObject
+- (nonnull NSString *)objectAtIndexedSubscript:(NSInteger)i __attribute__((deprecated));
 @end

--- a/test/ClangImporter/availability.swift
+++ b/test/ClangImporter/availability.swift
@@ -25,10 +25,18 @@ func test_unavailable_func(_ x : NSObject) {
   NSDeallocateObject(x) // expected-error {{'NSDeallocateObject' is unavailable}}
 }
 
-func test_unavailable_accessors(_ obj: UnavailableAccessors) {
+func test_unavailable_accessors(_ obj: UnavailableAccessors,
+    _ sub: UnavailableSubscript,
+    _ subGetter: UnavailableGetterSubscript,
+    _ subSetter: UnavailableSetterSubscript,
+    _ subReadOnly: UnavailableReadOnlySubscript) {
   _ = obj.fullyUnavailable // expected-error {{'fullyUnavailable' is unavailable}}
   obj.fullyUnavailable = 0 // expected-error {{'fullyUnavailable' is unavailable}}
   obj.fullyUnavailable += 1 // expected-error {{'fullyUnavailable' is unavailable}}
+
+  _ = obj.fullyUnavailableOnAccessors // expected-error {{getter for 'fullyUnavailableOnAccessors' is unavailable}}
+  obj.fullyUnavailableOnAccessors = 0 // expected-error {{setter for 'fullyUnavailableOnAccessors' is unavailable}}
+  obj.fullyUnavailableOnAccessors += 1 // expected-error {{getter for 'fullyUnavailableOnAccessors' is unavailable}} expected-error {{setter for 'fullyUnavailableOnAccessors' is unavailable}}
 
   _ = obj.getterUnavailable // expected-error {{getter for 'getterUnavailable' is unavailable}}
   obj.getterUnavailable = 0
@@ -45,14 +53,36 @@ func test_unavailable_accessors(_ obj: UnavailableAccessors) {
   _ = UnavailableAccessors.setterUnavailableClass
   UnavailableAccessors.setterUnavailableClass = 0 // expected-error {{setter for 'setterUnavailableClass' is unavailable}}
   UnavailableAccessors.setterUnavailableClass += 1 // expected-error {{setter for 'setterUnavailableClass' is unavailable}}
+
+  _ = sub[0] // expected-error {{getter for 'subscript' is unavailable: bad subscript getter}}
+  sub[0] = "" // expected-error {{setter for 'subscript' is unavailable: bad subscript setter}}
+  sub[0] += "" // expected-error {{getter for 'subscript' is unavailable: bad subscript getter}} expected-error {{setter for 'subscript' is unavailable: bad subscript setter}}
+
+  _ = subGetter[0] // expected-error {{getter for 'subscript' is unavailable: bad subscript getter}}
+  subGetter[0] = ""
+  subGetter[0] += "" // expected-error {{getter for 'subscript' is unavailable: bad subscript getter}}
+
+  _ = subSetter[0]
+  subSetter[0] = "" // expected-error {{setter for 'subscript' is unavailable: bad subscript setter}}
+  subSetter[0] += "" // expected-error {{setter for 'subscript' is unavailable: bad subscript setter}}
+
+  _ = subReadOnly[0] // expected-error {{getter for 'subscript' is unavailable}}
 }
 
-func test_deprecated(_ s:UnsafeMutablePointer<CChar>, _ obj: AccessorDeprecations) {
+func test_deprecated(_ s:UnsafeMutablePointer<CChar>, _ obj: AccessorDeprecations,
+    _ sub: DeprecatedSubscript,
+    _ subGetter: DeprecatedGetterSubscript,
+    _ subSetter: DeprecatedSetterSubscript,
+    _ subReadOnly: DeprecatedReadOnlySubscript) {
   _ = tmpnam(s) // expected-warning {{'tmpnam' is deprecated: Due to security concerns inherent in the design of tmpnam(3), it is highly recommended that you use mkstemp(3) instead.}}
 
   _ = obj.fullyDeprecated // expected-warning {{'fullyDeprecated' is deprecated}}
   obj.fullyDeprecated = 0 // expected-warning {{'fullyDeprecated' is deprecated}}
   obj.fullyDeprecated += 1 // expected-warning {{'fullyDeprecated' is deprecated}}
+
+  _ = obj.fullyDeprecatedOnAccessors // expected-warning {{getter for 'fullyDeprecatedOnAccessors' is deprecated}}
+  obj.fullyDeprecatedOnAccessors = 0 // expected-warning {{setter for 'fullyDeprecatedOnAccessors' is deprecated}}
+  obj.fullyDeprecatedOnAccessors += 1 // expected-warning {{getter for 'fullyDeprecatedOnAccessors' is deprecated}} expected-warning {{setter for 'fullyDeprecatedOnAccessors' is deprecated}}
 
   _ = obj.getterDeprecated // expected-warning {{getter for 'getterDeprecated' is deprecated}}
   obj.getterDeprecated = 0
@@ -69,6 +99,20 @@ func test_deprecated(_ s:UnsafeMutablePointer<CChar>, _ obj: AccessorDeprecation
   _ = AccessorDeprecations.setterDeprecatedClass
   AccessorDeprecations.setterDeprecatedClass = 0 // expected-warning {{setter for 'setterDeprecatedClass' is deprecated}}
   AccessorDeprecations.setterDeprecatedClass += 1 // expected-warning {{setter for 'setterDeprecatedClass' is deprecated}}
+
+  _ = sub[0] // expected-warning {{getter for 'subscript' is deprecated: bad subscript getter}}
+  sub[0] = "" // expected-warning {{setter for 'subscript' is deprecated: bad subscript setter}}
+  sub[0] += "" // expected-warning {{getter for 'subscript' is deprecated: bad subscript getter}} expected-warning {{setter for 'subscript' is deprecated: bad subscript setter}}
+
+  _ = subGetter[0] // expected-warning {{getter for 'subscript' is deprecated: bad subscript getter}}
+  subGetter[0] = ""
+  subGetter[0] += "" // expected-warning {{getter for 'subscript' is deprecated: bad subscript getter}}
+
+  _ = subSetter[0]
+  subSetter[0] = "" // expected-warning {{setter for 'subscript' is deprecated: bad subscript setter}}
+  subSetter[0] += "" // expected-warning {{setter for 'subscript' is deprecated: bad subscript setter}}
+
+  _ = subReadOnly[0] // expected-warning {{getter for 'subscript' is deprecated}}
 }
 
 func test_NSInvocation(_ x: NSInvocation,         // expected-error {{'NSInvocation' is unavailable}}


### PR DESCRIPTION
Objective-C subscript accessors' attributes were being imported through the alternative declaration (`getAlternateDecls(decl)`) of one of the accessors (usually the getter), and this alternative declaration was the entire subscript declaration, not the getter or setter. Since there is no 1:1 equivalent between Objective-C and Swift of a subscript declaration like there is a property declaration, I opted to not import any attributes to the Swift subscript declaration we generate. The accessor attributes are imported 1:1 to their respective Swift thunks.

I noticed that, for "unavailable" subscripts, diagnostics outputs a "note" to point out where the subscript was marked unavailable but it doesn't output where. I would expect it to be able to point out the line in the Objective-C header, but it tries to point out the thunk, which is generated and thus nothing gets output. It seems there are similar problems with normal properties, except that it shows the hidden __ObjC module's generated Swift interface. Therefore I assumed that my fix didn't break those diagnostics.

I changed one `dyn_cast` to `cast` because I didn't think there would be a case where it would fail, and a couple of lines down there was a dereference anyways.

Resolves [SR-7398](https://bugs.swift.org/browse/SR-7398).