### PR TITLE
Push FunctionTypeRepr Input Invariants Up

### DIFF
--- a/include/swift/AST/DiagnosticsCommon.def
+++ b/include/swift/AST/DiagnosticsCommon.def
@@ -90,6 +90,9 @@ ERROR(generic_signature_not_minimal,none,
 ERROR(attr_only_on_parameters, none,
       "'%0' may only be used on parameters", (StringRef))
 
+ERROR(function_type_no_parens,none,
+      "single argument function types require parentheses", ())
+
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3465,8 +3465,6 @@ ERROR(objc_invalid_with_generic_params,none,
 ERROR(objc_convention_invalid,none,
       "%0 is not representable in Objective-C, so it cannot be used"
       " with '@convention(%1)'", (Type, StringRef))
-ERROR(function_type_no_parens,none,
-      "single argument function types require parentheses", ())
 WARNING(paren_void_probably_void,none,
       "when calling this function in Swift 4 or later, you must pass a '()' tuple; did you mean for the input type to be '()'?", ())
 NOTE(not_objc_empty_protocol_composition,none,

--- a/include/swift/AST/TypeRepr.h
+++ b/include/swift/AST/TypeRepr.h
@@ -34,6 +34,7 @@ namespace swift {
   class DeclContext;
   class GenericEnvironment;
   class IdentTypeRepr;
+  class TupleTypeRepr;
   class TypeDecl;
 
 enum class TypeReprKind : uint8_t {
@@ -467,7 +468,9 @@ inline IdentTypeRepr::ComponentRange IdentTypeRepr::getComponentRange() {
 
 /// \brief A function type.
 /// \code
-///   Foo -> Bar
+///   (Foo) -> Bar
+///   (Foo, Bar) -> Baz
+///   (x: Foo, y: Bar) -> Baz
 /// \endcode
 class FunctionTypeRepr : public TypeRepr {
   // These three are only used in SIL mode, which is the only time
@@ -475,13 +478,13 @@ class FunctionTypeRepr : public TypeRepr {
   GenericParamList *GenericParams;
   GenericEnvironment *GenericEnv;
 
-  TypeRepr *ArgsTy;
+  TupleTypeRepr *ArgsTy;
   TypeRepr *RetTy;
   SourceLoc ArrowLoc;
   SourceLoc ThrowsLoc;
 
 public:
-  FunctionTypeRepr(GenericParamList *genericParams, TypeRepr *argsTy,
+  FunctionTypeRepr(GenericParamList *genericParams, TupleTypeRepr *argsTy,
                    SourceLoc throwsLoc, SourceLoc arrowLoc, TypeRepr *retTy)
     : TypeRepr(TypeReprKind::Function),
       GenericParams(genericParams),
@@ -498,7 +501,7 @@ public:
     GenericEnv = genericEnv;
   }
 
-  TypeRepr *getArgsTypeRepr() const { return ArgsTy; }
+  TupleTypeRepr *getArgsTypeRepr() const { return ArgsTy; }
   TypeRepr *getResultTypeRepr() const { return RetTy; }
   bool throws() const { return ThrowsLoc.isValid(); }
 
@@ -511,7 +514,7 @@ public:
   static bool classof(const FunctionTypeRepr *T) { return true; }
 
 private:
-  SourceLoc getStartLocImpl() const { return ArgsTy->getStartLoc(); }
+  SourceLoc getStartLocImpl() const;
   SourceLoc getEndLocImpl() const { return RetTy->getEndLoc(); }
   SourceLoc getLocImpl() const { return ArrowLoc; }
 

--- a/lib/AST/TypeRepr.cpp
+++ b/lib/AST/TypeRepr.cpp
@@ -157,11 +157,12 @@ TypeRepr *CloneVisitor::visitCompoundIdentTypeRepr(CompoundIdentTypeRepr *T) {
 }
 
 TypeRepr *CloneVisitor::visitFunctionTypeRepr(FunctionTypeRepr *T) {
-  return new (Ctx) FunctionTypeRepr(/*FIXME: Clone?*/T->getGenericParams(),
-                                    visit(T->getArgsTypeRepr()),
-                                    T->getThrowsLoc(),
-                                    T->getArrowLoc(),
-                                    visit(T->getResultTypeRepr()));
+  return new (Ctx) FunctionTypeRepr(
+                              /*FIXME: Clone?*/T->getGenericParams(),
+                              cast<TupleTypeRepr>(visit(T->getArgsTypeRepr())),
+                              T->getThrowsLoc(),
+                              T->getArrowLoc(),
+                              visit(T->getResultTypeRepr()));
 }
 
 TypeRepr *CloneVisitor::visitArrayTypeRepr(ArrayTypeRepr *T) {
@@ -476,6 +477,10 @@ SILBoxTypeRepr *SILBoxTypeRepr::create(ASTContext &C,
   auto mem = C.Allocate(size, alignof(SILBoxTypeRepr));
   return new (mem) SILBoxTypeRepr(GenericParams, LBraceLoc, Fields, RBraceLoc,
                                   ArgLAngleLoc, GenericArgs, ArgRAngleLoc);
+}
+
+SourceLoc FunctionTypeRepr::getStartLocImpl() const {
+  return ArgsTy->getStartLoc();
 }
 
 SourceLoc SILBoxTypeRepr::getStartLocImpl() const {

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -44,24 +44,6 @@ TypeRepr *Parser::applyAttributeToType(TypeRepr *ty,
 
   // Apply 'inout' or '__shared' or '__owned'
   if (specifierLoc.isValid()) {
-    if (auto *fnTR = dyn_cast<FunctionTypeRepr>(ty)) {
-      // If the input to the function isn't parenthesized, apply the inout
-      // to the first (only) parameter, as we would in Swift 2. (This
-      // syntax is deprecated in Swift 3.)
-      TypeRepr *argsTR = fnTR->getArgsTypeRepr();
-      if (!isa<TupleTypeRepr>(argsTR)) {
-        auto *newArgsTR =
-          new (Context) InOutTypeRepr(argsTR, specifierLoc);
-        auto *newTR =
-          new (Context) FunctionTypeRepr(fnTR->getGenericParams(),
-              newArgsTR,
-              fnTR->getThrowsLoc(),
-              fnTR->getArrowLoc(),
-              fnTR->getResultTypeRepr());
-        newTR->setGenericEnvironment(fnTR->getGenericEnvironment());
-        return newTR;
-      }
-    }
     switch (specifier) {
     case VarDecl::Specifier::Owned:
       ty = new (Context) OwnedTypeRepr(ty, specifierLoc);
@@ -461,7 +443,33 @@ ParserResult<TypeRepr> Parser::parseType(Diag<> MessageID,
       }
       SyntaxContext->addSyntax(Builder.build());
     }
-    tyR = new (Context) FunctionTypeRepr(generics, tyR, throwsLoc, arrowLoc,
+
+    TupleTypeRepr *argsTyR = nullptr;
+    if (auto *TTArgs = dyn_cast<TupleTypeRepr>(tyR)) {
+      argsTyR = TTArgs;
+    } else {
+      bool isVoid = false;
+      if (const auto Void = dyn_cast<SimpleIdentTypeRepr>(tyR)) {
+        if (Void->getIdentifier().str() == "Void") {
+          isVoid = true;
+        }
+      }
+
+      if (isVoid) {
+        diagnose(tyR->getStartLoc(), diag::function_type_no_parens)
+          .fixItReplace(tyR->getStartLoc(), "()");
+        argsTyR = TupleTypeRepr::createEmpty(Context, tyR->getSourceRange());
+      } else {
+        diagnose(tyR->getStartLoc(), diag::function_type_no_parens)
+          .highlight(tyR->getSourceRange())
+          .fixItInsert(tyR->getStartLoc(), "(")
+          .fixItInsertAfter(tyR->getEndLoc(), ")");
+        argsTyR = TupleTypeRepr::create(Context, {tyR},
+                                        tyR->getSourceRange());
+      }
+    }
+
+    tyR = new (Context) FunctionTypeRepr(generics, argsTyR, throwsLoc, arrowLoc,
                                          SecondHalf.get());
   } else if (generics) {
     // Only function types may be generic.

--- a/test/IDE/complete_crashes.swift
+++ b/test/IDE/complete_crashes.swift
@@ -140,7 +140,7 @@ func flip<A, B, C>(_ f: A -> B -> C) -> B -> A -> C { }
 func rdar22688199() {
   let f = flip(curried)(#^RDAR_22688199^#
 }
-// FLIP_CURRIED: Pattern/CurrModule: ['(']{#Int#}, {#Int#}[')'][#(Int) -> ()#]
+// FLIP_CURRIED: Pattern/CurrModule: ['(']{#(Int, Int)#}[')'][#(Int) -> ()#]
 
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RDAR_22836263
 func rdar22836263() {

--- a/test/IRGen/bridge_object_arm64.sil
+++ b/test/IRGen/bridge_object_arm64.sil
@@ -41,7 +41,7 @@ entry(%c : $C, %w : $Builtin.Word):
 // CHECK:         br label %tagged-cont
 // CHECK:      tagged-cont:
 // CHECK:         phi [[C]] [ [[TAGGED_RESULT]], %tagged-pointer ], [ [[MASKED_RESULT]], %not-tagged-pointer ]
-sil @convert_from_bridge_object : $Builtin.BridgeObject -> (ObjC, Builtin.Word) {
+sil @convert_from_bridge_object : $(Builtin.BridgeObject) -> (ObjC, Builtin.Word) {
 entry(%b : $Builtin.BridgeObject):
   %c = bridge_object_to_ref %b : $Builtin.BridgeObject to $ObjC
   %w = bridge_object_to_word %b : $Builtin.BridgeObject to $Builtin.Word
@@ -49,7 +49,7 @@ entry(%b : $Builtin.BridgeObject):
   return %t : $(ObjC, Builtin.Word)
 }
 
-sil @convert_from_native_bridge_object : $Builtin.BridgeObject -> C {
+sil @convert_from_native_bridge_object : $(Builtin.BridgeObject) -> C {
 entry(%b : $Builtin.BridgeObject):
   %c = bridge_object_to_ref %b : $Builtin.BridgeObject to $C
   return %c : $C

--- a/test/IRGen/bridge_object_armv7.sil
+++ b/test/IRGen/bridge_object_armv7.sil
@@ -28,7 +28,7 @@ entry(%c : $C, %w : $Builtin.Word):
 // CHECK:         [[BOBITS:%.*]] = ptrtoint [[BRIDGE:%swift.bridge\*]] %0 to i32
 // CHECK:         [[MASKED_BITS:%.*]] = and i32 [[BOBITS]], -4
 // CHECK:         inttoptr i32 [[MASKED_BITS]] to [[C:%objc_object\*]]
-sil @convert_from_bridge_object : $Builtin.BridgeObject -> (ObjC, Builtin.Word) {
+sil @convert_from_bridge_object : $(Builtin.BridgeObject) -> (ObjC, Builtin.Word) {
 entry(%b : $Builtin.BridgeObject):
   %c = bridge_object_to_ref %b : $Builtin.BridgeObject to $ObjC
   %w = bridge_object_to_word %b : $Builtin.BridgeObject to $Builtin.Word
@@ -36,7 +36,7 @@ entry(%b : $Builtin.BridgeObject):
   return %t : $(ObjC, Builtin.Word)
 }
 
-sil @convert_from_native_bridge_object : $Builtin.BridgeObject -> C {
+sil @convert_from_native_bridge_object : $(Builtin.BridgeObject) -> C {
 entry(%b : $Builtin.BridgeObject):
   %c = bridge_object_to_ref %b : $Builtin.BridgeObject to $C
   return %c : $C

--- a/test/IRGen/bridge_object_x86_64.sil
+++ b/test/IRGen/bridge_object_x86_64.sil
@@ -48,7 +48,7 @@ entry(%c : $C, %w : $Builtin.Word):
 // CHECK:      tagged-cont:
 // CHECK:         phi [[C]] [ [[TAGGED_RESULT]], %tagged-pointer ], [ [[MASKED_RESULT]], %not-tagged-pointer ]
 
-sil @convert_from_bridge_object : $Builtin.BridgeObject -> (ObjC, Builtin.Word) {
+sil @convert_from_bridge_object : $(Builtin.BridgeObject) -> (ObjC, Builtin.Word) {
 entry(%b : $Builtin.BridgeObject):
   %c = bridge_object_to_ref %b : $Builtin.BridgeObject to $ObjC
   %w = bridge_object_to_word %b : $Builtin.BridgeObject to $Builtin.Word
@@ -61,7 +61,7 @@ entry(%b : $Builtin.BridgeObject):
 // CHECK:         [[MASKED_BITS:%.*]] = and i64 [[BOBITS]], 72057594037927928
 // CHECK:         [[RESULT:%.*]] = inttoptr i64 [[MASKED_BITS]] to [[C:%T13bridge_object1CC\*]]
 // CHECK:         ret %T13bridge_object1CC* [[RESULT]]
-sil @convert_from_native_bridge_object : $Builtin.BridgeObject -> C {
+sil @convert_from_native_bridge_object : $(Builtin.BridgeObject) -> C {
 entry(%b : $Builtin.BridgeObject):
   %c = bridge_object_to_ref %b : $Builtin.BridgeObject to $C
   return %c : $C

--- a/test/IRGen/c_layout.sil
+++ b/test/IRGen/c_layout.sil
@@ -104,7 +104,7 @@ bb0:
 }
 
 sil public_external @createSIMDStruct : $@convention(c) () -> SIMDStruct
-sil public_external @consumeSIMDStruct : $@convention(c) SIMDStruct -> ()
+sil public_external @consumeSIMDStruct : $@convention(c) (SIMDStruct) -> ()
 
 // CHECK-x86_64-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @testSIMDStruct()
 // CHECK-x86_64:         call <3 x float> @createSIMDStruct
@@ -113,8 +113,8 @@ sil @testSIMDStruct : $() -> () {
 bb0:
   %f = function_ref @createSIMDStruct : $@convention(c) () -> SIMDStruct
   %x = apply %f() : $@convention(c) () -> SIMDStruct
-  %g = function_ref @consumeSIMDStruct : $@convention(c) SIMDStruct -> ()
-  %z = apply %g(%x) : $@convention(c) SIMDStruct -> ()
+  %g = function_ref @consumeSIMDStruct : $@convention(c) (SIMDStruct) -> ()
+  %z = apply %g(%x) : $@convention(c) (SIMDStruct) -> ()
   return undef : $()
 }
 

--- a/test/IRGen/class.sil
+++ b/test/IRGen/class.sil
@@ -73,7 +73,7 @@ bb0(%0 : $C):
 
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc [[REF]]* @unchecked_ref_cast_cast([[C_CLASS]]*)
 // CHECK:   bitcast [[C_CLASS]]* {{%.*}} to [[REF]]*
-sil @unchecked_ref_cast_cast : $@convention(thin) C -> Builtin.NativeObject {
+sil @unchecked_ref_cast_cast : $@convention(thin) (C) -> Builtin.NativeObject {
 entry(%c : $C):
   %r = unchecked_ref_cast %c : $C to $Builtin.NativeObject
   return %r : $Builtin.NativeObject
@@ -81,7 +81,7 @@ entry(%c : $C):
 
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc [[OBJCOBJ]]* @ref_to_objc_pointer_cast([[C_CLASS]]*)
 // CHECK:   bitcast [[C_CLASS]]* %0 to [[OBJCOBJ]]*
-sil @ref_to_objc_pointer_cast : $@convention(thin) C -> Builtin.UnknownObject {
+sil @ref_to_objc_pointer_cast : $@convention(thin) (C) -> Builtin.UnknownObject {
 entry(%c : $C):
   %r = unchecked_ref_cast %c : $C to $Builtin.UnknownObject
   return %r : $Builtin.UnknownObject

--- a/test/IRGen/dynamic_lookup.sil
+++ b/test/IRGen/dynamic_lookup.sil
@@ -148,7 +148,7 @@ bb0(%0 : $AnyObject, %1 : $Int):
 bb1(%13 : $@convention(objc_method) (Int, Builtin.UnknownObject) -> Int): // Preds: bb0
   %14 = partial_apply %13(%11) : $@convention(objc_method) (Int, Builtin.UnknownObject) -> Int
   %15 = load %3a : $*Int
-  %16 = apply %14(%15) : $@callee_owned Int -> Int
+  %16 = apply %14(%15) : $@callee_owned (Int) -> Int
   br bb3
 
 bb2:

--- a/test/IRGen/enum.sil
+++ b/test/IRGen/enum.sil
@@ -1285,7 +1285,7 @@ entry(%r : $*DynamicSinglePayload<T>):
 // CHECK:     i8 2, label {{.*}}
 // CHECK:     i8 3, label {{.*}}
 // CHECK:   ]
-sil @dynamic_single_payload_empty_payload_switch : $DynamicSinglePayload<()> -> () {
+sil @dynamic_single_payload_empty_payload_switch : $(DynamicSinglePayload<()>) -> () {
 entry(%x : $DynamicSinglePayload<()>):
   switch_enum %x : $DynamicSinglePayload<()>, case #DynamicSinglePayload.x!enumelt.1: x_case, case #DynamicSinglePayload.y!enumelt: y_case, case #DynamicSinglePayload.z!enumelt: z_case, default default_case
 
@@ -2452,7 +2452,7 @@ entry(%0 : $DynamicSingleton<NoPayloads>):
 enum Optionable<T> {
   case some(T), none
 }
-sil @optional_optional_class_protocol : $@convention(thin) Optionable<Optionable<PC>> -> Builtin.Int1 {
+sil @optional_optional_class_protocol : $@convention(thin) (Optionable<Optionable<PC>>) -> Builtin.Int1 {
 entry(%o : $Optionable<Optionable<PC>>):
   %t = integer_literal $Builtin.Int1, 1
   %f = integer_literal $Builtin.Int1, 0
@@ -2504,7 +2504,7 @@ entry(%x : $Int32):
   return %d : $Optional<(Optional<()>, Int32)>
 }
 
-sil @optional_float80 : $@convention(thin) Float80 -> () {
+sil @optional_float80 : $@convention(thin) (Float80) -> () {
 entry(%x : $Float80):
   %y = enum $Optional<Float80>, #Optional.some!enumelt.1, %x : $Float80
   return undef : $()

--- a/test/IRGen/generic_classes.sil
+++ b/test/IRGen/generic_classes.sil
@@ -264,7 +264,7 @@ entry:
 // RootGeneric.x has fixed layout
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc i8 @RootGeneric_concrete_fragile_dependent_member_access_x
 // CHECK:   getelementptr inbounds [[ROOTGENERIC]], [[ROOTGENERIC]]* %0, i32 0, i32 1
-sil @RootGeneric_concrete_fragile_dependent_member_access_x : $<F> RootGeneric<F> -> UInt8 {
+sil @RootGeneric_concrete_fragile_dependent_member_access_x : $<F> (RootGeneric<F>) -> UInt8 {
 entry(%c : $RootGeneric<F>):
   %p = ref_element_addr %c : $RootGeneric<F>, #RootGeneric.x
   %x = load_borrow %p : $*UInt8
@@ -306,7 +306,7 @@ entry(%z : $*Int, %c : $RootGeneric<Int>):
 // CHECK:   [[CLASS_BYTE_ARRAY:%.*]] = bitcast [[ROOTGENERIC]]* {{%.*}} to i8*
 // CHECK:   [[Z_ADDR:%.*]] = getelementptr inbounds i8, i8* [[CLASS_BYTE_ARRAY]], i64 [[Z_OFFSET]]
 // CHECK:   bitcast i8* [[Z_ADDR]] to %Ts5UInt8V*
-sil @RootGeneric_concrete_fragile_dependent_member_access_z : $<F> RootGeneric<F> -> UInt8 {
+sil @RootGeneric_concrete_fragile_dependent_member_access_z : $<F> (RootGeneric<F>) -> UInt8 {
 entry(%c : $RootGeneric<F>):
   %p = ref_element_addr %c : $RootGeneric<F>, #RootGeneric.z
   %z = load_borrow %p : $*UInt8
@@ -317,7 +317,7 @@ entry(%c : $RootGeneric<F>):
 // CHECK:   [[Z_ADDR:%.*]] = getelementptr inbounds {{.*}}, {{.*}}* %0, i32 0, i32 4
 // CHECK:   [[T0:%.*]] = getelementptr inbounds %Ts5UInt8V, %Ts5UInt8V* [[Z_ADDR]], i32 0, i32 0
 // CHECK:   load i8, i8* [[T0]], align
-sil @RootGeneric_subst_concrete_fragile_dependent_member_access_z : $RootGeneric<Int> -> UInt8 {
+sil @RootGeneric_subst_concrete_fragile_dependent_member_access_z : $(RootGeneric<Int>) -> UInt8 {
 entry(%c : $RootGeneric<Int>):
   %p = ref_element_addr %c : $RootGeneric<Int>, #RootGeneric.z
   %z = load_borrow %p : $*UInt8

--- a/test/IRGen/indirect_argument.sil
+++ b/test/IRGen/indirect_argument.sil
@@ -15,40 +15,40 @@ struct HugeAlignment {
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_method(%T17indirect_argument4HugeV* noalias nocapture swiftself dereferenceable({{.*}}))
 // CHECK-NOT:     alloca
 // CHECK:         call swiftcc void @huge_method(%T17indirect_argument4HugeV* noalias nocapture swiftself dereferenceable({{.*}}) %0)
-sil @huge_method : $@convention(method) Huge -> () {
+sil @huge_method : $@convention(method) (Huge) -> () {
 entry(%x : $Huge):
-  %f = function_ref @huge_method : $@convention(method) Huge -> ()
-  %z = apply %f(%x) : $@convention(method) Huge -> ()
+  %f = function_ref @huge_method : $@convention(method) (Huge) -> ()
+  %z = apply %f(%x) : $@convention(method) (Huge) -> ()
   return %z : $()
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_param(%T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}))
 // CHECK-NOT:         alloca
 // CHECK:         call swiftcc void @huge_param(%T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}) %0)
-sil @huge_param : $@convention(thin) Huge -> () {
+sil @huge_param : $@convention(thin) (Huge) -> () {
 entry(%x : $Huge):
-  %f = function_ref @huge_param : $@convention(thin) Huge -> ()
-  %z = apply %f(%x) : $@convention(thin) Huge -> ()
+  %f = function_ref @huge_param : $@convention(thin) (Huge) -> ()
+  %z = apply %f(%x) : $@convention(thin) (Huge) -> ()
   return %z : $()
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_alignment_param(%T17indirect_argument13HugeAlignmentV* noalias nocapture dereferenceable({{.*}}))
 // CHECK-NOT:     alloca
 // CHECK:         call swiftcc void @huge_alignment_param(%T17indirect_argument13HugeAlignmentV* noalias nocapture dereferenceable({{.*}}) %0)
-sil @huge_alignment_param : $@convention(thin) HugeAlignment -> () {
+sil @huge_alignment_param : $@convention(thin) (HugeAlignment) -> () {
 entry(%x : $HugeAlignment):
-  %f = function_ref @huge_alignment_param : $@convention(thin) HugeAlignment -> ()
-  %z = apply %f(%x) : $@convention(thin) HugeAlignment -> ()
+  %f = function_ref @huge_alignment_param : $@convention(thin) (HugeAlignment) -> ()
+  %z = apply %f(%x) : $@convention(thin) (HugeAlignment) -> ()
   return %z : $()
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc void @huge_param_and_return(%T17indirect_argument4HugeV* noalias nocapture sret, %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}))
 // CHECK:         [[TMP_RET:%.*]] = alloca
 // CHECK:         call swiftcc void @huge_param_and_return(%T17indirect_argument4HugeV* noalias nocapture sret [[TMP_RET]], %T17indirect_argument4HugeV* noalias nocapture dereferenceable({{.*}}) %1)
-sil @huge_param_and_return : $@convention(thin) Huge -> Huge {
+sil @huge_param_and_return : $@convention(thin) (Huge) -> Huge {
 entry(%x : $Huge):
-  %f = function_ref @huge_param_and_return : $@convention(thin) Huge -> Huge
-  %z = apply %f(%x) : $@convention(thin) Huge -> Huge
+  %f = function_ref @huge_param_and_return : $@convention(thin) (Huge) -> Huge
+  %z = apply %f(%x) : $@convention(thin) (Huge) -> Huge
   return %z : $Huge
 }
 

--- a/test/IRGen/objc_block.sil
+++ b/test/IRGen/objc_block.sil
@@ -7,11 +7,11 @@ import Swift
 class Foo {}
 sil_vtable Foo {}
 
-sil @$S10objc_block3FooCfD : $Foo -> ()
+sil @$S10objc_block3FooCfD : $(Foo) -> ()
 
-sil @call_block : $@convention(thin) (@convention(block) Foo -> Foo, Foo) -> Foo {
-entry(%b : $@convention(block) Foo -> Foo, %x : $Foo):
-  %y = apply %b(%x) : $@convention(block) Foo -> Foo
+sil @call_block : $@convention(thin) (@convention(block) (Foo) -> Foo, Foo) -> Foo {
+entry(%b : $@convention(block) (Foo) -> Foo, %x : $Foo):
+  %y = apply %b(%x) : $@convention(block) (Foo) -> Foo
   return %y : $Foo
 }
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc %T10objc_block3FooC* @call_block(%objc_block*, %T10objc_block3FooC*) {{.*}} {

--- a/test/IRGen/partial_apply.sil
+++ b/test/IRGen/partial_apply.sil
@@ -17,7 +17,7 @@ sil @partially_applyable_to_class : $@convention(thin) (@owned SwiftClass) -> ()
 // CHECK:   %2 = insertvalue { i8*, %swift.refcounted* } { i8* bitcast (void (%swift.refcounted*)* @"$S28partially_applyable_to_classTA" to i8*), %swift.refcounted* undef }, %swift.refcounted* %1, 1
 // CHECK:   ret { i8*, %swift.refcounted* } %2
 // CHECK: }
-sil @partial_apply_class : $@convention(thin) SwiftClass -> @callee_owned () -> () {
+sil @partial_apply_class : $@convention(thin) (SwiftClass) -> @callee_owned () -> () {
 entry(%c : $SwiftClass):
   %f = function_ref @partially_applyable_to_class : $@convention(thin) (@owned SwiftClass) -> ()
   %g = partial_apply %f(%c) : $@convention(thin) (@owned SwiftClass) -> ()
@@ -33,14 +33,14 @@ entry(%c : $SwiftClass):
 // CHECK:         bitcast %TSi* {{%.*}} to %swift.opaque*
 sil public_external @generic_captured_param : $@convention(thin) <T> (Int, @inout T) -> Int
 
-sil @partial_apply_generic_capture : $@convention(thin) Int -> @callee_owned Int -> Int {
+sil @partial_apply_generic_capture : $@convention(thin) (Int) -> @callee_owned (Int) -> Int {
 entry(%x : $Int):
   %a = alloc_stack $Int
   store %x to %a : $*Int
   %f = function_ref @generic_captured_param : $@convention(thin) <T> (Int, @inout T) -> Int
   %p = partial_apply %f<Int>(%a) : $@convention(thin) <T> (Int, @inout T) -> Int
   dealloc_stack %a : $*Int
-  return %p : $@callee_owned Int -> Int
+  return %p : $@callee_owned (Int) -> Int
 }
 
 sil public_external @generic_captured_and_open_param : $@convention(thin) <T> (@in T, @inout T) -> @out T

--- a/test/IRGen/partial_apply_objc.sil
+++ b/test/IRGen/partial_apply_objc.sil
@@ -108,11 +108,11 @@ entry(%f : $@callee_owned (Builtin.Word) -> (), %x : $Builtin.Word):
 // CHECK:   ret void
 // CHECK: }
 
-sil @objc_partial_apply : $@convention(thin) ObjCClass -> @callee_owned Int -> () {
+sil @objc_partial_apply : $@convention(thin) (ObjCClass) -> @callee_owned (Int) -> () {
 entry(%c : $ObjCClass):
   %m = objc_method %c : $ObjCClass, #ObjCClass.method!1.foreign : (ObjCClass) -> (Int) -> (), $@convention(objc_method) (Int, ObjCClass) -> ()
   %p = partial_apply %m(%c) : $@convention(objc_method) (Int, ObjCClass) -> ()
-  return %p : $@callee_owned Int -> ()
+  return %p : $@callee_owned (Int) -> ()
 }
 
 // CHECK-LABEL: define{{.*}} { i8*, %swift.refcounted* } @objc_partial_apply_indirect_sil_argument(%T18partial_apply_objc9ObjCClassC*) {{.*}}
@@ -129,11 +129,11 @@ entry(%c : $ObjCClass):
 // CHECK:  [[ORIGINX:%.*]] = getelementptr inbounds %TSo7NSPointV, %TSo7NSPointV* [[ORIGIN]]
 // CHECK:  [[ORIGINXVAL:%*]] = getelementptr inbounds %TSd, %TSd* [[ORIGINX]]
 // CHECK:  store double %0, double* [[ORIGINXVAL]]
-sil @objc_partial_apply_indirect_sil_argument : $@convention(thin) ObjCClass -> @callee_owned NSRect -> () {
+sil @objc_partial_apply_indirect_sil_argument : $@convention(thin) (ObjCClass) -> @callee_owned (NSRect) -> () {
 entry(%c : $ObjCClass):
   %m = objc_method %c : $ObjCClass, #ObjCClass.method2!1.foreign : (ObjCClass) -> (NSRect) -> (), $@convention(objc_method) (NSRect, ObjCClass) -> ()
   %p = partial_apply %m(%c) : $@convention(objc_method) (NSRect, ObjCClass) -> ()
-  return %p : $@callee_owned NSRect -> ()
+  return %p : $@callee_owned (NSRect) -> ()
 }
 
 // CHECK-LABEL: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @objc_partial_apply_consumes_self(%T18partial_apply_objc9ObjCClassC*) {{.*}} {
@@ -153,14 +153,14 @@ entry(%c : $ObjCClass):
 // CHECK:   ret void
 // CHECK: }
 
-sil @objc_partial_apply_consumes_self : $@convention(thin) ObjCClass -> @callee_owned () -> @owned ObjCClass {
+sil @objc_partial_apply_consumes_self : $@convention(thin) (ObjCClass) -> @callee_owned () -> @owned ObjCClass {
 entry(%c : $ObjCClass):
   %m = objc_method %c : $ObjCClass, #ObjCClass.fakeInitFamily!1.foreign : (ObjCClass) -> () -> ObjCClass, $@convention(objc_method) (@owned ObjCClass) -> @owned ObjCClass
   %p = partial_apply %m(%c) : $@convention(objc_method) (@owned ObjCClass) -> @owned ObjCClass
   return %p : $@callee_owned () -> @owned ObjCClass
 }
 
-sil @dummy : $@convention(thin) Int -> () {
+sil @dummy : $@convention(thin) (Int) -> () {
 entry(%x : $Int):
   %v = tuple ()
   return %v : $()
@@ -171,31 +171,31 @@ entry(%x : $Int):
 // CHECK: define internal swiftcc void [[DYNAMIC_LOOKUP_BR_PARTIAL_APPLY_STUB]](i64, %swift.refcounted* swiftself) {{.*}} {
 // CHECK:   load i8*, i8** @"\01L_selector(methodWithX:)", align 8
 
-sil @dynamic_lookup_br_partial_apply : $@convention(thin) Builtin.UnknownObject -> @callee_owned Int -> () {
+sil @dynamic_lookup_br_partial_apply : $@convention(thin) (Builtin.UnknownObject) -> @callee_owned (Int) -> () {
 entry(%o : $Builtin.UnknownObject):
   dynamic_method_br %o : $Builtin.UnknownObject, #ObjCClass.method!1.foreign, yes, no
 
 yes(%m : $@convention(objc_method) (Int, Builtin.UnknownObject) -> ()):
   %p = partial_apply %m(%o) : $@convention(objc_method) (Int, Builtin.UnknownObject) -> ()
-  br done(%p : $@callee_owned Int -> ())
+  br done(%p : $@callee_owned (Int) -> ())
 
 no:
-  %q = function_ref @dummy : $@convention(thin) Int -> ()
-  %r = thin_to_thick_function %q : $@convention(thin) Int -> () to $@callee_owned Int -> ()
-  br done(%r : $@callee_owned Int -> ())
+  %q = function_ref @dummy : $@convention(thin) (Int) -> ()
+  %r = thin_to_thick_function %q : $@convention(thin) (Int) -> () to $@callee_owned (Int) -> ()
+  br done(%r : $@callee_owned (Int) -> ())
 
-done(%f : $@callee_owned Int -> ()):
-  return %f : $@callee_owned Int -> ()
+done(%f : $@callee_owned (Int) -> ()):
+  return %f : $@callee_owned (Int) -> ()
 }
 
-sil @partially_applyable_to_pure_objc : $@convention(thin) Gizmo -> ()
+sil @partially_applyable_to_pure_objc : $@convention(thin) (Gizmo) -> ()
 
 // CHECK: define{{( dllexport)?}}{{( protected)?}} swiftcc { i8*, %swift.refcounted* } @partial_apply_pure_objc
 // CHECK:   @swift_allocObject
-sil @partial_apply_pure_objc : $@convention(thin) Gizmo -> @callee_owned () -> () {
+sil @partial_apply_pure_objc : $@convention(thin) (Gizmo) -> @callee_owned () -> () {
 entry(%c : $Gizmo):
-  %f = function_ref @partially_applyable_to_pure_objc : $@convention(thin) Gizmo -> ()
-  %g = partial_apply %f(%c) : $@convention(thin) Gizmo -> ()
+  %f = function_ref @partially_applyable_to_pure_objc : $@convention(thin) (Gizmo) -> ()
+  %g = partial_apply %f(%c) : $@convention(thin) (Gizmo) -> ()
   return %g : $@callee_owned () -> ()
 }
 
@@ -219,7 +219,7 @@ entry(%c : $Gizmo):
 // CHECK:  objc_msgSend
 // CHECK:  ret void
 
-sil @objc_partial_apply_2 : $@convention(thin) Gizmo -> @callee_owned (Fob) -> () {
+sil @objc_partial_apply_2 : $@convention(thin) (Gizmo) -> @callee_owned (Fob) -> () {
 entry(%c : $Gizmo):
   %m = objc_method %c : $Gizmo, #Gizmo.test!1.foreign : (Gizmo) -> (Fob) -> (), $@convention(objc_method) (Fob,  Gizmo) -> ()
   %p = partial_apply %m(%c) : $@convention(objc_method) (Fob,  Gizmo) -> ()
@@ -232,11 +232,11 @@ entry(%c : $Gizmo):
 // CHECK:  [[CLOSURE:%.*]] = insertvalue {{.*}}@"$STa.20"{{.*}}, {{.*}}[[CONTEXT]], 1
 // CHECK: ret {{.*}}[[CLOSURE]]
 
-sil @objc_partial_apply_callee_guaranteed : $@convention(thin) ObjCClass -> @callee_guaranteed Int -> () {
+sil @objc_partial_apply_callee_guaranteed : $@convention(thin) (ObjCClass) -> @callee_guaranteed (Int) -> () {
 entry(%c : $ObjCClass):
   %m = objc_method %c : $ObjCClass, #ObjCClass.method!1.foreign : (ObjCClass) -> (Int) -> (), $@convention(objc_method) (Int, ObjCClass) -> ()
   %p = partial_apply [callee_guaranteed] %m(%c) : $@convention(objc_method) (Int, ObjCClass) -> ()
-  return %p : $@callee_guaranteed Int -> ()
+  return %p : $@callee_guaranteed (Int) -> ()
 }
 
 // CHECK-LABEL: define {{.*}}swiftcc void @"$STa.20"(i64, %swift.refcounted* swiftself)
@@ -255,7 +255,7 @@ entry(%c : $ObjCClass):
 // CHECK:  [[CLOSURE:%.*]] = insertvalue {{.*}}@"$STa.23"{{.*}}, {{.*}}[[CONTEXT]], 1
 // CHECK: ret {{.*}}[[CLOSURE]]
 
-sil @objc_partial_apply_2_callee_guaranteed : $@convention(thin) Gizmo -> @callee_guaranteed (Fob) -> () {
+sil @objc_partial_apply_2_callee_guaranteed : $@convention(thin) (Gizmo) -> @callee_guaranteed (Fob) -> () {
 entry(%c : $Gizmo):
   %m = objc_method %c : $Gizmo, #Gizmo.test!1.foreign : (Gizmo) -> (Fob) -> (), $@convention(objc_method) (Fob,  Gizmo) -> ()
   %p = partial_apply [callee_guaranteed] %m(%c) : $@convention(objc_method) (Fob,  Gizmo) -> ()

--- a/test/Interpreter/currying_protocols.swift
+++ b/test/Interpreter/currying_protocols.swift
@@ -94,10 +94,10 @@ genericOlympicGames(Archimedes())
 func olympicGames(_ g1: Gymnast) -> Gymnast {
   // FIXME -- <rdar://problem/21391055>
 #if false
-  let f1: Double -> Gymnast = g1.backflip
+  let f1: (Double) -> Gymnast = g1.backflip
   let g2: Gymnast = f1(180)
 
-  let f2: Medal -> Gymnast = g2.compete
+  let f2: (Medal) -> Gymnast = g2.compete
   let g4: Gymnast = f2()(Medal.Gold)
 #endif
 

--- a/test/Parse/type_expr.swift
+++ b/test/Parse/type_expr.swift
@@ -238,6 +238,7 @@ func testFunctionCollectionTypes() {
 
   _ = [1 -> Int]() // expected-error {{expected type before '->'}}
   _ = [Int -> 1]() // expected-error {{expected type after '->'}}
+    // expected-error@-1 {{single argument function types require parentheses}}
 
   // Should parse () as void type when before or after arrow
   _ = [() -> Int]()

--- a/test/SIL/Parser/basic.sil
+++ b/test/SIL/Parser/basic.sil
@@ -391,7 +391,7 @@ bb0:
 }
 
 // CHECK-LABEL: sil @test_union_data_case : $@convention(thin) (Int) -> Beth {
-sil @test_union_data_case : $Int -> Beth {
+sil @test_union_data_case : $(Int) -> Beth {
 bb0(%0 : $Int):
   // CHECK: %1 = enum $Beth, #Beth.DataCase!enumelt.1, %0 : $Int
   %1 = enum $Beth, #Beth.DataCase!enumelt.1, %0 : $Int
@@ -490,7 +490,7 @@ class GenericClass<Q> {
 }
 
 // CHECK: sil @bound_generic_class_ref_element_addr : $@convention(thin) (GenericClass<Int>) -> Int {
-sil @bound_generic_class_ref_element_addr : $@convention(thin)  GenericClass<Int> -> Int {
+sil @bound_generic_class_ref_element_addr : $@convention(thin)  (GenericClass<Int>) -> Int {
 entry(%0 : $GenericClass<Int>):
   // CHECK: %1 = ref_element_addr %0 : $GenericClass<Int>, #GenericClass.member
   %1 = ref_element_addr %0 : $GenericClass<Int>, #GenericClass.member
@@ -1042,12 +1042,12 @@ sil @takes_unnamed_closure : $@convention(thin) (@callee_owned () -> Int) -> () 
 sil @takes_int64_float32 : $@convention(thin) (Int, Float32) -> ()
 
 // CHECK-LABEL: sil @test_partial_apply : $@convention(thin) (Float) -> @callee_owned (Int) -> () {
-sil @test_partial_apply : $@convention(thin)  Float -> @callee_owned Int -> () {
+sil @test_partial_apply : $@convention(thin)  (Float) -> @callee_owned (Int) -> () {
 bb0(%0 : $Float):
   %1 = function_ref @takes_int64_float32 : $@convention(thin) (Int, Float) -> ()
   // CHECK: partial_apply %{{.*}}(%{{.*}}) : $@convention(thin) (Int, Float) -> ()
   %2 = partial_apply %1(%0) : $@convention(thin) (Int, Float) -> ()
-  return %2 : $@callee_owned Int -> ()
+  return %2 : $@callee_owned (Int) -> ()
 }
 
 class X {
@@ -1104,7 +1104,7 @@ bb0(%0 : $Val):
 }
 
 // CHECK-LABEL: sil @test_autorelease_value
-sil @test_autorelease_value : $X -> X {
+sil @test_autorelease_value : $(X) -> X {
 bb0(%0 : $X):
   autorelease_value %0 : $X
   return %0 : $X
@@ -1113,7 +1113,7 @@ bb0(%0 : $X):
 }
 
 // CHECK-LABEL: sil @test_set_deallocating
-sil @test_set_deallocating : $X -> X {
+sil @test_set_deallocating : $(X) -> X {
 bb0(%0 : $X):
   set_deallocating %0 : $X
   return %0 : $X
@@ -1126,7 +1126,7 @@ struct GenericStruct<T> {
 }
 
 // CHECK-LABEL: sil @extract_generic_struct
-sil @extract_generic_struct : $GenericStruct<Int> -> Int {
+sil @extract_generic_struct : $(GenericStruct<Int>) -> Int {
 entry(%0 : $GenericStruct<Int>):
   // CHECK: %1 = struct_extract %0 : $GenericStruct<Int>, #GenericStruct.x
   %1 = struct_extract %0 : $GenericStruct<Int>, #GenericStruct.x
@@ -1178,7 +1178,7 @@ bb0(%0 : $Int32, %1 : $Int32, %2 : $Int32, %3 : $Foo):
 }
 
 // CHECK-LABEL: sil @cond_fail_test : $@convention(thin) (Builtin.Int1) -> () {
-sil @cond_fail_test : $Builtin.Int1 -> () {
+sil @cond_fail_test : $(Builtin.Int1) -> () {
 entry(%0 : $Builtin.Int1):
   // CHECK: cond_fail %0 : $Builtin.Int1
   cond_fail %0 : $Builtin.Int1
@@ -1231,7 +1231,7 @@ bb0(%0 : $Int, %1 : $*P):
 }
 
 // CHECK-LABEL: sil @block_storage_type
-sil @block_storage_type : $@convention(thin)  Int -> @convention(block) () -> () {
+sil @block_storage_type : $@convention(thin)  (Int) -> @convention(block) () -> () {
 entry(%0 : $Int):
   // CHECK: [[STORAGE:%.*]] = alloc_stack $@block_storage Int
   %s = alloc_stack $@block_storage Int

--- a/test/SIL/Parser/nonatomic_reference_counting.sil
+++ b/test/SIL/Parser/nonatomic_reference_counting.sil
@@ -76,7 +76,7 @@ bb0:
 // CHECK-LABEL: sil @test_set_deallocating
 // CHECK: set_deallocating [nonatomic]
 // CHECK: return
-sil @test_set_deallocating : $C -> C {
+sil @test_set_deallocating : $(C) -> C {
 bb0(%0 : $C):
   set_deallocating [nonatomic] %0 : $C
   return %0 : $C

--- a/test/SILOptimizer/sil_combine.sil
+++ b/test/SILOptimizer/sil_combine.sil
@@ -1264,7 +1264,7 @@ bb0(%0 : $AnyObject):
 // CHECK: bb0
 // CHECK-NEXT: unchecked_ref_cast
 // CHECK-NEXT: return
-sil @unchecked_ref_cast_upcast_combine : $@convention(thin) E -> Builtin.NativeObject {
+sil @unchecked_ref_cast_upcast_combine : $@convention(thin) (E) -> Builtin.NativeObject {
 bb0(%0 : $E):
   %1 = upcast %0 : $E to $B
   %2 = unchecked_ref_cast %1 : $B to $Builtin.NativeObject

--- a/test/SILOptimizer/unexpected_error.sil
+++ b/test/SILOptimizer/unexpected_error.sil
@@ -2,7 +2,7 @@
 import Swift
 
 // CHECK-LABEL: sil @unexpected_error : $@convention(thin) (Error) -> () {
-sil @unexpected_error : $@convention(thin) Error -> () {
+sil @unexpected_error : $@convention(thin) (Error) -> () {
 entry(%10 : $Error):
   // CHECK: builtin "unexpectedError"
   %11 = builtin "unexpectedError"(%10 : $Error) : $()
@@ -10,7 +10,7 @@ entry(%10 : $Error):
 }
 
 // CHECK-LABEL: sil @error_in_main : $@convention(thin) (Error) -> () {
-sil @error_in_main : $@convention(thin) Error -> () {
+sil @error_in_main : $@convention(thin) (Error) -> () {
 entry(%10 : $Error):
   // CHECK: builtin "errorInMain"
   %11 = builtin "errorInMain"(%10 : $Error) : $()

--- a/test/Serialization/Inputs/def_basic.sil
+++ b/test/Serialization/Inputs/def_basic.sil
@@ -344,7 +344,7 @@ bb0:
 }
 
 // CHECK-LABEL: @test_union_data_case : $@convention(thin) (Int) -> Beth {
-sil [transparent] [serialized] @test_union_data_case : $@convention(thin) Int -> Beth {
+sil [transparent] [serialized] @test_union_data_case : $@convention(thin) (Int) -> Beth {
 bb0(%0 : $Int):
   // CHECK: %1 = enum $Beth, #Beth.DataCase!enumelt.1, %0 : $Int
   %1 = enum $Beth, #Beth.DataCase!enumelt.1, %0 : $Int
@@ -935,12 +935,12 @@ sil [transparent] [serialized] @takes_unnamed_closure : $@convention(thin) (@cal
 sil [transparent] [serialized] @takes_int64_float32 : $@convention(thin) (Int, Float32) -> ()
 
 // CHECK-LABEL: sil public_external [transparent] [serialized] @test_partial_apply : $@convention(thin) (Float) -> @callee_owned (Int) -> () {
-sil [transparent] [serialized] @test_partial_apply : $@convention(thin) Float32 -> @callee_owned Int -> () {
+sil [transparent] [serialized] @test_partial_apply : $@convention(thin) (Float32) -> @callee_owned (Int) -> () {
 bb0(%0 : $Float32):
   %1 = function_ref @takes_int64_float32 : $@convention(thin) (Int, Float) -> ()
   // CHECK: partial_apply %{{.*}}(%{{.*}}) : $@convention(thin) (Int, Float) -> ()
   %2 = partial_apply %1(%0) : $@convention(thin) (Int, Float) -> ()
-  return %2 : $@callee_owned Int -> ()
+  return %2 : $@callee_owned (Int) -> ()
 }
 
 class X {
@@ -1034,7 +1034,7 @@ bb0(%0 : $Builtin.RawPointer, %1 : $Builtin.Word):
 }
 
 // CHECK: sil public_external [transparent] [serialized] @cond_fail_test : $@convention(thin) (Builtin.Int1) -> () {
-sil [transparent] [serialized] @cond_fail_test : $@convention(thin) Builtin.Int1 -> () {
+sil [transparent] [serialized] @cond_fail_test : $@convention(thin) (Builtin.Int1) -> () {
 entry(%0 : $Builtin.Int1):
   // CHECK: cond_fail %0 : $Builtin.Int1
   cond_fail %0 : $Builtin.Int1
@@ -1043,7 +1043,7 @@ entry(%0 : $Builtin.Int1):
 }
 
 // CHECK-LABEL: sil public_external [transparent] [serialized] @block_storage_type
-sil [transparent] [serialized] @block_storage_type : $@convention(thin) Int -> @convention(block) () -> () {
+sil [transparent] [serialized] @block_storage_type : $@convention(thin) (Int) -> @convention(block) () -> () {
 entry(%0 : $Int):
   // CHECK: [[STORAGE:%.*]] = alloc_stack $@block_storage Int
   %s = alloc_stack $@block_storage Int
@@ -1149,7 +1149,7 @@ struct GenericStruct<T> {
 }
 
 // CHECK-LABEL: sil public_external [transparent] [serialized] @extract_generic_struct
-sil [transparent] [serialized] @extract_generic_struct : $@convention(thin) GenericStruct<Int64> -> Int64 {
+sil [transparent] [serialized] @extract_generic_struct : $@convention(thin) (GenericStruct<Int64>) -> Int64 {
 entry(%0 : $GenericStruct<Int64>):
   // CHECK: %1 = struct_extract %0 : $GenericStruct<Int64>, #GenericStruct.x
   %1 = struct_extract %0 : $GenericStruct<Int64>, #GenericStruct.x
@@ -1449,7 +1449,7 @@ bb0:
   %31 = function_ref @$S6struct5AlephVyAcA3RefC1a_AA3ValV1btcACmcfC : $@convention(thin) (Ref, Val, @thin Aleph.Type) -> Aleph
   %33 = function_ref @$S6struct5AlephVyACycACmcfC : $@convention(thin) (@thin Aleph.Type) -> Aleph
   %35 = function_ref @test_union_empty_case : $@convention(thin) () -> Beth
-  %37 = function_ref @test_union_data_case : $@convention(thin) Int -> Beth
+  %37 = function_ref @test_union_data_case : $@convention(thin) (Int) -> Beth
   %39 = function_ref @test_union_addr_empty_case : $@convention(thin) () -> @out Gimel
   %41 = function_ref @test_union_addr_data_case : $@convention(thin) (@in Q) -> @out Gimel
   %43 = function_ref @$S5tuple5float1xySf_tF : $@convention(thin) (Float32) -> ()
@@ -1494,16 +1494,16 @@ bb0:
   %136 = function_ref @test_onone : $@convention(thin) () -> ()
   %137 = function_ref @test_ospeed : $@convention(thin) () -> ()
   %138 = function_ref @test_osize : $@convention(thin) () -> ()
-  %111 = function_ref @test_partial_apply : $@convention(thin) Float32 -> @callee_owned Int -> ()
+  %111 = function_ref @test_partial_apply : $@convention(thin) (Float32) -> @callee_owned (Int) -> ()
   %113 = function_ref @test_dynamic_lookup_br : $@convention(thin) (AnyObject) -> ()
   %115 = function_ref @test_mark_fn_escape : $@convention(thin) () -> ()
   %117 = function_ref @test_copy_release_value : $@convention(thin) (X) -> (X)
   %118 = function_ref @test_set_deallocating : $@convention(thin) (X) -> (X)
   %119 = function_ref @test_pointer_to_address : $@convention(thin) (Builtin.RawPointer, X) -> ()
   %120 = function_ref @test_bind_memory : $@convention(thin) (Builtin.RawPointer, Builtin.Word) -> ()
-  %121 = function_ref @cond_fail_test : $@convention(thin) Builtin.Int1 -> ()
+  %121 = function_ref @cond_fail_test : $@convention(thin) (Builtin.Int1) -> ()
 
-  %124 = function_ref @block_storage_type : $@convention(thin) Int -> @convention(block) () -> ()
+  %124 = function_ref @block_storage_type : $@convention(thin) (Int) -> @convention(block) () -> ()
   %127 = function_ref @bitcasts : $@convention(thin) (@owned Class1) -> @owned (Class2, Int)
   %133 = function_ref @test_try_apply : $@convention(thin) (@convention(thin) () -> @error Error) -> @error Error
   %135 = function_ref @test_try_nothrow : $@convention(thin) (@convention(thin) () -> @error Error) -> ()
@@ -1511,7 +1511,7 @@ bb0:
   %140 = function_ref @test_forward_ref : $@convention(thin) (UInt8, UInt8) -> UInt8
   %141 = function_ref @partial_apply : $@convention(thin) (@convention(thin) (Int) -> @out Int, Int) -> Int
   %142 = function_ref @partial_apply_with_closure : $@convention(thin) (@owned @callee_owned () -> Bool, @owned String, UnsafePointer<Int8>, Int64) -> ()
-  %143 = function_ref @extract_generic_struct : $@convention(thin) GenericStruct<Int64> -> Int64
+  %143 = function_ref @extract_generic_struct : $@convention(thin) (GenericStruct<Int64>) -> Int64
   %148 = function_ref @select_enum : $@convention(thin) (@in Beth) -> ()
   %149 = function_ref @existential_box : $@convention(thin) (SomeError) -> ()
   %150 = function_ref @bridge_object : $@convention(thin) (@owned Class1, Builtin.Word) -> ()

--- a/test/type/types.swift
+++ b/test/type/types.swift
@@ -165,9 +165,10 @@ class r21949448 {
 
 // SE-0066 - Standardize function type argument syntax to require parentheses
 let _ : Int -> Float // expected-error {{single argument function types require parentheses}} {{9-9=(}} {{12-12=)}}
-let _ : inout Int -> Float // expected-error {{single argument function types require parentheses}} {{9-9=(}} {{18-18=)}}
+let _ : inout Int -> Float // expected-error {{'inout' may only be used on parameters}}
+// expected-error@-1 {{single argument function types require parentheses}} {{15-15=(}} {{18-18=)}}
 func testNoParenFunction(x: Int -> Float) {} // expected-error {{single argument function types require parentheses}} {{29-29=(}} {{32-32=)}}
-func testNoParenFunction(x: inout Int -> Float) {} // expected-error {{single argument function types require parentheses}} {{29-29=(}} {{38-38=)}}
+func testNoParenFunction(x: inout Int -> Float) {} // expected-error {{single argument function types require parentheses}} {{35-35=(}} {{38-38=)}}
 
 func foo1(a : UnsafePointer<Void>) {} // expected-warning {{UnsafePointer<Void> has been replaced by UnsafeRawPointer}}{{15-34=UnsafeRawPointer}}
 func foo2(a : UnsafeMutablePointer<()>) {} // expected-warning {{UnsafeMutablePointer<Void> has been replaced by UnsafeMutableRawPointer}}{{15-39=UnsafeMutableRawPointer}}
@@ -180,7 +181,7 @@ class C {
   }
 }
 
-let _ : inout @convention(c) Int -> Int // expected-error {{'inout' may only be used on parameters}}
+let _ : inout @convention(c) (Int) -> Int // expected-error {{'inout' may only be used on parameters}}
 func foo3(inout a: Int -> Void) {} // expected-error {{'inout' before a parameter name is not allowed, place it before the parameter type instead}} {{11-16=}} {{20-20=inout }}
                                    // expected-error @-1 {{single argument function types require parentheses}} {{20-20=(}} {{23-23=)}}
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1461,26 +1461,18 @@ private:
     bool walkToTypeReprPre(TypeRepr *T) override {
       if (auto *FTR = dyn_cast<FunctionTypeRepr>(T)) {
         FoundFunctionTypeRepr = true;
-        if (auto *TTR = FTR->getArgsTypeRepr()) {
-          for (auto &ArgElt : TTR->getElements()) {
-            CharSourceRange NR;
-            CharSourceRange TR;
-            auto name = ArgElt.Name;
-            if (!name.empty()) {
-              NR = CharSourceRange(ArgElt.NameLoc,
-                                   name.getLength());
-            }
-            SourceLoc SRE = Lexer::getLocForEndOfToken(SM,
-                                                    ArgElt.Type->getEndLoc());
-            TR = CharSourceRange(SM, ArgElt.Type->getStartLoc(), SRE);
-            Info.Params.emplace_back(NR, TR);
-          }
-        } else if (FTR->getArgsTypeRepr()) {
+        for (auto &ArgElt : FTR->getArgsTypeRepr()->getElements()) {
+          CharSourceRange NR;
           CharSourceRange TR;
-          TR = CharSourceRange(SM, FTR->getArgsTypeRepr()->getStartLoc(),
-                               Lexer::getLocForEndOfToken(SM,
-                                        FTR->getArgsTypeRepr()->getEndLoc()));
-          Info.Params.emplace_back(CharSourceRange(), TR);
+          auto name = ArgElt.Name;
+          if (!name.empty()) {
+            NR = CharSourceRange(ArgElt.NameLoc,
+                                 name.getLength());
+          }
+          SourceLoc SRE = Lexer::getLocForEndOfToken(SM,
+                                                  ArgElt.Type->getEndLoc());
+          TR = CharSourceRange(SM, ArgElt.Type->getStartLoc(), SRE);
+          Info.Params.emplace_back(NR, TR);
         }
         if (auto *RTR = FTR->getResultTypeRepr()) {
           SourceLoc SRE = Lexer::getLocForEndOfToken(SM, RTR->getEndLoc());

--- a/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftEditor.cpp
@@ -1461,7 +1461,7 @@ private:
     bool walkToTypeReprPre(TypeRepr *T) override {
       if (auto *FTR = dyn_cast<FunctionTypeRepr>(T)) {
         FoundFunctionTypeRepr = true;
-        if (auto *TTR = dyn_cast_or_null<TupleTypeRepr>(FTR->getArgsTypeRepr())) {
+        if (auto *TTR = FTR->getArgsTypeRepr()) {
           for (auto &ArgElt : TTR->getElements()) {
             CharSourceRange NR;
             CharSourceRange TR;


### PR DESCRIPTION
Validation of the input side of FunctionTypeRepr was previously being done in Sema because of expression folding.  If we instead push the invariant that the input TypeRepr should always be a TupleTypeRepr into the AST a number of nice cleanups fall out:

- The SIL Parser no longer accepts Swift 2-style type declarations
-  Parse is more cleanly able to reject invalid FunctionTypeReprs
- Clients of the AST can be assured the input type is always a TupleType so we can flush Swift 2 hacks
