### PR TITLE
[CodeCompletion] Resolve witnesses when conformance in different file to avoid dups

### DIFF
--- a/lib/AST/LookupVisibleDecls.cpp
+++ b/lib/AST/LookupVisibleDecls.cpp
@@ -441,9 +441,13 @@ static void lookupDeclsFromProtocolsBeingConformedTo(
         continue;
       }
       if (auto *VD = dyn_cast<ValueDecl>(Member)) {
-        if (TypeResolver)
+        if (TypeResolver) {
           TypeResolver->resolveDeclSignature(VD);
-
+          if (!NormalConformance->hasWitness(VD) &&
+              (Conformance->getDeclContext()->getParentSourceFile() !=
+              FromContext->getParentSourceFile()))
+            TypeResolver->resolveWitness(NormalConformance, VD);
+        }
         // Skip value requirements that have corresponding witnesses. This cuts
         // down on duplicates.
         if (!NormalConformance->hasWitness(VD) ||

--- a/test/IDE/complete_multiple_files.swift
+++ b/test/IDE/complete_multiple_files.swift
@@ -16,9 +16,6 @@ func testObjectExpr() {
 // T1-NEXT: Keyword[self]/CurrNominal: self[#FooStruct#]; name=self
 // T1-NEXT: Decl[InstanceVar]/CurrNominal:    instanceVar[#Int#]{{; name=.+$}}
 // T1-NEXT: Decl[InstanceMethod]/CurrNominal: instanceFunc0()[#Void#]{{; name=.+$}}
-//
-// FIX-ME(SR-7225): We shouldn't duplicate this.
-// T1-NEXT: Decl[InstanceVar]/Super: instanceVar[#Int#]{{; name=.+$}}
 // T1-NEXT: End completions
 
 func testGenericObjectExpr() {
@@ -28,9 +25,6 @@ func testGenericObjectExpr() {
 // T2-NEXT: Keyword[self]/CurrNominal: self[#GenericFooStruct<Void>#]; name=self
 // T2-NEXT: Decl[InstanceVar]/CurrNominal:    instanceVar[#Int#]{{; name=.+$}}
 // T2-NEXT: Decl[InstanceMethod]/CurrNominal: instanceFunc0()[#Void#]{{; name=.+$}}
-//
-// FIX-ME(SR-7225): We shouldn't duplicate this.
-// T2-NEXT: Decl[InstanceVar]/Super: instanceVar[#Int#]{{; name=.+$}}
 // T2-NEXT: End completions
 
 func topLevel1() {


### PR DESCRIPTION
Resolves [SR-7225](https://bugs.swift.org/browse/SR-7225).