### PR TITLE
DebugInfo: Bypass resilience to calculate if a global is indirect or not [4.2]

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -1952,7 +1952,7 @@ bool LinkInfo::isUsed(llvm::GlobalValue::LinkageTypes Linkage,
 llvm::GlobalVariable *swift::irgen::createVariable(
     IRGenModule &IGM, LinkInfo &linkInfo, llvm::Type *storageType,
     Alignment alignment, DebugTypeInfo DbgTy, Optional<SILLocation> DebugLoc,
-    StringRef DebugName, bool inFixedBuffer) {
+    StringRef DebugName, bool inFixedBuffer, bool indirectForDebugInfo) {
   auto name = linkInfo.getName();
   llvm::GlobalValue *existingValue = IGM.Module.getNamedGlobal(name);
   if (existingValue) {
@@ -1984,7 +1984,7 @@ llvm::GlobalVariable *swift::irgen::createVariable(
   if (IGM.DebugInfo && !DbgTy.isNull() && linkInfo.isForDefinition())
     IGM.DebugInfo->emitGlobalVariableDeclaration(
         var, DebugName.empty() ? name : DebugName, name, DbgTy,
-        var->hasInternalLinkage(), inFixedBuffer, DebugLoc);
+        var->hasInternalLinkage(), indirectForDebugInfo, DebugLoc);
 
   return var;
 }
@@ -2121,6 +2121,7 @@ Address IRGenModule::getAddrOfSILGlobalVariable(SILGlobalVariable *var,
   Size fixedSize;
   Alignment fixedAlignment;
   bool inFixedBuffer = false;
+  bool indirectForDebugInfo = false;
 
   if (var->isInitializedObject()) {
     assert(ti.isFixedSize(expansion));
@@ -2154,6 +2155,28 @@ Address IRGenModule::getAddrOfSILGlobalVariable(SILGlobalVariable *var,
     storageType = getFixedBufferTy();
     fixedSize = Size(DataLayout.getTypeAllocSize(storageType));
     fixedAlignment = Alignment(DataLayout.getABITypeAlignment(storageType));
+
+    // DebugInfo is not resilient for now, so disable resilience to figure out
+    // if lldb needs to dereference the global variable or not.
+    //
+    // FIXME: Once lldb can make use of remote mirrors to calculate layouts
+    // at runtime, this should be removed.
+    {
+      CompletelyFragileScope Scope(*this);
+
+      SILType loweredTy = var->getLoweredType();
+      auto &nonResilientTI = cast<FixedTypeInfo>(getTypeInfo(loweredTy));
+      auto packing = nonResilientTI.getFixedPacking(*this);
+      switch (packing) {
+      case FixedPacking::OffsetZero:
+        break;
+      case FixedPacking::Allocate:
+        indirectForDebugInfo = true;
+        break;
+      default:
+        llvm_unreachable("Bad packing");
+      }
+    }
   }
 
   // Check whether we've created the global variable already.
@@ -2195,7 +2218,8 @@ Address IRGenModule::getAddrOfSILGlobalVariable(SILGlobalVariable *var,
       auto DbgTy = DebugTypeInfo::getGlobal(var, storageTypeWithContainer,
                                             fixedSize, fixedAlignment);
       gvar = createVariable(*this, link, storageTypeWithContainer,
-                            fixedAlignment, DbgTy, loc, name, inFixedBuffer);
+                            fixedAlignment, DbgTy, loc, name, inFixedBuffer,
+                            indirectForDebugInfo);
     }
     /// Add a zero initializer.
     if (forDefinition)

--- a/lib/IRGen/GenDecl.h
+++ b/lib/IRGen/GenDecl.h
@@ -50,7 +50,8 @@ namespace irgen {
   createVariable(IRGenModule &IGM, LinkInfo &linkInfo, llvm::Type *objectType,
                  Alignment alignment, DebugTypeInfo DebugType = DebugTypeInfo(),
                  Optional<SILLocation> DebugLoc = None,
-                 StringRef DebugName = StringRef(), bool heapAllocated = false);
+                 StringRef DebugName = StringRef(), bool heapAllocated = false,
+                 bool indirectForDebugInfo = false);
 
   void disableAddressSanitizer(IRGenModule &IGM, llvm::GlobalVariable *var);
 }

--- a/lib/IRGen/IRGenDebugInfo.cpp
+++ b/lib/IRGen/IRGenDebugInfo.cpp
@@ -1994,7 +1994,7 @@ void IRGenDebugInfoImpl::emitDbgIntrinsic(
 
 void IRGenDebugInfoImpl::emitGlobalVariableDeclaration(
     llvm::GlobalVariable *Var, StringRef Name, StringRef LinkageName,
-    DebugTypeInfo DbgTy, bool IsLocalToUnit, bool InFixedBuffer,
+    DebugTypeInfo DbgTy, bool IsLocalToUnit, bool Indirect,
     Optional<SILLocation> Loc) {
   if (Opts.DebugInfoKind <= IRGenDebugInfoKind::LineTables)
     return;
@@ -2014,11 +2014,7 @@ void IRGenDebugInfoImpl::emitGlobalVariableDeclaration(
   llvm::DIExpression *Expr = nullptr;
   if (!Var)
     Expr = DBuilder.createConstantValueExpression(0);
-  else if (InFixedBuffer)
-    // FIXME: This is *not* generally correct, but LLDB at the moment cannot
-    // poke to runtime to figure out whether a resilient value has inline
-    // storage, so this is assuming that it doesn't to get the majority of
-    // resilient Foundation types.
+  else if (Indirect)
     Expr =
         DBuilder.createExpression(ArrayRef<uint64_t>(llvm::dwarf::DW_OP_deref));
   auto *GV = DBuilder.createGlobalVariableExpression(
@@ -2148,10 +2144,10 @@ void IRGenDebugInfo::emitDbgIntrinsic(IRBuilder &Builder, llvm::Value *Storage,
 
 void IRGenDebugInfo::emitGlobalVariableDeclaration(
     llvm::GlobalVariable *Storage, StringRef Name, StringRef LinkageName,
-    DebugTypeInfo DebugType, bool IsLocalToUnit, bool InFixedBuffer,
+    DebugTypeInfo DebugType, bool IsLocalToUnit, bool Indirect,
     Optional<SILLocation> Loc) {
   static_cast<IRGenDebugInfoImpl *>(this)->emitGlobalVariableDeclaration(
-      Storage, Name, LinkageName, DebugType, IsLocalToUnit, InFixedBuffer, Loc);
+      Storage, Name, LinkageName, DebugType, IsLocalToUnit, Indirect, Loc);
 }
 
 void IRGenDebugInfo::emitTypeMetadata(IRGenFunction &IGF, llvm::Value *Metadata,

--- a/test/DebugInfo/global_resilience.swift
+++ b/test/DebugInfo/global_resilience.swift
@@ -1,0 +1,27 @@
+
+// RUN: %empty-directory(%t)
+//
+// Compile the external swift module.
+// RUN: %target-swift-frontend -g -emit-module -enable-resilience \
+// RUN:   -emit-module-path=%t/resilient_struct.swiftmodule \
+// RUN:   -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
+//
+// RUN: %target-swift-frontend -g -I %t -emit-ir -enable-resilience %s  -o - \
+// RUN:  | %FileCheck %s
+import resilient_struct
+
+// Fits in buffer
+let small = Size(w: 1, h: 2)
+
+// Needs out-of-line allocation
+let large = Rectangle(p: Point(x: 1, y: 2), s: Size(w: 3, h: 4), color: 5)
+
+// CHECK: @"$S17global_resilience5small16resilient_struct4SizeVvp" =
+// CHECK-SAME: !dbg ![[SMALL:[0-9]+]]
+// CHECK: @"$S17global_resilience5large16resilient_struct9RectangleVvp" =
+// CHECK-SAME: !dbg ![[LARGE:[0-9]+]]
+
+// CHECK: ![[SMALL]] = !DIGlobalVariableExpression(
+// CHECK-SAME:            expr: !DIExpression())
+// CHECK: ![[LARGE]] = !DIGlobalVariableExpression(
+// CHECK-SAME:            expr: !DIExpression(DW_OP_deref))

--- a/test/DebugInfo/struct_resilience.swift
+++ b/test/DebugInfo/struct_resilience.swift
@@ -13,24 +13,13 @@
 // RUN:    -enable-resilience-bypass | %FileCheck %s --check-prefix=CHECK-LLDB
 import resilient_struct
 
-let fixed = Point(x: 1, y: 2)
-let non_fixed = Size(w: 1, h: 2)
-let int = ResilientInt(i: 1)
-// CHECK: @"$S10resilience5fixed16resilient_struct5PointVvp" =
-// CHECK-SAME: !dbg ![[FIXED:[0-9]+]]
-// CHECK: @"$S10resilience9non_fixed16resilient_struct4SizeVvp" =
-// CHECK-SAME: !dbg ![[NON_FIXED:[0-9]+]]
-// CHECK: @"$S10resilience3int16resilient_struct12ResilientIntVvp" =
-// CHECK-SAME: !dbg ![[INT:[0-9]+]]
-// CHECK-LABEL: define{{.*}}main
-
-// CHECK-LABEL: define{{.*}} swiftcc void @"$S10resilience9takesSizeyy16resilient_struct0C0VF"(%swift.opaque* noalias nocapture)
-// CHECK-LLDB-LABEL: define{{.*}} swiftcc void @"$S10resilience9takesSizeyy16resilient_struct0C0VF"(%T16resilient_struct4SizeV* noalias nocapture dereferenceable({{8|16}}))
+// CHECK-LABEL: define{{.*}} swiftcc void @"$S17struct_resilience9takesSizeyy010resilient_A00D0VF"(%swift.opaque* noalias nocapture)
+// CHECK-LLDB-LABEL: define{{.*}} swiftcc void @"$S17struct_resilience9takesSizeyy010resilient_A00D0VF"(%T16resilient_struct4SizeV* noalias nocapture dereferenceable({{8|16}}))
 public func takesSize(_ s: Size) {}
 
 
-// CHECK-LABEL: define{{.*}} swiftcc void @"$S10resilience1fyyF"()
-// CHECK-LLDB-LABEL: define{{.*}} swiftcc void @"$S10resilience1fyyF"()
+// CHECK-LABEL: define{{.*}} swiftcc void @"$S17struct_resilience1fyyF"()
+// CHECK-LLDB-LABEL: define{{.*}} swiftcc void @"$S17struct_resilience1fyyF"()
 func f() {
   let s1 = Size(w: 1, h: 2)
   takesSize(s1)
@@ -48,19 +37,12 @@ func f() {
 }
 f()
 
-// Note that these DW_OP_deref are not necessarily correct, but it's the best
-// approxmiation we have until LLDB can query the runtime for whether a relient
-// type's storage is inline or not.
-// CHECK: ![[FIXED]] = !DIGlobalVariableExpression(
-// CHECK-SAME:            expr: !DIExpression())
-// CHECK: ![[NON_FIXED]] = !DIGlobalVariableExpression(
-// CHECK-SAME:            expr: !DIExpression(DW_OP_deref))
 // CHECK: ![[TY:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Size",
-// CHECK: ![[INT]] = !DIGlobalVariableExpression(
-// CHECK-SAME:            expr: !DIExpression(DW_OP_deref))
+// CHECK: ![[TY:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Size",
 
 // CHECK: ![[V1]] = !DILocalVariable(name: "s1", {{.*}}type: ![[TY]])
 
+// CHECK-LLDB: ![[TY:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Size",
 // CHECK-LLDB: ![[TY:[0-9]+]] = !DICompositeType(tag: DW_TAG_structure_type, name: "Size",
 // CHECK-LLDB: ![[V1]] = !DILocalVariable(name: "s1", {{.*}}type: ![[TY]])
 

--- a/test/IRGen/global_resilience.sil
+++ b/test/IRGen/global_resilience.sil
@@ -1,5 +1,8 @@
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -I %S/../Inputs -enable-source-import -emit-ir -enable-resilience %s | %FileCheck %s
-// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -I %S/../Inputs -enable-source-import -emit-ir -enable-resilience -O %s
+// RUN: %empty-directory(%t)
+
+// RUN: %target-swift-frontend %S/../Inputs/resilient_struct.swift -enable-resilience -emit-module -emit-module-path %t/resilient_struct.swiftmodule
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-resilience -I %t -emit-ir %s | %FileCheck %s
+// RUN: %target-swift-frontend -assume-parsing-unqualified-ownership-sil -enable-resilience -I %t -emit-ir -O %s
 
 // CHECK: %swift.type = type { [[INT:i32|i64]] }
 


### PR DESCRIPTION
Progress on rdar://problem/39722386.