### PR TITLE
[Docs] Fix a typo in docs/WindowsCrossCompile.md

### DIFF
--- a/docs/WindowsCrossCompile.md
+++ b/docs/WindowsCrossCompile.md
@@ -1,6 +1,6 @@
 # Cross-compiling Swift for Windows with `clang`
 
-This document describes how to cross compile Swift on Windows on a non-Windows
+This document describes how to cross compile Swift for Windows on a non-Windows
 host. For more context on the status of Swift on Windows in general, see
 [Getting Started with Swift on Windows](./Windows.md)
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
The line: "how to cross compile Swift on Windows" should read "how to cross compile Swift for Windows".  I believe this is a typo.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->
