### PR TITLE
Rename accessor kinds from IsGetter -> IsGet, etc.

### DIFF
--- a/include/swift/AST/AccessorKinds.def
+++ b/include/swift/AST/AccessorKinds.def
@@ -1,0 +1,196 @@
+//===--- AccessorKinds.def - Swift accessor metaprogramming -----*- C++ -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines macros used for macro-metaprogramming with accessor kinds.
+//
+//===----------------------------------------------------------------------===//
+
+#if defined(ACCESSOR) && defined(ACCESSOR_KEYWORD)
+#error do not define both ACCESSOR and ACCESSOR_KEYWORD
+#elif !defined(ACCESSOR) && !defined(ACCESSOR_KEYWORD)
+#error must define either ACCESSOR or ACCESSOR_KEYWORD
+#endif
+
+/// ACCESSOR(ID)
+///   There is an accessor with the enumerator value AccessorKind::ID.
+#if !defined(ACCESSOR) && defined(ACCESSOR_KEYWORD)
+#define ACCESSOR(ID)
+#endif
+
+/// SINGLETON_ACCESSOR(ID, KEYWORD)
+///   The given accessor has only one matching accessor keyword.
+///
+/// Defaults to ACCESSOR(ID) or ACCESSOR_KEYWORD(KEYWORD), depending on which
+/// is defined.
+#ifndef SINGLETON_ACCESSOR
+#if defined(ACCESSOR_KEYWORD)
+#define SINGLETON_ACCESSOR(ID, KEYWORD) ACCESSOR_KEYWORD(KEYWORD)
+#else
+#define SINGLETON_ACCESSOR(ID, KEYWORD) ACCESSOR(ID)
+#endif
+#endif
+
+/// OBSERVING_ACCESSOR(ID, KEYWORD)
+///   The given accessor is an observing accessor.
+///
+///   Defaults to SINGLETON_ACCESSOR(ID, KEYWORD).
+#ifndef OBSERVING_ACCESSOR
+#define OBSERVING_ACCESSOR(ID, KEYWORD) SINGLETON_ACCESSOR(ID, KEYWORD)
+#endif
+
+/// OPAQUE_ACCESSOR(ID, KEYWORD)
+///   The given accessor is used in the opaque access pattern and is created
+///   for (mutable) storage whenever its implementation is unknown, such as
+///   when it is resilient, overridable, or accessed through a protocol.
+///
+///   Defaults to SINGLETON_ACCESSOR(ID, KEYWORD).
+#ifndef OPAQUE_ACCESSOR
+#define OPAQUE_ACCESSOR(ID, KEYWORD) SINGLETON_ACCESSOR(ID, KEYWORD)
+#endif
+
+/// OBJC_ACCESSOR(ID, KEYWORD)
+///   The given accessor is used in Objective-C, i.e. it is a getter or setter.
+///
+///   Defaults to OPAQUE_ACCESSOR(ID, KEYWORD).
+#ifndef OBJC_ACCESSOR
+#define OBJC_ACCESSOR(ID, KEYWORD) OPAQUE_ACCESSOR(ID, KEYWORD)
+#endif
+
+/// ANY_ADDRESSOR(ACCESSOR_ID, ADDRESSOR_ID, KEYWORD)
+///   The given keyword corresponds to an addressor of the given kind.
+///
+///   Defaults to ACCESSOR_KEYWORD(KEYWORD) if that is defined; otherwise
+///   defaults to nothing.
+#ifndef ANY_ADDRESSOR
+#if defined(ACCESSOR_KEYWORD)
+#define ANY_ADDRESSOR(ACCESSOR_ID, ADDRESSOR_ID, KEYWORD) \
+  ACCESSOR_KEYWORD(KEYWORD)
+#else
+#define ANY_ADDRESSOR(ACCESSOR_ID, ADDRESSOR_ID, KEYWORD)
+#endif
+#endif
+
+/// IMMUTABLE_ADDRESSOR(ADDRESSOR_ID, KEYWORD)
+///   The given keyword corresponds to an immutable addressor of the given kind.
+///
+///   DEfaults to ANY_ADDRESSOR(Address, ADDRESSOR_ID, KEYWORD).
+#ifndef IMMUTABLE_ADDRESSOR
+#define IMMUTABLE_ADDRESSOR(ADDRESSOR_ID, KEYWORD) \
+  ANY_ADDRESSOR(Address, ADDRESSOR_ID, KEYWORD)
+#endif
+
+/// MUTABLE_ADDRESSOR(ADDRESSOR_ID, KEYWORD)
+///   The given keyword corresponds to a mutable addressor of the given kind.
+///
+///   DEfaults to ANY_ADDRESSOR(MutableAddress, ADDRESSOR_ID, KEYWORD).
+#ifndef MUTABLE_ADDRESSOR
+#define MUTABLE_ADDRESSOR(ADDRESSOR_ID, KEYWORD) \
+  ANY_ADDRESSOR(MutableAddress, ADDRESSOR_ID, KEYWORD)
+#endif
+
+// Suppress entries for accessors which can't be written in source code.
+#ifndef SUPPRESS_ARTIFICIAL_ACCESSORS
+#define SUPPRESS_ARTIFICIAL_ACCESSORS 0
+#endif
+
+/// This is a getter: a function that is called when a value is loaded
+/// from the storage.  It returns an owned value of the storage type.
+///
+/// If the storage is not implemented with a getter, a getter can
+/// always be synthesized.  However, this will not be true when
+/// move-only types are introduced.
+OBJC_ACCESSOR(Get, get)
+
+/// This is a setter: a function that is called when a value is assigned
+/// to the storage.  It takes a value of the storage type as its
+/// primary parameter, in addition to any index values that may be
+/// required for a subscript.
+///
+/// If the storage is not implemented with a setter, a setter can
+/// always be synthesized if the storage is mutable at all.
+OBJC_ACCESSOR(Set, set)
+
+/// This is a materializeForSet accessor: a function which is called
+/// when a combined read-modify operation is performed on the storage,
+/// such as passing it as an inout argument (which includes calling
+/// a mutating function on it).  It is essentially a SILGen-lowered
+/// coroutine that yields a pointer to a mutable value of the storage
+/// type.
+///
+/// We do not allow users to provide materializeForSet.  It can always
+/// be synthesized if the storage is mutable at all.
+#if !(SUPPRESS_ARTIFICIAL_ACCESSORS)
+OPAQUE_ACCESSOR(MaterializeForSet, materializeForSet)
+#endif
+
+/// This is a willSet observer: a function which "decorates" an
+/// underlying assignment operation by being called prior to the
+/// operation when a value is assigned to the storage.
+///
+/// willSet is essentially sugar for implementing a certain common
+/// setter idiom.
+OBSERVING_ACCESSOR(WillSet, willSet)
+
+/// This is a didSet observer: a function which "decorates" an
+/// underlying assignment operation by being called after the
+/// operation when a value is assigned to the storage.
+///
+/// didSet is essentially sugar for implementing a certain common
+/// setter idiom.
+OBSERVING_ACCESSOR(DidSet, didSet)
+
+/// This is an address-family accessor: a function that is called when
+/// a value is loaded from the storage, like a getter, but which works
+/// by returning a pointer to an immutable value of the storage type.
+/// This kind of accessor also has an addressor kind.
+///
+/// Addressors are a way of proving more efficient access to storage
+/// when it is already stored in memory (but not as a stored member
+/// of the type).
+ACCESSOR(Address)
+
+IMMUTABLE_ADDRESSOR(Unsafe, unsafeAddress)
+IMMUTABLE_ADDRESSOR(Owning, addressWithOwner)
+IMMUTABLE_ADDRESSOR(NativeOwning, addressWithNativeOwner)
+IMMUTABLE_ADDRESSOR(NativePinning, addressWithPinnedNativeOwner)
+
+/// This is a mutableAddress-family accessor: a function that is
+/// called when the storage is assigned to (like a setter) or
+/// read-modified (like materializeForSet), but which works by
+/// returning a pointer to a mutable value of the storage type.
+/// This kind of accessor also has an addressor kind.
+///
+/// Addressors are a way of proving more efficient access to storage
+/// when it is already stored in memory (but not as a stored member
+/// of the type).
+ACCESSOR(MutableAddress)
+
+MUTABLE_ADDRESSOR(Unsafe, unsafeMutableAddress)
+MUTABLE_ADDRESSOR(Owning, mutableAddressWithOwner)
+MUTABLE_ADDRESSOR(NativeOwning, mutableAddressWithNativeOwner)
+MUTABLE_ADDRESSOR(NativePinning, mutableAddressWithPinnedNativeOwner)
+
+#ifdef LAST_ACCESSOR
+LAST_ACCESSOR(MutableAddress)
+#undef LAST_ACCESSOR
+#endif
+
+#undef IMMUTABLE_ADDRESSOR
+#undef MUTABLE_ADDRESSOR
+#undef ANY_ADDRESSOR
+#undef OBJC_ACCESSOR
+#undef OPAQUE_ACCESSOR
+#undef OBSERVING_ACCESSOR
+#undef SINGLETON_ACCESSOR
+#undef ACCESSOR
+#undef ACCESSOR_KEYWORD
+#undef SUPPRESS_ARTIFICIAL_ACCESSORS

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -3949,23 +3949,15 @@ public:
 // Note that the values of these enums line up with %select values in
 // diagnostics.
 enum class AccessorKind {
-  /// \brief This is a getter for a property or subscript.
-  IsGetter = 0,
-  /// \brief This is a setter for a property or subscript.
-  IsSetter = 1,
-  /// \brief This is a willSet specifier for a property.
-  IsWillSet = 2,
-  /// \brief This is a didSet specifier for a property.
-  IsDidSet = 3,
-  /// \brief This is a materializeForSet accessor for a property.
-  IsMaterializeForSet = 4,
-  /// \brief This is an address-family accessor for a property or
-  /// subscript.  It also has an addressor kind.
-  IsAddressor = 5,
-  /// \brief This is a mutableAddress-family accessor for a property
-  /// or subscript.  It also has an addressor kind.
-  IsMutableAddressor = 6,
+#define ACCESSOR(ID) ID,
+#define LAST_ACCESSOR(ID) Last = ID
+#include "swift/AST/AccessorKinds.def"
 };
+
+static inline IntRange<AccessorKind> allAccessorKinds() {
+  return IntRange<AccessorKind>(AccessorKind(0),
+                                AccessorKind(unsigned(AccessorKind::Last) + 1));
+}
 
 /// The safety semantics of this addressor.
 enum class AddressorKind : uint8_t {
@@ -5735,15 +5727,15 @@ public:
     return AddressorKind(Bits.AccessorDecl.AddressorKind);
   }
 
-  bool isGetter() const { return getAccessorKind() == AccessorKind::IsGetter; }
-  bool isSetter() const { return getAccessorKind() == AccessorKind::IsSetter; }
+  bool isGetter() const { return getAccessorKind() == AccessorKind::Get; }
+  bool isSetter() const { return getAccessorKind() == AccessorKind::Set; }
   bool isMaterializeForSet() const {
-    return getAccessorKind() == AccessorKind::IsMaterializeForSet;
+    return getAccessorKind() == AccessorKind::MaterializeForSet;
   }
   bool isAnyAddressor() const {
     auto kind = getAccessorKind();
-    return kind == AccessorKind::IsAddressor
-        || kind == AccessorKind::IsMutableAddressor;
+    return kind == AccessorKind::Address
+        || kind == AccessorKind::MutableAddress;
   }
 
   /// isGetterOrSetter - Determine whether this is specifically a getter or
