### PR TITLE
[DNM] Implementation for proposal "Deprecate Strange Interpolations"

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -1224,6 +1224,16 @@ ERROR(expected_type_after_as,none,
 ERROR(string_interpolation_extra,none,
       "extra tokens after interpolated string expression", ())
 
+// Interpolations with parameter labels or multiple values
+WARNING(string_interpolation_list_changing,none,
+      "interpolating multiple values will not form a tuple in future versions of Swift", ())
+NOTE(string_interpolation_list_insert_parens,none,
+      "insert parentheses to keep current behavior", ())
+WARNING(string_interpolation_label_changing,none,
+      "labeled interpolations will not be ignored in future versions of Swift", ())
+NOTE(string_interpolation_remove_label,none,
+      "remove %0 label to keep current behavior", (Identifier))
+
 // Keypath expressions.
 ERROR(expr_keypath_expected_lparen,PointsToFirstBadToken,
       "expected '(' following '#keyPath'", ())

--- a/lib/Parse/ParseExpr.cpp
+++ b/lib/Parse/ParseExpr.cpp
@@ -1907,9 +1907,28 @@ parseStringSegments(SmallVectorImpl<Lexer::StringSegment> &Segments,
       Status |= E;
       if (auto expr = E.getPtrOrNull()) {
         if (auto tuple = dyn_cast<TupleExpr>(expr)) {
+          // Warn the user that this won't always be allowed.
+          if (tuple->getNumElements() > 1) {
+            auto rParenLoc = tuple->getRParenLoc();
+            auto secondExprLoc = tuple->getElement(1)->getLoc();
+            
+            diagnose(secondExprLoc, diag::string_interpolation_list_changing)
+              .highlightChars(secondExprLoc, rParenLoc);
+            diagnose(secondExprLoc, diag::string_interpolation_list_insert_parens)
+              .fixItInsertAfter(tuple->getLParenLoc(), "(")
+              .fixItInsert(rParenLoc, ")");
+          } else if (tuple->getNumElements() == 1 && tuple->hasElementNames()) {
+            auto startLoc = tuple->getElementNameLoc(0);
+            auto endLoc = tuple->getElement(0)->getStartLoc();
+            
+            diagnose(startLoc, diag::string_interpolation_label_changing)
+              .highlightChars(startLoc, endLoc);
+            diagnose(startLoc, diag::string_interpolation_remove_label, tuple->getElementName(0))
+              .fixItRemoveChars(startLoc, endLoc);
+          }
+          
           // This needs to be wrapped in a ParenExpr so it won't be interpreted
           // as an argument list.
-          // FIXME: Do we want to warn/error about any of these cases?
           expr = new (Context) ParenExpr(SourceLoc(), tuple, SourceLoc(), 
                                          /*hasTrailingClosure=*/false);
           expr->setImplicit();

--- a/test/Parse/strange_interpolation.swift
+++ b/test/Parse/strange_interpolation.swift
@@ -1,0 +1,46 @@
+// RUN: %target-run-simple-swift -verify %s | %FileCheck %s
+
+let x = 1
+
+print("[\(x)]")
+// CHECK: [1]
+
+print("[\(foo: x)]")
+// CHECK: [1]
+// expected-warning@-2{{labeled interpolations will not be ignored in future versions of Swift}}
+// expected-note@-3{{remove 'foo' label to keep current behavior}} {{11-16=}}
+
+print("[\(x, x)]")
+// CHECK: [(1, 1)]
+// expected-warning@-2{{interpolating multiple values will not form a tuple in future versions of Swift}}
+// expected-note@-3{{insert parentheses to keep current behavior}} {{11-11=(}} {{15-15=)}}
+
+print("[\(foo: x, x)]")
+// CHECK: [(foo: 1, 1)]
+// expected-warning@-2{{interpolating multiple values will not form a tuple in future versions of Swift}}
+// expected-note@-3{{insert parentheses to keep current behavior}} {{11-11=(}} {{20-20=)}}
+
+print("[\(x, foo: x)]")
+// CHECK: [(1, foo: 1)]
+// expected-warning@-2{{interpolating multiple values will not form a tuple in future versions of Swift}}
+// expected-note@-3{{insert parentheses to keep current behavior}} {11-11(}} {{20-20=)}}
+
+print("[\(foo: x, foo: x)]")
+// CHECK: [(foo: 1, foo: 1)]
+// expected-warning@-2{{interpolating multiple values will not form a tuple in future versions of Swift}}
+// expected-note@-3{{insert parentheses to keep current behavior}} {11-11(}} {{25-25=)}}
+
+print("[\(describing: x)]")
+// CHECK: [1]
+// expected-warning@-2{{labeled interpolations will not be ignored in future versions of Swift}}
+// expected-note@-3{{remove 'describing' label to keep current behavior}} {{11-23=}}
+
+print("[\(x, radix: x)]")
+// CHECK: [(1, radix: 1)]
+// expected-warning@-2{{interpolating multiple values will not form a tuple in future versions of Swift}}
+// expected-note@-3{{insert parentheses to keep current behavior}} {11-11(}} {{25-25=)}}
+
+print("[\(stringInterpolationSegment: x)]")
+// CHECK: [1]
+// expected-warning@-2{{labeled interpolations will not be ignored in future versions of Swift}}
+// expected-note@-3{{remove 'stringInterpolationSegment' label to keep current behavior}} {{11-39=}}


### PR DESCRIPTION
This is the implementation for a proposal to deprecate several forms of string interpolation, like `\(foo: x)` and `\(x, y)`, which are unintentionally permitted by the parser. The proposal calls for Swift 4.2 to warn about these constructs and provide fix-its which produce identical behavior.

If accepted, this implementation should be merged into master and backported to Swift 4.2 so that the very few uses of these in the wild can be updated before Swift 5.

Implements apple/swift-evolution#867. Resolves [SR-7937](https://bugs.swift.org/browse/SR-7937) and [SR-7958](https://bugs.swift.org/browse/SR-7958).