### PR TITLE
[stdlib] Don’t use an error for flow control in Sequence.first(where:)

### DIFF
--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -944,12 +944,6 @@ extension Sequence {
   }
 }
 
-@usableFromInline
-@_frozen
-internal enum _StopIteration : Error {
-  case stop
-}
-
 extension Sequence {
   /// Returns the first element of the sequence that satisfies the given
   /// predicate.
@@ -972,16 +966,12 @@ extension Sequence {
   public func first(
     where predicate: (Element) throws -> Bool
   ) rethrows -> Element? {
-    var foundElement: Element?
-    do {
-      try self.forEach {
-        if try predicate($0) {
-          foundElement = $0
-          throw _StopIteration.stop
-        }
+    for element in self  {
+      if try predicate(element) {
+        return element
       }
-    } catch is _StopIteration { }
-    return foundElement
+    }
+    return nil
   }
 }
 


### PR DESCRIPTION
This PR alters the `Sequence.first(where:)` function to remove the use of a thrown error for flow control. When called under Xcode with the "Swift Error Breakpoint" (swift_willThrow) active, it will cause the debugger to stop wherever this API is used, even in a success state. 

Further (amusing) discussion here on Twitter: https://twitter.com/tonyarnold/status/1007510236372979712

Resolves [SR-3166](https://bugs.swift.org/browse/SR-3166).