### PR TITLE
[stdlib] Move two more Iterators into nested types

### DIFF
--- a/stdlib/public/core/Algorithm.swift
+++ b/stdlib/public/core/Algorithm.swift
@@ -159,5 +159,5 @@ extension EnumeratedSequence: Sequence {
   }
 }
 
-@available(*, deprecated: 4.2, renamed: "EmptyCollection.Iterator")
+@available(*, deprecated: 4.2, renamed: "EnumeratedSequence.Iterator")
 public typealias EnumeratedIterator<T: Sequence> = EnumeratedSequence<T>.Iterator

--- a/stdlib/public/core/EmptyCollection.swift
+++ b/stdlib/public/core/EmptyCollection.swift
@@ -173,5 +173,5 @@ extension EmptyCollection : Equatable {
   }
 }
 
-// @available(*, deprecated, renamed: "EmptyCollection.Iterator")
+@available(*, deprecated: 4.2, renamed: "EmptyCollection.Iterator")
 public typealias EmptyIterator<T> = EmptyCollection<T>.Iterator

--- a/stdlib/public/core/Zip.swift
+++ b/stdlib/public/core/Zip.swift
@@ -152,5 +152,5 @@ extension Zip2Sequence: Sequence {
   }
 }
 
-// @available(*, deprecated, renamed: "Zip2Sequence.Iterator")
+@available(*, deprecated: 4.2, renamed: "Zip2Sequence.Iterator")
 public typealias Zip2Iterator<T, U> = Zip2Sequence<T, U>.Iterator where T: Sequence, U: Sequence

--- a/validation-test/stdlib/Lazy.swift.gyb
+++ b/validation-test/stdlib/Lazy.swift.gyb
@@ -124,7 +124,7 @@ LazyTestSuite.test("CollectionOfOne/AssociatedTypes") {
   typealias Subject = CollectionOfOne<OpaqueValue<Int>>
   expectRandomAccessCollectionAssociatedTypes(
     collectionType: Subject.self,
-    iteratorType: IteratorOverOne<OpaqueValue<Int>>.self,
+    iteratorType: Subject.Iterator.self,
     subSequenceType: Slice<Subject>.self,
     indexType: Int.self,
     indicesType: Range<Int>.self)


### PR DESCRIPTION
This was all done a while back in 4.0/4.1 once it was possible, but these got missed.