### PR TITLE
[WIP] SIL serialization recovery for instructions

### DIFF
--- a/lib/Serialization/Deserialization.cpp
+++ b/lib/Serialization/Deserialization.cpp
@@ -129,17 +129,6 @@ void TypeError::anchor() {}
 const char ExtensionError::ID = '\0';
 void ExtensionError::anchor() {}
 
-LLVM_NODISCARD
-static std::unique_ptr<llvm::ErrorInfoBase> takeErrorInfo(llvm::Error error) {
-  std::unique_ptr<llvm::ErrorInfoBase> result;
-  llvm::handleAllErrors(std::move(error),
-                        [&](std::unique_ptr<llvm::ErrorInfoBase> info) {
-    result = std::move(info);
-  });
-  return result;
-}
-
-
 /// Skips a single record in the bitstream.
 ///
 /// Returns true if the next entry is a record of type \p recordKind.
@@ -4756,27 +4745,42 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
     }
 
     auto processParameter = [&](TypeID typeID, uint64_t rawConvention)
-                                  -> Optional<SILParameterInfo> {
+                                  -> llvm::Expected<SILParameterInfo> {
       auto convention = getActualParameterConvention(rawConvention);
-      auto type = getType(typeID);
-      if (!convention || !type) return None;
-      return SILParameterInfo(type->getCanonicalType(), *convention);
+      if (!convention) {
+        error();
+        llvm_unreachable("an error is a fatal exit at this point");
+      }
+      auto type = getTypeChecked(typeID);
+      if (!type)
+        return type.takeError();
+      return SILParameterInfo(type.get()->getCanonicalType(), *convention);
     };
 
     auto processYield = [&](TypeID typeID, uint64_t rawConvention)
-                                  -> Optional<SILYieldInfo> {
+                                  -> llvm::Expected<SILYieldInfo> {
       auto convention = getActualParameterConvention(rawConvention);
-      auto type = getType(typeID);
-      if (!convention || !type) return None;
-      return SILYieldInfo(type->getCanonicalType(), *convention);
+      if (!convention) {
+        error();
+        llvm_unreachable("an error is a fatal exit at this point");
+      }
+      auto type = getTypeChecked(typeID);
+      if (!type)
+        return type.takeError();
+      return SILYieldInfo(type.get()->getCanonicalType(), *convention);
     };
 
     auto processResult = [&](TypeID typeID, uint64_t rawConvention)
-                               -> Optional<SILResultInfo> {
+                               -> llvm::Expected<SILResultInfo> {
       auto convention = getActualResultConvention(rawConvention);
-      auto type = getType(typeID);
-      if (!convention || !type) return None;
-      return SILResultInfo(type->getCanonicalType(), *convention);
+      if (!convention) {
+        error();
+        llvm_unreachable("an error is a fatal exit at this point");
+      }
+      auto type = getTypeChecked(typeID);
+      if (!type)
+        return type.takeError();
+      return SILResultInfo(type.get()->getCanonicalType(), *convention);
     };
 
     // Bounds check.  FIXME: overflow
@@ -4795,11 +4799,9 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
       auto typeID = variableData[nextVariableDataIndex++];
       auto rawConvention = variableData[nextVariableDataIndex++];
       auto param = processParameter(typeID, rawConvention);
-      if (!param) {
-        error();
-        return nullptr;
-      }
-      allParams.push_back(*param);
+      if (!param)
+        return param.takeError();
+      allParams.push_back(param.get());
     }
 
     // Process the yields.
@@ -4809,11 +4811,9 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
       auto typeID = variableData[nextVariableDataIndex++];
       auto rawConvention = variableData[nextVariableDataIndex++];
       auto yield = processYield(typeID, rawConvention);
-      if (!yield) {
-        error();
-        return nullptr;
-      }
-      allYields.push_back(*yield);
+      if (!yield)
+        return yield.takeError();
+      allYields.push_back(yield.get());
     }
 
     // Process the results.
@@ -4823,11 +4823,9 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
       auto typeID = variableData[nextVariableDataIndex++];
       auto rawConvention = variableData[nextVariableDataIndex++];
       auto result = processResult(typeID, rawConvention);
-      if (!result) {
-        error();
-        return nullptr;
-      }
-      allResults.push_back(*result);
+      if (!result)
+        return result.takeError();
+      allResults.push_back(result.get());
     }
 
     // Process the error result.
