### PR TITLE
[String] Remove `_core` which is not used in swift-corelibs-foundation anymore

### DIFF
--- a/stdlib/public/core/StringGuts.swift
+++ b/stdlib/public/core/StringGuts.swift
@@ -1311,14 +1311,6 @@ extension _SwiftStringStorage {
   }
 }
 
-extension String {
-  // FIXME: Remove. Still used by swift-corelibs-foundation
-  @available(*, deprecated, renamed: "_guts")
-  public var _core: _StringGuts {
-    return _guts
-  }
-}
-
 extension _StringGuts {
   // FIXME: Remove. Still used by swift-corelibs-foundation
   @available(*, deprecated)


### PR DESCRIPTION
The usages were removed in https://github.com/apple/swift-corelibs-foundation/pull/1584.