### PR TITLE
[Sema] Remove redundant simplification

### DIFF
--- a/lib/Sema/CSSolver.cpp
+++ b/lib/Sema/CSSolver.cpp
@@ -1417,12 +1417,6 @@ bool ConstraintSystem::solve(Expr *const expr,
   // Set up solver state.
   SolverState state(expr, *this);
 
-  // Simplify any constraints left active after constraint generation
-  // and optimization. Return if the resulting system has no
-  // solutions.
-  if (failedConstraint || simplify())
-    return true;
-
   // Solve the system.
   solveRec(solutions, allowFreeTypeVariables);
 


### PR DESCRIPTION
The call to `solveRec`, below, immediately performs this same check. While that doesn't result in an early return from `solve`, the effect appears to be the same.

This seems like it should avoid some unnecessary work.