### PR TITLE
[Diagnostics]: Rewrite "no subscript members" error

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -62,8 +62,8 @@ ERROR(ambiguous_member_overload_set,none,
 ERROR(ambiguous_subscript,none,
       "ambiguous subscript with base type %0 and index type %1",
       (Type, Type))
-ERROR(type_not_subscriptable,none,
-      "type %0 has no subscript members",
+ERROR(could_not_find_value_subscript,none,
+      "value of type %0 has no subscripts",
       (Type))
 
 ERROR(could_not_find_tuple_member,none,

--- a/lib/Sema/CSDiag.cpp
+++ b/lib/Sema/CSDiag.cpp
@@ -1382,7 +1382,7 @@ diagnoseUnviableLookupResults(MemberLookupResult &result, Type baseObjTy,
 
     // TODO: This should handle tuple member lookups, like x.1231 as well.
     if (memberName.getBaseName().getKind() == DeclBaseName::Kind::Subscript) {
-      diagnose(loc, diag::type_not_subscriptable, baseObjTy)
+      diagnose(loc, diag::could_not_find_value_subscript, baseObjTy)
         .highlight(baseRange);
     } else if (memberName.getBaseName() == "deinit") {
       // Specialised diagnostic if trying to access deinitialisers

--- a/test/ClangImporter/attr-swift_private.swift
+++ b/test/ClangImporter/attr-swift_private.swift
@@ -65,8 +65,8 @@ public func testFactoryMethods() {
 
 #if !IRGEN
 public func testSubscript(_ foo: Foo) {
-  _ = foo[foo] // expected-error {{type 'Foo' has no subscript members}}
-  _ = foo[1] // expected-error {{type 'Foo' has no subscript members}}
+  _ = foo[foo] // expected-error {{value of type 'Foo' has no subscripts}}
+  _ = foo[1] // expected-error {{value of type 'Foo' has no subscripts}}
 }
 #endif
 

--- a/test/ClangImporter/objc_parse.swift
+++ b/test/ClangImporter/objc_parse.swift
@@ -241,7 +241,7 @@ func overridingTest(_ srs: SuperRefsSub) {
 }
 
 func almostSubscriptableValueMismatch(_ as1: AlmostSubscriptable, a: A) {
-  as1[a] // expected-error{{type 'AlmostSubscriptable' has no subscript members}}
+  as1[a] // expected-error{{value of type 'AlmostSubscriptable' has no subscripts}}
 }
 
 func almostSubscriptableKeyMismatch(_ bc: BadCollection, key: NSString) {

--- a/test/Constraints/diagnostics.swift
+++ b/test/Constraints/diagnostics.swift
@@ -651,7 +651,7 @@ _ = -UnaryOp() // expected-error {{unary operator '-' cannot be applied to an op
 // <rdar://problem/23433271> Swift compiler segfault in failure diagnosis
 func f23433271(_ x : UnsafePointer<Int>) {}
 func segfault23433271(_ a : UnsafeMutableRawPointer) {
-  f23433271(a[0])  // expected-error {{type 'UnsafeMutableRawPointer' has no subscript members}}
+  f23433271(a[0])  // expected-error {{value of type 'UnsafeMutableRawPointer' has no subscripts}}
 }
 
 

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -182,7 +182,7 @@ struct MissingGetterSubscript2 {
 
 func test_subscript(_ x2: inout X2, i: Int, j: Int, value: inout Int, no: NoSubscript,
                     ovl: inout OverloadedSubscript, ret: inout RetOverloadedSubscript) {
-  no[i] = value // expected-error{{type 'NoSubscript' has no subscript members}}
+  no[i] = value // expected-error{{value of type 'NoSubscript' has no subscripts}}
 
   value = x2[i]
   x2[i] = value


### PR DESCRIPTION
• Change name to match names of member diagnostics.

• Explicitly call out that this is a "value of type". This matches the error from non-existent methods and properties.

• Don't call them "subscript members". That term is never used in documentation and "member" doesn't add anything besides confusion.

Before:

```
 error: type 'Int' has no subscript members
_ = 2[foo: 1]
    ^
```

After:

```
error: value of type 'Int' has no subscripts
_ = 2[foo: 1]
    ^
```

Similar error for a missing method, for comparison:

```
error: value of type 'Int' has no member 'foo'
_ = 2.foo(1)
    ^ ~~~
```