### PR TITLE
[4.2][Parse] <rdar://41154797> Detect eof in non-string-arg recovery loop in #error arg list

### DIFF
--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -3211,7 +3211,7 @@ ParserResult<PoundDiagnosticDecl> Parser::parseDeclPoundDiagnostic() {
     // Catch #warning(oops, forgot the quotes)
     SourceLoc wordsStartLoc = Tok.getLoc();
 
-    while (!Tok.isAtStartOfLine() && Tok.isNot(tok::r_paren)) {
+    while (!Tok.isAtStartOfLine() && !Tok.isAny(tok::r_paren, tok::eof)) {
       skipSingle();
     }
 

--- a/test/Parse/multiline_pound_diagnostic_arg_rdar_41154797.swift
+++ b/test/Parse/multiline_pound_diagnostic_arg_rdar_41154797.swift
@@ -1,0 +1,4 @@
+// RUN: not %target-typecheck-verify-swift
+
+#error("""
+


### PR DESCRIPTION
cherry-pick of #17508

rdar://41154797