### PR TITLE
[stdlib] Make test for Sequence.map actually test a sequence

### DIFF
--- a/test/stdlib/ErrorHandling.swift
+++ b/test/stdlib/ErrorHandling.swift
@@ -6,6 +6,7 @@
 //
 
 import StdlibUnittest
+import StdlibCollectionUnittest
 
 
 var NoisyCount = 0
@@ -280,8 +281,8 @@ ErrorHandlingTests.test("ErrorHandling/operators") {
 
 ErrorHandlingTests.test("ErrorHandling/Sequence map") {
   let initialCount = NoisyCount
-  let sequence = AnySequence([1, 2, 3])
   for throwAtCount in 0...3 {
+    let sequence = MinimalSequence(elements: [1, 2, 3])
     var loopCount = 0
     do {
       let result: [Noisy] = try sequence.map { _ in


### PR DESCRIPTION
AnySequence just forwards the call to map to its underlying storage which currently is an Array (and thus a collection). 
Using `MinimalSequence` guarantees that we are actually calling a `Sequence.map`.