### PR TITLE
SourceKit: enable lld for libdispatch if used

### DIFF
--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -1926,6 +1926,10 @@ for host in "${ALL_HOSTS[@]}"; do
                     "${llvm_cmake_options[@]}"
                 )
 
+                cmake_options+=(
+                  -DLLVM_TOOL_LLD_BUILD:BOOL=TRUE
+                )
+
                 if [[ ! -z "${CLANG_TOOLS_EXTRA_SOURCE_DIR}" ]] ; then
                   cmake_options+=(
                     -DLLVM_EXTERNAL_CLANG_TOOLS_EXTRA_SOURCE_DIR="${CLANG_TOOLS_EXTRA_SOURCE_DIR}"


### PR DESCRIPTION
If we are using lld for building swift, enable lld for the libdispatch
build as well.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
