### PR TITLE
[WIP] [4.2] Allow a specialized conformance to fail

### DIFF
--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -1891,6 +1891,12 @@ ASTContext::getSpecializedConformance(Type type,
   if (auto *genericSig = generic->getGenericSignature())
     genericSig->getSubstitutions(subMap, subs);
 
+  bool anyError = llvm::any_of(subs, [](const Substitution &sub) {
+    return sub.getReplacement()->hasError();
+  });
+  if (anyError)
+    return nullptr;
+
   return getSpecializedConformance(type, generic, subs,
                                    /*alreadyCheckedCollapsed=*/true);
 }

--- a/lib/AST/ConformanceLookupTable.cpp
+++ b/lib/AST/ConformanceLookupTable.cpp
@@ -851,6 +851,8 @@ ConformanceLookupTable::getConformance(NominalTypeDecl *nominal,
     ModuleDecl *module = entry->getDeclContext()->getParentModule();
     auto inheritedConformance = module->lookupConformance(superclassTy,
                                                           protocol);
+    if (!inheritedConformance)
+      return nullptr;
 
     // Form the inherited conformance.
     entry->Conformance =

--- a/lib/AST/Module.cpp
+++ b/lib/AST/Module.cpp
@@ -689,8 +689,11 @@ ModuleDecl::lookupConformance(Type type, ProtocolDecl *protocol) {
       auto subMap = type->getContextSubstitutionMap(this, explicitConformanceDC);
 
       // Create the specialized conformance entry.
-      auto result = ctx.getSpecializedConformance(type, conformance, subMap);
-      return ProtocolConformanceRef(result);
+      if (auto result = ctx.getSpecializedConformance(type, conformance,
+                                                      subMap)) {
+        return ProtocolConformanceRef(result);
+      }
+      return None;
     }
   }
 


### PR DESCRIPTION
This handles the case where a conditional conformance cannot be inherited because the subclass provides a generic argument that doesn't satisfy the conditional requirements.

[SR-7337](https://bugs.swift.org/browse/SR-7337) / rdar://problem/39142121