### PR TITLE
[stdlib] Add @usableFromInline to internal typealiases that need it

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -299,9 +299,11 @@
 @_fixed_layout
 public struct Array<Element>: _DestructorSafeContainer {
   #if _runtime(_ObjC)
-    internal typealias _Buffer = _ArrayBuffer<Element>
+  @usableFromInline
+  internal typealias _Buffer = _ArrayBuffer<Element>
   #else
-    internal typealias _Buffer = _ContiguousArrayBuffer<Element>
+  @usableFromInline
+  internal typealias _Buffer = _ContiguousArrayBuffer<Element>
   #endif
 
   @usableFromInline

--- a/stdlib/public/core/ArrayBuffer.swift
+++ b/stdlib/public/core/ArrayBuffer.swift
@@ -18,6 +18,7 @@
 #if _runtime(_ObjC)
 import SwiftShims
 
+@usableFromInline
 internal typealias _ArrayBridgeStorage
   = _BridgeStorage<_ContiguousArrayStorageBase, _NSArrayCore>
 
@@ -520,6 +521,7 @@ extension _ArrayBuffer {
 
   //===--- private --------------------------------------------------------===//
   internal typealias Storage = _ContiguousArrayStorage<Element>
+  @usableFromInline
   internal typealias NativeBuffer = _ContiguousArrayBuffer<Element>
 
   @inlinable

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -116,7 +116,8 @@
 
 @_fixed_layout
 public struct ArraySlice<Element>: _DestructorSafeContainer {
-    internal typealias _Buffer = _SliceBuffer<Element>
+  @usableFromInline
+  internal typealias _Buffer = _SliceBuffer<Element>
 
   @usableFromInline
   internal var _buffer: _Buffer

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -373,6 +373,7 @@ extension Character : CustomDebugStringConvertible {
 }
 
 extension Character {
+  @usableFromInline
   internal typealias _SmallUTF16 = _UIntBuffer<UInt64, Unicode.UTF16.CodeUnit>
 
   @inlinable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/Codable.swift.gyb
+++ b/stdlib/public/core/Codable.swift.gyb
@@ -1490,6 +1490,7 @@ internal class _KeyedEncodingContainerBase<Key : CodingKey> {
 internal final class _KeyedEncodingContainerBox<
   Concrete : KeyedEncodingContainerProtocol
 > : _KeyedEncodingContainerBase<Concrete.Key> {
+  @usableFromInline
   typealias Key = Concrete.Key
 
   @usableFromInline
@@ -1663,6 +1664,7 @@ internal class _KeyedDecodingContainerBase<Key : CodingKey> {
 internal final class _KeyedDecodingContainerBox<
   Concrete : KeyedDecodingContainerProtocol
 > : _KeyedDecodingContainerBase<Concrete.Key> {
+  @usableFromInline
   typealias Key = Concrete.Key
 
   @usableFromInline

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -35,7 +35,8 @@
 /// which `ContiguousArray` shares most properties and methods.
 @_fixed_layout
 public struct ContiguousArray<Element>: _DestructorSafeContainer {
-    internal typealias _Buffer = _ContiguousArrayBuffer<Element>
+  @usableFromInline
+  internal typealias _Buffer = _ContiguousArrayBuffer<Element>
 
   @usableFromInline
   internal var _buffer: _Buffer

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -382,8 +382,11 @@ import SwiftShims
 @_fixed_layout
 public struct Dictionary<Key: Hashable, Value> {
 
+  @usableFromInline
   internal typealias _Self = Dictionary<Key, Value>
+  @usableFromInline
   internal typealias _VariantBuffer = _VariantDictionaryBuffer<Key, Value>
+  @usableFromInline
   internal typealias _NativeBuffer = _NativeDictionaryBuffer<Key, Value>
 
   /// The element type of a dictionary: a tuple containing an individual
@@ -1835,6 +1838,7 @@ public func _dictionaryBridgeFromObjectiveCConditional<
 internal class _RawNativeDictionaryStorage
   : _SwiftNativeNSDictionary, _NSDictionaryCore
 {
+  @usableFromInline
   internal typealias RawStorage = _RawNativeDictionaryStorage
 
   @usableFromInline // FIXME(sil-serialize-all)
@@ -2008,7 +2012,9 @@ internal class _TypedNativeDictionaryStorage<Key, Value>
 final internal class _HashableTypedNativeDictionaryStorage<Key: Hashable, Value>
   : _TypedNativeDictionaryStorage<Key, Value> {
 
+  @usableFromInline
   internal typealias FullContainer = Dictionary<Key, Value>
+  @usableFromInline
   internal typealias Buffer = _NativeDictionaryBuffer<Key, Value>
 
   // This type is made with allocWithTailElems, so no init is ever called.
@@ -2157,11 +2163,16 @@ final internal class _HashableTypedNativeDictionaryStorage<Key: Hashable, Value>
 @_fixed_layout
 internal struct _NativeDictionaryBuffer<Key, Value> {
 
+  @usableFromInline // FIXME(sil-serialize-all)
   internal typealias RawStorage = _RawNativeDictionaryStorage
+  @usableFromInline // FIXME(sil-serialize-all)
   internal typealias TypedStorage = _TypedNativeDictionaryStorage<Key, Value>
+  @usableFromInline // FIXME(sil-serialize-all)
   internal typealias Buffer = _NativeDictionaryBuffer<Key, Value>
+  @usableFromInline // FIXME(sil-serialize-all)
   internal typealias Index = _NativeDictionaryIndex<Key, Value>
 
+  @usableFromInline
   internal typealias SequenceElementWithoutLabels = (Key, Value)
 
   /// See this comments on _RawNativeDictionaryStorage and its subclasses to
@@ -2406,8 +2417,10 @@ internal struct _NativeDictionaryBuffer<Key, Value> {
 
 extension _NativeDictionaryBuffer where Key: Hashable
 {
+  @usableFromInline
   internal typealias HashTypedStorage =
     _HashableTypedNativeDictionaryStorage<Key, Value>
+  @usableFromInline
   internal typealias SequenceElement = (key: Key, value: Value)
 
   @inlinable // FIXME(sil-serialize-all)
@@ -2657,7 +2670,9 @@ extension _NativeDictionaryBuffer where Key: Hashable
 final internal class _NativeDictionaryNSEnumerator<Key, Value>
   : _SwiftNativeNSEnumerator, _NSEnumerator {
 
+  @usableFromInline
   internal typealias Buffer = _NativeDictionaryBuffer<Key, Value>
+  @usableFromInline
   internal typealias Index = _NativeDictionaryIndex<Key, Value>
 
   @inlinable // FIXME(sil-serialize-all)
@@ -2739,9 +2754,13 @@ final internal class _NativeDictionaryNSEnumerator<Key, Value>
 final internal class _SwiftDeferredNSDictionary<Key: Hashable, Value>
   : _SwiftNativeNSDictionary, _NSDictionaryCore {
 
+  @usableFromInline
   internal typealias NativeBuffer = _NativeDictionaryBuffer<Key, Value>
+  @usableFromInline
   internal typealias BridgedBuffer = _NativeDictionaryBuffer<AnyObject, AnyObject>
+  @usableFromInline
   internal typealias NativeIndex = _NativeDictionaryIndex<Key, Value>
+  @usableFromInline
   internal typealias BridgedIndex = _NativeDictionaryIndex<AnyObject, AnyObject>
 
   @inlinable // FIXME(sil-serialize-all)
@@ -3038,11 +3057,16 @@ internal struct _CocoaDictionaryBuffer: _HashBuffer {
     self.cocoaDictionary = cocoaDictionary
   }
 
+  @usableFromInline
   internal typealias Index = _CocoaDictionaryIndex
+  @usableFromInline
   internal typealias SequenceElement = (AnyObject, AnyObject)
+  @usableFromInline
   internal typealias SequenceElementWithoutLabels = (AnyObject, AnyObject)
 
+  @usableFromInline
   internal typealias Key = AnyObject
+  @usableFromInline
   internal typealias Value = AnyObject
 
   @inlinable // FIXME(sil-serialize-all)
@@ -3161,13 +3185,19 @@ internal struct _CocoaDictionaryBuffer: _HashBuffer {
 @_frozen
 internal enum _VariantDictionaryBuffer<Key: Hashable, Value>: _HashBuffer {
 
+  @usableFromInline
   internal typealias NativeBuffer = _NativeDictionaryBuffer<Key, Value>
+  @usableFromInline
   internal typealias NativeIndex = _NativeDictionaryIndex<Key, Value>
 #if _runtime(_ObjC)
+  @usableFromInline
   internal typealias CocoaBuffer = _CocoaDictionaryBuffer
 #endif
+  @usableFromInline
   internal typealias SequenceElement = (key: Key, value: Value)
+  @usableFromInline
   internal typealias SequenceElementWithoutLabels = (key: Key, value: Value)
+  @usableFromInline
   internal typealias SelfType = _VariantDictionaryBuffer
 
   case native(NativeBuffer)
@@ -3389,6 +3419,7 @@ internal enum _VariantDictionaryBuffer<Key: Hashable, Value>: _HashBuffer {
   // _HashBuffer conformance
   //
 
+  @usableFromInline
   internal typealias Index = DictionaryIndex<Key, Value>
 
   @inlinable // FIXME(sil-serialize-all)
@@ -4259,9 +4290,12 @@ extension _CocoaDictionaryIndex {
 @_frozen // FIXME(sil-serialize-all)
 @usableFromInline // FIXME(sil-serialize-all)
 internal enum DictionaryIndexRepresentation<Key: Hashable, Value> {
+  @usableFromInline
   typealias _Index = DictionaryIndex<Key, Value>
+  @usableFromInline
   typealias _NativeIndex = _Index._NativeIndex
 #if _runtime(_ObjC)
+  @usableFromInline
   typealias _CocoaIndex = _Index._CocoaIndex
 #endif
 
@@ -4292,8 +4326,10 @@ extension Dictionary {
     // safe to copy the state.  So, we cannot implement Index that is a value
     // type for bridged NSDictionary in terms of Cocoa enumeration facilities.
 
+    @usableFromInline
     internal typealias _NativeIndex = _NativeDictionaryIndex<Key, Value>
 #if _runtime(_ObjC)
+    @usableFromInline
     internal typealias _CocoaIndex = _CocoaDictionaryIndex
 #endif
 
@@ -4423,6 +4459,7 @@ extension Dictionary.Index {
 @_fixed_layout // FIXME(sil-serialize-all)
 @usableFromInline
 final internal class _CocoaDictionaryIterator: IteratorProtocol {
+  @usableFromInline
   internal typealias Element = (AnyObject, AnyObject)
 
   // Cocoa Dictionary iterator has to be a class, otherwise we cannot
@@ -4509,9 +4546,11 @@ final internal class _CocoaDictionaryIterator: IteratorProtocol {
 @usableFromInline
 @_frozen // FIXME(sil-serialize-all)
 internal enum DictionaryIteratorRepresentation<Key: Hashable, Value> {
+  @usableFromInline
   internal typealias _Iterator = DictionaryIterator<Key, Value>
-  internal typealias _NativeBuffer =
-    _NativeDictionaryBuffer<Key, Value>
+  @usableFromInline
+  internal typealias _NativeBuffer = _NativeDictionaryBuffer<Key, Value>
+  @usableFromInline
   internal typealias _NativeIndex = _Iterator._NativeIndex
 
   // For native buffer, we keep two indices to keep track of the iteration
@@ -4540,8 +4579,9 @@ public struct DictionaryIterator<Key: Hashable, Value>: IteratorProtocol {
   // Index, which is multi-pass, it is suitable for implementing a
   // IteratorProtocol, which is being consumed as iteration proceeds.
 
-  internal typealias _NativeBuffer =
-    _NativeDictionaryBuffer<Key, Value>
+  @usableFromInline
+  internal typealias _NativeBuffer = _NativeDictionaryBuffer<Key, Value>
+  @usableFromInline
   internal typealias _NativeIndex = _NativeDictionaryIndex<Key, Value>
 
   @usableFromInline

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -411,6 +411,7 @@ internal class _AnyRandomAccessCollectionBox<Element>
 @usableFromInline
 internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Element>
 {
+  @usableFromInline
   internal typealias Element = S.Element
 
   @inline(__always)

--- a/stdlib/public/core/FixedArray.swift.gyb
+++ b/stdlib/public/core/FixedArray.swift.gyb
@@ -60,6 +60,7 @@ extension _FixedArray${N} {
 }
 
 extension _FixedArray${N} : RandomAccessCollection, MutableCollection {
+  @usableFromInline
   internal typealias Index = Int
 
   @inlinable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/HeapBuffer.swift
+++ b/stdlib/public/core/HeapBuffer.swift
@@ -11,7 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftShims
-typealias _HeapObject = SwiftShims.HeapObject
+
+@usableFromInline // FIXME(sil-serialize-all)
+internal typealias _HeapObject = SwiftShims.HeapObject
 
 @usableFromInline
 internal protocol _HeapBufferHeader_ {
@@ -30,13 +32,16 @@ internal struct _HeapBufferHeader<T> : _HeapBufferHeader_ {
   internal var value: T
 }
 
+@usableFromInline
 internal typealias _HeapBuffer<Value,Element>
   = ManagedBufferPointer<_HeapBufferHeader<Value>, Element>
 
+@usableFromInline
 internal typealias _HeapBufferStorage<Value,Element>
   = ManagedBuffer<_HeapBufferHeader<Value>, Element>
 
 extension ManagedBufferPointer where Header : _HeapBufferHeader_ {
+  @usableFromInline // FIXME(sil-serialize-all)
   internal typealias Value = Header.Value
 
   @inlinable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -209,6 +209,7 @@ public class KeyPath<Root, Value>: PartialKeyPath<Root> {
   }
   
   // MARK: Implementation
+  @usableFromInline // FIXME(sil-serialize-all)
   internal typealias Kind = KeyPathKind
   @inlinable // FIXME(sil-serialize-all)
   internal class var kind: Kind { return .readOnly }
@@ -650,6 +651,7 @@ internal final class ClassHolder<ProjectionType> {
 
   /// The type of the scratch record passed to the runtime to record
   /// accesses to guarantee exlcusive access.
+  @usableFromInline // FIXME(sil-serialize-all)
   internal typealias AccessRecord = Builtin.UnsafeValueBuffer
 
   @usableFromInline // FIXME(sil-serialize-all)
@@ -1036,8 +1038,10 @@ internal struct RawKeyPathComponent {
       as: UnsafeRawPointer.self)
   }
 
+  @usableFromInline // FIXME(sil-serialize-all)
   internal typealias ComputedArgumentLayoutFn = @convention(thin)
     (_ patternArguments: UnsafeRawPointer) -> (size: Int, alignmentMask: Int)
+  @usableFromInline // FIXME(sil-serialize-all)
   internal typealias ComputedArgumentInitializerFn = @convention(thin)
     (_ patternArguments: UnsafeRawPointer,
      _ instanceArguments: UnsafeMutableRawPointer) -> ()
@@ -2181,6 +2185,7 @@ internal func _getKeyPath_instantiateInline(
     unsafeBitCast(keyPathClass, to: OpaquePointer.self))
 }
 
+@usableFromInline // FIXME(sil-serialize-all)
 internal typealias MetadataAccessor =
   @convention(c) (UnsafeRawPointer) -> UnsafeRawPointer
 

--- a/stdlib/public/core/ManagedBuffer.swift
+++ b/stdlib/public/core/ManagedBuffer.swift
@@ -369,6 +369,7 @@ public struct ManagedBufferPointer<Header, Element> : Equatable {
     _nativeBuffer = Builtin.unsafeCastToNativeObject(buffer)
   }
 
+  @usableFromInline // FIXME(sil-serialize-all)
   internal typealias _My = ManagedBufferPointer
 
   @inlinable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/ReflectionMirror.swift
+++ b/stdlib/public/core/ReflectionMirror.swift
@@ -18,6 +18,7 @@ internal func _getNormalizedType<T>(_: T, type: Any.Type) -> Any.Type
 @_silgen_name("swift_reflectionMirror_count")
 internal func _getChildCount<T>(_: T, type: Any.Type) -> Int
 
+@usableFromInline // FIXME(sil-serialize-all)
 internal typealias NameFreeFunc = @convention(c) (UnsafePointer<CChar>?) -> Void
 
 @usableFromInline // FIXME(sil-serialize-all)

--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -745,7 +745,8 @@ internal struct _PrefixSequence<Base : IteratorProtocol>
 internal struct _DropWhileSequence<Base : IteratorProtocol>
     : Sequence, IteratorProtocol {
 
-      typealias Element = Base.Element
+  @usableFromInline
+  typealias Element = Base.Element
 
   @usableFromInline
   internal var _iterator: Base

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -152,7 +152,9 @@ import SwiftShims
 /// share buffer.
 @_fixed_layout
 public struct Set<Element: Hashable> {
+  @usableFromInline
   internal typealias _VariantBuffer = _VariantSetBuffer<Element>
+  @usableFromInline
   internal typealias _NativeBuffer = _NativeSetBuffer<Element>
 
   @usableFromInline
@@ -1458,6 +1460,7 @@ extension Set {
 internal class _RawNativeSetStorage:
   _SwiftNativeNSSet, _NSSetCore
 {
+  @usableFromInline
   internal typealias RawStorage = _RawNativeSetStorage
 
   @usableFromInline // FIXME(sil-serialize-all)
@@ -1569,7 +1572,9 @@ internal class _RawNativeSetStorage:
 @usableFromInline
 internal class _TypedNativeSetStorage<Element>: _RawNativeSetStorage {
 
+  @usableFromInline
   internal typealias Key = Element
+  @usableFromInline
   internal typealias Value = Element
 
   deinit {
@@ -1609,7 +1614,9 @@ internal class _TypedNativeSetStorage<Element>: _RawNativeSetStorage {
 final internal class _HashableTypedNativeSetStorage<Element: Hashable>
   : _TypedNativeSetStorage<Element> {
 
+  @usableFromInline
   internal typealias FullContainer = Set<Element>
+  @usableFromInline
   internal typealias Buffer = _NativeSetBuffer<Element>
 
   // This type is made with allocWithTailElems, so no init is ever called.
@@ -1723,13 +1730,20 @@ final internal class _HashableTypedNativeSetStorage<Element: Hashable>
 @_fixed_layout
 internal struct _NativeSetBuffer<Element> {
 
+  @usableFromInline
   internal typealias RawStorage = _RawNativeSetStorage
+  @usableFromInline
   internal typealias TypedStorage = _TypedNativeSetStorage<Element>
+  @usableFromInline
   internal typealias Buffer = _NativeSetBuffer<Element>
+  @usableFromInline
   internal typealias Index = _NativeSetIndex<Element>
 
+  @usableFromInline
   internal typealias Key = Element
+  @usableFromInline
   internal typealias Value = Element
+  @usableFromInline
   internal typealias SequenceElementWithoutLabels = Element
 
   /// See this comments on _RawNativeSetStorage and its subclasses to
@@ -1959,8 +1973,10 @@ internal struct _NativeSetBuffer<Element> {
 
 extension _NativeSetBuffer where Element: Hashable
 {
+  @usableFromInline
   internal typealias HashTypedStorage =
     _HashableTypedNativeSetStorage<Element>
+  @usableFromInline
   internal typealias SequenceElement = Element
 
   @inlinable // FIXME(sil-serialize-all)
@@ -2214,7 +2230,9 @@ extension _NativeSetBuffer where Element: Hashable
 final internal class _NativeSetNSEnumerator<Element>
   : _SwiftNativeNSEnumerator, _NSEnumerator {
 
+  @usableFromInline
   internal typealias Buffer = _NativeSetBuffer<Element>
+  @usableFromInline
   internal typealias Index = _NativeSetIndex<Element>
 
   @inlinable // FIXME(sil-serialize-all)
@@ -2296,12 +2314,18 @@ final internal class _NativeSetNSEnumerator<Element>
 final internal class _SwiftDeferredNSSet<Element: Hashable>
   : _SwiftNativeNSSet, _NSSetCore {
 
+  @usableFromInline
   internal typealias NativeBuffer = _NativeSetBuffer<Element>
+  @usableFromInline
   internal typealias BridgedBuffer = _NativeSetBuffer<AnyObject>
+  @usableFromInline
   internal typealias NativeIndex = _NativeSetIndex<Element>
+  @usableFromInline
   internal typealias BridgedIndex = _NativeSetIndex<AnyObject>
 
+  @usableFromInline
   internal typealias Key = Element
+  @usableFromInline
   internal typealias Value = Element
 
   @inlinable // FIXME(sil-serialize-all)
@@ -2522,11 +2546,16 @@ internal struct _CocoaSetBuffer: _HashBuffer {
     self.cocoaSet = cocoaSet
   }
 
+  @usableFromInline
   internal typealias Index = _CocoaSetIndex
+  @usableFromInline
   internal typealias SequenceElement = AnyObject
+  @usableFromInline
   internal typealias SequenceElementWithoutLabels = AnyObject
 
+  @usableFromInline
   internal typealias Key = AnyObject
+  @usableFromInline
   internal typealias Value = AnyObject
 
   @inlinable // FIXME(sil-serialize-all)
@@ -2645,16 +2674,24 @@ internal struct _CocoaSetBuffer: _HashBuffer {
 @_frozen
 internal enum _VariantSetBuffer<Element: Hashable>: _HashBuffer {
 
+  @usableFromInline
   internal typealias NativeBuffer = _NativeSetBuffer<Element>
+  @usableFromInline
   internal typealias NativeIndex = _NativeSetIndex<Element>
 #if _runtime(_ObjC)
+  @usableFromInline
   internal typealias CocoaBuffer = _CocoaSetBuffer
 #endif
+  @usableFromInline
   internal typealias SequenceElement = Element
+  @usableFromInline
   internal typealias SequenceElementWithoutLabels = Element
+  @usableFromInline
   internal typealias SelfType = _VariantSetBuffer
 
+  @usableFromInline
   internal typealias Key = Element
+  @usableFromInline
   internal typealias Value = Element
 
   case native(NativeBuffer)
@@ -2871,6 +2908,7 @@ internal enum _VariantSetBuffer<Element: Hashable>: _HashBuffer {
   // _HashBuffer conformance
   //
 
+  @usableFromInline
   internal typealias Index = SetIndex<Element>
 
   @inlinable // FIXME(sil-serialize-all)
@@ -3524,9 +3562,12 @@ extension _CocoaSetIndex {
 @_frozen // FIXME(sil-serialize-all)
 @usableFromInline // FIXME(sil-serialize-all)
 internal enum SetIndexRepresentation<Element: Hashable> {
+  @usableFromInline
   typealias _Index = SetIndex<Element>
+  @usableFromInline
   typealias _NativeIndex = _Index._NativeIndex
 #if _runtime(_ObjC)
+  @usableFromInline
   typealias _CocoaIndex = _Index._CocoaIndex
 #endif
 
@@ -3547,12 +3588,16 @@ extension Set {
     // safe to copy the state.  So, we cannot implement Index that is a value
     // type for bridged NSSet in terms of Cocoa enumeration facilities.
 
+    @usableFromInline
     internal typealias _NativeIndex = _NativeSetIndex<Element>
 #if _runtime(_ObjC)
+    @usableFromInline
     internal typealias _CocoaIndex = _CocoaSetIndex
 #endif
 
+    @usableFromInline
     internal typealias Key = Element
+    @usableFromInline
     internal typealias Value = Element
 
     @inlinable // FIXME(sil-serialize-all)
@@ -3684,6 +3729,7 @@ extension Set.Index {
 @_fixed_layout // FIXME(sil-serialize-all)
 @usableFromInline
 final internal class _CocoaSetIterator: IteratorProtocol {
+  @usableFromInline
   internal typealias Element = AnyObject
 
   // Cocoa Set iterator has to be a class, otherwise we cannot
@@ -3769,9 +3815,11 @@ final internal class _CocoaSetIterator: IteratorProtocol {
 @usableFromInline
 @_frozen // FIXME(sil-serialize-all)
 internal enum SetIteratorRepresentation<Element: Hashable> {
+  @usableFromInline
   internal typealias _Iterator = SetIterator<Element>
-  internal typealias _NativeBuffer =
-    _NativeSetBuffer<Element>
+  @usableFromInline
+  internal typealias _NativeBuffer = _NativeSetBuffer<Element>
+  @usableFromInline
   internal typealias _NativeIndex = _Iterator._NativeIndex
 
   // For native buffer, we keep two indices to keep track of the iteration
@@ -3800,8 +3848,9 @@ public struct SetIterator<Element: Hashable>: IteratorProtocol {
   // Index, which is multi-pass, it is suitable for implementing a
   // IteratorProtocol, which is being consumed as iteration proceeds.
 
-  internal typealias _NativeBuffer =
-    _NativeSetBuffer<Element>
+  @usableFromInline
+  internal typealias _NativeBuffer = _NativeSetBuffer<Element>
+  @usableFromInline
   internal typealias _NativeIndex = _NativeSetIndex<Element>
 
   @usableFromInline

--- a/stdlib/public/core/SliceBuffer.swift
+++ b/stdlib/public/core/SliceBuffer.swift
@@ -18,6 +18,7 @@ internal struct _SliceBuffer<Element>
     RandomAccessCollection
 {
   internal typealias NativeStorage = _ContiguousArrayStorage<Element>
+  @usableFromInline
   internal typealias NativeBuffer = _ContiguousArrayBuffer<Element>
 
   @inlinable

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -32,6 +32,7 @@ func unsupportedOn32bit() -> Never { _conditionallyUnreachable() }
 @_fixed_layout
 public // @testable
 struct _SmallUTF8String {
+  @usableFromInline
   typealias _RawBitPattern = (low: UInt, high: UInt)
 
   //
@@ -731,7 +732,8 @@ extension _SmallUTF8String {
 }
 
 extension _SmallUTF8String {//}: _StringVariant {
-  typealias TranscodedBuffer = _SmallUTF16StringBuffer
+  @usableFromInline
+  internal typealias TranscodedBuffer = _SmallUTF16StringBuffer
 
   @inlinable
   @discardableResult

--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -204,6 +204,7 @@ extension String._CharacterView {
 }
 
 extension String._CharacterView {
+  @usableFromInline
   internal typealias UnicodeScalarView = String.UnicodeScalarView
 
   @inlinable // FIXME(sil-serialize-all)

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -13,6 +13,7 @@ extension String {
   /// A position of a character or code unit in a string.
   @_fixed_layout // FIXME(sil-serialize-all)
   public struct Index {
+    @usableFromInline
     internal typealias _UTF8Buffer = UTF8.EncodedScalar
 
     @usableFromInline // FIXME(sil-serialize-all)

--- a/stdlib/public/core/StringStorage.swift
+++ b/stdlib/public/core/StringStorage.swift
@@ -43,6 +43,7 @@ class _SwiftRawStringStorage : _SwiftNativeNSString {
 }
 
 internal typealias _ASCIIStringStorage = _SwiftStringStorage<UInt8>
+@usableFromInline // FIXME(sil-serialize-all)
 internal typealias _UTF16StringStorage = _SwiftStringStorage<UTF16.CodeUnit>
 
 @_fixed_layout

--- a/stdlib/public/core/StringSwitch.swift
+++ b/stdlib/public/core/StringSwitch.swift
@@ -39,6 +39,7 @@ struct _OpaqueStringSwitchCache {
   var b: Builtin.Word
 }
 
+@usableFromInline // FIXME(sil-serialize-all)
 internal typealias _StringSwitchCache = Dictionary<String, Int>
 
 @_fixed_layout // FIXME(sil-serialize-all)

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -515,7 +515,9 @@ extension String.UTF8View : _SwiftStringView {
 extension String.UTF8View {
   @_fixed_layout // FIXME(sil-serialize-all)
   public struct Iterator {
+    @usableFromInline
     internal typealias _OutputBuffer = _ValidUTF8Buffer<UInt64>
+
     @usableFromInline
     internal let _guts: _StringGuts
     @usableFromInline

--- a/stdlib/public/core/SwiftNativeNSArray.swift
+++ b/stdlib/public/core/SwiftNativeNSArray.swift
@@ -161,6 +161,7 @@ extension _SwiftNativeNSArrayWithContiguousStorage : _NSArrayCore {
       to: Optional<AnyObject>.self)
   }
 
+  @usableFromInline
   internal typealias HeapBufferStorage = _HeapBufferStorage<Int, AnyObject>
 
   @inlinable

--- a/stdlib/public/core/UnmanagedOpaqueString.swift
+++ b/stdlib/public/core/UnmanagedOpaqueString.swift
@@ -93,6 +93,7 @@ extension _UnmanagedOpaqueString : Sequence {
   @usableFromInline
   @_fixed_layout
   struct Iterator : IteratorProtocol {
+    @usableFromInline
     internal typealias Element = UTF16.CodeUnit
 
 #if _runtime(_ObjC) // FIXME unify

--- a/stdlib/public/core/VarArgs.swift
+++ b/stdlib/public/core/VarArgs.swift
@@ -93,10 +93,14 @@ internal let _registerSaveWords = _countGPRegisters
 #endif
 
 #if arch(s390x)
+@usableFromInline
 internal typealias _VAUInt = CUnsignedLongLong
+@usableFromInline
 internal typealias _VAInt  = Int64
 #else
+@usableFromInline
 internal typealias _VAUInt = CUnsignedInt
+@usableFromInline
 internal typealias _VAInt  = Int32
 #endif
 


### PR DESCRIPTION
This fixes 3659 issues in the standard library, uncovered by @slavapestov's change in https://github.com/apple/swift/pull/17257