### PR TITLE
[master-next] Adjust syntax for setting an Optional member

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -861,7 +861,7 @@ void SpecializedProtocolConformance::computeConditionalRequirements() const {
     auto &ctxt = getProtocol()->getASTContext();
     ConditionalRequirements = ctxt.AllocateCopy(newReqs);
   } else {
-    ConditionalRequirements = {};
+    ConditionalRequirements = Optional<ArrayRef<Requirement>>();
   }
 }
 


### PR DESCRIPTION
Setting the ConditionalRequirements member of SpecializedProtocolConformance
to "{}" works fine with the swift-4.2-branch of swift-llvm, but with the
current upstream-with-swift branch, that results in a build failure:

error: use of overloaded operator '=' is ambiguous (with operand types
'Optional<ArrayRef<swift::Requirement> >' and 'void')

I suspect this is due to LLVM r322838 which made a bunch of changes to
LLVM's Optional type.