### PR TITLE
[gardening] Clean up gyb-related Emacs local variables

### DIFF
--- a/benchmark/single-source/CharacterProperties.swift
+++ b/benchmark/single-source/CharacterProperties.swift
@@ -453,3 +453,6 @@ public func run_CharacterPropertiesPrecomputed(_ N: Int) {
 
 // TODO: run_CharacterPropertiesComputed
 
+// Local Variables:
+// eval: (read-only-mode 1)
+// End:

--- a/benchmark/single-source/CharacterProperties.swift.gyb
+++ b/benchmark/single-source/CharacterProperties.swift.gyb
@@ -175,3 +175,6 @@ public func run_CharacterPropertiesPrecomputed(_ N: Int) {
 
 // TODO: run_CharacterPropertiesComputed
 
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/benchmark/single-source/DropFirst.swift
+++ b/benchmark/single-source/DropFirst.swift
@@ -237,3 +237,7 @@ public func run_DropFirstArrayLazy(_ N: Int) {
     CheckResults(result == sumCount)
   }
 }
+
+// Local Variables:
+// eval: (read-only-mode 1)
+// End:

--- a/benchmark/single-source/DropFirst.swift.gyb
+++ b/benchmark/single-source/DropFirst.swift.gyb
@@ -65,3 +65,7 @@ public func run_DropFirst${Name}(_ N: Int) {
   }
 }
 % end
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/benchmark/single-source/DropLast.swift
+++ b/benchmark/single-source/DropLast.swift
@@ -236,3 +236,7 @@ public func run_DropLastArrayLazy(_ N: Int) {
     CheckResults(result == sumCount)
   }
 }
+
+// Local Variables:
+// eval: (read-only-mode 1)
+// End:

--- a/benchmark/single-source/DropLast.swift.gyb
+++ b/benchmark/single-source/DropLast.swift.gyb
@@ -64,3 +64,7 @@ public func run_DropLast${Name}(_ N: Int) {
   }
 }
 % end
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/benchmark/single-source/DropWhile.swift
+++ b/benchmark/single-source/DropWhile.swift
@@ -236,3 +236,7 @@ public func run_DropWhileArrayLazy(_ N: Int) {
     CheckResults(result == sumCount)
   }
 }
+
+// Local Variables:
+// eval: (read-only-mode 1)
+// End:

--- a/benchmark/single-source/DropWhile.swift.gyb
+++ b/benchmark/single-source/DropWhile.swift.gyb
@@ -64,3 +64,7 @@ public func run_DropWhile${Name}(_ N: Int) {
   }
 }
 % end
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/benchmark/single-source/Prefix.swift
+++ b/benchmark/single-source/Prefix.swift
@@ -235,3 +235,7 @@ public func run_PrefixArrayLazy(_ N: Int) {
     CheckResults(result == sumCount)
   }
 }
+
+// Local Variables:
+// eval: (read-only-mode 1)
+// End:

--- a/benchmark/single-source/Prefix.swift.gyb
+++ b/benchmark/single-source/Prefix.swift.gyb
@@ -63,3 +63,7 @@ public func run_Prefix${Name}(_ N: Int) {
   }
 }
 % end
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/benchmark/single-source/PrefixWhile.swift
+++ b/benchmark/single-source/PrefixWhile.swift
@@ -235,3 +235,7 @@ public func run_PrefixWhileArrayLazy(_ N: Int) {
     CheckResults(result == sumCount)
   }
 }
+
+// Local Variables:
+// eval: (read-only-mode 1)
+// End:

--- a/benchmark/single-source/PrefixWhile.swift.gyb
+++ b/benchmark/single-source/PrefixWhile.swift.gyb
@@ -63,3 +63,7 @@ public func run_PrefixWhile${Name}(_ N: Int) {
   }
 }
 % end
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/benchmark/single-source/StringComparison.swift
+++ b/benchmark/single-source/StringComparison.swift
@@ -515,3 +515,7 @@ struct Workload {
   )
   
 }
+
+// Local Variables:
+// eval: (read-only-mode 1)
+// End:

--- a/benchmark/single-source/StringComparison.swift.gyb
+++ b/benchmark/single-source/StringComparison.swift.gyb
@@ -281,3 +281,7 @@ struct Workload {
   )
   
 }
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/benchmark/single-source/StringWalk.swift
+++ b/benchmark/single-source/StringWalk.swift
@@ -1224,3 +1224,7 @@ public func run_CharIndexing_punctuatedJapanese_unicodeScalars_Backwards(_ N: In
 
 
 
+
+// Local Variables:
+// eval: (read-only-mode 1)
+// End:

--- a/benchmark/single-source/StringWalk.swift.gyb
+++ b/benchmark/single-source/StringWalk.swift.gyb
@@ -195,3 +195,7 @@ public func run_CharIndexing_${Name}_unicodeScalars_Backwards(_ N: Int) {
 
 
 % end
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/benchmark/single-source/Suffix.swift
+++ b/benchmark/single-source/Suffix.swift
@@ -235,3 +235,7 @@ public func run_SuffixArrayLazy(_ N: Int) {
     CheckResults(result == sumCount)
   }
 }
+
+// Local Variables:
+// eval: (read-only-mode 1)
+// End:

--- a/benchmark/single-source/Suffix.swift.gyb
+++ b/benchmark/single-source/Suffix.swift.gyb
@@ -63,3 +63,7 @@ public func run_Suffix${Name}(_ N: Int) {
   }
 }
 % end
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift
+++ b/stdlib/private/StdlibCollectionUnittest/MinimalCollections.swift
@@ -6053,8 +6053,3 @@ public struct DefaultedRandomAccessRangeReplaceableSlice<Element>
   }
 }
 */
