### PR TITLE
[stdlib] Uninline Existential Collections

### DIFF
--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -43,6 +43,7 @@ internal func _abstract(
 /// underlying `IteratorProtocol`.
 @_fixed_layout
 public struct AnyIterator<Element> {
+  @usableFromInline
   internal let _box: _AnyIteratorBoxBase<Element>
 
   /// Creates an iterator that wraps a base iterator but whose type depends
@@ -66,6 +67,7 @@ public struct AnyIterator<Element> {
   ///     }
   ///
   /// - Parameter base: An iterator to type-erase.
+  @inlinable
   public init<I : IteratorProtocol>(_ base: I) where I.Element == Element {
     self._box = _IteratorBox(base)
   }
@@ -86,10 +88,12 @@ public struct AnyIterator<Element> {
   /// - Parameter body: A closure that returns an optional element. `body` is
   ///   executed each time the `next()` method is called on the resulting
   ///   iterator.
+  @inlinable
   public init(_ body: @escaping () -> Element?) {
     self._box = _IteratorBox(_ClosureBasedIterator(body))
   }
 
+  @usableFromInline
   internal init(_box: _AnyIteratorBoxBase<Element>) {
     self._box = _box
   }
@@ -100,6 +104,7 @@ extension AnyIterator: IteratorProtocol {
   /// exists.
   ///
   /// Once `nil` has been returned, all subsequent calls return `nil`.
+  @inlinable
   public func next() -> Element? {
     return _box.next()
   }
@@ -109,14 +114,18 @@ extension AnyIterator: IteratorProtocol {
 /// traversing the sequence consumes the iterator.
 extension AnyIterator: Sequence { }
 
+@usableFromInline
 internal struct _ClosureBasedIterator<Element> : IteratorProtocol {
+  @usableFromInline
   internal init(_ body: @escaping () -> Element?) {
     self._body = body
   }
+  @usableFromInline
   internal func next() -> Element? { return _body() }
   internal let _body: () -> Element?
 }
 
+@usableFromInline
 internal class _AnyIteratorBoxBase<Element> : IteratorProtocol {
   internal init() {}
 
@@ -127,14 +136,18 @@ internal class _AnyIteratorBoxBase<Element> : IteratorProtocol {
   /// Once `nil` has been returned, all subsequent calls return `nil`.
   ///
   /// - Note: Subclasses must override this method.
+  @usableFromInline
   internal func next() -> Element? { _abstract() }
 }
 
+@usableFromInline
 internal final class _IteratorBox<
   Base : IteratorProtocol
 > : _AnyIteratorBoxBase<Base.Element> {
+  @usableFromInline
   internal init(_ base: Base) { self._base = base }
   deinit {}
+  @usableFromInline
   internal override func next() -> Base.Element? { return _base.next() }
   internal var _base: Base
 }
@@ -144,6 +157,7 @@ internal final class _IteratorBox<
 
 % for Kind in ['Sequence', 'Collection', 'BidirectionalCollection', 'RandomAccessCollection']:
 
+@usableFromInline
 %   if Kind == 'Sequence':
 internal class _AnySequenceBox<Element>
 %   elif Kind == 'Collection':
@@ -162,44 +176,52 @@ internal class _AnyRandomAccessCollectionBox<Element>
 %   if Kind == 'Sequence':
   internal init() { }
 
+  @usableFromInline
   internal func _makeIterator() -> AnyIterator<Element> { _abstract() }
 
+  @usableFromInline
   internal var _underestimatedCount: Int { _abstract() }
 
-  internal func _map<T>(
-    _ transform: (Element) throws -> T
+  @usableFromInline
+  internal func _map<T>(_ transform: (Element) throws -> T
   ) rethrows -> [T] {
     _abstract()
   }
 
+  @usableFromInline
   internal func _filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> [Element] {
     _abstract()
   }
 
+  @usableFromInline
   internal func _forEach(
     _ body: (Element) throws -> Void
   ) rethrows {
     _abstract()
   }
 
+  @usableFromInline
   internal func __customContainsEquatableElement(
     _ element: Element
   ) -> Bool? {
     _abstract()
   }
 
+  @usableFromInline
   internal func __preprocessingPass<R>(
     _ preprocess: () throws -> R
   ) rethrows -> R? {
     _abstract()
   }
 
+  @usableFromInline
   internal func __copyToContiguousArray() -> ContiguousArray<Element> {
     _abstract()
   }
 
+  @usableFromInline
   internal func __copyContents(initializing buf: UnsafeMutableBufferPointer<Element>)
     -> (AnyIterator<Element>,UnsafeMutableBufferPointer<Element>.Index) {
     _abstract()
@@ -211,34 +233,41 @@ internal class _AnyRandomAccessCollectionBox<Element>
   deinit {}
 
 %   override = 'override' if Kind != 'Sequence' else ''
+  @usableFromInline
   internal ${override} func _drop(
     while predicate: (Element) throws -> Bool
   ) rethrows -> _Any${Kind}Box<Element> {
     _abstract()
   }
 
+  @usableFromInline
   internal ${override} func _dropFirst(_ n: Int) -> _Any${Kind}Box<Element> {
     _abstract()
   }
 
+  @usableFromInline
   internal ${override} func _dropLast(_ n: Int) -> _Any${Kind}Box<Element> {
     _abstract()
   }
 
+  @usableFromInline
   internal ${override} func _prefix(_ maxLength: Int) -> _Any${Kind}Box<Element> {
     _abstract()
   }
 
+  @usableFromInline
   internal ${override} func _prefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> _Any${Kind}Box<Element> {
     _abstract()
   }
 
+  @usableFromInline
   internal ${override} func _suffix(_ maxLength: Int) -> _Any${Kind}Box<Element> {
     _abstract()
   }
 
+  @usableFromInline
   internal func _split(
     maxSplits: Int, omittingEmptySubsequences: Bool,
     whereSeparator isSeparator: (Element) throws -> Bool
@@ -247,34 +276,42 @@ internal class _AnyRandomAccessCollectionBox<Element>
   }
 
 %   if Kind == 'Collection':
+  @usableFromInline
   internal subscript(i: _AnyIndexBox) -> Element { _abstract() }
 
+  @usableFromInline
   internal func _index(after i: _AnyIndexBox) -> _AnyIndexBox { _abstract() }
 
+  @usableFromInline
   internal func _formIndex(after i: _AnyIndexBox) { _abstract() }
 
+  @usableFromInline
   internal func _index(
     _ i: _AnyIndexBox, offsetBy n: Int
   ) -> _AnyIndexBox {
     _abstract()
   }
 
+  @usableFromInline
   internal func _index(
     _ i: _AnyIndexBox, offsetBy n: Int, limitedBy limit: _AnyIndexBox
   ) -> _AnyIndexBox? {
     _abstract()
   }
 
+  @usableFromInline
   internal func _formIndex(_ i: inout _AnyIndexBox, offsetBy n: Int) {
     _abstract()
   }
 
+  @usableFromInline
   internal func _formIndex(
     _ i: inout _AnyIndexBox, offsetBy n: Int, limitedBy limit: _AnyIndexBox
   ) -> Bool {
     _abstract()
   }
 
+  @usableFromInline
   internal func _distance(
     from start: _AnyIndexBox, to end: _AnyIndexBox
   ) -> Int {
@@ -294,6 +331,7 @@ internal class _AnyRandomAccessCollectionBox<Element>
   var isEmpty: Bool { get }
   */
 
+  @usableFromInline
   internal var _count: Int { _abstract() }
 
   // TODO: swift-3-indexing-model: forward the following methods.
@@ -302,8 +340,10 @@ internal class _AnyRandomAccessCollectionBox<Element>
   func _customLastIndexOfEquatableElement(element: Element) -> Index??
   */
 
+  @usableFromInline
   internal var _first: Element? { _abstract() }
 
+  @usableFromInline
   internal init(
     _startIndex: _AnyIndexBox,
     endIndex: _AnyIndexBox
@@ -312,13 +352,16 @@ internal class _AnyRandomAccessCollectionBox<Element>
     self._endIndex = endIndex
   }
 
+  @usableFromInline
   internal let _startIndex: _AnyIndexBox
 
+  @usableFromInline
   internal let _endIndex: _AnyIndexBox
 %   end
 
 %   if Kind in ['Collection', 'BidirectionalCollection', 'RandomAccessCollection']:
 %     override = 'override' if Kind != 'Collection' else ''
+  @usableFromInline
   internal ${override} subscript(
     start start: _AnyIndexBox,
     end end: _AnyIndexBox
@@ -326,8 +369,11 @@ internal class _AnyRandomAccessCollectionBox<Element>
 %   end
 
 %   if Kind == 'BidirectionalCollection':
+  @usableFromInline
   internal func _index(before i: _AnyIndexBox) -> _AnyIndexBox { _abstract() }
+  @usableFromInline
   internal func _formIndex(before i: _AnyIndexBox) { _abstract() }
+  @usableFromInline
   internal var _last: Element? { _abstract() }
 %   end
 }
@@ -348,10 +394,12 @@ internal class _AnyRandomAccessCollectionBox<Element>
 %   end
 
 
-
+@usableFromInline
 internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Element>
 {
   internal typealias Element = S.Element
+
+  internal var _base: S
 
   internal override func _makeIterator() -> AnyIterator<Element> {
     return AnyIterator(_base.makeIterator())
@@ -432,10 +480,12 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
   deinit {}
 
 %   if Kind == 'Sequence':
+  @usableFromInline
   internal init(_base: S) {
     self._base = _base
   }
 %   else:
+  @usableFromInline
   internal init(_base: S) {
     self._base = _base
     super.init(
@@ -547,19 +597,21 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
 %     end
 
 %   end
-  internal var _base: S
 }
 % end
 
+@usableFromInline
 internal struct _ClosureBasedSequence<Iterator : IteratorProtocol> {
   internal var _makeUnderlyingIterator: () -> Iterator
 
+  @usableFromInline
   internal init(_ makeUnderlyingIterator: @escaping () -> Iterator) {
     self._makeUnderlyingIterator = makeUnderlyingIterator
   }
 }
 
 extension _ClosureBasedSequence: Sequence {
+  @usableFromInline
   internal func makeIterator() -> Iterator {
     return _makeUnderlyingIterator()
   }
@@ -573,25 +625,29 @@ extension _ClosureBasedSequence: Sequence {
 //
 @_fixed_layout
 public struct AnySequence<Element> {
+  @usableFromInline
   internal let _box: _AnySequenceBox<Element>
   
   /// Creates a sequence whose `makeIterator()` method forwards to
   /// `makeUnderlyingIterator`.
+  @inlinable
   public init<I : IteratorProtocol>(
     _ makeUnderlyingIterator: @escaping () -> I
   ) where I.Element == Element {
     self.init(_ClosureBasedSequence(makeUnderlyingIterator))
   }
 
+  @usableFromInline
   internal init(_box: _AnySequenceBox<Element>) {
     self._box = _box
   }
 }
 
-extension  AnySequence: Sequence {
+extension AnySequence: Sequence {
   public typealias Iterator = AnyIterator<Element>
 
   /// Creates a new sequence that wraps and forwards operations to `base`.
+  @inlinable
   public init<S : Sequence>(_ base: S)
     where
     S.Element == Element {
@@ -606,60 +662,72 @@ extension Any${Kind} {
 %   else:
   /// Returns an iterator over the elements of this collection.
 %   end
+  @inlinable
   public func makeIterator() -> Iterator {
     return _box._makeIterator()
   }
 
+  @inlinable
   public var underestimatedCount: Int {
     return _box._underestimatedCount
   }
 
+  @inlinable
   public func map<T>(
     _ transform: (Element) throws -> T
   ) rethrows -> [T] {
     return try _box._map(transform)
   }
 
+  @inlinable
   public func filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> [Element] {
     return try _box._filter(isIncluded)
   }
 
+  @inlinable
   public func forEach(
     _ body: (Element) throws -> Void
   ) rethrows {
     return try _box._forEach(body)
   }
 
+  @inlinable
   public func drop(
     while predicate: (Element) throws -> Bool
   ) rethrows -> Any${Kind}<Element> {
     return try Any${Kind}(_box: _box._drop(while: predicate))
   }
 
+  @inlinable
   public func dropFirst(_ n: Int) -> Any${Kind}<Element> {
     return Any${Kind}(_box: _box._dropFirst(n))
   }
 
+  @inlinable
   public func dropLast(_ n: Int) -> Any${Kind}<Element> {
     return Any${Kind}(_box: _box._dropLast(n))
   }
 
+  @inlinable
   public func prefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> Any${Kind}<Element> {
     return try Any${Kind}(_box: _box._prefix(while: predicate))
   }
 
+  @inlinable
   public func prefix(_ maxLength: Int) -> Any${Kind}<Element> {
     return Any${Kind}(_box: _box._prefix(maxLength))
   }
 
+  @inlinable
   public func suffix(_ maxLength: Int) -> Any${Kind}<Element> {
     return Any${Kind}(_box: _box._suffix(maxLength))
   }
 
+  @inlinable
   public func split(
     maxSplits: Int = Int.max,
     omittingEmptySubsequences: Bool = true,
@@ -671,22 +739,26 @@ extension Any${Kind} {
       whereSeparator: isSeparator)
   }
 
+  @inlinable
   public func _customContainsEquatableElement(
     _ element: Element
   ) -> Bool? {
     return _box.__customContainsEquatableElement(element)
   }
 
+  @inlinable
   public func _preprocessingPass<R>(
     _ preprocess: () throws -> R
   ) rethrows -> R? {
     return try _box.__preprocessingPass(preprocess)
   }
 
+  @inlinable
   public func _copyToContiguousArray() -> ContiguousArray<Element> {
     return self._box.__copyToContiguousArray()
   }
 
+  @inlinable
   public func _copyContents(initializing buf: UnsafeMutableBufferPointer<Element>)
   -> (AnyIterator<Element>,UnsafeMutableBufferPointer<Element>.Index) {
     let (it,idx) = _box.__copyContents(initializing: buf)
@@ -708,11 +780,14 @@ internal protocol _AnyIndexBox : class {
   func _isLess(than rhs: _AnyIndexBox) -> Bool
 }
 
+@usableFromInline
+@_fixed_layout
 internal final class _IndexBox<
   BaseIndex : Comparable
 > : _AnyIndexBox {
   internal var _base: BaseIndex
 
+  @usableFromInline
   internal init(_base: BaseIndex) {
     self._base = _base
   }
@@ -741,17 +816,21 @@ internal final class _IndexBox<
 /// A wrapper over an underlying index that hides the specific underlying type.
 @_fixed_layout
 public struct AnyIndex {
+  @usableFromInline
   internal var _box: _AnyIndexBox
 
   /// Creates a new index wrapping `base`.
+  @inlinable
   public init<BaseIndex : Comparable>(_ base: BaseIndex) {
     self._box = _IndexBox(_base: base)
   }
 
+  @usableFromInline
   internal init(_box: _AnyIndexBox) {
     self._box = _box
   }
 
+  @usableFromInline
   internal var _typeID: ObjectIdentifier {
     return _box._typeID
   }
@@ -766,6 +845,7 @@ extension AnyIndex : Comparable {
   /// - Parameters:
   ///   - lhs: An index to compare.
   ///   - rhs: Another index to compare.
+  @inlinable
   public static func == (lhs: AnyIndex, rhs: AnyIndex) -> Bool {
     _precondition(lhs._typeID == rhs._typeID, "Base index types differ")
     return lhs._box._isEqual(to: rhs._box)
@@ -779,6 +859,7 @@ extension AnyIndex : Comparable {
   /// - Parameters:
   ///   - lhs: An index to compare.
   ///   - rhs: Another index to compare.
+  @inlinable
   public static func < (lhs: AnyIndex, rhs: AnyIndex) -> Bool {
     _precondition(lhs._typeID == rhs._typeID, "Base index types differ")
     return lhs._box._isLess(than: rhs._box)
@@ -806,8 +887,10 @@ protocol _AnyCollectionProtocol : Collection {
 /// collection.
 @_fixed_layout
 public struct ${Self}<Element> {
+  @usableFromInline
   internal let _box: _${Self}Box<Element>
 
+  @usableFromInline
   internal init(_box: _${Self}Box<Element>) {
     self._box = _box
   }
@@ -826,6 +909,7 @@ extension ${Self}: ${SelfProtocol} {
   /// - Parameter base: The collection to wrap.
   ///
   /// - Complexity: O(1).
+  @inlinable
   public init<C : ${SubProtocol}>(_ base: C) where C.Element == Element {
     // Traversal: ${Traversal}
     // SubTraversal: ${SubTraversal}
@@ -836,6 +920,7 @@ extension ${Self}: ${SelfProtocol} {
   /// Creates an `${Self}` having the same underlying collection as `other`.
   ///
   /// - Complexity: O(1)
+  @inlinable
   public init(_ other: Any${SubProtocol}<Element>) {
     self._box = other._box
   }
@@ -848,6 +933,7 @@ extension ${Self}: ${SelfProtocol} {
   /// `${SelfProtocol}`, the result is `nil`.
   ///
   /// - Complexity: O(1)
+  @inlinable
   public init?(_ other: Any${collectionForTraversal(SuperTraversal)}<Element>) {
     guard let box =
       other._box as? _${Self}Box<Element> else {
@@ -860,6 +946,7 @@ extension ${Self}: ${SelfProtocol} {
   /// The position of the first element in a non-empty collection.
   ///
   /// In an empty collection, `startIndex == endIndex`.
+  @inlinable
   public var startIndex: Index {
     return AnyIndex(_box: _box._startIndex)
   }
@@ -869,6 +956,7 @@ extension ${Self}: ${SelfProtocol} {
   ///
   /// `endIndex` is always reachable from `startIndex` by zero or more
   /// applications of `index(after:)`.
+  @inlinable
   public var endIndex: Index {
     return AnyIndex(_box: _box._endIndex)
   }
@@ -877,31 +965,37 @@ extension ${Self}: ${SelfProtocol} {
   ///
   /// - Precondition: `position` indicates a valid position in `self` and
   ///   `position != endIndex`.
+  @inlinable
   public subscript(position: Index) -> Element {
     return _box[position._box]
   }
 
+  @inlinable
   public subscript(bounds: Range<Index>) -> SubSequence {
     return ${Self}(_box:
       _box[start: bounds.lowerBound._box, end: bounds.upperBound._box])
   }
 
+  @inlinable
   public func _failEarlyRangeCheck(_ index: Index, bounds: Range<Index>) {
     // Do nothing.  Doing a range check would involve unboxing indices,
     // performing dynamic dispatch etc.  This seems to be too costly for a fast
     // range check for QoI purposes.
   }
 
+  @inlinable
   public func _failEarlyRangeCheck(_ range: Range<Index>, bounds: Range<Index>) {
     // Do nothing.  Doing a range check would involve unboxing indices,
     // performing dynamic dispatch etc.  This seems to be too costly for a fast
     // range check for QoI purposes.
   }
 
+  @inlinable
   public func index(after i: Index) -> Index {
     return AnyIndex(_box: _box._index(after: i._box))
   }
 
+  @inlinable
   public func formIndex(after i: inout Index) {
     if _isUnique(&i._box) {
       _box._formIndex(after: i._box)
@@ -911,10 +1005,12 @@ extension ${Self}: ${SelfProtocol} {
     }
   }
 
+  @inlinable
   public func index(_ i: Index, offsetBy n: Int) -> Index {
     return AnyIndex(_box: _box._index(i._box, offsetBy: n))
   }
 
+  @inlinable
   public func index(
     _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
@@ -922,6 +1018,7 @@ extension ${Self}: ${SelfProtocol} {
       .map { AnyIndex(_box:$0) }
   }
 
+  @inlinable
   public func formIndex(_ i: inout Index, offsetBy n: Int) {
     if _isUnique(&i._box) {
       return _box._formIndex(&i._box, offsetBy: n)
@@ -930,6 +1027,7 @@ extension ${Self}: ${SelfProtocol} {
     }
   }
 
+  @inlinable
   public func formIndex(
     _ i: inout Index,
     offsetBy n: Int,
@@ -946,6 +1044,7 @@ extension ${Self}: ${SelfProtocol} {
     return false
   }
 
+  @inlinable
   public func distance(from start: Index, to end: Index) -> Int {
     return _box._distance(from: start._box, to: end._box)
   }
@@ -959,19 +1058,23 @@ extension ${Self}: ${SelfProtocol} {
   ///
 % end
   /// - Complexity: ${'O(1)' if Traversal == 'RandomAccess' else 'O(*n*)'}
+  @inlinable
   public var count: Int {
     return _box._count
   }
 
+  @inlinable
   public var first: Element? {
     return _box._first
   }
 
 %   if Traversal == 'Bidirectional' or Traversal == 'RandomAccess':
+  @inlinable
   public func index(before i: Index) -> Index {
     return AnyIndex(_box: _box._index(before: i._box))
   }
 
+  @inlinable
   public func formIndex(before i: inout Index) {
     if _isUnique(&i._box) {
       _box._formIndex(before: i._box)
@@ -981,6 +1084,7 @@ extension ${Self}: ${SelfProtocol} {
     }
   }
 
+  @inlinable
   public var last: Element? {
     return _box._last
   }

--- a/stdlib/public/core/ExistentialCollection.swift.gyb
+++ b/stdlib/public/core/ExistentialCollection.swift.gyb
@@ -43,7 +43,6 @@ internal func _abstract(
 /// underlying `IteratorProtocol`.
 @_fixed_layout
 public struct AnyIterator<Element> {
-  @usableFromInline
   internal let _box: _AnyIteratorBoxBase<Element>
 
   /// Creates an iterator that wraps a base iterator but whose type depends
@@ -67,7 +66,6 @@ public struct AnyIterator<Element> {
   ///     }
   ///
   /// - Parameter base: An iterator to type-erase.
-  @inlinable
   public init<I : IteratorProtocol>(_ base: I) where I.Element == Element {
     self._box = _IteratorBox(base)
   }
@@ -88,12 +86,10 @@ public struct AnyIterator<Element> {
   /// - Parameter body: A closure that returns an optional element. `body` is
   ///   executed each time the `next()` method is called on the resulting
   ///   iterator.
-  @inlinable
   public init(_ body: @escaping () -> Element?) {
     self._box = _IteratorBox(_ClosureBasedIterator(body))
   }
 
-  @inlinable
   internal init(_box: _AnyIteratorBoxBase<Element>) {
     self._box = _box
   }
@@ -104,7 +100,6 @@ extension AnyIterator: IteratorProtocol {
   /// exists.
   ///
   /// Once `nil` has been returned, all subsequent calls return `nil`.
-  @inlinable
   public func next() -> Element? {
     return _box.next()
   }
@@ -114,26 +109,17 @@ extension AnyIterator: IteratorProtocol {
 /// traversing the sequence consumes the iterator.
 extension AnyIterator: Sequence { }
 
-@usableFromInline
-@_fixed_layout
 internal struct _ClosureBasedIterator<Element> : IteratorProtocol {
-  @inlinable
   internal init(_ body: @escaping () -> Element?) {
     self._body = body
   }
-  @inlinable
   internal func next() -> Element? { return _body() }
-  @usableFromInline
   internal let _body: () -> Element?
 }
 
-@_fixed_layout
-@usableFromInline
 internal class _AnyIteratorBoxBase<Element> : IteratorProtocol {
-  @inlinable // FIXME(sil-serialize-all)
   internal init() {}
 
-  @inlinable // FIXME(sil-serialize-all)
   deinit {}
   /// Advances to the next element and returns it, or `nil` if no next element
   /// exists.
@@ -141,22 +127,15 @@ internal class _AnyIteratorBoxBase<Element> : IteratorProtocol {
   /// Once `nil` has been returned, all subsequent calls return `nil`.
   ///
   /// - Note: Subclasses must override this method.
-  @inlinable // FIXME(sil-serialize-all)
   internal func next() -> Element? { _abstract() }
 }
 
-@_fixed_layout
-@usableFromInline
 internal final class _IteratorBox<
   Base : IteratorProtocol
 > : _AnyIteratorBoxBase<Base.Element> {
-  @inlinable
   internal init(_ base: Base) { self._base = base }
-  @inlinable // FIXME(sil-serialize-all)
   deinit {}
-  @inlinable
   internal override func next() -> Base.Element? { return _base.next() }
-  @usableFromInline
   internal var _base: Base
 }
 
@@ -165,8 +144,6 @@ internal final class _IteratorBox<
 
 % for Kind in ['Sequence', 'Collection', 'BidirectionalCollection', 'RandomAccessCollection']:
 
-@_fixed_layout
-@usableFromInline
 %   if Kind == 'Sequence':
 internal class _AnySequenceBox<Element>
 %   elif Kind == 'Collection':
@@ -183,56 +160,46 @@ internal class _AnyRandomAccessCollectionBox<Element>
 {
 
 %   if Kind == 'Sequence':
-  @inlinable // FIXME(sil-serialize-all)
   internal init() { }
 
-  @inlinable
   internal func _makeIterator() -> AnyIterator<Element> { _abstract() }
 
-  @inlinable
   internal var _underestimatedCount: Int { _abstract() }
 
-  @inlinable
   internal func _map<T>(
     _ transform: (Element) throws -> T
   ) rethrows -> [T] {
     _abstract()
   }
 
-  @inlinable
   internal func _filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> [Element] {
     _abstract()
   }
 
-  @inlinable
   internal func _forEach(
     _ body: (Element) throws -> Void
   ) rethrows {
     _abstract()
   }
 
-  @inlinable
   internal func __customContainsEquatableElement(
     _ element: Element
   ) -> Bool? {
     _abstract()
   }
 
-  @inlinable
   internal func __preprocessingPass<R>(
     _ preprocess: () throws -> R
   ) rethrows -> R? {
     _abstract()
   }
 
-  @inlinable
   internal func __copyToContiguousArray() -> ContiguousArray<Element> {
     _abstract()
   }
 
-  @inlinable
   internal func __copyContents(initializing buf: UnsafeMutableBufferPointer<Element>)
     -> (AnyIterator<Element>,UnsafeMutableBufferPointer<Element>.Index) {
     _abstract()
@@ -241,45 +208,37 @@ internal class _AnyRandomAccessCollectionBox<Element>
 %   end
 
 % # This deinit has to be present on all the types
-  @inlinable // FIXME(sil-serialize-all)
   deinit {}
 
 %   override = 'override' if Kind != 'Sequence' else ''
-  @inlinable
   internal ${override} func _drop(
     while predicate: (Element) throws -> Bool
   ) rethrows -> _Any${Kind}Box<Element> {
     _abstract()
   }
 
-  @inlinable
   internal ${override} func _dropFirst(_ n: Int) -> _Any${Kind}Box<Element> {
     _abstract()
   }
 
-  @inlinable
   internal ${override} func _dropLast(_ n: Int) -> _Any${Kind}Box<Element> {
     _abstract()
   }
 
-  @inlinable
   internal ${override} func _prefix(_ maxLength: Int) -> _Any${Kind}Box<Element> {
     _abstract()
   }
 
-  @inlinable
   internal ${override} func _prefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> _Any${Kind}Box<Element> {
     _abstract()
   }
 
-  @inlinable
   internal ${override} func _suffix(_ maxLength: Int) -> _Any${Kind}Box<Element> {
     _abstract()
   }
 
-  @inlinable
   internal func _split(
     maxSplits: Int, omittingEmptySubsequences: Bool,
     whereSeparator isSeparator: (Element) throws -> Bool
@@ -288,42 +247,34 @@ internal class _AnyRandomAccessCollectionBox<Element>
   }
 
 %   if Kind == 'Collection':
-  @inlinable
   internal subscript(i: _AnyIndexBox) -> Element { _abstract() }
 
-  @inlinable
   internal func _index(after i: _AnyIndexBox) -> _AnyIndexBox { _abstract() }
 
-  @inlinable
   internal func _formIndex(after i: _AnyIndexBox) { _abstract() }
 
-  @inlinable
   internal func _index(
     _ i: _AnyIndexBox, offsetBy n: Int
   ) -> _AnyIndexBox {
     _abstract()
   }
 
-  @inlinable
   internal func _index(
     _ i: _AnyIndexBox, offsetBy n: Int, limitedBy limit: _AnyIndexBox
   ) -> _AnyIndexBox? {
     _abstract()
   }
 
-  @inlinable
   internal func _formIndex(_ i: inout _AnyIndexBox, offsetBy n: Int) {
     _abstract()
   }
 
-  @inlinable
   internal func _formIndex(
     _ i: inout _AnyIndexBox, offsetBy n: Int, limitedBy limit: _AnyIndexBox
   ) -> Bool {
     _abstract()
   }
 
-  @inlinable
   internal func _distance(
     from start: _AnyIndexBox, to end: _AnyIndexBox
   ) -> Int {
@@ -343,7 +294,6 @@ internal class _AnyRandomAccessCollectionBox<Element>
   var isEmpty: Bool { get }
   */
 
-  @inlinable // FIXME(sil-serialize-all)
   internal var _count: Int { _abstract() }
 
   // TODO: swift-3-indexing-model: forward the following methods.
@@ -352,10 +302,8 @@ internal class _AnyRandomAccessCollectionBox<Element>
   func _customLastIndexOfEquatableElement(element: Element) -> Index??
   */
 
-  @inlinable // FIXME(sil-serialize-all)
   internal var _first: Element? { _abstract() }
 
-  @inlinable
   internal init(
     _startIndex: _AnyIndexBox,
     endIndex: _AnyIndexBox
@@ -364,16 +312,13 @@ internal class _AnyRandomAccessCollectionBox<Element>
     self._endIndex = endIndex
   }
 
-  @usableFromInline
   internal let _startIndex: _AnyIndexBox
 
-  @usableFromInline
   internal let _endIndex: _AnyIndexBox
 %   end
 
 %   if Kind in ['Collection', 'BidirectionalCollection', 'RandomAccessCollection']:
 %     override = 'override' if Kind != 'Collection' else ''
-  @inlinable
   internal ${override} subscript(
     start start: _AnyIndexBox,
     end end: _AnyIndexBox
@@ -381,11 +326,8 @@ internal class _AnyRandomAccessCollectionBox<Element>
 %   end
 
 %   if Kind == 'BidirectionalCollection':
-  @inlinable
   internal func _index(before i: _AnyIndexBox) -> _AnyIndexBox { _abstract() }
-  @inlinable
   internal func _formIndex(before i: _AnyIndexBox) { _abstract() }
-  @inlinable
   internal var _last: Element? { _abstract() }
 %   end
 }
@@ -407,92 +349,72 @@ internal class _AnyRandomAccessCollectionBox<Element>
 
 
 
-@_fixed_layout
-@usableFromInline
 internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Element>
 {
-  @usableFromInline
   internal typealias Element = S.Element
 
-  @inline(__always)
-  @inlinable
   internal override func _makeIterator() -> AnyIterator<Element> {
     return AnyIterator(_base.makeIterator())
   }
-  @inlinable
   internal override var _underestimatedCount: Int {
     return _base.underestimatedCount
   }
-  @inlinable
   internal override func _map<T>(
     _ transform: (Element) throws -> T
   ) rethrows -> [T] {
     return try _base.map(transform)
   }
-  @inlinable
   internal override func _filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> [Element] {
     return try _base.filter(isIncluded)
   }
-  @inlinable
   internal override func _forEach(
     _ body: (Element) throws -> Void
   ) rethrows {
     return try _base.forEach(body)
   }
-  @inlinable
   internal override func __customContainsEquatableElement(
     _ element: Element
   ) -> Bool? {
     return _base._customContainsEquatableElement(element)
   }
-  @inlinable
   internal override func __preprocessingPass<R>(
     _ preprocess: () throws -> R
   ) rethrows -> R? {
     return try _base._preprocessingPass(preprocess)
   }
-  @inlinable
   internal override func __copyToContiguousArray() -> ContiguousArray<Element> {
     return _base._copyToContiguousArray()
   }
-  @inlinable
   internal override func __copyContents(initializing buf: UnsafeMutableBufferPointer<Element>)
     -> (AnyIterator<Element>,UnsafeMutableBufferPointer<Element>.Index) {
     let (it,idx) = _base._copyContents(initializing: buf)
     return (AnyIterator(it),idx)
   }
-  @inlinable
   internal override func _drop(
     while predicate: (Element) throws -> Bool
   ) rethrows -> _Any${Kind}Box<Element> {
     return try _${Kind}Box<S.SubSequence>(_base: _base.drop(while: predicate))
   }
-  @inlinable
   internal override func _dropFirst(_ n: Int) -> _Any${Kind}Box<Element> {
     return _${Kind}Box<S.SubSequence>(_base: _base.dropFirst(n))
   }
-  @inlinable
   internal override func _dropLast(_ n: Int) -> _Any${Kind}Box<Element> {
     return _${Kind}Box<S.SubSequence>(_base: _base.dropLast(n))
   }
-  @inlinable
   internal override func _prefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> _Any${Kind}Box<Element> {
     return try _${Kind}Box<S.SubSequence>(_base: _base.prefix(while: predicate))
   }
-  @inlinable
   internal override func _prefix(_ maxLength: Int) -> _Any${Kind}Box<Element> {
     return _${Kind}Box<S.SubSequence>(_base: _base.prefix(maxLength))
   }
-  @inlinable
   internal override func _suffix(_ maxLength: Int) -> _Any${Kind}Box<Element> {
     return _${Kind}Box<S.SubSequence>(_base: _base.suffix(maxLength))
   }
 %   for ResultKind in EqualAndWeakerKinds:
-  @inlinable
   internal override func _split(
     maxSplits: Int, omittingEmptySubsequences: Bool,
     whereSeparator isSeparator: (Element) throws -> Bool
@@ -507,16 +429,13 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
   }
 %   end
 
-  @inlinable // FIXME(sil-serialize-all)
   deinit {}
 
 %   if Kind == 'Sequence':
-  @inlinable
   internal init(_base: S) {
     self._base = _base
   }
 %   else:
-  @inlinable
   internal init(_base: S) {
     self._base = _base
     super.init(
@@ -524,7 +443,6 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
       endIndex: _IndexBox(_base: _base.endIndex))
   }
 
-  @inlinable
   internal func _unbox(
     _ position: _AnyIndexBox, file: StaticString = #file, line: UInt = #line
   ) -> S.Index {
@@ -534,12 +452,10 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
     fatalError("Index type mismatch!", file: file, line: line)
   }
 
-  @inlinable
   internal override subscript(position: _AnyIndexBox) -> Element {
     return _base[_unbox(position)]
   }
 
-  @inlinable
   internal override subscript(start start: _AnyIndexBox, end end: _AnyIndexBox)
     -> _Any${Kind}Box<Element>
   {
@@ -548,12 +464,10 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
     )
   }
 
-  @inlinable
   internal override func _index(after position: _AnyIndexBox) -> _AnyIndexBox {
     return _IndexBox(_base: _base.index(after: _unbox(position)))
   }
 
-  @inlinable
   internal override func _formIndex(after position: _AnyIndexBox) {
     if let p = position as? _IndexBox<S.Index> {
       return _base.formIndex(after: &p._base)
@@ -561,14 +475,12 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
     fatalError("Index type mismatch!")
   }
 
-  @inlinable
   internal override func _index(
     _ i: _AnyIndexBox, offsetBy n: Int
   ) -> _AnyIndexBox {
     return _IndexBox(_base: _base.index(_unbox(i), offsetBy: numericCast(n)))
   }
 
-  @inlinable
   internal override func _index(
     _ i: _AnyIndexBox,
     offsetBy n: Int,
@@ -581,7 +493,6 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
       .map { _IndexBox(_base: $0) }
   }
 
-  @inlinable
   internal override func _formIndex(
     _ i: inout _AnyIndexBox, offsetBy n: Int
   ) {
@@ -591,7 +502,6 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
     fatalError("Index type mismatch!")
   }
 
-  @inlinable
   internal override func _formIndex(
     _ i: inout _AnyIndexBox, offsetBy n: Int, limitedBy limit: _AnyIndexBox
   ) -> Bool {
@@ -604,7 +514,6 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
     fatalError("Index type mismatch!")
   }
 
-  @inlinable
   internal override func _distance(
     from start: _AnyIndexBox,
     to end: _AnyIndexBox
@@ -612,23 +521,19 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
     return numericCast(_base.distance(from: _unbox(start), to: _unbox(end)))
   }
 
-  @inlinable
   internal override var _count: Int {
     return numericCast(_base.count)
   }
 
-  @inlinable
   internal override var _first: Element? {
     return _base.first
   }
 
 %     if Kind in ['BidirectionalCollection', 'RandomAccessCollection']:
-  @inlinable
   internal override func _index(before position: _AnyIndexBox) -> _AnyIndexBox {
     return _IndexBox(_base: _base.index(before: _unbox(position)))
   }
 
-  @inlinable
   internal override func _formIndex(before position: _AnyIndexBox) {
     if let p = position as? _IndexBox<S.Index> {
       return _base.formIndex(before: &p._base)
@@ -636,32 +541,25 @@ internal final class _${Kind}Box<S : ${Kind}> : _Any${Kind}Box<S.Iterator.Elemen
     fatalError("Index type mismatch!")
   }
 
-  @inlinable
   internal override var _last: Element? {
     return _base.last
   }
 %     end
 
 %   end
-  @usableFromInline
   internal var _base: S
 }
 % end
 
-@usableFromInline
-@_fixed_layout
 internal struct _ClosureBasedSequence<Iterator : IteratorProtocol> {
-  @usableFromInline
   internal var _makeUnderlyingIterator: () -> Iterator
 
-  @inlinable
   internal init(_ makeUnderlyingIterator: @escaping () -> Iterator) {
     self._makeUnderlyingIterator = makeUnderlyingIterator
   }
 }
 
 extension _ClosureBasedSequence: Sequence {
-  @inlinable
   internal func makeIterator() -> Iterator {
     return _makeUnderlyingIterator()
   }
@@ -672,22 +570,19 @@ extension _ClosureBasedSequence: Sequence {
 /// An instance of `AnySequence` forwards its operations to an underlying base
 /// sequence having the same `Element` type, hiding the specifics of the
 /// underlying sequence.
-//@usableFromInline
+//
 @_fixed_layout
 public struct AnySequence<Element> {
-  @usableFromInline
   internal let _box: _AnySequenceBox<Element>
   
   /// Creates a sequence whose `makeIterator()` method forwards to
   /// `makeUnderlyingIterator`.
-  @inlinable
   public init<I : IteratorProtocol>(
     _ makeUnderlyingIterator: @escaping () -> I
   ) where I.Element == Element {
     self.init(_ClosureBasedSequence(makeUnderlyingIterator))
   }
 
-  @inlinable
   internal init(_box: _AnySequenceBox<Element>) {
     self._box = _box
   }
@@ -697,7 +592,6 @@ extension  AnySequence: Sequence {
   public typealias Iterator = AnyIterator<Element>
 
   /// Creates a new sequence that wraps and forwards operations to `base`.
-  @inlinable
   public init<S : Sequence>(_ base: S)
     where
     S.Element == Element {
@@ -712,73 +606,60 @@ extension Any${Kind} {
 %   else:
   /// Returns an iterator over the elements of this collection.
 %   end
-  @inline(__always)
-  @inlinable
   public func makeIterator() -> Iterator {
     return _box._makeIterator()
   }
 
-  @inlinable
   public var underestimatedCount: Int {
     return _box._underestimatedCount
   }
 
-  @inlinable
   public func map<T>(
     _ transform: (Element) throws -> T
   ) rethrows -> [T] {
     return try _box._map(transform)
   }
 
-  @inlinable
   public func filter(
     _ isIncluded: (Element) throws -> Bool
   ) rethrows -> [Element] {
     return try _box._filter(isIncluded)
   }
 
-  @inlinable
   public func forEach(
     _ body: (Element) throws -> Void
   ) rethrows {
     return try _box._forEach(body)
   }
 
-  @inlinable
   public func drop(
     while predicate: (Element) throws -> Bool
   ) rethrows -> Any${Kind}<Element> {
     return try Any${Kind}(_box: _box._drop(while: predicate))
   }
 
-  @inlinable
   public func dropFirst(_ n: Int) -> Any${Kind}<Element> {
     return Any${Kind}(_box: _box._dropFirst(n))
   }
 
-  @inlinable
   public func dropLast(_ n: Int) -> Any${Kind}<Element> {
     return Any${Kind}(_box: _box._dropLast(n))
   }
 
-  @inlinable
   public func prefix(
     while predicate: (Element) throws -> Bool
   ) rethrows -> Any${Kind}<Element> {
     return try Any${Kind}(_box: _box._prefix(while: predicate))
   }
 
-  @inlinable
   public func prefix(_ maxLength: Int) -> Any${Kind}<Element> {
     return Any${Kind}(_box: _box._prefix(maxLength))
   }
 
-  @inlinable
   public func suffix(_ maxLength: Int) -> Any${Kind}<Element> {
     return Any${Kind}(_box: _box._suffix(maxLength))
   }
 
-  @inlinable
   public func split(
     maxSplits: Int = Int.max,
     omittingEmptySubsequences: Bool = true,
@@ -790,26 +671,22 @@ extension Any${Kind} {
       whereSeparator: isSeparator)
   }
 
-  @inlinable
   public func _customContainsEquatableElement(
     _ element: Element
   ) -> Bool? {
     return _box.__customContainsEquatableElement(element)
   }
 
-  @inlinable
   public func _preprocessingPass<R>(
     _ preprocess: () throws -> R
   ) rethrows -> R? {
     return try _box.__preprocessingPass(preprocess)
   }
 
-  @inlinable
   public func _copyToContiguousArray() -> ContiguousArray<Element> {
     return self._box.__copyToContiguousArray()
   }
 
-  @inlinable
   public func _copyContents(initializing buf: UnsafeMutableBufferPointer<Element>)
   -> (AnyIterator<Element>,UnsafeMutableBufferPointer<Element>.Index) {
     let (it,idx) = _box.__copyContents(initializing: buf)
@@ -821,7 +698,6 @@ extension Any${Kind} {
 //===--- Index ------------------------------------------------------------===//
 //===----------------------------------------------------------------------===//
 
-@usableFromInline
 internal protocol _AnyIndexBox : class {
   var _typeID: ObjectIdentifier { get }
 
@@ -832,40 +708,31 @@ internal protocol _AnyIndexBox : class {
   func _isLess(than rhs: _AnyIndexBox) -> Bool
 }
 
-@_fixed_layout
-@usableFromInline
 internal final class _IndexBox<
   BaseIndex : Comparable
 > : _AnyIndexBox {
-  @usableFromInline
   internal var _base: BaseIndex
 
-  @inlinable
   internal init(_base: BaseIndex) {
     self._base = _base
   }
 
-  @inlinable
   internal func _unsafeUnbox(_ other: _AnyIndexBox) -> BaseIndex {
     return unsafeDowncast(other, to: _IndexBox.self)._base
   }
 
-  @inlinable
   internal var _typeID: ObjectIdentifier {
     return ObjectIdentifier(type(of: self))
   }
 
-  @inlinable
   internal func _unbox<T : Comparable>() -> T? {
     return (self as _AnyIndexBox as? _IndexBox<T>)?._base
   }
 
-  @inlinable
   internal func _isEqual(to rhs: _AnyIndexBox) -> Bool {
     return _base == _unsafeUnbox(rhs)
   }
 
-  @inlinable
   internal func _isLess(than rhs: _AnyIndexBox) -> Bool {
     return _base < _unsafeUnbox(rhs)
   }
@@ -874,21 +741,17 @@ internal final class _IndexBox<
 /// A wrapper over an underlying index that hides the specific underlying type.
 @_fixed_layout
 public struct AnyIndex {
-  @usableFromInline
   internal var _box: _AnyIndexBox
 
   /// Creates a new index wrapping `base`.
-  @inlinable
   public init<BaseIndex : Comparable>(_ base: BaseIndex) {
     self._box = _IndexBox(_base: base)
   }
 
-  @inlinable
   internal init(_box: _AnyIndexBox) {
     self._box = _box
   }
 
-  @inlinable
   internal var _typeID: ObjectIdentifier {
     return _box._typeID
   }
@@ -903,7 +766,6 @@ extension AnyIndex : Comparable {
   /// - Parameters:
   ///   - lhs: An index to compare.
   ///   - rhs: Another index to compare.
-  @inlinable
   public static func == (lhs: AnyIndex, rhs: AnyIndex) -> Bool {
     _precondition(lhs._typeID == rhs._typeID, "Base index types differ")
     return lhs._box._isEqual(to: rhs._box)
@@ -917,7 +779,6 @@ extension AnyIndex : Comparable {
   /// - Parameters:
   ///   - lhs: An index to compare.
   ///   - rhs: Another index to compare.
-  @inlinable
   public static func < (lhs: AnyIndex, rhs: AnyIndex) -> Bool {
     _precondition(lhs._typeID == rhs._typeID, "Base index types differ")
     return lhs._box._isLess(than: rhs._box)
@@ -945,10 +806,8 @@ protocol _AnyCollectionProtocol : Collection {
 /// collection.
 @_fixed_layout
 public struct ${Self}<Element> {
-  @usableFromInline
   internal let _box: _${Self}Box<Element>
 
-  @inlinable
   internal init(_box: _${Self}Box<Element>) {
     self._box = _box
   }
@@ -967,7 +826,6 @@ extension ${Self}: ${SelfProtocol} {
   /// - Parameter base: The collection to wrap.
   ///
   /// - Complexity: O(1).
-  @inlinable
   public init<C : ${SubProtocol}>(_ base: C) where C.Element == Element {
     // Traversal: ${Traversal}
     // SubTraversal: ${SubTraversal}
@@ -978,7 +836,6 @@ extension ${Self}: ${SelfProtocol} {
   /// Creates an `${Self}` having the same underlying collection as `other`.
   ///
   /// - Complexity: O(1)
-  @inlinable
   public init(_ other: Any${SubProtocol}<Element>) {
     self._box = other._box
   }
@@ -991,7 +848,6 @@ extension ${Self}: ${SelfProtocol} {
   /// `${SelfProtocol}`, the result is `nil`.
   ///
   /// - Complexity: O(1)
-  @inlinable
   public init?(_ other: Any${collectionForTraversal(SuperTraversal)}<Element>) {
     guard let box =
       other._box as? _${Self}Box<Element> else {
@@ -1004,7 +860,6 @@ extension ${Self}: ${SelfProtocol} {
   /// The position of the first element in a non-empty collection.
   ///
   /// In an empty collection, `startIndex == endIndex`.
-  @inlinable
   public var startIndex: Index {
     return AnyIndex(_box: _box._startIndex)
   }
@@ -1014,7 +869,6 @@ extension ${Self}: ${SelfProtocol} {
   ///
   /// `endIndex` is always reachable from `startIndex` by zero or more
   /// applications of `index(after:)`.
-  @inlinable
   public var endIndex: Index {
     return AnyIndex(_box: _box._endIndex)
   }
@@ -1023,37 +877,31 @@ extension ${Self}: ${SelfProtocol} {
   ///
   /// - Precondition: `position` indicates a valid position in `self` and
   ///   `position != endIndex`.
-  @inlinable
   public subscript(position: Index) -> Element {
     return _box[position._box]
   }
 
-  @inlinable
   public subscript(bounds: Range<Index>) -> SubSequence {
     return ${Self}(_box:
       _box[start: bounds.lowerBound._box, end: bounds.upperBound._box])
   }
 
-  @inlinable
   public func _failEarlyRangeCheck(_ index: Index, bounds: Range<Index>) {
     // Do nothing.  Doing a range check would involve unboxing indices,
     // performing dynamic dispatch etc.  This seems to be too costly for a fast
     // range check for QoI purposes.
   }
 
-  @inlinable
   public func _failEarlyRangeCheck(_ range: Range<Index>, bounds: Range<Index>) {
     // Do nothing.  Doing a range check would involve unboxing indices,
     // performing dynamic dispatch etc.  This seems to be too costly for a fast
     // range check for QoI purposes.
   }
 
-  @inlinable
   public func index(after i: Index) -> Index {
     return AnyIndex(_box: _box._index(after: i._box))
   }
 
-  @inlinable
   public func formIndex(after i: inout Index) {
     if _isUnique(&i._box) {
       _box._formIndex(after: i._box)
@@ -1063,12 +911,10 @@ extension ${Self}: ${SelfProtocol} {
     }
   }
 
-  @inlinable
   public func index(_ i: Index, offsetBy n: Int) -> Index {
     return AnyIndex(_box: _box._index(i._box, offsetBy: n))
   }
 
-  @inlinable
   public func index(
     _ i: Index, offsetBy n: Int, limitedBy limit: Index
   ) -> Index? {
@@ -1076,7 +922,6 @@ extension ${Self}: ${SelfProtocol} {
       .map { AnyIndex(_box:$0) }
   }
 
-  @inlinable
   public func formIndex(_ i: inout Index, offsetBy n: Int) {
     if _isUnique(&i._box) {
       return _box._formIndex(&i._box, offsetBy: n)
@@ -1085,7 +930,6 @@ extension ${Self}: ${SelfProtocol} {
     }
   }
 
-  @inlinable
   public func formIndex(
     _ i: inout Index,
     offsetBy n: Int,
@@ -1102,7 +946,6 @@ extension ${Self}: ${SelfProtocol} {
     return false
   }
 
-  @inlinable
   public func distance(from start: Index, to end: Index) -> Int {
     return _box._distance(from: start._box, to: end._box)
   }
@@ -1116,23 +959,19 @@ extension ${Self}: ${SelfProtocol} {
   ///
 % end
   /// - Complexity: ${'O(1)' if Traversal == 'RandomAccess' else 'O(*n*)'}
-  @inlinable
   public var count: Int {
     return _box._count
   }
 
-  @inlinable
   public var first: Element? {
     return _box._first
   }
 
 %   if Traversal == 'Bidirectional' or Traversal == 'RandomAccess':
-  @inlinable
   public func index(before i: Index) -> Index {
     return AnyIndex(_box: _box._index(before: i._box))
   }
 
-  @inlinable
   public func formIndex(before i: inout Index) {
     if _isUnique(&i._box) {
       _box._formIndex(before: i._box)
@@ -1142,7 +981,6 @@ extension ${Self}: ${SelfProtocol} {
     }
   }
 
-  @inlinable
   public var last: Element? {
     return _box._last
   }
@@ -1151,7 +989,6 @@ extension ${Self}: ${SelfProtocol} {
 
 extension ${Self}: _AnyCollectionProtocol {
   /// Uniquely identifies the stored underlying collection.
-  @inlinable
   public // Due to language limitations only
   var _boxID: ObjectIdentifier {
     return ObjectIdentifier(_box)

--- a/validation-test/Sema/type_checker_perf/fast/rdar22770433.swift
+++ b/validation-test/Sema/type_checker_perf/fast/rdar22770433.swift
@@ -3,7 +3,6 @@
 
 func test(n: Int) -> Int {
   return n == 0 ? 0 : (0..<n).reduce(0) {
-  // expected-error@-1 {{reasonable time}}
     ($0 > 0 && $1 % 2 == 0) ? (($0 + $1) / ($1 - $0)) : $0
   }
 }


### PR DESCRIPTION
Similar to #17476 but for `AnySequence` and friends. Many of these should be unnecessary since they're internal types/methods. Removing them all might hurt performance but lets start with this and add some back in where appropriate.