### PR TITLE
[NOMERGE] [stdlib] Test different array growth strategy

### DIFF
--- a/stdlib/public/core/ArrayShared.swift
+++ b/stdlib/public/core/ArrayShared.swift
@@ -143,7 +143,7 @@ internal func _expectEnd<C: Collection>(of s: C, is i: C.Index) {
 
 @inlinable
 internal func _growArrayCapacity(_ capacity: Int) -> Int {
-  return capacity * 2
+  return capacity + capacity / 2
 }
 
 //===--- generic helpers --------------------------------------------------===//


### PR DESCRIPTION
There's some theoretical basis for a growth factor of 2 being problematic, due to the size of each new block being larger than all the ones before it combined. This means that new allocations always have to proceed forward in memory instead of reusing freed space, which may hurt locality. See https://github.com/facebook/folly/blob/master/folly/docs/FBVector.md#memory-handling
