### PR TITLE
[4.2][projection] Add non-supported projection users to the non projection…

### DIFF
--- a/lib/SIL/Projection.cpp
+++ b/lib/SIL/Projection.cpp
@@ -840,6 +840,24 @@ createProjection(SILBuilder &B, SILLocation Loc, SILValue Arg) const {
   return Proj->createProjection(B, Loc, Arg);
 }
 
+// Projection tree only supports structs and tuples today.
+static bool isSupportedProjection(const Projection &p) {
+  switch (p.getKind()) {
+  case ProjectionKind::Struct:
+  case ProjectionKind::Tuple:
+    return true;
+  case ProjectionKind::Class:
+  case ProjectionKind::Enum:
+  case ProjectionKind::Box:
+  case ProjectionKind::Upcast:
+  case ProjectionKind::RefCast:
+  case ProjectionKind::BitwiseCast:
+  case ProjectionKind::TailElems:
+  case ProjectionKind::Index:
+    return false;
+  }
+}
+
 void
 ProjectionTreeNode::
 processUsersOfValue(ProjectionTree &Tree,
@@ -863,12 +881,11 @@ processUsersOfValue(ProjectionTree &Tree,
       continue;
     }
 
-    // Check whether the user is such a projection.
     auto P = Projection(projectionInst);
 
-    // If we fail to create a projection, add User as a user to this node and
-    // continue.
-    if (!P.isValid()) {
+    // If we fail to create a projection or this is a type of projection that we
+    // do not support, add User as a user to this node and continue.
+    if (!P.isValid() || !isSupportedProjection(P)) {
       DEBUG(llvm::dbgs() << "            Failed to create projection. Adding "
             "to non projection user!\n");
       addNonProjectionUser(Op);


### PR DESCRIPTION
… user list.

Otherwise when we try to rewrite uses, we will run into one of these
values. Since ProjectionTree won't know how to deal with those, we will crash.

rdar://41146023
(cherry picked from commit 9bba33866867e058e143494eedc836269e3db56d)
