### PR TITLE
🙅🏼‍♂️ [stdlib] Add method for accessing full storage capacity of array

### DIFF
--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1572,16 +1572,17 @@ extension Array {
   ///       you initialize or deinitialize any elements inside `body`, update
   ///       `initializedCount` with the new count for the array.
   /// - Returns: The return value, if any, of the `body` closure parameter.
-  public mutating func withUnsafeMutableBufferPointerToFullCapacity<R>(
+  @inlinable
+  public mutating func withUnsafeMutableBufferPointerToStorage<R>(
     capacity: Int,
     _ body: (
-      _ buffer: UnsafeMutableBufferPointer<Element>,
+      _ buffer: inout UnsafeMutableBufferPointer<Element>,
       _ initializedCount: inout Int
     ) throws -> R
   ) rethrows -> R {
     // Ensure unique storage and requested capacity
-    reserveCapacity(capacity)
     _precondition(capacity >= self.count)
+    reserveCapacity(capacity)
 
     var initializedCount = self.count
 
@@ -1594,7 +1595,7 @@ extension Array {
     // Create an UnsafeBufferPointer over the full capacity of `work`
     // that we can pass to `body`.
     let pointer = work._buffer.firstElementAddress
-    let bufferPointer = UnsafeMutableBufferPointer(
+    var inoutBufferPointer = UnsafeMutableBufferPointer(
       start: pointer, count: capacity)
 
     // Put the working array back before returning and update the count.
@@ -1604,7 +1605,7 @@ extension Array {
     }
 
     // Invoke the body.
-    return try body(bufferPointer, &initializedCount)
+    return try body(&inoutBufferPointer, &initializedCount)
   }
 }
 

--- a/test/stdlib/Inputs/CommonArrayTests.gyb
+++ b/test/stdlib/Inputs/CommonArrayTests.gyb
@@ -434,9 +434,9 @@ ${Suite}.test("${ArrayType}/init(unsafeUninitializedCapacity:...:)/throwing") {
   expectEqual(0, InstanceCountedClass.instanceCounter)
 }
 
-${Suite}.test("${ArrayType}/withUnsafeMutableBufferPointerToFullCapacity") {
+${Suite}.test("${ArrayType}/withUnsafeMutableBufferPointerToStorage") {
   var a = Array<Int>()
-  let result: Int = a.withUnsafeMutableBufferPointerToFullCapacity(reservingCapacity: 10) {
+  let result: Int = a.withUnsafeMutableBufferPointerToStorage(capacity: 10) {
     buffer, initializedCount in
     expectEqual(10, buffer.count)
     expectEqual(0, initializedCount)
@@ -451,10 +451,10 @@ ${Suite}.test("${ArrayType}/withUnsafeMutableBufferPointerToFullCapacity") {
   expectEqual(5, a.count)
 }
 
-${Suite}.test("${ArrayType}/withUnsafeMutableBufferPointerToFullCapacity/throwing") {
+${Suite}.test("${ArrayType}/withUnsafeMutableBufferPointerToStorage/throwing") {
   do {
     var a = Array<InstanceCountedClass>()
-    a.withUnsafeMutableBufferPointerToFullCapacity(capacity: 10) { buffer, c in
+    a.withUnsafeMutableBufferPointerToStorage(capacity: 10) { buffer, c in
       let p = buffer.baseAddress!
       for i in 0..<5 {
         (p + i).initialize(to: InstanceCountedClass())
@@ -466,7 +466,7 @@ ${Suite}.test("${ArrayType}/withUnsafeMutableBufferPointerToFullCapacity/throwin
 
     a = []
     expectEqual(0, InstanceCountedClass.instanceCounter)
-    try a.withUnsafeMutableBufferPointerToFullCapacity(capacity: 10) { buffer, c in
+    try a.withUnsafeMutableBufferPointerToStorage(capacity: 10) { buffer, c in
       let p = buffer.baseAddress!
       for i in 0..<5 {
         (p + i).initialize(to: InstanceCountedClass())

--- a/test/stdlib/Inputs/CommonArrayTests.gyb
+++ b/test/stdlib/Inputs/CommonArrayTests.gyb
@@ -357,14 +357,14 @@ ${Suite}.test("${ArrayType}/reserveCapacity") {
 }
 
 //===----------------------------------------------------------------------===//
-// init(_unsafeUninitializedCapacity:initializingWith:)
+// init(unsafeUninitializedCapacity:initializingWith:)
 //===----------------------------------------------------------------------===//
 
 extension Collection {
   func stablyPartitioned(
     by belongsInFirstPartition: (Element) -> Bool
   ) -> ${ArrayType}<Element> {
-    let result = ${ArrayType}<Element>(_unsafeUninitializedCapacity: self.count) {
+    let result = ${ArrayType}<Element>(unsafeUninitializedCapacity: self.count) {
       buffer, initializedCount in
       var lowIndex = 0
       var highIndex = buffer.count
@@ -385,7 +385,15 @@ extension Collection {
   }
 }
 
-${Suite}.test("${ArrayType}/init(_unsafeUninitializedCapacity:...:)") {
+final class InstanceCountedClass {
+  static var instanceCounter = 0
+
+  init() { InstanceCountedClass.instanceCounter += 1 }
+  deinit { InstanceCountedClass.instanceCounter -= 1 }
+}
+enum E: Error { case error }
+
+${Suite}.test("${ArrayType}/init(unsafeUninitializedCapacity:...:)") {
   var a = ${ArrayType}(0..<300)
   let p = a.stablyPartitioned(by: { $0 % 2 == 0 })
   expectEqualSequence(
@@ -394,17 +402,9 @@ ${Suite}.test("${ArrayType}/init(_unsafeUninitializedCapacity:...:)") {
   )
 }
 
-${Suite}.test("${ArrayType}/init(_unsafeUninitializedCapacity:...:)/throwing") {
-  final class InstanceCountedClass {
-    static var instanceCounter = 0
-
-    init() { InstanceCountedClass.instanceCounter += 1 }
-    deinit { InstanceCountedClass.instanceCounter -= 1 }
-  }
-  enum E: Error { case error }
-
+${Suite}.test("${ArrayType}/init(unsafeUninitializedCapacity:...:)/throwing") {
   do {
-    var a = Array<InstanceCountedClass>(_unsafeUninitializedCapacity: 10) { buffer, c in
+    var a = Array<InstanceCountedClass>(unsafeUninitializedCapacity: 10) { buffer, c in
       let p = buffer.baseAddress!
       for i in 0..<5 {
         (p + i).initialize(to: InstanceCountedClass())
@@ -417,7 +417,7 @@ ${Suite}.test("${ArrayType}/init(_unsafeUninitializedCapacity:...:)/throwing") {
     a = []
     expectEqual(0, InstanceCountedClass.instanceCounter)
 
-    a = try Array(_unsafeUninitializedCapacity: 10) { buffer, c in
+    a = try Array(unsafeUninitializedCapacity: 10) { buffer, c in
       let p = buffer.baseAddress!
       for i in 0..<5 {
         (p + i).initialize(to: InstanceCountedClass())
@@ -429,7 +429,56 @@ ${Suite}.test("${ArrayType}/init(_unsafeUninitializedCapacity:...:)/throwing") {
     // The throw above should prevent reaching here, which should mean the
     // instances created in the closure should get deallocated before the final
     // expectation outside the do/catch block.
-    expectTrue(false)
+    expectUnreachable()
+  } catch {}
+  expectEqual(0, InstanceCountedClass.instanceCounter)
+}
+
+${Suite}.test("${ArrayType}/withUnsafeMutableBufferPointerToFullCapacity") {
+  var a = Array<Int>()
+  let result: Int = a.withUnsafeMutableBufferPointerToFullCapacity(reservingCapacity: 10) {
+    buffer, initializedCount in
+    expectEqual(10, buffer.count)
+    expectEqual(0, initializedCount)
+
+    for i in 0..<5 {
+      buffer[i] = i
+    }
+    initializedCount = 5
+    return buffer[0..<5].reduce(0, +)
+  }
+  expectEqual(10, a.reduce(0, +))
+  expectEqual(5, a.count)
+}
+
+${Suite}.test("${ArrayType}/withUnsafeMutableBufferPointerToFullCapacity/throwing") {
+  do {
+    var a = Array<InstanceCountedClass>()
+    a.withUnsafeMutableBufferPointerToFullCapacity(capacity: 10) { buffer, c in
+      let p = buffer.baseAddress!
+      for i in 0..<5 {
+        (p + i).initialize(to: InstanceCountedClass())
+      }
+      c = 5
+    }
+    expectEqual(5, a.count)
+    expectEqual(5, InstanceCountedClass.instanceCounter)
+
+    a = []
+    expectEqual(0, InstanceCountedClass.instanceCounter)
+    try a.withUnsafeMutableBufferPointerToFullCapacity(capacity: 10) { buffer, c in
+      let p = buffer.baseAddress!
+      for i in 0..<5 {
+        (p + i).initialize(to: InstanceCountedClass())
+      }
+      c = 5
+      throw E.error
+    }
+
+    // The throw above should prevent reaching here, which means that the
+    // instances created in the closure should get deallocated before the final
+    // expectation outside the do/catch block.
+    expectUnreachable()
   } catch {}
   expectEqual(0, InstanceCountedClass.instanceCounter)
 }


### PR DESCRIPTION
This is an implementation of a `withUnsafeMutableBufferPointerToStorage` method and `init(unsafeUninitializedCapacity:initializingWith:)` for arrays. Under review here: https://forums.swift.org/t/se-0223-accessing-an-arrays-uninitialized-buffer/15194

To do:
- [ ] Check inlining annotations
- [ ] Add `@_semantics` attributes?
- [ ] Revise documentation
- [ ] Duplicate onto `ContiguousArray`

Resolves #45677.