### PR TITLE
[4.2] [ConstraintSystem] Allow LValues for the bindings of an IUO @optional…

### DIFF
--- a/lib/Sema/ConstraintSystem.cpp
+++ b/lib/Sema/ConstraintSystem.cpp
@@ -1726,7 +1726,7 @@ void ConstraintSystem::resolveOverload(ConstraintLocator *locator,
       if (choice.isImplicitlyUnwrappedValueOrReturnValue()) {
         // Build the disjunction to attempt binding both T? and T (or
         // function returning T? and function returning T).
-        Type ty = createTypeVariable(locator);
+        Type ty = createTypeVariable(locator, TVO_CanBindToLValue);
         buildDisjunctionForImplicitlyUnwrappedOptional(ty, refType, locator);
         addConstraint(ConstraintKind::Bind, boundType,
                       OptionalType::get(ty->getRValueType()), locator);

--- a/test/Constraints/iuo_objc.swift
+++ b/test/Constraints/iuo_objc.swift
@@ -28,4 +28,14 @@ func iuo_error(prop: IUOProperty) {
   // expected-error@-1 {{cannot invoke 'optional' with no arguments}}
   let _: Coat = prop.iuo!.optional!()
   let _: Coat = prop.iuo!.optional!()!
+
+  let _ = prop.iuo.name
+}
+
+protocol X {}
+
+extension X where Self : OptionalRequirements {
+  func test() {
+    let _ = self.name
+  }
 }

--- a/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/Foundation.h
@@ -1153,11 +1153,12 @@ void takeNullableId(__nullable id);
 @interface I
 @end
 
-@protocol OptionalMethods
+@protocol OptionalRequirements
 @optional
 - (Coat *)optional;
+@property NSString *name;
 @end
 
 @interface IUOProperty
-@property (readonly) id<OptionalMethods> iuo;
+@property (readonly) id<OptionalRequirements> iuo;
 @end


### PR DESCRIPTION
*  Explanation: Uses of IUO properties that are @optional Obj-C protocol requirements fail to type check. The fix here is trivial - we need to allow the type variables we create for these to be bound to LValue types.
*  Scope: This could break any client code importing Obj-C code that has @optional properties that are not null-annotated, or are annotated such that we import them as IUOs.
*  Issue #: rdar://problem/40868990
*  Risk: Very low.
*  Testing: Standard regression tests plus source compatibility tests.
*  Reviewer: @xedin 