### PR TITLE
[4.2] SILGen: Pseudogeneric partial applications do not produce pseudogeneric results.

### DIFF
--- a/lib/SIL/SILBuilder.cpp
+++ b/lib/SIL/SILBuilder.cpp
@@ -61,8 +61,9 @@ SILType SILBuilder::getPartialApplyResultType(SILType origTy, unsigned argCount,
   auto params = FTI->getParameters();
   auto newParams = params.slice(0, params.size() - argCount);
 
-  auto extInfo = FTI->getExtInfo().withRepresentation(
-      SILFunctionType::Representation::Thick);
+  auto extInfo = FTI->getExtInfo()
+    .withRepresentation(SILFunctionType::Representation::Thick)
+    .withIsPseudogeneric(false);
 
   // If the original method has an @unowned_inner_pointer return, the partial
   // application thunk will lifetime-extend 'self' for us, converting the

--- a/lib/SILGen/SILGenBridging.cpp
+++ b/lib/SILGen/SILGenBridging.cpp
@@ -514,7 +514,7 @@ ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
   // escaped by storing a withoutActuallyEscaping closure in the block and after
   // the block is ultimately destroyed checking that the closure is uniquely
   // referenced.
-  bool useWithoutEscapingVerifcation = false;
+  bool useWithoutEscapingVerification = false;
 	ManagedValue escaping;
   if (loweredFuncTy->isNoEscape()) {
     auto escapingTy = loweredFuncTy->getWithExtInfo(
@@ -527,7 +527,7 @@ ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
         funcType.withExtInfo(funcType->getExtInfo().withNoEscape(false));
     funcType = escapingAnyTy;
     fn = B.createCopyValue(loc, escaping);
-    useWithoutEscapingVerifcation = true;
+    useWithoutEscapingVerification = true;
   }
 
   // Build the invoke function signature. The block will capture the original
@@ -597,7 +597,7 @@ ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
     // another reference for the is_escaping sentinel.
     buildFuncToBlockInvokeBody(thunkSGF, loc, funcType, blockType,
                                loweredFuncTy, loweredBlockTy, storageTy,
-                               useWithoutEscapingVerifcation);
+                               useWithoutEscapingVerification);
   }
 
   // Form the block on the stack.
@@ -617,7 +617,7 @@ ManagedValue SILGenFunction::emitFuncToBlock(SILLocation loc,
   // copy_block_without_escaping %block withoutEscaping %closure instruction.
   // A mandatory SIL pass will replace this instruction by the required
   // verification instruction sequence.
-  auto heapBlock = useWithoutEscapingVerifcation
+  auto heapBlock = useWithoutEscapingVerification
                        ? SILValue(B.createCopyBlockWithoutEscaping(
                              loc, stackBlock, escaping.forward(*this)))
                        : SILValue(B.createCopyBlock(loc, stackBlock));

--- a/test/Reflection/capture_descriptors.sil
+++ b/test/Reflection/capture_descriptors.sil
@@ -210,11 +210,11 @@ bb0(%t: $T, %u: $U):
   return %12 : $()
 }
 
-sil @pseudogeneric_caller : $@convention(thin) @pseudogeneric <A : AnyObject, B : AnyObject, C : AnyObject> (@owned A, @owned B) -> @owned @pseudogeneric @callee_guaranteed () -> () {
+sil @pseudogeneric_caller : $@convention(thin) @pseudogeneric <A : AnyObject, B : AnyObject, C : AnyObject> (@owned A, @owned B) -> @owned @callee_guaranteed () -> () {
 bb0(%a: $A, %b: $B):
   %f = function_ref @pseudogeneric_callee : $@convention(thin) @pseudogeneric <T : AnyObject, U : AnyObject> (@owned T, @owned U) -> ()
   %c = partial_apply [callee_guaranteed] %f<A, B>(%a, %b) : $@convention(thin) @pseudogeneric <A : AnyObject, B : AnyObject> (@owned A, @owned B) -> ()
-  return %c : $@pseudogeneric @callee_guaranteed () -> ()
+  return %c : $@callee_guaranteed () -> ()
 }
 
 // CHECK:      - Capture types:

--- a/test/SILGen/Inputs/objc_block_to_func_to_block.h
+++ b/test/SILGen/Inputs/objc_block_to_func_to_block.h
@@ -1,0 +1,7 @@
+@import Foundation;
+
+@interface Foo<A>: NSObject
+
+- (void)blockInception:(void (^ _Nonnull)(void (^ _Nonnull)(void (^ _Nonnull)(Foo<A> * _Nonnull))))b;
+
+@end

--- a/test/SILGen/objc_block_to_func_to_block.swift
+++ b/test/SILGen/objc_block_to_func_to_block.swift
@@ -1,0 +1,8 @@
+// RUN: %target-swift-frontend(mock-sdk: %clang-importer-sdk) -import-objc-header %S/Inputs/objc_block_to_func_to_block.h -emit-silgen -verify %s
+// REQUIRES: objc_interop
+
+import Foundation
+
+func bar<A>(x: Foo<A>) {
+  x.blockInception { f in f { _ = $0 } }
+}


### PR DESCRIPTION
partial_apply always fully applies the generic environment, so the result is not generic at all. Fixes rdar://problem/41474371 | SR-8107.