### PR TITLE
Replace SubstitutionList with SubstitutionMap in TF extensions

### DIFF
--- a/lib/IRGen/GenBuiltin.cpp
+++ b/lib/IRGen/GenBuiltin.cpp
@@ -1004,7 +1004,8 @@ if (Builtin.ID == BuiltinValueKind::id) { \
   // OpaqueValue *swift_autoDiffCreateTape(Metadata *type);
   if (Builtin.ID == BuiltinValueKind::AutoDiffCreateTape) {
     auto valueTy =
-      getLoweredTypeAndTypeInfo(IGF.IGM, substitutions[0].getReplacement());
+      getLoweredTypeAndTypeInfo(
+        IGF.IGM, substitutions.getReplacementTypes().front());
     auto *metadata =
       IGF.emitTypeMetadataRef(valueTy.first.getSwiftRValueType());
     out.add(IGF.Builder.CreateCall(IGF.IGM.getAutoDiffCreateTapeFn(),
@@ -1044,8 +1045,8 @@ if (Builtin.ID == BuiltinValueKind::id) { \
     // `id` argument may be discarded. It is used as a marker in SIL.
     (void)args.claimAll();
 
-    auto valueTy = getLoweredTypeAndTypeInfo(IGF.IGM,
-                                             substitutions[0].getReplacement());
+    auto valueTy = getLoweredTypeAndTypeInfo(
+      IGF.IGM, substitutions.getReplacementTypes().front());
     auto pointerTy = valueTy.second.getStorageType()->getPointerTo();
 
     // Pop alloca from tape and cast to pointer type.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -1585,7 +1585,7 @@ bool Parser::parseNewDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc,
 
   /// SWIFT_ENABLE_TENSORFLOW
   case DAK_Differentiable: {
-    ParserResult<DifferentiableAttr> Attr = parseDifferentiableAttribute(AtLoc, Loc);
+    auto Attr = parseDifferentiableAttribute(AtLoc, Loc);
     if (Attr.isNonNull()) {
       Attributes.add(Attr.get());
     }

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1006,7 +1006,7 @@ static bool parseSymbolicValue(SymbolicValue &value, SILParser &SP,
     SILType temp;
     if (SP.parseSILType(temp))
       return true;
-    auto metatype = CanMetatypeType::get(temp.getSwiftRValueType());
+    auto metatype = CanMetatypeType::get(temp.getASTType());
     value = SymbolicValue::getMetatype(metatype);
     return false;
   }
@@ -2873,7 +2873,8 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
     P.Context.TheBuiltinModule->lookupMember(foundBuiltins,
                                              P.Context.TheBuiltinModule, Id,
                                              Identifier());
-
+    // SWIFT_ENABLE_TENSORFLOW
+    SubstitutionMap subMap;
     if (!foundBuiltins.empty()) {
       assert(foundBuiltins.size() == 1 && "ambiguous builtin name?!");
 
@@ -2881,7 +2882,6 @@ bool SILParser::parseSILInstruction(SILBuilder &B) {
       GenericEnvironment *genericEnv = builtinFunc->getGenericEnvironment();
 
       SmallVector<ParsedSubstitution, 4> parsedSubs;
-      SubstitutionMap subMap;
       if (parseSubstitutions(parsedSubs))
         return true;
 

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1469,14 +1469,14 @@ public:
   void checkAutoDiffBuiltinInst(BuiltinInst *BI) {
     auto &ctx = M->getASTContext();
     auto id = BI->getBuiltinInfo().ID;
-    require(BI->getSubstitutions().size() == 1,
+    require(BI->getSubstitutions().getReplacementTypes().size() == 1,
             "autodiff builtin should have a single type parameter");
 
     auto name = getBuiltinName(id);
     auto resultErrorMsg = "unexpected result type for '" + name + "'";
     auto operandErrorMsg = "unexpected operand type for '" + name + "'";
 
-    auto canGenericParam = BI->getSubstitutions()[0].getReplacement()
+    auto canGenericParam = BI->getSubstitutions().getReplacementTypes()[0]
       ->getCanonicalType();
     auto tapeType = SILType::getPrimitiveObjectType(
       BoundGenericType::get(ctx.get_AutoDiffTapeDecl(), Type(), canGenericParam)

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -369,7 +369,7 @@ static BuiltinInst *simplifyOperands(BuiltinInst *inst, TFDeabstraction &TFDA) {
   // parameter.
   auto canSimplifyOperand = [&](SILType type) -> bool {
     return isLoadableAddressType(type) ||
-           getPrimitiveStructField(type.getSwiftRValueType()) != nullptr;
+           getPrimitiveStructField(type.getASTType()) != nullptr;
   };
 
   // If we don't have to change any operands, don't rewrite the builtin.
@@ -408,7 +408,7 @@ static BuiltinInst *simplifyOperands(BuiltinInst *inst, TFDeabstraction &TFDA) {
 
     // If this is a struct value, emit struct extraction instruction(s).
     while (auto fieldDecl = getPrimitiveStructField(
-                                     operand->getType().getSwiftRValueType())) {
+                                     operand->getType().getASTType())) {
       auto extract = B.createStructExtract(inst->getLoc(), operand, fieldDecl);
       extract->setDebugLocation(inst->getDebugLocation());
       operand = extract;
@@ -1544,7 +1544,7 @@ static void expandArrayConstant(ArrayRef<SymbolicValue> arrayElements,
   name += SILTensorOpInfo::getOperandClassSuffix(attrKind);
 
   auto metatypeType =
-    MetatypeType::get(arrayEltType.getSwiftRValueType(),
+    MetatypeType::get(arrayEltType.getASTType(),
                       MetatypeRepresentation::Thin)
       ->getCanonicalType();
   operands.push_back(B.createMetatype(forInst->getLoc(),
@@ -1644,7 +1644,7 @@ tryToPromoteTensorFromScalars(ApplyInst *inst,
 
   if (!errorInfo.empty()) {
     auto loc = getUserSourceLocation(inst);
-    diagnose(inst->getType().getSwiftRValueType()->getASTContext(),
+    diagnose(inst->getType().getASTType()->getASTContext(),
              loc.getSourceLoc(), diag::tf_op_misuse, errorInfo)
       .highlight(loc.getSourceRange());
     return nullptr;

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -421,7 +421,7 @@ static BuiltinInst *simplifyOperands(BuiltinInst *inst, TFDeabstraction &TFDA) {
   // the old one.
   auto *newInst =
     B.createBuiltin(inst->getLoc(), inst->getName(),
-                    inst->getType(), /*no substitions*/{}, operands);
+                    inst->getType(), SubstitutionMap(), operands);
   newInst->setDebugLocation(inst->getDebugLocation());
 
   // Replace the old with the new and delete the old instruction.
@@ -1664,7 +1664,7 @@ tryToPromoteTensorFromScalars(ApplyInst *inst,
   auto newInst =
     B.createBuiltin(inst->getLoc(),
                     B.getASTContext().getIdentifier(name),
-                    inst->getType(), /*no substitions*/{},
+                    inst->getType(), SubstitutionMap(),
                     operands);
   newInst->setDebugLocation(inst->getDebugLocation());
   inst->replaceAllUsesPairwiseWith(newInst);
@@ -1751,7 +1751,7 @@ tryToPromoteTensorFromScalars1D(ApplyInst *inst,
   auto newInst =
     B.createBuiltin(inst->getLoc(),
                     B.getASTContext().getIdentifier(name),
-                    inst->getType(), /*no substitions*/{},
+                    inst->getType(), SubstitutionMap(),
                     operands);
   newInst->setDebugLocation(inst->getDebugLocation());
   inst->replaceAllUsesPairwiseWith(newInst);

--- a/lib/SILOptimizer/Mandatory/TFDevicePartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDevicePartition.cpp
@@ -217,11 +217,10 @@ void DevicePartitionCloner::addD2DSend(BuiltinInst *inst, int transferId,
   auto voidTy = B.getModule().Types.getEmptyTupleType();
   auto valueToSend = remapValue(inst->getOperand(0));
   auto destDeviceStr = getDeviceString(destDevice);
-  auto valueTy = inst->getResults()[0]->getType();
   auto destDeviceAttr = B.createStringLiteral(
       loc, StringRef(destDeviceStr), StringLiteralInst::Encoding::UTF8);
   B.createBuiltin(loc, ctx.getIdentifier(newInstName), voidTy,
-                  /*MERGE*/ inst->getSubstitutions(),
+                  inst->getSubstitutions(),
                   {valueToSend, transferIdAttr, destDeviceAttr, deviceAttr});
   // Do not update ValueMap since Send does not produce a value.
 }

--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -629,7 +629,7 @@ TF_DataType TFGraphLowering::getTensorFlowDataType(SILType type,
   // Handle things like TensorHandle<Float>.
   switch (classifyTensorFlowValue(type)) {
   case TFValueKind::TensorHandle: {
-    auto elt = getTensorHandleElementType(type.getSwiftRValueType());
+    auto elt = getTensorHandleElementType(type.getASTType());
     assert(elt && "We know this is TensorHandle!");
     if (auto ty = (TF_DataType)convertSwiftTypeToTF(elt))
       return ty;
@@ -641,7 +641,7 @@ TF_DataType TFGraphLowering::getTensorFlowDataType(SILType type,
     return TF_VARIANT;
   case TFValueKind::Nope:
     // Otherwise this must be a scalar type we're promoting to a tensor.
-    if (auto ty = (TF_DataType)convertSwiftTypeToTF(type.getSwiftRValueType()))
+    if (auto ty = (TF_DataType)convertSwiftTypeToTF(type.getASTType()))
       return ty;
     break;
   }
@@ -1128,7 +1128,7 @@ void TFGraphLowering::visitTFDataset(BuiltinInst *inst) {
   assert(inst->getNumResults() == 1);
 
   std::vector<TF_DataType> outputTypes;
-  auto outputType = inst->getType().getSwiftRValueType();
+  auto outputType = inst->getType().getASTType();
   if (auto tfType = getTFDataTypeFromTensorGenericType(outputType)) {
     outputTypes.push_back(static_cast<TF_DataType>(tfType));
   } else {

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -427,7 +427,7 @@ struct GraphGlobalConfiguration {
     /// Return true if the specified type contains a TensorFlow value type that
     /// will be exposed after deabstraction.
     bool containsTensorFlowValue(SILType ty) {
-      return containsTensorFlowValue(ty.getSwiftRValueType());
+      return containsTensorFlowValue(ty.getASTType());
     }
 
   };

--- a/stdlib/public/Python/Python.swift
+++ b/stdlib/public/Python/Python.swift
@@ -37,7 +37,7 @@ public typealias OwnedPyObjectPointer = UnsafeMutablePointer<PyObject>
 // - Note: When Swift has ownership, `PyReference` should be removed.
 //   `PythonObject` will define copy constructors, move constructors, etc. to
 //   implement move semantics.
-@_versioned @_fixed_layout
+@usableFromInline @_fixed_layout
 final class PyReference {
   private var pointer: OwnedPyObjectPointer
 
@@ -88,7 +88,7 @@ public struct PythonObject {
   /// The underlying `PyReference`.
   fileprivate var reference: PyReference
 
-  @_versioned
+  @usableFromInline
   init(_ pointer: PyReference) {
     reference = pointer
   }

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -1845,7 +1845,7 @@ extension FloatingPoint {
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
-  @differentiable(reverse, withRespectTo: (self), adjoint: _adjointSquareRoot)
+  // @differentiable(reverse, withRespectTo: (self), adjoint: _adjointSquareRoot)
   public func squareRoot( ) -> Self {
     var lhs = self
     lhs.formSquareRoot( )
@@ -1855,7 +1855,7 @@ extension FloatingPoint {
   /// SWIFT_ENABLE_TENSORFLOW
   /// The adjoint of `squareRoot`. Returns the gradient of `squareRoot` with
   /// respect to `self`.
-  @_versioned @_inlineable // FIXME(sil-serialize-all)
+  @inlinable // FIXME(sil-serialize-all)
   func _adjointSquareRoot(originalValue: Self, adjoint: Self) -> Self {
     return 2 * self * adjoint
   }
@@ -1876,9 +1876,9 @@ extension FloatingPoint {
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
-  @differentiable(
-    reverse, withRespectTo: (self, .0, .1), adjoint: _adjointAddingProduct
-  )
+  // @differentiable(
+  //   reverse, withRespectTo: (self, .0, .1), adjoint: _adjointAddingProduct
+  // )
   public func addingProduct(_ lhs: Self, _ rhs: Self) -> Self {
     var addend = self
     addend.addProduct(lhs, rhs)
@@ -1888,7 +1888,7 @@ extension FloatingPoint {
   /// SWIFT_ENABLE_TENSORFLOW
   /// The adjoint of `addingProduct`. Returns the gradient of `addingProduct`
   /// with respect to `self`, `lhs` and `rhs`.
-  @_versioned @_inlineable
+  @inlinable
   func _adjointAddingProduct(
     _ lhs: Self, _ rhs: Self,
     originalValue: Self, adjoint: Self

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1732,7 +1732,7 @@ extension ${Self} {
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
-  @differentiable(reverse, adjoint: _adjointAdd)
+  // @differentiable(reverse, adjoint: _adjointAdd)
   public static func + (lhs: ${Self}, rhs: ${Self}) -> ${Self} {
     var lhs = lhs
     lhs += rhs
@@ -1742,7 +1742,7 @@ extension ${Self} {
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
-  @differentiable(reverse, adjoint: _adjointSubtract)
+  // @differentiable(reverse, adjoint: _adjointSubtract)
   public static func - (lhs: ${Self}, rhs: ${Self}) -> ${Self} {
     var lhs = lhs
     lhs -= rhs
@@ -1752,7 +1752,7 @@ extension ${Self} {
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
-  @differentiable(reverse, adjoint: _adjointMultiply)
+  // @differentiable(reverse, adjoint: _adjointMultiply)
   public static func * (lhs: ${Self}, rhs: ${Self}) -> ${Self} {
     var lhs = lhs
     lhs *= rhs
@@ -1762,7 +1762,7 @@ extension ${Self} {
   @inlinable // FIXME(sil-serialize-all)
   @_transparent
   /// SWIFT_ENABLE_TENSORFLOW
-  @differentiable(reverse, adjoint: _adjointDivide)
+  // @differentiable(reverse, adjoint: _adjointDivide)
   public static func / (lhs: ${Self}, rhs: ${Self}) -> ${Self} {
     var lhs = lhs
     lhs /= rhs
@@ -1773,7 +1773,7 @@ extension ${Self} {
 /// SWIFT_ENABLE_TENSORFLOW
 /// Adjoints of standard binary operators.
 extension ${Self} {
-  @_versioned @_inlineable // FIXME(sil-serialize-all)
+  @inlinable // FIXME(sil-serialize-all)
   @_transparent
   static func _adjointAdd(
     _ lhs: ${Self}, _ rhs: ${Self}, originalValue: ${Self}, adjoint: ${Self}
@@ -1781,7 +1781,7 @@ extension ${Self} {
     return (adjoint, adjoint)
   }
 
-  @_versioned @_inlineable // FIXME(sil-serialize-all)
+  @inlinable // FIXME(sil-serialize-all)
   @_transparent
   static func _adjointSubtract(
     _ lhs: ${Self}, _ rhs: ${Self}, originalValue: ${Self}, adjoint: ${Self}
@@ -1789,7 +1789,7 @@ extension ${Self} {
     return (adjoint, -adjoint)
   }
 
-  @_versioned @_inlineable // FIXME(sil-serialize-all)
+  @inlinable // FIXME(sil-serialize-all)
   @_transparent
   static func _adjointMultiply(
     _ lhs: ${Self}, _ rhs: ${Self}, originalValue: ${Self}, adjoint: ${Self}
@@ -1797,7 +1797,7 @@ extension ${Self} {
     return (rhs * adjoint, lhs * adjoint)
   }
 
-  @_versioned @_inlineable // FIXME(sil-serialize-all)
+  @inlinable // FIXME(sil-serialize-all)
   @_transparent
   static func _adjointDivide(
     _ lhs: ${Self}, _ rhs: ${Self}, originalValue: ${Self}, adjoint: ${Self}


### PR DESCRIPTION
- Replace `SubstitutionList`-related code paths in graph program extraction, constexpr and autodiff with `SubstitutionMap` APIs.
- Replace `SILType::getSwiftRValueType` (deprecated) with `SILType::getASTType`.
- Replace `@_inlineable` with `@inlinable`, and `@_versioned` with `@usableFromInline`. In places where `@inlinable` is used, omit `@usableFromInline` since it is now implied.