### PR TITLE
Remove 'of:' from #gradient expression syntax and rename 'withRespectTo:' to 'wrt:'

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1670,7 +1670,10 @@ ERROR(expr_expected_label,none,
 ERROR(expr_expected_function_to_differentiate,none,
       "expected a function to be differentiated", ())
 ERROR(gradient_expr_expected_parameter,none,
-      "expected a parameter, which can be the index of a function parameter with a leading dot (e.g. '.0'), or 'self'", ())
+      "expected a parameter, which can be the index of a function parameter "
+      "with a leading dot (e.g. '.0'), or 'self'", ())
+ERROR(gradient_expr_use_wrt_not_withrespectto,none,
+      "use 'wrt:' to specify parameters to differentiate with respect to", ())
 
 // SWIFT_ENABLE_TENSORFLOW
 //------------------------------------------------------------------------------

--- a/test/AutoDiff/autodiff_diagnostics.swift
+++ b/test/AutoDiff/autodiff_diagnostics.swift
@@ -1,5 +1,5 @@
 // RUN: %target-swift-frontend -emit-sil -verify %s
 
 func foo(_ f: @escaping (Float) -> Float) -> Float {
-  return #gradient(of: f)(0) // expected-error {{differentiating an opaque function is not supported yet}}
+  return #gradient(f)(0) // expected-error {{differentiating an opaque function is not supported yet}}
 }

--- a/test/AutoDiff/autodiff_e2e_basic.swift
+++ b/test/AutoDiff/autodiff_e2e_basic.swift
@@ -9,7 +9,7 @@ func adjointId(_ x: Float, originalValue: Float, seed: Float) -> Float {
   return seed
 }
 
-_ = #gradient(of: id)(2)
+_ = #gradient(id)(2)
 
 // CHECK: @{{.*}}id{{.*}}__grad_src_0_wrt_0
 // CHECK-LABEL: @{{.*}}id{{.*}}__grad_src_0_wrt_0_s_p
@@ -37,8 +37,8 @@ func adjointSigmoid(_ x: Double, checkpoints: (Double, Double, Double), result: 
   return result * (1 - result)
 }
 
-let x = #gradient(of: sigmoid)(3)
-let (value: y, gradient: z) = #valueAndGradient(of: sigmoid)(4)
+let x = #gradient(sigmoid)(3)
+let (value: y, gradient: z) = #valueAndGradient(sigmoid)(4)
 print(x * z)
 
 // CHECK: @{{.*}}sigmoid{{.*}}__grad_src_0_wrt_0

--- a/test/AutoDiff/gradient_expr_parse.swift
+++ b/test/AutoDiff/gradient_expr_parse.swift
@@ -1,16 +1,14 @@
 // RUN: %target-swift-frontend -parse -verify %s
 
-#gradient(foo, wrt:) // expected-error {{expected label 'of:'}}
-#gradient(of: foo, wrt:) // expected-error {{expected label 'withRespectTo:'}}
+#gradient(foo, withRespectTo:) // expected-error {{use 'wrt:' to specify parameters to differentiate with respect to}}
 
-#gradient(of: foo) // okay
-#gradient(of: foo, withRespectTo: 1) // expected-error {{expected a parameter, which can be }}
-#gradient(of: foo, withRespectTo: 0) // expected-error {{expected a parameter, which can be }}
-#gradient(of: foo, withRespectTo: .0) // okay
-#gradient(of: foo, withRespectTo: .0, .1, self) // okay
+#gradient(foo) // okay
+#gradient(foo, wrt: 1) // expected-error {{expected a parameter, which can be }}
+#gradient(foo, wrt: 0) // expected-error {{expected a parameter, which can be }}
+#gradient(foo, wrt: .0) // okay
+#gradient(foo, wrt: .0, .1, self) // okay
 
-#valueAndGradient(foo, wrt:) // expected-error {{expected label 'of:'}}
-#valueAndGradient(of: foo, withRespectTo: .0, .1) // okay
+#valueAndGradient(foo, wrt: .0, .1) // okay
 
 #adjoint(foo(_:_:)) // okay
 #adjoint() // expected-error {{expected function name within '#adjoint` expression}}

