### PR TITLE
[4.2] IRGen: Fix multi-payload enum lowering

### DIFF
--- a/lib/IRGen/GenDecl.cpp
+++ b/lib/IRGen/GenDecl.cpp
@@ -4115,6 +4115,9 @@ IRGenModule::getResilienceExpansionForAccess(NominalTypeDecl *decl) {
 // layout. Calling isResilient() with this scope will always return false.
 ResilienceExpansion
 IRGenModule::getResilienceExpansionForLayout(NominalTypeDecl *decl) {
+  if (Types.isCompletelyFragile())
+    return ResilienceExpansion::Minimal;
+
   if (isResilient(decl, ResilienceExpansion::Minimal))
     return ResilienceExpansion::Maximal;
 

--- a/test/IRGen/enum_resilience_objc.swift
+++ b/test/IRGen/enum_resilience_objc.swift
@@ -1,0 +1,25 @@
+// RUN: %empty-directory(%t)
+// RUN: %target-swift-frontend -emit-module -enable-resilience -emit-module-path=%t/resilient_struct.swiftmodule -module-name=resilient_struct %S/../Inputs/resilient_struct.swift
+// RUN: %target-swift-frontend -module-name enum_resilience -I %t -emit-ir -enable-resilience %s | %FileCheck %s -DINT=i%target-ptrsize
+// RUN: %target-swift-frontend -module-name enum_resilience -I %t -emit-ir -enable-resilience -O %s
+
+// REQUIRES: objc_interop
+
+// Because the enum is resilient we cannot pack the tag into the pointer inside of the resilient payload.
+// CHECK: %T15enum_resilience9ContainerC5Multi33_{{.*}}LLO.0 = type <{ [{{(8|4)}} x i8], [1 x i8] }>
+
+import resilient_struct
+
+public class Container {
+  private enum Multi {
+    case none
+    case some(Container)
+    case data(ResilientRef)
+  }
+  private var e: Multi
+  var i: Int
+  init() {
+    e = .none
+    i = 0
+  }
+}

--- a/test/Inputs/resilient_struct.swift
+++ b/test/Inputs/resilient_struct.swift
@@ -77,3 +77,17 @@ public struct ResilientDouble {
     self.d = d
   }
 }
+
+public class Referent {}
+
+public struct ResilientWeakRef {
+  public weak var ref: Referent?
+
+  public init (_ r: Referent) {
+    ref = r
+  }
+}
+
+public struct ResilientRef {
+  public var r: Referent
+}

--- a/test/Interpreter/enum_resilience.swift
+++ b/test/Interpreter/enum_resilience.swift
@@ -436,4 +436,28 @@ ResilientEnumTestSuite.test("ResilientEnumExtension") {
   expectEqual(Base.self, ResilientMultiPayloadGenericEnumFixedSize<Base>.A.getTypeParameter())
 }
 
+public class Container {
+  private enum Multi {
+    case none
+    case some(Container)
+    case other(ResilientRef)
+  }
+  private var m: Multi
+  var i: Int
+  init() {
+    m = .none
+    i = 0
+    switch self.m {
+      case .none:
+        print("success")
+      case .some(_), .other(_):
+        assert(false, "noooo!")
+    }
+  }
+}
+
+ResilientEnumTestSuite.test("ResilientPrivateEnumMember") {
+  _ = Container()
+}
+
 runAllTests()


### PR DESCRIPTION
When we have a private resilient enum that is resilient because one of
its payloads is resilient but we have disabled resilience in the
context of lowering the enum as a class member (sigh), we must consider
it's payload's layout enum in the minimal domain (ignore the private
visibility) because we don't truly know the layout.

* Scope: Private enums that contain a resilient payload and are used as
a stored property inside of a class will cause crashes. This regression was introduced recently when we made resilient properties no resilient when used as stored properties in classes to fix ObjectiveC's incapability to handle resilient stored properties.

* Risk: Low
* Reviewed by: Slava
* Testing: CI test cases added

rdar://41308521