### PR TITLE
[Request-evaluator] Track # of evaluations for each request kind.

### DIFF
--- a/include/swift/AST/ASTContext.h
+++ b/include/swift/AST/ASTContext.h
@@ -263,6 +263,9 @@ public:
   /// Optional table of counters to report, nullptr when not collecting.
   UnifiedStatsReporter *Stats = nullptr;
 
+  /// Set a new stats reporter.
+  void setStatsReporter(UnifiedStatsReporter *stats);
+
 private:
   /// \brief The current generation number, which reflects the number of
   /// times that external modules have been loaded.

--- a/include/swift/Basic/Statistics.def
+++ b/include/swift/Basic/Statistics.def
@@ -195,6 +195,11 @@ FRONTEND_STATISTIC(Sema, NumTypesValidated)
 /// Number of lazy iterable declaration contexts left unloaded.
 FRONTEND_STATISTIC(Sema, NumUnloadedLazyIterableDeclContexts)
 
+/// All type check requests go into the Sema area.
+#define SWIFT_TYPEID(NAME) FRONTEND_STATISTIC(Sema, NAME)
+#include "swift/Sema/TypeCheckerTypeIDZone.def"
+#undef SWIFT_TYPEID
+
 /// The next 10 statistics count 5 kinds of SIL entities present
 /// after the SILGen and SILOpt phases. The entities are functions,
 /// vtables, witness tables, default witness tables and global
@@ -229,4 +234,5 @@ FRONTEND_STATISTIC(IRModule, NumIRInsts)
 /// of the frontend job, which should be the same as the size of
 /// the .o file you find on disk after the frontend exits.
 FRONTEND_STATISTIC(LLVM, NumLLVMBytesOutput)
+
 #endif

--- a/include/swift/Sema/TypeCheckRequests.h
+++ b/include/swift/Sema/TypeCheckRequests.h
@@ -19,6 +19,7 @@
 #include "swift/AST/Type.h"
 #include "swift/AST/Evaluator.h"
 #include "swift/AST/SimpleRequest.h"
+#include "swift/Basic/Statistic.h"
 #include "llvm/ADT/Hashing.h"
 
 namespace swift {
@@ -126,6 +127,16 @@ public:
 #define SWIFT_TYPEID_ZONE 10
 #define SWIFT_TYPEID_HEADER "swift/Sema/TypeCheckerTypeIDZone.def"
 #include "swift/Basic/DefineTypeIDZone.h"
+
+// Set up reporting of evaluated requests.
+#define SWIFT_TYPEID(RequestType)                                \
+template<>                                                       \
+inline void reportEvaluatedRequest(UnifiedStatsReporter &stats,  \
+                            const RequestType &request) {        \
+  ++stats.getFrontendCounters().RequestType;                     \
+}
+#include "swift/Sema/TypeCheckerTypeIDZone.def"
+#undef SWIFT_TYPEID
 
 } // end namespace swift
 

--- a/lib/AST/ASTContext.cpp
+++ b/lib/AST/ASTContext.cpp
@@ -528,6 +528,12 @@ llvm::BumpPtrAllocator &ASTContext::getAllocator(AllocationArena arena) const {
   llvm_unreachable("bad AllocationArena");
 }
 
+/// Set a new stats reporter.
+void ASTContext::setStatsReporter(UnifiedStatsReporter *stats) {
+  Stats = stats;
+  evaluator.setStatsReporter(stats);
+}
+
 syntax::SyntaxArena &ASTContext::getSyntaxArena() const {
   return getImpl().TheSyntaxArena;
 }

--- a/lib/FrontendTool/FrontendTool.cpp
+++ b/lib/FrontendTool/FrontendTool.cpp
@@ -1800,7 +1800,7 @@ int swift::performFrontend(ArrayRef<const char *> Args,
     // Install stats-reporter somewhere visible for subsystems that
     // need to bump counters as they work, rather than measure
     // accumulated work on completion (mostly: TypeChecker).
-    Instance->getASTContext().Stats = StatsReporter.get();
+    Instance->getASTContext().setStatsReporter(StatsReporter.get());
   }
 
   // The compiler instance has been configured; notify our observer.

--- a/test/decl/class/circular_inheritance.swift
+++ b/test/decl/class/circular_inheritance.swift
@@ -1,7 +1,12 @@
+// RUN: rm -rf %t/stats-dir
+// RUN: mkdir -p %t/stats-dir
 // RUN: %target-typecheck-verify-swift
-// RUN: not %target-swift-frontend -typecheck -debug-cycles %s -output-request-graphviz %t.dot 2> %t.cycles
+// RUN: not %target-swift-frontend -typecheck -debug-cycles %s -output-request-graphviz %t.dot -stats-output-dir %t/stats-dir 2> %t.cycles
 // RUN: %FileCheck %s < %t.cycles
 // RUN: %FileCheck -check-prefix CHECK-DOT %s  < %t.dot
+
+// Check that we produced superclass type requests.
+// RUN: %{python} %utils/process-stats-dir.py --evaluate 'SuperclassTypeRequest == 16' %t/stats-dir
 
 class C : B { } // expected-error{{circular class inheritance 'C' -> 'B' -> 'A' -> 'C'}}
 class B : A { } // expected-note{{class 'B' declared here}}


### PR DESCRIPTION
Using the unified stats reporter, track the # of evaluations for each
type checking request kind.
