### PR TITLE
[SIL] Remove dependency on SILConstants.h from SILInstruction.h.

### DIFF
--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -286,6 +286,14 @@ public:
   void dump() const;
 };
 
+/// SWIFT_ENABLE_TENSORFLOW
+/// A graph operation attribute, used by GraphOperationInst.
+/// Attributes have a name and a constant value.
+struct GraphOperationAttribute {
+  Identifier name;
+  SymbolicValue value;
+};
+
 } // end namespace swift
 
 #endif

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -29,8 +29,6 @@
 #include "swift/Basic/Range.h"
 #include "swift/SIL/Consumption.h"
 #include "swift/SIL/SILAllocated.h"
-// SWIFT_ENABLE_TENSORFLOW
-#include "swift/SIL/SILConstants.h"
 #include "swift/SIL/SILDeclRef.h"
 #include "swift/SIL/SILFunctionConventions.h"
 #include "swift/SIL/SILLocation.h"
@@ -54,6 +52,7 @@ class MultipleValueInstructionResult;
 class DestructureTupleInst;
 class DestructureStructInst;
 // SWIFT_ENABLE_TENSORFLOW
+struct GraphOperationAttribute;
 class GraphOperationInst;
 class NonValueInstruction;
 class SILBasicBlock;
@@ -8170,13 +8169,6 @@ public:
 };
 
 /// SWIFT_ENABLE_TENSORFLOW
-/// A graph operation attribute. Attributes have a name and a constant value.
-struct GraphOperationAttribute {
-  Identifier name;
-  SymbolicValue value;
-};
-
-/// SWIFT_ENABLE_TENSORFLOW
 /// A graph operation. This instruction will be extracted to a graph program
 /// via graph program extraction passes.
 class GraphOperationInst final
@@ -8186,41 +8178,27 @@ class GraphOperationInst final
     public MultipleValueInstructionTrailingObjects<
                GraphOperationInst, GraphOperationResult,
                InitialTrailingObjects<>,
