### PR TITLE
[4.2-06-11] Only disable Network test on watchOS

### DIFF
--- a/test/stdlib/Network.swift
+++ b/test/stdlib/Network.swift
@@ -2,8 +2,7 @@
 // REQUIRES: executable_test
 
 // REQUIRES: objc_interop
-
-// REQUIRES: rdar40799651
+// UNSUPPORTED: OS=watchos
 
 import Network
 import Foundation


### PR DESCRIPTION
Similar to #17204

* Explanation: In order to have some coverage of Network overlay, the test should run. We don’t build Network for watchOS so it’s OK to disable it for watchOS only.
* Risk: Minimal
* Reviewed By: Mishal Shah
* Testing: Automated test suite
* Directions for QA: N/A
* Radar: rdar://problem/40799651