### PR TITLE
[ParseSIL] Fix metatype SymbolicValue parsing.

### DIFF
--- a/lib/ParseSIL/ParseSIL.cpp
+++ b/lib/ParseSIL/ParseSIL.cpp
@@ -1007,8 +1007,7 @@ static bool parseSymbolicValue(SymbolicValue &value, SILParser &SP,
     SILType temp;
     if (SP.parseSILType(temp))
       return true;
-    auto metatype = CanMetatypeType::get(temp.getASTType());
-    value = SymbolicValue::getMetatype(metatype);
+    value = SymbolicValue::getMetatype(temp.getASTType());
     return false;
   }
   // Handle SIL function references.


### PR DESCRIPTION
Fixes `test/TensorFlow/graph_op_inst.sil`.