### PR TITLE
[master-next] Use new llvm::sys::procid_t type from LLVM r334294

### DIFF
--- a/include/swift/Basic/TaskQueue.h
+++ b/include/swift/Basic/TaskQueue.h
@@ -33,7 +33,7 @@ namespace sys {
 
 class Task; // forward declared to allow for platform-specific implementations
 
-using ProcessId = llvm::sys::ProcessInfo::ProcessId;
+using ProcessId = llvm::sys::procid_t;
 
 /// \brief Indicates how a TaskQueue should respond to the task finished event.
 enum class TaskFinishedResponse {

--- a/include/swift/Driver/Job.h
+++ b/include/swift/Driver/Job.h
@@ -338,7 +338,7 @@ public:
   /// contained within this Job; if this job is not a BatchJob, just pass \c
   /// this and the provided \p OSPid back to the Callback.
   virtual void forEachContainedJobAndPID(
-      llvm::sys::ProcessInfo::ProcessId OSPid,
+      llvm::sys::procid_t OSPid,
       llvm::function_ref<void(const Job *, Job::PID)> Callback) const {
     Callback(this, static_cast<Job::PID>(OSPid));
   }
@@ -383,7 +383,7 @@ public:
   /// Call the provided callback for each Job in the batch, passing the
   /// corresponding quasi-PID with each Job.
   void forEachContainedJobAndPID(
-      llvm::sys::ProcessInfo::ProcessId OSPid,
+      llvm::sys::procid_t OSPid,
       llvm::function_ref<void(const Job *, Job::PID)> Callback) const override {
     Job::PID QPid = QuasiPIDBase;
     assert(QPid < 0);


### PR DESCRIPTION
Use llvm::sys::procid_t instead of llvm::sys::ProcessInfo::ProcessId.
Patch by Jason Molenda
rdar://problem/41025619