### PR TITLE
check whether the compile-time interpreter can deal with the types

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2527,6 +2527,9 @@ ERROR(differentiable_attr_invalid_access,none,
 
 ERROR(compiler_evaluable_bad_context,none,
       "@compilerEvaluable functions not allowed here", ())
+ERROR(compiler_evaluable_protocol_requirement,none,
+      "protocol requirements cannot be declared @compilerEvaluable", ())
+
 ERROR(compiler_evaluable_loop,none,
       "loops not allowed in @compilerEvaluable functions", ())
 ERROR(compiler_evaluable_forbidden_expression,none,
@@ -2545,6 +2548,32 @@ ERROR(tf_graph_attr_function_tensorflow_value_only,none,
       "@TensorFlowGraph can only be applied to functions whose parameters and "
       "return values are TensorFlow values or aggregates of TensorFlow "
       "values", ())
+
+ERROR(compiler_evaluable_bad_self_parameter,none,
+      "@compilerEvaluable function not allowed in %0", (Type))
+ERROR(compiler_evaluable_bad_parameter,none,
+      "@compilerEvaluable function not allowed to have parameter of type %0", (Type))
+ERROR(compiler_evaluable_bad_result,none,
+      "@compilerEvaluable function not allowed to have result of type %0", (Type))
+
+NOTE(compiler_evaluable_unrepresentable_class,none,
+     "type %0 cannot be used because it is a class", (Type))
+NOTE(compiler_evaluable_unrepresentable_metatype,none,
+     "metatype %0 cannot be used because it is the metatype of %1", (Type, Type))
+NOTE(compiler_evaluable_unrepresentable_generic_arg,none,
+     "type %0 cannot be used because it has generic argument %1", (Type, Type))
+NOTE(compiler_evaluable_unrepresentable_stdlib_type,none,
+     "type %0 is an unsupported standard library type", (Type))
+NOTE(compiler_evaluable_unrepresentable_enum_element,none,
+     "enum %0 cannot be used because it has element %1 with payload %2", (Type, DeclName, Type))
+NOTE(compiler_evaluable_unrepresentable_field,none,
+     "struct %0 cannot be used because it has field %1 with type %2", (Type, DeclName, Type))
+NOTE(compiler_evaluable_unrepresentable_tuple_element,none,
+     "tuple %0 cannot be used because it has element %1", (Type, Type))
+NOTE(compiler_evaluable_unrepresentable_param,none,
+     "function type %0 cannot be used because it has parameter type %1", (Type, Type))
+NOTE(compiler_evaluable_unrepresentable_result,none,
+     "function type %0 cannot be used because it has result type %1", (Type, Type))
 
 //------------------------------------------------------------------------------
 // Type Check Expressions

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -2525,6 +2525,14 @@ ERROR(differentiable_attr_invalid_access,none,
       "@usableFromInline because the original function %1 is public or "
       "@usableFromInline", (DeclName, DeclName, bool))
 
+// @TensorFlowGraph attribute
+ERROR(tf_graph_attr_top_level_only,none,
+      "@TensorFlowGraph can only be applied to top-level functions", ())
+ERROR(tf_graph_attr_function_tensorflow_value_only,none,
+      "@TensorFlowGraph can only be applied to functions whose parameters and "
+      "return values are TensorFlow values or aggregates of TensorFlow "
+      "values", ())
+
 ERROR(compiler_evaluable_bad_context,none,
       "@compilerEvaluable functions not allowed here", ())
 ERROR(compiler_evaluable_protocol_requirement,none,
@@ -2540,14 +2548,6 @@ ERROR(compiler_evaluable_forbidden_type,none,
       "type %0 cannot be used in @compilerEvaluable functions", (Type))
 ERROR(compiler_evaluable_ref_non_compiler_evaluable,none,
       "@compilerEvaluable functions may not reference non-@compilerEvaluable functions", ())
-
-// @TensorFlowGraph attribute
-ERROR(tf_graph_attr_top_level_only,none,
-      "@TensorFlowGraph can only be applied to top-level functions", ())
-ERROR(tf_graph_attr_function_tensorflow_value_only,none,
-      "@TensorFlowGraph can only be applied to functions whose parameters and "
-      "return values are TensorFlow values or aggregates of TensorFlow "
-      "values", ())
 
 ERROR(compiler_evaluable_bad_self_parameter,none,
       "@compilerEvaluable function not allowed in %0", (Type))

--- a/lib/Sema/CMakeLists.txt
+++ b/lib/Sema/CMakeLists.txt
@@ -40,6 +40,7 @@ add_swift_library(swiftSema STATIC
   TypeCheckCaptures.cpp
   TypeCheckCircularity.cpp
   # SWIFT_ENABLE_TENSORFLOW
+  CompilerRepresentable.cpp
   TypeCheckCompilerEvaluable.cpp
   TypeCheckConstraints.cpp
   TypeCheckDecl.cpp

--- a/lib/Sema/CompilerRepresentable.cpp
+++ b/lib/Sema/CompilerRepresentable.cpp
@@ -1,0 +1,312 @@
+//===--- CompilerRepresentable.cpp - Check compiler evaluability of types -===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// SWIFT_ENABLE_TENSORFLOW
+// Checks if the compile-time evaluator can handle values of a type.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CompilerRepresentable.h"
+#include "swift/AST/ParameterList.h"
+
+namespace swift {
+
+UnrepresentableReasonPtr
+UnrepresentableReason::getIsClass(Type UnrepresentableType) {
+  return std::unique_ptr<UnrepresentableReason>(
+      new UnrepresentableReason(IsClass, UnrepresentableType, nullptr));
+}
+
+UnrepresentableReasonPtr
+UnrepresentableReason::getUnknownTypeKind(Type UnrepresentableType) {
+  return std::unique_ptr<UnrepresentableReason>(
+      new UnrepresentableReason(UnknownTypeKind, UnrepresentableType, nullptr));
+}
+
+UnrepresentableReasonPtr UnrepresentableReason::getMetatypeOfUnrepresentable(
+    Type UnrepresentableType, UnrepresentableReasonPtr UnderlyingReason) {
+  assert(UnderlyingReason);
+  return std::unique_ptr<UnrepresentableReason>(
+      new UnrepresentableReason(MetatypeOfUnrepresentable, UnrepresentableType,
+                                std::move(UnderlyingReason)));
+}
+
+UnrepresentableReasonPtr UnrepresentableReason::getGenericArgUnrepresentable(
+    Type UnrepresentableType, UnrepresentableReasonPtr UnderlyingReason) {
+  assert(UnderlyingReason);
+  return std::unique_ptr<UnrepresentableReason>(
+      new UnrepresentableReason(GenericArgUnrepresentable, UnrepresentableType,
+                                std::move(UnderlyingReason)));
+}
+
+UnrepresentableReasonPtr UnrepresentableReason::getEnumElementUnrepresentable(
+    Type UnrepresentableType,
+    const EnumElementDecl *UnrepresentableEnumElementDecl,
+    UnrepresentableReasonPtr UnderlyingReason) {
+  assert(UnderlyingReason);
+  auto reason = std::unique_ptr<UnrepresentableReason>(
+      new UnrepresentableReason(EnumElementUnrepresentable, UnrepresentableType,
+                                std::move(UnderlyingReason)));
+  reason->UnrepresentableEnumElementDecl = UnrepresentableEnumElementDecl;
+  return reason;
+}
+
+UnrepresentableReasonPtr UnrepresentableReason::getFieldUnrepresentable(
+    Type UnrepresentableType, const VarDecl *UnrepresentableFieldDecl,
+    UnrepresentableReasonPtr UnderlyingReason) {
+  assert(UnderlyingReason);
+  auto reason = std::unique_ptr<UnrepresentableReason>(
+      new UnrepresentableReason(FieldUnrepresentable, UnrepresentableType,
+                                std::move(UnderlyingReason)));
+  reason->UnrepresentableFieldDecl = UnrepresentableFieldDecl;
+  return reason;
+}
+
+UnrepresentableReasonPtr UnrepresentableReason::getTupleElementUnrepresentable(
+    Type UnrepresentableType, UnrepresentableReasonPtr UnderlyingReason) {
+  assert(UnderlyingReason);
+  return std::unique_ptr<UnrepresentableReason>(new UnrepresentableReason(
+      TupleElementUnrepresentable, UnrepresentableType,
+      std::move(UnderlyingReason)));
+}
+
+UnrepresentableReasonPtr UnrepresentableReason::getParamUnrepresentable(
+    Type UnrepresentableType, UnrepresentableReasonPtr UnderlyingReason) {
+  assert(UnderlyingReason);
+  return std::unique_ptr<UnrepresentableReason>(new UnrepresentableReason(
+      ParamUnrepresentable, UnrepresentableType, std::move(UnderlyingReason)));
+}
+
+UnrepresentableReasonPtr UnrepresentableReason::getResultUnrepresentable(
+    Type UnrepresentableType, UnrepresentableReasonPtr UnderlyingReason) {
+  assert(UnderlyingReason);
+  return std::unique_ptr<UnrepresentableReason>(new UnrepresentableReason(
+      ResultUnrepresentable, UnrepresentableType, std::move(UnderlyingReason)));
+}
+
+template <class DiagTarget>
+void UnrepresentableReason::emitDiagnosticNotesImpl(TypeChecker &TC,
+                                                    DiagTarget Target) const {
+  // TODO(marcrasi): Make the notes point at the problematic decls rather than
+  // the places where they get used.
+
+  switch (Kind) {
+  case IsClass:
+    TC.diagnose(Target, diag::compiler_evaluable_unrepresentable_class,
+                UnrepresentableType);
+    return;
+  case UnknownTypeKind:
+    return;
+  case MetatypeOfUnrepresentable:
+    assert(UnderlyingReason);
+    TC.diagnose(Target, diag::compiler_evaluable_unrepresentable_metatype,
+                UnrepresentableType, UnderlyingReason->UnrepresentableType);
+    break;
+  case GenericArgUnrepresentable:
+    assert(UnderlyingReason);
+    TC.diagnose(Target, diag::compiler_evaluable_unrepresentable_generic_arg,
+                UnrepresentableType, UnderlyingReason->UnrepresentableType);
+    break;
+  case EnumElementUnrepresentable:
+    assert(UnderlyingReason);
+
+    if (UnrepresentableFieldDecl->getDeclContext()->isChildContextOf(
+            TC.Context.TheStdlibModule)) {
+      TC.diagnose(Target, diag::compiler_evaluable_unrepresentable_stdlib_type,
+                  UnrepresentableType);
+      return;
+    }
+
+    TC.diagnose(Target, diag::compiler_evaluable_unrepresentable_enum_element,
+                UnrepresentableType, UnrepresentableEnumElementDecl->getName(),
+                UnderlyingReason->UnrepresentableType);
+    break;
+  case FieldUnrepresentable:
+    assert(UnderlyingReason);
+
+    if (UnrepresentableFieldDecl->getDeclContext()->isChildContextOf(
+            TC.Context.TheStdlibModule)) {
+      TC.diagnose(Target, diag::compiler_evaluable_unrepresentable_stdlib_type,
+                  UnrepresentableType);
+      return;
+    }
+
+    TC.diagnose(Target, diag::compiler_evaluable_unrepresentable_field,
+                UnrepresentableType, UnrepresentableFieldDecl->getName(),
+                UnderlyingReason->UnrepresentableType);
+    break;
+  case TupleElementUnrepresentable:
+    assert(UnderlyingReason);
+    TC.diagnose(Target, diag::compiler_evaluable_unrepresentable_tuple_element,
+                UnrepresentableType, UnderlyingReason->UnrepresentableType);
+    break;
+  case ParamUnrepresentable:
+    assert(UnderlyingReason);
+    TC.diagnose(Target, diag::compiler_evaluable_unrepresentable_param,
+                UnrepresentableType, UnderlyingReason->UnrepresentableType);
+    break;
+  case ResultUnrepresentable:
+    assert(UnderlyingReason);
+    TC.diagnose(Target, diag::compiler_evaluable_unrepresentable_result,
+                UnrepresentableType, UnderlyingReason->UnrepresentableType);
+    break;
+  }
+
+  assert(UnderlyingReason);
+  UnderlyingReason->emitDiagnosticNotesImpl(TC, Target);
+}
+
+void UnrepresentableReason::emitDiagnosticNotes(TypeChecker &TC,
+                                                const Decl *Target) const {
+  emitDiagnosticNotesImpl(TC, Target);
+}
+
+void UnrepresentableReason::emitDiagnosticNotes(TypeChecker &TC,
+                                                SourceLoc Target) const {
+  emitDiagnosticNotesImpl(TC, Target);
+}
+
+// Checks if the compile-time evaluator can handle the types that the generic
+// arguments are bound to.
+UnrepresentableReasonPtr
+CompilerRepresentableChecker::checkGenericArgs(CanBoundGenericType type) {
+  assert(type);
+  for (auto arg : type->getGenericArgs()) {
+    if (auto unrepresentable = check(arg)) {
+      return UnrepresentableReason::getGenericArgUnrepresentable(
+          type, std::move(unrepresentable));
+    }
+  }
+  return nullptr;
+}
+
+// Checks if the compile-time evaluator can handle this enum.
+UnrepresentableReasonPtr
+CompilerRepresentableChecker::checkDeclaredType(const EnumDecl *decl) {
+  assert(decl);
+  for (auto *elementDecl : decl->getAllElements()) {
+    auto *parameterList = elementDecl->getParameterList();
+    if (!parameterList)
+      continue;
+
+    for (auto *paramDecl : *parameterList) {
+      if (auto unrepresentable = check(paramDecl->getType())) {
+        return UnrepresentableReason::getEnumElementUnrepresentable(
+            decl->getDeclaredType(), elementDecl, std::move(unrepresentable));
+      }
+    }
+  }
+  return nullptr;
+}
+
+// Checks if the compile-time evaluator can handle this struct.
+UnrepresentableReasonPtr
+CompilerRepresentableChecker::checkDeclaredType(const StructDecl *decl) {
+  assert(decl);
+  for (auto *fieldDecl : decl->getStoredProperties()) {
+    if (auto unrepresentable = check(fieldDecl->getType())) {
+      return UnrepresentableReason::getFieldUnrepresentable(
+          decl->getDeclaredType(), fieldDecl, std::move(unrepresentable));
+    }
+  }
+  return nullptr;
+}
+
+// Checks if the compile-time evaluator can handle the types of the parameters
+// of this function.
+UnrepresentableReasonPtr
+CompilerRepresentableChecker::checkParams(CanAnyFunctionType type) {
+  assert(type);
+  for (auto param : type->getParams()) {
+    if (auto unrepresentable = check(param.getType())) {
+      return UnrepresentableReason::getParamUnrepresentable(
+          type, std::move(unrepresentable));
+    }
+  }
+  return nullptr;
+}
+
+// Checks if the compile-time evaluator can handle values of type `type`.
+UnrepresentableReasonPtr CompilerRepresentableChecker::check(Type type) {
+  if (!type)
+    return nullptr;
+
+  auto canType = type->getCanonicalType();
+  if (isa<BuiltinIntegerType>(canType)) {
+    // Allowed builtins.
+    return nullptr;
+  } else if (isa<ArchetypeType>(canType) ||
+             isa<GenericTypeParamType>(canType) ||
+             isa<UnboundGenericType>(canType)) {
+    // Always allow generic types, because we always check that the concrete
+    // types that they get bound to are allowed (see the BoundGeneric* cases).
+    return nullptr;
+  } else if (isa<ErrorType>(canType)) {
+    // Allow ErrorTypes so that we don't pile additional errors on top of them.
+    return nullptr;
+  } else if (isa<ClassType>(canType) || isa<BoundGenericClassType>(canType)) {
+    return UnrepresentableReason::getIsClass(canType);
+  } else if (auto enumType = dyn_cast<EnumType>(canType)) {
+    return checkDeclaredType(enumType->getDecl());
+  } else if (auto enumType = dyn_cast<BoundGenericEnumType>(canType)) {
+    if (auto unrepresentable = checkDeclaredType(enumType->getDecl())) {
+      return unrepresentable;
+    }
+
+    // When the decl check that we just did visits a generic type, it accepts it
+    // regardless of what it is bound to, because we do not tell it what any of
+    // the generic types are bound to. So now we need to make sure that all the
+    // generic types are bound to compiler-representable types. This is overly
+    // conservative.
+    return checkGenericArgs(enumType);
+  } else if (auto structType = dyn_cast<StructType>(canType)) {
+    return checkDeclaredType(structType->getDecl());
+  } else if (auto structType = dyn_cast<BoundGenericStructType>(canType)) {
+    if (auto unrepresentable = checkDeclaredType(structType->getDecl())) {
+      return unrepresentable;
+    }
+
+    // Same thing as in the BoundGenericEnumType case. See the comment there.
+    return checkGenericArgs(structType);
+  } else if (auto anyFunctionType = dyn_cast<AnyFunctionType>(canType)) {
+    if (auto unrepresentable = checkParams(anyFunctionType)) {
+      return unrepresentable;
+    }
+    if (auto unrepresentable = check(anyFunctionType.getResult())) {
+      return UnrepresentableReason::getResultUnrepresentable(
+          canType, std::move(unrepresentable));
+    }
+    return nullptr;
+  } else if (auto metatypeType = dyn_cast<MetatypeType>(canType)) {
+    if (auto unrepresentable = check(metatypeType->getInstanceType())) {
+      return UnrepresentableReason::getMetatypeOfUnrepresentable(
+          canType, std::move(unrepresentable));
+    }
+    return nullptr;
+  } else if (auto tupleType = dyn_cast<TupleType>(canType)) {
+    for (auto element : tupleType->getElements()) {
+      if (auto unrepresentable = check(element.getType())) {
+        return UnrepresentableReason::getTupleElementUnrepresentable(
+            canType, std::move(unrepresentable));
+      }
+    }
+    return nullptr;
+  } else if (auto lValueType = dyn_cast<LValueType>(canType)) {
+    return check(lValueType.getObjectType());
+  } else if (auto inOutType = dyn_cast<InOutType>(canType)) {
+    return check(inOutType.getObjectType());
+  } else {
+    return UnrepresentableReason::getUnknownTypeKind(canType);
+  }
+}
+
+} // end namespace swift

--- a/lib/Sema/CompilerRepresentable.h
+++ b/lib/Sema/CompilerRepresentable.h
@@ -1,0 +1,155 @@
+//===--- CompilerRepresentable.h - Check compiler evaluability of types ---===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// SWIFT_ENABLE_TENSORFLOW
+// Checks if the compile-time evaluator can handle values of a type.
+//
+//===----------------------------------------------------------------------===//
+
+#include "TypeChecker.h"
+#include "swift/AST/Type.h"
+#include "swift/AST/Types.h"
+
+namespace swift {
+
+class UnrepresentableReason;
+typedef std::unique_ptr<const UnrepresentableReason> UnrepresentableReasonPtr;
+
+/// Stores the reason why the compile-time evaluator cannot handle a type.
+class UnrepresentableReason {
+private:
+  enum UnrepresentableKind {
+    // It's unrepresentable because it's a class.
+    // UnderlyingReason is nullptr.
+    IsClass,
+
+    // It has a kind that we do not know how to handle.
+    // UnderlyingReason is nullptr.
+    UnknownTypeKind,
+
+    // It is the metatype of a unrepresentable type.
+    // UnderlyingReason is the reason that that type is unrepresentable.
+    MetatypeOfUnrepresentable,
+
+    // It is a bound generic type, and one of the arguments is unrepresentable.
+    // UnderlyingReason is the reason that the argument is unrepresentable.
+    GenericArgUnrepresentable,
+
+    // It is an enum with an unrepresentable element.
+    // UnderlyingReason is the reason that the element is unrepresentable.
+    EnumElementUnrepresentable,
+
+    // It has a field with unrepresentable type.
+    // UnderlyingReason is the reason that the field type is unrepresentable.
+    FieldUnrepresentable,
+
+    // It has a tuple element of unrepresentable type.
+    // UnderlyingReason is the reason that the element type is unrepresentable.
+    TupleElementUnrepresentable,
+
+    // It is a function type with an unrepresentable parameter type.
+    // UnderlyingReason is the reason that the parameter type is
+    // unrepresentable.
+    ParamUnrepresentable,
+
+    // It is a function type with an unrepresentable result type.
+    // UnderlyingReason is the reason that the result type is unrepresentable.
+    ResultUnrepresentable,
+  };
+
+  UnrepresentableKind Kind;
+
+  union {
+    // When the Kind is EnumElementUnrepresentable, this is the declaration of
+    // the unrepresentable enum element.
+    const EnumElementDecl *UnrepresentableEnumElementDecl;
+
+    // When the kind is FieldUnrepresentable, this is the declaration of the
+    // unrepresentable field.
+    const VarDecl *UnrepresentableFieldDecl;
+  };
+
+  // The type that is not representable.
+  Type UnrepresentableType;
+
+  // When the reason says that another type is unrepresentable, this stores the
+  // reason that that type is unrepresentable.
+  UnrepresentableReasonPtr UnderlyingReason;
+
+  UnrepresentableReason(UnrepresentableKind Kind, Type UnrepresentableType,
+                        UnrepresentableReasonPtr UnderlyingReason)
+      : Kind(Kind), UnrepresentableType(UnrepresentableType),
+        UnderlyingReason(std::move(UnderlyingReason)) {}
+
+  template <class DiagTarget>
+  void emitDiagnosticNotesImpl(TypeChecker &TC, DiagTarget Target) const;
+
+public:
+  static UnrepresentableReasonPtr getIsClass(Type UnrepresentableType);
+
+  static UnrepresentableReasonPtr getUnknownTypeKind(Type UnrepresentableType);
+
+  static UnrepresentableReasonPtr
+  getMetatypeOfUnrepresentable(Type UnrepresentableType,
+                               UnrepresentableReasonPtr UnderlyingReason);
+
+  static UnrepresentableReasonPtr
+  getGenericArgUnrepresentable(Type UnrepresentableType,
+                               UnrepresentableReasonPtr UnderlyingReason);
+
+  static UnrepresentableReasonPtr getEnumElementUnrepresentable(
+      Type UnrepresentableType,
+      const EnumElementDecl *UnrepresentableEnumElementDecl,
+      UnrepresentableReasonPtr UnderlyingReason);
+
+  static UnrepresentableReasonPtr
+  getFieldUnrepresentable(Type UnrepresentableType,
+                          const VarDecl *UnrepresentableFieldDecl,
+                          UnrepresentableReasonPtr UnderlyingReason);
+
+  static UnrepresentableReasonPtr
+  getTupleElementUnrepresentable(Type UnrepresentableType,
+                                 UnrepresentableReasonPtr UnderlyingReason);
+
+  static UnrepresentableReasonPtr
+  getParamUnrepresentable(Type UnrepresentableType,
+                          UnrepresentableReasonPtr UnderlyingReason);
+
+  static UnrepresentableReasonPtr
+  getResultUnrepresentable(Type UnrepresentableType,
+                           UnrepresentableReasonPtr UnderlyingReason);
+
+  void emitDiagnosticNotes(TypeChecker &TC, SourceLoc Target) const;
+  void emitDiagnosticNotes(TypeChecker &TC, const Decl *Target) const;
+};
+
+class CompilerRepresentableChecker {
+  // Checks if the compile-time evaluator can handle the types that the generic
+  // arguments are bound to.
+  UnrepresentableReasonPtr checkGenericArgs(CanBoundGenericType type);
+
+  // Checks if the compile-time evaluator can handle this enum.
+  UnrepresentableReasonPtr checkDeclaredType(const EnumDecl *decl);
+
+  // Checks if the compile-time evaluator can handle this struct.
+  UnrepresentableReasonPtr checkDeclaredType(const StructDecl *decl);
+
+  // Checks if the compile-time evaluator can handle the types of the parameters
+  // of this function.
+  UnrepresentableReasonPtr checkParams(CanAnyFunctionType type);
+
+public:
+  // Checks if the compile-time evaluator can handle values of type `type`.
+  UnrepresentableReasonPtr check(Type type);
+};
+
+} // end namespace swift


### PR DESCRIPTION
This implements a real check for whether the compile-time interpreter can deal with a type.

I did not add any checks for fixed-layoutness, because I think that existing resilience checks will do that for us once we make compilerEvaluable imply inlinable for public functions.

I have some questions:
* Should I cache the results of the check? What's a good container to put the cache in?
* Rather than recursively checking types for compiler-representability, like I do in this PR, should we instead ask users to mark decls as `@compilerEvaluable`? It seems like the same arguments for doing that on functions apply to doing that on types. I don't think we have considered this possibility yet.