### PR TITLE
Add swift-stdlib-build-type=Release to the

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1129,6 +1129,7 @@ tvos
 watchos
 build-swift-static-stdlib
 build-swift-static-sdk-overlay
+swift-stdlib-build-type=Release
 
 [preset: LLDB_Swift_ReleaseAssert]
 mixin-preset=
@@ -1152,6 +1153,7 @@ tvos
 watchos
 build-swift-static-stdlib
 build-swift-static-sdk-overlay
+swift-stdlib-build-type=Release
 
 #===------------------------------------------------------------------------===#
 # Test all platforms on OS X builder


### PR DESCRIPTION
Add swift-stdlib-build-type=Release to the
LLDB_Swift_DebugAssert_with_devices and
LLDB_Swift_ReleaseAssert_with_devices presets -
we don't need debug information in the stdlib
that we use when testing on-device.

(cherry picked from commit c7ce1148a3d735282e072115b3eebc9309d710b3)
