### PR TITLE
Make `Tensor.broadcast(toShape:)` public

### DIFF
--- a/stdlib/public/TensorFlow/Ops.swift
+++ b/stdlib/public/TensorFlow/Ops.swift
@@ -999,8 +999,8 @@ public extension Tensor {
 //===----------------------------------------------------------------------===//
 
 public extension Tensor {
-  @_versioned @_inlineable @inline(__always)
-  internal func broadcast(toShape shape: Tensor<Int32>) -> Tensor {
+  @_inlineable @inline(__always)
+  func broadcast(toShape shape: Tensor<Int32>) -> Tensor {
     return Raw.broadcastTo(self, shape: shape)
   }
 


### PR DESCRIPTION
Previously we have `Tensor.broadcast(to:)` which takes a `TensorShape`. However, in expressions like `x.broadcast(to: y.shape)`, there's a conversion chain that the compiler isn't yet able to eliminate: `Tensor<Int32> -> TensorShape -> Tensor<Int32>`, and it requires send/receive. Before guaranteed promotion is possible, we need the tensor-only version of this op.