### PR TITLE
[SILOptimizer] Properly disconnect the signature optimized function from a parent class.

### DIFF
--- a/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
+++ b/lib/SILOptimizer/FunctionSignatureTransforms/FunctionSignatureOpts.cpp
@@ -496,11 +496,14 @@ void FunctionSignatureTransform::createFunctionSignatureOptimizedFunction() {
     NewFGenericEnv = nullptr;
   }
 
+  // The specialized function is an internal detail, so we need to disconnect it
+  // from a parent class, if one exists, thus the override of the
+  // classSubclassScope.
   TransformDescriptor.OptimizedFunction = M.createFunction(
       linkage, Name, NewFTy, NewFGenericEnv, F->getLocation(), F->isBare(),
       F->isTransparent(), F->isSerialized(), F->getEntryCount(), F->isThunk(),
-      F->getClassSubclassScope(), F->getInlineStrategy(), F->getEffectsKind(),
-      nullptr, F->getDebugScope());
+      /*classSubclassScope=*/SubclassScope::NotApplicable,
+      F->getInlineStrategy(), F->getEffectsKind(), nullptr, F->getDebugScope());
   SILFunction *NewF = TransformDescriptor.OptimizedFunction.get();
   if (!F->hasQualifiedOwnership()) {
     NewF->setUnqualifiedOwnership();

--- a/test/TBD/specialization.swift
+++ b/test/TBD/specialization.swift
@@ -17,6 +17,10 @@ open class Foo {
 }
 
 open class Bar<T> {
+    public init() {
+        bar()
+    }
+
     @inline(never)
     fileprivate func bar() {}
 }
@@ -28,8 +32,14 @@ public func f() {
 }
 
 
+// Generic specialization, from the foo call in f
 // CHECK-LABEL: // specialized Foo.foo<A>(_:)
 // CHECK-NEXT: sil private [noinline] @$S14specialization3FooC3foo33_A6E3E43DB6679655BDF5A878ABC489A0LLyyxmlFSi_Tg5Tf4dd_n : $@convention(thin) () -> ()
 
+// Function signature specialization, from the bar call in Bar.init
+// CHECK-LABEL: // specialized Bar.bar()
+// CHECK-NEXT: sil private [noinline] @$S14specialization3BarC3bar33_A6E3E43DB6679655BDF5A878ABC489A0LLyyFTf4d_n : $@convention(thin) () -> () {
+
+// Generic specialization, from the bar call in f
 // CHECK-LABEL: // specialized Bar.bar()
 // CHECK-NEXT: sil private [noinline] @$S14specialization3BarC3bar33_A6E3E43DB6679655BDF5A878ABC489A0LLyyFSi_Tg5Tf4d_n : $@convention(thin) () -> ()


### PR DESCRIPTION
The new function with an optimized signature _shouldn't_ have a non-trivial
classSubclassScope, even if the original function did, since the original
function (that becomes the thunk) is the symbol that serves that role.

Also part of rdar://problem/40738913

A missed case in https://github.com/apple/swift/pull/16959