### PR TITLE
[TypeReconstruction] Dependent member types can't have existential as bases.

### DIFF
--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -748,27 +748,6 @@ static void VisitNodeAssociatedTypeRef(
           return;
         }
       }
-      ProtocolType *protocol_type = type->getAs<ProtocolType>();
-      if (protocol_type) {
-        Identifier assoc_id = ast->getIdentifier(ident->getText());
-        ProtocolDecl *protocol_decl = protocol_type->getDecl();
-        AssociatedTypeDecl *associated = nullptr;
-        for (auto member : protocol_decl->getMembers()) {
-          auto *atd = dyn_cast<AssociatedTypeDecl>(member);
-          if (!atd)
-            continue;
-          if (assoc_id == atd->getName()) {
-            associated = atd;
-            break;
-          }
-        }
-        if (associated) {
-          result._types.push_back(
-          DependentMemberType::get(protocol_type, assoc_id));
-          result._module = type_result._module;
-          return;
-        }
-      }
     }
   }
   result._types.clear();

--- a/test/DebugInfo/Inputs/type-reconstr-names.txt
+++ b/test/DebugInfo/Inputs/type-reconstr-names.txt
@@ -9,4 +9,4 @@ $S7ElementQzD ---> τ_0_0.Element
 $S13EyeCandySwift21_previousUniqueNumber33_ADC08935D64EA4F796440E7335798735LLs6UInt64Vvp ---> UInt64
 $SSayypXpG ---> Array<Any.Type>
 $S12EyeCandyCore11XPCListenerC14messageHandleryyAA13XPCConnectionV_AA10XPCMessageVxtcvpfiyAF_AHxtcfU_TA.4 ---> Can't resolve type of $S12EyeCandyCore11XPCListenerC14messageHandleryyAA13XPCConnectionV_AA10XPCMessageVxtcvpfiyAF_AHxtcfU_TA.4
-$Ss10CollectionP7ElementQa ---> Collection.Element
+$Ss10CollectionP7ElementQa ---> Can't resolve type of $Ss10CollectionP7ElementQa


### PR DESCRIPTION
This basically means the mangling isn't really quite valid, and
given we don't have a full compiler testcase to see what generates
this, we're going to reject this for now.

<rdar://problem/38931073>
