### PR TITLE
build: switch to CMake for XCTest

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2406,29 +2406,56 @@ for host in "${ALL_HOSTS[@]}"; do
                 FOUNDATION_BUILD_DIR=$(build_directory ${host} foundation)
                 SWIFT_BUILD_DIR=$(build_directory ${host} swift)
 
-                # Staging: require opt-in for building with dispatch
-                if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
-                    LIBDISPATCH_BUILD_DIR="$(build_directory ${host} libdispatch)"
-                    LIBDISPATCH_BUILD_ARGS="--libdispatch-src-dir=${LIBDISPATCH_SOURCE_DIR} --libdispatch-build-dir=${LIBDISPATCH_BUILD_DIR}"
-                fi
+                case "${host}" in
+                macosx-*)
+                  # Staging: require opt-in for building with dispatch
+                  if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
+                      LIBDISPATCH_BUILD_DIR="$(build_directory ${host} libdispatch)"
+                      LIBDISPATCH_BUILD_ARGS="--libdispatch-src-dir=${LIBDISPATCH_SOURCE_DIR} --libdispatch-build-dir=${LIBDISPATCH_BUILD_DIR}"
+                  fi
 
-                # Use XCTEST_BUILD_TYPE to build either --debug or --release.
-                if [[ "${XCTEST_BUILD_TYPE}" ==  "Debug" ]] ; then
-                    XCTEST_BUILD_ARGS="--debug"
-                else
-                    XCTEST_BUILD_ARGS="--release"
-                fi
+                  # Use XCTEST_BUILD_TYPE to build either --debug or --release.
+                  if [[ "${XCTEST_BUILD_TYPE}" ==  "Debug" ]] ; then
+                      XCTEST_BUILD_ARGS="--debug"
+                  else
+                      XCTEST_BUILD_ARGS="--release"
+                  fi
 
-                call "${XCTEST_SOURCE_DIR}"/build_script.py \
-                    --swiftc="${SWIFTC_BIN}" \
-                    --build-dir="${XCTEST_BUILD_DIR}" \
-                    --foundation-build-dir="${FOUNDATION_BUILD_DIR}/Foundation" \
-                    --swift-build-dir="${SWIFT_BUILD_DIR}" \
-                    $LIBDISPATCH_BUILD_ARGS \
-                    $XCTEST_BUILD_ARGS
+                  call "${XCTEST_SOURCE_DIR}"/build_script.py \
+                      --swiftc="${SWIFTC_BIN}" \
+                      --build-dir="${XCTEST_BUILD_DIR}" \
+                      --foundation-build-dir="${FOUNDATION_BUILD_DIR}/Foundation" \
+                      --swift-build-dir="${SWIFT_BUILD_DIR}" \
+                      $LIBDISPATCH_BUILD_ARGS \
+                      $XCTEST_BUILD_ARGS
 
-                # XCTest builds itself and doesn't rely on cmake
-                continue
+                  # XCTest builds itself and doesn't rely on cmake
+                  continue
+                ;;
+                *)
+                  cmake_options=(
+                    ${cmake_options[@]}
+                    -DCMAKE_BUILD_TYPE:STRING="${LIBDISPATCH_BUILD_TYPE}"
+                    -DCMAKE_C_COMPILER:PATH="${LLVM_BIN}/clang"
+                    -DCMAKE_CXX_COMPILER:PATH="${LLVM_BIN}/clang++"
+                    -DCMAKE_SWIFT_COMPILER:PATH="${SWIFTC_BIN}"
+                    -DCMAKE_INSTALL_PREFIX:PATH="$(get_host_install_prefix ${host})"
+                    -DCMAKE_INSTALL_LIBDIR:PATH="lib"
+
+                    -DXCTEST_PATH_TO_LIBDISPATCH_SOURCE:PATH=${LIBDISPATCH_SOURCE_DIR}
+                    -DXCTEST_PATH_TO_LIBDISPATCH_BUILD:PATH=${LIBDISPATCH_BUILD_DIR}
+
+                    -DXCTEST_PATH_TO_FOUNDATION_BUILD:PATH=${FOUNDATION_BUILD_DIR}
+
+                    -DXCTEST_PATH_TO_COREFOUNDATION_BUILD:PATH=${FOUNDATION_BUILD_DIR}/Foundation/CoreFoundation
+
+                    -DCMAKE_PREFIX_PATH:PATH=$(build_directory ${host} llvm)
+
+                    -DENABLE_TESTING=YES
+                  )
+                ;;
+                esac
+
                 ;;
             foundation)
                 # The configuration script requires knowing about XCTest's
@@ -3226,42 +3253,13 @@ for host in "${ALL_HOSTS[@]}"; do
                 fi
 
                 case ${host} in
-                    linux-*)
-                        LIB_TARGET="linux"
-                        ;;
-                    freebsd-*)
-                        LIB_TARGET="freebsd"
-                        ;;
-                    cygwin-*)
-                        LIB_TARGET="windows"
-                        ;;
-                    haiku-*)
-                        LIB_TARGET="haiku"
-                        ;;
-                    *)
-                        echo "error: --install-xctest is not supported on this platform"
-                        exit 1
-                        ;;
+                  linux-*|freebsd-*|cygwin-*|haiku-*) ;;
+                  *)
+                    echo "error: --install-xctest is not supported on this platform"
+                    exit 1
+                  ;;
                 esac
 
-                echo "--- Installing ${product} ---"
-                XCTEST_BUILD_DIR=$(build_directory ${host} xctest)
-                XCTEST_INSTALL_PREFIX="${host_install_destdir}${host_install_prefix}/lib/swift/${LIB_TARGET}"
-                if [ $(true_false "${BUILD_SWIFT_STATIC_STDLIB}") == "TRUE" ]; then
-                    XCTEST_STATIC_INSTALL_PREFIX="${host_install_destdir}${host_install_prefix}/lib/swift_static/${LIB_TARGET}"
-                    xctest_static_install="--static-library-install-path=${XCTEST_STATIC_INSTALL_PREFIX}"
-                else
-                    xctest_static_install=""
-                fi
-                # Note that installing directly to /usr/lib/swift usually
-                # requires root permissions.
-                call "${XCTEST_SOURCE_DIR}"/build_script.py install \
-                    --library-install-path="${XCTEST_INSTALL_PREFIX}" ${xctest_static_install} \
-                    --module-install-path="${XCTEST_INSTALL_PREFIX}"/"${SWIFT_HOST_VARIANT_ARCH}" \
-                    "${XCTEST_BUILD_DIR}"
-
-                # As XCTest installation is self-contained, we break early here.
-                continue
                 ;;
             foundation)
                 # FIXME: Foundation doesn't build from the script on OS X


### PR DESCRIPTION
Now that XCTest has a CMake build system, use that for the non-Darwin
builds.  This sets the stage for building Foundation with CMake.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
