### PR TITLE
[master-next] Use new IntrinsicEnums.inc file

### DIFF
--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1251,12 +1251,12 @@ inline bool isBuiltinTypeOverloaded(Type T, OverloadedBuiltinKind OK) {
 static const char *const IntrinsicNameTable[] = {
     "not_intrinsic",
 #define GET_INTRINSIC_NAME_TABLE
-#include "llvm/IR/Intrinsics.inc"
+#include "llvm/IR/IntrinsicEnums.inc"
 #undef GET_INTRINSIC_NAME_TABLE
 };
 
 #define GET_INTRINSIC_TARGET_DATA
-#include "llvm/IR/Intrinsics.inc"
+#include "llvm/IR/IntrinsicEnums.inc"
 #undef GET_INTRINSIC_TARGET_DATA
 
 /// getLLVMIntrinsicID - Given an LLVM IR intrinsic name with argument types


### PR DESCRIPTION
LLVM r335407 split up the Intrinsics.inc file into separate files with
the enums and implementations. Change Swift to use the new file for the
enums.