### PR TITLE
Usability fixes for swift-api-dump

### DIFF
--- a/test/IDE/print_module_missing.swift
+++ b/test/IDE/print_module_missing.swift
@@ -1,0 +1,11 @@
+// Make sure we emit some kind of error message when we cannot find the module
+// to print.
+
+// RUN: not %target-swift-ide-test -print-module -print-interface -no-empty-line-between-members -module-to-print=NoSuchModule -source-filename=%s 2> %t.err
+// RUN: %FileCheck %s -check-prefix=CHECK-MISSING < %t.err
+
+// RUN: not %target-swift-ide-test -print-module -print-interface -no-empty-line-between-members -module-to-print=Swift.NoSuchSubModule -source-filename=%s 2> %t.suberr
+// RUN: %FileCheck %s -check-prefix=CHECK-MISSING-SUBMODULE < %t.suberr
+
+// CHECK-MISSING: 'NoSuchModule'
+// CHECK-MISSING-SUBMODULE: 'Swift.NoSuchSubModule'

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1854,6 +1854,8 @@ static int doPrintModules(const CompilerInvocation &InitInvok,
     // Get the (sub)module to print.
     auto *M = getModuleByFullName(Context, ModuleToPrint);
     if (!M) {
+      llvm::errs() << "error: could not find module '" << ModuleToPrint
+                   << "'\n";
       ExitCode = 1;
       continue;
     }
@@ -1873,6 +1875,8 @@ static int doPrintModules(const CompilerInvocation &InitInvok,
     if (ModuleName.size() > 1) {
       M = getModuleByFullName(Context, ModuleName[0]);
       if (!M) {
+        llvm::errs() << "error: could not find module '" << ModuleName[0]
+                     << "'\n";
         ExitCode = 1;
         continue;
       }

--- a/utils/swift-api-dump.py
+++ b/utils/swift-api-dump.py
@@ -5,9 +5,9 @@
 # (Objective-)C APIs, any API notes added on top of those APIs, and the
 # Clang importer itself. One can execute it to dump the API of a given
 # module within a particular SDK, e.g., UIKit from the iOS SDK as seen in
-# Swift 3 compatibility mode:
+# Swift 4 compatibility mode:
 #
-#   /path/to/bin/dir/swift-api-dump.py -swift-version 3 -o output-dir \
+#   /path/to/bin/dir/swift-api-dump.py -swift-version 4 -o output-dir \
 #       -m UIKit -s iphoneos
 #
 # The "-m" argument can be omitted, in which case the script will collect
@@ -15,9 +15,9 @@
 #
 # One can supply multiple SDKs, written as a list. For example, to
 # dump the API for all frameworks across macOS, iOS, watchOS, and tvOS,
-# in Swift 4, use:
+# in Swift 4.2, use:
 #
-#  /path/to/bin/dir/swift-api-dump.py -swift-version 4 -o output-dir \
+#  /path/to/bin/dir/swift-api-dump.py -swift-version 4.2 -o output-dir \
 #      -s macosx iphoneos watchos appletvos
 #
 
@@ -102,7 +102,7 @@ def create_parser():
     parser.add_argument('--enable-infer-import-as-member', action='store_true',
                         help='Infer when a global could be imported as a ' +
                         'member.')
-    parser.add_argument('-swift-version', type=int, metavar='N',
+    parser.add_argument('-swift-version', metavar='N',
                         help='the Swift version to use')
     parser.add_argument('-show-overlay', action='store_true',
                         help='Show overlay API in addition to Objective-C ' +
@@ -326,7 +326,7 @@ def main():
     if args.enable_infer_import_as_member:
         extra_args = extra_args + ['-enable-infer-import-as-member']
     if args.swift_version:
-        extra_args = extra_args + ['-swift-version', '%d' % args.swift_version]
+        extra_args = extra_args + ['-swift-version', '%s' % args.swift_version]
 
     # Create a .swift file we can feed into swift-ide-test
     subprocess.call(['touch', source_filename])


### PR DESCRIPTION
Two small usability fixes for swift-api-dump.py:

* Make sure that `swift-ide-test` complains if the module specified to be printed isn't found (fixes rdar://problem/41048812), and
* Allow "-swift-version 4.2", rather than only integer version numbers (fixes rdar://problem/41141987)