### PR TITLE
When loading Obj-C methods via a selector and the method is an accessor, import the property as well.

### DIFF
--- a/lib/ClangImporter/ClangImporter.cpp
+++ b/lib/ClangImporter/ClangImporter.cpp
@@ -2769,6 +2769,11 @@ void ClangImporter::loadObjCMethods(
     if (objcMethod->getClassInterface() != objcClass)
       continue;
 
+    // If we found a property accessor, import the property.
+    if (objcMethod->isPropertyAccessor())
+      (void)Impl.importDecl(objcMethod->findPropertyDecl(true),
+                            Impl.CurrentVersion);
+
     if (auto method = dyn_cast_or_null<AbstractFunctionDecl>(
                         Impl.importDecl(objcMethod, Impl.CurrentVersion))) {
       foundMethods.push_back(method);


### PR DESCRIPTION
When loading Obj-C methods via a selector and the method is an accessor, import the property as well. This fixes a failing test in LLDB, <https://github.com/apple/swift-lldb/pull/681>.