### PR TITLE
Revert "[ConstExpr] Emit traceback when failing during nested call evaluation"

### DIFF
--- a/include/swift/AST/DiagnosticsSIL.def
+++ b/include/swift/AST/DiagnosticsSIL.def
@@ -218,9 +218,6 @@ WARNING(designated_init_in_cross_module_extension,none,
 NOTE(designated_init_c_struct_fix,none,
      "use \"self.init()\" to initialize the struct with zero values", ())
 
-NOTE(constexpr_called_from, none, "when called from here", ())
-NOTE(constexpr_not_evaluable, none,
-     "expression not evaluable as constant here", ())
 
 // SWIFT_ENABLE_TENSORFLOW
 // TensorFlow Support Diagnostics.
@@ -262,6 +259,7 @@ ERROR(tf_op_misuse, none,
       "%0", (StringRef))
 NOTE(tf_op_misuse_note, none,
      "%0", (StringRef))
+
 
 // Control flow diagnostics.
 ERROR(missing_return,none,

--- a/lib/SILOptimizer/Mandatory/TFConstExpr.h
+++ b/lib/SILOptimizer/Mandatory/TFConstExpr.h
@@ -24,16 +24,15 @@
 #ifndef SWIFT_SILOPTIMIZER_TF_CONSTEXPR_H
 #define SWIFT_SILOPTIMIZER_TF_CONSTEXPR_H
 
-#include "swift/Basic/LLVM.h"
-#include "swift/Basic/SourceLoc.h"
 #include "llvm/Support/Allocator.h"
+#include "swift/Basic/LLVM.h"
 
 namespace swift {
-class SingleValueInstruction;
-class SILBuilder;
-class SILModule;
-class SILValue;
-class SymbolicValue;
+  class SingleValueInstruction;
+  class SILBuilder;
+  class SILModule;
+  class SILValue;
+  class SymbolicValue;
 
 namespace tf {
 
@@ -44,26 +43,13 @@ class ConstExprEvaluator {
   /// result values for the cached constexpr calls we have already analyzed.
   llvm::BumpPtrAllocator allocator;
 
-  /// The current call stack, used for providing accurate diagnostics.
-  llvm::SmallVector<SourceLoc, 4> callStack;
-
   ConstExprEvaluator(const ConstExprEvaluator &) = delete;
   void operator=(const ConstExprEvaluator &) = delete;
-
 public:
   explicit ConstExprEvaluator(SILModule &m);
   ~ConstExprEvaluator();
 
   llvm::BumpPtrAllocator &getAllocator() { return allocator; }
-
-  void pushCallStack(SourceLoc loc) { callStack.push_back(std::move(loc)); }
-
-  void popCallStack() {
-    assert(!callStack.empty());
-    callStack.pop_back();
-  }
-
-  const llvm::SmallVector<SourceLoc, 4> &getCallStack() { return callStack; }
 
   /// Analyze the specified values to determine if they are constant values.
   /// This is done in code that is not necessarily itself a constexpr

--- a/test/SILOptimizer/pound_assert.swift
+++ b/test/SILOptimizer/pound_assert.swift
@@ -64,7 +64,6 @@ func loops1(a: Int) -> Int {
 // @constexpr
 func loops2(a: Int) -> Int {
   var x = 42
-  // expected-note @+1 {{expression not evaluable as constant here}}
   for i in 0 ... a {
     x += i
   }
@@ -137,26 +136,6 @@ func testGenericThunk() {
   // TODO: expected-error @+1 {{#assert condition not constant}}
   #assert(myTransform.fn(42) > 1)
   // expected-note @-1{{could not fold operation}}
-}
-
-//===----------------------------------------------------------------------===//
-
-func foo() -> Bool {
-  // expected-note @+1 {{expression not evaluable as constant here}}
-  print("not constexpr")
-  return true
-}
-
-func baz() -> Bool {
-  return foo() // expected-note {{when called from here}}
-}
-
-func bar() -> Bool {
-  return baz() // expected-note {{when called from here}}
-}
-
-func testCallStack() {
-  #assert(bar()) // expected-error{{#assert condition not constant}}
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Reverts apple/swift#17517

Still got my training wheels on github; saw rxwei had approved and failed to refresh the page in the morning so didn't see lattner's comments before merging.

Apologies!