### PR TITLE
[master-next] Adjust for VersionTuple moving from clang to llvm.

### DIFF
--- a/include/swift/AST/Attr.h
+++ b/include/swift/AST/Attr.h
@@ -37,7 +37,7 @@
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/TrailingObjects.h"
-#include "clang/Basic/VersionTuple.h"
+#include "llvm/Support/VersionTuple.h"
 
 namespace swift {
 class ASTPrinter;
@@ -616,16 +616,16 @@ enum class PlatformAgnosticAvailabilityKind {
 class AvailableAttr : public DeclAttribute {
 public:
 #define INIT_VER_TUPLE(X)\
-  X(X.empty() ? Optional<clang::VersionTuple>() : X)
+  X(X.empty() ? Optional<llvm::VersionTuple>() : X)
 
   AvailableAttr(SourceLoc AtLoc, SourceRange Range,
                    PlatformKind Platform,
                    StringRef Message, StringRef Rename,
-                   const clang::VersionTuple &Introduced,
+                   const llvm::VersionTuple &Introduced,
                    SourceRange IntroducedRange,
-                   const clang::VersionTuple &Deprecated,
+                   const llvm::VersionTuple &Deprecated,
                    SourceRange DeprecatedRange,
-                   const clang::VersionTuple &Obsoleted,
+                   const llvm::VersionTuple &Obsoleted,
                    SourceRange ObsoletedRange,
                    PlatformAgnosticAvailabilityKind PlatformAgnostic,
                    bool Implicit)
@@ -652,19 +652,19 @@ public:
   const StringRef Rename;
 
   /// Indicates when the symbol was introduced.
-  const Optional<clang::VersionTuple> Introduced;
+  const Optional<llvm::VersionTuple> Introduced;
 
   /// Indicates where the Introduced version was specified.
   const SourceRange IntroducedRange;
 
   /// Indicates when the symbol was deprecated.
-  const Optional<clang::VersionTuple> Deprecated;
+  const Optional<llvm::VersionTuple> Deprecated;
 
   /// Indicates where the Deprecated version was specified.
   const SourceRange DeprecatedRange;
 
   /// Indicates when the symbol was obsoleted.
-  const Optional<clang::VersionTuple> Obsoleted;
+  const Optional<llvm::VersionTuple> Obsoleted;
 
   /// Indicates where the Obsoleted version was specified.
   const SourceRange ObsoletedRange;
@@ -725,8 +725,8 @@ public:
   createPlatformAgnostic(ASTContext &C, StringRef Message, StringRef Rename = "",
                       PlatformAgnosticAvailabilityKind Reason
                          = PlatformAgnosticAvailabilityKind::Unavailable,
-                         clang::VersionTuple Obsoleted
-                         = clang::VersionTuple());
+                         llvm::VersionTuple Obsoleted
+                         = llvm::VersionTuple());
 
   static bool classof(const DeclAttribute *DA) {
     return DA->getKind() == DAK_Available;

--- a/include/swift/AST/Availability.h
+++ b/include/swift/AST/Availability.h
@@ -19,8 +19,8 @@
 
 #include "swift/AST/Type.h"
 #include "swift/Basic/LLVM.h"
-#include "clang/Basic/VersionTuple.h"
 #include "llvm/ADT/Optional.h"
+#include "llvm/Support/VersionTuple.h"
 
 namespace swift {
 class ASTContext;
@@ -43,7 +43,7 @@ class VersionRange {
   // a single version tuple value representing the lower end point x.y.z of a
   // range [x.y.z, +Inf).
   union {
-    clang::VersionTuple LowerEndpoint;
+    llvm::VersionTuple LowerEndpoint;
     ExtremalRange ExtremalValue;
   };
   
@@ -65,7 +65,7 @@ public:
   bool hasLowerEndpoint() const { return HasLowerEndpoint; }
 
   /// Returns the range's lower endpoint.
-  const clang::VersionTuple &getLowerEndpoint() const {
+  const llvm::VersionTuple &getLowerEndpoint() const {
     assert(HasLowerEndpoint);
     return LowerEndpoint;
   }
@@ -110,7 +110,7 @@ public:
     }
 
     // The g.l.b of [v1, +Inf), [v2, +Inf) is [max(v1,v2), +Inf)
-    const clang::VersionTuple maxVersion =
+    const llvm::VersionTuple maxVersion =
         std::max(this->getLowerEndpoint(), Other.getLowerEndpoint());
 
     setLowerEndpoint(maxVersion);
@@ -131,7 +131,7 @@ public:
     }
 
     // The l.u.b of [v1, +Inf), [v2, +Inf) is [min(v1,v2), +Inf)
-    const clang::VersionTuple minVersion =
+    const llvm::VersionTuple minVersion =
         std::min(this->getLowerEndpoint(), Other.getLowerEndpoint());
 
     setLowerEndpoint(minVersion);
@@ -156,12 +156,12 @@ public:
 
   /// Returns a version range representing all versions greater than or equal
   /// to the passed-in version.
-  static VersionRange allGTE(const clang::VersionTuple &EndPoint) {
+  static VersionRange allGTE(const llvm::VersionTuple &EndPoint) {
     return VersionRange(EndPoint);
   }
 
 private:
-  VersionRange(const clang::VersionTuple &LowerEndpoint) {
+  VersionRange(const llvm::VersionTuple &LowerEndpoint) {
     setLowerEndpoint(LowerEndpoint);
   }
 
@@ -174,7 +174,7 @@ private:
     ExtremalValue = Version;
   }
 
-  void setLowerEndpoint(const clang::VersionTuple &Version) {
+  void setLowerEndpoint(const llvm::VersionTuple &Version) {
     HasLowerEndpoint = 1;
     LowerEndpoint = Version;
   }

--- a/include/swift/AST/AvailabilitySpec.h
+++ b/include/swift/AST/AvailabilitySpec.h
@@ -20,7 +20,7 @@
 #include "swift/AST/Identifier.h"
 #include "swift/Basic/SourceLoc.h"
 #include "swift/AST/PlatformKind.h"
-#include "clang/Basic/VersionTuple.h"
+#include "llvm/Support/VersionTuple.h"
 
 namespace swift {
 class ASTContext;
@@ -64,13 +64,13 @@ class PlatformVersionConstraintAvailabilitySpec : public AvailabilitySpec {
   PlatformKind Platform;
   SourceLoc PlatformLoc;
 
-  clang::VersionTuple Version;
+  llvm::VersionTuple Version;
   SourceRange VersionSrcRange;
 
 public:
   PlatformVersionConstraintAvailabilitySpec(PlatformKind Platform,
                                             SourceLoc PlatformLoc,
-                                            clang::VersionTuple Version,
+                                            llvm::VersionTuple Version,
                                             SourceRange VersionSrcRange)
     : AvailabilitySpec(AvailabilitySpecKind::PlatformVersionConstraint),
       Platform(Platform),
@@ -82,7 +82,7 @@ public:
   SourceLoc getPlatformLoc() const { return PlatformLoc; }
   
   // The platform version to compare against.
-  clang::VersionTuple getVersion() const { return Version; }
+  llvm::VersionTuple getVersion() const { return Version; }
   SourceRange getVersionSrcRange() const { return VersionSrcRange; }
 
   SourceRange getSourceRange() const;
@@ -105,12 +105,12 @@ public:
 class LanguageVersionConstraintAvailabilitySpec : public AvailabilitySpec {
   SourceLoc SwiftLoc;
 
-  clang::VersionTuple Version;
+  llvm::VersionTuple Version;
   SourceRange VersionSrcRange;
 
 public:
   LanguageVersionConstraintAvailabilitySpec(SourceLoc SwiftLoc,
-                                            clang::VersionTuple Version,
+                                            llvm::VersionTuple Version,
                                             SourceRange VersionSrcRange)
     : AvailabilitySpec(AvailabilitySpecKind::LanguageVersionConstraint),
       SwiftLoc(SwiftLoc), Version(Version),
@@ -119,7 +119,7 @@ public:
   SourceLoc getSwiftLoc() const { return SwiftLoc; }
 
   // The platform version to compare against.
-  clang::VersionTuple getVersion() const { return Version; }
+  llvm::VersionTuple getVersion() const { return Version; }
   SourceRange getVersionSrcRange() const { return VersionSrcRange; }
 
   SourceRange getSourceRange() const;

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -109,7 +109,7 @@ namespace swift {
       StaticSpellingKind StaticSpellingKindVal;
       DescriptiveDeclKind DescriptiveDeclKindVal;
       const DeclAttribute *DeclAttributeVal;
-      clang::VersionTuple VersionVal;
+      llvm::VersionTuple VersionVal;
       LayoutConstraint LayoutConstraintVal;
     };
     
@@ -181,7 +181,7 @@ namespace swift {
         : Kind(DiagnosticArgumentKind::DeclAttribute),
           DeclAttributeVal(attr) {}
 
-    DiagnosticArgument(clang::VersionTuple version)
+    DiagnosticArgument(llvm::VersionTuple version)
       : Kind(DiagnosticArgumentKind::VersionTuple),
         VersionVal(version) { }
 
@@ -264,7 +264,7 @@ namespace swift {
       return DeclAttributeVal;
     }
 
-    clang::VersionTuple getAsVersionTuple() const {
+    llvm::VersionTuple getAsVersionTuple() const {
       assert(Kind == DiagnosticArgumentKind::VersionTuple);
       return VersionVal;
     }

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1493,7 +1493,7 @@ ERROR(protocol_has_missing_requirements,none,
 ERROR(protocol_has_missing_requirements_versioned,none,
       "type %0 cannot conform to protocol %1 (compiled with Swift %2) because "
       "it has requirements that could not be loaded in Swift %3",
-      (Type, Type, clang::VersionTuple, clang::VersionTuple))
+      (Type, Type, llvm::VersionTuple, llvm::VersionTuple))
 ERROR(requirement_restricts_self,none,
       "%0 requirement %1 cannot add constraint '%2%select{:|:| ==|:}3 %4' on "
       "'Self'",
@@ -2081,7 +2081,7 @@ ERROR(inheritance_from_class_with_missing_vtable_entries,none,
 ERROR(inheritance_from_class_with_missing_vtable_entries_versioned,none,
       "cannot inherit from class %0 (compiled with Swift %1) because it has "
       "overridable members that could not be loaded in Swift %2",
-      (Identifier, clang::VersionTuple, clang::VersionTuple))
+      (Identifier, llvm::VersionTuple, llvm::VersionTuple))
 ERROR(inheritance_from_cf_class,none,
       "cannot inherit from Core Foundation type %0", (Identifier))
 ERROR(inheritance_from_objc_runtime_visible_class,none,
@@ -3713,21 +3713,21 @@ NOTE(availability_marked_unavailable, none,
 
 NOTE(availability_introduced_in_swift, none,
      "%select{getter for |setter for |}0%1 was introduced in Swift %2",
-     (unsigned, DeclName, clang::VersionTuple))
+     (unsigned, DeclName, llvm::VersionTuple))
 
 NOTE(availability_obsoleted, none,
      "%select{getter for |setter for |}0%1 was obsoleted in %2 %3",
-     (unsigned, DeclName, StringRef, clang::VersionTuple))
+     (unsigned, DeclName, StringRef, llvm::VersionTuple))
 
 WARNING(availability_deprecated, none,
         "%select{getter for |setter for |}0%1 %select{is|%select{is|was}4}2 "
         "deprecated%select{| %select{on|in}4 %3%select{| %5}4}2",
-        (unsigned, DeclName, bool, StringRef, bool, clang::VersionTuple))
+        (unsigned, DeclName, bool, StringRef, bool, llvm::VersionTuple))
 
 WARNING(availability_deprecated_msg, none,
         "%select{getter for |setter for |}0%1 %select{is|%select{is|was}4}2 "
         "deprecated%select{| %select{on|in}4 %3%select{| %5}4}2: %6",
-        (unsigned, DeclName, bool, StringRef, bool, clang::VersionTuple,
+        (unsigned, DeclName, bool, StringRef, bool, llvm::VersionTuple,
          StringRef))
 
 WARNING(availability_deprecated_rename, none,
@@ -3735,7 +3735,7 @@ WARNING(availability_deprecated_rename, none,
         "deprecated%select{| %select{on|in}4 %3%select{| %5}4}2: "
         "%select{renamed to|replaced by}6%" REPLACEMENT_DECL_KIND_SELECT "7 "
         "'%8'",
-        (unsigned, DeclName, bool, StringRef, bool, clang::VersionTuple, bool,
+        (unsigned, DeclName, bool, StringRef, bool, llvm::VersionTuple, bool,
          unsigned, StringRef))
 #undef REPLACEMENT_DECL_KIND_SELECT
 
@@ -3750,7 +3750,7 @@ NOTE(availability_decl_more_than_enclosing_enclosing_here, none,
 
 ERROR(availability_decl_only_version_newer, none,
       "%0 is only available on %1 %2 or newer",
-      (DeclName, StringRef, clang::VersionTuple))
+      (DeclName, StringRef, llvm::VersionTuple))
 
 NOTE(availability_guard_with_version_check, none,
      "add 'if #available' version check", ())
@@ -3761,12 +3761,12 @@ NOTE(availability_add_attribute, none,
 ERROR(availability_accessor_only_version_newer, none,
       "%select{getter|setter}0 for %1 is only available on %2 %3"
       " or newer",
-      (/*AccessorKind*/unsigned, DeclName, StringRef, clang::VersionTuple))
+      (/*AccessorKind*/unsigned, DeclName, StringRef, llvm::VersionTuple))
 
 ERROR(availability_inout_accessor_only_version_newer, none,
       "cannot pass as inout because %select{getter|setter}0 for %1 is only "
       "available on %2 %3 or newer",
-      (/*AccessorKind*/unsigned, DeclName, StringRef, clang::VersionTuple))
+      (/*AccessorKind*/unsigned, DeclName, StringRef, llvm::VersionTuple))
 
 ERROR(availability_query_required_for_platform, none,
       "condition required for target platform '%0'", (StringRef))
@@ -3788,7 +3788,7 @@ ERROR(availability_stored_property_no_potential,
 
 ERROR(availability_protocol_requires_version,
       none, "protocol %0 requires %1 to be available on %2 %3 and newer",
-      (DeclName, DeclName, StringRef, clang::VersionTuple))
+      (DeclName, DeclName, StringRef, llvm::VersionTuple))
 
 NOTE(availability_protocol_requirement_here, none,
      "protocol requirement here", ())

--- a/include/swift/AST/TypeRefinementContext.h
+++ b/include/swift/AST/TypeRefinementContext.h
@@ -233,7 +233,7 @@ public:
   SourceRange
   getAvailabilityConditionVersionSourceRange(
       PlatformKind Platform,
-      const clang::VersionTuple &Version) const;
+      const llvm::VersionTuple &Version) const;
 
   /// Returns the source range on which this context refines types.
   SourceRange getSourceRange() const { return SrcRange; }

--- a/include/swift/Basic/LangOptions.h
+++ b/include/swift/Basic/LangOptions.h
@@ -21,7 +21,6 @@
 #include "swift/Config.h"
 #include "swift/Basic/LLVM.h"
 #include "swift/Basic/Version.h"
-#include "clang/Basic/VersionTuple.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Hashing.h"
 #include "llvm/ADT/SmallVector.h"
@@ -30,6 +29,7 @@
 #include "llvm/ADT/Triple.h"
 #include "llvm/Support/Regex.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/VersionTuple.h"
 #include <string>
 #include <vector>
 
@@ -277,7 +277,7 @@ namespace swift {
     ///
     /// This is only implemented on certain OSs. If no target has been
     /// configured, returns v0.0.0.
-    clang::VersionTuple getMinPlatformVersion() const {
+    llvm::VersionTuple getMinPlatformVersion() const {
       unsigned major, minor, revision;
       if (Target.isMacOSX()) {
         Target.getMacOSXVersion(major, minor, revision);
@@ -293,7 +293,7 @@ namespace swift {
       } else {
         llvm_unreachable("Unsupported target OS");
       }
-      return clang::VersionTuple(major, minor, revision);
+      return llvm::VersionTuple(major, minor, revision);
     }
 
     /// Sets an implicit platform condition.

--- a/include/swift/Basic/Version.h
+++ b/include/swift/Basic/Version.h
@@ -24,7 +24,7 @@
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
-#include "clang/Basic/VersionTuple.h"
+#include "llvm/Support/VersionTuple.h"
 #include <string>
 
 namespace swift {
@@ -93,9 +93,9 @@ public:
     return Components.empty();
   }
 
-  /// Convert to a (maximum-4-element) clang::VersionTuple, truncating
+  /// Convert to a (maximum-4-element) llvm::VersionTuple, truncating
   /// away any 5th component that might be in this version.
-  operator clang::VersionTuple() const;
+  operator llvm::VersionTuple() const;
 
   /// Returns the concrete version to use when \e this version is provided as
   /// an argument to -swift-version.

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -825,7 +825,7 @@ public:
 
   /// Parse a version tuple of the form x[.y[.z]]. Returns true if there was
   /// an error parsing.
-  bool parseVersionTuple(clang::VersionTuple &Version, SourceRange &Range,
+  bool parseVersionTuple(llvm::VersionTuple &Version, SourceRange &Range,
                          const Diagnostic &D);
 
   bool parseTypeAttributeList(VarDecl::Specifier &Specifier,

--- a/lib/AST/Attr.cpp
+++ b/lib/AST/Attr.cpp
@@ -89,7 +89,7 @@ bool DeclAttribute::canAttributeAppearOnDeclKind(DeclAttrKind DAK, DeclKind DK) 
 bool
 DeclAttributes::isUnavailableInSwiftVersion(
   const version::Version &effectiveVersion) const {
-  clang::VersionTuple vers = effectiveVersion;
+  llvm::VersionTuple vers = effectiveVersion;
   for (auto attr : *this) {
     if (auto available = dyn_cast<AvailableAttr>(attr)) {
       if (available->isInvalid())
@@ -158,11 +158,11 @@ DeclAttributes::getDeprecated(const ASTContext &ctx) const {
       if (AvAttr->isUnconditionallyDeprecated())
         return AvAttr;
 
-      Optional<clang::VersionTuple> DeprecatedVersion = AvAttr->Deprecated;
+      Optional<llvm::VersionTuple> DeprecatedVersion = AvAttr->Deprecated;
       if (!DeprecatedVersion.hasValue())
         continue;
 
-      clang::VersionTuple MinVersion =
+      llvm::VersionTuple MinVersion =
         AvAttr->isLanguageVersionSpecific() ?
         ctx.LangOpts.EffectiveLanguageVersion :
         ctx.LangOpts.getMinPlatformVersion();
@@ -761,9 +761,9 @@ AvailableAttr::createPlatformAgnostic(ASTContext &C,
                                    StringRef Message,
                                    StringRef Rename,
                                    PlatformAgnosticAvailabilityKind Kind,
-                                   clang::VersionTuple Obsoleted) {
+                                   llvm::VersionTuple Obsoleted) {
   assert(Kind != PlatformAgnosticAvailabilityKind::None);
-  clang::VersionTuple NoVersion;
+  llvm::VersionTuple NoVersion;
   if (Kind == PlatformAgnosticAvailabilityKind::SwiftVersionSpecific) {
     assert(!Obsoleted.empty());
   }
@@ -829,7 +829,7 @@ AvailableVersionComparison AvailableAttr::getVersionAvailability(
   if (isUnconditionallyUnavailable())
     return AvailableVersionComparison::Unavailable;
 
-  clang::VersionTuple queryVersion =
+  llvm::VersionTuple queryVersion =
     isLanguageVersionSpecific() ?
     ctx.LangOpts.EffectiveLanguageVersion :
     ctx.LangOpts.getMinPlatformVersion();

--- a/lib/AST/Availability.cpp
+++ b/lib/AST/Availability.cpp
@@ -32,22 +32,22 @@ struct InferredAvailability {
   PlatformAgnosticAvailabilityKind PlatformAgnostic
     = PlatformAgnosticAvailabilityKind::None;
   
-  Optional<clang::VersionTuple> Introduced;
-  Optional<clang::VersionTuple> Deprecated;
-  Optional<clang::VersionTuple> Obsoleted;
+  Optional<llvm::VersionTuple> Introduced;
+  Optional<llvm::VersionTuple> Deprecated;
+  Optional<llvm::VersionTuple> Obsoleted;
 };
 
 /// The type of a function that merges two version tuples.
-typedef const clang::VersionTuple &(*MergeFunction)(
-    const clang::VersionTuple &, const clang::VersionTuple &);
+typedef const llvm::VersionTuple &(*MergeFunction)(
+    const llvm::VersionTuple &, const llvm::VersionTuple &);
 
 } // end anonymous namespace
 
 /// Apply a merge function to two optional versions, returning the result
 /// in Inferred.
 static void
-mergeIntoInferredVersion(const Optional<clang::VersionTuple> &Version,
-                         Optional<clang::VersionTuple> &Inferred,
+mergeIntoInferredVersion(const Optional<llvm::VersionTuple> &Version,
+                         Optional<llvm::VersionTuple> &Inferred,
                          MergeFunction Merge) {
   if (Version.hasValue()) {
     if (Inferred.hasValue()) {
@@ -83,12 +83,12 @@ createAvailableAttr(PlatformKind Platform,
                        const InferredAvailability &Inferred,
                        ASTContext &Context) {
 
-  clang::VersionTuple Introduced =
-      Inferred.Introduced.getValueOr(clang::VersionTuple());
-  clang::VersionTuple Deprecated =
-      Inferred.Deprecated.getValueOr(clang::VersionTuple());
-  clang::VersionTuple Obsoleted =
-      Inferred.Obsoleted.getValueOr(clang::VersionTuple());
+  llvm::VersionTuple Introduced =
+      Inferred.Introduced.getValueOr(llvm::VersionTuple());
+  llvm::VersionTuple Deprecated =
+      Inferred.Deprecated.getValueOr(llvm::VersionTuple());
+  llvm::VersionTuple Obsoleted =
+      Inferred.Obsoleted.getValueOr(llvm::VersionTuple());
 
   return new (Context) AvailableAttr(
       SourceLoc(), SourceRange(), Platform,

--- a/lib/AST/TypeRefinementContext.cpp
+++ b/lib/AST/TypeRefinementContext.cpp
@@ -197,7 +197,7 @@ SourceLoc TypeRefinementContext::getIntroductionLoc() const {
 static SourceRange
 getAvailabilityConditionVersionSourceRange(const PoundAvailableInfo *PAI,
                                            PlatformKind Platform,
-                                           const clang::VersionTuple &Version) {
+                                           const llvm::VersionTuple &Version) {
   SourceRange Range;
   for (auto *S : PAI->getQueries()) {
     if (auto *V = dyn_cast<PlatformVersionConstraintAvailabilitySpec>(S)) {
@@ -217,7 +217,7 @@ static SourceRange
 getAvailabilityConditionVersionSourceRange(
     const MutableArrayRef<StmtConditionElement> &Conds,
     PlatformKind Platform,
-    const clang::VersionTuple &Version) {
+    const llvm::VersionTuple &Version) {
   SourceRange Range;
   for (auto const& C : Conds) {
     if (C.getKind() == StmtConditionElement::CK_Availability) {
@@ -236,7 +236,7 @@ getAvailabilityConditionVersionSourceRange(
 static SourceRange
 getAvailabilityConditionVersionSourceRange(const DeclAttributes &DeclAttrs,
                                            PlatformKind Platform,
-                                           const clang::VersionTuple &Version) {
+                                           const llvm::VersionTuple &Version) {
   SourceRange Range;
   for (auto *Attr : DeclAttrs) {
     if (auto *AA = dyn_cast<AvailableAttr>(Attr)) {
@@ -258,7 +258,7 @@ getAvailabilityConditionVersionSourceRange(const DeclAttributes &DeclAttrs,
 SourceRange
 TypeRefinementContext::getAvailabilityConditionVersionSourceRange(
     PlatformKind Platform,
-    const clang::VersionTuple &Version) const {
+    const llvm::VersionTuple &Version) const {
   switch (getReason()) {
   case Reason::Decl:
     return ::getAvailabilityConditionVersionSourceRange(

--- a/lib/Basic/Version.cpp
+++ b/lib/Basic/Version.cpp
@@ -273,23 +273,23 @@ Version::preprocessorDefinition(StringRef macroName,
   return define;
 }
 
-Version::operator clang::VersionTuple() const
+Version::operator llvm::VersionTuple() const
 {
   switch (Components.size()) {
  case 0:
-   return clang::VersionTuple();
+   return llvm::VersionTuple();
  case 1:
-   return clang::VersionTuple((unsigned)Components[0]);
+   return llvm::VersionTuple((unsigned)Components[0]);
  case 2:
-   return clang::VersionTuple((unsigned)Components[0],
+   return llvm::VersionTuple((unsigned)Components[0],
                               (unsigned)Components[1]);
  case 3:
-   return clang::VersionTuple((unsigned)Components[0],
+   return llvm::VersionTuple((unsigned)Components[0],
                               (unsigned)Components[1],
                               (unsigned)Components[2]);
  case 4:
  case 5:
-   return clang::VersionTuple((unsigned)Components[0],
+   return llvm::VersionTuple((unsigned)Components[0],
                               (unsigned)Components[1],
                               (unsigned)Components[2],
                               (unsigned)Components[3]);

--- a/lib/ClangImporter/ClangAdapter.cpp
+++ b/lib/ClangImporter/ClangAdapter.cpp
@@ -694,7 +694,7 @@ bool importer::isUnavailableInSwift(
     }
 
     if (platformAvailability.deprecatedAsUnavailableFilter) {
-      clang::VersionTuple version = attr->getDeprecated();
+      llvm::VersionTuple version = attr->getDeprecated();
       if (version.empty())
         continue;
       if (platformAvailability.deprecatedAsUnavailableFilter(

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1786,7 +1786,7 @@ static void applyAvailableAttribute(Decl *decl, AvailabilityContext &info,
   if (info.isAlwaysAvailable())
     return;
 
-  clang::VersionTuple noVersion;
+  llvm::VersionTuple noVersion;
   auto AvAttr = new (C) AvailableAttr(SourceLoc(), SourceRange(),
                                       targetPlatform(C.LangOpts),
                                       /*Message=*/StringRef(),
@@ -2340,10 +2340,10 @@ namespace {
           // However, a Swift 4 name is obsoleted in Swift 4.2.
           // FIXME: it would be better to have a unified place
           // to represent Swift versions for API versioning.
-          clang::VersionTuple obsoletedVersion =
+          llvm::VersionTuple obsoletedVersion =
             (majorVersion == 4 && minorVersion < 2)
-                ? clang::VersionTuple(4, 2)
-                : clang::VersionTuple(majorVersion + 1);
+                ? llvm::VersionTuple(4, 2)
+                : llvm::VersionTuple(majorVersion + 1);
           attr = AvailableAttr::createPlatformAgnostic(
               ctx, /*Message*/StringRef(), ctx.AllocateCopy(renamed.str()),
               PlatformAgnosticAvailabilityKind::SwiftVersionSpecific,
@@ -2351,16 +2351,16 @@ namespace {
         } else {
           // Future names are introduced in their future version.
           assert(getVersion() > getActiveSwiftVersion());
-          clang::VersionTuple introducedVersion =
+          llvm::VersionTuple introducedVersion =
             (majorVersion == 4 && minorVersion == 2)
-                ? clang::VersionTuple(4, 2)
-                : clang::VersionTuple(majorVersion);
+                ? llvm::VersionTuple(4, 2)
+                : llvm::VersionTuple(majorVersion);
           attr = new (ctx) AvailableAttr(
               SourceLoc(), SourceRange(), PlatformKind::none,
               /*Message*/StringRef(), ctx.AllocateCopy(renamed.str()),
               /*Introduced*/introducedVersion, SourceRange(),
-              /*Deprecated*/clang::VersionTuple(), SourceRange(),
-              /*Obsoleted*/clang::VersionTuple(), SourceRange(),
+              /*Deprecated*/llvm::VersionTuple(), SourceRange(),
+              /*Obsoleted*/llvm::VersionTuple(), SourceRange(),
               PlatformAgnosticAvailabilityKind::SwiftVersionSpecific,
               /*Implicit*/false);
         }
@@ -4215,7 +4215,7 @@ namespace {
 
     /// Returns the latest "introduced" version on the current platform for
     /// \p D.
-    clang::VersionTuple findLatestIntroduction(const clang::Decl *D);
+    llvm::VersionTuple findLatestIntroduction(const clang::Decl *D);
 
     /// Returns true if importing \p objcMethod will produce a "better"
     /// initializer than \p existingCtor.
@@ -6020,13 +6020,13 @@ ConstructorDecl *SwiftDeclConverter::importConstructor(
 
 /// Returns the latest "introduced" version on the current platform for
 /// \p D.
-clang::VersionTuple
+llvm::VersionTuple
 SwiftDeclConverter::findLatestIntroduction(const clang::Decl *D) {
-  clang::VersionTuple result;
+  llvm::VersionTuple result;
 
   for (auto *attr : D->specific_attrs<clang::AvailabilityAttr>()) {
     if (attr->getPlatform()->getName() == "swift") {
-      clang::VersionTuple maxVersion{~0U, ~0U, ~0U};
+      llvm::VersionTuple maxVersion{~0U, ~0U, ~0U};
       return maxVersion;
     }
 
@@ -6081,7 +6081,7 @@ bool SwiftDeclConverter::existingConstructorIsWorse(
   // was introduced first.
   // FIXME: But if one of them is now deprecated, should we prefer the
   // other?
-  clang::VersionTuple introduced = findLatestIntroduction(objcMethod);
+  llvm::VersionTuple introduced = findLatestIntroduction(objcMethod);
   AvailabilityContext existingAvailability =
       AvailabilityInference::availableRange(existingCtor, Impl.SwiftContext);
   assert(!existingAvailability.isKnownUnreachable());
@@ -7470,7 +7470,7 @@ void ClangImporter::Implementation::importAttributes(
 
       StringRef message = avail->getMessage();
 
-      clang::VersionTuple deprecated = avail->getDeprecated();
+      llvm::VersionTuple deprecated = avail->getDeprecated();
 
       if (!deprecated.empty()) {
         if (platformAvailability.deprecatedAsUnavailableFilter &&
@@ -7483,8 +7483,8 @@ void ClangImporter::Implementation::importAttributes(
         }
       }
 
-      clang::VersionTuple obsoleted = avail->getObsoleted();
-      clang::VersionTuple introduced = avail->getIntroduced();
+      llvm::VersionTuple obsoleted = avail->getObsoleted();
+      llvm::VersionTuple introduced = avail->getIntroduced();
 
       const auto &replacement = avail->getReplacement();
 

--- a/lib/ClangImporter/ImportEnumInfo.cpp
+++ b/lib/ClangImporter/ImportEnumInfo.cpp
@@ -282,7 +282,7 @@ void EnumInfo::determineConstantNamePrefix(const clang::EnumDecl *decl) {
     if (elem->hasAttr<clang::SwiftNameAttr>())
       return false;
 
-    clang::VersionTuple maxVersion{~0U, ~0U, ~0U};
+    llvm::VersionTuple maxVersion{~0U, ~0U, ~0U};
     switch (elem->getAvailability(nullptr, maxVersion)) {
     case clang::AR_Available:
     case clang::AR_NotYetIntroduced:

--- a/lib/ClangImporter/ImportName.cpp
+++ b/lib/ClangImporter/ImportName.cpp
@@ -552,7 +552,7 @@ namespace {
 /// For a SwiftVersionedRemovalAttr, the Attr member will be null.
 struct VersionedSwiftNameInfo {
   const clang::SwiftNameAttr *Attr;
-  clang::VersionTuple Version;
+  llvm::VersionTuple Version;
   bool IsReplacedByActive;
 };
 
@@ -573,7 +573,7 @@ enum class VersionedSwiftNameAction {
 
 static VersionedSwiftNameAction
 checkVersionedSwiftName(VersionedSwiftNameInfo info,
-                        clang::VersionTuple bestSoFar,
+                        llvm::VersionTuple bestSoFar,
                         ImportNameVersion requestedVersion) {
   if (!bestSoFar.empty() && bestSoFar <= info.Version)
     return VersionedSwiftNameAction::Ignore;
@@ -624,7 +624,7 @@ findSwiftNameAttr(const clang::Decl *decl, ImportNameVersion version) {
 
     const auto *activeAttr = decl->getAttr<clang::SwiftNameAttr>();
     const clang::SwiftNameAttr *result = activeAttr;
-    clang::VersionTuple bestSoFar;
+    llvm::VersionTuple bestSoFar;
     for (auto *attr : decl->attrs()) {
       VersionedSwiftNameInfo info;
 

--- a/lib/ClangImporter/ImportName.h
+++ b/lib/ClangImporter/ImportName.h
@@ -82,9 +82,9 @@ public:
     return 0;
   }
 
-  clang::VersionTuple asClangVersionTuple() const {
+  llvm::VersionTuple asClangVersionTuple() const {
     assert(*this != ImportNameVersion::raw());
-    return clang::VersionTuple(majorVersionNumber(), minorVersionNumber());    
+    return llvm::VersionTuple(majorVersionNumber(), minorVersionNumber());
   }
 
   bool operator==(ImportNameVersion other) const {

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1165,7 +1165,7 @@ static void diagnoseOutputModeArg(DiagnosticEngine &diags, const Arg *arg,
   }
 }
 
-static bool isSDKTooOld(StringRef sdkPath, clang::VersionTuple minVersion,
+static bool isSDKTooOld(StringRef sdkPath, llvm::VersionTuple minVersion,
                         StringRef firstPrefix, StringRef secondPrefix = {}) {
   // FIXME: This is a hack.
   // We should be looking at the SDKSettings.plist.
@@ -1188,7 +1188,7 @@ static bool isSDKTooOld(StringRef sdkPath, clang::VersionTuple minVersion,
   if (versionEnd == StringRef::npos)
     return false;
 
-  clang::VersionTuple version;
+  llvm::VersionTuple version;
   if (version.tryParse(sdkDirName.slice(versionStart, versionEnd)))
     return false;
   return version < minVersion;
@@ -1198,14 +1198,14 @@ static bool isSDKTooOld(StringRef sdkPath, clang::VersionTuple minVersion,
 /// the given target.
 static bool isSDKTooOld(StringRef sdkPath, const llvm::Triple &target) {
   if (target.isMacOSX()) {
-    return isSDKTooOld(sdkPath, clang::VersionTuple(10, 14), "OSX");
+    return isSDKTooOld(sdkPath, llvm::VersionTuple(10, 14), "OSX");
 
   } else if (target.isiOS()) {
     // Includes both iOS and TVOS.
-    return isSDKTooOld(sdkPath, clang::VersionTuple(12, 0), "Simulator", "OS");
+    return isSDKTooOld(sdkPath, llvm::VersionTuple(12, 0), "Simulator", "OS");
 
   } else if (target.isWatchOS()) {
-    return isSDKTooOld(sdkPath, clang::VersionTuple(5, 0), "Simulator", "OS");
+    return isSDKTooOld(sdkPath, llvm::VersionTuple(5, 0), "Simulator", "OS");
 
   } else {
     return false;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -318,7 +318,7 @@ ParserResult<AvailableAttr> Parser::parseExtendedAvailabilitySpecList(
   StringRef Platform = Tok.getText();
 
   StringRef Message, Renamed;
-  clang::VersionTuple Introduced, Deprecated, Obsoleted;
+  llvm::VersionTuple Introduced, Deprecated, Obsoleted;
   SourceRange IntroducedRange, DeprecatedRange, ObsoletedRange;
   auto PlatformAgnostic = PlatformAgnosticAvailabilityKind::None;
 
@@ -1286,7 +1286,7 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
 
       for (auto *Spec : Specs) {
         PlatformKind Platform;
-        clang::VersionTuple Version;
+        llvm::VersionTuple Version;
         SourceRange VersionRange;
         PlatformAgnosticAvailabilityKind PlatformAgnostic;
 
@@ -1316,9 +1316,9 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
                                      /*Rename=*/StringRef(),
                                      /*Introduced=*/Version,
                                      /*IntroducedRange=*/VersionRange,
-                                     /*Deprecated=*/clang::VersionTuple(),
+                                     /*Deprecated=*/llvm::VersionTuple(),
                                      /*DeprecatedRange=*/SourceRange(),
-                                     /*Obsoleted=*/clang::VersionTuple(),
+                                     /*Obsoleted=*/llvm::VersionTuple(),
                                      /*ObsoletedRange=*/SourceRange(),
                                      PlatformAgnostic,
                                      /*Implicit=*/false));
@@ -1438,7 +1438,7 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
   return false;
 }
 
-bool Parser::parseVersionTuple(clang::VersionTuple &Version,
+bool Parser::parseVersionTuple(llvm::VersionTuple &Version,
                                SourceRange &Range,
                                const Diagnostic &D) {
   SyntaxParsingContext VersionContext(SyntaxContext, SyntaxKind::VersionTuple);
@@ -1459,7 +1459,7 @@ bool Parser::parseVersionTuple(clang::VersionTuple &Version,
       consumeToken();
       return true;
     }
-    Version = clang::VersionTuple(major);
+    Version = llvm::VersionTuple(major);
     Range = SourceRange(StartLoc, Tok.getLoc());
     consumeToken();
     return false;
@@ -1493,9 +1493,9 @@ bool Parser::parseVersionTuple(clang::VersionTuple &Version,
     Range = SourceRange(StartLoc, Tok.getLoc());
     consumeToken();
     
-    Version = clang::VersionTuple(major, minor, micro);
+    Version = llvm::VersionTuple(major, minor, micro);
   } else {
-    Version = clang::VersionTuple(major, minor);
+    Version = llvm::VersionTuple(major, minor);
   }
 
   return false;

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3468,7 +3468,7 @@ Parser::parseLanguageVersionConstraintSpec() {
   SyntaxParsingContext VersionRestrictionContext(
       SyntaxContext, SyntaxKind::AvailabilityVersionRestriction);
   SourceLoc SwiftLoc;
-  clang::VersionTuple Version;
+  llvm::VersionTuple Version;
   SourceRange VersionRange;
   if (!(Tok.isIdentifierOrUnderscore() && Tok.getText() == "swift"))
     return nullptr;
@@ -3514,7 +3514,7 @@ Parser::parsePlatformVersionConstraintSpec() {
     consumeToken();
   }
 
-  clang::VersionTuple Version;
+  llvm::VersionTuple Version;
   SourceRange VersionRange;
 
   if (parseVersionTuple(Version, VersionRange,

--- a/lib/SILGen/SILGenDecl.cpp
+++ b/lib/SILGen/SILGenDecl.cpp
@@ -1172,7 +1172,7 @@ void SILGenFunction::visitVarDecl(VarDecl *D) {
 SILValue SILGenFunction::emitOSVersionRangeCheck(SILLocation loc,
                                                  const VersionRange &range) {
   // Emit constants for the checked version range.
-  clang::VersionTuple Vers = range.getLowerEndpoint();
+  llvm::VersionTuple Vers = range.getLowerEndpoint();
   unsigned major = Vers.getMajor();
   unsigned minor =
       (Vers.getMinor().hasValue() ? Vers.getMinor().getValue() : 0);

--- a/lib/Sema/TypeCheckAvailability.cpp
+++ b/lib/Sema/TypeCheckAvailability.cpp
@@ -1961,7 +1961,7 @@ void TypeChecker::diagnoseIfDeprecated(SourceRange ReferenceRange,
       getAccessorKindAndNameForDiagnostics(DeprecatedDecl);
 
   StringRef Platform = Attr->prettyPlatformString();
-  clang::VersionTuple DeprecatedVersion;
+  llvm::VersionTuple DeprecatedVersion;
   if (Attr->Deprecated)
     DeprecatedVersion = Attr->Deprecated.getValue();
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -1029,8 +1029,8 @@ static void checkRedeclaration(TypeChecker &tc, ValueDecl *current) {
 
       if (isAcceptableVersionBasedChange) {
         class AvailabilityRange {
-          Optional<clang::VersionTuple> introduced;
-          Optional<clang::VersionTuple> obsoleted;
+          Optional<llvm::VersionTuple> introduced;
+          Optional<llvm::VersionTuple> obsoleted;
 
         public:
           static AvailabilityRange from(const ValueDecl *VD) {

--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -2462,11 +2462,11 @@ ModuleFile::getDeclCheckedImpl(DeclID DID, Optional<DeclContext *> ForcedContext
 #define DECODE_VER_TUPLE(X)\
   if (X##_HasMinor) {\
     if (X##_HasSubminor)\
-      X = clang::VersionTuple(X##_Major, X##_Minor, X##_Subminor);\
+      X = llvm::VersionTuple(X##_Major, X##_Minor, X##_Subminor);\
     else\
-      X = clang::VersionTuple(X##_Major, X##_Minor);\
+      X = llvm::VersionTuple(X##_Major, X##_Minor);\
     }\
-  else X = clang::VersionTuple(X##_Major);
+  else X = llvm::VersionTuple(X##_Major);
 
         bool isImplicit;
         bool isUnavailable;
@@ -2486,7 +2486,7 @@ ModuleFile::getDeclCheckedImpl(DeclID DID, Optional<DeclContext *> ForcedContext
         StringRef message = blobData.substr(0, messageSize);
         blobData = blobData.substr(messageSize);
         StringRef rename = blobData.substr(0, renameSize);
-        clang::VersionTuple Introduced, Deprecated, Obsoleted;
+        llvm::VersionTuple Introduced, Deprecated, Obsoleted;
         DECODE_VER_TUPLE(Introduced)
         DECODE_VER_TUPLE(Deprecated)
         DECODE_VER_TUPLE(Obsoleted)

--- a/tools/SourceKit/include/SourceKit/Core/LangSupport.h
+++ b/tools/SourceKit/include/SourceKit/Core/LangSupport.h
@@ -15,7 +15,7 @@
 
 #include "SourceKit/Core/LLVM.h"
 #include "SourceKit/Support/UIdent.h"
-#include "clang/Basic/VersionTuple.h"
+#include "llvm/Support/VersionTuple.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/Optional.h"
 #include "llvm/ADT/SmallString.h"
@@ -383,9 +383,9 @@ struct AvailableAttrInfo {
   bool IsDeprecated = false;
   UIdent Platform;
   llvm::SmallString<32> Message;
-  llvm::Optional<clang::VersionTuple> Introduced;
-  llvm::Optional<clang::VersionTuple> Deprecated;
-  llvm::Optional<clang::VersionTuple> Obsoleted;
+  llvm::Optional<llvm::VersionTuple> Introduced;
+  llvm::Optional<llvm::VersionTuple> Deprecated;
+  llvm::Optional<llvm::VersionTuple> Obsoleted;
 };
 
 struct NoteRegion {

--- a/unittests/AST/VersionRangeLattice.cpp
+++ b/unittests/AST/VersionRangeLattice.cpp
@@ -9,10 +9,10 @@ public:
   VersionRange All = VersionRange::all();
 
   VersionRange GreaterThanEqual10_10 =
-      VersionRange::allGTE(clang::VersionTuple(10, 10));
+      VersionRange::allGTE(llvm::VersionTuple(10, 10));
 
   VersionRange GreaterThanEqual10_9 =
-      VersionRange::allGTE(clang::VersionTuple(10, 9));
+      VersionRange::allGTE(llvm::VersionTuple(10, 9));
 
   VersionRange Empty = VersionRange::empty();
 


### PR DESCRIPTION
LLVM r334399 (and related Clang changes) moved clang::VersionTuple to
llvm::VersionTuple. Update Swift to match.

Patch by Jason Molenda.
rdar://problem/41025046