### PR TITLE
[stdlib] Replace _CharacterView with a typealias

### DIFF
--- a/stdlib/public/core/StringCharacterView.swift
+++ b/stdlib/public/core/StringCharacterView.swift
@@ -21,356 +21,77 @@
 import SwiftShims
 
 extension String {
-  @available(swift, deprecated: 3.2, message:
-    "Please use String or Substring directly")
-  public typealias CharacterView = _CharacterView
-  
   /// A view of a string's contents as a collection of characters.
   ///
-  /// In Swift, every string provides a view of its contents as characters. In
-  /// this view, many individual characters---for example, "é", "김", and
-  /// "🇮🇳"---can be made up of multiple Unicode scalar values. These scalar
-  /// values are combined by Unicode's boundary algorithms into *extended
-  /// grapheme clusters*, represented by the `Character` type. Each element of
-  /// a `CharacterView` collection is a `Character` instance.
-  ///
-  ///     let flowers = "Flowers 💐"
-  ///     for c in flowers.characters {
-  ///         print(c)
-  ///     }
-  ///     // F
-  ///     // l
-  ///     // o
-  ///     // w
-  ///     // e
-  ///     // r
-  ///     // s
-  ///     //
-  ///     // 💐
-  ///
-  /// You can convert a `String.CharacterView` instance back into a string
-  /// using the `String` type's `init(_:)` initializer.
-  ///
-  ///     let name = "Marie Curie"
-  ///     if let firstSpace = name.characters.firstIndex(of: " ") {
-  ///         let firstName = String(name.characters[..<firstSpace])
-  ///         print(firstName)
-  ///     }
-  ///     // Prints "Marie"
-  @_fixed_layout // FIXME(sil-serialize-all)
-  public struct _CharacterView {
-    @usableFromInline
-    internal var _base: String
-
-    /// The offset of this view's `_guts` from an original guts. This works
-    /// around the fact that `_StringGuts` is always zero-indexed.
-    /// `_baseOffset` should be subtracted from `Index.encodedOffset` before
-    /// that value is used as a `_guts` index.
-    @usableFromInline
-    internal var _baseOffset: Int
-
-    /// Creates a view of the given string.
-    @inlinable // FIXME(sil-serialize-all)
-    public init(_ text: String) {
-      self._base = text
-      self._baseOffset = 0
-    }
-
-    @inlinable // FIXME(sil-serialize-all)
-    public // @testable
-    init(_ _base: String, baseOffset: Int = 0) {
-      self._base = _base
-      self._baseOffset = baseOffset
-    }
-  }
-  
-  /// A view of the string's contents as a collection of characters.
-  @_transparent // FIXME(sil-serialize-all)
-  public var _characters: _CharacterView {
-    get {
-      return _CharacterView(self)
-    }
-    set {
-      self = newValue._base
-    }
-  }
+  /// Previous versions of Swift provided this view since String
+  /// itself was not a collection. String is now a collection of
+  /// characters, so this type is now just an alias for String.
+  @available(swift, deprecated: 3.2, obsoleted: 5.0, 
+    message: "Please use String directly")
+  public typealias CharacterView = String
 
   /// A view of the string's contents as a collection of characters.
   @inlinable // FIXME(sil-serialize-all)
-  @available(swift, deprecated: 3.2, message:
-    "Please use String or Substring directly")
-  public var characters: CharacterView {
+  @available(swift, deprecated: 3.2, obsoleted: 5.0, 
+    message: "Please use String directly")
+  public var characters: String {
     get {
-      return _characters
+      return self
     }
     set {
-      _characters = newValue
+      self = newValue
     }
   }
 
   /// Applies the given closure to a mutable view of the string's characters.
   ///
-  /// Do not use the string that is the target of this method inside the
-  /// closure passed to `body`, as it may not have its correct value. Instead,
-  /// use the closure's `CharacterView` argument.
-  ///
-  /// This example below uses the `withMutableCharacters(_:)` method to
-  /// truncate the string `str` at the first space and to return the remainder
-  /// of the string.
-  ///
-  ///     var str = "All this happened, more or less."
-  ///     let afterSpace = str.withMutableCharacters {
-  ///         chars -> String.CharacterView in
-  ///         if let i = chars.firstIndex(of: " ") {
-  ///             let result = chars[chars.index(after: i)...]
-  ///             chars.removeSubrange(i...)
-  ///             return result
-  ///         }
-  ///         return String.CharacterView()
-  ///     }
-  ///
-  ///     print(str)
-  ///     // Prints "All"
-  ///     print(String(afterSpace))
-  ///     // Prints "this happened, more or less."
-  ///
-  /// - Parameter body: A closure that takes a character view as its argument.
-  ///   If `body` has a return value, that value is also used as the return
-  ///   value for the `withMutableCharacters(_:)` method. The `CharacterView`
-  ///   argument is valid only for the duration of the closure's execution.
-  /// - Returns: The return value, if any, of the `body` closure parameter.
+  /// Previous versions of Swift provided this view since String
+  /// itself was not a collection. String is now a collection of
+  /// characters, so this type is now just an alias for String.
   @inlinable // FIXME(sil-serialize-all)
-  @available(swift, deprecated: 3.2, message:
-    "Please mutate String or Substring directly")
+  @available(swift, deprecated: 3.2, obsoleted: 5.0, 
+    message: "Please mutate the String directly")
   public mutating func withMutableCharacters<R>(
-    _ body: (inout CharacterView) -> R
+    _ body: (inout String) -> R
   ) -> R {
-    // Naively mutating self.characters forces multiple references to
-    // exist at the point of mutation. Instead, temporarily move the
-    // guts of this string into a CharacterView.
-    var tmp = _CharacterView("")
-    (_guts, tmp._base._guts) = (tmp._base._guts, _guts)
-    let r = body(&tmp)
-    (_guts, tmp._base._guts) = (tmp._base._guts, _guts)
-    return r
-  }
-
-  /// Creates a string from the given character view.
-  ///
-  /// Use this initializer to recover a string after performing a collection
-  /// slicing operation on a string's character view.
-  ///
-  ///     let poem = """
-  ///           'Twas brillig, and the slithy toves /
-  ///           Did gyre and gimbal in the wabe: /
-  ///           All mimsy were the borogoves /
-  ///           And the mome raths outgrabe.
-  ///           """
-  ///     let excerpt = String(poem.characters.prefix(22)) + "..."
-  ///     print(excerpt)
-  ///     // Prints "'Twas brillig, and the..."
-  ///
-  /// - Parameter characters: A character view to convert to a string.
-  @inlinable // FIXME(sil-serialize-all)
-  @available(swift, deprecated: 3.2, message:
-    "Please use String or Substring directly")
-  public init(_ characters: CharacterView) {
-    self = characters._base
+    return body(&self)
   }
 }
 
-extension String._CharacterView : _SwiftStringView {
+extension Substring {
+  /// A view of a string's contents as a collection of characters.
+  ///
+  /// Previous versions of Swift provided this view since String
+  /// itself was not a collection. String is now a collection of
+  /// characters, so this type is now just an alias for String.
+  @available(swift, deprecated: 3.2, obsoleted: 5.0, 
+    message: "Please use Substring directly")
+  public typealias CharacterView = Substring
+
+  /// A view of the string's contents as a collection of characters.
   @inlinable // FIXME(sil-serialize-all)
-  internal var _persistentContent : String {
-    return _base
+  @available(swift, deprecated: 3.2, obsoleted: 5.0,
+    message: "Please use Substring directly")
+  public var characters: Substring {
+    get {
+      return self
+    }
+    set {
+      self = newValue
+    }
   }
 
+  /// Applies the given closure to a mutable view of the string's characters.
+  ///
+  /// Previous versions of Swift provided this view since String
+  /// itself was not a collection. String is now a collection of
+  /// characters, so this type is now just an alias for String.
   @inlinable // FIXME(sil-serialize-all)
-  internal var _wholeString : String {
-    return _base
-  }
-
-  @inlinable // FIXME(sil-serialize-all)
-  internal var _encodedOffsetRange : Range<Int> {
-    return _base._encodedOffsetRange
-  }
-}
-
-extension String._CharacterView {
-  @inlinable // FIXME(sil-serialize-all)
-  internal var _guts: _StringGuts {
-    return _base._guts
-  }
-}
-
-extension String._CharacterView {
-  @usableFromInline
-  internal typealias UnicodeScalarView = String.UnicodeScalarView
-
-  @inlinable // FIXME(sil-serialize-all)
-  internal var unicodeScalars: UnicodeScalarView {
-    return UnicodeScalarView(_base._guts, coreOffset: _baseOffset)
-  }
-}
-
-/// `String.CharacterView` is a collection of `Character`.
-extension String._CharacterView : BidirectionalCollection {
-  public typealias Index = String.Index
-  public typealias IndexDistance = String.IndexDistance
-
-  /// Translates a view index into an index in the underlying base string using
-  /// this view's `_baseOffset`.
-  @inlinable // FIXME(sil-serialize-all)
-  internal func _toBaseIndex(_ index: Index) -> Index {
-    return String.Index(from: index, adjustingEncodedOffsetBy: -_baseOffset)
-  }
-
-  /// Translates an index in the underlying base string into a view index using
-  /// this view's `_baseOffset`.
-  @inlinable // FIXME(sil-serialize-all)
-  internal func _toViewIndex(_ index: Index) -> Index {
-    return String.Index(from: index, adjustingEncodedOffsetBy: _baseOffset)
-  }
-
-  /// The position of the first character in a nonempty character view.
-  /// 
-  /// In an empty character view, `startIndex` is equal to `endIndex`.
-  @inlinable // FIXME(sil-serialize-all)
-  public var startIndex: Index {
-    return _toViewIndex(_base.startIndex)
-  }
-
-  /// A character view's "past the end" position---that is, the position one
-  /// greater than the last valid subscript argument.
-  ///
-  /// In an empty character view, `endIndex` is equal to `startIndex`.
-  @inlinable // FIXME(sil-serialize-all)
-  public var endIndex: Index {
-    return _toViewIndex(_base.endIndex)
-  }
-
-  /// Returns the next consecutive position after `i`.
-  ///
-  /// - Precondition: The next position is valid.
-  @inlinable // FIXME(sil-serialize-all)
-  public func index(after i: Index) -> Index {
-    return _toViewIndex(_base.index(after: _toBaseIndex(i)))
-  }
-
-  /// Returns the previous consecutive position before `i`.
-  ///
-  /// - Precondition: The previous position is valid.
-  @inlinable // FIXME(sil-serialize-all)
-  public func index(before i: Index) -> Index {
-    return _toViewIndex(_base.index(before: _toBaseIndex(i)))
-  }
-
-  /// Accesses the character at the given position.
-  ///
-  /// The following example searches a string's character view for a capital
-  /// letter and then prints the character at the found index:
-  ///
-  ///     let greeting = "Hello, friend!"
-  ///     if let i = greeting.characters.firstIndex(where: { "A"..."Z" ~= $0 }) {
-  ///         print("First capital letter: \(greeting.characters[i])")
-  ///     }
-  ///     // Prints "First capital letter: H"
-  ///
-  /// - Parameter position: A valid index of the character view. `position`
-  ///   must be less than the view's end index.
-  @inlinable // FIXME(sil-serialize-all)
-  public subscript(i: Index) -> Character {
-    return _base[_toBaseIndex(i)]
-  }
-}
-
-extension String._CharacterView : RangeReplaceableCollection {
-  /// Creates an empty character view.
-  @inlinable // FIXME(sil-serialize-all)
-  public init() {
-    self.init("")
-  }
-
-  /// Replaces the characters within the specified bounds with the given
-  /// characters.
-  ///
-  /// Invalidates all indices with respect to the string.
-  ///
-  /// - Parameters:
-  ///   - bounds: The range of characters to replace. The bounds of the range
-  ///     must be valid indices of the character view.
-  ///   - newElements: The new characters to add to the view.
-  ///
-  /// - Complexity: O(*m*), where *m* is the combined length of the character
-  ///   view and `newElements`. If the call to `replaceSubrange(_:with:)`
-  ///   simply removes characters at the end of the view, the complexity is
-  ///   O(*n*), where *n* is equal to `bounds.count`.
-  @inlinable // FIXME(sil-serialize-all)
-  public mutating func replaceSubrange<C>(
-    _ bounds: Range<Index>,
-    with newElements: C
-  ) where C : Collection, C.Element == Character {
-    _base.replaceSubrange(
-      _toBaseIndex(bounds.lowerBound) ..< _toBaseIndex(bounds.upperBound),
-      with: newElements)
-  }
-
-  /// Reserves enough space in the character view's underlying storage to store
-  /// the specified number of ASCII characters.
-  ///
-  /// Because each element of a character view can require more than a single
-  /// ASCII character's worth of storage, additional allocation may be
-  /// necessary when adding characters to the character view after a call to
-  /// `reserveCapacity(_:)`.
-  ///
-  /// - Parameter n: The minimum number of ASCII character's worth of storage
-  ///   to allocate.
-  ///
-  /// - Complexity: O(*n*), where *n* is the capacity being reserved.
-  public mutating func reserveCapacity(_ n: Int) {
-    _base.reserveCapacity(n)
-  }
-
-  /// Appends the given character to the character view.
-  ///
-  /// - Parameter c: The character to append to the character view.
-  public mutating func append(_ c: Character) {
-    _base.append(c)
-  }
-
-  /// Appends the characters in the given sequence to the character view.
-  /// 
-  /// - Parameter newElements: A sequence of characters.
-  @inlinable // FIXME(sil-serialize-all)
-  public mutating func append<S : Sequence>(contentsOf newElements: S)
-  where S.Element == Character {
-    _base.append(contentsOf: newElements)
-  }
-}
-
-// Algorithms
-extension String._CharacterView {
-  /// Accesses the characters in the given range.
-  ///
-  /// The example below uses this subscript to access the characters up to, but
-  /// not including, the first comma (`","`) in the string.
-  ///
-  ///     let str = "All this happened, more or less."
-  ///     let i = str.characters.firstIndex(of: ",")!
-  ///     let substring = str.characters[str.characters.startIndex ..< i]
-  ///     print(String(substring))
-  ///     // Prints "All this happened"
-  ///
-  /// - Complexity: O(*n*) if the underlying string is bridged from
-  ///   Objective-C, where *n* is the length of the string; otherwise, O(1).
-  @available(swift, deprecated: 3.2, message:
-    "Please use String or Substring directly")
-  public subscript(bounds: Range<Index>) -> String.CharacterView {
-    let offsetRange: Range<Int> =
-      _toBaseIndex(bounds.lowerBound).encodedOffset ..<
-      _toBaseIndex(bounds.upperBound).encodedOffset
-    return String.CharacterView(
-      String(_base._guts._extractSlice(offsetRange)),
-      baseOffset: bounds.lowerBound.encodedOffset)
+  @available(swift, deprecated: 3.2, obsoleted: 5.0, 
+    message: "Please mutate the Substring directly")
+  public mutating func withMutableCharacters<R>(
+    _ body: (inout Substring) -> R
+  ) -> R {
+    return body(&self)
   }
 }

--- a/stdlib/public/core/StringIndex.swift
+++ b/stdlib/public/core/StringIndex.swift
@@ -158,14 +158,6 @@ extension String.Index {
     self.init(encodedOffset: _codeUnitOffset)
   }
 
-  @inlinable // FIXME(sil-serialize-all)
-  @available(swift, deprecated: 3.2)
-  @available(swift, obsoleted: 4.0)
-  public // SPI(Foundation)
-  init(_base: String.Index, in c: String.CharacterView) {
-    self = _base
-  }
-
   /// The integer offset of this index in UTF-16 code units.
   @inlinable // FIXME(sil-serialize-all)
   @available(swift, deprecated: 3.2)

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -365,37 +365,28 @@ extension Substring : LosslessStringConvertible {
 %   ('utf8', 'UTF8'),
 %   ('utf16', 'UTF16'),
 %   ('unicodeScalars', 'UnicodeScalar'),
-%   ('characters', 'Character')
 % ]:
 %   View = ViewPrefix + 'View'
-%   _View = '_CharacterView' if property == 'characters' else View
-%   _property = '_characters' if property == 'characters' else property
 %
 extension Substring {
-  % if View == 'CharacterView':
-  @available(swift, deprecated: 3.2, message:
-    "Please use String or Substring directly")
-  public typealias CharacterView = _CharacterView
-  % end
-
   @_fixed_layout // FIXME(sil-serialize-all)
-  public struct ${_View} {
+  public struct ${View} {
     @usableFromInline // FIXME(sil-serialize-all)
-    internal var _slice: Slice<String.${_View}>
+    internal var _slice: Slice<String.${View}>
   }
 }
 
-extension Substring.${_View} : BidirectionalCollection {
+extension Substring.${View} : BidirectionalCollection {
   public typealias Index = String.${View}.Index
   public typealias Indices = String.${View}.Indices
   public typealias Element = String.${View}.Element
-  public typealias SubSequence = Substring.${_View}
+  public typealias SubSequence = Substring.${View}
 
   /// Creates an instance that slices `base` at `_bounds`.
   @inlinable // FIXME(sil-serialize-all)
-  internal init(_ base: String.${_View}, _bounds: Range<Index>) {
+  internal init(_ base: String.${View}, _bounds: Range<Index>) {
     _slice = Slice(
-      base: String(base._guts).${_property},
+      base: String(base._guts).${property},
       bounds: _bounds)
   }
 
@@ -471,57 +462,25 @@ extension Substring.${_View} : BidirectionalCollection {
   }
 
   @inlinable // FIXME(sil-serialize-all)
-  % if property == 'characters':
-  @available(swift, deprecated: 3.2, message:
-    "Please use String or Substring directly")
-  % end
   public subscript(r: Range<Index>) -> Substring.${View} {
     // FIXME(strings): tests.
     _precondition(r.lowerBound >= startIndex && r.upperBound <= endIndex,
       "${View} index range out of bounds")
-    return Substring.${_View}(_wholeString.${_property}, _bounds: r)
+    return Substring.${View}(_wholeString.${property}, _bounds: r)
   }
 }
 
-  % if View == 'CharacterView':
-@available(swift, deprecated: 3.2)
 extension Substring {
   @inlinable // FIXME(sil-serialize-all)
-  @available(swift, deprecated: 3.2, message:
-    "Please use String or Substring directly")
-  public var characters: CharacterView {
+  public var ${property}: ${View} {
     get {
-      return _characters
-    }
-    set {
-      _characters = newValue
-    }
-  }
-
-  /// Creates a Substring having the given content.
-  ///
-  /// - Complexity: O(1)
-  @inlinable // FIXME(sil-serialize-all)
-  @available(swift, deprecated: 3.2, message:
-    "Please use String or Substring directly")
-  public init(_ content: ${View}) {
-    self = content._wholeString[content.startIndex..<content.endIndex]
-  }
-}
-  % end
-
-extension Substring {
-  @inlinable // FIXME(sil-serialize-all)
-  public var ${_property}: ${_View} {
-    get {
-      return ${_View}(_wholeString.${_property}, _bounds: startIndex..<endIndex)
+      return ${View}(_wholeString.${property}, _bounds: startIndex..<endIndex)
     }
     set {
       self = Substring(newValue)
     }
   }
 
-  % if View != 'CharacterView':
   /// Creates a Substring having the given content.
   ///
   /// - Complexity: O(1)
@@ -529,7 +488,6 @@ extension Substring {
   public init(_ content: ${View}) {
     self = content._wholeString[content.startIndex..<content.endIndex]
   }
-  % end
 }
 
 extension String {
@@ -555,10 +513,6 @@ extension String {
   /// - Complexity: O(N), where N is the length of the resulting `String`'s
   ///   UTF-16.
   @inlinable // FIXME(sil-serialize-all)
-  % if property == 'characters':
-  @available(swift, deprecated: 3.2, message:
-    "Please use String or Substring directly")
-  % end
   public init(_ content: Substring.${View}) {
     self = String(Substring(content))
   }
@@ -720,18 +674,6 @@ extension String {
     let element = first!
     let nextIdx = self.index(after: self.startIndex)
     self = String(self[nextIdx...])
-    return element
-  }
-}
-extension String._CharacterView {
-  @inlinable // FIXME(sil-serialize-all)
-  @available(swift, deprecated: 3.2, obsoleted: 4, message:
-    "Please use 'first', 'dropFirst()', or 'Substring.CharacterView.popFirst()'.")
-  public mutating func popFirst() -> String._CharacterView.Element? {
-    guard !isEmpty else { return nil }
-    let element = first!
-    let nextIdx = self.index(after: self.startIndex)
-    self = String(self[nextIdx...])._characters
     return element
   }
 }

--- a/test/stdlib/StringCompatibilityDiagnostics.swift
+++ b/test/stdlib/StringCompatibilityDiagnostics.swift
@@ -1,22 +1,23 @@
-// RUN: %target-swift-frontend -typecheck -swift-version 4 %s -verify
+// RUN: %target-swift-frontend -typecheck -swift-version 5 %s -verify
 
 func testPopFirst() {
   var str = "abc"
   _ = str.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.popFirst()'}}
-  _ = str.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
+  _ = str.characters.popFirst() // expected-error{{'characters' is unavailable: Please use String directly}}
+  // expected-error@-1{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.popFirst()'}}
   _ = str.unicodeScalars.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.UnicodeScalarView.popFirst()'}}
 
-  var charView: String.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String or Substring directly}}
-  charView = str.characters // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
+  var charView: String.CharacterView // expected-error{{'CharacterView' is unavailable: Please use String directly}}
+  _ = str.characters // expected-error{{'characters' is unavailable: Please use String directly}}
   dump(charView)
 
   var substr = str[...]
   _ = substr.popFirst() // ok
-  _ = substr.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
+  _ = substr.characters.popFirst() // expected-error{{'characters' is unavailable: Please use Substring directly}}
   _ = substr.unicodeScalars.popFirst() // ok
 
-  var charSubView: Substring.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String or Substring directly}}
-  charSubView = substr.characters // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
+  var charSubView: Substring.CharacterView // expected-error{{'CharacterView' is unavailable: Please use Substring directly}}
+  _ = substr.characters // expected-error{{'characters' is unavailable: Please use Substring directly}}
   dump(charSubView)
 }
 

--- a/test/stdlib/StringCompatibilityDiagnostics3.swift
+++ b/test/stdlib/StringCompatibilityDiagnostics3.swift
@@ -3,21 +3,21 @@
 func testPopFirst() {
   var str = "abc"
   _ = str.popFirst() // expected-warning{{'popFirst()' is deprecated: Please use 'first', 'dropFirst()', or 'Substring.popFirst()'}}
-  _ = str.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
-    // expected-warning@-1{{'popFirst()' is deprecated: Please use 'first', 'dropFirst()', or 'Substring.CharacterView.popFirst()'}}
+  _ = str.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use String directly}}
+    // expected-warning@-1{{'popFirst()' is deprecated: Please use 'first', 'dropFirst()', or 'Substring.popFirst()'}}
   _ = str.unicodeScalars.popFirst() // expected-warning{{'popFirst()' is deprecated: Please use 'first', 'dropFirst()', or 'Substring.UnicodeScalarView.popFirst()'}}
 
-  var charView: String.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String or Substring directly}}
-  charView = str.characters // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
+  var charView: String.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String directly}}
+  charView = str.characters // expected-warning{{'characters' is deprecated: Please use String directly}}
   dump(charView)
 
   var substr = str[...]
   _ = substr.popFirst() // ok
-  _ = substr.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
+  _ = substr.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use Substring directly}}
   _ = substr.unicodeScalars.popFirst() // ok
 
