### PR TITLE
[LICM] Array Semantics: only hoist kGetCount and kGetCapacity

### DIFF
--- a/lib/SILOptimizer/LoopTransforms/LICM.cpp
+++ b/lib/SILOptimizer/LoopTransforms/LICM.cpp
@@ -472,8 +472,18 @@ static bool canHoistUpDefault(SILInstruction *inst, SILLoop *Loop,
     return false;
   }
 
+  // We can’t hoist everything that is hoist-able
+  // The canHoist method does not do all the required analysis
+  // Some of the work is done at COW Array Opt
+  // TODO: Refactor COW Array Opt + canHoist - radar 41601468
   ArraySemanticsCall semCall(inst);
-  return semCall.canHoist(Preheader->getTerminator(), DT);
+  switch (semCall.getKind()) {
+  case ArrayCallKind::kGetCount:
+  case ArrayCallKind::kGetCapacity:
+    return semCall.canHoist(Preheader->getTerminator(), DT);
+  default:
+    return false;
+  }
 }
 
 // Check If all the end accesses of the given begin do not prevent hoisting

--- a/test/SILOptimizer/array_mutable_assertonly.swift
+++ b/test/SILOptimizer/array_mutable_assertonly.swift
@@ -87,6 +87,7 @@ struct Array2d {
 // TEST6-LABEL: COW Array Opts in Func {{.*}}test2DArrayLoop{{.*}}
 // TEST6:        Array Opts in Loop Loop at depth 2
 // TEST6-NOT:   COW Array Opts in
+// TEST6:        Hoisting make_mutable
 // TEST6:        Array Opts in Loop Loop at depth 1
 // TEST6-NOT:   COW Array Opts in
 // TEST6:        Hoisting make_mutable


### PR DESCRIPTION
We can’t hoist everything that is hoist-able

The canHoist method does not do all the required analysis

Some of the work is done at COW Array Opt

radar rdar://problem/41591454