### PR TITLE
[DebugInfo] Only run this test when the shadow copy is happening.

### DIFF
--- a/test/DebugInfo/guard-let.swift
+++ b/test/DebugInfo/guard-let.swift
@@ -21,9 +21,13 @@ public func f(_ i : Int?)
   use(val)
 }
 
-// With large type optimizations the string is passed indirectly on i386 so
-// there is no shadow copy happening.
+// With large type optimizations the string is passed indirectly on the
+// following architectures so there is no shadow copy happening. As this
+// tests that we're emitting the DI correctly, we can skip running on them.
 // UNSUPPORTED: CPU=i386
+// UNSUPPORTED: CPU=armv7
+// UNSUPPORTED: CPU=armv7s
+// UNSUPPORTED: CPU=armv7k
 
 public func g(_ s : String?)
 {


### PR DESCRIPTION
The optimizations kick in only on some architectures, and
elsewhere this particular sequence is not emitted.

<rdar://problem/41439607>