### PR TITLE
[lit] Add swift-demangle-yamldump as a dependency of the lit test suite.

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,7 +43,7 @@ function(get_test_dependencies SDK result_var_name)
       swift swift-ide-test swift-syntax-test sil-opt swift-llvm-opt swift-demangle
       sil-func-extractor sil-llvm-gen sil-nm sil-passpipeline-dumper
       lldb-moduleimport-test swift-reflection-dump swift-remoteast-test
-      swift-api-digester swift-refactor)
+      swift-api-digester swift-refactor swift-demangle-yamldump)
   if(NOT SWIFT_BUILT_STANDALONE)
     list(APPEND deps_binaries FileCheck arcmt-test c-arcmt-test c-index-test
          clang llc llvm-cov llvm-dwarfdump llvm-link llvm-as llvm-dis


### PR DESCRIPTION
I added a test to make sure that this utility continued to work as expected...
but I forgot to add the utility as a dependency of the test... *doh*.

Thanks to the buildczar Slava for catching this. All hail the mighty buildczar!
