### PR TITLE
[TF] Use decl names in graph node names for better debugging support

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -218,7 +218,8 @@ struct TFGraphLowering : public SILInstructionVisitor<TFGraphLowering> {
   llvm::SmallSet<int, 4> processedTensorIdsForReceive;
 
   /// Mapping from declarations to the number to times a TF_Function took the
-  /// name from.
+  /// name from the declaration. This will be used in `getUniqueName` to produce
+  /// uniqued graph node names.
   llvm::SmallDenseMap<ValueDecl *, unsigned> uniqueNames;
 
   /// This flag gets set if lowering code to the graph produces a TensorFlow

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -626,10 +626,11 @@ std::string TFGraphLowering::getUniqueName(SILDebugLocation loc,
       // Otherwise, use the SIL name.
       std::string funcName;
       auto *dc = SILFn.getDeclContext();
-      if (AbstractFunctionDecl *afd = dyn_cast_or_null<AbstractFunctionDecl>(dc)) {
+      if (auto *afd = dyn_cast_or_null<AbstractFunctionDecl>(dc)) {
         funcName = escapeDeclName(afd->getEffectiveFullName());
         // Make sure the name is unique.
-        if (auto declCountLookup = uniqueNames.find(afd))
+        auto declCountLookup = uniqueNames.find(afd);
+        if (declCountLookup != uniqueNames.end())
           funcName += "_" + llvm::itostr(declCountLookup->getSecond()++);
         else
           uniqueNames.insert({afd, 1});

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -595,6 +595,9 @@ std::string TFGraphLowering::getUniqueName(SILDebugLocation loc,
   // Form a name for this op based on the user's source location and "stack
   // trace" of where it got inlined in user code.  We use the form
   // "file:line:col".
+  //
+  // FIXME: InlinedCallSite is always nullptr even if we use the performance
+  // inliner, so it currently does not track the inlined call site.
   for (auto ds = loc.getScope(); ds; ds = ds->InlinedCallSite) {
     // If the call site location is invalid, stop scanning.
     if (!ds->Loc.getSourceLoc().isValid())

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -580,7 +580,7 @@ static std::string escapeDeclName(DeclName name) {
   for (char &c : buffer) {
     if (c == '(' || c == ')')
       c = '.';
-    if (c == ':')
+    else if (!llvm::isAlnum(c))
       c = '_';
   }
   return newName.str();

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -586,7 +586,6 @@ static std::string escapeDeclName(DeclName name) {
 std::string TFGraphLowering::getUniqueName(SILDebugLocation loc,
                                            const char *baseName) {
   std::string name = baseName;
-  auto *outerScope = loc.getScope();
 
   // Skip over internal implementation details of the Tensor library.
   loc = skipInternalLocations(loc);

--- a/test/TensorFlow/graph_node_names.swift
+++ b/test/TensorFlow/graph_node_names.swift
@@ -16,11 +16,14 @@ func baz() -> Tensor<Float> {
 }
 
 func main() {
-  baz()
+  _ = baz()
 }
 
 main()
 
-// CHECK-LABEL:      node_def {
-// CHECK:            op: "Sin"
-// CHECK-NEXT:       input: "op/main/baz/bar.
+/// FIXME: Currently the performance inliner is not capturing inlining trace for
+/// some reason. When that's fixed, add checks in this file.
+///
+/// Expected node names:
+/// - Sin: op/main/baz/bar/sin
+/// - Const: op/main/baz/bar/foo

--- a/test/TensorFlow/graph_node_names.swift
+++ b/test/TensorFlow/graph_node_names.swift
@@ -21,9 +21,9 @@ func main() {
 
 main()
 
-/// CHECK-LABEL:         op: "Sin"
-
-/// CHECK-LABEL:         op: "Const"
+/// CHECK: op: "Const"
+/// CHECK: op: "Sin"
+/// CHECK: op: "Add"
 
 /// FIXME: Currently the performance inliner is not capturing inlining trace for
 /// some reason. When that's fixed, add checks in this file.

--- a/test/TensorFlow/graph_node_names.swift
+++ b/test/TensorFlow/graph_node_names.swift
@@ -1,0 +1,26 @@
+// RUN: %target-swift-frontend -Xllvm -tf-dump-graph -O -emit-sil %s -verify | %FileCheck %s
+
+import TensorFlow
+
+
+func foo() -> Tensor<Float> {
+  return Tensor(1)
+}
+
+func bar() -> Tensor<Float> {
+  return sin(foo())
+}
+
+func baz() -> Tensor<Float> {
+  return bar() + 1
+}
+
+func main() {
+  baz()
+}
+
+main()
+
+// CHECK-LABEL:      node_def {
+// CHECK:            op: "Sin"
+// CHECK-NEXT:       input: "op/main/baz/bar.

--- a/test/TensorFlow/graph_node_names.swift
+++ b/test/TensorFlow/graph_node_names.swift
@@ -21,6 +21,12 @@ func main() {
 
 main()
 
+/// CHECK-LABEL: node_def {
+/// CHECK:         op: "Identity"
+
+/// CHECK-LABEL: node_def {
+/// CHECK:         op: "Sin"
+
 /// FIXME: Currently the performance inliner is not capturing inlining trace for
 /// some reason. When that's fixed, add checks in this file.
 ///

--- a/test/TensorFlow/graph_node_names.swift
+++ b/test/TensorFlow/graph_node_names.swift
@@ -21,11 +21,9 @@ func main() {
 
 main()
 
-/// CHECK-LABEL: node_def {
-/// CHECK:         op: "Identity"
+/// CHECK-LABEL:         op: "Sin"
 
-/// CHECK-LABEL: node_def {
-/// CHECK:         op: "Sin"
+/// CHECK-LABEL:         op: "Const"
 
 /// FIXME: Currently the performance inliner is not capturing inlining trace for
 /// some reason. When that's fixed, add checks in this file.

--- a/test/TensorFlow/sends_recvs.swift
+++ b/test/TensorFlow/sends_recvs.swift
@@ -54,7 +54,7 @@ public func test1SendWithParam(x: Float) {
 // CHECK:          node_def {
 // CHECK:            name: "RunControlDependency"
 // CHECK:            op: "Identity"
-// CHECK-NEXT:       input: "op.
+// CHECK-NEXT:       input: "op/test1SendWithParam.x_
 // CHECK-NEXT:       input: "^tf_send_0"
 
 public func test2Sends() {


### PR DESCRIPTION
Originally names of TF graph nodes generated by TFLowerGraph were mangled SIL function names. Now we change those to the AST names with argument labels, with a "stack trace" of inlining separated by `/`. This makes TensorBoard produce a hierarchical view of the graph for better debugging and visualization.

Known problem: `SILDebugScope::InlinedCallsite` is always `nullptr` even though we are using the performance inliner. This PR has not changed that behavior so we'll investigate it later.