--- a/test/AutoDiff/gradient_expr_silgen.swift
+++ b/test/AutoDiff/gradient_expr_silgen.swift
@@ -45,12 +45,12 @@ public func foo_generic_vector<T : VectorNumeric>(x: T, y: T) -> T where T.Scala
 @_silgen_name("foo_generic_vector_and_scalar")
 public func foo_generic_vector_and_scalar<T : FloatingPoint, U : VectorNumeric>(x: T, y: U) -> U where U.ScalarElement : FloatingPoint { return y }
 
-let _ = #gradient(of: foo)
-let _ = #gradient(of: foo, withRespectTo: .0)
-let _ = #valueAndGradient(of: foo)
-let _: (Float, Float, [Int]) -> (Float, Float) = #gradient(of: foo_indir_ret, withRespectTo: .0, .1)
-let _: (Vector, Vector) -> (Vector, Vector) = #gradient(of: foo_generic_vector)
-let _: (Float, Vector) -> (Float, Vector) = #gradient(of: foo_generic_vector_and_scalar)
+let _ = #gradient(foo)
+let _ = #gradient(foo, wrt: .0)
+let _ = #valueAndGradient(foo)
+let _: (Float, Float, [Int]) -> (Float, Float) = #gradient(foo_indir_ret, wrt: .0, .1)
+let _: (Vector, Vector) -> (Vector, Vector) = #gradient(foo_generic_vector)
+let _: (Float, Vector) -> (Float, Vector) = #gradient(foo_generic_vector_and_scalar)
 
 // CHECK-LABEL: sil @main :
 // CHECK: [[FOO_1:%.*]] = function_ref @foo

--- a/test/AutoDiff/gradient_expr_type_checking.swift
+++ b/test/AutoDiff/gradient_expr_type_checking.swift
@@ -4,91 +4,91 @@ func foo(x: Float, y: Float) -> Float {}
 
 let someVar: Int = 100
 
-#gradient(of: someVar) // expected-error {{only functions can be differentiated}}
-#valueAndGradient(of: someVar) // expected-error {{only functions can be differentiated}}
+#gradient(someVar) // expected-error {{only functions can be differentiated}}
+#valueAndGradient(someVar) // expected-error {{only functions can be differentiated}}
 
-let _ = #gradient(of: foo) // ok
-let _ = #valueAndGradient(of: foo) // ok
-let _: (Float, Float) -> (Float, Float) = #gradient(of: foo) // ok
-let _: (Float, Float) -> (value: Float, gradient: (Float, Float)) = #valueAndGradient(of: foo) // ok
+let _ = #gradient(foo) // ok
+let _ = #valueAndGradient(foo) // ok
+let _: (Float, Float) -> (Float, Float) = #gradient(foo) // ok
+let _: (Float, Float) -> (value: Float, gradient: (Float, Float)) = #valueAndGradient(foo) // ok
 
-let _: (Float, Float) -> Float = #gradient(of: foo, withRespectTo: .0) // ok
+let _: (Float, Float) -> Float = #gradient(foo, wrt: .0) // ok
 let _: (Float, Float) -> (value: Float, gradient: Float)
