### PR TITLE
[4.2 EARLY] Hack: Force UIEdgeInsets.zero to always come from the SDK

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -7336,6 +7336,21 @@ getSwiftNameFromClangName(StringRef replacement) {
   return SwiftContext.AllocateCopy(StringRef(renamed));
 }
 
+bool importer::isSpecialUIKitStructZeroProperty(const clang::NamedDecl *decl) {
+  // FIXME: Once UIKit removes the "nonswift" availability in their versioned
+  // API notes, this workaround can go away.
+  auto *constant = dyn_cast<clang::VarDecl>(decl);
+  if (!constant)
+    return false;
+
+  clang::DeclarationName name = constant->getDeclName();
+  const clang::IdentifierInfo *ident = name.getAsIdentifierInfo();
+  if (!ident)
+    return false;
+
+  return ident->isStr("UIEdgeInsetsZero") || ident->isStr("UIOffsetZero");
+}
+
 /// Import Clang attributes as Swift attributes.
 void ClangImporter::Implementation::importAttributes(
     const clang::NamedDecl *ClangDecl,
@@ -7400,6 +7415,11 @@ void ClangImporter::Implementation::importAttributes(
 
       // Is this our special "availability(swift, unavailable)" attribute?
       if (Platform == "swift") {
+        // FIXME: Until Apple gets a chance to update UIKit's API notes, ignore
+        // the Swift-unavailability for certain properties.
+        if (isSpecialUIKitStructZeroProperty(ClangDecl))
+          continue;
+
         auto replacement = avail->getReplacement();
         StringRef swiftReplacement = "";
         if (!replacement.empty())

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -616,6 +616,12 @@ findSwiftNameAttr(const clang::Decl *decl, ImportNameVersion version) {
 
   // Handle versioned API notes for Swift 3 and later. This is the common case.
   if (version > ImportNameVersion::swift2()) {
+    // FIXME: Until Apple gets a chance to update UIKit's API notes, always use
+    // the new name for certain properties.
+    if (auto *namedDecl = dyn_cast<clang::NamedDecl>(decl))
+      if (importer::isSpecialUIKitStructZeroProperty(namedDecl))
+        version = ImportNameVersion::swift4_2();
+
     const auto *activeAttr = decl->getAttr<clang::SwiftNameAttr>();
     const clang::SwiftNameAttr *result = activeAttr;
     clang::VersionTuple bestSoFar;

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -1383,6 +1383,10 @@ namespace importer {
 /// Whether we should suppress the import of the given Clang declaration.
 bool shouldSuppressDeclImport(const clang::Decl *decl);
 
+/// Identifies certain UIKit constants that used to have overlay equivalents,
+/// but are now renamed using the swift_name attribute.
+bool isSpecialUIKitStructZeroProperty(const clang::NamedDecl *decl);
+
 /// Finds a particular kind of nominal by looking through typealiases.
 template <typename T>
 static T *dynCastIgnoringCompatibilityAlias(Decl *D) {

--- a/stdlib/public/SDK/UIKit/UIKit.swift
+++ b/stdlib/public/SDK/UIKit/UIKit.swift
@@ -21,22 +21,6 @@ import _SwiftUIKitOverlayShims
 // UIGeometry
 //===----------------------------------------------------------------------===//
 
-extension UIEdgeInsets {
-  @available(swift, obsoleted: 4.2) // in 4.2 it is provided by the apinotes
-  public static var zero: UIEdgeInsets {
-    @_transparent // @fragile
-    get { return UIEdgeInsets(top: 0.0, left: 0.0, bottom: 0.0, right: 0.0) }
-  }
-}
-
-extension UIOffset {
-  @available(swift, obsoleted: 4.2) // in 4.2 it is provided by the apinotes
-  public static var zero: UIOffset {
-    @_transparent // @fragile
-    get { return UIOffset(horizontal: 0.0, vertical: 0.0) }
-  }
-}
-
 extension UIEdgeInsets : Equatable {
   @_transparent // @fragile
   public static func == (lhs: UIEdgeInsets, rhs: UIEdgeInsets) -> Bool {

--- a/validation-test/Serialization/SR7879.swift
+++ b/validation-test/Serialization/SR7879.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-module-path %t/main4.swiftmodule -swift-version 4 %s
+// RUN: %target-build-swift -emit-module-path %t/main4_2.swiftmodule -swift-version 4.2 %s
+
+// REQUIRES: OS=ios
+
+import UIKit
+
+public func testInsets(_: UIEdgeInsets = .zero) {}
+public func testOffsets(_: UIOffset = .zero) {}


### PR DESCRIPTION
- **Explanation**: The UIKit overlay has long had convenience properties `UIEdgeInsets.zero` and `UIOffset.zero`, as Swiftier versions of constants in the UIKit framework UIEdgeInsetsZero and UIOffsetZero. In the iOS 12 SDK, we (Apple) tried to switch over to using the real C constants, since there's no need to duplicate the logic in Swift. However, trying to keep both declarations around but with different availability led to a crash in deserialization, which (deliberately) doesn't respect availability. Instead, let's go all the way to using the framework declarations…even though that means hacking the importer a little to pretend that UIKit's already updated their API notes.

- **Scope**: Affects UIEdgeInsetsZero and UIOffsetZero only.

- **Issue**: [SR-7879](https://bugs.swift.org/browse/SR-7879) / rdar://problem/40735990

- **Risk**: Low. This is a targeted hack with very little chance of affecting anything else, and it should not make things worse either.

- **Testing**: Added compiler regression tests.

- **Reviewed by**: @moiseev 