### PR TITLE
Update Sanitizers/witness_table_lookup.swift test for Swift 4

### DIFF
--- a/validation-test/Sanitizers/witness_table_lookup.swift
+++ b/validation-test/Sanitizers/witness_table_lookup.swift
@@ -31,7 +31,7 @@ protocol P {
 struct B<T : Q> : Q, Q2 {
   static func foo() { consume(type(of: self)) }
 }
-struct A<T : Q where T : Q2> : P {
+struct A<T : Q> : P where T : Q2 {
   typealias E = B<T>
   let value: T
 }


### PR DESCRIPTION
I missed this with my previous patch.