### PR TITLE
[4.2] [ConstraintSystem] Use the type cache to read types in constraint gen…

### DIFF
--- a/lib/Sema/CSGen.cpp
+++ b/lib/Sema/CSGen.cpp
@@ -2756,8 +2756,8 @@ namespace {
       auto locator = CS.getConstraintLocator(expr);
       auto projectedTy = CS.createTypeVariable(locator,
                                                TVO_CanBindToLValue);
-      CS.addKeyPathApplicationConstraint(expr->getKeyPath()->getType(),
-                                         expr->getBase()->getType(),
+      CS.addKeyPathApplicationConstraint(CS.getType(expr->getKeyPath()),
+                                         CS.getType(expr->getBase()),
                                          projectedTy,
                                          locator);
       return projectedTy;


### PR DESCRIPTION
…eration.

We should pretty much always be reading
expression types out of the type cache in the constraint system.

We only see key path applications here on the path where we are
diagnosing a failure.

I haven't yet managed to come up with a test case that reproduces a crash
here.

Fixes: rdar://problem/41306933
(cherry picked from commit d48fea83dd9be44e3227d97263b7db666e300826)
