### PR TITLE
Sema: Explicitly check for 'inout' parameters on @objc functions

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3522,6 +3522,9 @@ ERROR(objc_addressor, none,
 ERROR(objc_invalid_on_func_variadic,none,
       "method cannot be %" OBJC_ATTR_SELECT "0 because it has a variadic "
       "parameter", (unsigned))
+ERROR(objc_invalid_on_func_inout,none,
+      "method cannot be %" OBJC_ATTR_SELECT "0 because inout "
+      "parameters cannot be represented in Objective-C", (unsigned))
 ERROR(objc_invalid_on_func_param_type,none,
       "method cannot be %" OBJC_ATTR_SELECT "1 because the type of the "
       "parameter %0 cannot be represented in Objective-C", (unsigned, unsigned))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3515,9 +3515,6 @@ WARNING(witness_swift3_objc_inference,none,
         (DescriptiveDeclKind, DeclName, Type))
 
 
-ERROR(objc_invalid_on_func_curried,none,
-      "method cannot be %" OBJC_ATTR_SELECT "0 because curried functions "
-      "cannot be represented in Objective-C", (unsigned))
 ERROR(objc_observing_accessor, none,
       "observing accessors are not allowed to be marked @objc", ())
 ERROR(objc_addressor, none,

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3601,20 +3601,6 @@ bool TypeChecker::isRepresentableInObjC(
     llvm_unreachable("bad kind");
   }
 
-  if (auto *FD = dyn_cast<FuncDecl>(AFD)) {
-    unsigned ExpectedParamPatterns = 1;
-    if (FD->getImplicitSelfDecl())
-      ExpectedParamPatterns++;
-    if (FD->getParameterLists().size() != ExpectedParamPatterns) {
-      if (Diagnose) {
-        diagnose(AFD->getLoc(), diag::objc_invalid_on_func_curried,
-                 getObjCDiagnosticAttrKind(Reason));
-        describeObjCReason(*this, AFD, Reason);
-      }
-      return false;
-    }
-  }
-
   // As a special case, an initializer with a single, named parameter of type
   // '()' is always representable in Objective-C. This allows us to cope with
   // zero-parameter methods with selectors that are longer than "init". For

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -3360,7 +3360,7 @@ static bool isParamListRepresentableInObjC(TypeChecker &TC,
   unsigned NumParams = PL->size();
   for (unsigned ParamIndex = 0; ParamIndex != NumParams; ParamIndex++) {
     auto param = PL->get(ParamIndex);
-    
+
     // Swift Varargs are not representable in Objective-C.
     if (param->isVariadic()) {
       if (Diagnose && shouldDiagnoseObjCReason(Reason, TC.Context)) {
@@ -3369,10 +3369,22 @@ static bool isParamListRepresentableInObjC(TypeChecker &TC,
           .highlight(param->getSourceRange());
         describeObjCReason(TC, AFD, Reason);
       }
-      
+
       return false;
     }
-    
+
+    // Swift inout parameters are not representable in Objective-C.
+    if (param->isInOut()) {
+      if (Diagnose && shouldDiagnoseObjCReason(Reason, TC.Context)) {
+        TC.diagnose(param->getStartLoc(), diag::objc_invalid_on_func_inout,
+                    getObjCDiagnosticAttrKind(Reason))
+          .highlight(param->getSourceRange());
+        describeObjCReason(TC, AFD, Reason);
+      }
+
+      return false;
+    }
+
     if (param->getType()->isRepresentableIn(
           ForeignLanguage::ObjectiveC,
           const_cast<AbstractFunctionDecl *>(AFD)))

--- a/test/attr/attr_objc.swift
+++ b/test/attr/attr_objc.swift
@@ -354,6 +354,8 @@ class ConcreteContext3 {
 
   typealias NSCodingExistential = NSCoding.Type
 
+  @objc func inoutFunc(a: inout Int) {}
+  // expected-error@-1{{method cannot be marked @objc because inout parameters cannot be represented in Objective-C}}
   @objc func metatypeOfExistentialMetatypePram1(a: NSCodingExistential.Protocol) {}
   // expected-error@-1{{method cannot be marked @objc because the type of the parameter cannot be represented in Objective-C}}
 


### PR DESCRIPTION
Fixes <rdar://problem/41129106>.

Note that this fixes a regression from a change that's only on master; I'm not cherry-picking this into 4.2 branch, where we already catch this error, just with a worse diagnostic.