### PR TITLE
[ClangImporter] Defend against ObjC properties without getters

### DIFF
--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -4891,13 +4891,18 @@ namespace {
       Impl.recordImplicitUnwrapForDecl(result,
                                        importedType.isImplicitlyUnwrapped());
 
+      // Recover from a missing getter in no-asserts builds. We're still not
+      // sure under what circumstances this occurs, but we shouldn't crash.
+      auto clangGetter = decl->getGetterMethodDecl();
+      assert(clangGetter && "ObjC property without getter");
+      if (!clangGetter)
+        return nullptr;
+
       // Import the getter.
-      AccessorDecl *getter = nullptr;
-      if (auto clangGetter = decl->getGetterMethodDecl()) {
-        getter = importAccessor(clangGetter, result, AccessorKind::Get, dc);
-        if (!getter)
-          return nullptr;
-      }
+      AccessorDecl *getter = importAccessor(clangGetter, result,
+                                            AccessorKind::Get, dc);
+      if (!getter)
+        return nullptr;
 
       // Import the setter, if there is one.
       AccessorDecl *setter = nullptr;


### PR DESCRIPTION
Objective-C provides no way to declare such a thing, so for this to occur something else must have gone wrong. Unfortunately all we have is a SourceKit crash log, so I couldn't write a test case. Hopefully some day the assert will fire and we can handle this properly.

rdar://problem/41305904