### PR TITLE
Use the generated ops for conv2d and pooling operations.

### DIFF
--- a/stdlib/public/TensorFlow/Gradients.swift
+++ b/stdlib/public/TensorFlow/Gradients.swift
@@ -289,9 +289,12 @@ extension Tensor where Scalar : BinaryFloatingPoint {
     strides: (Int32, Int32, Int32, Int32),
     padding: Padding
   ) -> Tensor {
-    return #tfop("Conv2DBackpropInput", shape, filter, backpropOutput,
-                 strides: [strides.0, strides.1, strides.2, strides.3],
-                 padding: padding.cName)
+    return Raw.conv2DBackpropInput(
+      inputSizes: shape,
+      filter: filter,
+      outBackprop: backpropOutput,
+      strides: [strides.0, strides.1, strides.2, strides.3],
+      padding: padding.raw)
   }
 
   /// TensorFlow builtin conv2d gradient helper for the filter.
@@ -307,9 +310,12 @@ extension Tensor where Scalar : BinaryFloatingPoint {
     strides: (Int32, Int32, Int32, Int32),
     padding: Padding
   ) -> Tensor {
-    return #tfop("Conv2DBackpropFilter", input, filterSizes, backpropOutput,
-                 strides: [strides.0, strides.1, strides.2, strides.3],
-                 padding: padding.cName)
+    return Raw.conv2DBackpropFilter(
+      input,
+      filterSizes: filterSizes,
+      outBackprop: backpropOutput,
+      strides: [strides.0, strides.1, strides.2, strides.3],
+      padding: padding.raw)
   }
 
   @_inlineable @_versioned
@@ -378,9 +384,13 @@ extension Tensor where Scalar : BinaryFloatingPoint {
   ) -> Tensor {
     // TODO: Currently this is not higher order differentiable. Redefine in
     // closed form.
-    return #tfop(
-      "MaxPoolGradV2", shapeTensor, originalValue, seed, Tensor<Int32>(kernelSize),
-      Tensor<Int32>(strides), padding: padding.cName
+    return Raw.maxPoolGradV2(
+      origInput: self,
+      origOutput: originalValue,
+      grad: seed,
+      ksize: Tensor<Int32>(kernelSize),
+      strides: Tensor<Int32>(strides),
+      padding: padding.raw
     )
   }
 
@@ -394,11 +404,12 @@ extension Tensor where Scalar : BinaryFloatingPoint {
   ) -> Tensor {
     // TODO: Currently this is not higher order differentiable. Redefine in
     // closed form.
-    return #tfop(
-      "AvgPoolGrad", shapeTensor, seed,
+    return Raw.avgPoolGrad(
+      origInputShape: shapeTensor,
+      grad: seed,
       ksize: [kernelSize.0, kernelSize.1, kernelSize.2, kernelSize.3],
       strides: [strides.0, strides.1, strides.2, strides.3],
-      padding: padding.cName
+      padding: padding.raw
     )
   }
 }

