### PR TITLE
[4.2][TypeChecker] When formatting witness type for diagnostics don't assu…

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -937,13 +937,13 @@ static void checkRedeclaration(TypeChecker &tc, ValueDecl *current) {
     if (!other->isAccessibleFrom(currentDC))
       continue;
 
-    const auto markInvalid = [&current, &tc]() {
+    const auto markInvalid = [&current]() {
       current->setInvalid();
       if (auto *varDecl = dyn_cast<VarDecl>(current))
         if (varDecl->hasType())
-          varDecl->setType(ErrorType::get(tc.Context));
+          varDecl->setType(ErrorType::get(varDecl->getType()));
       if (current->hasInterfaceType())
-        current->setInterfaceType(ErrorType::get(tc.Context));
+        current->setInterfaceType(ErrorType::get(current->getInterfaceType()));
     };
 
     // Thwart attempts to override the same declaration more than once.

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -1666,6 +1666,17 @@ static Type getTypeForDisplay(ModuleDecl *module, ValueDecl *decl) {
     }
   }
 
+  // Redeclaration checking might mark a candidate as `invalid` and
+  // reset it's type to ErrorType, let's dig out original type to
+  // make the diagnostic better.
+  if (auto errorType = type->getAs<ErrorType>()) {
+    auto originalType = errorType->getOriginalType();
+    if (!originalType || !originalType->is<AnyFunctionType>())
+      return type;
+
+    type = originalType;
+  }
+
   return type->castTo<AnyFunctionType>()->getResult();
 }
 

--- a/validation-test/compiler_crashers_2_fixed/0160-rdar41141944.swift
+++ b/validation-test/compiler_crashers_2_fixed/0160-rdar41141944.swift
@@ -1,0 +1,18 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -typecheck %s -verify
+// REQUIRES: objc_interop
+
+import Foundation
+
+@objc protocol P {
+  func foo(a arg: Int) // expected-note {{protocol requires function 'foo(a:)' with type '(Int) -> ()'; do you want to add a stub?}}
+}
+
+class C : P {
+// expected-error@-1 {{type 'C' does not conform to protocol 'P'}}
+  var foo: Float = 0.75
+  // expected-note@-1 {{'foo' previously declared here}}
+  // expected-note@-2 {{candidate is not a function}}
+  func foo() {}
+  // expected-error@-1 {{invalid redeclaration of 'foo()'}}
+  // expected-note@-2 {{candidate has non-matching type '() -> ()'}}
+}


### PR DESCRIPTION
…me it's always valid

Sometimes witness candidates have error type e.g. when re-declaration checking
marks them as `invalid`, so formatting of the diagnostic
should account of potential witnesses not having a valid type.

Resolves: rdar://problem/41141944
(cherry picked from commit 235ed55004ca07e713d005de8f0922c2ece1dd0b)

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
