### PR TITLE
Only warn about @inlinable implying @usableFromInline in -swift-version 4.2

### DIFF
--- a/lib/Sema/DerivedConformanceRawRepresentable.cpp
+++ b/lib/Sema/DerivedConformanceRawRepresentable.cpp
@@ -121,6 +121,22 @@ static void deriveBodyRawRepresentable_raw(AbstractFunctionDecl *toRawDecl) {
   toRawDecl->setBody(body);
 }
 
+static void maybeMarkAsInlinable(DerivedConformance &derived,
+                                 AbstractFunctionDecl *afd) {
+  ASTContext &C = derived.TC.Context;
+  auto parentDC = derived.getConformanceContext();
+  if (parentDC->getParentModule()->getResilienceStrategy() !=
+      ResilienceStrategy::Resilient) {
+    AccessScope access =
+        afd->getFormalAccessScope(nullptr,
+                                  /*treatUsableFromInlineAsPublic*/true);
+    if (auto *attr = afd->getAttrs().getAttribute<UsableFromInlineAttr>())
+      attr->setInvalid();
+    if (access.isPublic())
+      afd->getAttrs().add(new (C) InlinableAttr(/*implicit*/false));
+  }
+}
+
 static VarDecl *deriveRawRepresentable_raw(DerivedConformance &derived) {
   ASTContext &C = derived.TC.Context;
 
@@ -143,14 +159,7 @@ static VarDecl *deriveRawRepresentable_raw(DerivedConformance &derived) {
 
   // If the containing module is not resilient, make sure clients can get at
   // the raw value without function call overhead.
-  if (parentDC->getParentModule()->getResilienceStrategy() !=
-      ResilienceStrategy::Resilient) {
-    AccessScope access =
-        enumDecl->getFormalAccessScope(nullptr,
-                                       /*treatUsableFromInlineAsPublic*/true);
-    if (access.isPublic())
-      getterDecl->getAttrs().add(new (C) InlinableAttr(/*implicit*/false));
-  }
+  maybeMarkAsInlinable(derived, getterDecl);
 
   derived.addMembersToConformanceContext({getterDecl, propDecl, pbDecl});
 
@@ -350,14 +359,7 @@ deriveRawRepresentable_init(DerivedConformance &derived) {
 
   // If the containing module is not resilient, make sure clients can construct
   // an instance without function call overhead.
-  if (parentDC->getParentModule()->getResilienceStrategy() !=
-      ResilienceStrategy::Resilient) {
-    AccessScope access =
-        enumDecl->getFormalAccessScope(nullptr,
-                                       /*treatUsableFromInlineAsPublic*/true);
-    if (access.isPublic())
-      initDecl->getAttrs().add(new (C) InlinableAttr(/*implicit*/false));
-  }
+  maybeMarkAsInlinable(derived, initDecl);
 
   C.addSynthesizedDecl(initDecl);
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1982,7 +1982,8 @@ void AttributeChecker::visitUsableFromInlineAttr(UsableFromInlineAttr *attr) {
 
   // On internal declarations, @inlinable implies @usableFromInline.
   if (VD->getAttrs().hasAttribute<InlinableAttr>()) {
-    diagnoseAndRemoveAttr(attr, diag::inlinable_implies_usable_from_inline);
+    if (TC.Context.isSwiftVersionAtLeast(4,2))
+      diagnoseAndRemoveAttr(attr, diag::inlinable_implies_usable_from_inline);
     return;
   }
 }

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1982,10 +1982,7 @@ void AttributeChecker::visitUsableFromInlineAttr(UsableFromInlineAttr *attr) {
 
   // On internal declarations, @inlinable implies @usableFromInline.
   if (VD->getAttrs().hasAttribute<InlinableAttr>()) {
-    if (attr->isImplicit())
-      attr->setInvalid();
-    else
-      diagnoseAndRemoveAttr(attr, diag::inlinable_implies_usable_from_inline);
+    diagnoseAndRemoveAttr(attr, diag::inlinable_implies_usable_from_inline);
     return;
   }
 }

--- a/test/Compatibility/attr_inlinable_old_spelling_4.swift
+++ b/test/Compatibility/attr_inlinable_old_spelling_4.swift
@@ -5,3 +5,6 @@
 
 @_inlineable public func oldInlinableFunction() {}
 @_versioned func oldVersionedFunction() {}
+
+// No warning here
+@_inlineable @_versioned func redundantAttribute() {}

--- a/test/Compatibility/attr_inlinable_old_spelling_42.swift
+++ b/test/Compatibility/attr_inlinable_old_spelling_42.swift
@@ -7,3 +7,6 @@
 
 @_versioned func oldVersionedFunction() {}
 // expected-warning@-1 {{'@_versioned' has been renamed to '@usableFromInline'}}{{2-12=usableFromInline}}
+
+@inlinable @usableFromInline func redundantAttribute() {}
+// expected-warning@-1 {{'@inlinable' declaration is already '@usableFromInline'}}

--- a/test/attr/attr_inlinable.swift
+++ b/test/attr/attr_inlinable.swift
@@ -1,7 +1,7 @@
-// RUN: %target-typecheck-verify-swift -swift-version 4
-// RUN: %target-typecheck-verify-swift -swift-version 4 -enable-testing
-// RUN: %target-typecheck-verify-swift -swift-version 4 -enable-resilience
-// RUN: %target-typecheck-verify-swift -swift-version 4 -enable-resilience -enable-testing
+// RUN: %target-typecheck-verify-swift -swift-version 4.2
+// RUN: %target-typecheck-verify-swift -swift-version 4.2 -enable-testing
+// RUN: %target-typecheck-verify-swift -swift-version 4.2 -enable-resilience
+// RUN: %target-typecheck-verify-swift -swift-version 4.2 -enable-resilience -enable-testing
 @inlinable struct TestInlinableStruct {}
 // expected-error@-1 {{'@inlinable' attribute cannot be applied to this declaration}}
 


### PR DESCRIPTION
Fixes <https://bugs.swift.org/browse/SR-7578>.