### PR TITLE
[DebugInfo] Don't record that the standard library imports itself

### DIFF
--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1696,15 +1696,8 @@ void IRGenDebugInfoImpl::emitImport(ImportDecl *D) {
   if (Opts.DebugInfoKind <= IRGenDebugInfoKind::LineTables)
     return;
 
-  swift::ModuleDecl *M = IGM.Context.getModule(D->getModulePath());
-  if (!M &&
-      D->getModulePath()[0].first == IGM.Context.TheBuiltinModule->getName())
-    M = IGM.Context.TheBuiltinModule;
-  if (!M) {
-    assert(M && "Could not find module for import decl.");
-    return;
-  }
-  ModuleDecl::ImportedModule Imported = {D->getModulePath(), M};
+  assert(D->getModule() && "compiler-synthesized ImportDecl is incomplete");
+  ModuleDecl::ImportedModule Imported = {D->getModulePath(), D->getModule()};
   auto DIMod = getOrCreateModule(Imported);
   auto L = getDebugLoc(*this, D);
   auto *File = getOrCreateFile(L.Filename);

--- a/test/DebugInfo/ImportsStdlib.swift
+++ b/test/DebugInfo/ImportsStdlib.swift
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend -emit-ir -parse-stdlib -module-name NotTheStdlib %s -I %t -g -o - > %t.ll
+// RUN: %FileCheck %s < %t.ll
+// RUN: %FileCheck -check-prefix=NEGATIVE %s < %t.ll
+
+// RUN: %target-swift-frontend -c -parse-stdlib -module-name NotTheStdlib %s -I %t -g -o %t.o
+// RUN: %llvm-dwarfdump -a %t.o > %t.dump
+// RUN: %FileCheck -check-prefix=DWARF %s < %t.dump
+// RUN: %FileCheck -check-prefix=NEGATIVE-DWARF %s < %t.dump
+
+// CHECK-DAG: ![[MODULE:[0-9]+]] = !DIModule({{.*}}, name: "NotTheStdlib", includePath: "{{.*}}test{{.*}}DebugInfo{{.*}}"
+// CHECK-DAG: !DIImportedEntity(tag: DW_TAG_imported_module, scope: ![[THISFILE:[0-9]+]], entity: ![[MODULE]]
+// CHECK-DAG: ![[THISFILE]] = !DIFile(filename: "ImportsStdlib.swift", directory: "{{.*}}test/DebugInfo")
+
+// NEGATIVE-NOT: !DIFile(filename: "Swift.swiftmodule"
+// NEGATIVE-NOT: !DIModule({{.*}}, name: "Swift"
+
+// DWARF: .debug_info
+// DWARF: DW_TAG_module
+// DWARF:   DW_AT_name ("NotTheStdlib")
+// DWARF:   DW_AT_LLVM_include_path
+
+// DWARF: file_names{{.*}} ImportsStdlib.swift
+
+// NEGATIVE-DWARF-NOT: DW_AT_name ("Swift")


### PR DESCRIPTION
This causes problems for cross-compilation -parse-stdlib tests that emit debug info. At the moment we have zero of those, but we're trying to add one (#17087).

Also, don't try to load new modules when recording imports. (This isn't harmful, just inefficient.)