### PR TITLE
Point the SILLocations of function-level SILDebugScopes to the beginn…

### DIFF
--- a/include/swift/SIL/SILLocation.h
+++ b/include/swift/SIL/SILLocation.h
@@ -406,6 +406,13 @@ public:
   /// Return the location as a DeclContext or null.
   DeclContext *getAsDeclContext() const;
 
+  /// Convert a specialized location kind into a regular location.
+  SILLocation getAsRegularLocation() {
+    SILLocation RegularLoc = *this;
+    RegularLoc.setLocationKind(RegularKind);
+    return RegularLoc;
+  }
+
   SourceLoc getDebugSourceLoc() const;
   SourceLoc getSourceLoc() const;
   SourceLoc getStartSourceLoc() const;

--- a/lib/SILGen/SILGenFunction.h
+++ b/lib/SILGen/SILGenFunction.h
@@ -441,7 +441,8 @@ public:
   void enterDebugScope(SILLocation Loc) {
     auto *Parent =
         DebugScopeStack.size() ? DebugScopeStack.back() : F.getDebugScope();
-    auto *DS = new (SGM.M) SILDebugScope(Loc, &getFunction(), Parent);
+    auto *DS = new (SGM.M)
+        SILDebugScope(Loc.getAsRegularLocation(), &getFunction(), Parent);
     DebugScopeStack.push_back(DS);
     B.setCurrentDebugScope(DS);
   }

--- a/test/DebugInfo/inlined-generics-basic.swift
+++ b/test/DebugInfo/inlined-generics-basic.swift
@@ -1,0 +1,42 @@
+// RUN: %target-swift-frontend -parse-as-library -module-name A -Xllvm -sil-print-debuginfo %s -g -O -o - -emit-sil | %FileCheck %s --check-prefix=SIL
+
+@inline(never)
+func yes() -> Bool { return true }
+
+@inline(never)
+func use<V>(_ v: V) {}
+
+@inline(__always)
+func h<U>(_ u: U) {
+  yes()
+  use(u)
+}
+
+#sourceLocation(file: "g.swift", line: 1)
+@inline(__always) func g<T>(_ t: T) {
+  if (yes()) {
+    use(t)
+  }
+}
+
+// SIL: sil_scope [[F:.*]] { {{.*}}parent @$S1A1CC1fyyqd__lF
+// SIL: sil_scope [[F0:.*]] { loc "f.swift":1:29 parent [[F]] }
+// SIL: sil_scope [[F_G_S:.*]] { loc "f.swift":5:5 parent [[F0]] }
+// SIL: sil_scope [[G_S:.*]] { loc "g.swift":2:3 {{.*}} inlined_at [[F_G_S]] }
+
+#sourceLocation(file: "C.swift", line: 1)
+public class C<R> {
+  let r : R
+  init(_ _r: R) { r = _r }
+
+  // SIL: // C.f<A>(_:)
+#sourceLocation(file: "f.swift", line: 1)
+  public func f<S> (_ s: S) {
+    // SIL: debug_value_addr %0 : $*S, let, name "s", argno 1,
+    // SIL-SAME:             scope [[F]]
+    // SIL: function_ref {{.*}}yes{{.*}} scope [[G_S]]
+    g(s)
+    g(r)
+    g((s, s))
+  }
+}


### PR DESCRIPTION
…ing of the scope.

This mostly makes textual SIL easier to read and has no effect on the generated DWARF.

<rdar://problem/28859432>