-  var charSubView: Substring.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String or Substring directly}}
-  charSubView = substr.characters // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
+  var charSubView: Substring.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use Substring directly}}
+  charSubView = substr.characters // expected-warning{{'characters' is deprecated: Please use Substring directly}}
   dump(charSubView)
 
   var _ = String(str.utf8) ?? "" // expected-warning{{'init' is deprecated: Failable initializer was removed in Swift 4. When upgrading to Swift 4, please use non-failable String.init(_:UTF8View)}}

--- a/test/stdlib/StringCompatibilityDiagnostics4.swift
+++ b/test/stdlib/StringCompatibilityDiagnostics4.swift
@@ -3,21 +3,22 @@
 func testPopFirst() {
   var str = "abc"
   _ = str.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.popFirst()'}}
-  _ = str.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
+  _ = str.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use String directly}}
+    // expected-error@-1{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.popFirst()'}}
   _ = str.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.popFirst()'}}
   _ = str.unicodeScalars.popFirst() // expected-error{{'popFirst()' is unavailable: Please use 'first', 'dropFirst()', or 'Substring.UnicodeScalarView.popFirst()'}}
 
-  var charView: String.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String or Substring directly}}
-  charView = str.characters // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
+  var charView: String.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String directly}}
+  charView = str.characters // expected-warning{{'characters' is deprecated: Please use String directly}}
   dump(charView)
 
   var substr = str[...]
   _ = substr.popFirst() // ok
