### PR TITLE
Make Debugging Executables/LLDB top level section

### DIFF
--- a/docs/DebuggingTheCompiler.rst
+++ b/docs/DebuggingTheCompiler.rst
@@ -2,11 +2,10 @@
 
 .. highlight:: none
 
-============================
+.. contents::
+
 Debugging the Swift Compiler
 ============================
-
-.. contents::
 
 Abstract
 --------
@@ -440,14 +439,14 @@ For more information and a high level example, see:
 
 
 Debugging Swift Executables
----------------------------
+===========================
 
 One can use the previous tips for debugging the Swift compiler with Swift
 executables as well. Here are some additional useful techniques that one can use
 in Swift executables.
 
 Determining the mangled name of a function in LLDB
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--------------------------------------------------
 
 One problem that often comes up when debugging Swift code in LLDB is that LLDB
 shows the demangled name instead of the mangled name. This can lead to mistakes
@@ -461,8 +460,8 @@ function in the current frame::
     Module: file = "/Volumes/Files/work/solon/build/build-swift/validation-test-macosx-x86_64/stdlib/Output/CollectionType.swift.gyb.tmp/CollectionType3", arch = "x86_64"
     Symbol: id = {0x0000008c}, range = [0x0000000100004db0-0x00000001000056f0), name="ext.CollectionType3.CollectionType3.MutableCollectionType2<A where A: CollectionType3.MutableCollectionType2>.(subscript.materializeForSet : (Swift.Range<A.Index>) -> Swift.MutableSlice<A>).(closure #1)", mangled="_TFFeRq_15CollectionType322MutableCollectionType2_S_S0_m9subscriptFGVs5Rangeqq_s16MutableIndexable5Index_GVs12MutableSliceq__U_FTBpRBBRQPS0_MS4__T_"
 
-Debugging failures in LLDB
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Debugging LLDB failures
+=======================
 
 Sometimes one needs to be able to while debugging actually debug LLDB and its
 interaction with Swift itself. Some examples of problems where this can come up
@@ -483,7 +482,7 @@ For more details about any of the information below, please run::
     (lldb) help log enable
 
 "Types" Log
-```````````
+-----------
 
 The "types" log reports on LLDB's process of constructing SwiftASTContexts and
 errors that may occur. The two main tasks here are:
@@ -514,7 +513,7 @@ This will ensure that the type import command is run before /any/ modules are
 imported.
 
 "Expression" Log
-````````````````
+----------------
 
 The "expression" log reports on the process of wrapping, parsing, SILGen'ing,
 JITing, and inserting an expression into the current Swift module. Since this can
@@ -542,7 +541,7 @@ such a situation, run all expressions before the bad expression, turn on the
 logging, and only then run the bad expression.
 
 Multiple Logs at a Time
-```````````````````````
+-----------------------
 
 Note, you can also turn on more than one log at a time as well, e.x.::
 


### PR DESCRIPTION
Previously these were under "Debugging the Compiler"... but really they are more general so it makes sense for them to have their own sections.
