### PR TITLE
[stdlib][nfc] Inlineable audit

### DIFF
--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -16,7 +16,7 @@
 ///   - x: A value to compare.
 ///   - y: Another value to compare.
 /// - Returns: The lesser of `x` and `y`. If `x` is equal to `y`, returns `x`.
-@inlinable
+@inlinable // protocol-only
 public func min<T : Comparable>(_ x: T, _ y: T) -> T {
   // In case `x == y` we pick `x`.
   // This preserves any pre-existing order in case `T` has identity,
@@ -34,7 +34,7 @@ public func min<T : Comparable>(_ x: T, _ y: T) -> T {
 ///   - rest: Zero or more additional values.
 /// - Returns: The least of all the arguments. If there are multiple equal
 ///   least arguments, the result is the first one.
-@inlinable
+@inlinable // protocol-only
 public func min<T : Comparable>(_ x: T, _ y: T, _ z: T, _ rest: T...) -> T {
   var minValue = min(min(x, y), z)
   // In case `value == minValue`, we pick `minValue`. See min(_:_:).
@@ -50,7 +50,7 @@ public func min<T : Comparable>(_ x: T, _ y: T, _ z: T, _ rest: T...) -> T {
 ///   - x: A value to compare.
 ///   - y: Another value to compare.
 /// - Returns: The greater of `x` and `y`. If `x` is equal to `y`, returns `y`.
-@inlinable
+@inlinable // protocol-only
 public func max<T : Comparable>(_ x: T, _ y: T) -> T {
   // In case `x == y`, we pick `y`. See min(_:_:).
   return y >= x ? y : x
@@ -65,7 +65,7 @@ public func max<T : Comparable>(_ x: T, _ y: T) -> T {
 ///   - rest: Zero or more additional values.
 /// - Returns: The greatest of all the arguments. If there are multiple equal
 ///   greatest arguments, the result is the last one.
-@inlinable
+@inlinable // protocol-only
 public func max<T : Comparable>(_ x: T, _ y: T, _ z: T, _ rest: T...) -> T {
   var maxValue = max(max(x, y), z)
   // In case `value == maxValue`, we pick `value`. See min(_:_:).

--- a/stdlib/public/core/Assert.swift
+++ b/stdlib/public/core/Assert.swift
@@ -267,7 +267,7 @@ public func _debugPrecondition(
   file: StaticString = #file, line: UInt = #line
 ) {
   // Only check in debug mode.
-  if _isDebugAssertConfiguration() {
+  if _slowPath(_isDebugAssertConfiguration()) {
     if !_branchHint(condition(), expected: true) {
       _fatalErrorMessage("Fatal error", message, file: file, line: line,
         flags: _fatalErrorFlags())
@@ -281,7 +281,7 @@ public func _debugPreconditionFailure(
   _ message: StaticString = StaticString(),
   file: StaticString = #file, line: UInt = #line
 ) -> Never {
-  if _isDebugAssertConfiguration() {
+  if _slowPath(_isDebugAssertConfiguration()) {
     _precondition(false, message, file: file, line: line)
   }
   _conditionallyUnreachable()

--- a/stdlib/public/core/BidirectionalCollection.swift
+++ b/stdlib/public/core/BidirectionalCollection.swift
@@ -131,13 +131,13 @@ where SubSequence: BidirectionalCollection, Indices: BidirectionalCollection {
 /// Default implementation for bidirectional collections.
 extension BidirectionalCollection {
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   @inline(__always)
   public func formIndex(before i: inout Index) {
     i = index(before: i)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public func index(_ i: Index, offsetBy n: Int) -> Index {
     if n >= 0 {
       return _advanceForward(i, by: n)
@@ -149,7 +149,7 @@ extension BidirectionalCollection {
     return i
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public func index(
     _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
@@ -166,7 +166,7 @@ extension BidirectionalCollection {
     return i
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public func distance(from start: Index, to end: Index) -> Int {
     var start = start
     var count = 0
@@ -199,7 +199,7 @@ extension BidirectionalCollection where SubSequence == Self {
   ///   or more elements; otherwise, `nil`.
   ///
   /// - Complexity: O(1).
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public mutating func popLast() -> Element? {
     guard !isEmpty else { return nil }
     let element = last!
@@ -215,7 +215,7 @@ extension BidirectionalCollection where SubSequence == Self {
   /// - Returns: The last element of the collection.
   ///
   /// - Complexity: O(1)
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   @discardableResult
   public mutating func removeLast() -> Element {
     let element = last!
@@ -232,7 +232,7 @@ extension BidirectionalCollection where SubSequence == Self {
   /// - Complexity: O(1) if the collection conforms to
   ///   `RandomAccessCollection`; otherwise, O(*n*), where *n* is the length
   ///   of the collection.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public mutating func removeLast(_ n: Int) {
     if n == 0 { return }
     _precondition(n >= 0, "Number of elements to remove should be non-negative")
@@ -260,7 +260,7 @@ extension BidirectionalCollection {
   /// - Returns: A subsequence that leaves off `n` elements from the end.
   ///
   /// - Complexity: O(*n*), where *n* is the number of elements to drop.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public func dropLast(_ n: Int) -> SubSequence {
     _precondition(
       n >= 0, "Can't drop a negative number of elements from a collection")
@@ -289,7 +289,7 @@ extension BidirectionalCollection {
   ///   most `maxLength` elements.
   ///
   /// - Complexity: O(*n*), where *n* is equal to `maxLength`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public func suffix(_ maxLength: Int) -> SubSequence {
     _precondition(
       maxLength >= 0,

--- a/stdlib/public/core/Builtin.swift
+++ b/stdlib/public/core/Builtin.swift
@@ -78,7 +78,7 @@ func _canBeClass<T>(_: T.Type) -> Int8 {
 ///   - type: The type to cast `x` to. `type` and the type of `x` must have the
 ///     same size of memory representation and compatible memory layout.
 /// - Returns: A new instance of type `U`, cast from `x`.
-@inlinable // FIXME(sil-serialize-all)
+@inlinable // unsafe-performance
 @_transparent
 public func unsafeBitCast<T, U>(_ x: T, to type: U.Type) -> U {
   _precondition(MemoryLayout<T>.size == MemoryLayout<U>.size,

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -96,7 +96,7 @@ extension ClosedRange {
 }
 
 extension ClosedRange: RangeExpression {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public func relative<C: Collection>(to collection: C) -> Range<Bound>
   where C.Index == Bound {
     return Range(
@@ -330,7 +330,7 @@ extension Comparable {
   /// - Parameters:
   ///   - minimum: The lower bound for the range.
   ///   - maximum: The upper bound for the range.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   @_transparent
   public static func ... (minimum: Self, maximum: Self) -> ClosedRange<Self> {
     _precondition(
@@ -362,7 +362,7 @@ extension Strideable where Stride: SignedInteger {
   /// - Parameters:)`.
   ///   - minimum: The lower bound for the range.
   ///   - maximum: The upper bound for the range.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   @_transparent
   public static func ... (minimum: Self, maximum: Self) -> ClosedRange<Self> {
     // FIXME: swift-3-indexing-model: tests for traps.
@@ -404,7 +404,7 @@ extension ClosedRange: Hashable where Bound: Hashable {
 
 extension ClosedRange : CustomStringConvertible {
   /// A textual representation of the range.
-  @inlinable // FIXME(sil-serialize-all)...
+  @inlinable // trivial-implementation...
   public var description: String {
     return "\(lowerBound)...\(upperBound)"
   }
@@ -444,7 +444,7 @@ extension ClosedRange {
   ///
   /// - Parameter limits: The range to clamp the bounds of this range.
   /// - Returns: A new range clamped to the bounds of `limits`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   @inline(__always)
   public func clamped(to limits: ClosedRange) -> ClosedRange {
     let lower =         

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -1094,7 +1094,7 @@ extension Collection {
 /// `IndexingIterator<Self>`.
 extension Collection where Iterator == IndexingIterator<Self> {
   /// Returns an iterator over the elements of the collection.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   @inline(__always)
   public func makeIterator() -> IndexingIterator<Self> {
     return IndexingIterator(_elements: self)

--- a/stdlib/public/core/Collection.swift
+++ b/stdlib/public/core/Collection.swift
@@ -804,7 +804,7 @@ extension Collection {
   ///
   /// - Parameter i: A valid index of the collection. `i` must be less than
   ///   `endIndex`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   @inline(__always)
   public func formIndex(after i: inout Index) {
     i = index(after: i)

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -21,15 +21,15 @@
 ///     let toAdd = 100
 ///     let b = a + CollectionOfOne(toAdd)
 ///     // b == [1, 2, 3, 4, 100]
-@_fixed_layout // FIXME(sil-serialize-all)
+@_fixed_layout // trivial-implementation
 public struct CollectionOfOne<Element> {
-  @usableFromInline // FIXME(sil-serialize-all)
+  @usableFromInline // trivial-implementation
   internal var _element: Element
 
   /// Creates an instance containing just the given element.
   ///
   /// - Parameter element: The element to store in the collection.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public init(_ element: Element) {
     self._element = element
   }
@@ -39,14 +39,14 @@ extension CollectionOfOne {
   /// An iterator that produces one or zero instances of an element.
   ///
   /// `IteratorOverOne` is the iterator for the `CollectionOfOne` type.
-  @_fixed_layout // FIXME(sil-serialize-all)
+  @_fixed_layout // trivial-implementation
   public struct Iterator {
-    @usableFromInline // FIXME(sil-serialize-all)
+    @usableFromInline // trivial-implementation
     internal var _elements: Element?
 
     /// Construct an instance that generates `_element!`, or an empty
     /// sequence if `_element == nil`.
-    @inlinable // FIXME(sil-serialize-all)
+    @inlinable // trivial-implementation
     public // @testable
     init(_elements: Element?) {
       self._elements = _elements
@@ -62,7 +62,7 @@ extension CollectionOfOne.Iterator: IteratorProtocol {
   ///
   /// - Returns: The next element in the underlying sequence, if a next element
   ///   exists; otherwise, `nil`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public mutating func next() -> Element? {
     let result = _elements
     _elements = nil
@@ -88,7 +88,7 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
   /// last valid subscript argument.
   ///
   /// In a `CollectionOfOne` instance, `endIndex` is always `1`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public var endIndex: Index {
     return 1
   }
@@ -97,7 +97,7 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
   ///
   /// - Parameter i: A valid index of the collection. `i` must be `0`.
   /// - Returns: The index value immediately after `i`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public func index(after i: Index) -> Index {
     _precondition(i == startIndex)
     return 1
@@ -107,7 +107,7 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
   ///
   /// - Parameter i: A valid index of the collection. `i` must be `1`.
   /// - Returns: The index value immediately before `i`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public func index(before i: Index) -> Index {
     _precondition(i == endIndex)
     return 0
@@ -116,7 +116,7 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
   /// Returns an iterator over the elements of this collection.
   ///
   /// - Complexity: O(1)
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public func makeIterator() -> Iterator {
     return Iterator(_elements: _element)
   }
@@ -125,7 +125,7 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
   ///
   /// - Parameter position: The position of the element to access. The only
   ///   valid position in a `CollectionOfOne` instance is `0`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public subscript(position: Int) -> Element {
     get {
       _precondition(position == 0, "Index out of range")
@@ -137,7 +137,7 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
     }
   }
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public subscript(bounds: Range<Int>) -> SubSequence {
     get {
       _failEarlyRangeCheck(bounds, bounds: 0..<1)
@@ -152,7 +152,7 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
   }
 
   /// The number of elements in the collection, which is always one.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public var count: Int {
     return 1
   }

--- a/stdlib/public/core/Equatable.swift
+++ b/stdlib/public/core/Equatable.swift
@@ -188,7 +188,7 @@ extension Equatable {
   /// - Parameters:
   ///   - lhs: A value to compare.
   ///   - rhs: Another value to compare.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   @_transparent
   public static func != (lhs: Self, rhs: Self) -> Bool {
     return !(lhs == rhs)

--- a/stdlib/public/core/Indices.swift
+++ b/stdlib/public/core/Indices.swift
@@ -119,7 +119,7 @@ extension Collection where Indices == DefaultIndices<Self> {
   ///         i = c.index(after: i)
   ///     }
   ///     // c == MyFancyCollection([2, 4, 6, 8, 10])
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public var indices: DefaultIndices<Self> {
     return DefaultIndices(
       _elements: self,

--- a/stdlib/public/core/LazyCollection.swift
+++ b/stdlib/public/core/LazyCollection.swift
@@ -29,7 +29,7 @@ public protocol LazyCollectionProtocol: Collection, LazySequenceProtocol {
 
 extension LazyCollectionProtocol {
   // Lazy things are already lazy
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public var lazy: LazyCollection<Elements> {
     return elements.lazy
   }
@@ -37,7 +37,7 @@ extension LazyCollectionProtocol {
 
 extension LazyCollectionProtocol where Elements: LazyCollectionProtocol {
   // Lazy things are already lazy
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public var lazy: Elements {
     return elements
   }

--- a/stdlib/public/core/LazySequence.swift
+++ b/stdlib/public/core/LazySequence.swift
@@ -154,19 +154,19 @@ public protocol LazySequenceProtocol : Sequence {
 /// property is provided.
 extension LazySequenceProtocol where Elements == Self {
   /// Identical to `self`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public var elements: Self { return self }
 }
 
 extension LazySequenceProtocol {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public var lazy: LazySequence<Elements> {
     return elements.lazy
   }
 }
 
 extension LazySequenceProtocol where Elements: LazySequenceProtocol {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public var lazy: Elements {
     return elements
   }
@@ -202,7 +202,7 @@ extension Sequence {
   /// A sequence containing the same elements as this sequence,
   /// but on which some operations, such as `map` and `filter`, are
   /// implemented lazily.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public var lazy: LazySequence<Self> {
     return LazySequence(_base: self)
   }

--- a/stdlib/public/core/RandomAccessCollection.swift
+++ b/stdlib/public/core/RandomAccessCollection.swift
@@ -195,7 +195,7 @@ where Index : Strideable,
   /// - Parameter i: A valid index of the collection. `i` must be greater than
   ///   `startIndex`.
   /// - Returns: The index value immediately before `i`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public func index(before i: Index) -> Index {
     let result = i.advanced(by: -1)
     // FIXME: swift-3-indexing-model: tests for the trap.

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -644,7 +644,7 @@ extension Comparable {
   /// - Parameters:
   ///   - minimum: The lower bound for the range.
   ///   - maximum: The upper bound for the range.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   @_transparent
   public static func ..< (minimum: Self, maximum: Self) -> Range<Self> {
     _precondition(minimum <= maximum,
@@ -674,7 +674,7 @@ extension Comparable {
   ///     // Prints "[10, 20, 30]"
   ///
   /// - Parameter maximum: The upper bound for the range.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   @_transparent
   public static prefix func ..< (maximum: Self) -> PartialRangeUpTo<Self> {
     return PartialRangeUpTo(maximum)
@@ -702,7 +702,7 @@ extension Comparable {
   ///     // Prints "[10, 20, 30, 40]"
   ///
   /// - Parameter maximum: The upper bound for the range.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   @_transparent
   public static prefix func ... (maximum: Self) -> PartialRangeThrough<Self> {
     return PartialRangeThrough(maximum)
@@ -730,7 +730,7 @@ extension Comparable {
   ///     // Prints "[40, 50, 60, 70]"
   ///
   /// - Parameter minimum: The lower bound for the range.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   @_transparent
   public static postfix func ... (minimum: Self) -> PartialRangeFrom<Self> {
     return PartialRangeFrom(minimum)

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -303,7 +303,7 @@ extension Range: RangeExpression {
   ///   is *not* guaranteed to be inside the bounds of `collection`. Callers
   ///   should apply the same preconditions to the return value as they would
   ///   to a range provided directly by the user.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public func relative<C: Collection>(to collection: C) -> Range<Bound>
   where C.Index == Bound {
     return Range(uncheckedBounds: (lower: lowerBound, upper: upperBound))
@@ -329,7 +329,7 @@ extension Range {
   ///
   /// - Parameter limits: The range to clamp the bounds of this range.
   /// - Returns: A new range clamped to the bounds of `limits`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   @inline(__always)
   public func clamped(to limits: Range) -> Range {
     let lower =         
@@ -346,7 +346,7 @@ extension Range {
 
 extension Range : CustomStringConvertible {
   /// A textual representation of the range.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public var description: String {
     return "\(lowerBound)..<\(upperBound)"
   }
@@ -430,19 +430,19 @@ extension Range: Hashable where Bound: Hashable {
 public struct PartialRangeUpTo<Bound: Comparable> {
   public let upperBound: Bound
   
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public init(_ upperBound: Bound) { self.upperBound = upperBound }
 }
 
 extension PartialRangeUpTo: RangeExpression {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   @_transparent
   public func relative<C: Collection>(to collection: C) -> Range<Bound>
   where C.Index == Bound {
     return collection.startIndex..<self.upperBound
   }
   
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   @_transparent
   public func contains(_ element: Bound) -> Bool {
     return element < upperBound
@@ -474,18 +474,18 @@ extension PartialRangeUpTo: RangeExpression {
 public struct PartialRangeThrough<Bound: Comparable> {  
   public let upperBound: Bound
   
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public init(_ upperBound: Bound) { self.upperBound = upperBound }
 }
 
 extension PartialRangeThrough: RangeExpression {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   @_transparent
   public func relative<C: Collection>(to collection: C) -> Range<Bound>
   where C.Index == Bound {
     return collection.startIndex..<collection.index(after: self.upperBound)
   }
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   @_transparent
   public func contains(_ element: Bound) -> Bool {
     return element <= upperBound
@@ -577,19 +577,19 @@ extension PartialRangeThrough: RangeExpression {
 public struct PartialRangeFrom<Bound: Comparable> {
   public let lowerBound: Bound
 
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public init(_ lowerBound: Bound) { self.lowerBound = lowerBound }
 }
 
 extension PartialRangeFrom: RangeExpression {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   @_transparent
   public func relative<C: Collection>(
     to collection: C
   ) -> Range<Bound> where C.Index == Bound {
     return self.lowerBound..<collection.endIndex
   }
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public func contains(_ element: Bound) -> Bool {
     return lowerBound <= element
   }

--- a/stdlib/public/core/Repeat.swift
+++ b/stdlib/public/core/Repeat.swift
@@ -45,7 +45,7 @@ extension Repeated: RandomAccessCollection {
 
   /// Creates an instance that contains `count` elements having the
   /// value `repeatedValue`.
-  @inlinable
+  @inlinable // trivial-implementation
   internal init(_repeating repeatedValue: Element, count: Int) {
     _precondition(count >= 0, "Repetition count should be non-negative")
     self.count = count
@@ -56,7 +56,7 @@ extension Repeated: RandomAccessCollection {
   ///
   /// In a `Repeated` collection, `startIndex` is always equal to zero. If the
   /// collection is empty, `startIndex` is equal to `endIndex`.
-  @inlinable
+  @inlinable // trivial-implementation
   public var startIndex: Index {
     return 0
   }
@@ -66,7 +66,7 @@ extension Repeated: RandomAccessCollection {
   ///
   /// In a `Repeated` collection, `endIndex` is always equal to `count`. If the
   /// collection is empty, `endIndex` is equal to `startIndex`.
-  @inlinable
+  @inlinable // trivial-implementation
   public var endIndex: Index {
     return count
   }
@@ -76,7 +76,7 @@ extension Repeated: RandomAccessCollection {
   /// - Parameter position: The position of the element to access. `position`
   ///   must be a valid index of the collection that is not equal to the
   ///   `endIndex` property.
-  @inlinable
+  @inlinable // trivial-implementation
   public subscript(position: Int) -> Element {
     _precondition(position >= 0 && position < count, "Index out of range")
     return repeatedValue
@@ -103,7 +103,7 @@ extension Repeated: RandomAccessCollection {
 ///   - count: The number of times to repeat `element`.
 /// - Returns: A collection that contains `count` elements that are all
 ///   `element`.
-@inlinable
+@inlinable // trivial-implementation
 public func repeatElement<T>(_ element: T, count n: Int) -> Repeated<T> {
   return Repeated(_repeating: element, count: n)
 }

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -22,7 +22,7 @@ extension MutableCollection where Self: BidirectionalCollection {
   ///
   /// - Complexity: O(*n*), where *n* is the number of elements in the
   ///   collection.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public mutating func reverse() {
     if isEmpty { return }
     var f = startIndex

--- a/stdlib/public/core/SequenceAlgorithms.swift
+++ b/stdlib/public/core/SequenceAlgorithms.swift
@@ -61,7 +61,7 @@ extension Sequence {
   ///     // Prints "Mateo"
   ///
   /// - Returns: A sequence of pairs enumerating the sequence.
-  @inlinable
+  @inlinable // protocol-only
   public func enumerated() -> EnumeratedSequence<Self> {
     return EnumeratedSequence(_base: self)
   }
@@ -102,7 +102,7 @@ extension Sequence {
   /// - Returns: The sequence's minimum element, according to
   ///   `areInIncreasingOrder`. If the sequence has no elements, returns
   ///   `nil`.
-  @inlinable
+  @inlinable // protocol-only
   @warn_unqualified_access
   public func min(
     by areInIncreasingOrder: (Element, Element) throws -> Bool
@@ -144,7 +144,7 @@ extension Sequence {
   ///   otherwise, `false`.
   /// - Returns: The sequence's maximum element if the sequence is not empty;
   ///   otherwise, `nil`.
-  @inlinable
+  @inlinable // protocol-only
   @warn_unqualified_access
   public func max(
     by areInIncreasingOrder: (Element, Element) throws -> Bool
@@ -742,7 +742,7 @@ extension Sequence {
   ///
   /// - Complexity: O(*m* + *n*), where *m* is the length of this sequence
   ///   and *n* is the length of the result.
-  @inlinable
+  @inlinable // protocol-only
   public func compactMap<ElementOfResult>(
     _ transform: (Element) throws -> ElementOfResult?
   ) rethrows -> [ElementOfResult] {
@@ -752,7 +752,7 @@ extension Sequence {
   // The implementation of flatMap accepting a closure with an optional result.
   // Factored out into a separate functions in order to be used in multiple
   // overloads.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   @inline(__always)
   public func _compactMap<ElementOfResult>(
     _ transform: (Element) throws -> ElementOfResult?

--- a/stdlib/public/core/SetAlgebra.swift
+++ b/stdlib/public/core/SetAlgebra.swift
@@ -405,7 +405,7 @@ extension SetAlgebra {
   ///     // Prints "[6, 0, 1, 3]"
   ///
   /// - Parameter sequence: The elements to use as members of the new set.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public init<S : Sequence>(_ sequence: S)
     where S.Element == Element {
     self.init()
@@ -425,7 +425,7 @@ extension SetAlgebra {
   ///     // Prints "["Diana", "Chris", "Alicia"]"
   ///
   /// - Parameter other: A set of the same type as the current set.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public mutating func subtract(_ other: Self) {
     self.formIntersection(self.symmetricDifference(other))
   }
@@ -443,7 +443,7 @@ extension SetAlgebra {
   ///
   /// - Parameter other: A set of the same type as the current set.
   /// - Returns: `true` if the set is a subset of `other`; otherwise, `false`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public func isSubset(of other: Self) -> Bool {
     return self.intersection(other) == self
   }
@@ -462,7 +462,7 @@ extension SetAlgebra {
   /// - Parameter other: A set of the same type as the current set.
   /// - Returns: `true` if the set is a superset of `other`; otherwise,
   ///   `false`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public func isSuperset(of other: Self) -> Bool {
     return other.isSubset(of: self)
   }
@@ -481,7 +481,7 @@ extension SetAlgebra {
   /// - Parameter other: A set of the same type as the current set.
   /// - Returns: `true` if the set has no elements in common with `other`;
   ///   otherwise, `false`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public func isDisjoint(with other: Self) -> Bool {
     return self.intersection(other).isEmpty
   }
@@ -500,13 +500,13 @@ extension SetAlgebra {
   ///
   /// - Parameter other: A set of the same type as the current set.
   /// - Returns: A new set.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public func subtracting(_ other: Self) -> Self {
     return self.intersection(self.symmetricDifference(other))
   }
 
   /// A Boolean value that indicates whether the set has no elements.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public var isEmpty: Bool {
     return self == Self()
   }
@@ -530,7 +530,7 @@ extension SetAlgebra {
   /// - Parameter other: A set of the same type as the current set.
   /// - Returns: `true` if the set is a strict superset of `other`; otherwise,
   ///   `false`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public func isStrictSuperset(of other: Self) -> Bool {
     return self.isSuperset(of: other) && self != other
   }
@@ -554,7 +554,7 @@ extension SetAlgebra {
   /// - Parameter other: A set of the same type as the current set.
   /// - Returns: `true` if the set is a strict subset of `other`; otherwise,
   ///   `false`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public func isStrictSubset(of other: Self) -> Bool {
     return other.isStrictSuperset(of: self)
   }
@@ -579,7 +579,7 @@ extension SetAlgebra where Element == ArrayLiteralElement {
   ///     // Prints "Whatever it is, it's bound to be delicious!"
   ///
   /// - Parameter arrayLiteral: A list of elements of the new set.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // protocol-only
   public init(arrayLiteral: Element...) {
     self.init(arrayLiteral)
   }  

--- a/stdlib/public/core/Stride.swift.gyb
+++ b/stdlib/public/core/Stride.swift.gyb
@@ -226,7 +226,7 @@ extension ${Base} {
 //===----------------------------------------------------------------------===//
 
 extension Strideable {
-  @inlinable
+  @inlinable // protocol-only
   public static func _step(
     after current: (index: Int?, value: Self),
     from start: Self, by distance: Self.Stride
@@ -236,7 +236,7 @@ extension Strideable {
 }
 
 extension Strideable where Stride : FloatingPoint {
-  @inlinable
+  @inlinable // protocol-only
   public static func _step(
     after current: (index: Int?, value: Self),
     from start: Self, by distance: Self.Stride
@@ -251,7 +251,7 @@ extension Strideable where Stride : FloatingPoint {
 }
 
 extension Strideable where Self : FloatingPoint, Self == Stride {
-  @inlinable
+  @inlinable // protocol-only
   public static func _step(
     after current: (index: Int?, value: Self),
     from start: Self, by distance: Self.Stride

--- a/stdlib/public/core/StringIndexConversions.swift
+++ b/stdlib/public/core/StringIndexConversions.swift
@@ -79,7 +79,7 @@ extension String.Index {
   ///   If this index does not have an exact corresponding position in `utf8`,
   ///   this method returns `nil`. For example, an attempt to convert the
   ///   position of a UTF-16 trailing surrogate returns `nil`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public func samePosition(
     in utf8: String.UTF8View
   ) -> String.UTF8View.Index? {
@@ -108,7 +108,7 @@ extension String.Index {
   ///   index. If this index does not have an exact corresponding position in
   ///   `utf16`, this method returns `nil`. For example, an attempt to convert
   ///   the position of a UTF-8 continuation byte returns `nil`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // trivial-implementation
   public func samePosition(
     in utf16: String.UTF16View
   ) -> String.UTF16View.Index? {

--- a/stdlib/public/core/Tuple.swift.gyb
+++ b/stdlib/public/core/Tuple.swift.gyb
@@ -132,7 +132,7 @@ public func >=(lhs: (), rhs: ()) -> Bool {
 /// - Parameters:
 ///   - lhs: A tuple of `Equatable` elements.
 ///   - rhs: Another tuple of elements of the same type as `lhs`.
-@inlinable // FIXME(sil-serialize-all)
+@inlinable // trivial-implementation
 public func == <${equatableTypeParams}>(lhs: ${tupleT}, rhs: ${tupleT}) -> Bool {
   guard lhs.0 == rhs.0 else { return false }
   /*tail*/ return (
@@ -161,7 +161,7 @@ public func == <${equatableTypeParams}>(lhs: ${tupleT}, rhs: ${tupleT}) -> Bool 
 /// - Parameters:
 ///   - lhs: A tuple of `Equatable` elements.
 ///   - rhs: Another tuple of elements of the same type as `lhs`.
-@inlinable // FIXME(sil-serialize-all)
+@inlinable // trivial-implementation
 public func != <${equatableTypeParams}>(lhs: ${tupleT}, rhs: ${tupleT}) -> Bool {
   guard lhs.0 == rhs.0 else { return true }
   /*tail*/ return (
@@ -184,7 +184,7 @@ public func != <${equatableTypeParams}>(lhs: ${tupleT}, rhs: ${tupleT}) -> Bool 
 /// - Parameters:
 ///   - lhs: A tuple of `Comparable` elements.
 ///   - rhs: Another tuple of elements of the same type as `lhs`.
-@inlinable // FIXME(sil-serialize-all)
+@inlinable // trivial-implementation
 public func ${op} <${comparableTypeParams}>(lhs: ${tupleT}, rhs: ${tupleT}) -> Bool {
   if lhs.0 != rhs.0 { return lhs.0 ${op} rhs.0 }
   /*tail*/ return (

--- a/stdlib/public/core/Tuple.swift.gyb
+++ b/stdlib/public/core/Tuple.swift.gyb
@@ -31,7 +31,7 @@ comparableOperators = [
 /// - Parameters:
 ///   - lhs: An empty tuple.
 ///   - rhs: An empty tuple.
-@inlinable // FIXME(sil-serialize-all)
+@inlinable // trivial-implementation
 public func ==(lhs: (), rhs: ()) -> Bool {
   return true
 }
@@ -44,7 +44,7 @@ public func ==(lhs: (), rhs: ()) -> Bool {
 /// - Parameters:
 ///   - lhs: An empty tuple.
 ///   - rhs: An empty tuple.
-@inlinable // FIXME(sil-serialize-all)
+@inlinable // trivial-implementation
 public func !=(lhs: (), rhs: ()) -> Bool {
     return false
 }
@@ -58,7 +58,7 @@ public func !=(lhs: (), rhs: ()) -> Bool {
 /// - Parameters:
 ///   - lhs: An empty tuple.
 ///   - rhs: An empty tuple.
-@inlinable // FIXME(sil-serialize-all)
+@inlinable // trivial-implementation
 public func <(lhs: (), rhs: ()) -> Bool {
     return false
 }
@@ -72,7 +72,7 @@ public func <(lhs: (), rhs: ()) -> Bool {
 /// - Parameters:
 ///   - lhs: An empty tuple.
 ///   - rhs: An empty tuple.
-@inlinable // FIXME(sil-serialize-all)
+@inlinable // trivial-implementation
 public func <=(lhs: (), rhs: ()) -> Bool {
     return true
 }
@@ -86,7 +86,7 @@ public func <=(lhs: (), rhs: ()) -> Bool {
 /// - Parameters:
 ///   - lhs: An empty tuple.
 ///   - rhs: An empty tuple.
-@inlinable // FIXME(sil-serialize-all)
+@inlinable // trivial-implementation
 public func >(lhs: (), rhs: ()) -> Bool {
     return false
 }
@@ -100,7 +100,7 @@ public func >(lhs: (), rhs: ()) -> Bool {
 /// - Parameters:
 ///   - lhs: An empty tuple.
 ///   - rhs: An empty tuple.
-@inlinable // FIXME(sil-serialize-all)
+@inlinable // trivial-implementation
 public func >=(lhs: (), rhs: ()) -> Bool {
     return true
 }

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -32,7 +32,7 @@
 // FIXME: rdar://18157434 - until this is fixed, this has to be fixed layout
 // to avoid a hang in Foundation, which has the following setup:
 // struct A { struct B { let x: UnsafeMutableBufferPointer<...> } let b: B }
-@_fixed_layout
+@_fixed_layout // unsafe-performance
 public struct Unsafe${Mutable}BufferPointer<Element> {
 
   @usableFromInline
@@ -49,12 +49,12 @@ public struct Unsafe${Mutable}BufferPointer<Element> {
 extension UnsafeBufferPointer {
   /// An iterator for the elements in the buffer referenced by an
   /// `UnsafeBufferPointer` or `UnsafeMutableBufferPointer` instance.
-  @_fixed_layout
+  @_fixed_layout // unsafe-performance
   public struct Iterator {
     @usableFromInline
     internal var _position, _end: UnsafePointer<Element>?
 
-    @inlinable
+    @inlinable // unsafe-performance
     public init(_position: UnsafePointer<Element>?, _end: UnsafePointer<Element>?) {
         self._position = _position
         self._end = _end
@@ -67,7 +67,7 @@ extension UnsafeBufferPointer.Iterator: IteratorProtocol {
   /// exists.
   ///
   /// Once `nil` has been returned, all subsequent calls return `nil`.
-  @inlinable
+  @inlinable // unsafe-performance
   public mutating func next() -> Element? {
     guard let start = _position else {
       return nil
@@ -91,7 +91,7 @@ extension Unsafe${Mutable}BufferPointer: Sequence {
   /// Returns an iterator over the elements of this buffer.
   ///
   /// - Returns: An iterator over the elements of this buffer.
-  @inlinable
+  @inlinable // unsafe-performance
   public func makeIterator() -> Iterator {
     guard let start = _position else {
       return Iterator(_position: nil, _end: nil)
@@ -104,7 +104,7 @@ extension Unsafe${Mutable}BufferPointer: Sequence {
   ///
   /// - Returns: an iterator over any remaining elements of `self` and the
   ///   number of elements initialized.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   public func _copyContents(
     initializing destination: UnsafeMutableBufferPointer<Element>
   ) -> (Iterator, UnsafeMutableBufferPointer<Element>.Index) {
@@ -125,7 +125,7 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
   ///
   /// The `startIndex` property of an `Unsafe${Mutable}BufferPointer` instance
   /// is always zero.
-  @inlinable
+  @inlinable // unsafe-performance
   public var startIndex: Int { return 0 }
 
   /// The "past the end" position---that is, the position one greater than the
@@ -133,10 +133,10 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
   ///
   /// The `endIndex` property of an `Unsafe${Mutable}BufferPointer` instance is
   /// always identical to `count`.
-  @inlinable
+  @inlinable // unsafe-performance
   public var endIndex: Int { return count }
 
-  @inlinable
+  @inlinable // unsafe-performance
   public func index(after i: Int) -> Int {
     // NOTE: this is a manual specialization of index movement for a Strideable
     // index that is required for UnsafeBufferPointer performance. The
@@ -146,7 +146,7 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     return i + 1
   }
 
-  @inlinable
+  @inlinable // unsafe-performance
   public func formIndex(after i: inout Int) {
     // NOTE: this is a manual specialization of index movement for a Strideable
     // index that is required for UnsafeBufferPointer performance. The
@@ -156,7 +156,7 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     i += 1
   }
 
-  @inlinable
+  @inlinable // unsafe-performance
   public func index(before i: Int) -> Int {
     // NOTE: this is a manual specialization of index movement for a Strideable
     // index that is required for UnsafeBufferPointer performance. The
@@ -166,7 +166,7 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     return i - 1
   }
 
-  @inlinable
+  @inlinable // unsafe-performance
   public func formIndex(before i: inout Int) {
     // NOTE: this is a manual specialization of index movement for a Strideable
     // index that is required for UnsafeBufferPointer performance. The
@@ -176,7 +176,7 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     i -= 1
   }
 
-  @inlinable
+  @inlinable // unsafe-performance
   public func index(_ i: Int, offsetBy n: Int) -> Int {
     // NOTE: this is a manual specialization of index movement for a Strideable
     // index that is required for UnsafeBufferPointer performance. The
@@ -186,7 +186,7 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     return i + n
   }
 
-  @inlinable
+  @inlinable // unsafe-performance
   public func index(_ i: Int, offsetBy n: Int, limitedBy limit: Int) -> Int? {
     // NOTE: this is a manual specialization of index movement for a Strideable
     // index that is required for UnsafeBufferPointer performance. The
@@ -200,7 +200,7 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     return i + n
   }
 
-  @inlinable
+  @inlinable // unsafe-performance
   public func distance(from start: Int, to end: Int) -> Int {
     // NOTE: this is a manual specialization of index movement for a Strideable
     // index that is required for UnsafeBufferPointer performance. The
@@ -210,21 +210,21 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
     return end - start
   }
 
-  @inlinable
+  @inlinable // unsafe-performance
   public func _failEarlyRangeCheck(_ index: Int, bounds: Range<Int>) {
     // NOTE: In release mode, this method is a no-op for performance reasons.
     _debugPrecondition(index >= bounds.lowerBound)
     _debugPrecondition(index < bounds.upperBound)
   }
 
-  @inlinable
+  @inlinable // unsafe-performance
   public func _failEarlyRangeCheck(_ range: Range<Int>, bounds: Range<Int>) {
     // NOTE: In release mode, this method is a no-op for performance reasons.
     _debugPrecondition(range.lowerBound >= bounds.lowerBound)
     _debugPrecondition(range.upperBound <= bounds.upperBound)
   }
 
-  @inlinable
+  @inlinable // unsafe-performance
   public var indices: Indices {
     return startIndex..<endIndex
   }
@@ -265,7 +265,7 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
   ///
   /// - Parameter i: The position of the element to access. `i` must be in the
   ///   range `0..<count`.
-  @inlinable
+  @inlinable // unsafe-performance
   public subscript(i: Int) -> Element {
     get {
       _debugPrecondition(i >= 0)
@@ -318,7 +318,7 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
   ///
   /// - Parameter bounds: A range of the buffer's indices. The bounds of
   ///   the range must be valid indices of the buffer.
-  @inlinable
+  @inlinable // unsafe-performance
   public subscript(bounds: Range<Int>)
     -> Slice<Unsafe${Mutable}BufferPointer<Element>>
   {
@@ -354,7 +354,7 @@ extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessColle
   /// - Parameters:
   ///   - i: The index of the first value to swap.
   ///   - j: The index of the second value to swap.
-  @inlinable
+  @inlinable // unsafe-performance
   public func swapAt(_ i: Int, _ j: Int) {
     guard i != j else { return }
     _debugPrecondition(i >= 0 && j >= 0)
@@ -379,7 +379,7 @@ extension Unsafe${Mutable}BufferPointer {
   ///     `MemoryLayout<Element>.alignment`.
   ///   - count: The number of instances in the buffer. `count` must not be
   ///     negative.
-  @inlinable
+  @inlinable // unsafe-performance
   public init(start: Unsafe${Mutable}Pointer<Element>?, count: Int) {
     _precondition(
       count >= 0, "Unsafe${Mutable}BufferPointer with negative count")
@@ -390,7 +390,7 @@ extension Unsafe${Mutable}BufferPointer {
     self.count = count
   }
 
-  @inlinable
+  @inlinable // unsafe-performance
   public init(_empty: ()) {
     _position = nil
     count = 0
@@ -402,7 +402,7 @@ extension Unsafe${Mutable}BufferPointer {
   /// given immutable buffer pointer.
   ///
   /// - Parameter other: The immutable buffer pointer to convert.
-  @inlinable
+  @inlinable // unsafe-performance
   public init(mutating other: UnsafeBufferPointer<Element>) {
     _position = UnsafeMutablePointer<Element>(mutating: other._position)
     count = other.count
@@ -414,7 +414,7 @@ extension Unsafe${Mutable}BufferPointer {
   /// given mutable buffer pointer.
   ///
   /// - Parameter other: The mutable buffer pointer to convert.
-  @inlinable
+  @inlinable // unsafe-performance
   public init(_ other: UnsafeMutableBufferPointer<Element>) {
     _position = UnsafePointer<Element>(other._position)
     count = other.count
@@ -443,7 +443,7 @@ extension Unsafe${Mutable}BufferPointer {
   /// - `rebased.count == slice.count`
   ///
   /// - Parameter slice: The buffer slice to rebase.
-  @inlinable
+  @inlinable // unsafe-performance
   public init(rebasing slice: Slice<UnsafeBufferPointer<Element>>) {
     self.init(start: slice.base.baseAddress! + slice.startIndex,
       count: slice.count)
@@ -470,7 +470,7 @@ extension Unsafe${Mutable}BufferPointer {
   /// - `rebased.count == slice.count`
   ///
   /// - Parameter slice: The buffer slice to rebase.
-  @inlinable
+  @inlinable // unsafe-performance
   public init(rebasing slice: Slice<UnsafeMutableBufferPointer<Element>>) {
     self.init(
       start: slice.base.baseAddress! + slice.startIndex,
@@ -485,7 +485,7 @@ extension Unsafe${Mutable}BufferPointer {
   /// `nil`, this function does nothing. Otherwise, the memory must not be initialized 
   /// or `Pointee` must be a trivial type. This buffer pointer's `count` must 
   /// be equal to the originally allocated size of the memory block.
-  @inlinable
+  @inlinable // unsafe-performance
   public func deallocate() {
     _position?.deallocate()
   }
@@ -513,7 +513,7 @@ extension Unsafe${Mutable}BufferPointer {
   ///
   /// - Parameter count: The amount of memory to allocate, counted in instances
   ///   of `Element`. 
-  @inlinable
+  @inlinable // unsafe-performance
   public static func allocate(capacity count: Int) 
     -> UnsafeMutableBufferPointer<Element> {
     let size = MemoryLayout<Element>.stride * count
@@ -531,7 +531,7 @@ extension Unsafe${Mutable}BufferPointer {
   ///
   /// - Parameters:
   ///   - repeatedValue: The instance to initialize this buffer's memory with.
-  @inlinable
+  @inlinable // unsafe-performance
   public func initialize(repeating repeatedValue: Element) {
     guard let dstBase = _position else {
       return
@@ -551,7 +551,7 @@ extension Unsafe${Mutable}BufferPointer {
   /// Warning: All buffer elements must be initialized before calling this. 
   /// Assigning to part of the buffer must be done using the `assign(repeating:count:)`` 
   /// method on the buffer’s `baseAddress`. 
-  @inlinable
+  @inlinable // unsafe-performance
   public func assign(repeating repeatedValue: Element) {
     guard let dstBase = _position else {
       return
@@ -600,7 +600,7 @@ extension Unsafe${Mutable}BufferPointer {
   ///     value is also used as the return value for the `withMemoryRebound(to:_:)` 
   ///     method.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  @inlinable
+  @inlinable // unsafe-performance
   public func withMemoryRebound<T, Result>(
     to type: T.Type, _ body: (${Self}<T>) throws -> Result
   ) rethrows -> Result {
@@ -623,7 +623,7 @@ extension Unsafe${Mutable}BufferPointer {
   ///
   /// If the `baseAddress` of this buffer is `nil`, the count is zero. However,
   /// a buffer can have a `count` of zero even with a non-`nil` base address.
-  @inlinable
+  @inlinable // unsafe-performance
   public var baseAddress: Unsafe${Mutable}Pointer<Element>? {
     return _position
   }
@@ -660,7 +660,7 @@ extension UnsafeMutableBufferPointer {
   /// - Returns: An iterator to any elements of `source` that didn't fit in the
   ///   buffer, and an index to the point in the buffer one past the last
   ///   element written.
-  @inlinable
+  @inlinable // unsafe-performance
   public func initialize<S: Sequence>(from source: S) -> (S.Iterator, Index)
     where S.Element == Element {
     return source._copyContents(initializing: self)

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -271,7 +271,7 @@
 ///       var number = 5
 ///       let numberPointer = Unsafe${Mutable}Pointer<Int>(&number)
 ///       // Accessing 'numberPointer' is undefined behavior.
-@_fixed_layout
+@_fixed_layout // unsafe-performance
 public struct ${Self}<Pointee>: _Pointer {
 
   /// A type that represents the distance between two pointers.
@@ -281,7 +281,7 @@ public struct ${Self}<Pointee>: _Pointer {
   public let _rawValue: Builtin.RawPointer
 
   /// Creates ${a_Self} from a builtin raw pointer.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   @_transparent
   public init(_ _rawValue : Builtin.RawPointer) {
     self._rawValue = _rawValue
@@ -290,7 +290,7 @@ public struct ${Self}<Pointee>: _Pointer {
   /// Creates a new typed pointer from the given opaque pointer.
   ///
   /// - Parameter from: The opaque pointer to convert to a typed pointer.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   @_transparent
   public init(_ from : OpaquePointer) {
     _rawValue = from._rawValue
@@ -300,7 +300,7 @@ public struct ${Self}<Pointee>: _Pointer {
   ///
   /// - Parameter from: The opaque pointer to convert to a typed pointer. If
   ///   `from` is `nil`, the result of this initializer is `nil`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   @_transparent
   public init?(_ from : OpaquePointer?) {
     guard let unwrapped = from else { return nil }
@@ -316,7 +316,7 @@ public struct ${Self}<Pointee>: _Pointer {
   ///
   /// - Parameter bitPattern: A bit pattern to use for the address of the new
   ///   pointer. If `bitPattern` is zero, the result is `nil`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   @_transparent
   public init?(bitPattern: Int) {
     if bitPattern == 0 { return nil }
@@ -332,7 +332,7 @@ public struct ${Self}<Pointee>: _Pointer {
   ///
   /// - Parameter bitPattern: A bit pattern to use for the address of the new
   ///   pointer. If `bitPattern` is zero, the result is `nil`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   @_transparent
   public init?(bitPattern: UInt) {
     if bitPattern == 0 { return nil }
@@ -342,7 +342,7 @@ public struct ${Self}<Pointee>: _Pointer {
   /// Creates a new pointer from the given typed pointer.
   ///
   /// - Parameter other: The typed pointer to convert.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   @_transparent
   public init(_ other: ${Self}<Pointee>) {
     self = other
@@ -352,7 +352,7 @@ public struct ${Self}<Pointee>: _Pointer {
   ///
   /// - Parameter other: The typed pointer to convert. If `other` is `nil`, the
   ///   result is `nil`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   @_transparent
   public init?(_ other: ${Self}<Pointee>?) {
     guard let unwrapped = other else { return nil }
@@ -364,7 +364,7 @@ public struct ${Self}<Pointee>: _Pointer {
   /// immutable pointer.
   ///
   /// - Parameter other: The immutable pointer to convert.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   @_transparent
   public init(mutating other: UnsafePointer<Pointee>) {
     self._rawValue = other._rawValue
@@ -375,7 +375,7 @@ public struct ${Self}<Pointee>: _Pointer {
   ///
   /// - Parameter other: The immutable pointer to convert. If `other` is `nil`,
   ///   the result is `nil`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   @_transparent
   public init?(mutating other: UnsafePointer<Pointee>?) {
     guard let unwrapped = other else { return nil }
@@ -386,7 +386,7 @@ public struct ${Self}<Pointee>: _Pointer {
   /// given mutable pointer.
   ///
   /// - Parameter other: The pointer to convert.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   @_transparent
   public init(_ other: UnsafeMutablePointer<Pointee>) {
     self._rawValue = other._rawValue
@@ -397,7 +397,7 @@ public struct ${Self}<Pointee>: _Pointer {
   ///
   /// - Parameter other: The pointer to convert. If `other` is `nil`, the
   ///   result is `nil`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   @_transparent
   public init?(_ other: UnsafeMutablePointer<Pointee>?) {
     guard let unwrapped = other else { return nil }
@@ -462,7 +462,7 @@ public struct ${Self}<Pointee>: _Pointer {
   /// When reading from the `pointee` property, the instance referenced by
   /// this pointer must already be initialized.
 %  end
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   public var pointee: Pointee {
 %  if mutable:
     @_transparent unsafeAddress {
@@ -830,7 +830,7 @@ extension ${Self}: Equatable {
   ///   - rhs: Another pointer.
   /// - Returns: `true` if `lhs` and `rhs` reference the same memory address;
   ///   otherwise, `false`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   @_transparent
   public static func == (lhs: ${Self}<Pointee>, rhs: ${Self}<Pointee>) -> Bool {
     return Bool(Builtin.cmp_eq_RawPointer(lhs._rawValue, rhs._rawValue))
@@ -850,7 +850,7 @@ extension ${Self}: Comparable {
   ///   - rhs: Another pointer.
   /// - Returns: `true` if `lhs` references a memory address earlier than
   ///   `rhs`; otherwise, `false`.
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   @_transparent
   public static func < (lhs: ${Self}<Pointee>, rhs: ${Self}<Pointee>) -> Bool {
     return Bool(Builtin.cmp_ult_RawPointer(lhs._rawValue, rhs._rawValue))
@@ -985,7 +985,7 @@ extension UInt {
   ///
   /// - Parameter pointer: The pointer to use as the source for the new
   ///   integer.
-  @inlinable
+  @inlinable // unsafe-performance
   public init<U>(bitPattern pointer: ${Self}<U>?) {
     if let pointer = pointer {
       self = UInt(Builtin.ptrtoint_Word(pointer._rawValue))
@@ -996,7 +996,7 @@ extension UInt {
 }
 
 extension ${Self} {
-  @inlinable // FIXME(sil-serialize-all)
+  @inlinable // unsafe-performance
   internal static var _max : ${Self} {
     return ${Self}(
       bitPattern: 0 as Int &- MemoryLayout<Pointee>.stride


### PR DESCRIPTION
PR to gather commits auditing the use off inlinable use in the std lib.

`@inlineable` code with a `// FIXME(sil-serialize-all)` comment will be updated with a tag describing why the function should be inlineable such as:

- only uses a protocol interface
- unsafe performance critical
- transparent wrapping of builtin
- trivial implementation of simple types