### PR TITLE
[ConstExpr] Emit traceback when failing during nested call evaluation

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -218,6 +218,9 @@ WARNING(designated_init_in_cross_module_extension,none,
 NOTE(designated_init_c_struct_fix,none,
      "use \"self.init()\" to initialize the struct with zero values", ())
 
+NOTE(constexpr_called_from, none, "when called from here", ())
+NOTE(constexpr_not_evaluable, none,
+     "expression not evaluable as constant here", ())
 
 // SWIFT_ENABLE_TENSORFLOW
 // TensorFlow Support Diagnostics.
@@ -259,7 +262,6 @@ ERROR(tf_op_misuse, none,
       "%0", (StringRef))
 NOTE(tf_op_misuse_note, none,
      "%0", (StringRef))
-
 
 // Control flow diagnostics.
 ERROR(missing_return,none,

--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -63,6 +63,10 @@ enum class UnknownReason {
 /// symbolic values (e.g. to save memory).  It provides a simpler public
 /// interface though.
 class SymbolicValue {
+public:
+  struct UnknownInfo;
+
+private:
   enum RepresentationKind {
     /// This value is an alloc stack that is has not (yet) been initialized
     /// by flow-sensitive analysis.
@@ -111,11 +115,9 @@ class SymbolicValue {
   RepresentationKind representationKind : 8;
 
   union {
-    /// When the value is Unknown, this contains the value that was the
+    /// When the value is Unknown, this contains information about the
     /// unfoldable part of the computation.
-    ///
-    /// TODO: make this a more rich representation.
-    SILNode *unknown;
+    UnknownInfo *unknown;
 
     /// This is always a SILType with an object category.  This is the value
     /// of the underlying instance type, not the MetatypeType.
@@ -146,14 +148,20 @@ class SymbolicValue {
     AggregateSymbolicValue *aggregate;
   } value;
 
-  union {
-    UnknownReason unknown_reason;
-
-    // unsigned integer_bitwidth;
-    // ...
-  } aux;
-
 public:
+  /// When the value is Unknown, this contains information about the unfoldable
+  /// part of the computation.
+  struct UnknownInfo {
+    /// The value that was unfoldable.
+    SILNode *node;
+
+    /// A more explanatory reason for the value being unknown.
+    UnknownReason reason;
+
+    /// The call stack while evaluating the unknown value.
+    llvm::SmallVector<SourceLoc, 4> call_stack;
+  };
+
   /// This enum is used to indicate the sort of value held by a SymbolicValue
   /// independent of its concrete representation.  This is the public
   /// interface to SymbolicValue.
@@ -194,12 +202,14 @@ public:
     return kind != Unknown && kind != UninitMemory;
   }
 
-  static SymbolicValue getUnknown(SILNode *node, UnknownReason reason) {
+  static SymbolicValue getUnknown(SILNode *node, UnknownReason reason,
+                                  llvm::ArrayRef<SourceLoc> callStack,
+                                  llvm::BumpPtrAllocator &allocator) {
     assert(node && "node must be present");
     SymbolicValue result;
     result.representationKind = RK_Unknown;
-    result.value.unknown = node;
-    result.aux.unknown_reason = reason;
+    result.value.unknown = new (allocator)
+        UnknownInfo{node, reason, {callStack.begin(), callStack.end()}};
     return result;
   }
 
@@ -207,9 +217,9 @@ public:
 
   /// Return information about an unknown result, including the SIL node that
   /// is a problem, and the reason it is an issue.
-  std::pair<SILNode *, UnknownReason> getUnknownValue() const {
+  const UnknownInfo &getUnknownInfo() const {
     assert(representationKind == RK_Unknown);
-    return {value.unknown, aux.unknown_reason};
+    return *value.unknown;
   }
 
   static SymbolicValue getUninitMemory() {

--- a/include/swift/SIL/SILConstants.h
+++ b/include/swift/SIL/SILConstants.h
@@ -54,7 +54,6 @@ enum class UnknownReason {
   Trap,
 };
 
-
 /// This is the symbolic value tracked for each SILValue in a scope.  We
 /// support multiple representational forms for the constant node in order to
 /// avoid pointless memory bloat + copying.  This is intended to be a
@@ -150,12 +149,11 @@ class SymbolicValue {
   union {
     UnknownReason unknown_reason;
 
-    //unsigned integer_bitwidth;
+    // unsigned integer_bitwidth;
     // ...
   } aux;
 
 public:
-
   /// This enum is used to indicate the sort of value held by a SymbolicValue
   /// independent of its concrete representation.  This is the public
   /// interface to SymbolicValue.
@@ -205,15 +203,13 @@ public:
     return result;
   }
 
-  bool isUnknown() const {
-    return getKind() == Unknown;
-  }
+  bool isUnknown() const { return getKind() == Unknown; }
 
   /// Return information about an unknown result, including the SIL node that
   /// is a problem, and the reason it is an issue.
   std::pair<SILNode *, UnknownReason> getUnknownValue() const {
     assert(representationKind == RK_Unknown);
-    return { value.unknown, aux.unknown_reason };
+    return {value.unknown, aux.unknown_reason};
   }
 
   static SymbolicValue getUninitMemory() {

--- a/lib/SIL/SILConstants.cpp
+++ b/lib/SIL/SILConstants.cpp
@@ -13,15 +13,15 @@
 // SWIFT_ENABLE_TENSORFLOW
 
 #include "swift/SIL/SILConstants.h"
-#include "swift/SIL/SILBuilder.h"
-#include "swift/Demangling/Demangle.h"
 #include "swift/AST/DiagnosticsSIL.h"
+#include "swift/Demangling/Demangle.h"
+#include "swift/SIL/SILBuilder.h"
 #include "llvm/Support/TrailingObjects.h"
 using namespace swift;
 
-template<typename...T, typename...U>
-static InFlightDiagnostic
-diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag, U &&...args) {
+template <typename... T, typename... U>
+static InFlightDiagnostic diagnose(ASTContext &Context, SourceLoc loc,
+                                   Diag<T...> diag, U &&... args) {
   return Context.Diags.diagnose(loc, diag, std::forward<U>(args)...);
 }
 
@@ -32,7 +32,9 @@ diagnose(ASTContext &Context, SourceLoc loc, Diag<T...> diag, U &&...args) {
 void SymbolicValue::print(llvm::raw_ostream &os, unsigned indent) const {
   os.indent(indent);
   switch (representationKind) {
-  case RK_UninitMemory: os << "uninit\n"; return;
+  case RK_UninitMemory:
+    os << "uninit\n";
+    return;
   case RK_Unknown: {
     std::pair<SILNode *, UnknownReason> unknown = getUnknownValue();
     os << "unknown(" << (int)unknown.second << "): ";
@@ -73,35 +75,41 @@ void SymbolicValue::print(llvm::raw_ostream &os, unsigned indent) const {
       return;
     } else if (elements.size() == 1) {
       os << "agg: 1 elt: ";
-      elements[0].print(os, indent+2);
+      elements[0].print(os, indent + 2);
       return;
     }
-    os << "agg: " << elements.size() << " element" << "s"[elements.size() == 1]
-       << " [\n";
+    os << "agg: " << elements.size() << " element"
+       << "s"[elements.size() == 1] << " [\n";
     for (auto elt : elements)
-      elt.print(os, indent+2);
+      elt.print(os, indent + 2);
     os.indent(indent) << "]\n";
     return;
   }
   }
 }
 
-void SymbolicValue::dump() const {
-  print(llvm::errs());
-}
+void SymbolicValue::dump() const { print(llvm::errs()); }
 
 /// For constant values, return the classification of this value.  We have
 /// multiple forms for efficiency, but provide a simpler interface to clients.
 SymbolicValue::Kind SymbolicValue::getKind() const {
   switch (representationKind) {
-  case RK_UninitMemory: return UninitMemory;
-  case RK_Unknown:      return Unknown;
-  case RK_Metatype:     return Metatype;
-  case RK_Function:     return Function;
-  case RK_Aggregate:    return Aggregate;
-  case RK_Integer:      return Integer;
-  case RK_Float:        return Float;
-  case RK_String:       return String;
+  case RK_UninitMemory:
+    return UninitMemory;
+  case RK_Unknown:
+    return Unknown;
+  case RK_Metatype:
+    return Metatype;
+  case RK_Function:
+    return Function;
+  case RK_Aggregate:
+    return Aggregate;
+  case RK_Integer:
+    return Integer;
+  case RK_Float:
+    return Float;
+  case RK_String:
+    return String;
   case RK_Inst:
     auto *inst = value.inst;
     if (isa<IntegerLiteralInst>(inst))
@@ -115,7 +123,8 @@ SymbolicValue::Kind SymbolicValue::getKind() const {
 
 /// Clone this SymbolicValue into the specified allocator and return the new
 /// version.  This only works for valid constants.
-SymbolicValue SymbolicValue::cloneInto(llvm::BumpPtrAllocator &allocator) const{
+SymbolicValue
+SymbolicValue::cloneInto(llvm::BumpPtrAllocator &allocator) const {
   switch (getKind()) {
   case SymbolicValue::Unknown:
   case SymbolicValue::UninitMemory:
@@ -141,8 +150,6 @@ SymbolicValue SymbolicValue::cloneInto(llvm::BumpPtrAllocator &allocator) const{
   }
 }
 
-
-
 //===----------------------------------------------------------------------===//
 // Integers
 //===----------------------------------------------------------------------===//
@@ -151,8 +158,8 @@ namespace swift {
 /// This is a representation of an integer value, stored as a trailing array
 /// of words.  Elements of this value are bump-pointer allocated.
 struct alignas(uint64_t) APIntSymbolicValue final
-  : private llvm::TrailingObjects<APIntSymbolicValue, uint64_t> {
-    friend class llvm::TrailingObjects<APIntSymbolicValue, uint64_t>;
+    : private llvm::TrailingObjects<APIntSymbolicValue, uint64_t> {
+  friend class llvm::TrailingObjects<APIntSymbolicValue, uint64_t>;
 
   /// The number of words in the trailing array and # bits of the value.
   const unsigned numWords, numBits;
@@ -161,7 +168,7 @@ struct alignas(uint64_t) APIntSymbolicValue final
                                     ArrayRef<uint64_t> elements,
                                     llvm::BumpPtrAllocator &allocator) {
     auto byteSize =
-      APIntSymbolicValue::totalSizeToAlloc<uint64_t>(elements.size());
+        APIntSymbolicValue::totalSizeToAlloc<uint64_t>(elements.size());
     auto rawMem = allocator.Allocate(byteSize, alignof(APIntSymbolicValue));
 
     //  Placement initialize the APIntSymbolicValue.
@@ -172,28 +179,26 @@ struct alignas(uint64_t) APIntSymbolicValue final
   }
 
   APInt getValue() const {
-    return APInt(numBits, { getTrailingObjects<uint64_t>(), numWords });
+    return APInt(numBits, {getTrailingObjects<uint64_t>(), numWords});
   }
 
   // This is used by the llvm::TrailingObjects base class.
-  size_t numTrailingObjects(OverloadToken<uint64_t>) const {
-    return numWords;
-  }
+  size_t numTrailingObjects(OverloadToken<uint64_t>) const { return numWords; }
+
 private:
   APIntSymbolicValue() = delete;
   APIntSymbolicValue(const APIntSymbolicValue &) = delete;
   APIntSymbolicValue(unsigned numBits, unsigned numWords)
-    : numWords(numWords), numBits(numBits) {}
+      : numWords(numWords), numBits(numBits) {}
 };
 } // end namespace swift
 
 SymbolicValue SymbolicValue::getInteger(const APInt &value,
                                         llvm::BumpPtrAllocator &allocator) {
   // TODO: Could store these inline in the union in the common case.
-  auto intValue =
-    APIntSymbolicValue::create(value.getBitWidth(),
-                               { value.getRawData(), value.getNumWords()},
-                               allocator);
+  auto intValue = APIntSymbolicValue::create(
+      value.getBitWidth(), {value.getRawData(), value.getNumWords()},
+      allocator);
   assert(intValue && "Integer value must be present");
   SymbolicValue result;
   result.representationKind = RK_Integer;
@@ -219,18 +224,18 @@ namespace swift {
 /// This is a representation of a floating point value, stored as a trailing
 /// array of words.  Elements of this value are bump-pointer allocated.
 struct alignas(uint64_t) APFloatSymbolicValue final
-  : private llvm::TrailingObjects<APFloatSymbolicValue, uint64_t> {
-    friend class llvm::TrailingObjects<APFloatSymbolicValue, uint64_t>;
+    : private llvm::TrailingObjects<APFloatSymbolicValue, uint64_t> {
+  friend class llvm::TrailingObjects<APFloatSymbolicValue, uint64_t>;
 
   const llvm::fltSemantics &semantics;
 
   static APFloatSymbolicValue *create(const llvm::fltSemantics &semantics,
-                                     ArrayRef<uint64_t> elements,
-                                     llvm::BumpPtrAllocator &allocator) {
-    assert((APFloat::getSizeInBits(semantics)+63)/64 == elements.size());
+                                      ArrayRef<uint64_t> elements,
+                                      llvm::BumpPtrAllocator &allocator) {
+    assert((APFloat::getSizeInBits(semantics) + 63) / 64 == elements.size());
 
     auto byteSize =
-      APFloatSymbolicValue::totalSizeToAlloc<uint64_t>(elements.size());
+        APFloatSymbolicValue::totalSizeToAlloc<uint64_t>(elements.size());
     auto rawMem = allocator.Allocate(byteSize, alignof(APFloatSymbolicValue));
 
     //  Placement initialize the APFloatSymbolicValue.
@@ -242,34 +247,31 @@ struct alignas(uint64_t) APFloatSymbolicValue final
 
   APFloat getValue() const {
     auto val = APInt(APFloat::getSizeInBits(semantics),
-                     { getTrailingObjects<uint64_t>(),
-                       numTrailingObjects(OverloadToken<uint64_t>())
-                     });
+                     {getTrailingObjects<uint64_t>(),
+                      numTrailingObjects(OverloadToken<uint64_t>())});
     return APFloat(semantics, val);
   }
 
   // This is used by the llvm::TrailingObjects base class.
   size_t numTrailingObjects(OverloadToken<uint64_t>) const {
-    return (APFloat::getSizeInBits(semantics)+63)/64;
+    return (APFloat::getSizeInBits(semantics) + 63) / 64;
   }
+
 private:
   APFloatSymbolicValue() = delete;
   APFloatSymbolicValue(const APFloatSymbolicValue &) = delete;
   APFloatSymbolicValue(const llvm::fltSemantics &semantics)
-    : semantics(semantics) {}
+      : semantics(semantics) {}
 };
 } // end namespace swift
-
 
 SymbolicValue SymbolicValue::getFloat(const APFloat &value,
                                       llvm::BumpPtrAllocator &allocator) {
   APInt val = value.bitcastToAPInt();
 
   // TODO: Could store these inline in the union in the common case.
-  auto fpValue =
-    APFloatSymbolicValue::create(value.getSemantics(),
-                                 { val.getRawData(), val.getNumWords()},
-                                 allocator);
+  auto fpValue = APFloatSymbolicValue::create(
+      value.getSemantics(), {val.getRawData(), val.getNumWords()}, allocator);
   assert(fpValue && "Floating point value must be present");
   SymbolicValue result;
   result.representationKind = RK_Float;
@@ -295,8 +297,8 @@ namespace swift {
 /// This is a representation of an UTF-8 encoded string, stored as a trailing
 /// array of bytes.  Elements of this value are bump-pointer allocated.
 struct alignas(uint64_t) StringSymbolicValue final
-  : private llvm::TrailingObjects<StringSymbolicValue, char> {
-    friend class llvm::TrailingObjects<StringSymbolicValue, char>;
+    : private llvm::TrailingObjects<StringSymbolicValue, char> {
+  friend class llvm::TrailingObjects<StringSymbolicValue, char>;
 
   /// The number of bytes in the trailing array.
   const unsigned numBytes;
@@ -314,20 +316,17 @@ struct alignas(uint64_t) StringSymbolicValue final
   }
 
   StringRef getValue() const {
-    return {
-      getTrailingObjects<char>(), numTrailingObjects(OverloadToken<char>())
-    };
+    return {getTrailingObjects<char>(),
+            numTrailingObjects(OverloadToken<char>())};
   }
 
   // This is used by the llvm::TrailingObjects base class.
-  size_t numTrailingObjects(OverloadToken<char>) const {
-    return numBytes;
-  }
+  size_t numTrailingObjects(OverloadToken<char>) const { return numBytes; }
+
 private:
   StringSymbolicValue() = delete;
   StringSymbolicValue(const StringSymbolicValue &) = delete;
-  StringSymbolicValue(unsigned numBytes) :
-    numBytes(numBytes) {}
+  StringSymbolicValue(unsigned numBytes) : numBytes(numBytes) {}
 };
 } // end namespace swift
 
@@ -364,16 +363,16 @@ namespace swift {
 /// element structs do not use this (as a performance optimization to reduce
 /// allocations).
 struct alignas(SymbolicValue) AggregateSymbolicValue final
-: private llvm::TrailingObjects<AggregateSymbolicValue, SymbolicValue> {
+    : private llvm::TrailingObjects<AggregateSymbolicValue, SymbolicValue> {
   friend class llvm::TrailingObjects<AggregateSymbolicValue, SymbolicValue>;
 
   /// This is the number of elements in the aggregate.
   const unsigned numElements;
 
   static AggregateSymbolicValue *create(ArrayRef<SymbolicValue> elements,
-                                       llvm::BumpPtrAllocator &allocator) {
-    auto byteSize =
-      AggregateSymbolicValue::totalSizeToAlloc<SymbolicValue>(elements.size());
+                                        llvm::BumpPtrAllocator &allocator) {
+    auto byteSize = AggregateSymbolicValue::totalSizeToAlloc<SymbolicValue>(
+        elements.size());
     auto rawMem = allocator.Allocate(byteSize, alignof(AggregateSymbolicValue));
 
     //  Placement initialize the AggregateSymbolicValue.
@@ -386,20 +385,20 @@ struct alignas(SymbolicValue) AggregateSymbolicValue final
   /// Return the element constants for this aggregate constant.  These are
   /// known to all be constants.
   ArrayRef<SymbolicValue> getElements() const {
-    return { getTrailingObjects<SymbolicValue>(), numElements };
+    return {getTrailingObjects<SymbolicValue>(), numElements};
   }
 
   // This is used by the llvm::TrailingObjects base class.
   size_t numTrailingObjects(OverloadToken<SymbolicValue>) const {
     return numElements;
   }
+
 private:
   AggregateSymbolicValue() = delete;
   AggregateSymbolicValue(const AggregateSymbolicValue &) = delete;
   AggregateSymbolicValue(unsigned numElements) : numElements(numElements) {}
 };
 } // end namespace swift
-
 
 /// This returns a constant Symbolic value with the specified elements in it.
 /// This assumes that the elements lifetime has been managed for this.
@@ -421,7 +420,6 @@ ArrayRef<SymbolicValue> SymbolicValue::getAggregateValue() const {
 //===----------------------------------------------------------------------===//
 // Higher level code
 //===----------------------------------------------------------------------===//
-
 
 /// The SIL location for operations we process are usually deep in the bowels
 /// of inlined code from opaque libraries, which are all implementation details
@@ -457,7 +455,8 @@ static SILDebugLocation skipInternalLocations(SILDebugLocation loc) {
 void SymbolicValue::emitUnknownDiagnosticNotes(SILLocation fallbackLoc) {
   std::pair<SILNode *, UnknownReason> unknown = getUnknownValue();
   auto badInst = dyn_cast<SILInstruction>(unknown.first);
-  if (!badInst) return;
+  if (!badInst)
+    return;
 
   std::string error;
   switch (unknown.second) {
@@ -484,15 +483,12 @@ void SymbolicValue::emitUnknownDiagnosticNotes(SILLocation fallbackLoc) {
   auto loc = skipInternalLocations(badInst->getDebugLocation()).getLocation();
   if (loc.isNull()) {
     // If we have important clarifying information, make sure to emit it.
-    if (unknown.second == UnknownReason::Default ||
-        fallbackLoc.isNull())
+    if (unknown.second == UnknownReason::Default || fallbackLoc.isNull())
       return;
     loc = fallbackLoc;
   }
 
-  diagnose(module.getASTContext(), loc.getSourceLoc(),
-           diag::tf_op_misuse_note, error)
-    .highlight(loc.getSourceRange());
+  diagnose(module.getASTContext(), loc.getSourceLoc(), diag::tf_op_misuse_note,
+           error)
+      .highlight(loc.getSourceRange());
 }
-
-

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.cpp
@@ -28,21 +28,19 @@ using namespace swift;
 using namespace tf;
 
 static llvm::cl::opt<unsigned>
-ConstExprLimit("constexpr-limit", llvm::cl::init(512),
-               llvm::cl::desc("Number of instructions interpreted in a"
-                              " constexpr function"));
+    ConstExprLimit("constexpr-limit", llvm::cl::init(512),
+                   llvm::cl::desc("Number of instructions interpreted in a"
+                                  " constexpr function"));
 
 static llvm::Optional<SymbolicValue>
 evaluateAndCacheCall(SILFunction &fn, SubstitutionMap substitutionMap,
                      ArrayRef<SymbolicValue> arguments,
                      SmallVectorImpl<SymbolicValue> &results,
-                     unsigned &numInstEvaluated,
-                     ConstExprEvaluator &evaluator);
+                     unsigned &numInstEvaluated, ConstExprEvaluator &evaluator);
 
 // TODO: ConstantTracker in the performance inliner and the
 // ConstantFolding.h/cpp files should be subsumed by this, as this is a more
 // general framework.
-
 
 // We have a list of functions that we hackily special case.  In order to keep
 // this localized, we use this classifier function.  This should be replaced
@@ -53,7 +51,6 @@ enum class WellKnownFunction {
   AssertionFailure, // _assertionFailure(_:_:file:line:flags:)
 };
 
-
 static WellKnownFunction classifyFunction(StringRef mangledName) {
   if (mangledName == "$SS2SycfC")
     return WellKnownFunction::StringInitEmpty;
@@ -63,102 +60,102 @@ static WellKnownFunction classifyFunction(StringRef mangledName) {
   return WellKnownFunction::Unknown;
 }
 
-
-
 //===----------------------------------------------------------------------===//
 // AddressValue implementation.
 //===----------------------------------------------------------------------===//
 
 namespace {
-  /// This is a representation of an address value, stored as a base ID plus
-  /// trailing array of indices.  Elements of this value are bump-pointer
-  /// allocated.
-  struct alignas(unsigned) DerivedAddressValue final
-  : private llvm::TrailingObjects<DerivedAddressValue, unsigned> {
-    friend class llvm::TrailingObjects<DerivedAddressValue, unsigned>;
+/// This is a representation of an address value, stored as a base ID plus
+/// trailing array of indices.  Elements of this value are bump-pointer
+/// allocated.
+struct alignas(unsigned) DerivedAddressValue final
+    : private llvm::TrailingObjects<DerivedAddressValue, unsigned> {
+  friend class llvm::TrailingObjects<DerivedAddressValue, unsigned>;
 
-    const unsigned objectID;
-    const unsigned numIndices;
+  const unsigned objectID;
+  const unsigned numIndices;
 
-    static DerivedAddressValue *create(unsigned objectID,
-                                        ArrayRef<unsigned> indices,
-                                        llvm::BumpPtrAllocator &allocator) {
-      auto byteSize =
+  static DerivedAddressValue *create(unsigned objectID,
+                                     ArrayRef<unsigned> indices,
+                                     llvm::BumpPtrAllocator &allocator) {
+    auto byteSize =
         DerivedAddressValue::totalSizeToAlloc<unsigned>(indices.size());
-      auto rawMem = allocator.Allocate(byteSize, alignof(DerivedAddressValue));
+    auto rawMem = allocator.Allocate(byteSize, alignof(DerivedAddressValue));
 
-      //  Placement initialize the AddressSymbolicValue.
-      auto alv = ::new (rawMem) DerivedAddressValue(objectID, indices.size());
-      std::uninitialized_copy(indices.begin(), indices.end(),
-                              alv->getTrailingObjects<unsigned>());
-      return alv;
-    }
+    //  Placement initialize the AddressSymbolicValue.
+    auto alv = ::new (rawMem) DerivedAddressValue(objectID, indices.size());
+    std::uninitialized_copy(indices.begin(), indices.end(),
+                            alv->getTrailingObjects<unsigned>());
+    return alv;
+  }
 
-    ArrayRef<unsigned> getIndices() const {
-      return { getTrailingObjects<unsigned>(), numIndices };
-    }
+  ArrayRef<unsigned> getIndices() const {
+    return {getTrailingObjects<unsigned>(), numIndices};
+  }
 
-    // This is used by the llvm::TrailingObjects base class.
-    size_t numTrailingObjects(OverloadToken<unsigned>) const {
-      return numIndices;
-    }
-  private:
-    DerivedAddressValue() = delete;
-    DerivedAddressValue(const DerivedAddressValue &) = delete;
-    DerivedAddressValue(unsigned objectID, unsigned numIndices)
+  // This is used by the llvm::TrailingObjects base class.
+  size_t numTrailingObjects(OverloadToken<unsigned>) const {
+    return numIndices;
+  }
+
+private:
+  DerivedAddressValue() = delete;
+  DerivedAddressValue(const DerivedAddressValue &) = delete;
+  DerivedAddressValue(unsigned objectID, unsigned numIndices)
       : objectID(objectID), numIndices(numIndices) {}
-  };
+};
 
-  /// AddressValue is our model for (possibly derived) SILValue pointers.  Given
-  /// a SILValue, we need to identify which slot in the MemoryObjects list they
-  /// reference, along with the accesspath (a sequence of struct_element_addr
-  /// and tuple_element_addr's) into the memory object.
-  ///
-  /// This is a small POD value that is intended to be stored in the value of a
-  /// DenseMap.
-  class AddressValue {
-    typedef llvm::PointerEmbeddedInt<unsigned, 31> InlineRepresentationTy;
-    // An address value is either a directly stored integer, or a pointer that
-    // holds an access path.
-    PointerUnion<InlineRepresentationTy, DerivedAddressValue*> value;
+/// AddressValue is our model for (possibly derived) SILValue pointers.  Given
+/// a SILValue, we need to identify which slot in the MemoryObjects list they
+/// reference, along with the accesspath (a sequence of struct_element_addr
+/// and tuple_element_addr's) into the memory object.
+///
+/// This is a small POD value that is intended to be stored in the value of a
+/// DenseMap.
+class AddressValue {
+  typedef llvm::PointerEmbeddedInt<unsigned, 31> InlineRepresentationTy;
+  // An address value is either a directly stored integer, or a pointer that
+  // holds an access path.
+  PointerUnion<InlineRepresentationTy, DerivedAddressValue *> value;
 
-    AddressValue(PointerUnion<InlineRepresentationTy,
-                              DerivedAddressValue*> value) : value(value) {}
-  public:
+  AddressValue(
+      PointerUnion<InlineRepresentationTy, DerivedAddressValue *> value)
+      : value(value) {}
 
-    static AddressValue get(unsigned objectID) {
-      auto val = InlineRepresentationTy(objectID);
-      return AddressValue(val);
-    }
+public:
+  static AddressValue get(unsigned objectID) {
+    auto val = InlineRepresentationTy(objectID);
+    return AddressValue(val);
+  }
 
-    static AddressValue get(unsigned objectID, ArrayRef<unsigned> indices,
-                            llvm::BumpPtrAllocator &allocator) {
-      if (indices.empty())
-        return get(objectID);
-      auto val = DerivedAddressValue::create(objectID, indices, allocator);
-      return AddressValue(val);
-    }
+  static AddressValue get(unsigned objectID, ArrayRef<unsigned> indices,
+                          llvm::BumpPtrAllocator &allocator) {
+    if (indices.empty())
+      return get(objectID);
+    auto val = DerivedAddressValue::create(objectID, indices, allocator);
+    return AddressValue(val);
+  }
 
-    /// Return the ID of the memory object being referenced.
-    unsigned getObjectID() const {
-      if (value.is<InlineRepresentationTy>())
-        return value.get<InlineRepresentationTy>();
-      return value.get<DerivedAddressValue*>()->objectID;
-    }
+  /// Return the ID of the memory object being referenced.
+  unsigned getObjectID() const {
+    if (value.is<InlineRepresentationTy>())
+      return value.get<InlineRepresentationTy>();
+    return value.get<DerivedAddressValue *>()->objectID;
+  }
 
-    /// Return the memory object of this reference along with any access path
-    /// indices involved.
-    unsigned getState(SmallVectorImpl<unsigned> &accessPath) const;
+  /// Return the memory object of this reference along with any access path
+  /// indices involved.
+  unsigned getState(SmallVectorImpl<unsigned> &accessPath) const;
 
-    void dump() const;
-  };
+  void dump() const;
+};
 } // end anonymous namespace
 
 unsigned AddressValue::getState(SmallVectorImpl<unsigned> &accessPath) const {
   if (value.is<InlineRepresentationTy>())
     return value.get<InlineRepresentationTy>();
 
-  auto derived = value.get<DerivedAddressValue*>();
+  auto derived = value.get<DerivedAddressValue *>();
   auto indices = derived->getIndices();
 
   accessPath.clear();
@@ -177,115 +174,110 @@ void AddressValue::dump() const {
   llvm::errs() << "\n";
 }
 
-
-
 //===----------------------------------------------------------------------===//
 // ConstExprFunctionState implementation.
 //===----------------------------------------------------------------------===//
 
 namespace {
-  /// This type represents the state of computed values within a function
-  /// as evaluation happens.  A separate instance of this is made for each
-  /// callee in a call chain to represent the constant values given the set of
-  /// formal parameters that callee was invoked with.
-  class ConstExprFunctionState {
-    /// This is the evaluator we put bump pointer allocated values into.
-    ConstExprEvaluator &evaluator;
+/// This type represents the state of computed values within a function
+/// as evaluation happens.  A separate instance of this is made for each
+/// callee in a call chain to represent the constant values given the set of
+/// formal parameters that callee was invoked with.
+class ConstExprFunctionState {
+  /// This is the evaluator we put bump pointer allocated values into.
+  ConstExprEvaluator &evaluator;
 
-    /// If we are analyzing the body of a constexpr function, this is the
-    /// function.  This is null for the top-level expression.
-    SILFunction *fn;
+  /// If we are analyzing the body of a constexpr function, this is the
+  /// function.  This is null for the top-level expression.
+  SILFunction *fn;
 
-    /// substitutionMap specifies a mapping from all of the protocol and type
-    /// requirements in the generic signature down to concrete conformances and
-    /// concrete types.
-    SubstitutionMap substitutionMap;
+  /// substitutionMap specifies a mapping from all of the protocol and type
+  /// requirements in the generic signature down to concrete conformances and
+  /// concrete types.
+  SubstitutionMap substitutionMap;
 
-    /// This keeps track of the number of instructions we've evaluated.  If this
-    /// goes beyond the execution cap, then we start returning unknown values.
-    unsigned &numInstEvaluated;
+  /// This keeps track of the number of instructions we've evaluated.  If this
+  /// goes beyond the execution cap, then we start returning unknown values.
+  unsigned &numInstEvaluated;
 
-    /// This is a state of previously analyzed values, maintained and filled in
-    /// by getConstantValue.  This does not hold SIL address values.
-    llvm::DenseMap<SILValue, SymbolicValue> calculatedValues;
+  /// This is a state of previously analyzed values, maintained and filled in
+  /// by getConstantValue.  This does not hold SIL address values.
+  llvm::DenseMap<SILValue, SymbolicValue> calculatedValues;
 
-    /// Memory objects tracked by the evaluator each get an entry in this array.
-    /// In addition to the current value, we track the type of the whole object.
-    SmallVector<std::pair<SymbolicValue, Type>, 8> memoryObjects;
+  /// Memory objects tracked by the evaluator each get an entry in this array.
+  /// In addition to the current value, we track the type of the whole object.
+  SmallVector<std::pair<SymbolicValue, Type>, 8> memoryObjects;
 
-    /// Each SIL address gets an entry in this mapping, indicating which memory
-    /// object it is addressing and any indices into that object.
-    llvm::DenseMap<SILValue, AddressValue> addressValues;
+  /// Each SIL address gets an entry in this mapping, indicating which memory
+  /// object it is addressing and any indices into that object.
+  llvm::DenseMap<SILValue, AddressValue> addressValues;
 
-  public:
-    ConstExprFunctionState(ConstExprEvaluator &evaluator, SILFunction *fn,
-                           SubstitutionMap substitutionMap,
-                           unsigned &numInstEvaluated)
+public:
+  ConstExprFunctionState(ConstExprEvaluator &evaluator, SILFunction *fn,
+                         SubstitutionMap substitutionMap,
+                         unsigned &numInstEvaluated)
       : evaluator(evaluator), fn(fn), substitutionMap(substitutionMap),
-        numInstEvaluated(numInstEvaluated) {
-    }
+        numInstEvaluated(numInstEvaluated) {}
 
-    void setValue(SILValue value, SymbolicValue symVal) {
-      assert(!value->getType().isAddress() &&
-             "addresses are tracked separately");
-      calculatedValues.insert({ value, symVal });
-    }
+  void setValue(SILValue value, SymbolicValue symVal) {
+    assert(!value->getType().isAddress() && "addresses are tracked separately");
+    calculatedValues.insert({value, symVal});
+  }
 
-    void setAddress(SILValue addr, AddressValue addrVal) {
-      assert(addr->getType().isAddress() && "values are tracked separately");
-      addressValues.insert({ addr, addrVal });
-    }
+  void setAddress(SILValue addr, AddressValue addrVal) {
+    assert(addr->getType().isAddress() && "values are tracked separately");
+    addressValues.insert({addr, addrVal});
+  }
 
-    AddressValue createMemoryObject(SILValue addr, SymbolicValue initialValue) {
-      unsigned objectID = memoryObjects.size();
-      auto objectType = simplifyType(addr->getType().getSwiftRValueType());
-      memoryObjects.push_back({initialValue, objectType});
+  AddressValue createMemoryObject(SILValue addr, SymbolicValue initialValue) {
+    unsigned objectID = memoryObjects.size();
+    auto objectType = simplifyType(addr->getType().getSwiftRValueType());
+    memoryObjects.push_back({initialValue, objectType});
 
-      auto result = AddressValue::get(objectID);
-      setAddress(addr, result);
-      return result;
-    }
+    auto result = AddressValue::get(objectID);
+    setAddress(addr, result);
+    return result;
+  }
 
-    /// In failure cases computing addresses, we want to return an address
-    /// pointing to a reason address computation failed.
-    AddressValue getUnknownAddress(SILValue addr, UnknownReason reason) {
-      return createMemoryObject(addr, SymbolicValue::getUnknown(addr, reason));
-    }
+  /// In failure cases computing addresses, we want to return an address
+  /// pointing to a reason address computation failed.
+  AddressValue getUnknownAddress(SILValue addr, UnknownReason reason) {
+    return createMemoryObject(addr, SymbolicValue::getUnknown(addr, reason));
+  }
 
-    /// Return the SymbolicValue for the specified SIL value, lazily computing
-    /// it if needed.
-    SymbolicValue getConstantValue(SILValue value);
+  /// Return the SymbolicValue for the specified SIL value, lazily computing
+  /// it if needed.
+  SymbolicValue getConstantValue(SILValue value);
 
-    /// Return the AddressValue for the specified SIL address, lazily computing
-    /// it if needed.
-    AddressValue getAddressValue(SILValue addr);
+  /// Return the AddressValue for the specified SIL address, lazily computing
+  /// it if needed.
+  AddressValue getAddressValue(SILValue addr);
 
-    /// Evaluate the specified instruction in a flow sensitive way, for use by
-    /// the constexpr function evaluator.  This does not handle control flow
-    /// statements.
-    llvm::Optional<SymbolicValue> evaluateFlowSensitive(SILInstruction *inst);
+  /// Evaluate the specified instruction in a flow sensitive way, for use by
+  /// the constexpr function evaluator.  This does not handle control flow
+  /// statements.
+  llvm::Optional<SymbolicValue> evaluateFlowSensitive(SILInstruction *inst);
 
-    Type simplifyType(Type ty);
-    CanType simplifyType(CanType ty) {
-      return simplifyType(Type(ty))->getCanonicalType();
-    }
-    SymbolicValue computeConstantValue(SILValue value);
-    SymbolicValue computeConstantValueBuiltin(BuiltinInst *inst);
+  Type simplifyType(Type ty);
+  CanType simplifyType(CanType ty) {
+    return simplifyType(Type(ty))->getCanonicalType();
+  }
+  SymbolicValue computeConstantValue(SILValue value);
+  SymbolicValue computeConstantValueBuiltin(BuiltinInst *inst);
 
-    AddressValue computeSingleStoreAddressValue(SILValue addr);
-    llvm::Optional<SymbolicValue> computeCallResult(ApplyInst *apply);
+  AddressValue computeSingleStoreAddressValue(SILValue addr);
+  llvm::Optional<SymbolicValue> computeCallResult(ApplyInst *apply);
 
-    llvm::Optional<SymbolicValue>
-    computeOpaqueCallResult(ApplyInst *apply, SILFunction *callee);
+  llvm::Optional<SymbolicValue> computeOpaqueCallResult(ApplyInst *apply,
+                                                        SILFunction *callee);
 
-    SymbolicValue computeLoadResult(SILValue addr);
-    llvm::Optional<SymbolicValue> computeFSStore(SymbolicValue storedCst,
-                                                 SILValue dest);
+  SymbolicValue computeLoadResult(SILValue addr);
+  llvm::Optional<SymbolicValue> computeFSStore(SymbolicValue storedCst,
+                                               SILValue dest);
 
-    AddressValue computeAddressValue(SILValue addr);
-  };
+  AddressValue computeAddressValue(SILValue addr);
+};
 } // end anonymous namespace
-
 
 /// Simplify the specified type based on knowledge of substitutions if we have
 /// any.
@@ -306,7 +298,7 @@ static void lookupOrLinkWitnessTable(ProtocolConformanceRef confRef,
     return;
 
   auto *decl =
-    conf->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
+      conf->getDeclContext()->getAsNominalTypeOrNominalTypeExtensionContext();
   auto linkage = getSILLinkage(getDeclLinkage(decl), NotForDefinition);
   auto *newTable = module.createWitnessTableDeclaration(conf, linkage);
   newTable = module.getSILLoader()->lookupWitnessTable(newTable);
@@ -317,7 +309,6 @@ static void lookupOrLinkWitnessTable(ProtocolConformanceRef confRef,
     if (entry.getKind() == SILWitnessTable::WitnessKind::Method)
       entry.getMethodWitness().Witness->setLinkage(linkage);
 }
-
 
 SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
   // If this a trivial constant instruction that we can handle, then fold it
@@ -339,7 +330,8 @@ SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
 
   if (auto *tei = dyn_cast<TupleExtractInst>(value)) {
     auto val = getConstantValue(tei->getOperand());
-    if (!val.isConstant()) return val;
+    if (!val.isConstant())
+      return val;
     return val.getAggregateValue()[tei->getFieldNo()];
   }
 
@@ -347,7 +339,8 @@ SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
   // element being extracted.
   if (auto *sei = dyn_cast<StructExtractInst>(value)) {
     auto val = getConstantValue(sei->getOperand());
-    if (!val.isConstant()) return val;
+    if (!val.isConstant())
+      return val;
     return val.getAggregateValue()[sei->getFieldNo()];
   }
 
@@ -360,7 +353,8 @@ SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
 
     for (unsigned i = 0, e = inst->getNumOperands(); i != e; ++i) {
       auto val = getConstantValue(inst->getOperand(i));
-      if (!val.isConstant()) return val;
+      if (!val.isConstant())
+        return val;
       elts.push_back(val);
     }
 
@@ -377,8 +371,8 @@ SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
 
   // Try to resolve a witness method against our known conformances.
   if (auto *wmi = dyn_cast<WitnessMethodInst>(value)) {
-    auto confResult = substitutionMap.lookupConformance(wmi->getLookupType(),
-                         wmi->getConformance().getRequirement());
+    auto confResult = substitutionMap.lookupConformance(
+        wmi->getLookupType(), wmi->getConformance().getRequirement());
     if (!confResult)
       return SymbolicValue::getUnknown(value, UnknownReason::Default);
     auto conf = confResult.getValue();
@@ -386,7 +380,7 @@ SymbolicValue ConstExprFunctionState::computeConstantValue(SILValue value) {
 
     // Look up the conformance's withness table and the member out of it.
     SILFunction *fn =
-      module.lookUpFunctionInWitnessTable(conf, wmi->getMember()).first;
+        module.lookUpFunctionInWitnessTable(conf, wmi->getMember()).first;
     if (!fn) {
       // If that failed, try force loading it, and try again.
       lookupOrLinkWitnessTable(conf, wmi->getModule());
@@ -433,7 +427,8 @@ ConstExprFunctionState::computeConstantValueBuiltin(BuiltinInst *inst) {
   // Nullary operations.
   if (inst->getNumOperands() == 0) {
     switch (builtin.ID) {
-    default: break;
+    default:
+      break;
     case BuiltinValueKind::AssertConf: {
       // assert_configuration builtin gets replaces with debug/release/etc
       // constants.
@@ -442,13 +437,12 @@ ConstExprFunctionState::computeConstantValueBuiltin(BuiltinInst *inst) {
       if (config == SILOptions::DisableReplacement)
         break;
       auto resultBitWidth =
-        inst->getType().castTo<BuiltinIntegerType>()->getGreatestWidth();
+          inst->getType().castTo<BuiltinIntegerType>()->getGreatestWidth();
       auto result = APInt(resultBitWidth, config);
       return SymbolicValue::getInteger(result, evaluator.getAllocator());
     }
     }
   }
-
 
   // Unary operations.
   if (inst->getNumOperands() == 1) {
@@ -465,21 +459,22 @@ ConstExprFunctionState::computeConstantValueBuiltin(BuiltinInst *inst) {
     //
     // TODO: We can/should diagnose statically detectable integer overflow
     // errors and subsume the ConstantFolding.cpp mandatory SIL pass.
-    auto IntCheckedTruncFn = [&](bool srcSigned, bool dstSigned)->SymbolicValue{
+    auto IntCheckedTruncFn = [&](bool srcSigned,
+                                 bool dstSigned) -> SymbolicValue {
       if (operand.getKind() != SymbolicValue::Integer)
         return unknownResult();
 
       auto operandVal = operand.getIntegerValue();
       uint32_t srcBitWidth = operandVal.getBitWidth();
       auto dstBitWidth =
-        builtin.Types[1]->castTo<BuiltinIntegerType>()->getGreatestWidth();
+          builtin.Types[1]->castTo<BuiltinIntegerType>()->getGreatestWidth();
 
       APInt result = operandVal.trunc(dstBitWidth);
 
       // Compute the overflow by re-extending the value back to its source and
       // checking for loss of value.
-      APInt reextended = dstSigned ? result.sext(srcBitWidth)
-                                   : result.zext(srcBitWidth);
+      APInt reextended =
+          dstSigned ? result.sext(srcBitWidth) : result.zext(srcBitWidth);
       bool overflowed = (operandVal != reextended);
 
       if (builtin.ID == BuiltinValueKind::UToSCheckedTrunc)
@@ -491,14 +486,15 @@ ConstExprFunctionState::computeConstantValueBuiltin(BuiltinInst *inst) {
 
       auto &allocator = evaluator.getAllocator();
       // Build the Symbolic value result for our truncated value.
-      return SymbolicValue::getAggregate({
-          SymbolicValue::getInteger(result, allocator),
-          SymbolicValue::getInteger(APInt(1, overflowed), allocator)
-      }, allocator);
+      return SymbolicValue::getAggregate(
+          {SymbolicValue::getInteger(result, allocator),
+           SymbolicValue::getInteger(APInt(1, overflowed), allocator)},
+          allocator);
     };
 
     switch (builtin.ID) {
-    default: break;
+    default:
+      break;
     case BuiltinValueKind::SToSCheckedTrunc:
       return IntCheckedTruncFn(true, true);
     case BuiltinValueKind::UToSCheckedTrunc:
@@ -514,7 +510,7 @@ ConstExprFunctionState::computeConstantValueBuiltin(BuiltinInst *inst) {
 
       auto operandVal = operand.getIntegerValue();
       auto &semantics =
-        inst->getType().castTo<BuiltinFloatType>()->getAPFloatSemantics();
+          inst->getType().castTo<BuiltinFloatType>()->getAPFloatSemantics();
       APFloat apf(semantics,
                   APInt::getNullValue(APFloat::semanticsSizeInBits(semantics)));
       apf.convertFromAPInt(operandVal, builtin.ID == BuiltinValueKind::SIToFP,
@@ -532,12 +528,13 @@ ConstExprFunctionState::computeConstantValueBuiltin(BuiltinInst *inst) {
         return unknownResult();
 
       unsigned destBitWidth =
-        inst->getType().castTo<BuiltinIntegerType>()->getGreatestWidth();
+          inst->getType().castTo<BuiltinIntegerType>()->getGreatestWidth();
 
       APInt result = operand.getIntegerValue();
       if (result.getBitWidth() != destBitWidth) {
         switch (builtin.ID) {
-        default: assert(0 && "Unknown case");
+        default:
+          assert(0 && "Unknown case");
         case BuiltinValueKind::Trunc:
         case BuiltinValueKind::TruncOrBitCast:
           result = result.trunc(destBitWidth);
@@ -571,11 +568,13 @@ ConstExprFunctionState::computeConstantValueBuiltin(BuiltinInst *inst) {
   if (inst->getNumOperands() == 2) {
     auto operand0 = getConstantValue(inst->getOperand(0));
     auto operand1 = getConstantValue(inst->getOperand(1));
-    if (!operand0.isConstant()) return operand0;
-    if (!operand1.isConstant()) return operand1;
+    if (!operand0.isConstant())
+      return operand0;
+    if (!operand1.isConstant())
+      return operand1;
 
     auto constFoldIntCompare =
-      [&](const std::function<bool(const APInt &, const APInt &)> &fn)
+        [&](const std::function<bool(const APInt &, const APInt &)> &fn)
         -> SymbolicValue {
       if (operand0.getKind() != SymbolicValue::Integer ||
           operand1.getKind() != SymbolicValue::Integer)
@@ -586,7 +585,7 @@ ConstExprFunctionState::computeConstantValueBuiltin(BuiltinInst *inst) {
                                        evaluator.getAllocator());
     };
     auto constFoldFPCompare =
-      [&](const std::function<bool(APFloat::cmpResult result)> &fn)
+        [&](const std::function<bool(APFloat::cmpResult result)> &fn)
         -> SymbolicValue {
       if (operand0.getKind() != SymbolicValue::Float ||
           operand1.getKind() != SymbolicValue::Float)
@@ -598,89 +597,88 @@ ConstExprFunctionState::computeConstantValueBuiltin(BuiltinInst *inst) {
                                        evaluator.getAllocator());
     };
 
-#define REQUIRE_KIND(KIND)                          \
-  if (operand0.getKind() != SymbolicValue::KIND ||  \
-      operand1.getKind() != SymbolicValue::KIND)    \
-      return unknownResult();
+#define REQUIRE_KIND(KIND)                                                     \
+  if (operand0.getKind() != SymbolicValue::KIND ||                             \
+      operand1.getKind() != SymbolicValue::KIND)                               \
+    return unknownResult();
 
     switch (builtin.ID) {
-    default: break;
-#define INT_BINOP(OPCODE, EXPR)                                            \
-    case BuiltinValueKind::OPCODE: {                                       \
-      REQUIRE_KIND(Integer)                                                \
-      auto l = operand0.getIntegerValue(), r = operand1.getIntegerValue(); \
-      return SymbolicValue::getInteger((EXPR), evaluator.getAllocator());  \
-    }
-    INT_BINOP(Add,  l+r)
-    INT_BINOP(And,  l&r)
-    INT_BINOP(AShr, l.ashr(r))
-    INT_BINOP(LShr, l.lshr(r))
-    INT_BINOP(Or,   l|r)
-    INT_BINOP(Mul,  l*r)
-    INT_BINOP(SDiv, l.sdiv(r))
-    INT_BINOP(Shl,  l << r)
-    INT_BINOP(SRem, l.srem(r))
-    INT_BINOP(Sub,  l-r)
-    INT_BINOP(UDiv, l.udiv(r))
-    INT_BINOP(URem, l.urem(r))
-    INT_BINOP(Xor,  l^r)
+    default:
+      break;
+#define INT_BINOP(OPCODE, EXPR)                                                \
+  case BuiltinValueKind::OPCODE: {                                             \
+    REQUIRE_KIND(Integer)                                                      \
+    auto l = operand0.getIntegerValue(), r = operand1.getIntegerValue();       \
+    return SymbolicValue::getInteger((EXPR), evaluator.getAllocator());        \
+  }
+      INT_BINOP(Add, l + r)
+      INT_BINOP(And, l & r)
+      INT_BINOP(AShr, l.ashr(r))
+      INT_BINOP(LShr, l.lshr(r))
+      INT_BINOP(Or, l | r)
+      INT_BINOP(Mul, l * r)
+      INT_BINOP(SDiv, l.sdiv(r))
+      INT_BINOP(Shl, l << r)
+      INT_BINOP(SRem, l.srem(r))
+      INT_BINOP(Sub, l - r)
+      INT_BINOP(UDiv, l.udiv(r))
+      INT_BINOP(URem, l.urem(r))
+      INT_BINOP(Xor, l ^ r)
 #undef INT_BINOP
-#define FP_BINOP(OPCODE, EXPR)                                           \
-    case BuiltinValueKind::OPCODE: {                                     \
-      REQUIRE_KIND(Float)                                                \
-      auto l = operand0.getFloatValue(), r = operand1.getFloatValue();   \
-      return SymbolicValue::getFloat((EXPR), evaluator.getAllocator());  \
-    }
-    FP_BINOP(FAdd, l+r)
-    FP_BINOP(FSub, l-r)
-    FP_BINOP(FMul, l*r)
-    FP_BINOP(FDiv, l/r)
-    FP_BINOP(FRem, (l.mod(r), l))
+#define FP_BINOP(OPCODE, EXPR)                                                 \
+  case BuiltinValueKind::OPCODE: {                                             \
+    REQUIRE_KIND(Float)                                                        \
+    auto l = operand0.getFloatValue(), r = operand1.getFloatValue();           \
+    return SymbolicValue::getFloat((EXPR), evaluator.getAllocator());          \
+  }
+      FP_BINOP(FAdd, l + r)
+      FP_BINOP(FSub, l - r)
+      FP_BINOP(FMul, l * r)
+      FP_BINOP(FDiv, l / r)
+      FP_BINOP(FRem, (l.mod(r), l))
 #undef FP_BINOP
 
 #define INT_COMPARE(OPCODE, EXPR)                                              \
-    case BuiltinValueKind::OPCODE:                                             \
-      REQUIRE_KIND(Integer)                                                    \
-      return constFoldIntCompare([&](const APInt &l, const APInt &r) -> bool { \
-        return (EXPR);                                                         \
-      })
-    INT_COMPARE(ICMP_EQ, l == r);
-    INT_COMPARE(ICMP_NE, l != r);
-    INT_COMPARE(ICMP_SLT, l.slt(r));
-    INT_COMPARE(ICMP_SGT, l.sgt(r));
-    INT_COMPARE(ICMP_SLE, l.sle(r));
-    INT_COMPARE(ICMP_SGE, l.sge(r));
-    INT_COMPARE(ICMP_ULT, l.ult(r));
-    INT_COMPARE(ICMP_UGT, l.ugt(r));
-    INT_COMPARE(ICMP_ULE, l.ule(r));
-    INT_COMPARE(ICMP_UGE, l.uge(r));
+  case BuiltinValueKind::OPCODE:                                               \
+    REQUIRE_KIND(Integer)                                                      \
+    return constFoldIntCompare(                                                \
+        [&](const APInt &l, const APInt &r) -> bool { return (EXPR); })
+      INT_COMPARE(ICMP_EQ, l == r);
+      INT_COMPARE(ICMP_NE, l != r);
+      INT_COMPARE(ICMP_SLT, l.slt(r));
+      INT_COMPARE(ICMP_SGT, l.sgt(r));
+      INT_COMPARE(ICMP_SLE, l.sle(r));
+      INT_COMPARE(ICMP_SGE, l.sge(r));
+      INT_COMPARE(ICMP_ULT, l.ult(r));
+      INT_COMPARE(ICMP_UGT, l.ugt(r));
+      INT_COMPARE(ICMP_ULE, l.ule(r));
+      INT_COMPARE(ICMP_UGE, l.uge(r));
 #undef INT_COMPARE
-#define FP_COMPARE(OPCODE, EXPR)                                         \
-    case BuiltinValueKind::OPCODE:                                       \
-      REQUIRE_KIND(Float)                                                \
-      return constFoldFPCompare([&](APFloat::cmpResult result) -> bool { \
-        return (EXPR);                                                   \
-      })
-    FP_COMPARE(FCMP_OEQ, result == APFloat::cmpEqual);
-    FP_COMPARE(FCMP_OGT, result == APFloat::cmpGreaterThan);
-    FP_COMPARE(FCMP_OGE, result == APFloat::cmpGreaterThan ||
-                         result == APFloat::cmpEqual);
-    FP_COMPARE(FCMP_OLT, result == APFloat::cmpLessThan);
-    FP_COMPARE(FCMP_OLE, result == APFloat::cmpLessThan ||
-                         result == APFloat::cmpEqual);
-    FP_COMPARE(FCMP_ONE, result == APFloat::cmpLessThan ||
-                         result == APFloat::cmpGreaterThan);
-    FP_COMPARE(FCMP_ORD, result != APFloat::cmpUnordered);
-    FP_COMPARE(FCMP_UEQ, result == APFloat::cmpUnordered ||
-                         result == APFloat::cmpEqual);
-    FP_COMPARE(FCMP_UGT, result == APFloat::cmpUnordered ||
-                         result == APFloat::cmpGreaterThan);
-    FP_COMPARE(FCMP_UGE, result != APFloat::cmpLessThan);
-    FP_COMPARE(FCMP_ULT, result == APFloat::cmpUnordered ||
-                         result == APFloat::cmpLessThan);
-    FP_COMPARE(FCMP_ULE, result != APFloat::cmpGreaterThan);
-    FP_COMPARE(FCMP_UNE, result != APFloat::cmpEqual);
-    FP_COMPARE(FCMP_UNO, result == APFloat::cmpUnordered);
+#define FP_COMPARE(OPCODE, EXPR)                                               \
+  case BuiltinValueKind::OPCODE:                                               \
+    REQUIRE_KIND(Float)                                                        \
+    return constFoldFPCompare(                                                 \
+        [&](APFloat::cmpResult result) -> bool { return (EXPR); })
+      FP_COMPARE(FCMP_OEQ, result == APFloat::cmpEqual);
+      FP_COMPARE(FCMP_OGT, result == APFloat::cmpGreaterThan);
+      FP_COMPARE(FCMP_OGE, result == APFloat::cmpGreaterThan ||
+                               result == APFloat::cmpEqual);
+      FP_COMPARE(FCMP_OLT, result == APFloat::cmpLessThan);
+      FP_COMPARE(FCMP_OLE,
+                 result == APFloat::cmpLessThan || result == APFloat::cmpEqual);
+      FP_COMPARE(FCMP_ONE, result == APFloat::cmpLessThan ||
+                               result == APFloat::cmpGreaterThan);
+      FP_COMPARE(FCMP_ORD, result != APFloat::cmpUnordered);
+      FP_COMPARE(FCMP_UEQ, result == APFloat::cmpUnordered ||
+                               result == APFloat::cmpEqual);
+      FP_COMPARE(FCMP_UGT, result == APFloat::cmpUnordered ||
+                               result == APFloat::cmpGreaterThan);
+      FP_COMPARE(FCMP_UGE, result != APFloat::cmpLessThan);
+      FP_COMPARE(FCMP_ULT, result == APFloat::cmpUnordered ||
+                               result == APFloat::cmpLessThan);
+      FP_COMPARE(FCMP_ULE, result != APFloat::cmpGreaterThan);
+      FP_COMPARE(FCMP_UNE, result != APFloat::cmpEqual);
+      FP_COMPARE(FCMP_UNO, result == APFloat::cmpUnordered);
 #undef FP_COMPARE
 #undef REQUIRE_KIND
     }
@@ -691,15 +689,18 @@ ConstExprFunctionState::computeConstantValueBuiltin(BuiltinInst *inst) {
     auto operand0 = getConstantValue(inst->getOperand(0));
     auto operand1 = getConstantValue(inst->getOperand(1));
     auto operand2 = getConstantValue(inst->getOperand(2));
-    if (!operand0.isConstant()) return operand0;
-    if (!operand1.isConstant()) return operand1;
-    if (!operand2.isConstant()) return operand2;
+    if (!operand0.isConstant())
+      return operand0;
+    if (!operand1.isConstant())
+      return operand1;
+    if (!operand2.isConstant())
+      return operand2;
 
     // Overflowing integer operations like sadd_with_overflow take three
     // operands: the last one is a "should report overflow" bit.
     auto constFoldIntOverflow =
-      [&](const std::function<APInt(const APInt &, const APInt &, bool &)> &fn)
-            -> SymbolicValue {
+        [&](const std::function<APInt(const APInt &, const APInt &, bool &)>
+                &fn) -> SymbolicValue {
       if (operand0.getKind() != SymbolicValue::Integer ||
           operand1.getKind() != SymbolicValue::Integer ||
           operand2.getKind() != SymbolicValue::Integer)
@@ -717,27 +718,28 @@ ConstExprFunctionState::computeConstantValueBuiltin(BuiltinInst *inst) {
 
       auto &allocator = evaluator.getAllocator();
       // Build the Symbolic value result for our normal and overflow bit.
-      return SymbolicValue::getAggregate({
-        SymbolicValue::getInteger(result, allocator),
-        SymbolicValue::getInteger(APInt(1, overflowed), allocator)
-      }, allocator);
+      return SymbolicValue::getAggregate(
+          {SymbolicValue::getInteger(result, allocator),
+           SymbolicValue::getInteger(APInt(1, overflowed), allocator)},
+          allocator);
     };
 
     switch (builtin.ID) {
-    default: break;
+    default:
+      break;
 
-#define INT_OVERFLOW(OPCODE, METHOD)                                   \
-    case BuiltinValueKind::OPCODE:                                     \
-      return constFoldIntOverflow([&](const APInt &l, const APInt &r,  \
-                                      bool &overflowed) -> APInt {     \
-        return l.METHOD(r, overflowed);                                \
-      })
-    INT_OVERFLOW(SAddOver, sadd_ov);
-    INT_OVERFLOW(UAddOver, uadd_ov);
-    INT_OVERFLOW(SSubOver, ssub_ov);
-    INT_OVERFLOW(USubOver, usub_ov);
-    INT_OVERFLOW(SMulOver, smul_ov);
-    INT_OVERFLOW(UMulOver, umul_ov);
+#define INT_OVERFLOW(OPCODE, METHOD)                                           \
+  case BuiltinValueKind::OPCODE:                                               \
+    return constFoldIntOverflow(                                               \
+        [&](const APInt &l, const APInt &r, bool &overflowed) -> APInt {       \
+          return l.METHOD(r, overflowed);                                      \
+        })
+      INT_OVERFLOW(SAddOver, sadd_ov);
+      INT_OVERFLOW(UAddOver, uadd_ov);
+      INT_OVERFLOW(SSubOver, ssub_ov);
+      INT_OVERFLOW(USubOver, usub_ov);
+      INT_OVERFLOW(SMulOver, smul_ov);
+      INT_OVERFLOW(UMulOver, umul_ov);
 #undef INT_OVERFLOW
     }
   }
@@ -745,12 +747,12 @@ ConstExprFunctionState::computeConstantValueBuiltin(BuiltinInst *inst) {
   // Handle LLVM intrinsics.
   auto &intrinsic = inst->getIntrinsicInfo();
   switch (intrinsic.ID) {
-  default: break;
+  default:
+    break;
   case llvm::Intrinsic::expect:
     // llvm.expect(x, y) always lowers to x.
     return getConstantValue(inst->getOperand(0));
   }
-
 
   DEBUG(llvm::dbgs() << "ConstExpr Unknown Builtin: " << *inst << "\n");
 
@@ -767,28 +769,27 @@ ConstExprFunctionState::computeOpaqueCallResult(ApplyInst *apply,
   if (callee->hasSemanticsAttr("arc.programtermination_point")) {
     // TODO: Actually get the message out of fatalError.  We can literally get
     // its string and file/line/col info and propagate it up!
-    return SymbolicValue::getUnknown((SILInstruction*)apply,
+    return SymbolicValue::getUnknown((SILInstruction *)apply,
                                      UnknownReason::Trap);
   }
-  
+
   if (classifyFunction(callee->getName()) ==
       WellKnownFunction::AssertionFailure) {
     // TODO: Actually get the message out of fatalError.  We can literally get
     // its string and file/line/col info and propagate it up!
-    return SymbolicValue::getUnknown((SILInstruction*)apply,
+    return SymbolicValue::getUnknown((SILInstruction *)apply,
                                      UnknownReason::Trap);
   }
 
   DEBUG(llvm::dbgs() << "ConstExpr Opaque Callee: " << *callee << "\n");
-  return SymbolicValue::getUnknown((SILInstruction*)apply,
+  return SymbolicValue::getUnknown((SILInstruction *)apply,
                                    UnknownReason::Default);
 }
 
-
 // TODO: Refactor this to someplace common, this is defined in Devirtualize.cpp.
-SubstitutionMap
-getWitnessMethodSubstitutions(SILModule &Module, ApplySite AI, SILFunction *F,
-                              ProtocolConformanceRef CRef);
+SubstitutionMap getWitnessMethodSubstitutions(SILModule &Module, ApplySite AI,
+                                              SILFunction *F,
+                                              ProtocolConformanceRef CRef);
 
 /// Given a call to a function, determine whether it is a call to a constexpr
 /// function.  If so, collect its arguments as constants, fold it and return
@@ -801,7 +802,7 @@ ConstExprFunctionState::computeCallResult(ApplyInst *apply) {
   // Determine the callee.
   auto calleeFn = getConstantValue(apply->getOperand(0));
   if (calleeFn.getKind() != SymbolicValue::Function)
-    return SymbolicValue::getUnknown((SILInstruction*)apply,
+    return SymbolicValue::getUnknown((SILInstruction *)apply,
                                      UnknownReason::Default);
 
   SILFunction *callee = calleeFn.getFunctionValue();
@@ -823,8 +824,9 @@ ConstExprFunctionState::computeCallResult(ApplyInst *apply) {
   // @constexprSemantics sort of attribute that indicates it is well known,
   // just like the existing SemanticsAttr thing.
   switch (classifyFunction(callee->getName())) {
-  default: break;
-  case WellKnownFunction::StringInitEmpty: {  // String.init()
+  default:
+    break;
+  case WellKnownFunction::StringInitEmpty: { // String.init()
     assert(conventions.getNumDirectSILResults() == 1 &&
            conventions.getNumIndirectSILResults() == 0 &&
            "unexpected String.init() signature");
@@ -836,12 +838,12 @@ ConstExprFunctionState::computeCallResult(ApplyInst *apply) {
 
   // Verify that we can fold all of the arguments to the call.
   SmallVector<SymbolicValue, 4> paramConstants;
-  unsigned applyParamBaseIndex = 1+conventions.getNumIndirectSILResults();
+  unsigned applyParamBaseIndex = 1 + conventions.getNumIndirectSILResults();
   auto paramInfos = conventions.getParameters();
   for (unsigned i = 0, e = paramInfos.size(); i != e; ++i) {
     // If any of the arguments is a non-constant value, then we can't fold this
     // call.
-    auto op = apply->getOperand(applyParamBaseIndex+i);
+    auto op = apply->getOperand(applyParamBaseIndex + i);
     SymbolicValue argValue;
     if (op->getType().isObject())
       argValue = getConstantValue(op);
@@ -871,10 +873,10 @@ ConstExprFunctionState::computeCallResult(ApplyInst *apply) {
       // current type space.
       auto conformance = calleeFnType->getWitnessMethodConformance();
       auto selfTy = conformance.getRequirement()->getSelfInterfaceType();
-      auto conf = substitutionMap.lookupConformance(selfTy->getCanonicalType(),
-                                                 conformance.getRequirement());
+      auto conf = substitutionMap.lookupConformance(
+          selfTy->getCanonicalType(), conformance.getRequirement());
       if (!conf.hasValue())
-        return SymbolicValue::getUnknown((SILInstruction*)apply,
+        return SymbolicValue::getUnknown((SILInstruction *)apply,
                                          UnknownReason::Default);
 
       // Witness methods have special magic that is required to resolve them.
@@ -883,9 +885,8 @@ ConstExprFunctionState::computeCallResult(ApplyInst *apply) {
     } else {
       auto requirementSig = AI.getOrigCalleeType()->getGenericSignature();
       callSubMap =
-        requirementSig->getSubstitutionMap(apply->getSubstitutions());
+          requirementSig->getSubstitutionMap(apply->getSubstitutions());
     }
-
 
     // The substitution map for the callee is the composition of the callers
     // substitution map (which is always type/conformance to a concrete type
@@ -898,9 +899,8 @@ ConstExprFunctionState::computeCallResult(ApplyInst *apply) {
   // Now that have successfully folded all of the parameters, we can evaluate
   // the call.
   SmallVector<SymbolicValue, 4> results;
-  auto callResult =
-    evaluateAndCacheCall(*callee, calleeSubMap, paramConstants, results,
-                         numInstEvaluated, evaluator);
+  auto callResult = evaluateAndCacheCall(*callee, calleeSubMap, paramConstants,
+                                         results, numInstEvaluated, evaluator);
   if (callResult.hasValue())
     return callResult.getValue();
 
@@ -916,8 +916,9 @@ ConstExprFunctionState::computeCallResult(ApplyInst *apply) {
   }
 
   // Handle indirect results as well.
-  for (unsigned i = 0, e = conventions.getNumIndirectSILResults(); i != e; ++i){
-    auto error = computeFSStore(results[nextResult], apply->getOperand(1+i));
+  for (unsigned i = 0, e = conventions.getNumIndirectSILResults(); i != e;
+       ++i) {
+    auto error = computeFSStore(results[nextResult], apply->getOperand(1 + i));
     if (error.hasValue())
       return error;
     ++nextResult;
@@ -936,7 +937,8 @@ SymbolicValue ConstExprFunctionState::getConstantValue(SILValue value) {
 
   // Check to see if we already have an answer.
   auto it = calculatedValues.find(value);
-  if (it != calculatedValues.end()) return it->second;
+  if (it != calculatedValues.end())
+    return it->second;
 
   // Compute the value of a normal instruction based on its operands.
   auto result = computeConstantValue(value);
@@ -944,14 +946,11 @@ SymbolicValue ConstExprFunctionState::getConstantValue(SILValue value) {
   // If this is the top-level lazy interpreter, output a debug trace.
   if (!fn) {
     DEBUG(llvm::dbgs() << "ConstExpr top level: "; value->dump());
-    DEBUG(llvm::dbgs() << "  RESULT: ";  result.dump());
+    DEBUG(llvm::dbgs() << "  RESULT: "; result.dump());
   }
 
   return calculatedValues[value] = result;
 }
-
-
-
 
 /// Given an aggregate value like {{1, 2}, 3} and an access path like [0,1], and
 /// a scalar like 4, return the aggregate value with the indexed element
@@ -1010,8 +1009,8 @@ static bool updateIndexedElement(SymbolicValue &aggregate,
   // Update the indexed element of the aggregate.
   auto oldElts = aggregate.getAggregateValue();
   SmallVector<SymbolicValue, 4> newElts(oldElts.begin(), oldElts.end());
-  if (updateIndexedElement(newElts[elementNo], indices.drop_front(),
-                           scalar, eltType, allocator))
+  if (updateIndexedElement(newElts[elementNo], indices.drop_front(), scalar,
+                           eltType, allocator))
     return true;
 
   aggregate = SymbolicValue::getAggregate(newElts, allocator);
@@ -1031,7 +1030,7 @@ ConstExprFunctionState::computeSingleStoreAddressValue(SILValue addr) {
 
   // Keep track of the value found for the first constant store.
   unsigned objectID =
-    createMemoryObject(alloc, SymbolicValue::getUninitMemory()).getObjectID();
+      createMemoryObject(alloc, SymbolicValue::getUninitMemory()).getObjectID();
 
   // Okay, check out all of the users of this value looking for semantic stores
   // into the address.  If we find more than one, then this was a var or
@@ -1041,8 +1040,7 @@ ConstExprFunctionState::computeSingleStoreAddressValue(SILValue addr) {
 
     // Ignore markers, loads, and other things that aren't stores to this stack
     // value.
-    if (isa<LoadInst>(user) ||
-        isa<DeallocStackInst>(user) ||
+    if (isa<LoadInst>(user) || isa<DeallocStackInst>(user) ||
         isa<DebugValueAddrInst>(user))
       continue;
 
@@ -1056,8 +1054,8 @@ ConstExprFunctionState::computeSingleStoreAddressValue(SILValue addr) {
 
         // If we have already found a value for this stack slot then we're done:
         // we don't support multiple assignment.
-        if (memoryObjects[objectID].first.getKind()
-            != SymbolicValue::UninitMemory)
+        if (memoryObjects[objectID].first.getKind() !=
+            SymbolicValue::UninitMemory)
           return getUnknownAddress(alloc, UnknownReason::Default);
 
         auto result = getConstantValue(si->getOperand(0));
@@ -1077,13 +1075,14 @@ ConstExprFunctionState::computeSingleStoreAddressValue(SILValue addr) {
       // If this is an out-parameter, it is like a store.  If not, this is an
       // indirect read which is ok.
       unsigned numIndirectResults = conventions.getNumIndirectSILResults();
-      unsigned opNum = use->getOperandNumber()-1;
+      unsigned opNum = use->getOperandNumber() - 1;
       if (opNum >= numIndirectResults)
         continue;
 
       // Otherwise this is a write.  If we have already found a value for this
       // stack slot then we're done: we don't support multiple assignment.
-      if (memoryObjects[objectID].first.getKind() !=SymbolicValue::UninitMemory)
+      if (memoryObjects[objectID].first.getKind() !=
+          SymbolicValue::UninitMemory)
         return getUnknownAddress(alloc, UnknownReason::Default);
 
       // The callee needs to be a direct call to a constant expression.
@@ -1102,9 +1101,8 @@ ConstExprFunctionState::computeSingleStoreAddressValue(SILValue addr) {
       continue;
     }
 
-
-    DEBUG(llvm::dbgs() << "Unknown SingleStore ConstExpr user: "
-                       << *user << "\n");
+    DEBUG(llvm::dbgs() << "Unknown SingleStore ConstExpr user: " << *user
+                       << "\n");
 
     // If this is some other user that we don't know about, then we should
     // treat it conservatively, because it could store into the address.
@@ -1118,7 +1116,6 @@ ConstExprFunctionState::computeSingleStoreAddressValue(SILValue addr) {
   // Otherwise, return unknown.
   return getUnknownAddress(addr, UnknownReason::Default);
 }
-
 
 /// Given the operand to a load, resolve it to a constant if possible.
 SymbolicValue ConstExprFunctionState::computeLoadResult(SILValue addrVal) {
@@ -1180,7 +1177,6 @@ ConstExprFunctionState::computeFSStore(SymbolicValue storedCst, SILValue dest) {
   return None;
 }
 
-
 AddressValue ConstExprFunctionState::computeAddressValue(SILValue addr) {
   // If this is a struct or tuple element addressor, compute a more derived
   // address.
@@ -1211,7 +1207,6 @@ AddressValue ConstExprFunctionState::computeAddressValue(SILValue addr) {
   return getUnknownAddress(addr, UnknownReason::Default);
 }
 
-
 /// Return the AddressValue for the specified SIL address, lazily computing
 /// it if needed.
 AddressValue ConstExprFunctionState::getAddressValue(SILValue addr) {
@@ -1237,7 +1232,6 @@ AddressValue ConstExprFunctionState::getAddressValue(SILValue addr) {
   addressValues.insert({addr, result});
   return result;
 }
-
 
 /// Evaluate the specified instruction in a flow sensitive way, for use by
 /// the constexpr function evaluator.  This does not handle control flow
@@ -1306,7 +1300,7 @@ ConstExprFunctionState::evaluateFlowSensitive(SILInstruction *inst) {
       auto result = getConstantValue(oneResultVal);
       if (!result.isConstant())
         return result;
-      DEBUG(llvm::dbgs() << "  RESULT: ";  result.dump());
+      DEBUG(llvm::dbgs() << "  RESULT: "; result.dump());
     } else {
       auto result = getAddressValue(oneResultVal);
       // If the address could not be resolved, puts the 'unknown' code into
@@ -1314,7 +1308,7 @@ ConstExprFunctionState::evaluateFlowSensitive(SILInstruction *inst) {
       auto memVal = memoryObjects[result.getObjectID()].first;
       if (memVal.isUnknown())
         return memVal;
-      DEBUG(llvm::dbgs() << "  RESULT: ";  result.dump());
+      DEBUG(llvm::dbgs() << "  RESULT: "; result.dump());
     }
     return None;
   }
@@ -1324,17 +1318,14 @@ ConstExprFunctionState::evaluateFlowSensitive(SILInstruction *inst) {
   return SymbolicValue::getUnknown(inst, UnknownReason::Default);
 }
 
-
 /// Evaluate a call to the specified function as if it were a constant
 /// expression, returning None and filling in `results` on success, or
 /// returning an 'Unknown' SymbolicValue on failure carrying the error.
 ///
-static llvm::Optional<SymbolicValue>
-evaluateAndCacheCall(SILFunction &fn, SubstitutionMap substitutionMap,
-                     ArrayRef<SymbolicValue> arguments,
-                     SmallVectorImpl<SymbolicValue> &results,
-                     unsigned &numInstEvaluated,
-                     ConstExprEvaluator &evaluator) {
+static llvm::Optional<SymbolicValue> evaluateAndCacheCall(
+    SILFunction &fn, SubstitutionMap substitutionMap,
+    ArrayRef<SymbolicValue> arguments, SmallVectorImpl<SymbolicValue> &results,
+    unsigned &numInstEvaluated, ConstExprEvaluator &evaluator) {
   assert(!fn.isExternalDeclaration() && "Can't analyze bodyless function");
   ConstExprFunctionState state(evaluator, &fn, substitutionMap,
                                numInstEvaluated);
@@ -1347,11 +1338,10 @@ evaluateAndCacheCall(SILFunction &fn, SubstitutionMap substitutionMap,
   unsigned nextBBArg = 0;
   const auto &argList = fn.front().getArguments();
 
-  DEBUG(llvm::dbgs().changeColor(raw_ostream::SAVEDCOLOR, /*bold*/true)
-        << "\nConstExpr call fn: "
-        << Demangle::demangleSymbolAsString(fn.getName());
-        llvm::dbgs().resetColor()
-        << "\n");
+  DEBUG(llvm::dbgs().changeColor(raw_ostream::SAVEDCOLOR, /*bold*/ true)
+            << "\nConstExpr call fn: "
+            << Demangle::demangleSymbolAsString(fn.getName());
+        llvm::dbgs().resetColor() << "\n");
 
   for (unsigned i = 0, e = conventions.getNumIndirectSILResults(); i != e; ++i)
     state.createMemoryObject(argList[nextBBArg++],
@@ -1370,7 +1360,7 @@ evaluateAndCacheCall(SILFunction &fn, SubstitutionMap substitutionMap,
 
   // Keep track of which blocks we've already visited.  We don't support loops
   // and this allows us to reject them.
-  SmallPtrSet<SILBasicBlock*, 8> visitedBlocks;
+  SmallPtrSet<SILBasicBlock *, 8> visitedBlocks;
 
   // Keep track of the current "instruction pointer".
   SILBasicBlock::iterator nextInst = fn.front().begin();
@@ -1410,8 +1400,8 @@ evaluateAndCacheCall(SILFunction &fn, SubstitutionMap substitutionMap,
         results.append(results.begin(), results.end());
       }
 
-      for (unsigned i = 0, e = conventions.getNumIndirectSILResults();
-           i != e; ++i) {
+      for (unsigned i = 0, e = conventions.getNumIndirectSILResults(); i != e;
+           ++i) {
         auto result = state.computeLoadResult(argList[i]);
         if (!result.isConstant())
           return result;
@@ -1434,7 +1424,8 @@ evaluateAndCacheCall(SILFunction &fn, SubstitutionMap substitutionMap,
       // Set up basic block arguments.
       for (unsigned i = 0, e = br->getNumArgs(); i != e; ++i) {
         auto argument = state.getConstantValue(br->getArg(i));
-        if (!argument.isConstant()) return argument;
+        if (!argument.isConstant())
+          return argument;
         state.setValue(destBB->getArgument(i), argument);
       }
       // Set the instruction pointer to the first instruction of the block.
@@ -1472,11 +1463,9 @@ evaluateAndCacheCall(SILFunction &fn, SubstitutionMap substitutionMap,
 // ConstExprEvaluator implementation.
 //===----------------------------------------------------------------------===//
 
-ConstExprEvaluator::ConstExprEvaluator(SILModule &m) {
-}
+ConstExprEvaluator::ConstExprEvaluator(SILModule &m) {}
 
-ConstExprEvaluator::~ConstExprEvaluator() {
-}
+ConstExprEvaluator::~ConstExprEvaluator() {}
 
 /// Analyze the specified values to determine if they are constant values.  This
 /// is done in code that is not necessarily itself a constexpr function.  The
@@ -1486,9 +1475,8 @@ ConstExprEvaluator::~ConstExprEvaluator() {
 /// TODO: Return information about which callees were found to be
 /// constexprs, which would allow the caller to delete dead calls to them
 /// that occur after after folding them.
-void ConstExprEvaluator::
-computeConstantValues(ArrayRef<SILValue> values,
-                      SmallVectorImpl<SymbolicValue> &results) {
+void ConstExprEvaluator::computeConstantValues(
+    ArrayRef<SILValue> values, SmallVectorImpl<SymbolicValue> &results) {
   unsigned numInstEvaluated = 0;
   ConstExprFunctionState state(*this, nullptr, {}, numInstEvaluated);
   for (auto v : values) {

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.h
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.h
@@ -25,6 +25,7 @@
 #define SWIFT_SILOPTIMIZER_TF_CONSTEXPR_H
 
 #include "swift/Basic/LLVM.h"
+#include "swift/Basic/SourceLoc.h"
 #include "llvm/Support/Allocator.h"
 
 namespace swift {
@@ -43,6 +44,9 @@ class ConstExprEvaluator {
   /// result values for the cached constexpr calls we have already analyzed.
   llvm::BumpPtrAllocator allocator;
 
+  /// The current call stack, used for providing accurate diagnostics.
+  llvm::SmallVector<SourceLoc, 4> callStack;
+
   ConstExprEvaluator(const ConstExprEvaluator &) = delete;
   void operator=(const ConstExprEvaluator &) = delete;
 
@@ -51,6 +55,15 @@ public:
   ~ConstExprEvaluator();
 
   llvm::BumpPtrAllocator &getAllocator() { return allocator; }
+
+  void pushCallStack(SourceLoc loc) { callStack.push_back(std::move(loc)); }
+
+  void popCallStack() {
+    assert(!callStack.empty());
+    callStack.pop_back();
+  }
+
+  const llvm::SmallVector<SourceLoc, 4> &getCallStack() { return callStack; }
 
   /// Analyze the specified values to determine if they are constant values.
   /// This is done in code that is not necessarily itself a constexpr

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.h
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.h
@@ -24,15 +24,15 @@
 #ifndef SWIFT_SILOPTIMIZER_TF_CONSTEXPR_H
 #define SWIFT_SILOPTIMIZER_TF_CONSTEXPR_H
 
-#include "llvm/Support/Allocator.h"
 #include "swift/Basic/LLVM.h"
+#include "llvm/Support/Allocator.h"
 
 namespace swift {
-  class SingleValueInstruction;
-  class SILBuilder;
-  class SILModule;
-  class SILValue;
-  class SymbolicValue;
+class SingleValueInstruction;
+class SILBuilder;
+class SILModule;
+class SILValue;
+class SymbolicValue;
 
 namespace tf {
 
@@ -45,6 +45,7 @@ class ConstExprEvaluator {
 
   ConstExprEvaluator(const ConstExprEvaluator &) = delete;
   void operator=(const ConstExprEvaluator &) = delete;
+
 public:
   explicit ConstExprEvaluator(SILModule &m);
   ~ConstExprEvaluator();

--- a/test/SILOptimizer/pound_assert.swift
+++ b/test/SILOptimizer/pound_assert.swift
@@ -64,6 +64,7 @@ func loops1(a: Int) -> Int {
 // @constexpr
 func loops2(a: Int) -> Int {
   var x = 42
+  // expected-note @+1 {{expression not evaluable as constant here}}
   for i in 0 ... a {
     x += i
   }
@@ -136,6 +137,26 @@ func testGenericThunk() {
   // TODO: expected-error @+1 {{#assert condition not constant}}
   #assert(myTransform.fn(42) > 1)
   // expected-note @-1{{could not fold operation}}
+}
+
+//===----------------------------------------------------------------------===//
+
+func foo() -> Bool {
+  // expected-note @+1 {{expression not evaluable as constant here}}
+  print("not constexpr")
+  return true
+}
+
+func baz() -> Bool {
+  return foo() // expected-note {{when called from here}}
+}
+
+func bar() -> Bool {
+  return baz() // expected-note {{when called from here}}
+}
+
+func testCallStack() {
+  #assert(bar()) // expected-error{{#assert condition not constant}}
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
When emitting a constexpr-evaluation failure message, this change emits
a trace of the calls the evaluator followed to generate the failure.

To make the output easier to read, calls on the same source line as the
failing location are elided from the output. So for example:

func foo() -> Bool {
  print("Un-constant")
  return true
}

test.swift:6:1: error: #assert condition not constant
^
test.swift:2:9: note: expression not evaluable as constant here
  print("Un-constant")

Notice there is no stack trace for the evaluation of the lambda.
