### PR TITLE
[AutoDiff] Finish #adjoint expression (Sema and SILGen).

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1255,6 +1255,10 @@ ERROR(expr_typeof_expected_rparen,PointsToFirstBadToken,
 ERROR(expr_dynamictype_deprecated,PointsToFirstBadToken,
       "'.dynamicType' is deprecated. Use 'type(of: ...)' instead", ())
 
+// Adjoint expressions.
+ERROR(expr_adjoint_expected_function_name,PointsToFirstBadToken,
+      "expected function name within '#adjoint` expression", ())
+
 //------------------------------------------------------------------------------
 // Attribute-parsing diagnostics
 //------------------------------------------------------------------------------

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -722,6 +722,25 @@ ERROR(gradient_expr_incompatible_contextual_type,none,
       "cannot convert gradient expression to incompatible contextual type %0",
       (Type))
 
+// '#adjoint(...)' expression for automatic differentiation
+ERROR(adjoint_expr_original_base_type_unresolved,none,
+      "could not resolve base type %0 of original function in #adjoint "
+      "expression", (TypeLoc))
+ERROR(adjoint_expr_original_not_func_decl,none,
+      "#adjoint expression can only be applied to function declarations, but %0"
+      "is not a function declaration", (DeclName))
+ERROR(adjoint_expr_original_func_decl_unresolved,none,
+      "original function declaration could not be resolved", ())
+ERROR(adjoint_expr_original_no_valid_differentiable_attr,none,
+      "the original function %0 does not declare a valid @differentiable "
+      "attribute", (DeclName))
+ERROR(adjoint_expr_original_overload_not_found,none,
+      "could not find original function %0 with valid @differentiable "
+      "attribute in #adjoint expression", (DeclName))
+ERROR(adjoint_expr_ambiguous_original_function_identifier,none,
+      "ambiguous or overloaded original function identifier %0 cannot be used "
+      "in #adjoint expression", (DeclName))
+
 ERROR(use_local_before_declaration,none,
       "use of local variable %0 before its declaration", (DeclName))
 ERROR(unsupported_existential_type,none,

--- a/include/swift/AST/Expr.h
+++ b/include/swift/AST/Expr.h
@@ -347,6 +347,11 @@ protected:
     NumArgLabels : 16
   );
 
+  // SWIFT_ENABLE_TENSORFLOW
+  SWIFT_INLINE_BITFIELD(AdjointExpr, Expr, 2,
+                        FunctionRefKind : 2
+  );
+
   enum { NumCheckedCastKindBits = 4 };
   SWIFT_INLINE_BITFIELD(CheckedCastExpr, Expr, NumCheckedCastKindBits,
     CastKind : NumCheckedCastKindBits
@@ -3944,34 +3949,56 @@ private:
                           originalExpr, params, rParenLoc) {}
 };
 
