### PR TITLE
stdlib: Update for stricter enforcement of @usableFromInline

### DIFF
--- a/stdlib/public/core/Character.swift
+++ b/stdlib/public/core/Character.swift
@@ -84,6 +84,7 @@ public struct Character {
     return UInt64(Builtin.zext_Int63_Int64(value))
   }
 
+  @usableFromInline // FIXME(sil-serialize-all)
   typealias UTF16View = String.UTF16View
   @inlinable // FIXME(sil-serialize-all)
   internal var utf16: UTF16View {

--- a/stdlib/public/core/HeapBuffer.swift
+++ b/stdlib/public/core/HeapBuffer.swift
@@ -25,6 +25,7 @@ internal protocol _HeapBufferHeader_ {
 @_fixed_layout // FIXME(sil-serialize-all)
 @usableFromInline
 internal struct _HeapBufferHeader<T> : _HeapBufferHeader_ {
+  @usableFromInline // FIXME(sil-serialize-all)
   internal typealias Value = T
   @inlinable // FIXME(sil-serialize-all)
   internal init(_ value: T) { self.value = value }

--- a/stdlib/public/core/KeyPath.swift
+++ b/stdlib/public/core/KeyPath.swift
@@ -479,17 +479,21 @@ internal struct ComputedPropertyID: Hashable {
 @usableFromInline // FIXME(sil-serialize-all)
 @_fixed_layout // FIXME(sil-serialize-all)
 internal struct ComputedArgumentWitnesses {
+  @usableFromInline // FIXME(sil-serialize-all)
   internal typealias Destroy = @convention(thin)
     (_ instanceArguments: UnsafeMutableRawPointer, _ size: Int) -> ()
+  @usableFromInline // FIXME(sil-serialize-all)
   internal typealias Copy = @convention(thin)
     (_ srcInstanceArguments: UnsafeRawPointer,
      _ destInstanceArguments: UnsafeMutableRawPointer,
      _ size: Int) -> ()
+  @usableFromInline // FIXME(sil-serialize-all)
   internal typealias Equals = @convention(thin)
     (_ xInstanceArguments: UnsafeRawPointer,
      _ yInstanceArguments: UnsafeRawPointer,
      _ size: Int) -> Bool
   // FIXME(hasher) Combine to an inout Hasher instead
+  @usableFromInline // FIXME(sil-serialize-all)
   internal typealias Hash = @convention(thin)
     (_ instanceArguments: UnsafeRawPointer,
      _ size: Int) -> Int

--- a/stdlib/public/core/SmallString.swift
+++ b/stdlib/public/core/SmallString.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@usableFromInline // FIXME(sil-serialize-all)
 internal
 typealias _SmallUTF16StringBuffer = _FixedArray16<UInt16>
 

--- a/stdlib/public/core/StringComparison.swift
+++ b/stdlib/public/core/StringComparison.swift
@@ -13,6 +13,7 @@
 import SwiftShims
 
 // TODO: pick values that give us the best branching pattern
+@usableFromInline // FIXME(sil-serialize-all)
 internal
 enum _GutsClassification: UInt {
   case smallUTF8 = 0

--- a/stdlib/public/core/UnmanagedOpaqueString.swift
+++ b/stdlib/public/core/UnmanagedOpaqueString.swift
@@ -157,6 +157,8 @@ extension _UnmanagedOpaqueString : Sequence {
 extension _UnmanagedOpaqueString : RandomAccessCollection {
   internal typealias IndexDistance = Int
   internal typealias Indices = Range<Index>
+
+  @usableFromInline // FIXME(sil-serialize-all)
   internal typealias SubSequence = _UnmanagedOpaqueString
 
   @_fixed_layout

--- a/stdlib/public/core/UnmanagedString.swift
+++ b/stdlib/public/core/UnmanagedString.swift
@@ -12,7 +12,10 @@
 
 import SwiftShims
 
+@usableFromInline
 internal typealias _UnmanagedASCIIString = _UnmanagedString<UInt8>
+
+@usableFromInline
 internal typealias _UnmanagedUTF16String = _UnmanagedString<UTF16.CodeUnit>
 
 @inlinable
@@ -142,9 +145,12 @@ extension _UnmanagedString : RandomAccessCollection {
   // requires that SubSequence share indices with the original collection.
   // Therefore, we use pointers as the index type; however, we also provide
   // integer subscripts as a convenience, in a separate extension below.
+  @usableFromInline // FIXME(sil-serialize-all)
   internal typealias Index = UnsafePointer<CodeUnit>
   internal typealias IndexDistance = Int
   internal typealias Indices = Range<Index>
+
+  @usableFromInline // FIXME(sil-serialize-all)
   internal typealias SubSequence = _UnmanagedString
 
   @inlinable


### PR DESCRIPTION
The enforcement patch isn't ready yet (https://github.com/apple/swift/pull/16586) but this patch keeps getting merge conflicts so I'm going to merge it now since it's harmless.