### PR TITLE
[4.2] [Driver] Completely remove -emit-public-type-metadata-accessors.

### DIFF
--- a/include/swift/AST/DiagnosticsDriver.def
+++ b/include/swift/AST/DiagnosticsDriver.def
@@ -155,10 +155,6 @@ WARNING(warn_use_filelists_deprecated, none,
         "the option '-driver-use-filelists' is deprecated; use "
         "'-driver-filelist-threshold=0' instead", ())
 
-WARNING(warn_emit_public_type_metadata_accessors_deprecated, none,
-        "the option '-emit-public-type-metadata-accessors' is no longer "
-        "needed and is deprecated; consider removing it", ())
-
 ERROR(cannot_find_migration_script, none,
       "missing migration script from path '%0'", (StringRef))
 

--- a/include/swift/Option/Options.td
+++ b/include/swift/Option/Options.td
@@ -355,11 +355,6 @@ def warn_swift3_objc_inference : Flag<["-"], "warn-swift3-objc-inference">,
   Alias<warn_swift3_objc_inference_complete>,
   Flags<[FrontendOption, DoesNotAffectIncrementalBuild, HelpHidden]>;
 
-def emit_public_type_metadata_accessors :
-  Flag<["-"], "emit-public-type-metadata-accessors">,
-  Flags<[FrontendOption]>,
-  HelpText<"Emit all type metadata accessors as public (deprecated: now does nothing)">;
-
 def Rpass_EQ : Joined<["-"], "Rpass=">,
   Flags<[FrontendOption]>,
   HelpText<"Report performed transformations by optimization passes whose "

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -244,10 +244,6 @@ static void validateArgs(DiagnosticEngine &diags, const ArgList &args) {
   validateDebugInfoArgs(diags, args);
   validateCompilationConditionArgs(diags, args);
   validateAutolinkingArgs(diags, args);
-
-  if (args.hasArg(options::OPT_emit_public_type_metadata_accessors))
-    diags.diagnose(SourceLoc(),
-                   diag::warn_emit_public_type_metadata_accessors_deprecated);
 }
 
 std::unique_ptr<ToolChain>

--- a/test/Driver/emit_public_type_metadata_accessors.swift
+++ b/test/Driver/emit_public_type_metadata_accessors.swift
@@ -1,3 +1,0 @@
-// RUN: %target-build-swift %s -emit-public-type-metadata-accessors 2>&1 | %FileCheck %s
-
-// CHECK: the option '-emit-public-type-metadata-accessors' is no longer needed and is deprecated; consider removing it


### PR DESCRIPTION
Explanation: https://github.com/apple/swift/pull/16615 fixed a major problem but couldn't be landed in time for the earliest betas. Instead we introduced -emit-public-type-metadata-accessors as a work-around, and once the proper fix landed, we turned the flag into a no-op with a deprecation warning. Now that #16615 is available in beta 3, the flag isn't needed at all.
Scope: This doesn't change behaviour; just removes a flag that does nothing. Doing now ensures that there's will be a transition period in which people get the warnings from beta 3.
Radar/SR Issue: rdar://problem/40502379
Risk: Zero, it is deleting a no-op flag.
Testing: PR testing.
Reviewer: John McCall

4.2 merge of https://github.com/apple/swift/pull/17415