-               FinalTrailingObjects<Operand, GraphOperationAttribute>> {
+               FinalTrailingObjects<Operand>> {
   friend TrailingObjects;
 
   /// The name of the graph operation.
   Identifier Name;
   /// The number of operands.
   unsigned NumOperands;
-  /// The number of attributes.
-  unsigned NumAttributes;
+  /// The attributes of the graph operation.
+  MutableArrayRef<GraphOperationAttribute> Attributes;
 
   GraphOperationInst(SILModule &M, SILDebugLocation loc, Identifier name,
                      ArrayRef<SILValue> arguments,
                      ArrayRef<GraphOperationAttribute> attrs,
                      ArrayRef<SILType> resultTypes,
-                     ArrayRef<ValueOwnershipKind> resultOwnerships) :
-    InstructionBase(loc),
-    MultipleValueInstructionTrailingObjects(this, resultTypes,
-                                            resultOwnerships),
-    Name(name), NumOperands(arguments.size()), NumAttributes(attrs.size()) {
-      auto allOperands = getAllOperands();
-      for (unsigned i : indices(arguments))
-        new (&allOperands[i]) Operand(this, arguments[i]);
-      std::uninitialized_copy(attrs.begin(), attrs.end(),
-                              getAttributes().data());
-    }
+                     ArrayRef<ValueOwnershipKind> resultOwnerships);
 
 public:
   using MultipleValueInstructionTrailingObjects::numTrailingObjects;
   using MultipleValueInstructionTrailingObjects::totalSizeToAlloc;
 
-  ~GraphOperationInst() {
-    for (auto &operand : getAllOperands())
-      operand.~Operand();
-  }
-
+  ~GraphOperationInst();
   static GraphOperationInst *create(SILModule &M, SILDebugLocation loc,
                                     Identifier name,
                                     ArrayRef<SILValue> arguments,
@@ -8229,7 +8207,7 @@ public:
 
   Identifier getName() const { return Name; }
   unsigned getNumOperands() const { return NumOperands; }
-  unsigned getNumAttributes() const { return NumAttributes; }
+  unsigned getNumAttributes() const { return Attributes.size(); }
 
   unsigned numTrailingObjects(OverloadToken<Operand>) const {
     return NumOperands;
@@ -8247,20 +8225,9 @@ public:
     return OperandValueArrayRef(getAllOperands());
   }
 
-  ArrayRef<GraphOperationAttribute> getAttributes() const {
-    return { getTrailingObjects<GraphOperationAttribute>(), NumAttributes };
-  }
-
-  MutableArrayRef<GraphOperationAttribute> getAttributes() {
-    return { getTrailingObjects<GraphOperationAttribute>(), NumAttributes };
-  }
-
-  Optional<GraphOperationAttribute> getAttribute(StringRef name) {
-    for (auto attr : getAttributes())
-      if (attr.name.is(name))
-        return attr;
-    return None;
-  };
+  ArrayRef<GraphOperationAttribute> getAttributes() const;
+  MutableArrayRef<GraphOperationAttribute> getAttributes();
+  Optional<GraphOperationAttribute> getAttribute(StringRef name);
 
   static bool classof(const SILNode *N) {
     return N->getKind() == SILNodeKind::GraphOperationInst;

--- a/include/swift/SIL/SILInstruction.h
+++ b/include/swift/SIL/SILInstruction.h
@@ -8225,8 +8225,14 @@ public:
     return OperandValueArrayRef(getAllOperands());
   }
 
-  ArrayRef<GraphOperationAttribute> getAttributes() const;
-  MutableArrayRef<GraphOperationAttribute> getAttributes();
+  ArrayRef<GraphOperationAttribute> getAttributes() const {
+    return Attributes;
+  }
+
+  MutableArrayRef<GraphOperationAttribute> getAttributes() {
+    return Attributes;
+  }
+
   Optional<GraphOperationAttribute> getAttribute(StringRef name);
 
   static bool classof(const SILNode *N) {

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -2499,8 +2499,7 @@ GraphOperationInst::GraphOperationInst(
   auto allOperands = getAllOperands();
   for (unsigned i : indices(arguments))
     new (&allOperands[i]) Operand(this, arguments[i]);
-  auto attrBuf = AlignedAlloc(sizeof(GraphOperationAttribute) * attrs.size(),
-                              alignof(GraphOperationAttribute));
+  auto attrBuf = new GraphOperationAttribute[attrs.size()];
   Attributes = MutableArrayRef<GraphOperationAttribute>(
     static_cast<GraphOperationAttribute *>(attrBuf), attrs.size());
   std::uninitialized_copy(attrs.begin(), attrs.end(), Attributes.data());
@@ -2509,7 +2508,7 @@ GraphOperationInst::GraphOperationInst(
 GraphOperationInst::~GraphOperationInst() {
   for (auto &operand : getAllOperands())
     operand.~Operand();
-  delete getAttributes().data();
+  delete[] getAttributes().data();
 }
 
 GraphOperationInst *GraphOperationInst::create(
@@ -2529,16 +2528,6 @@ GraphOperationInst *GraphOperationInst::create(
   void *buffer = M.allocateInst(size, alignof(GraphOperationInst));
   return ::new (buffer) GraphOperationInst(M, loc, name, arguments, attributes,
                                            resultTypes, resultOwnerships);
-}
-
-ArrayRef<GraphOperationAttribute>
-GraphOperationInst::getAttributes() const {
-  return Attributes;
-}
-
-MutableArrayRef<GraphOperationAttribute>
-GraphOperationInst::getAttributes() {
-  return Attributes;
 }
 
 Optional<GraphOperationAttribute>

--- a/lib/SIL/SILInstructions.cpp
+++ b/lib/SIL/SILInstructions.cpp
@@ -23,6 +23,8 @@
 #include "swift/SIL/Projection.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILCloner.h"
+// SWIFT_ENABLE_TENSORFLOW
+#include "swift/SIL/SILConstants.h"
 #include "swift/SIL/SILInstruction.h"
 #include "swift/SIL/SILModule.h"
 #include "swift/SIL/SILVisitor.h"
@@ -2484,6 +2486,32 @@ DestructureTupleInst *DestructureTupleInst::create(SILModule &M,
 }
 
 // SWIFT_ENABLE_TENSORFLOW
+GraphOperationInst::GraphOperationInst(
+    SILModule &M, SILDebugLocation loc, Identifier name,
+    ArrayRef<SILValue> arguments, ArrayRef<GraphOperationAttribute> attrs,
+    ArrayRef<SILType> resultTypes,
+    ArrayRef<ValueOwnershipKind> resultOwnerships) :
+  InstructionBase(loc),
+  MultipleValueInstructionTrailingObjects(this, resultTypes,
+                                          resultOwnerships),
+  Name(name), NumOperands(arguments.size())
+{
+  auto allOperands = getAllOperands();
+  for (unsigned i : indices(arguments))
+    new (&allOperands[i]) Operand(this, arguments[i]);
+  auto attrBuf = AlignedAlloc(sizeof(GraphOperationAttribute) * attrs.size(),
+                              alignof(GraphOperationAttribute));
+  Attributes = MutableArrayRef<GraphOperationAttribute>(
+    static_cast<GraphOperationAttribute *>(attrBuf), attrs.size());
+  std::uninitialized_copy(attrs.begin(), attrs.end(), Attributes.data());
+}
+
+GraphOperationInst::~GraphOperationInst() {
+  for (auto &operand : getAllOperands())
+    operand.~Operand();
+  delete getAttributes().data();
+}
+
 GraphOperationInst *GraphOperationInst::create(
     SILModule &M, SILDebugLocation loc, Identifier name,
     ArrayRef<SILValue> arguments, ArrayRef<GraphOperationAttribute> attributes,
@@ -2496,10 +2524,27 @@ GraphOperationInst *GraphOperationInst::create(
   }
 
   unsigned size =
-    totalSizeToAlloc<MultipleValueInstruction *, GraphOperationResult, Operand,
-                     GraphOperationAttribute>(
-      1, resultTypes.size(), arguments.size(), attributes.size());
+    totalSizeToAlloc<MultipleValueInstruction *, GraphOperationResult, Operand>(
+      1, resultTypes.size(), arguments.size());
   void *buffer = M.allocateInst(size, alignof(GraphOperationInst));
   return ::new (buffer) GraphOperationInst(M, loc, name, arguments, attributes,
                                            resultTypes, resultOwnerships);
 }
+
+ArrayRef<GraphOperationAttribute>
+GraphOperationInst::getAttributes() const {
+  return Attributes;
+}
+
+MutableArrayRef<GraphOperationAttribute>
+GraphOperationInst::getAttributes() {
+  return Attributes;
+}
+
+Optional<GraphOperationAttribute>
+GraphOperationInst::getAttribute(StringRef name) {
+  for (auto attr : getAttributes())
+    if (attr.name.is(name))
+      return attr;
+  return None;
+};

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -21,6 +21,8 @@
 #include "swift/Basic/QuotedString.h"
 #include "swift/SIL/SILPrintContext.h"
 #include "swift/SIL/CFG.h"
+// SWIFT_ENABLE_TENSORFLOW
+#include "swift/SIL/SILConstants.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILCoverageMap.h"
 #include "swift/SIL/SILDebugScope.h"

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -27,6 +27,8 @@
 #include "swift/SIL/DynamicCasts.h"
 #include "swift/SIL/PostOrder.h"
 #include "swift/SIL/PrettyStackTrace.h"
+// SWIFT_ENABLE_TENSORFLOW
+#include "swift/SIL/SILConstants.h"
 #include "swift/SIL/SILDebugScope.h"
 #include "swift/SIL/SILFunction.h"
 #include "swift/SIL/SILModule.h"


### PR DESCRIPTION
- Move `GraphOperationAttribute` to SILConstants.h and forward declare it in
  SILInstruction.h.
- Change `GraphOperationInst` to dynamically allocate attributes rather than
  tail allocation. This is necessary because `GraphOperationAttribute` cannot
  be used as a template parameter to `TrailingObjects`.
- Move `GraphOperationInst::getAttributes` and related methods to
  SILInstructions.cpp.
- Include SILConstants.h in source files that use `GraphOperationAttribute`.

Quality-of-life improvement requested by @lattner.
Previously, since SILInstruction.h included SILConstants.h, any change to SILConstants.h caused recompilation of all of SIL.