### PR TITLE
[4.2] [Clang importer] Don't bridge blocks to Swift functions in ObjC generic arguments.

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -1283,8 +1283,9 @@ static ImportedType adjustTypeForConcreteImport(
   }
 
   // SwiftTypeConverter turns block pointers into @convention(block) types.
-  // In a bridgeable context, or in the direct structure of a typedef,
-  // we would prefer to instead use the default Swift convention.
+  // In some contexts, we bridge them to use the Swift function type
+  // representation. This includes typedefs of block types, which use the
+  // Swift function type representation.
   if (hint == ImportHint::Block) {
     if (canBridgeTypes(importKind)) {
       // Determine the function type representation we need.

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -108,8 +108,8 @@ enum class ImportTypeKind {
   /// \brief Import the type of a literal value.
   Value,
 
-  /// \brief Import the type of a literal value that can be bridged.
-  BridgedValue,
+  /// \brief Import the type of an Objective-C generic argument.
+  ObjCGenericArgument,
 
   /// \brief Import the declared type of a variable.
   Variable,

--- a/lib/ClangImporter/ImporterImpl.h
+++ b/lib/ClangImporter/ImporterImpl.h
@@ -109,7 +109,7 @@ enum class ImportTypeKind {
   Value,
 
   /// \brief Import the type of an Objective-C generic argument.
-  ObjCGenericArgument,
+  ObjCCollectionElement,
 
   /// \brief Import the declared type of a variable.
   Variable,

--- a/test/ClangImporter/objc_bridging_generics.swift
+++ b/test/ClangImporter/objc_bridging_generics.swift
@@ -414,3 +414,7 @@ func testHashableGenerics(
   let _: Int = insufficient.foo // expected-error{{cannot convert value of type 'Set<AnyHashable>' to specified type 'Int'}}
   let _: Int = extra.foo // expected-error{{cannot convert value of type 'Set<ElementConcrete>' to specified type 'Int'}}
 }
+
+func testGenericsWithTypedefBlocks(hba: HasBlockArray) {
+  let _: Int = hba.blockArray() // expected-error{{type '[@convention(block) () -> Void]'}}
+}

--- a/test/ClangImporter/objc_ir.swift
+++ b/test/ClangImporter/objc_ir.swift
@@ -13,6 +13,7 @@ import Foundation
 import objc_ext
 import TestProtocols
 import ObjCIRExtras
+import objc_generics
 
 // CHECK: @"\01L_selector_data(method:withFloat:)" = private global [18 x i8] c"method:withFloat:\00"
 // CHECK: @"\01L_selector_data(method:withDouble:)" = private global [19 x i8] c"method:withDouble:\00"
@@ -342,6 +343,13 @@ func testGenericCompatibilityAliasMangling(generic_obj: SwiftGenericNameAlias<NS
 
 func testConstrGenericCompatibilityAliasMangling(constr_generic_obj: SwiftConstrGenericNameAlias<NSNumber>) {
   // CHECK: call void @llvm.dbg.declare(metadata %TSo26SwiftConstrGenericNameTestCySo8NSNumberCG** {{%.+}}, metadata ![[SWIFT_CONSTR_GENERIC_NAME_ALIAS_VAR:[0-9]+]], metadata !DIExpression())
+}
+
+// CHECK-LABEL: S7objc_ir22testBlocksWithGenerics3hbaypSo13HasBlockArrayC_tF
+func testBlocksWithGenerics(hba: HasBlockArray) -> Any {
+  // CHECK: {{call swiftcc.*SSo13HasBlockArrayC05blockC0SayyyXBGyFTcTO}}
+  let _ = hba.blockPointerType()
+  return hba.blockArray
 }
 
 // CHECK: linkonce_odr hidden {{.*}} @"$SSo1BC3intABSgs5Int32V_tcfcTO"

--- a/test/Inputs/clang-importer-sdk/usr/include/objc_generics.h
+++ b/test/Inputs/clang-importer-sdk/usr/include/objc_generics.h
@@ -112,3 +112,10 @@ typedef id <Fungible> FungibleObject;
 
 @interface Third : Second<Third *>
 @end
+
+typedef void (^ _Nonnull BlockPointerType)(void);
+
+@interface HasBlockArray : NSObject
+- (NSArray<BlockPointerType> * _Nonnull)blockArray;
+- (BlockPointerType)blockPointerType;
+@end


### PR DESCRIPTION
**Explanation:** The Clang importer is importing `NSArray<some-typedef-of-a-block-type>*` as a Swift array of functions that use the Swift calling convention, which is not supported by the dynamic bridging implementation. Such a type should be imported as a Swift array of block-convention functions, e.g., `[@convention(block) (...) -> ...]`.
**Scope:** Affects projects that import Objective-C APIs that use types of the aforementioned form.
**Risk:** Low; importing these APIs with the current Swift 4.2 causes a crash in IR generation.
**Testing:** Compiler regression tests, including new tests
**Reviewer:** @jrose-apple 
**SR / Radar:** rdar://problem/40879067