### PR TITLE
Fixed a bug when lowering a while loop involving recvFromHost at

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
+++ b/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp
@@ -137,7 +137,7 @@ namespace {
     /// This is a list of all of the operations that make up this function.
     std::vector<const TF_Operation*> operations;
 
-    // When true, lower effectful ops (e.g. Swift->TF send ops), if any, in the
+    // When true, lower effectful ops (e.g. TF->Swift send ops), if any, in the
     // corresponding TF function. Currently in a While op context, these ops
     // should not be run in the cond function.
     // TODO(b/78472806): Add a more thorough and proper fix for effectful ops in
@@ -960,7 +960,13 @@ void TFGraphLowering::visitBuiltinRecvFromHostInst(SILTensorOpInfo &tfopInfo) {
   auto &graphFn = getCurrentGraphFunction();
   // TODO(b/78472806): Add a more thorough and proper fix for effectful ops in
   // the while cond function.
-  if (!graphFn.shouldLowerEffectfulOps) return;
+  if (!graphFn.shouldLowerEffectfulOps) {
+    internalError(
+        getUserSourceLocation(tfopInfo.inst->getDebugLocation()),
+        "FIXME: cannot lower a Host->TF tensor transfer in a loop header",
+        diag::tfop_invalid_tfop);
+    return;
+  }
 
   // Type check and process the parameters.
   // recvFromHost has type <T> (tensorId$int, device$string) -> (T)

--- a/test/TensorFlow/sends_recvs.swift
+++ b/test/TensorFlow/sends_recvs.swift
@@ -319,3 +319,19 @@ public func test1RecvTensor() {
 // CHECK-NEXT: [[SEND_FN:%.*]] = function_ref
 // CHECK-NEXT: apply [[SEND_FN]]<Float>({{.*}}, {{.*}}, [[B_HANDLE]])
 // CHECK:      function_ref @_swift_tfc_FinishTensorComputation
+
+public func testRecvsInALoop() {
+  let maxCount = 10
+  var count = 1
+  var a = Tensor<Float>(1.0)
+  while count < maxCount {
+    // One recv.
+    // expected-error @+1 {{tfop invalid: FIXME: cannot lower a Host->TF tensor transfer in a loop header}}
+    let b = atariSim(a.toHost()).toAccelerator()
+    a += b
+    count += 1
+  }
+  a += a
+  // This one should not be a send.
+  _hostOp(a.toHost())
+}


### PR DESCRIPTION
`TFGraphLowering::visitBuiltinRecvFromHostInst()`. We cannot simply skip the
lowering, since that'll cause the lowering of a subsequent instruction which
consumes the recv'ed value to hit the assertion:

> swift: /usr/local/google/home/hongm/ssd_part/git/swift-base/swift/lib/SILOptimizer/Mandatory/TFLowerGraph.cpp:478: TF_Output (anonymous namespace)::TFGraphLowering::getOperandValue(SILOpResult): Assertion `valueInfo.first.oper != nullptr && "didn't find live-in value?"' failed.

Instead added an internal error as suggested by @lattner, and added a test case
to confirm that it'll trigger this internal error instead of the assertion
failure above.

Overall, the graphFn.shouldLowerEffectfulOps based mechanism is a hack to allow
us to compile some of the stateful computation (e.g. sending tensor from TF to
Swift host) within a loop body. It should be replaced with the more proper fix
based on loop rotation.
