### PR TITLE
[4.2] [Serialization] Fix message for using an older compiler's module file

### DIFF
--- a/include/swift/AST/DiagnosticsSema.def
+++ b/include/swift/AST/DiagnosticsSema.def
@@ -575,7 +575,8 @@ ERROR(serialization_module_too_new,Fatal,
       "module file was created by a newer version of the compiler: %0",
       (StringRef))
 ERROR(serialization_module_language_version_mismatch,Fatal,
-      "module compiled with Swift %0 cannot be imported in Swift %1: %2",
+      "module compiled with Swift %0 cannot be imported by the Swift %1 "
+      "compiler: %2",
       (StringRef, StringRef, StringRef))
 ERROR(serialization_module_too_old,Fatal,
       "module file was created by an older version of the compiler; "

--- a/lib/Serialization/SerializedModuleLoader.cpp
+++ b/lib/Serialization/SerializedModuleLoader.cpp
@@ -27,6 +27,7 @@
 #include <system_error>
 
 using namespace swift;
+using swift::version::Version;
 
 namespace {
 using AccessPathElem = std::pair<Identifier, SourceLoc>;
@@ -240,7 +241,7 @@ FileUnit *SerializedModuleLoader::loadAST(
 
     SmallString<32> versionBuf;
     llvm::raw_svector_ostream versionString(versionBuf);
-    versionString << Ctx.LangOpts.EffectiveLanguageVersion;
+    versionString << Version::getCurrentLanguageVersion();
     if (versionString.str() == shortVersion)
       return false;
 

--- a/test/Serialization/version-mismatches.swift
+++ b/test/Serialization/version-mismatches.swift
@@ -1,25 +1,19 @@
 // RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs/too-old/ -show-diagnostics-after-fatal 2>&1 | %FileCheck -check-prefix CHECK -check-prefix TOO-OLD %s
 // RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs/too-new/ -show-diagnostics-after-fatal 2>&1 | %FileCheck -check-prefix CHECK -check-prefix TOO-NEW %s
 
-// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs/too-old-language/ -show-diagnostics-after-fatal 2>&1 | %FileCheck -check-prefix CHECK -check-prefix LANGUAGE %s
-// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs/too-new-language/ -show-diagnostics-after-fatal 2>&1 | %FileCheck -check-prefix CHECK -check-prefix LANGUAGE %s
-
 // Update this line when "-swift-version 3" is no longer supported.
-// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs/too-new-language/ -show-diagnostics-after-fatal -swift-version 3 2>&1 | %FileCheck -check-prefix CHECK -check-prefix LANGUAGE-3 %s
-// Update this line when "-swift-version 4" is no longer supported.
-// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs/too-new-language/ -show-diagnostics-after-fatal -swift-version 4 2>&1 | %FileCheck -check-prefix CHECK -check-prefix LANGUAGE-4 %s
+// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs/too-new-language/ -show-diagnostics-after-fatal -swift-version 3 2>&1 | %FileCheck -check-prefix CHECK -check-prefix LANGUAGE %s
+// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs/too-new-language/ -show-diagnostics-after-fatal -swift-version 4 2>&1 | %FileCheck -check-prefix CHECK -check-prefix LANGUAGE %s
+// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs/too-new-language/ -show-diagnostics-after-fatal -swift-version 5 2>&1 | %FileCheck -check-prefix CHECK -check-prefix LANGUAGE %s
+
+// RUN: not %target-swift-frontend %s -typecheck -I %S/Inputs/too-old-language/ -show-diagnostics-after-fatal 2>&1 | %FileCheck -check-prefix CHECK -check-prefix LANGUAGE %s
 
 import Library
 // TOO-OLD: :[[@LINE-1]]:8: error: module file was created by an older version of the compiler; rebuild 'Library' and try again: {{.*}}too-old/Library.swiftmodule{{$}}
 // TOO-NEW: :[[@LINE-2]]:8: error: module file was created by a newer version of the compiler: {{.*}}too-new/Library.swiftmodule{{$}}
 
-// Update this line when the default language version changes
-// LANGUAGE: :[[@LINE-5]]:8: error: module compiled with Swift X.Y cannot be imported in Swift {{.+}}.{{.+}}: {{.*}}too-{{old|new}}-language/Library.swiftmodule{{$}}
-
-// Update this line when "-swift-version 3" is no longer supported.
-// LANGUAGE-3: :[[@LINE-8]]:8: error: module compiled with Swift X.Y cannot be imported in Swift 3.{{.+}}: {{.*}}too-{{old|new}}-language/Library.swiftmodule{{$}}
-// Update this line when "-swift-version 3" is no longer supported.
-// LANGUAGE-4: :[[@LINE-10]]:8: error: module compiled with Swift X.Y cannot be imported in Swift 4.{{.+}}: {{.*}}too-{{old|new}}-language/Library.swiftmodule{{$}}
+// Update this line when the compiler version changes.
+// LANGUAGE: :[[@LINE-5]]:8: error: module compiled with Swift X.Y cannot be imported by the Swift 4.{{.+}} compiler: {{.*}}too-{{old|new}}-language/Library.swiftmodule{{$}}
 
 // Compiler thinks that the module is empty in all cases.
 // CHECK: :[[@LINE+1]]:1: error: module 'Library' has no member named 'foo'


### PR DESCRIPTION
Cherry-pick of #17340 to the 4.2 branch. Reviewed by @graydon.