### PR TITLE
[TF] Add BFloat16 type support

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -182,6 +182,7 @@ unsigned tf::convertSwiftTypeToTF(Type ty) {
       .Case("UInt64", TF_UINT64)
       .Case("Int8", TF_INT8)
       .Case("UInt8", TF_UINT8)
+      .Case("BFloat16", TF_BFLOAT16)
       .Case("Float", TF_FLOAT)
       .Case("Double", TF_DOUBLE)
       .Case("Int", is64(s) ? TF_INT64 : TF_INT32)

--- a/stdlib/public/TensorFlow/CompilerRuntime.swift
+++ b/stdlib/public/TensorFlow/CompilerRuntime.swift
@@ -415,6 +415,9 @@ internal func dumpCTensorHandleContent(
   case TF_FLOAT: dumpTensorContent(inputTensorHandle, Float.self)
   case TF_DOUBLE: dumpTensorContent(inputTensorHandle, Double.self)
   case TF_BOOL: dumpTensorContent(inputTensorHandle, Bool.self)
+  // TODO: Handle `TF_BFloat16`? BFloat16 does not have a host-side
+  // representation and cannot be printed directly. Consider calling into TF
+  // runtime.
   default: fatalError("Unsupported dtype \(dType)")
   }
 }

--- a/stdlib/public/TensorFlow/DataTypes.swift
+++ b/stdlib/public/TensorFlow/DataTypes.swift
@@ -302,6 +302,7 @@ extension UInt64 : AccelerableByTensorFlow {
 
 @_fixed_layout
 public struct BFloat16 {
+  @usableFromInline var data: Int16
   private init() {}
 }
 

--- a/stdlib/public/TensorFlow/DataTypes.swift
+++ b/stdlib/public/TensorFlow/DataTypes.swift
@@ -300,6 +300,38 @@ extension UInt64 : AccelerableByTensorFlow {
   }
 }
 
+public struct BFloat16 {
+  private init() {}
+}
+
+extension BFloat16 : AccelerableByTensorFlow {
+  public static var _tensorFlowDataType: _TensorDataType {
+    return _TensorDataType(TF_BFLOAT16)
+  }
+  @_silgen_name("__tf_get_scalar_or_die_BFloat16") @inline(never)
+  public static func _getScalarOrDie
+    (_ handle: TensorHandle<BFloat16>
+  ) -> BFloat16 {
+    return _TFGetScalarOrDieImpl(handle)
+  }
+  @_silgen_name("__tf_get_scalar_BFloat16") @inline(never)
+  public static func _getScalar(_ handle: TensorHandle<BFloat16>) -> BFloat16? {
+    return _TFGetScalarImpl(handle)
+  }
+  @_inlineable @inline(__always)
+  public static func _makeScalarTensor(
+    _ scalar: BFloat16
+  ) -> TensorHandle<BFloat16> {
+    return #tfop("tfc.scalarToTensor", scalar)
+  }
+  @_silgen_name("__tf_hoistable_BFloat16") @_optimize(none) @inline(never)
+  public static func _hoistableClosure(
+    _ fn: () -> TensorHandle<BFloat16>
+  ) -> TensorHandle<BFloat16> {
+    return fn()
+  }
+}
+
 extension Float : AccelerableByTensorFlow {
   public static var _tensorFlowDataType: _TensorDataType {
     return _TensorDataType(TF_FLOAT)

--- a/stdlib/public/TensorFlow/DataTypes.swift
+++ b/stdlib/public/TensorFlow/DataTypes.swift
@@ -302,7 +302,7 @@ extension UInt64 : AccelerableByTensorFlow {
 
 @_fixed_layout
 public struct BFloat16 {
-  @usableFromInline var data: Int16
+  @usableFromInline var data: Int16 = 0
   private init() {}
 }
 

--- a/stdlib/public/TensorFlow/DataTypes.swift
+++ b/stdlib/public/TensorFlow/DataTypes.swift
@@ -300,6 +300,7 @@ extension UInt64 : AccelerableByTensorFlow {
   }
 }
 
+@_fixed_layout
 public struct BFloat16 {
   private init() {}
 }


### PR DESCRIPTION
Wire up support for [bfloat16](https://en.wikipedia.org/wiki/Bfloat16_floating-point_format) floating point dtype. This type is `AccelerableByTensorFlow` and thus can be used as the scalar type of a `Tensor`.

```swift
struct BFloat16 { 
  private init() {}
}
```

`BFloat16` does not have a host-side representation - it's just an empty, non-initializable struct. 

TODO:
- Add tests for graph generation.
- Add runtime tests for TPU execution.