-  = #valueAndGradient(of: foo, withRespectTo: .0) // ok
-let _: (Float, Float) -> (Float, Float) = #gradient(of: foo, withRespectTo: self, .0) // expected-error {{a 'self' parameter can only be used in an instance declaration}}
-let _: (Float, Float) -> (Float, Float) = #gradient(of: foo, withRespectTo: self, .0) // expected-error {{a 'self' parameter can only be used in an instance declaration}}
-let _: (Float, Float) -> (Float, Float) = #gradient(of: foo, withRespectTo: .0, self) // expected-error {{the 'self' parameter must be the first}}
-let _: (Float, Float) -> (Float, Float) = #gradient(of: foo, withRespectTo: .0, .1) // ok
-let _: (Float, Float) -> (Float, Float, Float) = #gradient(of: foo, withRespectTo: .0, .1, .2) // expected-error {{the parameter index is out of bounds for type}}
+  = #valueAndGradient(foo, wrt: .0) // ok
+let _: (Float, Float) -> (Float, Float) = #gradient(foo, wrt: self, .0) // expected-error {{a 'self' parameter can only be used in an instance declaration}}
+let _: (Float, Float) -> (Float, Float) = #gradient(foo, wrt: self, .0) // expected-error {{a 'self' parameter can only be used in an instance declaration}}
+let _: (Float, Float) -> (Float, Float) = #gradient(foo, wrt: .0, self) // expected-error {{the 'self' parameter must be the first}}
+let _: (Float, Float) -> (Float, Float) = #gradient(foo, wrt: .0, .1) // ok
+let _: (Float, Float) -> (Float, Float, Float) = #gradient(foo, wrt: .0, .1, .2) // expected-error {{the parameter index is out of bounds for type}}
 
 // S is not a valid differentiation parameter because it does not conform to FloatingPoint.
 struct S {
   func a(_ x: Float) -> Float {}
 
-  lazy var da = #gradient(of: self.a) // ok
-  lazy var daWithValue = #valueAndGradient(of: self.a) // ok
-  lazy var da2: (Float) -> Float = #gradient(of: self.a) // ok
-  lazy var daWithValue2: (Float) -> (value: Float, gradient: Float) = #valueAndGradient(of: self.a) // ok
+  lazy var da = #gradient(self.a) // ok
+  lazy var daWithValue = #valueAndGradient(self.a) // ok
+  lazy var da2: (Float) -> Float = #gradient(self.a) // ok
+  lazy var daWithValue2: (Float) -> (value: Float, gradient: Float) = #valueAndGradient(self.a) // ok
 
   func b() {
-    let _: (Float) -> Float = #gradient(of: a) // ok
-    let _: (Float) -> S = #gradient(of: a, withRespectTo: self) // expected-error {{gradient parameter has non-differentiable type 'S'}}
+    let _: (Float) -> Float = #gradient(a) // ok
+    let _: (Float) -> S = #gradient(a, wrt: self) // expected-error {{gradient parameter has non-differentiable type 'S'}}
   }
 
   static func c(_ x: Float) -> Float {}
 
   static func d() -> Float {
-    let _: (Float) -> S = #gradient(of: c, withRespectTo: self) // expected-error {{a 'self' parameter can only be used in an instance declaration context}}
+    let _: (Float) -> S = #gradient(c, wrt: self) // expected-error {{a 'self' parameter can only be used in an instance declaration context}}
   }
 }
 
 let s = S()
-let _: (Float) -> Float = #gradient(of: s.a)
-let _: (Float) -> (Float, Float) = #valueAndGradient(of: s.a)
-let _: (Double) -> Double = #gradient(of: s.a)
+let _: (Float) -> Float = #gradient(s.a)
+let _: (Float) -> (Float, Float) = #valueAndGradient(s.a)
+let _: (Double) -> Double = #gradient(s.a)
 // expected-error @-1 {{cannot convert value of type '(Float) -> Float' to specified type}}
-let _: (Double) -> (Double, Double) = #valueAndGradient(of: s.a)
+let _: (Double) -> (Double, Double) = #valueAndGradient(s.a)
 // expected-error @-1 {{cannot convert value of type '(Float) -> (value: Float, gradient: Float)' to specified type}}
 
 // Gradient expressions with generic primal.
 func e<T>(_ x: T) -> T {} // expected-note 2 {{in call to function 'e'}}
 
-let _ = #gradient(of: e) // expected-error {{generic parameter 'T' could not be inferred}}
-let _ = #valueAndGradient(of: e) // expected-error {{generic parameter 'T' could not be inferred}}
-let _: (Float) -> Float = #gradient(of: e)
-let _: (Double) -> Double = #gradient(of: e)
-let _: (Float) -> (Float, Float) = #valueAndGradient(of: e)
-let _: (Double) -> (Double, Double) = #valueAndGradient(of: e)
+let _ = #gradient(e) // expected-error {{generic parameter 'T' could not be inferred}}
+let _ = #valueAndGradient(e) // expected-error {{generic parameter 'T' could not be inferred}}
+let _: (Float) -> Float = #gradient(e)
+let _: (Double) -> Double = #gradient(e)
+let _: (Float) -> (Float, Float) = #valueAndGradient(e)
+let _: (Double) -> (Double, Double) = #valueAndGradient(e)
 
