### PR TITLE
[SIL] Support SILFunction as a `GraphOperationInst` attribute.

### DIFF
--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1212,6 +1212,12 @@ public:
       *this << SILType::getPrimitiveObjectType(metatype.getInstanceType());
       return;
     }
+    case SymbolicValue::Function: {
+      auto function = v.getFunctionValue();
+      *this << "@" << function->getName();
+      *this << " : $" << function->getLoweredFunctionType();
+      return;
+    }
     case SymbolicValue::Aggregate:
       *this << "[";
       interleave(v.getAggregateValue(), [&](SymbolicValue element) {
@@ -1221,7 +1227,6 @@ public:
       });
       *this << "]";
       return;
-    case SymbolicValue::Function:
     case SymbolicValue::Address:
     case SymbolicValue::UninitMemory:
     case SymbolicValue::Unknown:

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1213,7 +1213,7 @@ public:
       return;
     }
     case SymbolicValue::Function: {
-      auto function = v.getFunctionValue();
+      auto function = v.getFunctionValue().first;
       *this << "@" << function->getName();
       *this << " : $" << function->getLoweredFunctionType();
       return;

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1213,6 +1213,9 @@ public:
       return;
     }
     case SymbolicValue::Function: {
+      assert(!v.getFunctionValue().second &&
+             "SILFunction SymbolicValues with protocol conformances cannot be "
+             "printed");
       auto function = v.getFunctionValue().first;
       *this << "@" << function->getName();
       *this << " : $" << function->getLoweredFunctionType();

--- a/test/TensorFlow/graph_op_inst.sil
+++ b/test/TensorFlow/graph_op_inst.sil
@@ -15,7 +15,8 @@ bb0:
   %2 = graph_op "tf.Dummy"() {float1: f64 3.14, float2: f32 -3.14} : $Tensor<Float>
   %3 = graph_op "tf.Dummy"() {string1: "hello", string2: "world"} : $Tensor<Float>
   %4 = graph_op "tf.Dummy"() {metatype1: $Float, metatype2: $Tensor<Float>} : $Tensor<Float>
-  %5 = graph_op "tf.Dummy"() {array: [[i8 1, i32 -2], [f32 -1.0, $Float]]} : $Tensor<Float>
+  %5 = graph_op "tf.Dummy"() {function1: @chained_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float>} : $Tensor<Float>
+  %6 = graph_op "tf.Dummy"() {array: [[i8 1, i32 -2], [f32 -1.0, $Float]]} : $Tensor<Float>
   return %0 : $Tensor<Float>
 }
 
@@ -26,7 +27,8 @@ bb0:
 // CHECK-NEXT:   %2 = graph_op "tf.Dummy"() {float1: f64 0x40091EB851EB851F /* 3.1400000000000001 */, float2: f32 0xC048F5C3 /* -3.1400001 */} : $Tensor<Float>
 // CHECK-NEXT:   %3 = graph_op "tf.Dummy"() {string1: "hello", string2: "world"} : $Tensor<Float>
 // CHECK-NEXT:   %4 = graph_op "tf.Dummy"() {metatype1: $Float, metatype2: $Tensor<Float>} : $Tensor<Float>
-// CHECK-NEXT:   %5 = graph_op "tf.Dummy"() {array: {{\[\[}}i8 1, i32 -2], [f32 0xBF800000 /* -1 */, $Float]]} : $Tensor<Float>
+// CHECK-NEXT:   %5 = graph_op "tf.Dummy"() {function1: @chained_op_test : $@convention(thin) (Tensor<Float>, Tensor<Float>) -> Tensor<Float>} : $Tensor<Float>
+// CHECK-NEXT:   %6 = graph_op "tf.Dummy"() {array: {{\[\[}}i8 1, i32 -2], [f32 0xBF800000 /* -1 */, $Float]]} : $Tensor<Float>
 // CHECK-NEXT:   return %0 : $Tensor<Float>
 // CHECK-NEXT: }
 


### PR DESCRIPTION
- Implement parsing/printing for SILFunction SymbolicValues.
  - It's necessary to include function type in the textual representation to
    enable forward references to SIL functions.
- Update test.