### PR TITLE
[4.2] [Serialization] Handle llvm::Error in member deserialization recovery

### DIFF
--- a/lib/Serialization/ModuleFile.cpp
+++ b/lib/Serialization/ModuleFile.cpp
@@ -1855,6 +1855,8 @@ ModuleFile::loadNamedMembers(const IterableDeclContext *IDC, DeclBaseName N,
       } else {
         if (!getContext().LangOpts.EnableDeserializationRecovery)
           fatal(mem.takeError());
+        llvm::consumeError(mem.takeError());
+
         // Treat this as a cache-miss to the caller and let them attempt
         // to refill through the normal loadAllMembers() path.
         return None;

--- a/test/Serialization/Recovery/Inputs/typedefs-helper.swift
+++ b/test/Serialization/Recovery/Inputs/typedefs-helper.swift
@@ -1,0 +1,11 @@
+// Tiny test that only accesses specific members of the 'User' class, never
+// forcing /all/ members to be loaded, in order to test recovery for lazy member
+// loading.
+
+import Typedefs
+import Lib
+
+func test(user: User) {
+  _ = user.returnsWrappedMethod() // expected-error {{value of type 'User' has no member 'returnsWrappedMethod'; did you mean 'returnsUnwrappedMethod'?}}
+  _ = user.returnsUnwrappedMethod() // okay
+}

--- a/test/Serialization/Recovery/typedefs.swift
+++ b/test/Serialization/Recovery/typedefs.swift
@@ -13,6 +13,8 @@
 // RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/custom-modules -DTEST %s | %FileCheck -check-prefix CHECK-IR %s
 // RUN: %target-swift-frontend -emit-ir -I %t -I %S/Inputs/custom-modules -Xcc -DBAD -DTEST %s | %FileCheck -check-prefix CHECK-IR %s
 
+// RUN: %target-swift-frontend -typecheck -I %t -I %S/Inputs/custom-modules -Xcc -DBAD %S/Inputs/typedefs-helper.swift -verify
+
 #if TEST
 
 import Typedefs


### PR DESCRIPTION
Cherry-pick of #16957 to the 4.2 branch to fix an asserts-only issue. Reviewed by @graydon.

rdar://problem/40738521