### PR TITLE
[TypeChecker][Diag] Suggest fixits for close-match range operators

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -676,8 +676,8 @@ ERROR(unspaced_unary_operator,none,
 ERROR(use_unresolved_identifier,none,
       "use of unresolved %select{identifier|operator}1 %0", (DeclName, bool))
 ERROR(use_unresolved_identifier_corrected,none,
-      "use of unresolved %select{identifier|operator}1 %0; did you mean %2?",
-      (DeclName, bool, DeclName))
+      "use of unresolved %select{identifier|operator}1 %0; did you mean '%2'?",
+      (DeclName, bool, StringRef))
 NOTE(confusable_character,none,
       "%select{identifier|operator}0 '%1' contains possibly confused characters; "
       "did you mean to use '%2'?",

--- a/test/decl/func/operator.swift
+++ b/test/decl/func/operator.swift
@@ -355,3 +355,13 @@ class C6 {
     if x == x && x = x { } // expected-error{{expression is not assignable: '&&' returns immutable value}}
   }
 }
+
+_ = 1..<1 // OK
+_ = 1…1 // expected-error {{use of unresolved operator '…'; did you mean '...'?}} {{6-9=...}}
+_ = 1….1 // expected-error {{use of unresolved operator '…'; did you mean '...'?}} {{6-9=...}}
+_ = 1.…1 // expected-error {{use of unresolved operator '.…'; did you mean '...'?}} {{6-10=...}}
+_ = 1…<1 // expected-error {{use of unresolved operator '…<'; did you mean '..<'?}} {{6-10=..<}}
+_ = 1..1 // expected-error {{use of unresolved operator '..'; did you mean '...'?}} {{6-8=...}}
+_ = 1....1 // expected-error {{use of unresolved operator '....'; did you mean '...'?}} {{6-10=...}}
+_ = 1...<1 // expected-error {{use of unresolved operator '...<'; did you mean '..<'?}} {{6-10=..<}}
+_ = 1....<1 // expected-error {{use of unresolved operator '....<'; did you mean '..<'?}} {{6-11=..<}}


### PR DESCRIPTION
Pretty straight-forward and ugly, but `performTypoCorrection`, namely `lookupVisibleDecls`, doesn't include member decls from other modules, and manually doing unqualified lookup for `Comparable` to include the results IMO isn't worth the expense and arguably neater code.

Goes in front of juxtaposition diagnosing not to treat `...<` as one.

Resolves [SR-6012](https://bugs.swift.org/browse/SR-6012)
