### PR TITLE
[MiscDiagnostics] Emit a deprecation warning for some writes through …

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -495,6 +495,9 @@ ERROR(expr_keypath_subscript_index_not_hashable, none,
 ERROR(expr_smart_keypath_application_type_mismatch,none,
       "key path of type %0 cannot be applied to a base of type %1",
       (Type, Type))
+WARNING(expr_deprecated_writable_keypath,none,
+        "forming a writable keypath to property %0 that is read-only in this context "
+        "is deprecated and will be removed in a future release",(DeclName))
 
 // Selector expressions.
 ERROR(expr_selector_no_objc_runtime,none,

--- a/test/Constraints/keypath.swift
+++ b/test/Constraints/keypath.swift
@@ -5,9 +5,17 @@ struct S {
 
   init() {
     let _: WritableKeyPath<S, Int> = \.i // no error for Swift 3/4
+
+    S()[keyPath: \.i] = 1
+    // expected-error@-1 {{cannot assign to immutable expression}}
   }
 }
 
 func test() {
   let _: WritableKeyPath<C, Int> = \.i // no error for Swift 3/4
+
+  C()[keyPath: \.i] = 1   // warning on write with literal keypath
+  // expected-warning@-1 {{forming a writable keypath to property}}
+
+  let _ = C()[keyPath: \.i] // no warning for a read
 }

--- a/test/Constraints/keypath_swift_5.swift
+++ b/test/Constraints/keypath_swift_5.swift
@@ -5,9 +5,17 @@ struct S {
 
   init() {
     let _: WritableKeyPath<S, Int> = \.i // expected-error {{type of expression is ambiguous without more context}}
+
+    S()[keyPath: \.i] = 1
+    // expected-error@-1 {{cannot assign to immutable expression}}
   }
 }
 
 func test() {
   let _: WritableKeyPath<C, Int> = \.i // expected-error {{type of expression is ambiguous without more context}}
+
+  C()[keyPath: \.i] = 1
+  // expected-error@-1 {{cannot assign to immutable expression}}
+
+  let _ = C()[keyPath: \.i] // no warning for a read
 }


### PR DESCRIPTION
…literal keypaths.

We incorrectly allowed some keypaths to be inferred as writable
keypaths in Swift 3/4 modes. This no longer happens when
-swift-version 5 is specified.

This warning is a limited attempt at providing some advanced notice of
code that will break, only in the cases where the keypath is a direct
argument to a keypath subscript write.

Fixes: rdar://problem/40068274