### PR TITLE
Sema: Force the 'getElements' array of a type-checked ArrayExpr to contain rvalues.

### DIFF
--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2988,6 +2988,14 @@ namespace {
       DeclName name(tc.Context, DeclBaseName::createConstructor(),
                     { tc.Context.Id_arrayLiteral });
 
+      // Coerce the array elements to be rvalues, so that other type-checker
+      // code that attempts to peephole the AST doesn't have to re-load the
+      // elements (and break the invariant that lvalue nodes only get their
+      // access kind set once).
+      for (auto &element : expr->getElements()) {
+        element = cs.coerceToRValue(element);
+      }
+
       // Restructure the argument to provide the appropriate labels in the
       // tuple.
       SmallVector<TupleTypeElt, 4> typeElements;

--- a/test/decl/var/Inputs/lazy_properties_batch_mode_b.swift
+++ b/test/decl/var/Inputs/lazy_properties_batch_mode_b.swift
@@ -1,0 +1,7 @@
+struct B {
+  var other: Int = 0
+  lazy var crash: String = {
+    return ""
+  }()
+}
+

--- a/test/expr/cast/objc_coerce_array.swift
+++ b/test/expr/cast/objc_coerce_array.swift
@@ -1,0 +1,7 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -emit-silgen -verify %s
+// REQUIRES: objc_interop
+import Foundation
+
+var x = 1
+
+_ = [x] as [NSNumber]


### PR DESCRIPTION
There are other parts of CSApply that attempt to peephole transform ArrayExprs (particularly bridging, which tries to turn `[x, y, ...] as T` into `[x as T, y as T, ...]`) and expect the elements to have already been rvalue-d. Fixes rdar://problem/40859007.