### PR TITLE
ConstExpr: Reimplement the mutable memory representation

### DIFF
--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -29,7 +29,6 @@ class SerializedSILLoader;
 struct APIntSymbolicValue;
 struct APFloatSymbolicValue;
 struct StringSymbolicValue;
-struct AddressSymbolicValue;
 struct AggregateSymbolicValue;
 
 /// When we fail to constant fold a value, this captures a reason why,
@@ -97,12 +96,6 @@ class SymbolicValue {
     /// representing a UTF-8 encoded string.
     RK_String,
 
-    /// This value is a pointer to a tracked memory location, along with zero
-    /// or more indices (tuple indices, struct field indices, etc) into the
-    /// value if it is an aggregate.
-    ///
-    RK_Address,
-
     /// This value is an array, struct, or tuple of constants.  This is
     /// tracked by the "aggregate" member of the value union.  Note that we
     /// cheat and represent single-element structs as the value of their
@@ -142,10 +135,6 @@ class SymbolicValue {
     /// When this SymbolicValue is of "String" kind, this pointer stores
     /// information about the StringRef value it holds.
     StringSymbolicValue *string;
-
-    /// When this SymbolicValue is of "Address" kind, this pointer stores
-    /// info about the base and the indices for the address.
-    AddressSymbolicValue *address;
 
     /// When this SymbolicValue is of "Aggregate" kind, this pointer stores
     /// information about the array elements, count, and element type.
@@ -196,7 +185,6 @@ public:
 
     /// These values are generally only seen internally to the system, external
     /// clients shouldn't have to deal with them.
-    Address,
     UninitMemory
   };
 
@@ -216,6 +204,10 @@ public:
     result.value.unknown = node;
     result.aux.unknown_reason = reason;
     return result;
+  }
+
+  bool isUnknown() const {
+    return getKind() == Unknown;
   }
 
   /// Return information about an unknown result, including the SIL node that
@@ -302,22 +294,6 @@ public:
 
   /// Returns the UTF-8 encoded string underlying a SymbolicValue.
   StringRef getStringValue() const;
-
-  /// Get a SymbolicValue corresponding to a memory object with an optional
-  /// list of indices into it.  This is used by (e.g.) a struct_element_addr
-  /// of a stack_alloc.
-  static SymbolicValue getAddress(SILValue base,
-                                  ArrayRef<unsigned> indices,
-                                  llvm::BumpPtrAllocator &allocator);
-
-  /// Accessors for Address SymbolicValue's.
-  bool isAddress() const {
-    return getKind() == Address;
-  }
-
-  SILValue getAddressBase() const;
-  ArrayRef<unsigned> getAddressIndices() const;
-
 
   /// This returns an aggregate value with the specified elements in it.  This
   /// copies the elements into the specified allocator.

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1222,7 +1222,6 @@ public:
       *this << "]";
       return;
     case SymbolicValue::Function:
-    case SymbolicValue::Address:
     case SymbolicValue::UninitMemory:
     case SymbolicValue::Unknown:
       llvm_unreachable("Unimplemented SymbolicValue case");

--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -1499,7 +1499,6 @@ emitConstantInst(SymbolicValue symVal, SILType type, SILLocation loc,
   switch (symVal.getKind()) {
   case SymbolicValue::Unknown:
   case SymbolicValue::UninitMemory:
-  case SymbolicValue::Address:
     assert(0 && "Shouldn't happen");
   case SymbolicValue::Aggregate:
   case SymbolicValue::Function:

--- a/test/SILOptimizer/pound_assert.swift
+++ b/test/SILOptimizer/pound_assert.swift
@@ -112,8 +112,6 @@ func substitutionsF<T: SubstitutionsP>(_: T.Type) -> T {
 }
 
 func testProto() {
-  // This is because our memory representation is not correct.
-  // BUG: expected-error @+1 {{#assert condition not constant}}
   #assert(substitutionsF(SubstitutionsX.self).getState() == 123)
 }
 


### PR DESCRIPTION
Now we track addresses independently of the memory they point to, instead of conflating
the two together.  This has some happy benefits:

 - “Addresses” are no longer a thing in the SILConstants.h world, they are just part of the
   ConstExpr interpreter implementation.
 - Addresses get a proper structured representation, named AddressValue and we get
   strong assertions that values and addresses are not getting mixed up.
 - This fixes the testProto() testcase in SILOptimizer/pound_assert.swift.

This also renames ConstExprFunctionCache -> ConstExprFunctionState.