-  _ = substr.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
+  _ = substr.characters.popFirst() // expected-warning{{'characters' is deprecated: Please use Substring directly}}
   _ = substr.unicodeScalars.popFirst() // ok
 
-  var charSubView: Substring.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use String or Substring directly}}
-  charSubView = substr.characters // expected-warning{{'characters' is deprecated: Please use String or Substring directly}}
+  var charSubView: Substring.CharacterView // expected-warning{{'CharacterView' is deprecated: Please use Substring directly}}
+  charSubView = substr.characters // expected-warning{{'characters' is deprecated: Please use Substring directly}}
   dump(charSubView)
 
   var _ = String(str.utf8) ?? "" // expected-warning{{left side of nil coalescing operator '??' has non-optional type 'String', so the right side is never used}}

--- a/validation-test/stdlib/String.swift
+++ b/validation-test/stdlib/String.swift
@@ -31,15 +31,6 @@ extension Collection {
 }
 
 extension String {
-  internal func index(_nth n: Int) -> Index {
-    return characters.index(_nth: n)
-  }
-  internal func index(_nthLast n: Int) -> Index {
-    return characters.index(_nthLast: n)
-  }
-}
-
-extension String {
   var nativeCapacity: Int {
     precondition(_guts._isNative)
     return _guts.capacity
@@ -139,13 +130,12 @@ StringTests.test("AssociatedTypes-UnicodeScalarView") {
 }
 
 StringTests.test("AssociatedTypes-CharacterView") {
-  typealias View = String.CharacterView
   expectCollectionAssociatedTypes(
-    collectionType: View.self,
-    iteratorType: IndexingIterator<View>.self,
-    subSequenceType: View.self,
-    indexType: View.Index.self,
-    indicesType: DefaultIndices<View>.self)
+    collectionType: String.self,
+    iteratorType: IndexingIterator<String>.self,
+    subSequenceType: Substring.self,
+    indexType: String.Index.self,
+    indicesType: DefaultIndices<String>.self)
 }
 
 func checkUnicodeScalarViewIteration(
@@ -1013,27 +1003,6 @@ StringTests.test("StringGutsReplace") {
       checkRangeReplaceable(
         { StringGutsCollection(g1) },
         { Array(StringGutsCollection(g2))[0..<$0] }
-      )
-    }
-  }
-}
-
-StringTests.test("CharacterViewReplace") {
-  let narrow = "01234567890"
-  let wide = "ⅠⅡⅢⅣⅤⅥⅦⅧⅨⅩⅪ"
-  
-  for s1 in [narrow, wide] {
-    for s2 in [narrow, wide] {
-      let g1 = makeStringGuts(s1)
-      let g2 = makeStringGuts(s2 + s2)
-      checkRangeReplaceable(
-        { () -> String._CharacterView in
-          String._CharacterView(String(g1)) },
-        { String._CharacterView(String(g2._extractSlice(0..<$0))) }
-      )
-      checkRangeReplaceable(
-        { String._CharacterView(String(g1)) },
-        { Array(String._CharacterView(String(g2)))[0..<$0] }
       )
     }
   }


### PR DESCRIPTION
`CharacterView` is already a type alias for an underscored type. This removes that type completely and aliases `CharacterView` to `String`, now that `String` itself is basically what `CharacterView` was. This should reduce code size, and will avoid baking `_CharacterView` into the ABI, while still allowing migration. Also obsoletes `CharacterView` from 5.0 on.