### PR TITLE
[WIP] [stdlib] Improve performance of Array initialization with known capacity

### DIFF
--- a/test/stdlib/ErrorHandling.swift
+++ b/test/stdlib/ErrorHandling.swift
@@ -280,7 +280,7 @@ ErrorHandlingTests.test("ErrorHandling/operators") {
 
 ErrorHandlingTests.test("ErrorHandling/Sequence map") {
   let initialCount = NoisyCount
-  let sequence = AnySequence([1, 2, 3])
+  let sequence = stride(from: 1, through: 3, by: 1)
   for throwAtCount in 0...3 {
     var loopCount = 0
     do {


### PR DESCRIPTION
Currently the initialisation of an array with a known number of elements has two performance problems:
- An _EmptyArrayStorage is allocated and directly released once the first element is added (rdar://41214707)
- For each `append`, `_ContiguousArrayStorage` is retained and released when `append` is exited. Since the Array already holds a reference to its storage this shouldn't be necessary.

### The fix

I've optimised the `Collection.map` and `Sequence.map` to directly allocate the required storage and write to its memory directly by calling to `_allocateUninitialized` instead of `ContiguousArray.init()`.