### PR TITLE
Implicit tuple interpolations, take two

### DIFF
--- a/validation-test/compiler_crashers_2_fixed/0160-sr7958.swift
+++ b/validation-test/compiler_crashers_2_fixed/0160-sr7958.swift
@@ -1,4 +1,4 @@
-// RUN: not --crash %target-swift-frontend %s -emit-ir
+// RUN: not %target-swift-frontend %s -emit-ir
 
 func foo<U>(_ x: U?) {
   _ = "\(anyLabelHere: x)"

--- a/validation-test/compiler_crashers_2_fixed/0160-sr7958.swift
+++ b/validation-test/compiler_crashers_2_fixed/0160-sr7958.swift
@@ -1,4 +1,4 @@
-// RUN: not %target-swift-frontend %s -emit-ir
+// RUN: %target-swift-frontend %s -emit-ir
 
 func foo<U>(_ x: U?) {
   _ = "\(anyLabelHere: x)"


### PR DESCRIPTION
When the parser encounters a "weird" string interpolation, like `\(x, y)` or `\(foo: x)`, it sometimes produces a `TupleExpr` instead of a `ParenExpr`. This change wraps any such `TupleExpr`s in `ParenExpr`s to keep them from being interpreted as argument lists. This doesn't stop us from getting strange nodes like single-expression labeled tuples, but at least they're strange in ways that the compiler can cope with, and unlike #17074, this solution doesn't appear to cause any source breakage.

I'll post on Evolution soon about how to deal with these interpolations on a more permanent basis.

Resolves [SR-7958](https://bugs.swift.org/browse/SR-7958) (again).

cc @CodaFi 