### PR TITLE
[stdlib][4.2] Don’t use an error for flow control in Sequence.first(where:)

### DIFF
--- a/stdlib/public/core/Sequence.swift
+++ b/stdlib/public/core/Sequence.swift
@@ -943,12 +943,6 @@ extension Sequence {
   }
 }
 
-@usableFromInline
-@_frozen
-internal enum _StopIteration : Error {
-  case stop
-}
-
 extension Sequence {
   /// Returns the first element of the sequence that satisfies the given
   /// predicate.
@@ -971,16 +965,12 @@ extension Sequence {
   public func first(
     where predicate: (Element) throws -> Bool
   ) rethrows -> Element? {
-    var foundElement: Element?
-    do {
-      try self.forEach {
-        if try predicate($0) {
-          foundElement = $0
-          throw _StopIteration.stop
-        }
+    for element in self  {
+      if try predicate(element) {
+        return element
       }
-    } catch is _StopIteration { }
-    return foundElement
+    }
+    return nil
   }
 }
 


### PR DESCRIPTION
Cherry pick of #17387 