### PR TITLE
[SourceKit] Disable expensive SIL options

### DIFF
--- a/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp
@@ -464,6 +464,9 @@ bool SwiftASTManager::initCompilerInvocation(CompilerInvocation &Invocation,
   // We don't care about LLVMArgs
   FrontendOpts.LLVMArgs.clear();
 
+  // Disable expensive SIL options to reduce time spent in SILGen.
+  disableExpensiveSILOptions(Invocation.getSILOptions());
+
   return false;
 }
 

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.cpp
@@ -18,6 +18,7 @@
 
 #include "swift/AST/ASTVisitor.h"
 #include "swift/AST/ClangModuleLoader.h"
+#include "swift/AST/SILOptions.h"
 #include "swift/AST/USRGeneration.h"
 #include "swift/Config.h"
 #include "swift/IDE/CodeCompletion.h"
@@ -776,4 +777,14 @@ CloseClangModuleFiles::~CloseClangModuleFiles() {
     if (!M->isSubModule() && M->getASTFile())
       M->getASTFile()->closeFile();
   }
+}
+
+void SourceKit::disableExpensiveSILOptions(SILOptions &Opts) {
+  // Disable the sanitizers.
+  Opts.Sanitizers = {};
+
+  // Disable PGO and code coverage.
+  Opts.GenerateProfile = false;
+  Opts.EmitProfileCoverageMapping = false;
+  Opts.UseProfile = "";
 }

--- a/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
+++ b/tools/SourceKit/lib/SwiftLang/SwiftLangSupport.h
@@ -39,6 +39,7 @@ namespace swift {
   class Type;
   class AbstractStorageDecl;
   class SourceFile;
+  class SILOptions;
   class ValueDecl;
   enum class AccessorKind;
 
@@ -531,6 +532,10 @@ public:
   CloseClangModuleFiles(swift::ClangModuleLoader &loader) : loader(loader) {}
   ~CloseClangModuleFiles();
 };
+
+
+/// Disable expensive SIL options which do not affect indexing or diagnostics.
+void disableExpensiveSILOptions(swift::SILOptions &Opts);
 
 } // namespace SourceKit
 


### PR DESCRIPTION
Disable the sanitizers and code coverage when building a swift
invocation for the purpose of collecting diagnostics.

This should speed up diagnostic generation and reduce exposure to
compiler bugs.

rdar://40955900