### PR TITLE
[ConstExpr] Remove conformance info from constant function representation

### DIFF
--- a/lib/SIL/SILConstants.cpp
+++ b/lib/SIL/SILConstants.cpp
@@ -45,7 +45,7 @@ void SymbolicValue::print(llvm::raw_ostream &os, unsigned indent) const {
     os << "\n";
     return;
   case RK_Function: {
-    auto fn = getFunctionValue().first;
+    auto fn = getFunctionValue();
     os << "fn: " << fn->getName() << ": ";
     os << Demangle::demangleSymbolAsString(fn->getName());
     os << "\n";

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1213,10 +1213,7 @@ public:
       return;
     }
     case SymbolicValue::Function: {
-      assert(!v.getFunctionValue().second &&
-             "SILFunction SymbolicValues with protocol conformances cannot be "
-             "printed");
-      auto function = v.getFunctionValue().first;
+      auto function = v.getFunctionValue();
       *this << "@" << function->getName();
       *this << " : $" << function->getLoweredFunctionType();
       return;

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
@@ -873,8 +873,9 @@ ConstExprFunctionState::computeCallResult(ApplyInst *apply) {
       auto selfTy = conformance.getRequirement()->getSelfInterfaceType();
       auto conf = substitutionMap.lookupConformance(selfTy->getCanonicalType(),
                                                  conformance.getRequirement());
-      assert(conf.hasValue() &&
-             "Should always be able to resolve conformances");
+      if (!conf.hasValue())
+        return SymbolicValue::getUnknown((SILInstruction*)apply,
+                                         UnknownReason::Default);
 
       // Witness methods have special magic that is required to resolve them.
       callSubMap = getWitnessMethodSubstitutions(apply->getModule(), AI, callee,

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
@@ -395,7 +395,7 @@ SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
 
     // If we were able to resolve it, then we can proceed.
     if (fn)
-      return SymbolicValue::getFunction(fn, conf);
+      return SymbolicValue::getFunction(fn);
 
     DEBUG(llvm::dbgs() << "ConstExpr Unresolved witness: " << *value << "\n");
     return SymbolicValue::getUnknown(value, UnknownReason::Default);
@@ -800,14 +800,11 @@ ConstExprFunctionState::computeCallResult(ApplyInst *apply) {
 
   // Determine the callee.
   auto calleeFn = getConstantValue(apply->getOperand(0));
-  if (!calleeFn.isConstant())
+  if (calleeFn.getKind() != SymbolicValue::Function)
     return SymbolicValue::getUnknown((SILInstruction*)apply,
                                      UnknownReason::Default);
 
-  SILFunction *callee;
-  Optional<ProtocolConformanceRef> conformance;
-  std::tie(callee, conformance) = calleeFn.getFunctionValue();
-
+  SILFunction *callee = calleeFn.getFunctionValue();
 
   // If we reached an external function that hasn't been deserialized yet, make
   // sure to pull it in so we can see its body.  If that fails, then we can't
@@ -868,10 +865,20 @@ ConstExprFunctionState::computeCallResult(ApplyInst *apply) {
     // Get the substitution map of the call.  This maps from the callee's space
     // into the caller's world.
     SubstitutionMap callSubMap;
-    if (conformance.hasValue()) {
+    if (calleeFnType->getRepresentation() ==
+        SILFunctionType::Representation::WitnessMethod) {
+      // Get the conformance out of the SILFunctionType and map it into our
+      // current type space.
+      auto conformance = calleeFnType->getWitnessMethodConformance();
+      auto selfTy = conformance.getRequirement()->getSelfInterfaceType();
+      auto conf = substitutionMap.lookupConformance(selfTy->getCanonicalType(),
+                                                 conformance.getRequirement());
+      assert(conf.hasValue() &&
+             "Should always be able to resolve conformances");
+
       // Witness methods have special magic that is required to resolve them.
       callSubMap = getWitnessMethodSubstitutions(apply->getModule(), AI, callee,
-                                                 conformance.getValue());
+                                                 conf.getValue());
     } else {
       auto requirementSig = AI.getOrigCalleeType()->getGenericSignature();
       callSubMap =


### PR DESCRIPTION
[ConstExpr] Remove conformance info from constant function representation

Slava pointed out on swift-dev that SILFunctionType for witness methods
actually carry the conformance information needed to resolve members.
Using it eliminates the need to track it, simplifying everything!