### PR TITLE
SILGen: Emit "trivial" property descriptors for properties that withhold no information about their implementation.

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -4228,6 +4228,25 @@ public:
     llvm_unreachable("bad storage kind");
   }
 
+  /// \brief Return true if this is a VarDecl that has storage associated with
+  /// it which can be trivially accessed.
+  bool hasTrivialStorage() const {
+    switch (getStorageKind()) {
+    case Stored:
+    case StoredWithTrivialAccessors:
+      return true;
+    case StoredWithObservers:
+    case InheritedWithObservers:
+    case Computed:
+    case ComputedWithMutableAddress:
+    case Addressed:
+    case AddressedWithTrivialAccessors:
+    case AddressedWithObservers:
+      return false;
+    }
+    llvm_unreachable("bad storage kind");
+  }
+
   /// \brief Return true if this object has a getter (and, if mutable,
   /// a setter and a materializeForSet).
   bool hasAccessorFunctions() const {
@@ -4456,7 +4475,8 @@ public:
 
   /// Determine how this storage declaration should actually be accessed.
   AccessStrategy getAccessStrategy(AccessSemantics semantics,
-                                   AccessKind accessKind) const;
+                                   AccessKind accessKind,
+                                   DeclContext *accessFromDC = nullptr) const;
 
   /// \brief Should this declaration behave as if it must be accessed
   /// resiliently, even when we're building a non-resilient module?

--- a/include/swift/SIL/SILProperty.h
+++ b/include/swift/SIL/SILProperty.h
@@ -42,11 +42,11 @@ private:
   AbstractStorageDecl *Decl;
   
   /// The key path component that represents its implementation.
-  KeyPathPatternComponent Component;
+  Optional<KeyPathPatternComponent> Component;
 
   SILProperty(bool Serialized,
               AbstractStorageDecl *Decl,
-              KeyPathPatternComponent Component)
+              Optional<KeyPathPatternComponent> Component)
     : Serialized(Serialized), Decl(Decl), Component(Component)
   {}
 
@@ -54,13 +54,19 @@ public:
   static SILProperty *create(SILModule &M,
                              bool Serialized,
                              AbstractStorageDecl *Decl,
-                             KeyPathPatternComponent Component);
+                             Optional<KeyPathPatternComponent> Component);
   
   bool isSerialized() const { return Serialized; }
   
   AbstractStorageDecl *getDecl() const { return Decl; }
   
-  const KeyPathPatternComponent &getComponent() const { return Component; }
+  bool isTrivial() const {
+    return !Component.hasValue();
+  }
+  
+  const Optional<KeyPathPatternComponent> &getComponent() const {
+    return Component;
+  }
   
   void print(SILPrintContext &Ctx) const;
   void dump() const;

--- a/include/swift/SIL/TypeLowering.h
+++ b/include/swift/SIL/TypeLowering.h
@@ -983,6 +983,8 @@ public:
   CanSILBoxType getBoxTypeForEnumElement(SILType enumType,
                                          EnumElementDecl *elt);
 