-
-
-// Local Variables:
-// eval: (read-only-mode 1)
-// End:

--- a/stdlib/private/StdlibUnittest/MinimalTypes.swift
+++ b/stdlib/private/StdlibUnittest/MinimalTypes.swift
@@ -381,8 +381,3 @@ public struct MinimalStrideableValue : Equatable, Comparable, Strideable {
     return MinimalStrideableValue(self.value + n, identity: self.identity)
   }
 }
-
-
-// Local Variables:
-// eval: (read-only-mode 1)
-// End:

--- a/stdlib/private/StdlibUnittest/StdlibUnittest.swift
+++ b/stdlib/private/StdlibUnittest/StdlibUnittest.swift
@@ -3003,7 +3003,3 @@ public func expectEqualUnicodeScalars(
       stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
   }
 }
-
-// Local Variables:
-// eval: (read-only-mode 1)
-// End:

--- a/stdlib/private/StdlibUnittest/StringConvertible.swift
+++ b/stdlib/private/StdlibUnittest/StringConvertible.swift
@@ -168,7 +168,3 @@ public func expectDumped<T>(
   expectEqual(expected, actual, message(),
     stackTrace: stackTrace.pushIf(showFrame, file: file, line: line))
 }
-
-// Local Variables:
-// eval: (read-only-mode 1)
-// End:

--- a/stdlib/public/core/Codable.swift.gyb
+++ b/stdlib/public/core/Codable.swift.gyb
@@ -2178,3 +2178,7 @@ public extension UnkeyedDecodingContainer {
     return try self.decode(T.self)
   }
 }
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -1158,3 +1158,7 @@ extension ${Self}: _AnyCollectionProtocol {
   }
 }
 % end
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/stdlib/public/core/FixedArray.swift.gyb
+++ b/stdlib/public/core/FixedArray.swift.gyb
@@ -184,3 +184,7 @@ extension _FixedArray${N} {
 }
 
 % end
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/stdlib/public/core/FloatingPoint.swift.gyb
+++ b/stdlib/public/core/FloatingPoint.swift.gyb
@@ -2587,3 +2587,7 @@ extension BinaryFloatingPoint {
 
 @available(*, unavailable, renamed: "FloatingPoint")
 public typealias FloatingPointType = FloatingPoint
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/stdlib/public/core/FloatingPointParsing.swift.gyb
+++ b/stdlib/public/core/FloatingPointParsing.swift.gyb
@@ -149,3 +149,7 @@ extension ${Self} : LosslessStringConvertible {
 % end
 
 % end
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -1880,3 +1880,7 @@ public func % <T : BinaryFloatingPoint>(lhs: T, rhs: T) -> T {
 public func %= <T : BinaryFloatingPoint> (lhs: inout T, rhs: T) {
   fatalError("%= is not available.")
 }
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -4269,3 +4269,7 @@ extension SignedInteger where Self : FixedWidthInteger {
   }
 %   end
 }
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/stdlib/public/core/Runtime.swift.gyb
+++ b/stdlib/public/core/Runtime.swift.gyb
@@ -626,3 +626,7 @@ internal class _SwiftNativeNSSet {
 }
 
 #endif
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/stdlib/public/core/Sort.swift.gyb
+++ b/stdlib/public/core/Sort.swift.gyb
@@ -426,3 +426,7 @@ public func swap<T>(_ a: inout T, _ b: inout T) {
   // Initialize P2.
   Builtin.initialize(tmp, p2)
 }
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/stdlib/public/core/Stride.swift.gyb
+++ b/stdlib/public/core/Stride.swift.gyb
@@ -720,3 +720,7 @@ public func stride<T>(
 ) -> StrideThrough<T> {
   return StrideThrough(_start: start, end: end, stride: stride)
 }
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -747,3 +747,7 @@ extension String.UnicodeScalarView {
     return element
   }
 }
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/stdlib/public/core/Tuple.swift.gyb
+++ b/stdlib/public/core/Tuple.swift.gyb
@@ -195,3 +195,7 @@ public func ${op} <${comparableTypeParams}>(lhs: ${tupleT}, rhs: ${tupleT}) -> B
 }
 %   end
 % end
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/stdlib/public/core/UnavailableStringAPIs.swift.gyb
+++ b/stdlib/public/core/UnavailableStringAPIs.swift.gyb
@@ -69,3 +69,7 @@ ${stringSubscriptComment}
   }
 }
 
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -820,3 +820,7 @@ public typealias UnsafeRawBufferPointerIterator<T> = UnsafeBufferPointer<T>.Iter
 
 // @available(*, deprecated, renamed: "UnsafeRawBufferPointer.Iterator")
 public typealias UnsafeMutableRawBufferPointerIterator<T> = UnsafeBufferPointer<T>.Iterator
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:

--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -1075,3 +1075,7 @@ extension UnsafeMutableRawPointer {
   @available(*, unavailable, renamed: "init(mutating:)")
   public init?<T>(_ from : UnsafePointer<T>?) { Builtin.unreachable(); return nil }
 }
+
+// ${'Local Variables'}:
+// eval: (read-only-mode 1)
+// End:


### PR DESCRIPTION
Some gyb files end with a specially prepared local variables section that made Emacs editors open the generated file in read-only mode. This is useful in preventing accidental edits that will get overwritten during the build.

Remove this section from degybbed sources and add it to all remaining .gyb files in the stdlib and the benchmark suite.

NFC