### PR TITLE
[ClangImporter] Handle lookup tables with many entries

### DIFF
--- a/lib/ClangImporter/SwiftLookupTable.cpp
+++ b/lib/ClangImporter/SwiftLookupTable.cpp
@@ -961,6 +961,7 @@ namespace {
       if (key.Kind == DeclBaseName::Kind::Normal) {
         keyLength += key.Name.size(); // The name's length
       }
+      assert(keyLength == static_cast<uint16_t>(keyLength));
 
       // # of entries
       uint32_t dataLength = sizeof(uint16_t);
@@ -982,7 +983,7 @@ namespace {
 
       endian::Writer<little> writer(out);
       writer.write<uint16_t>(keyLength);
-      writer.write<uint16_t>(dataLength);
+      writer.write<uint32_t>(dataLength);
       return { keyLength, dataLength };
     }
 
@@ -1066,10 +1067,12 @@ namespace {
       uint32_t keyLength = 1;
       if (SwiftLookupTable::contextRequiresName(key.first))
         keyLength += key.second.size();
+      assert(keyLength == static_cast<uint16_t>(keyLength));
 
       // # of entries
       uint32_t dataLength =
         sizeof(uint16_t) + sizeof(uint64_t) * data.size();
+      assert(dataLength == static_cast<uint16_t>(dataLength));
 
       endian::Writer<little> writer(out);
       writer.write<uint16_t>(keyLength);
@@ -1225,7 +1228,7 @@ namespace {
     static std::pair<unsigned, unsigned>
     ReadKeyDataLength(const uint8_t *&data) {
       unsigned keyLength = endian::readNext<uint16_t, little, unaligned>(data);
-      unsigned dataLength = endian::readNext<uint16_t, little, unaligned>(data);
+      unsigned dataLength = endian::readNext<uint32_t, little, unaligned>(data);
       return { keyLength, dataLength };
     }
 


### PR DESCRIPTION
In particular, there are frameworks with more than 65536 entries for `init` as a base name.

I can't think of a test case for this besides actually adding such a massive framework, but the assertions that were added here should catch the issue in Debug builds if it ever comes up again. I'm going to go harden everything else that uses this API next (`llvm::endian::Writer`).

rdar://problem/40828315