### PR TITLE
[4.2] Several fixes for de/re/-mangling of generic typealiases

### DIFF
--- a/include/swift/AST/ASTMangler.h
+++ b/include/swift/AST/ASTMangler.h
@@ -197,6 +197,15 @@ protected:
 
   void appendBoundGenericArgs(Type type, bool &isFirstArgList);
 
+  /// Append the bound generics arguments for the given declaration context
+  /// based on a complete substitution map.
+  ///
+  /// \returns the number of generic parameters that were emitted
+  /// thus far.
+  unsigned appendBoundGenericArgs(DeclContext *dc,
+                                  SubstitutionMap subs,
+                                  bool &isFirstArgList);
+
   /// Append any retroactive conformances.
   void appendRetroactiveConformances(Type type);
 

--- a/lib/AST/ASTMangler.cpp
+++ b/lib/AST/ASTMangler.cpp
@@ -22,6 +22,7 @@
 #include "swift/AST/Initializer.h"
 #include "swift/AST/Module.h"
 #include "swift/AST/ParameterList.h"
+#include "swift/AST/PrettyStackTrace.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/ProtocolConformanceRef.h"
 #include "swift/Basic/Defer.h"
@@ -380,6 +381,9 @@ std::string ASTMangler::mangleReabstractionThunkHelper(
 
 std::string ASTMangler::mangleTypeForDebugger(Type Ty, const DeclContext *DC,
                                               GenericEnvironment *GE) {
+  PrettyStackTraceType prettyStackTrace(Ty->getASTContext(),
+                                        "mangling type for debugger", Ty);
+
   GenericEnv = GE;
   DWARFMangling = true;
   beginMangling();
@@ -746,17 +750,13 @@ void ASTMangler::appendType(Type type) {
         return appendType(aliasTy->getSinglyDesugaredType());
       }
 
-      if (type->isSpecialized()) {
+      if (aliasTy->getSubstitutionMap().hasAnySubstitutableParams()) {
         // Try to mangle the entire name as a substitution.
         if (tryMangleSubstitution(tybase))
           return;
 
         appendAnyGenericType(decl);
         bool isFirstArgList = true;
-        if (auto *nominalType = type->getAs<NominalType>()) {
-          if (nominalType->getParent())
-            type = nominalType->getParent();
-        }
         appendBoundGenericArgs(type, isFirstArgList);
         appendRetroactiveConformances(type);
         appendOperator("G");
@@ -1080,16 +1080,68 @@ void ASTMangler::bindGenericParameters(const DeclContext *DC) {
     bindGenericParameters(sig->getCanonicalSignature());
 }
 
+unsigned ASTMangler::appendBoundGenericArgs(DeclContext *dc,
+                                            SubstitutionMap subs,
+                                            bool &isFirstArgList) {
+  auto decl = dc->getInnermostDeclarationDeclContext();
+  if (!decl) return 0;
+
+  // Handle the generic arguments of the parent.
+  unsigned currentGenericParamIdx =
+    appendBoundGenericArgs(decl->getDeclContext(), subs, isFirstArgList);
+
+  // If this is potentially a generic context, emit a generic argument list.
+  if (auto genericContext = decl->getAsGenericContext()) {
+    if (isFirstArgList) {
+      appendOperator("y");
+      isFirstArgList = false;
+    } else {
+      appendOperator("_");
+    }
+
+    // If we are generic at this level, emit all of the replacements at
+    // this level.
+    if (genericContext->isGeneric()) {
+      auto genericParams = subs.getGenericSignature()->getGenericParams();
+      unsigned depth = genericParams[currentGenericParamIdx]->getDepth();
+      assert(genericContext->getGenericParams()->getDepth() == depth &&
+             "Depth mismatch mangling substitution map");
+      auto replacements = subs.getReplacementTypes();
+      for (unsigned lastGenericParamIdx = genericParams.size();
+           (currentGenericParamIdx != lastGenericParamIdx &&
+            genericParams[currentGenericParamIdx]->getDepth() == depth);
+           ++currentGenericParamIdx) {
+        Type replacementType = replacements[currentGenericParamIdx];
+        if (replacementType->hasArchetype())
+          replacementType = replacementType->mapTypeOutOfContext();
+
+        appendType(replacementType);
+      }
+    }
+  }
+
+  return currentGenericParamIdx;
+}
+
 void ASTMangler::appendBoundGenericArgs(Type type, bool &isFirstArgList) {
-  BoundGenericType *boundType = nullptr;
-  if (auto *unboundType = type->getAs<UnboundGenericType>()) {
+  TypeBase *typePtr = type.getPointer();
+  ArrayRef<Type> genericArgs;
+  if (auto *typeAlias = dyn_cast<NameAliasType>(typePtr)) {
+    appendBoundGenericArgs(typeAlias->getDecl(),
+                           typeAlias->getSubstitutionMap(),
+                           isFirstArgList);
+    return;
+  }
+
+  if (auto *unboundType = dyn_cast<UnboundGenericType>(typePtr)) {
     if (Type parent = unboundType->getParent())
       appendBoundGenericArgs(parent, isFirstArgList);
-  } else if (auto *nominalType = type->getAs<NominalType>()) {
+  } else if (auto *nominalType = dyn_cast<NominalType>(typePtr)) {
     if (Type parent = nominalType->getParent())
       appendBoundGenericArgs(parent, isFirstArgList);
   } else {
-    boundType = type->castTo<BoundGenericType>();
+    auto boundType = cast<BoundGenericType>(typePtr);
+    genericArgs = boundType->getGenericArgs();
     if (Type parent = boundType->getParent())
       appendBoundGenericArgs(parent, isFirstArgList);
   }
@@ -1099,10 +1151,8 @@ void ASTMangler::appendBoundGenericArgs(Type type, bool &isFirstArgList) {
   } else {
     appendOperator("_");
   }
-  if (boundType) {
-    for (Type arg : boundType->getGenericArgs()) {
-      appendType(arg);
-    }
+  for (Type arg : genericArgs) {
+    appendType(arg);
   }
 }
 

--- a/lib/Demangling/OldRemangler.cpp
+++ b/lib/Demangling/OldRemangler.cpp
@@ -1240,11 +1240,7 @@ void Remangler::mangleBuiltinTypeName(Node *node) {
 }
 
 void Remangler::mangleTypeAlias(Node *node, EntityContext &ctx) {
-  SubstitutionEntry entry;
-  if (trySubstitution(node, entry)) return;
-  Out << 'a';
-  mangleChildNodes(node); // context, identifier
-  addSubstitution(entry);
+  mangleAnyNominalType(node, ctx);
 }
 
 void Remangler::mangleFunctionType(Node *node) {
@@ -1825,6 +1821,9 @@ void Remangler::mangleAnyNominalType(Node *node, EntityContext &ctx) {
     break;
   case Node::Kind::Class:
     mangleNominalType(node, 'C', ctx);
+    break;
+  case Node::Kind::TypeAlias:
+    mangleNominalType(node, 'a', ctx);
     break;
   default:
     unreachable("bad nominal type kind");

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -474,6 +474,7 @@ void Remangler::mangleGenericArgs(Node *node, char &Separator) {
     case Node::Kind::Structure:
     case Node::Kind::Enum:
     case Node::Kind::Class:
+    case Node::Kind::TypeAlias:
       mangleGenericArgs(node->getChild(0), Separator);
       Buffer << Separator;
       Separator = '_';
@@ -1698,7 +1699,7 @@ void Remangler::mangleType(Node *node) {
 }
 
 void Remangler::mangleTypeAlias(Node *node) {
-  mangleAnyGenericType(node, "a");
+  mangleAnyNominalType(node);
 }
 
 void Remangler::mangleTypeList(Node *node) {
@@ -2043,6 +2044,7 @@ bool Demangle::isSpecialized(Node *node) {
     case Node::Kind::Structure:
     case Node::Kind::Enum:
     case Node::Kind::Class:
+    case Node::Kind::TypeAlias:
     case Node::Kind::OtherNominalType:
       return isSpecialized(node->getChild(0));
 
@@ -2059,6 +2061,7 @@ NodePointer Demangle::getUnspecialized(Node *node, NodeFactory &Factory) {
     case Node::Kind::Structure:
     case Node::Kind::Enum:
     case Node::Kind::Class:
+    case Node::Kind::TypeAlias:
     case Node::Kind::OtherNominalType: {
       NodePointer result = Factory.createNode(node->getKind());
       NodePointer parentOrModule = node->getChild(0);

--- a/lib/Demangling/Remangler.cpp
+++ b/lib/Demangling/Remangler.cpp
@@ -248,10 +248,10 @@ class Remangler {
   }
 
   void manglePureProtocol(Node *Proto) {
+    Proto = skipType(Proto);
     if (mangleStandardSubstitution(Proto))
       return;
     
-    Proto = skipType(Proto);
     mangleChildNodes(Proto);
   }
 

--- a/test/DebugInfo/DumpDeclFromMangledName.swift
+++ b/test/DebugInfo/DumpDeclFromMangledName.swift
@@ -39,3 +39,38 @@ func patatino() -> Int {
 }
 
 patatino()
+
+class Foo<T> {
+  var x : T
+  init(_ x : T) {
+    self.x = x
+  }
+}
+
+typealias Patatino<T> = Foo<T>
+
+public struct Outer<T> {
+  public struct Inner { }
+  public struct GenericInner<U> { }
+
+  public typealias Foo<U> = Outer<U>.Inner
+
+  public func blah() {
+    let foo: Foo<Int> = Outer<Int>.Inner()
+  }
+}
+
+extension Outer.GenericInner {
+  public typealias Bar = Int
+
+  public func useBar() {
+    let bar: Bar = 7
+  }
+}
+
+func main() -> Int {
+  var p : Patatino<Int> = Patatino(23);
+  return 0
+}
+
+let _ = main()

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -310,5 +310,5 @@ _$S3BBBBf0602365061_ ---> _$S3BBBBf0602365061_
 _$S3BBBBi0602365061_ ---> _$S3BBBBi0602365061_
 _$S3BBBBv0602365061_ ---> _$S3BBBBv0602365061_
 _T0lxxxmmmTk ---> _T0lxxxmmmTk
-$S4blah8PatatinoaySiGD -> blah.Patatino<Swift.Int>
-
+$S4blah8PatatinoaySiGD ---> blah.Patatino<Swift.Int>
+$SSiSHsWP ---> protocol witness table for Swift.Int : Swift.Hashable in Swift

--- a/test/Demangle/Inputs/manglings.txt
+++ b/test/Demangle/Inputs/manglings.txt
@@ -312,3 +312,5 @@ _$S3BBBBv0602365061_ ---> _$S3BBBBv0602365061_
 _T0lxxxmmmTk ---> _T0lxxxmmmTk
 $S4blah8PatatinoaySiGD ---> blah.Patatino<Swift.Int>
 $SSiSHsWP ---> protocol witness table for Swift.Int : Swift.Hashable in Swift
+$S7TestMod5OuterV3Fooayx_SiGD ---> TestMod.Outer<A>.Foo<Swift.Int>
+$Ss17_VariantSetBufferO05CocoaC0ayx_GD ---> Swift._VariantSetBuffer<A>.CocoaBuffer

--- a/test/IDE/print_module_missing.swift
+++ b/test/IDE/print_module_missing.swift
@@ -1,0 +1,11 @@
+// Make sure we emit some kind of error message when we cannot find the module
+// to print.
+
+// RUN: not %target-swift-ide-test -print-module -print-interface -no-empty-line-between-members -module-to-print=NoSuchModule -source-filename=%s 2> %t.err
+// RUN: %FileCheck %s -check-prefix=CHECK-MISSING < %t.err
+
+// RUN: not %target-swift-ide-test -print-module -print-interface -no-empty-line-between-members -module-to-print=Swift.NoSuchSubModule -source-filename=%s 2> %t.suberr
+// RUN: %FileCheck %s -check-prefix=CHECK-MISSING-SUBMODULE < %t.suberr
+
+// CHECK-MISSING: 'NoSuchModule'
+// CHECK-MISSING-SUBMODULE: 'Swift.NoSuchSubModule'

--- a/test/SILOptimizer/array_contentof_opt.swift
+++ b/test/SILOptimizer/array_contentof_opt.swift
@@ -32,7 +32,7 @@ public func testThreeInts(_ a: inout [Int]) {
 
 // CHECK-LABEL: sil @{{.*}}testTooManyInts
 // CHECK-NOT: apply
-// CHECK:        [[F:%[0-9]+]] = function_ref  @$SSa6append10contentsOfyqd___t7ElementQyd__Rszs8SequenceRd__lFSi_SaySiGTg5
+// CHECK:        [[F:%[0-9]+]] = function_ref  @$SSa6append10contentsOfyqd___t7ElementQyd__RszSTRd__lFSi_SaySiGTg5
 // CHECK-NOT: apply
 // CHECK:        apply [[F]]
 // CHECK-NOT: apply

--- a/test/SILOptimizer/eager_specialize.sil
+++ b/test/SILOptimizer/eager_specialize.sil
@@ -182,7 +182,7 @@ bb2:
 }
 
 // specialized divideNum<A where ...> (A, den : A) throws -> A
-// CHECK-LABEL: sil shared @$S16eager_specialize9divideNum_3denxx_xtKs13SignedIntegerRzlFSi_Tg5 : $@convention(thin) (Int, Int) -> (Int, @error Error) {
+// CHECK-LABEL: sil shared @$S16eager_specialize9divideNum_3denxx_xtKSZRzlFSi_Tg5 : $@convention(thin) (Int, Int) -> (Int, @error Error) {
 // CHECK: bb0(%0 : $Int, %1 : $Int):
 // CHECK: return %{{.*}}
 // CHECK: throw %{{.*}}
@@ -224,7 +224,7 @@ bb2:
 // CHECK:   %{{.*}} = unchecked_addr_cast %2 : $*T to $*Int
 // CHECK:   %{{.*}} = load %{{.*}} : $*Int
 // CHECK:   // function_ref specialized divideNum<A>(_:den:)
-// CHECK:   %{{.*}} = function_ref @$S16eager_specialize9divideNum_3denxx_xtKs13SignedIntegerRzlFSi_Tg5 : $@convention(thin) (Int, Int) -> (Int, @error Error)
+// CHECK:   %{{.*}} = function_ref @$S16eager_specialize9divideNum_3denxx_xtKSZRzlFSi_Tg5 : $@convention(thin) (Int, Int) -> (Int, @error Error)
 // CHECK:   try_apply %{{.*}}(%{{.*}}, %{{.*}}) : $@convention(thin) (Int, Int) -> (Int, @error Error), normal bb8, error bb7
 
 // CHECK: bb7(%{{.*}} : $Error):

--- a/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
+++ b/tools/lldb-moduleimport-test/lldb-moduleimport-test.cpp
@@ -191,6 +191,9 @@ int main(int argc, char **argv) {
   llvm::cl::opt<std::string> DumpTypeFromMangled(
       "type-from-mangled", llvm::cl::desc("dump type from mangled names list"));
 
+  llvm::cl::opt<std::string> ResourceDir("resource-dir",
+      llvm::cl::desc("The directory that holds the compiler resource files"));
+
   llvm::cl::ParseCommandLineOptions(argc, argv);
   // Unregister our options so they don't interfere with the command line
   // parsing in CodeGen/BackendUtil.cpp.
@@ -255,6 +258,10 @@ int main(int argc, char **argv) {
 
   Invocation.setModuleName("lldbtest");
   Invocation.getClangImporterOptions().ModuleCachePath = ModuleCachePath;
+
+  if (!ResourceDir.empty()) {
+    Invocation.setRuntimeResourcePath(ResourceDir);
+  }
 
   if (CI.setup(Invocation))
     return 1;

--- a/tools/swift-ide-test/swift-ide-test.cpp
+++ b/tools/swift-ide-test/swift-ide-test.cpp
@@ -1854,6 +1854,8 @@ static int doPrintModules(const CompilerInvocation &InitInvok,
     // Get the (sub)module to print.
     auto *M = getModuleByFullName(Context, ModuleToPrint);
     if (!M) {
+      llvm::errs() << "error: could not find module '" << ModuleToPrint
+                   << "'\n";
       ExitCode = 1;
       continue;
     }
@@ -1873,6 +1875,8 @@ static int doPrintModules(const CompilerInvocation &InitInvok,
     if (ModuleName.size() > 1) {
       M = getModuleByFullName(Context, ModuleName[0]);
       if (!M) {
+        llvm::errs() << "error: could not find module '" << ModuleName[0]
+                     << "'\n";
         ExitCode = 1;
         continue;
       }

--- a/utils/swift-api-dump.py
+++ b/utils/swift-api-dump.py
@@ -5,9 +5,9 @@
 # (Objective-)C APIs, any API notes added on top of those APIs, and the
 # Clang importer itself. One can execute it to dump the API of a given
 # module within a particular SDK, e.g., UIKit from the iOS SDK as seen in
-# Swift 3 compatibility mode:
+# Swift 4 compatibility mode:
 #
-#   /path/to/bin/dir/swift-api-dump.py -swift-version 3 -o output-dir \
+#   /path/to/bin/dir/swift-api-dump.py -swift-version 4 -o output-dir \
 #       -m UIKit -s iphoneos
 #
 # The "-m" argument can be omitted, in which case the script will collect
@@ -15,9 +15,9 @@
 #
 # One can supply multiple SDKs, written as a list. For example, to
 # dump the API for all frameworks across macOS, iOS, watchOS, and tvOS,
-# in Swift 4, use:
+# in Swift 4.2, use:
 #
-#  /path/to/bin/dir/swift-api-dump.py -swift-version 4 -o output-dir \
+#  /path/to/bin/dir/swift-api-dump.py -swift-version 4.2 -o output-dir \
 #      -s macosx iphoneos watchos appletvos
 #
 
@@ -102,7 +102,7 @@ def create_parser():
     parser.add_argument('--enable-infer-import-as-member', action='store_true',
                         help='Infer when a global could be imported as a ' +
                         'member.')
-    parser.add_argument('-swift-version', type=int, metavar='N',
+    parser.add_argument('-swift-version', metavar='N',
                         help='the Swift version to use')
     parser.add_argument('-show-overlay', action='store_true',
                         help='Show overlay API in addition to Objective-C ' +
@@ -326,7 +326,7 @@ def main():
     if args.enable_infer_import_as_member:
         extra_args = extra_args + ['-enable-infer-import-as-member']
     if args.swift_version:
-        extra_args = extra_args + ['-swift-version', '%d' % args.swift_version]
+        extra_args = extra_args + ['-swift-version', '%s' % args.swift_version]
 
     # Create a .swift file we can feed into swift-ide-test
     subprocess.call(['touch', source_filename])


### PR DESCRIPTION
Introduce several fixes for mangling and remangling of generic typealiases:

* Mangle the generic arguments of a typealias type directly, rather than (incorrectly) mangling the generic arguments of the underlying nominal type, and also account for nested generic typealiases.
* Remangle generic typealiases the same way we remangle generic nominal types
* Aside: fix remangling of protocol references (we were missing substitutions)
* Type reconstruction: guard against demangling the wrong # of generic arguments. This is a hack to avoid crashing; a more complete fix requires deeper changes to the type reconstruction logic.

Fixes rdar://problem/41444286