### PR TITLE
[Mangling] Several fixes for de/re/-mangling of generic typealiases

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -197,6 +197,15 @@ protected:
 
   void appendBoundGenericArgs(Type type, bool &isFirstArgList);
 
+  /// Append the bound generics arguments for the given declaration context
+  /// based on a complete substitution map.
+  ///
+  /// \returns the number of generic parameters that were emitted
+  /// thus far.
+  unsigned appendBoundGenericArgs(DeclContext *dc,
+                                  SubstitutionMap subs,
+                                  bool &isFirstArgList);
+
   /// Append any retroactive conformances.
   void appendRetroactiveConformances(Type type);
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/Initializer.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ParameterList.h"
+#include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/ProtocolConformanceRef.h"
 #include "swift/Basic/Defer.h"
@@ -380,6 +381,9 @@ std::string ASTMangler::mangleReabstractionThunkHelper(
 
 std::string ASTMangler::mangleTypeForDebugger(Type Ty, const DeclContext *DC,
                                               GenericEnvironment *GE) {
+  PrettyStackTraceType prettyStackTrace(Ty->getASTContext(),
+                                        "mangling type for debugger", Ty);
+
   GenericEnv = GE;
   DWARFMangling = true;
   beginMangling();
@@ -746,17 +750,13 @@ void ASTMangler::appendType(Type type) {
         return appendType(aliasTy->getSinglyDesugaredType());
       }
 
-      if (type->isSpecialized()) {
+      if (aliasTy->getSubstitutionMap().hasAnySubstitutableParams()) {
         // Try to mangle the entire name as a substitution.
         if (tryMangleSubstitution(tybase))
           return;
 
         appendAnyGenericType(decl);
         bool isFirstArgList = true;
-        if (auto *nominalType = type->getAs<NominalType>()) {
-          if (nominalType->getParent())
-            type = nominalType->getParent();
-        }
         appendBoundGenericArgs(type, isFirstArgList);
         appendRetroactiveConformances(type);
         appendOperator("G");
@@ -1039,16 +1039,68 @@ void ASTMangler::bindGenericParameters(const DeclContext *DC) {
     bindGenericParameters(sig->getCanonicalSignature());
 }
 
+unsigned ASTMangler::appendBoundGenericArgs(DeclContext *dc,
+                                            SubstitutionMap subs,
+                                            bool &isFirstArgList) {
+  auto decl = dc->getInnermostDeclarationDeclContext();
+  if (!decl) return 0;
+
+  // Handle the generic arguments of the parent.
+  unsigned currentGenericParamIdx =
+    appendBoundGenericArgs(decl->getDeclContext(), subs, isFirstArgList);
+
+  // If this is potentially a generic context, emit a generic argument list.
+  if (auto genericContext = decl->getAsGenericContext()) {
+    if (isFirstArgList) {
+      appendOperator("y");
+      isFirstArgList = false;
+    } else {
+      appendOperator("_");
+    }
+
+    // If we are generic at this level, emit all of the replacements at
+    // this level.
+    if (genericContext->isGeneric()) {
+      auto genericParams = subs.getGenericSignature()->getGenericParams();
+      unsigned depth = genericParams[currentGenericParamIdx]->getDepth();
+      assert(genericContext->getGenericParams()->getDepth() == depth &&
+             "Depth mismatch mangling substitution map");
+      auto replacements = subs.getReplacementTypes();
+      for (unsigned lastGenericParamIdx = genericParams.size();
+           (currentGenericParamIdx != lastGenericParamIdx &&
+            genericParams[currentGenericParamIdx]->getDepth() == depth);
+           ++currentGenericParamIdx) {
+        Type replacementType = replacements[currentGenericParamIdx];
+        if (replacementType->hasArchetype())
+          replacementType = replacementType->mapTypeOutOfContext();
+
+        appendType(replacementType);
+      }
+    }
+  }
+
+  return currentGenericParamIdx;
+}
+
 void ASTMangler::appendBoundGenericArgs(Type type, bool &isFirstArgList) {
-  BoundGenericType *boundType = nullptr;
-  if (auto *unboundType = type->getAs<UnboundGenericType>()) {
+  TypeBase *typePtr = type.getPointer();
+  ArrayRef<Type> genericArgs;
+  if (auto *typeAlias = dyn_cast<NameAliasType>(typePtr)) {
+    appendBoundGenericArgs(typeAlias->getDecl(),
+                           typeAlias->getSubstitutionMap(),
+                           isFirstArgList);
+    return;
+  }
+
+  if (auto *unboundType = dyn_cast<UnboundGenericType>(typePtr)) {
     if (Type parent = unboundType->getParent())
       appendBoundGenericArgs(parent, isFirstArgList);
-  } else if (auto *nominalType = type->getAs<NominalType>()) {
+  } else if (auto *nominalType = dyn_cast<NominalType>(typePtr)) {
     if (Type parent = nominalType->getParent())
       appendBoundGenericArgs(parent, isFirstArgList);
   } else {
-    boundType = type->castTo<BoundGenericType>();
+    auto boundType = cast<BoundGenericType>(typePtr);
+    genericArgs = boundType->getGenericArgs();
     if (Type parent = boundType->getParent())
       appendBoundGenericArgs(parent, isFirstArgList);
   }
@@ -1058,10 +1110,8 @@ void ASTMangler::appendBoundGenericArgs(Type type, bool &isFirstArgList) {
   } else {
     appendOperator("_");
   }
-  if (boundType) {
-    for (Type arg : boundType->getGenericArgs()) {
-      appendType(arg);
-    }
+  for (Type arg : genericArgs) {
+    appendType(arg);
   }
 }
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -1045,6 +1045,12 @@ unsigned ASTMangler::appendBoundGenericArgs(DeclContext *dc,
   auto decl = dc->getInnermostDeclarationDeclContext();
   if (!decl) return 0;
 
+  // For an extension declaration, use the nominal type declaration instead.
+  // This is important when extending a nested type, because the generic
+  // parameters will line up with the (semantic) nesting of the nominal type.
+  if (auto ext = dyn_cast<ExtensionDecl>(decl))
+    decl = ext->getAsNominalTypeOrNominalTypeExtensionContext();
+
   // Handle the generic arguments of the parent.
   unsigned currentGenericParamIdx =
     appendBoundGenericArgs(decl->getDeclContext(), subs, isFirstArgList);

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -1243,11 +1243,7 @@ void Remangler::mangleBuiltinTypeName(Node *node) {
 }
 
 void Remangler::mangleTypeAlias(Node *node, EntityContext &ctx) {
-  SubstitutionEntry entry;
-  if (trySubstitution(node, entry)) return;
-  Out << 'a';
-  mangleChildNodes(node); // context, identifier
-  addSubstitution(entry);
+  mangleAnyNominalType(node, ctx);
 }
 
 void Remangler::mangleFunctionType(Node *node) {
@@ -1823,6 +1819,9 @@ void Remangler::mangleAnyNominalType(Node *node, EntityContext &ctx) {
     break;
   case Node::Kind::Class:
     mangleNominalType(node, 'C', ctx);
+    break;
+  case Node::Kind::TypeAlias:
+    mangleNominalType(node, 'a', ctx);
     break;
   default:
     unreachable("bad nominal type kind");

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -248,10 +248,10 @@ class Remangler {
   }
 
   void manglePureProtocol(Node *Proto) {
+    Proto = skipType(Proto);
     if (mangleStandardSubstitution(Proto))
       return;
     
-    Proto = skipType(Proto);
     mangleChildNodes(Proto);
   }
 

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -474,6 +474,7 @@ void Remangler::mangleGenericArgs(Node *node, char &Separator) {
     case Node::Kind::Structure:
     case Node::Kind::Enum:
     case Node::Kind::Class:
+    case Node::Kind::TypeAlias:
       mangleGenericArgs(node->getChild(0), Separator);
       Buffer << Separator;
       Separator = '_';
@@ -1712,7 +1713,7 @@ void Remangler::mangleType(Node *node) {
 }
 
 void Remangler::mangleTypeAlias(Node *node) {
-  mangleAnyGenericType(node, "a");
+  mangleAnyNominalType(node);
 }
 
 void Remangler::mangleTypeList(Node *node) {
@@ -2057,6 +2058,7 @@ bool Demangle::isSpecialized(Node *node) {
     case Node::Kind::Structure:
     case Node::Kind::Enum:
     case Node::Kind::Class:
+    case Node::Kind::TypeAlias:
     case Node::Kind::OtherNominalType:
       return isSpecialized(node->getChild(0));
 
@@ -2073,6 +2075,7 @@ NodePointer Demangle::getUnspecialized(Node *node, NodeFactory &Factory) {
     case Node::Kind::Structure:
     case Node::Kind::Enum:
     case Node::Kind::Class:
+    case Node::Kind::TypeAlias:
     case Node::Kind::OtherNominalType: {
       NodePointer result = Factory.createNode(node->getKind());
       NodePointer parentOrModule = node->getChild(0);

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -778,8 +778,24 @@ static void VisitNodeGenericTypealias(ASTContext *ast,
   auto *genericTypeAlias =
       cast<TypeAliasDecl>(generic_type_result._decls.front());
   GenericSignature *signature = genericTypeAlias->getGenericSignature();
-  if (template_types_result._types.size() != signature->getGenericParams().size())
+  if (signature &&
+      template_types_result._types.size() !=
+        signature->getGenericParams().size()) {
+    result._error = stringWithFormat(
+        "wrong number of generic arguments (%d) for generic typealias %s; "
+        "expected %d",
+        template_types_result._types.size(),
+        genericTypeAlias->getBaseName().userFacingName(),
+        signature->getGenericParams().size());
+
     return;
+  }
+
+  if (signature && signature->getNumConformanceRequirements() != 0) {
+    result._error =
+      "cannot handle generic typealias with conformance requirements";
+    return;
+  }
 
   // FIXME: handle conformances.
   SubstitutionMap subMap;

--- a/lib/IDE/TypeReconstruction.cpp
+++ b/lib/IDE/TypeReconstruction.cpp
@@ -772,13 +772,15 @@ static void VisitNodeGenericTypealias(ASTContext *ast,
   }
 
   if (generic_type_result._decls.size() != 1 ||
-      generic_type_result._types.size() != 1 ||
-      template_types_result._types.empty())
+      generic_type_result._types.size() != 1)
     return;
 
   auto *genericTypeAlias =
       cast<TypeAliasDecl>(generic_type_result._decls.front());
   GenericSignature *signature = genericTypeAlias->getGenericSignature();
+  if (template_types_result._types.size() != signature->getGenericParams().size())
+    return;
+
   // FIXME: handle conformances.
   SubstitutionMap subMap;
   if (signature)

--- a/test/DebugInfo/DumpDeclFromMangledName.swift
+++ b/test/DebugInfo/DumpDeclFromMangledName.swift
@@ -49,6 +49,16 @@ class Foo<T> {
 
 typealias Patatino<T> = Foo<T>
 
+public struct Outer<T> {
+  public struct Inner { }
+
+  public typealias Foo<U> = Outer<U>.Inner
+
+  public func blah() {
+    let foo: Foo<Int> = Outer<Int>.Inner()
+  }
+}
+
 func main() -> Int {
   var p : Patatino<Int> = Patatino(23);
   return 0

--- a/test/DebugInfo/DumpDeclFromMangledName.swift
+++ b/test/DebugInfo/DumpDeclFromMangledName.swift
@@ -51,11 +51,20 @@ typealias Patatino<T> = Foo<T>
 
 public struct Outer<T> {
   public struct Inner { }
+  public struct GenericInner<U> { }
 
   public typealias Foo<U> = Outer<U>.Inner
 
   public func blah() {
     let foo: Foo<Int> = Outer<Int>.Inner()
+  }
+}
+
+extension Outer.GenericInner {
+  public typealias Bar = Int
+
+  public func useBar() {
+    let bar: Bar = 7
   }
 }
 

--- a/test/DebugInfo/DumpTypeFromMangledName.swift
+++ b/test/DebugInfo/DumpTypeFromMangledName.swift
@@ -32,6 +32,16 @@ class Foo<T> {
 
 typealias Patatino<T> = Foo<T>
 
+public struct Outer<T> {
+  public struct Inner { }
+
+  public typealias Foo<U> = Outer<U>.Inner
+
+  public func blah() {
+    let foo: Foo<Int> = Outer<Int>.Inner()
+  }
+}
+
 func main() -> Int {
   struct patatino {}
   var p : Patatino<Int> = Patatino(23);

--- a/test/DebugInfo/Inputs/decl-reconstr-names.txt
+++ b/test/DebugInfo/Inputs/decl-reconstr-names.txt
@@ -2,3 +2,4 @@ $S12DeclReconstr8patatinoSiyF ---> func patatino() -> Int
 $S12DeclReconstr1SVACycfC ---> init()
 $S12DeclReconstr8PatatinoaySiGD ---> typealias Patatino<T> = Foo<T>
 $S12DeclReconstr5OuterV3Fooayx_SiGD ---> Can't resolve decl of $S12DeclReconstr5OuterV3Fooayx_SiGD
+$S12DeclReconstr5OuterV12GenericInnerV3Barayx_qd___GD ---> typealias Bar = Int

--- a/test/DebugInfo/Inputs/decl-reconstr-names.txt
+++ b/test/DebugInfo/Inputs/decl-reconstr-names.txt
@@ -1,3 +1,4 @@
 $S12DeclReconstr8patatinoSiyF ---> func patatino() -> Int
 $S12DeclReconstr1SVACycfC ---> init()
 $S12DeclReconstr8PatatinoaySiGD ---> typealias Patatino<T> = Foo<T>
+$S12DeclReconstr5OuterV3Fooayx_SiGD ---> Can't resolve decl of $S12DeclReconstr5OuterV3Fooayx_SiGD

--- a/test/DebugInfo/Inputs/type-reconstr-names.txt
+++ b/test/DebugInfo/Inputs/type-reconstr-names.txt
@@ -11,3 +11,4 @@ $SSayypXpG ---> Array<Any.Type>
 $S12EyeCandyCore11XPCListenerC14messageHandleryyAA13XPCConnectionV_AA10XPCMessageVxtcvpfiyAF_AHxtcfU_TA.4 ---> Can't resolve type of $S12EyeCandyCore11XPCListenerC14messageHandleryyAA13XPCConnectionV_AA10XPCMessageVxtcvpfiyAF_AHxtcfU_TA.4
 $Ss10CollectionP7ElementQa ---> Can't resolve type of $Ss10CollectionP7ElementQa
 $S12TypeReconstr8patatinoayAA5tinkyVGSgD ---> Optional<patatino>
+$S12TypeReconstr5OuterV3Fooayx_SiGD ---> Can't resolve type of $S12TypeReconstr5OuterV3Fooayx_SiGD

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -313,5 +313,5 @@ _$S3BBBBf0602365061_ ---> _$S3BBBBf0602365061_
 _$S3BBBBi0602365061_ ---> _$S3BBBBi0602365061_
 _$S3BBBBv0602365061_ ---> _$S3BBBBv0602365061_
 _T0lxxxmmmTk ---> _T0lxxxmmmTk
-$S4blah8PatatinoaySiGD -> blah.Patatino<Swift.Int>
-
+$S4blah8PatatinoaySiGD ---> blah.Patatino<Swift.Int>
+$SSiSHsWP ---> protocol witness table for Swift.Int : Swift.Hashable in Swift

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -315,3 +315,5 @@ _$S3BBBBv0602365061_ ---> _$S3BBBBv0602365061_
 _T0lxxxmmmTk ---> _T0lxxxmmmTk
 $S4blah8PatatinoaySiGD ---> blah.Patatino<Swift.Int>
 $SSiSHsWP ---> protocol witness table for Swift.Int : Swift.Hashable in Swift
+$S7TestMod5OuterV3Fooayx_SiGD ---> TestMod.Outer<A>.Foo<Swift.Int>
+$Ss17_VariantSetBufferO05CocoaC0ayx_GD ---> Swift._VariantSetBuffer<A>.CocoaBuffer

--- a/test/SILOptimizer/array_contentof_opt.swift
+++ b/test/SILOptimizer/array_contentof_opt.swift
@@ -32,7 +32,7 @@ public func testThreeInts(_ a: inout [Int]) {
 
 // CHECK-LABEL: sil @{{.*}}testTooManyInts
 // CHECK-NOT: apply
-// CHECK:        [[F:%[0-9]+]] = function_ref  @$SSa6append10contentsOfyqd___t7ElementQyd__Rszs8SequenceRd__lFSi_SaySiGTg5
+// CHECK:        [[F:%[0-9]+]] = function_ref  @$SSa6append10contentsOfyqd___t7ElementQyd__RszSTRd__lFSi_SaySiGTg5
 // CHECK-NOT: apply
 // CHECK:        apply [[F]]
 // CHECK-NOT: apply

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -182,7 +182,7 @@ bb2:
 }
 
 // specialized divideNum<A where ...> (A, den : A) throws -> A
-// CHECK-LABEL: sil shared @$S16eager_specialize9divideNum_3denxx_xtKs13SignedIntegerRzlFSi_Tg5 : $@convention(thin) (Int, Int) -> (Int, @error Error) {
+// CHECK-LABEL: sil shared @$S16eager_specialize9divideNum_3denxx_xtKSZRzlFSi_Tg5 : $@convention(thin) (Int, Int) -> (Int, @error Error) {
 // CHECK: bb0(%0 : $Int, %1 : $Int):
 // CHECK: return %{{.*}}
 // CHECK: throw %{{.*}}
@@ -224,7 +224,7 @@ bb2:
 // CHECK:   %{{.*}} = unchecked_addr_cast %2 : $*T to $*Int
 // CHECK:   %{{.*}} = load %{{.*}} : $*Int
 // CHECK:   // function_ref specialized divideNum<A>(_:den:)
-// CHECK:   %{{.*}} = function_ref @$S16eager_specialize9divideNum_3denxx_xtKs13SignedIntegerRzlFSi_Tg5 : $@convention(thin) (Int, Int) -> (Int, @error Error)
+// CHECK:   %{{.*}} = function_ref @$S16eager_specialize9divideNum_3denxx_xtKSZRzlFSi_Tg5 : $@convention(thin) (Int, Int) -> (Int, @error Error)
 // CHECK:   try_apply %{{.*}}(%{{.*}}, %{{.*}}) : $@convention(thin) (Int, Int) -> (Int, @error Error), normal bb8, error bb7
 
 // CHECK: bb7(%{{.*}} : $Error):

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -192,6 +192,9 @@ int main(int argc, char **argv) {
   llvm::cl::opt<std::string> DumpTypeFromMangled(
       "type-from-mangled", llvm::cl::desc("dump type from mangled names list"));
 
+  llvm::cl::opt<std::string> ResourceDir("resource-dir",
+      llvm::cl::desc("The directory that holds the compiler resource files"));
+
   llvm::cl::ParseCommandLineOptions(argc, argv);
   // Unregister our options so they don't interfere with the command line
   // parsing in CodeGen/BackendUtil.cpp.
@@ -253,6 +256,10 @@ int main(int argc, char **argv) {
 
   Invocation.setModuleName("lldbtest");
   Invocation.getClangImporterOptions().ModuleCachePath = ModuleCachePath;
+
+  if (!ResourceDir.empty()) {
+    Invocation.setRuntimeResourcePath(ResourceDir);
+  }
 
   if (CI.setup(Invocation))
     return 1;


### PR DESCRIPTION
Introduce several fixes for mangling and remangling of generic typealiases:

* Mangle the generic arguments of a typealias type directly, rather than (incorrectly) mangling the generic arguments of the underlying nominal type, and also account for nested generic typealiases.
* Remangle generic typealiases the same way we remangle generic nominal types
* Aside: fix remangling of protocol references (we were missing substitutions)
* Type reconstruction: guard against demangling the wrong # of generic arguments. This is a hack to avoid crashing; a more complete fix requires deeper changes to the type reconstruction logic.

Should fix rdar://problem/41444286