### PR TITLE
Remove stale references to '@_semantics(optimize.sil.preserve_exclusi…

### DIFF
--- a/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
@@ -18,13 +18,6 @@
 /// This is an always-on pass for temporary bootstrapping. It allows running
 /// test cases through the pipeline and exercising SIL verification before all
 /// passes support access markers.
-///
-/// This must only run before inlining _semantic calls. If we inline and drop
-/// the @_semantics("optimize.sil.preserve_exclusivity") attribute, the inlined
-/// markers will be eliminated, but the noninlined markers will not. This would
-/// result in inconsistent begin/end_unpaired_access resulting in unpredictable,
-/// potentially catastrophic runtime behavior.
-///
 //===----------------------------------------------------------------------===//
 
 #define DEBUG_TYPE "access-marker-elim"

--- a/test/IRGen/preserve_exclusivity.swift
+++ b/test/IRGen/preserve_exclusivity.swift
@@ -32,7 +32,6 @@ public func endAccess(_ address: Builtin.RawPointer) {
 // CHECK-LABEL: define {{.*}}swiftcc void @"$S20preserve_exclusivity10readAccessyyBp_xmtlF"(i8*, %swift.type*{{.*}}, %swift.type*{{.*}} %T1)
 // CHECK:   call void @swift_beginAccess
 // CHECK: ret void
-@_semantics("optimize.sil.preserve_exclusivity")
 public func readAccess<T1>(_ address: Builtin.RawPointer, _ ty1: T1.Type) {
   marker3()
   Builtin.performInstantaneousReadAccess(address, ty1);


### PR DESCRIPTION
…vity)'.
