### PR TITLE
[Batch Mode] Cherry-pick: rdar://40167351 Replace non-specific error with truncated serialized diagnostics files.

### DIFF
--- a/include/swift/AST/DiagnosticConsumer.h
+++ b/include/swift/AST/DiagnosticConsumer.h
@@ -100,7 +100,16 @@ public:
                                 const DiagnosticInfo &Info) = 0;
 
   /// \returns true if an error occurred while finishing-up.
-  virtual bool finishProcessing(SourceManager &) { return false; }
+  virtual bool finishProcessing() { return false; }
+
+  /// In batch mode, any error causes failure for all primary files, but
+  /// anyone consulting .dia files will only see an error for a particular
+  /// primary in that primary's serialized diagnostics file. For other
+  /// primaries' serialized diagnostics files, do something to signal the driver
+  /// what happened. This is only meaningful for SerializedDiagnosticConsumers,
+  /// so here's a placeholder.
+
+  virtual void informDriverOfIncompleteBatchModeCompilation() {}
 };
   
 /// \brief DiagnosticConsumer that discards all diagnostics.
@@ -193,13 +202,14 @@ public:
                         ArrayRef<DiagnosticArgument> FormatArgs,
                         const DiagnosticInfo &Info) override;
 
-  bool finishProcessing(SourceManager &) override;
+  bool finishProcessing() override;
 
 private:
   /// In batch mode, any error causes failure for all primary files, but
   /// Xcode will only see an error for a particular primary in that primary's
-  /// serialized diagnostics file. So, emit errors for all other primaries here.
-  void addNonSpecificErrors(SourceManager &SM);
+  /// serialized diagnostics file. So, tell the subconsumers to inform the
+  /// driver of incomplete batch mode compilation.
+  void tellSubconsumersToInformDriverOfIncompleteBatchModeCompilation() const;
 
   void computeConsumersOrderedByRange(SourceManager &SM);
 

