### PR TITLE
Enable strict verification of begin_access patterns in all SIL passes.

### DIFF
--- a/include/swift/SIL/SILGlobalVariable.h
+++ b/include/swift/SIL/SILGlobalVariable.h
@@ -68,7 +68,8 @@ private:
   /// once (either in its declaration, or once later), making it immutable.
   unsigned IsLet : 1;
 
-  /// The VarDecl associated with this SILGlobalVariable. For debugger purpose.
+  /// The VarDecl associated with this SILGlobalVariable. Must by nonnull for
+  /// language-level global variables.
   VarDecl *VDecl;
 
   /// Whether or not this is a declaration.

--- a/lib/SIL/SILVerifier.cpp
+++ b/lib/SIL/SILVerifier.cpp
@@ -1581,17 +1581,21 @@ public:
             "category");
   }
 
+  template <class AI>
+  void checkAccessEnforcement(AI *AccessInst) {
+    if (AccessInst->getModule().getStage() != SILStage::Raw) {
+      require(AccessInst->getEnforcement() != SILAccessEnforcement::Unknown,
+              "access must have known enforcement outside raw stage");
+    }
+  }
+
   void checkBeginAccessInst(BeginAccessInst *BAI) {
-    auto sourceOper = BAI->getOperand();
-    requireSameType(BAI->getType(), sourceOper->getType(),
+    requireSameType(BAI->getType(), BAI->getSource()->getType(),
                     "result must be same type as operand");
     require(BAI->getType().isAddress(),
             "begin_access operand must have address type");
 
-    if (BAI->getModule().getStage() != SILStage::Raw) {
-      require(BAI->getEnforcement() != SILAccessEnforcement::Unknown,
-              "access must have known enforcement outside raw stage");
-    }
+    checkAccessEnforcement(BAI);
 
     switch (BAI->getAccessKind()) {
     case SILAccessKind::Init:
@@ -1605,10 +1609,25 @@ public:
       break;
     }
 
-    // For dynamic Read/Modify access, AccessEnforcementWMO assumes a valid
-    // AccessedStorage and runs very late in the optimizer pipeline.
-    // TODO: eventually, make this true for any kind of access.
-    findAccessedStorage(sourceOper);
+    // Verify that all formal accesses patterns are recognized as part of a
+    // whitelist. The presence of an unknown pattern means that analysis will
+    // silently fail, and the compiler may be introducing undefined behavior
+    // with no other way to detect it.
+    //
+    // For example, AccessEnforcementWMO runs very late in the
+    // pipeline and assumes valid storage for all dynamic Read/Modify access. It
+    // also requires that Unidentified access fit a whitelist on known
+    // non-internal globals or class properties.
+    //
+    // First check that findAccessedStorage returns without asserting. For
+    // Unsafe enforcement, that is sufficient. For any other enforcement
+    // level also require that it returns a valid AccessedStorage object.
+    // Unsafe enforcement is used for some unrecognizable access patterns,
+    // like debugger variables. The compiler never cares about the source of
+    // those accesses.
+    AccessedStorage storage = findAccessedStorage(BAI->getSource());
+    if (BAI->getEnforcement() != SILAccessEnforcement::Unsafe)
+      require(storage, "Unknown formal access pattern");
   }
 
   void checkEndAccessInst(EndAccessInst *EAI) {
@@ -1623,13 +1642,34 @@ public:
     }
   }
 
