### PR TITLE
[WIP] Report detailed build version from Benchmark drivers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ compile_commands.json
 SortedCFDatabase.def
 htmlcov
 .coverage
+/benchmark/utils/Version.swift
+/benchmark/.build

--- a/benchmark/Package.swift
+++ b/benchmark/Package.swift
@@ -56,7 +56,7 @@ let p = Package(
     .target(name: "DriverUtils",
       dependencies: [.target(name: "TestsUtils")],
       path: "utils",
-      sources: ["DriverUtils.swift", "ArgParse.swift"]),
+      sources: ["DriverUtils.swift", "ArgParse.swift", "UnknownVersion.swift"]),
     .target(name: "SwiftBench",
             dependencies: [
               .target(name: "TestsUtils"),

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -94,6 +94,7 @@ enum TestAction {
   case listTests
   case fail(String)
   case help([String])
+  case version
 }
 
 struct TestConfig {
@@ -137,7 +138,7 @@ struct TestConfig {
     let validOptions = [
       "--iter-scale", "--num-samples", "--num-iters",
       "--verbose", "--delim", "--list", "--sleep",
-      "--tags", "--skip-tags", "--help"
+      "--tags", "--skip-tags", "--help", "--version"
     ]
     let maybeBenchArgs: Arguments? = parseArgs(validOptions)
     if maybeBenchArgs == nil {
@@ -149,6 +150,10 @@ struct TestConfig {
 
     if benchArgs.optionalArgsMap["--help"] != nil {
       return .help(validOptions)
+    }
+
+    if benchArgs.optionalArgsMap["--version"] != nil {
+      return .version
     }
 
     if let x = benchArgs.optionalArgsMap["--iter-scale"] {
@@ -492,6 +497,8 @@ public func main() {
       for v in validOptions {
         print("    \(v)")
       }
+    case .version:
+      print(version)
     case let .fail(msg):
       // We do this since we need an autoclosure...
       fatalError("\(msg)")

--- a/benchmark/utils/UnknownVersion.swift
+++ b/benchmark/utils/UnknownVersion.swift
@@ -1,0 +1,17 @@
+//===--- UnknownVersion.swift ---------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// SwiftPM doesn't support code generation and scripting, so we cannot determine
+// the versions of Swift compiler and the git branch during build.
+public let version = """
+Swift Benchmark Suite unknown (SwiftPM build)
+"""

--- a/benchmark/utils/Version.swift.in
+++ b/benchmark/utils/Version.swift.in
@@ -1,0 +1,18 @@
+//===--- Version.swift ----------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+// Swift Benchmark Suite version is composed of Swift version and the git branch
+// version as determined during CMake build and generated into this file.
+public let version = """
+Swift Benchmark Suite @BRANCH_VERSION@
+@SWIFT_VERSION@
+"""


### PR DESCRIPTION
SR-4675 Report detailed build version from Benchmark drivers
https://bugs.swift.org/browse/SR-4675

This is partial implementation of printing the version information directly from Swift Benchmark Suite binaries.

There are few issue currently, that need to be evaluated before the merge. I'm seeking advice on how to resolve this:
* SwiftPM is currently [crashing the build with strange errors](https://gist.github.com/palimondo/1af3c794ef2efe17bbb15e71127a61aa)
* The cmake build doesn't trigger `Version.swift` re-generation when that file is modified manually
* Remove debug messages from final code (?)

I'm a little bit worried if I'm doing this the right way. When I build with `build-script`, all works as expected. But I don't know how is `cmake` tracking file changes (when and what to rebuild). I have been testing the re-builing, by manually clearing the `version` String in the generated `Version.swift` like this (after the initial `build-script`): 

````
Mondoshawan:swift-macosx-x86_64 mondo$ pwd
/Users/mondo/Developer/swift-source/build/Ninja-ReleaseAssert/swift-macosx-x86_64
Mondoshawan:swift-macosx-x86_64 mondo$ ninja swift-benchmark-macosx-x86_64
````
This doesn't always trigger re-generation and the binaries print empty string (`Benchamrk_O --version`), so the binary is clearly rebuilt.

The file `Version.swift` is added as part of the `DriverUtils` module, right next to `ArgsParse.swift`. I have moved the code that generates the `Version.swift` from `Version.swift.in` from the [`macro(configure_build)`](https://github.com/palimondo/swift/blob/d5b16b3982a052b9bafe0866413f8868962ce7ec/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake#L5) into  [function `swift_benchmark_suite_version`](https://github.com/palimondo/swift/blob/d5b16b3982a052b9bafe0866413f8868962ce7ec/benchmark/cmake/modules/AddSwiftBenchmarkSuite.cmake#L270-L295) and call that from the preexisting function `swift_benchmark_compile`. But doesn't help, instead it just unnecessarily triggers the generation multiple time. So that's clearly worse than before... 

Can you help, @gottesmm ?