### PR TITLE
[4.2 EARLY] [ClangImporter] Hardcode NSString being bridged to String

### DIFF
--- a/lib/ClangImporter/ImportType.cpp
+++ b/lib/ClangImporter/ImportType.cpp
@@ -949,12 +949,13 @@ namespace {
         }
 
         // Determine whether this Objective-C class type is bridged to
-        // a Swift type.
+        // a Swift type. Hardcode "NSString" since it's referenced from
+        // the ObjectiveC module (a level below Foundation).
         Type bridgedType;
         if (auto objcClassDef = objcClass->getDefinition())
           bridgedType = mapSwiftBridgeAttr(objcClassDef);
-        else
-          bridgedType = mapSwiftBridgeAttr(objcClass);
+        else if (objcClass->getName() == "NSString")
+          bridgedType = Impl.SwiftContext.getStringDecl()->getDeclaredType();
 
         if (bridgedType) {
           // Gather the type arguments.


### PR DESCRIPTION
- **Explanation**: apple/swift-clang#199 removes support for API notes on forward declarations of ObjC classes and protocols, but we were still using that in one place: to bridge NSString to String in the ObjectiveC module, a level below Foundation. (This wouldn't have to go into the early branch except that Clang just has swift-4.2-branch for both.)

- **Scope**: Disallows all ObjC forward class declarations from being bridged to value types *except* NSString.

- **Issue**: rdar://problem/40278479

- **Risk**: Low. No one would have been doing this for any type other than NSString (because you can't implement the corresponding bridging protocol to go the other way), and almost no one imports the ObjectiveC module without Foundation.

- **Testing**: Passed existing compiler regression tests with and without the Clang change.

- **Reviewed by**: @DougGregor 