-let _: (Float) -> (Float, Float, Float) = #gradient(of: e) // expected-error {{cannot convert gradient expression to incompatible contextual type}}
-let _: ((Float, Float)) -> (Float, Float) = #gradient(of: e) // expected-error {{gradient parameter has non-differentiable type '(Float, Float)'}}
-let _: (Int) -> (Int) = #gradient(of: e) // expected-error {{gradient parameter has non-differentiable type 'Int'}}
-let _: (Float) -> Double = #gradient(of: e) // expected-error {{cannot convert gradient expression to incompatible contextual type}}
+let _: (Float) -> (Float, Float, Float) = #gradient(e) // expected-error {{cannot convert gradient expression to incompatible contextual type}}
+let _: ((Float, Float)) -> (Float, Float) = #gradient(e) // expected-error {{gradient parameter has non-differentiable type '(Float, Float)'}}
+let _: (Int) -> (Int) = #gradient(e) // expected-error {{gradient parameter has non-differentiable type 'Int'}}
+let _: (Float) -> Double = #gradient(e) // expected-error {{cannot convert gradient expression to incompatible contextual type}}
 
 // Complex type inference.
 func add<T : FloatingPoint>(_ x: T, _ y: T) -> T {
   return x + y
 }
 func dadd<T : FloatingPoint>(_ x: T, _ y: T) -> (T, T) {
-  return #gradient(of: add)(x, y) // ok
+  return #gradient(add)(x, y) // ok
 }
 func daddWithValue<T : FloatingPoint>(
   _ x: T, _ y: T
 ) -> (value: T, gradient: (T, T)) {
-  return #valueAndGradient(of: add)(x, y) // ok
+  return #valueAndGradient(add)(x, y) // ok
 }
 
 func addNumeric<T : Numeric>(_ x: T, _ y: T) -> T {
   return x + y
 }
 func daddNumeric<T : Numeric>(_ x: T, _ y: T) -> (T, T) {
-  return #gradient(of: addNumeric)(x, y) // expected-error {{gradient parameter has non-differentiable type 'T'}}
+  return #gradient(addNumeric)(x, y) // expected-error {{gradient parameter has non-differentiable type 'T'}}
 }
 // Ok because the constraint on daddNumeric is FloatingPoint, not Numeric.
 func daddFloatingPoint<T : FloatingPoint>(_ x: T, _ y: T) -> (T, T) {
-  return #gradient(of: addNumeric)(x, y) // ok
+  return #gradient(addNumeric)(x, y) // ok
 }
 // Ok because the constraint on daddNumeric is FloatingPoint, not Numeric.
 func daddFloatingPointWithValue<T : FloatingPoint>(_ x: T, _ y: T) -> (value: T, gradient: (T, T)) {
-  return #valueAndGradient(of: addNumeric)(x, y) // ok
+  return #valueAndGradient(addNumeric)(x, y) // ok
 }

--- a/test/TensorFlow/tensor_autodiff.swift
+++ b/test/TensorFlow/tensor_autodiff.swift
@@ -11,7 +11,7 @@ func dConcreteTanh(_ x: Tensor<Float>, tanhx: Tensor<Float>, seed: Tensor<Float>
   return seed * (1 - tanhx * tanhx)
 }
 
-_ = #gradient(of: concreteTanh)([1,2,3,4,5])
+_ = #gradient(concreteTanh)([1,2,3,4,5])
 
 // CHECK: @{{.*}}concreteTanh{{.*}}__grad_src_0_wrt_0_s_p
 // CHECK: @{{.*}}concreteTanh{{.*}}__grad_src_0_wrt_0


### PR DESCRIPTION
`#gradient` isn't really a Swift function so it doesn't have to conform to the Swift naming convention. Plus, labels in other pound-expressions in Swift don't form prepositional phrases with the base name. Now it's a much simpler pound-expression!

Before: `#gradient(of: foo, withRespectTo: (.0, .1))`
After: `#gradient(foo, wrt: (.0, .1))`