### PR TITLE
 [4.2] Cleanup dead blocks after noreturn folding 

### DIFF
--- a/include/swift/SILOptimizer/Utils/CFG.h
+++ b/include/swift/SILOptimizer/Utils/CFG.h
@@ -171,6 +171,9 @@ void completeJointPostDominanceSet(
     ArrayRef<SILBasicBlock *> UserBlocks, ArrayRef<SILBasicBlock *> DefBlocks,
     llvm::SmallVectorImpl<SILBasicBlock *> &Completion);
 
+/// \brief Remove all unreachable blocks in a function.
+bool removeUnreachableBlocks(SILFunction &Fn);
+
 } // end namespace swift
 
 #endif

--- a/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
+++ b/lib/SILOptimizer/Transforms/SimplifyCFG.cpp
@@ -191,14 +191,6 @@ namespace {
     void findLoopHeaders();
   };
 
-  class RemoveUnreachable {
-    SILFunction &Fn;
-    llvm::SmallSet<SILBasicBlock *, 8> Visited;
-  public:
-    RemoveUnreachable(SILFunction &Fn) : Fn(Fn) { }
-    void visit(SILBasicBlock *BB);
-    bool run();
-  };
 } // end anonymous namespace
 
 /// Return true if there are any users of V outside the specified block.
@@ -2161,36 +2153,6 @@ bool SimplifyCFG::simplifyTermWithIdenticalDestBlocks(SILBasicBlock *BB) {
   return true;
 }
 
-void RemoveUnreachable::visit(SILBasicBlock *BB) {
-  if (!Visited.insert(BB).second)
-    return;
-
-  for (auto &Succ : BB->getSuccessors())
-    visit(Succ);
-}
-
-bool RemoveUnreachable::run() {
-  bool Changed = false;
-
-  // Clear each time we run so that we can run multiple times.
-  Visited.clear();
-
-  // Visit all blocks reachable from the entry block of the function.
-  visit(&*Fn.begin());
-
-  // Remove the blocks we never reached.
-  for (auto It = Fn.begin(), End = Fn.end(); It != End; ) {
-    auto *BB = &*It++;
-    if (!Visited.count(BB)) {
-      DEBUG(llvm::dbgs() << "remove unreachable bb" << BB->getDebugID() << '\n');
-      removeDeadBlock(BB);
-      Changed = true;
-    }
-  }
-
-  return Changed;
-}
-
 /// Checks if the block contains a cond_fail as first side-effect instruction
 /// and tries to move it to the predecessors (if beneficial). A sequence
 ///
@@ -2844,10 +2806,8 @@ bool SimplifyCFG::run() {
 
   DEBUG(llvm::dbgs() << "### Run SimplifyCFG on " << Fn.getName() << '\n');
 
-  RemoveUnreachable RU(Fn);
-
   // First remove any block not reachable from the entry.
-  bool Changed = RU.run();
+  bool Changed = removeUnreachableBlocks(Fn);
 
   // Find the set of loop headers. We don't want to jump-thread through headers.
   findLoopHeaders();
@@ -2860,7 +2820,7 @@ bool SimplifyCFG::run() {
   if (simplifyBlocks()) {
     // Simplifying other blocks might have resulted in unreachable
     // loops.
-    RU.run();
+    removeUnreachableBlocks(Fn);
 
     Changed = true;
   }
@@ -2880,14 +2840,14 @@ bool SimplifyCFG::run() {
   if (simplifyBlocks()) {
     // Simplifying other blocks might have resulted in unreachable
     // loops.
-    RU.run();
+    removeUnreachableBlocks(Fn);
     Changed = true;
   }
 
   if (tailDuplicateObjCMethodCallSuccessorBlocks()) {
     Changed = true;
     if (simplifyBlocks())
-      RU.run();
+      removeUnreachableBlocks(Fn);
   }
 
   // Split all critical edges from non cond_br terminators.

--- a/test/SILOptimizer/mandatory_inlining.swift
+++ b/test/SILOptimizer/mandatory_inlining.swift
@@ -175,3 +175,16 @@ public class A {
     }
   }
 }
+
+// This used to crash during mandatory inlining because noreturn folding would
+// create sil instructions with undef in unreachable code.
+func dontCrash() {
+  fatalError() // expected-note {{a call to a never-returning function}}
+  let k = "foo" // expected-warning {{will never be executed}}
+  switch k {
+  case "bar":
+    return
+  default:
+    fatalError("baz \(k)")
+  }
+}


### PR DESCRIPTION
Follow-up passes might not handle blocks with undef instruction operands
well.

rdar://41139395
