### PR TITLE
[SR-7497] [stdlib] Fix KeyPaths hashing

### DIFF
--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -597,7 +597,6 @@ internal enum KeyPathComponent: Hashable {
 
   @_effects(releasenone)
   internal func hash(into hasher: inout Hasher) {
-    var hasher = hasher
     func appendHashFromArgument(
       _ argument: KeyPathComponent.ArgumentRef?
     ) {

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -59,6 +59,7 @@ public class AnyKeyPath: Hashable, _AppendKeyPath {
   ///   of this instance.
   @_effects(releasenone)
   final public func hash(into hasher: inout Hasher) {
+    hasher.combine(unsafeBitCast(type(of: self) as Any.Type, to: Int.self))
     return withBuffer {
       var buffer = $0
       while true {

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -59,7 +59,7 @@ public class AnyKeyPath: Hashable, _AppendKeyPath {
   ///   of this instance.
   @_effects(releasenone)
   final public func hash(into hasher: inout Hasher) {
-    hasher.combine(unsafeBitCast(type(of: self) as Any.Type, to: Int.self))
+    ObjectIdentifier(type(of: self)).hash(into: &hasher)
     return withBuffer {
       var buffer = $0
       while true {

--- a/test/stdlib/KeyPathImplementation.swift
+++ b/test/stdlib/KeyPathImplementation.swift
@@ -680,6 +680,24 @@ keyPathImpl.test("equality") {
   expectNotEqual(s_c_z_p_x, s_c_z_p)
   expectNotEqual(s_c_z_p, s_c_z_p_x)
 
+  let s_x = WritableKeyPath<S<String>, Int>
+    .build(capacityInBytes: MemoryLayout<Int>.size + 4) {
+      $0.addHeader(trivial: true, hasReferencePrefix: false)
+      $0.addStructComponent(offset: S<String>.x_offset)
+    }
+
+  let si_x = WritableKeyPath<S<Int>, Int>
+    .build(capacityInBytes: MemoryLayout<Int>.size + 4) {
+      $0.addHeader(trivial: true, hasReferencePrefix: false)
+      $0.addStructComponent(offset: S<Int>.x_offset)
+    }
+
+  expectNotEqual(s_x, si_x)
+  expectNotEqual(s_x.hashValue, si_x.hashValue)
+
+  expectNotEqual(si_x, s_x)
+  expectNotEqual(si_x.hashValue, s_x.hashValue)
+
   // Same path, no reference prefix
   let s_c_z_p_x_readonly = KeyPath<S<S<String>>, Double>
     .build(capacityInBytes: 7 * MemoryLayout<Int>.size + 4) {

--- a/test/stdlib/KeyPathImplementation.swift
+++ b/test/stdlib/KeyPathImplementation.swift
@@ -657,7 +657,10 @@ keyPathImpl.test("equality") {
     }
 
   expectNotEqual(s_c_z_p_x, s_c_z_p_y)
+  expectNotEqual(s_c_z_p_x.hashValue, s_c_z_p_y.hashValue)
+
   expectNotEqual(s_c_z_p_y, s_c_z_p_x)
+  expectNotEqual(s_c_z_p_y.hashValue, s_c_z_p_x.hashValue)
 
   // Different path type
   let s_c_z_p = ReferenceWritableKeyPath<S<S<String>>, Point>


### PR DESCRIPTION
- The cause of hashing regression was a shadowed `hasher` argument in component hashing, so the component type/offset wasn't taken into account
- Currently only path components are hashed, so paths with distinct types but properties of equal kind and offset result in same hash values. That differs from equatable implementation as type of two key paths must be the same to consider them equal.
So I thought it'd make sense to include the type metadata pointer while hashing. As far as I understand it, the metadata pointer doesn't change during program execution. 

Regarding code:
 I'm not sure if `type(of: self) as Any.Type` cast is necessary. 
Quickly running REPL trying to do `unsafeBitCast(type(of: Int(0)), to: Int.self)`crashes, casting the `type(of:)` result to `Any.Type` helps though. 
Is this caused by value vs ref type difference? Doing so with a class object works. 
I was looking at `_getTypeName` and other core functions, but I couldn't really find a place where `Any.Type` is guaranteed to be `const Metadata*` and how `Any.Type` differs from e.g. `Int.Type`. 
Is it somehow implemented at SIL level? Would be great if someone could maybe give me a tip where to look for information/code regarding this. 

Resolves [SR-7497](https://bugs.swift.org/browse/SR-7497).

P.S. That's my first attempt at contribution to Swift. Hello everyone 👋