### PR TITLE
query string fetching for URL.swift

### DIFF
--- a/stdlib/public/SDK/Foundation/URL.swift
+++ b/stdlib/public/SDK/Foundation/URL.swift
@@ -893,6 +893,18 @@ public struct URL : ReferenceConvertible, Equatable {
             return self
         }
     }
+ 
+    //Return a specific value in query string URL path simply
+    //
+    //Example: swift:\\host.com?version=4.0
+    //this function can fetch 'version' of value
+    func fetch(key:String) -> String? {
+        if let uri = URLComponents(string: self.absoluteString){
+            return uri.queryItems?.first(where: {$0.name == key})?.value
+        }
+        return nil
+    }
+    
     
     /// Returns a URL constructed by removing any path extension.
     ///


### PR DESCRIPTION
add a function for simply fetch from URL path query strings

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
