### PR TITLE
[DefiniteInitialization] Check whether globals captured by top-level defer statements are initialized.

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -137,6 +137,9 @@ ERROR(variable_inout_before_initialized,none,
 ERROR(variable_closure_use_uninit,none,
       "%select{variable|constant}1 '%0' captured by a closure before being"
       " initialized", (StringRef, bool))
+ERROR(variable_defer_use_uninit,none,
+      "%select{variable|constant}1 '%0' used in defer before being"
+      " initialized", (StringRef, bool))
 ERROR(self_closure_use_uninit,none,
       "'self' captured by a closure before all members were initialized", ())
 

--- a/test/SILGen/toplevel.swift
+++ b/test/SILGen/toplevel.swift
@@ -102,6 +102,17 @@ fooUsesUninitializedValue()
 NotInitializedInteger = 10
 fooUsesUninitializedValue()
 
+// Test initialization of variables captured by top-level defer.
+
+// CHECK: alloc_global @$S8toplevel9uninitVarSiv
+// CHECK-NEXT: [[UNINIADDR:%[0-9]+]] = global_addr @$S8toplevel9uninitVarSiv
+// CHECK-NEXT: [[UNINIMUI:%[0-9]+]] = mark_uninitialized [var] [[UNINIADDR]] : $*Int
+// CHECK-NEXT: mark_function_escape [[UNINIMUI]] : $*Int
+var uninitVar: Int
+defer {
+  print(uninitVar)
+}
+
 
 
 

--- a/test/SILOptimizer/definite_init_diagnostics_globals.swift
+++ b/test/SILOptimizer/definite_init_diagnostics_globals.swift
@@ -1,0 +1,86 @@
+// RUN: %target-swift-frontend -emit-sil -enable-sil-ownership -primary-file %s -o /dev/null -verify
+
+import Swift
+
+// Tests for definite initialization of globals.
+
+var x: Int         // expected-note {{variable defined here}}
+                   // expected-note@-1 {{variable defined here}}
+                   // expected-note@-2 {{variable defined here}}
+                   // expected-note@-3 {{variable defined here}}
+
+let y: Int         // expected-note {{constant defined here}}
+                   // expected-note@-1 {{constant defined here}}
+                   // expected-note@-2 {{constant defined here}}
+
+// Test top-level defer.
+defer { print(x) } // expected-error {{variable 'x' used in defer before being initialized}}
+
+defer { print(y) } // expected-error {{constant 'y' used in defer before being initialized}}
+
+// Test top-level functions.
+
+func testFunc() {       // expected-error {{variable 'x' used by function definition before being initialized}}
+  defer { print(x) }
+}
+
+// Test top-level closures.
+
+let clo: () -> Void = { print(y) } // expected-error {{constant 'y' captured by a closure before being initialized}}
+clo()
+
+({ () -> Void in print(x) })() // expected-error {{variable 'x' captured by a closure before being initialized}}
+
+let clo2: () -> Void = { [x] in print(x) } // expected-error {{variable 'x' used before being initialized}}
+clo2()
+
+class C {
+  var f = 0
+}
+
+var c: C  // expected-note {{variable defined here}}
+
+let clo3: () -> Void = { [weak c] in  // expected-error {{variable 'c' used before being initialized}}
+  guard let cref = c else{ return }
+  print(cref)
+}
+clo3()
+
+// Test inner functions.
+
+func testFunc2() {    // expected-error {{constant 'y' used by function definition before being initialized}}
+  func innerFunc() {
+    print(y)
+  }
+}
+
+// Test class initialization and methods.
+
+var w: String  // expected-note {{variable defined here}}
+               // expected-note@-1 {{variable defined here}}
+               // expected-note@-2 {{variable defined here}}
+
+// FIXME: the error should blame the class definition: <rdar://41490541>.
+class TestClass1 { // expected-error {{variable 'w' used by function definition before being initialized}}
+  let fld = w
+}
+
+class TestClass2 {
+  init() {        // expected-error {{variable 'w' used by function definition before being initialized}}
+    print(w)
+  }
+
+  func bar() {    // expected-error {{variable 'w' used by function definition before being initialized}}
+    print(w)
+  }
+}
+
+// Test initialization of global variables of protocol type.
+
+protocol P {
+  var f: Int { get }
+}
+
+var p: P    // expected-note {{variable defined here}}
+
+defer { print(p.f) } // expected-error {{variable 'p' used in defer before being initialized}}


### PR DESCRIPTION
<rdar://30720636>