### PR TITLE
[4.2] Keep more ParenType parameter flags when canonicalizing function types

### DIFF
--- a/lib/AST/Type.cpp
+++ b/lib/AST/Type.cpp
@@ -1061,9 +1061,8 @@ getCanonicalInputType(AnyFunctionType *funcType,
 
   auto flags = ParameterTypeFlags().withInOut(inputType->is<InOutType>());
   if (auto *parenTy = dyn_cast<ParenType>(origInputType.getPointer())) {
-    auto parenFlags = parenTy->getParameterFlags();
-    flags =
-        flags.withShared(parenFlags.isShared()).withOwned(parenFlags.isOwned());
+    flags = parenTy->getParameterFlags().withInOut(flags.isInOut());
+    assert(!flags.isVariadic() && "variadic ParenType");
   }
 
   inputType = ParenType::get(inputType->getASTContext(),

--- a/validation-test/Serialization/Inputs/SR8045-other.swift
+++ b/validation-test/Serialization/Inputs/SR8045-other.swift
@@ -1,0 +1,5 @@
+public typealias Alias<T> = (T) -> ()
+
+public class Super {
+  public func foo(_ f: @escaping Alias<Bool>) {}
+}

--- a/validation-test/Serialization/SR8045.swift
+++ b/validation-test/Serialization/SR8045.swift
@@ -1,0 +1,6 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-module-path %t/main.swiftmodule -module-name main %s %S/Inputs/SR8045-other.swift
+
+public class Sub: Super {
+  public override func foo(_ f: @escaping Alias<Bool>) {}
+}


### PR DESCRIPTION
Cherry-pick of #17369 to the 4.2 branch. Reviewed by @CodaFi.

[SR-8045](https://bugs.swift.org/browse/SR-8045) / rdar://40984769, likely others