### PR TITLE
SILGen: createWithoutActuallyEscapingClosure needs to use a substitut…

### DIFF
--- a/test/SILGen/without_actually_escaping.swift
+++ b/test/SILGen/without_actually_escaping.swift
@@ -43,3 +43,27 @@ func letEscape(f: () -> ()) -> () -> () {
 func letEscapeThrow(f: () throws -> () -> ()) throws -> () -> () {
   return try withoutActuallyEscaping(f) { return try $0() }
 }
+
+// We used to crash on this example because we would use the wrong substitution
+// map.
+struct DontCrash {
+  private func firstEnv<L1>(
+    closure1: (L1) -> Bool,
+    closure2: (L1) -> Bool
+  ) {
+    withoutActuallyEscaping(closure1) { closure1 in
+        secondEnv(
+            closure1: closure1,
+            closure2: closure2
+        )
+    }
+  }
+
+  private func secondEnv<L2>(
+    closure1: @escaping (L2) -> Bool,
+    closure2: (L2) -> Bool
+  ) {
+    withoutActuallyEscaping(closure2) { closure2 in
+    }
+  }
+}


### PR DESCRIPTION
…ion map in the context of the current generic enviroment

We used a substitution map derived from a thunk that might have been
created in a different function if that other function used the same
thunk type.
Instead use a substitution map that was derived from the
current functions generic environment.

rdar://41331672
SR-8064