### PR TITLE
Sema: Make implicit elementwise struct init insensitive to lazy validation order.

### DIFF
--- a/test/decl/var/Inputs/lazy_properties_batch_mode_b.swift
+++ b/test/decl/var/Inputs/lazy_properties_batch_mode_b.swift
@@ -1,0 +1,7 @@
+struct B {
+  var other: Int = 0
+  lazy var crash: String = {
+    return ""
+  }()
+}
+

--- a/test/decl/var/lazy_properties_batch_mode.swift
+++ b/test/decl/var/lazy_properties_batch_mode.swift
@@ -1,0 +1,4 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -c -primary-file %s -o %t/a.o -primary-file %S/Inputs/lazy_properties_batch_mode_b.swift -o %t/b.o
+func foo(_: B) {}
+


### PR DESCRIPTION
With batch mode, other files may have forced lazy properties to get finalized before the implicit constructor is formed. Avoid the order dependency by making the behavior stable regardless of the type-checking phase of lazy declarations. Fixes rdar://problem/40903186.