### PR TITLE
[master-next] Avoid use of StringRef::split and rsplit

### DIFF
--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -1226,14 +1226,17 @@ void Remangler::mangleBuiltinTypeName(Node *node) {
   } else if (stripPrefix(text, "Builtin.Float")) {
     Out << 'f' << text << '_';
   } else if (stripPrefix(text, "Builtin.Vec")) {
-    auto split = text.split('x');
-    Out << 'v' << split.first << 'B';
-    if (split.second == "RawPointer") {
+    // Avoid using StringRef::split because its definition is not
+    // provided in the header so that it requires linking with libSupport.a.
+    size_t splitIdx = text.find('x');
+    Out << 'v' << text.substr(0, splitIdx) << 'B';
+    auto Element = text.substr(splitIdx).substr(1);
+    if (Element == "RawPointer") {
       Out << 'p';
-    } else if (stripPrefix(split.second, "Float")) {
-      Out << 'f' << split.second << '_';
-    } else if (stripPrefix(split.second, "Int")) {
-      Out << 'i' << split.second << '_';
+    } else if (stripPrefix(Element, "Float")) {
+      Out << 'f' << Element << '_';
+    } else if (stripPrefix(Element, "Int")) {
+      Out << 'i' << Element << '_';
     } else {
       unreachable("unexpected builtin vector type");
     }

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -1230,13 +1230,13 @@ void Remangler::mangleBuiltinTypeName(Node *node) {
     // provided in the header so that it requires linking with libSupport.a.
     size_t splitIdx = text.find('x');
     Out << 'v' << text.substr(0, splitIdx) << 'B';
-    auto Element = text.substr(splitIdx).substr(1);
-    if (Element == "RawPointer") {
+    auto element = text.substr(splitIdx).substr(1);
+    if (element == "RawPointer") {
       Out << 'p';
-    } else if (stripPrefix(Element, "Float")) {
-      Out << 'f' << Element << '_';
-    } else if (stripPrefix(Element, "Int")) {
-      Out << 'i' << Element << '_';
+    } else if (stripPrefix(element, "Float")) {
+      Out << 'f' << element << '_';
+    } else if (stripPrefix(element, "Int")) {
+      Out << 'i' << element << '_';
     } else {
       unreachable("unexpected builtin vector type");
     }

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -621,13 +621,13 @@ void Remangler::mangleBuiltinTypeName(Node *node) {
     // Avoid using StringRef::split because its definition is not
     // provided in the header so that it requires linking with libSupport.a.
     size_t splitIdx = text.find('x');
-    auto Element = text.substr(splitIdx).substr(1);
-    if (Element == "RawPointer") {
+    auto element = text.substr(splitIdx).substr(1);
+    if (element == "RawPointer") {
       Buffer << 'p';
-    } else if (Element.consume_front("Float")) {
-      Buffer << 'f' << Element << '_';
-    } else if (Element.consume_front("Int")) {
-      Buffer << 'i' << Element << '_';
+    } else if (element.consume_front("Float")) {
+      Buffer << 'f' << element << '_';
+    } else if (element.consume_front("Int")) {
+      Buffer << 'i' << element << '_';
     } else {
       unreachable("unexpected builtin vector type");
     }

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -618,17 +618,20 @@ void Remangler::mangleBuiltinTypeName(Node *node) {
   } else if (text.consume_front(BUILTIN_TYPE_NAME_FLOAT)) {
     Buffer << 'f' << text << '_';
   } else if (text.consume_front(BUILTIN_TYPE_NAME_VEC)) {
-    auto split = text.split('x');
-    if (split.second == "RawPointer") {
+    // Avoid using StringRef::split because its definition is not
+    // provided in the header so that it requires linking with libSupport.a.
+    size_t splitIdx = text.find('x');
+    auto Element = text.substr(splitIdx).substr(1);
+    if (Element == "RawPointer") {
       Buffer << 'p';
-    } else if (split.second.consume_front("Float")) {
-      Buffer << 'f' << split.second << '_';
-    } else if (split.second.consume_front("Int")) {
-      Buffer << 'i' << split.second << '_';
+    } else if (Element.consume_front("Float")) {
+      Buffer << 'f' << Element << '_';
+    } else if (Element.consume_front("Int")) {
+      Buffer << 'i' << Element << '_';
     } else {
       unreachable("unexpected builtin vector type");
     }
-    Buffer << "Bv" << split.first << '_';
+    Buffer << "Bv" << text.substr(0, splitIdx) << '_';
   } else {
     unreachable("unexpected builtin type");
   }

--- a/stdlib/public/runtime/Errors.cpp
+++ b/stdlib/public/runtime/Errors.cpp
@@ -140,8 +140,11 @@ void swift::dumpStackTraceEntry(unsigned index, void *framePC,
   }
 
   // If lookupSymbol succeeded then fileName is non-null. Thus, we find the
-  // library name here.
-  StringRef libraryName = StringRef(syminfo.fileName).rsplit('/').second;
+  // library name here. Avoid using StringRef::rsplit because its definition
+  // is not provided in the header so that it requires linking with
+  // libSupport.a.
+  StringRef libraryName = StringRef(syminfo.fileName);
+  libraryName = libraryName.substr(libraryName.rfind('/')).substr(1);
 
   // Next we get the symbol name that we are going to use in our backtrace.
   std::string symbolName;

--- a/stdlib/public/runtime/MetadataLookup.cpp
+++ b/stdlib/public/runtime/MetadataLookup.cpp
@@ -639,14 +639,16 @@ Optional<unsigned> findAssociatedTypeByName(const ProtocolDescriptor *protocol,
   unsigned matchingAssocTypeIdx = 0;
   bool found = false;
   while (!associatedTypeNames.empty()) {
-    auto split = associatedTypeNames.split(' ');
-    if (split.first == name) {
+    // Avoid using StringRef::split because its definition is not
+    // provided in the header so that it requires linking with libSupport.a.
+    auto splitIdx = associatedTypeNames.find(' ');
+    if (associatedTypeNames.substr(0, splitIdx) == name) {
       found = true;
       break;
     }
 
     ++matchingAssocTypeIdx;
-    associatedTypeNames = split.second;
+    associatedTypeNames = associatedTypeNames.substr(splitIdx).substr(1);
   }
 
   if (!found) return None;


### PR DESCRIPTION
LLVM r334283 changed StringRef::split(char) to be implemented using
StringRef::split(StringRef), which is not defined inline. Because Swift
uses StringRef without linking LLVM's libSupport.a, we can only use
functions that are defined inline in the headers. Swift currently only
builds LLVM for the host, so we cannot link libSupport.a without building
it for every target, which would be a big change. Instead, this changes
a few places in Swift to avoid using those split and rsplit functions.

rdar://problem/41029268