### PR TITLE
[Type checker] Handle literals based on superclass constraints.

### DIFF
--- a/lib/AST/ProtocolConformance.cpp
+++ b/lib/AST/ProtocolConformance.cpp
@@ -130,12 +130,6 @@ ProtocolConformanceRef::getTypeWitnessByName(Type type,
                                              ProtocolConformanceRef conformance,
                                              Identifier name,
                                              LazyResolver *resolver) {
-  // For an archetype, retrieve the nested type with the appropriate
-  // name. There are no conformance tables.
-  if (auto archetype = type->getAs<ArchetypeType>()) {
-    return archetype->getNestedType(name);
-  }
-
   // Find the named requirement.
   AssociatedTypeDecl *assocType = nullptr;
   auto members = conformance.getRequirement()->lookupDirect(name);
@@ -149,8 +143,15 @@ ProtocolConformanceRef::getTypeWitnessByName(Type type,
   if (!assocType)
     return nullptr;
 
-  if (conformance.isAbstract())
+  if (conformance.isAbstract()) {
+    // For an archetype, retrieve the nested type with the appropriate
+    // name. There are no conformance tables.
+    if (auto archetype = type->getAs<ArchetypeType>()) {
+      return archetype->getNestedType(name);
+    }
+
     return DependentMemberType::get(type, assocType);
+  }
 
   auto concrete = conformance.getConcrete();
   if (!concrete->hasTypeWitness(assocType, resolver)) {

--- a/lib/ClangImporter/ImportDecl.cpp
+++ b/lib/ClangImporter/ImportDecl.cpp
@@ -1198,6 +1198,7 @@ createDefaultConstructor(ClangImporter::Implementation &Impl,
 
   auto call = CallExpr::createImplicit(context, zeroInitializerRef, {}, {});
   call->setType(selfType);
+  call->setThrows(false);
 
   auto assign = new (context) AssignExpr(lhs, SourceLoc(), call,
                                          /*implicit*/ true);

--- a/lib/Sema/TypeCheckProtocol.cpp
+++ b/lib/Sema/TypeCheckProtocol.cpp
@@ -3115,7 +3115,7 @@ ResolveWitnessResult ConformanceChecker::resolveTypeWitnessViaLookup(
   for (auto candidate : candidates) {
     // Skip nested generic types.
     if (auto *genericDecl = dyn_cast<GenericTypeDecl>(candidate.Member))
-      if (genericDecl->getGenericParams())
+      if (genericDecl->isGeneric())
         continue;
 
     // Skip typealiases with an unbound generic type as their underlying type.

--- a/test/Constraints/generic_super_constraint.swift
+++ b/test/Constraints/generic_super_constraint.swift
@@ -24,4 +24,4 @@ class IntegerClass : ExpressibleByIntegerLiteral, Equatable {
   static func ==(lhs: IntegerClass, rhs: IntegerClass) -> Bool { return true }
 }
 
-func foo<T: IntegerClass>(_ num: T) { let x =  num != 0 }
+func foo<T: IntegerClass>(_ num: T) { let _ =  num != 0 }

--- a/test/Constraints/generic_super_constraint.swift
+++ b/test/Constraints/generic_super_constraint.swift
@@ -17,3 +17,11 @@ func bar<T, U>(_ x: U, y: T) -> (Derived, Int) where U: Base<T>, U: Derived {
   // expected-error@+1{{cannot convert return expression}}
   return (x, y)
 }
+
+// SR-7551 captures a crash on this code.
+class IntegerClass : ExpressibleByIntegerLiteral, Equatable {
+  required init(integerLiteral value: Int) { }
+  static func ==(lhs: IntegerClass, rhs: IntegerClass) -> Bool { return true }
+}
+
+func foo<T: IntegerClass>(_ num: T) { let x =  num != 0 }


### PR DESCRIPTION
When we form a literal whose type is a type parameter where the literal
conformance comes from a superclass constraint of that type parameter,
make sure we can property extract the type witness we need.

Fixes SR-7551 / rdar://problem/39860617.