### PR TITLE
[4.2 2018-06-11] Fix benchmarks on 32-bit platforms

### DIFF
--- a/benchmark/single-source/RandomValues.swift
+++ b/benchmark/single-source/RandomValues.swift
@@ -54,10 +54,10 @@ public func run_RandomIntegersDef(_ N: Int) {
 @inline(never)
 public func run_RandomIntegersLCG(_ N: Int) {
   for _ in 0 ..< N {
-    var x = 0
+    var x: Int64 = 0
     var generator = LCRNG(seed: 0)
     for _ in 0 ..< 100_000 {
-      x &+= Int.random(in: 0...10_000, using: &generator)
+      x &+= Int64.random(in: 0...10_000, using: &generator)
     }
     CheckResults(x == 498214315)
   }

--- a/benchmark/utils/DriverUtils.swift
+++ b/benchmark/utils/DriverUtils.swift
@@ -388,6 +388,10 @@ func runBench(_ test: Test, _ c: TestConfig) -> BenchResults {
       // Compute the scaling factor if a fixed c.fixedNumIters is not specified.
       scale = c.fixedNumIters
     }
+    // Make integer overflow less likely on platforms where Int is 32 bits wide.
+    // FIXME: Switch BenchmarkInfo to use Int64 for the iteration scale, or fix
+    // benchmarks to not let scaling get off the charts.
+    scale = min(scale, UInt(Int.max) / 10_000)
 
     // Rerun the test with the computed scale factor.
     if scale > 1 {


### PR DESCRIPTION
**Explanation:** Keeps the benchmark suite working on platforms where Int is 32-bit wide. Having this fixed will make it easier to re-run benchmarks & compare performance across other branches.
**Scope:** Only touches the benchmarking suite.
**Risk:** Low.
**Testing:** Executed benchmarks
**Reviewer:** @natecook1000, @gottesmm
**SR / Radar:** rdar://problem/41177686