### PR TITLE
[Refactoring] Handle TupleShuffleExpr in "convert to trailing closure" action

### DIFF
--- a/lib/IDE/Refactoring.cpp
+++ b/lib/IDE/Refactoring.cpp
@@ -2775,7 +2775,7 @@ bool RefactoringActionTrailingClosure::performChange() {
     return true;
   Expr *Args = CE->getArg();
   if (auto *TSE = dyn_cast<TupleShuffleExpr>(Args))
-    Args = TSE;
+    Args = TSE->getSubExpr();
 
   Expr *ClosureArg = nullptr;
   Expr *PrevArg = nullptr;

--- a/test/refactoring/TrailingClosure/Outputs/basic/L10.swift.expected
+++ b/test/refactoring/TrailingClosure/Outputs/basic/L10.swift.expected
@@ -14,6 +14,10 @@ func testTrailingClosure() -> String {
     .map({ $0 + 1 })
 }
 
+func foobar(first: String? = nil, closure: () -> Void) { fatalError() }
+func blah() {
+  _ = foobar(closure: { print("foo") })
+}
 
 
 

--- a/test/refactoring/TrailingClosure/Outputs/basic/L13.swift.expected
+++ b/test/refactoring/TrailingClosure/Outputs/basic/L13.swift.expected
@@ -14,6 +14,10 @@ func testTrailingClosure() -> String {
     .map({ $0 + 1 })
 }
 
+func foobar(first: String? = nil, closure: () -> Void) { fatalError() }
+func blah() {
+  _ = foobar(closure: { print("foo") })
+}
 
 
 

--- a/test/refactoring/TrailingClosure/Outputs/basic/L19.swift.expected
+++ b/test/refactoring/TrailingClosure/Outputs/basic/L19.swift.expected
@@ -11,12 +11,12 @@ func testTrailingClosure() -> String {
 
   [1,2,3]
     .filter({ $0 % 2 == 0 })
-    .map { $0 + 1 }
+    .map({ $0 + 1 })
 }
 
 func foobar(first: String? = nil, closure: () -> Void) { fatalError() }
 func blah() {
-  _ = foobar(closure: { print("foo") })
+  _ = foobar { print("foo") }
 }
 
 

--- a/test/refactoring/TrailingClosure/Outputs/basic/L7.swift.expected
+++ b/test/refactoring/TrailingClosure/Outputs/basic/L7.swift.expected
@@ -14,6 +14,10 @@ func testTrailingClosure() -> String {
     .map({ $0 + 1 })
 }
 
+func foobar(first: String? = nil, closure: () -> Void) { fatalError() }
+func blah() {
+  _ = foobar(closure: { print("foo") })
+}
 
 
 

--- a/test/refactoring/TrailingClosure/Outputs/basic/L8.swift.expected
+++ b/test/refactoring/TrailingClosure/Outputs/basic/L8.swift.expected
@@ -14,6 +14,10 @@ func testTrailingClosure() -> String {
     .map({ $0 + 1 })
 }
 
+func foobar(first: String? = nil, closure: () -> Void) { fatalError() }
+func blah() {
+  _ = foobar(closure: { print("foo") })
+}
 
 
 

--- a/test/refactoring/TrailingClosure/Outputs/basic/L9.swift.expected
+++ b/test/refactoring/TrailingClosure/Outputs/basic/L9.swift.expected
@@ -14,6 +14,10 @@ func testTrailingClosure() -> String {
     .map({ $0 + 1 })
 }
 
+func foobar(first: String? = nil, closure: () -> Void) { fatalError() }
+func blah() {
+  _ = foobar(closure: { print("foo") })
+}
 
 
 

--- a/test/refactoring/TrailingClosure/basic.swift
+++ b/test/refactoring/TrailingClosure/basic.swift
@@ -13,6 +13,11 @@ func testTrailingClosure() -> String {
     .filter({ $0 % 2 == 0 })
     .map({ $0 + 1 })
 }
+
+func foobar(first: String? = nil, closure: () -> Void) { fatalError() }
+func blah() {
+  _ = foobar(closure: { print("foo") })
+}
 // RUN: %empty-directory(%t.result)
 
 // RUN: %refactor -trailingclosure -source-filename %s -pos=7:3 > %t.result/L7.swift
@@ -31,4 +36,5 @@ func testTrailingClosure() -> String {
 // RUN: diff -u %S/Outputs/basic/L13.swift.expected %t.result/L13.swift
 // RUN: %refactor -trailingclosure -source-filename %s -pos=14:5 > %t.result/L14.swift
 // RUN: diff -u %S/Outputs/basic/L14.swift.expected %t.result/L14.swift
-
+// RUN: %refactor -trailingclosure -source-filename %s -pos=19:7 > %t.result/L19.swift
+// RUN: diff -u %S/Outputs/basic/L19.swift.expected %t.result/L19.swift


### PR DESCRIPTION
Fixes crash in "Convert To Trailing Closure" action if call has defaulted parameters. Handle `TupleShuffleExpr` properly.

rdar://problem/41093898