### PR TITLE
[master-next] fix DebugInfo/ImportsStdlib.swift test to match LLVM r325970

### DIFF
--- a/test/DebugInfo/ImportsStdlib.swift
+++ b/test/DebugInfo/ImportsStdlib.swift
@@ -21,6 +21,7 @@
 // DWARF:   DW_AT_name ("NotTheStdlib")
 // DWARF:   DW_AT_LLVM_include_path
 
-// DWARF: file_names{{.*}} ImportsStdlib.swift
+// DWARF: file_names{{.*}}
+// DWARF-NEXT: "ImportsStdlib.swift"
 
 // NEGATIVE-DWARF-NOT: DW_AT_name ("Swift")


### PR DESCRIPTION
The LLVM change happened a while ago, but this is new test in Swift that
needs adjustment to work with the newer version of LLVM.