### PR TITLE
[4.2] migrator: avoid adding conversion functions when expression types change as well.

### DIFF
--- a/test/Migrator/Inputs/Cities.swift
+++ b/test/Migrator/Inputs/Cities.swift
@@ -88,3 +88,5 @@ public class Wrapper {
     public typealias RawValue = String
   }
 }
+
+public typealias AliasAttribute = String

--- a/test/Migrator/Inputs/string-representable.json
+++ b/test/Migrator/Inputs/string-representable.json
@@ -249,4 +249,15 @@
     "RightComment": "String",
     "ModuleName": "Cities"
   },
+  {
+    "DiffItemKind": "CommonDiffItem",
+    "NodeKind": "TypeAlias",
+    "NodeAnnotation": "TypeAliasDeclToRawRepresentable",
+    "ChildIndex": "0",
+    "LeftUsr": "s:6Cities14AliasAttributea",
+    "LeftComment": "String",
+    "RightUsr": "",
+    "RightComment": "String",
+    "ModuleName": "Cities"
+  },
 ]

--- a/test/Migrator/string-representable.swift
+++ b/test/Migrator/string-representable.swift
@@ -54,3 +54,9 @@ func revert(_ a: AwesomeCityAttribute, b: Wrapper.Attribute) {
   _ = Wrapper.Attribute.init(rawValue: "somevalue")
   _ = b.rawValue
 }
+
+
+func bar(_ c: Container) {
+  let attr: AliasAttribute = ""
+  c.add(single: attr)
+}

--- a/test/Migrator/string-representable.swift.expected
+++ b/test/Migrator/string-representable.swift.expected
@@ -55,6 +55,12 @@ func revert(_ a: AwesomeCityAttribute, b: Wrapper.Attribute) {
   _ = b
 }
 
+
+func bar(_ c: Container) {
+  let attr: AliasAttribute = ""
+  c.add(single: attr)
+}
+
 // Helper function inserted by Swift 4.2 migrator.
 fileprivate func convertToNewAttribute(_ input: String) -> NewAttribute {
 	return NewAttribute(rawValue: input)


### PR DESCRIPTION
When inserting conversion functions around expressions, we should check
whether the type of the expression is a recognized name alias that is
known to be changed to raw-value representable type. We should avoid
inserting conversion functions in this case because doing so causes
build errors.

resolves: rdar://40463990