### PR TITLE
More errors instead of crashes for conditional conformances that are invalid or involve hard-to-resolve recursion

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1806,6 +1806,9 @@ NOTE(redundant_conformance_here,none,
      "inferred from type here}0",
      (unsigned, Type, ProtocolDecl *))
 
+ERROR(unsupported_recursive_requirements, none,
+      "requirement involves recursion that is not currently supported", ())
+
 ERROR(same_type_conflict,none,
       "%select{generic parameter |protocol |}0%1 cannot be equal to both "
       "%2 and %3", (unsigned, Type, Type, Type))

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -660,6 +660,9 @@ ERROR(ambiguous_module_type,none,
 ERROR(use_nonmatching_operator,none,
       "%0 is not a %select{binary|prefix unary|postfix unary}1 operator",
       (DeclName, unsigned))
+ERROR(unsupported_recursion_in_associated_type_reference,none,
+      "unsupported recursion for reference to associated type %0 of type %1",
+      (DeclName, Type))
 ERROR(broken_associated_type_witness,none,
       "reference to invalid associated type %0 of type %1", (DeclName, Type))
 

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -337,6 +337,10 @@ private:
                                    EquivalenceClass *unresolvedEquivClass,
                                    UnresolvedHandlingKind unresolvedHandling);
 
+  /// Add any conditional requirements from the given conformance.
+  void addConditionalRequirements(ProtocolConformanceRef conformance,
+                                  ModuleDecl *inferForModule);
+
   /// Resolve the conformance of the given type to the given protocol when the
   /// potential archetype is known to be equivalent to a concrete type.
   ///

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -338,8 +338,10 @@ private:
                                    UnresolvedHandlingKind unresolvedHandling);
 
   /// Add any conditional requirements from the given conformance.
-  void addConditionalRequirements(ProtocolConformanceRef conformance,
-                                  ModuleDecl *inferForModule);
+  ///
+  /// \returns \c true if an error occurred, \c false if not.
+  bool addConditionalRequirements(ProtocolConformanceRef conformance,
+                                  ModuleDecl *inferForModule, SourceLoc loc);
 
   /// Resolve the conformance of the given type to the given protocol when the
   /// potential archetype is known to be equivalent to a concrete type.

--- a/include/swift/AST/ProtocolConformanceRef.h
+++ b/include/swift/AST/ProtocolConformanceRef.h
@@ -131,6 +131,10 @@ public:
   ProtocolConformanceRef getCanonicalConformanceRef() const;
 
   /// Get any additional requirements that are required for this conformance to
+  /// be satisfied, if they're possible to compute.
+  Optional<ArrayRef<Requirement>> getConditionalRequirementsIfAvailable() const;
+
+  /// Get any additional requirements that are required for this conformance to
   /// be satisfied.
   ArrayRef<Requirement> getConditionalRequirements() const;
   

--- a/lib/AST/ASTDumper.cpp
+++ b/lib/AST/ASTDumper.cpp
@@ -2926,10 +2926,17 @@ static void dumpProtocolConformanceRec(
       }
     }
 
-    for (auto requirement : normal->getConditionalRequirements()) {
+    if (auto condReqs = normal->getConditionalRequirementsIfAvailableOrCached(
+            /*computeIfPossible=*/false)) {
+      for (auto requirement : *condReqs) {
+        out << '\n';
+        out.indent(indent + 2);
+        requirement.dump(out);
+      }
+    } else {
       out << '\n';
       out.indent(indent + 2);
-      requirement.dump(out);
+      out << "(conditional requirements unable to be computed)";
     }
     break;
   }
@@ -2957,10 +2964,16 @@ static void dumpProtocolConformanceRec(
                            SubstitutionMap::DumpStyle::Full, indent + 2,
                            visited);
     out << '\n';
