### PR TITLE
[SR-7904] Add source filenames in the output of `-dump-ast`

### DIFF
--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -774,7 +774,9 @@ namespace {
     void visitSourceFile(const SourceFile &SF) {
       OS.indent(Indent);
       PrintWithColorRAII(OS, ParenthesisColor) << '(';
-      PrintWithColorRAII(OS, ASTNodeColor) << "source_file";
+      PrintWithColorRAII(OS, ASTNodeColor) << "source_file ";
+      PrintWithColorRAII(OS, LocationColor) << '\"' << SF.getFilename() << '\"';
+      
       for (Decl *D : SF.Decls) {
         if (D->isImplicit())
           continue;


### PR DESCRIPTION
<!-- What's in this pull request? -->
Text by Vinicius Vendramini in [SR-7904](https://bugs.swift.org/browse/SR-7904):

The Swift compiler's `-dump-ast` functionality prints an output that doesn't include the file names, which can make it impossible to distinguish between different files.
For instance, when compiling two files `a.swift` and `b.swift`, both containing the code `"private func foo() { }"`, with the command `"$ swiftc b.swift a.swift -dump-ast"`, we get this output:
```
(source_file
  (func_decl "foo()" interface type='() -> ()' access=private
    (parameter_list)
    (brace_stmt)))
(source_file
  (func_decl "foo()" interface type='() -> ()' access=private
    (parameter_list)
    (brace_stmt)))
```
It would be very useful if this information included the file name (or, even better, the file path). Something like this:
```
(source_file "/path/to/a.swift"
  (func_decl "foo()" interface type='() -> ()' access=private
    (parameter_list)
    (brace_stmt)))
(source_file "/path/to/b.swift"
  (func_decl "foo()" interface type='() -> ()' access=private
    (parameter_list)
    (brace_stmt)))
```

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-7904](https://bugs.swift.org/browse/SR-7904).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->