### PR TITLE
Add and enable an AccessEnforcementWMO pass.

### DIFF
--- a/include/swift/SILOptimizer/PassManager/Passes.def
+++ b/include/swift/SILOptimizer/PassManager/Passes.def
@@ -58,6 +58,8 @@ PASS(AccessEnforcementOpts, "access-enforcement-opts",
      "Access Enforcement Optimization")
 PASS(AccessEnforcementSelection, "access-enforcement-selection",
      "Access Enforcement Selection")
+PASS(AccessEnforcementWMO, "access-enforcement-wmo",
+     "Access Enforcement Whole Module Optimization")
 PASS(AccessSummaryDumper, "access-summary-dump",
      "Dump Address Parameter Access Summary")
 PASS(AccessedStorageDumper, "accessed-storage-dump",

--- a/lib/SILOptimizer/PassManager/PassPipeline.cpp
+++ b/lib/SILOptimizer/PassManager/PassPipeline.cpp
@@ -479,6 +479,7 @@ static void addLateLoopOptPassPipeline(SILPassPipelinePlan &P) {
 static void addLastChanceOptPassPipeline(SILPassPipelinePlan &P) {
   // Optimize access markers for improved IRGen after all other optimizations.
   P.addAccessEnforcementOpts();
+  P.addAccessEnforcementWMO();
 
   // Only has an effect if the -assume-single-thread option is specified.
   P.addAssumeSingleThreaded();

--- a/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementOpts.cpp
@@ -285,7 +285,7 @@ public:
   }
   bool hasConflictFreeAccess() const {
     NoNestedConflictIterator iterator(*this);
-    return iterator.next() == nullptr;
+    return iterator.next() != nullptr;
   }
 
   bool hasInScopeAccess() const {
@@ -623,6 +623,9 @@ struct AccessEnforcementOpts : public SILFunctionTransform {
     SILFunction *F = getFunction();
     if (F->empty())
       return;
+
+    DEBUG(llvm::dbgs() << "Running local AccessEnforcementOpts on "
+                       << F->getName() << "\n");
 
     PostOrderFunctionInfo *PO = getAnalysis<PostOrderAnalysis>()->get(F);
     AccessedStorageAnalysis *ASA = getAnalysis<AccessedStorageAnalysis>();

--- a/lib/SILOptimizer/Transforms/AccessEnforcementWMO.cpp
+++ b/lib/SILOptimizer/Transforms/AccessEnforcementWMO.cpp
@@ -1,0 +1,277 @@
+//===--- AccessEnforcementWMO.cpp - Whole-module access enforcement opt ---===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+///
+/// This module pass removes dynamic access enforcement based on whole module
+/// information.
+///
+/// This maps each access of identified storage onto a disjoint access
+/// location. Local accesses (Box and Stack) already have unique AccessedStorage
+/// and should be removed by an earlier function pass. This pass handles Class
+/// and Global access by partitioning their non-unique AccessedStorage objects
+/// into unique DisjointAccessLocations. These disjoint access locations may be
+/// accessed across multiple functions, so a module pass is required to identify
+/// and optimize them.
+///
+/// Class accesses are partitioned by their fully qualified property
+/// name. Global accesses are partitioned by the global variable name. Argument
+/// accesses are ignored because they are considered an access in the caller,
+/// while Class and Global access always occurs in the callee. Note that a SIL
+/// function argument value may be the source of a either a Class-kind
+/// AccessedStorage or an Argument-kind AccessedStorage. When the argument is
+/// used to access a class, it will always be identified as a Class-kind
+/// AccessedStorage even though its source is an argument.
+///
+/// For each function, discover the disjointly accessed locations. Each location
+/// is optimistically mapped to a `noNestedConflict` flag (if a location has not
+/// been mapped, then it is assumed not to have nested conflict). Each location
+/// without any nested conflict maps to a set of accesses that the optimization
+/// may be able to remove.
+///
+/// After analyzing all functions in the module, disable any class property and
+/// global variable access that still have not seen any nested conflicts by
+/// giving them static enforcement.
+///
+/// Warning: This is only sound when unidentified accesses can never alias with
+/// Class/Global access. To enforce this, the SILVerifier calls
+/// findAccessedStorage() for every access, which asserts that any Unidentified
+/// access belongs to a know pattern that cannot originate from Class or Global
+/// accesses.
+///
+/// Note: This optimization must be aware of all possible access to a Class or
+/// Global address. This includes unpaired access instructions and keypath
+/// instructions. Ignoring any access pattern would weaken enforcement.
+//===----------------------------------------------------------------------===//
+
+#define DEBUG_TYPE "access-enforcement-wmo"
+
+#include "swift/SIL/DebugUtils.h"
+#include "swift/SIL/MemAccessUtils.h"
+#include "swift/SIL/SILFunction.h"
+#include "swift/SILOptimizer/PassManager/Transforms.h"
+#include "swift/SILOptimizer/Utils/Local.h"
+
+using namespace swift;
+
+using llvm::DenseMap;
+using llvm::SmallDenseSet;
+
+// Get the VarDecl that represents the DisjointAccessLocation for the given
+// AccessedStorage. Returns nullptr for any storage that can't be partitioned
+// into a disjoint location.
+//
+// findAccessedStorage may only return Unidentified storage for a global
+// variable access if the global is defined in a different module.
+VarDecl *getDisjointAccessLocation(const AccessedStorage &storage) {
+  switch (storage.getKind()) {
+  case AccessedStorage::Global:
+    // A global variable may return a null decl. These variables are
+    // implementation details that aren't formally accessed.
+    return storage.getGlobal()->getDecl();
+  case AccessedStorage::Class: {
+    const ObjectProjection &objProj = storage.getObjectProjection();
+    return objProj.getProjection().getVarDecl(objProj.getObject()->getType());
+  }
+  case AccessedStorage::Box:
+  case AccessedStorage::Stack:
+  case AccessedStorage::Argument:
+  case AccessedStorage::Unidentified:
+    return nullptr;
+  case AccessedStorage::Nested:
+    llvm_unreachable("Unexpected Nested access.");
+  }
+}
+
+namespace {
+// Implements an optimization to remove access markers on disjoint memory
+// locations that are never reentrantly accessed. For a given memory location,
+// if there are no potential nested conflicts, then enforcement must succeed for
+// any access to that location.
+//
+// The existence of unidentified access complicates this problem. For this
+// optimization to be valid, Global and Class property access must always be
+// identifiable. findAccessedStorage() in MemAccessUtils enforces a short list
+// of unidentified producers (non-address PHIArgument, PointerToAddress, Undef,
+// & local-init). We cannot allow the address of a global variable or class
+// property to be exposed via one of these instructions, unless the declaration
+// is considered "visible externally".
+//
+// Note: This assumes that PointerToAddress is never used to access a global or
+// class property unless it's done via an Unsafe API that doesn't need
+// enforcement.
+//
+// FIXME: Tail-allocated heap storage is currently categorized as
+// Unidentified. This is conservatively safe because it can't also be accessed
+// as a class property. However, it is inconsistent with the general rule that
+// only local storage is unidentified, and we can probably remove a lot of
+// accesses by being more precise here (OTOH, if this is known CoW storage, we
+// should eventually add an even stronger optimization to remove exclusivity
+// checks).
+class GlobalAccessRemoval {
+  SILModule &module;
+
+  using BeginAccessSet = SmallDenseSet<BeginAccessInst *, 8>;
+
+  /// Information for an access location that, if it is valid, must be disjoint
+  /// from all other access locations.
+  struct DisjointAccessLocationInfo {
+    AccessedStorage::Kind accessKind = AccessedStorage::Unidentified;
+    // False if any nested conflict has been seen at this location.
+    bool noNestedConflict = true;
+    BeginAccessSet beginAccessSet;
+  };
+
+  DenseMap<VarDecl *, DisjointAccessLocationInfo> disjointAccessMap;
+
+public:
+  GlobalAccessRemoval(SILModule &module) : module(module) {}
+
+  void perform();
+
+protected:
+  void visitInstruction(SILInstruction *I);
+  void recordAccess(SILInstruction *beginAccess, VarDecl *decl,
+                    AccessedStorage::Kind storageKind,
+                    bool hasNoNestedConflict);
+  void removeNonreentrantAccess();
+};
+} // namespace
+
+/// Process all begin_access instructions in the module, recording their
+/// DisjointAccessLocation. Ignore accesses at call sites because Arguments and
+/// Unidentified access can only local storage.
+void GlobalAccessRemoval::perform() {
+  for (auto &F : module) {
+    if (F.empty())
+      continue;
+
+    for (auto &BB : F) {
+      for (auto &I : BB)
+        visitInstruction(&I);
+    }
+  }
+  removeNonreentrantAccess();
+}
+
+void GlobalAccessRemoval::visitInstruction(SILInstruction *I) {
+  if (auto *BAI = dyn_cast<BeginAccessInst>(I)) {
+    AccessedStorage storage = findAccessedStorageNonNested(BAI->getSource());
+    VarDecl *decl = getDisjointAccessLocation(storage);
+    recordAccess(BAI, decl, storage.getKind(), BAI->hasNoNestedConflict());
+    return;
+  }
+  if (auto *BUAI = dyn_cast<BeginUnpairedAccessInst>(I)) {
+    AccessedStorage storage = findAccessedStorageNonNested(BUAI->getSource());
+    VarDecl *decl = getDisjointAccessLocation(storage);
+    recordAccess(BUAI, decl, storage.getKind(), BUAI->hasNoNestedConflict());
+    return;
+  }
+  if (auto *KPI = dyn_cast<KeyPathInst>(I)) {
+    for (const KeyPathPatternComponent &component :
+         KPI->getPattern()->getComponents()) {
+      switch (component.getKind()) {
+      case KeyPathPatternComponent::Kind::StoredProperty:
+        recordAccess(KPI, component.getStoredPropertyDecl(),
+                     AccessedStorage::Class, /*hasNoNestedConflict=*/false);
+        break;
+      case KeyPathPatternComponent::Kind::GettableProperty:
+      case KeyPathPatternComponent::Kind::SettableProperty:
+      case KeyPathPatternComponent::Kind::External:
+      case KeyPathPatternComponent::Kind::OptionalChain:
+      case KeyPathPatternComponent::Kind::OptionalForce:
+      case KeyPathPatternComponent::Kind::OptionalWrap:
+        break;
+      }
+    }
+    return;
+  }
+}
+
+// Record an access in the disjointAccessMap.
+//
+// `beginAccess` is any instruction that represents a potential access,
+// including key_path. One of the following conditions must be true for every
+// begin_[unpaired_]access instructions:
+// - it is guaranteed to access local memory, not a class property or global.
+// - it has an identifiable source.
+// - is is generated from a Builtin, which is assumed to have an associated
+// key_path instruction somewhere else in the same module (or it must be dead
+// code, or only access public properties).
+//
+// `decl` may be nullptr if the declaration can't be determined from the
+// access. This is only legal when the access is known to be a local access, not
+// a class property or global.
+void GlobalAccessRemoval::recordAccess(SILInstruction *beginAccess,
+                                       VarDecl *decl,
+                                       AccessedStorage::Kind storageKind,
+                                       bool hasNoNestedConflict) {
+  if (!decl || module.isVisibleExternally(decl))
+    return;
+
+  DEBUG(if (!hasNoNestedConflict) llvm::dbgs()
+        << "Nested conflict on " << decl->getName() << " at" << *beginAccess
+        << "\n");
+
+  auto accessLocIter = disjointAccessMap.find(decl);
+  if (accessLocIter != disjointAccessMap.end()) {
+    // Add this begin_access to an existing DisjointAccessLocationInfo.
+    DisjointAccessLocationInfo &info = accessLocIter->second;
+    assert(info.accessKind == storageKind);
+    info.noNestedConflict &= hasNoNestedConflict;
+    // Don't currently optimize unpaired access.
+    if (auto *BAI = dyn_cast<BeginAccessInst>(beginAccess))
+      info.beginAccessSet.insert(BAI);
+    return;
+  }
+
+  // Create the first DisjointAccessLocationInfo for this begin_access.
+  DisjointAccessLocationInfo info;
+  info.accessKind = storageKind;
+  info.noNestedConflict = hasNoNestedConflict;
+  if (auto *BA = dyn_cast<BeginAccessInst>(beginAccess))
+    info.beginAccessSet.insert(BA);
+  disjointAccessMap.insert(std::make_pair(decl, info));
+}
+
+// For each unique storage within this function that is never reentrantly
+// accessed, promote all access checks for that storage to static enforcement.
+void GlobalAccessRemoval::removeNonreentrantAccess() {
+  for (auto &declAndInfo : disjointAccessMap) {
+    const DisjointAccessLocationInfo &info = declAndInfo.second;
+    if (!info.noNestedConflict)
+      continue;
+
+    VarDecl *decl = declAndInfo.first;
+    DEBUG(llvm::dbgs() << "Eliminating all formal access on " << decl->getName()
+                       << "\n");
+    assert(!module.isVisibleExternally(decl));
+    (void)decl;
+
+    // Non-deterministic iteration, only used to set a flag.
+    for (BeginAccessInst *beginAccess : info.beginAccessSet) {
+      DEBUG(llvm::dbgs() << "  Disabling access marker " << *beginAccess);
+      beginAccess->setEnforcement(SILAccessEnforcement::Static);
+    }
+  }
+}
+
+namespace {
+struct AccessEnforcementWMO : public SILModuleTransform {
+  void run() override {
+    GlobalAccessRemoval eliminationPass(*getModule());
+    eliminationPass.perform();
+  }
+};
+}
+
+SILTransform *swift::createAccessEnforcementWMO() {
+  return new AccessEnforcementWMO();
+}

--- a/lib/SILOptimizer/Transforms/CMakeLists.txt
+++ b/lib/SILOptimizer/Transforms/CMakeLists.txt
@@ -1,6 +1,7 @@
 silopt_register_sources(
   ARCCodeMotion.cpp
   AccessEnforcementOpts.cpp
+  AccessEnforcementWMO.cpp
   AllocBoxToStack.cpp
   ArrayCountPropagation.cpp
   ArrayElementValuePropagation.cpp

--- a/test/SILOptimizer/Inputs/access_wmo_def.swift
+++ b/test/SILOptimizer/Inputs/access_wmo_def.swift
@@ -1,0 +1,15 @@
+// Input for access-enforcement-wmo multi-file test cases.
+
+var internalGlobal: Int = 0
+
+public var publicGlobal: Int = 0
+
+public class C {
+  var setterProp: Int = 0 // Only modified via setter.
+  final var finalProp: Int = 0 // modified directly.
+  var inlinedProp: Int = 0 // modification via materializeForSet inlined.
+  var internalProp: Int = 0 // modified opaquely via materializeForSet.
+  var keyPathProp: Int = 0 // modified via a keypath.
+  final var finalKeyPathProp: Int = 0 // modified via a keypath.
+  public var publicProp: Int = 0
+}

--- a/test/SILOptimizer/access_wmo.sil
+++ b/test/SILOptimizer/access_wmo.sil
@@ -1,0 +1,338 @@
+// RUN: %target-sil-opt -wmo -access-enforcement-wmo -assume-parsing-unqualified-ownership-sil %s -enable-sil-verify-all | %FileCheck %s
+//
+// Test the AccessEnforcementWMO pass in isolation. This ensures that
+// no upstream passes have removed SIL-level access markers that are
+// required to ensure the pass is not overly optimistic. It also
+// checks generated getters and setters are handled as expected.
+
+sil_stage canonical
+
+import Builtin
+import Swift
+import SwiftShims
+
+var internalGlobal: Int64
+
+public var publicGlobal: Int64
+
+public class C {
+  @sil_stored var setterProp: Int64 { get set }
+  @sil_stored final var finalProp: Int64 { get set }
+  @sil_stored var inlinedProp: Int64 { get set }
+  @sil_stored var internalProp: Int64 { get set }
+  @sil_stored var keyPathProp: Int64 { get set }
+  @sil_stored final var finalKeyPathProp: Int64 { get set }
+  @sil_stored public var publicProp: Int64 { get set }
+  init()
+  deinit
+}
+
+// internalGlobal
+sil_global hidden @$S10access_wmo14internalGlobalSivp : $Int64 = {
+  %0 = integer_literal $Builtin.Int64, 0          // user: %1
+  %initval = struct $Int64 (%0 : $Builtin.Int64)
+}
+
+
+// publicGlobal
+sil_global @$S10access_wmo12publicGlobalSivp : $Int64 = {
+  %0 = integer_literal $Builtin.Int64, 0          // user: %1
+  %initval = struct $Int64 (%0 : $Builtin.Int64)
+}
+
+// readGlobal()
+// CHECK-LABEL: sil @$S10access_wmo10readGlobalSiyF : $@convention(thin) () -> Int64 {
+//
+// The internal global is promoted to static.
+// CHECK: [[G1:%.]] = global_addr @$S10access_wmo14internalGlobalSivp : $*Int64
+// CHECK: begin_access [read] [static] [no_nested_conflict] [[G1]] : $*Int64
+//
+// The public global remains dynamic.
+// CHECK: [[G2:%.*]] = global_addr @$S10access_wmo12publicGlobalSivp : $*Int
+// CHECK: begin_access [read] [dynamic] [no_nested_conflict] [[G2]] : $*Int64
+// CHECK-LABEL: } // end sil function '$S10access_wmo10readGlobalSiyF'
+sil @$S10access_wmo10readGlobalSiyF : $@convention(thin) () -> Int64 {
+bb0:
+  %0 = global_addr @$S10access_wmo14internalGlobalSivp : $*Int64
+  %1 = begin_access [read] [dynamic] [no_nested_conflict] %0 : $*Int64
+  %2 = struct_element_addr %1 : $*Int64, #Int64._value
+  %3 = load %2 : $*Builtin.Int64
+  end_access %1 : $*Int64
+  %5 = global_addr @$S10access_wmo12publicGlobalSivp : $*Int64
+  %6 = begin_access [read] [dynamic] [no_nested_conflict] %5 : $*Int64
+  %7 = struct_element_addr %6 : $*Int64, #Int64._value
+  %8 = load %7 : $*Builtin.Int64
+  end_access %6 : $*Int64
+  %10 = integer_literal $Builtin.Int1, -1
+  %11 = builtin "sadd_with_overflow_Int64"(%3 : $Builtin.Int64, %8 : $Builtin.Int64, %10 : $Builtin.Int1) : $(Builtin.Int64, Builtin.Int1)
+  %12 = tuple_extract %11 : $(Builtin.Int64, Builtin.Int1), 0
+  %13 = tuple_extract %11 : $(Builtin.Int64, Builtin.Int1), 1
+  cond_fail %13 : $Builtin.Int1
+  %15 = struct $Int64 (%12 : $Builtin.Int64)
+  return %15 : $Int64
+} // end sil function '$S10access_wmo10readGlobalSiyF'
+
+// setInt(_:_:)
+sil [noinline] @$S10access_wmo6setIntyySiz_SitF : $@convention(thin) (@inout Int64, Int64) -> ()
+
+// testAccessGlobal(v:)
+// CHECK-LABEL: sil @$S10access_wmo16testAccessGlobal1vySi_tF : $@convention(thin) (Int64) -> () {
+// CHECK: [[G1:%.*]] = global_addr @$S10access_wmo14internalGlobalSivp : $*Int64
+// CHECK: begin_access [modify] [static] [no_nested_conflict] [[G1]] : $*Int64
+// CHECK: [[G2:%.*]] = global_addr @$S10access_wmo12publicGlobalSivp : $*Int64
+// CHECK: begin_access [modify] [dynamic] [no_nested_conflict] [[G2]] : $*Int64
+// CHECK-LABEL: } // end sil function '$S10access_wmo16testAccessGlobal1vySi_tF'
+sil @$S10access_wmo16testAccessGlobal1vySi_tF : $@convention(thin) (Int64) -> () {
+// %0                                             // users: %9, %5, %1
+bb0(%0 : $Int64):
+  %1 = global_addr @$S10access_wmo14internalGlobalSivp : $*Int64
+  %2 = begin_access [modify] [dynamic] [no_nested_conflict] %1 : $*Int64
+  // function_ref setInt(_:_:)
+  %3 = function_ref @$S10access_wmo6setIntyySiz_SitF : $@convention(thin) (@inout Int64, Int64) -> ()
+  %4 = apply %3(%2, %0) : $@convention(thin) (@inout Int64, Int64) -> ()
+  end_access %2 : $*Int64
+  %6 = global_addr @$S10access_wmo12publicGlobalSivp : $*Int64
+  %7 = begin_access [modify] [dynamic] [no_nested_conflict] %6 : $*Int64
+  %8 = apply %3(%7, %0) : $@convention(thin) (@inout Int64, Int64) -> ()
+  end_access %7 : $*Int64
+  %10 = tuple ()
+  return %10 : $()
+} // end sil function '$S10access_wmo16testAccessGlobal1vySi_tF'
+
+// setKeyPath(_:_:_:)
+sil [noinline] @$S10access_wmo10setKeyPathyyAA1CC_s017ReferenceWritabledE0CyADSiGSitF : $@convention(thin) (@guaranteed C, @guaranteed ReferenceWritableKeyPath<C, Int64>, Int64) -> ()
+
+// readProp(c:)
+//
+// See the explanation in access_wmo.swift for why some non-public
+// properties cannot currently be promoted to static enforcement.
+//
+// CHECK-LABEL: sil @$S10access_wmo8readProp1cyAA1CC_tF : $@convention(thin) (@guaranteed C) -> () {
+// CHECK: [[E1:%.*]] = ref_element_addr %0 : $C, #C.setterProp
+// CHECK: begin_access [read] [static] [no_nested_conflict] [[E1]] : $*Int64
+// CHECK: [[E2:%.*]] = ref_element_addr %0 : $C, #C.finalProp
+// CHECK: begin_access [read] [static] [no_nested_conflict] [[E2]] : $*Int64
+// CHECK: [[E3:%.*]] = ref_element_addr %0 : $C, #C.inlinedProp
+// CHECK: begin_access [read] [dynamic] [no_nested_conflict] [[E3]] : $*Int64
+// CHECK: [[E4:%.*]] = ref_element_addr %0 : $C, #C.internalProp
+// CHECK: begin_access [read] [dynamic] [no_nested_conflict] [[E4]] : $*Int64
+// CHECK: [[E5:%.*]] = ref_element_addr %0 : $C, #C.keyPathProp
+// CHECK: begin_access [read] [static] [no_nested_conflict] [[E5]] : $*Int64
+// CHECK: [[E5:%.*]] = ref_element_addr %0 : $C, #C.finalKeyPathProp
+// CHECK: begin_access [read] [dynamic] [no_nested_conflict] [[E5]] : $*Int64
+// CHECK: [[E6:%.*]] = ref_element_addr %0 : $C, #C.publicProp
+// CHECK: begin_access [read] [dynamic] [no_nested_conflict] [[E6]] : $*Int64
+// CHECK-LABEL: } // end sil function '$S10access_wmo8readProp1cyAA1CC_tF'
+sil @$S10access_wmo8readProp1cyAA1CC_tF : $@convention(thin) (@guaranteed C) -> () {
+// %0
+bb0(%0 : $C):
+  %1 = ref_element_addr %0 : $C, #C.setterProp
+  %2 = begin_access [read] [dynamic] [no_nested_conflict] %1 : $*Int64
+  %3 = struct_element_addr %2 : $*Int64, #Int64._value
+  %4 = load %3 : $*Builtin.Int64
+  end_access %2 : $*Int64
+  %6 = ref_element_addr %0 : $C, #C.finalProp
+  %7 = begin_access [read] [dynamic] [no_nested_conflict] %6 : $*Int64
+  %8 = struct_element_addr %7 : $*Int64, #Int64._value
+  %9 = load %8 : $*Builtin.Int64
+  end_access %7 : $*Int64
+  %11 = ref_element_addr %0 : $C, #C.inlinedProp
+  %12 = begin_access [read] [dynamic] [no_nested_conflict] %11 : $*Int64
+  %13 = struct_element_addr %12 : $*Int64, #Int64._value
+  %14 = load %13 : $*Builtin.Int64
+  end_access %12 : $*Int64
+  %16 = ref_element_addr %0 : $C, #C.internalProp
+  %17 = begin_access [read] [dynamic] [no_nested_conflict] %16 : $*Int64
+  %18 = struct_element_addr %17 : $*Int64, #Int64._value
+  %19 = load %18 : $*Builtin.Int64
+  end_access %17 : $*Int64
+  %21 = ref_element_addr %0 : $C, #C.keyPathProp
+  %22 = begin_access [read] [dynamic] [no_nested_conflict] %21 : $*Int64
+  %23 = struct_element_addr %22 : $*Int64, #Int64._value
+  %24 = load %23 : $*Builtin.Int64
+  end_access %22 : $*Int64
+  %26 = ref_element_addr %0 : $C, #C.finalKeyPathProp
+  %27 = begin_access [read] [dynamic] [no_nested_conflict] %26 : $*Int64
+  %28 = struct_element_addr %27 : $*Int64, #Int64._value
+  %29 = load %28 : $*Builtin.Int64
+  end_access %27 : $*Int64
+  %31 = ref_element_addr %0 : $C, #C.publicProp
+  %32 = begin_access [read] [dynamic] [no_nested_conflict] %31 : $*Int64
+  %33 = struct_element_addr %32 : $*Int64, #Int64._value
+  %34 = load %33 : $*Builtin.Int64
+  end_access %32 : $*Int64
+  %36 = tuple ()
+  return %36 : $()
+} // end sil function '$S10access_wmo8readProp1cyAA1CC_tF'
+
+// testAccessProp(c:v:)
+// CHECK-LABEL: sil @$S10access_wmo14testAccessProp1c1vyAA1CC_SitF : $@convention(thin) (@guaranteed C, Int64) -> () {
+// CHECK: bb0(%0 : $C, %1 : $Int64):
+// CHECK: [[E1:%.*]] = ref_element_addr %0 : $C, #C.setterProp
+// CHECK: begin_access [modify] [static] [no_nested_conflict] [[E1]] : $*Int64
+// CHECK: [[E2:%.*]] = ref_element_addr %0 : $C, #C.finalProp
+// CHECK: begin_access [modify] [static] [no_nested_conflict] [[E2]] : $*Int64
+// CHECK: [[E3:%.*]] = ref_element_addr %0 : $C, #C.inlinedProp
+// CHECK: begin_unpaired_access [modify] [dynamic] [[E3]] : $*Int64, %{{.*}} : $*Builtin.UnsafeValueBuffer
+// CHECK: [[E4:%.*]] = ref_element_addr %0 : $C, #C.internalProp
+// CHECK: begin_unpaired_access [modify] [dynamic] [[E4]] : $*Int64, %{{.*}} : $*Builtin.UnsafeValueBuffer
+// CHECK: keypath $ReferenceWritableKeyPath<C, Int64>, (root $C; settable_property $Int64,  id #C.keyPathProp!getter.1 : (C) -> () -> Int64, getter @$S10access_wmo1CC11keyPathPropSivpACTK : $@convention(thin) (@in_guaranteed C) -> @out Int64, setter @$S10access_wmo1CC11keyPathPropSivpACTk : $@convention(thin) (@in_guaranteed Int64, @in_guaranteed C) -> ())
+// CHECK: keypath $ReferenceWritableKeyPath<C, Int64>, (root $C; stored_property #C.finalKeyPathProp : $Int64)
+// CHECK: [[E5:%.*]] = ref_element_addr %0 : $C, #C.publicProp
+// CHECK: begin_unpaired_access [modify] [dynamic] [[E5]] : $*Int64, %{{.*}} : $*Builtin.UnsafeValueBuffer
+// CHECK-LABEL: } // end sil function '$S10access_wmo14testAccessProp1c1vyAA1CC_SitF'
+sil @$S10access_wmo14testAccessProp1c1vyAA1CC_SitF : $@convention(thin) (@guaranteed C, Int64) -> () {
+bb0(%0 : $C, %1 : $Int64):
+  %2 = ref_element_addr %0 : $C, #C.setterProp
+  %3 = begin_access [modify] [dynamic] [no_nested_conflict] %2 : $*Int64
+  store %1 to %3 : $*Int64
+  end_access %3 : $*Int64
+  %6 = ref_element_addr %0 : $C, #C.finalProp
+  %7 = begin_access [modify] [dynamic] [no_nested_conflict] %6 : $*Int64
+  // function_ref setInt(_:_:)
+  %8 = function_ref @$S10access_wmo6setIntyySiz_SitF : $@convention(thin) (@inout Int64, Int64) -> ()
+  %9 = apply %8(%7, %1) : $@convention(thin) (@inout Int64, Int64) -> ()
+  end_access %7 : $*Int64
+  %11 = alloc_stack $Builtin.UnsafeValueBuffer
+  %12 = ref_element_addr %0 : $C, #C.inlinedProp
+  begin_unpaired_access [modify] [dynamic] %12 : $*Int64, %11 : $*Builtin.UnsafeValueBuffer
+  %14 = mark_dependence %12 : $*Int64 on %0 : $C
+  store %1 to %14 : $*Int64
+  end_unpaired_access [dynamic] %11 : $*Builtin.UnsafeValueBuffer
+  dealloc_stack %11 : $*Builtin.UnsafeValueBuffer
+  %18 = alloc_stack $Builtin.UnsafeValueBuffer
+  %19 = ref_element_addr %0 : $C, #C.internalProp
+  begin_unpaired_access [modify] [dynamic] %19 : $*Int64, %18 : $*Builtin.UnsafeValueBuffer
+  %21 = mark_dependence %19 : $*Int64 on %0 : $C
+  %22 = apply %8(%21, %1) : $@convention(thin) (@inout Int64, Int64) -> ()
+  end_unpaired_access [dynamic] %18 : $*Builtin.UnsafeValueBuffer
+  dealloc_stack %18 : $*Builtin.UnsafeValueBuffer
+  %25 = keypath $ReferenceWritableKeyPath<C, Int64>, (root $C; settable_property $Int64,  id #C.keyPathProp!getter.1 : (C) -> () -> Int64, getter @$S10access_wmo1CC11keyPathPropSivpACTK : $@convention(thin) (@in_guaranteed C) -> @out Int64, setter @$S10access_wmo1CC11keyPathPropSivpACTk : $@convention(thin) (@in_guaranteed Int64, @in_guaranteed C) -> ())
+  // function_ref setKeyPath(_:_:_:)
+  %26 = function_ref @$S10access_wmo10setKeyPathyyAA1CC_s017ReferenceWritabledE0CyADSiGSitF : $@convention(thin) (@guaranteed C, @guaranteed ReferenceWritableKeyPath<C, Int64>, Int64) -> ()
+  %27 = apply %26(%0, %25, %1) : $@convention(thin) (@guaranteed C, @guaranteed ReferenceWritableKeyPath<C, Int64>, Int64) -> ()
+  strong_release %25 : $ReferenceWritableKeyPath<C, Int64>
+  %29 = keypath $ReferenceWritableKeyPath<C, Int64>, (root $C; stored_property #C.finalKeyPathProp : $Int64)
+  %30 = apply %26(%0, %29, %1) : $@convention(thin) (@guaranteed C, @guaranteed ReferenceWritableKeyPath<C, Int64>, Int64) -> ()
+  strong_release %29 : $ReferenceWritableKeyPath<C, Int64>
+  %32 = alloc_stack $Builtin.UnsafeValueBuffer
+  %33 = ref_element_addr %0 : $C, #C.publicProp
+  begin_unpaired_access [modify] [dynamic] %33 : $*Int64, %32 : $*Builtin.UnsafeValueBuffer
+  %35 = mark_dependence %33 : $*Int64 on %0 : $C
+  %36 = apply %8(%35, %1) : $@convention(thin) (@inout Int64, Int64) -> ()
+  end_unpaired_access [dynamic] %32 : $*Builtin.UnsafeValueBuffer
+  dealloc_stack %32 : $*Builtin.UnsafeValueBuffer
+  %39 = tuple ()
+  return %39 : $()
+} // end sil function '$S10access_wmo14testAccessProp1c1vyAA1CC_SitF'
+
+// key path getter for C.keyPathProp : C
+//
+// CHECK-LABEL: sil shared [thunk] @$S10access_wmo1CC11keyPathPropSivpACTK : $@convention(thin) (@in_guaranteed C) -> @out Int64 {
+// CHECK: begin_access [read] [static] [no_nested_conflict] %{{.*}} : $*Int64
+// CHECK-LABEL: } // end sil function '$S10access_wmo1CC11keyPathPropSivpACTK'
+sil shared [thunk] @$S10access_wmo1CC11keyPathPropSivpACTK : $@convention(thin) (@in_guaranteed C) -> @out Int64 {
+bb0(%0 : $*Int64, %1 : $*C):
+  %2 = load %1 : $*C                              // user: %3
+  %3 = ref_element_addr %2 : $C, #C.keyPathProp   // user: %4
+  %4 = begin_access [read] [dynamic] [no_nested_conflict] %3 : $*Int64 // users: %6, %5
+  %5 = load %4 : $*Int64                          // user: %7
+  end_access %4 : $*Int64                         // id: %6
+  store %5 to %0 : $*Int64                        // id: %7
+  %8 = tuple ()                                   // user: %9
+  return %8 : $()                                 // id: %9
+} // end sil function '$S10access_wmo1CC11keyPathPropSivpACTK'
+
+// key path setter for C.keyPathProp : C
+//
+// CHECK-LABEL: sil shared [thunk] @$S10access_wmo1CC11keyPathPropSivpACTk : $@convention(thin) (@in_guaranteed Int64, @in_guaranteed C) -> () {
+// CHECK: begin_access [modify] [static] [no_nested_conflict] %{{.*}} : $*Int64
+// CHECK-LABEL: } // end sil function '$S10access_wmo1CC11keyPathPropSivpACTk'
+sil shared [thunk] @$S10access_wmo1CC11keyPathPropSivpACTk : $@convention(thin) (@in_guaranteed Int64, @in_guaranteed C) -> () {
+bb0(%0 : $*Int64, %1 : $*C):
+  %2 = load %0 : $*Int64                          // user: %6
+  %3 = load %1 : $*C                              // user: %4
+  %4 = ref_element_addr %3 : $C, #C.keyPathProp   // user: %5
+  %5 = begin_access [modify] [dynamic] [no_nested_conflict] %4 : $*Int64 // users: %7, %6
+  store %2 to %5 : $*Int64                        // id: %6
+  end_access %5 : $*Int64                         // id: %7
+  %8 = tuple ()                                   // user: %9
+  return %8 : $()                                 // id: %9
+} // end sil function '$S10access_wmo1CC11keyPathPropSivpACTk'
+
+// C.keyPathProp.getter
+// CHECK-LABEL: sil hidden [transparent] @$S10access_wmo1CC11keyPathPropSivg : $@convention(method) (@guaranteed C) -> Int64 {
+// CHECK: begin_access [read] [static] [no_nested_conflict] %{{.*}} : $*Int64
+// CHECK-LABEL: } // end sil function '$S10access_wmo1CC11keyPathPropSivg'
+sil hidden [transparent] @$S10access_wmo1CC11keyPathPropSivg : $@convention(method) (@guaranteed C) -> Int64 {
+// %0
+bb0(%0 : $C):
+  %1 = ref_element_addr %0 : $C, #C.keyPathProp   // user: %2
+  %2 = begin_access [read] [dynamic] [no_nested_conflict] %1 : $*Int64 // users: %4, %3
+  %3 = load %2 : $*Int64                          // user: %5
+  end_access %2 : $*Int64                         // id: %4
+  return %3 : $Int64                              // id: %5
+} // end sil function '$S10access_wmo1CC11keyPathPropSivg'
+
+// variable initialization expression of C.publicProp
+sil [transparent] @$S10access_wmo1CC10publicPropSivpfi : $@convention(thin) () -> Int64 {
+bb0:
+  %0 = integer_literal $Builtin.Int64, 0
+  %1 = struct $Int64 (%0 : $Builtin.Int64)
+  return %1 : $Int64
+} // end sil function '$S10access_wmo1CC10publicPropSivpfi'
+
+// C.publicProp.getter
+//
+// CHECK-LABEL: sil [transparent] @$S10access_wmo1CC10publicPropSivg : $@convention(method) (@guaranteed C) -> Int64 {
+// CHECK: begin_access [read] [dynamic] [no_nested_conflict] %{{.*}} : $*Int64
+// CHECK-LABEL: } // end sil function '$S10access_wmo1CC10publicPropSivg'
+sil [transparent] @$S10access_wmo1CC10publicPropSivg : $@convention(method) (@guaranteed C) -> Int64 {
+// %0
+bb0(%0 : $C):
+  %1 = ref_element_addr %0 : $C, #C.publicProp    // user: %2
+  %2 = begin_access [read] [dynamic] [no_nested_conflict] %1 : $*Int64 // users: %4, %3
+  %3 = load %2 : $*Int64                          // user: %5
+  end_access %2 : $*Int64                         // id: %4
+  return %3 : $Int64                              // id: %5
+} // end sil function '$S10access_wmo1CC10publicPropSivg'
+
+// C.publicProp.setter
+// CHECK-LABEL: sil [transparent] @$S10access_wmo1CC10publicPropSivs : $@convention(method) (Int64, @guaranteed C) -> () {
+// CHECK: bb0(%0 : $Int64, %1 : $C):
+// CHECK: begin_access [modify] [dynamic] [no_nested_conflict] %{{.*}} : $*Int64
+// CHECK-LABEL: } // end sil function '$S10access_wmo1CC10publicPropSivs'
+sil [transparent] @$S10access_wmo1CC10publicPropSivs : $@convention(method) (Int64, @guaranteed C) -> () {
+bb0(%0 : $Int64, %1 : $C):
+  %2 = ref_element_addr %1 : $C, #C.publicProp    // user: %3
+  %3 = begin_access [modify] [dynamic] [no_nested_conflict] %2 : $*Int64 // users: %5, %4
+  store %0 to %3 : $*Int64                        // id: %4
+  end_access %3 : $*Int64                         // id: %5
+  %6 = tuple ()                                   // user: %7
+  return %6 : $()                                 // id: %7
+} // end sil function '$S10access_wmo1CC10publicPropSivs'
+
+// closure #1 in C.publicProp.materializeForSet
+sil shared [transparent] @$S10access_wmo1CC10publicPropSivmytfU_ : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @in_guaranteed C, @thick C.Type) -> () {
+bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $*C, %3 : $@thick C.Type):
+  end_unpaired_access [dynamic] %1 : $*Builtin.UnsafeValueBuffer
+  %5 = tuple ()
+  return %5 : $()
+} // end sil function '$S10access_wmo1CC10publicPropSivmytfU_'
+
+// C.publicProp.materializeForSet
+// CHECK-LABEL: sil [transparent] @$S10access_wmo1CC10publicPropSivm : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed C) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
+// CHECK: begin_unpaired_access [modify] [dynamic] %{{.*}} : $*Int64, %{{.*}} : $*Builtin.UnsafeValueBuffer
+// CHECK-LABEL: } // end sil function '$S10access_wmo1CC10publicPropSivm'
+sil [transparent] @$S10access_wmo1CC10publicPropSivm : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @guaranteed C) -> (Builtin.RawPointer, Optional<Builtin.RawPointer>) {
+bb0(%0 : $Builtin.RawPointer, %1 : $*Builtin.UnsafeValueBuffer, %2 : $C):
+  %3 = ref_element_addr %2 : $C, #C.publicProp
+  begin_unpaired_access [modify] [dynamic] %3 : $*Int64, %1 : $*Builtin.UnsafeValueBuffer
+  %5 = address_to_pointer %3 : $*Int64 to $Builtin.RawPointer
+  // function_ref closure #1 in C.publicProp.materializeForSet
+  %6 = function_ref @$S10access_wmo1CC10publicPropSivmytfU_ : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @in_guaranteed C, @thick C.Type) -> ()
+  %7 = thin_function_to_pointer %6 : $@convention(method) (Builtin.RawPointer, @inout Builtin.UnsafeValueBuffer, @in_guaranteed C, @thick C.Type) -> () to $Builtin.RawPointer
+  %8 = enum $Optional<Builtin.RawPointer>, #Optional.some!enumelt.1, %7 : $Builtin.RawPointer
+  %9 = tuple (%5 : $Builtin.RawPointer, %8 : $Optional<Builtin.RawPointer>)
+  return %9 : $(Builtin.RawPointer, Optional<Builtin.RawPointer>)
+} // end sil function '$S10access_wmo1CC10publicPropSivm'

--- a/test/SILOptimizer/access_wmo.swift
+++ b/test/SILOptimizer/access_wmo.swift
@@ -1,0 +1,242 @@
+// RUN: %target-swift-frontend -parse-as-library -emit-sil -enforce-exclusivity=checked -O -primary-file %s %S/Inputs/access_wmo_def.swift | %FileCheck %s --check-prefix=PRIMARY
+// RUN: %target-swift-frontend -parse-as-library -emit-sil -enforce-exclusivity=checked -O %s %S/Inputs/access_wmo_def.swift | %FileCheck %s --check-prefix=WMO
+
+// ===---------------------------------------------------------------------===//
+// testAccessGlobal: Access a global defined in another file.
+//
+// In -primary-file mode, all begin_access markers remain dynamic.
+//
+// With WMO, only the begin_access markers for the internal global should be
+// promoted to static.
+// ===---------------------------------------------------------------------===//
+
+// readGlobal():
+// PRIMARY-LABEL: sil @$S10access_wmo10readGlobalSiyF : $@convention(thin) () -> Int {
+// function_ref internalGlobal.unsafeMutableAddressor
+// PRIMARY: [[F1:%.*]] = function_ref @$S10access_wmo14internalGlobalSivau : $@convention(thin) () -> Builtin.RawPointer
+// PRIMARY: [[G1:%.*]] = apply [[F1]]() : $@convention(thin) () -> Builtin.RawPointer
+// PRIMARY: [[P1:%.*]] = pointer_to_address [[G1]] : $Builtin.RawPointer to [strict] $*Int
+// PRIMARY: [[A1:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[P1]] : $*Int
+// PRIMARY: end_access [[A1]] : $*Int
+// function_ref publicGlobal.unsafeMutableAddressor
+// PRIMARY: [[F2:%.*]] = function_ref @$S10access_wmo12publicGlobalSivau : $@convention(thin) () -> Builtin.RawPointer
+// PRIMARY: [[G2:%.*]] = apply [[F2]]() : $@convention(thin) () -> Builtin.RawPointer
+// PRIMARY: [[P2:%.*]] = pointer_to_address [[G2]] : $Builtin.RawPointer to [strict] $*Int
+// PRIMARY: [[A2:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[P2]] : $*Int
+// PRIMARY: end_access [[A2]] : $*Int
+// PRIMARY-LABEL: } // end sil function '$S10access_wmo10readGlobalSiyF'
+//
+// WMO-LABEL: sil @$S10access_wmo10readGlobalSiyF : $@convention(thin) () -> Int {
+// WMO: [[G1:%.*]] = global_addr @$S10access_wmo14internalGlobalSivp : $*Int
+// WMO: [[A1:%.*]] = begin_access [read] [static] [no_nested_conflict] [[G1]] : $*Int
+// WMO: end_access [[A1]] : $*Int
+// WMO: [[G2:%.*]] = global_addr @$S10access_wmo12publicGlobalSivp : $*Int
+// WMO: [[A2:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[G2]] : $*Int
+// WMO: end_access [[A2]] : $*Int
+// WMO-LABEL: } // end sil function '$S10access_wmo10readGlobalSiyF'
+public func readGlobal() -> Int {
+  return internalGlobal + publicGlobal
+}
+
+@inline(never)
+func setInt(_ i: inout Int, _ v: Int) {
+  i = v
+}
+
+func inlinedSetInt(_ i: inout Int, _ v: Int) {
+  i = v
+}
+
+// testAccessGlobal(v:)
+// PRIMARY-LABEL: sil @$S10access_wmo16testAccessGlobal1vySi_tF : $@convention(thin) (Int) -> () {
+// PRIMARY: bb0(%0 : $Int):
+//
+// function_ref internalGlobal.unsafeMutableAddressor
+// PRIMARY: [[F1:%.*]] = function_ref @$S10access_wmo14internalGlobalSivau : $@convention(thin) () -> Builtin.RawPointer
+// PRIMARY: [[G1:%.*]] = apply [[F1]]() : $@convention(thin) () -> Builtin.RawPointer
+// PRIMARY: [[P1:%.*]] = pointer_to_address [[G1]] : $Builtin.RawPointer to [strict] $*Int
+// PRIMARY: [[A1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[P1]] : $*Int
+// function_ref setInt(_:_:)
+// PRIMARY: [[F2:%.*]] = function_ref @$S10access_wmo6setIntyySiz_SitF : $@convention(thin) (@inout Int, Int) -> ()
+// PRIMARY: apply [[F2]]([[A1]], %0) : $@convention(thin) (@inout Int, Int) -> ()
+// PRIMARY: end_access [[A1]] : $*Int
+//
+// function_ref publicGlobal.unsafeMutableAddressor
+// PRIMARY: [[F3:%.*]] = function_ref @$S10access_wmo12publicGlobalSivau : $@convention(thin) () -> Builtin.RawPointer
+// PRIMARY: [[G2:%.*]] = apply [[F3]]() : $@convention(thin) () -> Builtin.RawPointer
+// PRIMARY: [[P2:%.*]] = pointer_to_address [[G2]] : $Builtin.RawPointer to [strict] $*Int
+// PRIMARY: [[A2:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[P2]] : $*Int
+// PRIMARY: apply [[F2]]([[A2]], %0) : $@convention(thin) (@inout Int, Int) -> ()
+// PRIMARY: end_access [[A2]] : $*Int
+// PRIMARY-LABEL: } // end sil function '$S10access_wmo16testAccessGlobal1vySi_tF'
+//
+// WMO-LABEL: sil @$S10access_wmo16testAccessGlobal1vySi_tF : $@convention(thin) (Int) -> () {
+// WMO: bb0(%0 : $Int):
+// WMO: [[G1:%.*]] = global_addr @$S10access_wmo14internalGlobalSivp : $*Int
+// WMO: [[A1:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[G1]] : $*Int
+// function_ref setInt(_:_:)
+// WMO: [[F:%.*]] = function_ref @$S10access_wmo6setIntyySiz_SitF : $@convention(thin) (@inout Int, Int) -> ()
+// WMO: apply [[F]]([[A1]], %0) : $@convention(thin) (@inout Int, Int) -> ()
+// WMO: end_access [[A1]] : $*Int
+//
+// WMO: [[G2:%.*]] = global_addr @$S10access_wmo12publicGlobalSivp : $*Int
+// WMO: [[A2:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[G2]] : $*Int
+// function_ref setInt(_:_:)
+// WMO: apply [[F]]([[A2]], %0) : $@convention(thin) (@inout Int, Int) -> ()
+// WMO: end_access [[A2]] : $*Int
+// WMO-LABEL: } // end sil function '$S10access_wmo16testAccessGlobal1vySi_tF'
+public func testAccessGlobal(v: Int) {
+  setInt(&internalGlobal, v)
+  setInt(&publicGlobal, v)
+}
+
+@inline(never)
+func setKeyPath(_ c: C, _ kp: ReferenceWritableKeyPath<C, Int>, _ v: Int) {
+  c[keyPath: kp] = v
+}
+
+// ===---------------------------------------------------------------------===//
+// testAccessProp: Access a class property defined in another file.
+//
+// In -primary-file mode, all nonfinal access is behind
+// getter, setter, or materializeForSet calls. The final access remains
+// dynamic because the property is "visibleExternally". i.e. the compiler can't
+// see how other files are using it.
+// 
+// With WMO...
+//
+// access to setterProp and finalProp are promoted to static.
+// setterProp is a setter call, and finalProp is non-polymorphic.
+//
+// inlinedProp and internalProp could be also be promoted to static, but are
+// accessed via begin_unpaired_access in materializeForSet. (When the class
+// definition is in another file, the compiler unfortunately and unnecessarilly
+// generates materializeForSet calls even in "wmo" mode). These unpaired access
+// cannot (easily) be marked [no_nested_conflict]. Failing to mark the modify
+// as [no_nested_access] in turn inhibits optimization of the property reads.
+// Rather than teach the WMO to handle unpaired access, better solutions would
+// be either:
+//
+// - The inlinedProp case could be handled with a separate pass that promotes
+//   obvious unpaired access patterns to regular scoped access.
+//
+// - To handle internalProp SILGen could stop using materializeForSet for
+//   stored properties:
+//
+// See <rdar://problem/41302183> [exclusivity] Optimize formal access from
+// inlined materializeForSet.
+//
+// keyPathProp is promoted to static enforcement because a settable_property
+// keypath can only be formally accessed within the getter and setter, which
+// the compiler can already see.
+//
+// Perversely, finalKeyPathProp *cannot* be promoted to static enforcement
+// because a storedProperty keypath is formed. The compiler does not currently
+// attempt to track down all uses of a storedProperty keypath. The actual
+// access occurs via a Builtin that takes a RawPointer. The formation of a
+// stored_property keypath is always conservatively considered a possible
+// nested access.
+// ===---------------------------------------------------------------------===//
+public func readProp(c: C) -> Int {
+  return c.setterProp + c.finalProp + c.inlinedProp + c.internalProp
+  + c.keyPathProp + c.finalKeyPathProp + c.publicProp
+}
+public func testAccessProp(c: C, v: Int) {
+  c.setterProp = v
+  setInt(&c.finalProp, v)
+  inlinedSetInt(&c.inlinedProp, v)
+  setInt(&c.internalProp, v)
+  setKeyPath(c, \C.keyPathProp, v)
+  setKeyPath(c, \C.finalKeyPathProp, v)
+  setInt(&c.publicProp, v)
+}
+
+// PRIMARY-LABEL: sil @$S10access_wmo8readProp1cSiAA1CC_tF : $@convention(thin) (@guaranteed C) -> Int {
+// PRIMARY-NOT: begin_{{.*}}access
+// PRIMARY: [[E1:%.*]] = ref_element_addr %0 : $C, #C.finalProp
+// PRIMARY: [[A1:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[E1]] : $*Int
+// PRIMARY: end_access [[A1]] : $*Int
+// PRIMARY-NOT: begin_{{.*}}access
+// PRIMARY: [[E2:%.*]] = ref_element_addr %0 : $C, #C.finalKeyPathProp
+// PRIMARY: [[A2:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[E2]] : $*Int
+// PRIMARY: end_access [[A2]] : $*Int
+// PRIMARY-NOT: begin_{{.*}}access
+// PRIMARY-LABEL:  } // end sil function '$S10access_wmo8readProp1cSiAA1CC_tF'
+//
+// WMO-LABEL: sil @$S10access_wmo8readProp1cSiAA1CC_tF : $@convention(thin) (@guaranteed C) -> Int {
+// WMO: [[E1:%.*]] = ref_element_addr %0 : $C, #C.setterProp
+// WMO: [[A1:%.*]] = begin_access [read] [static] [no_nested_conflict] [[E1]] : $*Int
+// WMO: end_access [[A1]] : $*Int
+//
+// WMO: [[E2:%.*]] = ref_element_addr %0 : $C, #C.finalProp
+// WMO: [[A2:%.*]] = begin_access [read] [static] [no_nested_conflict] [[E2]] : $*Int
+// WMO: end_access [[A2]] : $*Int
+//
+// WMO: [[E3:%.*]] = ref_element_addr %0 : $C, #C.inlinedProp
+// WMO: [[A3:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[E3]] : $*Int
+// WMO: end_access [[A3]] : $*Int
+//
+// WMO: [[E4:%.*]] = ref_element_addr %0 : $C, #C.internalProp
+// WMO: [[A4:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[E4]] : $*Int
+// WMO: end_access [[A4]] : $*Int
+//
+// WMO: [[E5:%.*]] = ref_element_addr %0 : $C, #C.keyPathProp
+// WMO: [[A5:%.*]] = begin_access [read] [static] [no_nested_conflict] [[E5]] : $*Int
+// WMO: end_access [[A5]] : $*Int
+//
+// WMO: [[E6:%.*]] = ref_element_addr %0 : $C, #C.finalKeyPathProp
+// WMO: [[A6:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[E6]] : $*Int
+// WMO: end_access [[A6]] : $*Int
+//
+// WMO: [[E7:%.*]] = ref_element_addr %0 : $C, #C.publicProp
+// WMO: [[A7:%.*]] = begin_access [read] [dynamic] [no_nested_conflict] [[E7]] : $*Int
+// WMO: end_access [[A7]] : $*Int
+// WMO-LABEL: } // end sil function '$S10access_wmo8readProp1cSiAA1CC_tF'
+
+// PRIMARY-LABEL: sil @$S10access_wmo14testAccessProp1c1vyAA1CC_SitF : $@convention(thin) (@guaranteed C, Int) -> () {
+// PRIMARY-NOT: begin_{{.*}}access
+// PRIMARY: [[E1:%.*]] = ref_element_addr %0 : $C, #C.finalProp
+// PRIMARY: [[A1:%.*]] = begin_access [modify] [dynamic] [no_nested_conflict] [[E1]] : $*Int
+// function_ref setInt(_:_:)
+// PRIMARY: [[F1:%.*]] = function_ref @$S10access_wmo6setIntyySiz_SitF : $@convention(thin) (@inout Int, Int) -> ()
+// PRIMARY: apply [[F1]]([[A1]], %1) : $@convention(thin) (@inout Int, Int) -> ()
+// PRIMARY: end_access [[A1]] : $*Int
+// PRIMARY-NOT: begin_{{.*}}access
+// PRIMARY-LABEL: } // end sil function '$S10access_wmo14testAccessProp1c1vyAA1CC_SitF'
+
+// WMO-LABEL: sil @$S10access_wmo14testAccessProp1c1vyAA1CC_SitF : $@convention(thin) (@guaranteed C, Int) -> () {
+// WMO: [[E1:%.*]] = ref_element_addr %0 : $C, #C.setterProp
+// WMO: [[A1:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[E1]] : $*Int
+// WMO: end_access [[A1]] : $*Int
+//
+// WMO: [[E2:%.*]] = ref_element_addr %0 : $C, #C.finalProp
+// WMO: [[A2:%.*]] = begin_access [modify] [static] [no_nested_conflict] [[E2]] : $*Int
+// function_ref setInt(_:_:)
+// WMO: [[F1:%.*]] = function_ref @$S10access_wmo6setIntyySiz_SitF : $@convention(thin) (@inout Int, Int) -> ()
+// WMO: apply [[F1]]([[A2]], %1) : $@convention(thin) (@inout Int, Int) -> ()
+// WMO: end_access [[A2]] : $*Int
+//
+// WMO: [[E3:%.*]] = ref_element_addr %0 : $C, #C.inlinedProp
+// WMO: begin_unpaired_access [modify] [dynamic] [[E3]] : $*Int, %{{.*}} : $*Builtin.UnsafeValueBuffer
+// WMO: end_unpaired_access [dynamic] %{{.*}} : $*Builtin.UnsafeValueBuffer
+//
+// WMO: [[E4:%.*]] = ref_element_addr %0 : $C, #C.internalProp
+// WMO: begin_unpaired_access [modify] [dynamic] [[E4]] : $*Int, %{{.*}} : $*Builtin.UnsafeValueBuffer
+// WMO: [[D4:%.*]] = mark_dependence [[E4]] : $*Int on %0 : $C
+// WMO: apply [[F1]]([[D4]], %1) : $@convention(thin) (@inout Int, Int) -> ()
+// WMO: end_unpaired_access [dynamic] %{{.*}} : $*Builtin.UnsafeValueBuffer
+//
+// WMO: [[KP:%.*]] = keypath $ReferenceWritableKeyPath<C, Int>, (root $C; settable_property $Int,  id #C.keyPathProp!getter.1 : (C) -> () -> Int, getter @$S10access_wmo1CC11keyPathPropSivpACTK : $@convention(thin) (@in_guaranteed C) -> @out Int, setter @$S10access_wmo1CC11keyPathPropSivpACTk : $@convention(thin) (@in_guaranteed Int, @in_guaranteed C) -> ())
+// function_ref setKeyPath(_:_:_:)
+// WMO: [[F2:%.*]] = function_ref @$S10access_wmo10setKeyPathyyAA1CC_s017ReferenceWritabledE0CyADSiGSitF : $@convention(thin) (@guaranteed C, @guaranteed ReferenceWritableKeyPath<C, Int>, Int) -> ()
+// WMO: apply [[F2]](%0, [[KP]], %1) : $@convention(thin) (@guaranteed C, @guaranteed ReferenceWritableKeyPath<C, Int>, Int) -> ()
+//
+// WMO: [[FKP:%.*]] = keypath $ReferenceWritableKeyPath<C, Int>, (root $C; stored_property #C.finalKeyPathProp : $Int)
+// WMO: apply [[F2]](%0, [[FKP]], %1) : $@convention(thin) (@guaranteed C, @guaranteed ReferenceWritableKeyPath<C, Int>, Int) -> ()
+//
+// WMO: [[E4:%.*]] = ref_element_addr %0 : $C, #C.publicProp
+// WMO: begin_unpaired_access [modify] [dynamic] [[E4]] : $*Int, %{{.*}} : $*Builtin.UnsafeValueBuffer
+// WMO: [[D4:%.*]] = mark_dependence [[E4]] : $*Int on %0 : $C
+// WMO: apply [[F1]]([[D4]], %1) : $@convention(thin) (@inout Int, Int) -> ()
+// WMO: end_unpaired_access [dynamic] %{{.*}} : $*Builtin.UnsafeValueBuffer
+// WMO-LABEL: } // end sil function '$S10access_wmo14testAccessProp1c1vyAA1CC_SitF'

--- a/test/SILOptimizer/access_wmo_diagnose.swift
+++ b/test/SILOptimizer/access_wmo_diagnose.swift
@@ -1,0 +1,14 @@
+// RUN: %target-swift-frontend -parse-as-library -emit-sil -enforce-exclusivity=checked -primary-file %s -o /dev/null -verify
+
+// AccessEnforcementWMO assumes that the only way to address a global or static
+// property is via a formal begin_access. If we ever allow keypaths for static
+// properties, which I think is conceivable, then this test will fail to produce
+// a diagnostic error and AccessEnforcementWMO must be fixed to handle "meta"
+// keypaths.
+public class C {
+  public static var globalProp: Int = 0
+}
+
+public func testGlobalProp() {
+  let a: AnyKeyPath = \C.globalProp // expected-error{{type of expression is ambiguous without more context}}
+}


### PR DESCRIPTION
I'll push the earlier commits first as separate PRs after adding more tests for SIL global decl parsing. I'm posting this now so people can comment on the actual optimization, which is only the final commit.

These are my local results. The few "regressions" are pure luck based on linker decisions (i.e. changes in the binary size of unrelated benchmarks affect the score of these). In the cases I looked at the pre-linked binaries are identical. Also, I've seen recent "improvements" by the same amount. At any any rate, it's inconveivable that this optimization could prohibit any other optimization.

**Regressions:** 
```
Sim2DArray                                        +22.7%   **0.82x** 
MapReduce                                         +19.8%   **0.83x** 
Calculator                                        +11.3%   **0.90x** 
StringHasSuffixAscii                              +8.9%    **0.92x** 
```
**Improvements**
```
RecursiveOwnedParameter                           -93.7%   **15.75x** 
ReversedArray                                     -89.1%   **9.17x** 
ReversedDictionary                                -81.0%   **5.28x** 
ArrayInClass                                      -74.3%   **3.89x** 
Ary3                                              -71.7%   **3.54x** 
Random                                            -66.2%   **2.96x** 
StringWalk                                        -63.5%   **2.74x** 
LevenshteinDistance                               -55.4%   **2.24x** 
Voronoi                                           -50.0%   **2.00x** 
HashTest                                          -47.7%   **1.91x** 
Richards                                          -46.7%   **1.88x** 
NopDeinit                                         -44.8%   **1.81x** 
Rectangles                                        -41.3%   **1.70x** 
MultiFileTogether                                 -33.1%   **1.50x** 
MultiFileSeparate                                 -32.8%   **1.49x** 
SetIntersect_OfObjects                            -26.5%   **1.36x** 
Ary2                                              -22.7%   **1.29x** 
Prims                                             -21.9%   **1.28x** 
PrimsSplit                                        -21.8%   **1.28x** 
SetExclusiveOr_OfObjects                          -19.4%   **1.24x** 
ObjectAllocation                                  -18.6%   **1.23x** 
DropFirstAnySeqCRangeIterLazy                     -17.2%   **1.21x** 
DropFirstAnySeqCRangeIter                         -17.2%   **1.21x** 
Dictionary4OfObjects                              -16.5%   **1.20x** 
SetUnion_OfObjects                                -15.3%   **1.18x** 
DropWhileCountableRangeLazy                       -15.3%   **1.18x** 
CharIndexing_[*]_Backwards                        -14.6%   **1.17x** 
(all 17 variants of CharIndexing are -14%, 1.17x)
CharIteration_[*]_Backwards                       -14.3%   **1.17x** 
(all 17 variants of CharIteration take 14%, 1.17x)
RGBHistogramOfObjects                             -14.2%   **1.17x** 
DeltaBlue                                         -13.5%   **1.16x** 
CharacterPropertiesPrecomputed                    -12.4%   **1.14x** 
DictionarySwapOfObjects                           -9.9%    **1.11x** 
ClassArrayGetter                                  -9.8%    **1.11x** 
DictionaryGroupOfObjects                          -7.9%    **1.09x** 
DictionaryRemoveOfObjects                         -7.2%    **1.08x** 
Dictionary4OfObjectsLegacy                        -6.8%    **1.07x** 
Havlak                                            -6.4%    **1.07x** 
COWTree                                           -6.2%    **1.07x** 
Radix2CooleyTukeyf                                -5.6%    **1.06x** 

```