### PR TITLE
[Sema][GSB] Fix crash on cond conformances with invalid req

### DIFF
--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -4721,12 +4721,21 @@ ConstraintResult GenericSignatureBuilder::addTypeRequirement(
         // type that makes sense to use here, but, in practice, all
         // getLookupConformanceFns used in here don't use that parameter anyway.
         auto dependentType = CanType();
-        auto conformance =
-            getLookupConformanceFn()(dependentType, subjectType, proto->getDecl());
 
-        // FIXME: diagnose if there's no conformance.
-        if (conformance) {
-          addConditionalRequirements(*this, *conformance, inferForModule);
+        auto D = getGenericParams().front()->getDecl();
+        auto DC = D ? D->getDeclContext() : nullptr;
+        auto NTD = DC ? DC->getAsNominalTypeOrNominalTypeExtensionContext()
+                      : nullptr;
+        auto subjectNTD = subjectType->getAnyNominal();
+
+        if (!NTD || !subjectNTD || NTD != subjectNTD) {
+          auto conformance =
+            getLookupConformanceFn()(dependentType, subjectType,
+                                     proto->getDecl());
+          // FIXME: diagnose if there's no conformance.
+          if (conformance) {
+            addConditionalRequirements(*this, *conformance, inferForModule);
+          }
         }
       }
     }

--- a/test/decl/ext/generic.swift
+++ b/test/decl/ext/generic.swift
@@ -144,6 +144,23 @@ extension GenericClass where Self : P3 { }
 // expected-error@-1{{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'GenericClass'?}} {{30-34=GenericClass}}
 // expected-error@-2{{type 'GenericClass<T>' in conformance requirement does not refer to a generic parameter or associated type}}
 
+protocol Prot1 {}
+protocol Prot2 {}
+protocol Prot3 {}
+protocol Prot4 {}
+protocol Prot5 {}
+
+extension GenericClass: Prot1 where T: Prot1 {}
+extension GenericClass: Prot2 where Self: Prot1 {}
+// expected-error@-1 {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'GenericClass'?}}
+// expected-error@-2 {{type 'GenericClass<T>' in conformance requirement does not refer to a generic parameter or associated type}}
+extension GenericClass: Prot3 where GenericClass<T>: Prot1 {}
+// expected-error @-1 {{type 'GenericClass<T>' in conformance requirement does not refer to a generic parameter or associated type}}
+extension GenericClass: Prot4 where GenericClass<Int>: Prot1 {}
+// expected-error @-1 {{type 'GenericClass<Int>' in conformance requirement does not refer to a generic parameter or associated type}}
+extension GenericClass: Prot5 where GenericClass: Prot5 {}
+// expected-error @-1 {{type 'GenericClass<T>' in conformance requirement does not refer to a generic parameter or associated type}}
+
 protocol P4 {
   associatedtype T
   init(_: T)


### PR DESCRIPTION
### Example
``` swift
protocol P1 {}; protocol P2 {}; protocol P3 {}

class Foo<T> {}
extension Foo: P1 where T: P1 {}
extension Foo: P2 where Foo: P1 {} // #1 crash

extension Foo: P3 where Foo: P3 {} // #2 crash
```

The crash happens because an extension doesn't yet have a generic signature. The signature is retrieved eventually when calling `lookupConformance` during `addTypeParameter`. In `#2`, the reason is quite obvious: `lookupConformance` is called on `Foo` and `P3`, which leads to retrieving the gen sig of the same extension which is still being built. `#1` is a bit trickier. First, consider this example that **does not** crash:
``` swift
extension Foo: P1 where T: P1 {}
extension Foo where Foo: P1 {}
```
This doesn't crash because the absence of `Foo: P2`, unlike `#1`, results in the extensions being type-checked sequentially. This means that while type-checking the second extension, the first already has a gen sig and the assertion doesn't get tripped. Now, back to `#1`:
``` swift
extension Foo: P1 where T: P1 {}
extension Foo: P2 where Foo: P1 {}
```
Here, with `Foo: P2`,  type-checking the first extension for some reason triggers the second extension to be type-checked as well; by the time we reach the assertion both extensions still don't have a gen sig.

The call chain is rather long and I yet haven't found out the reason of the difference in type-checking. Maybe that's the way it should be..
### Solution
The solution applied is more general and does not focus on how each individual case is type-checked. Check whether the subject of the requirement is `self` and prevent looking up conformances and adding additional requirements in that case. This isn't harmful since the requirement is invalid anyway.

Resolves [SR-7989](https://bugs.swift.org/browse/SR-7989).

Do crash fixes have to go to 4.2?