-/// The `#adjoint(...)` expression for the manual retrival of basic adjoints of
-/// functions that are marked `@differentiable(reverse, ...)`.
+/// The `#adjoint(...)` expression returns the declared adjoint of functions
+/// with the `@differentiable(reverse, ...)` attribute.
 class AdjointExpr : public Expr {
 private:
   SourceLoc Loc, LParenLoc;
-  Expr *OriginalExpr;
+  // The original function name.
+  DeclName OriginalName;
+  DeclNameLoc OriginalNameLoc;
+  // The base type of the original function.
+  // This is non-null only when the original function is not top-level (i.e. it
+  // is an instance/static method).
+  TypeLoc BaseType;
+  // The resolved adjoint function declaration.
+  ConcreteDeclRef AdjointFunction = nullptr;
   SourceLoc RParenLoc;
 
-  explicit AdjointExpr(SourceLoc loc, SourceLoc lParenLoc, Expr *originalExpr,
-                       SourceLoc rParenLoc)
-    : Expr(ExprKind::Adjoint, /*implicit*/ false), Loc(loc),
-      LParenLoc(lParenLoc), OriginalExpr(originalExpr), RParenLoc(rParenLoc) {}
+  explicit AdjointExpr(SourceLoc loc, SourceLoc lParenLoc,
+                       DeclName originalName, DeclNameLoc originalNameLoc,
+                       TypeLoc baseType, SourceLoc rParenLoc)
+    : Expr(ExprKind::Adjoint, /*Implicit*/ false), Loc(loc),
+      LParenLoc(lParenLoc), OriginalName(originalName),
+      OriginalNameLoc(originalNameLoc), BaseType(baseType),
+      RParenLoc(rParenLoc) {
+    Bits.AdjointExpr.FunctionRefKind =
+      static_cast<unsigned>(FunctionRefKind::Unapplied);
+  }
 
 public:
   static AdjointExpr *create(ASTContext &ctx, SourceLoc loc,
-                             SourceLoc lParenLoc, Expr *originalExpr,
+                             SourceLoc lParenLoc, DeclName originalName,
+                             DeclNameLoc originalNameLoc, TypeRepr *baseType,
                              SourceLoc rParenLoc);
 
-  Expr *getOriginalExpr() const {
-    return OriginalExpr;
+  DeclName getOriginalName() const { return OriginalName; }
+  DeclNameLoc getOriginalNameLoc() const { return OriginalNameLoc; }
+  TypeLoc getBaseType() const { return BaseType; }
+
+  ConcreteDeclRef getAdjointFunction() { return AdjointFunction; }
+  void setAdjointFunction(ConcreteDeclRef ref) { AdjointFunction = ref; }
+
+  SourceRange getSourceRange() const { return SourceRange(Loc, RParenLoc); }
+
+  /// Retrieve the kind of function reference.
+  FunctionRefKind getFunctionRefKind() const {
+    return static_cast<FunctionRefKind>(Bits.AdjointExpr.FunctionRefKind);
   }
 
-  void setOriginalExpr(Expr *newOriginal) {
-    OriginalExpr = newOriginal;
-  }
-
-  SourceRange getSourceRange() const {
-    return SourceRange(Loc, RParenLoc);
+  /// Set the kind of function reference.
+  void setFunctionRefKind(FunctionRefKind refKind) {
+    Bits.AdjointExpr.FunctionRefKind = static_cast<unsigned>(refKind);
   }
 
   static bool classof(const Expr *E) {

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -968,7 +968,9 @@ public:
                              SourceLoc &LAngleLoc,
                              SourceLoc &RAngleLoc);
 
-  ParserResult<TypeRepr> parseTypeIdentifier();
+  // SWIFT_ENABLE_TENSORFLOW: Added `isParsingQualifiedDeclName` flag.
+  ParserResult<TypeRepr>
+    parseTypeIdentifier(bool isParsingQualifiedDeclName = false);
   ParserResult<TypeRepr> parseOldStyleProtocolComposition();
   ParserResult<CompositionTypeRepr> parseAnyType();
   ParserResult<TypeRepr> parseSILBoxType(GenericParamList *generics,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -969,6 +969,9 @@ public:
                              SourceLoc &RAngleLoc);
 
   // SWIFT_ENABLE_TENSORFLOW: Added `isParsingQualifiedDeclName` flag.
+  /// The `isParsingQualifiedDeclName` flag controls whether parsing is done as
+  /// if this type identifier is the prefix to a qualified declaration name. If
+  /// true, backtrack parsing the last identifier.
   ParserResult<TypeRepr>
     parseTypeIdentifier(bool isParsingQualifiedDeclName = false);
   ParserResult<TypeRepr> parseOldStyleProtocolComposition();

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1834,9 +1834,17 @@ public:
 
   void visitAdjointExpr(AdjointExpr *E) {
     printCommon(E, "adjoint_expr");
-    OS << " original=";
-    E->getOriginalExpr()->dump(OS);
-    OS << ')';
+    PrintWithColorRAII(OS, TypeReprColor) << " base_type='";
+    if (auto baseRepr = E->getBaseType().getTypeRepr())
+      baseRepr->print(PrintWithColorRAII(OS, TypeReprColor).getOS());
+    else
+      PrintWithColorRAII(OS, TypeReprColor) << "<<NULL>>";
+    PrintWithColorRAII(OS, TypeReprColor) << "'";
+    PrintWithColorRAII(OS, IdentifierColor) << " original_name='"
+      << E->getOriginalName() << "'";
+    PrintWithColorRAII(OS, ExprModifierColor)
+      << " function_ref=" << getFunctionRefKindStr(E->getFunctionRefKind());
+    PrintWithColorRAII(OS, ParenthesisColor) << ')';
   }
 
   void visitObjectLiteralExpr(ObjectLiteralExpr *E) {

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -1835,7 +1835,7 @@ public:
   void visitAdjointExpr(AdjointExpr *E) {
     printCommon(E, "adjoint_expr");
     PrintWithColorRAII(OS, TypeReprColor) << " base_type='";
-    if (auto baseRepr = E->getBaseType().getTypeRepr())
+    if (auto *baseRepr = E->getBaseType().getTypeRepr())
       baseRepr->print(PrintWithColorRAII(OS, TypeReprColor).getOS());
     else
       PrintWithColorRAII(OS, TypeReprColor) << "<<NULL>>";

--- a/lib/AST/ASTWalker.cpp
+++ b/lib/AST/ASTWalker.cpp
@@ -462,9 +462,6 @@ class Traversal : public ASTVisitor<Traversal, Expr*, Stmt*,
   }
 
   Expr *visitAdjointExpr(AdjointExpr *E) {
-    Expr *originalExpr = doIt(E->getOriginalExpr());
-    if (!originalExpr) return nullptr;
-    E->setOriginalExpr(originalExpr);
     return E;
   }
 

--- a/lib/AST/Expr.cpp
+++ b/lib/AST/Expr.cpp
@@ -1311,8 +1311,10 @@ ValueAndGradientExpr::create(ASTContext &ctx, SourceLoc loc,
 
 AdjointExpr *
 AdjointExpr::create(ASTContext &ctx, SourceLoc loc, SourceLoc lParenLoc,
-                    Expr *originalExpr, SourceLoc rParenLoc) {
-  return new (ctx) AdjointExpr(loc, lParenLoc, originalExpr, rParenLoc);
+                    DeclName originalName, DeclNameLoc originalNameLoc,
+                    TypeRepr *baseType, SourceLoc rParenLoc) {
+  return new (ctx) AdjointExpr(loc, lParenLoc, originalName, originalNameLoc,
+                               TypeLoc(baseType, Type()), rParenLoc);
 }
 
 ObjectLiteralExpr::ObjectLiteralExpr(SourceLoc PoundLoc, LiteralKind LitKind,

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3760,7 +3760,7 @@ ParserResult<Expr> Parser::parseExprGradientBody(ExprKind kind) {
 /// parseFunctionIdentifier
 ///
 ///   function-identifier:
-///     type-identifier unqualified-decl-name
+///     type-identifier? unqualified-decl-name
 ///   type-identifier:
 ///     identifier generic-args? ('.' identifier generic-args?)*
 ///

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -3757,158 +3757,44 @@ ParserResult<Expr> Parser::parseExprGradientBody(ExprKind kind) {
 }
 
 /// SWIFT_ENABLE_TENSORFLOW
-/// parseFunctionIdentifier
+/// parseQualifiedDeclName
 ///
-///   function-identifier:
+///   qualified-decl-name:
 ///     type-identifier? unqualified-decl-name
 ///   type-identifier:
 ///     identifier generic-args? ('.' identifier generic-args?)*
 ///
-/// Note: this function is largely copied from `parseTypeIdentifier` and should
-/// be kept in sync.
-/// The code is duplicated because custom backtracking logic is needed to parse
-/// the final unqualified decl name.
+/// Parses an optional base type, followed by a declaration name.
 /// Returns true on error (if function decl name could not be parsed).
-static bool parseFunctionIdentifier(Parser &P, TypeRepr *&baseType,
-                                    DeclName &funcName,
-                                    DeclNameLoc &funcNameLoc) {
-  if (P.Tok.isNot(tok::identifier) && P.Tok.isNot(tok::kw_Self)
-      && !P.Tok.isAnyOperator()) {
-    if (P.Tok.is(tok::kw_Any)) {
-      baseType = P.parseAnyType().get();
-      return true;
-    } else if (P.Tok.is(tok::code_complete)) {
-      if (P.CodeCompletion)
-        P.CodeCompletion->completeTypeSimpleBeginning();
-      // Eat the code completion token because we handled it.
-      P.consumeToken(tok::code_complete);
-      return true;
+static bool parseQualifiedDeclName(Parser &P, Diag<> nameParseError,
+                                   TypeRepr *&baseType, DeclName &name,
+                                   DeclNameLoc &nameLoc) {
+  // If the current token is an identifier or `Self` or `Any`, then attempt to
+  // parse the base type. Otherwise, base type is null.
+  auto currentPosition = P.getParserPosition();
+  bool canParseBaseType = P.canParseTypeIdentifier();
+  P.backtrackToPosition(currentPosition);
+  if (canParseBaseType)
+    baseType =
+      P.parseTypeIdentifier(/*isParsingQualifiedDeclName*/ true).getPtrOrNull();
+  else
+    baseType = nullptr;
+
+  // If base type was parsed and has at least one component, then there was a
+  // dot before the current token.
+  bool afterDot = false;
+  if (baseType) {
+    if (auto ident = dyn_cast<IdentTypeRepr>(baseType)) {
+      auto components = ident->getComponentRange();
+      afterDot = std::distance(components.begin(), components.end()) > 0;
     }
-    P.diagnose(P.Tok, diag::expected_identifier_for_type);
-
-    // If there is a keyword at the start of a new line, we won't want to
-    // skip it as a recovery but rather keep it.
-    if (P.Tok.isKeyword() && !P.Tok.isAtStartOfLine())
-      P.consumeToken();
-
-    return true;
   }
-  SyntaxParsingContext IdentTypeCtxt(P.SyntaxContext, SyntaxContextKind::Type);
-  // Store the position for backtracking.
-  ParserPosition backtrackingPosition;
-  // True if an operator token is encountered.
-  // If true, backtracking is not necessary.
-  bool foundOperator = false;
-
-  ParserStatus Status;
-  SmallVector<ComponentIdentTypeRepr *, 4> ComponentsR;
-  SourceLoc EndLoc;
-  while (true) {
-    backtrackingPosition = P.getParserPosition();
-    SourceLoc Loc;
-    Identifier Name;
-    if (P.Tok.is(tok::kw_Self)) {
-      Loc = P.consumeIdentifier(&Name);
-    } else if (P.Tok.isAnyOperator()) {
-      // If an operator is encountered, break early and don't backtrack.
-      // The operator will be parsed as the final unqualified decl name.
-      foundOperator = true;
-      break;
-    } else {
-      // FIXME: specialize diagnostic for 'Type': type cannot start with
-      // 'metatype'
-      // FIXME: offer a fixit: 'self' -> 'Self'
-      if (P.parseIdentifier(Name, Loc,
-                            diag::expected_identifier_in_dotted_type)) {
-        Status.setIsParseError();
-        break;
-      }
-    }
-
-    if (Loc.isValid()) {
-      SourceLoc LAngle, RAngle;
-      SmallVector<TypeRepr*, 8> GenericArgs;
-      if (P.startsWithLess(P.Tok)) {
-        if (P.parseGenericArguments(GenericArgs, LAngle, RAngle))
-          return true;
-      }
-      EndLoc = Loc;
-
-      ComponentIdentTypeRepr *CompT;
-      if (!GenericArgs.empty())
-        CompT = GenericIdentTypeRepr::create(P.Context, Loc, Name, GenericArgs,
-                                             SourceRange(LAngle, RAngle));
-      else
-        CompT = new (P.Context) SimpleIdentTypeRepr(Loc, Name);
-      ComponentsR.push_back(CompT);
-    }
-    P.SyntaxContext->createNodeInPlace(ComponentsR.size() == 1
-                                       ? SyntaxKind::SimpleTypeIdentifier
-                                       : SyntaxKind::MemberTypeIdentifier);
-
-    // Treat 'Foo.<anything>' as an attempt to write a dotted type
-    // unless <anything> is 'Type'.
-    if ((P.Tok.is(tok::period) || P.Tok.is(tok::period_prefix))) {
-      if (P.peekToken().is(tok::code_complete)) {
-        Status.setHasCodeCompletion();
-        break;
-      }
-      if (!P.peekToken().isContextualKeyword("Type")
-          && !P.peekToken().isContextualKeyword("Protocol")) {
-        P.consumeToken();
-        continue;
-      }
-    } else if (P.Tok.is(tok::code_complete)) {
-      if (!P.Tok.isAtStartOfLine())
-        Status.setHasCodeCompletion();
-      break;
-    } else if (P.startsWithSymbol(P.Tok, '.')) {
-      if (P.Tok.getLength() != 1 || !P.peekToken().is(tok::identifier)) {
-        P.consumeStartingCharacterOfCurrentToken(tok::period);
-        continue;
-      }
-    }
-    break;
-  }
-
-  // If an operator was not encountered, backtrack before parsing the last
-  // identifier.
-  if (!foundOperator) {
-    P.restoreParserPosition(backtrackingPosition);
-    if (!ComponentsR.empty())
-      ComponentsR.pop_back();
-  }
-  bool afterDot = ComponentsR.size() > 0;
-  funcName =
-    P.parseUnqualifiedDeclName(afterDot, funcNameLoc,
-                               diag::attr_implements_expected_member_name,
-                               /*allowOperators*/ true,
-                               /*allowZeroArgCompoundNames*/ true);
-
-  IdentTypeRepr *ITR = nullptr;
-  if (!ComponentsR.empty()) {
-    // Lookup element #0 through our current scope chains in case it is some
-    // thing local (this returns null if nothing is found).
-    if (auto Entry = P.lookupInScope(ComponentsR[0]->getIdentifier()))
-      if (auto *TD = dyn_cast<TypeDecl>(Entry))
-        ComponentsR[0]->setValue(TD, nullptr);
-    ITR = IdentTypeRepr::create(P.Context, ComponentsR);
-  }
-
-  if (Status.hasCodeCompletion() && P.CodeCompletion) {
-    if (P.Tok.isNot(tok::code_complete)) {
-      // We have a dot.
-      P.consumeToken();
-      P.CodeCompletion->completeTypeIdentifierWithDot(ITR);
-    } else {
-      P.CodeCompletion->completeTypeIdentifierWithoutDot(ITR);
-    }
-    // Eat the code completion token because we handled it.
-    P.consumeToken(tok::code_complete);
-  }
-
-  assert(funcName && "Function name should have been parsed");
-  baseType = ITR;
+  name = P.parseUnqualifiedDeclName(afterDot, nameLoc, nameParseError,
+                                    /*allowOperators*/ true,
+                                    /*allowZeroArgCompoundNames*/ true);
+  // The base type is optional, but the final unqualified decl name is not.
+  // If name could not be parsed, return true for error.
+  if (!name) return true;
   return false;
 }
 
@@ -3933,7 +3819,8 @@ ParserResult<Expr> Parser::parseExprAdjoint() {
   TypeRepr *baseType;
   DeclName originalName;
   DeclNameLoc originalNameLoc;
-  if (parseFunctionIdentifier(*this, baseType, originalName, originalNameLoc))
+  if (parseQualifiedDeclName(*this, diag::expr_adjoint_expected_function_name,
+                             baseType, originalName, originalNameLoc))
     return errorAndSkipToEnd();
   if (parseToken(tok::r_paren, rParenLoc, diag::expr_expected_rparen,
                  "#adjoint"))

--- a/lib/Parse/ParseType.cpp
+++ b/lib/Parse/ParseType.cpp
@@ -546,9 +546,6 @@ bool Parser::parseGenericArguments(SmallVectorImpl<TypeRepr*> &Args,
 ///     identifier generic-args? ('.' identifier generic-args?)*
 ///
 /// SWIFT_ENABLE_TENSORFLOW: Added `isParsingQualifiedDeclName` flag.
-/// The `isParsingQualifiedDeclName` flag controls whether parsing is done as if
-/// this type identifier is the prefix to a qualified declaration name. If true,
-/// backtrack parsing the last identifier.
 ParserResult<TypeRepr>
 Parser::parseTypeIdentifier(bool isParsingQualifiedDeclName) {
   if (!isParsingQualifiedDeclName || Tok.isNotAnyOperator()) {

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3037,15 +3037,14 @@ visitAdjointExpr(AdjointExpr *E, SGFContext C) {
                            adjointFunc.getSubstitutions().toList());
     return RValue(SGF, loc, resultTy, result);
   }
-  // Otherwise, partially apply metatype to static adjoint method.
+  // Otherwise, apply metatype to static adjoint method.
   SILValue ref = SGF.emitGlobalFunctionRef(loc, adjointDeclRef, adjointInfo);
   auto subs = adjointFunc.getSubstitutions();
   auto baseMeta = adjointInfo.SILFnType->substGenericArgs(SGF.SGM.M, subs)
     ->getSelfParameter().getType();
   auto metatype = SGF.B.createMetatype(loc, SGF.getLoweredType(baseMeta));
-  auto partialApply =
-    SGF.B.createApply(loc, ref, subs.toList(), { metatype }, false);
-  ManagedValue adjointValue = SGF.emitManagedRValueWithCleanup(partialApply);
+  auto apply = SGF.B.createApply(loc, ref, subs.toList(), { metatype }, false);
+  ManagedValue adjointValue = SGF.emitManagedRValueWithCleanup(apply);
   return RValue(SGF, E, adjointValue);
 }
 

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3024,7 +3024,7 @@ visitAdjointExpr(AdjointExpr *E, SGFContext C) {
   SILDeclRef adjointDeclRef(adjointDecl);
 
   // If adjoint has multiple parameter lists, mark as curried.
-  if (adjointDecl->getNumParameterLists() == 2) {
+  if (adjointDecl->getNumParameterLists() >= 2) {
     adjointDeclRef = adjointDeclRef.asCurried();
   }
   auto adjointInfo = SGF.getConstantInfo(adjointDeclRef);

--- a/lib/SILGen/SILGenExpr.cpp
+++ b/lib/SILGen/SILGenExpr.cpp
@@ -3015,9 +3015,38 @@ visitValueAndGradientExpr(ValueAndGradientExpr *E, SGFContext C) {
   return emitGradientInst(*this, C, E, /*isValueAndGrad*/ true);
 }
 
+// SWIFT_ENABLE_TENSORFLOW
 RValue RValueEmitter::
 visitAdjointExpr(AdjointExpr *E, SGFContext C) {
-  llvm_unreachable("handle #adjoint");
+  ConcreteDeclRef adjointFunc = E->getAdjointFunction();
+  FuncDecl *adjointDecl = cast<FuncDecl>(adjointFunc.getDecl());
+  SILLocation loc(adjointDecl);
+  SILDeclRef adjointDeclRef(adjointDecl);
+
+  // If adjoint has multiple parameter lists, mark as curried.
+  if (adjointDecl->getNumParameterLists() == 2) {
+    adjointDeclRef = adjointDeclRef.asCurried();
+  }
+  auto adjointInfo = SGF.getConstantInfo(adjointDeclRef);
+
+  // Convert function ref to thick function type.
+  if (!adjointDecl->isStatic()) {
+    auto resultTy = E->getType()->getCanonicalType();
+    ManagedValue result =
+      SGF.emitClosureValue(loc, adjointDeclRef, resultTy,
+                           adjointFunc.getSubstitutions().toList());
+    return RValue(SGF, loc, resultTy, result);
+  }
+  // Otherwise, partially apply metatype to static adjoint method.
+  SILValue ref = SGF.emitGlobalFunctionRef(loc, adjointDeclRef, adjointInfo);
+  auto subs = adjointFunc.getSubstitutions();
+  auto baseMeta = adjointInfo.SILFnType->substGenericArgs(SGF.SGM.M, subs)
+    ->getSelfParameter().getType();
+  auto metatype = SGF.B.createMetatype(loc, SGF.getLoweredType(baseMeta));
+  auto partialApply =
+    SGF.B.createApply(loc, ref, subs.toList(), { metatype }, false);
+  ManagedValue adjointValue = SGF.emitManagedRValueWithCleanup(partialApply);
+  return RValue(SGF, E, adjointValue);
 }
 
 RValue RValueEmitter::

--- a/lib/Sema/CSApply.cpp
+++ b/lib/Sema/CSApply.cpp
@@ -2507,9 +2507,33 @@ namespace {
       return handleReverseAutoDiffExpr(expr, /*preservingOriginalResult=*/true);
     }
 
+    // SWIFT_ENABLE_TENSORFLOW
     Expr *visitAdjointExpr(AdjointExpr *expr) {
-      // FIXME
-      llvm_unreachable("Handle #adjoint");
+      auto locator = cs.getConstraintLocator(expr);
+      auto adjointDeclRef = expr->getAdjointFunction();
+      auto adjointDecl = cast<FuncDecl>(adjointDeclRef.getDecl());
+
+      // If adjoint is within a type context (it is an instance/static method),
+      // use member locator.
+      if (adjointDecl->getInnermostTypeContext())
+        locator = cs.getConstraintLocator(expr, ConstraintLocator::Member);
+
+      // If adjoint has generic signature, calculate substitutions and update
+      // adjoint decl ref with them.
+      SubstitutionMap substitutions;
+      if (auto genSig = adjointDecl->getGenericSignature()) {
+        substitutions = solution.computeSubstitutions(genSig, locator);
+        expr->setAdjointFunction(
+          ConcreteDeclRef(adjointDecl, substitutions));
+      }
+
+      auto selected = getOverloadChoice(locator);
+      auto simplifiedType = simplifyType(selected.openedFullType);
+      // For static methods, return result of curried method.
+      if (adjointDecl->isStatic())
+        simplifiedType = simplifiedType->castTo<AnyFunctionType>()->getResult();
+      cs.setType(expr, simplifiedType);
+      return expr;
     }
 
     // SWIFT_ENABLE_TENSORFLOW

--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -1404,8 +1404,158 @@ namespace {
     }
 
     Type visitAdjointExpr(AdjointExpr *AE) {
-      // FIXME
-      llvm_unreachable("Handle #adjoint");
+      // Note: This function performs the following steps:
+      // 1. Look up original function declaration using original function name
+      //    and, if defined, base type.
+      // 2. Verify that original function declaration has the @differentiable
+      //    attribute. Extract adjoint function from the attribute and store in
+      //    the AdjointExpr.
+      // 3. Constrain the type of the AdjointExpr to the expected type of the
+      //    adjoint function. The logic here is copied from other functions in
+      //    CSGen, namely `visitDeclRefExpr` and `visitUnresolvedDotExpr`.
+      auto &TC = CS.getTypeChecker();
+      auto &ctx = CS.getASTContext();
+      auto locator = CS.getConstraintLocator(AE);
+      auto originalName = AE->getOriginalName();
+      auto originalNameLoc = AE->getOriginalNameLoc();
+
+      // The original function declaration. This needs to be resolved.
+      FuncDecl *originalDecl = nullptr;
+      // The base type of the original function expression. This is relevant
+      // for type-checking the adjoint.
+      Type baseType;
+
+      if (auto repr = AE->getBaseType().getTypeRepr()) {
+        baseType = resolveTypeReferenceInExpression(repr);
+        if (baseType.isNull() || baseType->hasError()) {
+          TC.diagnose(AE->getBaseType().getLoc(),
+                      diag::adjoint_expr_original_base_type_unresolved, repr);
+          return nullptr;
+        }
+      }
+
+      // Prepare to look up the original function.
+      auto originalTypeCtx = CurDC->getInnermostTypeContext();
+      if (!originalTypeCtx) originalTypeCtx = CurDC;
+
+      auto overloadDiagnostic = [&]() {
+        TC.diagnose(originalNameLoc,
+                    diag::adjoint_expr_original_overload_not_found,
+                    originalName);
+      };
+      auto ambiguousDiagnostic = [&]() {
+        TC.diagnose(originalNameLoc,
+                    diag::adjoint_expr_ambiguous_original_function_identifier,
+                    originalName);
+      };
+      auto notFunctionDiagnostic = [&]() {
+        TC.diagnose(originalNameLoc,
+                    diag::adjoint_expr_original_not_func_decl,
+                    originalName);
+      };
+
+      // The original function must have the @differentiable attribute.
+      auto isValidOriginalDecl = [&](FuncDecl *candidate) {
+        return candidate->getAttrs().hasAttribute<DifferentiableAttr>();
+      };
+
+      NameLookupOptions lookupOptions = baseType
+        ? defaultMemberLookupOptions
+        : defaultUnqualifiedLookupOptions;
+
+      // Look up the original function.
+      originalDecl =
+        TC.lookupFuncDecl(originalName, originalNameLoc.getBaseNameLoc(),
+                          baseType, originalTypeCtx, isValidOriginalDecl,
+                          overloadDiagnostic, ambiguousDiagnostic,
+                          notFunctionDiagnostic, lookupOptions);
+      if (!originalDecl) return nullptr;
+
+      // Get the @differentiable attribute of the original func decl.
+      auto originalAttrs = originalDecl->getAttrs();
+      if (!originalAttrs.hasAttribute<DifferentiableAttr>()) {
+        TC.diagnose(originalNameLoc,
+                    diag::adjoint_expr_original_no_valid_differentiable_attr,
+                    originalDecl->getFullName());
+        return nullptr;
+      }
+      auto diffAttr = originalAttrs.getAttribute<DifferentiableAttr>();
+
+      // Set the adjoint function in the adjoint expression.
+      auto adjointFunc = diffAttr->getAdjointFunction();
+      assert(adjointFunc &&
+             "adjoint for valid @differentiable attribute should be defined");
+
+      // This is an inline version of `addMemberRefConstraints` that tries to
+      // serve the same purpose, but ignores access control when performing
+      // lookup. This is important for finding normally inaccessible adjoint
+      // functions.
+      // This version omits code for handling member expressions that
+      // aren't methods (e.g. stored variables).
+      auto addMemberRefConstraints =
+          [&](Expr *expr, DeclName name, FunctionRefKind funcRefKind) -> Type {
+        assert(baseType && "Base type must be set");
+
+        auto memberLocator =
+          CS.getConstraintLocator(expr, ConstraintLocator::Member);
+        auto tv = CS.createTypeVariable(
+          memberLocator, TVO_CanBindToLValue | TVO_CanBindToInOut);
+
+        // Code copied from CS.performMemberLookup, with simplifications.
+        Type baseObjTy = baseType->getRValueType();
+        Type instanceTy = baseObjTy;
+        if (auto baseObjMeta = baseObjTy->getAs<AnyMetatypeType>())
+          instanceTy = baseObjMeta->getInstanceType();
+
+        MemberLookupResult result;
+        if (auto *selfTy = instanceTy->getAs<DynamicSelfType>())
+          instanceTy = selfTy->getSelfType();
+        assert(instanceTy->mayHaveMembers() &&
+               "Instance type should be able to have members");
+
+        // Ignore access control when doing adjoint lookup.
+        auto options = defaultMemberLookupOptions
+          | NameLookupFlags::IgnoreAccessControl;
+        auto lookupResult = TC.lookupMember(CurDC, instanceTy, name, options);
+        for (auto entry : lookupResult) {
+          OverloadChoice choice(baseType, entry.getValueDecl(), funcRefKind);
+          result.addViable(choice);
+        }
+        CS.addOverloadSet(tv, result.ViableCandidates, CurDC, memberLocator,
+                          result.getFavoredChoice());
+        return tv;
+      };
+
+      // The adjoint decl ref is set here, without substitutions.
+      // The correct substitutions for the adjoint decl ref are set in CSApply.
+      AE->setAdjointFunction(adjointFunc);
+
+      // Add constraints on the type of the #adjoint expression.
+      // - If adjoint is within a type context (it is an instance/static
+      //   method), add member reference constraints.
+      // Code copied from `visitUnresolvedDotExpr`.
+      if (adjointFunc->getInnermostTypeContext()) {
+        if (!baseType) {
+          assert(adjointFunc->isInstanceMember() || adjointFunc->isStatic() &&
+                 "Expected adjoint to be an instance/static method");
+          auto methodContext = CurDC->getInnermostMethodContext();
+          baseType = methodContext->getParameterList(0)->get(0)->getType();
+        }
+        if (adjointFunc->isInstanceMember())
+          baseType = MetatypeType::get(baseType, ctx);
+        if (baseType->hasUnboundGenericType())
+          baseType = CS.openUnboundGenericType(baseType, locator);
+        return addMemberRefConstraints(AE, adjointFunc->getFullName(),
+                                       AE->getFunctionRefKind());
+      }
+
+      // - Otherwise, if adjoint is a top-level function, create overload choice
+      //   and immediately resolve it.
+      // Code copied from `visitDeclRefExpr`.
+      auto tv = CS.createTypeVariable(locator, TVO_CanBindToLValue);
+      OverloadChoice choice(Type(), adjointFunc, AE->getFunctionRefKind());
+      CS.resolveOverload(locator, tv, choice, CurDC);
+      return tv;
     }
 
     Type visitPoundAssertExpr(PoundAssertExpr *PAE) {

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -2304,10 +2304,6 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   auto originalTypeCtx = original->getInnermostTypeContext();
   if (!originalTypeCtx) originalTypeCtx = original->getParent();
 
-  Type originalBaseType;
-  if (originalTypeCtx->isTypeContext())
-    originalBaseType = originalTypeCtx->getSelfTypeInContext();
-
   // Set lookup options.
   auto lookupOptions = defaultMemberLookupOptions
     | NameLookupFlags::IgnoreAccessControl;
@@ -2370,7 +2366,7 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
     };
 
     primal = TC.lookupFuncDecl(
-      primalSpecifier.Name, primalNameLoc, originalBaseType,
+      primalSpecifier.Name, primalNameLoc, /*baseType*/ Type(),
       originalTypeCtx, isValidPrimal, primalOverloadDiagnostic,
       primalAmbiguousDiagnostic, primalNotFunctionDiagnostic, lookupOptions,
       hasValidTypeContext, primalInvalidTypeContextDiagnostic);
@@ -2556,8 +2552,8 @@ void AttributeChecker::visitDifferentiableAttr(DifferentiableAttr *attr) {
   };
 
   adjoint =
-    TC.lookupFuncDecl(adjointSpecifier.Name, adjointNameLoc, originalBaseType,
-                      originalTypeCtx, isValidAdjoint,
+    TC.lookupFuncDecl(adjointSpecifier.Name, adjointNameLoc,
+                      /*baseType*/ Type(), originalTypeCtx, isValidAdjoint,
                       adjointOverloadDiagnostic, adjointAmbiguousDiagnostic,
                       adjointNotFunctionDiagnostic, lookupOptions,
                       hasValidTypeContext, adjointInvalidTypeContextDiagnostic);

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -2547,7 +2547,8 @@ public:
   // lookup context. If the function declaration cannot be resolved, emits a
   // diagnostic and returns nullptr.
   FuncDecl *lookupFuncDecl(
-      DeclName funcName, SourceLoc funcNameLoc, DeclContext *lookupContext,
+      DeclName funcName, SourceLoc funcNameLoc, Type baseType,
+      DeclContext *lookupContext,
       const std::function<bool(FuncDecl *)> &isValidFuncDecl,
       const std::function<void()> &overloadDiagnostic,
       const std::function<void()> &ambiguousDiagnostic,

--- a/test/AutoDiff/adjoint_expr_silgen.swift
+++ b/test/AutoDiff/adjoint_expr_silgen.swift
@@ -22,7 +22,7 @@ func testTopLevel() -> Float {
 }
 // CHECK-LABEL: sil hidden @test_top_level
 // CHECK: [[DSQUARE_RAW:%.*]] = function_ref @dsquare : $@convention(thin) <τ_0_0 where τ_0_0 : FloatingPoint> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> @out τ_0_0
-// CHECK: [[DSQUARE:%.*]] = partial_apply [callee_guaranteed] [[DSQUARE_RAW]]<Float>
+// CHECK: {{%.*}} = partial_apply [callee_guaranteed] [[DSQUARE_RAW]]<Float>
 
 @_silgen_name("test_top_level_generic")
 func testTopLevelGeneric<T : FloatingPoint>(_ x: T) -> T {
@@ -31,7 +31,7 @@ func testTopLevelGeneric<T : FloatingPoint>(_ x: T) -> T {
 }
 // CHECK-LABEL: sil hidden @test_top_level_generic : $@convention(thin) <T where T : FloatingPoint> (@in_guaranteed T) -> @out T
 // CHECK: [[DSQUARE_RAW_2:%.*]] = function_ref @dsquare : $@convention(thin) <τ_0_0 where τ_0_0 : FloatingPoint> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> @out τ_0_0
-// CHECK: [[DSQUARE_2:%.*]] = partial_apply [callee_guaranteed] [[DSQUARE_RAW_2]]<T>()
+// CHECK: {{%.*}} = partial_apply [callee_guaranteed] [[DSQUARE_RAW_2]]<T>()
 
 //===----------------------------------------------------------------------===//
 // Nested type
@@ -76,10 +76,10 @@ func testNested() {
 // CHECK-LABEL: sil hidden @test_nested
 // CHECK: [[NESTED_DADD_THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) (@thin A.B.C.Type) -> @owned @callee_guaranteed (A.B.C, A.B.C, A.B.C, A.B.C) -> (A.B.C, A.B.C)
 // CHECK: [[NESTED_META:%.*]] = metatype $@thin A.B.C.Type
-// CHECK: [[NESTED_DADD:%.*]] = apply [[NESTED_DADD_THUNK]]([[NESTED_META]])
+// CHECK: {{%.*}} = apply [[NESTED_DADD_THUNK]]([[NESTED_META]])
 
 // CHECK: [[NESTED_DSUB_THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) (A.B.C) -> @owned @callee_guaranteed (A.B.C, A.B.C, A.B.C) -> (A.B.C, A.B.C)
-// CHECK: [[NESTED_DSUB:%.*]] = thin_to_thick_function [[NESTED_DSUB_THUNK]]
+// CHECK: {{%.*}} = thin_to_thick_function [[NESTED_DSUB_THUNK]]
 
 //===----------------------------------------------------------------------===//
 // Non-generic type
@@ -126,10 +126,10 @@ extension Pair {
 // CHECK-LABEL: sil hidden @test_pair_extension
 // CHECK: [[PAIR_DADD_THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) (@thin Pair.Type) -> @owned @callee_guaranteed (Pair, Pair, Pair, Pair) -> (Pair, Pair)
 // CHECK: [[PAIR_META:%.*]] = metatype $@thin Pair.Type
-// CHECK: [[PAIR_DADD:%.*]] = apply [[PAIR_DADD_THUNK]]([[PAIR_META]])
+// CHECK: {{%.*}} = apply [[PAIR_DADD_THUNK]]([[PAIR_META]])
 
 // CHECK: [[PAIR_DSUB_THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) (Pair) -> @owned @callee_guaranteed (Pair, Pair, Pair) -> (Pair, Pair)
-// CHECK: [[PAIR_DSUB:%.*]] = thin_to_thick_function [[PAIR_DSUB_THUNK]]
+// CHECK: {{%.*}} = thin_to_thick_function [[PAIR_DSUB_THUNK]]
 
 @_silgen_name("test_pair")
 func testPair() {
@@ -139,10 +139,10 @@ func testPair() {
 // CHECK-LABEL: sil hidden @test_pair
 // CHECK: [[PAIR_DADD_THUNK_2:%.*]] = function_ref {{.*}} : $@convention(thin) (@thin Pair.Type) -> @owned @callee_guaranteed (Pair, Pair, Pair, Pair) -> (Pair, Pair)
 // CHECK: [[PAIR_META_2:%.*]] = metatype $@thin Pair.Type
-// CHECK: [[PAIR_DADD_2:%.*]] = apply [[PAIR_DADD_THUNK_2]]([[PAIR_META_2]])
+// CHECK: {{%.*}} = apply [[PAIR_DADD_THUNK_2]]([[PAIR_META_2]])
 
 // CHECK: [[PAIR_DSUB_THUNK_2:%.*]] = function_ref {{.*}} : $@convention(thin) (Pair) -> @owned @callee_guaranteed (Pair, Pair, Pair) -> (Pair, Pair)
-// CHECK: [[PAIR_DSUB_2:%.*]] = thin_to_thick_function [[PAIR_DSUB_THUNK_2]]
+// CHECK: {{%.*}} = thin_to_thick_function [[PAIR_DSUB_THUNK_2]]
 
 //===----------------------------------------------------------------------===//
 // Generic type with generic functions
@@ -189,10 +189,10 @@ extension Vector {
 // CHECK-LABEL: sil hidden @test_vector_extension : $@convention(method) <T> (Vector<T>) -> ()
 // CHECK: [[VEC_DMUL_THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : FloatingPoint> (@thin Vector<τ_0_0>.Type) -> @owned @callee_guaranteed (Vector<τ_1_0>, Vector<τ_1_0>, Vector<τ_1_0>, Vector<τ_1_0>) -> (Vector<τ_1_0>, Vector<τ_1_0>)
 // CHECK: [[VEC_DMUL_META:%.*]] = metatype $@thin Vector<T>.Type
-// CHECK: [[VEC_DMUL:%.*]] = apply [[VEC_DMUL_THUNK]]<T, Float>([[VEC_DMUL_META]])
+// CHECK: {{%.*}} = apply [[VEC_DMUL_THUNK]]<T, Float>([[VEC_DMUL_META]])
 
 // CHECK: [[VEC_DDIV_THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : FloatingPoint> (Vector<τ_0_0>) -> @owned @callee_guaranteed (Vector<τ_1_0>, Vector<τ_1_0>, Vector<τ_1_0>) -> (Vector<τ_0_0>, Vector<τ_1_0>)
-// CHECK: [[VEC_DDIV:%.*]] = partial_apply [callee_guaranteed] [[VEC_DDIV_THUNK]]<T, Float>()
+// CHECK: {{%.*}} = partial_apply [callee_guaranteed] [[VEC_DDIV_THUNK]]<T, Float>()
 
 @_silgen_name("test_vector")
 func testVector<T, A : FloatingPoint>(_ t: T, _ a: A) {
@@ -204,7 +204,7 @@ func testVector<T, A : FloatingPoint>(_ t: T, _ a: A) {
 // CHECK-LABEL: sil hidden @test_vector : $@convention(thin) <T, A where A : FloatingPoint> (@in_guaranteed T, @in_guaranteed A) -> ()
 // CHECK: [[VEC_DMUL_THUNK_2:%.*]] = function_ref {{.*}} : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : FloatingPoint> (@thin Vector<τ_0_0>.Type) -> @owned @callee_guaranteed (Vector<τ_1_0>, Vector<τ_1_0>, Vector<τ_1_0>, Vector<τ_1_0>) -> (Vector<τ_1_0>, Vector<τ_1_0>)
 // CHECK: [[VEC_DMUL_META_2:%.*]] = metatype $@thin Vector<T>.Type
-// CHECK: [[VEC_DMUL_2:%.*]] = apply [[VEC_DMUL_THUNK_2]]<T, A>([[VEC_DMUL_META_2]])
+// CHECK: {{%.*}} = apply [[VEC_DMUL_THUNK_2]]<T, A>([[VEC_DMUL_META_2]])
 
 // CHECK: [[VEC_DDIV_THUNK_2:%.*]] = function_ref {{.*}} : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : FloatingPoint> (Vector<τ_0_0>) -> @owned @callee_guaranteed (Vector<τ_1_0>, Vector<τ_1_0>, Vector<τ_1_0>) -> (Vector<τ_0_0>, Vector<τ_1_0>)
-// CHECK: [[VEC_DDIV_2:%.*]] = partial_apply [callee_guaranteed] [[VEC_DDIV_THUNK_2]]<T, A>()
+// CHECK: {{%.*}} = partial_apply [callee_guaranteed] [[VEC_DDIV_THUNK_2]]<T, A>()

--- a/test/AutoDiff/adjoint_expr_silgen.swift
+++ b/test/AutoDiff/adjoint_expr_silgen.swift
@@ -1,0 +1,210 @@
+// RUN: %target-swift-frontend -emit-sil -verify %s | %FileCheck %s
+
+// Note: the adjoint calculations in this file are not intended to be accurate.
+
+//===----------------------------------------------------------------------===//
+// Top-level function
+//===----------------------------------------------------------------------===//
+
+@differentiable(reverse, adjoint: dSquare(_:primal:seed:))
+func square<T : FloatingPoint>(_ x: T) -> T {
+  return x * x
+}
+@_silgen_name("dsquare")
+private func dSquare<T : FloatingPoint>(_ x: T, primal: T, seed: T) -> T {
+  return 2 * x
+}
+
+@_silgen_name("test_top_level")
+func testTopLevel() -> Float {
+  let adjointSquare: (Float, Float, Float) -> Float = #adjoint(square)
+  return adjointSquare(1, 2, 3)
+}
+// CHECK-LABEL: sil hidden @test_top_level
+// CHECK: [[DSQUARE_RAW:%.*]] = function_ref @dsquare : $@convention(thin) <τ_0_0 where τ_0_0 : FloatingPoint> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> @out τ_0_0
+// CHECK: [[DSQUARE:%.*]] = partial_apply [callee_guaranteed] [[DSQUARE_RAW]]<Float>
+
+@_silgen_name("test_top_level_generic")
+func testTopLevelGeneric<T : FloatingPoint>(_ x: T) -> T {
+  let adjointSquare: (T, T, T) -> T = #adjoint(square)
+  return adjointSquare(x, x, x)
+}
+// CHECK-LABEL: sil hidden @test_top_level_generic : $@convention(thin) <T where T : FloatingPoint> (@in_guaranteed T) -> @out T
+// CHECK: [[DSQUARE_RAW_2:%.*]] = function_ref @dsquare : $@convention(thin) <τ_0_0 where τ_0_0 : FloatingPoint> (@in_guaranteed τ_0_0, @in_guaranteed τ_0_0, @in_guaranteed τ_0_0) -> @out τ_0_0
+// CHECK: [[DSQUARE_2:%.*]] = partial_apply [callee_guaranteed] [[DSQUARE_RAW_2]]<T>()
+
+//===----------------------------------------------------------------------===//
+// Nested type
+//===----------------------------------------------------------------------===//
+
+struct A {
+  struct B {
+    struct C {
+      @differentiable(reverse, adjoint: dAdd(a:b:primal:seed:))
+      public static func add(a: C, b: C) -> C {
+        return a
+      }
+
+      @usableFromInline internal static func dAdd(
+        a: C, b: C, primal: C, seed: C
+      ) -> (C, C) {
+        return (seed, seed)
+      }
+
+      @differentiable(
+        reverse, withRespectTo: (self, .0),
+        adjoint: dSubtract(a:primal:seed:)
+      )
+      func subtract(a: C) -> C {
+        return a
+      }
+
+      private func dSubtract(
+        a: C, primal: C, seed: C
+      ) -> (C, C) {
+        return (seed, seed)
+      }
+    }
+  }
+}
+
+@_silgen_name("test_nested")
+func testNested() {
+  _ = #adjoint(A.B.C.add)
+  _ = #adjoint(A.B.C.subtract)
+}
+// CHECK-LABEL: sil hidden @test_nested
+// CHECK: [[NESTED_DADD_THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) (@thin A.B.C.Type) -> @owned @callee_guaranteed (A.B.C, A.B.C, A.B.C, A.B.C) -> (A.B.C, A.B.C)
+// CHECK: [[NESTED_META:%.*]] = metatype $@thin A.B.C.Type
+// CHECK: [[NESTED_DADD:%.*]] = apply [[NESTED_DADD_THUNK]]([[NESTED_META]])
+
+// CHECK: [[NESTED_DSUB_THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) (A.B.C) -> @owned @callee_guaranteed (A.B.C, A.B.C, A.B.C) -> (A.B.C, A.B.C)
+// CHECK: [[NESTED_DSUB:%.*]] = thin_to_thick_function [[NESTED_DSUB_THUNK]]
+
+//===----------------------------------------------------------------------===//
+// Non-generic type
+//===----------------------------------------------------------------------===//
+
+struct Pair {
+  let x: Float
+  let y: Float
+}
+extension Pair {
+  @differentiable(reverse, adjoint: dAdd(_:_:primal:seed:))
+  static func + (_ a: Pair, _ b: Pair) -> Pair {
+    return Pair(x: a.x+b.x, y: a.y+b.y)
+  }
+
+  private static func dAdd(
+    _ a: Pair, _ b: Pair, primal: Pair, seed: Pair
+  ) -> (Pair, Pair) {
+    return (seed, seed)
+  }
+
+  @differentiable(
+    reverse, withRespectTo: (self, .0),
+    adjoint: dSubtract(_:primal:seed:)
+  )
+  func subtract(_ a: Pair) -> Pair {
+    return Pair(x: x-a.x, y: y-a.y)
+  }
+
+  private func dSubtract(
+    _ a: Pair, primal: Pair, seed: Pair
+  ) -> (Pair, Pair) {
+    return (seed, Pair(x: -seed.x, y: -seed.y))
+  }
+}
+
+extension Pair {
+  @_silgen_name("test_pair_extension")
+  func testSameTypeContext() {
+    _ = #adjoint(+)
+    _ = #adjoint(subtract)
+  }
+}
+// CHECK-LABEL: sil hidden @test_pair_extension
+// CHECK: [[PAIR_DADD_THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) (@thin Pair.Type) -> @owned @callee_guaranteed (Pair, Pair, Pair, Pair) -> (Pair, Pair)
+// CHECK: [[PAIR_META:%.*]] = metatype $@thin Pair.Type
+// CHECK: [[PAIR_DADD:%.*]] = apply [[PAIR_DADD_THUNK]]([[PAIR_META]])
+
+// CHECK: [[PAIR_DSUB_THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) (Pair) -> @owned @callee_guaranteed (Pair, Pair, Pair) -> (Pair, Pair)
+// CHECK: [[PAIR_DSUB:%.*]] = thin_to_thick_function [[PAIR_DSUB_THUNK]]
+
+@_silgen_name("test_pair")
+func testPair() {
+  _ = #adjoint(Pair.+)
+  _ = #adjoint(Pair.subtract)
+}
+// CHECK-LABEL: sil hidden @test_pair
+// CHECK: [[PAIR_DADD_THUNK_2:%.*]] = function_ref {{.*}} : $@convention(thin) (@thin Pair.Type) -> @owned @callee_guaranteed (Pair, Pair, Pair, Pair) -> (Pair, Pair)
+// CHECK: [[PAIR_META_2:%.*]] = metatype $@thin Pair.Type
+// CHECK: [[PAIR_DADD_2:%.*]] = apply [[PAIR_DADD_THUNK_2]]([[PAIR_META_2]])
+
+// CHECK: [[PAIR_DSUB_THUNK_2:%.*]] = function_ref {{.*}} : $@convention(thin) (Pair) -> @owned @callee_guaranteed (Pair, Pair, Pair) -> (Pair, Pair)
+// CHECK: [[PAIR_DSUB_2:%.*]] = thin_to_thick_function [[PAIR_DSUB_THUNK_2]]
+
+//===----------------------------------------------------------------------===//
+// Generic type with generic functions
+//===----------------------------------------------------------------------===//
+
+struct Vector<T> {
+  @differentiable(reverse, adjoint: dMultiply(_:_:primal:seed:))
+  static func * <A : FloatingPoint>(
+    _ a: Vector<A>, _ b: Vector<A>
+  ) -> Vector<A> {
+    return a
+  }
+
+  @differentiable(
+    reverse, withRespectTo: (self, .0),
+    adjoint: dDivide(_:primal:seed:)
+  )
+  func divide<A : FloatingPoint>(_ a: Vector<A>) -> Vector<A> {
+    return a
+  }
+
+  static func dMultiply<A : FloatingPoint>(
+    _ a: Vector<A>, _ b: Vector<A>, primal: Vector<A>, seed: Vector<A>
+  ) -> (Vector<A>, Vector<A>) {
+    return (seed, seed)
+  }
+
+  func dDivide<A : FloatingPoint>(
+    _ a: Vector<A>, primal: Vector<A>, seed: Vector<A>
+  ) -> (Vector, Vector<A>) {
+    return (self, seed)
+  }
+}
+
+extension Vector {
+  @_silgen_name("test_vector_extension")
+  func testSameTypeContext() {
+    let _: (Vector<Float>, Vector<Float>, Vector<Float>, Vector<Float>) -> (Vector<Float>, Vector<Float>)
+      = #adjoint(*)
+    let _: (Vector) -> (Vector<Float>, Vector<Float>, Vector<Float>) -> (Vector, Vector<Float>)
+      = #adjoint(divide)
+  }
+}
+// CHECK-LABEL: sil hidden @test_vector_extension : $@convention(method) <T> (Vector<T>) -> ()
+// CHECK: [[VEC_DMUL_THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : FloatingPoint> (@thin Vector<τ_0_0>.Type) -> @owned @callee_guaranteed (Vector<τ_1_0>, Vector<τ_1_0>, Vector<τ_1_0>, Vector<τ_1_0>) -> (Vector<τ_1_0>, Vector<τ_1_0>)
+// CHECK: [[VEC_DMUL_META:%.*]] = metatype $@thin Vector<T>.Type
+// CHECK: [[VEC_DMUL:%.*]] = apply [[VEC_DMUL_THUNK]]<T, Float>([[VEC_DMUL_META]])
+
+// CHECK: [[VEC_DDIV_THUNK:%.*]] = function_ref {{.*}} : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : FloatingPoint> (Vector<τ_0_0>) -> @owned @callee_guaranteed (Vector<τ_1_0>, Vector<τ_1_0>, Vector<τ_1_0>) -> (Vector<τ_0_0>, Vector<τ_1_0>)
+// CHECK: [[VEC_DDIV:%.*]] = partial_apply [callee_guaranteed] [[VEC_DDIV_THUNK]]<T, Float>()
+
+@_silgen_name("test_vector")
+func testVector<T, A : FloatingPoint>(_ t: T, _ a: A) {
+  let _: (Vector<A>, Vector<A>, Vector<A>, Vector<A>) -> (Vector<A>, Vector<A>)
+    = #adjoint(Vector<T>.*)
+  let _: (Vector<T>) -> (Vector<A>, Vector<A>, Vector<A>) -> (Vector<T>, Vector<A>)
+    = #adjoint(Vector<T>.divide)
+}
+// CHECK-LABEL: sil hidden @test_vector : $@convention(thin) <T, A where A : FloatingPoint> (@in_guaranteed T, @in_guaranteed A) -> ()
+// CHECK: [[VEC_DMUL_THUNK_2:%.*]] = function_ref {{.*}} : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : FloatingPoint> (@thin Vector<τ_0_0>.Type) -> @owned @callee_guaranteed (Vector<τ_1_0>, Vector<τ_1_0>, Vector<τ_1_0>, Vector<τ_1_0>) -> (Vector<τ_1_0>, Vector<τ_1_0>)
+// CHECK: [[VEC_DMUL_META_2:%.*]] = metatype $@thin Vector<T>.Type
+// CHECK: [[VEC_DMUL_2:%.*]] = apply [[VEC_DMUL_THUNK_2]]<T, A>([[VEC_DMUL_META_2]])
+
+// CHECK: [[VEC_DDIV_THUNK_2:%.*]] = function_ref {{.*}} : $@convention(thin) <τ_0_0><τ_1_0 where τ_1_0 : FloatingPoint> (Vector<τ_0_0>) -> @owned @callee_guaranteed (Vector<τ_1_0>, Vector<τ_1_0>, Vector<τ_1_0>) -> (Vector<τ_0_0>, Vector<τ_1_0>)
+// CHECK: [[VEC_DDIV_2:%.*]] = partial_apply [callee_guaranteed] [[VEC_DDIV_THUNK_2]]<T, A>()

--- a/test/AutoDiff/adjoint_expr_type_checking.swift
+++ b/test/AutoDiff/adjoint_expr_type_checking.swift
@@ -1,0 +1,234 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+// Note: the adjoint calculations in this file are not intended to be accurate.
+
+//===----------------------------------------------------------------------===//
+// Top-level function
+//===----------------------------------------------------------------------===//
+
+@differentiable(reverse, adjoint: dSquare(_:primal:seed:))
+func square<T : FloatingPoint>(_ x: T) -> T {
+  return x * x
+}
+// expected-note @+1 {{in call to function 'dSquare(_:primal:seed:)'}}
+private func dSquare<T : FloatingPoint>(_ x: T, primal: T, seed: T) -> T {
+  return 2 * x
+}
+
+let _: (Float, Float, Float) -> Float = #adjoint(square)
+func testTopLevel() -> Float {
+  let adjointSquare: (Float, Float, Float) -> Float = #adjoint(square)
+  return adjointSquare(1, 2, 3)
+}
+func testTopLevelGeneric<T : FloatingPoint>(_ x: T) -> T {
+  let adjointSquare: (T, T, T) -> T = #adjoint(square)
+  return adjointSquare(x, x, x)
+}
+func testTopLevel2() -> Float {
+  return #adjoint(square)(1, primal: 2, seed: 3)
+}
+func testTopLevelGeneric2<T : FloatingPoint>(_ x: T) -> T {
+  return #adjoint(square)(x, primal: x, seed: x)
+}
+
+//===----------------------------------------------------------------------===//
+// Nested type
+//===----------------------------------------------------------------------===//
+
+struct A {
+  struct B {
+    struct C {
+      @differentiable(reverse, adjoint: dAdd(a:b:primal:seed:))
+      public static func add(a: C, b: C) -> C {
+        return a
+      }
+
+      @usableFromInline internal static func dAdd(
+        a: C, b: C, primal: C, seed: C
+      ) -> (C, C) {
+        return (seed, seed)
+      }
+
+      @differentiable(reverse, adjoint: dSubtract(a:b:primal:seed:))
+      func subtract(a: C, b: C) -> C {
+        return a
+      }
+
+      private func dSubtract(
+        a: C, b: C, primal: C, seed: C
+      ) -> (C, C) {
+        return (seed, seed)
+      }
+    }
+  }
+}
+
+let _ = #adjoint(A.B.C.add)
+let _ = #adjoint(A.B.C.subtract)
+extension A {
+  func test() {
+    _ = #adjoint(B.C.add)
+    _ = #adjoint(B.C.subtract)
+  }
+}
+extension A.B {
+  func test() {
+    _ = #adjoint(C.add)
+    _ = #adjoint(C.subtract)
+  }
+}
+func testNested() {
+  _ = #adjoint(A.B.C.add)
+  _ = #adjoint(A.B.C.subtract)
+}
+
+//===----------------------------------------------------------------------===//
+// Non-generic type
+//===----------------------------------------------------------------------===//
+
+struct Pair {
+  let x: Float
+  let y: Float
+}
+extension Pair {
+  @differentiable(reverse, adjoint: dAdd(_:_:primal:seed:))
+  static func + (_ a: Pair, _ b: Pair) -> Pair {
+    return Pair(x: a.x+b.x, y: a.y+b.y)
+  }
+
+  private static func dAdd(
+    _ a: Pair, _ b: Pair, primal: Pair, seed: Pair
+  ) -> (Pair, Pair) {
+    return (seed, seed)
+  }
+
+  @differentiable(
+    reverse, withRespectTo: (self, .0),
+    adjoint: dSubtract(_:primal:seed:)
+  )
+  func subtract(_ a: Pair) -> Pair {
+    return Pair(x: x-a.x, y: y-a.y)
+  }
+
+  private func dSubtract(
+    _ a: Pair, primal: Pair, seed: Pair
+  ) -> (Pair, Pair) {
+    return (seed, Pair(x: -seed.x, y: -seed.y))
+  }
+}
+
+extension Pair {
+  func testSameTypeContext() {
+    _ = #adjoint(+)
+    _ = #adjoint(subtract)
+  }
+}
+
+func testPair() {
+  _ = #adjoint(Pair.+)
+  _ = #adjoint(Pair.+(_:_:))
+  _ = #adjoint(Pair.subtract)
+  _ = #adjoint(Pair.subtract(_:))
+}
+
+//===----------------------------------------------------------------------===//
+// Generic type with generic functions
+//===----------------------------------------------------------------------===//
+
+struct Vector<T> {
+  @differentiable(reverse, adjoint: dMultiply(_:_:primal:seed:))
+  static func * <A : FloatingPoint>(
+    _ a: Vector<A>, _ b: Vector<A>
+  ) -> Vector<A> {
+    return a
+  }
+
+  @differentiable(
+    reverse, withRespectTo: (self, .0),
+    adjoint: dDivide(_:primal:seed:)
+  )
+  func divide<A : FloatingPoint>(_ a: Vector<A>) -> Vector<A> {
+    return a
+  }
+
+  static func dMultiply<A : FloatingPoint>(
+    _ a: Vector<A>, _ b: Vector<A>, primal: Vector<A>, seed: Vector<A>
+  ) -> (Vector<A>, Vector<A>) {
+    return (seed, seed)
+  }
+
+  func dDivide<A : FloatingPoint>(
+    _ a: Vector<A>, primal: Vector<A>, seed: Vector<A>
+  ) -> (Vector, Vector<A>) {
+    return (self, seed)
+  }
+}
+
+extension Vector {
+  static func dMultiply2<A : FloatingPoint>(
+    _ a: Vector<A>, _ b: Vector<A>, primal: Vector<A>, seed: Vector<A>
+  ) -> (Vector<A>, Vector<A>) {
+    let adjoint: (Vector<A>, Vector<A>, Vector<A>, Vector<A>) -> (Vector<A>, Vector<A>)
+      = #adjoint(*)
+    return adjoint(a, b, primal, seed)
+  }
+
+  func dDivide2<A : FloatingPoint>(
+    _ a: Vector<A>, primal: Vector<A>, seed: Vector<A>
+  ) -> (Vector, Vector<A>) {
+    let adjoint: (Vector) -> (Vector<A>, Vector<A>, Vector<A>) -> (Vector, Vector<A>) =
+      #adjoint(divide)
+    return adjoint(self)(a, primal, seed)
+  }
+
+  static func dMultiply3<A : FloatingPoint>(
+    _ a: Vector<A>, _ b: Vector<A>, primal: Vector<A>, seed: Vector<A>
+  ) -> (Vector<A>, Vector<A>) {
+    return #adjoint(*(_:_:))(a, b, primal: primal, seed: seed)
+  }
+
+  func dDivide3<A : FloatingPoint>(
+    _ a: Vector<A>, primal: Vector<A>, seed: Vector<A>
+  ) -> (Vector, Vector<A>) {
+    return #adjoint(divide(_:))(self)(a, primal: primal, seed: seed)
+  }
+}
+
+let _: (Vector<Float>, Vector<Float>, Vector<Float>, Vector<Float>) -> (Vector<Float>, Vector<Float>)
+  = #adjoint(Vector<Any>.*)
+let _: (Vector<Any>) -> (Vector<Float>, Vector<Float>, Vector<Float>) -> (Vector<Any>, Vector<Float>)
+  = #adjoint(Vector.divide)
+
+extension Vector {
+  func testSameTypeContext() {
+    let _: (Vector<Float>, Vector<Float>, Vector<Float>, Vector<Float>) -> (Vector<Float>, Vector<Float>)
+      = #adjoint(*)
+    let _: (Vector) -> (Vector<Float>, Vector<Float>, Vector<Float>) -> (Vector, Vector<Float>)
+      = #adjoint(divide)
+  }
+}
+
+func testVector<T, A : FloatingPoint>(_ t: T, _ a: A) {
+  let _: (Vector<A>, Vector<A>, Vector<A>, Vector<A>) -> (Vector<A>, Vector<A>)
+    = #adjoint(Vector<T>.*)
+  let _: (Vector<T>) -> (Vector<A>, Vector<A>, Vector<A>) -> (Vector<T>, Vector<A>)
+    = #adjoint(Vector<T>.divide)
+}
+
+//===----------------------------------------------------------------------===//
+// Errors
+//===----------------------------------------------------------------------===//
+
+let _ = #adjoint(square) // expected-error {{generic parameter 'T' could not be inferred}}
+let _ = dSquare // expected-error {{generic parameter 'T' could not be inferred}}
+
+// Note: I think the case below is theoretically resolvable by the type checker.
+// The failing behavior is consistent for both #adjoint and direct function
+// reference, so things are good.
+
+// expected-error @+2 {{cannot convert value of type '(Vector<_>, Vector<_>, Vector<_>, Vector<_>) -> (Vector<_>, Vector<_>)' to specified type '(Vector<Float>, Vector<Float>, Vector<Float>, Vector<Float>) -> (Vector<Float>, Vector<Float>)'}}
+let _: (Vector<Float>, Vector<Float>, Vector<Float>, Vector<Float>) -> (Vector<Float>, Vector<Float>)
+  = #adjoint(Vector.*)
+// expected-error @+2 {{cannot convert value of type '(Vector<_>, Vector<_>, Vector<_>, Vector<_>) -> (Vector<_>, Vector<_>)' to specified type '(Vector<Float>, Vector<Float>, Vector<Float>, Vector<Float>) -> (Vector<Float>, Vector<Float>)'}}
+let _: (Vector<Float>, Vector<Float>, Vector<Float>, Vector<Float>) -> (Vector<Float>, Vector<Float>)
+  = Vector.dMultiply

--- a/test/AutoDiff/adjoint_expr_type_checking.swift
+++ b/test/AutoDiff/adjoint_expr_type_checking.swift
@@ -7,13 +7,14 @@
 //===----------------------------------------------------------------------===//
 
 @differentiable(reverse, adjoint: dSquare(_:primal:seed:))
-func square<T : FloatingPoint>(_ x: T) -> T {
-  return x * x
-}
+func square<T : FloatingPoint>(_ x: T) -> T { return x * x }
 // expected-note @+1 {{in call to function 'dSquare(_:primal:seed:)'}}
 private func dSquare<T : FloatingPoint>(_ x: T, primal: T, seed: T) -> T {
   return 2 * x
 }
+// Overload `square` with non-differentiable cases.
+func square(_ x: Float) -> Float { return x * x }
+func square(_ x: Double) -> Double { return x * x }
 
 let _: (Float, Float, Float) -> Float = #adjoint(square)
 func testTopLevel() -> Float {
@@ -226,7 +227,7 @@ let _ = #adjoint(square) // expected-error {{generic parameter 'T' could not be 
 let _ = dSquare // expected-error {{generic parameter 'T' could not be inferred}}
 
 // Note: I think the case below is theoretically resolvable by the type checker.
-// The failing behavior is consistent for both #adjoint and direct function
+// The failing behavior is consistent for both #adjoint and direct adjoint
 // reference, so things are good.
 
 // expected-error @+2 {{cannot convert value of type '(Vector<_>, Vector<_>, Vector<_>, Vector<_>) -> (Vector<_>, Vector<_>)' to specified type '(Vector<Float>, Vector<Float>, Vector<Float>, Vector<Float>) -> (Vector<Float>, Vector<Float>)'}}

--- a/test/AutoDiff/adjoint_expr_type_checking.swift
+++ b/test/AutoDiff/adjoint_expr_type_checking.swift
@@ -49,13 +49,16 @@ struct A {
         return (seed, seed)
       }
 
-      @differentiable(reverse, adjoint: dSubtract(a:b:primal:seed:))
-      func subtract(a: C, b: C) -> C {
+      @differentiable(
+        reverse, withRespectTo: (self, .0),
+        adjoint: dSubtract(a:primal:seed:)
+      )
+      func subtract(a: C) -> C {
         return a
       }
 
       private func dSubtract(
-        a: C, b: C, primal: C, seed: C
+        a: C, primal: C, seed: C
       ) -> (C, C) {
         return (seed, seed)
       }

--- a/test/AutoDiff/gradient_expr_parse.swift
+++ b/test/AutoDiff/gradient_expr_parse.swift
@@ -13,4 +13,4 @@
 #valueAndGradient(of: foo, withRespectTo: .0, .1) // okay
 
 #adjoint(foo(_:_:)) // okay
-#adjoint() // expected-error {{expected a function to be differentiated}}
+#adjoint() // expected-error {{expected function name within '#adjoint` expression}}

--- a/test/TensorFlow/adjoint_expr_type_checking.swift
+++ b/test/TensorFlow/adjoint_expr_type_checking.swift
@@ -35,6 +35,7 @@ func testLabels<T : BinaryFloatingPoint>(_ t: Tensor<T>) {
   // If the #adjoint expression is applied directly, argument labels are
   // necessary.
   // This matches the behavior for normal function application.
+  _ = #adjoint(matmul)(t, t, originalValue: t, seed: t)
   _ = #adjoint(Tensor.+)(t, t, originalValue: t, seed: t)
   _ = #adjoint(Tensor.batchNormalized)(t)(
     alongAxis: 0, offset: 0, scale: 0, epsilon: 0, originalValue: t, seed: t
@@ -42,6 +43,9 @@ func testLabels<T : BinaryFloatingPoint>(_ t: Tensor<T>) {
 
   // If the #adjoint expression is unapplied and bound to a variable, argument
   // labels are not necessary.
+  let dMatmul: (Tensor<T>, Tensor<T>, Tensor<T>, Tensor<T>) -> (Tensor<T>, Tensor<T>)
+    = #adjoint(matmul)
+  _ = dMatmul(t, t, t, t)
   let dAdd = #adjoint(Tensor<T>.+)
   _ = dAdd(t, t, t, t)
   let dBatchNorm = #adjoint(Tensor<T>.batchNormalized)

--- a/test/TensorFlow/adjoint_expr_type_checking.swift
+++ b/test/TensorFlow/adjoint_expr_type_checking.swift
@@ -1,0 +1,49 @@
+// RUN: %target-swift-frontend -typecheck -verify %s
+
+import TensorFlow
+
+// Test overloading top-level `sin` function.
+func sin(_ x: Float) -> Float { return x }
+
+func testSpecialized(_ t: Tensor<Float>) {
+  _ = #adjoint(relu)(t, originalValue: t, seed: t)
+  _ = #adjoint(sin)(t, originalValue: t, seed: t)
+
+  _ = #adjoint(Tensor<Float>.+)
+  let _: (Tensor<Float>, Tensor<Float>, Tensor<Float>, Tensor<Float>) -> (Tensor<Float>, Tensor<Float>)
+    = #adjoint(Tensor.+)
+
+  _ = #adjoint(Tensor<Float>.convolved2D)
+  let _: (Tensor<Float>) -> (Tensor<Float>, (Int32, Int32, Int32, Int32), Padding, Tensor<Float>, Tensor<Float>) -> (Tensor<Float>, Tensor<Float>)
+    = #adjoint(Tensor.convolved2D)
+}
+
+func testGeneric<T : BinaryFloatingPoint>( _ t: Tensor<T>) {
+  let _ = #adjoint(relu)(t, originalValue: t, seed: t)
+  let _ = #adjoint(sin)(t, originalValue: t, seed: t)
+
+  _ = #adjoint(Tensor<T>.+)
+  let _: (Tensor<T>, Tensor<T>, Tensor<T>, Tensor<T>) -> (Tensor<T>, Tensor<T>)
+    = #adjoint(Tensor.+)
+
+  _ = #adjoint(Tensor<T>.convolved2D)
+  let _: (Tensor<T>) -> (Tensor<T>, (Int32, Int32, Int32, Int32), Padding, Tensor<T>, Tensor<T>) -> (Tensor<T>, Tensor<T>)
+    = #adjoint(Tensor.convolved2D)
+}
+
+func testLabels<T : BinaryFloatingPoint>(_ t: Tensor<T>) {
+  // If the #adjoint expression is applied directly, argument labels are
+  // necessary.
+  // This matches the behavior for normal function application.
+  _ = #adjoint(Tensor.+)(t, t, originalValue: t, seed: t)
+  _ = #adjoint(Tensor.batchNormalized)(t)(
+    alongAxis: 0, offset: 0, scale: 0, epsilon: 0, originalValue: t, seed: t
+  )
+
+  // If the #adjoint expression is unapplied and bound to a variable, argument
+  // labels are not necessary.
+  let dAdd = #adjoint(Tensor<T>.+)
+  _ = dAdd(t, t, t, t)
+  let dBatchNorm = #adjoint(Tensor<T>.batchNormalized)
+  _ = dBatchNorm(t)(0, 0, 0, 0, t, t)
+}


### PR DESCRIPTION
The purpose of `#adjoint` is to lookup and return the adjoint function
corresponding to a `@differentiable` function.

- Change AdjointExpr to represent original function as a DeclName (and optional
  base type) rather than an expression.
  - The argument of `#adjoint(...)` is a function identifier: this is better
    modeled as a DeclName (and optional base type) rather than an expression,
    which is overly general.
  - Representing the original function as an expression also makes
    type-checking difficult. The relationship between the types of the original
    and adjoint cannot be easily modeled using the constraint system.
- SILGen AdjointExpr.
  - Rather than rewriting AdjointExpr to a different Expr in CSApply (e.g.
    a DeclRefExpr referencing the adjoint function), custom SILGen is used
    because AdjointExpr can represent functions that are normally inaccessible.
    Such DeclRefExprs would be invalid in the AST.