### PR TITLE
Generalize accessor storage to preserve the original accessor list.

### DIFF
--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -878,6 +878,7 @@ public:
 
   struct ParsedAccessors {
     SourceLoc LBLoc, RBLoc;
+    SmallVector<AccessorDecl*, 16> Accessors;
 
 #define ACCESSOR(ID) AccessorDecl *ID = nullptr;
 #include "swift/AST/AccessorKinds.def"
@@ -887,6 +888,17 @@ public:
                 const DeclAttributes &attrs,
                 TypeLoc elementTy, ParameterList *indices,
                 SmallVectorImpl<Decl *> &decls);
+
+    AbstractStorageDecl::StorageKindTy
+    classify(Parser &P, AbstractStorageDecl *storage, bool invalid,
+             ParseDeclOptions flags, SourceLoc staticLoc,
+             const DeclAttributes &attrs,
+             TypeLoc elementTy, ParameterList *indices);
+
+    /// Add an accessor.  If there's an existing accessor of this kind,
+    /// return it.  The new accessor is still remembered but will be
+    /// ignored.
+    AccessorDecl *add(AccessorDecl *accessor);
   };
 
   void parseAccessorAttributes(DeclAttributes &Attributes);
@@ -898,15 +910,14 @@ public:
                        ParsedAccessors &accessors,
                        AbstractStorageDecl *storage,
                        SourceLoc &LastValidLoc,
-                       SourceLoc StaticLoc, SourceLoc VarLBLoc,
-                       SmallVectorImpl<Decl *> &Decls);
+                       SourceLoc StaticLoc, SourceLoc VarLBLoc);
   bool parseGetSet(ParseDeclOptions Flags,
                    GenericParamList *GenericParams,
                    ParameterList *Indices,
                    TypeLoc ElementTy,
                    ParsedAccessors &accessors,
                    AbstractStorageDecl *storage,
-                   SourceLoc StaticLoc, SmallVectorImpl<Decl *> &Decls);
+                   SourceLoc StaticLoc);
   void recordAccessors(AbstractStorageDecl *storage, ParseDeclOptions flags,
                        TypeLoc elementTy, const DeclAttributes &attrs,
                        SourceLoc staticLoc, ParsedAccessors &accessors);

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -3644,134 +3644,169 @@ void ProtocolDecl::setDefaultWitness(ValueDecl *requirement, Witness witness) {
   (void) pair;
 }
 
-AccessorDecl *
-AbstractStorageDecl::getAccessorFunction(AccessorKind kind) const {
-  // This function shouldn't assert if asked for an accessor that the
-  // storage doesn't have.  It can be convenient to ask for accessors
-  // before the declaration is fully-configured.
-  switch (kind) {
-  case AccessorKind::Get:
-    return getGetter();
-  case AccessorKind::Set:
-    return getSetter();
-  case AccessorKind::MaterializeForSet:
-    return getMaterializeForSetFunc();
-  case AccessorKind::Address:
-    return hasAddressors() ? getAddressor() : nullptr;
-  case AccessorKind::MutableAddress:
-    return hasAddressors() ? getMutableAddressor() : nullptr;
-  case AccessorKind::DidSet:
-    return hasObservers() ? getDidSetFunc() : nullptr;
-  case AccessorKind::WillSet:
-    return hasObservers() ? getWillSetFunc() : nullptr;
-  }
-  llvm_unreachable("bad accessor kind!");
-}
-
-void AbstractStorageDecl::getAllAccessorFunctions(
-    SmallVectorImpl<Decl *> &decls) const {
-  auto tryPush = [&](Decl *decl) {
-    if (decl)
-      decls.push_back(decl);
-  };
-
-  tryPush(getGetter());
-  tryPush(getSetter());
-  tryPush(getMaterializeForSetFunc());
-
-  if (hasObservers()) {
-    tryPush(getDidSetFunc());
-    tryPush(getWillSetFunc());
-  }
-
-  if (hasAddressors()) {
-    tryPush(getAddressor());
-    tryPush(getMutableAddressor());
-  }
-}
-
 #ifndef NDEBUG
-
 static bool isAccessor(AccessorDecl *accessor, AccessorKind kind,
                        AbstractStorageDecl *storage) {
-  // TODO: this originally asserted that the storage matched, but the
-  // importer likes to break that assumption.
-  return (accessor == nullptr ||
-          accessor->getAccessorKind() == kind);
+  // TODO: this should check that the accessor belongs to this storage, but
+  // the Clang importer currently likes to violate that condition.
+  return (accessor && accessor->getAccessorKind() == kind);
 }
-
-#define isAccessor(accessor, kind, storage) \
-  isAccessor(accessor, AccessorKind::kind, storage)
 #endif
 
