### PR TITLE
[RemoteMirrors] Clear the Demangler on each iteration of the loop in getFieldTypeInfo.

### DIFF
--- a/stdlib/public/Reflection/TypeRefBuilder.cpp
+++ b/stdlib/public/Reflection/TypeRefBuilder.cpp
@@ -160,6 +160,7 @@ TypeRefBuilder::getFieldTypeInfo(const TypeRef *TR) {
       auto CandidateMangledName = FD.getMangledTypeName(TypeRefOffset);
       auto NormalizedName = normalizeReflectionName(Dem, CandidateMangledName);
       FieldTypeInfoCache[NormalizedName] = {&FD, &Info};
+      Dem.clear();
     }
   }
 


### PR DESCRIPTION
Otherwise the Demangler can end up allocating hundreds of megabytes of memory.

Cherry-pick for swift-4.2-branch-06-11-2018

rdar://problem/40826018