### PR TITLE
[master-next] Fix to use IntrinsicImpl.inc file for target data.

### DIFF
--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1256,7 +1256,7 @@ static const char *const IntrinsicNameTable[] = {
 };
 
 #define GET_INTRINSIC_TARGET_DATA
-#include "llvm/IR/IntrinsicEnums.inc"
+#include "llvm/IR/IntrinsicImpl.inc"
 #undef GET_INTRINSIC_TARGET_DATA
 
 /// getLLVMIntrinsicID - Given an LLVM IR intrinsic name with argument types


### PR DESCRIPTION
My previous adjustment for LLVM r335407 used IntrinsicEnums.inc in two
places, but the second one needs to use IntrinsicImpl.inc instead.