-void AbstractStorageDecl::configureGetSetRecord(GetSetRecord *getSetInfo,
-                                                AccessorDecl *getter,
-                                                AccessorDecl *setter,
-                                              AccessorDecl *materializeForSet) {
-  assert(isAccessor(getter, Get, this));
-  getSetInfo->Get = getter;
+void AbstractStorageDecl::configureAccessor(AccessorDecl *accessor) {
+  assert(isAccessor(accessor, accessor->getAccessorKind(), this));
 
-  configureSetRecord(getSetInfo, setter, materializeForSet);
-}
+  switch (accessor->getAccessorKind()) {
+  case AccessorKind::Get:
+  case AccessorKind::Address:
+    // Nothing to do.
+    return;
 
-void AbstractStorageDecl::configureSetRecord(GetSetRecord *getSetInfo,
-                                             AccessorDecl *setter,
-                                             AccessorDecl *materializeForSet) {
-  assert(isAccessor(setter, Set, this));
-  assert(isAccessor(materializeForSet, MaterializeForSet, this));
-  getSetInfo->Set = setter;
-  getSetInfo->MaterializeForSet = materializeForSet;
-
-  auto setSetterAccess = [&](AccessorDecl *fn) {
-    if (auto setterAccess = GetSetInfo.getInt()) {
-      assert(!fn->hasAccess() ||
-             fn->getFormalAccess() == setterAccess.getValue());
-      fn->overwriteAccess(setterAccess.getValue());
-    }    
-  };
-
-  if (setter) {
-    setSetterAccess(setter);
+  case AccessorKind::Set:
+  case AccessorKind::MaterializeForSet:
+  case AccessorKind::WillSet:
+  case AccessorKind::DidSet:
+  case AccessorKind::MutableAddress:
+    // Propagate the setter access.
+    if (auto setterAccess = Accessors.getInt()) {
+      assert(!accessor->hasAccess() ||
+             accessor->getFormalAccess() == setterAccess.getValue());
+      accessor->overwriteAccess(setterAccess.getValue());
+    }
+    return;
   }
-
-  if (materializeForSet) {
-    setSetterAccess(materializeForSet);
-  }
+  llvm_unreachable("bad accessor kind");
 }
 
-void AbstractStorageDecl::configureAddressorRecord(AddressorRecord *record,
-                                                   AccessorDecl *addressor,
-                                               AccessorDecl *mutableAddressor) {
-  assert(isAccessor(addressor, Address, this));
-  assert(isAccessor(mutableAddressor, MutableAddress, this));
-  record->Address = addressor;
-  record->MutableAddress = mutableAddressor;
-}
-
-void AbstractStorageDecl::configureObservingRecord(ObservingRecord *record,
-                                                   AccessorDecl *willSet,
-                                                   AccessorDecl *didSet) {
-  assert(isAccessor(willSet, WillSet, this));
-  assert(isAccessor(didSet, DidSet, this));
-  record->WillSet = willSet;
-  record->DidSet = didSet;
-}
-
-void AbstractStorageDecl::makeComputed(SourceLoc LBraceLoc,
-                                       AccessorDecl *Get,
-                                       AccessorDecl *Set,
-                                       AccessorDecl *MaterializeForSet,
-                                       SourceLoc RBraceLoc) {
+void AbstractStorageDecl::setAccessors(StorageKindTy storageKind,
+                                       SourceLoc lbraceLoc,
+                                       ArrayRef<AccessorDecl *> accessors,
+                                       SourceLoc rbraceLoc) {
   assert(getStorageKind() == Stored && "StorageKind already set");
-  auto &Context = getASTContext();
-  void *Mem = Context.Allocate(sizeof(GetSetRecord), alignof(GetSetRecord));
-  auto *getSetInfo = new (Mem) GetSetRecord();
-  getSetInfo->Braces = SourceRange(LBraceLoc, RBraceLoc);
-  GetSetInfo.setPointer(getSetInfo);
-  configureGetSetRecord(getSetInfo, Get, Set, MaterializeForSet);
 
-  // Mark that this is a computed property.
-  setStorageKind(Computed);
+  // The only situation where we allow the incoming storage kind to be
+  // Stored is when there are no accessors.  This happens when the program
+  // has {} as the accessor clause (or unparsable contents).
+  assert((storageKind != Stored || accessors.empty()) &&
+         "cannot combine Stored storage kind with any accessors");
+  setStorageKind(storageKind);
+
+  // This method is called after we've already recorded an accessors clause
+  // only on recovery paths and only when that clause was empty.
+  auto record = Accessors.getPointer();
+  if (record) {
+    assert(record->getAllAccessors().empty());
+    for (auto accessor : accessors) {
+      (void) record->addOpaqueAccessor(accessor);
+    }
+  } else {
+    record = AccessorRecord::create(getASTContext(),
+                                    SourceRange(lbraceLoc, rbraceLoc),
+                                    accessors);
+    Accessors.setPointer(record);
+  }
+
+  for (auto accessor : accessors)
+    configureAccessor(accessor);
+}
+
+// Compute the number of opaque accessors.
+const size_t NumOpaqueAccessors =
+  0
+#define ACCESSOR(ID)
+#define OPAQUE_ACCESSOR(ID, KEYWORD) \
+  + 1
+#include "swift/AST/AccessorKinds.def"
+;
+
+AbstractStorageDecl::AccessorRecord *
+AbstractStorageDecl::AccessorRecord::create(ASTContext &ctx,
+                                            SourceRange braces,
+                                            ArrayRef<AccessorDecl*> accessors) {
+  // Silently cap the number of accessors we store at a number that should
+  // be easily sufficient for all the valid cases, including space for adding
+  // implicit opaque accessors later.
+  //
+  // We should have already emitted a diagnostic in the parser if we have
+  // this many accessors, because most of them will necessarily be redundant.
+  if (accessors.size() + NumOpaqueAccessors > MaxNumAccessors) {
+    accessors = accessors.slice(0, MaxNumAccessors - NumOpaqueAccessors);
+  }
+
+  // Make sure that we have enough space to add implicit opaque accessors later.
+  size_t numMissingOpaque = NumOpaqueAccessors;
+  {
+#define ACCESSOR(ID)
+#define OPAQUE_ACCESSOR(ID, KEYWORD)          \
+    bool has##ID = false;
+#include "swift/AST/AccessorKinds.def"
+    for (auto accessor : accessors) {
+      switch (accessor->getAccessorKind()) {
+#define ACCESSOR(ID)                          \
+      case AccessorKind::ID:                  \
+        continue;
+#define OPAQUE_ACCESSOR(ID, KEYWORD)          \
+      case AccessorKind::ID:                  \
+        if (!has##ID) {                       \
+          has##ID = true;                     \
+          numMissingOpaque--;                 \
+        }                                     \
+        continue;
+#include "swift/AST/AccessorKinds.def"
+      }
+      llvm_unreachable("bad accessor kind");
+    }
+  }
+
+  auto accessorsCapacity = AccessorIndex(accessors.size() + numMissingOpaque);
+  void *mem = ctx.Allocate(totalSizeToAlloc<AccessorDecl*>(accessorsCapacity),
+                           alignof(AccessorRecord));
+  return new (mem) AccessorRecord(braces, accessors, accessorsCapacity);
+}
+
+AbstractStorageDecl::AccessorRecord::AccessorRecord(SourceRange braces,
+                                           ArrayRef<AccessorDecl *> accessors,
+                                           AccessorIndex accessorsCapacity)
+    : Braces(braces), NumAccessors(accessors.size()),
+      AccessorsCapacity(accessorsCapacity), AccessorIndices{} {
+
+  // Copy the complete accessors list into place.
+  memcpy(getAccessorsBuffer().data(), accessors.data(),
+         accessors.size() * sizeof(AccessorDecl*));
+
+  // Register all the accessors.
+  for (auto index : indices(accessors)) {
+    (void) registerAccessor(accessors[index], index);
+  }
+}
+
+void AbstractStorageDecl::AccessorRecord::addOpaqueAccessor(AccessorDecl *decl){
+  assert(decl);
+
+  // Add the accessor to the array.
+  assert(NumAccessors < AccessorsCapacity);
+  AccessorIndex index = NumAccessors++;
+  getAccessorsBuffer()[index] = decl;
+
+  // Register it.
+  bool isUnique = registerAccessor(decl, index);
+  assert(isUnique && "adding opaque accessor that's already present");
+  (void) isUnique;
+}
+
+/// Register that we have an accessor of the given kind.
+bool AbstractStorageDecl::AccessorRecord::registerAccessor(AccessorDecl *decl,
+                                                           AccessorIndex index){
+  // Remember that we have at least one accessor of this kind.
+  auto &indexSlot = AccessorIndices[unsigned(decl->getAccessorKind())];
+  if (indexSlot) {
+    return false;
+  } else {
+    indexSlot = index + 1;
+
+    assert(getAccessor(decl->getAccessorKind()) == decl);
+    return true;
+  }
 }
 
 void AbstractStorageDecl::setComputedSetter(AccessorDecl *setter) {
@@ -3779,14 +3814,53 @@ void AbstractStorageDecl::setComputedSetter(AccessorDecl *setter) {
   assert(getGetter() && "sanity check: missing getter");
   assert(!getSetter() && "already has a setter");
   assert(hasClangNode() && "should only be used for ObjC properties");
+  assert(isAccessor(setter, AccessorKind::Set, this));
   assert(setter && "should not be called for readonly properties");
-  assert(isAccessor(setter, Set, this));
-  GetSetInfo.getPointer()->Set = setter;
-  if (auto setterAccess = GetSetInfo.getInt()) {
-    assert(!setter->hasAccess() ||
-           setter->getFormalAccess() == setterAccess.getValue());
-    setter->overwriteAccess(setterAccess.getValue());
+
+  Accessors.getPointer()->addOpaqueAccessor(setter);
+  configureAccessor(setter);
+}
+
+void AbstractStorageDecl::setMaterializeForSetFunc(AccessorDecl *accessor) {
+  assert(hasAccessorFunctions() && "No accessors for declaration!");
+  assert(getSetter() && "declaration is not settable");
+  assert(!getMaterializeForSetFunc() && "already has a materializeForSet");
+  assert(isAccessor(accessor, AccessorKind::MaterializeForSet, this));
+
+  Accessors.getPointer()->addOpaqueAccessor(accessor);
+  configureAccessor(accessor);
+}
+
+/// \brief Turn this into a StoredWithTrivialAccessors var, specifying the
+/// accessors (getter and setter) that go with it.
+void AbstractStorageDecl::addTrivialAccessors(AccessorDecl *getter,
+                                              AccessorDecl *setter,
+                                              AccessorDecl *materializeForSet) {
+  assert((getStorageKind() == Stored ||
+          getStorageKind() == Addressed) && "StorageKind already set");
+  assert(getter);
+
+  if (getStorageKind() == Addressed) {
+    setStorageKind(AddressedWithTrivialAccessors);
+  } else {
+    setStorageKind(StoredWithTrivialAccessors);
+    if (!Accessors.getPointer()) {
+      Accessors.setPointer(AccessorRecord::create(getASTContext(),
+                                                  SourceRange(), {}));
+    }
   }
+
+  auto record = Accessors.getPointer();
+  assert(record);
+
+  auto collect = [&](AccessorDecl *accessor) {
+    record->addOpaqueAccessor(accessor);
+    configureAccessor(accessor);
+  };
+
+  collect(getter);
+  if (setter) collect(setter);
+  if (materializeForSet) collect(materializeForSet);
 }
 
 void AbstractStorageDecl::addBehavior(TypeRepr *Type,
@@ -3796,180 +3870,6 @@ void AbstractStorageDecl::addBehavior(TypeRepr *Type,
                                       alignof(BehaviorRecord));
   auto behavior = new (mem) BehaviorRecord{Type, Param};
   BehaviorInfo.setPointer(behavior);
-}
-
-void AbstractStorageDecl::makeComputedWithMutableAddress(SourceLoc lbraceLoc,
-                                                AccessorDecl *get,
-                                                AccessorDecl *set,
-                                                AccessorDecl *materializeForSet,
-                                                AccessorDecl *mutableAddressor,
-                                                SourceLoc rbraceLoc) {
-  assert(getStorageKind() == Stored && "StorageKind already set");
-  assert(get);
-  assert(mutableAddressor);
-  auto &ctx = getASTContext();
-
-  static_assert(alignof(AddressorRecord) == alignof(GetSetRecord),
-                "inconsistent alignment");
-  void *mem = ctx.Allocate(sizeof(AddressorRecord) + sizeof(GetSetRecord),
-                           alignof(AddressorRecord));
-  auto addressorInfo = new (mem) AddressorRecord();
-  auto info = new (addressorInfo->getGetSet()) GetSetRecord();
-  info->Braces = SourceRange(lbraceLoc, rbraceLoc);
-  GetSetInfo.setPointer(info);
-  setStorageKind(ComputedWithMutableAddress);
-
-  configureAddressorRecord(addressorInfo, nullptr, mutableAddressor);
-  configureGetSetRecord(info, get, set, materializeForSet);
-}
-
-void AbstractStorageDecl::setMaterializeForSetFunc(AccessorDecl *accessor) {
-  assert(hasAccessorFunctions() && "No accessors for declaration!");
-  assert(getSetter() && "declaration is not settable");
-  assert(!getMaterializeForSetFunc() && "already has a materializeForSet");
-  assert(isAccessor(accessor, MaterializeForSet, this));
-  GetSetInfo.getPointer()->MaterializeForSet = accessor;
-  if (auto setterAccess = GetSetInfo.getInt()) {
-    assert(!accessor->hasAccess() ||
-           accessor->getFormalAccess() == setterAccess.getValue());
-    accessor->overwriteAccess(setterAccess.getValue());
-  }
-}
-
-/// \brief Turn this into a StoredWithTrivialAccessors var, specifying the
-/// accessors (getter and setter) that go with it.
-void AbstractStorageDecl::addTrivialAccessors(AccessorDecl *Get,
-                                              AccessorDecl *Set,
-                                              AccessorDecl *MaterializeForSet) {
-  assert((getStorageKind() == Stored ||
-          getStorageKind() == Addressed) && "StorageKind already set");
-  assert(Get);
-
-  auto &ctx = getASTContext();
-  GetSetRecord *getSetInfo;
-  if (getStorageKind() == Addressed) {
-    getSetInfo = GetSetInfo.getPointer();
-    setStorageKind(AddressedWithTrivialAccessors);
-  } else {
-    void *mem = ctx.Allocate(sizeof(GetSetRecord), alignof(GetSetRecord));
-    getSetInfo = new (mem) GetSetRecord();
-    getSetInfo->Braces = SourceRange();
-    GetSetInfo.setPointer(getSetInfo);
-    setStorageKind(StoredWithTrivialAccessors);
-  }
-  configureGetSetRecord(getSetInfo, Get, Set, MaterializeForSet);
-}
-
-void AbstractStorageDecl::makeAddressed(SourceLoc lbraceLoc,
-                                        AccessorDecl *addressor,
-                                        AccessorDecl *mutableAddressor,
-                                        SourceLoc rbraceLoc) {
-  assert(getStorageKind() == Stored && "StorageKind already set");
-  assert(addressor && "addressed mode, but no addressor function?");
-
-  auto &ctx = getASTContext();
-
-  static_assert(alignof(AddressorRecord) == alignof(GetSetRecord),
-                "inconsistent alignment");
-  void *mem = ctx.Allocate(sizeof(AddressorRecord) + sizeof(GetSetRecord),
-                           alignof(AddressorRecord));
-  auto addressorInfo = new (mem) AddressorRecord();
-  auto info = new (addressorInfo->getGetSet()) GetSetRecord();
-  info->Braces = SourceRange(lbraceLoc, rbraceLoc);
-  GetSetInfo.setPointer(info);
-  setStorageKind(Addressed);
-
-  configureAddressorRecord(addressorInfo, addressor, mutableAddressor);
-}
-
-void AbstractStorageDecl::makeStoredWithObservers(SourceLoc LBraceLoc,
-                                                  AccessorDecl *WillSet,
-                                                  AccessorDecl *DidSet,
-                                                  SourceLoc RBraceLoc) {
-  assert(getStorageKind() == Stored && "VarDecl StorageKind already set");
-  assert((WillSet || DidSet) &&
-         "Can't be Observing without one or the other");
-  auto &Context = getASTContext();
-  void *Mem = Context.Allocate(sizeof(ObservingRecord),
-                               alignof(ObservingRecord));
-  auto *observingInfo = new (Mem) ObservingRecord;
-  observingInfo->Braces = SourceRange(LBraceLoc, RBraceLoc);
-  GetSetInfo.setPointer(observingInfo);
-
-  // Mark that this is an observing property.
-  setStorageKind(StoredWithObservers);
-
-  configureObservingRecord(observingInfo, WillSet, DidSet);
-}
-
-void AbstractStorageDecl::makeInheritedWithObservers(SourceLoc lbraceLoc,
-                                                     AccessorDecl *willSet,
-                                                     AccessorDecl *didSet,
-                                                     SourceLoc rbraceLoc) {
-  assert(getStorageKind() == Stored && "StorageKind already set");
-  assert((willSet || didSet) &&
-         "Can't be Observing without one or the other");
-  auto &ctx = getASTContext();
-  void *mem = ctx.Allocate(sizeof(ObservingRecord), alignof(ObservingRecord));
-  auto *observingInfo = new (mem) ObservingRecord;
-  observingInfo->Braces = SourceRange(lbraceLoc, rbraceLoc);
-  GetSetInfo.setPointer(observingInfo);
-
-  // Mark that this is an observing property.
-  setStorageKind(InheritedWithObservers);
-
-  configureObservingRecord(observingInfo, willSet, didSet);
-}
-
-void AbstractStorageDecl::makeAddressedWithObservers(SourceLoc lbraceLoc,
-                                                     AccessorDecl *addressor,
-                                                 AccessorDecl *mutableAddressor,
-                                                     AccessorDecl *willSet,
-                                                     AccessorDecl *didSet,
-                                                     SourceLoc rbraceLoc) {
-  assert(getStorageKind() == Stored && "VarDecl StorageKind already set");
-  assert(addressor);
-  assert(mutableAddressor && "observing but immutable?");
-  assert((willSet || didSet) &&
-         "Can't be Observing without one or the other");
-
-  auto &ctx = getASTContext();
-  static_assert(alignof(AddressorRecord) == alignof(ObservingRecord),
-                "inconsistent alignment");
-  void *mem = ctx.Allocate(sizeof(AddressorRecord) + sizeof(ObservingRecord),
-                           alignof(AddressorRecord));
-  auto addressorInfo = new (mem) AddressorRecord();
-  auto observerInfo = new (addressorInfo->getGetSet()) ObservingRecord();
-  observerInfo->Braces = SourceRange(lbraceLoc, rbraceLoc);
-  GetSetInfo.setPointer(observerInfo);
-  setStorageKind(AddressedWithObservers);
-
-  configureAddressorRecord(addressorInfo, addressor, mutableAddressor);
-  configureObservingRecord(observerInfo, willSet, didSet);
-}
-
-/// \brief Specify the synthesized get/set functions for a Observing var.
-/// This is used by Sema.
-void AbstractStorageDecl::setObservingAccessors(AccessorDecl *Get,
-                                                AccessorDecl *Set,
-                                              AccessorDecl *MaterializeForSet) {
-  assert(hasObservers() && "VarDecl is wrong type");
-  assert(!getGetter() && !getSetter() && "getter and setter already set");
-  assert(Get && Set && "Must specify getter and setter");
-  configureGetSetRecord(GetSetInfo.getPointer(), Get, Set, MaterializeForSet);
-}
-
-void AbstractStorageDecl::setInvalidBracesRange(SourceRange BracesRange) {
-  assert(!GetSetInfo.getPointer() && "Braces range has already been set");
-
-  auto &Context = getASTContext();
-  void *Mem = Context.Allocate(sizeof(GetSetRecord), alignof(GetSetRecord));
-  auto *getSetInfo = new (Mem) GetSetRecord();
-  getSetInfo->Braces = BracesRange;
-  getSetInfo->Get = nullptr;
-  getSetInfo->Set = nullptr;
-  getSetInfo->MaterializeForSet = nullptr;
-  GetSetInfo.setPointer(getSetInfo);
 }
 
 static Optional<ObjCSelector>

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -185,6 +185,15 @@ static FuncDecl *createFuncOrAccessor(ASTContext &ctx, SourceLoc funcLoc,
   }
 }
 
+static void makeComputed(AbstractStorageDecl *storage,
+                         AccessorDecl *getter, AccessorDecl *setter) {
+  assert(getter);
+  AccessorDecl *buffer[] = { getter, setter };
+  auto accessors = llvm::makeArrayRef(buffer).slice(0, setter ? 2 : 1);
+  storage->setAccessors(AbstractStorageDecl::Computed,
+                        SourceLoc(), accessors, SourceLoc());
+}
+
 #ifndef NDEBUG
 static bool verifyNameMapping(MappedTypeNameKind NameMapping,
                               StringRef left, StringRef right) {
@@ -525,8 +534,7 @@ static AccessorDecl *makeEnumRawValueGetter(ClangImporter::Implementation &Impl,
 
   getterDecl->setAccess(AccessLevel::Public);
 
-  rawValueDecl->makeComputed(SourceLoc(), getterDecl, nullptr, nullptr,
-                             SourceLoc());
+  makeComputed(rawValueDecl, getterDecl, nullptr);
 
   // Don't bother synthesizing the body if we've already finished type-checking.
   if (Impl.hasFinishedTypeChecking())
@@ -759,8 +767,7 @@ makeIndirectFieldAccessors(ClangImporter::Implementation &Impl,
                                         importedStructDecl,
                                         importedFieldDecl);
 
-  importedFieldDecl->makeComputed(SourceLoc(), getterDecl, setterDecl, nullptr,
-                                  SourceLoc());
+  makeComputed(importedFieldDecl, getterDecl, setterDecl);
 
   auto containingField = indirectField->chain().front();
   VarDecl *anonymousFieldDecl = nullptr;
@@ -869,8 +876,7 @@ makeUnionFieldAccessors(ClangImporter::Implementation &Impl,
                                         importedUnionDecl,
                                         importedFieldDecl);
 
-  importedFieldDecl->makeComputed(SourceLoc(), getterDecl, setterDecl, nullptr,
-                                  SourceLoc());
+  makeComputed(importedFieldDecl, getterDecl, setterDecl);
 
   // Don't bother synthesizing the body if we've already finished type-checking.
   if (Impl.hasFinishedTypeChecking())
@@ -1026,11 +1032,7 @@ makeBitFieldAccessors(ClangImporter::Implementation &Impl,
                                         importedFieldDecl,
                                         cSetterDecl);
 
-  importedFieldDecl->makeComputed(SourceLoc(),
-                                  getterDecl,
-                                  setterDecl,
-                                  nullptr,
-                                  SourceLoc());
+  makeComputed(importedFieldDecl, getterDecl, setterDecl);
 
   // Don't bother synthesizing the body if we've already finished type-checking.
   if (Impl.hasFinishedTypeChecking())
@@ -1552,8 +1554,7 @@ static void makeStructRawValuedWithBridge(
   // Create the getter for the computed value variable.
   auto computedVarGetter = makeStructRawValueGetter(
       Impl, structDecl, computedVar, storedVar);
-  computedVar->makeComputed(SourceLoc(), computedVarGetter, nullptr, nullptr,
-                            SourceLoc());
+  makeComputed(computedVar, computedVarGetter, nullptr);
 
   // Create a pattern binding to describe the variable.
   Pattern *computedVarPattern = createTypedNamedPattern(computedVar);
@@ -1882,10 +1883,7 @@ static bool addErrorDomain(NominalTypeDecl *swiftDecl,
 
   swiftDecl->addMember(errorDomainPropertyDecl);
   swiftDecl->addMember(getterDecl);
-  errorDomainPropertyDecl->makeComputed(SourceLoc(), getterDecl,
-                                        /*Set=*/nullptr,
-                                        /*MaterializeForSet=*/nullptr,
-                                        SourceLoc());
+  makeComputed(errorDomainPropertyDecl, getterDecl, nullptr);
 
   getterDecl->setImplicit();
   getterDecl->setStatic(isStatic);
@@ -4910,7 +4908,7 @@ namespace {
       // Turn this into a computed property.
       // FIXME: Fake locations for '{' and '}'?
       result->setIsSetterMutating(false);
-      result->makeComputed(SourceLoc(), getter, setter, nullptr, SourceLoc());
+      makeComputed(result, getter, setter);
       addObjCAttribute(result, Impl.importIdentifier(decl->getIdentifier()));
       applyPropertyOwnership(result, decl->getPropertyAttributesAsWritten());
 
@@ -5961,8 +5959,7 @@ SwiftDeclConverter::getImplicitProperty(ImportedName importedName,
   if (swiftSetter) property->setIsSetterMutating(swiftSetter->isMutating());
 
   // Make this a computed property.
-  property->makeComputed(SourceLoc(), swiftGetter, swiftSetter, nullptr,
-                         SourceLoc());
+  makeComputed(property, swiftGetter, swiftSetter);
 
   // Make the property the alternate declaration for the getter.
   Impl.addAlternateDecl(swiftGetter, property);
@@ -6719,8 +6716,7 @@ SwiftDeclConverter::importSubscript(Decl *decl,
   subscript->setGenericEnvironment(dc->getGenericEnvironmentOfContext());
 
   subscript->setIsSetterMutating(false);
-  subscript->makeComputed(SourceLoc(), getterThunk, setterThunk, nullptr,
-                          SourceLoc());
+  makeComputed(subscript, getterThunk, setterThunk);
   auto indicesType = bodyParams->getType(C);
 
   AnyFunctionType *fnType;
@@ -8397,7 +8393,7 @@ ClangImporter::Implementation::createConstant(Identifier name, DeclContext *dc,
   func->getAttrs().add(new (C) TransparentAttr(/*implicit*/ true));
   
   // Set the function up as the getter.
-  var->makeComputed(SourceLoc(), func, nullptr, nullptr, SourceLoc());
+  makeComputed(var, func, nullptr);
 
   // Register this thunk as an external definition.
   registerExternalDecl(func);

--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -1612,8 +1612,7 @@ class FindAllSubDecls : public SourceEntityWalker {
       return false;
 
     if (auto ASD = dyn_cast<AbstractStorageDecl>(D)) {
-      llvm::SmallVector<Decl *, 6> accessors;
-      ASD->getAllAccessorFunctions(accessors);
+      auto accessors = ASD->getAllAccessorFunctions();
       Found.insert(accessors.begin(), accessors.end());
     }
     return true;

--- a/lib/Sema/CodeSynthesis.cpp
+++ b/lib/Sema/CodeSynthesis.cpp
@@ -396,8 +396,9 @@ createMaterializeForSetPrototype(AbstractStorageDecl *storage,
 static void convertStoredVarInProtocolToComputed(VarDecl *VD, TypeChecker &TC) {
   auto *Get = createGetterPrototype(VD, TC);
   
-  // Okay, we have both the getter and setter.  Set them in VD.
-  VD->makeComputed(SourceLoc(), Get, nullptr, nullptr, SourceLoc());
+  // Okay, we have the getter; make the VD computed.
+  VD->setAccessors(AbstractStorageDecl::Computed,
+                   SourceLoc(), {Get}, SourceLoc());
   
   // We've added some members to our containing class, add them to the members
   // list.
@@ -817,7 +818,7 @@ synthesizeSetterForMutableAddressedStorage(AbstractStorageDecl *storage,
                                            TypeChecker &TC) {
   auto setter = storage->getSetter();
   assert(setter);
-  assert(!storage->getSetter()->getBody());
+  if (setter->getBody()) return;
   assert(storage->getStorageKind() ==
            AbstractStorageDecl::ComputedWithMutableAddress);
 
@@ -855,7 +856,7 @@ static void convertNSManagedStoredVarToComputed(VarDecl *VD, TypeChecker &TC) {
   auto *Set = createSetterPrototype(VD, SetValueDecl, TC);
 
   // Okay, we have both the getter and setter.  Set them in VD.
-  VD->makeComputed(SourceLoc(), Get, Set, nullptr, SourceLoc());
+  VD->setAccessors(VarDecl::Computed, SourceLoc(), {Get, Set}, SourceLoc());
 
   // We've added some members to our containing class/extension, add them to
   // the members list.
@@ -898,22 +899,26 @@ void TypeChecker::synthesizeWitnessAccessorsForStorage(
 /// (trivial) getter and the setter, which calls these.
 void swift::synthesizeObservingAccessors(VarDecl *VD, TypeChecker &TC) {
   assert(VD->hasObservers());
-  assert(VD->getGetter() && VD->getSetter() &&
-         !VD->getGetter()->hasBody() && !VD->getSetter()->hasBody() &&
-         "willSet/didSet var already has a getter or setter");
+  assert(VD->getGetter() && VD->getSetter());
   
   auto &Ctx = VD->getASTContext();
   SourceLoc Loc = VD->getLoc();
+
+  // We have to be paranoid about the accessors already having bodies
+  // because there might be an (invalid) existing definition.
   
   // The getter is always trivial: just perform a (direct!) load of storage, or
   // a call of a superclass getter if this is an override.
   auto *Get = VD->getGetter();
-  synthesizeTrivialGetter(Get, VD, TC);
-  maybeMarkTransparent(Get, VD, TC);
+  if (!Get->hasBody()) {
+    synthesizeTrivialGetter(Get, VD, TC);
+    maybeMarkTransparent(Get, VD, TC);
+  }
 
   // Okay, the getter is done, create the setter now.  Start by finding the
   // decls for 'self' and 'value'.
   auto *Set = VD->getSetter();
+  if (Set->hasBody()) return;
   auto *SelfDecl = Set->getImplicitSelfDecl();
   VarDecl *ValueDecl = Set->getParameterLists().back()->get(0);
 
@@ -1690,8 +1695,11 @@ void swift::maybeAddAccessorsToVariable(VarDecl *var, TypeChecker &TC) {
         setter->setSelfAccessKind(SelfAccessKind::NonMutating);
         setter->setAccess(var->getFormalAccess());
       }
-      
-      var->makeComputed(SourceLoc(), getter, setter, nullptr, SourceLoc());
+
+      SmallVector<AccessorDecl*, 2> accessors;
+      accessors.push_back(getter);
+      if (setter) accessors.push_back(setter);
+      var->setAccessors(VarDecl::Computed, SourceLoc(), accessors, SourceLoc());
       
       // Save the conformance and 'value' decl for later type checking.
       behavior->Conformance = conformance;
@@ -1796,12 +1804,17 @@ void swift::maybeAddAccessorsToVariable(VarDecl *var, TypeChecker &TC) {
     auto *setter = createSetterPrototype(var, newValueParam, TC);
 
     AccessorDecl *materializeForSet = nullptr;
-    if (dc->getAsNominalTypeOrNominalTypeExtensionContext())
+    if (dc->getAsNominalTypeOrNominalTypeExtensionContext()) {
       materializeForSet = createMaterializeForSetPrototype(var,
                                                            getter, setter,
                                                            TC);
+    }
 
-    var->makeComputed(SourceLoc(), getter, setter, materializeForSet, SourceLoc());
+    SmallVector<AccessorDecl *, 3> accessors;
+    accessors.push_back(getter);
+    accessors.push_back(setter);
+    if (materializeForSet) accessors.push_back(materializeForSet);
+    var->setAccessors(VarDecl::Computed, SourceLoc(), accessors, SourceLoc());
 
     addMemberToContextIfNeeded(getter, dc, var);
     addMemberToContextIfNeeded(setter, dc, getter);

--- a/lib/Sema/DerivedConformanceEquatableHashable.cpp
+++ b/lib/Sema/DerivedConformanceEquatableHashable.cpp
@@ -1101,8 +1101,8 @@ static ValueDecl *deriveHashable_hashValue(DerivedConformance &derived) {
   hashValueDecl->setImplicit();
   hashValueDecl->setInterfaceType(intType);
   hashValueDecl->setValidationStarted();
-  hashValueDecl->makeComputed(SourceLoc(), getterDecl,
-                              nullptr, nullptr, SourceLoc());
+  hashValueDecl->setAccessors(VarDecl::Computed, SourceLoc(), {getterDecl},
+                              SourceLoc());
   hashValueDecl->copyFormalAccessFrom(derived.Nominal,
                                       /*sourceIsParentContext*/ true);
 

--- a/lib/Sema/DerivedConformances.cpp
+++ b/lib/Sema/DerivedConformances.cpp
@@ -272,7 +272,8 @@ addGetterToReadOnlyDerivedProperty(TypeChecker &tc,
   auto getter =
     declareDerivedPropertyGetter(tc, property, propertyContextType);
 
-  property->makeComputed(SourceLoc(), getter, nullptr, nullptr, SourceLoc());
+  property->setAccessors(VarDecl::Computed,
+                         SourceLoc(), {getter}, SourceLoc());
 
   return getter;
 }

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4307,7 +4307,8 @@ public:
 
     // If this is a willSet/didSet property, synthesize the getter and setter
     // decl.
-    if (VD->hasObservers() && !VD->getGetter()->getBody())
+    if (VD->hasObservers() &&
+        (!VD->getGetter()->getBody() || !VD->getSetter()->getBody()))
       synthesizeObservingAccessors(VD, TC);
 
     // If this is a get+mutableAddress property, synthesize the setter body.

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -483,10 +483,6 @@ namespace {
   struct Accessors {
     StorageKind Kind;
     SmallVector<AccessorDecl *, 8> Decls;
-
-    void add(AccessorDecl *accessor) {
-      if (accessor) Decls.push_back(accessor);
-    }
   };
 } // end anonymous namespace
 
@@ -510,35 +506,9 @@ static StorageKind getRawStorageKind(AbstractStorageDecl::StorageKindTy kind) {
 static Accessors getAccessors(const AbstractStorageDecl *storage) {
   Accessors accessors;
   accessors.Kind = getRawStorageKind(storage->getStorageKind());
-  switch (auto storageKind = storage->getStorageKind()) {
-  case AbstractStorageDecl::Stored:
-    return accessors;
-
-  case AbstractStorageDecl::Addressed:
-  case AbstractStorageDecl::AddressedWithTrivialAccessors:
-  case AbstractStorageDecl::ComputedWithMutableAddress:
-    accessors.add(storage->getAddressor());
-    accessors.add(storage->getMutableAddressor());
-    if (storageKind == AbstractStorageDecl::Addressed)
-      return accessors;
-    goto getset;
-
-  case AbstractStorageDecl::StoredWithObservers:
-  case AbstractStorageDecl::InheritedWithObservers:
-  case AbstractStorageDecl::AddressedWithObservers:
-    accessors.add(storage->getWillSetFunc());
-    accessors.add(storage->getDidSetFunc());
-    goto getset;
-
-  case AbstractStorageDecl::StoredWithTrivialAccessors:
-  case AbstractStorageDecl::Computed:
-  getset:
-    accessors.add(storage->getGetter());
-    accessors.add(storage->getSetter());
-    accessors.add(storage->getMaterializeForSetFunc());
-    return accessors;
-  }
-  llvm_unreachable("bad storage kind");
+  auto decls = storage->getAllAccessorFunctions();
+  accessors.Decls.append(decls.begin(), decls.end());
+  return accessors;
 }
 
 DeclID Serializer::addLocalDeclContextRef(const DeclContext *DC) {

--- a/lib/TBDGen/TBDGen.cpp
+++ b/lib/TBDGen/TBDGen.cpp
@@ -164,10 +164,8 @@ void TBDGenVisitor::visitAccessorDecl(AccessorDecl *AD) {
 
 void TBDGenVisitor::visitAbstractStorageDecl(AbstractStorageDecl *ASD) {
   // Explicitly look at each accessor here: see visitAccessorDecl.
-  SmallVector<Decl *, 8> accessors;
-  ASD->getAllAccessorFunctions(accessors);
-  for (auto accessor : accessors) {
-    visitAbstractFunctionDecl(cast<AbstractFunctionDecl>(accessor));
+  for (auto accessor : ASD->getAllAccessorFunctions()) {
+    visitAbstractFunctionDecl(accessor);
   }
 }
 

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.helper.response
@@ -202,13 +202,14 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FooHelperUnnamedEnumeratorA1",
     key.offset: 123,
     key.length: 45,
     key.typename: "Int",
     key.nameoffset: 127,
     key.namelength: 28,
+    key.bodyoffset: 162,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 116,
@@ -220,13 +221,14 @@ public var FooHelperUnnamedEnumeratorA2: Int { get }
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FooHelperUnnamedEnumeratorA2",
     key.offset: 176,
     key.length: 45,
     key.typename: "Int",
     key.nameoffset: 180,
     key.namelength: 28,
+    key.bodyoffset: 215,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 169,

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.response
@@ -4367,13 +4367,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum1X",
     key.offset: 405,
     key.length: 31,
     key.typename: "FooEnum1",
     key.nameoffset: 409,
     key.namelength: 9,
+    key.bodyoffset: 430,
+    key.bodylength: 5,
     key.docoffset: 371,
     key.doclength: 27,
     key.attributes: [
@@ -4499,13 +4500,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum2X",
     key.offset: 607,
     key.length: 31,
     key.typename: "FooEnum2",
     key.nameoffset: 611,
     key.namelength: 9,
+    key.bodyoffset: 632,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 600,
@@ -4517,13 +4519,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum2Y",
     key.offset: 646,
     key.length: 31,
     key.typename: "FooEnum2",
     key.nameoffset: 650,
     key.namelength: 9,
+    key.bodyoffset: 671,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 639,
@@ -4647,13 +4650,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum3X",
     key.offset: 847,
     key.length: 31,
     key.typename: "FooEnum3",
     key.nameoffset: 851,
     key.namelength: 9,
+    key.bodyoffset: 872,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 840,
@@ -4665,13 +4669,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FooEnum3Y",
     key.offset: 886,
     key.length: 31,
     key.typename: "FooEnum3",
     key.nameoffset: 890,
     key.namelength: 9,
+    key.bodyoffset: 911,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 879,
@@ -4830,13 +4835,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.static,
         key.accessibility: source.lang.swift.accessibility.public,
-        key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "enableMince",
         key.offset: 1283,
         key.length: 49,
         key.typename: "FooRuncingOptions",
         key.nameoffset: 1294,
         key.namelength: 11,
+        key.bodyoffset: 1326,
+        key.bodylength: 5,
         key.attributes: [
           {
             key.offset: 1276,
@@ -4848,13 +4854,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.static,
         key.accessibility: source.lang.swift.accessibility.public,
-        key.setter_accessibility: source.lang.swift.accessibility.public,
         key.name: "enableQuince",
         key.offset: 1345,
         key.length: 50,
         key.typename: "FooRuncingOptions",
         key.nameoffset: 1356,
         key.namelength: 12,
+        key.bodyoffset: 1389,
+        key.bodylength: 5,
         key.attributes: [
           {
             key.offset: 1338,
@@ -5985,13 +5992,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
       {
         key.kind: source.lang.swift.decl.var.instance,
         key.accessibility: source.lang.swift.accessibility.open,
-        key.setter_accessibility: source.lang.swift.accessibility.open,
         key.name: "fooProperty3",
         key.offset: 4301,
         key.length: 31,
         key.typename: "Int32",
         key.nameoffset: 4305,
         key.namelength: 12,
+        key.bodyoffset: 4326,
+        key.bodylength: 5,
         key.attributes: [
           {
             key.offset: 4296,
@@ -6132,13 +6140,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_1",
     key.offset: 4721,
     key.length: 30,
     key.typename: "Int32",
     key.nameoffset: 4725,
     key.namelength: 11,
+    key.bodyoffset: 4745,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 4714,
@@ -6150,13 +6159,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_2",
     key.offset: 4759,
     key.length: 30,
     key.typename: "Int32",
     key.nameoffset: 4763,
     key.namelength: 11,
+    key.bodyoffset: 4783,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 4752,
@@ -6168,13 +6178,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_3",
     key.offset: 4797,
     key.length: 30,
     key.typename: "Int32",
     key.nameoffset: 4801,
     key.namelength: 11,
+    key.bodyoffset: 4821,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 4790,
@@ -6186,13 +6197,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_4",
     key.offset: 4874,
     key.length: 31,
     key.typename: "UInt32",
     key.nameoffset: 4878,
     key.namelength: 11,
+    key.bodyoffset: 4899,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 4867,
@@ -6204,13 +6216,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_5",
     key.offset: 4913,
     key.length: 31,
     key.typename: "UInt64",
     key.nameoffset: 4917,
     key.namelength: 11,
+    key.bodyoffset: 4938,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 4906,
@@ -6222,13 +6235,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_6",
     key.offset: 4952,
     key.length: 38,
     key.typename: "typedef_int_t",
     key.nameoffset: 4956,
     key.namelength: 11,
+    key.bodyoffset: 4984,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 4945,
@@ -6240,13 +6254,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_7",
     key.offset: 4998,
     key.length: 38,
     key.typename: "typedef_int_t",
     key.nameoffset: 5002,
     key.namelength: 11,
+    key.bodyoffset: 5030,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 4991,
@@ -6258,13 +6273,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_8",
     key.offset: 5044,
     key.length: 29,
     key.typename: "Int8",
     key.nameoffset: 5048,
     key.namelength: 11,
+    key.bodyoffset: 5067,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 5037,
@@ -6276,13 +6292,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_9",
     key.offset: 5081,
     key.length: 30,
     key.typename: "Int32",
     key.nameoffset: 5085,
     key.namelength: 11,
+    key.bodyoffset: 5105,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 5074,
@@ -6294,13 +6311,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_10",
     key.offset: 5119,
     key.length: 31,
     key.typename: "Int16",
     key.nameoffset: 5123,
     key.namelength: 12,
+    key.bodyoffset: 5144,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 5112,
@@ -6312,13 +6330,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_11",
     key.offset: 5158,
     key.length: 29,
     key.typename: "Int",
     key.nameoffset: 5162,
     key.namelength: 12,
+    key.bodyoffset: 5181,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 5151,
@@ -6330,13 +6349,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_OR",
     key.offset: 5195,
     key.length: 31,
     key.typename: "Int32",
     key.nameoffset: 5199,
     key.namelength: 12,
+    key.bodyoffset: 5220,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 5188,
@@ -6348,13 +6368,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_AND",
     key.offset: 5234,
     key.length: 32,
     key.typename: "Int32",
     key.nameoffset: 5238,
     key.namelength: 13,
+    key.bodyoffset: 5260,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 5227,
@@ -6366,13 +6387,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_BITWIDTH",
     key.offset: 5274,
     key.length: 38,
     key.typename: "UInt64",
     key.nameoffset: 5278,
     key.namelength: 18,
+    key.bodyoffset: 5306,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 5267,
@@ -6384,13 +6406,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_SIGNED",
     key.offset: 5320,
     key.length: 36,
     key.typename: "UInt32",
     key.nameoffset: 5324,
     key.namelength: 16,
+    key.bodyoffset: 5350,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 5313,
@@ -6402,13 +6425,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_REDEF_1",
     key.offset: 5365,
     key.length: 36,
     key.typename: "Int32",
     key.nameoffset: 5369,
     key.namelength: 17,
+    key.bodyoffset: 5395,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 5358,
@@ -6420,13 +6444,14 @@ public class FooOverlayClassDerived : Foo.FooOverlayClassBase {
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FOO_MACRO_REDEF_2",
     key.offset: 5410,
     key.length: 36,
     key.typename: "Int32",
     key.nameoffset: 5414,
     key.namelength: 17,
+    key.bodyoffset: 5440,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 5403,

--- a/test/SourceKit/InterfaceGen/gen_clang_module.swift.sub.response
+++ b/test/SourceKit/InterfaceGen/gen_clang_module.swift.sub.response
@@ -469,13 +469,14 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubEnum1X",
     key.offset: 273,
     key.length: 37,
     key.typename: "FooSubEnum1",
     key.nameoffset: 277,
     key.namelength: 12,
+    key.bodyoffset: 304,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 266,
@@ -487,13 +488,14 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubEnum1Y",
     key.offset: 318,
     key.length: 37,
     key.typename: "FooSubEnum1",
     key.nameoffset: 322,
     key.namelength: 12,
+    key.bodyoffset: 349,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 311,
@@ -505,13 +507,14 @@ public var FooSubUnnamedEnumeratorA1: Int { get }
   {
     key.kind: source.lang.swift.decl.var.global,
     key.accessibility: source.lang.swift.accessibility.public,
-    key.setter_accessibility: source.lang.swift.accessibility.public,
     key.name: "FooSubUnnamedEnumeratorA1",
     key.offset: 364,
     key.length: 42,
     key.typename: "Int",
     key.nameoffset: 368,
     key.namelength: 25,
+    key.bodyoffset: 400,
+    key.bodylength: 5,
     key.attributes: [
       {
         key.offset: 357,

--- a/test/decl/subscript/addressors.swift
+++ b/test/decl/subscript/addressors.swift
@@ -75,7 +75,7 @@ struct AddressorAndGet {
       return base
     }
     get {
-      return base.get()
+      return base.get() // expected-error {{value of type 'UnsafePointer<Int>' has no member 'get'}}
     }
   }
 }
@@ -198,7 +198,7 @@ struct RedundantAddressors2 {
 struct RedundantAddressors3 {
   var owner : Builtin.NativeObject
   subscript(index: Int) -> Int {
-    addressWithNativeOwner { return someValidAddress() } // expected-note {{previous definition of addressor is here}}
+    addressWithNativeOwner { return (someValidAddress(), owner) } // expected-note {{previous definition of addressor is here}}
     addressWithPinnedNativeOwner { return (someValidAddress(), owner)  } // expected-error {{subscript already has a addressor}}
   }
 }

--- a/test/decl/subscript/subscripting.swift
+++ b/test/decl/subscript/subscripting.swift
@@ -102,16 +102,16 @@ protocol ProtocolGetSet4 {
 }
 
 protocol ProtocolWillSetDidSet1 {
-  subscript(i: Int) -> Int { willSet } // expected-error {{expected get or set in a protocol property}}
+  subscript(i: Int) -> Int { willSet } // expected-error {{expected get or set in a protocol property}} expected-error {{subscript declarations must have a getter}}
 }
 protocol ProtocolWillSetDidSet2 {
-  subscript(i: Int) -> Int { didSet } // expected-error {{expected get or set in a protocol property}}
+  subscript(i: Int) -> Int { didSet } // expected-error {{expected get or set in a protocol property}} expected-error {{subscript declarations must have a getter}}
 }
 protocol ProtocolWillSetDidSet3 {
-  subscript(i: Int) -> Int { willSet didSet } // expected-error {{expected get or set in a protocol property}}
+  subscript(i: Int) -> Int { willSet didSet } // expected-error 2 {{expected get or set in a protocol property}} expected-error {{subscript declarations must have a getter}}
 }
 protocol ProtocolWillSetDidSet4 {
-  subscript(i: Int) -> Int { didSet willSet } // expected-error {{expected get or set in a protocol property}}
+  subscript(i: Int) -> Int { didSet willSet } // expected-error 2 {{expected get or set in a protocol property}} expected-error {{subscript declarations must have a getter}}
 }
 
 class DidSetInSubscript {

--- a/test/decl/var/properties.swift
+++ b/test/decl/var/properties.swift
@@ -284,7 +284,7 @@ var duplicateAccessors1: X {
     return _x
   }
   set { // expected-note {{previous definition of setter is here}}
-    _x = value
+    _x = newValue
   }
   get { // expected-error {{duplicate definition of getter}}
     return _x
@@ -327,10 +327,10 @@ var extraTokensInAccessorBlock4: X {
 var extraTokensInAccessorBlock5: X {
   set blah wibble // expected-error{{expected '{' to start setter definition}}
 }
-var extraTokensInAccessorBlock6: X {
+var extraTokensInAccessorBlock6: X { // expected-error{{non-member observing properties require an initializer}}
   willSet blah wibble // expected-error{{expected '{' to start willSet definition}}
 }
-var extraTokensInAccessorBlock7: X {
+var extraTokensInAccessorBlock7: X { // expected-error{{non-member observing properties require an initializer}}
   didSet blah wibble // expected-error{{expected '{' to start didSet definition}}
 }
 
@@ -737,7 +737,7 @@ struct WillSetDidSetProperties {
       markUsed("woot")
     }
     set { // expected-error {{willSet variable must not also have a set specifier}}
-      return 4
+      return 4 // expected-error {{unexpected non-void return value in void function}}
     }
   }
 
@@ -875,10 +875,10 @@ protocol ProtocolWillSetDidSet2 {
   var a: Int { didSet } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} expected-error {{expected get or set in a protocol property}}
 }
 protocol ProtocolWillSetDidSet3 {
-  var a: Int { willSet didSet } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} expected-error {{expected get or set in a protocol property}}
+  var a: Int { willSet didSet } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} expected-error 2 {{expected get or set in a protocol property}}
 }
 protocol ProtocolWillSetDidSet4 {
-  var a: Int { didSet willSet } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} expected-error {{expected get or set in a protocol property}}
+  var a: Int { didSet willSet } // expected-error {{property in protocol must have explicit { get } or { get set } specifier}} expected-error 2 {{expected get or set in a protocol property}}
 }
 
 var globalDidsetWillSet: Int {  // expected-error {{non-member observing properties require an initializer}}


### PR DESCRIPTION
Only not NFC because it's detectable by source tools.