### PR TITLE
[4.2] Re-apply "[migrator] migrator: avoid inserting base name while renaming if users' member access doesn't specify the base name. rdar://40373279"

### DIFF
--- a/test/Migrator/Inputs/qualified.json
+++ b/test/Migrator/Inputs/qualified.json
@@ -38,5 +38,13 @@
     "OldTypeName": "",
     "NewPrintedName": "internalType",
     "NewTypeName": "ToplevelWrapper"
-  }
+  },
+  {
+    "DiffItemKind": "TypeMemberDiffItem",
+    "Usr": "c:@E@FooComparisonResult@FooOrderedMemberSame",
+    "OldPrintedName": "orderedMemberSame",
+    "OldTypeName": "FooComparisonResult",
+    "NewPrintedName": "orderedMemberSame",
+    "NewTypeName": "NewFooComparisonResult.Nested"
+  },
 ]

--- a/test/Migrator/mock-sdk/Bar.framework/Headers/Bar.h
+++ b/test/Migrator/mock-sdk/Bar.framework/Headers/Bar.h
@@ -53,7 +53,8 @@ typedef SomeItemSet SomeEnvironment;
 typedef NS_ENUM(long, FooComparisonResult) {
   FooOrderedAscending = -1L,
   FooOrderedSame,
-  FooOrderedDescending
+  FooOrderedDescending,
+  FooOrderedMemberSame,
 };
 
 @interface BarBase

--- a/test/Migrator/qualified-replacement.swift
+++ b/test/Migrator/qualified-replacement.swift
@@ -14,6 +14,11 @@ func foo() {
   _ = Cities.CityKind.Town
   _ = ToplevelType()
   _ = ToplevelType(recordName: "")
+  bar(.orderedSame)
+  bar(.orderedMemberSame)
+  bar(FooComparisonResult.orderedSame)
+  bar(FooComparisonResult.orderedMemberSame)
 }
 
 func foo(_: ToplevelType) {}
+func bar(_ : FooComparisonResult) {}

--- a/test/Migrator/qualified-replacement.swift.expected
+++ b/test/Migrator/qualified-replacement.swift.expected
@@ -14,6 +14,11 @@ func foo() {
   _ = NewCityKind.NewTown
   _ = ToplevelWrapper.internalType()
   _ = ToplevelWrapper.internalType(recordName: "")
+  bar(NewFooComparisonResult.NewFooOrderedSame)
+  bar(.orderedMemberSame)
+  bar(NewFooComparisonResult.NewFooOrderedSame)
+  bar(NewFooComparisonResult.Nested.orderedMemberSame)
 }
 
 func foo(_: ToplevelWrapper.internalType) {}
+func bar(_ : FooComparisonResult) {}


### PR DESCRIPTION
Previously, we saw that unconditionally omitting type names can lead to
build errors (rdar://40458118). This revised fix omits type names only when
the new member name is identical to the old one.