### PR TITLE
fix TPU test

### DIFF
--- a/test/TensorFlowRuntime/tensor.swift
+++ b/test/TensorFlowRuntime/tensor.swift
@@ -44,8 +44,12 @@ TensorTests.testAllBackends("NumericInitializers") {
 }
 
 TensorTests.testAllBackends("RandomInitializer") {
-  let _ = Tensor<Float>(randomUniform: [3, 4])
-  let _ = Tensor<Float>(randomNormal: [3, 4])
+  let x = Tensor<Float>(randomUniform: [3, 4])
+  let y = Tensor<Float>(randomNormal: [3, 4])
+
+  // Dummy expects because TPU tests fail when the tensors don't get used.
+  expectEqual([3, 4], x.array.shape)
+  expectEqual([3, 4], y.array.shape)
 }
 
 TensorTests.testAllBackends("ScalarToTensorConversion") {
@@ -239,10 +243,13 @@ TensorTests.testAllBackends("SimpleMath") {
 }
 
 TensorTests.testAllBackends("ReductionToScalar") {
-  let _: Tensor<Float> = [1, 2, 3, 4, 5]
+  let x: Tensor<Float> = [1, 2, 3, 4, 5]
   // expectEqual(x.mean(), 3)
   // TODO: Test other reduction ops here. Currently code motion isn't
   // smart enough to avoid send/receive.
+
+  // Dummy expect because TPU tests fail when the tensors don't get used.
+  expectEqual([5], x.array.shape)
 }
 
 TensorTests.testAllBackends("BatchNormalization") {


### PR DESCRIPTION
These two tests fail on TPUs when the tensors don't get used. @mhong, do you think there is some underlying problem that I should file a bug about?

Here's a log of the failure:
```
-- Test started at 2018-06-27 12:17:40 PDT --
-----------------------------------------------------------------------------
[ RUN      ] Tensor.Initializers_TPU
[       OK ] Tensor.Initializers_TPU
[ RUN      ] Tensor.FactoryInitializers_TPU
[       OK ] Tensor.FactoryInitializers_TPU
[ RUN      ] Tensor.NumericInitializers_TPU
[       OK ] Tensor.NumericInitializers_TPU
[ RUN      ] Tensor.RandomInitializer_TPU
stderr>>> Fatal error: PruneForTargets: Some target nodes not found: tfc_func_S4mainyycfU2_.tf : file third_party/unsupported_toolchains/swift/src/swift/stdlib/public/TensorFlow/CompilerRuntime.swift, line 532
stderr>>> Current stack trace:
stderr>>> CRASHED: SIGILL
the test crashed unexpectedly
[     FAIL ] Tensor.RandomInitializer_TPU
[ RUN      ] Tensor.ScalarToTensorConversion_TPU
[       OK ] Tensor.ScalarToTensorConversion_TPU
[ RUN      ] Tensor.ArrayConversion_TPU
[       OK ] Tensor.ArrayConversion_TPU
[ RUN      ] Tensor.DataTypeCast_NonTPU_TPU
[       OK ] Tensor.DataTypeCast_NonTPU_TPU
[ RUN      ] Tensor.DataTypeCast_TPU_TPU
stderr>>> E0627 12:17:46.014672    4467 executor.cc:697] Executor failed to create kernel. Unimplemented: Cast float to uint32 is not supported
stderr>>> 	 [[Node: tfc_func_S4mainyycfU6_.tf/op/_S4mainyycfU6_.tf_TPU.76.49_4 = Cast[DstT=DT_UINT32, SrcT=DT_FLOAT, _tpu_replicate="TPUReplicate/cluster", _device="/device:TPU_REPLICATED_CORE"](op/_S4mainyycfU6_.tf_TPU.76.49_3)]]
stderr>>> E0627 12:17:46.016581    4467 executor.cc:697] Executor failed to create kernel. Unimplemented: Cast float to uint32 is not supported
stderr>>> 	 [[Node: tfc_func_S4mainyycfU6_.tf/op/_S4mainyycfU6_.tf_TPU.76.49_4 = Cast[DstT=DT_UINT32, SrcT=DT_FLOAT, _tpu_replicate="TPUReplicate/cluster", _device="/device:TPU_REPLICATED_CORE"](op/_S4mainyycfU6_.tf_TPU.76.49_3)]]
stderr>>> E0627 12:17:46.018999    4467 executor.cc:697] Executor failed to create kernel. Unimplemented: Cast float to uint32 is not supported
stderr>>> 	 [[Node: tfc_func_S4mainyycfU6_.tf/op/_S4mainyycfU6_.tf_TPU.76.49_4 = Cast[DstT=DT_UINT32, SrcT=DT_FLOAT, _tpu_replicate="TPUReplicate/cluster", _device="/device:TPU_REPLICATED_CORE"](op/_S4mainyycfU6_.tf_TPU.76.49_3)]]
[       OK ] Tensor.DataTypeCast_TPU_TPU
[ RUN      ] Tensor.BoolToNumericCast_NonTPU_TPU
[       OK ] Tensor.BoolToNumericCast_NonTPU_TPU
[ RUN      ] Tensor.ElementIndexing_TPU
[       OK ] Tensor.ElementIndexing_TPU
[ RUN      ] Tensor.NestedElementIndexing_TPU
[       OK ] Tensor.NestedElementIndexing_TPU
[ RUN      ] Tensor.SliceIndexing_TPU
[       OK ] Tensor.SliceIndexing_TPU
[ RUN      ] Tensor.WholeTensorSlicing
[       OK ] Tensor.WholeTensorSlicing
[ RUN      ] Tensor.Reduction_TPU
[       OK ] Tensor.Reduction_TPU
[ RUN      ] Tensor.Concatenation_TPU
[       OK ] Tensor.Concatenation_TPU
[ RUN      ] Tensor.ArgMax_TPU
[       OK ] Tensor.ArgMax_TPU
[ RUN      ] Tensor.SimpleMath_TPU
[       OK ] Tensor.SimpleMath_TPU
[ RUN      ] Tensor.ReductionToScalar_TPU
stderr>>> Fatal error: PruneForTargets: Some target nodes not found: tfc_func_S4mainyycfU16_.tf : file third_party/unsupported_toolchains/swift/src/swift/stdlib/public/TensorFlow/CompilerRuntime.swift, line 532
stderr>>> Current stack trace:
stderr>>> CRASHED: SIGILL
the test crashed unexpectedly
[     FAIL ] Tensor.ReductionToScalar_TPU
[ RUN      ] Tensor.BatchNormalization_TPU
[       OK ] Tensor.BatchNormalization_TPU
[ RUN      ] Tensor.Convolution_TPU
[       OK ] Tensor.Convolution_TPU
[ RUN      ] Tensor.3Adds_TPU
[       OK ] Tensor.3Adds_TPU
[ RUN      ] Tensor.MultiOpMath_TPU
[       OK ] Tensor.MultiOpMath_TPU
[ RUN      ] Tensor.XWPlusB_TPU
[       OK ] Tensor.XWPlusB_TPU
[ RUN      ] Tensor.Transpose_TPU
[       OK ] Tensor.Transpose_TPU
[ RUN      ] Tensor.SimpleCond_TPU
[       OK ] Tensor.SimpleCond_TPU
[ RUN      ] Tensor.XORInference_TPU
[       OK ] Tensor.XORInference_TPU
[ RUN      ] Tensor.MLPClassifierStruct_TPU
[       OK ] Tensor.MLPClassifierStruct_TPU
[ RUN      ] Tensor.Reshape_TPU
[       OK ] Tensor.Reshape_TPU
[ RUN      ] Tensor.Flatten_TPU
[       OK ] Tensor.Flatten_TPU
[ RUN      ] Tensor.Flatten0D_TPU
[       OK ] Tensor.Flatten0D_TPU
[ RUN      ] Tensor.ReshapeToScalar_TPU
[       OK ] Tensor.ReshapeToScalar_TPU
[ RUN      ] Tensor.ReshapeTensor_TPU
[       OK ] Tensor.ReshapeTensor_TPU
[ RUN      ] Tensor.BroadcastTensor_TPU
[       OK ] Tensor.BroadcastTensor_TPU
[ RUN      ] Tensor.Unbroadcast1_TPU
[       OK ] Tensor.Unbroadcast1_TPU
[ RUN      ] Tensor.Unbroadcast2_TPU
[       OK ] Tensor.Unbroadcast2_TPU
[ RUN      ] Tensor.RankGetter_TPU
[       OK ] Tensor.RankGetter_TPU
[ RUN      ] Tensor.RankGetter2_TPU
[       OK ] Tensor.RankGetter2_TPU
[ RUN      ] Tensor.RankGetter3_TPU
[       OK ] Tensor.RankGetter3_TPU
[ RUN      ] Tensor.RankGetter4_TPU
[       OK ] Tensor.RankGetter4_TPU
[ RUN      ] Tensor.ShapeGetter_TPU
[       OK ] Tensor.ShapeGetter_TPU
[ RUN      ] Tensor.ShapeGetter2_TPU
[       OK ] Tensor.ShapeGetter2_TPU
[ RUN      ] Tensor.ShapeGetter3_TPU
[       OK ] Tensor.ShapeGetter3_TPU
[ RUN      ] Tensor.ShapeGetter4_TPU
[       OK ] Tensor.ShapeGetter4_TPU
Tensor: Some tests failed, aborting
UXPASS: []
FAIL: ["RandomInitializer_TPU", "ReductionToScalar_TPU"]
SKIP: []
```