### PR TITLE
Add swift-stdlib-build-type=Release to the

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1129,6 +1129,7 @@ tvos
 watchos
 build-swift-static-stdlib
 build-swift-static-sdk-overlay
+swift-stdlib-build-type=Release
 
 [preset: LLDB_Swift_ReleaseAssert]
 mixin-preset=
@@ -1152,6 +1153,7 @@ tvos
 watchos
 build-swift-static-stdlib
 build-swift-static-sdk-overlay
+swift-stdlib-build-type=Release
 
 #===------------------------------------------------------------------------===#
 # Test all platforms on OS X builder


### PR DESCRIPTION
LLDB_Swift_DebugAssert_with_devices and
LLDB_Swift_ReleaseAssert_with_devices presets -
we don't need debug information in the stdlib
that we use when testing on-device.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
