### PR TITLE
Fix Runtime/Syntax test failures.

### DIFF
--- a/test/Runtime/linux-fatal-backtrace.swift
+++ b/test/Runtime/linux-fatal-backtrace.swift
@@ -9,6 +9,14 @@
 // run when optimizations are enabled.
 // REQUIRES: swift_test_mode_optimize_none
 
+// SWIFT_ENABLE_TENSORFLOW
+// `utils/symbolicate-linux-fatal` fails with TensorFlow support because
+// libtensorflow.so is not linked properly. `import lldb` causes an import
+// error:
+// "ImportError: libtensorflow.so: cannot open shared object file"
+// The lldb swig setup scripts should be edited to fix this.
+// UNSUPPORTED: tensorflow
+
 func funcB() {
     fatalError("linux-fatal-backtrace");
 }

--- a/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
+++ b/test/Syntax/Outputs/round_trip_parse_gen.swift.withkinds
@@ -548,9 +548,7 @@ func foo<FunctionSignature><ParameterClause>() </ParameterClause></FunctionSigna
 
 #sourceLocation()</PoundSourceLocation>
 
-"<StringSegment>abc </StringSegment>\( } )<StringSegment> def</StringSegment>"
-
-@_alignment(16) </Attribute><DeclModifier>public </DeclModifier>struct float3 <MemberDeclBlock>{ <MemberDeclListItem><VariableDecl><DeclModifier>public </DeclModifier>var <PatternBinding><IdentifierPattern>x</IdentifierPattern>, </PatternBinding><PatternBinding><IdentifierPattern>y</IdentifierPattern>, </PatternBinding><PatternBinding><IdentifierPattern>z</IdentifierPattern><TypeAnnotation>: <SimpleTypeIdentifier>Float </SimpleTypeIdentifier></TypeAnnotation></PatternBinding></VariableDecl></MemberDeclListItem>}</MemberDeclBlock></StructDecl><FunctionDecl><Attribute>
+"<StringSegment>abc </StringSegment>\( } )<StringSegment> def</StringSegment>"<FunctionDecl><Attribute>
 
 // SWIFT_ENABLE_TENSORFLOW
 @differentiable(<DifferentiableAttributeArguments>reverse, <DifferentiableAttributeFuncSpecifier>adjoint: foo<DeclNameArguments>(<DeclNameArgument>_:</DeclNameArgument><DeclNameArgument>_:</DeclNameArgument>)</DeclNameArguments></DifferentiableAttributeFuncSpecifier></DifferentiableAttributeArguments>)</Attribute>


### PR DESCRIPTION
**Runtime/linux-fatal-backtrace.swift:**

`utils/symbolicate-linux-fatal` fails with TensorFlow support because
libtensorflow.so is not linked properly.

`import lldb` causes an import error:
`"ImportError: libtensorflow.so: cannot open shared object file"`

The lldb swig setup scripts should be edited to fix this.

---

**Syntax/round_trip_parse_gen.swift test:**

The content of `round_trip_parse_gen.swift` changed, requiring the corresponding Outputs file to be updated.