### PR TITLE
[viewcfg] Explicitly tell open to use Graphviz instead of relying on …

### DIFF
--- a/utils/viewcfg
+++ b/utils/viewcfg
@@ -171,9 +171,8 @@ def main():
 
         out_file.write("}\n")
 
-    # Open the dot file (should be done with Graphviz).
-
-    subprocess.call(["open", file_name])
+    # Open the dot file.
+    subprocess.call(["open", "-a", "Graphviz", file_name])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
…system defaults.

Just eliminates a source of unnecessary error. We only support graphviz so
nothing is lost here.
