### PR TITLE
[Sema] Warn about redundant ': Any' conformances

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1724,6 +1724,11 @@ WARNING(redundant_conformance_adhoc_conditional,none,
 NOTE(redundant_conformance_witness_ignored,none,
      "%0 %1 will not be used to satisfy the conformance to %2",
      (DescriptiveDeclKind, DeclName, DeclName))
+WARNING(redundant_conformance_warning,none,
+        "redundant conformance of %0 to %1", (Type, Type))
+NOTE(all_types_implicitly_conform_to,none,
+     "all types implicitly conform to %0", (Type))
+
 
 // "Near matches"
 WARNING(req_near_match,none,

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -363,8 +363,11 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
   // Retrieve the location of the start of the inheritance clause.
   auto getStartLocOfInheritanceClause = [&] {
     if (auto genericTypeDecl = dyn_cast<GenericTypeDecl>(decl)) {
-      if (auto genericParams = genericTypeDecl->getGenericParams())
-        return genericParams->getSourceRange().End;
+      // Get the end location of the generic parameters, except for protocols
+      // which don't have explicit generic parameters.
+      if (!isa<ProtocolDecl>(decl))
+        if (auto genericParams = genericTypeDecl->getGenericParams())
+          return genericParams->getSourceRange().End;
 
       return genericTypeDecl->getNameLoc();
     }
@@ -373,7 +376,7 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
       return typeDecl->getNameLoc();
 
     if (auto ext = dyn_cast<ExtensionDecl>(decl))
-      return ext->getSourceRange().End;
+      return ext->getExtendedTypeLoc().getLoc();
 
     return SourceLoc();
   };

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -51,26 +51,73 @@ protocol FormattedPrintable : CustomStringConvertible {
   func print(format: TestFormat)
 }
 
+// expected-warning@+2 {{redundant conformance of 'X0' to 'Any'}} {{13-18=}}
+// expected-note@+1 {{all types implicitly conform to 'Any'}}
 struct X0 : Any, CustomStringConvertible {
   func print() {}
 }
 
+// expected-warning@+2 {{redundant conformance of 'X1' to 'Any'}} {{12-17=}}
+// expected-note@+1 {{all types implicitly conform to 'Any'}}
 class X1 : Any, CustomStringConvertible {
   func print() {}
 }
 
+// expected-warning@+2 {{redundant conformance of 'X2' to 'Any'}} {{8-14=}}
+// expected-note@+1 {{all types implicitly conform to 'Any'}}
 enum X2 : Any { }
 
 extension X2 : CustomStringConvertible {
   func print() {}
 }
 
+struct X5 {
+  func print() {}
+}
+extension X5 : Any {} // expected-warning {{redundant conformance of 'X5' to 'Any'}} {{13-19=}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+extension X5 : Any, CustomStringConvertible {} // expected-warning {{redundant conformance of 'X5' to 'Any'}} {{16-21=}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+struct X6 {
+  func print() {}
+}
+extension X6 : CustomStringConvertible, Any {} // expected-warning {{redundant conformance of 'X6' to 'Any'}} {{39-44=}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+struct X7<T> : Any {} // expected-warning {{redundant conformance of 'X7<T>' to 'Any'}} {{13-19=}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+struct X8<T> {
+  func print() {}
+}
+extension X8 : Any where T : CustomStringConvertible {} // expected-warning {{redundant conformance of 'X8<T>' to 'Any'}} {{13-19=}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+typealias AnyAlias = Any
+class X9 : AnyAlias {} // expected-warning {{redundant conformance of 'X9' to 'AnyAlias' (aka 'Any')}} {{9-20=}}
+// expected-note@-1 {{all types implicitly conform to 'AnyAlias' (aka 'Any')}}
+
+struct X10 : Any & Any {} // expected-warning {{redundant conformance of 'X10' to 'Any'}} {{11-23=}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+// FIX-ME(SR-8009): Handle these cases.
+protocol P5 : Any {}
+func foo<T : Any>(_ x: T) {}
+
 // Explicit conformance checks (unsuccessful)
 
+// expected-warning@+2 {{redundant conformance of 'NotPrintableS' to 'Any'}} {{24-29=}}
+// expected-note@+1 {{all types implicitly conform to 'Any'}}
 struct NotPrintableS : Any, CustomStringConvertible {} // expected-error{{type 'NotPrintableS' does not conform to protocol 'CustomStringConvertible'}}
 
+// expected-warning@+2 {{redundant conformance of 'NotPrintableC' to 'Any'}} {{46-51=}}
+// expected-note@+1 {{all types implicitly conform to 'Any'}}
 class NotPrintableC : CustomStringConvertible, Any {} // expected-error{{type 'NotPrintableC' does not conform to protocol 'CustomStringConvertible'}}
 
+// expected-warning@+2 {{redundant conformance of 'NotPrintableO' to 'Any'}} {{22-27=}}
+// expected-note@+1 {{all types implicitly conform to 'Any'}}
 enum NotPrintableO : Any, CustomStringConvertible {} // expected-error{{type 'NotPrintableO' does not conform to protocol 'CustomStringConvertible'}}
 
 struct NotFormattedPrintable : FormattedPrintable { // expected-error{{type 'NotFormattedPrintable' does not conform to protocol 'CustomStringConvertible'}}


### PR DESCRIPTION
This is the first half of the implementation to warn about `: Any` conformances and constraints (I decided to split it up as the implementation for the removal fix-its for constraints in the generic signature builder is proving to be more involved than I thought it would).

In this PR is the logic that deals with conformances. Note that we avoid dealing with protocols and generic placeholders in the added logic, as that will be covered by a follow-up PR that diagnoses redundant `: Any` constraints in the generic signature builder (and `checkInheritanceClause` can get called more than once when dealing with generic signatures, which would incorrectly lead to multiple warnings being emitted in that case).

Resolves [SR-8008](https://bugs.swift.org/browse/SR-8008).
