### PR TITLE
[4.2] Sema: Make implicit elementwise struct init insensitive to lazy validation order.

### DIFF
--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -1888,12 +1888,21 @@ ConstructorDecl *swift::createImplicitConstructor(TypeChecker &tc,
   if (ICK == ImplicitConstructorKind::Memberwise) {
     assert(isa<StructDecl>(decl) && "Only struct have memberwise constructor");
 
-    // Computed and static properties are not initialized.
-    for (auto var : decl->getStoredProperties()) {
-      if (var->isImplicit())
+    for (auto member : decl->getMembers()) {
+      auto var = dyn_cast<VarDecl>(member);
+      if (!var)
+        continue;
+      
+      // Implicit, computed, and static properties are not initialized.
+      // The exception is lazy properties, which due to batch mode we may or
+      // may not have yet finalized, so they may currently be "stored" or
+      // "computed" in the current AST state.
+      if (var->isImplicit() || var->isStatic())
         continue;
       tc.validateDecl(var);
-      
+      if (!var->hasStorage() && !var->getAttrs().hasAttribute<LazyAttr>())
+        continue;
+
       // Initialized 'let' properties have storage, but don't get an argument
       // to the memberwise initializer since they already have an initial
       // value that cannot be overridden.

--- a/test/decl/var/Inputs/lazy_properties_batch_mode_b.swift
+++ b/test/decl/var/Inputs/lazy_properties_batch_mode_b.swift
@@ -1,0 +1,7 @@
+struct B {
+  var other: Int = 0
+  lazy var crash: String = {
+    return ""
+  }()
+}
+

--- a/test/decl/var/lazy_properties_batch_mode.swift
+++ b/test/decl/var/lazy_properties_batch_mode.swift
@@ -1,0 +1,4 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -c -primary-file %s -o %t/a.o -primary-file %S/Inputs/lazy_properties_batch_mode_b.swift -o %t/b.o
+func foo(_: B) {}
+


### PR DESCRIPTION
With batch mode, other files may have forced lazy properties to get finalized before the implicit constructor is formed. Avoid the order dependency by making the behavior stable regardless of the type-checking phase of lazy declarations. Fixes rdar://problem/40903186.