### PR TITLE
Rename Tensor.makeTensor(withRank:) to Tensor.makeTensor(rank:)

### DIFF
--- a/stdlib/public/TensorFlow/Tensor.swift
+++ b/stdlib/public/TensorFlow/Tensor.swift
@@ -671,7 +671,7 @@ public extension AccelerableByTensorFlow {
   /// Convert to a tensor with the specified rank, with all dimensions equal to
   /// 1.
   @_inlineable @inline(__always)
-  func makeTensor(withRank rank: Int32) -> Tensor<Self> {
+  func makeTensor(rank: Int32) -> Tensor<Self> {
     return Raw.fill(
       dims: Tensor<Int32>(ones: TensorShape(rank)),
       value: Tensor(self))


### PR DESCRIPTION
https://swift.org/documentation/api-design-guidelines/

> The first argument to initializer and factory methods calls should not form a phrase starting with the base name.