### PR TITLE
[SILGen] Don't force thunks for Clang declarations to be serialized

### DIFF
--- a/lib/SILGen/SILGenThunk.cpp
+++ b/lib/SILGen/SILGenThunk.cpp
@@ -211,7 +211,7 @@ void SILGenModule::emitForeignToNativeThunk(SILDeclRef thunk) {
   SILFunction *f = getFunction(thunk, ForDefinition);
   f->setThunk(IsThunk);
   if (thunk.asForeign().isClangGenerated())
-    f->setSerialized(IsSerialized);
+    f->setSerialized(IsSerializable);
   preEmitFunction(thunk, thunk.getDecl(), f, thunk.getDecl());
   PrettyStackTraceSILFunction X("silgen emitForeignToNativeThunk", f);
   SILGenFunction(*this, *f).emitForeignToNativeThunk(thunk);

--- a/test/SILGen/external_definitions.swift
+++ b/test/SILGen/external_definitions.swift
@@ -29,7 +29,7 @@ hasNoPrototype()
 // CHECK-LABEL: sil shared [serializable] @$SSo7AnsibleC{{[_0-9a-zA-Z]*}}fC : $@convention(method) (@in Optional<Any>, @thick Ansible.Type) -> @owned Optional<Ansible>
 
 // -- Native Swift thunk for NSAnse
-// CHECK: sil shared [serialized] [thunk] @$SSo6NSAnseySo7AnsibleCSgADFTO : $@convention(thin) (@guaranteed Optional<Ansible>) -> @owned Optional<Ansible> {
+// CHECK: sil shared [serializable] [thunk] @$SSo6NSAnseySo7AnsibleCSgADFTO : $@convention(thin) (@guaranteed Optional<Ansible>) -> @owned Optional<Ansible> {
 // CHECK: bb0([[ARG0:%.*]] : @guaranteed $Optional<Ansible>):
 // CHECK:   [[ARG0_COPY:%.*]] = copy_value [[ARG0]]
 // CHECK:   [[FUNC:%.*]] = function_ref @NSAnse : $@convention(c) (Optional<Ansible>) -> @autoreleased Optional<Ansible>

--- a/test/SILGen/objc_subscript.swift
+++ b/test/SILGen/objc_subscript.swift
@@ -1,4 +1,11 @@
-// RUN: %target-swift-emit-silgen -enable-sil-ownership %s -emit-verbose-sil -enable-objc-interop -disable-objc-attr-requires-foundation-module | %FileCheck %s
+// RUN: %empty-directory(%t)
+// RUN: %build-silgen-test-overlays
+
+// RUN: %target-swift-emit-silgen(mock-sdk: -sdk %S/Inputs -I %t) -enable-sil-ownership %s -emit-verbose-sil -disable-objc-attr-requires-foundation-module | %FileCheck %s
+
+// REQUIRES: objc_interop
+
+import gizmo
 
 @objc class ObjCClass {}
 
@@ -38,3 +45,16 @@ class B : A {
     }
   }
 }
+
+protocol SubscriptProto {
+  subscript(i: Int) -> Any! { get }
+}
+extension Guisemeau: SubscriptProto {}
+
+// CHECK-LABEL: sil private [transparent] [thunk] @$SSo9GuisemeauC14objc_subscript14SubscriptProtoA2cDPyypSgSicigTW
+// CHECK: function_ref @$SSo9GuisemeauCyypSgSicigTO
+// CHECK: end sil function '$SSo9GuisemeauC14objc_subscript14SubscriptProtoA2cDPyypSgSicigTW'
+
+// CHECK-LABEL: sil shared [serializable] [thunk] @$SSo9GuisemeauCyypSgSicigTO
+// CHECK: objc_method {{%[0-9]+}} : $Guisemeau, #Guisemeau.subscript!getter.1.foreign : (Guisemeau) -> (Int) -> Any?, $@convention(objc_method) (Int, Guisemeau) -> @autoreleased Optional<AnyObject>
+// CHECK: end sil function '$SSo9GuisemeauCyypSgSicigTO'


### PR DESCRIPTION
They "may be serialized", not "must be serialized". Small compile-time win (and helps decrease the frequency of SIL bugs around mixing Swift versions).