--- a/include/swift/AST/DiagnosticEngine.h
+++ b/include/swift/AST/DiagnosticEngine.h
@@ -759,7 +759,7 @@ namespace swift {
 
     /// \returns true if any diagnostic consumer gave an error while invoking
     //// \c finishProcessing.
-    bool finishProcessing(SourceManager &);
+    bool finishProcessing();
 
     /// \brief Format the given diagnostic text and place the result in the given
     /// buffer.

--- a/include/swift/AST/DiagnosticsFrontend.def
+++ b/include/swift/AST/DiagnosticsFrontend.def
@@ -235,8 +235,6 @@ WARNING(cannot_assign_value_to_conditional_compilation_flag,none,
 ERROR(error_optimization_remark_pattern, none, "%0 in '%1'",
       (StringRef, StringRef))
 
-ERROR(error_compilation_stopped_by_errors_in_other_files,none, "compilation stopped by errors in other files", ())
-
 #ifndef DIAG_NO_UNDEF
 # if defined(DIAG)
 #  undef DIAG

--- a/lib/AST/DiagnosticEngine.cpp
+++ b/lib/AST/DiagnosticEngine.cpp
@@ -251,10 +251,10 @@ bool DiagnosticEngine::isDiagnosticPointsToFirstBadToken(DiagID ID) const {
   return storedDiagnosticInfos[(unsigned) ID].pointsToFirstBadToken;
 }
 
-bool DiagnosticEngine::finishProcessing(SourceManager &SM) {
+bool DiagnosticEngine::finishProcessing() {
   bool hadError = false;
   for (auto &Consumer : Consumers) {
-    hadError |= Consumer->finishProcessing(SM);
+    hadError |= Consumer->finishProcessing();
   }
   return hadError;
 }

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -404,7 +404,7 @@ private:
     }
   }
 
-  bool finishProcessing(SourceManager &) override {
+  bool finishProcessing() override {
     std::error_code EC;
     std::unique_ptr<llvm::raw_fd_ostream> OS;
     OS.reset(new llvm::raw_fd_ostream(FixitsOutputPath,
@@ -1651,7 +1651,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
 
   auto finishDiagProcessing = [&](int retValue) -> int {
     FinishDiagProcessingCheckRAII.CalledFinishDiagProcessing = true;
-    bool err = Instance->getDiags().finishProcessing(Instance->getSourceMgr());
+    bool err = Instance->getDiags().finishProcessing();
     return retValue ? retValue : err;
   };
 

--- a/test/Misc/serialized-diagnostics-batch-mode-nonprimary-errors-only.swift
+++ b/test/Misc/serialized-diagnostics-batch-mode-nonprimary-errors-only.swift
@@ -3,14 +3,9 @@
 // RUN: rm -f %t.*
 
 // RUN: not %target-swift-frontend -typecheck  -primary-file %s  -serialize-diagnostics-path %t.main.dia -primary-file %S/../Inputs/empty.swift  -serialize-diagnostics-path %t.empty.dia %S/Inputs/serialized-diagnostics-batch-mode-suppression-helper.swift  2> %t.stderr.txt
-// RUN: c-index-test -read-diagnostics %t.main.dia 2> %t.main.txt
 
-// RUN: %FileCheck -check-prefix=NO-GENERAL-ERROR-OCCURRED %s <%t.main.txt
+// RUN: test -e %t.main.dia -a ! -s %t.empty.dia
 // RUN: test -e %t.empty.dia -a ! -s %t.empty.dia
-// GENERAL-ERROR-OCCURRED: compilation stopped by errors in other files
-// NO-GENERAL-ERROR-OCCURRED-NOT: compilation stopped by errors in other files
-
 
 func test(x: SomeType) {
-    nonexistant()
 }

--- a/test/Misc/serialized-diagnostics-batch-mode-primary-errors.swift
+++ b/test/Misc/serialized-diagnostics-batch-mode-primary-errors.swift
@@ -4,11 +4,10 @@
 
 // RUN: not %target-swift-frontend -typecheck  -primary-file %s  -serialize-diagnostics-path %t.main.dia -primary-file %S/../Inputs/empty.swift  -serialize-diagnostics-path %t.empty.dia  2> %t.stderr.txt
 // RUN: c-index-test -read-diagnostics %t.main.dia 2> %t.main.txt
-// RUN: c-index-test -read-diagnostics %t.empty.dia 2> %t.empty.txt
 
 // RUN: %FileCheck -check-prefix=ERROR %s <%t.main.txt
 // RUN: %FileCheck -check-prefix=NO-NONSPECIFIC-ERROR %s <%t.main.txt
-// RUN: %FileCheck -check-prefix=NONSPECIFIC-ERROR %s <%t.empty.txt
+// RUN: test -e %t.empty.dia -a ! -s %t.empty.dia
 
 // ERROR: error:
 // NONSPECIFIC-ERROR: error: compilation stopped by errors in other files
@@ -17,4 +16,3 @@
 func test(x: SomeType) {
   nonexistent()
 }
-

--- a/unittests/AST/DiagnosticConsumerTests.cpp
+++ b/unittests/AST/DiagnosticConsumerTests.cpp
@@ -43,7 +43,7 @@ namespace {
       expected.erase(expected.begin());
     }
 
-    bool finishProcessing(SourceManager &) override {
+    bool finishProcessing() override {
       EXPECT_FALSE(hasFinished);
       if (previous)
         EXPECT_TRUE(previous->hasFinished);
@@ -68,7 +68,7 @@ TEST(FileSpecificDiagnosticConsumer, SubConsumersFinishInOrder) {
   consumers.emplace_back("", std::move(consumerUnaffiliated));
 
   FileSpecificDiagnosticConsumer topConsumer(consumers);
-  topConsumer.finishProcessing(sourceMgr);
+  topConsumer.finishProcessing();
 }
 
 TEST(FileSpecificDiagnosticConsumer, InvalidLocDiagsGoToEveryConsumer) {
@@ -89,7 +89,7 @@ TEST(FileSpecificDiagnosticConsumer, InvalidLocDiagsGoToEveryConsumer) {
   FileSpecificDiagnosticConsumer topConsumer(consumers);
   topConsumer.handleDiagnostic(sourceMgr, SourceLoc(), DiagnosticKind::Error,
                                "dummy", {}, DiagnosticInfo());
-  topConsumer.finishProcessing(sourceMgr);
+  topConsumer.finishProcessing();
 }
 
 TEST(FileSpecificDiagnosticConsumer, ErrorsWithLocationsGoToExpectedConsumers) {
@@ -139,7 +139,7 @@ TEST(FileSpecificDiagnosticConsumer, ErrorsWithLocationsGoToExpectedConsumers) {
                                "back", {}, DiagnosticInfo());
   topConsumer.handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Error,
                                "back", {}, DiagnosticInfo());
-  topConsumer.finishProcessing(sourceMgr);
+  topConsumer.finishProcessing();
 }
 
 TEST(FileSpecificDiagnosticConsumer,
@@ -193,7 +193,7 @@ TEST(FileSpecificDiagnosticConsumer,
                                "back", {}, DiagnosticInfo());
   topConsumer.handleDiagnostic(sourceMgr, backOfB, DiagnosticKind::Error,
                                "back", {}, DiagnosticInfo());
-  topConsumer.finishProcessing(sourceMgr);
+  topConsumer.finishProcessing();
 }
 
 TEST(FileSpecificDiagnosticConsumer, WarningsAndRemarksAreTreatedLikeErrors) {
@@ -234,7 +234,7 @@ TEST(FileSpecificDiagnosticConsumer, WarningsAndRemarksAreTreatedLikeErrors) {
                                "remark", {}, DiagnosticInfo());
   topConsumer.handleDiagnostic(sourceMgr, frontOfB, DiagnosticKind::Remark,
                                "remark", {}, DiagnosticInfo());
-  topConsumer.finishProcessing(sourceMgr);
+  topConsumer.finishProcessing();
 }
 
 TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToErrors) {
@@ -296,7 +296,7 @@ TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToErrors) {
                                "note", {}, DiagnosticInfo());
   topConsumer.handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
                                "note", {}, DiagnosticInfo());
-  topConsumer.finishProcessing(sourceMgr);
+  topConsumer.finishProcessing();
 }
 
 TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToWarningsAndRemarks) {
@@ -358,7 +358,7 @@ TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToWarningsAndRemarks) {
                                "note", {}, DiagnosticInfo());
   topConsumer.handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
                                "note", {}, DiagnosticInfo());
-  topConsumer.finishProcessing(sourceMgr);
+  topConsumer.finishProcessing();
 }
 
 TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToErrorsEvenAcrossFiles) {
@@ -417,7 +417,7 @@ TEST(FileSpecificDiagnosticConsumer, NotesAreAttachedToErrorsEvenAcrossFiles) {
                                "note", {}, DiagnosticInfo());
   topConsumer.handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
                                "note", {}, DiagnosticInfo());
-  topConsumer.finishProcessing(sourceMgr);
+  topConsumer.finishProcessing();
 }
 
 TEST(FileSpecificDiagnosticConsumer,
@@ -480,7 +480,7 @@ TEST(FileSpecificDiagnosticConsumer,
                                "note", {}, DiagnosticInfo());
   topConsumer.handleDiagnostic(sourceMgr, backOfA, DiagnosticKind::Note,
                                "note", {}, DiagnosticInfo());
-  topConsumer.finishProcessing(sourceMgr);
+  topConsumer.finishProcessing();
 }
 
 
@@ -529,5 +529,5 @@ TEST(FileSpecificDiagnosticConsumer,
                                "error", {}, DiagnosticInfo());
   topConsumer.handleDiagnostic(sourceMgr, SourceLoc(), DiagnosticKind::Note,
                                "note", {}, DiagnosticInfo());
-  topConsumer.finishProcessing(sourceMgr);
+  topConsumer.finishProcessing();
 }


### PR DESCRIPTION
<!-- What's in this pull request? -->
Cherry-pick pr 17131 from master: for rdar://40167351 Replace non-specific error with truncated serialized diagnostics files.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->


<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
