### PR TITLE
Add `stress-test` option to `tensorflow_test,long_test` build preset.

### DIFF
--- a/utils/build-presets.ini
+++ b/utils/build-presets.ini
@@ -1847,3 +1847,4 @@ validation-test
 [preset: tensorflow_test,long_test]
 mixin-preset=tensorflow_test
 long-test
+stress-test


### PR DESCRIPTION
An extension of https://github.com/apple/swift/pull/17439.

There's a discrepancy between `build-script` and `build-script-impl` which
requires `long-test` and `stress-test` to be specified together.