### PR TITLE
[SIL] Default arg generators shouldn't be connected to their class.

### DIFF
--- a/lib/SIL/SILDeclRef.cpp
+++ b/lib/SIL/SILDeclRef.cpp
@@ -775,6 +775,10 @@ SubclassScope SILDeclRef::getSubclassScope() const {
   if (isThunk() || isForeign)
     return SubclassScope::NotApplicable;
 
+  // Default arg generators only need to be visible in Swift 3.
+  if (isDefaultArgGenerator() && !context->getASTContext().isSwiftVersion3())
+    return SubclassScope::NotApplicable;
+
   auto *classType = context->getAsClassOrClassExtensionContext();
   if (!classType || classType->isFinal())
     return SubclassScope::NotApplicable;

--- a/test/TBD/class.swift
+++ b/test/TBD/class.swift
@@ -3,22 +3,27 @@
 // RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-testing
 // RUN: %target-swift-frontend -enable-resilience -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-testing
 
+// RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir=missing -O %s
+// RUN: %target-swift-frontend -enable-resilience -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir=missing -O %s
+// RUN: %target-swift-frontend -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-testing -O
+// RUN: %target-swift-frontend -enable-resilience -emit-ir -o- -parse-as-library -module-name test -validate-tbd-against-ir=missing %s -enable-testing -O
+
 open class OpenNothing {}
 
 open class OpenInit {
     public init() {}
-    public init(public_: Int) {}
+    public init(public_: Int, default_: Int = 0) {}
 
-    internal init(internal_: Int) {}
+    internal init(internal_: Int, default_: Int = 0) {}
 
     deinit {}
 }
 
 open class OpenMethods {
     public init() {}
-    public func publicMethod() {}
-    internal func internalMethod() {}
-    private func privateMethod() {}
+    public func publicMethod(default_: Int = 0) {}
+    internal func internalMethod(default_: Int = 0) {}
+    private func privateMethod(default_: Int = 0) {}
 }
 
 open class OpenProperties {
@@ -49,9 +54,9 @@ open class OpenProperties {
 }
 
 open class OpenStatics {
-    public static func publicStaticFunc() {}
-    internal static func internalStaticFunc() {}
-    private static func privateStaticFunc() {}
+    public static func publicStaticFunc(default_: Int = 0) {}
+    internal static func internalStaticFunc(default_: Int = 0) {}
+    private static func privateStaticFunc(default_: Int = 0) {}
 
     public static let publicLet: Int = 0
     internal static let internalLet: Int = 0
@@ -107,18 +112,18 @@ public class PublicNothing {}
 
 public class PublicInit {
     public init() {}
-    public init(public_: Int) {}
+    public init(public_: Int, default_: Int = 0) {}
     
-    internal init(internal_: Int) {}
+    internal init(internal_: Int, default_: Int = 0) {}
 
     deinit {}
 }
 
 public class PublicMethods {
     public init() {}
-    public func publicMethod() {}
-    internal func internalMethod() {}
-    private func privateMethod() {}
+    public func publicMethod(default_: Int = 0) {}
+    internal func internalMethod(default_: Int = 0) {}
+    private func privateMethod(default_: Int = 0) {}
 }
 
 public class PublicProperties {
@@ -149,9 +154,9 @@ public class PublicProperties {
 }
 
 public class PublicStatics {
-    public static func publicStaticFunc() {}
-    internal static func internalStaticFunc() {}
-    private static func privateStaticFunc() {}
+    public static func publicStaticFunc(default_: Int = 0) {}
+    internal static func internalStaticFunc(default_: Int = 0) {}
+    private static func privateStaticFunc(default_: Int = 0) {}
 
     public static let publicLet: Int = 0
     internal static let internalLet: Int = 0
@@ -188,19 +193,19 @@ public class PublicGeneric<T, U, V> {
   internal var internalVarConcrete: Int = 0
   private var privateVarConcrete: Int = 0
 
-  public init<S>(t: T, u: U, v: V, _: S) {
+  public init<S>(t: T, u: U, v: V, _: S, default_: Int = 0) {
     publicVar = t
     internalVar = u
     privateVar = v
   }
 
-  public func publicGeneric<A>(_: A) {}
-  internal func internalGeneric<A>(_: A) {}
-  private func privateGeneric<A>(_: A) {}
+  public func publicGeneric<A>(_: A, default_: Int = 0) {}
+  internal func internalGeneric<A>(_: A, default_: Int = 0) {}
+  private func privateGeneric<A>(_: A, default_: Int = 0) {}
 
-  public static func publicStaticGeneric<A>(_: A) {}
-  internal static func internalStaticGeneric<A>(_: A) {}
-  private static func privateStaticGeneric<A>(_: A) {}
+  public static func publicStaticGeneric<A>(_: A, default_: Int = 0) {}
+  internal static func internalStaticGeneric<A>(_: A, default_: Int = 0) {}
+  private static func privateStaticGeneric<A>(_: A, default_: Int = 0) {}
 }
 
 
@@ -208,14 +213,14 @@ internal class InternalNothing {}
 
 internal class InternalInit {
     internal init() {}
-    internal init(internal_: Int) {}
-    private init(private_: Int) {}
+    internal init(internal_: Int, default_: Int = 0) {}
+    private init(private_: Int, default_: Int = 0) {}
 }
 
 internal class InternalMethods {
     internal init() {}
-    internal func internalMethod() {}
-    private func privateMethod() {}
+    internal func internalMethod(default_: Int = 0) {}
+    private func privateMethod(default_: Int = 0) {}
 }
 
 internal class InternalProperties {
@@ -239,8 +244,8 @@ internal class InternalProperties {
 }
 
 internal class InternalStatics {
-    internal static func internalStaticFunc() {}
-    private static func privateStaticFunc() {}
+    internal static func internalStaticFunc(default_: Int = 0) {}
+    private static func privateStaticFunc(default_: Int = 0) {}
 
     internal static let internalLet: Int = 0
     private static let privateLet: Int = 0
@@ -268,16 +273,16 @@ internal class InternalGeneric<T, U, V> {
   internal var internalVarConcrete: Int = 0
   private var privateVarConcrete: Int = 0
 
-  internal init<S>(t: T, u: U, v: V, _: S) {
+  internal init<S>(t: T, u: U, v: V, _: S, default_: Int = 0) {
     internalVar = u
     privateVar = v
   }
 
-  internal func internalGeneric<A>(_: A) {}
-  private func privateGeneric<A>(_: A) {}
+  internal func internalGeneric<A>(_: A, default_: Int = 0) {}
+  private func privateGeneric<A>(_: A, default_: Int = 0) {}
 
-  internal static func internalStaticGeneric<A>(_: A) {}
-  private static func privateStaticGeneric<A>(_: A) {}
+  internal static func internalStaticGeneric<A>(_: A, default_: Int = 0) {}
+  private static func privateStaticGeneric<A>(_: A, default_: Int = 0) {}
 }
 
 
@@ -285,12 +290,12 @@ private class PrivateNothing {}
 
 private class PrivateInit {
     private init() {}
-    private init(private_: Int) {}
+    private init(private_: Int, default_: Int = 0) {}
 }
 
 private class PrivateMethods {
     private init() {}
-    private func privateMethod() {}
+    private func privateMethod(default_: Int = 0) {}
 }
 
 private class PrivateProperties {
@@ -307,7 +312,7 @@ private class PrivateProperties {
 }
 
 private class PrivateStatics {
-    private static func privateStaticFunc() {}
+    private static func privateStaticFunc(default_: Int = 0) {}
 
     private static let privateLet: Int = 0
 
@@ -326,11 +331,11 @@ private class PrivateGeneric<T, U, V> {
 
   private var privateVarConcrete: Int = 0
 
-  private init<S>(t: T, u: U, v: V, _: S) {
+  private init<S>(t: T, u: U, v: V, _: S, default_: Int = 0) {
     privateVar = v
   }
 
-  private func privateGeneric<A>(_: A) {}
+  private func privateGeneric<A>(_: A, default_: Int = 0) {}
 
-  private static func privateStaticGeneric<A>(_: A) {}
+  private static func privateStaticGeneric<A>(_: A, default_: Int = 0) {}
 }


### PR DESCRIPTION
These are never public (at least, in Swift > 4), and so shouldn't be connected
to their superclass.

Fixes rdar://problem/41563759.
