### PR TITLE
Add -ltensorflow_framework when the lit invocation specifies "--param swift_tensorflow_path"

### DIFF
--- a/test/lit.cfg
+++ b/test/lit.cfg
@@ -324,7 +324,7 @@ config.swift_test_options = '-swift-version ' + swift_version
 swift_tensorflow_linker_options = ""
 swift_tensorflow_path = lit_config.params.get('swift_tensorflow_path', None)
 if swift_tensorflow_path:
-    swift_tensorflow_linker_options = ('-L%s -ltensorflow' % swift_tensorflow_path)
+    swift_tensorflow_linker_options = ('-L%s -ltensorflow -ltensorflow_framework' % swift_tensorflow_path)
 
 test_options = os.environ.get('SWIFT_TEST_OPTIONS')
 if test_options:


### PR DESCRIPTION
This is needed in a new version of TF -- otherwise we get an undefined symbol at
runtime:

command:
```
../llvm/utils/lit/lit.py -j1 -sv --param swift_test_mode=optimize --param swift_tensorflow_path=../tensorflow/bazel-bin/tensorflow ../build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/test-linux-x86_64/TensorFlowRuntime/tensor_debuglog.swift
```
error:
```
/usr/local/google/home/hongm/ssd_part/git/swift-tensorflow-merge/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/test-linux-x86_64/TensorFlowRuntime/Output/tensor_debuglog.swift.tmp/a.out: symbol lookup error: /usr/local/google/home/hongm/ssd_part/git/swift-tensorflow-merge/build/Ninja-ReleaseAssert+stdlib-Release/swift-linux-x86_64/lib/swift/linux/libtensorflow.so: undefined symbol: _ZN10tensorflow10DeviceNameIN5Eigen9GpuDeviceEE5valueB5cxx11E
```
