### PR TITLE
Sema: Propagate noescape bit into closure passed to withoutActuallyEscaping [4.2]

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -6085,6 +6085,12 @@ static bool applyTypeToClosureExpr(ConstraintSystem &cs,
   // If we found an explicit ClosureExpr, update its type.
   if (auto CE = dyn_cast<ClosureExpr>(expr)) {
     cs.setType(CE, toType);
+
+    // If this is not a single-expression closure, write the type into the
+    // ClosureExpr directly here, since the visitor won't.
+    if (!CE->hasSingleExpressionBody())
+      CE->setType(toType);
+
     return true;
   }
 
@@ -7427,7 +7433,7 @@ Expr *ExprRewriter::finishApply(ApplyExpr *apply, Type openedType,
       }
       
       case DeclTypeCheckingSemantics::WithoutActuallyEscaping: {
-        // Resolve into a MakeTemporarilyEscapingExpr.
+        // Resolve into a MakeTemporarilyEscapableExpr.
         auto arg = cast<TupleExpr>(apply->getArg());
         assert(arg->getNumElements() == 2 && "should have two arguments");
         auto nonescaping = arg->getElements()[0];

--- a/test/Constraints/without_actually_escaping.swift
+++ b/test/Constraints/without_actually_escaping.swift
@@ -64,3 +64,29 @@ func rethrowThroughWAE(_ zz: (Int, Int, Int) throws -> Int, _ value: Int) throws
 let _: ((Int) -> Int, (@escaping (Int) -> Int) -> ()) -> ()
   = withoutActuallyEscaping(_:do:) // expected-error{{}}
 
+
+// Failing to propagate @noescape into non-single-expression
+// closure passed to withoutActuallyEscaping
+
+// https://bugs.swift.org/browse/SR-7886
+
+class Box<T> {
+  let value: T
+
+  init(_ value: T) {
+    self.value = value
+  }
+
+  func map1<U>(_ transform: (T) -> U) -> Box<U> {
+    return withoutActuallyEscaping(transform) { transform in
+      return Box<U>(transform(value))
+    }
+  }
+
+  func map2<U>(_ transform: (T) -> U) -> Box<U> {
+    return withoutActuallyEscaping(transform) { transform in
+      let v = Box<U>(transform(value))
+      return v
+    }
+  }
+}


### PR DESCRIPTION
Fixes <rdar://problem/40853562>, <https://bugs.swift.org/browse/SR-7886>.