### PR TITLE
[4.2] IRGen: Don't outline enum value functions when they involve open existential types

### DIFF
--- a/test/IRGen/outlined_copy_addr.swift
+++ b/test/IRGen/outlined_copy_addr.swift
@@ -58,3 +58,20 @@ func testIt<P: BaseProt>(_ f: GenericError<P>?) {
 func dontCrash<P: BaseProt>(_ f: GenericError<P>) {
   testIt(f)
 }
+
+protocol Baz : class {
+}
+extension Baz {
+  static func crash(setup: ((Self) -> ())?){
+  }
+}
+class Foobar {
+  public static func dontCrash() -> Baz? {
+     let cls : Baz.Type = Foobar1.self
+     // This used to crash because we tried to outline the optional consume with
+     // an opened payload existential type.
+     cls.crash(setup: { (arg:  Baz) -> () in  })
+     return nil
+  }
+}
+class Foobar1 : Foobar, Baz { }


### PR DESCRIPTION
We don't support doing so.

* Explanation: When trying to outline enum copy/destroy functions we would crash if the enum's payload type was an opened existential.

* Scope: Introduced with outlining copy/destroy functions sometime last year.

* Risk: Low the outlined code is emitted inline instead.

* Reviewed by: Joe S.

rdar://41009775