### PR TITLE
IRGen: Form stand-in zero pieces for `undef` debug info of the right size.

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1928,10 +1928,13 @@ void IRGenDebugInfoImpl::emitVariableDeclaration(
     if (Indirection)
       Operands.push_back(llvm::dwarf::DW_OP_deref);
 
-    // There are variables without storage, such as "struct { func foo() {}
-    // }". Emit them as constant 0.
-    if (isa<llvm::UndefValue>(Piece))
-      Piece = llvm::ConstantInt::get(IGM.Int64Ty, 0);
+    // There are undefined values. Emit them as constant 0.
+    if (isa<llvm::UndefValue>(Piece)) {
+      auto undefSize = IGM.DataLayout.getTypeSizeInBits(Piece->getType());
+      
+      Piece = llvm::ConstantInt::get(
+         llvm::IntegerType::get(IGM.getLLVMContext(), undefSize), 0);
+    }
 
     if (IsPiece) {
       // Advance the offset and align it for the next piece.

--- a/test/IRGen/debug_info_for_undef.sil
+++ b/test/IRGen/debug_info_for_undef.sil
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -g -O -emit-ir -verify %s
+
+import Swift
+
+sil_stage canonical
+
+struct Foo { var x: Int32; var y: Int32 }
+
+sil @undef_debug_info : $@convention(thin) (Int32) -> () {
+entry(%x : $Int32):
+  %y = struct $Foo (%x : $Int32, undef : $Int32)
+  debug_value %y : $Foo, let, name "x", argno 1
+  return undef : $()
+}


### PR DESCRIPTION
Previously, we would unilaterally create an `i64 0`, which would lead to assertion failures downstream.
