### PR TITLE
Expose swift_getTypeContextDescriptor() on Darwin.

### DIFF
--- a/include/swift/Runtime/Metadata.h
+++ b/include/swift/Runtime/Metadata.h
@@ -721,12 +721,8 @@ void swift_getFieldAt(
 void verifyMangledNameRoundtrip(const Metadata *metadata);
 #endif
 
-#if !SWIFT_OBJC_INTEROP
-
 SWIFT_CC(swift) SWIFT_RUNTIME_STDLIB_API
 const TypeContextDescriptor *swift_getTypeContextDescriptor(const Metadata *type);
-
-#endif // !SWIFT_OBJC_INTEROP
 
 } // end namespace swift
 

--- a/stdlib/public/runtime/Metadata.cpp
+++ b/stdlib/public/runtime/Metadata.cpp
@@ -3941,10 +3941,6 @@ void swift::verifyMangledNameRoundtrip(const Metadata *metadata) {
 }
 #endif
 
-#if !SWIFT_OBJC_INTEROP
-
 const TypeContextDescriptor *swift::swift_getTypeContextDescriptor(const Metadata *type) {
     return type->getTypeContextDescriptor();
 }
-
-#endif // !SWIFT_OBJC_INTEROP


### PR DESCRIPTION
I tried to be conservative in only allowing this call to be on non-ObjC platforms, but swift-corelibs-foundation _does_ run on a ObjC platform (namely, Darwin while testing).

Expose it unconditionally.

cc @jckarter 