### PR TITLE
Fixed _swift_dispatch_apply_current() for LLP64 platforms

### DIFF
--- a/stdlib/public/SwiftShims/DispatchOverlayShims.h
+++ b/stdlib/public/SwiftShims/DispatchOverlayShims.h
@@ -195,9 +195,9 @@ static inline void _swift_dispatch_after(
 
 static inline void _swift_dispatch_apply_current(
     size_t iterations,
-    void SWIFT_DISPATCH_NOESCAPE (^block)(long)) {
+    void SWIFT_DISPATCH_NOESCAPE (^block)(size_t)) {
   dispatch_apply(iterations, (dispatch_queue_t _Nonnull)0, ^(size_t i){
-    block((long)i);
+    block(i);
   });
 }
 


### PR DESCRIPTION
The implementation of the _swift_dispatch_apply_current() function used `long` instead of `size_t` which means that it would try to call the block with a 64bit value in a L64 environment and with a 32bit value in a LLP64 environment. However this function needs to call the block consistently with a 64bit value in LP64 and LLP64 environments.

This make this part of the libdispatch Swift overlay compile on Windows where it would previously fail to compile because `long` gets mapped to `Int32` on Windows since its a 32bit value there.