--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -1244,12 +1244,12 @@ public enum Padding {
 
 internal extension Padding {
   @_versioned @_inlineable
-  var cName: String {
+  var raw: Raw.Padding {
     @inline(__always)
     get {
       switch self {
-      case .same: return "SAME"
-      case .valid: return "VALID"
+      case .same: return .same
+      case .valid: return .valid
       }
     }
   }
@@ -1276,9 +1276,11 @@ public extension Tensor where Scalar : BinaryFloatingPoint {
     strides: (Int32, Int32, Int32, Int32),
     padding: Padding
   ) -> Tensor {
-    return #tfop("Conv2D", handle, filter,
-                 strides: [strides.0, strides.1, strides.2, strides.3],
-                 padding: padding.cName)
+    return Raw.conv2D(
+      self,
+      filter: filter,
+      strides: [strides.0, strides.1, strides.2, strides.3],
+      padding: padding.raw)
   }
 
   /// Computes a 2-D max pooling, with the specified kernel sizes, strides, and
@@ -1299,8 +1301,11 @@ public extension Tensor where Scalar : BinaryFloatingPoint {
     strides: (Int32, Int32, Int32, Int32),
     padding: Padding
   ) -> Tensor {
-    return #tfop("MaxPoolV2", handle, Tensor<Int32>(kernelSize),
-                 Tensor<Int32>(strides), padding: padding.cName)
+    return Raw.maxPoolV2(
+      self,
+      ksize: Tensor<Int32>(kernelSize),
+      strides: Tensor<Int32>(strides),
+      padding: padding.raw)
   }
 
   /// Computes a 2-D average pooling, with the specified kernel sizes, strides,
@@ -1321,11 +1326,10 @@ public extension Tensor where Scalar : BinaryFloatingPoint {
     strides: (Int32, Int32, Int32, Int32),
     padding: Padding
   ) -> Tensor {
-    return #tfop(
-      "AvgPool", handle,
+    return Raw.avgPool(
+      value: self,
       ksize: [kernelSize.0, kernelSize.1, kernelSize.2, kernelSize.3],
       strides: [strides.0, strides.1, strides.2, strides.3],
-      padding: padding.cName
-    )
+      padding: padding.raw)
   }
 }

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -59,14 +59,16 @@ public func testConvolution(x : Tensor<Float>, filter: Tensor<Float>) -> Tensor<
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testConvolution
 // CHECK: sil private @{{.*}}testConvolution{{.*}} : $@callee_owned (TensorHandle<Float>, TensorHandle<Float>) -> TensorHandle<Float> {
 // CHECK: bb0(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>):
-// CHECK-NEXT:  %2 = metatype $@thin Int32.Type
-// CHECK-NEXT:  %3 = integer_literal $Builtin.Int32, 1
-// CHECK-NEXT:  %4 = integer_literal $Builtin.Int32, 2
-// CHECK-NEXT:  %5 = integer_literal $Builtin.Int32, 3
-// CHECK-NEXT:  %6 = integer_literal $Builtin.Int32, 4
-// CHECK-NEXT:  %7 = string_literal utf8 "SAME"
-// CHECK:       %9 = builtin "__tfop_Conv2D,$in,$in,strides$array,$elt,$elt,$elt,$elt,padding,device"(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>, %2 : $@thin Int32.Type, %3 : $Builtin.Int32, %4 : $Builtin.Int32, %5 : $Builtin.Int32, %6 : $Builtin.Int32, %7 : $Builtin.RawPointer
-// CHECK-NEXT:  return %9 : $TensorHandle<Float>
+// CHECK-NEXT:  %2 = metatype $@thick Float.Type
+// CHECK-NEXT:  %3 = metatype $@thin Int32.Type
+// CHECK-NEXT:  %4 = integer_literal $Builtin.Int32, 1
+// CHECK-NEXT:  %5 = integer_literal $Builtin.Int32, 2
+// CHECK-NEXT:  %6 = integer_literal $Builtin.Int32, 3
+// CHECK-NEXT:  %7 = integer_literal $Builtin.Int32, 4
+// CHECK-NEXT:  %8 = integer_literal $Builtin.Int1, -1
+// CHECK-NEXT:  %9 = string_literal utf8 "SAME"
+// CHECK:       builtin "__tfop_Conv2D,$in,$in,T,strides$array,$elt,$elt,$elt,$elt,use_cudnn_on_gpu,padding,data_format,dilations$array,$elt,$elt,$elt,$elt,device"(%0 : $TensorHandle<Float>, %1 : $TensorHandle<Float>, %2 : $@thick Float.Type, %3 : $@thin Int32.Type, %4 : $Builtin.Int32, %5 : $Builtin.Int32, %6 : $Builtin.Int32, %7 : $Builtin.Int32, %8 : $Builtin.Int1, %9 : $Builtin.RawPointer, %10 : $Builtin.RawPointer, %11 : $@thin Int32.Type, %12 : $Builtin.Int32, %13 : $Builtin.Int32, %14 : $Builtin.Int32, %15 : $Builtin.Int32, %16 : $Builtin.RawPointer) : $TensorHandle<Float>
+// CHECK-NEXT:  return %17 : $TensorHandle<Float>
 // CHECK-NEXT:}
 
 


### PR DESCRIPTION
This replaces some occurrences of `#tfop` with the appropriate generated raw ops for convolution and pooling operations (this hasn't been done before because of an issue when inlining enums).