### PR TITLE
SourceKit: use shared blocksruntime

### DIFF
--- a/tools/SourceKit/CMakeLists.txt
+++ b/tools/SourceKit/CMakeLists.txt
@@ -107,7 +107,7 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
                           -DENABLE_SWIFT=YES
                         BUILD_BYPRODUCTS
                           ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/src/${CMAKE_SHARED_LIBRARY_PREFIX}dispatch${CMAKE_SHARED_LIBRARY_SUFFIX}
-                          ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/${CMAKE_STATIC_LIBRARY_PREFIX}BlocksRuntime${CMAKE_STATIC_LIBRARY_SUFFIX}
+                          ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/${CMAKE_SHARED_LIBRARY_PREFIX}BlocksRuntime${CMAKE_SHARED_LIBRARY_SUFFIX}
                         STEP_TARGETS
                           configure
                         BUILD_ALWAYS
@@ -144,11 +144,11 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
                           IMPORTED_LINK_INTERFACE_LIBRARIES
                             swiftCore-${SWIFT_SDK_${SWIFT_HOST_VARIANT_SDK}_LIB_SUBDIR}-${SWIFT_HOST_VARIANT_ARCH})
 
-  add_library(BlocksRuntime STATIC IMPORTED)
+  add_library(BlocksRuntime SHARED IMPORTED)
   set_target_properties(BlocksRuntime
                         PROPERTIES
                           IMPORTED_LOCATION
-                            ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/${CMAKE_STATIC_LIBRARY_PREFIX}BlocksRuntime${CMAKE_STATIC_LIBRARY_SUFFIX}
+                            ${SWIFT_PATH_TO_LIBDISPATCH_BUILD}/${CMAKE_SHARED_LIBRARY_PREFIX}BlocksRuntime${CMAKE_SHARED_LIBRARY_SUFFIX}
                           INTERFACE_INCLUDE_DIRECTORIES
                             ${SWIFT_PATH_TO_LIBDISPATCH_SOURCE}/src/BlocksRuntime)
 

--- a/utils/build-script-impl
+++ b/utils/build-script-impl
@@ -2955,7 +2955,7 @@ for host in "${ALL_HOSTS[@]}"; do
                 fi
                 # If libdispatch is being built, TestFoundation will need access to it
                 if [[ ! "${SKIP_BUILD_LIBDISPATCH}" ]] ; then
-                    LIBDISPATCH_LIB_DIR=":$(build_directory ${host} libdispatch)/src/.libs"
+                    LIBDISPATCH_LIB_DIR=":$(build_directory ${host} libdispatch)/src/.libs:$(build_directory ${host} libdispatch)"
                 else
                     LIBDISPATCH_LIB_DIR=""
                 fi


### PR DESCRIPTION
Switch libdispatch to shared BlocksRuntime.  Update the dependency here
accordingly.

<!-- What's in this pull request? -->
Replace this paragraph with a description of your changes and rationale. Provide links to external references/discussions if appropriate.

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
Resolves [SR-NNNN](https://bugs.swift.org/browse/SR-NNNN).

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
