### PR TITLE
When a TF program has no result tensors, run the function as a target node instead of skipping its execution

### DIFF
--- a/test/TensorFlow/sends_recvs.swift
+++ b/test/TensorFlow/sends_recvs.swift
@@ -137,6 +137,25 @@ public func testSendsInALoopGPU() {
 // CHECK:      bb2
 // CHECK:      builtin "__tfop_tfc.TensorTransfer
 
+public func testSendsInALoopWithNoResultTensor() {
+  let maxCount = 10
+  var count = 1
+  var a = Tensor<Float>(1.0)
+  while count < maxCount {
+    a += a
+    // One send.
+    print(a.toHost())
+    count += 1
+  }
+}
+
+// No result tensor from this accelerator function.
+// CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testSendsInALoopWithNoResultTensor{{.*}}
+//
+// CHECK:      sil {{.*}}testSendsInALoopWithNoResultTensor{{.*}} () -> () {
+// CHECK:        return {{.*}} : $()
+// CHECK-NEXT: } // end sil function {{.*}}testSendsInALoopWithNoResultTensor{{.*}}
+
 public func testCannotSendResource() {
   // expected-error @+2 {{This value type cannot be sent/received}}
   let iterator: ResourceHandle =

--- a/test/TensorFlowRuntime/sends_recvs_1.swift
+++ b/test/TensorFlowRuntime/sends_recvs_1.swift
@@ -72,6 +72,22 @@ func testSendsInALoop() {
 }
 SendsRecvsTests.testCPU("testSendsInALoop", testSendsInALoop)
 
+
+@inline(never)
+func testSendsInALoopWithNoResultTensor() {
+  let maxCount = 10
+  var count = 1
+  var a = Tensor<Float>(1.0)
+  while count < maxCount {
+    a += a
+    // One send.
+    print(a.toHost())
+    count += 1
+  }
+}
+SendsRecvsTests.testCPU("testSendsInALoopWithNoResultTensor",
+                        testSendsInALoopWithNoResultTensor)
+
 func test1RecvFloatScalar() {
   let x = Tensor<Float>(1.0)
   let y = x.scalar! + 2.0


### PR DESCRIPTION
This is needed for correctness, because the
TF program execution could have side effects such as sending/enqueuing tensors.

Added compiler and run-time unit tests on such an example.

Resolves [SR-7705](https://bugs.swift.org/browse/SR-7705).
