### PR TITLE
[NOMERGE] Make Sequence be a typealias for Collection

### DIFF
--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1893,6 +1893,10 @@ extension Collection where Self.Index == DefaultIndex<Self> {
     return j
   }
 
+  func distance(from start: Index, to end: Index) -> Int {
+    return start.distance(to: end)
+  }
+  
   // DWA WORKAROUND: for https://bugs.swift.org/browse/SR-7605 from Nate Cook
 #if false
   public func formIndex(after i: inout DefaultIndex<Self>) {


### PR DESCRIPTION
# Work In Progress

See [this thread](https://forums.swift.org/t/pitch-make-collection-super-convenient-and-retire-sequence) for background.

## TODO

- [x] Make `DefaultIndex` into a `struct` that contains an enum.
- [x] Rename the compiler-known protocol `Sequence` to `_Sequence` and introduce `Sequence` typealias (induces SourceKit crashes, but https://github.com/dabrahams/swift/tree/ezCollection)
- [ ] Make the compiler-known protocol be `Collection`.