### PR TITLE
[master-next] Replace use of F_RW flag that was removed in LLVM r334221

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1227,7 +1227,8 @@ void Decl::dump() const {
 
 void Decl::dump(const char *filename) const {
   std::error_code ec;
-  llvm::raw_fd_ostream stream(filename, ec, llvm::sys::fs::F_RW);
+  llvm::raw_fd_ostream stream(filename, ec, llvm::sys::fs::FA_Read |
+                              llvm::sys::fs::FA_Write);
   // In assert builds, we blow up. Otherwise, we just return.
   assert(!ec && "Failed to open file for dumping?!");
   if (ec)


### PR DESCRIPTION
Use a combination of the new FA_Read and FA_Write flags instead.