### PR TITLE
runtime: workaround GCC 4.8 libstdc++ C++11 conformance

### DIFF
--- a/stdlib/public/runtime/Casting.cpp
+++ b/stdlib/public/runtime/Casting.cpp
@@ -44,6 +44,11 @@
 #include <cstring>
 #include <type_traits>
 
+#if defined(__GLIBCXX__) && __GLIBCXX__ < 20160726
+#include <stddef.h>
+namespace std { using ::max_align_t; }
+#endif
+
 using namespace swift;
 using namespace swift::hashable_support;
 using namespace metadataimpl;


### PR DESCRIPTION
libstdc++ included with GCC 4.8 does not define `std::max_align_t` as
required by the C++11 specification.  As a workaround, explicitly create
the definition locally.  This was fixed in GCC 4.9 and later.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
