### PR TITLE
Perform function conversions when converting between autoclosures

### DIFF
--- a/test/attr/attr_autoclosure.swift
+++ b/test/attr/attr_autoclosure.swift
@@ -146,6 +146,7 @@ func migrateAC(@autoclosure _: () -> ()) { }
 func migrateACE(@autoclosure(escaping) _: () -> ()) { }
 
 func takesAutoclosure(_ fn: @autoclosure () -> Int) {}
+func takesThrowingAutoclosure(_: @autoclosure () throws -> Int) {}
 
 func callAutoclosureWithNoEscape(_ fn: () -> Int) {
   takesAutoclosure(1+1) // ok
@@ -160,4 +161,17 @@ func callAutoclosureWithNoEscape_3(_ fn: @autoclosure () -> Int) {
 // expected-error @+1 {{'@autoclosure' must not be used on variadic parameters}}
 func variadicAutoclosure(_ fn: @autoclosure () -> ()...) {
   for _ in fn {}
+}
+
+// rdar://41219750
+// These are all arguably invalid; the autoclosure should have to be called.
+// But as long as we allow them, we shouldn't crash.
+func passNonThrowingToNonThrowingAC(_ fn: @autoclosure () -> Int) {
+  takesAutoclosure(fn)
+}
+func passNonThrowingToThrowingAC(_ fn: @autoclosure () -> Int) {
+  takesThrowingAutoclosure(fn)
+}
+func passThrowingToThrowingAC(_ fn: @autoclosure () throws -> Int) {
+  takesThrowingAutoclosure(fn)
 }


### PR DESCRIPTION
This is correct because it's the apparent rule used by CSSimplify: value-to-autoclosure conversion is considered if and only if the input type is not an autoclosure function type.

The real solution to this problem is that `@autoclosure` should be tracked as a bit on the parameter type instead of as a bit on function types. Slava has a PR leading towards that (https://github.com/apple/swift/pull/10094), but it causes a source-compatibility problem when forwarding autoclosures.  You really shouldn't be able to forward autoclosures, but that's an issue for the core team to resolve, and in the meantime there's this bug.

Fixes rdar://41219750.