-    for (auto subReq : conf->getConditionalRequirements()) {
+    if (auto condReqs = conf->getConditionalRequirementsIfAvailableOrCached(
+            /*computeIfPossible=*/false)) {
+      for (auto subReq : *condReqs) {
+        out.indent(indent + 2);
+        subReq.dump(out);
+        out << '\n';
+      }
+    } else {
       out.indent(indent + 2);
-      subReq.dump(out);
-      out << '\n';
+      out << "(conditional requirements unable to be computed)\n";
     }
     dumpProtocolConformanceRec(conf->getGenericConformance(), out, indent + 2,
                                visited);

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2604,17 +2604,28 @@ ConstraintResult GenericSignatureBuilder::handleUnresolvedRequirement(
   }
 }
 
-void GenericSignatureBuilder::addConditionalRequirements(
-    ProtocolConformanceRef conformance, ModuleDecl *inferForModule) {
+bool GenericSignatureBuilder::addConditionalRequirements(
+    ProtocolConformanceRef conformance, ModuleDecl *inferForModule,
+    SourceLoc loc) {
   // Abstract conformances don't have associated decl-contexts/modules, but also
   // don't have conditional requirements.
   if (conformance.isConcrete()) {
-    auto source = FloatingRequirementSource::forInferred(nullptr);
-    for (auto requirement : conformance.getConditionalRequirements()) {
-      addRequirement(requirement, source, inferForModule);
-      ++NumConditionalRequirementsAdded;
+    if (auto condReqs = conformance.getConditionalRequirementsIfAvailable()) {
+      auto source = FloatingRequirementSource::forInferred(nullptr);
+      for (auto requirement : *condReqs) {
+        addRequirement(requirement, source, inferForModule);
+        ++NumConditionalRequirementsAdded;
+      }
+    } else {
+      if (loc.isValid())
+        Diags.diagnose(loc, diag::unsupported_recursive_requirements);
+
+      Impl->HadAnyError = true;
+      return true;
     }
   }
+
+  return false;
 }
 
 const RequirementSource *
@@ -2653,7 +2664,10 @@ GenericSignatureBuilder::resolveConcreteConformance(ResolvedType type,
 
   concreteSource = concreteSource->viaConcrete(*this, *conformance);
   equivClass->recordConformanceConstraint(*this, type, proto, concreteSource);
-  addConditionalRequirements(*conformance, /*inferForModule=*/nullptr);
+  if (addConditionalRequirements(*conformance, /*inferForModule=*/nullptr,
+                                 concreteSource->getLoc()))
+    return nullptr;
+
   return concreteSource;
 }
 const RequirementSource *GenericSignatureBuilder::resolveSuperConformance(
@@ -2682,7 +2696,10 @@ const RequirementSource *GenericSignatureBuilder::resolveSuperConformance(
   superclassSource =
     superclassSource->viaSuperclass(*this, *conformance);
   equivClass->recordConformanceConstraint(*this, type, proto, superclassSource);
-  addConditionalRequirements(*conformance, /*inferForModule=*/nullptr);
+  if (addConditionalRequirements(*conformance, /*inferForModule=*/nullptr,
+                                 superclassSource->getLoc()))
+    return nullptr;
+
   return superclassSource;
 }
 
@@ -4738,7 +4755,9 @@ ConstraintResult GenericSignatureBuilder::addTypeRequirement(
 
         // FIXME: diagnose if there's no conformance.
         if (conformance) {
-          addConditionalRequirements(*conformance, inferForModule);
+          if (addConditionalRequirements(*conformance, inferForModule,
+                                         source.getLoc()))
+            return ConstraintResult::Conflicting;
         }
       }
     }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -2604,17 +2604,14 @@ ConstraintResult GenericSignatureBuilder::handleUnresolvedRequirement(
   }
 }
 
-// Function for feeding through any other requirements that the conformance
-// requires to be satisfied. These are things we're inferring.
-static void addConditionalRequirements(GenericSignatureBuilder &builder,
-                                       ProtocolConformanceRef conformance,
-                                       ModuleDecl *inferForModule) {
+void GenericSignatureBuilder::addConditionalRequirements(
+    ProtocolConformanceRef conformance, ModuleDecl *inferForModule) {
   // Abstract conformances don't have associated decl-contexts/modules, but also
   // don't have conditional requirements.
   if (conformance.isConcrete()) {
     auto source = FloatingRequirementSource::forInferred(nullptr);
     for (auto requirement : conformance.getConditionalRequirements()) {
-      builder.addRequirement(requirement, source, inferForModule);
+      addRequirement(requirement, source, inferForModule);
       ++NumConditionalRequirementsAdded;
     }
   }
@@ -2656,7 +2653,7 @@ GenericSignatureBuilder::resolveConcreteConformance(ResolvedType type,
 
   concreteSource = concreteSource->viaConcrete(*this, *conformance);
   equivClass->recordConformanceConstraint(*this, type, proto, concreteSource);
-  addConditionalRequirements(*this, *conformance, /*inferForModule=*/nullptr);
+  addConditionalRequirements(*conformance, /*inferForModule=*/nullptr);
   return concreteSource;
 }
 const RequirementSource *GenericSignatureBuilder::resolveSuperConformance(
@@ -2685,7 +2682,7 @@ const RequirementSource *GenericSignatureBuilder::resolveSuperConformance(
   superclassSource =
     superclassSource->viaSuperclass(*this, *conformance);
   equivClass->recordConformanceConstraint(*this, type, proto, superclassSource);
-  addConditionalRequirements(*this, *conformance, /*inferForModule=*/nullptr);
+  addConditionalRequirements(*conformance, /*inferForModule=*/nullptr);
   return superclassSource;
 }
 
@@ -4741,7 +4738,7 @@ ConstraintResult GenericSignatureBuilder::addTypeRequirement(
 
         // FIXME: diagnose if there's no conformance.
         if (conformance) {
-          addConditionalRequirements(*this, *conformance, inferForModule);
+          addConditionalRequirements(*conformance, inferForModule);
         }
       }
     }

--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -367,8 +367,24 @@ bool NormalProtocolConformance::isSynthesizedNonUnique() const {
   return isa<ClangModuleUnit>(getDeclContext()->getModuleScopeContext());
 }
 
+Optional<ArrayRef<Requirement>>
+ProtocolConformance::getConditionalRequirementsIfAvailable() const {
+  CONFORMANCE_SUBCLASS_DISPATCH(getConditionalRequirementsIfAvailable, ());
+}
+
 ArrayRef<Requirement> ProtocolConformance::getConditionalRequirements() const {
   CONFORMANCE_SUBCLASS_DISPATCH(getConditionalRequirements, ());
+}
+
+Optional<ArrayRef<Requirement>>
+ProtocolConformanceRef::getConditionalRequirementsIfAvailable() const {
+  if (isConcrete())
+    return getConcrete()->getConditionalRequirementsIfAvailable();
+  else
+    // An abstract conformance is never conditional: any conditionality in the
+    // concrete types that will eventually pass through this at runtime is
+    // completely pre-checked and packaged up.
+    return ArrayRef<Requirement>();
 }
 
 ArrayRef<Requirement>
@@ -376,35 +392,66 @@ ProtocolConformanceRef::getConditionalRequirements() const {
   if (isConcrete())
     return getConcrete()->getConditionalRequirements();
   else
-    // An abstract conformance is never conditional: any conditionality in the
-    // concrete types that will eventually pass through this at runtime is
-    // completely pre-checked and packaged up.
+    // An abstract conformance is never conditional, as above.
     return {};
 }
 
-void NormalProtocolConformance::differenceAndStoreConditionalRequirements() {
-  assert(ConditionalRequirements.empty() &&
-         "should not recompute conditional requirements");
+void NormalProtocolConformance::differenceAndStoreConditionalRequirements()
+    const {
+  switch (CRState) {
+  case ConditionalRequirementsState::Complete:
+    // already done!
+    return;
+  case ConditionalRequirementsState::Computing:
+    // recursive
+    return;
+  case ConditionalRequirementsState::Uncomputed:
+    // try to compute it!
+    break;
+  };
+
+  CRState = ConditionalRequirementsState::Computing;
+  auto success = [this](ArrayRef<Requirement> reqs) {
+    ConditionalRequirements = reqs;
+    assert(CRState == ConditionalRequirementsState::Computing);
+    CRState = ConditionalRequirementsState::Complete;
+  };
+  auto failure = [this] {
+    assert(CRState == ConditionalRequirementsState::Computing);
+    CRState = ConditionalRequirementsState::Uncomputed;
+  };
+
   auto &ctxt = getProtocol()->getASTContext();
   auto DC = getDeclContext();
-  // Only conformances in extensions can be conditional
-  if (!isa<ExtensionDecl>(DC))
+  // A non-extension conformance won't have conditional requirements.
+  if (!isa<ExtensionDecl>(DC)) {
+    success({});
     return;
+  }
 
   auto typeSig = DC->getAsNominalTypeOrNominalTypeExtensionContext()
                      ->getGenericSignature();
-  auto extensionSig = DC->getGenericSignatureOfContext();
 
-  // If the type is generic, the extension should be too, and vice versa.
-  assert((bool)typeSig == (bool)extensionSig &&
-         "unexpected generic-ness mismatch on conformance");
-  if (!typeSig)
+  // A non-generic type won't have conditional requirements.
+  if (!typeSig) {
+    success({});
     return;
+  }
+
+  auto extensionSig = DC->getGenericSignatureOfContext();
+  // The type is generic, but the extension doesn't have a signature yet, so
+  // we can't do any differencing.
+  if (!extensionSig) {
+    failure();
+    return;
+  }
 
   auto canExtensionSig = extensionSig->getCanonicalSignature();
   auto canTypeSig = typeSig->getCanonicalSignature();
-  if (canTypeSig == canExtensionSig)
+  if (canTypeSig == canExtensionSig) {
+    success({});
     return;
+  }
 
   // The extension signature should be a superset of the type signature, meaning
   // every thing in the type signature either is included too or is implied by
@@ -415,8 +462,7 @@ void NormalProtocolConformance::differenceAndStoreConditionalRequirements() {
 
   // Find the requirements in the extension that aren't proved by the original
   // type, these are the ones that make the conformance conditional.
-  ConditionalRequirements =
-      ctxt.AllocateCopy(extensionSig->requirementsNotSatisfiedBy(typeSig));
+  success(ctxt.AllocateCopy(extensionSig->requirementsNotSatisfiedBy(typeSig)));
 }
 
 void NormalProtocolConformance::setSignatureConformances(
@@ -604,6 +650,12 @@ NormalProtocolConformance::getTypeWitnessAndDecl(AssociatedTypeDecl *assocType,
     return { Type(), nullptr };
   }
 
+  // If the conditional requirements aren't known, we can't properly run
+  // inference.
+  if (!getConditionalRequirementsIfAvailable()) {
+    return {Type(), nullptr};
+  }
+
   // Otherwise, resolve the type witness.
   PrettyStackTraceRequirement trace("resolving", this, assocType);
   assert(resolver && "Unable to resolve type witness");
@@ -779,8 +831,20 @@ SpecializedProtocolConformance::SpecializedProtocolConformance(
     GenericSubstitutions(substitutions)
 {
   assert(genericConformance->getKind() != ProtocolConformanceKind::Specialized);
+  computeConditionalRequirements();
+}
 
-  if (!GenericConformance->getConditionalRequirements().empty()) {
+void SpecializedProtocolConformance::computeConditionalRequirements() const {
+  // already computed?
+  if (ConditionalRequirements)
+    return;
+
+  auto parentCondReqs =
+      GenericConformance->getConditionalRequirementsIfAvailable();
+  if (!parentCondReqs)
+    return;
+
+  if (!parentCondReqs->empty()) {
     // Substitute the conditional requirements so that they're phrased in
     // terms of the specialized types, not the conformance-declaring decl's
     // types.
@@ -789,13 +853,15 @@ SpecializedProtocolConformance::SpecializedProtocolConformance(
     auto subMap = getType()->getContextSubstitutionMap(module, nominal);
 
     SmallVector<Requirement, 4> newReqs;
-    for (auto oldReq : GenericConformance->getConditionalRequirements()) {
+    for (auto oldReq : *parentCondReqs) {
       if (auto newReq = oldReq.subst(QuerySubstitutionMap{subMap},
                                      LookUpConformanceInModule(module)))
         newReqs.push_back(*newReq);
     }
     auto &ctxt = getProtocol()->getASTContext();
     ConditionalRequirements = ctxt.AllocateCopy(newReqs);
+  } else {
+    ConditionalRequirements = {};
   }
 }
 

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3825,11 +3825,18 @@ Optional<ProtocolConformanceRef> TypeChecker::conformsToProtocol(
     markConformanceUsed(*lookupResult, DC);
   }
 
-  // If we have a concrete conformance with conditional requirements that
+  auto condReqs = lookupResult->getConditionalRequirementsIfAvailable();
+  // If we have a conditional requirements that
   // we need to check, do so now.
-  if (lookupResult->isConcrete() &&
-      !lookupResult->getConditionalRequirements().empty() &&
-      !options.contains(ConformanceCheckFlags::SkipConditionalRequirements)) {
+  if (!condReqs) {
+    assert(
+        options.contains(
+            ConformanceCheckFlags::AllowUnavailableConditionalRequirements) &&
+        "unhandled recursion: missing conditional requirements when they're "
+        "required");
+  } else if (!condReqs->empty() &&
+             !options.contains(
+                 ConformanceCheckFlags::SkipConditionalRequirements)) {
     // Figure out the location of the conditional conformance.
     auto conformanceDC = lookupResult->getConcrete()->getDeclContext();
     SourceLoc noteLoc;
@@ -3838,16 +3845,12 @@ Optional<ProtocolConformanceRef> TypeChecker::conformsToProtocol(
     else
       noteLoc = cast<NominalTypeDecl>(conformanceDC)->getLoc();
 
-    auto conditionalCheckResult =
-      checkGenericArguments(DC, ComplainLoc, noteLoc, T,
-                            { Type(lookupResult->getRequirement()
-                                ->getProtocolSelfType()) },
-                            lookupResult->getConditionalRequirements(),
-                            [](SubstitutableType *dependentType) {
-                              return Type(dependentType);
-                            },
-                            LookUpConformance(*this, DC),
-                            options);
+    auto conditionalCheckResult = checkGenericArguments(
+        DC, ComplainLoc, noteLoc, T,
+        {Type(lookupResult->getRequirement()->getProtocolSelfType())},
+        *condReqs,
+        [](SubstitutableType *dependentType) { return Type(dependentType); },
+        LookUpConformance(*this, DC), options);
     switch (conditionalCheckResult) {
     case RequirementCheckResult::Success:
       break;

--- a/lib/Sema/TypeCheckType.cpp
+++ b/lib/Sema/TypeCheckType.cpp
@@ -678,11 +678,11 @@ static void maybeDiagnoseBadConformanceRef(TypeChecker &tc,
                                            AssociatedTypeDecl *assocType) {
   // If we weren't given a conformance, go look it up.
   ProtocolConformance *conformance = nullptr;
-  if (auto conformanceRef =
-        tc.conformsToProtocol(
+  if (auto conformanceRef = tc.conformsToProtocol(
           parentTy, assocType->getProtocol(), dc,
-          (ConformanceCheckFlags::InExpression|
-           ConformanceCheckFlags::SuppressDependencyTracking))) {
+          (ConformanceCheckFlags::InExpression |
+           ConformanceCheckFlags::SuppressDependencyTracking |
+           ConformanceCheckFlags::AllowUnavailableConditionalRequirements))) {
     if (conformanceRef->isConcrete())
       conformance = conformanceRef->getConcrete();
   }
@@ -692,9 +692,14 @@ static void maybeDiagnoseBadConformanceRef(TypeChecker &tc,
   if (tc.Context.Diags.hadAnyError())
     return;
 
-  tc.diagnose(loc, diag::broken_associated_type_witness,
-              assocType->getFullName(), parentTy);
-};
+  auto diagCode =
+      (conformance && !conformance->getConditionalRequirementsIfAvailable())
+          ? diag::unsupported_recursion_in_associated_type_reference
+          : diag::broken_associated_type_witness;
+
+  tc.diagnose(loc, diagCode, assocType->getFullName(), parentTy);
+}
+
 /// \brief Returns a valid type or ErrorType in case of an error.
 static Type resolveTypeDecl(TypeChecker &TC, TypeDecl *typeDecl, SourceLoc loc,
                             DeclContext *foundDC,

--- a/lib/Sema/TypeChecker.h
+++ b/lib/Sema/TypeChecker.h
@@ -675,6 +675,13 @@ enum class ConformanceCheckFlags {
   /// correctly used. Otherwise (the default), all of the conditional
   /// requirements will be checked.
   SkipConditionalRequirements = 0x08,
+
+  /// Whether to require that the conditional requirements have been computed.
+  ///
+  /// When set, if the conditional requirements aren't available, they are just
+  /// skipped, and the caller is responsible for detecting and handling this
+  /// case (likely via another call to getConditionalRequirementsIfAvailable).
+  AllowUnavailableConditionalRequirements = 0x10,
 };
 
 /// Options that control protocol conformance checking.

--- a/validation-test/compiler_crashers_2_fixed/0161-sr6569.swift
+++ b/validation-test/compiler_crashers_2_fixed/0161-sr6569.swift
@@ -1,0 +1,10 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {
+    associatedtype A: P
+}
+
+struct Type<Param> {}
+extension Type: P where Param: P, Param.A == Type<Param> { // expected-error {{requirement involves recursion that is not currently supported}}
+    typealias A = Param
+}

--- a/validation-test/compiler_crashers_2_fixed/0162-sr8019.swift
+++ b/validation-test/compiler_crashers_2_fixed/0162-sr8019.swift
@@ -1,0 +1,5 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P {}
+struct A<C> {}
+extension A: P where A: P {} // expected-error {{requirement involves recursion that is not currently supported}}

--- a/validation-test/compiler_crashers_2_fixed/0163-sr8033.swift
+++ b/validation-test/compiler_crashers_2_fixed/0163-sr8033.swift
@@ -1,0 +1,9 @@
+// RUN: %target-typecheck-verify-swift
+
+struct Foo<T> {}
+
+protocol P1 {
+    associatedtype A // expected-note {{protocol requires nested type 'A'; do you want to add it?}}
+}
+extension Foo: P1 where A : P1 {} // expected-error {{unsupported recursion for reference to associated type 'A' of type 'Foo<T>'}}
+// expected-error@-1 {{type 'Foo<T>' does not conform to protocol 'P1'}}

--- a/validation-test/compiler_crashers_2_fixed/0164-sr7989.swift
+++ b/validation-test/compiler_crashers_2_fixed/0164-sr7989.swift
@@ -1,0 +1,12 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P1 {}
+protocol P2 {}
+
+struct Var<N> {}
+
+extension Var : P2 where N : P1 { }
+
+protocol P3 {}
+extension Var : P3 where Self : P2 {} // expected-error {{'Self' is only available in a protocol or as the result of a method in a class; did you mean 'Var'?}}
+// expected-error@-1 {{type 'Var<N>' in conformance requirement does not refer to a generic parameter or associated type}}


### PR DESCRIPTION
Two cases go from being a crash to being a more explanatory error with locations etc.:

- rdar://problem/41281406, https://bugs.swift.org/browse/SR-8019 (rdar://problem/41216423) and https://bugs.swift.org/browse/SR-7989 (rdar://problem/41126254).

- https://bugs.swift.org/browse/SR-8033.

This doesn't fix the recursion itself. It also doesn't use the request evaluator, because I want to put this into the 4.2 branch.