### PR TITLE
Don't flatten input types in ObjC representation check

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1951,30 +1951,41 @@ getForeignRepresentable(Type type, ForeignLanguage language,
       break;
     }
 
+    auto success = [](bool anyStaticBridged,
+                      bool anyBridged,
+                      bool isBlock) -> std::pair<ForeignRepresentableKind,
+                                                 ProtocolConformance *> {
+      // We have something representable; check how it is representable.
+      return { anyStaticBridged ? ForeignRepresentableKind::StaticBridged
+                   : anyBridged ? ForeignRepresentableKind::Bridged
+                   : isBlock    ? ForeignRepresentableKind::Object
+                   : ForeignRepresentableKind::Trivial,
+                   nullptr };
+    };
+
+    // HACK: In Swift 3 mode, we accepted (Void) -> Void for () -> Void
+    if (dc->getASTContext().isSwiftVersion3()
+        && functionType->getParams().size() == 1
+        && functionType->getParams()[0].getLabel().empty()
+        && functionType->getParams()[0].getType()->isVoid()
+        && functionType->getResult()->isVoid()) {
+      return success(anyStaticBridged, anyBridged, isBlock);
+    }
+
     // Look at the result type.
     Type resultType = functionType->getResult();
     if (!resultType->isVoid() && recurse(resultType))
       return failure();
 
-    // Look at the input types.
-    Type inputType = functionType->getInput();
-    if (auto inputTuple = inputType->getAs<TupleType>()) {
-      for (const auto &elt : inputTuple->getElements()) {
-        if (elt.isVararg())
-          return failure();
-        if (recurse(elt.getType()))
-          return failure();
-      }
-    } else if (recurse(inputType)) {
-      return failure();
+    // Look at the input params.
+    for (const auto &param : functionType->getParams()) {
+      if (param.isVariadic())
+        return failure();
+      if (recurse(param.getType()))
+        return failure();
     }
 
-    // We have something representable; check how it is representable.
-    return { anyStaticBridged ? ForeignRepresentableKind::StaticBridged
-                 : anyBridged ? ForeignRepresentableKind::Bridged
-                 : isBlock    ? ForeignRepresentableKind::Object
-                 : ForeignRepresentableKind::Trivial,
-             nullptr };
+    return success(anyStaticBridged, anyBridged, isBlock);
   }
 
   // Give special dispensation to builtin types for testing purposes.

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -633,6 +633,17 @@ class NewtypeUser {
   @objc func intNewtypeDictionary(a: [MyInt: NSObject]) {} // expected-error {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
   @objc func cfNewtype(a: CFNewType) {}
   @objc func cfNewtypeArray(a: [CFNewType]) {} // expected-error {{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+
+  typealias MyTuple = (Int, AnyObject?)
+  typealias MyNamedTuple = (a: Int, b: AnyObject?)
+  
+  @objc func blockWithTypealias(_ input: @escaping (MyTuple) -> MyInt) {}
+  // expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // expected-note@-2{{function types cannot be represented in Objective-C}}
+
+  @objc func blockWithTypealiasWithNames(_ input: (MyNamedTuple) -> MyInt) {}
+  // expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
+  // expected-note@-2{{function types cannot be represented in Objective-C}}
 }
 
 func testTypeAndValue() {

--- a/test/PrintAsObjC/blocks.swift
+++ b/test/PrintAsObjC/blocks.swift
@@ -10,8 +10,6 @@
 
 import ObjectiveC
 
-typealias MyTuple = (Int, AnyObject?)
-typealias MyNamedTuple = (a: Int, b: AnyObject?)
 typealias MyInt = Int
 typealias MyBlockWithEscapingParam = (@escaping () -> ()) -> Int
 typealias MyBlockWithNoescapeParam = (() -> ()) -> Int
@@ -60,9 +58,6 @@ typealias MyBlockWithNoescapeParam = (() -> ()) -> Int
   @objc func returnsBlockWithTwoInputs() -> ((NSObject, NSObject) -> ())? {
     return nil
   }
-
-  // CHECK-NEXT: - (void)blockWithTypealias:(NSInteger (^ _Nonnull)(NSInteger, id _Nullable))input;
-  @objc func blockWithTypealias(_ input: @escaping (MyTuple) -> MyInt) {}
   
   // CHECK-NEXT: - (void)blockWithSimpleTypealias:(NSInteger (^ _Nonnull)(NSInteger))input;
   @objc func blockWithSimpleTypealias(_ input: @escaping (MyInt) -> MyInt) {}
@@ -77,9 +72,6 @@ typealias MyBlockWithNoescapeParam = (() -> ()) -> Int
   @objc func returnsBlockWithNamedInput() -> ((_ object: NSObject) -> ())? {
     return nil
   }
-
-  // CHECK-NEXT: - (void)blockWithTypealiasWithNames:(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(NSInteger a, id _Nullable b))input;
-  @objc func blockWithTypealiasWithNames(_ input: (MyNamedTuple) -> MyInt) {}
 
   // CHECK-NEXT: - (void)blockWithKeyword:(SWIFT_NOESCAPE NSInteger (^ _Nonnull)(NSInteger))_Nullable_;
   @objc func blockWithKeyword(_ _Nullable: (_ `class`: Int) -> Int) {}


### PR DESCRIPTION
Arguments of tuple type are not representable in Objective-C but the
old check was looking specifically for them.

Let's see what this breaks