### PR TITLE
[Sema][GSB] Warn about redundant ': Any' conformances & constraints

### DIFF
--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1183,13 +1183,13 @@ public:
     return SeparatorLoc;
   }
 
-  /// Retrieve the source range suitable for removing the requirement. Unlike
-  /// \c getSourceRange(), this range includes everything that needs to be
-  /// removed to keep the program syntactically valid (e.g. the 'where' keyword
-  /// and commas).
+  /// Retrieve the source range suitable for removing the requirement, if any.
+  /// Unlike \c getSourceRange(), this range includes everything that needs to
+  /// be removed to keep the program syntactically valid (e.g. the 'where'
+  /// keyword and commas).
   SourceRange getRemovalRange() const { return RemovalRange; }
 
-  /// Set the source range suitable for removing the requirement. Unlike
+  /// Set the source range suitable for removing the requirement, if any. Unlike
   /// \c getSourceRange(), this range includes everything that needs to be
   /// removed to keep the program syntactically valid (e.g. the 'where' keyword
   /// and commas).

--- a/include/swift/AST/Decl.h
+++ b/include/swift/AST/Decl.h
@@ -1012,6 +1012,12 @@ enum class RequirementReprKind : unsigned {
 /// \c GenericParamList assumes these are POD-like.
 class RequirementRepr {
   SourceLoc SeparatorLoc;
+
+  /// This range includes everything that needs to be removed to keep the
+  /// program syntactically valid (e.g. where and commas), unlike just from
+  /// the start of \c FirstType to the end of \c SecondType.
+  SourceRange RemovalRange;
+
   RequirementReprKind Kind : 2;
   bool Invalid : 1;
   TypeLoc FirstType;
@@ -1027,15 +1033,17 @@ class RequirementRepr {
   /// for the generated interface.
   StringRef AsWrittenString;
 
-  RequirementRepr(SourceLoc SeparatorLoc, RequirementReprKind Kind,
-                  TypeLoc FirstType, TypeLoc SecondType)
-    : SeparatorLoc(SeparatorLoc), Kind(Kind), Invalid(false),
-      FirstType(FirstType), SecondType(SecondType) { }
+  RequirementRepr(SourceLoc SeparatorLoc, SourceRange RemovalRange,
+                  RequirementReprKind Kind, TypeLoc FirstType,
+                  TypeLoc SecondType)
+      : SeparatorLoc(SeparatorLoc), RemovalRange(RemovalRange), Kind(Kind),
+        Invalid(false), FirstType(FirstType), SecondType(SecondType) {}
 
-  RequirementRepr(SourceLoc SeparatorLoc, RequirementReprKind Kind,
-                  TypeLoc FirstType, LayoutConstraintLoc SecondLayout)
-    : SeparatorLoc(SeparatorLoc), Kind(Kind), Invalid(false),
-      FirstType(FirstType), SecondLayout(SecondLayout) { }
+  RequirementRepr(SourceLoc SeparatorLoc, SourceRange RemovalRange,
+                  RequirementReprKind Kind, TypeLoc FirstType,
+                  LayoutConstraintLoc SecondLayout)
+      : SeparatorLoc(SeparatorLoc), RemovalRange(RemovalRange), Kind(Kind),
+        Invalid(false), FirstType(FirstType), SecondLayout(SecondLayout) {}
 
   void printImpl(ASTPrinter &OS, bool AsWritten) const;
 
@@ -1048,10 +1056,15 @@ public:
   /// this requirement was implied.
   /// \param Constraint The protocol or protocol composition to which the
   /// subject must conform, or superclass from which the subject must inherit.
-  static RequirementRepr getTypeConstraint(TypeLoc Subject,
-                                           SourceLoc ColonLoc,
-                                           TypeLoc Constraint) {
-    return { ColonLoc, RequirementReprKind::TypeConstraint, Subject, Constraint };
+  /// \param RemovalRange A source range suitable for removing the requirement
+  /// from the associated where clause, including everything that needs to be
+  /// removed to keep the program syntactically valid (e.g. the 'where' keyword
+  /// and commas).
+  static RequirementRepr getTypeConstraint(TypeLoc Subject, SourceLoc ColonLoc,
+                                           TypeLoc Constraint,
+                                           SourceRange RemovalRange) {
+    return {ColonLoc, RemovalRange, RequirementReprKind::TypeConstraint,
+            Subject, Constraint};
   }
 
   /// \brief Construct a new same-type requirement.
@@ -1060,25 +1073,34 @@ public:
   /// \param EqualLoc The location of the '==' in the same-type constraint, or
   /// an invalid location if this requirement was implied.
   /// \param SecondType The second type.
-  static RequirementRepr getSameType(TypeLoc FirstType,
-                                     SourceLoc EqualLoc,
-                                     TypeLoc SecondType) {
-    return { EqualLoc, RequirementReprKind::SameType, FirstType, SecondType };
+  /// \param RemovalRange A source range suitable for removing the requirement
+  /// from the associated where clause, including everything that needs to be
+  /// removed to keep the program syntactically valid (e.g. the 'where' keyword
+  /// and commas).
+  static RequirementRepr getSameType(TypeLoc FirstType, SourceLoc EqualLoc,
+                                     TypeLoc SecondType,
+                                     SourceRange RemovalRange) {
+    return {EqualLoc, RemovalRange, RequirementReprKind::SameType, FirstType,
+            SecondType};
   }
 
   /// \brief Construct a new layout-constraint requirement.
   ///
-  /// \param Subject The type that must conform to the given layout 
-  /// requirement.
+  /// \param Subject The type that must conform to the given layout requirement.
   /// \param ColonLoc The location of the ':', or an invalid location if
   /// this requirement was implied.
   /// \param Layout The layout requirement to which the
   /// subject must conform.
+  /// \param RemovalRange A source range suitable for removing the requirement
+  /// from the associated where clause, including everything that needs to be
+  /// removed to keep the program syntactically valid (e.g. the 'where' keyword
+  /// and commas).
   static RequirementRepr getLayoutConstraint(TypeLoc Subject,
                                              SourceLoc ColonLoc,
-                                             LayoutConstraintLoc Layout) {
-    return {ColonLoc, RequirementReprKind::LayoutConstraint, Subject,
-            Layout};
+                                             LayoutConstraintLoc Layout,
+                                             SourceRange RemovalRange) {
+    return {ColonLoc, RemovalRange, RequirementReprKind::LayoutConstraint,
+            Subject, Layout};
   }
 
   /// \brief Determine the kind of requirement
@@ -1159,6 +1181,20 @@ public:
     assert(getKind() == RequirementReprKind::TypeConstraint ||
            getKind() == RequirementReprKind::LayoutConstraint);
     return SeparatorLoc;
+  }
+
+  /// Retrieve the source range suitable for removing the requirement. Unlike
+  /// \c getSourceRange(), this range includes everything that needs to be
+  /// removed to keep the program syntactically valid (e.g. the 'where' keyword
+  /// and commas).
+  SourceRange getRemovalRange() const { return RemovalRange; }
+
+  /// Set the source range suitable for removing the requirement. Unlike
+  /// \c getSourceRange(), this range includes everything that needs to be
+  /// removed to keep the program syntactically valid (e.g. the 'where' keyword
+  /// and commas).
+  void setRemovalRange(SourceRange removalRange) {
+    RemovalRange = removalRange;
   }
 
   /// \brief Retrieve the first type of a same-type requirement.

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1913,11 +1913,11 @@ ERROR(requires_generic_param_same_type_does_not_conform,none,
 ERROR(requires_same_concrete_type,none,
       "generic signature requires types %0 and %1 to be the same", (Type, Type))
 WARNING(redundant_conformance_constraint,none,
-        "redundant conformance constraint %0: %1", (Type, ProtocolDecl *))
+        "redundant conformance constraint %0: %1", (Type, Type))
 NOTE(redundant_conformance_here,none,
      "conformance constraint %1: %2 %select{written here|implied here|"
      "inferred from type here}0",
-     (unsigned, Type, ProtocolDecl *))
+     (unsigned, Type, Type))
 
 ERROR(unsupported_recursive_requirements, none,
       "requirement involves recursion that is not currently supported", ())

--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -1834,6 +1834,11 @@ WARNING(redundant_conformance_adhoc_conditional,none,
 NOTE(redundant_conformance_witness_ignored,none,
      "%0 %1 will not be used to satisfy the conformance to %2",
      (DescriptiveDeclKind, DeclName, DeclName))
+WARNING(redundant_conformance_warning,none,
+        "redundant conformance of %0 to %1", (Type, Type))
+NOTE(all_types_implicitly_conform_to,none,
+     "all types implicitly conform to %0", (Type))
+
 
 // "Near matches"
 WARNING(req_near_match,none,

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1282,6 +1282,12 @@ public:
   /// Retrieve the source range for the requirement, if any.
   SourceRange getSourceRange() const;
 
+  /// Retrieve the source range suitable for removing the requirement, if any.
+  /// Unlike \c getSourceRange(), this range includes everything that needs to
+  /// be removed to keep the program syntactically valid (e.g. the 'where'
+  /// keyword and commas).
+  SourceRange getRemovalRange() const;
+
   /// Compare two requirement sources to determine which has the more
   /// optimal path.
   ///
@@ -1457,6 +1463,12 @@ public:
 
   /// Retrieve the source range for this requirement, if any.
   SourceRange getSourceRange() const;
+
+  /// Retrieve the source range suitable for removing the requirement, if any.
+  /// Unlike \c getSourceRange(), this range includes everything that needs to
+  /// be removed to keep the program syntactically valid (e.g. the 'where'
+  /// keyword and commas).
+  SourceRange getRemovalRange() const;
 
   /// Whether this is an explicitly-stated requirement.
   bool isExplicit() const;

--- a/include/swift/AST/GenericSignatureBuilder.h
+++ b/include/swift/AST/GenericSignatureBuilder.h
@@ -1276,8 +1276,11 @@ public:
                                             ProtocolDecl *proto,
                                             bool &derivedViaConcrete) const;
 
-  /// Retrieve a source location that corresponds to the requirement.
+  /// Retrieve a source location that corresponds to the requirement, if any.
   SourceLoc getLoc() const;
+
+  /// Retrieve the source range for the requirement, if any.
+  SourceRange getSourceRange() const;
 
   /// Compare two requirement sources to determine which has the more
   /// optimal path.
@@ -1449,8 +1452,11 @@ public:
   const RequirementSource *getSource(GenericSignatureBuilder &builder,
                                      Type type) const;
 
-  /// Retrieve the source location for this requirement.
+  /// Retrieve the source location for this requirement, if any.
   SourceLoc getLoc() const;
+
+  /// Retrieve the source range for this requirement, if any.
+  SourceRange getSourceRange() const;
 
   /// Whether this is an explicitly-stated requirement.
   bool isExplicit() const;

--- a/lib/AST/Decl.cpp
+++ b/lib/AST/Decl.cpp
@@ -614,7 +614,8 @@ GenericParamList::clone(DeclContext *dc) const {
       reqt = RequirementRepr::getTypeConstraint(
           first.clone(ctx),
           reqt.getColonLoc(),
-          second.clone(ctx));
+          second.clone(ctx),
+          reqt.getRemovalRange());
       break;
     }
     case RequirementReprKind::SameType: {
@@ -623,7 +624,8 @@ GenericParamList::clone(DeclContext *dc) const {
       reqt = RequirementRepr::getSameType(
           first.clone(ctx),
           reqt.getEqualLoc(),
-          second.clone(ctx));
+          second.clone(ctx),
+          reqt.getRemovalRange());
       break;
     }
     case RequirementReprKind::LayoutConstraint: {
@@ -632,7 +634,8 @@ GenericParamList::clone(DeclContext *dc) const {
       reqt = RequirementRepr::getLayoutConstraint(
           first.clone(ctx),
           reqt.getColonLoc(),
-          layout);
+          layout,
+          reqt.getRemovalRange());
       break;
     }
     }

--- a/lib/AST/GenericSignatureBuilder.cpp
+++ b/lib/AST/GenericSignatureBuilder.cpp
@@ -6292,7 +6292,7 @@ void GenericSignatureBuilder::checkConformanceConstraints(
     // Remove any self-derived constraints.
     removeSelfDerived(*this, entry.second, entry.first);
 
-    checkConstraintList<ProtocolDecl *, ProtocolDecl *>(
+    checkConstraintList<ProtocolDecl *, Type>(
       genericParams, entry.second,
       [](const Constraint<ProtocolDecl *> &constraint) {
         return true;
@@ -6324,7 +6324,7 @@ void GenericSignatureBuilder::checkConformanceConstraints(
       None,
       diag::redundant_conformance_constraint,
       diag::redundant_conformance_here,
-      [](ProtocolDecl *proto) { return proto; },
+      [](ProtocolDecl *proto) { return proto->getDeclaredType(); },
       /*removeSelfDerived=*/false);
   }
 }

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -14,11 +14,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "swift/Parse/Parser.h"
 #include "swift/AST/DiagnosticsParse.h"
+#include "swift/Basic/Defer.h"
 #include "swift/Parse/CodeCompletionCallbacks.h"
-#include "swift/Parse/SyntaxParsingContext.h"
 #include "swift/Parse/Lexer.h"
+#include "swift/Parse/Parser.h"
+#include "swift/Parse/SyntaxParsingContext.h"
 #include "swift/Syntax/SyntaxBuilders.h"
 #include "swift/Syntax/SyntaxNodes.h"
 using namespace swift;
@@ -273,20 +274,24 @@ ParserStatus Parser::parseGenericWhereClause(
   SyntaxParsingContext ReqListContext(SyntaxContext,
                                       SyntaxKind::GenericRequirementList);
   bool HasNextReq;
+  SourceLoc LastCommaLoc;
   do {
     SyntaxParsingContext ReqContext(SyntaxContext, SyntaxContextKind::Syntax);
     // Parse the leading type-identifier.
-    ParserResult<TypeRepr> FirstType = parseTypeIdentifier();
+    ParserResult<TypeRepr> FirstTypeResult = parseTypeIdentifier();
 
-    if (FirstType.hasCodeCompletion()) {
+    if (FirstTypeResult.hasCodeCompletion()) {
       Status.setHasCodeCompletion();
       FirstTypeInComplete = true;
     }
 
-    if (FirstType.isNull()) {
+    if (FirstTypeResult.isNull()) {
       Status.setIsParseError();
       break;
     }
+
+    auto FirstType = FirstTypeResult.get();
+    auto FirstTypeLoc = FirstType->getStartLoc();
 
     if (Tok.is(tok::colon)) {
       // A conformance-requirement.
@@ -311,8 +316,8 @@ ParserStatus Parser::parseGenericWhereClause(
         } else {
           // Add the layout requirement.
           Requirements.push_back(RequirementRepr::getLayoutConstraint(
-              FirstType.get(), ColonLoc,
-              LayoutConstraintLoc(Layout, LayoutLoc)));
+              FirstType, ColonLoc, LayoutConstraintLoc(Layout, LayoutLoc),
+              SourceRange(FirstTypeLoc, PreviousLoc)));
         }
       } else {
         // Parse the protocol or composition.
@@ -327,7 +332,8 @@ ParserStatus Parser::parseGenericWhereClause(
 
         // Add the requirement.
         Requirements.push_back(RequirementRepr::getTypeConstraint(
-            FirstType.get(), ColonLoc, Protocol.get()));
+            FirstType, ColonLoc, Protocol.get(),
+            SourceRange(FirstTypeLoc, PreviousLoc)));
       }
     } else if ((Tok.isAnyOperator() && Tok.getText() == "==") ||
                Tok.is(tok::equal)) {
@@ -349,15 +355,37 @@ ParserStatus Parser::parseGenericWhereClause(
       }
 
       // Add the requirement
-      Requirements.push_back(RequirementRepr::getSameType(FirstType.get(),
-                                                      EqualLoc,
-                                                      SecondType.get()));
+      Requirements.push_back(RequirementRepr::getSameType(
+          FirstType, EqualLoc, SecondType.get(),
+          SourceRange(FirstTypeLoc, PreviousLoc)));
     } else {
       diagnose(Tok, diag::expected_requirement_delim);
       Status.setIsParseError();
       break;
     }
-    HasNextReq = consumeIf(tok::comma);
+    SourceLoc NextCommaLoc;
+    HasNextReq = consumeIf(tok::comma, NextCommaLoc);
+    SWIFT_DEFER { LastCommaLoc = NextCommaLoc; };
+
+    auto &req = Requirements.back();
+    auto removalRange = req.getRemovalRange();
+
+    if (!HasNextReq && LastCommaLoc.isInvalid()) {
+      // Include the where clause in the removal range for the first and only
+      // requirement.
+      removalRange.Start = WhereLoc;
+    }
+    if (!HasNextReq && LastCommaLoc.isValid()) {
+      // Include the previous comma in the removal range of the last
+      // requirement.
+      removalRange.Start = LastCommaLoc;
+    }
+    if (HasNextReq) {
+      // Include the next comma in the removal range of a middle requirement.
+      removalRange.End = NextCommaLoc;
+    }
+    req.setRemovalRange(removalRange);
+
     // If there's a comma, keep parsing the list.
   } while (HasNextReq);
 

--- a/lib/Parse/ParseGeneric.cpp
+++ b/lib/Parse/ParseGeneric.cpp
@@ -375,14 +375,18 @@ ParserStatus Parser::parseGenericWhereClause(
       // requirement.
       removalRange.Start = WhereLoc;
     }
-    if (!HasNextReq && LastCommaLoc.isValid()) {
-      // Include the previous comma in the removal range of the last
-      // requirement.
-      removalRange.Start = LastCommaLoc;
-    }
     if (HasNextReq) {
       // Include the next comma in the removal range of a middle requirement.
       removalRange.End = NextCommaLoc;
+    }
+    if (!HasNextReq && LastCommaLoc.isValid()) {
+      // HACK: Don't provide removal ranges for last-but-not-only requirements.
+      // This is in order to avoid emitting removal fix-its that would require
+      // their source range to be re-calculated after the application of another
+      // fix-it.
+      // FIX-ME(SR-8102): Improve the fix-it engine to handle such 'dependant'
+      // removal fix-its.
+      removalRange = SourceRange();
     }
     req.setRemovalRange(removalRange);
 

--- a/lib/Sema/TypeCheckAttr.cpp
+++ b/lib/Sema/TypeCheckAttr.cpp
@@ -1819,11 +1819,13 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
       if (interfaceFirstType->hasTypeParameter()) {
         resolvedRequirements.push_back(RequirementRepr::getSameType(
             TypeLoc(req.getFirstTypeRepr(), genericType), req.getEqualLoc(),
-            TypeLoc(req.getSecondTypeRepr(), concreteType)));
+            TypeLoc(req.getSecondTypeRepr(), concreteType),
+            req.getRemovalRange()));
       } else {
         resolvedRequirements.push_back(RequirementRepr::getSameType(
             TypeLoc(req.getFirstTypeRepr(), concreteType), req.getEqualLoc(),
-            TypeLoc(req.getSecondTypeRepr(), genericType)));
+            TypeLoc(req.getSecondTypeRepr(), genericType),
+            req.getRemovalRange()));
       }
 
       // Convert the requirement into a form which uses canonical interface
