### PR TITLE
[test] Fix load-invalid-arch.swift to use the "major" architecture

### DIFF
--- a/test/Serialization/load-invalid-arch.swift
+++ b/test/Serialization/load-invalid-arch.swift
@@ -5,13 +5,13 @@
 // RUN: touch %t/new_module.swiftmodule/ppc65.swiftmodule
 // RUN: touch %t/new_module.swiftmodule/i387.swiftdoc
 // RUN: touch %t/new_module.swiftmodule/ppc65.swiftdoc
-// RUN: not %target-swift-frontend %s -typecheck -I %t -show-diagnostics-after-fatal 2>&1 | %FileCheck %s -DTARGET_ARCHITECTURE=%target-cpu
+// RUN: not %target-swift-frontend %s -typecheck -I %t -show-diagnostics-after-fatal 2>&1 | %FileCheck %s -DTARGET_ARCHITECTURE=$(echo %target-swiftmodule-name | cut -d. -f1)
 
 // RUN: %empty-directory(%t)
 // RUN: mkdir -p %t/new_module.framework/Modules/new_module.swiftmodule/
 // RUN: touch %t/new_module.framework/Modules/new_module.swiftmodule/i387.swiftmodule
 // RUN: touch %t/new_module.framework/Modules/new_module.swiftmodule/ppc65.swiftmodule
-// RUN: not %target-swift-frontend %s -F %t -typecheck -show-diagnostics-after-fatal 2>&1 | %FileCheck %s -DTARGET_ARCHITECTURE=%target-cpu
+// RUN: not %target-swift-frontend %s -F %t -typecheck -show-diagnostics-after-fatal 2>&1 | %FileCheck %s -DTARGET_ARCHITECTURE=$(echo %target-swiftmodule-name | cut -d. -f1)
 
 //CHECK: {{.*}} error: could not find module 'new_module' for architecture '[[TARGET_ARCHITECTURE]]'; found: {{ppc65, i387|i387, ppc65}}
 //CHECK-NEXT: import new_module


### PR DESCRIPTION
armv7, armv7s, and armv7k all get encoded as "arm" in today's scheme for swiftmodules, so we can't just use the CPU part of the triple as the expected swiftmodule architecture in the diagnostic.

rdar://problem/41262878