### PR TITLE
[4.2] SILGen: createWithoutActuallyEscapingClosure needs to use a sub…

### DIFF
--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -2939,13 +2939,13 @@ static ManagedValue createThunk(SILGenFunction &SGF,
 
 static CanSILFunctionType buildWithoutActuallyEscapingThunkType(
     SILGenFunction &SGF, CanSILFunctionType &noEscapingType,
-    CanSILFunctionType &escapingType, GenericEnvironment *&genericEnv) {
+    CanSILFunctionType &escapingType, GenericEnvironment *&genericEnv,
+    SubstitutionMap &interfaceSubs) {
 
   assert(escapingType->getExtInfo() ==
          noEscapingType->getExtInfo().withNoEscape(false));
 
   CanType inputSubstType, outputSubstType;
-  SubstitutionMap interfaceSubs;
   return SGF.buildThunkType(noEscapingType, escapingType,
                             inputSubstType, outputSubstType,
                             genericEnv, interfaceSubs,
@@ -3000,12 +3000,13 @@ SILGenFunction::createWithoutActuallyEscapingClosure(
                                            ->getExtInfo()
                                            .withNoEscape(false));
 
+  SubstitutionMap interfaceSubs;
   GenericEnvironment *genericEnv = nullptr;
   auto noEscapingFnTy =
       noEscapingFunctionValue.getType().castTo<SILFunctionType>();
 
   auto thunkType = buildWithoutActuallyEscapingThunkType(
-      *this, noEscapingFnTy, escapingFnTy, genericEnv);
+      *this, noEscapingFnTy, escapingFnTy, genericEnv, interfaceSubs);
 
   auto *thunk = SGM.getOrCreateReabstractionThunk(
       thunkType, noEscapingFnTy, escapingFnTy, F.isSerialized());
@@ -3016,8 +3017,13 @@ SILGenFunction::createWithoutActuallyEscapingClosure(
     buildWithoutActuallyEscapingThunkBody(thunkSGF);
   }
 
-  CanSILFunctionType substFnType = thunkType->substGenericArgs(
-      F.getModule(), thunk->getForwardingSubstitutions());
+  CanSILFunctionType substFnTy = thunkType;
+  // Use the subsitution map in the context of the current function.
+  // thunk->getForwardingSubstitutionMap() / thunk might have been created in a
+  // different function's generic enviroment.
+  if (auto genericSig = thunkType->getGenericSignature()) {
+    substFnTy = thunkType->substGenericArgs(F.getModule(), interfaceSubs);
+  }
 
   // Create it in our current function.
   auto thunkValue = B.createFunctionRef(loc, thunk);
@@ -3025,8 +3031,8 @@ SILGenFunction::createWithoutActuallyEscapingClosure(
       noEscapingFunctionValue.ensurePlusOne(*this, loc).forward(*this);
   SingleValueInstruction *thunkedFn = B.createPartialApply(
       loc, thunkValue,
-      SILType::getPrimitiveObjectType(substFnType),
-      thunk->getForwardingSubstitutions(),
+      SILType::getPrimitiveObjectType(substFnTy),
+      interfaceSubs,
       noEscapeValue,
       SILType::getPrimitiveObjectType(escapingFnTy));
   // We need to ensure the 'lifetime' of the trivial values context captures. As

--- a/lib/SILGen/SILGenPoly.cpp
+++ b/lib/SILGen/SILGenPoly.cpp
@@ -3021,7 +3021,9 @@ SILGenFunction::createWithoutActuallyEscapingClosure(
   // Use the subsitution map in the context of the current function.
   // thunk->getForwardingSubstitutionMap() / thunk might have been created in a
   // different function's generic enviroment.
+  SmallVector<Substitution, 4> subs;
   if (auto genericSig = thunkType->getGenericSignature()) {
+    genericSig->getSubstitutions(interfaceSubs, subs);
     substFnTy = thunkType->substGenericArgs(F.getModule(), interfaceSubs);
   }
 
@@ -3032,7 +3034,7 @@ SILGenFunction::createWithoutActuallyEscapingClosure(
   SingleValueInstruction *thunkedFn = B.createPartialApply(
       loc, thunkValue,
       SILType::getPrimitiveObjectType(substFnTy),
-      interfaceSubs,
+      subs,
       noEscapeValue,
       SILType::getPrimitiveObjectType(escapingFnTy));
   // We need to ensure the 'lifetime' of the trivial values context captures. As

--- a/test/SILGen/without_actually_escaping.swift
+++ b/test/SILGen/without_actually_escaping.swift
@@ -43,3 +43,27 @@ func letEscape(f: () -> ()) -> () -> () {
 func letEscapeThrow(f: () throws -> () -> ()) throws -> () -> () {
   return try withoutActuallyEscaping(f) { return try $0() }
 }
+
+// We used to crash on this example because we would use the wrong substitution
+// map.
+struct DontCrash {
+  private func firstEnv<L1>(
+    closure1: (L1) -> Bool,
+    closure2: (L1) -> Bool
+  ) {
+    withoutActuallyEscaping(closure1) { closure1 in
+        secondEnv(
+            closure1: closure1,
+            closure2: closure2
+        )
+    }
+  }
+
+  private func secondEnv<L2>(
+    closure1: @escaping (L2) -> Bool,
+    closure2: (L2) -> Bool
+  ) {
+    withoutActuallyEscaping(closure2) { closure2 in
+    }
+  }
+}


### PR DESCRIPTION
…stitution map in the context of the current generic enviroment

We used a substitution map derived from a thunk that might have been
created in a different function if that other function used the same
thunk type.
Instead use a substitution map that was derived from the
current functions generic environment.

rdar://41331672
SR-8064