### PR TITLE
Fix a bunch of performance issues in Function Signature Optimizations

### DIFF
--- a/include/swift/SILOptimizer/Analysis/ARCAnalysis.h
+++ b/include/swift/SILOptimizer/Analysis/ARCAnalysis.h
@@ -13,16 +13,17 @@
 #ifndef SWIFT_SILOPTIMIZER_ANALYSIS_ARCANALYSIS_H
 #define SWIFT_SILOPTIMIZER_ANALYSIS_ARCANALYSIS_H
 
+#include "swift/Basic/LLVM.h"
 #include "swift/SIL/SILArgument.h"
-#include "swift/SIL/SILValue.h"
 #include "swift/SIL/SILBasicBlock.h"
+#include "swift/SIL/SILValue.h"
 #include "swift/SILOptimizer/Analysis/AliasAnalysis.h"
 #include "swift/SILOptimizer/Analysis/PostOrderAnalysis.h"
 #include "swift/SILOptimizer/Analysis/RCIdentityAnalysis.h"
 #include "llvm/ADT/BitVector.h"
-#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/MapVector.h"
 #include "llvm/ADT/SetVector.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/ADT/TinyPtrVector.h"
 
 namespace swift {
@@ -181,7 +182,8 @@ public:
 private:
   /// Return true if all the successors of the EpilogueRetainInsts do not have
   /// a retain.
-  bool isTransitiveSuccessorsRetainFree(llvm::DenseSet<SILBasicBlock *> BBs);
+  bool
+  isTransitiveSuccessorsRetainFree(const llvm::DenseSet<SILBasicBlock *> &BBs);
 
   /// Finds matching releases in the provided block \p BB.
   RetainKindValue findMatchingRetainsInBasicBlock(SILBasicBlock *BB,

--- a/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/ARCAnalysis.cpp
@@ -707,9 +707,8 @@ void ConsumedArgToEpilogueReleaseMatcher::recompute() {
   findMatchingReleases(&*BB);
 }
 
-bool
-ConsumedArgToEpilogueReleaseMatcher::
-isRedundantRelease(ReleaseList Insts, SILValue Base, SILValue Derived) {
+bool ConsumedArgToEpilogueReleaseMatcher::isRedundantRelease(
+    ArrayRef<SILInstruction *> Insts, SILValue Base, SILValue Derived) {
   // We use projection path to analyze the relation.
   auto POp = ProjectionPath::getProjectionPath(Base, Derived);
   // We can not build a projection path from the base to the derived, bail out.
@@ -730,9 +729,8 @@ isRedundantRelease(ReleaseList Insts, SILValue Base, SILValue Derived) {
   return false;
 }
 
-bool
-ConsumedArgToEpilogueReleaseMatcher::
-releaseArgument(ReleaseList Insts, SILValue Arg) {
+bool ConsumedArgToEpilogueReleaseMatcher::releaseArgument(
+    ArrayRef<SILInstruction *> Insts, SILValue Arg) {
   // Reason about whether all parts are released.
   SILModule *Mod = &(*Insts.begin())->getModule();
 

--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.h
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.h
@@ -65,14 +65,14 @@ struct ArgumentDescriptor {
   /// Is this parameter an indirect result?
   bool IsIndirectResult;
 
-  /// If non-null, this is the release in the return block of the callee, which
-  /// is associated with this parameter if it is @owned. If the parameter is not
-  /// @owned or we could not find such a release in the callee, this is null.
-  ReleaseList CalleeRelease;
+  /// If non-empty, this is the set of releases in the return block of
+  /// the callee associated with this parameter if it is @owned. If it
+  /// is empty then we could not find any such releases.
+  TinyPtrVector<SILInstruction *> CalleeRelease;
 
-  /// The same as CalleeRelease, but the release in the throw block, if it is a
-  /// function which has a throw block.
-  ReleaseList CalleeReleaseInThrowBlock;
+  /// The same as CalleeRelease, but the releases are post-dominated
+  /// by the throw block, if it is a function which has a throw block.
+  TinyPtrVector<SILInstruction *> CalleeReleaseInThrowBlock;
 
   /// The projection tree of this arguments.
   ProjectionTree ProjTree;

--- a/lib/SILOptimizer/FunctionSignatureTransforms/OwnedToGuaranteedTransform.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/OwnedToGuaranteedTransform.cpp
@@ -92,8 +92,11 @@ bool FunctionSignatureTransform::OwnedToGuaranteedAnalyzeParameters() {
         auto ReleasesInThrow =
             ArgToThrowReleaseMap.getReleasesForArgument(A.Arg);
         if (!ArgToThrowReleaseMap.hasBlock() || !ReleasesInThrow.empty()) {
-          A.CalleeRelease = Releases;
-          A.CalleeReleaseInThrowBlock = ReleasesInThrow;
+          assert(A.CalleeRelease.empty());
+          assert(A.CalleeReleaseInThrowBlock.empty());
+          copy(Releases, std::back_inserter(A.CalleeRelease));
+          copy(ReleasesInThrow,
+               std::back_inserter(A.CalleeReleaseInThrowBlock));
           // We can convert this parameter to a @guaranteed.
           A.OwnedToGuaranteed = true;
           SignatureOptimize = true;


### PR DESCRIPTION
Found a bunch of pretty bad performance problems in Function Signature Optimizations. Not going to say how they got here... but I am going to fix them real quick.

Specifically we were copying around ADTs just to read them. There is no excuse for that.

rdar://41146023