### PR TITLE
[AutoDiff] Update @differentiable attribute, refactor `lookupFuncDecl` method.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1439,13 +1439,7 @@ ERROR(attr_implements_expected_member_name,PointsToFirstBadToken,
 // SWIFT_ENABLE_TENSORFLOW
 // differentiable
 ERROR(attr_differentiable_expected_function_name,PointsToFirstBadToken,
-      "expected a qualified function to differentiate", ())
-
-ERROR(attr_differentiable_missing_lsquare,PointsToFirstBadToken,
-      "missing '[' for parameter index list", ())
-
-ERROR(attr_differentiable_missing_rsquare,PointsToFirstBadToken,
-      "missing ']' for parameter index list", ())
+      "expected a qualified %0 function", (StringRef))
 
 ERROR(attr_differentiable_expected_parameter_list,PointsToFirstBadToken,
       "expected a list of parameters to differentiate with respect to, e.g. (.0, w, b)", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2439,8 +2439,8 @@ ERROR(differentiable_attr_forward_mode_unsupported,none,
       "forward-mode automatic differentiation is not supported yet", ())
 ERROR(differentiable_attr_invalid_access,none,
       "%select{adjoint|primal}2 %0 is required to either be public or "
-      "@_versioned because the original function %1 is public or @_versioned",
-      (DeclName, DeclName, bool))
+      "@usableFromInline because the original function %1 is public or "
+      "@usableFromInline", (DeclName, DeclName, bool))
 
 ERROR(compiler_evaluable_bad_context,none,
       "@compilerEvaluable functions not allowed here", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2435,6 +2435,9 @@ ERROR(differentiable_attr_ambiguous_function_identifier,none,
       "attribute", (DeclName))
 ERROR(differentiable_attr_forward_mode_unsupported,none,
       "forward-mode automatic differentiation is not supported yet", ())
+ERROR(differentiable_attr_adjoint_invalid_access,none,
+      "adjoint %0 of public or @_versioned function %1 is required to either "
+      "be public or @_versioned", (DeclName, DeclName))
 
 ERROR(compiler_evaluable_bad_context,none,
       "@compilerEvaluable functions not allowed here", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2410,6 +2410,8 @@ ERROR(implements_attr_protocol_not_conformed_to,none,
 // SWIFT_ENABLE_TENSORFLOW
 ERROR(differentiable_attr_no_parameters,none,
       "%0 has no parameters to differentiate with respect to", (DeclName))
+ERROR(differentiable_attr_void_result,none,
+      "cannot differentiate void function %0", (DeclName))
 ERROR(differentiable_attr_primal_overload_not_found,none,
       "%0 does not have expected parameters' type %1", (DeclName, Type))
 ERROR(differentiable_attr_adjoint_overload_not_found,none,
@@ -2428,16 +2430,17 @@ ERROR(differentiable_attr_cannot_diff_wrt_objects_or_existentials,none,
 ERROR(differentiable_attr_function_not_same_type_context,none,
       "%0 is not defined in the current type context", (DeclName))
 ERROR(differentiable_attr_specified_not_function,none,
-      "%0 is not a function to be used as %select{primal|adjoint}1",
+      "%0 is not a function to be used as %select{adjoint|primal}1",
       (DeclName, bool))
 ERROR(differentiable_attr_ambiguous_function_identifier,none,
       "ambiguous or overloaded identifier %0 cannot be used in @differentiable "
       "attribute", (DeclName))
 ERROR(differentiable_attr_forward_mode_unsupported,none,
       "forward-mode automatic differentiation is not supported yet", ())
-ERROR(differentiable_attr_adjoint_invalid_access,none,
-      "adjoint %0 of public or @_versioned function %1 is required to either "
-      "be public or @_versioned", (DeclName, DeclName))
+ERROR(differentiable_attr_invalid_access,none,
+      "%select{adjoint|primal}2 %0 is required to either be public or "
+      "@_versioned because the original function %1 is public or @_versioned",
+      (DeclName, DeclName, bool))
 
 ERROR(compiler_evaluable_bad_context,none,
       "@compilerEvaluable functions not allowed here", ())

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -612,12 +612,13 @@ Parser::parseDifferentiableAttribute(SourceLoc atLoc, SourceLoc loc) {
         parseToken(tok::colon,
           diag::attr_differentiable_expected_colon_after_label, label))
       return true;
-    // Parse the name of the adjoint function.
+    // Parse the name of the function.
+    Diagnostic funcDiag(diag::attr_differentiable_expected_function_name.ID,
+                        { label });
     result.Name =
       parseUnqualifiedDeclName(/*afterDot=*/false, result.Loc,
-                              diag::attr_implements_expected_member_name,
-                              /*allowOperators=*/true,
-                              /*allowZeroArgCompoundNames=*/true);
+                               funcDiag, /*allowOperators=*/true,
+                               /*allowZeroArgCompoundNames=*/true);
     return !result.Name;
   };
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2249,8 +2249,8 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   auto originalParamsTy = originalParams.getInterfaceType(ctx);
 
   // If the original function and the primal/adjoint have different parents, or
-  // if they both have no type context and are in different modules, then
-  // it's an error.
+  // if they both have no type context and are in different modules, then it's
+  // an error.
   // Returns true on error.
   std::function<bool(FuncDecl *)> hasValidTypeContext
     = [&](FuncDecl *func) {
@@ -2268,17 +2268,19 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     return original->getParent() == func->getParent();
   };
 
-  // If the original function is exported (i.e. it is public or @_versioned),
-  // then the primal/adjoint must also be exported.
+  // If the original function is exported (i.e. it is public or
+  // @usableFromInline), then the primal/adjoint must also be exported.
   // Returns true on error.
   using FuncSpecifier = DifferentiableAttr::FunctionSpecifier;
   auto checkAccessControl = [&](FuncDecl *func, FuncSpecifier funcSpec,
                                 bool isPrimal) {
-    auto originalAccess = original->getFormalAccess(/*useDC*/ nullptr,
-                                                    /*respectVersioned*/ true);
+    auto originalAccess =
+      original->getFormalAccess(/*useDC*/ nullptr,
+		                /*treatUsableFromInlineAsPublic*/ true);
     if (originalAccess < AccessLevel::Public) return false;
-    auto funcAccess = func->getFormalAccess(/*useDC*/ nullptr,
-                                            /*respectVersioned*/ true);
+    auto funcAccess =
+      func->getFormalAccess(/*useDC*/ nullptr,
+		            /*treatUsableFromInlineAsPublic*/ true);
     if (funcAccess >= AccessLevel::Public) return false;
     TC.diagnose(funcSpec.Loc.getBaseNameLoc(),
                 diag::differentiable_attr_invalid_access,

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -709,3 +709,107 @@ bool TypeChecker::isCompatibleWithVectorAutoDiff(Type type, DeclContext *DC) {
   }
   return false;
 }
+
+// SWIFT_ENABLE_TENSORFLOW
+// Returns the function declaration corresponding to the given function name and
+// lookup context. If the function declaration cannot be resolved, emits a
+// diagnostic and returns nullptr.
+FuncDecl *
+TypeChecker::lookupFuncDecl(
+    DeclName funcName, SourceLoc funcNameLoc, DeclContext *lookupContext,
+    const std::function<bool(FuncDecl *)> &isValidFuncDecl,
+    const std::function<void()> &overloadDiagnostic,
+    const std::function<void()> &ambiguousDiagnostic,
+    const std::function<void()> &notFunctionDiagnostic,
+    NameLookupOptions lookupOptions,
+    const Optional<std::function<bool(FuncDecl *)>> &hasValidTypeCtx,
+    const Optional<std::function<void()>> &invalidTypeCtxDiagnostic) {
+
+  FuncDecl *resolvedFuncDecl = nullptr;
+
+  // Perform lookup.
+  auto results =
+    lookupUnqualified(lookupContext, funcName, funcNameLoc, lookupOptions);
+
+  // If looking up an operator within a type context, look specifically within
+  // the type context.
+  // This works around the fact that operators cannot be specified with a
+  // qualified name (i.e. only `(+)` works, `Float.(+)` doesn't).
+  if (funcName.isOperator() && lookupContext->isTypeContext()) {
+    auto tmp = lookupMember(lookupContext,
+                            lookupContext->getSelfTypeInContext(), funcName);
+    if (!tmp.empty())
+      results = tmp;
+  }
+  // Note: static methods are omitted from `TypeChecker.lookupUnqualified` in
+  // Swift 3. The code below is a workaround for resolving them.
+  //
+  // This is necessary because the stdlib is compiled with `-swift-version 3`
+  // for Swift 3 compatibility, and floating point types use the
+  // `@differentiable` attribute with static adjoint methods (such as
+  // `_adjointAdd`).
+  else if (lookupContext->getASTContext().isSwiftVersion3()
+           && results.empty() && lookupContext->isTypeContext()) {
+    results = lookupMember(lookupContext, lookupContext->getSelfTypeInContext(),
+                           funcName);
+  }
+
+  // Initialize error flags.
+  bool notAFuncDecl = false;
+  bool wrongTypeContext = false;
+  bool ambiguousFuncDecl = false;
+  bool overloadNotFound = false;
+
+  // Filter lookup results.
+  for (auto choice : results) {
+    auto decl = choice.getValueDecl();
+    if (!decl) continue;
+
+    auto funcDecl = dyn_cast<FuncDecl>(decl);
+    if (!funcDecl) {
+      notAFuncDecl = true;
+      continue;
+    }
+    if (hasValidTypeCtx.hasValue()) {
+      auto hasValidTypeContext = hasValidTypeCtx.getValue();
+      if (!hasValidTypeContext(funcDecl)) {
+        wrongTypeContext = true;
+        continue;
+      }
+    }
+    if (!isValidFuncDecl(funcDecl)) {
+      overloadNotFound = true;
+      continue;
+    }
+    if (resolvedFuncDecl) {
+      ambiguousFuncDecl = true;
+      resolvedFuncDecl = nullptr;
+      break;
+    }
+    resolvedFuncDecl = funcDecl;
+  }
+  // If function declaration could not be resolved, emit the appropriate
+  // diagnostic.
+  if (!resolvedFuncDecl) {
+    if (results.empty()) {
+      diagnose(funcNameLoc, diag::use_unresolved_identifier, funcName,
+               funcName.isOperator());
+    } else if (ambiguousFuncDecl) {
+      ambiguousDiagnostic();
+    } else if (wrongTypeContext) {
+      assert(invalidTypeCtxDiagnostic &&
+             "Type context diagnostic should've been specified");
+      diagnose(funcNameLoc,
+               diag::differentiable_attr_function_not_same_type_context,
+               funcName);
+      invalidTypeCtxDiagnostic.getValue()();
+    } else if (overloadNotFound) {
+      overloadDiagnostic();
+    } else {
+      assert(notAFuncDecl && "Expected 'not a function' error");
+      notFunctionDiagnostic();
+    }
+  }
+
+  return resolvedFuncDecl;
+}

--- a/lib/Sema/TypeCheckExpr.cpp
+++ b/lib/Sema/TypeCheckExpr.cpp
@@ -735,11 +735,12 @@ TypeChecker::lookupFuncDecl(
   // the type context.
   // This works around the fact that operators cannot be specified with a
   // qualified name (i.e. only `(+)` works, `Float.(+)` doesn't).
-  if (funcName.isOperator() && lookupContext->isTypeContext())
+  if (funcName.isOperator() && lookupContext->isTypeContext()) {
     if (auto tmp = lookupMember(lookupContext,
                                 lookupContext->getSelfTypeInContext(),
                                 funcName))
       results = tmp;
+  }
   // Note: static methods are omitted from `TypeChecker.lookupUnqualified` in
   // Swift 3. The code below is a workaround for resolving them.
   //
@@ -747,8 +748,8 @@ TypeChecker::lookupFuncDecl(
   // for Swift 3 compatibility, and floating point types use the
   // `@differentiable` attribute with static adjoint methods (such as
   // `_adjointAdd`).
-  else if (lookupContext->getASTContext().isSwiftVersion3()
-           && results.empty() && lookupContext->isTypeContext()) {
+  else if (lookupContext->getASTContext().isSwiftVersion3() &&
+           results.empty() && lookupContext->isTypeContext()) {
     results = lookupMember(lookupContext, lookupContext->getSelfTypeInContext(),
                            funcName);
   }
@@ -802,10 +803,7 @@ TypeChecker::lookupFuncDecl(
   if (wrongTypeContext) {
     assert(invalidTypeCtxDiagnostic &&
            "Type context diagnostic should've been specified");
-    diagnose(funcNameLoc,
-             diag::differentiable_attr_function_not_same_type_context,
-             funcName);
-    invalidTypeCtxDiagnostic.getValue()();
+    (*invalidTypeCtxDiagnostic)();
     return nullptr;
   }
   if (overloadNotFound) {

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2534,12 +2534,25 @@ public:
   /// We say that a type supports scalar AD when it conforms to
   /// `FloatingPoint`.
   bool isCompatibleWithScalarAutoDiff(Type type, DeclContext *DC);
-  
-  
+
   /// Determines whether the specified type supports vector differentiation.
   /// We say that a type supports vector AD when it conforms to
   /// `VectorNumeric` while its `ScalarElement` supports scalar AD.
   bool isCompatibleWithVectorAutoDiff(Type type, DeclContext *DC);
+
+  /// SWIFT_ENABLE_TENSORFLOW
+  // Returns the function declaration corresponding to the given function name and
+  // lookup context. If the function declaration cannot be resolved, emits a
+  // diagnostic and returns nullptr.
+  FuncDecl *lookupFuncDecl(
+      DeclName funcName, SourceLoc funcNameLoc, DeclContext *lookupContext,
+      const std::function<bool(FuncDecl *)> &isValidFuncDecl,
+      const std::function<void()> &overloadDiagnostic,
+      const std::function<void()> &ambiguousDiagnostic,
+      const std::function<void()> &notFunctionDiagnostic,
+      NameLookupOptions lookupOptions = defaultMemberLookupOptions,
+      const Optional<std::function<bool(FuncDecl *)>> &hasValidTypeCtx = None,
+      const Optional<std::function<void()>> &invalidTypeCtxDiagnostic = None);
 };
 
 /// \brief RAII object that cleans up the given expression if not explicitly

--- a/test/AutoDiff/differentiable_attr_access_control.swift
+++ b/test/AutoDiff/differentiable_attr_access_control.swift
@@ -1,0 +1,32 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+// If the original function is "exported" (public or @_versioned), then its
+// primal/adjoint must also be exported.
+
+// Ok: all public.
+@differentiable(reverse, adjoint: dfoo1(_:primal:seed:))
+public func foo1(_ x: Float) -> Float { return 1 }
+public func dfoo1(_ x: Float, primal: Float, seed: Float) -> Float { return 1 }
+
+// Ok: all internal.
+struct CheckpointsFoo {}
+@differentiable(reverse, primal: pfoo2(_:), adjoint: dfoo2(_:checkpoints:originalValue:seed:))
+func foo2(_ x: Float) -> Float { return 1 }
+func pfoo2(_ x: Float) -> (checkpoints: CheckpointsFoo, originalValue: Float) { return (CheckpointsFoo(), 1) }
+func dfoo2(_ x: Float, checkpoints: CheckpointsFoo, originalValue: Float, seed: Float) -> Float { return 1 }
+
+// Ok: all private.
+@differentiable(reverse, adjoint: dfoo3(_:primal:seed:))
+private func foo3(_ x: Float) -> Float { return 1 }
+private func dfoo3(_ x: Float, primal: Float, seed: Float) -> Float { return 1 }
+
+// Error: adjoint not exported.
+@differentiable(reverse, adjoint: dbar1(_:primal:seed:)) // expected-error {{adjoint 'dbar1(_:primal:seed:)' is required to either be public or @_versioned because the original function 'bar1' is public or @_versioned}}
+public func bar1(_ x: Float) -> Float { return 1 }
+private func dbar1(_ x: Float, primal: Float, seed: Float) -> Float { return 1 }
+
+// Error: primal not exported.
+@differentiable(reverse, primal: pbar2(_:), adjoint: dbar2(_:checkpoints:originalValue:seed:)) // expected-error {{primal 'pbar2' is required to either be public or @_versioned because the original function 'bar2' is public or @_versioned}}
+@_versioned func bar2(_ x: Float) -> Float { return 1 }
+func pbar2(_ x: Float) -> (checkpoints: CheckpointsFoo, originalValue: Float) { return (CheckpointsFoo(), 1) }
+func dbar2(_ x: Float, checkpoints: CheckpointsFoo, originalValue: Float, seed: Float) -> Float { return 1 }

--- a/test/AutoDiff/differentiable_attr_access_control.swift
+++ b/test/AutoDiff/differentiable_attr_access_control.swift
@@ -1,7 +1,7 @@
 // RUN: %target-swift-frontend -typecheck -verify %s
 
-// If the original function is "exported" (public or @_versioned), then its
-// primal/adjoint must also be exported.
+// If the original function is "exported" (public or @usableFromInline), then
+// its primal/adjoint must also be exported.
 
 // Ok: all public.
 @differentiable(reverse, adjoint: dfoo1(_:primal:seed:))
@@ -21,12 +21,12 @@ private func foo3(_ x: Float) -> Float { return 1 }
 private func dfoo3(_ x: Float, primal: Float, seed: Float) -> Float { return 1 }
 
 // Error: adjoint not exported.
-@differentiable(reverse, adjoint: dbar1(_:primal:seed:)) // expected-error {{adjoint 'dbar1(_:primal:seed:)' is required to either be public or @_versioned because the original function 'bar1' is public or @_versioned}}
+@differentiable(reverse, adjoint: dbar1(_:primal:seed:)) // expected-error {{adjoint 'dbar1(_:primal:seed:)' is required to either be public or @usableFromInline because the original function 'bar1' is public or @usableFromInline}}
 public func bar1(_ x: Float) -> Float { return 1 }
 private func dbar1(_ x: Float, primal: Float, seed: Float) -> Float { return 1 }
 
 // Error: primal not exported.
-@differentiable(reverse, primal: pbar2(_:), adjoint: dbar2(_:checkpoints:originalValue:seed:)) // expected-error {{primal 'pbar2' is required to either be public or @_versioned because the original function 'bar2' is public or @_versioned}}
+@differentiable(reverse, primal: pbar2(_:), adjoint: dbar2(_:checkpoints:originalValue:seed:)) // expected-error {{primal 'pbar2' is required to either be public or @usableFromInline because the original function 'bar2' is public or @usableFromInline}}
 @_versioned func bar2(_ x: Float) -> Float { return 1 }
 func pbar2(_ x: Float) -> (checkpoints: CheckpointsFoo, originalValue: Float) { return (CheckpointsFoo(), 1) }
 func dbar2(_ x: Float, checkpoints: CheckpointsFoo, originalValue: Float, seed: Float) -> Float { return 1 }

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -16,9 +16,7 @@ func foo(_ x: Float) -> Float {
 }
 
 // Primal returns custom checkpoints type.
-struct CheckpointsFoo {
-}
-
+struct CheckpointsFoo {}
 func pfoo(_ x: Float) -> (checkpoints: CheckpointsFoo, originalValue: Float) {
   return (CheckpointsFoo(), x * x)
 }

--- a/test/AutoDiff/differentiable_attr_type_checking.swift
+++ b/test/AutoDiff/differentiable_attr_type_checking.swift
@@ -15,6 +15,11 @@ func foo(_ x: Float) -> Float {
   return x * x
 }
 
+// Original function must return non-Void type.
+@differentiable(reverse, adjoint: dvoid) // expected-error {{cannot differentiate void function 'void'}}
+func void(_ a: Float) {}
+func dvoid(_ a: Float, _ x: (), _ y: ()) -> Float { return 1 }
+
 // Primal returns custom checkpoints type.
 struct CheckpointsFoo {}
 func pfoo(_ x: Float) -> (checkpoints: CheckpointsFoo, originalValue: Float) {


### PR DESCRIPTION
- Add adjoint access level check to `@differentiable` attribute.
  - If the original function is "exported" (public or @_versioned), then the
    adjoint must also be exported.
- Generalize `lookupFuncDecl` function and add it as a method to `TypeChecker`
  so that it can be used for type-checking `#adjoint` expression in a later
  commit.