### PR TITLE
[TypeReconstruction] Don't choke on slightly invalid mangled names.

### DIFF
--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -2269,7 +2269,9 @@ static void VisitNodeGlobal(ASTContext *ast, Demangle::NodePointer cur_node,
 static void VisitNode(
     ASTContext *ast,
     Demangle::NodePointer node, VisitNodeResult &result) {
-  assert(result._error.empty());
+  // If we have an error, no point in going forward.
+  if (!result._error.empty())
+    return;
 
   const Demangle::Node::Kind nodeKind = node->getKind();
 

--- a/test/DebugInfo/Inputs/type-reconstr-names.txt
+++ b/test/DebugInfo/Inputs/type-reconstr-names.txt
@@ -8,3 +8,4 @@ $S12TypeReconstr8PatatinoaySiGD ---> Patatino<Int>
 $S7ElementQzD ---> τ_0_0.Element
 $S13EyeCandySwift21_previousUniqueNumber33_ADC08935D64EA4F796440E7335798735LLs6UInt64Vvp ---> UInt64
 $SSayypXpG ---> Array<Any.Type>
+$S12EyeCandyCore11XPCListenerC14messageHandleryyAA13XPCConnectionV_AA10XPCMessageVxtcvpfiyAF_AHxtcfU_TA.4 ---> Can't resolve type of $S12EyeCandyCore11XPCListenerC14messageHandleryyAA13XPCConnectionV_AA10XPCMessageVxtcvpfiyAF_AHxtcfU_TA.4


### PR DESCRIPTION
This was taken from a real project, but I don't have it anymore
and I can't reproduce it on newer versions of swift (probably
something changed in the DWARF type mangling). In any case, as
this can be triggered by user input, we shouldn't assert, and
error out instead.

<rdar://problem/39283717>