@@ -4835,11 +4833,10 @@ Expected<Type> ModuleFile::getTypeChecked(TypeID TID) {
     if (hasErrorResult) {
       auto typeID = variableData[nextVariableDataIndex++];
       auto rawConvention = variableData[nextVariableDataIndex++];
-      errorResult = processResult(typeID, rawConvention);
-      if (!errorResult) {
-        error();
-        return nullptr;
-      }
+      auto maybeErrorResult = processResult(typeID, rawConvention);
+      if (!maybeErrorResult)
+        return maybeErrorResult.takeError();
+      errorResult = maybeErrorResult.get();
     }
 
     Optional<ProtocolConformanceRef> witnessMethodConformance;

--- a/lib/Serialization/DeserializeSIL.cpp
+++ b/lib/Serialization/DeserializeSIL.cpp
@@ -12,13 +12,16 @@
 
 #define DEBUG_TYPE "deserialize"
 #include "DeserializeSIL.h"
+
+#include "DeserializationErrors.h"
+#include "SILFormat.h"
+
 #include "swift/Basic/Defer.h"
 #include "swift/Basic/PrettyStackTrace.h"
 #include "swift/AST/GenericSignature.h"
 #include "swift/AST/ProtocolConformance.h"
 #include "swift/AST/PrettyStackTrace.h"
 #include "swift/Serialization/ModuleFile.h"
-#include "SILFormat.h"
 #include "swift/SIL/SILArgument.h"
 #include "swift/SIL/SILBuilder.h"
 #include "swift/SIL/SILDebugScope.h"
@@ -37,6 +40,9 @@ using namespace swift;
 using namespace swift::serialization;
 using namespace swift::serialization::sil_block;
 using namespace llvm::support;
+
+const char SILEntityError::ID = '\0';
+void SILEntityError::anchor() {}
 
 STATISTIC(NumDeserializedFunc, "Number of deserialized SIL functions");
 
@@ -339,7 +345,14 @@ SILFunction *SILDeserializer::getFuncForReference(StringRef name,
     // Otherwise, look for a function with this name in the module.
     auto iter = FuncTable->find(name);
     if (iter != FuncTable->end()) {
-      fn = readSILFunction(*iter, nullptr, name, /*declarationOnly*/ true);
+      auto maybeFn = readSILFunctionChecked(*iter, nullptr, name,
+                                            /*declarationOnly*/ true);
+      if (maybeFn) {
+        fn = maybeFn.get();
+      } else {
+        // Ignore the failure; we'll synthesize a bogus function instead.
+        llvm::consumeError(maybeFn.takeError());
+      }
     }
   }
 
@@ -386,6 +399,19 @@ SILFunction *SILDeserializer::readSILFunction(DeclID FID,
                                               StringRef name,
                                               bool declarationOnly,
                                               bool errorIfEmptyBody) {
+  llvm::Expected<SILFunction *> deserialized =
+      readSILFunctionChecked(FID, existingFn, name, declarationOnly,
+                             errorIfEmptyBody);
+  if (!deserialized) {
+    MF->fatal(deserialized.takeError());
+  }
+  return deserialized.get();
+}
+
+llvm::Expected<SILFunction *>
+SILDeserializer::readSILFunctionChecked(DeclID FID, SILFunction *existingFn,
+                                        StringRef name, bool declarationOnly,
+                                        bool errorIfEmptyBody) {
   // We can't deserialize function bodies after IRGen lowering passes have
   // happened since other definitions in the module will no longer be in
   // canonical SIL form.
@@ -444,7 +470,16 @@ SILFunction *SILDeserializer::readSILFunction(DeclID FID,
     MF->error();
     return nullptr;
   }
-  auto ty = getSILType(MF->getType(funcTyID), SILValueCategory::Object);
+  auto astType = MF->getTypeChecked(funcTyID);
+  if (!astType) {
+    if (!existingFn || errorIfEmptyBody) {
+      return llvm::make_error<SILEntityError>(
+          name, takeErrorInfo(astType.takeError()));
+    }
+    llvm::consumeError(astType.takeError());
+    return existingFn;
+  }
+  auto ty = getSILType(astType.get(), SILValueCategory::Object);
   if (!ty.is<SILFunctionType>()) {
     DEBUG(llvm::dbgs() << "not a function type for SILFunction\n");
     MF->error();
@@ -2396,14 +2431,21 @@ SILFunction *SILDeserializer::lookupSILFunction(SILFunction *InFunc) {
   if (iter == FuncTable->end())
     return nullptr;
 
-  auto Func = readSILFunction(*iter, InFunc, name, /*declarationOnly*/ false);
-  if (Func) {
-    DEBUG(llvm::dbgs() << "Deserialize SIL:\n";
-          Func->dump());
-    assert(InFunc->getName() == Func->getName());
+  auto maybeFunc = readSILFunctionChecked(*iter, InFunc, name,
+                                          /*declarationOnly*/ false);
+  if (!maybeFunc) {
+    // Ignore the error; treat it as if we didn't have a definition.
+    llvm::consumeError(maybeFunc.takeError());
+    return nullptr;
   }
 
-  return Func;
+  if (maybeFunc.get()) {
+    DEBUG(llvm::dbgs() << "Deserialize SIL:\n";
+          maybeFunc.get()->dump());
+    assert(InFunc->getName() == maybeFunc.get()->getName());
+  }
+
+  return maybeFunc.get();
 }
 
 /// Check for existence of a function with a given name and required linkage.
@@ -2480,11 +2522,20 @@ SILFunction *SILDeserializer::lookupSILFunction(StringRef name,
   if (iter == FuncTable->end())
     return nullptr;
 
-  auto Func = readSILFunction(*iter, nullptr, name, declarationOnly);
-  if (Func)
+  auto maybeFunc = readSILFunctionChecked(*iter, nullptr, name,
+                                          declarationOnly);
+
+  if (!maybeFunc) {
+    // Ignore the error; treat it as if we didn't have a definition.
+    llvm::consumeError(maybeFunc.takeError());
+    return nullptr;
+  }
+
+  if (maybeFunc.get()) {
     DEBUG(llvm::dbgs() << "Deserialize SIL:\n";
-          Func->dump());
-  return Func;
+          maybeFunc.get()->dump());
+  }
+  return maybeFunc.get();
 }
 
 SILGlobalVariable *SILDeserializer::readGlobalVar(StringRef Name) {
@@ -2580,8 +2631,12 @@ void SILDeserializer::getAllSILFunctions() {
     auto DI = FuncTable->find(*KI);
     assert(DI != FuncTable->end() && "There should never be a key without data.");
 
-    readSILFunction(*DI, nullptr, *KI, false,
-                    false/*errorIfEmptyBody*/);
+    auto maybeFunc = readSILFunctionChecked(*DI, nullptr, *KI, false,
+                                            false/*errorIfEmptyBody*/);
+    if (!maybeFunc) {
+      // Ignore the error; treat it as if we didn't have a definition.
+      llvm::consumeError(maybeFunc.takeError());
+    }
   }
 }
 

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -92,10 +92,10 @@ namespace swift {
                                      SILBasicBlock *Prev,
                                      SmallVectorImpl<uint64_t> &scratch);
     /// Read a SIL instruction within a given SIL basic block.
-    bool readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
-                            SILBuilder &Builder,
-                            unsigned RecordKind,
-                            SmallVectorImpl<uint64_t> &scratch);
+    llvm::Error readSILInstruction(SILFunction *Fn, SILBasicBlock *BB,
+                                   SILBuilder &Builder,
+                                   unsigned RecordKind,
+                                   SmallVectorImpl<uint64_t> &scratch);
 
     /// Read the SIL function table.
     std::unique_ptr<SerializedFuncTable>

--- a/lib/Serialization/DeserializeSIL.h
+++ b/lib/Serialization/DeserializeSIL.h
@@ -81,6 +81,12 @@ namespace swift {
     SILFunction *readSILFunction(serialization::DeclID, SILFunction *InFunc,
                                  StringRef Name, bool declarationOnly,
                                  bool errorIfEmptyBody = true);
+    /// Read a SIL function.
+    llvm::Expected<SILFunction *>
+    readSILFunctionChecked(serialization::DeclID, SILFunction *InFunc,
+                           StringRef Name, bool declarationOnly,
+                           bool errorIfEmptyBody = true);
+
     /// Read a SIL basic block within a given SIL function.
     SILBasicBlock *readSILBasicBlock(SILFunction *Fn,
                                      SILBasicBlock *Prev,

--- a/test/SIL/Serialization/Recovery/Inputs/bad-modules/Types.h
+++ b/test/SIL/Serialization/Recovery/Inputs/bad-modules/Types.h
@@ -1,0 +1,3 @@
+// struct SoonToBeMissing {
+//   int value;
+// };

--- a/test/SIL/Serialization/Recovery/Inputs/bad-modules/Types.h
+++ b/test/SIL/Serialization/Recovery/Inputs/bad-modules/Types.h
@@ -1,3 +1,9 @@
 // struct SoonToBeMissing {
 //   int value;
 // };
+
+// @interface SoonToBeMissingClass
+// @end
+
+// @protocol SoonToBeMissingProto
+// @end

--- a/test/SIL/Serialization/Recovery/Inputs/bad-modules/module.modulemap
+++ b/test/SIL/Serialization/Recovery/Inputs/bad-modules/module.modulemap
@@ -1,0 +1,1 @@
+module Types { header "Types.h" }

--- a/test/SIL/Serialization/Recovery/Inputs/good-modules/Types.h
+++ b/test/SIL/Serialization/Recovery/Inputs/good-modules/Types.h
@@ -1,0 +1,3 @@
+struct SoonToBeMissing {
+  int value;
+};

--- a/test/SIL/Serialization/Recovery/Inputs/good-modules/Types.h
+++ b/test/SIL/Serialization/Recovery/Inputs/good-modules/Types.h
@@ -1,3 +1,9 @@
 struct SoonToBeMissing {
   int value;
 };
+
+@interface SoonToBeMissingClass
+@end
+
+@protocol SoonToBeMissingProto
+@end

--- a/test/SIL/Serialization/Recovery/Inputs/good-modules/module.modulemap
+++ b/test/SIL/Serialization/Recovery/Inputs/good-modules/module.modulemap
@@ -1,0 +1,1 @@
+module Types { header "Types.h" }

--- a/test/SIL/Serialization/Recovery/function.sil
+++ b/test/SIL/Serialization/Recovery/function.sil
@@ -1,0 +1,26 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -parse-sil %s -emit-sib -o %t/Library.sib -module-name Library -I %S/Inputs/good-modules -parse-stdlib
+// RUN: %target-sil-opt %t/Library.sib -I %S/Inputs/good-modules | %FileCheck %s
+// RUN: %target-sil-opt %t/Library.sib -I %S/Inputs/bad-modules | %FileCheck -check-prefix=CHECK-RECOVERY %s
+// RUN: %target-sil-opt %t/Library.sib -I %S/Inputs/bad-modules | %FileCheck -check-prefix=CHECK-RECOVERY-NEGATIVE %s
+
+// CHECK-LABEL: sil_stage raw
+// CHECK-RECOVERY-LABEL: sil_stage raw
+
+sil_stage raw
+import Types
+
+// CHECK-LABEL: sil @missingParam : $@convention(thin) (SoonToBeMissing) -> () {
+// CHECK-RECOVERY-NEGATIVE-NOT: sil @missingParam
+sil @missingParam : $@convention(thin) (SoonToBeMissing) -> () {
+entry(%arg: $SoonToBeMissing):
+  %9999 = tuple()
+  return %9999 : $()
+}
+
+// CHECK-LABEL: sil @missingResult : $@convention(thin) () -> SoonToBeMissing {
+// CHECK-RECOVERY-NEGATIVE-NOT: sil @missingResult
+sil @missingResult : $@convention(thin) () -> (SoonToBeMissing) {
+entry:
+  unreachable
+}

--- a/test/SIL/Serialization/Recovery/function.sil
+++ b/test/SIL/Serialization/Recovery/function.sil
@@ -1,14 +1,16 @@
 // RUN: %empty-directory(%t)
-// RUN: %target-swift-frontend -parse-sil %s -emit-sib -o %t/Library.sib -module-name Library -I %S/Inputs/good-modules -parse-stdlib
-// RUN: %target-sil-opt %t/Library.sib -I %S/Inputs/good-modules | %FileCheck %s
-// RUN: %target-sil-opt %t/Library.sib -I %S/Inputs/bad-modules | %FileCheck -check-prefix=CHECK-RECOVERY %s
-// RUN: %target-sil-opt %t/Library.sib -I %S/Inputs/bad-modules | %FileCheck -check-prefix=CHECK-RECOVERY-NEGATIVE %s
+// RUN: %target-swift-frontend -parse-sil %s -emit-sibgen -o %t/Library.sib -module-name Library -I %S/Inputs/good-modules -parse-stdlib
+// RUN: %target-sil-opt %t/Library.sib -I %S/Inputs/good-modules -emit-sorted-sil | %FileCheck %s
+// RUN: %target-sil-opt %t/Library.sib -I %S/Inputs/bad-modules -emit-sorted-sil | %FileCheck -check-prefix=CHECK-RECOVERY %s
+// RUN: %target-sil-opt %t/Library.sib -I %S/Inputs/bad-modules -emit-sorted-sil | %FileCheck -check-prefix=CHECK-RECOVERY-NEGATIVE %s
 
 // CHECK-LABEL: sil_stage raw
 // CHECK-RECOVERY-LABEL: sil_stage raw
 
 sil_stage raw
 import Types
+
+// Please keep this file in alphabetical order!
 
 // CHECK-LABEL: sil @missingParam : $@convention(thin) (SoonToBeMissing) -> () {
 // CHECK-RECOVERY-NEGATIVE-NOT: sil @missingParam

--- a/test/SIL/Serialization/Recovery/function_body.sil
+++ b/test/SIL/Serialization/Recovery/function_body.sil
@@ -1,0 +1,74 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -parse-sil %s -emit-sibgen -o %t/Library.sib -module-name Library -I %S/Inputs/good-modules -parse-stdlib -enable-objc-interop
+// RUN: %target-sil-opt %t/Library.sib -I %S/Inputs/good-modules -emit-sorted-sil -enable-objc-interop | %FileCheck %s
+// RUN: %target-sil-opt %t/Library.sib -I %S/Inputs/bad-modules -emit-sorted-sil -enable-objc-interop | %FileCheck -check-prefix=CHECK-RECOVERY %s
+
+// CHECK-LABEL: sil_stage raw
+// CHECK-RECOVERY-LABEL: sil_stage raw
+
+sil_stage raw
+import Builtin
+import Types
+
+// Please keep this file in alphabetical order!
+
+// CHECK-LABEL: sil @dropBody_alloc_stack : $@convention(thin) () -> () {
+// CHECK-RECOVERY-LABEL: sil @dropBody_alloc_stack : $@convention(thin) () -> (){{$}}
+sil @dropBody_alloc_stack : $@convention(thin) () -> () {
+entry:
+  // CHECK: alloc_stack $SoonToBeMissing
+  %0 = alloc_stack $SoonToBeMissing
+  dealloc_stack %0 : $*SoonToBeMissing
+  %9999 = tuple()
+  return %9999 : $()
+} // CHECK: end sil function 'dropBody_alloc_stack'
+
+// CHECK-LABEL: sil @dropBody_metatype : $@convention(thin) () -> () {
+// CHECK-RECOVERY-LABEL: sil @dropBody_metatype : $@convention(thin) () -> (){{$}}
+sil @dropBody_metatype : $@convention(thin) () -> () {
+entry:
+  // CHECK: metatype $@thin SoonToBeMissing.Type
+  %0 = metatype $@thin SoonToBeMissing.Type
+  %9999 = tuple()
+  return %9999 : $()
+} // CHECK: end sil function 'dropBody_metatype'
+
+// CHECK-LABEL: sil @dropBody_unchecked_addr_cast : $@convention(thin) (@in ()) -> () {
+// CHECK-RECOVERY-LABEL: sil @dropBody_unchecked_addr_cast : $@convention(thin) (@in ()) -> (){{$}}
+sil @dropBody_unchecked_addr_cast : $@convention(thin) (@in ()) -> () {
+entry(%0 : $*()):
+  // CHECK: unchecked_addr_cast %0 : $*() to $*SoonToBeMissing
+  %result = unchecked_addr_cast %0 : $*() to $*SoonToBeMissing
+  %9999 = tuple()
+  return %9999 : $()
+} // CHECK: end sil function 'dropBody_unchecked_addr_cast'
+
+// CHECK-LABEL: sil @dropBody_unchecked_bitwise_cast : $@convention(thin) (Builtin.Int32) -> () {
+// CHECK-RECOVERY-LABEL: sil @dropBody_unchecked_bitwise_cast : $@convention(thin) (Builtin.Int32) -> (){{$}}
+sil @dropBody_unchecked_bitwise_cast : $@convention(thin) (Builtin.Int32) -> () {
+entry(%0 : $Builtin.Int32):
+  // CHECK: unchecked_bitwise_cast %0 : $Builtin.Int32 to $SoonToBeMissing
+  %result = unchecked_bitwise_cast %0 : $Builtin.Int32 to $SoonToBeMissing
+  %9999 = tuple()
+  return %9999 : $()
+} // CHECK: end sil function 'dropBody_unchecked_bitwise_cast'
+
+// CHECK-LABEL: sil @dropBody_unchecked_ref_cast : $@convention(thin) (@guaranteed AnyObject) -> () {
+// CHECK-RECOVERY-LABEL: sil @dropBody_unchecked_ref_cast : $@convention(thin) (@guaranteed AnyObject) -> (){{$}}
+sil @dropBody_unchecked_ref_cast : $@convention(thin) (@guaranteed Builtin.AnyObject) -> () {
+entry(%0 : $Builtin.AnyObject):
+  // CHECK: unchecked_ref_cast %0 : $AnyObject to $SoonToBeMissingClass
+  %result = unchecked_ref_cast %0 : $Builtin.AnyObject to $SoonToBeMissingClass
+  %9999 = tuple()
+  return %9999 : $()
+} // CHECK: end sil function 'dropBody_unchecked_ref_cast'
+
+// CHECK-LABEL: sil @dropBody_unchecked_trivial_bit_cast : $@convention(thin) (Builtin.Int32) -> () {
+// CHECK-RECOVERY-LABEL: sil @dropBody_unchecked_trivial_bit_cast : $@convention(thin) (Builtin.Int32) -> (){{$}}
+sil @dropBody_unchecked_trivial_bit_cast : $@convention(thin) (Builtin.Int32) -> () {
+entry(%0 : $Builtin.Int32):
+  // CHECK: unchecked_trivial_bit_cast %0 : $Builtin.Int32 to $SoonToBeMissing
+  %result = unchecked_trivial_bit_cast %0 : $Builtin.Int32 to $SoonToBeMissing
+  %9999 = tuple()
+  return %9999 : $()
+} // CHECK: end sil function 'dropBody_unchecked_trivial_bit_cast'


### PR DESCRIPTION
When instructions in an inlinable SIL function can't be deserialized, drop the body of the function and make it external. This commit tests that behavior by making several simple classes of SILInstruction recover from their types not being deserializable.

Builds on #17564; this is the more interesting part.

Still to do:
- Many more instruction kinds
- Cascading failures: if a 'shared' function can't be deserialized, anything that references it should also fail.
- Produce an error in SIL diagnostics if the function that got dropped was an always-emit-into-client function, and thus cannot be marked external.

Part of rdar://problem/40899824
