### PR TITLE
Devirtualizer: disable the “effectively final” optimization if the caller is serialized

### DIFF
--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -516,7 +516,9 @@ bool swift::canDevirtualizeClassMethod(FullApplySite AI,
 
   // We need to disable the  “effectively final” opt if a function is inlinable
   if (isEffectivelyFinalMethod &&
-      F->getResilienceExpansion() == ResilienceExpansion::Minimal) {
+      ((F->getResilienceExpansion() == ResilienceExpansion::Minimal) ||
+       AI.getFunction()->getResilienceExpansion() ==
+           ResilienceExpansion::Minimal)) {
     DEBUG(llvm::dbgs() << "        FAIL: Could not optimize function because "
                           "it is an effectively-final inlinable: "
                        << F->getName() << "\n");

--- a/test/SILOptimizer/devirtualize_inlinable_mandatory.swift
+++ b/test/SILOptimizer/devirtualize_inlinable_mandatory.swift
@@ -1,0 +1,13 @@
+// RUN: %target-swift-frontend %s -whole-module-optimization -emit-sil | %FileCheck %s
+
+public class C {
+  public func f() {}
+}
+
+//CHECK-LABEL: sil [serialized] @$S32devirtualize_inlinable_mandatory1gyyAA1CCF : $@convention(thin) (@guaranteed C) -> () {
+//CHECK: class_method %0 : $C, #C.f!1 : (C) -> () -> (), $@convention(method) (@guaranteed C) -> ()
+//CHECK-NOT: function_ref
+//CHECK: return 
+@inlinable public func g(_ x: C) {
+  x.f()
+}


### PR DESCRIPTION
rdar://problem/41106812

Improve the check done in https://github.com/apple/swift/pull/14740

The class_method being devirtualized might be OK for most call sites, i.e. we are allowed to devirtualize it, however, the caller itself might have been marked with inlinable