### PR TITLE
fix implicit conversion from nullptr to boolean (breaks Piper)

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
+++ b/lib/SILOptimizer/Mandatory/TFDeabstraction.cpp
@@ -251,7 +251,7 @@ void TFDeabstraction::inlineCalls() {
        if (callee.empty() &&
            !site.getModule().linkFunction(&callee,
                                           SILModule::LinkingMode::LinkAll))
-         return nullptr;
+         return false;
 
        if (!shouldInline(site, callee))
          return false;


### PR DESCRIPTION
This is causing an error in Piper because our build flags there have "-Werror,-Wnull-conversion".

Long term we should probably get the flags in closer sync, but I think we should wait and see how much of a problem it is before we spend effort figuring out how to do that. So I'm not changing any flags in this PR.