### PR TITLE
[TypeReconstruction] Don't crash on null genericSignature.

### DIFF
--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -786,9 +786,10 @@ static void VisitNodeGenericTypealias(ASTContext *ast,
       cast<TypeAliasDecl>(generic_type_result._decls.front());
   GenericSignature *signature = genericTypeAlias->getGenericSignature();
   // FIXME: handle conformances.
-  SubstitutionMap subMap =
-      SubstitutionMap::get(signature, template_types_result._types,
-                           ArrayRef<ProtocolConformanceRef>({}));
+  SubstitutionMap subMap;
+  if (signature)
+    subMap = SubstitutionMap::get(signature, template_types_result._types,
+                                  ArrayRef<ProtocolConformanceRef>({}));
   Type parentType;
   if (auto nominal = genericTypeAlias->getDeclContext()
                          ->getAsNominalTypeOrNominalTypeExtensionContext()) {

--- a/test/DebugInfo/DumpTypeFromMangledName.swift
+++ b/test/DebugInfo/DumpTypeFromMangledName.swift
@@ -39,3 +39,18 @@ func main() -> Int {
 }
 
 let _ = main()
+
+public struct tinky : Equatable, Hashable {
+  internal let _value: Int
+
+  public var hashValue: Int {
+    return 0
+  }
+}
+
+public func == (lhs: tinky, rhs: tinky) -> Bool {
+  return true
+}
+
+public typealias patatino = UnsafePointer<tinky>
+var local_thread_one: patatino?

--- a/test/DebugInfo/Inputs/type-reconstr-names.txt
+++ b/test/DebugInfo/Inputs/type-reconstr-names.txt
@@ -10,3 +10,4 @@ $S13EyeCandySwift21_previousUniqueNumber33_ADC08935D64EA4F796440E7335798735LLs6U
 $SSayypXpG ---> Array<Any.Type>
 $S12EyeCandyCore11XPCListenerC14messageHandleryyAA13XPCConnectionV_AA10XPCMessageVxtcvpfiyAF_AHxtcfU_TA.4 ---> Can't resolve type of $S12EyeCandyCore11XPCListenerC14messageHandleryyAA13XPCConnectionV_AA10XPCMessageVxtcvpfiyAF_AHxtcfU_TA.4
 $Ss10CollectionP7ElementQa ---> Can't resolve type of $Ss10CollectionP7ElementQa
+$S12TypeReconstr8patatinoayAA5tinkyVGSgD ---> Optional<patatino>


### PR DESCRIPTION
<rdar://problem/41343572>

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
