### PR TITLE
Fix a partitioner crasher

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -3844,8 +3844,8 @@ public:
     // it's not clear if we should allow partitioning to work on unspecialized
     // generics.
     if (hostFn->getLoweredFunctionType()->isPolymorphic()) {
-      auto &ctx = fn->getASTContext();
-      diagnose(ctx, fn->getLocation().getSourceLoc(),
+      auto &ctx = hostFn->getASTContext();
+      diagnose(ctx, hostFn->getLocation().getSourceLoc(),
                diag::tf_internal_error,
                "TensorFlow graph program extraction does not work on generic "
                "functions yet");

--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -820,7 +820,7 @@ diagnoseCopyToAccelerator(SILValue value, SILInstruction *user,
                           bool isTensorProgramArgument) {
   // If it isn't the result of a "send" operation, then produce a warning about
   // an implicit copy to the accelerator.
-  if (auto *apply = dyn_cast<ApplyInst>((SILNode*)value))
+  if (auto *apply = dyn_cast<ApplyInst>(value))
     if (classifyInst(apply) == PartitioningClass::ExplicitSend) {
       explicitCopyMarkers.insert(apply);
       return;
@@ -1141,7 +1141,7 @@ static ScalarPromoteClass shouldPromoteToTensorOp(SILInstruction *inst,
 
   // We can handle (struct_extract x, 0) if x is __tf_get_scalar_or_die.
   if (auto *SE = dyn_cast<StructExtractInst>(inst)) {
-    auto *op = dyn_cast<SILInstruction>((SILNode*)SE->getOperand());
+    auto *op = SE->getOperand()->getDefiningInstruction();
     if (op && SE->getFieldNo() == 0 &&
         classifyInst(op) == PartitioningClass::GetScalarOrDie)
       return ScalarPromoteClass::ShouldPromote;
@@ -1394,7 +1394,7 @@ static bool hoistValueAboveStartPoint(SILInstruction *inst,
     // We can hoist one of these instructions if all of their operands are
     // hoistable.
     for (auto &op : inst->getAllOperands()) {
-      if (auto *opInst = dyn_cast<SILInstruction>((SILNode*)op.get())) {
+      if (auto *opInst = op.get()->getDefiningInstruction()) {
         if (!hoistValueAboveStartPoint(opInst, tensorStartPoint, DI))
           return false;
       } else if (!DI.properlyDominates(op.get(), tensorStartPoint))
@@ -1526,7 +1526,7 @@ void TFFunctionPartition::markValue(SILValue value, SILInstruction *user) {
   if (auto *arg = dyn_cast<SILArgument>(value))
     return markArgument(arg, user);
 
-  auto *inst = cast<SILInstruction>((SILNode*)value);
+  auto *inst = value->getDefiningInstruction();
   if (markedInstructions.count(inst))
     return;
 
@@ -2626,9 +2626,7 @@ static SILValue createHostSend(SILBuilder &B, SILLocation loc, SILValue value,
       // In this case we set `value` to the Float operand like %33 above.
       auto *SEI = cast<StructExtractInst>(value->getDefiningInstruction());
       assert(SEI->getFieldNo() == 0);
-      auto *structValue = cast<SILInstruction>((SILNode *)SEI->getOperand());
-      assert(structValue->getNumResults() == 1);
-      value = structValue->getResults()[0];
+      value = SEI->getOperand();
       scalarValueTy = value->getType().getSwiftRValueType();
     }
     tensorValueTy =
@@ -2753,7 +2751,7 @@ void PartitionCloner::insertSend(SILInstruction &inst) {
 }
 
 bool PartitionCloner::insertReceive(SILValue value, SILLocation loc) {
-  assert(isa<SILInstruction>((SILNode*)value) || isa<SILArgument>(value) &&
+  assert(value->getDefiningInstruction() || isa<SILArgument>(value) &&
          "Don't know how to receive this value");
   SILFunction *receiveFn =
       lookupSendReceiveFunction("receiveFromAccelerator", value, loc);
@@ -2767,11 +2765,11 @@ bool PartitionCloner::insertReceive(SILValue value, SILLocation loc) {
   SILBuilder BH(FP.hostFn);      // Builder for the host.
   auto BA = getBuilder();        // Builder for accelerator.
 
-  if (auto *inst = dyn_cast<SILInstruction>((SILNode*)value)) {
+  if (auto *inst = value->getDefiningInstruction()) {
     assert(!isa<TermInst>(inst) && "Cannot move a terminator");
     BH.setInsertionPoint(++SILBasicBlock::iterator(inst));
 
-    auto otherInst = cast<SILInstruction>((SILNode*)ValueMap[value]);
+    auto otherInst = ValueMap[value]->getDefiningInstruction();
     BA.setInsertionPoint(++SILBasicBlock::iterator(otherInst));
 
   } else {
@@ -3846,10 +3844,11 @@ public:
     // it's not clear if we should allow partitioning to work on unspecialized
     // generics.
     if (hostFn->getLoweredFunctionType()->isPolymorphic()) {
-      auto &ctx = hostFn->getASTContext();
-      diagnose(
-          ctx, hostFn->getLocation().getSourceLoc(), diag::tf_internal_error,
-          "TensorFlow partitioning does not work on generic functions yet");
+      auto &ctx = fn->getASTContext();
+      diagnose(ctx, fn->getLocation().getSourceLoc(),
+               diag::tf_internal_error,
+               "TensorFlow graph program extraction does not work on generic "
+               "functions yet");
       return;
     }
 
@@ -3860,8 +3859,8 @@ public:
       diagnose(ctx, hostFn->getLocation().getSourceLoc(),
                diag::tf_internal_error,
                "nothing in the TensorFlow module should require partitioning, "
-               "did you forget @_inlineable on '" +
-                   hostFn->getName().str() + "'?");
+               "did you forget @inlinable on '" + hostFn->getName().str()
+               + "'?");
       return;
     }
 

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -237,7 +237,7 @@ public func testMultiOutputsFnResults() -> (Tensor<Float>,  Tensor<Float>) {
 var globalThing: Int32!
 
 public func testStructExtractBBArg(x: Tensor<Float>) -> Tensor<Int32> {
-  _ = x.toDevice() + 1
+  _ = x.toAccelerator() + 1
   //	%21 = argument of bb2 : $Int32                    // user: %22
   // [Send]	  %22 = struct_extract %21 : $Int32, #Int32._value // user: %23
   // expected-warning @+1 {{value implicitly copied to the accelerator}}

--- a/test/TensorFlow/crashers.swift
+++ b/test/TensorFlow/crashers.swift
@@ -234,3 +234,13 @@ public func testMultiOutputsFnResults() -> (Tensor<Float>,  Tensor<Float>) {
   return (x.toHost(),y.toHost())
 }
 
+var globalThing: Int32!
+
+public func testStructExtractBBArg(x: Tensor<Float>) -> Tensor<Int32> {
+  _ = x.toDevice() + 1
+  //	%21 = argument of bb2 : $Int32                    // user: %22
+  // [Send]	  %22 = struct_extract %21 : $Int32, #Int32._value // user: %23
+  // expected-warning @+1 {{value implicitly copied to the accelerator}}
+  return Tensor<Int32>(globalThing)
+}
+


### PR DESCRIPTION
The following code triggers an `isa<>` assertion caused by the use of `cast<>`. This issue comes up very often during model building - when using a scalar that is defined globally or as a type member from a tensor program region.

```swift
import TensorFlow
var globalThing: Int32!
public func testStructExtractBBArg(x: Tensor<Float>) -> Tensor<Int32> {
  _ = x.toAccelerator() + 1
  return Tensor<Int32>(globalThing)
}
```

This `struct_extract` is taking a BB argument:
```swift
	%21 = argument of bb2 : $Int32                    // user: %22
 [Send]	  %22 = struct_extract %21 : $Int32, #Int32._value // user: %23
 expected-warning @+1 {{value implicitly copied to the accelerator}}
```

... but the code is assuming it to be an instruction. Now it's fixed :)

This patch also includes minor cleanup including [SR-7995](https://bugs.swift.org/browse/SR-7995).
