### PR TITLE
[4.2] Only disable Network test on watchOS

### DIFF
--- a/test/stdlib/Network.swift
+++ b/test/stdlib/Network.swift
@@ -2,8 +2,8 @@
 // REQUIRES: executable_test
 
 // REQUIRES: objc_interop
+// UNSUPPORTED: OS=watchos
 
-// REQUIRES: rdar40799651
 
 import Network
 import Foundation


### PR DESCRIPTION
Similar to https://github.com/apple/swift/pull/17204

Related to: rdar://problem/40799651