### PR TITLE
Sema: Type aliases referenced from @inlinable functions must be public or @usableFromInline

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -3849,6 +3849,11 @@ ERROR(resilience_decl_unavailable,
       "cannot be referenced from " FRAGILE_FUNC_KIND "3",
       (DescriptiveDeclKind, DeclName, AccessLevel, unsigned))
 
+WARNING(resilience_decl_unavailable_warn,
+        none, "%0 %1 is %select{private|fileprivate|internal|%error|%error}2 and "
+        "should not be referenced from " FRAGILE_FUNC_KIND "3",
+        (DescriptiveDeclKind, DeclName, AccessLevel, unsigned))
+
 #undef FRAGILE_FUNC_KIND
 
 NOTE(resilience_decl_declared_here_public,

--- a/lib/Sema/ResilienceDiagnostics.cpp
+++ b/lib/Sema/ResilienceDiagnostics.cpp
@@ -86,6 +86,13 @@ void TypeChecker::diagnoseInlinableLocalType(const NominalTypeDecl *NTD) {
   }
 }
 
+/// A uniquely-typed boolean to reduce the chances of accidentally inverting
+/// a check.
+enum class DowngradeToWarning: bool {
+  No,
+  Yes
+};
+
 bool TypeChecker::diagnoseInlinableDeclRef(SourceLoc loc,
                                            const ValueDecl *D,
                                            const DeclContext *DC,
@@ -119,11 +126,18 @@ bool TypeChecker::diagnoseInlinableDeclRef(SourceLoc loc,
   if (D->isDynamic())
     return false;
 
-  // FIXME: Figure out what to do with typealiases
-  if (isa<TypeAliasDecl>(D))
-    return false;
+  DowngradeToWarning downgradeToWarning = DowngradeToWarning::No;
 
-  diagnose(loc, diag::resilience_decl_unavailable,
+  // Swift 4.2 did not perform any checks for type aliases.
+  if (!Context.isSwiftVersionAtLeast(5) &&
+      isa<TypeAliasDecl>(D))
+    downgradeToWarning = DowngradeToWarning::Yes;
+
+  auto diagID = diag::resilience_decl_unavailable;
+  if (downgradeToWarning == DowngradeToWarning::Yes)
+    diagID = diag::resilience_decl_unavailable_warn;
+
+  diagnose(loc, diagID,
            D->getDescriptiveKind(), D->getFullName(),
            D->getFormalAccessScope().accessLevelForDiagnostics(),
            static_cast<unsigned>(Kind));
@@ -136,6 +150,6 @@ bool TypeChecker::diagnoseInlinableDeclRef(SourceLoc loc,
              D->getDescriptiveKind(), D->getFullName());
   }
 
-  return true;
+  return (downgradeToWarning == DowngradeToWarning::No);
 }
 

--- a/test/Compatibility/attr_inlinable_typealias.swift
+++ b/test/Compatibility/attr_inlinable_typealias.swift
@@ -1,4 +1,4 @@
-// RUN: %target-typecheck-verify-swift -swift-version 5
+// RUN: %target-typecheck-verify-swift -swift-version 4
 
 private typealias PrivateAlias = Int
 // expected-note@-1 {{type alias 'PrivateAlias' is not '@usableFromInline' or public}}
@@ -12,10 +12,10 @@ public typealias PublicAlias = Int
 
 @inlinable public func f() {
   _ = PrivateAlias.self
-  // expected-error@-1 {{type alias 'PrivateAlias' is private and cannot be referenced from an '@inlinable' function}}
+  // expected-warning@-1 {{type alias 'PrivateAlias' is private and should not be referenced from an '@inlinable' function}}
 
   _ = InternalAlias.self
-  // expected-error@-1 {{type alias 'InternalAlias' is internal and cannot be referenced from an '@inlinable' function}}
+  // expected-warning@-1 {{type alias 'InternalAlias' is internal and should not be referenced from an '@inlinable' function}}
 
   _ = UsableFromInlineAlias.self
 

--- a/test/SIL/Serialization/Inputs/def_generic.swift
+++ b/test/SIL/Serialization/Inputs/def_generic.swift
@@ -1,15 +1,12 @@
 @_fixed_layout
 public class A<T> {
-  typealias Element = T
-  @usableFromInline
-  @inlinable
-  func convertFromArrayLiteral(_ elements: Element...) -> A {
+  @usableFromInline typealias Element = T
+
+  @inlinable func convertFromArrayLiteral(_ elements: Element...) -> A {
     return A()
   }
 
-  @usableFromInline
-  @inlinable
-  init() {}
+  @inlinable init() {}
 
   @inlinable public subscript<U>(value: T) -> U? {
     return nil


### PR DESCRIPTION
This is a source breaking change, so emit a warning in Swift 4 mode,
and an error in Swift 5 mode.

Another stand-alone piece from https://github.com/apple/swift/pull/16586.