@@ -5753,8 +5745,8 @@ public:
   bool isGetterOrSetter() const { return isGetter() || isSetter(); }
 
   bool isObservingAccessor() const {
-    return getAccessorKind() == AccessorKind::IsDidSet ||
-           getAccessorKind() == AccessorKind::IsWillSet;
+    return getAccessorKind() == AccessorKind::DidSet ||
+           getAccessorKind() == AccessorKind::WillSet;
   }
 
   static bool classof(const Decl *D) {

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -265,7 +265,7 @@ ERROR(conflicting_property_addressor,none,
       "%select{variable|subscript}0 already has a "
       "%select{addressor|mutable addressor}1", (unsigned, unsigned))
 ERROR(expected_accessor_name,none,
-      "expected %select{%error|setter|willSet|didSet}0 parameter name",
+      "expected %select{%error|setter|%error|willSet|didSet}0 parameter name",
       (unsigned))
 ERROR(expected_rparen_set_name,none,
       "expected ')' after setter parameter name",())

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -878,12 +878,9 @@ public:
 
   struct ParsedAccessors {
     SourceLoc LBLoc, RBLoc;
-    AccessorDecl *Get = nullptr;
-    AccessorDecl *Set = nullptr;
-    AccessorDecl *Addressor = nullptr;
-    AccessorDecl *MutableAddressor = nullptr;
-    AccessorDecl *WillSet = nullptr;
-    AccessorDecl *DidSet = nullptr;
+
+#define ACCESSOR(ID) AccessorDecl *ID = nullptr;
+#include "swift/AST/AccessorKinds.def"
 
     void record(Parser &P, AbstractStorageDecl *storage, bool invalid,
                 ParseDeclOptions flags, SourceLoc staticLoc,

--- a/include/swift/Serialization/ModuleFile.h
+++ b/include/swift/Serialization/ModuleFile.h
@@ -568,16 +568,14 @@ private:
   /// Populates TopLevelIDs for name lookup.
   void buildTopLevelDeclMap();
 
+  struct AccessorRecord {
+    SmallVector<serialization::DeclID, 8> IDs;
+  };
+
   /// Sets the accessors for \p storage based on \p rawStorageKind.
   void configureStorage(AbstractStorageDecl *storage,
                         unsigned rawStorageKind,
-                        serialization::DeclID getter,
-                        serialization::DeclID setter,
-                        serialization::DeclID materializeForSet,
-                        serialization::DeclID addressor,
-                        serialization::DeclID mutableAddressor,
-                        serialization::DeclID willSet,
-                        serialization::DeclID didSet);
+                        AccessorRecord &accessors);
 
 public:
   /// Loads a module from the given memory buffer.

--- a/include/swift/Serialization/ModuleFormat.h
+++ b/include/swift/Serialization/ModuleFormat.h
@@ -55,7 +55,7 @@ const uint16_t VERSION_MAJOR = 0;
 /// describe what change you made. The content of this comment isn't important;
 /// it just ensures a conflict if two people change the module format.
 /// Don't worry about adhering to the 80-column limit for this line.
-const uint16_t VERSION_MINOR = 419; // Last change: Remove discriminator from LocalDeclTableInfo.
+const uint16_t VERSION_MINOR = 420; // Last change: accessor refactor
 
 using DeclIDField = BCFixed<31>;
 
@@ -188,15 +188,17 @@ using OperatorKindField = BCFixed<3>;
 // These IDs must \em not be renumbered or reordered without incrementing
 // VERSION_MAJOR.
 enum AccessorKind : uint8_t {
-  Getter = 0,
-  Setter,
+  Get = 0,
+  Set,
   WillSet,
   DidSet,
   MaterializeForSet,
-  Addressor,
-  MutableAddressor,
+  Address,
+  MutableAddress,
 };
 using AccessorKindField = BCFixed<3>;
+
+using AccessorCountField = BCFixed<3>;
 
 // These IDs must \em not be renumbered or reordered without incrementing
 // VERSION_MAJOR.
@@ -956,18 +958,12 @@ namespace decls_block {
     BCFixed<1>,   // is getter mutating?
     BCFixed<1>,   // is setter mutating?
     StorageKindField,   // StorageKind
+    AccessorCountField, // number of accessors
     TypeIDField,  // interface type
-    DeclIDField,  // getter
-    DeclIDField,  // setter
-    DeclIDField,  // materializeForSet
-    DeclIDField,  // addressor
-    DeclIDField,  // mutableAddressor
-    DeclIDField,  // willset
-    DeclIDField,  // didset
     DeclIDField,  // overridden decl
     AccessLevelField, // access level
     AccessLevelField, // setter access, if applicable
-    BCArray<TypeIDField> // dependencies
+    BCArray<TypeIDField> // accessors and dependencies
   >;
 
   using ParamLayout = BCRecordLayout<
@@ -1099,20 +1095,15 @@ namespace decls_block {
     BCFixed<1>,   // is getter mutating?
     BCFixed<1>,   // is setter mutating?
     StorageKindField,   // StorageKind
+    AccessorCountField, // number of accessors
     GenericEnvironmentIDField, // generic environment
     TypeIDField, // interface type
-    DeclIDField, // getter
-    DeclIDField, // setter
-    DeclIDField, // materializeForSet
-    DeclIDField, // addressor
-    DeclIDField, // mutableAddressor
-    DeclIDField, // willSet
-    DeclIDField, // didSet
     DeclIDField, // overridden decl
     AccessLevelField, // access level
     AccessLevelField, // setter access, if applicable
     BCVBR<5>,    // number of parameter name components
     BCArray<IdentifierIDField> // name components,
+                               // followed by DeclID accessors,
                                // followed by TypeID dependencies
     // Trailed by:
     // - generic parameters, if any

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -2152,20 +2152,20 @@ std::pair<unsigned, DeclName> swift::getObjCMethodDiagInfo(
 
   if (auto accessor = dyn_cast<AccessorDecl>(member)) {
     switch (accessor->getAccessorKind()) {
-    case AccessorKind::IsAddressor:
-    case AccessorKind::IsDidSet:
-    case AccessorKind::IsMaterializeForSet:
-    case AccessorKind::IsMutableAddressor:
-    case AccessorKind::IsWillSet:
+    case AccessorKind::Address:
+    case AccessorKind::DidSet:
+    case AccessorKind::MaterializeForSet:
+    case AccessorKind::MutableAddress:
+    case AccessorKind::WillSet:
       llvm_unreachable("Not an Objective-C entry point");
 
-    case AccessorKind::IsGetter:
+    case AccessorKind::Get:
       if (auto var = dyn_cast<VarDecl>(accessor->getStorage()))
         return { 5, var->getFullName() };
 
       return { 6, Identifier() };
 
-    case AccessorKind::IsSetter:
+    case AccessorKind::Set:
       if (auto var = dyn_cast<VarDecl>(accessor->getStorage()))
         return { 7, var->getFullName() };
       return { 8, Identifier() };

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -294,13 +294,12 @@ static StringRef getDefaultArgumentKindString(DefaultArgumentKind value) {
 }
 static StringRef getAccessorKindString(AccessorKind value) {
   switch (value) {
-    case AccessorKind::IsGetter: return "getter";
-    case AccessorKind::IsSetter: return "setter";
-    case AccessorKind::IsWillSet: return "willSet";
-    case AccessorKind::IsDidSet: return "didSet";
-    case AccessorKind::IsMaterializeForSet: return "materializeForSet";
-    case AccessorKind::IsAddressor: return "addressor";
-    case AccessorKind::IsMutableAddressor: return "mutableAddressor";
+#define ACCESSOR(ID)
+#define SINGLETON_ACCESSOR(ID, KEYWORD) \
+  case AccessorKind::ID: return #KEYWORD;
+#include "swift/AST/AccessorKinds.def"
+  case AccessorKind::Address: return "address";
+  case AccessorKind::MutableAddress: return "mutableAddress";
   }
 
   llvm_unreachable("Unhandled AccessorKind in switch.");

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -46,15 +46,15 @@ using namespace swift::Mangle;
 static StringRef getCodeForAccessorKind(AccessorKind kind,
                                         AddressorKind addressorKind) {
   switch (kind) {
-  case AccessorKind::IsGetter:
+  case AccessorKind::Get:
     return "g";
-  case AccessorKind::IsSetter:
+  case AccessorKind::Set:
     return "s";
-  case AccessorKind::IsWillSet:
+  case AccessorKind::WillSet:
     return "w";
-  case AccessorKind::IsDidSet:
+  case AccessorKind::DidSet:
     return "W";
-  case AccessorKind::IsAddressor:
+  case AccessorKind::Address:
     // 'l' is for location. 'A' was taken.
     switch (addressorKind) {
     case AddressorKind::NotAddressor:
@@ -69,7 +69,7 @@ static StringRef getCodeForAccessorKind(AccessorKind kind,
       return "lp";
     }
     llvm_unreachable("bad addressor kind");
-  case AccessorKind::IsMutableAddressor:
+  case AccessorKind::MutableAddress:
     switch (addressorKind) {
     case AddressorKind::NotAddressor:
       llvm_unreachable("bad combo");
@@ -83,7 +83,7 @@ static StringRef getCodeForAccessorKind(AccessorKind kind,
       return "aP";
     }
     llvm_unreachable("bad addressor kind");
-  case AccessorKind::IsMaterializeForSet:
+  case AccessorKind::MaterializeForSet:
     return "m";
   }
   llvm_unreachable("bad accessor kind");

--- a/lib/AST/ASTPrinter.cpp
+++ b/lib/AST/ASTPrinter.cpp
@@ -1386,15 +1386,15 @@ bool PrintAST::shouldPrint(const Decl *D, bool Notify) {
 
 static bool isAccessorAssumedNonMutating(AccessorDecl *accessor) {
   switch (accessor->getAccessorKind()) {
-  case AccessorKind::IsGetter:
-  case AccessorKind::IsAddressor:
+  case AccessorKind::Get:
+  case AccessorKind::Address:
     return true;
 
-  case AccessorKind::IsSetter:
-  case AccessorKind::IsWillSet:
-  case AccessorKind::IsDidSet:
-  case AccessorKind::IsMaterializeForSet:
-  case AccessorKind::IsMutableAddressor:
+  case AccessorKind::Set:
+  case AccessorKind::WillSet:
+  case AccessorKind::DidSet:
+  case AccessorKind::MaterializeForSet:
+  case AccessorKind::MutableAddress:
     return false;
   }
   llvm_unreachable("bad addressor kind");
@@ -2401,29 +2401,29 @@ void PrintAST::visitAccessorDecl(AccessorDecl *decl) {
   printDocumentationComment(decl);
   printAttributes(decl);
   switch (auto kind = decl->getAccessorKind()) {
-  case AccessorKind::IsGetter:
-  case AccessorKind::IsAddressor:
+  case AccessorKind::Get:
+  case AccessorKind::Address:
     recordDeclLoc(decl,
       [&]{
-        Printer << (kind == AccessorKind::IsGetter
+        Printer << (kind == AccessorKind::Get
                       ? "get" : getAddressorLabel(decl));
       });
     Printer << " {";
     break;
-  case AccessorKind::IsDidSet:
-  case AccessorKind::IsMaterializeForSet:
-  case AccessorKind::IsMutableAddressor:
+  case AccessorKind::DidSet:
+  case AccessorKind::MaterializeForSet:
+  case AccessorKind::MutableAddress:
     recordDeclLoc(decl,
       [&]{
-        Printer << (kind == AccessorKind::IsDidSet ? "didSet" :
-                    kind == AccessorKind::IsMaterializeForSet
+        Printer << (kind == AccessorKind::DidSet ? "didSet" :
+                    kind == AccessorKind::MaterializeForSet
                       ? "materializeForSet"
                       : getMutableAddressorLabel(decl));
       });
     Printer << " {";
     break;
-  case AccessorKind::IsSetter:
-  case AccessorKind::IsWillSet:
+  case AccessorKind::Set:
+  case AccessorKind::WillSet:
     recordDeclLoc(decl,
       [&]{
         Printer << (decl->isSetter() ? "set" : "willSet");

--- a/lib/AST/ASTVerifier.cpp
+++ b/lib/AST/ASTVerifier.cpp
@@ -2966,19 +2966,19 @@ public:
       }
 
       switch (FD->getAccessorKind()) {
-      case AccessorKind::IsGetter:
-      case AccessorKind::IsSetter:
-      case AccessorKind::IsWillSet:
-      case AccessorKind::IsDidSet:
-      case AccessorKind::IsMaterializeForSet:
+      case AccessorKind::Get:
+      case AccessorKind::Set:
+      case AccessorKind::WillSet:
+      case AccessorKind::DidSet:
+      case AccessorKind::MaterializeForSet:
         if (FD->getAddressorKind() != AddressorKind::NotAddressor) {
           Out << "non-addressor accessor has an addressor kind\n";
           abort();
         }
         break;
 
-      case AccessorKind::IsAddressor:
-      case AccessorKind::IsMutableAddressor:
+      case AccessorKind::Address:
+      case AccessorKind::MutableAddress:
         if (FD->getAddressorKind() == AddressorKind::NotAddressor) {
           Out << "addressor does not have an addressor kind\n";
           abort();

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -177,25 +177,25 @@ DescriptiveDeclKind Decl::getDescriptiveKind() const {
      auto accessor = cast<AccessorDecl>(this);
 
      switch (accessor->getAccessorKind()) {
-     case AccessorKind::IsGetter:
+     case AccessorKind::Get:
        return DescriptiveDeclKind::Getter;
 
-     case AccessorKind::IsSetter:
+     case AccessorKind::Set:
        return DescriptiveDeclKind::Setter;
 
-     case AccessorKind::IsWillSet:
+     case AccessorKind::WillSet:
        return DescriptiveDeclKind::WillSet;
 
-     case AccessorKind::IsDidSet:
+     case AccessorKind::DidSet:
        return DescriptiveDeclKind::DidSet;
 
-     case AccessorKind::IsAddressor:
+     case AccessorKind::Address:
        return DescriptiveDeclKind::Addressor;
 
-     case AccessorKind::IsMutableAddressor:
+     case AccessorKind::MutableAddress:
        return DescriptiveDeclKind::MutableAddressor;
 
-     case AccessorKind::IsMaterializeForSet:
+     case AccessorKind::MaterializeForSet:
        return DescriptiveDeclKind::MaterializeForSet;
      }
      llvm_unreachable("bad accessor kind");
@@ -3501,7 +3501,7 @@ bool ProtocolDecl::existentialTypeSupportedSlow(LazyResolver *resolver) {
     if (auto valueMember = dyn_cast<ValueDecl>(member)) {
       // materializeForSet has a funny type signature.
       if (auto accessor = dyn_cast<AccessorDecl>(member)) {
-        if (accessor->getAccessorKind() == AccessorKind::IsMaterializeForSet)
+        if (accessor->getAccessorKind() == AccessorKind::MaterializeForSet)
           continue;
       }
 
@@ -3617,19 +3617,19 @@ AbstractStorageDecl::getAccessorFunction(AccessorKind kind) const {
   // storage doesn't have.  It can be convenient to ask for accessors
   // before the declaration is fully-configured.
   switch (kind) {
-  case AccessorKind::IsGetter:
+  case AccessorKind::Get:
     return getGetter();
-  case AccessorKind::IsSetter:
+  case AccessorKind::Set:
     return getSetter();
-  case AccessorKind::IsMaterializeForSet:
+  case AccessorKind::MaterializeForSet:
     return getMaterializeForSetFunc();
-  case AccessorKind::IsAddressor:
+  case AccessorKind::Address:
     return hasAddressors() ? getAddressor() : nullptr;
-  case AccessorKind::IsMutableAddressor:
+  case AccessorKind::MutableAddress:
     return hasAddressors() ? getMutableAddressor() : nullptr;
-  case AccessorKind::IsDidSet:
+  case AccessorKind::DidSet:
     return hasObservers() ? getDidSetFunc() : nullptr;
-  case AccessorKind::IsWillSet:
+  case AccessorKind::WillSet:
     return hasObservers() ? getWillSetFunc() : nullptr;
   }
   llvm_unreachable("bad accessor kind!");
@@ -3675,7 +3675,7 @@ void AbstractStorageDecl::configureGetSetRecord(GetSetRecord *getSetInfo,
                                                 AccessorDecl *getter,
                                                 AccessorDecl *setter,
                                               AccessorDecl *materializeForSet) {
-  assert(isAccessor(getter, IsGetter, this));
+  assert(isAccessor(getter, Get, this));
   getSetInfo->Get = getter;
 
   configureSetRecord(getSetInfo, setter, materializeForSet);
@@ -3684,8 +3684,8 @@ void AbstractStorageDecl::configureGetSetRecord(GetSetRecord *getSetInfo,
 void AbstractStorageDecl::configureSetRecord(GetSetRecord *getSetInfo,
                                              AccessorDecl *setter,
                                              AccessorDecl *materializeForSet) {
-  assert(isAccessor(setter, IsSetter, this));
-  assert(isAccessor(materializeForSet, IsMaterializeForSet, this));
+  assert(isAccessor(setter, Set, this));
+  assert(isAccessor(materializeForSet, MaterializeForSet, this));
   getSetInfo->Set = setter;
   getSetInfo->MaterializeForSet = materializeForSet;
 
@@ -3709,8 +3709,8 @@ void AbstractStorageDecl::configureSetRecord(GetSetRecord *getSetInfo,
 void AbstractStorageDecl::configureAddressorRecord(AddressorRecord *record,
                                                    AccessorDecl *addressor,
                                                AccessorDecl *mutableAddressor) {
-  assert(isAccessor(addressor, IsAddressor, this));
-  assert(isAccessor(mutableAddressor, IsMutableAddressor, this));
+  assert(isAccessor(addressor, Address, this));
+  assert(isAccessor(mutableAddressor, MutableAddress, this));
   record->Address = addressor;
   record->MutableAddress = mutableAddressor;
 }
@@ -3718,8 +3718,8 @@ void AbstractStorageDecl::configureAddressorRecord(AddressorRecord *record,
 void AbstractStorageDecl::configureObservingRecord(ObservingRecord *record,
                                                    AccessorDecl *willSet,
                                                    AccessorDecl *didSet) {
-  assert(isAccessor(willSet, IsWillSet, this));
-  assert(isAccessor(didSet, IsDidSet, this));
+  assert(isAccessor(willSet, WillSet, this));
+  assert(isAccessor(didSet, DidSet, this));
   record->WillSet = willSet;
   record->DidSet = didSet;
 }
@@ -3741,18 +3741,18 @@ void AbstractStorageDecl::makeComputed(SourceLoc LBraceLoc,
   setStorageKind(Computed);
 }
 
-void AbstractStorageDecl::setComputedSetter(AccessorDecl *Set) {
+void AbstractStorageDecl::setComputedSetter(AccessorDecl *setter) {
   assert(getStorageKind() == Computed && "Not a computed variable");
   assert(getGetter() && "sanity check: missing getter");
   assert(!getSetter() && "already has a setter");
   assert(hasClangNode() && "should only be used for ObjC properties");
-  assert(Set && "should not be called for readonly properties");
-  assert(isAccessor(Set, IsSetter, this));
-  GetSetInfo.getPointer()->Set = Set;
+  assert(setter && "should not be called for readonly properties");
+  assert(isAccessor(setter, Set, this));
+  GetSetInfo.getPointer()->Set = setter;
   if (auto setterAccess = GetSetInfo.getInt()) {
-    assert(!Set->hasAccess() ||
-           Set->getFormalAccess() == setterAccess.getValue());
-    Set->overwriteAccess(setterAccess.getValue());
+    assert(!setter->hasAccess() ||
+           setter->getFormalAccess() == setterAccess.getValue());
+    setter->overwriteAccess(setterAccess.getValue());
   }
 }
 
@@ -3794,7 +3794,7 @@ void AbstractStorageDecl::setMaterializeForSetFunc(AccessorDecl *accessor) {
   assert(hasAccessorFunctions() && "No accessors for declaration!");
   assert(getSetter() && "declaration is not settable");
   assert(!getMaterializeForSetFunc() && "already has a materializeForSet");
-  assert(isAccessor(accessor, IsMaterializeForSet, this));
+  assert(isAccessor(accessor, MaterializeForSet, this));
   GetSetInfo.getPointer()->MaterializeForSet = accessor;
   if (auto setterAccess = GetSetInfo.getInt()) {
     assert(!accessor->hasAccess() ||
@@ -4656,22 +4656,22 @@ DeclName AbstractFunctionDecl::getEffectiveFullName() const {
     auto subscript = dyn_cast<SubscriptDecl>(storage);
     switch (auto accessorKind = accessor->getAccessorKind()) {
     // These don't have any extra implicit parameters.
-    case AccessorKind::IsAddressor:
-    case AccessorKind::IsMutableAddressor:
-    case AccessorKind::IsGetter:
+    case AccessorKind::Address:
+    case AccessorKind::MutableAddress:
+    case AccessorKind::Get:
       return subscript ? subscript->getFullName()
                        : DeclName(ctx, storage->getBaseName(),
                                   ArrayRef<Identifier>());
 
-    case AccessorKind::IsSetter:
-    case AccessorKind::IsMaterializeForSet:
-    case AccessorKind::IsDidSet:
-    case AccessorKind::IsWillSet: {
+    case AccessorKind::Set:
+    case AccessorKind::MaterializeForSet:
+    case AccessorKind::DidSet:
+    case AccessorKind::WillSet: {
       SmallVector<Identifier, 4> argNames;
       // The implicit value/buffer parameter.
       argNames.push_back(Identifier());
       // The callback storage parameter on materializeForSet.
-      if (accessorKind  == AccessorKind::IsMaterializeForSet)
+      if (accessorKind  == AccessorKind::MaterializeForSet)
         argNames.push_back(Identifier());
       // The subscript index parameters.
       if (subscript) {
@@ -4962,13 +4962,13 @@ static bool requiresNewVTableEntry(const AbstractFunctionDecl *decl) {
 
   if (auto *accessor = dyn_cast<AccessorDecl>(decl)) {
     switch (accessor->getAccessorKind()) {
-    case AccessorKind::IsGetter:
-    case AccessorKind::IsSetter:
+    case AccessorKind::Get:
+    case AccessorKind::Set:
       break;
-    case AccessorKind::IsAddressor:
-    case AccessorKind::IsMutableAddressor:
+    case AccessorKind::Address:
+    case AccessorKind::MutableAddress:
       return false;
-    case AccessorKind::IsMaterializeForSet:
+    case AccessorKind::MaterializeForSet:
       // Special case -- materializeForSet on dynamic storage is not
       // itself dynamic, but should be treated as such for the
       // purpose of constructing a vtable.
@@ -4976,8 +4976,8 @@ static bool requiresNewVTableEntry(const AbstractFunctionDecl *decl) {
       if (accessor->getStorage()->isDynamic())
         return false;
       break;
-    case AccessorKind::IsWillSet:
-    case AccessorKind::IsDidSet:
+    case AccessorKind::WillSet:
+    case AccessorKind::DidSet:
       return false;
     }
   }

--- a/lib/AST/PrettyStackTrace.cpp
+++ b/lib/AST/PrettyStackTrace.cpp
@@ -51,25 +51,25 @@ void swift::printDeclDescription(llvm::raw_ostream &out, const Decl *D,
       auto ASD = accessor->getStorage();
       if (ASD->hasName()) {
         switch (accessor->getAccessorKind()) {
-        case AccessorKind::IsGetter:
+        case AccessorKind::Get:
           out << "getter";
           break;
-        case AccessorKind::IsSetter:
+        case AccessorKind::Set:
           out << "setter";
           break;
-        case AccessorKind::IsWillSet:
+        case AccessorKind::WillSet:
           out << "willset";
           break;
-        case AccessorKind::IsDidSet:
+        case AccessorKind::DidSet:
           out << "didset";
           break;
-        case AccessorKind::IsMaterializeForSet:
+        case AccessorKind::MaterializeForSet:
           out << "materializeForSet";
           break;
-        case AccessorKind::IsAddressor:
+        case AccessorKind::Address:
           out << "addressor";
           break;
-        case AccessorKind::IsMutableAddressor:
+        case AccessorKind::MutableAddress:
           out << "mutableAddressor";
           break;
         }

--- a/lib/AST/USRGeneration.cpp
+++ b/lib/AST/USRGeneration.cpp
@@ -105,10 +105,10 @@ static bool printObjCUSRForAccessor(const AbstractStorageDecl *ASD,
 
   ObjCSelector Selector;
   switch (Kind) {
-    case swift::AccessorKind::IsGetter:
+    case swift::AccessorKind::Get:
       Selector = ASD->getObjCGetterSelector();
       break;
-    case swift::AccessorKind::IsSetter:
+    case swift::AccessorKind::Set:
       Selector = ASD->getObjCSetterSelector();
       break;
     default:

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -507,7 +507,7 @@ static AccessorDecl *makeEnumRawValueGetter(ClangImporter::Implementation &Impl,
   auto getterDecl = AccessorDecl::create(C,
                      /*FuncLoc=*/SourceLoc(),
                      /*AccessorKeywordLoc=*/SourceLoc(),
-                     AccessorKind::IsGetter,
+                     AccessorKind::Get,
                      AddressorKind::NotAddressor,
                      rawValueDecl,
                      /*StaticLoc=*/SourceLoc(),
@@ -592,7 +592,7 @@ static AccessorDecl *makeStructRawValueGetter(
   auto getterDecl = AccessorDecl::create(C,
                      /*FuncLoc=*/SourceLoc(),
                      /*AccessorKeywordLoc=*/SourceLoc(),
-                     AccessorKind::IsGetter,
+                     AccessorKind::Get,
                      AddressorKind::NotAddressor,
                      computedVar,
                      /*StaticLoc=*/SourceLoc(),
@@ -661,7 +661,7 @@ static AccessorDecl *makeFieldGetterDecl(ClangImporter::Implementation &Impl,
   auto getterDecl = AccessorDecl::create(C,
                      /*FuncLoc=*/importedFieldDecl->getLoc(),
                      /*AccessorKeywordLoc=*/SourceLoc(),
-                     AccessorKind::IsGetter,
+                     AccessorKind::Get,
                      AddressorKind::NotAddressor,
                      importedFieldDecl,
                      /*StaticLoc=*/SourceLoc(),
@@ -703,7 +703,7 @@ static AccessorDecl *makeFieldSetterDecl(ClangImporter::Implementation &Impl,
   auto setterDecl = AccessorDecl::create(C,
                      /*FuncLoc=*/SourceLoc(),
                      /*AccessorKeywordLoc=*/SourceLoc(),
-                     AccessorKind::IsSetter,
+                     AccessorKind::Set,
                      AddressorKind::NotAddressor,
                      importedFieldDecl,
                      /*StaticLoc=*/SourceLoc(),
@@ -1623,7 +1623,7 @@ buildSubscriptGetterDecl(ClangImporter::Implementation &Impl,
   auto thunk = AccessorDecl::create(C,
                      /*FuncLoc=*/loc,
                      /*AccessorKeywordLoc=*/SourceLoc(),
-                     AccessorKind::IsGetter,
+                     AccessorKind::Get,
                      AddressorKind::NotAddressor,
                      subscript,
                      /*StaticLoc=*/SourceLoc(),
@@ -1694,7 +1694,7 @@ buildSubscriptSetterDecl(ClangImporter::Implementation &Impl,
   auto thunk = AccessorDecl::create(C,
                      /*FuncLoc=*/setter->getLoc(),
                      /*AccessorKeywordLoc=*/SourceLoc(),
-                     AccessorKind::IsSetter,
+                     AccessorKind::Set,
                      AddressorKind::NotAddressor,
                      subscript,
                      /*StaticLoc=*/SourceLoc(),
@@ -1868,7 +1868,7 @@ static bool addErrorDomain(NominalTypeDecl *swiftDecl,
   auto getterDecl = AccessorDecl::create(C,
                      /*FuncLoc=*/SourceLoc(),
                      /*AccessorKeywordLoc=*/SourceLoc(),
-                     AccessorKind::IsGetter,
+                     AccessorKind::Get,
                      AddressorKind::NotAddressor,
                      errorDomainPropertyDecl,
                      /*StaticLoc=*/SourceLoc(),
@@ -4788,7 +4788,7 @@ namespace {
         return;
 
       AccessorDecl *setter = importAccessor(clangSetter,
-                                            original, AccessorKind::IsSetter,
+                                            original, AccessorKind::Set,
                                             original->getDeclContext());
       if (!setter)
         return;
@@ -4894,7 +4894,7 @@ namespace {
       // Import the getter.
       AccessorDecl *getter = nullptr;
       if (auto clangGetter = decl->getGetterMethodDecl()) {
-        getter = importAccessor(clangGetter, result, AccessorKind::IsGetter, dc);
+        getter = importAccessor(clangGetter, result, AccessorKind::Get, dc);
         if (!getter)
           return nullptr;
       }
@@ -4902,7 +4902,7 @@ namespace {
       // Import the setter, if there is one.
       AccessorDecl *setter = nullptr;
       if (auto clangSetter = decl->getSetterMethodDecl()) {
-        setter = importAccessor(clangSetter, result, AccessorKind::IsSetter, dc);
+        setter = importAccessor(clangSetter, result, AccessorKind::Set, dc);
         if (!setter)
           return nullptr;
       }
@@ -5933,7 +5933,7 @@ SwiftDeclConverter::getImplicitProperty(ImportedName importedName,
   // Import the getter.
   auto *swiftGetter = dyn_cast_or_null<AccessorDecl>(
       importFunctionDecl(getter, getterName, None,
-                         AccessorInfo{property, AccessorKind::IsGetter}));
+                         AccessorInfo{property, AccessorKind::Get}));
   if (!swiftGetter)
     return nullptr;
 
@@ -5947,7 +5947,7 @@ SwiftDeclConverter::getImplicitProperty(ImportedName importedName,
   if (setter) {
     swiftSetter = dyn_cast_or_null<AccessorDecl>(
         importFunctionDecl(setter, setterName, None,
-                           AccessorInfo{property, AccessorKind::IsSetter}));
+                           AccessorInfo{property, AccessorKind::Set}));
     if (!swiftSetter)
       return nullptr;
 
@@ -8339,7 +8339,7 @@ ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
   auto func = AccessorDecl::create(C,
                      /*FuncLoc=*/SourceLoc(),
                      /*AccessorKeywordLoc=*/SourceLoc(),
-                     AccessorKind::IsGetter,
+                     AccessorKind::Get,
                      AddressorKind::NotAddressor,
                      var,
                      /*StaticLoc=*/SourceLoc(),

--- a/lib/IRGen/GenClass.cpp
+++ b/lib/IRGen/GenClass.cpp
@@ -1644,19 +1644,19 @@ namespace {
         return emitObjCMethodDescriptor(IGM, descriptors, method);
 
       switch (accessor->getAccessorKind()) {
-      case AccessorKind::IsGetter:
+      case AccessorKind::Get:
         return emitObjCGetterDescriptor(IGM, descriptors,
                                         accessor->getStorage());
 
-      case AccessorKind::IsSetter:
+      case AccessorKind::Set:
         return emitObjCSetterDescriptor(IGM, descriptors,
                                         accessor->getStorage());
 
-      case AccessorKind::IsWillSet:
-      case AccessorKind::IsDidSet:
-      case AccessorKind::IsMaterializeForSet:
-      case AccessorKind::IsAddressor:
-      case AccessorKind::IsMutableAddressor:
+      case AccessorKind::WillSet:
+      case AccessorKind::DidSet:
+      case AccessorKind::MaterializeForSet:
+      case AccessorKind::Address:
+      case AccessorKind::MutableAddress:
         llvm_unreachable("shouldn't be trying to build this accessor");
       }
       llvm_unreachable("bad accessor kind");

--- a/lib/IRGen/GenMeta.cpp
+++ b/lib/IRGen/GenMeta.cpp
@@ -134,16 +134,16 @@ static Flags getMethodDescriptorFlags(ValueDecl *fn) {
     auto accessor = dyn_cast<AccessorDecl>(fn);
     if (!accessor) return Flags::Kind::Method;
     switch (accessor->getAccessorKind()) {
-    case AccessorKind::IsGetter:
+    case AccessorKind::Get:
       return Flags::Kind::Getter;
-    case AccessorKind::IsSetter:
+    case AccessorKind::Set:
       return Flags::Kind::Setter;
-    case AccessorKind::IsMaterializeForSet:
+    case AccessorKind::MaterializeForSet:
       return Flags::Kind::MaterializeForSet;
-    case AccessorKind::IsWillSet:
-    case AccessorKind::IsDidSet:
-    case AccessorKind::IsAddressor:
-    case AccessorKind::IsMutableAddressor:
+    case AccessorKind::WillSet:
+    case AccessorKind::DidSet:
+    case AccessorKind::Address:
+    case AccessorKind::MutableAddress:
       llvm_unreachable("these accessors never appear in protocols or v-tables");
     }
     llvm_unreachable("bad kind");

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -352,25 +352,25 @@ private:
       if (ValueDecl *VD = accessor->getStorage()) {
         const char *Kind;
         switch (accessor->getAccessorKind()) {
-        case AccessorKind::IsGetter:
+        case AccessorKind::Get:
           Kind = ".get";
           break;
-        case AccessorKind::IsSetter:
+        case AccessorKind::Set:
           Kind = ".set";
           break;
-        case AccessorKind::IsWillSet:
+        case AccessorKind::WillSet:
           Kind = ".willset";
           break;
-        case AccessorKind::IsDidSet:
+        case AccessorKind::DidSet:
           Kind = ".didset";
           break;
-        case AccessorKind::IsMaterializeForSet:
+        case AccessorKind::MaterializeForSet:
           Kind = ".materialize";
           break;
-        case AccessorKind::IsAddressor:
+        case AccessorKind::Address:
           Kind = ".addressor";
           break;
-        case AccessorKind::IsMutableAddressor:
+        case AccessorKind::MutableAddress:
           Kind = ".mutableAddressor";
           break;
         }

--- a/lib/Index/Index.cpp
+++ b/lib/Index/Index.cpp
@@ -37,22 +37,22 @@ using namespace swift::index;
 static bool
 printArtificialName(const swift::AbstractStorageDecl *ASD, AccessorKind AK, llvm::raw_ostream &OS) {
   switch (AK) {
-  case AccessorKind::IsGetter:
+  case AccessorKind::Get:
     OS << "getter:" << ASD->getFullName();
     return false;
-  case AccessorKind::IsSetter:
+  case AccessorKind::Set:
     OS << "setter:" << ASD->getFullName();
     return false;
-  case AccessorKind::IsDidSet:
+  case AccessorKind::DidSet:
     OS << "didSet:" << ASD->getFullName();
     return false;
-  case AccessorKind::IsWillSet:
+  case AccessorKind::WillSet:
     OS << "willSet:" << ASD->getFullName() ;
     return false;
 
-  case AccessorKind::IsMaterializeForSet:
-  case AccessorKind::IsAddressor:
-  case AccessorKind::IsMutableAddressor:
+  case AccessorKind::MaterializeForSet:
+  case AccessorKind::Address:
+  case AccessorKind::MutableAddress:
     return true;
   }
 
@@ -407,11 +407,11 @@ private:
   NominalTypeDecl *getTypeLocAsNominalTypeDecl(const TypeLoc &Ty);
 
   bool reportPseudoGetterDecl(VarDecl *D) {
-    return reportPseudoAccessor(D, AccessorKind::IsGetter, /*IsRef=*/false,
+    return reportPseudoAccessor(D, AccessorKind::Get, /*IsRef=*/false,
                                 D->getLoc());
   }
   bool reportPseudoSetterDecl(VarDecl *D) {
-    return reportPseudoAccessor(D, AccessorKind::IsSetter, /*IsRef=*/false,
+    return reportPseudoAccessor(D, AccessorKind::Set, /*IsRef=*/false,
                                 D->getLoc());
   }
   bool reportPseudoAccessor(AbstractStorageDecl *D, AccessorKind AccKind,
@@ -962,11 +962,11 @@ bool IndexSwiftASTWalker::reportRef(ValueDecl *D, SourceLoc Loc,
     bool UsesSetter = Info.roles & (SymbolRoleSet)SymbolRole::Write;
 
     if (UsesGetter)
-      if (!reportPseudoAccessor(ASD, AccessorKind::IsGetter, /*IsRef=*/true,
+      if (!reportPseudoAccessor(ASD, AccessorKind::Get, /*IsRef=*/true,
                                 Loc))
         return false;
     if (UsesSetter)
-      if (!reportPseudoAccessor(ASD, AccessorKind::IsSetter, /*IsRef=*/true,
+      if (!reportPseudoAccessor(ASD, AccessorKind::Set, /*IsRef=*/true,
                                 Loc))
         return false;
   }

--- a/lib/Index/IndexSymbol.cpp
+++ b/lib/Index/IndexSymbol.cpp
@@ -229,14 +229,14 @@ SymbolInfo index::getSymbolInfoForDecl(const Decl *D) {
 
 SymbolSubKind index::getSubKindForAccessor(AccessorKind AK) {
   switch (AK) {
-  case AccessorKind::IsGetter:    return SymbolSubKind::AccessorGetter;
-  case AccessorKind::IsSetter:    return SymbolSubKind::AccessorSetter;
-  case AccessorKind::IsWillSet:   return SymbolSubKind::SwiftAccessorWillSet;
-  case AccessorKind::IsDidSet:    return SymbolSubKind::SwiftAccessorDidSet;
-  case AccessorKind::IsAddressor: return SymbolSubKind::SwiftAccessorAddressor;
-  case AccessorKind::IsMutableAddressor:
+  case AccessorKind::Get:    return SymbolSubKind::AccessorGetter;
+  case AccessorKind::Set:    return SymbolSubKind::AccessorSetter;
+  case AccessorKind::WillSet:   return SymbolSubKind::SwiftAccessorWillSet;
+  case AccessorKind::DidSet:    return SymbolSubKind::SwiftAccessorDidSet;
+  case AccessorKind::Address: return SymbolSubKind::SwiftAccessorAddressor;
+  case AccessorKind::MutableAddress:
     return SymbolSubKind::SwiftAccessorMutableAddressor;
-  case AccessorKind::IsMaterializeForSet:
+  case AccessorKind::MaterializeForSet:
     llvm_unreachable("unexpected MaterializeForSet");
   }
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3801,19 +3801,19 @@ static AccessorDecl *createAccessorFunc(SourceLoc DeclLoc,
   // default to mutating.  get/address default to
   // non-mutating.
   switch (Kind) {
-  case AccessorKind::IsAddressor:
-  case AccessorKind::IsGetter:
+  case AccessorKind::Address:
+  case AccessorKind::Get:
     break;
 
-  case AccessorKind::IsMutableAddressor:
-  case AccessorKind::IsSetter:
-  case AccessorKind::IsWillSet:
-  case AccessorKind::IsDidSet:
+  case AccessorKind::MutableAddress:
+  case AccessorKind::Set:
+  case AccessorKind::WillSet:
+  case AccessorKind::DidSet:
     if (D->isInstanceMember())
       D->setSelfAccessKind(SelfAccessKind::Mutating);
     break;
 
-  case AccessorKind::IsMaterializeForSet:
+  case AccessorKind::MaterializeForSet:
     llvm_unreachable("not parseable accessors");
   }
 
@@ -3829,7 +3829,7 @@ static ParamDecl *createSetterAccessorArgument(SourceLoc nameLoc,
   bool isNameImplicit = name.empty();
   if (isNameImplicit) {
     const char *implName =
-      accessorKind == AccessorKind::IsDidSet ? "oldValue" : "newValue";
+      accessorKind == AccessorKind::DidSet ? "oldValue" : "newValue";
     name = P.Context.getIdentifier(implName);
   }
 
@@ -3862,8 +3862,8 @@ static ParameterList *parseOptionalAccessorArgument(SourceLoc SpecifierLoc,
                                                     TypeLoc ElementTy) {
   // 'set' and 'willSet' have a (value) parameter, 'didSet' takes an (oldValue)
   // parameter and 'get' and always takes a () parameter.
-  if (Kind != AccessorKind::IsSetter && Kind != AccessorKind::IsWillSet &&
-      Kind != AccessorKind::IsDidSet)
+  if (Kind != AccessorKind::Set && Kind != AccessorKind::WillSet &&
+      Kind != AccessorKind::DidSet)
     return nullptr;
 
   SourceLoc StartLoc, NameLoc, EndLoc;
@@ -3887,8 +3887,8 @@ static ParameterList *parseOptionalAccessorArgument(SourceLoc SpecifierLoc,
       NameLoc = P.consumeToken();
 
       auto DiagID =
-         Kind == AccessorKind::IsSetter ? diag::expected_rparen_set_name :
-         Kind == AccessorKind::IsWillSet ? diag::expected_rparen_willSet_name :
+         Kind == AccessorKind::Set ? diag::expected_rparen_set_name :
+         Kind == AccessorKind::WillSet ? diag::expected_rparen_willSet_name :
           diag::expected_rparen_didSet_name;
       
       // Look for the closing ')'.
@@ -3960,58 +3960,33 @@ void Parser::consumeGetSetBody(AbstractFunctionDecl *AFD,
   }
 }
 
-static AddressorKind getImmutableAddressorKind(Token &tok) {
-  if (tok.isContextualKeyword("unsafeAddress")) {
-    return AddressorKind::Unsafe;
-  } else if (tok.isContextualKeyword("addressWithOwner")) {
-    return AddressorKind::Owning;
-  } else if (tok.isContextualKeyword("addressWithNativeOwner")) {
-    return AddressorKind::NativeOwning;
-  } else if (tok.isContextualKeyword("addressWithPinnedNativeOwner")) {
-    return AddressorKind::NativePinning;
-  } else {
-    return AddressorKind::NotAddressor;
-  }
-}
-static AddressorKind getMutableAddressorKind(Token &tok) {
-  if (tok.isContextualKeyword("unsafeMutableAddress")) {
-    return AddressorKind::Unsafe;
-  } else if (tok.isContextualKeyword("mutableAddressWithOwner")) {
-    return AddressorKind::Owning;
-  } else if (tok.isContextualKeyword("mutableAddressWithNativeOwner")) {
-    return AddressorKind::NativeOwning;
-  } else if (tok.isContextualKeyword("mutableAddressWithPinnedNativeOwner")) {
-    return AddressorKind::NativePinning;
-  } else {
-    return AddressorKind::NotAddressor;
-  }
-}
-
-/// Returns an accessor kind that 
+/// Returns a descriptive name for the given accessor/addressor kind.
 static StringRef getAccessorNameForDiagnostic(AccessorKind accessorKind,
                                               AddressorKind addressorKind) {
   switch (accessorKind) {
-  case AccessorKind::IsGetter: return "getter";
-  case AccessorKind::IsSetter: return "setter";
-  case AccessorKind::IsDidSet: return "didSet";
-  case AccessorKind::IsWillSet: return "willSet";
-  case AccessorKind::IsMaterializeForSet: return "materializeForSet";
-  case AccessorKind::IsAddressor:
+  case AccessorKind::Get: return "getter";
+  case AccessorKind::Set: return "setter";
+#define ACCESSOR(ID)
+#define OBJC_ACCESSOR(ID, KEYWORD) // treated specially above
+#define SINGLETON_ACCESSOR(ID, KEYWORD) \
+  case AccessorKind::ID: return #KEYWORD;
+#include "swift/AST/AccessorKinds.def"
+  case AccessorKind::Address:
     switch (addressorKind) {
     case AddressorKind::NotAddressor: llvm_unreachable("invalid");
-    case AddressorKind::Unsafe: return "unsafeAddress";
-    case AddressorKind::Owning: return "addressWithOwner";
-    case AddressorKind::NativeOwning: return "addressWithNativeOwner";
-    case AddressorKind::NativePinning: return "addressWithPinnedNativeOwner";
+#define ACCESSOR_KEYWORD(KEYWORD)
+#define IMMUTABLE_ADDRESSOR(ID, KEYWORD) \
+    case AddressorKind::ID: return #KEYWORD;
+#include "swift/AST/AccessorKinds.def"
     }
     llvm_unreachable("bad addressor kind");
-  case AccessorKind::IsMutableAddressor:
+  case AccessorKind::MutableAddress:
     switch (addressorKind) {
     case AddressorKind::NotAddressor: llvm_unreachable("invalid");
-    case AddressorKind::Unsafe: return "unsafeMutableAddress";
-    case AddressorKind::Owning: return "mutableAddressWithOwner";
-    case AddressorKind::NativeOwning: return "mutableAddressWithNativeOwner";
-    case AddressorKind::NativePinning: return "mutableAddressWithPinnedNativeOwner";
+#define ACCESSOR_KEYWORD(KEYWORD)
+#define MUTABLE_ADDRESSOR(ID, KEYWORD) \
+    case AddressorKind::ID: return #KEYWORD;
+#include "swift/AST/AccessorKinds.def"
     }
     llvm_unreachable("bad addressor kind");
   }
@@ -4025,15 +4000,15 @@ static void diagnoseRedundantAccessors(Parser &P, SourceLoc loc,
                                        AccessorDecl *previousDecl) {
   // Different addressor safety kinds still count as the same addressor.
   if (previousDecl->getAddressorKind() != addressorKind) {
-    assert(accessorKind == AccessorKind::IsAddressor ||
-           accessorKind == AccessorKind::IsMutableAddressor);
+    assert(accessorKind == AccessorKind::Address ||
+           accessorKind == AccessorKind::MutableAddress);
     P.diagnose(loc, diag::conflicting_property_addressor,
                unsigned(isSubscript),
-               unsigned(accessorKind == AccessorKind::IsMutableAddressor));
+               unsigned(accessorKind == AccessorKind::MutableAddress));
 
     // Be less specific about the previous definition.
     P.diagnose(previousDecl->getLoc(), diag::previous_accessor,
-               accessorKind == AccessorKind::IsMutableAddressor
+               accessorKind == AccessorKind::MutableAddress
                  ? "mutable addressor" : "addressor");
     return;
   }
@@ -4092,23 +4067,23 @@ bool Parser::parseGetSetImpl(ParseDeclOptions Flags,
       AddressorKind addressorKind = AddressorKind::NotAddressor;
       AccessorDecl **TheDeclPtr;
       SourceLoc AccessorKeywordLoc = Tok.getLoc();
-      if (Tok.isContextualKeyword("get")) {
-        Kind = AccessorKind::IsGetter;
-        TheDeclPtr = &accessors.Get;
-      } else if (Tok.isContextualKeyword("set")) {
-        Kind = AccessorKind::IsSetter;
-        TheDeclPtr = &accessors.Set;
-      } else if (!Flags.contains(PD_InProtocol) &&
-                 (addressorKind = getImmutableAddressorKind(Tok))
-                   != AddressorKind::NotAddressor) {
-        Kind = AccessorKind::IsAddressor;
-        TheDeclPtr = &accessors.Addressor;
-      } else if (!Flags.contains(PD_InProtocol) &&
-                 (addressorKind = getMutableAddressorKind(Tok))
-                   != AddressorKind::NotAddressor) {
-        Kind = AccessorKind::IsMutableAddressor;
-        TheDeclPtr = &accessors.MutableAddressor;
-      } else {
+      if (false) {}
+#define SUPPRESS_ARTIFICIAL_ACCESSORS 1
+#define ACCESSOR_KEYWORD(KEYWORD)
+#define OBSERVING_ACCESSOR(ID, KEYWORD) // don't allow here
+#define SINGLETON_ACCESSOR(ID, KEYWORD)                 \
+      else if (Tok.isContextualKeyword(#KEYWORD)) {     \
+        Kind = AccessorKind::ID;                        \
+        TheDeclPtr = &accessors.ID;                     \
+      }
+#define ANY_ADDRESSOR(ID, ADDRESSOR_ID, KEYWORD)        \
+      else if (Tok.isContextualKeyword(#KEYWORD)) {     \
+        Kind = AccessorKind::ID;                        \
+        TheDeclPtr = &accessors.ID;                     \
+        addressorKind = AddressorKind::ADDRESSOR_ID;    \
+      }
+#include "swift/AST/AccessorKinds.def"
+      else {
         AccessorCtx.setTransparent();
         AccessorKeywordLoc = SourceLoc();
         diagnose(Tok, diag::expected_getset_in_protocol);
@@ -4192,27 +4167,22 @@ bool Parser::parseGetSetImpl(ParseDeclOptions Flags,
     AddressorKind addressorKind = AddressorKind::NotAddressor;
     AccessorDecl **TheDeclPtr;
     SourceLoc AccessorKeywordLoc =  Tok.getLoc();
-    if (Tok.isContextualKeyword("get")) {
-      Kind = AccessorKind::IsGetter;
-      TheDeclPtr = &accessors.Get;
-    } else if (Tok.isContextualKeyword("set")) {
-      Kind = AccessorKind::IsSetter;
-      TheDeclPtr = &accessors.Set;
-    } else if (Tok.isContextualKeyword("willSet")) {
-      Kind = AccessorKind::IsWillSet;
-      TheDeclPtr = &accessors.WillSet;
-    } else if (Tok.isContextualKeyword("didSet")) {
-      Kind = AccessorKind::IsDidSet;
-      TheDeclPtr = &accessors.DidSet;
-    } else if ((addressorKind = getImmutableAddressorKind(Tok))
-                 != AddressorKind::NotAddressor) {
-      Kind = AccessorKind::IsAddressor;
-      TheDeclPtr = &accessors.Addressor;
-    } else if ((addressorKind = getMutableAddressorKind(Tok))
-                 != AddressorKind::NotAddressor) {
-      Kind = AccessorKind::IsMutableAddressor;
-      TheDeclPtr = &accessors.MutableAddressor;
-    } else {
+    if (false) {}
+#define SUPPRESS_ARTIFICIAL_ACCESSORS 1
+#define ACCESSOR_KEYWORD(KEYWORD)
+#define SINGLETON_ACCESSOR(ID, KEYWORD)               \
+    else if (Tok.isContextualKeyword(#KEYWORD)) {     \
+      Kind = AccessorKind::ID;                        \
+      TheDeclPtr = &accessors.ID;                     \
+    }
+#define ANY_ADDRESSOR(ID, ADDRESSOR_ID, KEYWORD)      \
+    else if (Tok.isContextualKeyword(#KEYWORD)) {     \
+      Kind = AccessorKind::ID;                        \
+      TheDeclPtr = &accessors.ID;                     \
+      addressorKind = AddressorKind::ADDRESSOR_ID;    \
+    }
+#include "swift/AST/AccessorKinds.def"
+    else {
       AccessorKeywordLoc = SourceLoc();
       // This is an implicit getter.  Might be not valid in this position,
       // though.  Anyway, go back to the beginning of the getter code to ensure
@@ -4230,7 +4200,7 @@ bool Parser::parseGetSetImpl(ParseDeclOptions Flags,
         // Don't signal an error since we recovered.
         return false;
       }
-      Kind = AccessorKind::IsGetter;
+      Kind = AccessorKind::Get;
       TheDeclPtr = &accessors.Get;
       isImplicitGet = true;
     }
@@ -4426,20 +4396,20 @@ static void fillInAccessorTypeErrors(Parser &P, FuncDecl *accessor,
 
   // Fill in the result type.
   switch (kind) {
-  case AccessorKind::IsMaterializeForSet:
+  case AccessorKind::MaterializeForSet:
     llvm_unreachable("should never be seen here");
 
   // These have non-trivial returns, so fill in error.
-  case AccessorKind::IsGetter:
-  case AccessorKind::IsAddressor:
-  case AccessorKind::IsMutableAddressor:
+  case AccessorKind::Get:
+  case AccessorKind::Address:
+  case AccessorKind::MutableAddress:
     accessor->getBodyResultTypeLoc().setType(P.Context.TheErrorType, true);
     return;
 
   // These return void.
-  case AccessorKind::IsSetter:
-  case AccessorKind::IsWillSet:
-  case AccessorKind::IsDidSet:
+  case AccessorKind::Set:
+  case AccessorKind::WillSet:
+  case AccessorKind::DidSet:
     return;
   }
   llvm_unreachable("bad kind");
@@ -4449,13 +4419,9 @@ static void fillInAccessorTypeErrors(Parser &P, FuncDecl *accessor,
 /// Fill in various slots with type errors.
 static void fillInAccessorTypeErrors(Parser &P,
                                      Parser::ParsedAccessors &accessors) {
-  fillInAccessorTypeErrors(P, accessors.Get, AccessorKind::IsGetter);
-  fillInAccessorTypeErrors(P, accessors.Set, AccessorKind::IsSetter);
-  fillInAccessorTypeErrors(P, accessors.Addressor, AccessorKind::IsAddressor);
-  fillInAccessorTypeErrors(P, accessors.MutableAddressor,
-                           AccessorKind::IsMutableAddressor);
-  fillInAccessorTypeErrors(P, accessors.WillSet, AccessorKind::IsWillSet);
-  fillInAccessorTypeErrors(P, accessors.DidSet, AccessorKind::IsDidSet);
+#define ACCESSOR(ID) \
+  fillInAccessorTypeErrors(P, accessors.ID, AccessorKind::ID);
+#include "swift/AST/AccessorKinds.def"
 }
 
 /// \brief Parse the brace-enclosed getter and setter for a variable.
@@ -4548,8 +4514,8 @@ VarDecl *Parser::parseDeclVarGetSet(Pattern *pattern,
   }
 
   if (!TyLoc.hasLocation()) {
-    if (accessors.Get || accessors.Set || accessors.Addressor ||
-        accessors.MutableAddressor) {
+    if (accessors.Get || accessors.Set || accessors.Address ||
+        accessors.MutableAddress) {
       SourceLoc locAfterPattern = pattern->getLoc().getAdvancedLoc(
         pattern->getBoundName().getLength());
       diagnose(pattern->getLoc(), diag::computed_property_missing_type)
@@ -4563,7 +4529,7 @@ VarDecl *Parser::parseDeclVarGetSet(Pattern *pattern,
     Diag<> DiagID;
     if (accessors.WillSet || accessors.DidSet)
       DiagID = diag::let_cannot_be_observing_property;
-    else if (accessors.Addressor || accessors.MutableAddressor)
+    else if (accessors.Address || accessors.MutableAddress)
       DiagID = diag::let_cannot_be_addressed_property;
     else
       DiagID = diag::let_cannot_be_computed_property;
@@ -4586,6 +4552,15 @@ VarDecl *Parser::parseDeclVarGetSet(Pattern *pattern,
                    Attributes, TyLoc, /*indices*/ nullptr, Decls);
 
   return PrimaryVar;
+}
+
+static Optional<std::pair<AccessorDecl*, size_t>>
+findFirstNonNull(ArrayRef<AccessorDecl*> accessors) {
+  for (auto i : indices(accessors)) {
+    if (accessors[i])
+      return std::make_pair(accessors[i], i);
+  }
+  return None;
 }
 
 /// Record a bunch of parsed accessors into the given abstract storage decl.
@@ -4619,40 +4594,47 @@ void Parser::ParsedAccessors::record(Parser &P, AbstractStorageDecl *storage,
 
   // Create an implicit accessor declaration.
   auto createImplicitAccessor =
-  [&](AccessorKind kind, AddressorKind addressorKind,
-      ParameterList *argList) -> AccessorDecl* {
+  [&](AccessorKind kind, AddressorKind addressorKind, ParameterList *argList) {
     auto accessor = createAccessorFunc(SourceLoc(), argList,
                                        genericParams, indices, elementTy,
                                        staticLoc, flags, kind, addressorKind,
                                        storage, &P, SourceLoc());
     accessor->setImplicit();
     decls.push_back(accessor);
-    return accessor;
+
+    switch (kind) {
+#define ACCESSOR(ID)            \
+    case AccessorKind::ID:      \
+      ID = accessor;            \
+      return;
+#include "swift/AST/AccessorKinds.def"
+    }
+    llvm_unreachable("bad accessor kind");
   };
 
-  // 'address' is exclusive with 'get', and 'mutableAddress' is
-  // exclusive with 'set'.
-  if (Addressor || MutableAddressor) {
+  // 'address' is exclusive with 'get'/'read', and 'mutableAddress' is
+  // exclusive with 'set'/'modify'.
+  if (Address || MutableAddress) {
     // Require either a 'get' or an 'address' accessor if there's
     // a 'mutableAddress' accessor.  In principle, we could synthesize
     // 'address' from 'mutableAddress', but for now we'll enforce this.
-    if (!Addressor && !Get) {
-      P.diagnose(MutableAddressor->getLoc(),
+    if (!Address && !Get) {
+      P.diagnose(MutableAddress->getLoc(),
                  diag::mutableaddressor_without_address,
                  isa<SubscriptDecl>(storage));
 
-      Addressor = createImplicitAccessor(AccessorKind::IsAddressor,
-                                         AddressorKind::Unsafe,
-                                         nullptr);
+      createImplicitAccessor(AccessorKind::Address, AddressorKind::Unsafe,
+                             nullptr);
+    }
 
     // Don't allow both.
-    } else if (Addressor && Get) {
-      P.diagnose(Addressor->getLoc(), diag::addressor_with_getter,
-                 isa<SubscriptDecl>(storage));      
+    if (Address && Get) {
+      P.diagnose(Address->getLoc(), diag::addressor_with_getter,
+                 isa<SubscriptDecl>(storage));
       ignoreInvalidAccessor(Get);
     }
 
-    // Disallow mutableAddress+set.
+    // Disallow mutableAddress+{set,modify}.
     //
     // Currently we don't allow the address+set combination either.
     // In principle, this is an unnecessary restriction, and you can
@@ -4661,8 +4643,8 @@ void Parser::ParsedAccessors::record(Parser &P, AbstractStorageDecl *storage,
     // important.  (For example, we don't make any effort to optimize
     // them for polymorphic accesses.)
     if (Set) {
-      if (MutableAddressor) {
-        P.diagnose(MutableAddressor->getLoc(), diag::mutableaddressor_with_setter,
+      if (MutableAddress) {
+        P.diagnose(MutableAddress->getLoc(), diag::mutableaddressor_with_setter,
                    isa<SubscriptDecl>(storage));
       } else {
         P.diagnose(Set->getLoc(), diag::addressor_with_setter,
@@ -4679,38 +4661,37 @@ void Parser::ParsedAccessors::record(Parser &P, AbstractStorageDecl *storage,
     ignoreInvalidAccessor(WillSet);
     ignoreInvalidAccessor(DidSet);
   }
-  
+
   // If this decl is invalid, mark any parsed accessors as invalid to avoid
   // tripping up later invariants.
   if (invalid) {
-    flagInvalidAccessor(Get);
-    flagInvalidAccessor(Set);
-    flagInvalidAccessor(Addressor);
-    flagInvalidAccessor(MutableAddressor);
-    flagInvalidAccessor(WillSet);
-    flagInvalidAccessor(DidSet);
+#define ACCESSOR(ID) flagInvalidAccessor(ID);
+#include "swift/AST/AccessorKinds.def"
   }
 
   // If this is a willSet/didSet observing property, record this and we're done.
   if (WillSet || DidSet) {
-    if (Get || Set) {
-      P.diagnose(Get ? Get->getLoc() : Set->getLoc(),
-                 diag::observingproperty_with_getset, bool(DidSet), bool(Set));
+    if (Get) {
+      P.diagnose(Get->getLoc(), diag::observingproperty_with_getset,
+                 bool(DidSet), /*getter*/0);
       ignoreInvalidAccessor(Get);
+    }
+    if (Set) {
+      P.diagnose(Set->getLoc(), diag::observingproperty_with_getset,
+                 bool(DidSet), /*setter*/1);
       ignoreInvalidAccessor(Set);
     }
 
-    if (Addressor) {
-      if (!MutableAddressor) {
+    if (Address) {
+      if (!MutableAddress) {
         P.diagnose(WillSet ? WillSet->getLoc() : DidSet->getLoc(),
                    diag::observingproperty_without_mutableaddress,
                    bool(DidSet));
-        MutableAddressor =
-          createImplicitAccessor(AccessorKind::IsMutableAddressor,
-                                 AddressorKind::Unsafe, nullptr);
+        createImplicitAccessor(AccessorKind::MutableAddress,
+                               AddressorKind::Unsafe, nullptr);
       }
 
-      storage->makeAddressedWithObservers(LBLoc, Addressor, MutableAddressor,
+      storage->makeAddressedWithObservers(LBLoc, Address, MutableAddress,
                                           WillSet, DidSet, RBLoc);
     } else if (attrs.hasAttribute<OverrideAttr>()) {
       storage->makeInheritedWithObservers(LBLoc, WillSet, DidSet, RBLoc);
@@ -4720,44 +4701,44 @@ void Parser::ParsedAccessors::record(Parser &P, AbstractStorageDecl *storage,
 
     // Observing properties will have getters and setters synthesized by sema.
     // Create their prototypes now.
-    Get = createImplicitAccessor(AccessorKind::IsGetter,
-                                 AddressorKind::NotAddressor, nullptr);
+    createImplicitAccessor(AccessorKind::Get,
+                           AddressorKind::NotAddressor, nullptr);
 
     auto argFunc = (WillSet ? WillSet : DidSet);
     auto argLoc = argFunc->getParameterLists().back()->getStartLoc();
 
     auto argument = createSetterAccessorArgument(
-        argLoc, Identifier(), AccessorKind::IsSetter, P, elementTy);
+        argLoc, Identifier(), AccessorKind::Set, P, elementTy);
     auto argList = ParameterList::create(P.Context, argument);
-    Set = createImplicitAccessor(AccessorKind::IsSetter,
-                                 AddressorKind::NotAddressor, argList);
+    createImplicitAccessor(AccessorKind::Set,
+                           AddressorKind::NotAddressor, argList);
 
     storage->setObservingAccessors(Get, Set, nullptr);
     return;
   }
 
   // If we have addressors, at this point mark it as addressed.
-  if (Addressor) {
+  if (Address) {
     assert(!Get && !Set);
-    storage->makeAddressed(LBLoc, Addressor, MutableAddressor, RBLoc);
+    storage->makeAddressed(LBLoc, Address, MutableAddress, RBLoc);
     return;
   }
 
   // If this is a get+mutableAddress property, synthesize an implicit
   // setter and record what we've got.
-  if (MutableAddressor) {
+  if (MutableAddress) {
     assert(Get && !Set);
     auto argument =
-        createSetterAccessorArgument(MutableAddressor->getLoc(), Identifier(),
-                                     AccessorKind::IsSetter, P, elementTy);
+        createSetterAccessorArgument(MutableAddress->getLoc(), Identifier(),
+                                     AccessorKind::Set, P, elementTy);
     auto argList = ParameterList::create(P.Context, argument);
-    Set = createImplicitAccessor(AccessorKind::IsSetter,
-                                 AddressorKind::NotAddressor, argList);
+    createImplicitAccessor(AccessorKind::Set,
+                           AddressorKind::NotAddressor, argList);
 
     storage->makeComputedWithMutableAddress(LBLoc, Get, Set, nullptr,
-                                            MutableAddressor, RBLoc);
+                                            MutableAddress, RBLoc);
     return;
-  } 
+  }
 
   // Otherwise, this must be a get/set property.  The set is optional,
   // but get is not.
@@ -4768,14 +4749,14 @@ void Parser::ParsedAccessors::record(Parser &P, AbstractStorageDecl *storage,
       if (!invalid) P.diagnose(LBLoc, diag::subscript_without_get);
       // Create a getter so we don't break downstream invariants by having a
       // setter without a getter.
-      Get = createImplicitAccessor(AccessorKind::IsGetter,
-                                   AddressorKind::NotAddressor, nullptr);
+      createImplicitAccessor(AccessorKind::Get,
+                             AddressorKind::NotAddressor, nullptr);
     } else if (Set) {
       if (!invalid) P.diagnose(Set->getLoc(), diag::var_set_without_get);
       // Create a getter so we don't break downstream invariants by having a
       // setter without a getter.
-      Get = createImplicitAccessor(AccessorKind::IsGetter,
-                                   AddressorKind::NotAddressor, nullptr);
+      createImplicitAccessor(AccessorKind::Get,
+                             AddressorKind::NotAddressor, nullptr);
     }
   }
 

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1229,11 +1229,11 @@ bool SILParser::parseSILDottedPathWithoutPound(ValueDecl *&Decl,
 
 static Optional<AccessorKind> getAccessorKind(StringRef ident) {
   return llvm::StringSwitch<Optional<AccessorKind>>(ident)
-           .Case("getter", AccessorKind::IsGetter)
-           .Case("setter", AccessorKind::IsSetter)
-           .Case("addressor", AccessorKind::IsAddressor)
-           .Case("mutableAddressor", AccessorKind::IsMutableAddressor)
-           .Case("materializeForSet", AccessorKind::IsMaterializeForSet)
+           .Case("getter", AccessorKind::Get)
+           .Case("setter", AccessorKind::Set)
+           .Case("addressor", AccessorKind::Address)
+           .Case("mutableAddressor", AccessorKind::MutableAddress)
+           .Case("materializeForSet", AccessorKind::MaterializeForSet)
            .Default(None);
 }
 

--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -653,7 +653,7 @@ std::string SILDeclRef::mangle(ManglingKind MKind) const {
 
   case SILDeclRef::Kind::GlobalAccessor:
     assert(!isCurried);
-    return mangler.mangleAccessorEntity(AccessorKind::IsMutableAddressor,
+    return mangler.mangleAccessorEntity(AccessorKind::MutableAddress,
                                         AddressorKind::Unsafe,
                                         cast<AbstractStorageDecl>(getDecl()),
                                         /*isStatic*/ false,

--- a/lib/SIL/SILFunctionType.cpp
+++ b/lib/SIL/SILFunctionType.cpp
@@ -1783,14 +1783,14 @@ static SelectorFamily getSelectorFamily(SILDeclRef c) {
     auto *FD = cast<FuncDecl>(c.getDecl());
     if (auto accessor = dyn_cast<AccessorDecl>(FD)) {
       switch (accessor->getAccessorKind()) {
-      case AccessorKind::IsGetter:
-      case AccessorKind::IsSetter:
+      case AccessorKind::Get:
+      case AccessorKind::Set:
         break;
-      case AccessorKind::IsWillSet:
-      case AccessorKind::IsDidSet:
-      case AccessorKind::IsAddressor:
-      case AccessorKind::IsMutableAddressor:
-      case AccessorKind::IsMaterializeForSet:
+      case AccessorKind::WillSet:
+      case AccessorKind::DidSet:
+      case AccessorKind::Address:
+      case AccessorKind::MutableAddress:
+      case AccessorKind::MaterializeForSet:
         llvm_unreachable("Unexpected AccessorKind of foreign FuncDecl");
       }
     }

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -284,31 +284,31 @@ void SILDeclRef::print(raw_ostream &OS) const {
       isDot = false;
     } else {
       switch (accessor->getAccessorKind()) {
-      case AccessorKind::IsWillSet:
+      case AccessorKind::WillSet:
         printValueDecl(accessor->getStorage(), OS);
         OS << "!willSet";
         break;
-      case AccessorKind::IsDidSet:
+      case AccessorKind::DidSet:
         printValueDecl(accessor->getStorage(), OS);
         OS << "!didSet";
         break;
-      case AccessorKind::IsGetter:
+      case AccessorKind::Get:
         printValueDecl(accessor->getStorage(), OS);
         OS << "!getter";
         break;
-      case AccessorKind::IsSetter:
+      case AccessorKind::Set:
         printValueDecl(accessor->getStorage(), OS);
         OS << "!setter";
         break;
-      case AccessorKind::IsMaterializeForSet:
+      case AccessorKind::MaterializeForSet:
         printValueDecl(accessor->getStorage(), OS);
         OS << "!materializeForSet";
         break;
-      case AccessorKind::IsAddressor:
+      case AccessorKind::Address:
         printValueDecl(accessor->getStorage(), OS);
         OS << "!addressor";
         break;
-      case AccessorKind::IsMutableAddressor:
+      case AccessorKind::MutableAddress:
         printValueDecl(accessor->getStorage(), OS);
         OS << "!mutableAddressor";
         break;

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -160,7 +160,7 @@ static AccessorDecl *createGetterPrototype(AbstractStorageDecl *storage,
 
   auto getter = AccessorDecl::create(
       TC.Context, loc, /*AccessorKeywordLoc*/ loc,
-      AccessorKind::IsGetter, AddressorKind::NotAddressor, storage,
+      AccessorKind::Get, AddressorKind::NotAddressor, storage,
       staticLoc, StaticSpellingKind::None,
       /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
       /*GenericParams=*/nullptr,
@@ -211,7 +211,7 @@ static AccessorDecl *createSetterPrototype(AbstractStorageDecl *storage,
   Type setterRetTy = TupleType::getEmpty(TC.Context);
   auto setter = AccessorDecl::create(
       TC.Context, loc, /*AccessorKeywordLoc*/ SourceLoc(),
-      AccessorKind::IsSetter, AddressorKind::NotAddressor, storage,
+      AccessorKind::Set, AddressorKind::NotAddressor, storage,
       /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
       /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
       /*GenericParams=*/nullptr, params, TypeLoc::withoutLoc(setterRetTy),
@@ -328,7 +328,7 @@ createMaterializeForSetPrototype(AbstractStorageDecl *storage,
 
   auto *materializeForSet = AccessorDecl::create(
       ctx, loc, /*AccessorKeywordLoc=*/SourceLoc(),
-      AccessorKind::IsMaterializeForSet, AddressorKind::NotAddressor, storage,
+      AccessorKind::MaterializeForSet, AddressorKind::NotAddressor, storage,
       /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
       /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
       (genericParams
@@ -453,11 +453,11 @@ static Expr *buildSubscriptIndexReference(ASTContext &ctx,
   auto accessorKind = accessor->getAccessorKind();
 
   // Ignore the value/buffer parameter.
-  if (accessorKind != AccessorKind::IsGetter)
+  if (accessorKind != AccessorKind::Get)
     params = params.slice(1);
 
   // Ignore the materializeForSet callback storage parameter.
-  if (accessorKind == AccessorKind::IsMaterializeForSet)
+  if (accessorKind == AccessorKind::MaterializeForSet)
     params = params.slice(1);
   
   // Okay, everything else should be forwarded, build the expression.

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -1070,7 +1070,7 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
 
   AccessorDecl *getterDecl = AccessorDecl::create(C,
       /*FuncLoc=*/SourceLoc(), /*AccessorKeywordLoc=*/SourceLoc(),
-      AccessorKind::IsGetter, AddressorKind::NotAddressor, hashValueDecl,
+      AccessorKind::Get, AddressorKind::NotAddressor, hashValueDecl,
       /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
       /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
       /*GenericParams=*/nullptr, params,

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -296,7 +296,7 @@ DerivedConformance::declareDerivedPropertyGetter(TypeChecker &tc,
   
   auto getterDecl = AccessorDecl::create(C,
     /*FuncLoc=*/SourceLoc(), /*AccessorKeywordLoc=*/SourceLoc(),
-    AccessorKind::IsGetter, AddressorKind::NotAddressor, property,
+    AccessorKind::Get, AddressorKind::NotAddressor, property,
     /*StaticLoc=*/SourceLoc(), StaticSpellingKind::None,
     /*Throws=*/false, /*ThrowsLoc=*/SourceLoc(),
     /*GenericParams=*/nullptr, params,

--- a/lib/Sema/MiscDiagnostics.cpp
+++ b/lib/Sema/MiscDiagnostics.cpp
@@ -1610,7 +1610,7 @@ static void diagRecursivePropertyAccess(TypeChecker &TC, const Expr *E,
           // it is about to get overwritten.
           if (isStore &&
               DRE->getAccessSemantics() == AccessSemantics::DirectToStorage &&
-              Accessor->getAccessorKind() == AccessorKind::IsWillSet) {
+              Accessor->getAccessorKind() == AccessorKind::WillSet) {
             TC.diagnose(E->getLoc(), diag::store_in_willset, Var->getName());
           }
         }
@@ -1645,7 +1645,7 @@ static void diagRecursivePropertyAccess(TypeChecker &TC, const Expr *E,
           // it is about to get overwritten.
           if (isStore &&
               MRE->getAccessSemantics() == AccessSemantics::DirectToStorage &&
-              Accessor->getAccessorKind() == AccessorKind::IsWillSet) {
+              Accessor->getAccessorKind() == AccessorKind::WillSet) {
               TC.diagnose(subExpr->getLoc(), diag::store_in_willset,
                           Var->getName());
           }
@@ -2391,7 +2391,7 @@ public:
     // the containing property so if newValue isn't used but the getter is used
     // an error can be reported.
     if (auto FD = dyn_cast<AccessorDecl>(AFD)) {
-      if (FD->getAccessorKind() == AccessorKind::IsSetter) {
+      if (FD->getAccessorKind() == AccessorKind::Set) {
         if (auto getter = dyn_cast<VarDecl>(FD->getStorage())) {
           auto arguments = FD->getParameterLists().back();
           VarDecls[arguments->get(0)] = 0;
@@ -2638,7 +2638,7 @@ VarDeclUsageChecker::~VarDeclUsageChecker() {
     // more annoying than it is useful.
     if (auto param = dyn_cast<ParamDecl>(var)) {
       auto FD = dyn_cast<AccessorDecl>(param->getDeclContext());
-      if (FD && FD->getAccessorKind() == AccessorKind::IsSetter) {
+      if (FD && FD->getAccessorKind() == AccessorKind::Set) {
         auto getter = dyn_cast<VarDecl>(FD->getStorage());
         if ((access & RK_Read) == 0 && AssociatedGetter == getter) {
           if (auto DRE = AssociatedGetterDeclRef) {
@@ -3509,21 +3509,21 @@ public:
         auto bestAccessor = dyn_cast<AccessorDecl>(bestMethod);
         if (bestAccessor) {
           switch (bestAccessor->getAccessorKind()) {
-          case AccessorKind::IsGetter:
+          case AccessorKind::Get:
             out << "getter: ";
             name = bestAccessor->getStorage()->getFullName();
             break;
 
-          case AccessorKind::IsSetter:
-          case AccessorKind::IsWillSet:
-          case AccessorKind::IsDidSet:
+          case AccessorKind::Set:
+          case AccessorKind::WillSet:
+          case AccessorKind::DidSet:
             out << "setter: ";
             name = bestAccessor->getStorage()->getFullName();
             break;
 
-          case AccessorKind::IsMaterializeForSet:
-          case AccessorKind::IsAddressor:
-          case AccessorKind::IsMutableAddressor:
+          case AccessorKind::MaterializeForSet:
+          case AccessorKind::Address:
+          case AccessorKind::MutableAddress:
             llvm_unreachable("cannot be @objc");
           }
         } else {

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -214,17 +214,17 @@ static bool shouldUseSetterRequirements(AccessorKind reqtKind) {
   // allow them as protocol requirements someday.
 
   switch (reqtKind) {
-  case AccessorKind::IsGetter:
-  case AccessorKind::IsAddressor:
+  case AccessorKind::Get:
+  case AccessorKind::Address:
     return false;
 
-  case AccessorKind::IsSetter:
-  case AccessorKind::IsMutableAddressor:
-  case AccessorKind::IsMaterializeForSet:
+  case AccessorKind::Set:
+  case AccessorKind::MutableAddress:
+  case AccessorKind::MaterializeForSet:
     return true;
 
-  case AccessorKind::IsWillSet:
-  case AccessorKind::IsDidSet:
+  case AccessorKind::WillSet:
+  case AccessorKind::DidSet:
     llvm_unreachable("willSet/didSet protocol requirement?");
   }
   llvm_unreachable("bad accessor kind");
@@ -446,12 +446,12 @@ swift::matchWitness(
     // Validate that the 'mutating' bit lines up for getters and setters.
     if (checkMutating(reqASD->getGetter(), witnessASD->getGetter(),
                       witnessASD))
-      return RequirementMatch(getStandinForAccessor(AccessorKind::IsGetter),
+      return RequirementMatch(getStandinForAccessor(AccessorKind::Get),
                               MatchKind::MutatingConflict);
     
     if (req->isSettable(req->getDeclContext()) &&
         checkMutating(reqASD->getSetter(), witnessASD->getSetter(), witnessASD))
-      return RequirementMatch(getStandinForAccessor(AccessorKind::IsSetter),
+      return RequirementMatch(getStandinForAccessor(AccessorKind::Set),
                               MatchKind::MutatingConflict);
 
     // Decompose the parameters for subscript declarations.
@@ -4914,17 +4914,17 @@ TypeChecker::findWitnessedObjCRequirements(const ValueDecl *witness,
   if (auto *accessor = dyn_cast<AccessorDecl>(witness)) {
     accessorKind = accessor->getAccessorKind();
     switch (*accessorKind) {
-    case AccessorKind::IsAddressor:
-    case AccessorKind::IsMutableAddressor:
-    case AccessorKind::IsMaterializeForSet:
+    case AccessorKind::Address:
+    case AccessorKind::MutableAddress:
+    case AccessorKind::MaterializeForSet:
       // These accessors are never exposed to Objective-C.
       return result;
-    case AccessorKind::IsDidSet:
-    case AccessorKind::IsWillSet:
+    case AccessorKind::DidSet:
+    case AccessorKind::WillSet:
       // These accessors are folded into the setter.
       return result;
-    case AccessorKind::IsGetter:
-    case AccessorKind::IsSetter:
+    case AccessorKind::Get:
+    case AccessorKind::Set:
       // These are found relative to the main decl.
       name = accessor->getStorage()->getFullName();
       break;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3568,8 +3568,8 @@ bool TypeChecker::isRepresentableInObjC(
     }
 
     switch (accessor->getAccessorKind()) {
-    case AccessorKind::IsDidSet:
-    case AccessorKind::IsWillSet:
+    case AccessorKind::DidSet:
+    case AccessorKind::WillSet:
         // willSet/didSet implementations are never exposed to objc, they are
         // always directly dispatched from the synthesized setter.
       if (Diagnose) {
@@ -3578,16 +3578,16 @@ bool TypeChecker::isRepresentableInObjC(
       }
       return false;
 
-    case AccessorKind::IsGetter:
-    case AccessorKind::IsSetter:
+    case AccessorKind::Get:
+    case AccessorKind::Set:
       return true;
 
-    case AccessorKind::IsMaterializeForSet:
+    case AccessorKind::MaterializeForSet:
       // materializeForSet is synthesized, so never complain about it
       return false;
 
-    case AccessorKind::IsAddressor:
-    case AccessorKind::IsMutableAddressor:
+    case AccessorKind::Address:
+    case AccessorKind::MutableAddress:
       if (Diagnose) {
         diagnose(accessor->getLoc(), diag::objc_addressor);
         describeObjCReason(*this, accessor, Reason);

--- a/lib/Serialization/DeserializationErrors.h
+++ b/lib/Serialization/DeserializationErrors.h
@@ -110,19 +110,19 @@ class XRefTracePath {
         break;
       case Kind::Accessor:
         switch (getDataAs<uintptr_t>()) {
-        case Getter:
+        case Get:
           os << "(getter)";
           break;
-        case Setter:
+        case Set:
           os << "(setter)";
           break;
         case MaterializeForSet:
           os << "(materializeForSet)";
           break;
-        case Addressor:
+        case Address:
           os << "(addressor)";
           break;
-        case MutableAddressor:
+        case MutableAddress:
           os << "(mutableAddressor)";
           break;
         case WillSet:

--- a/test/Driver/dump-parse.swift
+++ b/test/Driver/dump-parse.swift
@@ -39,8 +39,8 @@ enum TrailingSemi {
   case A,B;
 
   // CHECK-LABEL: (subscript_decl{{.*}}trailing_semi
-  // CHECK-NOT:   (func_decl{{.*}}trailing_semi 'anonname={{.*}}' getter_for=subscript(_:)
-  // CHECK:       (accessor_decl{{.*}}'anonname={{.*}}' getter_for=subscript(_:)
+  // CHECK-NOT:   (func_decl{{.*}}trailing_semi 'anonname={{.*}}' get_for=subscript(_:)
+  // CHECK:       (accessor_decl{{.*}}'anonname={{.*}}' get_for=subscript(_:)
   subscript(x: Int) -> Int {
     // CHECK-LABEL: (pattern_binding_decl{{.*}}trailing_semi
     // CHECK-NOT:   (var_decl{{.*}}trailing_semi "y"

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -212,19 +212,19 @@ UIdent SwiftLangSupport::getUIDForAccessor(const ValueDecl *D,
                                            AccessorKind AccKind,
                                            bool IsRef) {
   switch (AccKind) {
-  case AccessorKind::IsMaterializeForSet:
+  case AccessorKind::MaterializeForSet:
     llvm_unreachable("unexpected MaterializeForSet");
-  case AccessorKind::IsGetter:
+  case AccessorKind::Get:
     return IsRef ? KindRefAccessorGetter : KindDeclAccessorGetter;
-  case AccessorKind::IsSetter:
+  case AccessorKind::Set:
     return IsRef ? KindRefAccessorSetter : KindDeclAccessorSetter;
-  case AccessorKind::IsWillSet:
+  case AccessorKind::WillSet:
     return IsRef ? KindRefAccessorWillSet : KindDeclAccessorWillSet;
-  case AccessorKind::IsDidSet:
+  case AccessorKind::DidSet:
     return IsRef ? KindRefAccessorDidSet : KindDeclAccessorDidSet;
-  case AccessorKind::IsAddressor:
+  case AccessorKind::Address:
     return IsRef ? KindRefAccessorAddress : KindDeclAccessorAddress;
-  case AccessorKind::IsMutableAddressor:
+  case AccessorKind::MutableAddress:
     return IsRef ? KindRefAccessorMutableAddress
                  : KindDeclAccessorMutableAddress;
   }

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -2169,25 +2169,25 @@ public:
     if (auto accessor = dyn_cast<AccessorDecl>(VD)) {
       auto *storage = accessor->getStorage();
       switch (accessor->getAccessorKind()) {
-      case AccessorKind::IsGetter:
+      case AccessorKind::Get:
         OS << "<getter for ";
         break;
-      case AccessorKind::IsSetter:
+      case AccessorKind::Set:
         OS << "<setter for ";
         break;
-      case AccessorKind::IsWillSet:
+      case AccessorKind::WillSet:
         OS << "<willSet for ";
         break;
-      case AccessorKind::IsDidSet:
+      case AccessorKind::DidSet:
         OS << "<didSet for ";
         break;
-      case AccessorKind::IsAddressor:
+      case AccessorKind::Address:
         OS << "<addressor for ";
         break;
-      case AccessorKind::IsMutableAddressor:
+      case AccessorKind::MutableAddress:
         OS << "<mutableAddressor for ";
         break;
-      case AccessorKind::IsMaterializeForSet:
+      case AccessorKind::MaterializeForSet:
         OS << "<materializeForSet for ";
         break;
       }


### PR DESCRIPTION
Introduce some metaprogramming of accessors and generally prepare for storing less-structured accessor lists.

NFC except for a change to the serialization format.