### PR TITLE
[Serialization] Drop extensions whose requirements are missing types

### DIFF
--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -2698,10 +2698,12 @@ void Serializer::writeDecl(const Decl *D) {
       inheritedAndDependencyTypes.push_back(addTypeRef(inherited.getType()));
     size_t numInherited = inheritedAndDependencyTypes.size();
 
-    // FIXME: Figure out what to do with requirements and such, which the
-    // extension also depends on. Right now just do what is safe to drop, which
-    // is the base declaration.
-    auto dependencies = collectDependenciesFromType(baseTy);
+    llvm::SmallSetVector<Type, 4> dependencies;
+    collectDependenciesFromType(dependencies, baseTy, /*excluding*/nullptr);
+    for (Requirement req : extension->getGenericRequirements()) {
+      collectDependenciesFromRequirement(dependencies, req,
+                                         /*excluding*/nullptr);
+    }
     for (auto dependencyTy : dependencies)
       inheritedAndDependencyTypes.push_back(addTypeRef(dependencyTy));
 

--- a/test/Serialization/Recovery/type-removal-objc.swift
+++ b/test/Serialization/Recovery/type-removal-objc.swift
@@ -43,3 +43,15 @@ public unowned(unsafe) var someUnownedUnsafeObject: Base = Base()
 // CHECK-DAG: weak var someWeakObject: @sil_weak Base
 // CHECK-RECOVERY-NEGATIVE-NOT: var someWeakObject:
 public weak var someWeakObject: Base? = nil
+
+// CHECK-DAG: struct GenericStruct<T>
+// CHECK-RECOVERY-DAG: struct GenericStruct<T>
+struct GenericStruct<T> {}
+
+// CHECK-DAG: extension GenericStruct where T : SomeProto
+// CHECK-RECOVERY-NEGATIVE-NOT: extension GenericStruct{{.*}}SomeProto
+extension GenericStruct where T: SomeProto {
+  // CHECK-DAG: func someOperation
+  // CHECK-RECOVERY-NEGATIVE-NOT: someOperation
+  func someOperation() {}
+}


### PR DESCRIPTION
If, for whatever reason, a type used in an extension's generic requirements is missing, just drop the whole extension. This isn't wonderful recovery, but in practice nothing should be able to use the extension anyway, since the relevant type in question is missing.

...Okay, that's not quite true; there could, for example, be inlinable code that references one of these methods. However, that (1) isn't worse than the behavior for any other inlinable code (which doesn't yet attempt to recover from missing declarations), and (2) is still a strict improvement over the current situation, where we will eagerly abort the compiler trying to load the extension in the first place.

rdar://problem/40956460