### PR TITLE
[Type checker] Make sure we get all conformances for extended nominal types

### DIFF
--- a/lib/Sema/TypeCheckDecl.cpp
+++ b/lib/Sema/TypeCheckDecl.cpp
@@ -5204,6 +5204,13 @@ public:
       ACC.checkGenericParamAccess(ED->getGenericParams(), ED,
                                   desiredAccessScope, access);
     }
+
+    // Trigger the creation of all of the conformances associated with this
+    // nominal type.
+    // FIXME: This is a hack to make sure that the type checker precomputes
+    // enough information for later passes that might query conformances.
+    if (auto nominal = ED->getAsNominalTypeOrNominalTypeExtensionContext())
+      (void)nominal->getAllConformances();
   }
 
   void visitTopLevelCodeDecl(TopLevelCodeDecl *TLCD) {

--- a/test/Index/Store/Inputs/cross-file-extension-crash-other.swift
+++ b/test/Index/Store/Inputs/cross-file-extension-crash-other.swift
@@ -1,0 +1,4 @@
+final class X<T> { }
+
+protocol P { }
+extension X: P { }

--- a/test/Index/Store/cross-file-extension-crash.swift
+++ b/test/Index/Store/cross-file-extension-crash.swift
@@ -1,0 +1,11 @@
+// Ensure that we don't crash due to resolving an extension in a non-primary
+// file.
+
+// XFAIL: linux
+
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -index-store-path %t/idx -o %t/file.o -typecheck -primary-file %s %S/Inputs/cross-file-extension-crash-other.swift -verify
+
+extension X {
+  func foo() { }
+}

--- a/test/Index/Store/cross-file-extension-crash.swift
+++ b/test/Index/Store/cross-file-extension-crash.swift
@@ -1,8 +1,6 @@
 // Ensure that we don't crash due to resolving an extension in a non-primary
 // file.
 
-// XFAIL: linux
-
 // RUN: %empty-directory(%t)
 // RUN: %target-swift-frontend -index-store-path %t/idx -o %t/file.o -typecheck -primary-file %s %S/Inputs/cross-file-extension-crash-other.swift -verify
 


### PR DESCRIPTION
Index-while-building ends up querying some conformances that aren’t
strictly needed by the type-checker, but which require us to pre-check all
conformances for any extension we have. Long-term, this is wasted effort, but
for now it eliminates a recent regression caused by the request-evaluator,
which (intentionally) tries to perform less work for non-primary files.

Fixes rdar://problem/41392714.
