### PR TITLE
[4.2] Mark swift sections as 1 byte aligned

### DIFF
--- a/stdlib/public/runtime/SwiftRT-ELF.cpp
+++ b/stdlib/public/runtime/SwiftRT-ELF.cpp
@@ -18,10 +18,10 @@
 // by the linker.  Otherwise, we may end up with undefined symbol references as
 // the linker table section was never constructed.
 
-#define DECLARE_SWIFT_SECTION(name)                                            \
-  __asm__("\t.section " #name ",\"a\"\n");                                     \
-  __attribute__((__visibility__("hidden"))) extern const char __start_##name;  \
-  __attribute__((__visibility__("hidden"))) extern const char __stop_##name;
+#define DECLARE_SWIFT_SECTION(name)                                                          \
+  __asm__("\t.section " #name ",\"a\"\n");                                                   \
+  __attribute__((__visibility__("hidden"),__aligned__(1))) extern const char __start_##name; \
+  __attribute__((__visibility__("hidden"),__aligned__(1))) extern const char __stop_##name;
 
 extern "C" {
 DECLARE_SWIFT_SECTION(swift4_protocols)


### PR DESCRIPTION
Cherry pick of 94ffb3404b952e158c36d968cb8ff1c51caa0667 from master for 4.2.

The C compiler on some platforms (such as s390x) assumes that the
data pointed to by symbols meets certain alignment requirements.
The swift sections do not necessarily meet these alignment
requirements so this change adds alignment attributes to them to
force the compiler to emit the instruction sequences and relocations
required to address unaligned data.

This fixes a 'R_390_PC32DBL target misaligned' warning issued by
gold on s390x.