### PR TITLE
[NFC] Separate FunctionTypeRepr Input Resolution

### DIFF
--- a/lib/Sema/TypeCheckPattern.cpp
+++ b/lib/Sema/TypeCheckPattern.cpp
@@ -962,12 +962,7 @@ bool TypeChecker::typeCheckPattern(Pattern *P, DeclContext *dc,
     bool hadError = false;
     SmallVector<TupleTypeElt, 8> typeElts;
 
-    // If this is the top level of a function input list, peel off the
-    // ImmediateFunctionInput marker and install a FunctionInput one instead.
-    auto elementOptions = withoutContext(options);
-    if (options & TypeResolutionFlags::ImmediateFunctionInput)
-      elementOptions |= TypeResolutionFlags::FunctionInput;
-
+    const auto elementOptions = withoutContext(options);
     bool missingType = false;
     for (unsigned i = 0, e = tuplePat->getNumElements(); i != e; ++i) {
       TuplePatternElt &elt = tuplePat->getElement(i);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -506,9 +506,6 @@ enum class TypeResolutionFlags : unsigned {
   /// tuple type.  This is not set for multi-level tuple arguments.
   FunctionInput = 0x40,
 
-  /// Whether this is the immediate input type to a function type,
-  ImmediateFunctionInput = 0x80,
-
   /// Whether this is a variadic function input.
   VariadicFunctionInput = 0x100,
 
@@ -584,7 +581,6 @@ using TypeResolutionOptions = OptionSet<TypeResolutionFlags>;
 /// Strip the contextual options from the given type resolution options.
 static inline TypeResolutionOptions
 withoutContext(TypeResolutionOptions options, bool preserveSIL = false) {
-  options -= TypeResolutionFlags::ImmediateFunctionInput;
   options -= TypeResolutionFlags::FunctionInput;
   options -= TypeResolutionFlags::VariadicFunctionInput;
   options -= TypeResolutionFlags::EnumCase;

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -487,92 +487,92 @@ public:
 /// type.
 enum class TypeResolutionFlags : unsigned {
   /// Whether to allow unspecified types within a pattern.
-  AllowUnspecifiedTypes = 0x01,
+  AllowUnspecifiedTypes = 1 << 0,
 
   /// Whether the given type can override the type of a typed pattern.
-  OverrideType = 0x04,
+  OverrideType = 1 << 1,
 
   /// Whether to allow unbound generic types.
-  AllowUnboundGenerics = 0x08,
+  AllowUnboundGenerics = 1 << 2,
 
   /// Whether we are validating the type for SIL.
-  SILType = 0x10,
+  SILType = 1 << 3,
 
   /// Whether we are parsing a SIL file.  Not the same as SILType,
   /// because the latter is not set if we're parsing an AST type.
-  SILMode = 0x20,
+  SILMode = 1 << 4,
 
   /// Whether we are in the input type of a function, or under one level of
   /// tuple type.  This is not set for multi-level tuple arguments.
-  FunctionInput = 0x40,
+  FunctionInput = 1 << 5,
 
   /// Whether this is a variadic function input.
-  VariadicFunctionInput = 0x100,
+  VariadicFunctionInput = 1 << 6,
 
   /// Whether we are in the result type of a function body that is
   /// known to produce dynamic Self.
-  DynamicSelfResult = 0x200,
+  DynamicSelfResult = 1 << 7,
 
   /// Whether this is a resolution based on a non-inferred type pattern.
-  FromNonInferredPattern = 0x400,
+  FromNonInferredPattern = 1 << 8,
 
   /// Whether we are the variable type in a for/in statement.
-  EnumerationVariable = 0x800,
+  EnumerationVariable = 1 << 9,
 
   /// Whether we are looking only in the generic signature of the context
   /// we're searching, rather than the entire context.
-  GenericSignature = 0x1000,
+  GenericSignature = 1 << 10,
 
   /// Whether an unavailable protocol can be referenced.
-  AllowUnavailableProtocol = 0x2000,
+  AllowUnavailableProtocol = 1 << 11,
 
   /// Whether this type is the value carried in an enum case.
-  EnumCase = 0x4000,
+  EnumCase = 1 << 12,
 
   /// Whether this type is being used in an expression or local declaration.
   ///
   /// This affects what sort of dependencies are recorded when resolving the
   /// type.
-  InExpression = 0x8000,
+  InExpression = 1 << 13,
 
   /// Whether this type resolution is guaranteed not to affect downstream files.
-  KnownNonCascadingDependency = 0x10000,
+  KnownNonCascadingDependency = 1 << 14,
 
   /// Whether we should allow references to unavailable types.
-  AllowUnavailable = 0x20000,
+  AllowUnavailable = 1 << 15,
 
   /// Whether this is the payload subpattern of an enum pattern.
-  EnumPatternPayload = 0x40000,
+  EnumPatternPayload = 1 << 16,
 
   /// Whether we are binding an extension declaration, which limits
   /// the lookup.
-  ExtensionBinding = 0x80000,
+  ExtensionBinding = 1 << 17,
 
   /// Whether we are in the inheritance clause of a nominal type declaration
   /// or extension.
-  InheritanceClause = 0x100000,
+  InheritanceClause = 1 << 18,
 
   /// Whether we should resolve only the structure of the resulting
   /// type rather than its complete semantic properties.
-  ResolveStructure = 0x200000,
+  ResolveStructure = 1 << 19,
 
   /// Whether this is the type of an editor placeholder.
-  EditorPlaceholder = 0x400000,
+  EditorPlaceholder = 1 << 20,
 
   /// Whether we are in a type argument for an optional
-  ImmediateOptionalTypeArgument = 0x800000,
+  ImmediateOptionalTypeArgument = 1 << 21,
 
   /// Whether we are checking the underlying type of a typealias.
-  TypeAliasUnderlyingType = 0x1000000,
+  TypeAliasUnderlyingType = 1 << 22,
 
   /// Whether we are checking the parameter list of a subscript.
-  SubscriptParameters = 0x2000000,
+  SubscriptParameters = 1 << 23,
 
   /// Is it okay to resolve an IUO sigil ("!") here?
-  AllowIUO = 0x4000000,
+  AllowIUO = 1 << 24,
 
   /// Is it okay to resolve an IUO sigil ("!") here with a deprecation warning?
-  AllowIUODeprecated = 0x8000000,
+  AllowIUODeprecated = 1 << 25,
 };
 
 /// Option set describing how type resolution should work.


### PR DESCRIPTION
Extract function parameter resolution as a separate kind of operation in TypeCheckType.  This greatly simplifies the `TupleTypeRepr` resolution case and moves us closer to a world where we can drop the `ParameterTypeFlags` out of `TupleTypeElt`.