### PR TITLE
Add libSyntax support for #tfop and @differentiable.

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1456,9 +1456,6 @@ ERROR(attr_implements_expected_member_name,PointsToFirstBadToken,
 ERROR(attr_differentiable_expected_function_name,PointsToFirstBadToken,
       "expected a qualified %0 function", (StringRef))
 
-ERROR(attr_differentiable_expected_rparen,PointsToFirstBadToken,
-      "expected ')' at end of parameter index list", ())
-
 ERROR(attr_differentiable_expected_parameter_list,PointsToFirstBadToken,
       "expected a list of parameters to differentiate with respect to, e.g. (.0, w, b)", ())
 

--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1456,6 +1456,9 @@ ERROR(attr_implements_expected_member_name,PointsToFirstBadToken,
 ERROR(attr_differentiable_expected_function_name,PointsToFirstBadToken,
       "expected a qualified %0 function", (StringRef))
 
+ERROR(attr_differentiable_expected_rparen,PointsToFirstBadToken,
+      "expected ')' at end of parameter index list", ())
+
 ERROR(attr_differentiable_expected_parameter_list,PointsToFirstBadToken,
       "expected a list of parameters to differentiate with respect to, e.g. (.0, w, b)", ())
 

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -829,6 +829,14 @@ public:
   ParserResult<DifferentiableAttr> parseDifferentiableAttribute(SourceLoc AtLoc,
                                                                 SourceLoc Loc);
 
+  /// Parse the arguments inside the @differentiable attribute.
+  bool parseDifferentiableAttributeArguments(
+      AutoDiffMode &mode, SourceLoc &modeLoc,
+      SmallVectorImpl<AutoDiffParameter> &params,
+      Optional<DifferentiableAttr::FunctionSpecifier> &primalSpec,
+      DifferentiableAttr::FunctionSpecifier &adjointSpec,
+      TrailingWhereClause *&whereClause);
+
   /// Parse a specific attribute.
   bool parseDeclAttribute(DeclAttributes &Attributes, SourceLoc AtLoc);
 

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -956,7 +956,6 @@ bool Parser::parseDifferentiableAttributeArguments(
   }
 
   // Parse a trailing 'where' clause if any.
-  // TrailingWhereClause *whereClause;
   if (Tok.is(tok::kw_where)) {
     SourceLoc whereLoc;
     SmallVector<RequirementRepr, 4> requirements;

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -798,8 +798,7 @@ Parser::parseDifferentiableAttribute(SourceLoc atLoc, SourceLoc loc) {
   if (!consumeIf(tok::r_paren, rParenLoc)) {
     diagnose(getEndOfPreviousLoc(), diag::attr_expected_rparen, AttrName,
              /*DeclModifier=*/false);
-    Status.setIsParseError();
-    return Status;
+    return makeParserError();
   }
 
   return ParserResult<DifferentiableAttr>(

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -770,31 +770,72 @@ Parser::parseDifferentiableAttribute(SourceLoc atLoc, SourceLoc loc) {
   ParserStatus Status;
   SourceLoc lParenLoc, rParenLoc;
 
-  // Set parse error, skip until ')' and parse it.
-  auto errorAndSkipToEnd = [&](int parenDepth = 1) -> ParserStatus {
-    Status.setIsParseError();
-    for (int i = 0; i < parenDepth; i++) {
-      skipUntil(tok::r_paren);
-      if (!consumeIf(tok::r_paren, rParenLoc))
-        diagnose(Tok, diag::attr_expected_rparen, AttrName,
-                 /*DeclModifier=*/false);
-    }
-    return Status;
-  };
-
+  // Parse '('.
   if (!consumeIf(tok::l_paren, lParenLoc)) {
     diagnose(Tok, diag::attr_expected_lparen, AttrName,
              /*DeclModifier=*/false);
-    return errorAndSkipToEnd();
+    skipUntil(tok::r_paren);
+    if (!consumeIf(tok::r_paren, rParenLoc))
+      diagnose(Tok, diag::attr_expected_rparen, AttrName,
+               /*DeclModifier=*/false);
+    return makeParserError();
   }
 
-  // Parse 'forward' or 'reverse'.
+  using FuncSpec = DifferentiableAttr::FunctionSpecifier;
+  AutoDiffMode mode;
+  SourceLoc modeLoc;
+  SmallVector<AutoDiffParameter, 8> params;
+  Optional<FuncSpec> primalSpec;
+  FuncSpec adjointSpec;
+  TrailingWhereClause *whereClause = nullptr;
+
+  // Parse @differentiable attribute arguments.
+  if (parseDifferentiableAttributeArguments(mode, modeLoc, params, primalSpec,
+                                            adjointSpec, whereClause))
+    return makeParserError();
+
+  // Parse ')'.
+  if (!consumeIf(tok::r_paren, rParenLoc)) {
+    diagnose(getEndOfPreviousLoc(), diag::attr_expected_rparen, AttrName,
+             /*DeclModifier=*/false);
+    Status.setIsParseError();
+    return Status;
+  }
+
+  return ParserResult<DifferentiableAttr>(
+    DifferentiableAttr::create(Context, atLoc, SourceRange(loc, rParenLoc),
+                               mode, modeLoc, params, primalSpec, adjointSpec,
+                               whereClause));
+}
+
+bool Parser::parseDifferentiableAttributeArguments(
+    AutoDiffMode &mode, SourceLoc &modeLoc,
+    SmallVectorImpl<AutoDiffParameter> &params,
+    Optional<DifferentiableAttr::FunctionSpecifier> &primalSpec,
+    DifferentiableAttr::FunctionSpecifier &adjointSpec,
+    TrailingWhereClause *&whereClause) {
+  StringRef AttrName = "differentiable";
+
+  // Set parse error, skip until ')' and parse it.
+  auto errorAndSkipToEnd = [&](int parenDepth = 1) -> bool {
+    for (int i = 0; i < parenDepth; i++) {
+      skipUntil(tok::r_paren);
+      if (!consumeIf(tok::r_paren))
+        diagnose(Tok, diag::attr_expected_rparen, AttrName,
+                 /*DeclModifier=*/false);
+    }
+    return true;
+  };
+
+  SyntaxParsingContext ContentContext(
+      SyntaxContext, SyntaxKind::DifferentiableAttributeArguments);
+
+  // Parse differentiation mode ('forward' or 'reverse').
   if (!Tok.is(tok::identifier)) {
     diagnose(Tok, diag::attr_differentiable_expected_mode);
     return errorAndSkipToEnd();
   }
   auto modeText = Tok.getText();
-  AutoDiffMode mode;
   if (modeText == "forward")
     mode = AutoDiffMode::Forward;
   else if (modeText == "reverse")
@@ -803,14 +844,16 @@ Parser::parseDifferentiableAttribute(SourceLoc atLoc, SourceLoc loc) {
     diagnose(Tok, diag::attr_differentiable_expected_mode);
     return errorAndSkipToEnd();
   }
-  auto modeLoc = consumeToken(tok::identifier); // 'forward' or 'reverse'.
+  modeLoc = consumeToken(tok::identifier);
   // Parse comma.
   parseToken(tok::comma, diag::attr_expected_comma, "differentiable",
              /*isDeclModifier=*/false);
 
-  // Parse optional 'withRespectTo:' label.
-  SmallVector<AutoDiffParameter, 8> params;
+  // Parse optional differentiation parameters, starting with the
+  // 'withRespectTo:' label.
   if (Tok.is(tok::identifier) && Tok.getText() == "withRespectTo") {
+    SyntaxParsingContext DiffParamsContext(
+        SyntaxContext, SyntaxKind::DifferentiableAttributeDiffParams);
     consumeToken(tok::identifier);
     if (!consumeIf(tok::colon)) {
       diagnose(Tok, diag::attr_differentiable_expected_colon_after_label,
@@ -822,12 +865,17 @@ Parser::parseDifferentiableAttribute(SourceLoc atLoc, SourceLoc loc) {
                    diag::attr_differentiable_expected_parameter_list)) {
       return errorAndSkipToEnd();
     }
+
     // Function that parses a parameter into `params`. Returns true if error
     // occurred.
     auto parseParam = [&]() -> bool {
+      SyntaxParsingContext DiffParamContext(
+          SyntaxContext, SyntaxKind::DifferentiableAttributeDiffParam);
       SourceLoc paramLoc;
       switch (Tok.getKind()) {
       case tok::period_prefix: {
+        SyntaxParsingContext IndexParamContext(
+            SyntaxContext, SyntaxKind::DifferentiableAttributeIndexParam);
         consumeToken(tok::period_prefix);
         unsigned index;
         if (parseUnsignedInteger(index, paramLoc,
@@ -846,21 +894,24 @@ Parser::parseDifferentiableAttribute(SourceLoc atLoc, SourceLoc loc) {
         diagnose(Tok, diag::attr_differentiable_expected_parameter);
         return true;
       }
+      if (Tok.isNot(tok::r_paren))
+        return parseToken(tok::comma, diag::attr_expected_comma,
+                          "differentiable", /*isDeclModifier=*/false);
       return false;
     };
-    // Parse first parameter.
+
+    // Parse first parameter. At least one is required.
     if (parseParam())
       return errorAndSkipToEnd(2);
     // Parse remaining parameters until ')'.
-    while (!consumeIf(tok::r_paren)) {
-      if (parseToken(tok::comma, diag::attr_expected_comma,
-                     "differentiable", /*isDeclModifier=*/false) ||
-          parseParam()) {
+    while (Tok.isNot(tok::r_paren))
+      if (parseParam())
         return errorAndSkipToEnd(2);
-      }
-    }
 
-    // Parse comma.
+    SyntaxContext->collectNodesInPlace(
+        SyntaxKind::DifferentiableAttributeDiffParamList);
+    // Parse closing ')' of the parameter list and a comma.
+    consumeToken(tok::r_paren);
     parseToken(tok::comma, diag::attr_expected_comma, "differentiable",
                /*isDeclModifier=*/false);
   }
@@ -886,8 +937,9 @@ Parser::parseDifferentiableAttribute(SourceLoc atLoc, SourceLoc loc) {
   };
 
   // Parse 'primal: <func_name>' (optional).
-  Optional<FuncSpec> primalSpec;
   if (Tok.is(tok::identifier) && Tok.getText() == "primal") {
+    SyntaxParsingContext PrimalContext(
+        SyntaxContext, SyntaxKind::DifferentiableAttributeFuncSpecifier);
     primalSpec = FuncSpec();
     if (parseFuncSpec("primal", *primalSpec)) return errorAndSkipToEnd();
     // Parse comma.
@@ -896,12 +948,15 @@ Parser::parseDifferentiableAttribute(SourceLoc atLoc, SourceLoc loc) {
   }
 
   // Parse 'adjoint: <func_name>'.
-  FuncSpec adjointSpec;
-  if (parseFuncSpec("adjoint", adjointSpec))
-    return errorAndSkipToEnd();
+  {
+    SyntaxParsingContext AdjointContext(
+        SyntaxContext, SyntaxKind::DifferentiableAttributeFuncSpecifier);
+    if (parseFuncSpec("adjoint", adjointSpec))
+      return errorAndSkipToEnd();
+  }
 
   // Parse a trailing 'where' clause if any.
-  TrailingWhereClause *whereClause;
+  // TrailingWhereClause *whereClause;
   if (Tok.is(tok::kw_where)) {
     SourceLoc whereLoc;
     SmallVector<RequirementRepr, 4> requirements;
@@ -910,19 +965,7 @@ Parser::parseDifferentiableAttribute(SourceLoc atLoc, SourceLoc loc) {
                             /*AllowLayoutConstraints=*/true);
     whereClause = TrailingWhereClause::create(Context, whereLoc, requirements);
   }
-
-  // Parse ')'.
-  if (!consumeIf(tok::r_paren, rParenLoc)) {
-    diagnose(getEndOfPreviousLoc(), diag::attr_expected_rparen, AttrName,
-             /*DeclModifier=*/false);
-    Status.setIsParseError();
-    return Status;
-  }
-
-  return ParserResult<DifferentiableAttr>(
-    DifferentiableAttr::create(Context, atLoc, SourceRange(loc, rParenLoc),
-                               mode, modeLoc, params, primalSpec, adjointSpec,
-                               whereClause));
+  return false;
 }
 
 void Parser::parseObjCSelector(SmallVector<Identifier, 4> &Names,

--- a/utils/gyb_syntax_support/AttributeNodes.py
+++ b/utils/gyb_syntax_support/AttributeNodes.py
@@ -17,6 +17,7 @@ ATTRIBUTE_NODES = [
     #                | availability-spec-list
     #                | specialize-attr-spec-list
     #                | implements-attr-arguments
+    #                | differentiable-attr-arguments
     #              )? ')'?
     Node('Attribute', kind='Syntax',
          description='''
@@ -42,6 +43,8 @@ ATTRIBUTE_NODES = [
                        Child('ObjCName', kind='ObjCSelector'),
                        Child('ImplementsArguments', 
                              kind='ImplementsAttributeArguments'),
+                       Child('DifferentiableArguments',
+                             kind='DifferentiableAttributeArguments'),
                    ], description='''
                    The arguments of the attribute. In case the attribute  \
                    takes multiple arguments, they are gather in the \
@@ -125,6 +128,117 @@ ATTRIBUTE_NODES = [
                    The argument labels of the protocol\'s requirement if it \
                    is a function requirement.
                    '''),
+         ]),
+
+    # SWIFT_ENABLE_TENSORFLOW
+    # The argument of '@differentiable(...)'.
+    # differentiable-attr-arguments ->
+    #     ('forward' | 'reverse') ','
+    #     differentiable-attr-parameters?
+    #     differentiable-attr-func-specifier?
+    #     differentiable-attr-func-specifier?
+    Node('DifferentiableAttributeArguments', kind='Syntax',
+         description='''
+         The arguments for the `@differentiable` attribute: differentiation
+         mode ('forward' or 'reverse'), an optional differentiation parameter
+         list, an optional primal function, and an adjoint function.
+         ''',
+         children=[
+              Child('AutoDiffMode', kind='IdentifierToken',
+                    text_choices=['forward', 'reverse'],
+                    description='The mode of automatic differentiation.'),
+             Child('Comma', kind='CommaToken', is_optional=True,
+                   description='''
+                   The comma separating the differentiation mode and the
+                   differentiation parameter list.
+                   '''),
+             Child('DiffParams', kind='DifferentiableAttributeDiffParams',
+                   is_optional=True),
+             Child('PrimalFunction', kind='DifferentiableAttributeFuncSpecifier',
+                   is_optional=True),
+             Child('AdjointFunction', kind='DifferentiableAttributeFuncSpecifier',
+                   is_optional=True),
+             Child('WhereClause', kind='GenericWhereClause', is_optional=True),
+         ]),
+
+    # differentiable-attr-parameters ->
+    #     'withRespectTo' ':' '(' differentiable-attr-parameter-list ')'
+    Node('DifferentiableAttributeDiffParams', kind='Syntax',
+         description='The parameters to differentiate with respect to.',
+         traits=['WithTrailingComma'],
+         children=[
+             Child('WithRespectToKeyword', kind='IdentifierToken',
+                   text_choices=['withRespectTo'],
+                   description='The "withRespectTo" label.'),
+             Child('Colon', kind='ColonToken', description='''
+                   The colon separating "withRespectTo" and the parameter list.
+                   '''),
+             Child('LeftParen', kind='LeftParenToken'),
+             Child('DiffParams', kind='DifferentiableAttributeDiffParamList',
+                   description='The parameters for differentiation.'),
+             Child('RightParen', kind='RightParenToken'),
+             Child('TrailingComma', kind='CommaToken', is_optional=True),
+         ]),
+
+    # differentiable-attr-parameter-list ->
+    #     differentiable-attr-parameter differentiable-attr-parameter-list?
+    Node('DifferentiableAttributeDiffParamList', kind='SyntaxCollection',
+         element='DifferentiableAttributeDiffParam'),
+
+    # differentiable-attr-parameter ->
+    #     'self' | differentiable-attr-index-parameter
+    Node('DifferentiableAttributeDiffParam', kind='Syntax',
+         description='''
+         A differentiation parameter: either the "self" identifier or a period
+         followed by an unsigned integer (e.g. `.0`).
+         ''',
+         traits=['WithTrailingComma'],
+         children=[
+             Child('DiffParam', kind='Syntax',
+                   node_choices=[
+                       Child('Self', kind='SelfToken'),
+                       Child('Index', kind='DifferentiableAttributeIndexParam'),
+                   ]),
+             Child('TrailingComma', kind='CommaToken', is_optional=True),
+         ]),
+
+    # differentiable-attr-index-parameter -> '.' integer-literal
+    Node('DifferentiableAttributeIndexParam', kind='Syntax',
+         description='''
+         A differentiation index parameter: a period followed by an unsigned \
+         integer (e.g. `.0`)
+         ''',
+         children=[
+             Child('PrefixPeriod', kind='PrefixPeriodToken'),
+             Child('IntegerLiteral', kind='IntegerLiteralToken'),
+         ]),
+
+    # differentiable-attr-func-specifier ->
+    #     ('primal' | 'adjoint') ':' decl-name
+    # decl-name -> (identifier | operator) decl-name-arguments?
+    Node('DifferentiableAttributeFuncSpecifier', kind='Syntax',
+         description='''
+         A function specifier, consisting of an identifier, colon, and a \
+         function declaration name (e.g. `adjoint: foo(_:_:)`.
+         ''',
+         traits=['WithTrailingComma'],
+         children=[
+             Child('Label', kind='IdentifierToken',
+                   text_choices=['primal', 'adjoint']),
+             Child('Colon', kind='ColonToken'),
+             Child('DeclBaseName', kind='Syntax', description='''
+                   The base name of the referenced function.
+                   ''',
+                   node_choices=[
+                       Child('Identifier', kind='IdentifierToken'),
+                       Child('Operator', kind='PrefixOperatorToken'),
+                   ]),
+             Child('DeclNameArguments', kind='DeclNameArguments',
+                   is_optional=True, description='''
+                   The argument labels of the referenced function, optionally \
+                   specified.
+                   '''),
+             Child('TrailingComma', kind='CommaToken', is_optional=True),
          ]),
 
     # objc-selector-piece -> identifier? ':'?

--- a/utils/gyb_syntax_support/ExprNodes.py
+++ b/utils/gyb_syntax_support/ExprNodes.py
@@ -562,6 +562,8 @@ EXPR_NODES = [
                        'PoundColorLiteralToken',
                        'PoundFileLiteralToken',
                        'PoundImageLiteralToken',
+                       # SWIFT_ENABLE_TENSORFLOW
+                       'PoundTensorFlowOpToken',
                    ]),
              Child('LeftParen', kind='LeftParenToken'),
              Child('Arguments', kind='FunctionCallArgumentList'),

--- a/utils/gyb_syntax_support/Token.py
+++ b/utils/gyb_syntax_support/Token.py
@@ -120,6 +120,9 @@ SYNTAX_TOKENS = [
           is_keyword=True),
     Token('PoundImageLiteral', 'pound_imageLiteral', text='#imageLiteral',
           is_keyword=True),
+    # SWIFT_ENABLE_TENSORFLOW
+    Token('PoundTensorFlowOp', 'pound_tfop', text='#tfop',
+          is_keyword=True),
     Token('Arrow', 'arrow', text='->'),
     Token('AtSign', 'at_sign', text='@'),
     Token('Colon', 'colon', text=':'),


### PR DESCRIPTION
The `-verify-syntax-tree` flag has been enabled when compiling the stdlib:
https://github.com/apple/swift/commit/9cb383edcee217d2cbd3fdc074db417f89fddec9

`-verify-syntax-tree` verifies that no unknown nodes exist in the libSyntax
tree. `#tfop` and `@differentiable` are used in the TensorFlow module of the
stdlib but did not have libSyntax support, causing verification errors during
compilation.

Todo:
- Add libSyntax support for `#adjoint` and `#gradient`.
  - This currently isn't necessary to compile the stdlib because those
    expressions aren't used within the stdlib.

---

Regarding downstreaming changes from master:
- The stdlib now compiles successfully. Compilation doesn't fail until lldb, which is not yet in sync (needs to downstream changes also).
- Various tests are failing on Linux (it's likely others are failing on Mac):
```
Failing Tests (10):
    Swift(linux-x86_64) :: IRGen/ordering_x86.sil
    Swift(linux-x86_64) :: Runtime/linux-fatal-backtrace.swift
    Swift(linux-x86_64) :: TensorFlow/crashers.swift
    Swift(linux-x86_64) :: TensorFlow/dataset.swift
    Swift(linux-x86_64) :: TensorFlow/device_placement.swift
    Swift(linux-x86_64) :: TensorFlow/diagnostics.swift
    Swift(linux-x86_64) :: TensorFlow/integration.swift
    Swift(linux-x86_64) :: TensorFlow/no_copy.swift
    Swift(linux-x86_64) :: TensorFlow/sends_recvs.swift
    Swift(linux-x86_64) :: TensorFlow/tensor_autodiff.swift
```