### PR TITLE
Enhance deabstraction to start producing GraphOperationInst in simple cases

### DIFF
--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -294,7 +294,6 @@ public:
   /// version.  This only works for valid constants.
   SymbolicValue cloneInto(llvm::BumpPtrAllocator &allocator) const;
 
-
   void print(llvm::raw_ostream &os, unsigned indent = 0) const;
   void dump() const;
 };

--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -290,6 +290,11 @@ public:
   /// reason, we fall back to using the specified location.
   void emitUnknownDiagnosticNotes(SILLocation fallbackLoc);
 
+  /// Clone this SymbolicValue into the specified allocator and return the new
+  /// version.  This only works for valid constants.
+  SymbolicValue cloneInto(llvm::BumpPtrAllocator &allocator) const;
+
+
   void print(llvm::raw_ostream &os, unsigned indent = 0) const;
   void dump() const;
 };

--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1007,8 +1007,7 @@ static bool parseSymbolicValue(SymbolicValue &value, SILParser &SP,
     SILType temp;
     if (SP.parseSILType(temp))
       return true;
-    auto metatype = CanMetatypeType::get(temp.getSwiftRValueType());
-    value = SymbolicValue::getMetatype(metatype);
+    value = SymbolicValue::getMetatype(temp.getSwiftRValueType());
     return false;
   }
   // Handle SIL function references.

--- a/lib/SIL/SILPrinter.cpp
+++ b/lib/SIL/SILPrinter.cpp
@@ -1207,11 +1207,9 @@ public:
     case SymbolicValue::String:
       *this << QuotedString(v.getStringValue());
       return;
