### PR TITLE
[ConstraintSystem] Allow LValues for the bindings of an IUO @optional…

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1763,7 +1763,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
       if (choice.isImplicitlyUnwrappedValueOrReturnValue()) {
         // Build the disjunction to attempt binding both T? and T (or
         // function returning T? and function returning T).
-        Type ty = createTypeVariable(locator);
+        Type ty = createTypeVariable(locator, TVO_CanBindToLValue);
         buildDisjunctionForImplicitlyUnwrappedOptional(ty, refType, locator);
         addConstraint(ConstraintKind::Bind, boundType,
                       OptionalType::get(ty->getRValueType()), locator);

--- a/test/Constraints/iuo_objc.swift
+++ b/test/Constraints/iuo_objc.swift
@@ -28,4 +28,14 @@ func iuo_error(prop: IUOProperty) {
   // expected-error@-1 {{cannot invoke 'optional' with no arguments}}
   let _: Coat = prop.iuo!.optional!()
   let _: Coat = prop.iuo!.optional!()!
+
+  let _ = prop.iuo.name
+}
+
+protocol X {}
+
+extension X where Self : OptionalRequirements {
+  func test() {
+    let _ = self.name
+  }
 }

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -1158,11 +1158,12 @@ void takeNullableId(_Nullable id);
 @interface I
 @end
 
-@protocol OptionalMethods
+@protocol OptionalRequirements
 @optional
 - (Coat *)optional;
+@property NSString *name;
 @end
 
 @interface IUOProperty
-@property (readonly) id<OptionalMethods> iuo;
+@property (readonly) id<OptionalRequirements> iuo;
 @end


### PR DESCRIPTION
… requirement.

We were failing to bind the alternatives for an IUO @optional
requirement because we forgot to set the appropriate type variable option.

Fixes: rdar://problem/40868990
