### PR TITLE
[4.2] Add context pointer to swift_getFieldAt function.

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -4386,8 +4386,13 @@ const Metadata *_swift_class_getSuperclass(const Metadata *theClass);
 
 SWIFT_RUNTIME_STDLIB_INTERFACE
 void swift_getFieldAt(
-    const Metadata *type, unsigned index,
-    std::function<void(llvm::StringRef name, FieldType type)> callback);
+  const Metadata *base, unsigned index, 
+  void (*callback)(const char *name, const Metadata *type, void *ctx), void *callbackCtx);
+
+void _swift_getFieldAt(
+    const Metadata *base, unsigned index,
+    std::function<void(llvm::StringRef name, FieldType fieldInfo)>
+        callback);
 
 } // end namespace swift
 

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -1099,6 +1099,12 @@ swift_getTypeByMangledNameImpl(const char *typeNameStart, size_t typeNameLength,
 }
 
 void swift::swift_getFieldAt(
+  const Metadata *base, unsigned index, 
+  void (*callback)(const char *name, const Metadata *type, void *ctx), void *callbackCtx) {
+    swift::_swift_getFieldAt(base, index, [&] (llvm::StringRef name, FieldType fieldInfo) { callback(name.data(), fieldInfo.getType(), callbackCtx); });
+}
+
+void swift::_swift_getFieldAt(
     const Metadata *base, unsigned index,
     std::function<void(llvm::StringRef name, FieldType fieldInfo)>
         callback) {

--- a/stdlib/public/runtime/ReflectionMirror.mm
+++ b/stdlib/public/runtime/ReflectionMirror.mm
@@ -278,7 +278,7 @@ struct StructImpl : ReflectionMirrorImpl {
 
     Any result;
     
-    swift_getFieldAt(type, i, [&](llvm::StringRef name, FieldType fieldInfo) {
+    _swift_getFieldAt(type, i, [&](llvm::StringRef name, FieldType fieldInfo) {
       assert(!fieldInfo.isIndirect() && "indirect struct fields not implemented");
       
       *outName = name.data();
@@ -319,7 +319,7 @@ struct EnumImpl : ReflectionMirrorImpl {
     bool indirect = false;
     
     const char *caseName = nullptr;
-    swift_getFieldAt(type, tag, [&](llvm::StringRef name, FieldType info) {
+    _swift_getFieldAt(type, tag, [&](llvm::StringRef name, FieldType info) {
       caseName = name.data();
       payloadType = info.getType();
       indirect = info.isIndirect();
@@ -435,7 +435,7 @@ struct ClassImpl : ReflectionMirrorImpl {
 
     Any result;
     
-    swift_getFieldAt(type, i, [&](llvm::StringRef name, FieldType fieldInfo) {
+    _swift_getFieldAt(type, i, [&](llvm::StringRef name, FieldType fieldInfo) {
       assert(!fieldInfo.isIndirect() && "class indirect properties not implemented");
       
       auto *bytes = *reinterpret_cast<char * const *>(value);


### PR DESCRIPTION
Allow C code to invoke getFieldAt from outside the Swift runtime as a stopgap to a proper ABI for this.