### PR TITLE
Revert "runtime: use `std::max_align_t` over `max_align_t` (NFC)"

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -40,7 +40,6 @@
 #include "SwiftValue.h"
 #endif
 
-#include <cstddef>
 #include <cstring>
 #include <type_traits>
 
@@ -2667,7 +2666,7 @@ static bool _dynamicCastClassToValueViaObjCBridgeable(
   // Allocate a buffer to store the T? returned by bridging.
   // The extra byte is for the tag.
   const std::size_t inlineValueSize = 3 * sizeof(void*);
-  alignas(std::max_align_t) char inlineBuffer[inlineValueSize + 1];
+  alignas(max_align_t) char inlineBuffer[inlineValueSize + 1];
   void *optDestBuffer;
   if (targetType->getValueWitnesses()->getStride() <= inlineValueSize) {
     // Use the inline buffer.


### PR DESCRIPTION
This reverts commit 638b89d12d273a0ede166a055a501c6a7559f3c9.

It resulted in the Linux CI bots failing.
