### PR TITLE
[stdlib] Remove _random() customization point

### DIFF
--- a/stdlib/public/core/Integers.swift.gyb
+++ b/stdlib/public/core/Integers.swift.gyb
@@ -2421,10 +2421,6 @@ ${operatorComment(x.operator, False)}
 ${assignmentOperatorComment(x.operator, False)}
   static func ${x.operator}=(_ lhs: inout Self, _ rhs: Self)
 % end
-
-  static func _random<R: RandomNumberGenerator>(
-    using generator: inout R
-  ) -> Self
 }
 
 extension FixedWidthInteger {
@@ -3025,6 +3021,7 @@ ${assignmentOperatorComment('&' + x.operator, True)}
 }
 
 extension FixedWidthInteger {
+  @inlinable
   public static func _random<R: RandomNumberGenerator>(
     using generator: inout R
   ) -> Self {
@@ -4044,17 +4041,6 @@ public func _assumeNonNegative(_ x: ${Self}) -> ${Self} {
   return ${Self}(Builtin.assumeNonNegative_${BuiltinName}(x._value))
 }
 % end
-
-extension ${Self} {
-  @inlinable
-  public static func _random<R: RandomNumberGenerator>(
-    using generator: inout R
-  ) -> ${Self} {
-    var result: ${Self} = 0
-    withUnsafeMutableBytes(of: &result) { generator._fill(bytes: $0) }
-    return result
-  }
-}
 
 //===--- end of FIXME(integers) -------------------------------------------===//
 


### PR DESCRIPTION
This is a continuation of https://github.com/apple/swift/pull/16863. @lorentey you said you weren't too worried about the `FixedWidthInteger._random()` implementation as it will soon use the new words initializer™, but I'm simply curious to see if this has any improvements for custom generators in any way. (Can you benchmark?)