### PR TITLE
[TypeReconstruction] Fix reconstruction for existential metatypes.

### DIFF
--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -1906,6 +1906,30 @@ static void VisitNodeInOut(
   }
 }
 
+static void VisitNodeExistentialMetatype(ASTContext *ast,
+                                         Demangle::NodePointer cur_node,
+                                         VisitNodeResult &result) {
+  VisitNodeResult type_result;
+  Optional<MetatypeRepresentation> metatype_repr;
+
+  for (auto &child : *cur_node) {
+    switch (child->getKind()) {
+    case Demangle::Node::Kind::Type:
+      VisitNode(ast, child, type_result);
+      break;
+    default:
+      break;
+    }
+  }
+
+  if (type_result.HasSingleType())
+    result._types.push_back(
+        ExistentialMetatypeType::get(type_result._types[0], metatype_repr));
+  else
+    result._error = stringWithFormat(
+        "instance type for existential metatype cannot be uniquely resolved");
+}
+
 static void VisitNodeMetatype(
     ASTContext *ast,
     Demangle::NodePointer cur_node, VisitNodeResult &result) {
@@ -2357,6 +2381,10 @@ static void VisitNode(
 
   case Demangle::Node::Kind::InOut:
     VisitNodeInOut(ast, node, result);
+    break;
+
+  case Demangle::Node::Kind::ExistentialMetatype:
+    VisitNodeExistentialMetatype(ast, node, result);
     break;
 
   case Demangle::Node::Kind::Metatype:

--- a/test/DebugInfo/Inputs/type-reconstr-names.txt
+++ b/test/DebugInfo/Inputs/type-reconstr-names.txt
@@ -6,4 +6,5 @@ $Ss10CollectionP7Element ---> Can't resolve type of $Ss10CollectionP7Element
 $Ss15ContiguousArrayV9formIndex5afterySiz_tFSS_Tg5 ---> (inout Int) -> ()
 $S12TypeReconstr8PatatinoaySiGD ---> Patatino<Int>
 $S7ElementQzD ---> τ_0_0.Element
-$S13EyeCandySwift21_previousUniqueNumber33_ADC08935D64EA4F796440E7335798735LLs6UInt64Vvp -> UInt64
+$S13EyeCandySwift21_previousUniqueNumber33_ADC08935D64EA4F796440E7335798735LLs6UInt64Vvp ---> UInt64
+$SSayypXpG ---> Array<Any.Type>


### PR DESCRIPTION
Without this, we wouldn't be able to show an array of `Any.Type`
in the debugger.

Fixes <rdar://problem/40940701>.