### PR TITLE
[master-next] Reenable PrintAsObjC/enums.swift test

### DIFF
--- a/test/PrintAsObjC/enums.swift
+++ b/test/PrintAsObjC/enums.swift
@@ -7,7 +7,6 @@
 // RUN: %check-in-clang -fno-modules -Qunused-arguments %t/enums.h -include Foundation.h -include ctypes.h -include CoreFoundation.h
 
 // REQUIRES: objc_interop
-// REQUIRES: rdar38854095
 
 import Foundation
 


### PR DESCRIPTION
This test was temporarily disabled due to a Clang bug that is now
fixed as of r333471