### PR TITLE
Restrict RemoteASTTypeBuilder::findModule() to the list of loaded mod…

### DIFF
--- a/lib/RemoteAST/RemoteAST.cpp
+++ b/lib/RemoteAST/RemoteAST.cpp
@@ -569,7 +569,13 @@ RemoteASTTypeBuilder::createNominalTypeDecl(const Demangle::NodePointer &node) {
 ModuleDecl *RemoteASTTypeBuilder::findModule(const Demangle::NodePointer &node){
   assert(node->getKind() == Demangle::Node::Kind::Module);
   const auto &moduleName = node->getText();
-  return Ctx.getModuleByName(moduleName);
+  // Intentionally using getLoadedModule() instead of getModuleByName() here.
+  // LLDB uses RemoteAST for its per-module SwiftASTContext. Importing external
+  // modules here could permanently damage this context, for example when a
+  // Clang import fails because of missing header search options. To avoid this
+  // situation, restrict RemoteAST's access to only the module's transitive
+  // closure of imports.
+  return Ctx.getLoadedModule(Ctx.getIdentifier(moduleName));
 }
 
 Demangle::NodePointer


### PR DESCRIPTION
…ules.

LLDB uses RemoteAST for its per-module SwiftASTContext. Importing
external modules here could permanently damage this context, for
example when a Clang import fails because of missing header search
options. To avoid this situation, restrict RemoteAST's access to only
the module's transitive closure of imports.

Triggering this situation needs two independent Swift compilation
units. An accompanying testcase (Swift/RemoteASTImport.test) has been
added to LLDB.

rdar://problem/40950542
(cherry picked from commit 30ea6ec66cdc662f13ae149defda7224df8b7f36)

