### PR TITLE
Add a tensor differentiation runtime test

### DIFF
--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -1,0 +1,19 @@
+// RUN: %target-run-simple-swift
+// REQUIRES: executable_test
+// REQUIRES: swift_test_mode_optimize
+//
+// Tensor AD runtime tests.
+
+import TensorFlow
+import StdlibUnittest
+import TensorFlowUnittest
+
+var TensorADTests = TestSuite("TensorAD")
+
+TensorADTests.testAllBackends("SimpleAdjointCall") {
+  let adjPlus = #adjoint(Tensor<Float>.+)
+  let x = Tensor<Float>(1)
+  expectNearlyEqual(1, adjPlus(x, x, x + x, x).scalarized())
+}
+
+runAllTests()

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -13,7 +13,7 @@ var TensorADTests = TestSuite("TensorAD")
 TensorADTests.testAllBackends("SimpleAdjointCall") {
   let adjPlus = #adjoint(Tensor<Float>.+)
   let x = Tensor<Float>(1)
-  expectNearlyEqual(1, adjPlus(x, x, x + x, x).scalarized())
+  expectNearlyEqual(1, adjPlus(x, x, x + x, x).0.scalarized())
 }
 
 runAllTests()

--- a/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
+++ b/test/TensorFlowRuntime/tensor_autodiff_runtime.swift
@@ -13,7 +13,9 @@ var TensorADTests = TestSuite("TensorAD")
 TensorADTests.testAllBackends("SimpleAdjointCall") {
   let adjPlus = #adjoint(Tensor<Float>.+)
   let x = Tensor<Float>(1)
-  expectNearlyEqual(1, adjPlus(x, x, x + x, x).0.scalarized())
+  let (d0, d1) = adjPlus(x, x, x + x, x)
+  expectNearlyEqual(1, d0.scalarized())
+  expectNearlyEqual(1, d1.scalarized())
 }
 
 runAllTests()


### PR DESCRIPTION
Although the AD pass isn't checked in yet, let's start adding runtime test for the existing infra so that we can make sure things work well with tensor deabstraction.

This includes a simple test that validates a recent fix: #17468.