### PR TITLE
Prevent an exclusivity benchmark from being optimized too much.

### DIFF
--- a/benchmark/single-source/Exclusivity.swift
+++ b/benchmark/single-source/Exclusivity.swift
@@ -80,7 +80,7 @@ public func run_accessGlobal(_ N: Int) {
 // Hopefully the optimizer will not see this as "final" and optimize away the
 // materializeForSet.
 public class C {
-  var counter = 0
+  public var counter = 0
 
   func inc() {
     counter += 1


### PR DESCRIPTION
Whole module exclusivity optimization was removing the exclusivity checks that the benchmark was designed to measure.