### PR TITLE
[CodeComplete] Typecheck SubscriptDecl context prior to completion

### DIFF
--- a/lib/IDE/CodeCompletion.cpp
+++ b/lib/IDE/CodeCompletion.cpp
@@ -1371,8 +1371,7 @@ class CodeCompletionCallbacksImpl : public CodeCompletionCallbacks {
       llvm_unreachable("module scope context handled above");
 
     case DeclContextKind::SubscriptDecl:
-      // FIXME: what do we need to check here?
-      return true;
+      return typeCheckCompletionDecl(cast<SubscriptDecl>(DC));
 
     case DeclContextKind::TopLevelCodeDecl:
       return typeCheckTopLevelCodeDecl(cast<TopLevelCodeDecl>(DC));

--- a/test/IDE/complete_type_subscript.swift
+++ b/test/IDE/complete_type_subscript.swift
@@ -1,3 +1,7 @@
+protocol It {
+  associatedtype Assoc
+}
+
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=PARAM_0 | %FileCheck %s -check-prefix=TOP_LEVEL_0
 // RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=RETURN_0 | %FileCheck %s -check-prefix=TOP_LEVEL_0
 
@@ -83,3 +87,34 @@ struct G5 {
 }
 // GEN_PARAM_5: Keyword/None:                       Type[#T.Type#];
 // GEN_PARAM_5-NOT: Keyword/CurrNominal:            self[#T#];
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GEN_PARAM_6 | %FileCheck %s -check-prefix=GEN_PARAM_6
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GEN_RETURN_6 | %FileCheck %s -check-prefix=GEN_PARAM_6
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GEN_EXT_PARAM_6 | %FileCheck %s -check-prefix=GEN_PARAM_6
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GEN_EXT_RETURN_6 | %FileCheck %s -check-prefix=GEN_PARAM_6
+struct G6<T: It> {
+  subscript(a x: T.#^GEN_PARAM_6^#) -> Int { return 0 }
+  subscript(a x: Int) -> T.#^GEN_RETURN_6^# { return 0 }
+}
+extension G6 {
+  subscript(b x: T.#^GEN_EXT_PARAM_6^#) -> Int { return 0 }
+  subscript(b x: Int) -> T.#^GEN_EXT_RETURN_6^# { return 0 }
+}
+// GEN_PARAM_6-DAG: Decl[AssociatedType]/Super:         Assoc;
+// GEN_PARAM_6-DAG: Keyword/None:                       Type[#T.Type#];
+
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENPROTO_PARAM_1 | %FileCheck %s -check-prefix=GENPROTO_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENPROTO_RETURN_1 | %FileCheck %s -check-prefix=GENPROTO_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENPROTO_EXT_PARAM_1 | %FileCheck %s -check-prefix=GENPROTO_1
+// RUN: %target-swift-ide-test -code-completion -source-filename %s -code-completion-token=GENPROTO_EXT_RETURN_1 | %FileCheck %s -check-prefix=GENPROTO_1
+protocol GP1 {
+  associatedtype I: It
+  subscript(a x: I.#^GENPROTO_PARAM_1^#) -> Int
+  subscript(ax: Int) -> I.#^GENPROTO_RETURN_1^#
+}
+extension GP1 {
+  subscript(b x: I.#^GENPROTO_EXT_PARAM_1^#) -> Int { return 1 }
+  subscript(b x: Int) -> I.#^GENPROTO_EXT_RETURN_1^# { return 1 }
+}
+// GENPROTO_1-DAG: Decl[AssociatedType]/Super:         Assoc;
+// GENPROTO_1-DAG: Keyword/None:                       Type[#Self.I.Type#];


### PR DESCRIPTION
Completing types in signature depends on its `GenericEnvironment` which is set during typechecking. 
Previously, completing signature using generic type used to cause assertion failure. e.g.

```swift
extension Collection {
  subscript(some index: Int) -> Iterator.<COMPLETE HERE>
```

rdar://problem/41227754