### PR TITLE
[Runtime] NFC: Switch Portability to use C++ stddef header

### DIFF
--- a/include/swift/Runtime/Portability.h
+++ b/include/swift/Runtime/Portability.h
@@ -16,7 +16,7 @@
 
 #ifndef SWIFT_RUNTIME_PORTABILITY_H
 #define SWIFT_RUNTIME_PORTABILITY_H
-#include <stddef.h>
+#include <cstddef>
 
 size_t _swift_strlcpy(char *dst, const char *src, size_t maxlen);
 


### PR DESCRIPTION

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
