### PR TITLE
Devirtualizer: enable inline an inlinable function into a non-inlinable function

### DIFF
--- a/lib/SILOptimizer/Utils/Devirtualize.cpp
+++ b/lib/SILOptimizer/Utils/Devirtualize.cpp
@@ -515,13 +515,11 @@ bool swift::canDevirtualizeClassMethod(FullApplySite AI,
   }
 
   // We need to disable the  “effectively final” opt if a function is inlinable
-  if (isEffectivelyFinalMethod &&
-      ((F->getResilienceExpansion() == ResilienceExpansion::Minimal) ||
-       AI.getFunction()->getResilienceExpansion() ==
-           ResilienceExpansion::Minimal)) {
+  if (isEffectivelyFinalMethod && AI.getFunction()->getResilienceExpansion() ==
+                                      ResilienceExpansion::Minimal) {
     DEBUG(llvm::dbgs() << "        FAIL: Could not optimize function because "
                           "it is an effectively-final inlinable: "
-                       << F->getName() << "\n");
+                       << AI.getFunction()->getName() << "\n");
     return false;
   }
 

--- a/test/SILOptimizer/devirt_access_serialized.sil
+++ b/test/SILOptimizer/devirt_access_serialized.sil
@@ -31,8 +31,8 @@ sil @_TFC14devirt_access21YcfMS0_FT_S0_ : $@convention(method) (@owned Y) -> @ow
 sil @_TFC14devirt_access21YCfMS0_FT_S0_ : $@convention(thin) (@thick Y.Type) -> @owned Y
 
 //CHECK-LABEL: sil @Case
-//CHECK-NOT: function_ref @_TFC14devirt_access21X4pingfS0_FT_Si
-//CHECK: class_method
+//CHECK: function_ref @_TFC14devirt_access21X4pingfS0_FT_Si : $@convention(method) (@guaranteed X)
+//CHECK-NOT: class_method
 //CHECK: apply
 //CHECK: return
 sil @Case : $@convention(thin) (@owned Y) -> Int {


### PR DESCRIPTION
Follow-up to https://github.com/apple/swift/pull/17327