### PR TITLE
[4.2][ConstraintSystem] Fix a logic error in computing potential bindings.

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -66,6 +66,14 @@ ConstraintSystem::determineBestBindings() {
         continue;
 
       for (auto &binding : relatedBindings->getSecond().Bindings) {
+        // We need the binding kind for the potential binding to
+        // either be Exact or Supertypes in order for it to make sense
+        // to add Supertype bindings based on the relationship between
+        // our type variables.
+        if (binding.Kind != AllowedBindingKind::Exact
+            && binding.Kind != AllowedBindingKind::Supertypes)
+          continue;
+
         auto type = binding.BindingType;
 
         if (ConstraintSystem::typeVarOccursInType(typeVar, type))

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -70,8 +70,8 @@ ConstraintSystem::determineBestBindings() {
         // either be Exact or Supertypes in order for it to make sense
         // to add Supertype bindings based on the relationship between
         // our type variables.
-        if (binding.Kind != AllowedBindingKind::Exact
-            && binding.Kind != AllowedBindingKind::Supertypes)
+        if (binding.Kind != AllowedBindingKind::Exact &&
+            binding.Kind != AllowedBindingKind::Supertypes)
           continue;
 
         auto type = binding.BindingType;

--- a/test/Constraints/sr7875.swift
+++ b/test/Constraints/sr7875.swift
@@ -1,0 +1,20 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol Proto {}
+class Base {}
+class Test : Base, Proto {}
+
+struct A {}
+struct B {}
+
+func overloaded<T: Proto & Base>(_ f: () -> T, _ g: (T, A) -> ()) {}
+func overloaded<T: Proto & Base>(_ f: () -> T, _ g: (T, B) -> ()) {}
+
+func f() -> Test { return Test() }
+
+func g<T: Proto & Base>(_ t: T, _ a: A) -> () {}
+
+func test() {
+  overloaded(f, g as (Test, A) -> ())
+  overloaded(f, g)
+}


### PR DESCRIPTION
A change was made to attempt to use constraints that we have between
type variables to inform potential bindings, such that if we have:
   $T1 <: $T2
we would use $T1's bindings to add to the bindings of $T2. This is
only valid if we're adding bindings where $T1 is the supertype,
though, otherwise we could have the constraints:
  $T1 <: $T2
  $T1 <: X
imply that $T2 is a supertype of X, which doesn't make sense.

Fixes rdar://problem/40810000 (aka https://bugs.swift.org/browse/SR-7875).

(cherry picked from commit 54b2504)