### PR TITLE
[master-next] Take 3 on adjusting to LLVM r335407 splitting Intrinsics.inc

### DIFF
--- a/lib/AST/Builtins.cpp
+++ b/lib/AST/Builtins.cpp
@@ -1251,7 +1251,7 @@ inline bool isBuiltinTypeOverloaded(Type T, OverloadedBuiltinKind OK) {
 static const char *const IntrinsicNameTable[] = {
     "not_intrinsic",
 #define GET_INTRINSIC_NAME_TABLE
-#include "llvm/IR/IntrinsicEnums.inc"
+#include "llvm/IR/IntrinsicImpl.inc"
 #undef GET_INTRINSIC_NAME_TABLE
 };
 


### PR DESCRIPTION
There were only 2 places to update and I got them both wrong... We need
the IntrinsicImpl.inc file in both places. I've actually tested it this
time.