@@ -1855,8 +1857,8 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
       // Re-create a requirement using the resolved interface types.
       auto resolvedReq = RequirementRepr::getLayoutConstraint(
           TypeLoc(req.getSubjectRepr(), interfaceSubjectType),
-          req.getColonLoc(),
-          req.getLayoutConstraintLoc());
+          req.getColonLoc(), req.getLayoutConstraintLoc(),
+          req.getRemovalRange());
 
       // Add a resolved requirement.
       resolvedRequirements.push_back(resolvedReq);
@@ -1897,7 +1899,8 @@ void AttributeChecker::visitSpecializeAttr(SpecializeAttr *attr) {
       auto resolvedReq = RequirementRepr::getTypeConstraint(
           TypeLoc(req.getSubjectRepr(), interfaceSubjectType),
           req.getColonLoc(),
-          TypeLoc(req.getConstraintRepr(), interfaceLayoutConstraint));
+          TypeLoc(req.getConstraintRepr(), interfaceLayoutConstraint),
+          req.getRemovalRange());
 
       // Add a resolved requirement.
       resolvedRequirements.push_back(resolvedReq);

--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -311,8 +311,11 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
   // Retrieve the location of the start of the inheritance clause.
   auto getStartLocOfInheritanceClause = [&] {
     if (auto genericTypeDecl = dyn_cast<GenericTypeDecl>(decl)) {
-      if (auto genericParams = genericTypeDecl->getGenericParams())
-        return genericParams->getSourceRange().End;
+      // Get the end location of the generic parameters, except for protocols
+      // which don't have explicit generic parameters.
+      if (!isa<ProtocolDecl>(decl))
+        if (auto genericParams = genericTypeDecl->getGenericParams())
+          return genericParams->getSourceRange().End;
 
       return genericTypeDecl->getNameLoc();
     }
@@ -321,7 +324,7 @@ void TypeChecker::checkInheritanceClause(Decl *decl,
       return typeDecl->getNameLoc();
 
     if (auto ext = dyn_cast<ExtensionDecl>(decl))
-      return ext->getSourceRange().End;
+      return ext->getExtendedTypeLoc().getLoc();
 
     return SourceLoc();
   };

--- a/test/FixCode/fixits-redundant-any.swift
+++ b/test/FixCode/fixits-redundant-any.swift
@@ -1,0 +1,54 @@
+// RUN: not %swift -typecheck -target %target-triple %s -fixit-all -emit-fixits-path %t.remap
+// RUN: c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
+
+protocol P {}
+
+// FIX-ME(SR-8102): Emit fix-its for the last requirements once we support bulk
+// removal of 'dependant' fix-its.
+struct S1<T> where T : Any, T : Any, T : Any {}
+struct S2<T> where T : P, T : Any, T : Any {}
+struct S3<T> where T : Any, T : P, T : Any {}
+struct S4<T> where T : Any, T : Any, T : P {}
+struct S5<T> where T : Any {}
+
+protocol P1 {
+  associatedtype X1 where X1 : Any
+  associatedtype X2 where X2 : Any, X2 : Any
+  associatedtype X3 where X2 : Any, X2 : Any, X2 : P
+}
+
+// FIX-ME(SR-8102): Always emit fix-its for the second conformances once we
+// support bulk removal of 'dependant' fix-its.
+struct S6 : Any, Any, Any {}
+struct S7 : P, Any, Any {}
+struct S8 : Any, P, Any {}
+struct S9 : Any, Any, P {}
+struct S10 : Any {}
+struct S11 : Any, P {}
+
+enum E1 : Any, String { case x }
+enum E2 : String, Any { case x }
+enum E3 : Any {}
+enum E4 : Any, Any, String { case x }
+
+class C {}
+class C1 : Any, C {}
+class C2 : C, Any {}
+class C3 : Any {}
+class C4 : Any, Any, C {}
+class C5 : Any, AnyObject {}
+class C6 : AnyObject, Any {}
+class C7 : Any, Any, AnyObject {}
+
+// FIX-ME: Implement redundant Any fix-its for requirements parsed as inheritance clauses.
+struct S12<T : Any> {}
+protocol P2 : Any {}
+protocol P3 : Any, Any {}
+protocol P4 : Any, class, AnyObject {} // Parse will re-arrange 'class' to be first.
+protocol P5 : class, Any, AnyObject {}
+protocol P6 : class, AnyObject, Any {}
+
+protocol P7 {
+  associatedtype X1 : Any
+  associatedtype X2 : Any, Any
+}

--- a/test/FixCode/fixits-redundant-any.swift.result
+++ b/test/FixCode/fixits-redundant-any.swift.result
@@ -43,12 +43,12 @@ class C7 : Any, AnyObject {}
 // FIX-ME: Implement redundant Any fix-its for requirements parsed as inheritance clauses.
 struct S12<T : Any> {}
 protocol P2 : Any {}
-protocol P3 : Any, Any {}
+protocol P3 : Any {}
 protocol P4 : class, Any, AnyObject {} // Parse will re-arrange 'class' to be first.
 protocol P5 : Any, AnyObject {}
 protocol P6 : AnyObject, Any {}
 
 protocol P7 {
   associatedtype X1 : Any
-  associatedtype X2 : Any, Any
+  associatedtype X2 : Any
 }

--- a/test/FixCode/fixits-redundant-any.swift.result
+++ b/test/FixCode/fixits-redundant-any.swift.result
@@ -1,0 +1,54 @@
+// RUN: not %swift -typecheck -target %target-triple %s -fixit-all -emit-fixits-path %t.remap
+// RUN: c-arcmt-test %t.remap | arcmt-test -verify-transformed-files %s.result
+
+protocol P {}
+
+// FIX-ME(SR-8102): Emit fix-its for the last requirements once we support bulk
+// removal of 'dependant' fix-its.
+struct S1<T> where T : Any {}
+struct S2<T> where T : P, T : Any {}
+struct S3<T> where T : P, T : Any {}
+struct S4<T> where T : P {}
+struct S5<T> {}
+
+protocol P1 {
+  associatedtype X1 
+  associatedtype X2 where X2 : Any
+  associatedtype X3 where X2 : P
+}
+
+// FIX-ME(SR-8102): Always emit fix-its for the second conformances once we
+// support bulk removal of 'dependant' fix-its.
+struct S6 : Any {}
+struct S7 : P {}
+struct S8 : P {}
+struct S9 : Any, P {}
+struct S10 {}
+struct S11 : P {}
+
+enum E1 : String { case x }
+enum E2 : String { case x }
+enum E3 {}
+enum E4 : String, Any { case x }
+
+class C {}
+class C1 : C {}
+class C2 : C {}
+class C3 {}
+class C4 : C, Any {}
+class C5 : AnyObject {}
+class C6 : AnyObject {}
+class C7 : Any, AnyObject {}
+
+// FIX-ME: Implement redundant Any fix-its for requirements parsed as inheritance clauses.
+struct S12<T : Any> {}
+protocol P2 : Any {}
+protocol P3 : Any, Any {}
+protocol P4 : class, Any, AnyObject {} // Parse will re-arrange 'class' to be first.
+protocol P5 : Any, AnyObject {}
+protocol P6 : AnyObject, Any {}
+
+protocol P7 {
+  associatedtype X1 : Any
+  associatedtype X2 : Any, Any
+}

--- a/test/Generics/function_decls.swift
+++ b/test/Generics/function_decls.swift
@@ -5,7 +5,9 @@
 //===----------------------------------------------------------------------===//
 
 func f0<T>(x: Int, y: Int, t: T) { }
-func f1<T : Any>(x: Int, y: Int, t: T) { }
+func f1<T : Any>(x: Int, y: Int, t: T) { } // expected-warning {{redundant conformance constraint 'T': 'Any'}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
 func f2<T : IteratorProtocol>(x: Int, y: Int, t: T) { }
 func f3<T : () -> ()>(x: Int, y: Int, t: T) { } // expected-error{{expected a class type or protocol-constrained type restricting 'T'}}
 func f4<T>(x: T, y: T) { }

--- a/test/Generics/redundant_constraints.swift
+++ b/test/Generics/redundant_constraints.swift
@@ -1,0 +1,122 @@
+// RUN: %target-typecheck-verify-swift
+
+protocol P1 {}
+protocol P2 {}
+
+struct S01<T : Any> {} // expected-warning {{redundant conformance constraint 'T': 'Any'}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+struct S02<T> where T : Any {} // expected-warning {{redundant conformance constraint 'T': 'Any'}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+struct S04<T : P1> where T : Any {} // expected-warning {{redundant conformance constraint 'T': 'Any'}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+struct S05<T : Any> where T : P1 {} // expected-warning {{redundant conformance constraint 'T': 'Any'}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+struct S06<T : Any> where T : Any {}
+// expected-warning@-1 {{redundant conformance constraint 'T': 'Any'}}
+// expected-note@-2 {{all types implicitly conform to 'Any'}}
+// expected-warning@-3 {{redundant conformance constraint 'T': 'Any'}}
+// expected-note@-4 {{all types implicitly conform to 'Any'}}
+
+struct S07<T> where T : Any, T : P1 {}
+// expected-warning@-1 {{redundant conformance constraint 'T': 'Any'}}
+// expected-note@-2 {{all types implicitly conform to 'Any'}}
+
+struct S08<T> where T : P1, T : Any {}
+// expected-warning@-1 {{redundant conformance constraint 'T': 'Any'}}
+// expected-note@-2 {{all types implicitly conform to 'Any'}}
+
+struct S09<T> where T : P1, T : Any, T : P2 {}
+// expected-warning@-1 {{redundant conformance constraint 'T': 'Any'}}
+// expected-note@-2 {{all types implicitly conform to 'Any'}}
+
+struct S10<T> where T : P1, T : P2, T : Any {}
+// expected-warning@-1 {{redundant conformance constraint 'T': 'Any'}}
+// expected-note@-2 {{all types implicitly conform to 'Any'}}
+
+struct S11<T, U> {}
+extension S11 where T : Any {} // expected-warning {{redundant conformance constraint 'T': 'Any'}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+extension S11 where T : Any, T : P1 {} // expected-warning {{redundant conformance constraint 'T': 'Any'}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+extension S11 where T : Any, U : Any {}
+// expected-warning@-1 {{redundant conformance constraint 'T': 'Any'}}
+// expected-note@-2 {{all types implicitly conform to 'Any'}}
+// expected-warning@-3 {{redundant conformance constraint 'U': 'Any'}}
+// expected-note@-4 {{all types implicitly conform to 'Any'}}
+
+
+protocol P3 {
+  // expected-warning@-1 {{redundant conformance constraint 'Self.X1': 'Any'}}
+  // expected-note@-2 {{all types implicitly conform to 'Any'}}
+  // expected-warning@-3 {{redundant conformance constraint 'Self.X2': 'Any'}}
+  // expected-note@-4 {{all types implicitly conform to 'Any'}}
+
+  associatedtype X1 : Any
+  associatedtype X2 where X2 : Any
+}
+
+protocol P4 {
+  // expected-warning@-1 {{redundant conformance constraint 'Self.X1': 'Any'}}
+  // expected-note@-2 {{all types implicitly conform to 'Any'}}
+  // expected-warning@-3 {{redundant conformance constraint 'Self.X1': 'Any'}}
+  // expected-note@-4 {{all types implicitly conform to 'Any'}}
+  // expected-warning@-5 {{redundant conformance constraint 'Self.X2': 'Any'}}
+  // expected-note@-6 {{all types implicitly conform to 'Any'}}
+  // expected-warning@-7 {{redundant conformance constraint 'Self.X2': 'Any'}}
+  // expected-note@-8 {{all types implicitly conform to 'Any'}}
+  // expected-warning@-9 {{redundant conformance constraint 'Self.X3': 'Any'}}
+  // expected-note@-10 {{all types implicitly conform to 'Any'}}
+  // expected-warning@-11 {{redundant conformance constraint 'Self.X3': 'Any'}}
+  // expected-note@-12 {{all types implicitly conform to 'Any'}}
+
+  associatedtype X1 : Any, Any
+  associatedtype X2 where X2 : Any, X2 : Any
+  associatedtype X3 where X3 : Any, X3 : Any, X3 : P1
+}
+
+protocol P5 : Any {} // expected-warning {{redundant conformance constraint 'Self': 'Any'}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+protocol P6 : Any & Any {} // expected-warning {{redundant conformance constraint 'Self': 'Any'}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+protocol P7 : Any, Any {}
+// expected-warning@-1 {{redundant conformance constraint 'Self': 'Any'}}
+// expected-note@-2 {{all types implicitly conform to 'Any'}}
+// expected-warning@-3 {{redundant conformance constraint 'Self': 'Any'}}
+// expected-note@-4 {{all types implicitly conform to 'Any'}}
+
+func f1<T : Any>(_ x: T) {} // expected-warning {{redundant conformance constraint 'T': 'Any'}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+func f2<T>(_ x: T) where T : Any {} // expected-warning {{redundant conformance constraint 'T': 'Any'}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+typealias AnyAlias = Any
+func f3<T>(_ x: T) where T : AnyAlias {} // expected-warning {{redundant conformance constraint 'T': 'AnyAlias' (aka 'Any')}}
+// expected-note@-1 {{all types implicitly conform to 'AnyAlias' (aka 'Any')}}
+
+func f4<T : Any & Any>(_ x: T) {} // expected-warning {{redundant conformance constraint 'T': 'Any'}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+func f5<T>(_ x: T) where T : Any & Any {} // expected-warning {{redundant conformance constraint 'T': 'Any'}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+typealias AnyAnyAlias = Any & Any
+func f6<T : AnyAnyAlias>(_ x: T) where T : Any {}
+// expected-warning@-1 {{redundant conformance constraint 'T': 'AnyAnyAlias' (aka 'Any')}}
+// expected-note@-2 {{all types implicitly conform to 'AnyAnyAlias' (aka 'Any')}}
+// expected-warning@-3 {{redundant conformance constraint 'T': 'Any'}}
+// expected-note@-4 {{all types implicitly conform to 'Any'}}
+
+// Don't specifically warn on 'Any & P' constraints.
+// FIX-ME(SR-8082): Implement a general diagnostic for the usage of Any & P1.
+func f7<T : Any & P1>(_ x: T) {}
+func f8<T>(_ x: T) where T : P1 & Any {}
+

--- a/test/Generics/redundant_constraints.swift
+++ b/test/Generics/redundant_constraints.swift
@@ -75,7 +75,7 @@ protocol P4 {
   // expected-warning@-11 {{redundant conformance constraint 'Self.X3': 'Any'}} {{37-47=}}
   // expected-note@-12 {{all types implicitly conform to 'Any'}}
 
-  associatedtype X1 : Any, Any
+  associatedtype X1 : Any, Any // expected-error {{duplicate inheritance from 'Any'}} {{26-31=}}
   associatedtype X2 where X2 : Any, X2 : Any
   associatedtype X3 where X3 : Any, X3 : Any, X3 : P1
 }
@@ -91,6 +91,7 @@ protocol P7 : Any, Any {}
 // expected-note@-2 {{all types implicitly conform to 'Any'}}
 // expected-warning@-3 {{redundant conformance constraint 'Self': 'Any'}}
 // expected-note@-4 {{all types implicitly conform to 'Any'}}
+// expected-error@-5 {{duplicate inheritance from 'Any'}} {{18-23=}}
 
 func f1<T : Any>(_ x: T) {} // expected-warning {{redundant conformance constraint 'T': 'Any'}}
 // expected-note@-1 {{all types implicitly conform to 'Any'}}

--- a/test/Generics/redundant_constraints.swift
+++ b/test/Generics/redundant_constraints.swift
@@ -26,7 +26,7 @@ struct S07<T> where T : Any, T : P1 {}
 // expected-note@-2 {{all types implicitly conform to 'Any'}}
 
 struct S08<T> where T : P1, T : Any {}
-// expected-warning@-1 {{redundant conformance constraint 'T': 'Any'}} {{27-36=}}
+// expected-warning@-1 {{redundant conformance constraint 'T': 'Any'}} // FIX-ME(SR-8102): Add expected fix-it {{27-36=}}
 // expected-note@-2 {{all types implicitly conform to 'Any'}}
 
 struct S09<T> where T : P1, T : Any, T : P2 {}
@@ -34,7 +34,7 @@ struct S09<T> where T : P1, T : Any, T : P2 {}
 // expected-note@-2 {{all types implicitly conform to 'Any'}}
 
 struct S10<T> where T : P1, T : P2, T : Any {}
-// expected-warning@-1 {{redundant conformance constraint 'T': 'Any'}} {{35-44=}}
+// expected-warning@-1 {{redundant conformance constraint 'T': 'Any'}} // FIX-ME(SR-8102): Add expected fix-it {{35-44=}}
 // expected-note@-2 {{all types implicitly conform to 'Any'}}
 
 struct S11<T, U> {}
@@ -47,7 +47,7 @@ extension S11 where T : Any, T : P1 {} // expected-warning {{redundant conforman
 extension S11 where T : Any, U : Any {}
 // expected-warning@-1 {{redundant conformance constraint 'T': 'Any'}} {{21-30=}}
 // expected-note@-2 {{all types implicitly conform to 'Any'}}
-// expected-warning@-3 {{redundant conformance constraint 'U': 'Any'}} {{28-37=}}
+// expected-warning@-3 {{redundant conformance constraint 'U': 'Any'}} // FIX-ME(SR-8102): Add expected fix-it {{28-37=}}
 // expected-note@-4 {{all types implicitly conform to 'Any'}}
 
 
@@ -68,7 +68,7 @@ protocol P4 {
   // expected-note@-4 {{all types implicitly conform to 'Any'}}
   // expected-warning@-5 {{redundant conformance constraint 'Self.X2': 'Any'}} {{27-37=}}
   // expected-note@-6 {{all types implicitly conform to 'Any'}}
-  // expected-warning@-7 {{redundant conformance constraint 'Self.X2': 'Any'}} {{35-45=}}
+  // expected-warning@-7 {{redundant conformance constraint 'Self.X2': 'Any'}} // FIX-ME(SR-8102): Add expected fix-it {{35-45=}}
   // expected-note@-8 {{all types implicitly conform to 'Any'}}
   // expected-warning@-9 {{redundant conformance constraint 'Self.X3': 'Any'}} {{27-37=}}
   // expected-note@-10 {{all types implicitly conform to 'Any'}}

--- a/test/Generics/redundant_constraints.swift
+++ b/test/Generics/redundant_constraints.swift
@@ -6,10 +6,10 @@ protocol P2 {}
 struct S01<T : Any> {} // expected-warning {{redundant conformance constraint 'T': 'Any'}}
 // expected-note@-1 {{all types implicitly conform to 'Any'}}
 
-struct S02<T> where T : Any {} // expected-warning {{redundant conformance constraint 'T': 'Any'}}
+struct S02<T> where T : Any {} // expected-warning {{redundant conformance constraint 'T': 'Any'}} {{15-29=}}
 // expected-note@-1 {{all types implicitly conform to 'Any'}}
 
-struct S04<T : P1> where T : Any {} // expected-warning {{redundant conformance constraint 'T': 'Any'}}
+struct S04<T : P1> where T : Any {} // expected-warning {{redundant conformance constraint 'T': 'Any'}} {{20-34=}}
 // expected-note@-1 {{all types implicitly conform to 'Any'}}
 
 struct S05<T : Any> where T : P1 {} // expected-warning {{redundant conformance constraint 'T': 'Any'}}
@@ -18,43 +18,43 @@ struct S05<T : Any> where T : P1 {} // expected-warning {{redundant conformance 
 struct S06<T : Any> where T : Any {}
 // expected-warning@-1 {{redundant conformance constraint 'T': 'Any'}}
 // expected-note@-2 {{all types implicitly conform to 'Any'}}
-// expected-warning@-3 {{redundant conformance constraint 'T': 'Any'}}
+// expected-warning@-3 {{redundant conformance constraint 'T': 'Any'}} {{21-35=}}
 // expected-note@-4 {{all types implicitly conform to 'Any'}}
 
 struct S07<T> where T : Any, T : P1 {}
-// expected-warning@-1 {{redundant conformance constraint 'T': 'Any'}}
+// expected-warning@-1 {{redundant conformance constraint 'T': 'Any'}} {{21-30=}}
 // expected-note@-2 {{all types implicitly conform to 'Any'}}
 
 struct S08<T> where T : P1, T : Any {}
-// expected-warning@-1 {{redundant conformance constraint 'T': 'Any'}}
+// expected-warning@-1 {{redundant conformance constraint 'T': 'Any'}} {{27-36=}}
 // expected-note@-2 {{all types implicitly conform to 'Any'}}
 
 struct S09<T> where T : P1, T : Any, T : P2 {}
-// expected-warning@-1 {{redundant conformance constraint 'T': 'Any'}}
+// expected-warning@-1 {{redundant conformance constraint 'T': 'Any'}} {{29-38=}}
 // expected-note@-2 {{all types implicitly conform to 'Any'}}
 
 struct S10<T> where T : P1, T : P2, T : Any {}
-// expected-warning@-1 {{redundant conformance constraint 'T': 'Any'}}
+// expected-warning@-1 {{redundant conformance constraint 'T': 'Any'}} {{35-44=}}
 // expected-note@-2 {{all types implicitly conform to 'Any'}}
 
 struct S11<T, U> {}
-extension S11 where T : Any {} // expected-warning {{redundant conformance constraint 'T': 'Any'}}
+extension S11 where T : Any {} // expected-warning {{redundant conformance constraint 'T': 'Any'}} {{15-29=}}
 // expected-note@-1 {{all types implicitly conform to 'Any'}}
 
-extension S11 where T : Any, T : P1 {} // expected-warning {{redundant conformance constraint 'T': 'Any'}}
+extension S11 where T : Any, T : P1 {} // expected-warning {{redundant conformance constraint 'T': 'Any'}} {{21-30=}}
 // expected-note@-1 {{all types implicitly conform to 'Any'}}
 
 extension S11 where T : Any, U : Any {}
-// expected-warning@-1 {{redundant conformance constraint 'T': 'Any'}}
+// expected-warning@-1 {{redundant conformance constraint 'T': 'Any'}} {{21-30=}}
 // expected-note@-2 {{all types implicitly conform to 'Any'}}
-// expected-warning@-3 {{redundant conformance constraint 'U': 'Any'}}
+// expected-warning@-3 {{redundant conformance constraint 'U': 'Any'}} {{28-37=}}
 // expected-note@-4 {{all types implicitly conform to 'Any'}}
 
 
 protocol P3 {
   // expected-warning@-1 {{redundant conformance constraint 'Self.X1': 'Any'}}
   // expected-note@-2 {{all types implicitly conform to 'Any'}}
-  // expected-warning@-3 {{redundant conformance constraint 'Self.X2': 'Any'}}
+  // expected-warning@-3 {{redundant conformance constraint 'Self.X2': 'Any'}} {{21-35=}}
   // expected-note@-4 {{all types implicitly conform to 'Any'}}
 
   associatedtype X1 : Any
@@ -66,13 +66,13 @@ protocol P4 {
   // expected-note@-2 {{all types implicitly conform to 'Any'}}
   // expected-warning@-3 {{redundant conformance constraint 'Self.X1': 'Any'}}
   // expected-note@-4 {{all types implicitly conform to 'Any'}}
-  // expected-warning@-5 {{redundant conformance constraint 'Self.X2': 'Any'}}
+  // expected-warning@-5 {{redundant conformance constraint 'Self.X2': 'Any'}} {{27-37=}}
   // expected-note@-6 {{all types implicitly conform to 'Any'}}
-  // expected-warning@-7 {{redundant conformance constraint 'Self.X2': 'Any'}}
+  // expected-warning@-7 {{redundant conformance constraint 'Self.X2': 'Any'}} {{35-45=}}
   // expected-note@-8 {{all types implicitly conform to 'Any'}}
-  // expected-warning@-9 {{redundant conformance constraint 'Self.X3': 'Any'}}
+  // expected-warning@-9 {{redundant conformance constraint 'Self.X3': 'Any'}} {{27-37=}}
   // expected-note@-10 {{all types implicitly conform to 'Any'}}
-  // expected-warning@-11 {{redundant conformance constraint 'Self.X3': 'Any'}}
+  // expected-warning@-11 {{redundant conformance constraint 'Self.X3': 'Any'}} {{37-47=}}
   // expected-note@-12 {{all types implicitly conform to 'Any'}}
 
   associatedtype X1 : Any, Any
@@ -95,24 +95,24 @@ protocol P7 : Any, Any {}
 func f1<T : Any>(_ x: T) {} // expected-warning {{redundant conformance constraint 'T': 'Any'}}
 // expected-note@-1 {{all types implicitly conform to 'Any'}}
 
-func f2<T>(_ x: T) where T : Any {} // expected-warning {{redundant conformance constraint 'T': 'Any'}}
+func f2<T>(_ x: T) where T : Any {} // expected-warning {{redundant conformance constraint 'T': 'Any'}} {{20-34=}}
 // expected-note@-1 {{all types implicitly conform to 'Any'}}
 
 typealias AnyAlias = Any
-func f3<T>(_ x: T) where T : AnyAlias {} // expected-warning {{redundant conformance constraint 'T': 'AnyAlias' (aka 'Any')}}
+func f3<T>(_ x: T) where T : AnyAlias {} // expected-warning {{redundant conformance constraint 'T': 'AnyAlias' (aka 'Any')}} {{20-39=}}
 // expected-note@-1 {{all types implicitly conform to 'AnyAlias' (aka 'Any')}}
 
 func f4<T : Any & Any>(_ x: T) {} // expected-warning {{redundant conformance constraint 'T': 'Any'}}
 // expected-note@-1 {{all types implicitly conform to 'Any'}}
 
-func f5<T>(_ x: T) where T : Any & Any {} // expected-warning {{redundant conformance constraint 'T': 'Any'}}
+func f5<T>(_ x: T) where T : Any & Any {} // expected-warning {{redundant conformance constraint 'T': 'Any'}} {{20-40=}}
 // expected-note@-1 {{all types implicitly conform to 'Any'}}
 
 typealias AnyAnyAlias = Any & Any
 func f6<T : AnyAnyAlias>(_ x: T) where T : Any {}
 // expected-warning@-1 {{redundant conformance constraint 'T': 'AnyAnyAlias' (aka 'Any')}}
 // expected-note@-2 {{all types implicitly conform to 'AnyAnyAlias' (aka 'Any')}}
-// expected-warning@-3 {{redundant conformance constraint 'T': 'Any'}}
+// expected-warning@-3 {{redundant conformance constraint 'T': 'Any'}} {{34-48=}}
 // expected-note@-4 {{all types implicitly conform to 'Any'}}
 
 // Don't specifically warn on 'Any & P' constraints.

--- a/test/Sema/diag_ambiguous_overloads.swift
+++ b/test/Sema/diag_ambiguous_overloads.swift
@@ -58,7 +58,8 @@ Variadic.foo(1.0, 2.0, 3.0) // expected-error {{cannot convert value of type 'Do
 
 //=-------------- SR-7918 --------------=/
 class sr7918_Suit {
-  static func foo<T: Any>(_ :inout T) {}
+  static func foo<T: Any>(_ :inout T) {} // expected-warning {{redundant conformance constraint 'T': 'Any'}}
+  // expected-note@-1 {{all types implicitly conform to 'Any'}}
   static func foo() {}
 }
 

--- a/test/decl/inherit/inherit.swift
+++ b/test/decl/inherit/inherit.swift
@@ -21,11 +21,15 @@ class D : P, A { } // expected-error{{superclass 'A' must appear first in the in
 
 // SR-8160
 class D1 : Any, A { } // expected-error{{superclass 'A' must appear first in the inheritance clause}}{{15-18=}}{{12-12=A, }}
+// expected-warning@-1 {{redundant conformance of 'D1' to 'Any'}}
+// expected-note@-2 {{all types implicitly conform to 'Any'}}
 
 class D2 : P & P1, A { } // expected-error{{superclass 'A' must appear first in the inheritance clause}}{{18-21=}}{{12-12=A, }}
 
 @usableFromInline
 class D3 : Any, A { } // expected-error{{superclass 'A' must appear first in the inheritance clause}}{{15-18=}}{{12-12=A, }}
+// expected-warning@-1 {{redundant conformance of 'D3' to 'Any'}}
+// expected-note@-2 {{all types implicitly conform to 'Any'}}
 
 @usableFromInline
 class D4 : P & P1, A { } // expected-error{{superclass 'A' must appear first in the inheritance clause}}{{18-21=}}{{12-12=A, }}

--- a/test/decl/inherit/inherit.swift
+++ b/test/decl/inherit/inherit.swift
@@ -20,15 +20,15 @@ class C : B, A { } // expected-error{{multiple inheritance from classes 'B' and 
 class D : P, A { } // expected-error{{superclass 'A' must appear first in the inheritance clause}}{{12-15=}}{{11-11=A, }}
 
 // SR-8160
-class D1 : Any, A { } // expected-error{{superclass 'A' must appear first in the inheritance clause}}{{15-18=}}{{12-12=A, }}
-// expected-warning@-1 {{redundant conformance of 'D1' to 'Any'}}
+class D1 : Any, A { } // expected-error{{superclass 'A' must appear first in the inheritance clause}} // We don't emit a fix-it in this case in order to avoid overlapping removal fix-it ranges. However, we emit a removal fix-it for the redundant 'Any', which has the same effect.
+// expected-warning@-1 {{redundant conformance of 'D1' to 'Any'}} {{12-17=}}
 // expected-note@-2 {{all types implicitly conform to 'Any'}}
 
 class D2 : P & P1, A { } // expected-error{{superclass 'A' must appear first in the inheritance clause}}{{18-21=}}{{12-12=A, }}
 
 @usableFromInline
-class D3 : Any, A { } // expected-error{{superclass 'A' must appear first in the inheritance clause}}{{15-18=}}{{12-12=A, }}
-// expected-warning@-1 {{redundant conformance of 'D3' to 'Any'}}
+class D3 : Any, A { } // expected-error{{superclass 'A' must appear first in the inheritance clause}} // We don't emit a fix-it in this case in order to avoid overlapping removal fix-it ranges. However, we emit a removal fix-it for the redundant 'Any', which has the same effect.
+// expected-warning@-1 {{redundant conformance of 'D3' to 'Any'}} {{12-17=}}
 // expected-note@-2 {{all types implicitly conform to 'Any'}}
 
 @usableFromInline

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -51,26 +51,80 @@ protocol FormattedPrintable : CustomStringConvertible {
   func print(format: TestFormat)
 }
 
+// expected-warning@+2 {{redundant conformance of 'X0' to 'Any'}} {{13-18=}}
+// expected-note@+1 {{all types implicitly conform to 'Any'}}
 struct X0 : Any, CustomStringConvertible {
   func print() {}
 }
 
+// expected-warning@+2 {{redundant conformance of 'X1' to 'Any'}} {{12-17=}}
+// expected-note@+1 {{all types implicitly conform to 'Any'}}
 class X1 : Any, CustomStringConvertible {
   func print() {}
 }
 
+// expected-warning@+2 {{redundant conformance of 'X2' to 'Any'}} {{8-14=}}
+// expected-note@+1 {{all types implicitly conform to 'Any'}}
 enum X2 : Any { }
 
 extension X2 : CustomStringConvertible {
   func print() {}
 }
 
+struct X5 {
+  func print() {}
+}
+extension X5 : Any {} // expected-warning {{redundant conformance of 'X5' to 'Any'}} {{13-19=}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+extension X5 : Any, CustomStringConvertible {} // expected-warning {{redundant conformance of 'X5' to 'Any'}} {{16-21=}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+struct X6 {
+  func print() {}
+}
+extension X6 : CustomStringConvertible, Any {} // expected-warning {{redundant conformance of 'X6' to 'Any'}} {{39-44=}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+struct X7<T> : Any {} // expected-warning {{redundant conformance of 'X7<T>' to 'Any'}} {{13-19=}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+struct X8<T> {
+  func print() {}
+}
+extension X8 : Any where T : CustomStringConvertible {} // expected-warning {{redundant conformance of 'X8<T>' to 'Any'}} {{13-19=}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+typealias AnyAlias = Any
+class X9 : AnyAlias {} // expected-warning {{redundant conformance of 'X9' to 'AnyAlias' (aka 'Any')}} {{9-20=}}
+// expected-note@-1 {{all types implicitly conform to 'AnyAlias' (aka 'Any')}}
+
+struct X10 : Any & Any {} // expected-warning {{redundant conformance of 'X10' to 'Any'}} {{11-23=}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
+typealias AnyAnyAlias = Any & Any
+
+class X11 : AnyAnyAlias {} // expected-warning {{redundant conformance of 'X11' to 'AnyAnyAlias' (aka 'Any')}} {{10-24=}}
+// expected-note@-1 {{all types implicitly conform to 'AnyAnyAlias' (aka 'Any')}}
+
+struct X12 : Any, Any {}
+// expected-warning@-1 {{redundant conformance of 'X12' to 'Any'}} {{14-19=}}
+// expected-note@-2 {{all types implicitly conform to 'Any'}}
+// expected-warning@-3 {{redundant conformance of 'X12' to 'Any'}} {{17-22=}}
+// expected-note@-4 {{all types implicitly conform to 'Any'}}
+
 // Explicit conformance checks (unsuccessful)
 
+// expected-warning@+2 {{redundant conformance of 'NotPrintableS' to 'Any'}} {{24-29=}}
+// expected-note@+1 {{all types implicitly conform to 'Any'}}
 struct NotPrintableS : Any, CustomStringConvertible {} // expected-error{{type 'NotPrintableS' does not conform to protocol 'CustomStringConvertible'}}
 
+// expected-warning@+2 {{redundant conformance of 'NotPrintableC' to 'Any'}} {{46-51=}}
+// expected-note@+1 {{all types implicitly conform to 'Any'}}
 class NotPrintableC : CustomStringConvertible, Any {} // expected-error{{type 'NotPrintableC' does not conform to protocol 'CustomStringConvertible'}}
 
+// expected-warning@+2 {{redundant conformance of 'NotPrintableO' to 'Any'}} {{22-27=}}
+// expected-note@+1 {{all types implicitly conform to 'Any'}}
 enum NotPrintableO : Any, CustomStringConvertible {} // expected-error{{type 'NotPrintableO' does not conform to protocol 'CustomStringConvertible'}}
 
 struct NotFormattedPrintable : FormattedPrintable { // expected-error{{type 'NotFormattedPrintable' does not conform to protocol 'CustomStringConvertible'}}

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -110,7 +110,7 @@ class X11 : AnyAnyAlias {} // expected-warning {{redundant conformance of 'X11' 
 struct X12 : Any, Any {}
 // expected-warning@-1 {{redundant conformance of 'X12' to 'Any'}} {{14-19=}}
 // expected-note@-2 {{all types implicitly conform to 'Any'}}
-// expected-warning@-3 {{redundant conformance of 'X12' to 'Any'}} {{17-22=}}
+// expected-warning@-3 {{redundant conformance of 'X12' to 'Any'}} // FIX-ME(SR-8102): Add expected fix-it {{17-22=}}
 // expected-note@-4 {{all types implicitly conform to 'Any'}}
 
 // Explicit conformance checks (unsuccessful)

--- a/test/decl/protocol/protocols.swift
+++ b/test/decl/protocol/protocols.swift
@@ -110,8 +110,7 @@ class X11 : AnyAnyAlias {} // expected-warning {{redundant conformance of 'X11' 
 struct X12 : Any, Any {}
 // expected-warning@-1 {{redundant conformance of 'X12' to 'Any'}} {{14-19=}}
 // expected-note@-2 {{all types implicitly conform to 'Any'}}
-// expected-warning@-3 {{redundant conformance of 'X12' to 'Any'}} // FIX-ME(SR-8102): Add expected fix-it {{17-22=}}
-// expected-note@-4 {{all types implicitly conform to 'Any'}}
+// expected-error@-3 {{duplicate inheritance from 'Any'}} // FIX-ME(SR-8102): Add expected fix-it {{17-22=}}
 
 // Explicit conformance checks (unsuccessful)
 

--- a/test/type/protocol_composition.swift
+++ b/test/type/protocol_composition.swift
@@ -26,8 +26,13 @@ typealias Any1 = protocol<> // expected-error {{'protocol<>' syntax has been rem
 typealias Any2 = protocol< > // expected-error {{'protocol<>' syntax has been removed; use 'Any' instead}}
 
 // Okay to inherit a typealias for Any type.
-protocol P5 : Any { }
+protocol P5 : Any { } // expected-warning {{redundant conformance constraint 'Self': 'Any'}}
+// expected-note@-1 {{all types implicitly conform to 'Any'}}
+
 protocol P6 : protocol<> { } // expected-error {{'protocol<>' syntax has been removed; use 'Any' instead}}
+// expected-warning@-1 {{redundant conformance constraint 'Self': 'Any'}}
+// expected-note@-2 {{all types implicitly conform to 'Any'}}
+
 typealias P7 = Any & Any1
 
 extension Int : P5 { }


### PR DESCRIPTION
This PR implements a warning for explicitly stated `: Any` conformances and constraints, which are always redundant. In addition, a fix-it for removal is provided, except for the case of constraints that are parsed as inheritance clauses, e.g `<T : Any>` & `protocol P : Any`. I couldn't see a simple way to implement fix-its for these cases, as inherited types are just represented as TypeReprs in GSB. 

From what I can tell (there may well be a better approach I'm overlooking), we'd need a custom data structure by which to represent inheritance constraints (which can include a removal range), much like `RequirementRepr`, which we would need to store on `TypeDecl` and `ExtensionDecl` AST nodes.

Such a change would be pretty widespread, so I think it would be best to do it in a follow-up PR (I'll file a JIRA if/when this is merged). GSB already doesn't provide fix-its for its existing redundant constraint warning, so I think this PR is an acceptable waypoint.

Resolves [SR-8008] & [SR-8009].

  [SR-8008]: https://bugs.swift.org/browse/SR-8008
  [SR-8009]: https://bugs.swift.org/browse/SR-8009