### PR TITLE
[func-sig-opts][projection] All projection trees during the run on a …

### DIFF
--- a/include/swift/SIL/Projection.h
+++ b/include/swift/SIL/Projection.h
@@ -841,7 +841,7 @@ class ProjectionTree {
   ///
   /// FIXME: This should be a reference to an outside allocator. We shouldn't
   /// have each ProjectionTree have its own allocator.
-  llvm::SpecificBumpPtrAllocator<ProjectionTreeNode> Allocator;
+  llvm::SpecificBumpPtrAllocator<ProjectionTreeNode> &Allocator;
 
   // A common pattern is a 3 field struct.
   llvm::SmallVector<ProjectionTreeNode *, 4> ProjectionTreeNodes;
@@ -851,10 +851,13 @@ class ProjectionTree {
 
 public:
   /// Construct a projection tree from BaseTy.
-  ProjectionTree(SILModule &Mod, SILType BaseTy);
+  ProjectionTree(SILModule &Mod, SILType BaseTy,
+                 llvm::SpecificBumpPtrAllocator<ProjectionTreeNode> &Allocator);
   /// Construct an uninitialized projection tree, which can then be
   /// initialized by initializeWithExistingTree.
-  ProjectionTree(SILModule &Mod) : Mod(Mod) {}
+  ProjectionTree(SILModule &Mod,
+                 llvm::SpecificBumpPtrAllocator<ProjectionTreeNode> &Allocator)
+      : Mod(Mod), Allocator(Allocator) {}
   ~ProjectionTree();
   ProjectionTree(const ProjectionTree &) = delete;
   ProjectionTree(ProjectionTree &&) = default;

--- a/lib/SIL/Projection.cpp
+++ b/lib/SIL/Projection.cpp
@@ -1103,8 +1103,10 @@ public:
 //                               ProjectionTree
 //===----------------------------------------------------------------------===//
 
-ProjectionTree::
-ProjectionTree(SILModule &Mod, SILType BaseTy) : Mod(Mod) {
+ProjectionTree::ProjectionTree(
+    SILModule &Mod, SILType BaseTy,
+    llvm::SpecificBumpPtrAllocator<ProjectionTreeNode> &Allocator)
+    : Mod(Mod), Allocator(Allocator) {
   DEBUG(llvm::dbgs() << "Constructing Projection Tree For : " << BaseTy
                      << "\n");
 

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -779,11 +779,12 @@ public:
     }
 
     // Allocate the argument and result descriptors.
+    llvm::SpecificBumpPtrAllocator<ProjectionTreeNode> Allocator;
     llvm::SmallVector<ArgumentDescriptor, 4> ArgumentDescList;
     llvm::SmallVector<ResultDescriptor, 4> ResultDescList;
     auto Args = F->begin()->getFunctionArguments();
     for (unsigned i : indices(Args)) {
-      ArgumentDescList.emplace_back(Args[i]);
+      ArgumentDescList.emplace_back(Args[i], Allocator);
     }
     for (SILResultInfo IR : F->getLoweredFunctionType()->getResults()) {
       ResultDescList.emplace_back(IR);

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.h
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.h
@@ -86,12 +86,15 @@ struct ArgumentDescriptor {
   /// to the original argument. The reason why we do this is to make sure we
   /// have access to the original argument's state if we modify the argument
   /// when optimizing.
-  ArgumentDescriptor(SILFunctionArgument *A)
+  ArgumentDescriptor(
+      SILFunctionArgument *A,
+      llvm::SpecificBumpPtrAllocator<ProjectionTreeNode> &Allocator)
       : Arg(A), PInfo(A->getKnownParameterInfo()), Index(A->getIndex()),
         Decl(A->getDecl()), IsEntirelyDead(false), WasErased(false),
         Explode(false), OwnedToGuaranteed(false),
         IsIndirectResult(A->isIndirectResult()), CalleeRelease(),
-        CalleeReleaseInThrowBlock(), ProjTree(A->getModule(), A->getType()) {
+        CalleeReleaseInThrowBlock(),
+        ProjTree(A->getModule(), A->getType(), Allocator) {
     if (!A->isIndirectResult()) {
       PInfo = Arg->getKnownParameterInfo();
     }


### PR DESCRIPTION
…function should share the same bump ptr allocator.

Found while reading code.
