### PR TITLE
[SourceKit] Return error when key.name is empty for editor.open request

### DIFF
--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -1362,7 +1362,8 @@ std::vector<Token> &SourceFile::getTokenVector() {
 }
 
 ArrayRef<Token> SourceFile::getAllTokens() const {
-  assert(shouldCollectToken() && "Disabled");
+  if (!shouldCollectToken())
+    return {};
   return *AllCorrectedTokens;
 }
 

--- a/test/SourceKit/Misc/empty_open.swift
+++ b/test/SourceKit/Misc/empty_open.swift
@@ -1,0 +1,8 @@
+let a = 12
+
+// RUN: not %sourcekitd-test \
+// RUN:   -req=open %s -- %s == \
+// RUN:   -req=open '' \
+// RUN:   2>&1 | %FileCheck %s
+
+// CHECK: empty 'key.name'

--- a/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
+++ b/tools/SourceKit/tools/sourcekitd/lib/API/Requests.cpp
@@ -415,6 +415,8 @@ void handleRequestImpl(sourcekitd_object_t ReqObj, ResponseReceiver Rec) {
     Optional<StringRef> Name = Req.getString(KeyName);
     if (!Name.hasValue())
       return Rec(createErrorRequestInvalid("missing 'key.name'"));
+    if (Name->empty())
+      return Rec(createErrorRequestInvalid("empty 'key.name'"));
     std::unique_ptr<llvm::MemoryBuffer>
     InputBuf = getInputBufForRequest(SourceFile, SourceText, ErrBuf);
     if (!InputBuf)


### PR DESCRIPTION
Previously, the behavior was undefined.

The actual behavior was [assertion hit in `SourceFile::getAllTokens()`](https://github.com/apple/swift/blob/c0836b9cf816c73be28b9cbf89feb1f018075167/lib/AST/Module.cpp#L1365). `Invocation.getLangOptions().CollectParsedToken` is false because of [failure in `resolveSymbolicLinksInInputs()`](https://github.com/apple/swift/blob/c0836b9cf816c73be28b9cbf89feb1f018075167/tools/SourceKit/lib/SwiftLang/SwiftASTManager.cpp#L445-L458).

rdar://problem/40646921