### PR TITLE
[string] ASCII/UTF-8 fast paths for String.init(decoding:as:)

### DIFF
--- a/stdlib/public/core/CString.swift
+++ b/stdlib/public/core/CString.swift
@@ -174,7 +174,7 @@ internal func _decodeValidCString(
   return cString.withMemoryRebound(to: UInt8.self, capacity: len) {
     (ptr: UnsafePointer<UInt8>) -> String in
     let bufPtr = UnsafeBufferPointer(start: ptr, count: len)
-    return String._fromWellFormedUTF8CodeUnitSequence(bufPtr, repair: repair)
+    return String._fromWellFormedUTF8(bufPtr, repair: repair)
   }
 }
 
@@ -183,7 +183,7 @@ internal func _decodeValidCString(
 ) -> String {
   let len = UTF8._nullCodeUnitOffset(in: cString)
   let bufPtr = UnsafeBufferPointer(start: cString, count: len)
-  return String._fromWellFormedUTF8CodeUnitSequence(bufPtr, repair: repair)
+  return String._fromWellFormedUTF8(bufPtr, repair: repair)
 }
 
 internal func _decodeCString(
@@ -193,7 +193,7 @@ internal func _decodeCString(
   return cString.withMemoryRebound(to: UInt8.self, capacity: len) {
     (ptr: UnsafePointer<UInt8>) -> String? in
     let bufPtr = UnsafeBufferPointer(start: ptr, count: len)
-    return String._fromUTF8CodeUnitSequence(bufPtr, repair: repair)
+    return String._fromUTF8(bufPtr, repair: repair)
   }
 }
 
@@ -202,7 +202,7 @@ internal func _decodeCString(
 ) -> String? {
   let len = UTF8._nullCodeUnitOffset(in: cString)
   let bufPtr = UnsafeBufferPointer(start: cString, count: len)
-  return String._fromUTF8CodeUnitSequence(bufPtr, repair: repair)
+  return String._fromUTF8(bufPtr, repair: repair)
 }
 
 /// Creates a new string by copying the null-terminated data referenced by

--- a/stdlib/public/core/InputStream.swift
+++ b/stdlib/public/core/InputStream.swift
@@ -64,7 +64,7 @@ public func readLine(strippingNewline: Bool = true) -> String? {
       }
     }
   }
-  let result = String._fromUTF8CodeUnitSequence(
+  let result = String._fromUTF8(
     UnsafeBufferPointer(start: linePtr, count: readBytes),
     repair: true)!
   _stdlib_free(linePtr)

--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -272,7 +272,7 @@ public struct StaticString
       if isASCII {
         return String._fromASCII(buffer)
       } else {
-        return String._fromWellFormedUTF8CodeUnitSequence(buffer)
+        return String._fromWellFormedUTF8(buffer)
       }
     }
   }


### PR DESCRIPTION
Add some fast paths to String.init(decoding:as:) for inputs of
contiguously stored UTF-8 code units. Dramatically speeds up creation
when the String happens to be ASCII and we can form more small
strings.
