### PR TITLE
[4.2] IRGen: More specifically curtail JIT use of relative references to the integrated REPL.

### DIFF
--- a/include/swift/AST/IRGenOptions.h
+++ b/include/swift/AST/IRGenOptions.h
@@ -103,6 +103,9 @@ public:
   /// \brief Whether we're generating IR for the JIT.
   unsigned UseJIT : 1;
   
+  /// \brief Whether we're generating code for the integrated REPL.
+  unsigned IntegratedREPL : 1;
+  
   /// \brief Whether we should run LLVM optimizations after IRGen.
   unsigned DisableLLVMOptzns : 1;
 
@@ -182,6 +185,7 @@ public:
         Verify(true), OptMode(OptimizationMode::NotSet),
         Sanitizers(OptionSet<SanitizerKind>()),
         DebugInfoKind(IRGenDebugInfoKind::None), UseJIT(false),
+        IntegratedREPL(false),
         DisableLLVMOptzns(false), DisableSwiftSpecificLLVMOptzns(false),
         DisableLLVMSLPVectorizer(false), DisableFPElim(true), Playground(false),
         EmitStackPromotionChecks(false), PrintInlineTree(false),

--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -2580,12 +2580,12 @@ IRGenModule::getAddrOfLLVMVariableOrGOTEquivalent(LinkEntity entity,
   // binary, then we ought to be able to directly relative-reference the
   // symbol. However, some platforms don't have the necessary relocations to
   // represent a relative reference to an undefined symbol, so conservatively
-  // produce an indirect reference in this case. Also, some JIT modes
-  // incrementally add new definitions that refer back to existing ones
+  // produce an indirect reference in this case. Also, the integrated REPL
+  // incrementally adds new definitions that refer back to existing ones
   // relatively, so always use indirect references in this situation.
   auto entry = GlobalVars[entity];
   if (forceIndirectness == ConstantReference::Direct &&
-      !IRGen.Opts.UseJIT &&
+      !IRGen.Opts.IntegratedREPL &&
       (!entity.isAvailableExternally(*this) || isDefinition(entry))) {
     // FIXME: Relative references to aliases break MC on 32-bit Mach-O
     // platforms (rdar://problem/22450593 ), so substitute an alias with its

--- a/lib/IRGen/IRGenMangler.cpp
+++ b/lib/IRGen/IRGenMangler.cpp
@@ -92,7 +92,7 @@ IRGenMangler::mangleTypeForReflection(IRGenModule &IGM,
   
   if (IGM.CurSourceFile
       && !isa<ClangModuleUnit>(IGM.CurSourceFile)
-      && !IGM.getOptions().UseJIT) {
+      && !IGM.getOptions().IntegratedREPL) {
     CanSymbolicReference = [&](const DeclContext *dc) -> bool {
       // Symbolically reference types that are defined in the same file unit
       // as we're referencing from.

--- a/lib/Immediate/REPL.cpp
+++ b/lib/Immediate/REPL.cpp
@@ -1004,6 +1004,7 @@ public:
     IRGenOpts.OptMode = OptimizationMode::NoOptimization;
     IRGenOpts.OutputKind = IRGenOutputKind::Module;
     IRGenOpts.UseJIT = true;
+    IRGenOpts.IntegratedREPL = true;
     IRGenOpts.DebugInfoKind = IRGenDebugInfoKind::None;
 
     if (!ParseStdlib) {


### PR DESCRIPTION
The other JIT modes all still build an entire local context into one LLVM module, so it's safe to form relative references, and necessary for reflection to work with private and local contexts. Only the integrated REPL needs this prohibition. Fixes rdar://problem/40607819.