-    case SymbolicValue::Metatype: {
-      auto metatype = cast<AnyMetatypeType>(v.getMetatypeValue());
-      *this << SILType::getPrimitiveObjectType(metatype.getInstanceType());
+    case SymbolicValue::Metatype:
+      *this << SILType::getPrimitiveObjectType(v.getMetatypeValue());
       return;
-    }
     case SymbolicValue::Function: {
       auto function = v.getFunctionValue();
       *this << "@" << function->getName();

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -1111,6 +1111,9 @@ SILTensorOpInfo::getOperandClass(StringRef suffix) {
 
 /// Verify that any attribute operands are passed acceptable constants,
 /// returning a non-empty error string to emit if that is not the case.
+///
+/// TODO: Remove this when deabstraction has taken over.
+///
 std::string SILTensorOpInfo::checkAndDiagnoseOperands() const {
   // Attribute values require constant values.  If we don't have one then this
   // op is invalid and must be rejected.
@@ -1143,7 +1146,7 @@ std::string SILTensorOpInfo::checkAndDiagnoseOperands() const {
         break;
       }
 
-      // TensorFloat values and metatype inputs are ok.
+      // TensorFlow values and metatype inputs are ok.
       if (isTensorFlowValue(opTy) || opTy.is<MetatypeType>())
         break;
 
@@ -1350,7 +1353,7 @@ static SILValue getTensorProtocolHandleMember(SILValue v, SILLocation loc,
 /// Replace any indirect memory operands with direct references to the
 /// scalars they reference.  This potentially replaces the builtin
 /// instruction, so it returns the right one to use.
-// TODO(clattner): Move this into deabstraction when it exists.
+// TODO(clattner): Remove this when deabstraction has subsumed it.
 SILInstruction *SILTensorOpInfo::canonicalizeOperands(
     GraphGlobalConfiguration *configuration) {
   // TODO: Canonicalize metatypes into constants!

--- a/test/TensorFlow/integration.swift
+++ b/test/TensorFlow/integration.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s
 // RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s | %FileCheck %s
+// TODO run: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -Xllvm -tf-strict-deabstraction -DSTRICT_DA %s  | %FileCheck %s -check-prefix=STRICTDA
 
 import TensorFlow
 

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -1,6 +1,7 @@
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s
 // RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s | %FileCheck %s
-// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify -Xllvm -tf-strict-deabstraction -DSTRICT_DA %s  | %FileCheck %s -check-prefix=STRICTDA
+
+// TODO: Enable -verify mode.
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -Xllvm -tf-strict-deabstraction -DSTRICT_DA %s  | %FileCheck %s -check-prefix=STRICTDA
 import TensorFlow
 
 // This test is intended to verify that all of the operations end up in the
@@ -12,6 +13,9 @@ import TensorFlow
 // file.
 
 
+/* TODO build this out.
+STRICTDA: --- TFDeabstraction Result: {{.*}}testSelect
+*/
 public func testSelect(conds1: Tensor<Bool>, x1: Tensor<Float>, y1: Tensor<Float>)
   -> Tensor<Float> {
   let conds = conds1.toAccelerator()

--- a/test/TensorFlow/no_copy.swift
+++ b/test/TensorFlow/no_copy.swift
@@ -1,5 +1,6 @@
 // RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s
 // RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify %s | %FileCheck %s
+// RUN: %target-swift-frontend -Xllvm -tf-dump-intermediates -O -emit-sil -verify -Xllvm -tf-strict-deabstraction -DSTRICT_DA %s  | %FileCheck %s -check-prefix=STRICTDA
 import TensorFlow
 
 // This test is intended to verify that all of the operations end up in the
@@ -32,11 +33,13 @@ public func testSelect(conds1: Tensor<Bool>, x1: Tensor<Float>, y1: Tensor<Float
  CHECK-NEXT:  return %11 : $TensorHandle<Float>
  CHECK-NEXT:}
 */
-
 public func testEmptyScalarsArray() {
   let y = Tensor<Int32>(shape: [0, 20, 30], scalars: [])
   _ = y+y
 }
+
+// Strict deabstraction doesn't support the strides array yet.
+#if !STRICT_DA
 
 /*
  CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testEmptyScalarsArray
@@ -49,12 +52,12 @@ public func testEmptyScalarsArray() {
  CHECK: builtin "__tfop_Add,$in,$in,T,device"({{.*}} : $TensorHandle<Int32>, {{.*}} : $TensorHandle<Int32>
  */
 
-
 // This tests the attributes necessary to get arrays of integers and strings going.
 public func testConvolution(x : Tensor<Float>, filter: Tensor<Float>) -> Tensor<Float> {
   return x.toAccelerator().convolved2D(withFilter: filter.toAccelerator(),
                        strides: (1, 2, 3, 4), padding: .same)
 }
+#endif
 
 // CHECK-LABEL: --- TFPartition Accelerator Result: {{.*}}testConvolution
 // CHECK: sil private @{{.*}}testConvolution{{.*}} : $@callee_owned (TensorHandle<Float>, TensorHandle<Float>) -> TensorHandle<Float> {
@@ -72,6 +75,8 @@ public func testConvolution(x : Tensor<Float>, filter: Tensor<Float>) -> Tensor<
 // CHECK-NEXT:}
 
 
+// Strict deabstraction doesn't support the value array yet.
+#if !STRICT_DA
 
 // Testcase for an op that uses the $tensor and $shape modifiers.
 public func testConstantArray() -> TensorHandle<Float> {
@@ -89,6 +94,7 @@ public func testConstantArray() -> TensorHandle<Float> {
 // CHECK-NEXT:  %5 = integer_literal $Builtin.Int64, 2
 // CHECK:       %7 = builtin "__tfop_Const,dtype,value$tensor,$elt,$elt,value$shape,$elt,device"(%0 : $@thin Float.Type, %1 : $@thin Double.Type, %2 : $Builtin.FPIEEE64, %3 : $Builtin.FPIEEE64, %4 : $@thin Int.Type, %5 : $Builtin.Int64
 // CHECK-NEXT:  return %7 : $TensorHandle<Float>
+#endif
 
 // Sigmoid shouldn't cause copies.  This should compile with no copy warnings/errors.
 public func testSigmoid(x: Tensor<Float>, y: Tensor<Float>) -> (Tensor<Float>, Tensor<Float>) {
@@ -145,11 +151,15 @@ public func test75494462() {
   print(x.array)
 }
 
+// Strict deabstraction doesn't support arrays yet.
+#if !STRICT_DA
+
 public func paddingTuplesHoistable() {
   let matrix: Tensor<Float> = Tensor([[1, 2, 3], [4, 5, 6]]) + 1
   let padded = matrix.padded(forSizes: [(before: 1, after: 1), (before: 2, after: 2)]).toAccelerator()
   _ = padded.array
 }
+#endif
 
 // b/76184126
 public func rangeLiteral() -> Tensor<Float> {


### PR DESCRIPTION
Enhance deabstraction to start producing GraphOperationInst in simple cases
when -tf-strict-deabstraction is enabled. Along with this, fix some minor
issues with GraphOperationInst handling metatypes, and add support for cloning
constants from the ConstExpr bump pointer to the ASTContext's when forming
instructions.

Lots of caveats remain:
- ConstExpr doesn't know about arrays.
- Partitioning doesn't know about GraphOperationInst.
- We don't handle input list operands.
- probably lots of other stuff to do.

The next steps after this is to wire up partitioning to act on these just
like they do other tensor ops.
