### PR TITLE
[Serialization] Deal with ErrorTypes in specialized conformances

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -678,6 +678,8 @@ ModuleFile::maybeReadSubstitution(llvm::BitstreamCursor &cursor,
                                                           numConformances);
 
   auto replacementTy = getType(replacementID);
+  if (!replacementTy)
+    replacementTy = ErrorType::get(getContext());
   if (genericEnv) {
     replacementTy = genericEnv->mapTypeIntoContext(replacementTy);
   }

--- a/lib/Serialization/Serialization.cpp
+++ b/lib/Serialization/Serialization.cpp
@@ -1646,7 +1646,8 @@ Serializer::writeConformance(ProtocolConformanceRef conformanceRef,
                                                      abbrCode,
                                                      addTypeRef(type),
                                                      substitutions.size());
-    writeSubstitutions(substitutions, abbrCodes, genericEnv);
+    writeSubstitutions(substitutions, abbrCodes, genericEnv,
+                       /*ignoreReplacementErrors*/true);
 
     writeConformance(conf->getGenericConformance(), abbrCodes, genericEnv);
     break;
@@ -1691,7 +1692,8 @@ Serializer::writeConformances(ArrayRef<ProtocolConformance*> conformances,
 void
 Serializer::writeSubstitutions(SubstitutionList substitutions,
                                const std::array<unsigned, 256> &abbrCodes,
-                               GenericEnvironment *genericEnv) {
+                               GenericEnvironment *genericEnv,
+                               bool ignoreReplacementErrors) {
   using namespace decls_block;
   auto abbrCode = abbrCodes[BoundGenericSubstitutionLayout::Code];
 
@@ -1700,6 +1702,8 @@ Serializer::writeSubstitutions(SubstitutionList substitutions,
     if (genericEnv && replacementType->hasArchetype()) {
       replacementType = replacementType->mapTypeOutOfContext();
     }
+    if (replacementType->hasError() && ignoreReplacementErrors)
+      replacementType = Type();
 
     BoundGenericSubstitutionLayout::emitRecord(
       Out, ScratchRecord, abbrCode,

--- a/lib/Serialization/Serialization.h
+++ b/lib/Serialization/Serialization.h
@@ -495,7 +495,8 @@ public:
   /// being written.
   void writeSubstitutions(SubstitutionList substitutions,
                           const std::array<unsigned, 256> &abbrCodes,
-                          GenericEnvironment *genericEnv = nullptr);
+                          GenericEnvironment *genericEnv = nullptr,
+                          bool ignoreReplacementErrors = false);
 
   /// Write a normal protocol conformance.
   void writeNormalConformance(const NormalProtocolConformance *conformance);

--- a/validation-test/Serialization/SR7337.swift
+++ b/validation-test/Serialization/SR7337.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-module -o %t/Lib.swiftmodule %s -DLIB
+// RUN: %target-build-swift -emit-module -o %t/main.swiftmodule -I %t %s
+
+#if LIB
+
+protocol Proto {}
+
+open class Base<T> {}
+public struct ArbitraryStruct {}
+
+extension Base: Proto where T: Proto {}
+
+#else // LIB
+
+import Lib
+
+final class ConcreteSub: Base<ArbitraryStruct> {}
+
+#endif // LIB


### PR DESCRIPTION
This can represent a conformance that can never actually be used, such as an inherited conditional conformance where the subclass has provided a concrete generic parameter. (See the test case.)

We probably shouldn't be forming these conformances at all, but for now this lets us build without errors. Alternate solution compared to #17406.

[SR-7337](https://bugs.swift.org/browse/SR-7337) / rdar://problem/39142121