### PR TITLE
Make FloatingPoint require that Self.Magnitude == Self

### DIFF
--- a/stdlib/public/Platform/tgmath.swift.gyb
+++ b/stdlib/public/Platform/tgmath.swift.gyb
@@ -14,8 +14,8 @@ import SwiftShims
 
 // Generic functions implementable directly on FloatingPoint.
 @_transparent
-public func fabs<T: FloatingPoint>(_ x: T) -> T
-  where T.Magnitude == T {
+@available(swift, deprecated: 4.2, renamed: "abs")
+public func fabs<T: FloatingPoint>(_ x: T) -> T {
   return x.magnitude
 }
 

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -167,12 +167,8 @@ word_bits = int(CMAKE_SIZEOF_VOID_P) * 8
 ///     print("Average: \(average)°F in \(validTemps.count) " +
 ///           "out of \(tempsFahrenheit.count) observations.")
 ///     // Prints "Average: 74.84°F in 5 out of 7 observations."
-public protocol FloatingPoint: SignedNumeric, Strideable, Hashable {
-
-  // For the minimumMagnitude and maximumMagnitude methods
-  /// A type that can represent the absolute value of any possible value of the
-  /// conforming type.
-  associatedtype Magnitude = Self
+public protocol FloatingPoint : SignedNumeric, Strideable, Hashable
+                                where Magnitude == Self {
 
   /// A type that can represent any written exponent.
   associatedtype Exponent: SignedInteger

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -2501,13 +2501,6 @@ where Self.RawSignificand : FixedWidthInteger,
 
 % end
 
-/// Returns the absolute value of `x`.
-@inlinable // FIXME(sil-serialize-all)
-@_transparent
-public func abs<T : FloatingPoint>(_ x: T) -> T where T.Magnitude == T {
-  return x.magnitude
-}
-
 extension FloatingPoint {
   @inlinable // FIXME(sil-serialize-all)
   @available(swift, obsoleted: 4, message: "Please use operators instead.")

--- a/test/SourceKit/CodeComplete/complete_moduleimportdepth.swift
+++ b/test/SourceKit/CodeComplete/complete_moduleimportdepth.swift
@@ -35,18 +35,6 @@ func test() {
 // CHECK:        key.modulename: "Swift"
 // CHECK-NEXT: },
 
-// CHECK-LABEL:  key.name: "abs(:)",
-// CHECK-NEXT:   key.sourcetext: "abs(<#T##x: FloatingPoint##FloatingPoint#>)",
-// CHECK-NEXT:   key.description: "abs(x: FloatingPoint)",
-// CHECK-NEXT:   key.typename: "FloatingPoint",
-// CHECK-NEXT:   key.doc.brief: "Returns the absolute value of x.",
-// CHECK-NEXT:   key.context: source.codecompletion.context.othermodule,
-// CHECK-NEXT:   key.moduleimportdepth: 1,
-// CHECK-NEXT:   key.num_bytes_to_erase: 0,
-// CHECK-NOT:    key.modulename
-// CHECK:        key.modulename: "Swift"
-// CHECK-NEXT: },
-
 // FooHelper.FooHelperExplicit == 1
 // CHECK-LABEL:  key.name: "fooHelperExplicitFrameworkFunc1(:)",
 // CHECK-NEXT:   key.sourcetext: "fooHelperExplicitFrameworkFunc1(<#T##a: Int32##Int32#>)",


### PR DESCRIPTION
We didn't have the where clause to express this constraint at the time that the FloatingPoint protocol was implemented, but we do now. This is not a semantic change to FloatingPoint, which has always bound IEEE-754 arithmetic types, for which this constraint would necessarily hold, but it does effect the type system.

For example, currently the following function does not type check:
~~~~
func foo<T>(x: T) -> T where T: FloatingPoint {
  var r = x.remainder(dividingBy: 1)
  return r.magnitude
}
~~~~
with this change, it compiles correctly.

This is an ABI change, but a very minor one which should not break any currently-functioning code.