### PR TITLE
Revert "[TypeChecker] Fix crash with Objective C keypaths."

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -3280,8 +3280,7 @@ namespace {
       if (auto keyPath = dyn_cast<KeyPathExpr>(expr)) {
         if (keyPath->isObjC()) {
           auto &cs = CG.getConstraintSystem();
-          if (!cs.getTypeChecker().checkObjCKeyPathExpr(cs.DC, keyPath))
-            return { false, nullptr };
+          (void)cs.getTypeChecker().checkObjCKeyPathExpr(cs.DC, keyPath);
         }
       }
 

--- a/lib/Sema/TypeCheckExprObjC.cpp
+++ b/lib/Sema/TypeCheckExprObjC.cpp
@@ -2,7 +2,7 @@
 //
 // This source file is part of the Swift.org open source project
 //
-// Copyright (c) 2014 - 2018 Apple Inc. and the Swift project authors
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
 // Licensed under Apache License v2.0 with Runtime Library Exception
 //
 // See https://swift.org/LICENSE.txt for license information
@@ -317,10 +317,6 @@ Optional<Type> TypeChecker::checkObjCKeyPathExpr(DeclContext *dc,
     // Handle property references.
     if (auto var = dyn_cast<VarDecl>(found)) {
       validateDecl(var);
-      if (var->isInvalid() || !var->hasInterfaceType() ||
-          var->getInterfaceType()->hasError()) {
-        return None;
-      }
 
       // Resolve this component to the variable we found.
       auto varRef = ConcreteDeclRef(var);

--- a/test/expr/primary/keypath/keypath-objc.swift
+++ b/test/expr/primary/keypath/keypath-objc.swift
@@ -4,7 +4,7 @@ import Foundation
 
 // REQUIRES: objc_interop
 
-@objc class A : NSObject { // expected-error {{class 'A' has no initializers}}
+@objc class A : NSObject {
   @objc var propB: B = B()
   @objc var propString: String = "" // expected-note {{did you mean 'propString'}}
   @objc var propArray: [String] = []
@@ -21,8 +21,6 @@ import Foundation
   @objc func someMethod() { }
 
   @objc var `repeat`: String?
-
-  @objc var noType // expected-error {{type annotation missing in pattern}}
 }
 
 @objc class B : NSObject  {
@@ -107,9 +105,6 @@ func testKeyPath(a: A, b: B) {
 
   // Property with keyword name.
   let _: String = #keyPath(A.repeat)
-
-  // Property with no type
-  let _: String = #keyPath(A.noType)
 
   // Nested type of a bridged type (rdar://problem/28061409).
   typealias IntArray = [Int]


### PR DESCRIPTION
Reverts apple/swift#17497

It's a likely cause of a validation failure during source compatibility testing (CoreStore).

I'm still trying to reproduce the failure, but I'll back this out for the moment to get the builders back on their feet.