### PR TITLE
[stdlib] Uninline mirror code

### DIFF
--- a/stdlib/public/core/AnyHashable.swift
+++ b/stdlib/public/core/AnyHashable.swift
@@ -305,7 +305,6 @@ extension AnyHashable : CustomStringConvertible {
 }
 
 extension AnyHashable : CustomDebugStringConvertible {
-  @inlinable // FIXME(sil-serialize-all)
   public var debugDescription: String {
     return "AnyHashable(" + String(reflecting: base) + ")"
   }

--- a/stdlib/public/core/CTypes.swift
+++ b/stdlib/public/core/CTypes.swift
@@ -187,7 +187,6 @@ extension OpaquePointer: Hashable {
 
 extension OpaquePointer : CustomDebugStringConvertible {
   /// A textual representation of the pointer, suitable for debugging.
-  @inlinable // FIXME(sil-serialize-all)
   public var debugDescription: String {
     return _rawPointerToString(_rawValue)
   }
@@ -236,7 +235,6 @@ public struct CVaListPointer {
 
 extension CVaListPointer : CustomDebugStringConvertible {
   /// A textual representation of the pointer, suitable for debugging.
-  @inlinable // FIXME(sil-serialize-all)
   public var debugDescription: String {
     return value.debugDescription
   }

--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -366,7 +366,6 @@ extension Character : LosslessStringConvertible { }
 
 extension Character : CustomDebugStringConvertible {
   /// A textual representation of the character, suitable for debugging.
-  @inlinable // FIXME(sil-serialize-all)
   public var debugDescription: String {
     return String(self).debugDescription
   }

--- a/stdlib/public/core/ClosedRange.swift
+++ b/stdlib/public/core/ClosedRange.swift
@@ -412,7 +412,6 @@ extension ClosedRange : CustomStringConvertible {
 
 extension ClosedRange : CustomDebugStringConvertible {
   /// A textual representation of the range, suitable for debugging.
-  @inlinable // FIXME(sil-serialize-all)
   public var debugDescription: String {
     return "ClosedRange(\(String(reflecting: lowerBound))"
     + "...\(String(reflecting: upperBound)))"
@@ -420,7 +419,6 @@ extension ClosedRange : CustomDebugStringConvertible {
 }
 
 extension ClosedRange : CustomReflectable {
-  @inlinable // FIXME(sil-serialize-all)
   public var customMirror: Mirror {
     return Mirror(
       self, children: ["lowerBound": lowerBound, "upperBound": upperBound])

--- a/stdlib/public/core/Codable.swift.gyb
+++ b/stdlib/public/core/Codable.swift.gyb
@@ -92,7 +92,6 @@ extension CodingKey {
   }
 
   /// A textual representation of this key, suitable for debugging.
-  @inlinable // FIXME(sil-serialize-all)
   public var debugDescription: String {
     return description
   }

--- a/stdlib/public/core/CollectionOfOne.swift
+++ b/stdlib/public/core/CollectionOfOne.swift
@@ -160,14 +160,12 @@ extension CollectionOfOne: RandomAccessCollection, MutableCollection {
 
 extension CollectionOfOne : CustomDebugStringConvertible {
   /// A textual representation of the collection, suitable for debugging.
-  @inlinable // FIXME(sil-serialize-all)
   public var debugDescription: String {
     return "CollectionOfOne(\(String(reflecting: _element)))"
   }
 }
 
 extension CollectionOfOne : CustomReflectable {
-  @inlinable // FIXME(sil-serialize-all)
   public var customMirror: Mirror {
     return Mirror(self, children: ["element": _element])
   }

--- a/stdlib/public/core/Dictionary.swift
+++ b/stdlib/public/core/Dictionary.swift
@@ -1348,7 +1348,6 @@ extension Dictionary {
       return _makeCollectionDescription(for: self, withTypeName: nil)
     }
 
-    @inlinable // FIXME(sil-serialize-all)
     public var debugDescription: String {
       return _makeCollectionDescription(for: self, withTypeName: "Dictionary.Keys")
     }
@@ -1419,7 +1418,6 @@ extension Dictionary {
       return _makeCollectionDescription(for: self, withTypeName: nil)
     }
 
-    @inlinable // FIXME(sil-serialize-all)
     public var debugDescription: String {
       return _makeCollectionDescription(for: self, withTypeName: "Dictionary.Values")
     }
@@ -1551,7 +1549,6 @@ extension Dictionary: CustomStringConvertible, CustomDebugStringConvertible {
 
   /// A string that represents the contents of the dictionary, suitable for
   /// debugging.
-  @inlinable // FIXME(sil-serialize-all)
   public var debugDescription: String {
     return _makeDescription()
   }
@@ -4661,7 +4658,6 @@ public struct DictionaryIterator<Key: Hashable, Value>: IteratorProtocol {
 
 extension DictionaryIterator: CustomReflectable {
   /// A mirror that reflects the iterator.
-  @inlinable // FIXME(sil-serialize-all)
   public var customMirror: Mirror {
     return Mirror(
       self,
@@ -4671,7 +4667,6 @@ extension DictionaryIterator: CustomReflectable {
 
 extension Dictionary: CustomReflectable {
   /// A mirror that reflects the dictionary.
-  @inlinable // FIXME(sil-serialize-all)
   public var customMirror: Mirror {
     let style = Mirror.DisplayStyle.dictionary
     return Mirror(self, unlabeledChildren: self, displayStyle: style)

--- a/stdlib/public/core/FloatingPointTypes.swift.gyb
+++ b/stdlib/public/core/FloatingPointTypes.swift.gyb
@@ -97,7 +97,6 @@ extension ${Self} : CustomStringConvertible {
 
 extension ${Self} : CustomDebugStringConvertible {
   /// A textual representation of the value, suitable for debugging.
-  @inlinable // FIXME(sil-serialize-all)
   public var debugDescription: String {
     if isFinite || isNaN {
       return _float${bits}ToString(self, debug: true)

--- a/stdlib/public/core/Mirror.swift
+++ b/stdlib/public/core/Mirror.swift
@@ -37,7 +37,6 @@
 ///
 /// To customize the mirror representation of a custom type, add conformance to
 /// the `CustomReflectable` protocol.
-@_fixed_layout // FIXME(sil-serialize-all)
 public struct Mirror {
   /// Representation of descendant classes that don't override
   /// `customMirror`.
@@ -45,8 +44,6 @@ public struct Mirror {
   /// Note that the effect of this setting goes no deeper than the
   /// nearest descendant class that overrides `customMirror`, which
   /// in turn can determine representation of *its* descendants.
-  @_frozen // FIXME(sil-serialize-all)
-  @usableFromInline // FIXME(sil-serialize-all)
   internal enum _DefaultDescendantRepresentation {
     /// Generate a default mirror for descendant classes that don't
     /// override `customMirror`.
@@ -115,7 +112,6 @@ public struct Mirror {
   /// though, the observability of mutations is unspecified.
   ///
   /// - Parameter subject: The instance for which to create a mirror.
-  @inlinable // FIXME(sil-serialize-all)
   public init(reflecting subject: Any) {
     if case let customized as CustomReflectable = subject {
       self = customized.customMirror
@@ -156,12 +152,10 @@ public struct Mirror {
     case dictionary, `set`
   }
 
-  @inlinable // FIXME(sil-serialize-all)
   internal static func _noSuperclassMirror() -> Mirror? { return nil }
 
   @_semantics("optimize.sil.specialize.generic.never")
   @inline(never)
-  @usableFromInline
   internal static func _superclassIterator<Subject>(
     _ subject: Subject, _ ancestorRepresentation: AncestorRepresentation
   ) -> () -> Mirror? {
@@ -218,7 +212,6 @@ public struct Mirror {
   ///   - ancestorRepresentation: The means of generating the subject's
   ///     ancestor representation. `ancestorRepresentation` is ignored if
   ///     `subject` is not a class instance. The default is `.generated`.
-  @inlinable // FIXME(sil-serialize-all)
   public init<Subject, C : Collection>(
     _ subject: Subject,
     children: C,
@@ -264,7 +257,6 @@ public struct Mirror {
   ///   - ancestorRepresentation: The means of generating the subject's
   ///     ancestor representation. `ancestorRepresentation` is ignored if
   ///     `subject` is not a class instance. The default is `.generated`.
-  @inlinable // FIXME(sil-serialize-all)
   public init<Subject, C : Collection>(
     _ subject: Subject,
     unlabeledChildren: C,
@@ -315,7 +307,6 @@ public struct Mirror {
   ///   - ancestorRepresentation: The means of generating the subject's
   ///     ancestor representation. `ancestorRepresentation` is ignored if
   ///     `subject` is not a class instance. The default is `.generated`.
-  @inlinable // FIXME(sil-serialize-all)
   public init<Subject>(
     _ subject: Subject,
     children: DictionaryLiteral<String, Any>,
@@ -348,14 +339,11 @@ public struct Mirror {
   public let displayStyle: DisplayStyle?
 
   /// A mirror of the subject's superclass, if one exists.
-  @inlinable // FIXME(sil-serialize-all)
   public var superclassMirror: Mirror? {
     return _makeSuperclassMirror()
   }
 
-  @usableFromInline // FIXME(sil-serialize-all)
   internal let _makeSuperclassMirror: () -> Mirror?
-  @usableFromInline // FIXME(sil-serialize-all)
   internal let _defaultDescendantRepresentation: _DefaultDescendantRepresentation
 }
 
@@ -393,16 +381,11 @@ extension Int : MirrorPath {}
 extension String : MirrorPath {}
 
 extension Mirror {
-  @_fixed_layout // FIXME(sil-serialize-all)
-  @usableFromInline // FIXME(sil-serialize-all)
   internal struct _Dummy : CustomReflectable {
-    @inlinable // FIXME(sil-serialize-all)
-    internal init(mirror: Mirror) {
+      internal init(mirror: Mirror) {
       self.mirror = mirror
     }
-    @usableFromInline // FIXME(sil-serialize-all)
     internal var mirror: Mirror
-    @inlinable // FIXME(sil-serialize-all)
     internal var customMirror: Mirror { return mirror }
   }
 
@@ -450,7 +433,6 @@ extension Mirror {
   ///   - rest: Any remaining mirror path components.
   /// - Returns: The descendant of this mirror specified by the given mirror
   ///   path components if such a descendant exists; otherwise, `nil`.
-  @inlinable // FIXME(sil-serialize-all)
   public func descendant(
     _ first: MirrorPath, _ rest: MirrorPath...
   ) -> Any? {
@@ -584,7 +566,6 @@ extension PlaygroundQuickLook {
   ///
   /// - Parameter subject: The instance to represent with the resulting Quick
   ///   Look.
-  @inlinable // FIXME(sil-serialize-all)
   @available(*, deprecated, message: "PlaygroundQuickLook will be removed in a future Swift version.")
   public init(reflecting subject: Any) {
     if let customized = subject as? CustomPlaygroundQuickLookable {
@@ -712,7 +693,6 @@ public struct DictionaryLiteral<Key, Value> : ExpressibleByDictionaryLiteral {
   ///
   /// The order of the key-value pairs is kept intact in the resulting
   /// `DictionaryLiteral` instance.
-  @inlinable // FIXME(sil-serialize-all)
   public init(dictionaryLiteral elements: (Key, Value)...) {
     self._elements = elements
   }
@@ -856,14 +836,12 @@ extension String {
 
 /// Reflection for `Mirror` itself.
 extension Mirror : CustomStringConvertible {
-  @inlinable // FIXME(sil-serialize-all)
   public var description: String {
     return "Mirror for \(self.subjectType)"
   }
 }
 
 extension Mirror : CustomReflectable {
-  @inlinable // FIXME(sil-serialize-all)
   public var customMirror: Mirror {
     return Mirror(self, children: [:])
   }

--- a/stdlib/public/core/Mirrors.swift.gyb
+++ b/stdlib/public/core/Mirrors.swift.gyb
@@ -39,7 +39,6 @@ for self_ty in all_integer_types(word_bits):
 
 extension ${Type[0]} : CustomReflectable {
   /// A mirror that reflects the `${Type[0]}` instance.
-  @inlinable // FIXME(sil-serialize-all)
   public var customMirror: Mirror {
     return Mirror(self, unlabeledChildren: EmptyCollection<Void>())
   }

--- a/stdlib/public/core/ObjectIdentifier.swift
+++ b/stdlib/public/core/ObjectIdentifier.swift
@@ -63,7 +63,6 @@ public struct ObjectIdentifier {
 
 extension ObjectIdentifier : CustomDebugStringConvertible {
   /// A textual representation of the identifier, suitable for debugging.
-  @inlinable // FIXME(sil-serialize-all)
   public var debugDescription: String {
     return "ObjectIdentifier(\(_rawPointerToString(_value)))"
   }

--- a/stdlib/public/core/Optional.swift
+++ b/stdlib/public/core/Optional.swift
@@ -269,7 +269,6 @@ public enum Optional<Wrapped> : ExpressibleByNilLiteral {
 
 extension Optional : CustomDebugStringConvertible {
   /// A textual representation of this instance, suitable for debugging.
-  @inlinable // FIXME(sil-serialize-all)
   public var debugDescription: String {
     switch self {
     case .some(let value):
@@ -284,7 +283,6 @@ extension Optional : CustomDebugStringConvertible {
 }
 
 extension Optional : CustomReflectable {
-  @inlinable // FIXME(sil-serialize-all)
   public var customMirror: Mirror {
     switch self {
     case .some(let value):

--- a/stdlib/public/core/Range.swift
+++ b/stdlib/public/core/Range.swift
@@ -363,7 +363,6 @@ extension Range : CustomStringConvertible {
 
 extension Range : CustomDebugStringConvertible {
   /// A textual representation of the range, suitable for debugging.
-  @inlinable // FIXME(sil-serialize-all)
   public var debugDescription: String {
     return "Range(\(String(reflecting: lowerBound))"
     + "..<\(String(reflecting: upperBound)))"
@@ -371,7 +370,6 @@ extension Range : CustomDebugStringConvertible {
 }
 
 extension Range : CustomReflectable {
-  @inlinable // FIXME(sil-serialize-all)
   public var customMirror: Mirror {
     return Mirror(
       self, children: ["lowerBound": lowerBound, "upperBound": upperBound])

--- a/stdlib/public/core/ReflectionMirror.swift
+++ b/stdlib/public/core/ReflectionMirror.swift
@@ -10,18 +10,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-@usableFromInline // FIXME(sil-serialize-all)
 @_silgen_name("swift_reflectionMirror_normalizedType")
 internal func _getNormalizedType<T>(_: T, type: Any.Type) -> Any.Type
 
-@usableFromInline // FIXME(sil-serialize-all)
 @_silgen_name("swift_reflectionMirror_count")
 internal func _getChildCount<T>(_: T, type: Any.Type) -> Int
 
-@usableFromInline // FIXME(sil-serialize-all)
 internal typealias NameFreeFunc = @convention(c) (UnsafePointer<CChar>?) -> Void
 
-@usableFromInline // FIXME(sil-serialize-all)
 @_silgen_name("swift_reflectionMirror_subscript")
 internal func _getChild<T>(
   of: T,
@@ -32,11 +28,9 @@ internal func _getChild<T>(
 ) -> Any
 
 // Returns 'c' (class), 'e' (enum), 's' (struct), 't' (tuple), or '\0' (none)
-@usableFromInline // FIXME(sil-serialize-all)
 @_silgen_name("swift_reflectionMirror_displayStyle")
 internal func _getDisplayStyle<T>(_: T) -> CChar
 
-@inlinable // FIXME(sil-serialize-all)
 internal func getChild<T>(of value: T, type: Any.Type, index: Int) -> (label: String?, value: Any) {
   var nameC: UnsafePointer<CChar>? = nil
   var freeFunc: NameFreeFunc? = nil
@@ -49,20 +43,16 @@ internal func getChild<T>(of value: T, type: Any.Type, index: Int) -> (label: St
 }
 
 #if _runtime(_ObjC)
-@usableFromInline // FIXME(sil-serialize-all)
 @_silgen_name("swift_reflectionMirror_quickLookObject")
 internal func _getQuickLookObject<T>(_: T) -> AnyObject?
 
-@usableFromInline // FIXME(sil-serialize-all)
 @_silgen_name("_swift_stdlib_NSObject_isKindOfClass")
 internal func _isImpl(_ object: AnyObject, kindOf: AnyObject) -> Bool
 
-@inlinable // FIXME(sil-serialize-all)
 internal func _is(_ object: AnyObject, kindOf `class`: String) -> Bool {
   return _isImpl(object, kindOf: `class` as AnyObject)
 }
 
-@inlinable // FIXME(sil-serialize-all)
 internal func _getClassPlaygroundQuickLook(
   _ object: AnyObject
 ) -> PlaygroundQuickLook? {
@@ -112,7 +102,6 @@ internal func _getClassPlaygroundQuickLook(
 #endif
 
 extension Mirror {
-  @inlinable // FIXME(sil-serialize-all)
   internal init(internalReflecting subject: Any,
               subjectType: Any.Type? = nil,
               customAncestor: Mirror? = nil)
@@ -160,7 +149,6 @@ extension Mirror {
     self._defaultDescendantRepresentation = .generated
   }
   
-  @inlinable // FIXME(sil-serialize-all)
   internal static func quickLookObject(_ subject: Any) -> PlaygroundQuickLook? {
 #if _runtime(_ObjC)
     let object = _getQuickLookObject(subject)

--- a/stdlib/public/core/Set.swift
+++ b/stdlib/public/core/Set.swift
@@ -1038,7 +1038,6 @@ extension Set: CustomStringConvertible, CustomDebugStringConvertible {
   }
 
   /// A string that represents the contents of the set, suitable for debugging.
-  @inlinable // FIXME(sil-serialize-all)
   public var debugDescription: String {
     return _makeCollectionDescription(for: self, withTypeName: "Set")
   }
@@ -3928,7 +3927,6 @@ public struct SetIterator<Element: Hashable>: IteratorProtocol {
 
 extension SetIterator: CustomReflectable {
   /// A mirror that reflects the iterator.
-  @inlinable // FIXME(sil-serialize-all)
   public var customMirror: Mirror {
     return Mirror(
       self,
@@ -3938,7 +3936,6 @@ extension SetIterator: CustomReflectable {
 
 extension Set: CustomReflectable {
   /// A mirror that reflects the set.
-  @inlinable // FIXME(sil-serialize-all)
   public var customMirror: Mirror {
     let style = Mirror.DisplayStyle.`set`
     return Mirror(self, unlabeledChildren: self, displayStyle: style)

--- a/stdlib/public/core/StaticString.swift
+++ b/stdlib/public/core/StaticString.swift
@@ -278,14 +278,12 @@ public struct StaticString
   }
 
   /// A textual representation of the static string, suitable for debugging.
-  @inlinable // FIXME(sil-serialize-all)
   public var debugDescription: String {
     return self.description.debugDescription
   }
 }
 
 extension StaticString {
-  @inlinable // FIXME(sil-serialize-all)
   public var customMirror: Mirror {
     return Mirror(reflecting: description)
   }

--- a/stdlib/public/core/Stride.swift.gyb
+++ b/stdlib/public/core/Stride.swift.gyb
@@ -372,7 +372,6 @@ extension StrideTo: Sequence {
 }
 
 extension StrideTo: CustomReflectable {
-  @inlinable // FIXME(sil-serialize-all)
   public var customMirror: Mirror {
     return Mirror(self, children: ["from": _start, "to": _end, "by": _stride])
   }
@@ -588,7 +587,6 @@ extension StrideThrough: Sequence {
 }
 
 extension StrideThrough: CustomReflectable {
-  @inlinable // FIXME(sil-serialize-all)
   public var customMirror: Mirror {
     return Mirror(self,
       children: ["from": _start, "through": _end, "by": _stride])

--- a/stdlib/public/core/String.swift
+++ b/stdlib/public/core/String.swift
@@ -859,7 +859,6 @@ extension String : ExpressibleByStringLiteral {
 
 extension String : CustomDebugStringConvertible {
   /// A representation of the string that is suitable for debugging.
-  @inlinable // FIXME(sil-serialize-all)
   public var debugDescription: String {
     var result = "\""
     for us in self.unicodeScalars {

--- a/stdlib/public/core/StringUTF16.swift
+++ b/stdlib/public/core/StringUTF16.swift
@@ -269,7 +269,6 @@ extension String {
       return String(_guts._extractSlice(_encodedOffsetRange))
     }
 
-    @inlinable // FIXME(sil-serialize-all)
     public var debugDescription: String {
       return "StringUTF16(\(self.description.debugDescription))"
     }
@@ -430,7 +429,6 @@ extension String.UTF16View.Index {
 // Reflection
 extension String.UTF16View : CustomReflectable {
   /// Returns a mirror that reflects the UTF-16 view of a string.
-  @inlinable // FIXME(sil-serialize-all)
   public var customMirror: Mirror {
     return Mirror(self, unlabeledChildren: self)
   }

--- a/stdlib/public/core/StringUTF8.swift
+++ b/stdlib/public/core/StringUTF8.swift
@@ -396,7 +396,6 @@ extension String {
       return String(_guts)
     }
 
-    @inlinable // FIXME(sil-serialize-all)
     public var debugDescription: String {
       return "UTF8View(\(self.description.debugDescription))"
     }
@@ -718,7 +717,6 @@ extension String.UTF8View.Index {
 // Reflection
 extension String.UTF8View : CustomReflectable {
   /// Returns a mirror that reflects the UTF-8 view of a string.
-  @inlinable // FIXME(sil-serialize-all)
   public var customMirror: Mirror {
     return Mirror(self, unlabeledChildren: self)
   }

--- a/stdlib/public/core/StringUnicodeScalarView.swift
+++ b/stdlib/public/core/StringUnicodeScalarView.swift
@@ -549,7 +549,6 @@ extension String.UnicodeScalarView {
 // Reflection
 extension String.UnicodeScalarView : CustomReflectable {
   /// Returns a mirror that reflects the Unicode scalars view of a string.
-  @inlinable // FIXME(sil-serialize-all)
   public var customMirror: Mirror {
     return Mirror(self, unlabeledChildren: self)
   }

--- a/stdlib/public/core/Substring.swift.gyb
+++ b/stdlib/public/core/Substring.swift.gyb
@@ -325,7 +325,6 @@ extension Substring : _SwiftStringView {
 }
 
 extension Substring : CustomReflectable {
-  @inlinable // FIXME(sil-serialize-all)
   public var customMirror: Mirror {
     return String(self).customMirror
   }
@@ -347,7 +346,6 @@ extension Substring : CustomStringConvertible {
 }
 
 extension Substring : CustomDebugStringConvertible {
-  @inlinable // FIXME(sil-serialize-all)
   public var debugDescription: String {
     return String(self).debugDescription
   }

--- a/stdlib/public/core/UnicodeScalar.swift
+++ b/stdlib/public/core/UnicodeScalar.swift
@@ -293,7 +293,6 @@ extension Unicode.Scalar : CustomStringConvertible, CustomDebugStringConvertible
 
   /// An escaped textual representation of the Unicode scalar, suitable for
   /// debugging.
-  @inlinable // FIXME(sil-serialize-all)
   public var debugDescription: String {
     return "\"\(escaped(asASCII: true))\""
   }

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -631,7 +631,6 @@ extension Unsafe${Mutable}BufferPointer {
 
 extension Unsafe${Mutable}BufferPointer : CustomDebugStringConvertible {
   /// A textual representation of the buffer, suitable for debugging.
-  @inlinable // FIXME(sil-serialize-all)
   public var debugDescription: String {
     return "Unsafe${Mutable}BufferPointer"
       + "(start: \(_position.map(String.init(describing:)) ?? "nil"), count: \(count))"

--- a/stdlib/public/core/UnsafePointer.swift.gyb
+++ b/stdlib/public/core/UnsafePointer.swift.gyb
@@ -987,14 +987,12 @@ extension ${Self}: Strideable {
 
 extension ${Self} : CustomDebugStringConvertible {
   /// A textual representation of the pointer, suitable for debugging.
-  @inlinable // FIXME(sil-serialize-all)
   public var debugDescription: String {
     return _rawPointerToString(_rawValue)
   }
 }
 
 extension ${Self} : CustomReflectable {
-  @inlinable // FIXME(sil-serialize-all)
   public var customMirror: Mirror {
     let ptrValue = UInt64(bitPattern: Int64(Int(Builtin.ptrtoint_Word(_rawValue))))
     return Mirror(self, children: ["pointerValue": ptrValue])

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -690,7 +690,6 @@ extension Unsafe${Mutable}RawBufferPointer {
 
 extension Unsafe${Mutable}RawBufferPointer : CustomDebugStringConvertible {
   /// A textual representation of the buffer, suitable for debugging.
-  @inlinable // FIXME(sil-serialize-all)
   public var debugDescription: String {
     return "${Self}"
       + "(start: \(_position.map(String.init(describing:)) ?? "nil"), count: \(count))"

--- a/stdlib/public/core/UnsafeRawPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawPointer.swift.gyb
@@ -978,14 +978,12 @@ extension ${Self}: Hashable {
 
 extension Unsafe${Mutable}RawPointer : CustomDebugStringConvertible {
   /// A textual representation of the pointer, suitable for debugging.
-  @inlinable // FIXME(sil-serialize-all)
   public var debugDescription: String {
     return _rawPointerToString(_rawValue)
   }
 }
 
 extension Unsafe${Mutable}RawPointer : CustomReflectable {
-  @inlinable // FIXME(sil-serialize-all)
   public var customMirror: Mirror {
     let ptrValue = UInt64(
       bitPattern: Int64(Int(Builtin.ptrtoint_Word(_rawValue))))


### PR DESCRIPTION
Removes inlineability from mirror stuff in the stdlib. This code shouldn't be performance critical, and mirrors are likely to evolve in the future. 

Also uninlines `debugDescription` for all types, which usually uses mirrors and is similarly not performance sensitive.