+  bool canStorageUseStoredKeyPathComponent(AbstractStorageDecl *decl);
+  
 private:
   CanType getLoweredRValueType(AbstractionPattern origType, CanType substType);
 

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -1414,7 +1414,8 @@ ValueDecl::getAccessSemanticsFromContext(const DeclContext *UseDC,
 
 AccessStrategy
 AbstractStorageDecl::getAccessStrategy(AccessSemantics semantics,
-                                       AccessKind accessKind) const {
+                                       AccessKind accessKind,
+                                       DeclContext *accessFromDC) const {
   switch (semantics) {
   case AccessSemantics::DirectToStorage:
     switch (getStorageKind()) {
@@ -1481,7 +1482,14 @@ AbstractStorageDecl::getAccessStrategy(AccessSemantics semantics,
       // This is done by using DirectToStorage semantics above, with the
       // understanding that the access semantics are with respect to the
       // resilience domain of the accessor's caller.
-      if (isResilient())
+      bool resilient;
+      if (accessFromDC)
+        resilient = isResilient(accessFromDC->getParentModule(),
+                                ResilienceExpansion::Maximal);
+      else
+        resilient = isResilient();
+      
+      if (resilient)
         return AccessStrategy::DirectToAccessor;
 
       if (storageKind == StoredWithObservers ||

--- a/lib/IRGen/IRGenModule.h
+++ b/lib/IRGen/IRGenModule.h
@@ -570,6 +570,8 @@ public:
   llvm::PointerType *OpenedErrorTriplePtrTy; /// { %swift.opaque*, %swift.type*, i8** }*
   llvm::PointerType *WitnessTablePtrPtrTy;   /// i8***
 
+  llvm::GlobalVariable *TheTrivialPropertyDescriptor = nullptr;
+
   /// Used to create unique names for class layout types with tail allocated
   /// elements.
   unsigned TailElemTypeID = 0;

--- a/lib/SIL/SILModule.cpp
+++ b/lib/SIL/SILModule.cpp
@@ -849,7 +849,7 @@ void SILModule::setOptRecordStream(
 SILProperty *SILProperty::create(SILModule &M,
                                  bool Serialized,
                                  AbstractStorageDecl *Decl,
-                                 KeyPathPatternComponent Component) {
+                                 Optional<KeyPathPatternComponent> Component) {
   auto prop = new (M) SILProperty(Serialized, Decl, Component);
   M.properties.push_back(prop);
   return prop;

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -2648,10 +2648,10 @@ void SILProperty::print(SILPrintContext &Ctx) const {
   if (auto sig = getDecl()->getInnermostDeclContext()
                           ->getGenericSignatureOfContext()) {
     sig->getCanonicalSignature()->print(OS, Options);
-    OS << ' ';
   }
-  OS << '(';
-  SILPrinter(Ctx).printKeyPathPatternComponent(getComponent());
+  OS << " (";
+  if (auto component = getComponent())
+    SILPrinter(Ctx).printKeyPathPatternComponent(*component);
   OS << ")\n";
 }
 

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -4814,7 +4814,6 @@ void SILProperty::verify(const SILModule &M) const {
 
   auto *decl = getDecl();
   auto *dc = decl->getInnermostDeclContext();
-  auto &component = getComponent();
   
   // TODO: base type for global/static descriptors
   auto sig = dc->getGenericSignatureOfContext();
@@ -4844,21 +4843,22 @@ void SILProperty::verify(const SILModule &M) const {
       }
     };
 
-  verifyKeyPathComponent(const_cast<SILModule&>(M),
-    require,
-    baseTy,
-    leafTy,
-    component,
-    {},
-    canSig,
-    subs,
-    /*property descriptor*/true,
-    hasIndices);
-  
-  // verifyKeyPathComponent updates baseTy to be the projected type of the
-  // component, which should be the same as the type of the declared storage
-  require(baseTy == leafTy,
-          "component type of property descriptor should match type of storage");
+  if (auto &component = getComponent()) {
+    verifyKeyPathComponent(const_cast<SILModule&>(M),
+      require,
+      baseTy,
+      leafTy,
+      *component,
+      {},
+      canSig,
+      subs,
+      /*property descriptor*/true,
+      hasIndices);
+    // verifyKeyPathComponent updates baseTy to be the projected type of the
+    // component, which should be the same as the type of the declared storage
+    require(baseTy == leafTy,
+            "component type of property descriptor should match type of storage");
+  }
 }
 
 /// Verify that a vtable follows invariants.

--- a/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
+++ b/lib/SILOptimizer/IPO/DeadFunctionElimination.cpp
@@ -599,7 +599,9 @@ class DeadFunctionElimination : FunctionLivenessComputation {
     }
     // Check property descriptor implementations.
     for (SILProperty &P : Module->getPropertyList()) {
-      ensureKeyPathComponentIsAlive(P.getComponent());
+      if (auto component = P.getComponent()) {
+        ensureKeyPathComponentIsAlive(*component);
+      }
     }
 
   }

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -762,11 +762,15 @@ static SILDeclRef getSILDeclRef(ModuleFile *MF,
   return DRef;
 }
 
-KeyPathPatternComponent
+Optional<KeyPathPatternComponent>
 SILDeserializer::readKeyPathComponent(ArrayRef<uint64_t> ListOfValues,
                                       unsigned &nextValue) {
   auto kind =
     (KeyPathComponentKindEncoding)ListOfValues[nextValue++];
+  
+  if (kind == KeyPathComponentKindEncoding::Trivial)
+    return None;
+  
   auto type = MF->getType(ListOfValues[nextValue++])
     ->getCanonicalType();
 
@@ -860,7 +864,11 @@ SILDeserializer::readKeyPathComponent(ArrayRef<uint64_t> ListOfValues,
                                                 indicesEquals, indicesHash,
                                                 type);
   }
+  case KeyPathComponentKindEncoding::Trivial:
+    llvm_unreachable("handled above");
   }
+  
+  llvm_unreachable("invalid key path component kind encoding");
 }
 
 bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
@@ -2338,7 +2346,7 @@ bool SILDeserializer::readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
     SmallVector<KeyPathPatternComponent, 4> components;
     components.reserve(numComponents);
     while (numComponents-- > 0) {
-      components.push_back(readKeyPathComponent(ListOfValues, nextValue));
+      components.push_back(*readKeyPathComponent(ListOfValues, nextValue));
     }
     
     SmallVector<Requirement, 4> requirements;

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -114,7 +114,7 @@ namespace swift {
     readDefaultWitnessTable(serialization::DeclID,
                             SILDefaultWitnessTable *existingWt);
 
-    KeyPathPatternComponent
+    Optional<KeyPathPatternComponent>
     readKeyPathComponent(ArrayRef<uint64_t> ListOfValues, unsigned &nextValue);
     
 public:

--- a/lib/Serialization/SILFormat.h
+++ b/lib/Serialization/SILFormat.h
@@ -85,6 +85,7 @@ enum class KeyPathComponentKindEncoding : uint8_t {
   OptionalForce,
   OptionalWrap,
   External,
+  Trivial,
 };
 enum class KeyPathComputedComponentIdKindEncoding : uint8_t {
   Property,

--- a/lib/Serialization/SerializeSIL.cpp
+++ b/lib/Serialization/SerializeSIL.cpp
@@ -2222,8 +2222,11 @@ void SILSerializer::writeSILProperty(const SILProperty &prop) {
   SmallVector<ValueID, 4> componentValues;
   SmallVector<ProtocolConformanceRef, 4> serializeAfter;
   
-  writeKeyPathPatternComponent(prop.getComponent(),
-                               componentValues, serializeAfter);
+  if (auto component = prop.getComponent()) {
+    writeKeyPathPatternComponent(*component, componentValues, serializeAfter);
+  } else {
+    componentValues.push_back((unsigned)KeyPathComponentKindEncoding::Trivial);
+  }
   
   PropertyLayout::emitRecord(
     Out, ScratchRecord,

--- a/stdlib/public/SwiftShims/KeyPath.h
+++ b/stdlib/public/SwiftShims/KeyPath.h
@@ -56,6 +56,9 @@ static const __swift_uint32_t _SwiftKeyPathComponentHeader_OptionalTag
 static const __swift_uint32_t _SwiftKeyPathComponentHeader_ExternalTag
   = 0x7F;
 
+static const __swift_uint32_t
+_SwiftKeyPathComponentHeader_TrivialPropertyDescriptorMarker = 0xFFFFFFFFU;
+
 static const __swift_uint32_t _SwiftKeyPathComponentHeader_MaximumOffsetPayload
   = 0x00FFFFFCU;
   

--- a/test/IRGen/property_descriptor.sil
+++ b/test/IRGen/property_descriptor.sil
@@ -15,6 +15,8 @@ public struct ExternalGeneric<T: Comparable> {
 
   public subscript<U: Hashable>(_: U) -> T { get set }
 
+  public var computedWithTrivialDescriptor: Int { get }
+
   init()
 }
 
@@ -27,6 +29,8 @@ public struct External {
 
   public subscript(_: String) -> Int { get set }
 
+  public var computedWithTrivialDescriptor: Int { get }
+
   init()
 }
 
@@ -36,20 +40,20 @@ public struct ExternalReabstractions<T> {
 }
 
 // -- 0xff_fffe - struct property, offset resolved from field offset vector in metadata
-// CHECK-64: @"$S19property_descriptor15ExternalGenericV2roxvpMV" ={{( dllexport)?}}{{( protected)?}} constant
+// CHECK-64: @"$S19property_descriptor15ExternalGenericV2roxvpMV" =
 // CHECK-64-SAME: <{ <i32 0x00ff_fffe>, i32 32 }>, align 8
-// CHECK-32: @"$S19property_descriptor15ExternalGenericV2roxvpMV" ={{( dllexport)?}}{{( protected)?}} constant
+// CHECK-32: @"$S19property_descriptor15ExternalGenericV2roxvpMV" =
 // CHECK-32-SAME: <{ <i32 0x00ff_fffe>, i32 16 }>, align 4
 sil_property #ExternalGeneric.ro <T: Comparable> (
   stored_property #ExternalGeneric.ro : $T)
-// CHECK-64: @"$S19property_descriptor15ExternalGenericV2rwxvpMV" ={{( dllexport)?}}{{( protected)?}} constant
+// CHECK-64: @"$S19property_descriptor15ExternalGenericV2rwxvpMV" =
 // CHECK-64-SAME: <{ <i32 0x00ff_fffe>, i32 36 }>, align 8
-// CHECK-32: @"$S19property_descriptor15ExternalGenericV2rwxvpMV" ={{( dllexport)?}}{{( protected)?}} constant
+// CHECK-32: @"$S19property_descriptor15ExternalGenericV2rwxvpMV" =
 // CHECK-32-SAME: <{ <i32 0x00ff_fffe>, i32 20 }>, align 4
 sil_property #ExternalGeneric.rw <T: Comparable> (
   stored_property #ExternalGeneric.rw : $T)
 
-// CHECK: @"$S19property_descriptor15ExternalGenericV10computedROxvpMV" ={{( dllexport)?}}{{( protected)?}} constant
+// CHECK: @"$S19property_descriptor15ExternalGenericV10computedROxvpMV" =
 // -- 0x0108_0000 - computed, readonly, has arguments
 // CHECK-SAME:  <{ <i32 0x0108_0000>,
 // CHECK-SAME:     @id_computed, 
@@ -62,7 +66,7 @@ sil_property #ExternalGeneric.computedRO <T: Comparable> (
     id @id_computed : $@convention(thin) () -> (),
     getter @get_computed_generic : $@convention(thin) <T: Comparable> (@in_guaranteed ExternalGeneric<T>) -> @out T)
 
-// CHECK: @"$S19property_descriptor15ExternalGenericV10computedRWxvpMV" ={{( dllexport)?}}{{( protected)?}} constant
+// CHECK: @"$S19property_descriptor15ExternalGenericV10computedRWxvpMV" =
 // -- 0x01c8_0000 - computed, settable, mutating, has arguments
 // CHECK-SAME:  <{ <i32 0x01c8_0000>, 
 // CHECK-SAME:     @id_computed,
@@ -77,7 +81,7 @@ sil_property #ExternalGeneric.computedRW <T: Comparable> (
     getter @get_computed_generic : $@convention(thin) <T: Comparable> (@in_guaranteed ExternalGeneric<T>) -> @out T,
     setter @set_computed_generic : $@convention(thin) <T: Comparable> (@in_guaranteed T, @inout ExternalGeneric<T>) -> ())
 
-// CHECK: @"$S19property_descriptor15ExternalGenericVyxqd__cSHRd__luipMV" ={{( dllexport)?}}{{( protected)?}} constant
+// CHECK: @"$S19property_descriptor15ExternalGenericVyxqd__cSHRd__luipMV" =
 // -- 0x01c8_0000 - computed, settable, mutating, has arguments
 // CHECK-SAME:  <{ <i32 0x01c8_0000>, 
 // CHECK-SAME:     @id_computed,
@@ -92,9 +96,9 @@ sil_property #ExternalGeneric.subscript <T: Comparable><U: Hashable> (
     getter @get_computed_generic_subscript : $@convention(thin) <T: Comparable><U: Hashable> (@in_guaranteed ExternalGeneric<T>, UnsafeRawPointer) -> @out T,
     setter @set_computed_generic_subscript : $@convention(thin) <T: Comparable><U: Hashable> (@in_guaranteed T, @inout ExternalGeneric<T>, UnsafeRawPointer) -> ())
 
-// CHECK: @"$S19property_descriptor8ExternalV2roSivpMV" ={{( dllexport)?}}{{( protected)?}} constant <{ i32 }> zeroinitializer, align 4
-// CHECK-64: @"$S19property_descriptor8ExternalV2rwSivpMV" ={{( dllexport)?}}{{( protected)?}} constant <{ i32 }> <{ i32 8 }>, align 4
-// CHECK-32: @"$S19property_descriptor8ExternalV2rwSivpMV" ={{( dllexport)?}}{{( protected)?}} constant <{ i32 }> <{ i32 4 }>, align 4
+// CHECK: @"$S19property_descriptor8ExternalV2roSivpMV" =
+// CHECK-64: @"$S19property_descriptor8ExternalV2rwSivpMV" =
+// CHECK-32: @"$S19property_descriptor8ExternalV2rwSivpMV" =
 sil_property #External.ro (stored_property #External.ro : $Int)
 sil_property #External.rw (stored_property #External.rw : $Int)
 sil_property #External.computedRO (
@@ -120,6 +124,17 @@ sil_property #ExternalReabstractions.reabstracted <T> (
     id ##ExternalReabstractions.reabstracted,
     getter @get_reabstracted : $@convention(thin) <T> (@in_guaranteed ExternalReabstractions<T>) -> @out @callee_guaranteed (@in_guaranteed ()) -> @out (),
     setter @set_reabstracted : $@convention(thin) <T> (@in_guaranteed @callee_guaranteed (@in_guaranteed ()) -> @out (), @inout ExternalReabstractions<T>) -> ())
+
+// All trivial descriptors should share a definition by aliasing to the common
+// definition
+
+// CHECK-LABEL: @"$S19property_descriptor15ExternalGenericV29computedWithTrivialDescriptorSivpMV" =
+// CHECK-SAME:    { i32 } { i32 -1 }, align 4
+sil_property #ExternalGeneric.computedWithTrivialDescriptor <T: Comparable> ()
+
+// CHECK-LABEL: @"$S19property_descriptor8ExternalV29computedWithTrivialDescriptorSivpMV" =
+// CHECK-SAME:    alias {{.*}} @"$S19property_descriptor15ExternalGenericV29computedWithTrivialDescriptorSivpMV"
+sil_property #External.computedWithTrivialDescriptor ()
 
 sil @id_computed : $@convention(thin) () -> ()
 sil @get_computed : $@convention(thin) (@in_guaranteed External) -> @out Int

--- a/test/SILGen/keypath_property_descriptors.swift
+++ b/test/SILGen/keypath_property_descriptors.swift
@@ -1,4 +1,5 @@
-// RUN: %target-swift-emit-silgen -enable-key-path-resilience %s | %FileCheck %s
+// RUN: %target-swift-emit-silgen -enable-key-path-resilience %s | %FileCheck --check-prefix=CHECK --check-prefix=NONRESILIENT %s
+// RUN: %target-swift-emit-silgen -enable-resilience -enable-key-path-resilience %s | %FileCheck --check-prefix=CHECK --check-prefix=RESILIENT %s
 
 // TODO: globals should get descriptors
 public var a: Int = 0
@@ -16,14 +17,16 @@ internal var d: Int = 0
 private var e: Int = 0
 
 public struct A {
-  // CHECK-LABEL: sil_property #A.a
+  // NONRESILIENT-LABEL: sil_property #A.a ()
+  // RESILIENT-LABEL: sil_property #A.a (stored_property
   public var a: Int = 0
 
-  // CHECK-LABEL: sil_property #A.b
+  // CHECK-LABEL: sil_property #A.b ()
   @inlinable
   public var b: Int { return 0 }
 
-  // CHECK-LABEL: sil_property #A.c
+  // NONRESILIENT-LABEL: sil_property #A.c ()
+  // RESILIENT-LABEL: sil_property #A.c (stored_property
   @usableFromInline
   internal var c: Int = 0
 
@@ -50,12 +53,12 @@ public struct A {
   // CHECK-NOT: sil_property #A.f
   private static var f: Int = 0
 
-  // CHECK-LABEL: sil_property #A.subscript{{.*}} id @{{.*}}1a
+  // CHECK-LABEL: sil_property #A.subscript{{.*}} (){{$}}
   public subscript(a x: Int) -> Int { return x }
-  // CHECK-LABEL: sil_property #A.subscript{{.*}} id @{{.*}}1b
+  // CHECK-LABEL: sil_property #A.subscript{{.*}} (){{$}}
   @inlinable
   public subscript(b x: Int) -> Int { return x }
-  // CHECK-LABEL: sil_property #A.subscript{{.*}} id @{{.*}}1c
+  // CHECK-LABEL: sil_property #A.subscript{{.*}} (){{$}}
   @usableFromInline
   internal subscript(c x: Int) -> Int { return x }
   
@@ -65,12 +68,12 @@ public struct A {
   fileprivate subscript(e x: Int) -> Int { return x }
   private subscript(f x: Int) -> Int { return x }
 
-  // CHECK-LABEL: sil_property #A.subscript{{.*}} id @{{.*}}1a
+  // CHECK-LABEL: sil_property #A.subscript{{.*}} (){{$}}
   public subscript<T>(a x: T) -> T { return x }
-  // CHECK-LABEL: sil_property #A.subscript{{.*}} id @{{.*}}1b
+  // CHECK-LABEL: sil_property #A.subscript{{.*}} (){{$}}
   @inlinable
   public subscript<T>(b x: T) -> T { return x }
-  // CHECK-LABEL: sil_property #A.subscript{{.*}} id @{{.*}}1c
+  // CHECK-LABEL: sil_property #A.subscript{{.*}} (){{$}}
   @usableFromInline
   internal subscript<T>(c x: T) -> T { return x }
   
@@ -81,6 +84,7 @@ public struct A {
   private subscript<T>(f x: T) -> T { return x }
 
   // no descriptor
+  // CHECK-NOT: sil_property #A.count
   public var count: Int {
     mutating get {
       _count += 1
@@ -91,6 +95,39 @@ public struct A {
     }
   }
 
+  // CHECK-NOT: sil_property #A._count
   private var _count: Int = 0
+
+  // NONRESILIENT-LABEL: sil_property #A.getSet ()
+  // RESILIENT-LABEL: sil_property #A.getSet (settable_property
+  public var getSet: Int {
+    get { return 0 }
+    set { }
+  }
+
+  // CHECK-LABEL: sil_property #A.hiddenSetter (settable_property
+  public internal(set) var hiddenSetter: Int {
+    get { return 0 }
+    set { }
+  }
+
+  // NONRESILIENT-LABEL: sil_property #A.usableFromInlineSetter ()
+  // RESILIENT-LABEL: sil_property #A.usableFromInlineSetter (settable_property
+  public internal(set) var usableFromInlineSetter: Int {
+    get { return 0 }
+    @usableFromInline set { }
+  }
 }
 
+@_fixed_layout
+public struct FixedLayout {
+  // NONRESILIENT-LABEL: sil_property #FixedLayout.a ()
+  // RESILIENT-LABEL: sil_property #FixedLayout.a (stored_property
+  public var a: Int
+  // NONRESILIENT-LABEL: sil_property #FixedLayout.b ()
+  // RESILIENT-LABEL: sil_property #FixedLayout.b (stored_property
+  public var b: Int
+  // NONRESILIENT-LABEL: sil_property #FixedLayout.c ()
+  // RESILIENT-LABEL: sil_property #FixedLayout.c (stored_property
+  public var c: Int
+}


### PR DESCRIPTION
Client code can make a best effort at emitting a key path referencing a property with its publicly exposed API, which in the common case will match what the defining module would produce as the canonical key path component representation of the declaration. We can reduce the code size impact of these descriptors by not emitting them when there's no hidden or possibly-resiliently-changed-in-the-past information about a storage declaration, having the property descriptor symbol reference a sentinel value telling client key paths to use their definition of the key path component.