### PR TITLE
[test] Add minimized test case from SR-7337

### DIFF
--- a/validation-test/Serialization/SR7337.swift
+++ b/validation-test/Serialization/SR7337.swift
@@ -1,0 +1,20 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-build-swift -emit-module -o %t/Lib.swiftmodule %s -DLIB
+// RUN: %target-build-swift -emit-module -o %t/main.swiftmodule -I %t %s
+
+#if LIB
+
+protocol Proto {}
+
+open class Base<T> {}
+public struct ArbitraryStruct {}
+
+extension Base: Proto where T: Proto {}
+
+#else // LIB
+
+import Lib
+
+final class ConcreteSub: Base<ArbitraryStruct> {}
+
+#endif // LIB


### PR DESCRIPTION
Because we've changed how conformances represent associated types since Swift 4.2 branched, the error described there (and addressed in #17523) no longer occurs. But we still want to make sure we don't regress.

[SR-7337](https://bugs.swift.org/browse/SR-7337) / rdar://problem/39142121