### PR TITLE
Move convertToTensorValueType from TFPartition to TFUtilities

### DIFF
--- a/lib/SILOptimizer/Mandatory/TFPartition.cpp
+++ b/lib/SILOptimizer/Mandatory/TFPartition.cpp
@@ -258,26 +258,6 @@ classifyPromotedScalarOp(SILInstruction *inst) {
   }
 }
 
-/// `ty` must be a valid TensorFlow element type "T", like Builtin.Int32. Turn
-/// it into a TensorHandle<T> type.
-static SILType convertToTensorValueType(Type ty, const ASTContext& ctx) {
-  assert(isValidTensorFlowElementType(ty));
-  auto decl = ctx.getTensorHandleDecl();
-  auto tensorType = BoundGenericClassType::get(decl, /*parent*/ Type(), ty);
-
-  return SILType::getPrimitiveObjectType(tensorType->getCanonicalType());
-}
-
-/// If the specified type is a TensorFlow value type, return it.  Otherwise, it
-/// must be a primitive type T.  In that case, wrap it to form TensorHandle<T>.
-static SILType convertToTensorValueType(SILType ty) {
-  // If this is already TensorHandle<T>, return it.
-  if (isTensorFlowValue(ty))
-    return ty;
-
-  return convertToTensorValueType(ty.getSwiftRValueType(), ty.getASTContext());
-}
-
 /// Returns true when this function must be entirely lowered to a TF graph
 /// function, with no host-side logic remaining (i.e., no sends/recvs, and no
 /// start/stop tensor computation on the host side). In other words, this

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -222,7 +222,7 @@ unsigned tf::convertSwiftTypeToTF(Type ty) {
 
 /// `ty` must be a valid TensorFlow element type "T", like Builtin.Int32. Turn
 /// it into a TensorHandle<T> type.
-SILType tf::convertToTensorValueType(Type ty, const ASTContext& ctx) {
+SILType tf::convertElementTypeToTensorValueType(Type ty, const ASTContext& ctx) {
   assert(isValidTensorFlowElementType(ty));
   auto decl = ctx.getTensorHandleDecl();
   auto tensorType = BoundGenericClassType::get(decl, /*parent*/ Type(), ty);
@@ -232,12 +232,13 @@ SILType tf::convertToTensorValueType(Type ty, const ASTContext& ctx) {
 
 /// If the specified type is a TensorFlow value type, return it.  Otherwise, it
 /// must be a primitive type T.  In that case, wrap it to form TensorHandle<T>.
-SILType tf::convertToTensorValueType(SILType ty) {
+SILType tf::convertElementTypeToTensorValueType(SILType ty) {
   // If this is already TensorHandle<T>, return it.
   if (isTensorFlowValue(ty))
     return ty;
 
-  return convertToTensorValueType(ty.getSwiftRValueType(), ty.getASTContext());
+  return convertElementTypeToTensorValueType(ty.getSwiftRValueType(),
+                                             ty.getASTContext());
 }
 
 /// Looks up a function in the current module. If it exists, returns it.

--- a/lib/SILOptimizer/Mandatory/TFUtilities.cpp
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.cpp
@@ -220,6 +220,26 @@ unsigned tf::convertSwiftTypeToTF(Type ty) {
   return 0;
 }
 
+/// `ty` must be a valid TensorFlow element type "T", like Builtin.Int32. Turn
+/// it into a TensorHandle<T> type.
+SILType tf::convertToTensorValueType(Type ty, const ASTContext& ctx) {
+  assert(isValidTensorFlowElementType(ty));
+  auto decl = ctx.getTensorHandleDecl();
+  auto tensorType = BoundGenericClassType::get(decl, /*parent*/ Type(), ty);
+
+  return SILType::getPrimitiveObjectType(tensorType->getCanonicalType());
+}
+
+/// If the specified type is a TensorFlow value type, return it.  Otherwise, it
+/// must be a primitive type T.  In that case, wrap it to form TensorHandle<T>.
+SILType tf::convertToTensorValueType(SILType ty) {
+  // If this is already TensorHandle<T>, return it.
+  if (isTensorFlowValue(ty))
+    return ty;
+
+  return convertToTensorValueType(ty.getSwiftRValueType(), ty.getASTContext());
+}
+
 /// Looks up a function in the current module. If it exists, returns it.
 /// Otherwise, attempt to link it from imported modules. Returns null if such
 /// function name does not exist.

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -241,11 +241,11 @@ private:
 
   /// `ty` must be a valid TensorFlow element type "T", like Builtin.Int32. Turn
   /// it into a TensorHandle<T> type.
-  SILType convertToTensorValueType(Type ty, const ASTContext& ctx);
+  SILType convertElementTypeToTensorValueType(Type ty, const ASTContext& ctx);
 
   /// If the specified type is a TensorFlow value type, return it.  Otherwise, it
   /// must be a primitive type T.  In that case, wrap it to form TensorHandle<T>.
-  SILType convertToTensorValueType(SILType ty);
+  SILType convertElementTypeToTensorValueType(SILType ty);
 
   /// Return true if the specified type is a valid tensor element type.  For
   /// example, int128 and pointers are not.

--- a/lib/SILOptimizer/Mandatory/TFUtilities.h
+++ b/lib/SILOptimizer/Mandatory/TFUtilities.h
@@ -239,6 +239,14 @@ private:
   /// LLVM Builtin type like Builtin.f32) into the TensorFlow TF_DataType value.
   unsigned convertSwiftTypeToTF(Type ty);
 
+  /// `ty` must be a valid TensorFlow element type "T", like Builtin.Int32. Turn
+  /// it into a TensorHandle<T> type.
+  SILType convertToTensorValueType(Type ty, const ASTContext& ctx);
+
+  /// If the specified type is a TensorFlow value type, return it.  Otherwise, it
+  /// must be a primitive type T.  In that case, wrap it to form TensorHandle<T>.
+  SILType convertToTensorValueType(SILType ty);
+
   /// Return true if the specified type is a valid tensor element type.  For
   /// example, int128 and pointers are not.
   ///


### PR DESCRIPTION
<!-- What's in this pull request? -->
Moves the convertToTensorValueType helper function from TFPartition.cpp to TFUtilities. 