### PR TITLE
[4.2][ConstraintSystem] Fix a logic error in computing potential bindings.

### DIFF
--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -66,6 +66,14 @@ ConstraintSystem::determineBestBindings() {
         continue;
 
       for (auto &binding : relatedBindings->getSecond().Bindings) {
+        // We need the binding kind for the potential binding to
+        // either be Exact or Supertypes in order for it to make sense
+        // to add Supertype bindings based on the relationship between
+        // our type variables.
+        if (binding.Kind != AllowedBindingKind::Exact
+            && binding.Kind != AllowedBindingKind::Supertypes)
+          continue;
+
         auto type = binding.BindingType;
 
         if (ConstraintSystem::typeVarOccursInType(typeVar, type))

--- a/lib/Sema/CSBindings.cpp
+++ b/lib/Sema/CSBindings.cpp
@@ -70,8 +70,8 @@ ConstraintSystem::determineBestBindings() {
         // either be Exact or Supertypes in order for it to make sense
         // to add Supertype bindings based on the relationship between
         // our type variables.
-        if (binding.Kind != AllowedBindingKind::Exact
-            && binding.Kind != AllowedBindingKind::Supertypes)
+        if (binding.Kind != AllowedBindingKind::Exact &&
+            binding.Kind != AllowedBindingKind::Supertypes)
           continue;
 
         auto type = binding.BindingType;

--- a/test/Constraints/sr7875.swift
+++ b/test/Constraints/sr7875.swift
@@ -1,0 +1,20 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol Proto {}
+class Base {}
+class Test : Base, Proto {}
+
+struct A {}
+struct B {}
+
+func overloaded<T: Proto & Base>(_ f: () -> T, _ g: (T, A) -> ()) {}
+func overloaded<T: Proto & Base>(_ f: () -> T, _ g: (T, B) -> ()) {}
+
+func f() -> Test { return Test() }
+
+func g<T: Proto & Base>(_ t: T, _ a: A) -> () {}
+
+func test() {
+  overloaded(f, g as (Test, A) -> ())
+  overloaded(f, g)
+}


### PR DESCRIPTION
*  Explanation:  In some cases we're failing to select potential type bindings for type variables due to a change that was made after 4.1 was released. The result is that we fail to type check code that worked before. The fix is a simple check of a condition that is missing in the code that computes potential bindings.
*  Scope: This could potentially hit any project.
*  Issue #: rdar://problem/40810000 / https://bugs.swift.org/browse/SR-7875
*  Risk: Very low.
*  Testing: Standard regression tests plus source compatibility tests.
*  Reviewer: @xedin 