-  void checkBeginUnpairedAccessInst(BeginUnpairedAccessInst *I) {
-    require(I->getEnforcement() != SILAccessEnforcement::Unknown,
+  void checkBeginUnpairedAccessInst(BeginUnpairedAccessInst *BUAI) {
+    require(BUAI->getEnforcement() != SILAccessEnforcement::Unknown,
             "unpaired access can never use unknown enforcement");
-    require(I->getSource()->getType().isAddress(),
+    require(BUAI->getSource()->getType().isAddress(),
             "address operand must have address type");
-    requireAddressType(BuiltinUnsafeValueBufferType, I->getBuffer(),
+    requireAddressType(BuiltinUnsafeValueBufferType, BUAI->getBuffer(),
                        "scratch buffer operand");
+
+    checkAccessEnforcement(BUAI);
+
+    switch (BUAI->getAccessKind()) {
+    case SILAccessKind::Init:
+    case SILAccessKind::Deinit:
+      require(BUAI->getEnforcement() == SILAccessEnforcement::Static,
+              "init/deinit accesses cannot use non-static enforcement");
+      break;
+    case SILAccessKind::Read:
+    case SILAccessKind::Modify:
+      break;
+    }
+
+    // First check that findAccessedStorage never asserts.
+    AccessedStorage storage = findAccessedStorage(BUAI->getSource());
+    // Only allow Unsafe and Builtin access to have invalid storage.
+    if (BUAI->getEnforcement() != SILAccessEnforcement::Unsafe
+        && !BUAI->isFromBuiltin()) {
+      require(storage, "Unknown formal access pattern");
+    }
   }
 
   void checkEndUnpairedAccessInst(EndUnpairedAccessInst *I) {
@@ -1637,6 +1677,8 @@ public:
             "unpaired access can never use unknown enforcement");
     requireAddressType(BuiltinUnsafeValueBufferType, I->getBuffer(),
                        "scratch buffer operand");
+
+    checkAccessEnforcement(I);
   }
 
   void checkStoreInst(StoreInst *SI) {

--- a/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
+++ b/lib/SILOptimizer/Analysis/AccessSummaryAnalysis.cpp
@@ -68,13 +68,15 @@ void AccessSummaryAnalysis::processArgument(FunctionInfo *info,
     switch (user->getKind()) {
     case SILInstructionKind::BeginAccessInst: {
       auto *BAI = cast<BeginAccessInst>(user);
-      const IndexTrieNode *subPath = findSubPathAccessed(BAI);
-      summary.mergeWith(BAI->getAccessKind(), BAI->getLoc(), subPath);
-      // We don't add the users of the begin_access to the worklist because
-      // even if these users eventually begin an access to the address
-      // or a projection from it, that access can't begin more exclusive
-      // access than this access -- otherwise it will be diagnosed
-      // elsewhere.
+      if (BAI->getEnforcement() != SILAccessEnforcement::Unsafe) {
+        const IndexTrieNode *subPath = findSubPathAccessed(BAI);
+        summary.mergeWith(BAI->getAccessKind(), BAI->getLoc(), subPath);
+        // We don't add the users of the begin_access to the worklist because
+        // even if these users eventually begin an access to the address
+        // or a projection from it, that access can't begin more exclusive
+        // access than this access -- otherwise it will be diagnosed
+        // elsewhere.
+      }
       break;
     }
     case SILInstructionKind::EndUnpairedAccessInst:

--- a/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
+++ b/lib/SILOptimizer/Mandatory/AccessMarkerElimination.cpp
@@ -32,9 +32,6 @@ using namespace swift;
 // This temporary option allows markers during optimization passes. Enabling
 // this flag causes this pass to preserve only dynamic checks when dynamic
 // checking is enabled. Otherwise, this pass removes all checks.
-//
-// This is currently unsupported because tail duplication results in
-// address-type block arguments.
 llvm::cl::opt<bool> EnableOptimizedAccessMarkers(
     "sil-optimized-access-markers", llvm::cl::init(true),
     llvm::cl::desc("Enable memory access markers during optimization passes."));

--- a/test/SILOptimizer/accessed_storage_analysis.sil
+++ b/test/SILOptimizer/accessed_storage_analysis.sil
@@ -129,45 +129,207 @@ bb0(%0 : $Int):
   return %6 : $Int
 }
 
-sil_global @int_global : $Int
+public var defined_global: Int64
 
-// CHECK-LABEL: @readIdentifiedGlobal
-// CHECK: [read] Global // int_global
-// CHECK: sil_global @int_global : $Int
-sil @readIdentifiedGlobal : $@convention(thin) () -> Int {
+// defined_global definition and initializer.
+//
+// A global defined in the current module must have a Swift declaration.
+// The variable name is derived from the mangled SIL name.
+sil_global @$S25accessed_storage_analysis14defined_globalSivp : $Int64
+
+sil_global private @globalinit_33_45D320C25F1882286C6F155330EA3839_token0 : $Builtin.Word
+
+sil private @globalinit_33_45D320C25F1882286C6F155330EA3839_func0 : $@convention(c) () -> () {
 bb0:
-  %1 = global_addr @int_global : $*Int
-  %2 = begin_access [read] [dynamic] %1 : $*Int
-  %3 = load %2 : $*Int
-  end_access %2 : $*Int
-  return %3 : $Int
+  alloc_global @$S25accessed_storage_analysis14defined_globalSivp
+  %1 = global_addr @$S25accessed_storage_analysis14defined_globalSivp : $*Int64
+  %2 = integer_literal $Builtin.Int64, 0
+  %3 = struct $Int64 (%2 : $Builtin.Int64)
+  store %3 to %1 : $*Int64
+  %5 = tuple ()
+  return %5 : $()
 }
 
-// CHECK-LABEL: @writeIdentifiedGlobal
-// CHECK: [modify] Global // int_global
-// CHECK: sil_global @int_global : $Int
-sil @writeIdentifiedGlobal : $@convention(thin) (Int) -> () {
-bb0(%0 : $Int):
-  %1 = global_addr @int_global : $*Int
-  %2 = begin_access [modify] [dynamic] %1 : $*Int
-  store %0 to %2 : $*Int
-  end_access %2 : $*Int
+// defined_global.unsafeMutableAddressor
+sil hidden [global_init] @$S25accessed_storage_analysis14defined_globalSivau : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = global_addr @globalinit_33_45D320C25F1882286C6F155330EA3839_token0 : $*Builtin.Word
+  %1 = address_to_pointer %0 : $*Builtin.Word to $Builtin.RawPointer
+  %2 = function_ref @globalinit_33_45D320C25F1882286C6F155330EA3839_func0 : $@convention(c) () -> ()
+  %3 = builtin "once"(%1 : $Builtin.RawPointer, %2 : $@convention(c) () -> ()) : $()
+  %4 = global_addr @$S25accessed_storage_analysis14defined_globalSivp : $*Int64
+  %5 = address_to_pointer %4 : $*Int64 to $Builtin.RawPointer
+  return %5 : $Builtin.RawPointer
+}
+
+// CHECK-LABEL: @readIdentifiedDefinedGlobal
+// CHECK: [read] Global // defined_global
+// CHECK: sil_global @$S25accessed_storage_analysis14defined_globalSivp : $Int64
+sil @readIdentifiedDefinedGlobal : $@convention(thin) () -> Int64 {
+bb0:
+  %1 = global_addr @$S25accessed_storage_analysis14defined_globalSivp : $*Int64
+  %2 = begin_access [read] [dynamic] %1 : $*Int64
+  %3 = load %2 : $*Int64
+  end_access %2 : $*Int64
+  return %3 : $Int64
+}
+
+// CHECK-LABEL: @writeIdentifiedDefinedGlobal
+// CHECK: [modify] Global // defined_global
+// CHECK: sil_global @$S25accessed_storage_analysis14defined_globalSivp : $Int64
+sil @writeIdentifiedDefinedGlobal : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  %1 = global_addr @$S25accessed_storage_analysis14defined_globalSivp : $*Int64
+  %2 = begin_access [modify] [dynamic] %1 : $*Int64
+  store %0 to %2 : $*Int64
+  end_access %2 : $*Int64
   %v = tuple ()
   return %v : $()
 }
 
-// CHECK-LABEL: @readWriteIdentifiedGlobal
-// CHECK: [modify] Global // int_global
-// CHECK: sil_global @int_global : $Int
-sil @readWriteIdentifiedGlobal : $@convention(thin) (Int) -> (Int) {
-bb0(%0 : $Int):
-  %1 = function_ref @writeIdentifiedGlobal : $@convention(thin) (Int) -> ()
-  %2 = apply %1(%0) : $@convention(thin) (Int) -> ()
-  %3 = global_addr @int_global : $*Int
-  %4 = begin_access [read] [dynamic] %3 : $*Int
-  %5 = load %4 : $*Int
-  end_access %4 : $*Int
-  return %5 : $Int
+// CHECK-LABEL: @readWriteIdentifiedDefinedGlobal
+// CHECK: [modify] Global // defined_global
+// CHECK: sil_global @$S25accessed_storage_analysis14defined_globalSivp : $Int64
+sil @readWriteIdentifiedDefinedGlobal : $@convention(thin) (Int64) -> (Int64) {
+bb0(%0 : $Int64):
+  %1 = function_ref @writeIdentifiedDefinedGlobal : $@convention(thin) (Int64) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (Int64) -> ()
+  %3 = global_addr @$S25accessed_storage_analysis14defined_globalSivp : $*Int64
+  %4 = begin_access [read] [dynamic] %3 : $*Int64
+  %5 = load %4 : $*Int64
+  end_access %4 : $*Int64
+  return %5 : $Int64
+}
+
+// CHECK-LABEL: @readIdentifiedAddressedGlobal
+// CHECK: [read] Global // defined_global
+// CHECK: sil_global @$S25accessed_storage_analysis14defined_globalSivp : $Int64
+sil @readIdentifiedAddressedGlobal : $@convention(thin) () -> Int64 {
+bb0:
+  // function_ref myGlobal.unsafeMutableAddressor
+  %0 = function_ref @$S25accessed_storage_analysis14defined_globalSivau : $@convention(thin) () -> Builtin.RawPointer
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Int64
+  %3 = begin_access [read] [dynamic] %2 : $*Int64
+  %4 = load %3 : $*Int64
+  end_access %3 : $*Int64
+  return %4 : $Int64
+}
+
+// CHECK-LABEL: @writeIdentifiedAddressedGlobal
+// CHECK: [modify] Global // defined_global
+// CHECK: sil_global @$S25accessed_storage_analysis14defined_globalSivp : $Int64
+sil @writeIdentifiedAddressedGlobal : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  // function_ref myGlobal.unsafeMutableAddressor
+  %1 = function_ref @$S25accessed_storage_analysis14defined_globalSivau : $@convention(thin) () -> Builtin.RawPointer
+  %2 = apply %1() : $@convention(thin) () -> Builtin.RawPointer
+  %3 = pointer_to_address %2 : $Builtin.RawPointer to [strict] $*Int64
+  %4 = begin_access [modify] [dynamic] %3 : $*Int64
+  store %0 to %4 : $*Int64
+  end_access %4 : $*Int64
+  %v = tuple ()
+  return %v : $()
+}
+
+// CHECK-LABEL: @readWriteIdentifiedAddressedGlobal
+// CHECK: [modify] Global // defined_global
+// CHECK: sil_global @$S25accessed_storage_analysis14defined_globalSivp : $Int64
+sil @readWriteIdentifiedAddressedGlobal : $@convention(thin) (Int64) -> (Int64) {
+bb0(%0 : $Int64):
+  %1 = function_ref @writeIdentifiedAddressedGlobal : $@convention(thin) (Int64) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (Int64) -> ()
+  // function_ref myGlobal.unsafeMutableAddressor
+  %3 = function_ref @$S25accessed_storage_analysis14defined_globalSivau : $@convention(thin) () -> Builtin.RawPointer
+  %4 = apply %3() : $@convention(thin) () -> Builtin.RawPointer
+  %5 = pointer_to_address %4 : $Builtin.RawPointer to [strict] $*Int64
+  %6 = begin_access [modify] [dynamic] %5 : $*Int64
+  %7 = load %6 : $*Int64
+  end_access %6 : $*Int64
+  return %7 : $Int64
+}
+
+public var static_global: Int64
+
+// static_global definition and static initializer.
+//
+// A global defined in the current module must have a Swift declaration.
+// The variable name is derived from the mangled SIL name.
+sil_global @$S25accessed_storage_analysis13static_globalSivp : $Int64 = {
+  %0 = integer_literal $Builtin.Int64, 0
+  %initval = struct $Int64 (%0 : $Builtin.Int64)
+}
+
+// static_global.unsafeMutableAddressor
+sil hidden [global_init] @$S25accessed_storage_analysis13static_globalSivau : $@convention(thin) () -> Builtin.RawPointer {
+bb0:
+  %0 = global_addr @$S25accessed_storage_analysis14defined_globalSivp : $*Int64
+  %1 = address_to_pointer %0 : $*Int64 to $Builtin.RawPointer
+  return %1 : $Builtin.RawPointer
+}
+
+// A sil_global such as this without a corresponding Swift declaration must be
+// defined in another module. Such a global can only be identified when accessed
+// via global_addr instruction (as happens with C imports). Any access via an
+// addessor (as with Swift imports) will be Unidentified. For the purpose of
+// access analysis, a global is considered "external" based on the availabitiy
+// of a Swift declaraion. We only consider an global to be a disjoint access
+// location if its declaration is available.
+sil_global @external_global : $Int64
+
+sil hidden_external [global_init] @globalAddressor : $@convention(thin) () -> Builtin.RawPointer
+
+// CHECK-LABEL: @readIdentifiedExternalGlobal
+// CHECK: [read] Global // external_global
+// CHECK: sil_global @external_global : $Int64
+sil @readIdentifiedExternalGlobal : $@convention(thin) () -> Int64 {
+bb0:
+  %1 = global_addr @external_global : $*Int64
+  %2 = begin_access [read] [dynamic] %1 : $*Int64
+  %3 = load %2 : $*Int64
+  end_access %2 : $*Int64
+  return %3 : $Int64
+}
+
+// CHECK-LABEL: @writeIdentifiedExternalGlobal
+// CHECK: [modify] Global // external_global
+// CHECK: sil_global @external_global : $Int64
+sil @writeIdentifiedExternalGlobal : $@convention(thin) (Int64) -> () {
+bb0(%0 : $Int64):
+  %1 = global_addr @external_global : $*Int64
+  %2 = begin_access [modify] [dynamic] %1 : $*Int64
+  store %0 to %2 : $*Int64
+  end_access %2 : $*Int64
+  %v = tuple ()
+  return %v : $()
+}
+
+// CHECK-LABEL: @readWriteIdentifiedExternalGlobal
+// CHECK: [modify] Global // external_global
+// CHECK: sil_global @external_global : $Int64
+sil @readWriteIdentifiedExternalGlobal : $@convention(thin) (Int64) -> (Int64) {
+bb0(%0 : $Int64):
+  %1 = function_ref @writeIdentifiedExternalGlobal : $@convention(thin) (Int64) -> ()
+  %2 = apply %1(%0) : $@convention(thin) (Int64) -> ()
+  %3 = global_addr @external_global : $*Int64
+  %4 = begin_access [read] [dynamic] %3 : $*Int64
+  %5 = load %4 : $*Int64
+  end_access %4 : $*Int64
+  return %5 : $Int64
+}
+
+// CHECK-LABEL: @readUnidentifiedExternalGlobal
+// CHECK-NOT: Global
+// CHECK: unidentified accesses: modify
+sil @readUnidentifiedExternalGlobal : $@convention(thin) () -> Int64 {
+bb0:
+  %0 = function_ref @globalAddressor : $@convention(thin) () -> Builtin.RawPointer
+  %1 = apply %0() : $@convention(thin) () -> Builtin.RawPointer
+  %2 = pointer_to_address %1 : $Builtin.RawPointer to [strict] $*Int64
+  %3 = begin_access [read] [dynamic] %2 : $*Int64
+  %4 = load %3 : $*Int64
+  end_access %3 : $*Int64
+  return %4 : $Int64
 }
 
 class C {
@@ -262,42 +424,6 @@ bb0(%0 : $Int):
   return %7 : $Int
 }
 
-// CHECK-LABEL: @readUnidentified
-// CHECK: unidentified accesses: read
-sil @readUnidentified : $@convention(thin) (Builtin.RawPointer) -> Int {
-bb0(%0 : $Builtin.RawPointer):
-  %1 = pointer_to_address %0 : $Builtin.RawPointer to $*Int
-  %2 = begin_access [read] [dynamic] %1 : $*Int
-  %4 = load %2 : $*Int
-  end_access %2 : $*Int
-  return %4 : $Int
-}
-
-// CHECK-LABEL: @writeUnidentified
-// CHECK: unidentified accesses: modify
-sil @writeUnidentified : $@convention(thin) (Builtin.RawPointer, Int) -> () {
-bb0(%0 : $Builtin.RawPointer, %1 : $Int):
-  %2 = pointer_to_address %0 : $Builtin.RawPointer to $*Int
-  %3 = begin_access [modify] [dynamic] %2 : $*Int
-  store %1 to %3 : $*Int
-  end_access %3 : $*Int
-  %v = tuple ()
-  return %v : $()
-}
-
-// CHECK-LABEL: @readWriteUnidentified
-// CHECK: unidentified accesses: modify
-sil @readWriteUnidentified : $@convention(thin) (Builtin.RawPointer, Int) -> Int {
-bb0(%0 : $Builtin.RawPointer, %1 : $Int):
-  %2 = function_ref @writeUnidentified : $@convention(thin) (Builtin.RawPointer, Int) -> ()
-  %3 = apply %2(%0, %1) : $@convention(thin) (Builtin.RawPointer, Int) -> ()
-  %4 = pointer_to_address %0 : $Builtin.RawPointer to $*Int
-  %5 = begin_access [read] [dynamic] %4 : $*Int
-  %6 = load %5 : $*Int
-  end_access %5 : $*Int
-  return %6 : $Int
-}
-
 enum TreeB<T> {
   case Nil
   case Leaf(T)
@@ -360,13 +486,6 @@ class CP : P {
 // CHECK: unidentified accesses: read
 sil @readUnexpected : $@convention(thin) (@inout Int, @inout Int?, @inout Builtin.UnsafeValueBuffer) -> () {
 bb0(%inout : $*Int, %oi : $*Optional<Int>, %b : $*Builtin.UnsafeValueBuffer):
-  br bb1(%inout : $*Int)
-
-bb1(%phi : $*Int):
-  %phiAccess = begin_access [read] [dynamic] %phi : $*Int
-  %ld = load %phiAccess : $*Int
-  end_access %phiAccess : $*Int
-
   %ea = init_enum_data_addr %oi : $*Optional<Int>, #Optional.some!enumelt.1
   %eaAccess = begin_access [read] [dynamic] %ea : $*Int
   %eaload = load %eaAccess : $*Int

--- a/test/SILOptimizer/exclusivity_static_diagnostics.sil
+++ b/test/SILOptimizer/exclusivity_static_diagnostics.sil
@@ -990,3 +990,35 @@ bb0(%0 : $Int):
   %v = tuple ()
   return %v : $()
 }
+
+class SomeClass {}
+
+// LLDB uses mark_uninitialized [var] in an unsupported way via an address to
+// pointer. LLDB shouldn't do this, but until it is removed and validated we
+// need a test for this.
+//
+// Check that this doesn't trigger the DiagnoseStaticExclusivity
+// assert that all accesses have a valid AccessedStorage source.
+sil @lldb_unsupported_markuninitialized_testcase : $@convention(thin) (UnsafeMutablePointer<Any>) -> () {
+bb0(%0 : $UnsafeMutablePointer<Any>):
+  %2 = struct_extract %0 : $UnsafeMutablePointer<Any>, #UnsafeMutablePointer._rawValue
+  %3 = integer_literal $Builtin.Int64, 8
+  %4 = index_raw_pointer %2 : $Builtin.RawPointer, %3 : $Builtin.Int64
+  %5 = pointer_to_address %4 : $Builtin.RawPointer to [strict] $*Builtin.RawPointer
+  %6 = load [trivial] %5 : $*Builtin.RawPointer
+  %7 = pointer_to_address %6 : $Builtin.RawPointer to [strict] $*Error
+  %8 = mark_uninitialized [var] %7 : $*Error
+  %9 = struct_extract %0 : $UnsafeMutablePointer<Any>, #UnsafeMutablePointer._rawValue
+  %10 = integer_literal $Builtin.Int64, 0
+  %11 = index_raw_pointer %9 : $Builtin.RawPointer, %10 : $Builtin.Int64
+  %12 = pointer_to_address %11 : $Builtin.RawPointer to [strict] $*Builtin.RawPointer
+  %13 = load [trivial] %12 : $*Builtin.RawPointer
+  %14 = pointer_to_address %13 : $Builtin.RawPointer to [strict] $*@thick SomeClass.Type
+  %15 = mark_uninitialized [var] %14 : $*@thick SomeClass.Type
+  %16 = metatype $@thick SomeClass.Type
+  %17 = begin_access [modify] [unsafe] %15 : $*@thick SomeClass.Type
+  assign %16 to %17 : $*@thick SomeClass.Type
+  end_access %17 : $*@thick SomeClass.Type
+  %9999 = tuple()
+  return %9999 : $()
+}


### PR DESCRIPTION
This also adds handling additional cases like global addressors.