### PR TITLE
Hack: Force UIEdgeInsets.zero to always come from the SDK

### DIFF
--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -616,6 +616,12 @@ findSwiftNameAttr(const clang::Decl *decl, ImportNameVersion version) {
 
   // Handle versioned API notes for Swift 3 and later. This is the common case.
   if (version > ImportNameVersion::swift2()) {
+    // FIXME: Until Apple gets a chance to update UIKit's API notes, always use
+    // the new name for certain properties.
+    if (auto *namedDecl = dyn_cast<clang::NamedDecl>(decl))
+      if (importer::isSpecialUIKitStructZeroProperty(namedDecl))
+        version = ImportNameVersion::swift4_2();
+
     const auto *activeAttr = decl->getAttr<clang::SwiftNameAttr>();
     const clang::SwiftNameAttr *result = activeAttr;
     clang::VersionTuple bestSoFar;

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1383,6 +1383,10 @@ namespace importer {
 /// Whether we should suppress the import of the given Clang declaration.
 bool shouldSuppressDeclImport(const clang::Decl *decl);
 
+/// Identifies certain UIKit constants that used to have overlay equivalents,
+/// but are now renamed using the swift_name attribute.
+bool isSpecialUIKitStructZeroProperty(const clang::NamedDecl *decl);
+
 /// Finds a particular kind of nominal by looking through typealiases.
 template <typename T>
 static T *dynCastIgnoringCompatibilityAlias(Decl *D) {

--- a/stdlib/public/SDK/UIKit/UIKit.swift
+++ b/stdlib/public/SDK/UIKit/UIKit.swift
@@ -21,22 +21,6 @@ import _SwiftUIKitOverlayShims
 // UIGeometry
 //===----------------------------------------------------------------------===//
 
-extension UIEdgeInsets {
-  @available(swift, obsoleted: 4.2) // in 4.2 it is provided by the apinotes
-  public static var zero: UIEdgeInsets {
-    @_transparent // @fragile
-    get { return UIEdgeInsets(top: 0.0, left: 0.0, bottom: 0.0, right: 0.0) }
-  }
-}
-
-extension UIOffset {
-  @available(swift, obsoleted: 4.2) // in 4.2 it is provided by the apinotes
-  public static var zero: UIOffset {
-    @_transparent // @fragile
-    get { return UIOffset(horizontal: 0.0, vertical: 0.0) }
-  }
-}
-
 extension UIEdgeInsets : Equatable {
   @_transparent // @fragile
   public static func == (lhs: UIEdgeInsets, rhs: UIEdgeInsets) -> Bool {

--- a/validation-test/Serialization/SR7879.swift
+++ b/validation-test/Serialization/SR7879.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-module-path %t/main4.swiftmodule -swift-version 4 %s
+// RUN: %target-build-swift -emit-module-path %t/main4_2.swiftmodule -swift-version 4.2 %s
+
+// REQUIRES: OS=ios
+
+import UIKit
+
+public func testInsets(_: UIEdgeInsets = .zero) {}
+public func testOffsets(_: UIOffset = .zero) {}


### PR DESCRIPTION
...instead of relying on the one in the overlay in pre-4.2 versions of Swift. This caused crashes in deserialization, which (deliberately) doesn't respect availability.

There are three changes here:

- Remove `UIEdgeInsets.zero` and `UIOffset.zero` from the UIKit overlay.
- Always use the 4.2 name for `UIEdgeInsetsZero` and `UIOffsetZero` from the underlying UIKit framework. (This is the nested name.)
- Ignore the unavailability messages for those two constants in pre-4.2 Swift, since we're now relying on them being present.

The latter two, the compiler changes, can go away once UIKit's API notes no longer specify different pre-4.2 behavior, but meanwhile we need to keep compatibility with the SDKs released in Xcode 10b1.

[SR-7879](https://bugs.swift.org/browse/SR-7879) / rdar://problem/40735990