### PR TITLE
[Build System] Ninja should build using the Host OS toolchain

### DIFF
--- a/utils/swift_build_support/swift_build_support/products/ninja.py
+++ b/utils/swift_build_support/swift_build_support/products/ninja.py
@@ -35,7 +35,7 @@ class Ninja(product.Product):
 
         env = None
         if platform.system() == 'Darwin':
-            sysroot = os.environ.get('SDKROOT', xcrun.sdk_path('macosx'))
+            sysroot = xcrun.sdk_path('macosx')
             assert sysroot is not None
 
             osx_version_min = self.args.darwin_deployment_version_osx


### PR DESCRIPTION
# Purpose

This PR partially reverts changes from #13829 forcing Ninja to build using the Host OS toolchain (i.e. macOS) rather than using the `SDKROOT` environment variable.

rdar://40458074