### PR TITLE
Access control improvements

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1325,7 +1325,7 @@ ERROR(unsupported_nested_protocol,none,
 // Type aliases
 ERROR(type_alias_underlying_type_access,none,
       "type alias %select{must be declared %select{"
-      "%select{private|fileprivate|internal|%error|%error}2|private or fileprivate}3"
+      "%select{private|fileprivate|internal|%error|%error}1|private or fileprivate}3"
       "|cannot be declared "
       "%select{in this context|fileprivate|internal|public|open}1}0 "
       "because its underlying type uses "
@@ -1333,7 +1333,7 @@ ERROR(type_alias_underlying_type_access,none,
       (bool, AccessLevel, AccessLevel, bool))
 WARNING(type_alias_underlying_type_access_warn,none,
         "type alias %select{should be declared "
-        "%select{private|fileprivate|internal|%error|%error}2"
+        "%select{private|fileprivate|internal|%error|%error}1"
         "|should not be declared "
         "%select{in this context|fileprivate|internal|public|open}1}0 "
         "because its underlying type uses "
@@ -1351,7 +1351,7 @@ ERROR(subscript_type_access,none,
       (bool, AccessLevel, AccessLevel, bool))
 WARNING(subscript_type_access_warn,none,
         "subscript %select{should be declared "
-        "%select{private|fileprivate|internal|%error|%error}2"
+        "%select{private|fileprivate|internal|%error|%error}1"
         "|should not be declared %select{in this context|fileprivate|internal|public|open}1}0 "
         "because its %select{index|element type}3 uses "
         "%select{a private|a fileprivate|an internal|%error|%error}2 type",
@@ -1369,7 +1369,7 @@ ERROR(function_type_access,none,
       (bool, AccessLevel, bool, AccessLevel, unsigned, bool))
 WARNING(function_type_access_warn,none,
         "%select{function|method|initializer}4 "
-        "%select{should be declared %select{private|fileprivate|internal|%error|%error}3"
+        "%select{should be declared %select{private|fileprivate|internal|%error|%error}1"
         "|should not be declared %select{in this context|fileprivate|internal|public|open}1}0 "
         "because its %select{parameter|result}5 uses "
         "%select{a private|a fileprivate|an internal|%error|%error}3 type",
@@ -1567,7 +1567,7 @@ NOTE(witness_fix_access,none,
 
 ERROR(protocol_refine_access,none,
       "%select{protocol must be declared %select{"
-      "%select{private|fileprivate|internal|%error|%error}2"
+      "%select{private|fileprivate|internal|%error|%error}1"
       "|private or fileprivate}3 because it refines"
       "|%select{in this context|fileprivate|internal|public|%error}1 "
       "protocol cannot refine}0 "
@@ -2122,7 +2122,7 @@ NOTE(enum_declares_rawrep_with_raw_type,none,
       "%0 declares raw type %1, which implies RawRepresentable", (Type, Type))
 ERROR(enum_raw_type_access,none,
       "enum %select{must be declared %select{"
-      "%select{private|fileprivate|internal|%error|%error}2|private or fileprivate}3"
+      "%select{private|fileprivate|internal|%error|%error}1|private or fileprivate}3"
       "|cannot be declared "
       "%select{in this context|fileprivate|internal|public|open}1}0 "
       "because its raw type uses "
@@ -2130,7 +2130,7 @@ ERROR(enum_raw_type_access,none,
       (bool, AccessLevel, AccessLevel, bool))
 WARNING(enum_raw_type_access_warn,none,
         "enum %select{should be declared "
-        "%select{private|fileprivate|internal|%error|%error}2"
+        "%select{private|fileprivate|internal|%error|%error}1"
         "|should not be declared %select{in this context|fileprivate|internal|public|open}1}0 "
         "because its raw type uses "
         "%select{a private|a fileprivate|an internal|%error|%error}2 type",
@@ -3238,7 +3238,7 @@ ERROR(bool_intrinsics_not_found,none,
       "broken standard library: cannot find intrinsic operations on Bool", ())
 ERROR(class_super_access,none,
       "class %select{must be declared %select{"
-      "%select{private|fileprivate|internal|%error|%error}2|private or fileprivate}3"
+      "%select{private|fileprivate|internal|%error|%error}1|private or fileprivate}3"
       "|cannot be declared %select{in this context|fileprivate|internal|public|open}1}0 "
       "because its superclass "
       "%select{is %select{private|fileprivate|internal|%error|%error}2"
@@ -3247,7 +3247,7 @@ ERROR(class_super_access,none,
       (bool, AccessLevel, AccessLevel, bool, bool))
 WARNING(class_super_access_warn,none,
       "class %select{should be declared "
-      "%select{private|fileprivate|internal|%error|%error}2"
+      "%select{private|fileprivate|internal|%error|%error}1"
       "|should not be declared %select{in this context|fileprivate|internal|public|open}1}0 "
       "because its superclass "
       "%select{is %select{private|fileprivate|internal|%error|%error}2"

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1565,20 +1565,22 @@ NOTE(witness_fix_access,none,
      "mark the %0 as '%select{%error|fileprivate|internal|public|%error}1' to "
      "satisfy the requirement", (DescriptiveDeclKind, AccessLevel))
 
-ERROR(protocol_refine_access,none,
+ERROR(protocol_access,none,
       "%select{protocol must be declared %select{"
       "%select{private|fileprivate|internal|%error|%error}1"
-      "|private or fileprivate}3 because it refines"
+      "|private or fileprivate}4 because %select{it refines|its 'where' clause uses}2"
       "|%select{in this context|fileprivate|internal|public|%error}1 "
-      "protocol cannot refine}0 "
-      "%select{a private|a fileprivate|an internal|%error|%error}2 protocol",
-      (bool, AccessLevel, AccessLevel, bool))
-WARNING(protocol_refine_access_warn,none,
+      "%select{protocol cannot refine|protocol's 'where' clause cannot use}2}0 "
+      "%select{a private|a fileprivate|an internal|%error|%error}3 protocol",
+      (bool, AccessLevel, bool, AccessLevel, bool))
+WARNING(protocol_access_warn,none,
         "%select{protocol should be declared "
-        "%select{private|fileprivate|internal|%error|%error}2 because it refines"
-        "|%select{in this context|fileprivate|internal|public|%error}1 protocol should not "
-        "refine}0 %select{a private|a fileprivate|an internal|%error|%error}2 protocol",
-        (bool, AccessLevel, AccessLevel, bool))
+        "%select{private|fileprivate|internal|%error|%error}1 because "
+        "%select{it refines|its 'where' clause uses}2"
+        "|%select{in this context|fileprivate|internal|public|%error}1 "
+        "%select{protocol should not refine|protocol's 'where' clause should not use}2}0 "
+        "%select{a private|a fileprivate|an internal|%error|%error}3 protocol",
+        (bool, AccessLevel, bool, AccessLevel, bool))
 ERROR(protocol_property_must_be_computed_var,none,
       "immutable property requirement must be declared as 'var' with a "
       "'{ get }' specifier", ())

--- a/lib/AST/SubstitutionMap.cpp
+++ b/lib/AST/SubstitutionMap.cpp
@@ -620,7 +620,7 @@ void SubstitutionMap::verify() const {
         substType->dump();
         llvm::dbgs() << "SubstitutionMap:\n";
         dump(llvm::dbgs());
-        llvm::errs() << "\n";
+        llvm::dbgs() << "\n";
       }
 
       assert(proto->isObjC() &&
@@ -634,7 +634,7 @@ void SubstitutionMap::verify() const {
       substType->dump(llvm::dbgs());
       llvm::dbgs() << "SubstitutionMap:\n";
       dump(llvm::dbgs());
-      llvm::errs() << "\n";
+      llvm::dbgs() << "\n";
     }
     assert(conformance.isConcrete() && "Conformance should be concrete");
 

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -4424,7 +4424,6 @@ public:
 
   void visitTypeAliasDecl(TypeAliasDecl *TAD) {
     TC.checkDeclAttributesEarly(TAD);
-    TC.computeAccessLevel(TAD);
 
     TC.validateDecl(TAD);
     TC.checkDeclAttributes(TAD);
@@ -4492,7 +4491,6 @@ public:
 
   void visitEnumDecl(EnumDecl *ED) {
     TC.checkDeclAttributesEarly(ED);
-    TC.computeAccessLevel(ED);
 
     checkUnsupportedNestedType(ED);
 
@@ -4526,7 +4524,6 @@ public:
 
   void visitStructDecl(StructDecl *SD) {
     TC.checkDeclAttributesEarly(SD);
-    TC.computeAccessLevel(SD);
 
     checkUnsupportedNestedType(SD);
 
@@ -4651,7 +4648,6 @@ public:
 
   void visitClassDecl(ClassDecl *CD) {
     TC.checkDeclAttributesEarly(CD);
-    TC.computeAccessLevel(CD);
 
     checkUnsupportedNestedType(CD);
 
@@ -4776,7 +4772,6 @@ public:
 
   void visitProtocolDecl(ProtocolDecl *PD) {
     TC.checkDeclAttributesEarly(PD);
-    TC.computeAccessLevel(PD);
 
     checkUnsupportedNestedType(PD);
 
@@ -7208,7 +7203,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     }
 
     checkDeclAttributesEarly(FD);
-    computeAccessLevel(FD);
 
     FD->setIsBeingValidated();
 
@@ -7508,7 +7502,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     CD->setIsBeingValidated();
 
     checkDeclAttributesEarly(CD);
-    computeAccessLevel(CD);
 
     // convenience initializers are only allowed on classes and in
     // extensions thereof.
@@ -7785,7 +7778,6 @@ void TypeChecker::validateDecl(ValueDecl *D) {
     SD->setIsBeingValidated(false);
 
     checkDeclAttributesEarly(SD);
-    computeAccessLevel(SD);
 
     validateAttributes(*this, SD);
 

--- a/test/Compatibility/accessibility_where.swift
+++ b/test/Compatibility/accessibility_where.swift
@@ -1,0 +1,57 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+private struct PrivateStruct {} // expected-note 6{{type declared here}}
+internal struct InternalStruct {} // expected-note 2{{type declared here}}
+public struct PublicStruct {}
+
+public protocol BaseProtocol {
+  associatedtype T
+}
+
+public protocol PublicProtocol1 : BaseProtocol where T == PrivateStruct {
+  // expected-warning@-1 {{public protocol's 'where' clause should not use a private protocol}}
+
+  associatedtype X : BaseProtocol where X.T == PrivateStruct
+  // expected-warning@-1 {{associated type in a public protocol uses a private type in its requirement}}
+}
+
+public protocol PublicProtocol2 : BaseProtocol where T == InternalStruct {
+  // expected-warning@-1 {{public protocol's 'where' clause should not use an internal protocol}}
+
+  associatedtype X : BaseProtocol where X.T == InternalStruct
+  // expected-warning@-1 {{associated type in a public protocol uses an internal type in its requirement}}
+}
+
+public protocol PublicProtocol3 : BaseProtocol where T == PublicStruct {
+  associatedtype X : BaseProtocol where X.T == PublicStruct
+}
+
+internal protocol InternalProtocol1 : BaseProtocol where T == PrivateStruct {
+  // expected-warning@-1 {{internal protocol's 'where' clause should not use a private protocol}}
+
+  associatedtype X : BaseProtocol where X.T == PrivateStruct
+  // expected-warning@-1 {{associated type in an internal protocol uses a private type in its requirement}}
+}
+
+internal protocol InternalProtocol2 : BaseProtocol where T == InternalStruct {
+  associatedtype X : BaseProtocol where X.T == InternalStruct
+}
+
+internal protocol InternalProtocol3 : BaseProtocol where T == PublicStruct {
+  associatedtype X : BaseProtocol where X.T == PublicStruct
+}
+
+protocol Protocol1 : BaseProtocol where T == PrivateStruct {
+  // expected-warning@-1 {{protocol should be declared fileprivate because its 'where' clause uses a private protocol}}
+
+  associatedtype X : BaseProtocol where X.T == PrivateStruct
+  // expected-warning@-1 {{associated type in an internal protocol uses a private type in its requirement}}
+}
+
+protocol Protocol2 : BaseProtocol where T == InternalStruct {
+  associatedtype X : BaseProtocol where X.T == InternalStruct
+}
+
+protocol Protocol3 : BaseProtocol where T == PublicStruct {
+  associatedtype X : BaseProtocol where X.T == PublicStruct
+}

--- a/test/Sema/accessibility.swift
+++ b/test/Sema/accessibility.swift
@@ -413,6 +413,15 @@ private typealias PrivateInt = Int
 enum DefaultRawPrivate : PrivateInt { // expected-error {{enum must be declared private or fileprivate because its raw type uses a private type}}
   case A
 }
+
+// Note: fileprivate is the most visible valid access level for
+// Outer.DefaultRawPrivate, so the diagnostic should say that.
+class Outer {
+  enum DefaultRawPrivate : PrivateInt { // expected-error {{enum must be declared fileprivate because its raw type uses a private type}}
+    case A
+  }
+}
+
 public enum PublicRawPrivate : PrivateInt { // expected-error {{enum cannot be declared public because its raw type uses a private type}}
   case A
 }

--- a/test/Sema/accessibility_protocol_extension.swift
+++ b/test/Sema/accessibility_protocol_extension.swift
@@ -1,0 +1,52 @@
+// RUN: %target-typecheck-verify-swift -swift-version 4
+
+fileprivate struct FilePrivateStruct {}
+// expected-note@-1 4{{type declared here}}
+
+private struct PrivateStruct {}
+// expected-note@-1 4{{type declared here}}
+
+internal struct InternalStruct {}
+// expected-note@-1 4{{type declared here}}
+
+public protocol P {
+  typealias TFP = FilePrivateStruct
+  // expected-error@-1 {{type alias cannot be declared public because its underlying type uses a fileprivate type}}
+
+  typealias TP = PrivateStruct
+  // expected-error@-1 {{type alias cannot be declared public because its underlying type uses a private type}}
+
+  typealias TI = InternalStruct
+  // expected-error@-1 {{type alias cannot be declared public because its underlying type uses an internal type}}
+}
+
+extension P {
+  func usesFilePrivateStructFunc(_: FilePrivateStruct) {}
+  // expected-error@-1 {{method must be declared fileprivate because its parameter uses a fileprivate type}}
+
+  typealias UsesFilePrivateStructAlias = FilePrivateStruct
+  // expected-error@-1 {{type alias must be declared fileprivate because its underlying type uses a fileprivate type}}
+
+  var usesFilePrivateStructProp: FilePrivateStruct { get { } set { } }
+  // expected-error@-1 {{property must be declared fileprivate because its type uses a fileprivate type}}
+
+
+  func usesPrivateStructFunc(_: PrivateStruct) {}
+  // expected-error@-1 {{method must be declared fileprivate because its parameter uses a private type}}
+
+  typealias UsesPrivateStructAlias = PrivateStruct
+  // expected-error@-1 {{type alias must be declared fileprivate because its underlying type uses a private type}}
+
+  var usesPrivateStructProp: PrivateStruct { get { } set { } }
+  // expected-error@-1 {{property must be declared fileprivate because its type uses a private type}}
+
+
+  public func usesInternalStruct(_: InternalStruct) {}
+  // expected-error@-1 {{method cannot be declared public because its parameter uses an internal type}}
+
+  public typealias UsesInternalStructAlias = InternalStruct
+  // expected-error@-1 {{type alias cannot be declared public because its underlying type uses an internal type}}
+
+  public var usesInternalStructProp: InternalStruct { get { } set { } }
+  // expected-error@-1 {{property cannot be declared public because its type uses an internal type}}
+}

--- a/test/Sema/accessibility_where.swift
+++ b/test/Sema/accessibility_where.swift
@@ -1,0 +1,57 @@
+// RUN: %target-typecheck-verify-swift -swift-version 5
+
+private struct PrivateStruct {} // expected-note 6{{type declared here}}
+internal struct InternalStruct {} // expected-note 2{{type declared here}}
+public struct PublicStruct {}
+
+public protocol BaseProtocol {
+  associatedtype T
+}
+
+public protocol PublicProtocol1 : BaseProtocol where T == PrivateStruct {
+  // expected-error@-1 {{public protocol's 'where' clause cannot use a private protocol}}
+
+  associatedtype X : BaseProtocol where X.T == PrivateStruct
+  // expected-error@-1 {{associated type in a public protocol uses a private type in its requirement}}
+}
+
+public protocol PublicProtocol2 : BaseProtocol where T == InternalStruct {
+  // expected-error@-1 {{public protocol's 'where' clause cannot use an internal protocol}}
+
+  associatedtype X : BaseProtocol where X.T == InternalStruct
+  // expected-error@-1 {{associated type in a public protocol uses an internal type in its requirement}}
+}
+
+public protocol PublicProtocol3 : BaseProtocol where T == PublicStruct {
+  associatedtype X : BaseProtocol where X.T == PublicStruct
+}
+
+internal protocol InternalProtocol1 : BaseProtocol where T == PrivateStruct {
+  // expected-error@-1 {{internal protocol's 'where' clause cannot use a private protocol}}
+
+  associatedtype X : BaseProtocol where X.T == PrivateStruct
+  // expected-error@-1 {{associated type in an internal protocol uses a private type in its requirement}}
+}
+
+internal protocol InternalProtocol2 : BaseProtocol where T == InternalStruct {
+  associatedtype X : BaseProtocol where X.T == InternalStruct
+}
+
+internal protocol InternalProtocol3 : BaseProtocol where T == PublicStruct {
+  associatedtype X : BaseProtocol where X.T == PublicStruct
+}
+
+protocol Protocol1 : BaseProtocol where T == PrivateStruct {
+  // expected-error@-1 {{protocol must be declared private or fileprivate because its 'where' clause uses a private protocol}}
+
+  associatedtype X : BaseProtocol where X.T == PrivateStruct
+  // expected-error@-1 {{associated type in an internal protocol uses a private type in its requirement}}
+}
+
+protocol Protocol2 : BaseProtocol where T == InternalStruct {
+  associatedtype X : BaseProtocol where X.T == InternalStruct
+}
+
+protocol Protocol3 : BaseProtocol where T == PublicStruct {
+  associatedtype X : BaseProtocol where X.T == PublicStruct
+}


### PR DESCRIPTION
- Check type references from 'where' clauses in protocols and associated types
- Clean up some wording around `private` vs `fileprivate`
- Small code cleanups

This is just landing a piece of https://github.com/apple/swift/pull/16586.