### PR TITLE
add @compilerEvaluable to Bool, Integer, and Optional functions in the stdlib

### DIFF
--- a/include/swift/AST/Attr.def
+++ b/include/swift/AST/Attr.def
@@ -321,7 +321,8 @@ DECL_ATTR(differentiable, Differentiable,
           OnFunc | LongAttribute, 76)
 
 SIMPLE_DECL_ATTR(compilerEvaluable, CompilerEvaluable,
-                 OnFunc | OnConstructor, /* Not serialized */ 77)
+                 OnFunc | OnConstructor | OnSubscript,
+		 /* Not serialized */ 77)
 
 #undef TYPE_ATTR
 #undef DECL_ATTR_ALIAS

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2594,6 +2594,16 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   attr->setAdjointFunction(resolvedAdjoint);
 }
 
+static bool
+compilerEvaluableAllowedInExtensionDecl(ExtensionDecl *extensionDecl) {
+  auto extendedTypeKind = extensionDecl->getExtendedType()->getKind();
+  return extendedTypeKind == TypeKind::Enum ||
+         extendedTypeKind == TypeKind::Protocol ||
+         extendedTypeKind == TypeKind::Struct ||
+         extendedTypeKind == TypeKind::BoundGenericEnum ||
+         extendedTypeKind == TypeKind::BoundGenericStruct;
+}
+
 void AttributeChecker::visitCompilerEvaluableAttr(CompilerEvaluableAttr *attr) {
   // Check that the function is defined in an allowed context.
   // TODO(marcrasi): In many cases, we can probably generate a more informative
@@ -2605,11 +2615,26 @@ void AttributeChecker::visitCompilerEvaluableAttr(CompilerEvaluableAttr *attr) {
   case DeclContextKind::AbstractFunctionDecl:
     // Nested functions are okay.
     break;
+  case DeclContextKind::ExtensionDecl:
+    // Enum, Protocol, and Struct extensions are okay. For Enums and Structs
+    // extensions, the extended type must be compiler-representable.
+    // TODO(marcrasi): Check that the extended type is compiler-representable.
+    if (!compilerEvaluableAllowedInExtensionDecl(
+            cast<ExtensionDecl>(declContext))) {
+      TC.diagnose(D, diag::compiler_evaluable_bad_context);
+      attr->setInvalid();
+      return;
+    }
+    break;
   case DeclContextKind::FileUnit:
     // Top level functions are okay.
     break;
   case DeclContextKind::GenericTypeDecl:
     switch (cast<GenericTypeDecl>(declContext)->getKind()) {
+    case DeclKind::Enum:
+      // Enums are okay, if they are compiler-representable.
+      // TODO(marcrasi): Check that it's compiler-representable.
+      break;
     case DeclKind::Struct:
       // Structs are okay, if they are compiler-representable.
       // TODO(marcrasi): Check that it's compiler-representable.

--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -21,6 +21,7 @@ import SwiftShims
 
 @_inlineable // FIXME(sil-serialize-all)
 @_transparent
+@compilerEvaluable
 public // @testable
 func _isDebugAssertConfiguration() -> Bool {
   // The values for the assert_configuration call are:
@@ -33,6 +34,7 @@ func _isDebugAssertConfiguration() -> Bool {
 @_inlineable // FIXME(sil-serialize-all)
 @_versioned
 @_transparent
+@compilerEvaluable
 internal func _isReleaseAssertConfiguration() -> Bool {
   // The values for the assert_configuration call are:
   // 0: Debug
@@ -43,6 +45,7 @@ internal func _isReleaseAssertConfiguration() -> Bool {
 
 @_inlineable // FIXME(sil-serialize-all)
 @_transparent
+@compilerEvaluable
 public // @testable
 func _isFastAssertConfiguration() -> Bool {
   // The values for the assert_configuration call are:

--- a/stdlib/public/core/Bool.swift
+++ b/stdlib/public/core/Bool.swift
@@ -70,6 +70,7 @@ public struct Bool {
   /// `false` to create a new `Bool` instance.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public init() {
     let zero: Int8 = 0
     self._value = Builtin.trunc_Int8_Int1(zero._value)
@@ -78,12 +79,14 @@ public struct Bool {
   @_inlineable // FIXME(sil-serialize-all)
   @_versioned
   @_transparent
+  @compilerEvaluable
   internal init(_ v: Builtin.Int1) { self._value = v }
   
   /// Creates an instance equal to the given Boolean value.
   ///
   /// - Parameter value: The Boolean value to copy.
   @_inlineable // FIXME(sil-serialize-all)
+  @compilerEvaluable
   public init(_ value: Bool) {
     self = value
   }
@@ -92,6 +95,7 @@ public struct Bool {
 extension Bool : _ExpressibleByBuiltinBooleanLiteral, ExpressibleByBooleanLiteral {
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public init(_builtinBooleanLiteral value: Builtin.Int1) {
     self._value = value
   }
@@ -116,6 +120,7 @@ extension Bool : _ExpressibleByBuiltinBooleanLiteral, ExpressibleByBooleanLitera
   /// - Parameter value: The value of the new instance.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public init(booleanLiteral value: Bool) {
     self = value
   }
@@ -125,6 +130,7 @@ extension Bool {
   // This is a magic entry point known to the compiler.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public // COMPILER_INTRINSIC
   func _getBuiltinLogicValue() -> Builtin.Int1 {
     return _value
@@ -165,6 +171,7 @@ extension Bool : Equatable, Hashable {
 
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static func == (lhs: Bool, rhs: Bool) -> Bool {
     return Bool(Builtin.cmp_eq_Int1(lhs._value, rhs._value))
   }
@@ -211,6 +218,7 @@ extension Bool {
   /// - Parameter a: The Boolean value to negate.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static prefix func ! (a: Bool) -> Bool {
     return Bool(Builtin.xor_Int1(a._value, true._value))
   }
@@ -252,6 +260,7 @@ extension Bool {
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   @inline(__always)
+  @compilerEvaluable
   public static func && (lhs: Bool, rhs: @autoclosure () throws -> Bool) rethrows
       -> Bool {
     return lhs ? try rhs() : false
@@ -293,6 +302,7 @@ extension Bool {
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   @inline(__always)
+  @compilerEvaluable
   public static func || (lhs: Bool, rhs: @autoclosure () throws -> Bool) rethrows
       -> Bool {
     return lhs ? true : try rhs()

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -291,6 +291,7 @@ public func _getUnsafePointerToStoredProperties(_ x: AnyObject)
 @_versioned
 @_transparent
 @_semantics("branchhint")
+@compilerEvaluable
 internal func _branchHint(_ actual: Bool, expected: Bool) -> Bool {
   return Bool(Builtin.int_expect_Int1(actual._value, expected._value))
 }
@@ -299,6 +300,7 @@ internal func _branchHint(_ actual: Bool, expected: Bool) -> Bool {
 @_inlineable // FIXME(sil-serialize-all)
 @_transparent
 @_semantics("fastpath")
+@compilerEvaluable
 public func _fastPath(_ x: Bool) -> Bool {
   return _branchHint(x, expected: true)
 }
@@ -307,6 +309,7 @@ public func _fastPath(_ x: Bool) -> Bool {
 @_inlineable // FIXME(sil-serialize-all)
 @_transparent
 @_semantics("slowpath")
+@compilerEvaluable
 public func _slowPath(_ x: Bool) -> Bool {
   return _branchHint(x, expected: false)
 }

--- a/stdlib/public/core/Equatable.swift
+++ b/stdlib/public/core/Equatable.swift
@@ -190,6 +190,7 @@ extension Equatable {
   ///   - rhs: Another value to compare.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static func != (lhs: Self, rhs: Self) -> Bool {
     return !(lhs == rhs)
   }

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -83,6 +83,7 @@ extension ExpressibleByIntegerLiteral
   where Self : _ExpressibleByBuiltinIntegerLiteral {
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public init(integerLiteral value: Self) {
     self = value
   }
@@ -1043,6 +1044,7 @@ extension ${Protocol} {
 ${operatorComment(x.operator, False)}
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static func ${x.operator}(_ lhs: Self, _ rhs: Self) -> Self {
     var lhs = lhs
     lhs ${x.operator}= rhs
@@ -1116,6 +1118,7 @@ extension SignedNumeric {
   /// - Returns: The additive inverse of the argument.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static prefix func - (_ operand: Self) -> Self {
     var result = operand
     result.negate()
@@ -1132,6 +1135,7 @@ extension SignedNumeric {
   ///     // x == -21
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public mutating func negate() {
     self = 0 - self
   }
@@ -1144,6 +1148,7 @@ extension SignedNumeric {
 /// - Returns: The absolute value of `x`.
 @_inlineable // FIXME(sil-serialize-all)
 @_transparent
+@compilerEvaluable
 public func abs<T : SignedNumeric>(_ x: T) -> T
   where T.Magnitude == T {
   return x.magnitude
@@ -1163,6 +1168,7 @@ public func abs<T : SignedNumeric>(_ x: T) -> T
 /// - Parameter x: A signed number.
 /// - Returns: The absolute value of `x`.
 @_inlineable // FIXME(sil-serialize-all)
+@compilerEvaluable
 public func abs<T : SignedNumeric & Comparable>(_ x: T) -> T {
   return x < 0 ? -x : x
 }
@@ -1181,6 +1187,7 @@ extension Numeric {
   /// - Returns: The given argument without any changes.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static prefix func + (x: Self) -> Self {
     return x
   }
@@ -1588,6 +1595,7 @@ extension BinaryInteger {
   /// Creates a new value equal to zero.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public init() {
     self = 0
   }
@@ -1599,6 +1607,7 @@ extension BinaryInteger {
   ///   type.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public func signum() -> Self {
     return (self > (0 as Self) ? 1 : 0) - (self < (0 as Self) ? 1 : 0)
   }
@@ -1649,6 +1658,7 @@ extension BinaryInteger {
   /// - Returns: A tuple containing the quotient and remainder of this value
   ///   divided by `rhs`.
   @_inlineable // FIXME(sil-serialize-all)
+  @compilerEvaluable
   public func quotientAndRemainder(dividingBy rhs: Self)
     -> (quotient: Self, remainder: Self) {
     return (self / rhs, self % rhs)
@@ -1660,6 +1670,7 @@ extension BinaryInteger {
 ${operatorComment(x.operator, False)}
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static func ${x.operator} (lhs: Self, rhs: Self) -> Self {
     var lhs = lhs
     lhs ${x.operator}= rhs
@@ -1673,6 +1684,7 @@ ${operatorComment(x.operator, False)}
 ${operatorComment(x.nonMaskingOperator, False)}
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @_inlineable
+  @compilerEvaluable
   public static func ${x.nonMaskingOperator}<RHS: BinaryInteger>(
     _ lhs: Self, _ rhs: RHS
   ) -> Self {
@@ -1770,6 +1782,7 @@ extension BinaryInteger {
   /// - Returns: The distance from this value to `other`.
   @_inlineable // FIXME(sil-serialize-all)
   @inline(__always)
+  @compilerEvaluable
   public func distance(to other: Self) -> Int {
     if !Self.isSigned {
       if self > other {
@@ -1810,6 +1823,7 @@ extension BinaryInteger {
   /// - Returns: A value that is offset from this value by `n`.
   @_inlineable // FIXME(sil-serialize-all)
   @inline(__always)
+  @compilerEvaluable
   public func advanced(by n: Int) -> Self {
     if !Self.isSigned {
       return n < (0 as Int)
@@ -1837,6 +1851,7 @@ extension Int {
   /// - Returns: The distance from this value to `other`.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public func distance(to other: Int) -> Int {
     return other - self
   }
@@ -1855,6 +1870,7 @@ extension Int {
   /// - Returns: A value that is offset from this value by `n`.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public func advanced(by n: Int) -> Int {
     return self + n
   }
@@ -1886,6 +1902,7 @@ extension BinaryInteger {
   ///   - rhs: Another integer to compare.
   @_inlineable // FIXME(sil-serialize-all)
   @inline(__always)
+  @compilerEvaluable
   public static func == <
     Other : BinaryInteger
   >(lhs: Self, rhs: Other) -> Bool {
@@ -1944,6 +1961,7 @@ extension BinaryInteger {
   ///   - rhs: Another integer to compare.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static func != <
     Other : BinaryInteger
   >(lhs: Self, rhs: Other) -> Bool {
@@ -1962,6 +1980,7 @@ extension BinaryInteger {
   ///   - rhs: Another integer to compare.
   @_inlineable // FIXME(sil-serialize-all)
   @inline(__always)
+  @compilerEvaluable
   public static func < <Other : BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
     let lhsNegative = Self.isSigned && lhs < (0 as Self)
     let rhsNegative = Other.isSigned && rhs < (0 as Other)
@@ -2006,6 +2025,7 @@ extension BinaryInteger {
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   //@inline(__always)
+  @compilerEvaluable
   public static func <= <Other : BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
     return !(rhs < lhs)
   }
@@ -2023,6 +2043,7 @@ extension BinaryInteger {
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   //@inline(__always)
+  @compilerEvaluable
   public static func >= <Other : BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
     return !(lhs < rhs)
   }
@@ -2040,6 +2061,7 @@ extension BinaryInteger {
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   //@inline(__always)
+  @compilerEvaluable
   public static func > <Other : BinaryInteger>(lhs: Self, rhs: Other) -> Bool {
     return rhs < lhs
   }
@@ -2064,24 +2086,28 @@ extension BinaryInteger {
 extension BinaryInteger {
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static func != (lhs: Self, rhs: Self) -> Bool {
     return !(lhs == rhs)
   }
 
   @_inlineable // FIXME(sil-serialize-all)
   @inline(__always)
+  @compilerEvaluable
   public static func <= (lhs: Self, rhs: Self) -> Bool {
     return !(rhs < lhs)
   }
 
   @_inlineable // FIXME(sil-serialize-all)
   @inline(__always)
+  @compilerEvaluable
   public static func >= (lhs: Self, rhs: Self) -> Bool {
     return !(lhs < rhs)
   }
 
   @_inlineable // FIXME(sil-serialize-all)
   @inline(__always)
+  @compilerEvaluable
   public static func > (lhs: Self, rhs: Self) -> Bool {
     return rhs < lhs
   }
@@ -2325,6 +2351,7 @@ extension FixedWidthInteger {
   public var bitWidth: Int { return Self.bitWidth }
 
   @_inlineable // FIXME(sil-serialize-all)
+  @compilerEvaluable
   public func _binaryLogarithm() -> Self {
     _precondition(self > (0 as Self))
     return Self(Self.bitWidth &- (leadingZeroBitCount &+ 1))
@@ -2336,6 +2363,7 @@ extension FixedWidthInteger {
   /// - Parameter value: A value to use as the little-endian representation of
   ///   the new integer.
   @_inlineable // FIXME(sil-serialize-all)
+  @compilerEvaluable
   public init(littleEndian value: Self) {
 #if _endian(little)
     self = value
@@ -2350,6 +2378,7 @@ extension FixedWidthInteger {
   /// - Parameter value: A value to use as the big-endian representation of the
   ///   new integer.
   @_inlineable // FIXME(sil-serialize-all)
+  @compilerEvaluable
   public init(bigEndian value: Self) {
 #if _endian(big)
     self = value
@@ -2393,6 +2422,7 @@ ${operatorComment(x.operator, False)}
   @_inlineable // FIXME(sil-serialize-all)
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @_transparent
+  @compilerEvaluable
   public static func ${x.operator} (lhs: Self, rhs: Self) -> Self {
     var lhs = lhs
     lhs ${x.operator}= rhs
@@ -2404,6 +2434,7 @@ ${operatorComment(x.operator, False)}
 ${operatorComment(x.operator, False)}
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @_inlineable
+  @compilerEvaluable
   public static func ${x.operator} <
     Other : BinaryInteger
   >(lhs: Self, rhs: Other) -> Self {
@@ -2415,6 +2446,7 @@ ${assignmentOperatorComment(x.operator, False)}
   @_inlineable // FIXME(sil-serialize-all)
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @_transparent
+  @compilerEvaluable
   public static func ${x.operator}= <
     Other : BinaryInteger
   >(lhs: inout Self, rhs: Other) {
@@ -2448,6 +2480,7 @@ extension FixedWidthInteger {
   /// - Complexity: O(1).
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static prefix func ~ (x: Self) -> Self {
     return 0 &- x &- 1
   }
@@ -2462,6 +2495,7 @@ ${operatorComment(x.nonMaskingOperator, True)}
   @_inlineable // FIXME(sil-serialize-all)
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @_transparent
+  @compilerEvaluable
   public static func ${x.nonMaskingOperator} <
     Other : BinaryInteger
   >(lhs: Self, rhs: Other) -> Self {
@@ -2473,6 +2507,7 @@ ${operatorComment(x.nonMaskingOperator, True)}
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
   @_semantics("optimize.sil.specialize.generic.partial.never")
+  @compilerEvaluable
   public static func ${x.nonMaskingOperator}= <
     Other : BinaryInteger
   >(lhs: inout Self, rhs: Other) {
@@ -2481,6 +2516,7 @@ ${operatorComment(x.nonMaskingOperator, True)}
 
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static func ${x.helper}Generic <
     Other : BinaryInteger
   >(_ lhs: inout Self, _ rhs: Other) {
@@ -2494,6 +2530,7 @@ ${operatorComment(x.nonMaskingOperator, True)}
 %   isRightShift = '>' in x.operator
   @_inlineable // FIXME(sil-serialize-all)
   @inline(__always)
+  @compilerEvaluable
   public static func ${x.helper}(_ lhs: Self, _ rhs: Int) -> Self {
     let overshiftR = Self.isSigned ? lhs &>> (Self.bitWidth - 1) : 0
     let overshiftL: Self = 0
@@ -2625,6 +2662,7 @@ extension FixedWidthInteger {
   /// - Parameter source: An integer to convert to this type.
   @_inlineable // FIXME(sil-serialize-all)
   @_semantics("optimize.sil.specialize.generic.partial.never")
+  @compilerEvaluable
   public init<Other : BinaryInteger>(clamping source: Other) {
     if _slowPath(source < Self.min) {
       self = Self.min
@@ -2642,6 +2680,7 @@ extension FixedWidthInteger {
 #if false
 ${assignmentOperatorComment(x.operator, True)}
   @_transparent
+  @compilerEvaluable
   public static func ${x.operator}=(_ lhs: inout Self, _ rhs: Self) {
     let (result, overflow) = lhs.${x.name}ReportingOverflow(${callLabel}rhs)
     _precondition(!overflow, "Overflow in ${x.operator}=")
@@ -2653,6 +2692,7 @@ ${assignmentOperatorComment(x.operator, True)}
 ${unsafeOperationComment(x.operator)}
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public func unsafe${capitalize(x.name)}(${x.firstArg} other: Self) -> Self {
     let (result, overflow) = self.${x.name}ReportingOverflow(${callLabel}other)
 
@@ -2706,6 +2746,7 @@ ${unsafeOperationComment(x.operator)}
   /// - Parameter source: An integer to convert to this type.
   @_inlineable // FIXME(sil-serialize-all)
   @inline(__always)
+  @compilerEvaluable
   public init<T : BinaryInteger>(truncatingIfNeeded source: T) {
     if Self.bitWidth <= ${word_bits} {
       self = Self.init(_truncatingBits: source._lowWord)
@@ -2740,6 +2781,7 @@ ${unsafeOperationComment(x.operator)}
 ${operatorComment('&' + x.operator, True)}
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static func &${x.operator} (lhs: Self, rhs: Self) -> Self {
     return lhs.${x.name}ReportingOverflow(${callLabel}rhs).partialValue
   }
@@ -2799,6 +2841,7 @@ extension UnsignedInteger where Self : FixedWidthInteger {
   @_inlineable // FIXME(sil-serialize-all)
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @inline(__always)
+  @compilerEvaluable
   public init<T : BinaryInteger>(_ source: T) {
     // This check is potentially removable by the optimizer
     if T.isSigned {
@@ -2830,6 +2873,7 @@ extension UnsignedInteger where Self : FixedWidthInteger {
   @_inlineable // FIXME(sil-serialize-all)
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @inline(__always)
+  @compilerEvaluable
   public init?<T : BinaryInteger>(exactly source: T) {
     // This check is potentially removable by the optimizer
     if T.isSigned && source < (0 as T) {
@@ -2907,6 +2951,7 @@ extension SignedInteger where Self : FixedWidthInteger {
   @_inlineable // FIXME(sil-serialize-all)
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @inline(__always)
+  @compilerEvaluable
   public init<T : BinaryInteger>(_ source: T) {
     // This check is potentially removable by the optimizer
     if T.isSigned && source.bitWidth > Self.bitWidth {
@@ -2940,6 +2985,7 @@ extension SignedInteger where Self : FixedWidthInteger {
   @_inlineable // FIXME(sil-serialize-all)
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @inline(__always)
+  @compilerEvaluable
   public init?<T : BinaryInteger>(exactly source: T) {
     // This check is potentially removable by the optimizer
     if T.isSigned && source.bitWidth > Self.bitWidth && source < Self.min {
@@ -3012,6 +3058,7 @@ public struct ${Self}
 
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public init(_builtinIntegerLiteral x: _MaxBuiltinIntegerType) {
     _value = Builtin.s_to_${u}_checked_trunc_${IntLiteral}_${BuiltinName}(x).0
   }
@@ -3028,6 +3075,7 @@ public struct ${Self}
   ///   representation.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public init(bitPattern x: ${OtherSelf}) {
     _value = x._value
   }
@@ -3036,6 +3084,7 @@ public struct ${Self}
 %     Floating = {32 : 'Float', 64 : 'Double'}[bits]
   @available(*, unavailable,
     message: "Please use ${Self}(bitPattern: ${OtherSelf}) in combination with ${Floating}.bitPattern property.")
+  @compilerEvaluable
   public init(bitPattern x: ${Floating}) {
     Builtin.unreachable()
   }
@@ -3112,12 +3161,14 @@ public struct ${Self}
 
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static func == (lhs: ${Self}, rhs: ${Self}) -> Bool {
     return Bool(Builtin.cmp_eq_Int${bits}(lhs._value, rhs._value))
   }
 
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static func < (lhs: ${Self}, rhs: ${Self}) -> Bool {
     return Bool(Builtin.cmp_${u}lt_Int${bits}(lhs._value, rhs._value))
   }
@@ -3127,6 +3178,7 @@ public struct ${Self}
 ${assignmentOperatorComment(x.operator, True)}
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static func ${x.operator}=(_ lhs: inout ${Self}, _ rhs: ${Self}) {
 %   if x.kind == '/':
     // No LLVM primitives for checking overflow of division operations, so we
@@ -3161,6 +3213,7 @@ ${assignmentOperatorComment(x.operator, True)}
 ${overflowOperationComment(x.operator)}
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public func ${x.name}ReportingOverflow(
     ${x.firstArg} other: ${Self}
   ) -> (partialValue: ${Self}, overflow: Bool) {
@@ -3197,6 +3250,7 @@ ${overflowOperationComment(x.operator)}
 ${assignmentOperatorComment('%', True)}
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static func %=(_ lhs: inout ${Self}, _ rhs: ${Self}) {
     // No LLVM primitives for checking overflow of division operations, so we
     // check manually.
@@ -3219,6 +3273,7 @@ ${assignmentOperatorComment('%', True)}
 
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public init(_ _value: Builtin.Int${bits}) {
     self._value = _value
   }
@@ -3227,6 +3282,7 @@ ${assignmentOperatorComment('%', True)}
   // updated
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public init(_bits: Builtin.Int${bits}) {
     self._value = _bits
   }
@@ -3235,6 +3291,7 @@ ${assignmentOperatorComment('%', True)}
 ${assignmentOperatorComment(x.operator, True)}
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static func ${x.operator}=(_ lhs: inout ${Self}, _ rhs: ${Self}) {
     lhs = ${Self}(Builtin.${x.llvmName}_Int${bits}(lhs._value, rhs._value))
   }
@@ -3245,6 +3302,7 @@ ${assignmentOperatorComment(x.operator, True)}
 ${assignmentOperatorComment(x.operator, True)}
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static func ${x.operator}=(_ lhs: inout ${Self}, _ rhs: ${Self}) {
     let rhs_ = rhs & ${bits - 1}
     lhs = ${Self}(
@@ -3327,6 +3385,7 @@ ${assignmentOperatorComment(x.operator, True)}
     internal var _value: ${Self}
 
     @_inlineable // FIXME(sil-serialize-all)
+    @compilerEvaluable
     public init(_ value: ${Self}) {
       self._value = value
     }
@@ -3347,13 +3406,16 @@ ${assignmentOperatorComment(x.operator, True)}
 
     @_inlineable // FIXME(sil-serialize-all)
     @_transparent
+    @compilerEvaluable
     public func index(after i: Int) -> Int { return i + 1 }
 
     @_inlineable // FIXME(sil-serialize-all)
     @_transparent
+    @compilerEvaluable
     public func index(before i: Int) -> Int { return i - 1 }
 
     @_inlineable // FIXME(sil-serialize-all)
+    @compilerEvaluable
     public subscript(position: Int) -> UInt {
       get {
         _precondition(position >= 0, "Negative word index")
@@ -3390,6 +3452,7 @@ ${assignmentOperatorComment(x.operator, True)}
 
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public // transparent
   init(_truncatingBits bits: UInt) {
     % truncOrExt = 'zext' if bits > word_bits else 'trunc'
@@ -3455,6 +3518,7 @@ ${assignmentOperatorComment(x.operator, True)}
   /// - Returns: A tuple containing the high and low parts of the result of
   ///   multiplying this value and `other`.
   @_inlineable // FIXME(sil-serialize-all)
+  @compilerEvaluable
   public func multipliedFullWidth(by other: ${Self})
     -> (high: ${Self}, low: ${Self}.Magnitude) {
     // FIXME(integers): tests
@@ -3550,6 +3614,7 @@ ${assignmentOperatorComment(x.operator, True)}
 % if self_type.is_word:
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public // @testable
   init(_ _v: Builtin.Word) {
 % if BuiltinName == 'Int32':
@@ -3573,6 +3638,7 @@ ${assignmentOperatorComment(x.operator, True)}
 
   @_inlineable // FIXME(sil-serialize-all)
   @available(swift, obsoleted: 4.0, message: "Use initializers instead")
+  @compilerEvaluable
   public func to${U}IntMax() -> ${U}Int64 {
     return numericCast(self)
   }
@@ -3592,6 +3658,7 @@ ${assignmentOperatorComment(x.operator, True)}
   ///   type.
   @_inlineable // FIXME(sil-serialize-all)
   @inline(__always)
+  @compilerEvaluable
   public func signum() -> ${Self} {
     let isPositive = ${Self}(Builtin.zext_Int1_Int${bits}(
       (self > (0 as ${Self}))._value))
@@ -3661,6 +3728,7 @@ extension ${Self} {
   @_inlineable // FIXME(sil-serialize-all)
   @available(swift, obsoleted: 4.0, renamed: "init(truncatingIfNeeded:)")
   @_transparent
+  @compilerEvaluable
   public init(truncatingBitPattern source: ${Src}) {
     let src = source._value
 %     if self_type.bits == src_type.bits:
@@ -3686,6 +3754,7 @@ extension ${Self} {
 ${operatorComment(x.operator, True)}
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static func ${x.operator}(_ lhs: ${Self}, _ rhs: ${Self}) -> ${Self} {
     var lhs = lhs
     lhs ${x.operator}= rhs
@@ -3701,6 +3770,7 @@ ${operatorComment(x.operator, True)}
   @available(swift, obsoleted: 4)
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @_transparent
+  @compilerEvaluable
   public static func ${op.nonMaskingOperator}(
     lhs: ${Self}, rhs: ${Self}
   ) -> ${Self} {
@@ -3714,6 +3784,7 @@ ${assignmentOperatorComment(x.operator, True)}
   @available(swift, obsoleted: 4)
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @_transparent
+  @compilerEvaluable
   public static func ${op.nonMaskingOperator}=(
     lhs: inout ${Self}, rhs: ${Self}
   ) {
@@ -3724,24 +3795,28 @@ ${assignmentOperatorComment(x.operator, True)}
 
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static func != (lhs: ${Self}, rhs: ${Self}) -> Bool {
     return !(lhs == rhs)
   }
 
   @_inlineable // FIXME(sil-serialize-all)
   @inline(__always)
+  @compilerEvaluable
   public static func <= (lhs: ${Self}, rhs: ${Self}) -> Bool {
     return !(rhs < lhs)
   }
 
   @_inlineable // FIXME(sil-serialize-all)
   @inline(__always)
+  @compilerEvaluable
   public static func >= (lhs: ${Self}, rhs: ${Self}) -> Bool {
     return !(lhs < rhs)
   }
 
   @_inlineable // FIXME(sil-serialize-all)
   @inline(__always)
+  @compilerEvaluable
   public static func > (lhs: ${Self}, rhs: ${Self}) -> Bool {
     return rhs < lhs
   }
@@ -3754,6 +3829,7 @@ ${assignmentOperatorComment(x.operator, True)}
 /// It has only an effect if the argument is a load or call.
 @_inlineable // FIXME(sil-serialize-all)
 @_transparent
+@compilerEvaluable
 public func _assumeNonNegative(_ x: ${Self}) -> ${Self} {
   _sanityCheck(x >= (0 as ${Self}))
   return ${Self}(Builtin.assumeNonNegative_${BuiltinName}(x._value))
@@ -3789,6 +3865,7 @@ public func _assumeNonNegative(_ x: ${Self}) -> ${Self} {
 /// - Returns: The value of `x` converted to type `U`.
 @_inlineable // FIXME(sil-serialize-all)
 @_transparent
+@compilerEvaluable
 public func numericCast<T : BinaryInteger, U : BinaryInteger>(_ x: T) -> U {
   return U(x)
 }
@@ -3796,6 +3873,7 @@ public func numericCast<T : BinaryInteger, U : BinaryInteger>(_ x: T) -> U {
 // FIXME(integers): switch to using `FixedWidthInteger.unsafeAdding`
 @_inlineable // FIXME(sil-serialize-all)
 @_versioned // FIXME(sil-serialize-all)
+@compilerEvaluable
 internal func _unsafePlus(_ lhs: Int, _ rhs: Int) -> Int {
 #if INTERNAL_CHECKS_ENABLED
   return lhs + rhs
@@ -3807,6 +3885,7 @@ internal func _unsafePlus(_ lhs: Int, _ rhs: Int) -> Int {
 // FIXME(integers): switch to using `FixedWidthInteger.unsafeSubtracting`
 @_inlineable // FIXME(sil-serialize-all)
 @_versioned // FIXME(sil-serialize-all)
+@compilerEvaluable
 internal func _unsafeMinus(_ lhs: Int, _ rhs: Int) -> Int {
 #if INTERNAL_CHECKS_ENABLED
   return lhs - rhs
@@ -3836,6 +3915,7 @@ extension SignedNumeric where Self : Comparable {
   @_inlineable // FIXME(sil-serialize-all)
   @available(swift, obsoleted: 4, message: "Please use the 'abs(_:)' free function.")
   @_transparent
+  @compilerEvaluable
   public static func abs(_ x: Self) -> Self {
     return Swift.abs(x)
   }
@@ -3845,6 +3925,7 @@ extension SignedNumeric where Self : Comparable {
 extension BinaryInteger {
   @_inlineable // FIXME(sil-serialize-all)
   @available(swift, obsoleted: 4)
+  @compilerEvaluable
   public func toIntMax() -> Int64 {
     return Int64(self)
   }
@@ -3853,6 +3934,7 @@ extension BinaryInteger {
 extension UnsignedInteger {
   @_inlineable // FIXME(sil-serialize-all)
   @available(swift, obsoleted: 4)
+  @compilerEvaluable
   public func toUIntMax() -> UInt64 {
     return UInt64(self)
   }
@@ -3872,6 +3954,7 @@ extension FixedWidthInteger {
   @available(swift, obsoleted: 4)
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @_transparent
+  @compilerEvaluable
   public static func ${op.nonMaskingOperator}(
     lhs: Self, rhs: Self
   ) -> Self {
@@ -3884,6 +3967,7 @@ extension FixedWidthInteger {
   @available(swift, obsoleted: 4)
   @_semantics("optimize.sil.specialize.generic.partial.never")
   @_transparent
+  @compilerEvaluable
   public static func ${op.nonMaskingOperator}=(
     lhs: inout Self, rhs: Self
   ) {
@@ -3909,6 +3993,7 @@ extension FixedWidthInteger {
   @_inlineable // FIXME(sil-serialize-all)
   @available(swift, obsoleted: 4, message: "Use ${newPrefix}ReportingOverflow(${argLabel or '_:'}) instead.")
   @_transparent
+  @compilerEvaluable
   public static func ${oldPrefix}WithOverflow(
     _ lhs: Self, _ rhs: Self
   ) -> (Self, overflow: Bool) {
@@ -3925,6 +4010,7 @@ extension BinaryInteger {
   @_inlineable // FIXME(sil-serialize-all)
   @available(swift, obsoleted: 3.2,
     message: "Please use FixedWidthInteger protocol as a generic constraint and ${newPrefix}ReportingOverflow(${argLabel or '_:'}) method instead.")
+  @compilerEvaluable
   public static func ${oldPrefix}WithOverflow(
     _ lhs: Self, _ rhs: Self
   ) -> (Self, overflow: Bool) {
@@ -3948,6 +4034,7 @@ extension BinaryInteger {
 extension SignedInteger {
 %   for (op, helper, _) in maskingOpsSwift3:
   @_inlineable // FIXME(sil-serialize-all)
+  @compilerEvaluable
   public static func ${helper}(_ lhs: Self, _ rhs: Self) -> Self {
     fatalError("Should be overridden in a more specific type")
   }
@@ -3955,6 +4042,7 @@ extension SignedInteger {
   @_inlineable // FIXME(sil-serialize-all)
   @available(swift, obsoleted: 4.0,
       message: "Please use 'FixedWidthInteger' instead of 'SignedInteger' to get '${op}' in generic code.")
+  @compilerEvaluable
   public static func ${op} (lhs: Self, rhs: Self) -> Self {
     return ${helper}(lhs, rhs)
   }
@@ -3966,11 +4054,13 @@ extension SignedInteger where Self : FixedWidthInteger {
   // This overload is supposed to break the ambiguity between the
   // implementations on SignedInteger and FixedWidthInteger
   @_inlineable // FIXME(sil-serialize-all)
+  @compilerEvaluable
   public static func ${op} (lhs: Self, rhs: Self) -> Self {
     return ${helper}(lhs, rhs)
   }
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static func ${helper}(_ lhs: Self, _ rhs: Self) -> Self {
     return lhs.${action}ReportingOverflow(rhs).partialValue
   }

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -135,6 +135,7 @@ public enum Optional<Wrapped> : ExpressibleByNilLiteral {
   /// Creates an instance that stores the given value.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public init(_ some: Wrapped) { self = .some(some) }
 
   /// Evaluates the given closure when this `Optional` instance is not `nil`,
@@ -159,6 +160,7 @@ public enum Optional<Wrapped> : ExpressibleByNilLiteral {
   /// - Returns: The result of the given closure. If this instance is `nil`,
   ///   returns `nil`.
   @_inlineable
+  @compilerEvaluable
   public func map<U>(
     _ transform: (Wrapped) throws -> U
   ) rethrows -> U? {
@@ -190,6 +192,7 @@ public enum Optional<Wrapped> : ExpressibleByNilLiteral {
   /// - Returns: The result of the given closure. If this instance is `nil`,
   ///   returns `nil`.
   @_inlineable
+  @compilerEvaluable
   public func flatMap<U>(
     _ transform: (Wrapped) throws -> U?
   ) rethrows -> U? {
@@ -212,6 +215,7 @@ public enum Optional<Wrapped> : ExpressibleByNilLiteral {
   /// initializer behind the scenes.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public init(nilLiteral: ()) {
     self = .none
   }
@@ -359,6 +363,7 @@ extension Optional : Equatable where Wrapped : Equatable {
   ///   - lhs: An optional value to compare.
   ///   - rhs: Another optional value to compare.
   @_inlineable
+  @compilerEvaluable
   public static func ==(lhs: Wrapped?, rhs: Wrapped?) -> Bool {
     switch (lhs, rhs) {
     case let (l?, r?):
@@ -404,6 +409,7 @@ extension Optional : Equatable where Wrapped : Equatable {
   ///   - lhs: An optional value to compare.
   ///   - rhs: Another optional value to compare.
   @_inlineable
+  @compilerEvaluable
   public static func !=(lhs: Wrapped?, rhs: Wrapped?) -> Bool {
     return !(lhs == rhs)
   }
@@ -416,6 +422,7 @@ public struct _OptionalNilComparisonType : ExpressibleByNilLiteral {
   /// Create an instance initialized with `nil`.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public init(nilLiteral: ()) {
   }
 }
@@ -453,6 +460,7 @@ extension Optional {
   ///   - rhs: A value to match against `nil`.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static func ~=(lhs: _OptionalNilComparisonType, rhs: Wrapped?) -> Bool {
     switch rhs {
     case .some(_):
@@ -488,6 +496,7 @@ extension Optional {
   ///   - rhs: A `nil` literal.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static func ==(lhs: Wrapped?, rhs: _OptionalNilComparisonType) -> Bool {
     switch lhs {
     case .some(_):
@@ -520,6 +529,7 @@ extension Optional {
   ///   - rhs: A `nil` literal.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static func !=(lhs: Wrapped?, rhs: _OptionalNilComparisonType) -> Bool {
     switch lhs {
     case .some(_):
@@ -552,6 +562,7 @@ extension Optional {
   ///   - rhs: A value to compare to `nil`.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static func ==(lhs: _OptionalNilComparisonType, rhs: Wrapped?) -> Bool {
     switch rhs {
     case .some(_):
@@ -584,6 +595,7 @@ extension Optional {
   ///   - rhs: A value to compare to `nil`.
   @_inlineable // FIXME(sil-serialize-all)
   @_transparent
+  @compilerEvaluable
   public static func !=(lhs: _OptionalNilComparisonType, rhs: Wrapped?) -> Bool {
     switch rhs {
     case .some(_):
@@ -628,6 +640,7 @@ extension Optional {
 ///     type as the `Wrapped` type of `optional`.
 @_inlineable // FIXME(sil-serialize-all)
 @_transparent
+@compilerEvaluable
 public func ?? <T>(optional: T?, defaultValue: @autoclosure () throws -> T)
     rethrows -> T {
   switch optional {
@@ -682,6 +695,7 @@ public func ?? <T>(optional: T?, defaultValue: @autoclosure () throws -> T)
 ///     `optional` have the same type.
 @_inlineable // FIXME(sil-serialize-all)
 @_transparent
+@compilerEvaluable
 public func ?? <T>(optional: T?, defaultValue: @autoclosure () throws -> T?)
     rethrows -> T? {
   switch optional {

--- a/test/Sema/compiler_evaluable.swift
+++ b/test/Sema/compiler_evaluable.swift
@@ -7,7 +7,7 @@ protocol AProtocol {
 
 extension AProtocol {
   @compilerEvaluable
-  func extensionFunc() {} // expected-error{{@compilerEvaluable functions not allowed here}}
+  func extensionFunc() {}
 }
 
 class AClass {
@@ -16,6 +16,11 @@ class AClass {
 
   @compilerEvaluable
   func classFunc() {} // expected-error{{@compilerEvaluable functions not allowed here}}
+}
+
+extension AClass {
+  @compilerEvaluable
+  func extensionFunc() {} // expected-error{{@compilerEvaluable functions not allowed here}}
 }
 
 struct AStruct {
@@ -34,9 +39,66 @@ struct AStruct {
     @compilerEvaluable
     set(prop) {}
   }
+
+  subscript(i: Int) -> Int {
+    @compilerEvaluable
+    get {}
+
+    @compilerEvaluable
+    set(v) {}
+  }
+}
+
+extension AStruct {
+  @compilerEvaluable
+  func extensionFunc() {}
+}
+
+struct AGenericStruct<T> {
+  @compilerEvaluable
+  init() {}
+
+  @compilerEvaluable
+  func structFunc() {}
+}
+
+extension AGenericStruct {
+  @compilerEvaluable
+  func extensionFunc() {}
+}
+
+enum AEnum {
+  case thing1
+  case thing2
+
+  @compilerEvaluable
+  func enumFunc() {}
+}
+
+extension AEnum {
+  @compilerEvaluable
+  func extensionFunc() {}
+}
+
+enum AGenericEnum<T> {
+  case thing1
+  case thing2
+
+  @compilerEvaluable
+  func enumFunc() {}
+}
+
+extension AGenericEnum {
+  @compilerEvaluable
+  func extensionFunc() {}
 }
 
 func aFunction() {
+  @compilerEvaluable
+  func functionFunc() {}
+}
+
+func aGenericFunction<T>(t: T) {
   @compilerEvaluable
   func functionFunc() {}
 }

--- a/test/SourceKit/DocSupport/doc_swift_module.swift.response
+++ b/test/SourceKit/DocSupport/doc_swift_module.swift.response
@@ -36,7 +36,7 @@ extension C1 : P4 {
 
 extension C1.C1Cases {
 
-    static func != (_ lhs: C1.C1Cases, _ rhs: C1.C1Cases) -> Bool
+    @compilerEvaluable static func != (_ lhs: C1.C1Cases, _ rhs: C1.C1Cases) -> Bool
 }
 
 class C2 : cake.C1 {
@@ -69,7 +69,7 @@ enum MyEnum : Int {
 
     case Blah
 
-    static func != (_ lhs: MyEnum, _ rhs: MyEnum) -> Bool
+    @compilerEvaluable static func != (_ lhs: MyEnum, _ rhs: MyEnum) -> Bool
 }
 
 @objc protocol P2 {
@@ -142,7 +142,7 @@ struct S1 {
 
 extension S1.SE {
 
-    static func != (_ lhs: S1.SE, _ rhs: S1.SE) -> Bool
+    @compilerEvaluable static func != (_ lhs: S1.SE, _ rhs: S1.SE) -> Bool
 }
 
 struct S2 : P3 {
@@ -470,38 +470,19 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
     key.length: 7
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
     key.offset: 455,
+    key.length: 18
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 474,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 462,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 471,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 473,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.ref.class,
-    key.name: "C1",
-    key.usr: "s:4cake2C1C",
-    key.offset: 478,
-    key.length: 2
-  },
-  {
-    key.kind: source.lang.swift.ref.enum,
-    key.name: "C1Cases",
-    key.usr: "s:4cake2C1C0B5CasesO",
     key.offset: 481,
-    key.length: 7
+    key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
@@ -528,80 +509,94 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
     key.length: 7
   },
   {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 509,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 511,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.class,
+    key.name: "C1",
+    key.usr: "s:4cake2C1C",
+    key.offset: 516,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.ref.enum,
+    key.name: "C1Cases",
+    key.usr: "s:4cake2C1C0B5CasesO",
+    key.offset: 519,
+    key.length: 7
+  },
+  {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 512,
+    key.offset: 531,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 520,
+    key.offset: 539,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 526,
+    key.offset: 545,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 531,
+    key.offset: 550,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "C1",
     key.usr: "s:4cake2C1C",
-    key.offset: 536,
+    key.offset: 555,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 546,
+    key.offset: 565,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 551,
+    key.offset: 570,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 564,
+    key.offset: 583,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 569,
+    key.offset: 588,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 579,
+    key.offset: 598,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 594,
+    key.offset: 613,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 599,
+    key.offset: 618,
     key.length: 5
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 616,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 621,
-    key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
@@ -611,785 +606,768 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 640,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 654,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 659,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 652,
+    key.offset: 671,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 662,
+    key.offset: 681,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 664,
+    key.offset: 683,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 671,
+    key.offset: 690,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 679,
+    key.offset: 698,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 685,
+    key.offset: 704,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 694,
+    key.offset: 713,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "C2",
     key.usr: "s:4cake2C2C",
-    key.offset: 704,
+    key.offset: 723,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P4",
     key.usr: "s:4cake2P4P",
-    key.offset: 709,
+    key.offset: 728,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 719,
+    key.offset: 738,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 724,
+    key.offset: 743,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 737,
+    key.offset: 756,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 744,
+    key.offset: 763,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 760,
+    key.offset: 779,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 765,
+    key.offset: 784,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 773,
+    key.offset: 792,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 775,
+    key.offset: 794,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P4",
     key.usr: "s:4cake2P4P",
-    key.offset: 778,
+    key.offset: 797,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 791,
+    key.offset: 810,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 796,
+    key.offset: 815,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 805,
+    key.offset: 824,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 816,
+    key.offset: 835,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 821,
+    key.offset: 840,
     key.length: 4
   },
   {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 831,
-    key.length: 6
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 850,
+    key.length: 18
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 838,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 847,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 849,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.ref.enum,
-    key.name: "MyEnum",
-    key.usr: "s:4cake6MyEnumO",
-    key.offset: 854,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 862,
-    key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 864,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.ref.enum,
-    key.name: "MyEnum",
-    key.usr: "s:4cake6MyEnumO",
     key.offset: 869,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 876,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 885,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 887,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.enum,
+    key.name: "MyEnum",
+    key.usr: "s:4cake6MyEnumO",
+    key.offset: 892,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.argument,
+    key.offset: 900,
+    key.length: 1
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.parameter,
+    key.offset: 902,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.ref.enum,
+    key.name: "MyEnum",
+    key.usr: "s:4cake6MyEnumO",
+    key.offset: 907,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 880,
+    key.offset: 918,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 888,
+    key.offset: 926,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 894,
+    key.offset: 932,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 903,
+    key.offset: 941,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 913,
+    key.offset: 951,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.attribute.builtin,
-    key.offset: 919,
+    key.offset: 957,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 928,
+    key.offset: 966,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 933,
+    key.offset: 971,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 943,
+    key.offset: 981,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 952,
+    key.offset: 990,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 962,
+    key.offset: 1000,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 977,
+    key.offset: 1015,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 982,
+    key.offset: 1020,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 991,
+    key.offset: 1029,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 999,
+    key.offset: 1037,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1008,
+    key.offset: 1046,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1018,
+    key.offset: 1056,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1033,
+    key.offset: 1071,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1044,
+    key.offset: 1082,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1053,
+    key.offset: 1091,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P5",
     key.usr: "s:4cake2P5P",
-    key.offset: 1058,
+    key.offset: 1096,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1066,
+    key.offset: 1104,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P6",
     key.usr: "s:4cake2P6P",
-    key.offset: 1076,
+    key.offset: 1114,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1086,
+    key.offset: 1124,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1090,
+    key.offset: 1128,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Self",
     key.usr: "s:4cake2P6P4Selfxmfp",
-    key.offset: 1096,
+    key.offset: 1134,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1101,
+    key.offset: 1139,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1112,
+    key.offset: 1150,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1121,
+    key.offset: 1159,
     key.length: 8
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1130,
+    key.offset: 1168,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1142,
+    key.offset: 1180,
     key.length: 14
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1157,
+    key.offset: 1195,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1170,
+    key.offset: 1208,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1174,
+    key.offset: 1212,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 1177,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1183,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1194,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1199,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1210,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
     key.offset: 1215,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1221,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1232,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1237,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1248,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1253,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1225,
+    key.offset: 1263,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot",
     key.usr: "s:4cake4ProtP",
-    key.offset: 1235,
+    key.offset: 1273,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1247,
+    key.offset: 1285,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1252,
+    key.offset: 1290,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1264,
+    key.offset: 1302,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1274,
+    key.offset: 1312,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1276,
+    key.offset: 1314,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 1283,
+    key.offset: 1321,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 1291,
+    key.offset: 1329,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1297,
+    key.offset: 1335,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1306,
+    key.offset: 1344,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot",
     key.usr: "s:4cake4ProtP",
-    key.offset: 1316,
+    key.offset: 1354,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1321,
+    key.offset: 1359,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.ref.generic_type_param,
     key.name: "Self",
     key.usr: "s:4cake4ProtPAASi7ElementRtzrlE4Selfxmfp",
-    key.offset: 1327,
+    key.offset: 1365,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1332,
+    key.offset: 1370,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 1343,
+    key.offset: 1381,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1354,
+    key.offset: 1392,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1359,
+    key.offset: 1397,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1371,
+    key.offset: 1409,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1378,
+    key.offset: 1416,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1388,
+    key.offset: 1426,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1393,
+    key.offset: 1431,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1407,
+    key.offset: 1445,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1412,
+    key.offset: 1450,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1423,
+    key.offset: 1461,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1428,
+    key.offset: 1466,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1439,
+    key.offset: 1477,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1444,
+    key.offset: 1482,
     key.length: 1
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1457,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1462,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1474,
-    key.length: 6
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1481,
-    key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
     key.offset: 1495,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1500,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1512,
+    key.length: 6
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1519,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1533,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1499,
+    key.offset: 1537,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 1502,
+    key.offset: 1540,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1515,
+    key.offset: 1553,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "S1",
     key.usr: "s:4cake2S1V",
-    key.offset: 1525,
+    key.offset: 1563,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "SE",
     key.usr: "s:4cake2S1V2SEO",
-    key.offset: 1528,
+    key.offset: 1566,
     key.length: 2
   },
   {
+    key.kind: source.lang.swift.syntaxtype.attribute.builtin,
+    key.offset: 1576,
+    key.length: 18
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1538,
+    key.offset: 1595,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1545,
+    key.offset: 1602,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1554,
+    key.offset: 1611,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1556,
+    key.offset: 1613,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "S1",
     key.usr: "s:4cake2S1V",
-    key.offset: 1561,
+    key.offset: 1618,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "SE",
     key.usr: "s:4cake2S1V2SEO",
-    key.offset: 1564,
+    key.offset: 1621,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1568,
+    key.offset: 1625,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1570,
+    key.offset: 1627,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "S1",
     key.usr: "s:4cake2S1V",
-    key.offset: 1575,
+    key.offset: 1632,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.enum,
     key.name: "SE",
     key.usr: "s:4cake2S1V2SEO",
-    key.offset: 1578,
+    key.offset: 1635,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Bool",
     key.usr: "s:Sb",
-    key.offset: 1585,
+    key.offset: 1642,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1593,
+    key.offset: 1650,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1600,
+    key.offset: 1657,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P3",
     key.usr: "s:4cake2P3P",
-    key.offset: 1605,
+    key.offset: 1662,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1615,
+    key.offset: 1672,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1625,
+    key.offset: 1682,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1629,
+    key.offset: 1686,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "S2",
     key.usr: "s:4cake2S2V",
-    key.offset: 1634,
+    key.offset: 1691,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1640,
+    key.offset: 1697,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1647,
+    key.offset: 1704,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1650,
+    key.offset: 1707,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P5",
     key.usr: "s:4cake2P5P",
-    key.offset: 1661,
+    key.offset: 1718,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1664,
+    key.offset: 1721,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1670,
+    key.offset: 1727,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "P5",
     key.usr: "s:4cake2P5P",
-    key.offset: 1680,
+    key.offset: 1737,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1690,
+    key.offset: 1747,
     key.length: 9
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1700,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1710,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1718,
-    key.length: 7
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1729,
-    key.length: 9
-  },
-  {
-    key.kind: source.lang.swift.ref.struct,
-    key.name: "S3",
-    key.usr: "s:4cake2S3V",
-    key.offset: 1739,
-    key.length: 2
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1749,
-    key.length: 3
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1753,
-    key.length: 4
-  },
-  {
-    key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1759,
+    key.offset: 1757,
     key.length: 7
   },
   {
@@ -1398,109 +1376,146 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
     key.length: 7
   },
   {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1775,
+    key.length: 7
+  },
+  {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1778,
+    key.offset: 1786,
+    key.length: 9
+  },
+  {
+    key.kind: source.lang.swift.ref.struct,
+    key.name: "S3",
+    key.usr: "s:4cake2S3V",
+    key.offset: 1796,
+    key.length: 2
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1806,
+    key.length: 3
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.identifier,
+    key.offset: 1810,
+    key.length: 4
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1816,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.typeidentifier,
+    key.offset: 1824,
+    key.length: 7
+  },
+  {
+    key.kind: source.lang.swift.syntaxtype.keyword,
+    key.offset: 1835,
     key.length: 3
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1787,
+    key.offset: 1844,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1792,
+    key.offset: 1849,
     key.length: 6
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1799,
+    key.offset: 1856,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.identifier,
-    key.offset: 1803,
+    key.offset: 1860,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1807,
+    key.offset: 1864,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1809,
+    key.offset: 1866,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1813,
+    key.offset: 1870,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.argument,
-    key.offset: 1817,
+    key.offset: 1874,
     key.length: 1
   },
   {
     key.kind: source.lang.swift.syntaxtype.parameter,
-    key.offset: 1819,
+    key.offset: 1876,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1823,
+    key.offset: 1880,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.keyword,
-    key.offset: 1827,
+    key.offset: 1884,
     key.length: 5
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1833,
+    key.offset: 1890,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.ref.protocol,
     key.name: "Prot",
     key.usr: "s:4cake4ProtP",
-    key.offset: 1838,
+    key.offset: 1895,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1844,
+    key.offset: 1901,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1849,
+    key.offset: 1906,
     key.length: 4
   },
   {
     key.kind: source.lang.swift.ref.class,
     key.name: "C1",
     key.usr: "s:4cake2C1C",
-    key.offset: 1854,
+    key.offset: 1911,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1858,
+    key.offset: 1915,
     key.length: 2
   },
   {
     key.kind: source.lang.swift.syntaxtype.typeidentifier,
-    key.offset: 1861,
+    key.offset: 1918,
     key.length: 7
   },
   {
     key.kind: source.lang.swift.ref.struct,
     key.name: "Int",
     key.usr: "s:Si",
-    key.offset: 1872,
+    key.offset: 1929,
     key.length: 3
   }
 ]
@@ -1729,7 +1744,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
   {
     key.kind: source.lang.swift.decl.extension.enum,
     key.offset: 427,
-    key.length: 91,
+    key.length: 110,
     key.extends: {
       key.kind: source.lang.swift.ref.enum,
       key.name: "C1Cases",
@@ -1741,23 +1756,23 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.name: "!=(_:_:)",
         key.usr: "s:s9EquatablePsE2neoiySbx_xtFZ::SYNTHESIZED::s:4cake2C1C0B5CasesO",
         key.original_usr: "s:s9EquatablePsE2neoiySbx_xtFZ",
-        key.doc.full_as_xml: "<Function><Name>!=(_:_:)</Name><USR>s:s9EquatablePsE2neoiySbx_xtFZ</USR><Declaration>static func != (lhs: Self, rhs: Self) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are not equal.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A value to compare.</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Another value to compare.</Para></Discussion></Parameter></Parameters><Discussion><Para>Inequality is the inverse of equality. For any values <codeVoice>a</codeVoice> and <codeVoice>b</codeVoice>, <codeVoice>a != b</codeVoice> implies that <codeVoice>a == b</codeVoice> is <codeVoice>false</codeVoice>.</Para><Para>This is the default implementation of the not-equal-to operator (<codeVoice>!=</codeVoice>) for any type that conforms to <codeVoice>Equatable</codeVoice>.</Para></Discussion></CommentParts></Function>",
+        key.doc.full_as_xml: "<Function><Name>!=(_:_:)</Name><USR>s:s9EquatablePsE2neoiySbx_xtFZ</USR><Declaration>@compilerEvaluable static func != (lhs: Self, rhs: Self) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are not equal.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A value to compare.</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Another value to compare.</Para></Discussion></Parameter></Parameters><Discussion><Para>Inequality is the inverse of equality. For any values <codeVoice>a</codeVoice> and <codeVoice>b</codeVoice>, <codeVoice>a != b</codeVoice> implies that <codeVoice>a == b</codeVoice> is <codeVoice>false</codeVoice>.</Para><Para>This is the default implementation of the not-equal-to operator (<codeVoice>!=</codeVoice>) for any type that conforms to <codeVoice>Equatable</codeVoice>.</Para></Discussion></CommentParts></Function>",
         key.offset: 455,
-        key.length: 61,
-        key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@_inlineable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr=\"s:4cake2C1C\">C1</ref.class>.<ref.enum usr=\"s:4cake2C1C0B5CasesO\">C1Cases</ref.enum></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr=\"s:4cake2C1C\">C1</ref.class>.<ref.enum usr=\"s:4cake2C1C0B5CasesO\">C1Cases</ref.enum></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
+        key.length: 80,
+        key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@_inlineable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.attribute.builtin><syntaxtype.attribute.name>@compilerEvaluable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr=\"s:4cake2C1C\">C1</ref.class>.<ref.enum usr=\"s:4cake2C1C0B5CasesO\">C1Cases</ref.enum></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.class usr=\"s:4cake2C1C\">C1</ref.class>.<ref.enum usr=\"s:4cake2C1C0B5CasesO\">C1Cases</ref.enum></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
         key.entities: [
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "lhs",
-            key.offset: 478,
+            key.offset: 497,
             key.length: 10
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rhs",
-            key.offset: 497,
+            key.offset: 516,
             key.length: 10
           }
         ]
@@ -1768,7 +1783,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
     key.kind: source.lang.swift.decl.class,
     key.name: "C2",
     key.usr: "s:4cake2C2C",
-    key.offset: 520,
+    key.offset: 539,
     key.length: 172,
     key.fully_annotated_decl: "<decl.class><syntaxtype.keyword>class</syntaxtype.keyword> <decl.name>C2</decl.name> : <ref.class usr=\"s:4cake2C1C\">C1</ref.class></decl.class>",
     key.inherits: [
@@ -1783,7 +1798,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "C2foo()",
         key.usr: "s:4cake2C2C5C2fooyyF",
-        key.offset: 546,
+        key.offset: 565,
         key.length: 12,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>C2foo</decl.name>()</decl.function.method.instance>"
       },
@@ -1792,7 +1807,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.name: "C1Cases",
         key.usr: "s:4cake2C1C0B5CasesO::SYNTHESIZED::s:4cake2C2C",
         key.original_usr: "s:4cake2C1C0B5CasesO",
-        key.offset: 564,
+        key.offset: 583,
         key.length: 46,
         key.fully_annotated_decl: "<decl.enum><syntaxtype.keyword>enum</syntaxtype.keyword> <decl.name>C1Cases</decl.name> : <ref.struct usr=\"s:Si\">Int</ref.struct></decl.enum>",
         key.inherits: [
@@ -1807,7 +1822,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
             key.kind: source.lang.swift.decl.enumelement,
             key.name: "case1",
             key.usr: "s:4cake2C1C0B5CasesO5case1yA2EmF",
-            key.offset: 594,
+            key.offset: 613,
             key.length: 10,
             key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>case1</decl.name></decl.enumelement>"
           }
@@ -1818,7 +1833,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.name: "extfoo()",
         key.usr: "s:4cake4ProtPAASi7ElementRtzrlE6extfooyyF::SYNTHESIZED::s:4cake2C2C",
         key.original_usr: "s:4cake4ProtPAASi7ElementRtzrlE6extfooyyF",
-        key.offset: 616,
+        key.offset: 635,
         key.length: 13,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>extfoo</decl.name>()</decl.function.method.instance>"
       },
@@ -1827,7 +1842,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.name: "foo1()",
         key.usr: "s:4cake4ProtPAAE4foo1yyF::SYNTHESIZED::s:4cake2C2C",
         key.original_usr: "s:4cake4ProtPAAE4foo1yyF",
-        key.offset: 635,
+        key.offset: 654,
         key.length: 11,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo1</decl.name>()</decl.function.method.instance>"
       },
@@ -1836,7 +1851,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.name: "subscript(_:)",
         key.usr: "s:4cake4ProtPAAEyS2icip::SYNTHESIZED::s:4cake2C2C",
         key.original_usr: "s:4cake4ProtPAAEyS2icip",
-        key.offset: 652,
+        key.offset: 671,
         key.length: 38,
         key.fully_annotated_decl: "<decl.function.subscript><syntaxtype.keyword>subscript</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.name>index</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int</ref.struct></decl.function.returntype> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.function.subscript>",
         key.entities: [
@@ -1844,7 +1859,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "index",
-            key.offset: 671,
+            key.offset: 690,
             key.length: 3
           }
         ]
@@ -1853,7 +1868,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
   },
   {
     key.kind: source.lang.swift.decl.extension.class,
-    key.offset: 694,
+    key.offset: 713,
     key.length: 95,
     key.conforms: [
       {
@@ -1873,7 +1888,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.name: "C1foo()",
         key.usr: "s:4cake2C1C5C1fooyyF::SYNTHESIZED::s:4cake2C2C",
         key.original_usr: "s:4cake2C1C5C1fooyyF",
-        key.offset: 719,
+        key.offset: 738,
         key.length: 12,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>C1foo</decl.name>()</decl.function.method.instance>"
       },
@@ -1882,7 +1897,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.name: "C1S1",
         key.usr: "s:4cake2C1C0B2S1V::SYNTHESIZED::s:4cake2C2C",
         key.original_usr: "s:4cake2C1C0B2S1V",
-        key.offset: 737,
+        key.offset: 756,
         key.length: 50,
         key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>C1S1</decl.name></decl.struct>",
         key.entities: [
@@ -1890,7 +1905,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
             key.kind: source.lang.swift.decl.function.method.instance,
             key.name: "C1S1foo(a:)",
             key.usr: "s:4cake2C1C0B2S1V0B5S1foo1ayAA2P4_p_tF",
-            key.offset: 760,
+            key.offset: 779,
             key.length: 21,
             key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>C1S1foo</decl.name>(<decl.var.parameter><decl.var.parameter.argument_label>a</decl.var.parameter.argument_label>: <decl.var.parameter.type><ref.protocol usr=\"s:4cake2P4P\">P4</ref.protocol></decl.var.parameter.type></decl.var.parameter>)</decl.function.method.instance>",
             key.entities: [
@@ -1898,7 +1913,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
                 key.kind: source.lang.swift.decl.var.local,
                 key.keyword: "a",
                 key.name: "a",
-                key.offset: 778,
+                key.offset: 797,
                 key.length: 2
               }
             ]
@@ -1911,8 +1926,8 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
     key.kind: source.lang.swift.decl.enum,
     key.name: "MyEnum",
     key.usr: "s:4cake6MyEnumO",
-    key.offset: 791,
-    key.length: 95,
+    key.offset: 810,
+    key.length: 114,
     key.fully_annotated_decl: "<decl.enum><syntaxtype.keyword>enum</syntaxtype.keyword> <decl.name>MyEnum</decl.name> : <ref.struct usr=\"s:Si\">Int</ref.struct></decl.enum>",
     key.inherits: [
       {
@@ -1926,7 +1941,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.enumelement,
         key.name: "Blah",
         key.usr: "s:4cake6MyEnumO4BlahyA2CmF",
-        key.offset: 816,
+        key.offset: 835,
         key.length: 9,
         key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>Blah</decl.name></decl.enumelement>"
       },
@@ -1935,23 +1950,23 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.name: "!=(_:_:)",
         key.usr: "s:s9EquatablePsE2neoiySbx_xtFZ::SYNTHESIZED::s:4cake6MyEnumO",
         key.original_usr: "s:s9EquatablePsE2neoiySbx_xtFZ",
-        key.doc.full_as_xml: "<Function><Name>!=(_:_:)</Name><USR>s:s9EquatablePsE2neoiySbx_xtFZ</USR><Declaration>static func != (lhs: Self, rhs: Self) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are not equal.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A value to compare.</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Another value to compare.</Para></Discussion></Parameter></Parameters><Discussion><Para>Inequality is the inverse of equality. For any values <codeVoice>a</codeVoice> and <codeVoice>b</codeVoice>, <codeVoice>a != b</codeVoice> implies that <codeVoice>a == b</codeVoice> is <codeVoice>false</codeVoice>.</Para><Para>This is the default implementation of the not-equal-to operator (<codeVoice>!=</codeVoice>) for any type that conforms to <codeVoice>Equatable</codeVoice>.</Para></Discussion></CommentParts></Function>",
-        key.offset: 831,
-        key.length: 53,
-        key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@_inlineable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:4cake6MyEnumO\">MyEnum</ref.enum></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:4cake6MyEnumO\">MyEnum</ref.enum></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
+        key.doc.full_as_xml: "<Function><Name>!=(_:_:)</Name><USR>s:s9EquatablePsE2neoiySbx_xtFZ</USR><Declaration>@compilerEvaluable static func != (lhs: Self, rhs: Self) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are not equal.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A value to compare.</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Another value to compare.</Para></Discussion></Parameter></Parameters><Discussion><Para>Inequality is the inverse of equality. For any values <codeVoice>a</codeVoice> and <codeVoice>b</codeVoice>, <codeVoice>a != b</codeVoice> implies that <codeVoice>a == b</codeVoice> is <codeVoice>false</codeVoice>.</Para><Para>This is the default implementation of the not-equal-to operator (<codeVoice>!=</codeVoice>) for any type that conforms to <codeVoice>Equatable</codeVoice>.</Para></Discussion></CommentParts></Function>",
+        key.offset: 850,
+        key.length: 72,
+        key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@_inlineable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.attribute.builtin><syntaxtype.attribute.name>@compilerEvaluable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:4cake6MyEnumO\">MyEnum</ref.enum></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.enum usr=\"s:4cake6MyEnumO\">MyEnum</ref.enum></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
         key.entities: [
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "lhs",
-            key.offset: 854,
+            key.offset: 892,
             key.length: 6
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rhs",
-            key.offset: 869,
+            key.offset: 907,
             key.length: 6
           }
         ]
@@ -1962,7 +1977,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
     key.kind: source.lang.swift.decl.protocol,
     key.name: "P2",
     key.usr: "c:@M@cake@objc(pl)P2",
-    key.offset: 888,
+    key.offset: 926,
     key.length: 53,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@objc</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P2</decl.name></decl.protocol>",
     key.entities: [
@@ -1970,7 +1985,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo1()",
         key.usr: "c:@M@cake@objc(pl)P2(im)foo1",
-        key.offset: 913,
+        key.offset: 951,
         key.length: 26,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@objc</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>optional</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo1</decl.name>()</decl.function.method.instance>",
         key.is_optional: 1
@@ -1981,7 +1996,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
     key.kind: source.lang.swift.decl.protocol,
     key.name: "P3",
     key.usr: "s:4cake2P3P",
-    key.offset: 943,
+    key.offset: 981,
     key.length: 37,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P3</decl.name></decl.protocol>",
     key.entities: [
@@ -1989,7 +2004,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.associatedtype,
         key.name: "T",
         key.usr: "s:4cake2P3P1T",
-        key.offset: 962,
+        key.offset: 1000,
         key.length: 16,
         key.fully_annotated_decl: "<decl.associatedtype><syntaxtype.keyword>associatedtype</syntaxtype.keyword> <decl.name>T</decl.name></decl.associatedtype>"
       }
@@ -1999,7 +2014,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
     key.kind: source.lang.swift.decl.protocol,
     key.name: "P4",
     key.usr: "s:4cake2P4P",
-    key.offset: 982,
+    key.offset: 1020,
     key.length: 15,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P4</decl.name></decl.protocol>"
   },
@@ -2007,7 +2022,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
     key.kind: source.lang.swift.decl.protocol,
     key.name: "P5",
     key.usr: "s:4cake2P5P",
-    key.offset: 999,
+    key.offset: 1037,
     key.length: 43,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P5</decl.name></decl.protocol>",
     key.entities: [
@@ -2015,7 +2030,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.associatedtype,
         key.name: "Element",
         key.usr: "s:4cake2P5P7Element",
-        key.offset: 1018,
+        key.offset: 1056,
         key.length: 22,
         key.fully_annotated_decl: "<decl.associatedtype><syntaxtype.keyword>associatedtype</syntaxtype.keyword> <decl.name>Element</decl.name></decl.associatedtype>"
       }
@@ -2025,7 +2040,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
     key.kind: source.lang.swift.decl.protocol,
     key.name: "P6",
     key.usr: "s:4cake2P6P",
-    key.offset: 1044,
+    key.offset: 1082,
     key.length: 20,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>P6</decl.name> : <ref.protocol usr=\"s:4cake2P5P\">P5</ref.protocol></decl.protocol>",
     key.conforms: [
@@ -2038,7 +2053,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
   },
   {
     key.kind: source.lang.swift.decl.extension.protocol,
-    key.offset: 1066,
+    key.offset: 1104,
     key.length: 53,
     key.extends: {
       key.kind: source.lang.swift.ref.protocol,
@@ -2050,7 +2065,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "null",
         key.usr: "s:4cake2P6PAAE4null7ElementQzSgvp",
-        key.offset: 1086,
+        key.offset: 1124,
         key.length: 31,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>null</decl.name>: <decl.var.type><ref.generic_type_param usr=\"s:4cake2P6P4Selfxmfp\">Self</ref.generic_type_param>.Element?</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       }
@@ -2060,7 +2075,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
     key.kind: source.lang.swift.decl.protocol,
     key.name: "Prot",
     key.usr: "s:4cake4ProtP",
-    key.offset: 1121,
+    key.offset: 1159,
     key.length: 102,
     key.fully_annotated_decl: "<decl.protocol><syntaxtype.keyword>protocol</syntaxtype.keyword> <decl.name>Prot</decl.name></decl.protocol>",
     key.entities: [
@@ -2068,7 +2083,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.associatedtype,
         key.name: "Element",
         key.usr: "s:4cake4ProtP7Element",
-        key.offset: 1142,
+        key.offset: 1180,
         key.length: 22,
         key.fully_annotated_decl: "<decl.associatedtype><syntaxtype.keyword>associatedtype</syntaxtype.keyword> <decl.name>Element</decl.name></decl.associatedtype>"
       },
@@ -2076,7 +2091,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.var.instance,
         key.name: "p",
         key.usr: "s:4cake4ProtP1pSivp",
-        key.offset: 1170,
+        key.offset: 1208,
         key.length: 18,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>p</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       },
@@ -2084,7 +2099,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo()",
         key.usr: "s:4cake4ProtP3fooyyF",
-        key.offset: 1194,
+        key.offset: 1232,
         key.length: 10,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo</decl.name>()</decl.function.method.instance>"
       },
@@ -2092,7 +2107,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo1()",
         key.usr: "s:4cake4ProtP4foo1yyF",
-        key.offset: 1210,
+        key.offset: 1248,
         key.length: 11,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo1</decl.name>()</decl.function.method.instance>"
       }
@@ -2100,7 +2115,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
   },
   {
     key.kind: source.lang.swift.decl.extension.protocol,
-    key.offset: 1225,
+    key.offset: 1263,
     key.length: 79,
     key.extends: {
       key.kind: source.lang.swift.ref.protocol,
@@ -2113,7 +2128,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.name: "foo1()",
         key.usr: "s:4cake4ProtPAAE4foo1yyF",
         key.default_implementation_of: "s:4cake4ProtP4foo1yyF",
-        key.offset: 1247,
+        key.offset: 1285,
         key.length: 11,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo1</decl.name>()</decl.function.method.instance>"
       },
@@ -2121,7 +2136,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.function.subscript,
         key.name: "subscript(_:)",
         key.usr: "s:4cake4ProtPAAEyS2icip",
-        key.offset: 1264,
+        key.offset: 1302,
         key.length: 38,
         key.fully_annotated_decl: "<decl.function.subscript><syntaxtype.keyword>subscript</syntaxtype.keyword>(<decl.var.parameter><decl.var.parameter.name>index</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Si\">Int</ref.struct></decl.function.returntype> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.function.subscript>",
         key.entities: [
@@ -2129,7 +2144,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "index",
-            key.offset: 1283,
+            key.offset: 1321,
             key.length: 3
           }
         ]
@@ -2143,7 +2158,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.description: "Self.Element == Int"
       }
     ],
-    key.offset: 1306,
+    key.offset: 1344,
     key.length: 63,
     key.extends: {
       key.kind: source.lang.swift.ref.protocol,
@@ -2155,7 +2170,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "extfoo()",
         key.usr: "s:4cake4ProtPAASi7ElementRtzrlE6extfooyyF",
-        key.offset: 1354,
+        key.offset: 1392,
         key.length: 13,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>extfoo</decl.name>()</decl.function.method.instance>"
       }
@@ -2165,7 +2180,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
     key.kind: source.lang.swift.decl.struct,
     key.name: "S1",
     key.usr: "s:4cake2S1V",
-    key.offset: 1371,
+    key.offset: 1409,
     key.length: 142,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S1</decl.name></decl.struct>",
     key.entities: [
@@ -2173,7 +2188,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.enum,
         key.name: "SE",
         key.usr: "s:4cake2S1V2SEO",
-        key.offset: 1388,
+        key.offset: 1426,
         key.length: 63,
         key.fully_annotated_decl: "<decl.enum><syntaxtype.keyword>enum</syntaxtype.keyword> <ref.struct usr=\"s:4cake2S1V\">S1</ref.struct>.<decl.name>SE</decl.name></decl.enum>",
         key.entities: [
@@ -2181,7 +2196,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
             key.kind: source.lang.swift.decl.enumelement,
             key.name: "a",
             key.usr: "s:4cake2S1V2SEO1ayA2EmF",
-            key.offset: 1407,
+            key.offset: 1445,
             key.length: 6,
             key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>a</decl.name></decl.enumelement>"
           },
@@ -2189,7 +2204,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
             key.kind: source.lang.swift.decl.enumelement,
             key.name: "b",
             key.usr: "s:4cake2S1V2SEO1byA2EmF",
-            key.offset: 1423,
+            key.offset: 1461,
             key.length: 6,
             key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>b</decl.name></decl.enumelement>"
           },
@@ -2197,7 +2212,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
             key.kind: source.lang.swift.decl.enumelement,
             key.name: "c",
             key.usr: "s:4cake2S1V2SEO1cyA2EmF",
-            key.offset: 1439,
+            key.offset: 1477,
             key.length: 6,
             key.fully_annotated_decl: "<decl.enumelement><syntaxtype.keyword>case</syntaxtype.keyword> <decl.name>c</decl.name></decl.enumelement>"
           }
@@ -2207,7 +2222,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.function.method.instance,
         key.name: "foo1()",
         key.usr: "s:4cake2S1V4foo1yyF",
-        key.offset: 1457,
+        key.offset: 1495,
         key.length: 11,
         key.fully_annotated_decl: "<decl.function.method.instance><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>foo1</decl.name>()</decl.function.method.instance>"
       },
@@ -2215,7 +2230,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.struct,
         key.name: "S2",
         key.usr: "s:4cake2S1V2S2V",
-        key.offset: 1474,
+        key.offset: 1512,
         key.length: 37,
         key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S2</decl.name></decl.struct>",
         key.entities: [
@@ -2223,7 +2238,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
             key.kind: source.lang.swift.decl.var.instance,
             key.name: "b",
             key.usr: "s:4cake2S1V2S2V1bSivp",
-            key.offset: 1495,
+            key.offset: 1533,
             key.length: 10,
             key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>let</syntaxtype.keyword> <decl.name>b</decl.name>: <decl.var.type><ref.struct usr=\"s:Si\">Int</ref.struct></decl.var.type></decl.var.instance>"
           }
@@ -2233,8 +2248,8 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
   },
   {
     key.kind: source.lang.swift.decl.extension.enum,
-    key.offset: 1515,
-    key.length: 76,
+    key.offset: 1553,
+    key.length: 95,
     key.extends: {
       key.kind: source.lang.swift.ref.enum,
       key.name: "SE",
@@ -2246,23 +2261,23 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.name: "!=(_:_:)",
         key.usr: "s:s9EquatablePsE2neoiySbx_xtFZ::SYNTHESIZED::s:4cake2S1V2SEO",
         key.original_usr: "s:s9EquatablePsE2neoiySbx_xtFZ",
-        key.doc.full_as_xml: "<Function><Name>!=(_:_:)</Name><USR>s:s9EquatablePsE2neoiySbx_xtFZ</USR><Declaration>static func != (lhs: Self, rhs: Self) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are not equal.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A value to compare.</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Another value to compare.</Para></Discussion></Parameter></Parameters><Discussion><Para>Inequality is the inverse of equality. For any values <codeVoice>a</codeVoice> and <codeVoice>b</codeVoice>, <codeVoice>a != b</codeVoice> implies that <codeVoice>a == b</codeVoice> is <codeVoice>false</codeVoice>.</Para><Para>This is the default implementation of the not-equal-to operator (<codeVoice>!=</codeVoice>) for any type that conforms to <codeVoice>Equatable</codeVoice>.</Para></Discussion></CommentParts></Function>",
-        key.offset: 1538,
-        key.length: 51,
-        key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@_inlineable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:4cake2S1V\">S1</ref.struct>.<ref.enum usr=\"s:4cake2S1V2SEO\">SE</ref.enum></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:4cake2S1V\">S1</ref.struct>.<ref.enum usr=\"s:4cake2S1V2SEO\">SE</ref.enum></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
+        key.doc.full_as_xml: "<Function><Name>!=(_:_:)</Name><USR>s:s9EquatablePsE2neoiySbx_xtFZ</USR><Declaration>@compilerEvaluable static func != (lhs: Self, rhs: Self) -&gt; Bool</Declaration><CommentParts><Abstract><Para>Returns a Boolean value indicating whether two values are not equal.</Para></Abstract><Parameters><Parameter><Name>lhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>A value to compare.</Para></Discussion></Parameter><Parameter><Name>rhs</Name><Direction isExplicit=\"0\">in</Direction><Discussion><Para>Another value to compare.</Para></Discussion></Parameter></Parameters><Discussion><Para>Inequality is the inverse of equality. For any values <codeVoice>a</codeVoice> and <codeVoice>b</codeVoice>, <codeVoice>a != b</codeVoice> implies that <codeVoice>a == b</codeVoice> is <codeVoice>false</codeVoice>.</Para><Para>This is the default implementation of the not-equal-to operator (<codeVoice>!=</codeVoice>) for any type that conforms to <codeVoice>Equatable</codeVoice>.</Para></Discussion></CommentParts></Function>",
+        key.offset: 1576,
+        key.length: 70,
+        key.fully_annotated_decl: "<decl.function.operator.infix><syntaxtype.attribute.builtin><syntaxtype.attribute.name>@_inlineable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.attribute.builtin><syntaxtype.attribute.name>@compilerEvaluable</syntaxtype.attribute.name></syntaxtype.attribute.builtin> <syntaxtype.keyword>static</syntaxtype.keyword> <syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>!= </decl.name>(<decl.var.parameter><decl.var.parameter.name>lhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:4cake2S1V\">S1</ref.struct>.<ref.enum usr=\"s:4cake2S1V2SEO\">SE</ref.enum></decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.name>rhs</decl.var.parameter.name>: <decl.var.parameter.type><ref.struct usr=\"s:4cake2S1V\">S1</ref.struct>.<ref.enum usr=\"s:4cake2S1V2SEO\">SE</ref.enum></decl.var.parameter.type></decl.var.parameter>) -&gt; <decl.function.returntype><ref.struct usr=\"s:Sb\">Bool</ref.struct></decl.function.returntype></decl.function.operator.infix>",
         key.entities: [
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "lhs",
-            key.offset: 1561,
+            key.offset: 1618,
             key.length: 5
           },
           {
             key.kind: source.lang.swift.decl.var.local,
             key.keyword: "_",
             key.name: "rhs",
-            key.offset: 1575,
+            key.offset: 1632,
             key.length: 5
           }
         ]
@@ -2273,7 +2288,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
     key.kind: source.lang.swift.decl.struct,
     key.name: "S2",
     key.usr: "s:4cake2S2V",
-    key.offset: 1593,
+    key.offset: 1650,
     key.length: 45,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S2</decl.name> : <ref.protocol usr=\"s:4cake2P3P\">P3</ref.protocol></decl.struct>",
     key.conforms: [
@@ -2288,7 +2303,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.typealias,
         key.name: "T",
         key.usr: "s:4cake2S2V1Ta",
-        key.offset: 1615,
+        key.offset: 1672,
         key.length: 21,
         key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <ref.struct usr=\"s:4cake2S2V\">S2</ref.struct>.<decl.name>T</decl.name> = <ref.struct usr=\"s:4cake2S2V\">S2</ref.struct></decl.typealias>",
         key.conforms: [
@@ -2315,7 +2330,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.description: "Wrapped : P5"
       }
     ],
-    key.offset: 1640,
+    key.offset: 1697,
     key.length: 87,
     key.fully_annotated_decl: "<decl.struct><syntaxtype.keyword>struct</syntaxtype.keyword> <decl.name>S3</decl.name>&lt;<decl.generic_type_param usr=\"s:4cake2S3V7Wrappedxmfp\"><decl.generic_type_param.name>Wrapped</decl.generic_type_param.name></decl.generic_type_param>&gt; : <ref.protocol usr=\"s:4cake2P5P\">P5</ref.protocol> <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement>Wrapped : <ref.protocol usr=\"s:4cake2P5P\">P5</ref.protocol></decl.generic_type_requirement></decl.struct>",
     key.conforms: [
@@ -2330,7 +2345,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.typealias,
         key.name: "Element",
         key.usr: "s:4cake2S3V7Elementa",
-        key.offset: 1690,
+        key.offset: 1747,
         key.length: 35,
         key.fully_annotated_decl: "<decl.typealias><syntaxtype.keyword>typealias</syntaxtype.keyword> <ref.struct usr=\"s:4cake2S3V\">S3</ref.struct>&lt;Wrapped&gt;.<decl.name>Element</decl.name> = Wrapped.Element</decl.typealias>",
         key.conforms: [
@@ -2345,7 +2360,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
   },
   {
     key.kind: source.lang.swift.decl.extension.struct,
-    key.offset: 1729,
+    key.offset: 1786,
     key.length: 56,
     key.extends: {
       key.kind: source.lang.swift.ref.struct,
@@ -2358,7 +2373,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.name: "null",
         key.usr: "s:4cake2P6PAAE4null7ElementQzSgvp::SYNTHESIZED::s:4cake2S3V",
         key.original_usr: "s:4cake2P6PAAE4null7ElementQzSgvp",
-        key.offset: 1749,
+        key.offset: 1806,
         key.length: 34,
         key.fully_annotated_decl: "<decl.var.instance><syntaxtype.keyword>var</syntaxtype.keyword> <decl.name>null</decl.name>: <decl.var.type>Wrapped.Element?</decl.var.type> { <syntaxtype.keyword>get</syntaxtype.keyword> }</decl.var.instance>"
       }
@@ -2387,7 +2402,7 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.description: "T1.Element == Int"
       }
     ],
-    key.offset: 1787,
+    key.offset: 1844,
     key.length: 88,
     key.fully_annotated_decl: "<decl.function.free><syntaxtype.keyword>func</syntaxtype.keyword> <decl.name>genfoo</decl.name>&lt;<decl.generic_type_param usr=\"s:4cake6genfoo1x1yyx_q_tAA4ProtRzAA2C1CRb_Si7ElementRtzr0_lF2T1L_xmfp\"><decl.generic_type_param.name>T1</decl.generic_type_param.name></decl.generic_type_param>, <decl.generic_type_param usr=\"s:4cake6genfoo1x1yyx_q_tAA4ProtRzAA2C1CRb_Si7ElementRtzr0_lF2T2L_q_mfp\"><decl.generic_type_param.name>T2</decl.generic_type_param.name></decl.generic_type_param>&gt;(<decl.var.parameter><decl.var.parameter.argument_label>x</decl.var.parameter.argument_label> <decl.var.parameter.name>ix</decl.var.parameter.name>: <decl.var.parameter.type>T1</decl.var.parameter.type></decl.var.parameter>, <decl.var.parameter><decl.var.parameter.argument_label>y</decl.var.parameter.argument_label> <decl.var.parameter.name>iy</decl.var.parameter.name>: <decl.var.parameter.type>T2</decl.var.parameter.type></decl.var.parameter>) <syntaxtype.keyword>where</syntaxtype.keyword> <decl.generic_type_requirement>T1 : <ref.protocol usr=\"s:4cake4ProtP\">Prot</ref.protocol></decl.generic_type_requirement>, <decl.generic_type_requirement>T2 : <ref.class usr=\"s:4cake2C1C\">C1</ref.class></decl.generic_type_requirement>, <decl.generic_type_requirement>T1.Element == <ref.struct usr=\"s:Si\">Int</ref.struct></decl.generic_type_requirement></decl.function.free>",
     key.entities: [
@@ -2395,14 +2410,14 @@ func genfoo<T1, T2>(x ix: T1, y iy: T2) where T1 : Prot, T2 : cake.C1, T1.Elemen
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "x",
         key.name: "ix",
-        key.offset: 1813,
+        key.offset: 1870,
         key.length: 2
       },
       {
         key.kind: source.lang.swift.decl.var.local,
         key.keyword: "y",
         key.name: "iy",
-        key.offset: 1823,
+        key.offset: 1880,
         key.length: 2
       }
     ]


### PR DESCRIPTION
Doing this as a first step does two useful things:
1. Makes it possible to implement the check that callees are `@compilerEvaluable` without immediately getting tons of errors about calls to stdlib functions.
2. Serves as a way to test that my checks allow "enough" stuff.

Some possibly-problematic things I noticed while doing this:
* A lot of integer functions call `_precondition`, which does stuff with `String`s and which also calls out to the `SwiftShims` clangmodule. To make these work "for real", we'll need general support for `String`s and clangmodules. For now, I think I'll just special-case calls to `_precondition` to be allowed no matter what's inside them.
* A lot of integer functions call boolean `&&` and `||`, which use `@autoclosure`. So I think I'll make the checker allow closures and autoclosures, even though we didn't mention them in the proposal.