### PR TITLE
Add `stress-test` option to `tensorflow_osx` build preset.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1778,6 +1778,7 @@ test
 test-optimized
 validation-test
 long-test
+stress-test
 
 [preset: tensorflow_osx,no_test]
 mixin-preset=tensorflow_osx_base


### PR DESCRIPTION
There's a discrepancy between `build-script` and `build-script-impl` which
requires `long-test` and `stress-test` to be specified together.

Currently, only `long-test` is specified, causing `build-script` and
`build-script-impl` to set different "test subset" suffixes and crash.
A robust change to fix this should be done upstream.