### PR TITLE
Fix benchmark suite on 32-bit platforms

### DIFF
--- a/benchmark/single-source/RandomValues.swift
+++ b/benchmark/single-source/RandomValues.swift
@@ -54,10 +54,10 @@ public func run_RandomIntegersDef(_ N: Int) {
 @inline(never)
 public func run_RandomIntegersLCG(_ N: Int) {
   for _ in 0 ..< N {
-    var x = 0
+    var x: Int64 = 0
     var generator = LCRNG(seed: 0)
     for _ in 0 ..< 100_000 {
-      x &+= Int.random(in: 0...10_000, using: &generator)
+      x &+= Int64.random(in: 0...10_000, using: &generator)
     }
     CheckResults(x == 498214315)
   }

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -403,6 +403,10 @@ func runBench(_ test: Test, _ c: TestConfig) -> BenchResults? {
       // Compute the scaling factor if a fixed c.fixedNumIters is not specified.
       scale = c.fixedNumIters
     }
+    // Make integer overflow less likely on platforms where Int is 32 bits wide.
+    // FIXME: Switch BenchmarkInfo to use Int64 for the iteration scale, or fix
+    // benchmarks to not let scaling get off the charts.
+    scale = min(scale, UInt(Int.max) / 10_000)
 
     // Rerun the test with the computed scale factor.
     if scale > 1 {


### PR DESCRIPTION
- Fix integer overflow issues with iteration count
- Fix RandomIntegersLCG to use an integer type with a non-varying width

rdar://problem/41177686